### PR TITLE
Bug 857199: Add ability to force a button to point to stub.

### DIFF
--- a/apps/firefox/templates/firefox/channel.html
+++ b/apps/firefox/templates/firefox/channel.html
@@ -30,7 +30,7 @@
       <h2 class="channel-title channel-title-beta"><img src="{{ media('/img/firefox/channel/title-beta.png') }}" alt="Firefox Beta" /></h2>
       <h3>The latest features in a more stable environment</h3>
       <div class="download-box" id="beta-desktop">
-        {{ download_firefox('beta', icon=False, small=True) }}
+        {{ download_firefox('beta', icon=False, small=True, force_stub_installer=True) }}
       </div>
       <div class="download-box mobile" id="beta-mobile">
         {{ download_firefox('beta', icon=False, mobile=True, small=True) }}

--- a/apps/mozorg/tests/test_helper_download_buttons.py
+++ b/apps/mozorg/tests/test_helper_download_buttons.py
@@ -209,3 +209,24 @@ class TestDownloadButtons(unittest.TestCase):
         url = make_download_link('firefox', 'beta', '20.0b4', 'os_windows',
                                  'fr', force_funnelcake=True)
         ok_('product=firefox-beta-latest&' not in url)
+
+    def test_force_stub_installer(self):
+        url = make_download_link('firefox', 'release', 19.0, 'os_windows',
+                                 'en-US', force_stub_installer=True)
+        ok_('product=firefox-stub&' in url)
+
+        url = make_download_link('firefox', 'beta', '20.0b4', 'os_windows',
+                                 'en-US', force_stub_installer=True)
+        ok_('product=firefox-beta-stub&' in url)
+
+    def test_force_stub_installer_en_us_win_only(self):
+        """
+        Ensure that force_funnelcake doesn't affect non en-US Windows urls
+        """
+        url = make_download_link('firefox', 'release', 19.0, 'os_osx',
+                                 'en-US', force_stub_installer=True)
+        ok_('product=firefox-stub&' not in url)
+
+        url = make_download_link('firefox', 'beta', '20.0b4', 'os_windows',
+                                 'fr', force_stub_installer=True)
+        ok_('product=firefox-beta-stub&' not in url)


### PR DESCRIPTION
Adds force_stub_installer keyword arg to button helper that will change the
download product to use the firefox-*-stub product for en-US Windows download
buttons.
