### PR TITLE
Bug 892470 - enable plugincheck for ml, ro

### DIFF
--- a/etc/httpd/global.conf
+++ b/etc/httpd/global.conf
@@ -65,7 +65,7 @@ RewriteRule ^/ports(.*)$ http://www-archive.mozilla.org/ports$1 [L,R=301]
 ## Redirect things to django!
 
 # bug 797192, 892470
-RewriteRule ^/(en-US|ast|cs|csb|da|de|el|eo|es-AR|es-CL|es-ES|eu|fr|hy-AM|is|it|ko|mk|pt-BR|ru|sk|sl|sq|sr|sv-SE|zh-TW)/plugincheck(/?)$ /b/$1/plugincheck$2 [PT]
+RewriteRule ^/(en-US|ast|cs|csb|da|de|el|eo|es-AR|es-CL|es-ES|eu|fr|hy-AM|is|it|ko|mk|ml|pt-BR|ro|ru|sk|sl|sq|sr|sv-SE|zh-TW)/plugincheck(/?)$ /b/$1/plugincheck$2 [PT]
 
 # bug 835506
 RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?facebookapps/(.*)?$ /b/$1facebookapps/$2 [PT]


### PR DESCRIPTION
Note: don't close the bug when merged, it's used to track activations for all locales.
