### PR TITLE
Bug 936554: enable home, plugincheck, firefox/new Bedrock redirects for xh

### DIFF
--- a/etc/httpd/global.conf
+++ b/etc/httpd/global.conf
@@ -83,7 +83,7 @@ RewriteRule ^(.*)index\.html$ $1 [L,R=301]
 ## Redirect things to django!
 
 # bug 797192, 892470
-RewriteRule ^/(en-US|af|ak|an|ast|bg|bn-IN|br|ca|cs|csb|cy|da|de|el|en-GB|eo|es-AR|es-CL|es-ES|es-MX|et|eu|fa|ff|fi|fr|fy-NL|ga-IE|gd|he|hi-IN|hr|hu|hy-AM|id|is|it|ja|ka|kk|ko|ku|lt|lv|mai|mk|ml|mr|ms|my|nb-NO|nl|nn-NO|nso|oc|pa-IN|pl|pt-BR|pt-PT|rm|ro|ru|sk|sl|son|sq|sr|sv-SE|sw|ta|ta-LK|te|th|tr|uk|ur|vi|wo|zh-CN|zh-TW)/plugincheck(/?)$ /b/$1/plugincheck$2 [PT]
+RewriteRule ^/(en-US|af|ak|an|ast|bg|bn-IN|br|ca|cs|csb|cy|da|de|el|en-GB|eo|es-AR|es-CL|es-ES|es-MX|et|eu|fa|ff|fi|fr|fy-NL|ga-IE|gd|he|hi-IN|hr|hu|hy-AM|id|is|it|ja|ka|kk|ko|ku|lt|lv|mai|mk|ml|mr|ms|my|nb-NO|nl|nn-NO|nso|oc|pa-IN|pl|pt-BR|pt-PT|rm|ro|ru|sk|sl|son|sq|sr|sv-SE|sw|ta|ta-LK|te|th|tr|uk|ur|vi|wo|xh|zh-CN|zh-TW)/plugincheck(/?)$ /b/$1/plugincheck$2 [PT]
 
 # bug 925551
 RewriteRule ^/en-US/plugincheck/more_info.html$ /plugincheck/ [L,R=301]
@@ -125,7 +125,7 @@ RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/toolkit/download-to-your-devices(.*)
 # Has to be this way because of old
 # legacy platform url conflicts.
 # bug 921564
-RewriteRule ^/(ach|af|ak|an|ar|as|ast|az|be|bg|bn-BD|bn-IN|br|bs|ca|cs|csb|cy|da|de|el|en-GB|en-US|en-ZA|eo|es-AR|es-CL|es-ES|es-MX|et|eu|fa|ff|fi|fr|fy-NL|ga-IE|gd|gl|gu-IN|he|hi-IN|hr|hu|hy-AM|id|is|it|ja|ja-JP-mac|ka|kk|km|kn|ko|ku|lg|lij|lt|lv|mai|mk|ml|mn|mr|ms|my|nb-NO|nl|nn-NO|nso|oc|or|pa-IN|pl|pt-BR|pt-PT|rm|ro|ru|sah|si|sk|sl|son|sq|sr|sv-SE|sw|ta|ta-LK|te|th|tr|uk|ur|vi|wo|zh-CN|zh-TW|zu)(/?)$ /b/$1$2 [PT]
+RewriteRule ^/(ach|af|ak|an|ar|as|ast|az|be|bg|bn-BD|bn-IN|br|bs|ca|cs|csb|cy|da|de|el|en-GB|en-US|en-ZA|eo|es-AR|es-CL|es-ES|es-MX|et|eu|fa|ff|fi|fr|fy-NL|ga-IE|gd|gl|gu-IN|he|hi-IN|hr|hu|hy-AM|id|is|it|ja|ja-JP-mac|ka|kk|km|kn|ko|ku|lg|lij|lt|lv|mai|mk|ml|mn|mr|ms|my|nb-NO|nl|nn-NO|nso|oc|or|pa-IN|pl|pt-BR|pt-PT|rm|ro|ru|sah|si|sk|sl|son|sq|sr|sv-SE|sw|ta|ta-LK|te|th|tr|uk|ur|vi|wo|xh|zh-CN|zh-TW|zu)(/?)$ /b/$1$2 [PT]
 
 # bug 822260
 RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?about/mission.html$ /b/$1about/mission.html [PT]
@@ -182,7 +182,7 @@ RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/community(/?)$ /$1contribute/ [L,R=3
 
 # bug 881754, 883127
 # TODO: Remove when all locales are done.
-RewriteRule ^/(an|ar|ast|bg|br|ca|cs|csb|cy|da|de|el|eo|es-AR|es-CL|es-ES|es-MX|et|eu|fa|fi|fr|fy-NL|ga-IE|gd|hi-IN|hr|hu|hy-AM|id|is|it|ka|kk|ko|lij|lt|lv|mk|ml|mr|my|nb-NO|nl|pa-IN|pl|pt-BR|pt-PT|rm|ro|ru|sk|sl|son|sq|sr|sv-SE|ta|te|tr|uk|zh-CN|zh-TW)/firefox/new(/?)$ /b/$1/firefox/new$2 [PT]
+RewriteRule ^/(an|ar|ast|bg|br|ca|cs|csb|cy|da|de|el|eo|es-AR|es-CL|es-ES|es-MX|et|eu|fa|fi|fr|fy-NL|ga-IE|gd|hi-IN|hr|hu|hy-AM|id|is|it|ka|kk|ko|lij|lt|lv|mk|ml|mr|my|nb-NO|nl|pa-IN|pl|pt-BR|pt-PT|rm|ro|ru|sk|sl|son|sq|sr|sv-SE|ta|te|tr|uk|xh|zh-CN|zh-TW)/firefox/new(/?)$ /b/$1/firefox/new$2 [PT]
 
 # bug 796952, 915845, 915867
 RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/unsupported/(.*)$ /b/$1firefox/unsupported/$2 [PT]


### PR DESCRIPTION
This locale is not available on the PHP side (/trunk/xh), only on Bedrock (/trunk/locales/xh). We don't need it on prod at the moment, only on www-dev.
