### PR TITLE
Fix bug 854992 - Make subject line of contribute email localizable

### DIFF
--- a/bedrock/mozorg/email_contribute.py
+++ b/bedrock/mozorg/email_contribute.py
@@ -156,7 +156,7 @@ def send(request, data):
     functional_area = FUNCTIONAL_AREAS_DICT[data['interest']]
 
     from_ = 'contribute-form@mozilla.org'
-    subject = 'Inquiry about Mozilla %s' % functional_area.subject
+    subject = _('Welcome to Mozilla!')
     msg = jingo.render_to_string(request, 'mozorg/emails/infos.txt', data)
     headers = {'Reply-To': data['email']}
 


### PR DESCRIPTION
First PR against bedrock :smile:

Took @nukeador's suggestion in the bugzilla bug: rather than customize the subject line per functional area, I went with the simple and friendly, "Welcome to Mozilla!"

Couple of questions:
- The bug mentions that metrics relies on the subject line in analyzing emails--should that block merging this PR?
- Do I need to add unit tests for this change?
- I haven't extracted the new string and put it in the l10n svn repo, do I need to do that, or will bedrock's l10n crew handle it? (On Persona, @mathjazz would handle that part for us.)
- Are there cleanup opportunities I've missed within this file, simplifying the FUNCTIONAL_AREAS dict, or is it fine as it stands?
- In general, should questions like these go in the bugzilla bug instead? Not sure quite where to draw the line.
