### PR TITLE
Bug 899837 - Always display thanks on /updated page

### DIFF
--- a/bedrock/base/templates/base-resp.html
+++ b/bedrock/base/templates/base-resp.html
@@ -70,6 +70,16 @@
 
     {% block mosaic %}{% endblock %}
 
+    {% block messages %}
+      {% if messages %}
+        <ul class="messagelist billboard">
+          {% for message in messages %}
+            <li{% if message.tags %} class="{{ message.tags }}"{% endif %}>{{ message }}</li>
+          {% endfor %}
+        </ul>
+      {% endif %}
+    {% endblock messages %}
+
     {% block content %}{% endblock %}
 
     {% block email_form %}{{ email_newsletter_form() }}{% endblock %}

--- a/bedrock/base/templates/base.html
+++ b/bedrock/base/templates/base.html
@@ -61,6 +61,16 @@
       </header>
     {% endblock %}
 
+    {% block messages %}
+      {% if messages %}
+        <ul class="messagelist billboard">
+          {% for message in messages %}
+            <li{% if message.tags %} class="{{ message.tags }}"{% endif %}>{{ message }}</li>
+          {% endfor %}
+        </ul>
+      {% endif %}
+    {% endblock messages %}
+
     {% block content %}{% endblock %}
 
     {% block email_form %}{{ email_newsletter_form() }}{% endblock %}

--- a/bedrock/newsletter/templates/newsletter/updated.html
+++ b/bedrock/newsletter/templates/newsletter/updated.html
@@ -3,14 +3,6 @@
 {% block body_id %}newsletter-updated{% endblock body_id %}
 
 {% block content %}
-  {% if messages %}  {# FIXME - this ought to be in base-resp.html #}
-    <ul class="messagelist billboard">
-      {% for message in messages %}
-        <li{% if message.tags %} class="{{ message.tags }}"{% endif %}>{{ message }}</li>
-      {% endfor %}
-    </ul>
-  {% endif %}
-
   {% if unsubscribed_all %}  {# user requested to unsub all #}
 
     <div id="main-feature" class="unsub">

--- a/bedrock/newsletter/tests/test_views.py
+++ b/bedrock/newsletter/tests/test_views.py
@@ -234,8 +234,8 @@ class TestExistingNewsletterView(TestCase):
                 with patch('lib.l10n_utils.render'):
                     basket_patches['user'].return_value = self.user
                     rsp = self.client.post(url, self.data)
-        # Should have given some messages
-        self.assertEqual(1, add_msg.call_count,
+        # Should have given no messages
+        self.assertEqual(0, add_msg.call_count,
                          msg=repr(add_msg.call_args_list))
         # Should have called update_user with subscription list
         self.assertEqual(1, basket_patches['update_user'].call_count)
@@ -338,8 +338,8 @@ class TestExistingNewsletterView(TestCase):
              'newsletters': u'mozilla-and-you'},
             kwargs
         )
-        # One message should be emitted
-        self.assertEqual(1, add_msg.call_count,
+        # No messages should be emitted
+        self.assertEqual(0, add_msg.call_count,
                          msg=repr(add_msg.call_args_list))
         # Should redirect to the 'updated' view
         url = reverse('newsletter.updated')

--- a/bedrock/newsletter/views.py
+++ b/bedrock/newsletter/views.py
@@ -184,7 +184,6 @@ def existing(request, token=None):
                     )
                     return l10n_utils.render(request,
                                              'newsletter/existing.html')
-                messages.add_message(request, messages.INFO, thank_you)
 
             # If they chose to remove all, tell basket that they've opted out
             if remove_all:
@@ -197,9 +196,6 @@ def existing(request, token=None):
                     )
                     return l10n_utils.render(request,
                                              'newsletter/existing.html')
-                if not kwargs:
-                    # We haven't told them thank you yet
-                    messages.add_message(request, messages.INFO, thank_you)
                 # We need to pass their token to the next view
                 url = reverse('newsletter.updated') \
                     + "?unsub=%s&token=%s" % (UNSUB_UNSUBSCRIBED_ALL, token)
@@ -282,6 +278,9 @@ def updated(request):
 
     # Token might also have been passed (on remove_all only)
     token = request.REQUEST.get('token', None)
+
+    # Always say thank you
+    messages.add_message(request, messages.INFO, thank_you)
 
     if request.method == 'POST' and reasons_submitted and token:
         # Tell basket about their reasons


### PR DESCRIPTION
Always display "Thank you for updating your email preferences"
at the top of the /newsletter/updated/ page.
