### PR TITLE
Fix for 720432

### DIFF
--- a/apps/firefox/templates/firefox/features.html
+++ b/apps/firefox/templates/firefox/features.html
@@ -341,7 +341,7 @@
 
         </video>
     </div>
-    <p>Runfield is a Web-based game built with JavaScript and Canvas. <a href="http://mozillademos.org/demos/runfield/demo.html">Try it for yourself »</a></p>
+    <p>Runfield is a Web-based game built with JavaScript and Canvas. <a href="https://developer.mozilla.org/en-US/demosdetail/runfield">Try it for yourself »</a></p>
     </div>
     <div class="column1">
       <div class="feature">


### PR DESCRIPTION
The link http://mozillademos.org/demos/runfield/demo.html is changed to https://developer.mozilla.org/en-US/demosdetail/runfield in apps/firefox/templates/firefox/features.html 
