### PR TITLE
bug 829990 - Tabzilla CSS broken in local installs

### DIFF
--- a/templates/base-resp.html
+++ b/templates/base-resp.html
@@ -11,7 +11,7 @@
 
     <title>{% block page_title_prefix %}Mozilla — {% endblock %}{% block page_title %}{% endblock %}{% block page_title_suffix %} — mozilla.org{% endblock %}</title>
 
-    <link href="/tabzilla/media/css/tabzilla.css" rel="stylesheet">
+    {{ css('tabzilla') }}
 
     <!--[if lte IE 8]>
     <script src="{{ MEDIA_URL }}js/libs/html5shiv.js"></script>

--- a/templates/base.html
+++ b/templates/base.html
@@ -11,7 +11,7 @@
     <title>{% block page_title_prefix %}Mozilla — {% endblock %}{% block page_title %}{% endblock %}{% block page_title_suffix %} — mozilla.org{% endblock %}</title>
     <meta name="description" content="{% block description %}{% endblock %}">
 
-    <link href="/tabzilla/media/css/tabzilla.css" rel="stylesheet">
+    {{ css('tabzilla') }}
 
     <!--[if lt IE 9]>
       <script src="{{ MEDIA_URL }}js/libs/html5shiv.js"></script>


### PR DESCRIPTION
Replaced <link href="/tabzilla/media/css/tabzilla.css" rel="stylesheet"> with {{ css('tabzilla') }} in templates/base.html and templates/base-resp.html.
