### PR TITLE
Bug 867985 - update number of locales

### DIFF
--- a/bedrock/mozorg/templates/mozorg/contribute.html
+++ b/bedrock/mozorg/templates/mozorg/contribute.html
@@ -154,7 +154,7 @@
           <div class="message">
           <p>
           {% trans %}
-            Our global community has helped translate Firefox into 89 languages, making the browser available to more than 95% of the world's population.
+            Our global community has helped translate Firefox into over 70 languages, making the browser available to more than 90% of the world's population.
           {% endtrans %}
           </p>
           </div>


### PR DESCRIPTION
We went from 89 to 80 locales. Amending the text to "over 70" and "more than 90%" is vague enough to be accurate for the foreseeable future even as the specific number fluctuates.

Since this changes the string it will break current translations. We should merge strings and give localizers a chance to update before this goes to production. (attention @pascalchevrel)
