### PR TITLE
Bug 892470: add more plugincheck redirects

### DIFF
--- a/etc/httpd/global.conf
+++ b/etc/httpd/global.conf
@@ -83,7 +83,7 @@ RewriteRule ^(.*)index\.html$ $1 [L,R=301]
 ## Redirect things to django!
 
 # bug 797192, 892470
-RewriteRule ^/(en-US|af|an|ast|bg|bn-IN|br|ca|cs|csb|cy|da|de|el|eo|es-AR|es-CL|es-ES|es-MX|et|eu|fa|ff|fi|fr|fy-NL|ga-IE|gd|he|hi-IN|hr|hu|hy-AM|id|is|it|ja|ka|kk|ko|ku|lt|lv|mk|ml|mr|ms|nb-NO|nl|pa-IN|pl|pt-BR|pt-PT|rm|ro|ru|sk|sl|son|sq|sr|sv-SE|te|th|tr|uk|vi|zh-CN|zh-TW)/plugincheck(/?)$ /b/$1/plugincheck$2 [PT]
+RewriteRule ^/(en-US|af|ak|an|ast|bg|bn-IN|br|ca|cs|csb|cy|da|de|el|en-GB|eo|es-AR|es-CL|es-ES|es-MX|et|eu|fa|ff|fi|fr|fy-NL|ga-IE|gd|he|hi-IN|hr|hu|hy-AM|id|is|it|ja|ka|kk|ko|ku|lt|lv|mai|mk|ml|mr|ms|my|nb-NO|nl|nn-NO|nso|oc|pa-IN|pl|pt-BR|pt-PT|rm|ro|ru|sk|sl|son|sq|sr|sv-SE|sw|ta|ta-LK|te|th|tr|uk|ur|vi|wo|zh-CN|zh-TW)/plugincheck(/?)$ /b/$1/plugincheck$2 [PT]
 
 # bug 925551
 RewriteRule ^/en-US/plugincheck/more_info.html$ /plugincheck/ [L,R=301]


### PR DESCRIPTION
Have bedrock handle these locales which are deleted on svn:
ak, en-GB, mai, my, nn-NO, nso, oc, sw, ta, ta-LK, ur, wo

These locales won't get updated any time soon and some are not shipped, it's better to fallback to the bedrock en-US plugincheck page than the old mozilla.com one
