### PR TITLE
Bug 893165: Turn off specialness of newsletter span

### DIFF
--- a/bedrock/newsletter/templates/newsletter/mozilla-and-you.html
+++ b/bedrock/newsletter/templates/newsletter/mozilla-and-you.html
@@ -7,6 +7,7 @@
 
 {% block newsletter_content %}
   <div id="main-feature">
+    {# Remove the span tags from the headline next time it changes: #}
     <h1 class="large">{{ _('Read all about it in our <span>newsletter</span>') }}</h1>
     <p>
       {% trans %}Subscribe to monthly updates and keep current with Mozilla news, including the latest tips and tricks for getting the most out of your Firefox browser. It’s the perfect way for us to keep in touch!{% endtrans %}

--- a/media/css/newsletter/newsletter.less
+++ b/media/css/newsletter/newsletter.less
@@ -9,9 +9,6 @@
     h1 {
         line-height: 1.1;
         margin: 0;
-        span {
-            font-size: 64px;
-        }
     }
 }
 
@@ -215,9 +212,6 @@
     #main-feature {
         h1 {
             font-size: 26px;
-            span {
-                font-size: inherit;
-            }
         }
     }
 


### PR DESCRIPTION
In the headline on the /newsletter page, turn off the special styling
of the span tag. We'd rather just remove the span tag from the text,
but that would invalidate all the existing translations.

Was discussed with @sgarrity in pull request #1078.
