### PR TITLE
Bug 935877 - Enable VTCS for more locales

### DIFF
--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -763,7 +763,8 @@ LOCALES_WITH_LIGHTBEAM_HOME = ['en-GB', 'en-US', 'en-ZA', 'ar', 'ca', 'da', 'de'
                             'ko', 'mk', 'nl', 'pt-BR', 'ru', 'sq', 'sv-SE', 'tr', 'zh-TW']
 
 # Locales with the Vans Triple Crown banner on home page
-LOCALES_WITH_VTCS_HOME = ['en-GB', 'en-US', 'en-ZA', 'de', 'eu', 'it', 'sv-SE', 'zh-TW']
+LOCALES_WITH_VTCS_HOME = ['en-GB', 'en-US', 'en-ZA', 'da', 'de', 'el', 'es-ES', 'eu',
+                          'it', 'sv-SE', 'tr', 'zh-TW']
 
 # reCAPTCHA keys
 RECAPTCHA_PUBLIC_KEY = ''


### PR DESCRIPTION
Added locales:
- VTCS: da, el, es-ES, tr

Maybe we could try to merge this PR just before the next merge to stage/prod. This way we'll have only one PR open and pending on these arrays and I can keep adding locales as soon as they become available (obviously if this make any sense). Tracking these locales is kind of hard on our side too, since these files are already "active".
