### PR TITLE
Bug 924713 - dev.allizom.org/b/en-US/ has invalid attribute on Line 670, Column 54

### DIFF
--- a/bedrock/base/templates/includes/lang_switcher.html
+++ b/bedrock/base/templates/includes/lang_switcher.html
@@ -3,7 +3,7 @@
  # file, You can obtain one at http://mozilla.org/MPL/2.0/. #}
 
 {% if translations|length > 1 %}
-<form id="lang_form" dir="ltr" method="get" action="">
+<form id="lang_form" dir="ltr" method="get" action="#">
   <label for="language">{{ _('Other languages:') }}</label>
   <select id="language" name="lang" dir="ltr">
     {% for code, label in translations|dictsort -%}


### PR DESCRIPTION
I think we don't have to use a `{{ secure_url() }}` in the `action` as no sensitive information will be transmitted.
