### PR TITLE
migrate geolocation demo to google maps api v3

### DIFF
--- a/apps/firefox/templates/firefox/geolocation.html
+++ b/apps/firefox/templates/firefox/geolocation.html
@@ -124,6 +124,6 @@
 
 </div> <!-- end #main -->
 
-<script src="http://maps.google.com/maps?file=api&amp;v=2&amp;sensor=true&amp;key={{ gmap_api_key }}"></script>
+<script src="//maps.googleapis.com/maps/api/js?sensor=true&amp;key={{ gmap_api_key }}"></script>
 
 {% endblock %}

--- a/media/js/geolocation-demo.js
+++ b/media/js/geolocation-demo.js
@@ -3,52 +3,39 @@ var overlay = null;
 
 var geodemo = {
     initialize: function() {
-        map = new GMap2(document.getElementById("map_canvas"));
-        map.setCenter(new GLatLng(37.41, -122.08), 1);
-        map.addControl(new GSmallMapControl());
-        map.addControl(new GMapTypeControl());
-    },
-
-    getCircleOverlay: function(lat, lon, err) {
-        // math lifted from maps.forum.nu.  you want map examples, go there.
-        with (Math) {
-            var points = Array();
-            var d = err/6378800;// accuracy / meters of Earth radius = radians  
-            var lat1 = (PI/180)* lat; // radians                                                                                                                                                                                    
-            var lng1 = (PI/180)* lon; // radians 
-            
-            for (var a = 0 ; a < 361 ; a+=10 ) {
-                var tc = (PI/180)*a;
-                var y = asin(sin(lat1)*cos(d)+cos(lat1)*sin(d)*cos(tc));
-                var dlng = atan2(sin(tc)*sin(d)*cos(lat1),cos(d)-sin(lat1)*sin(y));
-                var x = ((lng1-dlng+PI) % (2*PI)) - PI ; // MOD function
-                var point = new GLatLng(parseFloat(y*(180/PI)),parseFloat(x*(180/PI)));
-                points.push(point);
-            }
-        }
-        return new GPolygon(points,'#0000ff',1,1,'#0000ff',0.2)
-    },
-
-    zoomLevel: function(a, step) {
-        step++;
-        map.setCenter(new GLatLng(a.coords.latitude, a.coords.longitude), step);
-        if (step > 14) return;
-        window.setTimeout(function() { geodemo.zoomLevel(a, step) }, 250);
+        map = new google.maps.Map(document.getElementById("map_canvas"), {
+            center: new google.maps.LatLng(37.41, -122.08),
+            zoom: 1,
+            mapTypeId: google.maps.MapTypeId.ROADMAP
+        });
     },
 
     aaa: function(a) {
+        var center = new google.maps.LatLng(a.coords.latitude, a.coords.longitude);
         $('#locateButton').siblings('img').hide();
         var zoomLevel = 14;
 
         if (a.coords.accuracy > 500)
             zoomLevel = 10;
 
-        map.setCenter(new GLatLng(a.coords.latitude, a.coords.longitude), zoomLevel);
+        map.setCenter(center);
+        map.setZoom(zoomLevel);
 
-        if (overlay) map.removerOverlay(overlay);
+        if (overlay) {
+            overlay.setMap(null);
+            overlay = null;
+        }
 
-        overlay = geodemo.getCircleOverlay(a.coords.latitude, a.coords.longitude, a.coords.accuracy);
-        map.addOverlay(overlay);
+        overlay = new google.maps.Circle({
+            center: center,
+            radius: a.coords.accuracy,
+            fillColor: '#0000ff',
+            fillOpacity: 0.2,
+            strokeColor: '#0000ff',
+            strokeOpacity: 1,
+            strokeWeight: 1
+        });
+        overlay.setMap(map);
     },
 
     handleError: function(a) {


### PR DESCRIPTION
Google Maps Javascript API v2 is long-deprecated[1](https://developers.google.com/maps/documentation/javascript/v2/). This pull request update geolocation-demo.js with its v3 equivalent, with the exception of using v3's default control UI.
