### PR TITLE
Minor requirements cleanup

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -41,6 +41,7 @@ You need to create a virtual environment for Python libraries. Skip the first in
     $ virtualenv venv                            # create a virtual env in the folder `venv`
     $ source venv/bin/activate                   # activate the virtual env
     $ pip install -r requirements/compiled.txt   # installs compiled dependencies
+    $ pip install -r requirements/dev.txt        # installs test dependencies
 
 If you are on OSX and some of the compiled dependencies fails to compile, try explicitly setting the arch flags and try again::
 

--- a/requirements/compiled.txt
+++ b/requirements/compiled.txt
@@ -1,9 +1,2 @@
-#MySQL-python==1.2.3c1
 Jinja2==2.5.5
-
-# for bcrypt passwords
-hmac==20101005
-hashlib==20081119
-py-bcrypt==0.2
-
 lxml==2.3.3

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -1,5 +1,6 @@
-# Django stuff
--e git://github.com/django/django@1.4.2#egg=django
+# Django 1.4.5 is also in vendor, but needs to be kept here so packages that
+# depend on Django do not install a newer version
+Django==1.4.5
 
 # Templates
 -e git://github.com/jbalogh/jingo.git#egg=jingo
@@ -17,9 +18,6 @@ GitPython==0.1.7
 # Celery: Message queue
 celery
 django-celery
-
-# bcrypt
-django-bcrypt
 
 # L10n
 Babel>=0.9.4


### PR DESCRIPTION
Remove unused django-bcrypt and its dependencies.

Update Django version in requirements.txt to 1.4.5 with explanatory
comment.

Add instruction to installation docs to install dev requirements after
compiled requirements.
