### PR TITLE
Share full URLs with locale strings

### DIFF
--- a/bedrock/base/templates/macros.html
+++ b/bedrock/base/templates/macros.html
@@ -411,8 +411,8 @@ set video_locales = {
 {%
 set share_urls = {
     'twitter': 'http://mzl.la/fx10',
-    'googleplus': 'http://mzl.la/1vV6ZHq',
-    'facebook': 'http://mzl.la/1EpcVPe'
+    'googleplus': 'https://www.mozilla.org/' + LANG + '/firefox/independent/?utm_source=Google&utm_medium=MozLandingPage&utm_campaign=FX10&utm_content=WebsiteShare',
+    'facebook': 'https://www.mozilla.org/' + LANG + '/firefox/independent/?utm_source=Facebook&utm_medium=MozLandingPage&utm_campaign=FX10&utm_content=WebsiteShare#play'
 }
 %}
 


### PR DESCRIPTION
Just for Google and Facebook; Twitter still gets a short URL.
This also moves the #play hash to the end.
