### PR TITLE
Switch to django_nose test runner.

### DIFF
--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -987,7 +987,7 @@ RECAPTCHA_PUBLIC_KEY = ''
 RECAPTCHA_PRIVATE_KEY = ''
 RECAPTCHA_USE_SSL = True
 
-TEST_RUNNER = 'test_utils.runner.RadicalTestSuiteRunner'
+TEST_RUNNER = 'django_nose.NoseTestSuiteRunner'
 
 # Use a message storage mechanism that doesn't need a database.
 # This can be changed to use session once we do add a database.


### PR DESCRIPTION
This should avoid strange table missing errors when using the
runner from test_utils.

This does not skip DB creation by default like the last one, you have
to set the REUSE_DB=1 env variable to enable this behavior.
