### PR TITLE
When using html5 and it's served as text/html CDATA comments are not necessary

### DIFF
--- a/apps/mozorg/templates/mozorg/home.html
+++ b/apps/mozorg/templates/mozorg/home.html
@@ -41,9 +41,9 @@
   <div class="pager-content">
 
     <div class="default-page pager-page" id="promo-beta">
-      <script>// <![CDATA[
-      document.getElementById('promo-beta').id = 'page-promo-beta';
-      // ]]></script>
+      <script>
+        document.getElementById('promo-beta').id = 'page-promo-beta';
+      </script>
       <a href="{{ php_url('/firefox/beta/') }}?WT.mc_id=mofxbeta&amp;WT.mc_ev=click" class="container">
         <img src="{{ media('img/home/promo-beta.jpg') }}" alt="Firefox Beta blueprint artwork">
         <div>
@@ -54,9 +54,9 @@
     </div>
 
     <div class="pager-page" id="promo-flicks">
-      <script>// <![CDATA[
-      document.getElementById('promo-flicks').id = 'page-promo-flicks';
-      // ]]></script>
+      <script>
+        document.getElementById('promo-flicks').id = 'page-promo-flicks';
+      </script>
       <a href="https://firefoxflicks.mozilla.org/?WT.mc_id=mofxflicks&amp;WT.mc_ev=click" class="container">
         <img src="{{ media('img/home/promo-flicks.jpg') }}" alt="Firefox Flicks artwork">
         <div>
@@ -67,9 +67,9 @@
     </div>
 
     <div class="pager-page" id="promo-affiliates">
-      <script>// <![CDATA[
-      document.getElementById('promo-affiliates').id = 'page-promo-affiliates';
-      // ]]></script>
+      <script>
+        document.getElementById('promo-affiliates').id = 'page-promo-affiliates';
+      </script>
       <a href="https://affiliates.mozilla.org/?WT.mc_id=moaff&amp;WT.mc_ev=click" class="container">
         <img src="{{ media('img/home/promo-affiliates.jpg') }}" alt="Firefox Affiliates banners and buttons">
         <div>


### PR DESCRIPTION
in fact they are bogus comments:

http://wiki.whatwg.org/wiki/HTML_vs._XHTML

> &lt;![CDATA[…]]&gt; is a a bogus comment. The sequence of characters "]]&gt;" in content when it does not mark the end of a CDATA section is just regular character data. An exception is made for foreign content such as SVG or MathML.
