### PR TITLE
Bug 935877 - Home page: enable VTCS and Lightbeam for more locales

### DIFF
--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -762,15 +762,16 @@ LOCALES_WITH_MOZ15 = ['bg', 'cs', 'de', 'el', 'en-GB', 'en-US', 'es-AR', 'es-CL'
 
 # Locales with the Lightbeam and Webmaker banners on home page
 LOCALES_WITH_LIGHTBEAM_HOME = ['en-GB', 'en-US', 'en-ZA', 'ar', 'ca', 'cs', 'cy',
-                               'da', 'de', 'el', 'es-AR', 'es-CL', 'es-MX', 'es-ES',
-                               'eu', 'fr', 'fy-NL', 'hy-AM', 'is', 'it', 'ko', 'mk',
-                               'nl', 'pl', 'pt-BR', 'ru', 'sq', 'sv-SE', 'tr', 'uk',
-                               'zh-TW']
+                               'da', 'de', 'el', 'es-AR', 'es-CL', 'es-ES', 'es-MX',
+                               'et', 'eu', 'fr', 'fy-NL', 'hy-AM', 'hr', 'is', 'it',
+                               'ko', 'mk', 'nl', 'pl', 'pt-BR', 'ru', 'sq', 'sv-SE',
+                               'tr', 'uk', 'xh', 'zh-TW']
 
 # Locales with the Vans Triple Crown banner on home page
-LOCALES_WITH_VTCS_HOME = ['en-GB', 'en-US', 'en-ZA', 'cy', 'da', 'de', 'el', 'es-AR',
-                          'es-CL', 'es-MX', 'es-ES', 'eu', 'fr', 'fy-NL', 'is', 'it',
-                          'mk', 'pl', 'sq', 'sv-SE', 'tr', 'uk', 'zh-TW']
+LOCALES_WITH_VTCS_HOME = ['en-GB', 'en-US', 'en-ZA', 'ar', 'ca', 'cs', 'cy', 'da', 'de',
+                          'el', 'es-AR', 'es-CL', 'es-ES', 'es-MX', 'et', 'eu', 'fr',
+                          'fy-NL', 'hy-AM', 'hr', 'is', 'it', 'ko', 'mk', 'nl', 'pl',
+                          'pt-BR', 'ru', 'sq', 'sv-SE', 'tr', 'uk', 'zh-TW']
 
 # reCAPTCHA keys
 RECAPTCHA_PUBLIC_KEY = ''


### PR DESCRIPTION
Added locales: 
Lightbeam: et, hr, xh
VTCS: ar, ca, cs, et, hy-AM, hr, ko, nl, pt-BR, ru

Fixed alphabetical order (es-ES comes before es-MX)

Please keep this PR open until next push to prod, so I can keep adding locales as they become available.
