### PR TITLE
[fix bug 1003048] Tour pages should try to detect if Mozilla.UITour APIs are working

### DIFF
--- a/media/js/firefox/australis/browser-tour.js
+++ b/media/js/firefox/australis/browser-tour.js
@@ -502,11 +502,10 @@ if (typeof Mozilla == 'undefined') {
         this.tourHasStarted = false;
         this.tourHasFinished = true;
 
-        this.$mask.one('transitionend', this.onCloseTour.bind(this));
-
         this.$cta.fadeOut('fast', $.proxy(function () {
             this.$tour.removeClass('in');
             this.$mask.addClass('out');
+            setTimeout(this.onCloseTour.bind(this), 600);
         }, this));
     };
 

--- a/media/js/firefox/australis/firstrun.js
+++ b/media/js/firefox/australis/firstrun.js
@@ -6,21 +6,22 @@
     //Only run the tour if user is on Firefox 29 for desktop.
     if (window.isFirefox() && !window.isFirefoxMobile() && window.getFirefoxMasterVersion() >= 29) {
 
-        // if user has submitted newsletter don't show the tour again
-        if (window.location.hash !== '#footer-email-form') {
-            // add a callback when user finishes tour to update the cta
-            // id is used for Telemetry
-            var tour = new Mozilla.BrowserTour({
-                id: 'australis-tour-firstrun-29-release'
-            });
-
-            tour.init();
-        }
-
-        // if user has Sync already, don't show the page prommo
+        // Query if the UITour API is working before we start the tour
         Mozilla.UITour.getConfiguration('sync', function (config) {
             var visible = '';
 
+            // if user has submitted newsletter don't show the tour again
+            if (window.location.hash !== '#footer-email-form') {
+                // add a callback when user finishes tour to update the cta
+                // id is used for Telemetry
+                var tour = new Mozilla.BrowserTour({
+                    id: 'australis-tour-firstrun-29-release'
+                });
+
+                tour.init();
+            }
+
+            // if user has Sync already, don't show the page prommo
             if (config.setup === false) {
                 $('.sync-cta').show();
                 visible = 'YES';

--- a/media/js/firefox/australis/whatsnew.js
+++ b/media/js/firefox/australis/whatsnew.js
@@ -6,18 +6,19 @@
     //Only run the tour if user is on Firefox 29 for desktop.
     if (window.isFirefox() && !window.isFirefoxMobile() && window.getFirefoxMasterVersion() >= 29) {
 
-        // add a callback when user finishes tour to update the cta
-        // id is used for Telemetry
-        var tour = new Mozilla.BrowserTour({
-            id: 'australis-tour-whatsnew-29-release'
-        });
-
-        tour.init();
-
-        // if user has Sync already, don't show the page prommo
+        // Query if the UITour API is working before we start the tour
         Mozilla.UITour.getConfiguration('sync', function (config) {
             var visible = '';
 
+            // add a callback when user finishes tour to update the cta
+            // id is used for Telemetry
+            var tour = new Mozilla.BrowserTour({
+                id: 'australis-tour-whatsnew-29-release'
+            });
+
+            tour.init();
+
+            // if user has Sync already, don't show the page prommo
             if (config.setup === false) {
                 // Show CTA if the user does not already have Sync
                 $('.sync-cta').show();


### PR DESCRIPTION
This PR adds a safety measure that ensures the tour should only start if the super-power API is working. If not, the user should just get the regular web-page.

This moves the code that starts the tour inside the API callback to `getConfiguration`, so it only gets called when the callback is returned.

Also includes a minor alteration when calling `onCloseTour` on the last step in `browser-tour.js`
