### PR TITLE
Prevent tabzilla.js from being cached by proxies, Bug 1018724 followup

### DIFF
--- a/bedrock/tabzilla/tests.py
+++ b/bedrock/tabzilla/tests.py
@@ -49,7 +49,7 @@ class TabzillaViewTests(TestCase):
         """
         with self.activate('en-US'):
             resp = self.client.get(reverse('tabzilla'))
-        self.assertEqual(resp['cache-control'], 'max-age=43200')  # 12h
+        self.assertEqual(resp['cache-control'], 'private, max-age=43200')  # 12h
 
         now_date = floor(time.time())
         exp_date = parse_http_date(resp['expires'])

--- a/bedrock/tabzilla/views.py
+++ b/bedrock/tabzilla/views.py
@@ -8,6 +8,7 @@ from datetime import datetime
 from django.conf import settings
 from django.http import HttpResponseRedirect
 from django.template import loader
+from django.views.decorators.cache import cache_control
 from django.views.decorators.http import last_modified
 from django.views.decorators.vary import vary_on_headers
 
@@ -49,6 +50,7 @@ def _resp(request, path, ctype, context=None):
     return resp
 
 
+@cache_control(private=True)
 @cache_control_expires(12)
 @last_modified(template_last_modified('tabzilla/tabzilla.js'))
 @vary_on_headers('Accept-Language')


### PR DESCRIPTION
Use `Cache-Control: private` to make sure `Vary: Accept-Languages` always works.
