### PR TITLE
Fix Bug 1095548 - Hacks embedable newsletter form not hiding "thank you" message

### DIFF
--- a/bedrock/newsletter/templates/newsletter/includes/form.html
+++ b/bedrock/newsletter/templates/newsletter/includes/form.html
@@ -74,7 +74,7 @@
 
     <div id="newsletter-spinner" class="hidden"></div>
   </form>
-  <div id="newsletter-form-thankyou" class="thank billboard newsletter-form">
+  <div id="newsletter-form-thankyou" class="thank billboard newsletter-form hidden">
     {{ email_form_thankyou() }}
   </div>
 {% elif use_thankyou %}


### PR DESCRIPTION
Simply add the `hidden` class. Tested locally.
