### PR TITLE
Upgrade py-bcrypt.

### DIFF
--- a/requirements/compiled.txt
+++ b/requirements/compiled.txt
@@ -4,6 +4,6 @@ Jinja2==2.5.5
 # for bcrypt passwords
 hmac==20101005
 hashlib==20081119
-py-bcrypt==0.2
+py-bcrypt==0.3
 
 lxml==2.3.3


### PR DESCRIPTION
Maintainer appears to have deleted v0.2 of py-bcrypt from pypi, and this is
causing jenkins to fail.
