### PR TITLE
Enable /plugincheck and /new for nb-NO

### DIFF
--- a/etc/httpd/global.conf
+++ b/etc/httpd/global.conf
@@ -68,7 +68,7 @@ RewriteRule ^/ports(.*)$ http://www-archive.mozilla.org/ports$1 [L,R=301]
 ## Redirect things to django!
 
 # bug 797192, 892470
-RewriteRule ^/(en-US|ast|cs|csb|da|de|el|eo|es-AR|es-CL|es-ES|et|eu|fr|hu|hy-AM|is|it|ja|ko|lv|mk|mr|nl|pl|pt-PT|pt-BR|rm|ru|sk|sl|sq|sr|sv-SE|tr|uk|zh-TW)/plugincheck(/?)$ /b/$1/plugincheck$2 [PT]
+RewriteRule ^/(en-US|ast|cs|csb|da|de|el|eo|es-AR|es-CL|es-ES|et|eu|fr|hu|hy-AM|is|it|ja|ko|lv|mk|mr|nb-NO|nl|pl|pt-PT|pt-BR|rm|ru|sk|sl|sq|sr|sv-SE|tr|uk|zh-TW)/plugincheck(/?)$ /b/$1/plugincheck$2 [PT]
 
 # bug 835506
 RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?facebookapps/(.*)?$ /b/$1facebookapps/$2 [PT]
@@ -151,7 +151,7 @@ RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/update(.*)$ /b/$1firefox/update$2 [P
 
 # bug 881754, 883127
 # TODO: Remove when all locales are done.
-RewriteRule ^/(bg|cs|csb|cy|da|de|el|eo|es-AR|es-CL|es-ES|es-MX|et|eu|fr|fy-NL|ga-IE|gd|hr|hu|hy-AM|id|is|it|ko|lij|lt|lv|ml|mk|mr|my|nl|pl|pt-BR|rm|ro|ru|sl|sk|sq|sr|sv-SE|te|tr|uk|zh-TW)/firefox/new(/?)$ /b/$1/firefox/new$2 [PT]
+RewriteRule ^/(bg|cs|csb|cy|da|de|el|eo|es-AR|es-CL|es-ES|es-MX|et|eu|fr|fy-NL|ga-IE|gd|hr|hu|hy-AM|id|is|it|ko|lij|lt|lv|ml|mk|mr|my|nb-NO|nl|pl|pt-BR|rm|ro|ru|sl|sk|sq|sr|sv-SE|te|tr|uk|zh-TW)/firefox/new(/?)$ /b/$1/firefox/new$2 [PT]
 
 # bug 796952
 RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/unsupported/(.*)$ /b/$1firefox/unsupported/$2 [PT]


### PR DESCRIPTION
Updated rewrite rule to enable plugincheck (bug 892470) and new download page (bug 881754) for nb-NO
