### PR TITLE
Bug 931184 - Add page image and descriptions to the Lightbeam landing pages

### DIFF
--- a/bedrock/lightbeam/templates/lightbeam/about.html
+++ b/bedrock/lightbeam/templates/lightbeam/about.html
@@ -6,8 +6,10 @@
 {% extends "base-resp.html" %}
 
 {% block page_title %}{{_('Lightbeam for Firefox')}}{% endblock %}
+{% block page_desc %}{{_('Lightbeam visualizes the relationships between the sites you visit and the third party sites that are active on those pages.')}}{% endblock %}
 {% block body_id %}lightbeam{% endblock %}
 {% block body_class %}sky about{% endblock %}
+{% block page_image %}{{ media('img/lightbeam/lightbeam_logo-wordmark_500x156.png') }}{% endblock %}
 {% block page_favicon %}{{ media('img/lightbeam/favicon.png') }}{% endblock %}
 {% block site_header_logo %}
   <h2><a href="{{ url('lightbeam.lightbeam') }}"><img src="{{ media('img/lightbeam/lightbeam_logo-wordmark_500x156.png') }}" class="ligthbeam-wordmark"></a></h2>

--- a/bedrock/lightbeam/templates/lightbeam/database.html
+++ b/bedrock/lightbeam/templates/lightbeam/database.html
@@ -6,8 +6,10 @@
 {% extends "base-resp.html" %}
 
 {% block page_title %}{{_('Lightbeam for Firefox')}}{% endblock %}
+{% block page_desc %}{{_('The data that you contribute to Lightbeam helps us generate a larger understanding of how we collectively interact in the online space.')}}{% endblock %}
 {% block body_id %}lightbeam{% endblock %}
 {% block body_class %}sky database{% endblock %}
+{% block page_image %}{{ media('img/lightbeam/lightbeam_logo-wordmark_500x156.png') }}{% endblock %}
 {% block page_favicon %}{{ media('img/lightbeam/favicon.png') }}{% endblock %}
 {% block site_header_logo %}
   <h2><a href="{{ url('lightbeam.lightbeam') }}"><img src="{{ media('img/lightbeam/lightbeam_logo-wordmark_500x156.png') }}" class="ligthbeam-wordmark"></a></h2>

--- a/bedrock/lightbeam/templates/lightbeam/lightbeam.html
+++ b/bedrock/lightbeam/templates/lightbeam/lightbeam.html
@@ -5,8 +5,10 @@
 {% extends "base-resp.html" %}
 
 {% block page_title %}{{_('Lightbeam for Firefox')}}{% endblock %}
+{% block page_desc %}{{_('Lightbeam is a Firefox add-on that uses interactive visualizations to show you the first and third party sites you interact with on the Web.')}}{% endblock %}
 {% block body_id %}lightbeam{% endblock %}
 {% block body_class %}sky lightbeam-home{% endblock %}
+{% block page_image %}{{ media('img/lightbeam/lightbeam_logo-wordmark_500x156.png') }}{% endblock %}
 {% block page_favicon %}{{ media('img/lightbeam/favicon.png') }}{% endblock %}
 {% block site_header_logo %}
   <h2><a href="{{ url('lightbeam.lightbeam') }}"><img src="{{ media('img/lightbeam/lightbeam_logo-wordmark_500x156.png') }}" class="ligthbeam-wordmark"></a></h2>

--- a/bedrock/lightbeam/templates/lightbeam/profile.html
+++ b/bedrock/lightbeam/templates/lightbeam/profile.html
@@ -8,6 +8,7 @@
 {% block page_title %}{{_('Lightbeam for Firefox')}}{% endblock %}
 {% block body_id %}lightbeam{% endblock %}
 {% block body_class %}sky profile{% endblock %}
+{% block page_image %}{{ media('img/lightbeam/lightbeam_logo-wordmark_500x156.png') }}{% endblock %}
 {% block page_favicon %}{{ media('img/lightbeam/favicon.png') }}{% endblock %}
 {% block site_header_logo %}
   <h2><a href="{{ url('lightbeam.lightbeam') }}"><img src="{{ media('img/lightbeam/lightbeam_logo-wordmark_500x156.png') }}" class="ligthbeam-wordmark"></a></h2>


### PR DESCRIPTION
Reuse the pages' first paragraph as the descriptions. The page image can be the same as the page header image.
