### PR TITLE
[fix bug 1040213] Poster images for HTML5 videos don't appear in IE9

### DIFF
--- a/bedrock/mozorg/templates/mozorg/contact/spaces/mountain-view.html
+++ b/bedrock/mozorg/templates/mozorg/contact/spaces/mountain-view.html
@@ -43,19 +43,22 @@
         <h3>{{ _('Creating in the Open') }}</h3>
         <p>{{ _('What do you do when you have a giant sphere in the middle of the office? Watch artist Andrew Shoultz paint it and talk about his process and inspiration.') }}</p>
 
-        <video controls preload="metadata" poster="{{ media('img/contact/poster-sphere.jpg') }}">
-          <source src="//videos.cdn.mozilla.net/uploads/drafts/Creating_in_the%20Open.webm" type="video/webm">
-          <source src="//videos.cdn.mozilla.net/uploads/drafts/Creating_in_the%20Open.mp4" type="video/mp4">
-          <figure>
-            <img src="{{ media('img/contact/poster-sphere.jpg') }}" alt="">
-            <figcaption>
-          {% trans link_webm='//videos.cdn.mozilla.net/uploads/drafts/Creating_in_the%20Open.webm',
-                   link_mp4='//videos.cdn.mozilla.net/uploads/drafts/Creating_in_the%20Open.mp4' %}
-            Download this video in <a href="{{ link_webm }}">WebM</a> or <a href="{{ link_mp4 }}">MP4</a>.
-          {% endtrans %}
-            <figcaption>
-          </figure>
-        </video>
+        <div class="moz-video-container">
+          <button class="moz-video-button" type="button" aria-controls="spaces-video">{{ _('Play video') }}</button>
+          <video id="spaces-video" poster="{{ media('img/contact/poster-sphere.jpg') }}" controls preload="metadata">
+            <source src="//videos.cdn.mozilla.net/uploads/drafts/Creating_in_the%20Open.webm" type="video/webm">
+            <source src="//videos.cdn.mozilla.net/uploads/drafts/Creating_in_the%20Open.mp4" type="video/mp4">
+            <figure>
+              <img src="{{ media('img/contact/poster-sphere.jpg') }}" alt="">
+              <figcaption>
+            {% trans link_webm='//videos.cdn.mozilla.net/uploads/drafts/Creating_in_the%20Open.webm',
+                     link_mp4='//videos.cdn.mozilla.net/uploads/drafts/Creating_in_the%20Open.mp4' %}
+              Download this video in <a href="{{ link_webm }}">WebM</a> or <a href="{{ link_mp4 }}">MP4</a>.
+            {% endtrans %}
+              </figcaption>
+            </figure>
+          </video>
+        </div>
       </section>
 
     </section>

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -142,6 +142,7 @@ MINIFY_BUNDLES = {
         'contact-spaces': (
             'css/libs/mapbox-1.6.3.css',
             'css/libs/magnific-popup.css',
+            'css/base/mozilla-video-poster.less',
             'css/mozorg/contact-spaces.less',
         ),
         'contact-spaces-ie7': (
@@ -452,6 +453,7 @@ MINIFY_BUNDLES = {
             'js/libs/jquery.history.js',
             'js/mozorg/contact-data.js',
             'js/libs/jquery.magnific-popup.min.js',
+            'js/base/mozilla-video-poster.js',
             'js/mozorg/contact-spaces.js',
         ),
         'contact-spaces-ie7': (

--- a/media/css/base/mozilla-video-poster.less
+++ b/media/css/base/mozilla-video-poster.less
@@ -1,0 +1,66 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+@import "../sandstone/lib.less";
+
+.moz-video-button {
+    display: none;
+}
+
+.js {
+    .moz-video-container {
+        position: relative;
+        width: 100%;
+        video {
+            z-index: 0;
+        }
+    }
+
+    .moz-video-button {
+        position: absolute;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        width: 100%;
+        border: none;
+        color: #fff;
+        z-index: 1;
+        cursor: pointer;
+        font-size: 0;
+        background-color: transparent;
+        background-position: top left;
+        background-repeat: no-repeat;
+        -webkit-background-size: cover;
+        background-size: cover;
+
+        &:after {
+            position: absolute;
+            top: 50%;
+            left: 50%;
+            content: '';
+            width: 100px;
+            height: 100px;
+            margin: -50px 0 0 -50px;
+            background: url(/media/img/sandstone/video/play.png) top left no-repeat;
+            .transition(opacity .3s);
+            opacity: 0.7;
+            z-index: 2;
+        }
+
+        &:hover:after,
+        &:focus:after {
+            opacity: 1;
+        }
+    }
+
+    .supports-video {
+        .moz-video-button {
+            display: block;
+        }
+        .moz-video-container video {
+            visibility: hidden;
+        }
+    }
+}

--- a/media/css/mozorg/contact-spaces.less
+++ b/media/css/mozorg/contact-spaces.less
@@ -508,6 +508,15 @@
     height: auto;
 }
 
+.js {
+    #mv-sphere-video {
+        .moz-video-button {
+            background-image: url(/media/img/contact/poster-sphere.jpg);
+        }
+    }
+}
+
+
 
 // @Category meta info
 // General footers for the tab content, one for spaces and one for community.

--- a/media/js/base/mozilla-video-poster.js
+++ b/media/js/base/mozilla-video-poster.js
@@ -1,0 +1,85 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/* A simple HTML5 Video poster image helper.
+ * https://bugzilla.mozilla.org/show_bug.cgi?id=1040213
+ * CSS Styles: 'media/css/base/mozilla-video-poster.less' */
+
+/* HTML markup:
+<div class="moz-video-container">
+  <button class="moz-video-button" type="button" aria-controls="some-video">{{ _('Play video') }}</button>
+  <video id="some-video"></video>
+</div>
+*/
+
+// create namespace
+if (typeof Mozilla === 'undefined') {
+    var Mozilla = {};
+}
+
+/*
+ * HTML5 Video poster image helper.
+ * @param selector (string) container for one or more video elements
+ */
+Mozilla.videoPosterHelper = function (selector) {
+    'use strict';
+
+    this.$container = $(selector);
+};
+
+/*
+ * If browser supports HTML5 Video show the poster button and bind events.
+ * Else fallback content will be displayed natively by the browser.
+ */
+Mozilla.videoPosterHelper.prototype.init = function () {
+    'use strict';
+
+    if (this.$container.length && this.supportsVideo()) {
+        this.showPoster();
+        this.bindEvents();
+    }
+}
+
+/*
+ * Check for HTML5 Video playback support
+ */
+Mozilla.videoPosterHelper.prototype.supportsVideo = function () {
+    'use strict';
+
+    return typeof HTMLMediaElement !== 'undefined';
+};
+
+/*
+ * Add CSS class to container to display .moz-video-button.
+ */
+Mozilla.videoPosterHelper.prototype.showPoster = function () {
+    'use strict';
+
+    this.$container.addClass('supports-video');
+};
+
+/*
+ * Bind click event to container and delegate events to .moz-video-button
+ */
+Mozilla.videoPosterHelper.prototype.bindEvents = function () {
+    'use strict';
+
+    this.$container.on('click.moz-video', '.moz-video-button', function () {
+        var $poster = $(this);
+        var $video = $poster.closest('.moz-video-container').find('video');
+        $video.css('visibility', 'visible');
+        $video[0].play();
+        $poster.hide();
+    });
+};
+
+/*
+ * Unbind events and hide overlay button
+ */
+Mozilla.videoPosterHelper.prototype.destroy = function () {
+    'use strict';
+
+    this.$container.off('click.moz-video');
+    this.$container.removeClass('supports-video');
+};

--- a/media/js/mozorg/contact-spaces.js
+++ b/media/js/mozorg/contact-spaces.js
@@ -93,6 +93,10 @@
                 gallery: { enabled: true },
                 type: 'image'
             });
+
+            // init HTML5 video poster helper
+            var video = new Mozilla.videoPosterHelper('#page-content');
+            video.init();
         },
 
         /*
@@ -170,6 +174,14 @@
                 // close any photo galleries that may have been open
                 $.magnificPopup.close();
             });
+
+            // If pushState is emulated (html4 browsers) and we have a hash (a '#' in the url)
+            // trigger the statechange event
+            if (History.emulated.pushState && History.getHash()) {
+                $(document).ready(function() {
+                    History.Adapter.trigger(window, 'statechange');
+                });
+            }
         },
 
         /*


### PR DESCRIPTION
- Adds a basic HTML5 Video Poster helper which we can use on the contact pages (and other parts of bedrock if the need arises).
- Also fixes a bug with `statechange` event sometimes not firing in IE8 on the contact pages.
