### PR TITLE
[fix bug 1073239] Update support link on Firefox release notes

### DIFF
--- a/bedrock/firefox/templates/firefox/releases/release-notes.html
+++ b/bedrock/firefox/templates/firefox/releases/release-notes.html
@@ -125,7 +125,7 @@
       <section id="problems">
         <h3>{{ _('Having Problems?') }}</h3>
         <ol>
-          <li><a href="http://support.mozilla.org/">{{ _('Search for answers on the Firefox Support page') }}</a></li>
+          <li><a href="{{ support_url }}">{{ _('Search for answers on the Firefox Support page') }}</a></li>
           {% if known_issues %}
           <li><a href="#known-issues">{{ _('Look at the known issues list and see if we already know about the problem') }}</a></li>
           {% endif %}

--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -103,6 +103,12 @@ INSTALLER_CHANNElS = [
     # 'nightly',  # soon
 ]
 
+SUPPORT_URLS = {
+    'Firefox for Android': 'https://support.mozilla.org/products/mobile',
+    'Firefox OS': 'https://support.mozilla.org/products/firefox-os',
+    'Firefox': 'https://support.mozilla.org/products/firefox'
+}
+
 
 def get_js_bundle_files(bundle):
     """
@@ -540,6 +546,7 @@ def release_notes(request, fx_version, product='Firefox'):
         request, release_notes_template(release.channel, product), {
             'version': fx_version,
             'download_url': get_download_url(release),
+            'support_url': SUPPORT_URLS.get(product, 'https://support.mozilla.org/'),
             'release': release,
             'equivalent_release_url': equivalent_release_url(release),
             'new_features': new_features,


### PR DESCRIPTION
Update support link on Firefox release notes depending on product.

https://bugzilla.mozilla.org/show_bug.cgi?id=1073239
