### PR TITLE
Email console backend should only be used on local environments

### DIFF
--- a/settings/base.py
+++ b/settings/base.py
@@ -458,7 +458,7 @@ TEST_RUNNER = 'test_utils.runner.NoDBTestSuiterunner'
 
 def lazy_email_backend():
     from django.conf import settings
-    return ('django.core.mail.backends.console.EmailBackend' if settings.DEV
+    return ('django.core.mail.backends.console.EmailBackend' if settings.DEBUG
             else 'django.core.mail.backends.smtp.EmailBackend')
 
 EMAIL_BACKEND = lazy(lazy_email_backend, str)()


### PR DESCRIPTION
`settings.DEV` is set on our dev and stage servers.
`settings.DEBUG` is more appropriate for this since developers will have this set on their machine.

bug 780913
