### PR TITLE
Bug 1008388 - Localized system requirements and release notes are 404 instead of redirecting to en-US

### DIFF
--- a/etc/httpd/global.conf
+++ b/etc/httpd/global.conf
@@ -506,15 +506,15 @@ RewriteRule ^/en-US/firefox/releases/0\.(.*)$ http://website-archive.mozilla.org
 RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)(firefox|mobile)/(\d)\.(.*)/releasenotes(.*)$ http://website-archive.mozilla.org/www.mozilla.org/firefox_releasenotes/$1$2/$3.$4/releasenotes$5 [L,R=301]
 
 # bug 988746, 989423, 994186
-RewriteRule ^/(en-US/)?(firefox|mobile)/(2[38]\.0(?:\.\d)?)/releasenotes(/)?$ /b/$1$2/$3/releasenotes$4 [PT]
-RewriteRule ^/(en-US/)?firefox/(2[38]\.0(?:\.\d)?)/system-requirements(/)?$ /b/$1firefox/$2/system-requirements$3 [PT]
-RewriteRule ^/(en-US/)?(firefox|mobile)/(29\.0(?:beta|\.\d)?)/releasenotes(/)?$ /b/$1$2/$3/releasenotes$4 [PT]
-RewriteRule ^/(en-US/)?firefox/(29\.0(?:beta|\.\d)?)/system-requirements(/)?$ /b/$1firefox/$2/system-requirements$3 [PT]
-RewriteRule ^/(en-US/)?(firefox|mobile)/([3-9]\d\.\d(?:a2|beta|\.\d)?)/(aurora|release)notes(/)?$ /b/$1$2/$3/$4notes$5 [PT]
-RewriteRule ^/(en-US/)?firefox/([3-9]\d\.\d(?:a2|beta|\.\d)?)/system-requirements(/)?$ /b/$1firefox/$2/system-requirements$3 [PT]
+RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?(firefox|mobile)/(2[38]\.0(?:\.\d)?)/releasenotes(/)?$ /b/$1$2/$3/releasenotes$4 [PT]
+RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/(2[38]\.0(?:\.\d)?)/system-requirements(/)?$ /b/$1firefox/$2/system-requirements$3 [PT]
+RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?(firefox|mobile)/(29\.0(?:beta|\.\d)?)/releasenotes(/)?$ /b/$1$2/$3/releasenotes$4 [PT]
+RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/(29\.0(?:beta|\.\d)?)/system-requirements(/)?$ /b/$1firefox/$2/system-requirements$3 [PT]
+RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?(firefox|mobile)/([3-9]\d\.\d(?:a2|beta|\.\d)?)/(aurora|release)notes(/)?$ /b/$1$2/$3/$4notes$5 [PT]
+RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/([3-9]\d\.\d(?:a2|beta|\.\d)?)/system-requirements(/)?$ /b/$1firefox/$2/system-requirements$3 [PT]
 
 # bug 1001238
-RewriteRule ^/(en-US/)?firefox/(24\.[5678]\.\d)/(releasenotes|system-requirements)(/)?$ /b/$1firefox/$2/$3$4 [PT]
+RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/(24\.[5678]\.\d)/(releasenotes|system-requirements)(/)?$ /b/$1firefox/$2/$3$4 [PT]
 
 # bug 818323
 RewriteRule ^/projects/security/known-vulnerabilities.html$ /security/known-vulnerabilities/ [L,R=301]


### PR DESCRIPTION
This will redirect non-existent localized page to en-US.
