### PR TITLE
Updates to State of Mozilla

### DIFF
--- a/apps/foundation/templates/foundation/annualreport/2011.html
+++ b/apps/foundation/templates/foundation/annualreport/2011.html
@@ -13,6 +13,17 @@
 {% block extrahead %}
   {{ css('annual_2011') }}
   <link rel="stylesheet" media="print" href="{{ MEDIA_URL }}css/foundation/annual2011print.css">
+
+  <script type="text/javascript">
+    var _gaq = _gaq || [];
+    _gaq.push(['_setAccount', 'UA-36116321-1']);
+    _gaq.push(['_trackPageview']);
+    (function() {
+      var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
+      ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
+      var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
+    })();
+  </script>
 {% endblock %}
 
 {% block js %}
@@ -54,7 +65,7 @@
 
       <figure class="right video">
         <a class="video-play" href="https://videos-cdn.mozilla.net/brand/Mozilla_2011_Story.webm" data-video-source="https://videos-cdn.mozilla.net/brand/Mozilla_2011_Story" title="{{ _('Click to play this video') }}">
-          <img src="{{ MEDIA_URL }}img/foundation/annualreport/2011/vid-welcome.jpg" alt="" width="380">
+          <img src="{{ media('img/foundation/annualreport/2011/vid-welcome.jpg') }}" alt="{{ _('Watch a brief video about Mozilla and our mission') }}" width="380">
         </a>
       </figure>
 
@@ -103,9 +114,9 @@
       <section class="row has-overlay mob-intro">
         <div class="overlay-wrap">
           <ul class="mob-topics">
-            <li id="topic-firefox"><img src="{{ MEDIA_URL }}img/foundation/annualreport/2011/logo-firefox.png" alt="">Firefox</li>
-            <li id="topic-firefoxos"><img src="{{ MEDIA_URL }}img/foundation/annualreport/2011/logo-firefoxos.png" alt="">Firefox OS</li>
-            <li id="topic-webmaker"><img src="{{ MEDIA_URL }}img/foundation/annualreport/2011/logo-webmaker.png" alt="">Webmaker</li>
+            <li id="topic-firefox"><img src="{{ media('img/foundation/annualreport/2011/logo-firefox.png') }}" alt="">Firefox</li>
+            <li id="topic-firefoxos"><img src="{{ media('img/foundation/annualreport/2011/logo-firefoxos.png') }}" alt="">Firefox OS</li>
+            <li id="topic-webmaker"><img src="{{ media('img/foundation/annualreport/2011/logo-webmaker.png') }}" alt="">Webmaker</li>
           </ul>
 
           <div class="overlay">
@@ -192,7 +203,7 @@
       <section class="row has-overlay mob-fxandroid">
         <h3>{{ _('Firefox for Android') }}</h3>
 
-        <img class="left" src="{{ MEDIA_URL }}img/foundation/annualreport/2011/fxandroid-phone.png" alt="">
+        <img class="left" src="{{ media('img/foundation/annualreport/2011/fxandroid-phone.png') }}" alt="">
 
         <div class="right overlay-wrap">
           {# L10N: "Fast. Smart. Safe." is a slogan for Firefox for Android. It appears here as three separate strings for styling and layout purposes. #}
@@ -250,9 +261,9 @@
               Several performance and security improvements, memory enhancements make
               this the best Firefox yet. We're proud of the work that we're doing to
               make developing on Firefox easier by adding exciting tools for developers,
-              like <a href="{{ cmdline_url }}" rel="external">Developer Command Line</a>,
-              <a href="{{ console_url }}" rel="external">Web Console</a>
-              and <a href="{{ tilt_url }}" rel="external">“Tilt” the 3D Page Inspector</a>.
+              like <a href="{{ cmdline_url }}" rel="external" hreflang="en-US">Developer Command Line</a>,
+              <a href="{{ console_url }}" rel="external" hreflang="en-US">Web Console</a>
+              and <a href="{{ tilt_url }}" rel="external" hreflang="en-US">“Tilt” the 3D Page Inspector</a>.
             {% endtrans %}
             </p>
 
@@ -318,7 +329,7 @@
         <h3>{{ _('Webmaker: Video') }}</h3>
         <figure class="video">
           <a class="video-play" href="https://webmaker.org/videos/" data-video-source="https://videos-cdn.mozilla.net/serv/webmademovies/webmakers-instructors" title="{{ _('Click to view this video') }}">
-            <img src="{{ MEDIA_URL }}img/foundation/annualreport/2011/vid-webmaker.jpg" alt="{{ _('Webmaker: Video') }}">
+            <img src="{{ media('img/foundation/annualreport/2011/vid-webmaker.jpg') }}" alt="{{ _('Watch this video about teaching the next generation of Webmakers') }}">
           </a>
         </figure>
       </aside>
@@ -345,12 +356,12 @@
                 ocallahan_url='http://robert.ocallahan.org/' %}
               Mozilla has always contributed to Web standards, going back
               as far as the start of the project, and we will continue to do
-              that moving forward. We <a href="{{ cofound_url }}" rel="external">co-founded</a>
-              the <a href="{{ whatwg_url }}" rel="external">WHAT-WG</a> to kick off
-              <a href="{{ html5_url }}" rel="external">HTML5</a>. We are a leaders in
-              <a href="{{ javascript_url }}" rel="external">JavaScript standardization</a>. We
-              have some of the top <a href="{{ dbaron_url }}" rel="external">CSS</a> and
-              <a href="{{ ocallahan_url }}" rel="external">layout</a> experts in the world.
+              that moving forward. We <a href="{{ cofound_url }}" rel="external" hreflang="en-US">co-founded</a>
+              the <a href="{{ whatwg_url }}" rel="external" hreflang="en-US">WHAT-WG</a> to kick off
+              <a href="{{ html5_url }}" rel="external" hreflang="en-US">HTML5</a>. We are a leaders in
+              <a href="{{ javascript_url }}" rel="external" hreflang="en-US">JavaScript standardization</a>. We
+              have some of the top <a href="{{ dbaron_url }}" rel="external" hreflang="en-US">CSS</a> and
+              <a href="{{ ocallahan_url }}" rel="external" hreflang="en-US">layout</a> experts in the world.
             {% endtrans %}
             </p>
 
@@ -404,7 +415,7 @@
         <h3>{{ _('Do Not Track') }}</h3>
 
         <div class="overlay-wrap">
-          <img src="{{ MEDIA_URL }}img/foundation/annualreport/2011/logo-donottrack.png" alt="">
+          <img src="{{ media('img/foundation/annualreport/2011/logo-donottrack.png') }}" alt="">
 
           <div class="overlay">
             <p>
@@ -425,7 +436,7 @@
               we developed the <a href="{{ dnt_url }}" rel="external">Do Not Track</a> feature
               in Firefox. We also became the first browser manufacturer to offer
               it on multiple platforms, including Windows, Mac, Linux and Android.
-              <a href="{{ dntfxos_url }}" rel="external">Do Not Track is even available for Firefox OS</a>
+              <a href="{{ dntfxos_url }}" rel="external" hreflang="en-US">Do Not Track is even available for Firefox OS</a>
               so that user privacy settings can be controlled on a system-wide
               level to ensure that every third-party application on a user's device
               respects their choice.
@@ -448,13 +459,14 @@
     <div class="row">
 
       <section class="left act-sopa has-overlay">
+        {# L10N: These acronyms don't require translation, but the structure of the heading may change for some locales. #}
         <h3>{{ _('SOPA / PIPA & ACTA') }}</h3>
 
         <div class="overlay-wrap">
-          <img src="{{ MEDIA_URL }}img/foundation/annualreport/2011/act-sopa.jpg" alt="">
+          <img src="{{ media('img/foundation/annualreport/2011/act-sopa.jpg') }}" alt="">
 
           <div class="overlay">
-            <h4>SOPA/PIPA</h4>
+            <h4>{{ _('SOPA/PIPA') }}</h4>
 
             <p>
             {% trans %}
@@ -484,7 +496,7 @@
             {% trans acta_url='https://blog.lizardwrangler.com/2012/02/10/acta-is-a-bad-way-to-develop-internet-policy/' %}
               Early in 2012, Mozilla warned against the ratification of the
               Anti-Counterfeiting Trade Agreement (<abbr>ACTA</abbr>) by the
-              European Parliament. <a href="{{ acta_url }}" rel="external">In a blog post</a>,
+              European Parliament. <a href="{{ acta_url }}" rel="external" hreflang="en-US">In a blog post</a>,
               Mitchell Baker urged the policymakers that opaque processes were a
               “bad way to develop Internet policy” — in particular, that the global
               trade agreement was negotiated in private without open involvement
@@ -501,7 +513,7 @@
         <h3>{{ _('Firefox Flicks') }}</h3>
 
         <div class="overlay-wrap">
-          <img src="{{ MEDIA_URL }}img/foundation/annualreport/2011/logo-firefoxflicks.png" alt="">
+          <img src="{{ media('img/foundation/annualreport/2011/logo-firefoxflicks.png') }}" alt="">
           <div class="overlay">
             <p>
             {% trans flicks_url='https://firefoxflicks.mozilla.org/' %}
@@ -528,11 +540,11 @@
         <h3>{{ _('Collusion') }}</h3>
 
         <div class="left overlay-wrap">
-          <img src="{{ MEDIA_URL }}img/foundation/annualreport/2011/act-collusion.jpg" alt="">
+          <img src="{{ media('img/foundation/annualreport/2011/act-collusion.jpg') }}" alt="">
           <div class="overlay">
             <p>
             {% trans collusion_url='https://www.mozilla.org/collusion/' %}
-              <a href="{{ collusion_url }}" rel="external">Mozilla Collusion</a>
+              <a href="{{ collusion_url }}" rel="external" hreflang="en-US">Mozilla Collusion</a>
               gives consumers a powerful tool to protect their privacy, arming
               them with transparency, facts and the power to make their own
               decisions about how their personal data is shared and used. Made
@@ -547,7 +559,7 @@
 
         <figure class="right video act-kovacsted">
           <a class="vid-youtube" href="https://www.youtube.com/watch?v=f_f5wNw-2c0" title="{{ _('Click to view this video') }}">
-            <img src="{{ MEDIA_URL }}img/foundation/annualreport/2011/vid-kovacsted.jpg" alt="">
+            <img src="{{ media('img/foundation/annualreport/2011/vid-kovacsted.jpg') }}" alt="{{ _('Watch a video of Mozilla CEO Gary Kovacs presenting Collusion at TED') }}">
           </a>
         </figure>
 
@@ -562,7 +574,7 @@
 
       <section class="com-intro">
         <aside class="pull">
-          <img src="{{ MEDIA_URL }}img/foundation/annualreport/2011/com-intro.png" alt="">
+          <img src="{{ media('img/foundation/annualreport/2011/com-intro.png') }}" alt="">
           <h3><span>{{ _('Our success begins with you.') }}</span></h3>
         </aside>
 
@@ -575,8 +587,13 @@
           We have Mozilla communities spanning the world and these remarkable
           people are responsible for coding, testing, localizing, hosting
           hackfests and summer code parties, teaching Webmakers, marketing,
-          evangelizing Mozilla products and much more.
+          evangelizing Mozilla products and much more. 
         {% endtrans %}
+      {% if request.locale.startswith('en') %}
+        {% trans contribute_url='https://www.mozilla.org/contribute' %}
+          Learn more about how you can <a href="{{ contribute_url }}" rel="external" hreflang="en-US">get involved with Mozilla</a>.
+        {% endtrans %}
+      {% endif %}
         </p>
       </section>
 
@@ -584,7 +601,7 @@
         <h3>{{ _('Mozilla Reps') }}</h3>
 
         <div class="overlay-wrap left">
-          <img src="{{ MEDIA_URL }}img/foundation/annualreport/2011/com-reps.jpg" alt="">
+          <img src="{{ media('img/foundation/annualreport/2011/com-reps.jpg') }}" alt="">
 
           <div class="overlay">
             <p>
@@ -604,21 +621,21 @@
           </div>
         </div>
 
-        <img class="rep right" src="{{ MEDIA_URL }}img/foundation/annualreport/2011/mozilla-rep.png" alt="">
+        <img class="rep right" src="{{ media('img/foundation/annualreport/2011/mozilla-rep.png') }}" alt="">
       </section>
 
       <section class="row haz-overlay com-mozcamps">
         <h3>{{ _('MozCamps') }}</h3>
 
         <aside class="video left">
-          <img src="{{ MEDIA_URL }}img/foundation/annualreport/2011/logo-mozcamp.png" alt="">
+          <img src="{{ media('img/foundation/annualreport/2011/logo-mozcamp.png') }}" alt="">
           <a class="video-play" href="http://videos-cdn.mozilla.net/serv/drafts/MozCamp-Latam.webm" data-video-source="http://videos-cdn.mozilla.net/serv/drafts/MozCamp-Latam" title="{{ _('Click to play this video') }}">
-            <img src="{{ MEDIA_URL }}img/foundation/annualreport/2011/vid-mozcamp.jpg" alt="">
+            <img src="{{ media('img/foundation/annualreport/2011/vid-mozcamp.jpg') }}" alt="{{ _('Watch this video showing some of the activities from MozCamp in Latin America') }}">
           </a>
         </aside>
 
         <div class="overlay-wrap right">
-          <img src="{{ MEDIA_URL }}img/foundation/annualreport/2011/com-mozcamp.jpg" alt="">
+          <img src="{{ media('img/foundation/annualreport/2011/com-mozcamp.jpg') }}" alt="">
           <div class="overlay">
             <p>
             {% trans %}
@@ -654,7 +671,7 @@
         <h3>{{ _('Emerging Communities') }}</h3>
 
         <div class="overlay-wrap left">
-          <img src="{{ MEDIA_URL }}img/foundation/annualreport/2011/com-emerging.jpg" alt="">
+          <img src="{{ media('img/foundation/annualreport/2011/com-emerging.jpg') }}" alt="">
           <div class="overlay">
             <p>
             {% trans
@@ -678,7 +695,7 @@
             </p>
           </div>
         </div>
-        <img class="meet right" src="{{ MEDIA_URL }}img/foundation/annualreport/2011/community-meet.png" alt="">
+        <img class="meet right" src="{{ media('img/foundation/annualreport/2011/community-meet.png') }}" alt="">
       </section>
 
       <section class="row com-stories">
@@ -693,7 +710,7 @@
           <ul id="story-slider">
 
             <li id="story-chit" class="vcard">
-              <a class="contributor contrib-play" href="http://videos-cdn.mozilla.net/serv/drafts/Contributorstory1.webm" data-poster="{{ MEDIA_URL }}img/foundation/annualreport/2011/contributors/chit-poster.jpg">
+              <a class="contributor contrib-play" href="http://videos-cdn.mozilla.net/serv/drafts/Contributorstory1.webm" data-poster="{{ media('img/foundation/annualreport/2011/contributors/chit-poster.jpg') }}">
                 <hgroup>
                   <h4 class="fn">{{ _('Chit Thiri Maung') }}</h4>
                   <h5>
@@ -701,7 +718,7 @@
                     <span class="country-name">{{ _('Myanmar') }}</span>
                   </h5>
                 </hgroup>
-                <img class="photo" src="{{ MEDIA_URL }}img/foundation/annualreport/2011/contributors/chit-thumb.jpg" alt="">
+                <img class="photo" src="{{ media('img/foundation/annualreport/2011/contributors/chit-thumb.jpg') }}" alt="">
                 <p class="note">
                 {% trans %}
                   Chit started contributing to Mozilla in 2010 and has been
@@ -712,7 +729,7 @@
             </li>
 
             <li id="story-viking" class="vcard">
-              <a class="contributor contrib-play" href="http://videos-cdn.mozilla.net/serv/drafts/Contributorstory2.webm" data-poster="{{ MEDIA_URL }}img/foundation/annualreport/2011/contributors/viking-poster.jpg">
+              <a class="contributor contrib-play" href="http://videos-cdn.mozilla.net/serv/drafts/Contributorstory2.webm" data-poster="{{ media('img/foundation/annualreport/2011/contributors/viking-poster.jpg') }}">
                 <hgroup>
                   <h4 class="fn">{{ _('Viking Karwur') }}</h4>
                   <h5>
@@ -720,7 +737,7 @@
                     <span class="country-name">{{ _('Indonesia') }}</span>
                   </h5>
                 </hgroup>
-                <img class="photo" src="{{ MEDIA_URL }}img/foundation/annualreport/2011/contributors/viking-thumb.jpg" alt="">
+                <img class="photo" src="{{ media('img/foundation/annualreport/2011/contributors/viking-thumb.jpg') }}" alt="">
                 <p class="note">
                 {% trans %}
                   Viking organized the first ever Firefox launch party in
@@ -732,7 +749,7 @@
             </li>
 
             <li id="story-keng" class="vcard">
-              <a class="contributor contrib-play" href="http://videos-cdn.mozilla.net/serv/drafts/Contributorstory4.webm" data-poster="{{ MEDIA_URL }}img/foundation/annualreport/2011/contributors/keng-poster.jpg">
+              <a class="contributor contrib-play" href="http://videos-cdn.mozilla.net/serv/drafts/Contributorstory4.webm" data-poster="{{ media('img/foundation/annualreport/2011/contributors/keng-poster.jpg') }}">
                 <hgroup>
                   <h4 class="fn">{{ _('Patipat “Keng” Susumpow') }}</h4>
                   <h5>
@@ -740,7 +757,7 @@
                     <span class="country-name">{{ _('Thailand') }}</span>
                   </h5>
                 </hgroup>
-                <img class="photo" src="{{ MEDIA_URL }}img/foundation/annualreport/2011/contributors/keng-thumb.jpg" alt="">
+                <img class="photo" src="{{ media('img/foundation/annualreport/2011/contributors/keng-thumb.jpg') }}" alt="">
                 <p class="note">
                 {% trans %}
                   Keng kickstarted efforts to get Firefox localized in Thai and
@@ -751,7 +768,7 @@
             </li>
 
             <li id="story-claire" class="vcard">
-              <a class="contributor contrib-play" href="http://videos-cdn.mozilla.net/serv/drafts/Contributorstory5.webm" data-poster="{{ MEDIA_URL }}img/foundation/annualreport/2011/contributors/claire-poster.jpg">
+              <a class="contributor contrib-play" href="http://videos-cdn.mozilla.net/serv/drafts/Contributorstory5.webm" data-poster="{{ media('img/foundation/annualreport/2011/contributors/claire-poster.jpg') }}">
                 <hgroup>
                   <h4 class="fn">{{ _('Claire Corgnou') }}</h4>
                   <h5>
@@ -759,7 +776,7 @@
                     <span class="country-name">{{ _('France') }}</span>
                   </h5>
                 </hgroup>
-                <img class="photo" src="{{ MEDIA_URL }}img/foundation/annualreport/2011/contributors/claire-thumb.jpg" alt="">
+                <img class="photo" src="{{ media('img/foundation/annualreport/2011/contributors/claire-thumb.jpg') }}" alt="">
                 <p class="note">
                 {% trans %}
                   Claire started contributing to Mozilla in 2009 and is the editor
@@ -770,7 +787,7 @@
             </li>
 
             <li id="story-haitham" class="vcard">
-              <a class="contributor contrib-play" href="http://videos-cdn.mozilla.net/serv/drafts/Contributorstory6.webm" data-poster="{{ MEDIA_URL }}img/foundation/annualreport/2011/contributors/haitham-poster.jpg">
+              <a class="contributor contrib-play" href="http://videos-cdn.mozilla.net/serv/drafts/Contributorstory6.webm" data-poster="{{ media('img/foundation/annualreport/2011/contributors/haitham-poster.jpg') }}">
                 <hgroup>
                   <h4 class="fn">{{ _('Haitham El-Ghareeb') }}</h4>
                   <h5>
@@ -778,7 +795,7 @@
                     <span class="country-name">{{ _('Egypt') }}</span>
                   </h5>
                 </hgroup>
-                <img class="photo" src="{{ MEDIA_URL }}img/foundation/annualreport/2011/contributors/haitham-thumb.jpg" alt="">
+                <img class="photo" src="{{ media('img/foundation/annualreport/2011/contributors/haitham-thumb.jpg') }}" alt="">
                 <p class="note">
                 {% trans %}
                   A passionate open source evangelist in his native Egypt, Haitham
@@ -789,7 +806,7 @@
             </li>
 
             <li id="story-ioana" class="vcard">
-              <a class="contributor contrib-play" href="http://videos-cdn.mozilla.net/serv/drafts/Contributorstory7.webm" data-poster="{{ MEDIA_URL }}img/foundation/annualreport/2011/contributors/ioana-poster.jpg">
+              <a class="contributor contrib-play" href="http://videos-cdn.mozilla.net/serv/drafts/Contributorstory7.webm" data-poster="{{ media('img/foundation/annualreport/2011/contributors/ioana-poster.jpg') }}">
                 <hgroup>
                   <h4 class="fn">{{ _('Ioana Chiorean') }}</h4>
                   <h5>
@@ -797,7 +814,7 @@
                     <span class="country-name">{{ _('Romania') }}</span>
                   </h5>
                 </hgroup>
-                <img class="photo" src="{{ MEDIA_URL }}img/foundation/annualreport/2011/contributors/ioana-thumb.jpg" alt="">
+                <img class="photo" src="{{ media('img/foundation/annualreport/2011/contributors/ioana-thumb.jpg') }}" alt="">
                 <p class="note">
                 {% trans %}
                   Ioana has been driving Mozilla hackathons across her native Romania
@@ -808,7 +825,7 @@
             </li>
 
             <li id="story-brian" class="vcard">
-              <a class="contributor contrib-play" href="http://videos-cdn.mozilla.net/serv/drafts/Contributorstory8.webm" data-poster="{{ MEDIA_URL }}img/foundation/annualreport/2011/contributors/brian-poster.jpg">
+              <a class="contributor contrib-play" href="http://videos-cdn.mozilla.net/serv/drafts/Contributorstory8.webm" data-poster="{{ media('img/foundation/annualreport/2011/contributors/brian-poster.jpg') }}">
                 <hgroup>
                   <h4 class="fn">{{ _('Brian King') }}</h4>
                   <h5>
@@ -816,7 +833,7 @@
                     <span class="country-name">{{ _('Slovenia') }}</span>
                   </h5>
                 </hgroup>
-                <img class="photo" src="{{ MEDIA_URL }}img/foundation/annualreport/2011/contributors/brian-thumb.jpg" alt="">
+                <img class="photo" src="{{ media('img/foundation/annualreport/2011/contributors/brian-thumb.jpg') }}" alt="">
                 <p class="note">
                 {% trans %}
                   Brian has been contributing to Mozilla for more than a decade and
@@ -827,7 +844,7 @@
             </li>
 
             <li id="story-mohomodou" class="vcard">
-              <a class="contributor contrib-play" href="http://videos-cdn.mozilla.net/serv/drafts/Contributorstory9.webm" data-poster="{{ MEDIA_URL }}img/foundation/annualreport/2011/contributors/mohomodou-poster.jpg">
+              <a class="contributor contrib-play" href="http://videos-cdn.mozilla.net/serv/drafts/Contributorstory9.webm" data-poster="{{ media('img/foundation/annualreport/2011/contributors/mohomodou-poster.jpg') }}">
                 <hgroup>
                   <h4 class="fn">{{ _('Mohomodou Houssouba') }}</h4>
                   <h5>
@@ -835,7 +852,7 @@
                     <span class="country-name">{{ _('Mali') }}</span>
                   </h5>
                 </hgroup>
-                <img class="photo" src="{{ MEDIA_URL }}img/foundation/annualreport/2011/contributors/mohomodou-thumb.jpg" alt="">
+                <img class="photo" src="{{ media('img/foundation/annualreport/2011/contributors/mohomodou-thumb.jpg') }}" alt="">
                 <p class="note">
                 {% trans %}
                   Passionate about reviving Songay, a dialect in his native Mali,
@@ -915,17 +932,6 @@
 
 {# L10N: This is a label for a button that controls a slider control, advancing to reveal the next item. #}
 <button type="button" class="btn-next">{{ _('Next') }}</button>
-
-<script type="text/javascript">
-  var _gaq = _gaq || [];
-  _gaq.push(['_setAccount', 'UA-36116321-1']);
-  _gaq.push(['_trackPageview']);
-  (function() {
-    var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
-    ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
-    var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
-  })();
-</script>
 
 {% endblock %}
 

--- a/apps/foundation/templates/foundation/annualreport/2011faq.html
+++ b/apps/foundation/templates/foundation/annualreport/2011faq.html
@@ -12,6 +12,18 @@
 
 {% block extrahead %}
   {{ css('annual_2011') }}
+  <link rel="stylesheet" media="print" href="{{ MEDIA_URL }}css/foundation/annual2011print.css">
+  
+  <script type="text/javascript">
+    var _gaq = _gaq || [];
+    _gaq.push(['_setAccount', 'UA-36116321-1']);
+    _gaq.push(['_trackPageview']);
+    (function() {
+      var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
+      ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
+      var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
+    })();
+  </script>
 {% endblock %}
 
 {% block js %}
@@ -380,17 +392,6 @@
     </dl>
 
   </article>
-
-<script type="text/javascript">
-  var _gaq = _gaq || [];
-  _gaq.push(['_setAccount', 'UA-36116321-1']);
-  _gaq.push(['_trackPageview']);
-  (function() {
-    var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
-    ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
-    var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
-  })();
-</script>
 
 {% endblock %}
 

--- a/media/css/foundation/annual2011.less
+++ b/media/css/foundation/annual2011.less
@@ -149,7 +149,7 @@ body.noscroll {
   right: 0;
   bottom: 0;
   left: 0;
-  z-index: 99;
+  z-index: 999;
   overflow: auto;
   #inner {
     width: 80%;


### PR DESCRIPTION
- Bug 812206 - modal overlay z-index
- Bug 812338 - add link to /contribute
- Bug 811477 - alt text for video images
- Switched inline images to media function instead of the MEDIA_URL constant.
- Added hreflang to several links.
- Bug 812338 - Add Get Involved link for en locales
  We can display this link to more locales once the Get Involved page is localized.
