### PR TITLE
[no bug] Add grunt task to remove generated less.css files for development

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -47,7 +47,8 @@ module.exports = function (grunt) {
           unit: {
             configFile: 'media/js/test/karma.conf.js'
           }
-        }
+        },
+        clean: ['media/css/**/*.less.css']
     });
 
     // Update the config to only build the changed files.
@@ -59,6 +60,7 @@ module.exports = function (grunt) {
         grunt.config(['jshint', 'development'], [filepath]);
     });
 
+    grunt.loadNpmTasks('grunt-contrib-clean');
     grunt.loadNpmTasks('grunt-contrib-less');
     grunt.loadNpmTasks('grunt-contrib-jshint');
     grunt.loadNpmTasks('grunt-contrib-watch');

--- a/docs/grunt.rst
+++ b/docs/grunt.rst
@@ -79,3 +79,15 @@ To perform a single run of the test suite, type the following command::
 
     The Tabzilla tests require that you have your local bedrock development server running on port 8000.
 
+
+Cleaning generated CSS files
+----------------------------
+
+Bedrock uses `Less <http://lesscss.org/>`_ to generate CSS files. Sometimes during development you may
+want to clear out your cached CSS that gets generated. To make this easier, you can clear all
+``*.less.css`` files located in ``media/css/`` directories with the following command::
+
+    grunt clean
+
+
+

--- a/package.json
+++ b/package.json
@@ -21,21 +21,22 @@
   "devDependencies": {
     "grunt": "~0.4.2",
     "grunt-cli": "~0.1.11",
-    "grunt-contrib-watch": "~0.5.3",
+    "grunt-contrib-clean": "^0.6.0",
     "grunt-contrib-jshint": "~0.8.0",
     "grunt-contrib-less": "~0.9.0",
-    "karma-script-launcher": "~0.1.0",
+    "grunt-contrib-watch": "~0.5.3",
+    "grunt-karma": "~0.6.2",
+    "karma": "~0.10.9",
     "karma-chrome-launcher": "~0.1.2",
+    "karma-coffee-preprocessor": "~0.1.3",
     "karma-firefox-launcher": "~0.1.3",
     "karma-html2js-preprocessor": "~0.1.0",
     "karma-jasmine": "~0.1.5",
-    "karma-coffee-preprocessor": "~0.1.3",
-    "requirejs": "~2.1.11",
-    "karma-requirejs": "~0.2.1",
+    "karma-junit-reporter": "~0.2.1",
     "karma-phantomjs-launcher": "~0.1.2",
-    "karma": "~0.10.9",
-    "grunt-karma": "~0.6.2",
-    "sinon": "~1.8.2",
-    "karma-junit-reporter": "~0.2.1"
+    "karma-requirejs": "~0.2.1",
+    "karma-script-launcher": "~0.1.0",
+    "requirejs": "~2.1.11",
+    "sinon": "~1.8.2"
   }
 }


### PR DESCRIPTION
This adds a `grunt clean` task that will remove all generated `less.css` files from the `media/css/` directory. Useful if you want to be sure you're not seeing a cached CSS file when reviewing a PR for instance.
