### PR TITLE
[fix bug 1083381] Set twitter feed on homepage to not show @replies

### DIFF
--- a/bedrock/mozorg/cron.py
+++ b/bedrock/mozorg/cron.py
@@ -25,7 +25,7 @@ def update_feeds():
 def update_tweets():
     for account in settings.TWITTER_ACCOUNTS:
         try:
-            tweets = TwitterAPI(account).user_timeline(screen_name=account)
+            tweets = TwitterAPI(account).user_timeline(screen_name=account, exclude_replies='true')
         except Exception:
             tweets = None
 


### PR DESCRIPTION
Not quite ready to merge.

This change will mean Twitter @ replies will not be included in the cron job. One side effect of this is that the student ambassadors page will also not show replies in the timeline. If this is not desired (I'm getting [confirmation in the bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1083381#c9)), then I may need the guidance of either @pmclanahan or @jgmize on how best to accommodate this.
