### PR TITLE
Bug 897206 - Update en-US newsletter success message

### DIFF
--- a/bedrock/newsletter/templates/newsletter/mozilla-and-you.html
+++ b/bedrock/newsletter/templates/newsletter/mozilla-and-you.html
@@ -15,11 +15,6 @@
   </div>
 {% endblock %}
 
-{% block success_no_confirm %}
-  <p>{% trans %}We look forward to soon begin sharing tips &amp; tricks on getting the most out of Firefox, as well as exciting news about Mozilla and how we’re working to create a better Web.{% endtrans %}</p>
-  <p>{% trans %}Please be sure to add our sending address: mozilla@e.mozilla.org to your address book to ensure we always reach your inbox.{% endtrans %}</p>
-{% endblock success_no_confirm %}
-
 {% block success_confirm %}
   <p>{% trans %}Thanks! Please check your inbox to confirm your subscription.{% endtrans %}</p>
   <p>{% trans %}You'll receive an email from mozilla@e.mozilla.org to confirm your subscription. If you don't see it, check your spam filter. You must confirm your subscription to receive our newsletter.{% endtrans %}</p>

--- a/bedrock/newsletter/templates/newsletter/one_newsletter_signup.html
+++ b/bedrock/newsletter/templates/newsletter/one_newsletter_signup.html
@@ -29,19 +29,11 @@
       {# User has been subscribed #}
       <div id="email-form" class="thank billboard">
         <h3>{{ _('Thanks for Subscribing!') }}</h3>
-          {# user did not need to confirm before starting subscription (no double-opt-in) #}
-          {% if request.newsletter_lang.startswith('en') %}
-            {% block success_no_confirm %}
-              <p>{% trans %}We look forward to soon begin sharing tips &amp; tricks on getting the most out of Firefox, as well as exciting news about Mozilla and how we’re working to create a better Web.{% endtrans %}</p>
-              <p>{% trans %}Please be sure to add our sending address: mozilla@e.mozilla.org to your address book to ensure we always reach your inbox.{% endtrans %}</p>
-            {% endblock success_no_confirm %}
-          {% else %}
-            {# user will have to confirm before starting subscription #}
-            {% block success_confirm %}
-              <p>{% trans %}Thanks! Please check your inbox to confirm your subscription.{% endtrans %}</p>
-              <p>{% trans %}You'll receive an email from mozilla@e.mozilla.org to confirm your subscription. If you don't see it, check your spam filter. You must confirm your subscription to receive our newsletter.{% endtrans %}</p>
-            {% endblock success_confirm %}
-          {% endif %}
+          {# user will have to confirm before starting subscription #}
+          {% block success_confirm %}
+            <p>{% trans %}Thanks! Please check your inbox to confirm your subscription.{% endtrans %}</p>
+            <p>{% trans %}You'll receive an email from mozilla@e.mozilla.org to confirm your subscription. If you don't see it, check your spam filter. You must confirm your subscription to receive our newsletter.{% endtrans %}</p>
+          {% endblock success_confirm %}
       </div>
     {% else %}
       {% block newsletter_content %}{% endblock newsletter_content %}


### PR DESCRIPTION
When someone signs up for a newsletter in English, change the message
on the success page to say they'll have to confirm, just like any
other language.
