### PR TITLE
Port /about/legal/ page to Bedrock

### DIFF
--- a/bedrock/mozorg/templates/mozorg/about/legal.html
+++ b/bedrock/mozorg/templates/mozorg/about/legal.html
@@ -1,0 +1,164 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+
+{% extends "mozorg/about-base.html" %}
+
+{% block page_title %}{{ _('Legal Disclaimers and Limitations') }}{% endblock %}
+{% block body_id %}about-legal{% endblock %}
+
+{% block article %}
+<h1 class="title-shadow-box">{{ self.page_title() }}</h1>
+
+<p>
+{% trans link_privacy=url('privacy.notices.websites'), link_licensing=url('foundation.licensing') %}
+Any use of the Mozilla Foundation or Mozilla Corporation’s (collectively “Mozilla”) websites is subject to the following legal disclaimers and limitations, as well as to <a href="{{ link_privacy }}">Mozilla’s Privacy Policy</a> and <a href="{{ link_licensing }}">other proprietary rights and related policies</a>.
+{% endtrans %}
+</p>
+
+<ol>
+  <li>
+    <p>{{ _('Responsibility of Contributors.  Those who post material to, provide links to material from, or otherwise make material available by means of Mozilla’s websites (“Contributors”) are entirely responsible for the content of, and any harm resulting from, that material.  By acting as a Contributor, you represent and warrant that:') }}</p>
+    <ul>
+      <li>{{ _('the downloading, copying and use of the materials you make available will not infringe the proprietary rights, including but not limited to intellectual property rights, of any third party;') }}</li>
+      <li>{{ _('you have fully complied with any third-party licenses relating to such materials, and have done all things necessary to successfully pass through to end users any required terms;') }}</li>
+      <li>{{ _('the materials you make available do not contain any viruses, worms, Trojan horses or other harmful or destructive content;') }}</li>
+      <li>{{ _('the materials you make available are not obscene or libelous, and do not violate the right of privacy or publicity of any third party; and') }}</li>
+      <li>{{ _('you have, in the case of computer code, accurately categorized and described the type and nature of the materials if and when requested by Mozilla to do so.') }}</li>
+    </ul>
+    <p>{{ _('Without limiting any of those representations or warranties, Mozilla has the right (though not the obligation) to, in Mozilla’s sole discretion:  (a) remove any content that, in Mozilla’s reasonable opinion, violates any Mozilla policy or is in any way harmful or objectionable; or (b) require changes in any license agreement relating to any materials made available by any Contributor.') }}</p>
+  </li>
+  <li>
+    <p>{{ _('Responsibility of Website Users.  Mozilla has not reviewed, and cannot review, all of the material, including computer software, available on or by means of Mozilla’s websites, and cannot therefore be responsible for that material’s content, use or effects.  By operating its websites, Mozilla does not represent or imply that it endorses the material there available, or that it believes such material to be accurate, useful or nonharmful.  You are responsible for taking precautions as necessary to protect yourself and your computer systems from viruses, worms, Trojan horses and other harmful or destructive content.  Mozilla’s websites may contain content that is offensive, indecent or otherwise objectionable, as well as content containing technical inaccuracies, typographical mistakes and other errors.  Mozilla’s websites may also contain material that violates the privacy or publicity rights, or infringes the proprietary rights, of third parties, or the downloading, copying or use of which is subject to additional terms and conditions, stated or unstated.  Mozilla disclaims any responsibility for any harm resulting from the use by Mozilla’s visitors of Mozilla’s websites, or from any downloading by those visitors of content available on or by means of Mozilla’s websites.') }}</p>
+  </li>
+  <li>
+    <p>{{ _('Changes.  Content contained on Mozilla’s websites, including these Legal Disclaimers and Limitations, may be changed at the sole discretion of Mozilla and without notice.  You are bound by any such updates or changes, and so should periodically review these Legal Disclaimers and Limitations.') }}</p>
+  </li>
+  <li>
+    <p>{{ _('Content Posted on Other Websites.  Mozilla has not reviewed, and cannot review, all of the material, including computer software, made available through the websites and webpages to which Mozilla’s websites links, and that link to Mozilla’s websites.  Mozilla does not have any control over those non-Mozilla websites and webpages, and is not responsible for their contents or their use.  By linking to a non-Mozilla website or webpage, Mozilla does not represent or imply that it endorses such website or webpage.  You are responsible for taking precautions as necessary to protect yourself and your computer systems from viruses, worms, Trojan horses and other harmful or destructive content.  Mozilla disclaims any responsibility for any harm resulting from your use of non-Mozilla websites and webpages.') }}</p>
+  </li>
+  <li>
+    <p>{{ _('LIMITATION OF WARRANTIES OF MOZILLA.  EXCEPT AS OTHERWISE EXPRESSLY STATED, INCLUDING BUT NOT LIMITED TO IN A LICENSE OR OTHER AGREEMENT GOVERNING THE USE OF SPECIFIC CONTENT, ALL CONTENT LOCATED AT OR AVAILABLE FROM Mozilla’s WEBSITES IS PROVIDED "AS IS," AND MOZILLA, ITS CONTRACTORS AND ITS LICENSORS MAKE NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, TITLE OR NON-INFRINGEMENT OF PROPRIETARY RIGHTS.  WITHOUT LIMITING THE FOREGOING, MOZILLA, ITS CONTRACTORS AND ITS LICENSORS MAKE NO REPRESENTATION OR WARRANTY THAT CONTENT LOCATED AT Mozilla’s WEBSITES IS FREE FROM ERROR OR SUITABLE FOR ANY PURPOSE; NOR THAT THE USE OF SUCH CONTENT WILL NOT INFRINGE ANY THIRD PARTY COPYRIGHTS, TRADEMARKS OR OTHER INTELLECTUAL PROPERTY RIGHTS.  YOU UNDERSTAND AND AGREE THAT YOU DOWNLOAD OR OTHERWISE OBTAIN CONTENT THROUGH Mozilla’s WEBSITES AT YOUR OWN DISCRETION AND RISK, AND THAT MOZILLA, ITS CONTRACTORS AND ITS LICENSORS WILL HAVE NO LIABILITY OR RESPONSIBILITY FOR ANY DAMAGE TO YOUR COMPUTER SYSTEM OR DATA THAT RESULTS FROM THE DOWNLOAD OR USE OF SUCH CONTENT.  SOME JURISDICTIONS MAY NOT ALLOW THE EXCLUSION OF IMPLIED WARRANTIES, SO SOME OF THE ABOVE LIMITATIONS MAY NOT APPLY TO YOU.') }}</p>
+  </li>
+  <li>
+    <p>{{ _('LIMITATION OF LIABILITY OF MOZILLA.  EXCEPT AS OTHERWISE EXPRESSLY STATED, INCLUDING BUT NOT LIMITED TO IN A LICENSE OR OTHER AGREEMENT GOVERNING THE USE OF SPECIFIC CONTENT, IN NO EVENT WILL MOZILLA, ITS CONTRACTORS OR ITS LICENSORS BE LIABLE TO YOU OR ANY OTHER PARTY FOR ANY DIRECT, INDIRECT, SPECIAL, CONSEQUENTIAL OR EXEMPLARY DAMAGES, REGARDLESS OF THE BASIS OR NATURE OF THE CLAIM, RESULTING FROM ANY USE OF Mozilla’s WEBSITES, OR THE CONTENTS THEREOF OR OF ANY HYPERLINKED WEB SITE, INCLUDING WITHOUT LIMITATION ANY LOST PROFITS, BUSINESS INTERRUPTION, LOSS OF DATA OR OTHERWISE, EVEN IF MOZILLA, ITS CONTRACTORS OR ITS LICENSORS WERE EXPRESSLY ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.  SOME JURISDICTIONS MAY NOT ALLOW THE EXCLUSION OR LIMITATION OF LIABILITY FOR CERTAIN INCIDENTAL OR CONSEQUENTIAL DAMAGES, SO SOME OF THE ABOVE LIMITATIONS MAY NOT APPLY TO YOU.') }}</p>
+  </li>
+  <li>
+    <p>
+    {% trans link=url('foundation.licensing') %}
+    General Representation and Warranty. You represent and warrant that your use of Mozilla’s websites will be in accordance with Mozilla’s Privacy Policy, with these Legal Disclaimers and Limitations, with any applicable laws and regulations, and with any other applicable policy or terms and conditions, including without limitation our <a href="{{ link }}">Licensing Policies</a>.
+    {% endtrans %}
+    </p>
+  </li>
+  <li>
+    <p>{{ _('Indemnification.  You agree to defend, indemnify and hold harmless Mozilla, its contractors and its licensors, and their respective directors, officers, employees and agents from and against any and all third party claims and expenses, including attorneys’ fees, arising out of your use of Mozilla’s websites, including but not limited to out of your violation of any representation or warranty contained in these Legal Disclaimers and Limitations.') }}</p>
+  </li>
+</ol>
+
+<section id="dcma">
+  <h3>{{ _('Digital Millennium Copyright Act Notice') }}</h3>
+
+  <p>{{ _('If you are a copyright owner or an agent of a copyright owner and believe that content available by means of one of Mozilla’s websites infringes one or more of your copyrights, please immediately notify Mozilla’s Copyright Agent by means of emailed, mailed, or faxed notice ("DMCA Notice") and include the information described below.  You can review 17 U.S.C. § 512(c)(3) of the Digital Millennium Copyright Act for authoritative detail, or consult your own attorney if you need assistance.  If Mozilla takes action in response to a DMCA Notice, it will make a good faith attempt to contact the party that made such content available by means of the most recent email address, if any, provided by such party to Mozilla. You may be held liable for damages based on certain material misrepresentations contained in a DMCA Notice. Thus, if you are not sure content located on or linked to by the website infringes your copyright, you should consider first contacting an attorney.') }}</p>
+
+  <p>{{ _('All DMCA Notices should include the following:') }}</p>
+  <ul>
+    <li>{{ _('A signature, electronic or physical, of the owner, or a person authorized to act on behalf of the owner, of an exclusive copyright right that is being infringed;') }}</li>
+    <li>{{ _('An identification of the copyrighted work or works that you claim have been infringed;') }}</li>
+    <li>{{ _('A description of the nature and location of the material that you claim to infringe your copyright, in sufficient detail to permit Mozilla to find and positively identify that content, including the URL where it is located;') }}</li>
+    <li>{{ _('Your name, address, telephone number, and email address where we can contact you; and') }}</li>
+    <li>{{ _('A statement by you: (i) that you believe in good faith that the use of the material that you claim infringes your copyright is not authorized by law, or by the copyright owner or such owner’s agent; and, (ii) that all of the information contained in your DMCA Notice is accurate, and under penalty of perjury, that you are either the owner of, or a person authorized to act on behalf an owner of, the exclusive copyright right that is being infringed.') }}</li>
+  </ul>
+   
+  <p>{{ _('Mozilla’s designated Copyright Agent to receive notifications of claimed infringement is as follows:') }}</p>
+
+  <address>
+  <p>
+  {% trans %}
+  Denelle Dixon-Thayer<br>
+  Mozilla Corporation<br>
+  331 E. Evelyn Avenue<br>
+  Mountain View, CA 94041<br>
+  USA<br>
+  Email: dmcanotice at mozilla dot com<br>
+  Phone Number: 650-903-0800<br>
+  Fax: 650-903-0875
+  {% endtrans %}
+  </p>
+  </address>
+
+  <p>{{ _('If you fail to comply with all of the requirements of a DMCA notice, Mozilla may not act upon your notice.') }}</p>
+
+  <p>{{ _('Mozilla will terminate a user’s account if, under appropriate circumstances, they are determined to be a repeat infringer.') }}</p>
+
+  <p>{{ _('The contact information provided above also applies to notices that are based on non-U.S. copyrights or trademarks.') }}</p>
+
+  <p>
+  {% trans link='https://support.mozilla.org' %}
+  Only DMCA Notices, Trademark Notices (which are defined below), and international copyright or trademark notices should go to the copyright agent.  Any other feedback, comments, requests for technical support, and other communications should be directed to personas at mozilla dot com (if related to Personas) or <a href="{{ link }}">{{ link }}</a> (for support).
+  {% endtrans %}
+  </p>
+
+  <p>
+  {% trans link='<a href="http://www.chillingeffects.org/">http://www.chillingeffects.org/</a>'|safe %}
+  Please be advised that any DMCA Notices sent to Mozilla may be sent to third parties (including the accused) and posted on the Internet (including at {{ link }}).
+  {% endtrans %}
+  </p>
+
+</section>
+
+<section id="trademark">
+
+  <h3>{{ _('Trademark Notices') }}</h3>
+
+  <p>{{ _('If you are a trademark owner or an agent of a trademark owner and believe that content available by means of one of Mozilla’s websites infringes one or more of your trademarks, please immediately notify Mozilla’s Copyright Agent by means of emailed, mailed, or faxed notice ("Trademark Notice") and include the information described above for DMCA notices.  Mozilla handles notices it receives of trademark violations via a process very similar to the DMCA Notice process that is described above for copyrights.  In addition to the DMCA Notice requirements, Mozilla requires that the entire Trademark Notice be made by the trademark owner (or her agent) under penalty of perjury.') }}</p>
+
+</section>
+
+<section id="site">
+
+  <h3>{{ _('Site Licensing Policy') }}</h3>
+
+  <p>
+  {% trans link_summary='http://creativecommons.org/licenses/by-sa/3.0/', link_details='http://creativecommons.org/licenses/by-sa/3.0/legalcode' %}
+  'The Mozilla web sites and wikis have been prepared with the contributions of many authors, both within and outside Mozilla.  Unless otherwise indicated, the content is available under the terms of the Creative Commons: Attribution Share Alike License v3.0 or any later version. A <a href="{{ link_summary }}">summary</a> of the terms of this license is available, as well as its <a href="{{ link_details }}">detailed terms</a>.
+  {% endtrans %}
+  </p>
+
+  <p>
+  {% trans link='http://www.opensource.org/licenses/mit-license.php' %}
+  If you wish to contribute content to this web site, you will be asked to make your content available under the Creative Commons: Attribution Share Alike License, and to make your code samples available under the <a href="{{ link }}">MIT License</a>.  Adding to the Mozilla web sites or Mozilla wikis without specifying the terms under which you have made your addition means you agree that your contributions will be available under these licenses.  The copyright for contributed materials remains with the author unless the author assigns it to someone else.
+  {% endtrans %}
+  </p>
+
+  <p>{{ _('While our intention is to make most of the content available under the Creative Commons license above, the following material and content is not licensed under the Creative Commons license:') }}</p>
+
+  <ul>
+    <li>{{ _('Portions of the web site are © 1998–2009 by individual mozilla.org contributors.') }}</li>
+    <li>{{ _('The trademarks and logos of the Mozilla Foundation and any third party and the look and feel of this web site (to the extent the look and feel elements are works of authorship, such as the graphic design, artwork, and artistic illustrations) are not included in the work that is licensed under the Creative Commons terms.') }}</li>
+    <li>{{ _('Software provided by Mozilla, contributors, or third-parties.') }}</li>
+    <li>{{ _('Code samples are available under the terms of the MIT License.') }}</li>
+    <li>{{ _('Any contribution or content that expressly indicates that the author intends for another license to apply, for example, add-ons, documents, code contributions, or graphic designs.') }}</li>
+  </ul>
+
+  <p>
+  {% trans link=url('foundation.licensing') %}
+  For more information about these and other licensing policies, please see our <a href="{{ link }}">Licensing Policies page</a>. If you have any other questions about complying with our licensing terms for this collection, you should email:
+  {% endtrans %}
+  </p>
+
+  <ul>
+    <li>
+    {% trans link='<a href="mailto:licensing@mozilla.org">licensing@mozilla.org</a>'|safe %}
+    {{ link }} for copyright questions;
+    {% endtrans %}
+    </li>
+    <li>
+    {% trans link='<a href="mailto:trademarks@mozilla.org">trademarks@mozilla.org</a>'|safe %}
+    {{ link }} for trademark or logo questions.
+    {% endtrans %}
+    </li>
+  </ul>
+
+</section>
+
+{% endblock %}

--- a/bedrock/mozorg/urls.py
+++ b/bedrock/mozorg/urls.py
@@ -38,6 +38,7 @@ urlpatterns = patterns('',
     page('about/governance/policies/security/plugin-whitelist-policy', 'mozorg/about/governance/policies/security/plugin-whitelist-policy.html'),
     page('about/governance/organizations', 'mozorg/about/governance/organizations.html'),
     page('about/governance/policies/participation', 'mozorg/about/governance/policies/participation.html'),
+    page('about/legal', 'mozorg/about/legal.html'),
 
     page('contact/spaces', 'mozorg/contact/spaces/spaces-landing.html'),
     page('contact/spaces/mountain-view', 'mozorg/contact/spaces/mountain-view.html'),

--- a/etc/httpd/global.conf
+++ b/etc/httpd/global.conf
@@ -104,6 +104,10 @@ RewriteRule ^(.*)index\.html$ $1 [L,R=301]
 
 ## Redirect things to django!
 
+# bug 960689
+RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?about/legal\.html$ /$1about/legal/ [L,R=301]
+RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?about(.*)$ /b/$1about$2 [PT]
+
 # bug 797192, 892470
 RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?plugincheck(/?)$ /b/$1/plugincheck$2 [PT]
 
@@ -115,11 +119,9 @@ RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?facebookapps/(.*)?$ /b/$1facebookapps/$2 [PT
 
 # bug 854561
 RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?projects/mozilla-based(\.html|/)?$ /$1about/mozilla-based/ [L,R=301]
-RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?about/mozilla-based(/?)$ /b/$1about/mozilla-based$2 [PT]
 
 # bug 851727
 RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?projects/powered-by(\.html|/)?$ /$1about/powered-by/ [L,R=301]
-RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?about/powered-by(/?)$ /b/$1about/powered-by$2 [PT]
 
 # bug 837883
 RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/firefox\.exe$ /$1 [NC,L,R=301]
@@ -162,17 +164,8 @@ RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/toolkit/download-to-your-devices(.*)
 # bug 921564
 RewriteRule ^/(ach|af|ak|an|ar|as|ast|az|be|bg|bn-BD|bn-IN|br|bs|ca|cs|csb|cy|da|de|el|en-GB|en-US|en-ZA|eo|es-AR|es-CL|es-ES|es-MX|et|eu|fa|ff|fi|fr|fy-NL|ga-IE|gd|gl|gu-IN|he|hi-IN|hr|hsb|hu|hy-AM|id|is|it|ja|ja-JP-mac|ka|kk|km|kn|ko|ku|lg|lij|lt|lv|mai|mk|ml|mn|mr|ms|my|nb-NO|nl|nn-NO|nso|oc|or|pa-IN|pl|pt-BR|pt-PT|rm|ro|ru|sah|si|sk|sl|son|sq|sr|sv-SE|sw|ta|ta-LK|te|th|tr|uk|ur|vi|wo|xh|zh-CN|zh-TW|zu)(/?)$ /b/$1$2 [PT]
 
-# bug 822260
-RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?about/mission.html$ /b/$1about/mission.html [PT]
-
 # bug 889958
-RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?about(/?)?$ /b/$1about$2 [PT]
-RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?about/partnerships(/?)$ /b/$1about/partnerships$2 [PT]
-RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?about/partnerships/distribution(/?)$ /b/$1about/partnerships/distribution$2 [PT]
 RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?mission(/?)$ /b/$1mission$2 [PT]
-
-# bug 843789
-RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?about/partnerships/contact-bizdev(/?)$ /b/$1about/partnerships/contact-bizdev$2 [PT]
 
 # bug 793754
 RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?contribute(/?)$ /b/$1contribute$2 [PT]
@@ -362,7 +355,6 @@ RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefoxflicks/?(.*) https://firefoxflicks.mo
 
 # bug 849426
 RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?about/history(\.html)?$ /$1about/history/ [L,R=301]
-RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?about/history/$ /b/$1about/history/ [PT]
 RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?about/bookmarks.html$ https://wiki.mozilla.org/Historical_Documents [L,R=301]
 RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?about/timeline.html$ https://wiki.mozilla.org/Timeline [L,R=301]
 
@@ -374,7 +366,6 @@ RewriteRule ^/(\w{2,3}(?:-\w{2})?/)about(?:/(?:index.html)?)$ /contribute/ [L,R=
 # bug 861243 and bug 869489
 RewriteRule ^/about/manifesto\.html$ /about/manifesto/ [L,R=301]
 RewriteRule ^/about/manifesto\.(.*)\.html$ /$1/about/manifesto/ [L,R=301]
-RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?about/manifesto(/?)$ /b/$1about/manifesto$2 [PT]
 
 # bug 856077
 RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?projects/toolkit(/?)$ https://developer.mozilla.org/docs/Toolkit_API [L,R=301]
@@ -396,7 +387,6 @@ RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/nightly/firstrun(.*)$ /b/$1firefox/n
 RewriteRule ^/about/governance\.html$ /about/governance/ [L,R=301]
 RewriteRule ^/about/roles\.html$ /about/governance/roles/ [L,R=301]
 RewriteRule ^/about/organizations\.html$ /about/governance/organizations/ [L,R=301]
-RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?about/governance(.*)$ /b/$1about/governance$2 [PT]
 
 # bug 790784
 # NB: The /foundation/privacy-policy.html redirect must appear before the
@@ -554,7 +544,6 @@ RewriteRule ^/info\.txt$ /media/info.txt [L,PT]
 RewriteRule ^/about/policies(/?)$ /about/governance/policies/ [L,R=301]
 RewriteRule ^/about/policies/participation.html$ /en-US/about/governance/policies/participation/ [L,R=301]
 RewriteRule ^/about/policies/policies.html$ /en-US/about/governance/policies/ [L,R=301]
-RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?about/governance(/.*)?$ /b/en-US/about/governance$1 [PT]
 
 # bug 882923
 RewriteRule ^/en-US/opt-out.html$ /privacy/websites/#user-choices [NE,L,R=301]


### PR DESCRIPTION
Also consolodate /about/\* redirects to bedrock (/b/)
Refs Bug 960689

The only files remaining under /en-US/about/ now are [these button images](http://viewvc.svn.mozilla.org/vc/projects/mozilla.com/tags/production/en-US/about/buttons/). Do those links still have to live on?
