### PR TITLE
Avoid non-default box-sizing styles in tabzilla

### DIFF
--- a/media/css/tabzilla/tabzilla.less
+++ b/media/css/tabzilla/tabzilla.less
@@ -103,6 +103,15 @@
     outline:none;
 }
 
+/* Tabzilla still must use content-box model to preserve layout */
+#tabzilla-panel *,
+#tabzilla-panel *:before,
+#tabzilla-panel *:after {
+    -webkit-box-sizing: content-box;
+       -moz-box-sizing: content-box;
+            box-sizing: content-box;
+}
+
 #tabzilla-contents {
     width: 960px;
     margin: 0 auto;


### PR DESCRIPTION
Bug 934348
Also fixes issue #1461
Thanks to @alexgibson for pointing to his version of this in remo.
