### PR TITLE
Fix layout glitch in webkit on Products page (Bug 796178)

### DIFF
--- a/media/css/products.less
+++ b/media/css/products.less
@@ -31,7 +31,6 @@
         list-style-type: none;
         a {
             display: block;
-            float: left;
             h3 {
                 color: @linkRed;
                 font-size: 22px;


### PR DESCRIPTION
Remove a float that was breaking the width of images inside each project list item in Chrome.
