### PR TITLE
Made "tour the interface" more accessible

### DIFF
--- a/media/js/firefox/central.js
+++ b/media/js/firefox/central.js
@@ -80,12 +80,12 @@ var gPlatformVista = navigator.userAgent.indexOf('Windows NT 6.0') !=-1
 	function addHandlers() {
         $('.tip-container').bind('mouseenter focusin', function (e) {
             var $this = $(this);
-			var $tip = $this.find('.tip');
-			var left = parseInt($tip.attr("data-left"), 10);
-			var top = parseInt($tip.attr("data-top"), 10);
+            var $tip = $this.find('.tip');
+            var left = parseInt($tip.data("left"), 10);
+            var top = parseInt($tip.data("top"), 10);
             $tip.css({'left': left, 'top': top})
                 .animate({'opacity': 1}, 300);
-			$this.children('.arrow')
+            $this.children('.arrow')
                 .animate({'opacity': 1}, 300);
             $this.children('.callout')
                 .animate({'opacity': 0}, 300);
@@ -94,7 +94,7 @@ var gPlatformVista = navigator.userAgent.indexOf('Windows NT 6.0') !=-1
             var $tip = $this.find('.tip');
             $this.children('.arrow, .tip')
                 .animate({'opacity': 0}, 300, function () {
-					$tip.css({'left': -999, 'top': 0})
+                    $tip.css({'left': -999, 'top': 0});
                 });
             $this.children('.callout')
                 .animate({'opacity': 1}, 300);
@@ -119,7 +119,7 @@ var gPlatformVista = navigator.userAgent.indexOf('Windows NT 6.0') !=-1
         if (left + tipWidth > sceneWidth) {
             left = sceneWidth - tipWidth;
         }
-        $tip.attr({"data-left":left, "data-top":tip.top});
+        $tip.data({"left":left, "top":tip.top});
         $tip.css({'left': -999, 'top': 0, 'opacity': 0});
         $container.append($tip);
 


### PR DESCRIPTION
added keyboard functionality on "Tour the User Interface"
used a more AT-friendly technique to hide and show the info popups. now the info is spoken to screen reader users.

It can be tested here if you want to http://icaaq.com/sandbox/mozilla/central.htm
