### PR TITLE
Enable get phone Spain (es) Firefox OS bug 878871

### DIFF
--- a/media/js/firefox/os/firefox-os.js
+++ b/media/js/firefox/os/firefox-os.js
@@ -14,14 +14,14 @@
   var COUNTRY_CODE = '';
 
   var PARTNER_DATA = {
-    // "es": {
-    //   "partner": [
-    //     {
-    //       "name": "Movistar",
-    //       "url": "http://www.movistar.es/firefoxos"
-    //     }
-    //   ]
-    // }
+    "es": {
+      "partner": [
+        {
+          "name": "Movistar",
+          "url": "http://www.movistar.es/firefoxos"
+        }
+      ]
+    }
   };
 
   /*


### PR DESCRIPTION
This PR is to enable the 'Get a Phone' call to action buttons for Spain (es).

Once merged this will be tested on dev/stage, before the set release date.
