### PR TITLE
Bug 963240 - Firefox OS FAQ: links to SUMO in "Using Firefox OS" send users to an English page

### DIFF
--- a/bedrock/firefox/templates/firefox/os/faq.html
+++ b/bedrock/firefox/templates/firefox/os/faq.html
@@ -108,25 +108,25 @@
           <dt>{{_('How do I…')}}</dt>
           <dd>
             <ul>
-              <li><a href="https://support.mozilla.org/kb/firefox-os-user-guide#w_how-to-make-a-call">
+              <li><a href="https://support.mozilla.org/kb/make-calls-and-access-voicemail-firefox-os">
                 {{_('…make a call?')}}
               </a></li>
-              <li><a href="https://support.mozilla.org/kb/firefox-os-user-guide#w_importing-facebook-sim-contacts">
+              <li><a href="https://support.mozilla.org/kb/import-add-and-manage-contacts-firefox-os">
                 {{_('…import my contacts? ')}}
               </a></li>
-              <li><a href="https://support.mozilla.org/kb/using-messages-application-firefox-os">
+              <li><a href="https://support.mozilla.org/kb/how-to-use-messages-app">
                 {{_('…create and view messages? ')}}
               </a></li>
-              <li><a href="https://support.mozilla.org/kb/firefox-os-user-guide#w_search">
+              <li><a href="https://support.mozilla.org/kb/get-connected-access-wi-fi-and-cellular-networks">
                 {{_('…use the internet?')}}
               </a></li>
-              <li><a href="https://support.mozilla.org/kb/firefox-os-user-guide#w_downloading-and-installing-apps">
+              <li><a href="https://support.mozilla.org/kb/how-download-and-install-apps">
                 {{_('…download and install an app?')}}
               </a></li>
-              <li><a href="https://support.mozilla.org/kb/firefox-os-user-guide#w_pictures-video-music">
+              <li><a href="https://support.mozilla.org/kb/taking-photos-firefox-os">
                 {{_('…take pictures?')}}
               </a></li>
-              <li><a href="https://support.mozilla.org/kb/firefox-os-user-guide#w_composing-and-sending-emails">
+              <li><a href="https://support.mozilla.org/kb/send-and-manage-email">
                 {{_('…compose and send an email?')}}
               </a></li>
             </ul>
@@ -169,7 +169,7 @@
       <div class="expander-content">
           <p>
           {{_('Mozilla was the first to implement the Do Not Track privacy feature.')}}
-          {% trans url='https://support.mozilla.org/kb/configure-mobile-privacy-and-security-settings' %}
+          {% trans url='https://support.mozilla.org/kb/how-turn-do-not-track-feature-firefox-os' %}
           Firefox also features customizable security settings to manage passwords, history, private data, cookies, site options and add-ons. <a href="{{url}}">Learn more.</a>
           {% endtrans %}
           </p>


### PR DESCRIPTION
Point to single localized articles instead of gigantic Firefox OS Guide.
