### PR TITLE
Fix CSS issue with pager on /firefox/partners/. Bug 1030381.

### DIFF
--- a/media/css/firefox/partners.less
+++ b/media/css/firefox/partners.less
@@ -686,13 +686,6 @@
 /* }}} */
 /* {{{ Pager */
 
-.js .pager-page {
-    display: none;
-    &.default-page {
-        display: block;
-    }
-}
-
 .js .pager-tabs {
     display: block;
 }


### PR DESCRIPTION
#2106 changed the way pager pages show/hide. CSS here needed an update to play well with the new approach.
