### PR TITLE
Highlight the developer information

### DIFF
--- a/bedrock/firefox/templates/firefox/releases/release-notes.html
+++ b/bedrock/firefox/templates/firefox/releases/release-notes.html
@@ -76,6 +76,11 @@
               {{ note.note|markdown|safe }}
           </li>
           {% endfor %}
+          {% if release.product == 'Firefox' %}
+          <li class="untagged" id="note-devnotes">
+            <p><a href="https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/{{ release.major_version() }}">{{ _('Developer Information') }}</a></p>
+          </li>
+          {% endif %}
         </ul>
       </section>
       {% endif %}


### PR DESCRIPTION
The idea here is to highlight the developer news. For now, they are not obvious to find in the right section "Other Resources" with a blog.
It is not obvious that this page is different for every release. Therefor, this pull request merges it the 'What's new' section.
