### PR TITLE
Bug 934807 - Change android download links from https:// to market:// for Android visitors only

### DIFF
--- a/bedrock/firefox/templates/firefox/fx.html
+++ b/bedrock/firefox/templates/firefox/fx.html
@@ -40,7 +40,7 @@
       </section>
       <ul class="sub-features">
         <li id="playstore-mobile">
-          <a class="mobile-link" href="https://market.android.com/details?id=org.mozilla.firefox">
+          <a class="mobile-link" href="https://play.google.com/store/apps/details?id=org.mozilla.firefox">
             <h3>Get Firefox for Android</h3>
             <span class="link">{{_('Get the mobile browser that\'s got your back for free from Google Play&nbsp;»')}}</span>
           </a>
@@ -93,7 +93,7 @@
           <li id="android-promo"><div class="wrap">
             <h4>{{ _('Get Firefox for Android')}}</h4><span class="icon"></span>
             <p>{{ _('Get the mobile browser that’s got your back free from the ') }}
-            <a href="https://market.android.com/details?id=org.mozilla.firefox">{{ _('Google Play Store&nbsp;»') }}</a></p>
+            <a href="https://play.google.com/store/apps/details?id=org.mozilla.firefox">{{ _('Google Play Store&nbsp;»') }}</a></p>
           </div></li>
         </ul>
       </section>
@@ -114,7 +114,7 @@
             <a class="link" href="{{ url('firefox.customize') }}">{{ _('Customize your Firefox with add-ons&nbsp;»') }}</a>
           </li>
           <li id="playstore">
-            <a class="link" href="https://market.android.com/details?id=org.mozilla.firefox">{{ _('Get Firefox for Android free from the Google Play Store&nbsp;»') }}</a>
+            <a class="link" href="https://play.google.com/store/apps/details?id=org.mozilla.firefox">{{ _('Get Firefox for Android free from the Google Play Store&nbsp;»') }}</a>
           </li>
         </ul>
       </section>

--- a/bedrock/firefox/templates/firefox/mobile/features.html
+++ b/bedrock/firefox/templates/firefox/mobile/features.html
@@ -55,7 +55,7 @@
     </section>
 
     <section id="get">
-      <p>{{_('Get Firefox for Android free from <a href="%s">Google Play</a>')|format('https://market.android.com/details?id=org.mozilla.firefox')}}</a></p>
+      <p>{{_('Get Firefox for Android free from <a href="%s">Google Play</a>')|format('https://play.google.com/store/apps/details?id=org.mozilla.firefox')}}</a></p>
     </section>
   </div>
 

--- a/bedrock/firefox/templates/firefox/partners/index.html
+++ b/bedrock/firefox/templates/firefox/partners/index.html
@@ -398,7 +398,7 @@
       <div class="article-content">
         <div class="intro tween">
           <h4>{{ _('A superior Web experience') }}</h4>
-          <a href="https://market.android.com/details?id=org.mozilla.firefox"><img src="{{ media('img/firefox/partners/google-play.png') }}" alt="{{ _('Get it on Google Play') }}" class="play" /></a>
+          <a href="https://play.google.com/store/apps/details?id=org.mozilla.firefox"><img src="{{ media('img/firefox/partners/google-play.png') }}" alt="{{ _('Get it on Google Play') }}" class="play" /></a>
           <p>{% trans url='class="view-section" data-section="android-partner" href="#"'|safe %}
             With high-performance, advanced cross-platform features and the latest in security, our top-rated browser offers an alternative to closed platforms, giving you the flexibility to design, distribute and charge as you see fit. <a {{ url }}>Learn more about partner opportunities.</a>
           {% endtrans %}</p>

--- a/bedrock/mozorg/templates/mozorg/mobile.html
+++ b/bedrock/mozorg/templates/mozorg/mobile.html
@@ -58,7 +58,7 @@
       and a redesigned look and feel.</p>
 
       <p><a class="go" href="/en-US/firefox/mobile/features">Learn more about Firefox for Android</a>
-      <br><a class="go" href="https://market.android.com/details?id=org.mozilla.firefox">Get Firefox for Android at the Google Play Store</a></p>
+      <br><a class="go" href="https://play.google.com/store/apps/details?id=org.mozilla.firefox">Get Firefox for Android at the Google Play Store</a></p>
     </section>
 
     <section id="marketplace">

--- a/media/js/base/global.js
+++ b/media/js/base/global.js
@@ -32,6 +32,17 @@ function init_download_links() {
     $('.download-list').attr('role', 'presentation');
 }
 
+// Replace Google Play links on Android devices to let them open
+// the native Play Store app
+function init_android_download_links() {
+    if (site.platform === 'android') {
+        $('a[href^="https://play.google.com/store/apps/"]').each(function() {
+            $(this).attr('href', $(this).attr('href')
+                .replace('https://play.google.com/store/apps/', 'market://'));
+        });
+    }
+}
+
 // language switcher
 
 function init_lang_switcher() {
@@ -90,6 +101,7 @@ function init_platform_imgs() {
 
 $(document).ready(function() {
     init_download_links();
+    init_android_download_links();
     init_lang_switcher();
     $(window).on('load', function () {
         $('html').addClass('loaded');

--- a/media/js/test/spec/global.js
+++ b/media/js/test/spec/global.js
@@ -56,6 +56,30 @@ describe("global.js", function() {
 
   });
 
+  describe("init_android_download_links", function () {
+
+    beforeEach(function () {
+      // Pretend we're on Android
+      window.site = {
+        platform: 'android'
+      };
+      //create an HTML fixture to test against
+      $('<a class="download-link" href="https://play.google.com/store/apps/details?id=org.mozilla.firefox">foo</a>').appendTo('body');
+    });
+
+    afterEach(function(){
+      // Tidy up after each test
+      window.site = null;
+      $('.download-link').remove();
+    });
+
+    it("should set a URL with the market scheme", function () {
+      init_android_download_links();
+      expect($('.download-link').attr('href')).toEqual('market://details?id=org.mozilla.firefox');
+    });
+
+  });
+
   describe("init_platform_imgs", function () {
 
     beforeEach(function () {


### PR DESCRIPTION
- Replace links with the new `init_android_download_links` function
- Update the outdated Android Market links
