### PR TITLE
Fix bug 960138 - add Privacy Day home page promo

### DIFF
--- a/bedrock/mozorg/templates/mozorg/home.html
+++ b/bedrock/mozorg/templates/mozorg/home.html
@@ -60,7 +60,20 @@
   <section class="pillars">
     <ul class="accordion">
 
-    {% if l10n_has_tag('promo_lightbeam') or settings.DEV %}
+    {% if l10n_has_tag('promo_privacyday') or settings.DEV %}
+      <li id="panel-lightbeam" class="panel" tabindex="0">
+        <h2 class="panel-title">{{ _('Data Privacy Day') }}</h2>
+        <div class="panel-inner">
+          <div class="panel-content">
+            <a href="{{ url('lightbeam.lightbeam')  }}">
+              <h3>{{ _('See how we put your privacy first') }}</h3>
+              <p>{{ _('For Data Privacy Day, take control of your user data with the Lightbeam add-on for Firefox.') }}</p>
+              <p class="go">{{ _('Install the Lightbeam add-on') }}</p>
+            </a>
+          </div>
+        </div>
+      </li>
+    {% elif l10n_has_tag('promo_lightbeam') %}
       <li id="panel-lightbeam" class="panel" tabindex="0">
         {# L10n: The active word should be wrapped in <i></i> tags, though it may appear at a different position in the translated title. #}
         <h2 class="panel-title">{{ _('<i>Watch</i> the watchers') }}</h2>

--- a/media/css/mozorg/home.less
+++ b/media/css/mozorg/home.less
@@ -765,7 +765,7 @@
         position: static;
         width: auto;
         height: auto;
-        padding: .75em 20px .75em 40%;
+        padding: .75em 25px .75em 40%;
         min-height: 3em;
         text-align: left;
         font-size: 16px;
@@ -773,7 +773,7 @@
         &:after {
             content: '\25bc'; /* Down arrow */
             position: absolute;
-            right: 25px;
+            right: 18px;
             top: 35%;
         }
     }


### PR DESCRIPTION
Repurposing the Lightbeam promo with different copy.

This needs to go to production before January 28 (Tuesday). We'll remove it the following week.
