### PR TITLE
Localize placeholders in privacy contact form

### DIFF
--- a/bedrock/privacy/forms.py
+++ b/bedrock/privacy/forms.py
@@ -9,6 +9,9 @@ from bedrock.mozorg.forms import HoneyPotWidget
 from lib.l10n_utils.dotlang import _lazy as _
 
 
+LANG_FILES = 'privacy/ffos_privacy'
+
+
 class EmailInput(widgets.TextInput):
     input_type = 'email'
 
@@ -31,7 +34,7 @@ class PrivacyContactForm(forms.Form):
         widget=EmailInput(
             attrs={
                 'required': 'required',
-                'placeholder': 'you@yourdomain.com'
+                'placeholder': _('you@yourdomain.com')
             }))
     comments = forms.CharField(
         required=True,
@@ -41,7 +44,7 @@ class PrivacyContactForm(forms.Form):
         widget=forms.Textarea(
             attrs={
                 'required': 'required',
-                'placeholder': 'Enter your comments...',
+                'placeholder': _('Enter your comments...'),
                 'rows': '10',
                 'cols': '77'
             }))


### PR DESCRIPTION
@pmclanahan as explained in issue #1205, this doesn't seem to work (at least locally on my machine). If you check es-ES has both strings already localized, but they're displayed in English.

I can't verify the other messages because I can't see them (I get a generic error when compiling the form on Safari).

Let me know if you want me to open a new bug on Bugzilla for this too.
