### PR TITLE
[fix bug 1038734] Adjust tour menu panel highlight timing

### DIFF
--- a/media/js/firefox/australis/browser-tour.js
+++ b/media/js/firefox/australis/browser-tour.js
@@ -329,7 +329,9 @@ if (typeof Mozilla == 'undefined') {
         } else {
             Mozilla.UITour.hideMenu('appMenu');
         }
-        $stepTarget.delay(100).trigger('tour-step');
+        setTimeout(function () {
+            $stepTarget.trigger('tour-step');
+        }, 200);
     };
 
     /*


### PR DESCRIPTION
The menu panel in Nightly now animates when it opens, which means we need to use a slight delay on the web page when telling the panel to open before highlighting an item.

https://bugzilla.mozilla.org/show_bug.cgi?id=1038734

Note: I've switched to using `setTimeout` here instead of jQuery `delay()` as it turns out it doesn't actually work on event triggers :smile: 
