### PR TITLE
Bug 925278 : firefox/channel page redirects for locales

### DIFF
--- a/etc/httpd/global.conf
+++ b/etc/httpd/global.conf
@@ -172,7 +172,7 @@ RewriteRule ^/en-US/firefox/releases(/?)$ /b/en-US/firefox/releases$1 [PT]
 
 # Bug 925278
 # TODO: Remove when all locales are done.
-RewriteRule ^/(ca|cs|de|es-MX|fr|he|sk|sl)/firefox/channel(/?)$ /b/$1/firefox/channel$2 [PT]
+RewriteRule ^/(ca|cs|da|de|el|eo|es-AR|es-ES|es-MX|fr|he|is|it|pt-BR|sk|sl|sq|sv-SE|tr|zh-TW)/firefox/channel(/?)$ /b/$1/firefox/channel$2 [PT]
 
 # bug 929775
 RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/update(.*)?$ /$1firefox/new/ [L,R=301]


### PR DESCRIPTION
locales added: da, el, eo, es-AR, es-ES, is, it, pt-BR, sq, sv-SE, tr, zh-TW
