### PR TITLE
Bug 906943: Update transbar string to avoid substitution.

### DIFF
--- a/bedrock/tabzilla/templates/tabzilla/tabzilla.js
+++ b/bedrock/tabzilla/templates/tabzilla/tabzilla.js
@@ -385,11 +385,6 @@ var Tabzilla = (function (Tabzilla) {
         userLang = (langLink.length) ? langLink.attr('hreflang')
                                      : langOption.val();
 
-        // The language label: English (US) -> English
-        var langLabel = (langLink.length) ? langLink.attr('title')
-                                          : langOption.text();
-        langLabel = langLabel.match(/^(.+?)(\s\(.+\))?$/)[1];
-
         // Log the language of the current page
         transbar.onshow.trackLabel = transbar.oncancel.trackLabel = userLang;
         transbar.oncancel.trackAction = 'hide';
@@ -411,7 +406,6 @@ var Tabzilla = (function (Tabzilla) {
         $.ajax({ url: '{{ settings.CDN_BASE_URL }}/' + userLang + '/tabzilla/transbar.jsonp',
                  cache: false, crossDomain: true, dataType: 'jsonp',
                  jsonpCallback: "_", success: function (str) {
-            str.message = str.message.replace('%s', langLabel);
             transbar.show(str).attr('lang', userLang);
         }});
     };

--- a/bedrock/tabzilla/templates/tabzilla/transbar.jsonp
+++ b/bedrock/tabzilla/templates/tabzilla/transbar.jsonp
@@ -1,7 +1,7 @@
 {% set_lang_files "tabzilla/tabzilla" %}
 _({
-    {# L10n: %s will be replaced with a language name like English. You can instead hardcode your language name in the string if you want. -#}
-    "message": "{{ _('Would you like to see this page in %s?')|js_escape }}",
+    {# L10n: You can replace 'in your language' in this string by the name of your language if you want. -#}
+    "message": "{{ _('Would you like to see this page in your language?')|js_escape }}",
     {# L10n: Your translation can just say Yes -#}
     "accept": "{{ _('Yes, please!')|js_escape }}",
     {# L10n: Your translation can just say No -#}


### PR DESCRIPTION
Many (most) localizers prefer to include their language name in their
translation for gramatical and style reasons.

@alexgibson @kyoshino r?
