### PR TITLE
Fix bug 824126: Conditionally redirect /ports/os2

### DIFF
--- a/etc/httpd/global.conf
+++ b/etc/httpd/global.conf
@@ -58,8 +58,11 @@ RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/webhero(.*)$ /firefox/ [L,R=301]
 RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/backtoschool(/?)$ https://addons.mozilla.org/firefox/collections/mozilla/back-to-school/ [L,R=301]
 RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/backtoschool/firstrun(/?)$ /firefox/firstrun/ [L,R=301]
 
-# bug 837942
+# bug 824126, 837942
 RewriteRule ^/ports/qtmozilla(?:/(?:index.html)?)?$ https://wiki.mozilla.org/Qt [L,R=301]
+RewriteRule ^/ports/os2/?$ https://wiki.mozilla.org/Ports/os2 [L,R=301]
+RewriteCond %{REQUEST_URI} !^/ports/os2/gcc/?
+RewriteCond %{REQUEST_URI} !^/ports/os2/selmail/?
 RewriteRule ^/ports(.*)$ http://www-archive.mozilla.org/ports$1 [L,R=301]
 
 ## Redirect things to django!


### PR DESCRIPTION
To test that this works correctly, ensure that the following redirects work (using regex pseudo-code here).
1. `mozilla.org/qtmozilla(optional /)`→`https://wiki.mozilla.org/Qt`
2. `mozilla.org/ports/os2(optional /)`→`https://wiki.mozilla.org/Ports/os2`
3. `mozilla.org/ports/os2/gcc(anything-or-nothing-else)`→`404 (intentionally)`
4. `mozilla.org/ports/os2/selmail(anything-or-nothing-else)`→`404 (intentionally)`
5. `mozilla.org/ports(anything-or-nothing-else)`→`http://www-archive.mozilla.org/ports(value-of-"anything-or-nothing-else"-from-before)`
