### PR TITLE
Bug 1069335 Include aurora notes in redirects to website-archive

### DIFF
--- a/etc/httpd/global.conf
+++ b/etc/httpd/global.conf
@@ -558,8 +558,8 @@ RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?(firefox|mobile)/([3-9]\d\.\d(?:a2|
 # bug 1001238, 1025056
 RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?firefox/(24\.[5678]\.\d)/releasenotes(/)?$ /b/$1firefox/$2/releasenotes$3 [L,PT]
 
-# bug 1041712
-RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)(firefox|mobile)/([0-9]|1[0-9]|2[0-8])\.(\d+(?:beta|\.\d+)?)/releasenotes/(.*)$ http://website-archive.mozilla.org/www.mozilla.org/firefox_releasenotes/$1$2/$3.$4/releasenotes/$5 [L,R=301]
+# bug 1041712, 1069335
+RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)(firefox|mobile)/([0-9]|1[0-9]|2[0-8])\.(\d+(?:beta|a2|\.\d+)?)/(release|aurora)notes/(.*)$ http://website-archive.mozilla.org/www.mozilla.org/firefox_releasenotes/$1$2/$3.$4/$5notes/$6 [L,R=301]
 
 # bug 957242
 RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?firefox/(.*)/system-requirements(/)?$ /b/$1firefox/$2/system-requirements$3 [PT]


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1069335

Update the legacy release notes website-archive redirects to include Aurora notes.
