### PR TITLE
Bug 893144 - /newsletter/existing/ styling

### DIFF
--- a/media/css/newsletter/newsletter.less
+++ b/media/css/newsletter/newsletter.less
@@ -97,10 +97,19 @@
             th {
                 text-align: left;
                 h4 {
-                    .open-sans;
-                    font-size: @baseFontSize;
-                    letter-spacing: normal;
-                    margin: 0;
+                    margin: 0 0 5px 0;
+                    font-size: 22px;
+                    .en-only {
+                        color: @textColorTertiary;
+                        font-size: @baseFontSize;
+                    }
+                }
+                .description {
+                    margin: 0.2em 0 0 0;
+                    color: @textColorTertiary;
+                    font-weight: normal;
+                    font-size: @smallFontSize;
+                    line-height: 1.3;
                 }
             }
             td {


### PR DESCRIPTION
The styling sheet on /newsletter/existing was messed up - the
descriptions were all bolded and the newsletter titles were small.

Reverted styling of the TH part of the table to what it was in an
earlier version of newsletter.less. No way to tell what happened
to it due to rebasing on the original branch.

@sgarrity can you review since you did the original styling?
