### PR TITLE
Update secure_url to match protocol of current page. Bug 901523.

### DIFF
--- a/bedrock/mozorg/helpers/misc.py
+++ b/bedrock/mozorg/helpers/misc.py
@@ -43,9 +43,12 @@ def secure_url(ctx, viewname=None):
     """Retrieve a full secure URL especially for form submissions"""
     _path = url(viewname) if viewname else None
     _url = ctx['request'].build_absolute_uri(_path)
-    if settings.DEBUG:
-        return _url
-    return _url.replace('http://', 'https://')
+
+    # only force https if current page was requested via SSL
+    # otherwise, CSRF/AJAX errors will occur (submitting to https from http)
+    if ctx['request'].is_secure():
+        return _url.replace('http://', 'https://')
+    return _url
 
 
 @jingo.register.function

--- a/bedrock/mozorg/tests/test_helper_misc.py
+++ b/bedrock/mozorg/tests/test_helper_misc.py
@@ -32,32 +32,29 @@ class TestSecureURL(TestCase):
     test_path = '/firefox/partners/'
     test_view_name = 'about.partnerships.contact-bizdev'
     req = RequestFactory(HTTP_HOST=host).get(test_path)
+    secure_req = RequestFactory(HTTP_HOST=host).get(test_path, {}, **{ 'wsgi.url_scheme': 'https' })
 
-    def _test(self, view_name, expected_url):
-        eq_(render("{{ secure_url('%s') }}" % view_name, {'request': self.req}),
+    def _test(self, view_name, expected_url, ssl):
+        eq_(render("{{ secure_url('%s') }}" % view_name, {'request': (self.secure_req if ssl else self.req)}),
             expected_url)
 
-    @patch('django.conf.settings.DEBUG', True)
-    def test_on_dev_with_view_name(self):
-        # Should output a reversed path
+    def test_no_ssl_with_view_name(self):
+        # Should output a reversed path without https
         self._test(self.test_view_name,
-                   'http://' + self.host + reverse(self.test_view_name))
+                   'http://' + self.host + reverse(self.test_view_name), False)
 
-    @patch('django.conf.settings.DEBUG', True)
-    def test_on_dev_without_view_name(self):
-        # Should output the current, full URL
-        self._test('', 'http://' + self.host + self.test_path)
+    def test_no_ssl_without_view_name(self):
+        # Should output the current, full URL without https
+        self._test('', 'http://' + self.host + self.test_path, False)
 
-    @patch('django.conf.settings.DEBUG', False)
-    def test_on_prod_with_view_name(self):
+    def test_ssl_with_view_name(self):
         # Should output a reversed, full secure URL
         self._test(self.test_view_name,
-                   'https://' + self.host + reverse(self.test_view_name))
+                   'https://' + self.host + reverse(self.test_view_name), True)
 
-    @patch('django.conf.settings.DEBUG', False)
-    def test_on_prod_without_view_name(self):
+    def test_ssl_without_view_name(self):
         # Should output the current, full secure URL
-        self._test('', 'https://' + self.host + self.test_path)
+        self._test('', 'https://' + self.host + self.test_path, True)
 
 @patch('bedrock.mozorg.helpers.misc.L10N_IMG_PATH', TEST_L10N_IMG_PATH)
 @patch('django.conf.settings.LANGUAGE_CODE', 'en-US')


### PR DESCRIPTION
AJAX requests will error out when being made from HTTP to HTTPS. CSRF protected forms require protocols to match.

Longer term solution (forcing all of mozilla.org to be HTTPS) is in the works. This is a passive patch to immediately fix HTTP to HTTPS errors introduced in PR 928 (https://github.com/mozilla/bedrock/pull/928).
