### PR TITLE
Fix first half of 971244 : Move "trap" & "attack "redirects to bedrock conf

### DIFF
--- a/etc/httpd/global.conf
+++ b/etc/httpd/global.conf
@@ -674,3 +674,7 @@ RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?press/speakerrequest(/?)$ /b/$1press/speaker
 
 # bug 970957
 RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/aurora/up-to-date(/?)$ /b/$1firefox/aurora/up-to-date$2 [PT]
+
+# bug 971244
+RewriteRule ^/firefox/its-a-trap.html$ http://www.itisatrap.org/firefox/its-a-trap.html [L]
+RewriteRule ^/firefox/its-an-attack.html$ http://www.itisatrap.org/firefox/its-an-attack.html [L]


### PR DESCRIPTION
To test locally go to either:

http://local.mozilla.org/firefox/its-a-trap.html
http://local.mozilla.org/firefox/its-an-attack.html

And click the following link. To retest you need to quit your browser.

![reported_web_forgery_-4](https://f.cloud.github.com/assets/198507/2300016/87de6de2-a0dc-11e3-80a9-7191476239cc.png)

Note I had to add a / to both redirects. This is something I did not have to do in the .htaccess - please verify this is correct.
