### PR TITLE
TEMPLATE_DEBUG in jenkins.sh -> override_settings in tests

### DIFF
--- a/bedrock/newsletter/tests/test_views.py
+++ b/bedrock/newsletter/tests/test_views.py
@@ -6,6 +6,7 @@ from bedrock.newsletter.views import unknown_address_text, recovery_text
 
 from django.http import HttpResponse
 from django.test.client import Client
+from django.test.utils import override_settings
 
 from mock import DEFAULT, patch
 from nose.tools import ok_
@@ -482,6 +483,7 @@ class TestRecoveryView(TestCase):
         self.url = reverse('newsletter.recovery')
         self.client = Client()
 
+    @override_settings(TEMPLATE_DEBUG=True)
     def test_bad_email(self):
         """Email syntax errors are caught"""
         data = {'email': 'not_an_email'}
@@ -489,6 +491,7 @@ class TestRecoveryView(TestCase):
         self.assertEqual(200, rsp.status_code)
         self.assertIn('email', rsp.context['form'].errors)
 
+    @override_settings(TEMPLATE_DEBUG=True)
     @patch('basket.send_recovery_message', autospec=True)
     def test_unknown_email(self, mock_basket):
         """Unknown email addresses give helpful error message"""
@@ -502,6 +505,7 @@ class TestRecoveryView(TestCase):
             reverse('newsletter.mozilla-and-you')
         self.assertIn(expected_error, form.errors['email'])
 
+    @override_settings(TEMPLATE_DEBUG=True)
     @patch('django.contrib.messages.add_message', autospec=True)
     @patch('basket.send_recovery_message', autospec=True)
     def test_good_email(self, mock_basket, add_msg):

--- a/bin/jenkins.sh
+++ b/bin/jenkins.sh
@@ -57,11 +57,6 @@ DATABASES = {
 HMAC_KEYS = {
     '2013-01-01': 'prositneujahr',
 }
-
-# TEMPLATE_DEBUG has to be True for jingo to call the template_rendered
-# signal which Django's test client uses to save away the contexts for your
-# test to look at later.
-TEMPLATE_DEBUG = True
 SETTINGS
 
 echo "Update product_details"

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -1,6 +1,6 @@
-# Django 1.4.5 is also in vendor, but needs to be kept here so packages that
+# Django 1.4.6 is also in vendor, but needs to be kept here so packages that
 # depend on Django do not install a newer version
-Django==1.4.5
+Django==1.4.6
 
 # Templates
 -e git://github.com/jbalogh/jingo.git#egg=jingo


### PR DESCRIPTION
I'd like to see this change as:
- I normally run `python manage.py test` manually, not through jenkins
- I didn't figure out the real conflict yet, but something in jingo-minify with `JINGO_MINIFY_USE_STATIC=True` caused many test failures: https://ci.mozilla.org/job/bedrock_github/1804/consoleFull
