### PR TITLE
Bug 974803 - MWC Partners page: improve display for locales

### DIFF
--- a/media/css/firefox/partners/desktop.less
+++ b/media/css/firefox/partners/desktop.less
@@ -798,6 +798,10 @@ html[lang="el"] {
         line-height: 1.2;
     }
 
+    #overview h2 {
+        font-size: 66px;
+    }
+
     .partner-article .article-header nav a {
         font-size: 12px;
         line-height: 1.2;
@@ -808,7 +812,6 @@ html[lang="el"] {
     }
 }
 
-html[lang="el"],
 html[lang="fr"],
 html[lang="pt-BR"] {
     #overview h2 {
@@ -816,6 +819,11 @@ html[lang="pt-BR"] {
     }
 }
 
+html[lang="zh-TW"] {
+    #marketplace-overview h4 {
+        margin-top: 20px;
+    }
+}
 
 // Cancel use of Journal font for these locales
 html[lang="cs"],
@@ -828,6 +836,10 @@ html[lang="sr"] {
         font-size: 14px;
         line-height: 1.2;
         font-family: inherit;
+    }
+
+    #explore {
+        min-height: 42px;
     }
 }
 
@@ -842,6 +854,12 @@ html[lang="ca"] {
     #overview-links li {
         font-size: 13px;
         line-height: 1.3em;
+    }
+}
+
+html[lang="ja"] {
+    #explore {
+        padding-left: 65px;
     }
 }
 


### PR DESCRIPTION
el: title overlapping with Firefox logo
zh-TW: text covered by Firefox’s tail in Marketplace section
cs, el, pl, ro, sr: arrow above the menu on the left is cut for locales not using font Journal
ja: text slightly overlaps with the menu on the left
