### PR TITLE
Fix bug 1022972 - strip leading "rv:" from version

### DIFF
--- a/bedrock/firefox/tests/test_base.py
+++ b/bedrock/firefox/tests/test_base.py
@@ -475,6 +475,14 @@ class TestWhatsNew(TestCase):
         template = render_mock.call_args[0][1]
         eq_(template, ['firefox/australis/whatsnew-no-tour.html'])
 
+    @override_settings(DEV=True)
+    def test_rv_prefix(self, render_mock):
+        """Prefixed oldversion shouldn't impact version sniffing."""
+        req = self.rf.get('/en-US/firefox/whatsnew/?oldversion=rv:10.0')
+        self.view(req, fx_version='30.0')
+        template = render_mock.call_args[0][1]
+        eq_(template, ['firefox/australis/whatsnew-tour.html'])
+
     @override_settings(DEV=False)
     def test_fx_australis_secure_redirect(self, render_mock):
         """Should redirect to https: for 29.0."""
@@ -764,6 +772,9 @@ class TestWhatsnewRedirect(FxVersionRedirectsMixin, TestCase):
         self.assertIn(self.expected, response.content)
 
         response = self.client.get(self.url + '?oldversion=4.0', HTTP_USER_AGENT=self.user_agent)
+        self.assertIn(self.expected, response.content)
+
+        response = self.client.get(self.url + '?oldversion=rv:10.0', HTTP_USER_AGENT=self.user_agent)
         self.assertIn(self.expected, response.content)
 
         response = self.client.get(self.url + '?oldversion=29.0', HTTP_USER_AGENT=self.user_agent)

--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -430,6 +430,9 @@ class WhatsnewView(LatestFxView):
         fc_ctx = funnelcake_param(self.request)
         f = fc_ctx.get('funnelcake_id', 0)
         oldversion = self.request.GET.get('oldversion', '')
+        # old versions of Firefox sent a prefixed version
+        if oldversion.startswith('rv:'):
+            oldversion = oldversion[3:]
         versions = ('29.', '30.', '31.')
 
         if version == '29.0a1':


### PR DESCRIPTION
Old Firefox clients may prefix their version with "rv:". This patch
strips that before performing a version compare.

---

Review note: this is my first contribution to bedrock. I didn't test this patch. I didn't see any obvious locations for tests for this code. I would be happy to add a test.

Ping me on IRC if you need anything. I'm :gps.
