### PR TITLE
Fix bug 930485: Only select country from country locales.

### DIFF
--- a/bedrock/newsletter/tests/test_forms.py
+++ b/bedrock/newsletter/tests/test_forms.py
@@ -199,11 +199,15 @@ class TestNewsletterFooterForm(TestCase):
         self.assertEqual(data['lang'], cleaned_data['lang'])
 
     def test_country_default(self):
-        """country defaults based on the locale"""
+        """country defaults based on the locale.
+
+        But only for country based locales (e.g. pt-BR)"""
         form = NewsletterFooterForm(locale='fr')
-        self.assertEqual('fr', form.fields['country'].initial)
+        self.assertEqual('', form.fields['country'].initial)
         form = NewsletterFooterForm(locale='pt-BR')
         self.assertEqual('br', form.fields['country'].initial)
+        form = NewsletterFooterForm(locale='zh-TW')
+        self.assertEqual('tw', form.fields['country'].initial)
 
     def test_lang_default(self):
         """lang defaults based on the locale"""

--- a/bedrock/newsletter/tests/test_middleware.py
+++ b/bedrock/newsletter/tests/test_middleware.py
@@ -24,10 +24,11 @@ class TestNewsletterFooter(TestCase):
         doc = pq(resp.content)
         eq_(doc('#id_country option[selected="selected"]').val(), 'us')
 
+        # no country in locale, no country selected
         with self.activate('fr'):
             resp = self.client.get(reverse(self.view_name))
         doc = pq(resp.content)
-        eq_(doc('#id_country option[selected="selected"]').val(), 'fr')
+        eq_(doc('#id_country option[selected="selected"]').val(), '')
 
         with self.activate('pt-BR'):
             resp = self.client.get(reverse(self.view_name))


### PR DESCRIPTION
'pt-BR' indicates country, but 'fr' does not. And some language codes do not
correspond to a country code that makes sense, as in this bug with Sierra
Leone.
