### PR TITLE
Fix bug 816559 - Fix the blog URL

### DIFF
--- a/apps/mozorg/templates/mozorg/itu.html
+++ b/apps/mozorg/templates/mozorg/itu.html
@@ -30,7 +30,7 @@
           <ol>
             <li>
               <h3>Learn Why This Matters</h3>
-              <p>Read <a href="https://blog.mozilla.org/blog/2012/11/30/the-itu-and-you/">Mozilla's position on the ITU</a> and explore other <a href="https://webmaker.org/ITU/kit/#the-issues">resources from across the Web</a>.</p>
+              <p>Read <a href="https://blog.mozilla.org/blog/2012/11/29/the-itu-and-you/">Mozilla's position on the ITU</a> and explore other <a href="https://webmaker.org/ITU/kit/#the-issues">resources from across the Web</a>.</p>
             </li>
             <li>
               <h3>Create Your Message</h3>


### PR DESCRIPTION
Now got 29 instead of 30 as the launch date
