### PR TITLE
Fix issue with undefined translations variable.

### DIFF
--- a/bedrock/base/templates/includes/head-meta.html
+++ b/bedrock/base/templates/includes/head-meta.html
@@ -1,5 +1,7 @@
     <link rel="canonical" hreflang="{{ LANG }}" href="{{ settings.CANONICAL_URL + '/' + LANG + canonical_path }}">
     <link rel="alternate" hreflang="x-default" href="{{ canonical_path }}">
-    {% for code, label in translations|dictsort -%}
-    <link rel="alternate" hreflang="{{ code }}" href="{{ '/' + code + canonical_path }}" title="{{ label|safe }}">
-    {% endfor -%}
+    {% if translations %}
+      {% for code, label in translations|dictsort -%}
+      <link rel="alternate" hreflang="{{ code }}" href="{{ '/' + code + canonical_path }}" title="{{ label|safe }}">
+      {% endfor -%}
+    {% endif %}


### PR DESCRIPTION
If the view doesn't use RequestContext the `translations` variable won't
exist, and the `dictsort` filter will raise and exception.
