### PR TITLE
[fix bug 1004228] Firefox Desktop product page Speed section animation bug

### DIFF
--- a/media/css/firefox/desktop/common.less
+++ b/media/css/firefox/desktop/common.less
@@ -485,9 +485,7 @@ html[dir="rtl"] {
         }
 
         #speed-fx-rank {
-            // use throw away variable to get past comma issue
-            @animation: expandFxRank 0.7s ease-out 0s 1 normal forwards, colorFxRank 0.3s ease-in 0.9s 1 normal forwards;
-            .animation(@animation);
+            .animation(expandFxRank 1s ease-out 0s 1 normal forwards);
         }
         #speed-opera-next-rank {
             .animation(expandOperaNextRank 0.6s ease-out 0s 1 normal forwards);
@@ -513,19 +511,25 @@ html[dir="rtl"] {
 }
 
 @-webkit-keyframes expandFxRank {
-    100% { width: 98%; }
+    70% {
+        width: 98%;
+        background-color: #bcc6d1;
+    }
+    100% {
+        width: 98%;
+        background-color: #ff7f00;
+    }
 }
 
 @keyframes expandFxRank {
-    100% { width: 98%; }
-}
-
-@-webkit-keyframes colorFxRank {
-    100% { background: #ff7f00; }
-}
-
-@keyframes colorFxRank {
-    100% { background: #ff7f00; }
+    70% {
+        width: 98%;
+        background-color: #bcc6d1;
+    }
+    100% {
+        width: 98%;
+        background-color: #ff7f00;
+    }
 }
 
 @-webkit-keyframes expandOperaNextRank {


### PR DESCRIPTION
Intermittent issue with the orange bar on the speed graph animation not changing colour on iOS. Combining into a single keyframe animation seems to fix the second part not firing on occasion.
