### PR TITLE
Bug 892716: Handle /firefox/ redirects in bedrock.

### DIFF
--- a/bedrock/firefox/firefox_details.py
+++ b/bedrock/firefox/firefox_details.py
@@ -28,7 +28,6 @@ class FirefoxDetails(ProductDetails):
         'esr': 'FIREFOX_ESR',
         'release': 'LATEST_FIREFOX_VERSION',
     }
-    esr_major_versions = [10, 17]
 
     def __init__(self):
         super(FirefoxDetails, self).__init__()
@@ -36,6 +35,18 @@ class FirefoxDetails(ProductDetails):
     def latest_version(self, channel):
         version = self.channel_map.get(channel, 'LATEST_FIREFOX_VERSION')
         return self.firefox_versions[version]
+
+    def latest_major_version(self, channel):
+        """Return latest major version as an int."""
+        lv = self.latest_version(channel)
+        try:
+            return int(lv.split('.')[0])
+        except ValueError:
+            return 0
+
+    @property
+    def esr_major_versions(self):
+        return range(10, self.latest_major_version('release'), 7)
 
     def _matches_query(self, info, query):
         query = query.lower()

--- a/bedrock/firefox/urls.py
+++ b/bedrock/firefox/urls.py
@@ -25,6 +25,7 @@ whatsnew_re = latest_re % (version_re, 'whatsnew')
 
 
 urlpatterns = patterns('',
+    url(r'^firefox/$', views.firefox_redirect, name='firefox'),
     url(r'^firefox/all/$', views.all_downloads, name='firefox.all'),
     page('firefox/central', 'firefox/central.html'),
     page('firefox/channel', 'firefox/channel.html'),

--- a/bedrock/mozorg/views.py
+++ b/bedrock/mozorg/views.py
@@ -12,8 +12,8 @@ from django.views.decorators.http import require_POST
 from django.shortcuts import redirect
 
 import basket
-from lib import l10n_utils
 import requests
+from lib import l10n_utils
 from commonware.decorators import xframe_allow
 from funfactory.urlresolvers import reverse
 from lib.l10n_utils.dotlang import _

--- a/etc/httpd/global.conf
+++ b/etc/httpd/global.conf
@@ -405,3 +405,6 @@ RewriteRule ^/projects/security/older-vulnerabilities.html$ /security/known-vuln
 
 # bug 860460, 892696
 RewriteRule ^/en-US/newsletter(/?)$ /b/en-US/newsletter$1 [PT]
+
+# bug 892716
+RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox(/)?$ /b/$1firefox$2 [PT]


### PR DESCRIPTION
This handles old, current, future, and ESR Fx versions, as well as non-Fx
browsers.
