### PR TITLE
[fix bug 970752] phone provider content for non-JS users on firefox os page has poor copy and old link

### DIFF
--- a/bedrock/firefox/templates/firefox/os/faq.html
+++ b/bedrock/firefox/templates/firefox/os/faq.html
@@ -61,20 +61,48 @@
           <dd>
             <p>{{_('Firefox OS is available to buy across 14 countries across the globe. You can purchase a device in:')}}</p>
             <ul class="unstyled">
-               <li>{{_('Spain with Movistar')}}</li>
-               <li>{{_('Poland with T-Mobile')}}</li>
-               <li>{{_('Venezuela with Movistar')}}</li>
-               <li>{{_('Colombia with Movistar')}}</li>
-               <li>{{_('Hungary with both Telenor and Telekom')}}</li>
-               <li>{{_('Peru with Movistar')}}</li>
-               <li>{{_('Serbia with Telenor')}}</li>
-               <li>{{_('Montenegro with Telenor')}}</li>
-               <li>{{_('Greece with Cosmote')}}</li>
-               <li>{{_('Germany with Congstar')}}</li>
-               <li>{{_('Brazil with Vivo')}}</li>
-               <li>{{_('Mexico with Movistar')}}</li>
-               <li>{{_('Italy with TIM')}}</li>
-               <li>{{_('Uruguay with Movistar')}}</li>
+              <li>
+                {{_('Spain with <a href="%s">Movistar</a>')|format('http://www.movistar.es/firefoxos?aff=aff-firefoxOS1')}}
+              </li>
+              <li>
+                {{_('Poland with <a href="%s">T-Mobile</a>')|format('http://www.t-mobile.pl/pl/firefox')}}
+              </li>
+              <li>
+                {{_('Venezuela with <a href="%s">Movistar</a>')|format('http://www.movistar.com.ve/movistar_firefox/index.html')}}
+              </li>
+              <li>
+                {{_('Colombia with <a href="%s">Movistar</a>')|format('http://www.movistar.co')}}
+              </li>
+              <li>
+                {{_('Hungary with both <a href="%s">Telenor</a> and <a href="%s">T-Mobile</a>')|format('http://www.telenor.hu/mobiltelefon/alcatel/one-touch-fire', 'https://webshop.t-mobile.hu/webapp/wcs/stores/ProductDisplay?catalogId=2001&storeId=2001&langId=-11&productId=644566')}}
+              </li>
+              <li>
+                {{_('Peru with <a href="%s">Movistar</a>')|format('http://catalogo.movistar.com.pe/zte-open')}}
+              </li>
+              <li>
+                {{_('Serbia with <a href="%s">Telenor</a>')|format('https://www.telenor.rs/sr/Privatni-korisnici/webshop/Mobilni-telefoni/Alcatel/One_Touch_Fire')}}
+              </li>
+              <li>
+                {{_('Montenegro with <a href="%s">Telenor</a>')|format('http://www.telenor.me/sr/Privatni-korisnici/Uredjaji/Mobilni-telefoni/Alcatel/OT_Fire')}}
+              </li>
+              <li>
+                {{_('Greece with <a href="%s">Cosmote</a>')|format('http://www.cosmote.gr/cosmoportal/cosmote.portal?_nfpb=true&_pageLabel=HDV&sku=20290038&s=0')}}
+              </li>
+              <li>
+                {{_('Germany with <a href="%s">Congstar</a>')|format('http://aktion.congstar.de/firefox-os')}}
+              </li>
+              <li>
+                {{_('Brazil with <a href="%s">Vivo</a>')|format('http://www.vivo.com.br/firefox')}}
+              </li>
+              <li>
+                {{_('Mexico with <a href="%s">Movistar</a>')|format('http://www.movistar.com.mx/firefox')}}
+              </li>
+              <li>
+                {{_('Italy with <a href="%s">TIM</a>')|format('http://www.tim.it/prodotti/alcatel-one-touch-fire-mozilla-orange')}}
+              </li>
+              <li>
+                {{_('Uruguay with <a href="%s">Movistar</a>')|format('http://www.firefoxos.movistar.com.uy/')}}
+              </li>
             </ul>
             <p>
             {{_('To date, 17 Operators spanning the globe have committed to distributing Firefox OS devices:')}}

--- a/bedrock/firefox/templates/firefox/os/index.html
+++ b/bedrock/firefox/templates/firefox/os/index.html
@@ -407,8 +407,8 @@
       <h2>{{_('We work with a number of providers to offer Firefox OS on a variety of devices.')}}</h2>
 
       <p id="provider-text-nojs">
-        {% trans link="//support.mozilla.org/kb/firefox-os-faq"|safe %}
-        All your questions will be answered <a href="{{link}}">Read our extra helpful FAQ</a>
+        {% trans link=url('firefox.os.faq') %}
+        Please read our FAQ for a <a href="{{link}}">full list of providers in available countries</a>.
         {% endtrans %}
       </p>
       <p id="provider-text-multi">{{_('Choose one from the list below to get a Firefox OS smartphone in your country.')}}</p>

--- a/media/css/firefox/os/firefox-os.less
+++ b/media/css/firefox/os/firefox-os.less
@@ -1266,6 +1266,7 @@ html[lang="pl"] {
 // get phone default no-JS styles
 #get-phone {
   padding: @baseLine;
+  width: @widthDesktop - (@gridGutterWidth * 4);
   margin: 0 auto @baseLine auto;
   background: #fff;
   header {
@@ -1393,6 +1394,7 @@ html[lang="pl"] {
 
   #get-phone {
     padding: 0;
+    width: auto;
     .content {
       text-align: center;
       font-size: 20px;
@@ -1689,6 +1691,7 @@ html[lang="en-US"].js {
       width: 400px;
     }
   }
+  #get-phone,
   #footer-email-form {
     width: @widthTablet - (@gridGutterWidth * 4);
   }
@@ -1705,6 +1708,9 @@ html[lang="en-US"].js {
           }
         }
       }
+    }
+    #get-phone {
+      width: auto;
     }
   }
   html[lang="en-US"] {
@@ -1978,6 +1984,9 @@ html[lang="en-US"].js {
   .bg-birthday {
     background: url('/media/img/firefox/os/bg/760/birthday.jpg') no-repeat center center;
   }
+  #get-phone {
+    width: @widthMobileLandscape - (@gridGutterWidth * 3);
+  }
   #footer-email-form {
     width: @widthMobileLandscape - (@gridGutterWidth * 2);
   }
@@ -1991,6 +2000,9 @@ html[lang="en-US"].js {
           border-left: none;
         }
       }
+    }
+    #get-phone {
+      width: auto;
     }
   }
 }
@@ -2190,6 +2202,9 @@ html[lang="en-US"].js {
       margin: 5px 0;
     }
   }
+  #get-phone {
+    width: @widthMobile - (@gridGutterWidth * 3);
+  }
   #footer-email-form {
     width: @widthMobile - (@gridGutterWidth * 2);
   }
@@ -2207,6 +2222,7 @@ html[lang="en-US"].js {
   }
   .js {
     #get-phone {
+      width: auto;
       .content {
         font-size: 16px;
         letter-spacing: 0;


### PR DESCRIPTION
- Added links to the existing list of providers on `/firefox/os/faq` and updated the link on `firefox/os` to point to that page for non-JS users.
- Also added a few CSS layout adjustments for the "Get a Phone" block when JS is disabled.
