### PR TITLE
Disable firstrun A/B test URLs. Bug 877206.

### DIFF
--- a/bedrock/firefox/templates/firefox/firstrun.html
+++ b/bedrock/firefox/templates/firefox/firstrun.html
@@ -14,24 +14,6 @@
 {% block site_header_nav %}{% endblock %}
 {% block site_header_logo %}{% endblock %}
 
-{% block extrahead %}
-  {# GA experiment. Remove when experiment is over. #}
-  <!-- Google Analytics Content Experiment code -->
-  <script>function utmx_section(){}function utmx(){}(function(){var
-  k='71153379-20',d=document,l=d.location,c=d.cookie;
-  if(l.search.indexOf('utm_expid='+k)>0)return;
-  function f(n){if(c){var i=c.indexOf(n+'=');if(i>-1){var j=c.
-  indexOf(';',i);return escape(c.substring(i+n.length+1,j<0?c.
-  length:j))}}}var x=f('__utmx'),xx=f('__utmxx'),h=l.hash;d.write(
-  '<sc'+'ript src="'+'http'+(l.protocol=='https:'?'s://ssl':
-  '://www')+'.google-analytics.com/ga_exp.js?'+'utmxkey='+k+
-  '&utmx='+(x?x:'')+'&utmxx='+(xx?xx:'')+'&utmxtime='+new Date().
-  valueOf()+(h?'&utmxhash='+escape(h.substr(1)):'')+
-  '" type="text/javascript" charset="utf-8"><\/sc'+'ript>')})();
-  </script><script>utmx('url','A/B');</script>
-  <!-- End of Google Analytics Content Experiment code -->
-{% endblock %}
-
 {% block site_css %}
   {{ css('firefox_firstrun') }}
 {% endblock %}

--- a/bedrock/firefox/urls.py
+++ b/bedrock/firefox/urls.py
@@ -65,8 +65,10 @@ urlpatterns = patterns('',
         kwargs={'template_name': 'firefox/firstrun.html'}),
     url(whatsnew_re, views.latest_fx_redirect, name='firefox.whatsnew',
         kwargs={'template_name': 'firefox/whatsnew.html'}),
-    # firstrun tests. remove when experiment is over
-    url('^firefox/21.0/firstrun/(?P<view>[a|b])(?P<version>[1-6])/$', views.firstrun_new, name='firefox.firstrun.new'),
+    # firstrun tests
+    # temporarily disabled - will be used on demo server 2013-06
+    # remove when instructed by bug 877202
+    #url('^firefox/21.0/firstrun/(?P<view>[a|b])(?P<version>[1-6])/$', views.firstrun_new, name='firefox.firstrun.new'),
 
     url(r'^firefox/partners/$', views.firefox_partners,
         name='firefox.partners.index'),

--- a/etc/httpd/global.conf
+++ b/etc/httpd/global.conf
@@ -215,7 +215,9 @@ RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?mwc/?$ /$1firefox/partners/ [NC,L,R
 RewriteRule ^/en-US/firefox(/(?:\d+\.\d+\.?(?:\d+)?\.?(?:\d+)?(?:[a|b]?)(?:\d*)(?:pre)?(?:\d)?))?/firstrun(/?)$ /b/en-US/firefox$1/firstrun$2 [PT]
 
 # bug 865433
-RewriteRule ^/en-US/firefox(/(?:\d+\.\d+\.?(?:\d+)?\.?(?:\d+)?(?:[a|b]?)(?:\d*)(?:pre)?(?:\d)?))?/firstrun/([a|b])([1-6])(/?)$ /b/en-US/firefox$1/firstrun/$2$3$4 [PT]
+# temporarily disabled - will be used on demo server 2013-06
+# remove when prompted by bug 877202
+# RewriteRule ^/en-US/firefox(/(?:\d+\.\d+\.?(?:\d+)?\.?(?:\d+)?(?:[a|b]?)(?:\d*)(?:pre)?(?:\d)?))?/firstrun/([a|b])([1-6])(/?)$ /b/en-US/firefox$1/firstrun/$2$3$4 [PT]
 
 # bug 748503
 RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?projects/firefox/([^/]+)a[0-9]+/firstrun(.*)$ /$1firefox/nightly/firstrun$3 [L,R=301]


### PR DESCRIPTION
Temporarily disable firstrun A/B test URLs. Will be used
on demo server 2013-06.

Remove GA experiment code from base /firefox/firstrun/
page.
