### PR TITLE
Apply the same tweaks during translation as extraction.

### DIFF
--- a/lib/l10n_utils/tests/locale/en-US/tweaked_message_translation.lang
+++ b/lib/l10n_utils/tests/locale/en-US/tweaked_message_translation.lang
@@ -1,0 +1,2 @@
+;Stuff about many things.
+This is the translation.

--- a/lib/l10n_utils/tests/test_py_extract.py.txt
+++ b/lib/l10n_utils/tests/test_py_extract.py.txt
@@ -1,0 +1,5 @@
+# coding: utf-8
+
+from l10n_utils.dotlang import _
+
+mystring = _(u'Stuff\xa0about\r\nmany\t   things.')

--- a/settings/base.py
+++ b/settings/base.py
@@ -44,16 +44,18 @@ TEMPLATE_DIRS = (
     path('locale')
 )
 
-JINJA_CONFIG = {
-    'extensions': [
-        'tower.template.i18n', 'jinja2.ext.do', 'jinja2.ext.with_',
-        'jinja2.ext.loopcontrols', 'l10n_utils.template.l10n_blocks',
-        'l10n_utils.template.lang_blocks'
-    ],
-    # Make None in templates render as ''
-    'finalize': lambda x: x if x is not None else '',
-    'auto_reload': True,
-}
+# has to stay a callable because tower expects that.
+def JINJA_CONFIG():
+    return {
+        'extensions': [
+            'tower.template.i18n', 'jinja2.ext.do', 'jinja2.ext.with_',
+            'jinja2.ext.loopcontrols', 'l10n_utils.template.l10n_blocks',
+            'l10n_utils.template.lang_blocks'
+        ],
+        # Make None in templates render as ''
+        'finalize': lambda x: x if x is not None else '',
+        'auto_reload': True,
+    }
 
 # Bundles is a dictionary of two dictionaries, css and js, which list css files
 # and js files that can be bundled together by the minify app.
@@ -411,7 +413,7 @@ INSTALLED_APPS = (
 
     # libs
     'l10n_utils',
-    'captcha'
+    'captcha',
 )
 
 TEMPLATE_CONTEXT_PROCESSORS += (

--- a/settings/local.py-dist
+++ b/settings/local.py-dist
@@ -1,7 +1,10 @@
 # This is an example settings_local.py file.
 # Copy it and add your local settings here.
 
-from settings import *
+from settings.base import *
+
+ADMINS = ('foo@bar.com',)
+MANAGERS = ADMINS
 
 # No database yet
 # DATABASES = {


### PR DESCRIPTION
This should fix bug 763913. I thought that the translation functions
would use the template .lang files, but they don't seem to in fact.
They would use the .lang file in an en-US directory, but no such
dir exists in the locale directory. I believe my tests are sufficient,
but please look at them carefully.
