### PR TITLE
[fix bug 1061715] Change download_url if it is an Android release

### DIFF
--- a/bedrock/firefox/tests/test_views.py
+++ b/bedrock/firefox/tests/test_views.py
@@ -191,3 +191,15 @@ class TestRNAViews(TestCase):
             mock_releasenotes_url.return_value)
         mock_releasenotes_url.assert_called_with(
             release.equivalent_desktop_release.return_value)
+
+    @patch('bedrock.firefox.views.android_builds')
+    def test_get_download_url_android(self, mock_android_builds):
+        """
+        Shoud return the download link for the release.channel from
+        android_builds
+        """
+        mock_android_builds.return_value = [{'download_link': '/download'}]
+        release = Mock(product='Firefox for Android')
+        link = views.get_download_url(release)
+        eq_(link, '/download')
+        mock_android_builds.assert_called_with(release.channel)

--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -28,6 +28,7 @@ from bedrock.mozorg.context_processors import funnelcake_param
 from bedrock.mozorg.decorators import cache_control_expires
 from bedrock.mozorg.views import process_partnership_form
 from bedrock.mozorg.helpers.misc import releasenotes_url
+from bedrock.mozorg.helpers.download_buttons import android_builds
 from bedrock.firefox.utils import is_current_or_newer
 from bedrock.firefox.firefox_details import firefox_details, mobile_details
 from lib.l10n_utils.dotlang import _
@@ -509,13 +510,16 @@ def get_release_or_404(version, product):
     return release
 
 
-def get_download_url(channel='Release'):
-    if channel == 'Aurora':
-        return reverse('firefox.channel') + '#aurora'
-    elif channel == 'Beta':
-        return reverse('firefox.channel') + '#beta'
+def get_download_url(release):
+    if release.product == 'Firefox for Android':
+        return android_builds(release.channel)[0]['download_link']
     else:
-        return reverse('firefox')
+        if release.channel == 'Aurora':
+            return reverse('firefox.channel') + '#aurora'
+        elif release.channel == 'Beta':
+            return reverse('firefox.channel') + '#beta'
+        else:
+            return reverse('firefox')
 
 
 @cache_control_expires(1)
@@ -535,7 +539,7 @@ def release_notes(request, fx_version, product='Firefox'):
     return l10n_utils.render(
         request, release_notes_template(release.channel, product), {
             'version': fx_version,
-            'download_url': get_download_url(release.channel),
+            'download_url': get_download_url(release),
             'release': release,
             'equivalent_release_url': equivalent_release_url(release),
             'new_features': new_features,

--- a/bedrock/mozorg/helpers/download_buttons.py
+++ b/bedrock/mozorg/helpers/download_buttons.py
@@ -126,6 +126,35 @@ def make_download_link(product, build, version, platform, locale,
                        plat=platform, locale=locale)
 
 
+def android_builds(build, builds=None):
+    builds = builds or []
+    android_link = settings.GOOGLE_PLAY_FIREFOX_LINK
+
+    if build == 'beta':
+        android_link = android_link.replace('org.mozilla.firefox',
+                                            'org.mozilla.firefox_beta')
+
+    if build == 'aurora':
+        for arch_pretty in ['ARMv7', 'x86']:
+            arch = arch_pretty.lower()
+            link = (download_urls['aurora-android-%s' % arch] %
+                    mobile_details.latest_version('aurora'))
+
+            builds.append({'os': 'os_android',
+                           'os_pretty': 'Android',
+                           'os_arch_pretty': 'Android %s' % arch_pretty,
+                           'arch': arch,
+                           'arch_pretty': arch_pretty,
+                           'download_link': link})
+
+    if build != 'aurora':
+        builds.append({'os': 'os_android',
+                       'os_pretty': 'Android',
+                       'download_link': android_link})
+
+    return builds
+
+
 @jingo.register.function
 @jinja2.contextfunction
 def download_firefox(ctx, build='release', small=False, icon=True,
@@ -220,29 +249,7 @@ def download_firefox(ctx, build='release', small=False, icon=True,
                            'download_link': download_link,
                            'download_link_direct': download_link_direct})
     if mobile is not False:
-        android_link = settings.GOOGLE_PLAY_FIREFOX_LINK
-
-        if build == 'beta':
-            android_link = android_link.replace('org.mozilla.firefox',
-                                                'org.mozilla.firefox_beta')
-
-        if build == 'aurora':
-            for arch_pretty in ['ARMv7', 'x86']:
-                arch = arch_pretty.lower()
-                link = (download_urls['aurora-android-%s' % arch] %
-                        mobile_details.latest_version('aurora'))
-
-                builds.append({'os': 'os_android',
-                               'os_pretty': 'Android',
-                               'os_arch_pretty': 'Android %s' % arch_pretty,
-                               'arch': arch,
-                               'arch_pretty': arch_pretty,
-                               'download_link': link})
-
-        if build != 'aurora':
-            builds.append({'os': 'os_android',
-                           'os_pretty': 'Android',
-                           'download_link': android_link})
+        builds = android_builds(build, builds)
 
     # Get the native name for current locale
     langs = firefox_details.languages


### PR DESCRIPTION
Bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1061715

Reference page: https://www.mozilla.org/en-US/mobile/32.0/releasenotes/

When toggling "View Notes To" in the "Mobile" mode, the "Download" link should point to the Google Play URL.
