### PR TITLE
Bug 795033: sq contribute page

### DIFF
--- a/apps/mozorg/email_contribute.py
+++ b/apps/mozorg/email_contribute.py
@@ -97,6 +97,7 @@ LOCALE_CONTACTS = {
     'id'   : ['info@mozilla.web.id'],
     'nl'   : ['contribute@mozilla-nl.org'],
     'pt-BR': ['mlcaraldi@gmail.com'],
+    'sq'   : ['besnik@programeshqip.org'],
     'zh-CN': ['contributor-zh-cn@mozilla.org'],
     'zh-TW': ['contribute@mail.moztw.org'],
 }

--- a/settings/base.py
+++ b/settings/base.py
@@ -618,7 +618,7 @@ LOCALES_WITH_TRANSITION = ['en-US', 'af', 'ar', 'ast', 'be', 'bg',
 
 # Locales showing the 15th Anniversary slideshow on /contribute
 LOCALES_WITH_MOZ15 = ['en-US', 'en-GB', 'de', 'es-ES', 'fr',
-                      'id', 'nl', 'pt-BR', 'zh-TW', 'zh-CN',]
+                      'id', 'nl', 'pt-BR', 'sq', 'zh-TW', 'zh-CN',]
 
 # reCAPTCHA keys
 RECAPTCHA_PUBLIC_KEY = ''


### PR DESCRIPTION
Add Besnik email as contact point for sq contribute page, activate locale as participating in the 15 years of Mozilla campaign.
