### PR TITLE
Fix a typo on the powered-by page

### DIFF
--- a/bedrock/mozorg/templates/mozorg/powered-by.html
+++ b/bedrock/mozorg/templates/mozorg/powered-by.html
@@ -66,7 +66,7 @@
 			<li><a href="http://www.seamonkey-project.org">{{ _("SeaMonkey")}}</a></li>
 			<li><a href="http://www.smartreport.eu">{{ _("SmartReport")}}</a></li>
 			<li><a href="http://www.surfeasy.com">{{ _("SurfEasy")}}</a></li>
-			<li><a href="http://www.telasocial.com/">{{ _("TeleSocial")}}</a></li>
+			<li><a href="http://www.telasocial.com/">{{ _("Tela Social")}}</a></li>
 			<li><a href="{{ php_url('/thunderbird/') }}">{{ _("Thunderbird")}}</a></li>
 			<li><a href="http://topstyle4.com">{{ _("TopStyle")}}</a></li>
 			<li><a href="http://waterfoxproj.sourceforge.net">{{ _("Waterfox")}}</a></li>


### PR DESCRIPTION
TeleSocial should be Tela Social as per https://groups.google.com/forum/#!topic/mozilla.marketing/YE0Obo62Vs0
