### PR TITLE
Bug 837883: Redirect /firefox/firefox.exe to /firefox/.

### DIFF
--- a/etc/httpd/global.conf
+++ b/etc/httpd/global.conf
@@ -19,8 +19,11 @@ RewriteRule ^/zh-CN/$ http://firefox.com.cn/ [L,R=301]
 
 ## Redirect things to django!
 
+# bug 837883
+RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?firefox/firefox\.exe$ /$1 [NC,L,R=301]
+
 # bug 815908
-RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?newsletter/hacks.mozilla.org(/?)$ /b/$1newsletter/hacks.mozilla.org/ [PT]
+RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?newsletter/hacks\.mozilla\.org(/?)$ /b/$1newsletter/hacks.mozilla.org$2 [PT]
 
 # bug 821006
 RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?firefox/all(\.html)?$ /$1firefox/all/ [L,R=301]


### PR DESCRIPTION
The `NC` part in the rule flags is `nocase` to make it
case insensitive as requested in the bug. The changes to
the rule for hacks.mozilla.org were due to the unescaped
use of `.` in the regex when it meant to be searching for
a literal period.
