### PR TITLE
Fix bug 774675: Redirect /es/* to /es-ES/*

### DIFF
--- a/etc/httpd/global.conf
+++ b/etc/httpd/global.conf
@@ -4,6 +4,13 @@
 
 ExpiresActive on
 
+## Fix locales
+
+# bug 774675
+RewriteRule ^/en/(.*)$ /en-US/$1 [L,R=301]
+RewriteRule ^/es/(.*)$ /es-ES/$1 [L,R=301]
+RewriteRule ^/pt/(.*)$ /pt-BR/$1 [L,R=301]
+
 ## Redirect things externally!
 
 # bug 855734 - if request comes in with hostname that has a trailing ".", strip it off


### PR DESCRIPTION
Also:
- /en/ -> /en-US/
- /pt/ -> /pt-BR/
