### PR TITLE
bug 929775 -- change update redirect url

### DIFF
--- a/etc/httpd/global.conf
+++ b/etc/httpd/global.conf
@@ -187,7 +187,7 @@ RewriteRule ^/en-US/firefox/releases(/?)$ /b/en-US/firefox/releases$1 [PT]
 RewriteRule ^/(af|an|ar|az|be|br|ca|cs|cy|da|de|el|eo|es-AR|es-ES|es-CL|es-MX|et|eu|fi|fr|fy-NL|gd|gl|he|hr|hu|hy-AM|is|it|km|ko|ku|lt|mk|ms|nl|pa-IN|pl|pt-BR|ru|sk|sl|sq|sr|sv-SE|tr|uk|xh|zh-CN|zh-TW)/firefox/channel(/?)$ /b/$1/firefox/channel$2 [PT]
 
 # bug 929775
-RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/update(.*)?$ /$1firefox/new/ [L,R=301]
+RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/update(.*)?$ /$1firefox/new/?utm_source=mozilla.org&utm_medium=referral&utm_campaign=firefox-update-redirect [L,R=301]
 
 # bug 927442
 RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/community(/?)$ /$1contribute/ [L,R=301]


### PR DESCRIPTION
Added UTM tags to /firefox/new/ from /firefox/update/
