### PR TITLE
Remove duplicate messages from /newsletter/existing

### DIFF
--- a/bedrock/newsletter/templates/newsletter/existing.html
+++ b/bedrock/newsletter/templates/newsletter/existing.html
@@ -13,14 +13,6 @@
     </div>
   {% endblock %}
 
-  {% if messages %}  {# FIXME - this ought to be in base-resp.html #}
-    <ul class="messagelist billboard">
-      {% for message in messages %}
-        <li{% if message.tags %} class="{{ message.tags }}"{% endif %}>{{ message }}</li>
-      {% endfor %}
-    </ul>
-  {% endif %}
-
   {% if formset %}
     <form method="post" action="{{ secure_url() }}" id="existing-newsletter-form" class="container billboard"
         data-initial-newsletters='{{ newsletters_subscribed }}'>


### PR DESCRIPTION
The template for /existing displayed the Django messages so we could
tell the user when their token was bad or other errors occurred.

In bug 899837, we changed the base template to display Django messages,
resulting in the /existing page showing the messages twice.

Remove the display of messages from the /existing page's template so
we only see the messages once, via the base template.
