### PR TITLE
call Tabzilla.close() instead of close()

### DIFF
--- a/bedrock/tabzilla/templates/tabzilla/tabzilla.js
+++ b/bedrock/tabzilla/templates/tabzilla/tabzilla.js
@@ -333,7 +333,7 @@ var Tabzilla = (function (Tabzilla) {
         panel.on('keydown', function (event) {
             if (event.which === 27) {
                 event.preventDefault();
-                close();
+                Tabzilla.close();
             }
         });
 


### PR DESCRIPTION
fixes bug 941516
