### PR TITLE
Bug 775542: Query lang files in the proper order.

### DIFF
--- a/lib/l10n_utils/dotlang.py
+++ b/lib/l10n_utils/dotlang.py
@@ -54,7 +54,9 @@ def parse(path):
                 for tag in ('{ok}', '{l10n-extra}'):
                     if line.endswith(tag):
                         line = line[:-len(tag)]
-                trans[source] = line.strip()
+                line = line.strip()
+                if not source == line:
+                    trans[source] = line
 
     return trans
 

--- a/lib/l10n_utils/helpers.py
+++ b/lib/l10n_utils/helpers.py
@@ -16,9 +16,10 @@ def install_lang_files(ctx):
 
     if not hasattr(req, 'langfiles'):
         files = list(settings.DOTLANG_FILES)
-        if ctx.get('langfile'):
-            files.append(ctx.get('langfile'))
-        setattr(req, 'langfiles', files)
+        langfile = ctx.get('langfile')
+        if langfile:
+            files.insert(0, langfile)
+        req.langfiles = files
 
 
 def add_lang_files(ctx, files):

--- a/lib/l10n_utils/tests/test_dotlang.py
+++ b/lib/l10n_utils/tests/test_dotlang.py
@@ -8,13 +8,13 @@ import os
 
 from django.conf import settings
 from django.core import mail
+from django.core.cache import cache
 from django.core.urlresolvers import clear_url_caches
 from django.test.client import Client
 
 from jingo import env
 from jinja2 import FileSystemLoader
 from mock import patch
-from nose.plugins.skip import SkipTest
 from nose.tools import assert_not_equal, eq_, ok_
 from pyquery import PyQuery as pq
 from tower.management.commands.extract import extract_tower_python
@@ -37,7 +37,7 @@ class TestLangFilesActivation(TestCase):
         clear_url_caches()
         self.client = Client()
 
-    @patch.object(settings, 'DEV', False)
+    @patch('l10n_utils.settings.DEV', False)
     def test_lang_file_is_active(self):
         """
         `lang_file_is_active` should return true if lang file has the
@@ -48,7 +48,7 @@ class TestLangFilesActivation(TestCase):
         ok_(not lang_file_is_active('inactive_de_lang_file', 'de'))
         ok_(not lang_file_is_active('does_not_exist', 'de'))
 
-    @patch.object(settings, 'DEV', False)
+    @patch('l10n_utils.settings.DEV', False)
     def test_active_locale_not_redirected(self):
         """ Active lang file should render correctly. """
         response = self.client.get('/de/active-de-lang-file/')
@@ -56,7 +56,7 @@ class TestLangFilesActivation(TestCase):
         doc = pq(response.content)
         eq_(doc('h1').text(), 'Die Lage von Mozilla')
 
-    @patch.object(settings, 'DEV', False)
+    @patch('l10n_utils.settings.DEV', False)
     @patch.object(settings, 'LANGUAGE_CODE', 'en-US')
     def test_inactive_locale_redirected(self):
         """ Inactive locale should redirect to en-US. """
@@ -68,13 +68,11 @@ class TestLangFilesActivation(TestCase):
         doc = pq(response.content)
         eq_(doc('h1').text(), 'The State of Mozilla')
 
-    @patch.object(settings, 'DEV', True)
+    @patch('l10n_utils.settings.DEV', True)
     def test_inactive_locale_not_redirected_dev_true(self):
         """
         Inactive lang file should not redirect in DEV mode.
         """
-        # Disabled because of bug 815573
-        raise SkipTest
         response = self.client.get('/de/inactive-de-lang-file/')
         eq_(response.status_code, 200)
         doc = pq(response.content)
@@ -82,6 +80,11 @@ class TestLangFilesActivation(TestCase):
 
 
 class TestDotlang(TestCase):
+    def setUp(self):
+        cache.clear()
+        clear_url_caches()
+        self.client = Client()
+
     def test_parse(self):
         path = os.path.join(ROOT, 'test.lang')
         parsed = parse(path)
@@ -105,6 +108,15 @@ class TestDotlang(TestCase):
         }
         eq_(parsed, expected)
         mail.outbox = []
+
+    def test_parse_ingnores_untranslated(self):
+        """parse should skip strings that aren't translated."""
+        path = os.path.join(ROOT, 'locale/de/main.lang')
+        parsed = parse(path)
+        expected = {
+            u'The State of Mozilla': u'Awesome Baby! YEEEAAHHHH!!'
+        }
+        self.assertDictEqual(parsed, expected)
 
     def test_format_identifier_re(self):
         eq_(FORMAT_IDENTIFIER_RE.findall('%s %s'),
@@ -137,6 +149,16 @@ class TestDotlang(TestCase):
             result = translate(expected, [path])
         assert_not_equal(expected, result)
         eq_(len(mail.outbox), 0)
+
+    @patch.object(env, 'loader', FileSystemLoader(TEMPLATE_DIRS))
+    @patch.object(settings, 'ROOT_URLCONF', 'l10n_utils.tests.test_files.urls')
+    @patch.object(settings, 'ROOT', ROOT)
+    def test_lang_files_queried_in_order(self):
+        """The more specific lang files should be searched first."""
+        response = self.client.get('/de/trans-block-reload-test/')
+        doc = pq(response.content)
+        gettext_call = doc('h1')
+        eq_(gettext_call.text(), 'Die Lage von Mozilla')
 
     @patch.object(settings, 'ROOT', ROOT)
     def test_extract_message_tweaks_do_not_break(self):

--- a/lib/l10n_utils/tests/test_files/locale/de/main.lang
+++ b/lib/l10n_utils/tests/test_files/locale/de/main.lang
@@ -1,0 +1,6 @@
+
+;The State of Mozilla
+Awesome Baby! YEEEAAHHHH!!
+
+;The Dude abides.
+The Dude abides.

--- a/lib/l10n_utils/tests/test_files/urls.py
+++ b/lib/l10n_utils/tests/test_files/urls.py
@@ -10,4 +10,5 @@ urlpatterns = patterns('',
     page('trans-block-reload-test', 'trans_block_reload_test.html'),
     page('active-de-lang-file', 'active_de_lang_file.html'),
     page('inactive-de-lang-file', 'inactive_de_lang_file.html'),
+    page('some-lang-files', 'some_lang_files.html'),
 )

--- a/lib/l10n_utils/tests/test_template.py
+++ b/lib/l10n_utils/tests/test_template.py
@@ -11,7 +11,7 @@ from django.test.client import Client
 from jingo import env
 from jinja2 import FileSystemLoader
 from jinja2.nodes import Block
-from mock import patch
+from mock import patch, ANY
 from nose.plugins.skip import SkipTest
 from nose.tools import eq_, ok_
 from pyquery import PyQuery as pq
@@ -65,6 +65,10 @@ class TestTransBlocks(TestCase):
 
 
 class TestTemplateLangFiles(TestCase):
+    def setUp(self):
+        clear_url_caches()
+        self.client = Client()
+
     @patch.object(env, 'loader', FileSystemLoader(TEMPLATE_DIRS))
     def test_added_lang_files(self):
         """
@@ -93,3 +97,30 @@ class TestTemplateLangFiles(TestCase):
         template.render(request=request)
         eq_(request.langfiles, ['donnie', 'smokey', 'jesus', 'dude', 'walter',
                                 'main', 'base', 'newsletter'])
+
+    @patch.object(env, 'loader', FileSystemLoader(TEMPLATE_DIRS))
+    @patch.object(settings, 'ROOT_URLCONF', 'l10n_utils.tests.test_files.urls')
+    @patch.object(settings, 'ROOT', ROOT)
+    @patch('l10n_utils.settings.DEV', True)
+    @patch('l10n_utils.helpers.translate')
+    def test_lang_files_order(self, translate):
+        """
+        Lang files should be queried in order they appear in the file and then
+        the defaults.
+        """
+        self.client.get('/de/some-lang-files/')
+        translate.assert_called_with(ANY, ['dude', 'walter', 'some_lang_files',
+                                           'main', 'base', 'newsletter'])
+
+    @patch.object(env, 'loader', FileSystemLoader(TEMPLATE_DIRS))
+    @patch.object(settings, 'ROOT_URLCONF', 'l10n_utils.tests.test_files.urls')
+    @patch.object(settings, 'ROOT', ROOT)
+    @patch('l10n_utils.settings.DEV', True)
+    @patch('l10n_utils.helpers.translate')
+    def test_lang_files_default_order(self, translate):
+        """
+        The template-specific lang file should come before the defaults.
+        """
+        self.client.get('/de/active-de-lang-file/')
+        translate.assert_called_with(ANY, ['active_de_lang_file', 'main',
+                                           'base', 'newsletter'])


### PR DESCRIPTION
It was looking in the default files before the lang file specifically
for the template. Pascal also wanted it to keep checking for
translations if the string was in the file, but untranslated.
