### PR TITLE
Bug 828064: Do not redirect ESR firefox to update.

### DIFF
--- a/apps/firefox/firefox_details.py
+++ b/apps/firefox/firefox_details.py
@@ -28,6 +28,7 @@ class FirefoxDetails(ProductDetails):
         'esr': 'FIREFOX_ESR',
         'release': 'LATEST_FIREFOX_VERSION',
     }
+    esr_major_versions = [10, 17]
 
     def __init__(self):
         super(FirefoxDetails, self).__init__()

--- a/apps/firefox/tests.py
+++ b/apps/firefox/tests.py
@@ -145,6 +145,25 @@ class FxVersionRedirectsMixin(object):
         eq_(response['Vary'], 'User-Agent')
 
     @patch.dict(product_details.firefox_versions,
+                LATEST_FIREFOX_VERSION='18.0')
+    def test_esr_firefox(self):
+        """
+        Currently released ESR firefoxen should not redirect. At present
+        they are 10.0.x and 17.0.x.
+        """
+        user_agent = ('Mozilla/5.0 (Macintosh; Intel Mac OS X 10.6; rv:10.0.12) '
+                      'Gecko/20111101 Firefox/10.0.12')
+        response = self.client.get(self.url, HTTP_USER_AGENT=user_agent)
+        eq_(response.status_code, 200)
+        eq_(response['Vary'], 'User-Agent')
+
+        user_agent = ('Mozilla/5.0 (Macintosh; Intel Mac OS X 10.7; rv:17.0) '
+                      'Gecko/20100101 Firefox/17.0')
+        response = self.client.get(self.url, HTTP_USER_AGENT=user_agent)
+        eq_(response.status_code, 200)
+        eq_(response['Vary'], 'User-Agent')
+
+    @patch.dict(product_details.firefox_versions,
                 LATEST_FIREFOX_VERSION='16.0')
     def test_current_firefox(self):
         user_agent = ('Mozilla/5.0 (Macintosh; Intel Mac OS X 10.7; rv:16.0) '

--- a/apps/firefox/views.py
+++ b/apps/firefox/views.py
@@ -114,6 +114,10 @@ def is_current_or_newer(user_version):
     latest = Version(product_details.firefox_versions['LATEST_FIREFOX_VERSION'])
     user = Version(user_version)
 
+    # check for ESR
+    if user.major in firefox_details.esr_major_versions:
+        return True
+
     # similar to the way comparison is done in the Version class,
     # but only using the major and minor versions.
     latest_int = int('%d%02d' % (latest.major, latest.minor1))


### PR DESCRIPTION
This is a bit of a bummer b/c it will also no longer
redirect people to update for any version of 17, but
as you see in the bug there is no way for us to tell
an ESR build from regular release.
