### PR TITLE
Bug 860991 - Firefox persona preview broke

### DIFF
--- a/media/js/firefox/customize.js
+++ b/media/js/firefox/customize.js
@@ -114,7 +114,7 @@ Mozilla.PersonaPreviewer = function(container)
 }
 
 Mozilla.PersonaPreviewer.LIVE_URL =
-	'http://www.getpersonas.com/en-US/external/mozilla/';
+	'http://static.getpersonas.com/en-US/external/mozilla/';
 
 Mozilla.PersonaPreviewer.prototype.getPseudoRandomPersona = function()
 {


### PR DESCRIPTION
Change from www.getpersonas.com to static.getpersonas.com until we have solution given that this page is broke right now.
