### PR TITLE
Bug 944936 - Implement schema.org for Mozilla Spaces

### DIFF
--- a/bedrock/mozorg/templates/mozorg/contact/spaces/auckland.html
+++ b/bedrock/mozorg/templates/mozorg/contact/spaces/auckland.html
@@ -9,16 +9,16 @@
 {% block contact_entry %}
   <div id="entry-container">
     <section class="entry entry-space" id="auckland" data-tab="spaces">
-      <div class="card vcard">
-        <h2 class="fn">{{ _('Auckland') }}</h2>
-        <p class="adr">
-        {# L10n: Addresses are marked up with hCard microformat. See http://microformats.org/wiki/h-card #}
+      <div class="card" itemscope itemtype="http://schema.org/Organization">
+        <h2>{{ _('Auckland') }}</h2>
+        <meta itemprop="name" content="{{ _('Mozilla Space, Auckland') }}">
+        <p itemprop="address" itemscope itemtype="http://schema.org/PostalAddress">
+        {# L10n: Addresses are marked up with Schema.org. See http://schema.org/PostalAddress #}
         {% trans %}
-          <span class="extended-address">Level 7</span><br>
-          <span class="street-address">5 Short St</span><br>
-          <span class="locality">Newmarket</span><br>
-          <abbr class="region">Auckland</abbr> <span class="postal-code">1023</span><br>
-          <span class="country-name">New Zealand</span>
+          <span itemprop="streetAddress">Level 7<br>5 Short St</span><br>
+          <span itemprop="addressLocality">Newmarket</span><br>
+          <span itemprop="addressRegion">Auckland</span> <span itemprop="postalCode">1023</span><br>
+          <span itemprop="addressCountry">New Zealand</span>
         {% endtrans %}
         </p>
 

--- a/bedrock/mozorg/templates/mozorg/contact/spaces/beijing.html
+++ b/bedrock/mozorg/templates/mozorg/contact/spaces/beijing.html
@@ -9,16 +9,16 @@
 {% block contact_entry %}
   <div id="entry-container">
     <section class="entry entry-space" id="beijing" data-tab="spaces">
-      <div class="card vcard">
-        <h2 class="fn">{{ _('Beijing') }}</h2>
-        <p class="adr">
-        {# L10n: Addresses are marked up with hCard microformat. See http://microformats.org/wiki/h-card #}
+      <div class="card" itemscope itemtype="http://schema.org/Organization">
+        <h2>{{ _('Beijing') }}</h2>
+        <meta itemprop="name" content="{{ _('Mozilla Space, Beijing') }}">
+        <p itemprop="address" itemscope itemtype="http://schema.org/PostalAddress">
+        {# L10n: Addresses are marked up with Schema.org. See http://schema.org/PostalAddress #}
         {% trans %}
-          <span class="org">Mozilla Online Ltd.</span><br>
-          <span class="extended-address">International Club Office Tower 800A</span><br>
-          <span class="street-address">21 Jian Guo Men Wai Avenue</span><br>
-          <abbr class="region">Chaoyang District</abbr>, <span class="locality">Beijing</span> <span class="postal-code">100020</span><br>
-          <span class="country-name">China</span>
+          <span itemprop="name">Mozilla Online Ltd.</span><br>
+          <span itemprop="streetAddress">International Club Office Tower 800A<br>21 Jian Guo Men Wai Avenue</span><br>
+          <span itemprop="addressRegion">Chaoyang District</span>, <span itemprop="addressLocality">Beijing</span> <span itemprop="postalCode">100020</span><br>
+          <span itemprop="addressCountry">China</span>
         {% endtrans %}
         </p>
 

--- a/bedrock/mozorg/templates/mozorg/contact/spaces/berlin.html
+++ b/bedrock/mozorg/templates/mozorg/contact/spaces/berlin.html
@@ -9,15 +9,15 @@
 {% block contact_entry %}
   <div id="entry-container">
     <section class="entry entry-space" id="berlin" data-tab="spaces">
-      <div class="card vcard">
-        <h2 class="fn">{{ _('Berlin') }}</h2>
-        <p class="adr">
-        {# L10n: Addresses are marked up with hCard microformat. See http://microformats.org/wiki/h-card #}
+      <div class="card" itemscope itemtype="http://schema.org/Organization">
+        <h2>{{ _('Berlin') }}</h2>
+        <meta itemprop="name" content="{{ _('Mozilla Space, Berlin') }}">
+        <p itemprop="address" itemscope itemtype="http://schema.org/PostalAddress">
+        {# L10n: Addresses are marked up with Schema.org. See http://schema.org/PostalAddress #}
         {% trans %}
-          <span class="extended-address">MZ Denmark ApS</span><br>
-          <span class="street-address">Rungestrasse 22 - 24</span><br>
-          <span class="locality">Berlin</span> <span class="postal-code">100020</span><br>
-          <span class="country-name">Germany</span>
+          <span itemprop="streetAddress">MZ Denmark ApS<br>Rungestrasse 22 - 24</span><br>
+          <span itemprop="addressLocality">Berlin</span> <span itemprop="postalCode">100020</span><br>
+          <span itemprop="addressCountry">Germany</span>
         {% endtrans %}
         </p>
 

--- a/bedrock/mozorg/templates/mozorg/contact/spaces/london.html
+++ b/bedrock/mozorg/templates/mozorg/contact/spaces/london.html
@@ -9,14 +9,15 @@
 {% block contact_entry %}
   <div id="entry-container">
     <section class="entry entry-space" id="london" data-tab="spaces">
-      <div class="card vcard">
-        <h2 class="fn">{{ _('London') }}</h2>
-        <p class="adr">
-        {# L10n: Addresses are marked up with hCard microformat. See http://microformats.org/wiki/h-card #}
+      <div class="card" itemscope itemtype="http://schema.org/Organization">
+        <h2>{{ _('London') }}</h2>
+        <meta itemprop="name" content="{{ _('Mozilla Space, London') }}">
+        <p itemprop="address" itemscope itemtype="http://schema.org/PostalAddress">
+        {# L10n: Addresses are marked up with Schema.org. See http://schema.org/PostalAddress #}
         {% trans %}
-          <span class="street-address">101 St Martin‘s Lane</span>, <span class="extended-address">3rd Floor</span><br>
-          <span class="locality">London</span> <span class="postal-code">WC2N 4AZ</span><br>
-          <abbr class="country-name" title="United Kingdom">UK</abbr>
+          <span itemprop="streetAddress">101 St Martin‘s Lane, 3rd Floor</span><br>
+          <span itemprop="addressLocality">London</span> <span itemprop="postalCode">WC2N 4AZ</span><br>
+          <abbr itemprop="addressCountry" title="United Kingdom">UK</abbr>
         {% endtrans %}
         </p>
 

--- a/bedrock/mozorg/templates/mozorg/contact/spaces/mountain-view.html
+++ b/bedrock/mozorg/templates/mozorg/contact/spaces/mountain-view.html
@@ -9,16 +9,16 @@
 {% block contact_entry %}
   <div id="entry-container">
     <section class="entry entry-space" id="mountain-view" data-tab="spaces">
-      <div class="card vcard">
-        <h2 class="fn">{{ _('Mountain View') }}</h2>
-        <p class="adr">
-        {# L10n: Addresses are marked up with hCard microformat. See http://microformats.org/wiki/h-card #}
+      <div class="card" itemscope itemtype="http://schema.org/Organization">
+        <h2>{{ _('Mountain View') }}</h2>
+        <meta itemprop="name" content="{{ _('Mozilla Space, Mountain View') }}">
+        <p itemprop="address" itemscope itemtype="http://schema.org/PostalAddress">
+        {# L10n: Addresses are marked up with Schema.org. See http://schema.org/PostalAddress #}
         {% trans %}
-          <span class="street-address">650 Castro Street</span><br>
-          <span class="extended-address">Suite 300</span><br>
-          <span class="locality">Mountain View</span>, <abbr class="region" title="California">CA</abbr><br>
-          <span class="postal-code">94041-2021</span><br>
-          <span class="country-name">USA</span>
+          <span itemprop="streetAddress">650 Castro Street<br>Suite 300</span><br>
+          <span itemprop="addressLocality">Mountain View</span>, <abbr itemprop="addressRegion" title="California">CA</abbr><br>
+          <span itemprop="postalCode">94041-2021</span><br>
+          <abbr itemprop="addressCountry" title="The United States of America">USA</abbr>
         {% endtrans %}
         </p>
 

--- a/bedrock/mozorg/templates/mozorg/contact/spaces/paris.html
+++ b/bedrock/mozorg/templates/mozorg/contact/spaces/paris.html
@@ -9,14 +9,15 @@
 {% block contact_entry %}
   <div id="entry-container">
     <section class="entry entry-space" id="paris" data-tab="spaces">
-      <div class="card vcard">
-        <h2 class="fn">{{ _('Paris') }}</h2>
-        <p class="adr">
-        {# L10n: Addresses are marked up with hCard microformat. See http://microformats.org/wiki/h-card #}
+      <div class="card" itemscope itemtype="http://schema.org/Organization">
+        <h2>{{ _('Paris') }}</h2>
+        <meta itemprop="name" content="{{ _('Mozilla Space, Paris') }}">
+        <p itemprop="address" itemscope itemtype="http://schema.org/PostalAddress">
+        {# L10n: Addresses are marked up with Schema.org. See http://schema.org/PostalAddress #}
         {% trans %}
-          <span class="street-address">16 Bis Boulevard Montmartre</span><br>
-          <span class="locality">Paris</span> <span class="postal-code">75009</span><br>
-          <span class="country-name">France</span>
+          <span itemprop="streetAddress">16 Bis Boulevard Montmartre</span><br>
+          <span itemprop="addressLocality">Paris</span> <span itemprop="postalCode">75009</span><br>
+          <span itemprop="addressCountry">France</span>
         {% endtrans %}
         </p>
 

--- a/bedrock/mozorg/templates/mozorg/contact/spaces/portland.html
+++ b/bedrock/mozorg/templates/mozorg/contact/spaces/portland.html
@@ -9,15 +9,15 @@
 {% block contact_entry %}
   <div id="entry-container">
     <section class="entry entry-space" id="portland" data-tab="spaces">
-      <div class="card vcard">
-        <h2 class="fn">{{ _('Portland') }}</h2>
-        <p class="adr">
-        {# L10n: Addresses are marked up with hCard microformat. See http://microformats.org/wiki/h-card #}
+      <div class="card" itemscope itemtype="http://schema.org/Organization">
+        <h2>{{ _('Portland') }}</h2>
+        <meta itemprop="name" content="{{ _('Mozilla Space, Portland') }}">
+        <p itemprop="address" itemscope itemtype="http://schema.org/PostalAddress">
+        {# L10n: Addresses are marked up with Schema.org. See http://schema.org/PostalAddress #}
         {% trans %}
-          Brewery Block 2<br>
-          <span class="street-address">1120 NW Couch St.</span>, <span class="extended-address">Suite 320</span><br>
-          <span class="locality">Portland</span>, <abbr class="region" title="Oregon">OR</abbr> <span class="postal-code">97209</span><br>
-          <span class="country-name">USA</span>
+          <span itemprop="streetAddress">Brewery Block 2<br>1120 NW Couch St., Suite 320</span><br>
+          <span itemprop="addressLocality">Portland</span>, <abbr itemprop="addressRegion" title="Oregon">OR</abbr> <span itemprop="postalCode">97209</span><br>
+          <abbr itemprop="addressCountry" title="The United States of America">USA</abbr>
         {% endtrans %}
         </p>
 

--- a/bedrock/mozorg/templates/mozorg/contact/spaces/san-francisco.html
+++ b/bedrock/mozorg/templates/mozorg/contact/spaces/san-francisco.html
@@ -9,15 +9,15 @@
 {% block contact_entry %}
   <div id="entry-container">
     <section class="entry entry-space" id="san-francisco" data-tab="spaces">
-      <div class="card vcard">
-        <h2 class="fn">{{ _('San Francisco') }}</h2>
-        <p class="adr">
-        {# L10n: Addresses are marked up with hCard microformat. See http://microformats.org/wiki/h-card #}
+      <div class="card" itemscope itemtype="http://schema.org/Organization">
+        <h2>{{ _('San Francisco') }}</h2>
+        <meta itemprop="name" content="{{ _('Mozilla Space, San Francisco') }}">
+        <p itemprop="address" itemscope itemtype="http://schema.org/PostalAddress">
+        {# L10n: Addresses are marked up with Schema.org. See http://schema.org/PostalAddress #}
         {% trans %}
-          <span class="street-address">2 Harrison Street</span><br>
-          <span class="extended-address">Suite 175</span><br>
-          <span class="locality">San Francisco</span>, <abbr class="region" title="California">CA</abbr> <span class="postal-code">94105</span><br>
-          <span class="country-name">USA</span>
+          <span itemprop="streetAddress">2 Harrison Street<br>Suite 175</span><br>
+          <span itemprop="addressLocality">San Francisco</span>, <abbr itemprop="addressRegion" title="California">CA</abbr> <span itemprop="postalCode">94105</span><br>
+          <abbr itemprop="addressCountry" title="The United States of America">USA</abbr>
         {% endtrans %}
         </p>
 

--- a/bedrock/mozorg/templates/mozorg/contact/spaces/taipei.html
+++ b/bedrock/mozorg/templates/mozorg/contact/spaces/taipei.html
@@ -9,14 +9,15 @@
 {% block contact_entry %}
   <div id="entry-container">
     <section class="entry entry-space" id="taipei" data-tab="spaces">
-      <div class="card vcard">
-        <h2 class="fn">{{ _('Taipei') }}</h2>
-        <p class="adr">
-        {# L10n: Addresses are marked up with hCard microformat. See http://microformats.org/wiki/h-card #}
+      <div class="card" itemscope itemtype="http://schema.org/Organization">
+        <h2>{{ _('Taipei') }}</h2>
+        <meta itemprop="name" content="{{ _('Mozilla Space, Taipei') }}">
+        <p itemprop="address" itemscope itemtype="http://schema.org/PostalAddress">
+        {# L10n: Addresses are marked up with Schema.org. See http://schema.org/PostalAddress #}
         {% trans %}
-          <span class="street-address">4F-A1, No. 106, Sec. 5, Xinyi Rd.</span>, <span class="extended-address">Xinyi Dist.</span><br>
-          <span class="locality">Taipei City</span> <span class="postal-code">11047</span><br>
-          <span class="country-name">Taiwan</span>
+          <span itemprop="streetAddress">4F-A1, No. 106, Sec. 5, Xinyi Rd., Xinyi Dist.</span><br>
+          <span itemprop="addressLocality">Taipei City</span> <span itemprop="postalCode">11047</span><br>
+          <span itemprop="addressCountry">Taiwan</span>
         {% endtrans %}
         </p>
 

--- a/bedrock/mozorg/templates/mozorg/contact/spaces/tokyo.html
+++ b/bedrock/mozorg/templates/mozorg/contact/spaces/tokyo.html
@@ -9,14 +9,15 @@
 {% block contact_entry %}
   <div id="entry-container">
     <section class="entry entry-space" id="tokyo" data-tab="spaces">
-      <div class="card vcard">
-        <h2 class="fn">{{ _('Tokyo') }}</h2>
-        <p class="adr">
-        {# L10n: Addresses are marked up with hCard microformat. See http://microformats.org/wiki/h-card #}
+      <div class="card" itemscope itemtype="http://schema.org/Organization">
+        <h2>{{ _('Tokyo') }}</h2>
+        <meta itemprop="name" content="{{ _('Mozilla Space, Tokyo') }}">
+        <p itemprop="address" itemscope itemtype="http://schema.org/PostalAddress">
+        {# L10n: Addresses are marked up with Schema.org. See http://schema.org/PostalAddress #}
         {% trans %}
-          <span class="street-address">7-5-6 Roppongi</span>, <span class="extended-address">Minato-ku</span><br>
-          <span class="locality">Tokyo</span> <span class="postal-code">106-0032</span><br>
-          <span class="country-name">Japan</span>
+          <span itemprop="streetAddress">7-5-6 Roppongi</span>, <span itemprop="addressLocality">Minato-ku</span><br>
+          <span itemprop="addressRegion">Tokyo</span> <span itemprop="postalCode">106-0032</span><br>
+          <span itemprop="addressCountry">Japan</span>
         {% endtrans %}
         </p>
 

--- a/bedrock/mozorg/templates/mozorg/contact/spaces/toronto.html
+++ b/bedrock/mozorg/templates/mozorg/contact/spaces/toronto.html
@@ -9,14 +9,15 @@
 {% block contact_entry %}
   <div id="entry-container">
     <section class="entry entry-space" id="toronto" data-tab="spaces">
-      <div class="card vcard">
-        <h2 class="fn">{{ _('Toronto') }}</h2>
-        <p class="adr">
-        {# L10n: Addresses are marked up with hCard microformat. See http://microformats.org/wiki/h-card #}
+      <div class="card" itemscope itemtype="http://schema.org/Organization">
+        <h2>{{ _('Toronto') }}</h2>
+        <meta itemprop="name" content="{{ _('Mozilla Space, Toronto') }}">
+        <p itemprop="address" itemscope itemtype="http://schema.org/PostalAddress">
+        {# L10n: Addresses are marked up with Schema.org. See http://schema.org/PostalAddress #}
         {% trans %}
-          <span class="street-address">366 Adelaide St W</span>, <span class="extended-address">Suite 500</span><br>
-          <span class="locality">Toronto</span>, <abbr class="region" title="Ontario">ON</abbr> <span class="postal-code">M5V 1R9</span><br>
-          <span class="country-name">Canada</span>
+          <span itemprop="streetAddress">366 Adelaide St W, Suite 500</span><br>
+          <span itemprop="addressLocality">Toronto</span>, <abbr itemprop="addressRegion" title="Ontario">ON</abbr> <span itemprop="postalCode">M5V 1R9</span><br>
+          <span itemprop="addressCountry">Canada</span>
         {% endtrans %}
         </p>
 

--- a/bedrock/mozorg/templates/mozorg/contact/spaces/vancouver.html
+++ b/bedrock/mozorg/templates/mozorg/contact/spaces/vancouver.html
@@ -9,14 +9,15 @@
 {% block contact_entry %}
   <div id="entry-container">
     <section class="entry entry-space" id="vancouver" data-tab="spaces">
-      <div class="card vcard">
-        <h2 class="fn">{{ _('Vancouver') }}</h2>
-        <p class="adr">
-        {# L10n: Addresses are marked up with hCard microformat. See http://microformats.org/wiki/h-card #}
+      <div class="card" itemscope itemtype="http://schema.org/Organization">
+        <h2>{{ _('Vancouver') }}</h2>
+        <meta itemprop="name" content="{{ _('Mozilla Space, Vancouver') }}">
+        <p itemprop="address" itemscope itemtype="http://schema.org/PostalAddress">
+        {# L10n: Addresses are marked up with Schema.org. See http://schema.org/PostalAddress #}
         {% trans %}
-          <span class="street-address">163 W Hastings St</span>, <span class="extended-address">Suite 209</span><br>
-          <span class="locality">Vancouver</span>, <abbr title="British Columbia" class="region">BC</abbr> <span class="postal-code">V6B 1H5</span><br>
-          <span class="country-name">Canada</span>
+          <span itemprop="streetAddress">163 W Hastings St, Suite 209</span><br>
+          <span itemprop="addressLocality">Vancouver</span>, <abbr itemprop="addressRegion" title="British Columbia">BC</abbr> <span itemprop="postalCode">V6B 1H5</span><br>
+          <span itemprop="addressCountry">Canada</span>
         {% endtrans %}
         </p>
 

--- a/media/css/mozorg/contact-spaces.less
+++ b/media/css/mozorg/contact-spaces.less
@@ -365,7 +365,7 @@
             text-shadow: none;
         }
 
-        .adr {
+        [itemprop="address"] {
             margin: 0 0 .5em;
             padding-left: 20px;
             position: relative;


### PR DESCRIPTION
Since the current names, like "Auckland", are too generic for the organization names, I have embedded better names like "Mozilla Space, Auckland" with meta elements. It's a valid format in Schema.org.

Also fixed the properties of the Tokyo space.
