### PR TITLE
Cope with long language codes from ET

### DIFF
--- a/bedrock/newsletter/forms.py
+++ b/bedrock/newsletter/forms.py
@@ -134,7 +134,11 @@ class ManageSubscriptionsForm(forms.Form):
         # better option.
         if lang not in [x[0] for x in self.LANG_CHOICES]:
             name = get_lang_name(lang) or lang
-            self.fields['lang'].choices.append( (lang, name))
+            # note: .choices is a property, not actually a list, so
+            # xxx.choices.append(y) silently does nothing useful. Be
+            # more explicit:
+            self.fields['lang'].choices = \
+                self.fields['lang'].choices + [(lang, name)]
 
         self.already_subscribed = initial.get('newsletters', [])
 

--- a/bedrock/newsletter/tests/test_forms.py
+++ b/bedrock/newsletter/tests/test_forms.py
@@ -65,6 +65,22 @@ class TestManageSubscriptionsForm(TestCase):
         self.assertEqual('pt', form.initial['lang'])
         self.assertEqual('br', form.initial['country'])
 
+    def test_long_language(self):
+        # Suppose their selected language in ET is a long form ("es-ES")
+        # while we only have the short forms ("es") in our list of
+        # valid languages.  We should fake it - add es-ES to the choices
+        # so that it both shows up, and is selected by default.
+        locale = "es-ES"
+        form = ManageSubscriptionsForm(locale=locale,
+                                       initial={
+                                           'lang': 'es-ES',
+                                           'country': 'es',
+                                       })
+        # Initial value is 'es-ES'
+        self.assertEqual('es-ES', form.initial['lang'])
+        # es-ES is one of the valid choices for this field
+        self.assertIn('es-ES', [x[0] for x in form.fields['lang'].choices])
+
 
 class TestNewsletterForm(TestCase):
     @mock.patch('bedrock.newsletter.utils.get_newsletters')

--- a/bedrock/newsletter/tests/test_middleware.py
+++ b/bedrock/newsletter/tests/test_middleware.py
@@ -1,4 +1,5 @@
 from mock import patch
+from django.conf import settings
 from django.test import Client
 from funfactory.urlresolvers import reverse
 import l10n_utils
@@ -13,6 +14,7 @@ class TestNewsletterFooter(TestCase):
         self.view_name = 'firefox.fx'
         self.client = Client()
 
+    @patch.object(settings, 'DEV', True)
     def test_country_selected(self):
         """
         The correct country for the locale should be initially selected.
@@ -32,6 +34,7 @@ class TestNewsletterFooter(TestCase):
         doc = pq(resp.content)
         eq_(doc('#id_country option[selected="selected"]').val(), 'br')
 
+    @patch.object(settings, 'DEV', True)
     def test_language_selected(self):
         """
         The correct language for the locale should be initially selected or


### PR DESCRIPTION
Our internal list of newsletter languages is all 2-letter codes, like
'es'. But some of our users have language preferences set in ET to
longer codes, like 'es-ES'. This was not getting matched up and the
result was when they loaded the /existing page, the initial language
selected was whatever was first in the list, like Indonesian.
