### PR TITLE
Bug 889958

### DIFF
--- a/etc/httpd/global.conf
+++ b/etc/httpd/global.conf
@@ -93,9 +93,10 @@ RewriteRule ^/en-US(/?)$ /b/en-US$1 [PT]
 # bug 822260
 RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?about/mission.html$ /b/$1about/mission.html [PT]
 
-RewriteRule ^/en-US/about(/?)?$ /b/en-US/about$1 [PT]
-RewriteRule ^/en-US/about/partnerships(/?)$ /b/en-US/about/partnerships$1 [PT]
-RewriteRule ^/en-US/about/partnerships/distribution(/?)$ /b/en-US/about/partnerships/distribution$1 [PT]
+# bug 889958
+RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?about(/?)?$ /b/$1about$2 [PT]
+RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?about/partnerships(/?)$ /b/$1about/partnerships$2 [PT]
+RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?about/partnerships/distribution(/?)$ /b/$1about/partnerships/distribution$2 [PT]
 RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?mission(/?)$ /b/$1mission$2 [PT]
 
 # bug 843789


### PR DESCRIPTION
Partnership pages in Tabzilla are 404, I believe this is because of the hardcoded en-US redirects on bedrock
