### PR TITLE
Bug 812263: Fix patch-level version comparison issue.

### DIFF
--- a/apps/firefox/tests.py
+++ b/apps/firefox/tests.py
@@ -3,6 +3,7 @@ import unittest
 from django.test.client import Client
 
 from funfactory.urlresolvers import reverse
+from mock import patch
 from mozorg.tests import TestCase
 from nose.plugins.skip import SkipTest
 from nose.tools import eq_
@@ -23,81 +24,66 @@ class TestLoadDevices(unittest.TestCase):
         #todo
 
 
-class TestWhatsnewRedirect(TestCase):
+class FxVersionRedirectsMixin(object):
+    def test_non_firefox(self):
+        user_agent = 'random'
+        response = self.client.get(self.url, HTTP_USER_AGENT=user_agent)
+        eq_(response.status_code, 301)
+        eq_(response['Vary'], 'User-Agent')
+        eq_(response['Location'],
+            'http://testserver%s' % reverse('firefox.new'))
+
+    @patch.dict(product_details.firefox_versions,
+                LATEST_FIREFOX_VERSION='14.0')
+    def test_old_firefox(self):
+        user_agent = ('Mozilla/5.0 (Macintosh; Intel Mac OS X 10.7; rv:13.0) '
+                      'Gecko/20100101 Firefox/13.0')
+        response = self.client.get(self.url, HTTP_USER_AGENT=user_agent)
+        eq_(response.status_code, 301)
+        eq_(response['Vary'], 'User-Agent')
+        eq_(response['Location'],
+            'http://testserver%s' % reverse('firefox.update'))
+
+    @patch.dict(product_details.firefox_versions,
+                LATEST_FIREFOX_VERSION='13.0.5')
+    def test_current_minor_version_firefox(self):
+        """
+        Should show current even if behind by a patch version
+        """
+        user_agent = ('Mozilla/5.0 (Macintosh; Intel Mac OS X 10.7; rv:13.0) '
+                      'Gecko/20100101 Firefox/13.0')
+        response = self.client.get(self.url, HTTP_USER_AGENT=user_agent)
+        eq_(response.status_code, 200)
+        eq_(response['Vary'], 'User-Agent')
+
+    @patch.dict(product_details.firefox_versions,
+                LATEST_FIREFOX_VERSION='16.0')
+    def test_current_firefox(self):
+        user_agent = ('Mozilla/5.0 (Macintosh; Intel Mac OS X 10.7; rv:16.0) '
+                      'Gecko/20100101 Firefox/16.0')
+        response = self.client.get(self.url, HTTP_USER_AGENT=user_agent)
+        eq_(response.status_code, 200)
+        eq_(response['Vary'], 'User-Agent')
+
+    @patch.dict(product_details.firefox_versions,
+                LATEST_FIREFOX_VERSION='16.0')
+    def test_future_firefox(self):
+        user_agent = ('Mozilla/5.0 (Macintosh; Intel Mac OS X 10.7; rv:18.0) '
+                      'Gecko/20100101 Firefox/18.0')
+        response = self.client.get(self.url, HTTP_USER_AGENT=user_agent)
+        eq_(response.status_code, 200)
+        eq_(response['Vary'], 'User-Agent')
+
+
+class TestWhatsnewRedirect(FxVersionRedirectsMixin, TestCase):
     def setUp(self):
         self.client = Client()
         with self.activate('en-US'):
             self.url = reverse('firefox.whatsnew', args=['13.0'])
 
-    def test_non_firefox(self):
-        user_agent = 'random'
-        response = self.client.get(self.url, HTTP_USER_AGENT=user_agent)
-        eq_(response.status_code, 301)
-        eq_(response['Vary'], 'User-Agent')
-        eq_(response['Location'],
-            'http://testserver%s' % reverse('firefox.new'))
 
-    def test_old_firefox(self):
-        user_agent = ('Mozilla/5.0 (Macintosh; Intel Mac OS X 10.7; rv:13.0) '
-                      'Gecko/20100101 Firefox/13.0')
-        response = self.client.get(self.url, HTTP_USER_AGENT=user_agent)
-        eq_(response.status_code, 301)
-        eq_(response['Vary'], 'User-Agent')
-        eq_(response['Location'],
-            'http://testserver%s' % reverse('firefox.update'))
-
-    def test_current_firefox(self):
-        current = product_details.firefox_versions['LATEST_FIREFOX_VERSION']
-        user_agent = ('Mozilla/5.0 (Macintosh; Intel Mac OS X 10.7; rv:%s) '
-                      'Gecko/20100101 Firefox/%s' % (current, current))
-        response = self.client.get(self.url, HTTP_USER_AGENT=user_agent)
-        eq_(response.status_code, 200)
-        eq_(response['Vary'], 'User-Agent')
-
-    def test_future_firefox(self):
-        future = product_details.firefox_versions['FIREFOX_AURORA']
-        user_agent = ('Mozilla/5.0 (Macintosh; Intel Mac OS X 10.7; rv:%s) '
-                      'Gecko/20100101 Firefox/%s' % (future, future))
-        response = self.client.get(self.url, HTTP_USER_AGENT=user_agent)
-        eq_(response.status_code, 200)
-        eq_(response['Vary'], 'User-Agent')
-
-
-class TestFirstrunRedirect(TestCase):
+class TestFirstrunRedirect(FxVersionRedirectsMixin, TestCase):
     def setUp(self):
         self.client = Client()
         with self.activate('en-US'):
             self.url = reverse('firefox.firstrun', args=['13.0'])
-
-    def test_non_firefox(self):
-        user_agent = 'random'
-        response = self.client.get(self.url, HTTP_USER_AGENT=user_agent)
-        eq_(response.status_code, 301)
-        eq_(response['Vary'], 'User-Agent')
-        eq_(response['Location'],
-            'http://testserver%s' % reverse('firefox.new'))
-
-    def test_old_firefox(self):
-        user_agent = ('Mozilla/5.0 (Macintosh; Intel Mac OS X 10.7; rv:13.0) '
-                      'Gecko/20100101 Firefox/13.0')
-        response = self.client.get(self.url, HTTP_USER_AGENT=user_agent)
-        eq_(response.status_code, 301)
-        eq_(response['Vary'], 'User-Agent')
-        eq_(response['Location'],
-            'http://testserver%s' % reverse('firefox.update'))
-
-    def test_current_firefox(self):
-        current = product_details.firefox_versions['LATEST_FIREFOX_VERSION']
-        user_agent = ('Mozilla/5.0 (Macintosh; Intel Mac OS X 10.7; rv:%s) '
-                      'Gecko/20100101 Firefox/%s' % (current, current))
-        response = self.client.get(self.url, HTTP_USER_AGENT=user_agent)
-        eq_(response.status_code, 200)
-        eq_(response['Vary'], 'User-Agent')
-
-    def test_future_firefox(self):
-        future = product_details.firefox_versions['FIREFOX_AURORA']
-        user_agent = ('Mozilla/5.0 (Macintosh; Intel Mac OS X 10.7; rv:%s) '
-                      'Gecko/20100101 Firefox/%s' % (future, future))
-        response = self.client.get(self.url, HTTP_USER_AGENT=user_agent)
-        eq_(response.status_code, 200)
-        eq_(response['Vary'], 'User-Agent')

--- a/apps/firefox/views.py
+++ b/apps/firefox/views.py
@@ -83,8 +83,7 @@ def latest_fx_redirect(request, fake_version, template_name):
     if match:
         user_version = match.group(1)
 
-    current_version = product_details.firefox_versions['LATEST_FIREFOX_VERSION']
-    if Version(user_version) < Version(current_version):
+    if not is_current_or_newer(user_version):
         url = reverse('firefox.update')
         return HttpResponsePermanentRedirect(url)
 
@@ -101,3 +100,17 @@ def latest_fx_redirect(request, fake_version, template_name):
     }
     return l10n_utils.render(request, template_name,
                              {'locales_with_video': locales_with_video})
+
+
+def is_current_or_newer(user_version):
+    """
+    Return true if the version (X.Y only) is for the latest Firefox or newer.
+    """
+    latest = Version(product_details.firefox_versions['LATEST_FIREFOX_VERSION'])
+    user = Version(user_version)
+
+    # similar to the way comparison is done in the Version class,
+    # but only using the major and minor versions.
+    latest_int = int('%d%02d' % (latest.major, latest.minor1))
+    user_int = int('%d%02d' % (user.major, user.minor1))
+    return user_int >= latest_int


### PR DESCRIPTION
Use mock to avoid relying on product_details for tests.
