### PR TITLE
Fix Bug 983201 - Missing links to latest financial documents

### DIFF
--- a/bedrock/foundation/templates/foundation/documents/index.html
+++ b/bedrock/foundation/templates/foundation/documents/index.html
@@ -146,6 +146,14 @@
         <li><a href="http://static.mozilla.com/moco/en-US/pdf/Mozilla%20Foundation%20and%20Subsidiaries%202011%20Audited%20Financial%20Statement.pdf">{{ _('2011 audited financial statement for the Mozilla Foundation') }}</a></li>
       </ul>
     </li>
+    <li>{{ _('2012 filings and related documents') }}
+      <ul>
+        <li>{{ _('2012 annual report:') }} <q><a href="{{ url('foundation.annualreport.2012.index') }}">{{ _('State of Mozilla 2012') }}</a></q></li>
+        <li><a href="{{ url('foundation.annualreport.2012.faq') }}">{{ _('Mozilla 2012 financial FAQ') }}</a></li>
+        <li><a href="https://static.mozilla.com/moco/en-US/pdf/2012_Mozilla_Form_990-Public_Disclosure.pdf">{{ _('2012 IRS Form 990 for the Mozilla Foundation') }}</a></li>
+        <li><a href="https://static.mozilla.com/moco/en-US/pdf/Mozilla_Audited_Financials_2012.pdf">{{ _('2012 audited financial statement for the Mozilla Foundation') }}</a></li>
+      </ul>
+    </li>
   </ul>
 
 {% endblock %}


### PR DESCRIPTION
http://www.mozilla.org/en-US/foundation/documents/ is not localized yet, so this can be merged without l10n.
