### PR TITLE
Improve release_notes view to fix multiple bugs

### DIFF
--- a/bedrock/firefox/urls.py
+++ b/bedrock/firefox/urls.py
@@ -16,7 +16,7 @@ whatsnew_re = latest_re % (version_re, 'whatsnew')
 tour_re = latest_re % (version_re, 'tour')
 product_re = '(?P<product>firefox|mobile)'
 channel_re = '(?P<channel>beta|aurora|organizations)'
-releasenotes_re = latest_re % (version_re, 'releasenotes')
+releasenotes_re = latest_re % (version_re, r'(aurora|release)notes')
 sysreq_re = latest_re % (version_re, 'releasenotes/system-requirements')
 
 
@@ -76,9 +76,9 @@ urlpatterns = patterns('',
     page('firefox/os/releases', 'firefox/os/releases.html'),
 
     # firefox/os/notes/ should redirect to the latest version; update this in /redirects/urls.py
-    page('firefox/os/notes/1.0.1', 'firefox/os/notes-1.0.1.html'),
-    page('firefox/os/notes/1.1', 'firefox/os/notes-1.1.html'),
-    page('firefox/os/notes/1.2', 'firefox/os/notes-1.2.html'),
+    url('^firefox/os/notes/(?P<fx_version>%s)/$' % version_re,
+        views.release_notes, {'product': 'Firefox OS'},
+        name='firefox.os.releasenotes'),
 
     page('mwc', 'firefox/os/mwc-2014-preview.html'),
     page('firefox/os/devices', 'firefox/os/devices.html'),

--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -8,7 +8,8 @@ import json
 import re
 
 from django.conf import settings
-from django.http import HttpResponsePermanentRedirect, HttpResponseRedirect
+from django.http import (
+    Http404, HttpResponsePermanentRedirect, HttpResponseRedirect)
 from django.shortcuts import get_object_or_404
 from django.views.decorators.csrf import csrf_exempt, csrf_protect
 from django.views.decorators.vary import vary_on_headers
@@ -423,13 +424,6 @@ class TourView(LatestFxView):
         return super(TourView, self).get(request, *args, **kwargs)
 
 
-def fix_fx_version(fx_version):
-    if len(fx_version.split('.')) == 2:
-        return fx_version + '.0'
-    else:
-        return fx_version
-
-
 def release_notes_template(channel, product):
     if product == 'Firefox OS':
         return 'firefox/releases/os-notes.html'
@@ -437,12 +431,18 @@ def release_notes_template(channel, product):
     return 'firefox/releases/%s-notes.html' % prefix.get(channel, 'release')
 
 
-def release_notes(request, fx_version, channel='Release', product='Firefox'):
-    release = get_object_or_404(Release, version=fix_fx_version(fx_version),
-                                channel=channel, product=product)
+def release_notes(request, fx_version, product='Firefox'):
+    if product == 'Firefox OS' and fx_version in (
+            '1.0.1', '1.1', '1.2', '1.3'):
+        return l10n_utils.render(
+            request, 'firefox/os/notes-%s.html' % fx_version)
+
+    release = get_object_or_404(Release, version=fx_version, product=product)
+    if not release.is_public and not settings.DEV:
+        raise Http404
     new_features, known_issues = release.notes()
     return l10n_utils.render(
-        request, release_notes_template(channel, product), {
+        request, release_notes_template(release.channel, product), {
             'version': fx_version,
             'major_version': fx_version.split('.', 1)[0],
             'release': release,
@@ -450,10 +450,8 @@ def release_notes(request, fx_version, channel='Release', product='Firefox'):
             'known_issues': known_issues})
 
 
-def system_requirements(request, fx_version, channel='Release',
-                        product='Firefox'):
-    release = get_object_or_404(Release, version=fix_fx_version(fx_version),
-                                channel=channel, product=product)
+def system_requirements(request, fx_version, product='Firefox'):
+    release = get_object_or_404(Release, version=fx_version, product=product)
     return l10n_utils.render(
         request, 'firefox/releases/system_requirements.html',
         {'release': release, 'version': fx_version})


### PR DESCRIPTION
```
Improve release_notes view to fix multiple bugs

Map URLs within bedrock for bug 978931

Map firefox os release notes urls to new RNA powered release_notes
view, with fallback to manual templates for 1.0.1, 1.1, and 1.2 to
support the template development for bug 978988

respect Release.is_public flag unless settings.DEV is True for Bug 980055  

Map auroranotes to RNA release_notes view

Beta notes will also work if the version # matches the version_re,
which for example 28.0b1 will, but 28.0beta will not

We no longer "fix" version numbers like 27.0 -> 27.0.0 for Bug 974667-- this was
an artifact of data migrations that we need to fix in the nucleus
DB now that we've gotten past those migrations

mobile release notes are not yet supported, further work
will be done as part of Bug 965012.
```
