### PR TITLE
Remove tweepy from requirements/prod.txt

### DIFF
--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -11,7 +11,6 @@ GitPython==0.1.7
 -e git://github.com/jsocol/commonware.git#egg=commonware
 -e git://github.com/mozilla/nuggets.git#egg=nuggets
 -e git://github.com/kurtmckee/feedparser#egg=feedparser
--e git://github.com/tweepy/tweepy.git#egg=tweepy
 -e git://github.com/waylan/Python-Markdown.git#egg=Python-Markdown
 -e git://github.com/aleray/mdx_outline.git#egg=mdx_outline
 beautifulsoup4


### PR DESCRIPTION
Fix jenkins builds that are breaking due to failed pip install
from tweepy master branch that are not needed due to us having
tweepy in a git submodule
