### PR TITLE
Bug 775542: Prevent templates from overriding with default langfiles.

### DIFF
--- a/lib/l10n_utils/dotlang.py
+++ b/lib/l10n_utils/dotlang.py
@@ -109,6 +109,7 @@ def translate(text, files):
 
 def _get_extra_lang_files():
     frame = inspect.currentframe()
+    new_lang_files = []
     if frame is None:
         if settings.DEBUG:
             import warnings
@@ -125,7 +126,7 @@ def _get_extra_lang_files():
         if new_lang_files:
             if isinstance(new_lang_files, basestring):
                 new_lang_files = [new_lang_files]
-    return new_lang_files
+    return [lf for lf in new_lang_files if lf not in settings.DOTLANG_FILES]
 
 
 def _(text, *args, **kwargs):

--- a/lib/l10n_utils/gettext.py
+++ b/lib/l10n_utils/gettext.py
@@ -116,7 +116,8 @@ def parse_python(path):
         new_lang_files = eval(untokenize(result))
         if isinstance(new_lang_files, basestring):
             new_lang_files = [new_lang_files]
-        return new_lang_files
+        # remove empties
+        return [lf for lf in new_lang_files if lf]
     return []
 
 
@@ -147,7 +148,8 @@ def parse_template(path):
                     lang_files.append(arg[2].strip('"'))
                     arg = ignore_whitespace(tokens)
 
-                lang_files = filter(lambda x: x, lang_files)
+                # remove empties
+                lang_files = [lf for lf in lang_files if lf]
                 if lang_files:
                     return lang_files
     return []

--- a/lib/l10n_utils/helpers.py
+++ b/lib/l10n_utils/helpers.py
@@ -46,7 +46,8 @@ def lang_files(ctx, *files):
     """Add more lang files to the translation object"""
     # Filter out empty files
     install_lang_files(ctx)
-    add_lang_files(ctx, [f for f in files if f])
+    add_lang_files(ctx, [f for f in files
+                         if f and f not in settings.DOTLANG_FILES])
 
 
 # backward compatible for imports

--- a/lib/l10n_utils/tests/test_dotlang.py
+++ b/lib/l10n_utils/tests/test_dotlang.py
@@ -198,6 +198,26 @@ class TestDotlang(TestCase):
         eq_(old_setting, settings.DOTLANG_FILES)
 
     @patch('l10n_utils.dotlang.translate')
+    def test_gettext_ignores_default_lang_files(self, trans_patch):
+        """
+        The `l10n_utils.dotlang._` function should search .lang files
+        specified in the module from which it's called before the
+        default files, but it should not include the defaults twice.
+        """
+        # use LANG_FILES global in this module
+        global LANG_FILES
+        old_lang_files = LANG_FILES
+
+        trans_str = 'Translate me'
+        LANG_FILES = [settings.DOTLANG_FILES[0], 'dude', 'donnie', 'walter']
+        _(trans_str)
+        call_lang_files = LANG_FILES[1:] + settings.DOTLANG_FILES
+        trans_patch.assert_called_with(trans_str, call_lang_files)
+
+        # restore original value to avoid test leakage
+        LANG_FILES = old_lang_files
+
+    @patch('l10n_utils.dotlang.translate')
     def test_gettext_searches_specified_lang_files(self, trans_patch):
         """
         The `l10n_utils.dotlang._` function should search .lang files
@@ -239,7 +259,6 @@ class TestDotlang(TestCase):
         # test the case when LANG_FILES is a list
         lang_files_list = ['maude', 'bunny', 'uli']
         _(trans_str, lang_files=lang_files_list)
-        print lang_files_list
         call_lang_files = lang_files_list + settings.DOTLANG_FILES
         trans_patch.assert_called_with(trans_str, call_lang_files)
 

--- a/lib/l10n_utils/tests/test_files/templates/some_lang_files.html
+++ b/lib/l10n_utils/tests/test_files/templates/some_lang_files.html
@@ -5,6 +5,6 @@
 {% extends "no_lang_files.html" %}
 
 {% block content %}
-    {% add_lang_files "dude" "walter" %}
+    {% add_lang_files "dude" "walter" "main" %}
     {{ _('Content yo!') }}
 {% endblock %}

--- a/lib/l10n_utils/tests/test_gettext.py
+++ b/lib/l10n_utils/tests/test_gettext.py
@@ -163,7 +163,7 @@ class TestLangfilesForPath(TestCase):
         """ If lang files are set, they should be returned. """
         lang_files = langfiles_for_path('lib/l10n_utils/tests/test_files/'
                                         'templates/some_lang_files.html')
-        eq_(lang_files, ['dude', 'walter'])
+        eq_(lang_files, ['dude', 'walter', 'main'])
 
     def test_py_no_lang_files_defined(self):
         """

--- a/lib/l10n_utils/tests/test_template.py
+++ b/lib/l10n_utils/tests/test_template.py
@@ -105,8 +105,8 @@ class TestTemplateLangFiles(TestCase):
     @patch('l10n_utils.helpers.translate')
     def test_lang_files_order(self, translate):
         """
-        Lang files should be queried in order they appear in the file and then
-        the defaults.
+        Lang files should be queried in order they appear in the file,
+        excluding defaults and then the defaults.
         """
         self.client.get('/de/some-lang-files/')
         translate.assert_called_with(ANY, ['dude', 'walter', 'some_lang_files',


### PR DESCRIPTION
The base templates had specified "main" in a "set_lang_files" tag. This was
causing child templates to look in "main.lang" before the lang file for the
template. This removes those errant calls, as well as prevents such accidental
additions from breaking things in future.
