### PR TITLE
Bug 874982: All buttons should offer stub for enabled builds.

### DIFF
--- a/bedrock/firefox/templates/firefox/channel.html
+++ b/bedrock/firefox/templates/firefox/channel.html
@@ -30,7 +30,7 @@
       <h2 class="channel-title channel-title-beta"><img src="{{ media('/img/firefox/channel/title-beta.png') }}" alt="Firefox Beta" /></h2>
       <h3>The latest features in a more stable environment</h3>
       <div class="download-box" id="beta-desktop">
-        {{ download_firefox('beta', icon=False, small=True, force_stub_installer=True) }}
+        {{ download_firefox('beta', icon=False, small=True) }}
       </div>
       <div class="download-box mobile" id="beta-mobile">
         {{ download_firefox('beta', icon=False, mobile=True, small=True) }}

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -697,6 +697,16 @@ EMAIL_BACKEND = lazy(lazy_email_backend, str)()
 
 AURORA_STUB_INSTALLER = False
 
+# special value that means all locales are enabled.
+STUB_INSTALLER_ALL = '__ALL__'
+# values should be a list of lower case locales per platform for which a
+# stub installer is available. Hopefully this can all be moved to bouncer.
+STUB_INSTALLER_LOCALES = {
+    'win': STUB_INSTALLER_ALL,
+    'osx': [],
+    'linux': [],
+}
+
 # Google Analytics
 GA_ACCOUNT_CODE = ''
 


### PR DESCRIPTION
This is the final version. Check the bug conversation for the requested spec.
