### PR TITLE
Fix Bug 1093985 - https://www.firefox.com/hello/ does not contain Hello content

### DIFF
--- a/etc/httpd/global.conf
+++ b/etc/httpd/global.conf
@@ -844,3 +844,6 @@ RewriteRule ^/hacking/notification/acceptance-email.txt$ https://static.mozilla.
 
 # bug 1071959
 RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/independent(/?.*)$ /b/$1firefox/independent$2 [PT]
+
+# bug 1093985, remove this once the product page is ready
+RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/hello(/?.*)$ https://support.mozilla.org/kb/respond-firefox-hello-invitation-guest-mode [L,R=temp]


### PR DESCRIPTION
Add a temporary redirect to the SUMO article.
