### PR TITLE
Careers teaser in comment and error console. Bug 937719.

### DIFF
--- a/bedrock/base/templates/base-resp.html
+++ b/bedrock/base/templates/base-resp.html
@@ -5,6 +5,9 @@
 {# Note the "windows" class, without javascript platform-specific
      assets default to windows #}
 <html class="windows no-js" lang="{{ LANG }}" dir="{{ DIR }}"{% block html_attrs %}{% endblock %}>
+<!--
+{% include "includes/careers-teaser.html" %}
+-->
   <head>
     {% block ga_experiments %}{% endblock %}
     <meta charset="utf-8">

--- a/bedrock/base/templates/includes/careers-teaser.html
+++ b/bedrock/base/templates/includes/careers-teaser.html
@@ -1,0 +1,23 @@
+             _.---.
+           7''  Q..\
+        _7         (_
+      _7  _/    _q.  /
+    _7 . ___  /VVvv-'_                                            .
+   7/ / /-- \_\\      '-._     .-'                      /       //
+  ./ ( /---/||'=.__  '::. '--'' {             ___   /  //     ./{
+ V   V----| ||   __''_   ':::.   ''---.___.-'' _/  // / {_   /  {  /
+  VV/-----|/ \ .'__'. '.    '::                     _ _ _        ''.
+  / /----||VVV/ /  \ )  \        _ __ ___   ___ ___(_) | | __ _   .::'
+ / (-----\\.-' /    \'   \::::. | '_ ` _ \ / _ \_  / | | |/ _` | :::'
+/..\    /..\__/      '     '::: | | | | | | (_) / /| | | | (_| | ::'
+vVVv    vVVv                 ': |_| |_| |_|\___/___|_|_|_|\__,_| ''
+
+Hi there, nice to meet you!
+
+Interested in having a direct impact on hundreds of millions of users? Join
+Mozilla, and become part of a global community that’s helping to build a
+brighter future for the Web.
+
+Visit https://careers.mozilla.org to learn about our current job openings.
+Visit https://www.mozilla.org/contribute for more ways to get involved and
+help support Mozilla.

--- a/bedrock/tabzilla/templates/tabzilla/tabzilla.js
+++ b/bedrock/tabzilla/templates/tabzilla/tabzilla.js
@@ -349,6 +349,13 @@ var Tabzilla = (function (Tabzilla) {
         });
 
         setupGATracking();
+
+        // Careers teaser in error console.
+        $(window).load(function() {
+            try {
+                console.log("{% filter js_escape|safe %}{% include "includes/careers-teaser.html" %}{% endfilter %}");
+            } catch(e) {}
+        });
     };
     var loadJQuery = function (callback) {
         var noConflictCallback = function() {


### PR DESCRIPTION
This adds a teaser to both the top of the page and the error console encouraging people who look at these kinds of things to head over to careers.mo and join us.

I would like feedback on a few things:
1) wording
2) implementation (I used a macro so I can reuse the same string and js_escape it; the same thing does not appear possible with a straight import)
3) repeating the console.log after 10 seconds, under the assumption that it'll probably get buried when slower connections keep loading assets. Am I overthinking this?
