### PR TITLE
Don't update URL/history with pager on home page (Bug 740705)

### DIFF
--- a/apps/mozorg/templates/mozorg/home.html
+++ b/apps/mozorg/templates/mozorg/home.html
@@ -33,7 +33,7 @@
   {{ download_button('download','small') }}
 </section>
 
-<section id="home-promo" class="pager pager-with-tabs pager-auto-rotate">
+<section id="home-promo" class="pager pager-with-tabs pager-auto-rotate pager-no-history">
 
   <div class="pager-content">
 


### PR DESCRIPTION
The mozilla-page.js script defaults to updating the URL/history so you can link to particular panels on the pager. This doesn't make sense on the home page where it auto-rotates through the panels. This change removes the URL/history updating.
