### PR TITLE
Bug 439031 - Missing link(s) to system requirements page

### DIFF
--- a/bedrock/firefox/templates/firefox/all.html
+++ b/bedrock/firefox/templates/firefox/all.html
@@ -22,6 +22,7 @@
   <hgroup id="main-feature">
     <h1>{{_('Download Firefox in your language')}}</h1>
     <h2>{{ _('Firefox is available in more than %s languages thanks to the contributions of Mozilla community members from around the world.')|format('70') }}</h2>
+    <p><a class="sysreq" href="{{ url('firefox.latest.sysreq') }}">{{ _('Check the system requirements') }}</a></p>
   </hgroup>
 
   <form id="language-search" method="get">

--- a/media/css/firefox/all.less
+++ b/media/css/firefox/all.less
@@ -17,6 +17,15 @@
         letter-spacing: -0.25px;
         .span(10);
         line-height: 1.1;
+        float: none;
+    }
+    p {
+        .span-all();
+        margin-top: @baseLine;
+
+        a.sysreq:after {
+            content: "\00A0\00BB";
+        }
     }
 }
 
@@ -144,6 +153,9 @@
             font-size: 18px;
             letter-spacing: normal;
             .span-all();
+        }
+        p {
+            margin-top: @baseLine / 2;
         }
     }
 


### PR DESCRIPTION
Add a link to the sysreq page to /firefox/all/
