### PR TITLE
Bug 892470 - enable plugincheck for pt-PT, rm, tr

### DIFF
--- a/etc/httpd/global.conf
+++ b/etc/httpd/global.conf
@@ -71,7 +71,7 @@ RewriteRule ^/ports(.*)$ http://www-archive.mozilla.org/ports$1 [L,R=301]
 ## Redirect things to django!
 
 # bug 797192, 892470
-RewriteRule ^/(en-US|ast|cs|csb|da|de|el|eo|es-AR|es-CL|es-ES|et|eu|fr|hu|hy-AM|is|it|ja|ko|lv|mk|mr|nl|pl|pt-BR|ru|sk|sl|sq|sr|sv-SE|uk|zh-TW)/plugincheck(/?)$ /b/$1/plugincheck$2 [PT]
+RewriteRule ^/(en-US|ast|cs|csb|da|de|el|eo|es-AR|es-CL|es-ES|et|eu|fr|hu|hy-AM|is|it|ja|ko|lv|mk|mr|nl|pl|pt-PT|pt-BR|rm|ru|sk|sl|sq|sr|sv-SE|tr|uk|zh-TW)/plugincheck(/?)$ /b/$1/plugincheck$2 [PT]
 
 # bug 835506
 RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?facebookapps/(.*)?$ /b/$1facebookapps/$2 [PT]


### PR DESCRIPTION
Note: don't close the bug when merged, it's used to track activations for all locales.
