### PR TITLE
Bug 900506: fix a few strings in products page for l10n

### DIFF
--- a/bedrock/mozorg/templates/mozorg/products.html
+++ b/bedrock/mozorg/templates/mozorg/products.html
@@ -47,14 +47,14 @@
     <li>
       <a href="{{ url('firefox.os.index') }}">
         <img src="{{ media('/img/products/badge-firefoxos.jpg?2013-06') }}" alt="">
-        <h3>OS</h3>
+        <h3>{{ _('OS') }}</h3>
         <p>{{ _('An open operating system for mobile devices.') }}</p>
       </a>
     </li>
     <li>
       <a href="https://marketplace.firefox.com/">
         <img src="{{ media('/img/products/badge-marketplace.jpg?2013-06') }}" alt="">
-        <h3>{{ _('Marketplace') }}</h3>
+        <h3>Marketplace</h3>
         <p>{{ _('A creation and distribution platform for apps.') }}</p>
       </a>
     </li>
@@ -147,7 +147,7 @@
     <li>
       <a href="https://developer.mozilla.org/Apps/Reference">
         <img src="{{ media('/img/products/badge-api.jpg') }}" alt="">
-        <h3>Firefox APIs</h3>
+        <h3>{{ _('Firefox APIs') }}</h3>
         <p>{{ _('The foundations for building a Firefox OS app.') }}</p>
       </a>
     </li>


### PR DESCRIPTION
- Marketplace is marketed as a brand name
- OS and APIs are not  brand names and need translation
