### PR TITLE
Avoid django DST error: bug 1092647

### DIFF
--- a/bedrock/events/tests/test_models.py
+++ b/bedrock/events/tests/test_models.py
@@ -3,6 +3,12 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import os.path
+from datetime import datetime
+
+from django.test.utils import override_settings
+
+from mock import patch
+from nose.tools import eq_
 
 from bedrock.events.models import Event
 from bedrock.mozorg.tests import TestCase
@@ -24,3 +30,23 @@ class TestICalSync(TestCase):
             Event.objects.sync_with_ical(fh.read())
 
         self.assertEqual(Event.objects.count(), 14)
+
+
+class TestFutureQuerySet(TestCase):
+    @override_settings(USE_TZ=True)
+    @patch('bedrock.events.models.datetime')
+    def test_future_dst_use_tz(self, mock_datetime):
+        """
+        Should not raise error during DST change
+        """
+        mock_datetime.utcnow.return_value = datetime(2014, 11, 02, 01, 01)
+        eq_(Event.objects.future().count(), 0)
+
+    @override_settings(USE_TZ=False)
+    @patch('bedrock.events.models.datetime')
+    def test_future_dst(self, mock_datetime):
+        """
+        Should not raise error during DST change
+        """
+        mock_datetime.utcnow.return_value = datetime(2014, 11, 02, 01, 01)
+        eq_(Event.objects.future().count(), 0)


### PR DESCRIPTION
Use tz-aware datetime in query to avoid automatic conversion by
django.utils.timezone.make_aware, which will throw an error during DST
change, because Zen. https://code.djangoproject.com/ticket/22598
