### PR TITLE
Bug 797556 tabzillalayout

### DIFF
--- a/media/css/sandstone/sandstone-resp.less
+++ b/media/css/sandstone/sandstone-resp.less
@@ -17,6 +17,7 @@ body {
 }
 
 #outer-wrapper {
+    position: relative;
     border-top: 2px solid #fff;
     background: #f9f9f9 url(/media/img/sandstone/bg-stone.png) 0 0 repeat-x;
 }

--- a/media/css/sandstone/sandstone.less
+++ b/media/css/sandstone/sandstone.less
@@ -17,6 +17,7 @@ body {
 }
 
 #outer-wrapper {
+    position: relative;
     border-top: 2px solid #fff;
     background: #f9f9f9 url(/media/img/sandstone/bg-stone.png) 0 0 repeat-x;
 }


### PR DESCRIPTION
 Add position:relative; to outer-wrapper div to keep tabzilla from overlapping page content in IE7.
