### PR TITLE
Bug 808539 - state of mozilla: specify lang fle to use for the main page

### DIFF
--- a/apps/foundation/templates/foundation/annualreport/2011.html
+++ b/apps/foundation/templates/foundation/annualreport/2011.html
@@ -3,6 +3,7 @@
 {% block page_title %}The State of Mozilla: 2011 Annual Report{% endblock %}
 {% block body_id %}annual-2011{% endblock %}
 {% block body_class %}sand{% endblock %}
+{% add_lang_files "foundation/annualreport/2011" %}
 
 {% block extrahead %}
   {{ css('annual_2011') }}
@@ -691,7 +692,7 @@
         </figure>
 
           <ul id="story-slider">
-          
+
             <li id="story-chit" class="vcard">
               <a class="contributor" href="http://videos-cdn.mozilla.net/serv/drafts/Contributorstory1.webm" data-poster="{{ MEDIA_URL }}img/foundation/annualreport/2011/contributors/chit-poster.jpg">
                 <hgroup>
@@ -710,7 +711,7 @@
                 </p>
               </a>
             </li>
-            
+
             <li id="story-viking" class="vcard">
               <a class="contributor" href="http://videos-cdn.mozilla.net/serv/drafts/Contributorstory2.webm" data-poster="{{ MEDIA_URL }}img/foundation/annualreport/2011/contributors/viking-poster.jpg">
                 <hgroup>
@@ -730,7 +731,7 @@
                 </p>
               </a>
             </li>
-            
+
             <li id="story-keng" class="vcard">
               <a class="contributor" href="http://videos-cdn.mozilla.net/serv/drafts/Contributorstory4.webm" data-poster="{{ MEDIA_URL }}img/foundation/annualreport/2011/contributors/keng-poster.jpg">
                 <hgroup>
@@ -749,7 +750,7 @@
                 </p>
               </a>
             </li>
-            
+
             <li id="story-claire" class="vcard">
               <a class="contributor" href="http://videos-cdn.mozilla.net/serv/drafts/Contributorstory5.webm" data-poster="{{ MEDIA_URL }}img/foundation/annualreport/2011/contributors/claire-poster.jpg">
                 <hgroup>
@@ -768,7 +769,7 @@
                 </p>
               </a>
             </li>
-            
+
             <li id="story-haitham" class="vcard">
               <a class="contributor" href="http://videos-cdn.mozilla.net/serv/drafts/Contributorstory6.webm" data-poster="{{ MEDIA_URL }}img/foundation/annualreport/2011/contributors/haitham-poster.jpg">
                 <hgroup>
@@ -787,7 +788,7 @@
                 </p>
               </a>
             </li>
-            
+
             <li id="story-ioana" class="vcard">
               <a class="contributor" href="http://videos-cdn.mozilla.net/serv/drafts/Contributorstory7.webm" data-poster="{{ MEDIA_URL }}img/foundation/annualreport/2011/contributors/ioana-poster.jpg">
                 <hgroup>
@@ -806,7 +807,7 @@
                 </p>
               </a>
             </li>
-            
+
             <li id="story-brian" class="vcard">
               <a class="contributor" href="http://videos-cdn.mozilla.net/serv/drafts/Contributorstory8.webm" data-poster="{{ MEDIA_URL }}img/foundation/annualreport/2011/contributors/brian-poster.jpg">
                 <hgroup>
@@ -825,7 +826,7 @@
                 </p>
               </a>
             </li>
-            
+
             <li id="story-mohomodou" class="vcard">
               <a class="contributor" href="http://videos-cdn.mozilla.net/serv/drafts/Contributorstory9.webm" data-poster="{{ MEDIA_URL }}img/foundation/annualreport/2011/contributors/mohomodou-poster.jpg">
                 <hgroup>
@@ -845,7 +846,7 @@
                 </p>
               </a>
             </li>
-  
+
           </ul>
 
       </section>


### PR DESCRIPTION
(also removes trailing white space)

I think this is a bedrock bug, but at least locally the only way to have localized strings in {%trans} blocks displayed consistently is to explicitely include the .lang file in the template. _() don't seem to have that problem and use the template path to get the strings, that's why I think menu items are translated on State of Mozilla but not the main text. Hopefuly, that will fix things on demo1 server (https://www-demo1.allizom.org/b/de/foundation/annualreport/2011/)
