### PR TITLE
[fix bug 943647] Add graceful degradation for IE7 on spaces contact page...

### DIFF
--- a/bedrock/mozorg/templates/mozorg/contact/contact-base.html
+++ b/bedrock/mozorg/templates/mozorg/contact/contact-base.html
@@ -10,13 +10,21 @@
 
 {% block extrahead %}
   {{ css('contact-spaces') }}
-  <!--[if lte IE 8]>
+  <!--[if IE 8]>
     {{ css('contact-spaces-ie8') }}
+  <![endif]-->
+  <!--[if lte IE 7]>
+    {{ css('contact-spaces-ie7') }}
   <![endif]-->
 {% endblock %}
 
 {% block js %}
-  {{ js('contact-spaces') }}
+  <!--[if gte IE 8]><!-->
+    {{ js('contact-spaces') }}
+  <!--<![endif]-->
+  <!--[if lte IE 7]>
+    {{ js('contact-spaces-ie7') }}
+  <![endif]-->
 {% endblock %}
 
 {% block string_data %}

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -136,6 +136,9 @@ MINIFY_BUNDLES = {
         'contact-spaces-ie8': (
             'css/libs/mapbox.ie.css',
         ),
+        'contact-spaces-ie7': (
+            'css/mozorg/contact-spaces-ie7.less',
+        ),
         'contribute': (
             'css/mozorg/contribute.less',
             'css/sandstone/video-resp.less',
@@ -401,6 +404,9 @@ MINIFY_BUNDLES = {
             'js/libs/jquery.history.js',
             'js/mozorg/contact-data.js',
             'js/mozorg/contact-spaces.js',
+        ),
+        'contact-spaces-ie7': (
+            'js/mozorg/contact-spaces-ie7.js',
         ),
         'contribute': (
             'js/libs/jquery.sequence.js',

--- a/media/css/mozorg/contact-spaces-ie7.less
+++ b/media/css/mozorg/contact-spaces-ie7.less
@@ -1,0 +1,27 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#map {
+    display: none;
+}
+
+.page-title {
+    background: #b30406;
+}
+
+#page-content {
+    margin-top: 140px;
+}
+
+.category-tabs {
+    li {
+        a {
+            width: 218px;
+        }
+    }
+}
+
+#outer-wrapper {
+    overflow: hidden;
+}

--- a/media/js/mozorg/contact-spaces-ie7.js
+++ b/media/js/mozorg/contact-spaces-ie7.js
@@ -1,0 +1,72 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+(function($) {
+    "use strict";
+
+    var mozMap = {
+
+        /*
+         * Sets the initial active tab and nav items on page load
+         * using the id and data-tab attribute of the entry section element
+         */
+        setInitialPageNavState: function () {
+            var $entry = $('#entry-container .entry');
+            var tab = $entry.data('tab');
+            var id = $entry.attr('id');
+
+            // set the current tab navigation item
+            $('ul.category-tabs li[data-id="' + tab + '"]').addClass('current');
+
+            // set the current list menu navigation item
+            $('.nav-category li[data-id="' + id + '"]').addClass('current');
+
+            // hide the community sub menu's
+            $('.accordion .submenu').hide();
+
+            // show the correct menu navigation
+            mozMap.toggleNav(tab);
+
+            // show the correct community sub menu
+            mozMap.toggleCommunitySubMenu();
+        },
+
+        /*
+         * Toggles the active tab nav menu visibility
+         */
+        toggleNav: function (tab) {
+            if (tab === 'spaces') {
+                $('#nav-communities, #meta-communities').hide();
+                $('#nav-spaces, #meta-spaces').show();
+            } else if (tab === 'communities') {
+                $('#nav-spaces, #meta-spaces').hide();
+                $('#nav-communities, #meta-communities').show();
+            }
+        },
+
+        /*
+         * Toggles the active community submenu nav
+         */
+        toggleCommunitySubMenu: function () {
+            var $current = $('#nav-communities li.current');
+            var $parent = $current.parent();
+
+            // if current item has a sub-menu which isn't open
+            if ($current.hasClass('hasmenu') && !$current.hasClass('open')) {
+                $('.accordion .submenu:visible').hide().parent().removeClass('open');
+                $current.addClass('open');
+                $current.find('.submenu').show();
+            }
+
+            // if current item is within a sub-menu and it's parent is not open
+            if ($parent.hasClass('submenu') && !$parent.is(':visible')) {
+                $('.accordion .submenu:visible').hide().parent().removeClass('open');
+                $parent.show().parent().addClass('open');
+            }
+        }
+    };
+
+    mozMap.setInitialPageNavState();
+
+})(jQuery);


### PR DESCRIPTION
Mapbox does not support IE7 ([more info](https://www.mapbox.com/blog/internet-explorer-seven/)), so this PR aims to add some graceful degradation for that browser:
- Adds an IE7 specific CSS stylesheet to fix up some layout issues
- Adds an IE7 JS file, as there is no need to load mapbox.js or the spaces & community data. This new file simply show's the right menu's on load, ensuring the pages are navigable.

This allows IE7 users to browse all the contact/spaces/community information, as well as still see the static maps.
