### PR TITLE
Bug 919581 - Remove conditional for en-US/locales on about/ intro paragraph

### DIFF
--- a/bedrock/mozorg/templates/mozorg/about.html
+++ b/bedrock/mozorg/templates/mozorg/about.html
@@ -26,15 +26,7 @@
 
   <h1 class="title-shadow-box">{{ _('Get to know Mozilla') }}</h1>
 
-  <p class="intro">
-    {# Note: This conditional is in place until the new en-US string can be translated. We
-       need to remove it in the future once l10n has caught up. #}
-    {% if request.locale.startswith('en-') %}
-      {{ _('Learn more about our projects, products and principles designed to help people take control and explore the full potential of their lives online.') }}
-    {% else %}
-      {{ _('Whether you want to learn more about who we are, how to be a part of Mozilla or just where to find us, you’ve come to the right place.') }}
-    {% endif %}
-  </p>
+  <p class="intro">{{ _('Learn more about our projects, products and principles designed to help people take control and explore the full potential of their lives online.') }}</p>
 
   <ul class="links">
     <li>


### PR DESCRIPTION
Current coverage is good to remove the condition (45 locales, 96% coverage).
