### PR TITLE
[fix bug 1004204] Mobile navigation menu highlighting issue

### DIFF
--- a/bedrock/base/templates/base-resp.html
+++ b/bedrock/base/templates/base-resp.html
@@ -92,7 +92,7 @@
 
         {% block site_header_nav %}
         <nav id="nav-main" role="navigation">
-          <span class="toggle" role="button" aria-controls="nav-main-menu" tabindex="0">{{_('Menu')}}</span>
+          <span class="toggle" role="button" aria-controls="nav-main-menu" aria-expanded="false" tabindex="0">{{_('Menu')}}</span>
           <ul id="nav-main-menu">
             <li class="first mission-item"><a href="{{ url('mozorg.mission') }}">{{_('Mission')}}</a></li>
             <li class="about-item"><a href="{{ url('mozorg.about') }}">{{_('About')}}</a></li>

--- a/bedrock/firefox/templates/firefox/base-resp.html
+++ b/bedrock/firefox/templates/firefox/base-resp.html
@@ -23,7 +23,7 @@
 
 {% block site_header_nav %}
 <nav id="nav-main" role="navigation">
-  <span class="toggle" role="button" aria-controls="nav-main-menu" tabindex="0">{{_('Menu')}}</span>
+  <span class="toggle" role="button" aria-controls="nav-main-menu" aria-expanded="false" tabindex="0">{{_('Menu')}}</span>
   <ul id="nav-main-menu" class="has-submenus">
     <li class="first" id="nav-main-features"><a href="{{ url('firefox.desktop.index') }}" tabindex="0" aria-owns="nav-main-features-submenu" aria-haspopup="true">{{_('Desktop')}}</a>
       <ul aria-expanded="false" id="nav-main-features-submenu" class="submenu">

--- a/bedrock/firefox/templates/firefox/desktop/desktop-base.html
+++ b/bedrock/firefox/templates/firefox/desktop/desktop-base.html
@@ -24,8 +24,8 @@
         <a id="site-header-logo" href="{{ url('firefox.desktop.index') }}"><img src="{{ MEDIA_URL }}img/firefox/desktop/firefox-header.png" alt="Firefox"></a>
       {% endblock %}
       {% block site_header_nav %}
-        <span class="toggle" role="button" aria-controls="nav-main-menu" tabindex="0">{{_('Menu')}}</span>
         <nav id="nav-main" role="navigation">
+          <span class="toggle" role="button" aria-controls="nav-main-menu" aria-expanded="false" tabindex="0">{{_('Menu')}}</span>
           <ul id="nav-main-menu">
             <li class="first"><a id="nav-main-trust" href="{{ url('firefox.desktop.trust') }}">{{ _('Trusted') }}</a></li>
             <li><a id="nav-main-customize" href="{{ url('firefox.desktop.customize') }}">{{ _('Flexible') }}</a></li>

--- a/bedrock/firefox/templates/firefox/os/index.html
+++ b/bedrock/firefox/templates/firefox/os/index.html
@@ -30,7 +30,7 @@
         {% endblock %}
         {% block site_header_nav %}
             <nav id="nav-main" role="navigation">
-            <span class="toggle" role="button" aria-controls="nav-main-menu" tabindex="0">{{_('Menu')}}</span>
+              <span class="toggle" role="button" aria-controls="nav-main-menu" aria-expanded="false" tabindex="0">{{_('Menu')}}</span>
               <ul id="nav-main-menu">
                 <li class="first"><a class="nav" href="#adaptive-wrapper">{{_('The Adaptive Phone')}}</a></li>
                 <li><a class="nav" href="#have-it-all">{{_('The Features')}}</a></li>

--- a/bedrock/firefox/templates/firefox/partners/index.html
+++ b/bedrock/firefox/templates/firefox/partners/index.html
@@ -40,7 +40,7 @@
     <a href="{{ url('mozorg.home') }}" id="tabzilla" data-infobar="{{ settings.TABZILLA_INFOBAR_OPTIONS }}">{{ _('Mozilla') }}</a>
     {% block site_header_nav %}
     <nav id="nav-main" role="navigation">
-      <span class="toggle" role="button" aria-controls="nav-main-menu" tabindex="0">{{_('Menu')}}</span>
+      <span class="toggle" role="button" aria-controls="nav-main-menu" aria-expanded="false" tabindex="0">{{_('Menu')}}</span>
       <ul id="nav-main-menu">
         <li class="first"><a href="#os">{{_('Firefox OS')}}</a></li>
         <li><a href="#marketplace">{{_('Marketplace')}}</a></li>

--- a/bedrock/gigabit/templates/gigabit/apply.html
+++ b/bedrock/gigabit/templates/gigabit/apply.html
@@ -19,7 +19,7 @@
 
 {% block site_header_nav %}
   <nav id="nav-main" role="navigation">
-    <span class="toggle" role="button" aria-controls="nav-main-menu" tabindex="0">{{_('Menu')}}</span>
+    <span class="toggle" role="button" aria-controls="nav-main-menu" aria-expanded="false" tabindex="0">{{_('Menu')}}</span>
     <ul id="nav-main-menu">
       <li>{{_('<a href="%s">Home</a>')|format(url('gigabit.gigabit')) }}</li>
       <li><b>{{_('Apply')}}</b></li>

--- a/bedrock/gigabit/templates/gigabit/gigabit.html
+++ b/bedrock/gigabit/templates/gigabit/gigabit.html
@@ -19,7 +19,7 @@
 
 {% block site_header_nav %}
   <nav id="nav-main" role="navigation">
-    <span class="toggle" role="button" aria-controls="nav-main-menu" tabindex="0">{{_('Menu')}}</span>
+    <span class="toggle" role="button" aria-controls="nav-main-menu" aria-expanded="false" tabindex="0">{{_('Menu')}}</span>
     <ul id="nav-main-menu">
       <li><b>{{_('Home')}}</b></li>
       <li>{{_('<a href="%s">Apply</a>')|format(url('gigabit.apply')) }}</li>

--- a/bedrock/lightbeam/templates/lightbeam/about.html
+++ b/bedrock/lightbeam/templates/lightbeam/about.html
@@ -16,7 +16,7 @@
 {% endblock %}
 {% block site_header_nav %}
   <nav id="nav-main" role="navigation">
-    <span class="toggle" role="button" aria-controls="nav-main-menu" tabindex="0">{{_('Menu')}}</span>
+    <span class="toggle" role="button" aria-controls="nav-main-menu" aria-expanded="false" tabindex="0">{{_('Menu')}}</span>
     <ul id="nav-main-menu">
       <li><a href="{{ url('lightbeam.lightbeam') }}">{{_('Home')}}</a></li>
       <li><b>{{_('About')}}</b></li>

--- a/bedrock/lightbeam/templates/lightbeam/database.html
+++ b/bedrock/lightbeam/templates/lightbeam/database.html
@@ -16,7 +16,7 @@
 {% endblock %}
 {% block site_header_nav %}
   <nav id="nav-main" role="navigation">
-    <span class="toggle" role="button" aria-controls="nav-main-menu" tabindex="0">{{_('Menu')}}</span>
+    <span class="toggle" role="button" aria-controls="nav-main-menu" aria-expanded="false" tabindex="0">{{_('Menu')}}</span>
     <ul id="nav-main-menu">
       <li><a href="{{ url('lightbeam.lightbeam') }}">{{_('Home')}}</a></li>
       <li><b>{{_('Database')}}</b></li>

--- a/bedrock/lightbeam/templates/lightbeam/lightbeam.html
+++ b/bedrock/lightbeam/templates/lightbeam/lightbeam.html
@@ -15,7 +15,7 @@
 {% endblock %}
 {% block site_header_nav %}
   <nav id="nav-main" role="navigation">
-    <span class="toggle" role="button" aria-controls="nav-main-menu" tabindex="0">{{_('Menu')}}</span>
+    <span class="toggle" role="button" aria-controls="nav-main-menu" aria-expanded="false" tabindex="0">{{_('Menu')}}</span>
     <ul id="nav-main-menu">
       <li><b>{{_('Home')}}</b></li>
       <li><a href="{{ url('lightbeam.about') }}">{{_('About')}}</a></li>

--- a/bedrock/lightbeam/templates/lightbeam/profile.html
+++ b/bedrock/lightbeam/templates/lightbeam/profile.html
@@ -15,7 +15,7 @@
 {% endblock %}
 {% block site_header_nav %}
   <nav id="nav-main" role="navigation">
-    <span class="toggle" role="button" aria-controls="nav-main-menu" tabindex="0">{{_('Menu')}}</span>
+    <span class="toggle" role="button" aria-controls="nav-main-menu" aria-expanded="false" tabindex="0">{{_('Menu')}}</span>
     <ul id="nav-main-menu">
       <li><a href="{{ url('lightbeam.lightbeam') }}">{{_('Home')}}</a></li>
       <li><b>Database</b></li>

--- a/bedrock/persona/templates/persona/about.html
+++ b/bedrock/persona/templates/persona/about.html
@@ -17,7 +17,7 @@
 {% endblock %}
 {% block site_header_nav %}
   <nav id="nav-main" role="navigation">
-    <span class="toggle" role="button" aria-controls="nav-main-menu" tabindex="0">{{_('Menu')}}</span>
+    <span class="toggle" role="button" aria-controls="nav-main-menu" aria-expanded="false" tabindex="0">{{_('Menu')}}</span>
     <ul id="nav-main-menu">
       <li><a href="/persona/">{{ _('Home') }}</a></li>
       <li><b>{{ _('About') }}</b></li>

--- a/bedrock/persona/templates/persona/persona.html
+++ b/bedrock/persona/templates/persona/persona.html
@@ -17,7 +17,7 @@
 {% endblock %}
 {% block site_header_nav %}
   <nav id="nav-main" role="navigation">
-    <span class="toggle" role="button" aria-controls="nav-main-menu" tabindex="0">{{_('Menu')}}</span>
+    <span class="toggle" role="button" aria-controls="nav-main-menu" aria-expanded="false" tabindex="0">{{_('Menu')}}</span>
     <ul id="nav-main-menu">
         <li><b>{{ _('Home') }}</b></li>
         <li><a href="/persona/about/">{{ _('About') }}</a></li>

--- a/bedrock/persona/templates/persona/privacy-policy.html
+++ b/bedrock/persona/templates/persona/privacy-policy.html
@@ -17,7 +17,7 @@
 {% endblock %}
 {% block site_header_nav %}
   <nav id="nav-main" role="navigation">
-    <span class="toggle" role="button" aria-controls="nav-main-menu" tabindex="0">{{_('Menu')}}</span>
+    <span class="toggle" role="button" aria-controls="nav-main-menu" aria-expanded="false" tabindex="0">{{_('Menu')}}</span>
     <ul id="nav-main-menu">
       <li><a href="/persona/">{{ _('Home') }}</a></li>
       <li><a href="/persona/about/">{{ _('About') }}</a></li>

--- a/bedrock/persona/templates/persona/terms-of-service.html
+++ b/bedrock/persona/templates/persona/terms-of-service.html
@@ -17,7 +17,7 @@
 {% endblock %}
 {% block site_header_nav %}
   <nav id="nav-main" role="navigation">
-    <span class="toggle" role="button" aria-controls="nav-main-menu" tabindex="0">{{_('Menu')}}</span>
+    <span class="toggle" role="button" aria-controls="nav-main-menu" aria-expanded="false" tabindex="0">{{_('Menu')}}</span>
     <ul id="nav-main-menu">
         <li><a href="/persona/">{{ _('Home') }}</a></li>
         <li><a href="/persona/about/">{{ _('About') }}</a></li>

--- a/bedrock/research/templates/research/base.html
+++ b/bedrock/research/templates/research/base.html
@@ -31,7 +31,7 @@
 {% endblock %}
 {% block site_header_nav %}
   <nav id="nav-main" role="navigation">
-    <span class="toggle" role="button" aria-controls="nav-main-menu" tabindex="0">{{_('Menu')}}</span>
+    <span class="toggle" role="button" aria-controls="nav-main-menu" aria-expanded="false" tabindex="0">{{_('Menu')}}</span>
     <ul id="nav-main-menu">
     {% for href, id, caption in navigation_bar %}
       <li>

--- a/media/css/sandstone/sandstone-resp.less
+++ b/media/css/sandstone/sandstone-resp.less
@@ -953,7 +953,7 @@ nav.menu-bar {
 
             &.clear {
                 clear: both;
-            } 
+            }
         }
     }
 
@@ -1305,23 +1305,15 @@ nav.menu-bar {
             background-color: #247ac1;
             background-position: 94% 50%;
             background-repeat: no-repeat;
-            background-image: -moz-linear-gradient(#43a6e2, #247ac1);
-            background-image: -ms-linear-gradient(#43a6e2, #247ac1);
-            background-image: -o-linear-gradient(#43a6e2, #247ac1);
-            background-image: -webkit-gradient(linear, left top, left bottom, color-stop(0%,#43a6e2), color-stop(100%,#247ac1));
-            background-image: -webkit-linear-gradient(#43a6e2, #247ac1);
-            background-image: linear-gradient(#43a6e2, #247ac1);
+            background-image: -webkit-linear-gradient(top, #43a6e2, #247ac1);
+            background-image: linear-gradient(to bottom, #43a6e2, #247ac1);
         }
 
         #nav-main-menu a.submenu-item:hover,
         #nav-main-menu a.submenu-item:focus,
         #nav-main-menu a.submenu-item:active {
-            background-image: url(/media/img/sandstone/arrow-go.png), -moz-linear-gradient(#43a6e2, #247ac1);
-            background-image: url(/media/img/sandstone/arrow-go.png), -ms-linear-gradient(#43a6e2, #247ac1);
-            background-image: url(/media/img/sandstone/arrow-go.png), -o-linear-gradient(#43a6e2, #247ac1);
-            background-image: url(/media/img/sandstone/arrow-go.png), -webkit-gradient(linear, left top, left bottom, color-stop(0%,#43a6e2), color-stop(100%,#247ac1));
-            background-image: url(/media/img/sandstone/arrow-go.png), -webkit-linear-gradient(#43a6e2, #247ac1);
-            background-image: url(/media/img/sandstone/arrow-go.png), linear-gradient(#43a6e2, #247ac1);
+            background-image: url(/media/img/sandstone/arrow-go.png), -webkit-linear-gradient(top, #43a6e2, #247ac1);
+            background-image: url(/media/img/sandstone/arrow-go.png), linear-gradient(to bottom, #43a6e2, #247ac1);
         }
 
         #nav-main-menu li.first > a {
@@ -1385,31 +1377,6 @@ nav.menu-bar {
         left: auto;
         right: 12px;
     }
-
-    #about {
-        #nav-main-menu .about-item > a {
-            background-color: #eee;
-        }
-    }
-
-    #mission {
-        #nav-main-menu .mission-item > a {
-            background-color: #eee;
-        }
-    }
-
-    #products-page {
-        #nav-main-menu .products-item > a {
-            background-color: #eee;
-        }
-    }
-
-    #contribute {
-        #nav-main-menu .contribute-item > a {
-            background-color: #eee;
-        }
-    }
-
 }
 
 

--- a/media/js/base/nav-main-resp.js
+++ b/media/js/base/nav-main-resp.js
@@ -72,8 +72,16 @@ NavMain.mainMenuItems = null;
  */
 NavMain.mainMenuLinks = null;
 
+/**
+ * Main menu mobile toggle button
+ *
+ * @var jQuery
+ */
+NavMain.toggleButton = null;
+
 NavMain.init = function()
 {
+    NavMain.toggleButton = $('#masthead .toggle');
     NavMain.mainMenuItems = $('#nav-main .has-submenus > li');
     NavMain.mainMenuLinks = $('#nav-main ul > li > [tabindex="0"]');
 
@@ -97,6 +105,8 @@ NavMain.init = function()
             if (e.keyCode == 13 || e.keyCode == 32) {
                 e.preventDefault();
                 NavMain.toggleSmallMenu();
+            } else if (e.keyCode == 27 && NavMain.smallMenuOpen) {
+                NavMain.closeSmallMenu();
             }
         });
 
@@ -171,6 +181,9 @@ NavMain.initSubmenu = function(menu_idx)
         $(this).keydown(function(e) {
             var target;
             switch (e.keyCode) {
+                case 27: // Esc
+                    NavMain.handleEscKeypress(e);
+                    break;
                 case 33: // Page Up
                 case 36: // Home
                     target = menuItems.first();
@@ -267,7 +280,7 @@ NavMain.leaveSmallMode = function()
     $('#outer-wrapper').off('click.mobile-nav', NavMain.handleDocumentClick);
     $('a, input, textarea, button, :focus').off('focus.mobile-nav', NavMain.handleDocumentFocus);
 
-    $('#masthead .toggle').removeClass('open');
+    NavMain.toggleButton.removeClass('open').attr('aria-expanded', false);
 
     // reset submenus
     $('#nav-main-menu > li > .submenu')
@@ -377,6 +390,15 @@ NavMain.handleToggleKeypress = function(e)
     }
 };
 
+NavMain.handleEscKeypress = function(e)
+{
+    if (e.keyCode == 27 && NavMain.smallMenuOpen) {
+        NavMain.closeSmallMenu();
+        // Set focus back to the menu button
+        NavMain.toggleButton.focus();
+    }
+}
+
 NavMain.toggleSmallMenu = function()
 {
     if (NavMain.smallMenuOpen) {
@@ -396,15 +418,15 @@ NavMain.openSmallMenu = function()
         .slideDown(150)
         .removeAttr('aria-hidden');
 
-    $('#masthead .toggle').addClass('open');
+    NavMain.toggleButton.addClass('open').attr('aria-expanded', true);
 
     // add click handler and set submenu class on submenus
     NavMain.mainMenuLinks
         .addClass('submenu-item')
-        .click(NavMain.handleSubmenuClick);
+        .on('click', NavMain.handleSubmenuClick)
+        .on('keydown', NavMain.handleSubmenuKeypress);
 
-    // focus first item
-    $('#nav-main-menu a:first').get(0).focus();
+    $('#nav-main-menu > li > a').on('keydown', NavMain.handleEscKeypress);
 
     NavMain.smallMenuOpen = true;
 };
@@ -419,12 +441,15 @@ NavMain.closeSmallMenu = function()
         .slideUp(100)
         .attr('aria-hidden', 'true');
 
-    $('#masthead .toggle').removeClass('open');
+    NavMain.toggleButton.removeClass('open').attr('aria-expanded', false);
 
     // remove submenu click handler and CSS class
     NavMain.mainMenuLinks
         .addClass('submenu-item')
-        .unbind('click', NavMain.handleSubmenuClick);
+        .off('click', NavMain.handleSubmenuClick)
+        .off('keydown', NavMain.handleSubmenuKeypress);
+
+    $('#nav-main-menu > li > a').off('keydown', NavMain.handleEscKeypress);
 
     if (NavMain.currentSmallSubmenu) {
         NavMain.closeSmallSubmenu(NavMain.currentSmallSubmenu);
@@ -439,6 +464,15 @@ NavMain.handleSubmenuClick = function(e)
     e.preventDefault();
     var menu = $(this).siblings('.submenu');
     NavMain.openSmallSubmenu(menu);
+};
+
+NavMain.handleSubmenuKeypress = function(e)
+{
+    if (e.keyCode == 13 || e.keyCode == 32) {
+        e.preventDefault();
+        var menu = $(this).siblings('.submenu');
+        NavMain.openSmallSubmenu(menu);
+    }
 };
 
 NavMain.openSmallSubmenu = function(menu)


### PR DESCRIPTION
This PR adds a focus-able heading when opening the mobile navigation menu, instead of focusing on the first menu item.

Focusing the first item in the navigation list is still causing confusion for some folks, as they associate it with highlighting the current page and not the focused state. This PR should hopefully address the main issue, while still making things accessible for screen readers. It also means we can leave our menu link focus states intact this way.

I've reused the `'Menu'` string already in the template for the heading, although we could use another that's more appropriate (and wait on l10n). I'm open to suggestions.

I've also taken the opportunity to remove of some linear gradient vendor prefix cruft from the mobile nav.
