### PR TITLE
[bug 896961] Small refactor for two global.js unit tests

### DIFF
--- a/media/js/base/global.js
+++ b/media/js/base/global.js
@@ -11,9 +11,10 @@
  *
  * @param string direct link to download URL
  */
-function trigger_ie_download(link) {
+function trigger_ie_download(link, appVersion) {
+    var version = appVersion || navigator.appVersion;
     // Only open if we got a link and this is IE.
-    if (link && navigator.appVersion.indexOf('MSIE') != -1) {
+    if (link && version.indexOf('MSIE') != -1) {
         window.open(link, 'download_window', 'toolbar=0,location=no,directories=0,status=0,scrollbars=0,resizeable=0,width=1,height=1,top=0,left=0');
         window.focus();
     }
@@ -64,11 +65,12 @@ $(document).ready(function() {
 });
 
 //get Master firefox version
-function getFirefoxMasterVersion() {
+function getFirefoxMasterVersion(userAgent) {
     var version = 0;
+    var ua = userAgent || navigator.userAgent;
 
     var matches = /Firefox\/([0-9]+).[0-9]+(?:.[0-9]+)?/.exec(
-        navigator.userAgent
+        ua
     );
 
     if (matches !== null && matches.length > 0) {

--- a/media/js/test/spec/global.js
+++ b/media/js/test/spec/global.js
@@ -8,42 +8,27 @@ describe("global.js", function() {
 
   describe("trigger_ie_download", function () {
 
-    // Store navigator.appVersion for reference
-    var original = navigator.appVersion;
-
-    /* After each test in the scope of this suite, 
-     * reset navigator.appVersion to it's original value */
-    afterEach(function () {
-      navigator.__defineGetter__('appVersion', function(){
-        return original;
-      });
-    });
-
     it("should call window.open for internet explorer", function () {
 
       // Let's pretend to be IE just for this individual test
-      navigator.__defineGetter__('appVersion', function(){
-        return '5.0 (compatible; MSIE 9.0; Windows NT 6.1; WOW64; Trident/5.0)';
-      });
+      var appVersion = '5.0 (compatible; MSIE 9.0; Windows NT 6.1; WOW64; Trident/5.0)';
 
       /* Wrap window.open with a stub function, since all we need 
        * to know is that window.open gets called. We do not need 
        * window.open to excecute to satisfy the test. We can also 
        * spy on this stub to see if it gets called successfully. */
       window.open = sinon.stub();
-      trigger_ie_download('foo');
+      trigger_ie_download('foo', appVersion);
       expect(window.open.called).toBeTruthy();
     });
 
     it("should not window.open for other browsers", function () {
 
       // Let's pretend to be a non IE browser
-      navigator.__defineGetter__('appVersion', function(){
-        return '5.0 (Macintosh)';
-      });
+      var appVersion = '5.0 (Macintosh)';
 
       window.open = sinon.stub();
-      trigger_ie_download('foo');
+      trigger_ie_download('foo', appVersion);
       expect(window.open.called).not.toBeTruthy();
     });
 
@@ -101,31 +86,18 @@ describe("global.js", function() {
 
   describe("getFirefoxMasterVersion", function () {
 
-    var original = navigator.userAgent;
-
-    afterEach(function () {
-      navigator.__defineGetter__('userAgent', function(){
-        return original;
-      });
-    });
-
     it("should return the firefox master version number", function () {
       var result;
       // Pretend to be Firefox 23
-      navigator.__defineGetter__('userAgent', function() {
-        return 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.8; rv:23.0) Gecko/20100101 Firefox/23.0';
-      });
-      result = getFirefoxMasterVersion();
+      var ua = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.8; rv:23.0) Gecko/20100101 Firefox/23.0';
+      result = getFirefoxMasterVersion(ua);
       expect(result).toEqual(23);
     });
 
     it("should return 0 for non Firefox browsers", function () {
       var result;
-      // Pretend to be Chrome
-      navigator.__defineGetter__('userAgent', function() {
-        return 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/28.0.1500.71 Safari/537.36';
-      });
-      result = getFirefoxMasterVersion();
+      var ua = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/28.0.1500.71 Safari/537.36';
+      result = getFirefoxMasterVersion(ua);
       expect(result).toEqual(0);
     });
   });


### PR DESCRIPTION
Updates two if the initial global.js unit tests, removing the need for `__defineGetter__` (doesn't play nice with some Webkit versions, e.g. phantomJS).

Required a small change to the two corresponding global.js methods to make testing easier.
