### PR TITLE
Fix bug 912101 - version notes for Firefox OS 1.1

### DIFF
--- a/bedrock/firefox/templates/firefox/os/_notes_sidebar.html
+++ b/bedrock/firefox/templates/firefox/os/_notes_sidebar.html
@@ -1,0 +1,57 @@
+<section id="get-involved">
+  <h3>{{ _('Want to get involved?') }}</h3>
+  <p>
+  {% trans
+    nontech='https://support.mozilla.org/en-US/kb/how-contribute-firefox-os-even-if-youre-not-techni' %}
+    Firefox OS is an open web  platform and there are plenty of opportunities to contribute
+    in both technical and <a href="{{ nontech }}" rel="external">non-technical</a> areas.
+  {% endtrans %}
+  </p>
+  <p><a href="{{ url('mozorg.contribute') }}" class="button go">{{ _('Learn more') }}</a></p>
+
+</section>
+
+<section id="developers">
+  <h3>{{ _('Develop for Firefox OS') }}</h3>
+  <ul>
+    <li><a href="https://marketplace.firefox.com/developers/" rel="external" class="go">{{ _('Start here') }}</a></li>
+    <li><a href="https://developer.mozilla.org/docs/Mozilla/Firefox_OS" rel="external">{{ _('All the docs') }}</a></li>
+    <li>
+    {% trans
+      sim1='https://addons.mozilla.org/en-US/firefox/addon/firefox-os-simulator/',
+      sim2='http://people.mozilla.org/~myk/r2d2b2g/' %}
+      Firefox OS Simulators: <a href="{{ sim1 }}" rel="external">One</a>
+      and <a href="{{ sim2 }}" rel="external">Two</a>
+    {% endtrans %}
+    </li>
+    <li><a href="https://developer.mozilla.org/en-US/docs/Mozilla/Firefox_OS/Building_and_installing_Firefox_OS">{{ _('Build & Install Firefox OS') }}</a></li>
+    <li>
+    {% trans gaiacode='https://github.com/mozilla-b2g/gaia/',
+      geckocode='https://github.com/mozilla/mozilla-central/tree/master/b2g' %}
+      Get the code: <a href="{{ gaiacode }}" rel="external">Gaia</a>
+      and <a href="{{ geckocode }}" rel="external">Gecko</a>
+    {% endtrans %}
+    </li>
+    <li><a href="https://bugzilla.mozilla.org/buglist.cgi?list_id=6785406&resolution=---&query_format=advanced&bug_status=UNCONFIRMED&bug_status=NEW&bug_status=REOPENED&product=Boot2Gecko" rel="external">{{ _('Known Bugs') }}</a></li>
+  </ul>
+</section>
+
+<section id="version">
+  <h3>{{ _('How do the version numbers work?') }}</h3>
+  <p>
+  {% trans %}
+    Firefox OS has a 4 digit version number: <samp>X.X.X.Y</samp>.
+    The first 2 digits are owned by the Mozilla product team and will denote versions
+    with new features (eg: v1.1, 1.2, etc). The third digit will be incremented with
+    regular version tags (~every 6 weeks) for security updates, and the fourth will
+    be OEM owned.
+  {% endtrans %}
+  </p>
+</section>
+
+<section id="other">
+  <h3>{{ _('Other Resources') }}</h3>
+  <ul>
+    <li><a href="{{ url('firefox.partners.index') }}" class="go">{{ _('Partner Information') }}</a></li>
+  </ul>
+</section>

--- a/bedrock/firefox/templates/firefox/os/notes-1.0.1.html
+++ b/bedrock/firefox/templates/firefox/os/notes-1.0.1.html
@@ -5,7 +5,7 @@
 {% extends "firefox/fxos-base.html" %}
 
 {% block page_title_prefix %}{% endblock %}
-{% block page_title %}{{_('Firefox OS — Notes')}}{% endblock %}
+{% block page_title %}{{_('Firefox OS — 1.0.1 Notes')}}{% endblock %}
 
 {% block body_id %}notes{% endblock %}
 {% block body_class %}fxos-notes sky{% endblock %}
@@ -51,8 +51,8 @@
       <h3>{{ _('Features') }}</h3>
       <p>
       {% trans %}
-        Welcome to the first release version of the Firefox OS mobile operating system. 
-        This version contains many core applications required for a smart phone but 
+        Welcome to the first release version of the Firefox OS mobile operating system.
+        This version contains many core applications required for a smart phone but
         also some features that highlight the benefits and uniqueness of our open web
         platform offering.
       {% endtrans %}
@@ -300,63 +300,7 @@
 
   <aside id="sidebar" class="sidebar">
 
-    <section id="get-involved">
-      <h3>{{ _('Want to get involved?') }}</h3>
-      <p>
-      {% trans
-        nontech='https://support.mozilla.org/en-US/kb/how-contribute-firefox-os-even-if-youre-not-techni' %}
-        Firefox OS is an open web  platform and there are plenty of opportunities to contribute
-        in both technical and <a href="{{ nontech }}" rel="external">non-technical</a> areas.
-      {% endtrans %}
-      </p>
-      <p><a href="{{ url('mozorg.contribute') }}" class="button go">{{ _('Learn more') }}</a></p>
-
-    </section>
-
-    <section id="developers">
-      <h3>{{ _('Develop for Firefox OS') }}</h3>
-      <ul>
-        <li><a href="https://marketplace.firefox.com/developers/" rel="external" class="go">{{ _('Start here') }}</a></li>
-        <li><a href="https://developer.mozilla.org/docs/Mozilla/Firefox_OS" rel="external">{{ _('All the docs') }}</a></li>
-        <li>
-        {% trans
-          sim1='https://addons.mozilla.org/en-US/firefox/addon/firefox-os-simulator/',
-          sim2='http://people.mozilla.org/~myk/r2d2b2g/' %}
-          Firefox OS Simulators: <a href="{{ sim1 }}" rel="external">One</a>
-          and <a href="{{ sim2 }}" rel="external">Two</a>
-        {% endtrans %}
-        </li>
-        <li><a href="https://developer.mozilla.org/en-US/docs/Mozilla/Firefox_OS/Building_and_installing_Firefox_OS">{{ _('Build & Install Firefox OS') }}</a></li>
-        <li>
-        {% trans gaiacode='https://github.com/mozilla-b2g/gaia/',
-          geckocode='https://github.com/mozilla/mozilla-central/tree/master/b2g' %}
-          Get the code: <a href="{{ gaiacode }}" rel="external">Gaia</a>
-          and <a href="{{ geckocode }}" rel="external">Gecko</a>
-        {% endtrans %}
-        </li>
-        <li><a href="https://bugzilla.mozilla.org/buglist.cgi?list_id=6785406&resolution=---&query_format=advanced&bug_status=UNCONFIRMED&bug_status=NEW&bug_status=REOPENED&product=Boot2Gecko" rel="external">{{ _('Known Bugs') }}</a></li>
-      </ul>
-    </section>
-
-    <section id="version">
-      <h3>{{ _('How do the version numbers work?') }}</h3>
-      <p>
-      {% trans %}
-        Firefox OS has a 4 digit version number: <samp>X.X.X.Y</samp>.
-        The first 2 digits are owned by the Mozilla product team and will denote versions
-        with new features (eg: v1.1, 1.2, etc). The third digit will be incremented with
-        regular version tags (~every 6 weeks) for security updates, and the fourth will
-        be OEM owned.
-      {% endtrans %}
-      </p>
-    </section>
-
-    <section id="other">
-      <h3>{{ _('Other Resources') }}</h3>
-      <ul>
-        <li><a href="{{ url('firefox.partners.index') }}" class="go">{{ _('Partner Information') }}</a></li>
-      </ul>
-    </section>
+    {% include 'firefox/os/_notes_sidebar.html' %}
 
   </aside>
 

--- a/bedrock/firefox/templates/firefox/os/notes-1.1.html
+++ b/bedrock/firefox/templates/firefox/os/notes-1.1.html
@@ -1,0 +1,122 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. #}
+
+{% extends "firefox/fxos-base.html" %}
+
+{% block page_title_prefix %}{% endblock %}
+{% block page_title %}{{_('Firefox OS — 1.1 Notes')}}{% endblock %}
+
+{% block body_id %}notes{% endblock %}
+{% block body_class %}fxos-notes sky{% endblock %}
+
+
+{% block site_css %}
+  {{ css('firefox_releasenotes') }}
+{% endblock %}
+
+{% block extrahead %}
+{% endblock %}
+
+{% block content %}
+  <header id="main-feature">
+    <h1>{{ _('Firefox OS 1.1 Notes') }}</h1>
+
+    <h2>{{ _('First offered to partners for release on October 21, 2013') }}</h2>
+
+    <p>
+    {% trans feedback='https://input.mozilla.org/feedback',
+        bugzilla='https://bugzilla.mozilla.org/' %}
+      As always, you&#146;re encouraged to
+      <a href="{{ feedback }}">tell us what you think</a>,
+      or <a href="{{ bugzilla }}">file a bug in Bugzilla</a>.
+    {% endtrans %}
+    </p>
+  </header>
+
+<div id="main-content">
+  <article class="main-column">
+
+    <section class="notes-section" id="features">
+      <h3>{{ _('New Features') }}</h3>
+      <ul class="section-items">
+        <li>{{ _('Multimedia Messaging (MMS) support added to the messaging app so that you can send pictures, video, and audio to contacts, or a text message to multiple people at the same time.') }}</li>
+        <li>{{ _('Saving images, video, and audio from the browser is now supported.') }}</li>
+        <li>{{ _('Email account contacts can now be imported from Gmail and Windows Live Mail (Outlook).') }}</li>
+        <li>{{ _('Email image, audio and video attachment download has been implemented.') }}</li>
+        <li>{{ _('Attaching and sending Gallery images now supported.') }}</li>
+        <li>{{ _('Email draft mode has been implemented.') }}</li>
+        <li>{{ _('Improvements to the dialer and contacts, such as easily adding a dialed number to an existing contact and dialer suggestions to easily find contacts.') }}</li>
+        <li>{{ _('Cell Broadcast  implemented for simultaneous delivery of emergency messages to subscribed users.') }}</li>
+        <li>{{ _('Major performance improvements around application launch time and scrolling.') }}</li>
+        <li>{{ _('<b>Music</b> search to find music by artist, album or song title.') }}</li>
+        <li>{{ _('Firefox OS offers <b>Calendar</b> features such as:') }}
+          <ul>
+            <li>{{ _('Separate detail and edit views.') }}</li>
+            <li>{{ _('Alarm sound notification selection.') }}</li>
+            <li>{{ _('Direct event creation at specific date/time.') }}</li>
+          </ul>
+        </li>
+        <li>{{ _('<b>Push Notifications API</b>: Developers can make use of push to deliver timely notifications to apps and reduce overall battery consumption.') }}</li>
+      </ul>
+    </section>
+
+    <section class="notes-section" id="fixed">
+      <h3>{{ _('Fixed Issues') }}</h3>
+      <ul class="section-items">
+        <li><a href="https://bugzilla.mozilla.org/show_bug.cgi?id=817972">817972</a>: {{ _('[Bluetooth][File-Transfer] Support multiple files transferring.') }}</li>
+        <li><a href="https://bugzilla.mozilla.org/show_bug.cgi?id=834672">834672</a>: {{ _('AppProtocolHandler.js should never throw.') }}</li>
+        <li><a href="https://bugzilla.mozilla.org/show_bug.cgi?id=839500">839500</a>: {{ _('Gaia‘s identity.js opens a browser process that‘s stuck in the foreground. Therefore, if you open the marketplace app, you lose ~10% of available app memory until you reboot the phone.') }}
+        <li>{{ _('Memory fix for Persona logins.') }}</li>
+        <li><a href="https://bugzilla.mozilla.org/show_bug.cgi?id=834773">834773</a>: {{ _('Using the pick activity and confirming an image for the gallery — app gets hung with no perceived perf for 5–10 seconds') }}</li>
+        <li><a href="http://mzl.la/1bqXGXS">{{ _('Resolved crashes.') }}</a></li>
+      </ul>
+    </section>
+
+    <section class="notes-section" id="webapis">
+      <h3>{{ _('Web APIs') }}</h3>
+      <ul class="section-items">
+        <li>{{ _('MMS and MobileMessage-related') }}</li>
+        <li>{{ _('SimplePush') }}</li>
+        <li>{{ _('WAP Push') }}</li>
+      </ul>
+    </section>
+
+    <section class="notes-section" id="locales">
+      <h3>{{ _('Supported Locales') }}</h3>
+      <ul class="section-items">
+        <li>{{ _('Catalan') }}</li>
+        <li>{{ _('Croatian') }}</li>
+        <li>{{ _('Czech') }}</li>
+        <li>{{ _('Dutch') }}</li>
+        <li>{{ _('English (US)') }}</li>
+        <li>{{ _('German') }}</li>
+        <li>{{ _('Greek') }}</li>
+        <li>{{ _('Hungarian') }}</li>
+        <li>{{ _('Italian') }}</li>
+        <li>{{ _('Polish') }}</li>
+        <li>{{ _('Portugese (Brazil)') }}</li>
+        <li>{{ _('Romanian') }}</li>
+        <li>{{ _('Russian') }}</li>
+        <li>{{ _('Serbian') }}</li>
+        <li>{{ _('Slovak') }}</li>
+        <li>{{ _('Spanish (neutral)') }}</li>
+        <li>{{ _('Turkish') }}</li>
+      </ul>
+    </section>
+
+  </article>
+
+
+  <aside id="sidebar" class="sidebar">
+
+    {% include 'firefox/os/_notes_sidebar.html' %}
+
+  </aside>
+
+</div>
+{% endblock %}
+
+{% block js %}
+
+{% endblock  %}

--- a/bedrock/firefox/urls.py
+++ b/bedrock/firefox/urls.py
@@ -68,5 +68,8 @@ urlpatterns = patterns('',
     url('^firefox/$', views.fx_home_redirect, name='firefox'),
 
     page('firefox/os', 'firefox/os/index.html'),
-    page('firefox/os/notes/1.0.1', 'firefox/os/releasenotes.html'),
+
+    # firefox/os/notes/ should redirect to the latest version; update this in /redirects/urls.py
+    page('firefox/os/notes/1.0.1', 'firefox/os/notes-1.0.1.html'),
+    page('firefox/os/notes/1.1', 'firefox/os/notes-1.1.html'),
 )

--- a/bedrock/redirects/urls.py
+++ b/bedrock/redirects/urls.py
@@ -76,7 +76,7 @@ urlpatterns = patterns('',
     # Bug 867773 - Redirect the Persona "Developer FAQ" link to MDN
     redirect(r'^persona/developer-faq/$', 'https://developer.mozilla.org/persona'),
 
-    # Bug 869495 - For now we'll hard-code a redirect to 1.0.1
+    # Bug 912101 - For now we'll hard-code a redirect to 1.1
     # In the future this should automatically go to the latest version's notes
-    redirect(r'^firefox/os/notes/$', '/firefox/os/notes/1.0.1/'),
+    redirect(r'^firefox/os/notes/$', '/firefox/os/notes/1.1/'),
 )

--- a/etc/httpd/global.conf
+++ b/etc/httpd/global.conf
@@ -389,6 +389,8 @@ RewriteRule ^projects/mathml/screenshots(?:/(?:index.html)?)?$ https://developer
 
 # bug 869495
 RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/os/releasenotes/1.0.1(.*)$ /b/$1firefox/os/releasenotes/1.0.1$2 [PT]
+# bug 912101
+RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/os/releasenotes/1.1(.*)$ /b/$1firefox/os/releasenotes/1.1$2 [PT]
 
 # bug 858315
 RewriteRule ^/projects/devpreview/firstrun(?:/(?:index.html)?)?$ /firefox/firstrun/ [L,R=301]


### PR DESCRIPTION
This also renames the templates in a more future-friendly naming scheme, though hopefully future automated publishing will replace this anyway.

I'll be out of office Thursday and release engineering wants to get this live as soon as possible, so I'm closing PR #1337 and opening this one from the equivalent branch in the moz repo instead of from my own fork, so someone else can make edits without me if needed.

Preeti Raghunath is the releng point of contact for content questions (preeti on IRC).
