### PR TITLE
Bug 892470 : activate more locales for plugincheck

### DIFF
--- a/etc/httpd/global.conf
+++ b/etc/httpd/global.conf
@@ -58,7 +58,7 @@ RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/backtoschool/firstrun(/?)$ /firefox/
 ## Redirect things to django!
 
 # bug 797192, 892470
-RewriteRule ^/(en-US|de|el|eu|fr|is|it|sr|sv-SE|zh-TW)/plugincheck(/?)$ /b/$1/plugincheck$2 [PT]
+RewriteRule ^/(en-US|ast|cs|csb|da|de|el|eo|es-AR|es-CL|es-ES|eu|fr|hy-AM|is|it|ko|mk|pt-BR|ru|sk|sl|sq|sr|sv-SE|zh-TW)/plugincheck(/?)$ /b/$1/plugincheck$2 [PT]
 
 # bug 835506
 RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?facebookapps/(.*)?$ /b/$1facebookapps/$2 [PT]


### PR DESCRIPTION
activate these locales:
ast, cs, csb, da, eo, es-AR, es-CL, es-ES, hy-AM, ko, mk, pt-BR, ru, sk, sl, sq
