### PR TITLE
Bug 960651 Redirect all Firefox 'details' pages to bedrock

### DIFF
--- a/etc/httpd/global.conf
+++ b/etc/httpd/global.conf
@@ -213,6 +213,10 @@ RewriteRule ^/(pt-BR)/firefox/speed(/?)$ /b/$1/firefox/speed$2 [PT]
 # bug 796952, 915845, 915867
 RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/unsupported/(.*)$ /b/$1firefox/unsupported/$2 [PT]
 
+# bug 960651
+RewriteCond %{REQUEST_URI} !/unsupported
+RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?(firefox|mobile)/([^/]+)/details(/|/.+\.html)?$ /$1firefox/unsupported/details/ [L,R=301]
+
 # bug 757117
 RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?webmaker(.*)$ /b/$1webmaker$2 [PT]
 


### PR DESCRIPTION
For all locales, any URLs for /firefox or /mobile with /[version]/details/ will redirect to a localized
[general localized upgrade page in bedrock](http://www.mozilla.org/firefox/unsupported/details/).

https://bugzilla.mozilla.org/show_bug.cgi?id=960651
