### PR TITLE
Fix include font include syntax for Bug 860848

### DIFF
--- a/media/css/home.less
+++ b/media/css/home.less
@@ -6,19 +6,14 @@
 
 /* {{{ Meta Web Pro Black Italic font for Firefox OS MWCpromo */
 
-/* first for IE 6/7/8 */
 @font-face {
-  font-family: MetaWebPro-BlackIta;
-  src: url('/media/fonts/MetaWebPro-BlackIta.eotlite');
+	font-family: MetaWebPro-BlackIta;
+    src: url('/media/fonts/MetaWebPro-BlackIta.eotlite');
+    src: url('/media/fonts/MetaWebPro-BlackIta.eotlite?#iefix') format('embedded-opentype'),
+         url('/media/fonts/MetaWebPro-BlackIta.woff') format('woff');
+    font-weight: normal;
+    font-style: normal;
 }
-
-/* then for Mozilla browsers -> Firefox */
-@font-face {
-  font-family: MetaWebPro-BlackIta;
-  src: url('/media/fonts/MetaWebPro-BlackIta.woff') format('woff');
-}
-
-
 
 /* }}} */
 /* {{{ Vollkorn font for Firefox Flicks promo */

--- a/media/css/tabzilla.less
+++ b/media/css/tabzilla.less
@@ -38,16 +38,13 @@
 
 /* Meta Web Pro Black Italic font for Firefox OS MWCpromo */
 
-/* first for IE 6/7/8 */
 @font-face {
-  font-family: MetaWebPro-BlackIta;
-  src: url('/media/fonts/MetaWebPro-BlackIta.eotlite');
-}
-
-/* then for Mozilla browsers -> Firefox */
-@font-face {
-  font-family: MetaWebPro-BlackIta;
-  src: url('/media/fonts/MetaWebPro-BlackIta.woff') format('woff');
+	font-family: MetaWebPro-BlackIta;
+    src: url('/media/fonts/MetaWebPro-BlackIta.eotlite');
+    src: url('/media/fonts/MetaWebPro-BlackIta.eotlite?#iefix') format('embedded-opentype'),
+         url('/media/fonts/MetaWebPro-BlackIta.woff') format('woff');
+    font-weight: normal;
+    font-style: normal;
 }
 
 


### PR DESCRIPTION
Use the same web font include syntax that we use everywhere else on the site. Should fix the 404s we're seeing from IE8 on Bug 860848.
