### PR TITLE
[fix bug 986038] Mozilla.ImageHelper does not take into account additional platforms

### DIFF
--- a/media/js/base/global.js
+++ b/media/js/base/global.js
@@ -56,48 +56,6 @@ function init_lang_switcher() {
     });
 }
 
-// platform images
-
-function init_platform_imgs() {
-    function has_platform(platforms, platform) {
-        for (var i = 0; i < platforms.length; i++) {
-            if (platforms[i] === platform && site.platform === platform) {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    $('.platform-img').each(function() {
-        var suffix = '';
-        var $img = $(this);
-        var default_platforms = ['osx', 'oldmac', 'linux'];
-        var additional_platforms;
-        var platforms = default_platforms;
-
-        // use 'data-additional-platforms' to specify other supported platforms
-        // beyond the defaults
-        if ($img.data('additional-platforms')) {
-            additional_platforms = $img.data('additional-platforms').split(' ');
-            platforms = default_platforms.concat(additional_platforms);
-        }
-
-        if (has_platform(platforms, 'osx') || has_platform(platforms, 'oldmac')) {
-            suffix = '-mac';
-        } else if (has_platform(platforms, site.platform)) {
-            suffix = '-' + site.platform;
-        }
-
-        var orig_src = $img.data('src');
-        var i = orig_src.lastIndexOf('.');
-        var base = orig_src.substring(0, i);
-        var ext = orig_src.substring(i);
-        this.src = base + suffix + ext;
-        $img.addClass(site.platform);
-    });
-}
-
 // init
 
 $(document).ready(function() {

--- a/media/js/base/mozilla-image-helper.js
+++ b/media/js/base/mozilla-image-helper.js
@@ -36,13 +36,27 @@ Mozilla.ImageHelper.is_high_dpi = null;
 
 Mozilla.ImageHelper.initPlatformImages = function() {
     $('.platform-img').each(function() {
-        var suffix = '';
         var $img = $(this);
+        var suffix = '';
+        var platforms;
+        var additional_platforms;
+
+        // special handling for mac
         if (site.platform === 'osx' || site.platform === 'oldmac') {
             suffix = '-mac';
-        }
-        else if (site.platform === 'linux') {
-            suffix = '-linux';
+        } else {
+            platforms = ['linux']; // linux is supported by default
+
+            // use 'data-additional-platforms' to specify other supported platforms
+            // beyond the defaults
+            if ($img.data('additional-platforms')) {
+                additional_platforms = $img.data('additional-platforms').split(' ');
+                platforms = platforms.concat(additional_platforms);
+            }
+
+            if ($.inArray(site.platform, platforms) > -1) {
+                suffix = '-' + site.platform;
+            }
         }
 
         var orig_src = $img.data('src');
@@ -72,7 +86,6 @@ Mozilla.ImageHelper.initHighResImages = function() {
         if (Mozilla.ImageHelper.isHighDpi()) {
             src = Mozilla.ImageHelper.convertUrlToHighRes(src);
         }
-
         this.src = src;
     });
 };

--- a/media/js/test/karma.conf.js
+++ b/media/js/test/karma.conf.js
@@ -13,10 +13,12 @@ module.exports = function(config) {
             '../base/site.js',
             '../base/global.js',
             '../base/mozilla-form-helper.js',
+            '../base/mozilla-image-helper.js',
             'http://localhost:8000/tabzilla/tabzilla.js?build=dev',
             'spec/site.js',
             'spec/global.js',
             'spec/mozilla-form-helper.js',
+            'spec/mozilla-image-helper.js',
             'spec/tabzilla.js',
             {
                 pattern: '../../../node_modules/sinon/pkg/sinon.js',
@@ -47,7 +49,7 @@ module.exports = function(config) {
 
         // level of logging
         // possible values: LOG_DISABLE || LOG_ERROR || LOG_WARN || LOG_INFO || LOG_DEBUG
-        logLevel: LOG_INFO,
+        //logLevel: console.LOG_INFO,
 
         // enable / disable watching file and executing tests whenever any file changes
         autoWatch: true,

--- a/media/js/test/spec/global.js
+++ b/media/js/test/spec/global.js
@@ -87,34 +87,6 @@ describe("global.js", function() {
 
     });
 
-    describe("init_platform_imgs", function () {
-
-        beforeEach(function () {
-            // Pretend we're on osx for each test
-            window.site = {
-                platform: 'osx'
-            };
-            //create an HTML fixture to test against
-            $('<img class="platform-img js" data-src="foo/bar.jpg" src="">').appendTo('body');
-        });
-
-        afterEach(function(){
-            // Tidy up after each test
-            window.site = null;
-            $('.platform-img').remove();
-        });
-
-        it("should set platform specific src file", function () {
-            init_platform_imgs();
-            expect($('.platform-img').attr('src')).toEqual('foo/bar-mac.jpg');
-        });
-
-        it("should set platform specific css class", function () {
-            init_platform_imgs();
-            expect($('.platform-img').hasClass('osx')).toBeTruthy();
-        });
-    });
-
     describe("getFirefoxMasterVersion", function () {
 
         it("should return the firefox master version number", function () {

--- a/media/js/test/spec/mozilla-image-helper.js
+++ b/media/js/test/spec/mozilla-image-helper.js
@@ -1,0 +1,127 @@
+/* 
+ * For reference read the Jasmine and Sinon docs
+ * Jasmine docs: http://pivotal.github.io/jasmine/
+ * Sinon docs: http://sinonjs.org/docs/
+ */
+
+describe('mozilla-image-helper.js', function() {
+
+    describe('Mozilla.ImageHelper.initPlatformImages', function() {
+
+        beforeEach(function () {
+            window.site = {
+                platform: 'other'
+            };
+            $('<img class="platform-img js" data-src="browser.png" data-additional-platforms="android ios">').appendTo('body');
+        });
+
+        afterEach(function(){
+            window.site.platform = null;
+            $('.platform-img').remove();
+        });
+
+        it('should display default image for Windows', function() {
+            window.site.platform = 'windows';
+            Mozilla.ImageHelper.initPlatformImages();
+            expect($('.platform-img').attr('src')).toEqual('browser.png');
+            expect($('.platform-img').hasClass('windows')).toBeTruthy();
+        });
+
+        it('should display Mac platform image', function() {
+            window.site.platform = 'osx';
+            Mozilla.ImageHelper.initPlatformImages();
+            expect($('.platform-img').attr('src')).toEqual('browser-mac.png');
+            expect($('.platform-img').hasClass('osx')).toBeTruthy();
+        });
+
+        it('should display Linux platform image', function() {
+            window.site.platform = 'linux';
+            Mozilla.ImageHelper.initPlatformImages();
+            expect($('.platform-img').attr('src')).toEqual('browser-linux.png');
+            expect($('.platform-img').hasClass('linux')).toBeTruthy();
+        });
+
+        it('should display iOS platform image', function() {
+            window.site.platform = 'ios';
+            Mozilla.ImageHelper.initPlatformImages();
+            expect($('.platform-img').attr('src')).toEqual('browser-ios.png');
+            expect($('.platform-img').hasClass('ios')).toBeTruthy();
+        });
+
+        it('should display Android platform image', function() {
+            window.site.platform = 'android';
+            Mozilla.ImageHelper.initPlatformImages();
+            expect($('.platform-img').attr('src')).toEqual('browser-android.png');
+            expect($('.platform-img').hasClass('android')).toBeTruthy();
+        });
+
+        describe('high-res platform images', function () {
+
+            var stub;
+
+            beforeEach(function () {
+                window.site = {
+                    platform: 'other'
+                };
+                $('<img id="high-res-img" class="platform-img js" data-high-res="true" data-src="browser.png" data-additional-platforms="android ios">').appendTo('body');
+            });
+
+            afterEach(function(){
+                Mozilla.ImageHelper.isHighDpi.restore();
+                window.site.platform = null;
+                $('#high-res-img').remove();
+            });
+
+            it('should update image url for high-res devices', function () {
+                stub = sinon.stub(Mozilla.ImageHelper, 'isHighDpi', function () {
+                    return true;
+                });
+                window.site.platform = 'osx';
+                Mozilla.ImageHelper.initPlatformImages();
+                expect($('#high-res-img').attr('src')).toEqual('browser-mac-high-res.png');
+                expect($('#high-res-img').hasClass('osx')).toBeTruthy();
+            });
+
+            it('should not update image url for low-res devices', function () {
+                stub = sinon.stub(Mozilla.ImageHelper, 'isHighDpi', function () {
+                    return false;
+                });
+                window.site.platform = 'osx';
+                Mozilla.ImageHelper.initPlatformImages();
+                expect($('#high-res-img').attr('src')).toEqual('browser-mac.png');
+                expect($('#high-res-img').hasClass('osx')).toBeTruthy();
+            });
+        });
+    });
+
+    describe('Mozilla.ImageHelper.initHighResImages', function() {
+
+        var stub;
+
+        beforeEach(function () {
+            $('<img id="high-res-img" class="js" data-src="browser.png" src="" data-high-res="true">').appendTo('body');
+        });
+
+        afterEach(function(){
+            Mozilla.ImageHelper.isHighDpi.restore();
+            $('#high-res-img').remove();
+        });
+
+        it('should update image url for high-res devices', function() {
+            stub = sinon.stub(Mozilla.ImageHelper, 'isHighDpi', function () {
+                return true;
+            });
+            Mozilla.ImageHelper.initHighResImages();
+            expect($('#high-res-img').attr('src')).toEqual('browser-high-res.png');
+        });
+
+        it('should not update image url for low-res devices', function () {
+            stub = sinon.stub(Mozilla.ImageHelper, 'isHighDpi', function () {
+                return false;
+            });
+            Mozilla.ImageHelper.initHighResImages();
+            expect($('#high-res-img').attr('src')).toEqual('browser.png');
+        });
+    });
+
+});

--- a/media/js/test/tests.html
+++ b/media/js/test/tests.html
@@ -18,12 +18,14 @@
   <script type="text/javascript" src="../base/site.js"></script>
   <script type="text/javascript" src="../base/global.js"></script>
   <script type="text/javascript" src="../base/mozilla-form-helper.js"></script>
+  <script type="text/javascript" src="../base/mozilla-image-helper.js"></script>
   <script src="../../../tabzilla/tabzilla.js?build=dev"></script>
 
   <!-- include spec files here... -->
   <script type="text/javascript" src="spec/site.js"></script>
   <script type="text/javascript" src="spec/global.js"></script>
   <script type="text/javascript" src="spec/mozilla-form-helper.js"></script>
+  <script type="text/javascript" src="spec/mozilla-image-helper.js"></script>
   <script type="text/javascript" src="spec/tabzilla.js"></script>
 
   <style type="text/css">


### PR DESCRIPTION
- Updated `Mozilla.ImageHelper` to support additional platforms such as iOS and Android.
- Added JS test suite.
