### PR TITLE
Remove /about->/contribute redirects: fix bug 1020705

### DIFF
--- a/etc/httpd/global.conf
+++ b/etc/httpd/global.conf
@@ -366,11 +366,6 @@ RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?about/careers.html$ https://careers.mozilla.
 # bug 994831
 RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?about/history/details/$ /b/$1about/history/details/ [PT]
 
-# bug 885848
-RewriteRule ^/about/index.(.*)?.html$ /contribute/ [L,R=301]
-RewriteCond $1 !en-US/
-RewriteRule ^/(\w{2,3}(?:-\w{2})?/)about(?:/(?:index.html)?)$ /contribute/ [L,R=301]
-
 # bug 861243 and bug 869489
 RewriteRule ^/about/manifesto\.html$ /about/manifesto/ [L,R=301]
 RewriteRule ^/about/manifesto\.(.*)\.html$ /$1/about/manifesto/ [L,R=301]


### PR DESCRIPTION
Based on http://l10n.mozilla-community.org/~pascalc/langchecker/?locale=all&website=0&file=mozorg/about.lang only the locales in red need to continue to be redirected.
