### PR TITLE
bug-850164-remove-meta-desc

### DIFF
--- a/bedrock/firefox/templates/firefox/base-resp.html
+++ b/bedrock/firefox/templates/firefox/base-resp.html
@@ -8,7 +8,7 @@
 
 {% block body_class %}sky{% endblock %}
 
-{% block description %}{{_('Mozilla Firefox, free web browser, is created by a global non-profit dedicated to putting individuals in control &amp; shaping the future of the web for the public good.')}}{% endblock %}
+{% block description %}{% endblock %}
 
 {% block favicon %}<link rel="shortcut icon" type="image/icon" href="{{ MEDIA_URL }}img/firefox/favicon.ico?2013-08">{% endblock %}
 

--- a/bedrock/firefox/templates/firefox/base.html
+++ b/bedrock/firefox/templates/firefox/base.html
@@ -8,7 +8,7 @@
 
 {% block body_class %}sky{% endblock %}
 
-{% block description %}Mozilla Firefox, free web browser, is created by a global non-profit dedicated to putting individuals in control &amp; shaping the future of the web for the public good.{% endblock %}
+{% block description %}{% endblock %}
 
 {% block favicon %}<link rel="shortcut icon" href="{{ MEDIA_URL }}img/firefox/favicon.ico?2013-08">{% endblock %}
 


### PR DESCRIPTION
Removed meta descriptions from the Firefox base templates.
