### PR TITLE
Bug 770976 - better buttons for narrow viewports

### DIFF
--- a/media/css/contribute.less
+++ b/media/css/contribute.less
@@ -226,8 +226,7 @@
             }
             
             nav {
-                h5,
-                ul {
+                h5 {
                     display: block;
                     margin: 0 0 .5em;
                 }


### PR DESCRIPTION
The buttons are just barely too wide to fit on one line on an iPhone. Reduced the padding a bit so they'll fit better. However, once the page is localized some wrapping will be unavoidable, so I've also added some vertical margin to make them look better when they do inevitably wrap.
