### PR TITLE
Bug 869530 Add required minimum jQuery version and load in a non-conflicting manner...

### DIFF
--- a/apps/tabzilla/templates/tabzilla/tabzilla.js
+++ b/apps/tabzilla/templates/tabzilla/tabzilla.js
@@ -334,8 +334,8 @@ var Tabzilla = (function (Tabzilla) {
         return 0;
     };
     (function () {
-        if (   typeof window.jQuery !== 'undefined'
-            && compareVersion(window.jQuery.fn.jquery, minimumJQuery) !== -1
+        if (window.jQuery !== undefined &&
+            compareVersion(window.jQuery.fn.jquery, minimumJQuery) !== -1
         ) {
             // set up local jQuery aliases
             jQuery = window.jQuery;


### PR DESCRIPTION
... if jQuery exists but is older than the required version.
