### PR TITLE
Fix bug 1006647 - disable console logging for home page news

### DIFF
--- a/bedrock/mozorg/templates/mozorg/home.html
+++ b/bedrock/mozorg/templates/mozorg/home.html
@@ -208,7 +208,7 @@
 
       <section class="extra-news">
         <h2>{{ _('In the news') }}</h2>
-        <ul class="hfeed cycle-slideshow" data-cycle-timeout="6000" data-cycle-slides="> .hentry" data-cycle-fx="carousel" data-cycle-carousel-fluid="true" data-cycle-carousel-vertical="true" data-cycle-next=".news-buttons .btn-next" data-cycle-prev=".news-buttons .btn-prev" data-cycle-carousel-visible="1" data-cycle-pause-on-hover="true">
+        <ul class="hfeed cycle-slideshow" data-cycle-timeout="6000" data-cycle-slides="> .hentry" data-cycle-fx="carousel" data-cycle-carousel-fluid="true" data-cycle-carousel-vertical="true" data-cycle-next=".news-buttons .btn-next" data-cycle-prev=".news-buttons .btn-prev" data-cycle-carousel-visible="1" data-cycle-pause-on-hover="true" data-cycle-log="false">
 
         {% l10n home_news, 20140429 %}
           <li class="hentry">


### PR DESCRIPTION
We use jQuery Cycle2 to scroll news items on the home page. The plugin has logging on by default and needs it to be explicitly set to false.
