### PR TITLE
Add docs for mozilla-accordion.js. Bug 1007717.

### DIFF
--- a/bedrock/firefox/templates/firefox/android/faq.html
+++ b/bedrock/firefox/templates/firefox/android/faq.html
@@ -30,10 +30,10 @@
 
 <div id="main-content">
 
-  <div id="faq" class="accordion zebra" role="tablist" aria-multiselectable="true">
+  <div id="faq" class="accordion zebra">
     <section>
-      <h2 role="tab" aria-expanded="false">{{_('About Firefox for Android')}}</h2>
-      <div role="tabpanel">
+      <h2 data-accordion-role="tab">{{_('About Firefox for Android')}}</h2>
+      <div data-accordion-role="tabpanel">
         <dl class="faq">
 
         {% trans %}
@@ -81,8 +81,8 @@
       </div>
     </section>
     <section>
-      <h2 role="tab" aria-expanded="false">{{_('Downloading Firefox')}}</h2>
-      <div role="tabpanel">
+      <h2 data-accordion-role="tab">{{_('Downloading Firefox')}}</h2>
+      <div data-accordion-role="tabpanel">
         <dl class="faq">
         {% trans %}
           <dt>Where can I download Firefox for Android?</dt>
@@ -97,8 +97,8 @@
       </div>
     </section>
     <section>
-      <h2 role="tab" aria-expanded="false">{{_('Using Firefox')}}</h2>
-      <div role="tabpanel">
+      <h2 data-accordion-role="tab">{{_('Using Firefox')}}</h2>
+      <div data-accordion-role="tabpanel">
         <dl class="faq">
         {% trans %}
           <dt>How do I&hellip;</dt>
@@ -127,8 +127,8 @@
       </div>
     </section>
     <section>
-      <h2 role="tab" aria-expanded="false">{{_('Features')}}</h2>
-      <div role="tabpanel">
+      <h2 data-accordion-role="tab">{{_('Features')}}</h2>
+      <div data-accordion-role="tabpanel">
         <dl class="faq">
           {% trans %}
           <dt>How do I use the start page?</dt>
@@ -163,8 +163,8 @@
       </div>
     </section>
     <section>
-      <h2 role="tab" aria-expanded="false">{{_('Privacy and Security')}}</h2>
-      <div role="tabpanel">
+      <h2 data-accordion-role="tab">{{_('Privacy and Security')}}</h2>
+      <div data-accordion-role="tabpanel">
         <dl class="faq">
 
           {% trans %}
@@ -195,8 +195,8 @@
       </div>
     </section>
     <section>
-      <h2 role="tab" aria-expanded="false">{{_('Developer Questions')}}</h2>
-      <div role="tabpanel">
+      <h2 data-accordion-role="tab">{{_('Developer Questions')}}</h2>
+      <div data-accordion-role="tabpanel">
       {% trans %}
         <p>Are you a developer with questions? <a href="https://developer.mozilla.org/en/Mozilla/Firefox_for_Android">Learn more on Mozilla's Developer Network</a></p>
       {% endtrans %}

--- a/bedrock/firefox/templates/firefox/dnt.html
+++ b/bedrock/firefox/templates/firefox/dnt.html
@@ -61,12 +61,12 @@
 {% endtrans %}
 </p>
 
-<section id="faq" class="accordion zebra" role="tablist" aria-multiselectable="true">
+<section id="faq" class="accordion zebra">
 <h2>{{ _('Frequently Asked <span>Questions</span>') }}</h2>
 
 <section>
-  <h3 role="tab" aria-expanded="false">{{ _('What is Do Not Track?') }}</h3>
-  <div role="tabpanel">
+  <h3 data-accordion-role="tab">{{ _('What is Do Not Track?') }}</h3>
+  <div data-accordion-role="tabpanel">
     <p>
       {% trans %}
         Do Not Track is a step toward putting you in control of the way your
@@ -80,8 +80,8 @@
 </section>
 
 <section>
-  <h3 role="tab" aria-expanded="false">{{ _('Is Do Not Track available on Firefox for Android?') }}</h3>
-  <div role="tabpanel">
+  <h3 data-accordion-role="tab">{{ _('Is Do Not Track available on Firefox for Android?') }}</h3>
+  <div data-accordion-role="tabpanel">
     <p>
       {% trans %}
         Yes. Firefox for Android is the first mobile Web browser to offer
@@ -95,8 +95,8 @@
 </section>
 
 <section>
-  <h3 role="tab" aria-expanded="false">{{ _('Does Do Not Track block ads?') }}</h3>
-  <div role="tabpanel">
+  <h3 data-accordion-role="tab">{{ _('Does Do Not Track block ads?') }}</h3>
+  <div data-accordion-role="tabpanel">
     <p>
       {% trans %}
         No, you will still see ads with Do Not Track enabled. However, Do Not Track
@@ -110,8 +110,8 @@
 </section>
 
 <section>
-  <h3 role="tab" aria-expanded="false">{{ _('How does Do Not Track work with other privacy tools?') }}</h3>
-  <div role="tabpanel">
+  <h3 data-accordion-role="tab">{{ _('How does Do Not Track work with other privacy tools?') }}</h3>
+  <div data-accordion-role="tabpanel">
     <p>
       {% trans url=url('firefox.desktop.trust') %}
         Do Not Track is one of many privacy solutions. Do Not Track does not replace your
@@ -124,8 +124,8 @@
 </section>
 
 <section>
-  <h3 role="tab" aria-expanded="false">{{ _('Will Do Not Track affect the rest of my Web experience?') }}</h3>
-  <div role="tabpanel">
+  <h3 data-accordion-role="tab">{{ _('Will Do Not Track affect the rest of my Web experience?') }}</h3>
+  <div data-accordion-role="tabpanel">
     <p>
     {% trans %}
       Do Not Track may interfere with some personalized services you enjoy. For example,
@@ -139,8 +139,8 @@
 </section>
 
 <section>
-  <h3 role="tab" aria-expanded="false">{{ _('How do I enable Do Not Track in Firefox?') }}</h3>
-  <div role="tabpanel">
+  <h3 data-accordion-role="tab">{{ _('How do I enable Do Not Track in Firefox?') }}</h3>
+  <div data-accordion-role="tabpanel">
     <p>
       {% trans id='platform-note' %}
         This feature is not enabled by default. You can find the Do Not Track
@@ -166,8 +166,8 @@
 </section>
 
 <section>
-  <h3 role="tab" aria-expanded="false">{{ _('Will companies honor my Do Not Track preference?') }}</h3>
-  <div role="tabpanel">
+  <h3 data-accordion-role="tab">{{ _('Will companies honor my Do Not Track preference?') }}</h3>
+  <div data-accordion-role="tabpanel">
     <p>
     {% trans %}
       Companies are starting to support Do Not Track, but you may not notice any changes
@@ -179,8 +179,8 @@
 </section>
 
 <section>
-  <h3 role="tab" aria-expanded="false">{{ _('Where can I learn more?') }}</h3>
-  <div role="tabpanel">{{ _('Other interesting work about Do Not Track and online privacy:') }}
+  <h3 data-accordion-role="tab">{{ _('Where can I learn more?') }}</h3>
+  <div data-accordion-role="tabpanel">{{ _('Other interesting work about Do Not Track and online privacy:') }}
     <ul style='list-style-position:inside'>
       <li>
         {{ _('<a href="%s">Private browsing</a> in Firefox &#8212; limits saving data about which sites and pages you have visited online')|format('https://support.mozilla.org/en-US/kb/Private%20Browsing') }}

--- a/bedrock/firefox/templates/firefox/geolocation.html
+++ b/bedrock/firefox/templates/firefox/geolocation.html
@@ -34,12 +34,12 @@
 
 <div class="main-column">
 
-<section id="faq" class="accordion zebra" role="tablist" aria-multiselectable="true">
+<section id="faq" class="accordion zebra">
 <h2>{{ _('Frequently asked Questions') }}</h2>
 
 <section>
-  <h3 role="tab" aria-expanded="false">{{ _('What is Location-Aware Browsing?') }}</h3>
-  <div role="tabpanel">
+  <h3 data-accordion-role="tab">{{ _('What is Location-Aware Browsing?') }}</h3>
+  <div data-accordion-role="tabpanel">
     <p>
     {% trans %}
       Websites that use location-aware browsing will ask where you are in
@@ -63,8 +63,8 @@
 </section>
 
 <section>
-  <h3 role="tab" aria-expanded="false">{{ _('How does it work?') }}</h3>
-  <div role="tabpanel">
+  <h3 data-accordion-role="tab">{{ _('How does it work?') }}</h3>
+  <div data-accordion-role="tabpanel">
     <p>{{ _('When you visit a location-aware website, Firefox will ask you if you want to share your location.') }}</p>
     <p>
     {% trans %}
@@ -80,8 +80,8 @@
 </section>
 
 <section>
-  <h3 role="tab" aria-expanded="false">{{ _('How accurate are the locations?') }}</h3>
-  <div role="tabpanel">
+  <h3 data-accordion-role="tab">{{ _('How accurate are the locations?') }}</h3>
+  <div data-accordion-role="tabpanel">
     <p>
     {% trans %}
       Accuracy varies greatly from location to location.  In some places, our
@@ -96,12 +96,12 @@
 </section>
 
 <section>
-  <h3 role="tab" aria-expanded="false">
+  <h3 data-accordion-role="tab">
   {% trans %}
     What information is being sent, and to whom? How is my privacy protected?
   {% endtrans %}
   </h3>
-  <div role="tabpanel">
+  <div data-accordion-role="tabpanel">
     <p>
     {% trans %}
       Your privacy is extremely important to us, and Firefox never shares your
@@ -151,8 +151,8 @@
 </section>
 
 <section>
-  <h3 role="tab" aria-expanded="false">{{ _('Am I being tracked as I browse the web?') }}</h3>
-  <div role="tabpanel">
+  <h3 data-accordion-role="tab">{{ _('Am I being tracked as I browse the web?') }}</h3>
+  <div data-accordion-role="tabpanel">
     <p>
     {% trans %}
       No. Firefox only requests a location when a website makes a request, and
@@ -164,8 +164,8 @@
 </section>
 
 <section id="undo-permission">
-  <h3 role="tab" aria-expanded="false">{{ _('How do I undo a permission granted to a site?') }}</h3>
-  <div role="tabpanel">
+  <h3 data-accordion-role="tab">{{ _('How do I undo a permission granted to a site?') }}</h3>
+  <div data-accordion-role="tabpanel">
     <p>
     {% trans %}
       If you've given Firefox permission to always give your location to a site
@@ -183,8 +183,8 @@
 </section>
 
 <section>
-  <h3 role="tab" aria-expanded="false">{{ _('How do I turn off Location-Aware Browsing permanently?') }}</h3>
-  <div role="tabpanel">
+  <h3 data-accordion-role="tab">{{ _('How do I turn off Location-Aware Browsing permanently?') }}</h3>
+  <div data-accordion-role="tabpanel">
     <p>
     {% trans %}
       Location-Aware Browsing is always opt-in in Firefox. No location

--- a/bedrock/firefox/templates/firefox/os/faq.html
+++ b/bedrock/firefox/templates/firefox/os/faq.html
@@ -20,10 +20,10 @@
 
 <div id="main-content">
 
-  <div id="faq" class="accordion zebra" role="tablist" aria-multiselectable="true">
+  <div id="faq" class="accordion zebra">
     <section>
-      <h2 role="tab" aria-expanded="false">{{_('About Firefox OS')}}</h2>
-      <div role="tabpanel">
+      <h2 data-accordion-role="tab">{{_('About Firefox OS')}}</h2>
+      <div data-accordion-role="tabpanel">
         <dl class="faq">
 
           <dt>{{_('What is Firefox OS?')}}</dt>
@@ -50,8 +50,8 @@
       </div>
     </section>
     <section>
-      <h2 role="tab" aria-expanded="false">{{_('Buying Firefox OS')}}</h2>
-      <div role="tabpanel">
+      <h2 data-accordion-role="tab">{{_('Buying Firefox OS')}}</h2>
+      <div data-accordion-role="tabpanel">
         <dl class="faq">
 
           <dt>{{_('What phones will Firefox OS be available on?')}}</dt>
@@ -132,8 +132,8 @@
       </div>
     </section>
     <section>
-      <h2 role="tab" aria-expanded="false">{{_('Using Firefox OS')}}</h2>
-      <div role="tabpanel">
+      <h2 data-accordion-role="tab">{{_('Using Firefox OS')}}</h2>
+      <div data-accordion-role="tabpanel">
         <dl class="faq">
 
           <dt>{{_('How do I…')}}</dt>
@@ -167,8 +167,8 @@
       </div>
     </section>
     <section>
-      <h2 role="tab" aria-expanded="false">{{_('Features')}}</h2>
-      <div role="tabpanel">
+      <h2 data-accordion-role="tab">{{_('Features')}}</h2>
+      <div data-accordion-role="tabpanel">
         <dl class="faq">
 
           <dt>{{_('Adaptive App Search')}}</dt>
@@ -181,8 +181,7 @@
           <dd>{{_('The fast, smart, safe way to get the best of the Web.')}}</dd>
 
           <dt>{{_('Deep integration with social media')}}</dt>
-          <dd>{{_('Full access to every Twitter and Facebook update from wherever you are.
-')}}</dd>
+          <dd>{{_('Full access to every Twitter and Facebook update from wherever you are.')}}</dd>
 
           <dt>{{_('Camera')}}</dt>
           <dd>{{_('With built-in style filters for fun, creative shots.')}}</dd>
@@ -196,8 +195,8 @@
       </div>
     </section>
     <section>
-      <h2 role="tab" aria-expanded="false">{{_('Privacy and Security')}}</h2>
-      <div role="tabpanel">
+      <h2 data-accordion-role="tab">{{_('Privacy and Security')}}</h2>
+      <div data-accordion-role="tabpanel">
           <p>
           {{_('Mozilla was the first to implement the Do Not Track privacy feature.')}}
           {% trans url='https://support.mozilla.org/kb/how-turn-do-not-track-feature-firefox-os' %}
@@ -207,8 +206,8 @@
       </div>
     </section>
     <section>
-      <h2 role="tab" aria-expanded="false">{{_('Developer Questions')}}</h2>
-      <div role="tabpanel">
+      <h2 data-accordion-role="tab">{{_('Developer Questions')}}</h2>
+      <div data-accordion-role="tabpanel">
           <p>{% trans url='https://developer.mozilla.org/docs/Mozilla/Firefox_OS' %}
           Are you a developer? Have questions? <a href="{{url}}">Learn more at the Mozilla Developer Network.</a>
           {% endtrans %}</p>

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -384,6 +384,10 @@ MINIFY_BUNDLES = {
             'css/styleguide/communications.less',
             'css/styleguide/products-firefox-os.less',
         ),
+        'styleguide-docs-mozilla-accordion': (
+            'css/base/mozilla-accordion.less',
+            'css/sandstone/sandstone-resp.less',
+        ),
         'styleguide-docs-mozilla-pager': (
             'css/styleguide/docs/mozilla-pager.less',
         ),
@@ -677,6 +681,9 @@ MINIFY_BUNDLES = {
         ),
         'styleguide': (
             'js/styleguide/styleguide.js',
+        ),
+        'styleguide-docs-mozilla-accordion': (
+            'js/base/mozilla-accordion.js',
         ),
         'styleguide-docs-mozilla-pager': (
             'js/base/mozilla-pager.js',

--- a/bedrock/styleguide/templates/styleguide/docs/mozilla-accordion.html
+++ b/bedrock/styleguide/templates/styleguide/docs/mozilla-accordion.html
@@ -1,0 +1,67 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+
+{% extends "mozorg/base-resp.html" %}
+
+{% block page_title %}{{ _('mozilla-accordion.js example') }}{% endblock %}
+{% block body_id %}mozilla-accordion{% endblock %}
+{% block body_class %}sand{% endblock %}
+
+{% block site_css %}
+  {{ css('styleguide-docs-mozilla-accordion') }}
+{% endblock %}
+
+{% block content %}
+<article id="main-content">
+  <h1>{{ _('mozilla-accordion.js Example') }}</h1>
+
+  <section class="accordion example" id="example1">
+    <h2>{{ _('Basic accordion') }}</h2>
+
+    <section>
+      <h4 data-accordion-role="tab">{{ _('Section 1') }}</h4>
+
+      <div data-accordion-role="tabpanel">
+        <p>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur nec
+          odio vel metus vestibulum tempus. Integer imperdiet mollis pulvinar.
+          Praesent consectetur sagittis lacus, quis gravida mauris imperdiet in.
+          Fusce pretium, mi et tempus lobortis, lectus nunc mollis risus, sit amet
+          tempor eros eros eget nisl. Etiam quis placerat augue.
+        </p>
+      </div>
+    </section>
+
+    <section>
+      <h4 data-accordion-role="tab">{{ _('Section 2') }}</h4>
+
+      <div data-accordion-role="tabpanel">
+        <p>
+          Donec dapibus odio et pulvinar tristique. In a tristique tortor. Sed at
+          metus elit. Etiam commodo lobortis ligula auctor porta. Vivamus imperdiet,
+          dolor non pretium tempor, neque lectus pharetra tellus, at volutpat orci
+          velit at tellus. Curabitur in molestie ipsum. Maecenas imperdiet magna sed
+          aliquam tincidunt.
+        </p>
+      </div>
+    </section>
+
+    <section>
+      <h4 data-accordion-role="tab">{{ _('Section 3') }}</h4>
+
+      <div data-accordion-role="tabpanel">
+        <p>
+          Ut vitae consectetur mauris, a scelerisque quam. Vestibulum mi nibh,
+          porttitor et tellus vitae, rhoncus cursus sapien. Sed posuere leo neque,
+          vel dapibus ligula rhoncus et. Integer vehicula rhoncus volutpat.
+        </p>
+      </div>
+    </section>
+  </section>
+</article>
+{% endblock %}
+
+{% block js %}
+  {{ js('styleguide-docs-mozilla-accordion') }}
+{% endblock %}

--- a/bedrock/styleguide/templates/styleguide/docs/mozilla-pager.html
+++ b/bedrock/styleguide/templates/styleguide/docs/mozilla-pager.html
@@ -17,13 +17,13 @@
   <h1>{{ _('mozilla-pager.js Examples') }}</h1>
 
   <section class="example" id="example1">
-    <h2>Pager with nav, history, &amp; auto rotation</h2>
+    <h2>{{ _('Pager with nav, history, &amp; auto rotation') }}</h2>
 
     <div class="pager pager-auto-init pager-with-nav pager-auto-rotate">
       <!-- nav will be drawn here -->
       <div class="pager-content">
         <article id="example1-page1" class="pager-page">
-          <h3>Page 1</h3>
+          <h3>{{ _('Page 1') }}</h3>
 
           <p>
             Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur nec
@@ -34,7 +34,7 @@
           </p>
         </article>
         <article id="example1-page2" class="pager-page">
-          <h3>Page 2</h3>
+          <h3>{{ _('Page 2') }}</h3>
 
           <p>
             Donec dapibus odio et pulvinar tristique. In a tristique tortor. Sed at
@@ -45,7 +45,7 @@
           </p>
         </article>
         <article id="example1-page3" class="pager-page">
-          <h3>Page 3</h3>
+          <h3>{{ _('Page 3') }}</h3>
 
           <p>
             Ut vitae consectetur mauris, a scelerisque quam. Vestibulum mi nibh,
@@ -58,23 +58,23 @@
   </section>
 
   <section class="example" id="example2">
-    <h2>Pager with tabs, no history, &amp; starting on page 2</h2>
+    <h2>{{ _('Pager with tabs, no history, &amp; starting on page 2') }}</h2>
 
     <div id="pager-example2" class="pager pager-auto-init pager-with-tabs pager-no-history">
       <ol class="pager-tabs">
         <li>
-          <a href="#example2-page1">Page 1</a>
+          <a href="#example2-page1">{{ _('Page 1') }}</a>
         </li>
         <li>
-          <a href="#example2-page2">Page 2</a>
+          <a href="#example2-page2">{{ _('Page 2') }}</a>
         </li>
         <li>
-          <a href="#example2-page3">Page 3</a>
+          <a href="#example2-page3">{{ _('Page 3') }}</a>
         </li>
       </ol>
       <div class="pager-content">
         <article id="example2-page1" class="pager-page">
-          <h3>Page 1</h3>
+          <h3>{{ _('Page 1') }}</h3>
 
           <p>
             Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur nec
@@ -85,7 +85,7 @@
           </p>
         </article>
         <article id="example2-page2" class="pager-page default-page">
-          <h3>Page 2</h3>
+          <h3>{{ _('Page 2') }}</h3>
 
           <p>
             Donec dapibus odio et pulvinar tristique. In a tristique tortor. Sed at
@@ -96,7 +96,7 @@
           </p>
         </article>
         <article id="example2-page3" class="pager-page">
-          <h3>Page 3</h3>
+          <h3>{{ _('Page 3') }}</h3>
 
           <p>
             Ut vitae consectetur mauris, a scelerisque quam. Vestibulum mi nibh,
@@ -109,26 +109,26 @@
   </section>
 
   <section class="example" id="example3">
-    <h2>Enable/Disable Pager with tabs, nav, &amp; random start page</h2>
+    <h2>{{ _('Enable/Disable Pager with tabs, nav, &amp; random start page') }}</h2>
 
-    <button type="button" id="pager3-enable">Enable Pager</button>
-    <button type="button" id="pager3-disable">Disable Pager</button>
+    <button type="button" id="pager3-enable">{{ _('Enable Pager') }}</button>
+    <button type="button" id="pager3-disable">{{ _('Disable Pager') }}</button>
 
     <div id="pager-example3" class="pager pager-with-tabs pager-with-nav pager-random">
       <ol class="pager-tabs">
         <li>
-          <a href="#example3-page1">Page 1</a>
+          <a href="#example3-page1">{{ _('Page 1') }}</a>
         </li>
         <li>
-          <a href="#example3-page2">Page 2</a>
+          <a href="#example3-page2">{{ _('Page 2') }}</a>
         </li>
         <li>
-          <a href="#example3-page3">Page 3</a>
+          <a href="#example3-page3">{{ _('Page 3') }}</a>
         </li>
       </ol>
       <div class="pager-content">
         <article id="example3-page1" class="pager-page">
-          <h3>Page 1</h3>
+          <h3>{{ _('Page 1') }}</h3>
 
           <p>
             Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur nec
@@ -139,7 +139,7 @@
           </p>
         </article>
         <article id="example3-page2" class="pager-page">
-          <h3>Page 2</h3>
+          <h3>{{ _('Page 2') }}</h3>
 
           <p>
             Donec dapibus odio et pulvinar tristique. In a tristique tortor. Sed at
@@ -150,7 +150,7 @@
           </p>
         </article>
         <article id="example3-page3" class="pager-page">
-          <h3>Page 3</h3>
+          <h3>{{ _('Page 3') }}</h3>
 
           <p>
             Ut vitae consectetur mauris, a scelerisque quam. Vestibulum mi nibh,
@@ -163,16 +163,16 @@
   </section>
 
   <section class="example" id="example4">
-    <h2>Pager with custom next/previous controls</h2>
+    <h2>{{ _('Pager with custom next/previous controls') }}</h2>
 
     <div id="pager-example4" class="pager pager-auto-init">
 
-      <button type="button" class="link-button" id="prev">Previous</button>
-      <button type="button" class="link-button" id="next">Next</button>
+      <button type="button" class="link-button" id="prev">{{ _('Previous') }}</button>
+      <button type="button" class="link-button" id="next">{{ _('Next') }}</button>
 
       <div class="pager-content">
         <article id="example4-page1" class="pager-page">
-          <h3>Page 1</h3>
+          <h3>{{ _('Page 1') }}</h3>
 
           <p>
             Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur nec
@@ -183,7 +183,7 @@
           </p>
         </article>
         <article id="example4-page2" class="pager-page">
-          <h3>Page 2</h3>
+          <h3>{{ _('Page 2') }}</h3>
 
           <p>
             Donec dapibus odio et pulvinar tristique. In a tristique tortor. Sed at
@@ -194,7 +194,7 @@
           </p>
         </article>
         <article id="example4-page3" class="pager-page">
-          <h3>Page 3</h3>
+          <h3>{{ _('Page 3') }}</h3>
 
           <p>
             Ut vitae consectetur mauris, a scelerisque quam. Vestibulum mi nibh,

--- a/bedrock/styleguide/urls.py
+++ b/bedrock/styleguide/urls.py
@@ -97,6 +97,8 @@ if settings.DEV:
         PageNode('Docs', path='docs', children=(
             PageNode('Mozilla Pager JS', path='mozilla-pager',
                     template='styleguide/docs/mozilla-pager.html'),
+            PageNode('Mozilla Accordion JS', path='mozilla-accordion',
+                    template='styleguide/docs/mozilla-accordion.html'),
         )),
     ))
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -29,7 +29,7 @@ Contents
    php
    l10n
    coding
-   jslibs
+   javascript-libs
    contribute
    grunt
    newsletters

--- a/docs/javascript-libs.rst
+++ b/docs/javascript-libs.rst
@@ -11,3 +11,4 @@ JavaScript Libraries
 .. _with mozillapager:
 
 - :ref:`mozilla-pager.js<mozillapager>`
+- :ref:`mozilla-accordion.js<mozillaaccordion>`

--- a/docs/mozilla-accordion.rst
+++ b/docs/mozilla-accordion.rst
@@ -1,0 +1,60 @@
+.. This Source Code Form is subject to the terms of the Mozilla Public
+.. License, v. 2.0. If a copy of the MPL was not distributed with this
+.. file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+.. _mozillaaccordion:
+
+=================
+Mozilla Accordion
+=================
+
+`mozilla-accordion.js` converts a section of markup into a vertically expanding/collapsing list. Each accordion requires the following HTML elements/structure:
+
+- An accordion container element with the class ``accordion``, which contains,
+    - Multiple section containing elements (commonly ``<section>`` tags), each which contain,
+        - Any element with a ``data-accordion-role`` attribute set to ``tab`` (commonly an ``<h[1-6]>`` tag)
+        - Any element with a ``data-accordion-role`` attribute set to ``tabpanel`` (commonly a ``<div>`` tag)
+
+A very basic example might look like::
+
+    <div class="accordion">
+        <section>
+            <h2 data-accordion-role="tab">Section 1</h2>
+            <div data-accordion-role="tabpanel">
+                Section 1 content that will be displayed when the above heading is clicked.
+            </div>
+        </section>
+
+        <section>
+            <h2 data-accordion-role="tab">Section 2</h2>
+            <div data-accordion-role="tabpanel">
+                Section 2 content that will be displayed when the above heading is clicked.
+            </div>
+        </section>
+    </div>
+
+In the above example, the ``<h2>`` elements are given click handlers that toggle the open/closed state of the sibling ``<div>``.
+
+Note that the ``tab`` and ``tabpanel`` elements must be siblings, and must be direct descendants of the section container.
+
+Styling
+-------
+
+Include ``mozilla-accordion.less`` for default styling, complete with open/closed icons.
+
+Add the ``zebra`` class to your ``accordion`` container element for striped sections.
+
+Persistence
+-----------
+
+If ``sessionStorage`` is available, the library will remember the open/closed state of each section on subsequent page loads.
+
+Analytics
+---------
+
+The library will automatically send a Google Analytics event each time a user clicks to expand or collapse a section.
+
+Examples
+--------
+
+You can view simple examples by navigating to ``/styleguide/docs/mozilla-accordion/`` in your local development environment (not available in production).

--- a/media/css/base/mozilla-accordion.less
+++ b/media/css/base/mozilla-accordion.less
@@ -5,7 +5,7 @@
 @import "../sandstone/lib.less";
 
 .accordion {
-  [role="tab"] {
+  [data-accordion-role="tab"] {
     overflow: hidden;
     margin: 0;
     outline: 0;
@@ -13,13 +13,13 @@
     text-shadow: 1px 1px 0 rgba(255,255,255,.75);
   }
 
-  [role="tabpanel"] {
+  [data-accordion-role="tabpanel"] {
     overflow: hidden;
     padding: 0 20px;
   }
 
   &.activated {
-    [role="tab"] {
+    [data-accordion-role="tab"] {
       padding: 15px 15px 15px 45px;
       cursor: pointer;
 
@@ -64,7 +64,7 @@
       }
     }
 
-    [role="tabpanel"] {
+    [data-accordion-role="tabpanel"] {
       padding: 0 15px 15px 45px;
 
       &[aria-hidden="true"] {


### PR DESCRIPTION
- Add GA tracking for accordion collapse event.
- Move ARIA from HTML to JS.
- Refactor mozilla-accordion.less to rely on new
  (non-ARIA) HTML hooks.
- Disallow direct child tabs - all accordion tabs/panels
  must be in a separate wrapper element.
