### PR TITLE
Bug 880182 - /ja-JP-mac/ should be redirected to /ja/

### DIFF
--- a/etc/httpd/global.conf
+++ b/etc/httpd/global.conf
@@ -12,6 +12,9 @@ ExpiresActive on
 RewriteCond %{HTTP_HOST} ^(.*)\.$
 RewriteRule ^(.*)$ $1 [L,R=301]
 
+# bug 880182
+RewriteRule ^/ja-JP-mac(/.*)? /ja$1 [L,R=301]
+
 # bug 764261, 841393
 RewriteRule ^/zh-TW/$ http://mozilla.com.tw/ [L,R=301]
 RewriteCond %{REQUEST_URI} !^/zh-TW/firefox/partners
@@ -27,10 +30,10 @@ RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?home/?$ /$1firefox/ [L,R=301]
 RewriteRule ^/zh-CN/$ http://firefox.com.cn/ [L,R=301]
 
 #bug 857246 redirect /products/firefox/start/  to start.mozilla.org
-RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?products/firefox/start(/?)$ http://start.mozilla.org [L,R=301]
+RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?products/firefox/start(/?)$ http://start.mozilla.org [L,R=301]
 
 #bug 856081 redirect /about/drivers https://wiki.mozilla.org/Firefox/Drivers
-RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?about/drivers(\.html|/)?$ https://wiki.mozilla.org/Firefox/Drivers [L,R=301]
+RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?about/drivers(\.html|/)?$ https://wiki.mozilla.org/Firefox/Drivers [L,R=301]
 
 # bug 856075
 RewriteRule ^/projects/technologies\.html$ https://developer.mozilla.org/docs/Mozilla/Using_Mozilla_code_in_other_projects [L,R=301]
@@ -42,8 +45,8 @@ RewriteRule ^/projects/security/components(.*)$ http://www-archive.mozilla.org/p
 RewriteRule ^/projects/testopia/?$ https://developer.mozilla.org/docs/Mozilla/Bugzilla/Testopia [L,R=301]
 
 # bug 874525
-RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?projects/security/pki/nss.*$ https://developer.mozilla.org/docs/NSS [L,R=301]
-RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?projects/security/pki/jss.*$ https://developer.mozilla.org/docs/JSS [L,R=301]
+RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?projects/security/pki/nss.*$ https://developer.mozilla.org/docs/NSS [L,R=301]
+RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?projects/security/pki/jss.*$ https://developer.mozilla.org/docs/JSS [L,R=301]
 
 ## Redirect things to django!
 
@@ -51,63 +54,63 @@ RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?projects/security/pki/jss.*$ https:
 RewriteRule ^/en-US/plugincheck(/?)$ /b/en-US/plugincheck$1 [PT]
 
 # bug 835506
-RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?facebookapps/(.*)?$ /b/$1facebookapps/$2 [PT]
+RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?facebookapps/(.*)?$ /b/$1facebookapps/$2 [PT]
 
 # bug 854561
-RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?projects/mozilla-based(\.html|/)?$ /$1about/mozilla-based/ [L,R=301]
-RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?about/mozilla-based(/?)$ /b/$1about/mozilla-based$2 [PT]
+RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?projects/mozilla-based(\.html|/)?$ /$1about/mozilla-based/ [L,R=301]
+RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?about/mozilla-based(/?)$ /b/$1about/mozilla-based$2 [PT]
 
 # bug 851727
-RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?projects/powered-by(\.html|/)?$ /$1about/powered-by/ [L,R=301]
-RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?about/powered-by(/?)$ /b/$1about/powered-by$2 [PT]
+RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?projects/powered-by(\.html|/)?$ /$1about/powered-by/ [L,R=301]
+RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?about/powered-by(/?)$ /b/$1about/powered-by$2 [PT]
 
 # bug 837883
-RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?firefox/firefox\.exe$ /$1 [NC,L,R=301]
+RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/firefox\.exe$ /$1 [NC,L,R=301]
 
 # bug 815908
-RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?newsletter/hacks\.mozilla\.org(/?)$ /b/$1newsletter/hacks.mozilla.org$2 [PT]
+RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?newsletter/hacks\.mozilla\.org(/?)$ /b/$1newsletter/hacks.mozilla.org$2 [PT]
 
 # bug 821006
-RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?firefox/all(\.html)?$ /$1firefox/all/ [L,R=301]
-RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?firefox/all/$ /b/$1firefox/all/ [PT]
+RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/all(\.html)?$ /$1firefox/all/ [L,R=301]
+RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/all/$ /b/$1firefox/all/ [PT]
 
 # bug 803345
-RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?apps(.*)$ /b/$1apps$2 [PT]
+RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?apps(.*)$ /b/$1apps$2 [PT]
 
-RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?persona(.*)$ /b/$1persona$2 [PT]
-RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?b2g(.*)$ /b/$1b2g$2 [PT]
-RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?collusion(.*)$ /b/$1collusion$2 [PT]
+RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?persona(.*)$ /b/$1persona$2 [PT]
+RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?b2g(.*)$ /b/$1b2g$2 [PT]
+RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?collusion(.*)$ /b/$1collusion$2 [PT]
 
 # bug 882845
-RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?firefox/toolkit/download-to-your-devices(.*)$ /$1firefox/ [L,R=301]
+RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/toolkit/download-to-your-devices(.*)$ /$1firefox/ [L,R=301]
 
 RewriteRule ^/en-US(/?)$ /b/en-US$1 [PT]
 
 # bug 822260
-RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?about/mission.html$ /b/$1about/mission.html [PT]
+RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?about/mission.html$ /b/$1about/mission.html [PT]
 
 RewriteRule ^/en-US/about(/?)?$ /b/en-US/about$1 [PT]
 RewriteRule ^/en-US/about/partnerships(/?)$ /b/en-US/about/partnerships$1 [PT]
 RewriteRule ^/en-US/about/partnerships/distribution(/?)$ /b/en-US/about/partnerships/distribution$1 [PT]
-RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?mission(/?)$ /b/$1mission$2 [PT]
+RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?mission(/?)$ /b/$1mission$2 [PT]
 
 # bug 843789
-RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?about/partnerships/contact-bizdev(/?)$ /b/$1about/partnerships/contact-bizdev$2 [PT]
+RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?about/partnerships/contact-bizdev(/?)$ /b/$1about/partnerships/contact-bizdev$2 [PT]
 
 # bug 793754
-RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?contribute(/?)$ /b/$1contribute$2 [PT]
-RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?contribute/page(/?)$ /b/$1contribute/page$2 [PT]
+RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?contribute(/?)$ /b/$1contribute$2 [PT]
+RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?contribute/page(/?)$ /b/$1contribute/page$2 [PT]
 
 # bug 807155
-RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?contribute/embed(/?)$ /b/$1contribute/embed$2 [PT]
+RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?contribute/embed(/?)$ /b/$1contribute/embed$2 [PT]
 
 # bug 787953
-RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?contribute/event(.*)$ /b/$1contribute/event$2 [PT]
+RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?contribute/event(.*)$ /b/$1contribute/event$2 [PT]
 
 # bug 859564
-RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?contribute/universityambassadors(.*)$ /b/$1contribute/universityambassadors$2 [PT]
+RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?contribute/universityambassadors(.*)$ /b/$1contribute/universityambassadors$2 [PT]
 
-RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?projects(/?)$ /b/$1projects$2 [PT]
+RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?projects(/?)$ /b/$1projects$2 [PT]
 
 RewriteRule ^/en-US/firefox/new(/?)$ /b/en-US/firefox/new$1 [PT]
 RewriteRule ^/en-US/firefox/fx(/?)$ /b/en-US/firefox/fx$1 [PT]
@@ -130,104 +133,104 @@ RewriteRule ^/en-US/firefox/channel(/?)$ /b/en-US/firefox/channel$1 [PT]
 RewriteRule ^/es-ES/firefox/new(/?)$ /b/es-ES/firefox/new$1 [PT]
 
 # bug 796952
-RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?firefox/unsupported/(.*)$ /b/$1firefox/unsupported/$2 [PT]
+RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/unsupported/(.*)$ /b/$1firefox/unsupported/$2 [PT]
 
 # bug 757117
-RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?webmaker(.*)$ /b/$1webmaker$2 [PT]
+RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?webmaker(.*)$ /b/$1webmaker$2 [PT]
 
 # bug 760194
-RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?dnt(.*)$ /b/$1dnt$2 [PT]
+RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?dnt(.*)$ /b/$1dnt$2 [PT]
 
 # bug 767614
 RewriteRule ^/en-US/mobile(/?)$ /b/en-US/mobile$1 [PT]
-RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?firefox/mobile/features(/?)$ /b/$1firefox/mobile/features$2 [PT]
-RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?firefox/mobile/faq(/?)$ /b/$1firefox/mobile/faq$2 [PT]
-RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?firefox/mobile/platforms(/?)$ /b/$1firefox/mobile/platforms$2 [PT]
+RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/mobile/features(/?)$ /b/$1firefox/mobile/features$2 [PT]
+RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/mobile/faq(/?)$ /b/$1firefox/mobile/faq$2 [PT]
+RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/mobile/platforms(/?)$ /b/$1firefox/mobile/platforms$2 [PT]
 
 # bug 876668
-RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?mobile/customize(?:/.*)?$ /$1firefox/mobile/features/ [L,R=301]
+RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?mobile/customize(?:/.*)?$ /$1firefox/mobile/features/ [L,R=301]
 
 # bug 773739
-RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?products(/?)$ /b/$1products$2 [PT]
-RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?firefox(/(?:\d+\.\d+\.?(?:\d+)?\.?(?:\d+)?(?:[a|b]?)(?:\d*)(?:pre)?(?:\d)?))?/whatsnew(/?)$ /b/$1firefox$2/whatsnew$3 [PT]
+RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?products(/?)$ /b/$1products$2 [PT]
+RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox(/(?:\d+\.\d+\.?(?:\d+)?\.?(?:\d+)?(?:[a|b]?)(?:\d*)(?:pre)?(?:\d)?))?/whatsnew(/?)$ /b/$1firefox$2/whatsnew$3 [PT]
 
 # bug 778752
 RewriteRule ^/en-US/firefox/channel/android(/?)$ /b/en-US/firefox/channel/android$1 [PT]
 
 # bug 784737
-RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?firefox/memory(.*)$ /b/$1firefox/memory$2 [PT]
+RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/memory(.*)$ /b/$1firefox/memory$2 [PT]
 
-RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?styleguide(.*)$ /b/$1styleguide$2 [PT]
+RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?styleguide(.*)$ /b/$1styleguide$2 [PT]
 
-RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?firefox/sms(.*)$ /b/$1firefox/sms$2 [PT]
+RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/sms(.*)$ /b/$1firefox/sms$2 [PT]
 
-RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?grants(.*)$ /b/$1grants$2 [PT] # bug 793181
+RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?grants(.*)$ /b/$1grants$2 [PT] # bug 793181
 
 # request to ensure https is present for pluginchecks bug 795291
 RewriteCond %{ENV:HTTPS} !on
 RewriteRule ^/.*/plugincheck/ https://%{SERVER_NAME}%{REQUEST_URI} [L,R=301]
 
 # bug 797236, 839678
-RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?firefoxos(.*)$ /$1firefox/partners/#os [NE,L,R=301]
+RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefoxos(.*)$ /$1firefox/partners/#os [NE,L,R=301]
 
 # bug 797337
-RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?contribute/areas.html$ /b/$1contribute/areas.html [PT]
+RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?contribute/areas.html$ /b/$1contribute/areas.html [PT]
 
 # bug 846362
 RewriteRule ^/community/index.(de|fr|hr|sq).html$ /contribute/ [L,R=301]
 RewriteRule ^/community/(index.html)?$ /contribute/ [L,R=301]
 
 # bug 798453
-RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?firefox/installer-help(.*)$ /b/$1firefox/installer-help$2 [PT]
+RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/installer-help(.*)$ /b/$1firefox/installer-help$2 [PT]
 
 # bug 801705
-RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?gameon(.*)$ /b/$1gameon$2 [PT]
+RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?gameon(.*)$ /b/$1gameon$2 [PT]
 
 # bug 799767
-RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?book(.*)$ /b/$1book$2 [PT]
+RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?book(.*)$ /b/$1book$2 [PT]
 
 # bug 800461
-RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?firefox/brand(.*)$ /b/$1firefox/brand$2 [PT]
+RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/brand(.*)$ /b/$1firefox/brand$2 [PT]
 
 # bug 800649
-RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?privacy/policies/facebook(.*)$ /b/$1privacy/policies/facebook$2 [PT]
+RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?privacy/policies/facebook(.*)$ /b/$1privacy/policies/facebook$2 [PT]
 
 # bug 820212
-RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?privacy/firefox-os/?$ /$1privacy/policies/firefox-os/ [L,R=301]
-RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?privacy/policies/firefox-os(.*)$ /b/$1privacy/policies/firefox-os$2 [PT]
+RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?privacy/firefox-os/?$ /$1privacy/policies/firefox-os/ [L,R=301]
+RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?privacy/policies/firefox-os(.*)$ /b/$1privacy/policies/firefox-os$2 [PT]
 
 # bug 807323
-RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?foundation/identity-guidelines(.*)$ /b/$1foundation/identity-guidelines$2 [PT]
+RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?foundation/identity-guidelines(.*)$ /b/$1foundation/identity-guidelines$2 [PT]
 
 # bug 809426
-RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?legal/eula(/?)$ /b/$1legal/eula$2 [PT]
+RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?legal/eula(/?)$ /b/$1legal/eula$2 [PT]
 
 # bug 811787
-RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?foundation/annualreport/2011(.*)$ /b/$1foundation/annualreport/2011$2 [PT]
+RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?foundation/annualreport/2011(.*)$ /b/$1foundation/annualreport/2011$2 [PT]
 
 # bug 816249
-RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?privacy(/?)$ /b/$1privacy$2 [PT]
+RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?privacy(/?)$ /b/$1privacy$2 [PT]
 
 # bug 815731 /ITU/
-RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?ITU(.*)$ /b/$1ITU$2 [PT]
+RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?ITU(.*)$ /b/$1ITU$2 [PT]
 
 # bug 821838
-RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?tabzilla/(.*)$ /b/$1tabzilla/$2 [PT]
+RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?tabzilla/(.*)$ /b/$1tabzilla/$2 [PT]
 
 # bug 821937
-RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?m/privacy.html$ /b/$1m/privacy.html [PT]
+RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?m/privacy.html$ /b/$1m/privacy.html [PT]
 
 # bug 683375
-RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?research(.*)$ /b/$1research$2 [PT]
+RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?research(.*)$ /b/$1research$2 [PT]
 
 # bug 822817
 RewriteRule ^/telemetry/?$ /b/telemetry/ [PT]
 
 # bug 829091
-RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?firefox/partners(.*)$ /b/$1firefox/partners$2 [PT]
+RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/partners(.*)$ /b/$1firefox/partners$2 [PT]
 
 # bug 831810
-RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?mwc/?$ /$1firefox/partners/ [NC,L,R=301]
+RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?mwc/?$ /$1firefox/partners/ [NC,L,R=301]
 
 # bug 833645
 RewriteRule ^/en-US/firefox(/(?:\d+\.\d+\.?(?:\d+)?\.?(?:\d+)?(?:[a|b]?)(?:\d*)(?:pre)?(?:\d)?))?/firstrun(/?)$ /b/en-US/firefox$1/firstrun$2 [PT]
@@ -238,43 +241,43 @@ RewriteRule ^/en-US/firefox(/(?:\d+\.\d+\.?(?:\d+)?\.?(?:\d+)?(?:[a|b]?)(?:\d*)(
 # RewriteRule ^/en-US/firefox(/(?:\d+\.\d+\.?(?:\d+)?\.?(?:\d+)?(?:[a|b]?)(?:\d*)(?:pre)?(?:\d)?))?/firstrun/([a|b])([1-6])(/?)$ /b/en-US/firefox$1/firstrun/$2$3$4 [PT]
 
 # bug 748503
-RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?projects/firefox/([^/]+)a[0-9]+/(firstrun|whatsnew)(.*)$ /$1firefox/nightly/firstrun$4 [L,R=301]
-RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?firefox/nightly/firstrun(.*)$ /b/$1firefox/nightly/firstrun$2 [PT]
+RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?projects/firefox/([^/]+)a[0-9]+/(firstrun|whatsnew)(.*)$ /$1firefox/nightly/firstrun$4 [L,R=301]
+RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/nightly/firstrun(.*)$ /b/$1firefox/nightly/firstrun$2 [PT]
 
 # bug 840814
-RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?projects/firefox(/(?:\d+\.\d+\.?(?:\d+)?\.?(?:\d+)?(?:[a|b]?)(?:\d*)(?:pre)?(?:\d)?))(/(?:firstrun|whatsnew))(/.*)?$ /$1firefox$2$3$4 [L,R=301]
+RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?projects/firefox(/(?:\d+\.\d+\.?(?:\d+)?\.?(?:\d+)?(?:[a|b]?)(?:\d*)(?:pre)?(?:\d)?))(/(?:firstrun|whatsnew))(/.*)?$ /$1firefox$2$3$4 [L,R=301]
 
 # bug 845983
-RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?metrofirefox(/.*)? /$1firefox$2 [L,R=301]
+RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?metrofirefox(/.*)? /$1firefox$2 [L,R=301]
 
 # bug 878926
-RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?firefoxflicks/?(.*) https://firefoxflicks.mozilla.org/$1$2 [L,R=301]
+RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefoxflicks/?(.*) https://firefoxflicks.mozilla.org/$1$2 [L,R=301]
 
 # bug 849426
-RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?about/history(\.html)?$ /$1about/history/ [L,R=301]
-RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?about/history/$ /b/$1about/history/ [PT]
-RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?about/bookmarks.html$ https://wiki.mozilla.org/Historical_Documents [L,R=301]
-RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?about/timeline.html$ https://wiki.mozilla.org/Timeline [L,R=301]
+RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?about/history(\.html)?$ /$1about/history/ [L,R=301]
+RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?about/history/$ /b/$1about/history/ [PT]
+RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?about/bookmarks.html$ https://wiki.mozilla.org/Historical_Documents [L,R=301]
+RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?about/timeline.html$ https://wiki.mozilla.org/Timeline [L,R=301]
 
 # bug 861243 and bug 869489
 RewriteRule ^/about/manifesto\.html$ /about/manifesto/ [L,R=301]
 RewriteRule ^/about/manifesto\.(.*)\.html$ /$1/about/manifesto/ [L,R=301]
-RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?about/manifesto(/?)$ /b/$1about/manifesto$2 [PT]
+RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?about/manifesto(/?)$ /b/$1about/manifesto$2 [PT]
 
 # bug 856077
-RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?projects/toolkit(/?)$ https://developer.mozilla.org/docs/Toolkit_API [L,R=301]
+RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?projects/toolkit(/?)$ https://developer.mozilla.org/docs/Toolkit_API [L,R=301]
 
 # bug 877165
-RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?firefox/connect.*$ / [L,R=301]
+RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/connect.*$ / [L,R=301]
 
 # bug 657049
 RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/accountmanager/?$ /$1persona/ [L,R=301]
 
 # bug 841846
-RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?firefox/nightly(/?)$ https://nightly.mozilla.org [L,R=302]
+RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/nightly(/?)$ https://nightly.mozilla.org [L,R=302]
 
 # bug 748503
-RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?firefox/nightly/firstrun(.*)$ /b/$1firefox/nightly/firstrun$2 [PT]
+RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/nightly/firstrun(.*)$ /b/$1firefox/nightly/firstrun$2 [PT]
 
 # Bug 845904 - /newsletter/existing and /newsletter/updated served from bedrock
 # en-US only until translations are done.
@@ -285,7 +288,7 @@ RewriteRule  ^/en-US/newsletter/updated(.*)$ /b/en-US/newsletter/updated$1 [PT]
 RewriteRule ^/about/governance\.html$ /about/governance/ [L,R=301]
 RewriteRule ^/about/roles\.html$ /about/governance/roles/ [L,R=301]
 RewriteRule ^/about/organizations\.html$ /about/governance/organizations/ [L,R=301]
-RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?about/governance(.*)$ /b/$1about/governance$2 [PT]
+RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?about/governance(.*)$ /b/$1about/governance$2 [PT]
 
 # bug 724633 - Porting foundation pages
 # Add redirects for the pdfs that were under /foundation/documents/
@@ -293,27 +296,27 @@ RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?about/governance(.*)$ /b/$1about/go
 # (The links within the foundation pages have been updated, but there are
 # probably many links to them from other pages and sites that need to keep
 # working.)
-RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?foundation/documents/([^/]+).pdf$ https://static.mozilla.com/foundation/documents/$2.pdf [NC,L,R=301]
+RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?foundation/documents/([^/]+).pdf$ https://static.mozilla.com/foundation/documents/$2.pdf [NC,L,R=301]
 
 # openwebfund/ and openwebfund/index.html redirect to another site.  Careful because
 # there are other pages under openwebfund that still need to be served from Bedrock.
-RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?foundation/openwebfund/(index.html)?$ https://sendto.mozilla.org/page/contribute/join-mozilla?source=owf_redirect [NC,L,R=301]
-RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?foundation/donate\.html$ https://sendto.mozilla.org/page/contribute/openwebfund [NC,L,R=301]
+RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?foundation/openwebfund/(index.html)?$ https://sendto.mozilla.org/page/contribute/join-mozilla?source=owf_redirect [NC,L,R=301]
+RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?foundation/donate\.html$ https://sendto.mozilla.org/page/contribute/openwebfund [NC,L,R=301]
 
 # FIXUPs for changing foo/index.html to foo/, and foo/bar.html to foo/bar/
 # Redirect foundation/index.html -> foundation/
-RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?foundation/index.html$ /$1foundation/ [NC,L,R=301]
+RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?foundation/index.html$ /$1foundation/ [NC,L,R=301]
 # Redirect foundation/foo/bar/index.html -> foundation/foo/bar
-RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?foundation/(.*)/index.html$ /$1foundation/$2/ [NC,L,R=301]
+RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?foundation/(.*)/index.html$ /$1foundation/$2/ [NC,L,R=301]
 # Redirect foundation/foo.html to foundation/foo/, with a redirect for the nice search engines
-RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?foundation/(about|careers|licensing|moco|mocosc).html$ /$1foundation/$2/ [NC,L,R=301]
+RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?foundation/(about|careers|licensing|moco|mocosc).html$ /$1foundation/$2/ [NC,L,R=301]
 # Redirect foundation/anything/foo.html to foundation/anything/foo/, with a redirect for the nice search engines
-RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?foundation/((annualreport|documents|feed-icon-guidelines|licensing|openwebfund|trademarks)/.*).html$ /$1foundation/$2/ [NC,L,R=301]
-RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?foundation/documents/(index|mozilla-200.-financial-faq).html$ /$1foundation/$2/ [NC,L,R=301]
+RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?foundation/((annualreport|documents|feed-icon-guidelines|licensing|openwebfund|trademarks)/.*).html$ /$1foundation/$2/ [NC,L,R=301]
+RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?foundation/documents/(index|mozilla-200.-financial-faq).html$ /$1foundation/$2/ [NC,L,R=301]
 
 # Add /b to all foundation URLs to serve them from Bedrock.
 # (The old foundation pages had no locale in the URL.
 # But when the rewritten locale-less URLs hit Bedrock, Bedrock will return
 # a redirect with the locale added. So we need to make sure both kinds of
 # URL end up in Bedrock.)
-RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?foundation(/.*)?$ /b/$1foundation$2 [PT]
+RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?foundation(/.*)?$ /b/$1foundation$2 [PT]


### PR DESCRIPTION
Removed `(?:-mac)?` as it's no longer needed
