### PR TITLE
Redirect /about/index.* files for Bug 885848

### DIFF
--- a/etc/httpd/global.conf
+++ b/etc/httpd/global.conf
@@ -256,6 +256,12 @@ RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?about/history/$ /b/$1about/history/
 RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?about/bookmarks.html$ https://wiki.mozilla.org/Historical_Documents [L,R=301]
 RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?about/timeline.html$ https://wiki.mozilla.org/Timeline [L,R=301]
 
+# bug 885848
+RewriteRule ^/about/index.html$ /about/ [L,R=301]
+RewriteRule ^/about/index.(.*)?.html$ /contribute/ [L,R=301]
+RewriteCond $1 !en-US/
+RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)about(?:/(?:index.html)?)$ /contribute/ [L,R=301]
+
 # bug 861243 and bug 869489
 RewriteRule ^/about/manifesto\.html$ /about/manifesto/ [L,R=301]
 RewriteRule ^/about/manifesto\.(.*)\.html$ /$1/about/manifesto/ [L,R=301]


### PR DESCRIPTION
Redirect /about/index.html to /about/ and redirect the l10n'ed /about/index.XX.html files to /contribute/ (since /contribute/ is localized).
