### PR TITLE
Fix Bug 1005674 - The Flash video player allows cross-site includes due to a missing source check

### DIFF
--- a/etc/httpd/global.conf
+++ b/etc/httpd/global.conf
@@ -727,3 +727,7 @@ RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/technology(/?)$ https://developer.mo
 
 # Bug 920212
 RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/fx(/?)$ /$1firefox/new/ [L,R=301]
+
+# Bug 1005674
+RewriteCond %{QUERY_STRING} !^flv=(?:https?://videos\.(?:mozilla\.org|cdn\.mozilla\.net))?/\w+/
+RewriteRule ^/media/flash/playerWithControls.swf - [F]


### PR DESCRIPTION
Add a check for the query string. It should start with `flv=/uploads/`, `flv=/serv/` or something. `[F]` means forbidden. This mitigation was originally in the PHP side's .htaccess ([Bug 439560 Comment 7](https://bugzilla.mozilla.org/show_bug.cgi?id=439560#c7), [r15841](http://viewvc.svn.mozilla.org/vc?view=revision&revision=15841)) but lost at some point.
