### PR TITLE
Bug 1026184: Fix security product version compare.

### DIFF
--- a/bedrock/security/models.py
+++ b/bedrock/security/models.py
@@ -28,6 +28,8 @@ class Product(models.Model):
     @property
     def name_tuple(self):
         name, vers = self.name.rsplit(None, 1)
+        if '.' not in vers:
+            vers += '.0'
         return name, Version(vers)
 
     @property

--- a/bedrock/security/tests/test_models.py
+++ b/bedrock/security/tests/test_models.py
@@ -12,8 +12,10 @@ class TestModels(TestCase):
         pv2 = Product.objects.create(name='Firefox 24.0')
         pv0 = Product.objects.create(name='Fennec 24.0')
         pv1 = Product.objects.create(name='Firefox 23.0')
-        pvs = [pv2, pv0, pv3, pv1]
-        self.assertListEqual([pv0, pv1, pv2, pv3], sorted(pvs))
+        pv4 = Product.objects.create(name='Firefox 25')
+        pv5 = Product.objects.create(name='Firefox 22')
+        pvs = [pv2, pv0, pv3, pv1, pv4, pv5]
+        self.assertListEqual([pv0, pv5, pv1, pv2, pv3, pv4], sorted(pvs))
 
     def test_product_version_slug(self):
         """Slug should include the version."""


### PR DESCRIPTION
Would fail to create a proper version if version
string contained no minor version (e.g. "31").

@jgmize r?
