### PR TITLE
Safer bin/jenkins.sh

### DIFF
--- a/bin/jenkins.sh
+++ b/bin/jenkins.sh
@@ -7,6 +7,10 @@
 # codebase.
 set -e
 
+if [ -z $WORKSPACE ] ; then
+  WORKSPACE=`/bin/pwd`
+fi
+
 cd $WORKSPACE
 VENV=$WORKSPACE/venv
 


### PR DESCRIPTION
If someone runs bin/jenkins.sh without first setting $WORKSPACE,
don't cd to their home directory and start rampaging around.
Just use the current directory.
