### PR TITLE
Bug 837763 - Add Firefox's Google+ and YouTube links to universal footer

### DIFF
--- a/bedrock/base/templates/base-resp.html
+++ b/bedrock/base/templates/base-resp.html
@@ -102,8 +102,10 @@
 
           {% block social %}
           <ul class="footer-nav">
-            <li><a href="http://twitter.com/firefox">{{_('Twitter')}}</a></li>
-            <li><a href="http://facebook.com/Firefox">{{_('Facebook')}}</a></li>
+            <li><a href="https://twitter.com/firefox">{{_('Twitter')}}</a></li>
+            <li><a href="https://facebook.com/Firefox">{{_('Facebook')}}</a></li>
+            <li><a href="https://plus.google.com/+firefox/posts">{{_('Google+')}}</a></li>
+            <li><a href="http://www.youtube.com/firefoxchannel">{{_('YouTube')}}</a></li>
             <li><a href="https://affiliates.mozilla.org/">{{_('Firefox Affiliates')}}</a></li>
           </ul>
           {% endblock %}

--- a/bedrock/base/templates/base.html
+++ b/bedrock/base/templates/base.html
@@ -95,8 +95,10 @@
 
           {% block social %}
           <ul class="footer-nav">
-            <li><a href="http://twitter.com/firefox">{{_('Twitter')}}</a></li>
-            <li><a href="http://facebook.com/Firefox">{{_('Facebook')}}</a></li>
+            <li><a href="https://twitter.com/firefox">{{_('Twitter')}}</a></li>
+            <li><a href="https://facebook.com/Firefox">{{_('Facebook')}}</a></li>
+            <li><a href="https://plus.google.com/+firefox/posts">{{_('Google+')}}</a></li>
+            <li><a href="http://www.youtube.com/firefoxchannel">{{_('YouTube')}}</a></li>
             <li><a href="https://affiliates.mozilla.org/">{{_('Firefox Affiliates')}}</a></li>
           </ul>
           {% endblock %}


### PR DESCRIPTION
Also fixes Bug 638699 - Links to Facebook and Twitter should be HTTPS
