### PR TITLE
Bug 900597 - Fixed gaia_url

### DIFF
--- a/bedrock/mozorg/templates/mozorg/contribute.html
+++ b/bedrock/mozorg/templates/mozorg/contribute.html
@@ -418,7 +418,7 @@ Get involved with Mozilla by making Firefox, Thunderbird and other projects <a h
                 <h3 id="webdev">{{_('Web Development') }}</h3>
                 <div class="content">
                   <p>
-{% trans webdev_url='https://wiki.mozilla.org/Webdev/GetInvolved', gaia_url='https://wiki.mozilla.org/Gaia/Hacking' %}
+{% trans webdev_url='https://wiki.mozilla.org/Webdev/GetInvolved', gaia_url='https://developer.mozilla.org/en-US/docs/Mozilla/Firefox_OS/Platform/Gaia/Hacking' %}
 Our web sites are open for web developers to hack on.  <a href="{{ webdev_url }}">Find a web site project</a> to get started on.  Your web skills can also be used to <a href="{{ gaia_url }}">help us build our new Firefox OS</a>.
 {% endtrans %}
                   </p>


### PR DESCRIPTION
Bug 900597 - Wrong Gaia hacking link on "get involved" page 

Fixed gaia_url on line 421
