### PR TITLE
Turn off android animation for small screens

### DIFF
--- a/media/css/firefox/fx.less
+++ b/media/css/firefox/fx.less
@@ -290,6 +290,15 @@
             img {
                 height: auto;
             }
+            #phone-screen {
+                top: 36px;
+                left: 39px;
+                height: 214px;
+                width: 126px;
+                -moz-animation: none;
+                -webkit-animation: none;
+                animation: none;
+            }
         }
         #download-column,
         .sub-features {


### PR DESCRIPTION
[Bug 815636] New: /firefox/fx looks bad with a 855px browser width
