### PR TITLE
Bug 888653

### DIFF
--- a/bedrock/firefox/templates/firefox/partners/index.html
+++ b/bedrock/firefox/templates/firefox/partners/index.html
@@ -104,11 +104,11 @@
           <div id="overview-news">
             <h3>{{ _('Recent news') }}</h3>
             <ul>
-              {% if LANG == 'en-US' %}
-              <li><a href="https://blog.mozilla.org/blog/2013/07/01/mozilla-and-partners-prepare-to-launch-first-firefox-os-smartphones">{{ _('Mozilla and partners prepare to launch first Firefox OS smartsphones') }}</a></li>
+              {% if request.locale in locale_os_release_active %}
+              <li><a href="{{ locale_os_release_url }}">{{ _('Mozilla and partners prepare to launch first Firefox OS smartsphones') }}</a></li>
               {% endif %}
               <li><a href="#mwc-wrapup" class="modal">{{ _('Watch our wrap-up video from Mobile World Congress 2013') }}</a></li>
-              {% if LANG != 'en-US' %}
+              {% if request.locale not in locale_os_release_active %}
               <li><a href="{{ locale_os_url }}" rel="external">{{ _('Mozilla Announces Global Expansion for Firefox OS') }}</a></li>
               {% endif %}
             </ul>

--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -38,6 +38,17 @@ LOCALE_OS_URLS = {
     'es-ES': 'http://blog.mozilla.org/press-es/?p=340',
     'en-GB': 'http://blog.mozilla.org/press-uk/?p=471'
 }
+
+LOCALE_OS_RELEASE_URLS = {
+    'de': 'https://blog.mozilla.org/press-de/2013/07/01/mozilla-und-partner-machen-sich-bereit-fur-den-ersten-firefox-os-launch/',
+    'en-GB': 'https://blog.mozilla.org/press-uk/2013/07/01/mozilla-and-partners-prepare-to-launch-first-firefox-os-smartphones/',
+    'en-US': 'https://blog.mozilla.org/blog/2013/07/01/mozilla-and-partners-prepare-to-launch-first-firefox-os-smartphones',
+    'es-ES': 'http://blog.mozilla.org/press-es/?p=482',
+    'fr': 'https://blog.mozilla.org/press-fr/2013/07/01/mozilla-et-ses-partenaires-preparent-le-lancement-des-premiers-smartphones-sous-firefox-os/',
+    'it': 'https://blog.mozilla.org/press-it/2013/07/01/mozilla-e-i-suoi-partner-si-preparano-al-lancio-dei-primi-smartphone-con-firefox-os/',
+    'pl': 'https://blog.mozilla.org/press-pl/2013/07/01/mozilla-wraz-z-partnerami-przygotowuje-sie-do-wprowadzenia-na-rynek-pierwszych-smartfonow-z-firefox-os/',
+}
+
 INSTALLER_CHANNElS = [
     'release',
     'beta',
@@ -186,12 +197,17 @@ def all_downloads(request):
 @csrf_protect
 def firefox_partners(request):
     # If the current locale isn't in our list, return the en-US value
+    # MWC announcement
     locale_os_url = LOCALE_OS_URLS.get(request.locale, LOCALE_OS_URLS['en-US'])
+    # Firefox OS 1.0 release
+    locale_os_release_url = LOCALE_OS_RELEASE_URLS.get(request.locale, LOCALE_OS_RELEASE_URLS['en-US'])
 
     form = WebToLeadForm()
 
     template_vars = {
         'locale_os_url': locale_os_url,
+        'locale_os_release_url': locale_os_release_url,
+        'locale_os_release_active': LOCALE_OS_RELEASE_URLS,
         'js_common': JS_COMMON,
         'js_mobile': JS_MOBILE,
         'js_desktop': JS_DESKTOP,


### PR DESCRIPTION
Make the news item about Firefox OS release conditionnally included for locales and insert the right blog post
Currently only en-US and es-ES
