### PR TITLE
Bug 846362 - Redirect /community pages to /contribute

### DIFF
--- a/etc/httpd/global.conf
+++ b/etc/httpd/global.conf
@@ -169,6 +169,10 @@ RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?firefoxos(.*)$ /$1firefox/partners/
 # bug 797337
 RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?contribute/areas.html$ /b/$1contribute/areas.html [PT]
 
+# bug 846362
+RewriteRule ^/community/index.(de|fr|hr|sq).html$ /contribute/ [L,R=301]
+RewriteRule ^/community/(index.html)?$ /contribute/ [L,R=301]
+
 # bug 798453
 RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?firefox/installer-help(.*)$ /b/$1firefox/installer-help$2 [PT]
 


### PR DESCRIPTION
Redirect the following URLs to /contribute

http://www.mozilla.org/community/
http://www.mozilla.org/community/index.fr.html
http://www.mozilla.org/community/index.de.html
http://www.mozilla.org/community/index.hr.html
http://www.mozilla.org/community/index.sq.html

Didn't use a more broad regex because there are some other pages still living in the /community/ dir that aren't ported/redirected yet.
