### PR TITLE
Add Gruntfile.js to bedrock [no bug]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ venv
 .vagrant
 *.db
 james.ini
+node_modules

--- a/.jshintrc-dist
+++ b/.jshintrc-dist
@@ -1,0 +1,89 @@
+{
+    // JSHint Default Configuration File (slightly edited for Bedrock)
+    // See http://jshint.com/docs/ for more details
+
+    "maxerr"        : 50,       // {int} Maximum error before stopping
+
+    // Enforcing
+    "bitwise"       : true,     // true: Prohibit bitwise operators (&, |, ^, etc.)
+    "camelcase"     : true,     // true: Identifiers must be in camelCase
+    "curly"         : true,     // true: Require {} for every new block or scope
+    "eqeqeq"        : true,     // true: Require triple equals (===) for comparison
+    "forin"         : true,     // true: Require filtering for..in loops with obj.hasOwnProperty()
+    "immed"         : false,    // true: Require immediate invocations to be wrapped in parens e.g. `(function () { } ());`
+    "indent"        : 4,        // {int} Number of spaces to use for indentation
+    "latedef"       : false,    // true: Require variables/functions to be defined before being used
+    "newcap"        : true,     // true: Require capitalization of all constructor functions e.g. `new F()`
+    "noarg"         : true,     // true: Prohibit use of `arguments.caller` and `arguments.callee`
+    "noempty"       : true,     // true: Prohibit use of empty blocks
+    "nonew"         : false,    // true: Prohibit use of constructors for side-effects (without assignment)
+    "plusplus"      : false,    // true: Prohibit use of `++` & `--`
+    "quotmark"      : true,     // Quotation mark consistency:
+                                //   false    : do nothing (default)
+                                //   true     : ensure whatever is used is consistent
+                                //   "single" : require single quotes
+                                //   "double" : require double quotes
+    "undef"         : true,     // true: Require all non-global variables to be declared (prevents global leaks)
+    "unused"        : true,     // true: Require all defined variables be used
+    "strict"        : true,     // true: Requires all functions run in ES5 Strict Mode
+    "trailing"      : true,     // true: Prohibit trailing whitespaces
+    "maxparams"     : false,    // {int} Max number of formal params allowed per function
+    "maxdepth"      : false,    // {int} Max depth of nested blocks (within functions)
+    "maxstatements" : false,    // {int} Max number statements per function
+    "maxcomplexity" : false,    // {int} Max cyclomatic complexity per function
+    "maxlen"        : false,    // {int} Max number of characters per line
+
+    // Relaxing
+    "asi"           : false,     // true: Tolerate Automatic Semicolon Insertion (no semicolons)
+    "boss"          : false,     // true: Tolerate assignments where comparisons would be expected
+    "debug"         : false,     // true: Allow debugger statements e.g. browser breakpoints.
+    "eqnull"        : false,     // true: Tolerate use of `== null`
+    "es5"           : false,     // true: Allow ES5 syntax (ex: getters and setters)
+    "esnext"        : false,     // true: Allow ES.next (ES6) syntax (ex: `const`)
+    "moz"           : false,     // true: Allow Mozilla specific syntax (extends and overrides esnext features)
+                                 // (ex: `for each`, multiple try/catch, function expression…)
+    "evil"          : false,     // true: Tolerate use of `eval` and `new Function()`
+    "expr"          : false,     // true: Tolerate `ExpressionStatement` as Programs
+    "funcscope"     : false,     // true: Tolerate defining variables inside control statements"
+    "globalstrict"  : false,     // true: Allow global "use strict" (also enables 'strict')
+    "iterator"      : false,     // true: Tolerate using the `__iterator__` property
+    "lastsemic"     : false,     // true: Tolerate omitting a semicolon for the last statement of a 1-line block
+    "laxbreak"      : false,     // true: Tolerate possibly unsafe line breakings
+    "laxcomma"      : false,     // true: Tolerate comma-first style coding
+    "loopfunc"      : false,     // true: Tolerate functions being defined in loops
+    "multistr"      : false,     // true: Tolerate multi-line strings
+    "proto"         : false,     // true: Tolerate using the `__proto__` property
+    "scripturl"     : false,     // true: Tolerate script-targeted URLs
+    "smarttabs"     : false,     // true: Tolerate mixed tabs/spaces when used for alignment
+    "shadow"        : false,     // true: Allows re-define variables later in code e.g. `var x=1; x=2;`
+    "sub"           : false,     // true: Tolerate using `[]` notation when it can still be expressed in dot notation
+    "supernew"      : false,     // true: Tolerate `new function () { ... };` and `new Object;`
+    "validthis"     : false,     // true: Tolerate using this in a non-constructor function
+
+    // Environments
+    "browser"       : true,     // Web Browser (window, document, etc)
+    "couch"         : false,    // CouchDB
+    "devel"         : true,     // Development/debugging (alert, confirm, etc)
+    "dojo"          : false,    // Dojo Toolkit
+    "jquery"        : true,     // jQuery
+    "mootools"      : false,    // MooTools
+    "node"          : false,    // Node.js
+    "nonstandard"   : false,    // Widely adopted globals (escape, unescape, etc)
+    "prototypejs"   : false,    // Prototype and Scriptaculous
+    "rhino"         : false,    // Rhino
+    "worker"        : false,    // Web Workers
+    "wsh"           : false,    // Windows Scripting Host
+    "yui"           : false,    // Yahoo User Interface
+
+    // Legacy
+    "nomen"         : false,    // true: Prohibit dangling `_` in variables
+    "onevar"        : false,    // true: Allow only one `var` statement per function
+    "passfail"      : false,    // true: Stop on first error
+    "white"         : false,    // true: Check against strict whitespace and indentation rules
+
+    // Custom Globals for bedrock
+    "globals"       : {
+        "Mozilla"   : false,
+        "gaTrack"   : false
+    }
+}

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,0 +1,64 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+path = require('path');
+
+module.exports = function (grunt) {
+
+    // Project configuration.
+    grunt.initConfig({
+        pkg: grunt.file.readJSON('package.json'),
+        jshint: {
+            options: {
+                jshintrc: true
+            },
+            development: ['media/js/**/*.js']
+        },
+        less: {
+            development: {
+                options: {
+                    paths: ['media/css/']
+                },
+                files: {
+                    'media/css/**/*.css': 'media/css/**/*.less'
+                }
+            }
+        },
+        watch: {
+            options: {
+                port: 35729,
+                livereload: true,
+                nospawn: true
+            },
+            css: {
+                files: ['media/css/**/*.less'],
+                tasks: ['less']
+            },
+            scripts: {
+                files: ['media/js/**/*.js'],
+                tasks: ['jshint']
+            },
+            html: {
+                files: ['bedrock/**/*.html']
+            }
+        }
+    });
+
+    // Update the config to only build the changed files.
+    grunt.event.on('watch', function (action, filepath) {
+        grunt.config(['less', 'development', 'files'], [
+            { src: filepath, dest: filepath + '.css' }
+        ]);
+
+        grunt.config(['jshint', 'development'], [filepath]);
+    });
+
+    grunt.loadNpmTasks('grunt-contrib-less');
+    grunt.loadNpmTasks('grunt-contrib-jshint');
+    grunt.loadNpmTasks('grunt-contrib-watch');
+
+    // Default task(s).
+    grunt.registerTask('default', ['watch']);
+
+};

--- a/bedrock/base/templates/base-resp.html
+++ b/bedrock/base/templates/base-resp.html
@@ -172,5 +172,8 @@
       <script src="{{ settings.CDN_BASE_URL }}{{ url('tabzilla') }}?build={{ BUILD_ID_JS }}"></script>
     {% endblock %}
     {% block js %}{% endblock %}
+    {% if settings.USE_GRUNT_LIVERELOAD %}
+      <script src="//localhost:35729/livereload.js"></script>
+    {% endif %}
   </body>
 </html>

--- a/bedrock/base/templates/base.html
+++ b/bedrock/base/templates/base.html
@@ -158,5 +158,8 @@
       <script src="{{ settings.CDN_BASE_URL }}{{ url('tabzilla') }}?build={{ BUILD_ID_JS }}"></script>
     {% endblock %}
     {% block js %}{% endblock %}
+    {% if settings.USE_GRUNT_LIVERELOAD %}
+      <script src="//localhost:35729/livereload.js"></script>
+    {% endif %}
   </body>
 </html>

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -911,3 +911,6 @@ OPTIMIZELY_PROJECT_ID = None
 GOOGLE_PLAY_FIREFOX_LINK = ('https://play.google.com/store/apps/details?'
                             'id=org.mozilla.firefox&utm_source=mozilla&'
                             'utm_medium=Referral&utm_campaign=mozilla-org')
+
+# Use bedrock Gruntfile.js for live reload
+USE_GRUNT_LIVERELOAD = False

--- a/bedrock/settings/local.py-dist
+++ b/bedrock/settings/local.py-dist
@@ -26,3 +26,5 @@ STATSD_CLIENT = 'django_statsd.clients.normal'
 GA_ACCOUNT_CODE = ''
 
 SESSION_COOKIE_SECURE = False
+
+USE_GRUNT_LIVERELOAD = False

--- a/docs/grunt.rst
+++ b/docs/grunt.rst
@@ -1,0 +1,66 @@
+.. This Source Code Form is subject to the terms of the Mozilla Public
+.. License, v. 2.0. If a copy of the MPL was not distributed with this
+.. file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+.. _grunt:
+
+===========
+Using Grunt
+===========
+
+Introduction
+------------
+
+If you haven't used `Grunt <http://gruntjs.com/>`_ before, be sure to check
+out the `Getting Started guide <http://gruntjs.com/getting-started>`_, as
+it explains how to create a `Gruntfile <http://gruntjs.com/sample-gruntfile>`_
+as well as install and use Grunt plugins.
+
+Bedrock provides a Gruntfile.js in the root of the project to make local
+development easier, by automating common tasks such as:
+
+* Compiling CSS when a LESS file changes.
+* Running `JSHint <http://www.jshint.com/>`_ when a JavaScript file changes.
+* Live reloading in the browser whenever an HTML, CSS of JavaScript file changes.
+
+
+Installation
+------------
+
+Grunt and Grunt plugins are installed and managed via `npm <https://npmjs.org/>`_,
+the `Node <http://nodejs.org/>`_ package manager.
+
+In order to get started, you'll want to install Grunt's command line interface
+(CLI) globally. You may need to use sudo (for OSX, *nix, BSD etc) or run your
+command shell as Administrator (for Windows) to do this.
+
+    npm install -g grunt-cli
+
+You may also want to install JSHint globally using:
+
+    npm install -g jshint
+
+Finally, install the dependencies that the bedrock Gruntfile needs:
+
+    npm install
+
+
+Usage
+-----
+
+To start the grunt task runner, simply run:
+
+    grunt
+
+To enable live-reload in the browser you must set `USE_GRUNT_LIVERELOAD` to
+`True` in `bedrock/settings/local.py`
+
+    USE_GRUNT_LIVERELOAD = True
+
+In the root directory you will also find a `.jshintrc-dist` file which contains
+a basic set of defaults for running JSHint. If you wish to use these defaults
+with Grunt then copy the contents to a local `.jshintrc` file:
+
+	cp .jshintrc-dist .jshintrc
+
+

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -29,5 +29,6 @@ Contents
    l10n
    coding
    contribute
+   grunt
    newsletters
    tabzilla

--- a/package.json
+++ b/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "bedrock",
+  "version": "0.1.0",
+  "description": "Making mozilla.org awesome, one pebble at a time",
+  "private": true,
+  "scripts": {},
+  "dependencies": {
+    "less": "~1.4.1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/mozilla/bedrock.git"
+  },
+  "author": "Mozilla",
+  "license": "MPL",
+  "bugs": {
+    "url": "https://bugzilla.mozilla.org/"
+  },
+  "devDependencies": {
+    "grunt": "~0.4.2",
+    "grunt-cli": "~0.1.11",
+    "grunt-contrib-watch": "~0.5.3",
+    "grunt-contrib-jshint": "~0.8.0",
+    "grunt-contrib-less": "~0.9.0"
+  }
+}


### PR DESCRIPTION
Let's try and improve our front-end development workflow on bedrock...

This PR includes a basic [Grunt](http://gruntjs.com/) file to help automate the following tasks:
- Compiling CSS when a LESS file changes (no more manually reloading the page twice, yay!).
- Running JSHint when a JavaScript file changes.
- Live reloading in the browser whenever an HTML, CSS of JavaScript file changes.

There's probably more stuff we can build on, but this is a start at least for discussion/testing.

This PR leaves using Grunt as totally optional, so it doesn't make getting set up on bedrock any more difficult. It is just there for those who may want to try using it.
