### PR TITLE
Fix bug 1085484: Set utf-8 content type for calendar files.

### DIFF
--- a/media/.htaccess
+++ b/media/.htaccess
@@ -8,7 +8,7 @@ AddType application/font-woff .woff
 AddType application/vnd.ms-fontobject .eot
 AddType application/octet-stream .ttf
 
-AddCharset utf-8 .css .js
+AddCharset utf-8 .css .js .ics
 
 # Set far-future Expires headers for static media
 ExpiresActive on


### PR DESCRIPTION
I've not tested this, but this should work. We can verify on dev.
