### PR TITLE
Make focus detection in pager more general using focusin/focusout on the...

### DIFF
--- a/media/js/mozilla-pager.js
+++ b/media/js/mozilla-pager.js
@@ -722,7 +722,9 @@ Mozilla.Pager.prototype.startAutoRotate = function()
             Mozilla.Pager.AUTO_ROTATE_INTERVAL, pager)
     }
 
-    setupInterval(this);
+    if (!this.autoRotateInterval) {
+        setupInterval(this);
+    }
 };
 
 // }}}


### PR DESCRIPTION
... container instead of on specific elements within the container. See Bugzilla #833327. https://bugzilla.mozilla.org/show_bug.cgi?id=833327
