### PR TITLE
Bug 1026184: Fix known-vulnerabilities anchors and add redirects.

### DIFF
--- a/bedrock/security/models.py
+++ b/bedrock/security/models.py
@@ -27,10 +27,15 @@ class Product(models.Model):
 
     @property
     def name_tuple(self):
-        name, vers = self.name.rsplit(None, 1)
+        product, vers = self.name.rsplit(None, 1)
         if '.' not in vers:
             vers += '.0'
-        return name, Version(vers)
+        return product, Version(vers)
+
+    @property
+    def html_id(self):
+        """Conform to the IDs from the old page so old URL anchors work."""
+        return self.slug.replace('-', '')
 
     @property
     def version(self):
@@ -45,9 +50,11 @@ class Product(models.Model):
 
     def save(self, force_insert=False, force_update=False,
              using=None, update_fields=None):
-        self.product = self.name_tuple[0]
-        self.product_slug = slugify(self.product)
-        self.slug = '{0}-{1}'.format(self.product_slug, self.version)
+        # do not use self.name_tuple because don't want ".0" on versions.
+        product, vers = self.name.rsplit(None, 1)
+        self.product = product
+        self.product_slug = slugify(product)
+        self.slug = '{0}-{1}'.format(self.product_slug, vers)
         super(Product, self).save(force_insert, force_update,
                                   using, update_fields)
 

--- a/bedrock/security/templates/security/product-advisories.html
+++ b/bedrock/security/templates/security/product-advisories.html
@@ -12,8 +12,8 @@
       {% include "security/partials/impact_key.html" %}
 
       {% for version in product_versions %}
-        <h3 id="{{ version.slug }}" class="level-heading">
-          <a class="anchor" href="#{{ version.slug }}">#</a>
+        <h3 id="{{ version.html_id }}" class="level-heading">
+          <a class="anchor" href="#{{ version.html_id }}">#</a>
           Fixed in {{ version.name }}
         </h3>
         <ul>

--- a/bedrock/security/tests/test_commands.py
+++ b/bedrock/security/tests/test_commands.py
@@ -9,10 +9,14 @@ from bedrock.security.management.commands import update_security_advisories
 
 class TestUpdateSecurityAdvisories(TestCase):
     def test_fix_product_name(self):
-        """Should fix SeaMonkey and nothing else."""
+        """Should fix SeaMonkey and strip '.0' from names."""
         eq_(update_security_advisories.fix_product_name('Seamonkey 2.2'),
             'SeaMonkey 2.2')
         eq_(update_security_advisories.fix_product_name('Firefox 2.2'),
             'Firefox 2.2')
         eq_(update_security_advisories.fix_product_name('fredflintstone 2.2'),
             'fredflintstone 2.2')
+        eq_(update_security_advisories.fix_product_name('Firefox 32.0'),
+            'Firefox 32')
+        eq_(update_security_advisories.fix_product_name('Firefox 32.0.1'),
+            'Firefox 32.0.1')

--- a/bedrock/security/urls.py
+++ b/bedrock/security/urls.py
@@ -8,6 +8,7 @@ from bedrock.mozorg.util import page
 from bedrock.security.views import (
     AdvisoriesView,
     AdvisoryView,
+    KVRedirectsView,
     OldAdvisoriesListView,
     OldAdvisoriesView,
     ProductView,
@@ -31,6 +32,7 @@ urlpatterns = patterns('',  # noqa
         ProductView.as_view(), name='security.product-advisories'),
     url(r'^known-vulnerabilities/(?P<slug>[\w-]+-\d{1,3}(\.\d{1,3})?)/$',
         ProductVersionView.as_view(), name='security.product-version-advisories'),
+    url(r'^known-vulnerabilities/(?P<filename>.*)\.html$', KVRedirectsView.as_view()),
 
     url(r'^announce/\d{4}/mfsa(?P<pk>\d{4}-\d{2,3})\.html$', OldAdvisoriesView.as_view()),
     url(r'^announce/$', OldAdvisoriesListView.as_view()),


### PR DESCRIPTION
- Add flag for clearing the security advisories data.
- Default to stripping '.0' from versions for consistent naming.

@jgmize r?
