### PR TITLE
Bug 1013082 : Added a rule to redirect accesses to /ja/?$ to http://www.mozilla.jp/

### DIFF
--- a/etc/httpd/global.conf
+++ b/etc/httpd/global.conf
@@ -102,6 +102,9 @@ RewriteRule ^/ports(.*)$ http://www-archive.mozilla.org/ports$1 [L,R=301]
 RewriteCond %{THE_REQUEST} ^.+/index\.html\ HTTP
 RewriteRule ^(.*)index\.html$ $1 [L,R=301]
 
+# bug 1013082
+RewriteRule ^/ja/?$ http://www.mozilla.jp/ [L,R]
+
 ## Redirect things to django!
 
 # bug 797192, 892470


### PR DESCRIPTION
Bug #1013082 (https://github.com/chikoski/bedrock/compare/bug1013082?expand=1)

http://www.mozilla.jp/ provides Japanese specific information like MozBus in addition to global message provided in http://mozilla.org/. It would be convenient for ja locale users that their accesses to the top page of http://www.mozilla.org/ are redirected to http://www.mozilla.jp/
