### PR TITLE
Better HTML page titles for style guide pages (Bug 805875)

### DIFF
--- a/apps/styleguide/templates/styleguide/base.html
+++ b/apps/styleguide/templates/styleguide/base.html
@@ -1,6 +1,6 @@
 {% extends "base-resp.html" %}
 
-{% block page_title_prefix %}{% endblock %}
+{% block page_title_prefix %}{{ page_title }} — {% endblock %}
 {% block page_title %}Mozilla Style Guide{% endblock %}
 {% block body_id %}styleguide{% endblock %}
 {% block body_class %}sand{% endblock %}
@@ -53,7 +53,7 @@
 
 <div id="content_area" role="main">
 
-<h1>{% block content_title %}{% endblock%}</h1>
+<h1>{% block content_title %}{{ page_title }}{% endblock %}</h1>
 
 {% block subnav %}
 <div id="subnav">

--- a/apps/styleguide/templates/styleguide/communications/copy-rules.html
+++ b/apps/styleguide/templates/styleguide/communications/copy-rules.html
@@ -5,7 +5,8 @@
   communications-copy-rules
 {% endblock %}
 
-{% block content_title %}Copy rules{% endblock%}
+{% set page_title = 'Copy rules' %}
+
 {% block content_area %}
 
 <section id="az">

--- a/apps/styleguide/templates/styleguide/communications/copy-tone.html
+++ b/apps/styleguide/templates/styleguide/communications/copy-tone.html
@@ -5,7 +5,8 @@
   communications-copy-tone
 {% endblock %}
 
-{% block content_title %}Copy tone{% endblock%}
+{% set page_title = 'Copy tone' %}
+
 {% block content_area %}
 
 <div class="intro">

--- a/apps/styleguide/templates/styleguide/communications/presentations.html
+++ b/apps/styleguide/templates/styleguide/communications/presentations.html
@@ -5,7 +5,8 @@
   communications-presentations
 {% endblock %}
 
-{% block content_title %}Presentations{% endblock%}
+{% set page_title = 'Presentations' %}
+
 {% block content_area %}
 
 <section id="intro">

--- a/apps/styleguide/templates/styleguide/communications/translation.html
+++ b/apps/styleguide/templates/styleguide/communications/translation.html
@@ -5,7 +5,8 @@
   communications-translation
 {% endblock %}
 
-{% block content_title %}Translation{% endblock%}
+{% set page_title = 'Translation' %}
+
 {% block content_area %}
 
 <section id="locales">

--- a/apps/styleguide/templates/styleguide/communications/typefaces.html
+++ b/apps/styleguide/templates/styleguide/communications/typefaces.html
@@ -5,7 +5,8 @@
   communications-typefaces
 {% endblock %}
 
-{% block content_title %}Typefaces{% endblock%}
+{% set page_title = 'Typefaces' %}
+
 {% block content_area %}
 
 <section id="opensans">

--- a/apps/styleguide/templates/styleguide/communications/video.html
+++ b/apps/styleguide/templates/styleguide/communications/video.html
@@ -5,7 +5,8 @@
   communications-video
 {% endblock %}
 
-{% block content_title %}Video{% endblock%}
+{% set page_title = 'Video' %}
+
 {% block content_area %}
 
 <section id="intro">

--- a/apps/styleguide/templates/styleguide/home.html
+++ b/apps/styleguide/templates/styleguide/home.html
@@ -1,5 +1,7 @@
 {% extends "styleguide/base.html" %}
 
+{% block page_title_prefix %}{% endblock %}
+
 {% block body_class %}
   {{ super() }}
   styleguide-home

--- a/apps/styleguide/templates/styleguide/identity/firefox-branding.html
+++ b/apps/styleguide/templates/styleguide/identity/firefox-branding.html
@@ -5,7 +5,8 @@
   firefox-branding
 {% endblock %}
 
-{% block content_title %}Firefox branding{% endblock%}
+{% set page_title = 'Firefox branding' %}
+
 {% block content_area %}
 <section id="intro">
   <div id="guidelines">

--- a/apps/styleguide/templates/styleguide/identity/firefox-channels.html
+++ b/apps/styleguide/templates/styleguide/identity/firefox-channels.html
@@ -5,7 +5,8 @@
   firefox-channels
 {% endblock %}
 
-{% block content_title %}Firefox Browser channels{% endblock%}
+{% set page_title = 'Firefox Browser channels' %}
+
 {% block content_area %}
 <section id="intro">
   <h2>Release cycle</h2>

--- a/apps/styleguide/templates/styleguide/identity/firefox-color.html
+++ b/apps/styleguide/templates/styleguide/identity/firefox-color.html
@@ -5,7 +5,8 @@
   firefox-colors
 {% endblock %}
 
-{% block content_title %}Firefox Browser color{% endblock%}
+{% set page_title = 'Firefox Browser color' %}
+
 {% block content_area %}
 <section id="intro">
   <h2>Usage</h2>

--- a/apps/styleguide/templates/styleguide/identity/firefox-family-overview.html
+++ b/apps/styleguide/templates/styleguide/identity/firefox-family-overview.html
@@ -5,7 +5,8 @@
   firefox-family-overview
 {% endblock %}
 
-{% block content_title %}Firefox overview{% endblock%}
+{% set page_title = 'Firefox overview' %}
+
 {% block content_area %}
 <section id="intro">
   <p>Firefox is more than a browser (though it certainly is that). It’s the flagship brand that all our consumer products fall under. Any product bearing the Firefox name lets people know that it features the latest open, innovative technologies and that it’s made with a mission to keep the power of the Web in people’s hands and to build a brighter Internet future for all. The following pages go through each brand and its various elements in detail.</p>

--- a/apps/styleguide/templates/styleguide/identity/firefox-family-platform.html
+++ b/apps/styleguide/templates/styleguide/identity/firefox-family-platform.html
@@ -5,7 +5,8 @@
   firefox-family-platform
 {% endblock %}
 
-{% block content_title %}Firefox platform{% endblock%}
+{% set page_title = 'Firefox platform' %}
+
 {% block content_area %}
 <section id="intro">
   <div class="intro">

--- a/apps/styleguide/templates/styleguide/identity/firefox-wordmarks.html
+++ b/apps/styleguide/templates/styleguide/identity/firefox-wordmarks.html
@@ -5,7 +5,8 @@
   firefox-wordmarks
 {% endblock %}
 
-{% block content_title %}Firefox Browser wordmarks{% endblock%}
+{% set page_title = 'Firefox Browser wordmarks' %}
+
 {% block content_area %}
 <section id="intro">
   <h2>Usage</h2>

--- a/apps/styleguide/templates/styleguide/identity/firefoxos-branding.html
+++ b/apps/styleguide/templates/styleguide/identity/firefoxos-branding.html
@@ -5,7 +5,8 @@
   firefoxos-branding
 {% endblock %}
 
-{% block content_title %}Firefox OS branding{% endblock%}
+{% set page_title = 'Firefox OS branding' %}
+
 {% block content_area %}
 <section id="intro">
   <h2>Coming soon</h2>

--- a/apps/styleguide/templates/styleguide/identity/marketplace-branding.html
+++ b/apps/styleguide/templates/styleguide/identity/marketplace-branding.html
@@ -5,7 +5,8 @@
   marketplace-branding
 {% endblock %}
 
-{% block content_title %}Marketplace branding{% endblock%}
+{% set page_title = 'Marketplace branding' %}
+
 {% block content_area %}
 <section id="intro">
   <h2>Introduction</h2>

--- a/apps/styleguide/templates/styleguide/identity/marketplace-color.html
+++ b/apps/styleguide/templates/styleguide/identity/marketplace-color.html
@@ -5,7 +5,8 @@
   marketplace-color
 {% endblock %}
 
-{% block content_title %}Marketplace color{% endblock%}
+{% set page_title = 'Marketplace color' %}
+
 {% block content_area %}
 <section id="intro">
   <h2>Usage</h2>

--- a/apps/styleguide/templates/styleguide/identity/mozilla-branding.html
+++ b/apps/styleguide/templates/styleguide/identity/mozilla-branding.html
@@ -5,7 +5,8 @@
   mozilla-branding
 {% endblock %}
 
-{% block content_title %}Mozilla branding{% endblock%}
+{% set page_title = 'Mozilla branding' %}
+
 {% block content_area %}
 <section id="intro">
   <div id="guidelines">

--- a/apps/styleguide/templates/styleguide/identity/mozilla-color.html
+++ b/apps/styleguide/templates/styleguide/identity/mozilla-color.html
@@ -5,7 +5,8 @@
   mozilla-color
 {% endblock %}
 
-{% block content_title %}Mozilla color{% endblock%}
+{% set page_title = 'Mozilla color' %}
+
 {% block content_area %}
 <section id="intro">
   <h2>Usage</h2>

--- a/apps/styleguide/templates/styleguide/identity/mozilla-innovations.html
+++ b/apps/styleguide/templates/styleguide/identity/mozilla-innovations.html
@@ -5,7 +5,8 @@
   mozilla-innovations
 {% endblock %}
 
-{% block content_title %}Mozilla innovations{% endblock%}
+{% set page_title = 'Mozilla innovations' %}
+
 {% block content_area %}
 <section id="intro">
     <h2>Introduction</h2>

--- a/apps/styleguide/templates/styleguide/identity/thunderbird-channels.html
+++ b/apps/styleguide/templates/styleguide/identity/thunderbird-channels.html
@@ -5,7 +5,8 @@
   thunderbird-channels
 {% endblock %}
 
-{% block content_title %}Thunderbird channels{% endblock%}
+{% set page_title = 'Thunderbird channels' %}
+
 {% block content_area %}
 <section id="intro">
   <h2>Release cycle</h2>

--- a/apps/styleguide/templates/styleguide/identity/thunderbird-color.html
+++ b/apps/styleguide/templates/styleguide/identity/thunderbird-color.html
@@ -5,7 +5,8 @@
   thunderbird-color
 {% endblock %}
 
-{% block content_title %}Thunderbird color{% endblock%}
+{% set page_title = 'Thunderbird color' %}
+
 {% block content_area %}
 <section id="intro">
   <h2>Usage</h2>

--- a/apps/styleguide/templates/styleguide/identity/thunderbird-logo.html
+++ b/apps/styleguide/templates/styleguide/identity/thunderbird-logo.html
@@ -5,7 +5,8 @@
   thunderbird-logo
 {% endblock %}
 
-{% block content_title %}Thunderbird logo{% endblock%}
+{% set page_title = 'Thunderbird logo' %}
+
 {% block content_area %}
 <section id="intro">
   <h2>Introduction</h2>

--- a/apps/styleguide/templates/styleguide/identity/thunderbird-wordmarks.html
+++ b/apps/styleguide/templates/styleguide/identity/thunderbird-wordmarks.html
@@ -5,7 +5,8 @@
   thunderbird-wordmarks
 {% endblock %}
 
-{% block content_title %}Thunderbird wordmarks{% endblock%}
+{% set page_title = 'Thunderbird wordmarks' %}
+
 {% block content_area %}
 <section id="intro">
   <h2>Usage</h2>

--- a/apps/styleguide/templates/styleguide/identity/webmaker-branding.html
+++ b/apps/styleguide/templates/styleguide/identity/webmaker-branding.html
@@ -5,7 +5,8 @@
   webmaker-branding
 {% endblock %}
 
-{% block content_title %}Webmaker branding{% endblock%}
+{% set page_title = 'Webmaker branding' %}
+
 {% block content_area %}
 <section id="intro">
   <h2>Introduction</h2>

--- a/apps/styleguide/templates/styleguide/identity/webmaker-color.html
+++ b/apps/styleguide/templates/styleguide/identity/webmaker-color.html
@@ -5,7 +5,8 @@
   webmaker-color
 {% endblock %}
 
-{% block content_title %}Webmaker color{% endblock%}
+{% set page_title = 'Webmaker color' %}
+
 {% block content_area %}
 <section id="intro">
   <h2>Usage</h2>

--- a/apps/styleguide/templates/styleguide/websites/community-overview.html
+++ b/apps/styleguide/templates/styleguide/websites/community-overview.html
@@ -5,7 +5,8 @@
   community-overview
 {% endblock %}
 
-{% block content_title %}Community sites{% endblock%}
+{% set page_title = 'Community sites' %}
+
 {% block content_area %}
 <section id="intro">
 <h2>Overview</h2>

--- a/apps/styleguide/templates/styleguide/websites/domains-overview.html
+++ b/apps/styleguide/templates/styleguide/websites/domains-overview.html
@@ -5,7 +5,8 @@
   domains-overview
 {% endblock %}
 
-{% block content_title %}Domain strategy{% endblock%}
+{% set page_title = 'Domain strategy' %}
+
 {% block content_area %}
 <section id="intro">
 <h2>Overview</h2>

--- a/apps/styleguide/templates/styleguide/websites/sandstone-buttons.html
+++ b/apps/styleguide/templates/styleguide/websites/sandstone-buttons.html
@@ -5,7 +5,8 @@
   sandstone-buttons
 {% endblock %}
 
-{% block content_title %}Sandstone buttons &amp icons{% endblock%}
+{% set page_title = 'Sandstone buttons & icons' %}
+
 {% block content_area %}
 
 <section id="buttons">

--- a/apps/styleguide/templates/styleguide/websites/sandstone-colors.html
+++ b/apps/styleguide/templates/styleguide/websites/sandstone-colors.html
@@ -5,7 +5,8 @@
   sandstone-colors
 {% endblock %}
 
-{% block content_title %}Sandstone backgrounds &amp color{% endblock%}
+{% set page_title = 'Sandstone backgrounds & color' %}
+
 {% block content_area %}
 
 <section id="backgrounds">

--- a/apps/styleguide/templates/styleguide/websites/sandstone-examples.html
+++ b/apps/styleguide/templates/styleguide/websites/sandstone-examples.html
@@ -5,7 +5,8 @@
   sandstone-examples
 {% endblock %}
 
-{% block content_title %}Sandstone examples{% endblock%}
+{% set page_title = 'Sandstone examples' %}
+
 {% block content_area %}
 <section id="intro">
   <h2>Websites</h2>

--- a/apps/styleguide/templates/styleguide/websites/sandstone-forms.html
+++ b/apps/styleguide/templates/styleguide/websites/sandstone-forms.html
@@ -5,7 +5,8 @@
   sandstone-forms
 {% endblock %}
 
-{% block content_title %}Sandstone forms &amp; modules{% endblock%}
+{% set page_title = 'Sandstone forms & modules' %}
+
 {% block content_area %}
 <section id="forms">
   <div class="intro">

--- a/apps/styleguide/templates/styleguide/websites/sandstone-grids.html
+++ b/apps/styleguide/templates/styleguide/websites/sandstone-grids.html
@@ -5,7 +5,8 @@
   sandstone-grids
 {% endblock %}
 
-{% block content_title %}Sandstone grid system{% endblock%}
+{% set page_title = 'Sandstone grid system' %}
+
 {% block content_area %}
 <section id="intro">
 <div>

--- a/apps/styleguide/templates/styleguide/websites/sandstone-intro.html
+++ b/apps/styleguide/templates/styleguide/websites/sandstone-intro.html
@@ -5,7 +5,8 @@
   sandstone-intro
 {% endblock %}
 
-{% block content_title %}Sandstone introduction{% endblock%}
+{% set page_title = 'Sandstone introduction' %}
+
 {% block content_area %}
 <section id="intro">
 <h2>What is Sandstone?</h2>

--- a/apps/styleguide/templates/styleguide/websites/sandstone-tables.html
+++ b/apps/styleguide/templates/styleguide/websites/sandstone-tables.html
@@ -5,7 +5,8 @@
   sandstone-tables
 {% endblock %}
 
-{% block content_title %}Sandstone tables &amp; lists{% endblock%}
+{% set page_title = 'Sandstone tables & lists' %}
+
 {% block content_area %}
 <section id="tables">
   <div class="intro">

--- a/apps/styleguide/templates/styleguide/websites/sandstone-tabzilla.html
+++ b/apps/styleguide/templates/styleguide/websites/sandstone-tabzilla.html
@@ -5,7 +5,8 @@
   sandstone-tabzilla
 {% endblock %}
 
-{% block content_title %}Sandstone Tabzilla{% endblock%}
+{% set page_title = 'Sandstone Tabzilla' %}
+
 {% block content_area %}
 <section id="intro">
 <div>

--- a/apps/styleguide/templates/styleguide/websites/sandstone-typefaces.html
+++ b/apps/styleguide/templates/styleguide/websites/sandstone-typefaces.html
@@ -5,7 +5,8 @@
   sandstone-typefaces
 {% endblock %}
 
-{% block content_title %}Sandstone typefaces{% endblock%}
+{% set page_title = 'Sandstone typefaces' %}
+
 {% block content_area %}
 <section id="intro">
   <h2>Open Sans @font-face</h2>

--- a/media/css/styleguide/websites-sandstone.less
+++ b/media/css/styleguide/websites-sandstone.less
@@ -358,3 +358,12 @@
 }
 
 /* }}} */
+/* {{{ Domain strategy*/
+
+.domains-overview {
+    #intro {
+        .span_guide(12);
+    }
+}
+
+/* }}} */


### PR DESCRIPTION
(use a template var to share title between HTML page title and in-page heading)
Also, a tiny style fix for the Domain strategory page
