### PR TITLE
Fix bug 1079272: Fix unicode error in tweet formatting.

### DIFF
--- a/bedrock/mozorg/helpers/social_widgets.py
+++ b/bedrock/mozorg/helpers/social_widgets.py
@@ -1,6 +1,7 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
+from __future__ import unicode_literals
 
 from datetime import datetime
 import urllib
@@ -26,15 +27,16 @@ def format_tweet_body(tweet):
     for hashtags in entities['hashtags']:
         hash = hashtags['text']
         text = text.replace('#' + hash,
-                            ('<a href="https://twitter.com/search?q=%s&amp;src=hash" class="hash">#%s</a>'
-                             % ('%23' + urllib.quote(hash), hash)))
+                            ('<a href="https://twitter.com/search?q=%s&amp;src=hash"'
+                             ' class="hash">#%s</a>' % ('%23' + urllib.quote(hash.encode('utf8')),
+                                                        hash)))
 
     # Mentions (@someone)
     for user in entities['user_mentions']:
         name = user['screen_name']
         text = text.replace('@' + name,
                             ('<a href="https://twitter.com/%s" class="mention">@%s</a>'
-                             % (urllib.quote(name), name)))
+                             % (urllib.quote(name.encode('utf8')), name)))
 
     # URLs
     for url in entities['urls']:
@@ -47,7 +49,8 @@ def format_tweet_body(tweet):
         for medium in entities['media']:
             text = text.replace(medium['url'],
                                 ('<a href="%s" title="%s" class="media">%s</a>'
-                                 % (medium['url'], medium['expanded_url'], medium['display_url'])))
+                                 % (medium['url'], medium['expanded_url'],
+                                    medium['display_url'])))
 
     return text
 

--- a/bedrock/mozorg/tests/test_files/data/tweets.json
+++ b/bedrock/mozorg/tests/test_files/data/tweets.json
@@ -1,1 +1,2664 @@
-[{"contributors": null, "truncated": false, "text": "How amazing is this @webmaker Video Tutorial created by your fellow Ambassador Eliezer!? https://t.co/r2ZgkyDX2H Great job!", "in_reply_to_status_id": null, "id": 426065020921712640, "favorite_count": 1, "source": "web", "retweeted": false, "coordinates": null, "entities": {"symbols": [], "user_mentions": [{"id": 545363950, "indices": [20, 29], "id_str": "545363950", "screen_name": "webmaker", "name": "Mozilla Webmaker"}], "hashtags": [], "urls": [{"url": "https://t.co/r2ZgkyDX2H", "indices": [89, 112], "expanded_url": "https://eliezerb.makes.org/popcorn/1p96", "display_url": "eliezerb.makes.org/popcorn/1p96"}]}, "in_reply_to_screen_name": null, "id_str": "426065020921712640", "retweet_count": 2, "in_reply_to_user_id": null, "favorited": false, "user": {"follow_request_sent": false, "profile_use_background_image": true, "default_profile_image": false, "id": 23925141, "verified": false, "profile_text_color": "333333", "profile_image_url_https": "https://pbs.twimg.com/profile_images/378800000072303285/0501b9c8a3d883a327f816f5ce3eaad2_normal.png", "profile_sidebar_fill_color": "DDEEF6", "entities": {"url": {"urls": [{"url": "http://t.co/0thqsyksC3", "indices": [0, 22], "expanded_url": "http://www.mozilla.org/en-US/contribute/universityambassadors/", "display_url": "mozilla.org/en-US/contribu\u2026"}]}, "description": {"urls": []}}, "followers_count": 3601, "profile_sidebar_border_color": "C0DEED", "id_str": "23925141", "profile_background_color": "C0DEED", "listed_count": 148, "profile_background_image_url_https": "https://abs.twimg.com/images/themes/theme1/bg.png", "utc_offset": -28800, "statuses_count": 588, "description": "Mozilla's Firefox Student Ambassadors help spread @Firefox and promote @Mozilla\u2019s mission at their schools. Join us and make a difference to the Web!", "friends_count": 326, "location": "Earth", "profile_link_color": "0084B4", "profile_image_url": "http://pbs.twimg.com/profile_images/378800000072303285/0501b9c8a3d883a327f816f5ce3eaad2_normal.png", "following": true, "geo_enabled": true, "profile_background_image_url": "http://abs.twimg.com/images/themes/theme1/bg.png", "screen_name": "mozstudents", "lang": "en", "profile_background_tile": false, "favourites_count": 33, "name": "Student Ambassadors", "notifications": false, "url": "http://t.co/0thqsyksC3", "created_at": "Thu Mar 12 09:31:59 +0000 2009", "contributors_enabled": false, "time_zone": "Pacific Time (US & Canada)", "protected": false, "default_profile": true, "is_translator": false}, "geo": null, "in_reply_to_user_id_str": null, "possibly_sensitive": false, "lang": "en", "created_at": "Wed Jan 22 18:53:11 +0000 2014", "in_reply_to_status_id_str": null, "place": null}, {"contributors": null, "truncated": false, "text": "Congrats to those of you who received your Open Badge in Jan! Apply for Feb by following these directions http://t.co/rpFeEe1Bp4", "in_reply_to_status_id": null, "id": 425700814015852544, "favorite_count": 1, "source": "web", "retweeted": false, "coordinates": null, "entities": {"symbols": [], "user_mentions": [], "hashtags": [], "urls": [{"url": "http://t.co/rpFeEe1Bp4", "indices": [106, 128], "expanded_url": "http://mzl.la/1cRd7qc", "display_url": "mzl.la/1cRd7qc"}]}, "in_reply_to_screen_name": null, "id_str": "425700814015852544", "retweet_count": 4, "in_reply_to_user_id": null, "favorited": false, "user": {"follow_request_sent": false, "profile_use_background_image": true, "default_profile_image": false, "id": 23925141, "verified": false, "profile_text_color": "333333", "profile_image_url_https": "https://pbs.twimg.com/profile_images/378800000072303285/0501b9c8a3d883a327f816f5ce3eaad2_normal.png", "profile_sidebar_fill_color": "DDEEF6", "entities": {"url": {"urls": [{"url": "http://t.co/0thqsyksC3", "indices": [0, 22], "expanded_url": "http://www.mozilla.org/en-US/contribute/universityambassadors/", "display_url": "mozilla.org/en-US/contribu\u2026"}]}, "description": {"urls": []}}, "followers_count": 3601, "profile_sidebar_border_color": "C0DEED", "id_str": "23925141", "profile_background_color": "C0DEED", "listed_count": 148, "profile_background_image_url_https": "https://abs.twimg.com/images/themes/theme1/bg.png", "utc_offset": -28800, "statuses_count": 588, "description": "Mozilla's Firefox Student Ambassadors help spread @Firefox and promote @Mozilla\u2019s mission at their schools. Join us and make a difference to the Web!", "friends_count": 326, "location": "Earth", "profile_link_color": "0084B4", "profile_image_url": "http://pbs.twimg.com/profile_images/378800000072303285/0501b9c8a3d883a327f816f5ce3eaad2_normal.png", "following": true, "geo_enabled": true, "profile_background_image_url": "http://abs.twimg.com/images/themes/theme1/bg.png", "screen_name": "mozstudents", "lang": "en", "profile_background_tile": false, "favourites_count": 33, "name": "Student Ambassadors", "notifications": false, "url": "http://t.co/0thqsyksC3", "created_at": "Thu Mar 12 09:31:59 +0000 2009", "contributors_enabled": false, "time_zone": "Pacific Time (US & Canada)", "protected": false, "default_profile": true, "is_translator": false}, "geo": null, "in_reply_to_user_id_str": null, "possibly_sensitive": false, "lang": "en", "created_at": "Tue Jan 21 18:45:57 +0000 2014", "in_reply_to_status_id_str": null, "place": null}, {"contributors": null, "truncated": false, "text": "Looking for a way to celebrate Data Privacy Day on January 28? Get started with the Privacy &amp; Security Teaching Kit http://t.co/XLuho2eyYy", "in_reply_to_status_id": null, "id": 425489316819632128, "favorite_count": 3, "source": "web", "retweeted": false, "coordinates": null, "entities": {"symbols": [], "user_mentions": [], "hashtags": [], "urls": [{"url": "http://t.co/XLuho2eyYy", "indices": [120, 142], "expanded_url": "http://bit.ly/1dPx3yq", "display_url": "bit.ly/1dPx3yq"}]}, "in_reply_to_screen_name": null, "id_str": "425489316819632128", "retweet_count": 2, "in_reply_to_user_id": null, "favorited": false, "user": {"follow_request_sent": false, "profile_use_background_image": true, "default_profile_image": false, "id": 23925141, "verified": false, "profile_text_color": "333333", "profile_image_url_https": "https://pbs.twimg.com/profile_images/378800000072303285/0501b9c8a3d883a327f816f5ce3eaad2_normal.png", "profile_sidebar_fill_color": "DDEEF6", "entities": {"url": {"urls": [{"url": "http://t.co/0thqsyksC3", "indices": [0, 22], "expanded_url": "http://www.mozilla.org/en-US/contribute/universityambassadors/", "display_url": "mozilla.org/en-US/contribu\u2026"}]}, "description": {"urls": []}}, "followers_count": 3601, "profile_sidebar_border_color": "C0DEED", "id_str": "23925141", "profile_background_color": "C0DEED", "listed_count": 148, "profile_background_image_url_https": "https://abs.twimg.com/images/themes/theme1/bg.png", "utc_offset": -28800, "statuses_count": 588, "description": "Mozilla's Firefox Student Ambassadors help spread @Firefox and promote @Mozilla\u2019s mission at their schools. Join us and make a difference to the Web!", "friends_count": 326, "location": "Earth", "profile_link_color": "0084B4", "profile_image_url": "http://pbs.twimg.com/profile_images/378800000072303285/0501b9c8a3d883a327f816f5ce3eaad2_normal.png", "following": true, "geo_enabled": true, "profile_background_image_url": "http://abs.twimg.com/images/themes/theme1/bg.png", "screen_name": "mozstudents", "lang": "en", "profile_background_tile": false, "favourites_count": 33, "name": "Student Ambassadors", "notifications": false, "url": "http://t.co/0thqsyksC3", "created_at": "Thu Mar 12 09:31:59 +0000 2009", "contributors_enabled": false, "time_zone": "Pacific Time (US & Canada)", "protected": false, "default_profile": true, "is_translator": false}, "geo": null, "in_reply_to_user_id_str": null, "possibly_sensitive": false, "lang": "en", "created_at": "Tue Jan 21 04:45:32 +0000 2014", "in_reply_to_status_id_str": null, "place": null}, {"contributors": null, "truncated": false, "text": "If you're interested in Webmaker, check out our Video Tutorials! The deadline to submit videos this month is Jan 25! http://t.co/ailOA0rP5U", "in_reply_to_status_id": null, "id": 425094136786472960, "favorite_count": 1, "source": "web", "retweeted": false, "coordinates": null, "entities": {"symbols": [], "user_mentions": [], "hashtags": [], "urls": [{"url": "http://t.co/ailOA0rP5U", "indices": [117, 139], "expanded_url": "http://mzl.la/1dhjGSV", "display_url": "mzl.la/1dhjGSV"}]}, "in_reply_to_screen_name": null, "id_str": "425094136786472960", "retweet_count": 8, "in_reply_to_user_id": null, "favorited": false, "user": {"follow_request_sent": false, "profile_use_background_image": true, "default_profile_image": false, "id": 23925141, "verified": false, "profile_text_color": "333333", "profile_image_url_https": "https://pbs.twimg.com/profile_images/378800000072303285/0501b9c8a3d883a327f816f5ce3eaad2_normal.png", "profile_sidebar_fill_color": "DDEEF6", "entities": {"url": {"urls": [{"url": "http://t.co/0thqsyksC3", "indices": [0, 22], "expanded_url": "http://www.mozilla.org/en-US/contribute/universityambassadors/", "display_url": "mozilla.org/en-US/contribu\u2026"}]}, "description": {"urls": []}}, "followers_count": 3601, "profile_sidebar_border_color": "C0DEED", "id_str": "23925141", "profile_background_color": "C0DEED", "listed_count": 148, "profile_background_image_url_https": "https://abs.twimg.com/images/themes/theme1/bg.png", "utc_offset": -28800, "statuses_count": 588, "description": "Mozilla's Firefox Student Ambassadors help spread @Firefox and promote @Mozilla\u2019s mission at their schools. Join us and make a difference to the Web!", "friends_count": 326, "location": "Earth", "profile_link_color": "0084B4", "profile_image_url": "http://pbs.twimg.com/profile_images/378800000072303285/0501b9c8a3d883a327f816f5ce3eaad2_normal.png", "following": true, "geo_enabled": true, "profile_background_image_url": "http://abs.twimg.com/images/themes/theme1/bg.png", "screen_name": "mozstudents", "lang": "en", "profile_background_tile": false, "favourites_count": 33, "name": "Student Ambassadors", "notifications": false, "url": "http://t.co/0thqsyksC3", "created_at": "Thu Mar 12 09:31:59 +0000 2009", "contributors_enabled": false, "time_zone": "Pacific Time (US & Canada)", "protected": false, "default_profile": true, "is_translator": false}, "geo": null, "in_reply_to_user_id_str": null, "possibly_sensitive": false, "lang": "en", "created_at": "Mon Jan 20 02:35:14 +0000 2014", "in_reply_to_status_id_str": null, "place": null}, {"contributors": null, "truncated": false, "text": "Doing a Video Tutorial this month? Reminder to submit it by January 21st using this form: http://t.co/g6CXXISvyi #students #contest", "in_reply_to_status_id": null, "id": 424217143480041472, "favorite_count": 0, "source": "web", "retweeted": false, "coordinates": null, "entities": {"symbols": [], "user_mentions": [], "hashtags": [{"indices": [113, 122], "text": "students"}, {"indices": [123, 131], "text": "contest"}], "urls": [{"url": "http://t.co/g6CXXISvyi", "indices": [90, 112], "expanded_url": "http://bit.ly/1mb4H2k", "display_url": "bit.ly/1mb4H2k"}]}, "in_reply_to_screen_name": null, "id_str": "424217143480041472", "retweet_count": 1, "in_reply_to_user_id": null, "favorited": false, "user": {"follow_request_sent": false, "profile_use_background_image": true, "default_profile_image": false, "id": 23925141, "verified": false, "profile_text_color": "333333", "profile_image_url_https": "https://pbs.twimg.com/profile_images/378800000072303285/0501b9c8a3d883a327f816f5ce3eaad2_normal.png", "profile_sidebar_fill_color": "DDEEF6", "entities": {"url": {"urls": [{"url": "http://t.co/0thqsyksC3", "indices": [0, 22], "expanded_url": "http://www.mozilla.org/en-US/contribute/universityambassadors/", "display_url": "mozilla.org/en-US/contribu\u2026"}]}, "description": {"urls": []}}, "followers_count": 3601, "profile_sidebar_border_color": "C0DEED", "id_str": "23925141", "profile_background_color": "C0DEED", "listed_count": 148, "profile_background_image_url_https": "https://abs.twimg.com/images/themes/theme1/bg.png", "utc_offset": -28800, "statuses_count": 588, "description": "Mozilla's Firefox Student Ambassadors help spread @Firefox and promote @Mozilla\u2019s mission at their schools. Join us and make a difference to the Web!", "friends_count": 326, "location": "Earth", "profile_link_color": "0084B4", "profile_image_url": "http://pbs.twimg.com/profile_images/378800000072303285/0501b9c8a3d883a327f816f5ce3eaad2_normal.png", "following": true, "geo_enabled": true, "profile_background_image_url": "http://abs.twimg.com/images/themes/theme1/bg.png", "screen_name": "mozstudents", "lang": "en", "profile_background_tile": false, "favourites_count": 33, "name": "Student Ambassadors", "notifications": false, "url": "http://t.co/0thqsyksC3", "created_at": "Thu Mar 12 09:31:59 +0000 2009", "contributors_enabled": false, "time_zone": "Pacific Time (US & Canada)", "protected": false, "default_profile": true, "is_translator": false}, "geo": null, "in_reply_to_user_id_str": null, "possibly_sensitive": false, "lang": "en", "created_at": "Fri Jan 17 16:30:23 +0000 2014", "in_reply_to_status_id_str": null, "place": null}, {"contributors": null, "truncated": false, "text": "Want more information about the @mozstudents program? Sign-up and get a monthly newsletter in your in-box http://t.co/0thqsyksC3 #students", "in_reply_to_status_id": null, "id": 423899555776589824, "favorite_count": 1, "source": "web", "retweeted": false, "coordinates": null, "entities": {"symbols": [], "user_mentions": [{"id": 23925141, "indices": [32, 44], "id_str": "23925141", "screen_name": "mozstudents", "name": "Student Ambassadors"}], "hashtags": [{"indices": [129, 138], "text": "students"}], "urls": [{"url": "http://t.co/0thqsyksC3", "indices": [106, 128], "expanded_url": "http://www.mozilla.org/en-US/contribute/universityambassadors/", "display_url": "mozilla.org/en-US/contribu\u2026"}]}, "in_reply_to_screen_name": null, "id_str": "423899555776589824", "retweet_count": 1, "in_reply_to_user_id": null, "favorited": false, "user": {"follow_request_sent": false, "profile_use_background_image": true, "default_profile_image": false, "id": 23925141, "verified": false, "profile_text_color": "333333", "profile_image_url_https": "https://pbs.twimg.com/profile_images/378800000072303285/0501b9c8a3d883a327f816f5ce3eaad2_normal.png", "profile_sidebar_fill_color": "DDEEF6", "entities": {"url": {"urls": [{"url": "http://t.co/0thqsyksC3", "indices": [0, 22], "expanded_url": "http://www.mozilla.org/en-US/contribute/universityambassadors/", "display_url": "mozilla.org/en-US/contribu\u2026"}]}, "description": {"urls": []}}, "followers_count": 3601, "profile_sidebar_border_color": "C0DEED", "id_str": "23925141", "profile_background_color": "C0DEED", "listed_count": 148, "profile_background_image_url_https": "https://abs.twimg.com/images/themes/theme1/bg.png", "utc_offset": -28800, "statuses_count": 588, "description": "Mozilla's Firefox Student Ambassadors help spread @Firefox and promote @Mozilla\u2019s mission at their schools. Join us and make a difference to the Web!", "friends_count": 326, "location": "Earth", "profile_link_color": "0084B4", "profile_image_url": "http://pbs.twimg.com/profile_images/378800000072303285/0501b9c8a3d883a327f816f5ce3eaad2_normal.png", "following": true, "geo_enabled": true, "profile_background_image_url": "http://abs.twimg.com/images/themes/theme1/bg.png", "screen_name": "mozstudents", "lang": "en", "profile_background_tile": false, "favourites_count": 33, "name": "Student Ambassadors", "notifications": false, "url": "http://t.co/0thqsyksC3", "created_at": "Thu Mar 12 09:31:59 +0000 2009", "contributors_enabled": false, "time_zone": "Pacific Time (US & Canada)", "protected": false, "default_profile": true, "is_translator": false}, "geo": null, "in_reply_to_user_id_str": null, "possibly_sensitive": false, "lang": "en", "created_at": "Thu Jan 16 19:28:24 +0000 2014", "in_reply_to_status_id_str": null, "place": null}, {"contributors": null, "truncated": false, "text": "RT @STPIFirefoxClub: Hacking Web With Webmaker \u201cWebmaker Party\u201d by STPI Firefox Club  @mozstudents @webmaker http://t.co/4dVunerWCD #MakerP\u2026", "in_reply_to_status_id": null, "id": 423267155551858688, "favorite_count": 0, "source": "web", "retweeted": false, "coordinates": null, "entities": {"symbols": [], "user_mentions": [{"id": 1437282660, "indices": [3, 19], "id_str": "1437282660", "screen_name": "STPIFirefoxClub", "name": "STPI Firefox Club"}, {"id": 23925141, "indices": [86, 98], "id_str": "23925141", "screen_name": "mozstudents", "name": "Student Ambassadors"}, {"id": 545363950, "indices": [99, 108], "id_str": "545363950", "screen_name": "webmaker", "name": "Mozilla Webmaker"}], "hashtags": [{"indices": [132, 140], "text": "MakerParty"}, {"indices": [139, 140], "text": "firefoxstudents"}], "urls": [{"url": "http://t.co/4dVunerWCD", "indices": [109, 131], "expanded_url": "http://oonlab.com/hacking-web-with-webmaker-webmaker-party.onto", "display_url": "oonlab.com/hacking-web-wi\u2026"}]}, "in_reply_to_screen_name": null, "id_str": "423267155551858688", "retweet_count": 1, "in_reply_to_user_id": null, "favorited": false, "retweeted_status": {"contributors": null, "truncated": false, "text": "Hacking Web With Webmaker \u201cWebmaker Party\u201d by STPI Firefox Club  @mozstudents @webmaker http://t.co/4dVunerWCD #MakerParty #firefoxstudents", "in_reply_to_status_id": null, "id": 423079698982129664, "favorite_count": 3, "source": "web", "retweeted": false, "coordinates": null, "entities": {"symbols": [], "user_mentions": [{"id": 23925141, "indices": [65, 77], "id_str": "23925141", "screen_name": "mozstudents", "name": "Student Ambassadors"}, {"id": 545363950, "indices": [78, 87], "id_str": "545363950", "screen_name": "webmaker", "name": "Mozilla Webmaker"}], "hashtags": [{"indices": [111, 122], "text": "MakerParty"}, {"indices": [123, 139], "text": "firefoxstudents"}], "urls": [{"url": "http://t.co/4dVunerWCD", "indices": [88, 110], "expanded_url": "http://oonlab.com/hacking-web-with-webmaker-webmaker-party.onto", "display_url": "oonlab.com/hacking-web-wi\u2026"}]}, "in_reply_to_screen_name": null, "id_str": "423079698982129664", "retweet_count": 1, "in_reply_to_user_id": null, "favorited": false, "user": {"follow_request_sent": false, "profile_use_background_image": true, "default_profile_image": false, "id": 1437282660, "verified": false, "profile_text_color": "333333", "profile_image_url_https": "https://pbs.twimg.com/profile_images/421896693647278080/Fpkr82Vx_normal.png", "profile_sidebar_fill_color": "EFEFEF", "entities": {"url": {"urls": [{"url": "https://t.co/QUTEKB0sba", "indices": [0, 23], "expanded_url": "https://wiki.mozilla.org/STPI_Firefox_Club", "display_url": "wiki.mozilla.org/STPI_Firefox_C\u2026"}]}, "description": {"urls": []}}, "followers_count": 93, "profile_sidebar_border_color": "EEEEEE", "id_str": "1437282660", "profile_background_color": "131516", "listed_count": 1, "profile_background_image_url_https": "https://abs.twimg.com/images/themes/theme14/bg.gif", "utc_offset": 25200, "statuses_count": 794, "description": "We help spread @Firefox and promote @Mozilla\u2019s mission and Tax Education at Sekolah Tinggi Perpajakan Indonesia. Join us and make a difference to the Web!", "friends_count": 62, "location": "Earth", "profile_link_color": "009999", "profile_image_url": "http://pbs.twimg.com/profile_images/421896693647278080/Fpkr82Vx_normal.png", "following": false, "geo_enabled": false, "profile_banner_url": "https://pbs.twimg.com/profile_banners/1437282660/1389658660", "profile_background_image_url": "http://abs.twimg.com/images/themes/theme14/bg.gif", "screen_name": "STPIFirefoxClub", "lang": "en", "profile_background_tile": true, "favourites_count": 37, "name": "STPI Firefox Club", "notifications": false, "url": "https://t.co/QUTEKB0sba", "created_at": "Sat May 18 03:31:24 +0000 2013", "contributors_enabled": false, "time_zone": "Bangkok", "protected": false, "default_profile": false, "is_translator": false}, "geo": null, "in_reply_to_user_id_str": null, "possibly_sensitive": false, "lang": "en", "created_at": "Tue Jan 14 13:10:35 +0000 2014", "in_reply_to_status_id_str": null, "place": null}, "user": {"follow_request_sent": false, "profile_use_background_image": true, "default_profile_image": false, "id": 23925141, "verified": false, "profile_text_color": "333333", "profile_image_url_https": "https://pbs.twimg.com/profile_images/378800000072303285/0501b9c8a3d883a327f816f5ce3eaad2_normal.png", "profile_sidebar_fill_color": "DDEEF6", "entities": {"url": {"urls": [{"url": "http://t.co/0thqsyksC3", "indices": [0, 22], "expanded_url": "http://www.mozilla.org/en-US/contribute/universityambassadors/", "display_url": "mozilla.org/en-US/contribu\u2026"}]}, "description": {"urls": []}}, "followers_count": 3601, "profile_sidebar_border_color": "C0DEED", "id_str": "23925141", "profile_background_color": "C0DEED", "listed_count": 148, "profile_background_image_url_https": "https://abs.twimg.com/images/themes/theme1/bg.png", "utc_offset": -28800, "statuses_count": 588, "description": "Mozilla's Firefox Student Ambassadors help spread @Firefox and promote @Mozilla\u2019s mission at their schools. Join us and make a difference to the Web!", "friends_count": 326, "location": "Earth", "profile_link_color": "0084B4", "profile_image_url": "http://pbs.twimg.com/profile_images/378800000072303285/0501b9c8a3d883a327f816f5ce3eaad2_normal.png", "following": true, "geo_enabled": true, "profile_background_image_url": "http://abs.twimg.com/images/themes/theme1/bg.png", "screen_name": "mozstudents", "lang": "en", "profile_background_tile": false, "favourites_count": 33, "name": "Student Ambassadors", "notifications": false, "url": "http://t.co/0thqsyksC3", "created_at": "Thu Mar 12 09:31:59 +0000 2009", "contributors_enabled": false, "time_zone": "Pacific Time (US & Canada)", "protected": false, "default_profile": true, "is_translator": false}, "geo": null, "in_reply_to_user_id_str": null, "possibly_sensitive": false, "lang": "en", "created_at": "Wed Jan 15 01:35:28 +0000 2014", "in_reply_to_status_id_str": null, "place": null}, {"contributors": null, "truncated": false, "text": "Join us tomorrow for Office Hours! Catch up on IRC (#firefoxstudents) at 3:30pm UTC http://t.co/fT5tEPWRZv #students", "in_reply_to_status_id": null, "id": 423146061482307585, "favorite_count": 0, "source": "web", "retweeted": false, "coordinates": null, "entities": {"symbols": [], "user_mentions": [], "hashtags": [{"indices": [52, 68], "text": "firefoxstudents"}, {"indices": [107, 116], "text": "students"}], "urls": [{"url": "http://t.co/fT5tEPWRZv", "indices": [84, 106], "expanded_url": "http://mzl.la/1cX79pI", "display_url": "mzl.la/1cX79pI"}]}, "in_reply_to_screen_name": null, "id_str": "423146061482307585", "retweet_count": 1, "in_reply_to_user_id": null, "favorited": false, "user": {"follow_request_sent": false, "profile_use_background_image": true, "default_profile_image": false, "id": 23925141, "verified": false, "profile_text_color": "333333", "profile_image_url_https": "https://pbs.twimg.com/profile_images/378800000072303285/0501b9c8a3d883a327f816f5ce3eaad2_normal.png", "profile_sidebar_fill_color": "DDEEF6", "entities": {"url": {"urls": [{"url": "http://t.co/0thqsyksC3", "indices": [0, 22], "expanded_url": "http://www.mozilla.org/en-US/contribute/universityambassadors/", "display_url": "mozilla.org/en-US/contribu\u2026"}]}, "description": {"urls": []}}, "followers_count": 3601, "profile_sidebar_border_color": "C0DEED", "id_str": "23925141", "profile_background_color": "C0DEED", "listed_count": 148, "profile_background_image_url_https": "https://abs.twimg.com/images/themes/theme1/bg.png", "utc_offset": -28800, "statuses_count": 588, "description": "Mozilla's Firefox Student Ambassadors help spread @Firefox and promote @Mozilla\u2019s mission at their schools. Join us and make a difference to the Web!", "friends_count": 326, "location": "Earth", "profile_link_color": "0084B4", "profile_image_url": "http://pbs.twimg.com/profile_images/378800000072303285/0501b9c8a3d883a327f816f5ce3eaad2_normal.png", "following": true, "geo_enabled": true, "profile_background_image_url": "http://abs.twimg.com/images/themes/theme1/bg.png", "screen_name": "mozstudents", "lang": "en", "profile_background_tile": false, "favourites_count": 33, "name": "Student Ambassadors", "notifications": false, "url": "http://t.co/0thqsyksC3", "created_at": "Thu Mar 12 09:31:59 +0000 2009", "contributors_enabled": false, "time_zone": "Pacific Time (US & Canada)", "protected": false, "default_profile": true, "is_translator": false}, "geo": null, "in_reply_to_user_id_str": null, "possibly_sensitive": false, "lang": "en", "created_at": "Tue Jan 14 17:34:17 +0000 2014", "in_reply_to_status_id_str": null, "place": null}, {"contributors": null, "truncated": false, "text": "The PNUP Fx Club hosted their first ever campus event January 11 Find out more information about how it went here http://t.co/MYtHCpIOSl", "in_reply_to_status_id": null, "id": 422783419802611714, "favorite_count": 2, "source": "web", "retweeted": false, "coordinates": null, "entities": {"symbols": [], "user_mentions": [], "hashtags": [], "urls": [{"url": "http://t.co/MYtHCpIOSl", "indices": [114, 136], "expanded_url": "http://bit.ly/L2HzIa", "display_url": "bit.ly/L2HzIa"}]}, "in_reply_to_screen_name": null, "id_str": "422783419802611714", "retweet_count": 3, "in_reply_to_user_id": null, "favorited": false, "user": {"follow_request_sent": false, "profile_use_background_image": true, "default_profile_image": false, "id": 23925141, "verified": false, "profile_text_color": "333333", "profile_image_url_https": "https://pbs.twimg.com/profile_images/378800000072303285/0501b9c8a3d883a327f816f5ce3eaad2_normal.png", "profile_sidebar_fill_color": "DDEEF6", "entities": {"url": {"urls": [{"url": "http://t.co/0thqsyksC3", "indices": [0, 22], "expanded_url": "http://www.mozilla.org/en-US/contribute/universityambassadors/", "display_url": "mozilla.org/en-US/contribu\u2026"}]}, "description": {"urls": []}}, "followers_count": 3601, "profile_sidebar_border_color": "C0DEED", "id_str": "23925141", "profile_background_color": "C0DEED", "listed_count": 148, "profile_background_image_url_https": "https://abs.twimg.com/images/themes/theme1/bg.png", "utc_offset": -28800, "statuses_count": 588, "description": "Mozilla's Firefox Student Ambassadors help spread @Firefox and promote @Mozilla\u2019s mission at their schools. Join us and make a difference to the Web!", "friends_count": 326, "location": "Earth", "profile_link_color": "0084B4", "profile_image_url": "http://pbs.twimg.com/profile_images/378800000072303285/0501b9c8a3d883a327f816f5ce3eaad2_normal.png", "following": true, "geo_enabled": true, "profile_background_image_url": "http://abs.twimg.com/images/themes/theme1/bg.png", "screen_name": "mozstudents", "lang": "en", "profile_background_tile": false, "favourites_count": 33, "name": "Student Ambassadors", "notifications": false, "url": "http://t.co/0thqsyksC3", "created_at": "Thu Mar 12 09:31:59 +0000 2009", "contributors_enabled": false, "time_zone": "Pacific Time (US & Canada)", "protected": false, "default_profile": true, "is_translator": false}, "geo": null, "in_reply_to_user_id_str": null, "possibly_sensitive": false, "lang": "en", "created_at": "Mon Jan 13 17:33:16 +0000 2014", "in_reply_to_status_id_str": null, "place": null}, {"contributors": null, "truncated": false, "text": "Awesome post from Eliezer (from the Joa\u00e7aba Firefox Club) on the importance of blogging Give it a read this weekend! https://t.co/qkVGi2aG8n", "in_reply_to_status_id": null, "id": 421788841712701440, "favorite_count": 3, "source": "web", "retweeted": false, "coordinates": null, "entities": {"symbols": [], "user_mentions": [], "hashtags": [], "urls": [{"url": "https://t.co/qkVGi2aG8n", "indices": [117, 140], "expanded_url": "https://blog.mozilla.org/studentambassadors/2014/01/10/the-importance-of-blogging/", "display_url": "blog.mozilla.org/studentambassa\u2026"}]}, "in_reply_to_screen_name": null, "id_str": "421788841712701440", "retweet_count": 3, "in_reply_to_user_id": null, "favorited": false, "user": {"follow_request_sent": false, "profile_use_background_image": true, "default_profile_image": false, "id": 23925141, "verified": false, "profile_text_color": "333333", "profile_image_url_https": "https://pbs.twimg.com/profile_images/378800000072303285/0501b9c8a3d883a327f816f5ce3eaad2_normal.png", "profile_sidebar_fill_color": "DDEEF6", "entities": {"url": {"urls": [{"url": "http://t.co/0thqsyksC3", "indices": [0, 22], "expanded_url": "http://www.mozilla.org/en-US/contribute/universityambassadors/", "display_url": "mozilla.org/en-US/contribu\u2026"}]}, "description": {"urls": []}}, "followers_count": 3601, "profile_sidebar_border_color": "C0DEED", "id_str": "23925141", "profile_background_color": "C0DEED", "listed_count": 148, "profile_background_image_url_https": "https://abs.twimg.com/images/themes/theme1/bg.png", "utc_offset": -28800, "statuses_count": 588, "description": "Mozilla's Firefox Student Ambassadors help spread @Firefox and promote @Mozilla\u2019s mission at their schools. Join us and make a difference to the Web!", "friends_count": 326, "location": "Earth", "profile_link_color": "0084B4", "profile_image_url": "http://pbs.twimg.com/profile_images/378800000072303285/0501b9c8a3d883a327f816f5ce3eaad2_normal.png", "following": true, "geo_enabled": true, "profile_background_image_url": "http://abs.twimg.com/images/themes/theme1/bg.png", "screen_name": "mozstudents", "lang": "en", "profile_background_tile": false, "favourites_count": 33, "name": "Student Ambassadors", "notifications": false, "url": "http://t.co/0thqsyksC3", "created_at": "Thu Mar 12 09:31:59 +0000 2009", "contributors_enabled": false, "time_zone": "Pacific Time (US & Canada)", "protected": false, "default_profile": true, "is_translator": false}, "geo": null, "in_reply_to_user_id_str": null, "possibly_sensitive": false, "lang": "en", "created_at": "Fri Jan 10 23:41:10 +0000 2014", "in_reply_to_status_id_str": null, "place": null}, {"contributors": null, "truncated": false, "text": "Know how to code (and want to use your skills for good)? Contribute your code to help improve Mozilla's products http://t.co/1jcnutCtzz", "in_reply_to_status_id": null, "id": 421692692678975488, "favorite_count": 2, "source": "web", "retweeted": false, "coordinates": null, "entities": {"symbols": [], "user_mentions": [], "hashtags": [], "urls": [{"url": "http://t.co/1jcnutCtzz", "indices": [113, 135], "expanded_url": "http://mzl.la/1ew7XCq", "display_url": "mzl.la/1ew7XCq"}]}, "in_reply_to_screen_name": null, "id_str": "421692692678975488", "retweet_count": 4, "in_reply_to_user_id": null, "favorited": false, "user": {"follow_request_sent": false, "profile_use_background_image": true, "default_profile_image": false, "id": 23925141, "verified": false, "profile_text_color": "333333", "profile_image_url_https": "https://pbs.twimg.com/profile_images/378800000072303285/0501b9c8a3d883a327f816f5ce3eaad2_normal.png", "profile_sidebar_fill_color": "DDEEF6", "entities": {"url": {"urls": [{"url": "http://t.co/0thqsyksC3", "indices": [0, 22], "expanded_url": "http://www.mozilla.org/en-US/contribute/universityambassadors/", "display_url": "mozilla.org/en-US/contribu\u2026"}]}, "description": {"urls": []}}, "followers_count": 3601, "profile_sidebar_border_color": "C0DEED", "id_str": "23925141", "profile_background_color": "C0DEED", "listed_count": 148, "profile_background_image_url_https": "https://abs.twimg.com/images/themes/theme1/bg.png", "utc_offset": -28800, "statuses_count": 588, "description": "Mozilla's Firefox Student Ambassadors help spread @Firefox and promote @Mozilla\u2019s mission at their schools. Join us and make a difference to the Web!", "friends_count": 326, "location": "Earth", "profile_link_color": "0084B4", "profile_image_url": "http://pbs.twimg.com/profile_images/378800000072303285/0501b9c8a3d883a327f816f5ce3eaad2_normal.png", "following": true, "geo_enabled": true, "profile_background_image_url": "http://abs.twimg.com/images/themes/theme1/bg.png", "screen_name": "mozstudents", "lang": "en", "profile_background_tile": false, "favourites_count": 33, "name": "Student Ambassadors", "notifications": false, "url": "http://t.co/0thqsyksC3", "created_at": "Thu Mar 12 09:31:59 +0000 2009", "contributors_enabled": false, "time_zone": "Pacific Time (US & Canada)", "protected": false, "default_profile": true, "is_translator": false}, "geo": null, "in_reply_to_user_id_str": null, "possibly_sensitive": false, "lang": "en", "created_at": "Fri Jan 10 17:19:07 +0000 2014", "in_reply_to_status_id_str": null, "place": null}, {"contributors": null, "truncated": false, "text": "RT @firefox: No respecting Firefox employee (or any self-respecting fox) can resist the #SelfieOlympics challenge! http://t.co/BfI952AJsG", "in_reply_to_status_id": null, "id": 420687071095693312, "favorite_count": 0, "source": "web", "retweeted": false, "coordinates": null, "entities": {"symbols": [], "user_mentions": [{"id": 2142731, "indices": [3, 11], "id_str": "2142731", "screen_name": "firefox", "name": "Firefox"}], "hashtags": [{"indices": [88, 103], "text": "SelfieOlympics"}], "urls": [], "media": [{"expanded_url": "http://twitter.com/firefox/status/420686256922574848/photo/1", "display_url": "pic.twitter.com/BfI952AJsG", "url": "http://t.co/BfI952AJsG", "media_url_https": "https://pbs.twimg.com/media/BdaT6_pCQAAm12p.jpg", "id_str": "420686256930963456", "sizes": {"small": {"h": 170, "resize": "fit", "w": 340}, "large": {"h": 512, "resize": "fit", "w": 1024}, "medium": {"h": 300, "resize": "fit", "w": 600}, "thumb": {"h": 150, "resize": "crop", "w": 150}}, "indices": [115, 137], "type": "photo", "id": 420686256930963456, "media_url": "http://pbs.twimg.com/media/BdaT6_pCQAAm12p.jpg"}]}, "in_reply_to_screen_name": null, "id_str": "420687071095693312", "retweet_count": 71, "in_reply_to_user_id": null, "favorited": false, "retweeted_status": {"contributors": null, "truncated": false, "text": "No respecting Firefox employee (or any self-respecting fox) can resist the #SelfieOlympics challenge! http://t.co/BfI952AJsG", "in_reply_to_status_id": null, "id": 420686256922574848, "favorite_count": 78, "source": "web", "retweeted": false, "coordinates": null, "entities": {"symbols": [], "user_mentions": [], "hashtags": [{"indices": [75, 90], "text": "SelfieOlympics"}], "urls": [], "media": [{"expanded_url": "http://twitter.com/firefox/status/420686256922574848/photo/1", "display_url": "pic.twitter.com/BfI952AJsG", "url": "http://t.co/BfI952AJsG", "media_url_https": "https://pbs.twimg.com/media/BdaT6_pCQAAm12p.jpg", "id_str": "420686256930963456", "sizes": {"small": {"h": 170, "resize": "fit", "w": 340}, "large": {"h": 512, "resize": "fit", "w": 1024}, "medium": {"h": 300, "resize": "fit", "w": 600}, "thumb": {"h": 150, "resize": "crop", "w": 150}}, "indices": [102, 124], "type": "photo", "id": 420686256930963456, "media_url": "http://pbs.twimg.com/media/BdaT6_pCQAAm12p.jpg"}]}, "in_reply_to_screen_name": null, "id_str": "420686256922574848", "retweet_count": 71, "in_reply_to_user_id": null, "favorited": false, "user": {"follow_request_sent": false, "profile_use_background_image": true, "default_profile_image": false, "id": 2142731, "verified": true, "profile_text_color": "333333", "profile_image_url_https": "https://pbs.twimg.com/profile_images/378800000324784929/1a4ee3fde80808a96ed268a7fb94682d_normal.png", "profile_sidebar_fill_color": "FFFF99", "entities": {"url": {"urls": [{"url": "http://t.co/tpjpvutErf", "indices": [0, 22], "expanded_url": "http://blog.mozilla.org/", "display_url": "blog.mozilla.org"}]}, "description": {"urls": []}}, "followers_count": 2342460, "profile_sidebar_border_color": "FFFFFF", "id_str": "2142731", "profile_background_color": "00539F", "listed_count": 24712, "profile_background_image_url_https": "https://pbs.twimg.com/profile_background_images/378800000055149944/1a3613e8848e7323bcac10ebeae06090.jpeg", "utc_offset": -28800, "statuses_count": 11701, "description": "I make the web a little faster, safer, smarter, better.", "friends_count": 2931, "location": "All over the world", "profile_link_color": "CC3300", "profile_image_url": "http://pbs.twimg.com/profile_images/378800000324784929/1a4ee3fde80808a96ed268a7fb94682d_normal.png", "following": true, "geo_enabled": false, "profile_banner_url": "https://pbs.twimg.com/profile_banners/2142731/1366395406", "profile_background_image_url": "http://pbs.twimg.com/profile_background_images/378800000055149944/1a3613e8848e7323bcac10ebeae06090.jpeg", "screen_name": "firefox", "lang": "en", "profile_background_tile": false, "favourites_count": 6570, "name": "Firefox", "notifications": false, "url": "http://t.co/tpjpvutErf", "created_at": "Sat Mar 24 23:58:14 +0000 2007", "contributors_enabled": false, "time_zone": "Pacific Time (US & Canada)", "protected": false, "default_profile": false, "is_translator": false}, "geo": null, "in_reply_to_user_id_str": null, "possibly_sensitive": false, "lang": "en", "created_at": "Tue Jan 07 22:39:54 +0000 2014", "in_reply_to_status_id_str": null, "place": null}, "user": {"follow_request_sent": false, "profile_use_background_image": true, "default_profile_image": false, "id": 23925141, "verified": false, "profile_text_color": "333333", "profile_image_url_https": "https://pbs.twimg.com/profile_images/378800000072303285/0501b9c8a3d883a327f816f5ce3eaad2_normal.png", "profile_sidebar_fill_color": "DDEEF6", "entities": {"url": {"urls": [{"url": "http://t.co/0thqsyksC3", "indices": [0, 22], "expanded_url": "http://www.mozilla.org/en-US/contribute/universityambassadors/", "display_url": "mozilla.org/en-US/contribu\u2026"}]}, "description": {"urls": []}}, "followers_count": 3601, "profile_sidebar_border_color": "C0DEED", "id_str": "23925141", "profile_background_color": "C0DEED", "listed_count": 148, "profile_background_image_url_https": "https://abs.twimg.com/images/themes/theme1/bg.png", "utc_offset": -28800, "statuses_count": 588, "description": "Mozilla's Firefox Student Ambassadors help spread @Firefox and promote @Mozilla\u2019s mission at their schools. Join us and make a difference to the Web!", "friends_count": 326, "location": "Earth", "profile_link_color": "0084B4", "profile_image_url": "http://pbs.twimg.com/profile_images/378800000072303285/0501b9c8a3d883a327f816f5ce3eaad2_normal.png", "following": true, "geo_enabled": true, "profile_background_image_url": "http://abs.twimg.com/images/themes/theme1/bg.png", "screen_name": "mozstudents", "lang": "en", "profile_background_tile": false, "favourites_count": 33, "name": "Student Ambassadors", "notifications": false, "url": "http://t.co/0thqsyksC3", "created_at": "Thu Mar 12 09:31:59 +0000 2009", "contributors_enabled": false, "time_zone": "Pacific Time (US & Canada)", "protected": false, "default_profile": true, "is_translator": false}, "geo": null, "in_reply_to_user_id_str": null, "possibly_sensitive": false, "lang": "en", "created_at": "Tue Jan 07 22:43:08 +0000 2014", "in_reply_to_status_id_str": null, "place": null}, {"contributors": null, "truncated": false, "text": "Congratulations to FirefoxNUST, Mozilla India, and UnikomFxClub Firefox Clubs for #winning our Affiliates #contest in December! #students", "in_reply_to_status_id": null, "id": 420236151538974720, "favorite_count": 2, "source": "web", "retweeted": false, "coordinates": null, "entities": {"symbols": [], "user_mentions": [], "hashtags": [{"indices": [82, 90], "text": "winning"}, {"indices": [106, 114], "text": "contest"}, {"indices": [128, 137], "text": "students"}], "urls": []}, "in_reply_to_screen_name": null, "id_str": "420236151538974720", "retweet_count": 3, "in_reply_to_user_id": null, "favorited": false, "user": {"follow_request_sent": false, "profile_use_background_image": true, "default_profile_image": false, "id": 23925141, "verified": false, "profile_text_color": "333333", "profile_image_url_https": "https://pbs.twimg.com/profile_images/378800000072303285/0501b9c8a3d883a327f816f5ce3eaad2_normal.png", "profile_sidebar_fill_color": "DDEEF6", "entities": {"url": {"urls": [{"url": "http://t.co/0thqsyksC3", "indices": [0, 22], "expanded_url": "http://www.mozilla.org/en-US/contribute/universityambassadors/", "display_url": "mozilla.org/en-US/contribu\u2026"}]}, "description": {"urls": []}}, "followers_count": 3601, "profile_sidebar_border_color": "C0DEED", "id_str": "23925141", "profile_background_color": "C0DEED", "listed_count": 148, "profile_background_image_url_https": "https://abs.twimg.com/images/themes/theme1/bg.png", "utc_offset": -28800, "statuses_count": 588, "description": "Mozilla's Firefox Student Ambassadors help spread @Firefox and promote @Mozilla\u2019s mission at their schools. Join us and make a difference to the Web!", "friends_count": 326, "location": "Earth", "profile_link_color": "0084B4", "profile_image_url": "http://pbs.twimg.com/profile_images/378800000072303285/0501b9c8a3d883a327f816f5ce3eaad2_normal.png", "following": true, "geo_enabled": true, "profile_background_image_url": "http://abs.twimg.com/images/themes/theme1/bg.png", "screen_name": "mozstudents", "lang": "en", "profile_background_tile": false, "favourites_count": 33, "name": "Student Ambassadors", "notifications": false, "url": "http://t.co/0thqsyksC3", "created_at": "Thu Mar 12 09:31:59 +0000 2009", "contributors_enabled": false, "time_zone": "Pacific Time (US & Canada)", "protected": false, "default_profile": true, "is_translator": false}, "geo": null, "in_reply_to_user_id_str": null, "lang": "en", "created_at": "Mon Jan 06 16:51:20 +0000 2014", "in_reply_to_status_id_str": null, "place": null}, {"contributors": null, "truncated": false, "text": "Entering our January App contest? Don't forget to tag your app with #firefoxstudents when you submit it. Good luck!", "in_reply_to_status_id": null, "id": 419949395174375425, "favorite_count": 0, "source": "web", "retweeted": false, "coordinates": null, "entities": {"symbols": [], "user_mentions": [], "hashtags": [{"indices": [68, 84], "text": "firefoxstudents"}], "urls": []}, "in_reply_to_screen_name": null, "id_str": "419949395174375425", "retweet_count": 2, "in_reply_to_user_id": null, "favorited": false, "user": {"follow_request_sent": false, "profile_use_background_image": true, "default_profile_image": false, "id": 23925141, "verified": false, "profile_text_color": "333333", "profile_image_url_https": "https://pbs.twimg.com/profile_images/378800000072303285/0501b9c8a3d883a327f816f5ce3eaad2_normal.png", "profile_sidebar_fill_color": "DDEEF6", "entities": {"url": {"urls": [{"url": "http://t.co/0thqsyksC3", "indices": [0, 22], "expanded_url": "http://www.mozilla.org/en-US/contribute/universityambassadors/", "display_url": "mozilla.org/en-US/contribu\u2026"}]}, "description": {"urls": []}}, "followers_count": 3601, "profile_sidebar_border_color": "C0DEED", "id_str": "23925141", "profile_background_color": "C0DEED", "listed_count": 148, "profile_background_image_url_https": "https://abs.twimg.com/images/themes/theme1/bg.png", "utc_offset": -28800, "statuses_count": 588, "description": "Mozilla's Firefox Student Ambassadors help spread @Firefox and promote @Mozilla\u2019s mission at their schools. Join us and make a difference to the Web!", "friends_count": 326, "location": "Earth", "profile_link_color": "0084B4", "profile_image_url": "http://pbs.twimg.com/profile_images/378800000072303285/0501b9c8a3d883a327f816f5ce3eaad2_normal.png", "following": true, "geo_enabled": true, "profile_background_image_url": "http://abs.twimg.com/images/themes/theme1/bg.png", "screen_name": "mozstudents", "lang": "en", "profile_background_tile": false, "favourites_count": 33, "name": "Student Ambassadors", "notifications": false, "url": "http://t.co/0thqsyksC3", "created_at": "Thu Mar 12 09:31:59 +0000 2009", "contributors_enabled": false, "time_zone": "Pacific Time (US & Canada)", "protected": false, "default_profile": true, "is_translator": false}, "geo": null, "in_reply_to_user_id_str": null, "lang": "en", "created_at": "Sun Jan 05 21:51:52 +0000 2014", "in_reply_to_status_id_str": null, "place": null}, {"contributors": null, "truncated": false, "text": "@MozPk @mozilla please make sure to tag your app submissions #firefoxstudents in the Firefox Marketplace. Good luck!", "in_reply_to_status_id": 419876972424990720, "id": 419949006400151552, "favorite_count": 0, "source": "web", "retweeted": false, "coordinates": null, "entities": {"symbols": [], "user_mentions": [{"id": 415929399, "indices": [0, 6], "id_str": "415929399", "screen_name": "MozPk", "name": "Mozilla Pakistan"}, {"id": 106682853, "indices": [7, 15], "id_str": "106682853", "screen_name": "mozilla", "name": "Mozilla"}], "hashtags": [{"indices": [61, 77], "text": "firefoxstudents"}], "urls": []}, "in_reply_to_screen_name": "MozPk", "id_str": "419949006400151552", "retweet_count": 0, "in_reply_to_user_id": 415929399, "favorited": false, "user": {"follow_request_sent": false, "profile_use_background_image": true, "default_profile_image": false, "id": 23925141, "verified": false, "profile_text_color": "333333", "profile_image_url_https": "https://pbs.twimg.com/profile_images/378800000072303285/0501b9c8a3d883a327f816f5ce3eaad2_normal.png", "profile_sidebar_fill_color": "DDEEF6", "entities": {"url": {"urls": [{"url": "http://t.co/0thqsyksC3", "indices": [0, 22], "expanded_url": "http://www.mozilla.org/en-US/contribute/universityambassadors/", "display_url": "mozilla.org/en-US/contribu\u2026"}]}, "description": {"urls": []}}, "followers_count": 3601, "profile_sidebar_border_color": "C0DEED", "id_str": "23925141", "profile_background_color": "C0DEED", "listed_count": 148, "profile_background_image_url_https": "https://abs.twimg.com/images/themes/theme1/bg.png", "utc_offset": -28800, "statuses_count": 588, "description": "Mozilla's Firefox Student Ambassadors help spread @Firefox and promote @Mozilla\u2019s mission at their schools. Join us and make a difference to the Web!", "friends_count": 326, "location": "Earth", "profile_link_color": "0084B4", "profile_image_url": "http://pbs.twimg.com/profile_images/378800000072303285/0501b9c8a3d883a327f816f5ce3eaad2_normal.png", "following": true, "geo_enabled": true, "profile_background_image_url": "http://abs.twimg.com/images/themes/theme1/bg.png", "screen_name": "mozstudents", "lang": "en", "profile_background_tile": false, "favourites_count": 33, "name": "Student Ambassadors", "notifications": false, "url": "http://t.co/0thqsyksC3", "created_at": "Thu Mar 12 09:31:59 +0000 2009", "contributors_enabled": false, "time_zone": "Pacific Time (US & Canada)", "protected": false, "default_profile": true, "is_translator": false}, "geo": null, "in_reply_to_user_id_str": "415929399", "lang": "en", "created_at": "Sun Jan 05 21:50:20 +0000 2014", "in_reply_to_status_id_str": "419876972424990720", "place": null}, {"contributors": null, "truncated": false, "text": "RT @elfasza: Thanks for the appreciation! http://t.co/sBg0ijkVbS @krnasz @mozstudents #IAMMOZILLIAN", "in_reply_to_status_id": null, "id": 419225998224146432, "favorite_count": 0, "source": "web", "retweeted": false, "coordinates": null, "entities": {"symbols": [], "user_mentions": [{"id": 74994115, "indices": [3, 11], "id_str": "74994115", "screen_name": "elfasza", "name": "Zayed Elfasa"}, {"id": 23775506, "indices": [65, 72], "id_str": "23775506", "screen_name": "krnasz", "name": "Katherine Naszradi"}, {"id": 23925141, "indices": [73, 85], "id_str": "23925141", "screen_name": "mozstudents", "name": "Student Ambassadors"}], "hashtags": [{"indices": [86, 99], "text": "IAMMOZILLIAN"}], "urls": [{"url": "http://t.co/sBg0ijkVbS", "indices": [42, 64], "expanded_url": "http://badg.us/en-US/badges/badge/Firefox-Student-Ambassador-Badge/awards/24041", "display_url": "badg.us/en-US/badges/b\u2026"}]}, "in_reply_to_screen_name": null, "id_str": "419225998224146432", "retweet_count": 1, "in_reply_to_user_id": null, "favorited": false, "retweeted_status": {"contributors": null, "truncated": false, "text": "Thanks for the appreciation! http://t.co/sBg0ijkVbS @krnasz @mozstudents #IAMMOZILLIAN", "in_reply_to_status_id": null, "id": 418011326783315968, "favorite_count": 0, "source": "web", "retweeted": false, "coordinates": null, "entities": {"symbols": [], "user_mentions": [{"id": 23775506, "indices": [52, 59], "id_str": "23775506", "screen_name": "krnasz", "name": "Katherine Naszradi"}, {"id": 23925141, "indices": [60, 72], "id_str": "23925141", "screen_name": "mozstudents", "name": "Student Ambassadors"}], "hashtags": [{"indices": [73, 86], "text": "IAMMOZILLIAN"}], "urls": [{"url": "http://t.co/sBg0ijkVbS", "indices": [29, 51], "expanded_url": "http://badg.us/en-US/badges/badge/Firefox-Student-Ambassador-Badge/awards/24041", "display_url": "badg.us/en-US/badges/b\u2026"}]}, "in_reply_to_screen_name": null, "id_str": "418011326783315968", "retweet_count": 1, "in_reply_to_user_id": null, "favorited": false, "user": {"follow_request_sent": false, "profile_use_background_image": true, "default_profile_image": false, "id": 74994115, "verified": false, "profile_text_color": "C3C99D", "profile_image_url_https": "https://pbs.twimg.com/profile_images/420974918432346112/n5FRusAZ_normal.jpeg", "profile_sidebar_fill_color": "25262E", "entities": {"url": {"urls": [{"url": "http://t.co/UibYwJeqAt", "indices": [0, 22], "expanded_url": "http://elfalinks.blogspot.com", "display_url": "elfalinks.blogspot.com"}]}, "description": {"urls": []}}, "followers_count": 733, "profile_sidebar_border_color": "000000", "id_str": "74994115", "profile_background_color": "DBD6E6", "listed_count": 6, "profile_background_image_url_https": "https://pbs.twimg.com/profile_background_images/187791891/tuxs.jpg", "utc_offset": 25200, "statuses_count": 20570, "description": "Mozilla Indonesia | Open Source enthusiast | Information System Student | Mozilla Reps @ID_Mozilla | check blog!", "friends_count": 576, "location": "STIKOM Surabaya", "profile_link_color": "4FC215", "profile_image_url": "http://pbs.twimg.com/profile_images/420974918432346112/n5FRusAZ_normal.jpeg", "following": false, "geo_enabled": false, "profile_banner_url": "https://pbs.twimg.com/profile_banners/74994115/1379343472", "profile_background_image_url": "http://pbs.twimg.com/profile_background_images/187791891/tuxs.jpg", "screen_name": "elfasza", "lang": "en", "profile_background_tile": true, "favourites_count": 92, "name": "Zayed Elfasa", "notifications": false, "url": "http://t.co/UibYwJeqAt", "created_at": "Thu Sep 17 11:58:36 +0000 2009", "contributors_enabled": false, "time_zone": "Jakarta", "protected": false, "default_profile": false, "is_translator": false}, "geo": null, "in_reply_to_user_id_str": null, "possibly_sensitive": false, "lang": "en", "created_at": "Tue Dec 31 13:30:41 +0000 2013", "in_reply_to_status_id_str": null, "place": null}, "user": {"follow_request_sent": false, "profile_use_background_image": true, "default_profile_image": false, "id": 23925141, "verified": false, "profile_text_color": "333333", "profile_image_url_https": "https://pbs.twimg.com/profile_images/378800000072303285/0501b9c8a3d883a327f816f5ce3eaad2_normal.png", "profile_sidebar_fill_color": "DDEEF6", "entities": {"url": {"urls": [{"url": "http://t.co/0thqsyksC3", "indices": [0, 22], "expanded_url": "http://www.mozilla.org/en-US/contribute/universityambassadors/", "display_url": "mozilla.org/en-US/contribu\u2026"}]}, "description": {"urls": []}}, "followers_count": 3601, "profile_sidebar_border_color": "C0DEED", "id_str": "23925141", "profile_background_color": "C0DEED", "listed_count": 148, "profile_background_image_url_https": "https://abs.twimg.com/images/themes/theme1/bg.png", "utc_offset": -28800, "statuses_count": 588, "description": "Mozilla's Firefox Student Ambassadors help spread @Firefox and promote @Mozilla\u2019s mission at their schools. Join us and make a difference to the Web!", "friends_count": 326, "location": "Earth", "profile_link_color": "0084B4", "profile_image_url": "http://pbs.twimg.com/profile_images/378800000072303285/0501b9c8a3d883a327f816f5ce3eaad2_normal.png", "following": true, "geo_enabled": true, "profile_background_image_url": "http://abs.twimg.com/images/themes/theme1/bg.png", "screen_name": "mozstudents", "lang": "en", "profile_background_tile": false, "favourites_count": 33, "name": "Student Ambassadors", "notifications": false, "url": "http://t.co/0thqsyksC3", "created_at": "Thu Mar 12 09:31:59 +0000 2009", "contributors_enabled": false, "time_zone": "Pacific Time (US & Canada)", "protected": false, "default_profile": true, "is_translator": false}, "geo": null, "in_reply_to_user_id_str": null, "possibly_sensitive": false, "lang": "en", "created_at": "Fri Jan 03 21:57:21 +0000 2014", "in_reply_to_status_id_str": null, "place": null}, {"contributors": null, "truncated": false, "text": "Happy 2014 Ambassadors! Check-out our Jan + Feb themes for App of the Month! http://t.co/A1UgwnPve4 #contest #prizes #win #students", "in_reply_to_status_id": null, "id": 419225870822154240, "favorite_count": 1, "source": "web", "retweeted": false, "coordinates": null, "entities": {"symbols": [], "user_mentions": [], "hashtags": [{"indices": [100, 108], "text": "contest"}, {"indices": [109, 116], "text": "prizes"}, {"indices": [117, 121], "text": "win"}, {"indices": [122, 131], "text": "students"}], "urls": [{"url": "http://t.co/A1UgwnPve4", "indices": [77, 99], "expanded_url": "http://mzl.la/192Sj3K", "display_url": "mzl.la/192Sj3K"}]}, "in_reply_to_screen_name": null, "id_str": "419225870822154240", "retweet_count": 5, "in_reply_to_user_id": null, "favorited": false, "user": {"follow_request_sent": false, "profile_use_background_image": true, "default_profile_image": false, "id": 23925141, "verified": false, "profile_text_color": "333333", "profile_image_url_https": "https://pbs.twimg.com/profile_images/378800000072303285/0501b9c8a3d883a327f816f5ce3eaad2_normal.png", "profile_sidebar_fill_color": "DDEEF6", "entities": {"url": {"urls": [{"url": "http://t.co/0thqsyksC3", "indices": [0, 22], "expanded_url": "http://www.mozilla.org/en-US/contribute/universityambassadors/", "display_url": "mozilla.org/en-US/contribu\u2026"}]}, "description": {"urls": []}}, "followers_count": 3601, "profile_sidebar_border_color": "C0DEED", "id_str": "23925141", "profile_background_color": "C0DEED", "listed_count": 148, "profile_background_image_url_https": "https://abs.twimg.com/images/themes/theme1/bg.png", "utc_offset": -28800, "statuses_count": 588, "description": "Mozilla's Firefox Student Ambassadors help spread @Firefox and promote @Mozilla\u2019s mission at their schools. Join us and make a difference to the Web!", "friends_count": 326, "location": "Earth", "profile_link_color": "0084B4", "profile_image_url": "http://pbs.twimg.com/profile_images/378800000072303285/0501b9c8a3d883a327f816f5ce3eaad2_normal.png", "following": true, "geo_enabled": true, "profile_background_image_url": "http://abs.twimg.com/images/themes/theme1/bg.png", "screen_name": "mozstudents", "lang": "en", "profile_background_tile": false, "favourites_count": 33, "name": "Student Ambassadors", "notifications": false, "url": "http://t.co/0thqsyksC3", "created_at": "Thu Mar 12 09:31:59 +0000 2009", "contributors_enabled": false, "time_zone": "Pacific Time (US & Canada)", "protected": false, "default_profile": true, "is_translator": false}, "geo": null, "in_reply_to_user_id_str": null, "possibly_sensitive": false, "lang": "en", "created_at": "Fri Jan 03 21:56:51 +0000 2014", "in_reply_to_status_id_str": null, "place": null}, {"contributors": null, "truncated": false, "text": "RT @nikeshbalami: My Journey with Mozilla Nepal Community http://t.co/ebJbx1XsQY @mozstudents @MozillaNepal @OpenBadges", "in_reply_to_status_id": null, "id": 417135721104019456, "favorite_count": 0, "source": "web", "retweeted": false, "coordinates": null, "entities": {"symbols": [], "user_mentions": [{"id": 533004465, "indices": [3, 16], "id_str": "533004465", "screen_name": "nikeshbalami", "name": "Nikesh  Balami"}, {"id": 23925141, "indices": [81, 93], "id_str": "23925141", "screen_name": "mozstudents", "name": "Student Ambassadors"}, {"id": 1051912478, "indices": [94, 107], "id_str": "1051912478", "screen_name": "MozillaNepal", "name": "Mozilla Nepal"}, {"id": 437707118, "indices": [108, 119], "id_str": "437707118", "screen_name": "OpenBadges", "name": "Mozilla Open Badges"}], "hashtags": [], "urls": [{"url": "http://t.co/ebJbx1XsQY", "indices": [58, 80], "expanded_url": "http://www.neekes.com.np/journey-with-mozilla-nepal-community/", "display_url": "neekes.com.np/journey-with-m\u2026"}]}, "in_reply_to_screen_name": null, "id_str": "417135721104019456", "retweet_count": 2, "in_reply_to_user_id": null, "favorited": false, "retweeted_status": {"contributors": null, "truncated": false, "text": "My Journey with Mozilla Nepal Community http://t.co/ebJbx1XsQY @mozstudents @MozillaNepal @OpenBadges", "in_reply_to_status_id": null, "id": 416164359895670784, "favorite_count": 1, "source": "web", "retweeted": false, "coordinates": null, "entities": {"symbols": [], "user_mentions": [{"id": 23925141, "indices": [63, 75], "id_str": "23925141", "screen_name": "mozstudents", "name": "Student Ambassadors"}, {"id": 1051912478, "indices": [76, 89], "id_str": "1051912478", "screen_name": "MozillaNepal", "name": "Mozilla Nepal"}, {"id": 437707118, "indices": [90, 101], "id_str": "437707118", "screen_name": "OpenBadges", "name": "Mozilla Open Badges"}], "hashtags": [], "urls": [{"url": "http://t.co/ebJbx1XsQY", "indices": [40, 62], "expanded_url": "http://www.neekes.com.np/journey-with-mozilla-nepal-community/", "display_url": "neekes.com.np/journey-with-m\u2026"}]}, "in_reply_to_screen_name": null, "id_str": "416164359895670784", "retweet_count": 2, "in_reply_to_user_id": null, "favorited": false, "user": {"follow_request_sent": false, "profile_use_background_image": true, "default_profile_image": false, "id": 533004465, "verified": false, "profile_text_color": "3E4415", "profile_image_url_https": "https://pbs.twimg.com/profile_images/378800000724872104/f98dd01a1f034a97c13f6f14a4debe60_normal.jpeg", "profile_sidebar_fill_color": "99CC33", "entities": {"url": {"urls": [{"url": "http://t.co/Zu931m9MEi", "indices": [0, 22], "expanded_url": "http://neekes.com.np/", "display_url": "neekes.com.np"}]}, "description": {"urls": []}}, "followers_count": 182, "profile_sidebar_border_color": "829D5E", "id_str": "533004465", "profile_background_color": "352726", "listed_count": 0, "profile_background_image_url_https": "https://abs.twimg.com/images/themes/theme5/bg.gif", "utc_offset": 20700, "statuses_count": 308, "description": "Hello Everyone! I am Nikesh Balami from Balaju-16, Kathmandu, Nepal. I am reading Diploma in computer engineering at Acme Engineering College.", "friends_count": 760, "location": "Balaju-16, Kathmandu, Nepal", "profile_link_color": "D02B55", "profile_image_url": "http://pbs.twimg.com/profile_images/378800000724872104/f98dd01a1f034a97c13f6f14a4debe60_normal.jpeg", "following": false, "geo_enabled": true, "profile_background_image_url": "http://abs.twimg.com/images/themes/theme5/bg.gif", "screen_name": "nikeshbalami", "lang": "en", "profile_background_tile": false, "favourites_count": 9, "name": "Nikesh  Balami", "notifications": false, "url": "http://t.co/Zu931m9MEi", "created_at": "Thu Mar 22 07:40:57 +0000 2012", "contributors_enabled": false, "time_zone": "Kathmandu", "protected": false, "default_profile": false, "is_translator": false}, "geo": null, "in_reply_to_user_id_str": null, "possibly_sensitive": false, "lang": "en", "created_at": "Thu Dec 26 11:11:30 +0000 2013", "in_reply_to_status_id_str": null, "place": null}, "user": {"follow_request_sent": false, "profile_use_background_image": true, "default_profile_image": false, "id": 23925141, "verified": false, "profile_text_color": "333333", "profile_image_url_https": "https://pbs.twimg.com/profile_images/378800000072303285/0501b9c8a3d883a327f816f5ce3eaad2_normal.png", "profile_sidebar_fill_color": "DDEEF6", "entities": {"url": {"urls": [{"url": "http://t.co/0thqsyksC3", "indices": [0, 22], "expanded_url": "http://www.mozilla.org/en-US/contribute/universityambassadors/", "display_url": "mozilla.org/en-US/contribu\u2026"}]}, "description": {"urls": []}}, "followers_count": 3601, "profile_sidebar_border_color": "C0DEED", "id_str": "23925141", "profile_background_color": "C0DEED", "listed_count": 148, "profile_background_image_url_https": "https://abs.twimg.com/images/themes/theme1/bg.png", "utc_offset": -28800, "statuses_count": 588, "description": "Mozilla's Firefox Student Ambassadors help spread @Firefox and promote @Mozilla\u2019s mission at their schools. Join us and make a difference to the Web!", "friends_count": 326, "location": "Earth", "profile_link_color": "0084B4", "profile_image_url": "http://pbs.twimg.com/profile_images/378800000072303285/0501b9c8a3d883a327f816f5ce3eaad2_normal.png", "following": true, "geo_enabled": true, "profile_background_image_url": "http://abs.twimg.com/images/themes/theme1/bg.png", "screen_name": "mozstudents", "lang": "en", "profile_background_tile": false, "favourites_count": 33, "name": "Student Ambassadors", "notifications": false, "url": "http://t.co/0thqsyksC3", "created_at": "Thu Mar 12 09:31:59 +0000 2009", "contributors_enabled": false, "time_zone": "Pacific Time (US & Canada)", "protected": false, "default_profile": true, "is_translator": false}, "geo": null, "in_reply_to_user_id_str": null, "possibly_sensitive": false, "lang": "en", "created_at": "Sun Dec 29 03:31:20 +0000 2013", "in_reply_to_status_id_str": null, "place": null}, {"contributors": null, "truncated": false, "text": "RT @AsaLugada: Many thanks to @mozilla @firefox @mozstudents for my FSA Package i received this month. You made my Christmas Season! http:/\u2026", "in_reply_to_status_id": null, "id": 417135577197477888, "favorite_count": 0, "source": "web", "retweeted": false, "coordinates": null, "entities": {"symbols": [], "user_mentions": [{"id": 1324664282, "indices": [3, 13], "id_str": "1324664282", "screen_name": "AsaLugada", "name": "Asa Lugada"}, {"id": 106682853, "indices": [30, 38], "id_str": "106682853", "screen_name": "mozilla", "name": "Mozilla"}, {"id": 2142731, "indices": [39, 47], "id_str": "2142731", "screen_name": "firefox", "name": "Firefox"}, {"id": 23925141, "indices": [48, 60], "id_str": "23925141", "screen_name": "mozstudents", "name": "Student Ambassadors"}], "hashtags": [], "urls": [], "media": [{"expanded_url": "http://twitter.com/AsaLugada/status/416849136730644480/photo/1", "display_url": "pic.twitter.com/ql7iJTvRq8", "url": "http://t.co/ql7iJTvRq8", "media_url_https": "https://pbs.twimg.com/media/BcjyFNBCIAAXDTk.jpg", "id_str": "416849136739033088", "sizes": {"large": {"h": 768, "resize": "fit", "w": 1024}, "small": {"h": 255, "resize": "fit", "w": 340}, "medium": {"h": 450, "resize": "fit", "w": 600}, "thumb": {"h": 150, "resize": "crop", "w": 150}}, "indices": [139, 140], "type": "photo", "id": 416849136739033088, "media_url": "http://pbs.twimg.com/media/BcjyFNBCIAAXDTk.jpg"}]}, "in_reply_to_screen_name": null, "id_str": "417135577197477888", "retweet_count": 3, "in_reply_to_user_id": null, "favorited": false, "retweeted_status": {"contributors": null, "truncated": false, "text": "Many thanks to @mozilla @firefox @mozstudents for my FSA Package i received this month. You made my Christmas Season! http://t.co/ql7iJTvRq8", "in_reply_to_status_id": null, "id": 416849136730644480, "favorite_count": 2, "source": "web", "retweeted": false, "coordinates": null, "entities": {"symbols": [], "user_mentions": [{"id": 106682853, "indices": [15, 23], "id_str": "106682853", "screen_name": "mozilla", "name": "Mozilla"}, {"id": 2142731, "indices": [24, 32], "id_str": "2142731", "screen_name": "firefox", "name": "Firefox"}, {"id": 23925141, "indices": [33, 45], "id_str": "23925141", "screen_name": "mozstudents", "name": "Student Ambassadors"}], "hashtags": [], "urls": [], "media": [{"expanded_url": "http://twitter.com/AsaLugada/status/416849136730644480/photo/1", "display_url": "pic.twitter.com/ql7iJTvRq8", "url": "http://t.co/ql7iJTvRq8", "media_url_https": "https://pbs.twimg.com/media/BcjyFNBCIAAXDTk.jpg", "id_str": "416849136739033088", "sizes": {"large": {"h": 768, "resize": "fit", "w": 1024}, "small": {"h": 255, "resize": "fit", "w": 340}, "medium": {"h": 450, "resize": "fit", "w": 600}, "thumb": {"h": 150, "resize": "crop", "w": 150}}, "indices": [118, 140], "type": "photo", "id": 416849136739033088, "media_url": "http://pbs.twimg.com/media/BcjyFNBCIAAXDTk.jpg"}]}, "in_reply_to_screen_name": null, "id_str": "416849136730644480", "retweet_count": 3, "in_reply_to_user_id": null, "favorited": false, "user": {"follow_request_sent": false, "profile_use_background_image": true, "default_profile_image": false, "id": 1324664282, "verified": false, "profile_text_color": "333333", "profile_image_url_https": "https://pbs.twimg.com/profile_images/378800000723535367/aceea1b45cb626c5aa440a89bf1a10c3_normal.jpeg", "profile_sidebar_fill_color": "DDEEF6", "entities": {"description": {"urls": []}}, "followers_count": 28, "profile_sidebar_border_color": "C0DEED", "id_str": "1324664282", "profile_background_color": "C0DEED", "listed_count": 0, "profile_background_image_url_https": "https://abs.twimg.com/images/themes/theme1/bg.png", "utc_offset": null, "statuses_count": 14, "description": "Tech, Business, Innovation, Africa and Mozilla.", "friends_count": 90, "location": "Kampala, Uganda", "profile_link_color": "0084B4", "profile_image_url": "http://pbs.twimg.com/profile_images/378800000723535367/aceea1b45cb626c5aa440a89bf1a10c3_normal.jpeg", "following": false, "geo_enabled": false, "profile_background_image_url": "http://abs.twimg.com/images/themes/theme1/bg.png", "screen_name": "AsaLugada", "lang": "en", "profile_background_tile": false, "favourites_count": 2, "name": "Asa Lugada", "notifications": false, "url": null, "created_at": "Wed Apr 03 14:02:02 +0000 2013", "contributors_enabled": false, "time_zone": null, "protected": false, "default_profile": true, "is_translator": false}, "geo": null, "in_reply_to_user_id_str": null, "possibly_sensitive": false, "lang": "en", "created_at": "Sat Dec 28 08:32:33 +0000 2013", "in_reply_to_status_id_str": null, "place": null}, "user": {"follow_request_sent": false, "profile_use_background_image": true, "default_profile_image": false, "id": 23925141, "verified": false, "profile_text_color": "333333", "profile_image_url_https": "https://pbs.twimg.com/profile_images/378800000072303285/0501b9c8a3d883a327f816f5ce3eaad2_normal.png", "profile_sidebar_fill_color": "DDEEF6", "entities": {"url": {"urls": [{"url": "http://t.co/0thqsyksC3", "indices": [0, 22], "expanded_url": "http://www.mozilla.org/en-US/contribute/universityambassadors/", "display_url": "mozilla.org/en-US/contribu\u2026"}]}, "description": {"urls": []}}, "followers_count": 3601, "profile_sidebar_border_color": "C0DEED", "id_str": "23925141", "profile_background_color": "C0DEED", "listed_count": 148, "profile_background_image_url_https": "https://abs.twimg.com/images/themes/theme1/bg.png", "utc_offset": -28800, "statuses_count": 588, "description": "Mozilla's Firefox Student Ambassadors help spread @Firefox and promote @Mozilla\u2019s mission at their schools. Join us and make a difference to the Web!", "friends_count": 326, "location": "Earth", "profile_link_color": "0084B4", "profile_image_url": "http://pbs.twimg.com/profile_images/378800000072303285/0501b9c8a3d883a327f816f5ce3eaad2_normal.png", "following": true, "geo_enabled": true, "profile_background_image_url": "http://abs.twimg.com/images/themes/theme1/bg.png", "screen_name": "mozstudents", "lang": "en", "profile_background_tile": false, "favourites_count": 33, "name": "Student Ambassadors", "notifications": false, "url": "http://t.co/0thqsyksC3", "created_at": "Thu Mar 12 09:31:59 +0000 2009", "contributors_enabled": false, "time_zone": "Pacific Time (US & Canada)", "protected": false, "default_profile": true, "is_translator": false}, "geo": null, "in_reply_to_user_id_str": null, "possibly_sensitive": false, "lang": "en", "created_at": "Sun Dec 29 03:30:46 +0000 2013", "in_reply_to_status_id_str": null, "place": null}, {"contributors": null, "truncated": false, "text": "@sinoy_siby @Firefox_GR sure! Please find all of our resources here: https://t.co/d8VaSxrWmP", "in_reply_to_status_id": 413982269397663744, "id": 414146493310726144, "favorite_count": 0, "source": "web", "retweeted": false, "coordinates": null, "entities": {"symbols": [], "user_mentions": [{"id": 2253197042, "indices": [0, 11], "id_str": "2253197042", "screen_name": "sinoy_siby", "name": "Sinoy Siby"}, {"id": 1364943300, "indices": [12, 23], "id_str": "1364943300", "screen_name": "Firefox_GR", "name": "Firefox Greece"}], "hashtags": [], "urls": [{"url": "https://t.co/d8VaSxrWmP", "indices": [69, 92], "expanded_url": "https://wiki.mozilla.org/StudentAmbassadors/Activities", "display_url": "wiki.mozilla.org/StudentAmbassa\u2026"}]}, "in_reply_to_screen_name": "sinoy_siby", "id_str": "414146493310726144", "retweet_count": 0, "in_reply_to_user_id": 2253197042, "favorited": false, "user": {"follow_request_sent": false, "profile_use_background_image": true, "default_profile_image": false, "id": 23925141, "verified": false, "profile_text_color": "333333", "profile_image_url_https": "https://pbs.twimg.com/profile_images/378800000072303285/0501b9c8a3d883a327f816f5ce3eaad2_normal.png", "profile_sidebar_fill_color": "DDEEF6", "entities": {"url": {"urls": [{"url": "http://t.co/0thqsyksC3", "indices": [0, 22], "expanded_url": "http://www.mozilla.org/en-US/contribute/universityambassadors/", "display_url": "mozilla.org/en-US/contribu\u2026"}]}, "description": {"urls": []}}, "followers_count": 3601, "profile_sidebar_border_color": "C0DEED", "id_str": "23925141", "profile_background_color": "C0DEED", "listed_count": 148, "profile_background_image_url_https": "https://abs.twimg.com/images/themes/theme1/bg.png", "utc_offset": -28800, "statuses_count": 588, "description": "Mozilla's Firefox Student Ambassadors help spread @Firefox and promote @Mozilla\u2019s mission at their schools. Join us and make a difference to the Web!", "friends_count": 326, "location": "Earth", "profile_link_color": "0084B4", "profile_image_url": "http://pbs.twimg.com/profile_images/378800000072303285/0501b9c8a3d883a327f816f5ce3eaad2_normal.png", "following": true, "geo_enabled": true, "profile_background_image_url": "http://abs.twimg.com/images/themes/theme1/bg.png", "screen_name": "mozstudents", "lang": "en", "profile_background_tile": false, "favourites_count": 33, "name": "Student Ambassadors", "notifications": false, "url": "http://t.co/0thqsyksC3", "created_at": "Thu Mar 12 09:31:59 +0000 2009", "contributors_enabled": false, "time_zone": "Pacific Time (US & Canada)", "protected": false, "default_profile": true, "is_translator": false}, "geo": null, "in_reply_to_user_id_str": "2253197042", "possibly_sensitive": false, "lang": "en", "created_at": "Fri Dec 20 21:33:13 +0000 2013", "in_reply_to_status_id_str": "413982269397663744", "place": null}]
+[
+    {
+        "contributors": null,
+        "truncated": false,
+        "text": "How amazing is this @webmaker Video Tutorial created by your fellow Ambassador Eliezer!? https://t.co/r2ZgkyDX2H Great job!",
+        "in_reply_to_status_id": null,
+        "id": 426065020921712640,
+        "favorite_count": 1,
+        "source": "web",
+        "retweeted": false,
+        "coordinates": null,
+        "entities": {
+            "symbols": [],
+            "user_mentions": [
+                {
+                    "id": 545363950,
+                    "indices": [20, 29],
+                    "id_str": "545363950",
+                    "screen_name": "webmaker",
+                    "name": "Mozilla Webmaker"
+                }
+            ],
+            "hashtags": [],
+            "urls": [
+                {
+                    "url": "https://t.co/r2ZgkyDX2H",
+                    "indices": [89, 112],
+                    "expanded_url": "https://eliezerb.makes.org/popcorn/1p96",
+                    "display_url": "eliezerb.makes.org/popcorn/1p96"
+                }
+            ]
+        },
+        "in_reply_to_screen_name": null,
+        "id_str": "426065020921712640",
+        "retweet_count": 2,
+        "in_reply_to_user_id": null,
+        "favorited": false,
+        "user": {
+            "follow_request_sent": false,
+            "profile_use_background_image": true,
+            "default_profile_image": false,
+            "id": 23925141,
+            "verified": false,
+            "profile_text_color": "333333",
+            "profile_image_url_https": "https://pbs.twimg.com/profile_images/378800000072303285/0501b9c8a3d883a327f816f5ce3eaad2_normal.png",
+            "profile_sidebar_fill_color": "DDEEF6",
+            "entities": {
+                "url": {
+                    "urls": [
+                        {
+                            "url": "http://t.co/0thqsyksC3",
+                            "indices": [0, 22],
+                            "expanded_url": "http://www.mozilla.org/en-US/contribute/universityambassadors/",
+                            "display_url": "mozilla.org/en-US/contribu\u2026"
+                        }
+                    ]
+                },
+                "description": {
+                    "urls": []
+                }
+            },
+            "followers_count": 3601,
+            "profile_sidebar_border_color": "C0DEED",
+            "id_str": "23925141",
+            "profile_background_color": "C0DEED",
+            "listed_count": 148,
+            "profile_background_image_url_https": "https://abs.twimg.com/images/themes/theme1/bg.png",
+            "utc_offset": -28800,
+            "statuses_count": 588,
+            "description": "Mozilla's Firefox Student Ambassadors help spread @Firefox and promote @Mozilla\u2019s mission at their schools. Join us and make a difference to the Web!",
+            "friends_count": 326,
+            "location": "Earth",
+            "profile_link_color": "0084B4",
+            "profile_image_url": "http://pbs.twimg.com/profile_images/378800000072303285/0501b9c8a3d883a327f816f5ce3eaad2_normal.png",
+            "following": true,
+            "geo_enabled": true,
+            "profile_background_image_url": "http://abs.twimg.com/images/themes/theme1/bg.png",
+            "screen_name": "mozstudents",
+            "lang": "en",
+            "profile_background_tile": false,
+            "favourites_count": 33,
+            "name": "Student Ambassadors",
+            "notifications": false,
+            "url": "http://t.co/0thqsyksC3",
+            "created_at": "Thu Mar 12 09:31:59 +0000 2009",
+            "contributors_enabled": false,
+            "time_zone": "Pacific Time (US & Canada)",
+            "protected": false,
+            "default_profile": true,
+            "is_translator": false
+        },
+        "geo": null,
+        "in_reply_to_user_id_str": null,
+        "possibly_sensitive": false,
+        "lang": "en",
+        "created_at": "Wed Jan 22 18:53:11 +0000 2014",
+        "in_reply_to_status_id_str": null,
+        "place": null
+    },
+    {
+        "contributors": null,
+        "truncated": false,
+        "text": "Congrats to those of you who received your Open Badge in Jan! Apply for Feb by following these directions http://t.co/rpFeEe1Bp4",
+        "in_reply_to_status_id": null,
+        "id": 425700814015852544,
+        "favorite_count": 1,
+        "source": "web",
+        "retweeted": false,
+        "coordinates": null,
+        "entities": {
+            "symbols": [],
+            "user_mentions": [],
+            "hashtags": [],
+            "urls": [
+                {
+                    "url": "http://t.co/rpFeEe1Bp4",
+                    "indices": [106, 128],
+                    "expanded_url": "http://mzl.la/1cRd7qc",
+                    "display_url": "mzl.la/1cRd7qc"
+                }
+            ]
+        },
+        "in_reply_to_screen_name": null,
+        "id_str": "425700814015852544",
+        "retweet_count": 4,
+        "in_reply_to_user_id": null,
+        "favorited": false,
+        "user": {
+            "follow_request_sent": false,
+            "profile_use_background_image": true,
+            "default_profile_image": false,
+            "id": 23925141,
+            "verified": false,
+            "profile_text_color": "333333",
+            "profile_image_url_https": "https://pbs.twimg.com/profile_images/378800000072303285/0501b9c8a3d883a327f816f5ce3eaad2_normal.png",
+            "profile_sidebar_fill_color": "DDEEF6",
+            "entities": {
+                "url": {
+                    "urls": [
+                        {
+                            "url": "http://t.co/0thqsyksC3",
+                            "indices": [0, 22],
+                            "expanded_url": "http://www.mozilla.org/en-US/contribute/universityambassadors/",
+                            "display_url": "mozilla.org/en-US/contribu\u2026"
+                        }
+                    ]
+                },
+                "description": {
+                    "urls": []
+                }
+            },
+            "followers_count": 3601,
+            "profile_sidebar_border_color": "C0DEED",
+            "id_str": "23925141",
+            "profile_background_color": "C0DEED",
+            "listed_count": 148,
+            "profile_background_image_url_https": "https://abs.twimg.com/images/themes/theme1/bg.png",
+            "utc_offset": -28800,
+            "statuses_count": 588,
+            "description": "Mozilla's Firefox Student Ambassadors help spread @Firefox and promote @Mozilla\u2019s mission at their schools. Join us and make a difference to the Web!",
+            "friends_count": 326,
+            "location": "Earth",
+            "profile_link_color": "0084B4",
+            "profile_image_url": "http://pbs.twimg.com/profile_images/378800000072303285/0501b9c8a3d883a327f816f5ce3eaad2_normal.png",
+            "following": true,
+            "geo_enabled": true,
+            "profile_background_image_url": "http://abs.twimg.com/images/themes/theme1/bg.png",
+            "screen_name": "mozstudents",
+            "lang": "en",
+            "profile_background_tile": false,
+            "favourites_count": 33,
+            "name": "Student Ambassadors",
+            "notifications": false,
+            "url": "http://t.co/0thqsyksC3",
+            "created_at": "Thu Mar 12 09:31:59 +0000 2009",
+            "contributors_enabled": false,
+            "time_zone": "Pacific Time (US & Canada)",
+            "protected": false,
+            "default_profile": true,
+            "is_translator": false
+        },
+        "geo": null,
+        "in_reply_to_user_id_str": null,
+        "possibly_sensitive": false,
+        "lang": "en",
+        "created_at": "Tue Jan 21 18:45:57 +0000 2014",
+        "in_reply_to_status_id_str": null,
+        "place": null
+    },
+    {
+        "contributors": null,
+        "truncated": false,
+        "text": "Looking for a way to celebrate Data Privacy Day on January 28? Get started with the Privacy &amp; Security Teaching Kit http://t.co/XLuho2eyYy",
+        "in_reply_to_status_id": null,
+        "id": 425489316819632128,
+        "favorite_count": 3,
+        "source": "web",
+        "retweeted": false,
+        "coordinates": null,
+        "entities": {
+            "symbols": [],
+            "user_mentions": [],
+            "hashtags": [],
+            "urls": [
+                {
+                    "url": "http://t.co/XLuho2eyYy",
+                    "indices": [120, 142],
+                    "expanded_url": "http://bit.ly/1dPx3yq",
+                    "display_url": "bit.ly/1dPx3yq"
+                }
+            ]
+        },
+        "in_reply_to_screen_name": null,
+        "id_str": "425489316819632128",
+        "retweet_count": 2,
+        "in_reply_to_user_id": null,
+        "favorited": false,
+        "user": {
+            "follow_request_sent": false,
+            "profile_use_background_image": true,
+            "default_profile_image": false,
+            "id": 23925141,
+            "verified": false,
+            "profile_text_color": "333333",
+            "profile_image_url_https": "https://pbs.twimg.com/profile_images/378800000072303285/0501b9c8a3d883a327f816f5ce3eaad2_normal.png",
+            "profile_sidebar_fill_color": "DDEEF6",
+            "entities": {
+                "url": {
+                    "urls": [
+                        {
+                            "url": "http://t.co/0thqsyksC3",
+                            "indices": [0, 22],
+                            "expanded_url": "http://www.mozilla.org/en-US/contribute/universityambassadors/",
+                            "display_url": "mozilla.org/en-US/contribu\u2026"
+                        }
+                    ]
+                },
+                "description": {
+                    "urls": []
+                }
+            },
+            "followers_count": 3601,
+            "profile_sidebar_border_color": "C0DEED",
+            "id_str": "23925141",
+            "profile_background_color": "C0DEED",
+            "listed_count": 148,
+            "profile_background_image_url_https": "https://abs.twimg.com/images/themes/theme1/bg.png",
+            "utc_offset": -28800,
+            "statuses_count": 588,
+            "description": "Mozilla's Firefox Student Ambassadors help spread @Firefox and promote @Mozilla\u2019s mission at their schools. Join us and make a difference to the Web!",
+            "friends_count": 326,
+            "location": "Earth",
+            "profile_link_color": "0084B4",
+            "profile_image_url": "http://pbs.twimg.com/profile_images/378800000072303285/0501b9c8a3d883a327f816f5ce3eaad2_normal.png",
+            "following": true,
+            "geo_enabled": true,
+            "profile_background_image_url": "http://abs.twimg.com/images/themes/theme1/bg.png",
+            "screen_name": "mozstudents",
+            "lang": "en",
+            "profile_background_tile": false,
+            "favourites_count": 33,
+            "name": "Student Ambassadors",
+            "notifications": false,
+            "url": "http://t.co/0thqsyksC3",
+            "created_at": "Thu Mar 12 09:31:59 +0000 2009",
+            "contributors_enabled": false,
+            "time_zone": "Pacific Time (US & Canada)",
+            "protected": false,
+            "default_profile": true,
+            "is_translator": false
+        },
+        "geo": null,
+        "in_reply_to_user_id_str": null,
+        "possibly_sensitive": false,
+        "lang": "en",
+        "created_at": "Tue Jan 21 04:45:32 +0000 2014",
+        "in_reply_to_status_id_str": null,
+        "place": null
+    },
+    {
+        "contributors": null,
+        "truncated": false,
+        "text": "If you're interested in Webmaker, check out our Video Tutorials! The deadline to submit videos this month is Jan 25! http://t.co/ailOA0rP5U",
+        "in_reply_to_status_id": null,
+        "id": 425094136786472960,
+        "favorite_count": 1,
+        "source": "web",
+        "retweeted": false,
+        "coordinates": null,
+        "entities": {
+            "symbols": [],
+            "user_mentions": [],
+            "hashtags": [],
+            "urls": [
+                {
+                    "url": "http://t.co/ailOA0rP5U",
+                    "indices": [117, 139],
+                    "expanded_url": "http://mzl.la/1dhjGSV",
+                    "display_url": "mzl.la/1dhjGSV"
+                }
+            ]
+        },
+        "in_reply_to_screen_name": null,
+        "id_str": "425094136786472960",
+        "retweet_count": 8,
+        "in_reply_to_user_id": null,
+        "favorited": false,
+        "user": {
+            "follow_request_sent": false,
+            "profile_use_background_image": true,
+            "default_profile_image": false,
+            "id": 23925141,
+            "verified": false,
+            "profile_text_color": "333333",
+            "profile_image_url_https": "https://pbs.twimg.com/profile_images/378800000072303285/0501b9c8a3d883a327f816f5ce3eaad2_normal.png",
+            "profile_sidebar_fill_color": "DDEEF6",
+            "entities": {
+                "url": {
+                    "urls": [
+                        {
+                            "url": "http://t.co/0thqsyksC3",
+                            "indices": [0, 22],
+                            "expanded_url": "http://www.mozilla.org/en-US/contribute/universityambassadors/",
+                            "display_url": "mozilla.org/en-US/contribu\u2026"
+                        }
+                    ]
+                },
+                "description": {
+                    "urls": []
+                }
+            },
+            "followers_count": 3601,
+            "profile_sidebar_border_color": "C0DEED",
+            "id_str": "23925141",
+            "profile_background_color": "C0DEED",
+            "listed_count": 148,
+            "profile_background_image_url_https": "https://abs.twimg.com/images/themes/theme1/bg.png",
+            "utc_offset": -28800,
+            "statuses_count": 588,
+            "description": "Mozilla's Firefox Student Ambassadors help spread @Firefox and promote @Mozilla\u2019s mission at their schools. Join us and make a difference to the Web!",
+            "friends_count": 326,
+            "location": "Earth",
+            "profile_link_color": "0084B4",
+            "profile_image_url": "http://pbs.twimg.com/profile_images/378800000072303285/0501b9c8a3d883a327f816f5ce3eaad2_normal.png",
+            "following": true,
+            "geo_enabled": true,
+            "profile_background_image_url": "http://abs.twimg.com/images/themes/theme1/bg.png",
+            "screen_name": "mozstudents",
+            "lang": "en",
+            "profile_background_tile": false,
+            "favourites_count": 33,
+            "name": "Student Ambassadors",
+            "notifications": false,
+            "url": "http://t.co/0thqsyksC3",
+            "created_at": "Thu Mar 12 09:31:59 +0000 2009",
+            "contributors_enabled": false,
+            "time_zone": "Pacific Time (US & Canada)",
+            "protected": false,
+            "default_profile": true,
+            "is_translator": false
+        },
+        "geo": null,
+        "in_reply_to_user_id_str": null,
+        "possibly_sensitive": false,
+        "lang": "en",
+        "created_at": "Mon Jan 20 02:35:14 +0000 2014",
+        "in_reply_to_status_id_str": null,
+        "place": null
+    },
+    {
+        "contributors": null,
+        "truncated": false,
+        "text": "Doing a Video Tutorial this month? Reminder to submit it by January 21st using this form: http://t.co/g6CXXISvyi #students #contest",
+        "in_reply_to_status_id": null,
+        "id": 424217143480041472,
+        "favorite_count": 0,
+        "source": "web",
+        "retweeted": false,
+        "coordinates": null,
+        "entities": {
+            "symbols": [],
+            "user_mentions": [],
+            "hashtags": [
+                {
+                    "indices": [113, 122],
+                    "text": "students"
+                },
+                {
+                    "indices": [123, 131],
+                    "text": "contest"
+                }
+            ],
+            "urls": [
+                {
+                    "url": "http://t.co/g6CXXISvyi",
+                    "indices": [90, 112],
+                    "expanded_url": "http://bit.ly/1mb4H2k",
+                    "display_url": "bit.ly/1mb4H2k"
+                }
+            ]
+        },
+        "in_reply_to_screen_name": null,
+        "id_str": "424217143480041472",
+        "retweet_count": 1,
+        "in_reply_to_user_id": null,
+        "favorited": false,
+        "user": {
+            "follow_request_sent": false,
+            "profile_use_background_image": true,
+            "default_profile_image": false,
+            "id": 23925141,
+            "verified": false,
+            "profile_text_color": "333333",
+            "profile_image_url_https": "https://pbs.twimg.com/profile_images/378800000072303285/0501b9c8a3d883a327f816f5ce3eaad2_normal.png",
+            "profile_sidebar_fill_color": "DDEEF6",
+            "entities": {
+                "url": {
+                    "urls": [
+                        {
+                            "url": "http://t.co/0thqsyksC3",
+                            "indices": [0, 22],
+                            "expanded_url": "http://www.mozilla.org/en-US/contribute/universityambassadors/",
+                            "display_url": "mozilla.org/en-US/contribu\u2026"
+                        }
+                    ]
+                },
+                "description": {
+                    "urls": []
+                }
+            },
+            "followers_count": 3601,
+            "profile_sidebar_border_color": "C0DEED",
+            "id_str": "23925141",
+            "profile_background_color": "C0DEED",
+            "listed_count": 148,
+            "profile_background_image_url_https": "https://abs.twimg.com/images/themes/theme1/bg.png",
+            "utc_offset": -28800,
+            "statuses_count": 588,
+            "description": "Mozilla's Firefox Student Ambassadors help spread @Firefox and promote @Mozilla\u2019s mission at their schools. Join us and make a difference to the Web!",
+            "friends_count": 326,
+            "location": "Earth",
+            "profile_link_color": "0084B4",
+            "profile_image_url": "http://pbs.twimg.com/profile_images/378800000072303285/0501b9c8a3d883a327f816f5ce3eaad2_normal.png",
+            "following": true,
+            "geo_enabled": true,
+            "profile_background_image_url": "http://abs.twimg.com/images/themes/theme1/bg.png",
+            "screen_name": "mozstudents",
+            "lang": "en",
+            "profile_background_tile": false,
+            "favourites_count": 33,
+            "name": "Student Ambassadors",
+            "notifications": false,
+            "url": "http://t.co/0thqsyksC3",
+            "created_at": "Thu Mar 12 09:31:59 +0000 2009",
+            "contributors_enabled": false,
+            "time_zone": "Pacific Time (US & Canada)",
+            "protected": false,
+            "default_profile": true,
+            "is_translator": false
+        },
+        "geo": null,
+        "in_reply_to_user_id_str": null,
+        "possibly_sensitive": false,
+        "lang": "en",
+        "created_at": "Fri Jan 17 16:30:23 +0000 2014",
+        "in_reply_to_status_id_str": null,
+        "place": null
+    },
+    {
+        "contributors": null,
+        "truncated": false,
+        "text": "Want more information about the @mozstudents program? Sign-up and get a monthly newsletter in your in-box http://t.co/0thqsyksC3 #oto\u00f1o",
+        "in_reply_to_status_id": null,
+        "id": 423899555776589824,
+        "favorite_count": 1,
+        "source": "web",
+        "retweeted": false,
+        "coordinates": null,
+        "entities": {
+            "symbols": [],
+            "user_mentions": [
+                {
+                    "id": 23925141,
+                    "indices": [32, 44],
+                    "id_str": "23925141",
+                    "screen_name": "mozstudents",
+                    "name": "Student Ambassadors"
+                }
+            ],
+            "hashtags": [
+                {
+                    "indices": [129, 135],
+                    "text": "oto\u00f1o"
+                }
+            ],
+            "urls": [
+                {
+                    "url": "http://t.co/0thqsyksC3",
+                    "indices": [106, 128],
+                    "expanded_url": "http://www.mozilla.org/en-US/contribute/universityambassadors/",
+                    "display_url": "mozilla.org/en-US/contribu\u2026"
+                }
+            ]
+        },
+        "in_reply_to_screen_name": null,
+        "id_str": "423899555776589824",
+        "retweet_count": 1,
+        "in_reply_to_user_id": null,
+        "favorited": false,
+        "user": {
+            "follow_request_sent": false,
+            "profile_use_background_image": true,
+            "default_profile_image": false,
+            "id": 23925141,
+            "verified": false,
+            "profile_text_color": "333333",
+            "profile_image_url_https": "https://pbs.twimg.com/profile_images/378800000072303285/0501b9c8a3d883a327f816f5ce3eaad2_normal.png",
+            "profile_sidebar_fill_color": "DDEEF6",
+            "entities": {
+                "url": {
+                    "urls": [
+                        {
+                            "url": "http://t.co/0thqsyksC3",
+                            "indices": [0, 22],
+                            "expanded_url": "http://www.mozilla.org/en-US/contribute/universityambassadors/",
+                            "display_url": "mozilla.org/en-US/contribu\u2026"
+                        }
+                    ]
+                },
+                "description": {
+                    "urls": []
+                }
+            },
+            "followers_count": 3601,
+            "profile_sidebar_border_color": "C0DEED",
+            "id_str": "23925141",
+            "profile_background_color": "C0DEED",
+            "listed_count": 148,
+            "profile_background_image_url_https": "https://abs.twimg.com/images/themes/theme1/bg.png",
+            "utc_offset": -28800,
+            "statuses_count": 588,
+            "description": "Mozilla's Firefox Student Ambassadors help spread @Firefox and promote @Mozilla\u2019s mission at their schools. Join us and make a difference to the Web!",
+            "friends_count": 326,
+            "location": "Earth",
+            "profile_link_color": "0084B4",
+            "profile_image_url": "http://pbs.twimg.com/profile_images/378800000072303285/0501b9c8a3d883a327f816f5ce3eaad2_normal.png",
+            "following": true,
+            "geo_enabled": true,
+            "profile_background_image_url": "http://abs.twimg.com/images/themes/theme1/bg.png",
+            "screen_name": "mozstudents",
+            "lang": "en",
+            "profile_background_tile": false,
+            "favourites_count": 33,
+            "name": "Student Ambassadors",
+            "notifications": false,
+            "url": "http://t.co/0thqsyksC3",
+            "created_at": "Thu Mar 12 09:31:59 +0000 2009",
+            "contributors_enabled": false,
+            "time_zone": "Pacific Time (US & Canada)",
+            "protected": false,
+            "default_profile": true,
+            "is_translator": false
+        },
+        "geo": null,
+        "in_reply_to_user_id_str": null,
+        "possibly_sensitive": false,
+        "lang": "en",
+        "created_at": "Thu Jan 16 19:28:24 +0000 2014",
+        "in_reply_to_status_id_str": null,
+        "place": null
+    },
+    {
+        "contributors": null,
+        "truncated": false,
+        "text": "RT @STPIFirefoxClub: Hacking Web With Webmaker \u201cWebmaker Party\u201d by STPI Firefox Club  @mozstudents @webmaker http://t.co/4dVunerWCD #MakerP\u2026",
+        "in_reply_to_status_id": null,
+        "id": 423267155551858688,
+        "favorite_count": 0,
+        "source": "web",
+        "retweeted": false,
+        "coordinates": null,
+        "entities": {
+            "symbols": [],
+            "user_mentions": [
+                {
+                    "id": 1437282660,
+                    "indices": [3, 19],
+                    "id_str": "1437282660",
+                    "screen_name": "STPIFirefoxClub",
+                    "name": "STPI Firefox Club"
+                },
+                {
+                    "id": 23925141,
+                    "indices": [86, 98],
+                    "id_str": "23925141",
+                    "screen_name": "mozstudents",
+                    "name": "Student Ambassadors"
+                },
+                {
+                    "id": 545363950,
+                    "indices": [99, 108],
+                    "id_str": "545363950",
+                    "screen_name": "webmaker",
+                    "name": "Mozilla Webmaker"
+                }
+            ],
+            "hashtags": [
+                {
+                    "indices": [132, 140],
+                    "text": "MakerParty"
+                },
+                {
+                    "indices": [139, 140],
+                    "text": "firefoxstudents"
+                }
+            ],
+            "urls": [
+                {
+                    "url": "http://t.co/4dVunerWCD",
+                    "indices": [109, 131],
+                    "expanded_url": "http://oonlab.com/hacking-web-with-webmaker-webmaker-party.onto",
+                    "display_url": "oonlab.com/hacking-web-wi\u2026"
+                }
+            ]
+        },
+        "in_reply_to_screen_name": null,
+        "id_str": "423267155551858688",
+        "retweet_count": 1,
+        "in_reply_to_user_id": null,
+        "favorited": false,
+        "retweeted_status": {
+            "contributors": null,
+            "truncated": false,
+            "text": "Hacking Web With Webmaker \u201cWebmaker Party\u201d by STPI Firefox Club  @mozstudents @webmaker http://t.co/4dVunerWCD #MakerParty #firefoxstudents",
+            "in_reply_to_status_id": null,
+            "id": 423079698982129664,
+            "favorite_count": 3,
+            "source": "web",
+            "retweeted": false,
+            "coordinates": null,
+            "entities": {
+                "symbols": [],
+                "user_mentions": [
+                    {
+                        "id": 23925141,
+                        "indices": [65, 77],
+                        "id_str": "23925141",
+                        "screen_name": "mozstudents",
+                        "name": "Student Ambassadors"
+                    },
+                    {
+                        "id": 545363950,
+                        "indices": [78, 87],
+                        "id_str": "545363950",
+                        "screen_name": "webmaker",
+                        "name": "Mozilla Webmaker"
+                    }
+                ],
+                "hashtags": [
+                    {
+                        "indices": [111, 122],
+                        "text": "MakerParty"
+                    },
+                    {
+                        "indices": [123, 139],
+                        "text": "firefoxstudents"
+                    }
+                ],
+                "urls": [
+                    {
+                        "url": "http://t.co/4dVunerWCD",
+                        "indices": [88, 110],
+                        "expanded_url": "http://oonlab.com/hacking-web-with-webmaker-webmaker-party.onto",
+                        "display_url": "oonlab.com/hacking-web-wi\u2026"
+                    }
+                ]
+            },
+            "in_reply_to_screen_name": null,
+            "id_str": "423079698982129664",
+            "retweet_count": 1,
+            "in_reply_to_user_id": null,
+            "favorited": false,
+            "user": {
+                "follow_request_sent": false,
+                "profile_use_background_image": true,
+                "default_profile_image": false,
+                "id": 1437282660,
+                "verified": false,
+                "profile_text_color": "333333",
+                "profile_image_url_https": "https://pbs.twimg.com/profile_images/421896693647278080/Fpkr82Vx_normal.png",
+                "profile_sidebar_fill_color": "EFEFEF",
+                "entities": {
+                    "url": {
+                        "urls": [
+                            {
+                                "url": "https://t.co/QUTEKB0sba",
+                                "indices": [0, 23],
+                                "expanded_url": "https://wiki.mozilla.org/STPI_Firefox_Club",
+                                "display_url": "wiki.mozilla.org/STPI_Firefox_C\u2026"
+                            }
+                        ]
+                    },
+                    "description": {
+                        "urls": []
+                    }
+                },
+                "followers_count": 93,
+                "profile_sidebar_border_color": "EEEEEE",
+                "id_str": "1437282660",
+                "profile_background_color": "131516",
+                "listed_count": 1,
+                "profile_background_image_url_https": "https://abs.twimg.com/images/themes/theme14/bg.gif",
+                "utc_offset": 25200,
+                "statuses_count": 794,
+                "description": "We help spread @Firefox and promote @Mozilla\u2019s mission and Tax Education at Sekolah Tinggi Perpajakan Indonesia. Join us and make a difference to the Web!",
+                "friends_count": 62,
+                "location": "Earth",
+                "profile_link_color": "009999",
+                "profile_image_url": "http://pbs.twimg.com/profile_images/421896693647278080/Fpkr82Vx_normal.png",
+                "following": false,
+                "geo_enabled": false,
+                "profile_banner_url": "https://pbs.twimg.com/profile_banners/1437282660/1389658660",
+                "profile_background_image_url": "http://abs.twimg.com/images/themes/theme14/bg.gif",
+                "screen_name": "STPIFirefoxClub",
+                "lang": "en",
+                "profile_background_tile": true,
+                "favourites_count": 37,
+                "name": "STPI Firefox Club",
+                "notifications": false,
+                "url": "https://t.co/QUTEKB0sba",
+                "created_at": "Sat May 18 03:31:24 +0000 2013",
+                "contributors_enabled": false,
+                "time_zone": "Bangkok",
+                "protected": false,
+                "default_profile": false,
+                "is_translator": false
+            },
+            "geo": null,
+            "in_reply_to_user_id_str": null,
+            "possibly_sensitive": false,
+            "lang": "en",
+            "created_at": "Tue Jan 14 13:10:35 +0000 2014",
+            "in_reply_to_status_id_str": null,
+            "place": null
+        },
+        "user": {
+            "follow_request_sent": false,
+            "profile_use_background_image": true,
+            "default_profile_image": false,
+            "id": 23925141,
+            "verified": false,
+            "profile_text_color": "333333",
+            "profile_image_url_https": "https://pbs.twimg.com/profile_images/378800000072303285/0501b9c8a3d883a327f816f5ce3eaad2_normal.png",
+            "profile_sidebar_fill_color": "DDEEF6",
+            "entities": {
+                "url": {
+                    "urls": [
+                        {
+                            "url": "http://t.co/0thqsyksC3",
+                            "indices": [0, 22],
+                            "expanded_url": "http://www.mozilla.org/en-US/contribute/universityambassadors/",
+                            "display_url": "mozilla.org/en-US/contribu\u2026"
+                        }
+                    ]
+                },
+                "description": {
+                    "urls": []
+                }
+            },
+            "followers_count": 3601,
+            "profile_sidebar_border_color": "C0DEED",
+            "id_str": "23925141",
+            "profile_background_color": "C0DEED",
+            "listed_count": 148,
+            "profile_background_image_url_https": "https://abs.twimg.com/images/themes/theme1/bg.png",
+            "utc_offset": -28800,
+            "statuses_count": 588,
+            "description": "Mozilla's Firefox Student Ambassadors help spread @Firefox and promote @Mozilla\u2019s mission at their schools. Join us and make a difference to the Web!",
+            "friends_count": 326,
+            "location": "Earth",
+            "profile_link_color": "0084B4",
+            "profile_image_url": "http://pbs.twimg.com/profile_images/378800000072303285/0501b9c8a3d883a327f816f5ce3eaad2_normal.png",
+            "following": true,
+            "geo_enabled": true,
+            "profile_background_image_url": "http://abs.twimg.com/images/themes/theme1/bg.png",
+            "screen_name": "mozstudents",
+            "lang": "en",
+            "profile_background_tile": false,
+            "favourites_count": 33,
+            "name": "Student Ambassadors",
+            "notifications": false,
+            "url": "http://t.co/0thqsyksC3",
+            "created_at": "Thu Mar 12 09:31:59 +0000 2009",
+            "contributors_enabled": false,
+            "time_zone": "Pacific Time (US & Canada)",
+            "protected": false,
+            "default_profile": true,
+            "is_translator": false
+        },
+        "geo": null,
+        "in_reply_to_user_id_str": null,
+        "possibly_sensitive": false,
+        "lang": "en",
+        "created_at": "Wed Jan 15 01:35:28 +0000 2014",
+        "in_reply_to_status_id_str": null,
+        "place": null
+    },
+    {
+        "contributors": null,
+        "truncated": false,
+        "text": "Join us tomorrow for Office Hours! Catch up on IRC (#firefoxstudents) at 3:30pm UTC http://t.co/fT5tEPWRZv #students",
+        "in_reply_to_status_id": null,
+        "id": 423146061482307585,
+        "favorite_count": 0,
+        "source": "web",
+        "retweeted": false,
+        "coordinates": null,
+        "entities": {
+            "symbols": [],
+            "user_mentions": [],
+            "hashtags": [
+                {
+                    "indices": [52, 68],
+                    "text": "firefoxstudents"
+                },
+                {
+                    "indices": [107, 116],
+                    "text": "students"
+                }
+            ],
+            "urls": [
+                {
+                    "url": "http://t.co/fT5tEPWRZv",
+                    "indices": [84, 106],
+                    "expanded_url": "http://mzl.la/1cX79pI",
+                    "display_url": "mzl.la/1cX79pI"
+                }
+            ]
+        },
+        "in_reply_to_screen_name": null,
+        "id_str": "423146061482307585",
+        "retweet_count": 1,
+        "in_reply_to_user_id": null,
+        "favorited": false,
+        "user": {
+            "follow_request_sent": false,
+            "profile_use_background_image": true,
+            "default_profile_image": false,
+            "id": 23925141,
+            "verified": false,
+            "profile_text_color": "333333",
+            "profile_image_url_https": "https://pbs.twimg.com/profile_images/378800000072303285/0501b9c8a3d883a327f816f5ce3eaad2_normal.png",
+            "profile_sidebar_fill_color": "DDEEF6",
+            "entities": {
+                "url": {
+                    "urls": [
+                        {
+                            "url": "http://t.co/0thqsyksC3",
+                            "indices": [0, 22],
+                            "expanded_url": "http://www.mozilla.org/en-US/contribute/universityambassadors/",
+                            "display_url": "mozilla.org/en-US/contribu\u2026"
+                        }
+                    ]
+                },
+                "description": {
+                    "urls": []
+                }
+            },
+            "followers_count": 3601,
+            "profile_sidebar_border_color": "C0DEED",
+            "id_str": "23925141",
+            "profile_background_color": "C0DEED",
+            "listed_count": 148,
+            "profile_background_image_url_https": "https://abs.twimg.com/images/themes/theme1/bg.png",
+            "utc_offset": -28800,
+            "statuses_count": 588,
+            "description": "Mozilla's Firefox Student Ambassadors help spread @Firefox and promote @Mozilla\u2019s mission at their schools. Join us and make a difference to the Web!",
+            "friends_count": 326,
+            "location": "Earth",
+            "profile_link_color": "0084B4",
+            "profile_image_url": "http://pbs.twimg.com/profile_images/378800000072303285/0501b9c8a3d883a327f816f5ce3eaad2_normal.png",
+            "following": true,
+            "geo_enabled": true,
+            "profile_background_image_url": "http://abs.twimg.com/images/themes/theme1/bg.png",
+            "screen_name": "mozstudents",
+            "lang": "en",
+            "profile_background_tile": false,
+            "favourites_count": 33,
+            "name": "Student Ambassadors",
+            "notifications": false,
+            "url": "http://t.co/0thqsyksC3",
+            "created_at": "Thu Mar 12 09:31:59 +0000 2009",
+            "contributors_enabled": false,
+            "time_zone": "Pacific Time (US & Canada)",
+            "protected": false,
+            "default_profile": true,
+            "is_translator": false
+        },
+        "geo": null,
+        "in_reply_to_user_id_str": null,
+        "possibly_sensitive": false,
+        "lang": "en",
+        "created_at": "Tue Jan 14 17:34:17 +0000 2014",
+        "in_reply_to_status_id_str": null,
+        "place": null
+    },
+    {
+        "contributors": null,
+        "truncated": false,
+        "text": "The PNUP Fx Club hosted their first ever campus event January 11 Find out more information about how it went here http://t.co/MYtHCpIOSl",
+        "in_reply_to_status_id": null,
+        "id": 422783419802611714,
+        "favorite_count": 2,
+        "source": "web",
+        "retweeted": false,
+        "coordinates": null,
+        "entities": {
+            "symbols": [],
+            "user_mentions": [],
+            "hashtags": [],
+            "urls": [
+                {
+                    "url": "http://t.co/MYtHCpIOSl",
+                    "indices": [114, 136],
+                    "expanded_url": "http://bit.ly/L2HzIa",
+                    "display_url": "bit.ly/L2HzIa"
+                }
+            ]
+        },
+        "in_reply_to_screen_name": null,
+        "id_str": "422783419802611714",
+        "retweet_count": 3,
+        "in_reply_to_user_id": null,
+        "favorited": false,
+        "user": {
+            "follow_request_sent": false,
+            "profile_use_background_image": true,
+            "default_profile_image": false,
+            "id": 23925141,
+            "verified": false,
+            "profile_text_color": "333333",
+            "profile_image_url_https": "https://pbs.twimg.com/profile_images/378800000072303285/0501b9c8a3d883a327f816f5ce3eaad2_normal.png",
+            "profile_sidebar_fill_color": "DDEEF6",
+            "entities": {
+                "url": {
+                    "urls": [
+                        {
+                            "url": "http://t.co/0thqsyksC3",
+                            "indices": [0, 22],
+                            "expanded_url": "http://www.mozilla.org/en-US/contribute/universityambassadors/",
+                            "display_url": "mozilla.org/en-US/contribu\u2026"
+                        }
+                    ]
+                },
+                "description": {
+                    "urls": []
+                }
+            },
+            "followers_count": 3601,
+            "profile_sidebar_border_color": "C0DEED",
+            "id_str": "23925141",
+            "profile_background_color": "C0DEED",
+            "listed_count": 148,
+            "profile_background_image_url_https": "https://abs.twimg.com/images/themes/theme1/bg.png",
+            "utc_offset": -28800,
+            "statuses_count": 588,
+            "description": "Mozilla's Firefox Student Ambassadors help spread @Firefox and promote @Mozilla\u2019s mission at their schools. Join us and make a difference to the Web!",
+            "friends_count": 326,
+            "location": "Earth",
+            "profile_link_color": "0084B4",
+            "profile_image_url": "http://pbs.twimg.com/profile_images/378800000072303285/0501b9c8a3d883a327f816f5ce3eaad2_normal.png",
+            "following": true,
+            "geo_enabled": true,
+            "profile_background_image_url": "http://abs.twimg.com/images/themes/theme1/bg.png",
+            "screen_name": "mozstudents",
+            "lang": "en",
+            "profile_background_tile": false,
+            "favourites_count": 33,
+            "name": "Student Ambassadors",
+            "notifications": false,
+            "url": "http://t.co/0thqsyksC3",
+            "created_at": "Thu Mar 12 09:31:59 +0000 2009",
+            "contributors_enabled": false,
+            "time_zone": "Pacific Time (US & Canada)",
+            "protected": false,
+            "default_profile": true,
+            "is_translator": false
+        },
+        "geo": null,
+        "in_reply_to_user_id_str": null,
+        "possibly_sensitive": false,
+        "lang": "en",
+        "created_at": "Mon Jan 13 17:33:16 +0000 2014",
+        "in_reply_to_status_id_str": null,
+        "place": null
+    },
+    {
+        "contributors": null,
+        "truncated": false,
+        "text": "Awesome post from Eliezer (from the Joa\u00e7aba Firefox Club) on the importance of blogging Give it a read this weekend! https://t.co/qkVGi2aG8n",
+        "in_reply_to_status_id": null,
+        "id": 421788841712701440,
+        "favorite_count": 3,
+        "source": "web",
+        "retweeted": false,
+        "coordinates": null,
+        "entities": {
+            "symbols": [],
+            "user_mentions": [],
+            "hashtags": [],
+            "urls": [
+                {
+                    "url": "https://t.co/qkVGi2aG8n",
+                    "indices": [117, 140],
+                    "expanded_url": "https://blog.mozilla.org/studentambassadors/2014/01/10/the-importance-of-blogging/",
+                    "display_url": "blog.mozilla.org/studentambassa\u2026"
+                }
+            ]
+        },
+        "in_reply_to_screen_name": null,
+        "id_str": "421788841712701440",
+        "retweet_count": 3,
+        "in_reply_to_user_id": null,
+        "favorited": false,
+        "user": {
+            "follow_request_sent": false,
+            "profile_use_background_image": true,
+            "default_profile_image": false,
+            "id": 23925141,
+            "verified": false,
+            "profile_text_color": "333333",
+            "profile_image_url_https": "https://pbs.twimg.com/profile_images/378800000072303285/0501b9c8a3d883a327f816f5ce3eaad2_normal.png",
+            "profile_sidebar_fill_color": "DDEEF6",
+            "entities": {
+                "url": {
+                    "urls": [
+                        {
+                            "url": "http://t.co/0thqsyksC3",
+                            "indices": [0, 22],
+                            "expanded_url": "http://www.mozilla.org/en-US/contribute/universityambassadors/",
+                            "display_url": "mozilla.org/en-US/contribu\u2026"
+                        }
+                    ]
+                },
+                "description": {
+                    "urls": []
+                }
+            },
+            "followers_count": 3601,
+            "profile_sidebar_border_color": "C0DEED",
+            "id_str": "23925141",
+            "profile_background_color": "C0DEED",
+            "listed_count": 148,
+            "profile_background_image_url_https": "https://abs.twimg.com/images/themes/theme1/bg.png",
+            "utc_offset": -28800,
+            "statuses_count": 588,
+            "description": "Mozilla's Firefox Student Ambassadors help spread @Firefox and promote @Mozilla\u2019s mission at their schools. Join us and make a difference to the Web!",
+            "friends_count": 326,
+            "location": "Earth",
+            "profile_link_color": "0084B4",
+            "profile_image_url": "http://pbs.twimg.com/profile_images/378800000072303285/0501b9c8a3d883a327f816f5ce3eaad2_normal.png",
+            "following": true,
+            "geo_enabled": true,
+            "profile_background_image_url": "http://abs.twimg.com/images/themes/theme1/bg.png",
+            "screen_name": "mozstudents",
+            "lang": "en",
+            "profile_background_tile": false,
+            "favourites_count": 33,
+            "name": "Student Ambassadors",
+            "notifications": false,
+            "url": "http://t.co/0thqsyksC3",
+            "created_at": "Thu Mar 12 09:31:59 +0000 2009",
+            "contributors_enabled": false,
+            "time_zone": "Pacific Time (US & Canada)",
+            "protected": false,
+            "default_profile": true,
+            "is_translator": false
+        },
+        "geo": null,
+        "in_reply_to_user_id_str": null,
+        "possibly_sensitive": false,
+        "lang": "en",
+        "created_at": "Fri Jan 10 23:41:10 +0000 2014",
+        "in_reply_to_status_id_str": null,
+        "place": null
+    },
+    {
+        "contributors": null,
+        "truncated": false,
+        "text": "Know how to code (and want to use your skills for good)? Contribute your code to help improve Mozilla's products http://t.co/1jcnutCtzz",
+        "in_reply_to_status_id": null,
+        "id": 421692692678975488,
+        "favorite_count": 2,
+        "source": "web",
+        "retweeted": false,
+        "coordinates": null,
+        "entities": {
+            "symbols": [],
+            "user_mentions": [],
+            "hashtags": [],
+            "urls": [
+                {
+                    "url": "http://t.co/1jcnutCtzz",
+                    "indices": [113, 135],
+                    "expanded_url": "http://mzl.la/1ew7XCq",
+                    "display_url": "mzl.la/1ew7XCq"
+                }
+            ]
+        },
+        "in_reply_to_screen_name": null,
+        "id_str": "421692692678975488",
+        "retweet_count": 4,
+        "in_reply_to_user_id": null,
+        "favorited": false,
+        "user": {
+            "follow_request_sent": false,
+            "profile_use_background_image": true,
+            "default_profile_image": false,
+            "id": 23925141,
+            "verified": false,
+            "profile_text_color": "333333",
+            "profile_image_url_https": "https://pbs.twimg.com/profile_images/378800000072303285/0501b9c8a3d883a327f816f5ce3eaad2_normal.png",
+            "profile_sidebar_fill_color": "DDEEF6",
+            "entities": {
+                "url": {
+                    "urls": [
+                        {
+                            "url": "http://t.co/0thqsyksC3",
+                            "indices": [0, 22],
+                            "expanded_url": "http://www.mozilla.org/en-US/contribute/universityambassadors/",
+                            "display_url": "mozilla.org/en-US/contribu\u2026"
+                        }
+                    ]
+                },
+                "description": {
+                    "urls": []
+                }
+            },
+            "followers_count": 3601,
+            "profile_sidebar_border_color": "C0DEED",
+            "id_str": "23925141",
+            "profile_background_color": "C0DEED",
+            "listed_count": 148,
+            "profile_background_image_url_https": "https://abs.twimg.com/images/themes/theme1/bg.png",
+            "utc_offset": -28800,
+            "statuses_count": 588,
+            "description": "Mozilla's Firefox Student Ambassadors help spread @Firefox and promote @Mozilla\u2019s mission at their schools. Join us and make a difference to the Web!",
+            "friends_count": 326,
+            "location": "Earth",
+            "profile_link_color": "0084B4",
+            "profile_image_url": "http://pbs.twimg.com/profile_images/378800000072303285/0501b9c8a3d883a327f816f5ce3eaad2_normal.png",
+            "following": true,
+            "geo_enabled": true,
+            "profile_background_image_url": "http://abs.twimg.com/images/themes/theme1/bg.png",
+            "screen_name": "mozstudents",
+            "lang": "en",
+            "profile_background_tile": false,
+            "favourites_count": 33,
+            "name": "Student Ambassadors",
+            "notifications": false,
+            "url": "http://t.co/0thqsyksC3",
+            "created_at": "Thu Mar 12 09:31:59 +0000 2009",
+            "contributors_enabled": false,
+            "time_zone": "Pacific Time (US & Canada)",
+            "protected": false,
+            "default_profile": true,
+            "is_translator": false
+        },
+        "geo": null,
+        "in_reply_to_user_id_str": null,
+        "possibly_sensitive": false,
+        "lang": "en",
+        "created_at": "Fri Jan 10 17:19:07 +0000 2014",
+        "in_reply_to_status_id_str": null,
+        "place": null
+    },
+    {
+        "contributors": null,
+        "truncated": false,
+        "text": "RT @firefox: No respecting Firefox employee (or any self-respecting fox) can resist the #SelfieOlympics challenge! http://t.co/BfI952AJsG",
+        "in_reply_to_status_id": null,
+        "id": 420687071095693312,
+        "favorite_count": 0,
+        "source": "web",
+        "retweeted": false,
+        "coordinates": null,
+        "entities": {
+            "symbols": [],
+            "user_mentions": [
+                {
+                    "id": 2142731,
+                    "indices": [3, 11],
+                    "id_str": "2142731",
+                    "screen_name": "firefox",
+                    "name": "Firefox"
+                }
+            ],
+            "hashtags": [
+                {
+                    "indices": [88, 103],
+                    "text": "SelfieOlympics"
+                }
+            ],
+            "urls": [],
+            "media": [
+                {
+                    "expanded_url": "http://twitter.com/firefox/status/420686256922574848/photo/1",
+                    "display_url": "pic.twitter.com/BfI952AJsG",
+                    "url": "http://t.co/BfI952AJsG",
+                    "media_url_https": "https://pbs.twimg.com/media/BdaT6_pCQAAm12p.jpg",
+                    "id_str": "420686256930963456",
+                    "sizes": {
+                        "small": {
+                            "h": 170,
+                            "resize": "fit",
+                            "w": 340
+                        },
+                        "large": {
+                            "h": 512,
+                            "resize": "fit",
+                            "w": 1024
+                        },
+                        "medium": {
+                            "h": 300,
+                            "resize": "fit",
+                            "w": 600
+                        },
+                        "thumb": {
+                            "h": 150,
+                            "resize": "crop",
+                            "w": 150
+                        }
+                    },
+                    "indices": [115, 137],
+                    "type": "photo",
+                    "id": 420686256930963456,
+                    "media_url": "http://pbs.twimg.com/media/BdaT6_pCQAAm12p.jpg"
+                }
+            ]
+        },
+        "in_reply_to_screen_name": null,
+        "id_str": "420687071095693312",
+        "retweet_count": 71,
+        "in_reply_to_user_id": null,
+        "favorited": false,
+        "retweeted_status": {
+            "contributors": null,
+            "truncated": false,
+            "text": "No respecting Firefox employee (or any self-respecting fox) can resist the #SelfieOlympics challenge! http://t.co/BfI952AJsG",
+            "in_reply_to_status_id": null,
+            "id": 420686256922574848,
+            "favorite_count": 78,
+            "source": "web",
+            "retweeted": false,
+            "coordinates": null,
+            "entities": {
+                "symbols": [],
+                "user_mentions": [],
+                "hashtags": [
+                    {
+                        "indices": [75, 90],
+                        "text": "SelfieOlympics"
+                    }
+                ],
+                "urls": [],
+                "media": [
+                    {
+                        "expanded_url": "http://twitter.com/firefox/status/420686256922574848/photo/1",
+                        "display_url": "pic.twitter.com/BfI952AJsG",
+                        "url": "http://t.co/BfI952AJsG",
+                        "media_url_https": "https://pbs.twimg.com/media/BdaT6_pCQAAm12p.jpg",
+                        "id_str": "420686256930963456",
+                        "sizes": {
+                            "small": {
+                                "h": 170,
+                                "resize": "fit",
+                                "w": 340
+                            },
+                            "large": {
+                                "h": 512,
+                                "resize": "fit",
+                                "w": 1024
+                            },
+                            "medium": {
+                                "h": 300,
+                                "resize": "fit",
+                                "w": 600
+                            },
+                            "thumb": {
+                                "h": 150,
+                                "resize": "crop",
+                                "w": 150
+                            }
+                        },
+                        "indices": [102, 124],
+                        "type": "photo",
+                        "id": 420686256930963456,
+                        "media_url": "http://pbs.twimg.com/media/BdaT6_pCQAAm12p.jpg"
+                    }
+                ]
+            },
+            "in_reply_to_screen_name": null,
+            "id_str": "420686256922574848",
+            "retweet_count": 71,
+            "in_reply_to_user_id": null,
+            "favorited": false,
+            "user": {
+                "follow_request_sent": false,
+                "profile_use_background_image": true,
+                "default_profile_image": false,
+                "id": 2142731,
+                "verified": true,
+                "profile_text_color": "333333",
+                "profile_image_url_https": "https://pbs.twimg.com/profile_images/378800000324784929/1a4ee3fde80808a96ed268a7fb94682d_normal.png",
+                "profile_sidebar_fill_color": "FFFF99",
+                "entities": {
+                    "url": {
+                        "urls": [
+                            {
+                                "url": "http://t.co/tpjpvutErf",
+                                "indices": [0, 22],
+                                "expanded_url": "http://blog.mozilla.org/",
+                                "display_url": "blog.mozilla.org"
+                            }
+                        ]
+                    },
+                    "description": {
+                        "urls": []
+                    }
+                },
+                "followers_count": 2342460,
+                "profile_sidebar_border_color": "FFFFFF",
+                "id_str": "2142731",
+                "profile_background_color": "00539F",
+                "listed_count": 24712,
+                "profile_background_image_url_https": "https://pbs.twimg.com/profile_background_images/378800000055149944/1a3613e8848e7323bcac10ebeae06090.jpeg",
+                "utc_offset": -28800,
+                "statuses_count": 11701,
+                "description": "I make the web a little faster, safer, smarter, better.",
+                "friends_count": 2931,
+                "location": "All over the world",
+                "profile_link_color": "CC3300",
+                "profile_image_url": "http://pbs.twimg.com/profile_images/378800000324784929/1a4ee3fde80808a96ed268a7fb94682d_normal.png",
+                "following": true,
+                "geo_enabled": false,
+                "profile_banner_url": "https://pbs.twimg.com/profile_banners/2142731/1366395406",
+                "profile_background_image_url": "http://pbs.twimg.com/profile_background_images/378800000055149944/1a3613e8848e7323bcac10ebeae06090.jpeg",
+                "screen_name": "firefox",
+                "lang": "en",
+                "profile_background_tile": false,
+                "favourites_count": 6570,
+                "name": "Firefox",
+                "notifications": false,
+                "url": "http://t.co/tpjpvutErf",
+                "created_at": "Sat Mar 24 23:58:14 +0000 2007",
+                "contributors_enabled": false,
+                "time_zone": "Pacific Time (US & Canada)",
+                "protected": false,
+                "default_profile": false,
+                "is_translator": false
+            },
+            "geo": null,
+            "in_reply_to_user_id_str": null,
+            "possibly_sensitive": false,
+            "lang": "en",
+            "created_at": "Tue Jan 07 22:39:54 +0000 2014",
+            "in_reply_to_status_id_str": null,
+            "place": null
+        },
+        "user": {
+            "follow_request_sent": false,
+            "profile_use_background_image": true,
+            "default_profile_image": false,
+            "id": 23925141,
+            "verified": false,
+            "profile_text_color": "333333",
+            "profile_image_url_https": "https://pbs.twimg.com/profile_images/378800000072303285/0501b9c8a3d883a327f816f5ce3eaad2_normal.png",
+            "profile_sidebar_fill_color": "DDEEF6",
+            "entities": {
+                "url": {
+                    "urls": [
+                        {
+                            "url": "http://t.co/0thqsyksC3",
+                            "indices": [0, 22],
+                            "expanded_url": "http://www.mozilla.org/en-US/contribute/universityambassadors/",
+                            "display_url": "mozilla.org/en-US/contribu\u2026"
+                        }
+                    ]
+                },
+                "description": {
+                    "urls": []
+                }
+            },
+            "followers_count": 3601,
+            "profile_sidebar_border_color": "C0DEED",
+            "id_str": "23925141",
+            "profile_background_color": "C0DEED",
+            "listed_count": 148,
+            "profile_background_image_url_https": "https://abs.twimg.com/images/themes/theme1/bg.png",
+            "utc_offset": -28800,
+            "statuses_count": 588,
+            "description": "Mozilla's Firefox Student Ambassadors help spread @Firefox and promote @Mozilla\u2019s mission at their schools. Join us and make a difference to the Web!",
+            "friends_count": 326,
+            "location": "Earth",
+            "profile_link_color": "0084B4",
+            "profile_image_url": "http://pbs.twimg.com/profile_images/378800000072303285/0501b9c8a3d883a327f816f5ce3eaad2_normal.png",
+            "following": true,
+            "geo_enabled": true,
+            "profile_background_image_url": "http://abs.twimg.com/images/themes/theme1/bg.png",
+            "screen_name": "mozstudents",
+            "lang": "en",
+            "profile_background_tile": false,
+            "favourites_count": 33,
+            "name": "Student Ambassadors",
+            "notifications": false,
+            "url": "http://t.co/0thqsyksC3",
+            "created_at": "Thu Mar 12 09:31:59 +0000 2009",
+            "contributors_enabled": false,
+            "time_zone": "Pacific Time (US & Canada)",
+            "protected": false,
+            "default_profile": true,
+            "is_translator": false
+        },
+        "geo": null,
+        "in_reply_to_user_id_str": null,
+        "possibly_sensitive": false,
+        "lang": "en",
+        "created_at": "Tue Jan 07 22:43:08 +0000 2014",
+        "in_reply_to_status_id_str": null,
+        "place": null
+    },
+    {
+        "contributors": null,
+        "truncated": false,
+        "text": "Congratulations to FirefoxNUST, Mozilla India, and UnikomFxClub Firefox Clubs for #winning our Affiliates #contest in December! #students",
+        "in_reply_to_status_id": null,
+        "id": 420236151538974720,
+        "favorite_count": 2,
+        "source": "web",
+        "retweeted": false,
+        "coordinates": null,
+        "entities": {
+            "symbols": [],
+            "user_mentions": [],
+            "hashtags": [
+                {
+                    "indices": [82, 90],
+                    "text": "winning"
+                },
+                {
+                    "indices": [106, 114],
+                    "text": "contest"
+                },
+                {
+                    "indices": [128, 137],
+                    "text": "students"
+                }
+            ],
+            "urls": []
+        },
+        "in_reply_to_screen_name": null,
+        "id_str": "420236151538974720",
+        "retweet_count": 3,
+        "in_reply_to_user_id": null,
+        "favorited": false,
+        "user": {
+            "follow_request_sent": false,
+            "profile_use_background_image": true,
+            "default_profile_image": false,
+            "id": 23925141,
+            "verified": false,
+            "profile_text_color": "333333",
+            "profile_image_url_https": "https://pbs.twimg.com/profile_images/378800000072303285/0501b9c8a3d883a327f816f5ce3eaad2_normal.png",
+            "profile_sidebar_fill_color": "DDEEF6",
+            "entities": {
+                "url": {
+                    "urls": [
+                        {
+                            "url": "http://t.co/0thqsyksC3",
+                            "indices": [0, 22],
+                            "expanded_url": "http://www.mozilla.org/en-US/contribute/universityambassadors/",
+                            "display_url": "mozilla.org/en-US/contribu\u2026"
+                        }
+                    ]
+                },
+                "description": {
+                    "urls": []
+                }
+            },
+            "followers_count": 3601,
+            "profile_sidebar_border_color": "C0DEED",
+            "id_str": "23925141",
+            "profile_background_color": "C0DEED",
+            "listed_count": 148,
+            "profile_background_image_url_https": "https://abs.twimg.com/images/themes/theme1/bg.png",
+            "utc_offset": -28800,
+            "statuses_count": 588,
+            "description": "Mozilla's Firefox Student Ambassadors help spread @Firefox and promote @Mozilla\u2019s mission at their schools. Join us and make a difference to the Web!",
+            "friends_count": 326,
+            "location": "Earth",
+            "profile_link_color": "0084B4",
+            "profile_image_url": "http://pbs.twimg.com/profile_images/378800000072303285/0501b9c8a3d883a327f816f5ce3eaad2_normal.png",
+            "following": true,
+            "geo_enabled": true,
+            "profile_background_image_url": "http://abs.twimg.com/images/themes/theme1/bg.png",
+            "screen_name": "mozstudents",
+            "lang": "en",
+            "profile_background_tile": false,
+            "favourites_count": 33,
+            "name": "Student Ambassadors",
+            "notifications": false,
+            "url": "http://t.co/0thqsyksC3",
+            "created_at": "Thu Mar 12 09:31:59 +0000 2009",
+            "contributors_enabled": false,
+            "time_zone": "Pacific Time (US & Canada)",
+            "protected": false,
+            "default_profile": true,
+            "is_translator": false
+        },
+        "geo": null,
+        "in_reply_to_user_id_str": null,
+        "lang": "en",
+        "created_at": "Mon Jan 06 16:51:20 +0000 2014",
+        "in_reply_to_status_id_str": null,
+        "place": null
+    },
+    {
+        "contributors": null,
+        "truncated": false,
+        "text": "Entering our January App contest? Don't forget to tag your app with #firefoxstudents when you submit it. Good luck!",
+        "in_reply_to_status_id": null,
+        "id": 419949395174375425,
+        "favorite_count": 0,
+        "source": "web",
+        "retweeted": false,
+        "coordinates": null,
+        "entities": {
+            "symbols": [],
+            "user_mentions": [],
+            "hashtags": [
+                {
+                    "indices": [68, 84],
+                    "text": "firefoxstudents"
+                }
+            ],
+            "urls": []
+        },
+        "in_reply_to_screen_name": null,
+        "id_str": "419949395174375425",
+        "retweet_count": 2,
+        "in_reply_to_user_id": null,
+        "favorited": false,
+        "user": {
+            "follow_request_sent": false,
+            "profile_use_background_image": true,
+            "default_profile_image": false,
+            "id": 23925141,
+            "verified": false,
+            "profile_text_color": "333333",
+            "profile_image_url_https": "https://pbs.twimg.com/profile_images/378800000072303285/0501b9c8a3d883a327f816f5ce3eaad2_normal.png",
+            "profile_sidebar_fill_color": "DDEEF6",
+            "entities": {
+                "url": {
+                    "urls": [
+                        {
+                            "url": "http://t.co/0thqsyksC3",
+                            "indices": [0, 22],
+                            "expanded_url": "http://www.mozilla.org/en-US/contribute/universityambassadors/",
+                            "display_url": "mozilla.org/en-US/contribu\u2026"
+                        }
+                    ]
+                },
+                "description": {
+                    "urls": []
+                }
+            },
+            "followers_count": 3601,
+            "profile_sidebar_border_color": "C0DEED",
+            "id_str": "23925141",
+            "profile_background_color": "C0DEED",
+            "listed_count": 148,
+            "profile_background_image_url_https": "https://abs.twimg.com/images/themes/theme1/bg.png",
+            "utc_offset": -28800,
+            "statuses_count": 588,
+            "description": "Mozilla's Firefox Student Ambassadors help spread @Firefox and promote @Mozilla\u2019s mission at their schools. Join us and make a difference to the Web!",
+            "friends_count": 326,
+            "location": "Earth",
+            "profile_link_color": "0084B4",
+            "profile_image_url": "http://pbs.twimg.com/profile_images/378800000072303285/0501b9c8a3d883a327f816f5ce3eaad2_normal.png",
+            "following": true,
+            "geo_enabled": true,
+            "profile_background_image_url": "http://abs.twimg.com/images/themes/theme1/bg.png",
+            "screen_name": "mozstudents",
+            "lang": "en",
+            "profile_background_tile": false,
+            "favourites_count": 33,
+            "name": "Student Ambassadors",
+            "notifications": false,
+            "url": "http://t.co/0thqsyksC3",
+            "created_at": "Thu Mar 12 09:31:59 +0000 2009",
+            "contributors_enabled": false,
+            "time_zone": "Pacific Time (US & Canada)",
+            "protected": false,
+            "default_profile": true,
+            "is_translator": false
+        },
+        "geo": null,
+        "in_reply_to_user_id_str": null,
+        "lang": "en",
+        "created_at": "Sun Jan 05 21:51:52 +0000 2014",
+        "in_reply_to_status_id_str": null,
+        "place": null
+    },
+    {
+        "contributors": null,
+        "truncated": false,
+        "text": "@MozPk @mozilla please make sure to tag your app submissions #firefoxstudents in the Firefox Marketplace. Good luck!",
+        "in_reply_to_status_id": 419876972424990720,
+        "id": 419949006400151552,
+        "favorite_count": 0,
+        "source": "web",
+        "retweeted": false,
+        "coordinates": null,
+        "entities": {
+            "symbols": [],
+            "user_mentions": [
+                {
+                    "id": 415929399,
+                    "indices": [0, 6],
+                    "id_str": "415929399",
+                    "screen_name": "MozPk",
+                    "name": "Mozilla Pakistan"
+                },
+                {
+                    "id": 106682853,
+                    "indices": [7, 15],
+                    "id_str": "106682853",
+                    "screen_name": "mozilla",
+                    "name": "Mozilla"
+                }
+            ],
+            "hashtags": [
+                {
+                    "indices": [61, 77],
+                    "text": "firefoxstudents"
+                }
+            ],
+            "urls": []
+        },
+        "in_reply_to_screen_name": "MozPk",
+        "id_str": "419949006400151552",
+        "retweet_count": 0,
+        "in_reply_to_user_id": 415929399,
+        "favorited": false,
+        "user": {
+            "follow_request_sent": false,
+            "profile_use_background_image": true,
+            "default_profile_image": false,
+            "id": 23925141,
+            "verified": false,
+            "profile_text_color": "333333",
+            "profile_image_url_https": "https://pbs.twimg.com/profile_images/378800000072303285/0501b9c8a3d883a327f816f5ce3eaad2_normal.png",
+            "profile_sidebar_fill_color": "DDEEF6",
+            "entities": {
+                "url": {
+                    "urls": [
+                        {
+                            "url": "http://t.co/0thqsyksC3",
+                            "indices": [0, 22],
+                            "expanded_url": "http://www.mozilla.org/en-US/contribute/universityambassadors/",
+                            "display_url": "mozilla.org/en-US/contribu\u2026"
+                        }
+                    ]
+                },
+                "description": {
+                    "urls": []
+                }
+            },
+            "followers_count": 3601,
+            "profile_sidebar_border_color": "C0DEED",
+            "id_str": "23925141",
+            "profile_background_color": "C0DEED",
+            "listed_count": 148,
+            "profile_background_image_url_https": "https://abs.twimg.com/images/themes/theme1/bg.png",
+            "utc_offset": -28800,
+            "statuses_count": 588,
+            "description": "Mozilla's Firefox Student Ambassadors help spread @Firefox and promote @Mozilla\u2019s mission at their schools. Join us and make a difference to the Web!",
+            "friends_count": 326,
+            "location": "Earth",
+            "profile_link_color": "0084B4",
+            "profile_image_url": "http://pbs.twimg.com/profile_images/378800000072303285/0501b9c8a3d883a327f816f5ce3eaad2_normal.png",
+            "following": true,
+            "geo_enabled": true,
+            "profile_background_image_url": "http://abs.twimg.com/images/themes/theme1/bg.png",
+            "screen_name": "mozstudents",
+            "lang": "en",
+            "profile_background_tile": false,
+            "favourites_count": 33,
+            "name": "Student Ambassadors",
+            "notifications": false,
+            "url": "http://t.co/0thqsyksC3",
+            "created_at": "Thu Mar 12 09:31:59 +0000 2009",
+            "contributors_enabled": false,
+            "time_zone": "Pacific Time (US & Canada)",
+            "protected": false,
+            "default_profile": true,
+            "is_translator": false
+        },
+        "geo": null,
+        "in_reply_to_user_id_str": "415929399",
+        "lang": "en",
+        "created_at": "Sun Jan 05 21:50:20 +0000 2014",
+        "in_reply_to_status_id_str": "419876972424990720",
+        "place": null
+    },
+    {
+        "contributors": null,
+        "truncated": false,
+        "text": "RT @elfasza: Thanks for the appreciation! http://t.co/sBg0ijkVbS @krnasz @mozstudents #IAMMOZILLIAN",
+        "in_reply_to_status_id": null,
+        "id": 419225998224146432,
+        "favorite_count": 0,
+        "source": "web",
+        "retweeted": false,
+        "coordinates": null,
+        "entities": {
+            "symbols": [],
+            "user_mentions": [
+                {
+                    "id": 74994115,
+                    "indices": [3, 11],
+                    "id_str": "74994115",
+                    "screen_name": "elfasza",
+                    "name": "Zayed Elfasa"
+                },
+                {
+                    "id": 23775506,
+                    "indices": [65, 72],
+                    "id_str": "23775506",
+                    "screen_name": "krnasz",
+                    "name": "Katherine Naszradi"
+                },
+                {
+                    "id": 23925141,
+                    "indices": [73, 85],
+                    "id_str": "23925141",
+                    "screen_name": "mozstudents",
+                    "name": "Student Ambassadors"
+                }
+            ],
+            "hashtags": [
+                {
+                    "indices": [86, 99],
+                    "text": "IAMMOZILLIAN"
+                }
+            ],
+            "urls": [
+                {
+                    "url": "http://t.co/sBg0ijkVbS",
+                    "indices": [42, 64],
+                    "expanded_url": "http://badg.us/en-US/badges/badge/Firefox-Student-Ambassador-Badge/awards/24041",
+                    "display_url": "badg.us/en-US/badges/b\u2026"
+                }
+            ]
+        },
+        "in_reply_to_screen_name": null,
+        "id_str": "419225998224146432",
+        "retweet_count": 1,
+        "in_reply_to_user_id": null,
+        "favorited": false,
+        "retweeted_status": {
+            "contributors": null,
+            "truncated": false,
+            "text": "Thanks for the appreciation! http://t.co/sBg0ijkVbS @krnasz @mozstudents #IAMMOZILLIAN",
+            "in_reply_to_status_id": null,
+            "id": 418011326783315968,
+            "favorite_count": 0,
+            "source": "web",
+            "retweeted": false,
+            "coordinates": null,
+            "entities": {
+                "symbols": [],
+                "user_mentions": [
+                    {
+                        "id": 23775506,
+                        "indices": [52, 59],
+                        "id_str": "23775506",
+                        "screen_name": "krnasz",
+                        "name": "Katherine Naszradi"
+                    },
+                    {
+                        "id": 23925141,
+                        "indices": [60, 72],
+                        "id_str": "23925141",
+                        "screen_name": "mozstudents",
+                        "name": "Student Ambassadors"
+                    }
+                ],
+                "hashtags": [
+                    {
+                        "indices": [73, 86],
+                        "text": "IAMMOZILLIAN"
+                    }
+                ],
+                "urls": [
+                    {
+                        "url": "http://t.co/sBg0ijkVbS",
+                        "indices": [29, 51],
+                        "expanded_url": "http://badg.us/en-US/badges/badge/Firefox-Student-Ambassador-Badge/awards/24041",
+                        "display_url": "badg.us/en-US/badges/b\u2026"
+                    }
+                ]
+            },
+            "in_reply_to_screen_name": null,
+            "id_str": "418011326783315968",
+            "retweet_count": 1,
+            "in_reply_to_user_id": null,
+            "favorited": false,
+            "user": {
+                "follow_request_sent": false,
+                "profile_use_background_image": true,
+                "default_profile_image": false,
+                "id": 74994115,
+                "verified": false,
+                "profile_text_color": "C3C99D",
+                "profile_image_url_https": "https://pbs.twimg.com/profile_images/420974918432346112/n5FRusAZ_normal.jpeg",
+                "profile_sidebar_fill_color": "25262E",
+                "entities": {
+                    "url": {
+                        "urls": [
+                            {
+                                "url": "http://t.co/UibYwJeqAt",
+                                "indices": [0, 22],
+                                "expanded_url": "http://elfalinks.blogspot.com",
+                                "display_url": "elfalinks.blogspot.com"
+                            }
+                        ]
+                    },
+                    "description": {
+                        "urls": []
+                    }
+                },
+                "followers_count": 733,
+                "profile_sidebar_border_color": "000000",
+                "id_str": "74994115",
+                "profile_background_color": "DBD6E6",
+                "listed_count": 6,
+                "profile_background_image_url_https": "https://pbs.twimg.com/profile_background_images/187791891/tuxs.jpg",
+                "utc_offset": 25200,
+                "statuses_count": 20570,
+                "description": "Mozilla Indonesia | Open Source enthusiast | Information System Student | Mozilla Reps @ID_Mozilla | check blog!",
+                "friends_count": 576,
+                "location": "STIKOM Surabaya",
+                "profile_link_color": "4FC215",
+                "profile_image_url": "http://pbs.twimg.com/profile_images/420974918432346112/n5FRusAZ_normal.jpeg",
+                "following": false,
+                "geo_enabled": false,
+                "profile_banner_url": "https://pbs.twimg.com/profile_banners/74994115/1379343472",
+                "profile_background_image_url": "http://pbs.twimg.com/profile_background_images/187791891/tuxs.jpg",
+                "screen_name": "elfasza",
+                "lang": "en",
+                "profile_background_tile": true,
+                "favourites_count": 92,
+                "name": "Zayed Elfasa",
+                "notifications": false,
+                "url": "http://t.co/UibYwJeqAt",
+                "created_at": "Thu Sep 17 11:58:36 +0000 2009",
+                "contributors_enabled": false,
+                "time_zone": "Jakarta",
+                "protected": false,
+                "default_profile": false,
+                "is_translator": false
+            },
+            "geo": null,
+            "in_reply_to_user_id_str": null,
+            "possibly_sensitive": false,
+            "lang": "en",
+            "created_at": "Tue Dec 31 13:30:41 +0000 2013",
+            "in_reply_to_status_id_str": null,
+            "place": null
+        },
+        "user": {
+            "follow_request_sent": false,
+            "profile_use_background_image": true,
+            "default_profile_image": false,
+            "id": 23925141,
+            "verified": false,
+            "profile_text_color": "333333",
+            "profile_image_url_https": "https://pbs.twimg.com/profile_images/378800000072303285/0501b9c8a3d883a327f816f5ce3eaad2_normal.png",
+            "profile_sidebar_fill_color": "DDEEF6",
+            "entities": {
+                "url": {
+                    "urls": [
+                        {
+                            "url": "http://t.co/0thqsyksC3",
+                            "indices": [0, 22],
+                            "expanded_url": "http://www.mozilla.org/en-US/contribute/universityambassadors/",
+                            "display_url": "mozilla.org/en-US/contribu\u2026"
+                        }
+                    ]
+                },
+                "description": {
+                    "urls": []
+                }
+            },
+            "followers_count": 3601,
+            "profile_sidebar_border_color": "C0DEED",
+            "id_str": "23925141",
+            "profile_background_color": "C0DEED",
+            "listed_count": 148,
+            "profile_background_image_url_https": "https://abs.twimg.com/images/themes/theme1/bg.png",
+            "utc_offset": -28800,
+            "statuses_count": 588,
+            "description": "Mozilla's Firefox Student Ambassadors help spread @Firefox and promote @Mozilla\u2019s mission at their schools. Join us and make a difference to the Web!",
+            "friends_count": 326,
+            "location": "Earth",
+            "profile_link_color": "0084B4",
+            "profile_image_url": "http://pbs.twimg.com/profile_images/378800000072303285/0501b9c8a3d883a327f816f5ce3eaad2_normal.png",
+            "following": true,
+            "geo_enabled": true,
+            "profile_background_image_url": "http://abs.twimg.com/images/themes/theme1/bg.png",
+            "screen_name": "mozstudents",
+            "lang": "en",
+            "profile_background_tile": false,
+            "favourites_count": 33,
+            "name": "Student Ambassadors",
+            "notifications": false,
+            "url": "http://t.co/0thqsyksC3",
+            "created_at": "Thu Mar 12 09:31:59 +0000 2009",
+            "contributors_enabled": false,
+            "time_zone": "Pacific Time (US & Canada)",
+            "protected": false,
+            "default_profile": true,
+            "is_translator": false
+        },
+        "geo": null,
+        "in_reply_to_user_id_str": null,
+        "possibly_sensitive": false,
+        "lang": "en",
+        "created_at": "Fri Jan 03 21:57:21 +0000 2014",
+        "in_reply_to_status_id_str": null,
+        "place": null
+    },
+    {
+        "contributors": null,
+        "truncated": false,
+        "text": "Happy 2014 Ambassadors! Check-out our Jan + Feb themes for App of the Month! http://t.co/A1UgwnPve4 #contest #prizes #win #students",
+        "in_reply_to_status_id": null,
+        "id": 419225870822154240,
+        "favorite_count": 1,
+        "source": "web",
+        "retweeted": false,
+        "coordinates": null,
+        "entities": {
+            "symbols": [],
+            "user_mentions": [],
+            "hashtags": [
+                {
+                    "indices": [100, 108],
+                    "text": "contest"
+                },
+                {
+                    "indices": [109, 116],
+                    "text": "prizes"
+                },
+                {
+                    "indices": [117, 121],
+                    "text": "win"
+                },
+                {
+                    "indices": [122, 131],
+                    "text": "students"
+                }
+            ],
+            "urls": [
+                {
+                    "url": "http://t.co/A1UgwnPve4",
+                    "indices": [77, 99],
+                    "expanded_url": "http://mzl.la/192Sj3K",
+                    "display_url": "mzl.la/192Sj3K"
+                }
+            ]
+        },
+        "in_reply_to_screen_name": null,
+        "id_str": "419225870822154240",
+        "retweet_count": 5,
+        "in_reply_to_user_id": null,
+        "favorited": false,
+        "user": {
+            "follow_request_sent": false,
+            "profile_use_background_image": true,
+            "default_profile_image": false,
+            "id": 23925141,
+            "verified": false,
+            "profile_text_color": "333333",
+            "profile_image_url_https": "https://pbs.twimg.com/profile_images/378800000072303285/0501b9c8a3d883a327f816f5ce3eaad2_normal.png",
+            "profile_sidebar_fill_color": "DDEEF6",
+            "entities": {
+                "url": {
+                    "urls": [
+                        {
+                            "url": "http://t.co/0thqsyksC3",
+                            "indices": [0, 22],
+                            "expanded_url": "http://www.mozilla.org/en-US/contribute/universityambassadors/",
+                            "display_url": "mozilla.org/en-US/contribu\u2026"
+                        }
+                    ]
+                },
+                "description": {
+                    "urls": []
+                }
+            },
+            "followers_count": 3601,
+            "profile_sidebar_border_color": "C0DEED",
+            "id_str": "23925141",
+            "profile_background_color": "C0DEED",
+            "listed_count": 148,
+            "profile_background_image_url_https": "https://abs.twimg.com/images/themes/theme1/bg.png",
+            "utc_offset": -28800,
+            "statuses_count": 588,
+            "description": "Mozilla's Firefox Student Ambassadors help spread @Firefox and promote @Mozilla\u2019s mission at their schools. Join us and make a difference to the Web!",
+            "friends_count": 326,
+            "location": "Earth",
+            "profile_link_color": "0084B4",
+            "profile_image_url": "http://pbs.twimg.com/profile_images/378800000072303285/0501b9c8a3d883a327f816f5ce3eaad2_normal.png",
+            "following": true,
+            "geo_enabled": true,
+            "profile_background_image_url": "http://abs.twimg.com/images/themes/theme1/bg.png",
+            "screen_name": "mozstudents",
+            "lang": "en",
+            "profile_background_tile": false,
+            "favourites_count": 33,
+            "name": "Student Ambassadors",
+            "notifications": false,
+            "url": "http://t.co/0thqsyksC3",
+            "created_at": "Thu Mar 12 09:31:59 +0000 2009",
+            "contributors_enabled": false,
+            "time_zone": "Pacific Time (US & Canada)",
+            "protected": false,
+            "default_profile": true,
+            "is_translator": false
+        },
+        "geo": null,
+        "in_reply_to_user_id_str": null,
+        "possibly_sensitive": false,
+        "lang": "en",
+        "created_at": "Fri Jan 03 21:56:51 +0000 2014",
+        "in_reply_to_status_id_str": null,
+        "place": null
+    },
+    {
+        "contributors": null,
+        "truncated": false,
+        "text": "RT @nikeshbalami: My Journey with Mozilla Nepal Community http://t.co/ebJbx1XsQY @mozstudents @MozillaNepal @OpenBadges",
+        "in_reply_to_status_id": null,
+        "id": 417135721104019456,
+        "favorite_count": 0,
+        "source": "web",
+        "retweeted": false,
+        "coordinates": null,
+        "entities": {
+            "symbols": [],
+            "user_mentions": [
+                {
+                    "id": 533004465,
+                    "indices": [3, 16],
+                    "id_str": "533004465",
+                    "screen_name": "nikeshbalami",
+                    "name": "Nikesh  Balami"
+                },
+                {
+                    "id": 23925141,
+                    "indices": [81, 93],
+                    "id_str": "23925141",
+                    "screen_name": "mozstudents",
+                    "name": "Student Ambassadors"
+                },
+                {
+                    "id": 1051912478,
+                    "indices": [94, 107],
+                    "id_str": "1051912478",
+                    "screen_name": "MozillaNepal",
+                    "name": "Mozilla Nepal"
+                },
+                {
+                    "id": 437707118,
+                    "indices": [108, 119],
+                    "id_str": "437707118",
+                    "screen_name": "OpenBadges",
+                    "name": "Mozilla Open Badges"
+                }
+            ],
+            "hashtags": [],
+            "urls": [
+                {
+                    "url": "http://t.co/ebJbx1XsQY",
+                    "indices": [58, 80],
+                    "expanded_url": "http://www.neekes.com.np/journey-with-mozilla-nepal-community/",
+                    "display_url": "neekes.com.np/journey-with-m\u2026"
+                }
+            ]
+        },
+        "in_reply_to_screen_name": null,
+        "id_str": "417135721104019456",
+        "retweet_count": 2,
+        "in_reply_to_user_id": null,
+        "favorited": false,
+        "retweeted_status": {
+            "contributors": null,
+            "truncated": false,
+            "text": "My Journey with Mozilla Nepal Community http://t.co/ebJbx1XsQY @mozstudents @MozillaNepal @OpenBadges",
+            "in_reply_to_status_id": null,
+            "id": 416164359895670784,
+            "favorite_count": 1,
+            "source": "web",
+            "retweeted": false,
+            "coordinates": null,
+            "entities": {
+                "symbols": [],
+                "user_mentions": [
+                    {
+                        "id": 23925141,
+                        "indices": [63, 75],
+                        "id_str": "23925141",
+                        "screen_name": "mozstudents",
+                        "name": "Student Ambassadors"
+                    },
+                    {
+                        "id": 1051912478,
+                        "indices": [76, 89],
+                        "id_str": "1051912478",
+                        "screen_name": "MozillaNepal",
+                        "name": "Mozilla Nepal"
+                    },
+                    {
+                        "id": 437707118,
+                        "indices": [90, 101],
+                        "id_str": "437707118",
+                        "screen_name": "OpenBadges",
+                        "name": "Mozilla Open Badges"
+                    }
+                ],
+                "hashtags": [],
+                "urls": [
+                    {
+                        "url": "http://t.co/ebJbx1XsQY",
+                        "indices": [40, 62],
+                        "expanded_url": "http://www.neekes.com.np/journey-with-mozilla-nepal-community/",
+                        "display_url": "neekes.com.np/journey-with-m\u2026"
+                    }
+                ]
+            },
+            "in_reply_to_screen_name": null,
+            "id_str": "416164359895670784",
+            "retweet_count": 2,
+            "in_reply_to_user_id": null,
+            "favorited": false,
+            "user": {
+                "follow_request_sent": false,
+                "profile_use_background_image": true,
+                "default_profile_image": false,
+                "id": 533004465,
+                "verified": false,
+                "profile_text_color": "3E4415",
+                "profile_image_url_https": "https://pbs.twimg.com/profile_images/378800000724872104/f98dd01a1f034a97c13f6f14a4debe60_normal.jpeg",
+                "profile_sidebar_fill_color": "99CC33",
+                "entities": {
+                    "url": {
+                        "urls": [
+                            {
+                                "url": "http://t.co/Zu931m9MEi",
+                                "indices": [0, 22],
+                                "expanded_url": "http://neekes.com.np/",
+                                "display_url": "neekes.com.np"
+                            }
+                        ]
+                    },
+                    "description": {
+                        "urls": []
+                    }
+                },
+                "followers_count": 182,
+                "profile_sidebar_border_color": "829D5E",
+                "id_str": "533004465",
+                "profile_background_color": "352726",
+                "listed_count": 0,
+                "profile_background_image_url_https": "https://abs.twimg.com/images/themes/theme5/bg.gif",
+                "utc_offset": 20700,
+                "statuses_count": 308,
+                "description": "Hello Everyone! I am Nikesh Balami from Balaju-16, Kathmandu, Nepal. I am reading Diploma in computer engineering at Acme Engineering College.",
+                "friends_count": 760,
+                "location": "Balaju-16, Kathmandu, Nepal",
+                "profile_link_color": "D02B55",
+                "profile_image_url": "http://pbs.twimg.com/profile_images/378800000724872104/f98dd01a1f034a97c13f6f14a4debe60_normal.jpeg",
+                "following": false,
+                "geo_enabled": true,
+                "profile_background_image_url": "http://abs.twimg.com/images/themes/theme5/bg.gif",
+                "screen_name": "nikeshbalami",
+                "lang": "en",
+                "profile_background_tile": false,
+                "favourites_count": 9,
+                "name": "Nikesh  Balami",
+                "notifications": false,
+                "url": "http://t.co/Zu931m9MEi",
+                "created_at": "Thu Mar 22 07:40:57 +0000 2012",
+                "contributors_enabled": false,
+                "time_zone": "Kathmandu",
+                "protected": false,
+                "default_profile": false,
+                "is_translator": false
+            },
+            "geo": null,
+            "in_reply_to_user_id_str": null,
+            "possibly_sensitive": false,
+            "lang": "en",
+            "created_at": "Thu Dec 26 11:11:30 +0000 2013",
+            "in_reply_to_status_id_str": null,
+            "place": null
+        },
+        "user": {
+            "follow_request_sent": false,
+            "profile_use_background_image": true,
+            "default_profile_image": false,
+            "id": 23925141,
+            "verified": false,
+            "profile_text_color": "333333",
+            "profile_image_url_https": "https://pbs.twimg.com/profile_images/378800000072303285/0501b9c8a3d883a327f816f5ce3eaad2_normal.png",
+            "profile_sidebar_fill_color": "DDEEF6",
+            "entities": {
+                "url": {
+                    "urls": [
+                        {
+                            "url": "http://t.co/0thqsyksC3",
+                            "indices": [0, 22],
+                            "expanded_url": "http://www.mozilla.org/en-US/contribute/universityambassadors/",
+                            "display_url": "mozilla.org/en-US/contribu\u2026"
+                        }
+                    ]
+                },
+                "description": {
+                    "urls": []
+                }
+            },
+            "followers_count": 3601,
+            "profile_sidebar_border_color": "C0DEED",
+            "id_str": "23925141",
+            "profile_background_color": "C0DEED",
+            "listed_count": 148,
+            "profile_background_image_url_https": "https://abs.twimg.com/images/themes/theme1/bg.png",
+            "utc_offset": -28800,
+            "statuses_count": 588,
+            "description": "Mozilla's Firefox Student Ambassadors help spread @Firefox and promote @Mozilla\u2019s mission at their schools. Join us and make a difference to the Web!",
+            "friends_count": 326,
+            "location": "Earth",
+            "profile_link_color": "0084B4",
+            "profile_image_url": "http://pbs.twimg.com/profile_images/378800000072303285/0501b9c8a3d883a327f816f5ce3eaad2_normal.png",
+            "following": true,
+            "geo_enabled": true,
+            "profile_background_image_url": "http://abs.twimg.com/images/themes/theme1/bg.png",
+            "screen_name": "mozstudents",
+            "lang": "en",
+            "profile_background_tile": false,
+            "favourites_count": 33,
+            "name": "Student Ambassadors",
+            "notifications": false,
+            "url": "http://t.co/0thqsyksC3",
+            "created_at": "Thu Mar 12 09:31:59 +0000 2009",
+            "contributors_enabled": false,
+            "time_zone": "Pacific Time (US & Canada)",
+            "protected": false,
+            "default_profile": true,
+            "is_translator": false
+        },
+        "geo": null,
+        "in_reply_to_user_id_str": null,
+        "possibly_sensitive": false,
+        "lang": "en",
+        "created_at": "Sun Dec 29 03:31:20 +0000 2013",
+        "in_reply_to_status_id_str": null,
+        "place": null
+    },
+    {
+        "contributors": null,
+        "truncated": false,
+        "text": "RT @AsaLugada: Many thanks to @mozilla @firefox @mozstudents for my FSA Package i received this month. You made my Christmas Season! http:/\u2026",
+        "in_reply_to_status_id": null,
+        "id": 417135577197477888,
+        "favorite_count": 0,
+        "source": "web",
+        "retweeted": false,
+        "coordinates": null,
+        "entities": {
+            "symbols": [],
+            "user_mentions": [
+                {
+                    "id": 1324664282,
+                    "indices": [3, 13],
+                    "id_str": "1324664282",
+                    "screen_name": "AsaLugada",
+                    "name": "Asa Lugada"
+                },
+                {
+                    "id": 106682853,
+                    "indices": [30, 38],
+                    "id_str": "106682853",
+                    "screen_name": "mozilla",
+                    "name": "Mozilla"
+                },
+                {
+                    "id": 2142731,
+                    "indices": [39, 47],
+                    "id_str": "2142731",
+                    "screen_name": "firefox",
+                    "name": "Firefox"
+                },
+                {
+                    "id": 23925141,
+                    "indices": [48, 60],
+                    "id_str": "23925141",
+                    "screen_name": "mozstudents",
+                    "name": "Student Ambassadors"
+                }
+            ],
+            "hashtags": [],
+            "urls": [],
+            "media": [
+                {
+                    "expanded_url": "http://twitter.com/AsaLugada/status/416849136730644480/photo/1",
+                    "display_url": "pic.twitter.com/ql7iJTvRq8",
+                    "url": "http://t.co/ql7iJTvRq8",
+                    "media_url_https": "https://pbs.twimg.com/media/BcjyFNBCIAAXDTk.jpg",
+                    "id_str": "416849136739033088",
+                    "sizes": {
+                        "large": {
+                            "h": 768,
+                            "resize": "fit",
+                            "w": 1024
+                        },
+                        "small": {
+                            "h": 255,
+                            "resize": "fit",
+                            "w": 340
+                        },
+                        "medium": {
+                            "h": 450,
+                            "resize": "fit",
+                            "w": 600
+                        },
+                        "thumb": {
+                            "h": 150,
+                            "resize": "crop",
+                            "w": 150
+                        }
+                    },
+                    "indices": [139, 140],
+                    "type": "photo",
+                    "id": 416849136739033088,
+                    "media_url": "http://pbs.twimg.com/media/BcjyFNBCIAAXDTk.jpg"
+                }
+            ]
+        },
+        "in_reply_to_screen_name": null,
+        "id_str": "417135577197477888",
+        "retweet_count": 3,
+        "in_reply_to_user_id": null,
+        "favorited": false,
+        "retweeted_status": {
+            "contributors": null,
+            "truncated": false,
+            "text": "Many thanks to @mozilla @firefox @mozstudents for my FSA Package i received this month. You made my Christmas Season! http://t.co/ql7iJTvRq8",
+            "in_reply_to_status_id": null,
+            "id": 416849136730644480,
+            "favorite_count": 2,
+            "source": "web",
+            "retweeted": false,
+            "coordinates": null,
+            "entities": {
+                "symbols": [],
+                "user_mentions": [
+                    {
+                        "id": 106682853,
+                        "indices": [15, 23],
+                        "id_str": "106682853",
+                        "screen_name": "mozilla",
+                        "name": "Mozilla"
+                    },
+                    {
+                        "id": 2142731,
+                        "indices": [24, 32],
+                        "id_str": "2142731",
+                        "screen_name": "firefox",
+                        "name": "Firefox"
+                    },
+                    {
+                        "id": 23925141,
+                        "indices": [33, 45],
+                        "id_str": "23925141",
+                        "screen_name": "mozstudents",
+                        "name": "Student Ambassadors"
+                    }
+                ],
+                "hashtags": [],
+                "urls": [],
+                "media": [
+                    {
+                        "expanded_url": "http://twitter.com/AsaLugada/status/416849136730644480/photo/1",
+                        "display_url": "pic.twitter.com/ql7iJTvRq8",
+                        "url": "http://t.co/ql7iJTvRq8",
+                        "media_url_https": "https://pbs.twimg.com/media/BcjyFNBCIAAXDTk.jpg",
+                        "id_str": "416849136739033088",
+                        "sizes": {
+                            "large": {
+                                "h": 768,
+                                "resize": "fit",
+                                "w": 1024
+                            },
+                            "small": {
+                                "h": 255,
+                                "resize": "fit",
+                                "w": 340
+                            },
+                            "medium": {
+                                "h": 450,
+                                "resize": "fit",
+                                "w": 600
+                            },
+                            "thumb": {
+                                "h": 150,
+                                "resize": "crop",
+                                "w": 150
+                            }
+                        },
+                        "indices": [118, 140],
+                        "type": "photo",
+                        "id": 416849136739033088,
+                        "media_url": "http://pbs.twimg.com/media/BcjyFNBCIAAXDTk.jpg"
+                    }
+                ]
+            },
+            "in_reply_to_screen_name": null,
+            "id_str": "416849136730644480",
+            "retweet_count": 3,
+            "in_reply_to_user_id": null,
+            "favorited": false,
+            "user": {
+                "follow_request_sent": false,
+                "profile_use_background_image": true,
+                "default_profile_image": false,
+                "id": 1324664282,
+                "verified": false,
+                "profile_text_color": "333333",
+                "profile_image_url_https": "https://pbs.twimg.com/profile_images/378800000723535367/aceea1b45cb626c5aa440a89bf1a10c3_normal.jpeg",
+                "profile_sidebar_fill_color": "DDEEF6",
+                "entities": {
+                    "description": {
+                        "urls": []
+                    }
+                },
+                "followers_count": 28,
+                "profile_sidebar_border_color": "C0DEED",
+                "id_str": "1324664282",
+                "profile_background_color": "C0DEED",
+                "listed_count": 0,
+                "profile_background_image_url_https": "https://abs.twimg.com/images/themes/theme1/bg.png",
+                "utc_offset": null,
+                "statuses_count": 14,
+                "description": "Tech, Business, Innovation, Africa and Mozilla.",
+                "friends_count": 90,
+                "location": "Kampala, Uganda",
+                "profile_link_color": "0084B4",
+                "profile_image_url": "http://pbs.twimg.com/profile_images/378800000723535367/aceea1b45cb626c5aa440a89bf1a10c3_normal.jpeg",
+                "following": false,
+                "geo_enabled": false,
+                "profile_background_image_url": "http://abs.twimg.com/images/themes/theme1/bg.png",
+                "screen_name": "AsaLugada",
+                "lang": "en",
+                "profile_background_tile": false,
+                "favourites_count": 2,
+                "name": "Asa Lugada",
+                "notifications": false,
+                "url": null,
+                "created_at": "Wed Apr 03 14:02:02 +0000 2013",
+                "contributors_enabled": false,
+                "time_zone": null,
+                "protected": false,
+                "default_profile": true,
+                "is_translator": false
+            },
+            "geo": null,
+            "in_reply_to_user_id_str": null,
+            "possibly_sensitive": false,
+            "lang": "en",
+            "created_at": "Sat Dec 28 08:32:33 +0000 2013",
+            "in_reply_to_status_id_str": null,
+            "place": null
+        },
+        "user": {
+            "follow_request_sent": false,
+            "profile_use_background_image": true,
+            "default_profile_image": false,
+            "id": 23925141,
+            "verified": false,
+            "profile_text_color": "333333",
+            "profile_image_url_https": "https://pbs.twimg.com/profile_images/378800000072303285/0501b9c8a3d883a327f816f5ce3eaad2_normal.png",
+            "profile_sidebar_fill_color": "DDEEF6",
+            "entities": {
+                "url": {
+                    "urls": [
+                        {
+                            "url": "http://t.co/0thqsyksC3",
+                            "indices": [0, 22],
+                            "expanded_url": "http://www.mozilla.org/en-US/contribute/universityambassadors/",
+                            "display_url": "mozilla.org/en-US/contribu\u2026"
+                        }
+                    ]
+                },
+                "description": {
+                    "urls": []
+                }
+            },
+            "followers_count": 3601,
+            "profile_sidebar_border_color": "C0DEED",
+            "id_str": "23925141",
+            "profile_background_color": "C0DEED",
+            "listed_count": 148,
+            "profile_background_image_url_https": "https://abs.twimg.com/images/themes/theme1/bg.png",
+            "utc_offset": -28800,
+            "statuses_count": 588,
+            "description": "Mozilla's Firefox Student Ambassadors help spread @Firefox and promote @Mozilla\u2019s mission at their schools. Join us and make a difference to the Web!",
+            "friends_count": 326,
+            "location": "Earth",
+            "profile_link_color": "0084B4",
+            "profile_image_url": "http://pbs.twimg.com/profile_images/378800000072303285/0501b9c8a3d883a327f816f5ce3eaad2_normal.png",
+            "following": true,
+            "geo_enabled": true,
+            "profile_background_image_url": "http://abs.twimg.com/images/themes/theme1/bg.png",
+            "screen_name": "mozstudents",
+            "lang": "en",
+            "profile_background_tile": false,
+            "favourites_count": 33,
+            "name": "Student Ambassadors",
+            "notifications": false,
+            "url": "http://t.co/0thqsyksC3",
+            "created_at": "Thu Mar 12 09:31:59 +0000 2009",
+            "contributors_enabled": false,
+            "time_zone": "Pacific Time (US & Canada)",
+            "protected": false,
+            "default_profile": true,
+            "is_translator": false
+        },
+        "geo": null,
+        "in_reply_to_user_id_str": null,
+        "possibly_sensitive": false,
+        "lang": "en",
+        "created_at": "Sun Dec 29 03:30:46 +0000 2013",
+        "in_reply_to_status_id_str": null,
+        "place": null
+    },
+    {
+        "contributors": null,
+        "truncated": false,
+        "text": "@sinoy_siby @Firefox_GR sure! Please find all of our resources here: https://t.co/d8VaSxrWmP",
+        "in_reply_to_status_id": 413982269397663744,
+        "id": 414146493310726144,
+        "favorite_count": 0,
+        "source": "web",
+        "retweeted": false,
+        "coordinates": null,
+        "entities": {
+            "symbols": [],
+            "user_mentions": [
+                {
+                    "id": 2253197042,
+                    "indices": [0, 11],
+                    "id_str": "2253197042",
+                    "screen_name": "sinoy_siby",
+                    "name": "Sinoy Siby"
+                },
+                {
+                    "id": 1364943300,
+                    "indices": [12, 23],
+                    "id_str": "1364943300",
+                    "screen_name": "Firefox_GR",
+                    "name": "Firefox Greece"
+                }
+            ],
+            "hashtags": [],
+            "urls": [
+                {
+                    "url": "https://t.co/d8VaSxrWmP",
+                    "indices": [69, 92],
+                    "expanded_url": "https://wiki.mozilla.org/StudentAmbassadors/Activities",
+                    "display_url": "wiki.mozilla.org/StudentAmbassa\u2026"
+                }
+            ]
+        },
+        "in_reply_to_screen_name": "sinoy_siby",
+        "id_str": "414146493310726144",
+        "retweet_count": 0,
+        "in_reply_to_user_id": 2253197042,
+        "favorited": false,
+        "user": {
+            "follow_request_sent": false,
+            "profile_use_background_image": true,
+            "default_profile_image": false,
+            "id": 23925141,
+            "verified": false,
+            "profile_text_color": "333333",
+            "profile_image_url_https": "https://pbs.twimg.com/profile_images/378800000072303285/0501b9c8a3d883a327f816f5ce3eaad2_normal.png",
+            "profile_sidebar_fill_color": "DDEEF6",
+            "entities": {
+                "url": {
+                    "urls": [
+                        {
+                            "url": "http://t.co/0thqsyksC3",
+                            "indices": [0, 22],
+                            "expanded_url": "http://www.mozilla.org/en-US/contribute/universityambassadors/",
+                            "display_url": "mozilla.org/en-US/contribu\u2026"
+                        }
+                    ]
+                },
+                "description": {
+                    "urls": []
+                }
+            },
+            "followers_count": 3601,
+            "profile_sidebar_border_color": "C0DEED",
+            "id_str": "23925141",
+            "profile_background_color": "C0DEED",
+            "listed_count": 148,
+            "profile_background_image_url_https": "https://abs.twimg.com/images/themes/theme1/bg.png",
+            "utc_offset": -28800,
+            "statuses_count": 588,
+            "description": "Mozilla's Firefox Student Ambassadors help spread @Firefox and promote @Mozilla\u2019s mission at their schools. Join us and make a difference to the Web!",
+            "friends_count": 326,
+            "location": "Earth",
+            "profile_link_color": "0084B4",
+            "profile_image_url": "http://pbs.twimg.com/profile_images/378800000072303285/0501b9c8a3d883a327f816f5ce3eaad2_normal.png",
+            "following": true,
+            "geo_enabled": true,
+            "profile_background_image_url": "http://abs.twimg.com/images/themes/theme1/bg.png",
+            "screen_name": "mozstudents",
+            "lang": "en",
+            "profile_background_tile": false,
+            "favourites_count": 33,
+            "name": "Student Ambassadors",
+            "notifications": false,
+            "url": "http://t.co/0thqsyksC3",
+            "created_at": "Thu Mar 12 09:31:59 +0000 2009",
+            "contributors_enabled": false,
+            "time_zone": "Pacific Time (US & Canada)",
+            "protected": false,
+            "default_profile": true,
+            "is_translator": false
+        },
+        "geo": null,
+        "in_reply_to_user_id_str": "2253197042",
+        "possibly_sensitive": false,
+        "lang": "en",
+        "created_at": "Fri Dec 20 21:33:13 +0000 2013",
+        "in_reply_to_status_id_str": "413982269397663744",
+        "place": null
+    }
+]

--- a/bedrock/mozorg/tests/test_helper_social_widgets.py
+++ b/bedrock/mozorg/tests/test_helper_social_widgets.py
@@ -32,15 +32,16 @@ class TestFormatTweet(TestCase):
         """Should return a tweet in an HTML format"""
         # Note that … is a non-ASCII character. That's why the UTF-8 encoding is
         # specified at the top of the file.
+        actual = format_tweet_body(self.tweet)
         expected = (
             u'Want more information about the <a href="https://twitter.com/'
             u'mozstudents" class="mention">@mozstudents</a> program? Sign-up '
             u'and get a monthly newsletter in your in-box <a href="http://t.co/'
             u'0thqsyksC3" title="http://www.mozilla.org/en-US/contribute/'
             u'universityambassadors/">mozilla.org/en-US/contribu…</a> <a href='
-            u'"https://twitter.com/search?q=%23students&amp;src=hash" class='
-            u'"hash">#students</a>')
-        self.assertEqual(format_tweet_body(self.tweet), expected)
+            u'"https://twitter.com/search?q=%23oto%C3%B1o&amp;src=hash" class='
+            u'"hash">#otoño</a>')
+        self.assertEqual(actual, expected)
 
     def test_format_tweet_timestamp(self):
         """Should return a timestamp in an HTML format"""


### PR DESCRIPTION
The `tweets.json` file changes were mostly just adding indentation
so I could see what it was doing. I left it because it seems more useful this
way. I also changed a hash tag of the 6th tweet to the one that caused this problem.
This should have a separate test, but we're just pressed for time.
