### PR TITLE
Add missing [PT] for /legal/firefox/

### DIFF
--- a/etc/httpd/global.conf
+++ b/etc/httpd/global.conf
@@ -421,6 +421,7 @@ RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?legal/privacy/firefox-third-party /$1privacy
 RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?legal/privacy/notices-firefox /$1legal/firefox/ [L,R=301]
 RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?privacy/policies/(facebook|firefox-os|websites)/?$ /$1privacy/$2/ [L,R=301]
 RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?privacy(.*)$ /b/$1privacy$2 [PT]
+RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?legal/firefox(/?)$ /b/$1legal/firefox$2 [PT]
 
 # bug 724633 - Porting foundation pages
 # Add redirects for the pdfs that were under /foundation/documents/


### PR DESCRIPTION
[Bug 960689 Comment 16](https://bugzilla.mozilla.org/show_bug.cgi?id=960689#c16). @sgarrity noticed that /legal/firefox/ was 404. Somehow /b/ [PT] was lost during development.
