### PR TITLE
Bug 958321 - load Droid Arabic Naskh only for pages that need it

### DIFF
--- a/bedrock/base/templates/base-resp.html
+++ b/bedrock/base/templates/base-resp.html
@@ -47,6 +47,29 @@
       {{ css('responsive') }}
     {% endblock %}
 
+    {% if LANG in ['ar', 'fa'] %}
+    {# bug 958321 #}
+      <style type="text/css">
+        @font-face {
+          font-family: 'Droid Arabic Naskh';
+          src: url({{ media('fonts/DroidNaskh-Regular.eot?#iefix') }}) format('embedded-opentype'),
+               url({{ media('fonts/DroidNaskh-Regular.woff') }}) format('woff'),
+               url({{ media('fonts/DroidNaskh-Regular.ttf') }}) format('truetype');
+          font-style: normal;
+          font-weight: normal;
+        }
+
+        @font-face {
+          font-family: 'Droid Arabic Naskh';
+          src: url({{ media('/fonts/DroidNaskh-Bold.eot?#iefix') }}) format('embedded-opentype'),
+               url({{ media('/fonts/DroidNaskh-Bold.woff') }}) format('woff'),
+               url({{ media('/fonts/DroidNaskh-Bold.ttf') }}) format('truetype');
+          font-style: normal;
+          font-weight: bold;
+        }
+      </style>
+    {% endif %}
+
     {% block extrahead %}{% endblock %}
 
     {{ js('site') }}

--- a/bedrock/base/templates/base.html
+++ b/bedrock/base/templates/base.html
@@ -43,6 +43,29 @@
       {{ css('common') }}
     {% endblock %}
 
+    {% if LANG in ['ar', 'fa'] %}
+    {# bug 958321 #}
+      <style type="text/css">
+        @font-face {
+          font-family: 'Droid Arabic Naskh';
+          src: url({{ media('fonts/DroidNaskh-Regular.eot?#iefix') }}) format('embedded-opentype'),
+               url({{ media('fonts/DroidNaskh-Regular.woff') }}) format('woff'),
+               url({{ media('fonts/DroidNaskh-Regular.ttf') }}) format('truetype');
+          font-style: normal;
+          font-weight: normal;
+        }
+
+        @font-face {
+          font-family: 'Droid Arabic Naskh';
+          src: url({{ media('/fonts/DroidNaskh-Bold.eot?#iefix') }}) format('embedded-opentype'),
+               url({{ media('/fonts/DroidNaskh-Bold.woff') }}) format('woff'),
+               url({{ media('/fonts/DroidNaskh-Bold.ttf') }}) format('truetype');
+          font-style: normal;
+          font-weight: bold;
+        }
+      </style>
+    {% endif %}
+
     {% block extrahead %}{% endblock %}
 
     {{ js('site') }}

--- a/media/css/sandstone/fonts.less
+++ b/media/css/sandstone/fonts.less
@@ -55,23 +55,3 @@
     font-weight: normal;
     font-style: italic;
 }
-
-
-// Droid Arabic Naskh (Early Access) http://www.google.com/webfonts/earlyaccess
-@font-face {
-  font-family: 'Droid Arabic Naskh';
-  src: url('/media/fonts/DroidNaskh-Regular.eot?#iefix') format('embedded-opentype'),
-       url('/media/fonts/DroidNaskh-Regular.woff') format('woff'),
-       url('/media/fonts/DroidNaskh-Regular.ttf') format('truetype');
-  font-style: normal;
-  font-weight: normal;
-}
-
-@font-face {
-  font-family: 'Droid Arabic Naskh';
-  src: url('/media/fonts/DroidNaskh-Bold.eot?#iefix') format('embedded-opentype'),
-       url('/media/fonts/DroidNaskh-Bold.woff') format('woff'),
-       url('/media/fonts/DroidNaskh-Bold.ttf') format('truetype');
-  font-style: normal;
-  font-weight: bold;
-}


### PR DESCRIPTION
Declaring this font in the base style sheet adds 200k and two additional requests when the majority of visitors won't even need it. Instead we can load it only when the page is in a language where this font can be of use.
