### PR TITLE
Bug 915867: Port unsupported/details/ billboard.

### DIFF
--- a/bedrock/firefox/templates/firefox/unsupported-details.html
+++ b/bedrock/firefox/templates/firefox/unsupported-details.html
@@ -27,7 +27,8 @@
           <li>{{ _('experience faster performance') }}</li>
           <li>{{ _('Enjoy new features') }}</li>
         </ul>
-        <p>{{ _('This is your last reminder before you will be automatically updated to the latest version') }} </p>
+        {# Current version of this file in SVN does not have this paragraph.
+         #<p>{{ _('This is your last reminder before you will be automatically updated to the latest version') }} </p>#}
       </div>
     </div>
   </body>

--- a/bedrock/firefox/urls.py
+++ b/bedrock/firefox/urls.py
@@ -57,6 +57,7 @@ urlpatterns = patterns('',
     page('firefox/unsupported/warning', 'firefox/unsupported-warning.html'),
     page('firefox/unsupported/EOL', 'firefox/unsupported-EOL.html'),
     page('firefox/unsupported/mac', 'firefox/unsupported-mac.html'),
+    page('firefox/unsupported/details', 'firefox/unsupported-details.html'),
 
     url(r'^firefox/unsupported/win/$', views.windows_billboards),
     url('^dnt/$', views.dnt, name='firefox.dnt'),

--- a/etc/httpd/global.conf
+++ b/etc/httpd/global.conf
@@ -153,8 +153,8 @@ RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/update(.*)$ /b/$1firefox/update$2 [P
 # TODO: Remove when all locales are done.
 RewriteRule ^/(an|ast|bg|br|cs|csb|cy|da|de|el|eo|es-AR|es-CL|es-ES|es-MX|et|eu|fi|fr|fy-NL|ga-IE|gd|hr|hu|hy-AM|id|is|it|ko|lij|lt|lv|ml|mk|mr|my|nb-NO|nl|pl|pt-BR|pt-PT|rm|ro|ru|sl|sk|sq|sr|sv-SE|te|tr|uk|zh-TW)/firefox/new(/?)$ /b/$1/firefox/new$2 [PT]
 
-# bug 796952, 915845
-RewriteCond %{REQUEST_URI} !firefox/unsupported/details/index\.html$
+# bug 796952, 915845, 915867
+RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/unsupported/(.+)/index\.html$ /$1firefox/unsupported/$2/ [L,R=301]
 RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/unsupported/(.*)$ /b/$1firefox/unsupported/$2 [PT]
 
 # bug 757117


### PR DESCRIPTION
The odd thing about this is that the details template was already there;
it just wasn't hooked up in the urls.py. I did remove the paragraph at
the bottom as it's not in the current version in SVN, but I left it
there and commented out in case someone wants it back.
