### PR TITLE
Fix Bug 966938 - Firefox ESR download page is 404 for localized browsers

### DIFF
--- a/etc/httpd/global.conf
+++ b/etc/httpd/global.conf
@@ -134,7 +134,8 @@ RewriteRule ^/en-US/press/awards(?:\.html)?$ https://blog.mozilla.org/press/awar
 RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/all-(?:beta|rc)(?:\.html)?$ /firefox/beta/all/ [L,R=301]
 RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/all-aurora(?:\.html)?$ /firefox/aurora/all/ [L,R=301]
 RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/organizations/all(?:\.html)?$ /firefox/organizations/all/ [L,R=301]
-RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/(aurora|beta)/all/$ /b/$1firefox/$2/all/ [PT]
+RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/(aurora|beta)/all(/?)$ /b/$1firefox/$2/all$3 [PT]
+RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/organizations(.*)$ /b/$1firefox/organizations$2 [PT]
 
 # bug 803345
 RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?apps(.*)$ /b/$1apps$2 [PT]
@@ -188,7 +189,6 @@ RewriteRule ^/en-US/firefox/customize(/?)$ /b/en-US/firefox/customize$1 [PT]
 RewriteRule ^/en-US/firefox/performance(/?)$ /b/en-US/firefox/performance$1 [PT]
 RewriteRule ^/en-US/firefox/technology(/?)$ /b/en-US/firefox/technology$1 [PT]
 RewriteRule ^/en-US/firefox/security(/?)$ /b/en-US/firefox/security$1 [PT]
-RewriteRule ^/en-US/firefox/organizations(.*)$ /b/en-US/firefox/organizations$1 [PT]
 RewriteRule ^/en-US/firefox/central(/?)$ /b/en-US/firefox/central$1 [PT]
 RewriteRule ^/en-US/firefox/happy(/?)$ /b/en-US/firefox/happy$1 [PT]
 RewriteRule ^/en-US/firefox/speed(/?)$ /b/en-US/firefox/speed$1 [PT]


### PR DESCRIPTION
And fix Bug 967491 - Lack of trailing slash on aurora/beta all-downloads pages causes 404
