### PR TITLE
[fix bug 1011521] Remove duplicated title attributes from news links

### DIFF
--- a/media/js/mozorg/home.js
+++ b/media/js/mozorg/home.js
@@ -38,12 +38,23 @@
 
         // Adjust the news headlines
         $('.extra-news a').each(function () {
-            var title = $(this).attr('title');
+            var $this = $(this);
+            var title = $this.attr('title');
+
             if (!title) {
-                title = $.trim($(this).text());
-                $(this).attr('title', title);
+                title = $.trim($this.text());
             }
-            $(this).text(title).ellipsis({ row: 3 });
+
+            $this.text(title).ellipsis({
+                row: 3,
+                callback: function () {
+                    var text = $.trim($this.text());
+
+                    if (text.match('[.]{3}$')) {
+                        $this.attr('title', title);
+                    }
+                }
+            });
         });
     }
 


### PR DESCRIPTION
Removes duplicate `title` attributes from news links on the homepage (unless the link text has been truncated by the jQuery Ellipsis plugin).
