### PR TITLE
Move self-executing function to end of tabzilla.js. Bug 950121

### DIFF
--- a/bedrock/tabzilla/templates/tabzilla/tabzilla.js
+++ b/bedrock/tabzilla/templates/tabzilla/tabzilla.js
@@ -569,19 +569,6 @@ var Tabzilla = (function (Tabzilla) {
         script.src = '//mozorg.cdn.mozilla.net/media/js/libs/jquery-' + minimumJQuery + '.min.js';
         document.getElementsByTagName('head')[0].appendChild(script);
     };
-    (function () {
-        if (window.jQuery !== undefined &&
-            Tabzilla.compareVersion(window.jQuery.fn.jquery, minimumJQuery) !== -1
-        ) {
-            // set up local jQuery aliases
-            jQuery = window.jQuery;
-            $ = jQuery;
-            $(document).ready(init);
-        } else {
-            // no jQuery or older than minimum required jQuery
-            loadJQuery(init);
-        }
-    })();
     // icn=tabz appended to links for Google Analytics purposes
     var content =
       '<div id="tabzilla-panel" class="tabzilla-closed" tabindex="-1">'
@@ -659,6 +646,21 @@ var Tabzilla = (function (Tabzilla) {
     + '    </div>'
     + '  </div>';
     + '</div>';
+
+    // Self-executing function must be after all vars have been initialized
+    (function () {
+        if (window.jQuery !== undefined &&
+            Tabzilla.compareVersion(window.jQuery.fn.jquery, minimumJQuery) !== -1
+        ) {
+            // set up local jQuery aliases
+            jQuery = window.jQuery;
+            $ = jQuery;
+            $(document).ready(init);
+        } else {
+            // no jQuery or older than minimum required jQuery
+            loadJQuery(init);
+        }
+    })();
 
     return Tabzilla;
 


### PR DESCRIPTION
Kind of a tricky one to track down and test. From the bug:

> The self-executing function that calls the init function in tabzilla.js is declared before the content var is initialized (possibly) resulting in undefined content.
> 
> This bug has not shown up on mozilla.org likely due to init being called within $(document).ready. mozilla.org's doc.ready must take long enough for the parser to evaluate the content var's initialization.
