### PR TITLE
Bug 1092706 - Fix non localized strings in /contribute/signup

### DIFF
--- a/bedrock/mozorg/forms.py
+++ b/bedrock/mozorg/forms.py
@@ -27,7 +27,7 @@ from .email_contribute import INTEREST_CHOICES
 FORMATS = (('H', _lazy('HTML')), ('T', _lazy('Text')))
 LANGS_TO_STRIP = ['en-US', 'es']
 PARENTHETIC_RE = re.compile(r' \([^)]+\)$')
-LANG_FILES = ['mozorg/contribute', 'firefox/partners/index']
+LANG_FILES = ['firefox/partners/index', 'mozorg/contribute', 'mozorg/contribute/index']
 
 
 def strip_parenthetical(lang_name):


### PR DESCRIPTION
As pmac suggested in the bug, adding the new .lang file (mozorg/contribute/index) to the form fixes the issue.
