### PR TITLE
Store mult categories per article: fix bug 1083256

### DIFF
--- a/bedrock/openstandard/cron.py
+++ b/bedrock/openstandard/cron.py
@@ -1,9 +1,19 @@
 import cronjobs
 
-from .utils import delete_old_articles, update_from_category_feeds
+from .utils import (delete_old_articles, update_from_category_feeds,
+                    update_on_homepage)
 
 
 @cronjobs.register
-def update_openstandard():
+def update_openstandard_on_homepage():
+    update_on_homepage()
+
+
+@cronjobs.register
+def update_openstandard_feeds():
     update_from_category_feeds()
+
+
+@cronjobs.register
+def delete_old_openstandard_articles():
     delete_old_articles()

--- a/bedrock/openstandard/migrations/0002_auto__add_field_article_on_homepage__chg_field_article_link__add_index.py
+++ b/bedrock/openstandard/migrations/0002_auto__add_field_article_on_homepage__chg_field_article_link__add_index.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding field 'Article.on_homepage'
+        db.add_column(u'openstandard_article', 'on_homepage',
+                      self.gf('django.db.models.fields.DateTimeField')(null=True, db_index=True),
+                      keep_default=False)
+
+
+        # Changing field 'Article.link'
+        db.alter_column(u'openstandard_article', 'link', self.gf('django.db.models.fields.URLField')(max_length=2000))
+        # Adding index on 'Article', fields ['link']
+        db.create_index(u'openstandard_article', ['link'])
+
+
+    def backwards(self, orm):
+        # Removing index on 'Article', fields ['link']
+        db.delete_index(u'openstandard_article', ['link'])
+
+        # Deleting field 'Article.on_homepage'
+        db.delete_column(u'openstandard_article', 'on_homepage')
+
+
+        # Changing field 'Article.link'
+        db.alter_column(u'openstandard_article', 'link', self.gf('django.db.models.fields.CharField')(max_length=2000))
+
+    models = {
+        u'openstandard.article': {
+            'Meta': {'object_name': 'Article'},
+            'author': ('django.db.models.fields.CharField', [], {'max_length': '2000'}),
+            'category': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'image': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['openstandard.ArticleImage']", 'null': 'True', 'blank': 'True'}),
+            'link': ('django.db.models.fields.URLField', [], {'max_length': '2000', 'db_index': 'True'}),
+            'on_homepage': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'db_index': 'True'}),
+            'published': ('django.db.models.fields.DateTimeField', [], {}),
+            'summary': ('django.db.models.fields.CharField', [], {'max_length': '2000'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '2000'})
+        },
+        u'openstandard.articleimage': {
+            'Meta': {'object_name': 'ArticleImage'},
+            'alt': ('django.db.models.fields.CharField', [], {'max_length': '2000', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '2000'}),
+            'original': ('django.db.models.fields.CharField', [], {'max_length': '2000'})
+        }
+    }
+
+    complete_apps = ['openstandard']

--- a/bedrock/openstandard/models.py
+++ b/bedrock/openstandard/models.py
@@ -18,10 +18,11 @@ class Article(models.Model):
     author = models.CharField(max_length=2000)
     category = models.CharField(max_length=255)
     image = models.ForeignKey(ArticleImage, blank=True, null=True)
-    link = models.CharField(max_length=2000)
+    link = models.URLField(max_length=2000, db_index=True)
     title = models.CharField(max_length=2000)
     summary = models.CharField(max_length=2000)
     published = models.DateTimeField()
+    on_homepage = models.DateTimeField(null=True, db_index=True)
 
     def __unicode__(self):
         return self.title

--- a/bedrock/openstandard/tests.py
+++ b/bedrock/openstandard/tests.py
@@ -1,0 +1,114 @@
+from datetime import datetime
+
+from django.test import TestCase
+from django.test.utils import override_settings
+
+from dateutil.tz import tzutc
+from mock import Mock, patch
+from nose.tools import eq_
+
+from . import utils
+
+
+class UtilsTest(TestCase):
+    @patch('bedrock.openstandard.utils.cache')
+    def test_categorized_articles_cache_hit(self, cache_mock):
+        """
+        Should return cached result
+        """
+        eq_(utils.categorized_articles(), cache_mock.get.return_value)
+        cache_mock.get.assert_called_with('openstandard_articles')
+
+    @patch('bedrock.openstandard.utils.cache')
+    @patch('bedrock.openstandard.utils.Article')
+    def test_categorized_articles_cache_miss(self, article_mock, cache_mock):
+        """
+        Should construct dict from db, cache result, return dict
+        """
+        live1 = Mock(category='live')
+        live2 = Mock(category='live')
+        learn1 = Mock(category='learn')
+        learn2 = Mock(category='learn')
+        (article_mock.objects.exclude.return_value.select_related.return_value
+         .order_by.return_value) = [live1, live2, learn1, learn2]
+        cache_mock.get.return_value = None
+
+        categorized = utils.categorized_articles()
+        eq_(categorized['live'], [live1, live2])
+        eq_(categorized['learn'], [learn1, learn2])
+        cache_mock.get.assert_called_with('openstandard_articles')
+        cache_mock.set.assert_called_with('openstandard_articles', categorized, None)
+
+    @patch('bedrock.openstandard.utils.cache')
+    @patch('bedrock.openstandard.utils.Article')
+    def test_categorized_articles_force_cache_refresh(self, article_mock, cache_mock):
+        """
+        Should update cache from db and return without checking cache
+        """
+        live1 = Mock(category='live')
+        live2 = Mock(category='live')
+        learn1 = Mock(category='learn')
+        learn2 = Mock(category='learn')
+        (article_mock.objects.exclude.return_value.select_related.return_value
+         .order_by.return_value) = [live1, live2, learn1, learn2]
+
+        categorized = utils.categorized_articles(force_cache_refresh=True)
+        eq_(cache_mock.get.call_count, 0)
+        eq_(categorized['live'], [live1, live2])
+        eq_(categorized['learn'], [learn1, learn2])
+        cache_mock.set.assert_called_with('openstandard_articles', categorized, None)
+
+    @override_settings(USE_TZ=False, TIME_ZONE='America/Los_Angeles')
+    @patch('bedrock.openstandard.utils.categorized_feed_entries')
+    def test_published_in_feeds(self, categorized_feed_entries_mock):
+        categorized_feed_entries_mock.return_value = [
+            ('category', {'published': 'Fri, 17 Oct 2014 20:09:34 +0000'}),
+            ('category', {})]
+        eq_(list(utils.published_in_feeds()),
+            [datetime(2014, 10, 17, 20, 9, 34, tzinfo=tzutc())])
+
+    @patch('bedrock.openstandard.utils.Article')
+    @patch('bedrock.openstandard.utils.published_in_feeds')
+    @patch('bedrock.openstandard.utils.categorized_articles')
+    def test_delete_old_articles(self, categorized_articles_mock,
+                                 published_in_feeds_mock, article_mock):
+        """
+        Should delete articles older than those on homepage and/or in feeds
+        """
+        oldest_homepage_published = datetime(2001, 1, 1)
+        categorized_articles_mock.return_value.values.return_value = [
+            [Mock(published=oldest_homepage_published)]]
+        published_in_feeds_mock.return_value = [datetime(2001, 1, 2)]
+        utils.delete_old_articles()
+        article_mock.objects.filter.return_value.delete.assert_called_once_with()
+        article_mock.objects.filter.assert_called_once_with(
+            published__lt=oldest_homepage_published)
+
+    def test_multi_cateorize(self):
+        """
+        Should create a sorted csv of deduped categories in the category key
+        """
+        eq_(utils.multi_categorize({'category': 'a'}, 'a'),
+            {'category': 'a'})
+        eq_(utils.multi_categorize({'category': 'b'}, 'a'),
+            {'category': 'a,b'})
+
+    def test_maybe_update_unchanged(self):
+        """
+        Should not call save method for unchanged data
+        """
+        model_instance_mock = Mock(key='value')
+        data = {'key': 'value'}
+        utils.maybe_update(model_instance_mock, data)
+        eq_(model_instance_mock.save.called, 0)
+
+    def test_maybe_update_changed(self):
+        """
+        Should call save method for changed data with specific update_fields
+        """
+        model_instance_mock = Mock(key='value')
+        data = {'key': 'value', 'changed_field': 'changed'}
+        utils.maybe_update(model_instance_mock, data)
+        eq_(model_instance_mock.changed_field, 'changed')
+        model_instance_mock.save.assert_called_once_with(
+            update_fields=['changed_field'])

--- a/bin/update/deploy_base.py
+++ b/bin/update/deploy_base.py
@@ -124,7 +124,8 @@ def pre_update(ctx, ref=settings.UPDATE_REF):
 @task
 def cronjobs(ctx):
     management_cmd(ctx, 'cron update_tweets')
-    management_cmd(ctx, 'cron update_openstandard')
+    management_cmd(ctx, 'cron update_openstandard_on_homepage'
+    management_cmd(ctx, 'cron update_openstandard_feeds')
     management_cmd(ctx, 'cron update_reps_ical')
 
 


### PR DESCRIPTION
Add Article.on_homepage field and associated cron task to avoid
race condition that could cause broken images if cache miss during
update_openstandard_feed cron job before images rsynced

Change Article.link to URLField

Implement delete_old_articles and separate cron job
