### PR TITLE
Fix bug 697531 - Tooltips explanation and capitalization changes for Firefox Central

### DIFF
--- a/apps/firefox/templates/firefox/central.html
+++ b/apps/firefox/templates/firefox/central.html
@@ -12,15 +12,19 @@
 <h1 class="container large center">Meet Mozilla Firefox</h1>
 
 <div id="main-feature" class="billboard">
-    <h2>Tour the User Interface</h2>
-    <p class="roll-over inset">Roll over the markers below for feature info</p>
+    <h2>Tour the User Interface</h2>   
     <div id="figure">
       {{ platform_img('img/firefox/central/screen.png', alt='Screenshot') }}
       <div id="svg-path"></div>
+      <span class="roll-over inset">Roll over the markers below for feature info</span>
     </div>
 </div>
+<article id="not-this-marker" class="tip">  
+    <h1>No, not this one</h1>  
+    <p>This one's just here to tell you to roll over the other ones, which you should do, instead of rolling over this one, which is also fine, but doesn't actually give you any info about Firefox.</p>
+</article>
 <article id="tabs-on-top" class="tip">
-    <h1>Tabs on Top</h1>
+    <h1>Tabs on top</h1>
     <p>Tabs are now located above the Awesome Bar to make it easier to focus on the content of the sites you visit.</p>
 </article>
 <article id="app-tab" class="tip">
@@ -28,11 +32,11 @@
     <p>Take sites you always keep open — like Web mail — off your tab bar and give them a permanent home in your browser.</p>
 </article>
 <article id="new-tab" class="tip">
-    <h1>New Tab</h1>
+    <h1>New tab</h1>
     <p>Firefox gets you to your next task faster than ever. Choose from your most recently and frequently visited sites when you open a new tab.</p>
 </article>
 <article id="switch-to-tab" class="tip">
-    <h1>Switch to Tab</h1>
+    <h1>Switch to tab</h1>
     <p>As you’re opening a new tab, Firefox will check to see if you already have that site open. If you do, you’ll be directed to the existing tab so you don’t open a duplicate.</p>
 </article>
 <article id="firefox-menu-button" class="tip">
@@ -76,7 +80,7 @@
     <li><a id="#get-started">Getting started</a></li>
     <li><a id="#speed">Experience super speed</a></li>
     <li><a id="#stay-in-sync">Stay in sync</a></li>
-    <li><a id="#customize">Customize your firefox</a></li>
+    <li><a id="#customize">Customize your Firefox</a></li>
     <li><a id="#personal">Secure your personal info</a></li>
   </ul>
 

--- a/media/css/firefox/central.less
+++ b/media/css/firefox/central.less
@@ -15,14 +15,13 @@ h1.large {
 
 .roll-over {
     position: absolute;
-    top: 20px;
-    right: 20px;
+    top: -110px;
+    right: -20px;
     width: 88px;
     padding: 12px 12px 12px 68px;
     font-size: @smallFontSize;
     line-height: 100%;
     color: @textColorSecondary;
-    background-image: url(/media/img/firefox/central/callout-down.png);
     background-repeat: no-repeat;
     background-position: 18px 50%;
     background-color: rgba(0,0,0,0.05);

--- a/media/js/firefox/central.js
+++ b/media/js/firefox/central.js
@@ -29,6 +29,7 @@ var gPlatformVista = navigator.userAgent.indexOf('Windows NT 6.0') !=-1
 
   var tips = {}
   tips[PLATFORM_WINDOWS] = [
+      {'left': 832, 'top': -48,  'id': 'not-this-marker'},
       {'left': 113, 'top': 34,  'id': 'firefox-menu-button'},
       {'left': 42,  'top': 70,  'id': 'app-tab', 'direction': 'up'},
       {'left': 587, 'top': 55,  'id': 'new-tab'},
@@ -43,6 +44,7 @@ var gPlatformVista = navigator.userAgent.indexOf('Windows NT 6.0') !=-1
       {'left': 894, 'top': 107, 'id': 'home-button', 'direction': 'up'}
   ];
   tips[PLATFORM_MACOSX] = [
+      {'left': 832, 'top': -48,  'id': 'not-this-marker'},    
       {'left': 38,  'top': 57,  'id': 'app-tab'},
       {'left': 582, 'top': 57,  'id': 'new-tab'},
       {'left': 76,  'top': 101, 'id': 'instant-website-id', 'direction': 'up'},
@@ -56,6 +58,7 @@ var gPlatformVista = navigator.userAgent.indexOf('Windows NT 6.0') !=-1
       {'left': 899, 'top': 101, 'id': 'home-button', 'direction': 'up'}
   ];
   tips[PLATFORM_LINUX] = [
+      {'left': 832, 'top': -48,  'id': 'not-this-marker'},
       {'left': 42,  'top': 94,  'id': 'app-tab'},
       {'left': 578, 'top': 100, 'id': 'new-tab'},
       {'left': 80,  'top': 142, 'id': 'instant-website-id', 'direction': 'up'},
@@ -69,7 +72,7 @@ var gPlatformVista = navigator.userAgent.indexOf('Windows NT 6.0') !=-1
   ];
 
 
-    var tipWidth = 500;
+    var tipWidth = 450;
     var sceneWidth = 950;
 
     $(tips[gPlatform]).each(function (index, tip) {


### PR DESCRIPTION
# Summary of changes
1. Added a new tip "Not this one".
2. Capitalization changes at
   - Tabs on top
   - Switch to tab
   - New tab
   - Customize your Firefox
3. Changed tip box width to prevent breaking of arrow from the box.
