### PR TITLE
Bug 860865, Reflect new /all/ download page URLs to download buttons and links

### DIFF
--- a/bedrock/firefox/templates/firefox/all.html
+++ b/bedrock/firefox/templates/firefox/all.html
@@ -37,7 +37,7 @@
   <hgroup id="main-feature">
     <h1>{{ self.page_title()  }}</h1>
     <h2>{{ self.page_desc() }}</h2>
-    <p><a class="sysreq" href="{{ url('firefox.latest.sysreq') }}">{{ _('Check the system requirements') }}</a></p>
+    <p><a class="sysreq" href="{{ product_url('firefox', 'sysreq', channel) }}">{{ _('Check the system requirements') }}</a></p>
   </hgroup>
 
   <form id="language-search" method="get">

--- a/bedrock/firefox/templates/firefox/firstrun.html
+++ b/bedrock/firefox/templates/firefox/firstrun.html
@@ -53,7 +53,7 @@
 <section id="colophon" class="billboard">
   <nav>
     <ul class="primary">
-      <li> <a href="{{ php_url('/firefox/notes') }}">{{ _('Release Notes') }}</a></li>
+      <li> <a href="{{ product_url('firefox', 'notes') }}">{{ _('Release Notes') }}</a></li>
       <li><a href="{{ url('firefox.features') }}">{{ _('Firefox Features') }}</a></li>
       <li><a href="https://support.mozilla.org/">{{ _('Firefox Help') }}</a></li>
     </ul>

--- a/bedrock/firefox/templates/firefox/nightly_firstrun.html
+++ b/bedrock/firefox/templates/firefox/nightly_firstrun.html
@@ -95,7 +95,7 @@
 <footer id="colophon">
   <nav>
     <ul class="primary">
-      <li> <a href="{{ php_url('/firefox/notes') }}">{{ _('Release Notes') }}</a></li>
+      <li> <a href="{{ product_url('firefox', 'notes') }}">{{ _('Release Notes') }}</a></li>
       <li><a href="{{ url('firefox.features') }}">{{ _('Firefox Features') }}</a></li>
       <li><a href="https://support.mozilla.org/">{{ _('Firefox Help') }}</a></li>
     </ul>

--- a/bedrock/firefox/templates/firefox/organizations/faq.html
+++ b/bedrock/firefox/templates/firefox/organizations/faq.html
@@ -169,6 +169,6 @@
 </p>
 
 <h4>{{ _('Where can I download Mozilla Firefox ESR?') }}</h4>
-<p>{{ _('You can download Mozilla Firefox ESR <a href="%s">here</a>.')|format(php_url('/firefox/organizations/all.html')) }}</p>
+<p>{{ _('You can download Mozilla Firefox ESR <a href="%s">here</a>.')|format(product_url('firefox', 'all', 'esr')) }}</p>
 
 {% endblock %}

--- a/bedrock/firefox/templates/firefox/whatsnew.html
+++ b/bedrock/firefox/templates/firefox/whatsnew.html
@@ -114,7 +114,7 @@
 <section id="colophon" class="billboard">
   <nav>
     <ul class="primary">
-      <li> <a href="{{ php_url('/firefox/notes') }}">{{ _('Release Notes') }}</a></li>
+      <li> <a href="{{ product_url('firefox', 'notes') }}">{{ _('Release Notes') }}</a></li>
       <li><a href="{{ url('firefox.features') }}">{{ _('Firefox Features') }}</a></li>
       <li><a href="https://support.mozilla.org/">{{ _('Firefox Help') }}</a></li>
     </ul>

--- a/bedrock/firefox/tests.py
+++ b/bedrock/firefox/tests.py
@@ -691,6 +691,12 @@ class TestNotesRedirects(TestCase):
         self._test('/firefox/aurora/notes/',
                    '/firefox/24.0a2/auroranotes/')
 
+    @patch.dict(product_details.firefox_versions,
+                FIREFOX_ESR='24.2.0esr')
+    def test_desktop_esr_version(self):
+        self._test('/firefox/organizations/notes/',
+                   '/firefox/24.2.0/releasenotes/')
+
     @patch.dict(product_details.mobile_details,
                 version='22.0')
     def test_mobile_release_version(self):
@@ -712,12 +718,33 @@ class TestNotesRedirects(TestCase):
 
 @patch.object(fx_views, 'firefox_details', firefox_details)
 class TestSysreqRedirect(TestCase):
-    @patch.dict(product_details.firefox_versions,
-                LATEST_FIREFOX_VERSION='22.0')
-    def test_release_version(self):
+    def _test(self, url_from, url_to):
         with self.activate('en-US'):
-            url = '/en-US/firefox/system-requirements.html'
+            url = '/en-US' + url_from
         response = self.client.get(url)
         eq_(response.status_code, 302)
-        eq_(response['Location'],
-            'http://testserver/en-US/firefox/22.0/system-requirements/')
+        eq_(response['Location'], 'http://testserver/en-US' + url_to)
+
+    @patch.dict(product_details.firefox_versions,
+                LATEST_FIREFOX_VERSION='22.0')
+    def test_desktop_release_version(self):
+        self._test('/firefox/system-requirements',
+                   '/firefox/22.0/system-requirements/')
+
+    @patch.dict(product_details.firefox_versions,
+                LATEST_FIREFOX_DEVEL_VERSION='23.0b1')
+    def test_desktop_beta_version(self):
+        self._test('/firefox/beta/system-requirements',
+                   '/firefox/23.0beta/system-requirements/')
+
+    @patch.dict(product_details.firefox_versions,
+                FIREFOX_AURORA='24.0a2')
+    def test_desktop_aurora_version(self):
+        self._test('/firefox/aurora/system-requirements',
+                   '/firefox/24.0a2/system-requirements/')
+
+    @patch.dict(product_details.firefox_versions,
+                FIREFOX_ESR='24.2.0esr')
+    def test_desktop_esr_version(self):
+        self._test('/firefox/organizations/system-requirements',
+                   '/firefox/24.0/system-requirements/')

--- a/bedrock/firefox/urls.py
+++ b/bedrock/firefox/urls.py
@@ -13,11 +13,13 @@ import views
 latest_re = r'^firefox(?:/(?P<fx_version>%s))?/%s/$'
 firstrun_re = latest_re % (version_re, 'firstrun')
 whatsnew_re = latest_re % (version_re, 'whatsnew')
+product_re = '(?P<product>firefox|mobile)'
+channel_re = '(?P<channel>beta|aurora|organizations)'
 
 
 urlpatterns = patterns('',
     redirect(r'^firefox/$', 'firefox.new', name='firefox'),
-    url(r'^firefox/(?:(?P<channel>beta|aurora|organizations)/)?all/$',
+    url(r'^firefox/(?:%s/)?all/$' % channel_re,
         views.all_downloads, name='firefox.all'),
     page('firefox/central', 'firefox/central.html'),
     page('firefox/channel', 'firefox/channel.html'),
@@ -27,11 +29,11 @@ urlpatterns = patterns('',
     page('firefox/fx', 'firefox/fx.html'),
     page('firefox/geolocation', 'firefox/geolocation.html'),
     page('firefox/happy', 'firefox/happy.html'),
-    url('^(?P<product>(firefox|mobile))/((?P<channel>(aurora|beta))/)?notes/$',
-        views.latest_notes, name='firefox.latest.notes'),
+    url('^(?:%s)/(?:%s/)?notes/$' % (product_re, channel_re),
+        views.latest_notes, name='firefox.notes'),
     url('^firefox/latest/releasenotes/$', views.latest_notes),
-    url('^firefox/system-requirements',
-        views.latest_sysreq, name='firefox.latest.sysreq'),
+    url('^firefox/(?:%s/)?system-requirements/?$' % channel_re,
+        views.latest_sysreq, name='firefox.sysreq'),
     page('firefox/memory', 'firefox/memory.html'),
     page('firefox/mobile/features', 'firefox/mobile/features.html'),
     page('firefox/mobile/faq', 'firefox/mobile/faq.html'),

--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -85,6 +85,9 @@ JS_DESKTOP = get_js_bundle_files('partners_desktop')
 
 
 def get_latest_version(product='firefox', channel='release'):
+    if channel == 'organizations':
+        channel = 'esr'
+
     if product == 'mobile':
         return mobile_details.latest_version(channel)
     else:
@@ -224,23 +227,29 @@ def releases_index(request):
 
 def latest_notes(request, product='firefox', channel='release'):
     version = get_latest_version(product, channel)
-    path = [
-        product,
-        re.sub(r'b\d+$', 'beta', version) if channel == 'beta' else version,
-        'auroranotes' if channel == 'aurora' else 'releasenotes'
-    ]
+
+    if channel == 'beta':
+        version = re.sub(r'b\d+$', 'beta', version)
+    if channel == 'organizations':
+        version = re.sub(r'esr$', '', version)
+
+    dir = 'auroranotes' if channel == 'aurora' else 'releasenotes'
+    path = [product, version, dir]
     locale = getattr(request, 'locale', None)
     if locale:
         path.insert(0, locale)
     return HttpResponseRedirect('/' + '/'.join(path) + '/')
 
 
-def latest_sysreq(request):
-    path = [
-        'firefox',
-        get_latest_version(),
-        'system-requirements'
-    ]
+def latest_sysreq(request, channel='release'):
+    version = get_latest_version('firefox', channel)
+
+    if channel == 'beta':
+        version = re.sub(r'b\d+$', 'beta', version)
+    if channel == 'organizations':
+        version = re.sub(r'^(\d+).+', r'\1.0', version)
+
+    path = ['firefox', version, 'system-requirements']
     locale = getattr(request, 'locale', None)
     if locale:
         path.insert(0, locale)

--- a/bedrock/mozorg/helpers/misc.py
+++ b/bedrock/mozorg/helpers/misc.py
@@ -378,3 +378,39 @@ def absolute_url(url):
         prefix = settings.CANONICAL_URL
 
     return prefix + url
+
+
+@jingo.register.function
+def product_url(product, page, channel=None):
+    """
+    Return a product-related URL like /firefox/all/ or /mobile/beta/notes/.
+
+    Examples
+    ========
+
+    In Template
+    -----------
+
+        {{ product_url('firefox', 'all', 'organizations') }}
+        {{ product_url('firefox', 'sysreq', channel) }}
+        {{ product_url('mobile', 'notes') }}
+    """
+
+    app = product
+    kwargs = {}
+
+    if product == 'mobile':
+        app = 'firefox'
+
+    # Tweak the channel name for the naming URL pattern in urls.py
+    if channel == 'release':
+        channel = None
+    if channel == 'esr':
+        channel = 'organizations'
+
+    if channel:
+        kwargs['channel'] = channel
+    if page == 'notes':
+        kwargs['product'] = product
+
+    return reverse('%s.%s' % (app, page), kwargs=kwargs)

--- a/bedrock/mozorg/templates/mozorg/download_firefox_button.html
+++ b/bedrock/mozorg/templates/mozorg/download_firefox_button.html
@@ -28,9 +28,8 @@
     <div class="unrecognized-download">
       {{ alt_buttons(builds) }}
     </div>
-    {% set requirements_url = php_url('/firefox/' ~ version ~ '/system-requirements/') %}
     <p class="unsupported-download">
-      {{ _('Your system doesn\'t meet the <a href="%(url)s">requirements</a> to run Firefox.')|format(url=requirements_url) }}
+      {{ _('Your system doesn\'t meet the <a href="%(url)s">requirements</a> to run Firefox.')|format(url=product_url('firefox', 'sysreq', build)) }}
     </p>
   {% endif %}
   <ul class="download-list">
@@ -71,23 +70,14 @@
   {% if show_mobile %}
     <small class="download-other os_android">
       <a href="https://support.mozilla.org/kb/will-firefox-work-my-mobile-device">{{ _('Supported Devices') }}</a> |
-      {% if build %}
-        <a href="/en-US/mobile/{{ build }}/notes">{{ _('What’s New') }}</a> |
-      {% else %}
-        <a href="/en-US/mobile/notes">{{ _('What’s New') }}</a> |
-      {% endif %}
+      <a href="{{ product_url('mobile', 'notes', build) }}">{{ _('What’s New') }}</a> |
       <a href="/en-US/legal/privacy/firefox.html">{{ _('Privacy') }}</a>
     </small>
   {% endif %}
   {% if show_desktop %}
     <small class="download-other os_linux os_osx os_windows">
-      {% if build %}
-        <a href="/en-US/firefox/all-{{ build }}.html">{{ _('Systems &amp; Languages') }}</a> |
-        <a href="/en-US/firefox/{{ build }}/notes">{{ _('What’s New') }}</a> |
-      {% else %}
-        <a href="/en-US/firefox/all">{{ _('Systems &amp; Languages') }}</a> |
-        <a href="/en-US/firefox/notes">{{ _('What’s New') }}</a> |
-      {% endif %}
+      <a href="{{ product_url('firefox', 'all', build) }}">{{ _('Systems &amp; Languages') }}</a> |
+      <a href="{{ product_url('firefox', 'notes', build) }}">{{ _('What’s New') }}</a> |
       <a href="/en-US/legal/privacy/firefox.html">{{ _('Privacy') }}</a>
     </small>
   {% endif %}

--- a/bedrock/mozorg/tests/test_helper_misc.py
+++ b/bedrock/mozorg/tests/test_helper_misc.py
@@ -518,3 +518,72 @@ class TestAbsoluteURLFilter(TestCase):
         expected = 'https:' + self.media_url_prod + self.image_path
         eq_(self._render(self.inline_template), expected)
         eq_(self._render(self.block_template), expected)
+
+
+class TestProductURL(TestCase):
+    rf = RequestFactory()
+
+    def _render(self, product, page, channel=None):
+        req = self.rf.get('/')
+        req.locale = 'en-US'
+        if channel:
+            tmpl = "{{ product_url('%s', '%s', '%s') }}" % (product, page, channel)
+        else:
+            tmpl = "{{ product_url('%s', '%s') }}" % (product, page)
+        return render(tmpl, {'request': req})
+
+    def test_firefox_all(self):
+        """Should return a reversed path for the Firefox download page"""
+        eq_(self._render('firefox', 'all'),
+            '/en-US/firefox/all/')
+        eq_(self._render('firefox', 'all', 'release'),
+            '/en-US/firefox/all/')
+        eq_(self._render('firefox', 'all', 'beta'),
+            '/en-US/firefox/beta/all/')
+        eq_(self._render('firefox', 'all', 'aurora'),
+            '/en-US/firefox/aurora/all/')
+        eq_(self._render('firefox', 'all', 'esr'),
+            '/en-US/firefox/organizations/all/')
+        eq_(self._render('firefox', 'all', 'organizations'),
+            '/en-US/firefox/organizations/all/')
+
+    def test_firefox_sysreq(self):
+        """Should return a reversed path for the Firefox sysreq page"""
+        eq_(self._render('firefox', 'sysreq'),
+            '/en-US/firefox/system-requirements')
+        eq_(self._render('firefox', 'sysreq', 'release'),
+            '/en-US/firefox/system-requirements')
+        eq_(self._render('firefox', 'sysreq', 'beta'),
+            '/en-US/firefox/beta/system-requirements')
+        eq_(self._render('firefox', 'sysreq', 'aurora'),
+            '/en-US/firefox/aurora/system-requirements')
+        eq_(self._render('firefox', 'sysreq', 'esr'),
+            '/en-US/firefox/organizations/system-requirements')
+        eq_(self._render('firefox', 'sysreq', 'organizations'),
+            '/en-US/firefox/organizations/system-requirements')
+
+    def test_firefox_notes(self):
+        """Should return a reversed path for the Firefox notes page"""
+        eq_(self._render('firefox', 'notes'),
+            '/en-US/firefox/notes/')
+        eq_(self._render('firefox', 'notes', 'release'),
+            '/en-US/firefox/notes/')
+        eq_(self._render('firefox', 'notes', 'beta'),
+            '/en-US/firefox/beta/notes/')
+        eq_(self._render('firefox', 'notes', 'aurora'),
+            '/en-US/firefox/aurora/notes/')
+        eq_(self._render('firefox', 'notes', 'esr'),
+            '/en-US/firefox/organizations/notes/')
+        eq_(self._render('firefox', 'notes', 'organizations'),
+            '/en-US/firefox/organizations/notes/')
+
+    def test_mobile_notes(self):
+        """Should return a reversed path for the mobile notes page"""
+        eq_(self._render('mobile', 'notes'),
+            '/en-US/mobile/notes/')
+        eq_(self._render('mobile', 'notes', 'release'),
+            '/en-US/mobile/notes/')
+        eq_(self._render('mobile', 'notes', 'beta'),
+            '/en-US/mobile/beta/notes/')
+        eq_(self._render('mobile', 'notes', 'aurora'),
+            '/en-US/mobile/aurora/notes/')


### PR DESCRIPTION
A follow-up of #1612. Use `/firefox/beta/all/` and `/firefox/aurora/all/` instead of `/firefox/all-beta.html` and `/firefox/all-aurora.html`. I'll update the privacy policy links in #1637.
