### PR TITLE
Bug 970870 :  Restrict Tabzilla MWC promo to MWC locales

### DIFF
--- a/bedrock/mozorg/templates/mozorg/home.html
+++ b/bedrock/mozorg/templates/mozorg/home.html
@@ -4,7 +4,7 @@
 
 {% extends "mozorg/base-resp.html" %}
 
-{% add_lang_files "mozorg/home" %}
+{% add_lang_files "mozorg/home" "mwc2014_promos" %}
 
 {% from 'macros.html' import facebook_share_url, twitter_share_url %}
 

--- a/bedrock/tabzilla/templates/tabzilla/tabzilla.js
+++ b/bedrock/tabzilla/templates/tabzilla/tabzilla.js
@@ -67,6 +67,9 @@
  * @author    Kohei Yoshino <kohei.yoshino@gmail.com>
  */
 
+ // Load mwc 2014 strings from mwc2014_promos.lang only for the locales we target
+{% add_lang_files "mwc2014_promos" %}
+
 var Tabzilla = (function (Tabzilla) {
     'use strict';
     var minimumJQuery = '1.7.1';
@@ -597,6 +600,7 @@ var Tabzilla = (function (Tabzilla) {
       '<div id="tabzilla-panel" class="tabzilla-closed" tabindex="-1">'
     + '  <div id="tabzilla-contents">'
     + '    <div id="tabzilla-promo">'
+    {% if l10n_has_tag('promo_mwc_2014') or settings.DEV %}
     +'      <div class="snippet" id="tabzilla-promo-mwc">'
     + '        <a href="https://www.mozilla.org/firefox/partners/?icn=tabz">'
     + '          <h4>{{ _('Unleash the future')|js_escape }}</h4>'
@@ -604,6 +608,15 @@ var Tabzilla = (function (Tabzilla) {
     + '        </a>'
     + '      </div>'
     + '    </div>'
+    {% else %}
+    +'      <div class="snippet" id="tabzilla-promo-fxos">'
+    + '        <a href="https://www.mozilla.org/firefox/os/?icn=tabz">'
+    + '          <h4>{{ _('Look ahead')|js_escape }}</h4>'
+    + '          <p>{{ _('Learn all about Firefox OS')|js_escape }} »</p>'
+    + '        </a>'
+    + '      </div>'
+    + '    </div>'
+    {% endif %}
     + '    <div id="tabzilla-nav">'
     + '      <ul>'
     + '        <li><h2>Mozilla</h2>'


### PR DESCRIPTION
- Tabzilla promo activated via a promo_mwc_2014 tag in tabzilla.lang
- Locales without the promo get the current Firefox OS promo (which is widely localized)
- Promo strings extracted from mwc2014_promos.lang for both the tabzilla promo and the home page tile, to restrict localization to 16 selected locales
