### PR TITLE
[bug 765783] Do sync POST to callback_url.

### DIFF
--- a/apps/mozorg/templates/mozorg/contribute-form.html
+++ b/apps/mozorg/templates/mozorg/contribute-form.html
@@ -9,6 +9,10 @@
   </h4>
   {% endif %}
 
+  <h4 id="submit-wait" style="display:none">
+    {{ _('Submitting data, please wait...') }}
+  </h4>
+
   {% if form.errors %}
   {{ form.non_field_errors()|safe }}
 


### PR DESCRIPTION
Doing to sync POST to callback_url will ensure that this request gets
completed before POSTing the form.
