### PR TITLE
fixed broken video links bug #792875 & bug #790493

### DIFF
--- a/apps/firefox/templates/firefox/performance.html
+++ b/apps/firefox/templates/firefox/performance.html
@@ -43,7 +43,7 @@
         controls="controls">
 
         <source src="http://videos-cdn.mozilla.net/serv/mozhacks/demos/screencasts/runfield/screencast.webm" type="video/webm" />
-        <source src="http://videos-cdn.mozilla.net/serv/mozhacks/demos/screencasts/runfield/screencast.theora.ogv" type="video/ogg; codecs=&quot;theora, vorbis&quot;" />
+        <source src="http://videos-cdn.mozilla.net/serv/mozhacks/demos/screencasts/runfield/screencast.ogv" type="video/ogg; codecs=&quot;theora, vorbis&quot;" />
         <source src="http://videos-cdn.mozilla.net/serv/mozhacks/demos/screencasts/runfield/screencast.mp4" type="video/mp4" />
 
         <object type="application/x-shockwave-flash"

--- a/apps/mozorg/templates/mozorg/mission.html
+++ b/apps/mozorg/templates/mozorg/mission.html
@@ -35,7 +35,7 @@
         poster="{{ media('img/mission/poster-mission.jpg') }}"
         controls="controls">
         <source src="//videos-cdn.mozilla.net/brand/Mozilla_2011_Story.webm" type="video/webm">
-        <source src="//videos-cdn.mozilla.net/brand/Mozilla_2011_Story.theora.ogv" type="video/ogg; codecs=&quot;theora, vorbis&quot;">
+        <source src="//videos-cdn.mozilla.net/brand/Mozilla_2011_Story.ogv" type="video/ogg; codecs=&quot;theora, vorbis&quot;">
         <source src="//videos-cdn.mozilla.net/brand/Mozilla_2011_Story.mp4" type="video/mp4">
         <object type="application/x-shockwave-flash"
           style="width: 460px; height: 259px;"


### PR DESCRIPTION
Fixed typos in 2 video links

https://bugzilla.mozilla.org/show_bug.cgi?id=790493

https://bugzilla.mozilla.org/show_bug.cgi?id=792875
