### PR TITLE
Bug 934374 Exclude SeaMonkey from isFirefox check

### DIFF
--- a/media/js/base/global.js
+++ b/media/js/base/global.js
@@ -127,7 +127,11 @@ function getFirefoxMasterVersion(userAgent) {
 function isFirefox(userAgent) {
     var ua = userAgent || navigator.userAgent;
     // camino UA string contains 'like Firefox'
-    return ((/\sFirefox/).test(ua) && !(/like Firefox/i).test(ua));
+    return (
+        (/\sFirefox/).test(ua) &&
+        !(/like Firefox/i).test(ua) &&
+        !(/SeaMonkey/i).test(ua)
+    );
 }
 
 function isFirefoxUpToDate(latest, esr) {

--- a/media/js/test/spec/global.js
+++ b/media/js/test/spec/global.js
@@ -158,6 +158,12 @@ describe("global.js", function() {
       var result = isFirefox(ua);
       expect(result).not.toBeTruthy();
     });
+
+    it("should not consider SeaMonkey to be Firefox", function() {
+      var ua = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.9; rv:25.0) Gecko/20100101 Firefox/25.0 SeaMonkey/2.22.1';
+      var result = isFirefox(ua);
+      expect(result).not.toBeTruthy();
+    });
   });
 
   describe("isFirefoxUpToDate", function () {


### PR DESCRIPTION
SeaMonkey thinks it's Firefox!

This fixes https://bugzilla.mozilla.org/show_bug.cgi?id=934374
