### PR TITLE
[fix bug 970957] Create a What's new page for Firefox Aurora 29

### DIFF
--- a/bedrock/firefox/templates/firefox/whatsnew-aurora-29-survey.html
+++ b/bedrock/firefox/templates/firefox/whatsnew-aurora-29-survey.html
@@ -1,0 +1,19 @@
+{% extends 'firefox/whatsnew.html' %}
+
+{% block body_class %} {{ super() }} whatsnew29 {% endblock %}
+
+{% block content %}
+  <h1 id="whatsnew-header">{{ _('Firefox Aurora is up to date.') }}</h1>
+  <article id="main-content" class="billboard">
+    <div class="content-column">
+      <h3>{{ _('Now help us make it better.') }}</h3>
+      <p>{{ _('You’ve probably noticed that Firefox has been looking different lately. Features have changed and moved around. It’s all part of our effort to make it easier to use and easier on the eyes.') }}</p>
+      <p>{{ _('And we need your help.') }}
+      <p>{{ _('We created a survey to help us understand how you use Firefox so we can shape it to serve you better. We’d really appreciate it if you took a few minutes to fill it out. Thanks!') }}</p>
+      <p><a href="http://www.surveygizmo.com/s3/1512875/Aurora-Australis-29-Survey" class="button">{{ _('Start the survey') }}</a></p>
+    </div>
+    <div class="image-column">
+      {{ platform_img('img/firefox/whatsnew/australis.png', {'alt': _('New Firefox interface')}) }}
+    </div>
+  </article>
+{% endblock %}

--- a/bedrock/firefox/urls.py
+++ b/bedrock/firefox/urls.py
@@ -78,4 +78,7 @@ urlpatterns = patterns('',
 
     page('mwc', 'firefox/os/mwc-2014-preview.html'),
     page('firefox/os/devices', 'firefox/os/devices.html'),
+
+    # temporary URL for Aurora 29 survey
+    page('firefox/aurora/up-to-date', 'firefox/whatsnew-aurora-29-survey.html'),
 )

--- a/etc/httpd/global.conf
+++ b/etc/httpd/global.conf
@@ -671,3 +671,6 @@ RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?gigabit(.*)$ /b/$1gigabit$2 [PT]
 
 # bug 940555
 RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?press/speakerrequest(/?)$ /b/$1press/speakerrequest$2 [PT]
+
+# bug 970957
+RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/aurora/up-to-date(/?)$ /b/$1firefox/aurora/up-to-date$2 [PT]


### PR DESCRIPTION
This is a temporary, one-off what's new page for Aurora 29. It is not replacing the current Australis UI Tour page, and is instead being shown to users at a later date, as a secondary update page that will be activated and shown in-product. For this reason it does not use the regular what's new URL scheme.

Template wise, this just reuses the current Nightly 29 what's new template, the only difference being a new survey link and change of page title.

This needs to go out ASAP, so we can then do the necessary work to load this URL in-product.

This page URL will only be up for a short period and it can be removed again.
