### PR TITLE
Fix bug 935164 - update purchase link for Montenegro

### DIFF
--- a/media/js/firefox/os/firefox-os.js
+++ b/media/js/firefox/os/firefox-os.js
@@ -70,7 +70,7 @@
       "partner": [
         {
           "name": "Telenor",
-          "url": "http://www.telenor.me/sr/Privatni-korisnici/Uredjaji/Alcatel/Alcatel-One-Touch-Fire/"
+          "url": "http://www.telenor.me/sr/Privatni-korisnici/Uredjaji/Mobilni-telefoni/Alcatel/OT_Fire"
         }
       ]
     },


### PR DESCRIPTION
They changed their link but aren't redirecting the previous one, so this is a pretty urgent fix.
