### PR TITLE
Consolidate press kit redirects for Bug 957664

### DIFF
--- a/etc/httpd/global.conf
+++ b/etc/httpd/global.conf
@@ -546,6 +546,9 @@ RewriteRule ^/projects/fennec/(.*) http://website-archive.mozilla.org/www.mozill
 # bug 957637
 RewriteRule ^/en-US/sopa/ https://blog.mozilla.org/blog/2012/01/19/firefox-users-engage-congress-sopa-strike-stats/ [L,R=301]
 
+# Bug 608370, 957664
+RewriteRule ^/en-US/press/kit(?:.*\.html|s/?)$ https://blog.mozilla.org/press/kits/ [R=301,L]
+
 # bug 877198
 RewriteRule ^/en-US/press/news.html http://blog.mozilla.org/press/ [L,R=301]
 RewriteRule ^/en-US/press/mozilla-2003-10-15.html http://blog.mozilla.org/press/2003/10/mozilla-foundation-launches-new-web-browser-and-end-user-services/ [L,R=301]


### PR DESCRIPTION
This replaces a set of redirects for various URLs under/around /en-US/press/kit/.

It also adds en-US/press/kit.html to the redirects, as it was missing previously.

The following URLs should be redirected:

http://www.mozilla.org/en-US/press/kit-3-6.html
http://www.mozilla.org/en-US/press/kit-4b.html
http://www.mozilla.org/en-US/press/kit-N900.html
http://www.mozilla.org/en-US/press/kit-android.html
http://www.mozilla.org/en-US/press/kits/

I'll be submitting a patch to remove the old redirects from the SVN/PHP site .htaccess on [Bug 957664](https://bugzilla.mozilla.org/show_bug.cgi?id=957664)
