### PR TITLE
Redirect /firefox/mobile/ to /firefox/new/

### DIFF
--- a/bedrock/redirects/urls.py
+++ b/bedrock/redirects/urls.py
@@ -55,6 +55,9 @@ urlpatterns = patterns(
              'styleguide.communications.copy-rules'),
     redirect(r'^firefox/brand/downloads/$', 'styleguide.home'),
 
+    # Bug 1071318
+    redirect(r'^firefox/mobile/$', 'firefox'),
+
     # Bug 804810 Identity Guidelines -> Style Guide
     redirect(r'^foundation/identity-guidelines/index.html', 'styleguide.home'),
     redirect(r'^foundation/identity-guidelines/mozilla-foundation.html',

--- a/etc/httpd/global.conf
+++ b/etc/httpd/global.conf
@@ -216,6 +216,9 @@ RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/sync(/?)$ /b/$1firefox/sync$2 [PT]
 # bug 1071074
 RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/channel(/?)$ /b/$1firefox/channel$2 [PT]
 
+# bug 1071318
+RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/mobile(/?)$ /b/$1firefox/mobile$2 [PT]
+
 # bug 929775
 RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/update(.*)?$ /$1firefox/new/?utm_source=firefox-browser&utm_medium=firefox-browser&utm_campaign=firefox-update-redirect [L,R=301]
 


### PR DESCRIPTION
[Bug 1071318](https://bugzilla.mozilla.org/show_bug.cgi?id=1071318)

Moving this redirect from the PHP .htaccess file (see https://bugzilla.mozilla.org/show_bug.cgi?id=1071318#c3) into bedrock so we can more easily/quickly update it when the new /firefox/android page is ready.
