### PR TITLE
Update openstandard cache before updating db

### DIFF
--- a/bedrock/openstandard/cron.py
+++ b/bedrock/openstandard/cron.py
@@ -1,6 +1,12 @@
 import cronjobs
 
-from .utils import delete_old_articles, update_from_category_feeds
+from .utils import (
+    categorized_articles, delete_old_articles, update_from_category_feeds)
+
+
+@cronjobs.register
+def update_openstandard_cache():
+    categorized_articles(force_cache_refresh=True)
 
 
 @cronjobs.register

--- a/bin/update/deploy_base.py
+++ b/bin/update/deploy_base.py
@@ -124,8 +124,9 @@ def pre_update(ctx, ref=settings.UPDATE_REF):
 @task
 def cronjobs(ctx):
     management_cmd(ctx, 'cron update_tweets')
-    management_cmd(ctx, 'cron update_openstandard')
     management_cmd(ctx, 'cron update_reps_ical')
+    management_cmd(ctx, 'cron update_openstandard_cache')
+    management_cmd(ctx, 'cron update_openstandard')
 
 
 @task


### PR DESCRIPTION
Reduce chance of broken images during deploy
