### PR TITLE
[fix bug 981542] Add callback to the new close button in Australis Tour door-hanger menu

### DIFF
--- a/bedrock/firefox/templates/firefox/whatsnew-aurora-29.html
+++ b/bedrock/firefox/templates/firefox/whatsnew-aurora-29.html
@@ -168,7 +168,7 @@
         </li>
       </ul>
       <div class="compact-title"></div>
-      <div class="tour-init tour-highlight" data-target="appMenu" data-icon="{{ MEDIA_URL }}img/firefox/australis/logo.png" data-icon-high-res="{{ MEDIA_URL }}img/firefox/australis/logo-high-res.png?2014-01"></div>
+      <div class="tour-init" data-target="appMenu" data-icon="{{ MEDIA_URL }}img/firefox/australis/logo.png" data-icon-high-res="{{ MEDIA_URL }}img/firefox/australis/logo-high-res.png?2014-01"></div>
 
       <div class="ui-tour-controls" aria-controls="ui-tour tour-content tour-progress">
         <button class="step prev">{{ _('Previous') }}</button>

--- a/media/js/firefox/australis/aurora-whatsnew.js
+++ b/media/js/firefox/australis/aurora-whatsnew.js
@@ -22,29 +22,19 @@
             onTourComplete: updateCTALinks
         });
 
-        /*
-         * Get Firefox Account Sync configuration.
-         * This will be used to determine conditional messaging.
-         * Note: Sync isn't being used in the first release,
-         * but this callback acts as a useful way to only start
-         * the tour is the API is working!
-         */
-        Mozilla.UITour.getSyncConfiguration(function (config) {
+        // scroll to top of window for mask overlay
+        if ($window.scrollTop() > 0) {
+            $window.scrollTop(0);
+        }
 
-            // scroll to top of window for mask overlay
-            if ($window.scrollTop() > 0) {
-                $window.scrollTop(0);
-            }
+        // start the by showing the doorhanger.
+        tour.init();
 
-            // start the by showing the doorhanger.
-            tour.init();
-
-            // show in-page cta to restart the tour
-            $giveTry.show().on('click', function (e) {
-                e.preventDefault();
-                tour.restartTour();
-                gaTrack(['_trackEvent', 'whatsnew Page Interactions - New Firefox Tour', 'click', 'Give it a try']);
-            });
+        // show in-page cta to restart the tour
+        $giveTry.show().on('click', function (e) {
+            e.preventDefault();
+            tour.restartTour();
+            gaTrack(['_trackEvent', 'whatsnew Page Interactions - New Firefox Tour', 'click', 'Give it a try']);
         });
 
         // track blue post-tour cta button

--- a/media/js/firefox/australis/australis-uitour.js
+++ b/media/js/firefox/australis/australis-uitour.js
@@ -4,153 +4,158 @@
 
 // create namespace
 if (typeof Mozilla == 'undefined') {
-    var Mozilla = {};
+	var Mozilla = {};
 }
 
 ;(function($) {
-    'use strict';
+	'use strict';
 
-    // create namespace
-    if (typeof Mozilla.UITour == 'undefined') {
-        Mozilla.UITour = {};
-    }
+	// create namespace
+	if (typeof Mozilla.UITour == 'undefined') {
+		Mozilla.UITour = {};
+	}
 
-    var themeIntervalId = null;
-    function _stopCyclingThemes() {
-        if (themeIntervalId) {
-            clearInterval(themeIntervalId);
-            themeIntervalId = null;
-        }
-    }
+	var themeIntervalId = null;
+	function _stopCyclingThemes() {
+		if (themeIntervalId) {
+			clearInterval(themeIntervalId);
+			themeIntervalId = null;
+		}
+	}
 
-    function _sendEvent(action, data) {
-        var event = new CustomEvent('mozUITour', {
-            bubbles: true,
-            detail: {
-                action: action,
-                data: data || {}
-            }
-        });
+	function _sendEvent(action, data) {
+		var event = new CustomEvent('mozUITour', {
+			bubbles: true,
+			detail: {
+				action: action,
+				data: data || {}
+			}
+		});
 
-        document.dispatchEvent(event);
-    }
+		document.dispatchEvent(event);
+	}
 
-    function _generateCallbackID() {
-        return Math.random().toString(36).replace(/[^a-z]+/g, '');
-    }
+	function _generateCallbackID() {
+		return Math.random().toString(36).replace(/[^a-z]+/g, '');
+	}
 
-    function _waitForCallback(callback) {
-        var id = _generateCallbackID();
+	function _waitForCallback(callback) {
+		var id = _generateCallbackID();
 
-        function listener(event) {
-            if (typeof event.detail != "object")
-                return;
-            if (event.detail.callbackID != id)
-                return;
+		function listener(event) {
+			if (typeof event.detail != "object")
+				return;
+			if (event.detail.callbackID != id)
+				return;
 
-            document.removeEventListener("mozUITourResponse", listener);
-            callback(event.detail.data);
-        }
-        document.addEventListener("mozUITourResponse", listener);
+			document.removeEventListener("mozUITourResponse", listener);
+			callback(event.detail.data);
+		}
+		document.addEventListener("mozUITourResponse", listener);
 
-        return id;
-    }
+		return id;
+	}
 
-    Mozilla.UITour.DEFAULT_THEME_CYCLE_DELAY = 10 * 1000;
+	Mozilla.UITour.DEFAULT_THEME_CYCLE_DELAY = 10 * 1000;
 
-    Mozilla.UITour.registerPageID = function(pageID) {
-        _sendEvent('registerPageID', {
-            pageID: pageID
-        });
-    };
+	Mozilla.UITour.registerPageID = function(pageID) {
+		_sendEvent('registerPageID', {
+			pageID: pageID
+		});
+	};
 
-    Mozilla.UITour.showHighlight = function(target, effect) {
-        _sendEvent('showHighlight', {
-            target: target,
-            effect: effect
-        });
-    };
+	Mozilla.UITour.showHighlight = function(target, effect) {
+		_sendEvent('showHighlight', {
+			target: target,
+			effect: effect
+		});
+	};
 
-    Mozilla.UITour.hideHighlight = function() {
-        _sendEvent('hideHighlight');
-    };
+	Mozilla.UITour.hideHighlight = function() {
+		_sendEvent('hideHighlight');
+	};
 
-    Mozilla.UITour.showInfo = function(target, title, text, icon, buttons) {
-        var buttonData = [];
-        if (Array.isArray(buttons)) {
-            for (var i = 0; i < buttons.length; i++) {
-                buttonData.push({
-                    label: buttons[i].label,
-                    icon: buttons[i].icon,
-                    style: buttons[i].style,
-                    callbackID: _waitForCallback(buttons[i].callback)
-                });
-            }
-        }
+	Mozilla.UITour.showInfo = function(target, title, text, icon, buttons, options) {
+		var buttonData = [];
+		if (Array.isArray(buttons)) {
+			for (var i = 0; i < buttons.length; i++) {
+				buttonData.push({
+					label: buttons[i].label,
+					icon: buttons[i].icon,
+					style: buttons[i].style,
+					callbackID: _waitForCallback(buttons[i].callback)
+				});
+			}
+		}
 
-        _sendEvent('showInfo', {
-            target: target,
-            title: title,
-            text: text,
-            icon: icon,
-            buttons: buttonData
-        });
-    };
+		var closeButtonCallbackID;
+		if (options && options.closeButtonCallback)
+			closeButtonCallbackID = _waitForCallback(options.closeButtonCallback);
 
-    Mozilla.UITour.hideInfo = function() {
-        _sendEvent('hideInfo');
-    };
+		_sendEvent('showInfo', {
+			target: target,
+			title: title,
+			text: text,
+			icon: icon,
+			buttons: buttonData,
+			closeButtonCallbackID: closeButtonCallbackID
+		});
+	};
 
-    Mozilla.UITour.previewTheme = function(theme) {
-        _stopCyclingThemes();
+	Mozilla.UITour.hideInfo = function() {
+		_sendEvent('hideInfo');
+	};
 
-        _sendEvent('previewTheme', {
-            theme: JSON.stringify(theme)
-        });
-    };
+	Mozilla.UITour.previewTheme = function(theme) {
+		_stopCyclingThemes();
 
-    Mozilla.UITour.resetTheme = function() {
-        _stopCyclingThemes();
+		_sendEvent('previewTheme', {
+			theme: JSON.stringify(theme)
+		});
+	};
 
-        _sendEvent('resetTheme');
-    };
+	Mozilla.UITour.resetTheme = function() {
+		_stopCyclingThemes();
 
-    Mozilla.UITour.cycleThemes = function(themes, delay, callback) {
-        _stopCyclingThemes();
+		_sendEvent('resetTheme');
+	};
 
-        if (!delay) {
-            delay = Mozilla.UITour.DEFAULT_THEME_CYCLE_DELAY;
-        }
+	Mozilla.UITour.cycleThemes = function(themes, delay, callback) {
+		_stopCyclingThemes();
 
-        function nextTheme() {
-            var theme = themes.shift();
-            themes.push(theme);
+		if (!delay) {
+			delay = Mozilla.UITour.DEFAULT_THEME_CYCLE_DELAY;
+		}
 
-            _sendEvent('previewTheme', {
-                theme: JSON.stringify(theme),
-                state: true
-            });
+		function nextTheme() {
+			var theme = themes.shift();
+			themes.push(theme);
 
-            callback(theme);
-        }
+			_sendEvent('previewTheme', {
+				theme: JSON.stringify(theme),
+				state: true
+			});
 
-        themeIntervalId = setInterval(nextTheme, delay);
-        nextTheme();
-    };
+			callback(theme);
+		}
 
-    Mozilla.UITour.addPinnedTab = function() {
-        _sendEvent('addPinnedTab');
-    };
+		themeIntervalId = setInterval(nextTheme, delay);
+		nextTheme();
+	};
 
-    Mozilla.UITour.removePinnedTab = function() {
-        _sendEvent('removePinnedTab');
-    };
+	Mozilla.UITour.addPinnedTab = function() {
+		_sendEvent('addPinnedTab');
+	};
 
-    Mozilla.UITour.showMenu = function(name) {
-        _sendEvent('showMenu', {
-            name: name
-        });
-    };
+	Mozilla.UITour.removePinnedTab = function() {
+		_sendEvent('removePinnedTab');
+	};
+
+	Mozilla.UITour.showMenu = function(name) {
+		_sendEvent('showMenu', {
+			name: name
+		});
+	};
 
         Mozilla.UITour.hideMenu = function(name) {
                 _sendEvent('hideMenu', {
@@ -158,21 +163,21 @@ if (typeof Mozilla == 'undefined') {
                 });
         };
 
-    Mozilla.UITour.startUrlbarCapture = function(text, url) {
-        _sendEvent('startUrlbarCapture', {
-            text: text,
-            url: url
-        });
-    };
+	Mozilla.UITour.startUrlbarCapture = function(text, url) {
+		_sendEvent('startUrlbarCapture', {
+			text: text,
+			url: url
+		});
+	};
 
-    Mozilla.UITour.endUrlbarCapture = function() {
-        _sendEvent('endUrlbarCapture');
-    };
+	Mozilla.UITour.endUrlbarCapture = function() {
+		_sendEvent('endUrlbarCapture');
+	};
 
-    Mozilla.UITour.getSyncConfiguration = function(callback) {
-        _sendEvent('getConfiguration', {
-            callbackID: _waitForCallback(callback),
-            configuration: "sync",
-        });
-    };
+	Mozilla.UITour.getSyncConfiguration = function(callback) {
+		_sendEvent('getConfiguration', {
+			callbackID: _waitForCallback(callback),
+			configuration: "sync",
+		});
+	};
 })();

--- a/media/js/firefox/australis/browser-tour.js
+++ b/media/js/firefox/australis/browser-tour.js
@@ -63,9 +63,6 @@ if (typeof Mozilla == 'undefined') {
         // show the door hanger if the tab is visible
         if (!document.hidden) {
             $('.tour-init').trigger('tour-step');
-            // temp workaround if bug 968039 does not make it into Aurora 29
-            // fixes highlight position first time browser is opened.
-            Mozilla.UITour.showHighlight('appMenu');
             // Register page id for Telemetry
             Mozilla.UITour.registerPageID(this.options.id);
         }
@@ -89,6 +86,11 @@ if (typeof Mozilla == 'undefined') {
             }
         ];
 
+        // callback to postpone tour if user clicks the (x) button
+        var options = {
+            closeButtonCallback: this.postponeTour.bind(this)
+        };
+
         // show the door-hanger info panel
         $('.tour-init').on('tour-step', function () {
             var icon = Mozilla.ImageHelper.isHighDpi() ? this.dataset.iconHighRes : this.dataset.icon;
@@ -98,7 +100,8 @@ if (typeof Mozilla == 'undefined') {
                 window.trans('title'),
                 window.trans('text'),
                 icon,
-                buttons
+                buttons,
+                options
             );
         });
 
@@ -522,6 +525,10 @@ if (typeof Mozilla == 'undefined') {
         setTimeout(function () {
             that.$tourList.find('li.current .step-target').trigger('tour-step');
             $current.find('h2').focus();
+
+            // temp workaround if bug 968039 does not make it into Aurora 29
+            // fixes highlight position first time browser is opened.
+            Mozilla.UITour.showHighlight('appMenu');
         }, 500);
 
         if (!this.tourIsPostponed) {


### PR DESCRIPTION
This PR does two things:
- Adds a callback to the new close (x) button in the door-hanger menu (use latest Nightly)
- Removes the initial blue UI highlight on the menu panel icon (required so [bug 971116](https://bugzilla.mozilla.org/show_bug.cgi?id=971116) can be landed).
