### PR TITLE
Bug 1018724 - Tabzilla lang bar broken

### DIFF
--- a/bedrock/base/templates/base-resp.html
+++ b/bedrock/base/templates/base-resp.html
@@ -147,7 +147,7 @@
       {{ js('common-resp') }}
     {% endblock %}
     {% block tabzilla_js %}
-      <script src="{{ settings.CDN_BASE_URL }}{{ url('tabzilla') }}?build={{ BUILD_ID_JS }}"></script>
+      <script src="{{ url('tabzilla') }}?build={{ BUILD_ID_JS }}"></script>
     {% endblock %}
     {% block js %}{% endblock %}
     {% if settings.USE_GRUNT_LIVERELOAD %}

--- a/bedrock/base/templates/base.html
+++ b/bedrock/base/templates/base.html
@@ -133,7 +133,7 @@
       {{ js('common') }}
     {% endblock %}
     {% block tabzilla_js %}
-      <script src="{{ settings.CDN_BASE_URL }}{{ url('tabzilla') }}?build={{ BUILD_ID_JS }}"></script>
+      <script src="{{ url('tabzilla') }}?build={{ BUILD_ID_JS }}"></script>
     {% endblock %}
     {% block js %}{% endblock %}
     {% if settings.USE_GRUNT_LIVERELOAD %}


### PR DESCRIPTION
A workaround for the wrong language detection due to caches, until the `Accept-Language` header issue is fixed by CDN.
