### PR TITLE
[fix bug 1067143] Missing ZTE Open C on german language Firefox OS page

### DIFF
--- a/bedrock/firefox/templates/firefox/os/_get_device.html
+++ b/bedrock/firefox/templates/firefox/os/_get_device.html
@@ -53,7 +53,7 @@
             <li><a class="alcatel-one-touch-fire" href="http://aktion.congstar.de/firefox-os">Alcatel One Touch Fire</a></li>
             <li><a class="alcatel-one-touch-fire-e" href="http://www.congstar.de/handy/alcatel-one-touch-fire-e-braun/">Alcatel One Touch Fire E</a></li>
             <li><a class="alcatel-one-touch-fire o2" href="http://www.o2online.de/handy/alcatel-onetouch-fire-e/">Alcatel One Touch Fire E</a></li>
-            <li class="developer-only"><a class="zte-open-c" href="http://www.ebay.de/itm/eBay-Exklusiv-ZTE-OPEN-C-Neuesten-Firefox-OS-DualCore-1-2-GHz-4-0-3G-Smartphone-/131151681046?ssPageName=STRK:MESE:IT">ZTE Open C</a></li>
+            <li><a class="zte-open-c" href="http://www.ebay.de/itm/eBay-Exklusiv-ZTE-OPEN-C-Neuesten-Firefox-OS-DualCore-1-2-GHz-4-0-3G-Smartphone-/131151681046?ssPageName=STRK:MESE:IT">ZTE Open C</a></li>
           </ul>
         </div>
         <div class="provider" data-country="es">
@@ -76,10 +76,10 @@
             <li><a class="webdistrib" href="http://www.webdistrib.com/cat/Smartphone-ZTE-Open-C-Night-Blue-Firefox-OS-__p_925735.html">Webdistrib</a></li>
           </ul>
         </div>
-        <div class="provider developer-only" data-country="gb">
+        <div class="provider" data-country="gb">
           <h3>{{_('United Kingdom')}}</h3>
           <ul>
-            <li class="developer-only"><a class="ebay" href="http://item.ebay.co.uk/171301269724">eBay</a></li>
+            <li><a class="ebay" href="http://item.ebay.co.uk/171301269724">eBay</a></li>
           </ul>
         </div>
         <div class="provider" data-country="gr">
@@ -165,10 +165,10 @@
             <li><a class="telenor" href="https://www.telenor.rs/sr/Privatni-korisnici/webshop/Mobilni-telefoni/Alcatel/One_Touch_Fire">Telenor</a></li>
           </ul>
         </div>
-        <div class="provider developer-only" data-country="ru">
+        <div class="provider" data-country="ru">
           <h3>{{_('Russia')}}</h3>
           <ul>
-            <li class="developer-only"><a class="ebay" href="http://www.ebay.com/itm/eBay-Exclusive-ZTE-OPEN-C-Dual-Core-4-Latest-Firefox-OS-3G-Unlocked-Smartphone-/111326263156?ssPageName=STRK:MESE:IT">eBay</a></li>
+            <li><a class="ebay" href="http://www.ebay.com/itm/eBay-Exclusive-ZTE-OPEN-C-Dual-Core-4-Latest-Firefox-OS-3G-Unlocked-Smartphone-/111326263156?ssPageName=STRK:MESE:IT">eBay</a></li>
           </ul>
         </div>
         <div class="provider" data-country="sv">
@@ -177,10 +177,10 @@
             <li><a class="movistar" href="http://www.movistar.com.sv/sv/root/catalogo/telefono.php?terminal=183">{{_('Movistar')}}</a></li>
           </ul>
         </div>
-        <div class="provider developer-only" data-country="us">
+        <div class="provider" data-country="us">
           <h3>{{_('United States')}}</h3>
           <ul>
-            <li class="developer-only"><a class="ebay" href="http://item.ebay.com/291125433026">eBay</a></li>
+            <li><a class="ebay" href="http://item.ebay.com/291125433026">eBay</a></li>
           </ul>
         </div>
         <div class="provider" data-country="uy">

--- a/media/css/firefox/os/firefox-os.less
+++ b/media/css/firefox/os/firefox-os.less
@@ -393,11 +393,6 @@ section p, header p {
   }
 }
 
-//developer only phones should only display on /firefox/os/devices
-#provider-links .developer-only {
-    display: none;
-}
-
 //get phone modals are JS dependent, so hide by default
 #primary-cta-phone, #secondary-cta-phone {
   display: none;

--- a/media/js/firefox/os/firefox-os.js
+++ b/media/js/firefox/os/firefox-os.js
@@ -27,7 +27,6 @@
     */
     function setPartnerContent () {
         var $provider = $('#provider-links').find('.provider[data-country="' + COUNTRY_CODE + '"]');
-        var $links;
 
         // show language content selector if user is in india visiting the en-US/en-GB page
         if (COUNTRY_CODE.toLowerCase() === 'in' && /en-US|en-GB/.test($('html').attr('lang'))) {
@@ -44,21 +43,15 @@
             initLangContentSelector(suppressLangContentSelector);
         }
 
-        if (COUNTRY_CODE !== '' && $provider.length > 0) {
-            // make sure there are consumer-focused (non 'developer_only') partners
-            // available in the current country
-            $links = $provider.find('li').not('.developer-only');
-        }
-
         // if there are partners available, update UI
-        if ($links && $links.length > 0) {
+        if (COUNTRY_CODE !== '' && $provider.length > 0) {
             // show get phone calls to action
             $('#primary-cta-phone').fadeIn();
             $('#primary-cta-signup').addClass('visibility', 'hidden');
             $('#secondary-cta-phone').css('display', 'inline-block');
 
             // if country has more than one provider, show the multi intro text
-            if ($links.length > 1) {
+            if ($provider.find('li').length > 1) {
                 $('#provider-text-single').hide();
                 $('#provider-text-multi').show();
             }
@@ -70,7 +63,7 @@
             $('#provider-links a').on('click', trackProviderExit);
 
             // persistent pencil icon is distracting/obtrusive on small screens
-            if ($(window).width() > 480) {
+            if ($window.width() > 480) {
                 $('#signup-toggle-icon').fadeIn();
             }
         } else {


### PR DESCRIPTION
New policy going forward is that all e-bay phone links will show up on both `/firefox/os` and `/firefox/os/devices`, as per [this comment in the bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1067143#c4).
