### PR TITLE
Add newsletter redirects for Bug 959310

### DIFF
--- a/etc/httpd/global.conf
+++ b/etc/httpd/global.conf
@@ -117,9 +117,6 @@ RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?about/powered-by(/?)$ /b/$1about/powered-by$
 # bug 837883
 RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/firefox\.exe$ /$1 [NC,L,R=301]
 
-# bug 815908
-RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?newsletter/hacks\.mozilla\.org(/?)$ /b/$1newsletter/hacks.mozilla.org$2 [PT]
-
 # bug 821006
 RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/all(\.html)?$ /$1firefox/all/ [L,R=301]
 RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/all/$ /b/$1firefox/all/ [PT]
@@ -405,10 +402,6 @@ RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/nightly(/?)$ https://nightly.mozilla
 # bug 748503
 RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/nightly/firstrun(.*)$ /b/$1firefox/nightly/firstrun$2 [PT]
 
-# Bug 845904 - /newsletter/existing and /newsletter/updated served from bedrock
-RewriteRule  ^/(\w{2,3}(?:-\w{2})?/)?newsletter/existing(.*)$ /b/$1newsletter/existing$2 [PT]
-RewriteRule  ^/(\w{2,3}(?:-\w{2})?/)?newsletter/updated(.*)$ /b/$1newsletter/updated$2 [PT]
-
 # bug 860532 - Reidrects for governance pages
 RewriteRule ^/about/governance\.html$ /about/governance/ [L,R=301]
 RewriteRule ^/about/roles\.html$ /about/governance/roles/ [L,R=301]
@@ -501,18 +494,14 @@ RewriteRule ^/en-US/firefox/releases/0\.(.*)$ http://website-archive.mozilla.org
 RewriteRule ^/projects/security/known-vulnerabilities.html$ /security/known-vulnerabilities/ [L,R=301]
 RewriteRule ^/projects/security/older-vulnerabilities.html$ /security/known-vulnerabilities/older-vulnerabilities.html [L,R=301]
 
-
-# bug 860460, 892696
-RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?newsletter(/?)$ /b/$1newsletter$2 [PT]
-
+# bug 926629
+RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?newsletter(.*)$ /b/$1newsletter$2 [PT]
+RewriteRule ^/en-US/newsletter/about_mobile(?:/(?:index.html)?)?$ /en-US/newsletter/ [L,R=301]
+RewriteRule ^/en-US/newsletter/about_mozilla(?:/(?:index.html)?)?$ /en-US/contribute/ [L,R=301]
+RewriteRule ^/en-US/newsletter/new(?:/(?:index.html)?)?$ /en-US/newsletter/ [L,R=301]
 
 # bug 892716
 RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox(/)?$ /b/$1firefox$2 [PT]
-
-
-# bug 897195, 900156
-RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?newsletter/confirm(.*)$ /b/$1newsletter/confirm$2 [PT]
-
 
 # bug 818321
 RewriteRule ^/projects/security/tld-idn-policy-list.html$ /about/governance/policies/security-group/tld-idn/ [L,R=301]
@@ -531,9 +520,6 @@ RewriteRule ^/projects/security/certs/policy/InclusionPolicy.html /about/governa
 
 # bug 903089
 RewriteRule ^/robots.txt$ /b/robots.txt [PT]
-
-# bug 901541
-RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?newsletter/recovery(/)?$ /b/$1newsletter/recovery$2 [PT]
 
 #bug 887426
 RewriteRule ^/about/policies(/?)$ /about/governance/policies/ [L,R=301]


### PR DESCRIPTION
Also consolidate /b/ bedrock redirects for /newsletter/*

The new redirects are pretty simple. Please confirm that the single /newsletter/ bedrock redirect will appropriately replace all those I've removed here.
