### PR TITLE
Add redirects for v2.x through v9.x release notes

### DIFF
--- a/etc/httpd/global.conf
+++ b/etc/httpd/global.conf
@@ -493,6 +493,8 @@ RewriteRule ^/projects/devpreview/(.*)$ http://website-archive.mozilla.org/www.m
 # bug 947890
 RewriteRule ^/en-US/firefox/releases/1\.(.*)$ http://website-archive.mozilla.org/www.mozilla.org/firefox_releasenotes/en-US/firefox/releases/1.$1 [L,R=301]
 RewriteRule ^/en-US/firefox/releases/0\.(.*)$ http://website-archive.mozilla.org/www.mozilla.org/firefox_releasenotes/en-US/firefox/releases/0.$1 [L,R=301]
+RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)(firefox|mobile)/(\d)\.(.*)/releasenotes(.*)$ http://website-archive.mozilla.org/www.mozilla.org/firefox_releasenotes/$1$2/$3.$4/releasenotes$5 [L,R=301]
+
 
 # bug 818323
 RewriteRule ^/projects/security/known-vulnerabilities.html$ /security/known-vulnerabilities/ [L,R=301]


### PR DESCRIPTION
Bug 971840

The following URLs should be redirected website-archive: https://gist.github.com/sgarrity/8981605
