### PR TITLE
[l10n] Bug 859537 - Fix CSS for slides on Russian (ru) Get Involved page 

### DIFF
--- a/media/css/mozorg/mozilla15.less
+++ b/media/css/mozorg/mozilla15.less
@@ -538,6 +538,11 @@
   }
 }
 
+/* Fact =02 Fixes for specific locales */
+.lang-ru #fact02 .message {
+  padding: 25px 105px 55px 35px;
+}
+
 @-webkit-keyframes fact02-logo-in {
   0% { top: -250px; }
   30% { top: 50px; }
@@ -1844,6 +1849,11 @@
       .base-animate-out;
     }
   }
+}
+
+/* Fact =14 Fixes for specific locales */
+.lang-ru #fact14 .message {
+  padding: 20px 50px 10px 30px;
 }
 
 /* Fact =15 - Thank you */


### PR DESCRIPTION
Added specific CSS rules to avoid text being displayed outside of the
background. See https://bugzilla.mozilla.org/show_bug.cgi?id=859537 for screenshots with this change applied.
