### PR TITLE
Bug 675031 Redirect fennec release notes to archive

### DIFF
--- a/etc/httpd/global.conf
+++ b/etc/httpd/global.conf
@@ -465,6 +465,9 @@ RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?lightbeam(/?.*)$ /b/$1lightbeam$2 [PT]
 # bug 876233
 RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?about/participate/?$ /$1contribute/ [L,R=301]
 
+# bug 675031
+RewriteRule ^/projects/fennec/(.*) http://website-archive.mozilla.org/www.mozilla.org/fennec_releasenotes/projects/fennec/$1 [L,R=301]
+
 # bug 877198
 RewriteRule ^/en-US/press/news.html http://blog.mozilla.org/press/ [L,R=301]
 RewriteRule ^/en-US/press/mozilla-2003-10-15.html http://blog.mozilla.org/press/2003/10/mozilla-foundation-launches-new-web-browser-and-end-user-services/ [L,R=301]


### PR DESCRIPTION
This redirect sends everything under /projects/fennec/ to the equivalent website-archive.mozilla.org URL.
