### PR TITLE
Bug 973657 - Fix CSS in tabzilla MWC promo for "ja" and "el"

### DIFF
--- a/media/css/tabzilla/tabzilla.less
+++ b/media/css/tabzilla/tabzilla.less
@@ -517,6 +517,16 @@ html[lang='de'] {
     }
 }
 
+html[lang='el'] {
+    #tabzilla-promo .snippet#tabzilla-promo-mwc a {
+        h4 {
+            font-size: 36px;
+            line-height: 40px;
+            margin-bottom: 40px;
+        }
+    }
+}
+
 html[lang='hu'],
 html[lang='it'] {
     #tabzilla-promo .snippet#tabzilla-promo-mwc a {
@@ -529,7 +539,7 @@ html[lang='it'] {
 html[lang='ja'] {
     #tabzilla-promo .snippet#tabzilla-promo-mwc a {
         h4 {
-            font-size: 44px;
+            font-size: 43px;
             margin-bottom: 60px;
         }
     }


### PR DESCRIPTION
Fix font size for “el” and “ja” (Japanese is currently fine on Windows and Linux, but not on OS X).
