### PR TITLE
Bug 852225 - override italics for zh-CN and zh-TW

### DIFF
--- a/media/css/mozilla15.less
+++ b/media/css/mozilla15.less
@@ -24,7 +24,7 @@
 .lang-zh-TW,
 .lang-zh-CN {
   #moz15 .cta p,
-  .message {
+  #moz15 .message {
     font-style: normal;
   }
 }


### PR DESCRIPTION
Needed a specificity boost. Just a one line CSS fix but we should push it to prod as soon as possible.
