### PR TITLE
Bug 859537 - Add specific CSS rules for Russian slides

### DIFF
--- a/media/css/mozorg/mozilla15.less
+++ b/media/css/mozorg/mozilla15.less
@@ -538,6 +538,11 @@
   }
 }
 
+/* Fact =02 Fixes for specific locales */
+.lang-ru #fact02 .message {
+  padding: 25px 105px 55px 35px;
+}
+
 @-webkit-keyframes fact02-logo-in {
   0% { top: -250px; }
   30% { top: 50px; }
@@ -1844,6 +1849,11 @@
       .base-animate-out;
     }
   }
+}
+
+/* Fact =14 Fixes for specific locales */
+.lang-ru #fact14 .message {
+  padding: 20px 50px 10px 30px;
 }
 
 /* Fact =15 - Thank you */


### PR DESCRIPTION
Added specific CSS rules to avoid text being displayed outside of the
background on slide #2 and #14. See
https://bugzilla.mozilla.org/attachment.cgi?id=756382 for screenshots
with this change applied.
