### PR TITLE
Cache-bust images in style guide (Bug 881125)

### DIFF
--- a/bedrock/styleguide/templates/styleguide/base.html
+++ b/bedrock/styleguide/templates/styleguide/base.html
@@ -33,7 +33,7 @@
 {% block sidebar %}
   <div id="sidebar">
   <h2><a href="{{ url('styleguide.home') }}">
-    <img src="{% block guide_logo %}{{ media('/img/styleguide/mozilla.png') }}{% endblock %}" height="28" width="107" alt="mozilla">
+    <img src="{% block guide_logo %}{{ media('/img/styleguide/mozilla.png?2013-06') }}{% endblock %}" height="28" width="107" alt="mozilla">
     Style guide
   </a></h2>
   <nav>

--- a/bedrock/styleguide/templates/styleguide/communications/copy-tone.html
+++ b/bedrock/styleguide/templates/styleguide/communications/copy-tone.html
@@ -27,7 +27,7 @@
 <div class="intro">
   <h2>Mozilla is people.</h2>
   <h3>(It’s people!)</h3>
-  <img src="{{ media('/img/styleguide/communications/copy-tone.png') }}" alt="Mozilla group photos" />
+  <img src="{{ media('/img/styleguide/communications/copy-tone.png?2013-06') }}" alt="Mozilla group photos" />
   <small>So many people.</small>
 </div>
 

--- a/bedrock/styleguide/templates/styleguide/communications/presentations.html
+++ b/bedrock/styleguide/templates/styleguide/communications/presentations.html
@@ -21,7 +21,7 @@
 
   <h3>Standard - Mozilla / Firefox / Product</h3>
   <div class="preview">
-    <img src="{{ media('/img/styleguide/communications/presentation-standard.png') }}" alt="Standard presentation preview" />
+    <img src="{{ media('/img/styleguide/communications/presentation-standard.png?2013-06') }}" alt="Standard presentation preview" />
     <ul class="button-list">
       <li><a href="https://assets.mozillalabs.com/Communications/Presentations/Keynote/" class="button-sand">Keynote</a></li><li>
       <a href="https://assets.mozillalabs.com/Communications/Presentations/PPT/" class="button-sand">PPT</a></li><li>

--- a/bedrock/styleguide/templates/styleguide/communications/typefaces.html
+++ b/bedrock/styleguide/templates/styleguide/communications/typefaces.html
@@ -73,7 +73,7 @@
       <p>The old, trusted Mozilla standard, Meta Bold is reserved for our Mozilla wordmark and usage at the Foundation level. It’s our rock.</p>
     </div>
     <div class="examples">
-      <img src="{{ media('/img/styleguide/communications/typefaces-metabold.png') }}" alt="Meta Bold sample" />
+      <img src="{{ media('/img/styleguide/communications/typefaces-metabold.png?2013-06') }}" alt="Meta Bold sample" />
     </div>
   </section>
   <section id="metamedium">
@@ -82,7 +82,7 @@
       <p>At the product level, Meta Medium is our champion and creates a second tier of Meta font usage. Sleek, svelte, nimble.</p>
     </div>
     <div class="examples">
-      <img src="{{ media('/img/styleguide/communications/typefaces-metamedium.png') }}" alt="Meta Medium sample" />
+      <img src="{{ media('/img/styleguide/communications/typefaces-metamedium.png?2013-06') }}" alt="Meta Medium sample" />
     </div>
   </section>
   <section id="metanormal">
@@ -91,7 +91,7 @@
       <p>Our third tier of font usage features Meta Normal as the light and lean choice for sub-branding. Light in weight, heavy in awesome.</p>
     </div>
     <div class="examples">
-      <img src="{{ media('/img/styleguide/communications/typefaces-metanormal.png') }}" alt="Meta Normal sample" />
+      <img src="{{ media('/img/styleguide/communications/typefaces-metanormal.png?2013-06') }}" alt="Meta Normal sample" />
     </div>
   </section>
 </section>

--- a/bedrock/styleguide/templates/styleguide/communications/video.html
+++ b/bedrock/styleguide/templates/styleguide/communications/video.html
@@ -20,12 +20,12 @@
     <p>You can find these assets in our <a href="https://assets.mozillalabs.com/Communications/Video%20Assets/">assets repository</a>.</p>
   </div>
   <div class="examples">
-    <img src="{{ media('/img/styleguide/communications/video-intro-blue.jpg') }}" alt="Video intro" />
+    <img src="{{ media('/img/styleguide/communications/video-intro-blue.jpg?2013-06') }}" alt="Video intro" />
     <div class="thumbnails">
-      <img src="{{ media('/img/styleguide/communications/video-intro-grey.jpg') }}" alt="Video intro" />
-      <img src="{{ media('/img/styleguide/communications/video-intro-light.jpg') }}" alt="Video intro" />
-      <img src="{{ media('/img/styleguide/communications/video-intro-orange.jpg') }}" alt="Video intro" />
-      <img src="{{ media('/img/styleguide/communications/video-intro-red.jpg') }}" alt="Video intro" />
+      <img src="{{ media('/img/styleguide/communications/video-intro-grey.jpg?2013-06') }}" alt="Video intro" />
+      <img src="{{ media('/img/styleguide/communications/video-intro-light.jpg?2013-06') }}" alt="Video intro" />
+      <img src="{{ media('/img/styleguide/communications/video-intro-orange.jpg?2013-06') }}" alt="Video intro" />
+      <img src="{{ media('/img/styleguide/communications/video-intro-red.jpg?2013-06') }}" alt="Video intro" />
     </div>
   </div>
 </section>
@@ -51,7 +51,7 @@
     <p>You can find these assets in our <a href="https://assets.mozillalabs.com/Communications/Video%20Assets/">assets repository</a>.</p>
   </div>
   <div class="examples">
-    <img src="{{ media('/img/styleguide/communications/video-outro.jpg') }}" alt="Video outro" />
+    <img src="{{ media('/img/styleguide/communications/video-outro.jpg?2013-06') }}" alt="Video outro" />
   </div>
 </section>
 {% endblock %}

--- a/bedrock/styleguide/templates/styleguide/identity/firefox-branding.html
+++ b/bedrock/styleguide/templates/styleguide/identity/firefox-branding.html
@@ -23,7 +23,7 @@
     <li>use our logos to, or in connection with, content that disparages us or sullies our reputation</li>
   </ul>
   <div id="guidelines-logo">
-    <img src="{{ media('/img/styleguide/identity/firefox/guidelines-logo.png') }}" alt="Logo" id="guidelines-logo-image" />
+    <img src="{{ media('/img/styleguide/identity/firefox/guidelines-logo.png?2013-06') }}" alt="Logo" id="guidelines-logo-image" />
     <h3>Download</h3>
     <ul class="button-list">
       <li><a href="https://assets.mozillalabs.com/Brands-Logos/Firefox/logo-only/firefox_logo-only_CMYK.eps" class="button-sand">EPS</a>
@@ -34,11 +34,11 @@
 </section>
 <section id="usage">
   <h2>Usage</h2>
-  <div><img src="{{ media('/img/styleguide/identity/firefox/usage-standard.png') }}" alt="Usage Standard" id="usage-standard" /></div>
+  <div><img src="{{ media('/img/styleguide/identity/firefox/usage-standard.png?2013-06') }}" alt="Usage Standard" id="usage-standard" /></div>
   <p>Our standard lockup. Outside of a few exceptions, this is the default, go-to, everybody’s- happy version. (In other words, when in doubt, use this.)</p>
-  <div><img src="{{ media('/img/styleguide/identity/firefox/usage-logo.png') }}" alt="Usage Logo" id="usage-logo" /></div>
+  <div><img src="{{ media('/img/styleguide/identity/firefox/usage-logo.png?2013-06') }}" alt="Usage Logo" id="usage-logo" /></div>
   <p>The logo alone. Use this only when Mozilla and Firefox are clearly visible or have been well established elsewhere on the page or in the design. (When in doubt, use the other one.)</p>
-  <div class="clear"><img src="{{ media('/img/styleguide/identity/firefox/usage-standard-alt.png') }}" alt="Usage Standard Alt" id="usage-standard-alt" /></div>
+  <div class="clear"><img src="{{ media('/img/styleguide/identity/firefox/usage-standard-alt.png?2013-06') }}" alt="Usage Standard Alt" id="usage-standard-alt" /></div>
   <p>Alternate lockup. Use this on posters, banners or when horizontal space is an issue. Unlike the standard horizontal lockup, do not use this with any of the channel logos or wordmarks.</p>
 </section>
 <section id="mistakes">
@@ -46,9 +46,9 @@
     <h2>Common mistakes</h2>
     <p>Think of these as the equivalent of wearing your shoes on the wrong feet: they’re still shoes, they’re basically where they’re supposed to be, but it just feels wrong.</p>
   </div>
-  <img src="{{ media('/img/styleguide/identity/firefox/common-mistakes.png') }}" alt="Common Mistakes" id="common-mistakes-image" />
+  <img src="{{ media('/img/styleguide/identity/firefox/common-mistakes.png?2013-06') }}" alt="Common Mistakes" id="common-mistakes-image" />
   <div id="what-to-look-for">
-    <img src="{{ media('/img/styleguide/box-arrow.png') }}" alt="" class="box-arrow" />
+    <img src="{{ media('/img/styleguide/box-arrow.png?2013-06') }}" alt="" class="box-arrow" />
     <div>
       <h4>What to look for</h4>
       <p>To avoid a faux-pas — or "faux-paw," as the case may be — please note the differences in tail and globe detail between past logos and our most recent version.</p>
@@ -56,7 +56,7 @@
     <p class="caption-1">The new globe has high gloss removed, softer deeper gradients for better contrast and new higher detail continents.</p>
     <p class="caption-2">The fox fur is now a softer gradient orange and has much less detail (he also has a proper shoulder).</p>
     <p class="caption-3">The tail still wraps around the globe, which peeks through in some places, but there is much less detail and there are more high contrast yellow/white flames.</p>
-    <img src="{{ media('/img/styleguide/identity/firefox/what-to-look-for.png') }}" alt="What To Look For" id="what-to-look-for-image" />
+    <img src="{{ media('/img/styleguide/identity/firefox/what-to-look-for.png?2013-06') }}" alt="What To Look For" id="what-to-look-for-image" />
   </div>
 </section>
 <section id="partner">
@@ -65,17 +65,17 @@
     <p>Sometimes we team up with partners. This is how you can make our logo play nice with others (as long as you have all the necessary permissions, of course).</p>
   </div>
   <div id="partner-standard">
-    <img src="{{ media('/img/styleguide/identity/firefox/partner-standard.png') }}" alt="Standard edition" id="partner-standard-image" />
+    <img src="{{ media('/img/styleguide/identity/firefox/partner-standard.png?2013-06') }}" alt="Standard edition" id="partner-standard-image" />
     <h4>Standard edition</h4>
     <p>For use in co-promotional campaigns and ads, joint announcements or press releases.</p>
   </div>
   <div id="partner-distribution-partner">
-    <img src="{{ media('/img/styleguide/identity/firefox/partner-distribution-partner.png') }}" alt="Distribution deal — partner edition" id="partner-distribution-partner-image" />
+    <img src="{{ media('/img/styleguide/identity/firefox/partner-distribution-partner.png?2013-06') }}" alt="Distribution deal — partner edition" id="partner-distribution-partner-image" />
     <h4>Distribution deal — partner edition</h4>
     <p>Use when one of our partners offers a custom Firefox build for download on their site.</p>
   </div>
   <div id="partner-distribution-standard">
-    <img src="{{ media('/img/styleguide/identity/firefox/partner-distribution-standard.png') }}" alt="Distribution deal — standard edition" id="partner-distribution-standard-image" />
+    <img src="{{ media('/img/styleguide/identity/firefox/partner-distribution-standard.png?2013-06') }}" alt="Distribution deal — standard edition" id="partner-distribution-standard-image" />
     <h4>Distribution deal — standard edition</h4>
     <p>Use when one of our partners offers an official Firefox build for download on their site, but still wants their brand associated with it.</p>
   </div>

--- a/bedrock/styleguide/templates/styleguide/identity/firefox-channels.html
+++ b/bedrock/styleguide/templates/styleguide/identity/firefox-channels.html
@@ -28,7 +28,7 @@
     <h4>Visual direction</h4>
     <p>Crisp, clean, light blue/grey grain as background</p>
   </div>
-  <div class="logo"><img src="{{ media('/img/styleguide/identity/firefox/channels-firefox.png') }}" alt="Logo" /></div>
+  <div class="logo"><img src="{{ media('/img/styleguide/identity/firefox/channels-firefox.png?2013-06') }}" alt="Logo" /></div>
   <div class="download">
     <h4>Download</h4>
     <ul class="button-list">
@@ -50,7 +50,7 @@
     <h4>Visual direction</h4>
     <p>Crisp, clean, light blue/grey grain as background*</p>
   </div>
-  <div class="logo"><img src="{{ media('/img/styleguide/identity/firefox/channels-firefox-beta.png') }}" alt="Logo" /></div>
+  <div class="logo"><img src="{{ media('/img/styleguide/identity/firefox/channels-firefox-beta.png?2013-06') }}" alt="Logo" /></div>
   <div class="download">
     <h4>Download <span>(with beta sash)</span></h4>
     <ul class="button-list">
@@ -73,7 +73,7 @@
     <h4>Visual direction</h4>
     <p>Branding works best on dark backgrounds, purple as primary Web color</p>
   </div>
-  <div class="logo"><img src="{{ media('/img/styleguide/identity/firefox/channels-firefox-aurora.png') }}" alt="Logo" /></div>
+  <div class="logo"><img src="{{ media('/img/styleguide/identity/firefox/channels-firefox-aurora.png?2013-06') }}" alt="Logo" /></div>
   <div class="download">
     <h4>Download</h4>
     <ul class="button-list">
@@ -95,7 +95,7 @@
     <h4>Visual direction</h4>
     <p>Branding works best on dark backgrounds, dark blue as primary Web color</p>
   </div>
-  <div class="logo"><img src="{{ media('/img/styleguide/identity/firefox/channels-firefox-nightly.png') }}" alt="Logo" /></div>
+  <div class="logo"><img src="{{ media('/img/styleguide/identity/firefox/channels-firefox-nightly.png?2013-06') }}" alt="Logo" /></div>
   <div class="download">
     <h4>Download</h4>
     <ul class="button-list">

--- a/bedrock/styleguide/templates/styleguide/identity/firefox-family-overview.html
+++ b/bedrock/styleguide/templates/styleguide/identity/firefox-family-overview.html
@@ -14,6 +14,6 @@
 {% block content_area %}
 <section id="intro">
   <p>Firefox is more than a browser (though it certainly is that). It’s the flagship brand that all our consumer products fall under. Any product bearing the Firefox name lets people know that it features the latest open, innovative technologies and that it’s made with a mission to keep the power of the Web in people’s hands and to build a brighter Internet future for all. The following pages go through each brand and its various elements in detail.</p>
-  <img src="{{ media('/img/styleguide/identity/firefox-family/overview.png') }}" alt="Logo" />
+  <img src="{{ media('/img/styleguide/identity/firefox-family/overview.png?2013-06') }}" alt="Logo" />
 </section>
 {% endblock %}

--- a/bedrock/styleguide/templates/styleguide/identity/firefox-family-platform.html
+++ b/bedrock/styleguide/templates/styleguide/identity/firefox-family-platform.html
@@ -17,7 +17,7 @@
     <p>Whether you're new to Firefox or you've been around for a while, you know there’s something very special about this brand.</p>
     <p>This section defines what makes Firefox special and gives you some tools to help articulate, express and evaluate the brand.</p>
   </div>
-  <img src="{{ media('/img/styleguide/identity/firefox-family/intro-logo.png') }}" alt="Logo" />
+  <img src="{{ media('/img/styleguide/identity/firefox-family/intro-logo.png?2013-06') }}" alt="Logo" />
 </section>
 <section id="promise-position">
   <div class="promise">
@@ -59,8 +59,8 @@
     <p>This is the language that is influenced by the world in which we live. This is the language that embodies the promise of “Firefox answers to no one but you.” </p>
   </div>
   <div class="image">
-    <img src="{{ media('/img/styleguide/box-arrow-left.png') }}" alt="" class="box-arrow" />
-    <img src="{{ media('/img/styleguide/identity/firefox-family/voice.png') }}" alt="Voice" />
+    <img src="{{ media('/img/styleguide/box-arrow-left.png?2013-06') }}" alt="" class="box-arrow" />
+    <img src="{{ media('/img/styleguide/identity/firefox-family/voice.png?2013-06') }}" alt="Voice" />
   </div>
 </section>
 <section id="mission">

--- a/bedrock/styleguide/templates/styleguide/identity/firefox-wordmarks.html
+++ b/bedrock/styleguide/templates/styleguide/identity/firefox-wordmarks.html
@@ -22,10 +22,10 @@
     <p>Our default Firefox wordmark is set in Meta Medium and sets the tone for our <a href="{{ url('styleguide.communications.typefaces') }}#wordmarks">tiered font system</a>.</p>
   </div>
   <div class="logo">
-    <img src="{{ media('/img/styleguide/box-arrow-left.png') }}" alt="" class="box-arrow" />
-    <img src="{{ media('/img/styleguide/identity/firefox/wordmark-logo.png') }}" alt="Logo" />
-    <img src="{{ media('/img/styleguide/identity/firefox/wordmark-vertical.png') }}" alt="Logo" />
-    <img src="{{ media('/img/styleguide/identity/firefox/wordmark.png') }}" alt="Logo" />
+    <img src="{{ media('/img/styleguide/box-arrow-left.png?2013-06') }}" alt="" class="box-arrow" />
+    <img src="{{ media('/img/styleguide/identity/firefox/wordmark-logo.png?2013-06') }}" alt="Logo" />
+    <img src="{{ media('/img/styleguide/identity/firefox/wordmark-vertical.png?2013-06') }}" alt="Logo" />
+    <img src="{{ media('/img/styleguide/identity/firefox/wordmark.png?2013-06') }}" alt="Logo" />
   </div>
   <div class="download">
     <h4>Download</h4>
@@ -55,9 +55,9 @@
     <p>The Firefox Beta wordmark uses our standard product + sub-brand <a href="{{ url('styleguide.communications.typefaces') }}#wordmarks">tiered font system</a>.</p>
   </div>
   <div class="logo">
-    <img src="{{ media('/img/styleguide/box-arrow-left.png') }}" alt="" class="box-arrow" />
-    <img src="{{ media('/img/styleguide/identity/firefox/wordmark-beta-logo.png') }}" alt="Logo" />
-    <img src="{{ media('/img/styleguide/identity/firefox/wordmark-beta.png') }}" alt="Logo" />
+    <img src="{{ media('/img/styleguide/box-arrow-left.png?2013-06') }}" alt="" class="box-arrow" />
+    <img src="{{ media('/img/styleguide/identity/firefox/wordmark-beta-logo.png?2013-06') }}" alt="Logo" />
+    <img src="{{ media('/img/styleguide/identity/firefox/wordmark-beta.png?2013-06') }}" alt="Logo" />
   </div>
   <div class="download">
     <h4>Download</h4>
@@ -81,9 +81,9 @@
     <p>The Firefox Aurora wordmark uses our standard product + sub-brand <a href="{{ url('styleguide.communications.typefaces') }}#wordmarks">tiered font system</a> and a special standard of white on dark.</p>
   </div>
   <div class="logo">
-    <img src="{{ media('/img/styleguide/box-arrow-left.png') }}" alt="" class="box-arrow" />
-    <img src="{{ media('/img/styleguide/identity/firefox/wordmark-aurora-logo.png') }}" alt="Logo" />
-    <img src="{{ media('/img/styleguide/identity/firefox/wordmark-aurora.png') }}" alt="Logo" />
+    <img src="{{ media('/img/styleguide/box-arrow-left.png?2013-06') }}" alt="" class="box-arrow" />
+    <img src="{{ media('/img/styleguide/identity/firefox/wordmark-aurora-logo.png?2013-06') }}" alt="Logo" />
+    <img src="{{ media('/img/styleguide/identity/firefox/wordmark-aurora.png?2013-06') }}" alt="Logo" />
   </div>
   <div class="download">
     <h4>Download</h4>
@@ -107,9 +107,9 @@
     <p>The Firefox Nightly wordmark uses our standard product + sub-brand <a href="{{ url('styleguide.communications.typefaces') }}#wordmarks">tiered font system</a> and a special standard of white on dark.</p>
   </div>
   <div class="logo">
-    <img src="{{ media('/img/styleguide/box-arrow-left.png') }}" alt="" class="box-arrow" />
-    <img src="{{ media('/img/styleguide/identity/firefox/wordmark-nightly-logo.png') }}" alt="Logo" />
-    <img src="{{ media('/img/styleguide/identity/firefox/wordmark-nightly.png') }}" alt="Logo" />
+    <img src="{{ media('/img/styleguide/box-arrow-left.png?2013-06') }}" alt="" class="box-arrow" />
+    <img src="{{ media('/img/styleguide/identity/firefox/wordmark-nightly-logo.png?2013-06') }}" alt="Logo" />
+    <img src="{{ media('/img/styleguide/identity/firefox/wordmark-nightly.png?2013-06') }}" alt="Logo" />
   </div>
   <div class="download">
     <h4>Download</h4>

--- a/bedrock/styleguide/templates/styleguide/identity/firefoxos-branding.html
+++ b/bedrock/styleguide/templates/styleguide/identity/firefoxos-branding.html
@@ -70,9 +70,9 @@
   </div>
   <div class="logo">
     <img src="{{ media('/img/styleguide/box-arrow-left.png') }}" alt="" class="box-arrow">
-    <img src="{{ media('/img/styleguide/identity/firefoxos/wordmark-logo.png?build=2') }}" alt="Firefox OS logo and wordmark">
-    <img src="{{ media('/img/styleguide/identity/firefoxos/wordmark.png?build=2') }}" alt="Firefox OS wordmark">
-    <img src="{{ media('/img/styleguide/identity/firefoxos/wordmark-logo-vertical.png?build=2') }}" alt="Firefox OS logo and wordmark, vertical orientation">
+    <img src="{{ media('/img/styleguide/identity/firefoxos/wordmark-logo.png?2013-06') }}" alt="Firefox OS logo and wordmark">
+    <img src="{{ media('/img/styleguide/identity/firefoxos/wordmark.png?2013-06') }}" alt="Firefox OS wordmark">
+    <img src="{{ media('/img/styleguide/identity/firefoxos/wordmark-logo-vertical.png?2013-06') }}" alt="Firefox OS logo and wordmark, vertical orientation">
   </div>
   <div class="download">
     <h4>Download</h4>

--- a/bedrock/styleguide/templates/styleguide/identity/firefoxos-community.html
+++ b/bedrock/styleguide/templates/styleguide/identity/firefoxos-community.html
@@ -66,7 +66,7 @@
       <p class="caption" id="caption-3">
         {{ _('Official Firefox OS logo lockup (or at least the wordmark)') }}
       </p>
-      <img id="guidelines-example" src="{{ media('/img/styleguide/identity/firefoxos/partners-community-guidelines-example.png') }}" alt="">
+      <img id="guidelines-example" src="{{ media('/img/styleguide/identity/firefoxos/partners-community-guidelines-example.png?2013-06') }}" alt="">
     </div>
   </div>
 </section>
@@ -88,14 +88,14 @@
         <p>{{ _('"The Look"') }}</p>
         <ul>
           <li>
-            <img src="{{ media('/img/styleguide/identity/firefoxos/partners-community-thelook-future.png') }}" alt="{{ _('The Look - Be The Future') }}">
+            <img src="{{ media('/img/styleguide/identity/firefoxos/partners-community-thelook-future.png?2013-06') }}" alt="{{ _('The Look - Be The Future') }}">
             <ul class="button-list">
               <li><a href="https://assets.mozillalabs.com/Projects/Firefox%20OS/Engagement/Community/Artwork/Print%20CMYK/The%20Look/" class="button-sand">{{ _('Print') }}</a>
               </li><li><a href="https://assets.mozillalabs.com/Projects/Firefox%20OS/Engagement/Community/Artwork/Web%20RGB/The%20Look/" class="button-sand">{{ _('Web') }}</a></li>
             </ul>
           </li>
           <li>
-            <img src="{{ media('/img/styleguide/identity/firefoxos/partners-community-thelook-blaze.png') }}" alt="{{ _('The Look - Blaze Your Own Path') }}">
+            <img src="{{ media('/img/styleguide/identity/firefoxos/partners-community-thelook-blaze.png?2013-06') }}" alt="{{ _('The Look - Blaze Your Own Path') }}">
             <ul class="button-list">
               <li><a href="https://assets.mozillalabs.com/Projects/Firefox%20OS/Engagement/Community/Artwork/Print%20CMYK/The%20Look/" class="button-sand">{{ _('Print') }}</a>
               </li><li><a href="https://assets.mozillalabs.com/Projects/Firefox%20OS/Engagement/Community/Artwork/Web%20RGB/The%20Look/" class="button-sand">{{ _('Web') }}</a></li>
@@ -108,14 +108,14 @@
         <p>{{ _('"The Charge"') }}</p>
         <ul>
           <li>
-            <img src="{{ media('/img/styleguide/identity/firefoxos/partners-community-thecharge-future.png') }}" alt="{{ _('The Charge - Be The Future') }}">
+            <img src="{{ media('/img/styleguide/identity/firefoxos/partners-community-thecharge-future.png?2013-06') }}" alt="{{ _('The Charge - Be The Future') }}">
             <ul class="button-list">
               <li><a href="https://assets.mozillalabs.com/Projects/Firefox%20OS/Engagement/Community/Artwork/Print%20CMYK/The%20Charge/" class="button-sand">{{ _('Print') }}</a>
               </li><li><a href="https://assets.mozillalabs.com/Projects/Firefox%20OS/Engagement/Community/Artwork/Web%20RGB/The%20Charge/" class="button-sand">{{ _('Web') }}</a></li>
             </ul>
           </li>
           <li>
-            <img src="{{ media('/img/styleguide/identity/firefoxos/partners-community-thecharge-blaze.png') }}" alt="{{ _('The Charge - Blaze Your Own Path') }}">
+            <img src="{{ media('/img/styleguide/identity/firefoxos/partners-community-thecharge-blaze.png?2013-06') }}" alt="{{ _('The Charge - Blaze Your Own Path') }}">
             <ul class="button-list">
               <li><a href="https://assets.mozillalabs.com/Projects/Firefox%20OS/Engagement/Community/Artwork/Print%20CMYK/The%20Charge/" class="button-sand">{{ _('Print') }}</a>
               </li><li><a href="https://assets.mozillalabs.com/Projects/Firefox%20OS/Engagement/Community/Artwork/Web%20RGB/The%20Charge/" class="button-sand">{{ _('Web') }}</a></li>
@@ -128,14 +128,14 @@
         <p>{{ _('"The Bolt"') }}</p>
         <ul>
           <li>
-            <img src="{{ media('/img/styleguide/identity/firefoxos/partners-community-thebolt-future.png') }}" alt="{{ _('The Bolt - Be The Future') }}">
+            <img src="{{ media('/img/styleguide/identity/firefoxos/partners-community-thebolt-future.png?2013-06') }}" alt="{{ _('The Bolt - Be The Future') }}">
             <ul class="button-list">
               <li><a href="https://assets.mozillalabs.com/Projects/Firefox%20OS/Engagement/Community/Artwork/Print%20CMYK/The%20Bolt/" class="button-sand">{{ _('Print') }}</a>
               </li><li><a href="https://assets.mozillalabs.com/Projects/Firefox%20OS/Engagement/Community/Artwork/Web%20RGB/The%20Bolt/" class="button-sand">{{ _('Web') }}</a></li>
             </ul>
           </li>
           <li>
-            <img src="{{ media('/img/styleguide/identity/firefoxos/partners-community-thebolt-blaze.png') }}" alt="{{ _('The Bolt - Blaze Your Own Path') }}">
+            <img src="{{ media('/img/styleguide/identity/firefoxos/partners-community-thebolt-blaze.png?2013-06') }}" alt="{{ _('The Bolt - Blaze Your Own Path') }}">
             <ul class="button-list">
               <li><a href="https://assets.mozillalabs.com/Projects/Firefox%20OS/Engagement/Community/Artwork/Print%20CMYK/The%20Bolt/" class="button-sand">{{ _('Print') }}</a>
               </li><li><a href="https://assets.mozillalabs.com/Projects/Firefox%20OS/Engagement/Community/Artwork/Web%20RGB/The%20Bolt/" class="button-sand">{{ _('Web') }}</a></li>
@@ -148,7 +148,7 @@
   </div>
 
   <aside id="examples" class="example">
-    <img src="{{ media('/img/styleguide/box-arrow.png') }}" alt="" class="box-arrow" />
+    <img src="{{ media('/img/styleguide/box-arrow.png?2013-06') }}" alt="" class="box-arrow" />
     <div class="left-col">
       <h2>{{ _('Example usage') }}</h2>
       <p>
@@ -156,7 +156,7 @@
       </p>
     </div>
     <div class="right-col">
-      <img src="{{ media('/img/styleguide/identity/firefoxos/partners-community-artwork-example.png') }}" alt="">
+      <img src="{{ media('/img/styleguide/identity/firefoxos/partners-community-artwork-example.png?2013-06') }}" alt="">
     </div>
   </aside>
 </section>

--- a/bedrock/styleguide/templates/styleguide/identity/firefoxos-partners.html
+++ b/bedrock/styleguide/templates/styleguide/identity/firefoxos-partners.html
@@ -49,11 +49,11 @@
     <div class="container">
       <div class="split the-look">
         {{ _('"The Look"') }}
-        <img src="{{ media('/img/styleguide/identity/firefoxos/partners-thelook.png') }}" alt="">
+        <img src="{{ media('/img/styleguide/identity/firefoxos/partners-thelook.png?2013-06') }}" alt="">
       </div>
       <div class="split">
         {{ _('"The Swoop"') }}
-        <img src="{{ media('/img/styleguide/identity/firefoxos/partners-theswoop.png') }}" alt="">
+        <img src="{{ media('/img/styleguide/identity/firefoxos/partners-theswoop.png?2013-06') }}" alt="">
       </div>
     </div>
   </div>
@@ -72,9 +72,9 @@
   </div>
   <div class="right-col">
     <div class="container">
-      <img class="based-on" src="{{ media('/img/styleguide/identity/firefoxos/partners-based-on-red.png') }}" alt="{{ _('Based on red') }}">
-      <img class="based-on" src="{{ media('/img/styleguide/identity/firefoxos/partners-based-on-black.png') }}" alt="{{ _('Based on black') }}">
-      <img class="based-on wordmark" src="{{ media('/img/styleguide/identity/firefoxos/partners-based-on-wordmark.png') }}" alt="{{ _('Based on wordmark') }}">
+      <img class="based-on" src="{{ media('/img/styleguide/identity/firefoxos/partners-based-on-red.png?2013-06') }}" alt="{{ _('Based on red') }}">
+      <img class="based-on" src="{{ media('/img/styleguide/identity/firefoxos/partners-based-on-black.png?2013-06') }}" alt="{{ _('Based on black') }}">
+      <img class="based-on wordmark" src="{{ media('/img/styleguide/identity/firefoxos/partners-based-on-wordmark.png?2013-06') }}" alt="{{ _('Based on wordmark') }}">
 
       <div class="download">
         <h5>{{ _('Color') }}</h5>

--- a/bedrock/styleguide/templates/styleguide/identity/marketplace-branding.html
+++ b/bedrock/styleguide/templates/styleguide/identity/marketplace-branding.html
@@ -27,7 +27,7 @@
     <li>use our logos to, or in connection with, content that disparages us or sullies our reputation</li>
   </ul>
   <div class="guidelines-logo">
-    <img src="{{ media('/img/styleguide/identity/marketplace/logo.png') }}" alt="Logo" />
+    <img src="{{ media('/img/styleguide/identity/marketplace/logo.png?2013-06') }}" alt="Logo" />
     <h3>Download</h3>
     <ul class="button-list">
       <li><a href="https://assets.mozillalabs.com/Brands-Logos/Firefox%20Marketplace/logo-only/firefox-marketplace_logo-only_CMYK-CS4.eps" class="button-sand">EPS</a>
@@ -38,11 +38,11 @@
 </section>
 <section id="usage">
   <h2>Firefox Usage</h2>
-  <div class="image usage-wordmark"><img src="{{ media('/img/styleguide/identity/marketplace/usage-wordmark.png') }}" alt="Usage Wordmark" /></div>
+  <div class="image usage-wordmark"><img src="{{ media('/img/styleguide/identity/marketplace/usage-wordmark.png?2013-06') }}" alt="Usage Wordmark" /></div>
   <p>Our standard lockup for representing the Firefox Marketplace or Mozilla apps in general. In most cases, use this.</p>
-  <div class="image"><img src="{{ media('/img/styleguide/identity/marketplace/usage-logo-bag.png') }}" alt="Usage Logo" /></div>
+  <div class="image"><img src="{{ media('/img/styleguide/identity/marketplace/usage-logo-bag.png?2013-06') }}" alt="Usage Logo" /></div>
   <p>The logo on its own. You can safely use this if Mozilla and the Marketplace are clearly visible or well established elsewhere on the page or in the design.</p>
-  <div class="image clear"><img src="{{ media('/img/styleguide/identity/marketplace/usage-logo-rocket.png') }}" alt="Usage Logo" /></div>
+  <div class="image clear"><img src="{{ media('/img/styleguide/identity/marketplace/usage-logo-rocket.png?2013-06') }}" alt="Usage Logo" /></div>
   <p>The rocket glyph can be used to represent the Marketplace or as the default symbol for a single app (i.e. one that doesn’t have its own logo).</p>
 </section>
 <section id="generic-usage">
@@ -51,10 +51,10 @@
     <p>Our standard lockups for representing the Marketplace when not deployed under the Firefox family of brands.</p>
   </div>
   <div class="image usage-wordmark">
-    <img src="{{ media('/img/styleguide/identity/marketplace/generic-usage-wordmark.png') }}" alt="Usage Wordmark" />
+    <img src="{{ media('/img/styleguide/identity/marketplace/generic-usage-wordmark.png?2013-06') }}" alt="Usage Wordmark" />
   </div>
   <div class="image usage-logo">
-    <img src="{{ media('/img/styleguide/identity/marketplace/generic-usage-logo.png') }}" alt="Usage Logo" />
+    <img src="{{ media('/img/styleguide/identity/marketplace/generic-usage-logo.png?2013-06') }}" alt="Usage Logo" />
   </div>
 </section>
 <section id="wordmark">
@@ -63,9 +63,9 @@
     <p>The Marketplace wordmark follows our <a href="{{ url('styleguide.communications.typefaces') }}#wordmarks">tiered font system</a>.</p>
   </div>
   <div class="logo">
-    <img src="{{ media('/img/styleguide/box-arrow-left.png') }}" alt="" class="box-arrow" />
-    <img src="{{ media('/img/styleguide/identity/marketplace/wordmark-firefox-logo.png') }}" alt="Logo" />
-    <img src="{{ media('/img/styleguide/identity/marketplace/wordmark-firefox.png') }}" alt="Logo" />
+    <img src="{{ media('/img/styleguide/box-arrow-left.png?2013-06') }}" alt="" class="box-arrow" />
+    <img src="{{ media('/img/styleguide/identity/marketplace/wordmark-firefox-logo.png?2013-06') }}" alt="Logo" />
+    <img src="{{ media('/img/styleguide/identity/marketplace/wordmark-firefox.png?2013-06') }}" alt="Logo" />
   </div>
   <div class="download">
     <h4>Download</h4>
@@ -85,8 +85,8 @@
 </section>
 <section id="wordmark-2">
   <div class="logo">
-    <img src="{{ media('/img/styleguide/identity/marketplace/wordmark-logo.png') }}" alt="Logo" />
-    <img src="{{ media('/img/styleguide/identity/marketplace/wordmark.png') }}" alt="Logo" />
+    <img src="{{ media('/img/styleguide/identity/marketplace/wordmark-logo.png?2013-06') }}" alt="Logo" />
+    <img src="{{ media('/img/styleguide/identity/marketplace/wordmark.png?2013-06') }}" alt="Logo" />
   </div>
   <div class="download">
     <h4>Download</h4>

--- a/bedrock/styleguide/templates/styleguide/identity/mozilla-branding.html
+++ b/bedrock/styleguide/templates/styleguide/identity/mozilla-branding.html
@@ -29,8 +29,8 @@
     <p>The standard Mozilla wordmark is set in Meta Bold. Please download one of the file formats to the right if you need to use it rather than typing and setting it yourself.</p>
   </div>
   <div class="logo">
-    <img src="{{ media('/img/styleguide/box-arrow-left.png') }}" alt="" class="box-arrow" />
-    <img src="{{ media('/img/styleguide/identity/mozilla/wordmark.png') }}" alt="Logo" />
+    <img src="{{ media('/img/styleguide/box-arrow-left.png?2013-06') }}" alt="" class="box-arrow" />
+    <img src="{{ media('/img/styleguide/identity/mozilla/wordmark.png?2013-06') }}" alt="Logo" />
   </div>
   <div class="download">
     <h4>Download</h4>
@@ -43,7 +43,7 @@
 </section>
 <section id="common-mistakes">
   <p>You can use any solid color for the Mozilla wordmark. Which color you choose depends on the color of the supporting design. When in doubt, please use the default charcoal color supplied above.</p>
-  <img src="{{ media('/img/styleguide/identity/mozilla/common-mistakes.png') }}" alt="Common Mistakes" />
+  <img src="{{ media('/img/styleguide/identity/mozilla/common-mistakes.png?2013-06') }}" alt="Common Mistakes" />
 </section>
 <section id="our-name">
   <h2>Our name</h2>

--- a/bedrock/styleguide/templates/styleguide/identity/mozilla-innovations.html
+++ b/bedrock/styleguide/templates/styleguide/identity/mozilla-innovations.html
@@ -29,7 +29,7 @@
 </section>
 <section id="downloads">
   <div id="webfwd">
-    <img src="{{ media('/img/styleguide/identity/mozilla/webfwd.png') }}" alt="Logo" />
+    <img src="{{ media('/img/styleguide/identity/mozilla/webfwd.png?2013-06') }}" alt="Logo" />
     <h3>WebFWD</h3>
     <ul class="button-list">
       <li><a href="https://assets.mozillalabs.com/Brands-Logos/WebFWD/webfwd_logo-only_CS4.eps" class="button-sand">EPS</a>
@@ -38,7 +38,7 @@
     </ul>
   </div>
   <div id="labs">
-    <img src="{{ media('/img/styleguide/identity/mozilla/labs.png') }}" alt="Logo" />
+    <img src="{{ media('/img/styleguide/identity/mozilla/labs.png?2013-06') }}" alt="Logo" />
     <h3>Mozilla Labs</h3>
     <ul class="button-list">
       <li><a href="https://assets.mozillalabs.com/Brands-Logos/Mozilla%20Labs/mozilla-labs_wordmark.eps" class="button-sand">EPS</a>
@@ -47,7 +47,7 @@
     </ul>
   </div>
   <div id="firebug" class="clear">
-    <img src="{{ media('/img/styleguide/identity/mozilla/firebug.png') }}" alt="Logo" />
+    <img src="{{ media('/img/styleguide/identity/mozilla/firebug.png?2013-06') }}" alt="Logo" />
     <h3>Firebug</h3>
     <ul class="button-list">
       <li><a href="https://assets.mozillalabs.com/Projects/Firebug/firebug_logo-only_CS4.eps" class="button-sand">EPS</a>
@@ -56,7 +56,7 @@
     </ul>
   </div>
   <div id="pancake">
-    <img src="{{ media('/img/styleguide/identity/mozilla/pancake.png') }}" alt="Logo" />
+    <img src="{{ media('/img/styleguide/identity/mozilla/pancake.png?2013-06') }}" alt="Logo" />
     <h3>Pancake</h3>
     <ul class="button-list">
       <li><a href="https://assets.mozillalabs.com/Projects/Pancake/pancake_logo-only_CS4.eps" class="button-sand">EPS</a>
@@ -65,7 +65,7 @@
     </ul>
   </div>
   <div id="rust">
-    <img src="{{ media('/img/styleguide/identity/mozilla/rust.png') }}" alt="Logo" />
+    <img src="{{ media('/img/styleguide/identity/mozilla/rust.png?2013-06') }}" alt="Logo" />
     <h3>Rust</h3>
     <ul class="button-list">
       <li><a href="https://assets.mozillalabs.com/Projects/Rust/rust_logo-only_CS4.eps" class="button-sand">EPS</a>

--- a/bedrock/styleguide/templates/styleguide/identity/thunderbird-channels.html
+++ b/bedrock/styleguide/templates/styleguide/identity/thunderbird-channels.html
@@ -24,7 +24,7 @@
     <h4>Tone</h4>
     <p>Friendly, accessible, trusted</p>
   </div>
-  <div class="logo"><img src="{{ media('/img/styleguide/identity/thunderbird/channels-thunderbird.png') }}" alt="Logo" /></div>
+  <div class="logo"><img src="{{ media('/img/styleguide/identity/thunderbird/channels-thunderbird.png?2013-06') }}" alt="Logo" /></div>
   <div class="download">
     <h4>Download</h4>
     <ul class="button-list">
@@ -42,7 +42,7 @@
     <h4>Tone</h4>
     <p>Friendly, accessible, trusted</p>
   </div>
-  <div class="logo"><img src="{{ media('/img/styleguide/identity/thunderbird/channels-thunderbird.png') }}" alt="Logo" /></div>
+  <div class="logo"><img src="{{ media('/img/styleguide/identity/thunderbird/channels-thunderbird.png?2013-06') }}" alt="Logo" /></div>
   <div class="download">
     <h4>Download</h4>
     <ul class="button-list">
@@ -60,7 +60,7 @@
     <h4>Tone</h4>
     <p>Friendly, accessible, mix of cutting edge and stable</p>
   </div>
-  <div class="logo"><img src="{{ media('/img/styleguide/identity/thunderbird/channels-thunderbird-earlybird.png') }}" alt="Logo" /></div>
+  <div class="logo"><img src="{{ media('/img/styleguide/identity/thunderbird/channels-thunderbird-earlybird.png?2013-06') }}" alt="Logo" /></div>
   <div class="download">
     <h4>Download</h4>
     <ul class="button-list">
@@ -78,7 +78,7 @@
     <h4>Tone</h4>
     <p>Friendly, accessbile, mix of cutting edge and stable</p>
   </div>
-  <div class="logo"><img src="{{ media('/img/styleguide/identity/thunderbird/channels-thunderbird-daily.png') }}" alt="Logo" /></div>
+  <div class="logo"><img src="{{ media('/img/styleguide/identity/thunderbird/channels-thunderbird-daily.png?2013-06') }}" alt="Logo" /></div>
   <div class="download">
     <h4>Download</h4>
     <ul class="button-list">

--- a/bedrock/styleguide/templates/styleguide/identity/thunderbird-logo.html
+++ b/bedrock/styleguide/templates/styleguide/identity/thunderbird-logo.html
@@ -27,7 +27,7 @@
     <li>use our logos to, or in connection with, content that disparages us or sullies our reputation</li>
   </ul>
   <div id="guidelines-logo">
-    <img src="{{ media('/img/styleguide/identity/thunderbird/logo.png') }}" alt="Logo" id="guidelines-logo-image" />
+    <img src="{{ media('/img/styleguide/identity/thunderbird/logo.png?2013-06') }}" alt="Logo" id="guidelines-logo-image" />
     <h3>Download</h3>
     <ul class="button-list">
       <li><a href="https://assets.mozillalabs.com/Brands-Logos/Thunderbird/logo-only/thunderbird_logo-only_CS4.eps" class="button-sand">EPS</a>
@@ -38,9 +38,9 @@
 </section>
 <section id="usage">
   <h2>Usage</h2>
-  <div><img src="{{ media('/img/styleguide/identity/thunderbird/usage-logo-wordmark.png') }}" alt="Usage Logo" id="usage-logo-wordmark" /></div>
+  <div><img src="{{ media('/img/styleguide/identity/thunderbird/usage-logo-wordmark.png?2013-06') }}" alt="Usage Logo" id="usage-logo-wordmark" /></div>
   <p>Our standard lockup for representing Thunderbird. In most cases, use this.</p>
-  <div><img src="{{ media('/img/styleguide/identity/thunderbird/usage-logo.png') }}" alt="Usage Logo" id="usage-logo" /></div>
+  <div><img src="{{ media('/img/styleguide/identity/thunderbird/usage-logo.png?2013-06') }}" alt="Usage Logo" id="usage-logo" /></div>
   <p>The logo on its own. You can safely use this if Mozilla and the Thunderbird brand are clearly visible or well established elsewhere on the page or in the design.</p>
 </section>
 </section>

--- a/bedrock/styleguide/templates/styleguide/identity/thunderbird-wordmarks.html
+++ b/bedrock/styleguide/templates/styleguide/identity/thunderbird-wordmarks.html
@@ -22,9 +22,9 @@
     <p>Our standard Thunderbird wordmark is set in Meta Medium and uses our standard <a href="{{ url('styleguide.communications.typefaces') }}#wordmarks">tiered font system</a>.</p>
   </div>
   <div class="logo">
-    <img src="{{ media('/img/styleguide/box-arrow-left.png') }}" alt="" class="box-arrow" />
-    <img src="{{ media('/img/styleguide/identity/thunderbird/wordmark-logo.png') }}" alt="Logo" />
-    <img src="{{ media('/img/styleguide/identity/thunderbird/wordmark.png') }}" alt="Logo" />
+    <img src="{{ media('/img/styleguide/box-arrow-left.png?2013-06') }}" alt="" class="box-arrow" />
+    <img src="{{ media('/img/styleguide/identity/thunderbird/wordmark-logo.png?2013-06') }}" alt="Logo" />
+    <img src="{{ media('/img/styleguide/identity/thunderbird/wordmark.png?2013-06') }}" alt="Logo" />
   </div>
   <div class="download">
     <h4>Download</h4>
@@ -48,9 +48,9 @@
     <p>The Thunderbird Beta wordmark uses our standard product + sub-brand <a href="{{ url('styleguide.communications.typefaces') }}#wordmarks">tiered font system</a>.</p>
   </div>
   <div class="logo">
-    <img src="{{ media('/img/styleguide/box-arrow-left.png') }}" alt="" class="box-arrow" />
-    <img src="{{ media('/img/styleguide/identity/thunderbird/wordmark-beta-logo.png') }}" alt="Logo" />
-    <img src="{{ media('/img/styleguide/identity/thunderbird/wordmark-beta.png') }}" alt="Logo" />
+    <img src="{{ media('/img/styleguide/box-arrow-left.png?2013-06') }}" alt="" class="box-arrow" />
+    <img src="{{ media('/img/styleguide/identity/thunderbird/wordmark-beta-logo.png?2013-06') }}" alt="Logo" />
+    <img src="{{ media('/img/styleguide/identity/thunderbird/wordmark-beta.png?2013-06') }}" alt="Logo" />
   </div>
   <div class="download">
     <h4>Download</h4>
@@ -74,9 +74,9 @@
     <p>The Thunderbird Earlybird wordmark uses our standard product + sub-brand <a href="{{ url('styleguide.communications.typefaces') }}#wordmarks">tiered font system</a>.</p>
   </div>
   <div class="logo">
-    <img src="{{ media('/img/styleguide/box-arrow-left.png') }}" alt="" class="box-arrow" />
-    <img src="{{ media('/img/styleguide/identity/thunderbird/wordmark-earlybird-logo.png') }}" alt="Logo" />
-    <img src="{{ media('/img/styleguide/identity/thunderbird/wordmark-earlybird.png') }}" alt="Logo" />
+    <img src="{{ media('/img/styleguide/box-arrow-left.png?2013-06') }}" alt="" class="box-arrow" />
+    <img src="{{ media('/img/styleguide/identity/thunderbird/wordmark-earlybird-logo.png?2013-06') }}" alt="Logo" />
+    <img src="{{ media('/img/styleguide/identity/thunderbird/wordmark-earlybird.png?2013-06') }}" alt="Logo" />
   </div>
   <div class="download">
     <h4>Download</h4>
@@ -100,9 +100,9 @@
     <p>The Thunderbird Daily wordmark uses our standard product + sub-brand <a href="{{ url('styleguide.communications.typefaces') }}#wordmarks">tiered font system</a>.</p>
   </div>
   <div class="logo">
-    <img src="{{ media('/img/styleguide/box-arrow-left.png') }}" alt="" class="box-arrow" />
-    <img src="{{ media('/img/styleguide/identity/thunderbird/wordmark-daily-logo.png') }}" alt="Logo" />
-    <img src="{{ media('/img/styleguide/identity/thunderbird/wordmark-daily.png') }}" alt="Logo" />
+    <img src="{{ media('/img/styleguide/box-arrow-left.png?2013-06') }}" alt="" class="box-arrow" />
+    <img src="{{ media('/img/styleguide/identity/thunderbird/wordmark-daily-logo.png?2013-06') }}" alt="Logo" />
+    <img src="{{ media('/img/styleguide/identity/thunderbird/wordmark-daily.png?2013-06') }}" alt="Logo" />
   </div>
   <div class="download">
     <h4>Download</h4>

--- a/bedrock/styleguide/templates/styleguide/identity/webmaker-branding.html
+++ b/bedrock/styleguide/templates/styleguide/identity/webmaker-branding.html
@@ -27,7 +27,7 @@
     <li>use our logos to, or in connection with, content that disparages us or sullies our reputation</li>
   </ul>
   <div class="guidelines-logo">
-    <img src="{{ media('/img/styleguide/identity/webmaker/logo.png') }}" alt="Logo" />
+    <img src="{{ media('/img/styleguide/identity/webmaker/logo.png?2013-06') }}" alt="Logo" />
     <h3>Download</h3>
     <ul class="button-list">
       <li><a href="https://assets.mozillalabs.com/Brands-Logos/Webmaker/mozilla-webmaker_logo-only_CS4.eps" class="button-sand">EPS</a>
@@ -38,11 +38,11 @@
 </section>
 <section id="usage">
   <h2>Usage</h2>
-  <div><img src="{{ media('/img/styleguide/identity/webmaker/usage-logo-wordmark.png') }}" alt="Usage Wordmark" /></div>
+  <div><img src="{{ media('/img/styleguide/identity/webmaker/usage-logo-wordmark.png?2013-06') }}" alt="Usage Wordmark" /></div>
   <p>Our standard lockup for representing Webmaker. In most cases, use this.</p>
-  <div><img src="{{ media('/img/styleguide/identity/webmaker/usage-logo.png') }}" alt="Usage Logo" /></div>
+  <div><img src="{{ media('/img/styleguide/identity/webmaker/usage-logo.png?2013-06') }}" alt="Usage Logo" /></div>
   <p>The logo on its own. You can safely use this if Mozilla and Webmaker are clearly visible or well established elsewhere on the page or in the design.</p>
-  <div class="clear"><img src="{{ media('/img/styleguide/identity/webmaker/usage-logo-bw.png') }}" alt="Usage Logo" /></div>
+  <div class="clear"><img src="{{ media('/img/styleguide/identity/webmaker/usage-logo-bw.png?2013-06') }}" alt="Usage Logo" /></div>
   <p>The one-color glyph can be used to represent Webmaker when a full color logo is not an option.</p>
 </section>
 <section id="wordmark">
@@ -51,9 +51,9 @@
     <p>The Webmaker wordmark follows our <a href="{{ url('styleguide.communications.typefaces') }}#wordmarks">tiered font system</a>.</p>
   </div>
   <div class="logo">
-    <img src="{{ media('/img/styleguide/box-arrow-left.png') }}" alt="" class="box-arrow" />
-    <img src="{{ media('/img/styleguide/identity/webmaker/wordmark-logo.png') }}" alt="Logo" />
-    <img src="{{ media('/img/styleguide/identity/webmaker/wordmark.png') }}" alt="Logo" />
+    <img src="{{ media('/img/styleguide/box-arrow-left.png?2013-06') }}" alt="" class="box-arrow" />
+    <img src="{{ media('/img/styleguide/identity/webmaker/wordmark-logo.png?2013-06') }}" alt="Logo" />
+    <img src="{{ media('/img/styleguide/identity/webmaker/wordmark.png?2013-06') }}" alt="Logo" />
   </div>
   <div class="download">
     <h4>Download</h4>

--- a/bedrock/styleguide/templates/styleguide/products/firefox-desktop-windows7.html
+++ b/bedrock/styleguide/templates/styleguide/products/firefox-desktop-windows7.html
@@ -1,6 +1,6 @@
 {% extends "styleguide/base.html" %}
 
-{% block guide_logo %}{{ media('/img/styleguide/mozilla-dark.png') }}{% endblock %}
+{% block guide_logo %}{{ media('/img/styleguide/mozilla-dark.png?2013-06') }}{% endblock %}
 
 {% block body_class %}
   {{ super() }}
@@ -14,22 +14,22 @@
 
   <figure id="tabs-shape">
     <figcaption>Shape</figcaption>
-    <img src="{{ media('/img/styleguide/products/firefox/tabs-shape.png') }}" alt="Tabs shape" />
+    <img src="{{ media('/img/styleguide/products/firefox/tabs-shape.png?2013-06') }}" alt="Tabs shape" />
   </figure>
 
   <figure id="tabs-dimentions">
     <figcaption>Dimentions | Padding</figcaption>
-    <img src="{{ media('/img/styleguide/products/firefox/tabs-dimentions.png') }}" alt="Tab dimensions | padding" />
+    <img src="{{ media('/img/styleguide/products/firefox/tabs-dimentions.png?2013-06') }}" alt="Tab dimensions | padding" />
   </figure>
 
   <figure id="tabs-overlap">
     <figcaption>Tab Overlap</figcaption>
-    <img src="{{ media('/img/styleguide/products/firefox/tabs-overlap.png') }}" alt="Tab overlap" />
+    <img src="{{ media('/img/styleguide/products/firefox/tabs-overlap.png?2013-06') }}" alt="Tab overlap" />
   </figure>
 
   <figure id="tabstrip">
     <figcaption>Tabstrip Layout Visualization</figcaption>
-    <img src="{{ media('/img/styleguide/products/firefox/tabstrip.png') }}" alt="Tabstrip layout visualization" />
+    <img src="{{ media('/img/styleguide/products/firefox/tabstrip.png?2013-06') }}" alt="Tabstrip layout visualization" />
   </figure>
 
 </section>

--- a/bedrock/styleguide/templates/styleguide/products/firefox-os-action-icons.html
+++ b/bedrock/styleguide/templates/styleguide/products/firefox-os-action-icons.html
@@ -1,6 +1,6 @@
 {% extends "styleguide/base.html" %}
 
-{% block guide_logo %}{{ media('/img/styleguide/mozilla-dark.png') }}{% endblock %}
+{% block guide_logo %}{{ media('/img/styleguide/mozilla-dark.png?2013-06') }}{% endblock %}
 
 {% block body_class %}
   {{ super() }}
@@ -53,7 +53,7 @@
     <div class="headers">
       <h4>{{ _('For headers and toolbars:') }}</h4>
       <figure>
-        <img src="{{ media('/img/styleguide/products/firefoxos/action-icons/icon-shadow.png') }}" alt="" />
+        <img src="{{ media('/img/styleguide/products/firefoxos/action-icons/icon-shadow.png?2013-06') }}" alt="" />
         <figcaption><div>
           <h5>{{ _('Drop shadow (Photoshop)') }}</h5>
           <ul>
@@ -73,7 +73,7 @@
     <div class="buttons">
       <h4>{{ _('For buttons:') }}</h4>
       <figure>
-        <img src="{{ media('/img/styleguide/products/firefoxos/action-icons/icon-no-shadow.png') }}" alt="" />
+        <img src="{{ media('/img/styleguide/products/firefoxos/action-icons/icon-no-shadow.png?2013-06') }}" alt="" />
         <figcaption><div>
           <h5>{{ _('No drop shadow') }}</h5>
         </div></figcaption>
@@ -83,7 +83,7 @@
     <div class="light">
       <h4>{{ _('For light backgrounds:') }}</h4>
       <figure>
-        <img src="{{ media('/img/styleguide/products/firefoxos/action-icons/icon-light.png') }}" alt="" />
+        <img src="{{ media('/img/styleguide/products/firefoxos/action-icons/icon-light.png?2013-06') }}" alt="" />
         <figcaption><div>
           <h5>{{ _('Drop shadow (same as above)') }}</h5>
         </div></figcaption>
@@ -104,9 +104,9 @@
       <li>{{ _('<strong>Approachable</strong> means friendly, inviting the user to touch.') }}</li>
     </ul>
     <p>{{ _('To achieve this look, we take the basic form of a radiused squared (approachable) and intersect it with both straight and elliptical cut lines (confident), as show below.') }}</p>
-    <p><img src="{{ media('/img/styleguide/products/firefoxos/action-icons/design-1.png') }}" alt="{{ _('Icon examples') }}" /></p>
+    <p><img src="{{ media('/img/styleguide/products/firefoxos/action-icons/design-1.png?2013-06') }}" alt="{{ _('Icon examples') }}" /></p>
     <p>{{ _('Complex forms can be achieved using radiused square, circle, & ellipse.') }}</p>
-    <p><img src="{{ media('/img/styleguide/products/firefoxos/action-icons/design-2.png') }}" alt="{{ _('Icon examples') }}" /></p>
+    <p><img src="{{ media('/img/styleguide/products/firefoxos/action-icons/design-2.png?2013-06') }}" alt="{{ _('Icon examples') }}" /></p>
     <p>{{ _('The designer should aim to create an icon that represents the desired function as simply and clearly as possible, while avoiding overly complex or compound ideas.') }}</p>
   </div>
 
@@ -123,13 +123,13 @@ as in the following examples.') }}</p>
   <div id="line-weights" class="sub-section">
     <h3>{{ _('Line weights') }}</h3>
     <p>{{ _('There are two main line weights that should be used. Additional line weights are allowed, but use sparingly if one of these two do not suffice.') }}</p>
-    <p><img src="{{ media('/img/styleguide/products/firefoxos/action-icons/line-weights.png') }}" alt="{{ _('Line weights: 2.4 pixels and 1.2 pixels') }}" /></p>
+    <p><img src="{{ media('/img/styleguide/products/firefoxos/action-icons/line-weights.png?2013-06') }}" alt="{{ _('Line weights: 2.4 pixels and 1.2 pixels') }}" /></p>
   </div>
 
   <div id="radius" class="sub-section">
     <h3>{{ _('Radiused Corners') }}</h3>
     <p>{{ _('Radiused corners come in two sizes. Use as you feel appropriate.') }}</p>
-    <p><img src="{{ media('/img/styleguide/products/firefoxos/action-icons/radiused-corners.png') }}" alt="{{ _('1.25 pixel radius or 2.5 pixel radius') }}" /></p>
+    <p><img src="{{ media('/img/styleguide/products/firefoxos/action-icons/radiused-corners.png?2013-06') }}" alt="{{ _('1.25 pixel radius or 2.5 pixel radius') }}" /></p>
   </div>
 
   <div id="arrows" class="sub-section">
@@ -137,15 +137,15 @@ as in the following examples.') }}</p>
     <p>{{ _('The use of arrow heads differs when it comes to navigation and non navigation UI.') }}</p>
     <p>{{ _('There are 3 types of arrows:') }}</p>
     <figure class="first">
-      <img src="{{ media('/img/styleguide/products/firefoxos/action-icons/arrows-ui.png') }}" alt="" />
+      <img src="{{ media('/img/styleguide/products/firefoxos/action-icons/arrows-ui.png?2013-06') }}" alt="" />
       <figcaption>UI navigation <small>(chevron)</small></figcaption>
     </figure>
     <figure>
-      <img src="{{ media('/img/styleguide/products/firefoxos/action-icons/arrows-web.png') }}" alt="" />
+      <img src="{{ media('/img/styleguide/products/firefoxos/action-icons/arrows-web.png?2013-06') }}" alt="" />
       <figcaption>Webpage navigation <small>(chevron + tail)</small></figcaption>
     </figure>
     <figure id="arrows-transfer">
-      <img src="{{ media('/img/styleguide/products/firefoxos/action-icons/arrows-transfer.png') }}" alt="" />
+      <img src="{{ media('/img/styleguide/products/firefoxos/action-icons/arrows-transfer.png?2013-06') }}" alt="" />
       <figcaption>Data transfer: E-Mail Send & Forward shown <small>(half radiused square head)</small></figcaption>
     </figure>
   </div>
@@ -153,7 +153,7 @@ as in the following examples.') }}</p>
   <div id="documents" class="sub-section">
     <h3>{{ _('Documents') }}</h3>
     <p>{{ _('Documents are represented by a 45 degree cut line on the top-left corner of a radiused square.') }}</p>
-    <p><img src="{{ media('/img/styleguide/products/firefoxos/action-icons/documents.png') }}" alt="{{ _('Document icons') }}</" /></p>
+    <p><img src="{{ media('/img/styleguide/products/firefoxos/action-icons/documents.png?2013-06') }}" alt="{{ _('Document icons') }}</" /></p>
   </div>
 
 </section>
@@ -167,66 +167,66 @@ as in the following examples.') }}</p>
   <div id="common-header-icons" class="common-icons">
     <h3>{{ _('Common Header Icons') }}</h3>
     <figure class="first">
-      <img src="{{ media('/img/styleguide/products/firefoxos/action-icons/common-menu.png') }}" alt="" />
+      <img src="{{ media('/img/styleguide/products/firefoxos/action-icons/common-menu.png?2013-06') }}" alt="" />
       <figcaption>{{ _('Menu') }}</figcaption>
     </figure>
     <figure>
-      <img src="{{ media('/img/styleguide/products/firefoxos/action-icons/common-back.png') }}" alt="" />
+      <img src="{{ media('/img/styleguide/products/firefoxos/action-icons/common-back.png?2013-06') }}" alt="" />
       <figcaption>{{ _('Back') }}</figcaption>
     </figure>
     <figure>
-      <img src="{{ media('/img/styleguide/products/firefoxos/action-icons/common-cancel.png') }}" alt="" />
+      <img src="{{ media('/img/styleguide/products/firefoxos/action-icons/common-cancel.png?2013-06') }}" alt="" />
       <figcaption>{{ _('Cancel') }}</figcaption>
     </figure>
     <figure>
-      <img src="{{ media('/img/styleguide/products/firefoxos/action-icons/common-new.png') }}" alt="" />
+      <img src="{{ media('/img/styleguide/products/firefoxos/action-icons/common-new.png?2013-06') }}" alt="" />
       <figcaption>{{ _('New') }}</figcaption>
     </figure>
     <figure class="first">
-      <img src="{{ media('/img/styleguide/products/firefoxos/action-icons/common-compose.png') }}" alt="" />
+      <img src="{{ media('/img/styleguide/products/firefoxos/action-icons/common-compose.png?2013-06') }}" alt="" />
       <figcaption>{{ _('Compose') }}</figcaption>
     </figure>
     <figure>
-      <img src="{{ media('/img/styleguide/products/firefoxos/action-icons/common-edit-list.png') }}" alt="" />
+      <img src="{{ media('/img/styleguide/products/firefoxos/action-icons/common-edit-list.png?2013-06') }}" alt="" />
       <figcaption>{{ _('Edit List') }}</figcaption>
     </figure>
     <figure>
-      <img src="{{ media('/img/styleguide/products/firefoxos/action-icons/common-settings.png') }}" alt="" />
+      <img src="{{ media('/img/styleguide/products/firefoxos/action-icons/common-settings.png?2013-06') }}" alt="" />
       <figcaption>{{ _('Settings') }}</figcaption>
     </figure>
   </div>
   <div id="common-toolbar-icons" class="common-icons">
     <h3>{{ _('Common toolbar icons') }}</h3>
     <figure class="first">
-      <img src="{{ media('/img/styleguide/products/firefoxos/action-icons/common-refresh.png') }}" alt="" />
+      <img src="{{ media('/img/styleguide/products/firefoxos/action-icons/common-refresh.png?2013-06') }}" alt="" />
       <figcaption>{{ _('Refresh') }}</figcaption>
     </figure>
     <figure>
-      <img src="{{ media('/img/styleguide/products/firefoxos/action-icons/common-delete.png') }}" alt="" />
+      <img src="{{ media('/img/styleguide/products/firefoxos/action-icons/common-delete.png?2013-06') }}" alt="" />
       <figcaption>{{ _('Delete') }}</figcaption>
     </figure>
     <figure>
-      <img src="{{ media('/img/styleguide/products/firefoxos/action-icons/common-search.png') }}" alt="" />
+      <img src="{{ media('/img/styleguide/products/firefoxos/action-icons/common-search.png?2013-06') }}" alt="" />
       <figcaption>{{ _('Search') }}</figcaption>
     </figure>
     <figure>
-      <img src="{{ media('/img/styleguide/products/firefoxos/action-icons/common-share.png') }}" alt="" />
+      <img src="{{ media('/img/styleguide/products/firefoxos/action-icons/common-share.png?2013-06') }}" alt="" />
       <figcaption>{{ _('Share') }}</figcaption>
     </figure>
     <figure class="first">
-      <img src="{{ media('/img/styleguide/products/firefoxos/action-icons/common-bookmark.png') }}" alt="" />
+      <img src="{{ media('/img/styleguide/products/firefoxos/action-icons/common-bookmark.png?2013-06') }}" alt="" />
       <figcaption>{{ _('Bookmark (Toggle)') }}</figcaption>
     </figure>
     <figure>
-      <img src="{{ media('/img/styleguide/products/firefoxos/action-icons/common-bookmarked.png') }}" alt="" />
+      <img src="{{ media('/img/styleguide/products/firefoxos/action-icons/common-bookmarked.png?2013-06') }}" alt="" />
       <figcaption>{{ _('Bookmarked (Toggle)') }}</figcaption>
     </figure>
     <figure>
-      <img src="{{ media('/img/styleguide/products/firefoxos/action-icons/common-mark.png') }}" alt="" />
+      <img src="{{ media('/img/styleguide/products/firefoxos/action-icons/common-mark.png?2013-06') }}" alt="" />
       <figcaption>{{ _('Mark (Toggle)') }}</figcaption>
     </figure>
     <figure>
-      <img src="{{ media('/img/styleguide/products/firefoxos/action-icons/common-marked.png') }}" alt="" />
+      <img src="{{ media('/img/styleguide/products/firefoxos/action-icons/common-marked.png?2013-06') }}" alt="" />
       <figcaption>{{ _('Marked (Toggle)') }}</figcaption>
     </figure>
   </div>
@@ -237,15 +237,15 @@ as in the following examples.') }}</p>
   <div class="intro">
     <figure>
       <h4>{{ _('Contact Details') }}</h4>
-      <img src="{{ media('/img/styleguide/products/firefoxos/action-icons/example-contact-details.png') }}" alt="" />
+      <img src="{{ media('/img/styleguide/products/firefoxos/action-icons/example-contact-details.png?2013-06') }}" alt="" />
     </figure>
     <figure>
       <h4>{{ _('Call Log') }}</h4>
-      <img src="{{ media('/img/styleguide/products/firefoxos/action-icons/example-call-log.png') }}" alt="" />
+      <img src="{{ media('/img/styleguide/products/firefoxos/action-icons/example-call-log.png?2013-06') }}" alt="" />
     </figure>
     <figure>
       <h4>{{ _('Email Inbox') }}</h4>
-      <img src="{{ media('/img/styleguide/products/firefoxos/action-icons/example-email-inbox.png') }}" alt="" />
+      <img src="{{ media('/img/styleguide/products/firefoxos/action-icons/example-email-inbox.png?2013-06') }}" alt="" />
     </figure>
   </div>
 </section>

--- a/bedrock/styleguide/templates/styleguide/products/firefox-os-icons.html
+++ b/bedrock/styleguide/templates/styleguide/products/firefox-os-icons.html
@@ -1,6 +1,6 @@
 {% extends "styleguide/base.html" %}
 
-{% block guide_logo %}{{ media('/img/styleguide/mozilla-dark.png') }}{% endblock %}
+{% block guide_logo %}{{ media('/img/styleguide/mozilla-dark.png?2013-06') }}{% endblock %}
 
 {% block body_class %}
   {{ super() }}
@@ -17,22 +17,22 @@
     <p>A Firefox OS application icon is a <strong>60x60 pixel</strong> image provided in 24-bit <strong>PNG</strong> format. Each of the standard OS application icons is contained within or underlayed with a <strong>58 pixel</strong> diameter circle shape.</p>
 
     <figure class="first">
-      <img src="{{ media('/img/styleguide/products/firefoxos/icon-template.png') }}" alt="Icon template" />
+      <img src="{{ media('/img/styleguide/products/firefoxos/icon-template.png?2013-06') }}" alt="Icon template" />
       <figcaption>60x60 pixel canvas<br />58 pixel diameter circle</figcaption>
     </figure>
 
     <figure>
-      <img src="{{ media('/img/styleguide/products/firefoxos/icon-circle.png') }}" alt="Circle container" />
+      <img src="{{ media('/img/styleguide/products/firefoxos/icon-circle.png?2013-06') }}" alt="Circle container" />
       <figcaption>Circle container</figcaption>
     </figure>
 
     <figure>
-      <img src="{{ media('/img/styleguide/products/firefoxos/icon-object-circle.png') }}" alt="Object + circle underlay" />
+      <img src="{{ media('/img/styleguide/products/firefoxos/icon-object-circle.png?2013-06') }}" alt="Object + circle underlay" />
       <figcaption>Object + circle underlay</figcaption>
     </figure>
 
     <figure class="last">
-      <img src="{{ media('/img/styleguide/products/firefoxos/icon-object-integrated-circle.png') }}" alt="Object integrated with circle" />
+      <img src="{{ media('/img/styleguide/products/firefoxos/icon-object-integrated-circle.png?2013-06') }}" alt="Object integrated with circle" />
       <figcaption>Object integrated with circle</figcaption>
     </figure>
 
@@ -43,17 +43,17 @@
     <p>A drop shadow is automatically generated based on the icon’s silhouette shape; <strong>do not</strong> include a drop shadow in the image you provide.</p>
 
     <figure>
-      <img src="{{ media('/img/styleguide/products/firefoxos/icon-shadow-correct.png') }}" alt="Correct way to provide icon" />
+      <img src="{{ media('/img/styleguide/products/firefoxos/icon-shadow-correct.png?2013-06') }}" alt="Correct way to provide icon" />
       <figcaption>Correct way to provide icon</figcaption>
     </figure>
 
     <figure>
-      <img src="{{ media('/img/styleguide/products/firefoxos/icon-shadow-automatic.png') }}" alt="Automatically generated drop shadow" />
+      <img src="{{ media('/img/styleguide/products/firefoxos/icon-shadow-automatic.png?2013-06') }}" alt="Automatically generated drop shadow" />
       <figcaption>Automatically generated drop shadow</figcaption>
     </figure>
 
     <figure>
-      <img src="{{ media('/img/styleguide/products/firefoxos/icon-shadow-incorrect.png') }}" alt="Incorrect" />
+      <img src="{{ media('/img/styleguide/products/firefoxos/icon-shadow-incorrect.png?2013-06') }}" alt="Incorrect" />
       <figcaption>Incorrect</figcaption>
     </figure>
 
@@ -74,15 +74,15 @@
   <div id="do">
     <h3>Do</h3>
     <figure>
-      <img src="{{ media('/img/styleguide/products/firefoxos/icon-do-circle.png') }}" alt="Circle example" />
+      <img src="{{ media('/img/styleguide/products/firefoxos/icon-do-circle.png?2013-06') }}" alt="Circle example" />
       <figcaption>If you use a circle, it should have a diameter of 58 pixels</figcaption>
     </figure>
     <figure>
-      <img src="{{ media('/img/styleguide/products/firefoxos/icon-do-rounded-square.png') }}" alt="Rounded square example" />
+      <img src="{{ media('/img/styleguide/products/firefoxos/icon-do-rounded-square.png?2013-06') }}" alt="Rounded square example" />
       <figcaption>Rounded square 8 pixel radius corners</figcaption>
     </figure>
     <figure>
-      <img src="{{ media('/img/styleguide/products/firefoxos/icon-do-square.png') }}" alt="Square example" />
+      <img src="{{ media('/img/styleguide/products/firefoxos/icon-do-square.png?2013-06') }}" alt="Square example" />
       <figcaption>Square 1 pixel radius corners</figcaption>
     </figure>
   </div>
@@ -90,13 +90,13 @@
   <div id="do-not">
     <h3>Do not do</h3>
     <figure>
-      <img src="{{ media('/img/styleguide/products/firefoxos/icon-do-not-circle.png') }}" alt="Do not do: Circle example" />
+      <img src="{{ media('/img/styleguide/products/firefoxos/icon-do-not-circle.png?2013-06') }}" alt="Do not do: Circle example" />
     </figure>
     <figure>
-      <img src="{{ media('/img/styleguide/products/firefoxos/icon-do-not-rounded-square.png') }}" alt="Do not do: Rounded square example" />
+      <img src="{{ media('/img/styleguide/products/firefoxos/icon-do-not-rounded-square.png?2013-06') }}" alt="Do not do: Rounded square example" />
     </figure>
     <figure>
-      <img src="{{ media('/img/styleguide/products/firefoxos/icon-do-not-square.png') }}" alt="Do not do: Square example" />
+      <img src="{{ media('/img/styleguide/products/firefoxos/icon-do-not-square.png?2013-06') }}" alt="Do not do: Square example" />
     </figure>
   </div>
 </section>
@@ -112,19 +112,19 @@ as in the following examples.</p>
   <div id="circle-a">
     <h3>a)</h3>
     <figure>
-      <img src="{{ media('/img/styleguide/products/firefoxos/icon-shape-logo.png') }}" alt="Your logo/icon" />
+      <img src="{{ media('/img/styleguide/products/firefoxos/icon-shape-logo.png?2013-06') }}" alt="Your logo/icon" />
       <figcaption>Your logo/icon</figcaption>
     </figure>
     <figure>
-      <img src="{{ media('/img/styleguide/products/firefoxos/icon-shape-cropped.png') }}" alt="Cropped" />
+      <img src="{{ media('/img/styleguide/products/firefoxos/icon-shape-cropped.png?2013-06') }}" alt="Cropped" />
       <figcaption>Cropped with 58 pixel diameter circle</figcaption>
     </figure>
     <figure>
-      <img src="{{ media('/img/styleguide/products/firefoxos/icon-shape-overlay.png') }}" alt="Overlay" />
+      <img src="{{ media('/img/styleguide/products/firefoxos/icon-shape-overlay.png?2013-06') }}" alt="Overlay" />
       <figcaption>Optional overlay supplied by Mozilla can be applied</figcaption>
     </figure>
     <figure>
-      <img src="{{ media('/img/styleguide/products/firefoxos/icon-shape-final.png') }}" alt="Final" />
+      <img src="{{ media('/img/styleguide/products/firefoxos/icon-shape-final.png?2013-06') }}" alt="Final" />
       <figcaption>Final</figcaption>
     </figure>
   </div>
@@ -132,15 +132,15 @@ as in the following examples.</p>
   <div id="circle-b">
     <h3>b)</h3>
     <figure>
-      <img src="{{ media('/img/styleguide/products/firefoxos/icon-icon.png') }}" alt="Your logo/icon" />
+      <img src="{{ media('/img/styleguide/products/firefoxos/icon-icon.png?2013-06') }}" alt="Your logo/icon" />
       <figcaption>Your logo/icon</figcaption>
     </figure>
     <figure>
-      <img src="{{ media('/img/styleguide/products/firefoxos/icon-icon-underlay.png') }}" alt="Icon with underlay" />
+      <img src="{{ media('/img/styleguide/products/firefoxos/icon-icon-underlay.png?2013-06') }}" alt="Icon with underlay" />
       <figcaption>Add circular underlay provided by Mozilla</figcaption>
     </figure>
     <figure>
-      <img src="{{ media('/img/styleguide/products/firefoxos/icon-icon-colors.png') }}" alt="Adjust colors" />
+      <img src="{{ media('/img/styleguide/products/firefoxos/icon-icon-colors.png?2013-06') }}" alt="Adjust colors" />
       <figcaption>Adjust colors</figcaption>
     </figure>
   </div>
@@ -149,15 +149,15 @@ as in the following examples.</p>
     <h3>c)</h3>
     <p>You can also make the object in front ‘break frame’, extending beyond the circle, as in the following example:</p>
     <figure>
-      <img src="{{ media('/img/styleguide/products/firefoxos/icon-break-example.png') }}" alt="Your logo/icon" />
+      <img src="{{ media('/img/styleguide/products/firefoxos/icon-break-example.png?2013-06') }}" alt="Your logo/icon" />
       <figcaption>Your logo/icon</figcaption>
     </figure>
     <figure>
-      <img src="{{ media('/img/styleguide/products/firefoxos/icon-break-underlay.png') }}" alt="Underlay" />
+      <img src="{{ media('/img/styleguide/products/firefoxos/icon-break-underlay.png?2013-06') }}" alt="Underlay" />
       <figcaption>Add circular underlay provided by Mozilla</figcaption>
     </figure>
     <figure>
-      <img src="{{ media('/img/styleguide/products/firefoxos/icon-break-colors.png') }}" alt="Adjust colors" />
+      <img src="{{ media('/img/styleguide/products/firefoxos/icon-break-colors.png?2013-06') }}" alt="Adjust colors" />
       <figcaption>Adjust colors</figcaption>
     </figure>
   </div>
@@ -167,24 +167,24 @@ as in the following examples.</p>
   <h2>Examples</h2>
   <div>
     <figure>
-      <img src="{{ media('/img/styleguide/products/firefoxos/icon-example-a.png') }}" alt="Example icon" />
+      <img src="{{ media('/img/styleguide/products/firefoxos/icon-example-a.png?2013-06') }}" alt="Example icon" />
     </figure>
     <figure>
-      <img src="{{ media('/img/styleguide/products/firefoxos/icon-example-b.png') }}" alt="Example icon" />
+      <img src="{{ media('/img/styleguide/products/firefoxos/icon-example-b.png?2013-06') }}" alt="Example icon" />
     </figure>
     <figure>
-      <img src="{{ media('/img/styleguide/products/firefoxos/icon-example-c.png') }}" alt="Example icon" />
+      <img src="{{ media('/img/styleguide/products/firefoxos/icon-example-c.png?2013-06') }}" alt="Example icon" />
     </figure>
   </div>
   <div>
     <figure>
-      <img src="{{ media('/img/styleguide/products/firefoxos/icon-example-1a.png') }}" alt="Example icon" />
+      <img src="{{ media('/img/styleguide/products/firefoxos/icon-example-1a.png?2013-06') }}" alt="Example icon" />
     </figure>
     <figure>
-      <img src="{{ media('/img/styleguide/products/firefoxos/icon-example-1b.png') }}" alt="Example icon" />
+      <img src="{{ media('/img/styleguide/products/firefoxos/icon-example-1b.png?2013-06') }}" alt="Example icon" />
     </figure>
     <figure>
-      <img src="{{ media('/img/styleguide/products/firefoxos/icon-example-1c.png') }}" alt="Example icon" />
+      <img src="{{ media('/img/styleguide/products/firefoxos/icon-example-1c.png?2013-06') }}" alt="Example icon" />
     </figure>
   </div>
 </section>

--- a/bedrock/styleguide/templates/styleguide/websites/community-overview.html
+++ b/bedrock/styleguide/templates/styleguide/websites/community-overview.html
@@ -18,15 +18,15 @@
   <p>Sandstone is a set of tools to help you make any community site consistent with our current brand guidelines and let visitors know that it is officially part of Mozilla.</p>
   <p>At minimum, please include <a href="{{ url('styleguide.websites.sandstone-tabzilla') }}">Tabzilla</a> and use <a href="{{ url('styleguide.websites.sandstone-typefaces') }}">Open Sans Light</a> for headers in your designs. You may also use responsive design, a large top promo area and a menu system like the one on mozilla.org and our other sites. The below examples show Sandstone implemented on various community pages. Please note the elements they have in common as well as those that have been customized or embellished.</p>
 </div>
-<img src="{{ media('/img/styleguide/websites/community-overview.png') }}" alt="Community sites overview" id="overview" />
+<img src="{{ media('/img/styleguide/websites/community-overview.png?2013-06') }}" alt="Community sites overview" id="overview" />
 </section>
 <section id="examples">
   <h3>Community</h3>
   <div>
-  <a href="http://www.mozillaparaguay.org/"><img src="{{ media('/img/styleguide/websites/sandstone/examples/paraguay.png') }}" alt="Mozilla Paraguay screenshot" /></a>
-  <a href="http://www.mozillabolivia.org/"><img src="{{ media('/img/styleguide/websites/sandstone/examples/bolivia.png') }}" alt="Mozilla Bolivia screenshot" /></a>
-  <a href="http://to.mozillacanada.org/"><img src="{{ media('/img/styleguide/websites/sandstone/examples/toblog.png') }}" alt="Mozilla Toronto screenshot" /></a>
-  <a href="http://mozilla-antarctica.org/"><img src="{{ media('/img/styleguide/websites/sandstone/examples/antarctica.png') }}" alt="Mozilla Antarctica screenshot" /></a>
+  <a href="http://www.mozillaparaguay.org/"><img src="{{ media('/img/styleguide/websites/sandstone/examples/paraguay.png?2013-06') }}" alt="Mozilla Paraguay screenshot" /></a>
+  <a href="http://www.mozillabolivia.org/"><img src="{{ media('/img/styleguide/websites/sandstone/examples/bolivia.png?2013-06') }}" alt="Mozilla Bolivia screenshot" /></a>
+  <a href="http://to.mozillacanada.org/"><img src="{{ media('/img/styleguide/websites/sandstone/examples/toblog.png?2013-06') }}" alt="Mozilla Toronto screenshot" /></a>
+  <a href="http://mozilla-antarctica.org/"><img src="{{ media('/img/styleguide/websites/sandstone/examples/antarctica.png?2013-06') }}" alt="Mozilla Antarctica screenshot" /></a>
   </div>
 </section>
 {% endblock %}

--- a/bedrock/styleguide/templates/styleguide/websites/sandstone-buttons.html
+++ b/bedrock/styleguide/templates/styleguide/websites/sandstone-buttons.html
@@ -59,7 +59,7 @@
     </div>
   </div>
   <div class="examples">
-    <img src="{{ media('/img/styleguide/websites/sandstone/icons.png') }}" alt="Sandstone icons" id="icons" />
+    <img src="{{ media('/img/styleguide/websites/sandstone/icons.png?2013-06') }}" alt="Sandstone icons" id="icons" />
   </div>
 </section>
 

--- a/bedrock/styleguide/templates/styleguide/websites/sandstone-examples.html
+++ b/bedrock/styleguide/templates/styleguide/websites/sandstone-examples.html
@@ -19,26 +19,26 @@
 <section id="examples">
   <h3>Product/Service/Innovation</h3>
   <div>
-  <a href="http://www.mozilla.org/"><img src="{{ media('/img/styleguide/websites/sandstone/examples/mozillaorg.png') }}" alt="Mozilla.org screenshot" /></a>
-  <a href="http://www.mozilla.org/firefox/"><img src="{{ media('/img/styleguide/websites/sandstone/examples/firefox.png') }}" alt="Firefox website screenshot" /></a>
-  <a href="http://www.mozilla.org/en-US/persona/"><img src="{{ media('/img/styleguide/websites/sandstone/examples/persona.png') }}" alt="Persona website screenshot" /></a>
-  <a href="https://air.mozilla.org/"><img src="{{ media('/img/styleguide/websites/sandstone/examples/airmozilla.png') }}" alt="Air Mozilla screenshot" /></a>
-  <a href="https://mozillalabs.com/"><img src="{{ media('/img/styleguide/websites/sandstone/examples/labs.png') }}" alt="Mozilla Labs screenshot" /></a>
-  <a href="https://webfwd.org/"><img src="{{ media('/img/styleguide/websites/sandstone/examples/webfwd.png') }}" alt="WebFWD screenshot" /></a>
+  <a href="http://www.mozilla.org/"><img src="{{ media('/img/styleguide/websites/sandstone/examples/mozillaorg.png?2013-06') }}" alt="Mozilla.org screenshot" /></a>
+  <a href="http://www.mozilla.org/firefox/"><img src="{{ media('/img/styleguide/websites/sandstone/examples/firefox.png?2013-06') }}" alt="Firefox website screenshot" /></a>
+  <a href="http://www.mozilla.org/en-US/persona/"><img src="{{ media('/img/styleguide/websites/sandstone/examples/persona.png?2013-06') }}" alt="Persona website screenshot" /></a>
+  <a href="https://air.mozilla.org/"><img src="{{ media('/img/styleguide/websites/sandstone/examples/airmozilla.png?2013-06') }}" alt="Air Mozilla screenshot" /></a>
+  <a href="https://mozillalabs.com/"><img src="{{ media('/img/styleguide/websites/sandstone/examples/labs.png?2013-06') }}" alt="Mozilla Labs screenshot" /></a>
+  <a href="https://webfwd.org/"><img src="{{ media('/img/styleguide/websites/sandstone/examples/webfwd.png?2013-06') }}" alt="WebFWD screenshot" /></a>
   </div>
 
   <h3>Blogs</h3>
   <div>
-  <a href="https://blog.mozilla.org/theden/"><img src="{{ media('/img/styleguide/websites/sandstone/examples/theden.png') }}" alt="The Den blog" /></a>
-  <a href="https://blog.mozilla.org/ux/"><img src="{{ media('/img/styleguide/websites/sandstone/examples/uxblog.png') }}" alt="Mozilla UX blog" /></a>
+  <a href="https://blog.mozilla.org/theden/"><img src="{{ media('/img/styleguide/websites/sandstone/examples/theden.png?2013-06') }}" alt="The Den blog" /></a>
+  <a href="https://blog.mozilla.org/ux/"><img src="{{ media('/img/styleguide/websites/sandstone/examples/uxblog.png?2013-06') }}" alt="Mozilla UX blog" /></a>
   </div>
 
   <h3>Community</h3>
   <div>
-  <a href="http://www.mozillaparaguay.org/"><img src="{{ media('/img/styleguide/websites/sandstone/examples/paraguay.png') }}" alt="Mozilla Paraguay screenshot" /></a>
-  <a href="http://www.mozillabolivia.org/"><img src="{{ media('/img/styleguide/websites/sandstone/examples/bolivia.png') }}" alt="Mozilla Bolivia screenshot" /></a>
-  <a href="http://to.mozillacanada.org/"><img src="{{ media('/img/styleguide/websites/sandstone/examples/toblog.png') }}" alt="Mozilla Toronto screenshot" /></a>
-  <a href="http://mozilla-antarctica.org/"><img src="{{ media('/img/styleguide/websites/sandstone/examples/antarctica.png') }}" alt="Mozilla Antarctica screenshot" /></a>
+  <a href="http://www.mozillaparaguay.org/"><img src="{{ media('/img/styleguide/websites/sandstone/examples/paraguay.png?2013-06') }}" alt="Mozilla Paraguay screenshot" /></a>
+  <a href="http://www.mozillabolivia.org/"><img src="{{ media('/img/styleguide/websites/sandstone/examples/bolivia.png?2013-06') }}" alt="Mozilla Bolivia screenshot" /></a>
+  <a href="http://to.mozillacanada.org/"><img src="{{ media('/img/styleguide/websites/sandstone/examples/toblog.png?2013-06') }}" alt="Mozilla Toronto screenshot" /></a>
+  <a href="http://mozilla-antarctica.org/"><img src="{{ media('/img/styleguide/websites/sandstone/examples/antarctica.png?2013-06') }}" alt="Mozilla Antarctica screenshot" /></a>
   </div>
 </section>
 

--- a/bedrock/styleguide/templates/styleguide/websites/sandstone-forms.html
+++ b/bedrock/styleguide/templates/styleguide/websites/sandstone-forms.html
@@ -33,7 +33,7 @@
     <p></p>
   </div>
   <div class="examples">
-    <img src="{{ media('/img/styleguide/websites/sandstone/modules.png') }}" alt="Call to action modules examples" id="module-examples" />
+    <img src="{{ media('/img/styleguide/websites/sandstone/modules.png?2013-06') }}" alt="Call to action modules examples" id="module-examples" />
   </div>
 </section>
 

--- a/bedrock/styleguide/templates/styleguide/websites/sandstone-grids.html
+++ b/bedrock/styleguide/templates/styleguide/websites/sandstone-grids.html
@@ -68,14 +68,14 @@
 
 <section id="grid-phone">
   <h3>Smartphone</h3>
-  <img src="{{ media('/img/styleguide/websites/sandstone/grid-phone.png') }}" alt="Smartphone grid" />
+  <img src="{{ media('/img/styleguide/websites/sandstone/grid-phone.png?2013-06') }}" alt="Smartphone grid" />
 </section>
 <section id="grid-tablet">
   <h3>Tablet</h3>
-  <img src="{{ media('/img/styleguide/websites/sandstone/grid-tablet.png') }}" alt="Tablet grid" />
+  <img src="{{ media('/img/styleguide/websites/sandstone/grid-tablet.png?2013-06') }}" alt="Tablet grid" />
 </section>
 <section id="grid-desktop">
   <h3>Desktop</h3>
-  <img src="{{ media('/img/styleguide/websites/sandstone/grid-desktop.png') }}" alt="Desktop grid" />
+  <img src="{{ media('/img/styleguide/websites/sandstone/grid-desktop.png?2013-06') }}" alt="Desktop grid" />
 </section>
 {% endblock %}

--- a/bedrock/styleguide/templates/styleguide/websites/sandstone-intro.html
+++ b/bedrock/styleguide/templates/styleguide/websites/sandstone-intro.html
@@ -15,6 +15,6 @@
 <section id="intro">
 <h2>What is Sandstone?</h2>
 <p>Sandstone is our defined style and form for Web properties. Combining set visual styles, UX elements, and a responsive grid system, it creates a cohesive brand experience across all our websites. This section details the key features of the system and how to make it your own!</p>
-<img src="{{ media('/img/styleguide/websites/sandstone/sandstone.png') }}" alt="Sandstone overview" id="overview" />
+<img src="{{ media('/img/styleguide/websites/sandstone/sandstone.png?2013-06') }}" alt="Sandstone overview" id="overview" />
 </section>
 {% endblock %}

--- a/bedrock/styleguide/templates/styleguide/websites/sandstone-tabzilla.html
+++ b/bedrock/styleguide/templates/styleguide/websites/sandstone-tabzilla.html
@@ -28,15 +28,15 @@
   <p>Tabzilla automatically resizes to the screen resolution and real estate of the device being used. All content is updated and pushed from a central location. Please read the requirements and follow the installation instructions further down this page to correctly add Tabzilla to your site.</p>
   <section id="tabzilla-phone">
     <h3>Smartphone tab</h3>
-    <img src="{{ media('/img/styleguide/websites/sandstone/tabzilla-phone.png') }}" alt="Smartphone tabzilla" />
+    <img src="{{ media('/img/styleguide/websites/sandstone/tabzilla-phone.png?2013-06') }}" alt="Smartphone tabzilla" />
   </section>
   <section id="tabzilla-tablet">
     <h3>Tablet tab</h3>
-    <img src="{{ media('/img/styleguide/websites/sandstone/tabzilla-tablet.png') }}" alt="Tablet tabzilla" />
+    <img src="{{ media('/img/styleguide/websites/sandstone/tabzilla-tablet.png?2013-06') }}" alt="Tablet tabzilla" />
   </section>
   <section id="tabzilla-desktop">
     <h3>Desktop tab</h3>
-    <img src="{{ media('/img/styleguide/websites/sandstone/tabzilla-desktop.png') }}" alt="Desktop tabzilla" />
+    <img src="{{ media('/img/styleguide/websites/sandstone/tabzilla-desktop.png?2013-06') }}" alt="Desktop tabzilla" />
   </section>
 </section>
 

--- a/media/css/styleguide/styleguide.less
+++ b/media/css/styleguide/styleguide.less
@@ -400,7 +400,7 @@ body.dark {
         clear: left;
     }
     #wrapper:before {
-        background: url(/media/img/styleguide/home.png) 50% 90px no-repeat;
+        background: url(/media/img/styleguide/home.png?2013-06) 50% 90px no-repeat;
         content:"";
         height: 800px;
         width: 100%;


### PR DESCRIPTION
Add URL var to end of image requests to ensure the new logo images are used rather than CDN cache.

This was a global search/replace. Please review carefully.
