### PR TITLE
updated home.less slideshow pager bullets

### DIFF
--- a/media/css/home.less
+++ b/media/css/home.less
@@ -264,14 +264,11 @@
                 text-decoration: none;
                 color: @textColorSecondary;
             }
+            &.selected {
+                color: @textColorSecondary;
+            }
         }
     }
-}
-
-.pager-selected-promo-mdn li#tab-mdn a,
-.pager-selected-promo-collusion li#tab-collusion a,
-.pager-selected-promo-contribute li#tab-contribute a {
-    color: @textColorSecondary;
 }
 
 /* }}} */


### PR DESCRIPTION
Old rules targeted specific IDs. Refactored to target a.selected instead. (selected class is added by slideshow script).
