### PR TITLE
Minor content edits for FxOS notes

### DIFF
--- a/bedrock/firefox/templates/firefox/os/releasenotes.html
+++ b/bedrock/firefox/templates/firefox/os/releasenotes.html
@@ -72,7 +72,7 @@
         </li>
         <li>
           <h4>{{ _('Contacts') }}</h4>
-          <p class="note">{{ _('Import your contact from your favorite social networks') }}</p>
+          <p class="note">{{ _('Import your contacts from your favorite social networks') }}</p>
         </li>
         <li>
           <h4>{{ _('Camera') }}</h4>
@@ -161,7 +161,7 @@
           <h4>{{ _('3G/Data') }}</h4>
         </li>
         <li>
-          <h4><a href="https://developer.mozilla.org/docs/WebAPI/WiFi_Information" rel="external">{{ _('WiFi') }}</a></h4>
+          <h4>{{ _('WiFi') }}</h4>
         </li>
         <li>
           <h4><a href="https://marketplace.firefox.com/" rel="external">{{ _('Open Web Apps') }}</a></h4>
@@ -179,7 +179,7 @@
           <h4>{{ _('Carrier billing') }}</h4>
         </li>
         <li>
-          <h4><a href="https://developer.mozilla.org/docs/WebAPI/WebBluetooth" rel="external">{{ _('Bluetooth') }}</a></h4>
+          <h4>{{ _('Bluetooth') }}</h4>
         </li>
         <li>
           <h4>{{ _('Network Manager') }}</h4>


### PR DESCRIPTION
Remove links for WiFi and Bluetooth.
Fix typo in Contacts description.
