### PR TITLE
Bug 893514 - Remove "en-US" and update SUMO links in /firefox/update

### DIFF
--- a/bedrock/firefox/templates/firefox/update.html
+++ b/bedrock/firefox/templates/firefox/update.html
@@ -46,7 +46,7 @@
     <h3 class="expander-header">{{ _('How do I update Firefox?') }}</h3>
     <div class="expander-content">
       <p>{{ _('By default, Firefox is configured to automatically check for updates for itself and notify you when one is available. When prompted, just click OK and the newest version will be downloaded and installed on your computer. You’ll need to restart Firefox to begin using the new version.') }}</p>
-      <p>{% trans link='href="https://support.mozilla.org/en-US/kb/Updating+Firefox#Manually_check_for_updates"'|safe %}
+      <p>{% trans link='href="https://support.mozilla.org/kb/update-firefox-latest-version#w_how-do-i-manually-check-for-updates"'|safe %}
       You are also able to check for updates manually. For details, check out the <a {{link}}>step-by-step guide</a>.</p>
       {% endtrans %}</p>
     </div>
@@ -55,7 +55,7 @@
   <div class="expander expander-odd">
     <h3 class="expander-header">{{ _('How do I know what version of Firefox I am currently on?') }}</h3>
     <div class="expander-content">
-      <p>{% trans link='href="http://support.mozilla.org/kb/Finding+your+Firefox+version"'|safe %}
+      <p>{% trans link='href="https://support.mozilla.org/kb/find-what-version-firefox-you-are-using"'|safe %}
       It varies slightly depending on the operating system you're using. You can find <a {{link}}>instructions for your computer here</a>.
       {% endtrans %}</p>
     </div>
@@ -78,7 +78,7 @@
   <div class="expander">
     <h3 class="expander-header">{{ _('How long will it take to update?') }}</h3>
     <div class="expander-content">
-      <p>{% trans link='href="https://support.mozilla.org/en-US/kb/Updating+Firefox#Automatic_updates"'|safe %}
+      <p>{% trans link='href="https://support.mozilla.org/kb/update-firefox-latest-version#w_how-do-automatic-updates-work"'|safe %}
       Not long at all – the entire process just takes a minute or two. Visit our support page for <a {{link}}>step-by-step instructions</a>.
       {% endtrans %}</p>
     </div>
@@ -109,7 +109,7 @@
     <h3 class="expander-header">{{ _('What if I miss an update? Can I check for one myself?') }}</h3>
     <div class="expander-content">
       <p>{{ _('Yes. Firefox is configured to automatically check for updates, but it’s also possible to check for updates yourself.') }}</p>
-      <p><a href="https://support.mozilla.org/en-US/kb/Updating+Firefox#Manually_check_for_updates">{{ _('Follow the step-by-step process') }}</a></p>
+      <p><a href="https://support.mozilla.org/kb/update-firefox-latest-version#w_how-do-i-manually-check-for-updates">{{ _('Follow the step-by-step process') }}</a></p>
     </div>
   </div>
 


### PR DESCRIPTION
1. We shouldn't have en-US hard-coded in links to let the locale redirection work on SUMO
2. Links are out of date, so we end up having 3 redirects and broken anchors even on en-US
