### PR TITLE
Bug  795546, add cn-community@mozilla.com as the contact email address f...

### DIFF
--- a/apps/mozorg/email_contribute.py
+++ b/apps/mozorg/email_contribute.py
@@ -95,6 +95,7 @@ LOCALE_CONTACTS = {
     'hr'   : ['contribute@mozilla-hr.org'],
     'nl'   : ['contribute@mozilla-nl.org'],
     'pt-BR': ['mlcaraldi@gmail.com'],
+    'zh-CN': ['cn-community@mozilla.com'],
     'zh-TW': ['contribute@mail.moztw.org'],
 }
 


### PR DESCRIPTION
...or zh-CN contribute page
