### PR TITLE
Fix broken links in b2g.html

### DIFF
--- a/apps/b2g/templates/b2g/b2g.html
+++ b/apps/b2g/templates/b2g/b2g.html
@@ -71,8 +71,8 @@
 <aside class="container" id="more-info">
   <h3>More Information</h3>
   <ul>
-    <li><a href="http://www-dev.allizom.org/b/en-US/b2g/about/">About the project</a></li>
-    <li><a href="http://www-dev.allizom.org/b/en-US/b2g/faq/">FAQ</a></li>
+    <li><a href="/b2g/about/">About the project</a></li>
+    <li><a href="/b2g/faq/">FAQ</a></li>
     <li><a href="http://brendaneich.com/2012/02/mobile-web-api-evolution/">Brendan Eich on the Mobile Web API Evolution</a></li>
   </ul>
 </aside>


### PR DESCRIPTION
Fix links that lead to www-dev.allizom to go to the production page (https://bugzilla.mozilla.org/show_bug.cgi?id=727876#c57)
