### PR TITLE
Fix bug 924347: Fall back to en-US download locale.

### DIFF
--- a/bedrock/mozorg/helpers/download_buttons.py
+++ b/bedrock/mozorg/helpers/download_buttons.py
@@ -144,8 +144,12 @@ def download_firefox(ctx, build='release', small=False, icon=True,
     funnelcake_id = ctx.get('funnelcake_id', False)
     dom_id = dom_id or 'download-button-%s-%s' % (platform, build)
 
-    version, platforms = (latest_version(locale, build) or
-                          latest_version('en-US', build))
+    l_version = latest_version(locale, build)
+    if l_version:
+        version, platforms = l_version
+    else:
+        locale = 'en-US'
+        version, platforms = latest_version('en-US', build)
 
     # Gather data about the build for each platform
     builds = []

--- a/bedrock/mozorg/tests/test_helper_download_buttons.py
+++ b/bedrock/mozorg/tests/test_helper_download_buttons.py
@@ -243,6 +243,22 @@ class TestDownloadButtons(TestCase):
         for link in links:
             ok_('stub' not in pq(link).attr('href'))
 
+    @patch.object(firefox_details, 'firefox_primary_builds', GOOD_BUILDS)
+    @patch.object(firefox_details, 'firefox_beta_builds', {})
+    @patch.dict(firefox_details.firefox_versions, GOOD_VERSIONS)
+    def test_download_unsupported_local(self):
+        """Should fall back to en-US"""
+        rf = RequestFactory()
+        get_request = rf.get('/fake')
+        get_request.locale = 'fr'
+        doc = pq(render("{{ download_firefox() }}",
+                        {'request': get_request}))
+
+        links = doc('.download-list a')[:3]
+        for link in links:
+            ok_('lang=fr' not in pq(link).attr('href'))
+            ok_('lang=en-US' in pq(link).attr('href'))
+
     def test_download_transition_link_contains_locale(self):
         """
         "transition" download links should include the locale in the path as


### PR DESCRIPTION
If no localized Fx build exists for the latest version fall back to an en-US
download link.

@jgmize r?
