### PR TITLE
Bug 773371 - [bedrock] Integrate Language Selector for M.o

### DIFF
--- a/bedrock/base/templates/base-resp.html
+++ b/bedrock/base/templates/base-resp.html
@@ -120,6 +120,11 @@
             <li><a href="https://affiliates.mozilla.org/">{{_('Firefox Affiliates')}}</a></li>
           </ul>
           {% endblock %}
+          {% block lang_switcher %}
+          <div class="footer-lang">
+            {% include 'includes/lang_switcher.html' %}
+          </div>
+          {% endblock %}
 
       </div>
       </footer>

--- a/bedrock/base/templates/includes/lang_switcher.html
+++ b/bedrock/base/templates/includes/lang_switcher.html
@@ -2,16 +2,18 @@
  # License, v. 2.0. If a copy of the MPL was not distributed with this
  # file, You can obtain one at http://mozilla.org/MPL/2.0/. #}
 
+{% if translations|length > 1 %}
 <form id="lang_form" dir="ltr" method="get" action="">
   <label for="language">{{ _('Other languages:') }}</label>
-  <select id="language" name="lang" dir="ltr" onchange="this.form.submit()">
-    {% for code, name in LANGUAGES|dictsort -%}
-      <option value="{{ code }}" {{ code|ifeq(LANG|lower, "selected") }}>
-        {{ name }}
-      </option>
-    {%- endfor %}
+  <select id="language" name="lang" dir="ltr">
+    {% for code, label in translations|dictsort -%}
+      {# Don't escape the label as it may include entity references
+       # like "Português (do&nbsp;Brasil)" (Bug 861149) #}
+      <option value="{{ code }}"{{ code|ifeq(LANG, " selected") }}>{{ label|safe }}</option>
+    {% endfor %}
   </select>
   <noscript>
     <button type="submit">{{ _('Go') }}</button>
   </noscript>
 </form>
+{% endif %}

--- a/media/css/sandstone/sandstone-resp.less
+++ b/media/css/sandstone/sandstone-resp.less
@@ -801,16 +801,14 @@ nav.menu-bar {
         margin: 0 (@gridGutterWidth / 2);
     }
 
-    .footer-logo {
-        .span(4);
-    }
-
-    .footer-license {
-        .span(3);
-    }
-
+    .footer-logo,
     .footer-nav {
         .span(2);
+    }
+
+    .footer-license,
+    .footer-lang {
+        .span(3);
     }
 
     a,
@@ -891,16 +889,21 @@ nav.menu-bar {
         .row {
             width: @widthTablet - (@gridGutterWidth * 2);
         }
-        .footer-logo {
-            .span_narrow(4);
-        }
-        .footer-license {
-            .span_narrow(3);
-        }
-        .footer-nav {
-            .span_narrow(2);
+
+        .footer-logo,
+        .footer-license,
+        .footer-lang {
+            .span(2.5);
         }
 
+        .footer-nav {
+            .span(2);
+        }
+
+        .footer-logo {
+            float: none;
+            margin-bottom: @baseLine;
+        }
     }
 
 }
@@ -1059,9 +1062,6 @@ nav.menu-bar {
         .footer-nav {
             width: auto;
             float: none;
-        }
-        .footer-logo,
-        .footer-license {
             margin-bottom: @baseLine;
         }
     }

--- a/media/js/base/global.js
+++ b/media/js/base/global.js
@@ -32,10 +32,23 @@ function init_download_links() {
     $('.download-list').attr('role', 'presentation');
 }
 
+// language switcher
+
+function init_lang_switcher() {
+    $('#language').change(function(event) {
+        event.preventDefault();
+        gaTrack(
+            ['_trackEvent', 'Language Switcher', 'change', $(this).val()],
+            function() {$('#lang_form').submit();}
+        );
+    });
+}
+
 // init
 
 $(document).ready(function() {
     init_download_links();
+    init_lang_switcher();
     $(window).on('load', function () {
         $('html').addClass('loaded');
     });


### PR DESCRIPTION
Implemented a simple language switcher with a **list of all available translations of the current page**.
The `translations` variable can be used for other purposes like a universal language selector or `rel="alternate" hreflang="x"` (Bug 875293).
