### PR TITLE
Bug 960064 Redirect Firefox VPAT pages to archive

### DIFF
--- a/etc/httpd/global.conf
+++ b/etc/httpd/global.conf
@@ -531,6 +531,10 @@ RewriteRule ^/en-US/mobile/home/1\.0/releasenotes(?:/(?:index.html)?)?$ http://w
 RewriteRule ^/en-US/mobile/home/1\.0\.2/releasenotes(?:/(?:index.html)?)?$ http://website-archive.mozilla.org/www.mozilla.org/firefox_home/en-US/mobile/home/1.0.2/releasenotes/  [L,R=301]
 RewriteRule ^/en-US/mobile/home/faq(?:/(?:index.html)?)?$ http://website-archive.mozilla.org/www.mozilla.org/firefox_home/en-US/mobile/home/faq/  [L,R=301]
 
+# bug 960064
+RewriteRule ^/en-US/firefox/(vpat-[\.1-5]+)(?:\.html)?$ http://website-archive.mozilla.org/www.mozilla.org/firefox_vpat/firefox-$1.html [L,R=301]
+RewriteRule ^/en-US/firefox/vpat(?:\.html)? http://website-archive.mozilla.org/www.mozilla.org/firefox_vpat/firefox-vpat-3.html [L,R=301]
+
 # bug 924687
 RewriteRule ^/en-US/opportunities(?:/(?:index.html)?)?$ https://careers.mozilla.org/ [L,R=301]
 


### PR DESCRIPTION
Redirecting:

http://www.mozilla.com/en-US/firefox/vpat-1.5.html
http://www.mozilla.com/en-US/firefox/vpat-2.html
http://www.mozilla.com/en-US/firefox/vpat-3.html
to:
http://website-archive.mozilla.org/www.mozilla.org/firefox_vpat/firefox-vpat-1.5.html
http://website-archive.mozilla.org/www.mozilla.org/firefox_vpat/firefox-vpat-2.html
http://website-archive.mozilla.org/www.mozilla.org/firefox_vpat/firefox-vpat-3.html

Also redirect /en-US/firefox/vpat.html to the v3 version so we can drop that [old redirect from the SVN .htaccess file](http://viewvc.svn.mozilla.org/vc/projects/mozilla.com/trunk/.htaccess?view=markup#l200).
