### PR TITLE
Bug 860865 Add All Downloads page for Beta, Aurora, and ESR to bedrock

### DIFF
--- a/bedrock/firefox/templates/firefox/all.html
+++ b/bedrock/firefox/templates/firefox/all.html
@@ -2,25 +2,40 @@
 
 {% block extra_meta %}<meta name="robots" content="noindex">{% endblock %}
 
-{% block page_title %}{{ _('Download Firefox in your language') }}{% endblock %}
-{% block page_desc %}{{ _('Firefox is available in more than %s languages thanks to the contributions of Mozilla community members from around the world.')|format('80') }}{% endblock %}
+{% block page_title %}{{ _('Download %s in your language')|format(channel_name) }}{% endblock %}
 {% block body_id %}firefox-all{% endblock %}
+
+{% block page_desc %}
+  {% if channel == 'beta' %}
+    {{ _('Download Firefox Beta in your language and experience cutting edge features before they make it to final release. Provide feedback to help us refine and polish the next version of Firefox.') }}
+  {% elif channel == 'aurora' %}
+    {{ _('Download Firefox Aurora in your language to experience the newest features and innovations in an unstable environment even before they go to Beta. Give us feedback that will determine what makes it to Final Release and help shape the future of Firefox.') }}
+  {% elif channel == 'esr' %}
+    {{ _('Firefox ESR is intended for groups who deploy and maintain the desktop environment in large organizations. <a href="%s">Learn more.</a>')|format(url('firefox.organizations.organizations')) }}
+  {% else %}
+    {{ _('Firefox is available in more than %s languages thanks to the contributions of Mozilla community members from around the world.')|format('80') }}
+  {% endif %}
+{% endblock %}
+
+{% block body_class -%}
+  sky firefox-all-{{ channel }} {% if channel == 'aurora' %}space{% endif %}
+{% endblock %}
 
 {% block site_css %}
   {{ css('firefox_all') }}
 {% endblock %}
 
-{% block breadcrumbs %}
-  <nav class="breadcrumbs">
-    <a href="{{ url('mozorg.home') }}">{{_('Home')}}</a> >
-    <a href="/firefox/">{{_('Firefox')}}</a> >
-    <span>{{_('Languages')}}</span>
-  </nav>
+{% block site_header_logo %}
+  {% if channel == 'aurora' %}
+    <h2><a href="{{ url('firefox') }}"><img alt="Mozilla Firefox" height="70" width="185" src="{{media('img/firefox/template/header-logo-inverse.png?2013-06') }}"></a></h2>
+  {% else %}
+    {{ super() }}
+  {% endif %}
 {% endblock %}
 
 {% block content %}
   <hgroup id="main-feature">
-    <h1>{{_('Download Firefox in your language')}}</h1>
+    <h1>{{ self.page_title()  }}</h1>
     <h2>{{ self.page_desc() }}</h2>
     <p><a class="sysreq" href="{{ url('firefox.latest.sysreq') }}">{{ _('Check the system requirements') }}</a></p>
   </hgroup>

--- a/bedrock/firefox/urls.py
+++ b/bedrock/firefox/urls.py
@@ -17,7 +17,8 @@ whatsnew_re = latest_re % (version_re, 'whatsnew')
 
 urlpatterns = patterns('',
     redirect(r'^firefox/$', 'firefox.new', name='firefox'),
-    url(r'^firefox/all/$', views.all_downloads, name='firefox.all'),
+    url(r'^firefox/(?:(?P<channel>beta|aurora|organizations)/)?all/$',
+        views.all_downloads, name='firefox.all'),
     page('firefox/central', 'firefox/central.html'),
     page('firefox/channel', 'firefox/channel.html'),
     redirect('^firefox/channel/android/$', 'firefox.channel'),

--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -151,13 +151,29 @@ def dnt(request):
     return response
 
 
-def all_downloads(request):
-    version = get_latest_version()
+def all_downloads(request, channel):
+    if channel is None:
+        channel = 'release'
+
+    if channel == 'organizations':
+        channel = 'esr'
+
+    version = get_latest_version('firefox', channel)
     query = request.GET.get('q')
+
+    channel_names = {
+        'release': _('Firefox'),
+        'beta': _('Firefox Beta'),
+        'aurora': _('Firefox Aurora'),
+        'esr': _('Firefox Extended Support Release'),
+    }
+
     return l10n_utils.render(request, 'firefox/all.html', {
         'full_builds': firefox_details.get_filtered_full_builds(version, query),
         'test_builds': firefox_details.get_filtered_test_builds(version, query),
         'query': query,
+        'channel': channel,
+        'channel_name': channel_names[channel],
     })
 
 

--- a/etc/httpd/global.conf
+++ b/etc/httpd/global.conf
@@ -127,6 +127,12 @@ RewriteRule ^/en-US/firefox/search(?:\.html)?$ /en-US/firefox/ [L,R=301]
 # bug 957664
 RewriteRule ^/en-US/press/awards(?:\.html)?$ https://blog.mozilla.org/press/awards/ [L,R=301]
 
+# bug 860865
+RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/all-(?:beta|rc)(?:\.html)?$ /firefox/beta/all/ [L,R=301]
+RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/all-aurora(?:\.html)?$ /firefox/aurora/all/ [L,R=301]
+RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/organizations/all(?:\.html)?$ /firefox/organizations/all/ [L,R=301]
+RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/(aurora|beta)/all/$ /b/$1firefox/$2/all/ [PT]
+
 # bug 803345
 RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?apps(.*)$ /b/$1apps$2 [PT]
 
@@ -179,8 +185,7 @@ RewriteRule ^/en-US/firefox/customize(/?)$ /b/en-US/firefox/customize$1 [PT]
 RewriteRule ^/en-US/firefox/performance(/?)$ /b/en-US/firefox/performance$1 [PT]
 RewriteRule ^/en-US/firefox/technology(/?)$ /b/en-US/firefox/technology$1 [PT]
 RewriteRule ^/en-US/firefox/security(/?)$ /b/en-US/firefox/security$1 [PT]
-RewriteRule ^/en-US/firefox/organizations(/?)$ /b/en-US/firefox/organizations$1 [PT]
-RewriteRule ^/en-US/firefox/organizations/faq(/?)$ /b/en-US/firefox/organizations/faq$1 [PT]
+RewriteRule ^/en-US/firefox/organizations(.*)$ /b/en-US/firefox/organizations$1 [PT]
 RewriteRule ^/en-US/firefox/central(/?)$ /b/en-US/firefox/central$1 [PT]
 RewriteRule ^/en-US/firefox/happy(/?)$ /b/en-US/firefox/happy$1 [PT]
 RewriteRule ^/en-US/firefox/speed(/?)$ /b/en-US/firefox/speed$1 [PT]

--- a/media/css/firefox/all.less
+++ b/media/css/firefox/all.less
@@ -8,16 +8,14 @@
 
 #main-feature {
     h1 {
-        font-size: 64px;
         .span-all;
         margin-bottom: @baseLine;
     }
     h2 {
         font-size: 24px;
         letter-spacing: -0.25px;
-        .span(10);
         line-height: 1.1;
-        float: none;
+        .span-all();
     }
     p {
         .span-all();
@@ -26,6 +24,16 @@
         a.sysreq:after {
             content: "\00A0\00BB";
         }
+    }
+}
+
+.firefox-all-release #main-feature {
+    h1 {
+        font-size: 64px;
+    }
+    h2 {
+        .span(10);
+        float: none;
     }
 }
 


### PR DESCRIPTION
Update the existing release channel page to support the other channels. This will require redirects from the old URLs, but I thought I would solicit feedback on the new urls first:

/firefox/all/ (same as current)
/firefox/beta/all/ (was /firefox/all-beta.html)
/firefox/aurora/all/ (was /firefox/all-aurora.html)
/firefox/organizations/all/ (was /firefox/organizations/all.html)

This PR doesn't attempt to merge all four channel "all" pages into one page with tabs or anything like that, though it may make sense to come back to that. This keeps them as distinct pages on the front-end, but shares a view/template on the backend.

I also wondered if I should be keeping all those conditionals out of the template, and creating child-templates for the beta/aurora/esr pages instead. Feedback please.

Also, I've taken the text from the existing beta/aurora/esr all download pages on the PHP site, but this will still need attention from l10n.
