### PR TITLE
Update the SSL-enabled product list for Firefox 29.0.1 (No bug)

### DIFF
--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -867,7 +867,7 @@ STUB_INSTALLER_LOCALES = {
 }
 
 # Force download via SSL
-FORCE_SSL_DOWNLOAD_VERSIONS = ['27.0', '27.0.1', '28.0', '29.0']
+FORCE_SSL_DOWNLOAD_VERSIONS = ['27.0', '27.0.1', '28.0', '29.0', '29.0.1']
 
 # Google Analytics
 GA_ACCOUNT_CODE = ''


### PR DESCRIPTION
29.0.1 is coming on Friday May 9th.
