### PR TITLE
Bug 947890 Redirect legacy Firefox release notes to archive

### DIFF
--- a/etc/httpd/global.conf
+++ b/etc/httpd/global.conf
@@ -435,6 +435,9 @@ RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/os/releasenotes/1.1(.*)$ /b/$1firefo
 RewriteRule ^/projects/devpreview/firstrun(?:/(?:index.html)?)?$ /firefox/firstrun/ [L,R=301]
 RewriteRule ^/projects/devpreview/(.*)$ http://website-archive.mozilla.org/www.mozilla.org/devpreview_releasenotes/projects/devpreview/$1 [L,R=301]
 
+# bug 947890
+RewriteRule ^/en-US/firefox/releases/1\.(.*)$ http://website-archive.mozilla.org/www.mozilla.org/firefox_releasenotes/en-US/firefox/releases/1.$1 [L,R=301]
+RewriteRule ^/en-US/firefox/releases/0\.(.*)$ http://website-archive.mozilla.org/www.mozilla.org/firefox_releasenotes/en-US/firefox/releases/0.$1 [L,R=301]
 
 # bug 818323
 RewriteRule ^/projects/security/known-vulnerabilities.html$ /security/known-vulnerabilities/ [L,R=301]


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=947890

These two lines could probably be done in one, but I wasn't exactly sure of the syntax, and this seemed a bit more readable. 
