### PR TITLE
Bug 887535 - Improve CSS and strings for l10n on privacy contact form

### DIFF
--- a/bedrock/privacy/templates/privacy/privacy_contact.html
+++ b/bedrock/privacy/templates/privacy/privacy_contact.html
@@ -19,22 +19,22 @@
 
       <div class="field">
         {{ form.name.errors }}
-        <label for="id_name">{{ _('Your name') }}:</label>
+        <label for="id_name">{{ _('Your name:') }}</label>
         {{ form.name }}
       </div>
 
       <div class="field">
         {{ form.sender.errors }}
-        <label for="id_sender">{{ _('Your email') }}:</label>
+        <label for="id_sender">{{ _('Your email:') }}</label>
         {{ form.sender }}
       </div>
 
       <div class="field">
         {{ form.comments.errors }}
-        <label for="id_comments">{{ _('Your comments') }}:</label><br />
+        <label for="id_comments">{{ _('Your comments:') }}</label><br />
         {{ form.comments }}
 
-        <input type="submit" class="button" value="{{ _('Send comments') }}&nbsp;»" id="contact_privacy_submit" />
+        <input type="submit" class="button" value="{{ _('Send comments') }}" id="contact_privacy_submit" />
       </div>
 
       {{ form.superpriority }}

--- a/media/css/privacy/privacy.less
+++ b/media/css/privacy/privacy.less
@@ -237,7 +237,6 @@ table.data-table tbody tr td:first-child {
 .firefoxos {
     h2 {
         margin: 10px 5px;
-        width: 285px;
         font-size: 1.5rem;
     }
     h3 {
@@ -258,9 +257,10 @@ table.data-table tbody tr td:first-child {
 }
 .firefoxos-header {
     background: transparent url("/media/img/home/firefox_small.png?2013-06") 0 3px no-repeat;
-    margin: 20px 0 0 10px;
-    padding-left: 85px;
-    width: 185px;
+    clear: both;
+    min-height: 83px;
+    padding-left: 85px; 
+    margin-left: 10px;     
     font-size: 42px;
 }
 time {
@@ -379,4 +379,12 @@ time {
         }
     }
 
+}
+
+/* Tablet Layout: 760px */
+@media only screen and (max-width: @breakTablet) {
+  .firefoxos-header {
+      background-position: 0 13px;
+      padding-top: 10px;    
+  }
 }


### PR DESCRIPTION
This makes the entire fields' labels localizable in https://www.mozilla.org/en-US/privacy/policies/firefox-os/ (I consider this as part of bug 887535).

Unfortunately this still doesn't solve the problem with placeholders defined in forms.py ('you@yourdomain.com' and ('Enter your comments...'), I tried putting those strings inside a _() but it won't work.

CSS changes:
- Remove width on h2 causing unnecessary wrapping in Contact us and Privacy policy title
- Header: set larger widht to fit longer localizations. Only downside of the larger width is that, at minimum width, the title is larger than the column for Spanish. en-US remains unaltered.
- Header: fix funny behavior between 1000px and 760px (en-US too).
