### PR TITLE
[bug 926629] Add /b/ redirects for lightbeam page urls

### DIFF
--- a/etc/httpd/global.conf
+++ b/etc/httpd/global.conf
@@ -439,3 +439,6 @@ RewriteRule ^/firefox/mobile/platforms?$ https://support.mozilla.org/kb/will-fir
 
 # bug 924687
 RewriteRule ^/en-US/opportunities(?:/(?:index.html)?)?$ https://careers.mozilla.org/ [L,R=301]
+
+# bug 926629
+RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?lightbeam(/?.*)$ /b/$1lightbeam$2 [PT]


### PR DESCRIPTION
Note: this PR doesn't address redirecting any of the old collusion pages, it just adds the `/b/` redirects for the new `/lightbeam` pages (which aren't included in PR #1332).
