### PR TITLE
Corrects firefox logo alt attribute

### DIFF
--- a/apps/mozorg/templates/mozorg/home.html
+++ b/apps/mozorg/templates/mozorg/home.html
@@ -23,7 +23,7 @@
   <!-- We intentionally don't use php_url() here because all locals
   are seeing this English page and we want them to hit their locale for firefox pages -->
   <a href="/firefox/" id="firefox-promo-link">
-  <img src="{{ media('img/home/firefox.png')}}" id="promo-logo" alt="Firefox logo">
+  <img src="{{ media('img/home/firefox.png')}}" id="promo-logo" alt="Firefox">
   </a>
   <h3>Different by Design</h3>
   <ul class="features">


### PR DESCRIPTION
If an image is sole content of a link, then the alt-attribute is the link text. The link points to the firefox page, not to a firefox logo.

For more info look at http://dev.w3.org/html5/alt-techniques/#sec1 example 1.2
