### PR TITLE
Bug 1008653 - History slides, add CSS fixes for km, uz

### DIFF
--- a/media/css/mozorg/history-slides.less
+++ b/media/css/mozorg/history-slides.less
@@ -290,6 +290,11 @@
     }
 }
 
+// Base fixes for locales
+[lang='km'] .on .message {
+    line-height: 1.4;
+}
+
 // Slides going from 'ready' to 'in'
 .on .animate-in {
     .number,
@@ -1002,7 +1007,8 @@
 // Fact @06 Fixes for specific locales
 [lang='lt'] .on #fact06 .message,
 [lang='pl'] .on #fact06 .message,
-[lang='sr'] .on #fact06 .message {
+[lang='sr'] .on #fact06 .message,
+[lang='uz'] .on #fact06 .message {
     padding: 25px 130px 15px 50px;
 }
 
@@ -1806,7 +1812,8 @@
 }
 
 // Fact @13 Fixes for specific locales
-[lang='pl'] .on #fact13 .message {
+[lang='pl'] .on #fact13 .message,
+[lang='uz'] .on #fact13 .message {
     padding: 30px 40px 25px 40px;
 }
 


### PR DESCRIPTION
I reused the old bug since I don't expect many more locales to come in.
- km: some glyphs override, no point in keeping a small line-height since their text is pretty short
- uz: a couple of slides need less margin on top
