### PR TITLE
Bug 768435 - Link Mozilla Firefox logo on new [Bedrock] Firefox pages

### DIFF
--- a/bedrock/firefox/templates/firefox/base-resp.html
+++ b/bedrock/firefox/templates/firefox/base-resp.html
@@ -80,7 +80,7 @@
 {% endblock %}
 
 {% block site_header_logo %}
-<h2><img src="{{ media('img/firefox/template/header-logo.png?2013-06') }}" alt="Mozilla Firefox" height="70" width="185" data-inverse-src="{{media('img/firefox/template/header-logo-inverse.png?2013-06') }}"></h2>
+<h2><a href="{{ url('firefox') }}"><img src="{{ media('img/firefox/template/header-logo.png?2013-06') }}" alt="Mozilla Firefox" height="70" width="185" data-inverse-src="{{media('img/firefox/template/header-logo-inverse.png?2013-06') }}"></a></h2>
 {% endblock %}
 
 {% block site_js %}

--- a/bedrock/firefox/templates/firefox/base.html
+++ b/bedrock/firefox/templates/firefox/base.html
@@ -79,7 +79,7 @@
 {% endblock %}
 
 {% block site_header_logo %}
-<h2><img src="{{ media('img/firefox/template/header-logo.png?2013-06') }}" alt="Mozilla Firefox" height="70" width="185" data-inverse-src="{{media('img/firefox/template/header-logo-inverse.png?2013-06') }}"></h2>
+<h2><a href="{{ url('firefox') }}"><img src="{{ media('img/firefox/template/header-logo.png?2013-06') }}" alt="Mozilla Firefox" height="70" width="185" data-inverse-src="{{media('img/firefox/template/header-logo-inverse.png?2013-06') }}"></a></h2>
 {% endblock %}
 
 {% block site_js %}

--- a/bedrock/firefox/templates/firefox/new.html
+++ b/bedrock/firefox/templates/firefox/new.html
@@ -11,7 +11,7 @@
 
 {% block site_header_nav %}{% endblock %}
 {% block site_header_logo %}
-  <h2><a href="{{ url('mozorg.home') }}"><img src="{{ MEDIA_URL }}img/firefox/new/header-firefox.png?2013-06" alt="{{_('Firefox for desktop')}}" /></a></h2>
+  <h2><img src="{{ MEDIA_URL }}img/firefox/new/header-firefox.png?2013-06" alt="{{_('Firefox for desktop')}}"></h2>
 {% endblock %}
 
 

--- a/bedrock/firefox/templates/firefox/organizations/organizations.html
+++ b/bedrock/firefox/templates/firefox/organizations/organizations.html
@@ -17,7 +17,7 @@
 {% endblock %}
 
 {% block site_header_logo %}
-<h2><img src="{{ media('img/firefox/organizations/title.png?2013-06') }}" alt="{{ _('Firefox ESR') }}" height="68" width="299"></h2>
+<h2><a href="{{ url('firefox.organizations.organizations') }}"><img src="{{ media('img/firefox/organizations/title.png?2013-06') }}" alt="{{ _('Firefox ESR') }}" height="68" width="299"></a></h2>
 {% endblock %}
 
 


### PR DESCRIPTION
Three templates have no links on the logo.
