### PR TITLE
Fix redirects for governance pages (Bug 860532)

### DIFF
--- a/bedrock/redirects/urls.py
+++ b/bedrock/redirects/urls.py
@@ -75,9 +75,4 @@ urlpatterns = patterns('',
 
     # Bug 867773 - Redirect the Persona "Developer FAQ" link to MDN
     redirect(r'^persona/developer-faq/$', 'https://developer.mozilla.org/persona'),
-
-    #Bug 860532- migrate governance, roles, and organizations to bedrock
-    redirect(r'^about/governance.html$', '/about/governance/'),
-    redirect(r'^about/roles.html$', '/about/governance/roles/'),
-    redirect(r'^about/organizations.html', '/about/governance/organizations/')
 )

--- a/etc/httpd/global.conf
+++ b/etc/httpd/global.conf
@@ -270,6 +270,12 @@ RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?firefox/nightly/firstrun(.*)$ /b/$1
 RewriteRule  ^/en-US/newsletter/existing(.*)$ /b/en-US/newsletter/existing$1 [PT]
 RewriteRule  ^/en-US/newsletter/updated(.*)$ /b/en-US/newsletter/updated$1 [PT]
 
+# bug 860532 - Reidrects for governance pages
+RewriteRule ^/about/governance\.html$ /about/governance/ [L,R=301]
+RewriteRule ^/about/roles\.html$ /about/governance/roles/ [L,R=301]
+RewriteRule ^/about/organizations\.html$ /about/governance/organizations/ [L,R=301]
+RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?about/governance(.*)$ /b/$1about/governance$2 [PT]
+
 # bug 724633 - Porting foundation pages
 # Add redirects for the pdfs that were under /foundation/documents/
 # that will now be served from static.mozilla.com/foundation/documents/


### PR DESCRIPTION
To atone for prematurely committing PR #836, I've updated the redirects for that PR.

The redirects have been moved from urls.py into global.conf, and a /b pass-through has been added.

I can't test the /b passthrough - but I think this should work (a single /b redirect for /about/governance\* after the other redirects from the old .html URLs).
