### PR TITLE
[fix bug 1009511] Update sandstone Less mixins for transitions, transforms and animations

### DIFF
--- a/media/css/sandstone/lib.less
+++ b/media/css/sandstone/lib.less
@@ -138,7 +138,6 @@
 // http://creativecommons.org/licenses/by/3.0/
 
 .border-radius(@radius: 0.25em) {
-  -moz-border-radius: @radius;
   border-radius: @radius;
 }
 
@@ -149,81 +148,55 @@
 }
 
 .box-shadow(@shadow: 0px 2px 0px 0px rgba(0, 0, 0, 0.1)) {
-  -webkit-box-shadow: @shadow;
-  -moz-box-shadow: @shadow;
   box-shadow: @shadow;
 }
 
 .transition(@transition: all linear .25s) {
   -webkit-transition: @transition;
-  -moz-transition: @transition;
-  -o-transition: @transition;
-  -ms-transition: @transition;
   transition: @transition;
 }
 
 .transform(@transform: inherit) {
   -webkit-transform: @transform;
-  -moz-transform: @transform;
-  -o-transform: @transform;
   -ms-transform: @transform;
   transform: @transform;
 }
 
 .transform-origin(@transform-origin: left top) {
   -webkit-transform-origin: @transform-origin;
-  -moz-transform-origin: @transform-origin;
-  -o-transform-origin: @transform-origin;
   -ms-transform-origin: @transform-origin;
   transform-origin: @transform-origin;
 }
 
 .transform-style(@transform-style: inherit) {
   -webkit-transform-style: @transform-style;
-  -o-transform-style: @transform-style;
   -ms-transform-style: @transform-style;
-  -moz-transform-style: @transform-style;
   transform-style: @transform-style;
 }
 
 // Extra mixins for fine-tuned transitions
 .transition-property(@transition-property: all) {
   -webkit-transition-property: @transition-property;
-  -moz-transition-property: @transition-property;
-  -o-transition-property: @transition-property;
-  -ms-transition-property: @transition-property;
   transition-property: @transition-property;
 }
 
 .transition-duration(@transition-duration: 1s) {
   -webkit-transition-duration: @transition-duration;
-  -moz-transition-duration: @transition-duration;
-  -o-transition-duration: @transition-duration;
-  -ms-transition-duration: @transition-duration;
   transition-duration: @transition-duration;
 }
 
 .transition-timing-function(@transition-timing-function: linear) {
   -webkit-transition-timing-function: @transition-timing-function;
-  -moz-transition-timing-function: @transition-timing-function;
-  -o-transition-timing-function: @transition-timing-function;
-  -ms-transition-timing-function: @transition-timing-function;
   transition-timing-function: @transition-timing-function;
 }
 
 .transition-delay(@transition-delay: 0s) {
   -webkit-transition-delay: @transition-delay;
-  -moz-transition-delay: @transition-delay;
-  -o-transition-delay: @transition-delay;
-  -ms-transition-delay: @transition-delay;
   transition-delay: @transition-delay;
 }
 
 .animation(@parameters) {
   -webkit-animation: @parameters;
-  -moz-animation: @parameters;
-  -o-animation: @parameters;
-  -ms-animation: @parameters;
   animation: @parameters;
 }
 

--- a/media/css/sandstone/mixins.less
+++ b/media/css/sandstone/mixins.less
@@ -2,7 +2,6 @@
 // http://creativecommons.org/licenses/by/3.0/
 
 .border-radius(@radius: 0.25em) {
-  -moz-border-radius: @radius;
   border-radius: @radius;
 }
 
@@ -13,23 +12,16 @@
 }
 
 .box-shadow(@shadow: 0px 2px 0px 0px rgba(0, 0, 0, 0.1)) {
-  -webkit-box-shadow: @shadow;
-  -moz-box-shadow: @shadow;
   box-shadow: @shadow;
 }
 
 .transition(@transition: all linear .25s) {
   -webkit-transition: @transition;
-  -moz-transition: @transition;
-  -o-transition: @transition;
-  -ms-transition: @transition;
   transition: @transition;
 }
 
 .transform(@transform) {
   -webkit-transform: @transform;
-  -moz-transform: @transform;
-  -o-transform: @transform;
   -ms-transform: @transform;
   transform: @transform;
 }


### PR DESCRIPTION
CSS transitions and keyframe animations can pretty safely drop all prefixes other than `-webkit-`. I've left in, `-ms-` prefix for CSS transforms, since it was partially supported in IE9 (2d only etc).

http://caniuse.com/#feat=css-transitions
http://caniuse.com/#feat=transforms2d
http://caniuse.com/#feat=transforms3d
http://caniuse.com/#feat=css-animation
