### PR TITLE
Fix bug 877698: Redirect components trailing path.

### DIFF
--- a/etc/httpd/global.conf
+++ b/etc/httpd/global.conf
@@ -32,8 +32,8 @@ RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?about/drivers(\.html|/)?$ https://w
 # bug 856075
 RewriteRule ^/projects/technologies\.html$ https://developer.mozilla.org/docs/Mozilla/Using_Mozilla_code_in_other_projects [L,R=301]
 
-# bug 874526
-RewriteRule ^/projects/security/components/?$ http://www-archive.mozilla.org/projects/security/components/ [L,R=301]
+# bug 874526, 877698
+RewriteRule ^/projects/security/components(.*)$ http://www-archive.mozilla.org/projects/security/components$1 [L,R=301]
 
 
 


### PR DESCRIPTION
Rationale in [bug 877698](https://bugzilla.mozilla.org/show_bug.cgi?id=877698).
