### PR TITLE
Bug 763659 fx14whatsnew l10n

### DIFF
--- a/apps/firefox/templates/firefox/whatsnew.html
+++ b/apps/firefox/templates/firefox/whatsnew.html
@@ -1,5 +1,7 @@
 {% extends "/firefox/base-resp.html" %}
 
+{% set_lang_files "whatsnew" %}
+
 {% block page_title_prefix %}{% endblock %}
 {% block page_title %}{{ _('Welcome to Firefox') }}{% endblock %}
 {% block page_title_suffix %}{% endblock %}
@@ -16,12 +18,34 @@
 
 <h1 id="whatsnew-header">{{ _('Hooray! Your Firefox is up to date.') }}</h1>
 
-{% l10n whatsnew_feature, 20120710 %}
 <article id="main-content" class="billboard">
-
   <h2>{{ _('Now get the mobile browser that’s got your back') }}</h2>
-
   <p>{{ _('<a href="%s">Get Firefox for Android</a> and put the power of the Web in your hands. It’s fast, smart and safe!')|format(url('firefox.fx') + '#mobile') }}</p>
+
+{% if request.locale == 'ru' %}
+
+
+  <div id="promo-android">
+    <a href="{{ url('firefox.fx') }}?WT.mc_id=moandroid&amp;WT.mc_ev=click#mobile" class="container">
+      <img src="{{ media('img/home/promo-android.jpg') }}" alt="{{ _('Firefox for Android artwork') }}">
+      <div>
+        <h3>{{ _('Fast. Smart. Safe.') }}</h3>
+        <h4>{{ _('Get the mobile browser that’s got your back.') }}</h4>
+        <p>{{ _('Get Firefox for Android') }}&nbsp;»</p>
+      </div>
+    </a>
+  </div>
+
+  {{ mobile_download_button('android-download') }}
+
+{% l10n whatsnew_feature, 20120712 %}
+  <p id="ru-search">
+    Also new in this release: Google is now your default search engine. To change the active search engine, click the down arrow next to the search engine's icon, and select a new search engine.
+    <a href="http://support.mozilla.org/ru/kb/stroka-poiska?e=es&redirectlocale=en-US&as=s&s=manage+search&r=3&redirectslug=Search+bar#w_managing-search-engines">Learn more.</a>
+  </p>
+{% endl10n %}
+
+{% else %}
 
 <div id="video-wrapper">
 
@@ -68,15 +92,18 @@
 
 {{ mobile_download_button('android-download') }}
 
-</article>
-{% endl10n %}
+{% endif %}
 {% endblock %}
+</article>
 
 {% block email_form %}
+{% if request.locale == 'en-US' %}
   <div id="email-form-wrapper" class="billboard">
   {{ super() }}
   </div>
+{% endif %}
 {% endblock%}
+
 
 {% block site_footer %}
 <section id="colophon" class="billboard">
@@ -92,7 +119,7 @@
     </ul>
   </nav>
   <p class="attribution"><small>
-    {{ _('The Android Robot was reproduced from work created and <a href="%(google)s">shared by Google</a> and used according to terms described in the <a href="%(cc)s">Creative Commons 3.0 Attribution License</a>.')|format(google='http://code.google.com/policies.html', cc='http://creativecommons.org/licenses/by/3.0/') }}
+    {{ _('The Android Robot was reproduced from work created and <a href="%s">shared by Google</a> and used according to terms described in the <a href="%s">Creative Commons 3.0 Attribution License</a>.')|format('http://code.google.com/policies.html', 'http://creativecommons.org/licenses/by/3.0/') }}
 </small></p>
 </section>
 {% endblock %}


### PR DESCRIPTION
Make the Whatsnew template more l10n friendly. Store strings in existing whatsnew.lang, only display the newsletter subscription box to en-US, display a different messaging for Russian per lforrest request, the l10n block only defines the Google search change, the other strings for Android are release neutral and can be used as fallback for other locales too for this release or future releases. Change the android licence string to use the same syntax as the string we already have in whatsnew.lang for the php site.
