### PR TITLE
Consolidate /b/ redirects for /firefox/ URLs

### DIFF
--- a/etc/httpd/global.conf
+++ b/etc/httpd/global.conf
@@ -154,10 +154,6 @@ RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/firefox\.exe$ /$1 [NC,L,R=301]
 
 # bug 821006
 RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/all(\.html)?$ /$1firefox/all/ [L,R=301]
-RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/all/$ /b/$1firefox/all/ [PT]
-
-# bug 1064416
-RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/interest-dashboard/$ /b/$1firefox/interest-dashboard/ [PT]
 
 # bug 727561
 RewriteRule ^/en-US/firefox/search(?:\.html)?$ /en-US/firefox/ [L,R=301]
@@ -169,8 +165,6 @@ RewriteRule ^/en-US/press/awards(?:\.html)?$ https://blog.mozilla.org/press/awar
 RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/all-(?:beta|rc)(?:\.html)?$ /firefox/beta/all/ [L,R=301]
 RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/all-aurora(?:\.html)?$ /firefox/aurora/all/ [L,R=301]
 RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/organizations/all(?:\.html)?$ /firefox/organizations/all/ [L,R=301]
-RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/(aurora|beta)/all(/?)$ /b/$1firefox/$2/all$3 [PT]
-RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/organizations(.*)$ /b/$1firefox/organizations$2 [PT]
 
 # bug 803345
 RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?apps(.*)$ /b/$1apps$2 [PT]
@@ -215,38 +209,17 @@ RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?projects(/?)$ /b/$1projects$2 [PT]
 # bug 1014823
 RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/releases/whatsnew(/?)$ /b/$1firefox/whatsnew/ [PT]
 
-RewriteRule ^/en-US/firefox/new(/?)$ /b/en-US/firefox/new$1 [PT]
-RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/geolocation(/?)$ /b/$1firefox/geolocation$2 [PT]
-RewriteRule ^/en-US/firefox/releases(/?)$ /b/en-US/firefox/releases$1 [PT]
-RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/sync(/?)$ /b/$1firefox/sync$2 [PT]
-
-# bug 1071074
-RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/channel(/?)$ /b/$1firefox/channel$2 [PT]
-
-# bug 1071318
-RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/mobile(/?)$ /b/$1firefox/mobile$2 [PT]
-
 # bug 929775
 RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/update(.*)?$ /$1firefox/new/?utm_source=firefox-browser&utm_medium=firefox-browser&utm_campaign=firefox-update-redirect [L,R=301]
 
 # bug 927442
 RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/community(/?)$ /$1contribute/ [L,R=301]
 
-# bug 1044352
-RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/new(/?)$ /b/$1firefox/new$2 [PT]
-
 # Bug 1006616
 RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?download/?$ /$1firefox/new/ [L,R=301]
 
-# bug 957283
-RewriteRule ^/(pt-BR)/firefox/speed(/?)$ /b/$1/firefox/speed$2 [PT]
-
-# bug 796952, 915845, 915867
-RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/unsupported/(.*)$ /b/$1firefox/unsupported/$2 [PT]
-
 # bug 988044
 RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/unsupported-systems\.html$ /$1firefox/unsupported-systems/ [L,R=301]
-RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/unsupported-systems(.*)$ /b/$1firefox/unsupported-systems$2 [PT]
 
 # Bug 1009247
 RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?(firefox|mobile)/(aurora|beta)/?$ /$1firefox/channel/#$3 [NE,L,R=301]
@@ -285,20 +258,8 @@ RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox(/(?:\d+\.\d+\.?(?:\d+)?\.?(?:\d+)?(?
 # bug 736934, 860865
 RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?(firefox|mobile)/((?:beta|aurora|organizations)/)?notes(/?)$ /b/$1$2/$3notes$4 [PT]
 RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/((?:beta|aurora|organizations)/)?system-requirements(\.html)?$ /$1firefox/$2system-requirements/ [L,R=301]
-RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/((?:beta|aurora|organizations)/)?system-requirements/$ /b/$1firefox/$2system-requirements/ [PT]
-
-# bug 778752
-RewriteRule ^/en-US/firefox/channel/android(/?)$ /b/en-US/firefox/channel/android$1 [PT]
-
-# bug 1059518
-RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/tiles(.*)$ /b/$1firefox/tiles$2 [PT]
-
-# bug 784737
-RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/memory(.*)$ /b/$1firefox/memory$2 [PT]
 
 RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?styleguide(.*)$ /b/$1styleguide$2 [PT]
-
-RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/sms(.*)$ /b/$1firefox/sms$2 [PT]
 
 RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?grants(.*)$ /b/$1grants$2 [PT] # bug 793181
 
@@ -322,7 +283,6 @@ RewriteCond %{ENV:HTTPS} !on
 RewriteRule ^/.*/plugincheck/ https://%{SERVER_NAME}%{REQUEST_URI} [L,R=301]
 
 # bug 878871
-RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/os(.*)$ /b/$1firefox/os$2 [PT]
 RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefoxos(.*)$ /$1firefox/os/ [NE,L,R=301]
 
 # bug 797337
@@ -332,17 +292,11 @@ RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?contribute/areas.html$ /b/$1contribute/areas
 RewriteRule ^/community/index.(de|fr|hr|sq).html$ /contribute/ [L,R=301]
 RewriteRule ^/community/(index.html)?$ /contribute/ [L,R=301]
 
-# bug 798453
-RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/installer-help(.*)$ /b/$1firefox/installer-help$2 [PT]
-
 # bug 801705
 RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?gameon(.*)$ /b/$1gameon$2 [PT]
 
 # bug 799767
 RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?book(.*)$ /b/$1book$2 [PT]
-
-# bug 800461
-RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/brand(.*)$ /b/$1firefox/brand$2 [PT]
 
 # bug 807323
 RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?foundation/identity-guidelines(.*)$ /b/$1foundation/identity-guidelines$2 [PT]
@@ -371,9 +325,6 @@ RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?research(.*)$ /b/$1research$2 [PT]
 # bug 822817
 RewriteRule ^/telemetry/?$ /b/telemetry/ [PT]
 
-# bug 829091
-RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/partners(.*)$ /b/$1firefox/partners$2 [PT]
-
 # bug 831810
 RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?mwc/?$ /$1firefox/partners/?utm_source=mozilla.org&utm_medium=referral&utm_campaign=mwc-redirect [NC,L,R=302]
 
@@ -387,7 +338,6 @@ RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox(/.+)/firstrun/eu/?$ /$1firefox$2/fir
 
 # bug 748503
 RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?projects/firefox/([^/]+)a[0-9]+/(firstrun|whatsnew)(.*)$ /$1firefox/nightly/firstrun$4 [L,R=301]
-RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/nightly/firstrun(.*)$ /b/$1firefox/nightly/firstrun$2 [PT]
 
 # bug 840814
 RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?projects/firefox(/(?:\d+\.\d+\.?(?:\d+)?\.?(?:\d+)?(?:[a|b]?)(?:\d*)(?:pre)?(?:\d)?))(/(?:firstrun|whatsnew))(/.*)?$ /$1firefox$2$3$4 [L,R=301]
@@ -421,10 +371,6 @@ RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/accountmanager/?$ /$1persona/ [L,R=3
 
 # bug 841846
 RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/nightly(/?)$ https://nightly.mozilla.org [L,R=302]
-
-
-# bug 748503
-RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/nightly/firstrun(.*)$ /b/$1firefox/nightly/firstrun$2 [PT]
 
 # bug 860532 - Reidrects for governance pages
 RewriteRule ^/about/governance\.html$ /about/governance/ [L,R=301]
@@ -550,11 +496,6 @@ RewriteRule ^/access/windows/at-apis.html$ https://developer.mozilla.org/en-US/d
 RewriteRule ^/access/windows/msaa-server.html$ https://developer.mozilla.org/en-US/docs/Web/Accessibility/Implementing_MSAA_server [L,R=301]
 RewriteRule ^/access/windows/zoomtext.html$ https://developer.mozilla.org/en-US/docs/Mozilla/Accessibility/ZoomText [L,R=301]
 
-# bug 869495
-RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/os/releasenotes/1.0.1(.*)$ /b/$1firefox/os/releasenotes/1.0.1$2 [PT]
-# bug 912101
-RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/os/releasenotes/1.1(.*)$ /b/$1firefox/os/releasenotes/1.1$2 [PT]
-
 # bug 858315
 RewriteRule ^/projects/devpreview/firstrun(?:/(?:index.html)?)?$ /firefox/firstrun/ [L,R=301]
 RewriteRule ^/projects/devpreview/(.*)$ http://website-archive.mozilla.org/www.mozilla.org/devpreview_releasenotes/projects/devpreview/$1 [L,R=301]
@@ -583,9 +524,6 @@ RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?firefox/(24\.[5678]\.\d)/releasenot
 # bug 1041712, 1069335, 1069902
 RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)(firefox|mobile)/([0-9]|1[0-9]|2[0-8])\.(\d+(?:beta|a2|\.\d+)?)/(release|aurora)notes/(.*)$ http://website-archive.mozilla.org/www.mozilla.org/firefox_releasenotes/en-US/$2/$3.$4/$5notes/$6 [L,R=301]
 
-# bug 957242
-RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?firefox/(.*)/system-requirements(/)?$ /b/$1firefox/$2/system-requirements$3 [PT]
-
 # bug 1017564
 RewriteRule ^/en-US/mobile/.*/system-requirements/?$ https://support.mozilla.org/kb/will-firefox-work-my-mobile-device [L,R=301]
 
@@ -598,12 +536,6 @@ RewriteRule ^/en-US/newsletter/about_mobile(?:/(?:index.html)?)?$ /en-US/newslet
 RewriteRule ^/en-US/newsletter/about_mozilla(?:/(?:index.html)?)?$ /en-US/contribute/ [L,R=301]
 RewriteRule ^/en-US/newsletter/new(?:/(?:index.html)?)?$ /en-US/newsletter/ [L,R=301]
 RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?newsletter(.*)$ /b/$1newsletter$2 [PT]
-
-# bug 892716
-RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox(/)?$ /b/$1firefox$2 [PT]
-
-# bug 1071922
-RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/developer(.*)$ /b/$1firefox/developer$2 [PT]
 
 # bug 818321
 RewriteRule ^/projects/security/tld-idn-policy-list.html$ /about/governance/policies/security-group/tld-idn/ [L,R=301]
@@ -769,9 +701,6 @@ RewriteRule ^/projects/calendar/caldata/(.*)$ /media/caldata/$1 [PT]
 # Bug 981063, catch all for old calendar urls.
 RewriteRule ^/projects/calendar/.+ /projects/calendar/ [L,R=301]
 
-# bug 947890
-RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/latest/releasenotes(/?)$ /b/$1firefox/latest/releasenotes$2 [PT]
-
 # bug 962307
 RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?gigabit(.*)$ /b/$1gigabit$2 [PT]
 
@@ -785,14 +714,9 @@ RewriteRule ^/firefox/its-an-attack.html$ http://www.itisatrap.org/firefox/its-a
 # bug 979217
 RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox(/(?:\d+\.\d+\.?(?:\d+)?\.?(?:\d+)?(?:[a|b]?)(?:\d*)(?:pre)?(?:\d)?))?/tour(/?)$ /b/$1firefox$2/tour$3 [PT]
 
-# bug 975156
-RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/desktop(/?.*)$ /b/$1firefox/desktop$2 [PT]
-
 # Bug 986174
 RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/mobile/features(/?)$ /$1firefox/android/ [L,R=301]
 RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/mobile/faq(/?)$ /$1firefox/android/faq/ [L,R=301]
-RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/android(/?)$ /b/$1firefox/android$2 [PT]
-RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/android/faq(/?)$ /b/$1firefox/android/faq$2 [PT]
 
 # Bug 979527
 RewriteCond %{HTTP_USER_AGENT} Firefox
@@ -849,3 +773,6 @@ RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/independent(/?.*)$ /b/$1firefox/inde
 # bug 1093985, 1105664, remove this once the Firefox Hello product page is ready
 RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/hello(/?.*)$ https://support.mozilla.org/kb/respond-firefox-hello-invitation-guest-mode [L,R=temp]
 RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/([3-9]\d\.\d(?:a1|a2|beta|\.\d)?)/hello/start/?$ https://support.mozilla.org/kb/firefox-hello-make-and-receive-calls-guest-mode [L,R=temp]
+
+# bug 1074261
+RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox(.*)$ /b/$1firefox$2 [PT]

--- a/etc/httpd/global.conf
+++ b/etc/httpd/global.conf
@@ -155,6 +155,9 @@ RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/firefox\.exe$ /$1 [NC,L,R=301]
 # bug 821006
 RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/all(\.html)?$ /$1firefox/all/ [L,R=301]
 
+# bug 730488
+RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/all-older\.html$ /$1firefox/ [L,R=301]
+
 # bug 727561
 RewriteRule ^/en-US/firefox/search(?:\.html)?$ /en-US/firefox/ [L,R=301]
 


### PR DESCRIPTION
[Bug 1074261](https://bugzilla.mozilla.org/show_bug.cgi?id=1074261)

The following lines may also be able to be removed, but I wasn't sure. Needs discussion.

```apache
RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?(firefox/)?dnt(.*)$ /b/$1$2dnt$3 [PT]

RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox(/(?:\d+\.\d+\.?(?:\d+)?\.?(?:\d+)?(?:[a|b]?)(?:\d*)(?:pre)?(?:\d)?))?/whatsnew(/?)$ /b/$1firefox$2/whatsnew$3 [PT]

RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?(firefox|mobile)/((?:beta|aurora|organizations)/)?notes(/?)$ /b/$1$2/$3notes$4 [PT]

RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox(/(?:\d+\.\d+\.?(?:\d+)?\.?(?:\d+)?(?:[a|b]?)(?:\d*)(?:pre)?(?:\d)?))?/firstrun(/?)$ /b/$1firefox$2/firstrun$3 [PT]

RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?(firefox|mobile)/(2[38]\.0(?:\.\d)?)/releasenotes(/)?$ /b/$1$2/$3/releasenotes$4 [L,PT]

RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?(firefox|mobile)/(29\.0(?:beta|\.\d)?)/releasenotes(/)?$ /b/$1$2/$3/releasenotes$4 [L,PT]

RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?(firefox|mobile)/([3-9]\d\.\d(?:a2|beta|\.\d)?)/(aurora|release)notes(/)?$ /b/$1$2/$3/$4notes$5 [L,PT]

RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?firefox/(24\.[5678]\.\d)/releasenotes(/)?$ /b/$1firefox/$2/releasenotes$3 [L,PT]

RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox(/(?:\d+\.\d+\.?(?:\d+)?\.?(?:\d+)?(?:[a|b]?)(?:\d*)(?:pre)?(?:\d)?))?/tour(/?)$ /b/$1firefox$2/tour$3 [PT]
```