### PR TITLE
Bug 975476: Update redirects for python-nss docs.

### DIFF
--- a/etc/httpd/global.conf
+++ b/etc/httpd/global.conf
@@ -86,7 +86,7 @@ RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?projects/security/pki/nss.*$ https://develop
 RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?projects/security/pki/jss.*$ https://developer.mozilla.org/docs/JSS [L,R=301]
 
 # bug 866190
-RewriteRule ^/projects/security/pki/python-nss/$ https://developer.mozilla.org/docs/Python_binding_for_NSS [L,R=301]
+RewriteRule ^/projects/security/pki/python-nss/?$ https://developer.mozilla.org/docs/Python_binding_for_NSS [L,R=301]
 
 # bug 1043035
 RewriteRule ^/projects/security/pki/(?:index.html)?$ https://developer.mozilla.org/docs/PKI [L,R=301]
@@ -95,7 +95,7 @@ RewriteRule ^/projects/security/pki/psm.* https://developer.mozilla.org/docs/Moz
 RewriteRule ^/projects/security/pki/src.* https://developer.mozilla.org/docs/Mozilla/Projects/NSS/NSS_Sources_Building_Testing [L,R=301]
 
 # bug 975476
-RewriteRule ^/projects/security/pki(.*)$ http://website-archive.mozilla.org/www.mozilla.org/python_nss_docs/projects/security/pki$1 [L,R=301]
+RewriteRule ^/projects/security/pki/python-nss/doc/api/current/html(.*)$ https://mozilla.github.io/python-nss-docs$1 [L,R=301]
 
 # bug 780672
 RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/webhero(.*)$ /firefox/ [L,R=301]


### PR DESCRIPTION
We now have a github repo setup using github-pages
to publish the docs. The developer (@jdennis) has
permissions on it, and they will be updated there.

I've made the redirect for the docs more specific since
after examining the archive it's clear that this directory
structure is all that was in there, so there wouldn't be
any valid links to any URLs between "python-nss" and "html".

I made the trailing slash on the MDN redirect optional since
that form of the URL is the one used on the PyPI page for the
package and was redirecting to a 404 at the archive.
