### PR TITLE
Redirect /mobile/credits to /credits/ for Bug 961010

### DIFF
--- a/etc/httpd/global.conf
+++ b/etc/httpd/global.conf
@@ -218,6 +218,9 @@ RewriteRule ^/en-US/mobile(/?)$ /b/en-US/mobile$1 [PT]
 RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/mobile/features(/?)$ /b/$1firefox/mobile/features$2 [PT]
 RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/mobile/faq(/?)$ /b/$1firefox/mobile/faq$2 [PT]
 
+# bug 961010
+RewriteRule ^/en-US/mobile/credits /credits/ [L,R=301]
+
 # bug 876668
 RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?mobile/customize(?:/.*)?$ /$1firefox/mobile/features/ [L,R=301]
 


### PR DESCRIPTION
leaving the open-ended /mobile/credits seemed like the simplest route
