### PR TITLE
Bug 764261: Fix still broken moz.org/zh-TW/ redirects.

### DIFF
--- a/etc/httpd/global.conf
+++ b/etc/httpd/global.conf
@@ -1,12 +1,13 @@
 ExpiresActive on
 
-## Redirect things to mozilla.com.tw
+## Redirect things externally!
+
 # bug 764261
 RewriteRule ^/zh-TW/$ http://mozilla.com.tw/ [L,R=301]
-RewriteRule ^/zh-TW/firefox/(.*)$ http://mozilla.com.tw/firefox/$1 [L,R=301]
-RewriteRule ^/zh-TW/mobile/(.*)$ http://mozilla.com.tw/firefox/mobile/$1 [L,R=301]
-RewriteRule ^/zh-TW/download/(.*)$ http://mozilla.com.tw/firefox/download/$1 [L,R=301]
-RewriteRule ^/zh-TW/products/(.*)$ http://mozilla.com.tw/products/$1 [L,R=301]
+RewriteRule ^/zh-TW/firefox(/.*)?$ http://mozilla.com.tw/firefox$1 [L,R=301]
+RewriteRule ^/zh-TW/mobile/?$ http://mozilla.com.tw/firefox/mobile/ [L,R=301]
+RewriteRule ^/zh-TW/download/?$ http://mozilla.com.tw/firefox/download/ [L,R=301]
+RewriteRule ^/zh-TW/products(/.*)?$ http://mozilla.com.tw/products$1 [L,R=301]
 
 
 ## Redirect things to django!
@@ -21,16 +22,12 @@ RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?firefox/all/$ /b/$1firefox/all/ [PT
 # bug 803345
 RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?apps(.*)$ /b/$1apps$2 [PT]
 
-RewriteRule ^/en-US/persona(.*)$ /b/en-US/persona$1 [PT]
-RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?persona(.*)$ /en-US/persona$2 [L,R=302]
-RewriteRule ^/en-US/b2g(.*)$ /b/en-US/b2g$1 [PT]
-RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?b2g(.*)$ /en-US/b2g$2 [L,R=302]
-RewriteRule ^/en-US/collusion(.*)$ /b/en-US/collusion$1 [PT]
-RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?collusion(.*)$ /en-US/collusion$2 [L,R=302]
+RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?persona(.*)$ /b/$1persona$2 [PT]
+RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?b2g(.*)$ /b/$1b2g$2 [PT]
+RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?collusion(.*)$ /b/$1collusion$2 [PT]
 
 # bug 737157
-RewriteRule ^/en-US/firefox/toolkit/download-to-your-devices(.*)$ /b/en-US/firefox/toolkit/download-to-your-devices$1 [PT]
-RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?firefox/toolkit/download-to-your-devices(.*)$ /en-US/firefox/toolkit/download-to-your-devices$2 [L,R=302]
+RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?firefox/toolkit/download-to-your-devices(.*)$ /b/$1firefox/toolkit/download-to-your-devices$2 [PT]
 
 RewriteRule ^/en-US(/?)$ /b/en-US$1 [PT]
 
@@ -40,24 +37,16 @@ RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?about/mission.html$ /b/$1about/miss
 RewriteRule ^/en-US/about(/?)?$ /b/en-US/about$1 [PT]
 RewriteRule ^/en-US/about/partnerships(/?)$ /b/en-US/about/partnerships$1 [PT]
 RewriteRule ^/en-US/about/partnerships/distribution(/?)$ /b/en-US/about/partnerships/distribution$1 [PT]
-RewriteRule ^/en-US/mission(/?)$ /b/en-US/mission$1 [PT]
-RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?mission/?$ /en-US/mission/ [L,R=302]
+RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?mission(/?)$ /b/$1mission$2 [PT]
 
 # bug 793754
-RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?contribute(/?)$ /b/$1contribute/ [PT]
-
-RewriteRule ^/en-US/contribute(/?)$ /b/en-US/contribute$1 [PT]
-RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?contribute(/?)$ /en-US/contribute/ [L,R=302]
-
-RewriteRule ^/en-US/contribute/page(/?)$ /b/en-US/contribute/page$1 [PT]
-RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?contribute/page(/?)$ /en-US/contribute/page/ [L,R=302]
+RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?contribute(/?)$ /b/$1contribute$2 [PT]
+RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?contribute/page(/?)$ /b/$1contribute/page$2 [PT]
 
 # bug 787953
-RewriteRule ^/en-US/contribute/event(/?)$ /b/en-US/contribute/event$1 [PT]
-RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?contribute/event(.*)$ /en-US/contribute/event$2 [L,R=302]
+RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?contribute/event(.*)$ /b/$1contribute/event$2 [PT]
 
-RewriteRule ^/en-US/projects(/?)$ /b/en-US/projects$1 [PT]
-RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?projects/?$ /en-US/projects/ [L,R=302]
+RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?projects(/?)$ /b/$1projects$2 [PT]
 
 RewriteRule ^/en-US/firefox/new(/?)$ /b/en-US/firefox/new$1 [PT]
 RewriteRule ^/en-US/firefox/fx(/?)$ /b/en-US/firefox/fx$1 [PT]
@@ -79,38 +68,29 @@ RewriteRule ^/en-US/firefox/channel(/?)$ /b/en-US/firefox/channel$1 [PT]
 RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?firefox/unsupported/(.*)$ /b/$1firefox/unsupported/$2 [PT]
 
 # bug 757117
-RewriteRule ^/en-US/webmaker(.*)$ /b/en-US/webmaker$1 [PT]
-RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?webmaker(.*)$ /en-US/webmaker$2 [L,R=302]
+RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?webmaker(.*)$ /b/$1webmaker$2 [PT]
 
 # bug 760194
-RewriteRule ^/en-US/dnt(.*)$ /b/en-US/dnt$1 [PT]
-RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?dnt(.*)$ /en-US/dnt$2 [L,R=302]
+RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?dnt(.*)$ /b/$1dnt$2 [PT]
 
 # bug 767614
 RewriteRule ^/en-US/mobile(/?)$ /b/en-US/mobile$1 [PT]
-RewriteRule ^/en-US/firefox/mobile/features(/?)$ /b/en-US/firefox/mobile/features$1 [PT]
-RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?firefox/mobile/features(/?)$ /en-US/firefox/mobile/features/ [L,R=302]
-RewriteRule ^/en-US/firefox/mobile/faq(/?)$ /b/en-US/firefox/mobile/faq$1 [PT]
-RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?firefox/mobile/faq(/?)$ /en-US/firefox/mobile/faq/ [L,R=302]
-RewriteRule ^/en-US/firefox/mobile/platforms(/?)$ /b/en-US/firefox/mobile/platforms$1 [PT]
-RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?firefox/mobile/platforms(/?)$ /en-US/firefox/mobile/platforms/ [L,R=302]
+RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?firefox/mobile/features(/?)$ /b/$1firefox/mobile/features$2 [PT]
+RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?firefox/mobile/faq(/?)$ /b/$1firefox/mobile/faq$2 [PT]
+RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?firefox/mobile/platforms(/?)$ /b/$1firefox/mobile/platforms$2 [PT]
 
 # bug 773739
-RewriteRule ^/en-US/projects/mozilla-based(/?)$ /b/en-US/projects/mozilla-based/ [PT]
-RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?projects/mozilla-based(/?)$ /en-US/projects/mozilla-based/ [L,R=302]
-RewriteRule ^/en-US/products(/?)$ /b/en-US/products/ [PT]
-RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?products(/?)$ /en-US/products/ [L,R=302]
-RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?firefox(/(?:\d+\.\d+\.?(?:\d+)?\.?(?:\d+)?(?:[a|b]?)(?:\d*)(?:pre)?(?:\d)?))?/whatsnew(/?)$ /b/$1firefox$2/whatsnew/ [PT]
+RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?projects/mozilla-based(/?)$ /b/$1projects/mozilla-based$2 [PT]
+RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?products(/?)$ /b/$1products$2 [PT]
+RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?firefox(/(?:\d+\.\d+\.?(?:\d+)?\.?(?:\d+)?(?:[a|b]?)(?:\d*)(?:pre)?(?:\d)?))?/whatsnew(/?)$ /b/$1firefox$2/whatsnew$3 [PT]
 
 # bug 778752
 RewriteRule ^/en-US/firefox/channel/android(/?)$ /b/en-US/firefox/channel/android$1 [PT]
 
 # bug 784737
-RewriteRule ^/en-US/firefox/memory(/?)$ /b/en-US/firefox/memory$1 [PT]
-RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?firefox/memory(.*)$ /en-US/firefox/memory$2 [L,R=302]
+RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?firefox/memory(.*)$ /b/$1firefox/memory$2 [PT]
 
-RewriteRule ^/en-US/styleguide(.*)$ /b/en-US/styleguide$1 [PT]
-RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?styleguide(.*)$ /en-US/styleguide$2 [L,R=302]
+RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?styleguide(.*)$ /b/$1styleguide$2 [PT]
 
 RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?firefox/sms(.*)$ /b/$1firefox/sms$2 [PT]
 
@@ -124,8 +104,7 @@ RewriteRule ^/.*/plugincheck/ https://%{SERVER_NAME}%{REQUEST_URI} [L,R=301]
 RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?firefoxos(.*)$ /b/$1firefoxos$2 [PT]
 
 # bug 797337
-RewriteRule ^/en-US/contribute/areas.html$ /b/en-US/contribute/areas.html [PT]
-RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?contribute/areas.html$ /en-US/contribute/areas.html [L,R=302]
+RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?contribute/areas.html$ /b/$1contribute/areas.html [PT]
 
 # bug 798453
 RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?firefox/installer-help(.*)$ /b/$1firefox/installer-help$2 [PT]
@@ -146,8 +125,7 @@ RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?privacy/policies/facebook(.*)$ /b/$
 RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?foundation/identity-guidelines(.*)$ /b/$1foundation/identity-guidelines$2 [PT]
 
 # bug 809426
-RewriteRule ^/en-US/legal/eula(/?)$ /b/en-US/legal/eula$1 [PT]
-RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?legal/eula(/?)$ /en-US/legal/eula$2 [L,R=302]
+RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?legal/eula(/?)$ /b/$1legal/eula$2 [PT]
 
 # bug 811787
 RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?foundation/annualreport/2011(.*)$ /b/$1foundation/annualreport/2011$2 [PT]


### PR DESCRIPTION
Also fix several rules that were forcing many URLs to be en-US only. Bedrock
now takes care of deciding which pages to redirect to the default lang (en-US)
and which to display as translated as of bug 794059. Allowing all locales to
pass through to bedrock for the ones that were redirecting all locales to
en-US will enable our l10n managers to turn on locales on a per-page basis
without the need for a code push.
