### PR TITLE
Bug 875052 Redirect /start/ to seamonkey and firefox pages

### DIFF
--- a/etc/httpd/global.conf
+++ b/etc/httpd/global.conf
@@ -42,6 +42,12 @@ RewriteRule ^/zh-CN/$ http://firefox.com.cn/ [L,R=301]
 #bug 857246 redirect /products/firefox/start/  to start.mozilla.org
 RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?products/firefox/start(/?)$ http://start.mozilla.org [L,R=301]
 
+
+# bug 875052
+RewriteCond %{HTTP_USER_AGENT} seamonkey [NC]
+RewriteRule ^/start/(.*)$ http://www.seamonkey-project.org/start/ [E=varyua:1,L,R=301]
+RewriteRule ^/start/(.*)$ /firefox/ [L,R=301]
+
 #bug 856081 redirect /about/drivers https://wiki.mozilla.org/Firefox/Drivers
 RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?about/drivers(\.html|/)?$ https://wiki.mozilla.org/Firefox/Drivers [L,R=301]
 


### PR DESCRIPTION
The bug called for redirecting any non-Firefox visitor to the seamonkey site, but I went with the option of redirecting SeaMonkey, and passing anyone else (including Firefox) on to /firefox/.

Feedback is welcome.

https://bugzilla.mozilla.org/show_bug.cgi?id=875052
