### PR TITLE
Tabzilla: Hide the info bar on the SUMO update article.

### DIFF
--- a/bedrock/tabzilla/templates/tabzilla/tabzilla.js
+++ b/bedrock/tabzilla/templates/tabzilla/tabzilla.js
@@ -494,6 +494,10 @@ var Tabzilla = (function (Tabzilla) {
         var isMobile = (/Mobile|Tablet|Fennec/i).test(ua);
         var userVersion = (isFirefox) ? parseInt(ua.match(/Firefox\/(\d+)/)[1], 10) : 0;
         var showInfobar = function () {
+            if ($('body').data('defaultSlug') === 'update-firefox-latest-version') {
+                // Don't show the info bar on the page that the info bar sends the user to.
+                return;
+            }
             // If the user accepts, show the SUMO article
             updatebar.onaccept.callback = function () {
                 location.href = 'https://support.mozilla.org/{{ LANG }}/kb/update-firefox-latest-version';


### PR DESCRIPTION
SUMO recently turned on Tabzilla's update nag, and turned ours off.
The bug for that is Bug 1092335. Now, if a user clicks on the "Update"
button in Tabzilla, they get sent to the SUMO article, which proceeds to
nag them again. This patch hides the update bar on the target url.
