### PR TITLE
Add note ids to release notes template

### DIFF
--- a/bedrock/firefox/templates/firefox/releases/release-notes.html
+++ b/bedrock/firefox/templates/firefox/releases/release-notes.html
@@ -67,13 +67,11 @@
         <h3>{{ _('New Features') }}</h3>
         <ul class="section-items tagged">
           {% for note in new_features %}
-          <li {% if not note.tag %}class="untagged"{% endif %}>
-            <p>
+          <li {% if not note.tag %}class="untagged"{% endif %} id="note-{{ note.id }}">
             {% if note.tag %}
               <b class="tag tag-{{ note.tag.lower() }}">{{ note.tag }}</b>
             {% endif %}
               {{ note.note|markdown|safe }}
-            </p>
           </li>
           {% endfor %}
         </ul>
@@ -84,11 +82,9 @@
         <h3>{{ _('Known Issues') }}</h3>
         <ul class="section-items tagged">
           {% for note in known_issues %}
-            <li>
-              <p>
+            <li id="note-{{ note.id }}">
                 <b class="tag tag-unresolved">{{ _('unresolved') }}</b>
                 {{ note.note|markdown|safe }}
-              </p>
             {% if note.fixed_in_release %}
               <p class="note">
                 <a href="{{ releasenotes_url(note.fixed_in_release) }}">


### PR DESCRIPTION
Allows us to troubleshoot which note is on a given page more easily and link to individual notes on the page.

Also remove extraneous p tags-- notes are already wrapped in p tags by markdown filter
