### PR TITLE
Partners page modal form not showing on Firefox OS devices bug 889776

### DIFF
--- a/media/css/firefox/partners.less
+++ b/media/css/firefox/partners.less
@@ -693,8 +693,8 @@ body.noscroll {
   height: 101%;
   position: fixed;
   top: 0;
-  right: 0;
-  bottom: 0;
+  right: auto;
+  bottom: auto;
   left: 0;
   z-index: 9999999;
   overflow: auto;


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=889776
