### PR TITLE
Add links to Firefox OS release notes (Bug 890123)

### DIFF
--- a/bedrock/firefox/templates/firefox/os/index.html
+++ b/bedrock/firefox/templates/firefox/os/index.html
@@ -377,6 +377,11 @@
             Get your app on Firefox OS <a href="{{link}}">Submit it to the Firefox Marketplace</a>
             {% endtrans %}
           </li>
+          <li>
+            {% trans link="/firefox/os/notes/" %}
+            View the version notes <a href="{{link}}">Read about features, changes and more</a>
+            {% endtrans %}
+          </li>
         </ul>
       </div>
 

--- a/bedrock/firefox/templates/firefox/partners/index.html
+++ b/bedrock/firefox/templates/firefox/partners/index.html
@@ -226,6 +226,10 @@
                 <h4>{{ _('Get involved') }}</h4>
                 <a href="#form" class="toggle-form">{{ _('Contact our business development team to get on board') }}</a>
               </div>
+              <div>
+                <h4>{{ _('View the version notes') }}</h4>
+                <a href="/firefox/os/notes/">{{ _('Read about features, changes and more') }}</a>
+              </div>
             </div>
           </div>
 

--- a/media/css/firefox/partners.less
+++ b/media/css/firefox/partners.less
@@ -351,9 +351,6 @@
     }
     #os-operators {
         padding-top: @baseLine * 2;
-        h4 {
-            font-size: 22px;
-        }
     }
 }
 

--- a/media/css/firefox/partners/desktop.less
+++ b/media/css/firefox/partners/desktop.less
@@ -332,9 +332,6 @@
             ul li {
                 margin: 10px 20px;
             }
-            .promos div {
-                .span-all();
-            }
         }
         .logos {
             .span(6);


### PR DESCRIPTION
Used direct links to `href="/firefox/os/notes/` because the named view includes the version number. This will be better in the ambiguous future.

Also note that this will need l10n before going into production
