### PR TITLE
at2x retina image function - fix bug 898013

### DIFF
--- a/bedrock/firefox/templates/firefox/new.html
+++ b/bedrock/firefox/templates/firefox/new.html
@@ -17,6 +17,7 @@
 {% endblock %}
 
 {% block content %}
+
 <main role="main">
   <div id="main-feature">
     <div class="row">

--- a/bedrock/mozorg/helpers/misc.py
+++ b/bedrock/mozorg/helpers/misc.py
@@ -131,10 +131,30 @@ def platform_img(url, optional_attributes=None):
         attrs = ''
 
     # Don't download any image until the javascript sets it based on
-    # data-src so we can to platform detection. If no js, show the
+    # data-src so we can do platform detection. If no js, show the
     # windows version.
     markup = ('<img class="platform-img js" src="" data-src="%s" %s>'
               '<noscript><img class="platform-img win" src="%s" %s></noscript>'
+              % (url, attrs, url, attrs))
+
+    return jinja2.Markup(markup)
+
+
+@jingo.register.function
+def high_res_img(url, optional_attributes=None):
+    if optional_attributes:
+        attrs = ' '.join(('%s="%s"' % (attr, val)
+                          for attr, val in optional_attributes.items()))
+    else:
+        attrs = ''
+
+    url = media(url)
+
+    # Don't download any image until the javascript sets it based on
+    # data-src so we can do high-dpi detection. If no js, show the
+    # normal-res version.
+    markup = ('<img class="js" src="" data-src="%s" data-high-res="true" %s>'
+              '<noscript><img src="%s" %s></noscript>'
               % (url, attrs, url, attrs))
 
     return jinja2.Markup(markup)

--- a/bedrock/mozorg/tests/test_helper_misc.py
+++ b/bedrock/mozorg/tests/test_helper_misc.py
@@ -15,6 +15,7 @@ from bedrock.newsletter.tests.test_views import newsletters
 from funfactory.urlresolvers import reverse
 
 from bedrock.mozorg.helpers.misc import platform_img
+from bedrock.mozorg.helpers.misc import high_res_img
 from bedrock.mozorg.tests import TestCase
 
 
@@ -304,3 +305,26 @@ class TestPressBlogUrl(TestCase):
     def test_press_blog_url_other_locale(self):
         """No blog for locale, fallback to default press blog"""
         eq_(self._render('oc'), 'https://blog.mozilla.org/press/')
+
+
+class TestHighResImg(TestCase):
+    @override_settings(MEDIA_URL='/media/')
+    def test_high_res_img_no_optional_attributes(self):
+        """Should return expected markup without optional attributes"""
+        markup = high_res_img('test.png')
+        expected = (
+            u'<img class="js" src="" data-src="/media/test.png" '
+            u'data-high-res="true" >'
+            u'<noscript><img src="/media/test.png" ></noscript>')
+        self.assertEqual(markup, jinja2.Markup(expected))
+
+    @override_settings(MEDIA_URL='/media/')
+    def test_high_res_img_with_optional_attributes(self):
+        """Should return expected markup with optional attributes"""
+        markup = high_res_img('test.png', {'data-test-attr': 'test'})
+        expected = (
+            u'<img class="js" src="" data-src="/media/test.png" '
+            u'data-high-res="true" data-test-attr="test">'
+            u'<noscript><img src="/media/test.png" data-test-attr="test">'
+            u'</noscript>')
+        self.assertEqual(markup, jinja2.Markup(expected))

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -367,6 +367,7 @@ MINIFY_BUNDLES = {
             'js/base/global.js',
             'js/base/footer-email-form.js',
             'js/base/mozilla-input-placeholder.js',
+            'js/base/mozilla-image-helper.js',
         ),
         'common-resp': (
             'js/libs/jquery-1.7.1.min.js',
@@ -374,6 +375,7 @@ MINIFY_BUNDLES = {
             'js/base/nav-main-resp.js',
             'js/base/footer-email-form.js',
             'js/base/mozilla-input-placeholder.js',
+            'js/base/mozilla-image-helper.js',
         ),
         'contribute': (
             'js/libs/jquery.sequence.js',
@@ -402,6 +404,7 @@ MINIFY_BUNDLES = {
             'js/base/nav-main.js',
             'js/base/footer-email-form.js',
             'js/base/mozilla-input-placeholder.js',
+            'js/base/mozilla-image-helper.js',
         ),
         'firefox_all': (
             'js/firefox/firefox-language-search.js',
@@ -412,6 +415,7 @@ MINIFY_BUNDLES = {
             'js/base/nav-main-resp.js',
             'js/base/footer-email-form.js',
             'js/base/mozilla-input-placeholder.js',
+            'js/base/mozilla-image-helper.js',
         ),
         'firefox_central': (
             'js/base/mozilla-video-tools.js',
@@ -512,6 +516,7 @@ MINIFY_BUNDLES = {
             'js/base/global.js',
             'js/base/nav-main-resp.js',
             'js/base/footer-email-form.js',
+            'js/base/mozilla-image-helper.js',
         ),
         'pager': (
             'js/base/mozilla-pager.js',

--- a/docs/coding.rst
+++ b/docs/coding.rst
@@ -33,6 +33,45 @@ template data as keyword arguments:
 
 The variable `latest_version` will be available in the template.
 
+Embedding images
+--------------------
+
+Images should be included on pages using helper functions.
+
+media()
+^^^^^^^^^^^
+For a simple image, the `media()` function is used to generate the image URL. For example::
+
+	<img src="{{ media('img/firefox/new/firefox-logo.png') }}" alt="Firefox" />
+
+will output an image::
+
+    <img src="/media/img/firefox/new/firefox-logo.png" alt="Firefox">
+
+high_res_img()
+^^^^^^^^^^^
+For images that include a high-resolution alternative for displays with a high pixel density, use the `high_res_img()` function::
+
+    high_res_img('img/firefox/new/firefox-logo.png', {'alt': 'Firefox', 'width': '200', 'height': '100'})
+
+The `high_res_img()` function will automatically look for the image in the URL parameter suffixed with `'-high-res'`, e.g. `img/firefox/new/firefox-logo-high-res.png` and switch to it if the display has high pixel density.
+
+img_l10n()
+^^^^^^^^^^
+Images that have translatable text can be handled with `img_l10n()`::
+
+	<img src="{{ img_l10n('firefox/os/have-it-all/messages.jpg') }}" />
+
+The images referenced by `img_l10n()` must exist in `media/img/l10n/`, so for above example, the images could include `media/img/l10n/en-US/firefox/os/have-it-all/messages.jpg` and `media/img/l10n/es-ES/firefox/os/have-it-all/messages.jpg`.
+
+platform_img()
+^^^^^^^^^^^^^^
+Finally, for outputting an image that differs depending on the platform being used, the `platform_img()` function will automatically display the image for the user's browser::
+
+    platform_img('img/firefox/new/browser.png', {'alt': 'Firefox screenshot'})
+
+`platform_img()` will automatically look for the images `browser-mac.png`, `browser-win.png`, `browser-linux.png`, etc. Platform image also supports hi-res images by adding `'data-high-res': true` to the list of optional attributes.
+
 Writing Views
 -------------
 

--- a/media/js/base/global.js
+++ b/media/js/base/global.js
@@ -32,33 +32,10 @@ function init_download_links() {
     $('.download-list').attr('role', 'presentation');
 }
 
-// platform images
-
-function init_platform_imgs() {
-    $('.platform-img').each(function() {
-        var suffix = '';
-        var $img = $(this);
-        if (site.platform === 'osx' || site.platform === 'oldmac') {
-            suffix = '-mac';
-        }
-        else if (site.platform === 'linux') {
-            suffix = '-linux';
-        }
-
-        var orig_src = $img.data('src');
-        var i = orig_src.lastIndexOf('.');
-        var base = orig_src.substring(0, i);
-        var ext = orig_src.substring(i);
-        this.src = base + suffix + ext;
-        $img.addClass(site.platform);
-    });
-}
-
 // init
 
 $(document).ready(function() {
     init_download_links();
-    init_platform_imgs();
     $(window).on('load', function () {
         $('html').addClass('loaded');
     });
@@ -107,7 +84,6 @@ function isFirefoxUpToDate(latest, esr) {
 function isMobile() {
     return /\sMobile/.test(window.navigator.userAgent);
 }
-
 
 // Create text translation function using #strings element.
 // TODO: Move to docs

--- a/media/js/base/mozilla-image-helper.js
+++ b/media/js/base/mozilla-image-helper.js
@@ -1,0 +1,107 @@
+/**
+ * Utility class for high-resolution detection and display and also platform
+ * images
+ *
+ * This code is licensed under the Mozilla Public License 1.1.
+ *
+ * @copyright 2013 Mozilla Foundation
+ * @license   http://www.mozilla.org/MPL/MPL-1.1.html Mozilla Public License 1.1
+ * @author    Nick Burka <nick@silverorange.com>
+ */
+
+$(document).ready(function() {
+    Mozilla.ImageHelper.initPlatformImages();
+    Mozilla.ImageHelper.initHighResImages();
+});
+
+// create namespace
+if (typeof Mozilla == 'undefined') {
+    var Mozilla = {};
+}
+
+// {{{ Mozilla.ImageHelper
+
+/**
+ * ImageHelper object
+ */
+Mozilla.ImageHelper = function() {
+};
+
+Mozilla.ImageHelper.is_high_dpi = null;
+
+// }}}
+
+// Platform Images
+// {{{ initPlatformImages()
+
+Mozilla.ImageHelper.initPlatformImages = function() {
+    $('.platform-img').each(function() {
+        var suffix = '';
+        var $img = $(this);
+        if (site.platform === 'osx' || site.platform === 'oldmac') {
+            suffix = '-mac';
+        }
+        else if (site.platform === 'linux') {
+            suffix = '-linux';
+        }
+
+        var orig_src = $img.data('src');
+        var i = orig_src.lastIndexOf('.');
+        var base = orig_src.substring(0, i);
+        var ext = orig_src.substring(i);
+        var src = base + suffix + ext;
+
+        if ($img.data('high-res') && Mozilla.ImageHelper.isHighDpi()) {
+            src = Mozilla.ImageHelper.convertUrlToHighRes(src);
+        }
+
+        this.src = src;
+
+        $img.addClass(site.platform);
+    });
+};
+
+// }}}
+
+// High Resolution Images
+// {{{ initHighResImages()
+
+Mozilla.ImageHelper.initHighResImages = function() {
+    $('img[src=""][data-src][data-high-res="true"]').each(function() {
+        var src = $(this).data('src');
+        if (Mozilla.ImageHelper.isHighDpi()) {
+            src = Mozilla.ImageHelper.convertUrlToHighRes(src);
+        }
+
+        this.src = src;
+    });
+};
+
+// }}}
+// {{{ isHighDpi()
+
+Mozilla.ImageHelper.isHighDpi = function() {
+    if (Mozilla.ImageHelper.is_high_dpi === null) {
+        var media_query = '(-webkit-min-device-pixel-ratio: 1.5),' +
+                          '(-o-min-device-pixel-ratio: 3/2),' +
+                          '(min--moz-device-pixel-ratio: 1.5),' +
+                          '(min-resolution: 1.5dppx)';
+
+        Mozilla.ImageHelper.is_high_dpi = (window.devicePixelRatio > 1 ||
+               (window.matchMedia && window.matchMedia(media_query).matches));
+    }
+
+    return Mozilla.ImageHelper.is_high_dpi;
+};
+
+// }}}
+// {{{ convertUrlToHighRes()
+
+Mozilla.ImageHelper.convertUrlToHighRes = function(url) {
+    var i = url.lastIndexOf('.');
+    var base = url.substring(0, i);
+    var ext = url.substring(i);
+    return base + '-high-res' + ext;
+};
+
+// }}}


### PR DESCRIPTION
A new utility script that allows the easy embedding of normal and high-dpi images. Simply call:

```
{{ at2x_img('img/firefox/normal-dpi.png', 'img/firefox/high-dpi.png', 300, 100, **{ 'alt': 'foo'}) }}
```

And an image tag that includes a "data-at2x-src" attribute will be embedded in the page. Javascript is then used to detect high-dpi screens and show the at2x src if supported, otherwise the normal res image is shown.

This also works with platform images:

```
{{ platform_img('img/firefox/normal-dpi.png', **{ 'data-at2x-src': 'img/firefox/high-dpi.png', 'width': '500', 'height': '200'}) }}
```
