### PR TITLE
This fixes skip-links on the affiliate page is not focusable [bug 752354]

### DIFF
--- a/media/css/covehead/template.css
+++ b/media/css/covehead/template.css
@@ -14,12 +14,6 @@ body {
     top: 0;
 }
 
-#nav-access a:focus {
-    left: 726px;
-    top: 10px;
-    background: rgba(255,255,255, .7);
-    padding: 3px;
-}
 
 #doc {
 	width: 980px;


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=752354
