### PR TITLE
[bug 898766] plugin search query should use https

### DIFF
--- a/media/js/plugincheck/check-plugins.js
+++ b/media/js/plugincheck/check-plugins.js
@@ -84,7 +84,7 @@ $(function() {
         }
     },
     unknownPluginUrl = function (pluginName) {
-        return 'http://www.google.com/search?q=' + encodeURI(window.trans('googleSearchq') + ' ' + pluginName);
+        return 'https://www.google.com/search?q=' + encodeURI(window.trans('googleSearchq') + ' ' + pluginName);
     },
     buildObject = function(data) {
         var plugin = data.pluginInfo.raw,


### PR DESCRIPTION
This one slipped through in #1139...
