### PR TITLE
Bug 1078297: Need localized number formatting helper for jinja templates

### DIFF
--- a/lib/l10n_utils/helpers.py
+++ b/lib/l10n_utils/helpers.py
@@ -6,6 +6,7 @@ import jingo
 import jinja2
 from babel.core import Locale, UnknownLocaleError
 from babel.dates import format_date
+from babel.numbers import format_number
 
 from django.conf import settings
 from django.utils.translation import get_language
@@ -94,3 +95,14 @@ def l10n_format_date(date, format='long'):
     """
     locale = current_locale()
     return format_date(date, locale=locale, format=format)
+
+
+
+@jingo.register.filter
+def l10n_format_number(number):
+    """
+    Formats a number according to the current locale. Wraps around
+    babel.numbers.format_number.
+    """
+    locale = current_locale()
+    return format_number(number, locale=locale)

--- a/lib/l10n_utils/tests/test_helpers.py
+++ b/lib/l10n_utils/tests/test_helpers.py
@@ -58,3 +58,13 @@ class TestL10nFormatDate(TestCase):
             format_date.return_value)
         format_date.assert_called_with(
             'somedate', locale=current_locale.return_value, format='long')
+
+
+class TestL10nFormatNumber(TestCase):
+    @patch('l10n_utils.helpers.current_locale')
+    @patch('l10n_utils.helpers.format_number')
+    def test_success(self, format_number, current_locale):
+        eq_(helpers.l10n_format_number(10000),
+            format_number.return_value)
+        format_number.assert_called_with(
+            10000, locale=current_locale.return_value)


### PR DESCRIPTION
Use in a template:
Contributors: {{ 108722|l10n_format_number }}

I noticed a caching problem locally, the format chosen for the locale seems to be reused if I switch of locale. It may be my local setup that is wrong though.
