### PR TITLE
Redirect /press/awards to mozilla blog awards page

### DIFF
--- a/etc/httpd/global.conf
+++ b/etc/httpd/global.conf
@@ -124,6 +124,9 @@ RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/all/$ /b/$1firefox/all/ [PT]
 # bug 727561
 RewriteRule ^/en-US/firefox/search(?:\.html)?$ /en-US/firefox/ [L,R=301]
 
+# bug 957664
+RewriteRule ^/en-US/press/awards(?:\.html)?$ https://blog.mozilla.org/press/awards/ [L,R=301]
+
 # bug 803345
 RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?apps(.*)$ /b/$1apps$2 [PT]
 


### PR DESCRIPTION
Bug 727561
