### PR TITLE
Remove additional font weight for IE7/8

### DIFF
--- a/media/css/sandstone/fonts.less
+++ b/media/css/sandstone/fonts.less
@@ -15,17 +15,6 @@
 
 @font-face {
     font-family: 'Open Sans Light';
-    src: url('/media/fonts/OpenSans-Regular-webfont.eot');
-    src: url('/media/fonts/OpenSans-Regular-webfont.eot?#iefix') format('embedded-opentype'),
-         url('/media/fonts/OpenSans-Regular-webfont.woff') format('woff'),
-         url('/media/fonts/OpenSans-Regular-webfont.ttf') format('truetype'),
-         url('/media/fonts/OpenSans-Regular-webfont.svg#OpenSansRegular') format('svg');
-    font-weight: bold;
-    font-style: normal;
-}
-
-@font-face {
-    font-family: 'Open Sans Light';
     src: url('/media/fonts/OpenSans-LightItalic-webfont.eot');
     src: url('/media/fonts/OpenSans-LightItalic-webfont.eot?#iefix') format('embedded-opentype'),
          url('/media/fonts/OpenSans-LightItalic-webfont.woff') format('woff'),


### PR DESCRIPTION
Bug 876439

IE7/8 get confused when two @font-face declarations point to the same font file.

In our case, were were pointing the 'bold' weight of "Open Sans Light" at the same font files as the 'normal' weight of "Open Sans".

I'm going to remove that "bold" Open Sans Light and leave another in there that calls a set of SemiBold open sans files. This seems to fix the IE7/8 issue and still provides a 'real' bold variant for cases where the Open Sans Light font is bold.

We actually had two duplicate @font-face declarations for Open Sans Light at the bold font-weight anyhow (one pointing to Regular and one to the Semibold variant.
