### PR TITLE
Add rewrite rules for new newsletter pages

### DIFF
--- a/etc/httpd/global.conf
+++ b/etc/httpd/global.conf
@@ -176,3 +176,7 @@ RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?projects/firefox(/(?:\d+\.\d+\.?(?:
 
 # bug 845983
 RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?metrofirefox(/.*)? /$1firefox$2 [L,R=301]
+
+# Bug 845904 - /newsletter/existing and /newsletter/updated served from bedrock
+RewriteRule  ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?newsletter/existing(.*)$ /b/$1newsletter/existing$2 [PT]
+RewriteRule  ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?newsletter/updated(.*)$ /b/$1newsletter/updated$2 [PT]


### PR DESCRIPTION
Add Apache rewrite rules for pages ported to Bedrock:
- /newsletter/existing/*
- /newsletter/updated

Bug 845904
