### PR TITLE
Bug 737257 - fix masthead width to prevent scrolling

### DIFF
--- a/media/css/fb-privacy.less
+++ b/media/css/fb-privacy.less
@@ -1,7 +1,11 @@
 @import "sandstone/variables-resp.less";
 
+#fb-privacy #masthead {
+  width: 100%;
+}
+
 #fb-privacy #wrapper {
-  width: 810px;
+  width: 790px;
   margin: 0 auto;
 }
 


### PR DESCRIPTION
As mentioned in https://bugzilla.mozilla.org/show_bug.cgi?id=737257#c19 the iframe is a bit narrower than the fixed masthead width. Changing the width to 100% eliminates the horizontal scrolling.
