### PR TITLE
Fix Bug 919702 - Adjust GA experiment code to only execute when f=[0-9]+ is *not* in query string

### DIFF
--- a/bedrock/firefox/templates/firefox/new.html
+++ b/bedrock/firefox/templates/firefox/new.html
@@ -16,8 +16,9 @@
 {% block extrahead %}
   {% if request.locale == 'en-US' %}
     <!-- Google Analytics Content Experiment code -->
-    <script>function utmx_section(){}function utmx(){}(function(){var
-    k='71153379-28',d=document,l=d.location,c=d.cookie;
+    <script>function utmx_section(){}function utmx(){}(function(){
+    if (! /[?&]f=[0-9]+/.test(window.location.search)){
+    var k='71153379-28',d=document,l=d.location,c=d.cookie;
     if(l.search.indexOf('utm_expid='+k)>0)return;
     function f(n){if(c){var i=c.indexOf(n+'=');if(i>-1){var j=c.
     indexOf(';',i);return escape(c.substring(i+n.length+1,j<0?c.
@@ -26,7 +27,8 @@
     '://www')+'.google-analytics.com/ga_exp.js?'+'utmxkey='+k+
     '&utmx='+(x?x:'')+'&utmxx='+(xx?xx:'')+'&utmxtime='+new Date().
     valueOf()+(h?'&utmxhash='+escape(h.substr(1)):'')+
-    '" type="text/javascript" charset="utf-8"><\/sc'+'ript>')})();
+    '" type="text/javascript" charset="utf-8"><\/sc'+'ript>')}})();
+
     </script><script>utmx('url','A/B');</script>
     <!-- End of Google Analytics Content Experiment code -->
   {% endif %}


### PR DESCRIPTION
Modify the GA Content Experiment code to be a no-op if the querystring
matches the regex /[?&]f=[0-9]+/
