### PR TITLE
Bug 894074: /firefox should redirect to fx/new/ for old fx.

### DIFF
--- a/bedrock/firefox/tests.py
+++ b/bedrock/firefox/tests.py
@@ -317,14 +317,14 @@ class FxVersionRedirectsMixin(object):
 
     def test_bad_firefox(self):
         user_agent = 'Mozilla/5.0 (SaferSurf) Firefox 1.5'
-        self.assert_ua_redirects_to(user_agent, 'firefox.update')
+        self.assert_ua_redirects_to(user_agent, 'firefox.new')
 
     @patch.dict(product_details.firefox_versions,
                 LATEST_FIREFOX_VERSION='14.0')
     def test_old_firefox(self):
         user_agent = ('Mozilla/5.0 (Macintosh; Intel Mac OS X 10.7; rv:13.0) '
                       'Gecko/20100101 Firefox/13.0')
-        self.assert_ua_redirects_to(user_agent, 'firefox.update')
+        self.assert_ua_redirects_to(user_agent, 'firefox.new')
 
     @patch.dict(product_details.firefox_versions,
                 LATEST_FIREFOX_VERSION='13.0.5')

--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -150,7 +150,7 @@ def firefox_redirect(request):
     Redirect visitors based on their user-agent.
 
     - Up-to-date Firefox users go to firefox/fx/.
-    - Other Firefox users go to the firefox/update/.
+    - Other Firefox users go to the firefox/new/.
     - Non Firefox users go to the new page.
     """
     user_agent = request.META.get('HTTP_USER_AGENT', '')
@@ -158,13 +158,13 @@ def firefox_redirect(request):
         # TODO : Where to redirect bug 757206
         return HttpResponsePermanentRedirect(reverse('firefox.new'))
 
-    user_version = "0"
+    user_version = '0'
     match = UA_REGEXP.search(user_agent)
     if match:
         user_version = match.group(1)
 
     if not is_current_or_newer(user_version):
-        return HttpResponsePermanentRedirect(reverse('firefox.update'))
+        return HttpResponsePermanentRedirect(reverse('firefox.new'))
 
     return HttpResponseRedirect(reverse('firefox.fx'))
 
@@ -175,7 +175,7 @@ def latest_fx_redirect(request, fake_version, template_name):
     Redirect visitors based on their user-agent.
 
     - Up-to-date Firefox users see the whatsnew page.
-    - Other Firefox users go to the update page.
+    - Other Firefox users go to the new page.
     - Non Firefox users go to the new page.
     """
     user_agent = request.META.get('HTTP_USER_AGENT', '')
@@ -190,7 +190,7 @@ def latest_fx_redirect(request, fake_version, template_name):
         user_version = match.group(1)
 
     if not is_current_or_newer(user_version):
-        url = reverse('firefox.update')
+        url = reverse('firefox.new')
         return HttpResponsePermanentRedirect(url)
 
     locales_with_video = {


### PR DESCRIPTION
Also fix bug 869937: Similar redirect semantics for whatsnew and firstrun
pages.
