### PR TITLE
Bug 935877 - Enable VTCS and Lightbeam for more locales

### DIFF
--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -758,13 +758,15 @@ LOCALES_WITH_MOZ15 = ['bg', 'cs', 'de', 'el', 'en-GB', 'en-US', 'es-AR', 'es-CL'
                       'ta', 'tr', 'zh-CN', 'zh-TW']
 
 # Locales with the Lightbeam and Webmaker banners on home page
-LOCALES_WITH_LIGHTBEAM_HOME = ['en-GB', 'en-US', 'en-ZA', 'ar', 'ca', 'da', 'de', 'el',
-                            'es-AR', 'es-CL', 'es-ES', 'eu', 'fr', 'hy-AM', 'is', 'it',
-                            'ko', 'mk', 'nl', 'pt-BR', 'ru', 'sq', 'sv-SE', 'tr', 'zh-TW']
+LOCALES_WITH_LIGHTBEAM_HOME = ['en-GB', 'en-US', 'en-ZA', 'ar', 'ca', 'cs', 'cy',
+                               'da', 'de', 'el', 'es-AR', 'es-CL', 'es-ES', 'eu',
+                               'fr', 'fy-NL', 'hy-AM', 'is', 'it', 'ko', 'mk', 'nl',
+                               'pl', 'pt-BR', 'ru', 'sq', 'sv-SE', 'tr', 'uk', 'zh-TW']
 
 # Locales with the Vans Triple Crown banner on home page
-LOCALES_WITH_VTCS_HOME = ['en-GB', 'en-US', 'en-ZA', 'da', 'de', 'el', 'es-ES', 'eu',
-                          'it', 'sv-SE', 'tr', 'zh-TW']
+LOCALES_WITH_VTCS_HOME = ['en-GB', 'en-US', 'en-ZA', 'da', 'de', 'el', 'es-AR', 'es-ES',
+                          'eu', 'fr', 'fy-NL', 'it', 'mk', 'pl', 'sq', 'sv-SE', 'tr',
+                          'uk', 'zh-TW']
 
 # reCAPTCHA keys
 RECAPTCHA_PUBLIC_KEY = ''


### PR DESCRIPTION
Added locales:
- VTCS: es-AR, fr, fy-NL, mk, pl, sq, uk
- Lightbeam: cs, cy, fy-NL, pl, uk

If possible merge this PR just before the next push to stage/prod: this way we'll have only one pending PR on this array in base.py and I can keep adding locales as soon as they become available. If that's not possible, PR is good to go at whenever you prefer :-)
