### PR TITLE
[bug 1016500] Fix image rotation on manifesto page

### DIFF
--- a/bedrock/mozorg/templates/mozorg/about/manifesto.html
+++ b/bedrock/mozorg/templates/mozorg/about/manifesto.html
@@ -310,15 +310,15 @@
       </div>
       <div id="mosaic-group-1" class="ri-grid">
         <ul>
-        {% for i in range(1, 37)|list|shuffle %}
+        {% for i in range(1, 40)|list|shuffle %}
           <li><a><img data-src="{{ media('img/mozorg/about/manifesto/mosaic/' ~ '%03d'|format(i) ~ '.jpg') }}" alt=""></a></li>
         {% endfor %}
         </ul>
       </div>
       <div id="mosaic-group-2" class="ri-grid">
         <ul>
-        {# The grid needs 34 + extra images to rotate. That's why there are some duplicated images. #}
-        {% for i in range(33, 69)|list|shuffle %}
+        {# The grid needs 36 + extra images to rotate. That's why there are some duplicated images. #}
+        {% for i in range(30, 69)|list|shuffle %}
           <li><a><img data-src="{{ media('img/mozorg/about/manifesto/mosaic/' ~ '%03d'|format(i) ~ '.jpg') }}" alt=""></a></li>
         {% endfor %}
         </ul>
@@ -335,8 +335,8 @@
   <!--[if IE 9]>
     {{ js('manifesto_ie9') }}
   <![endif]-->
-  {{ js('manifesto') }}
   {{ js('mosaic') }}
+  {{ js('manifesto') }}
 {% endblock %}
 
   {#- End the redesigned landing page -#}


### PR DESCRIPTION
We added 2 more rows of images to the manifesto page in #2185, but I forgot to increase the source list which meant the images weren't fading in/out.
