### PR TITLE
[bug 1088492] Stop redirecting campaign page to Mozilla Taiwan website

### DIFF
--- a/etc/httpd/global.conf
+++ b/etc/httpd/global.conf
@@ -31,6 +31,10 @@ RewriteRule ^(.*)//(.*)$ $1/$2 [L,R=301]
 
 # bug 764261, 841393, 996608, 1008162, 1067691
 RewriteRule ^/zh-TW/$ http://mozilla.com.tw/ [L,R=301]
+RewriteCond %{REQUEST_URI} !^/zh-TW/firefox/independent
+RewriteCond %{REQUEST_URI} !^/zh-TW/firefox/os/devices
+RewriteCond %{REQUEST_URI} !^/zh-TW/firefox/tiles
+RewriteCond %{REQUEST_URI} !^/zh-TW/firefox/android
 RewriteCond %{REQUEST_URI} !^/zh-TW/firefox/sync
 RewriteCond %{REQUEST_URI} !^/zh-TW/firefox/partners
 RewriteCond %{REQUEST_URI} !^/zh-TW/firefox/desktop/tips


### PR DESCRIPTION
- Prevents redirecting the 10th anniversary campaign page to Mozilla Taiwan website.
- Also prevents redirects for /firefox/os/devices/, /firefox/tiles/ and /firefox/android/ (as noted in the bug)

We should probably tidy up & consolidate these redirects at some point, but in the interest of getting this one out I'll keep it simple for now.
