### PR TITLE
Believe that Firefox OS Icons style guide actually specifies diameter, rather than radius.

### DIFF
--- a/apps/styleguide/templates/styleguide/products/firefox-os-icons.html
+++ b/apps/styleguide/templates/styleguide/products/firefox-os-icons.html
@@ -14,11 +14,11 @@
 
   <div id="shape">
 
-    <p>A Firefox OS application icon is a <strong>60x60 pixel</strong> image provided in 24-bit <strong>PNG</strong> format. Each of the standard OS application icons is contained within or underlayed with a <strong>58 pixel</strong> radius circle shape.</p>
+    <p>A Firefox OS application icon is a <strong>60x60 pixel</strong> image provided in 24-bit <strong>PNG</strong> format. Each of the standard OS application icons is contained within or underlayed with a <strong>58 pixel</strong> diameter circle shape.</p>
 
     <figure class="first">
       <img src="{{ media('/img/styleguide/products/firefoxos/icon-template.png') }}" alt="Icon template" />
-      <figcaption>60x60 pixel canvas<br />58 pixel radius circle</figcaption>
+      <figcaption>60x60 pixel canvas<br />58 pixel diameter circle</figcaption>
     </figure>
 
     <figure>
@@ -75,7 +75,7 @@
     <h3>Do</h3>
     <figure>
       <img src="{{ media('/img/styleguide/products/firefoxos/icon-do-circle.png') }}" alt="Circle example" />
-      <figcaption>If you use a circle, it should have a radius of 58 pixels</figcaption>
+      <figcaption>If you use a circle, it should have a diameter of 58 pixels</figcaption>
     </figure>
     <figure>
       <img src="{{ media('/img/styleguide/products/firefoxos/icon-do-rounded-square.png') }}" alt="Rounded square example" />
@@ -117,7 +117,7 @@ as in the following examples.</p>
     </figure>
     <figure>
       <img src="{{ media('/img/styleguide/products/firefoxos/icon-shape-cropped.png') }}" alt="Cropped" />
-      <figcaption>Cropped with 58 pixel radius circle</figcaption>
+      <figcaption>Cropped with 58 pixel diameter circle</figcaption>
     </figure>
     <figure>
       <img src="{{ media('/img/styleguide/products/firefoxos/icon-shape-overlay.png') }}" alt="Overlay" />


### PR DESCRIPTION
Hi! Just a very small content tweak, my OCD/pedantry could not let me leave this alone. I believe that 58 pixel 'radius' should actually be 'diameter' in reference to the Firefox OS app icon size in the style guide. This is my first ever contribution...
