### PR TITLE
Bug 867764 Translate newsletter names and descriptions

### DIFF
--- a/bedrock/newsletter/views.py
+++ b/bedrock/newsletter/views.py
@@ -17,7 +17,7 @@ import basket
 import commonware.log
 import lib.l10n_utils as l10n_utils
 import requests
-from lib.l10n_utils.dotlang import _lazy
+from lib.l10n_utils.dotlang import _, _lazy
 from commonware.decorators import xframe_allow
 from funfactory.urlresolvers import reverse
 
@@ -166,10 +166,10 @@ def existing(request, token=None):
         if data.get('show', False) or newsletter in user['newsletters']:
             langs = data['languages']
             form_data = {
-                'title': data['title'],
+                'title': _(data['title']),
                 'subscribed': newsletter in user['newsletters'],
                 'newsletter': newsletter,
-                'description': data['description'],
+                'description': _(data['description']),
                 'english_only': len(langs) == 1 and langs[0].startswith('en'),
             }
             if 'order' in data:

--- a/etc/httpd/global.conf
+++ b/etc/httpd/global.conf
@@ -312,8 +312,7 @@ RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/nightly(/?)$ https://nightly.mozilla
 RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/nightly/firstrun(.*)$ /b/$1firefox/nightly/firstrun$2 [PT]
 
 # Bug 845904 - /newsletter/existing and /newsletter/updated served from bedrock
-# en-US only until translations are done.
-RewriteRule  ^/en-US/newsletter/existing(.*)$ /b/en-US/newsletter/existing$1 [PT]
+RewriteRule  ^/(\w{2,3}(?:-\w{2})?/)?newsletter/existing(.*)$ /b/$1newsletter/existing$2 [PT]
 RewriteRule  ^/en-US/newsletter/updated(.*)$ /b/en-US/newsletter/updated$1 [PT]
 
 # bug 860532 - Reidrects for governance pages


### PR DESCRIPTION
- On the /existing page, take the names and descriptions of the newsletters
  that come back from Basket and wrap them for translation before passing them
  to the template.  Some of these are translated already.
- Update the rewrite rule for /newsletter/existing to match all locales.
