### PR TITLE
Bug 880002 Add Link to Partnerships page in bedrock footer

### DIFF
--- a/bedrock/base/templates/base-resp.html
+++ b/bedrock/base/templates/base-resp.html
@@ -95,11 +95,11 @@
           </div>
           <ul class="footer-nav">
             <li><a href="{{ php_url('/about/contact.html#map-mountain_view') }}">{{_('Contact Us')}}</a></li>
+            <li><a href="{{ url('mozorg.partnerships') }}">{{_('Partner with Us')}}</a></li>
             <li><a href="{{ url('privacy.index') }}">{{_('Privacy Policy')}}</a></li>
             <li><a href="{{ php_url('/about/legal.html') }}">{{_('Legal Notices')}}</a></li>
             <li><a href="{{ php_url('/legal/fraud-report/index.html') }}">{{_('Report Trademark Abuse')}}</a></li>
-          </ul>
-
+          </ul>  
           {% block social %}
           <ul class="footer-nav">
             <li><a href="http://twitter.com/firefox">{{_('Twitter')}}</a></li>


### PR DESCRIPTION
This adds a link to the partnerships page in bedrock
