### PR TITLE
Redirect to archived Python NSS docs

### DIFF
--- a/etc/httpd/global.conf
+++ b/etc/httpd/global.conf
@@ -94,6 +94,9 @@ RewriteRule ^/projects/security/pki/pkcs11.* https://developer.mozilla.org/docs/
 RewriteRule ^/projects/security/pki/psm.* https://developer.mozilla.org/docs/Mozilla/Projects/PSM [L,R=301]
 RewriteRule ^/projects/security/pki/src.* https://developer.mozilla.org/docs/Mozilla/Projects/NSS/NSS_Sources_Building_Testing [L,R=301]
 
+# bug 975476
+RewriteRule ^/projects/security/pki(.*)$ http://website-archive.mozilla.org/www.mozilla.org/python_nss_docs/projects/security/pki$1 [L,R=301]
+
 # bug 780672
 RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/webhero(.*)$ /firefox/ [L,R=301]
 


### PR DESCRIPTION
Bug 975476

https://www.mozilla.org/projects/security/pki/python-nss/doc/api/current/html/
