### PR TITLE
Bug 828064: Firefox pages' JS should consider ESR builds up to date.

### DIFF
--- a/apps/firefox/context_processors.py
+++ b/apps/firefox/context_processors.py
@@ -1,0 +1,12 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from firefox.firefox_details import firefox_details
+
+
+def latest_firefox_versions(request):
+    return {
+        'latest_firefox_version': firefox_details.latest_version('release'),
+        'esr_firefox_versions': firefox_details.esr_major_versions,
+    }

--- a/apps/firefox/templates/firefox/base-resp.html
+++ b/apps/firefox/templates/firefox/base-resp.html
@@ -85,6 +85,21 @@
 
 {% block site_js %}
   {{ js('firefox-resp') }}
+  <script type="text/javascript">
+      latest_firefox_version = parseInt('{{ latest_firefox_version }}'.split('.')[0], 10);
+      esr_firefox_versions = {{ esr_firefox_versions|safe }};
+
+      function isFirefox() {
+          return /\sFirefox/.test(navigator.userAgent);
+      }
+
+      //is firefox up-to-date
+      function isFirefoxUpToDate() {
+          var fx_version = getFirefoxMasterVersion();
+          return ($.inArray(fx_version, esr_firefox_versions) !== -1 ||
+                  latest_firefox_version <= fx_version);
+      }
+  </script>
 {% endblock %}
 
 {% block webtrends %}

--- a/apps/firefox/templates/firefox/devices.html
+++ b/apps/firefox/templates/firefox/devices.html
@@ -54,8 +54,8 @@
             <p id="fx-features"><a href="{{ php_url('/firefox/features/') }}" class="button go">{{ _('More Features') }}</a></p>
             <p id="fx-download"><a href="{{ php_url('/firefox/') }}" class="button go" onclick="dcsMultiTrack('WT.z_panel','Desktops & Laptops','WT.z_cta','download firefox','WT.z_convert','downloadfirefox','WT.dl',99);">{{ _('Download Firefox') }}</a> <br> <a href="/firefox/central/" class="go">Learn more</a></p>
           </div>
-          
-          <div id="gauge" data-latest-version="{{ latest_version }}">
+
+          <div id="gauge" data-latest-version="{{ latest_firefox_version }}">
             <img src="{{ media('img/firefox/devices/needle.png') }}" alt="" id="needle">
             <p id="gauge-slow">{{ _('Old Firefox = Sadface') }}</p>
             <p id="gauge-fast">{{ _('New Firefox = Yay!') }}</p>
@@ -66,7 +66,7 @@
               <p><strong>Now we’re talking!</strong> Feels better, doesn’t it? Welcome to the future of the Web. It’s nice here.</p>
             </div>
           </div>
-  
+
           <div id="non-fx">
             <p id="detected">Hey, looks like you’re using %BROWSER%. Why not grab Firefox and get up to speed?</p>
             <p id="notdetected">Hey, looks like you’re not using Firefox as your browser. Why not grab Firefox and get up to speed?</p>
@@ -74,7 +74,7 @@
           </div>
         </div>
       </section>
-      
+
       <section class="slide" id="smartphones-slide">
         <div class="slide-content">
           <div class="content">
@@ -88,16 +88,16 @@
                 </a>
               </p>
               <small class="download-other">
-                <a href="/legal/privacy/firefox.html">{{ _('Privacy Policy') }}</a> | 
-                <a href="/mobile/platforms">{{ _('Supported Devices') }}</a> | 
-                <a href="/mobile/{{latest_version}}/releasenotes">{{ _('Release Notes') }}</a>
+                <a href="/legal/privacy/firefox.html">{{ _('Privacy Policy') }}</a> |
+                <a href="/mobile/platforms">{{ _('Supported Devices') }}</a> |
+                <a href="/mobile/{{ latest_firefox_version }}/releasenotes">{{ _('Release Notes') }}</a>
               </small>
             </aside>
           </div>
           <p class="footnote">iPhone user? <a href="http://support.mozilla.org/en-US/kb/will-firefox-work-my-mobile-device?s=firefox+on+iphone&r=1&e=sph&as=s#w_firefox-home-for-iphone">Click here.</a></p>
         </div>
       </section>
-      
+
       <section class="slide" id="tablets-slide">
         <div class="slide-content">
           <div class="content">
@@ -111,16 +111,16 @@
                 </a>
               </p>
               <small class="download-other">
-                <a href="/legal/privacy/firefox.html">{{ _('Privacy Policy') }}</a> | 
-                <a href="/mobile/platforms">{{ _('Supported Devices') }}</a> | 
-                <a href="/mobile/{{latest_version}}/releasenotes">{{ _('Release Notes') }}</a>
+                <a href="/legal/privacy/firefox.html">{{ _('Privacy Policy') }}</a> |
+                <a href="/mobile/platforms">{{ _('Supported Devices') }}</a> |
+                <a href="/mobile/{{ latest_firefox_version }}/releasenotes">{{ _('Release Notes') }}</a>
               </small>
             </aside>
           </div>
           <p class="footnote">iPad user? <a href="http://support.mozilla.org/en-US/kb/will-firefox-work-my-mobile-device?s=firefox+on+iphone&r=1&e=sph&as=s#w_firefox-home-for-iphone">Click here.</a></p>
         </div>
       </section>
-      
+
       <section class="slide" id="addons-slide">
         <div class="slide-content">
           <div class="content">
@@ -129,7 +129,7 @@
           </div>
           <ul id="addons-list">
             <li class="addon">
-              <h3><a href="https://addons.mozilla.org/en-US/mobile/addon/adblock-plus/?src=fx-devices" rel="external"><img src="//static-ssl-cdn.addons.mozilla.net/img/uploads/addon_icons/1/1865-48.png" alt=""> {{ _('AdBlock Plus') }}</a></h3> 
+              <h3><a href="https://addons.mozilla.org/en-US/mobile/addon/adblock-plus/?src=fx-devices" rel="external"><img src="//static-ssl-cdn.addons.mozilla.net/img/uploads/addon_icons/1/1865-48.png" alt=""> {{ _('AdBlock Plus') }}</a></h3>
               <p class="desc">{{ _('Regain control and change the way that you view the Web.') }}</p>
               <ul class="add-to">
                 <li><a href="https://addons.mozilla.org/en-US/firefox/addon/adblock-plus/?src=fx-devices" onclick="dcsMultiTrack('WT.z_panel','Favorite Add-ons','WT.z_cta','Adblock Plus Desktop','WT.dl',99);">{{ _('Add to Desktop') }}</a></li>
@@ -150,13 +150,13 @@
               <ul class="add-to">
                 <li><a href="https://addons.mozilla.org/en-US/firefox/addon/speed-dial/?src=fx-devices" onclick="dcsMultiTrack('WT.z_panel','Favorite Add-ons','WT.z_cta','Speed Dial Desktop','WT.dl',99);">{{ _('Add to Desktop') }}</a></li>
                 <li><a href="https://addons.mozilla.org/en-US/mobile/addon/speed-dial/?src=fx-devices" onclick="dcsMultiTrack('WT.z_panel','Favorite Add-ons','WT.z_cta','Speed Dial Mobile','WT.dl',99);">{{ _('Add to Mobile') }}</a></li>
-              </ul>  
+              </ul>
             </li>
           </ul>
           <p class="footnote">These are just three of our favorites, but there are <a href="https://addons.mozilla.org">thousands more</a>.</p>
         </div>
       </section>
-      
+
       <section class="slide" id="sync-slide">
         <div class="slide-content">
           <div class="content">

--- a/apps/firefox/templates/firefox/fx.html
+++ b/apps/firefox/templates/firefox/fx.html
@@ -125,21 +125,19 @@
 {% block js %}
   {{ js('firefox_fx') }}
 
-<script>
-$(document).ready(function() {
-  var latestVersion = parseInt('{{latest_version}}'.split('.')[0], 10);
-  var isFirefox = (/\sFirefox/.test(window.navigator.userAgent));
-  var isMobile = (/\sMobile/.test(window.navigator.userAgent));
+  <script>
+    $(function() {
+      var isMobile = (/\sMobile/.test(window.navigator.userAgent));
 
-  // If Firefox is the latest version and not mobile,
-  // hide the out-of-date messaging and show up-to-date
-  if(isFirefox && !isMobile) {
-    if (latestVersion <= getFirefoxMasterVersion()) {
-      $('#out-of-date').hide();
-      $('#up-to-date').show();
-    }
-  }
-});
-</script>
+      // If Firefox is the latest version and not mobile,
+      // hide the out-of-date messaging and show up-to-date
+      if(isFirefox() && !isMobile) {
+        if (isFirefoxUpToDate()) {
+          $('#out-of-date').hide();
+          $('#up-to-date').show();
+        }
+      }
+    });
+  </script>
 {% endblock  %}
 

--- a/apps/firefox/templates/firefox/speed.html
+++ b/apps/firefox/templates/firefox/speed.html
@@ -14,11 +14,7 @@
   {{ css('firefox_speed') }}
 {% endblock %}
 
-{% block body_attrs %}{{ super() }} data-latest-firefox="{{ latest_version }}"{% endblock %}
-
 {% block content %}
-
-
 <div id="main-feature">
 {% block heading_primary %}
   <h1 class="">How fast is your Firefox?</h1>

--- a/apps/firefox/templates/firefox/update.html
+++ b/apps/firefox/templates/firefox/update.html
@@ -26,14 +26,14 @@
     <div class="section-content">
        <h3>Frequently asked <span>questions</span></h3>
     </div>
-  
+
   <div class="expander expander-odd">
       <h3 class="expander-header">What is a Firefox software update?</h3>
       <div class="expander-content">
           <p>A Firefox software update is a quick download of small amounts of new code to your existing Firefox browser. These small patches can contain security fixes or other little changes to the browser to ensure that you are using the best version of Firefox available.</p>
       </div>
   </div>
-  
+
   <div class="expander">
       <h3 class="expander-header">How do I update Firefox?</h3>
       <div class="expander-content">
@@ -41,56 +41,56 @@
           <p>You are also able to check for updates manually. For details, check out the <a href="https://support.mozilla.org/en-US/kb/Updating+Firefox#Manually_check_for_updates">step-by-step guide</a>.</p>
       </div>
   </div>
-  
+
   <div class="expander expander-odd">
       <h3 class="expander-header">How do I know what version of Firefox I am currently on?</h3>
       <div class="expander-content">
           <p>It varies slightly depending on the operating system you're using. You can find <a href="http://support.mozilla.org/kb/Finding+your+Firefox+version">instructions for your computer here</a>.</p>
       </div>
   </div>
-  
+
   <div class="expander">
       <h3 class="expander-header">Do I need to uninstall my current version of Firefox before upgrading?</h3>
       <div class="expander-content">
           <p>No. The new version of Firefox will automatically take the place of your older version. To start the upgrade process, just click the green download button to the right.</p>
       </div>
   </div>
-  
+
   <div class="expander expander-odd">
       <h3 class="expander-header">Why do I need to update?</h3>
       <div class="expander-content">
           <p>Firefox is constantly evolving as our community finds ways to make it better, and as we adjust to the latest security threats. Keeping your Firefox up-to-date is the best way to make sure that you are using the smartest, fastest and – most importantly – safest version of Firefox available.</p>
       </div>
   </div>
-  
+
   <div class="expander">
       <h3 class="expander-header">How long will it take to update?</h3>
       <div class="expander-content">
           <p>Not long at all – the entire process just takes a minute or two. Visit our support page for <a href="https://support.mozilla.org/en-US/kb/Updating+Firefox#Automatic_updates">step-by-step instructions</a>.</p>
       </div>
   </div>
-  
+
   <div class="expander expander-odd">
       <h3 class="expander-header">Will the update affect my settings and bookmarks?</h3>
       <div class="expander-content">
           <p>No. A Firefox update will not make any changes to your bookmarks, saved passwords or other settings. However, there is a possibility that some of your Add-ons won’t be immediately compatible with new updates.</p>
       </div>
   </div>
-  
+
   <div class="expander">
       <h3 class="expander-header">If I already have Firefox, and then do a fresh install, what happens to my settings?</h3>
       <div class="expander-content">
           <p>Nothing. Re-installing Firefox will not affect your settings, bookmarks or preferences in any way.</p>
       </div>
   </div>
-  
+
   <div class="expander expander-odd">
       <h3 class="expander-header">Are Firefox updates safe?</h3>
       <div class="expander-content">
           <p>Very much so – your security is our top priority. Our open source security process means we have an international community of experts working around the clock to monitor the latest threats. As soon as a security threat is discovered, we write a patch and release an update to stay one step ahead. Downloading Firefox updates is a very important part of staying safe online.</p>
       </div>
   </div>
-  
+
   <div class="expander">
       <h3 class="expander-header">What if I miss an update? Can I check for one myself?</h3>
       <div class="expander-content">
@@ -114,25 +114,21 @@
 
 {% block js %}
   {{ js('expanders') }}
-<script>
-$(document).ready(function() {
-    var latestVersion = parseInt('{{ latest_version }}'.split('.')[0], 10);
-    var isFirefox = (/\sFirefox/.test(window.navigator.userAgent));
-    var headline = $('#main-feature > h1');
-    var subheadline = $('#main-feature > h3');
+  <script>
+    $(function() {
+        var headline = $('#main-feature > h1');
+        var subheadline = $('#main-feature > h3');
 
-    if(isFirefox) {
-        if(latestVersion <= getFirefoxMasterVersion()) {
-            headline.html('Congratulations!');
-            subheadline.html('Your Firefox is up to date.');
+        if (isFirefox()) {
+            if (isFirefoxUpToDate()) {
+                headline.html('Congratulations!');
+                subheadline.html('Your Firefox is up to date.');
+            }
+            else {
+                headline.html('Your Firefox is out of date.');
+                subheadline.html('Get the newest version <a href="/firefox">here</a>.');
+            }
         }
-        else {
-            headline.html('Your Firefox is out of date.');
-            subheadline.html('Get the newest version <a href="/firefox">here</a>.');
-        }
-    }
-});
-</script>
-
+    });
+  </script>
 {% endblock %}
-

--- a/apps/firefox/urls.py
+++ b/apps/firefox/urls.py
@@ -4,7 +4,6 @@
 
 from django.conf.urls.defaults import *
 from django.conf import settings
-from product_details import product_details
 
 from firefox import version_re
 from redirects.util import redirect
@@ -23,13 +22,11 @@ urlpatterns = patterns('',
     redirect('^firefox/channel/android/$', 'firefox.channel'),
     page('firefox/customize', 'firefox/customize.html'),
     page('firefox/features', 'firefox/features.html'),
-    page('firefox/fx', 'firefox/fx.html',
-         latest_version=product_details.firefox_versions['LATEST_FIREFOX_VERSION']),
+    page('firefox/fx', 'firefox/fx.html'),
     page('firefox/geolocation', 'firefox/geolocation.html',
          gmap_api_key=settings.GMAP_API_KEY),
     page('firefox/happy', 'firefox/happy.html'),
-    page('firefox/memory', 'firefox/memory.html',
-         latest_version=product_details.firefox_versions['LATEST_FIREFOX_VERSION']),
+    page('firefox/memory', 'firefox/memory.html'),
     url('^firefox/mobile/platforms/$', views.platforms,
         name='firefox.mobile.platforms'),
     page('firefox/mobile/features', 'firefox/mobile/features.html'),
@@ -43,13 +40,10 @@ urlpatterns = patterns('',
     page('firefox/performance', 'firefox/performance.html'),
     page('firefox/security', 'firefox/security.html'),
     page('firefox/installer-help', 'firefox/installer-help.html'),
-    page('firefox/speed', 'firefox/speed.html',
-         latest_version=product_details.firefox_versions['LATEST_FIREFOX_VERSION']),
+    page('firefox/speed', 'firefox/speed.html'),
     page('firefox/technology', 'firefox/technology.html'),
-    page('firefox/toolkit/download-to-your-devices', 'firefox/devices.html',
-         latest_version=product_details.firefox_versions['LATEST_FIREFOX_VERSION']),
-    page('firefox/update', 'firefox/update.html',
-         latest_version=product_details.firefox_versions['LATEST_FIREFOX_VERSION']),
+    page('firefox/toolkit/download-to-your-devices', 'firefox/devices.html'),
+    page('firefox/update', 'firefox/update.html'),
 
     page('firefox/unsupported/warning', 'firefox/unsupported-warning.html'),
     page('firefox/unsupported/EOL', 'firefox/unsupported-EOL.html'),

--- a/apps/firefox/views.py
+++ b/apps/firefox/views.py
@@ -22,6 +22,9 @@ from firefox.firefox_details import firefox_details
 from l10n_utils.dotlang import _
 
 
+UA_REGEXP = re.compile(r"Firefox/(%s)" % version_re)
+
+
 @csrf_exempt
 def sms_send(request):
     form = SMSSendForm(request.POST or None)
@@ -83,8 +86,7 @@ def latest_fx_redirect(request, fake_version, template_name):
         return HttpResponsePermanentRedirect(url)
 
     user_version = "0"
-    ua_regexp = r"Firefox/(%s)" % version_re
-    match = re.search(ua_regexp, user_agent)
+    match = UA_REGEXP.search(user_agent)
     if match:
         user_version = match.group(1)
 

--- a/media/js/firefox/speed.js
+++ b/media/js/firefox/speed.js
@@ -13,9 +13,6 @@ $(document).ready(function() {
     var needle = $('#needle');
     var gauge = $('#gauge');
     var angle = 0;
-    var latestVersion = $('body').attr('data-latest-firefox');
-    latestVersion = parseInt(latestVersion.split('.')[0], 10);
-    var isFirefox = (/\sFirefox/.test(window.navigator.userAgent));
 
     $.easing.easeInOutSine = function (x, t, b, c, d) {
         return -c/2 * (Math.cos(Math.PI*t/d) - 1) + b;
@@ -80,11 +77,11 @@ $(document).ready(function() {
         }
     };
 
-    if (isFirefox) {
+    if (isFirefox()) {
         // initial position
         rotate(-1.5, 10, startWaver, 'linear');
 
-        if (latestVersion > getFirefoxMasterVersion()) {
+        if (!isFirefoxUpToDate()) {
             // slow
             setTimeout(function() {
                 stopWaver();

--- a/media/js/global.js
+++ b/media/js/global.js
@@ -73,8 +73,7 @@ $(document).ready(function() {
 });
 
 //get Master firefox version
-function getFirefoxMasterVersion()
-{
+function getFirefoxMasterVersion() {
     var version = 0;
 
     var matches = /Firefox\/([0-9]+).[0-9]+(?:.[0-9]+)?/.exec(

--- a/settings/base.py
+++ b/settings/base.py
@@ -522,6 +522,7 @@ INSTALLED_APPS = (
 
 TEMPLATE_CONTEXT_PROCESSORS += (
     'mozorg.context_processors.current_year',
+    'firefox.context_processors.latest_firefox_versions',
 )
 
 ## Auth


### PR DESCRIPTION
In which I refactor some global and firefox/\* page JS to always
include the latest Fx version in the context and abstract
more of Fx up-to-dateness for easier updates in future.

@Osmose r?
