### PR TITLE
Move os detection and os class

### DIFF
--- a/media/js/site.js
+++ b/media/js/site.js
@@ -27,13 +27,12 @@
     }
 
     function init() {
-        // Add the platform as a class name immediately to avoid lots
+        // Add the platform as a classname on the html-element immediately to avoid lots
         // of flickering
-        var b = document.body;
-        b.className = b.className.replace("windows", site.platform);
+        var h = document.documentElement;
+        h.className = h.className.replace("windows", site.platform);
 
         // Add class to reflect javascript availability for CSS
-        var h = document.documentElement;
         h.className = h.className.replace(/\bno-js\b/,'js');
     }
 

--- a/templates/base-resp.html
+++ b/templates/base-resp.html
@@ -1,6 +1,8 @@
 {% set_lang_files "main" %}
 <!doctype html>
-<html class="no-js" lang="{{ LANG }}" dir="{{ DIR }}">
+{# Note the "windows" class, without javascript platform-specific
+     assets default to windows #}
+<html class="windows no-js" lang="{{ LANG }}" dir="{{ DIR }}">
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -20,12 +22,11 @@
     {% block extrahead %}{% endblock %}
 
     {% block favicon %}<link rel="shortcut icon" type="image/png" href="{{ MEDIA_URL }}img/favicon.png">{% endblock %}
+    
+    {{ js('site') }}
   </head>
 
-  <!-- Note the "windows" class, without javascript platform-specific
-       assets default to windows -->
-  <body id="{% block body_id %}{% endblock %}" class="html-{{ DIR }} windows {% block body_class %}{% endblock %}">
-    {{ js('site') }}
+  <body id="{% block body_id %}{% endblock %}" class="html-{{ DIR }} {% block body_class %}{% endblock %}">
     <div id="outer-wrapper">
     <div id="wrapper">
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,6 +1,8 @@
 {% set_lang_files "main" %}
 <!doctype html>
-<html class="no-js" lang="{{ LANG }}" dir="{{ DIR }}">
+{# Note the "windows" class, without javascript platform-specific
+     assets default to windows #}
+<html class="windows no-js" lang="{{ LANG }}" dir="{{ DIR }}">
   <head>
     <meta charset="utf-8">
 
@@ -20,12 +22,11 @@
     {% block extrahead %}{% endblock %}
 
     {% block favicon %}<link rel="shortcut icon" type="image/png" href="{{ MEDIA_URL }}img/favicon.png">{% endblock %}
+
+    {{ js('site') }}
   </head>
 
-  <!-- Note the "windows" class, without javascript platform-specific
-       assets default to windows -->
-  <body id="{% block body_id %}{% endblock %}" class="html-{{ DIR }} windows {% block body_class %}{% endblock %}">
-    {{ js('site') }}
+  <body id="{% block body_id %}{% endblock %}" class="html-{{ DIR }} {% block body_class %}{% endblock %}">
     <div id="outer-wrapper">
     <div id="wrapper">
 


### PR DESCRIPTION
Moves the os detection into the head-element and also moves the platform classname to the html-element similar to the no-js/js handling.

According to paul irish "Scripts in the body blocks rendering…" http://paulirish.com/2009/avoiding-the-fouc-v3/
