### PR TITLE
[fix bug 1009570] Improve a11y of SVG and img alt text content on /firefox/desktop

### DIFF
--- a/bedrock/firefox/templates/firefox/desktop/customize.html
+++ b/bedrock/firefox/templates/firefox/desktop/customize.html
@@ -161,21 +161,12 @@
             {{ _('Choose from thousands of themes and dress up your browser with a single click.') }}
           </p>
 
-          {# TODO: add alt attributes to images below. #}
-          <ul id="themes-thumbs">
-            <li>
-              <a href="#" role="button" id="theme-yellow"><img src="{{ media('/img/firefox/desktop/customize/theme-thumb-yellow.png') }}"></a>
-            </li>
-            <li>
-              <a href="#" role="button" id="theme-green"><img src="{{ media('/img/firefox/desktop/customize/theme-thumb-green.png') }}"></a>
-            </li>
-            <li>
-              <a href="#" role="button" id="theme-blue"><img src="{{ media('/img/firefox/desktop/customize/theme-thumb-blue.png') }}"></a>
-            </li>
-            <li>
-              <a href="#" role="button" class="selected" id="theme-red"><img src="{{ media('/img/firefox/desktop/customize/theme-thumb-red.png') }}"></a>
-            </li>
-          </ul>
+          <div id="themes-thumbs">
+            <button type="button" aria-controls="theme-demo" id="theme-yellow">{{ _('Preview yellow theme') }}</button>
+            <button type="button" aria-controls="theme-demo" id="theme-green">{{ _('Preview green theme') }}</button>
+            <button type="button" aria-controls="theme-demo" id="theme-blue">{{ _('Preview blue theme') }}</button>
+            <button type="button" aria-controls="theme-demo" id="theme-red" class="selected">{{ _('Preview red theme') }}</button>
+          </div>
 
           <a class="more" rel="external" href="https://addons.mozilla.org/firefox/themes/">{{ _('Try it now') }}</a>
           <br>
@@ -185,8 +176,7 @@
         <a class="next show-customizer" href="#add-ons" role="button">{{ _('Next') }}</a>
 
         <div class="customizer-visual">
-          {# TODO: add alt value below. #}
-          <img id="theme-demo" src="{{ media('/img/firefox/desktop/customize/theme-red.png') }}" alt="">
+          <img id="theme-demo" src="{{ media('/img/firefox/desktop/customize/theme-red.png') }}" alt="{{ _('Preview of the currently selected theme') }}">
         </div>
       </div>
     </section>
@@ -214,7 +204,7 @@
         </div><!--/.customizer-copy-->
 
         <div class="customizer-visual">
-          <img src="{{ media('/img/firefox/desktop/customize/add-ons.png') }}">
+          <img src="{{ media('/img/firefox/desktop/customize/add-ons.png') }}" alt="">
         </div>
       </div>
     </section>
@@ -234,8 +224,7 @@
         </div>
 
         <div class="customizer-visual">
-          {# TODO: add alt value below. #}
-          <img src="{{ media('/img/firefox/desktop/customize/awesome-bar.png') }}" alt="">
+          <img src="{{ media('/img/firefox/desktop/customize/awesome-bar.png') }}" alt="{{ _('Firefox Awesome Bar') }}">
         </div>
       </div>
     </section>

--- a/bedrock/firefox/templates/firefox/desktop/includes/intro-anim.html
+++ b/bedrock/firefox/templates/firefox/desktop/includes/intro-anim.html
@@ -1,31 +1,34 @@
-<img id="intro-firefox-logo" src="{{ media('/img/firefox/desktop/index/animations/firefox-logo.png') }}" alt="">
+<img id="intro-firefox-logo" src="{{ media('/img/firefox/desktop/index/animations/firefox-logo.png') }}" alt="Firefox">
 <div id="intro-svg-anim">
   <!--[if gt IE 9]><!-->
   <div class="svg-wrapper intro-browser">
-    <svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 998 450" preserveAspectRatio="xMinYMin meet">
-      <path class="browser-outer" stroke-linejoin="round" stroke-linecap="round" stroke-width="2" stroke-opacity="1" fill-opacity="0" d="M445.0062607506216,1C447.13769942474363,1,992.786,1,992.786,1C995.113,1,997,2.439,997,4.214C997,4.214,996.76,445.787,996.76,445.787C996.76,447.56199999999995,994.873,449.001,992.5459999999999,449.001C992.5459999999999,449.001,5.455,449.001,5.455,449.001C3.1270000000000002,449.001,1.2409999999999997,447.56199999999995,1.2409999999999997,445.787C1.2409999999999997,445.787,1,4.214,1,4.214C1,2.439,2.887,1,5.214,1C5.214,1,445,1,445,1" stroke="#5d7489" fill="#5d7489"></path>
-      <path class="window-inner" stroke-linejoin="round" stroke-linecap="round" stroke-width="2" stroke-opacity="1" fill-opacity="0" d="M407.0044237520695,109.86700000000002C405.4464649047852,109.867,6.609,109.867,6.609,109.867C6.609,109.867,6.609,443.889,6.609,443.889C6.609,443.889,991.392,443.889,991.392,443.889C991.392,443.889,991.392,109.867,991.392,109.867C991.392,109.867,407.009,109.867,407.009,109.867" stroke="#5d7489" fill="#e7ebef"></path>
-      <path class="tabs-outer" stroke-linejoin="round" stroke-linecap="round" stroke-width="2" stroke-opacity="1" fill-opacity="0" d="M118.30958412832393,12.238000000000001C121.75586663818359,12.238,307.2769541015625,12.238,318.483,12.238C336.547,12.238,338.943,25.543999999999997,340.3,32.801C342.42,44.143,347.41,50.167,359.22200000000004,50.167C359.22200000000004,50.167,359.45200000000006,50.167,359.45200000000006,50.167C359.45200000000006,50.167,991.3800000000001,50.167,991.3800000000001,50.167C991.3800000000001,50.167,991.3800000000001,105.656,991.3800000000001,105.656C991.3800000000001,105.656,6.619,105.656,6.619,105.656C6.619,105.656,6.619,50.168,6.619,50.168C6.619,50.168,77.331,50.168,77.331,50.168C77.331,50.168,77.561,50.168,77.561,50.168C89.373,50.168,94.444,44.143,96.56400000000001,32.802C97.921,25.544,100.509,12.238,118.3,12.238" stroke="#5d7489" fill="#dee3ea"></path>
-      <path class="circle" stroke-linejoin="round" stroke-linecap="round" stroke-width="2" stroke-opacity="1" fill-opacity="0" d="M33.665530413296274,58.589001490321166C43.94406883919239,58.59306994020939,52.274,66.92651000976564,52.274,77.205C52.274,87.486,43.939,95.821,33.658,95.821C23.377000000000002,95.821,15.042000000000002,87.48599999999999,15.042000000000002,77.205C15.041,66.923,23.376,58.589,33.658,58.589" stroke="#5d7489" fill="#5d7489">
+    <svg role="img" aria-labelledby="browser-svg-img" xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 998 450" preserveAspectRatio="xMinYMin meet">
+      <title id="browser-svg-img">{{ _('Firefox web browser') }}</title>
+      <path role="presentation" class="browser-outer" stroke-linejoin="round" stroke-linecap="round" stroke-width="2" stroke-opacity="1" fill-opacity="0" d="M445.0062607506216,1C447.13769942474363,1,992.786,1,992.786,1C995.113,1,997,2.439,997,4.214C997,4.214,996.76,445.787,996.76,445.787C996.76,447.56199999999995,994.873,449.001,992.5459999999999,449.001C992.5459999999999,449.001,5.455,449.001,5.455,449.001C3.1270000000000002,449.001,1.2409999999999997,447.56199999999995,1.2409999999999997,445.787C1.2409999999999997,445.787,1,4.214,1,4.214C1,2.439,2.887,1,5.214,1C5.214,1,445,1,445,1" stroke="#5d7489" fill="#5d7489"></path>
+      <path role="presentation" class="window-inner" stroke-linejoin="round" stroke-linecap="round" stroke-width="2" stroke-opacity="1" fill-opacity="0" d="M407.0044237520695,109.86700000000002C405.4464649047852,109.867,6.609,109.867,6.609,109.867C6.609,109.867,6.609,443.889,6.609,443.889C6.609,443.889,991.392,443.889,991.392,443.889C991.392,443.889,991.392,109.867,991.392,109.867C991.392,109.867,407.009,109.867,407.009,109.867" stroke="#5d7489" fill="#e7ebef"></path>
+      <path role="presentation" class="tabs-outer" stroke-linejoin="round" stroke-linecap="round" stroke-width="2" stroke-opacity="1" fill-opacity="0" d="M118.30958412832393,12.238000000000001C121.75586663818359,12.238,307.2769541015625,12.238,318.483,12.238C336.547,12.238,338.943,25.543999999999997,340.3,32.801C342.42,44.143,347.41,50.167,359.22200000000004,50.167C359.22200000000004,50.167,359.45200000000006,50.167,359.45200000000006,50.167C359.45200000000006,50.167,991.3800000000001,50.167,991.3800000000001,50.167C991.3800000000001,50.167,991.3800000000001,105.656,991.3800000000001,105.656C991.3800000000001,105.656,6.619,105.656,6.619,105.656C6.619,105.656,6.619,50.168,6.619,50.168C6.619,50.168,77.331,50.168,77.331,50.168C77.331,50.168,77.561,50.168,77.561,50.168C89.373,50.168,94.444,44.143,96.56400000000001,32.802C97.921,25.544,100.509,12.238,118.3,12.238" stroke="#5d7489" fill="#dee3ea"></path>
+      <path role="presentation" class="circle" stroke-linejoin="round" stroke-linecap="round" stroke-width="2" stroke-opacity="1" fill-opacity="0" d="M33.665530413296274,58.589001490321166C43.94406883919239,58.59306994020939,52.274,66.92651000976564,52.274,77.205C52.274,87.486,43.939,95.821,33.658,95.821C23.377000000000002,95.821,15.042000000000002,87.48599999999999,15.042000000000002,77.205C15.041,66.923,23.376,58.589,33.658,58.589" stroke="#5d7489" fill="#5d7489">
       </path>
-      <path class="address-bar" stroke-linejoin="round" stroke-linecap="round" stroke-width="2" stroke-opacity="1" fill-opacity="0" d="M441.50381187045576,60.001000000000005C442.15098387145997,60.001,524.989,60.001,524.989,60.001C524.989,60.001,524.989,95.82300000000001,524.989,95.82300000000001C524.989,95.82300000000001,43.613,95.82300000000001,43.613,95.82300000000001C50.453,92.453,55.157,85.38600000000001,55.157,77.20400000000001C55.157,70.034,51.546,63.721000000000004,46.05,60.001000000000005C46.05,60.001000000000005,441.5,60.001000000000005,441.5,60.001000000000005" stroke="#5d7489" fill="#fff"></path>
-      <path class="search-bar" stroke-linejoin="round" stroke-linecap="round" stroke-width="2" stroke-opacity="1" fill-opacity="0" d="M532.0222039351463,60.001000000000005C533.5848302612305,60.001,733.601,60.001,733.601,60.001C733.601,60.001,733.601,95.82300000000001,733.601,95.82300000000001C733.601,95.82300000000001,532.013,95.82300000000001,532.013,95.82300000000001C532.013,95.82300000000001,532.013,60.001,532.013,60.001" stroke="#5d7489" fill="#fff"></path>
-      <path class="menu-icon" stroke-linejoin="round" stroke-linecap="round" stroke-width="2" stroke-opacity="1" fill-opacity="0" d="M927,50.002556800842285C927,50.4366455078125,927,106,927,106" stroke="#5d7489" fill="none"></path>
-      <path class="bookmarks-divider" stroke-linejoin="round" stroke-linecap="round" stroke-width="2" stroke-opacity="1" fill-opacity="0" d="M786,64.00473594665527C786,64.4046630859375,786,90,786,90" stroke="#5d7489" fill="none"></path>
+      <path role="presentation" class="address-bar" stroke-linejoin="round" stroke-linecap="round" stroke-width="2" stroke-opacity="1" fill-opacity="0" d="M441.50381187045576,60.001000000000005C442.15098387145997,60.001,524.989,60.001,524.989,60.001C524.989,60.001,524.989,95.82300000000001,524.989,95.82300000000001C524.989,95.82300000000001,43.613,95.82300000000001,43.613,95.82300000000001C50.453,92.453,55.157,85.38600000000001,55.157,77.20400000000001C55.157,70.034,51.546,63.721000000000004,46.05,60.001000000000005C46.05,60.001000000000005,441.5,60.001000000000005,441.5,60.001000000000005" stroke="#5d7489" fill="#fff"></path>
+      <path role="presentation" class="search-bar" stroke-linejoin="round" stroke-linecap="round" stroke-width="2" stroke-opacity="1" fill-opacity="0" d="M532.0222039351463,60.001000000000005C533.5848302612305,60.001,733.601,60.001,733.601,60.001C733.601,60.001,733.601,95.82300000000001,733.601,95.82300000000001C733.601,95.82300000000001,532.013,95.82300000000001,532.013,95.82300000000001C532.013,95.82300000000001,532.013,60.001,532.013,60.001" stroke="#5d7489" fill="#fff"></path>
+      <path role="presentation" class="menu-icon" stroke-linejoin="round" stroke-linecap="round" stroke-width="2" stroke-opacity="1" fill-opacity="0" d="M927,50.002556800842285C927,50.4366455078125,927,106,927,106" stroke="#5d7489" fill="none"></path>
+      <path role="presentation" class="bookmarks-divider" stroke-linejoin="round" stroke-linecap="round" stroke-width="2" stroke-opacity="1" fill-opacity="0" d="M786,64.00473594665527C786,64.4046630859375,786,90,786,90" stroke="#5d7489" fill="none"></path>
     </svg>
   </div>
   <div class="svg-wrapper">
     <div class="back-button icon">
-      <svg version="1.1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 324 324" preserveAspectRatio="xMinYMin meet">
-        <path class="icon-fill" fill-rule="evenodd" clip-rule="evenodd" fill="#5D7489" d="M277.5,201h-121l55,54c8.748,8.699,10.792,21.246,4,28l-25,25
+      <svg role="img" aria-labelledby="back-svg-img" version="1.1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 324 324" preserveAspectRatio="xMinYMin meet">
+        <title id="back-svg-img">{{ _('Back icon') }}</title>
+        <path role="presentation" class="icon-fill" fill-rule="evenodd" clip-rule="evenodd" fill="#5D7489" d="M277.5,201h-121l55,54c8.748,8.699,10.792,21.246,4,28l-25,25
           c-6.792,6.754-19.248,4.696-28-4l-127-125c-2.398-2.384-8.269-10.616-8-17c-0.323-7.663,5.656-13.671,8-16l126-126
           c8.752-8.699,22.208-10.754,29-4l25,25c6.792,6.754,4.748,19.304-4,28l-54,53h120c10.941,0,20,8.125,20,19v40
           C297.5,191.872,288.441,201,277.5,201z"></path>
       </svg>
     </div>
     <div class="bookmarks-button icon">
-      <svg version="1.1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 324 324" preserveAspectRatio="xMinYMin meet">
-        <path fill-rule="evenodd" clip-rule="evenodd" fill="#5D7489" d="M261.5,72h-40l-60-60l-60,60h-40c-22,0-40,18-40,40v160
+      <svg role="img" aria-labelledby="bookmarks-menu-svg-img" version="1.1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 324 324" preserveAspectRatio="xMinYMin meet">
+        <title id="bookmarks-menu-svg-img">{{ _('Bookmarks menu icon') }}</title>
+        <path role="presentation" fill-rule="evenodd" clip-rule="evenodd" fill="#5D7489" d="M261.5,72h-40l-60-60l-60,60h-40c-22,0-40,18-40,40v160
             c0,22.091,17.909,40,40,40h200c22,0,40-18,40-40V112C301.5,89.909,283.5,72,261.5,72z M81.5,272c-11,0-20-9-20-20s9-20,20-20
             s20,9,20,20S92.5,272,81.5,272z M81.5,212c-11,0-20-9-20-20s9-20,20-20s20,8.954,20,20C101.5,203,92.5,212,81.5,212z M81.5,152
             c-11,0-20-9-20-20s9-20,20-20s20,9,20,20S92.5,152,81.5,152z M261.5,272h-140v-40h140V272z M261.5,212h-140v-40h140V212z
@@ -33,16 +36,18 @@
       </svg>
     </div>
     <div class="bookmarks-star icon">
-      <svg version="1.1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 324 324" preserveAspectRatio="xMinYMin meet">
-        <path fill="#5D7489" d="M303.5,112l-86.37-14.06L177.5,17c-8-17-24-17-32,0l-39,81l-87,14c-19,3-24,17-11,31l63,64l-14,91
+      <svg role="img" aria-labelledby="bookmarks-svg-img" version="1.1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 324 324" preserveAspectRatio="xMinYMin meet">
+        <title id="bookmarks-svg-img">{{ _('Bookmarks icon') }}</title>
+        <path role="presentation" fill="#5D7489" d="M303.5,112l-86.37-14.06L177.5,17c-8-17-24-17-32,0l-39,81l-87,14c-19,3-24,17-11,31l63,64l-14,91
           c-3,19,9,26,26,18l78-41l78,41c17,9,29,0,26-18l-14-91l62-64C327.5,129,322.5,115,303.5,112z M237.5,160l-31,30l7,44
           c2,9-5,12-13,8l-39-19l-39,19c-8,4-14,1-13-8l7-43l-31-31c-7-7-5-13,5-15l44-6l19-39c4-8,12-8,16,0l20,39l43,6
           C241.5,147,244.5,153,237.5,160z"></path>
       </svg>
     </div>
     <div class="customize-button icon">
-      <svg version="1.1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 324 324" preserveAspectRatio="xMinYMin meet">
-        <path fill-rule="evenodd" clip-rule="evenodd" fill="#5D7489" d="M37.5,102h248c16.052,0,31-14.693,31-30s-14.948-30-31-30h-248
+      <svg role="img" aria-labelledby="customize-svg-img" version="1.1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 324 324" preserveAspectRatio="xMinYMin meet">
+        <title id="customize-svg-img">{{ _('Customize icon') }}</title>
+        <path role="presentation" fill-rule="evenodd" clip-rule="evenodd" fill="#5D7489" d="M37.5,102h248c16.052,0,31-14.693,31-30s-14.948-30-31-30h-248
       c-16.052,0-31,14.693-31,30S21.448,102,37.5,102z M37.567,192.023L285.5,192c16.052,0,31.076-14.693,31.076-30.001
       c0-15.304-14.949-30.024-31.001-30.024H37.567C21.515,131.975,6.5,146.693,6.5,162S21.515,192.023,37.567,192.023z M285.5,222
       h-248c-16.052,0-31,14.693-31,30s14.948,30,31,30h248c16.052,0,31.076-14.621,31.076-29.929
@@ -50,45 +55,52 @@
       </svg>
     </div>
     <div class="home-button icon">
-      <svg version="1.1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 324 324" preserveAspectRatio="xMinYMin meet">
-        <path fill-rule="evenodd" clip-rule="evenodd" fill="#5D7489" d="M281.5,162l-120-100l-120,100h-40l160-140l160,140H281.5z
+      <svg role="img" aria-labelledby="home-svg-img" version="1.1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 324 324" preserveAspectRatio="xMinYMin meet">
+        <title id="home-svg-img">{{ _('Home icon') }}</title>
+        <path role="presentation" fill-rule="evenodd" clip-rule="evenodd" fill="#5D7489" d="M281.5,162l-120-100l-120,100h-40l160-140l160,140H281.5z
    M261.5,162v140h-80V202h-40v100h-80V162l100-80L261.5,162z"></path>
       </svg>
     </div>
     <div class="download-button icon">
-      <svg version="1.1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 324 324" preserveAspectRatio="xMinYMin meet">
-        <path fill-rule="evenodd" clip-rule="evenodd" fill="#5D7489" d="M295.5,183l-112,110c-6,6-13,9-21,9s-15-3-21-9l-113-110
+      <svg role="img" aria-labelledby="downloads-svg-img" version="1.1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 324 324" preserveAspectRatio="xMinYMin meet">
+        <title id="downloads-svg-img">{{ _('Downloads icon') }}</title>
+        <path role="presentation" fill-rule="evenodd" clip-rule="evenodd" fill="#5D7489" d="M295.5,183l-112,110c-6,6-13,9-21,9s-15-3-21-9l-113-110
   c-12-12-8-21,9-21h65V42c0-11.045,8.952-20,20-20h80c11.045,0,20,8.955,20,20v120h64C303.5,162,307.5,171,295.5,183z"/>
       </svg>
     </div>
     <div class="search-button icon">
-      <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 324 324" preserveAspectRatio="xMinYMin meet">
-        <path fill-rule="evenodd" clip-rule="evenodd" fill="#5D7489" d="M209.5,174c9.129-15.129,12-33.061,12-52
+      <svg role="img" aria-labelledby="search-svg-img" version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 324 324" preserveAspectRatio="xMinYMin meet">
+        <title id="search-svg-img">{{ _('Search icon') }}</title>
+        <path role="presentation" fill-rule="evenodd" clip-rule="evenodd" fill="#5D7489" d="M209.5,174c9.129-15.129,12-33.061,12-52
             c0-55.584-44.216-100-100-100c-55.785,0-100,44.416-100,100c0,55.584,44.215,100,100,100c18.441,0,37.119-3.399,52-12l92,92l36-36
             L209.5,174z M121.5,182c-33.471,0-60-26.65-60-60s26.529-60,60-60c33.47,0,60,26.65,60,60S154.97,182,121.5,182z"></path>
       </svg>
     </div>
     <div class="history-down icon">
-      <svg version="1.1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 324 324" preserveAspectRatio="xMinYMin meet">
-        <path fill-rule="evenodd" clip-rule="evenodd" fill="#5D7489" d="M60.5,92h202l-101,140L60.5,92z"/>
+      <svg role="img" aria-labelledby="history-svg-img" version="1.1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 324 324" preserveAspectRatio="xMinYMin meet">
+        <title id="history-svg-img">{{ _('History icon') }}</title>
+        <path role="presentation" fill-rule="evenodd" clip-rule="evenodd" fill="#5D7489" d="M60.5,92h202l-101,140L60.5,92z"/>
       </svg>
     </div>
     <div class="reload-button icon">
-      <svg version="1.1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 324 324" preserveAspectRatio="xMinYMin meet">
-      <path fill-rule="evenodd" clip-rule="evenodd" fill="#5D7489" d="M271.5,162h-120l49-49c-11.178-7.406-24.583-11-39-11
+      <svg role="img" aria-labelledby="reload-svg-img" version="1.1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 324 324" preserveAspectRatio="xMinYMin meet">
+        <title id="reload-svg-img">{{ _('Reload icon') }}</title>
+        <path role="presentation" fill-rule="evenodd" clip-rule="evenodd" fill="#5D7489" d="M271.5,162h-120l49-49c-11.178-7.406-24.583-11-39-11
         c-39.109,0-70,30.893-70,70c0,39.108,30.891,70,70,70c20.815,0,40.044-8.7,53-23l33,20c-20.14,25.599-50.902,43-86,43
         c-60.752,0-110-49.248-110-110c0-60.751,49.248-110,110-110c25.273,0,48.439,8.66,67,23l43-43V162z"></path>
       </svg>
     </div>
     <div class="tab-close-button tab-icon">
-      <svg version="1.1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 324 324" preserveAspectRatio="xMinYMin meet">
-        <path fill-rule="evenodd" clip-rule="evenodd" fill="#5D7489" d="M241.5,210l-32,32l-48-49l-49,49l-31-32l48-48l-48-48l32-32l48,48
+      <svg role="img" aria-labelledby="close-tab-svg-img" version="1.1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 324 324" preserveAspectRatio="xMinYMin meet">
+        <title id="close-tab-svg-img">{{ _('Close tab icon') }}</title>
+        <path role="presentation" fill-rule="evenodd" clip-rule="evenodd" fill="#5D7489" d="M241.5,210l-32,32l-48-49l-49,49l-31-32l48-48l-48-48l32-32l48,48
           l48-48l32,32l-48,48L241.5,210z"></path>
       </svg>
     </div>
     <div class="tab-new-button tab-icon">
-      <svg version="1.1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 324 324" preserveAspectRatio="xMinYMin meet">
-        <path class="icon-fill" fill-rule="evenodd" clip-rule="evenodd" fill="#5D7489" d="M256.5,177h-80v80h-30v-80h-80v-30h80V67h30v80h80V177z"></path>
+      <svg role="img" aria-labelledby="new-tab-svg-img" version="1.1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 324 324" preserveAspectRatio="xMinYMin meet">
+        <title id="new-tab-svg-img">{{ _('New tab icon') }}</title>
+        <path role="presentation" class="icon-fill" fill-rule="evenodd" clip-rule="evenodd" fill="#5D7489" d="M256.5,177h-80v80h-30v-80h-80v-30h80V67h30v80h80V177z"></path>
       </svg>
     </div>
   </div>

--- a/media/css/firefox/desktop/customize.less
+++ b/media/css/firefox/desktop/customize.less
@@ -305,30 +305,53 @@ html[dir="rtl"] {
             margin: @baseLine 0 0;
             .clearfix();
 
-            li {
+            button {
                 float: left;
+                display: block;
                 width: 190px;
                 height: 68px;
-                overflow: hidden;
                 margin: 0 @baseLine @baseLine 0;
+                border-radius: 4px;
+                background-position: top left;
+                background-repeat: no-repeat;
+                background-size: 100% 100%;
+                background-color: transparent;
+                border: 4px solid transparent;
+                text-indent: -99em;
+                overflow: hidden;
+                .transition(border-color 0.2s ease);
 
-                a {
-                    display: block;
-                    width: 182px;
-                    height: 60px;
-                    border-radius: 4px;
-                    border: 4px solid transparent;
-                    .transition(all 0.2s ease);
-
-                    &:hover, &:focus {
-                        border-color: #fff;
-                        border-color: rgba(255, 255, 255, 0.7);
-                    }
-
-                    &.selected {
-                        border-color: #fe8207;
-                    }
+                &:hover,
+                &:focus {
+                    outline: none;
+                    cursor: pointer;
+                    border-color: #fff;
+                    border-color: rgba(255, 255, 255, 0.7);
                 }
+
+                &.selected {
+                    border-color: #fe8207;
+                }
+
+                &::-moz-focus-inner {
+                  border: 0;
+                }
+            }
+
+            #theme-yellow {
+                background-image: url(/media/img/firefox/desktop/customize/theme-thumb-yellow.png);
+            }
+
+            #theme-green {
+                background-image: url(/media/img/firefox/desktop/customize/theme-thumb-green.png);
+            }
+
+            #theme-blue {
+                background-image: url(/media/img/firefox/desktop/customize/theme-thumb-blue.png);
+            }
+
+            #theme-red {
+                background-image: url(/media/img/firefox/desktop/customize/theme-thumb-red.png);
             }
         }
 
@@ -388,7 +411,7 @@ html[dir="rtl"] {
         }
     }
 
-    #themes #themes-thumbs li {
+    #themes #themes-thumbs button{
         float: right;
         margin: 0 0 @baseLine @baseLine;
     }
@@ -1787,14 +1810,10 @@ html[dir="rtl"] {
                 width: 360px;
             }
 
-            #themes-thumbs li {
-                width: 160px;
-                height: 58px;
-
-                a {
-                    width: 152px;
-                    height: 50px;
-                }
+            #themes-thumbs button {
+                width: 152px;
+                height: 50px;
+                background-size: 144px 42px;
             }
 
             .customizer-visual {

--- a/media/js/firefox/desktop/customize.js
+++ b/media/js/firefox/desktop/customize.js
@@ -116,13 +116,13 @@
     });
 
     // handle clicks on theme thumbnails
-    $themes_thumbs.on('click', 'a', function(e) {
+    $themes_thumbs.on('click', 'button', function(e) {
         e.preventDefault();
 
         var $this = $(this);
 
         // de-select all
-        $themes_thumbs.find('a').removeClass('selected');
+        $themes_thumbs.find('button').removeClass('selected');
 
         // select clicked
         $this.addClass('selected');


### PR DESCRIPTION
- Added `<title>` text to inline SVG document images (I figured `<desc>` was probably overkill for these images).
- Added `alt` text to a couple of img's on `desktop/customize` where I think appropriate (most images are largely presentational I think).
- Changed image links in the Themes section to use real `<button>` elements.

There are some new strings introduced in this change, but I think we should review first and decide that a.) the new `alt` text is appropriate and b.) there's nowhere else in these pages where we should also be adding alternate text.
