### PR TITLE
[fix bug 1061715] Change download_url if it is an Android release

### DIFF
--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -531,11 +531,16 @@ def release_notes(request, fx_version, product='Firefox'):
         return HttpResponseRedirect(releasenotes_url(release))
 
     new_features, known_issues = release.notes(public_only=not settings.DEV)
+    
+    if release.product == 'Firefox for Android':
+        download_url = 'https://play.google.com/store/apps/details?id=org.mozilla.firefox'
+    else:
+        download_url = get_download_url(release.channel)
 
     return l10n_utils.render(
         request, release_notes_template(release.channel, product), {
             'version': fx_version,
-            'download_url': get_download_url(release.channel),
+            'download_url': download_url,
             'release': release,
             'equivalent_release_url': equivalent_release_url(release),
             'new_features': new_features,


### PR DESCRIPTION
Bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1061715

Reference page: http://bedrock-c9-ckprice.c9.io/en-US/mobile/32.0/releasenotes/

When toggling "View Notes To" in the "Mobile" mode, the "Download" link should point to the Google Play URL.
