### PR TITLE
Update page to say IDN TLD whitelist is no longer updated.

### DIFF
--- a/bedrock/mozorg/templates/mozorg/about/governance/policies/security/tld-idn.html
+++ b/bedrock/mozorg/templates/mozorg/about/governance/policies/security/tld-idn.html
@@ -16,7 +16,7 @@
 <h1 class="title-banner">{{ _('IDN-enabled TLDs') }}</h1>
 
 <p><strong>{% trans url='https://wiki.mozilla.org/IDN_Display_Algorithm' %}
-This document is of historical interest only. Firefox now uses an algorithm to decide which IDNs to display. <a href="{{ url }}">This document</a> has the details. The whitelist mechanism still remains in the product for backwards compatibility, but the whitelist of domains is no longer updated.
+This document is of historical interest only. Firefox now uses <a href="{{ url }}">an algorithm</a> to decide which IDNs to display. The whitelist mechanism still remains in the product for backwards compatibility, but the whitelist of domains is no longer updated.
 {% endtrans %}</strong></p>
 
 <h2>{{ _('ASCII Country Code or Generic/Sponsored Top Level Domains') }}</h2>


### PR DESCRIPTION
The IDN TLD whitelist has been superceded; the web page needs to reflect that.

Gerv
