### PR TITLE
Bug 944093 - remove fundraiser promo from tabzilla

### DIFF
--- a/bedrock/tabzilla/templates/tabzilla/tabzilla.js
+++ b/bedrock/tabzilla/templates/tabzilla/tabzilla.js
@@ -597,21 +597,12 @@ var Tabzilla = (function (Tabzilla) {
       '<div id="tabzilla-panel" class="tabzilla-closed" tabindex="-1">'
     + '  <div id="tabzilla-contents">'
     + '    <div id="tabzilla-promo">'
-    {% if request.locale in ['de', 'en-US', 'fr', 'pt-BR'] %}
-    + '      <div class="snippet" id="tabzilla-promo-donate-201312">'
-    + '        <a href="{{ donate_url() }}?icn=tabz&amp;source=tabzilla_image&amp;amount=20">'
-    + '          <h4>{{ _('Support Mozilla')|js_escape }}</h4>'
-    + '          <span class="button">{{ _('Donate')|js_escape }}</span>'
-    + '        </a>'
-    + '      </div>'
-    {% else %}
     +'      <div class="snippet" id="tabzilla-promo-fxos">'
     + '        <a href="https://www.mozilla.org/firefox/os/?icn=tabz">'
     + '          <h4>{{ _('Look ahead')|js_escape }}</h4>'
     + '          <p>{{ _('Learn all about Firefox OS')|js_escape }} »</p>'
     + '        </a>'
     + '      </div>'
-    {% endif %}
     + '    </div>'
     + '    <div id="tabzilla-nav">'
     + '      <ul>'

--- a/media/css/tabzilla/tabzilla.less
+++ b/media/css/tabzilla/tabzilla.less
@@ -435,51 +435,7 @@ html[lang=ru] {
     }
 }
 
-#tabzilla-promo .snippet#tabzilla-promo-donate-201312 a {
-    background: #c13832 url(/media/img/tabzilla/promo-donate-201312.png?2013-12);
-    background: url(/media/img/tabzilla/promo-donate-201312.png?2013-12),
-        #c13832 -webkit-linear-gradient(top, rgba(0,0,0,0) 80%, rgba(0,0,0,0.04) 90%, rgba(0,0,0,0.1) 95%, rgba(0,0,0,0.12) 100%);
-    background: url(/media/img/tabzilla/promo-donate-201312.png?2013-12),
-        #c13832 -moz-linear-gradient(top, rgba(0,0,0,0) 80%, rgba(0,0,0,0.04) 90%, rgba(0,0,0,0.1) 95%, rgba(0,0,0,0.12) 100%);
-    background: url(/media/img/tabzilla/promo-donate-201312.png?2013-12),
-        #c13832 -o-linear-gradient(top, rgba(0,0,0,0) 80%, rgba(0,0,0,0.04) 90%, rgba(0,0,0,0.1) 95%, rgba(0,0,0,0.12) 100%);
-    background: url(/media/img/tabzilla/promo-donate-201312.png?2013-12),
-        #c13832 linear-gradient(top, rgba(0,0,0,0) 80%, rgba(0,0,0,0.04) 90%, rgba(0,0,0,0.1) 95%, rgba(0,0,0,0.12) 100%);
 
-    background-repeat: no-repeat;
-    background-repeat: no-repeat, repeat-x;
-    background-position: -24px 16px;
-    background-position: -24px 16px, 0 0;
-
-    padding: 30px 10px 10px 150px;
-    height: 170px;
-    h4 {
-        font: bold 26px/26px 'Open Sans', sans-serif;
-        text-transform: uppercase;
-        color: #fff;
-        text-shadow: none;
-        margin-bottom: 1em;
-    }
-    span.button {
-        display: block;
-        font: 16px 'Open Sans Light', sans-serif;
-        padding: 10px;
-        width: 110px;
-        &:after {
-            content: ' »';
-        }
-    }
-}
-
-html[lang='de'] #tabzilla-promo .snippet#tabzilla-promo-donate-201312 a {
-    padding-left: 110px;
-    background-position: -68px 16px;
-    background-position: -68px 16px, 0 0;
-    h4 {
-        font-size: 22px;
-        line-height: 24px;
-    }
-}
 
 @media (-webkit-min-device-pixel-ratio: 1.5),
        (                min-resolution: 1.5dppx),
@@ -491,21 +447,6 @@ html[lang='de'] #tabzilla-promo .snippet#tabzilla-promo-donate-201312 a {
         background-size: 12px 10px;
     }
 
-    // high res promo background
-    #tabzilla-promo .snippet#tabzilla-promo-donate-201312 a {
-        background-image: url(/media/img/tabzilla/promo-donate-201312-hires.png);
-        background-image: url(/media/img/tabzilla/promo-donate-201312-hires.png),
-            -webkit-linear-gradient(top, rgba(0,0,0,0) 80%, rgba(0,0,0,0.04) 90%, rgba(0,0,0,0.1) 95%, rgba(0,0,0,0.12) 100%);
-        background-image: url(/media/img/tabzilla/promo-donate-201312-hires.png),
-            -moz-linear-gradient(top, rgba(0,0,0,0) 80%, rgba(0,0,0,0.04) 90%, rgba(0,0,0,0.1) 95%, rgba(0,0,0,0.12) 100%);
-        background-image: url(/media/img/tabzilla/promo-donate-201312-hires.png),
-            -o-linear-gradient(top, rgba(0,0,0,0) 80%, rgba(0,0,0,0.04) 90%, rgba(0,0,0,0.1) 95%, rgba(0,0,0,0.12) 100%);
-        background-image: url(/media/img/tabzilla/promo-donate-201312-hires.png),
-            linear-gradient(top, rgba(0,0,0,0) 80%, rgba(0,0,0,0.04) 90%, rgba(0,0,0,0.1) 95%, rgba(0,0,0,0.12) 100%);
-
-        background-size: 162px 135px;
-        background-size: 162px 135px, auto auto;
-    }
 }
 
 @media only screen and (min-width: 720px) and (max-width: 979px) {


### PR DESCRIPTION
This just removes the promo and reverts to the FxOS fallback. We'll update the donate links soon, once we have a new tag.
