### PR TITLE
Update Fx desktop fast tab animation. Bug 1000973.

### DIFF
--- a/media/css/firefox/desktop/fast.less
+++ b/media/css/firefox/desktop/fast.less
@@ -122,7 +122,7 @@ html[dir="rtl"] {
         // tabs container is on top of the chrome
         #feel-tabs {
             z-index: 2;
-            top: 11px;
+            top: 12px;
             left: 65px;
             width: 600px;
             height: 35px;


### PR DESCRIPTION
- Move the tabs down one pixel to fill gap noticeable
  on high resolution displays.

Chrome on OS X (release & Canary) is adding a weird 1px white inset border-ish thing to the tab on my MBP retina display. The bug doesn't appear on a standard resolution monitor. I spent a bit of time researching and trying little fixes, but nothing got rid of it. Looks fine in all other browsers. Didn't think it was worth more than 30 minutes, but worth mentioning.
