### PR TITLE
Turn the copyright notice into a l10n-ready string

### DIFF
--- a/apps/mozorg/context_processors.py
+++ b/apps/mozorg/context_processors.py
@@ -1,0 +1,5 @@
+from datetime import datetime
+
+
+def current_year(request):
+    return {"current_year": datetime.today().year}

--- a/settings/base.py
+++ b/settings/base.py
@@ -403,6 +403,10 @@ INSTALLED_APPS = (
     'captcha'
 )
 
+TEMPLATE_CONTEXT_PROCESSORS += (
+    'mozorg.context_processors.current_year',
+)
+
 ## Auth
 PWD_ALGORITHM = 'bcrypt'
 HMAC_KEYS = {

--- a/templates/base-resp.html
+++ b/templates/base-resp.html
@@ -1,4 +1,4 @@
-{% set_lang_files "" %}
+{% set_lang_files "main" %}
 <!doctype html>
 <html class="no-js" lang="{{ LANG }}" dir="{{ DIR }}">
   <head>
@@ -124,10 +124,11 @@
 
           <div class="footer-license">
               <p>
-                Portions of this content are ©1998–2012 by individual
+                {% trans url='/foundation/licensing/website-content.html' %}
+                Portions of this content are ©1998–{{ current_year }} by individual
                 mozilla.org contributors. Content available under
-                a <a href="/foundation/licensing/website-content.html">Creative
-                Commons license</a>.
+                a <a href="{{ url }}">Creative Commons license</a>.
+                {% endtrans %}
               </p>
               <p>
                 <a href="{{ url('mozorg.contribute_page') }}">{{_('Contribute to this page')}}</a>

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,4 +1,4 @@
-{% set_lang_files "" %}
+{% set_lang_files "main" %}
 <!doctype html>
 <html class="no-js" lang="{{ LANG }}" dir="{{ DIR }}">
   <head>
@@ -125,10 +125,11 @@
 
           <div class="span3">
               <p>
-                Portions of this content are ©1998–2012 by individual
+                {% trans url='/foundation/licensing/website-content.html' %}
+                Portions of this content are ©1998–{{ current_year }} by individual
                 mozilla.org contributors. Content available under
-                a <a href="/foundation/licensing/website-content.html">Creative
-                Commons license</a>.
+                a <a href="{{ url }}">Creative Commons license</a>.
+                {% endtrans %}
               </p>
               <p>
                 <a href="{{ url('mozorg.contribute_page') }}">{{_('Contribute to this page')}}</a>


### PR DESCRIPTION
Adds a current_year variable to all templates

fix bug 759139
