### PR TITLE
[bug 986174] Remove breadcrumb and nav on firefox android page

### DIFF
--- a/bedrock/firefox/templates/firefox/android/index.html
+++ b/bedrock/firefox/templates/firefox/android/index.html
@@ -12,13 +12,7 @@
   {{ css('mobile_features') }}
 {% endblock %}
 
-{% block breadcrumbs %}
-  <nav class="breadcrumbs">
-    <a href="{{ url('mozorg.home') }}">{{_('Home')}}</a> &gt;
-    <a href="{{ url('firefox') }}">{{_('Firefox')}}</a> &gt;
-    <span>{{_('Mobile')}}</span>
-  </nav>
-{% endblock %}
+{% block site_header_nav %}{% endblock %}
 
 {% block content %}
 


### PR DESCRIPTION
Follow up PR for bug 986174 to remove the top nav and breadcrumbs on `firefox/android`

https://bugzilla.mozilla.org/show_bug.cgi?id=986174#c14
