### PR TITLE
Offer a way to semi-permanently hide the Tabzilla error console easter egg

### DIFF
--- a/bedrock/base/templates/includes/tabzilla-console-footer.html
+++ b/bedrock/base/templates/includes/tabzilla-console-footer.html
@@ -1,0 +1,8 @@
+
+
+---
+
+If you don't want to see this message next time, run this JS statement:
+
+    Tabzilla.disableEasterEgg()
+

--- a/bedrock/tabzilla/templates/tabzilla/tabzilla.js
+++ b/bedrock/tabzilla/templates/tabzilla/tabzilla.js
@@ -244,6 +244,29 @@ var Tabzilla = (function (Tabzilla) {
         }
         return 0;
     };
+    // Changing this pref name causes the easter egg to reappear, requires a
+    // fresh disable. Might be handy if or when the message is changed.
+    Tabzilla.EASTER_EGG_PREF_NAME = 'tabzilla.showEasterEgg.careersTeaser';
+    Tabzilla.disableEasterEgg = function () {
+        try {
+            localStorage.setItem(this.EASTER_EGG_PREF_NAME, 'false');
+        } catch (ex) {}
+    };
+    Tabzilla.enableEasterEgg = function () {
+        try {
+            localStorage.setItem(this.EASTER_EGG_PREF_NAME, 'true');
+        } catch (ex) {}
+    };
+    Tabzilla.shouldShowEasterEgg = function () {
+        try {
+            return (localStorage.getItem(this.EASTER_EGG_PREF_NAME) !== 'false');
+        } catch (ex) {
+            // HACK: If there's an exception in getting a localStorage item,
+            // then the support is probably not there. Err on the side of not
+            // showing the easter egg, since it can't be turned off.
+            return false;
+        }
+    };
     var Infobar = function (id, name) {
         this.id = id;
         this.name = name;
@@ -571,8 +594,8 @@ var Tabzilla = (function (Tabzilla) {
         $(window).load(function() {
             try {
                 // Try to only show on stage and production environments.
-                if (/mozill|webmaker|allizom|firefox/.exec(location.hostname)) {
-                    console.log("{% filter js_escape|safe %}{% include "includes/careers-teaser.html" %}{% endfilter %}");
+                if (Tabzilla.shouldShowEasterEgg()) {
+                    console.log("{% filter js_escape|safe %}{% include "includes/careers-teaser.html" %}{% include "includes/tabzilla-console-footer.html" %}{% endfilter %}");
                 }
             } catch(e) {}
         });


### PR DESCRIPTION
The easter egg, though nifty, is a bit of console verbosity that seemed to show up inconsistently & got a bit stale after the 1000th reload. Here's an unsolicited pull request to add a switch that disables the easter egg, at least until the message gets switched.
