### PR TITLE
bug 977391 - add video engagement tracking

### DIFF
--- a/media/js/mozorg/contribute-faces.js
+++ b/media/js/mozorg/contribute-faces.js
@@ -103,9 +103,11 @@
 
         if (!$facesVid[0].paused) { // If the video is not paused
             $facesVid[0].pause();
+            gaTrack(['_trackEvent', '/contribute Page Interactions', 'pause', 'Get Involved video']);
             paused = true;
         } else if ($caption.is(':hidden') && $facesVid[0].paused) { // If the video is paused and caption is hidden
             $facesVid[0].play();
+            gaTrack(['_trackEvent', '/contribute Page Interactions', 'play', 'Get Involved video']);
             paused = false;
         }
 


### PR DESCRIPTION
Track pause/play events on the video sequence.

I hope it's this simple... I don't know if we can just make up new events like this without configuring something on the GA end first.
