### PR TITLE
Fix bug 1063342: reload loop edge case

### DIFF
--- a/media/js/firefox/new.js
+++ b/media/js/firefox/new.js
@@ -20,10 +20,10 @@
         latestFirefoxVersion = parseInt(latestFirefoxVersion.split('.')[0], 10);
 
         if (isFirefoxUpToDate(latestFirefoxVersion + '')) {
-            if (window.location.hash !== '#download-fx') {
+            if (window.location.hash !== '#download-fx' && window.location.search !== '?scene=2') {
                 // the firefox-latest class prevents the download from triggering
                 // and scene 2 from showing, which we want if the user lands on
-                // /firefox/new/ but if the user visits /firefox/new/#download-fx
+                // /firefox/new/ but if the user visits /firefox/new/?scene=2#download-fx
                 // (from a download button) then we want them to see the same scene 2
                 // as non-firefox users and initiate a download
                 $html.addClass('firefox-latest');


### PR DESCRIPTION
Prevent addition of .firefox-latest when ?scene=2 is present
