### PR TITLE
Bug 985067 remove link to Berlin spaces page

### DIFF
--- a/bedrock/mozorg/templates/mozorg/contact/spaces/berlin.html
+++ b/bedrock/mozorg/templates/mozorg/contact/spaces/berlin.html
@@ -21,9 +21,6 @@
         {% endtrans %}
         </p>
 
-        <ul class="extra">
-          <li><a href="https://wiki.mozilla.org/People:MozSpaces_Guidelines:Berlin" class="book">{{ _('Space operations guide') }}</a></li>
-        </ul>
 
         <figure class="feature-img">
           <img src="//api.tiles.mapbox.com/v3/{{ settings.MAPBOX_TOKEN }}/url-{{ 'mozorg.cdn.mozilla.net/media/img/contact/moz-map-pin.png'|urlencode }}(13.418735,52.512408)/13.418735,52.512408,16/460x250.png" alt="">


### PR DESCRIPTION
Removed a link that is no longer needed on the Berlin contact us page
