### PR TITLE
Bug 925278 - Make firefox/channel page localizable

### DIFF
--- a/bedrock/firefox/templates/firefox/channel.html
+++ b/bedrock/firefox/templates/firefox/channel.html
@@ -4,7 +4,8 @@
 
 {% extends "/firefox/base.html" %}
 
-{% block page_title %}Download Firefox Aurora or Beta &amp; Help Determine the Next Firefox{% endblock %}
+{# L10n: This is the string for the <title> tag on the page. #}
+{% block page_title %}{{_('Download Firefox Aurora or Beta &amp; Help Determine the Next Firefox')}}{% endblock %}
 {% block body_id %}channel{% endblock %}
 
 {% block site_css %}
@@ -28,39 +29,46 @@
 
     <div id="beta" class="pager-page">
       <h2 class="channel-title channel-title-beta"><img src="{{ media('/img/firefox/channel/title-beta.png') }}" alt="Firefox Beta" /></h2>
-      <h3>The latest features in a more stable environment</h3>
+      {# L10n: This description applies to Firefox Beta #}
+      <h3>{{_('The latest features in a more stable environment')}}</h3>
       <div class="download-box" id="beta-desktop">
         {{ download_firefox('beta', icon=False, small=True) }}
       </div>
       <div class="download-box mobile" id="beta-mobile">
         {{ download_firefox('beta', icon=False, mobile=True, small=True) }}
       </div>
-      <p class="more"><a href="{{ php_url('/firefox/beta/') }}">Learn more about Firefox Beta<span> »</span></a></p>
+      <p class="more"><a href="{{ php_url('/firefox/beta/') }}">{{_('Learn more about Firefox Beta')}}</a></p>
     </div>
 
     <div id="firefox" class="pager-page">
       <h2 class="channel-title channel-title-firefox"><img src="{{ media('/img/firefox/channel/title-firefox.png') }}" alt="Firefox" /></h2>
-      <h3>Tried, tested and used by millions around the world</h3>
+      {# L10n: This description applies to Firefox on the Release channel #}
+      <h3>{{_('Tried, tested and used by millions around the world')}}</h3>
       <div class="download-box" id="firefox-desktop">
         {{ download_firefox(icon=False, small=True) }}
       </div>
       <div class="download-box mobile" id="firefox-mobile">
         {{ download_firefox(icon=False, mobile=True, small=True) }}
       </div>
-      <p class="more"><a href="{{ php_url('/firefox/') }}">Learn more about Firefox<span> »</span></a></p>
+      <p class="more"><a href="{{ php_url('/firefox/') }}">{{_('Learn more about Firefox')}}</a></p>
     </div>
 
     <div id="aurora" class="pager-page">
       <h2 class="channel-title channel-title-aurora"><img src="{{ media('/img/firefox/channel/title-aurora.png') }}" alt="Firefox Aurora" /></h2>
-      <h3>The newest innovations in an experimental environment</h3>
+      {# L10n: This description applies to Firefox Aurora #}
+      <h3>{{_('The newest innovations in an experimental environment')}}</h3>
       <div class="download-box" id="aurora-desktop">
         {{ download_firefox('aurora', icon=False, small=True) }}
       </div>
       <div class="download-box mobile" id="aurora-mobile">
         {{ download_firefox('aurora', icon=False, mobile=True, small=True) }}
       </div>
-      <p class="more"><a href="{{ php_url('/mobile/aurora/') }}">Learn more about Firefox Aurora<span> »</span></a></p>
-      <p class="warning">Firefox Aurora automatically sends feedback to Mozilla. <a href="{{ php_url('/legal/privacy/firefox.html#telemetry') }}">Learn more</a>.</p>
+      <p class="more"><a href="{{ php_url('/mobile/aurora/') }}">{{_('Learn more about Firefox Aurora')}}</a></p>
+      <p class="warning">
+        {% trans link=php_url('/legal/privacy/firefox.html#telemetry') %}
+          Firefox Aurora automatically sends feedback to Mozilla. <a href="{{ link }}">Learn more</a>.
+        {% endtrans %}
+      </p>
     </div>
 
   </div>

--- a/media/css/firefox/channel.less
+++ b/media/css/firefox/channel.less
@@ -154,6 +154,10 @@ p.more {
     margin-bottom: @baseLine / 2;
 }
 
+p.more a:after {
+    content: ' »';
+}
+
 .warning {
     color: @textColorSecondary;
 }


### PR DESCRIPTION
- enclose strings in l10n calls + add l10n comments
- remove chevrons that are for decoration and cause l10n problems and generate them via CSS (gecko will revert them automatically in rtl)
