### PR TITLE
Bug 893854: Geolocation page mobile menu doesn't work

### DIFF
--- a/bedrock/firefox/templates/firefox/geolocation.html
+++ b/bedrock/firefox/templates/firefox/geolocation.html
@@ -12,6 +12,7 @@
 {% endblock %}
 
 {% block site_js %}
+  {{ super() }}
   {{ js('geolocation') }}
 {% endblock %}
 

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -481,11 +481,10 @@ MINIFY_BUNDLES = {
             'js/libs/socialshare.min.js',
         ),
         'geolocation': (
-            'js/libs/jquery-1.4.4.min.js',
+            #'js/libs/jquery-1.4.4.min.js',
             'js/libs/jquery.nyroModal.pack.js',
             'js/base/mozilla-expanders.js',
             'js/firefox/geolocation-demo.js',
-            'js/base/footer-email-form.js',
         ),
         'home': (
             'js/base/mozilla-pager.js',


### PR DESCRIPTION
Switching from jQuery 1.4.4 to 1.7.1 doesn't seem to break nyroModal, but maybe I should change this to use /media/js/mozilla-modal.js in [Bug 868132](https://bugzil.la/868132)
