### PR TITLE
Improve mozilla-pager.js. Bug 966702.

### DIFF
--- a/bedrock/base/templates/base-resp.html
+++ b/bedrock/base/templates/base-resp.html
@@ -82,7 +82,11 @@
   </head>
 
   <body {% if self.body_id() %}id="{% block body_id %}{% endblock %}" {% endif %}class="html-{{ DIR }} {% block body_class %}{% endblock %}"{% block body_attrs %}{% endblock %}>
-    <div id="strings" data-global-close="{{ _('Close') }}" {% block string_data %}{% endblock %}></div>
+    <div id="strings"
+      data-global-close="{{ _('Close') }}"
+      data-global-next="{{ _('Next') }}"
+      data-global-previous="{{ _('Previous') }}"
+      {% block string_data %}{% endblock %}></div>
     <div id="outer-wrapper">
     <div id="wrapper">
 

--- a/bedrock/base/templates/base.html
+++ b/bedrock/base/templates/base.html
@@ -80,7 +80,11 @@
   </head>
 
   <body {% if self.body_id() %}id="{% block body_id %}{% endblock %}" {% endif %}class="html-{{ DIR }} {% block body_class %}{% endblock %}"{% block body_attrs %}{% endblock %}>
-    <div id="strings" data-global-close="{{ _('Close') }}" {% block string_data %}{% endblock %}></div>
+    <div id="strings"
+      data-global-close="{{ _('Close') }}"
+      data-global-next="{{ _('Next') }}"
+      data-global-previous="{{ _('Previous') }}"
+      {% block string_data %}{% endblock %}></div>
     <div id="outer-wrapper">
     <div id="wrapper">
 

--- a/bedrock/base/templates/macros.html
+++ b/bedrock/base/templates/macros.html
@@ -11,14 +11,14 @@
 
     <div class="form-contents">
       <div class="field field-email">
-        <label for="id_email" class="hidden">{{ _('Email') }}</label>
+        <label for="id_email" class="visually-hidden">{{ _('Email') }}</label>
         <input name="email" type="email" id="id_email" value="" required aria-required="true" placeholder="{{ _('YOUR EMAIL HERE') }}">
       </div>
 
       <div id="form-details">
         <!-- This is bad, but a quick fix because we are pushing live in an hour -->
         <div class="field field-country">
-          <label for="country" class="hidden">{{ _('Country') }}</label>
+          <label for="country" class="visually-hidden">{{ _('Country') }}</label>
           <select id="country" name="country">
             <option value=""></option>
             <option value="AF">Afghanistan</option>

--- a/bedrock/firefox/templates/firefox/channel.html
+++ b/bedrock/firefox/templates/firefox/channel.html
@@ -15,7 +15,7 @@
 
 {% block content %}
 
-<div id="main-content" class="pager pager-with-tabs pager-cleartype-fix">
+<div id="main-content" class="pager pager-with-tabs pager-cleartype-fix pager-auto-init">
 
   <ul id="toggler-container" class="pager-tabs">
     <li id="beta-link"><a href="#beta"><img src="{{ media('/img/firefox/channel/toggler-beta.png?2013-06') }}" alt="Firefox Beta" id="toggler-logo-beta" /></a></li>
@@ -23,8 +23,8 @@
     <li id="aurora-link"><a href="#aurora"><img src="{{ media('/img/firefox/channel/toggler-aurora.png?2013-06') }}" alt="Firefox Aurora" id="toggler-logo-aurora" /></a></li>
   </ul>
 
-  <a href="#" id="carousel-left"></a>
-  <a href="#" id="carousel-right"></a>
+  <a href="#" id="carousel-left" aria-hidden="true"></a>
+  <a href="#" id="carousel-right" aria-hidden="true"></a>
 
   <div class="pager-content">
 

--- a/bedrock/firefox/templates/firefox/desktop/tips.html
+++ b/bedrock/firefox/templates/firefox/desktop/tips.html
@@ -38,12 +38,22 @@
       <div id="share-nav-wrapper" class="share-wrapper">
         {% include 'firefox/includes/social-share.html' %}
         <nav id="tips-nav-direct">
-          <ol>
-            <li><a href="#bookmarks"><span>{{ _('1') }}</span> {{ _('Bookmarks') }}</a></li>
-            <li><a href="#simplify"><span>{{ _('2') }}</span> {{ _('Simplify') }}</a></li>
-            <li><a href="#arrange"><span>{{ _('3') }}</span> {{ _('Arrange') }}</a></li>
-            <li><a href="#sync"><span>{{ _('4') }}</span> {{ _('Sync') }}</a></li>
-            <li><a href="#addons"><span>{{ _('5') }}</span> {{ _('Add-ons') }}</a></li>
+          <ol role="tablist">
+            <li role="presentation">
+              <a role="tab" aria-controls="bookmarks-tip" aria-selected="true" href="#bookmarks" id="tab-bookmarks"><span>{{ _('1') }}</span> {{ _('Bookmarks') }}</a>
+            </li>
+            <li role="presentation">
+              <a role="tab" aria-controls="simplify-tip" aria-selected="false" href="#simplify" id="tab-simplify"><span>{{ _('2') }}</span> {{ _('Simplify') }}</a>
+            </li>
+            <li role="presentation">
+              <a role="tab" aria-controls="arrange-tip" aria-selected="false" href="#arrange" id="tab-arrange"><span>{{ _('3') }}</span> {{ _('Arrange') }}</a>
+            </li>
+            <li role="presentation">
+              <a role="tab" aria-controls="sync-tip" aria-selected="false" href="#sync" id="tab-sync"><span>{{ _('4') }}</span> {{ _('Sync') }}</a>
+            </li>
+            <li role="presentation">
+              <a role="tab" aria-controls="addons-tip" aria-selected="false" href="#addons" id="tab-addons"><span>{{ _('5') }}</span> {{ _('Add-ons') }}</a>
+            </li>
           </ol>
         </nav>
       </div>{# /#share-nav-wrapper #}
@@ -51,9 +61,9 @@
   </div>{# /#page-header #}
 
   <div id="page-content">
-    <div class="container pager pager-no-history">
+    <div class="container pager pager-no-history pager-auto-init">
       <div id="tips-nav-prev-next">
-        <button class="link-button" id="tip-prev">{{ _('back') }}</button>
+        <button class="link-button" id="tip-prev" aria-controls="tips-wrapper">{{ _('back') }}</button>
 
         <div id="tips-nav-dots">
           <span data-tip="bookmarks">{{ _('1') }}</span>
@@ -63,11 +73,11 @@
           <span data-tip="addons">{{ _('5') }}</span>
         </div>
 
-        <button class="link-button" type="button" id="tip-next">{{ _('next') }}</button>
+        <button class="link-button" type="button" id="tip-next" aria-controls="tips-wrapper">{{ _('next') }}</button>
       </div>
 
       <div id="tips-wrapper" class="pager-content">
-        <div class="tip pager-page default-page" id="bookmarks-tip">
+        <div class="tip pager-page default-page" id="bookmarks-tip" role="tabpanel" aria-labelledby="tab-bookmarks">
           <div class="tip-copy">
             <div class="ordinal">{{ _('1') }}</div>
 
@@ -98,7 +108,7 @@
           </figure>
         </div>
 
-        <div class="tip pager-page" id="simplify-tip">
+        <div class="tip pager-page" id="simplify-tip" role="tabpanel" aria-labelledby="tab-simplify">
           <div class="tip-copy">
             <div class="ordinal">{{ _('2') }}</div>
 
@@ -129,7 +139,7 @@
           </figure>
         </div>
 
-        <div class="tip" id="arrange-tip">
+        <div class="tip pager-page" id="arrange-tip" role="tabpanel" aria-labelledby="tab-arrange">
           <div class="tip-copy">
             <div class="ordinal">{{ _('3') }}</div>
 
@@ -159,7 +169,7 @@
           </figure>
         </div>
 
-        <div class="tip" id="sync-tip">
+        <div class="tip pager-page" id="sync-tip" role="tabpanel" aria-labelledby="tab-sync">
           <div class="tip-copy">
             <div class="ordinal">{{ _('4') }}</div>
 
@@ -193,7 +203,7 @@
           </figure>
         </div>
 
-        <div class="tip" id="addons-tip">
+        <div class="tip pager-page" id="addons-tip" role="tabpanel" aria-labelledby="tab-addons">
           <div class="tip-copy">
             <div class="ordinal">{{ _('5') }}</div>
 

--- a/bedrock/firefox/templates/firefox/partners/index.html
+++ b/bedrock/firefox/templates/firefox/partners/index.html
@@ -116,7 +116,7 @@
           </div> <!--/#overview-news-links-->
 
           <div class="partner-logos">
-            <div class="pager pager-with-tabs pager-no-history pager-auto-rotate">
+            <div class="pager pager-with-tabs pager-no-history pager-auto-rotate pager-auto-init">
               <div class="pager-content">
                 <div class="pager-page default-page">
                   <ul class="logos">
@@ -318,7 +318,7 @@
               <a href="https://mobilepartners.mozilla.org/" class="button">{{ _('Partner with us') }}</a>
             </p>
           </div>
-          <div class="marketplace-logos pager pager-with-tabs pager-no-history">
+          <div class="marketplace-logos pager pager-with-tabs pager-no-history pager-auto-init">
             <div class="pager-content">
               <div class="pager-page default-page">
                 <ul class="logos">

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -371,6 +371,9 @@ MINIFY_BUNDLES = {
             'css/styleguide/communications.less',
             'css/styleguide/products-firefox-os.less',
         ),
+        'styleguide-docs-mozilla-pager': (
+            'css/styleguide/docs/mozilla-pager.less',
+        ),
         'tabzilla': (
             'css/tabzilla/tabzilla.less',
         ),
@@ -620,9 +623,6 @@ MINIFY_BUNDLES = {
         'nightly-firstrun': (
             'js/firefox/firstrun/nightly-firstrun.js',
         ),
-        'pager': (
-            'js/base/mozilla-pager.js',
-        ),
         'partnerships': (
             'js/libs/jquery.validate.js',
             'js/base/mozilla-form-helper.js',
@@ -654,6 +654,10 @@ MINIFY_BUNDLES = {
         ),
         'styleguide': (
             'js/styleguide/styleguide.js',
+        ),
+        'styleguide-docs-mozilla-pager': (
+            'js/base/mozilla-pager.js',
+            'js/styleguide/docs/mozilla-pager.js',
         ),
         'video': (
             'js/base/mozilla-video-tools.js',

--- a/bedrock/styleguide/templates/styleguide/docs/mozilla-pager.html
+++ b/bedrock/styleguide/templates/styleguide/docs/mozilla-pager.html
@@ -1,0 +1,213 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+
+{% extends "mozorg/base-resp.html" %}
+
+{% block page_title %}{{ _('mozilla-pager.js examples') }}{% endblock %}
+{% block body_id %}mozilla-pager{% endblock %}
+{% block body_class %}sand{% endblock %}
+
+{% block site_css %}
+  {{ css('styleguide-docs-mozilla-pager') }}
+{% endblock %}
+
+{% block content %}
+<article id="main-content">
+  <h1>{{ _('mozilla-pager.js Examples') }}</h1>
+
+  <section class="example" id="example1">
+    <h2>Pager with nav, history, &amp; auto rotation</h2>
+
+    <div class="pager pager-auto-init pager-with-nav pager-auto-rotate">
+      <!-- nav will be drawn here -->
+      <div class="pager-content">
+        <article id="example1-page1" class="pager-page">
+          <h3>Page 1</h3>
+
+          <p>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur nec
+            odio vel metus vestibulum tempus. Integer imperdiet mollis pulvinar.
+            Praesent consectetur sagittis lacus, quis gravida mauris imperdiet in.
+            Fusce pretium, mi et tempus lobortis, lectus nunc mollis risus, sit amet
+            tempor eros eros eget nisl. Etiam quis placerat augue.
+          </p>
+        </article>
+        <article id="example1-page2" class="pager-page">
+          <h3>Page 2</h3>
+
+          <p>
+            Donec dapibus odio et pulvinar tristique. In a tristique tortor. Sed at
+            metus elit. Etiam commodo lobortis ligula auctor porta. Vivamus imperdiet,
+            dolor non pretium tempor, neque lectus pharetra tellus, at volutpat orci
+            velit at tellus. Curabitur in molestie ipsum. Maecenas imperdiet magna sed
+            aliquam tincidunt.
+          </p>
+        </article>
+        <article id="example1-page3" class="pager-page">
+          <h3>Page 3</h3>
+
+          <p>
+            Ut vitae consectetur mauris, a scelerisque quam. Vestibulum mi nibh,
+            porttitor et tellus vitae, rhoncus cursus sapien. Sed posuere leo neque,
+            vel dapibus ligula rhoncus et. Integer vehicula rhoncus volutpat.
+          </p>
+        </article>
+      </div>
+    </div>
+  </section>
+
+  <section class="example" id="example2">
+    <h2>Pager with tabs, no history, &amp; starting on page 2</h2>
+
+    <div id="pager-example2" class="pager pager-auto-init pager-with-tabs pager-no-history">
+      <ol class="pager-tabs">
+        <li>
+          <a href="#example2-page1">Page 1</a>
+        </li>
+        <li>
+          <a href="#example2-page2">Page 2</a>
+        </li>
+        <li>
+          <a href="#example2-page3">Page 3</a>
+        </li>
+      </ol>
+      <div class="pager-content">
+        <article id="example2-page1" class="pager-page">
+          <h3>Page 1</h3>
+
+          <p>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur nec
+            odio vel metus vestibulum tempus. Integer imperdiet mollis pulvinar.
+            Praesent consectetur sagittis lacus, quis gravida mauris imperdiet in.
+            Fusce pretium, mi et tempus lobortis, lectus nunc mollis risus, sit amet
+            tempor eros eros eget nisl. Etiam quis placerat augue.
+          </p>
+        </article>
+        <article id="example2-page2" class="pager-page default-page">
+          <h3>Page 2</h3>
+
+          <p>
+            Donec dapibus odio et pulvinar tristique. In a tristique tortor. Sed at
+            metus elit. Etiam commodo lobortis ligula auctor porta. Vivamus imperdiet,
+            dolor non pretium tempor, neque lectus pharetra tellus, at volutpat orci
+            velit at tellus. Curabitur in molestie ipsum. Maecenas imperdiet magna sed
+            aliquam tincidunt.
+          </p>
+        </article>
+        <article id="example2-page3" class="pager-page">
+          <h3>Page 3</h3>
+
+          <p>
+            Ut vitae consectetur mauris, a scelerisque quam. Vestibulum mi nibh,
+            porttitor et tellus vitae, rhoncus cursus sapien. Sed posuere leo neque,
+            vel dapibus ligula rhoncus et. Integer vehicula rhoncus volutpat.
+          </p>
+        </article>
+      </div>
+    </div>
+  </section>
+
+  <section class="example" id="example3">
+    <h2>Enable/Disable Pager with tabs, nav, &amp; random start page</h2>
+
+    <button type="button" id="pager3-enable">Enable Pager</button>
+    <button type="button" id="pager3-disable">Disable Pager</button>
+
+    <div id="pager-example3" class="pager pager-with-tabs pager-with-nav pager-random">
+      <ol class="pager-tabs">
+        <li>
+          <a href="#example3-page1">Page 1</a>
+        </li>
+        <li>
+          <a href="#example3-page2">Page 2</a>
+        </li>
+        <li>
+          <a href="#example3-page3">Page 3</a>
+        </li>
+      </ol>
+      <div class="pager-content">
+        <article id="example3-page1" class="pager-page">
+          <h3>Page 1</h3>
+
+          <p>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur nec
+            odio vel metus vestibulum tempus. Integer imperdiet mollis pulvinar.
+            Praesent consectetur sagittis lacus, quis gravida mauris imperdiet in.
+            Fusce pretium, mi et tempus lobortis, lectus nunc mollis risus, sit amet
+            tempor eros eros eget nisl. Etiam quis placerat augue.
+          </p>
+        </article>
+        <article id="example3-page2" class="pager-page">
+          <h3>Page 2</h3>
+
+          <p>
+            Donec dapibus odio et pulvinar tristique. In a tristique tortor. Sed at
+            metus elit. Etiam commodo lobortis ligula auctor porta. Vivamus imperdiet,
+            dolor non pretium tempor, neque lectus pharetra tellus, at volutpat orci
+            velit at tellus. Curabitur in molestie ipsum. Maecenas imperdiet magna sed
+            aliquam tincidunt.
+          </p>
+        </article>
+        <article id="example3-page3" class="pager-page">
+          <h3>Page 3</h3>
+
+          <p>
+            Ut vitae consectetur mauris, a scelerisque quam. Vestibulum mi nibh,
+            porttitor et tellus vitae, rhoncus cursus sapien. Sed posuere leo neque,
+            vel dapibus ligula rhoncus et. Integer vehicula rhoncus volutpat.
+          </p>
+        </article>
+      </div>
+    </div>
+  </section>
+
+  <section class="example" id="example4">
+    <h2>Pager with custom next/previous controls</h2>
+
+    <div id="pager-example4" class="pager pager-auto-init">
+
+      <button type="button" class="link-button" id="prev">Previous</button>
+      <button type="button" class="link-button" id="next">Next</button>
+
+      <div class="pager-content">
+        <article id="example4-page1" class="pager-page">
+          <h3>Page 1</h3>
+
+          <p>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur nec
+            odio vel metus vestibulum tempus. Integer imperdiet mollis pulvinar.
+            Praesent consectetur sagittis lacus, quis gravida mauris imperdiet in.
+            Fusce pretium, mi et tempus lobortis, lectus nunc mollis risus, sit amet
+            tempor eros eros eget nisl. Etiam quis placerat augue.
+          </p>
+        </article>
+        <article id="example4-page2" class="pager-page">
+          <h3>Page 2</h3>
+
+          <p>
+            Donec dapibus odio et pulvinar tristique. In a tristique tortor. Sed at
+            metus elit. Etiam commodo lobortis ligula auctor porta. Vivamus imperdiet,
+            dolor non pretium tempor, neque lectus pharetra tellus, at volutpat orci
+            velit at tellus. Curabitur in molestie ipsum. Maecenas imperdiet magna sed
+            aliquam tincidunt.
+          </p>
+        </article>
+        <article id="example4-page3" class="pager-page">
+          <h3>Page 3</h3>
+
+          <p>
+            Ut vitae consectetur mauris, a scelerisque quam. Vestibulum mi nibh,
+            porttitor et tellus vitae, rhoncus cursus sapien. Sed posuere leo neque,
+            vel dapibus ligula rhoncus et. Integer vehicula rhoncus volutpat.
+          </p>
+        </article>
+      </div>
+    </div>
+  </section>
+</article>
+{% endblock %}
+
+{% block js %}
+  {{ js('styleguide-docs-mozilla-pager') }}
+{% endblock %}

--- a/bedrock/styleguide/urls.py
+++ b/bedrock/styleguide/urls.py
@@ -91,9 +91,13 @@ all_children = [
 ]
 
 if settings.DEV:
-    all_children.append(
+    all_children.extend((
         PageNode('All Buttons', path='all-download-buttons',
                  template='styleguide/websites/sandstone-all-download-buttons.html'),
-    )
+        PageNode('Docs', path='docs', children=(
+            PageNode('Mozilla Pager JS', path='mozilla-pager',
+                    template='styleguide/docs/mozilla-pager.html'),
+        )),
+    ))
 
 urlpatterns = PageRoot('Home', children=tuple(all_children)).as_urlpatterns()

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -28,6 +28,7 @@ Contents
    php
    l10n
    coding
+   jslibs
    contribute
    grunt
    newsletters

--- a/docs/javascript-libs.rst
+++ b/docs/javascript-libs.rst
@@ -1,0 +1,13 @@
+.. This Source Code Form is subject to the terms of the Mozilla Public
+.. License, v. 2.0. If a copy of the MPL was not distributed with this
+.. file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+.. _jslibs:
+
+====================
+JavaScript Libraries
+====================
+
+.. _with mozillapager:
+
+- :ref:`mozilla-pager.js<mozillapager>`

--- a/docs/mozilla-pager.rst
+++ b/docs/mozilla-pager.rst
@@ -1,0 +1,265 @@
+.. This Source Code Form is subject to the terms of the Mozilla Public
+.. License, v. 2.0. If a copy of the MPL was not distributed with this
+.. file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+.. _mozillapager:
+
+=============
+Mozilla Pager
+=============
+
+`mozilla-pager.js` converts a section of markup into a tabbed or carousel interface. At minimum, each pager requires the following HTML elements:
+
+- A container with the class ``pager``, which contains,
+    - A container with the class ``pager-content``, which contains,
+        - Multiple containers with the class ``pager-page``.
+
+A very basic (yet fully functional) example might look like::
+
+    <div class="pager pager-auto-init pager-with-nav">
+        <div class="pager-content">
+            <div class="pager-page">
+                <p>Page 1</p>
+            </div>
+            <div class="pager-page">
+                <p>Page 2</p>
+            </div>
+        </div>
+    </div>
+
+See below for explanation of the ``pager-auto-init`` and ``pager-with-nav`` classes.
+
+Defaults
+--------
+
+All pagers have the following default behaviors:
+
+- The first page (the first element with class ``pager-page``) will be displayed when the pager is initialized. Can be overridden using either the ``default-page`` class on a specific ``pager-page`` element, or by using the ``pager-random`` class on the ``pager`` element.
+- The URL hash will be updated when navigating to a page other than the default page. This URL hash will be honored on page reload, displayed the last viewed pager page. Can be overridden using the ``pager-no-history`` class on the ``pager`` element.
+
+Pager options
+-------------
+
+Each pager can be individually configured through classes on the
+container ``pager`` element:
+
+``pager-auto-init``
+    Instructs the library to initialize the pager on ``$(document).ready()``.
+``pager-with-tabs``
+    Instructs the ``pager`` to look for a child element with the class
+    ``pager-tabs``. Links within this element will be used to show specific
+    pages. For example::
+
+        <div class="pager pager-auto-init pager-with-tabs">
+            <ol class="pager-tabs">
+                <li><a href="#page1">Page 1</a></li>
+                <li><a href="#page2">Page 2</a></li>
+            </ol>
+            <div class="pager-content">
+                <div id="page1" class="pager-page">
+                    <p>Page 1</p>
+                </div>
+                <div id="page2" class="pager-page">
+                    <p>Page 2</p>
+                </div>
+            </div>
+        </div>
+
+    The ``pager-tabs`` element will usually either be a ``<ul>`` or ``<ol>``, but can be any element you wish. **Note that tab anchor tags must be inside of a container, such as an** ``<li>`` (as shown above).
+
+    The anchor tag linking to the currently displayed page will have a ``selected`` class applied.
+
+``pager-with-nav``
+    Instructs the pager to generate and insert navigational markup directly before the ``pager-content`` element. The **generated markup** would look like::
+
+
+        <div class="pager pager-auto-init pager-with-nav" id="mozilla-pager-1">
+
+            <!-- BEGIN GENERATED MARKUP -->
+            <div class="pager-nav">
+                <span class="pager-nav-page-number">1 / 2</span>
+                <fieldset class="pager-nav-links-wrapper" aria-controls="mozilla-pager-1-pages">
+                    <button type="button" class="pager-prev" disabled="disabled" aria-label="Previous">Previous</button>
+                    <span class="pager-nav-divider"></span>
+                    <button type="button" class="pager-next" aria-label="Next">Next</button>
+                </fieldset>
+            </div>
+            <!-- END GENERATED MARKUP -->
+
+            <div class="pager-content" id="mozilla-pager-1-pages">
+                <div id="page1" class="pager-page">
+                    <p>Page 1</p>
+                </div>
+                <div id="page2" class="pager-page">
+                    <p>Page 2</p>
+                </div>
+            </div>
+        </div>
+
+    The appearance of the nav can easily be customized by writing your own selectors for the relevant CSS class names.
+
+``pager-no-history``
+    Instructs the library **not** to update the URL hash with the currently visible page.
+``pager-random``
+    The pager will display a random page when initialized.
+``pager-auto-rotate``
+    The pager will automatically rotate through all pages, looping when when reaching the last page. Rotation will pause when the page is either focused or moused over.
+
+Page options
+------------
+
+Each page inside the pager can be customized by applying the following classes to the ``pager-page`` element:
+
+``default-page``
+    Sets the page as the default page for the pager. If not provided, defaults to first ``pager-page`` element.
+
+Pager API
+---------
+
+Initializing new pagers
+^^^^^^^^^^^^^^^^^^^^^^^
+
+You can initialize new pagers in bulk by calling the ``createPagers`` method::
+
+    Mozilla.Pager.createPagers();
+
+This call will initialize all un-initialized pagers.
+
+You can also initialize a single pager by creating a new ``Mozilla.Pager`` object, passing a reference to the ``pager`` element::
+
+    <div class="pager" id="delayed-pager">
+        <!-- additional pager markup here -->
+    </div>
+
+    <script>
+        var delayedPager = new Mozilla.Pager(document.querySelector('#delayed-pager'));
+    </script>
+
+Once initialized, the ``pager-initialized`` class is applied to each ``pager`` element.
+
+If a pager does not have an ``id`` specified, the library will provide one during initialization in the form of ``mozilla-pager-X``, where ``X`` represents the new pager's creation order.
+
+Accessing pagers
+^^^^^^^^^^^^^^^^
+
+All initialized pagers can be accessed through the ``Mozilla.Pager.pagers`` array::
+
+    var pagers = Mozilla.Pager.pagers;
+
+    // log the id of each pager
+    for (var i = 0; i < pagers.length; i++) {
+        console.log(pagers[i].id);
+    }
+
+You can also find a pager by its ``id`` using the ``Mozilla.Pager.findPagerById()`` function. Returns a ``Mozilla.Pager`` object on success, ``null`` on failure::
+
+    // assume pagers have already been initialized
+    var myPager = Mozilla.Pager.findPagerById('my-pager');
+
+Destroying pagers
+^^^^^^^^^^^^^^^^^
+
+Pagers can be destroyed by passing the pager's ``id`` to the ``Mozilla.Pagers.destroyPagerById()`` function::
+
+    <div class="pager" id="delayed-pager">
+        <!-- additional pager markup here -->
+    </div>
+
+    <button id="destroy-pager">Destroy Pager</button>
+
+    <script>
+        var delayed_pager = new Mozilla.Pager(document.querySelector('#delayed-pager'));
+
+        document.querySelector('#destroy-pager').addEventListener('click', function(e) {
+            Mozilla.Pager.destroyPagerById('delayed-pager');
+        });
+    </script>
+
+This function removes the pager from the ``Mozilla.Pager.pagers`` array, removes any generated navigational markup, displays all pages in the pager, removes the ``pager-initialized`` class, and unbinds all event listeners within the pager.
+
+IDs and WAI-ARIA attributes added by the library are not removed.
+
+Returns ``true`` on success and ``false`` on failure.
+
+You can destroy *all* pagers on a page using the ``Mozilla.Pager.destroyPagers()`` function, which simply calls ``Mozilla.Pager.destroyPagerById()`` for each existing pager.
+
+Accessing pages
+^^^^^^^^^^^^^^^
+
+All pagers have a ``pages`` array containing ``Mozilla.Page`` objects::
+
+    var my_pager = new Mozilla.Pager(document.querySelector('#my-pager'));
+
+    var my_pager_pages = my_pager.pages;
+
+    // log each page in my_pager
+    for (var i = 0; i < my_pager_pages.length; i++) {
+        console.log(my_pager_pages[i]);
+    }
+
+Changing pages
+^^^^^^^^^^^^^^^^^^^^^^
+
+A pager's currently displayed page can be set through a variety of methods:
+
+``nextPageWithAnimation``
+    Moves the pager to the next page in the set. Will loop back to the first page if currently on the last page. Optionally takes a numeric ``duration`` (in milliseconts) parameter::
+
+        var my_pager = new Mozilla.Pager(document.querySelector('#my-pager'));
+
+        my_pager.nextPageWithAnimation();
+
+``prevPageWithAnimation``
+    Moves the pager to the previous page in the set. Will loop back to the last page if currently on the first page. Optionally takes a numeric ``duration`` (in milliseconds) parameter::
+
+        var my_pager = new Mozilla.Pager(document.querySelector('#my-pager'));
+
+        my_pager.prevPageWithAnimation(400);
+
+``setPage``
+    Sets the current page to the passed ``Mozilla.Page`` object::
+
+        var my_pager = new Mozilla.Pager(document.querySelector('#my-pager'));
+
+        var my_pager_pages = my_pager.pages;
+
+        // display the third page
+        my_pager.setPage(my_pager_pages[2]);
+
+``setPageWithAnimation``
+    Same as ``setPage``, but with fade in/fade out animations. Takes an optional numeric ``duration`` (in milliseconds) parameter::
+
+        var my_pager = new Mozilla.Pager(document.querySelector('#my-pager'));
+
+        var my_pager_pages = my_pager.pages;
+
+        // display the second page
+        my_pager.setPageWithAnimation(my_pager_pages[1], 450);
+
+Global Settings
+---------------
+
+You can configure some appearance and behavior of the library by supplying custom values for the following. Custom values should generally be set prior to ``$(document).ready()``.
+
+``Mozilla.Pager.PAGE_DURATION``
+    Time taken for page to fade in/out from tab and nav interaction. Defaults to ``150`` (milliseconds).
+
+``Mozilla.Pager.PAGE_AUTO_DURATION``
+    Time taken for page to fade in/out during auto rotate. Defaults to ``850`` (milliseconds).
+
+``Mozilla.Pager.AUTO_ROTATE_INTERVAL``
+    Time page is visible during auto rotate. Defaults to ``7000`` (milliseconds).
+
+``Mozilla.Pager.NEXT_TEXT``
+    Sets the text displayed in the `next` link in the generated navigation. Defaults to 'Next'. Note that any new value supplied should be localized (likely using the ``window.trans`` function).
+
+``Mozilla.Pager.PREV_TEXT``
+    Same as above, but for the `previous` link.
+
+``Mozilla.Pager.HIDDEN_CLASS``
+    Sets the CSS class used to hide pages. If overridden, should set ``display: none;`` for ARIA purposes. Defaults to ``hidden``.
+
+Examples
+--------
+
+You can view some common pager examples by navigating to ``/styleguide/docs/mozilla-pager/`` in your local development environment (not available in production).

--- a/media/css/firefox/desktop/tips.less
+++ b/media/css/firefox/desktop/tips.less
@@ -391,7 +391,6 @@ html[lang^='en'] #tips-nav-direct li a span:after {
     }
 
     .tip {
-        display: none;
         margin-bottom: 0;
     }
 

--- a/media/css/firefox/os/devices.less
+++ b/media/css/firefox/os/devices.less
@@ -2,7 +2,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-
 @import "../../sandstone/sandstone-resp.less";
 @import "get_device.less";
 

--- a/media/css/sandstone/lib.less
+++ b/media/css/sandstone/lib.less
@@ -298,8 +298,11 @@
     color: @linkRed;
 }
 
+/****************************************************************************/
+// Classes used to hide content from users. Choose wisely!
+
 // Hide visually, but not to screen readers
-.visually-hidden() {
+.visually-hidden {
     position: absolute!important;
     height: 1px;
     width: 1px;
@@ -309,6 +312,13 @@
     padding: 0;
     border: 0;
 }
+
+// Hide visually & from screen readers
+.hidden {
+    display: none;
+}
+
+/****************************************************************************/
 
 // not the most up to date method, but works in IE7
 .image-replaced {
@@ -320,6 +330,13 @@
 .trailing-arrow() {
     &:after {
         content: "\00A0\00BB"; /* nbsp raquo */
+        white-space: nowrap;
+    }
+}
+
+.leading-arrow() {
+    &:before {
+        content: "« "; /* laquo nbsp */
         white-space: nowrap;
     }
 }

--- a/media/css/sandstone/mixins.less
+++ b/media/css/sandstone/mixins.less
@@ -170,8 +170,7 @@
 }
 
 .hidden {
-  position: absolute;
-  left: -999em;
+    display: none;
 }
 
 .form-field-error {

--- a/media/css/sandstone/oldIE.less
+++ b/media/css/sandstone/oldIE.less
@@ -670,10 +670,6 @@ img {
     display: none;
 }
 
-.hidden {
-    .visually-hidden();
-}
-
 // not the most up to date method, but works in IE7
 .image-replaced {
     text-indent: 110%; // extra 10% to account for fancy fonts that may overhang

--- a/media/css/sandstone/sandstone-resp.less
+++ b/media/css/sandstone/sandstone-resp.less
@@ -1458,8 +1458,4 @@ nav.menu-bar {
     display: none;
 }
 
-.hidden {
-    .visually-hidden();
-}
-
 /* }}} */

--- a/media/css/styleguide/docs/mozilla-pager.less
+++ b/media/css/styleguide/docs/mozilla-pager.less
@@ -1,0 +1,46 @@
+@import '../../sandstone/sandstone-resp.less';
+
+.example {
+    margin: (@baseLine * 2) 0;
+}
+
+.pager {
+    background: #fff;
+    padding: @baseLine;
+}
+
+.pager-nav {
+    margin-bottom: @baseLine;
+
+    button {
+        .link-button();
+
+        &.pager-prev {
+            .leading-arrow();
+        }
+
+        &.pager-next {
+            .trailing-arrow();
+        }
+
+        &:disabled {
+            color: @textColorLight;
+            &:hover {
+                text-decoration: none;
+                cursor: default;
+            }
+        }
+    }
+}
+
+.pager-nav-links-wrapper {
+    display: inline;
+    margin: 0 (@baseLine / 2);
+}
+
+.pager-nav-divider {
+    margin: 0 (@baseLine / 4);
+    &:after {
+        content: '|';
+    }
+}

--- a/media/js/base/mozilla-pager.js
+++ b/media/js/base/mozilla-pager.js
@@ -40,38 +40,16 @@
  * @copyright 2007-2010 Mozilla Foundation, 2007-2010 silverorange Inc.
  * @license   http://www.mozilla.org/MPL/MPL-1.1.html Mozilla Public License 1.1
  * @author    Michael Gauthier <mike@silverorange.com>
+ *
  */
 
-$(document).ready(function() {
-
-    // add easing functions
-    $.extend($.easing, {
-        'pagerFadeIn':  function (x, t, b, c, d) {
-            return c * (t /= d) * t + b;
-        },
-        'pagerFadeOut': function (x, t, b, c, d) {
-            return -c * (t /= d) * (t - 2) + b;
-        }
-    });
-
-    Mozilla.Pager.createPagers(document.body, Mozilla.Pager.rootPagers, null);
-
-    // If one or more root pagers have history enabled, check if window
-    // location changes from back/forward button use. This doesn't matter
-    // in IE but is nice for Firefox and recent Safari and Opera users.
-    for (var i = 0; i < Mozilla.Pager.rootPagers.length; i++) {
-        if (Mozilla.Pager.rootPagers[i].history) {
-            setInterval(Mozilla.Pager.checkLocation,
-                Mozilla.Pager.LOCATION_INTERVAL);
-
-            break;
-        }
-    }
-
-});
+/**
+ * Updated 2014-06
+ * @author Jon Petto <jon@equalparts.io>
+ */
 
 // create namespace
-if (typeof Mozilla == 'undefined') {
+if (typeof Mozilla === 'undefined') {
     var Mozilla = {};
 }
 
@@ -82,42 +60,105 @@ if (typeof Mozilla == 'undefined') {
  *
  * @param DOMElement container
  */
-Mozilla.Pager = function(container, parentPager)
-{
+Mozilla.Pager = function(container) {
+    'use strict';
+
     this.$container = $(container);
 
-    if (!container.id) {
-        container.id = 'mozilla-pager-' + Mozilla.Pager.currentId;
+    // If the potential pager has already been initialized, just return
+    // a reference to the existing pager object.
+    if (this.$container.hasClass('pager-initialized')) {
+        return Mozilla.Pager.findPagerById(this.$container.prop('id'));
+    }
+
+    // Store reference to page container.
+    this.$pageContainer = this.$container.find('.pager-content:first');
+
+    // If the potential pager does not have content, it's invalid.
+    if (!this.$pageContainer.length) {
+        return null;
+    }
+
+    // Make sure the container has an ID.
+    if (!this.$container.prop('id')) {
+        this.$container.prop('id', 'mozilla-pager-' + Mozilla.Pager.currentId);
         Mozilla.Pager.currentId++;
     }
 
-    var pagerContentNodes = this.$container.find('div.pager-content');
-    if (!pagerContentNodes.length) {
-        return;
+    // Make sure the page container has an ID.
+    if (!this.$pageContainer.prop('id')) {
+        this.$pageContainer.prop('id', this.$container.prop('id') + '-pages');
     }
 
-    this.$pageContainer = $(pagerContentNodes[0]);
+    // Mark pager as initialized.
+    this.$container.addClass('pager-initialized');
 
-    this.id           = container.id;
+    this.id           = this.$container.prop('id');
     this.pagesById    = {};
     this.pages        = [];
     this.previousPage = null;
     this.currentPage  = null;
     this.animatingOut = false;
-    this.childPagers  = {};
-    this.parentPager  = parentPager;
 
-    this.randomStartPage = (this.$container.hasClass('pager-random'));
+    this.randomStartPage = this.$container.hasClass('pager-random');
+
+    // add pages
+    var page;
+    var pageNodes = this.$pageContainer.children('.pager-page');
 
     if (this.$container.hasClass('pager-with-tabs')) {
-        var $tabs = this.$container.find('ul.pager-tabs');
-        if ($tabs.length) {
-            this.$tabs = $($tabs[0]);
-        } else {
-            this.$tabs = null;
-        }
+        // Should be either a <ol> or <ul>. Tab links must be contained
+        // in a wrapper, e.g. <li><a href="#sometab"></a></li>.
+        var $tabs = this.$container.find('.pager-tabs:first');
+
+        this.$tabs = ($tabs.length) ? $tabs : null;
     } else {
         this.$tabs = null;
+    }
+
+    var i;
+    if (this.$tabs) {
+        this.$tabNodes = this.$tabs.children().not('.pager-not-tab');
+
+        // initialize pages with tabs
+        var index = 0;
+
+        for (i = 0; i < pageNodes.length; i++) {
+            if (i < this.$tabNodes.length) {
+                var tabAnchorNode = $(this.$tabNodes[i]).children('a:first');
+
+                if (tabAnchorNode.length) {
+                    page = new Mozilla.Page(
+                        pageNodes[i],
+                        index,
+                        tabAnchorNode[0]
+                    );
+
+                    this.addPage(page);
+
+                    index++;
+                }
+            }
+        }
+
+        // Add WAI-ARIA support.
+        this.$tabs.attr('role', 'tablist');
+        this.$tabNodes.attr('role', 'presentation');
+        this.$tabNodes.find('a').each(function(index, anchor) {
+            var $anchor = $(anchor);
+
+            $anchor.attr({
+                'role': 'tab',
+                'aria-controls': $anchor.attr('href').replace(/#/, ''),
+                'aria-selected': 'false'
+            });
+        });
+    } else {
+        // initialize pages without tabs
+        for (i = 0; i < pageNodes.length; i++) {
+            page = new Mozilla.Page(pageNodes[i], i, false);
+            this.addPage(page);
+        }
     }
 
     if (this.$container.hasClass('pager-with-nav')) {
@@ -126,65 +167,14 @@ Mozilla.Pager = function(container, parentPager)
         this.$nav = null;
     }
 
-    this.history = (!this.$container.hasClass('pager-no-history'));
-
-    this.hideWithHiddenClass = this.$container.hasClass('pager-with-hidden-class');
-
-    this.cleartypeFix = (this.$container.hasClass('pager-cleartype-fix'));
-
-    // add pages
-    var page;
-    var pageNodes = this.$pageContainer.children('div');
-
-    if (this.$tabs) {
-        // initialize pages with tabs
-        var tabNodes = this.$tabs.children().not('.pager-not-tab');
-
-        var index = 0;
-        for (var i = 0; i < pageNodes.length; i++) {
-            if (i < tabNodes.length) {
-                var tabAnchorNodes = $(tabNodes[i]).children('a:first');
-                if (tabAnchorNodes.length) {
-                    page = new Mozilla.Page(
-                        pageNodes[i],
-                        index,
-                        tabAnchorNodes[0],
-                        this.hideWithHiddenClass
-                    );
-
-                    this.addPage(page);
-                    this.childPagers[page.id] = [];
-
-                    Mozilla.Pager.createPagers(
-                        page.el,
-                        this.childPagers[page.id],
-                        this
-                    );
-
-                    index++;
-                }
-            }
-        }
-    } else {
-        // initialize pages without tabs
-        for (var i = 0; i < pageNodes.length; i++) {
-            page = new Mozilla.Page(pageNodes[i], i, false, this.hideWithHiddenClass);
-            this.addPage(page);
-            this.childPagers[page.id] = [];
-
-            Mozilla.Pager.createPagers(
-                page.el,
-                this.childPagers[page.id],
-                this
-            );
-        }
-    }
+    this.history = !this.$container.hasClass('pager-no-history');
 
     // initialize current page
     var currentPage;
-    if (this.history && !this.parentPager) {
+
+    if (this.history) {
         var hash = location.hash;
-        hash = (hash.substring(0, 1) == '#') ? hash.substring(1) : hash;
+        hash = (hash.substring(0, 1) === '#') ? hash.substring(1) : hash;
 
         // trim leading and tailing slash
         hash = hash.replace(/(^\/|\/$)/g, '');
@@ -200,13 +190,16 @@ Mozilla.Pager = function(container, parentPager)
             this.setPage(this.getPseudoRandomPage());
         } else {
             var defPage = this.$pageContainer.children('.default-page:first');
+
             if (defPage.length) {
                 var defId;
-                if (defPage[0].id.substring(0, 5) == 'page-') {
+
+                if (defPage[0].id.substring(0, 5) === 'page-') {
                     defId = defPage[0].id.substring(5);
                 } else {
                     defId = defPage[0].id;
                 }
+
                 this.setPage(this.pagesById[defId]);
             } else {
                 this.setPage(this.pages[0]);
@@ -221,50 +214,217 @@ Mozilla.Pager = function(container, parentPager)
         this.startAutoRotate();
 
         // prevent auto-rotate when hovering over container
-        this.$container.hover(
-            function(e) { that.stopAutoRotate(); },
-            function(e) { if (that.autoRotate) { that.startAutoRotate(); } }
+        this.$container.on('mouseenter.' + Mozilla.Pager.EVENT_NAMESPACE,
+            function() {
+                that.stopAutoRotate();
+            }
+        ).on('mouseleave.' + Mozilla.Pager.EVENT_NAMESPACE,
+            function() {
+                if (that.autoRotate) { that.startAutoRotate(); }
+            }
         );
 
         // prevent auto-rotate when focused on container
-        this.$container.focusin(function(e) {
-            that.stopAutoRotate();
-        }).focusout(function(e) {
-            if (that.autoRotate) {
-                that.startAutoRotate();
+        this.$container.on('focusin.' + Mozilla.Pager.EVENT_NAMESPACE,
+            function() {
+                that.stopAutoRotate();
             }
-        });
+        ).on('focusout.' + Mozilla.Pager.EVENT_NAMESPACE,
+            function() {
+                if (that.autoRotate) {
+                    that.startAutoRotate();
+                }
+            }
+        );
     } else {
         this.autoRotate = false;
     }
 
-    // add a way to access the object from outside
-    Mozilla.Pager.pagers[this.id] = this;
-}
+    // Make pagers accessible from other scripts.
+    Mozilla.Pager.pagers.push(this);
+
+    // Make sure hash monitoring is active (if needed).
+    if (this.history) {
+        Mozilla.Pager.initHashMonitor();
+    }
+
+    return this;
+};
 
 // }}}
 
 Mozilla.Pager.currentId  = 1;
-Mozilla.Pager.pagers     = {};
-Mozilla.Pager.rootPagers = [];
+Mozilla.Pager.pagers = [];
+Mozilla.Pager.monitoringHash = false;
+
+// Time taken for page to fade in/out from tab/nav interaction.
+Mozilla.Pager.PAGE_DURATION = Mozilla.Pager.PAGE_DURATION || 150;    // milliseconds
+// Time taken for page to fade in/out during auto rotate.
+Mozilla.Pager.PAGE_AUTO_DURATION = Mozilla.Pager.PAGE_AUTO_DURATION || 850;    // milliseconds
+// Time page is visible during auto rotate.
+Mozilla.Pager.AUTO_ROTATE_INTERVAL = Mozilla.Pager.AUTO_ROTATE_INTERVAL || 7000;  // milliseconds
+Mozilla.Pager.NEXT_TEXT = Mozilla.Pager.NEXT_TEXT || window.trans('global-next');
+Mozilla.Pager.PREV_TEXT = Mozilla.Pager.PREV_TEXT || window.trans('global-previous');
+Mozilla.Pager.HIDDEN_CLASS = 'hidden'; // sets display: none;
+
+// Should not be overridden by implementing script.
+Mozilla.Pager.PAGE_NUMBER_TEXT = '%s / %s';
+Mozilla.Pager.EVENT_NAMESPACE = 'mozpager'; // targeted event (un)binding
 
 // {{{ createPagers()
 
-Mozilla.Pager.createPagers = function(node, pagers, parentPager)
-{
-    if (/(^pager$|^pager | pager$| pager )/.test(node.className)) {
-        var pager = new Mozilla.Pager(node, parentPager);
-//        pager.parentPager = parentPager;
-        pagers.push(pager);
-    } else {
-        for (var i = 0; i < node.childNodes.length; i++) {
-            if (node.nodeType == 1) {
-                Mozilla.Pager.createPagers(
-                    node.childNodes[i],
-                    pagers,
-                    parentPager
-                );
+/**
+ * Initializes pagers.
+ *
+ * @param Boolean autoOnly - If true, only initializes pagers with
+ *     'pager-auto-init' class.
+ */
+Mozilla.Pager.createPagers = function(autoOnly) {
+    'use strict';
+
+    // Find all pagers that have not been initialized.
+    $('.pager').not('.pager-initialized').each(function(i, pagerNode) {
+        if ((autoOnly && $(pagerNode).hasClass('pager-auto-init')) || !autoOnly) {
+            new Mozilla.Pager(pagerNode);
+        }
+    });
+};
+
+// }}}
+// {{{ findPager()
+
+Mozilla.Pager.findPagerById = function(pagerId) {
+    'use strict';
+
+    var pager = $.grep(Mozilla.Pager.pagers, function(elem) {
+        return elem.id === pagerId;
+    });
+
+    return pager.length > 0 ? pager[0] : null;
+};
+
+// }}}
+// {{{ destroyPagers()
+
+Mozilla.Pager.destroyPagers = function() {
+    'use strict';
+
+    var pagerIds = [], i;
+
+    for (i = 0; i < Mozilla.Pager.pagers.length; i++) {
+        pagerIds.push(Mozilla.Pager.pagers[i].id);
+    }
+
+    for (i = 0; i < pagerIds.length; i++) {
+        Mozilla.Pager.destroyPagerById(pagerIds[i]);
+    }
+};
+
+// }}}
+// {{{ destroyPagerById()
+
+Mozilla.Pager.destroyPagerById = function(pagerId) {
+    'use strict';
+
+    var pager = Mozilla.Pager.findPagerById(pagerId);
+
+    // If no pager is found, we're done here.
+    if (!pager) {
+        return false;
+    }
+
+    // Stop auto-rotate.
+    if (pager.autoRotate) {
+        pager.stopAutoRotate();
+    }
+
+    // Remove generated nav markup.
+    if (pager.$nav) {
+        pager.$nav.remove();
+    }
+
+    // Remove event listeners from container.
+    pager.$container.off('.' + Mozilla.Pager.EVENT_NAMESPACE);
+
+    if (pager.$tabs) {
+        // Remove 'selected' class from tab links.
+        pager.$tabNodes.find('a').removeClass('selected');
+
+        // Remove 'pager-selected-?' class from tab links container.
+        pager.$tabs[0].className = Mozilla.Pager.removePagerSelectedClass(pager.$tabs[0].className);
+    }
+
+    for (var i = 0; i < pager.pages.length; i++) {
+        // Remove hidden classes/ARIA states from pages
+        pager.pages[i].$el.removeClass(Mozilla.Pager.HIDDEN_CLASS).attr('aria-hidden', 'false');
+
+        // Revert page ID and remove data.
+        pager.pages[i].$el.prop('id', pager.pages[i].$el.data('orig-id'));
+        pager.pages[i].$el.data('orig-id', undefined);
+
+        // Remove event listeners on tabs.
+        if (pager.pages[i].tab) {
+            pager.pages[i].$tab.off('.' + Mozilla.Pager.EVENT_NAMESPACE).attr('aria-selected', 'false');
+        }
+
+        // Remove event listeners on page children.
+        pager.pages[i].$el.find('*').off('.' + Mozilla.Pager.EVENT_NAMESPACE);
+    }
+
+    // Remove from array
+    var pagerIndex = $.inArray(pager, Mozilla.Pager.pagers);
+    Mozilla.Pager.pagers.splice(pagerIndex, 1);
+
+    // Remove initialized class
+    pager.$container.removeClass('pager-initialized');
+
+    // Update hash monitoring
+    Mozilla.Pager.updateHashMonitor();
+
+    return true;
+};
+
+// }}}
+// {{{ initHashMonitor()
+
+Mozilla.Pager.initHashMonitor = function() {
+    'use strict';
+
+    if (!Mozilla.Pager.monitoringHash) {
+        // If one or more root pagers have history enabled, check if window
+        // location changes from back/forward button use.
+        for (var i = 0; i < Mozilla.Pager.pagers.length; i++) {
+            if (Mozilla.Pager.pagers[i].history) {
+                $(window).on('hashchange.' + Mozilla.Pager.EVENT_NAMESPACE, Mozilla.Pager.checkLocation);
+                Mozilla.Pager.monitoringHash = true;
+
+                break;
             }
+        }
+    }
+};
+
+// }}}
+// {{{ updateHashMonitor()
+
+Mozilla.Pager.updateHashMonitor = function() {
+    'use strict';
+
+    // Only proceed if hash is currently being monitored.
+    if (Mozilla.Pager.monitoringHash) {
+        var shouldMonitor = false;
+
+        // Make sure a pager with history still exists.
+        for (var i = 0; i < Mozilla.Pager.pagers.length; i++) {
+            if (Mozilla.Pager.pagers[i].history) {
+                shouldMonitor = true;
+                break;
+            }
+        }
+
+        // If no pager with history exists, stop hash monitoring.
+        if (!shouldMonitor) {
+            $(window).off('hashchange.' + Mozilla.Pager.EVENT_NAMESPACE);
         }
     }
 };
@@ -272,17 +432,20 @@ Mozilla.Pager.createPagers = function(node, pagers, parentPager)
 // }}}
 // {{{ checkLocation()
 
-Mozilla.Pager.checkLocation = function()
-{
+Mozilla.Pager.checkLocation = function() {
+    'use strict';
+
     var hash = location.hash;
-    hash = (hash.substring(0, 1) == '#') ? hash.substring(1) : hash;
+    hash = (hash.substring(0, 1) === '#') ? hash.substring(1) : hash;
 
     // trim leading and tailing slash
     hash = hash.replace(/(^\/|\/$)/g, '');
 
     var pager;
-    for (var i = 0; i < Mozilla.Pager.rootPagers.length; i++) {
-        pager = Mozilla.Pager.rootPagers[i];
+
+    for (var i = 0; i < Mozilla.Pager.pagers.length; i++) {
+        pager = Mozilla.Pager.pagers[i];
+
         if (pager.history) {
             pager.setStateFromPath(hash, true, true);
         }
@@ -292,8 +455,9 @@ Mozilla.Pager.checkLocation = function()
 // }}}
 // {{{ getPseudoRandomPage()
 
-Mozilla.Pager.prototype.getPseudoRandomPage = function()
-{
+Mozilla.Pager.prototype.getPseudoRandomPage = function() {
+    'use strict';
+
     var page = null;
 
     if (this.pages.length > 0) {
@@ -302,22 +466,14 @@ Mozilla.Pager.prototype.getPseudoRandomPage = function()
     }
 
     return page;
-}
+};
 
 // }}}
-
-Mozilla.Pager.PAGE_DURATION        = 150;    // milliseconds
-Mozilla.Pager.PAGE_AUTO_DURATION   = 850;    // milliseconds
-Mozilla.Pager.LOCATION_INTERVAL    = 200;    // milliseconds
-Mozilla.Pager.NEXT_TEXT            = 'Next';
-Mozilla.Pager.PREV_TEXT            = 'Previous';
-Mozilla.Pager.PAGE_NUMBER_TEXT     = '%s / %s';
-Mozilla.Pager.AUTO_ROTATE_INTERVAL = 7000;  // milliseconds
-
 // {{{ setStateFromPath()
 
-Mozilla.Pager.prototype.setStateFromPath = function(path, animate, focus)
-{
+Mozilla.Pager.prototype.setStateFromPath = function(path, animate, focus) {
+    'use strict';
+
     var base = path, pos = base.indexOf('/');
 
     if (pos !== -1) {
@@ -326,10 +482,12 @@ Mozilla.Pager.prototype.setStateFromPath = function(path, animate, focus)
     }
 
     var baseParts = base.split('+'), updateSelf, page;
+
     for (var i = 0; i < baseParts.length; i++) {
         base = baseParts[i];
         page = this.pagesById[base];
         updateSelf = (this.currentPage === null || base !== this.currentPage.id);
+
         if (page) {
             if (updateSelf) {
                 if (animate) {
@@ -340,15 +498,6 @@ Mozilla.Pager.prototype.setStateFromPath = function(path, animate, focus)
                 } else {
                     this.setPage(page);
                 }
-            }
-
-            // check for children
-            for (var j = 0; j < this.childPagers[base].length; j++) {
-                this.childPagers[base][j].setStateFromPath(
-                    path,
-                    animate,
-                    focus
-                );
             }
 
             if (updateSelf && focus) {
@@ -364,103 +513,94 @@ Mozilla.Pager.prototype.setStateFromPath = function(path, animate, focus)
 // }}}
 // {{{ prevPageWithAnimation()
 
-Mozilla.Pager.prototype.prevPageWithAnimation = function(duration)
-{
+Mozilla.Pager.prototype.prevPageWithAnimation = function(duration) {
+    'use strict';
+
     var index = this.currentPage.index - 1;
     if (index < 0) {
         index = this.pages.length - 1;
     }
 
     this.setPageWithAnimation(this.pages[index], duration);
-}
+};
 
 // }}}
 // {{{ nextPageWithAnimation()
 
-Mozilla.Pager.prototype.nextPageWithAnimation = function(duration)
-{
+Mozilla.Pager.prototype.nextPageWithAnimation = function(duration) {
+    'use strict';
+
     var index = this.currentPage.index + 1;
     if (index >= this.pages.length) {
         index = 0;
     }
 
     this.setPageWithAnimation(this.pages[index], duration);
-}
+};
 
 // }}}
 // {{{ drawNav()
 
-Mozilla.Pager.prototype.drawNav = function()
-{
+Mozilla.Pager.prototype.drawNav = function() {
+    'use strict';
+
     var that = this;
 
-    this.$nav = $('<div class="pager-nav">');
+    this.$nav = $('<div>').attr({
+        'class': 'pager-nav'
+    });
 
     // page numbers
-    this.$pageNumber = $('<span class="pager-nav-page-number">');
-    this.$pageNumber.appendTo(this.$nav)
+    this.$pageNumber = $('<span>').attr('class', 'pager-nav-page-number');
+    this.$pageNumber.appendTo(this.$nav);
 
-    // previous insensitive
-    this.$prevInsensitive = $('<span class="pager-prev-insensitive">');
-    this.$prevInsensitive
-        .css('display', 'none')
-        .appendTo(this.$nav);
+    this.$navLinksWrapper = $('<fieldset>').attr({
+        'class': 'pager-nav-links-wrapper'
+    });
+    this.$navLinksWrapper.appendTo(this.$nav);
 
     // create previous link
-    this.$prev = $(
-        '<a href="#" class="pager-prev" title="' +
-        Mozilla.Pager.PREV_TEXT + '"></a>'
-    );
+    this.$prev = $('<button>').attr({
+        'type': 'button',
+        'class': 'pager-prev',
+        'aria-controls': this.$pageContainer.prop('id')
+    }).text(Mozilla.Pager.PREV_TEXT);
 
-    this.$prev
-        .click(function(e) {
-            e.preventDefault();
-            that.prevPageWithAnimation(Mozilla.Pager.PAGE_DURATION);
-            that.autoRotate = false;
-            that.stopAutoRotate();
-        })
-        .dblclick(function(e) {
-            e.preventDefault();
-        })
-        .appendTo(this.$nav);
+    this.$prev.on('click.' + Mozilla.Pager.EVENT_NAMESPACE, function(e) {
+        e.preventDefault();
+        that.prevPageWithAnimation(Mozilla.Pager.PAGE_DURATION);
+        that.autoRotate = false;
+        that.stopAutoRotate();
+    }).appendTo(this.$navLinksWrapper);
 
     // divider
-    var $divider = $('<span class="pager-nav-divider">|</span>');
-    $divider.appendTo(this.$nav);
+    var $divider = $('<span>').attr('class', 'pager-nav-divider');
+    $divider.appendTo(this.$navLinksWrapper);
 
     // create next link
-    this.$next = $(
-        '<a href="#" class="pager-next" title="' +
-        Mozilla.Pager.NEXT_TEXT + '"></a>'
-    );
+    this.$next = $('<button>').attr({
+        'type': 'button',
+        'class': 'pager-next',
+        'aria-controls': this.$pageContainer.prop('id')
+    }).text(Mozilla.Pager.NEXT_TEXT);
 
-    this.$next
-        .click(function(e) {
-            e.preventDefault();
-            that.nextPageWithAnimation(Mozilla.Pager.PAGE_DURATION);
-            that.autoRotate = false;
-            that.stopAutoRotate();
-        })
-        .dblclick(function(e) {
-            e.preventDefault();
-        })
-        .appendTo(this.$nav);
-
-    // next insensitive
-    this.$nextInsensitive = $('<span class="pager-next-insensitive">');
-    this.$nextInsensitive
-        .css('display', 'none')
-        .appendTo(this.$nav);
+    this.$next.on('click.' + Mozilla.Pager.EVENT_NAMESPACE, function(e) {
+        e.preventDefault();
+        that.nextPageWithAnimation(Mozilla.Pager.PAGE_DURATION);
+        that.autoRotate = false;
+        that.stopAutoRotate();
+    }).appendTo(this.$navLinksWrapper);
 
     // add nav to the DOM
     this.$nav.insertBefore(this.$pageContainer);
-}
+};
 
 // }}}
 // {{{ updateLocation()
 
-Mozilla.Pager.prototype.updateLocation = function(page)
-{
+Mozilla.Pager.prototype.updateLocation = function(page) {
+    'use strict';
+
     if (!this.history) {
         return;
     }
@@ -470,55 +610,44 @@ Mozilla.Pager.prototype.updateLocation = function(page)
 
     var hash = page.id;
 
-    // if this is a child pager, set parent hashes
-    var pager = this;
-    while (pager.parentPager !== null) {
-        hash = pager.parentPager.currentPage.id + '/' + hash;
-        pager = pager.parentPager;
-    }
-
-    // if this is a parent pager, set child hashes for selected page
-    if (this.childPagers[page.id] && this.childPagers[page.id].length) {
-        hash += '/';
-        for (var i = 0; i < this.childPagers[page.id].length; i++) {
-            hash += this.childPagers[page.id][i].currentPage.id + '+';
-        }
-        hash = hash.substr(0, hash.length - 1);
-    }
-
     location.href = baseLocation + '#' + hash;
 };
 
 // }}}
 // {{{ addPage()
 
-Mozilla.Pager.prototype.addPage = function(page)
-{
+Mozilla.Pager.prototype.addPage = function(page) {
+    'use strict';
+
     var that = this;
+
     this.pagesById[page.id] = page;
     this.pages.push(page);
+
     if (page.tab) {
-        page.$tab.click(function(e) {
+        page.$tab.on('click.' + Mozilla.Pager.EVENT_NAMESPACE, function(e) {
             e.preventDefault();
             that.setPageWithAnimation(page, Mozilla.Pager.PAGE_DURATION);
             that.autoRotate = false;
             that.stopAutoRotate();
         });
     }
-    page.$el.find('*').focus(function(e) {
-        if (page.$el.hasClass('hidden')) {
+
+    page.$el.find('*').on('focus.' + Mozilla.Pager.EVENT_NAMESPACE, function() {
+        if (page.$el.hasClass(Mozilla.Pager.HIDDEN_CLASS)) {
             that.setPage(page);
             that.autoRotate = false;
             that.stopAutoRotate();
         }
     });
-}
+};
 
 // }}}
 // {{{ update()
 
-Mozilla.Pager.prototype.update = function()
-{
+Mozilla.Pager.prototype.update = function() {
+    'use strict';
+
     if (this.$tabs) {
         this.updateTabs();
     }
@@ -529,36 +658,41 @@ Mozilla.Pager.prototype.update = function()
 
     var el = this.$pageContainer.get(0);
 
-    var className = el.className;
-    className     = className.replace(/pager-selected-[\w-]+/g, '');
-    className     = className.replace(/^\s+|\s+$/g,'');
-    el.className  = className;
+    el.className = Mozilla.Pager.removePagerSelectedClass(el.className);
 
     this.$pageContainer.addClass('pager-selected-' + this.currentPage.id);
-}
+};
 
 // }}}
 // {{{ updateTabs()
 
-Mozilla.Pager.prototype.updateTabs = function()
-{
+Mozilla.Pager.prototype.updateTabs = function() {
+    'use strict';
+
     var el = this.$tabs.get(0);
 
-    var className = el.className;
-    className     = className.replace(/pager-selected-[\w-]+/g, '');
-    className     = className.replace(/^\s+|\s+$/g,'');
-    el.className  = className;
+    el.className = Mozilla.Pager.removePagerSelectedClass(el.className);
 
     this.currentPage.selectTab();
     this.$container.trigger('changePage', [this.currentPage.tab]);
     this.$tabs.addClass('pager-selected-' + this.currentPage.id);
-}
+};
+
+Mozilla.Pager.removePagerSelectedClass = function(className) {
+    'use strict';
+
+    className = className.replace(/pager-selected-[\w-]+/g, '');
+    className = className.replace(/^\s+|\s+$/g,'');
+
+    return className;
+};
 
 // }}}
 // {{{ updateNav()
 
-Mozilla.Pager.prototype.updateNav = function()
-{
+Mozilla.Pager.prototype.updateNav = function() {
+    'use strict';
+
     // update page number
     var pageNumber = this.currentPage.index + 1;
     var pageCount  = this.pages.length;
@@ -569,69 +703,60 @@ Mozilla.Pager.prototype.updateNav = function()
     this.$pageNumber.text(text);
 
     // update previous link
-    this.setPrevSensitivity(this.currentPage.index != 0);
+    this.updateNavPrevLink(this.currentPage.index === 0);
 
     // update next link
-    this.setNextSensitivity(this.currentPage.index != this.pages.length - 1);
-}
+    this.updateNavNextLink(this.currentPage.index === this.pages.length - 1);
+};
 
 // }}}
-// {{{ setPrevSensitivity()
+// {{{ updateNavPrevLink()
 
-Mozilla.Pager.prototype.setPrevSensitivity = function(sensitive)
-{
-    if (sensitive) {
-        this.$prevInsensitive.css('display', 'none');
-        this.$prev.css('display', 'inline');
-    } else {
-        this.$prevInsensitive.css('display', 'inline');
-        this.$prev.css('display', 'none');
-    }
-}
+Mozilla.Pager.prototype.updateNavPrevLink = function(disable) {
+    'use strict';
+
+    this.$prev.prop('disabled', disable);
+};
 
 // }}}
-// {{{ setNextSensitivity()
+// {{{ updateNavNextLink()
 
-Mozilla.Pager.prototype.setNextSensitivity = function(sensitive)
-{
-    if (sensitive) {
-        this.$nextInsensitive.css('display', 'none');
-        this.$next.css('display', 'inline');
+Mozilla.Pager.prototype.updateNavNextLink = function(disable) {
+    'use strict';
 
-    } else {
-        this.$nextInsensitive.css('display', 'inline');
-        this.$next.css('display', 'none');
-    }
-}
+    this.$next.prop('disabled', disable);
+};
 
 // }}}
 // {{{ setPage()
 
-Mozilla.Pager.prototype.setPage = function(page)
-{
+Mozilla.Pager.prototype.setPage = function(page) {
+    'use strict';
+
     if (this.currentPage !== page) {
         if (this.currentPage) {
             this.currentPage.deselectTab();
-            this.currentPage.hide(this.hideWithHiddenClass);
+            this.currentPage.hide();
         }
 
         if (this.previousPage) {
-            this.previousPage.hide(this.hideWithHiddenClass);
+            this.previousPage.hide();
         }
 
         this.previousPage = this.currentPage;
 
         this.currentPage = page;
-        this.currentPage.show(this.hideWithHiddenClass);
+        this.currentPage.show();
         this.update();
     }
-}
+};
 
 // }}}
 // {{{ setPageWithAnimation()
 
-Mozilla.Pager.prototype.setPageWithAnimation = function(page, duration)
-{
+Mozilla.Pager.prototype.setPageWithAnimation = function(page, duration) {
+    'use strict';
+
     if (this.currentPage !== page) {
 
         this.updateLocation(page);
@@ -643,7 +768,6 @@ Mozilla.Pager.prototype.setPageWithAnimation = function(page, duration)
 
         // fade out if we are not already fading out
         if (!this.animatingOut) {
-
             // if we were fading in, don't take as long to fade out
             if (this.$pageContainer.is(':animated')) {
                 var startOpacity = parseFloat(this.$pageContainer.css('opacity'));
@@ -662,6 +786,7 @@ Mozilla.Pager.prototype.setPageWithAnimation = function(page, duration)
             this.currentPage = page;
 
             var that = this;
+
             this.$pageContainer.animate(
                 { opacity: 0 },
                 duration,
@@ -681,35 +806,31 @@ Mozilla.Pager.prototype.setPageWithAnimation = function(page, duration)
 
     // for Safari 1.5.x bug setting window.location.
     return false;
-}
+};
 
 // }}}
 // {{{ fadeInPage()
 
-Mozilla.Pager.prototype.fadeInPage = function(duration)
-{
+Mozilla.Pager.prototype.fadeInPage = function(duration) {
+    'use strict';
+
     if (this.previousPage) {
-        this.previousPage.hide(this.hideWithHiddenClass);
+        this.previousPage.hide();
     }
 
-    this.currentPage.show(this.hideWithHiddenClass);
+    this.currentPage.show();
 
     this.animatingOut = false;
 
-    var that = this;
-    this.$pageContainer.animate({ opacity: 1 }, duration,
-        'pagerFadeOut', function() {
-            if (that.cleartypeFix && navigator.userAgent.indexOf('MSIE') !== -1) {
-                this.style.removeAttribute('filter');
-            }
-        });
-}
+    this.$pageContainer.animate({ opacity: 1 }, duration, 'pagerFadeOut');
+};
 
 // }}}
 // {{{ stopAutoRotate()
 
-Mozilla.Pager.prototype.stopAutoRotate = function()
-{
+Mozilla.Pager.prototype.stopAutoRotate = function() {
+    'use strict';
+
     if (this.autoRotateInterval) {
         clearInterval(this.autoRotateInterval);
         this.autoRotateInterval = null;
@@ -719,18 +840,17 @@ Mozilla.Pager.prototype.stopAutoRotate = function()
 // }}}
 // {{{ startAutoRotate()
 
-Mozilla.Pager.prototype.startAutoRotate = function()
-{
-    var setupInterval = function(pager)
-    {
-        var intervalFunction = function()
-        {
+Mozilla.Pager.prototype.startAutoRotate = function() {
+    'use strict';
+
+    var setupInterval = function(pager) {
+        var intervalFunction = function() {
             pager.nextPageWithAnimation(Mozilla.Pager.PAGE_AUTO_DURATION);
-        }
+        };
 
         pager.autoRotateInterval = setInterval(intervalFunction,
-            Mozilla.Pager.AUTO_ROTATE_INTERVAL, pager)
-    }
+            Mozilla.Pager.AUTO_ROTATE_INTERVAL, pager);
+    };
 
     if (!this.autoRotateInterval) {
         setupInterval(this);
@@ -744,40 +864,55 @@ Mozilla.Pager.prototype.startAutoRotate = function()
  * Page in a pager
  *
  * @param DOMElement el
+ * @param Number index
  * @param DOMElement tab
  */
-Mozilla.Page = function(el, index, tab, hideWithHiddenClass)
-{
-    this.el = el;
+Mozilla.Page = function(el, index, tab) {
+    'use strict';
 
-    if (!this.el.id) {
-        this.el.id = 'mozilla-pager-page-' + Mozilla.Page.currentId;
+    this.el = el;
+    this.$el = $(this.el);
+
+    // Make sure the Page has an ID.
+    if (!this.$el.prop('id')) {
+        this.$el.prop('id', 'mozilla-pager-page-' + Mozilla.Page.currentId);
         Mozilla.Page.currentId++;
     }
 
     // Change element id so updating the window.location does not navigate to
     // the page. This is mostly for IE.
-    if (this.el.id.substring(0, 5) == 'page-') {
+    if (this.el.id.substring(0, 5) === 'page-') {
         this.id = this.el.id.substring(5);
     } else {
         this.id = this.el.id;
     }
+
+    // Store original ID for revert when destroyed.
+    this.$el.data('orig-id', this.el.id);
 
     this.el.id = 'page-' + this.id;
     this.index = index;
 
     if (tab) {
         this.tab = tab;
-        this.tab.href = '#' + this.id;
         this.$tab = $(this.tab);
+
+        // Make sure the tab has an ID (for WAI-ARIA).
+        if (!this.$tab.prop('id')) {
+            this.$tab.prop('id', this.id + '-tab');
+        }
+
+        // Add WAI-ARIA support.
+        this.$el.attr({
+            'aria-labelledby': this.$tab.prop('id'),
+            'role': 'tabpanel'
+        });
     } else {
         this.tab = null;
     }
 
-    this.$el = $(this.el);
-
-    this.hide(hideWithHiddenClass);
-}
+    this.hide();
+};
 
 // }}}
 
@@ -785,55 +920,68 @@ Mozilla.Page.currentId = 1;
 
 // {{{ selectTab()
 
-Mozilla.Page.prototype.selectTab = function()
-{
+Mozilla.Page.prototype.selectTab = function() {
+    'use strict';
+
     if (this.tab) {
-        this.$tab.addClass('selected');
+        this.$tab.addClass('selected').attr('aria-selected', 'true');
     }
-}
+};
 
 // }}}
 // {{{ deselectTab()
 
-Mozilla.Page.prototype.deselectTab = function()
-{
+Mozilla.Page.prototype.deselectTab = function() {
+    'use strict';
+
     if (this.tab) {
-        this.$tab.removeClass('selected');
+        this.$tab.removeClass('selected').attr('aria-selected', 'false');
     }
-}
+};
 
 // }}}
 // {{{ focusTab()
 
-Mozilla.Page.prototype.focusTab = function()
-{
+Mozilla.Page.prototype.focusTab = function() {
+    'use strict';
+
     if (this.tab) {
         this.tab.focus();
     }
-}
+};
 
 // }}}
 // {{{ hide()
 
-Mozilla.Page.prototype.hide = function(hideWithHiddenClass)
-{
-    if (hideWithHiddenClass) {
-        this.$el.addClass('hidden');
-    } else {
-        this.el.style.display = 'none';
-    }
-}
+Mozilla.Page.prototype.hide = function() {
+    'use strict';
+
+    this.$el.addClass(Mozilla.Pager.HIDDEN_CLASS).attr('aria-hidden', 'true');
+};
 
 // }}}
 // {{{ show()
 
-Mozilla.Page.prototype.show = function(hideWithHiddenClass)
-{
-    if (hideWithHiddenClass) {
-        this.$el.removeClass('hidden');
-    } else {
-        this.el.style.display = 'block';
-    }
-}
+Mozilla.Page.prototype.show = function() {
+    'use strict';
+
+    this.$el.removeClass(Mozilla.Pager.HIDDEN_CLASS).attr('aria-hidden', 'false');
+};
 
 // }}}
+
+$(document).ready(function() {
+    'use strict';
+
+    // add easing functions
+    $.extend($.easing, {
+        'pagerFadeIn':  function (x, t, b, c, d) {
+            return c * (t /= d) * t + b;
+        },
+        'pagerFadeOut': function (x, t, b, c, d) {
+            return -c * (t /= d) * (t - 2) + b;
+        }
+    });
+
+    Mozilla.Pager.createPagers(true);
+});

--- a/media/js/firefox/channel.js
+++ b/media/js/firefox/channel.js
@@ -6,7 +6,7 @@ $(document).ready(function() {
     var $logo = $('#masthead h2 img');
     var logoOriginalSrc = $logo.attr('src');
 
-    var pager = Mozilla.Pager.rootPagers[0];
+    var pager = Mozilla.Pager.pagers[0];
     var selected_href = false;
 
     function redirect(a) {

--- a/media/js/firefox/desktop/tips.js
+++ b/media/js/firefox/desktop/tips.js
@@ -10,6 +10,7 @@
     var $tipPrev = $('#tip-prev');
     var $tipNext = $('#tip-next');
     var $tipsNavDirect = $('#tips-nav-direct');
+    var $tipsTabLinks = $tipsNavDirect.find('a');
     var $tipsNavDots = $('#tips-nav-dots');
 
     // only show download button for users on desktop platforms, using either a non-Firefox browser
@@ -25,7 +26,7 @@
         var currentURL = window.location.protocol + '//' + window.location.host + window.location.pathname + window.location.hash;
         gaTrack(['_trackEvent','/desktop/tips/ Interactions','page load', currentURL, 0, true]);
 
-        var pager = Mozilla.Pager.rootPagers[0];
+        var pager = Mozilla.Pager.pagers[0];
 
         // sets the current pager tab based on the url hash
         function setCurrentPage (noAnim) {
@@ -63,8 +64,8 @@
             var current = pager.currentPage.id.replace('-tip', '');
 
             // update direct nav links
-            $tipsNavDirect.find('a').removeClass('selected');
-            $tipsNavDirect.find('a[href="#' + current + '"]').addClass('selected');
+            $tipsTabLinks.removeClass('selected').attr('aria-selected', 'false');
+            $tipsNavDirect.find('a[href="#' + current + '"]').addClass('selected').attr('aria-selected', 'true');
 
             // update next/prev links
             if (pager.currentPage.index === 0) {

--- a/media/js/firefox/os/devices.js
+++ b/media/js/firefox/os/devices.js
@@ -3,7 +3,7 @@
 * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 // create namespace
-if (typeof Mozilla == 'undefined') {
+if (typeof Mozilla === 'undefined') {
     var Mozilla = {};
 }
 
@@ -13,8 +13,9 @@ if (typeof Mozilla == 'undefined') {
     var COUNTRY_CODE = '';
     var selectedDevice;
 
-    var isSmallViewport = $(window).width() < 760;
-    var isTouch = 'ontouchstart' in window || navigator.msMaxTouchPoints || navigator.maxTouchPoints || isSmallViewport;
+    // Will be used when color pickers are activated
+    //var isSmallViewport = $(window).width() < 760;
+    //var isTouch = 'ontouchstart' in window || navigator.msMaxTouchPoints || navigator.maxTouchPoints || isSmallViewport;
 
     var $purchaseDeviceButton = $('#purchase-device');
     var $locationSelect = $('#location');
@@ -22,12 +23,10 @@ if (typeof Mozilla == 'undefined') {
     var $deviceDetailLists = $('.device-detail-list');
     var $deviceDetails = $('.device-detail');
 
-    var $pagerPages = $('.pager-page');
-
     var $providerLinks = $('#provider-links');
 
     // create namespace
-    if (typeof Mozilla.FxOs == 'undefined') {
+    if (typeof Mozilla.FxOs === 'undefined') {
         Mozilla.FxOs = {};
     }
 
@@ -111,23 +110,14 @@ if (typeof Mozilla == 'undefined') {
     */
     var togglePagers = function(enable) {
         if (enable) {
-            $pagerPages.each(function(i, page) {
-                var $page = $(page);
-
-                $page.attr('style', $page.data('oldstyle')).data('oldstyle', '');
-            });
+            Mozilla.Pager.createPagers();
         } else {
-            $pagerPages.each(function(i, page) {
-                var $page = $(page);
-                $page.data('oldstyle', $page.attr('style'));
-
-                $page.attr('style', '');
-            });
+            Mozilla.Pager.destroyPagers();
         }
     };
 
     // wire up location select
-    $locationSelect.on('change', function(e) {
+    $locationSelect.on('change', function() {
         COUNTRY_CODE = $locationSelect.val();
         selectDevicesAndSetPartnerContent();
 
@@ -147,7 +137,7 @@ if (typeof Mozilla == 'undefined') {
     });
 
     // wire up thumbnail select
-    $('.device-thumbnails').on('click', '.device-thumbnail', function(e) {
+    $('.device-thumbnails').on('click', '.device-thumbnail', function() {
         var $this = $(this);
 
         selectedDevice = $this.attr('href').replace(/#/gi, '');
@@ -210,7 +200,7 @@ if (typeof Mozilla == 'undefined') {
             try {
                 COUNTRY_CODE = geoip_country_code().toLowerCase();
             } catch (e) {
-                COUNTRY_CODE = "";
+                COUNTRY_CODE = '';
             }
 
             if (COUNTRY_CODE !== '' && Mozilla.FxOs.Countries.hasOwnProperty(COUNTRY_CODE)) {
@@ -224,8 +214,8 @@ if (typeof Mozilla == 'undefined') {
     var queryIsMobile = matchMedia('(max-width: 480px)');
 
     setTimeout(function() {
-        if (queryIsMobile.matches) {
-            togglePagers(false);
+        if (!queryIsMobile.matches) {
+            togglePagers(true);
         }
     }, 500);
 
@@ -264,7 +254,7 @@ if (typeof Mozilla == 'undefined') {
     });
 
     // track mozilla pager tab clicks
-    $('.pager-tabs').on('click', 'a', function(e) {
+    $('.pager-tabs').on('click', 'a', function() {
         gaTrack(['_trackEvent', '/os/devices/ Interactions', selectedDevice + ' Interactions', $(this).data('label') + ' Tab']);
     });
 })(window.jQuery);

--- a/media/js/styleguide/docs/mozilla-pager.js
+++ b/media/js/styleguide/docs/mozilla-pager.js
@@ -1,0 +1,39 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+;(function($) {
+    'use strict';
+
+    // Customize global setting.
+    Mozilla.Pager.AUTO_ROTATE_INTERVAL = 4000;
+
+    var pager3;
+
+    $('#pager3-enable').on('click', function() {
+        if (!pager3) {
+            pager3 = new Mozilla.Pager($('#pager-example3'));
+        }
+    });
+
+    $('#pager3-disable').on('click', function() {
+        if (pager3) {
+            Mozilla.Pager.destroyPagerById(pager3.id);
+            pager3 = null;
+        }
+    });
+
+    // Bind custom next/previous buttons inside document ready
+    // to ensure pager is initialized.
+    $(function() {
+        var pager4 = Mozilla.Pager.findPagerById('pager-example4');
+
+        $('#next').on('click', function() {
+            pager4.nextPageWithAnimation();
+        });
+
+        $('#prev').on('click', function() {
+            pager4.prevPageWithAnimation();
+        });
+    });
+})(window.jQuery);


### PR DESCRIPTION
- Remove unused 'pager' JS bundle.
- Add docs pages for mozilla-pager (Bug 1007717).
- Add mozilla-pager.js demo page to styleguide (dev only).
- Add ARIA support for mozilla-pager.
- Add ability to create/destroy pagers.
- General performance/cleanup of mozilla-pager.js.
- Updated /firefox/desktop/tips/ and
  /firefox/channel/ to use newer pager features.
