### PR TITLE
Corrected subscription stop message and number

### DIFF
--- a/apps/firefox/templates/firefox/mobile/sms-send.html
+++ b/apps/firefox/templates/firefox/mobile/sms-send.html
@@ -41,7 +41,7 @@
         <input type="checkbox" id="sms-sub" name="optin" value="yes">
         {{ _("I'd like to receive SMS updates about Firefox for Android and other Mozilla products.") }}
       </label>
-      <p class="footnote">{{ _('Message and data rates may apply. Text STOP to 21534 to stop (a confirmation message will be sent).') }}</p>
+      <p class="footnote">{{ _('Message and data rates may apply. Text FFSTOP to 36698 to stop (a confirmation message will be sent).') }}</p>
     </div>
 
     <p class="also"><a href="https://market.android.com/details?id=org.mozilla.firefox" rel="external">{{ _('Also available as a free download from Google Play') }}</a></p>


### PR DESCRIPTION
Got an email from Winston that the unsubscribe information on the SMS page is wrong. We need this correction pushed to production as soon as possible.
