### PR TITLE
Bug 868895 - Wrong link on Contact Us page

### DIFF
--- a/bedrock/mozorg/templates/mozorg/contact/contact-base.html
+++ b/bedrock/mozorg/templates/mozorg/contact/contact-base.html
@@ -440,7 +440,7 @@
       <ul>
         <li><a href="https://facebook.com/mozilla" hreflang="en-US">{{ _('Facebook') }}</a></li>
         <li><a href="https://twitter.com/mozilla" hreflang="en-US">{{ _('Twitter') }}</a></li>
-        <li><a href="{{ php_url('/about/forums') }}">{{ _('Forums &amp; e-mail lists') }}</a></li>
+        <li><a href="/about/forums/">{{ _('Forums &amp; e-mail lists') }}</a></li>
         <li><a href="https://wiki.mozilla.org/IRC">{{ _('IRC channels') }}</a></li>
       </ul>
     </div>
@@ -460,8 +460,8 @@
         <li><a href="https://support.mozilla.org/">{{ _('Get support') }}</a></li>
         <li><a href="{{ press_blog_url() }}">{{ _('Press inquiries') }}</a></li>
         <li><a href="{{ url('foundation.licensing') }}">{{ _('Browser distribution &amp; licensing') }}</a></li>
-        <li><a href="https://input.mozilla.org/">{{ _('Firefox feedback') }}</a></li>
-        <li><a href="http://support.mozilla.org/kb/Websites+look+wrong">{{ _('Report a broken site') }}</a></li>
+        <li><a href="https://input.mozilla.org/feedback">{{ _('Firefox feedback') }}</a></li>
+        <li><a href="https://support.mozilla.org/kb/websites-look-wrong-or-appear-differently">{{ _('Report a broken site') }}</a></li>
         <li><a href="https://developer.mozilla.org/docs/Mozilla/QA/Bug_writing_guidelines">{{ _('How to report software issues') }}</a></li>
       </ul>
     </div>


### PR DESCRIPTION
Fixed the feedback link as well as the forums link. Updated a SUMO article link.
