### PR TITLE
Bug 833534 Add missing .visuallyhidden class

### DIFF
--- a/media/css/sandstone/lib.less
+++ b/media/css/sandstone/lib.less
@@ -316,13 +316,20 @@
     .box-shadow(@shadow);
 }
 
-.hidden {
-  position: absolute;
-  left: -999em;
-}
-
 .form-field-error {
   border-color: rgb(175,50,50);
   @shadow: 0 2px 1px rgba(0,0,0,0.1) inset, 0 0 8px 0 rgba(175,50,50,.6);
   .box-shadow(@shadow);
+}
+
+// Hide visually, but not to screen readers
+.visually-hidden() {
+    position: absolute;
+    height: 1px;
+    width: 1px;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0 0 0 0);
+    padding: 0;
+    border: 0;
 }

--- a/media/css/sandstone/sandstone-resp.less
+++ b/media/css/sandstone/sandstone-resp.less
@@ -1117,4 +1117,8 @@ nav.menu-bar {
     display: none;
 }
 
+.hidden {
+    .visually-hidden();
+}
+
 /* }}} */

--- a/media/js/mozorg/home.js
+++ b/media/js/mozorg/home.js
@@ -428,7 +428,7 @@ $(document).ready(function() {
 
     function createCloseButton() {
         var $close = $(
-            '<button class="video-close"><span class="visuallyhidden">Close Video </span><span aria-hidden="true">×</span></button>'
+            '<button class="video-close"><span class="hidden">Close Video </span><span aria-hidden="true">×</span></button>'
         );
 
         $close.attr('title', $('#strings').data('close'))


### PR DESCRIPTION
Added .visually-hidden() as a LESS mixin that will allow these styles to be added to other classes, but doesn't output anything in the CSS itself. Then there is a .visuallyhidden CSS class in sandstone-resp.less that uses this mixin.
