### PR TITLE
Bug 925931 - Restore secondary home page templates

### DIFF
--- a/bedrock/mozorg/templates/mozorg/home-b1.html
+++ b/bedrock/mozorg/templates/mozorg/home-b1.html
@@ -1,0 +1,204 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. #}
+
+{% add_lang_files "mozorg/home" %}
+
+{% extends "mozorg/base-resp.html" %}
+
+{% from 'macros.html' import facebook_share_url, twitter_share_url %}
+
+{% block page_title %}{{_('Home of the Mozilla Project')}}{% endblock %}
+{% block body_id %}home-b1{% endblock %}
+{% block body_class %}sand lang-{{ LANG }} home-b1{% endblock %}
+
+{% block extra_meta %}
+  <!-- validates bing webmaster tools -->
+  <meta name="msvalidate.01" content="B7B177115A634927D608514DA17B2574" />
+{% endblock %}
+
+{% block extrahead %}
+  {{ css('home-b') }}
+<!--[if IE 9]>
+  {{ css('home-b-ie9') }}
+<![endif]-->
+<!--[if IE 8]>
+  {{ css('home-b-ie8') }}
+<![endif]-->
+<!--[if lt IE 8]>
+  {{ css('home-b-ie') }}
+<![endif]-->
+{% endblock %}
+
+{% block string_data %}
+  {# L10n: Used as a label for a button that scrolls through latest news. #}
+  data-news-next='{{_('Next article')}}'
+  {# L10n: Used as a label for a button that scrolls through latest news. #}
+  data-news-prev='{{_('Previous article')}}'
+{% endblock %}
+
+{% block js %}
+{# This hides the script from IE 7 and lower #}
+<!--[if gt IE 7]> <!-- -->
+  {{ js('home-b') }}
+<!-- <![endif]-->
+{% endblock %}
+
+{% block site_header_logo %}{% endblock %}
+
+{% block content %}
+<main id="main-content" role="main">
+  <header class="mission">
+    {# L10n: The Mozilla wordmark appears inline as part of this headline, so it reads as "We are Mozilla." #}
+    <h1>{{ _('We are %(mozilla_wordmark)s') | format(mozilla_wordmark='<img src="'|safe+media('img/home/mozilla-wordmark-red.png')+'" alt="Mozilla" height="70" width="258">'|safe) }}</h1>
+    <p>{{ _('Doing good is part of our code') }}</p>
+    <p class="engage"><a href="{{ url('mozorg.contribute') }}" class="button go">{{ _('Get involved') }}</a></p>
+  </header>
+
+  <section class="pillars">
+    <ul class="accordion">
+      <li id="panel-mission" class="panel" tabindex="0">
+        {# L10n: The active word should be wrapped in <i></i> tags, though it may appear at a different position in the translated title. #}
+        <h2 class="panel-title">{{ _('<i>Explore</i> our mission') }}</h2>
+        <div class="panel-inner">
+          <div class="panel-content">
+            <a href="{{ url('mozorg.mission') }}">
+              <span class="panel-logo"><img src="{{ media('img/home/panel/mission/logo-mozilla.png') }}" alt="Mozilla"></span>
+              <h3>{{ _('Our principles guide us') }}</h3>
+              <p>{{ _('We’re a global community of technologists, thinkers and builders working to keep the Internet alive and accessible.') }}</p>
+              <p class="go">{{ _('Read more about our mission') }}</p>
+            </a>
+          </div>
+        </div>
+      </li>
+
+      <li id="panel-fxos" class="panel" tabindex="0">
+        {# L10n: The active word should be wrapped in <i></i> tags, though it may appear at a different position in the translated title. #}
+        <h2 class="panel-title">{{ _('<i>Look</i> ahead') }}</h2>
+        <div class="panel-inner">
+          <div class="panel-content">
+            <a href="{{ url('firefox.os.index') }}">
+              <span class="panel-logo"><img src="{{ media('img/home/panel/firefoxos/logo-firefoxos.png') }}" alt="Firefox OS"></span>
+              <h3>{{ _('Look ahead') }}</h3>
+              <p>{{ _('We‘re bringing more people to the Web in more ways and from more places than ever before.') }}</p>
+              <p class="go">{{ _('Learn more about Firefox OS') }}</p>
+            </a>
+          </div>
+        </div>
+      </li>
+
+      <li id="panel-mdn" class="panel" tabindex="0">
+        {# L10n: The active word should be wrapped in <i></i> tags, though it may appear at a different position in the translated title. #}
+        <h2 class="panel-title">{{ _('<i>Join</i> our community') }}</h2>
+        <div class="panel-inner">
+          <div class="panel-content">
+            <a href="https://developer.mozilla.org/">
+              {# L10n: This <br> is strictly for visual formatting; translations can omit or reposition as needed. #}
+              <h3>{{ _('Join our<br> developer community') }}</h3>
+              <p>{{ _('Get docs and demos, tools and tutorials and everything related to the Open Web.') }}</p>
+              <p class="go">{{ _('Visit the Mozilla Developer Network') }}</p>
+            </a>
+          </div>
+        </div>
+      </li>
+
+      <li id="panel-mozfest" class="panel" tabindex="0">
+        {# L10n: The active word should be wrapped in <i></i> tags, though it may appear at a different position in the translated title. #}
+        <h2 class="panel-title">{{ _('<i>Forge</i> the future') }}</h2>
+        <div class="panel-inner">
+          <div class="panel-content">
+            <a href="https://mozillafestival.org">
+              <span class="panel-logo"><img src="{{ media('img/home/panel/mozfest/logo-mozfest.png') }}" alt="{{ _('Mozilla Festival') }}"></span>
+              {# L10n: This <br> is strictly for visual formatting; translations can omit or reposition as needed. #}
+              <h3>{{ _('Forge the future<br> of the Web') }}</h3>
+              <p>{{ _('Learn from some of the most passionate thinkers and inventors from around the world.') }}</p>
+              <p class="go">{{ _('Come to the Mozilla Festival') }}</p>
+            </a>
+          </div>
+        </div>
+      </li>
+    </ul>
+  </section>
+
+  <section class="extra">
+
+      <section class="extra-download">
+        <h2>{{_('Different by&nbsp;design')}}</h2>
+        {{ download_firefox(icon=True) }}
+      </section>
+
+    {% if request.locale in settings.PRESS_BLOGS %}
+
+      <section class="extra-news">
+        <h2>{{ _('In the news') }}</h2>
+        <ul class="hfeed cycle-slideshow" data-cycle-timeout="6000" data-cycle-slides="> .hentry" data-cycle-fx="carousel" data-cycle-carousel-fluid="true" data-cycle-carousel-vertical="true" data-cycle-next=".news-buttons .btn-next" data-cycle-prev=".news-buttons .btn-prev" data-cycle-carousel-visible="1" data-cycle-pause-on-hover="true">
+
+        {% l10n home_news, 20131010 %}
+          <li class="hentry">
+            <h3 class="entry-title">
+              <a class="url go" rel="bookmark external" hreflang="en-US" href="https://blog.mozilla.org/blog/2013/10/09/mozilla-and-partners-to-kick-off-second-round-of-firefox-os-launches/">
+                Mozilla and Partners to Kick off Second Round of Firefox OS Launches in More Markets Around the World
+              </a>
+            </h3>
+          </li>
+          <li class="hentry">
+            <h3 class="entry-title">
+              <a class="url go" rel="bookmark external" hreflang="en-US" href="https://blog.mozilla.org/blog/2013/08/01/telefonica-announces-launches-of-first-firefox-os-devices-in-latin-america/">
+                Telefonica Announces Launches of First Firefox OS Devices in Latin America
+              </a>
+            </h3>
+          </li>
+
+          <li class="hentry">
+            <h3 class="entry-title">
+              <a class="url go" rel="bookmark external" hreflang="en-US" href="https://blog.mozilla.org/blog/2013/07/11/deutsche-telekom-announces-european-launch-of-firefox-os-devices/">
+                Deutsche Telekom Announces European Launch of Firefox OS Devices
+              </a>
+            </h3>
+          </li>
+        {% endl10n %}
+
+        </ul>
+        <p class="control"><a href="{{ press_blog_url() }}" class="go">{{ _('See all news') }}</a></p>
+      </section>
+
+    {% elif request.locale in ['hu','pt-BR'] %}
+
+      <section class="extra-contribute fxos">
+        <h2>{{ _('Get involved') }}</h2>
+        <p>
+        {% trans link_mobilizer=mobilizer_link %}
+          Help launch Firefox OS in your country.
+          <a href="{{ link_mobilizer }}">Become a Mobilizer today</a>.
+        {% endtrans %}
+        </p>
+      </section>
+
+    {% elif has_contribute %}
+
+      <section class="extra-contribute volunteer">
+        <h2>{{ _('Get involved') }}</h2>
+        <p>
+        {{ _('You don’t have to know how to code to get involved with Mozilla. <a href="%s">Learn more about our volunteer opportunities</a>.') | format(url('mozorg.contribute')) }}
+        </p>
+      </section>
+
+    {% else %}
+
+      <section class="extra-contribute locale">
+        <h2>{{ _('Get involved') }}</h2>
+        <p>
+        {% trans link_l10n='https://l10n.mozilla.org' %}
+          Thanks to our global community, Mozilla products and websites are available in over 70 languages.
+          <a href="{{ link_l10n }}">Help translate them into yours</a>.
+        {% endtrans %}
+        </p>
+      </section>
+
+    {% endif %}
+
+  </section>
+
+</main>
+
+{% endblock %}

--- a/bedrock/mozorg/templates/mozorg/home-b2.html
+++ b/bedrock/mozorg/templates/mozorg/home-b2.html
@@ -1,0 +1,219 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. #}
+
+{% add_lang_files "mozorg/home" %}
+
+{% extends "mozorg/base-resp.html" %}
+
+{% from 'macros.html' import facebook_share_url, twitter_share_url %}
+
+{% block page_title %}{{_('Home of the Mozilla Project')}}{% endblock %}
+{% block body_id %}home-b2{% endblock %}
+{% block body_class %}sand lang-{{ LANG }} home-b2{% endblock %}
+
+{% block extra_meta %}
+<!-- validates bing webmaster tools -->
+<meta name="msvalidate.01" content="B7B177115A634927D608514DA17B2574" />
+{% endblock %}
+
+{% block extrahead %}
+  {{ css('home-b') }}
+<!--[if IE 9]>
+  {{ css('home-b-ie9') }}
+<![endif]-->
+<!--[if IE 8]>
+  {{ css('home-b-ie8') }}
+<![endif]-->
+<!--[if lt IE 8]>
+  {{ css('home-b-ie') }}
+<![endif]-->
+{% endblock %}
+
+{% block string_data %}
+  {# L10n: Used as a label for a button that scrolls through latest news. #}
+  data-news-next='{{_('Next article')}}'
+  {# L10n: Used as a label for a button that scrolls through latest news. #}
+  data-news-prev='{{_('Previous article')}}'
+{% endblock %}
+
+{% block js %}
+{# This hides the script from IE 7 and lower #}
+<!--[if gt IE 7]> <!-- -->
+  {{ js('home-b') }}
+<!-- <![endif]-->
+{% endblock %}
+
+{% block site_header_logo %}{% endblock %}
+
+{% block content %}
+<main id="main-content" role="main">
+  <header class="mission">
+    {# L10n: The Mozilla wordmark appears inline as part of this headline, so it reads as "We are Mozilla." #}
+    <h1>{{ _('We are %(mozilla_wordmark)s') | format(mozilla_wordmark='<img src="'|safe+media('img/home/mozilla-wordmark-red.png')+'" alt="Mozilla" height="70" width="258">'|safe) }}</h1>
+    <p>{{ _('Doing good is part of our code') }}</p>
+    <p class="engage"><a href="{{ url('mozorg.contribute') }}" class="button go">{{ _('Get involved') }}</a></p>
+  </header>
+
+  <section class="pillars">
+    <ul class="accordion">
+      <li id="panel-mission" class="panel" tabindex="0">
+        {# L10n: The active word should be wrapped in <i></i> tags, though it may appear at a different position in the translated title. #}
+        <h2 class="panel-title">{{ _('<i>Explore</i> our mission') }}</h2>
+        <div class="panel-inner">
+          <div class="panel-content">
+            <a href="{{ url('mozorg.mission') }}">
+              <span class="panel-logo"><img src="{{ media('img/home/panel/mission/logo-mozilla.png') }}" alt="Mozilla"></span>
+              <h3>{{ _('Our principles guide us') }}</h3>
+              <p>{{ _('We’re a global community of technologists, thinkers and builders working to keep the Internet alive and accessible.') }}</p>
+              <p class="go">{{ _('Read more about our mission') }}</p>
+            </a>
+          </div>
+        </div>
+      </li>
+
+      <li id="panel-fxos" class="panel" tabindex="0">
+        {# L10n: The active word should be wrapped in <i></i> tags, though it may appear at a different position in the translated title. #}
+        <h2 class="panel-title">{{ _('<i>Look</i> ahead') }}</h2>
+        <div class="panel-inner">
+          <div class="panel-content">
+            <a href="{{ url('firefox.os.index') }}">
+              <span class="panel-logo"><img src="{{ media('img/home/panel/firefoxos/logo-firefoxos.png') }}" alt="Firefox OS"></span>
+              <h3>{{ _('Look ahead') }}</h3>
+              <p>{{ _('We‘re bringing more people to the Web in more ways and from more places than ever before.') }}</p>
+              <p class="go">{{ _('Learn more about Firefox OS') }}</p>
+            </a>
+          </div>
+        </div>
+      </li>
+
+      <li id="panel-mdn" class="panel" tabindex="0">
+        {# L10n: The active word should be wrapped in <i></i> tags, though it may appear at a different position in the translated title. #}
+        <h2 class="panel-title">{{ _('<i>Join</i> our community') }}</h2>
+        <div class="panel-inner">
+          <div class="panel-content">
+            <a href="https://developer.mozilla.org/">
+              {# L10n: This <br> is strictly for visual formatting; translations can omit or reposition as needed. #}
+              <h3>{{ _('Join our<br> developer community') }}</h3>
+              <p>{{ _('Get docs and demos, tools and tutorials and everything related to the Open Web.') }}</p>
+              <p class="go">{{ _('Visit the Mozilla Developer Network') }}</p>
+            </a>
+          </div>
+        </div>
+      </li>
+
+      <li id="panel-mozfest" class="panel" tabindex="0">
+        {# L10n: The active word should be wrapped in <i></i> tags, though it may appear at a different position in the translated title. #}
+        <h2 class="panel-title">{{ _('<i>Forge</i> the future') }}</h2>
+        <div class="panel-inner">
+          <div class="panel-content">
+            <a href="https://mozillafestival.org">
+              <span class="panel-logo"><img src="{{ media('img/home/panel/mozfest/logo-mozfest.png') }}" alt="{{ _('Mozilla Festival') }}"></span>
+              {# L10n: This <br> is strictly for visual formatting; translations can omit or reposition as needed. #}
+              <h3>{{ _('Forge the future<br> of the Web') }}</h3>
+              <p>{{ _('Learn from some of the most passionate thinkers and inventors from around the world.') }}</p>
+              <p class="go">{{ _('Come to the Mozilla Festival') }}</p>
+            </a>
+          </div>
+        </div>
+      </li>
+    </ul>
+  </section>
+
+  <section id="firefox-promo" class="billboard">
+    <div class="container">
+      <h3>{{_('Different by&nbsp;design')}}</h3>
+      {# We intentionally don't use php_url() here because all locals
+       # are seeing this English page and we want them to hit their locale for
+       # firefox pages #}
+      <a href="/firefox/" id="firefox-promo-link">
+      <img src="{{ media('img/home/firefox.png?2013-06')}}" id="promo-logo" alt="Firefox">
+      </a>
+
+      {{ download_firefox(small=True, icon=False) }}
+    </div>
+  </section>
+
+  <section class="extra">
+    <div class="container">
+
+      {{ mozorg_newsletter_form() }}
+
+    {% if request.locale in settings.PRESS_BLOGS %}
+
+      <section class="extra-news">
+        <h2>{{ _('In the news') }}</h2>
+        <ul class="hfeed cycle-slideshow" data-cycle-timeout="6000" data-cycle-slides="> .hentry" data-cycle-fx="carousel" data-cycle-carousel-fluid="true" data-cycle-carousel-vertical="true" data-cycle-next=".news-buttons .btn-next" data-cycle-prev=".news-buttons .btn-prev" data-cycle-carousel-visible="1" data-cycle-pause-on-hover="true">
+
+        {% l10n home_news, 20131010 %}
+          <li class="hentry">
+            <h3 class="entry-title">
+              <a class="url go" rel="bookmark external" hreflang="en-US" href="https://blog.mozilla.org/blog/2013/10/09/mozilla-and-partners-to-kick-off-second-round-of-firefox-os-launches/">
+                Mozilla and Partners to Kick off Second Round of Firefox OS Launches in More Markets Around the World
+              </a>
+            </h3>
+          </li>
+          <li class="hentry">
+            <h3 class="entry-title">
+              <a class="url go" rel="bookmark external" hreflang="en-US" href="https://blog.mozilla.org/blog/2013/08/01/telefonica-announces-launches-of-first-firefox-os-devices-in-latin-america/">
+                Telefonica Announces Launches of First Firefox OS Devices in Latin America
+              </a>
+            </h3>
+          </li>
+
+          <li class="hentry">
+            <h3 class="entry-title">
+              <a class="url go" rel="bookmark external" hreflang="en-US" href="https://blog.mozilla.org/blog/2013/07/11/deutsche-telekom-announces-european-launch-of-firefox-os-devices/">
+                Deutsche Telekom Announces European Launch of Firefox OS Devices
+              </a>
+            </h3>
+          </li>
+        {% endl10n %}
+
+        </ul>
+        <p class="control"><a href="{{ press_blog_url() }}" class="go">{{ _('See all news') }}</a></p>
+      </section>
+
+    {% elif request.locale in ['hu','pt-BR'] %}
+
+      <section class="extra-contribute fxos">
+        <h2>{{ _('Get involved') }}</h2>
+        <p>
+        {% trans link_mobilizer=mobilizer_link %}
+          Help launch Firefox OS in your country.
+          <a href="{{ link_mobilizer }}">Become a Mobilizer today</a>.
+        {% endtrans %}
+        </p>
+      </section>
+
+    {% elif has_contribute %}
+
+      <section class="extra-contribute volunteer">
+        <h2>{{ _('Get involved') }}</h2>
+        <p>
+        {{ _('You don’t have to know how to code to get involved with Mozilla. <a href="%s">Learn more about our volunteer opportunities</a>.') | format(url('mozorg.contribute')) }}
+        </p>
+      </section>
+
+    {% else %}
+
+      <section class="extra-contribute locale">
+        <h2>{{ _('Get involved') }}</h2>
+        <p>
+        {% trans link_l10n='https://l10n.mozilla.org' %}
+          Thanks to our global community, Mozilla products and websites are available in over 70 languages.
+          <a href="{{ link_l10n }}">Help translate them into yours</a>.
+        {% endtrans %}
+        </p>
+      </section>
+
+    {% endif %}
+
+    </div>
+  </section>
+
+</main>
+
+{% endblock %}
+
+{% block email_form %}{% endblock %}

--- a/bedrock/mozorg/templates/mozorg/home.html
+++ b/bedrock/mozorg/templates/mozorg/home.html
@@ -2,218 +2,218 @@
  # License, v. 2.0. If a copy of the MPL was not distributed with this
  # file, You can obtain one at http://mozilla.org/MPL/2.0/. #}
 
-{% add_lang_files "mozorg/home" %}
-
-{% extends "mozorg/base-resp.html" %}
+{% extends "/mozorg/base-resp.html" %}
 
 {% from 'macros.html' import facebook_share_url, twitter_share_url %}
 
 {% block page_title %}{{_('Home of the Mozilla Project')}}{% endblock %}
-{% block body_id %}home-b2{% endblock %}
-{% block body_class %}sand lang-{{ LANG }} home-b2{% endblock %}
+{% block body_id %}home{% endblock %}
+{% block body_class %}sand{% endblock %}
 
 {% block extra_meta %}
+  <!-- Google Analytics Content Experiment code -->
+  <script>function utmx_section(){}function utmx(){}(function(){var
+  k='71153379-29',d=document,l=d.location,c=d.cookie;
+  if(l.search.indexOf('utm_expid='+k)>0)return;
+  function f(n){if(c){var i=c.indexOf(n+'=');if(i>-1){var j=c.
+  indexOf(';',i);return escape(c.substring(i+n.length+1,j<0?c.
+  length:j))}}}var x=f('__utmx'),xx=f('__utmxx'),h=l.hash;d.write(
+  '<sc'+'ript src="'+'http'+(l.protocol=='https:'?'s://ssl':
+  '://www')+'.google-analytics.com/ga_exp.js?'+'utmxkey='+k+
+  '&utmx='+(x?x:'')+'&utmxx='+(xx?xx:'')+'&utmxtime='+new Date().
+  valueOf()+(h?'&utmxhash='+escape(h.substr(1)):'')+
+  '" type="text/javascript" charset="utf-8"><\/sc'+'ript>')})();
+  </script><script>utmx('url','A/B');</script>
+  <!-- End of Google Analytics Content Experiment code -->
+
   <!-- validates bing webmaster tools -->
   <meta name="msvalidate.01" content="B7B177115A634927D608514DA17B2574" />
 {% endblock %}
 
 {% block extrahead %}
-  {{ css('home-b') }}
-<!--[if IE 9]>
-  {{ css('home-b-ie9') }}
-<![endif]-->
-<!--[if IE 8]>
-  {{ css('home-b-ie8') }}
-<![endif]-->
-<!--[if lt IE 8]>
-  {{ css('home-b-ie') }}
-<![endif]-->
+  {{ css('home') }}
 {% endblock %}
 
 {% block string_data %}
-  {# L10n: Used as a label for a button that scrolls through latest news. #}
-  data-news-next='{{_('Next article')}}'
-  {# L10n: Used as a label for a button that scrolls through latest news. #}
-  data-news-prev='{{_('Previous article')}}'
+  data-close='{{_('Close')}}'
+  data-share='{{_('Share')}}'
 {% endblock %}
 
 {% block js %}
-{# This hides the script from IE 7 and lower #}
-<!--[if gt IE 7]> <!-- -->
-  {{ js('home-b') }}
-<!-- <![endif]-->
+  {{ js('home') }}
 {% endblock %}
 
 {% block site_header_logo %}{% endblock %}
-
 {% block content %}
-<main id="main-content" role="main">
-  <header class="mission">
-    {# L10n: The Mozilla wordmark appears inline as part of this headline, so it reads as "We are Mozilla." #}
-    <h1>{{ _('We are %(mozilla_wordmark)s') | format(mozilla_wordmark='<img src="'|safe+media('img/home/mozilla-wordmark-red.png')+'" alt="Mozilla" height="70" width="258">'|safe) }}</h1>
-    <p>{{ _('Doing good is part of our code') }}</p>
-    <p class="engage"><a href="{{ url('mozorg.contribute') }}" class="button go">{{ _('Get involved') }}</a></p>
-  </header>
 
-  <section class="pillars">
-    <ul class="accordion">
-      <li id="panel-mission" class="panel" tabindex="0">
-        {# L10n: The active word should be wrapped in <i></i> tags, though it may appear at a different position in the translated title. #}
-        <h2 class="panel-title">{{ _('<i>Explore</i> our mission') }}</h2>
-        <div class="panel-inner">
-          <div class="panel-content">
-            <a href="{{ url('mozorg.mission') }}">
-              <span class="panel-logo"><img src="{{ media('img/home/panel/mission/logo-mozilla.png') }}" alt="Mozilla"></span>
-              <h3>{{ _('Our principles guide us') }}</h3>
-              <p>{{ _('We’re a global community of technologists, thinkers and builders working to keep the Internet alive and accessible.') }}</p>
-              <p class="go">{{ _('Read more about our mission') }}</p>
-            </a>
-          </div>
+<hgroup id="main-feature" class="huge">
+  {# L10n: The Mozilla wordmark appears inline as part of this headline, so it reads as "We are Mozilla". #}
+  <h1>{{ _('We are %(mozilla_wordmark)s') | format(mozilla_wordmark='<img src="'|safe+media('img/home/title-wordmark.png')+'" alt="Mozilla" height="92" width="348">'|safe) }}</h1>
+  <h2>{{_('Doing good is part of our code')}}</h2>
+</hgroup>
+
+<section id="firefox-promo" class="billboard">
+  <h3>{{_('Different by&nbsp;design')}}</h3>
+  {# We intentionally don't use php_url() here because all locals
+   # are seeing this English page and we want them to hit their locale for
+   # firefox pages #}
+  <a href="/firefox/" id="firefox-promo-link">
+  <img src="{{ media('img/home/firefox.png?2013-06')}}" id="promo-logo" alt="Firefox">
+  </a>
+  <ul class="features">
+    {# L10n: Small piece of text that appears to the side of the download button on the homepage. #}
+    <li><small>{{_('Proudly <br> non-profit')}}</small></li>
+    {# L10n: Small piece of text that appears to the side of the download button on the homepage. #}
+    <li><small>{{_('Innovating <br> for&nbsp;you')}}</small></li>
+    {# L10n: Small piece of text that appears to the side of the download button on the homepage. #}
+    <li><small>{{_('Fast,&nbsp;flexible, <br> secure')}}</small></li>
+  </ul>
+
+  {{ download_firefox(small=True, icon=False) }}
+</section>
+
+<section id="home-promo" class="pager pager-with-tabs pager-auto-rotate pager-no-history pager-with-hidden-class">
+
+  <div class="pager-content">
+
+    <div class="pager-page default-page" id="promo-fxos">
+      <script>
+        document.getElementById('promo-fxos').id = 'page-promo-fxos';
+      </script>
+      <a href="{{ url('firefox.os.index')  }}" class="container">
+        <div class="content">
+          <h3>{{_('Look ahead')}}</h3>
+          <h4>{{_('Firefox OS lets you live every moment to its fullest and build a brighter future for the Web.')}}</h4>
+          <p class="go">{{_('Find out how')}}</p>
         </div>
+      </a>
+    </div>
+
+    <div class="pager-page" id="promo-makerparty">
+      <script>
+        document.getElementById('promo-makerparty').id = 'page-promo-makerparty';
+      </script>
+      <a href="https://webmaker.org/party/?icn=hpromo2" class="container">
+        <div class="content">
+          <h3>{{_('Did you know?')}}</h3>
+          <h4>{{_('From June 15 &ndash; September 15, thousands of Mozillians worldwide are throwing parties to make and share amazing projects.')}}</h4>
+          <p class="go">{{_('Join us')}}</p>
+        </div>
+      </a>
+    </div>
+
+    <div class="pager-page" id="promo-flickswinners">
+      <script>
+        document.getElementById('promo-flickswinners').id = 'page-promo-flickswinners';
+      </script>
+      <a href="https://firefoxflicks.mozilla.org/video/winners/" class="container">
+        <div class="content">
+          <h3><i class="hidden">{{_('Firefox Flicks')}}</i> {{_('Congratulations to our winners')}}</h3>
+          <h4>{{_('The votes are in and we‘re excited to present the winners of Firefox Flicks 2013. Thanks to everyone who entered!')}}</h4>
+          <p class="go">{{_('Watch the winning flicks')}}</p>
+        </div>
+      </a>
+      <img id="promo-flicks-keyframe" src="{{ media('img/home/promo/flickswinners/2013-winner-thumb.jpg') }}" alt="{{_('Play Video')}}" tabindex="0" role="button">
+      <div id="promo-flicks-overlay" class="video-overlay">
+        <a class="video-visit" href="https://firefoxflicks.mozilla.org/">{{_('Visit FirefoxFlicks.org')}}</a>
+        <ul class="share-links">
+          <li><a href="{{ facebook_share_url('https://firefoxflicks.org') }}" class="share-facebook">{{_('Share on Facebook')}}</a></li>
+          <li><a href="{{ twitter_share_url('https://firefoxflicks.org', _('I just watched the winning video in the #FirefoxFlicks contest. See all the winning flicks for yourself!')) }}" class="share-twitter">{{_('Tweet')}}</a></li>
+        </ul>
+        <span tabindex="0" role="button" class="video-replay">{{_('Replay')}}</span>
+        <span tabindex="0" role="button" class="video-continue">{{_('Continue')}}</span>
+      </div>
+    </div>
+
+    <div class="pager-page" id="promo-android">
+      <script>// <![CDATA[
+      document.getElementById('promo-android').id = 'page-promo-android';
+      // ]]></script>
+      <a href="{{ url('firefox.fx') }}" class="container">
+        <div class="content">
+          {# L10n: Firefox for Android tagline. #}
+          <h3>{{_('Fast. Smart. Safe.')}}</h3>
+          <h4>{{_('Get the mobile browser that’s got your back.')}}</h4>
+          <p class="go">{{_('Get Firefox for Android')}}</p>
+        </div>
+      </a>
+    </div>
+
+  </div>
+
+  <ul class="pager-tabs">
+    <li><a tabindex="-1" aria-hidden="true" href="#p1"></a></li>
+    <li><a tabindex="-1" aria-hidden="true" href="#p2"></a></li>
+    <li><a tabindex="-1" aria-hidden="true" href="#p3"></a></li>
+    <li><a tabindex="-1" aria-hidden="true" href="#p4"></a></li>
+  </ul>
+
+</section>
+
+<div id="main-content">
+
+  {% l10n home, 20130225 %}
+  <section id="home-news">
+    <h3>{{ _('In the news') }}</h3>
+    <ul>
+      <li>
+        <h4><a href="https://blog.mozilla.org/blog/2013/10/09/mozilla-and-partners-to-kick-off-second-round-of-firefox-os-launches/">{{ _('Mozilla and Partners to Kick off Second Round of Firefox OS Launches in More Markets Around the World') }}</a></h4>
       </li>
-
-      <li id="panel-fxos" class="panel" tabindex="0">
-        {# L10n: The active word should be wrapped in <i></i> tags, though it may appear at a different position in the translated title. #}
-        <h2 class="panel-title">{{ _('<i>Look</i> ahead') }}</h2>
-        <div class="panel-inner">
-          <div class="panel-content">
-            <a href="{{ url('firefox.os.index') }}">
-              <span class="panel-logo"><img src="{{ media('img/home/panel/firefoxos/logo-firefoxos.png') }}" alt="Firefox OS"></span>
-              <h3>{{ _('Look ahead') }}</h3>
-              <p>{{ _('We‘re bringing more people to the Web in more ways and from more places than ever before.') }}</p>
-              <p class="go">{{ _('Learn more about Firefox OS') }}</p>
-            </a>
-          </div>
-        </div>
+      <li>
+        <h4><a href="https://blog.mozilla.org/blog/2013/08/01/telefonica-announces-launches-of-first-firefox-os-devices-in-latin-america/">{{ _('Telefonica Announces Launches of First Firefox OS Devices in Latin America') }}</a></h4>
       </li>
-
-      <li id="panel-mdn" class="panel" tabindex="0">
-        {# L10n: The active word should be wrapped in <i></i> tags, though it may appear at a different position in the translated title. #}
-        <h2 class="panel-title">{{ _('<i>Join</i> our community') }}</h2>
-        <div class="panel-inner">
-          <div class="panel-content">
-            <a href="https://developer.mozilla.org/">
-              {# L10n: This <br> is strictly for visual formatting; translations can omit or reposition as needed. #}
-              <h3>{{ _('Join our<br> developer community') }}</h3>
-              <p>{{ _('Get docs and demos, tools and tutorials and everything related to the Open Web.') }}</p>
-              <p class="go">{{ _('Visit the Mozilla Developer Network') }}</p>
-            </a>
-          </div>
-        </div>
+      <li>
+        <h4><a href="https://blog.mozilla.org/blog/2013/07/11/deutsche-telekom-announces-european-launch-of-firefox-os-devices/">{{ _('Deutsche Telekom Announces European Launch of Firefox OS Devices') }}</a></h4>
       </li>
+    </ul>
+    <a href="https://blog.mozilla.org/" id="all-news">{{ _('See all news »') }}</a>
+  </section>
+  {% endl10n %}
 
-      <li id="panel-mozfest" class="panel" tabindex="0">
-        {# L10n: The active word should be wrapped in <i></i> tags, though it may appear at a different position in the translated title. #}
-        <h2 class="panel-title">{{ _('<i>Forge</i> the future') }}</h2>
-        <div class="panel-inner">
-          <div class="panel-content">
-            <a href="https://mozillafestival.org">
-              <span class="panel-logo"><img src="{{ media('img/home/panel/mozfest/logo-mozfest.png') }}" alt="{{ _('Mozilla Festival') }}"></span>
-              {# L10n: This <br> is strictly for visual formatting; translations can omit or reposition as needed. #}
-              <h3>{{ _('Forge the future<br> of the Web') }}</h3>
-              <p>{{ _('Learn from some of the most passionate thinkers and inventors from around the world.') }}</p>
-              <p class="go">{{ _('Come to the Mozilla Festival') }}</p>
-            </a>
-          </div>
-        </div>
+  <section id="home-promos">
+    <h3>{{ _('In the know') }}</h3>
+     <ul>
+      <li>
+        <h4><a href="{{ url('firefox.os.index') }}">{{_('Firefox OS')}}</a></h4>
+        <p>{{_('See what’s next for the mobile Web.')}}</p>
+      </li>
+      <li>
+        <h4><a href="https://affiliates.mozilla.org/">{{_('Become an Affiliate')}}</a></h4>
+        <p>{{_('Help us share Firefox with the world!')}}</p>
+      </li>
+      <li>
+        <h4><a href="{{ url('marketplace.marketplace') }}">{{ _('Firefox Marketplace') }}</a></h4>
+        <p>{{_('Launch your app on the web')}}</p>
       </li>
     </ul>
   </section>
 
-  <section id="firefox-promo" class="billboard">
-    <div class="container">
-      <h3>{{_('Different by&nbsp;design')}}</h3>
-      {# We intentionally don't use php_url() here because all locals
-       # are seeing this English page and we want them to hit their locale for
-       # firefox pages #}
-      <a href="/firefox/" id="firefox-promo-link">
-      <img src="{{ media('img/home/firefox.png?2013-06')}}" id="promo-logo" alt="Firefox">
-      </a>
-
-      {{ download_firefox(small=True, icon=False) }}
-    </div>
+  <section id="home-about">
+    <h3>{{ _('Be a part of Mozilla') }}</h3>
+    <ul>
+      <li id="about-volunteer"><a href="{{ url('mozorg.contribute') }}">
+        <h4>{{_('Volunteer with us')}}</h4>
+        <p>{{_('Get involved in any area of the Mozilla Project.')}}</p>
+      </a></li>
+      <li id="about-work"><a href="http://careers.mozilla.org/">
+        <h4>{{_('Work with us')}}</h4>
+        <p>{{_('Apply today and love the Web for a living.')}}</p>
+      </a></li>
+      <li id="about-find"><a href="{{ php_url('/about/mozilla-spaces/') }}">
+        <h4>{{_('Find us')}}</h4>
+        <p>{{_('Contact one of our global Mozilla Spaces.')}}</p>
+      </a></li>
+      <li id="about-join"><a href="https://sendto.mozilla.org/Join-Moz-Org">
+        <h4>{{_('Donate')}}</h4>
+        <p>{{_('Show your support and help us build a better Web.')}}</p>
+      </a></li>
+      <li id="about-learn"><a href="{{ url('mozorg.about') }}">
+        <h4>{{_('Learn more')}}</h4>
+        <p>{{_('Get to know Mozilla a little bit better.')}}</p>
+      </a></li>
+    </ul>
   </section>
 
-  <section class="extra">
-    <div class="container">
-
-      {{ mozorg_newsletter_form() }}
-
-    {% if request.locale in settings.PRESS_BLOGS %}
-
-      <section class="extra-news">
-        <h2>{{ _('In the news') }}</h2>
-        <ul class="hfeed cycle-slideshow" data-cycle-timeout="6000" data-cycle-slides="> .hentry" data-cycle-fx="carousel" data-cycle-carousel-fluid="true" data-cycle-carousel-vertical="true" data-cycle-next=".news-buttons .btn-next" data-cycle-prev=".news-buttons .btn-prev" data-cycle-carousel-visible="1" data-cycle-pause-on-hover="true">
-
-        {% l10n home_news, 20131010 %}
-          <li class="hentry">
-            <h3 class="entry-title">
-              <a class="url go" rel="bookmark external" hreflang="en-US" href="https://blog.mozilla.org/blog/2013/10/09/mozilla-and-partners-to-kick-off-second-round-of-firefox-os-launches/">
-                Mozilla and Partners to Kick off Second Round of Firefox OS Launches in More Markets Around the World
-              </a>
-            </h3>
-          </li>
-          <li class="hentry">
-            <h3 class="entry-title">
-              <a class="url go" rel="bookmark external" hreflang="en-US" href="https://blog.mozilla.org/blog/2013/08/01/telefonica-announces-launches-of-first-firefox-os-devices-in-latin-america/">
-                Telefonica Announces Launches of First Firefox OS Devices in Latin America
-              </a>
-            </h3>
-          </li>
-
-          <li class="hentry">
-            <h3 class="entry-title">
-              <a class="url go" rel="bookmark external" hreflang="en-US" href="https://blog.mozilla.org/blog/2013/07/11/deutsche-telekom-announces-european-launch-of-firefox-os-devices/">
-                Deutsche Telekom Announces European Launch of Firefox OS Devices
-              </a>
-            </h3>
-          </li>
-        {% endl10n %}
-
-        </ul>
-        <p class="control"><a href="{{ press_blog_url() }}" class="go">{{ _('See all news') }}</a></p>
-      </section>
-
-    {% elif request.locale in ['hu','pt-BR'] %}
-
-      <section class="extra-contribute fxos">
-        <h2>{{ _('Get involved') }}</h2>
-        <p>
-        {% trans link_mobilizer=mobilizer_link %}
-          Help launch Firefox OS in your country.
-          <a href="{{ link_mobilizer }}">Become a Mobilizer today</a>.
-        {% endtrans %}
-        </p>
-      </section>
-
-    {% elif has_contribute %}
-
-      <section class="extra-contribute volunteer">
-        <h2>{{ _('Get involved') }}</h2>
-        <p>
-        {{ _('You don’t have to know how to code to get involved with Mozilla. <a href="%s">Learn more about our volunteer opportunities</a>.') | format(url('mozorg.contribute')) }}
-        </p>
-      </section>
-
-    {% else %}
-
-      <section class="extra-contribute locale">
-        <h2>{{ _('Get involved') }}</h2>
-        <p>
-        {% trans link_l10n='https://l10n.mozilla.org' %}
-          Thanks to our global community, Mozilla products and websites are available in over 70 languages.
-          <a href="{{ link_l10n }}">Help translate them into yours</a>.
-        {% endtrans %}
-        </p>
-      </section>
-
-    {% endif %}
-
-    </div>
-  </section>
-
-</main>
+</div>
 
 {% endblock %}
-
-{% block email_form %}{% endblock %}

--- a/bedrock/mozorg/tests/test_views.py
+++ b/bedrock/mozorg/tests/test_views.py
@@ -13,7 +13,7 @@ from captcha.fields import ReCaptchaField
 from funfactory.urlresolvers import reverse
 from jinja2.exceptions import TemplateNotFound
 from requests.exceptions import Timeout
-from mock import Mock, patch
+from mock import ANY, Mock, patch
 from nose.tools import assert_false, eq_, ok_
 from pyquery import PyQuery as pq
 
@@ -30,6 +30,37 @@ class TestHome(TestCase):
     def setUp(self):
         self.view = views.HomeTestView.as_view()
         self.rf = RequestFactory()
+
+    def _test_view_template(self, resp_mock, template, qs=None, locale='en-US'):
+        args = ['/en-US/']
+        if qs is not None:
+            args.append(qs)
+        req = self.rf.get(*args)
+        req.locale = locale
+        self.view(req)
+        resp_mock.assert_called_once_with(req, template, ANY)
+        resp_mock.reset_mock()
+
+    def test_uses_default_template(self, resp_mock):
+        """Home page should render the default template with no QS."""
+        self._test_view_template(resp_mock, 'mozorg/home.html')
+
+    def test_uses_default_template_other_qs(self, resp_mock):
+        """Home page should render the default template with wrong QS."""
+        self._test_view_template(resp_mock, 'mozorg/home.html', {'a': 1})
+        self._test_view_template(resp_mock, 'mozorg/home.html', {'v': 42})
+        self._test_view_template(resp_mock, 'mozorg/home.html', {'v': 'Abide'})
+        self._test_view_template(resp_mock, 'mozorg/home.html', {'v': '1234'})
+
+    def test_uses_test_template(self, resp_mock):
+        """Home page should render the test template with the right QS."""
+        self._test_view_template(resp_mock, 'mozorg/home-b1.html', {'v': 1})
+        self._test_view_template(resp_mock, 'mozorg/home-b2.html', {'v': 2})
+
+    def test_uses_new_template_for_other_locales(self, resp_mock):
+        """Should render the new template for locales not in test."""
+        self._test_view_template(resp_mock, 'mozorg/home-b2.html', locale='xx')
+        self._test_view_template(resp_mock, 'mozorg/home-b2.html', {'v': 2}, locale='xx')
 
     @override_settings(MOBILIZER_LOCALE_LINK={'es-ES': 'El Dudarino', 'de': 'Herr Dude'})
     def test_gets_right_mobilizer_url(self, resp_mock):

--- a/bedrock/mozorg/views.py
+++ b/bedrock/mozorg/views.py
@@ -229,8 +229,8 @@ class Robots(TemplateView):
 
 
 class HomeTestView(TemplateView):
-    """Home page view."""
-    template_name = 'mozorg/home.html'
+    """Home page view that will use a different template for a QS."""
+    old_home_locales = ['en-US']
 
     def get_context_data(self, **kwargs):
         ctx = super(HomeTestView, self).get_context_data(**kwargs)
@@ -240,6 +240,20 @@ class HomeTestView(TemplateView):
         locale = locale if locale in settings.MOBILIZER_LOCALE_LINK else 'en-US'
         ctx['mobilizer_link'] = settings.MOBILIZER_LOCALE_LINK[locale]
         return ctx
+
+    def get_template_names(self):
+        locale = l10n_utils.get_locale(self.request)
+        if locale in self.old_home_locales:
+            version = self.request.GET.get('v', 0)
+            if version == '1':
+                template = 'mozorg/home-b1.html'
+            elif version == '2':
+                template = 'mozorg/home-b2.html'
+            else:
+                template = 'mozorg/home.html'
+        else:
+            template = 'mozorg/home-b2.html'
+        return template
 
     def render_to_response(self, context, **response_kwargs):
         return l10n_utils.render(self.request,

--- a/lib/l10n_utils/__init__.py
+++ b/lib/l10n_utils/__init__.py
@@ -26,8 +26,6 @@ def render(request, template, context=None, **kwargs):
     if present, otherwise, it'll render the specified (en-US) template.
     """
     context = {} if context is None else context
-    if isinstance(template, list):
-        template = template[0]
 
     # Every template gets its own .lang file, so figure out what it is
     # and pass it in the context


### PR DESCRIPTION
We're continuing the 80/10/10 split while we work on some further design options before going 100% with the new home page.

This restores the relevant files to the state they were in before fbc1b89709 but doesn't rewrite history the way a git revert does.
