### PR TITLE
Bug 906892 -- change download title and base template title suffix

### DIFF
--- a/bedrock/base/templates/base-resp.html
+++ b/bedrock/base/templates/base-resp.html
@@ -11,7 +11,7 @@
     {% block extra_meta %}{% endblock %}
     {% include 'includes/head-meta.html' %}
 
-    <title>{% block page_title_prefix %}Mozilla — {% endblock %}{% block page_title %}{% endblock %}{% block page_title_suffix %} — mozilla.org{% endblock %}</title>
+    <title>{% block page_title_prefix %}Mozilla — {% endblock %}{% block page_title %}{% endblock %}{% block page_title_suffix %} — Mozilla{% endblock %}</title>
     <meta name="description" content="{% block description %}{% endblock %}">
 
     {% block tabzilla_css %}

--- a/bedrock/base/templates/base.html
+++ b/bedrock/base/templates/base.html
@@ -9,7 +9,7 @@
     <meta charset="utf-8">
     {% include 'includes/head-meta.html' %}
 
-    <title>{% block page_title_prefix %}Mozilla — {% endblock %}{% block page_title %}{% endblock %}{% block page_title_suffix %} — mozilla.org{% endblock %}</title>
+    <title>{% block page_title_prefix %}Mozilla — {% endblock %}{% block page_title %}{% endblock %}{% block page_title_suffix %} — Mozilla{% endblock %}</title>
     <meta name="description" content="{% block description %}{% endblock %}">
 
     {% block tabzilla_css %}

--- a/bedrock/firefox/templates/firefox/new.html
+++ b/bedrock/firefox/templates/firefox/new.html
@@ -4,7 +4,8 @@
 
 {% extends "firefox/base-resp.html" %}
 
-{% block page_title %}{{_('Free Download')}}{% endblock %}
+{% block page_title_prefix %}{{_('Download Firefox')}} — {% endblock %}
+{% block page_title %}{{_('Free Web Browser')}}{% endblock %} 
 {% block body_id %}firefox-new{% endblock %}
 
 {% block site_header_nav %}{% endblock %}


### PR DESCRIPTION
This PR changes the title of the download by by overriding the prefix in the base template and changing title in new.html. It also changes the base template trailing title string from mozilla.org to Mozilla. Don't merge this until we have the strings translated.
