### PR TITLE
[State of Mozilla 2012] Fix video links

### DIFF
--- a/bedrock/foundation/templates/foundation/annualreport/2012/index.html
+++ b/bedrock/foundation/templates/foundation/annualreport/2012/index.html
@@ -51,7 +51,7 @@
 
       <ul class="box-links videos">
         <li class="baker">
-          <a class="video-play" id="baker-video-link" href="//videos-cdn.mozilla.net/brand/Mozilla_2011_Story.webm" title="{{ _('Click to play this video') }}" data-title="Mitchell Baker">
+          <a class="video-play" id="baker-video-link" href="//videos-cdn.mozilla.net/uploads/drafts/State of Mozilla 2013/State_of_Mozilla_Mitchell Baker_Who_is_Mozilla.webm" title="{{ _('Click to play this video') }}" data-title="Mitchell Baker">
             {# L10n: Text in <span> below visible to screen readers only. Line break is for visual formatting. #}
             {{ _('<span>Play a video of </span>Mitchell <br>Baker') }}
           </a>
@@ -66,7 +66,7 @@
           </div>
         </li>
         <li class="sullivan">
-          <a class="video-play" id="sullivan-video-link" href="//videos-cdn.mozilla.net/brand/Mozilla_2011_Story.webm" title="{{ _('Click to play this video') }}" data-title="Jay Sullivan">
+          <a class="video-play" id="sullivan-video-link" href="//videos-cdn.mozilla.net/uploads/drafts/State of Mozilla 2013/State_of_Mozilla_Jay_Sullivan_vision_for_Mozilla_products.webm" title="{{ _('Click to play this video') }}" data-title="Jay Sullivan">
             {# L10n: Text in <span> below visible to screen readers only. Line break is for visual formatting. #}
             {{ _('<span>Play a video of </span>Jay <br>Sullivan') }}
           </a>
@@ -81,7 +81,7 @@
           </div>
         </li>
         <li class="anderson">
-          <a class="video-play" id="anderson-video-link" href="//videos-cdn.mozilla.net/brand/Mozilla_2011_Story.webm" title="{{ _('Click to play this video') }}" data-title="Harvey Anderson">
+          <a class="video-play" id="anderson-video-link" href="//videos-cdn.mozilla.net/uploads/drafts/State of Mozilla 2013/State_of_Mozilla_Harvey_Anderson_Health_of_the_web.webm" title="{{ _('Click to play this video') }}" data-title="Harvey Anderson">
             {# L10n: Text in <span> below visible to screen readers only. Line break is for visual formatting. #}
             {{ _('<span>Play a video of </span>Harvey <br>Anderson') }}
           </a>
@@ -96,7 +96,7 @@
           </div>
         </li>
         <li class="surman">
-          <a class="video-play" id="surman-video-link" href="//videos-cdn.mozilla.net/brand/Mozilla_2011_Story.webm" title="{{ _('Click to play this video') }}" data-title="Mark Surman">
+          <a class="video-play" id="surman-video-link" href="//videos-cdn.mozilla.net/uploads/drafts/State of Mozilla 2013/State_of_Mozilla_Mark_Surman_how_are_we_teaching_the_web_to_the_world.webm" title="{{ _('Click to play this video') }}" data-title="Mark Surman">
             {# L10n: Text in <span> below visible to screen readers only. Line break is for visual formatting. #}
             {{ _('<span>Play a video of </span>Mark <br>Surman') }}
           </a>
@@ -111,7 +111,7 @@
           </div>
         </li>
         <li class="nightingale">
-          <a class="video-play" id="nightingale-video-link" href="//videos-cdn.mozilla.net/brand/Mozilla_2011_Story.webm" title="{{ _('Click to play this video') }}" data-title="Johnathan Nightingale">
+          <a class="video-play" id="nightingale-video-link" href="//videos-cdn.mozilla.net/uploads/drafts/State of Mozilla 2013/State of Mozilla - Johnathan Nightingale - How Firefox is continuing to break new ground..webm" title="{{ _('Click to play this video') }}" data-title="Johnathan Nightingale">
             {# L10n: Text in <span> below visible to screen readers only. Line break is for visual formatting. #}
             {{ _('<span>Play a video of </span>Johnathan <br>Nightingale')}}
           </a>
@@ -126,7 +126,7 @@
           </div>
         </li>
         <li class="eich">
-          <a class="video-play" id="eich-video-link" href="//videos-cdn.mozilla.net/brand/Mozilla_2011_Story.webm" title="{{ _('Click to play this video') }}" data-title="Brendan Eich">
+          <a class="video-play" id="eich-video-link" href="//videos-cdn.mozilla.net/uploads/drafts/State of Mozilla 2013/State_of_Mozilla_Brendan Eich_Envolving_the_web.webm" title="{{ _('Click to play this video') }}" data-title="Brendan Eich">
             {# L10n: Text in <span> below visible to screen readers only. Line break is for visual formatting. #}
             {{ _('<span>Play a video of </span>Brendan <br>Eich') }}
           </a>
@@ -164,7 +164,7 @@
 
       <ul class="box-links videos">
         <li class="mozillian">
-          <a class="video-play" id="mozillian-video-link" href="//videos-cdn.mozilla.net/brand/Mozilla_2011_Story.webm" title="{{ _('Click to play this video') }}" data-title="{{ _('I am a Mozillian') }}">
+          <a class="video-play" id="mozillian-video-link" href="//videos-cdn.mozilla.net/uploads/drafts/State of Mozilla 2013/I_am_a_Mozillian.webm" title="{{ _('Click to play this video') }}" data-title="{{ _('I am a Mozillian') }}">
             {# L10n: Text in <span> below visible to screen readers only. #}
             {{ _('<span>Play the "</span>I am a Mozillian<span>" video</span>') }}
           </a>


### PR DESCRIPTION
I just noticed the videos were located under /**uploads**/**drafts**/State of Mozilla **2013**/ :wink: 
