### PR TITLE
Bug 865058 - fix newsletter ordering

### DIFF
--- a/bedrock/newsletter/views.py
+++ b/bedrock/newsletter/views.py
@@ -114,7 +114,8 @@ def existing(request, token=None):
                 'subscribed': newsletter in user['newsletters'],
                 'newsletter': newsletter,
                 'description': data['description'],
-                'english_only': len(langs) == 1 and langs[0].startswith('en')
+                'english_only': len(langs) == 1 and langs[0].startswith('en'),
+                'order': data['order'],
             })
 
     # Sort by 'order' field if we were given it; otherwise, by title


### PR DESCRIPTION
- Fix sorting of newsletters on /existing page so they're sorted by
  the newsletters' `order` field
- Add a test
