### PR TITLE
[bug 1048689] sync cta doesn't appear on whats new

### DIFF
--- a/bedrock/firefox/templates/firefox/australis/firstrun-tour.html
+++ b/bedrock/firefox/templates/firefox/australis/firstrun-tour.html
@@ -144,7 +144,7 @@
       <p>{{ _('You don’t have to start over. Access your history, bookmarks and more.')}}</p>
     </header>
     <div class="sync-cta">
-      <button class="button">{{ _('Get started with Sync') }}</button>
+      <a href="{{ url('firefox.sync') }}" class="button">{{ _('Get started with Sync') }}</a>
       <small>{{ _('Create an account from the menu panel') }}</small>
     </div>
   </div>

--- a/bedrock/firefox/templates/firefox/australis/whatsnew-tour.html
+++ b/bedrock/firefox/templates/firefox/australis/whatsnew-tour.html
@@ -149,7 +149,7 @@
       <p>{{ _('Access your bookmarks, passwords and more from any device.')}}</p>
     </header>
     <div class="sync-cta">
-      <button class="button">{{ _('Get started with Sync') }}</button>
+      <a href="{{ url('firefox.sync') }}" class="button">{{ _('Get started with Sync') }}</a>
       <small>{{ _('Create an account from the menu panel') }}</small>
     </div>
   </div>

--- a/media/css/firefox/australis/australis-page-common.less
+++ b/media/css/firefox/australis/australis-page-common.less
@@ -145,8 +145,7 @@ header[role="banner"],
     overflow: hidden;
     background: #f7f7f7;
     text-align: center;
-    button {
-        display: block;
+    .button {
         position: relative;
         .open-sans-light;
         font-size: 18px;
@@ -164,6 +163,8 @@ header[role="banner"],
         }
     }
     small {
+        display: block;
+        margin-top: .5em;
         font-style: italic;
         color: #949899;
     }
@@ -171,10 +172,6 @@ header[role="banner"],
 
 .sync-anim {
     margin: 40px auto;
-}
-
-.sync-cta {
-    display: none;
 }
 
 .share {

--- a/media/js/firefox/australis/common.js
+++ b/media/js/firefox/australis/common.js
@@ -28,6 +28,8 @@
         e.preventDefault();
         e.stopPropagation();
         Mozilla.UITour.showHighlight('accountStatus', 'wobble');
+        // temp fix for Bug 1049130
+        Mozilla.UITour.showHighlight('accountStatus', 'wobble');
 
         // hide app menu when user clicks anywhere on the page
         $(document.body).one('click', function () {
@@ -73,7 +75,7 @@
     }
 
     // show sync in menu when user clicks cta
-    $('.sync-cta button').on('click', showSyncInMenu);
+    $('.sync-cta').on('click', '.menu-cta', showSyncInMenu);
 
     // track learn more links on click
     $('.learn-more a').on('click', trackLearnMoreLinks);

--- a/media/js/firefox/australis/no-tour.js
+++ b/media/js/firefox/australis/no-tour.js
@@ -8,10 +8,12 @@
 
         // if user has Sync already, don't show the page prommo
         Mozilla.UITour.getConfiguration('sync', function (config) {
+            var $syncButton = $('.sync-cta').find('.button');
             var visible = '';
 
             if (config.setup === false) {
-                $('.sync-cta').show();
+                $syncButton.attr('role', 'button');
+                $syncButton.addClass('menu-cta');
                 visible = 'YES';
             } else if (config.setup === true) {
                 // Hide Sync section in post tour-page

--- a/media/js/firefox/australis/tour.js
+++ b/media/js/firefox/australis/tour.js
@@ -8,6 +8,7 @@
 
         // Query if the UITour API is working before we start the tour
         Mozilla.UITour.getConfiguration('sync', function (config) {
+            var $syncButton = $('.sync-cta').find('.button');
             var visible = '';
 
             // if user has submitted newsletter don't show the tour again
@@ -23,7 +24,8 @@
 
             // if user has Sync already, don't show the page prommo
             if (config.setup === false) {
-                $('.sync-cta').show();
+                $syncButton.attr('role', 'button');
+                $syncButton.addClass('menu-cta');
                 visible = 'YES';
             } else if (config.setup === true) {
                 // Hide Sync section in post tour-page


### PR DESCRIPTION
Currently the Sync CTA on `firefox/31.0/whatsnew` and `firefox/31.0/firstrun` requires the UITour API to work, as it highlights the menu panel when clicked. This PR adds a fallback state that simply links the button to the `firefox/sync` page, should the UITour API not work for some reason (or JS be disabled).

This has come to light as it turns out there is a long-standing [Firefox bug](https://bugzilla.mozilla.org/show_bug.cgi?id=506446) where the preferences for things like UITour can get reset incorrectly. This bug is being escalated to be fixed now, but this should provide a fallback for the Sync CTA in the interim.

Note: you can test this works by setting `browser.uitour.enabled` to `false` in `about:config`
