### PR TITLE
Bug 987059: Stopage of the redirection /ja/about/ to /b/ja/about/

### DIFF
--- a/etc/httpd/global.conf
+++ b/etc/httpd/global.conf
@@ -164,6 +164,9 @@ RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/toolkit/download-to-your-devices(.*)
 # bug 921564
 RewriteRule ^/(ach|af|ak|an|ar|as|ast|az|be|bg|bn-BD|bn-IN|br|bs|ca|cs|csb|cy|da|de|dsb|el|en-GB|en-US|en-ZA|eo|es-AR|es-CL|es-ES|es-MX|et|eu|fa|ff|fi|fr|fy-NL|ga-IE|gd|gl|gu-IN|he|hi-IN|hr|hsb|hu|hy-AM|id|is|it|ja|ja-JP-mac|ka|kk|km|kn|ko|ku|lg|lij|lt|lv|mai|mk|ml|mn|mr|ms|my|nb-NO|nl|nn-NO|nso|oc|or|pa-IN|pl|pt-BR|pt-PT|rm|ro|ru|sah|si|sk|sl|son|sq|sr|sv-SE|sw|ta|ta-LK|te|th|tr|uk|ur|vi|wo|xh|zh-CN|zh-TW|zu)(/?)$ /b/$1$2 [PT]
 
+# bug 987059
+RewriteRule ^/ja/about(/?|/.+)$ http://www.mozilla.jp/about/mozilla/ [L,R=301]
+
 # bug 889958
 RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?mission(/?)$ /b/$1mission$2 [PT]
 


### PR DESCRIPTION
Mozilla Japan are merging their contents into mozilla.org.
Almost all contents can be merged, but there are some contents which can not be, 
because they have Japanese specific contents.

/about is the typical page which we can not merge into mozilla.org.
It contains Mozilla Japan's information and history.

We want to navigate Japanese users to http://mozilla.jp/about, who access to http://mozilla.org/ja/about.
The reason why we want to set such a redirection is available in https://bugzilla.mozilla.org/show_bug.cgi?id=987059. 

If this pull-request is merged, we can set the redirection for /about in mozilla.com/ja/.htaccess.
The destination will be specified in that file.
