### PR TITLE
rename "Mozilla Marketplace" to "Firefox Marketplace" everywhere (bug 841932)

### DIFF
--- a/apps/firefox/templates/firefox/partners/index.html
+++ b/apps/firefox/templates/firefox/partners/index.html
@@ -489,7 +489,7 @@
             </div>
             <div class="event">
               <h3>{{ _('Mobile Premier Awards & AppCircus After Party') }}</h3>
-              <p>{{ _('Mozilla Marketplace VP Rick Fant will select and present the winning app.') }}</p>
+              <p>{{ _('Firefox Marketplace VP Rick Fant will select and present the winning app.') }}</p>
               <div class="time">{{ _('16:00-23:00 CET (awards at 22:30)') }}</div>
               <div class="location">{{ _('Sala Apolo, Barcelona') }}</div>
             </div>

--- a/apps/foundation/templates/foundation/annualreport/2011faq.html
+++ b/apps/foundation/templates/foundation/annualreport/2011faq.html
@@ -13,7 +13,7 @@
 {% block extrahead %}
   {{ css('annual_2011') }}
   <link rel="stylesheet" media="print" href="{{ MEDIA_URL }}css/foundation/annual2011print.css">
-  
+
   <script type="text/javascript">
     var _gaq = _gaq || [];
     _gaq.push(['_setAccount', 'UA-36116321-1']);
@@ -144,7 +144,7 @@
         {#L10N: These variables will be numerals that won't require translation #}
         {% trans %}
           Mozilla’s consolidated reported revenue (Mozilla Foundation and all
-          subsidiaries) for 2011 was $163M (US), up approximately 33 percent 
+          subsidiaries) for 2011 was $163M (US), up approximately 33 percent
           from $123M in 2010.
         {% endtrans %}
         </p>
@@ -365,7 +365,7 @@
       <dd>
         <p>
         {% trans %}
-          The Mozilla Marketplace will offer developers’ discovery, distribution
+          The Firefox Marketplace will offer developers’ discovery, distribution
           and monetization opportunities and will also be customizable by
           partners. For example, with Telefónica, we will provide direct-to-bill
           capabilities in the device, in the event that app store owners would

--- a/apps/mozorg/templates/mozorg/home.html
+++ b/apps/mozorg/templates/mozorg/home.html
@@ -151,7 +151,7 @@
         <p>{{_('Help us share Firefox with the world!')}}</p>
       </li>
       <li>
-        <h4><a href="{{ url('marketplace.marketplace') }}">{{_('Mozilla Marketplace')}}</a></h4>
+        <h4><a href="{{ url('marketplace.marketplace') }}">{{ _('Firefox Marketplace') }}</a></h4>
         <p>{{_('Launch your app on the web')}}</p>
       </li>
     </ul>

--- a/apps/mozorg/templates/mozorg/mobile.html
+++ b/apps/mozorg/templates/mozorg/mobile.html
@@ -62,9 +62,9 @@
       choice &ndash; to the world of apps and giving developers with
       full control over content, functionality and how apps are
       distributed, including access to hundreds of millions of Firefox
-      users through the Mozilla Marketplace.</p>
+      users through the Firefox Marketplace.</p>
 
-      <p><a class="go" href="https://marketplace.mozilla.org">Learn more about apps and the Mozilla Marketplace</a></p>
+      <p><a class="go" href="https://marketplace.firefox.com">Learn more about apps and the Firefox Marketplace</a></p>
     </section>
   </section>
 

--- a/apps/privacy/templates/privacy/index.html
+++ b/apps/privacy/templates/privacy/index.html
@@ -126,7 +126,7 @@
       <li><a href="http://www.mozilla.org/en-US/privacy-policy.html" class="policy-moz-websites">Mozilla Websites</a></li>
       <li><a href="http://www.mozilla.org/en-US/legal/privacy/firefox.html" class="policy-firefox">Firefox</a></li>
       <li><a href="http://www.mozilla.org/en-US/thunderbird/legal/privacy/" class="policy-thunderbird">Thunderbird</a></li>
-      <li><a href="https://marketplace.mozilla.org/privacy-policy" class="policy-marketplace">Marketplace</a></li>
+      <li><a href="https://marketplace.firefox.com/privacy-policy" class="policy-marketplace">Marketplace</a></li>
       <li><a href="http://www.mozilla.org/en-US/persona/privacy-policy/" class="policy-persona">Persona</a></li>
       <li><a href="https://services.mozilla.com/privacy-policy/" class="policy-sync">Sync</a></li>
       <li><a href="https://testpilot.mozillalabs.com/privacy.php" class="policy-test-pilot">Test Pilot</a></li>

--- a/apps/privacy/templates/privacy/marketplace.html
+++ b/apps/privacy/templates/privacy/marketplace.html
@@ -18,16 +18,16 @@
         <h1>Marketplace Privacy Policy</h1>
         <h2>$FIXME:[publication date]</h2>
       </hgroup>
-      <p><em>Note: The proposed full version of the Privacy Policy for the Mozilla Marketplace is currently under review and comment on our <a href="http://groups.google.com/group/mozilla.governance/topics">governance 
-        mailing list</a>. When the Mozilla Marketplace is fully launched, we will ask for your consent to the final Privacy Policy.</em></p>
-      <p>The Mozilla Marketplace is a publicly available market maintained by Mozilla that allows developers to distribute their Apps (applications 
-        written using open web technologies that can run on multiple platforms) or Add-ons (extensions and themes that allow you to extend the 
-        functionality of the Firefox browser) to users for use on any device that can access the open web.  This policy describes how Mozilla deals 
-        with any info we get with respect to the Mozilla Marketplace. We have separate privacy policies for our other products and services.</p>
+      <p><em>Note: The proposed full version of the Privacy Policy for the Firefox Marketplace is currently under review and comment on our <a href="http://groups.google.com/group/mozilla.governance/topics">governance
+        mailing list</a>. When the Firefox Marketplace is fully launched, we will ask for your consent to the final Privacy Policy.</em></p>
+      <p>The Firefox Marketplace is a publicly available market maintained by Mozilla that allows developers to distribute their Apps (applications
+        written using open web technologies that can run on multiple platforms) or Add-ons (extensions and themes that allow you to extend the
+        functionality of the Firefox browser) to users for use on any device that can access the open web.  This policy describes how Mozilla deals
+        with any info we get with respect to the Firefox Marketplace. We have separate privacy policies for our other products and services.</p>
       <section>
         <h3>What we consider to be personal information</h3>
-        <p>We consider "personal information" to mean either information which identifies you, like your name or email address; or a combination 
-          of several pieces of information which couldn't identify you on their own, but which could become identifiable to you when put together. 
+        <p>We consider "personal information" to mean either information which identifies you, like your name or email address; or a combination
+          of several pieces of information which couldn't identify you on their own, but which could become identifiable to you when put together.
           Also, if we store personal information with other information that is not personal, we consider the combination to be personal information.</p>
         <h4>How we collect information about you</h4>
         <p>There are four ways we collect information about you:</p>
@@ -38,88 +38,88 @@
           <li>We try and understand more about you based on information you've already given us (like suggesting what Apps you might be interested in based on your purchase history).</li>
         </ol>
         <h5>Some specifics</h5>
-        <p>The Mozilla Marketplace uses cookies to help Mozilla identify and track visitors, their usage of Mozilla Marketplace, and their website 
-          access preferences across multiple requests and visits to the Mozilla Marketplace in order for us to understand how users use the Mozilla 
+        <p>The Firefox Marketplace uses cookies to help Mozilla identify and track visitors, their usage of Firefox Marketplace, and their website
+          access preferences across multiple requests and visits to the Firefox Marketplace in order for us to understand how users use the Mozilla
           Marketplace and to make your experience better. You can opt-out of this practice by following the instructions <a href="http://www.mozilla.org/en-US/opt-out.html">here</a>.</p>
-        <p>When you log in with BrowserID to the Mozilla Marketplace, the BrowserID service sends us your email address. You can browse the Mozilla 
-          Marketplace without logging in to BrowserID, however, you cannot install an App or purchase an Add-on without logging into the Mozilla 
-          Marketplace with BrowserID. If you have an existing Mozilla Add-ons account, you will be prompted to sign in with a BrowserID account before 
+        <p>When you log in with BrowserID to the Firefox Marketplace, the BrowserID service sends us your email address. You can browse the Mozilla
+          Marketplace without logging in to BrowserID, however, you cannot install an App or purchase an Add-on without logging into the Mozilla
+          Marketplace with BrowserID. If you have an existing Mozilla Add-ons account, you will be prompted to sign in with a BrowserID account before
           you can install an App or purchase an Add-on.</p>
-        <p>Firefox sends daily messages to Mozilla with metadata that helps ensure that you have the latest updates when you install an Add-on. Please 
-          see the <a href="FIXME">Firefox Privacy Policy</a> for more information on our Automated Update Service. You can opt out of these messages by following the 
+        <p>Firefox sends daily messages to Mozilla with metadata that helps ensure that you have the latest updates when you install an Add-on. Please
+          see the <a href="FIXME">Firefox Privacy Policy</a> for more information on our Automated Update Service. You can opt out of these messages by following the
           instructions here.</p>
-        <p>We collect the search terms you enter to find Apps or Add-ons and your interactions with the various parts of the Marketplace to better understand, in the 
-          aggregate, how users interact with the Mozilla Marketplace. We don’t tie this information to your BrowserID account.</p>
+        <p>We collect the search terms you enter to find Apps or Add-ons and your interactions with the various parts of the Marketplace to better understand, in the
+          aggregate, how users interact with the Firefox Marketplace. We don’t tie this information to your BrowserID account.</p>
       </section>
       <section>
         <h4>What we will do with your info</h4>
         <p>We use your information to help us provide better products and services to you. When you give us personal information, we will use it in the manner to which you consent.</p>
         <h5>Some specifics</h5>
-        <p>We may use your email address to inform you of transactional messages from the Mozilla Marketplace, and you may elect to receive additional communications 
-          from us. If you signed up to receive but no longer wish to receive electronic marketing communications from Mozilla about the Mozilla 
-          Marketplace, you can opt-out from receiving these communications by following the “unsubscribe” instructions in any such communication you 
+        <p>We may use your email address to inform you of transactional messages from the Firefox Marketplace, and you may elect to receive additional communications
+          from us. If you signed up to receive but no longer wish to receive electronic marketing communications from Mozilla about the Mozilla
+          Marketplace, you can opt-out from receiving these communications by following the “unsubscribe” instructions in any such communication you
           receive. You can manage the email and notification settings for Mozilla-sent email in your Marketplace Profile.</p>
-        <p>If you write App or Add-on reviews, create a collection, or create other content in the Mozilla Marketplace, your display name or username 
-          will be displayed publicly. You may optionally fill in details of your public user profile, such as a homepage or profile picture, which will 
+        <p>If you write App or Add-on reviews, create a collection, or create other content in the Firefox Marketplace, your display name or username
+          will be displayed publicly. You may optionally fill in details of your public user profile, such as a homepage or profile picture, which will
           be displayed publicly.</p>
-        <p>If you purchase an App, we sign your receipt with the BrowserID user name (usually an email address) that you registered with the Mozilla 
-          Marketplace through BrowserID. Apps you have installed may periodically communicate with Mozilla or an App developer for purposes of 
-          receipt/ownership verification, usage information, or other reasons as described in the individual App’s privacy policy. You should check an 
+        <p>If you purchase an App, we sign your receipt with the BrowserID user name (usually an email address) that you registered with the Mozilla
+          Marketplace through BrowserID. Apps you have installed may periodically communicate with Mozilla or an App developer for purposes of
+          receipt/ownership verification, usage information, or other reasons as described in the individual App’s privacy policy. You should check an
           App’s privacy policy to make sure you are okay with their information handling practices before installing or using an App.</p>
-        <p>When you purchase an App or Add-on from a developer, they may receive information about you from your selected payment provider, as described 
-          in that payment provider’s privacy policy. We help you maintain a history of your transactional activity (like which Apps you have purchased). 
-          No financial information (such as credit card info that you have used to make purchases in the Mozilla Marketplace) is collected, retained or used by Mozilla.</p>
-        <p>For an enhanced Marketplace experience, you may opt in to link your Marketplace account with your accounts on social networks. This is entirely 
-          optional and your accounts may be un-linked by you at any time. Once your account is un-linked, we do not continue to store or use information 
-          about your social graph or contacts from the social network you had linked. Individual Apps or Add-ons may allow you to link to your social 
+        <p>When you purchase an App or Add-on from a developer, they may receive information about you from your selected payment provider, as described
+          in that payment provider’s privacy policy. We help you maintain a history of your transactional activity (like which Apps you have purchased).
+          No financial information (such as credit card info that you have used to make purchases in the Firefox Marketplace) is collected, retained or used by Mozilla.</p>
+        <p>For an enhanced Marketplace experience, you may opt in to link your Marketplace account with your accounts on social networks. This is entirely
+          optional and your accounts may be un-linked by you at any time. Once your account is un-linked, we do not continue to store or use information
+          about your social graph or contacts from the social network you had linked. Individual Apps or Add-ons may allow you to link to your social
           network accounts and you should check the privacy policy of each App or Add-on to understand how they use your info.</p>
-        <p>If you ask us to send an App or Add-on to your phone, we will ask for your phone number and, with your permission, save it for future convenience. 
-          You may remove it by editing your Marketplace Profile. If you are a developer who submits an App or Add-on to the Mozilla Marketplace, we will 
-          ask for detailed information about your product that may be displayed publicly, unless otherwise noted. If you wish to use payments in your 
-          product, we will ask for your real legal name and address in order to validate your identity and manage the Mozilla Marketplace.</p>
-        <p>Add-ons installed in Firefox and other Mozilla products may check for new versions of those Add-ons with the Mozilla Marketplace each day. 
-          Additionally, Firefox may check for updates to other metadata related to Add-ons (e.g., updated descriptions, ratings, etc.) as described in 
-          the <a href="FIXME">Firefox Privacy Policy</a>. In aggregate, these update checks are used by Mozilla to determine the number of active users of an Add-on or App. 
-          You may opt out of the metadata transfer as described <a href="http://blog.mozilla.com/addons/how-to-opt-out-of-add-on-metadata-updates/">here</a>, and Add-on 
+        <p>If you ask us to send an App or Add-on to your phone, we will ask for your phone number and, with your permission, save it for future convenience.
+          You may remove it by editing your Marketplace Profile. If you are a developer who submits an App or Add-on to the Firefox Marketplace, we will
+          ask for detailed information about your product that may be displayed publicly, unless otherwise noted. If you wish to use payments in your
+          product, we will ask for your real legal name and address in order to validate your identity and manage the Firefox Marketplace.</p>
+        <p>Add-ons installed in Firefox and other Mozilla products may check for new versions of those Add-ons with the Firefox Marketplace each day.
+          Additionally, Firefox may check for updates to other metadata related to Add-ons (e.g., updated descriptions, ratings, etc.) as described in
+          the <a href="FIXME">Firefox Privacy Policy</a>. In aggregate, these update checks are used by Mozilla to determine the number of active users of an Add-on or App.
+          You may opt out of the metadata transfer as described <a href="http://blog.mozilla.com/addons/how-to-opt-out-of-add-on-metadata-updates/">here</a>, and Add-on
           updates as described <a href="http://blog.mozilla.com/addons/how-to-turn-off-add-on-updates/">here</a>.</p>
-        <p>The Get Add-ons page of the Add-ons Manager in Firefox may include the Add-ons you have installed in order to provide relevant recommendations 
-          of other Add-ons to install, as described in the <a href="FIXME">Firefox Privacy Policy</a>. You may opt out of this as described 
+        <p>The Get Add-ons page of the Add-ons Manager in Firefox may include the Add-ons you have installed in order to provide relevant recommendations
+          of other Add-ons to install, as described in the <a href="FIXME">Firefox Privacy Policy</a>. You may opt out of this as described
           <a href="http://blog.mozilla.com/addons/how-to-opt-out-of-add-on-metadata-updates/">here</a>.</p>
       </section>
       <section>
         <h4>When we share your info</h4>
-        <p>Mozilla is an open organization, and we publish information that we think will make our products better or help foster an open web. Whenever we 
+        <p>Mozilla is an open organization, and we publish information that we think will make our products better or help foster an open web. Whenever we
           publish information about our users, we'll remove anything that we believe can identify you.</p>
-        <p>If we share your personal information, we only share it with employees, contractors and service providers who have contractually promised to handle 
-          or use the data in ways that are approved by Mozilla. If our corporate structure or status changes (e.g., if we restructure, are acquired, or 
+        <p>If we share your personal information, we only share it with employees, contractors and service providers who have contractually promised to handle
+          or use the data in ways that are approved by Mozilla. If our corporate structure or status changes (e.g., if we restructure, are acquired, or
           go bankrupt) we'll pass on your information to a successor or affiliate.</p>
         <h5>Some specifics</h5>
-        <p>When you install a paid or free App, we send a digital receipt of that App to the developer of the App. This is to facilitate interactions between 
-          you and that developer as well as allow the developer to electronically authorize uses of the App. The digital receipt contains your BrowserID username 
-          (usually your email address) as well as other information. You can find a more detailed description of receipts and the information they contain 
-          <a href="https://wiki.mozilla.org/Apps/WebApplicationReceipt">here</a>. Additionally, if you request support or a refund for an App or Add-on through the 
-          Marketplace, we give the developer your email address so they can reply to you. A developer’s use of your email address or digital receipt is subject to 
+        <p>When you install a paid or free App, we send a digital receipt of that App to the developer of the App. This is to facilitate interactions between
+          you and that developer as well as allow the developer to electronically authorize uses of the App. The digital receipt contains your BrowserID username
+          (usually your email address) as well as other information. You can find a more detailed description of receipts and the information they contain
+          <a href="https://wiki.mozilla.org/Apps/WebApplicationReceipt">here</a>. Additionally, if you request support or a refund for an App or Add-on through the
+          Marketplace, we give the developer your email address so they can reply to you. A developer’s use of your email address or digital receipt is subject to
           their privacy policy. You should check an App’s privacy policy to make sure you are okay with their information handling practices before installing or using an App.</p>
-        <p>We share non-personal aggregated statistics with developers on the usage of their software, such as platform (Windows, Android, etc.) and browser version 
+        <p>We share non-personal aggregated statistics with developers on the usage of their software, such as platform (Windows, Android, etc.) and browser version
           information. We provide the information as a distribution of numbers and not tied to an email address, unique ID or other identifiable piece of information.</p>
-        <p>Mozilla does not currently process payments on its users behalf. When you make a purchase in the Marketplace, the information that you give to your selected 
-          payment provider is governed by that provider’s privacy policy. A list of third-party vendors that are authorized payment processors for the Marketplace 
-          are available here.[Link TBD]  Developers may also use their own payment providers – please check the privacy policy of any payment provider you use to 
+        <p>Mozilla does not currently process payments on its users behalf. When you make a purchase in the Marketplace, the information that you give to your selected
+          payment provider is governed by that provider’s privacy policy. A list of third-party vendors that are authorized payment processors for the Marketplace
+          are available here.[Link TBD]  Developers may also use their own payment providers – please check the privacy policy of any payment provider you use to
           make sure you are comfortable with their privacy practices.</p>
-        <p>A list of third party vendors that process information on Mozilla’s behalf related to the Mozilla Marketplace can be found here.[Link TBD]</p>
+        <p>A list of third party vendors that process information on Mozilla’s behalf related to the Firefox Marketplace can be found here.[Link TBD]</p>
       </section>
       <section>
         <h4>How we store and protect your info</h4>
-        <p>We work hard to protect your information. We take steps to make sure that anyone (like an authorized employee or contractor) who sees your personal 
+        <p>We work hard to protect your information. We take steps to make sure that anyone (like an authorized employee or contractor) who sees your personal
           information has a good reason and is only allowed to do Mozilla-approved things with it.</p>
-        <p>Despite our efforts, we can't guarantee that malicious agents can't break in and access your data. If we find out about a security breach, we'll try 
-          hard to let you know so that you can take appropriate protective steps. We only keep information as long as we need to do the thing we collected it for. 
+        <p>Despite our efforts, we can't guarantee that malicious agents can't break in and access your data. If we find out about a security breach, we'll try
+          hard to let you know so that you can take appropriate protective steps. We only keep information as long as we need to do the thing we collected it for.
           Once we don't need it any more, we'll destroy it unless we are forced by law to keep it longer.</p>
       </section>
       <section>
         <h4>International Privacy</h4>
-        <p>Privacy laws and expectations vary from country to country. We're a global company and our computers are in several different places around the world. 
-          We also use service providers whose computers may also be in various countries. This means that any information we have about you might end up on one 
+        <p>Privacy laws and expectations vary from country to country. We're a global company and our computers are in several different places around the world.
+          We also use service providers whose computers may also be in various countries. This means that any information we have about you might end up on one
           of those computers in another country, and that country may have a different level of data protection regulation than yours.</p>
       </section>
       <section>
@@ -129,18 +129,18 @@
           <li>the law requires us to or,</li>
           <li>it is reasonably necessary to do so to prevent harm to someone.</li>
         </ul>
-        <p>We follow the law whenever we receive requests about you and we'll notify you any time we are asked to hand over your personal info like this unless 
+        <p>We follow the law whenever we receive requests about you and we'll notify you any time we are asked to hand over your personal info like this unless
           we're legally prohibited from doing so, or circumstances require otherwise.</p>
       </section>
       <section>
         <h4>Children</h4>
-        <p>Unless specifically stated otherwise, our services are not directed to individuals under the age of 13. If you are under 13, please do not provide us 
-          with your personally identifiable information. If you are the parent and believe that your child who is under 13 has provided us with personally 
+        <p>Unless specifically stated otherwise, our services are not directed to individuals under the age of 13. If you are under 13, please do not provide us
+          with your personally identifiable information. If you are the parent and believe that your child who is under 13 has provided us with personally
           identifiable information, please contact us here.</p>
       </section>
       <section>
         <h4>Changes to this Policy and our Contact Information</h4>
-        <p>Sometimes, we change our privacy policies. When we do, we'll post a notice about the change on the Mozilla Marketplace.If you want to 
+        <p>Sometimes, we change our privacy policies. When we do, we'll post a notice about the change on the Firefox Marketplace. If you want to
           make a correction to your information, or you have any questions about our privacy policies, please get in touch with:</p>
         <p>Mozilla Corporation<br />Attn: Legal Notices -- Privacy<br />650 Castro Street, Suite 300<br />Mountain View, CA 94041-2072</p>
         <p>Phone: +1-650-903-0800</p>

--- a/apps/redirects/tests/test_util.py
+++ b/apps/redirects/tests/test_util.py
@@ -28,7 +28,7 @@ class TestUrlPatterns(unittest.TestCase):
     def test_external_redirect(self):
         response = self.client.get('/en-US/gloubi-boulga/ext/')
         eq_(response.status_code, 301)
-        eq_(response['Location'], 'https://marketplace.mozilla.org')
+        eq_(response['Location'], 'https://marketplace.firefox.com')
 
     def test_callable_redirect(self):
         response = self.client.get('/en-US/gloubi-boulga/call/')

--- a/apps/redirects/tests/urls.py
+++ b/apps/redirects/tests/urls.py
@@ -16,7 +16,7 @@ urlpatterns = patterns('',
     url(r'^mock/view/$', mock_view, name='mock_view'),
     redirect(r'^gloubi-boulga/$', 'mock_view'),
     redirect(r'^gloubi-boulga/tmp/$', 'mock_view', permanent=False),
-    redirect(r'^gloubi-boulga/ext/$', 'https://marketplace.mozilla.org'),
+    redirect(r'^gloubi-boulga/ext/$', 'https://marketplace.firefox.com'),
     redirect(r'^gloubi-boulga/call/$',
              lambda r: '/asdf' if r.GET.get('test', False) else '/qwer')
 )

--- a/apps/redirects/urls.py
+++ b/apps/redirects/urls.py
@@ -47,8 +47,8 @@ urlpatterns = patterns('',
     redirect(r'^foundation/identity-guidelines/mozilla-foundation.html', 'styleguide.identity.mozilla-branding'),
     redirect(r'^foundation/identity-guidelines/thunderbird.html', 'styleguide.identity.thunderbird-logo'),
 
-    # Bug 800467 /apps/partners -> marketplace.m.o/developers
-    redirect(r'apps/partners/$', 'https://marketplace.mozilla.org/developers/'),
+    # Bug 800467 /apps/partners -> marketplace.firefox.com/developers
+    redirect(r'apps/partners/$', 'https://marketplace.firefox.com/developers/'),
 
     # Bug 815527 /m/privacy.html -> /legal/privacy/firefox.html
     redirect(r'^m/privacy.html$', '/legal/privacy/firefox.html'),

--- a/apps/redirects/util.py
+++ b/apps/redirects/util.py
@@ -21,7 +21,7 @@ def redirect(pattern, to, permanent=True, anchor=None):
     Usage:
     urlpatterns = patterns('',
         redirect(r'^projects/$', 'mozorg.product'),
-        redirect(r'^apps/$', url='https://marketplace.mozilla.org'),
+        redirect(r'^apps/$', url='https://marketplace.firefox.com'),
     )
     """
     if permanent:


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=841932
