### PR TITLE
Remove invalid check for XP SP2: fix bug 1070625

### DIFF
--- a/media/js/base/site.js
+++ b/media/js/base/site.js
@@ -34,12 +34,6 @@
                  */
                 return 'oldwin';
             }
-            if (ua.indexOf("MSIE 6.0") !== -1 &&
-                    ua.indexOf("Windows NT 5.1") !== -1 &&
-                    ua.indexOf("SV1") === -1) {
-                // Windows XP SP1
-                return 'oldwin';
-            }
             if (pf.indexOf("Win32") !== -1 ||
                     pf.indexOf("Win64") !== -1) {
                 return 'windows';


### PR DESCRIPTION
Remove check for users on IE 6.0 on XP SP2 that was invalidated by SP3
