### PR TITLE
l10n: add an email address (temporary) for German contribute page so as ...

### DIFF
--- a/apps/mozorg/email_contribute.py
+++ b/apps/mozorg/email_contribute.py
@@ -89,6 +89,7 @@ FUNCTIONAL_AREAS_DICT = dict((area.id, area) for area in FUNCTIONAL_AREAS)
 
 LOCALE_CONTACTS = {
     'bn-BD': ['mahayalamkhan@gmail.com'],
+    'de'   : ['getinvolved@camp-firefox.de'],
     'fr'   : ['contact@mozfr.org'],
     'el'   : ['core@mozilla-greece.org'],
     'es-ES': ['participa@mozilla-hispano.org'],


### PR DESCRIPTION
...to allow them to participate in 15 years anniversary campaign. This address is a temporary one that we will use while they have a proper mailing list set up in Bug 856876
