### PR TITLE
Bug 957283: firefox/speed page for pt-BR

### DIFF
--- a/bedrock/firefox/templates/firefox/speed.html
+++ b/bedrock/firefox/templates/firefox/speed.html
@@ -84,9 +84,13 @@
     </div>
 
     <p id="followup">
+    <em>
+    {% trans %}
+        New Firefox is faster, free (as always), crashes less and protects  your privacy more.
+    {% endtrans %}
+    </em>
     {% trans url=url('firefox.new') %}
-        <em>New Firefox is faster, free (as always), crashes less and protects
-        your privacy more.</em> <a href="{{ url }}">Upgrading</a> takes less
+        <a href="{{ url }}">Upgrading</a> takes less
         than a minute and you won’t lose your history or bookmarks. Hooray!
     {% endtrans %}
     </p>

--- a/etc/httpd/global.conf
+++ b/etc/httpd/global.conf
@@ -196,6 +196,9 @@ RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/community(/?)$ /$1contribute/ [L,R=3
 # TODO: Remove when all locales are done.
 RewriteRule ^/(af|an|ar|ast|bg|br|ca|cs|csb|cy|da|de|el|eo|es-AR|es-CL|es-ES|es-MX|et|eu|fa|fi|fr|fy-NL|ga-IE|gd|hi-IN|hr|hu|hy-AM|id|is|it|ka|kk|km|ko|ku|lij|lt|lv|mk|ml|mr|ms|my|nb-NO|nl|oc|pa-IN|pl|pt-BR|pt-PT|rm|ro|ru|sk|sl|son|sq|sr|sv-SE|ta|te|th|tr|uk|ur|xh|zh-CN|zh-TW)/firefox/new(/?)$ /b/$1/firefox/new$2 [PT]
 
+# bug 957283
+RewriteRule ^/(pt-BR)/firefox/speed(/?)$ /b/$1/firefox/speed$2 [PT]
+
 # bug 796952, 915845, 915867
 RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/unsupported/(.*)$ /b/$1firefox/unsupported/$2 [PT]
 


### PR DESCRIPTION
- added a redirect for pt-BR to no longer hit the php page
- split a string in two to match the strings we already have translated
