### PR TITLE
Bug 899837 - Don't always say thanks on newsletter/updated

### DIFF
--- a/bedrock/newsletter/views.py
+++ b/bedrock/newsletter/views.py
@@ -312,8 +312,9 @@ def updated(request):
     # Token might also have been passed (on remove_all only)
     token = request.REQUEST.get('token', None)
 
-    # Always say thank you
-    messages.add_message(request, messages.INFO, thank_you)
+    # Say thank you unless we're saying something more specific
+    if not unsub:
+        messages.add_message(request, messages.INFO, thank_you)
 
     if request.method == 'POST' and reasons_submitted and token:
         # Tell basket about their reasons


### PR DESCRIPTION
Only say thanks on newsletter/updated page if the page isn't
already saying something more specific, like "We're sorry
to see you go" or "Thanks for telling us why you're leaving".
