### PR TITLE
Python 2.6 does not support assertRaises as a context manager.

### DIFF
--- a/apps/mozorg/tests/test_hierarchy.py
+++ b/apps/mozorg/tests/test_hierarchy.py
@@ -83,8 +83,7 @@ class TestPageNode(TestCase):
         child1 = PageNode('test')
         child2 = PageNode('test', children=[child1])
         PageNode('test', children=[child2, PageNode('test')])
-        with self.assertRaises(ValueError):
-            child1.root
+        self.assertRaises(ValueError, lambda: child1.root)
 
     def test_previous(self):
         """


### PR DESCRIPTION
bug 781664
