### PR TITLE
Bug 869495 - changing 'release notes' to 'version notes'

### DIFF
--- a/bedrock/firefox/templates/firefox/os/releasenotes.html
+++ b/bedrock/firefox/templates/firefox/os/releasenotes.html
@@ -42,7 +42,7 @@
       uses a Linux kernel and boots into a Gecko-based runtime engine, which lets
       users run applications developed entirely using HTML, JavaScript, and other
       open web application APIs.') }}</p>
-      <p>{{ _('These release notes document the features, changes, known issues
+      <p>{{ _('These version notes document the features, changes, and known issues,
       as well as links to useful resources to help developers and partners work
       with this open web technology.') }}</p>
     </section>
@@ -51,9 +51,9 @@
       <h3>{{ _('Features') }}</h3>
       <p>
       {% trans %}
-        Welcome to the first release of the Firefox OS mobile operating system. This
-        release contains many core applications required for a smart phone but also
-        some features that  highlight the benefits and uniqueness of our open web
+        Welcome to the first release version of the Firefox OS mobile operating system. 
+        This version contains many core applications required for a smart phone but 
+        also some features that highlight the benefits and uniqueness of our open web
         platform offering.
       {% endtrans %}
       </p>
@@ -127,7 +127,7 @@
           <h4>{{ _('Marketplace') }}</h4>
         </li>
         <li>
-          <h4>{{ _('Alarm Clock') }}</h4>
+          <h4>{{ _('Clock') }}</h4>
         </li>
         <li>
           <h4>{{ _('Camera') }}</h4>
@@ -145,7 +145,7 @@
           <h4>{{ _('FM Radio') }}</h4>
         </li>
         <li>
-          <h4>{{ _('Cost Control') }}</h4>
+          <h4>{{ _('Usage') }}</h4>
         </li>
       </ul>
     </section>
@@ -236,7 +236,7 @@
       <h3>{{ _('Supported Locales') }}</h3>
       <ul class="section-items">
         <li>
-          <h4>{{ _('Portugese (Brasil)') }}</h4>
+          <h4>{{ _('Portuguese (Brazil)') }}</h4>
         </li>
         <li>
           <h4>{{ _('English (US)') }}</h4>
@@ -246,21 +246,6 @@
         </li>
         <li>
           <h4>{{ _('Polish') }}</h4>
-        </li>
-        <li>
-          <h4>{{ _('Croatian') }}</h4>
-        </li>
-        <li>
-          <h4>{{ _('Czech') }}</h4>
-        </li>
-        <li>
-          <h4>{{ _('German') }}</h4>
-        </li>
-        <li>
-          <h4>{{ _('Hungarian') }}</h4>
-        </li>
-        <li>
-          <h4>{{ _('Romanian') }}</h4>
         </li>
       </ul>
     </section>
@@ -291,22 +276,6 @@
         </li>
         <li>
           <h4><a href="https://developer.mozilla.org/docs/WebAPI/Permissions" rel="external">{{ _('Permissions and Security Model') }}</a></h4>
-        </li>
-      </ul>
-    </section>
-
-
-    <section class="notes-section" id="device-compat">
-      <h3>{{ _('Device Compatibility') }}</h3>
-      <ul class="section-items">
-        <li>
-          <h4>{{ _('ZTE Open') }}</h4>
-          <ul>
-            <li>{{ _('1GHz Processor, 256MB RAM, HVGA display') }}</li>
-            <li>{{ _('Screen: Capacitive TouchScreen TFT 3.5“ 320x480,262K color') }}</li>
-            <li>{{ _('Internal memory: 512MB NAND + 256MB DDR SDRAM') }}</li>
-            <li>{{ _('Maximum capacity of external memory card (GB): 32GB') }}</li>
-          </ul>
         </li>
       </ul>
     </section>
@@ -359,9 +328,9 @@
       <p>
       {% trans %}
         Firefox OS has a 4 digit version number: <samp>X.X.X.Y</samp>.
-        The first 2 digits are owned by the Mozilla product team and will denote releases
+        The first 2 digits are owned by the Mozilla product team and will denote versions
         with new features (eg: v1.1, 1.2, etc). The third digit will be incremented with
-        regular release tags (~every 6 weeks) for security updates, and the fourth will
+        regular version tags (~every 6 weeks) for security updates, and the fourth will
         be OEM owned.
       {% endtrans %}
       </p>

--- a/bedrock/firefox/urls.py
+++ b/bedrock/firefox/urls.py
@@ -78,5 +78,5 @@ urlpatterns = patterns('',
 
     page('firefox/os', 'firefox/os/index.html'),
 
-    page('firefox/os/releasenotes/1.0.1', 'firefox/os/releasenotes.html'),
+    page('firefox/os/notes/1.0.1', 'firefox/os/releasenotes.html'),
 )

--- a/bedrock/redirects/urls.py
+++ b/bedrock/redirects/urls.py
@@ -77,6 +77,6 @@ urlpatterns = patterns('',
     redirect(r'^persona/developer-faq/$', 'https://developer.mozilla.org/persona'),
     
     # Bug 869495 - For now we'll hard-code a redirect to 1.0.1
-    # In the future this should automatically go to the latest version's release notes
-    redirect(r'^firefox/os/releasenotes/$', '/firefox/os/releasenotes/1.0.1/')
+    # In the future this should automatically go to the latest version's notes
+    redirect(r'^firefox/os/notes/$', '/firefox/os/notes/1.0.1/'),
 )


### PR DESCRIPTION
New URL, a few content changes, removing devices.
