### PR TITLE
Fix Bug 929141 - disable collectstatic on demo1

### DIFF
--- a/bin/update/deploy-demo1.py
+++ b/bin/update/deploy-demo1.py
@@ -34,7 +34,8 @@ def update_locales(ctx):
 @task
 def update_assets(ctx):
     with ctx.lcd(settings.SRC_DIR):
-        ctx.local("LANG=en_US.UTF-8 python2.6 manage.py collectstatic --noinput")
+        # uncomment the line below only if on a branch that uses staticfiles
+        #ctx.local("LANG=en_US.UTF-8 python2.6 manage.py collectstatic --noinput")
         ctx.local("LANG=en_US.UTF-8 python2.6 manage.py compress_assets")
         ctx.local("LANG=en_US.UTF-8 python2.6 manage.py update_product_details")
 


### PR DESCRIPTION
Disable collectstatic command in bin/update/deploy-demo1.py since we do not have staticfiles enabled in the main branch.
