### PR TITLE
Bug 1041712 Fix holes in release notes redirects

### DIFF
--- a/etc/httpd/global.conf
+++ b/etc/httpd/global.conf
@@ -555,7 +555,7 @@ RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?(firefox|mobile)/([3-9]\d\.\d(?:a2|
 RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?firefox/(24\.[5678]\.\d)/releasenotes(/)?$ /b/$1firefox/$2/releasenotes$3 [L,PT]
 
 # bug 1041712
-RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)(firefox|mobile)/([0-9]|1[0-9]|2[0-8])\.([\d.]+)/releasenotes/(.*)$ http://website-archive.mozilla.org/www.mozilla.org/firefox_releasenotes/$1$2/$3.$4/releasenotes$5 [L,R=301]
+RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)(firefox|mobile)/([0-9]|1[0-9]|2[0-8])\.(\d+(?:beta)?)/releasenotes/(.*)$ http://website-archive.mozilla.org/www.mozilla.org/firefox_releasenotes/$1$2/$3.$4/releasenotes/$5 [L,R=301]
 
 # bug 957242
 RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?firefox/(.*)/system-requirements(/)?$ /b/$1firefox/$2/system-requirements$3 [PT]


### PR DESCRIPTION
- Fix missing trailing slash on buglist.html redirects
- Fix redirects for beta releases

More details: https://bugzilla.mozilla.org/show_bug.cgi?id=1041712#c19
