### PR TITLE
Added aria-live support to the javascript-driven search

### DIFF
--- a/media/css/firefox/all.less
+++ b/media/css/firefox/all.less
@@ -5,6 +5,15 @@
         display: none;
     }
 }
+/* from http://snook.ca/archives/html_and_css/hiding-content-for-accessibility */
+.hide-offscreen {
+    position:absolute!important;
+    height:1px;
+    width:1px; 
+    overflow:hidden;
+    clip:rect(1px 1px 1px 1px); /* IE6, IE7 */
+    clip:rect(1px, 1px, 1px, 1px);
+}
 
 #main-feature {
     h1 {

--- a/media/js/firefox-language-search.js
+++ b/media/js/firefox-language-search.js
@@ -5,6 +5,13 @@ $(function(){
     var $form = $('#language-search');
     var $input = $('#language-search-q');
     var $tables = $('table.build-table');
+    var ariaAnnounce = $('<div/>').attr({
+        'role': 'status',
+        'aria-live': 'polite',
+        'class': 'hide-offscreen'
+    });
+    
+    $('body').append(ariaAnnounce);
 
     $form.on('submit', function(e){
         e.preventDefault();
@@ -35,8 +42,17 @@ $(function(){
                 $not_found.show();
             }
         });
+        aria_announcement(search_q);
     });
-
+    
+    function aria_announcement (search_q) {
+        var announcement = 'You have searched for '+search_q+', resulting in '+ $('#localized tbody tr:visible').length + ' fully localized version and '+ $('#localized-testing tbody tr:visible').length +' localized version in testing in the two tables below';
+        ariaAnnounce.html(announcement);
+        var clear_announcement = setTimeout(function() {
+            ariaAnnounce.html('');
+        }, 5000);
+    }
+ 
     function show_all(){
         $tables.find('thead, tbody').show();
         $('tr[data-search]').show();


### PR DESCRIPTION
When submitting the search form it's only a visual indication that something happens with the localized download tables. This pull request informs AT what they have searched for and how many results they have in the two tables

It would probably be better to use some sort of templating system that could be translated on the server instead of concatenating the string in the js-file but I'm not sure how you guys want it. This is more of a work in progress :)

also this is the first aria-live function in the bedrock project _yay_
