### PR TITLE
Bug 835506: Fix error 500 in Download Tab

### DIFF
--- a/apps/facebookapps/utils.py
+++ b/apps/facebookapps/utils.py
@@ -51,7 +51,7 @@ def unwrap_signed_request(request):
 
 
 def app_data_query_string_encode(app_data):
-    return urllib.urlencode([('app_data[{}]'.format(key), value) for key, value in app_data.items()])
+    return urllib.urlencode([('app_data[{key}]'.format(key=key), value) for key, value in app_data.items()])
 
 
 def get_best_locale(request, locale):


### PR DESCRIPTION
In Python 2.6, curly brace placeholders used in the str.format() must have an identifier. See http://stackoverflow.com/questions/10054122/valueerror-zero-length-field-name-in-format-python.
