### PR TITLE
removed meta name="viewport"

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -12,8 +12,6 @@
 
     <script src="/media/js/libs/modernizr-2.5.0.min.js"></script>
 
-    <meta name="viewport" content="width=device-width">
-
     {% block site_css %}
       {{ css('common') }}
     {% endblock %}


### PR DESCRIPTION
No mobile version of this site is present, and including this
meta-element only causes strange behaviors in mobile devices. for
example the http://www.mozilla.org/media/img/sandstone/bg-sand.png does
not repeat itself more the 320px on a iPhone. and on other devices when
page loads it is zoomed in to a not user-friendly level.

And it's safe to remove.
