### PR TITLE
Bug 760315 - Add Link to /Central Page

### DIFF
--- a/apps/firefox/templates/firefox/central.html
+++ b/apps/firefox/templates/firefox/central.html
@@ -149,6 +149,7 @@
           <li><a href="https://support.mozilla.org/kb/Customizing%20Firefox%20with%20add-ons">Ways to personalize your Firefox</a></li>
           <li><a href="https://support.mozilla.org/kb/Customizing%20Firefox%20with%20add-ons">How to install an add-on</a></li>
           <li><a href="http://support.mozilla.org/kb/how-do-i-customize-toolbars">Customize your toolbars</a></li>
+          <li><a href="http://blog.mozilla.org/addons/2012/05/24/addons-firefox-3-6/">Upgrading Firefox and alternatives to outdated add-ons</a></li>
       </ul>
     </div>
 


### PR DESCRIPTION
Add link from: https://bugzilla.mozilla.org/show_bug.cgi?id=760315
