### PR TITLE
Bug 956392: Escape ampersands in links

### DIFF
--- a/bedrock/firefox/templates/firefox/nightly_firstrun.html
+++ b/bedrock/firefox/templates/firefox/nightly_firstrun.html
@@ -41,7 +41,7 @@
 
     <h2>{{ _('Links in video') }}</h2>
     <ul class="unstyled">
-      <li><a href="http://widget.mibbit.com/?server=irc.mozilla.org&channel=%23testday">{{ _('Attend a Test Day every Friday on #testday') }}</a></li>
+      <li><a href="http://widget.mibbit.com/?server=irc.mozilla.org&amp;channel=%23testday">{{ _('Attend a Test Day every Friday on #testday') }}</a></li>
       <li><a href="{{ url('firefox.channel')|urlparams(hash='aurora') }}">{{ _('Download Firefox Aurora') }}</a></li>
       <li><a href="https://input.mozilla.org/feedback">{{ _('Submit feedback') }}</a></li>
       <li><a href="https://bugzilla.mozilla.org/enter_bug.cgi?product=Firefox">{{ _('Report bugs in Bugzilla') }}</a></li>

--- a/bedrock/firefox/templates/firefox/os/_notes_sidebar.html
+++ b/bedrock/firefox/templates/firefox/os/_notes_sidebar.html
@@ -32,7 +32,7 @@
       and <a href="{{ geckocode }}" rel="external">Gecko</a>
     {% endtrans %}
     </li>
-    <li><a href="https://bugzilla.mozilla.org/buglist.cgi?list_id=6785406&amp;resolution=---&amp;query_format=advanced&amp;bug_status=UNCONFIRMED&amp;bug_status=NEW&amp;bug_status=REOPENED&product=Boot2Gecko" rel="external">{{ _('Known Bugs') }}</a></li>
+    <li><a href="https://bugzilla.mozilla.org/buglist.cgi?list_id=6785406&amp;resolution=---&amp;query_format=advanced&amp;bug_status=UNCONFIRMED&amp;bug_status=NEW&amp;bug_status=REOPENED&amp;product=Boot2Gecko" rel="external">{{ _('Known Bugs') }}</a></li>
   </ul>
 </section>
 

--- a/bedrock/mozorg/templates/mozorg/about/governance/policies/security/certs/included.html
+++ b/bedrock/mozorg/templates/mozorg/about/governance/policies/security/certs/included.html
@@ -15,10 +15,10 @@
   <h1 class="title-banner">{{ _('Mozilla Included CA Certificate List') }}</h1>
   <p>{{ _('This is a list of CA certificates that are distributed with Mozilla software products. You can view the <a href="%s">source file with all of the included root certificates</a>.')|format('http://mxr.mozilla.org/mozilla-central/source/security/nss/lib/ckfw/builtins/certdata.txt') }}</p>
 
-  <p>{{ _('If the spreadsheet does not display in the iframe below, then you may <a href="%s">access the spreadsheet directly</a>.')|format('https://docs.google.com/spreadsheet/pub?key=0Ah-tHXMAwqU3dGx0cGFObG9QM192NFM4UWNBMlBaekE&single=true&gid=1&output=html') }}</p>
+  <p>{{ _('If the spreadsheet does not display in the iframe below, then you may <a href="%s">access the spreadsheet directly</a>.')|format('https://docs.google.com/spreadsheet/pub?key=0Ah-tHXMAwqU3dGx0cGFObG9QM192NFM4UWNBMlBaekE&amp;single=true&amp;gid=1&amp;output=html') }}</p>
 
-  <iframe height="700px" width="100%" src="https://docs.google.com/spreadsheet/pub?key=0Ah-tHXMAwqU3dGx0cGFObG9QM192NFM4UWNBMlBaekE&single=true&gid=1&output=html">
-    <a href="https://docs.google.com/spreadsheet/pub?key=0Ah-tHXMAwqU3dGx0cGFObG9QM192NFM4UWNBMlBaekE&single=true&gid=1&output=html">{{ _('View spreadsheet') }}</a>
+  <iframe height="700px" width="100%" src="https://docs.google.com/spreadsheet/pub?key=0Ah-tHXMAwqU3dGx0cGFObG9QM192NFM4UWNBMlBaekE&amp;single=true&amp;gid=1&amp;output=html">
+    <a href="https://docs.google.com/spreadsheet/pub?key=0Ah-tHXMAwqU3dGx0cGFObG9QM192NFM4UWNBMlBaekE&amp;single=true&amp;gid=1&amp;output=html">{{ _('View spreadsheet') }}</a>
   </iframe>
 
 

--- a/bedrock/mozorg/templates/mozorg/about/governance/policies/security/certs/pending.html
+++ b/bedrock/mozorg/templates/mozorg/about/governance/policies/security/certs/pending.html
@@ -37,10 +37,10 @@
 
   <p>{{ _('View the <a href="%s">list of CA certificates that are currently distributed with Mozilla software products</a>.')|format(url('mozorg.about.governance.policies.security.certs.included')) }}</p>
 
-  <p>{{ _('If the spreadsheet does not display in the iframe below, then you may <a href="%s">access the spreadsheet directly</a>.')|format('https://docs.google.com/spreadsheet/pub?key=0Ah-tHXMAwqU3dHEtbFRSUGVtN0hoUVZnajFNRlJWenc&output=html') }}</p>
+  <p>{{ _('If the spreadsheet does not display in the iframe below, then you may <a href="%s">access the spreadsheet directly</a>.')|format('https://docs.google.com/spreadsheet/pub?key=0Ah-tHXMAwqU3dHEtbFRSUGVtN0hoUVZnajFNRlJWenc&amp;output=html') }}</p>
 
-  <iframe width="100%" height="700px" src="https://docs.google.com/spreadsheet/pub?key=0Ah-tHXMAwqU3dHEtbFRSUGVtN0hoUVZnajFNRlJWenc&output=html">
-    <a href="https://docs.google.com/spreadsheet/pub?key=0Ah-tHXMAwqU3dHEtbFRSUGVtN0hoUVZnajFNRlJWenc&output=html">{{ _('View spreadsheet') }}</a>
+  <iframe width="100%" height="700px" src="https://docs.google.com/spreadsheet/pub?key=0Ah-tHXMAwqU3dHEtbFRSUGVtN0hoUVZnajFNRlJWenc&amp;output=html">
+    <a href="https://docs.google.com/spreadsheet/pub?key=0Ah-tHXMAwqU3dHEtbFRSUGVtN0hoUVZnajFNRlJWenc&amp;output=html">{{ _('View spreadsheet') }}</a>
   </iframe>
 
 {% endblock %}

--- a/bedrock/mozorg/templates/mozorg/about/governance/policies/security/tld-idn.html
+++ b/bedrock/mozorg/templates/mozorg/about/governance/policies/security/tld-idn.html
@@ -194,7 +194,7 @@ a link to their policy page, with an explanation of how their policy is equally 
   </tr>
   <tr>
     <td>.lt</td>
-    <td><a href="http://www.domreg.lt/public?pg=&sp=&loc=en">{{ _('Registry') }}</a></td>
+    <td><a href="http://www.domreg.lt/public?pg=&amp;sp=&amp;loc=en">{{ _('Registry') }}</a></td>
     <td><a href="http://www.domreg.lt/public?pg=8A7FB6&amp;sp=idn&amp;loc=en">{{ _('Policy') }}</a></td>
     <td><a href="http://www.domreg.lt/static/doc/public/idn_symbols-en.pdf">{{ _('Character List') }}</a></td>
   </tr>


### PR DESCRIPTION
Found some unescaped ampersands when looking at Bug 956392.
