### PR TITLE
fix bug 931634 - "Ligthbeam" typo

### DIFF
--- a/bedrock/lightbeam/templates/lightbeam/lightbeam.html
+++ b/bedrock/lightbeam/templates/lightbeam/lightbeam.html
@@ -4,7 +4,7 @@
 
 {% extends "base-resp.html" %}
 
-{% block page_title %}Ligthbeam for Firefox{% endblock %}
+{% block page_title %}Lightbeam for Firefox{% endblock %}
 {% block body_id %}lightbeam{% endblock %}
 {% block body_class %}sky lightbeam-home{% endblock %}
 {% block page_favicon %}{{ media('img/lightbeam/favicon.png') }}{% endblock %}


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=931634
