### PR TITLE
Fix bug 874525: Redirect NSS/* and JSS/* to MDN.

### DIFF
--- a/etc/httpd/global.conf
+++ b/etc/httpd/global.conf
@@ -38,6 +38,10 @@ RewriteRule ^/projects/security/components(.*)$ http://www-archive.mozilla.org/p
 # bug 876889
 RewriteRule ^/projects/testopia/?$ https://developer.mozilla.org/docs/Mozilla/Bugzilla/Testopia [L,R=301]
 
+# bug 874525
+RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?projects/security/pki/nss.*$ https://developer.mozilla.org/docs/NSS [L,R=301]
+RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?projects/security/pki/jss.*$ https://developer.mozilla.org/docs/JSS [L,R=301]
+
 
 
 ## Redirect things to django!
@@ -250,10 +254,6 @@ RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?projects/toolkit(/?)$ https://devel
 
 # bug 877165
 RewriteRule ^(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?firefox/connect/?(?:index.html)?$ / [L,R=301]
-
-# bug 874525
-RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?projects/security/pki/nss(/?)$ https://developer.mozilla.org/docs/NSS [L,R=301]
-RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?projects/security/pki/jss(/?)$ https://developer.mozilla.org/docs/JSS [L,R=301]
 
 # bug 841846
 RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?firefox/nightly(/?)$ https://nightly.mozilla.org [L,R=302]


### PR DESCRIPTION
Commit 98b4668f redirected the NSS and JSS directories to MDN. This
commit additionally redirects the files and directories that live below
them to MDN.
