### PR TITLE
Fix Bug 977355 - broken link to superheroes wanted on mozilla.org/contribute

### DIFF
--- a/bedrock/mozorg/templates/mozorg/contribute.html
+++ b/bedrock/mozorg/templates/mozorg/contribute.html
@@ -345,7 +345,7 @@
                 <h3 id="support">{{_('Helping Users')}}</h3>
                 <div class="content">
                   <p>
-{% trans fx_support_url='https://support.mozilla.org/get-involved', tb_support_url='http://support.mozillamessaging.com/kb/superheroes-wanted' %}
+{% trans fx_support_url='https://support.mozilla.org/get-involved', tb_support_url='https://support.mozilla.org/get-involved' %}
 Our support process relies on enthusiastic contributors like you to help others get the most out of Mozilla products. Find out more about <a href="{{ fx_support_url }}">how to help Firefox users</a> and <a href="{{ tb_support_url }}">how to help Thunderbird users</a>.
 {% endtrans %}
                   </p>

--- a/bedrock/mozorg/templates/mozorg/projects/calendar.html
+++ b/bedrock/mozorg/templates/mozorg/projects/calendar.html
@@ -39,7 +39,7 @@
       <li>
         <img src="{{ media('/img/projects/calendar/bulb-icon.png') }}" alt="">
         <div class="itemtext">
-          <a href="http://support.mozillamessaging.com/" class="title">{{ _('Knowledge Base') }}</a>
+          <a href="https://support.mozilla.org/products/thunderbird/calendar" class="title">{{ _('Knowledge Base') }}</a>
           <span class="desc">{{ _('Need help with Lightning?') }}</span>
         </div>
       </li>


### PR DESCRIPTION
I've kept the string as-is to prevent the effect to l10n, because [this page will be refreshed soon](https://bugzilla.mozilla.org/show_bug.cgi?id=973967).

A ridealong: Update the Calendar KB URL.
