### PR TITLE
[fix bug 984499] Update Sandstone Less mixins for CSS gradients

### DIFF
--- a/media/css/sandstone/lib.less
+++ b/media/css/sandstone/lib.less
@@ -238,48 +238,32 @@
   .horizontal (@startColor: #555, @endColor: #333) {
     background-color: @endColor;
     background-repeat: repeat-x;
-    background-image: -khtml-gradient(linear, left top, right top, from(@startColor), to(@endColor)); /* Konqueror */
-    background-image: -moz-linear-gradient(left, @startColor, @endColor); /* FF 3.6+ */
-    background-image: -ms-linear-gradient(left, @startColor, @endColor); /* IE10 */
-    background-image: -webkit-gradient(linear, left top, right top, color-stop(0%, @startColor), color-stop(100%, @endColor)); /* Safari 4+, Chrome 2+ */
     background-image: -webkit-linear-gradient(left, @startColor, @endColor); /* Safari 5.1+, Chrome 10+ */
-    background-image: -o-linear-gradient(left, @startColor, @endColor); /* Opera 11.10 */
     -ms-filter: %("progid:DXImageTransform.Microsoft.gradient(startColorstr='%d', endColorstr='%d', GradientType=1)",@startColor,@endColor); /* IE8+ */
-    background-image: linear-gradient(left, @startColor, @endColor); /* the standard */
+    background-image: linear-gradient(to right, @startColor, @endColor); /* the standard */
   }
   .vertical (@startColor: #555, @endColor: #333) {
     background-color: @endColor;
     background-repeat: repeat-x;
-    background-image: -khtml-gradient(linear, left top, left bottom, from(@startColor), to(@endColor)); /* Konqueror */
-    background-image: -moz-linear-gradient(@startColor, @endColor); /* FF 3.6+ */
-    background-image: -ms-linear-gradient(@startColor, @endColor); /* IE10 */
-    background-image: -webkit-gradient(linear, left top, left bottom, color-stop(0%, @startColor), color-stop(100%, @endColor)); /* Safari 4+, Chrome 2+ */
-    background-image: -webkit-linear-gradient(@startColor, @endColor); /* Safari 5.1+, Chrome 10+ */
-    background-image: -o-linear-gradient(@startColor, @endColor); /* Opera 11.10 */
+    background-image: -webkit-linear-gradient(top, @startColor, @endColor); /* Safari 5.1+, Chrome 10+ */
     -ms-filter: %("progid:DXImageTransform.Microsoft.gradient(startColorstr='%d', endColorstr='%d', GradientType=0)",@startColor,@endColor); /* IE8+ */
-    background-image: linear-gradient(@startColor, @endColor); /* the standard */
+    background-image: linear-gradient(to bottom, @startColor, @endColor); /* the standard */
   }
   .directional (@startColor: #555, @endColor: #333, @deg: 45deg) {
     background-color: @endColor;
     background-repeat: repeat-x;
-    background-image: -moz-linear-gradient(@deg, @startColor, @endColor); /* FF 3.6+ */
-    background-image: -ms-linear-gradient(@deg, @startColor, @endColor); /* IE10 */
     background-image: -webkit-linear-gradient(@deg, @startColor, @endColor); /* Safari 5.1+, Chrome 10+ */
-    background-image: -o-linear-gradient(@deg, @startColor, @endColor); /* Opera 11.10 */
     background-image: linear-gradient(@deg, @startColor, @endColor); /* the standard */
   }
-  .vertical-three-colors(@startColor: #00b3ee, @midColor: #7a43b6, @colorStop: 0.5, @endColor: #c3325f) {
+  .vertical-three-colors(@startColor: #00b3ee, @midColor: #7a43b6, @colorStop: 50%, @endColor: #c3325f) {
     background-color: @endColor;
     background-repeat: no-repeat;
-    background-image: -webkit-gradient(linear, 0 0, 0 100%, from(@startColor), color-stop(@colorStop, @midColor), to(@endColor));
-    background-image: -webkit-linear-gradient(@startColor, color-stop(@colorStop, @midColor), @endColor);
-    background-image: -moz-linear-gradient(@startColor, color-stop(@midColor, @colorStop), @endColor);
+    background-image: -webkit-linear-gradient(top, @startColor 0%, @midColor @colorStop, @endColor 100%); /* Chrome10+,Safari5.1+ */
+    background-image: linear-gradient(to bottom, @startColor 0%, @midColor @colorStop, @endColor 100%); /* the standard */
   }
   .radial(@posX:center, @posY:center, @shape:circle, @size:closest-side, @startColor:white, @endColor:black){
-    background-image: -moz-radial-gradient(@posX @posY, @shape @size, @startColor, @endColor);
     background-image: -webkit-radial-gradient(@posX @posY, @shape @size, @startColor, @endColor);
-    background-image: -o-radial-gradient(@posX @posY, @shape @size, @startColor, @endColor);
-    background-image: radial-gradient(@posX @posY, @shape @size, @startColor, @endColor);
+    background-image: radial-gradient(@shape @size at @posX @posY, @startColor, @endColor);
   }
 }
 

--- a/media/css/sandstone/mixins.less
+++ b/media/css/sandstone/mixins.less
@@ -45,48 +45,32 @@
   .horizontal (@startColor: #555, @endColor: #333) {
     background-color: @endColor;
     background-repeat: repeat-x;
-    background-image: -khtml-gradient(linear, left top, right top, from(@startColor), to(@endColor)); /* Konqueror */
-    background-image: -moz-linear-gradient(left, @startColor, @endColor); /* FF 3.6+ */
-    background-image: -ms-linear-gradient(left, @startColor, @endColor); /* IE10 */
-    background-image: -webkit-gradient(linear, left top, right top, color-stop(0%, @startColor), color-stop(100%, @endColor)); /* Safari 4+, Chrome 2+ */
     background-image: -webkit-linear-gradient(left, @startColor, @endColor); /* Safari 5.1+, Chrome 10+ */
-    background-image: -o-linear-gradient(left, @startColor, @endColor); /* Opera 11.10 */
     -ms-filter: %("progid:DXImageTransform.Microsoft.gradient(startColorstr='%d', endColorstr='%d', GradientType=1)",@startColor,@endColor); /* IE8+ */
-    background-image: linear-gradient(left, @startColor, @endColor); /* the standard */
+    background-image: linear-gradient(to right, @startColor, @endColor); /* the standard */
   }
   .vertical (@startColor: #555, @endColor: #333) {
     background-color: @endColor;
     background-repeat: repeat-x;
-    background-image: -khtml-gradient(linear, left top, left bottom, from(@startColor), to(@endColor)); /* Konqueror */
-    background-image: -moz-linear-gradient(@startColor, @endColor); /* FF 3.6+ */
-    background-image: -ms-linear-gradient(@startColor, @endColor); /* IE10 */
-    background-image: -webkit-gradient(linear, left top, left bottom, color-stop(0%, @startColor), color-stop(100%, @endColor)); /* Safari 4+, Chrome 2+ */
-    background-image: -webkit-linear-gradient(@startColor, @endColor); /* Safari 5.1+, Chrome 10+ */
-    background-image: -o-linear-gradient(@startColor, @endColor); /* Opera 11.10 */
+    background-image: -webkit-linear-gradient(top, @startColor, @endColor); /* Safari 5.1+, Chrome 10+ */
     -ms-filter: %("progid:DXImageTransform.Microsoft.gradient(startColorstr='%d', endColorstr='%d', GradientType=0)",@startColor,@endColor); /* IE8+ */
-    background-image: linear-gradient(@startColor, @endColor); /* the standard */
+    background-image: linear-gradient(to bottom, @startColor, @endColor); /* the standard */
   }
   .directional (@startColor: #555, @endColor: #333, @deg: 45deg) {
     background-color: @endColor;
     background-repeat: repeat-x;
-    background-image: -moz-linear-gradient(@deg, @startColor, @endColor); /* FF 3.6+ */
-    background-image: -ms-linear-gradient(@deg, @startColor, @endColor); /* IE10 */
     background-image: -webkit-linear-gradient(@deg, @startColor, @endColor); /* Safari 5.1+, Chrome 10+ */
-    background-image: -o-linear-gradient(@deg, @startColor, @endColor); /* Opera 11.10 */
     background-image: linear-gradient(@deg, @startColor, @endColor); /* the standard */
   }
-  .vertical-three-colors(@startColor: #00b3ee, @midColor: #7a43b6, @colorStop: 0.5, @endColor: #c3325f) {
+  .vertical-three-colors(@startColor: #00b3ee, @midColor: #7a43b6, @colorStop: 50%, @endColor: #c3325f) {
     background-color: @endColor;
     background-repeat: no-repeat;
-    background-image: -webkit-gradient(linear, 0 0, 0 100%, from(@startColor), color-stop(@colorStop, @midColor), to(@endColor));
-    background-image: -webkit-linear-gradient(@startColor, color-stop(@colorStop, @midColor), @endColor);
-    background-image: -moz-linear-gradient(@startColor, color-stop(@midColor, @colorStop), @endColor);
+    background-image: -webkit-linear-gradient(top, @startColor 0%, @midColor @colorStop, @endColor 100%); /* Chrome10+,Safari5.1+ */
+    background-image: linear-gradient(to bottom, @startColor 0%, @midColor @colorStop, @endColor 100%); /* the standard */
   }
   .radial(@posX:center, @posY:center, @shape:circle, @size:closest-side, @startColor:white, @endColor:black){
-    background-image: -moz-radial-gradient(@posX @posY, @shape @size, @startColor, @endColor);
     background-image: -webkit-radial-gradient(@posX @posY, @shape @size, @startColor, @endColor);
-    background-image: -o-radial-gradient(@posX @posY, @shape @size, @startColor, @endColor);
-    background-image: radial-gradient(@posX @posY, @shape @size, @startColor, @endColor);
+    background-image: radial-gradient(@shape @size at @posX @posY, @startColor, @endColor);
   }
 }
 


### PR DESCRIPTION
- Updated CSS gradient syntax for mixins in `lib.less` and `mixins.less`
- Removed `-khtml` vendor prefixes.
- Removed the outdated `-webkit-gradient` syntax rules.
- Removed `-o` vendor prefixes.
- Removed `-ms` vendor prefixes (I believe these we're only used in IE10 Preview. The release version uses standard syntax).

I've left in `-moz` for legacy Firefox support, but I'm totally open to what we include or leave out. Up for discussion!

For reference: http://caniuse.com/#search=grad
