### PR TITLE
Bug 869516 - base styles for older versions of IE

### DIFF
--- a/bedrock/base/templates/base-resp.html
+++ b/bedrock/base/templates/base-resp.html
@@ -6,9 +6,11 @@
 <html class="windows x86 no-js" lang="{{ LANG }}" dir="{{ DIR }}"{% block html_attrs %}{% endblock %}>
   <head>
     <meta charset="utf-8">{# Note: Must be within first 512 bytes of page #}
+
 <!--
 {% include "includes/careers-teaser.html" %}
 -->
+
     {% block ga_experiments %}{% endblock %}
     <meta name="viewport" content="width=device-width, initial-scale=1">
     {% block extra_meta %}{% endblock %}
@@ -40,16 +42,32 @@
     {% endblock %}
 
     <!--[if lte IE 8]>
-    <script src="{{ MEDIA_URL }}js/libs/html5shiv.js"></script>
+      {# Only needed for IE before v9 #}
+      <script src="{{ media('js/libs/html5shiv.js') }}"></script>
     <![endif]-->
 
+    <!--[if lte IE 7]>
+      {# Basic styles, only for IE7 and lower #}
+      {{ css('oldIE') }}
+    <![endif]-->
+
+    <!--[if !lte IE 7]><!-->
+    {# Global styles, hidden from IE7 and lower #}
     {% block site_css %}
       {{ css('responsive') }}
     {% endblock %}
 
+    {# Page-specific styles, hidden from IE7 and lower #}
+    {% block page_css %}{% endblock %}
+    <!--<![endif]-->
+
+    {% block extrahead %}
+      {# Extra header stuff (scripts, styles, metadata, etc) seen by all browsers. Use the 'page_css' block for CSS you want to hide from IE7 and lower. #}
+    {% endblock %}
+
     {% include 'includes/locale-font-faces.html' %}
 
-    {% block extrahead %}{% endblock %}
+    {% block favicon %}<link rel="shortcut icon" href="{{ media('img/favicon.ico') }}">{% endblock %}
 
     {{ js('site') }}
 
@@ -71,6 +89,7 @@
     {% block site_header %}
       <header id="masthead">
         <a href="{{ url('mozorg.home') }}" id="tabzilla" data-infobar="{{ settings.TABZILLA_INFOBAR_OPTIONS }}">Mozilla</a>
+
         {% block site_header_nav %}
         <span class="toggle" role="button" aria-controls="nav-main-menu" tabindex="0">{{_('Menu')}}</span>
         <nav id="nav-main" role="navigation">

--- a/bedrock/base/templates/base.html
+++ b/bedrock/base/templates/base.html
@@ -6,6 +6,10 @@
   <head>
     <meta charset="utf-8">{# Note: Must be within first 512 bytes of page #}
 
+<!--
+{% include "includes/careers-teaser.html" %}
+-->
+
     {% block ga_experiments %}{% endblock %}
     {% block extra_meta %}{% endblock %}
 
@@ -35,17 +39,33 @@
       {{ css('tabzilla') }}
     {% endblock %}
 
-    <!--[if lt IE 9]>
-      <script src="{{ MEDIA_URL }}js/libs/html5shiv.js"></script>
+    <!--[if lte IE 8]>
+      {# Only needed for IE before v9 #}
+      <script src="{{ media('js/libs/html5shiv.js') }}"></script>
     <![endif]-->
 
+    <!--[if lte IE 7]>
+      {# Basic styles, only for IE7 and lower #}
+      {{ css('oldIE') }}
+    <![endif]-->
+
+    <!--[if !lte IE 7]><!-->
+    {# Global styles, hidden from IE7 and lower #}
     {% block site_css %}
       {{ css('common') }}
     {% endblock %}
 
+    {# Page-specific styles, hidden from IE7 and lower #}
+    {% block page_css %}{% endblock %}
+    <!--<![endif]-->
+
+    {% block extrahead %}
+      {# Extra header stuff (scripts, styles, metadata, etc) seen by all browsers. Use the 'page_css' block for CSS you want to hide from IE7 and lower. #}
+    {% endblock %}
+
     {% include 'includes/locale-font-faces.html' %}
 
-    {% block extrahead %}{% endblock %}
+    {% block favicon %}<link rel="shortcut icon" href="{{ media('img/favicon.ico') }}">{% endblock %}
 
     {{ js('site') }}
 
@@ -53,6 +73,7 @@
       {% include 'includes/optimizely.html' %}
     {% endblock %}
 
+    {% block js_pretrack %}{# include JavaScript that must be run pre GA tracking here #}{% endblock %}
     {% block google_analytics %}
       {% include 'includes/google-analytics.html' %}
     {% endblock %}

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -125,6 +125,9 @@ MINIFY_BUNDLES = {
         'responsive': (
             'css/sandstone/sandstone-resp.less',
         ),
+        'oldIE': (
+            'css/sandstone/oldIE.less',
+        ),
         'newsletter': (
             'css/newsletter/newsletter.less',
         ),

--- a/media/css/firefox/menu.less
+++ b/media/css/firefox/menu.less
@@ -56,7 +56,7 @@ body.html-rtl #nav-main li ul {
 #nav-main li ul {
     position: absolute;
     left: -999em;
-    top: 48px;
+    top: 44px;
     opacity: 0;
     z-index: 999;
     width: 190px;

--- a/media/css/sandstone/oldIE.less
+++ b/media/css/sandstone/oldIE.less
@@ -1,0 +1,683 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// This style sheet is served exclusively to Internet Explorer 7 and older.
+// Old versions get this minimal style while IE8 and up recieve more advanced styling.
+
+@import "lib.less";
+@import "reset.less";
+@import "buttons.less";
+@import "../firefox/menu.less";
+
+// @Fonts
+// oldIE only supports EOT so we needn't include TTF or Woff.
+@font-face {
+    font-family: 'Open Sans Light';
+    src: url('/media/fonts/OpenSans-Light-webfont.eot?#iefix') format('embedded-opentype');
+    font-weight: normal;
+    font-style: normal;
+}
+
+@font-face {
+    font-family: 'Open Sans Light';
+    src: url('/media/fonts/OpenSans-Semibold-webfont.eot?#iefix') format('embedded-opentype');
+    font-weight: bold;
+    font-style: normal;
+}
+
+@font-face {
+    font-family: 'Open Sans Light';
+    src: url('/media/fonts/OpenSans-LightItalic-webfont.eot?#iefix') format('embedded-opentype');
+    font-weight: normal;
+    font-style: italic;
+}
+
+@font-face {
+    font-family: 'Open Sans';
+    src: url('/media/fonts/OpenSans-Regular-webfont.eot?#iefix') format('embedded-opentype');
+    font-weight: normal;
+    font-style: normal;
+}
+
+@font-face {
+    font-family: 'Open Sans';
+    src: url('/media/fonts/OpenSans-Bold-webfont.eot?#iefix') format('embedded-opentype');
+    font-weight: bold;
+    font-style: normal;
+}
+
+@font-face {
+    font-family: 'Open Sans';
+    src: url('/media/fonts/OpenSans-Italic-webfont.eot?#iefix') format('embedded-opentype');
+    font-weight: normal;
+    font-style: italic;
+}
+
+
+
+// General styles and containers
+html {
+    background: #fff;
+}
+
+body {
+    font-size: 100%;
+    line-height: 1.5;
+    font-family: @baseFontFamily;
+    color: @textColorPrimary;
+    background: #fff;
+}
+
+#outer-wrapper {
+    position: relative;
+    border-top: 2px solid #fff;
+    background: #f9f9f9 url(/media/img/sandstone/bg-stone.png) 0 0 repeat-x;
+    zoom: 1;
+}
+
+#wrapper {
+    margin: 0 auto;
+    position: relative;
+    width: @widthDesktop - (@gridGutterWidth * 2);
+    zoom: 1;
+}
+
+#masthead,
+#main-feature,
+#main-content,
+#colophon,
+.billboard,
+.container {
+    display: block;
+    margin: 0 auto;
+    padding-left: @gridGutterWidth;
+    padding-right: @gridGutterWidth;
+    width: @widthDesktop - (@gridGutterWidth * 2);
+    zoom: 1;
+}
+
+#main-content,
+#main-feature {
+    padding-bottom: 48px;
+}
+
+.main-column {
+    width: 540px;
+    float: left;
+    margin: 0 10px;
+}
+
+.sidebar {
+    width: 220px;
+    float: left;
+    margin: 0 10px 0 170px;
+}
+
+.billboard {
+    padding-top: @baseLine * 2;
+    padding-bottom: @baseLine * 2;
+    margin: 0 -@baseLine (@baseLine * 2) -@baseLine;
+    background: #fff;
+    border-bottom: 1px solid #ddd;
+
+    h1, h2, h3, h4, h5, h6, .huge, .large {
+        color: @textColorSecondary;
+    }
+}
+
+.callout-content {
+    display: block;
+    background: #fff;
+    border-bottom: 1px solid #ddd;
+    margin: 0 auto @baseLine;
+    padding-left: @gridGutterWidth;
+    padding-right: @gridGutterWidth;
+    zoom: 1;
+}
+
+// An arbitrary container for translatable strings to use in in scripts
+#strings {
+    display: none;
+}
+
+// oldIE doesn't get a mosaic
+#mosaic {
+    display: none;
+}
+
+
+
+// Links
+a:link,
+a:visited {
+    color: @linkBlue;
+    text-decoration: none;
+}
+
+a:hover,
+a:focus,
+a:active {
+    color: darken(@linkBlue, 10%);
+    text-decoration: underline;
+}
+
+
+
+// Headings
+h1, h2, h3, h4, h5, h6, legend, .huge, .large {
+    .open-sans-light;
+    color: @textColorSecondary;
+    display: block;
+    line-height: 1;
+    margin: 0 0 12px 0;
+}
+
+.huge,
+.huge h1 {
+    font-size: 6.75em;
+    letter-spacing: -4px;
+    line-height: 1;
+}
+
+.large,
+.large h1 {
+    font-size: 4.5em;
+    letter-spacing: -3px;
+    line-height: 1;
+}
+
+h1,
+.huge h2,
+.large h2,
+.billboard h2 {
+    font-size: 3em;
+    letter-spacing: -2px;
+}
+
+h2 {
+    font-size: 2em;
+    letter-spacing: -1px;
+}
+
+h3 {
+    font-size: 1.75em;
+    letter-spacing: -0.5px;
+}
+
+h4,
+h1 .large,
+h2 .large {
+    font-size: 1.5em;
+    letter-spacing: -0.25px;
+}
+
+h5, legend {
+    font-size: 1em;
+}
+
+h6 {
+    font-size: .875em;
+}
+
+.small,
+small {
+    font-size: .75em;
+    line-height: 1.25;
+}
+
+hgroup {
+    h1, h2, h3, h4, h5, h6 {
+        margin-bottom: 0;
+    }
+}
+
+legend {
+    color: @textColorPrimary;
+    white-space: normal;
+}
+
+.title-shadow-box {
+    .open-sans-light;
+    background: #b30406;
+    color: #fff;
+    font-size: 48px;
+    letter-spacing: -2px;
+    margin: -60px 10px 40px;
+    padding: 20px;
+    position: relative;
+    width: 420px;
+    zoom: 1;
+}
+
+
+
+// Common elements
+p,
+ul,
+ol,
+dl,
+hgroup {
+    margin: 0 0 @baseLine 0;
+}
+
+ul.unstyled,
+ol.unstyled {
+    li {
+        list-style-type: none;
+        margin-left: 0;
+    }
+    li li {
+        list-style-type: disc;
+        margin-left: 20px;
+    }
+}
+
+li ul,
+li ol {
+    margin-bottom: 0;
+}
+
+li {
+    margin-left: 20px;
+}
+
+dt {
+    .open-sans-light;
+    font-size: 2em;
+    line-height: 100%;
+    letter-spacing: -1px;
+    margin-bottom: @baseLine / 2;
+}
+
+dd {
+    margin-bottom: @baseLine * 2;
+}
+
+dl.faq dt {
+    font-size: 1.125em;
+}
+
+dl.faq dd {
+    margin-bottom: 1.5em;
+}
+
+pre,
+code {
+    color: @textColorTertiary;
+    font-size: .875em;
+}
+
+.center {
+    text-align: center;
+}
+
+img {
+    -ms-interpolation-mode: bicubic;
+}
+
+
+
+// Color schemes
+.sand #outer-wrapper {
+    background: #f5f1e8 url(/media/img/sandstone/bg-gradient-sand.png) repeat-x;
+}
+
+.sky {
+    #outer-wrapper {
+        background: #eee url(/media/img/sandstone/bg-gradient-sky.png) repeat-x;
+    }
+
+    a:link,
+    a:visited {
+        color: @linkSkyBlue;
+    }
+
+    a:hover,
+    a:focus,
+    a:active {
+        color: darken(@linkSkyBlue, 10%);
+    }
+
+    #main-feature {
+        position: relative;
+
+        .download-button {
+            position: absolute;
+            right: 30px;
+            top: 0;
+        }
+    }
+}
+
+.space {
+    color: #fff;
+
+    #outer-wrapper {
+        background: #04020b url(/media/img/sandstone/bg-space.png) repeat-x;
+    }
+
+    h1, h2, h3, h4, h5, h6 {
+        color: #fff;
+    }
+
+    a:link,
+    a:visited {
+        color: @linkSpaceBlue;
+    }
+
+    a:hover,
+    a:focus,
+    a:active {
+        color: lighten(@linkSpaceBlue, 10%);
+    }
+
+    #masthead nav li {
+        a:link,
+        a:visited {
+            color: @linkSpacePurple;
+        }
+
+        li {
+            a:link,
+            a:visited {
+                color: @textColorSecondary;
+            }
+        }
+    }
+}
+
+
+
+// Header navigation
+#masthead {
+    h2 {
+        padding: (@baseLine * 1.5) 0 @baseLine;
+        margin: 0 (@gridGutterWidth / 2);
+    }
+
+    nav {
+        float: right;
+        margin-right: 16px;
+        text-transform: uppercase;
+        font-size: .8125em;
+
+        li {
+            .inline-block;
+            list-style-type: none;
+            margin: 0;
+            a,
+            b {
+                display: inline-block;
+                padding: 12px;
+                font-weight: normal;
+            }
+            b,
+            .current {
+                background-position: 50% 0;
+                background-repeat: no-repeat;
+                background-image: url(/media/img/sandstone/menu-current.png);
+            }
+            a:link,
+            a:visited {
+                color: @textColorSecondary;
+            }
+        }
+    }
+}
+
+#masthead .toggle {
+    display: none; /* oldIE never gets a mobile menu. */
+}
+
+
+
+// Header Breadcrumbs
+#masthead {
+    .breadcrumbs {
+        padding: 0 10px (@baseLine / 2) 10px;
+        float: none;
+
+        a,
+        span {
+            margin-right: .5em;
+            margin-left: .5em;
+        }
+    }
+}
+
+
+
+// Menu bar
+.menu-bar {
+    margin-bottom: @baseLine * 2;
+    padding-bottom: 0;
+    padding-top: 0;
+    text-align: center;
+
+    ol,
+    ul {
+        margin: 0;
+        list-style: none;
+
+        li {
+            display: inline;
+            margin: 0;
+            padding-bottom: (@baseLine / 2);
+            padding-top: (@baseLine / 2);
+            zoom: 1;
+
+            a {
+                border-left: 1px dotted @borderColor;
+                display: inline;
+                padding: @baseLine / 3 @baseLine;
+                zoom: 1;
+
+                span {
+                    display: block;
+                }
+            }
+
+            &:first-child a {
+                border-left: 0;
+            }
+        }
+    }
+}
+
+
+
+// Sidebar navigation
+.sidebar nav,
+.sidebar .nav {
+    font-size: 1em;
+    color: @textColorSecondary;
+
+    li {
+        list-style-type: none;
+        border-bottom: 1px dotted #ccc;
+        margin: 0;
+        line-height: 1.1;
+
+        a, b {
+            display: block;
+            padding: 8px 0;
+        }
+
+        li b {
+            font-weight: bold;
+        }
+
+    }
+
+    li:first-child {
+        font-size: 24px;
+    }
+}
+
+.sidebar .reference {
+    margin: @baseLine * 2  auto;
+
+    .more {
+        display: block;
+        padding: (@baseLine / 2) 0;
+        border-bottom: 1px dotted @borderColor;
+    }
+
+    p {
+        margin: 0;
+    }
+}
+
+
+
+// Our standard footer email form
+#footer-email-form {
+    padding-top: @baseLine;
+    padding-bottom: @baseLine;
+    margin-bottom: 0;
+
+    h3 {
+        .span(4);
+    }
+
+    .form-contents {
+        .span(5);
+    }
+
+    .form-submit {
+        .span(3);
+
+        input {
+            overflow: visible;
+        }
+    }
+
+    .field {
+        padding: 0 0 8px 0;
+    }
+
+    .field-email input,
+    #form-details select {
+        width: 80%;
+    }
+
+    .field-privacy {
+        font-size: @smallFontSize;
+
+        input {
+            float: left;
+        }
+
+        .title {
+            display: block;
+            padding-left: 25px;
+        }
+    }
+}
+
+#footer-email-form.thank h3 {
+    width: auto;
+    margin: auto;
+    padding: 0;
+    float: none;
+}
+
+.js {
+    #form-details,
+    .form-details { display: none; }
+
+    .has-errors #form-details,
+    .has-errors .form-details { display: block; }
+
+    p.form-details {
+        margin-top: 8px;
+        line-height: 1;
+        color: @textColorSecondary;
+    }
+}
+
+#footer-email-errors .errorlist {
+    .container;
+    background: #af3232;
+    color: #fff;
+    padding-top: @baseLine / 2;
+    padding-bottom: @baseLine / 2;
+}
+
+
+
+// Footer
+#colophon {
+    background: #fff;
+    color: @textColorTertiary;
+    font-size: .875em;
+    margin: 1em 0 0;
+    padding: (@baseLine * 2) 0;
+    width: 100%;
+
+    .row {
+        width: @widthDesktop - (@gridGutterWidth * 2);
+        zoom: 1;
+        margin: 0 auto;
+    }
+
+    .footer-logo,
+    .footer-license,
+    .footer-nav {
+        margin: 0 (@gridGutterWidth / 2);
+    }
+
+    .footer-logo {
+        .span(3);
+    }
+
+    .footer-license {
+        .span(3);
+    }
+
+    .footer-nav {
+        .span(2);
+    }
+
+    a:link,
+    a:visited {
+        color: @linkBlue;
+    }
+
+    a:hover,
+    a:focus,
+    a:active {
+        color: darken(@linkBlue, 10%);
+    }
+
+    p {
+        margin-bottom: @baseLine / 2;
+    }
+
+    .footer-nav li {
+        list-style-type: none;
+        margin: 0 0 2px 0;
+    }
+}
+
+
+
+
+// Don't display the dynamic platform images when js is disabled
+// because the ones in the noscript tag will be shown
+.no-js .platform-img.js {
+    display: none;
+}
+
+.hidden {
+    .visually-hidden();
+}
+
+// not the most up to date method, but works in IE7
+.image-replaced {
+    text-indent: 110%; // extra 10% to account for fancy fonts that may overhang
+    white-space: nowrap;
+    overflow: hidden;
+}
+

--- a/media/css/sandstone/sandstone-resp.less
+++ b/media/css/sandstone/sandstone-resp.less
@@ -64,20 +64,18 @@ a.more:after {
     content: "\00A0\00BB"; /* nbsp raquo */
 }
 
-.sand {
-    #outer-wrapper {
-        background: #f5f1e8 url(/media/img/sandstone/bg-sand.png) repeat;
-        background: url(/media/img/sandstone/bg-gradient-sand.png) repeat-x 0 0,
-                    url(/media/img/sandstone/bg-sand.png) repeat 0 0,
-                    #f5f1e8;
-    }
+.sand #outer-wrapper {
+    background: #f5f1e8 url(/media/img/sandstone/bg-gradient-sand.png) repeat-x;
+    background: url(/media/img/sandstone/bg-gradient-sand.png) repeat-x,
+                url(/media/img/sandstone/bg-sand.png) repeat,
+                #f5f1e8;
 }
 
 .sky {
     #outer-wrapper {
-        background: #eee url(/media/img/sandstone/grain.png) repeat;
-        background: url(/media/img/sandstone/bg-gradient-sky.png) repeat-x 0 0,
-                    url(/media/img/sandstone/grain.png) repeat 0 0,
+        background: #eee url(/media/img/sandstone/bg-gradient-sky.png) repeat-x;
+        background: url(/media/img/sandstone/bg-gradient-sky.png) repeat-x,
+                    url(/media/img/sandstone/grain.png) repeat,
                     #eee;
     }
 
@@ -89,16 +87,13 @@ a.more:after {
             color: darken(@linkSkyBlue, 10%);
         }
     }
-
 }
 
 .space {
     color: #fff;
 
     #outer-wrapper {
-        background-color: #04020b;
-        background-image: url(/media/img/sandstone/bg-space.png);
-        background-repeat: repeat-x;
+        background: #04020b url(/media/img/sandstone/bg-space.png) repeat-x;
     }
 
     a {

--- a/media/css/sandstone/sandstone.less
+++ b/media/css/sandstone/sandstone.less
@@ -58,20 +58,18 @@ a.more:after {
     content: "\00A0\00BB"; /* nbsp raquo */
 }
 
-.sand {
-    #outer-wrapper {
-        background: #f5f1e8 url(/media/img/sandstone/bg-sand.png) repeat;
-        background: url(/media/img/sandstone/bg-gradient-sand.png) repeat-x 0 0,
-                    url(/media/img/sandstone/bg-sand.png) repeat 0 0,
-                    #f5f1e8;
-    }
+.sand #outer-wrapper {
+    background: #f5f1e8 url(/media/img/sandstone/bg-gradient-sand.png) repeat-x;
+    background: url(/media/img/sandstone/bg-gradient-sand.png) repeat-x,
+                url(/media/img/sandstone/bg-sand.png) repeat,
+                #f5f1e8;
 }
 
 .sky {
     #outer-wrapper {
-        background: #eee url(/media/img/sandstone/grain.png) repeat;
-        background: url(/media/img/sandstone/bg-gradient-sky.png) repeat-x 0 0,
-                    url(/media/img/sandstone/grain.png) repeat 0 0,
+        background: #eee url(/media/img/sandstone/bg-gradient-sky.png) repeat-x;
+        background: url(/media/img/sandstone/bg-gradient-sky.png) repeat-x,
+                    url(/media/img/sandstone/grain.png) repeat,
                     #eee;
     }
 
@@ -83,16 +81,13 @@ a.more:after {
             color: darken(@linkSkyBlue, 10%);
         }
     }
-
 }
 
 .space {
     color: #fff;
 
-    #wrapper {
-        background-color: #04020b;
-        background-image: url(/media/img/sandstone/bg-space.png);
-        background-repeat: repeat-x;
+    #outer-wrapper {
+        background: #04020b url(/media/img/sandstone/bg-space.png) repeat-x;
     }
 
     a {
@@ -634,6 +629,13 @@ nav.menu-bar {
     padding: 48px 0;
     font-size: 14px;
     line-height: 18px;
+    background: #fff;
+    width: 100%;
+
+    .row {
+        width: 960px;
+        margin: 0 auto;
+    }
 
     a,
     a:link,


### PR DESCRIPTION
**DO NOT MERGE** - We need to do some testing of major pages, especially those that need to perform well in IE like Firefox product pages, /new, /fx, etc.

After burning a lot of time updating a bunch of individual pages, I changed my approach and arrived at something much simpler by adding a new block in the base templates. The existing <code>site_css</code> block and the new <code>page_css</code> block are both hidden from old IEs but the <code>extrahead</code> block is not. This means most pages that already use <code>extrahead</code> to include page-specific styles continue to work as they have (since they've already been tested with old IEs).

Future pages that need page-specific styling can now use the <code>page_css</code> block to hide those styles from oldIE and you usually won't need to bother testing. Old IE gets the basic styling and doesn't see your new CSS at all. Use good markup and your content should degrade to something perfectly readable and presentable, just not fancy.

Note that the JavaScript blocks are NOT hidden from old IEs, in order to avoid breaking a lot of pages already built and tested for them. In the future, you can include conditional comments _inside_ the <code>site_js</code> or <code>js</code> blocks to let old IE degrade without any fancy JS, but I didn't want to make that change global in the base templates (I tried it; lots of stuff broke).

Script-heavy pages like /firefox/partners and /firefox/os will need some attention before this can merge since the JS on those pages makes some assumptions about the CSS. We can either ensure IE gets the styling (by putting it in <code>extrahead</code>) or we might be able to just hide the JS from oldIE on those pages and let them degrade.

Some pages might have content hidden in the page-specific CSS that is then made visible by JS when needed (stuff like modals and close buttons). If you're explicitly hiding elements in your page styles just remember that content will be visible in old IEs since they don't get your page-specific CSS. oldIE.less does include the same <code>.hidden</code> class from sandstone so you can still use that to visually hide content and it'll be hidden in IE as well.
