### PR TITLE
remove getpersona link in addons email txt bug 860996

### DIFF
--- a/apps/mozorg/templates/mozorg/emails/addons.txt
+++ b/apps/mozorg/templates/mozorg/emails/addons.txt
@@ -20,7 +20,7 @@ CREATE A THEME
 ================
 
 Background Themes let you personalize the look of your Firefox. To create your own, start here:
-http://www.getpersonas.com/en-US/demo_create
+https://addons.mozilla.org/firefox/themes/
 
 -------------------------------------------------------------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
There is another getpersonas URL that I believe can be updated here in the addons email text.
