### PR TITLE
Remove tcl device details on firefox os release notes page bug 869495

### DIFF
--- a/bedrock/firefox/templates/firefox/os/releasenotes.html
+++ b/bedrock/firefox/templates/firefox/os/releasenotes.html
@@ -308,15 +308,6 @@
             <li>{{ _('Maximum capacity of external memory card (GB): 32GB') }}</li>
           </ul>
         </li>
-        <li>
-          <h4>{{ _('Alcatel One Touch Fire') }}</h4>
-          <ul>
-            <li>{{ _('1GHz Processor, 256MB RAM, HVGA display') }}</li>
-            <li>{{ _('Screen: Capacitive touch, 3.5" HVGA, 320 x 480 pixels,TFT 262k color display') }}</li>
-            <li>{{ _('Internal memory 512MB NAND + 256MB RAM') }}</li>
-            <li>{{ _('Maximum Capacity of external memory card (GB) 32GB') }}</li>
-          </ul>
-        </li>
       </ul>
     </section>
 


### PR DESCRIPTION
This info has been requested to be removed (for the time being)
