### PR TITLE
Bug 925995 - Horizontal scrolling on the new channels page on RTL

### DIFF
--- a/media/css/firefox/menu.less
+++ b/media/css/firefox/menu.less
@@ -48,6 +48,11 @@
     display: block;
 }
 
+/* Bug 925995 */
+body.html-rtl #nav-main li ul {
+    left: 999em;
+}
+
 #nav-main li ul {
     position: absolute;
     left: -999em;


### PR DESCRIPTION
Fix is in menu.css so will apply to all pages using the Firefox menu
