### PR TITLE
Bug 939595 - lightbeam/about: make navigation menu localizable

### DIFF
--- a/bedrock/lightbeam/templates/lightbeam/about.html
+++ b/bedrock/lightbeam/templates/lightbeam/about.html
@@ -18,8 +18,8 @@
   <span class="toggle" role="button" aria-controls="nav-main-menu" tabindex="0">{{_('Menu')}}</span>
   <nav id="nav-main" role="navigation">
     <ul id="nav-main-menu">
-      <li><a href="{{ url('lightbeam.lightbeam') }}">Home</a></li>
-      <li><b>About</b></li>
+      <li><a href="{{ url('lightbeam.lightbeam') }}">{{_('Home')}}</a></li>
+      <li><b>{{_('About')}}</b></li>
   </ul>
   </nav>
 {% endblock %}


### PR DESCRIPTION
Wrap strings like in other pages
