### PR TITLE
Drop FUR manifesto rewrite exception (Bug 869489)

### DIFF
--- a/etc/httpd/global.conf
+++ b/etc/httpd/global.conf
@@ -238,9 +238,7 @@ RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?about/bookmarks.html$ https://wiki.
 RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?about/timeline.html$ https://wiki.mozilla.org/Timeline [L,R=301]
 
 # bug 861243 and bug 869489
-# FUR locale temporarily staying on PHP site
 RewriteRule ^/about/manifesto\.html$ /about/manifesto/ [L,R=301]
-RewriteCond %{REQUEST_URI} !^/about/manifesto.fur.html$
 RewriteRule ^/about/manifesto\.(.*)\.html$ /$1/about/manifesto/ [L,R=301]
 RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?about/manifesto(/?)$ /b/$1about/manifesto$2 [PT]
 


### PR DESCRIPTION
Based on a recommendation from @flodolo on Bug 869489, we're going to drop the FUR language manifesto as the locale is no longer maintained. The ported translation will remain in the .lang file and can be used if and when that locale is enabled on Bedrock.
