### PR TITLE
Bug 928120 - Import 2012/index.lang into 2012/faq

### DIFF
--- a/bedrock/foundation/templates/foundation/annualreport/2012/faq.html
+++ b/bedrock/foundation/templates/foundation/annualreport/2012/faq.html
@@ -4,6 +4,8 @@
 
 {% extends "base-resp.html" %}
 
+{% add_lang_files "foundation/annualreport/2012/index" %}
+
 {% block page_title %}{{ _('The State of Mozilla: 2012 Annual Report') }} | {{ _('Frequently Asked Questions') }}{% endblock %}
 {% block body_id %}annual-2012-faq{% endblock %}
 


### PR DESCRIPTION
In this way we can use only two lang files (index, faq) and reuse footer/header strings stored in index.lang

Checked locally and it works as expected.
