### PR TITLE
[fix bug 1058642] Show /whatsnew tour page for users updating to Firefox 33

### DIFF
--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -444,7 +444,7 @@ class WhatsnewView(LatestFxView):
         # old versions of Firefox sent a prefixed version
         if oldversion.startswith('rv:'):
             oldversion = oldversion[3:]
-        versions = ('29.', '30.', '31.')
+        versions = ('29.', '30.', '31.', '32.', '33.')
 
         if version == '29.0a1':
             template = 'firefox/whatsnew-nightly-29.html'


### PR DESCRIPTION
Adding 29 here as well if we are increasing the scope.

For users updating from a version prior to 29, they should see the tour. For users updating from a version greater than 29, they should just see the post tour web page. This is handled via the `oldversion` parameter.
