### PR TITLE
[bug 1096489] Temporarily disable doorhangers on dev browser firstrun for Mac users

### DIFF
--- a/media/js/firefox/dev-firstrun.js
+++ b/media/js/firefox/dev-firstrun.js
@@ -365,7 +365,7 @@ function onYouTubeIframeAPIReady() {
     }
 
     //Only run the tour if user is on Firefox 35 for desktop.
-    if (window.isFirefox() && !window.isFirefoxMobile() && window.getFirefoxMasterVersion() >= 35) {
+    if (window.isFirefox() && !window.isFirefoxMobile() && window.getFirefoxMasterVersion() >= 35 && !$('html').hasClass('osx')) {
 
         // if viewport is wider than 900px show the tour doorhanger
         if(queryIsLargeScreen.matches) {


### PR DESCRIPTION
See https://bugzilla.mozilla.org/show_bug.cgi?id=989947#c21

Marking this as do-not-merge for now. Still waiting on confirmation if this can get fixed in-product & uplifted, else we might need to temporarily disable for Mac OSX.
