### PR TITLE
Add Uruguay availability to ZTE Open C. Bug 1017186.

### DIFF
--- a/bedrock/firefox/templates/firefox/os/devices.html
+++ b/bedrock/firefox/templates/firefox/os/devices.html
@@ -930,6 +930,7 @@
                     <li>{{ _('Russia') }}</li>
                     <li>{{ _('United Kingdom') }}</li>
                     <li>{{ _('United States') }}</li>
+                    <li>{{ _('Uruguay') }}</li>
                   </ul>
                 </div>
               </div><!--/.features-->

--- a/media/js/firefox/os/partner_data.js
+++ b/media/js/firefox/os/partner_data.js
@@ -240,7 +240,7 @@ if (typeof Mozilla == 'undefined') {
         'zte_openc': {
             'type': 'smartphone',
             'display': 'ZTE Open C',
-            'countries': ['de', 'ru', 'gb', 'us']
+            'countries': ['de', 'ru', 'gb', 'us', 'uy']
         }
     };
 })(window.jQuery);


### PR DESCRIPTION
- May need to add ZTE Open C specific Movistar URL, waiting
  on carrier.
