### PR TITLE
Update the SSL-enabled product list for Firefox 30.0 (No bug)

### DIFF
--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -888,7 +888,7 @@ STUB_INSTALLER_LOCALES = {
 }
 
 # Force download via SSL
-FORCE_SSL_DOWNLOAD_VERSIONS = ['27.0', '27.0.1', '28.0', '29.0', '29.0.1']
+FORCE_SSL_DOWNLOAD_VERSIONS = ['27.0', '27.0.1', '28.0', '29.0', '29.0.1', '30.0']
 
 # Google Analytics
 GA_ACCOUNT_CODE = ''


### PR DESCRIPTION
Forgot to update the list. Once #1800 is merged, we no longer have to manually update this.
