### PR TITLE
Bug 794059. Allow pages to be activated per locale.

### DIFF
--- a/lib/l10n_utils/__init__.py
+++ b/lib/l10n_utils/__init__.py
@@ -1,8 +1,11 @@
 from django.conf import settings
+from django.http import HttpResponseRedirect
 
-from dotlang import get_lang_path
 import jingo
+from funfactory.urlresolvers import split_path
 from jinja2.exceptions import TemplateNotFound
+
+from dotlang import get_lang_path, lang_file_is_active
 
 
 def render(request, template, context={}, **kwargs):
@@ -18,17 +21,26 @@ def render(request, template, context={}, **kwargs):
 
     if present, otherwise, it'll render the specified (en-US) template.
     """
+    # Every template gets its own .lang file, so figure out what it is
+    # and pass it in the context
+    context['langfile'] = get_lang_path(template)
+
     # Look for localized template if not default lang.
     if request.locale != settings.LANGUAGE_CODE:
+
+        # redirect to default lang if locale not active
+        if not (settings.DEV or
+                lang_file_is_active(context['langfile'], request.locale)):
+            return HttpResponseRedirect('/' + '/'.join([
+                settings.LANGUAGE_CODE,
+                split_path(request.get_full_path())[1]
+            ]))
+
         localized_tmpl = '%s/templates/%s' % (request.locale, template)
         try:
             return jingo.render(request, localized_tmpl, context, **kwargs)
         except TemplateNotFound:
             # If not found, just go on and try rendering the parent template.
             pass
-
-    # Every template gets its own .lang file, so figure out what it is
-    # and pass it in the context
-    context['langfile'] = get_lang_path(template)
 
     return jingo.render(request, template, context, **kwargs)

--- a/lib/l10n_utils/dotlang.py
+++ b/lib/l10n_utils/dotlang.py
@@ -155,3 +155,30 @@ def get_lang_path(path):
     path = '/'.join(p)
     base, ext = os.path.splitext(path)
     return base
+
+
+def lang_file_is_active(path, lang):
+    """
+    If the lang file for a locale exists and has the correct comment returns
+    True, and False otherwise.
+    :param path: the relative lang file name
+    :param lang: the language code
+    :return: bool
+    """
+    rel_path = os.path.join('locale', lang, '%s.lang' % path)
+    cache_key = 'active:%s' % rel_path
+    is_active = cache.get(cache_key)
+    if is_active is None:
+        is_active = False
+        fpath = os.path.join(settings.ROOT, rel_path)
+        try:
+            with codecs.open(fpath, 'r', 'utf-8', errors='replace') as lines:
+                firstline = lines.readline()
+                if firstline.startswith('## active ##'):
+                    is_active = True
+        except IOError:
+            pass
+
+        cache.set(cache_key, is_active, settings.DOTLANG_CACHE)
+
+    return is_active

--- a/lib/l10n_utils/tests/test_files/locale/de/active_de_lang_file.lang
+++ b/lib/l10n_utils/tests/test_files/locale/de/active_de_lang_file.lang
@@ -1,0 +1,8 @@
+## active ##
+
+;The State of Mozilla
+Die Lage von Mozilla
+
+
+;Mozilla‘s vision of the Internet is a place where anyone can access information, a place where everyone can hack and tinker; one that has openness, freedom and transparency; where users have control over their personal data and where all minds have the freedom to create and to consume without walls or tight restrictions.
+Mozillas Vision des Internets ist ein Ort, wo jeder auf Informationen zugreifen kann, ein Ort, wo jeder programmieren und herumspielen kann; einer, der offen, frei und transparent ist; wo Benutzer die Kontrolle über ihre persönlichen Daten haben und wo jeder Geist die Freiheit hat, zu schaffen und zu konsumieren, ohne Mauern oder enge Einschränkungen.

--- a/lib/l10n_utils/tests/test_files/locale/de/inactive_de_lang_file.lang
+++ b/lib/l10n_utils/tests/test_files/locale/de/inactive_de_lang_file.lang
@@ -1,0 +1,6 @@
+;The State of Mozilla
+Die Lage von Mozilla
+
+
+;Mozilla‘s vision of the Internet is a place where anyone can access information, a place where everyone can hack and tinker; one that has openness, freedom and transparency; where users have control over their personal data and where all minds have the freedom to create and to consume without walls or tight restrictions.
+Mozillas Vision des Internets ist ein Ort, wo jeder auf Informationen zugreifen kann, ein Ort, wo jeder programmieren und herumspielen kann; einer, der offen, frei und transparent ist; wo Benutzer die Kontrolle über ihre persönlichen Daten haben und wo jeder Geist die Freiheit hat, zu schaffen und zu konsumieren, ohne Mauern oder enge Einschränkungen.

--- a/lib/l10n_utils/tests/test_files/templates/active_de_lang_file.html
+++ b/lib/l10n_utils/tests/test_files/templates/active_de_lang_file.html
@@ -1,0 +1,14 @@
+<html>
+<body>
+<h1>{{ _('The State of Mozilla') }}</h1>
+<p>
+    {% trans %}
+        Mozilla‘s vision of the Internet is a place where anyone can
+        access information, a place where everyone can hack and tinker;
+        one that has openness, freedom and transparency; where users have
+        control over their personal data and where all minds have the
+        freedom to create and to consume without walls or tight restrictions.
+    {% endtrans %}
+</p>
+</body>
+</html>

--- a/lib/l10n_utils/tests/test_files/templates/inactive_de_lang_file.html
+++ b/lib/l10n_utils/tests/test_files/templates/inactive_de_lang_file.html
@@ -1,0 +1,14 @@
+<html>
+<body>
+<h1>{{ _('The State of Mozilla') }}</h1>
+<p>
+    {% trans %}
+        Mozilla‘s vision of the Internet is a place where anyone can
+        access information, a place where everyone can hack and tinker;
+        one that has openness, freedom and transparency; where users have
+        control over their personal data and where all minds have the
+        freedom to create and to consume without walls or tight restrictions.
+    {% endtrans %}
+</p>
+</body>
+</html>

--- a/lib/l10n_utils/tests/test_files/urls.py
+++ b/lib/l10n_utils/tests/test_files/urls.py
@@ -4,4 +4,6 @@ from mozorg.util import page
 
 urlpatterns = patterns('',
     page('trans-block-reload-test', 'trans_block_reload_test.html'),
+    page('active-de-lang-file', 'active_de_lang_file.html'),
+    page('inactive-de-lang-file', 'inactive_de_lang_file.html'),
 )

--- a/lib/l10n_utils/tests/test_template.py
+++ b/lib/l10n_utils/tests/test_template.py
@@ -18,14 +18,14 @@ ROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'test_files')
 TEMPLATE_DIRS = (os.path.join(ROOT, 'templates'),)
 
 
+@patch.object(env, 'loader', FileSystemLoader(TEMPLATE_DIRS))
+@patch.object(settings, 'ROOT_URLCONF', 'l10n_utils.tests.test_files.urls')
+@patch.object(settings, 'ROOT', ROOT)
 class TestTransBlocks(TestCase):
     def setUp(self):
         clear_url_caches()
         self.client = Client()
 
-    @patch.object(env, 'loader', FileSystemLoader(TEMPLATE_DIRS))
-    @patch.object(settings, 'ROOT_URLCONF', 'l10n_utils.tests.test_files.urls')
-    @patch.object(settings, 'ROOT', ROOT)
     def test_trans_block_works(self):
         """ Sanity check to make sure translations work at all. """
         response = self.client.get('/de/trans-block-reload-test/')


### PR DESCRIPTION
Going to a page at a non en-US locale will now redirect
to en-US unless the corresponding .lang file for that 
template and locale has `## active ##` as its first
line. This will allow localizers to only publish a 
localized page after it's confirmed to be fully and
correctly translated.
