### PR TITLE
Update title on Firefox desktop home page. Bug 1048964.

### DIFF
--- a/bedrock/firefox/templates/firefox/desktop/index.html
+++ b/bedrock/firefox/templates/firefox/desktop/index.html
@@ -5,7 +5,13 @@
 {% extends "firefox/desktop/desktop-base.html" %}
 
 {% block page_title_prefix %}{% endblock %}
-{% block page_title %}{{ _("Firefox Web browser — Trusted, Flexible, Fast — There's never been a better time") }}{% endblock %}
+{% block page_title %}
+  {% if l10n_has_tag('home_title_update') or settings.DEV %}
+    {{ _("Firefox Web browser — Trusted, Flexible, Fast — Committed to you, your privacy and an open Web") }}
+  {% else %}
+    {{ _("Firefox Web browser — Trusted, Flexible, Fast — There's never been a better time") }}
+  {% endif %}
+{% endblock %}
 
 {% block site_css %}
   {{ css('firefox_desktop') }}


### PR DESCRIPTION
~~Checking if we need to wait for L10n...~~

Using the `l10n_has_tag`, so we should be good.

@flodolo - Does the L10n tag look okay? Any reason we should wait to merge?
