### PR TITLE
[fix bug 1067281] Remove duplicate CSS files from bedrock pages

### DIFF
--- a/bedrock/mozorg/templates/mozorg/mission.html
+++ b/bedrock/mozorg/templates/mozorg/mission.html
@@ -8,6 +8,8 @@
 {% block body_id %}mission{% endblock %}
 {% block body_class %}sand{% endblock %}
 
+{% block site_css %}{% endblock %}
+
 {% block extrahead %}
   {{ css('mission') }}
   {# The mosaic won't be loaded on IE8 and below. Adjust the margin of elements to keep the layout #}

--- a/bedrock/mozorg/templates/mozorg/powered-by.html
+++ b/bedrock/mozorg/templates/mozorg/powered-by.html
@@ -5,6 +5,8 @@
 {% block body_id %}powered-by{% endblock %}
 {% block body_class %}sand{% endblock %}
 
+{% block site_css %}{% endblock %}
+
 {% block extrahead %}
   {{ css('powered-by') }}
 {% endblock %}

--- a/media/css/firefox/channel.less
+++ b/media/css/firefox/channel.less
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-@import "template.less";
+@import "../sandstone/lib.less";
 
 #toggler-container {
     margin: 120px auto 40px auto;

--- a/media/css/firefox/os/devices.less
+++ b/media/css/firefox/os/devices.less
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-@import "../../sandstone/sandstone-resp.less";
+@import "../../sandstone/lib.less";
 @import "get_device.less";
 
 /* {{{ Template overrides */

--- a/media/css/mozorg/manifesto.less
+++ b/media/css/mozorg/manifesto.less
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-@import "../sandstone/sandstone-resp.less";
+@import "../sandstone/lib.less";
 @import "mosaic.less";
 
 @font-face {

--- a/media/css/plugincheck/plugincheck.less
+++ b/media/css/plugincheck/plugincheck.less
@@ -1,7 +1,7 @@
 // in order to use the mixins from sandstone and not inlclude the mixins file twice,
 // we need to import the main sandstone LESS file here. We are therefore also not
 // including it in the home.html template.
-@import "../sandstone/sandstone-resp.less";
+@import "../sandstone/lib.less";
 
 #main-feature {
     padding-bottom: 68px;

--- a/media/css/privacy/privacy.less
+++ b/media/css/privacy/privacy.less
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-@import "../sandstone/sandstone-resp.less";
+@import "../sandstone/lib.less";
 
 #outer-wrapper {
   overflow: hidden; /* Fix the layout on IE */
@@ -100,7 +100,7 @@
         display: none;
       }
     }
-  }  
+  }
 }
 
 .sidebar {

--- a/media/css/tabzilla/tabzilla.less
+++ b/media/css/tabzilla/tabzilla.less
@@ -3,8 +3,6 @@
 // IE does not like file-relative (e.g. '../fonts/*') URLs due to our
 // redirects. Always use domain-relative urls like the font URLs below.
 
-@import "../sandstone/lib.less";
-
 // Fonts
 
 


### PR DESCRIPTION
- `/mission/`
- `/about/powered-by/`
- `/firefox/channel/`
- `/firefox/os/devices/`
- `/about/manifesto/`
- `/plugincheck/`
- `/privacy/` base template
- `tabzilla.less` imported `lib.less` twice
