### PR TITLE
[fix bug 1060614] mozilla wordmark on homepage does not work in IE 6 & 7

### DIFF
--- a/media/js/base/mozilla-image-helper.js
+++ b/media/js/base/mozilla-image-helper.js
@@ -81,7 +81,7 @@ Mozilla.ImageHelper.initPlatformImages = function() {
 // {{{ initHighResImages()
 
 Mozilla.ImageHelper.initHighResImages = function() {
-    $('img[src=""][data-src][data-high-res="true"]').each(function() {
+    $('img[data-src][data-high-res="true"]').each(function() {
         var src = $(this).data('src');
         if (Mozilla.ImageHelper.isHighDpi()) {
             src = Mozilla.ImageHelper.convertUrlToHighRes(src);


### PR DESCRIPTION
This is the offending jQuery bug (3 years old!): http://bugs.jquery.com/ticket/8740

Simplest solution seems to be just to avoid using jQuery selectors with empty attributes. In the case of this particular selector, it's probably overly specific to begin with.
