### PR TITLE
Firefox pages JS should consider ESR builds up to date bug 828064

### DIFF
--- a/bedrock/firefox/context_processors.py
+++ b/bedrock/firefox/context_processors.py
@@ -1,0 +1,12 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from bedrock.firefox.firefox_details import firefox_details
+
+
+def latest_firefox_versions(request):
+    return {
+        'latest_firefox_version': firefox_details.latest_version('release'),
+        'esr_firefox_versions': firefox_details.esr_major_versions,
+    }

--- a/bedrock/firefox/templates/firefox/base-resp.html
+++ b/bedrock/firefox/templates/firefox/base-resp.html
@@ -20,6 +20,8 @@
 <meta name="og:image" content="{{ media('img/firefox/firefox-100.jpg') }}">
 {% endblock %}
 
+{% block body_attrs %}{{ super() }} data-latest-firefox="{{ latest_firefox_version }}" data-esr-versions="{{ esr_firefox_versions }}"{% endblock %}
+
 {% block site_header_nav %}
 <nav id="nav-main" role="navigation">
   <span class="toggle" role="button" aria-controls="nav-main-menu" tabindex="0">{{_('Menu')}}</span>

--- a/bedrock/firefox/templates/firefox/base.html
+++ b/bedrock/firefox/templates/firefox/base.html
@@ -20,6 +20,8 @@
 <meta name="og:image" content="{{ media('img/firefox/firefox-100.jpg') }}">
 {% endblock %}
 
+{% block body_attrs %}{{ super() }} data-latest-firefox="{{ latest_firefox_version }}" data-esr-versions="{{ esr_firefox_versions }}"{% endblock %}
+
 {% block site_header_nav %}
 <nav role="navigation" id="nav-main">
   <ul class="has-submenus">

--- a/bedrock/firefox/templates/firefox/devices.html
+++ b/bedrock/firefox/templates/firefox/devices.html
@@ -51,7 +51,7 @@
             <p id="fx-download"><a href="{{ php_url('/firefox/') }}" class="button go">{{ _('Download Firefox') }}</a> <br> <a href="/firefox/central/" class="go">Learn more</a></p>
           </div>
 
-          <div id="gauge" data-latest-version="{{ latest_version }}">
+          <div id="gauge">
             <img src="{{ media('img/firefox/devices/needle.png') }}" alt="" id="needle">
             <p id="gauge-slow">{{ _('Old Firefox = Sadface') }}</p>
             <p id="gauge-fast">{{ _('New Firefox = Yay!') }}</p>
@@ -84,9 +84,9 @@
                 </a>
               </p>
               <small class="download-other">
-                <a href="/legal/privacy/firefox.html">{{ _('Privacy Policy') }}</a> | 
-                <a href="/mobile/platforms">{{ _('Supported Devices') }}</a> | 
-                <a href="/mobile/{{latest_version}}/releasenotes">{{ _('Release Notes') }}</a>
+                <a href="/legal/privacy/firefox.html">{{ _('Privacy Policy') }}</a> |
+                <a href="/mobile/platforms">{{ _('Supported Devices') }}</a> |
+                <a href="/mobile/{{ latest_firefox_version }}/releasenotes">{{ _('Release Notes') }}</a>
               </small>
             </aside>
           </div>
@@ -107,9 +107,9 @@
                 </a>
               </p>
               <small class="download-other">
-                <a href="/legal/privacy/firefox.html">{{ _('Privacy Policy') }}</a> | 
-                <a href="/mobile/platforms">{{ _('Supported Devices') }}</a> | 
-                <a href="/mobile/{{latest_version}}/releasenotes">{{ _('Release Notes') }}</a>
+                <a href="/legal/privacy/firefox.html">{{ _('Privacy Policy') }}</a> |
+                <a href="/mobile/platforms">{{ _('Supported Devices') }}</a> |
+                <a href="/mobile/{{ latest_firefox_version }}/releasenotes">{{ _('Release Notes') }}</a>
               </small>
             </aside>
           </div>
@@ -125,7 +125,7 @@
           </div>
           <ul id="addons-list">
             <li class="addon">
-              <h3><a href="https://addons.mozilla.org/en-US/mobile/addon/adblock-plus/?src=fx-devices" rel="external"><img src="//static-ssl-cdn.addons.mozilla.net/img/uploads/addon_icons/1/1865-48.png" alt=""> {{ _('AdBlock Plus') }}</a></h3> 
+              <h3><a href="https://addons.mozilla.org/en-US/mobile/addon/adblock-plus/?src=fx-devices" rel="external"><img src="//static-ssl-cdn.addons.mozilla.net/img/uploads/addon_icons/1/1865-48.png" alt=""> {{ _('AdBlock Plus') }}</a></h3>
               <p class="desc">{{ _('Regain control and change the way that you view the Web.') }}</p>
               <ul class="add-to">
                 <li><a href="https://addons.mozilla.org/en-US/firefox/addon/adblock-plus/?src=fx-devices">{{ _('Add to Desktop') }}</a></li>

--- a/bedrock/firefox/templates/firefox/fx.html
+++ b/bedrock/firefox/templates/firefox/fx.html
@@ -132,21 +132,4 @@
 
 {% block js %}
   {{ js('firefox_fx') }}
-
-<script>
-$(document).ready(function() {
-  var latestVersion = parseInt('{{latest_version}}'.split('.')[0], 10);
-  var isFirefox = (/\sFirefox/.test(window.navigator.userAgent));
-  var isMobile = (/\sMobile/.test(window.navigator.userAgent));
-
-  // If Firefox is the latest version and not mobile,
-  // hide the out-of-date messaging and show up-to-date
-  if(isFirefox && !isMobile) {
-    if (latestVersion <= getFirefoxMasterVersion()) {
-      $('#out-of-date').hide();
-      $('#up-to-date').show();
-    }
-  }
-});
-</script>
 {% endblock  %}

--- a/bedrock/firefox/templates/firefox/speed.html
+++ b/bedrock/firefox/templates/firefox/speed.html
@@ -14,11 +14,7 @@
   {{ css('firefox_speed') }}
 {% endblock %}
 
-{% block body_attrs %}{{ super() }} data-latest-firefox="{{ latest_version }}"{% endblock %}
-
 {% block content %}
-
-
 <div id="main-feature">
 {% block heading_primary %}
   <h1 class="">How fast is your Firefox?</h1>

--- a/bedrock/firefox/templates/firefox/update.html
+++ b/bedrock/firefox/templates/firefox/update.html
@@ -12,6 +12,14 @@
   {{ super() }}
 {% endblock %}
 
+{% block string_data %}
+  {# L10n: Congratulates the user on having an up-to-date version of Firefox. #}
+  data-head-uptodate="{{ _('Congratulations!') }}"
+  data-sub-uptodate="{{ _('Your Firefox is up to date.') }}"
+  data-head-outofdate="{{ _('Your Firefox is out of date.') }}"
+  data-sub-outofdate="{{ _('Get the newest version <a href="{url}">here</a>.')|f(url=php_url('/firefox/'))|escape }}"
+{% endblock %}
+
 {% block content %}
 <div id="main-feature">
   <h1>Keep Your Firefox Happy!</h1>
@@ -114,24 +122,5 @@
 
 {% block js %}
   {{ js('expanders') }}
-<script>
-$(document).ready(function() {
-    var latestVersion = parseInt('{{ latest_version }}'.split('.')[0], 10);
-    var isFirefox = (/\sFirefox/.test(window.navigator.userAgent));
-    var headline = $('#main-feature > h1');
-    var subheadline = $('#main-feature > h3');
-
-    if(isFirefox) {
-        if(latestVersion <= getFirefoxMasterVersion()) {
-            headline.html('Congratulations!');
-            subheadline.html('Your Firefox is up to date.');
-        }
-        else {
-            headline.html('Your Firefox is out of date.');
-            subheadline.html('Get the newest version <a href="/firefox">here</a>.');
-        }
-    }
-});
-</script>
-
+  {{ js('firefox_update')}}
 {% endblock %}

--- a/bedrock/firefox/urls.py
+++ b/bedrock/firefox/urls.py
@@ -5,8 +5,6 @@
 from django.conf.urls.defaults import *  # noqa
 from django.conf import settings
 
-from product_details import product_details
-
 from bedrock.firefox import version_re
 from bedrock.redirects.util import redirect
 from bedrock.mozorg.util import page
@@ -33,13 +31,11 @@ urlpatterns = patterns('',
     redirect('^firefox/channel/android/$', 'firefox.channel'),
     page('firefox/customize', 'firefox/customize.html'),
     page('firefox/features', 'firefox/features.html'),
-    page('firefox/fx', 'firefox/fx.html',
-         latest_version=product_details.firefox_versions['LATEST_FIREFOX_VERSION']),
+    page('firefox/fx', 'firefox/fx.html'),
     page('firefox/geolocation', 'firefox/geolocation.html',
          gmap_api_key=settings.GMAP_API_KEY),
     page('firefox/happy', 'firefox/happy.html'),
-    page('firefox/memory', 'firefox/memory.html',
-         latest_version=product_details.firefox_versions['LATEST_FIREFOX_VERSION']),
+    page('firefox/memory', 'firefox/memory.html'),
     url('^firefox/mobile/platforms/$', views.platforms,
         name='firefox.mobile.platforms'),
     page('firefox/mobile/features', 'firefox/mobile/features.html'),
@@ -54,13 +50,10 @@ urlpatterns = patterns('',
     page('firefox/security', 'firefox/security.html'),
     url(r'^firefox/installer-help/$', views.installer_help,
         name='firefox.installer-help'),
-    page('firefox/speed', 'firefox/speed.html',
-         latest_version=product_details.firefox_versions['LATEST_FIREFOX_VERSION']),
+    page('firefox/speed', 'firefox/speed.html'),
     page('firefox/technology', 'firefox/technology.html'),
-    page('firefox/toolkit/download-to-your-devices', 'firefox/devices.html',
-         latest_version=product_details.firefox_versions['LATEST_FIREFOX_VERSION']),
-    page('firefox/update', 'firefox/update.html',
-         latest_version=product_details.firefox_versions['LATEST_FIREFOX_VERSION']),
+    page('firefox/toolkit/download-to-your-devices', 'firefox/devices.html'),
+    page('firefox/update', 'firefox/update.html'),
 
     page('firefox/unsupported/warning', 'firefox/unsupported-warning.html'),
     page('firefox/unsupported/EOL', 'firefox/unsupported-EOL.html'),

--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -27,6 +27,7 @@ from bedrock.firefox.utils import is_current_or_newer
 from bedrock.firefox.firefox_details import firefox_details
 from lib.l10n_utils.dotlang import _
 
+UA_REGEXP = re.compile(r"Firefox/(%s)" % version_re)
 
 LOCALE_OS_URLS = {
     'en-US': 'http://blog.mozilla.org/press/2013/02/firefox-os-expansion',
@@ -145,8 +146,7 @@ def latest_fx_redirect(request, fake_version, template_name):
         return HttpResponsePermanentRedirect(url)
 
     user_version = "0"
-    ua_regexp = r"Firefox/(%s)" % version_re
-    match = re.search(ua_regexp, user_agent)
+    match = UA_REGEXP.search(user_agent)
     if match:
         user_version = match.group(1)
 

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -412,6 +412,7 @@ MINIFY_BUNDLES = {
         'firefox_fx': (
             'js/base/mozilla-pager.js',
             'js/base/mozilla-video-tools.js',
+            'js/firefox/fx.js',
         ),
         'firefox_happy': (
             'js/libs/jquery-1.4.4.min.js',
@@ -433,6 +434,9 @@ MINIFY_BUNDLES = {
         ),
         'firefox_tech': (
             'js/firefox/technology/tech.js',
+        ),
+        'firefox_update': (
+            'js/firefox/update.js',
         ),
         'firefox_sms': (
             'js/firefox/sms.js',
@@ -627,6 +631,7 @@ LOCALE_PATHS = (
 
 TEMPLATE_CONTEXT_PROCESSORS = get_template_context_processors(append=(
     'bedrock.mozorg.context_processors.current_year',
+    'bedrock.firefox.context_processors.latest_firefox_versions',
 ))
 
 ## Auth

--- a/media/js/base/global.js
+++ b/media/js/base/global.js
@@ -61,8 +61,7 @@ $(document).ready(function() {
 });
 
 //get Master firefox version
-function getFirefoxMasterVersion()
-{
+function getFirefoxMasterVersion() {
     var version = 0;
 
     var matches = /Firefox\/([0-9]+).[0-9]+(?:.[0-9]+)?/.exec(
@@ -74,6 +73,32 @@ function getFirefoxMasterVersion()
     }
 
     return version;
+}
+
+function isFirefox() {
+    return /\sFirefox/.test(navigator.userAgent);
+}
+
+function isFirefoxUpToDate(latest, esr) {
+
+    var $body = $('body');
+    var fx_version = getFirefoxMasterVersion();
+    var esrFirefoxVersions = esr || $body.data('esr-versions');
+    var latestFirefoxVersion;
+
+    if (!latest) {
+        latestFirefoxVersion = $body.attr('data-latest-firefox');
+        latestFirefoxVersion = parseInt(latestFirefoxVersion.split('.')[0], 10);
+    } else {
+        latestFirefoxVersion = parseInt(latest.split('.')[0], 10);
+    }
+    
+    return ($.inArray(fx_version, esrFirefoxVersions) !== -1 ||
+            latestFirefoxVersion <= fx_version);
+}
+
+function isMobile() {
+    return /\sMobile/.test(window.navigator.userAgent);
 }
 
 

--- a/media/js/firefox/devices.js
+++ b/media/js/firefox/devices.js
@@ -4,12 +4,6 @@
 
 $(document).ready(function() {
 
-    // Get the latest version of firefox that is attached as a data
-    // attribute. Force a string because jquery sometimes converts it
-    // to an integer.
-    var latestVersion = ('' + $('#gauge').data('latest-version'));
-    latestVersion = parseInt(latestVersion.split('.')[0], 10);
-
     $('#fx-features').hide();
 
 
@@ -137,7 +131,9 @@ $(document).ready(function() {
             // initial position
             rotate(-1.5, 10, startWaver, 'linear');
 
-            if (latestVersion > getFirefoxMasterVersion()) { // latestVersion is defined inline on the page, fetched from product_details
+            // latestFirefoxVersion and esrFirefoxVersions are defined inline on the page
+            // fetched from product_details
+            if (!isFirefoxUpToDate()) { 
                 // slow
                 setTimeout(function() {
                     stopWaver();

--- a/media/js/firefox/fx.js
+++ b/media/js/firefox/fx.js
@@ -1,0 +1,14 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+;$(function () {
+    'use strict';
+
+    // If Firefox is the latest version and not mobile,
+    // hide the out-of-date messaging and show up-to-date
+    if (isFirefox() && !isMobile() && isFirefoxUpToDate()) {
+        $('#out-of-date').hide();
+        $('#up-to-date').show();
+    }
+});

--- a/media/js/firefox/speed.js
+++ b/media/js/firefox/speed.js
@@ -13,9 +13,6 @@ $(document).ready(function() {
     var needle = $('#needle');
     var gauge = $('#gauge');
     var angle = 0;
-    var latestVersion = $('body').attr('data-latest-firefox');
-    latestVersion = parseInt(latestVersion.split('.')[0], 10);
-    var isFirefox = (/\sFirefox/.test(window.navigator.userAgent));
 
     $.easing.easeInOutSine = function (x, t, b, c, d) {
         return -c/2 * (Math.cos(Math.PI*t/d) - 1) + b;
@@ -80,11 +77,11 @@ $(document).ready(function() {
         }
     };
 
-    if (isFirefox) {
+    if (isFirefox()) {
         // initial position
         rotate(-1.5, 10, startWaver, 'linear');
 
-        if (latestVersion > getFirefoxMasterVersion()) {
+        if (!isFirefoxUpToDate()) {
             // slow
             setTimeout(function() {
                 stopWaver();

--- a/media/js/firefox/update.js
+++ b/media/js/firefox/update.js
@@ -1,0 +1,20 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ 
+;$(function () {
+    'use strict';
+
+    var $headline = $('#main-feature > h1');
+    var $subheading = $('#main-feature > h3');
+
+    if (isFirefox()) {
+        if (isFirefoxUpToDate()) {
+            $headline.html(trans('head-uptodate'));
+            $subheading.html(trans('sub-uptodate'));
+        } else {
+            $headline.html(trans('head-outofdate'));
+            $subheading.html(trans('sub-outofdate'));
+        }
+    }
+});


### PR DESCRIPTION
Refactor of pull request #585 to bring JS up to date (Bug 828064).

This refactor includes suggestions based on the original code review, along with a few additions:
- Moving page specific inline JS to external files.
- Moving `isFirefox()` `isFirefoxUpToDate()` functions to `global.js`.
- Use of data attributes for Firefox and ESR version.
- L10n for heading and sub-heading in `update.html`.
- Additional ESR check in `devices.js` and `devices.html`

@pmclanahan @Osmose r?
