### PR TITLE
bug 800302 - fixing up where the webmaker URLs point to

### DIFF
--- a/apps/mozorg/templates/mozorg/contribute.html
+++ b/apps/mozorg/templates/mozorg/contribute.html
@@ -183,7 +183,7 @@ Be part of the research team&mdash;whether you want to be a <a href="{{ survey_u
                 <h3 id="education">{{_('Education') }}</h3>
                 <div class="content">
                   <p>
-{% trans moz_webmaker=url('webmaker.index'), webmaker='http://webmaker.org' %}
+{% trans moz_webmaker='https://webmaker.org/', webmaker='https://webmaker.org/events/' %}
 Help build a generation of webmakers&mdash;moving people from using the web making the web&mdash;by teaching others how to code and how the web works. <a href="{{ moz_webmaker }} ">Explore what the Mozilla Webmaker project is all about</a> or get started teaching others by <a href="{{ webmaker }}">setting up an event in your community today</a>.
 {% endtrans %}
                   </p>


### PR DESCRIPTION
As we look to point more of our traffic through webmaker.org opposed to mozilla.org/webmaker
