### PR TITLE
[bug 968039] Workaround for first highlight position in Australis tour

### DIFF
--- a/media/js/firefox/australis/browser-tour.js
+++ b/media/js/firefox/australis/browser-tour.js
@@ -62,6 +62,9 @@ if (typeof Mozilla == 'undefined') {
         // show the door hanger if the tab is visible
         if (!document.hidden) {
             $('.tour-init').trigger('tour-step');
+            // temp workaround if bug 968039 does not make it into Aurora 29
+            // fixes highlight position first time browser is opened.
+            Mozilla.UITour.showHighlight("appMenu");
         }
     };
 


### PR DESCRIPTION
For reference, this is a temp workaround to fix: https://github.com/mozilla/bedrock/pull/1657#issuecomment-34061377

Suggested here: https://bugzilla.mozilla.org/show_bug.cgi?id=968039#c3

You can test this PR in today's Nightly - first time you open the browser with this page in a loaded tab, you should be able to see the issue before this change.
