### PR TITLE
Bug 964928 - Code new version of Firefox Nightly First Run page

### DIFF
--- a/bedrock/firefox/templates/firefox/nightly_firstrun.html
+++ b/bedrock/firefox/templates/firefox/nightly_firstrun.html
@@ -30,7 +30,7 @@
 
      <h3>{{ _('By using a nightly build, you’re helping make Firefox better.') }}</h3>
 
-    <h3>{{ _('Learn more about Firefox and Mozilla:') }}</h2>
+    <h3>{{ _('Learn more about Firefox and Mozilla:') }}</h3>
     <ul class="unstyled">
         <li><a href="https://www.mozilla.org/manifesto/">{{ _('Read the Mozilla manifesto, our vision for a free and open Web.') }}</a></li>
         <li><a href="https://www.mozilla.org/en-US/firefox/29.0a2/whatsnew/">{{ _('Take a tour of the new Australis User Interface.') }}</a></li>


### PR DESCRIPTION
As per https://github.com/mozilla/bedrock/pull/1740

this is the following commits for Bug 924928 squashed.
- mhoye

Squashed commit of the following:

commit bc124abe08a6501e60e54dfcf412084537220e28
Merge: f05861d b6ce84d
Author: Mike Hoye mhoye@mozilla.com
Date:   Tue Mar 4 13:56:54 2014 -0500

```
Your daily update process.

Merge branch 'master' of https://github.com/mozilla/bedrock
```

commit f05861dc134a01cc8c4efa1fd72e4e3f9acacd77
Author: Mike Hoye mhoye@mozilla.com
Date:   Fri Feb 28 15:29:36 2014 -0500

```
Reshuffling some links, adding Call To Action.

Cutting down the number of links on the page, shuffling some others and
adding a call to action at the bottom.

- mhoye
```

commit f959bfa54cf593f47b426b672d5514197efb4edf
Author: Mike Hoye mhoye@mozilla.com
Date:   Thu Feb 27 14:05:20 2014 -0500

```
A revision to nightly_firstrun.html

I suppose it's possible I got this right this time. This modernizes the
currently-unused nightly firstrun page in preparation for our turning it
back on, with dead links and video removed and new links that do better
things added.

- mhoye
```

commit 48ccabdc572f32efc610bfe220c8e0ad8cb70bc5
Author: Mike Hoye mhoye@mozilla.com
Date:   Thu Feb 27 13:06:43 2014 -0500

```
Firefox Nightly page, modernized For Your Enjoyment.

Haha, that last one was just a vim swapfile because I'm Very Special.

Here's the real changes.

Again - removing dead links and outdated video, adding in the modern
links and onramps.

- mhoye
```

commit 8af24dcb5991306eef84e23e089faba23febe174
Author: Mike Hoye mhoye@mozilla.com
Date:   Thu Feb 27 12:18:25 2014 -0500

```
Bringing the Firefox Nighty page up to speed, culling dead links and
video, adding in modernity. Needs string localization work.

- mhoye
```
