### PR TITLE
Bug 893165 - /id/newsletter formatting

### DIFF
--- a/media/css/newsletter/newsletter.less
+++ b/media/css/newsletter/newsletter.less
@@ -10,10 +10,13 @@
         line-height: 1.1;
         margin: 0;
         span {
-            display: block;
             font-size: 64px;
         }
     }
+}
+
+#newsletter-existing #main-feature h1 span {
+    display: block;
 }
 
 #existing-newsletter-form {


### PR DESCRIPTION
The issue was that in the header 'Read all about it in our
<span>newsletter</span>', the <span> and </span> each were causing a
line break. In languages like Indonesian where the word order was
changed, e.g.:

```
Baca selengkapnya di <span>nawala</span> kami
```

this was breaking the header up into three short lines.

It turned out that header spans were being styled in newsletter.less
as "display: block". Getting rid of that solves the problem.

@sgarrity does this look okay?
