### PR TITLE
Bug 861231 - Video control-overlay link is missing a descriptive text on...

### DIFF
--- a/apps/firefox/templates/firefox/central.html
+++ b/apps/firefox/templates/firefox/central.html
@@ -95,7 +95,7 @@
       <p>Ready to begin? Good! Getting started with Firefox is actually quite simple. Here are a few handy shortcuts to help you get going:</p>
     <figure class="figure">
         <div class="mozilla-video-control">
-        <video width="436" height="245" controls="controls" poster="{{ media('img/firefox/central/poster-browsing-basics.png') }}">
+        <video width="436" height="245" controls="controls" poster="{{ media('img/firefox/central/poster-browsing-basics.png') }}" data-overlay-hidden-text="{{_('Play video')}}">
             <source src="http://videos-cdn.mozilla.net/serv/marketing/firefox4/Browsing-Basics-640.mp4" type='video/mp4; codecs="avc1.42E01E, mp4a.40.2"' />
             <source src="http://videos-cdn.mozilla.net/serv/marketing/firefox4/Browsing-Basics-640.webm" type='video/webm; codecs="vp8, vorbis"' />
             <source src="http://videos-cdn.mozilla.net/serv/marketing/firefox4/Browsing-Basics-640.theora.ogv" type='video/ogg; codecs="theora, vorbis"' />
@@ -145,7 +145,7 @@
       <p>When it comes to browsing, one size definitely doesn’t fit all. That’s why we’ve made sure you can customize Firefox to your exact needs in pretty much any possible way. Enhance functionality with extensions, add style with Themes or even change the toolbar icons to be just the way you like.</p>
       <figure class="figure">
         <div class="mozilla-video-control">
-        <video width="436" height="245" controls="controls" poster="{{ media('img/firefox/video/poster-addons.jpg') }}">
+        <video width="436" height="245" controls="controls" poster="{{ media('img/firefox/video/poster-addons.jpg') }}" data-overlay-hidden-text="{{_('Play video')}}">
                 <source src="http://videos-cdn.mozilla.net/serv/marketing/696470/FF%20576%20h264%20v6.mp4" type='video/mp4; codecs="avc1.42E01E, mp4a.40.2"' />
                 <source src="http://videos-cdn.mozilla.net/serv/marketing/696470/FF%20576%20h264%20v6.webm" type='video/webm; codecs="vp8, vorbis"' />
                 <source src="http://videos-cdn.mozilla.net/serv/marketing/696470/FF%20576%20h264%20v6.theora.ogv" type='video/ogg; codecs="theora, vorbis"' />
@@ -171,7 +171,7 @@
       <p>We’ve packed Firefox with highly advanced security features to keep you safe while you browse. And, as a non-profit organization, protecting your privacy by keeping you in control over your personal information is a key part of our mission.</p>
       <figure class="figure">
         <div class="mozilla-video-control">
-        <video width="436" height="245" controls="controls" poster="{{ media('img/firefox/central/poster-privatebrowsing.png') }}">
+        <video width="436" height="245" controls="controls" poster="{{ media('img/firefox/central/poster-privatebrowsing.png') }}" data-overlay-hidden-text="{{_('Play video')}}">
             <source src="http://videos-cdn.mozilla.net/serv/marketing/firefox4/privatebrowsing640.mp4" type='video/mp4; codecs="avc1.42E01E, mp4a.40.2"' />
             <source src="http://videos-cdn.mozilla.net/serv/marketing/firefox4/privatebrowsing640.webm" type='video/webm; codecs="vp8, vorbis"' />
             <source src="http://videos-cdn.mozilla.net/serv/marketing/firefox4/privatebrowsing640.theora.ogv" type='video/ogg; codecs="theora, vorbis"' />

--- a/apps/firefox/templates/firefox/customize.html
+++ b/apps/firefox/templates/firefox/customize.html
@@ -92,7 +92,8 @@
         width="620"
         height="349"
         poster="{{ media('img/firefox/video/poster-addons.jpg') }}"
-        controls="controls">
+        controls="controls"
+        data-overlay-hidden-text="{{_('Play video')}}">
 
         <source src="http://videos-cdn.mozilla.net/serv/marketing/696470/FF%20576%20h264%20v6.webm" type="video/webm" />
         <source src="http://videos-cdn.mozilla.net/serv/marketing/696470/FF%20576%20h264%20v6.theora.ogv" type="video/ogg; codecs=&quot;theora, vorbis&quot;" />
@@ -154,7 +155,8 @@
         width="620"
         height="349"
         poster="{{ media('img/firefox/video/poster-fx4-sync.jpg') }}"
-        controls="controls">
+        controls="controls"
+        data-overlay-hidden-text="{{_('Play video')}}">
 
         <source src="http://videos-cdn.mozilla.net/serv/marketing/firefox4/FoxySync640.webm" type="video/webm" />
         <source src="http://videos-cdn.mozilla.net/serv/marketing/firefox4/FoxySync640.theora.ogv" type="video/ogg; codecs=&quot;theora, vorbis&quot;" />

--- a/apps/firefox/templates/firefox/features.html
+++ b/apps/firefox/templates/firefox/features.html
@@ -317,7 +317,8 @@
             width="640"
             height="360"
             poster="{{ media('img/firefox/video/poster-runfield.jpg') }}"
-            controls="controls">
+            controls="controls"
+            data-overlay-hidden-text="{{_('Play video')}}">
 
             <source src="http://videos-cdn.mozilla.net/serv/mozhacks/demos/screencasts/runfield/screencast.webm" type="video/webm" />
             <source src="http://videos-cdn.mozilla.net/serv/mozhacks/demos/screencasts/runfield/screencast.theora.ogv" type="video/ogg; codecs=&quot;theora, vorbis&quot;" />
@@ -381,7 +382,8 @@
                         width="290"
                         height="163"
                         controls="controls"
-                        poster="{{ media('img/firefox/video/poster-3d.jpg') }}">
+                        poster="{{ media('img/firefox/video/poster-3d.jpg') }}"
+                        data-overlay-hidden-text="{{_('Play video')}}">
 
                         <source src="http://videos-cdn.mozilla.net/serv/mozhacks/demos/screencasts/remixingreality/screencast.ogv" type="video/ogg; codecs=&quot;theora, vorbis&quot;" />
                         <source src="http://videos-cdn.mozilla.net/serv/mozhacks/demos/screencasts/remixingreality/screencast.mp4" type="video/mp4" />
@@ -608,7 +610,8 @@
                         width="290"
                         height="163"
                         controls="controls"
-                        poster="{{ media('img/firefox/video/poster-brand.jpg') }}">
+                        poster="{{ media('img/firefox/video/poster-brand.jpg') }}"
+                        data-overlay-hidden-text="{{_('Play video')}}">
 
                         <source src="http://videos-cdn.mozilla.net/brand/Mozilla_Firefox_Manifesto_v0.2_640.webm" type="video/webm" />
                         <source src="http://videos-cdn.mozilla.net/brand/Mozilla_Firefox_Manifesto_v0.2_640.theora.ogv" type="video/ogg; codecs=&quot;theora, vorbis&quot;" />

--- a/apps/firefox/templates/firefox/firstrun.html
+++ b/apps/firefox/templates/firefox/firstrun.html
@@ -30,7 +30,8 @@
       controls="controls"
       poster="{{ media('/img/firefox/firstrun/video-poster.jpg') }}"
       height="360"
-      width="640">
+      width="640"
+      data-overlay-hidden-text="{{_('Play video')}}">
       <source src="http://videos-cdn.mozilla.net/brand/Mozilla_Firefox_Manifesto_v0.2_640.webm">
     </video>
   </div>

--- a/apps/firefox/templates/firefox/fx.html
+++ b/apps/firefox/templates/firefox/fx.html
@@ -74,7 +74,8 @@
             controls="controls"
             poster="{{ media('/img/firefox/video/poster-newtab.jpg') }}"
             height="360"
-            width="640">
+            width="640"
+            data-overlay-hidden-text="{{_('Play video')}}">
             <source src="http://videos.mozilla.org/serv/marketing/Firefox/Firefox%20Tabs_1.webm">
           </video>
         </div>

--- a/apps/firefox/templates/firefox/mobile/sms-thankyou.html
+++ b/apps/firefox/templates/firefox/mobile/sms-thankyou.html
@@ -22,7 +22,8 @@
         controls="controls"
         poster="{{ media('/img/firefox/mobile/poster-fxandroid.jpg') }}"
         height="304"
-        width="540">
+        width="540"
+        data-overlay-hidden-text="{{_('Play video')}}">
         <source src="http://videos-cdn.mozilla.net/serv/marketing/fxforandroid/10-07-12_firefox_for_android_american-640x360 Video Sharing.webm">
       </video>
     </div>

--- a/apps/firefox/templates/firefox/performance.html
+++ b/apps/firefox/templates/firefox/performance.html
@@ -44,7 +44,8 @@
         width="640"
         height="360"
         poster="{{ media('img/firefox/video/poster-runfield.jpg') }}"
-        controls="controls">
+        controls="controls"
+        data-overlay-hidden-text="{{_('Play video')}}">
 
         <source src="http://videos-cdn.mozilla.net/serv/mozhacks/demos/screencasts/runfield/screencast.webm" type="video/webm" />
         <source src="http://videos-cdn.mozilla.net/serv/mozhacks/demos/screencasts/runfield/screencast.ogv" type="video/ogg; codecs=&quot;theora, vorbis&quot;" />

--- a/apps/firefox/templates/firefox/whatsnew.html
+++ b/apps/firefox/templates/firefox/whatsnew.html
@@ -90,7 +90,8 @@
       controls="controls"
       poster="{{ media('/img/firefox/whatsnew/video-poster.jpg') }}"
       height="360"
-      width="640">
+      width="640"
+      data-overlay-hidden-text="{{_('Play video')}}">
       <source src="http://videos-cdn.mozilla.net/serv/marketing/fxforandroid/10-07-12_firefox_for_android_{{ locales_with_video[request.locale] }}-640x360 Video Sharing.webm">
     </video>
   </div>

--- a/apps/mozorg/templates/mozorg/contribute.html
+++ b/apps/mozorg/templates/mozorg/contribute.html
@@ -306,7 +306,8 @@
       width="640"
       height="360"
       poster="{{ MEDIA_URL }}img/contribute/poster-brand.jpg"
-      controls="controls">
+      controls="controls"
+      data-overlay-hidden-text="{{_('Play video')}}">
       <source src="//videos-cdn.mozilla.net/brand/Mozilla_Firefox_Manifesto_v0.2_640.webm" type="video/webm" />
       <source src="//videos-cdn.mozilla.net/brand/Mozilla_Firefox_Manifesto_v0.2_640.theora.ogv" type="video/ogg; codecs=&quot;theora, vorbis&quot;" />
       <source src="//videos-cdn.mozilla.net/brand/Mozilla_Firefox_Manifesto_v0.2_640.mp4" type="video/mp4" />

--- a/apps/mozorg/templates/mozorg/mission.html
+++ b/apps/mozorg/templates/mozorg/mission.html
@@ -37,7 +37,8 @@
         width="460"
         height="259"
         poster="{{ media('img/mission/poster-mission.jpg') }}"
-        controls="controls">
+        controls="controls"
+        data-overlay-hidden-text="{{ _('Play video') }}">
         <source src="//videos-cdn.mozilla.net/brand/Mozilla_2011_Story.webm" type="video/webm">
         <source src="//videos-cdn.mozilla.net/brand/Mozilla_2011_Story.ogv" type="video/ogg; codecs=&quot;theora, vorbis&quot;">
         <source src="//videos-cdn.mozilla.net/brand/Mozilla_2011_Story.mp4" type="video/mp4">

--- a/media/js/mozilla-video-tools.js
+++ b/media/js/mozilla-video-tools.js
@@ -87,9 +87,13 @@ Mozilla.VideoControl.controls = [];
 
 Mozilla.VideoControl.prototype.drawControl = function()
 {
-  var buttonTag = '<a href="#" class="mozilla-video-control-overlay" style="opacity: 0">' +
-                  '<span style="visibility:hidden;">' +
-                  this._video.id +
+  var $overlayHiddenText = $(this._video).data('overlay-hidden-text');
+  if (!$overlayHiddenText) {
+    $overlayHiddenText =  'Play video';
+  }
+  var buttonTag = '<a href="#" role="button" class="mozilla-video-control-overlay" style="opacity: 0">' +
+                  '<span class="hidden">' +
+                    $overlayHiddenText +
                   '</span></a>';
   this.control = $(buttonTag);
 


### PR DESCRIPTION
Added data-overlay-hidden-text attribute on .mozilla-video-control video elements
modified mozilla-video-tools.js to use that string. if not set it will fallback to 'Play video'
