### PR TITLE
Disable custom /firefox/whatsnew view for pl. Bug 936269.

### DIFF
--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -300,7 +300,7 @@ class FirstrunView(LatestFxView):
 
 class WhatsnewView(LatestFxView):
     # Locales targeted for FxOS
-    fxos_locales = ['pl']
+    fxos_locales = []
 
     locales_with_video = {
         'en-US': 'american',


### PR DESCRIPTION
- Keeping functionality & template around for future use.

Simplest PR ever man.

Didn't just update master in the case that the view code should be changed/optimized when (temporarily) having no possible branching.
