### PR TITLE
Fix Bug 920212 - Redirect /firefox/fx/ to /firefox/new/

### DIFF
--- a/etc/httpd/global.conf
+++ b/etc/httpd/global.conf
@@ -190,7 +190,6 @@ RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?contribute/(student|university)ambassadors(.
 RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?projects(/?)$ /b/$1projects$2 [PT]
 
 RewriteRule ^/en-US/firefox/new(/?)$ /b/en-US/firefox/new$1 [PT]
-RewriteRule ^/en-US/firefox/fx(/?)$ /b/en-US/firefox/new$1 [PT,QSA]
 RewriteRule ^/en-US/firefox/happy(/?)$ /b/en-US/firefox/happy$1 [PT]
 RewriteRule ^/en-US/firefox/speed(/?)$ /b/en-US/firefox/speed$1 [PT]
 RewriteRule ^/en-US/firefox/geolocation(/?)$ /b/en-US/firefox/geolocation$1 [PT]
@@ -721,3 +720,6 @@ RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/customize(/?)$ /$1firefox/desktop/cu
 RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/performance(/?)$ /$1firefox/desktop/fast/ [L,R=301]
 RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/security(/?)$ /$1firefox/desktop/trust/ [L,R=301]
 RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/technology(/?)$ https://developer.mozilla.org/docs/Tools [L,R=301]
+
+# Bug 920212
+RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/fx(/?)$ /$1firefox/new/ [L,R=301]


### PR DESCRIPTION
I think #1915 wasn't complete.
