### PR TITLE
Bug 868169: Redirect android download interstitial pages to play store

### DIFF
--- a/etc/httpd/global.conf
+++ b/etc/httpd/global.conf
@@ -573,3 +573,6 @@ RewriteRule ^/en-US/press/mozilla-foundation.html http://blog.mozilla.org/press/
 RewriteRule ^/en-US/press/mozilla1.0.html http://blog.mozilla.org/press/2002/06/mozilla-org-launches-mozilla-1-0/ [L,R=301]
 RewriteRule ^/en-US/press/open-source-security.html http://blog.mozilla.org/press/2000/01/open-source-development-of-security-products-possible-worldwide-enhancing-security-and-privacy-for-e-commerce-and-communication/ [L,R=301]
 
+# bug 868169
+RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?mobile/android-download\.html https://play.google.com/store/apps/details?id=org.mozilla.firefox [QSA,L,R=301]
+RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?mobile/android-download-beta\.html https://play.google.com/store/apps/details?id=org.mozilla.firefox_beta [QSA,L,R=301]


### PR DESCRIPTION
The [QSA] flag on the RewriteRule causes apache to keep and merge the Query
String from the original URL with the new one.

@jgmize r?
