### PR TITLE
Fix Bug 1018423 - Privacy Policy link broken on Donation page - returns 404: Page Not Found

### DIFF
--- a/etc/httpd/global.conf
+++ b/etc/httpd/global.conf
@@ -396,12 +396,6 @@ RewriteRule ^/about/organizations\.html$ /about/governance/organizations/ [L,R=3
 # bug 876233
 RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?about/participate/?$ /$1contribute/ [L,R=301]
 
-# bug 960689, 1013349, 896474
-RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?about/legal\.html$ /$1about/legal/ [L,R=301]
-RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?about/partnerships\.html$ /$1about/partnerships/ [L,R=301]
-RewriteCond %{REQUEST_URI} !/about/forums/?
-RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?about(.*)$ /b/$1about$2 [PT]
-
 # bug 790784
 # NB: The /foundation/privacy-policy.html redirect must appear before the
 # foundation redirects added with bug 724633. Otherwise, the address will first
@@ -429,6 +423,12 @@ RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?legal/privacy/notices-firefox /$1legal/firef
 RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?privacy/policies/(facebook|firefox-os|websites)/?$ /$1privacy/$2/ [L,R=301]
 RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?privacy(.*)$ /b/$1privacy$2 [PT]
 RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?legal/firefox(/?)$ /b/$1legal/firefox$2 [PT]
+
+# bug 960689, 1013349, 896474
+RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?about/legal\.html$ /$1about/legal/ [L,R=301]
+RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?about/partnerships\.html$ /$1about/partnerships/ [L,R=301]
+RewriteCond %{REQUEST_URI} !/about/forums/?
+RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?about(.*)$ /b/$1about$2 [PT]
 
 # bug 809426
 RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?legal/eula(/?)$ /b/$1legal/eula$2 [PT]


### PR DESCRIPTION
`RewriteRule ^/about/policies/privacy-policy\.html$ /privacy/websites/ [L,R=301]` is not working due to the preceding `RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?about(.*)$ /b/$1about$2 [PT]`
