### PR TITLE
Replace more ordered lists with unordered lists in navigation

### DIFF
--- a/apps/firefox/templates/firefox/base.html
+++ b/apps/firefox/templates/firefox/base.html
@@ -16,48 +16,48 @@
 
 {% block site_header_nav %}
 <nav role="navigation" id="nav-main">
-  <ol role="menubar">
+  <ul role="menubar">
     <li class="first" id="nav-main-features"><a href="/en-US/firefox/features/" tabindex="0" aria-owns="nav-main-features-submenu" aria-haspopup="true">Desktop</a>
-      <ol aria-expanded="false" id="nav-main-features-submenu">
+      <ul aria-expanded="false" id="nav-main-features-submenu">
         <li class="first"><a href="{{ url('firefox.features') }}" tabindex="-1">Features</a></li>
         <li><a href="{{ url('firefox.customize') }}" tabindex="-1">Customize</a></li>
         <li><a href="{{ url('firefox.performance') }}" tabindex="-1">Performance</a></li>
         <li><a href="{{ url('firefox.technology') }}" tabindex="-1">Technology</a></li>
         <li class="last"><a href="{{ url('firefox.security') }}" tabindex="-1">Privacy &amp; Security</a></li>
-      </ol>
+      </ul>
     </li>
     <li id="nav-main-mobile"><a href="/en-US/mobile/" tabindex="0" aria-owns="nav-main-mobile-submenu" aria-haspopup="true">Mobile</a>
-      <ol aria-expanded="false" id="nav-main-mobile-submenu">
+      <ul aria-expanded="false" id="nav-main-mobile-submenu">
         <li class="first"><a href="/en-US/mobile/" tabindex="-1">Download</a></li>
         <li><a href="/en-US/mobile/features/" tabindex="-1">Features</a></li>
         <li><a href="https://addons.mozilla.org/en-US/mobile/?browse=featured" tabindex="-1">Customize</a></li>
         <li class="last"><a href="/en-US/mobile/faq/" tabindex="-1">FAQ</a></li>
-      </ol>
+      </ul>
     </li>
     <li id="nav-main-releases" class=""><a href="/en-US/firefox/channel/" tabindex="0" aria-owns="nav-main-releases-submenu" aria-haspopup="true">Releases</a>
-      <ol aria-expanded="false" id="nav-main-releases-submenu">
+      <ul aria-expanded="false" id="nav-main-releases-submenu">
         <li class="first"><a href="/en-US/firefox/channel/" tabindex="-1">Overview</a></li>
         <li><a href="/en-US/firefox/aurora/" tabindex="-1">Firefox Aurora</a></li>
         <li><a href="/beta/" tabindex="-1">Firefox Beta</a></li>
         <li><a href="/en-US/firefox/" tabindex="-1">Firefox</a></li>
         <li class="last"><a href="/en-US/firefox/organizations/" tabindex="-1">Firefox for Organizations</a></li>
-      </ol>
+      </ul>
     </li>
     <li id="nav-main-addons"><a href="https://addons.mozilla.org/" tabindex="0" aria-owns="nav-main-addons-submenu" aria-haspopup="true">Add-ons</a>
-      <ol aria-expanded="false" id="nav-main-addons-submenu">
+      <ul aria-expanded="false" id="nav-main-addons-submenu">
         <li class="first"><a href="https://addons.mozilla.org/firefox/" tabindex="-1">Desktop Add-ons</a></li>
         <li><a href="https://addons.mozilla.org/mobile/" tabindex="-1">Mobile Add-ons</a></li>
         <li class="last"><a href="http://www.getpersonas.com/" tabindex="-1">Personas</a></li>
-      </ol>
+      </ul>
       </li>
       <li id="nav-main-support"><a href="http://support.mozilla.org/" tabindex="0" aria-owns="nav-main-support-submenu" aria-haspopup="true">Support</a>
-      <ol aria-expanded="false" id="nav-main-support-submenu">
+      <ul aria-expanded="false" id="nav-main-support-submenu">
         <li class="first"><a href="http://support.mozilla.org/en-US/kb/" tabindex="-1">Desktop Support</a></li>
         <li class="last"><a href="http://support.mozilla.org/mobile" tabindex="-1">Mobile Support</a></li>
-      </ol>
+      </ul>
     </li>
     <li class="last" id="nav-main-about"><a href="/en-US/firefox/about/" tabindex="0" aria-owns="nav-main-about-submenu" aria-haspopup="true">About</a>
-      <ol aria-expanded="false" id="nav-main-about-submenu">
+      <ul aria-expanded="false" id="nav-main-about-submenu">
         <li class="first"><a href="http://blog.mozilla.com/" tabindex="-1">Blog</a></li>
         <li><a href="/en-US/firefox/about/" tabindex="-1">About Firefox</a></li>
         <li><a href="http://www.mozilla.org/join" tabindex="-1">Join Mozilla</a></li>
@@ -67,9 +67,9 @@
         <li><a href="/en-US/about/careers.html" tabindex="-1">Careers</a></li>
         <li><a href="/en-US/about/partnerships.html" tabindex="-1">Partnerships</a></li>
         <li class="last"><a href="/en-US/about/contact.html" tabindex="-1">Contact Us</a></li>
-      </ol>
+      </ul>
     </li>
-  </ol>
+  </ul>
 </nav>
 {% endblock %}
 

--- a/media/css/firefox/menu.less
+++ b/media/css/firefox/menu.less
@@ -1,6 +1,5 @@
 /* Top Level Menu Items */
 
-#nav-main ol,
 #nav-main ul {
     .inline-block;
     margin: 0;
@@ -29,7 +28,6 @@
 
 /* Second-level Menu Items */
 
-.js #nav-main li.hover ol,
 .js #nav-main li.hover ul {
     left: 0;
     opacity: 1;
@@ -38,8 +36,6 @@
     transition: opacity 0.2s ease-in-out;
 }
 
-#nav-main li ol,
-#nav-main li ol li,
 #nav-main li ul,
 #nav-main li ul li {
     height: auto;
@@ -48,7 +44,6 @@
     display: block;
 }
 
-#nav-main li ol,
 #nav-main li ul {
     position: absolute;
     left: -999em;
@@ -100,7 +95,6 @@
 }
 /* Currently active menu items */
 
-#nav-mail ol li.current,
 #nav-mail ul li.current {
     span,
     a,
@@ -124,7 +118,6 @@
 /* }}} */
 /* {{{ Dark Background Header */
 
-.darkbg #nav-main ol li,
 .darkbg #nav-main ul li {
 
     a,

--- a/media/css/sandstone/sandstone.less
+++ b/media/css/sandstone/sandstone.less
@@ -416,7 +416,6 @@ nav.menu-bar {
     padding-top: 0;
     padding-bottom: 0;
 
-    ol,
     ul {
         margin: 0;
         li {
@@ -593,7 +592,6 @@ nav.menu-bar {
     nav {
         .open-sans;
 
-        ol li,
         ul li {
             list-style-type: none;
             margin: 0 0 2px 0;


### PR DESCRIPTION
This builds on icaaq's pull request #144 and applies the change to the Firefox menu as well.
