### PR TITLE
[fix bug 904042] Background fade display bug on IE8 Firefox os page

### DIFF
--- a/bedrock/firefox/templates/firefox/os/index.html
+++ b/bedrock/firefox/templates/firefox/os/index.html
@@ -116,9 +116,9 @@
 
   <div id="adaptive-wrapper" class="nav-anchor">
     <div id="adaptive-bgs">
-      <div id="adaptive-bg-birthday" class="adaptive-bg bg-birthday"></div>
-      <div id="adaptive-bg-cafe" class="adaptive-bg bg-cafe"></div>
-      <div id="adaptive-bg-soccer" class="adaptive-bg bg-soccer"></div>
+      <div id="adaptive-bg-birthday" data-current="1" class="adaptive-bg bg-birthday"></div>
+      <div id="adaptive-bg-cafe" data-current="0" class="adaptive-bg bg-cafe"></div>
+      <div id="adaptive-bg-soccer" data-current="0" class="adaptive-bg bg-soccer"></div>
 
       <a title="{{_('Scroll down')}}" href="#" id="keep-scrolling"></a>
     </div>

--- a/media/js/firefox/os/desktop.js
+++ b/media/js/firefox/os/desktop.js
@@ -62,13 +62,15 @@
       $bg_next = $intro_bg_a;
     }
 
-    displayPhoneScreen(intro_bg_index);
-
     $bg_next.attr('class', 'intro-bg bg-' + intro_bgs[intro_bg_index]).show();
     $bg_cur.fadeOut(1000, function() {
       $bg_next.css('z-index', 2);
       $bg_cur.css('z-index', 1);
     });
+
+    setTimeout(function () {
+      displayPhoneScreen(intro_bg_index);
+    }, 100);
   }
 
   function engageIntroBGRotation() {


### PR DESCRIPTION
This should fix the IE8 background image bug described here: https://bugzilla.mozilla.org/show_bug.cgi?id=904042

I also noticed that adding a slight (100ms) delay to the phone screen transition in the top section helps make for a smoother animation on older browsers, so I added that to this PR.
