### PR TITLE
Fix GA tracking on features/specs tabs. Bug 974154.

### DIFF
--- a/bedrock/firefox/templates/firefox/os/devices.html
+++ b/bedrock/firefox/templates/firefox/os/devices.html
@@ -106,8 +106,8 @@
               <h3 class="device-title">{{ _('Alcatel One Touch Fire') }}</h3>
 
               <ul class="pager-tabs">
-                <li><a href="#p1">{{_('Features')}}</a></li>
-                <li><a href="#p2">{{_('Specifications')}}</a></li>
+                <li><a href="#p1" data-label="Features">{{_('Features')}}</a></li>
+                <li><a href="#p2" data-label="Specifications">{{_('Specifications')}}</a></li>
               </ul>
 
               <button class="device-detail-close">{{ _('Close') }}</button>
@@ -308,8 +308,8 @@
               <h3 class="device-title">{{ _('LG Fireweb') }}</h3>
 
               <ul class="pager-tabs">
-                <li><a href="#p1">{{_('Features')}}</a></li>
-                <li><a href="#p2">{{_('Specifications')}}</a></li>
+                <li><a href="#p1" data-label="Features">{{_('Features')}}</a></li>
+                <li><a href="#p2" data-label="Specifications">{{_('Specifications')}}</a></li>
               </ul>
 
               <button class="device-detail-close">{{ _('Close') }}</button>
@@ -473,8 +473,8 @@
               <h3 class="device-title">{{ _('ZTE Open') }}</h3>
 
               <ul class="pager-tabs">
-                <li><a href="#p1">{{_('Features')}}</a></li>
-                <li><a href="#p2">{{_('Specifications')}}</a></li>
+                <li><a href="#p1" data-label="Features">{{_('Features')}}</a></li>
+                <li><a href="#p2" data-label="Specifications">{{_('Specifications')}}</a></li>
               </ul>
 
               <button class="device-detail-close">{{ _('Close') }}</button>

--- a/media/js/firefox/os/devices.js
+++ b/media/js/firefox/os/devices.js
@@ -252,6 +252,6 @@ if (typeof Mozilla == 'undefined') {
 
     // track mozilla pager tab clicks
     $('.pager-tabs').on('click', 'a', function(e) {
-        gaTrack(['_trackEvent', '/os/devices/ Interactions', selectedDevice + ' Interactions', $(this).text() + ' Tab']);
+        gaTrack(['_trackEvent', '/os/devices/ Interactions', selectedDevice + ' Interactions', $(this).data('label') + ' Tab']);
     });
 })(window.jQuery);


### PR DESCRIPTION
De-couple GA tracking labels from (localizable) text.
