### PR TITLE
Adjust mozilla.com.tw redirects for bug 996608

### DIFF
--- a/etc/httpd/global.conf
+++ b/etc/httpd/global.conf
@@ -29,9 +29,12 @@ RewriteRule ^(.*)$ $1 [L,R=301]
 # bug 845988 - remove double slashes in URLs
 RewriteRule ^(.*)//(.*)$ $1/$2 [L,R=301]
 
-# bug 764261, 841393
+# bug 764261, 841393, 996608
 RewriteRule ^/zh-TW/$ http://mozilla.com.tw/ [L,R=301]
 RewriteCond %{REQUEST_URI} !^/zh-TW/firefox/partners
+RewriteCond %{REQUEST_URI} !^/zh-TW/firefox(/(?:\d+\.\d+\.?(?:\d+)?\.?(?:\d+)?(?:[a|b]?)(?:\d*)(?:pre)?(?:\d)?))?/firstrun/?
+RewriteCond %{REQUEST_URI} !^/zh-TW/firefox(/(?:\d+\.\d+\.?(?:\d+)?\.?(?:\d+)?(?:[a|b]?)(?:\d*)(?:pre)?(?:\d)?))?/tour/?
+RewriteCond %{REQUEST_URI} !^/zh-TW/firefox(/(?:\d+\.\d+\.?(?:\d+)?\.?(?:\d+)?(?:[a|b]?)(?:\d*)(?:pre)?(?:\d)?))?/whatsnew/?
 RewriteRule ^/zh-TW/firefox(/.*)?$ http://mozilla.com.tw/firefox$1 [L,R=301]
 RewriteRule ^/zh-TW/mobile/?$ http://mozilla.com.tw/firefox/mobile/ [L,R=301]
 RewriteRule ^/zh-TW/download/?$ http://mozilla.com.tw/firefox/download/ [L,R=301]


### PR DESCRIPTION
Exclude /zh-TW/firefox{/version}/firstrun, tour, and whatsnew
