### PR TITLE
Bug 816531: fix a form string wrong on all pages for locales

### DIFF
--- a/templates/macros.html
+++ b/templates/macros.html
@@ -60,7 +60,7 @@
 
       <div class="form-submit">
         <input type="submit" id="footer_email_submit"
-               value="{{ _('Sign me up »') }}" class="button">
+               value="{{ _('Sign me up') }} »" class="button">
 
         <p class="form-details">
           <small>{{ _('We will only send you Mozilla-related information.') }}</small>


### PR DESCRIPTION
move decorator chevron out of the translation because we already have this string without it
