### PR TITLE
[bug 1071959] Add share CTA macro for 10th anniversary pages

### DIFF
--- a/bedrock/base/templates/macros.html
+++ b/bedrock/base/templates/macros.html
@@ -356,3 +356,14 @@
     {% endif -%}
   </section>
 {%- endmacro %}
+
+{% macro share_cta(cta_text, url, share_text) %}
+<div id="mozilla-share-cta" tabindex="0">
+  <h3>{{ cta_text }}</h3>
+  <ul>
+    <li><a class="twitter" href="{{ 'https://www.twitter.com/intent/tweet?url=%s&amp;text=%s'|format(url|urlencode, share_text|urlencode)|e }}" title="Twitter">Twitter</a></li>
+    <li><a class="facebook" href="{{ 'https://www.facebook.com/sharer/sharer.php?u=%s'|format(url|urlencode)|e }}" title="Facebook">Facebook</a></li>
+    <li><a class="g-plus" href="{{ 'https://plus.google.com/share?url=%s&amp;hl=%s'|format(url|urlencode, LANG)|e }}" title="Google+">Google+</a></li>
+  </ul>
+</div>
+{%- endmacro %}

--- a/media/css/base/mozilla-share-cta-ie.less
+++ b/media/css/base/mozilla-share-cta-ie.less
@@ -1,0 +1,19 @@
+#mozilla-share-cta {
+
+    h3:before {
+        font-family: inherit;
+        content: '';
+    }
+
+    ul li a {
+        font-size: 16px;
+
+        &.twitter:before,
+        &.facebook:before,
+        &.g-plus:before {
+            font-family: inherit;
+            content: '';
+            font-size: 16px;
+        }
+    }
+}

--- a/media/css/base/mozilla-share-cta.less
+++ b/media/css/base/mozilla-share-cta.less
@@ -1,0 +1,134 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+@font-face {
+  font-family: 'Font Awesome';
+  src: url('/media/fonts/fontawesome-webfont.eot?#iefix') format('embedded-opentype'),
+       url('/media/fonts/fontawesome-webfont.woff') format('woff'),
+       url('/media/fonts/fontawesome-webfont.ttf') format('truetype');
+  font-weight: normal;
+  font-style: normal;
+}
+
+#mozilla-share-cta {
+    position: relative;
+    width: 296px;
+    background: #0c99d5;
+    color: #fff;
+    border: 2px solid #9ed6ee;
+    border-radius: 8px;
+    overflow: hidden;
+    -webkit-transition: background .2s ease-in-out;
+            transition: background .2s ease-in-out;
+
+    &:hover,
+    &:focus {
+        background: lighten(#0c99d5, 2%);
+    }
+
+    h3 {
+        display: block;
+        width: 256px;
+        padding: 1em 20px;
+        margin: 0;
+        color: #fff;
+        font-size: 18px;
+        text-transform: uppercase;
+        border: none;
+        background: none;
+        text-align: center;
+        visibility: visible;
+        text-shadow: none;
+        font-family: 'Open Sans', sans-serif;
+        opacity: 1;
+        -webkit-transition: opacity .2s ease-in-out;
+                transition: opacity .2s ease-in-out;
+
+        &:before {
+            font-family: 'Font Awesome';
+            content: '\f1e0\00A0\00A0';
+            text-shadow: none;
+        }
+    }
+
+    ul {
+        display: table;
+        position: relative;
+        list-style-type: none;
+        margin: 0;
+        padding: 0;
+        width: 100%;
+        height: 100%;
+        visibility: hidden;
+
+        li {
+            display: table-cell;
+            width: 33.3%;
+            margin: 0;
+            padding: 0;
+            text-align: center;
+            vertical-align: middle;
+            opacity: 0;
+            -webkit-transition: opacity .2s ease-in-out;
+                    transition: opacity .2s ease-in-out;
+
+            a {
+                color: #fff;
+                font-size: 0;
+
+                &:before {
+                    font-family: 'Font Awesome';
+                    font-size: 28px;
+                    opacity: 0.9;
+                    padding-top: 1px;
+                    text-shadow: none;
+                    -webkit-font-smoothing: antialiased;
+                    -webkit-transition: opacity .2s ease-in-out;
+                            transition: opacity .2s ease-in-out;
+                }
+
+                &.twitter:before {
+                    content: '\f099\00A0';
+                }
+
+                &.facebook:before {
+                    content: '\f09a\00A0';
+                }
+
+                &.g-plus:before {
+                    content: '\f0d5\00A0';
+                }
+
+                &:hover,
+                &:focus {
+                    text-decoration: none;
+
+                    &:before {
+                        text-shadow: none;
+                        opacity: 1;
+                    }
+                }
+            }
+        }
+    }
+}
+
+.js #mozilla-share-cta {
+    h3 {
+        position: absolute;
+        top: 0;
+        left: 0;
+    }
+}
+
+.js #mozilla-share-cta {
+    h3.out {
+        opacity: 0;
+        -webkit-transition: opacity .2s ease-in-out;
+                transition: opacity .2s ease-in-out;
+    }
+    ul.in li {
+        opacity: 1;
+    }
+}

--- a/media/js/base/mozilla-share-cta.js
+++ b/media/js/base/mozilla-share-cta.js
@@ -1,0 +1,71 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+$(function() {
+    'use strict';
+
+    var $share = $('#mozilla-share-cta');
+    var $heading = $share.find('h3');
+    var $links = $share.find('ul');
+    var showTimeout;
+
+    $share.css('height', $heading.outerHeight());
+
+    function showLinks() {
+        $share.addClass('reveal');
+        $heading.addClass('out');
+
+        clearTimeout(showTimeout);
+        showTimeout = setTimeout(function () {
+            $heading.css('visibility', 'hidden');
+            $links.css('visibility', 'visible').addClass('in');
+        }, 200);
+    }
+
+    function hideLinks() {
+        $share.removeClass('reveal');
+        $links.removeClass('in');
+
+        clearTimeout(showTimeout);
+        showTimeout = setTimeout(function () {
+            $links.css('visibility', 'hidden');
+            $heading.css('visibility', 'visible').removeClass('out');
+        }, 200);
+    }
+
+    $share.on('mouseenter focusin', function() {
+        if (!$share.hasClass('reveal')) {
+            showLinks();
+        }
+    });
+
+    $share.on('mouseleave', function() {
+        if ($share.hasClass('reveal')) {
+            hideLinks();
+        }
+    });
+
+    $share.on('focusout', function(e) {
+        // only toggle state if target is last link in list
+        if ($share.hasClass('reveal') && $(e.target).parent().is('li:last-child')) {
+            hideLinks();
+        }
+    });
+
+    $links.find('a').on('click', function (e) {
+        var $this = $(this);
+        var newTab = (this.target === '_blank' || e.metaKey || e.ctrlKey);
+        var href = this.href;
+        var callback = function() {
+            window.location = href;
+        };
+
+        if (newTab) {
+            gaTrack(['_trackEvent', 'Share CTA Interactions', 'Social link click', $this.attr('title')]);
+        } else {
+            e.preventDefault();
+            gaTrack(['_trackEvent', 'Share CTA Interactions', 'Social link click', $this.attr('title')], callback);
+        }
+    });
+});


### PR DESCRIPTION
Import macro on any given template:

```
{% from "macros.html" import share_cta with context %}
```

Example usage:

```
{{ share_cta('Share the video', 'https://www.mozilla.org', 'Share text' }}
```

Additional files:
- mozilla-share-cta.less
- mozilla-share-cta-ie.less (fallback styles for IE8 if needed)
- mozilla-share-cta.js
