### PR TITLE
Fix button styles in Style Guide (Bug 842858)

### DIFF
--- a/media/css/sandstone/buttons.less
+++ b/media/css/sandstone/buttons.less
@@ -148,7 +148,6 @@
              -1px  0   0 0 rgba(255,255,255,0.5) inset,
               0   -2px 0 0 rgba(0,0,0,0.1)       inset;
     .box-shadow(@shadow);
-    .border-radius(8px);
     color: @linkBlue;
     text-shadow: none;
     &:hover,
@@ -178,8 +177,8 @@
         }
         &:first-child {
             .button-sand {
-                border-top-left-radius: 8px;
-                border-bottom-left-radius: 8px;
+                border-top-left-radius: 0.25em;
+                border-bottom-left-radius: 0.25em;
                 border-left-width: 1px;
                 @shadow:  0    1px 0 0 rgba(255,255,255,0.5) inset,
                           1px  0   0 0 rgba(255,255,255,0.5) inset,
@@ -194,8 +193,8 @@
         }
         &:last-child {
             .button-sand {
-                border-top-right-radius: 8px;
-                border-bottom-right-radius: 8px;
+                border-top-right-radius: 0.25em;
+                border-bottom-right-radius: 0.25em;
             }
         }
     }

--- a/media/css/styleguide/identity-firefox.less
+++ b/media/css/styleguide/identity-firefox.less
@@ -165,9 +165,6 @@
                 font-style: italic;
             }
         }
-        .button-sand, .button-sand:link, .button-sand:visited {
-            padding: 0 12px;
-        }
     }
 }
 
@@ -222,9 +219,6 @@
             p {
                 margin-bottom: 0;
             }
-        }
-        .button-sand, .button-sand:link, .button-sand:visited {
-            padding: 0 12px;
         }
     }
 }

--- a/media/css/styleguide/identity-firefoxos.less
+++ b/media/css/styleguide/identity-firefoxos.less
@@ -84,13 +84,9 @@
                 margin-bottom: 0;
             }
         }
-        .button-sand, .button-sand:link, .button-sand:visited {
-            padding: 0 12px;
-        }
     }
 }
 /* }}} */
-
 /* {{{ Firefox OS - Promo Materials  */
 .firefoxos-promo {
     #intro {
@@ -115,7 +111,6 @@
     }
 }
 /* }}} */
-
 /* {{{ Firefox OS - Colors  */
 .firefoxos-colors {
     #intro {

--- a/media/css/styleguide/identity-marketplace.less
+++ b/media/css/styleguide/identity-marketplace.less
@@ -104,9 +104,6 @@
                 margin-bottom: 0;
             }
         }
-        .button-sand, .button-sand:link, .button-sand:visited {
-            padding: 0 12px;
-        }
     }
     #wordmark-2 {
         .logo {

--- a/media/css/styleguide/identity-mozilla.less
+++ b/media/css/styleguide/identity-mozilla.less
@@ -47,9 +47,6 @@
                 margin-bottom: 0;
             }
         }
-        .button-sand, .button-sand:link, .button-sand:visited {
-            padding: 0 12px;
-        }
     }
     #common-mistakes {
         float: left;

--- a/media/css/styleguide/identity-persona.less
+++ b/media/css/styleguide/identity-persona.less
@@ -95,9 +95,6 @@
                 margin-bottom: 0;
             }
         }
-        .button-sand, .button-sand:link, .button-sand:visited {
-            padding: 0 12px;
-        }
     }
     #wordmark-2 {
         .logo {

--- a/media/css/styleguide/identity-thunderbird.less
+++ b/media/css/styleguide/identity-thunderbird.less
@@ -102,9 +102,6 @@
                 font-style: italic;
             }
         }
-        .button-sand, .button-sand:link, .button-sand:visited {
-            padding: 0 12px;
-        }
     }
 }
 
@@ -159,9 +156,6 @@
             p {
                 margin-bottom: 0;
             }
-        }
-        .button-sand, .button-sand:link, .button-sand:visited {
-            padding: 0 12px;
         }
     }
 }

--- a/media/css/styleguide/identity-webmaker.less
+++ b/media/css/styleguide/identity-webmaker.less
@@ -85,9 +85,6 @@
                 margin-bottom: 0;
             }
         }
-        .button-sand, .button-sand:link, .button-sand:visited {
-            padding: 0 12px;
-        }
     }
 }
 

--- a/media/css/styleguide/styleguide.less
+++ b/media/css/styleguide/styleguide.less
@@ -100,6 +100,15 @@ a[href="#TODO"] { color: #f00 !important; }
 }
 
 /* }}} */
+/* {{{ Buttons */
+
+.button-sand,
+.button-sand:link,
+.button-sand:visited {
+    font-weight: normal;
+}
+
+/* }}} */
 /* {{{ Sidebar */
 
 #sidebar {

--- a/media/css/styleguide/websites-sandstone.less
+++ b/media/css/styleguide/websites-sandstone.less
@@ -32,10 +32,6 @@
         }
         #grid-downloads {
             .span_guide(3);
-            .button-list .button-sand {
-                padding-left: 12px;
-                padding-right: 12px;
-            }
         }
     }
     #grid-phone,
@@ -72,10 +68,6 @@
         }
         #tabzilla-downloads {
             .span_guide(3);
-            .button-sand {
-                padding-left: 12px;
-                padding-right: 12px;
-            }
         }
     }
     #examples {
@@ -222,7 +214,7 @@
             }
         }
         #examples-standard {
-            .offset_guide(3);            
+            .offset_guide(3);
         }
     }
 
@@ -233,13 +225,6 @@
         .span_guide(9);
         .example {
             margin-bottom: @baseLine;
-        }
-    }
-    #buttons,
-    #icons {
-        .button-sand {
-            padding-left: 12px;
-            padding-right: 12px;
         }
     }
 }
@@ -281,7 +266,7 @@
             }
         }
         #examples-standard {
-            .offset_guide(3);            
+            .offset_guide(3);
         }
     }
 
@@ -292,13 +277,6 @@
         .span_guide(9);
         .example {
             margin-bottom: @baseLine;
-        }
-    }
-    #buttons,
-    #icons {
-        .button-sand {
-            padding-left: 12px;
-            padding-right: 12px;
         }
     }
 }


### PR DESCRIPTION
Update the button styles in the style guide to work with the new global button styles. This mostly involves undoing local custom padding and border-radius that isn't necessary with the new button styles.

These buttons don't look exactly like the Photoshop mockups of the Style Guide, but they are a better match with the new site-wide buttons.
