### PR TITLE
Devices page updates

### DIFF
--- a/apps/landing/templates/landing/devices.html
+++ b/apps/landing/templates/landing/devices.html
@@ -47,7 +47,7 @@
           <div class="content">
             <h2>{{ _('New Firefox is up to 7 times faster.') }}</h2>
             <p id="fx-upgrade"><a href="{{ php_url('/firefox/') }}" class="button go" onclick="dcsMultiTrack('WT.z_panel','Desktops & Laptops','WT.z_cta','upgrade firefox','WT.z_convert','downloadfirefox','WT.dl',99);">{{ _('Upgrade your Firefox') }}</a></p>
-            <p id="fx-features"><a href="{{ php_url('/firefox/features/') }}" class="button go">{{ _('More Firefox Features') }}</a></p>
+            <p id="fx-features"><a href="{{ php_url('/firefox/features/') }}" class="button go">{{ _('More Features') }}</a></p>
             <p id="fx-download"><a href="{{ php_url('/firefox/') }}" class="button go" onclick="dcsMultiTrack('WT.z_panel','Desktops & Laptops','WT.z_cta','download firefox','WT.z_convert','downloadfirefox','WT.dl',99);">{{ _('Download Firefox') }}</a> <br> <a href="/firefox/central/" class="go">Learn more</a></p>
           </div>
           
@@ -128,24 +128,24 @@
               <h3><a href="https://addons.mozilla.org/en-US/mobile/addon/adblock-plus/?src=fx-devices" rel="external"><img src="//static-ssl-cdn.addons.mozilla.net/img/uploads/addon_icons/1/1865-48.png" alt=""> {{ _('AdBlock Plus') }}</a></h3> 
               <p class="desc">{{ _('Regain control and change the way that you view the Web.') }}</p>
               <ul class="add-to">
-                <li><a href="https://addons.mozilla.org/firefox/downloads/latest/1865/addon-1865-latest.xpi?src=fx-devices" onclick="dcsMultiTrack('WT.z_panel','Favorite Add-ons','WT.z_cta','Adblock Plus Desktop','WT.dl',99);">{{ _('Add to Desktop') }}</a></li>
-                <li><a href="https://addons.mozilla.org/mobile/downloads/latest/1865/type:attachment/addon-1865-latest.xpi?src=fx-devices" onclick="dcsMultiTrack('WT.z_panel','Favorite Add-ons','WT.z_cta','Adblock Plus Mobile','WT.dl',99);">{{ _('Add to Mobile') }}</a></li>
+                <li><a href="https://addons.mozilla.org/en-US/firefox/addon/adblock-plus/?src=fx-devices" onclick="dcsMultiTrack('WT.z_panel','Favorite Add-ons','WT.z_cta','Adblock Plus Desktop','WT.dl',99);">{{ _('Add to Desktop') }}</a></li>
+                <li><a href="https://addons.mozilla.org/en-US/mobile/addon/adblock-plus/?src=fx-devices" onclick="dcsMultiTrack('WT.z_panel','Favorite Add-ons','WT.z_cta','Adblock Plus Mobile','WT.dl',99);">{{ _('Add to Mobile') }}</a></li>
               </ul>
             </li>
             <li class="addon">
               <h3><a href="https://addons.mozilla.org/en-US/mobile/addon/noscript/?src=fx-devices" rel="external"><img src="//static-ssl-cdn.addons.mozilla.net/img/uploads/addon_icons/0/722-48.png" alt=""> {{ _('No Script') }}</a></h3>
               <p class="desc">{{ _('Allow active content to run only from sites you trust.') }}</p>
               <ul class="add-to">
-                <li><a href="https://addons.mozilla.org/firefox/downloads/latest/722/addon-722-latest.xpi?src=fx-devices" onclick="dcsMultiTrack('WT.z_panel','Favorite Add-ons','WT.z_cta','No Script Desktop','WT.dl',99);">{{ _('Add to Desktop') }}</a></li>
-                <li><a href="https://addons.mozilla.org/mobile/downloads/latest/722/type:attachment/addon-722-latest.xpi?src=fx-devices" onclick="dcsMultiTrack('WT.z_panel','Favorite Add-ons','WT.z_cta','No Script Mobile','WT.dl',99);">{{ _('Add to Mobile') }}</a></li>
+                <li><a href="https://addons.mozilla.org/en-US/firefox/addon/noscript/?src=fx-devices" onclick="dcsMultiTrack('WT.z_panel','Favorite Add-ons','WT.z_cta','No Script Desktop','WT.dl',99);">{{ _('Add to Desktop') }}</a></li>
+                <li><a href="https://addons.mozilla.org/en-US/mobile/addon/noscript/?src=fx-devices" onclick="dcsMultiTrack('WT.z_panel','Favorite Add-ons','WT.z_cta','No Script Mobile','WT.dl',99);">{{ _('Add to Mobile') }}</a></li>
               </ul>
             </li>
             <li class="addon">
               <h3><a href="https://addons.mozilla.org/en-US/mobile/addon/speed-dial/?src=fx-devices" rel="external"><img src="//static-ssl-cdn.addons.mozilla.net/img/uploads/addon_icons/4/4810-48.png" alt=""> {{ _('Speed Dial') }}</a></h3>
               <p class="desc">{{ _('Direct access to your most visited websites.') }}</p>
               <ul class="add-to">
-                <li><a href="https://addons.mozilla.org/firefox/downloads/latest/4810/addon-4810-latest.xpi?src=fx-devices" onclick="dcsMultiTrack('WT.z_panel','Favorite Add-ons','WT.z_cta','Speed Dial Desktop','WT.dl',99);">{{ _('Add to Desktop') }}</a></li>
-                <li><a href="https://addons.mozilla.org/mobile/downloads/latest/4810/type:attachment/addon-4810-latest.xpi?src=fx-devices" onclick="dcsMultiTrack('WT.z_panel','Favorite Add-ons','WT.z_cta','Speed Dial Mobile','WT.dl',99);">{{ _('Add to Mobile') }}</a></li>
+                <li><a href="https://addons.mozilla.org/en-US/firefox/addon/speed-dial/?src=fx-devices" onclick="dcsMultiTrack('WT.z_panel','Favorite Add-ons','WT.z_cta','Speed Dial Desktop','WT.dl',99);">{{ _('Add to Desktop') }}</a></li>
+                <li><a href="https://addons.mozilla.org/en-US/mobile/addon/speed-dial/?src=fx-devices" onclick="dcsMultiTrack('WT.z_panel','Favorite Add-ons','WT.z_cta','Speed Dial Mobile','WT.dl',99);">{{ _('Add to Mobile') }}</a></li>
               </ul>  
             </li>
           </ul>

--- a/media/css/landing/devices.less
+++ b/media/css/landing/devices.less
@@ -10,11 +10,11 @@
   margin: -24px auto 24px;
   position: relative;
   overflow: visible;
-  -webkit-box-shadow: 0 0 0 1px #ffffff inset;
-  -moz-box-shadow: 0 0 0 1px #ffffff inset;
-  -o-box-shadow: 0 0 0 1px #ffffff inset;
-  -ms-box-shadow: 0 0 0 1px #ffffff inset;
-  box-shadow: 0 0 0 1px #ffffff inset;
+  -webkit-box-shadow: 0 0 0 1px #fff inset;
+  -moz-box-shadow: 0 0 0 1px #fff inset;
+  -o-box-shadow: 0 0 0 1px #fff inset;
+  -ms-box-shadow: 0 0 0 1px #fff inset;
+  box-shadow: 0 0 0 1px #fff inset;
   border-bottom: 1px solid #ddd;
   #gradient > .radial(center, 45px, ellipse, farthest-corner, rgba(255,255,255,0) 0%, #fff 100%);
 }
@@ -52,7 +52,7 @@
   float: left;
 }
 
-.slide .content .button {
+.content .button {
   min-width: 180px;
   font-size: 18px;
 }
@@ -504,3 +504,242 @@ nav.slider-dots {
 }
 
 /* }}} */
+
+/* @Tablet Layout: 768px.    */
+@media only screen and (min-width: 768px) and (max-width: 991px) {
+
+  #main-feature h1 {
+    font-size: 35px;
+  }
+
+  #feature {
+    width: 760px;
+  }
+  
+  .slide-content {
+    width: 624px;
+  }
+  
+  .slide .content {
+    width: 340px;
+    float: left;
+  }
+
+  .content h2 {
+    font-size: 24px;
+  }
+  
+  .content .button:link, 
+  .content .button:visited {
+    min-width: 100px;
+    height: 36px;
+    line-height: 36px;
+  }
+  
+  .button.download-android,
+  .button.download-android:link,
+  .button.download-android:visited {
+    height: auto;
+    min-width: 240px;
+  }
+
+  #speed-slide .content {
+    width: 200px;
+  }
+  #gauge {
+    width: 400px;
+    margin-top: 10px;
+  }
+  .note {
+    width: 400px;
+  }
+  #non-fx {
+    width: 380px;
+  }
+  
+  #gauge-fast,
+  #gauge-slow {
+    width: 150px;
+    font-size: 13px;
+  }
+  
+  #gauge-slow {
+    left: 40px;
+  }
+  
+  #gauge-fast {
+    right: 40px;
+  }
+  
+  #needle {
+    left: 55px;
+  }
+
+  #gauge-slow-note,
+  #gauge-fast-note {
+    background-image: none;
+  }
+  
+  #gauge-slow-note p, 
+  #gauge-fast-note p {
+    width: 100%;
+    top: -10px;
+    text-align: center;
+  }
+  
+  #smartphones-slide h2 {
+    width: 340px;
+    margin-right: -70px;
+  }
+  
+  #smartphones-slide {
+    background-position: 325px 15px;
+  }
+  
+  #smartphones-slide .footnote {
+    right: 430px;
+  }
+
+  #tablets-slide {
+    background-position: 390px 80px;
+    background-size: 320px auto;
+  }
+  
+  #tablets-slide .footnote {
+    left: 270px;
+  }
+  
+  #addons-slide .content {
+    width: 270px;
+  }
+  
+  #addons-slide .footnote {
+    width: 400px;
+    float: right;
+    margin: .5em -24px 0 0;
+    text-align: center;
+  }
+  
+  #addons-list {
+    width: 400px;
+  }
+  
+  #addons-list .addon {
+    width: 90px;
+    padding: 12px;
+    margin-right: 12px;
+  }
+
+  #sync-slide {
+    background-position: 150px 10px;
+  }
+
+}
+
+/* Mobile Layout: 320px. */
+@media only screen and (max-width: 767px) {
+
+  #main-feature h1 {
+    font-size: 35px;
+  }
+  
+  .slider-arrows,
+  .slider-dots {
+    display: none;
+  }
+
+  .js #feature {
+    width: auto;
+    height: auto;
+    margin: 0;
+    overflow: visible;
+    background: transparent none;
+    border: 0;
+    -webkit-box-shadow: none;
+    -moz-box-shadow: none;
+    -o-box-shadow: none;
+    -ms-box-shadow: none;
+    box-shadow: none;
+    .clearfix;
+  }
+    
+  .js #slider {
+    height: auto;
+    padding: 0;
+    overflow: visible;
+  }
+  
+  .js #slider .slide {
+    display: block;
+    min-height: 0;
+    background: #fff none;
+  }
+  
+  .slide-content {
+    width: auto;
+    min-height: 0;
+    padding: 24px;
+  }
+  
+  #slider .slide .content {
+    width: auto;
+    float: none;
+  }
+
+  #slider .content h2 {
+    width: auto;
+    font-size: 24px;
+    margin: 0 0 .5em;
+  }
+  
+  .content .button:link, 
+  .content .button:visited {
+    min-width: 100px;
+    height: 36px;
+    line-height: 36px;
+  }
+  
+  .button.download-android,
+  .button.download-android:link,
+  .button.download-android:visited {
+    height: auto;
+    min-width: 240px;
+  }
+
+  #speed-slide .content, 
+  #addons-slide .content {
+    width: auto;
+  }
+
+  #gauge {
+    display: none;
+  }
+  
+  #smartphones-slide .footnote, 
+  #tablets-slide .footnote, 
+  #addons-slide .footnote {
+    width: auto;
+    position: static;
+    text-align: left;
+    float: none;
+    margin: 1em 0;
+  }
+
+  #addons-list {
+    width: 100%;
+    float: none;
+    margin: 0 0 1em;
+    .clearfix;
+  }
+  
+  #addons-list .addon {
+    width: 26%;
+    padding: 12px 2.5%;
+    margin-right: 2%;
+  }
+  
+  #addons-list .addon:last-child {
+    margin-right: 0;
+  }
+
+}

--- a/media/js/landing/devices.js
+++ b/media/js/landing/devices.js
@@ -8,8 +8,10 @@ $(document).ready(function() {
 
     $('#fx-features').hide();
   
-    /* Set up the slider */
     
+if ($(window).width() > 750) { // Only do the slider in wide windows
+
+    /* Set up the slider */
     var $slides = $('section.slide'),
         isPrevNext = false;
     var getSlideIndex = function(id){
@@ -190,5 +192,7 @@ $(document).ready(function() {
         $nonfx.show();
         $nonfxbtn.show();
     }
+    
+}
     
   });


### PR DESCRIPTION
- Added more mobile-friendly layout alternatives
- Updated the add-on links (don't link directly to the installer)
- Slider script only fires in wide windows, narrow windows don't get a slider but still get to read and click buttons. It does mean you have to reload after resizing, but I'm ok with that (didn't think it was worth adding a resize event).
