### PR TITLE
[fix bug 1004412] Mobile nav does not close when clicking off the menu on iOS7

### DIFF
--- a/media/js/base/nav-main-resp.js
+++ b/media/js/base/nav-main-resp.js
@@ -239,9 +239,8 @@ NavMain.enterSmallMode = function()
 	.css('display', 'none')
 	.attr('aria-hidden');
 
-    $(document).click(NavMain.handleDocumentClick);
-    $('a, input, textarea, button, :focus')
-        .focus(NavMain.handleDocumentFocus);
+    $('#outer-wrapper').on('click.mobile-nav', NavMain.handleDocumentClick);
+    $('a, input, textarea, button, :focus').on('focus.mobile-nav', NavMain.handleDocumentFocus);
 
     $('#nav-main-menu, #nav-main-menu .submenu')
 	.attr('aria-hidden', 'true');
@@ -265,9 +264,8 @@ NavMain.leaveSmallMode = function()
 	.css('display', '')
 	.removeAttr('aria-hidden');
 
-    $(document).unbind('click', NavMain.handleDocumentClick);
-    $('a, input, textarea, button, :focus')
-        .unbind('focus', NavMain.handleDocumentFocus);
+    $('#outer-wrapper').off('click.mobile-nav', NavMain.handleDocumentClick);
+    $('a, input, textarea, button, :focus').off('focus.mobile-nav', NavMain.handleDocumentFocus);
 
     $('#masthead .toggle').removeClass('open');
 


### PR DESCRIPTION
Seems iOS7 does not bubble up `click` events to `document`. 
- Added an additional `touchend` event to the handler. 
- Also name-spaced the events using `mobile-nav` while I was there.

Tested on iOS7 and Firefox OS and working fine, but would be good to get someone else to test on Android as well before merging.

A good page to test this on is `/firefox/desktop`, as there is no focus-able content at the top of the page.
