### PR TITLE
Bug 857271 newsletter languages

### DIFF
--- a/apps/newsletter/forms.py
+++ b/apps/newsletter/forms.py
@@ -123,20 +123,9 @@ class ManageSubscriptionsForm(forms.Form):
 
     def clean(self):
         valid_newsletters = utils.get_newsletters()
-        lang = self.cleaned_data['lang']
         for newsletter in self.newsletters:
             if newsletter not in valid_newsletters:
                 msg = _("%s is not a valid newsletter") % newsletter
-                raise ValidationError(msg)
-            # Letters they're adding a new subscription to must exist
-            # in the language they've selected. But if they're already
-            # subscribed, that's okay.
-            if newsletter not in self.already_subscribed and \
-                    lang not in valid_newsletters[newsletter]['languages']:
-                template = _(
-                    "%s is not a valid newsletter in this language (%s)",
-                )
-                msg = template % (newsletter_title(newsletter), lang)
                 raise ValidationError(msg)
         return super(ManageSubscriptionsForm, self).clean()
 
@@ -150,6 +139,8 @@ class NewsletterForm(forms.Form):
         required=False,  # they have to answer, but answer can be False
     )
     newsletter = forms.CharField(widget=forms.HiddenInput)
+    # another hidden one, just so the template can get the data
+    english_only = forms.BooleanField(required=False)
 
 
 class NewsletterFooterForm(forms.Form):

--- a/apps/newsletter/templates/newsletter/existing.html
+++ b/apps/newsletter/templates/newsletter/existing.html
@@ -90,7 +90,7 @@ uncomment the next block or add it to the inheriting template:
             <thead>
             <tr>
               <td>{{ _('Our monthly newsletters') }}</td>
-              <th>{{ _(Subscribe') }}</th>
+              <th>{{ _('Subscribe') }}</th>
               <th>{{ _('Unsubscribe') }}</th>
             </tr>
             </thead>
@@ -101,7 +101,12 @@ uncomment the next block or add it to the inheriting template:
                   <h4 class="title">{{ formpart.initial['title'] }}</h4>
                   {# hidden field: #}
                   {{ formpart.newsletter }}
-                  <p class="description">{{ formpart.initial['description'] }}</p>
+                  <p class="description">
+                    {{ formpart.initial['description'] }}
+                    {% if formpart.initial['english_only'] %}
+                      ({{ _('English only') }})
+                    {% endif %}
+                  </p>
                 </th>
                 {{ formpart.subscribed }}
               </tr>

--- a/apps/newsletter/tests/test_forms.py
+++ b/apps/newsletter/tests/test_forms.py
@@ -65,30 +65,6 @@ class TestManageSubscriptionsForm(TestCase):
         self.assertEqual('pt', form.fields['lang'].initial)
         self.assertEqual('br', form.fields['country'].initial)
 
-    @mock.patch('newsletter.utils.get_newsletters')
-    def test_new_newsletters_in_language(self, get_newsletters):
-        # you cannot subscribe to newsletters that aren't available
-        # in the language that you've chosen
-        get_newsletters.return_value = newsletters
-        locale = "en-US"
-        user = {'email': 'user@example.com', 'format': 'H', 'newsletters': []}
-        form = ManageSubscriptionsForm(locale=locale, data=user)
-        form.newsletters = ['no-such-english-newsletter']
-        self.assertFalse(form.is_valid())
-
-    @mock.patch('newsletter.utils.get_newsletters')
-    def test_old_newsletters_any_language(self, get_newsletters):
-        # newsletters you were already subscribed to don't need to be
-        # validated against the language you submitted this time
-        get_newsletters.return_value = newsletters
-        locale = "fr"
-        user = {'email': 'user@example.com', 'format': 'H',
-                'newsletters': ['beta'],
-                'lang': 'fr'}
-        form = ManageSubscriptionsForm(locale=locale, initial=user, data=user)
-        form.newsletters = ['beta']
-        self.assertTrue(form.is_valid(), msg=form.errors)
-
 
 class TestNewsletterForm(TestCase):
     @mock.patch('newsletter.utils.get_newsletters')
@@ -102,6 +78,7 @@ class TestNewsletterForm(TestCase):
             'title': title,
             'newsletter': newsletter,
             'subscribed': True,
+            'english_only': False,
         }
         form = NewsletterForm(initial=initial)
         rendered = str(form)

--- a/apps/newsletter/views.py
+++ b/apps/newsletter/views.py
@@ -101,11 +101,13 @@ def existing(request, token=None):
         # Only show a newsletter if it has ['show'] == True or the
         # user is already subscribed
         if data.get('show', False) or newsletter in user['newsletters']:
+            langs = data['languages']
             initial.append({
                 'title': data['title'],
                 'subscribed': newsletter in user['newsletters'],
                 'newsletter': newsletter,
                 'description': data['description'],
+                'english_only': len(langs) == 1 and langs[0].startswith('en')
             })
 
     NewsletterFormSet = formset_factory(NewsletterForm, extra=0,


### PR DESCRIPTION
Always show any newsletters we're subscribed to, and any with the "always show" flag, regardless of language. Allow subscribing to any newsletter, regardless of language.

@pmclanahan r?
