### PR TITLE
Update nav chevron detection and mobile slider toggle CSS bug 878871

### DIFF
--- a/media/css/firefox/os/firefox-os.less
+++ b/media/css/firefox/os/firefox-os.less
@@ -550,6 +550,7 @@ html[lang="en-US"] #get-firefox-os {
     z-index: 2;
     width: 218px;
     height: 332px;
+    background-color: #000;
     overflow: hidden;
   }
 
@@ -1037,6 +1038,7 @@ html[lang=hu] {
     padding: 0;
     list-style-type: none;
     margin: @baseLine 0 0 0;
+    overflow: hidden;
     li {
       width: 34px;
       height: 34px;

--- a/media/js/firefox/os/desktop.js
+++ b/media/js/firefox/os/desktop.js
@@ -449,7 +449,7 @@
           $navs.find('a[href="' + side_nav_targets[cur_target_index - 1] + '"]').addClass('curr');
         }
       }
-    }, { offset: nav_height });
+    }, { offset: nav_height + 1 });
   }
 
   function initTouchNavScroll() {
@@ -525,7 +525,7 @@
 
     // pin the ffos section pretty much immediately on page load
     controller.pin($('#adaptive-wrapper'), pinDur, {
-      offset: -(nav_height-2), // -2 is for tabzilla top border
+      offset: -(nav_height - 1), // -1 is for tabzilla
       pushFollowers: false
     });
 


### PR DESCRIPTION
This PR includes fixes for:
- When you clicked 'Mission", the chevron was still under "Features" until you scrolled down another pixel.
- On some Android stock browsers, the have-it-all slider left/right buttons we're not clickable due to a CSS bug.
