### PR TITLE
Updates to Aurora download button to use thank-you page (Bug 725545)

### DIFF
--- a/apps/mozorg/helpers.py
+++ b/apps/mozorg/helpers.py
@@ -186,7 +186,8 @@ def download_button(ctx, id, format='large', build=None):
                                                     platform, locale)
         else:
             download_link_direct = make_download_link('firefox', build, version,
-                                                       platform, locale, True)
+                                                       platform, locale,
+                                                       force_direct=True)
         builds.append({'platform': platform,
                        'platform_pretty': platform_pretty,
                        'download_link': download_link,


### PR DESCRIPTION
This depends on changes in SVN (r107901).

Point Aurora downloads to the /products/download.html page, rather than a direct link. Also, pass the channel through the download URL.
