### PR TITLE
Bug 750555 android button

### DIFF
--- a/media/css/sandstone/buttons.less
+++ b/media/css/sandstone/buttons.less
@@ -225,5 +225,9 @@ li.os_android,
         font-size: 11px;
         letter-spacing: normal;
     }
+    .button-white {
+        padding-left: 6px;
+        padding-right: 6px;
+    }
 
 }


### PR DESCRIPTION
Fix wrapping of fallback download buttons (see: https://bugzilla.mozilla.org/show_bug.cgi?id=750555#c21)
