### PR TITLE
Fix Bug 903089 - robots.txt changes

### DIFF
--- a/bedrock/mozorg/templates/mozorg/robots.txt
+++ b/bedrock/mozorg/templates/mozorg/robots.txt
@@ -1,0 +1,10 @@
+user-agent: *
+{% if disallow_all -%}
+disallow: /
+{% else -%}
+disallow: /*/download/
+disallow: /*/firstrun/
+disallow: /*/newsletter/existing/
+disallow: /*/whatsnew/
+disallow: /b/
+{% endif %}

--- a/bedrock/mozorg/tests/test_views.py
+++ b/bedrock/mozorg/tests/test_views.py
@@ -17,6 +17,7 @@ from nose.tools import assert_false, eq_, ok_
 from pyquery import PyQuery as pq
 
 from bedrock.mozorg.tests import TestCase
+from bedrock.mozorg import views
 from lib import l10n_utils
 
 
@@ -285,3 +286,19 @@ class TestContribute(TestCase):
         eq_(len(mail.outbox), 1)
         m = mail.outbox[0]
         self.assertIn(EXPECTED, m.body)
+
+
+class TestRobots(TestCase):
+    @override_settings(SITE_URL='https://www.mozilla.org')
+    def test_production_disallow_all_is_false(self):
+        self.assertFalse(views.Robots().get_context_data()['disallow_all'])
+
+    @override_settings(SITE_URL='http://mozilla.local')
+    def test_non_production_disallow_all_is_true(self):
+        self.assertTrue(views.Robots().get_context_data()['disallow_all'])
+
+    @override_settings(SITE_URL='https://www.mozilla.org')
+    def test_robots_no_redirect(self):
+        response = Client().get('/robots.txt')
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(response.context['disallow_all'])

--- a/bedrock/mozorg/urls.py
+++ b/bedrock/mozorg/urls.py
@@ -56,4 +56,5 @@ urlpatterns = patterns('',
     url(r'^plugincheck/$',
         views.plugincheck,
         name='mozorg.plugincheck'),
+    url(r'^robots.txt$', views.Robots.as_view(), name='robots.txt'),
 )

--- a/bedrock/mozorg/views.py
+++ b/bedrock/mozorg/views.py
@@ -9,6 +9,7 @@ from django.core.context_processors import csrf
 from django.http import (HttpResponse, HttpResponseRedirect)
 from django.views.decorators.csrf import csrf_exempt, csrf_protect
 from django.views.decorators.http import require_POST
+from django.views.generic.base import TemplateView
 from django.shortcuts import redirect
 
 import basket
@@ -191,3 +192,11 @@ def contribute_university_ambassadors(request):
         request,
         'mozorg/contribute_university_ambassadors.html', {'form': form}
     )
+
+
+class Robots(TemplateView):
+    template_name = 'mozorg/robots.txt'
+
+    def get_context_data(self, **kwargs):
+        SITE_URL = getattr(settings, 'SITE_URL', '')
+        return {'disallow_all': not SITE_URL.endswith('://www.mozilla.org')}

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -56,6 +56,7 @@ SUPPORTED_NONLOCALES += [
     'telemetry',
     'webmaker',
     'gameon',
+    'robots.txt',
 ]
 
 ALLOWED_HOSTS = [

--- a/etc/httpd/global.conf
+++ b/etc/httpd/global.conf
@@ -390,3 +390,6 @@ RewriteRule ^/projects/security/tld-idn-policy-list.html$ /about/governance/poli
 RewriteRule ^/projects/security/membership-policy.html$ /about/governance/policies/security-group/membership/ [L,R=301]
 RewriteRule ^/projects/security/secgrouplist.html$ /about/governance/policies/security-group/ [L,R=301]
 RewriteRule ^/projects/security/security-bugs-policy.html$ /about/governance/policies/security-group/bugs/ [L,R=301]
+
+# bug 903089
+RewriteRule ^/robots.txt$ /b/robots.txt [PT]


### PR DESCRIPTION
In production, add the following line to robots.txt:

disallow: /*/newsletter/existing/

In dev, staging, etc:

user-agent: *
disallow: /

settings.SITE_URL is used to determine if we are in production.

In etc/httpd/global.conf, add a RewriteRule to serve robots.txt from
Django.

Add robots.txt to settings.SUPPORTED_NONLOCALES to eliminate redirect.
