### PR TITLE
Bug 919042 - /newsletter/existing l10n

### DIFF
--- a/bedrock/newsletter/templates/newsletter/existing.html
+++ b/bedrock/newsletter/templates/newsletter/existing.html
@@ -85,6 +85,8 @@
                 {# hidden field: #}
                 {{ formpart.newsletter }}
                 <p class="description">
+                  {# Note: the newsletter description is translated in the code, so
+                     does not need to be translated again here. #}
                   {{ formpart.initial['description'] }}
                 </p>
               </th>

--- a/bedrock/newsletter/templates/newsletter/updated.html
+++ b/bedrock/newsletter/templates/newsletter/updated.html
@@ -29,7 +29,7 @@
           </tr>
           <tr>
             <td></td>
-            <td><input type="submit" value="Submit" class="button" name="feedback" /></td>
+            <td><input type="submit" value="{{_('Submit') }}" class="button" name="feedback" /></td>
           </tr>
         </table>
       </form>


### PR DESCRIPTION
- Wrap "Submit" button on updated page for translation
- Add comment to "existing" page template reminding that the newsletter
  description is already translated in the view code, and doesn't need
  to be wrapped in the template.
