### PR TITLE
Bug 869489 - Port localized versions of Manifesto to Bedrock

### DIFF
--- a/bedrock/mozorg/templates/mozorg/about/manifesto.html
+++ b/bedrock/mozorg/templates/mozorg/about/manifesto.html
@@ -7,76 +7,88 @@
 {% block page_title %}{{ _('The Mozilla Manifesto') }}{% endblock %}
 {% block body_id %}about-manifesto{% endblock %}
 
+{% block extrahead %}
+  {{ super() }}
+  {{ css('manifesto') }}
+{% endblock %}
+
 
 {% block article %}
-    <h1 class="title-banner">{{ _('The Mozilla Manifesto') }}</h1>
-	<h2 id="introduction">{{_('Introduction')}}</h2>
-    <p>
-      {{_('The Internet is becoming an increasingly important part of our lives.')}}
-    </p>
-    
-    <p>
-      {{_('The Mozilla project is a global community of people who believe that openness, innovation, and opportunity are key to the continued health of the Internet. We have worked together since 1998 to ensure that the Internet is developed in a way that benefits everyone. We are best known for creating the Mozilla Firefox web browser.')}}
-    </p>
+  <h1 class="title-banner">{{ _('The Mozilla Manifesto') }}</h1>
+  <h2 id="introduction">{{_('Introduction')}}</h2>
 
-    <p>{{_('The Mozilla project uses a community-based approach to create world-class open source software and to develop new types of collaborative activities. We create communities of people involved in making the Internet experience better for all of us.')}} </p>
-    
-    <p> 
-      {{_('As a result of these efforts, we have distilled a set of principles that we believe are critical for the Internet to continue to benefit the public good as well as commercial aspects of life. We set out these principles below.')}} 
-    </p>
-    
-    <p>
-      {{_('The goals for the Manifesto are to:')}}
-    </p>
-    
-    <ol>
-      <li>{{_('articulate a vision for the Internet that Mozilla participants want the Mozilla Foundation to pursue;')}} </li>
-      <li>{{_('speak to people whether or not they have a technical background;')}}</li>
-      <li>{{_('make Mozilla contributors proud of what we\'re doing and motivate us to continue; and')}}</li>
-      <li>{{_('provide a framework for other people to advance this vision of the Internet.')}}</li>
-    </ol>
-    
-    <p>
-      {{_('These principles will not come to life on their own. People are needed to make the Internet open and participatory - people acting as individuals, working together in groups, and leading others. The Mozilla Foundation is committed to advancing the principles set out in the Mozilla Manifesto. We invite others to join us and make the Internet an ever better place for everyone.')}}
-    </p>
+  <p>
+    {{_('The Internet is becoming an increasingly important part of our lives.')}}
+  </p>
 
-    <h2 id="principles">{{_('Principles')}}</h2>
-    <ol>
-      <li>{{_('The Internet is an integral part of modern life—a key component in education, communication, collaboration, business, entertainment and society as a whole.')}} </li>
-      <li>{{_('The Internet is a global public resource that must remain open and accessible.')}}</li>
-      <li>{{_('The Internet should enrich the lives of individual human beings.')}}</li>
-      <li>{{_('Individuals’ security on the Internet is fundamental and cannot be treated as optional.')}}</li>
-      <li>{{_('Individuals must have the ability to shape their own experiences on the Internet.')}}</li>
-      <li>{{_('The effectiveness of the Internet as a public resource depends upon interoperability (protocols, data formats, content), innovation and decentralized participation worldwide.')}}</li>
-      <li>{{_('Free and open source software promotes the development of the Internet as a public resource.')}}</li>
-      <li>{{_('Transparent community-based processes promote participation, accountability, and trust.')}}</li>
-      <li>{{_('Commercial involvement in the development of the Internet brings many benefits; a balance between commercial goals and public benefit is critical.')}}</li>
-      <li>{{_('Magnifying the public benefit aspects of the Internet is an important goal, worthy of time, attention and commitment.')}}</li>
-    </ol>
+  <p>
+    {{_('The Mozilla project is a global community of people who believe that openness, innovation, and opportunity are key to the continued health of the Internet. We have worked together since 1998 to ensure that the Internet is developed in a way that benefits everyone. We are best known for creating the Mozilla Firefox web browser.')}}
+  </p>
 
-    <h2>{{_('Advancing the Mozilla Manifesto')}}</h2>
-    
-    <p>{{_('There are many different ways of advancing the principles of the Mozilla Manifesto. We welcome a broad range of activities, and anticipate the same creativity that Mozilla participants have shown in other areas of the project. For individuals not deeply involved in the Mozilla project, one basic and very effective way to support the Manifesto is to use Mozilla Firefox and other products that embody the principles of the Manifesto.')}} </p>
+  <p>{{_('The Mozilla project uses a community-based approach to create world-class open source software and to develop new types of collaborative activities. We create communities of people involved in making the Internet experience better for all of us.')}} </p>
 
-    <h3>{{_('Mozilla Foundation Pledge')}}</h3>
-    
-    <p>{{_('The Mozilla Foundation pledges to support the Mozilla Manifesto in its activities. Specifically, we will:')}}</p>
-    
-    <ul>
-      <li>{{_('build and enable open-source technologies and communities that support the Manifesto’s principles;')}}</li>
-      <li>{{_('build and deliver great consumer products that support the Manifesto’s principles;')}}</li>
-      <li>{{_('use the Mozilla assets (intellectual property such as copyrights and trademarks, infrastructure, funds, and reputation) to keep the Internet an open platform;')}}</li>
-      <li>{{_('promote models for creating economic value for the public benefit; and')}}</li>
-      <li>{{_('promote the Mozilla Manifesto principles in public discourse and within the Internet industry.')}}</li>
-    </ul>
+  <p>
+    {{_('As a result of these efforts, we have distilled a set of principles that we believe are critical for the Internet to continue to benefit the public good as well as commercial aspects of life. We set out these principles below.')}}
+  </p>
 
-    <p>
-      {{_('Some Foundation activities—currently the creation, delivery and promotion of consumer products—are conducted primarily through the Mozilla Foundation’s wholly owned subsidiary, the Mozilla Corporation.')}}
-    </p>
+  <p>
+    {{_('The goals for the Manifesto are to:')}}
+  </p>
 
-    <h3>{{_('Invitation')}}</h3>
+  <ol>
+    <li>{{_('articulate a vision for the Internet that Mozilla participants want the Mozilla Foundation to pursue;')}} </li>
+    <li>{{_('speak to people whether or not they have a technical background;')}}</li>
+    <li>{{_('make Mozilla contributors proud of what we\'re doing and motivate us to continue; and')}}</li>
+    <li>{{_('provide a framework for other people to advance this vision of the Internet.')}}</li>
+  </ol>
 
-    <p>
-      {{_('The Mozilla Foundation invites all others who support the principles of the Mozilla Manifesto to join with us, and to find new ways to make this vision of the Internet a reality.')}}
-    </p>
+  <p>
+    {{_('These principles will not come to life on their own. People are needed to make the Internet open and participatory - people acting as individuals, working together in groups, and leading others. The Mozilla Foundation is committed to advancing the principles set out in the Mozilla Manifesto. We invite others to join us and make the Internet an ever better place for everyone.')}}
+  </p>
+
+  <h2 id="principles">{{_('Principles')}}</h2>
+  <ol>
+    <li>{{_('The Internet is an integral part of modern life—a key component in education, communication, collaboration, business, entertainment and society as a whole.')}} </li>
+    <li>{{_('The Internet is a global public resource that must remain open and accessible.')}}</li>
+    <li>{{_('The Internet should enrich the lives of individual human beings.')}}</li>
+    <li>{{_('Individuals’ security on the Internet is fundamental and cannot be treated as optional.')}}</li>
+    <li>{{_('Individuals must have the ability to shape their own experiences on the Internet.')}}</li>
+    <li>{{_('The effectiveness of the Internet as a public resource depends upon interoperability (protocols, data formats, content), innovation and decentralized participation worldwide.')}}</li>
+    <li>{{_('Free and open source software promotes the development of the Internet as a public resource.')}}</li>
+    <li>{{_('Transparent community-based processes promote participation, accountability, and trust.')}}</li>
+    <li>{{_('Commercial involvement in the development of the Internet brings many benefits; a balance between commercial goals and public benefit is critical.')}}</li>
+    <li>{{_('Magnifying the public benefit aspects of the Internet is an important goal, worthy of time, attention and commitment.')}}</li>
+  </ol>
+
+  <h2>{{_('Advancing the Mozilla Manifesto')}}</h2>
+
+  <p>{{_('There are many different ways of advancing the principles of the Mozilla Manifesto. We welcome a broad range of activities, and anticipate the same creativity that Mozilla participants have shown in other areas of the project. For individuals not deeply involved in the Mozilla project, one basic and very effective way to support the Manifesto is to use Mozilla Firefox and other products that embody the principles of the Manifesto.')}} </p>
+
+  <h3>{{_('Mozilla Foundation Pledge')}}</h3>
+
+  <p>{{_('The Mozilla Foundation pledges to support the Mozilla Manifesto in its activities. Specifically, we will:')}}</p>
+
+  <ul>
+    <li>{{_('build and enable open-source technologies and communities that support the Manifesto’s principles;')}}</li>
+    <li>{{_('build and deliver great consumer products that support the Manifesto’s principles;')}}</li>
+    <li>{{_('use the Mozilla assets (intellectual property such as copyrights and trademarks, infrastructure, funds, and reputation) to keep the Internet an open platform;')}}</li>
+    <li>{{_('promote models for creating economic value for the public benefit; and')}}</li>
+    <li>{{_('promote the Mozilla Manifesto principles in public discourse and within the Internet industry.')}}</li>
+  </ul>
+
+  <p>
+    {{_('Some Foundation activities—currently the creation, delivery and promotion of consumer products—are conducted primarily through the Mozilla Foundation’s wholly owned subsidiary, the Mozilla Corporation.')}}
+  </p>
+
+  <h3>{{_('Invitation')}}</h3>
+
+  <p>
+    {{_('The Mozilla Foundation invites all others who support the principles of the Mozilla Manifesto to join with us, and to find new ways to make this vision of the Internet a reality.')}}
+  </p>
+
+  {# Per-locale translation credits #}
+  {% if _('Translation provided by [localizer].') != 'Translation provided by [localizer].'  %}
+  <p class="credit small">{{ _('Translation provided by [localizer].') }}</p>
+  {% endif %}
+
 {% endblock %}

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -240,6 +240,9 @@ MINIFY_BUNDLES = {
             'js/libs/video-js/video-js.css',
             'js/libs/video-js/video-js-sandstone.css',
         ),
+        'manifesto': (
+            'css/mozorg/manifesto.less',
+        ),
         'marketplace': (
             'css/marketplace/marketplace.less',
         ),

--- a/etc/httpd/global.conf
+++ b/etc/httpd/global.conf
@@ -219,8 +219,10 @@ RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?about/history/$ /b/$1about/history/
 RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?about/bookmarks.html$ https://wiki.mozilla.org/Historical_Documents [L,R=301]
 RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?about/timeline.html$ https://wiki.mozilla.org/Timeline [L,R=301]
 
-# bug 861243
-RewriteRule ^/about/manifesto\.en\.html$ /en-US/about/manifesto/ [L,R=301]
+# bug 861243 and bug 869489
+# FUR locale temporarily staying on PHP site
+RewriteCond %{REQUEST_URI} !^/about/manifesto.fur.html$
+RewriteRule ^/about/manifesto\.(.*)\.html$ /$1/about/manifesto/ [L,R=301]
 RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?about/manifesto(/?)$ /b/$1about/manifesto$2 [PT]
 
 # bug 748503

--- a/media/css/mozorg/manifesto.less
+++ b/media/css/mozorg/manifesto.less
@@ -1,0 +1,13 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+@import "../sandstone/lib.less";
+
+#introduction {
+    clear: both;
+}
+
+.main-column .credit {
+    color: @textColorLight;
+}


### PR DESCRIPTION
The actual .lang files have been committed to SVN trunk in r116254 and r116256. This commit includes minor CSS/template adjustments, the rewrites for the new URLs, and the credits for locales that contained them.
