### PR TITLE
more .hidden -> .visually-hidden

### DIFF
--- a/media/css/collusion/collusion.less
+++ b/media/css/collusion/collusion.less
@@ -256,7 +256,7 @@ line.bold {
 }
 
 .hidden {
-  display: none;
+  .visually-hidden();
 }
 
 

--- a/media/css/foundation/annual2011.less
+++ b/media/css/foundation/annual2011.less
@@ -680,7 +680,7 @@ body.noscroll {
       font-size: .928em;
     }
     .note {
-      .hidden;
+      .visually-hidden();
     }
     a {
       display: block;

--- a/media/css/mozorg/partnerships.less
+++ b/media/css/mozorg/partnerships.less
@@ -60,7 +60,7 @@
 
     #sf-form label {
         color: @textColorTertiary;
-        .hidden;
+        .visually-hidden();
         &.shown {
             text-indent: 0;
             left: auto;


### PR DESCRIPTION
[Bug 833534](https://bugzil.la/833534) (8ab27399) introduced `.visually-hidden`, made `.hidden` an alias in `sandstone/sandstone-resp.less`. For less files which imports only `sandstone/lib.less`, `.hidden` is broken. http://www.mozilla.org/en-US/about/partnerships/ is an example.

Or, maybe `.hidden` should be kept, as some times it make sense to hide some elements from screen reader, too?
