### PR TITLE
Fix Bug 1020764 - Users on OS X Yosemite see a system requirements error

### DIFF
--- a/media/js/base/site.js
+++ b/media/js/base/site.js
@@ -56,7 +56,7 @@
             if (pf.indexOf("MacPPC") !== -1) {
                 return 'oldmac';
             }
-            if (/Mac OS X 10.[0-5]/.test(ua)) {
+            if (/Mac OS X 10.[0-5]\D/.test(ua)) {
                 return 'oldmac';
             }
             if (pf.indexOf('iPhone') !== -1 ||

--- a/media/js/test/spec/site.js
+++ b/media/js/test/spec/site.js
@@ -40,6 +40,7 @@ describe("site.js", function () {
 
         it("should identify OSX", function () {
             expect(window.site.getPlatform('Mozilla/5.0 (Macintosh; Intel Mac OS X 10.8; rv:30.0) Gecko/20100101 Firefox/30.0', 'foo')).toBe('osx');
+            expect(window.site.getPlatform('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10) AppleWebKit/538.10.3 (KHTML, like Gecko) Chrome/21.0.1180.89 Safari/537.1', 'foo')).toBe('osx');
         });
 
         it("should identify Firefox OS", function () {


### PR DESCRIPTION
I haven’t tested it yet but… `10.10` or `10_10` shouldn’t match here.
