### PR TITLE
Bug 931932 - Please create version notes index for Firefox OS similar to desktop

### DIFF
--- a/bedrock/firefox/templates/firefox/os/releases.html
+++ b/bedrock/firefox/templates/firefox/os/releases.html
@@ -1,0 +1,39 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. #}
+
+{% extends "firefox/fxos-base.html" %}
+
+{% block page_title %}{{_('Release Notes')}}{% endblock %}
+{% block body_id %}firefox-os-releases-index{% endblock %}
+
+{% block site_css %}
+  {{ css('firefox_releases_index') }}
+{% endblock %}
+
+{% block breadcrumbs %}
+  <nav class="breadcrumbs">
+    <a href="{{ url('mozorg.home') }}">{{ _('Home') }}</a> &gt;
+    <a href="{{ url('firefox.new') }}">{{ _('Firefox') }}</a> &gt;
+    <a href="{{ url('firefox.os.index') }}">{{ _('Firefox OS') }}</a> &gt;
+    <span>{{ _('Release Notes') }}</span>
+  </nav>
+{% endblock %}
+
+{% block content %}
+  <div id="main-feature">
+    <h1>{{ _('Firefox OS Releases') }}</h1>
+    <p>{{ _('Firefox OS release notes are specific to each version of the application. Select your version from the list below to see the release notes for it.') }}</p>
+  </div>
+
+  <div id="main-content">
+    <ol reversed>
+      <li>
+        <strong><a href="../notes/1.1/">1.1</a></strong>
+      </li>
+      <li>
+        <strong><a href="../notes/1.0.1/">1.0.1</a></strong>
+      </li>
+    </ol>
+  </div>
+{% endblock %}

--- a/bedrock/firefox/urls.py
+++ b/bedrock/firefox/urls.py
@@ -67,6 +67,7 @@ urlpatterns = patterns('',
     url('^firefox/$', views.fx_home_redirect, name='firefox'),
 
     page('firefox/os', 'firefox/os/index.html'),
+    page('firefox/os/releases', 'firefox/os/releases.html'),
 
     # firefox/os/notes/ should redirect to the latest version; update this in /redirects/urls.py
     page('firefox/os/notes/1.0.1', 'firefox/os/notes-1.0.1.html'),


### PR DESCRIPTION
Add a static index page to /firefox/os/releases/
