### PR TITLE
Fix Bug 973311 - Make all Firefox Beta, Release and ESR channel download links default to SSL

### DIFF
--- a/bedrock/firefox/firefox_details.py
+++ b/bedrock/firefox/firefox_details.py
@@ -2,8 +2,6 @@ import re
 from operator import itemgetter
 from urllib import urlencode
 
-from django.conf import settings
-
 from product_details import ProductDetails
 
 
@@ -139,12 +137,6 @@ class FirefoxDetails(ProductDetails):
         :param product: optional. probably 'firefox'
         :return: string url
         """
-        product_code = [product, version]
-
-        # Force download via SSL
-        if version in settings.FORCE_SSL_DOWNLOAD_VERSIONS:
-            product_code.append('SSL')
-
         if platform == 'OS X' and language == 'ja':
             language = 'ja-JP-mac'
 
@@ -153,7 +145,7 @@ class FirefoxDetails(ProductDetails):
 
         return '?'.join([self.download_base_url_direct,
                          urlencode([
-                             ('product', '-'.join(product_code)),
+                             ('product', '-'.join([product, version, 'SSL'])),
                              ('os', self.platform_info[platform]['id']),
                              # Order matters, lang must be last for bouncer.
                              ('lang', language),

--- a/bedrock/firefox/tests/test_base.py
+++ b/bedrock/firefox/tests/test_base.py
@@ -108,15 +108,15 @@ class TestInstallerHelp(TestCase):
 class TestFirefoxDetails(TestCase):
 
     def test_get_download_url(self):
-        url = firefox_details.get_download_url('OS X', 'pt-BR', '17.0')
+        url = firefox_details.get_download_url('OS X', 'pt-BR', '17.0.1')
         self.assertListEqual(parse_qsl(urlparse(url).query),
-                             [('product', 'firefox-17.0'),
+                             [('product', 'firefox-17.0.1-SSL'),
                               ('os', 'osx'),
                               ('lang', 'pt-BR')])
         # Linux 64-bit
-        url = firefox_details.get_download_url('Linux 64', 'en-US', '26.0')
+        url = firefox_details.get_download_url('Linux 64', 'en-US', '17.0.1')
         self.assertListEqual(parse_qsl(urlparse(url).query),
-                             [('product', 'firefox-26.0'),
+                             [('product', 'firefox-17.0.1-SSL'),
                               ('os', 'linux64'),
                               ('lang', 'en-US')])
 
@@ -137,37 +137,28 @@ class TestFirefoxDetails(TestCase):
         self.assertIn('latest-mozilla-aurora-l10n/firefox-28.0a2.pt-BR.linux-i686.tar.bz2',
                       url)
 
-    @override_settings(FORCE_SSL_DOWNLOAD_VERSIONS=['27.0'])
     @override_settings(STUB_INSTALLER_LOCALES={'win': settings.STUB_INSTALLER_ALL})
     def get_download_url_ssl(self):
         """
-        SSL-enabled links should be used for the specific verions, except the
-        Windows stub installers.
+        SSL-enabled links should always be used except Windows stub installers.
         """
 
-        # SSL-enabled links won't be used for 26.0
-        url = firefox_details.get_download_url('OS X', 'pt-BR', '26.0')
-        self.assertListEqual(parse_qsl(urlparse(url).query),
-                             [('product', 'firefox-26.0'),
-                              ('os', 'osx'),
-                              ('lang', 'pt-BR')])
-
-        # SSL-enabled links won't be used for 27.0 Windows builds (but SSL
-        # download is enabled by default for stub installers)
+        # SSL-enabled links won't be used for Windows builds (but SSL download
+        # is enabled by default for stub installers)
         url = firefox_details.get_download_url('Windows', 'pt-BR', '27.0')
         self.assertListEqual(parse_qsl(urlparse(url).query),
                              [('product', 'firefox-27.0'),
                               ('os', 'win'),
                               ('lang', 'pt-BR')])
 
-        # SSL-enabled links will be used for 27.0 OS X builds
+        # SSL-enabled links will be used for OS X builds
         url = firefox_details.get_download_url('OS X', 'pt-BR', '27.0')
         self.assertListEqual(parse_qsl(urlparse(url).query),
                              [('product', 'firefox-27.0-SSL'),
                               ('os', 'osx'),
                               ('lang', 'pt-BR')])
 
-        # SSL-enabled links will be used for 27.0 Linux builds
+        # SSL-enabled links will be used for Linux builds
         url = firefox_details.get_download_url('Linux', 'pt-BR', '27.0')
         self.assertListEqual(parse_qsl(urlparse(url).query),
                              [('product', 'firefox-27.0-SSL'),

--- a/bedrock/mozorg/helpers/download_buttons.py
+++ b/bedrock/mozorg/helpers/download_buttons.py
@@ -96,10 +96,6 @@ def make_download_link(product, build, version, platform, locale,
         'os_osx': 'osx'
     }[platform]
 
-    # Force download via SSL
-    if version in settings.FORCE_SSL_DOWNLOAD_VERSIONS:
-        version += '-SSL'
-
     # stub installer exceptions
     # TODO: NUKE FROM ORBIT!
     stub_langs = settings.STUB_INSTALLER_LOCALES.get(platform, [])
@@ -110,6 +106,10 @@ def make_download_link(product, build, version, platform, locale,
             suffix = 'latest'
 
         version = ('beta-' if build == 'beta' else '') + suffix
+    elif not funnelcake_id:
+        # Force download via SSL. Stub installers are always downloaded via SSL.
+        # Funnelcakes may not be ready for SSL download
+        version += '-SSL'
 
     # append funnelcake id to version if we have one
     if funnelcake_id:

--- a/bedrock/mozorg/tests/test_helper_download_buttons.py
+++ b/bedrock/mozorg/tests/test_helper_download_buttons.py
@@ -328,8 +328,8 @@ class TestDownloadButtons(TestCase):
         well as the query string.
         """
         locale = settings.LOCALES_WITH_TRANSITION[0]
-        url = make_download_link('firefox', 'release', 19.0, 'os_osx', locale)
-        good_url = ('/{locale}/products/download.html?product=firefox-19.0&'
+        url = make_download_link('firefox', 'release', '19.0', 'os_osx', locale)
+        good_url = ('/{locale}/products/download.html?product=firefox-19.0-SSL&'
                     'os=osx&lang={locale}').format(locale=locale)
         eq_(url, good_url)
 
@@ -340,7 +340,7 @@ class TestDownloadButtons(TestCase):
         for en-US windows release downloads, and 'firefox-beta-latest' for
         beta.
         """
-        url = make_download_link('firefox', 'release', 19.0, 'os_windows',
+        url = make_download_link('firefox', 'release', '19.0', 'os_windows',
                                  'en-US', force_funnelcake=True)
         ok_('product=firefox-latest&' in url)
 
@@ -353,7 +353,7 @@ class TestDownloadButtons(TestCase):
         """
         Ensure that force_funnelcake doesn't affect non configured locale urls
         """
-        url = make_download_link('firefox', 'release', 19.0, 'os_osx',
+        url = make_download_link('firefox', 'release', '19.0', 'os_osx',
                                  'en-US', force_funnelcake=True)
         ok_('product=firefox-latest&' not in url)
 
@@ -368,7 +368,7 @@ class TestDownloadButtons(TestCase):
         for configured locale release downloads, and 'firefox-beta-latest' for
         beta.
         """
-        url = make_download_link('firefox', 'release', 19.0, 'os_windows',
+        url = make_download_link('firefox', 'release', '19.0', 'os_windows',
                                  'en-US', force_full_installer=True)
         ok_('product=firefox-latest&' in url)
 
@@ -381,7 +381,7 @@ class TestDownloadButtons(TestCase):
         """
         Ensure that force_full_installer doesn't affect non configured locales
         """
-        url = make_download_link('firefox', 'release', 19.0, 'os_osx',
+        url = make_download_link('firefox', 'release', '19.0', 'os_osx',
                                  'en-US', force_full_installer=True)
         ok_('product=firefox-latest&' not in url)
 
@@ -393,15 +393,15 @@ class TestDownloadButtons(TestCase):
         'win': ['en-us'], 'osx': ['fr', 'de'], 'linux': []})
     def test_stub_installer(self):
         """Button should give stub for builds in the setting always."""
-        url = make_download_link('firefox', 'release', 19.0, 'os_windows',
+        url = make_download_link('firefox', 'release', '19.0', 'os_windows',
                                  'en-US')
         ok_('product=firefox-stub&' in url)
 
-        url = make_download_link('firefox', 'release', 19.0, 'os_osx',
+        url = make_download_link('firefox', 'release', '19.0', 'os_osx',
                                  'fr')
         ok_('product=firefox-stub&' in url)
 
-        url = make_download_link('firefox', 'release', 19.0, 'os_osx',
+        url = make_download_link('firefox', 'release', '19.0', 'os_osx',
                                  'de')
         ok_('product=firefox-stub&' in url)
 
@@ -412,15 +412,15 @@ class TestDownloadButtons(TestCase):
     @override_settings(STUB_INSTALLER_LOCALES={'win': _ALL})
     def test_stub_installer_all(self):
         """Button should give stub for all langs when ALL is set."""
-        url = make_download_link('firefox', 'release', 19.0, 'os_windows',
+        url = make_download_link('firefox', 'release', '19.0', 'os_windows',
                                  'en-US')
         ok_('product=firefox-stub&' in url)
 
-        url = make_download_link('firefox', 'release', 19.0, 'os_windows',
+        url = make_download_link('firefox', 'release', '19.0', 'os_windows',
                                  'fr')
         ok_('product=firefox-stub&' in url)
 
-        url = make_download_link('firefox', 'release', 19.0, 'os_windows',
+        url = make_download_link('firefox', 'release', '19.0', 'os_windows',
                                  'de')
         ok_('product=firefox-stub&' in url)
 
@@ -433,7 +433,7 @@ class TestDownloadButtons(TestCase):
         """
         Ensure that builds not in the setting don't get stub.
         """
-        url = make_download_link('firefox', 'release', 19.0, 'os_osx',
+        url = make_download_link('firefox', 'release', '19.0', 'os_osx',
                                  'en-US')
         ok_('product=firefox-stub&' not in url)
 
@@ -444,15 +444,15 @@ class TestDownloadButtons(TestCase):
     @override_settings(STUB_INSTALLER_LOCALES={'win': _ALL})
     def test_funnelcake_id(self):
         """Button should append funnelcake ID to product in download URL."""
-        url = make_download_link('firefox', 'release', 19.0, 'os_windows',
+        url = make_download_link('firefox', 'release', '19.0', 'os_windows',
                                  'en-US', funnelcake_id='2')
         ok_('product=firefox-stub-f2&' in url)
 
-        url = make_download_link('firefox', 'release', 19.0, 'os_windows',
+        url = make_download_link('firefox', 'release', '19.0', 'os_windows',
                                  'fr', funnelcake_id='2')
         ok_('product=firefox-stub-f2&' in url)
 
-        url = make_download_link('firefox', 'release', 19.0, 'os_osx',
+        url = make_download_link('firefox', 'release', '19.0', 'os_osx',
                                  'de', funnelcake_id='23')
         ok_('product=firefox-19.0-f23&' in url)
 
@@ -460,38 +460,30 @@ class TestDownloadButtons(TestCase):
                                  'es-ES', funnelcake_id='234')
         ok_('product=firefox-20.0b4-f234&' in url)
 
-    @override_settings(FORCE_SSL_DOWNLOAD_VERSIONS=['27.0'])
     @override_settings(STUB_INSTALLER_LOCALES={'win': _ALL})
     def test_force_ssl(self):
         """
         Button should append 'SSL' to product in download URL, except the
         Windows stub installers.
         """
-        url = make_download_link('firefox', 'release', '26.0', 'os_windows',
-                                 'en-US')
+        url = mkln('firefox', 'release', '27.0', 'os_windows', 'en-US')
         ok_('product=firefox-stub&' in url)
 
-        url = make_download_link('firefox', 'release', '26.0', 'os_osx',
-                                 'en-US')
-        ok_('product=firefox-26.0&' in url)
-
-        url = make_download_link('firefox', 'release', '26.0', 'os_linux',
-                                 'en-US')
-        ok_('product=firefox-26.0&' in url)
-
-        url = make_download_link('firefox', 'release', '27.0', 'os_windows',
-                                 'en-US')
-        ok_('product=firefox-stub&' in url)
-
-        url = make_download_link('firefox', 'release', '27.0', 'os_osx',
-                                 'en-US')
+        url = mkln('firefox', 'release', '27.0', 'os_osx', 'en-US')
         ok_('product=firefox-27.0-SSL&' in url)
 
-        url = make_download_link('firefox', 'release', '27.0', 'os_linux',
-                                 'en-US')
+        url = mkln('firefox', 'release', '27.0', 'os_linux', 'en-US')
         ok_('product=firefox-27.0-SSL&' in url)
 
-    @override_settings(FORCE_SSL_DOWNLOAD_VERSIONS=['27.0'])
+        url = mkln('firefox', 'beta', '28.0b4', 'os_windows', 'en-US')
+        ok_('product=firefox-beta-stub&' in url)
+
+        url = mkln('firefox', 'beta', '28.0b4', 'os_osx', 'en-US')
+        ok_('product=firefox-28.0b4-SSL&' in url)
+
+        url = mkln('firefox', 'beta', '28.0b4', 'os_linux', 'en-US')
+        ok_('product=firefox-28.0b4-SSL&' in url)
+
     def test_linux64(self):
         """Button should give a linux64 build for all locales."""
         url = mkln('firefox', 'release', '27.0', 'os_linux64', 'en-US')
@@ -501,10 +493,10 @@ class TestDownloadButtons(TestCase):
         ok_('product=firefox-27.0-SSL&os=linux64&lang=fr' in url)
 
         url = mkln('firefox', 'beta', '28.0b4', 'os_linux64', 'en-US')
-        ok_('product=firefox-28.0b4&os=linux64&lang=en-US' in url)
+        ok_('product=firefox-28.0b4-SSL&os=linux64&lang=en-US' in url)
 
         url = mkln('firefox', 'beta', '28.0b4', 'os_linux64', 'de')
-        ok_('product=firefox-28.0b4&os=linux64&lang=de' in url)
+        ok_('product=firefox-28.0b4-SSL&os=linux64&lang=de' in url)
 
         url = mkln('firefox', 'aurora', '29.0a2', 'os_linux64', 'en-US')
         eq_(url, AURORA_DIR + '/firefox-29.0a2.en-US.linux-x86_64.tar.bz2')

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -887,9 +887,6 @@ STUB_INSTALLER_LOCALES = {
     'linux': [],
 }
 
-# Force download via SSL
-FORCE_SSL_DOWNLOAD_VERSIONS = ['27.0', '27.0.1', '28.0', '29.0', '29.0.1']
-
 # Google Analytics
 GA_ACCOUNT_CODE = ''
 


### PR DESCRIPTION
This enables secure downloads for all Beta, Release and ESR builds.
- Windows stub installers have already been downloaded via SSL
- funnelcakes are not included in this change
- Aurora links are pointing https://ftp.mozilla.org/ directly, instead of download.m.o
