### PR TITLE
Update the SSL-enabled product list for Firefox 29 (No bug)

### DIFF
--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -878,7 +878,7 @@ STUB_INSTALLER_LOCALES = {
 }
 
 # Force download via SSL
-FORCE_SSL_DOWNLOAD_VERSIONS = ['27.0', '27.0.1', '28.0']
+FORCE_SSL_DOWNLOAD_VERSIONS = ['27.0', '27.0.1', '28.0', '29.0']
 
 # Google Analytics
 GA_ACCOUNT_CODE = ''


### PR DESCRIPTION
We still have to update this manually until #1800 is merged.
