### PR TITLE
fix a string

### DIFF
--- a/apps/marketplace/templates/marketplace/partners.html
+++ b/apps/marketplace/templates/marketplace/partners.html
@@ -40,7 +40,7 @@
 <div class="row">
 
   <div class="span4">
-    <h2>{{_('The Mozilla apps platform')}}</h2>
+    <h2>{{_('The Mozilla apps platform')}}</h2>
     <p>{{_('Building apps for the Web provides developers with full control over content, functionality and how apps are distributed, including access to hundreds of millions of Firefox users through the Mozilla Marketplace.')}}</p>
     <p>{{_('Using open Web standards and Mozilla-designed APIs, great app experiences can be delivered across multiple platforms, devices and operating systems — closing the gap between Web and native apps for the first time.')}}</p>
     <p id="mdn-link"><a href="https://developer.mozilla.org/en-US/apps">{{_('Learn all about creating HTML5 apps at the Mozilla Developer Network »')}}</a></p>


### PR DESCRIPTION
 l10n: marketplace/partners, one English string remains displayed in English because it contains a space that is apparently not a standard space (maybe a non-utf8 character), this commit fixes that string
