### PR TITLE
Update .image-replaced LESS mixin. Bug 977696.

### DIFF
--- a/media/css/sandstone/lib.less
+++ b/media/css/sandstone/lib.less
@@ -339,7 +339,7 @@
 
 // not the most up to date method, but works in IE7
 .image-replaced {
-    text-indent: 110%; // extra 10% to account for fancy fonts that may overhang
+    text-indent: 120%; // extra 20% to account for fancy fonts that may overhang
     white-space: nowrap;
     overflow: hidden;
 }


### PR DESCRIPTION
Can test fix on /firefox/os/devices/ page. Close button on production has just a teensy bit of the "C" visible on the right edge of the button.
