### PR TITLE
return 500 in lib.bedrock_util.server_error_view

### DIFF
--- a/lib/bedrock_util.py
+++ b/lib/bedrock_util.py
@@ -22,4 +22,4 @@ def secure_required(view_func):
 
 def server_error_view(request, template_name='500.html'):
     """500 error handler that runs context processors."""
-    return l10n_utils.render(request, template_name)
+    return l10n_utils.render(request, template_name, status=500)


### PR DESCRIPTION
`handler500` is responsible for return the 500 status_code, IIUC.
