### PR TITLE
Bug 1008399 - RTL issue on mozilla.org/firefox/tips

### DIFF
--- a/media/css/firefox/desktop/tips.less
+++ b/media/css/firefox/desktop/tips.less
@@ -186,3 +186,13 @@
         margin-bottom: 0;
     }
 }
+
+html[dir="rtl"] {
+    #tip-next {
+        float: left;
+    }
+
+    #tip-prev {
+        float: right;
+    }
+}


### PR DESCRIPTION
Fix an RTL issue on "next" and "back" buttons.
