### PR TITLE
Bug 857246 redirect /products/firefox/start/ to start.mozilla.org

### DIFF
--- a/etc/httpd/global.conf
+++ b/etc/httpd/global.conf
@@ -17,6 +17,10 @@ RewriteRule ^/zh-TW/products(/.*)?$ http://mozilla.com.tw/products$1 [L,R=301]
 # bug 755826
 RewriteRule ^/zh-CN/$ http://firefox.com.cn/ [L,R=301]
 
+#bug 857246 redirect /products/firefox/start/  to start.mozilla.org
+RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?products/firefox/start(/?)$ http://start.mozilla.org [L,R=301]
+
+
 
 ## Redirect things to django!
 


### PR DESCRIPTION
@pmac  I've updated etc/httpd/global.conf
