### PR TITLE
Fix bug 905222: Redirect Privacy Policy PDF.

### DIFF
--- a/etc/httpd/global.conf
+++ b/etc/httpd/global.conf
@@ -330,6 +330,7 @@ RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?privacy/policies/websites(/?)$ /b/$1privacy/
 RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?privacy-policy(?:\.html)?$ /$1privacy/policies/websites/ [L,R=301]
 RewriteRule ^/foundation/privacy-policy\.html$ /privacy/policies/websites/ [L,R=301]
 RewriteRule ^/about/policies/privacy-policy\.html$ /privacy/policies/websites/ [L,R=301]
+RewriteRule ^/en-US/privacy-policy\.pdf$ https://static.mozilla.com/moco/en-US/pdf/mozilla_privacypolicy.pdf [L,R=301]
 
 # bug 724633 - Porting foundation pages
 # Add redirects for the pdfs that were under /foundation/documents/


### PR DESCRIPTION
This version of the Privacy Policy is obsolete. We no longer link to it,
but users could still be accessing it directly.
