### PR TITLE
Bug 814381 - enclose strings in l10n calls for /firefoxos/ page

### DIFF
--- a/apps/firefoxos/templates/firefoxos/firefoxos.html
+++ b/apps/firefoxos/templates/firefoxos/firefoxos.html
@@ -7,12 +7,12 @@
 
 <hgroup id="main-feature">
   <h1><img src="{{ MEDIA_URL }}img/firefoxos/wordmark-firefoxos.png" alt="Firefox OS"></h1>
-  <h2>Bringing the Open Web to mobile devices</h2>
+  <h2>{{ _('Bringing the Open Web to mobile devices') }}</h2>
 </hgroup>
 
 <section id="primary" class="billboard">
-  <h2>Welcome to a new, open and powerful mobile world!</h2>
-  <p>Firefox OS enables the Open Web as a platform for mobile devices. We’re making innovation possible by driving the development of new Web standards.</p>
+  <h2>{{ _('Welcome to a new, open and powerful mobile world!') }}</h2>
+  <p>{{ _('Firefox OS enables the Open Web as a platform for mobile devices. We’re making innovation possible by driving the development of new Web standards.') }}</p>
   <img src="{{ MEDIA_URL }}img/firefoxos/firefox-phone.png" alt="">
 </section>
 
@@ -22,11 +22,11 @@
     <div class="figure">
       <img src="{{ MEDIA_URL }}img/firefoxos/example-apps.jpg" alt="">
     </div>
-    <h3>New Web standards</h3>
-    <p>Firefox OS will produce an implementation of these new Web standards to free mobile platforms from the encumbrances of the rules and restrictions of existing proprietary platforms.</p>
+    <h3>{{ _('New Web standards') }}</h3>
+    <p>{{ _('Firefox OS will produce an implementation of these new Web standards to free mobile platforms from the encumbrances of the rules and restrictions of existing proprietary platforms.') }}</p>
    
-    <h3>Freedom from proprietary mobile platforms</h3>
-    <p>We're collaborating with OEMs and carriers directly, giving them more influence to meet the specific needs of their users and market. Users and developers aren't locked in to one platform, so they can access their info and use apps across multiple devices.</p>
+    <h3>{{ _('Freedom from proprietary mobile platforms') }}</h3>
+    <p>{{ _('We’re collaborating with <abbr title="Original Equipment Manufacturer">OEM</abbr>s and carriers directly, giving them more influence to meet the specific needs of their users and market. Users and developers aren’t locked in to one platform, so they can access their info and use apps across multiple devices.') }}</p>
   </div>
   
   <div class="section right">
@@ -34,16 +34,16 @@
       <img src="{{ MEDIA_URL }}img/firefoxos/example-radio.jpg" alt="">
       <img src="{{ MEDIA_URL }}img/firefoxos/example-music.jpg" alt="">
     </div>
-    <h3>Customization for OEMs and operators</h3>
-    <p>OEMs and operators will be able to provide content and services across their entire device portfolio, regardless of OS. And they will be able to customize user experiences, manage app distribution and retain customer attention, loyalty and billing relationships.</p>
+    <h3>{{ _('Customization for <abbr>OEM</abbr>s and operators')}}</h3> 
+    <p>{{ _('<abbr>OEM</abbr>s and operators will be able to provide content and services across their entire device portfolio, regardless of OS. And they will be able to customize user experiences, manage app distribution and retain customer attention, loyalty and billing relationships.') }}</p>
   </div>
   
   <div class="section left">
     <div class="figure">
       <img src="{{ MEDIA_URL }}img/firefoxos/example-browser.jpg" alt="">
     </div>
-    <h3>Opportunities for developers</h3>
-    <p>Using HTML5 and the new Mozilla-proposed standard APIs, developers everywhere will be able to create amazing experiences and apps. Developers will no longer need to learn and develop against platform-specific native APIs.</p>
+    <h3>{{ _('Opportunities for developers') }}</h3>
+    <p>{{ _('Using HTML5 and the new Mozilla-proposed standard APIs, developers everywhere will be able to create amazing experiences and apps. Developers will no longer need to learn and develop against platform-specific native APIs.') }}</p>
   </div>
   
   <div class="section right">
@@ -51,8 +51,8 @@
       <img src="{{ MEDIA_URL }}img/firefoxos/example-videos.jpg" alt="">
       <img src="{{ MEDIA_URL }}img/firefoxos/example-gallery.jpg" alt="">
     </div>
-    <h3>Consumer freedom</h3>
-    <p>Consumers who use devices powered by Firefox OS won't be locked into one specific platform giving them more choice, flexibility and freedom. With Firefox OS, the Web is the platform.</p>
+    <h3>{{ _('Consumer freedom') }}</h3>
+    <p>{{ _('Consumers who use devices powered by Firefox OS won’t be locked into one specific platform giving them more choice, flexibility and freedom. With Firefox OS, the Web is the platform.') }}</p>
   </div>
 
 </section>


### PR DESCRIPTION
This pull requests encloses all the strings in l10n calls, it also adds an abrr tag to OEM with a definition for the first occurrence for accessibility. Following OEM mentions in the page only use the abbr tag without a title (no need to repeat the definition but we need to use the abbr tag for text tp speech correct pronunciation of the acronym). Thanks to Kinouchou our accessibility expert from the French Mozilla community for the accessibility review :)
