### PR TITLE
[fix bug 1067863] Next/Prev button flicker in onboarding tour

### DIFF
--- a/bedrock/firefox/templates/firefox/australis/firstrun-tour.html
+++ b/bedrock/firefox/templates/firefox/australis/firstrun-tour.html
@@ -44,82 +44,84 @@
 
 {% block tour_content %}
   <div id="ui-tour" tabindex="-1" aria-expanded="false">
-    <div class="tour-inner">
-      <div id="tour-progress" class="progress-step">
-        <div class="logo"></div>
-        <span class="step"></span>
-        <div class="progress" role="progressbar" aria-valuenow="1" aria-valuemin="1" aria-valuemax="4">
-          <span class="indicator"></span>
+    <div class="cta">
+      <button type="button" aria-controls="ui-tour">{{ _('Start browsing') }}</button>
+    </div>
+    <div class="tour-tip"></div>
+    <div class="ui-tour-controls">
+      <button class="step prev" aria-controls="tour-steps tour-progress">{{ _('Previous') }}</button>
+      <button class="step next" aria-controls="tour-steps tour-progress">{{ _('Next') }}</button>
+      <button class="close" aria-controls="tour-steps tour-progress">{{ _('Close') }}</button>
+    </div>
+    <div class="tour-background">
+      <div class="tour-inner">
+        <div id="tour-progress" class="progress-step">
+          <div class="logo"></div>
+          <span class="step"></span>
+          <div class="progress" role="progressbar" aria-valuenow="1" aria-valuemin="1" aria-valuemax="4">
+            <span class="indicator"></span>
+          </div>
         </div>
-      </div>
-      <ul class="ui-tour-list">
-        <li class="tour-step current app-menu visible" data-step="1" data-tip-next="{{ _('<span>Next:</span> Customize') }}">
-          <div class="tour-item">
-            {# L10n: <br> tag below used for formatting only. #}
-            <h2 class="tour-highlight step-target" data-target="appMenu" data-effect="wobble">
-              {{ _('It starts with the new,<br> intuitive menu') }}
-            </h2>
-            <ul class="tour-highlight step-target" data-target="appMenu" data-effect="wobble">
-              <li>{{ _('The features you use most, all in one place') }}</li>
-              <li>{{ _('Grouped together for quick, easy access') }}</li>
-              <li><a href="#" role="button" class="more">{{ _('Learn how to customize your Firefox') }}</a></li>
-            </ul>
-          </div>
-          {{ high_res_img('img/firefox/australis/diag-menu-bar.jpg?03-2014', {'alt': _('The features you use most, all in one place'), 'width': '300', 'height': '188'}) }}
-        </li>
-        <li class="tour-step app-menu" data-step="2" data-tip-prev="{{ _('<span>Previous:</span> Menu') }}" data-tip-next="{{ _('<span>Next:</span> Add-ons') }}">
-          <div class="tour-item">
-            {# L10n: <br> tag below used for formatting only. #}
-            <h2 class="tour-highlight step-target" data-target="customize" data-effect="wobble">
-              {{ _('Designed so you can<br> make it your own') }}
-            </h2>
-            <ul>
-              <li>{{ _('How you use the Web is unique') }}</li>
-              <li>{{ _('Move or remove any button to match') }}</li>
-              <li><a href="#" role="button" class="more">{{ _('Add features and styles with add-ons') }}</a></li>
-            </ul>
-          </div>
-          {{ high_res_img('img/firefox/australis/diag-customize.jpg?03-2014', {'alt': _('Learn how to customize your Firefox'), 'width': '300', 'height': '188'}) }}
-        </li>
-        <li class="tour-step app-menu" data-step="3" data-tip-prev="{{ _('<span>Previous:</span> Customize') }}" data-tip-next="{{ _('<span>Next:</span> Bookmarks') }}">
-          <div class="tour-item">
-            {# L10n: <br> tag below used for formatting only. #}
-            <h2 class="tour-highlight step-target" data-target="addons" data-effect="wobble">
-              {{ _('Thousands of ways to<br> make Firefox do more') }}
-            </h2>
-            <ul>
-              <li>{{ _('Helps you do just about anything online') }}</li>
-              <li>{{ _('Easy to find, use and manage') }}</li>
-              <li><a href="#" role="button" class="more">{{ _('Use the star to create bookmarks') }}</a></li>
-            </ul>
-          </div>
-          {{ high_res_img('img/firefox/australis/diag-addons.jpg?03-2014', {'alt': _('Add features and styles with add-ons'), 'width': '300', 'height': '188'}) }}
-        </li>
-        <li class="tour-step" data-step="4" data-tip-prev="{{ _('<span>Previous:</span> Add-ons') }}">
-          <div class="tour-item">
-            {# L10n: <br> tag below used for formatting only. #}
-            <h2 class="tour-highlight step-target" data-target="bookmarks" data-effect="wobble">
-              {{ _('Your favorite sites<br> are closer than ever') }}
-            </h2>
-            <ul>
-              <li>{{ _('Add and view bookmarks from the same spot') }}</li>
-              <li>{{ _('Save sites with a single click') }}</li>
-              <li id="sync-link"><a href="#" role="button" class="more">{{ _('Enjoy seamless browsing between devices with Sync') }}</a></li>
-            </ul>
-          </div>
-          {{ high_res_img('img/firefox/australis/diag-bookmarks.jpg?03-2014', {'alt': _('Use the star to create bookmarks'), 'width': '300', 'height': '188'}) }}
-        </li>
-      </ul>
-      <div class="compact-title"></div>
-      <div class="tour-init" data-target="appMenu" data-icon="{{ MEDIA_URL }}img/firefox/australis/logo.png?2014-03" data-icon-high-res="{{ MEDIA_URL }}img/firefox/australis/logo-high-res.png?2014-03"></div>
-      <div class="cta">
-        <button type="button" aria-controls="ui-tour">{{ _('Start browsing') }}</button>
-      </div>
-      <div class="tour-tip"></div>
-      <div class="ui-tour-controls" aria-controls="ui-tour tour-content tour-progress">
-        <button class="step prev">{{ _('Previous') }}</button>
-        <button class="step next">{{ _('Next') }}</button>
-        <button class="close">{{ _('Close') }}</button>
+        <ul id="tour-steps" class="ui-tour-list">
+          <li class="tour-step current app-menu visible" data-step="1" data-tip-next="{{ _('<span>Next:</span> Customize') }}">
+            <div class="tour-item">
+              {# L10n: <br> tag below used for formatting only. #}
+              <h2 class="tour-highlight step-target" data-target="appMenu" data-effect="wobble">
+                {{ _('It starts with the new,<br> intuitive menu') }}
+              </h2>
+              <ul class="tour-highlight step-target" data-target="appMenu" data-effect="wobble">
+                <li>{{ _('The features you use most, all in one place') }}</li>
+                <li>{{ _('Grouped together for quick, easy access') }}</li>
+                <li><a href="#" role="button" class="more">{{ _('Learn how to customize your Firefox') }}</a></li>
+              </ul>
+            </div>
+            {{ high_res_img('img/firefox/australis/diag-menu-bar.jpg?03-2014', {'alt': _('The features you use most, all in one place'), 'width': '300', 'height': '188'}) }}
+          </li>
+          <li class="tour-step app-menu" data-step="2" data-tip-prev="{{ _('<span>Previous:</span> Menu') }}" data-tip-next="{{ _('<span>Next:</span> Add-ons') }}">
+            <div class="tour-item">
+              {# L10n: <br> tag below used for formatting only. #}
+              <h2 class="tour-highlight step-target" data-target="customize" data-effect="wobble">
+                {{ _('Designed so you can<br> make it your own') }}
+              </h2>
+              <ul>
+                <li>{{ _('How you use the Web is unique') }}</li>
+                <li>{{ _('Move or remove any button to match') }}</li>
+                <li><a href="#" role="button" class="more">{{ _('Add features and styles with add-ons') }}</a></li>
+              </ul>
+            </div>
+            {{ high_res_img('img/firefox/australis/diag-customize.jpg?03-2014', {'alt': _('Learn how to customize your Firefox'), 'width': '300', 'height': '188'}) }}
+          </li>
+          <li class="tour-step app-menu" data-step="3" data-tip-prev="{{ _('<span>Previous:</span> Customize') }}" data-tip-next="{{ _('<span>Next:</span> Bookmarks') }}">
+            <div class="tour-item">
+              {# L10n: <br> tag below used for formatting only. #}
+              <h2 class="tour-highlight step-target" data-target="addons" data-effect="wobble">
+                {{ _('Thousands of ways to<br> make Firefox do more') }}
+              </h2>
+              <ul>
+                <li>{{ _('Helps you do just about anything online') }}</li>
+                <li>{{ _('Easy to find, use and manage') }}</li>
+                <li><a href="#" role="button" class="more">{{ _('Use the star to create bookmarks') }}</a></li>
+              </ul>
+            </div>
+            {{ high_res_img('img/firefox/australis/diag-addons.jpg?03-2014', {'alt': _('Add features and styles with add-ons'), 'width': '300', 'height': '188'}) }}
+          </li>
+          <li class="tour-step" data-step="4" data-tip-prev="{{ _('<span>Previous:</span> Add-ons') }}">
+            <div class="tour-item">
+              {# L10n: <br> tag below used for formatting only. #}
+              <h2 class="tour-highlight step-target" data-target="bookmarks" data-effect="wobble">
+                {{ _('Your favorite sites<br> are closer than ever') }}
+              </h2>
+              <ul>
+                <li>{{ _('Add and view bookmarks from the same spot') }}</li>
+                <li>{{ _('Save sites with a single click') }}</li>
+                <li id="sync-link"><a href="#" role="button" class="more">{{ _('Enjoy seamless browsing between devices with Sync') }}</a></li>
+              </ul>
+            </div>
+            {{ high_res_img('img/firefox/australis/diag-bookmarks.jpg?03-2014', {'alt': _('Use the star to create bookmarks'), 'width': '300', 'height': '188'}) }}
+          </li>
+        </ul>
+        <div class="compact-title"></div>
+        <div class="tour-init" data-target="appMenu" data-icon="{{ MEDIA_URL }}img/firefox/australis/logo.png?2014-03" data-icon-high-res="{{ MEDIA_URL }}img/firefox/australis/logo-high-res.png?2014-03"></div>
       </div>
     </div>
   </div>

--- a/bedrock/firefox/templates/firefox/australis/whatsnew-tour.html
+++ b/bedrock/firefox/templates/firefox/australis/whatsnew-tour.html
@@ -44,82 +44,84 @@
 
 {% block tour_content %}
   <div id="ui-tour" tabindex="-1" aria-expanded="false">
-    <div class="tour-inner">
-      <div id="tour-progress" class="progress-step">
-        <div class="logo"></div>
-        <span class="step"></span>
-        <div class="progress" role="progressbar" aria-valuenow="1" aria-valuemin="1" aria-valuemax="4">
-          <span class="indicator"></span>
+    <div class="cta">
+      <button type="button" aria-controls="ui-tour">{{ _('Start browsing') }}</button>
+    </div>
+    <div class="tour-tip"></div>
+    <div class="ui-tour-controls">
+      <button class="step prev" aria-controls="tour-steps tour-progress">{{ _('Previous') }}</button>
+      <button class="step next" aria-controls="tour-steps tour-progress">{{ _('Next') }}</button>
+      <button class="close" aria-controls="tour-steps tour-progress">{{ _('Close') }}</button>
+    </div>
+    <div class="tour-background">
+      <div class="tour-inner">
+        <div id="tour-progress" class="progress-step">
+          <div class="logo"></div>
+          <span class="step"></span>
+          <div class="progress" role="progressbar" aria-valuenow="1" aria-valuemin="1" aria-valuemax="4">
+            <span class="indicator"></span>
+          </div>
         </div>
-      </div>
-      <ul class="ui-tour-list">
-        <li class="tour-step current app-menu visible" data-step="1" data-tip-next="{{ _('<span>Next:</span> Customize') }}">
-          <div class="tour-item">
-            {# L10n: <br> tag below used for formatting only. #}
-            <h2 class="tour-highlight step-target" data-target="appMenu" data-effect="wobble">
-              {{ _('It starts with the redesigned,<br> intuitive menu') }}
-            </h2>
-            <ul class="tour-highlight step-target" data-target="appMenu" data-effect="wobble">
-              <li>{{ _('Your favorite features, all in one place') }}</li>
-              <li>{{ _('Grouped together for quick, easy access') }}</li>
-              <li><a href="#" role="button" class="more">{{ _('Learn how to customize your Firefox') }}</a></li>
-            </ul>
-          </div>
-          {{ high_res_img('img/firefox/australis/diag-menu-bar.jpg?03-2014', {'alt': _('Your favorite features, all in one place'), 'width': '300', 'height': '188'}) }}
-        </li>
-        <li class="tour-step app-menu" data-step="2" data-tip-prev="{{ _('<span>Previous:</span> Menu') }}" data-tip-next="{{ _('<span>Next:</span> Add-ons') }}">
-          <div class="tour-item">
-            {# L10n: <br> tag below used for formatting only. #}
-            <h2 class="tour-highlight step-target" data-target="customize" data-effect="wobble">
-              {{ _('Designed so you can<br> make it your own') }}
-            </h2>
-            <ul>
-              <li>{{ _('How you use Firefox is unique') }}</li>
-              <li>{{ _('Move or remove any button to match') }}</li>
-              <li><a href="#" role="button" class="more">{{ _('Add features and styles with add-ons') }}</a></li>
-            </ul>
-          </div>
-          {{ high_res_img('img/firefox/australis/diag-customize.jpg?03-2014', {'alt': _('Learn how to customize your Firefox'), 'width': '300', 'height': '188'}) }}
-        </li>
-        <li class="tour-step app-menu" data-step="3" data-tip-prev="{{ _('<span>Previous:</span> Customize') }}" data-tip-next="{{ _('<span>Next:</span> Bookmarks') }}">
-          <div class="tour-item">
-            {# L10n: <br> tag below used for formatting only. #}
-            <h2 class="tour-highlight step-target" data-target="addons" data-effect="wobble">
-              {{ _('Thousands of ways to<br> make Firefox do more') }}
-            </h2>
-            <ul>
-              <li>{{ _('Helps you do just about anything online') }}</li>
-              <li>{{ _('Now easier to find, use and manage') }}</li>
-              <li><a href="#" role="button" class="more">{{ _('Use the star to create bookmarks') }}</a></li>
-            </ul>
-          </div>
-          {{ high_res_img('img/firefox/australis/diag-addons.jpg?03-2014', {'alt': _('Add features and styles with add-ons'), 'width': '300', 'height': '188'}) }}
-        </li>
-        <li class="tour-step" data-step="4" data-tip-prev="{{ _('<span>Previous:</span> Add-ons') }}">
-          <div class="tour-item">
-            {# L10n: <br> tag below used for formatting only. #}
-            <h2 class="tour-highlight step-target" data-target="bookmarks" data-effect="wobble">
-              {{ _('Your favorite sites are<br> closer than ever') }}
-            </h2>
-            <ul>
-              <li>{{ _('Add and view bookmarks from a new location') }}</li>
-              <li>{{ _('Save sites with a single click') }}</li>
-              <li id="sync-link"><a href="#" role="button" class="more">{{ _('Enjoy seamless browsing between devices with Sync') }}</a></li>
-            </ul>
-          </div>
-          {{ high_res_img('img/firefox/australis/diag-bookmarks.jpg?03-2014', {'alt': _('Use the star to create bookmarks'), 'width': '300', 'height': '188'}) }}
-        </li>
-      </ul>
-      <div class="compact-title"></div>
-      <div class="tour-init" data-target="appMenu" data-icon="{{ MEDIA_URL }}img/firefox/australis/logo.png?2014-03" data-icon-high-res="{{ MEDIA_URL }}img/firefox/australis/logo-high-res.png?2014-03"></div>
-      <div class="cta">
-        <button type="button" aria-controls="ui-tour">{{ _('Start browsing') }}</button>
-      </div>
-      <div class="tour-tip"></div>
-      <div class="ui-tour-controls" aria-controls="ui-tour tour-content tour-progress">
-        <button class="step prev">{{ _('Previous') }}</button>
-        <button class="step next">{{ _('Next') }}</button>
-        <button class="close">{{ _('Close') }}</button>
+        <ul id="tour-steps" class="ui-tour-list">
+          <li class="tour-step current app-menu visible" data-step="1" data-tip-next="{{ _('<span>Next:</span> Customize') }}">
+            <div class="tour-item">
+              {# L10n: <br> tag below used for formatting only. #}
+              <h2 class="tour-highlight step-target" data-target="appMenu" data-effect="wobble">
+                {{ _('It starts with the redesigned,<br> intuitive menu') }}
+              </h2>
+              <ul class="tour-highlight step-target" data-target="appMenu" data-effect="wobble">
+                <li>{{ _('Your favorite features, all in one place') }}</li>
+                <li>{{ _('Grouped together for quick, easy access') }}</li>
+                <li><a href="#" role="button" class="more">{{ _('Learn how to customize your Firefox') }}</a></li>
+              </ul>
+            </div>
+            {{ high_res_img('img/firefox/australis/diag-menu-bar.jpg?03-2014', {'alt': _('Your favorite features, all in one place'), 'width': '300', 'height': '188'}) }}
+          </li>
+          <li class="tour-step app-menu" data-step="2" data-tip-prev="{{ _('<span>Previous:</span> Menu') }}" data-tip-next="{{ _('<span>Next:</span> Add-ons') }}">
+            <div class="tour-item">
+              {# L10n: <br> tag below used for formatting only. #}
+              <h2 class="tour-highlight step-target" data-target="customize" data-effect="wobble">
+                {{ _('Designed so you can<br> make it your own') }}
+              </h2>
+              <ul>
+                <li>{{ _('How you use Firefox is unique') }}</li>
+                <li>{{ _('Move or remove any button to match') }}</li>
+                <li><a href="#" role="button" class="more">{{ _('Add features and styles with add-ons') }}</a></li>
+              </ul>
+            </div>
+            {{ high_res_img('img/firefox/australis/diag-customize.jpg?03-2014', {'alt': _('Learn how to customize your Firefox'), 'width': '300', 'height': '188'}) }}
+          </li>
+          <li class="tour-step app-menu" data-step="3" data-tip-prev="{{ _('<span>Previous:</span> Customize') }}" data-tip-next="{{ _('<span>Next:</span> Bookmarks') }}">
+            <div class="tour-item">
+              {# L10n: <br> tag below used for formatting only. #}
+              <h2 class="tour-highlight step-target" data-target="addons" data-effect="wobble">
+                {{ _('Thousands of ways to<br> make Firefox do more') }}
+              </h2>
+              <ul>
+                <li>{{ _('Helps you do just about anything online') }}</li>
+                <li>{{ _('Now easier to find, use and manage') }}</li>
+                <li><a href="#" role="button" class="more">{{ _('Use the star to create bookmarks') }}</a></li>
+              </ul>
+            </div>
+            {{ high_res_img('img/firefox/australis/diag-addons.jpg?03-2014', {'alt': _('Add features and styles with add-ons'), 'width': '300', 'height': '188'}) }}
+          </li>
+          <li class="tour-step" data-step="4" data-tip-prev="{{ _('<span>Previous:</span> Add-ons') }}">
+            <div class="tour-item">
+              {# L10n: <br> tag below used for formatting only. #}
+              <h2 class="tour-highlight step-target" data-target="bookmarks" data-effect="wobble">
+                {{ _('Your favorite sites are<br> closer than ever') }}
+              </h2>
+              <ul>
+                <li>{{ _('Add and view bookmarks from a new location') }}</li>
+                <li>{{ _('Save sites with a single click') }}</li>
+                <li id="sync-link"><a href="#" role="button" class="more">{{ _('Enjoy seamless browsing between devices with Sync') }}</a></li>
+              </ul>
+            </div>
+            {{ high_res_img('img/firefox/australis/diag-bookmarks.jpg?03-2014', {'alt': _('Use the star to create bookmarks'), 'width': '300', 'height': '188'}) }}
+          </li>
+        </ul>
+        <div class="compact-title"></div>
+        <div class="tour-init" data-target="appMenu" data-icon="{{ MEDIA_URL }}img/firefox/australis/logo.png?2014-03" data-icon-high-res="{{ MEDIA_URL }}img/firefox/australis/logo-high-res.png?2014-03"></div>
       </div>
     </div>
   </div>

--- a/media/css/firefox/australis/australis-ui-tour.less
+++ b/media/css/firefox/australis/australis-ui-tour.less
@@ -101,21 +101,28 @@ body.noscroll {
     position: fixed;
     left: 0;
     bottom: 0;
-    height: 290px;
+    height: 390px;
     width: 100%;
     font-family: 'Clear Sans Regular';
     margin: 0 auto;
-    background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAbgAAAEiCAMAAAC86TekAAABnlBMVEUAgL8AasoKds7k8vv////k8vsAAAAAccYAYL8Ab9MA//8AbbYAesgAAP8AeMM8nuEAcM8AVaoAgNGr2/Dk8PsAAAAAcL8AcMwAdMUAd8zS6voAZpkAec4AbcgAQP8AecIAYsQAQIAAc8yLzOzg8PkAVf8AgL8AddUAeckAXdEAgMoAAFXd7/kAdLkKeswAAP8AccZTrN/c7/kAeNIAacMoj9fT6vYAZswAbbbN5vUahNPr9/r///8AVVV6veYAcdXc7vm74PPX7fue0fDi8PsAZrvh8PkiiNXD5PSAv+bi8/lotOgAgLNMpd3Z6vcAYJ/Y7PvN6fXz+v4AM5kAdsQAgMzj8PkSgNEAVb8KgNjE4/S84vMAgMwAZrOw2/LU6/aSyerh8PvC3/Pg7/dyuOTf7/u74PNstej2/f4AbZLR5/rN5vW+4fPf7/mt1vGs2/EpjNaJyO3h8PnL6PWh0O+bze77/P7b7vnZ7fuk0fAAZv/L6PrF4fTa7vsAgKqVyOr+/v+94fNXruAAcaqHxezE5PTg7/cUgM602O+02O+pWta6AAAAinRSTlMIGBqM/wACEggXAQcXAREiEAYWRowBEBkWD2sFFQ4EFQ0EFDeFAwwYEwsYA4ALGQIJKHwRESBvDw5lHaIAAzISe1J0QosPih5eNIMsCiV5CHZmugUNFIccDBpaVwoKTXA9iViDL4FTLdAHaWdWf0tHHziIY0E943pyQwViXHUGPPJVKQk1X4IaTgCfIY3GAAAGjUlEQVR4Ae3dy1uUZRzG8QH5va8MvIgkPBCMvDPKOA4NmKKSZWVKR8xKjSyxLDufz+fz+b9u8ayaFi5y872u773RDZvfx3vzXO+NjcbIaM6e/Mdt/zaW/+D/BPsnGlGUnggJF7F33BMh4aJZeiIkXMTEpCdCwkU1tc8T8eBy6TwREi6qaU+EhIvYP3PXgT23y9ieoRB/gv8T/4KL2bmE+5dq43Lp5j0REi5iId3tiYhwsbjkiZBwEa3kiZBwuXSeiAeXS+eJgHBxcNkTIeEi6uSJkHDR7hw6jHhx8OXkv6Xz3zatcTkrHU+EhIvoHvGoSLhY6XlUJFzE0b5HRcLFam/0Ho8KhIsYrHlUJFys9zwqEi7iWN+j8uBy6e49znhx8OVkKI0R20BrXE5RelQkXMTe8cMelQgXzRMeFQmXv1X3qEC4qDY8KhIul86jAuGimvaoQLg8EBk94FGBcDE7d/IU48XBl5MYHojYBlzjck4n5ImEi8Ul5ImEi2g5hQTC5dIhTyRcxGa6j3gi4eLgMvJEwkXUTiGZcNHuIE8kXER95v4xfjBpPHDHstKxDcDG5YEI8kTCxdneg8QTCZcHIjIA4WL1IeSJhIsY9GVAwsW6U0giXB6IyICEi/Vy9GEZgHARjfFz/K87uN+c/I8Upf0BNi4PRGRAwkVzSgYgXP5WXQYkXFQbMgDhcukekYEIF9WcDEC4PBCRAQkXswtJBh5cHoicv4B4o/DlZDhbyf4AG5e/VX9UBiBcROsxGXhwuXQyIOEiNpMMSLhoL8uAhIuokwxIuGh3ZEDCRXTT4zIQ4WKl98STjDcKX05ieCDCa4ONywMRGZBwEYO+DEi4PBCRAQeXSycDES7Wy6dkIMJFbPdl4MHl0skAhMsDEeGQcFGUF59mvGr4cjKUS+PANti4PBB5RjggXB6ICAeEi2paOCRcxMSMcEi4qOaEQ8LlgYhwPLg8EBEOB5cHIs8KR4SL2Nr33Bg/lN8QeyezuIRrg43LaSXhkHBxeUk4JFzElSQcEi7aV0efFw4IF1HvCIeEi3ZHOCRcRDcJh4SLlZ5wSLiIF6696DcnQ0HAxdkesD82Ln+r/pJwRLhYLYVDwkVc7wuHhIv1UjgkXMTuiHBIuChK4YhweSAiHBEuihMXhePB5YHIDV9OeHB5IGLjApmJSeGYqaaFg2ZiRjhmqrn0snDI7J8RjpnZ00k4aOnmhYOmlYRjZnHplZu+nEBLZ+OYubz0qnDM1Ek4ZtpXhcOWTjhm2h3hoOkm4YDJA5HXhEPm6DXhmDnbu/W6LyfIDPo2jpnVUjhotvvCMbNeCgfN7sgbwiFTlMJB0xgXjpnihHDQXJoUjpnmxptv+RtikZmYtHHUb9X3CcfM2zPCMVMtJOGoAxHhmJndSsJRByLCQdNK7wgHHYgIB83mmXf95gQ6ELFx0NRJOOpARDhoukk46kDkhnDY0gkHHYgIB83giHDMrPaEg2aw9p4vJ9SByPs2DpntNeG4AxHhkDk2Ihx6ICIcdCAiHDDFlHDYgcgHwiHTnBYOmonJD305gQ5EbBx6ICIcdCAiHHQgckE45kDkI+G4AxHhkGkl4dADEeF4uZKEY+by8sef+HKCTJ0+tXHcgYhwxHSTcNSBCBrO0gkHHYgIBx2ICAcdiHwmHDPX+1Q4v1X//At/Qywyu30bRy2dcNiBiHDY/8zgS+G4AxHhoAMR4aADEeHQAxHhiAMR4bD/g8hXfnMCHYh8beOoAxE4nN+qCwfLbCsJx8w388JB00rCYQciN4VDpj4jHHUgIhw09c635JcTv1W3cbx0ExfO0gmHzNH0nXDcgYhw0IGIcNCBiHDYgQgYzm/VhSNmd+0c9OXE0h2ycdyBiHDQgYhw6IGIcLgUG8KBByLCQQci3wvHHYgIhxyICAfNDzPnD/hyQkx1Otk48EBEOOhARDjoQORH4ZjZTMJhByLCMVMn4cgDEeGA6SYqnN+q3/jJ3xCLTHfHxlFLJxw0gyQceiAiHHQgIhx0ICIcMtv9n4XjDkSEI+ZYnwpn6X457jcnyPw6YuOYKaaEg2bvuHDMNDduCccdiAhHTHNOOPZARDhcqgXhsAMR4Ziptk6e8uWEOxCxcdCBiHDQgYhw0FxJwoEHIsIRUyfhmDm4/Jtw1IEIFc5v1alwlm7nd/DLiaWzccAMknDYgcgfwiEz+FM47kBEOOhARDj0QEQ44kCEC2fphIMORP5q/G2AKab+ASk6O4/AZZLgAAAAAElFTkSuQmCC),
-                      linear-gradient(to right, rgba(255,255,255,0.00) 50%, rgba(0,149,221,0.30) 100%),
-                      linear-gradient(to bottom, #FFFFFF 0%, #F1F1F1 100%);
-    background-position: top right, top right, top left;
-    background-repeat: no-repeat, no-repeat, no-repeat;
-    box-shadow: 0 0 5px 0 rgba(0, 0, 0, 0.25);
     transition: all .6s cubic-bezier(.6, -0.08, .6, 1.08);
     transform: translate3d(0, 100%, 0);
     opacity: 0;
     z-index: 101;
     outline: none;
+
+    .tour-background {
+        width: 100%;
+        height: 290px;
+        margin-top: 100px;
+        background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAbgAAAEiCAMAAAC86TekAAABnlBMVEUAgL8AasoKds7k8vv////k8vsAAAAAccYAYL8Ab9MA//8AbbYAesgAAP8AeMM8nuEAcM8AVaoAgNGr2/Dk8PsAAAAAcL8AcMwAdMUAd8zS6voAZpkAec4AbcgAQP8AecIAYsQAQIAAc8yLzOzg8PkAVf8AgL8AddUAeckAXdEAgMoAAFXd7/kAdLkKeswAAP8AccZTrN/c7/kAeNIAacMoj9fT6vYAZswAbbbN5vUahNPr9/r///8AVVV6veYAcdXc7vm74PPX7fue0fDi8PsAZrvh8PkiiNXD5PSAv+bi8/lotOgAgLNMpd3Z6vcAYJ/Y7PvN6fXz+v4AM5kAdsQAgMzj8PkSgNEAVb8KgNjE4/S84vMAgMwAZrOw2/LU6/aSyerh8PvC3/Pg7/dyuOTf7/u74PNstej2/f4AbZLR5/rN5vW+4fPf7/mt1vGs2/EpjNaJyO3h8PnL6PWh0O+bze77/P7b7vnZ7fuk0fAAZv/L6PrF4fTa7vsAgKqVyOr+/v+94fNXruAAcaqHxezE5PTg7/cUgM602O+02O+pWta6AAAAinRSTlMIGBqM/wACEggXAQcXAREiEAYWRowBEBkWD2sFFQ4EFQ0EFDeFAwwYEwsYA4ALGQIJKHwRESBvDw5lHaIAAzISe1J0QosPih5eNIMsCiV5CHZmugUNFIccDBpaVwoKTXA9iViDL4FTLdAHaWdWf0tHHziIY0E943pyQwViXHUGPPJVKQk1X4IaTgCfIY3GAAAGjUlEQVR4Ae3dy1uUZRzG8QH5va8MvIgkPBCMvDPKOA4NmKKSZWVKR8xKjSyxLDufz+fz+b9u8ayaFi5y872u773RDZvfx3vzXO+NjcbIaM6e/Mdt/zaW/+D/BPsnGlGUnggJF7F33BMh4aJZeiIkXMTEpCdCwkU1tc8T8eBy6TwREi6qaU+EhIvYP3PXgT23y9ieoRB/gv8T/4KL2bmE+5dq43Lp5j0REi5iId3tiYhwsbjkiZBwEa3kiZBwuXSeiAeXS+eJgHBxcNkTIeEi6uSJkHDR7hw6jHhx8OXkv6Xz3zatcTkrHU+EhIvoHvGoSLhY6XlUJFzE0b5HRcLFam/0Ho8KhIsYrHlUJFys9zwqEi7iWN+j8uBy6e49znhx8OVkKI0R20BrXE5RelQkXMTe8cMelQgXzRMeFQmXv1X3qEC4qDY8KhIul86jAuGimvaoQLg8EBk94FGBcDE7d/IU48XBl5MYHojYBlzjck4n5ImEi8Ul5ImEi2g5hQTC5dIhTyRcxGa6j3gi4eLgMvJEwkXUTiGZcNHuIE8kXER95v4xfjBpPHDHstKxDcDG5YEI8kTCxdneg8QTCZcHIjIA4WL1IeSJhIsY9GVAwsW6U0giXB6IyICEi/Vy9GEZgHARjfFz/K87uN+c/I8Upf0BNi4PRGRAwkVzSgYgXP5WXQYkXFQbMgDhcukekYEIF9WcDEC4PBCRAQkXswtJBh5cHoicv4B4o/DlZDhbyf4AG5e/VX9UBiBcROsxGXhwuXQyIOEiNpMMSLhoL8uAhIuokwxIuGh3ZEDCRXTT4zIQ4WKl98STjDcKX05ieCDCa4ONywMRGZBwEYO+DEi4PBCRAQeXSycDES7Wy6dkIMJFbPdl4MHl0skAhMsDEeGQcFGUF59mvGr4cjKUS+PANti4PBB5RjggXB6ICAeEi2paOCRcxMSMcEi4qOaEQ8LlgYhwPLg8EBEOB5cHIs8KR4SL2Nr33Bg/lN8QeyezuIRrg43LaSXhkHBxeUk4JFzElSQcEi7aV0efFw4IF1HvCIeEi3ZHOCRcRDcJh4SLlZ5wSLiIF6696DcnQ0HAxdkesD82Ln+r/pJwRLhYLYVDwkVc7wuHhIv1UjgkXMTuiHBIuChK4YhweSAiHBEuihMXhePB5YHIDV9OeHB5IGLjApmJSeGYqaaFg2ZiRjhmqrn0snDI7J8RjpnZ00k4aOnmhYOmlYRjZnHplZu+nEBLZ+OYubz0qnDM1Ek4ZtpXhcOWTjhm2h3hoOkm4YDJA5HXhEPm6DXhmDnbu/W6LyfIDPo2jpnVUjhotvvCMbNeCgfN7sgbwiFTlMJB0xgXjpnihHDQXJoUjpnmxptv+RtikZmYtHHUb9X3CcfM2zPCMVMtJOGoAxHhmJndSsJRByLCQdNK7wgHHYgIB83mmXf95gQ6ELFx0NRJOOpARDhoukk46kDkhnDY0gkHHYgIB83giHDMrPaEg2aw9p4vJ9SByPs2DpntNeG4AxHhkDk2Ihx6ICIcdCAiHDDFlHDYgcgHwiHTnBYOmonJD305gQ5EbBx6ICIcdCAiHHQgckE45kDkI+G4AxHhkGkl4dADEeF4uZKEY+by8sef+HKCTJ0+tXHcgYhwxHSTcNSBCBrO0gkHHYgIBx2ICAcdiHwmHDPX+1Q4v1X//At/Qywyu30bRy2dcNiBiHDY/8zgS+G4AxHhoAMR4aADEeHQAxHhiAMR4bD/g8hXfnMCHYh8beOoAxE4nN+qCwfLbCsJx8w388JB00rCYQciN4VDpj4jHHUgIhw09c635JcTv1W3cbx0ExfO0gmHzNH0nXDcgYhw0IGIcNCBiHDYgQgYzm/VhSNmd+0c9OXE0h2ycdyBiHDQgYhw6IGIcLgUG8KBByLCQQci3wvHHYgIhxyICAfNDzPnD/hyQkx1Otk48EBEOOhARDjoQORH4ZjZTMJhByLCMVMn4cgDEeGA6SYqnN+q3/jJ3xCLTHfHxlFLJxw0gyQceiAiHHQgIhx0ICIcMtv9n4XjDkSEI+ZYnwpn6X457jcnyPw6YuOYKaaEg2bvuHDMNDduCccdiAhHTHNOOPZARDhcqgXhsAMR4Ziptk6e8uWEOxCxcdCBiHDQgYhw0FxJwoEHIsIRUyfhmDm4/Jtw1IEIFc5v1alwlm7nd/DLiaWzccAMknDYgcgfwiEz+FM47kBEOOhARDj0QEQ44kCEC2fphIMORP5q/G2AKab+ASk6O4/AZZLgAAAAAElFTkSuQmCC),
+                          linear-gradient(to right, rgba(255,255,255,0.00) 50%, rgba(0,149,221,0.30) 100%),
+                          linear-gradient(to bottom, #FFFFFF 0%, #F1F1F1 100%);
+        background-position: top right, top right, top left;
+        background-repeat: no-repeat, no-repeat, no-repeat;
+        box-shadow: 0 0 5px 0 rgba(0, 0, 0, 0.25);
+    }
+
     &.in {
         transition: all .6s cubic-bezier(.6, -0.08, .6, 1.08);
         transform: translate3d(0, 0, 0);
@@ -220,7 +227,7 @@ body.noscroll {
     .tour-tip {
         position: absolute;
         left: 0;
-        bottom: 350px;
+        bottom: 330px;
         width: 100%;
         text-align: center;
         color: #fff;
@@ -421,11 +428,13 @@ html[lang^="en"] {
 
 html[dir="rtl"] {
     #ui-tour {
-        background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAbgAAAEiCAMAAAC86TekAAABnlBMVEXk8vsKgNjk8Pv///+02O8AcMwAcdUAeckAAP8AgMoAesgAQP8AAAAAgKoAec4AAP8AbZIAVb8AgMwAdsQAdMUAdLkAbcgAb9MAgNEAM5kA//8AVVUAVf8AcM8AAAAAYJ8AasoAeMMAcaoAZrsAgL8AecIAddUAcL8AZv8AacMAgLMAeNIAd8wAYL88nuEAZrMAbbYAAFUAc8wSgNEKeswAXdEAQIAAgMyw2/IAbbYAYsTk8vsAZpkAZswahNMUgM4Accbg8Pni8PuLzOy74PPc7/kAccbT6vZMpd1yuOQAVarh8Psoj9ee0fCAv+bh8Pni8/nz+v7N6fXd7/nZ6vd6vebX7fvN5vXD5PQAgL+84vNotOjj8PnS6vqr2/Dc7vnY7PvC3/Pg7/ff7/tTrN+74PPU6/ZstegiiNXR5/rN5vW+4fPf7/mt1vGs2/EpjNbh8PmJyO3L6PWh0O/7/P6bze7b7vnZ7fuk0fDE4/TL6PrF4fTa7vvr9/qVyOr+/v+94fNXruCSyeqHxezE5PTg7/cKds602O/2/f7///9YS5i/AAAAiXRSTlMAGowAABkSEwEYFwQCBhUCBwwUDRYLDhcWBQEDAxABCBgRCQ8IFRgQBREKEQ8IIgoOAxQcGQsECk0HDYwFDx0aCYWLN1J8Em8lLwaJIEI0ioO6ZoB5MnRlXgxXLIdrRnt2WIOBKFNwLR5pZ1Z/S0cfiDhjQeM9enJDWmJcdaI88lUpPTVfghpO0Cssmt4AAAcLSURBVHhe7Ns/S8NAAIbxh8LR9A9xqamUtlRoLWIrGlRojGARIxQ3B3HQyc8S6LcWAhbJIG71hfemW37Tw7scHLfl9/n9tt3d9i8sJlPFcBZFF71wFv0l6IWzKAbohbNor0AunMX5cYRcOItqbnrhLEYRP8L98Wx3t30Ii8bH0QZQW5xFmI/RC2fR24BaOIv3sAC9cBZxjl44i5CAXjiLOEcvnEVIQC+cxayDXjiLkFE7///lxGL9kN4AaouzCBnohbNIh+iFszh5A71wFs0heuEsWtegFs7ipWxeohfO4uoQ9MJZNA/QC2fRuq/VEXg5sXj8rOamtjiLyRT0wlkUXeTCWaz7S9ALZ3E2QC+cRXsFeuEsTiPkwllUc9MLZzGKUAtn0ShrHzlA4OXE4ul5PgbUFmfR24BcOItwB3rhLOIcvXAWIQG9cBZxjlw4i9dwAXrhLGYd9MJZhAz0wlmkX+zdS2sTYRhH8aeEaSYhJFhtkxprFS+hVVsTcTS1iogMVfGKilXBG16+ggs3Lop+a+HZFlyF0APn3Z/Vj2cz8E+qmNH7O7fn+3Unz412cRaTU42ZvbnBWeSQg3ZxFq+aw8DBWeSQgwdnsTgOHpxFazmCB2fR7AUOziKHHDQ4iw8H9QzOzbXOvIv7/Rxy0C7Oou4ED84ihxw4OIuzJwMHZ5FDDh6cxUYZODiL13luODiLURk4OIsccuDgLIrLh4YcR/7LicW9xznkoF2cRXEuggZn8TSHHDg4ix8rETg4izw3HJxFDjlwcBYXqsDBWeSQgwdnMakCB2fxptg/BHDkv5xYPHuSfxEAuziLHHLw4Cyaw+DBWbSWI3hwFovjwMFZ5Lnh4Cze1b3gwVm0NiN4cBZ5bsLRikNDDr+cAIqXeznk8OJoRX89Qjha8TGHHMLRihxyCMcr1soQjlcMphHC8YpRGcLhihxyCEcrcsghHK54Mdshx3x+Idb3fCuHHF4crejuNo7kE+6/Rf4jhxeHK7qrIRyvKI5HCEcr3h8sVSEcr7i2EyEcr5hUIRyvyCGHcLhiBkMO1zpzL34uHIsILw5XNIchHK54m0MO4XBFPQ7heEXrRoRwvKLuhXC84sx2hHC8ou6EcLgihxzC4Yq9S53APdc6N/vrwXteXA45cE+49pSoJtxaCTQTbgA8N+G+FSPiuQk3eAjkEq64fRqoJdwJ4rkJV6zwoPxy8uh3d5fn5MUxz024T91VoJJwxQ4RSbiliqUjHPjchJsQz024Yp+HI9znHHLgnnAL13kyrnW+PGgOgTJeXGuZCCNcPQayCNfaJKoIV/d4JMJ9zSEH7glXd4AgwvXPEz2EIw45Qrg2cMjhL8T++b5BHHJ4ce1pg/f8hditUfmPvTtbSSiKwyguxsYMrWi0UCu0OXLoWGolYtFF0QP0CA7NIxZ2F/TWPseCdV7hx3f3X2cDB+TiMrNABeHCAWxuwnFDDuFCgRdyCMcMOYTrMkMO4Yghh7VOr1UmArg4XMghHDTkEA4acgjHvCwXrk4MOYRjzk04Zsgh3Bbysly4RIUHYK3Tj4Bzc3EDZsghXAQMOYSDhhzCrbdhAMJBQw7hsCGHcBvAuQl3zww5hMsBQw5vTh6YL3K4OFzIIRw05BCOGXII12GGHMI9AkMO4aAhh3C4kEM4bsghXJjnAVjrPD1vAkMOF/cCDDmEg4YcwkFDDuFwIYdw0LkJBw05hGOGHMK9IkMO4ZInPAD/EPv2jrwsd3HJ0gTw8w+xwLm5OGbIIdwH8IkA4aAhh3DQkEM4XMghHDfkEI4YcljrfCJf5HBxX8CQQzhcyCEc+bJcuLBEDDmEW9gRAAfHDDmEu2GGHMK1mgIQ4Yghh7XO8Ig2NxcHvSwXzpADCsecm3DfoSYADg4acggHDTmEw4UcwnFDDuEMOYg3J5dRSQDg4i6AcxMOGnIIhws5hAOHHMLt8uYmHDPkEO4HGHIIhw05hAOGHNY68dtMWgDg4sI5bm7CQUMO4Zghh3AjZMghXCgLAIRjhhzC8Z4IEA4acgjHvCz3D7G/dUMO5OLG7NxBCQAACANAwUYb7LMkFhJsbQ7BC3KsPOiHWGjZu5MUhKEoCqJOgsZ2YIuILbboQAUhiaATFcUNuBvFDnftOgpq8FdwuLNfPAcAXFxQFQAGBw05hIOGHMIxQw7h7uFMABwcNeQQLtwLwKt1Dg/k3Fxcty8ADo56IkC4+kIAINx52hQAB0cNOYQbw+YmHDjkEA55IkA4YshhrXO6DnBzc3HQkEM4aMghHDLkEC4oC4CDg4YcwjFDDuGew5wAODhqyCGcIQfxz8lrjZubi4POTThmyCHcmxlyCLcDzk04aMghHC7kEA4acggHDTmEc27M9zXkYL5/O3BMAwAAgDDs4ZwJ/JtEB8lackgDk80WO2jo99UAAAAASUVORK5CYII=),
-                          linear-gradient(to right, rgba(0,149,221,0.30) 0, rgba(255,255,255,0.00) 50%),
-                          linear-gradient(to bottom, #FFFFFF 0%, #F1F1F1 100%);
-        background-position: top left, top left, top left;
-        background-repeat: no-repeat, no-repeat, no-repeat;
+        .tour-background {
+            background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAbgAAAEiCAMAAAC86TekAAABnlBMVEXk8vsKgNjk8Pv///+02O8AcMwAcdUAeckAAP8AgMoAesgAQP8AAAAAgKoAec4AAP8AbZIAVb8AgMwAdsQAdMUAdLkAbcgAb9MAgNEAM5kA//8AVVUAVf8AcM8AAAAAYJ8AasoAeMMAcaoAZrsAgL8AecIAddUAcL8AZv8AacMAgLMAeNIAd8wAYL88nuEAZrMAbbYAAFUAc8wSgNEKeswAXdEAQIAAgMyw2/IAbbYAYsTk8vsAZpkAZswahNMUgM4Accbg8Pni8PuLzOy74PPc7/kAccbT6vZMpd1yuOQAVarh8Psoj9ee0fCAv+bh8Pni8/nz+v7N6fXd7/nZ6vd6vebX7fvN5vXD5PQAgL+84vNotOjj8PnS6vqr2/Dc7vnY7PvC3/Pg7/ff7/tTrN+74PPU6/ZstegiiNXR5/rN5vW+4fPf7/mt1vGs2/EpjNbh8PmJyO3L6PWh0O/7/P6bze7b7vnZ7fuk0fDE4/TL6PrF4fTa7vvr9/qVyOr+/v+94fNXruCSyeqHxezE5PTg7/cKds602O/2/f7///9YS5i/AAAAiXRSTlMAGowAABkSEwEYFwQCBhUCBwwUDRYLDhcWBQEDAxABCBgRCQ8IFRgQBREKEQ8IIgoOAxQcGQsECk0HDYwFDx0aCYWLN1J8Em8lLwaJIEI0ioO6ZoB5MnRlXgxXLIdrRnt2WIOBKFNwLR5pZ1Z/S0cfiDhjQeM9enJDWmJcdaI88lUpPTVfghpO0Cssmt4AAAcLSURBVHhe7Ns/S8NAAIbxh8LR9A9xqamUtlRoLWIrGlRojGARIxQ3B3HQyc8S6LcWAhbJIG71hfemW37Tw7scHLfl9/n9tt3d9i8sJlPFcBZFF71wFv0l6IWzKAbohbNor0AunMX5cYRcOItqbnrhLEYRP8L98Wx3t30Ii8bH0QZQW5xFmI/RC2fR24BaOIv3sAC9cBZxjl44i5CAXjiLOEcvnEVIQC+cxayDXjiLkFE7///lxGL9kN4AaouzCBnohbNIh+iFszh5A71wFs0heuEsWtegFs7ipWxeohfO4uoQ9MJZNA/QC2fRuq/VEXg5sXj8rOamtjiLyRT0wlkUXeTCWaz7S9ALZ3E2QC+cRXsFeuEsTiPkwllUc9MLZzGKUAtn0ShrHzlA4OXE4ul5PgbUFmfR24BcOItwB3rhLOIcvXAWIQG9cBZxjlw4i9dwAXrhLGYd9MJZhAz0wlmkX+zdS2sTYRhH8aeEaSYhJFhtkxprFS+hVVsTcTS1iogMVfGKilXBG16+ggs3Lop+a+HZFlyF0APn3Z/Vj2cz8E+qmNH7O7fn+3Unz412cRaTU42ZvbnBWeSQg3ZxFq+aw8DBWeSQgwdnsTgOHpxFazmCB2fR7AUOziKHHDQ4iw8H9QzOzbXOvIv7/Rxy0C7Oou4ED84ihxw4OIuzJwMHZ5FDDh6cxUYZODiL13luODiLURk4OIsccuDgLIrLh4YcR/7LicW9xznkoF2cRXEuggZn8TSHHDg4ix8rETg4izw3HJxFDjlwcBYXqsDBWeSQgwdnMakCB2fxptg/BHDkv5xYPHuSfxEAuziLHHLw4Cyaw+DBWbSWI3hwFovjwMFZ5Lnh4Cze1b3gwVm0NiN4cBZ5bsLRikNDDr+cAIqXeznk8OJoRX89Qjha8TGHHMLRihxyCMcr1soQjlcMphHC8YpRGcLhihxyCEcrcsghHK54Mdshx3x+Idb3fCuHHF4crejuNo7kE+6/Rf4jhxeHK7qrIRyvKI5HCEcr3h8sVSEcr7i2EyEcr5hUIRyvyCGHcLhiBkMO1zpzL34uHIsILw5XNIchHK54m0MO4XBFPQ7heEXrRoRwvKLuhXC84sx2hHC8ou6EcLgihxzC4Yq9S53APdc6N/vrwXteXA45cE+49pSoJtxaCTQTbgA8N+G+FSPiuQk3eAjkEq64fRqoJdwJ4rkJV6zwoPxy8uh3d5fn5MUxz024T91VoJJwxQ4RSbiliqUjHPjchJsQz024Yp+HI9znHHLgnnAL13kyrnW+PGgOgTJeXGuZCCNcPQayCNfaJKoIV/d4JMJ9zSEH7glXd4AgwvXPEz2EIw45Qrg2cMjhL8T++b5BHHJ4ce1pg/f8hditUfmPvTtbSSiKwyguxsYMrWi0UCu0OXLoWGolYtFF0QP0CA7NIxZ2F/TWPseCdV7hx3f3X2cDB+TiMrNABeHCAWxuwnFDDuFCgRdyCMcMOYTrMkMO4Yghh7VOr1UmArg4XMghHDTkEA4acgjHvCwXrk4MOYRjzk04Zsgh3Bbysly4RIUHYK3Tj4Bzc3EDZsghXAQMOYSDhhzCrbdhAMJBQw7hsCGHcBvAuQl3zww5hMsBQw5vTh6YL3K4OFzIIRw05BCOGXII12GGHMI9AkMO4aAhh3C4kEM4bsghXJjnAVjrPD1vAkMOF/cCDDmEg4YcwkFDDuFwIYdw0LkJBw05hGOGHMK9IkMO4ZInPAD/EPv2jrwsd3HJ0gTw8w+xwLm5OGbIIdwH8IkA4aAhh3DQkEM4XMghHDfkEI4YcljrfCJf5HBxX8CQQzhcyCEc+bJcuLBEDDmEW9gRAAfHDDmEu2GGHMK1mgIQ4Yghh7XO8Ig2NxcHvSwXzpADCsecm3DfoSYADg4acggHDTmEw4UcwnFDDuEMOYg3J5dRSQDg4i6AcxMOGnIIhws5hAOHHMLt8uYmHDPkEO4HGHIIhw05hAOGHNY68dtMWgDg4sI5bm7CQUMO4Zghh3AjZMghXCgLAIRjhhzC8Z4IEA4acgjHvCz3D7G/dUMO5OLG7NxBCQAACANAwUYb7LMkFhJsbQ7BC3KsPOiHWGjZu5MUhKEoCqJOgsZ2YIuILbboQAUhiaATFcUNuBvFDnftOgpq8FdwuLNfPAcAXFxQFQAGBw05hIOGHMIxQw7h7uFMABwcNeQQLtwLwKt1Dg/k3Fxcty8ADo56IkC4+kIAINx52hQAB0cNOYQbw+YmHDjkEA55IkA4YshhrXO6DnBzc3HQkEM4aMghHDLkEC4oC4CDg4YcwjFDDuGew5wAODhqyCGcIQfxz8lrjZubi4POTThmyCHcmxlyCLcDzk04aMghHC7kEA4acggHDTmEc27M9zXkYL5/O3BMAwAAgDDs4ZwJ/JtEB8lackgDk80WO2jo99UAAAAASUVORK5CYII=),
+                              linear-gradient(to right, rgba(0,149,221,0.30) 0, rgba(255,255,255,0.00) 50%),
+                              linear-gradient(to bottom, #FFFFFF 0%, #F1F1F1 100%);
+            background-position: top left, top left, top left;
+            background-repeat: no-repeat, no-repeat, no-repeat;
+        }
         .tour-item {
             float: right;
         }
@@ -502,6 +511,9 @@ html[dir="rtl"] {
     .progress-step {
         display: none;
     }
+    .tour-background {
+        height: auto;
+    }
     .ui-tour-list {
         .tour-step {
             display: block;
@@ -527,7 +539,6 @@ html[dir="rtl"] {
         background-size: 19px 19px;
     }
     #ui-tour {
-        background-size: 440px 290px, 100% 100%, 100% 100%;
         .ui-tour-controls {
             .next {
                 .right-arrow-high-res;
@@ -565,7 +576,10 @@ html[dir="rtl"] {
 
 @media only screen and (max-height: 629px) {
     #ui-tour {
-        height: 290px;
+        height: 390px;
+        .tour-background {
+            height: 290px;
+        }
         .ui-tour-list .tour-step {
             img {
                 display: none;
@@ -579,7 +593,10 @@ html[dir="rtl"] {
 
 @media only screen and (min-height: 630px) and (max-height: 768px) {
     #ui-tour {
-        height: 500px;
+        height: 600px;
+        .tour-background {
+            height: 500px;
+        }
         .ui-tour-list .tour-step {
             background-image: none;
             img {


### PR DESCRIPTION
![button-flicker-2](https://cloud.githubusercontent.com/assets/400117/4285388/204141fe-3d86-11e4-9bed-7ab5444060bf.gif)

Using the latest Nightly (35.0a1 2014-09-15) there's some slight flicker in the Next/Prev buttons in the on-boarding tour. Seems to be related to when CSS transforms occur going from one step to the next, and is caused because the buttons are overflowing their parent container visually.

This is likely a bug introduced in Firefox (going to see if I can make a reduced test case and file a bug if so), but we should probably find a workaround for the tour page in the meantime. This change moves the buttons so they are no longer a child element of the animated panel (and thus do not need to overflow the container). This fixes the flicker and also feels like a more solid and reliable choice.

example URL's to test:

`/firefox/32.0/whatsnew/?oldversion=28.0`
`/firefox/32.0/firstrun/`
