### PR TITLE
Bug 983410 - Update Mountain View office contact info on Mozilla Spaces and other web pages

### DIFF
--- a/bedrock/mozorg/templates/mozorg/contact/spaces/mountain-view.html
+++ b/bedrock/mozorg/templates/mozorg/contact/spaces/mountain-view.html
@@ -15,9 +15,9 @@
         <p itemprop="address" itemscope itemtype="http://schema.org/PostalAddress" class="adr">
         {# L10n: Addresses are marked up with hCard microformat and Schema.org. See http://microformats.org/wiki/h-card and http://schema.org/PostalAddress #}
         {% trans %}
-          <span itemprop="streetAddress" class="street-address">650 Castro Street <br>Suite 300</span><br>
+          <span itemprop="streetAddress" class="street-address">331 E. Evelyn Ave.</span><br>
           <span itemprop="addressLocality" class="locality">Mountain View</span>, <abbr itemprop="addressRegion" class="region" title="California">CA</abbr><br>
-          <span itemprop="postalCode" class="postal-code">94041-2021</span><br>
+          <span itemprop="postalCode" class="postal-code">94041</span><br>
           <span itemprop="addressCountry" class="country-name">USA</span>
         {% endtrans %}
         </p>

--- a/bedrock/persona/templates/persona/privacy-policy.html
+++ b/bedrock/persona/templates/persona/privacy-policy.html
@@ -129,8 +129,8 @@
 <blockquote><pre>
 {{ _('Mozilla Corporation') }}
 {{ _('Attn: Legal Notices – Privacy') }}
-{{ _('650 Castro Street, Suite 300') }}
-{{ _('Mountain View, CA 94041-2072') }}
+{{ _('331 E. Evelyn Ave.') }}
+{{ _('Mountain View, CA 94041') }}
 {{ _('Phone: +1-650-903-0800') }}
 <a href="{{ url('privacy.index' )}}#contactus">{{ _('Send us an email') }}</a>
 

--- a/bedrock/privacy/templates/privacy/archive/firefox-december-2010.html
+++ b/bedrock/privacy/templates/privacy/archive/firefox-december-2010.html
@@ -367,7 +367,7 @@
             We will seek to comply with such requests, provided that we have sufficient information to identify the Personal Information or 
             Potentially Personal Information related to you.</p>
           <p>Any such requests or other questions or concerns regarding this Policy and Mozilla's data protection practices should be addressed to:</p>
-          <p>Mozilla Corporation <br />Attn: Legal Notices - Privacy <br />650 Castro Street, Suite 300 <br />Mountain View, CA 94041-2072 
+          <p>Mozilla Corporation <br />Attn: Legal Notices - Privacy <br />331 E. Evelyn Ave. <br />Mountain View, CA 94041 
             <br />Phone: +1-650-903-0800</p>
               <div class="field">
                   <label for="name" class="open-sans-light">Your name:</label>

--- a/bedrock/privacy/templates/privacy/ffos_privacy.html
+++ b/bedrock/privacy/templates/privacy/ffos_privacy.html
@@ -116,8 +116,8 @@
         <p id="introtxt">{{ _('If you want to make a correction to your information, or you have any questions about our privacy policies, please get in touch with:') }}</p>
         <p>{{ _('Mozilla Corporation<br />
             Attn: Legal Notices - Privacy<br />
-            650 Castro Street, Suite 300<br />
-            Mountain View, CA 94041-2072<br />
+            331 E. Evelyn Ave.<br />
+            Mountain View, CA 94041<br />
             Phone: +1-650-903-0800') }}
         </p>
         {% include "privacy/privacy_contact.html" %}

--- a/bedrock/privacy/templates/privacy/firefox.html
+++ b/bedrock/privacy/templates/privacy/firefox.html
@@ -124,7 +124,7 @@
         You should come back to check for changes. You could also subscribe to this [RSS feed]($FIXME:[privacy-policy-changes-rss-feed]) instead.</p>
       <h3>Contact us</h3>
       <p>If you want to make a correction to your information, or you have any  questions about our privacy policies, please get in touch with:</p>
-      <p>Mozilla Corporation<br />Attn: Legal Notices -- Privacy<br />650 Castro Street, Suite 300<br />Mountain View, CA 94041-2072</p>
+      <p>Mozilla Corporation<br />Attn: Legal Notices -- Privacy<br />331 E. Evelyn Ave.<br />Mountain View, CA 94041</p>
       <p>Phone: +1-650-903-0800</p>
       <p>E-mail: privacy@mozilla.com</p>
       <h3>Specific Features</h3>

--- a/bedrock/privacy/templates/privacy/index.html
+++ b/bedrock/privacy/templates/privacy/index.html
@@ -111,8 +111,8 @@
       <h1>Contact the Mozilla Privacy Team</h1>
       <p>Mozilla Corporation<br />
         Attn: Legal Notices - Privacy<br />
-        650 Castro Street, Suite 300<br />
-        Mountain View, CA 94041-2729<br />
+        331 E. Evelyn Ave.<br />
+        Mountain View, CA 94041<br />
         Phone: +1-650-903-0800</p>
 
       {% include "privacy/privacy_contact.html" %}

--- a/bedrock/privacy/templates/privacy/marketplace.html
+++ b/bedrock/privacy/templates/privacy/marketplace.html
@@ -143,7 +143,7 @@
         <h4>Changes to this Policy and our Contact Information</h4>
         <p>Sometimes, we change our privacy policies. When we do, we'll post a notice about the change on the Firefox Marketplace. If you want to
           make a correction to your information, or you have any questions about our privacy policies, please get in touch with:</p>
-        <p>Mozilla Corporation<br />Attn: Legal Notices -- Privacy<br />650 Castro Street, Suite 300<br />Mountain View, CA 94041-2072</p>
+        <p>Mozilla Corporation<br />Attn: Legal Notices -- Privacy<br />331 E. Evelyn Ave.<br />Mountain View, CA 94041</p>
         <p>Phone: +1-650-903-0800</p>
         <p>E-mail: privacy@mozilla.com</p>
       </section>

--- a/bedrock/privacy/templates/privacy/thunderbird.html
+++ b/bedrock/privacy/templates/privacy/thunderbird.html
@@ -247,7 +247,7 @@
           to comply with such requests, provided that we have sufficient information to identify the Personal Information or Potentially Personal Information 
           related to you. Any such requests or other questions or concerns regarding this Policy and Mozilla's data protection practices should be 
           addressed to:</p>
-        <p>Mozilla Corporation<br />Attn: Legal Notices -- Privacy<br />650 Castro Street, Suite 300<br />Mountain View, CA 94041-2072</p>
+        <p>Mozilla Corporation<br />Attn: Legal Notices -- Privacy<br />331 E. Evelyn Ave.<br />Mountain View, CA 94041</p>
         <p>Phone: +1-650-903-0800</p>
         <p>E-mail: privacy@mozilla.com</p>
       </section>


### PR DESCRIPTION
MV office is moving today. The patches for the legacy PHP site attached in the [bug](https://bugzilla.mozilla.org/show_bug.cgi?id=983410) also need to be reviewed and merged.
