### PR TITLE
Bug 805277 : don't show marketplace newsletter subscription field to locales

### DIFF
--- a/apps/marketplace/templates/marketplace/marketplace.html
+++ b/apps/marketplace/templates/marketplace/marketplace.html
@@ -174,9 +174,11 @@
 {% endblock %}
 
 {% block email_form %}
-  {{ email_newsletter_form('app-dev',
-                           _('Sign up for more news about the Firefox Marketplace.'),
-                           include_language=False) }}
+  {% if LANG.startswith('en') %}
+      {{ email_newsletter_form('app-dev',
+                              _('Sign up for more news about the Firefox Marketplace.'),
+                              include_language=False) }}
+  {% endif %}
 {% endblock %}
 
 {% block js %}


### PR DESCRIPTION
As per comment 10 in Bug 805277, we are deactivating the marketplace newsletter subscription link for non English locales until engagement decides on a potential translation of these newsletters so as to allow pushing our translations of the page to production.
