### PR TITLE
Bug 657049 - [404] http://www.mozilla.com/en-US/firefox/accountmanager/

### DIFF
--- a/etc/httpd/global.conf
+++ b/etc/httpd/global.conf
@@ -259,6 +259,9 @@ RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?projects/toolkit(/?)$ https://devel
 # bug 877165
 RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?firefox/connect.*$ / [L,R=301]
 
+# bug 657049
+RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/accountmanager/?$ /$1persona/ [L,R=301]
+
 # bug 841846
 RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?firefox/nightly(/?)$ https://nightly.mozilla.org [L,R=302]
 


### PR DESCRIPTION
I have omitted `(?:-mac)?` because #985 will remove it anyway.
