### PR TITLE
Bug 892696 - Change default language for /newsletter

### DIFF
--- a/bedrock/base/templates/macros.html
+++ b/bedrock/base/templates/macros.html
@@ -13,6 +13,10 @@
                 <li>{{ _('Please enter a valid email address') }}</li>
             {% endif %}
 
+            {% if request.newsletter_form.lang.errors %}
+                <li>{{ request.newsletter_form.lang.errors }}</li>
+            {% endif %}
+
             {% if request.newsletter_form.newsletter.errors %}
                 <li>{{ request.newsletter_form.newsletter.errors }}</li>
             {% endif %}
@@ -42,7 +46,7 @@
       {% endif %}
 
       <div class="form-contents">
-        <div class="field field-email {% if request.newsletter_form.email.errors %}field-error{% endif %}">
+        <div class="field field-email {% if request.newsletter_form.email.errors %}form-field-error{% endif %}">
           {{ field_with_attrs(request.newsletter_form.email, placeholder=_('YOUR EMAIL HERE'))|safe }}
         </div>
 
@@ -53,14 +57,14 @@
             </div>
           {% endif %}
           {% if include_language %}
-            <div class="field field-language">
+            <div class="field field-language {% if request.newsletter_form.lang.errors %}form-field-error{% endif %}">
               {{ request.newsletter_form.lang|safe }}
             </div>
           {% endif %}
           <div class="field field-format">
             {{ request.newsletter_form.fmt|safe }}
           </div>
-          <div class="field field-privacy {% if request.newsletter_form.privacy.errors %}field-error{% endif %}">
+          <div class="field field-privacy {% if request.newsletter_form.privacy.errors %}form-field-error{% endif %}">
             {{ request.newsletter_form.privacy|safe }}
           </div>
         </div>

--- a/bedrock/mozorg/tests/test_helper_misc.py
+++ b/bedrock/mozorg/tests/test_helper_misc.py
@@ -33,7 +33,8 @@ class TestImgL10n(TestCase):
     def _render(self, locale, url):
         req = self.rf.get('/')
         req.locale = locale
-        return render("{{{{ img_l10n('{0}') }}}}".format(url), {'request': req})
+        return render("{{{{ img_l10n('{0}') }}}}".format(url),
+                      {'request': req})
 
     def test_works_for_default_lang(self):
         """Should output correct path for default lang always."""
@@ -170,16 +171,17 @@ class TestNewsletterFunction(TestCase):
 
     @patch('bedrock.newsletter.utils.get_newsletters')
     @patch.object(basket, 'subscribe')
-    def test_post_form_country_lang_not_required(self, sub_mock,
-                                                 get_newsletters):
+    def test_post_form_country_url_not_required(self, sub_mock,
+                                                get_newsletters):
         """
-        Form should successfully post without country, lang, or src url.
+        Form should successfully post without country or src url.
         """
         get_newsletters.return_value = newsletters
         data = {
             'newsletter-footer': 'Y',
             'newsletter': 'mozilla-and-you',
             'email': 'foo@bar.com',
+            'lang': 'en',
             'fmt': 'H',
             'privacy': 'Y',
         }
@@ -188,7 +190,7 @@ class TestNewsletterFunction(TestCase):
         assert_false(doc('form#footer-email-form'))
         ok_(doc('div#footer-email-form.thank'))
         sub_mock.assert_called_with('foo@bar.com', 'mozilla-and-you',
-                                    format='H')
+                                    format='H', lang='en')
 
     @patch('bedrock.newsletter.utils.get_newsletters')
     def test_post_wrong_form(self, get_newsletters):

--- a/bedrock/newsletter/tests/test_forms.py
+++ b/bedrock/newsletter/tests/test_forms.py
@@ -6,8 +6,8 @@ import mock
 from bedrock.mozorg.tests import TestCase
 
 from ..forms import (BooleanRadioRenderer, ManageSubscriptionsForm,
-                     NewsletterFooterForm, NewsletterForm, 
-                     UnlabeledTableCellRadios 
+                     NewsletterFooterForm, NewsletterForm,
+                     UnlabeledTableCellRadios
                      )
 from .test_views import newsletters
 
@@ -126,6 +126,7 @@ class TestNewsletterForm(TestCase):
         data = {
             'newsletter': 'mozilla-and-you',
             'email': 'dude@example.com',
+            'lang': 'en',
             'privacy': 'Y',
             'fmt': 'H',
         }
@@ -145,6 +146,7 @@ class TestNewsletterForm(TestCase):
         data = {
             'newsletter': 'mozilla-and-you,beta',
             'email': 'dude@example.com',
+            'lang': 'en',
             'privacy': 'Y',
             'fmt': 'H',
         }

--- a/bedrock/newsletter/tests/test_middleware.py
+++ b/bedrock/newsletter/tests/test_middleware.py
@@ -48,8 +48,8 @@ class TestNewsletterFooter(TestCase):
         doc = pq(resp.content)
         eq_(doc('#id_lang option[selected="selected"]').val(), 'pt')
 
-        # not supported. should default to 'en'
+        # not supported. should default to ''
         with self.activate('ak'):
             resp = self.client.get(reverse(self.view_name))
         doc = pq(resp.content)
-        eq_(doc('#id_lang option[selected="selected"]').val(), 'en')
+        eq_(doc('#id_lang option[selected="selected"]').val(), '')


### PR DESCRIPTION
On /newsletter and footer email forms, if the user's locale is not
for a language that our newsletters support, then instead of
defaulting the language field to 'en', default to having it not
set, to force the user to choose one of the supported languages
when subscribing instead of just clicking through and maybe not
wanting English but getting it anyway.
