### PR TITLE
Fix contribute email tests.

### DIFF
--- a/bedrock/mozorg/tests/test_util.py
+++ b/bedrock/mozorg/tests/test_util.py
@@ -6,9 +6,8 @@
 
 import os
 
-from django.conf import settings
+from django.test.utils import override_settings
 
-from mock import patch
 from nose.tools import ok_
 
 from bedrock.mozorg.tests import TestCase
@@ -18,8 +17,8 @@ from bedrock.mozorg.util import hide_contrib_form
 ROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'test_files')
 
 
-@patch.object(settings, 'ROOT', ROOT)
 class TestHideContribForm(TestCase):
+    @override_settings(ROOT=ROOT)
     def test_lang_file_is_hiding(self):
         """
         `hide_contrib_form` should return true if lang file has the

--- a/bedrock/mozorg/tests/test_views.py
+++ b/bedrock/mozorg/tests/test_views.py
@@ -2,18 +2,18 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from mock import Mock, patch
-from captcha.fields import ReCaptchaField
-
 from django.core import mail
 from django.test.client import Client
 
-from lib import l10n_utils
-from bedrock.mozorg.tests import TestCase
+from captcha.fields import ReCaptchaField
 from funfactory.urlresolvers import reverse
+from jinja2.exceptions import TemplateNotFound
+from mock import Mock, patch
 from nose.tools import assert_false, eq_, ok_
-from nose.plugins.skip import SkipTest
 from pyquery import PyQuery as pq
+
+from bedrock.mozorg.tests import TestCase
+from lib import l10n_utils
 
 
 class TestViews(TestCase):
@@ -145,10 +145,14 @@ class TestContribute(TestCase):
         eq_(m.extra_headers['Reply-To'], ','.join(cc))
 
     @patch.object(ReCaptchaField, 'clean', Mock())
-    def test_no_autoresponse_locale(self):
+    @patch('bedrock.mozorg.email_contribute.jingo.render_to_string')
+    def test_no_autoresponse_locale(self, render_mock):
         """
         L10N version to test contacts for functional area without autoresponses
         """
+        # first value is for send() and 2nd is for autorespond()
+        render_mock.side_effect = ['The Dude minds, man!',
+                                   TemplateNotFound('coding.txt')]
         self.data.update(interest='coding')
         self.client.post(self.url_pt_br, self.data)
         eq_(len(mail.outbox), 1)
@@ -160,17 +164,17 @@ class TestContribute(TestCase):
         eq_(m.extra_headers['Reply-To'], self.contact)
 
     @patch.object(ReCaptchaField, 'clean', Mock())
-    def test_with_autoresponse_locale(self):
+    @patch('bedrock.mozorg.email_contribute.jingo.render_to_string')
+    def test_with_autoresponse_locale(self, render_mock):
         """
         L10N version to test contacts for functional area with autoresponses
         """
-        # UnSkip once pt-BR translation of support.txt is done
-        raise SkipTest
+        render_mock.side_effect = 'The Dude abides.'
         self.data.update(interest='support')
         self.client.post(self.url_pt_br, self.data)
         eq_(len(mail.outbox), 2)
 
-        cc = ['marcelo.araldi@yahoo.com.br']
+        cc = ['envolva-se-mozilla-brasil@googlegroups.com']
         m = mail.outbox[0]
         eq_(m.from_email, 'contribute-form@mozilla.org')
         eq_(m.to, ['contribute@mozilla.org'])

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -9,7 +9,7 @@ Sphinx==1.0.7
 
 # Testing
 nose==1.0.0
-mock==0.8.0
+mock==1.0.1
 -e git://github.com/jbalogh/django-nose.git#egg=django_nose
 -e git://github.com/jbalogh/test-utils.git#egg=test-utils
 pyquery==1.0


### PR DESCRIPTION
These tests were relying on files in "locale" to either exist or not, and
these change often. I've added mocks that removes their dependence on these
sortof external files.

This does include an upgrade of the Mock library to 1.0.1. You'll need to `pip
install mock==1.0.1` in order to get your local tests to pass.
