### PR TITLE
Fix duplicate id on screenshot. Bug 849923.

### DIFF
--- a/apps/firefox/templates/firefox/new.html
+++ b/apps/firefox/templates/firefox/new.html
@@ -45,8 +45,8 @@
           </div>
         </div>
 
-        <div class="desktop">
-          {{ platform_img('img/firefox/new/browser.png', alt='Firefox screenshot', id='firefox-screenshot') }}
+        <div class="desktop" id="firefox-screenshot">
+          {{ platform_img('img/firefox/new/browser.png', alt='Firefox screenshot') }}
         </div>
       </div> <!-- /#scene1 -->
 

--- a/media/css/firefox/new.less
+++ b/media/css/firefox/new.less
@@ -249,7 +249,7 @@
     visibility: hidden;
 }
 
-#firefox-screenshot {
+#firefox-screenshot .platform-img {
     position: absolute;
     bottom: 0px;
 }


### PR DESCRIPTION
Platform image generator directly copies supplied
attributes, causing duplicate id's on page. Removed
id from screenshot/platform image. Targeting
containing div instead for styling purposes.
