### PR TITLE
Bug 894246: Cache-bust Open Sans fonts for IE

### DIFF
--- a/media/css/mozorg/home-promo.less
+++ b/media/css/mozorg/home-promo.less
@@ -4,11 +4,9 @@
 
 @font-face {
     font-family: 'Open Sans ExtraBoldItalic';
-    src: url('/media/fonts/OpenSans-ExtraBoldItalic-webfont.eot');
     src: url('/media/fonts/OpenSans-ExtraBoldItalic-webfont.eot?#iefix') format('embedded-opentype'),
          url('/media/fonts/OpenSans-ExtraBoldItalic-webfont.woff') format('woff'),
-         url('/media/fonts/OpenSans-ExtraBoldItalic-webfont.ttf') format('truetype'),
-         url('/media/fonts/OpenSans-ExtraBoldItalic-webfont.svg#OpenSansExtraBoldItalic') format('svg');
+         url('/media/fonts/OpenSans-ExtraBoldItalic-webfont.ttf') format('truetype');
     font-weight: normal;
     font-style: normal;
 }
@@ -18,22 +16,18 @@
 
 @font-face {
     font-family: 'VollkornRegular';
-    src: url('/media/fonts/Vollkorn-Regular-webfont.eot');
     src: url('/media/fonts/Vollkorn-Regular-webfont.eot?#iefix') format('embedded-opentype'),
          url('/media/fonts/Vollkorn-Regular-webfont.woff') format('woff'),
-         url('/media/fonts/Vollkorn-Regular-webfont.ttf') format('truetype'),
-         url('/media/fonts/Vollkorn-Regular-webfont.svg#OpenSansLight') format('svg');
+         url('/media/fonts/Vollkorn-Regular-webfont.ttf') format('truetype');
     font-weight: normal;
     font-style: normal;
 }
 
 @font-face {
     font-family: 'VollkornBold';
-    src: url('/media/fonts/Vollkorn-Bold-webfont.eot');
     src: url('/media/fonts/Vollkorn-Bold-webfont.eot?#iefix') format('embedded-opentype'),
          url('/media/fonts/Vollkorn-Bold-webfont.woff') format('woff'),
-         url('/media/fonts/Vollkorn-Bold-webfont.ttf') format('truetype'),
-         url('/media/fonts/Vollkorn-Bold-webfont.svg#OpenSansLight') format('svg');
+         url('/media/fonts/Vollkorn-Bold-webfont.ttf') format('truetype');
     font-weight: normal;
     font-style: normal;
 }

--- a/media/css/sandstone/fonts.less
+++ b/media/css/sandstone/fonts.less
@@ -4,66 +4,54 @@
 
 @font-face {
     font-family: 'Open Sans Light';
-    src: url('/media/fonts/OpenSans-Light-webfont.eot');
-    src: url('/media/fonts/OpenSans-Light-webfont.eot?#iefix') format('embedded-opentype'),
-         url('/media/fonts/OpenSans-Light-webfont.woff') format('woff'),
-         url('/media/fonts/OpenSans-Light-webfont.ttf') format('truetype'),
-         url('/media/fonts/OpenSans-Light-webfont.svg#OpenSansLight') format('svg');
+    src: url('/media/fonts/OpenSans-Light-webfont.eot?#iefix2013') format('embedded-opentype'),
+         url('/media/fonts/OpenSans-Light-webfont.woff?2013') format('woff'),
+         url('/media/fonts/OpenSans-Light-webfont.ttf?2013') format('truetype');
     font-weight: normal;
     font-style: normal;
 }
 
 @font-face {
     font-family: 'Open Sans Light';
-    src: url('/media/fonts/OpenSans-LightItalic-webfont.eot');
-    src: url('/media/fonts/OpenSans-LightItalic-webfont.eot?#iefix') format('embedded-opentype'),
-         url('/media/fonts/OpenSans-LightItalic-webfont.woff') format('woff'),
-         url('/media/fonts/OpenSans-LightItalic-webfont.ttf') format('truetype'),
-         url('/media/fonts/OpenSans-LightItalic-webfont.svg#OpenSansRegular') format('svg');
+    src: url('/media/fonts/OpenSans-Semibold-webfont.eot?#iefix2013') format('embedded-opentype'),
+         url('/media/fonts/OpenSans-Semibold-webfont.woff?2013') format('woff'),
+         url('/media/fonts/OpenSans-Semibold-webfont.ttf?2013') format('truetype');
+    font-weight: bold;
+    font-style: normal;
+}
+
+@font-face {
+    font-family: 'Open Sans Light';
+    src: url('/media/fonts/OpenSans-LightItalic-webfont.eot?#iefix2013') format('embedded-opentype'),
+         url('/media/fonts/OpenSans-LightItalic-webfont.woff?2013') format('woff'),
+         url('/media/fonts/OpenSans-LightItalic-webfont.ttf?2013') format('truetype');
     font-weight: normal;
     font-style: italic;
 }
 
 @font-face {
     font-family: 'Open Sans';
-    src: url('/media/fonts/OpenSans-Regular-webfont.eot');
-    src: url('/media/fonts/OpenSans-Regular-webfont.eot?#iefix') format('embedded-opentype'),
-         url('/media/fonts/OpenSans-Regular-webfont.woff') format('woff'),
-         url('/media/fonts/OpenSans-Regular-webfont.ttf') format('truetype'),
-         url('/media/fonts/OpenSans-Regular-webfont.svg#OpenSansRegular') format('svg');
+    src: url('/media/fonts/OpenSans-Regular-webfont.eot?#iefix2013') format('embedded-opentype'),
+         url('/media/fonts/OpenSans-Regular-webfont.woff?2013') format('woff'),
+         url('/media/fonts/OpenSans-Regular-webfont.ttf?2013') format('truetype');
     font-weight: normal;
     font-style: normal;
 }
 
 @font-face {
-    font-family: 'Open Sans Light';
-    src: url('/media/fonts/OpenSans-Semibold-webfont.eot');
-    src: url('/media/fonts/OpenSans-Semibold-webfont.eot?#iefix') format('embedded-opentype'),
-         url('/media/fonts/OpenSans-Semibold-webfont.woff') format('woff'),
-         url('/media/fonts/OpenSans-Semibold-webfont.ttf') format('truetype'),
-         url('/media/fonts/OpenSans-Semibold-webfont.svg#OpenSansSemibold') format('svg');
+    font-family: 'Open Sans';
+    src: url('/media/fonts/OpenSans-Bold-webfont.eot?#iefix2013') format('embedded-opentype'),
+         url('/media/fonts/OpenSans-Bold-webfont.woff?2013') format('woff'),
+         url('/media/fonts/OpenSans-Bold-webfont.ttf?2013') format('truetype');
     font-weight: bold;
     font-style: normal;
 }
 
 @font-face {
     font-family: 'Open Sans';
-    src: url('/media/fonts/OpenSans-Bold-webfont.eot');
-    src: url('/media/fonts/OpenSans-Bold-webfont.eot?#iefix') format('embedded-opentype'),
-         url('/media/fonts/OpenSans-Bold-webfont.woff') format('woff'),
-         url('/media/fonts/OpenSans-Bold-webfont.ttf') format('truetype'),
-         url('/media/fonts/OpenSans-Bold-webfont.svg#OpenSansBold') format('svg');
-    font-weight: bold;
-    font-style: normal;
-}
-
-@font-face {
-    font-family: 'Open Sans';
-    src: url('/media/fonts/OpenSans-Italic-webfont.eot');
-    src: url('/media/fonts/OpenSans-Italic-webfont.eot?#iefix') format('embedded-opentype'),
-         url('/media/fonts/OpenSans-Italic-webfont.woff') format('woff'),
-         url('/media/fonts/OpenSans-Italic-webfont.ttf') format('truetype'),
-         url('/media/fonts/OpenSans-Italic-webfont.svg#OpenSansItalic') format('svg');
+    src: url('/media/fonts/OpenSans-Italic-webfont.eot?#iefix2013') format('embedded-opentype'),
+         url('/media/fonts/OpenSans-Italic-webfont.woff?2013') format('woff'),
+         url('/media/fonts/OpenSans-Italic-webfont.ttf?2013') format('truetype');
     font-weight: normal;
     font-style: italic;
 }

--- a/media/css/tabzilla/tabzilla.less
+++ b/media/css/tabzilla/tabzilla.less
@@ -7,8 +7,8 @@
 // Open Sans Extra Bold Italic for Firefox OS promo
 @font-face {
     font-family: 'Open Sans ExtraBoldItalic';
-    src: url('/media/fonts/OpenSans-ExtraBoldItalic-webfont.eot');
-    src: url('/media/fonts/OpenSans-ExtraBoldItalic-webfont.eot?#iefix') format('embedded-opentype'),
+    src: url('/media/fonts/OpenSans-ExtraBoldItalic-webfont.eot?#2013');
+    src: url('/media/fonts/OpenSans-ExtraBoldItalic-webfont.eot?#iefix-2013') format('embedded-opentype'),
          url('/media/fonts/OpenSans-ExtraBoldItalic-webfont.woff') format('woff'),
          url('/media/fonts/OpenSans-ExtraBoldItalic-webfont.ttf') format('truetype'),
          url('/media/fonts/OpenSans-ExtraBoldItalic-webfont.svg#OpenSansExtraBoldItalic') format('svg');
@@ -17,35 +17,29 @@
 }
 
 @font-face {
-    font-family: 'Open Sans';
-    src: url('/media/fonts/OpenSans-Regular-webfont.eot');
-    src: url('/media/fonts/OpenSans-Regular-webfont.eot?#iefix') format('embedded-opentype'),
-         url('/media/fonts/OpenSans-Regular-webfont.woff') format('woff'),
-         url('/media/fonts/OpenSans-Regular-webfont.ttf') format('truetype'),
-         url('/media/fonts/OpenSans-Regular-webfont.svg#OpenSansRegular') format('svg');
-    font-weight: normal;
-    font-style: normal;
-}
-
-@font-face {
-    font-family: 'Open Sans';
-    src: url('/media/fonts/OpenSans-Semibold-webfont.eot');
-    src: url('/media/fonts/OpenSans-Semibold-webfont.eot?#iefix') format('embedded-opentype'),
-         url('/media/fonts/OpenSans-Semibold-webfont.woff') format('woff'),
-         url('/media/fonts/OpenSans-Semibold-webfont.ttf') format('truetype'),
-         url('/media/fonts/OpenSans-Semibold-webfont.svg#OpenSansSemibold') format('svg');
-    font-weight: bold;
-    font-style: normal;
-}
-
-@font-face {
     font-family: 'Open Sans Light';
-    src: url('/media/fonts/OpenSans-Light-webfont.eot');
-    src: url('/media/fonts/OpenSans-Light-webfont.eot?#iefix') format('embedded-opentype'),
-         url('/media/fonts/OpenSans-Light-webfont.woff') format('woff'),
-         url('/media/fonts/OpenSans-Light-webfont.ttf') format('truetype'),
-         url('/media/fonts/OpenSans-Light-webfont.svg#OpenSansLight') format('svg');
+    src: url('/media/fonts/OpenSans-Light-webfont.eot?#iefix2013') format('embedded-opentype'),
+         url('/media/fonts/OpenSans-Light-webfont.woff?2013') format('woff'),
+         url('/media/fonts/OpenSans-Light-webfont.ttf?2013') format('truetype');
     font-weight: normal;
+    font-style: normal;
+}
+
+@font-face {
+    font-family: 'Open Sans';
+    src: url('/media/fonts/OpenSans-Regular-webfont.eot?#iefix2013') format('embedded-opentype'),
+         url('/media/fonts/OpenSans-Regular-webfont.woff?2013') format('woff'),
+         url('/media/fonts/OpenSans-Regular-webfont.ttf?2013') format('truetype');
+    font-weight: normal;
+    font-style: normal;
+}
+
+@font-face {
+    font-family: 'Open Sans';
+    src: url('/media/fonts/OpenSans-Bold-webfont.eot?#iefix2013') format('embedded-opentype'),
+         url('/media/fonts/OpenSans-Bold-webfont.woff?2013') format('woff'),
+         url('/media/fonts/OpenSans-Bold-webfont.ttf?2013') format('truetype');
+    font-weight: bold;
     font-style: normal;
 }
 


### PR DESCRIPTION
- Cache-bust Open Sans fonts
- drop SVN include
- drop extra .eot
  These changes are based on http://www.fontspring.com/blog/the-new-bulletproof-font-face-syntax
