### PR TITLE
Conditional formatting for iOS on download button - bug 767985 

### DIFF
--- a/media/css/sandstone/buttons.less
+++ b/media/css/sandstone/buttons.less
@@ -462,6 +462,11 @@
     display: block !important;
 }
 
+.ios .download-button .unsupported-download,
+.oldmac .download-button .unsupported-download {
+    display: block;
+    max-width: 250px;
+}
 
 // Small print
 
@@ -492,10 +497,6 @@
     .unrecognized-download {
         display: block;
     }
-}
-
-.oldmac .download-button .unsupported-download {
-    display: block;
 }
 
 .download-button noscript,

--- a/media/js/site.js
+++ b/media/js/site.js
@@ -23,6 +23,11 @@
         if (/Mac OS X 10.[0-5]/.test(navigator.userAgent)) {
             return 'oldmac';
         }
+        if (navigator.platform.indexOf('iPhone') !== -1 || 
+                navigator.platform.indexOf('iPad') !== -1 || 
+                navigator.platform.indexOf('iPod') !== -1 ) {
+            return 'ios';
+        }
         if (navigator.userAgent.indexOf("Mac OS X") !== -1) {
             return 'osx';
         }


### PR DESCRIPTION
Add iOS detection in `site.js` and show `.unsupported-download` content in place of download button.

https://bugzilla.mozilla.org/show_bug.cgi?id=767985
