### PR TITLE
Bug 958186 - Remove links to /mobile on all states of /new

### DIFF
--- a/bedrock/firefox/templates/firefox/includes/simple_footer.html
+++ b/bedrock/firefox/templates/firefox/includes/simple_footer.html
@@ -3,7 +3,7 @@
     <ul class="primary">
       <li><a href="{{ url('firefox.central') }}"><span>{{_('Tour')}}</span></a></li>
       <li><a href="{{ url('firefox.features') }}"><span>{{_('Features')}}</span></a></li>
-      <li><a href="{{ url('firefox.fx') }}"><span>{{_('Mobile')}}</span></a></li>
+      <li><a href="{{ url('firefox.partners.index') }}"><span>{{_('Mobile')}}</span></a></li>
       <li><a href="https://addons.mozilla.org"><span>{{_('Add-ons')}}</span></a></li>
       <li><a href="https://support.mozilla.org/"><span>{{_('Support')}}</span></a></li>
       <li><a href="{{ url('mozorg.about') }}"><span>{{_('About')}}</span></a></li>

--- a/bedrock/firefox/templates/firefox/new.html
+++ b/bedrock/firefox/templates/firefox/new.html
@@ -119,7 +119,8 @@
             <ul>
               <li><a href="{{ url('firefox.central') }}">{{_('Learn more about Firefox for desktop')}}</a></li>
               <li><a href="https://support.mozilla.org/products/firefox">{{_('Need help?')}}</a></li>
-              <li><a href="{{ url('firefox.fx') }}">{{_('Looking for mobile?')}}</a></li>
+              <li><a href="{{settings.GOOGLE_PLAY_FIREFOX_LINK }}">{{_('Get Firefox on your Android device')}}</a></li>
+              <li><a href="{{ url('firefox.os.index') }}">{{_('Learn about Firefox OS')}}</a></li>
               <li><a href="{{ url('firefox.all') }}">{{_('Download a fresh copy')}}</a></li>
             </ul>
           </div>
@@ -131,12 +132,12 @@
           <div class="fxos-latest-links-wrapper latest-links-wrapper">
             <ul>
               <li><a href="{{ url('firefox.os.index') }}">{{_('Learn more about Firefox OS?')}}</a></li>
-              <li><a href="{{ url('firefox.fx') }}">{{_('Discover all the ways to take Firefox on the go')}}</a></li>
+              <li><a href="{{settings.GOOGLE_PLAY_FIREFOX_LINK }}">{{_('Discover all the ways to take Firefox on the go')}}</a></li>
             </ul>
           </div>
           <div class="ios-links-wrapper latest-links-wrapper">
             <ul>
-              <li><a href="{{ url('firefox.fx') }}">{{_('Looking for mobile?')}}</a></li>
+              <li><a href="{{settings.GOOGLE_PLAY_FIREFOX_LINK }}">{{_('Looking for mobile?')}}</a></li>
               <li><a href="https://support.mozilla.org/kb/is-firefox-available-iphone-or-ipad">{{_('Why don’t we offer an iOS version?')}}</a></li>
             </ul>
           </div>

--- a/bedrock/foundation/templates/foundation/annualreport/2011.html
+++ b/bedrock/foundation/templates/foundation/annualreport/2011.html
@@ -204,7 +204,7 @@
 
           <div class="overlay">
             <p>
-            {% trans mobile_url=url('firefox.fx') %}
+            {% trans mobile_url=url('firefox.partners.index') %}
               In June 2012 we released an update to <a href="{{ mobile_url }}" rel="external">Firefox for Android</a>
               that we believe is the best browser for Android available. We completely
               rebuilt and redesigned the product in native UI, resulting in a


### PR DESCRIPTION
This  fixes part  of https://bugzilla.mozilla.org/show_bug.cgi?id=920212 and solves https://bugzilla.mozilla.org/show_bug.cgi?id=958186. We need to change mobile links that point to firefox/fx to firefox/partners before we remove the firefox/fx page.  On the /new/ page we need to change the mobile links to point to the play store.
