### PR TITLE
refactored new.js

### DIFF
--- a/media/js/firefox/new.js
+++ b/media/js/firefox/new.js
@@ -1,15 +1,44 @@
-;(function(window, $, Modernizr, _gaq, site) {
+;(function($, Modernizr, _gaq, site) {   
     'use strict';
-
+    
     if (site.platform === 'android') {
         return;
     }
+    
+    var $scene1 = $('#scene1');
+    var $stage = $('#stage-firefox');
+    var $thankYou = $('.thankyou');
+    var hash_change = ('onhashchange' in window);
+    
+    function track_and_redirect(url) {
+        if (_gaq) {
+            _gaq.push(['_trackPageview',
+                       '/en-US/products/download.html?referrer=new-b']);
+        }
+        setTimeout(function() {
+            location.href = url;
+        }, 300);
+    }
 
-    // possible race condition? this is set on DOM ready, which *should* always happen
-    // prior to window.load. alternative could be re-querying the DOM for the dl link
-    // in window.load.
-    var ff_dl_url;
-
+    function show_scene(scene) {
+        var CSSbottom = (scene === 2) ? '-400px' : 0;
+        $stage.data('scene', scene);
+        $('.scene').css('visibility', 'visible');
+        if (!Modernizr.csstransitions) {
+            $stage.animate({
+                bottom: CSSbottom
+            }, 400);
+        } else {
+            $stage.toggleClass('scene2');
+        }
+        if (scene === 2) {
+            setTimeout(function() {
+                $scene1.css('visibility', 'hidden');
+                $thankYou.focus();
+            }, 500);
+        }
+    }
+    
     // Load images on load so as not to block the loading of other images.
     $(window).on('load', function() {
         // Screen 1 is unique for IE < 9
@@ -20,114 +49,43 @@
         $('body').addClass('ready-for-scene2');
 
         // initiate download/scene2 if coming directly to #download
-        // minor concern: what if install images are not loaded yet (slow connection)?
-        // tried to mitigate with timeout.
-        if (window.location.hash === '#download') {
-            setTimeout(function() {
-                ga_track();
-
-                show_scene(2);
-
-                dl_redirect(ff_dl_url);
-            }, 300);
+        if (location.hash === '#download-fx' && site.platform !== 'other') {
+            show_scene(2);
+            $('#direct-download-link').trigger('click');
         }
     });
 
-    function ga_track() {
-        if (_gaq) {
-            // track download click
-            _gaq.push(['_trackPageview',
-                       '/en-US/products/download.html?referrer=new-b']);
-        }
-    }
-
-    function dl_redirect(url) {
-        // delay redirect to ensure GA tracking occurs
-        window.setTimeout(function() {
-            window.location.href = url;
-        }, 300);
-    }
-
-    var $scene2 = $('#scene2');
-    var $stage = $('#stage-firefox');
-    var $thankYou = $('.thankyou');
-    // drop support for IE7/8. good?
-    var can_hashchange = ('onhashchange' in window && 'addEventListener' in window);
-
-    function show_scene(scene) {
-        if (scene === 2) {
-            if (!Modernizr.csstransitions) {
-                $scene2.css('visibility', 'visible'); // ensure visibility prior to animation
-                $stage.animate({
-                    bottom: '-400px'
-                }, 400, function() {
-                    $thankYou.focus();
-                });
-            } else {
-                $stage.addClass('scene2');
-                // transitionend fires multiple times in FF 17, including
-                // before the transition actually finished.
-                // Work-around with setTimeout.
-                window.setTimeout(function() {
-                    $thankYou.focus();
-                }, 500);
-            }
-        } else {
-            if (!Modernizr.csstransitions) {
-                $stage.animate({
-                    bottom: '0px'
-                }, 400, function() {
-                    $scene2.css('visibility', 'hidden'); // revert scene2 to hidden
-                    $thankYou.blur();
-                });
-            } else {
-                $scene2.css('visibility', 'visible'); // ensure visibility through animation
-                $stage.removeClass('scene2'); // remove class - transition to scene 1
-                window.setTimeout(function() {
-                    $scene2.css('visibility', ''); // revert to default (hidden)
-                    $thankYou.blur();
-                }, 500);
-            }
-        }
-    }
-
-    // Bind events on domReady.
-    $(function() {
-        if (can_hashchange) {
-            window.addEventListener('hashchange', function(e) {
-                if (window.location.hash === '#download') {
-                    show_scene(2);
-                } else {
-                    show_scene(1);
-                }
-            }, false);
-        }
-
+    $(function() {        
         // Pull Firefox download link from the download button and add to the
         // 'click here' link.
         // TODO: Remove and generate link in bedrock.
-        var $li = $('.download-list li:visible').filter(':first');
-        ff_dl_url = $li.find('a:first').attr('href');
-        $('#direct-download-link').attr('href', ff_dl_url).on('click', function(e) {
-            e.preventDefault();
-            ga_track();
-            dl_redirect($(this).attr('href'));
-        });
+        $('#direct-download-link').attr(
+            'href', $('.download-list li:visible .download-firefox').attr('href')
+        );
 
-        // Trigger animation after download.
-        $('.download-firefox').on('click', function(e) {
+        $stage.on('click', '#direct-download-link, .download-firefox', function(e) {
             e.preventDefault();
 
-            var $link = $(this);
-            ga_track();
-
-            if (can_hashchange) {
-                window.location.hash = '#download';
-            } else {
-                show_scene(2);
+            track_and_redirect($(e.currentTarget).attr('href'));
+            
+            if ($stage.data('scene') !== 2) {
+                if (hash_change) {
+                    location.hash = '#download-fx';
+                } else {
+                    show_scene(2);
+                }
             }
-
-            dl_redirect($link.attr('href'));
         });
+        
+        if (hash_change) {
+            $(window).on('hashchange', function() {
+                if (location.hash === '#download-fx') {
+                    show_scene(2);
+                }
+                if (location.hash === '') {
+                    show_scene(1);
+                }
+            });
+        }
     });
-})(window, window.jQuery, window.Modernizr, window._gaq, window.site);
+})(window.jQuery, window.Modernizr, window._gaq, window.site);


### PR DESCRIPTION
I didn't have much to do yesterday, when the son was sick so I refactored this one as well.
- DRY 
- Tested in the most commonly browsers/AT
- ~20% smaller than the current one (minified versions compared)
- Changed #download to #download-fx due to a existing #download element in the DOM (that made the page jump when added the hash)

Hope you like it :) ping @jpetto
