### PR TITLE
[no bug] Add Karma test runner Grunt task for local development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ venv
 *.db
 james.ini
 node_modules
+/media/js/test/test-results.xml

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -42,6 +42,11 @@ module.exports = function (grunt) {
             html: {
                 files: ['bedrock/**/*.html']
             }
+        },
+        karma: {
+          unit: {
+            configFile: 'media/js/test/karma.conf.js'
+          }
         }
     });
 
@@ -57,8 +62,12 @@ module.exports = function (grunt) {
     grunt.loadNpmTasks('grunt-contrib-less');
     grunt.loadNpmTasks('grunt-contrib-jshint');
     grunt.loadNpmTasks('grunt-contrib-watch');
+    grunt.loadNpmTasks('grunt-karma');
 
     // Default task(s).
     grunt.registerTask('default', ['watch']);
+
+    // Run JS tests in PhantomJS using Karma test runner
+    grunt.registerTask('test', ['karma']);
 
 };

--- a/docs/grunt.rst
+++ b/docs/grunt.rst
@@ -64,3 +64,14 @@ with Grunt then copy the contents to a local `.jshintrc` file:
 	cp .jshintrc-dist .jshintrc
 
 
+Testing
+-------
+
+Bedrock has a suite of JavaScript unit tests written using `Jasmine <http://pivotal.github.io/jasmine/>`_
+and `Sinon <http://sinonjs.org/>`_. You can run these tests on the command line using
+`Karma <http://karma-runner.github.io>`_ test runner and `PhantomJS <http://phantomjs.org/>`_.
+
+To perform a single run of the test suite, type the following command:
+
+	grunt test
+

--- a/media/js/test/karma.conf.js
+++ b/media/js/test/karma.conf.js
@@ -1,0 +1,72 @@
+module.exports = function(config) {
+    config.set({
+        // Karma configuration
+
+        // base path, that will be used to resolve files and exclude
+        basePath: '',
+
+        frameworks: ['jasmine'],
+
+        // list of files / patterns to load in the browser
+        files: [
+            '../libs/jquery-1.11.0.min.js',
+            '../base/site.js',
+            '../base/global.js',
+            '../base/mozilla-form-helper.js',
+            'http://localhost:8000/tabzilla/tabzilla.js?build=dev',
+            'spec/site.js',
+            'spec/global.js',
+            'spec/mozilla-form-helper.js',
+            'spec/tabzilla.js',
+            {
+                pattern: '../../../node_modules/sinon/pkg/sinon.js',
+                watched: false,
+                included: true
+            }
+        ],
+
+        // list of files to exclude
+        exclude: [],
+
+        // test results reporter to use
+        // possible values: 'dots', 'progress', 'junit'
+        reporters: ['dots', 'junit'],
+
+        junitReporter: {
+          outputFile: 'test-results.xml'
+        },
+
+        // web server port
+        port: 9876,
+
+        // cli runner port
+        runnerPort: 9100,
+
+        // enable / disable colors in the output (reporters and logs)
+        colors: true,
+
+        // level of logging
+        // possible values: LOG_DISABLE || LOG_ERROR || LOG_WARN || LOG_INFO || LOG_DEBUG
+        logLevel: LOG_INFO,
+
+        // enable / disable watching file and executing tests whenever any file changes
+        autoWatch: true,
+
+        // Start these browsers, currently available:
+        // - Chrome
+        // - ChromeCanary
+        // - Firefox
+        // - Opera
+        // - Safari (only Mac)
+        // - PhantomJS
+        // - IE (only Windows)
+        browsers: ['PhantomJS'],
+
+        // If browser does not capture in given timeout [ms], kill it
+        captureTimeout: 60000,
+
+        // Continuous Integration mode
+        // if true, it capture browsers, run tests and exit
+        singleRun: true
+    });
+};

--- a/package.json
+++ b/package.json
@@ -3,7 +3,9 @@
   "version": "0.1.0",
   "description": "Making mozilla.org awesome, one pebble at a time",
   "private": true,
-  "scripts": {},
+  "scripts": {
+    "test": "grunt test"
+  },
   "dependencies": {
     "less": "~1.4.1"
   },
@@ -21,6 +23,19 @@
     "grunt-cli": "~0.1.11",
     "grunt-contrib-watch": "~0.5.3",
     "grunt-contrib-jshint": "~0.8.0",
-    "grunt-contrib-less": "~0.9.0"
+    "grunt-contrib-less": "~0.9.0",
+    "karma-script-launcher": "~0.1.0",
+    "karma-chrome-launcher": "~0.1.2",
+    "karma-firefox-launcher": "~0.1.3",
+    "karma-html2js-preprocessor": "~0.1.0",
+    "karma-jasmine": "~0.1.5",
+    "karma-coffee-preprocessor": "~0.1.3",
+    "requirejs": "~2.1.11",
+    "karma-requirejs": "~0.2.1",
+    "karma-phantomjs-launcher": "~0.1.2",
+    "karma": "~0.10.9",
+    "grunt-karma": "~0.6.2",
+    "sinon": "~1.8.2",
+    "karma-junit-reporter": "~0.2.1"
   }
 }


### PR DESCRIPTION
This PR enables us to run our JS test suite on the command line using [Karma](http://karma-runner.github.io) and Phantom JS.

Update your dependencies using `npm install`

Then just run `grunt test` :smile: 
