### PR TITLE
Update the SSL-enabled product list for Firefox 28 (No bug)

### DIFF
--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -874,7 +874,7 @@ STUB_INSTALLER_LOCALES = {
 }
 
 # Force download via SSL
-FORCE_SSL_DOWNLOAD_VERSIONS = ['27.0', '27.0.1']
+FORCE_SSL_DOWNLOAD_VERSIONS = ['27.0', '27.0.1', '28.0']
 
 # Google Analytics
 GA_ACCOUNT_CODE = ''


### PR DESCRIPTION
For the release tomorrow morning PDT. The product has been generated as per [Bug 984662](https://bugzilla.mozilla.org/show_bug.cgi?id=984662).
