### PR TITLE
Bug 1088202 - remove platform switch from Aurora notes

### DIFF
--- a/bedrock/firefox/templates/firefox/releases/aurora-notes.html
+++ b/bedrock/firefox/templates/firefox/releases/aurora-notes.html
@@ -11,3 +11,5 @@
 {% block site_header_logo %}
     <h2><a href="{{ url('firefox') }}"><img alt="Mozilla Firefox" height="70" width="185" src="{{media('img/firefox/template/header-logo-inverse.png?2013-06') }}"></a></h2>
 {% endblock %}
+
+{% block platform_switch %}{% endblock %}


### PR DESCRIPTION
The switch was removed from the new Dev Edition notes, but still appeared for Android Aurora.
