### PR TITLE
hide .scene2 before the download click

### DIFF
--- a/media/css/firefox/new-test.less
+++ b/media/css/firefox/new-test.less
@@ -259,7 +259,10 @@
 
 #scene2 {
     top: -400px;
-    //display: none;
+    display: none;
+}
+.scene2 #scene2{
+    display: block;
 }
 
 #firefox-screenshot {


### PR DESCRIPTION
.scene2 needs to be hidden for AT before clicking the download link, and shown afterwards
