### PR TITLE
Bug 857179 - /b/ redirect for http://www.mozilla.org/en-US/privacy/policies/archive/firefox-mobile-september-2009/

### DIFF
--- a/etc/httpd/global.conf
+++ b/etc/httpd/global.conf
@@ -256,6 +256,10 @@ RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/brand(.*)$ /b/$1firefox/brand$2 [PT]
 # bug 800649
 RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?privacy/policies/facebook(.*)$ /b/$1privacy/policies/facebook$2 [PT]
 
+# bug 857179
+RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?privacy/policies/archive/(.*)$ /b/$privacy/policies/archive/$2 [PT]
+
+
 # bug 820212
 RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?privacy/firefox-os/?$ /$1privacy/policies/firefox-os/ [L,R=301]
 RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?privacy/policies/firefox-os(.*)$ /b/$1privacy/policies/firefox-os$2 [PT]


### PR DESCRIPTION
Bug 857179 -  /b/ redirect should be set for http://www.mozilla.org/en-US/privacy/policies/archive/firefox-mobile-september-2009/
