### PR TITLE
Bug 856919 - Fix request.locale attribute error

### DIFF
--- a/lib/l10n_utils/__init__.py
+++ b/lib/l10n_utils/__init__.py
@@ -30,7 +30,7 @@ def render(request, template, context={}, **kwargs):
     context['langfile'] = get_lang_path(template)
 
     # Look for localized template if not default lang.
-    if request.locale != settings.LANGUAGE_CODE:
+    if hasattr(request, 'locale') and request.locale != settings.LANGUAGE_CODE:
 
         # redirect to default lang if locale not active
         if not (settings.DEV or

--- a/lib/l10n_utils/tests/test_template.py
+++ b/lib/l10n_utils/tests/test_template.py
@@ -11,11 +11,12 @@ from django.test.client import Client
 from jingo import env
 from jinja2 import FileSystemLoader
 from jinja2.nodes import Block
-from mock import patch, ANY
+from mock import patch, ANY, Mock
 from nose.plugins.skip import SkipTest
 from nose.tools import eq_, ok_
 from pyquery import PyQuery as pq
 
+from l10n_utils import render
 from mozorg.tests import TestCase
 
 
@@ -124,3 +125,16 @@ class TestTemplateLangFiles(TestCase):
         self.client.get('/de/active-de-lang-file/')
         translate.assert_called_with(ANY, ['active_de_lang_file', 'main',
                                            'download_button', 'newsletter'])
+
+
+class TestNoLocale(TestCase):
+    @patch('l10n_utils.get_lang_path')
+    @patch('l10n_utils.django_render')
+    def test_render_no_locale(self, django_render, get_lang_path):
+        # Our render method doesn't blow up if the request has no .locale
+        # (can happen on 500 error path, for example)
+        get_lang_path.return_value = None
+        request = Mock(spec=object)
+        # Note: no .locale on request
+        # Should not cause an exception
+        render(request, None)


### PR DESCRIPTION
pmac opened the bug: We're seeing a few of these per day. I'm still not sure exactly when and why this happens, but it should be easy to fix.

Traceback (most recent call last):
File "/usr/lib64/python2.6/site-packages/newrelic-1.10.2.38/newrelic/hooks/framework_django.py", line 475, in wrapper return wrapped(_args, *_kwargs)
File "/data/www/www.mozilla.org-django/bedrock/lib/bedrock_util.py", line 25, in server_error_view return l10n_utils.render(request, template_name)
File "/data/www/www.mozilla.org-django/bedrock/lib/l10n_utils/**init**.py", line 33, in render if request.locale != settings.LANGUAGE_CODE:
AttributeError: 'WSGIRequest' object has no attribute 'locale'

This is happening when the 500 error handler,
bedrock_util.server_error_view, calls our l10n_utils.render method
before the middleware has set the .locale attribute on the request. In
the circumstances, just skip the code that wants the .locale if there
isn't one.  We don't want to try anything risky if we're already
handling a 500.
