### PR TITLE
Bug 854561 redirect mozilla.org/ports to https://developer.mozilla.org/docs/Tinderbox

### DIFF
--- a/apps/redirects/urls.py
+++ b/apps/redirects/urls.py
@@ -69,4 +69,7 @@ urlpatterns = patterns('',
 
     # Bug 822817 /telemetry/ -> http://wiki.mozilla.org/Telemetry/FAQ
     redirect(r'telemetry/$', 'http://wiki.mozilla.org/Telemetry/FAQ'),
+
+    #Bug 837942 /ports/ --> https://developer.mozilla.org/en-US/docs/Tinderbox
+    redirect(r'ports/$', 'https://developer.mozilla.org/docs/Tinderbox'),
 )


### PR DESCRIPTION
Bug 854561 redirect https://developer.mozilla.org/docs/Tinderbox
