### PR TITLE
[bug 905144] cache bust updated video-js image sprite

### DIFF
--- a/media/js/libs/video-js/video-js-sandstone.css
+++ b/media/js/libs/video-js/video-js-sandstone.css
@@ -37,7 +37,7 @@
 .vjs-sandstone-skin div.vjs-big-play-button span,
 .vjs-sandstone-skin .vjs-menu-button div,
 .vjs-sandstone-skin .vjs-menu-button ul li.vjs-selected {
-    background-image: url('/media/js/libs/video-js/video-js-sandstone.png?2013-08');
+    background-image: url('/media/js/libs/video-js/video-js-sandstone.png?2013-08-15');
 }
 
 /* General styles for individual controls. */


### PR DESCRIPTION
Cache bust the image sprite that was updated in #1163

Note: the other image in 1163 does not seem to be used at present.
