### PR TITLE
"What's new" page redirect based on the User Agent

### DIFF
--- a/apps/firefox/__init__.py
+++ b/apps/firefox/__init__.py
@@ -1,0 +1,9 @@
+# Adapted from django-mozilla-product-details
+version_re = (r"\d+"         # major (x in x.y)
+	      "\.\d+"        # minor1 (y in x.y)
+	      "\.?(?:\d+)?"  # minor2 (z in x.y.z)
+	      "\.?(?:\d+)?"  # minor3 (w in x.y.z.w)
+	      "(?:[a|b]?)"   # alpha/beta
+	      "(?:\d*)"      # alpha/beta version
+	      "(?:pre)?"     # pre release
+	      "(?:\d)?")     # pre release version

--- a/apps/firefox/tests.py
+++ b/apps/firefox/tests.py
@@ -1,6 +1,12 @@
 import unittest
 
+from django.test.client import Client
+
+from funfactory.urlresolvers import reverse
+from mozorg.tests import TestCase
 from nose.plugins.skip import SkipTest
+from nose.tools import eq_
+from product_details import product_details
 from platforms import load_devices
 
 
@@ -15,3 +21,39 @@ class TestLoadDevices(unittest.TestCase):
         devices = load_devices(self, self.file(), cacheDevices=False)
 
         #todo
+
+
+class TestWhatsnewRedirect(TestCase):
+    def setUp(self):
+	self.client = Client()
+	with self.activate('en-US'):
+	    self.url = reverse('firefox.whatsnew', args=['13.0'])
+
+    def test_non_firefox(self):
+	user_agent = 'random'
+	response = self.client.get(self.url, HTTP_USER_AGENT=user_agent)
+	eq_(response.status_code, 302)
+	eq_(response['Location'],
+	    'http://testserver%s' % reverse('firefox.new'))
+
+    def test_old_firefox(self):
+	user_agent = ('Mozilla/5.0 (Macintosh; Intel Mac OS X 10.7; rv:13.0) '
+		      'Gecko/20100101 Firefox/13.0')
+	response = self.client.get(self.url, HTTP_USER_AGENT=user_agent)
+	eq_(response.status_code, 302)
+	eq_(response['Location'],
+	    'http://testserver%s' % reverse('firefox.update'))
+
+    def test_current_firefox(self):
+	current = product_details.firefox_versions['LATEST_FIREFOX_VERSION']
+	user_agent = ('Mozilla/5.0 (Macintosh; Intel Mac OS X 10.7; rv:%s) '
+		      'Gecko/20100101 Firefox/%s' % (current, current))
+	response = self.client.get(self.url, HTTP_USER_AGENT=user_agent)
+	eq_(response.status_code, 200)
+
+    def test_future_firefox(self):
+	future = product_details.firefox_versions['FIREFOX_AURORA']
+	user_agent = ('Mozilla/5.0 (Macintosh; Intel Mac OS X 10.7; rv:%s) '
+		      'Gecko/20100101 Firefox/%s' % (future, future))
+	response = self.client.get(self.url, HTTP_USER_AGENT=user_agent)
+	eq_(response.status_code, 200)

--- a/apps/firefox/urls.py
+++ b/apps/firefox/urls.py
@@ -2,8 +2,11 @@ from django.conf.urls.defaults import *
 from django.conf import settings
 from product_details import product_details
 
+from firefox import version_re
 from mozorg.util import page
 import views
+
+whatsnew_re = r'^firefox/(%s)/whatsnew/$' % version_re
 
 urlpatterns = patterns('',
     page('firefox/central', 'firefox/central.html'),
@@ -13,7 +16,7 @@ urlpatterns = patterns('',
     page('firefox/fx', 'firefox/fx.html',
          latest_version=product_details.firefox_versions['LATEST_FIREFOX_VERSION']),
     page('firefox/geolocation', 'firefox/geolocation.html',
-	    gmap_api_key=settings.GMAP_API_KEY),
+	 gmap_api_key=settings.GMAP_API_KEY),
     page('firefox/happy', 'firefox/happy.html'),
     url('^firefox/mobile/platforms/$', views.platforms, name='firefox.mobile.platforms'),
     page('firefox/mobile/features', 'firefox/mobile/features.html'),
@@ -30,9 +33,8 @@ urlpatterns = patterns('',
 
     page('firefox/unsupported/warning', 'firefox/unsupported-warning.html'),
     page('firefox/unsupported/EOL', 'firefox/unsupported-EOL.html'),
-    page('firefox/whatsnew', 'firefox/whatsnew.html',
-	 latest_version=product_details.firefox_versions['LATEST_FIREFOX_VERSION']),
 
     url(r'^firefox/unsupported/win/$', views.windows_billboards),
     url('^dnt/$', views.dnt, name='firefox.dnt'),
+    url(whatsnew_re, views.whatsnew_redirect, name='firefox.whatsnew'),
 )

--- a/apps/firefox/views.py
+++ b/apps/firefox/views.py
@@ -1,7 +1,15 @@
+import re
+
+from firefox import version_re
 import l10n_utils
+from product_details import product_details
+from product_details.version_compare import Version
+from funfactory.urlresolvers import reverse
 
 from django.conf import settings
+from django.http import HttpResponseRedirect
 from platforms import load_devices
+
 
 def windows_billboards(req):
     major_version = req.GET.get('majorVersion')
@@ -25,3 +33,23 @@ def dnt(request):
     response = l10n_utils.render(request, 'firefox/dnt.html')
     response['Vary'] = 'DNT'
     return response
+
+
+def whatsnew_redirect(request, fake_version):
+    user_agent = request.META.get('HTTP_USER_AGENT', '')
+    if not 'Firefox' in user_agent:
+	url = reverse('firefox.new')
+	return HttpResponseRedirect(url)  # TODO : Where to redirect bug 757206
+
+    user_version = "0"
+    ua_regexp = r"Firefox/(%s)" % version_re
+    match = re.search(ua_regexp, user_agent)
+    if match:
+	user_version = match.group(1)
+
+    current_version = product_details.firefox_versions['LATEST_FIREFOX_VERSION']
+    if Version(user_version) < Version(current_version):
+	url = reverse('firefox.update')
+	return HttpResponseRedirect(url)
+    else:
+	return l10n_utils.render(request, 'firefox/whatsnew.html')

--- a/apps/mozorg/tests/__init__.py
+++ b/apps/mozorg/tests/__init__.py
@@ -1,0 +1,23 @@
+from contextlib import contextmanager
+import unittest
+
+from django.utils.translation import get_language
+
+import test_utils
+from tower import activate
+from funfactory.urlresolvers import (get_url_prefix, Prefixer, set_url_prefix)
+
+
+class TestCase(unittest.TestCase):
+    """Base class for Affiliates test cases."""
+    @contextmanager
+    def activate(self, locale):
+	"""Context manager that temporarily activates a locale."""
+	old_prefix = get_url_prefix()
+	old_locale = get_language()
+	rf = test_utils.RequestFactory()
+	set_url_prefix(Prefixer(rf.get('/%s/' % (locale,))))
+	activate(locale)
+	yield
+	set_url_prefix(old_prefix)
+	activate(old_locale)


### PR DESCRIPTION
Compared to bug 757206, I am missing some redirections but I'd like a review so that we can move quickly when I get an answer in the bug.
