### PR TITLE
Bug 821330: Fix translations on contribute page.

### DIFF
--- a/apps/mozorg/email_contribute.py
+++ b/apps/mozorg/email_contribute.py
@@ -12,8 +12,9 @@ from jinja2.exceptions import TemplateNotFound
 
 from l10n_utils.dotlang import _lazy as _
 
-fa = namedtuple('FunctionalArea', ['id', 'name', 'subject', 'contacts'])
 
+fa = namedtuple('FunctionalArea', ['id', 'name', 'subject', 'contacts'])
+LANG_FILES = 'mozorg/contribute'
 FUNCTIONAL_AREAS = (
     fa('support',
         _('Helping Users'),

--- a/apps/mozorg/forms.py
+++ b/apps/mozorg/forms.py
@@ -23,6 +23,7 @@ FORMATS = (('H', 'HTML'), ('T', 'Text'))
 LANGS = settings.NEWSLETTER_LANGUAGES
 LANGS_TO_STRIP = ['en-US', 'es']
 PARENTHETIC_RE = re.compile(r' \([^)]+\)$')
+LANG_FILES = 'mozorg/contribute'
 
 
 def strip_parenthetical(lang_name):

--- a/lib/l10n_utils/helpers.py
+++ b/lib/l10n_utils/helpers.py
@@ -36,9 +36,7 @@ def gettext(ctx, text):
     """Translate a string, loading the translations for the locale if
     necessary."""
     install_lang_files(ctx)
-
-    trans = translate(text, ctx['request'].langfiles)
-    return jinja2.Markup(trans)
+    return translate(text, ctx['request'].langfiles)
 
 
 @jingo.register.function

--- a/lib/l10n_utils/tests/test_files/extract_me_with_langfiles_lazy.py
+++ b/lib/l10n_utils/tests/test_files/extract_me_with_langfiles_lazy.py
@@ -1,0 +1,16 @@
+# coding: utf-8
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from l10n_utils.dotlang import _lazy as _
+
+
+LANG_FILES = [
+    'donnie',
+    'walter',
+]
+
+def do_translate():
+    return _(u"I'm The Dude, so that's what you call me, man.")


### PR DESCRIPTION
- Fix gettext lazy to be able to find additional lang files specified in
  python modules.
- Mark all translated strings a safe so that html entities aren't
  escaped.
