### PR TITLE
Redirect Firefox for Android privacy link

### DIFF
--- a/apps/redirects/urls.py
+++ b/apps/redirects/urls.py
@@ -41,6 +41,9 @@ urlpatterns = patterns('',
     # Bug 800467 /apps/partners -> marketplace.m.o/developers
     redirect(r'apps/partners/$', 'https://marketplace.mozilla.org/developers/'),
 
+    # Bug 815527 /m/privacy.html -> /legal/privacy/firefox.html
+    redirect(r'^m/privacy.html$', '/legal/privacy/firefox.html'),
+
     # Bug 800298 /webmaker/ -> wm.o and /webmaker/videos/ -> wm.o/videos/
     redirect(r'webmaker/$', 'https://webmaker.org'),
     redirect(r'webmaker/videos/$', 'https://webmaker.org/videos/'),


### PR DESCRIPTION
Bug 815527 - Firefox Android privacy link is wrong [need redirect]
