### PR TITLE
Bug 993297 - Sync page links to an anchor in the sumo article

### DIFF
--- a/bedrock/firefox/templates/firefox/sync.html
+++ b/bedrock/firefox/templates/firefox/sync.html
@@ -22,8 +22,8 @@
   <div class="contents">
     <h4>{{ _('Get started with Sync. It’s fast, safe and easy:') }}</h4>
     <ol>
-      <li>{% trans url='https://support.mozilla.org/kb/learn-more-about-the-design-of-new-firefox#w_a-handy-new-menu' %}
-        Open the <a href="{{ url }}">menu</a> in the top right of Firefox and select “Sign in to Sync.”
+      <li>{% trans url='https://support.mozilla.org/kb/learn-more-about-the-design-of-new-firefox' %}
+        Open the <a href="{{ url }}#w_a-handy-new-menu">menu</a> in the top right of Firefox and select “Sign in to Sync.”
       {% endtrans %}</li>
       <li>{{ _('Click “Get started” in the tab that opens.') }}</li>
       <li>{{ _('Enter an email address and password to “Create a Firefox Account.”') }}</li>


### PR DESCRIPTION
Anchor won't work for the redirected article to the localized page, this moves the anchor to the localized string which will allow localizers to put the real anchor.
