### PR TITLE
Bug 858657 Powered by header broken in IE8 ,IE7 and IE6

### DIFF
--- a/media/css/powered-by.less
+++ b/media/css/powered-by.less
@@ -37,8 +37,8 @@
     letter-spacing: -2px;
     color: #fff;
     text-shadow: none;
-    background-color: #b30406;
-    background-color: rgba(179,4,6,.95);
+    background: #b30406;
+    background: rgba(179,4,6,.95);
     margin: -60px 10px 40px;
     position: relative;
     float: left;


### PR DESCRIPTION
I removed  background-color: rgba(179,4,6,.95);  because  IE8, IE7 and IE6 did not show  the correct background-color with rgba values.  I tested this in Firefox, Chrome, Safari and older versions of IE.
