### PR TITLE
Bug 845904: initial locale when user has none

### DIFF
--- a/apps/newsletter/forms.py
+++ b/apps/newsletter/forms.py
@@ -95,6 +95,11 @@ class ManageSubscriptionsForm(forms.Form):
     remove_all = forms.BooleanField(required=False)
     LANG_CHOICES = get_lang_choices()
 
+    country = forms.ChoiceField(choices=[],  # will set choices based on locale
+                                required=False)
+    lang = forms.ChoiceField(choices=LANG_CHOICES,
+                             required=False)
+
     def __init__(self, locale, *args, **kwargs):
         regions = product_details.get_regions(locale)
         regions = sorted(regions.iteritems(), key=lambda x: x[1])
@@ -105,20 +110,16 @@ class ManageSubscriptionsForm(forms.Form):
         lang = lang if lang in LANGS else 'en'
 
         self.newsletters = kwargs.pop('newsletters', [])
-        self.must_subscribe = kwargs.pop('must_subscribe', False)
-
-        super(ManageSubscriptionsForm, self).__init__(*args, **kwargs)
 
         initial = kwargs.get('initial', {})
-        initial_country = initial['country'] \
-            if 'country' in initial else country
-        initial_lang = initial['lang'] if 'lang' in initial else lang
-        self.fields['country'] = forms.ChoiceField(choices=regions,
-                                                   initial=initial_country,
-                                                   required=False)
-        self.fields['lang'] = forms.ChoiceField(choices=self.LANG_CHOICES,
-                                                initial=initial_lang,
-                                                required=False)
+        if not initial.get('country', None):
+            initial['country'] = country
+        if not initial.get('lang', None):
+            initial['lang'] = lang
+        kwargs['initial'] = initial
+
+        super(ManageSubscriptionsForm, self).__init__(*args, **kwargs)
+        self.fields['country'].choices = regions
         self.already_subscribed = initial.get('newsletters', [])
 
     def clean(self):

--- a/apps/newsletter/tests/test_forms.py
+++ b/apps/newsletter/tests/test_forms.py
@@ -55,15 +55,15 @@ class TestManageSubscriptionsForm(TestCase):
         # First, not passed in
         locale = "en-US"
         form = ManageSubscriptionsForm(locale=locale, initial={})
-        self.assertEqual('en', form.fields['lang'].initial)
-        self.assertEqual('us', form.fields['country'].initial)
+        self.assertEqual('en', form.initial['lang'])
+        self.assertEqual('us', form.initial['country'])
         form = ManageSubscriptionsForm(locale=locale,
                                        initial={
                                            'lang': 'pt',
                                            'country': 'br',
                                        })
-        self.assertEqual('pt', form.fields['lang'].initial)
-        self.assertEqual('br', form.fields['country'].initial)
+        self.assertEqual('pt', form.initial['lang'])
+        self.assertEqual('br', form.initial['country'])
 
 
 class TestNewsletterForm(TestCase):

--- a/apps/newsletter/tests/test_views.py
+++ b/apps/newsletter/tests/test_views.py
@@ -119,7 +119,7 @@ class TestExistingNewsletterView(TestCase):
         request, template_name, context = render.call_args[0]
         form = context['form']
         self.assertNotIn('privacy', form.fields)
-        self.assertEqual(self.user['lang'], form.fields['lang'].initial)
+        self.assertEqual(self.user['lang'], form.initial['lang'])
 
     @patch('newsletter.utils.get_newsletters')
     def test_show(self, get_newsletters, mock_basket_request):


### PR DESCRIPTION
When the user goes to the /newsletter/existing page but has no
language or country set in ExactTarget, then initialize them on
the form based on the locale from the request URL.
