### PR TITLE
Add privacy policy links to dev edition page

### DIFF
--- a/bedrock/firefox/templates/firefox/developer.html
+++ b/bedrock/firefox/templates/firefox/developer.html
@@ -31,6 +31,15 @@
   <h1>{{ _('Built for those who build the Web') }}</h1>
   <h2>{{ _('Introducing the only browser made for developers like you.') }}</h2>
   {{ download_firefox('aurora', icon=False, small=True, simple=True) }}
+  <p class="privacy"><a href="{{ url('privacy.notices.firefox') }}">{{ _('Privacy') }}</a></p>
+
+  {% if l10n_has_tag('new_doorhanger') %}
+  <p class="feedback-note">
+    {{ _('Firefox Developer Edition automatically sends feedback to Mozilla.') }}
+    <a href="{{ url('privacy.notices.firefox') }}#telemetry" class="more">{{ _('Learn more') }}</a>
+  </p>
+  {% endif %}
+
   <img src="{{ media('img/firefox/developer/screenshot.jpg') }}" alt="{{ _('Firefox Developer Edition') }}" class="screenshot" />
 
   <ul class="intro-features">

--- a/media/css/firefox/developer.less
+++ b/media/css/firefox/developer.less
@@ -74,9 +74,14 @@
         margin-bottom: @baseLine * 2;
     }
     .screenshot {
-        margin: @baseLine*3 auto;
+        margin: @baseLine*2 auto @baseLine*3;
         border-radius: 4px;
         box-shadow: 0 4px 10px #000;
+    }
+    .privacy {
+        margin: @baseLine/2 auto 0;
+        font-size: @smallFontSize;
+        opacity: .8;
     }
 }
 
@@ -155,6 +160,15 @@
     .video {
         display: none;
     }
+}
+
+.feedback-note {
+    clear: both;
+    color: @blueprintTextColorSecondary;
+    font-size: @smallFontSize;
+    text-align: center;
+    margin: @baseLine 0 0;
+    opacity: .7;
 }
 
 .video-play {


### PR DESCRIPTION
[Bug 1097399](https://bugzilla.mozilla.org/show_bug.cgi?id=1097399)

This is waiting on https://github.com/mozilla/legal-docs/pull/264 before merging, but can be reviewed now. After https://github.com/mozilla/legal-docs/pull/264 is merged, I'll update this PR to pull the latest legal-docs into bedrock.
