### PR TITLE
Bug 827103 - [404] http://mozilla.org/ links to https://www.mozilla.org/en-US/firefox/17.0.1/requirements

### DIFF
--- a/apps/mozorg/templates/mozorg/download_buttons/base.html
+++ b/apps/mozorg/templates/mozorg/download_buttons/base.html
@@ -49,7 +49,7 @@
   {% endblock %}
 
   {% block unsupported %}
-    {% set requirements_url = php_url('/firefox/' ~ version ~ '/requirements') %}
+    {% set requirements_url = php_url('/firefox/' ~ version ~ '/system-requirements/') %}
     <p class="unsupported-download">
       {{ _('Your system doesn\'t meet the <a href="%(url)s">requirements</a> to run Firefox.')|format(url=requirements_url) }}
     </p>


### PR DESCRIPTION
On a computer that doesn't meet the requirements to run Firefox,
http://mozilla.org/ will lead the user to a 404 at
https://www.mozilla.org/en-US/firefox/17.0.1/requirements. Maybe it
would be better to change that link to
https://www.mozilla.org/en-US/firefox/17.0.1/system-requirements/.
