### PR TITLE
[fix bug 1004222] Firefox Desktop overview page make Trust links bold

### DIFF
--- a/media/css/firefox/desktop/common.less
+++ b/media/css/firefox/desktop/common.less
@@ -253,6 +253,7 @@ html[dir="rtl"] {
     }
 
     a {
+        .open-sans;
         margin-top: 5px;
         font-size: @baseFontSize;
 

--- a/media/css/firefox/desktop/index.less
+++ b/media/css/firefox/desktop/index.less
@@ -46,6 +46,10 @@
 
 #trust {
     background: #fcfcfa url(/media/img/firefox/desktop/bg-pixelfox.png) center bottom no-repeat;
+
+    a {
+        .open-sans;
+    }
 }
 
 #customize {


### PR DESCRIPTION
Switched to using Open Sans for Trust section links as opposed to Open Sans Light, to improve colour contrast on the light background.
