### PR TITLE
Fix Bug 1008521 - Broken link in about/history/details (foxkeh.com)

### DIFF
--- a/bedrock/mozorg/templates/mozorg/about/history-details.html
+++ b/bedrock/mozorg/templates/mozorg/about/history-details.html
@@ -189,7 +189,7 @@
       <li><a href="https://wiki.mozilla.org/Timeline">{{ _('Timeline of Mozilla Project') }}</a></li>
       <li><a href="http://mozillamemory.org/index.php">{{ _('Mozilla Digital Memory Bank') }}</a></li>
       <li>
-        {% trans link="//www.foxkeh.com/downloads/" %}
+        {% trans link="http://www.foxkeh.com/downloads/" %}
           <a href="{{ link }}">The History of Firefox and Mozilla Posters</a>
           (available in English and Japanese)
         {% endtrans %}


### PR DESCRIPTION
Use `http://` to avoid the SSL error.
