### PR TITLE
Linkfix on partners page: ecosystem -> developers. Bug 791368.

### DIFF
--- a/apps/marketplace/templates/marketplace/partners.html
+++ b/apps/marketplace/templates/marketplace/partners.html
@@ -32,7 +32,7 @@
   <ul>
     <li><a href="#platform">{{_('The Mozilla apps platform')}}</a></li>
     <li><a href="#marketplace">{{_('Mozilla Marketplace')}}</a></li>
-    <li><a href="https://marketplace.mozilla.org/ecosystem/" class="button">{{_('Submit your app&nbsp;»')}}<span class="icon"></span></a></li>
+    <li><a href="https://marketplace.mozilla.org/developers/" class="button">{{_('Submit your app&nbsp;»')}}<span class="icon"></span></a></li>
   </ul>
 </nav>
 


### PR DESCRIPTION
Submit link on the partners page points to the wrong URL. Here's a quick fix.

Bug 791368.
