### PR TITLE
adding deploy scripts from current chief bedrock environments.

### DIFF
--- a/bin/update/deploy-demo1.py
+++ b/bin/update/deploy-demo1.py
@@ -1,0 +1,122 @@
+"""
+Deployment for Bedrock in production.
+
+Requires commander (https://github.com/oremj/commander) which is installed on
+the systems that need it.
+"""
+
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.abspath(__file__)))
+
+from commander.deploy import task, hostgroups
+
+import commander_settings as settings
+
+
+@task
+def update_code(ctx, tag):
+    with ctx.lcd(settings.SRC_DIR):
+        ctx.local("git fetch")
+        ctx.local("git checkout -f %s" % tag)
+        ctx.local("git submodule sync")
+        ctx.local("git submodule update --init --recursive")
+
+
+@task
+def update_locales(ctx):
+    with ctx.lcd(os.path.join(settings.SRC_DIR, 'locale')):
+        ctx.local("svn up")
+#        ctx.local("./compile-mo.sh .")
+
+
+@task
+def update_assets(ctx):
+    with ctx.lcd(settings.SRC_DIR):
+        ctx.local("LANG=en_US.UTF-8 python2.6 manage.py collectstatic --noinput")
+        ctx.local("LANG=en_US.UTF-8 python2.6 manage.py compress_assets")
+        ctx.local("LANG=en_US.UTF-8 python2.6 manage.py update_product_details")
+
+
+# bedrock has no database
+#@task
+#def database(ctx):
+#    with ctx.lcd(settings.SRC_DIR):
+#        ctx.local("python2.6 ./vendor/src/schematic/schematic migrations")  # schematic (old)
+#        ctx.local("python2.6 manage.py migrate")                            # South (new)
+
+
+#@task
+#def install_cron(ctx):
+#    with ctx.lcd(settings.SRC_DIR):
+#        ctx.local("python2.6 ./scripts/crontab/gen-crons.py -k %s -u apache > /etc/cron.d/.%s" %
+#                  (settings.WWW_DIR, settings.CRON_NAME))
+#        ctx.local("mv /etc/cron.d/.%s /etc/cron.d/%s" % (settings.CRON_NAME, settings.CRON_NAME))
+
+
+@task
+def checkin_changes(ctx):
+    ctx.local(settings.DEPLOY_SCRIPT)
+
+
+@hostgroups(settings.WEB_HOSTGROUP, remote_kwargs={'ssh_key': settings.SSH_KEY})
+def deploy_app(ctx):
+    ctx.remote(settings.REMOTE_UPDATE_SCRIPT)
+    ctx.remote("service httpd graceful")
+
+@hostgroups(settings.WEB_HOSTGROUP, remote_kwargs={'ssh_key': settings.SSH_KEY})
+def prime_app(ctx):
+    for http_port in range(80, 82):
+        ctx.remote("for i in {1..10}; do curl -so /dev/null -H 'Host: %s' -I http://localhost:%s/ & sleep 1; done" % (settings.REMOTE_HOSTNAME, http_port))
+
+#@hostgroups(settings.CELERY_HOSTGROUP, remote_kwargs={'ssh_key': settings.SSH_KEY})
+#def update_celery(ctx):
+#    ctx.remote(settings.REMOTE_UPDATE_SCRIPT)
+#    ctx.remote('/sbin/service %s restart' % settings.CELERY_SERVICE)
+
+
+@task
+def update_info(ctx):
+    with ctx.lcd(settings.SRC_DIR):
+        ctx.local("date")
+        ctx.local("git branch")
+        ctx.local("git log -3")
+        ctx.local("git status")
+        ctx.local("git submodule status")
+        #ctx.local("python ./vendor/src/schematic/schematic -v migrations/")
+        #ctx.local("python ./manage.py migrate --list")
+        with ctx.lcd("locale"):
+            ctx.local("svn info")
+            ctx.local("svn status")
+
+        ctx.local("git rev-parse HEAD > media/revision.txt")
+
+
+@task
+def pre_update(ctx, ref=settings.UPDATE_REF):
+    update_code(ref)
+    update_info()
+
+
+@task
+def update(ctx):
+    update_assets()
+    update_locales()
+    #database()
+
+
+@task
+def deploy(ctx):
+#    install_cron()
+    checkin_changes()
+    deploy_app()
+#    prime_app()
+#    update_celery()
+
+
+@task
+def update_bedrock(ctx, tag):
+    """Do typical bedrock update"""
+    pre_update(tag)
+    update()

--- a/bin/update/deploy-demo2.py
+++ b/bin/update/deploy-demo2.py
@@ -1,0 +1,122 @@
+"""
+Deployment for Bedrock in production.
+
+Requires commander (https://github.com/oremj/commander) which is installed on
+the systems that need it.
+"""
+
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.abspath(__file__)))
+
+from commander.deploy import task, hostgroups
+
+import commander_settings as settings
+
+
+@task
+def update_code(ctx, tag):
+    with ctx.lcd(settings.SRC_DIR):
+        ctx.local("git fetch")
+        ctx.local("git fetch private")
+        ctx.local("git checkout -f %s" % tag)
+        ctx.local("git submodule sync")
+        ctx.local("git submodule update --init --recursive")
+
+
+@task
+def update_locales(ctx):
+    with ctx.lcd(os.path.join(settings.SRC_DIR, 'locale')):
+        ctx.local("svn up")
+#        ctx.local("./compile-mo.sh .")
+
+
+@task
+def update_assets(ctx):
+    with ctx.lcd(settings.SRC_DIR):
+        ctx.local("LANG=en_US.UTF-8 python2.6 manage.py compress_assets")
+        ctx.local("LANG=en_US.UTF-8 python2.6 manage.py update_product_details")
+
+
+# bedrock has no database
+#@task
+#def database(ctx):
+#    with ctx.lcd(settings.SRC_DIR):
+#        ctx.local("python2.6 ./vendor/src/schematic/schematic migrations")  # schematic (old)
+#        ctx.local("python2.6 manage.py migrate")                            # South (new)
+
+
+#@task
+#def install_cron(ctx):
+#    with ctx.lcd(settings.SRC_DIR):
+#        ctx.local("python2.6 ./scripts/crontab/gen-crons.py -k %s -u apache > /etc/cron.d/.%s" %
+#                  (settings.WWW_DIR, settings.CRON_NAME))
+#        ctx.local("mv /etc/cron.d/.%s /etc/cron.d/%s" % (settings.CRON_NAME, settings.CRON_NAME))
+
+
+@task
+def checkin_changes(ctx):
+    ctx.local(settings.DEPLOY_SCRIPT)
+
+
+@hostgroups(settings.WEB_HOSTGROUP, remote_kwargs={'ssh_key': settings.SSH_KEY})
+def deploy_app(ctx):
+    ctx.remote(settings.REMOTE_UPDATE_SCRIPT)
+    ctx.remote("service httpd graceful")
+
+@hostgroups(settings.WEB_HOSTGROUP, remote_kwargs={'ssh_key': settings.SSH_KEY})
+def prime_app(ctx):
+    for http_port in range(80, 82):
+        ctx.remote("for i in {1..10}; do curl -so /dev/null -H 'Host: %s' -I http://localhost:%s/ & sleep 1; done" % (settings.REMOTE_HOSTNAME, http_port))
+
+#@hostgroups(settings.CELERY_HOSTGROUP, remote_kwargs={'ssh_key': settings.SSH_KEY})
+#def update_celery(ctx):
+#    ctx.remote(settings.REMOTE_UPDATE_SCRIPT)
+#    ctx.remote('/sbin/service %s restart' % settings.CELERY_SERVICE)
+
+
+@task
+def update_info(ctx):
+    with ctx.lcd(settings.SRC_DIR):
+        ctx.local("date")
+        ctx.local("git branch")
+        ctx.local("git log -3")
+        ctx.local("git status")
+        ctx.local("git submodule status")
+        #ctx.local("python ./vendor/src/schematic/schematic -v migrations/")
+        #ctx.local("python ./manage.py migrate --list")
+        with ctx.lcd("locale"):
+            ctx.local("svn info")
+            ctx.local("svn status")
+
+        ctx.local("git rev-parse HEAD > media/revision.txt")
+
+
+@task
+def pre_update(ctx, ref=settings.UPDATE_REF):
+    update_code(ref)
+    update_info()
+
+
+@task
+def update(ctx):
+    update_assets()
+    update_locales()
+    #database()
+
+
+@task
+def deploy(ctx):
+#    install_cron()
+    checkin_changes()
+    deploy_app()
+#    prime_app()
+#    update_celery()
+
+
+@task
+def update_bedrock(ctx, tag):
+    """Do typical bedrock update"""
+    pre_update(tag)
+    update()

--- a/bin/update/deploy-demo3.py
+++ b/bin/update/deploy-demo3.py
@@ -1,0 +1,119 @@
+"""
+Deployment for Bedrock in production.
+
+Requires commander (https://github.com/oremj/commander) which is installed on
+the systems that need it.
+"""
+
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.abspath(__file__)))
+
+from commander.deploy import task, hostgroups
+
+import commander_settings as settings
+
+
+@task
+def update_code(ctx, tag):
+    with ctx.lcd(settings.SRC_DIR):
+        ctx.local("git fetch")
+        ctx.local("git checkout -f %s" % tag)
+        ctx.local("git submodule sync")
+        ctx.local("git submodule update --init --recursive")
+
+
+@task
+def update_locales(ctx):
+    with ctx.lcd(os.path.join(settings.SRC_DIR, 'locale')):
+        ctx.local("svn up")
+#        ctx.local("./compile-mo.sh .")
+
+
+@task
+def update_assets(ctx):
+    with ctx.lcd(settings.SRC_DIR):
+        ctx.local("LANG=en_US.UTF-8 python2.6 manage.py compress_assets")
+        ctx.local("LANG=en_US.UTF-8 python2.6 manage.py update_product_details")
+
+
+@task
+def database(ctx):
+    with ctx.lcd(settings.SRC_DIR):
+        ctx.local("python2.6 manage.py syncdb --noinput --migrate")
+
+
+#@task
+#def install_cron(ctx):
+#    with ctx.lcd(settings.SRC_DIR):
+#        ctx.local("python2.6 ./scripts/crontab/gen-crons.py -k %s -u apache > /etc/cron.d/.%s" %
+#                  (settings.WWW_DIR, settings.CRON_NAME))
+#        ctx.local("mv /etc/cron.d/.%s /etc/cron.d/%s" % (settings.CRON_NAME, settings.CRON_NAME))
+
+
+@task
+def checkin_changes(ctx):
+    ctx.local(settings.DEPLOY_SCRIPT)
+
+
+@hostgroups(settings.WEB_HOSTGROUP, remote_kwargs={'ssh_key': settings.SSH_KEY})
+def deploy_app(ctx):
+    ctx.remote(settings.REMOTE_UPDATE_SCRIPT)
+    ctx.remote("service httpd graceful")
+
+@hostgroups(settings.WEB_HOSTGROUP, remote_kwargs={'ssh_key': settings.SSH_KEY})
+def prime_app(ctx):
+    for http_port in range(80, 82):
+        ctx.remote("for i in {1..10}; do curl -so /dev/null -H 'Host: %s' -I http://localhost:%s/ & sleep 1; done" % (settings.REMOTE_HOSTNAME, http_port))
+
+#@hostgroups(settings.CELERY_HOSTGROUP, remote_kwargs={'ssh_key': settings.SSH_KEY})
+#def update_celery(ctx):
+#    ctx.remote(settings.REMOTE_UPDATE_SCRIPT)
+#    ctx.remote('/sbin/service %s restart' % settings.CELERY_SERVICE)
+
+
+@task
+def update_info(ctx):
+    with ctx.lcd(settings.SRC_DIR):
+        ctx.local("date")
+        ctx.local("git branch")
+        ctx.local("git log -3")
+        ctx.local("git status")
+        ctx.local("git submodule status")
+        #ctx.local("python ./vendor/src/schematic/schematic -v migrations/")
+        #ctx.local("python ./manage.py migrate --list")
+        with ctx.lcd("locale"):
+            ctx.local("svn info")
+            ctx.local("svn status")
+
+        ctx.local("git rev-parse HEAD > media/revision.txt")
+
+
+@task
+def pre_update(ctx, ref=settings.UPDATE_REF):
+    update_code(ref)
+    update_info()
+
+
+@task
+def update(ctx):
+    update_assets()
+    update_locales()
+    database()
+
+
+@task
+def deploy(ctx):
+#    install_cron()
+    checkin_changes()
+    deploy_app()
+#    prime_app()
+#    update_celery()
+
+
+@task
+def update_bedrock(ctx, tag):
+    """Do typical bedrock update"""
+    pre_update(tag)
+    update()

--- a/bin/update/deploy-prod.py
+++ b/bin/update/deploy-prod.py
@@ -1,0 +1,122 @@
+"""
+Deployment for Bedrock in production.
+
+Requires commander (https://github.com/oremj/commander) which is installed on
+the systems that need it.
+"""
+
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.abspath(__file__)))
+
+from commander.deploy import task, hostgroups
+
+import commander_settings as settings
+
+
+@task
+def update_code(ctx, tag):
+    with ctx.lcd(settings.SRC_DIR):
+        ctx.local("git fetch")
+        ctx.local("git checkout -f %s" % tag)
+        ctx.local("git submodule sync")
+        ctx.local("git submodule update --init --recursive")
+
+
+@task
+def update_locales(ctx):
+    with ctx.lcd(os.path.join(settings.SRC_DIR, 'locale')):
+        ctx.local("svn up")
+#        ctx.local("./compile-mo.sh .")
+
+
+@task
+def update_assets(ctx):
+    with ctx.lcd(settings.SRC_DIR):
+        ctx.local("LANG=en_US.UTF-8 python2.6 manage.py compress_assets")
+        ctx.local("LANG=en_US.UTF-8 python2.6 manage.py update_product_details")
+
+
+# bedrock has no database
+#@task
+#def database(ctx):
+#    with ctx.lcd(settings.SRC_DIR):
+#        ctx.local("python2.6 ./vendor/src/schematic/schematic migrations")  # schematic (old)
+#        ctx.local("python2.6 manage.py migrate")                            # South (new)
+
+
+#@task
+#def install_cron(ctx):
+#    with ctx.lcd(settings.SRC_DIR):
+#        ctx.local("python2.6 ./scripts/crontab/gen-crons.py -k %s -u apache > /etc/cron.d/.%s" %
+#                  (settings.WWW_DIR, settings.CRON_NAME))
+#        ctx.local("mv /etc/cron.d/.%s /etc/cron.d/%s" % (settings.CRON_NAME, settings.CRON_NAME))
+
+
+@task
+def checkin_changes(ctx):
+    ctx.local(settings.DEPLOY_SCRIPT)
+
+
+@hostgroups(settings.WEB_HOSTGROUP, remote_kwargs={'ssh_key': settings.SSH_KEY})
+def deploy_app(ctx):
+    ctx.remote(settings.REMOTE_UPDATE_SCRIPT)
+#    ctx.remote("/bin/touch %s" % settings.REMOTE_WSGI)
+    ctx.remote("service httpd graceful")
+
+@hostgroups(settings.WEB_HOSTGROUP, remote_kwargs={'ssh_key': settings.SSH_KEY})
+def prime_app(ctx):
+    for http_port in range(80, 82):
+        ctx.remote("for i in {1..10}; do curl -so /dev/null -H 'Host: %s' -I http://localhost:%s/ & sleep 1; done" % (settings.REMOTE_HOSTNAME, http_port))
+
+#@hostgroups(settings.CELERY_HOSTGROUP, remote_kwargs={'ssh_key': settings.SSH_KEY})
+#def update_celery(ctx):
+#    ctx.remote(settings.REMOTE_UPDATE_SCRIPT)
+#    ctx.remote('/sbin/service %s restart' % settings.CELERY_SERVICE)
+
+
+@task
+def update_info(ctx):
+    with ctx.lcd(settings.SRC_DIR):
+        ctx.local("date")
+        ctx.local("git branch")
+        ctx.local("git log -3")
+        ctx.local("git status")
+        ctx.local("git submodule status")
+        #ctx.local("python ./vendor/src/schematic/schematic -v migrations/")
+        #ctx.local("python ./manage.py migrate --list")
+        with ctx.lcd("locale"):
+            ctx.local("svn info")
+            ctx.local("svn status")
+
+        ctx.local("git rev-parse HEAD > media/revision.txt")
+
+
+@task
+def pre_update(ctx, ref=settings.UPDATE_REF):
+    update_code(ref)
+    update_info()
+
+
+@task
+def update(ctx):
+    update_assets()
+    update_locales()
+    #database()
+
+
+@task
+def deploy(ctx):
+#    install_cron()
+    checkin_changes()
+    deploy_app()
+#    prime_app()
+#    update_celery()
+
+
+@task
+def update_bedrock(ctx, tag):
+    """Do typical bedrock update"""
+    pre_update(tag)
+    update()

--- a/bin/update/deploy-stage.py
+++ b/bin/update/deploy-stage.py
@@ -1,0 +1,122 @@
+"""
+Deployment for Bedrock in production.
+
+Requires commander (https://github.com/oremj/commander) which is installed on
+the systems that need it.
+"""
+
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.abspath(__file__)))
+
+from commander.deploy import task, hostgroups
+
+import commander_settings as settings
+
+
+@task
+def update_code(ctx, tag):
+    with ctx.lcd(settings.SRC_DIR):
+        ctx.local("git fetch")
+        ctx.local("git checkout -f %s" % tag)
+        ctx.local("git submodule sync")
+        ctx.local("git submodule update --init --recursive")
+
+
+@task
+def update_locales(ctx):
+    with ctx.lcd(os.path.join(settings.SRC_DIR, 'locale')):
+        ctx.local("svn up")
+#        ctx.local("./compile-mo.sh .")
+
+
+@task
+def update_assets(ctx):
+    with ctx.lcd(settings.SRC_DIR):
+        ctx.local("LANG=en_US.UTF-8 python2.6 manage.py compress_assets")
+        ctx.local("LANG=en_US.UTF-8 python2.6 manage.py update_product_details")
+
+
+# bedrock has no database
+#@task
+#def database(ctx):
+#    with ctx.lcd(settings.SRC_DIR):
+#        ctx.local("python2.6 ./vendor/src/schematic/schematic migrations")  # schematic (old)
+#        ctx.local("python2.6 manage.py migrate")                            # South (new)
+
+
+#@task
+#def install_cron(ctx):
+#    with ctx.lcd(settings.SRC_DIR):
+#        ctx.local("python2.6 ./scripts/crontab/gen-crons.py -k %s -u apache > /etc/cron.d/.%s" %
+#                  (settings.WWW_DIR, settings.CRON_NAME))
+#        ctx.local("mv /etc/cron.d/.%s /etc/cron.d/%s" % (settings.CRON_NAME, settings.CRON_NAME))
+
+
+@task
+def checkin_changes(ctx):
+    ctx.local(settings.DEPLOY_SCRIPT)
+
+
+@hostgroups(settings.WEB_HOSTGROUP, remote_kwargs={'ssh_key': settings.SSH_KEY})
+def deploy_app(ctx):
+    ctx.remote(settings.REMOTE_UPDATE_SCRIPT)
+#    ctx.remote("/bin/touch %s" % settings.REMOTE_WSGI)
+    ctx.remote("service httpd graceful")
+
+@hostgroups(settings.WEB_HOSTGROUP, remote_kwargs={'ssh_key': settings.SSH_KEY})
+def prime_app(ctx):
+    for http_port in range(80, 82):
+        ctx.remote("for i in {1..10}; do curl -so /dev/null -H 'Host: %s' -I http://localhost:%s/ & sleep 1; done" % (settings.REMOTE_HOSTNAME, http_port))
+
+#@hostgroups(settings.CELERY_HOSTGROUP, remote_kwargs={'ssh_key': settings.SSH_KEY})
+#def update_celery(ctx):
+#    ctx.remote(settings.REMOTE_UPDATE_SCRIPT)
+#    ctx.remote('/sbin/service %s restart' % settings.CELERY_SERVICE)
+
+
+@task
+def update_info(ctx):
+    with ctx.lcd(settings.SRC_DIR):
+        ctx.local("date")
+        ctx.local("git branch")
+        ctx.local("git log -3")
+        ctx.local("git status")
+        ctx.local("git submodule status")
+        #ctx.local("python ./vendor/src/schematic/schematic -v migrations/")
+        #ctx.local("python ./manage.py migrate --list")
+        with ctx.lcd("locale"):
+            ctx.local("svn info")
+            ctx.local("svn status")
+
+        ctx.local("git rev-parse HEAD > media/revision.txt")
+
+
+@task
+def pre_update(ctx, ref=settings.UPDATE_REF):
+    update_code(ref)
+    update_info()
+
+
+@task
+def update(ctx):
+    update_assets()
+    update_locales()
+    #database()
+
+
+@task
+def deploy(ctx):
+#    install_cron()
+    checkin_changes()
+    deploy_app()
+#    prime_app()
+#    update_celery()
+
+
+@task
+def update_bedrock(ctx, tag):
+    """Do typical bedrock update"""
+    pre_update(tag)
+    update()


### PR DESCRIPTION
providing update scripts from current bedrock chief environments. currently, it looks like -dev is not configured to use chief at all, but instead is using the old "auto-update" shell script. will ask around to see if there was a good reason for this.
