### PR TITLE
added a rule which redirects the accesses to /ja/contribute to the equivalent page in Mozilla Japan's web site

### DIFF
--- a/etc/httpd/global.conf
+++ b/etc/httpd/global.conf
@@ -194,6 +194,9 @@ RewriteCond %{REQUEST_URI} !^/ja/about/manifesto
 RewriteCond %{REQUEST_URI} !^/ja/about/legal
 RewriteRule ^/ja/about(/?|/.+)$ http://www.mozilla.jp/about/mozilla/ [L,R=301]
 
+# bug 1091977
+RewriteRule ^/ja/contribute(/?|/.+)$ http://www.mozilla.jp/community/ [L,R=301]
+
 # bug 889958
 RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?mission(/?)$ /b/$1mission$2 [PT]
 


### PR DESCRIPTION
This pull request for Bug1091977.
