### PR TITLE
Bug 811230: fix a string in download box for whatsnew page not enclosed ...

### DIFF
--- a/apps/mozorg/templates/mozorg/download_button_base.html
+++ b/apps/mozorg/templates/mozorg/download_button_base.html
@@ -21,7 +21,7 @@
         {% block download_content scoped %}
           <span class="download-content">
             <span class="download-title">{% block title scoped %}Firefox{% endblock %}</span>
-            {% block subtitle scoped %}Free Download{% endblock %}
+            {% block subtitle scoped %}{{ _('Free Download') }}{% endblock %}
             {% block download_info scoped %}
               <span class="download-info">
                 {% block download_version scoped %}


### PR DESCRIPTION
...in l10n call
