### PR TITLE
Fix Bug 1072170: Stopped the redirection: /ja/about/legal -> mozilla.jp

### DIFF
--- a/etc/httpd/global.conf
+++ b/etc/httpd/global.conf
@@ -183,8 +183,9 @@ RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/toolkit/download-to-your-devices(.*)
 # bug 921564
 RewriteRule ^/(ach|af|ak|an|ar|as|ast|az|be|bg|bn-BD|bn-IN|br|bs|ca|cs|csb|cy|da|de|dsb|el|en-GB|en-US|en-ZA|eo|es-AR|es-CL|es-ES|es-MX|et|eu|fa|ff|fi|fr|fy-NL|ga-IE|gd|gl|gu-IN|he|hi-IN|hr|hsb|hu|hy-AM|id|is|it|ja|ja-JP-mac|ka|kk|km|kn|ko|ku|lg|lij|lt|lv|mai|mk|ml|mn|mr|ms|my|nb-NO|nl|nn-NO|nso|oc|or|pa-IN|pl|pt-BR|pt-PT|rm|ro|ru|sah|si|sk|sl|son|sq|sr|sv-SE|sw|ta|ta-LK|te|th|tr|uk|ur|uz|vi|wo|xh|zh-CN|zh-TW|zu)(/?)$ /b/$1$2 [PT]
 
-# bug 987059, 1050149
+# bug 987059, 1050149, 1072170
 RewriteCond %{REQUEST_URI} !^/ja/about/manifesto
+RewriteCond %{REQUEST_URI} !^/ja/about/legal
 RewriteRule ^/ja/about(/?|/.+)$ http://www.mozilla.jp/about/mozilla/ [L,R=301]
 
 # bug 889958


### PR DESCRIPTION
This modification is for Bug 1072170.
