### PR TITLE
Add styling for invalid form fields

### DIFF
--- a/media/css/sandstone/sandstone-resp.less
+++ b/media/css/sandstone/sandstone-resp.less
@@ -273,6 +273,18 @@ input.focus {
     .transition(all linear .1s);
 }
 
+textarea:-moz-ui-invalid:not(output),
+input[type=email]:-moz-ui-invalid:not(output),
+input[type=password]:-moz-ui-invalid:not(output),
+input[type=search]:-moz-ui-invalid:not(output),
+input[type=text]:-moz-ui-invalid:not(output),
+input.invalid {
+    border-color: #a91300;
+    @shadow: 0 0 0 2px rgba(255,80,80,0.4);
+    .box-shadow(@shadow);
+    .transition(all linear .1s);
+}
+
 .form-field {
     margin-bottom: @baseLine / 3;
 }


### PR DESCRIPTION
Our sandstone field styling adds a box-shadow and overrides Gecko's native styling for invalid fields. This rule applies our own style so errors still look nice in Firefox. This uses a proprietary selector so it only works in Gecko.
