### PR TITLE
Typo in persona/developer-faq.html, misplaced ')'

### DIFF
--- a/apps/persona/templates/persona/developer-faq.html
+++ b/apps/persona/templates/persona/developer-faq.html
@@ -44,7 +44,7 @@
 
     <dt>Can I be certain my email and password are secure?</dt>
     <dd>
-      <p>We take security and privacy very seriously (you can read our complete corporate <a href="http://www.mozilla.org/about/policies/privacy-policy.html)">privacy policy here</a>. With Persona, verified email addresses and encrypted passwords are saved on the Mozilla server.</p>
+      <p>We take security and privacy very seriously (you can read our complete corporate <a href="http://www.mozilla.org/about/policies/privacy-policy.html">privacy policy here</a>). With Persona, verified email addresses and encrypted passwords are saved on the Mozilla server.</p>
       <p>It uses a client-side cryptographic certificate (that is, it stores tamper-resistant proof in your browser) to prove to the site that the current user owns an particular email address. The site that you're logging in to never actually sees your password.</p>
     </dd>
     <dt>What is the difference between Persona and BrowserID?</dt>


### PR DESCRIPTION
The link to the privacy policy is broken on the live site: http://www.mozilla.org/en-US/persona/developer-faq/
