### PR TITLE
[bug 984294] Indicate that the tour start button is the primary one

### DIFF
--- a/media/js/firefox/australis/browser-tour.js
+++ b/media/js/firefox/australis/browser-tour.js
@@ -82,6 +82,7 @@ if (typeof Mozilla == 'undefined') {
             },
             {
                 label: window.trans('start'),
+                style: 'primary',
                 callback: this.startTour.bind(this)
             }
         ];


### PR DESCRIPTION
Untested patch
