### PR TITLE
Bug 764261: Redirect /zh-TW/* to mozilla.com.tw.

### DIFF
--- a/etc/httpd/global.conf
+++ b/etc/httpd/global.conf
@@ -160,3 +160,6 @@ RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?research(.*)$ /b/$1research$2 [PT]
 
 # bug 822817
 RewriteRule ^/telemetry/?$ /b/telemetry/ [PT]
+
+# bug 764261
+RewriteRule ^/zh-TW/ http://mozilla.com.tw/ [L,R=301]


### PR DESCRIPTION
This is pretty straight-forward, and I've tested
locally that it works. My concern is that these
*.conf files will begin to grow as unruly as
the .htaccess file in the mozilla.com svn repo.

Any discussion on this topic would be helpful, though
we do need to get this redirect in place quickly.
