### PR TITLE
Bug 808580. Correctly install gettext into Jinja2.

### DIFF
--- a/lib/l10n_utils/helpers.py
+++ b/lib/l10n_utils/helpers.py
@@ -25,9 +25,10 @@ def add_lang_files(ctx, files):
         req.langfiles = files + req.langfiles
 
 
-@jingo.register.function
+# TODO: make an ngettext compatible function. The pluaralize clause of a
+#       trans block won't work untill we do.
 @jinja2.contextfunction
-def _(ctx, text):
+def gettext(ctx, text):
     """Translate a string, loading the translations for the locale if
     necessary."""
     install_lang_files(ctx)
@@ -38,17 +39,17 @@ def _(ctx, text):
 
 @jingo.register.function
 @jinja2.contextfunction
-def gettext(ctx, text):
-    """Override the gettext call to pass through our system. This is
-    hacky, but lets us use the trans blocks and other nice integration
-    features of gettext. """
-    return _(ctx, text)
-
-
-@jingo.register.function
-@jinja2.contextfunction
 def lang_files(ctx, *files):
     """Add more lang files to the translation object"""
     # Filter out empty files
     install_lang_files(ctx)
     add_lang_files(ctx, [f for f in files if f])
+
+
+# backward compatible for imports
+_ = gettext
+
+
+# Once tower is fixed and we only need to install the above `gettext` function
+# into Jinja2 once, we should do it here. The call is simply:
+# jingo.env.install_gettext_callables(gettext, gettext)

--- a/lib/l10n_utils/middleware.py
+++ b/lib/l10n_utils/middleware.py
@@ -1,0 +1,17 @@
+import jingo
+
+from l10n_utils.helpers import gettext
+
+
+# TODO: Fix tower and remove this.
+class FixLangFileTranslationsMiddleware(object):
+    """
+    Middleware that will overwrite the gettext functions in the Jinja2 setup.
+    tower.activate() called by LocaleURLMiddleware sets them to tower's own
+    functions.
+
+    Bug 808580
+    """
+
+    def process_request(self, request):
+        jingo.env.install_gettext_callables(gettext, gettext)

--- a/lib/l10n_utils/template.py
+++ b/lib/l10n_utils/template.py
@@ -1,7 +1,16 @@
-import re
-import uuid
+from jinja2.ext import Extension, InternationalizationExtension, nodes
+from tower import strip_whitespace
 
-from jinja2.ext import Environment, Extension, nodes
+
+class I18nExtension(InternationalizationExtension):
+    """
+    Use this instead of `tower.template.i18n` because the override of `_`
+    global was throwing errors.
+    """
+    def _parse_block(self, parser, allow_pluralize):
+        ref, buffer = super(I18nExtension, self)._parse_block(parser,
+                                                              allow_pluralize)
+        return ref, strip_whitespace(buffer)
 
 
 class L10nBlockExtension(Extension):
@@ -80,7 +89,6 @@ class LoadLangExtension(Extension):
             content_nodes.insert(0, [nodes.Call(nodes.Name('super', 'load'),
                                                 [], [], None, None)])
 
-
         # Since we are a block, we must emit a block too, so make a
         # random one that contains a call to the load function
         node = nodes.Block().set_lineno(lineno)
@@ -94,3 +102,4 @@ class LoadLangExtension(Extension):
 # Makes for a prettier import in settings.py
 l10n_blocks = L10nBlockExtension
 lang_blocks = LoadLangExtension
+i18n = I18nExtension

--- a/lib/l10n_utils/tests/test_files/locale/de/trans_block_reload_test.lang
+++ b/lib/l10n_utils/tests/test_files/locale/de/trans_block_reload_test.lang
@@ -1,0 +1,6 @@
+;The State of Mozilla
+Die Lage von Mozilla
+
+
+;Mozilla‘s vision of the Internet is a place where anyone can access information, a place where everyone can hack and tinker; one that has openness, freedom and transparency; where users have control over their personal data and where all minds have the freedom to create and to consume without walls or tight restrictions.
+Mozillas Vision des Internets ist ein Ort, wo jeder auf Informationen zugreifen kann, ein Ort, wo jeder programmieren und herumspielen kann; einer, der offen, frei und transparent ist; wo Benutzer die Kontrolle über ihre persönlichen Daten haben und wo jeder Geist die Freiheit hat, zu schaffen und zu konsumieren, ohne Mauern oder enge Einschränkungen.

--- a/lib/l10n_utils/tests/test_files/templates/trans_block_reload_test.html
+++ b/lib/l10n_utils/tests/test_files/templates/trans_block_reload_test.html
@@ -1,0 +1,14 @@
+<html>
+  <body>
+    <h1>{{ _('The State of Mozilla') }}</h1>
+    <p>
+      {% trans %}
+        Mozilla‘s vision of the Internet is a place where anyone can
+        access information, a place where everyone can hack and tinker;
+        one that has openness, freedom and transparency; where users have
+        control over their personal data and where all minds have the
+        freedom to create and to consume without walls or tight restrictions.
+      {% endtrans %}
+    </p>
+  </body>
+</html>

--- a/lib/l10n_utils/tests/test_files/urls.py
+++ b/lib/l10n_utils/tests/test_files/urls.py
@@ -1,0 +1,7 @@
+from django.conf.urls.defaults import *
+from mozorg.util import page
+
+
+urlpatterns = patterns('',
+    page('trans-block-reload-test', 'trans_block_reload_test.html'),
+)

--- a/settings/base.py
+++ b/settings/base.py
@@ -48,7 +48,7 @@ TEMPLATE_DIRS = (
 def JINJA_CONFIG():
     return {
         'extensions': [
-            'tower.template.i18n', 'jinja2.ext.do', 'jinja2.ext.with_',
+            'l10n_utils.template.i18n', 'jinja2.ext.do', 'jinja2.ext.with_',
             'jinja2.ext.loopcontrols', 'l10n_utils.template.l10n_blocks',
             'l10n_utils.template.lang_blocks'
         ],
@@ -407,6 +407,7 @@ MIDDLEWARE_CLASSES = (
     'mozorg.middleware.CacheMiddleware',
     'mozorg.middleware.NewsletterMiddleware',
     'dnt.middleware.DoNotTrackMiddleware',
+    'l10n_utils.middleware.FixLangFileTranslationsMiddleware',
 )
 
 INSTALLED_APPS = (


### PR DESCRIPTION
Tower's `activate()` function installs its own gettext
functions on every request. This was causing bedrock
to be unable to use lang files with Jinja2's i18n
extension. For now we're using our own middleware
to uninstall tower's functions and reinstall our own,
but long term we should fix tower.
