### PR TITLE
Bug 742890: Add expires headers for static media for CDN prep.

### DIFF
--- a/media/.htaccess
+++ b/media/.htaccess
@@ -1,3 +1,36 @@
+# Cache control settings from:
+# https://github.com/mozilla/kitsune/blob/master/media/.htaccess
+
+# Neither Firefox nor Safari will draw these if they're text/xml
+AddType image/svg+xml .svg
+AddType application/octet-stream .exe
+
+AddCharset utf-8 .css .js
+
+# Set far-future Expires headers for static media
+ExpiresActive on
+
+ExpiresDefault "access plus 1 week"
+ExpiresByType text/css "access plus 1 year"
+ExpiresByType text/javascript "access plus 1 year"
+ExpiresByType image/png "access plus 1 month"
+ExpiresByType image/jpeg "access plus 1 month"
+ExpiresByType image/gif "access plus 1 month"
+ExpiresByType image/svg+xml "access plus 1 month"
+ExpiresByType image/vnd.microsoft.icon "access plus 1 month"
+ExpiresByType video/webm "access plus 1 week"
+ExpiresByType video/ogg "access plus 1 week"
+ExpiresByType video/x-flv "access plus 1 week"
+ExpiresByType application/x-shockwave-flash "access plus 1 week"
+ExpiresByType text/plain "access plus 0 seconds"
+ExpiresByType application/octet-stream "access plus 0 seconds"
+
+FileETag MTime
+
+<FilesMatch "\.txt$">
+    FileETag None
+</FilesMatch>
+
 <FilesMatch "\.(eot|svg|ttf|woff)$">
     Header set Access-Control-Allow-Origin "*"
 </FilesMatch>


### PR DESCRIPTION
Adds long expires headers for static media. The specific rules
added are from kitsune as recommended in the bug.

https://github.com/mozilla/kitsune/blob/master/media/.htaccess
