### PR TITLE
Add GA tracking to dl button on /new. bug 824370

### DIFF
--- a/apps/firefox/templates/firefox/new.html
+++ b/apps/firefox/templates/firefox/new.html
@@ -71,3 +71,7 @@ valueOf()+(h?'&utmxhash='+escape(h.substr(1)):'')+
 
   </footer>
 {% endblock %}
+
+{% block js %}
+  {{ js('firefox_new_a') }}
+{% endblock  %}

--- a/media/js/firefox/new-a.js
+++ b/media/js/firefox/new-a.js
@@ -1,0 +1,21 @@
+;(function(window, $, _gaq) {
+    'use strict';
+
+    // Bind events on domReady.
+    $(function() {
+        $('.download-firefox').on('click', function(e) {
+            e.preventDefault();
+            var $link = $(this);
+
+            if (_gaq) {
+                // track download click
+                _gaq.push(['_trackPageview',
+                           '/en-US/products/download.html?referrer=new']);
+            }
+
+            window.setTimeout(function() {
+                window.location.href = $link.attr('href');
+            }, 300);
+        });
+    });
+})(window, window.jQuery, window._gaq);

--- a/settings/base.py
+++ b/settings/base.py
@@ -340,6 +340,9 @@ MINIFY_BUNDLES = {
             'js/libs/modernizr.custom.csstransitions.js',
             'js/firefox/new.js',
         ),
+        'firefox_new_a': (
+            'js/firefox/new-a.js',
+        ),
         'firefox_platforms': (
             'js/mozilla-expanders.js',
         ),


### PR DESCRIPTION
Add firefox/new-a.js to /firefox/new page. Mimic GA tracking from /new-b.
