### PR TITLE
Bug 962204, update the SSL-enabled product list for Firefox 27.0.1

### DIFF
--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -849,7 +849,7 @@ STUB_INSTALLER_LOCALES = {
 }
 
 # Force download via SSL
-FORCE_SSL_DOWNLOAD_VERSIONS = ['27.0']
+FORCE_SSL_DOWNLOAD_VERSIONS = ['27.0', '27.0.1']
 
 # Google Analytics
 GA_ACCOUNT_CODE = ''


### PR DESCRIPTION
The new version is coming this Friday. Can be merged prior to the release.
