### PR TITLE
Bug 815908: Remove frame-options header from hacks newsletter page.

### DIFF
--- a/apps/mozorg/tests/test_views.py
+++ b/apps/mozorg/tests/test_views.py
@@ -16,6 +16,21 @@ from nose.plugins.skip import SkipTest
 from pyquery import PyQuery as pq
 
 
+class TestViews(TestCase):
+    def setUp(self):
+        self.client = Client()
+
+    def test_hacks_newsletter_frames_allow(self):
+        """
+        Bedrock pages get the 'x-frame-options: DENY' header by default.
+        The hacks newsletter page is framed, so needs to ALLOW.
+        """
+        with self.activate('en-US'):
+            resp = self.client.get(reverse('mozorg.hacks_newsletter'))
+
+        ok_('x-frame-options' not in resp)
+
+
 @patch.object(l10n_utils, 'lang_file_is_active', lambda *x: True)
 class TestContribute(TestCase):
     def setUp(self):

--- a/apps/mozorg/urls.py
+++ b/apps/mozorg/urls.py
@@ -3,7 +3,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 from django.conf.urls.defaults import *
-from redirects.util import redirect
 from util import page
 import views
 
@@ -21,8 +20,9 @@ urlpatterns = patterns('',
     page('mission', 'mozorg/mission.html'),
     page('mobile', 'mozorg/mobile.html'),
     page('ITU', 'mozorg/itu.html'),
-    page('newsletter/hacks.mozilla.org', 'mozorg/newsletter/hacks.mozilla.org.html'),
 
+    url('^newsletter/hacks\.mozilla\.org/$', views.hacks_newsletter,
+        name='mozorg.hacks_newsletter'),
     url('^contribute/$', views.contribute, name='mozorg.contribute',
         kwargs={'template': 'mozorg/contribute.html',
                 'return_to_form': False}),

--- a/apps/mozorg/views.py
+++ b/apps/mozorg/views.py
@@ -6,9 +6,16 @@ from django.views.decorators.csrf import csrf_exempt
 
 import basket
 import l10n_utils
+from commonware.decorators import xframe_allow
 
 from mozorg import email_contribute
 from mozorg.forms import ContributeForm, NewsletterForm
+
+
+@xframe_allow
+def hacks_newsletter(request):
+    return l10n_utils.render(request,
+                             'mozorg/newsletter/hacks.mozilla.org.html')
 
 
 @csrf_exempt


### PR DESCRIPTION
The sole purpose for this page is to be framed at hacks.mozilla.org.
