### PR TITLE
Bug 987202 - Fix form URL on http://www.mozilla.org/gigabit/apply/

### DIFF
--- a/bedrock/gigabit/templates/gigabit/apply.html
+++ b/bedrock/gigabit/templates/gigabit/apply.html
@@ -41,7 +41,7 @@
         <p>{{ _('Follow these instructions to apply for the <b>Spring Pilot Period</b>:') }}</p>
         <ol>
           <li>
-            {{ _('Complete the online application form - <a href="%s">click here</a> to access the form')|format('https://docs.google.com/forms/d/1HFas7B6sD3oLxE5FAAYDX1pLoxgBf5mHnj4a1oEay00/edit#') }}
+            {{ _('Complete the online application form - <a href="%s">click here</a> to access the form')|format('https://docs.google.com/forms/d/1HFas7B6sD3oLxE5FAAYDX1pLoxgBf5mHnj4a1oEay00/viewform') }}
           </li>
           <li>
             {{ _('Compile your fund proposal using this <a href="%s">template</a>')|format('https://docs.google.com/a/mozillafoundation.org/document/d/1JWCABAhvvRw3gqbGwBqRvdjh2wu3pwYhPKAISJB0Zak/edit') }}


### PR DESCRIPTION
Change link to the form("click here")
from: https://docs.google.com/forms/d/1HFas7B6sD3oLxE5FAAYDX1pLoxgBf5mHnj4a1oEay00/edit#
to: https://docs.google.com/forms/d/1HFas7B6sD3oLxE5FAAYDX1pLoxgBf5mHnj4a1oEay00/viewform
