### PR TITLE
Bug 1011081 - Fix MDN link in os/devices for l10n

### DIFF
--- a/bedrock/firefox/templates/firefox/os/devices.html
+++ b/bedrock/firefox/templates/firefox/os/devices.html
@@ -1003,7 +1003,7 @@
             <a href="https://support.mozilla.org/products/firefox-os" class="standard-link arrow-link">{{ _('Get help with your Firefox OS device from Mozilla Support') }}</a>
           </li>
           <li>
-            <a href="https://developer.mozilla.org/en-US/Firefox_OS" class="standard-link arrow-link">{{ _('See what Firefox OS offers and means for developers') }}</a>
+            <a href="https://developer.mozilla.org/Firefox_OS" class="standard-link arrow-link">{{ _('See what Firefox OS offers and means for developers') }}</a>
           </li>
           <li>
             <a href="{{ url('firefox.partners.index') }}#marketplace" class="standard-link arrow-link">{{ _('Learn about Firefox OS apps in Firefox Marketplace') }}</a>


### PR DESCRIPTION
Removing en-US so that users from mozilla.org localized page are redirected to MDN localized page
