### PR TITLE
Enable 24.5+ ESR release notes-- fix bug 1001238

### DIFF
--- a/bedrock/firefox/tests/test_views.py
+++ b/bedrock/firefox/tests/test_views.py
@@ -33,11 +33,22 @@ class TestRNAViews(TestCase):
         return self.mock_render.call_args[0][2]
 
     @patch('bedrock.firefox.views.get_object_or_404')
-    def test_get_release_or_404(self, get_object_or_404):
+    @patch('bedrock.firefox.views.Q')
+    def test_get_release_or_404(self, Q, get_object_or_404):
         eq_(views.get_release_or_404('version', 'product'),
             get_object_or_404.return_value)
         get_object_or_404.assert_called_with(
-            Release, version='version', product='product')
+            Release, Q.return_value, version='version')
+        Q.assert_called_with(product='product')
+
+    @patch('bedrock.firefox.views.get_object_or_404')
+    @patch('bedrock.firefox.views.Q')
+    def test_get_release_or_404_esr(self, Q, get_object_or_404):
+        eq_(views.get_release_or_404('24.5.0', 'Firefox'),
+            get_object_or_404.return_value)
+        Q.assert_any_call(product='Firefox')
+        Q.assert_any_call(product='Firefox Extended Support Release')
+        Q.__or__.assert_called()
 
     @patch('bedrock.firefox.views.get_release_or_404')
     @patch('bedrock.firefox.views.equivalent_release_url')

--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -8,6 +8,7 @@ import json
 import re
 
 from django.conf import settings
+from django.db.models import Q
 from django.http import (
     Http404, HttpResponsePermanentRedirect, HttpResponseRedirect)
 from django.shortcuts import get_object_or_404
@@ -464,7 +465,12 @@ def equivalent_release_url(release):
 
 
 def get_release_or_404(version, product):
-    release = get_object_or_404(Release, version=version, product=product)
+    if product == 'Firefox' and len(version.split('.')) == 3:
+        product_query = Q(product='Firefox') | Q(
+            product='Firefox Extended Support Release')
+    else:
+        product_query = Q(product=product)
+    release = get_object_or_404(Release, product_query, version=version)
     if not release.is_public and not settings.DEV:
         raise Http404
     return release

--- a/etc/httpd/global.conf
+++ b/etc/httpd/global.conf
@@ -514,6 +514,9 @@ RewriteRule ^/(en-US/)?firefox/(29\.0(?:beta|\.\d)?)/system-requirements(/)?$ /b
 RewriteRule ^/(en-US/)?(firefox|mobile)/([3-9]\d\.\d(?:a2|beta|\.\d)?)/(aurora|release)notes(/)?$ /b/$1$2/$3/$4notes$5 [PT]
 RewriteRule ^/(en-US/)?firefox/([3-9]\d\.\d(?:a2|beta|\.\d)?)/system-requirements(/)?$ /b/$1firefox/$2/system-requirements$3 [PT]
 
+# bug 1001238
+RewriteRule ^/(en-US/)?firefox/(24\.[5678]\.\d)/(releasenotes|system-requirements)(/)?$ /b/$1firefox/$2/$3$4 [PT]
+
 # bug 818323
 RewriteRule ^/projects/security/known-vulnerabilities.html$ /security/known-vulnerabilities/ [L,R=301]
 RewriteRule ^/projects/security/older-vulnerabilities.html$ /security/known-vulnerabilities/older-vulnerabilities.html [L,R=301]


### PR DESCRIPTION
Modify query logic in bedrock.firefox.views.get_release_or_404 to
handle ESR product

Map 24.[5678].\d releasenotes and system-requirements to bedrock
in etc/apache/global.conf
