### PR TITLE
Only parse .lang files if the cache is empty.

### DIFF
--- a/lib/l10n_utils/dotlang.py
+++ b/lib/l10n_utils/dotlang.py
@@ -53,7 +53,7 @@ def translate(text, files):
         key = "dotlang-%s-%s" % (lang, file_)
 
         trans = cache.get(key)
-        if not trans:
+        if trans is None:
             path = os.path.join(settings.ROOT, 'locale', lang,
                                 '%s.lang' % file_)
             trans = parse(path)


### PR DESCRIPTION
Before this, it would also parse when we cached an empty dict.
