### PR TITLE
bug 932108 - Tabzilla formatting issues

### DIFF
--- a/media/css/tabzilla/tabzilla.less
+++ b/media/css/tabzilla/tabzilla.less
@@ -290,6 +290,7 @@ html[dir='rtl'] #tabzilla {
     -webkit-transition: all .2s linear;
     transition: all .2s linear;
     font-size: 12px;
+    line-height: normal;
 }
 
 #tabzilla-panel #tabzilla-nav ul li#tabzilla-search input:hover {


### PR DESCRIPTION
Repositioned the `Search` placeholder by adjusting the line-height. It was affected by css from the body.

I targeted bug 932108 (from careers.mozilla.org) because I discovered this by comparing the two.
