### PR TITLE
change the second parameter of platform_img() to be a simple dictionary ...

### DIFF
--- a/bedrock/firefox/templates/firefox/central.html
+++ b/bedrock/firefox/templates/firefox/central.html
@@ -18,7 +18,7 @@
 <div id="main-feature" class="billboard">
     <h2>Tour the User Interface</h2>
     <div id="figure">
-      {{ platform_img('img/firefox/central/screen.png?2013-06', alt='Screenshot') }}
+      {{ platform_img('img/firefox/central/screen.png?2013-06', {'alt': 'Screenshot'}) }}
       <div id="svg-path"></div>
       <span class="roll-over inset">Roll over the markers below for feature info</span>
     </div>

--- a/bedrock/firefox/templates/firefox/customize.html
+++ b/bedrock/firefox/templates/firefox/customize.html
@@ -123,7 +123,7 @@
     <p>Plugins are small bits of third-party software built by companies like Adobe Systems or Apple to power videos, animation and games (examples include Flash Player or Quicktime). They can cause browser crashes or pose security risks when they get out of date, so we’ve built an easy tool to help you stay current. <a href="/en-US/plugincheck/">Check your plugins.</a></p>
   </div>
   <div class="span7">
-     {{ platform_img('img/firefox/customize/make-it-work.png?2013-06', alt='Make It Work: Plugins') }}
+     {{ platform_img('img/firefox/customize/make-it-work.png?2013-06', {'alt': 'Make It Work: Plugins'}) }}
   </div>
 </div>
 </section>
@@ -136,7 +136,7 @@
     <p>But, everyone has their own specific needs, and you can always adjust the interface to be exactly the way you like it: re-arrange, organize, add or remove buttons or fields to change your browsing experience however you want. <a href="https://support.mozilla.org/kb/How%20to%20customize%20the%20toolbar">Learn more.</a></p>
   </div>
   <div class="span7">
-     {{ platform_img('img/firefox/customize/adapt-your-interface.png', alt='Adapt Your Interface') }}
+     {{ platform_img('img/firefox/customize/adapt-your-interface.png', {'alt': 'Adapt Your Interface'}) }}
   </div>
 </div>
 </section>

--- a/bedrock/firefox/templates/firefox/features.html
+++ b/bedrock/firefox/templates/firefox/features.html
@@ -47,7 +47,7 @@
 
     <div id="awesomebar" class="feature">
       <h4>Awesome Bar</h4>
-      {{ platform_img('img/firefox/features/screen-awesomebar.png', alt='Awesome Bar screenshot') }}
+      {{ platform_img('img/firefox/features/screen-awesomebar.png', {'alt': 'Awesome Bar screenshot'}) }}
       <p>Get to your favorite sites quickly – even if you don’t remember the URLs. Type your term into the location bar (aka the Awesome Bar) and the autocomplete function will include possible matches from your browsing history, bookmarked sites and open tabs.</p>
       <p><a href="https://support.mozilla.org/kb/Location+bar+autocomplete">The Awesome Bar</a> learns as you use it—over time, it adapts to your preferences and offers better-fitting matches. We’ve tweaked it to give you greater control over the results (including privacy settings) and increased performance so you find what you need even faster.</p>
     </div>
@@ -62,7 +62,7 @@
         <div class="sub-feature">
           <h5>Tabs on Top</h5>
           <p>Tabs are above the Awesome Bar to make it easier to focus on the content of the sites you visit.</p>
-          {{ platform_img('img/firefox/features/screen-tabsontop.png', alt='Improved Interface screenshot') }}
+          {{ platform_img('img/firefox/features/screen-tabsontop.png', {'alt': 'Improved Interface screenshot'}) }}
         </div>
       </div>
 
@@ -70,7 +70,7 @@
         <div class="sub-feature">
           <h5>Firefox Button (Windows and Linux)</h5>
           <p>All your menu items are now found in a single button for easy access.</p>
-          {{ platform_img('img/firefox/features/screen-firefoxbutton.png', alt='Firefox Button screenshot') }}
+          {{ platform_img('img/firefox/features/screen-firefoxbutton.png', {'alt': 'Firefox Button screenshot'}) }}
         </div>
       </div>
 
@@ -78,7 +78,7 @@
         <div class="sub-feature">
           <h5>Bookmark Button</h5>
           <p>Manage your bookmarks in a single button. Find your favorite links without getting bogged down!</p>
-          {{ platform_img('img/firefox/features/screen-bookmarks.png', alt='Bookmarks Button screenshot') }}
+          {{ platform_img('img/firefox/features/screen-bookmarks.png', {'alt': 'Bookmarks Button screenshot'}) }}
         </div>
       </div>
 
@@ -86,7 +86,7 @@
         <div class="sub-feature">
           <h5>Simplified Reload/Stop Button</h5>
           <p>Your Awesome Bar now features one easy button to stop loading pages or reload pages.</p>
-          {{ platform_img('img/firefox/features/screen-reloadstop.png', alt='Reload/Stop Button screenshot') }}
+          {{ platform_img('img/firefox/features/screen-reloadstop.png', {'alt': 'Reload/Stop Button screenshot'}) }}
         </div>
       </div>
 
@@ -94,7 +94,7 @@
         <div class="sub-feature">
           <h5>Home Button</h5>
           <p>The Home button has been moved to the right side of the search-field.</p>
-          {{ platform_img('img/firefox/features/screen-home.png', alt='Home Button screenshot') }}
+          {{ platform_img('img/firefox/features/screen-home.png', {'alt': 'Home Button screenshot'}) }}
         </div>
       </div>
     </div>
@@ -109,7 +109,7 @@
         <div class="sub-feature">
           <h5>Pinned Tabs</h5>
           <p>Take sites you always keep open—like Web mail—off your tab bar and give them a permanent home in your browser. <a href="https://support.mozilla.org/kb/pinned-tabs-keep-favorite-websites-open">Learn how.</a></p>
-          {{ platform_img('img/firefox/features/screen-apptab.png', alt='Pinned Tabs screenshot') }}
+          {{ platform_img('img/firefox/features/screen-apptab.png', {'alt': 'Pinned Tabs screenshot'}) }}
         </div>
 
         <div class="feature">
@@ -122,7 +122,7 @@
         <div class="sub-feature">
           <h5>Switch-to-Tab</h5>
           <p>As you’re opening a new tab or typing in the Awesome Bar, Firefox will check to see if you already have that site open. If you do, you’ll be directed to the existing tab so you don’t open a duplicate.</p>
-          {{ platform_img('img/firefox/features/screen-switchtotab.png', alt='Switch-to-Tab screenshot') }}
+          {{ platform_img('img/firefox/features/screen-switchtotab.png', {'alt': 'Switch-to-Tab screenshot'}) }}
         </div>
 
         <div class="feature">
@@ -135,7 +135,7 @@
         <div class="sub-feature">
           <h5>New Tab</h5>
           <p>Firefox helps you get to your next task faster than ever by displaying a set of thumbnails of your most recently and frequently visited sites every time you open a new tab. You can also customize this page by adding, removing or reorganizing sites to get to where you want to go in one click.</p>
-          {{ platform_img('img/firefox/features/screen-newtab.jpg', alt='New Tab screenshot') }}
+          {{ platform_img('img/firefox/features/screen-newtab.jpg', {'alt': 'New Tab screenshot'}) }}
 
         </div>
       </div>
@@ -144,7 +144,7 @@
     <hr />
 
     <div id="sync" class="column-span feature">
-          {{ platform_img('img/firefox/features/screen-sync.png', alt='Sync screenshot') }}
+          {{ platform_img('img/firefox/features/screen-sync.png', {'alt': 'Sync screenshot'}) }}
       <h4>Stay in Sync</h4>
       <p>Sync seamlessly connects your desktop and mobile Firefoxes, so you can access your browsing history, passwords, bookmarks and even open tabs no matter which device you use. Access years of desktop browsing the first day you fire up your mobile, and use saved passwords from your desktop to fill out forms on your phone.</p>
       <p>Now you can surf the Web on your desktop, get up in the middle of browsing and have your open tabs ready and waiting on your mobile, just as you left them. Your browsing will never be the same! <a href="{{ php_url('/mobile/sync/') }}">Learn more about Sync</a> or <a href="{{ php_url('/mobile/') }}">get Firefox on your phone</a>.</p>
@@ -199,7 +199,7 @@
       </div>
 
       <div class="column1">
-          {{ platform_img('img/firefox/features/screen-search.png', alt='Search screenshot') }}
+          {{ platform_img('img/firefox/features/screen-search.png', {'alt': 'Search screenshot'}) }}
       </div>
 
       <div class="column2">
@@ -240,7 +240,7 @@
       <p>There’s a lot of great stuff on the Web, Firefox is full of ways to help you keep track.</p>
 
       <div class="oneclickbookmarking sub-feature">
-        {{ platform_img('img/firefox/features/screen-1clickbookmarks.png', alt='One-Click Bookmarking screenshot') }}
+        {{ platform_img('img/firefox/features/screen-1clickbookmarks.png', {'alt': 'One-Click Bookmarking screenshot'}) }}
         <h5>One-Click Bookmarking</h5>
         <p>Manage your bookmarks a lot or a little. One click on the star icon at the end of the location bar bookmarks a site. Two clicks and you can choose where to save it and whether to tag it. File bookmarked sites in easy-to-access folders and organize according to theme (like “job search” or “favorite shopping”). Find your bookmarked sites in a flash by entering the tag, page or bookmark name into the location bar. The more you use your tags and bookmark names in the location bar, the more the system will adapt to your preferences. <a href="https://support.mozilla.org/kb/how-do-i-use-bookmarks">Get all of the details on bookmarks.</a></p>
       </div>
@@ -425,8 +425,7 @@
       <div class="feature">
         <h4>Instant Web Site ID</h4>
         <p>Want to be extra sure about a site’s legitimacy before you make a purchase? Click on its favicon for an instant identity overview. Another click digs deeper: how many times have you visited? Are your passwords saved? Check up on suspicious sites, avoid Web forgeries and make sure a site is what it claims to be. <a href="https://support.mozilla.org/kb/Site+Identity+Button">Learn more.</a></p>
-        {{ platform_img('img/firefox/features/screen-websiteid.png', alt='Instant Web Site ID screenshot') }}
-
+        {{ platform_img('img/firefox/features/screen-websiteid.png', {'alt': 'Instant Web Site ID screenshot'}) }}
       </div>
 
       <div class="feature">
@@ -455,7 +454,7 @@
       <div class="feature">
         <h4>Private Browsing</h4>
         <p>Sometimes it’s nice to go undercover: Open a private window and protect your browsing history. You can switch between private and normal windows quickly, so it’s easy to go back to what you were doing before. This feature is great if you’re doing your online banking on a shared computer or checking email from an Internet café. <a href="https://support.mozilla.org/kb/Private+Browsing">Learn more.</a></p>
-        {{ platform_img('img/firefox/features/screen-private.png', alt='Private Browsing screenshot') }}
+        {{ platform_img('img/firefox/features/screen-private.png', {'alt': 'Private Browsing screenshot'}) }}
       </div>
 
       <div class="feature">
@@ -493,7 +492,7 @@
       <div class="feature">
         <h4>Securing Website Connections</h4>
         <p>Firefox keeps attackers from intercepting your sensitive data by automatically establishing secure connections to websites that offer secure https servers.</p>
-        {{ platform_img('img/firefox/features/screen-updates.png', alt='Automated Updates Bookmarking screenshot') }}
+        {{ platform_img('img/firefox/features/screen-updates.png', {'alt': 'Automated Updates Bookmarking screenshot'}) }}
       </div>
 
       <div class="feature">
@@ -516,7 +515,7 @@
     <h3>Powerful <span>Personalization</span></h3>
 
     <div class="addons-manager feature">
-      {{ platform_img('img/firefox/features/screen-addons.png', alt='Add-ons Manager screenshot') }}
+      {{ platform_img('img/firefox/features/screen-addons.png', {'alt': 'Add-ons Manager screenshot'}) }}
 
       <h4>Add-ons Manager</h4>
       <p>The Add-ons Manager has been redesigned to let you discover and install add-ons without ever leaving Firefox. Browse ratings, recommendations, descriptions and pictures of the add-ons in action to help you make your selection. Your Add-ons Manager even lets you view, manage and disable third-party plugins in a few easy clicks, checking and auto-updating any of your installed add-ons  every time you open the Manager pane. <a href="https://support.mozilla.org/kb/Customizing+Firefox+with+add-ons">Learn how to customize Firefox with add-ons.</a></p>
@@ -526,7 +525,7 @@
       <div class="feature">
         <h4>Dress Up Your Firefox with Themes</h4>
         <p>Change the look of your Firefox to practically anything with Themes: thousands of easy-to-install themes created by users from around the world (or that you make yourself!). With a single click, you can dress your browser up in simple designs, colorful patterns, and content from partners like Harry Potter and Bob Marley.</p>
-        {{ platform_img('img/firefox/features/screen-personas.png', alt='Theme screenshot') }}
+        {{ platform_img('img/firefox/features/screen-personas.png', {'alt': 'Theme screenshot'}) }}
       </div>
     </div>
 

--- a/bedrock/firefox/templates/firefox/firstrun/a.html
+++ b/bedrock/firefox/templates/firefox/firstrun/a.html
@@ -72,7 +72,7 @@
     </div>
 
     <div class="screenshot">
-      {{ platform_img('img/firefox/firstrun/themes.jpg', alt=_('Themes')) }}
+      {{ platform_img('img/firefox/firstrun/themes.jpg', {'alt': _('Themes')}) }}
     </div>
   </article>
 
@@ -93,7 +93,7 @@
     </div>
 
     <div class="screenshot">
-      {{ platform_img('img/firefox/firstrun/awesomebar.jpg', alt=_('Awesome Bar')) }}
+      {{ platform_img('img/firefox/firstrun/awesomebar.jpg', {'alt': _('Awesome Bar')}) }}
     </div>
   </article>
 
@@ -119,7 +119,7 @@
     </div>
 
     <div class="screenshot" id="pinnedtabs-screenshot">
-      {{ platform_img('img/firefox/firstrun/pinnedtabs.jpg', alt=_('Pinned tabs')) }}
+      {{ platform_img('img/firefox/firstrun/pinnedtabs.jpg', {'alt': _('Pinned tabs')}) }}
     </div>
   </article>
 

--- a/bedrock/firefox/templates/firefox/firstrun/b.html
+++ b/bedrock/firefox/templates/firefox/firstrun/b.html
@@ -71,7 +71,7 @@
       </div>
 
       <div class="screenshot">
-        {{ platform_img('img/firefox/firstrun/b/pinnedtabs.jpg', alt=_('Bookmarks')) }}
+        {{ platform_img('img/firefox/firstrun/b/pinnedtabs.jpg', {'alt': _('Bookmarks')}) }}
       </div>
     </aside>
 
@@ -90,7 +90,7 @@
       </div>
 
       <div class="screenshot">
-        {{ platform_img('img/firefox/firstrun/b/themes.jpg', alt=('Themes')) }}
+        {{ platform_img('img/firefox/firstrun/b/themes.jpg', {'alt': ('Themes')}) }}
       </div>
     </aside>
 
@@ -109,7 +109,7 @@
       </div>
 
       <div class="screenshot">
-        {{ platform_img('img/firefox/firstrun/b/awesomebar.jpg', alt=('Awesome Bar')) }}
+        {{ platform_img('img/firefox/firstrun/b/awesomebar.jpg', {'alt': ('Awesome Bar')}) }}
       </div>  
     </aside>
   </div>

--- a/bedrock/firefox/templates/firefox/fx.html
+++ b/bedrock/firefox/templates/firefox/fx.html
@@ -104,7 +104,7 @@
         </hgroup>
         {{ download_firefox() }}
         <figure id="firefox-screenshot">
-          {{ platform_img('img/firefox/fx/existing-screen.jpg?2013-06', alt='Firefox screenshot') }}
+          {{ platform_img('img/firefox/fx/existing-screen.jpg?2013-06', {'alt': 'Firefox screenshot'}) }}
         </figure>
         <ul class="sub-features">
           <li id="features">

--- a/bedrock/firefox/templates/firefox/new.html
+++ b/bedrock/firefox/templates/firefox/new.html
@@ -44,7 +44,7 @@
         </div>
 
         <div class="desktop" id="firefox-screenshot">
-          {{ platform_img('img/firefox/new/browser.png?2013-06', alt=_('Firefox screenshot')) }}
+          {{ platform_img('img/firefox/new/browser.png?2013-06', {'alt': _('Firefox screenshot'), 'data-additional-platforms': 'android ios'}) }}
         </div>
       </div> <!-- /#scene1 -->
 

--- a/bedrock/firefox/templates/firefox/security.html
+++ b/bedrock/firefox/templates/firefox/security.html
@@ -36,7 +36,7 @@
     <p class="top-link"><a href="#main-feature">Return to Top</a></p>
   </div>
   <div class="section-image span4">
-     {{ platform_img('img/firefox/security/screenshot-privacy.jpg', alt='Private Browsing screenshot') }}
+     {{ platform_img('img/firefox/security/screenshot-privacy.jpg', {'alt': 'Private Browsing screenshot'}) }}
   </div>
   <ul class="section-list span3">
     <li>
@@ -71,7 +71,7 @@
     <p class="top-link"><a href="#main-feature">Return to Top</a></p>
   </div>
   <div class="section-image span4">
-     {{ platform_img('img/firefox/security/screenshot-anti-malware.jpg', alt='Anti-Malware screenshot') }}
+     {{ platform_img('img/firefox/security/screenshot-anti-malware.jpg', {'alt': 'Anti-Malware screenshot'}) }}
   </div>
   <ul class="section-list span3">
     <li>
@@ -102,7 +102,7 @@
     <p class="top-link"><a href="#main-feature">Return to Top</a></p>
   </div>
   <div class="section-image span4">
-     {{ platform_img('img/firefox/security/screenshot-plugins.jpg', alt='Plugins screenshot') }}
+     {{ platform_img('img/firefox/security/screenshot-plugins.jpg', {'alt': 'Plugins screenshot'}) }}
   </div>
   <ul class="section-list span3">
     <li>

--- a/bedrock/mozorg/helpers/misc.py
+++ b/bedrock/mozorg/helpers/misc.py
@@ -113,9 +113,9 @@ def field_with_attrs(bfield, **kwargs):
 
 
 @jingo.register.function
-def platform_img(url, **kwargs):
+def platform_img(url, optional_attributes={}):
     attrs = ' '.join(('%s="%s"' % (attr, val)
-                      for attr, val in kwargs.items()))
+                      for attr, val in optional_attributes.items()))
     url = path.join(settings.MEDIA_URL, url.lstrip('/'))
 
     # Don't download any image until the javascript sets it based on


### PR DESCRIPTION
...instead of **kwargs. This allows naming the keys however we want instead of having to name them as valid python vars. Useful when the attribute has a dash in it. Update all current uses of platform_img to work with the new attribute type.
