### PR TITLE
fix video urls for the fallback flash player

### DIFF
--- a/bedrock/firefox/templates/firefox/partners/index.html
+++ b/bedrock/firefox/templates/firefox/partners/index.html
@@ -461,8 +461,8 @@
           {# L10n: The "Play Video" message must be url encoded, so spaces should be escaped as '%20' #}
           <object type="application/x-shockwave-flash"
             style="width: 640px; height: 362px;"
-            data="{{ MEDIA_URL }}flash/playerWithControls.swf?flv=/serv/drafts/MWC_2013.mp4&amp;autoplay=false&amp;msg={{ _('Play%20Video') }}">
-            <param name="movie" value="{{ MEDIA_URL }}flash/playerWithControls.swf?flv=/serv/drafts/MWC_2013.mp4&amp;autoplay=false&amp;msg={{ _('Play%20Video') }}">
+            data="{{ MEDIA_URL }}flash/playerWithControls.swf?flv=serv/drafts/MWC_2013.mp4&amp;autoplay=false&amp;msg={{ _('Play%20Video') }}">
+            <param name="movie" value="{{ MEDIA_URL }}flash/playerWithControls.swf?flv=serv/drafts/MWC_2013.mp4&amp;autoplay=false&amp;msg={{ _('Play%20Video') }}">
             <param name="wmode" value="transparent">
 
             <div class="video-player-no-flash">

--- a/bedrock/foundation/templates/foundation/annualreport/2009/a-competitive-world.html
+++ b/bedrock/foundation/templates/foundation/annualreport/2009/a-competitive-world.html
@@ -103,8 +103,8 @@
     <source src="//videos-cdn.mozilla.net/serv/mozillaorg/Firefox_global_final.webm" type="video/webm">
     <source src="//videos-cdn.mozilla.net/serv/mozillaorg/Firefox_global_final.theora.ogv" type="video/ogg">
     <source src="//videos-cdn.mozilla.net/serv/mozillaorg/Firefox_global_final.mp4" type="video/mp4">
-    <object type="application/x-shockwave-flash" style="width: 640px; height: 360px;" data="/includes/flash/playerWithControls.swf?flv=/serv/mozillaorg/Firefox_global_final.mp4&amp;autoplay=false&amp;msg=Play%20Video">
-      <param name="movie" value="/includes/flash/playerWithControls.swf?flv=//videos-cdn.mozilla.net/serv/mozillaorg/Firefox_global_final.mp4&amp;autoplay=false&amp;msg=Play%20Video"/>
+    <object type="application/x-shockwave-flash" style="width: 640px; height: 360px;" data="/includes/flash/playerWithControls.swf?flv=serv/mozillaorg/Firefox_global_final.mp4&amp;autoplay=false&amp;msg=Play%20Video">
+      <param name="movie" value="/includes/flash/playerWithControls.swf?flv=serv/mozillaorg/Firefox_global_final.mp4&amp;autoplay=false&amp;msg=Play%20Video"/>
       <param name="wmode" value="transparent"/>
     </object>
   </video>


### PR DESCRIPTION
the player will prepend the url with http://videos.mozilla.org/
