### PR TITLE
Bug 1049856 - update feedback link

### DIFF
--- a/bedrock/mozorg/templates/mozorg/contribute/contribute-base.html
+++ b/bedrock/mozorg/templates/mozorg/contribute/contribute-base.html
@@ -135,7 +135,7 @@
 
         <h3>{{ _('More links') }}</h3>
         <ul>
-          <li><a href="https://feedback.mozilla.org" rel="external">{{ _('Submit Firefox feedback') }}</a></li>
+          <li><a href="https://input.mozilla.org/feedback" rel="external">{{ _('Submit Firefox feedback') }}</a></li>
           <li><a href="https://careers.mozilla.org" rel="external">{{ _('Explore Mozilla careers') }}</a></li>
           <li><a href="https://support.mozilla.org" rel="external">{{ _('Get help with Firefox') }}</a></li>
         </ul>


### PR DESCRIPTION
https://feedback.mozilla.org errors out because only http://feedback.mozilla.org redirects to input.mozilla.org/feedback. This bug could change either the https to http or just change it to input.mozilla.org/feedback to eliminate a redirect.
