### PR TITLE
Fix Bug 1069902 - Broken link on website-archive

### DIFF
--- a/etc/httpd/global.conf
+++ b/etc/httpd/global.conf
@@ -544,10 +544,10 @@ RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/os/releasenotes/1.1(.*)$ /b/$1firefo
 RewriteRule ^/projects/devpreview/firstrun(?:/(?:index.html)?)?$ /firefox/firstrun/ [L,R=301]
 RewriteRule ^/projects/devpreview/(.*)$ http://website-archive.mozilla.org/www.mozilla.org/devpreview_releasenotes/projects/devpreview/$1 [L,R=301]
 
-# bug 947890
+# bug 947890, 1069902
 RewriteRule ^/en-US/firefox/releases/1\.(.*)$ http://website-archive.mozilla.org/www.mozilla.org/firefox_releasenotes/en-US/firefox/releases/1.$1 [L,R=301]
 RewriteRule ^/en-US/firefox/releases/0\.(.*)$ http://website-archive.mozilla.org/www.mozilla.org/firefox_releasenotes/en-US/firefox/releases/0.$1 [L,R=301]
-RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)(firefox|mobile)/(\d)\.(.*)/releasenotes(.*)$ http://website-archive.mozilla.org/www.mozilla.org/firefox_releasenotes/$1$2/$3.$4/releasenotes$5 [L,R=301]
+RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)(firefox|mobile)/(\d)\.(.*)/releasenotes(.*)$ http://website-archive.mozilla.org/www.mozilla.org/firefox_releasenotes/en-US/$2/$3.$4/releasenotes$5 [L,R=301]
 
 # bug 988746, 989423, 994186
 RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?(firefox|mobile)/(2[38]\.0(?:\.\d)?)/releasenotes(/)?$ /b/$1$2/$3/releasenotes$4 [L,PT]
@@ -557,8 +557,8 @@ RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?(firefox|mobile)/([3-9]\d\.\d(?:a2|
 # bug 1001238, 1025056
 RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?firefox/(24\.[5678]\.\d)/releasenotes(/)?$ /b/$1firefox/$2/releasenotes$3 [L,PT]
 
-# bug 1041712, 1069335
-RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)(firefox|mobile)/([0-9]|1[0-9]|2[0-8])\.(\d+(?:beta|a2|\.\d+)?)/(release|aurora)notes/(.*)$ http://website-archive.mozilla.org/www.mozilla.org/firefox_releasenotes/$1$2/$3.$4/$5notes/$6 [L,R=301]
+# bug 1041712, 1069335, 1069902
+RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)(firefox|mobile)/([0-9]|1[0-9]|2[0-8])\.(\d+(?:beta|a2|\.\d+)?)/(release|aurora)notes/(.*)$ http://website-archive.mozilla.org/www.mozilla.org/firefox_releasenotes/en-US/$2/$3.$4/$5notes/$6 [L,R=301]
 
 # bug 957242
 RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?firefox/(.*)/system-requirements(/)?$ /b/$1firefox/$2/system-requirements$3 [PT]


### PR DESCRIPTION
We don't have any translations for the release notes, we can just hardcode `en-US` in the URLs.
