### PR TITLE
Bug 1078297: Fix localized number formatting helper for jinja templates

### DIFF
--- a/lib/l10n_utils/helpers.py
+++ b/lib/l10n_utils/helpers.py
@@ -76,34 +76,39 @@ def l10n_has_tag(ctx, tag, langfile=None):
     return lang_file_has_tag(langfile, tag=tag)
 
 
+def get_locale(lang):
+    """Return a babel Locale object for lang. defaults to LANGUAGE_CODE."""
+    try:
+        return Locale.parse(lang, sep='-')
+    except (UnknownLocaleError, ValueError):
+        return Locale(*settings.LANGUAGE_CODE.split('-'))
+
+
 def current_locale():
     """
     Return the current Locale object (from Babel). Defaults to locale
     based on settings.LANGUAGE_CODE if locale does not exist.
     """
-    try:
-        return Locale.parse(get_language(), sep='-')
-    except (UnknownLocaleError, ValueError):
-        return Locale(*settings.LANGUAGE_CODE.split('-'))
+    return get_locale(get_language())
 
 
 @jingo.register.filter
-@jinja2.contextfunction
+@jinja2.contextfilter
 def l10n_format_date(ctx, date, format='long'):
     """
     Formats a date according to the current locale. Wraps around
     babel.dates.format_date.
     """
-    lang = ctx['LANG'].split('-')[0]
+    lang = get_locale(ctx['LANG'])
     return format_date(date, locale=lang, format=format)
 
 
 @jingo.register.filter
-@jinja2.contextfunction
+@jinja2.contextfilter
 def l10n_format_number(ctx, number):
     """
     Formats a number according to the current locale. Wraps around
     babel.numbers.format_number.
     """
-    lang = ctx['LANG'].split('-')[0]
+    lang = get_locale(ctx['LANG'])
     return format_number(number, locale=lang)

--- a/lib/l10n_utils/tests/test_helpers.py
+++ b/lib/l10n_utils/tests/test_helpers.py
@@ -3,7 +3,7 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
-from babel.core import UnknownLocaleError
+from babel.core import UnknownLocaleError, Locale
 from mock import patch
 from nose.tools import eq_
 
@@ -54,31 +54,35 @@ class TestL10nFormat(TestCase):
     @patch('l10n_utils.helpers.format_date')
     def test_format_date(self, format_date):
         ctx = {'LANG': 'de'}
+        locale = Locale('de')
         eq_(helpers.l10n_format_date(ctx, 'somedate', format='long'),
             format_date.return_value)
         format_date.assert_called_with(
-            'somedate', locale=ctx['LANG'], format='long')
+            'somedate', locale=locale, format='long')
 
     @patch('l10n_utils.helpers.format_date')
     def test_format_date_hyphenated_locale(self, format_date):
         ctx = {'LANG': 'en-US'}
+        locale = Locale('en', 'US')
         eq_(helpers.l10n_format_date(ctx, 'somedate', format='long'),
             format_date.return_value)
         format_date.assert_called_with(
-            'somedate', locale='en', format='long')
+            'somedate', locale=locale, format='long')
 
     @patch('l10n_utils.helpers.format_number')
     def test_format_number(self, format_number):
         ctx = {'LANG': 'de'}
+        locale = Locale('de')
         eq_(helpers.l10n_format_number(ctx, 10000),
             format_number.return_value)
         format_number.assert_called_with(
-            10000, locale=ctx['LANG'])
+            10000, locale=locale)
 
     @patch('l10n_utils.helpers.format_number')
     def test_format_number_hyphenated_locale(self, format_number):
         ctx = {'LANG': 'pt-BR'}
+        locale = Locale('pt', 'BR')
         eq_(helpers.l10n_format_number(ctx, 10000),
             format_number.return_value)
         format_number.assert_called_with(
-            10000, locale='pt')
+            10000, locale=locale)


### PR DESCRIPTION
I left them as filters because jinja does in fact have a decorator
to mark context filters. <3 Jinja2.
