### PR TITLE
Fix bug 1069545: OS X users should get 32.0 until Apple approves 32.0.2.

### DIFF
--- a/bedrock/firefox/firefox_details.py
+++ b/bedrock/firefox/firefox_details.py
@@ -151,10 +151,10 @@ class FirefoxDetails(ProductDetails):
         :return: string url
         """
         # Bug 1069545
-        # Have to serve OS X 32.0.1 until Apple whitelists 32.0.2 :/
+        # Have to serve OS X 32.0 until Apple whitelists 32.0.2 :/
         # TODO: REMOVE ME WHEN APPLE DOES THEIR JOB
-        if platform == 'OS X' and version == '32.0.2':
-            version = '32.0.1'
+        if platform == 'OS X' and version.startswith('32.0.'):
+            version = '32.0'
 
         if platform == 'OS X' and language == 'ja':
             language = 'ja-JP-mac'

--- a/bedrock/mozorg/helpers/download_buttons.py
+++ b/bedrock/mozorg/helpers/download_buttons.py
@@ -173,10 +173,10 @@ def download_firefox(ctx, build='release', small=False, icon=True,
     if not mobile:
         for plat_os in ['Windows', 'Linux', 'Linux 64', 'OS X']:
             # Bug 1069545
-            # Have to serve OS X 32.0.1 until Apple whitelists 32.0.2 :/
+            # Have to serve OS X 32.0 until Apple whitelists 32.0.2 :/
             # TODO: REMOVE ME WHEN APPLE DOES THEIR JOB
-            if plat_os == 'OS X' and version == '32.0.2':
-                version = '32.0.1'
+            if plat_os == 'OS X' and version.startswith('32.0.'):
+                version = '32.0'
 
             # Fallback to en-US if this plat_os/version isn't available
             # for the current locale


### PR DESCRIPTION
@jpetto another quick r?
