### PR TITLE
Copy fixes for Webmaker style guide page (Bug 801852)

### DIFF
--- a/apps/styleguide/templates/styleguide/identity/webmaker-branding.html
+++ b/apps/styleguide/templates/styleguide/identity/webmaker-branding.html
@@ -9,7 +9,7 @@
 {% block content_area %}
 <section id="intro">
   <h2>Introduction</h2>
-  <p>We’ve taken our core values — openness, freedom, user choice — and brought them to the world of apps. Here’s everything you need related to our apps offering and its distribution channel, the Firefox Marketplace.</p>
+  <p>We want to help Internet users everywhere make something amazing with the Web. Here you’ll find all the branding information related to our effort to create a generation of webmakers.</p>
 </section>
 <section id="guidelines">
   <div class="guidelines">
@@ -47,7 +47,7 @@
 <section id="wordmark">
   <div class="build">
     <h2>Wordmark</h2>
-    <p>The Marketplace wordmark follows our <a href="{{ url('styleguide.communications.typefaces') }}#wordmarks">tiered font system</a>.</p>
+    <p>The Webmaker wordmark follows our <a href="{{ url('styleguide.communications.typefaces') }}#wordmarks">tiered font system</a>.</p>
   </div>
   <div class="logo">
     <img src="{{ media('/img/styleguide/box-arrow-left.png') }}" alt="" class="box-arrow" />

--- a/apps/styleguide/urls.py
+++ b/apps/styleguide/urls.py
@@ -44,7 +44,7 @@ hierarchy = PageRoot('Home', children=(
             PageNode('Colors', path='colors', template='styleguide/websites/sandstone-colors.html'),
             PageNode('Forms', path='forms', template='styleguide/websites/sandstone-forms.html'),
             PageNode('Grids', path='grids', template='styleguide/websites/sandstone-grids.html'),
-            PageNode('Tables', path='tables', template='styleguide/websites/sandstone-tables.html'),
+            PageNode('Tables & Lists', path='tables', template='styleguide/websites/sandstone-tables.html'),
             PageNode('Tabzilla', path='tabzilla', template='styleguide/websites/sandstone-tabzilla.html'),
             PageNode('Typefaces', path='typefaces', template='styleguide/websites/sandstone-typefaces.html'),
             PageNode('Examples', path='examples', template='styleguide/websites/sandstone-examples.html'),


### PR DESCRIPTION
Copy fixes for Webmaker style guide page (Bug 801852) and change the "TABLES" section under WEBSITES > SANDSTONE  to TABLES & LISTS.
