### PR TITLE
Remove unnecessary log.exception call

### DIFF
--- a/bedrock/facebookapps/utils.py
+++ b/bedrock/facebookapps/utils.py
@@ -26,7 +26,6 @@ def unwrap_signed_request(request):
     try:
         encoded_signed_request = request.REQUEST['signed_request']
     except KeyError:
-        log.exception('signed_request not set')
         return {}
 
     encoded_string_data = encoded_signed_request.partition('.')[2]


### PR DESCRIPTION
This is the most frequent event that shows up in production on errormill, with 51k events in the past week. Since this isn't actually an exception, I propose that we get rid of this noise.
