### PR TITLE
Bug 957711 followup, fix NoReverseMatch error at /firefox/new/

### DIFF
--- a/bedrock/firefox/templates/firefox/new.html
+++ b/bedrock/firefox/templates/firefox/new.html
@@ -119,7 +119,7 @@
             <ul>
               <li><a href="{{ url('firefox.central') }}">{{_('Learn more about Firefox for desktop')}}</a></li>
               <li><a href="https://support.mozilla.org/products/firefox">{{_('Need help?')}}</a></li>
-              <li><a href="{{ url('firefox.mobile') }}">{{_('Looking for mobile?')}}</a></li>
+              <li><a href="{{ url('firefox.fx') }}">{{_('Looking for mobile?')}}</a></li>
               <li><a href="{{ url('firefox.all') }}">{{_('Download a fresh copy')}}</a></li>
             </ul>
           </div>

--- a/bedrock/newsletter/templates/newsletter/updated.html
+++ b/bedrock/newsletter/templates/newsletter/updated.html
@@ -56,7 +56,7 @@
       <div class="sub-feature" id="mobile">
         <h4>{{ _('Get up and go') }}</h4>
         <p>{{ _('It’s your Web anywhere you go.') }}</p>
-        <a href="{{ url('firefox.mobile') }}" class="link">{{ _('Get Firefox for mobile!') }}</a>
+        <a href="{{ url('firefox.fx') }}" class="link">{{ _('Get Firefox for mobile!') }}</a>
       </div>
       <div class="sub-feature" id="addons">
         <h4>{{ _('Added extras') }}</h4>


### PR DESCRIPTION
Fix an error after #1663 is merged: `url('firefox.mobile')` should be `url('firefox.fx')`
