### PR TITLE
bug 828050 - Adding Linux64 entries in firefox product details crashes a...

### DIFF
--- a/apps/firefox/firefox_details.py
+++ b/apps/firefox/firefox_details.py
@@ -21,6 +21,10 @@ class FirefoxDetails(ProductDetails):
             'title': 'Linux',
             'id': 'linux',
         },
+        'Linux64': {
+            'title': 'Linux64',
+            'id': 'linux64',
+        },
     }
     channel_map = {
         'aurora': 'FIREFOX_AURORA',


### PR DESCRIPTION
...ll.html

Added Linux64 entry in product_details.py.

Fix for the bedrock side of https://bugzilla.mozilla.org/show_bug.cgi?id=828050
