### PR TITLE
Bug 865376 - "Other languages" link on firefox/all/ downloads goes to nothing

### DIFF
--- a/bedrock/firefox/templates/firefox/all.html
+++ b/bedrock/firefox/templates/firefox/all.html
@@ -41,10 +41,12 @@
       </datalist>
       <button class="button arrow" type="submit"><span>{{ _('Search') }}</span></button>
     </div>
-    <div class="other-column">
-      <h4>{{ _('Other Firefox downloads') }}</h4>
-      <a href="#localized-testing">{{ _('New languages still in beta') }}</a>
-    </div>
+    {% if test_builds %}
+      <div class="other-column">
+        <h4>{{ _('Other Firefox downloads') }}</h4>
+        <a href="#localized-testing">{{ _('New languages still in beta') }}</a>
+      </div>
+    {% endif %}
   </form>
 
   <div id="main-content">
@@ -53,11 +55,13 @@
                       _('Fully localized versions')) }}
     </div>
 
-    <div id="localized-testing">
-      {{ build_table(test_builds,
-                      _('Localized versions in testing'),
-                      _('These localizations aren’t final. We’re waiting for more feedback from the community to perfect them.')) }}
-    </div>
+    {% if test_builds %}
+      <div id="localized-testing">
+        {{ build_table(test_builds,
+                        _('Localized versions in testing'),
+                        _('These localizations aren’t final. We’re waiting for more feedback from the community to perfect them.')) }}
+      </div>
+    {% endif %}
   </div>
 {% endblock %}
 


### PR DESCRIPTION
Simply hide the localized-testing section when no test builds are available.
