### PR TITLE
[fix bug 1047287] Firefox OS page Adaptive Phone section throwing error in IE9

### DIFF
--- a/media/js/firefox/os/desktop.js
+++ b/media/js/firefox/os/desktop.js
@@ -105,10 +105,15 @@
         // filter prop is applied via style attribte.
         // update the filter string to change the bg
         var cur_filter = $bg_a.css('filter');
-        var new_filter = cur_filter.replace(rotate_bg_re, new_bg);
 
-        // update bg_a classes and filter property
-        $bg_a.attr('class', css_classes).css('filter', new_filter);
+        if (cur_filter) {
+            var new_filter = cur_filter.replace(rotate_bg_re, new_bg);
+
+            // update bg_a classes and filter property
+            $bg_a.attr('class', css_classes).css('filter', new_filter);
+        } else {
+            $bg_a.attr('class', css_classes);
+        }
 
         $bg_a.fadeIn(300);
       } else {


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1047287

IE9 does not support transitions, so it uses the fallback animation method (which requires the IE specific stylesheet for the `filter` properties on background images). This checks if the `filter` property is present, and if not just assumes to use `background` instead.
