### PR TITLE
Bug 1078297: Need localized number formatting helper for jinja templates

### DIFF
--- a/lib/l10n_utils/helpers.py
+++ b/lib/l10n_utils/helpers.py
@@ -88,21 +88,22 @@ def current_locale():
 
 
 @jingo.register.filter
-def l10n_format_date(date, format='long'):
+@jinja2.contextfunction
+def l10n_format_date(ctx, date, format='long'):
     """
     Formats a date according to the current locale. Wraps around
     babel.dates.format_date.
     """
-    locale = current_locale()
-    return format_date(date, locale=locale, format=format)
-
+    lang = ctx['LANG'].split('-')[0]
+    return format_date(date, locale=lang, format=format)
 
 
 @jingo.register.filter
-def l10n_format_number(number):
+@jinja2.contextfunction
+def l10n_format_number(ctx, number):
     """
     Formats a number according to the current locale. Wraps around
     babel.numbers.format_number.
     """
-    locale = current_locale()
-    return format_number(number, locale=locale)
+    lang = ctx['LANG'].split('-')[0]
+    return format_number(number, locale=lang)

--- a/lib/l10n_utils/tests/test_helpers.py
+++ b/lib/l10n_utils/tests/test_helpers.py
@@ -50,21 +50,35 @@ class TestCurrentLocale(TestCase):
         Locale.parse.assert_called_with(get_language.return_value, sep='-')
 
 
-class TestL10nFormatDate(TestCase):
-    @patch('l10n_utils.helpers.current_locale')
+class TestL10nFormat(TestCase):
     @patch('l10n_utils.helpers.format_date')
-    def test_success(self, format_date, current_locale):
-        eq_(helpers.l10n_format_date('somedate', format='long'),
+    def test_format_date(self, format_date):
+        ctx = {'LANG': 'de'}
+        eq_(helpers.l10n_format_date(ctx, 'somedate', format='long'),
             format_date.return_value)
         format_date.assert_called_with(
-            'somedate', locale=current_locale.return_value, format='long')
+            'somedate', locale=ctx['LANG'], format='long')
 
+    @patch('l10n_utils.helpers.format_date')
+    def test_format_date_hyphenated_locale(self, format_date):
+        ctx = {'LANG': 'en-US'}
+        eq_(helpers.l10n_format_date(ctx, 'somedate', format='long'),
+            format_date.return_value)
+        format_date.assert_called_with(
+            'somedate', locale='en', format='long')
 
-class TestL10nFormatNumber(TestCase):
-    @patch('l10n_utils.helpers.current_locale')
     @patch('l10n_utils.helpers.format_number')
-    def test_success(self, format_number, current_locale):
-        eq_(helpers.l10n_format_number(10000),
+    def test_format_number(self, format_number):
+        ctx = {'LANG': 'de'}
+        eq_(helpers.l10n_format_number(ctx, 10000),
             format_number.return_value)
         format_number.assert_called_with(
-            10000, locale=current_locale.return_value)
+            10000, locale=ctx['LANG'])
+
+    @patch('l10n_utils.helpers.format_number')
+    def test_format_number_hyphenated_locale(self, format_number):
+        ctx = {'LANG': 'pt-BR'}
+        eq_(helpers.l10n_format_number(ctx, 10000),
+            format_number.return_value)
+        format_number.assert_called_with(
+            10000, locale='pt')


### PR DESCRIPTION
Also change l10n_format_\* helpers to use lang from context.
