### PR TITLE
Change download buttons to point to /firefox/new/

### DIFF
--- a/bedrock/mozorg/helpers/download_buttons.py
+++ b/bedrock/mozorg/helpers/download_buttons.py
@@ -27,7 +27,7 @@ nightly_android = ('https://ftp.mozilla.org/pub/mozilla.org/mobile/nightly/'
                    'latest-mozilla-aurora-android')
 
 download_urls = {
-    'transition': '/{locale}/firefox/new/#download-fx',
+    'transition': '/firefox/new/#download-fx',
     'direct': 'https://download.mozilla.org/',
     'aurora': nightly_desktop,
     'aurora-l10n': nightly_desktop + '-l10n',
@@ -115,9 +115,9 @@ def make_download_link(product, build, version, platform, locale,
     if funnelcake_id:
         version = '{vers}-f{fc}'.format(vers=version, fc=funnelcake_id)
 
-    # Figure out the base url. certain locales have a transitional
-    # thankyou-style page (most do)
-    if force_direct or locale not in settings.LOCALES_WITH_TRANSITION:
+    # Check if direct download link has been requested
+    # (bypassing the transition page)
+    if force_direct:
         # build a direct download link
         tmpl = '?'.join([download_urls['direct'],
                         'product={prod}-{vers}&os={plat}&lang={locale}'])

--- a/bedrock/mozorg/tests/test_helper_download_buttons.py
+++ b/bedrock/mozorg/tests/test_helper_download_buttons.py
@@ -322,17 +322,6 @@ class TestDownloadButtons(TestCase):
         list = doc('.download-other .arch')
         eq_(list.length, 0)
 
-    def test_download_transition_link_contains_locale(self):
-        """
-        "transition" download links should include the locale in the path as
-        well as the query string.
-        """
-        locale = settings.LOCALES_WITH_TRANSITION[0]
-        url = make_download_link('firefox', 'release', '19.0', 'os_osx', locale)
-        good_url = ('/{locale}/products/download.html?product=firefox-19.0-SSL&'
-                    'os=osx&lang={locale}').format(locale=locale)
-        eq_(url, good_url)
-
     @override_settings(STUB_INSTALLER_LOCALES={'win': ['en-us']})
     def test_force_funnelcake(self):
         """

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -862,20 +862,6 @@ BASKET_URL = 'http://basket.mozilla.com'
 # work on the dev site while we have a mix of Python/PHP
 FORCE_SLASH_B = False
 
-# Locals with transitional download pages
-LOCALES_WITH_TRANSITION = ['en-US', 'af', 'ar', 'ast', 'be', 'bg',
-                           'bn-BD', 'bn-IN', 'ca', 'cs', 'cy', 'da',
-                           'de', 'el', 'eo', 'es-AR', 'es-CL', 'es-ES',
-                           'es-MX', 'et', 'eu', 'fa', 'fi', 'fr',
-                           'fy-NL', 'ga-IE', 'gd', 'gl', 'gu-IN',
-                           'he', 'hi-IN', 'hr', 'hu', 'hy-AM', 'id',
-                           'is', 'it', 'ja', 'kk', 'kn', 'ko', 'ku',
-                           'lt', 'lv', 'mk', 'ml', 'mr', 'nb-NO',
-                           'nl', 'or', 'pa-IN', 'pl', 'pt-BR', 'pt-PT',
-                           'rm', 'ro', 'ru', 'si', 'sk', 'sl', 'sq',
-                           'sr', 'sv-SE', 'ta', 'ta-LK', 'te', 'th',
-                           'tr', 'uk', 'vi', 'zh-CN', 'zh-TW']
-
 # reCAPTCHA keys
 RECAPTCHA_PUBLIC_KEY = ''
 RECAPTCHA_PRIVATE_KEY = ''


### PR DESCRIPTION
Download links will point to the second scene of download page
with the url fragment /firefox/new/#download-fx
[Bug 874913](https://bugzilla.mozilla.org/show_bug.cgi?id=874913)
