### PR TITLE
Allow internal IPs access to demos with basic auth.

### DIFF
--- a/etc/httpd/demo.conf
+++ b/etc/httpd/demo.conf
@@ -2,9 +2,12 @@
 # Uncomment to enable password protection.
 # bug 924984
 #<Location />
+#  Order Deny,Allow
+#  Deny from all
+#  Allow from 10.0.0.0/8
 #  AuthType Basic
 #  AuthName "Authentication Required"
 #  AuthUserFile /etc/httpd/mozilla/domains/www-demo2_password
 #  Require valid-user
-#  Allow from all
+#  Satisfy Any
 #</Location>


### PR DESCRIPTION
This should allow the QA test infrastructure to run against the demo servers even
if they have basic auth on.
