### PR TITLE
Fix Bug 935719 - Tabzilla: Create an out of date version warning for users not on the current version

### DIFF
--- a/bedrock/base/templates/base-resp.html
+++ b/bedrock/base/templates/base-resp.html
@@ -94,7 +94,7 @@
 
     {% block site_header %}
       <header id="masthead">
-        <a href="{{ url('mozorg.home') }}" id="tabzilla" data-infobar="{{ settings.TABZILLA_INFOBAR_OPTIONS }}">Mozilla</a>
+        <a href="{{ url('mozorg.home') }}" id="tabzilla" data-infobar="{% block tabzilla_infobar %}{{ settings.TABZILLA_INFOBAR_OPTIONS }}{% endblock %}">Mozilla</a>
 
         {% block site_header_nav %}
         <nav id="nav-main" role="navigation">

--- a/bedrock/base/templates/base.html
+++ b/bedrock/base/templates/base.html
@@ -92,7 +92,7 @@
 
     {% block site_header %}
       <header id="masthead">
-        <a href="{{ url('mozorg.home') }}" id="tabzilla" data-infobar="{{ settings.TABZILLA_INFOBAR_OPTIONS }}">Mozilla</a>
+        <a href="{{ url('mozorg.home') }}" id="tabzilla" data-infobar="{% block tabzilla_infobar %}{{ settings.TABZILLA_INFOBAR_OPTIONS }}{% endblock %}">Mozilla</a>
 
         {% block site_header_nav %}
         <nav id="nav-main" role="navigation">

--- a/bedrock/firefox/templates/firefox/new.html
+++ b/bedrock/firefox/templates/firefox/new.html
@@ -9,6 +9,9 @@
 {% block page_desc %}{{_('Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox today!')}}{% endblock %}
 {% block body_id %}firefox-new{% endblock %}
 
+{#- Override the infobar options not to run the version check -#}
+{% block tabzilla_infobar %}translation{% endblock %}
+
 {% block site_header_nav %}{% endblock %}
 {% block site_header_logo %}
   <h2><img src="{{ MEDIA_URL }}img/firefox/new/header-firefox.png?2013-06" alt="{{_('Firefox for desktop')}}"></h2>

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -1053,7 +1053,8 @@ FIREFOX_TWITTER_ACCOUNTS = {
 # Mapbox token for spaces and communities pages
 MAPBOX_TOKEN = 'examples.map-i86nkdio'
 
-TABZILLA_INFOBAR_OPTIONS = 'translation'
+# Tabzilla Information Bar default options
+TABZILLA_INFOBAR_OPTIONS = 'update translation'
 
 # Optimize.ly project code for base template JS snippet
 OPTIMIZELY_PROJECT_ID = None

--- a/docs/tabzilla.rst
+++ b/docs/tabzilla.rst
@@ -80,3 +80,17 @@ Adding the Translation Bar extension to Tabzilla requires:
     <a href="https://www.mozilla.org/" id="tabzilla" data-infobar="translation">mozilla</a>
 
 .. note:: Though the Translation Bar is currently implemented as an extension of Tabzilla, it might be moved to a standalone language utility in the future.
+
+
+Update Bar
+---------------
+
+This is another information bar intended to improve user security. It checks if the user is using the latest Firefox version, and if not, prompts the user to update the browser.
+
+Adding the Update Bar extension to Tabzilla requires:
+
+1. Add the ``data-infobar`` attribute to the tab link, with the ``update`` option::
+
+    <a href="https://www.mozilla.org/" id="tabzilla" data-infobar="update translation">mozilla</a>
+
+The value of the ``data-infobar`` attribute is the order of priority. You can enable both the Update Bar and Translation Bar as the example above, but one information bar will be shown at a time.

--- a/media/js/test/spec/tabzilla.js
+++ b/media/js/test/spec/tabzilla.js
@@ -43,7 +43,7 @@ describe("tabzilla.js", function() {
 
     var testTransbar = function () {
 
-        var setup = Tabzilla.setupTransbar;
+        var setup = Tabzilla.infobar.translation;
 
         it('should return false if the user\'s language is the same as the page\'s language', function () {
 
@@ -82,7 +82,7 @@ describe("tabzilla.js", function() {
         });
     };
 
-    describe('setupTransbar – alternate URLs', function () {
+    describe('infobar.translation – alternate URLs', function () {
 
         beforeEach(function () {
             sandbox = sinon.sandbox.create();
@@ -99,7 +99,7 @@ describe("tabzilla.js", function() {
         testTransbar();
     });
 
-    describe('setupTransbar – language switcher', function () {
+    describe('infobar.translation – language switcher', function () {
 
         beforeEach(function () {
             sandbox = sinon.sandbox.create();
@@ -119,7 +119,7 @@ describe("tabzilla.js", function() {
         testTransbar();
     });
 
-    describe('setupTransbar – language switcher with path values', function () {
+    describe('infobar.translation – language switcher with path values', function () {
 
         beforeEach(function () {
             sandbox = sinon.sandbox.create();
@@ -137,5 +137,55 @@ describe("tabzilla.js", function() {
         });
 
         testTransbar();
+    });
+
+    describe("infobar.update", function () {
+
+        var setup = function (ua) {
+            // Test a case where the latest version is a non-dot release
+            var result1 = Tabzilla.infobar.update(ua, '26.0');
+
+            // Cleanup
+            $('#tabzilla-infobar').remove();
+
+            // Test a case where the latest version is a dot release
+            var result2 = Tabzilla.infobar.update(ua, '25.0.1');
+
+            // Cleanup
+            $('#tabzilla-infobar').remove();
+
+            return result1 && result2;
+        }
+
+        it('should return false if the user agent is not Firefox', function () {
+            expect(setup('Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Trident/5.0)')).toBeFalsy();
+            expect(setup('Mozilla/5.0 (Macintosh; U; PPC Mac OS X 10.4; en; rv:1.9.2.24) Gecko/20111114 Camino/2.1 (like Firefox/3.6.24)')).toBeFalsy();
+            expect(setup('Mozilla/5.0 (X11; Linux i686; rv:10.0.1) Gecko/20100101 Firefox/10.0.1 SeaMonkey/2.7.1')).toBeFalsy();
+            expect(setup('Mozilla/5.0 (Windows NT 5.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1650.16 Safari/537.36')).toBeFalsy();
+        });
+
+        it('should return false if the user agent is a latest Firefox version', function () {
+            expect(setup('Mozilla/5.0 (Macintosh; Intel Mac OS X 10.9; rv:29.0) Gecko/20100101 Firefox/29.0')).toBeFalsy();
+            expect(setup('Mozilla/5.0 (Windows NT 6.1; Win64; x64; rv:26.0) Gecko/20100101 Firefox/26.0')).toBeFalsy();
+            expect(setup('Mozilla/5.0 (Macintosh; Intel Mac OS X 10.8; rv:24.0) Gecko/20100101 Firefox/24.0')).toBeFalsy();
+        });
+
+        it('should return false if the user agent is Firefox for mobile', function () {
+            // Nokia N900 Linux mobile, on the Fennec browser
+            expect(setup('Mozilla/5.0 (Maemo; Linux armv7l; rv:10.0) Gecko/20100101 Firefox/10.0 Fennec/10.0')).toBeFalsy();
+            // Android phone and tablet
+            expect(setup('Mozilla/5.0 (Android; Mobile; rv:26.0) Gecko/26.0 Firefox/26.0')).toBeFalsy();
+            expect(setup('Mozilla/5.0 (Android; Tablet; rv:26.0) Gecko/26.0 Firefox/26.0')).toBeFalsy();
+            // Firefox OS phone and tablet
+            expect(setup('Mozilla/5.0 (Mobile; rv:26.0) Gecko/26.0 Firefox/26.0')).toBeFalsy();
+            expect(setup('Mozilla/5.0 (Tablet; rv:26.0) Gecko/26.0 Firefox/26.0')).toBeFalsy();
+        });
+
+        it('should return true if the user agent is an outdated Firefox version', function () {
+            expect(setup('Mozilla/5.0 (Windows NT 6.1; Win64; x64; rv:22.0) Gecko/20100101 Firefox/22.0')).toBeTruthy();
+            expect(setup('Mozilla/5.0 (Windows NT 6.2; WOW64; rv:16.0.1) Gecko/20121011 Firefox/16.0.1')).toBeTruthy();
+            expect(setup('Mozilla/5.0 (X11; U; Linux x86_64; en-US; rv:1.9.2.9) Gecko/20100915 Gentoo Firefox/3.6.9')).toBeTruthy();
+        });
+
     });
 });


### PR DESCRIPTION
There are no new strings included so this can be merged without l10n.
