### PR TITLE
Bug 756356 dnt2

### DIFF
--- a/apps/firefox/templates/firefox/dnt.html
+++ b/apps/firefox/templates/firefox/dnt.html
@@ -154,7 +154,7 @@ want to opt-out of tracking for purposes like behavioral advertising.</p>
 
     <div class="sidebar-box">
       <h4>Enable Do Not Track in Internet Explorer 9</h4>
-      <p>To enable Do Not Track in IE 9, you need to enable IE 9's <a href="http://ie.microsoft.com/testdrive/Browser/TrackingProtectionLists/faq.html">Tracking Protection</a> feature. The easiest way to do that is to install <a href="./dnt-enabler.tpl">Mozilla's Simple Tracking Protection List</a>. If you view this page in IE 9, there will be instructions right here.</p>
+      <p>To enable Do Not Track in IE 9, you need to enable IE 9's <a href="http://ie.microsoft.com/testdrive/Browser/TrackingProtectionLists/faq.html">Tracking Protection</a> feature. The easiest way to do that is to install <a href="{{ media('/dnt/dnt-enabler.tpl') }}">Mozilla's Simple Tracking Protection List</a>. If you view this page in IE 9, there will be instructions right here.</p>
     </div>
 
   </div>

--- a/media/dnt/dnt-enabler.tpl
+++ b/media/dnt/dnt-enabler.tpl
@@ -1,0 +1,17 @@
+msFilterList
+#
+# This tracking protection list only serves to enable the DNT: 1 http header
+# without actually blocking anything.
+#
+# From Mozilla, March 2011
+#
+# Check for updates every month (maximum value allowed by the spec).
+: Expires=30
+#
+# Whitelist hosting domain so when querying for updates, the request is not
+# blocked.
+#
++d dnt.mozilla.org
++d mozilla.org
++d mozilla.com
+


### PR DESCRIPTION
Adding the .tpl file for IE9 users on the Do Not Track site - will need a redirect for the old link when in production.
