### PR TITLE
Bug 925278 : use bedrock channel page instead of php one

### DIFF
--- a/etc/httpd/global.conf
+++ b/etc/httpd/global.conf
@@ -158,6 +158,10 @@ RewriteRule ^/en-US/firefox/geolocation(/?)$ /b/en-US/firefox/geolocation$1 [PT]
 RewriteRule ^/en-US/firefox/channel(/?)$ /b/en-US/firefox/channel$1 [PT]
 RewriteRule ^/en-US/firefox/releases(/?)$ /b/en-US/firefox/releases$1 [PT]
 
+# Bug 925278
+# TODO: Remove when all locales are done.
+RewriteRule ^/(de|he)/firefox/channel(/?)$ /b/$1/firefox/channel$2 [PT]
+
 # bug 893006
 RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/update(.*)$ /b/$1firefox/update$2 [PT]
 


### PR DESCRIPTION
- Add a bedrock redirect for firefox/channel
- include first locales ready: de, he
