### PR TITLE
Bug 884933 follow-up: fix 404 at /firefox/mobile/platforms/ and update a link in the FAQ

### DIFF
--- a/bedrock/firefox/templates/firefox/mobile/faq.html
+++ b/bedrock/firefox/templates/firefox/mobile/faq.html
@@ -60,7 +60,7 @@
         {% trans %}
           <dt>Is Firefox available for my platform or device?</dt>
           <dd>Firefox for Android works with Android phones version 2.2 (Froyo)
-          and above. <a href="/firefox/mobile/platforms">Visit our list of supported platforms and devices</a>.</dd>
+          and above. <a href="https://support.mozilla.org/kb/will-firefox-work-my-mobile-device">Visit our list of supported platforms and devices</a>.</dd>
         {% endtrans %}
 
         {% trans %}

--- a/etc/httpd/global.conf
+++ b/etc/httpd/global.conf
@@ -202,7 +202,6 @@ RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/mobile/faq/?$ /$1firefox/os/faq/? [L
 RewriteRule ^/en-US/mobile(/?)$ /b/en-US/mobile$1 [PT]
 RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/mobile/features(/?)$ /b/$1firefox/mobile/features$2 [PT]
 RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/mobile/faq(/?)$ /b/$1firefox/mobile/faq$2 [PT]
-RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/mobile/platforms(/?)$ /b/$1firefox/mobile/platforms$2 [PT]
 
 # bug 876668
 RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?mobile/customize(?:/.*)?$ /$1firefox/mobile/features/ [L,R=301]


### PR DESCRIPTION
The link is in a `trans` block but it's safe to be updated as the FAQ is not localized yet.
