### PR TITLE
Fix Bug 1086584: Add ID for anchor link in firefox/all template.

### DIFF
--- a/bedrock/firefox/templates/firefox/all.html
+++ b/bedrock/firefox/templates/firefox/all.html
@@ -113,7 +113,7 @@
         </div>
 
       {% if test_builds %}
-        <div class="localized-testing">
+        <div class="localized-testing" id="localized-testing">
           {{ build_table(test_builds,
                          _('Localized versions in testing'),
                          _('These localizations aren’t final. We’re waiting for more feedback from the community to perfect them.')) }}


### PR DESCRIPTION
See https://bugzilla.mozilla.org/show_bug.cgi?id=1086584 for details
