### PR TITLE
Bug 818321 security policies

### DIFF
--- a/bedrock/mozorg/templates/mozorg/about/governance/policies.html
+++ b/bedrock/mozorg/templates/mozorg/about/governance/policies.html
@@ -15,9 +15,9 @@
 
 <h2>{{ _('Governance') }}</h2>
 <ul>
-	<li><a href="//www.mozilla.org/hacking/module-ownership.html">{{ _('Mozilla Modules and Module Ownership') }}</a></li>
-	<li><a href="//wiki.mozilla.org/Modules">{{ _('Module Owners List') }}</a></li>
-	<li><a href="//www.mozilla.org/about/policies/participation.html">{{ _('Mozilla Community Participation Guidelines') }}</a></li>
+  <li><a href="//www.mozilla.org/hacking/module-ownership.html">{{ _('Mozilla Modules and Module Ownership') }}</a></li>
+  <li><a href="//wiki.mozilla.org/Modules">{{ _('Module Owners List') }}</a></li>
+  <li><a href="//www.mozilla.org/about/policies/participation.html">{{ _('Mozilla Community Participation Guidelines') }}</a></li>
 </ul>
 
 <p>{% trans roles_url = url('mozorg.about.governance.roles') %}
@@ -27,38 +27,41 @@ For additional information on Mozilla’s governance structure, see the <a href=
 <h2>{{_('Hacking')}}</h2>
 
 <ul>
-	<li><a href="//www.mozilla.org/hacking/committer/">{{ _('Commit Access Policy') }}</a></li>
-	<li><a href="//www.mozilla.org/hacking/reviewers.html">{{ _('Super-Review Policy') }}</a></li>
-	<li><a href="//www.mozilla.org/hacking/regression-policy.html">{{ _('Performance Regressions Policy') }}</a></li>
+  <li><a href="//www.mozilla.org/hacking/committer/">{{ _('Commit Access Policy') }}</a></li>
+  <li><a href="//www.mozilla.org/hacking/reviewers.html">{{ _('Super-Review Policy') }}</a></li>
+  <li><a href="//www.mozilla.org/hacking/regression-policy.html">{{ _('Performance Regressions Policy') }}</a></li>
 </ul>
 
 <h2>{{ _('Licensing') }}</h2>
 <ul>
-	<li><a href="//www.mozilla.org/MPL/">{{ _('Source Code Licensing Terms') }}</a></li>
-	<li><a href="//www.mozilla.org/MPL/license-policy.html">{{ _('Mozilla Foundation License Policy') }}</a></li>
-	<li><a href="//www.mozilla.org/legal/eula/">{{ _('Mozilla Corporation End-User Licensing Agreement') }}</a></li>
-	<li><a href="//www.mozilla.org/legal/eula/">{{ _('Mozilla Foundation End-User Licensing Agreement') }}</a></li>
+  <li><a href="//www.mozilla.org/MPL/">{{ _('Source Code Licensing Terms') }}</a></li>
+  <li><a href="//www.mozilla.org/MPL/license-policy.html">{{ _('Mozilla Foundation License Policy') }}</a></li>
+  <li><a href="//www.mozilla.org/legal/eula/">{{ _('Mozilla Corporation End-User Licensing Agreement') }}</a></li>
+  <li><a href="//www.mozilla.org/legal/eula/">{{ _('Mozilla Foundation End-User Licensing Agreement') }}</a></li>
 </ul>
 
 <h2>{{ _('Privacy') }}</h2>
 <ul>
-	<li><a href="/privacy-policy.html">{{ _('Mozilla Privacy Policy') }}</a></li>
-	<li><a href="/legal/privacy/firefox.html">{{ _('Mozilla Firefox Privacy Policy') }}</a></li>
-	<li><a href="//mozillalabs.com/weave/weave-privacy-policy/">{{ _('Weave Privacy Policy') }}</a></li>
-	<li><a href="//testpilot.mozillalabs.com/privacy.html">{{ _('Test Pilot Privacy Policy') }}</a></li>
+  <li><a href="/privacy-policy.html">{{ _('Mozilla Privacy Policy') }}</a></li>
+  <li><a href="/legal/privacy/firefox.html">{{ _('Mozilla Firefox Privacy Policy') }}</a></li>
+  <li><a href="//mozillalabs.com/weave/weave-privacy-policy/">{{ _('Weave Privacy Policy') }}</a></li>
+  <li><a href="//testpilot.mozillalabs.com/privacy.html">{{ _('Test Pilot Privacy Policy') }}</a></li>
 </ul>
 
 <h2>{{ _('Security') }}</h2>
 <ul>
-	<li><a href="/projects/security/security-bugs-policy.html">{{ _('Security Bugs Policy') }}</a></li>
-	<li><a href="/projects/security/certs/policy/">{{ _('Mozilla CA Certificate Policy') }}</a></li>
+  <li><a href="{{ url('mozorg.about.governance.policies.security.tld-idn') }}">{{ _('IDN-enabled TLDs') }}</a></li>
+  <li><a href="/projects/security/certs/policy/">{{ _('Mozilla CA Certificate Policy') }}</a></li>
+  <li><a href="{{ url('mozorg.about.governance.policies.security.group') }}">{{ _('Mozilla Security Group') }}</a></li>
+  <li><a href="{{ url('mozorg.about.governance.policies.security.membership') }}">{{ _('Mozilla Security Group Membership Policy') }}</a></li>
+  <li><a href="{{ url('mozorg.about.governance.policies.security.bugs') }}">{{ _('Security Bugs Policy') }}</a></li>
 </ul>
 <h2>{{ _('Trademarks') }}</h2>
 <ul>
-	<li><a href="/foundation/trademarks/policy.html">{{ _('Mozilla Trademark Policy') }}</a></li>
-	<li><a href="/foundation/trademarks/l10n-policy.html">{{ _('Mozilla Trademark Policy for Localization Projects') }}</a></li>
-	<li><a href="/foundation/trademarks/l10n-website-policy.html">{{ _('Mozilla Trademark Policy for Web Sites Created by Localization Teams (draft)') }}</a></li>
-	<li><a href="/foundation/trademarks/distribution-policy.html">{{ _('Mozilla Trademark Policy for Distribution Partners (draft)') }}</a></li>
+  <li><a href="/foundation/trademarks/policy.html">{{ _('Mozilla Trademark Policy') }}</a></li>
+  <li><a href="/foundation/trademarks/l10n-policy.html">{{ _('Mozilla Trademark Policy for Localization Projects') }}</a></li>
+  <li><a href="/foundation/trademarks/l10n-website-policy.html">{{ _('Mozilla Trademark Policy for Web Sites Created by Localization Teams (draft)') }}</a></li>
+  <li><a href="/foundation/trademarks/distribution-policy.html">{{ _('Mozilla Trademark Policy for Distribution Partners (draft)') }}</a></li>
 </ul>
 
 <p>{% trans trademarks_url = "//www.mozilla.org/foundation/trademarks/" %}
@@ -67,8 +70,8 @@ For guidelines, FAQs and other information about trademarks, see the <a href="{{
 
 <h2>{{ _('Website') }}</h2>
 <ul>
-	<li><a href="/foundation/licensing/website-markup.html">{{ _('Website Markup Usage Policy') }}</a></li>
-	<li><a href="/foundation/licensing/website-content.html">{{ _('Mozilla.org Site Licensing Policy') }}</a></li>
+  <li><a href="/foundation/licensing/website-markup.html">{{ _('Website Markup Usage Policy') }}</a></li>
+  <li><a href="/foundation/licensing/website-content.html">{{ _('Mozilla.org Site Licensing Policy') }}</a></li>
 </ul>
 
 {% endblock %}

--- a/bedrock/mozorg/templates/mozorg/about/governance/policies/security/bugs.html
+++ b/bedrock/mozorg/templates/mozorg/about/governance/policies/security/bugs.html
@@ -1,0 +1,155 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/. #}
+
+{% extends "mozorg/about-base.html" %}
+
+{% block page_title %}{{ _('Handling Mozilla Security Bugs') }}{% endblock %}
+{% block body_class %}sand{% endblock %}
+
+{% block extrahead %}
+{% endblock %}
+
+{% block article %}
+  <h1 class="title-banner">{{ _('Handling Mozilla Security Bugs') }}</h1>
+
+  <p>{{ _(' Version 1.1') }}</p>
+  <p>{{ _('') }}</p>
+
+  <p><strong>{% trans mail='mailto:security@mozilla.org?subject=Mozilla%20security%20bug%20report' %}
+    IMPORTANT: Anyone who believes they have found a Mozilla-related security vulnerability can and should report
+it by sending email to the address <a href="{{ mail }}">security@mozilla.org</a>.
+  {% endtrans %}</strong></p>
+
+  <h2 id="intro">{{ _('Introduction') }}</h2>
+
+  <p>{{ _('In order to improve the Mozilla project’s approach to resolving Mozilla security vulnerabilities, mozilla.org is creating more formal arrangements for handling Mozilla security-related bugs. First, mozilla.org is appointing a security module owner charged with primary responsibility for coordinating the investigation and resolution of reported Mozilla security vulnerabilities; the security module owner will have one or more peers to assist in this task. At the same time mozilla.org is also creating a larger “Mozilla security bug group” by which Mozilla contributors and others can participate in addressing security vulnerabilities in Mozilla. This document describes how this new organizational structure will work, and how security-related Mozilla bug reports will be handled.') }}</p>
+
+  <p>{{ _('Note that the focus of this new structure is restricted solely to addressing actual security vulnerabilities arising from problems in Mozilla code. This work is separate from the work of developers adding new security features (cryptographically-based or otherwise) to Mozilla, although obviously many of the same people will be involved in both sets of activities.') }}</p>
+
+  <h2 id="background">{{ _('Background') }}</h2>
+
+  <p>{{ _('Security vulnerabilities are different from other bugs, because their consequences are potentially so severe: users’ private information (including financial information) could be exposed, users’ data could be destroyed, and users’ systems could be used as platforms for attacks on other systems. Thus people have strong feelings about how security-related bugs are handled, and in particular about the degree to which information about such bugs is publicly disclosed.') }}</p>
+
+  <p>{{ _('The Mozilla project is a public software development project, and thus we have an inherent bias towards openness. In particular, we understand and acknowledge the concerns of those who believe that all information about security vulnerabilities should be publicly disclosed as soon as it is known, so that users may take immediate steps to protect themselves and so that problems can get the maximum amount of developer attention and be fixed as soon as possible.') }}</p>
+
+  <p>{{ _('At the same time the Mozilla project receives substantial contributions of code and developer time from organizations that use (or plan to use) Mozilla code in their own product offerings. Some of these products may be used by large populations of end users, many of whom may not often upgrade or check for recent security fixes. We understand and acknowledge the concerns of those who believe that too-hasty disclosure of exploit details can provide a short-term advantage to potential attackers, who can exploit a problem before most end users become aware of its existence.') }}</p>
+
+  <p>{{ _('We believe that both sets of concerns are valid, and that both are worth addressing as best we can. We have attempted to create a compromise scheme for how the Mozilla project will handle reports of security vulnerabilities. We believe that it is a compromise that can be justified to those on both sides of the question regarding disclosure.') }}</p>
+
+  <h2 id="policies">{{ _('General policies') }}</h2>
+
+  <p>{{ _('mozilla.org has adopted the following general policies for handling bug reports related to security vulnerabilities:') }}</p>
+
+  <ul>
+    <li>{{ _('Security bug reports can be treated as special and handled differently than “normal” bugs. In particular, the mozilla.org Bugzilla system will allow bug reports related to security vulnerabilities to be marked as “Security-Sensitive,” and will have special access control features specifically for use with such bug reports. However a security bug can revert back to being a normal bug (by having the “Security-Sensitive” flag removed), in which case the access control restrictions will no longer be in effect.') }}</li>
+    <li>{{ _('Full information about security bugs will be restricted to a known group of people, using the Bugzilla access control restrictions described above. However that group can and will be expanded as necessary and appropriate.') }}</li>
+    <li>{{ _('As noted above, information about security bugs can be held confidential for some period of time; there is no pre-determined limit on how long that time period might be. However this is offset by the fact that the person reporting a bug has visibility into the activities (if any) being taken to address the bug, and has the power to open the bug report for public scrutiny.') }}</li>
+  </ul>
+
+  <p>{{ _('The remaining sections of the document describe in more detail how these general policies have been implemented in practice.') }}</p>
+
+  <h2 id="organization">{{ _('Organizational structure for handling security bugs') }}</h2>
+
+  <p>{{ _('We are organizing the investigation and fixing of Mozilla security vulnerabilities similar to the way Mozilla project activities are handled in general: There will be a security module owner, a small core group of active contributors who can act as peers to the module owner, a larger group of less active participants, and other people who may become involved from time to time. As with other parts of the Mozilla project, participation in Mozilla security-related activities will be open to both independent volunteers and to employees of the various corporations and other organizations involved with Mozilla.') }}</p>
+
+  <h3 id="owners">{{ _('The Mozilla security module owner and peers') }}</h3>
+
+  <p>{{ _('The Mozilla security module owner will have a similar level of power and responsibility as other Mozilla module owners; also as with other Mozilla module owners, mozilla.org staff will oversee the work of the security module owner and select a new security module owner should that ever be necessary for any reason.') }}</p>
+
+  <p>{{ _('The Mozilla security module owner will work with mozilla.org staff to select one or more people to act as peers to the security module owner in investigating and resolving security vulnerabilities; the peers will share responsibility for overseeing and coordinating any and all activities related to security bugs.') }}</p>
+
+  <h3 id="security-group">{{ _('The Mozilla security bug group') }}</h3>
+
+  <p>{% trans group=url('mozorg.about.governance.policies.security.group') %}
+  The Mozilla security module owner and peers will form the core of the Mozilla security bug group, and will select a number of other people to round out the group’s membership. Each and every member of the Mozilla security bug group will automatically have access to all Mozilla bugs marked “Security-Sensitive.” The <a href="{{ group }}">members</a> of the Mozilla security bug group will be drawn primarily from the following groups:
+  {% endtrans %}</p>
+
+  <ul>
+    <li>{{ _('security developers (i.e., those whose bugs are often singled out as security-relevant or who have security-relevant bugs assigned to them), and security QA people who are the QA contacts for those bugs;') }}</li>
+    <li>{{ _('“exploit hunters” with a good track record of finding significant Mozilla security vulnerabilities;') }}</li>
+    <li>{{ _('representatives of the various companies and groups actively distributing Mozilla-based products; and') }}</li>
+    <li>{{ _('super-reviewers and drivers.') }}</li>
+  </ul>
+
+  <p>{{ _('(The Bugzilla administrators will technically be in the Mozilla security bug group as well, mainly because they already have visibility into all Bugzilla data hosted through mozilla.org.)') }}</p>
+
+  <p>{{ _('The Mozilla security bug group will have a private mailing list, security-group@mozilla.org, to which everyone in the security bug group will be subscribed. This list will act as a forum for discussing group policy and the addition of new members, as described below. In addition, Mozilla.org will maintain a second well-known address, security@mozilla.org, through which people not on the security group can submit reports of security bugs. Mail sent to this address will go to the security module owner and peers, who will be responsible for posting the information received to Bugzilla, and marking the bug as “Security-Sensitive” if it is warranted given the nature and severity of the bug and the risk of potential exploits.') }}</p>
+
+  <h3 id="other">{{ _('Other participants') }}</h3>
+
+  <p>{{ _('Besides the permanent security bug group members described above, there are two other categories of people who may participate in security bug group activities and have access to otherwise-confidential security bug reports:') }}</p>
+
+  <ul>
+    <li>{{ _('A person who reports a security bug will have continued access to all Bugzilla activities associated with that bug, even if the bug is marked “Security-Sensitive.”') }}</li>
+    <li>{{ _('Any other persons may be given access to a particular security bug, by someone else (who does have access) adding them to the CC list for that bug.') }}</li>
+  </ul>
+
+  <p>{{ _('Thus someone reporting a security bug in essence becomes a member of the overall group of people working to investigate and fix that particular vulnerability, and anyone else may be easily invited to assist as well if and when that makes sense.') }}</p>
+
+  <h3 id="expanding">{{ _('Expanding the Mozilla security bug group') }}</h3>
+
+  <p>{{ _('As previously described, the Mozilla security module owner can select one or more peers to share the core work of coordinating investigation and resolution of Mozilla security vulnerabilities, and will work with them to create some agreed-upon ground rules for how this work can be most effectively shared among themselves. As with other Mozilla modules, we intend that this core group (module owner plus peers) remain small; its membership should change only infrequently and only after consultation with mozilla.org staff.') }}</p>
+
+  <p>{{ _('The security module owner and peers will also work with mozilla.org to populate the initial security bug group. We expect that the Mozilla security bug group will initially be significantly larger than the core group of module owner and peers, and that it may grow even further over time. New members can be added to the Mozilla security bug group as follows:') }}</p>
+
+  <ul>
+    <li>{{ _('New people can apply to join the security bug group, or may be recruited by existing members. Applicants for membership must have someone currently in the security bug group who is willing to vouch for them and nominate them for membership. Nomination is done by the “voucher” sending email to the security bug group private mailing list.') }}</li>
+    <li>{{ _('The applicant’s nomination for membership will then be considered for a period of a few days, during which members of the security bug group can speak out in favor of or against the applicant.') }}</li>
+    <li>{{ _('At the end of this period, the security module owner will decide to accept the applicant or not, based on feedback and objections from the security bug group in general and from the module owner’s peers in particular. If anyone else in the security bug group has a problem with the module owner’s decision then they can appeal to mozilla.org staff, who will make the final decision.') }}</li>
+  </ul>
+
+  <p>{{ _('The criteria for membership in the Mozilla security bug group are as follows:') }}</p>
+
+  <ul>
+    <li>{{ _('The applicant must be trusted by those already in the group.') }}</li>
+    <li>{{ _('The applicant should have a legitimate purpose for wishing to join the group.') }}</li>
+    <li>{{ _('The applicant must be able to add value to the group’s activities in some way.') }}</li>
+  </ul>
+
+  <p>{{ _('In practice, if over time a particular person happens to be frequently added to the CC list for security-sensitive bugs then they would be a good candidate to be invited to join the security bug group. (As described previously, once added to the security bug group that person would then have automatic access to all bugs marked security-sensitive, without having to be explicitly added to the CC list for each one.)') }}</p>
+
+  <p>{{ _('Note that although we intend to make it relatively simple for a new person to join the security bug group, and we are not limiting the size of the group to any arbitrary number, we also don’t want the group to expand without any limits whatsoever. We reserve the right to cap the membership at some reasonable level, either by refusing new applications or (if necessary and appropriate) by removing some existing members of the security bug group to make room for new ones.') }}</p>
+
+  <h2 id="disclosure">{{ _('Disclosure of security vulnerabilities') }}</h2>
+
+  <p>{{ _('The security module owner, peers, and other members of the Mozilla security bug group will <em>not</em> be asked to sign formal nondisclosure agreements or other legal paperwork. However we do expect members of the group') }}</p>
+
+  <ul>
+    <li>{{ _('not to disclose security bug information to others who are not members of the Mozilla security bug group or are not otherwise involved in resolving the bug, except that if a member of the Mozilla security bug group is employed by a distributor of Mozilla-based products, then that member may share such information within that distributor, provided that this information is shared only with those who have a need to know, only to the extent they need to know, and such information is labeled and treated as the organization generally treats confidential material,') }}</li>
+    <li>{{ _('not to post descriptions of exploits in public forums like newsgroups, and') }}</li>
+    <li>{{ _('to be careful in whom they add to the CC field of a bug (since all those CC’d on a security bug potentially have access to the complete bug report).') }}</li>
+  </ul>
+
+  <p>{{ _('When a bug is put into the security bug group, the group members, bug reporter, and others associated with the bug will decide by consensus, either through comments on the bug or the group mailing list, whether an immediate warning to users is appropriate and how it should be worded. The goals of this warning are:') }}</p>
+
+  <ul>
+    <li>{{ _('to inform Mozilla users and testers of potential security risks in the versions they are using, and what can be done to mitigate those risks, and') }}</li>
+    <li>{{ _('to establish, for each bug, the amount of information a distributor can reveal immediately (before a fix is available) without putting other distributors and their customers at risk.') }}</li>
+  </ul>
+
+  <p>{% trans known='http://www.mozilla.org/projects/security/known-vulnerabilities.html' %}
+  A typical warning will mention the application or module affected, the affected versions, and a workaround (e.g. disabling JavaScript). If the group decides to publish a warning, the module owner, a peer, or some other person they may designate will post this message to the <a href="{{ known }}"> Known Vulnerabilities</a> page (which will be the authoritative source for this information) and will also send a copy of this message to an appropriate moderated mailing list and/or newsgroup (e.g., netscape.public.mozilla.announce and/or some other newsgroup/list established specifically for this purpose). Mozilla distributors who wish to inform their users of the existence of a vulnerability may repost any information from the Known Vulnerabilities page to their own websites, mailing lists, release notes, etc., but should not disclose any additional information about the bug.
+  {% endtrans %}</p>
+
+  <p>{{ _('The original reporter of a security bug may decide when that bug report will be made public; disclosure is done by clearing the bug’s “Security-Sensitive” flag, after which the bug will revert to being an ordinary bug. We believe that investing this power in the bug reporter simply acknowledges reality: Nothing prevents the person reporting a security bug from publicizing information about the bug by posting it to channels outside the context of the Mozilla project. By not doing so, and by instead choosing to report bugs through the standard Bugzilla processes, the bug reporter is doing a positive service to the Mozilla project; thus it makes sense that the bug reporter should be able to decide when the relevant Bugzilla data should be made public.') }}</p>
+
+  <p>{{ _('However we will ask all individuals and organizations reporting security bugs through Bugzilla to follow the voluntary guidelines below:') }}</p>
+
+  <ul>
+    <li>{{ _('Before making a security bug world-readable, please provide a few days notice to the Mozilla security bug group by sending email to the private security bug group mailing list.') }}</li>
+    <li>{{ _('Please try not to keep bugs in the security-sensitive category for an unreasonably long amount of time.') }}</li>
+    <li>{{ _('Please try to be understanding and accommodating if a Mozilla distributor has a legitimate need to keep a bug in the security-sensitive category for some reasonable additional time period, e.g., to get a new release distributed to users. (Regarding this point, if all Mozilla distributors have a representative on the security bug group, then even if a bug remains in the security-sensitive category all affected distributors can still be informed and take appropriate action.)') }}</li>
+  </ul>
+
+  <p>{{ _('The security module owner will be the primary person responsible for ensuring that security bug reports are investigated and publicly disclosed in a timely manner, and that such bug reports do not remain in the Bugzilla database uninvestigated and/or undisclosed. If disputes arise about whether or when to disclose information about a security bug, the security bug group will discuss the issue via its mailing list and attempt to reach consensus. If necessary mozilla.org staff will serve as the “court of last resort.”') }}</p>
+
+  <p>{{ _('A final point about duplicate bug reports: Note that security bugs marked as duplicates are still considered separate as far as disclosure is concerned. Thus, for example, if a particular security vulnerability is reported initially and then is independently reported again by someone else, each bug reporter retains control over whether to publicly disclose their own bug, but their decision will not affect disclosure for the bug reported by the other person.') }}</p>
+
+  <h2 id="changing">{{ _('Changing this policy') }}</h2>
+
+  <p>{{ _('This policy is not set in stone. It is our hope that any disputes that arise over membership, disclosure, or any other issue addressed by this policy can be resolved by consensus among the Mozilla security module owner, the module owner’s peers, and other security bug group members through discussions on the private security bug group mailing list.') }}</p>
+
+  <p>{{ _('As with other Mozilla project issues, mozilla.org staff will have the final authority to make changes to this policy, and will do so only after consulting with the various parties involved and with the public Mozilla community, in order to ensure that all views are taken into account.') }}</p> 
+
+{% endblock %}

--- a/bedrock/mozorg/templates/mozorg/about/governance/policies/security/group.html
+++ b/bedrock/mozorg/templates/mozorg/about/governance/policies/security/group.html
@@ -1,0 +1,211 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/. #}
+
+{% extends "mozorg/about-base.html" %}
+
+{% block page_title %}{{ _('Mozilla Security Group') }}{% endblock %}
+{% block body_class %}sand{% endblock %}
+
+{% block extrahead %}
+    {{ css('security-group') }}
+{% endblock %}
+
+{% block article %}
+  <h1 class="title-banner">{{ _('Mozilla Security Group') }}</h1>
+
+  <p><strong>{% trans mail='mailto:security@mozilla.org?subject=Mozilla%20security%20bug%20report' %}
+    IMPORTANT: Anyone who believes they have found a Mozilla-related security vulnerability can and should report
+it by sending email to the address <a href="{{ mail }}">security@mozilla.org</a>.
+  {% endtrans %}</strong></p>
+
+  <ul>
+    <li><a href="{{ url('mozorg.about.governance.policies.security.membership') }}">
+      {{ _('Mozilla Security Group Membership Policy') }}
+    </a></li>
+  </ul>
+
+  <h3>{{ _('Security Group') }}</h3>
+
+  <ul class="unstyled members">
+    <li>Daniel Veditz, Moderator ({{ _('Mozilla') }})</li>
+    <li>Al Billings ({{ _('Mozilla') }})</li>
+    <li>Alex Keybl ({{ _('Mozilla') }})</li>
+    <li>Alexander Sack ({{ _('Ubuntu') }})</li>
+    <li>Alfred Peng ({{ _('OpenSolaris') }})</li>
+    <li>Andreas Gal ({{ _('Mozilla') }})</li>
+    <li>Andrew McCreight ({{ _('Mozilla') }})</li>
+    <li>Arun Ranganathan ({{ _('Mozilla') }})</li>
+    <li>Asa Dotzler ({{ _('Mozilla') }})</li>
+    <li>Ben Adida ({{ _('Mozilla') }})</li>
+    <li>Ben Bucksch ({{ _('Beonex') }})</li>
+    <li>Ben Turner ({{ _('Mozilla') }})</li>
+    <li>Benjamin Smedberg ({{ _('Mozilla') }})</li>
+    <li>Bill McCloskey ({{ _('Mozilla') }})</li>
+    <li>Blake Kaplan ({{ _('Mozilla') }})</li>
+    <li>Bob Clary ({{ _('Mozilla') }})</li>
+    <li>Bob Lord ({{ _('advisory member, Twitter') }})</li>
+    <li>Bob Moss ({{ _('Mozilla') }})</li>
+    <li>Boris Zbarsky ({{ _('Mozilla') }})</li>
+    <li>Brad Lassey ({{ _('Mozilla') }})</li>
+    <li>Brandon Sterne ({{ _('advisory member, Workday') }})</li>
+    <li>Brendan Eich ({{ _('Mozilla') }})</li>
+    <li>Cameron Kaiser ({{ _('TenFourFox') }})</li>
+    <li>Camilo Viecco ({{ _('Mozilla') }})</li>
+    <li>Carsten Book ({{ _('Mozilla') }})</li>
+    <li>Cheng Wang ({{ _('Mozilla') }})</li>
+    <li>Chris Beard ({{ _('Mozilla') }})</li>
+    <li>Chris Hofmann ({{ _('Mozilla') }})</li>
+    <li>Chris Lyon ({{ _('advisory member, Jive') }})</li>
+    <li>Christian Holler ({{ _('Mozilla') }})</li>
+    <li>Clint Talbert ({{ _('Mozilla') }})</li>
+    <li>Colin Blake ({{ _('Arcot') }})</li>
+    <li>Curtis Koenig ({{ _('Mozilla') }})</li>
+    <li>Dan Mosedale ({{ _('Mozilla') }})</li>
+    <li>Daniel Holbert ({{ _('Mozilla') }})</li>
+    <li>David Anderson ({{ _('Mozilla') }})</li>
+    <li>David Ascher ({{ _('Mozilla') }})</li>
+    <li>David Baron ({{ _('Mozilla') }})</li>
+    <li>David Bienvenu ({{ _('Mozilla') }})</li>
+    <li>David Bolter ({{ _('Mozilla') }})</li>
+    <li>David Chan ({{ _('Mozilla') }})</li>
+    <li>David Keeler ({{ _('Mozilla') }})</li>
+    <li>Dietrich Ayala ({{ _('Mozilla') }})</li>
+    <li>Doug Turner ({{ _('Mozilla') }})</li>
+    <li>Huzaifa Sidhpurwala ({{ _('Red Hat') }})</li>
+    <li>Gary Kwong ({{ _('Mozilla') }})</li>
+    <li>Gavin Sharp ({{ _('Mozilla') }})</li>
+    <li>Gervase Markham ({{ _('Mozilla') }})</li>
+    <li>Guillaume Destuynder ({{ _('Mozilla') }})</li>
+    <li>Ginn Chen ({{ _('Oracle') }})</li>
+    <li>Giorgio Maone ({{ _('NoScript.net') }})</li>
+    <li>Graydon Hoare ({{ _('Mozilla') }})</li>
+    <li>Ian Hickson ({{ _('advisory member, Google') }})</li>
+    <li>Ian Melven ({{ _('Mozilla') }})</li>
+    <li>J. Paul Reed ({{ _('Release Engineering Approaches') }})</li>
+    <li>Jay Sullivan ({{ _('Mozilla') }})</li>
+    <li>Jeff Walden ({{ _('Mozilla') }})</li>
+    <li>Jesse Ruderman ({{ _('Mozilla') }})</li>
+    <li>Jet Villeges ({{ _('Mozilla') }})</li>
+    <li>Joe Stevensen ({{ _('Mozilla') }})</li>
+    <li>Johnathan Nightingale ({{ _('Mozilla') }})</li>
+    <li>Johnny Stenback ({{ _('Mozilla') }})</li>
+    <li>John O'Duinn ({{ _('Mozilla') }})</li>
+    <li>Jonas Sicking ({{ _('Mozilla') }})</li>
+    <li>Jason Orendorff ({{ _('Mozilla') }})</li>
+    <li>Josh Aas ({{ _('Mozilla') }})</li>
+    <li>Juan Becerra ({{ _('Mozilla') }})</li>
+    <li>Justin Dolske ({{ _('Mozilla') }})</li>
+    <li>Justin Scott ({{ _('Mozilla') }})</li>
+    <li>Justin Wood ({{ _('SeaMonkey') }})</li>
+    <li>Kai Engert ({{ _('Red Hat') }})</li>
+    <li>Kathleen Wilson ({{ _('Mozilla') }})</li>
+    <li>Kevin Brosnan ({{ _('Mozilla') }})</li>
+    <li>Larissa Co ({{ _('Mozilla') }})</li>
+    <li>Lucas Adamski ({{ _('Mozilla') }})</li>
+    <li>Lukas Blakk ({{ _('Mozilla') }})</li>
+    <li>Marcia Knous ({{ _('Mozilla') }})</li>
+    <li>Mark Banner ({{ _('Mozilla') }})</li>
+    <li>Mark Finkle ({{ _('Mozilla') }})</li>
+    <li>Mark Goodwin ({{ _('Mozilla') }})</li>
+    <li>Martijn Wargers ({{ _('Mozilla') }})</li>
+    <li>Martin Stránský ({{ _('Red Hat') }})</li>
+    <li>Mats Palmgren ({{ _('Mozilla') }})</li>
+    <li>Matthew Zeier ({{ _('Mozilla') }})</li>
+    <li>Michael Coates ({{ _('Mozilla') }})</li>
+    <li>Mike Connor ({{ _('Mozilla') }})</li>
+    <li>Mike Hommey ({{ _('Debian') }})</li>
+    <li>Mitchell Baker ({{ _('Mozilla') }})</li>
+    <li>Monica Chew ({{ _('Mozilla') }})</li>
+    <li>Naoki Hirata ({{ _('Mozilla') }})</li>
+    <li>Naveed Ihsanullah ({{ _('Mozilla') }})</li>
+    <li>Neil Rashbrook</li>
+    <li>Olli Pettay ({{ _('Mozilla') }})</li>
+    <li>Patrick McManus ({{ _('Mozilla') }})</li>
+    <li>Paxton Cooper ({{ _('Mozilla') }})</li>
+    <li>Peter Van der Beken ({{ _('Mozilla') }})</li>
+    <li>Philipp Kewisch ({{ _('Calendar') }})</li>
+    <li>Randell Jesup ({{ _('Mozilla') }})</li>
+    <li>Raymond Forbes ({{ _('Mozilla') }})</li>
+    <li>Reed Loden</li>
+    <li>Rob Campbell ({{ _('Mozilla') }})</li>
+    <li>Robert Kaiser ({{ _('SeaMonkey') }})</li>
+    <li>Robert O'Callahan ({{ _('Mozilla') }})</li>
+    <li>Robert Relyea ({{ _('Red Hat') }})</li>
+    <li>Scott MacGregor ({{ _('Postbox, Inc.') }})</li>
+    <li>Seth Spitzer ({{ _('Postbox, Inc.') }})</li>
+    <li>Sheila Mooney ({{ _('Mozilla') }})</li>
+    <li>Sid Stamm ({{ _('Mozilla') }})</li>
+    <li>Smokey Ardisson ({{ _('Camino') }})</li>
+    <li>Stefan Arentz ({{ _('Mozilla') }})</li>
+    <li>Stephen Donner ({{ _('Mozilla') }})</li>
+    <li>Stuart Morgan ({{ _('Camino') }})</li>
+    <li>Tanvi Vyas ({{ _('Mozilla') }})</li>
+    <li>Tony Chung ({{ _('Mozilla') }})</li>
+    <li>Wan-Teh Chang ({{ _('Google') }})</li>
+    <li>Wolfgang Rosenauer ({{ _('openSUSE') }})</li>
+    <li>Yvan Boily ({{ _('Mozilla') }})</li>
+  </ul>
+
+  <h4 id="additional">{{ _('Additional developers with security bug access')}}</h4>
+
+  <ul class="unstyled members">
+    <li>Andrew Overholt ({{ _('Mozilla') }})</li>
+    <li>Anthony Hughes ({{ _('Mozilla') }})</li>
+    <li>Ben Hearsum ({{ _('Mozilla') }})</li>
+    <li>Benoit Jacob ({{ _('Mozilla') }})</li>
+    <li>Bhavana Bajaj ({{ _('Mozilla') }})</li>
+    <li>Brian Bondy ({{ _('Mozilla') }})</li>
+    <li>Brian Hackett ({{ _('Mozilla') }})</li>
+    <li>Bobby Holley ({{ _('Mozilla') }})</li>
+    <li>Chris AtLee ({{ _('Mozilla') }})</li>
+    <li>Chris Double ({{ _('Mozilla') }})</li>
+    <li>Chris Lee ({{ _('Mozilla') }})</li>
+    <li>Chris Pearce ({{ _('Mozilla') }})</li>
+    <li>Dão Gottwald ({{ _('Mozilla') }})</li>
+    <li>Dave Townsend ({{ _('Mozilla') }})</li>
+    <li>Deb Richardson ({{ _('Mozilla') }})</li>
+    <li>Ehsan Akhgari ({{ _('Mozilla') }})</li>
+    <li>Ed Morley ({{ _('Mozilla') }})</li>
+    <li>Florian Quèze</li>
+    <li>Gabor Krizsanits ({{ _('Mozilla') }})</li>
+    <li>Geo Mealer ({{ _('Mozilla') }})</li>
+    <li>Gregor Wagner ({{ _('UC Irvine') }})</li>
+    <li>Henrik Skupin ({{ _('Mozilla') }})</li>
+    <li>Honza Bambas ({{ _('Mozilla') }})</li>
+    <li>Irving Reid ({{ _('Mozilla') }})</li>
+    <li>Jan de Mooij ({{ _('Mozilla') }})</li>
+    <li>Jason Duell ({{ _('Mozilla') }})</li>
+    <li>Jason Smith ({{ _('Mozilla') }})</li>
+    <li>Jeff Muizelaar ({{ _('Mozilla') }})</li>
+    <li>Jim Blandy ({{ _('Mozilla') }})</li>
+    <li>Joe Drew ({{ _('Mozilla') }})</li>
+    <li>John Daggett ({{ _('Mozilla') }})</li>
+    <li>Jonathan Kew ({{ _('Mozilla') }})</li>
+    <li>Julian Seward ({{ _('Mozilla') }})</li>
+    <li>Karl Tomlinson ({{ _('Mozilla') }})</li>
+    <li>Kyle Huey ({{ _('Mozilla') }})</li>
+    <li>Lawrence Mandel ({{ _('Mozilla') }})</li>
+    <li>Ludovic Hirlimann ({{ _('Mozilla') }})</li>
+    <li>Luke Wagner ({{ _('Mozilla') }})</li>
+    <li>Marty Rosenberg ({{ _('Mozilla') }})</li>
+    <li>Matthew Gregan ({{ _('Mozilla') }})</li>
+    <li>Milan Sreckovic ({{ _('Mozilla') }})</li>
+    <li>Nick Thomas ({{ _('Mozilla') }})</li>
+    <li>Nicolas Pierron ({{ _('Mozilla') }})</li>
+    <li>Paul Theriault ({{ _('Mozilla') }})</li>
+    <li>Robert Longson</li>
+    <li>Robert Strong ({{ _('Mozilla') }})</li>
+    <li>Ryan VanderMeulen</li>
+    <li>Sean Stangl ({{ _('Mozilla') }})</li>
+    <li>Simon Montagu ({{ _('Mozilla') }})</li>
+    <li>Steve Fink ({{ _('Mozilla') }})</li>
+    <li>Steven Michaud ({{ _('Mozilla') }})</li>
+    <li>Terrance Cole ({{ _('Mozilla') }})</li>
+    <li>Tim Terriberry ({{ _('Mozilla') }})</li>
+    <li>Tracy Walker ({{ _('Mozilla') }})</li>
+    <li>Wayne Mery</li>
+  </ul>
+
+
+{% endblock %}

--- a/bedrock/mozorg/templates/mozorg/about/governance/policies/security/membership.html
+++ b/bedrock/mozorg/templates/mozorg/about/governance/policies/security/membership.html
@@ -1,0 +1,34 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/. #}
+
+{% extends "mozorg/about-base.html" %}
+
+{% block extrahead %}
+{% endblock %}
+
+{% block page_title %}{{ _('Mozilla Security Group Membership Policy') }}{% endblock %}
+{% block body_class %}sand{% endblock %}
+
+{% block article %}
+  <h1 class="title-banner">{{ _('Mozilla Security Group Membership Policy') }}</h1>
+
+  <p>{{ _('Version 1.01 - 2008-03-07') }}</p>
+
+  <p>{% trans bugzilla="https://bugzilla.mozilla.org/" %}
+    The Mozilla project has a Security Group, which maintains a private mailing list for defining security policies, and assessing and discussing both individual and broader security issues. The list is also used for coordinating security-related information pertaining to releases (e.g. MSA/CVE numbers). Membership of the Security Group is given to anyone who the group considers would be useful. Membership includes access to bugs in the “security” group in <a href="{{ bugzilla }}">Bugzilla</a>.
+  {% endtrans %}</p>
+
+  <p>{% trans %}
+    A second group of people have access to those bugs but are not members of the mailing list. These are people who need to see or work on security bugs as part of their role in the project. This might include coders, QA, build/release engineers, super-reviewers or drivers.
+  {% endtrans %}</p>
+
+  <p>{% trans group=url('mozorg.about.governance.policies.security.group') %}
+    Membership of each group is decided by the current membership of the Security Group. The list of members is <a href="{{ group }}">available here</a>. The Security Group moderator may, at his discretion, move inactive members to an “Alumni” list. This would involve removing them from the mailing list and/or removing their bug access, as appropriate. They can be reactivated by him at their request. This is to keep the size of the group to the minimum necessary, for information security reasons.
+  {% endtrans %}</p>
+
+  <p>{% trans %}
+    We also maintain a “security-announce” list for keeping representatives of organisations who ship our code informed of progress. This is the correct list for people who are shipping derivative products rather than developing policy or making Mozilla releases. Membership of this list can be obtained from Dan Veditz, the Security Group moderator.
+  {% endtrans %}</p>
+
+{% endblock %}

--- a/bedrock/mozorg/templates/mozorg/about/governance/policies/security/tld-idn.html
+++ b/bedrock/mozorg/templates/mozorg/about/governance/policies/security/tld-idn.html
@@ -1,0 +1,430 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/. #}
+
+{% extends "mozorg/about-base.html" %}
+
+{% block page_title %}{{ _('IDN-enabled TLDs') }}{% endblock %}
+{% block body_class %}sand{% endblock %}
+
+{% block extrahead %}
+  {{ css('security-tld-idn') }}
+{% endblock %}
+
+{% block article %}
+
+<h1 class="title-banner">{{ _('IDN-enabled TLDs') }}</h1>
+
+<p>{{ _('This is a list of top-level domains (TLDs) for which software from the Mozilla project displays Internationalized Domain Names (IDNs). It may not exactly match your product, depending on which version you have; search “about:config” for “IDN.whitelist” to see the list in your copy.') }}</p>
+
+<p><strong>{% trans url='https://wiki.mozilla.org/IDN_Display_Algorithm' %}
+Please note that the mechanism by which Firefox makes these decisions is due to change. <a href="{{ url }}">This document</a> has the details. Note in particular the section marked “Transition”, which defines the new requirement for registries seeking inclusion on the list in the period before the new algorithm is implemented in Firefox.
+{% endtrans %}</strong></p>
+
+<p>{{ _('In the absence of an entry in the list, a domain will still work, but it is rendered in its Punycode form instead of in native form. This helps to keep confusingly similar domains from being displayed when rendered for the user.') }}</p>
+
+<h2>{{ _('To Add/Update a TLD') }}</h2>
+
+<p>{% trans url='https://bugzilla.mozilla.org/enter_bug.cgi?product=Core&amp;component=Networking:+Domain+Lists&amp;short_desc=Add+TLD+[YOURTLD]+to+IDN+whitelist&amp;comment=TLD:+[YOURTLD]%0ARegistry+URL:+[URL+of+NIC]%0AIDN+Policy+URL:[URL+of+Policy]%0ACharacter+Table+URL:+[URL+of+Characters]%0A%0A&lt;Description+of+Homographs+not+being+possible+or+link+to+document+that+explains&gt;%0A%0ASincerely,%0A-Official+NIC+Representative+for+TLD+[As+much+contact+info+as+possible]&amp;cc=gerv@mozilla.org' %}
+Any registry which wishes the Foundation to update their information or enable IDN display for their TLD should <a href="{{ url }}">submit a bug</a>, providing the following:
+{% endtrans %}
+
+<ul>
+<li>{{ _('the TLD(s) being submitted for addition or modification, and') }}</li>
+<li>{{ _('a link to their registry home page, and') }}</li>
+<li>{% trans url='https://wiki.mozilla.org/IDN_Display_Algorithm' %}
+a link to their policy page, with an explanation of how their policy is equally or more restrictive than the one set out in the <a href="{{ url }}">algorithm document</a>, and{% endtrans %}</li>
+<li>{{ _('Their name, and role within the TLD Registry, with contact information for further correspondance or clarifications') }}</li>
+</ul>
+  
+<p>Anyone who has evidence that a registry is not following their published policies, or that the policy has changed to permit the situation prohibited above should <a href="http://www.mozilla.org/security/#For_Developers">contact the Mozilla security group</a>.</p>
+
+<h2>{{ _('ASCII Country Code or Generic/Sponsored Top Level Domains') }}</h2>
+
+<table class="table">
+  <tr>
+    <td>.ac</td>
+    <td><a href="http://www.nic.ac/">{{ _('Registry') }}</a></td>
+    <td><a href="http://www.nic.ac/pdf/AC-IDN-Policy.pdf">{{ _('Policy') }}</a></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>.ar</td>
+    <td><a href="http://www.nic.ar/">{{ _('Registry') }}</a></td>
+    <td><a href="http://www.nic.ar/616.html">{{ _('Policy') }}</a></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>.asia</td>
+    <td><a href="http://www.registry.asia">{{ _('Registry') }}</a></td>
+    <td><a href="http://www.nic.at/en/service/legal_information/registration_guidelines/">{{ _('Policy') }}</a></td>
+    <td><a href="http://www.iana.org/domains/idn-tables/">{{ _('Character List') }}</a></td>
+  </tr>
+  <tr>
+    <td>.at</td>
+    <td><a href="http://www.nic.at/">{{ _('Registry') }}</a></td>
+    <td><a href="http://www.nic.at/en/service/legal_information/registration_guidelines/">{{ _('Policy') }}</a></td>
+    <td><a href="http://www.nic.at/en/service/technical_information/idn/charset_converter/">{{ _('Character List') }}</a></td>
+  </tr>
+  <tr>
+    <td>.biz</td>
+    <td><a href="http://www.neustarregistry.biz/">{{ _('Registry') }}</a></td>
+    <td><a href="http://www.neustarregistry.biz/products/idns">{{ _('Policy') }}</a></td>
+    <td><a href="http://www.iana.org/domains/idn-tables/">{{ _('Character List') }}</a></td>
+  </tr>
+  <tr>
+    <td>.br</td>
+    <td><a href="http://registro.br/">{{ _('Registry') }}</a></td>
+    <td><a href="http://registro.br/faq/faq6.html">{{ _('Policy') }}</a></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>.cat</td>
+    <td><a href="http://www.domini.cat/">{{ _('Registry') }}</a></td>
+    <td><a href="http://www.domini.cat/normativa/en_normativa_registre.html">{{ _('Policy') }}</a></td>
+    <td><a href="http://www.iana.org/domains/idn-tables/">{{ _('Character List') }}</a></td>
+  </tr>
+  <tr>
+    <td>.ch</td>
+    <td><a href="http://www.switch.ch/id/">{{ _('Registry') }}</a></td>
+    <td><a href="http://www.switch.ch/id/terms/agb.html#anhang1">{{ _('Policy') }}</a></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>.cl</td>
+    <td><a href="http://www.nic.cl/">{{ _('Registry') }}</a></td>
+    <td><a href="http://www.nic.cl/CL-IDN-policy.html">{{ _('Policy') }}</a></td>
+    <td><a href="http://www.iana.org/domains/idn-tables/">{{ _('Character List') }}</a></td>
+  </tr>
+  <tr>
+    <td>.cn</td>
+    <td><a href="http://www.cnnic.net.cn/">{{ _('Registry') }}</a></td>
+    <td><a href="http://www.faqs.org/rfcs/rfc3743.html">{{ _('Policy') }}</a></td>
+    <td><a href="http://www.iana.org/domains/idn-tables/">{{ _('Character List') }}</a><br />{{ _('(JET Guidelines') }})</td>
+  </tr>
+  <tr>
+    <td>.com</td>
+    <td><a href="http://verisigninc.com/en_US/products-and-services/domain-name-services/registry-services/index.xhtml">{{ _('Registry') }}</a></td>
+    <td><a href="http://verisigninc.com/en_US/products-and-services/domain-name-services/domain-information-center/idn-code-points/registration-rules/index.xhtml">{{ _('Policy') }}</a></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>.de</td>
+    <td><a href="http://www.denic.de/">{{ _('Registry') }}</a></td>
+    <td><a href="http://www.denic.de/en/richtlinien.html">{{ _('Policy') }}</a></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>.dk</td>
+    <td><a href="http://www.dk-hostmaster.dk/">{{ _('Registry') }}</a></td>
+    <td><a href="http://www.dk-hostmaster.dk/index.php?id=151">{{ _('Policy') }}</a></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>.es</td>
+    <td><a href="https://www.nic.es/">{{ _('Registry') }}</a></td>
+    <td><a href="https://www.nic.es/media/2008-12/1228818323935.pdf">{{ _('Policy') }}</a></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>.fi</td>
+    <td><a href="http://www.ficora.fi/">{{ _('Registry') }}</a></td>
+    <td><a href="http://www.ficora.fi/en/index/palvelut/fiverkkotunnukset/aakkostenkaytto.html">{{ _('Policy') }}</a></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>.gr</td>
+    <td><a href="https://grweb.ics.forth.gr/english/index.html">{{ _('Registry') }}</a></td>
+    <td><a href="https://grweb.ics.forth.gr/english/ENCharacterTable1.jsp">{{ _('Policy') }}</a></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>.hu</td>
+    <td><a href="http://www.domain.hu/domain/">{{ _('Registry') }}</a></td>
+    <td><a href="http://www.domain.hu/domain/English/szabalyzat.html">{{ _('Policy') }}</a></td>
+    <td>{{ _('(Characters in section 2.1.2 of Policy') }})</td>
+  </tr>
+  <tr>
+    <td>.il</td>
+    <td><a href="http://www.isoc.org.il/">{{ _('Registry') }}</a></td>
+    <td><a href="http://www.isoc.org.il/domains/il-domain-rules.html">{{ _('Policy') }}</a></td>
+    <td><a href="http://www.iana.org/domains/idn-tables/">{{ _('Character List') }}</a></td>
+  </tr>
+  <tr>
+    <td>.info</td>
+    <td><a href="http://www.afilias.info/">{{ _('Registry') }}</a></td>
+    <td><a href="http://www.afilias.info/register/idn/">{{ _('Policy') }}</a></td>
+    <td><a href="http://www.iana.org/domains/idn-tables/">{{ _('Character List') }}</a></td>
+  </tr>
+  <tr>
+    <td>.io</td>
+    <td><a href="http://www.nic.io">{{ _('Registry') }}</a></td>
+    <td><a href="http://www.nic.io/IO-IDN-Policy.pdf">{{ _('Policy') }}</a></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>.ir</td>
+    <td><a href="https://www.nic.ir/">{{ _('Registry') }}</a></td>
+    <td><a href="https://www.nic.ir/IDN">{{ _('Policy') }}</a></td>
+    <td><a href="http://www.iana.org/domains/idn-tables/">{{ _('Character List') }}</a></td>
+  </tr>
+  <tr>
+    <td>.is</td>
+    <td><a href="http://www.isnic.is/">{{ _('Registry') }}</a></td>
+    <td><a href="http://www.isnic.is/english/domain/rules.php">{{ _('Policy') }}</a></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>.jp</td>
+    <td><a href="http://jprs.co.jp/">{{ _('Registry') }}</a></td>
+    <td><a href="http://www.iana.org/assignments/idn/jp-japanese.html">{{ _('Policy') }}</a></td>
+    <td><a href="http://www.iana.org/domains/idn-tables/">{{ _('Character List') }}</a></td>
+  </tr>
+  <tr>
+    <td>.kr</td>
+    <td><a href="http://domain.nic.or.kr/">{{ _('Registry') }}</a></td>
+    <td><a href="http://www.faqs.org/rfcs/rfc3743.html">{{ _('Policy') }}</a></td>
+    <td><a href="http://www.iana.org/domains/idn-tables/">{{ _('Character List') }}</a><br />{{ _('(JET Guidelines') }})</td>
+  </tr>
+  <tr>
+    <td>.li</td>
+    <td><a href="http://www.switch.ch/id/">{{ _('Registry') }}</a></td>
+    <td><a href="http://www.switch.ch/id/terms/agb.html#anhang1">{{ _('Policy') }}</a></td>
+    <td>{{ _('(see .ch registry') }})</td>
+  </tr>
+  <tr>
+    <td>.lt</td>
+    <td><a href="http://www.domreg.lt/public?pg=&sp=&loc=en">{{ _('Registry') }}</a></td>
+    <td><a href="http://www.domreg.lt/public?pg=8A7FB6&amp;sp=idn&amp;loc=en">{{ _('Policy') }}</a></td>
+    <td><a href="http://www.domreg.lt/static/doc/public/idn_symbols-en.pdf">{{ _('Character List') }}</a></td>
+  </tr>
+  <tr>
+    <td>.lu</td>
+    <td><a href="http://www.dns.lu/">{{ _('Registry') }}</a></td>
+    <td><a href="http://www.dns.lu/en/support/general-information/domain-name-policy-lu-charter/">{{ _('Policy') }}</a></td>
+    <td><a href="http://www.dns.lu/en/support/general-information/idn/">{{ _('Character List') }}</a></td>
+  </tr>
+  <tr>
+    <td>.lv</td>
+    <td><a href="http://www.nic.lv/">{{ _('Registry') }}</a></td>
+    <td><a href="http://www.nic.lv/resource/show/53">{{ _('Policy') }}</a></td>
+    <td>{{ _('(Characters in 1.11 and 6.1.3 of Policy') }})</td>
+  </tr>
+  <tr>
+    <td>.museum</td>
+    <td><a href="http://about.museum/">{{ _('Registry') }}</a></td>
+    <td><a href="http://about.museum/idn/idnpolicy.html">{{ _('Policy') }}</a></td>
+    <td><a href="http://www.iana.org/domains/idn-tables/">{{ _('Character List') }}</a></td>
+  </tr>
+  <tr>
+    <td>.name</td>
+    <td><a href="http://verisigninc.com/en_US/products-and-services/domain-name-services/registry-services/index.xhtml">{{ _('Registry') }}</a></td>
+    <td><a href="http://verisigninc.com/en_US/products-and-services/domain-name-services/domain-information-center/idn-code-points/registration-rules/index.xhtml">{{ _('Policy') }}</a></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>.net</td>
+    <td><a href="http://verisigninc.com/en_US/products-and-services/domain-name-services/registry-services/index.xhtml">{{ _('Registry') }}</a></td>
+    <td><a href="http://verisigninc.com/en_US/products-and-services/domain-name-services/domain-information-center/idn-code-points/registration-rules/index.xhtml">{{ _('Policy') }}</a></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>.no</td>
+    <td><a href="http://www.norid.no/">{{ _('Registry') }}</a></td>
+    <td><a href="http://www.norid.no/domeneregistrering/veiviser.en.html">{{ _('Policy') }}</a></td>
+    <td>{{ _('(characters in section 4 of Policy') }})</td>
+  </tr>
+  <tr>
+    <td>.nu</td>
+    <td><a href="http://www.nunames.nu/">{{ _('Registry') }}</a></td>
+    <td><a href="http://www.nunames.nu/Local-Language.cfm">{{ _('Policy') }}</a></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>.nz</td>
+    <td><a href="http://dnc.org.nz/">{{ _('Registry') }}</a></td>
+    <td><a href="http://dnc.org.nz/content/rmc.html">{{ _('Policy') }}</a></td>
+    <td><a href="http://www.iana.org/domains/idn-tables/">{{ _('Character List') }}</a></td>
+  </tr>
+  <tr>
+    <td>.org</td>
+    <td><a href="http://www.pir.org/">{{ _('Registry') }}</a></td>
+    <td><a href="http://pir.org/PDFs/ORG-Extended-Characters-22-Jan-07.pdf">{{ _('Policy') }}</a></td>
+    <td><a href="http://www.iana.org/domains/idn-tables/">{{ _('Character List') }}</a></td>
+  </tr>
+  <tr>
+    <td>.pl</td>
+    <td><a href="http://www.nask.pl/">{{ _('Registry') }}</a></td>
+    <td><a href="http://www.dns.pl/IDN/idn-registration-policy.txt">{{ _('Policy') }}</a></td>
+    <td><a href="http://www.iana.org/domains/idn-tables/">{{ _('Character List') }}</a></td>
+  </tr>
+  <tr>
+    <td>.pr</td>
+    <td><a href="https://www.nic.pr/">{{ _('Registry') }}</a></td>
+    <td><a href="https://www.nic.pr/idn_rules.asp">{{ _('Policy') }}</a></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>.se</td>
+    <td><a href="http://www.nic-se.se/">{{ _('Registry') }}</a></td>
+    <td><a href="http://www.iis.se/en/domaner/internationaliserad-doman-idn/">{{ _('Policy') }}</a></td>
+    <td><a href="http://www.iis.se/docs/teckentabell-03.pdf">{{ _('Character List') }}</a></td>
+  </tr>
+  <tr>
+    <td>.sh</td>
+    <td><a href="http://www.nic.sh">{{ _('Registry') }}</a></td>
+    <td><a href="http://www.nic.sh/SH-IDN-Policy.pdf">{{ _('Policy') }}</a></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>.tel</td>
+    <td><a href="http://www.telnic.org/">{{ _('Registry') }}</a></td>
+    <td><a href="http://www.telnic.org/policies.html">{{ _('Policy') }}</a></td>
+    <td><a href="http://www.iana.org/domains/idn-tables/">{{ _('Character List') }}</a></td>
+  </tr>
+  <tr>
+    <td>.th</td>
+    <td><a href="http://www.thnic.or.th/">{{ _('Registry') }}</a></td>
+    <td><a href="http://www.iana.org/assignments/idn/th-thai.html">{{ _('Policy') }}</a></td>
+    <td><a href="http://www.iana.org/domains/idn-tables/">{{ _('Character List') }}</a></td>
+  </tr>
+  <tr>
+    <td>.tm</td>
+    <td><a href="http://www.nic.tm">{{ _('Registry') }}</a></td>
+    <td><a href="http://www.nic.tm/TM-IDN-Policy.pdf">{{ _('Policy') }}</a></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>.tw</td>
+    <td><a href="http://www.twnic.net.tw/">{{ _('Registry') }}</a></td>
+    <td><a href="http://www.faqs.org/rfcs/rfc3743.html">{{ _('Policy') }}</a></td>
+    <td><a href="http://www.iana.org/domains/idn-tables/">{{ _('Character List') }}</a><br />{{ _('(JET Guidelines') }})</td>
+  </tr>
+  <tr>
+    <td>.ua</td>
+    <td><a href="http://www.hostmaster.ua/">{{ _('Registry') }}</a></td>
+    <td><a href="http://www.hostmaster.ua/idn/">{{ _('Policy') }}</a></td>
+    <td><a href="http://www.iana.org/domains/idn-tables/">{{ _('Character List') }}</a></td>
+  </tr>
+  <tr>
+    <td>.vn</td>
+    <td><a href="http://www.vnnic.net.vn/">{{ _('Registry') }}</a></td>
+    <td><a href="http://www.vnnic.vn/english/5-6-300-2-2-04-20071115.htm">{{ _('Policy') }}</a></td>
+    <td><a href="http://vietunicode.sourceforge.net/tcvn6909.pdf">{{ _('Character List') }}</a></td>
+  </tr>
+</table>
+
+<h2 id="country-code">{{ _('IDN Country Code or Generic/Sponsored Top Level Domains') }}</h2>
+
+<table class="table">
+  <tr>
+    <td align="right">.الاردن</td>
+    <td>.xn--mgbayh7gpa</td>
+    <td>.&lt;al-Ordon&gt;</td>
+    <td><a href="http://www.nitc.gov.jo/">{{ _('Registry') }}</a></td>
+    <td><a href="http://www.iana.org/domains/idn-tables/tables/sa_ar_1.0.html">{{ _('Policy') }}</a></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td align="right">.السعودية</td>
+    <td>.xn--mgberp4a5d4ar  and variants</td>
+    <td>.&lt;al-Saudiah&gt;</td>
+    <td><a href="http://nic.net.sa/">{{ _('Registry') }}</a></td>
+    <td><a href="http://nic.net.sa/adn-en.php">{{ _('Policy') }}</a></td> 
+    <td><a href="http://tools.ietf.org/html/rfc5564">{{ _('Character List') }}</a></td>
+  </tr>
+  <tr>
+    <td>.中國 .中国</td>
+    <td>.xn--fiqz9s<br />.xn--fiqs8s</td>
+    <td>.&lt;China&gt;</td>
+    <td><a href="http://www.cnnic.cn/">{{ _('Registry') }}</a></td>
+    <td><a href="http://www.faqs.org/rfcs/rfc3743.html">{{ _('Policy') }}</a></td>
+    <td>{{ _('(JET Guidelines') }})</td>
+  </tr>
+  <tr>
+    <td align="right">.امارات</td>
+    <td>.xn--mgbaam7a8h</td>
+    <td>.&lt;Emarat&gt;</td>
+    <td><a href="http://aeda.ae/">{{ _('Registry') }}</a></td>
+    <td><a href="http://policy.aeda.ae">{{ _('Policy') }}</a></td>
+    <td><a href="http://aeda.ae/eng/emaratlngtb.php">{{ _('Character List') }}</a></td>
+  </tr>
+  <tr>
+    <td>.香港</td>
+    <td>.xn--j6w193g</td>
+    <td>.&lt;Hong Kong&gt;</td>
+    <td><a href=" https://www2.hkirc.hk/">{{ _('Registry') }}</a></td>
+    <td><a href="http://www.faqs.org/rfcs/rfc3743.html">{{ _('Policy') }}</a></td>
+    <td>{{ _('(JET Guidelines') }})</td>
+  </tr>
+  <tr>
+    <td align=right>.ایران</td>
+    <td>.xn--mgba3a4f16a<br />.xn--mgba3a4fra</td>
+    <td>.&lt;Iran&gt;</td>
+    <td><a href="http://www.nic.ir/">{{ _('Registry') }}</a></td>
+    <td><a href="http://www.nic.ir/IDN">{{ _('Policy') }}</a></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>.ලංකා<br />.இலங்கை</td>
+    <td>.xn--fzc2c9e2c<br />.xn--xkc2al3hye2a</td>
+    <td>.&lt;Lanka&gt;<br />.&lt;llangai&gt;</td>
+    <td><a href="http://www.nic.lk">{{ _('Registry') }}</a></td>
+    <td><a href="http://www.nic.lk/index.php/en/idn-policy">{{ _('Policy') }}</a></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td align=right>.مصر</td>
+    <td>.xn--wgbh1c</td>
+    <td>.&lt;Masr&gt;</td>
+    <td><a href="http://www.dotmasr.eg/">{{ _('Registry') }}</a></td>
+    <td><a href="http://www.dotmasr.eg/LanguageTable.pdf">{{ _('Policy') }}</a></td>
+    <td><a href="http://www.dotmasr.eg/LanguageTable.pdf">{{ _('Character List') }}</a></td>
+  </tr>
+  <tr>
+    <td align=right>.قطر</td>
+    <td>.xn--wgbl6a</td>
+    <td>.&lt;Qatar&gt;</td>
+    <td><a href="http://domains.qa/">{{ _('Registry') }}</a></td>
+    <td><a href="http://domains.qa/sites/default/files/Qatar%20Domains%20Registry-Domain%20Name%20Registration%20Policy_0.pdf">{{ _('Policy') }}</a></td>
+    <td>{{ _('(characters in Appendix A of Policy') }})</td>
+  </tr>
+  <tr>
+    <td>.РФ</td>
+    <td>.xn--p1ai</td>
+    <td>.&lt;RF&gt;</td>
+    <td><a href="http://www.cctld.ru/">{{ _('Registry') }}</a></td>
+    <td><a href="http://www.cctld.ru/en/docs/rulesrf.php">{{ _('Policy') }}</a></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td align=right>.سورية</td>
+    <td>.xn--ogbpf8fl</td>
+    <td>.&lt;Souria&gt;</td>
+    <td><a href="https://reg.tld.sy">{{ _('Registry') }}</a></td>
+    <td><a href="http://www.nans.gov.sy/index.php/services/sy-domain/29-dotsouria">{{ _('Policy') }}</a></td>
+    <td>{{ _('(JET Guidelines') }})</td>
+  </tr>
+  <tr>
+    <td>.台灣<br />.台湾</td>
+    <td>.xn--kpry57d <br />.xn--kprw13d</td>
+    <td>.&lt;Taiwan&gt;</td>
+    <td><a href="http://www.twnic.net/">{{ _('Registry') }}</a></td>
+    <td><a href="http://www.faqs.org/rfcs/rfc3743.html">{{ _('Policy') }}</a></td>
+    <td>{{ _('(JET Guidelines') }})</td>
+  </tr>
+
+<!--
+  <tr>
+    <td></td>
+    <td><a href="">{{ _('Registry') }}</a></td>
+    <td><a href="">{{ _('Policy') }}</a></td>
+  </tr>
+-->
+
+</table>
+    
+<h2 id="testing">{{ _('Testing') }}</h2>
+
+<p class="testing">{{ _('To enable IDN for a particular TLD for testing purposes, go to the URL <tt>about:config</tt> in Firefox 1.1 or above and add a boolean pref called "network.IDN.whitelist.tld", where "tld" is the TLD, and set it to "true". <em>This procedure is not recommended for users as it may expose them to security risk.') }}</em></p>
+{% endblock %}

--- a/bedrock/mozorg/urls.py
+++ b/bedrock/mozorg/urls.py
@@ -24,8 +24,11 @@ urlpatterns = patterns('',
     page('about/governance', 'mozorg/about/governance/governance.html'),
     page('about/governance/roles', 'mozorg/about/governance/roles.html'),
     page('about/governance/policies', 'mozorg/about/governance/policies.html'),
+    page('about/governance/policies/security-group', 'mozorg/about/governance/policies/security/group.html'),
+    page('about/governance/policies/security-group/bugs', 'mozorg/about/governance/policies/security/bugs.html'),
+    page('about/governance/policies/security-group/tld-idn', 'mozorg/about/governance/policies/security/tld-idn.html'),
+    page('about/governance/policies/security-group/membership', 'mozorg/about/governance/policies/security/membership.html'),
     page('about/governance/organizations', 'mozorg/about/governance/organizations.html'),
-
 
 
     url('^contribute/$', views.contribute, name='mozorg.contribute',

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -300,6 +300,12 @@ MINIFY_BUNDLES = {
         'research': (
             'css/research/research.less',
         ),
+        'security-group': (
+            'css/mozorg/security-group.less',
+        ),
+        'security-tld-idn': (
+            'css/mozorg/security-tld-idn.less',
+        ),
         'styleguide': (
             'css/styleguide/styleguide.less',
             'css/styleguide/websites-sandstone.less',

--- a/etc/httpd/global.conf
+++ b/etc/httpd/global.conf
@@ -384,3 +384,9 @@ RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox(/)?$ /b/$1firefox$2 [PT]
 
 # bug 897195
 RewriteRule ^/en-US/newsletter/confirm(.*)$ /b/en-US/newsletter/confirm$1 [PT]
+
+# bug 818321
+RewriteRule ^/projects/security/tld-idn-policy-list.html$ /about/governance/policies/security-group/tld-idn/ [L,R=301]
+RewriteRule ^/projects/security/membership-policy.html$ /about/governance/policies/security-group/membership/ [L,R=301]
+RewriteRule ^/projects/security/secgrouplist.html$ /about/governance/policies/security-group/ [L,R=301]
+RewriteRule ^/projects/security/security-bugs-policy.html$ /about/governance/policies/security-group/bugs/ [L,R=301]

--- a/media/css/mozorg/security-group.less
+++ b/media/css/mozorg/security-group.less
@@ -1,0 +1,28 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+@import "../sandstone/lib.less";
+
+ul.members {
+    -webkit-columns: 2;
+    -moz-columns: 2;
+    columns: 2;
+    -webkit-column-gap: @baseLine * 3;
+    -moz-column-gap: @baseLine * 3;
+    column-gap: @baseLine * 3;
+}
+
+/* {{{ Wide Mobile Layout: 480px */
+
+@media only screen and (min-width: @breakMobileLandscape) and (max-width: @breakTablet) {
+
+    ul.members {
+        -webkit-columns: 1;
+        -moz-columns: 1;
+        columns: 1;
+    }
+
+}
+
+/* }}} */

--- a/media/css/mozorg/security-tld-idn.less
+++ b/media/css/mozorg/security-tld-idn.less
@@ -1,0 +1,37 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+@import "../sandstone/lib.less";
+
+article {
+    .table {
+        margin-top: @baseLine;
+        margin-bottom: @baseLine * 2;
+        width: 100%;
+        td, th {
+            vertical-align: top;
+            text-align: inherit;
+            font-size: @smallFontSize;
+        }
+    }
+    .testing {
+        em {
+            color: red;
+        }
+    }
+}
+
+/* {{{ Wide Mobile Layout: 480px */
+
+@media only screen and (min-width: @breakMobileLandscape) and (max-width: @breakTablet) {
+
+    ul.members {
+        -webkit-columns: 1;
+        -moz-columns: 1;
+        columns: 1;
+    }
+
+}
+
+/* }}} */


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=818321

Ported these pages:
1. http://mozilla.org/projects/security/membership-policy.html 
2. http://mozilla.org/projects/security/secgrouplist.html 
3. http://mozilla.org/projects/security/security-bugs-policy.html 
4. http://mozilla.org/projects/security/tld-idn-policy-list.html

to:
1. /about/governance/policies/security-group/membership/
2. /about/governance/policies/security-group/
3. /about/governance/policies/security-group/bugs/
4. /about/governance/policies/security-group/tld-idn/

Used a very basic sandstone theme page. Feedback is welcome on the chosen new URLs. These are all security "policies". Also added links to these pages from the  /about/governance/policies/ page.
