### PR TITLE
Bug 869937 - Redirect all firstrun/whatsnew links to bedrock

### DIFF
--- a/etc/httpd/global.conf
+++ b/etc/httpd/global.conf
@@ -190,7 +190,6 @@ RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?mobile/customize(?:/.*)?$ /$1firefox/mobile/
 
 # bug 773739
 RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?products(/?)$ /b/$1products$2 [PT]
-RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox(/(?:\d+\.\d+\.?(?:\d+)?\.?(?:\d+)?(?:[a|b]?)(?:\d*)(?:pre)?(?:\d)?))?/whatsnew(/?)$ /b/$1firefox$2/whatsnew$3 [PT]
 
 # bug 736934
 RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?(firefox|mobile)/((?:aurora|beta)/)?notes(/?)$ /b/$1$2/$3notes$4 [PT]
@@ -275,8 +274,9 @@ RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/partners(.*)$ /b/$1firefox/partners$
 # bug 831810
 RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?mwc/?$ /$1firefox/partners/ [NC,L,R=301]
 
-# bug 833645
-RewriteRule ^/en-US/firefox(/(?:\d+\.\d+\.?(?:\d+)?\.?(?:\d+)?(?:[a|b]?)(?:\d*)(?:pre)?(?:\d)?))?/firstrun(/?)$ /b/en-US/firefox$1/firstrun$2 [PT]
+# bug 869937
+RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox(/.+)/firstrun(/?)$ /b/en-US/firefox$1/firstrun$2 [PT]
+RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox(/.+)/whatsnew(/?)$ /b/en-US/firefox$1/whatsnew$2 [PT]
 
 # bug 748503
 RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?projects/firefox/([^/]+)a[0-9]+/(firstrun|whatsnew)(.*)$ /$1firefox/nightly/firstrun$4 [L,R=301]
@@ -318,10 +318,6 @@ RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/accountmanager/?$ /$1persona/ [L,R=3
 
 # bug 841846
 RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/nightly(/?)$ https://nightly.mozilla.org [L,R=302]
-
-
-# bug 748503
-RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/nightly/firstrun(.*)$ /b/$1firefox/nightly/firstrun$2 [PT]
 
 # Bug 845904 - /newsletter/existing and /newsletter/updated served from bedrock
 RewriteRule  ^/(\w{2,3}(?:-\w{2})?/)?newsletter/existing(.*)$ /b/$1newsletter/existing$2 [PT]


### PR DESCRIPTION
WARNING: May require changes to PHP site .htaccess before merging.

This change would redirect all firefox/_/firstrun and firefox/_/whatsnew URLs to bedrock, which would then be dealt with smartly with the view behind the firstrun/whatsnew pages.

Once this is in place, we'll be able to delete approximately 10 billion old files from SVN.
