### PR TITLE
Bug 854992 Make subject line of contribute email for end-users localizable.

### DIFF
--- a/bedrock/mozorg/email_contribute.py
+++ b/bedrock/mozorg/email_contribute.py
@@ -180,7 +180,7 @@ def autorespond(request, data):
     """
     functional_area = FUNCTIONAL_AREAS_DICT[data['interest']]
 
-    subject = 'Inquiry about Mozilla %s' % functional_area.subject
+    subject = _('Welcome to Mozilla!')
     to = [data['email']]
     from_ = 'contribute-form@mozilla.org'
     reply_to = ['contribute@mozilla.org']


### PR DESCRIPTION
Keep the existing filterable subject lines for Mozilla contacts.
Fixes 854992

**Don't merge until 1/15 at the earliest, to allow time for feedback from [the community](https://mail.mozilla.org/pipermail/community-building/2014-January/001056.html)**

Last time I submitted this, I changed the wrong subject line :-P This one looks correct to me--we give interested new people a localized "welcome" message, but keep the existing filterable/subject-specific subject line for Mozillians who work with new peeps.
