### PR TITLE
Bug 930031 - Link to Firefox OS color swatch

### DIFF
--- a/bedrock/styleguide/templates/styleguide/products/firefox-os/color.html
+++ b/bedrock/styleguide/templates/styleguide/products/firefox-os/color.html
@@ -257,7 +257,7 @@
 <section id="downloads">
   <div class="intro">
     <h2>Download</h2>
-    <p>You can download the Firefox OS Stencil PSD <a href="https://mozilla.box.com/s/5ucf52a98q1rd20eu5lm">here</a>.</p>
+    <p>You can download the <a href="https://mozilla.box.com/s/qnkab0371lqsftlxh42v">Photoshop swatches here</a>.</p>
   </div>
 </section>
 


### PR DESCRIPTION
Just a simple link/text swap for https://bugzilla.mozilla.org/show_bug.cgi?id=930031
