### PR TITLE
Bug 877165 - Remove/redirect /firefox/connect page

### DIFF
--- a/etc/httpd/global.conf
+++ b/etc/httpd/global.conf
@@ -253,7 +253,7 @@ RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?about/manifesto(/?)$ /b/$1about/man
 RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?projects/toolkit(/?)$ https://developer.mozilla.org/docs/Toolkit_API [L,R=301]
 
 # bug 877165
-RewriteRule ^(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?firefox/connect/?(?:index.html)?$ / [L,R=301]
+RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?firefox/connect.*$ / [L,R=301]
 
 # bug 841846
 RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?firefox/nightly(/?)$ https://nightly.mozilla.org [L,R=302]


### PR DESCRIPTION
The previous PR #925 was missing a leading slash.
