### PR TITLE
Fix Bug 948007 - [B2G][Browser] Scrolling the Sign up for our monthly newsletter window scrolls the webpage behind it

### DIFF
--- a/media/js/firefox/os/desktop.js
+++ b/media/js/firefox/os/desktop.js
@@ -223,7 +223,7 @@
     }
 
     Mozilla.Modal.createModal(this, $signup_content, {
-        allowScroll: true,
+        allowScroll: !isSmallViewport,
         title: '<img src="/media/img/firefox/os/logo/firefox-os-white.png" alt="mozilla" />'
     });
 
@@ -303,7 +303,7 @@
     }
 
     Mozilla.Modal.createModal(this, $get_phone_content, {
-        allowScroll: true,
+        allowScroll: !isSmallViewport,
         title: '<img src="/media/img/firefox/os/logo/firefox-os-white.png" alt="mozilla" />'
     });
 


### PR DESCRIPTION
Disallow scroll on mobile devices. Tested on Android and Firefox OS phones.
