### PR TITLE
Bug 881754: add ka and pa-IN locales to firefox/new redirects

### DIFF
--- a/etc/httpd/global.conf
+++ b/etc/httpd/global.conf
@@ -151,7 +151,7 @@ RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/update(.*)$ /b/$1firefox/update$2 [P
 
 # bug 881754, 883127
 # TODO: Remove when all locales are done.
-RewriteRule ^/(an|ar|ast|bg|br|ca|cs|csb|cy|da|de|el|eo|es-AR|es-CL|es-ES|es-MX|et|eu|fi|fr|fy-NL|ga-IE|gd|hr|hu|hy-AM|id|is|it|ko|lij|lt|lv|ml|mk|mr|my|nb-NO|nl|pl|pt-BR|pt-PT|rm|ro|ru|sl|sk|sq|sr|sv-SE|te|tr|uk|zh-TW)/firefox/new(/?)$ /b/$1/firefox/new$2 [PT]
+RewriteRule ^/(an|ar|ast|bg|br|ca|cs|csb|cy|da|de|el|eo|es-AR|es-CL|es-ES|es-MX|et|eu|fi|fr|fy-NL|ga-IE|gd|hr|hu|hy-AM|id|is|it|ka|ko|lij|lt|lv|mk|ml|mr|my|nb-NO|nl|pa-IN|pl|pt-BR|pt-PT|rm|ro|ru|sk|sl|sq|sr|sv-SE|te|tr|uk|zh-TW)/firefox/new(/?)$ /b/$1/firefox/new$2 [PT]
 
 # bug 796952, 915845, 915867
 RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/unsupported/(.+)/index\.html$ /$1firefox/unsupported/$2/ [L,R=301]


### PR DESCRIPTION
And fix the alphabetical order (mk/ml, sk/sl) :-)
