### PR TITLE
Fix bug 876233: Redirect */about/participate/ -> /contribute/

### DIFF
--- a/etc/httpd/global.conf
+++ b/etc/httpd/global.conf
@@ -446,3 +446,6 @@ RewriteRule ^/en-US/opportunities(?:/(?:index.html)?)?$ https://careers.mozilla.
 
 # bug 926629
 RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?lightbeam(/?.*)$ /b/$1lightbeam$2 [PT]
+
+# bug 876233
+RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?about/participate/?$ /$1contribute/ [L,R=301]


### PR DESCRIPTION
Only question I have is whether we want to (as I did) use the
locale from the original url, or just send them to "/contribute/"
and let bedrock work out the best locale from their browser?

@pascalchevrel r?
