### PR TITLE
Bug 855734 - Strip trailing "." from request host

### DIFF
--- a/etc/httpd/global.conf
+++ b/etc/httpd/global.conf
@@ -6,6 +6,12 @@ ExpiresActive on
 
 ## Redirect things externally!
 
+# bug 855734 - if request comes in with hostname that has a trailing ".", strip it off
+# (note that Apache will put the hostname with "." stripped as the host of the
+# redirect URL by default; we just need to "redirect" to the same URL)
+RewriteCond %{HTTP_HOST} ^(.*)\.$
+RewriteRule ^(.*)$ $1 [L,R=301]
+
 # bug 764261, 841393
 RewriteRule ^/zh-TW/$ http://mozilla.com.tw/ [L,R=301]
 RewriteCond %{REQUEST_URI} !^/zh-TW/firefox/partners


### PR DESCRIPTION
People (several per day) are getting to mozilla.org via URLs like
http://www.mozilla.org./en-US/grants/. This causes the HTTP_HOST
header to be 'www.mozilla.org.', which doesn't match Django's
ALLOWED_HOSTS, which then throws errors. Apache redirect people
coming to the site with a HOST that ends in a ".".
