### PR TITLE
Bug 963816: Move privacy redirects above main /privacy/ passthrough.

### DIFF
--- a/etc/httpd/global.conf
+++ b/etc/httpd/global.conf
@@ -403,6 +403,15 @@ RewriteRule ^/about/roles\.html$ /about/governance/roles/ [L,R=301]
 RewriteRule ^/about/organizations\.html$ /about/governance/organizations/ [L,R=301]
 RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?about/governance(.*)$ /b/$1about/governance$2 [PT]
 
+# bug 790784
+# NB: The /foundation/privacy-policy.html redirect must appear before the
+# foundation redirects added with bug 724633. Otherwise, the address will first
+# be prefixed with a locale, and this redirect will not work.
+RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?privacy-policy(?:\.html)?$ /$1privacy/websites/ [L,R=301]
+RewriteRule ^/foundation/privacy-policy\.html$ /privacy/websites/ [L,R=301]
+RewriteRule ^/about/policies/privacy-policy\.html$ /privacy/websites/ [L,R=301]
+RewriteRule ^/en-US/privacy-policy\.pdf$ https://static.mozilla.com/moco/en-US/pdf/mozilla_privacypolicy.pdf [L,R=301]
+
 # bug 963816
 RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?legal/privacy/?$ /$1privacy/ [L,R=301]
 RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?legal/privacy/firefox(?:\.html)?$ /$1privacy/firefox/ [L,R=301]
@@ -420,15 +429,6 @@ RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?legal/privacy/firefox-third-party /$1privacy
 RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?legal/privacy/notices-firefox /$1legal/firefox/ [L,R=301]
 RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?privacy/policies/(facebook|firefox-os|websites)/?$ /$1privacy/$2/ [L,R=301]
 RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?privacy(.*)$ /b/$1privacy$2 [PT]
-
-# bug 790784
-# NB: The /foundation/privacy-policy.html redirect must appear before the
-# foundation redirects added with bug 724633. Otherwise, the address will first
-# be prefixed with a locale, and this redirect will not work.
-RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?privacy-policy(?:\.html)?$ /$1privacy/websites/ [L,R=301]
-RewriteRule ^/foundation/privacy-policy\.html$ /privacy/websites/ [L,R=301]
-RewriteRule ^/about/policies/privacy-policy\.html$ /privacy/websites/ [L,R=301]
-RewriteRule ^/en-US/privacy-policy\.pdf$ https://static.mozilla.com/moco/en-US/pdf/mozilla_privacypolicy.pdf [L,R=301]
 
 # bug 724633 - Porting foundation pages
 # Add redirects for the pdfs that were under /foundation/documents/


### PR DESCRIPTION
@sancus r?
