### PR TITLE
Add "Cookies" link to footers. Bug 1075252.

### DIFF
--- a/bedrock/base/templates/includes/site-footer.html
+++ b/bedrock/base/templates/includes/site-footer.html
@@ -20,6 +20,7 @@
             </ul>
             <ul class="links-legal">
               <li><a href="{{ url('privacy') }}">{{ _('Privacy') }}</a></li>
+              <li class="wrap"><a href="{{ url('privacy.notices.websites') }}">{{ _('Cookies') }}</a></li>
               <li class="wrap"><a href="{{ url('legal.index') }}">{{ _('Legal') }}</a></li>
               <li class="clear"><a href="{{ url('legal.fraud-report') }}">{{ _('Report Trademark Abuse') }}</a></li>
             </ul>

--- a/bedrock/firefox/templates/firefox/includes/simple_footer.html
+++ b/bedrock/firefox/templates/firefox/includes/simple_footer.html
@@ -12,8 +12,9 @@
       <li>{% include 'includes/lang_switcher.html' %}</li>
     </ul>
     <ul class="secondary">
-      <li><a href="{{ url('privacy') }}">{{_('Privacy Policy')}}</a></li>
-      <li><a href="{{ url('legal.index') }}">{{_('Legal Notices')}}</a></li>
+      <li><a href="{{ url('privacy') }}">{{_('Privacy')}}</a></li>
+      <li><a href="{{ url('privacy.notices.websites') }}">{{ _('Cookies') }}</a></li>
+      <li><a href="{{ url('legal.index') }}">{{_('Legal')}}</a></li>
     </ul>
   </div>
 </footer>

--- a/bedrock/firefox/templates/firefox/whatsnew.html
+++ b/bedrock/firefox/templates/firefox/whatsnew.html
@@ -119,8 +119,9 @@
       <li><a href="https://support.mozilla.org/">{{ _('Firefox Help') }}</a></li>
     </ul>
     <ul class="secondary">
-      <li><a href="{{ url('privacy') }}">{{ _('Privacy Policy') }}</a></li>
-      <li><a href="{{ url('legal.index') }}">{{ _('Legal Notices') }}</a></li>
+      <li><a href="{{ url('privacy') }}">{{ _('Privacy') }}</a></li>
+      <li><a href="{{ url('privacy.notices.websites') }}">{{ _('Cookies') }}</a></li>
+      <li><a href="{{ url('legal.index') }}">{{ _('Legal') }}</a></li>
     </ul>
   </nav>
   <p class="attribution"><small>


### PR DESCRIPTION
- Update "Legal Notices" to "Legal" and "Privacy Policy" to
  "Privacy" in custom/one-off footers.
