### PR TITLE
[no bug] Add <main> element to CSS reset

### DIFF
--- a/media/css/sandstone/reset.less
+++ b/media/css/sandstone/reset.less
@@ -2,13 +2,13 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-html, body, div, span, object, iframe, h1, h2, h3, h4, h5, h6, p, blockquote, pre, a, abbr, address, cite, code, del, dfn, em, img, ins, kbd, q, samp, small, strong, sub, sup, var, b, i, hr, dl, dt, dd, ol, ul, li, fieldset, form, label, legend, table, caption, tbody, tfoot, thead, tr, th, td, article, aside, canvas, details, figure, figcaption, hgroup, menu, footer, header, nav, section, summary, time, mark, audio, video {
+html, body, div, span, object, iframe, h1, h2, h3, h4, h5, h6, p, blockquote, pre, a, abbr, address, cite, code, del, dfn, em, img, ins, kbd, q, samp, small, strong, sub, sup, var, b, i, hr, dl, dt, dd, ol, ul, li, fieldset, form, label, legend, table, caption, tbody, tfoot, thead, tr, th, td, article, aside, canvas, details, figure, figcaption, hgroup, menu, footer, header, main, nav, section, summary, time, mark, audio, video {
     margin: 0;
     padding: 0;
     border: 0;
 }
 
-article, aside, canvas, figure, figure img, figcaption, hgroup, footer, header, nav, section, audio, video {
+article, aside, canvas, figure, figure img, figcaption, hgroup, footer, header, main, nav, section, audio, video {
     display: block;
 }
 


### PR DESCRIPTION
There's no associated bug for this (unless we think it's needed, in which case I'm happy to create one), but I noticed the `<main>` element is omitted from our CSS reset styles.
