### PR TITLE
Bug 944936 - Correct the org names in space hcards

### DIFF
--- a/bedrock/mozorg/templates/mozorg/contact/spaces/auckland.html
+++ b/bedrock/mozorg/templates/mozorg/contact/spaces/auckland.html
@@ -10,8 +10,8 @@
   <div id="entry-container">
     <section class="entry entry-space" id="auckland" data-tab="spaces">
       <div itemscope itemtype="http://schema.org/Organization" class="card vcard">
-        <h2 class="fn">{{ _('Auckland') }}</h2>
-        <meta itemprop="name" content="{{ _('Mozilla, Auckland') }}">
+        {# L10n: This span around the Mozilla name is presentational. It's included in the string in case some locales need to change the order. #}
+        <h2 itemprop="name" class="fn org">{{ _('<span>Mozilla</span> Auckland') }}</h2>
         <p itemprop="address" itemscope itemtype="http://schema.org/PostalAddress" class="adr">
         {# L10n: Addresses are marked up with hCard microformat and Schema.org. See http://microformats.org/wiki/h-card and http://schema.org/PostalAddress #}
         {% trans %}

--- a/bedrock/mozorg/templates/mozorg/contact/spaces/beijing.html
+++ b/bedrock/mozorg/templates/mozorg/contact/spaces/beijing.html
@@ -10,8 +10,8 @@
   <div id="entry-container">
     <section class="entry entry-space" id="beijing" data-tab="spaces">
       <div itemscope itemtype="http://schema.org/Organization" class="card vcard">
-        <h2 class="fn">{{ _('Beijing') }}</h2>
-        <meta itemprop="name" content="{{ _('Mozilla, Beijing') }}">
+        {# L10n: This span around the Mozilla name is presentational. It's included in the string in case some locales need to change the order. #}
+        <h2 itemprop="name" class="fn org">{{ _('<span>Mozilla</span> Beijing') }}</h2>
         <p itemprop="address" itemscope itemtype="http://schema.org/PostalAddress" class="adr">
         {# L10n: Addresses are marked up with hCard microformat and Schema.org. See http://microformats.org/wiki/h-card and http://schema.org/PostalAddress #}
         {% trans %}

--- a/bedrock/mozorg/templates/mozorg/contact/spaces/berlin.html
+++ b/bedrock/mozorg/templates/mozorg/contact/spaces/berlin.html
@@ -10,8 +10,8 @@
   <div id="entry-container">
     <section class="entry entry-space" id="berlin" data-tab="spaces">
       <div itemscope itemtype="http://schema.org/Organization" class="card vcard">
-        <h2 class="fn">{{ _('Berlin') }}</h2>
-        <meta itemprop="name" content="{{ _('Mozilla, Berlin') }}">
+        {# L10n: This span around the Mozilla name is presentational. It's included in the string in case some locales need to change the order. #}
+        <h2 itemprop="name" class="fn org">{{ _('<span>Mozilla</span> Berlin') }}</h2>
         <p itemprop="address" itemscope itemtype="http://schema.org/PostalAddress" class="adr">
         {# L10n: Addresses are marked up with hCard microformat and Schema.org. See http://microformats.org/wiki/h-card and http://schema.org/PostalAddress #}
         {% trans %}

--- a/bedrock/mozorg/templates/mozorg/contact/spaces/london.html
+++ b/bedrock/mozorg/templates/mozorg/contact/spaces/london.html
@@ -10,8 +10,8 @@
   <div id="entry-container">
     <section class="entry entry-space" id="london" data-tab="spaces">
       <div itemscope itemtype="http://schema.org/Organization" class="card vcard">
-        <h2 class="fn">{{ _('London') }}</h2>
-        <meta itemprop="name" content="{{ _('Mozilla, London') }}">
+        {# L10n: This span around the Mozilla name is presentational. It's included in the string in case some locales need to change the order. #}
+        <h2 itemprop="name" class="fn org">{{ _('<span>Mozilla</span> London') }}</h2>
         <p itemprop="address" itemscope itemtype="http://schema.org/PostalAddress" class="adr">
         {# L10n: Addresses are marked up with hCard microformat and Schema.org. See http://microformats.org/wiki/h-card and http://schema.org/PostalAddress #}
         {% trans %}

--- a/bedrock/mozorg/templates/mozorg/contact/spaces/mountain-view.html
+++ b/bedrock/mozorg/templates/mozorg/contact/spaces/mountain-view.html
@@ -10,8 +10,8 @@
   <div id="entry-container">
     <section class="entry entry-space" id="mountain-view" data-tab="spaces">
       <div itemscope itemtype="http://schema.org/Organization" class="card vcard">
-        <h2 class="fn">{{ _('Mountain View') }}</h2>
-        <meta itemprop="name" content="{{ _('Mozilla, Mountain View') }}">
+        {# L10n: This span around the Mozilla name is presentational. It's included in the string in case some locales need to change the order. #}
+        <h2 itemprop="name" class="fn org">{{ _('<span>Mozilla</span> Mountain View') }}</h2>
         <p itemprop="address" itemscope itemtype="http://schema.org/PostalAddress" class="adr">
         {# L10n: Addresses are marked up with hCard microformat and Schema.org. See http://microformats.org/wiki/h-card and http://schema.org/PostalAddress #}
         {% trans %}

--- a/bedrock/mozorg/templates/mozorg/contact/spaces/paris.html
+++ b/bedrock/mozorg/templates/mozorg/contact/spaces/paris.html
@@ -10,8 +10,8 @@
   <div id="entry-container">
     <section class="entry entry-space" id="paris" data-tab="spaces">
       <div itemscope itemtype="http://schema.org/Organization" class="card vcard">
-        <h2 class="fn">{{ _('Paris') }}</h2>
-        <meta itemprop="name" content="{{ _('Mozilla, Paris') }}">
+        {# L10n: This span around the Mozilla name is presentational. It's included in the string in case some locales need to change the order. #}
+        <h2 itemprop="name" class="fn org">{{ _('<span>Mozilla</span> Paris') }}</h2>
         <p itemprop="address" itemscope itemtype="http://schema.org/PostalAddress" class="adr">
         {# L10n: Addresses are marked up with hCard microformat and Schema.org. See http://microformats.org/wiki/h-card and http://schema.org/PostalAddress #}
         {% trans %}

--- a/bedrock/mozorg/templates/mozorg/contact/spaces/portland.html
+++ b/bedrock/mozorg/templates/mozorg/contact/spaces/portland.html
@@ -10,8 +10,8 @@
   <div id="entry-container">
     <section class="entry entry-space" id="portland" data-tab="spaces">
       <div itemscope itemtype="http://schema.org/Organization" class="card vcard">
-        <h2 class="fn">{{ _('Portland') }}</h2>
-        <meta itemprop="name" content="{{ _('Mozilla, Portland') }}">
+        {# L10n: This span around the Mozilla name is presentational. It's included in the string in case some locales need to change the order. #}
+        <h2 itemprop="name" class="fn org">{{ _('<span>Mozilla</span> Portland') }}</h2>
         <p itemprop="address" itemscope itemtype="http://schema.org/PostalAddress" class="adr">
         {# L10n: Addresses are marked up with hCard microformat and Schema.org. See http://microformats.org/wiki/h-card and http://schema.org/PostalAddress #}
         {% trans %}

--- a/bedrock/mozorg/templates/mozorg/contact/spaces/san-francisco.html
+++ b/bedrock/mozorg/templates/mozorg/contact/spaces/san-francisco.html
@@ -10,8 +10,8 @@
   <div id="entry-container">
     <section class="entry entry-space" id="san-francisco" data-tab="spaces">
       <div itemscope itemtype="http://schema.org/Organization" class="card vcard">
-        <h2 class="fn">{{ _('San Francisco') }}</h2>
-        <meta itemprop="name" content="{{ _('Mozilla, San Francisco') }}">
+        {# L10n: This span around the Mozilla name is presentational. It's included in the string in case some locales need to change the order. #}
+        <h2 itemprop="name" class="fn org">{{ _('<span>Mozilla</span> San Francisco') }}</h2>
         <p itemprop="address" itemscope itemtype="http://schema.org/PostalAddress" class="adr">
         {# L10n: Addresses are marked up with hCard microformat and Schema.org. See http://microformats.org/wiki/h-card and http://schema.org/PostalAddress #}
         {% trans %}

--- a/bedrock/mozorg/templates/mozorg/contact/spaces/taipei.html
+++ b/bedrock/mozorg/templates/mozorg/contact/spaces/taipei.html
@@ -10,8 +10,8 @@
   <div id="entry-container">
     <section class="entry entry-space" id="taipei" data-tab="spaces">
       <div itemscope itemtype="http://schema.org/Organization" class="card vcard">
-        <h2 class="fn">{{ _('Taipei') }}</h2>
-        <meta itemprop="name" content="{{ _('Mozilla, Taipei') }}">
+        {# L10n: This span around the Mozilla name is presentational. It's included in the string in case some locales need to change the order. #}
+        <h2 itemprop="name" class="fn org">{{ _('<span>Mozilla</span> Taipei') }}</h2>
         <p itemprop="address" itemscope itemtype="http://schema.org/PostalAddress" class="adr">
         {# L10n: Addresses are marked up with hCard microformat and Schema.org. See http://microformats.org/wiki/h-card and http://schema.org/PostalAddress #}
         {% trans %}

--- a/bedrock/mozorg/templates/mozorg/contact/spaces/tokyo.html
+++ b/bedrock/mozorg/templates/mozorg/contact/spaces/tokyo.html
@@ -10,8 +10,8 @@
   <div id="entry-container">
     <section class="entry entry-space" id="tokyo" data-tab="spaces">
       <div itemscope itemtype="http://schema.org/Organization" class="card vcard">
-        <h2 class="fn">{{ _('Tokyo') }}</h2>
-        <meta itemprop="name" content="{{ _('Mozilla, Tokyo') }}">
+        {# L10n: This span around the Mozilla name is presentational. It's included in the string in case some locales need to change the order. #}
+        <h2 itemprop="name" class="fn org">{{ _('<span>Mozilla</span> Tokyo') }}</h2>
         <p itemprop="address" itemscope itemtype="http://schema.org/PostalAddress" class="adr">
         {# L10n: Addresses are marked up with hCard microformat and Schema.org. See http://microformats.org/wiki/h-card and http://schema.org/PostalAddress #}
         {% trans %}

--- a/bedrock/mozorg/templates/mozorg/contact/spaces/toronto.html
+++ b/bedrock/mozorg/templates/mozorg/contact/spaces/toronto.html
@@ -10,8 +10,8 @@
   <div id="entry-container">
     <section class="entry entry-space" id="toronto" data-tab="spaces">
       <div itemscope itemtype="http://schema.org/Organization" class="card vcard">
-        <h2 class="fn">{{ _('Toronto') }}</h2>
-        <meta itemprop="name" content="{{ _('Mozilla, Toronto') }}">
+        {# L10n: This span around the Mozilla name is presentational. It's included in the string in case some locales need to change the order. #}
+        <h2 itemprop="name" class="fn org">{{ _('<span>Mozilla</span> Toronto') }}</h2>
         <p itemprop="address" itemscope itemtype="http://schema.org/PostalAddress" class="adr">
         {# L10n: Addresses are marked up with hCard microformat and Schema.org. See http://microformats.org/wiki/h-card and http://schema.org/PostalAddress #}
         {% trans %}

--- a/bedrock/mozorg/templates/mozorg/contact/spaces/vancouver.html
+++ b/bedrock/mozorg/templates/mozorg/contact/spaces/vancouver.html
@@ -10,8 +10,8 @@
   <div id="entry-container">
     <section class="entry entry-space" id="vancouver" data-tab="spaces">
       <div itemscope itemtype="http://schema.org/Organization" class="card vcard">
-        <h2 class="fn">{{ _('Vancouver') }}</h2>
-        <meta itemprop="name" content="{{ _('Mozilla, Vancouver') }}">
+        {# L10n: This span around the Mozilla name is presentational. It's included in the string in case some locales need to change the order. #}
+        <h2 itemprop="name" class="fn org">{{ _('<span>Mozilla</span> Vancouver') }}</h2>
         <p itemprop="address" itemscope itemtype="http://schema.org/PostalAddress" class="adr">
         {# L10n: Addresses are marked up with hCard microformat and Schema.org. See http://microformats.org/wiki/h-card and http://schema.org/PostalAddress #}
         {% trans %}

--- a/media/css/mozorg/contact-spaces.less
+++ b/media/css/mozorg/contact-spaces.less
@@ -363,6 +363,10 @@
             font-weight: normal;
             letter-spacing: normal;
             text-shadow: none;
+
+            span {
+                .visually-hidden;
+            }
         }
 
         .adr {


### PR DESCRIPTION
hcard requires fn but without org it assume it's a person, not a company, and will try to split multiple words into family-name and given-name. But "Mountain View" isn't the correct value for org. This adds a hidden span so the actual org name reads "Mozilla Mountain View" and so on. And now we can also eliminate the meta for schema.org since the h2 has a better machine-readable value.
