### PR TITLE
Use CSS long-hand for simple 1-image backgrounds for IE 6/7/8 and CSS sh...

### DIFF
--- a/media/css/sandstone/sandstone-resp.less
+++ b/media/css/sandstone/sandstone-resp.less
@@ -40,10 +40,10 @@ a {
 
 .sand {
     #outer-wrapper {
-        background-color: #f5f1e8;
-        background-image: url(/media/img/sandstone/bg-gradient-sand.png),
-                          url(/media/img/sandstone/bg-sand.png);
-        background-repeat: repeat-x, repeat;
+        background: #f5f1e8 url(/media/img/sandstone/bg-sand.png) repeat;
+        background: url(/media/img/sandstone/bg-gradient-sand.png) repeat-x 0 0,
+                    url(/media/img/sandstone/bg-sand.png) repeat 0 0,
+                    #f5f1e8;
     }
 }
 

--- a/media/css/sandstone/sandstone.less
+++ b/media/css/sandstone/sandstone.less
@@ -37,10 +37,10 @@ a {
 
 .sand {
     #outer-wrapper {
-        background-color: #f5f1e8;
-        background-image: url(/media/img/sandstone/bg-gradient-sand.png),
-                          url(/media/img/sandstone/bg-sand.png);
-        background-repeat: repeat-x, repeat;
+        background: #f5f1e8 url(/media/img/sandstone/bg-sand.png) repeat;
+        background: url(/media/img/sandstone/bg-gradient-sand.png) repeat-x 0 0,
+                    url(/media/img/sandstone/bg-sand.png) repeat 0 0,
+                    #f5f1e8;
     }
 }
 


### PR DESCRIPTION
...ort-hand to override that with nice two-background for modern browsers (Bug 797366)
