### PR TITLE
Add build id to tabzilla js.

### DIFF
--- a/bedrock/base/templates/base-resp.html
+++ b/bedrock/base/templates/base-resp.html
@@ -101,7 +101,7 @@
             <li><a href="{{ url('privacy.index') }}">{{_('Privacy Policy')}}</a></li>
             <li><a href="{{ php_url('/about/legal.html') }}">{{_('Legal Notices')}}</a></li>
             <li><a href="{{ php_url('/legal/fraud-report/index.html') }}">{{_('Report Trademark Abuse')}}</a></li>
-          </ul>  
+          </ul>
           {% block social %}
           <ul class="footer-nav">
             <li><a href="http://twitter.com/firefox">{{_('Twitter')}}</a></li>
@@ -124,7 +124,7 @@
       {{ js('common-resp') }}
     {% endblock %}
     {% block tabzilla_js %}
-      <script src="{{ settings.CDN_BASE_URL }}{{ url('tabzilla') }}"></script>
+      <script src="{{ settings.CDN_BASE_URL }}{{ url('tabzilla') }}?build={{ BUILD_ID_JS }}"></script>
     {% endblock %}
     {% block js %}{% endblock %}
   </body>

--- a/bedrock/base/templates/base.html
+++ b/bedrock/base/templates/base.html
@@ -112,7 +112,7 @@
       {{ js('common') }}
     {% endblock %}
     {% block tabzilla_js %}
-      <script src="{{ settings.CDN_BASE_URL }}{{ url('tabzilla') }}"></script>
+      <script src="{{ settings.CDN_BASE_URL }}{{ url('tabzilla') }}?build={{ BUILD_ID_JS }}"></script>
     {% endblock %}
     {% block js %}{% endblock %}
   </body>

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -667,6 +667,7 @@ TEMPLATE_CONTEXT_PROCESSORS = get_template_context_processors(append=(
     'django.contrib.messages.context_processors.messages',
     'bedrock.mozorg.context_processors.current_year',
     'bedrock.firefox.context_processors.latest_firefox_versions',
+    'jingo_minify.helpers.build_ids',
 ))
 
 ## Auth


### PR DESCRIPTION
This will cache-bust the JS in the same way the CSS is already done.
