### PR TITLE
Redirect flicks pages firefoxflicks.mozilla.org

### DIFF
--- a/etc/httpd/global.conf
+++ b/etc/httpd/global.conf
@@ -231,6 +231,9 @@ RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?projects/firefox(/(?:\d+\.\d+\.?(?:
 # bug 845983
 RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?metrofirefox(/.*)? /$1firefox$2 [L,R=301]
 
+# bug 878926
+RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?firefoxflicks/?(.*) https://firefoxflicks.mozilla.org/$1$2 [L,R=301]
+
 # bug 849426
 RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?about/history(\.html)?$ /$1about/history/ [L,R=301]
 RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?about/history/$ /b/$1about/history/ [PT]


### PR DESCRIPTION
Bug 878926

This is an update of the more specific rule from the PHP/SVN mozilla.com .htaccess file that only redirected the home page(s). This rule also covers the /faq/ and /brief/ pages across all locales.
