### PR TITLE
Refactor global gaTrack function. Bug 896001.

### DIFF
--- a/media/js/base/footer-email-form.js
+++ b/media/js/base/footer-email-form.js
@@ -60,14 +60,15 @@ $(document).ready(function() {
         newsletter = $input.val();
       }
 
-      if (gaTrack && newsletter !== '') {
+      if (typeof(gaTrack) === 'function' && newsletter !== '') {
         // Need to wait to submit, until after we're sure we've sent
         // the tracking event to GA.
         e.preventDefault();
         $form.unbind('submit');
-        gaTrack([['_trackEvent', 'Newsletter Registration', 'submit', newsletter]],
-                function () { $form.submit(); }
-                );
+        gaTrack(
+          ['_trackEvent', 'Newsletter Registration', 'submit', newsletter],
+          function (){ $form.submit(); }
+        );
       }
     }
     // Else, just let the form submit.

--- a/media/js/newsletter/existing.js
+++ b/media/js/newsletter/existing.js
@@ -13,16 +13,45 @@ jQuery(function($) {
     // from the form's data-initial-newsletters attribute.
     var initialNewsletters = $form.data('initialNewsletters');
     var events = [];
-    $form.find('input[name^="form-"][name$="-subscribed"]:checked').each(function () {
-      var newsletterInputName = $(this).attr('name').replace("-subscribed", "-newsletter");
+    var processed_newsletters = '';
+
+    // loop through all newsletters
+    $form.find('input[name^="form-"][name$="-subscribed"]').each(function () {
+      var $this = $(this);
+      var newsletterInputName = $this.attr('name').replace("-subscribed", "-newsletter");
       var newsletter = $("input[name='" + newsletterInputName + "']").val();
-      if (initialNewsletters.indexOf(newsletter) === -1) {
-        // newly subscribed to this newsletter
-        events.push(['_trackEvent', 'Newsletter Registration', 'submit', newsletter]);
+
+      // make sure we haven't already looked at radio buttons associated with this newsletter
+      if (processed_newsletters.indexOf(newsletter) === -1) {
+        // find value of checked radio button within this set
+        // True = subscribed, False = unsubscribed
+        var subscribed = $('input[name="' + $this.attr('name') + '"]:checked').val();
+
+        // if newsletter is checked and wasn't previously subscribed to, track the subscription
+        if (subscribed === 'True' && initialNewsletters.indexOf(newsletter) === -1) {
+          // newly subscribed to this newsletter
+          events.push(['_trackEvent', 'Newsletter Registration', 'subscribe', newsletter]);
+        // if newsletter is not checked and was previously subscribed to, track the unsubscription
+        } else if (subscribed === 'False' && initialNewsletters.indexOf(newsletter) > -1) {
+          // newly unsubscribed to this newsletter
+          events.push(['_trackEvent', 'Newsletter Registration', 'unsubscribe', newsletter]);
+        }
+
+        // make sure we don't re-process this newsletter
+        processed_newsletters += ',' + newsletter;
       }
     });
-    if (gaTrack && events.length > 0) {
-      gaTrack(events, function () { $form.submit(); });
+
+    if (typeof(gaTrack) === 'function' && events.length > 0) {
+      // make GA call for each event
+      $.each(events, function(i, evt) {
+        // if the last event, add callback to submit the form
+        if (i === (events.length - 1)) {
+          gaTrack(evt, function() { $form.submit(); });
+        } else {
+          gaTrack(evt);
+        }
+      });
     } else {
       $form.submit();
     }


### PR DESCRIPTION
- Takes a single array of event data (instead of an array of arrays).
- Only sets hitCallback/setTimeout if a callback exists.
- Existing newsletter JS only sets callback for last event track.
- Existing newsletter JS tracks both new subscriptions and unsubscriptions.

Gareth tested both newsletter signups and newsletter management, and all GA tracking appears to be running as expected.
