### PR TITLE
Bug 935877 - Locales with latest version of home page shown

### DIFF
--- a/bedrock/mozorg/templates/mozorg/home-b2.html
+++ b/bedrock/mozorg/templates/mozorg/home-b2.html
@@ -58,7 +58,7 @@
   <section class="pillars">
     <ul class="accordion">
 
-    {% if request.locale in ['en-US','en-GB'] or settings.DEV %}
+    {% if request.locale in settings.LOCALES_WITH_LATEST_HOME or settings.DEV %}
       <li id="panel-lightbeam" class="panel" tabindex="0">
         {# L10n: The active word should be wrapped in <i></i> tags, though it may appear at a different position in the translated title. #}
         <h2 class="panel-title">{{ _('<i>Watch</i> the watchers') }}</h2>
@@ -117,7 +117,7 @@
         </div>
       </li>
 
-    {% if request.locale in ['en-US','en-GB'] or settings.DEV %}
+    {% if request.locale in settings.LOCALES_WITH_LATEST_HOME or settings.DEV %}
       <li id="panel-webmaker" class="panel" tabindex="0">
         {# L10n: The active word should be wrapped in <i></i> tags, though it may appear at a different position in the translated title. #}
         <h2 class="panel-title">{{ _('<i>Learn</i> the Web') }}</h2>

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -741,6 +741,11 @@ LOCALES_WITH_MOZ15 = ['bg', 'cs', 'de', 'el', 'en-GB', 'en-US', 'es-AR', 'es-CL'
                       'ms', 'nl', 'pl', 'pt-BR', 'ro', 'ru', 'sl', 'sq', 'sr',
                       'ta', 'tr', 'zh-CN', 'zh-TW']
 
+# Locales with the latest banners on home page
+LOCALES_WITH_LATEST_HOME = ['en-GB', 'en-US', 'en-ZA', 'de', 'el', 'es-AR',
+                            'fr', 'hy-AM', 'is', 'it', 'ko', 'pt-BR', 'sq',
+                            'sv-SE', 'tr', 'zh-TW']
+
 # reCAPTCHA keys
 RECAPTCHA_PUBLIC_KEY = ''
 RECAPTCHA_PRIVATE_KEY = ''


### PR DESCRIPTION
- new LOCALES_WITH_LATEST_HOME constant in base.py
- used in home-b2.html only (home page used by locales)
- activate these locales: 'de', 'el', 'es-AR', 'fr', 'hy-AM', 'is', 'it', 'ko', 'pt-BR', 'sq', 'sv-SE', 'tr', 'zh-TW'
