### PR TITLE
Bug 834422, og:image should include a protocol

### DIFF
--- a/bedrock/base/templates/base-resp.html
+++ b/bedrock/base/templates/base-resp.html
@@ -20,7 +20,7 @@
     <meta property="og:site_name" content="{{ _('Mozilla') }}">
     <meta property="og:locale" content="{{ LANG|replace("-", "_") }}">
     <meta property="og:url" content="{{ settings.CANONICAL_URL + '/' + LANG + canonical_path }}">
-    <meta property="og:image" content="{% block page_image %}{{ media('img/mozorg/mozilla-256.jpg') }}{% endblock %}">
+    <meta property="og:image" content="{% filter absolute_url %}{% block page_image %}{{ media('img/mozorg/mozilla-256.jpg') }}{% endblock %}{% endfilter %}">
     <meta property="og:title" content="{{ self.page_title_full() }}">
     <meta property="og:description" content="{{ self.page_desc() }}">
     <meta property="fb:page_id" content="{% block facebook_id %}262134952380{# facebook.com/mozilla #}{% endblock %}">

--- a/bedrock/base/templates/base.html
+++ b/bedrock/base/templates/base.html
@@ -18,7 +18,7 @@
     <meta property="og:site_name" content="{{ _('Mozilla') }}">
     <meta property="og:locale" content="{{ LANG|replace("-", "_") }}">
     <meta property="og:url" content="{{ settings.CANONICAL_URL + '/' + LANG + canonical_path }}">
-    <meta property="og:image" content="{% block page_image %}{{ media('img/mozorg/mozilla-256.jpg') }}{% endblock %}">
+    <meta property="og:image" content="{% filter absolute_url %}{% block page_image %}{{ media('img/mozorg/mozilla-256.jpg') }}{% endblock %}{% endfilter %}">
     <meta property="og:title" content="{{ self.page_title_full() }}">
     <meta property="og:description" content="{{ self.page_desc() }}">
     <meta property="fb:page_id" content="{% block facebook_id %}262134952380{# facebook.com/mozilla #}{% endblock %}">

--- a/bedrock/mozorg/helpers/misc.py
+++ b/bedrock/mozorg/helpers/misc.py
@@ -259,3 +259,33 @@ def press_blog_url(ctx):
         locale = 'en-US'
 
     return settings.PRESS_BLOG_ROOT + settings.PRESS_BLOGS[locale]
+
+
+@jingo.register.filter
+def absolute_url(url):
+    """
+    Return a fully qualified URL including a protocol especially for the Open
+    Graph Protocol image object.
+
+    Examples
+    ========
+
+    In Template
+    -----------
+    This filter can be used in combination with the media helper like this:
+
+        {{ media('path/to/img')|absolute_url }}
+
+    With a block:
+
+        {% filter absolute_url %}
+          {% block page_image %}{{ media('path/to/img') }}{% endblock %}
+        {% endfilter %}
+    """
+
+    if url.startswith('//'):
+        prefix = 'https:'
+    else:
+        prefix = settings.CANONICAL_URL
+
+    return prefix + url


### PR DESCRIPTION
Facebook doesn't accept protocol-relative URLs in the `og:image` property. Simply replace `//` with `https://` with the new `absolute_url` filter.

My previous commit https://github.com/kyoshino/bedrock/commit/d342519d8ef3819f4fa7ed5f6efb44dc15353951 was adding an option to `media()` to include a protocol, but I thought it was unnecessary here.
