### PR TITLE
Bug 868618 - Update Google Play store URLs

### DIFF
--- a/bedrock/mozorg/helpers/download_buttons.py
+++ b/bedrock/mozorg/helpers/download_buttons.py
@@ -225,10 +225,10 @@ def download_firefox(ctx, build='release', small=False, icon=True,
         if build == 'aurora':
             android_link = download_urls['aurora-mobile']
         elif build == 'beta':
-            android_link = ('https://market.android.com/details?'
+            android_link = ('https://play.google.com/store/apps/details?'
                             'id=org.mozilla.firefox_beta')
         else:
-            android_link = ('https://market.android.com/details?'
+            android_link = ('https://play.google.com/store/apps/details?'
                             'id=org.mozilla.firefox')
 
         builds.append({'os': 'os_android',

--- a/bedrock/mozorg/tests/test_helper_download_buttons.py
+++ b/bedrock/mozorg/tests/test_helper_download_buttons.py
@@ -41,7 +41,7 @@ class TestDownloadButtons(unittest.TestCase):
 
         # Check that last link is Android
         eq_(pq(links[3]).attr('href'),
-            'https://market.android.com/details?id=org.mozilla.firefox')
+            'https://play.google.com/store/apps/details?id=org.mozilla.firefox')
 
     def test_button(self, small=False):
         rf = RequestFactory()


### PR DESCRIPTION
Changed from market.android.com... to play.google.com and verified the new URL format.

Update to #828.
