### PR TITLE
fix bug 917383 h1 overflow

### DIFF
--- a/bedrock/mozorg/templates/mozorg/plugincheck.html
+++ b/bedrock/mozorg/templates/mozorg/plugincheck.html
@@ -42,11 +42,11 @@
 {% block content %}
 <main role="main">
   <header id="main-feature">
+      {% if not is_latest %}
+      {{ download_firefox(small=True) }}
+      {% endif %}
       <h1 class="large">{{_('Check Your Plugins')}}</h1>
       <p class="preamble">{{_('Keeping your plugins up to date helps Firefox run safely and smoothly.')}}</p>
-      {% if not is_latest %}
-        {{ download_firefox(small=True) }}
-      {% endif %}
   </header>
   <section class="plugin-status-container billboard">
       <h2>{{_('Plugin Status')}}</h2>

--- a/media/css/plugincheck/plugincheck.less
+++ b/media/css/plugincheck/plugincheck.less
@@ -16,6 +16,9 @@
         text-shadow: 0px 1px 0px rgba(255, 255, 255, 0.75);
         color: rgb(72, 72, 72);
     }
+    .download-button ~ h1.large{
+        max-width: 700px;
+    }
 }
 .billboard {
     padding-top: 42px;


### PR DESCRIPTION
fix bug 917383 for h1 overflow on plugin check pages. bug currently effects es-CL, tr, sr, sq, ru, pt-PT, nb-NO, ca, bg and de sites. 
