### PR TITLE
Fix bug 920113, 949163: tags should be from all lang files.

### DIFF
--- a/bedrock/firefox/templates/firefox/australis/firstrun-tour.html
+++ b/bedrock/firefox/templates/firefox/australis/firstrun-tour.html
@@ -15,7 +15,7 @@
 {% block telemetry_id %}australis-tour-firstrun-29-release{% endblock %}
 
 {% block doorhanger_title %}
-  {% if l10n_has_tag('new_doorhanger') or settings.DEV %}
+  {% if l10n_has_tag('new_doorhanger') %}
     {# L10n: This is the title for a door-hanger menu that shows in the browser chrome #}
     data-title="{{ _('Take a quick tour') }}"
   {% else %}

--- a/bedrock/firefox/templates/firefox/channel.html
+++ b/bedrock/firefox/templates/firefox/channel.html
@@ -7,7 +7,7 @@
 {# L10n: This is the string for the <title> tag on the page. #}
 
 {% block page_title %}
-  {% if l10n_has_tag('channel_dev_edition') or settings.DEV %}
+  {% if l10n_has_tag('channel_dev_edition') %}
     {{_('Download Firefox Developer Edition or Beta &amp; Help Determine the Next Firefox')}}
   {% else %}
     {{_('Download Firefox Aurora or Beta &amp; Help Determine the Next Firefox')}}
@@ -15,7 +15,7 @@
 {% endblock %}
 
 {% block page_desc %}
-  {% if l10n_has_tag('channel_dev_edition') or settings.DEV %}
+  {% if l10n_has_tag('channel_dev_edition') %}
     {{ _('Download and test Firefox future releases. Experience the newest innovations with the Developer Edition or Beta builds.') }}
   {% else %}
     {{ _('Download and test Firefox future releases. Experience the newest innovations with the Aurora or Beta builds.') }}
@@ -53,7 +53,7 @@
       <div class="download-box mobile" id="beta-mobile">
         {{ download_firefox('beta', icon=False, mobile=True, small=True) }}
       </div>
-      {% if l10n_has_tag('telemetry_notice') or settings.DEV %}
+      {% if l10n_has_tag('telemetry_notice') %}
         <p class="warning">
         {% trans link=url('privacy.notices.firefox') + '#telemetry' %}
           Firefox Beta automatically sends feedback to Mozilla. <a href="{{ link }}">Learn more</a>.
@@ -83,7 +83,7 @@
     <div id="aurora" class="pager-page">
       <h2 class="channel-title channel-title-aurora">{{ high_res_img('img/firefox/channel/title-dev.png', {'alt': 'Firefox Developer Edition', 'width': '214', 'height': '100'}) }}</h2>
       {# L10n: This description applies to Firefox Developer Edition #}
-      {% if l10n_has_tag('channel_dev_edition') or settings.DEV %}
+      {% if l10n_has_tag('channel_dev_edition') %}
         <h3>{{_('Built for those who build the Web')}}</h3>
       {% else %}
         <h3>{{_('The newest innovations in an experimental environment')}}</h3>
@@ -95,7 +95,7 @@
         {{ download_firefox('aurora', icon=False, mobile=True, small=True) }}
       </div>
       <p class="warning">
-        {% if l10n_has_tag('channel_dev_edition') or settings.DEV %}
+        {% if l10n_has_tag('channel_dev_edition') %}
           {% trans link=url('privacy.notices.firefox') + '#telemetry' %}
             Firefox Aurora and Firefox Developer Edition automatically send feedback to Mozilla. <a href="{{ link }}">Learn more</a>.
           {% endtrans %}

--- a/bedrock/firefox/templates/firefox/desktop/index.html
+++ b/bedrock/firefox/templates/firefox/desktop/index.html
@@ -6,7 +6,7 @@
 
 {% block page_title_prefix %}{% endblock %}
 {% block page_title %}
-  {% if l10n_has_tag('home_title_update') or settings.DEV %}
+  {% if l10n_has_tag('home_title_update') %}
     {{ _("Firefox Web browser — Trusted, Flexible, Fast — Committed to you, your privacy and an open Web") }}
   {% else %}
     {{ _("Firefox Web browser — Trusted, Flexible, Fast — There's never been a better time") }}

--- a/bedrock/firefox/templates/firefox/desktop/tips.html
+++ b/bedrock/firefox/templates/firefox/desktop/tips.html
@@ -98,7 +98,7 @@
               <p>
                 {{ _('Click the star to add bookmarks and manage them from the same spot.') }}
                 <a href="https://support.mozilla.org/kb/use-bookmarks-to-save-and-organize-websites">
-                {% if l10n_has_tag('sync_device_note') or settings.DEV %}
+                {% if l10n_has_tag('sync_device_note') %}
                   {{ _('Learn more about bookmarks') }}
                 {% else %}
                   {{ _('Learn more') }}
@@ -129,7 +129,7 @@
               <p>
                 {{ _('Open the menu, select “<strong>Customize</strong>” and drag any button out of the toolbar.') }}
                 <a rel="external" href="https://support.mozilla.org/kb/customize-firefox-controls-buttons-and-toolbars">
-                {% if l10n_has_tag('sync_device_note') or settings.DEV %}
+                {% if l10n_has_tag('sync_device_note') %}
                   {{ _('Learn more about customizing') }}
                 {% else %}
                   {{ _('Learn more') }}
@@ -159,7 +159,7 @@
               <p>
                 {{ _('Open the menu, select “<strong>Customize</strong>” and drag any button into the toolbar or menu.') }}
                 <a rel="external" href="https://support.mozilla.org/kb/customize-firefox-controls-buttons-and-toolbars?src=tips-arrange">
-                {% if l10n_has_tag('sync_device_note') or settings.DEV %}
+                {% if l10n_has_tag('sync_device_note') %}
                   {{ _('Learn more about customizing') }}
                 {% else %}
                   {{ _('Learn more') }}
@@ -179,7 +179,7 @@
 
             <h3>{{ _('Stay in Sync') }}</h3>
             <p>
-            {% if l10n_has_tag('sync_device_note') or settings.DEV %}
+            {% if l10n_has_tag('sync_device_note') %}
               {{ _('Use Sync to magically access your open tabs, passwords and more wherever you use Firefox.') }}
             {% else %}
               {{ _('Use Sync to magically access your open tabs, passwords and more from any device.') }}
@@ -193,7 +193,7 @@
               <p>
                 {{ _('Choose “<strong>Sign in to Sync</strong>” from the menu and make Firefox your own wherever you use it.') }}
                 <a rel="external" href="https://support.mozilla.org/kb/how-do-i-set-up-firefox-sync">
-                {% if l10n_has_tag('sync_device_note') or settings.DEV %}
+                {% if l10n_has_tag('sync_device_note') %}
                   {{ _('Learn more about Sync') }}
                 {% else %}
                   {{ _('Learn more') }}
@@ -223,7 +223,7 @@
               <p>
                 {{ _('Select “<strong>Customize</strong>” from the menu and drag in the add-ons you want.') }}
                 <a rel="external" href="https://support.mozilla.org/kb/find-and-install-add-ons-add-features-to-firefox">
-                {% if l10n_has_tag('sync_device_note') or settings.DEV %}
+                {% if l10n_has_tag('sync_device_note') %}
                   {{ _('Learn more about add-ons') }}
                 {% else %}
                   {{ _('Learn more') }}

--- a/bedrock/firefox/templates/firefox/desktop/trust.html
+++ b/bedrock/firefox/templates/firefox/desktop/trust.html
@@ -61,7 +61,7 @@
 
           <a class="more" rel="external" href="https://support.mozilla.org/kb/private-browsing-browse-web-without-saving-info">{{ _('Learn how to open a private window') }}</a>
         </li>
-        {% if l10n_has_tag('forget_button') or settings.DEV %}
+        {% if l10n_has_tag('forget_button') %}
         <li id="privacy-forget" class="last">
           <h3>{{ _('Forget Button') }}</h3>
 

--- a/bedrock/firefox/templates/firefox/new.html
+++ b/bedrock/firefox/templates/firefox/new.html
@@ -74,7 +74,7 @@
     <div class="row">
       <img src="{{ media('img/firefox/new/firefox-logo.png?2013-06') }}" alt="Firefox" />
       <h1 class="large">
-      {% if l10n_has_tag('fx10_independent') or settings.DEV %}
+      {% if l10n_has_tag('fx10_independent') %}
         {{ _('Choose Independent.') }}
         <br>
         {{ _('Choose Firefox.') }}
@@ -106,7 +106,7 @@
             <ul>
               <li><a href="{{ url('firefox.desktop.index') }}">{{_('Learn more about Firefox for desktop')}}</a></li>
               <li><a href="https://support.mozilla.org/products/firefox">{{_('Need help?')}}</a></li>
-              {% if l10n_has_tag('mobile_links') or settings.DEV %}
+              {% if l10n_has_tag('mobile_links') %}
               <li><a href="{{settings.GOOGLE_PLAY_FIREFOX_LINK }}">{{_('Get Firefox on your Android device')}}</a></li>
               <li><a href="{{ url('firefox.os.index') }}">{{_('Learn about Firefox OS')}}</a></li>
               {% endif %}
@@ -126,7 +126,7 @@
           </div>
           <div class="ios-links-wrapper latest-links-wrapper">
             <ul>
-              {% if l10n_has_tag('mobile_links') or settings.DEV %}
+              {% if l10n_has_tag('mobile_links') %}
               <li>
                 <a href="{{ settings.GOOGLE_PLAY_FIREFOX_LINK }}">{{_('Get Firefox on your Android device')}}</a>
               </li>

--- a/bedrock/firefox/templates/firefox/nightly_firstrun.html
+++ b/bedrock/firefox/templates/firefox/nightly_firstrun.html
@@ -72,7 +72,7 @@
   </div>
 
   {% if not request.locale.startswith('en') %}
-    {% if l10n_has_tag('promo_locale') or settings.DEV %}
+    {% if l10n_has_tag('promo_locale') %}
     {# The following block is entirely defined by locales, and the placeholder in en-US here will never be exposed to production #}
       <div class="blue-box l10n">
         {% l10n promo_locale %}

--- a/bedrock/firefox/templates/firefox/privacy_tour/tour.html
+++ b/bedrock/firefox/templates/firefox/privacy_tour/tour.html
@@ -66,7 +66,7 @@
                 {{ _('%s lets you <br>search anonymously')|format('DuckDuckGo') }}
               </h2>
               <ul>
-                {% if l10n_has_tag('tracking_update') or settings.DEV %}
+                {% if l10n_has_tag('tracking_update') %}
                   <li>{{ _('Get great results with no tracking') }}</li>
                 {% else %}
                   <li>{{ _('Get great results with less tracking') }}</li>

--- a/bedrock/firefox/templates/firefox/sync-new.html
+++ b/bedrock/firefox/templates/firefox/sync-new.html
@@ -54,7 +54,7 @@
 
       <div class="show-not-fx warning">
         <p>
-          {% if l10n_has_tag('firefox_sync_non_fx') or settings.DEV %}
+          {% if l10n_has_tag('firefox_sync_non_fx') %}
             {{ _('Sync is just one of the great features you’ll only get with Firefox.') }}
           {% else %}
             {{ _('Sync is just one of the great features you’ll only get with Firefox. Discover them all!') }}

--- a/bedrock/firefox/templates/firefox/sync-old.html
+++ b/bedrock/firefox/templates/firefox/sync-old.html
@@ -28,7 +28,7 @@
     </header>
     <section>
       <ol>
-        {% if l10n_has_tag('sync_new_markup') or settings.DEV %}
+        {% if l10n_has_tag('sync_new_markup') %}
           <li>{% trans url='https://support.mozilla.org/kb/learn-more-about-the-design-of-new-firefox' %}
             Open the <a class="menu" href="{{ url }}#w_a-handy-new-menu">menu</a> in the top right of Firefox and select “<strong>Sign in to Sync.</strong>”
           {% endtrans %}</li>
@@ -61,7 +61,7 @@
     </header>
     <section>
       <p>
-      {% if l10n_has_tag('sync_new_markup') or settings.DEV %}
+      {% if l10n_has_tag('sync_new_markup') %}
         {% trans url=settings.GOOGLE_PLAY_FIREFOX_LINK %}
           <a href="{{ url }}">Download Firefox for Android</a> to sync between your desktop and mobile devices.
         {% endtrans %}

--- a/bedrock/firefox/templates/firefox/sync.html
+++ b/bedrock/firefox/templates/firefox/sync.html
@@ -2,7 +2,7 @@
  # License, v. 2.0. If a copy of the MPL was not distributed with this
  # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
 
-{% if l10n_has_tag('firefox_sync_redesign') or settings.DEV %}
+{% if l10n_has_tag('firefox_sync_redesign') %}
   {% include 'firefox/sync-new.html' %}
 {% else %}
   {% include 'firefox/sync-old.html' %}

--- a/bedrock/mozorg/templates/mozorg/about.html
+++ b/bedrock/mozorg/templates/mozorg/about.html
@@ -60,7 +60,7 @@
     </li>
     <li>
       <h4><a href="https://careers.mozilla.org/">{{ _('Career center') }}</a></h4>
-      {% if l10n_has_tag('about_links') or settings.DEV %}
+      {% if l10n_has_tag('about_links') %}
       <p>{{ _('Want to work at Mozilla? Apply today!') }}</p>
       {% else %}
       <p>{{ _('Want to work on Firefox? Apply today!') }}</p>
@@ -78,7 +78,7 @@
       <h4><a href="{{ url('mozorg.contact.spaces.spaces-landing') }}">{{ _('Locations & contacts') }}</a></h4>
       <p>{{ _('Addresses, emails, support and feedback forms') }}</p>
     </li>
-    {% if l10n_has_tag('about_links') or settings.DEV %}
+    {% if l10n_has_tag('about_links') %}
     <li>
       <h4><a href="{{ url('foundation.moco') }} ">{{ _('The Mozilla Corporation') }} </a></h4>
       <p>{{ _('A corporation that serves the public good. Seriously.') }}</p>
@@ -107,7 +107,7 @@
       <h4><a href="{{ php_url('/about/partnerships') }}">{{ _('Mozilla partnerships') }}</a></h4>
       <p>{{ _('Details about partnering with us') }}</p>
     </li>
-    {% if l10n_has_tag('about_links') or settings.DEV %}
+    {% if l10n_has_tag('about_links') %}
     <li>
       <h4><a href="{{ url('foundation.index') }}">{{ _('The Mozilla Foundation') }}</a></h4>
       <p>{{ _('The non-profit organization behind Firefox and all Mozilla products') }}</p>

--- a/bedrock/mozorg/templates/mozorg/about/manifesto.html
+++ b/bedrock/mozorg/templates/mozorg/about/manifesto.html
@@ -2,7 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
 
-{% if not settings.DEV and not l10n_has_tag('manifesto_landing') %}
+{% if not l10n_has_tag('manifesto_landing') %}
   {#- Show the old page if the landing page is not localized yet -#}
   {% include 'mozorg/about/manifesto-details.html' %}
 {% else %}
@@ -225,7 +225,7 @@
                   <ul class="resources">
                     <li><a href="https://groups.google.com/forum/#!forum/mozilla.governance">{{ _('Participate in our governance forum') }}</a></li>
 
-                    {% if l10n_has_tag('join-us') or settings.DEV %}
+                    {% if l10n_has_tag('join-us') %}
                       <li><a href="{{ url('mozorg.contribute') }}">{{ _('Join us as a volunteer') }}</a></li>
                       <li><a href="{{ url('mozorg.contribute.studentambassadors.landing') }}">{{ _('Join us as a student ambassador') }}</a></li>
                     {% else %}

--- a/bedrock/mozorg/templates/mozorg/contribute/contribute-base.html
+++ b/bedrock/mozorg/templates/mozorg/contribute/contribute-base.html
@@ -18,7 +18,7 @@
   {{ js('contribute-2015') }}
 {% endblock %}
 
-{% if l10n_has_tag('contribute_2015', 'mozorg/contribute') or settings.DEV %}
+{% if l10n_has_tag('contribute_2015') %}
   {% block site_header_nav %}{% endblock %}
   {% block site_header_logo %}{% endblock %}
 {% endif %}
@@ -26,7 +26,7 @@
 {% block content %}
 <main role="main">
 
-{% if l10n_has_tag('contribute_2015', 'mozorg/contribute') or settings.DEV %}
+{% if l10n_has_tag('contribute_2015') %}
 {% block contrib_head %}
   <header class="page-head">
     <div class="contribute-masthead">
@@ -107,7 +107,7 @@
 
   {% block contrib_content %}{% endblock contrib_content %}
 
-{% if l10n_has_tag('contribute_2015', 'mozorg/contribute') or settings.DEV %}
+{% if l10n_has_tag('contribute_2015') %}
   {% block contrib_footer %}
   <section class="section contrib-extra">
     <div class="container">

--- a/bedrock/mozorg/templates/mozorg/contribute/contribute-old.html
+++ b/bedrock/mozorg/templates/mozorg/contribute/contribute-old.html
@@ -106,7 +106,7 @@
         <img src="{{ media('/img/contribute/logos/qmo.png') }}" alt="">
         <h3>{{_('Quality Assurance')}}</h3>
         <p>
-        {% if l10n_has_tag('contribute_mayupdates', 'mozorg/contribute') or settings.DEV %}
+        {% if l10n_has_tag('contribute_mayupdates') %}
           {% trans %}
           Quality Assurance testing is one of the easiest ways to get started with Mozilla and is a great way to get familiar with our code and tools.
           {% endtrans %}
@@ -165,7 +165,7 @@
         </p>
       </li>
 
-    {% if l10n_has_tag('contribute_mayupdates', 'mozorg/contribute') or settings.DEV %}
+    {% if l10n_has_tag('contribute_mayupdates') %}
       <li id="markeplace">
         <img src="{{ media('/img/contribute/logos/marketplace.png') }}" alt="">
         <h3>{{ _('Firefox Marketplace') }}</h3>
@@ -181,7 +181,7 @@
         <img src="{{ media('/img/contribute/logos/addons.png') }}" alt="">
         <h3>{{_('Add-ons') }}</h3>
         <p>
-        {% if l10n_has_tag('contribute_mayupdates', 'mozorg/contribute') or settings.DEV %}
+        {% if l10n_has_tag('contribute_mayupdates') %}
           {% trans addons_url='https://addons.mozilla.org/developers/docs/getting-started', addons_wiki='https://wiki.mozilla.org/Marketplace/Contributing/Addons' %}
           Add-ons are what make Firefox the most extensible and customizable browser available. Get started <a href="{{ addons_url }}">building an add-on</a>, and <a href="{{ addons_wiki }}">learn more about the different ways you can contribute</a>.
           {% endtrans %}
@@ -217,7 +217,7 @@
         <img src="{{ media('/img/contribute/logos/webmaker.png') }}" alt="">
         <h3>{{_('Education') }}</h3>
         <p>
-      {% if l10n_has_tag('webmaker_update', 'mozorg/contribute') or settings.DEV %}
+      {% if l10n_has_tag('webmaker_update') %}
         {% trans webmaker='https://webmaker.org/',
             webmaker_tools='https://webmaker.org/tools/',
             webmaker_resources='https://webmaker.org/resources/',
@@ -233,7 +233,7 @@
         </p>
       </li>
 
-    {% if l10n_has_tag('contribute_fellowship', 'mozorg/contribute') or settings.DEV %}
+    {% if l10n_has_tag('contribute_fellowship') %}
       <li id="fellowship">
         <img src="{{ media('/img/contribute/logos/fellowship.png') }}" alt="">
         <h3>{{ _('Fellowships') }}</h3>
@@ -245,7 +245,7 @@
       </li>
     {% endif %}
 
-    {% if l10n_has_tag('hiveglobal', 'mozorg/contribute') or settings.DEV %}
+    {% if l10n_has_tag('hiveglobal') %}
       <li id="hivenetworks">
         <img src="{{ media('/img/contribute/logos/hive.png') }}" alt="">
         <h3>{{ _('Hive Networks') }}</h3>

--- a/bedrock/mozorg/templates/mozorg/contribute/index.html
+++ b/bedrock/mozorg/templates/mozorg/contribute/index.html
@@ -4,7 +4,7 @@
 
 {% add_lang_files "mozorg/contribute" %}
 
-{% if l10n_has_tag('contribute_2015', 'mozorg/contribute') or settings.DEV %}
+{% if l10n_has_tag('contribute_2015') %}
   {% include 'mozorg/contribute/contribute.html' %}
 {% else %}
   {% include 'mozorg/contribute/contribute-old.html' %}

--- a/bedrock/mozorg/templates/mozorg/home.html
+++ b/bedrock/mozorg/templates/mozorg/home.html
@@ -60,7 +60,7 @@
     <ul class="accordion">
 
 {# Position 1: "Shape Environments" #}
-    {% if l10n_has_tag('promo_lightbeam') or settings.DEV %}
+    {% if l10n_has_tag('promo_lightbeam') %}
       <li id="panel-lightbeam" class="panel" tabindex="0">
         {# L10n: The active word should be wrapped in <i></i> tags, though it may appear at a different position in the translated title. #}
         <h2 class="panel-title">{{ _('<i>Watch</i> the watchers') }}</h2>
@@ -91,7 +91,7 @@
     {% endif %}
 
 {# Position 2: "Build Products" #}
-    {% if l10n_has_tag('promo_fxdesktop') or settings.DEV %}
+    {% if l10n_has_tag('promo_fxdesktop') %}
       <li id="panel-fxdesktop" class="panel" tabindex="0">
         {# L10n: This is the label seen when the panel is collapsed so it may need to be altered to fit a limited space. The active phrase should be wrapped in <i></i> tags. #}
         <h2 class="panel-title">{{ _('<i>Try the best</i> Firefox yet') }}</h2>
@@ -123,7 +123,7 @@
     {% endif %}
 
 {# Position 3: "Enable Community" #}
-    {% if l10n_has_tag('promo_sumo') or settings.DEV %}
+    {% if l10n_has_tag('promo_sumo') %}
       <li id="panel-sumo" class="panel" tabindex="0">
         {# L10n: The active word should be wrapped in <i></i> tags, though it may appear at a different position in the translated title. #}
         <h2 class="panel-title">{{ _('<i>Help</i> Mozilla users') }}</h2>
@@ -173,7 +173,7 @@
     {#
     New Webmaker Party promo below. Will likely be used in the near future.
 
-    if l10n_has_tag('promo_makerparty') or settings.DEV
+    if l10n_has_tag('promo_makerparty')
       <li id="panel-makerparty" class="panel" tabindex="0">
         { L10n: The active word should be wrapped in <i></i> tags, though it may appear at a different position in the translated title. }
         { L10n: This <br> is strictly for visual formatting; translations can omit or reposition as needed. }
@@ -191,7 +191,7 @@
         </div>
       </li>
     #}
-    {% if l10n_has_tag('promo_webmaker') or settings.DEV %}
+    {% if l10n_has_tag('promo_webmaker') %}
       <li id="panel-webmaker" class="panel" tabindex="0">
         {# L10n: The active word should be wrapped in <i></i> tags, though it may appear at a different position in the translated title. #}
         <h2 class="panel-title">{{ _('<i>Learn</i> the Web') }}</h2>

--- a/bedrock/mozorg/templates/mozorg/home/home-new.html
+++ b/bedrock/mozorg/templates/mozorg/home/home-new.html
@@ -90,7 +90,7 @@
     <div class="promo-grid-inner">
       <ul class="promo-grid {% if tweets %}has-twitter-promo{% endif %}">
       {# L10n: Begin home page promos. Line breaks are for visual formatting only. #}
-      {% if l10n_has_tag('fx10_independent', 'mozorg/home/index') or settings.DEV %}
+      {% if l10n_has_tag('fx10_independent') %}
         <li id="promo-1" class="item promo-large-portrait firefox-independent" data-name="Firefox: The indepedent choice" tabindex="0">
           <h2 class="primary go">{{ _('Firefox: The independent choice') }}</h2>
           <a class="panel-link" href="{{ url('firefox.independent') }}#play">
@@ -154,7 +154,7 @@
             <h2>{{ _('Volunteer <br>with Mozilla') }}</h2>
           </a>
         </li>
-      {% if l10n_has_tag('fx10_independent', 'mozorg/home/index') or settings.DEV %}
+      {% if l10n_has_tag('fx10_independent') %}
         <li id="promo-10" class="item promo-large-portrait firefox-developer" tabindex="0" data-name="Introducing Firefox Developer Edition">
           <h2 class="primary go">{{ _('Introducing Firefox Developer Edition') }}</h2>
           <a class="panel-link" href="{{ url('firefox.developer') }}">
@@ -298,7 +298,7 @@
   <button id="scroll-prompt">{{ _('Discover more') }}</button>
 </main>
 
-{% if l10n_has_tag('fx10_independent', 'mozorg/home/index') or settings.DEV %}
+{% if l10n_has_tag('fx10_independent') %}
 <article id="fx10-splash">
   <div class="container">
     <h2 class="main-title">{{ _('Choose Independent') }}</h2>

--- a/bedrock/mozorg/templates/mozorg/plugincheck.html
+++ b/bedrock/mozorg/templates/mozorg/plugincheck.html
@@ -146,7 +146,7 @@
       <p>{{_('We automatically detected your plugins above, to view your installed plugins in Firefox follow these steps:')}}</p>
       <ol>
         <li>
-            {% if l10n_has_tag('plugin_updated_content') or settings.DEV %}
+            {% if l10n_has_tag('plugin_updated_content') %}
               {{_('Open the <span class="menu">menu</span>.')}}
             {% else %}
               {{_('Open the Tools menu.')}}
@@ -161,7 +161,7 @@
       <p>{{_('In Firefox:')}}</p>
       <ol>
         <li>
-          {% if l10n_has_tag('plugin_updated_content') or settings.DEV %}
+          {% if l10n_has_tag('plugin_updated_content') %}
             {{_('Open the <span class="menu">menu</span>.')}}
           {% else %}
             {{_('Open the Tools menu.')}}
@@ -170,14 +170,14 @@
         <li>{{_('Choose Add-ons.')}}</li>
         <li>{{_('Click the plugins tab.')}}</li>
         <li>
-            {% if l10n_has_tag('plugin_updated_content') or settings.DEV %}
+            {% if l10n_has_tag('plugin_updated_content') %}
               {{_('Click on the drop down next to the plugin you wish to disable.')}}
             {% else %}
               {{_('Click on a plugin in the list.')}}
             {% endif %}
         </li>
         <li>
-            {% if l10n_has_tag('plugin_updated_content') or settings.DEV %}
+            {% if l10n_has_tag('plugin_updated_content') %}
               {{_('Select "Never Activate" from the available choices.')}}
             {% else %}
               {{_('Click the Disable button.')}}
@@ -185,7 +185,7 @@
         </li>
       </ol>
       <p class="small">
-          {% if l10n_has_tag('plugin_disable_warning') or settings.DEV %}
+          {% if l10n_has_tag('plugin_disable_warning') %}
             {{ _('Caution: disabling a plugin means that you will no longer be able to do certain things. For example, if you disable Flash, you will not be able to watch videos on some streaming video websites.') }}
           {% else %}
             {{ _('Caution: disabling a plugin means that you will no longer be able to do certain things. For example, if you disable Flash, you will not be able to watch videos on YouTube.') }}

--- a/bedrock/mozorg/tests/test_util.py
+++ b/bedrock/mozorg/tests/test_util.py
@@ -41,8 +41,8 @@ class TestTwitterAPI(TestCase):
                                                                   count=100)
 
 
+@override_settings(ROOT=ROOT, DEV=False)
 class TestHideContribForm(TestCase):
-    @override_settings(ROOT=ROOT)
     def test_lang_file_is_hiding(self):
         """
         `hide_contrib_form` should return true if lang file has the

--- a/bedrock/mozorg/views.py
+++ b/bedrock/mozorg/views.py
@@ -364,7 +364,7 @@ def new_home(request, locale=None):
 def home(request):
     locale = l10n_utils.get_locale(request)
     new_template = 'mozorg/home/home-new.html'
-    if l10n_utils.template_is_active(new_template, locale) or settings.DEV:
+    if l10n_utils.template_is_active(new_template, locale):
         return new_home(request, locale=locale)
     else:
         return HomeTestView.as_view()(request)

--- a/lib/l10n_utils/__init__.py
+++ b/lib/l10n_utils/__init__.py
@@ -37,6 +37,7 @@ def render(request, template, context=None, **kwargs):
 
     # Every template gets its own .lang file, so figure out what it is
     # and pass it in the context
+    context['template'] = template
     context['langfile'] = get_lang_path(template)
 
     # Get the available translation list of the current page

--- a/lib/l10n_utils/dotlang.py
+++ b/lib/l10n_utils/dotlang.py
@@ -223,22 +223,14 @@ def lang_file_is_active(path, lang=None):
     return lang_file_has_tag(path, lang, 'active')
 
 
-def lang_file_has_tag(path, lang=None, tag='active'):
-    """
-    Return True if the lang file exists and has a line like "^## tag ##"
-    at the top. Stops looking at the line that doesn't have a tag.
-
-    Always returns true for the default lang.
+def lang_file_tag_set(path, lang=None):
+    """Return a set of tags for a specific lang file and locale.
 
     :param path: the relative lang file name
     :param lang: the language code or the lang of the request if omitted
-    @param tag: The string that should appear between ##'s. Can contain
-       alphanumerics and "_".
-    @return: bool
+    :return: set of strings
     """
     lang = lang or fix_case(translation.get_language())
-    if lang == settings.LANGUAGE_CODE:
-        return True
     rel_path = os.path.join('locale', lang, '%s.lang' % path)
     cache_key = 'tag:%s' % rel_path
     tag_set = cache.get(cache_key)
@@ -261,7 +253,26 @@ def lang_file_has_tag(path, lang=None, tag='active'):
 
         cache.set(cache_key, tag_set, settings.DOTLANG_CACHE)
 
-    return tag in tag_set
+    return tag_set
+
+
+def lang_file_has_tag(path, lang=None, tag='active'):
+    """
+    Return True if the lang file exists and has a line like "^## tag ##"
+    at the top. Stops looking at the line that doesn't have a tag.
+
+    Always returns true for the default lang.
+
+    :param path: the relative lang file name
+    :param lang: the language code or the lang of the request if omitted
+    @param tag: The string that should appear between ##'s. Can contain
+       alphanumerics and "_".
+    @return: bool
+    """
+    if settings.DEV or lang == settings.LANGUAGE_CODE:
+        return True
+
+    return tag in lang_file_tag_set(path, lang)
 
 
 def get_translations_for_langfile(langfile):

--- a/lib/l10n_utils/helpers.py
+++ b/lib/l10n_utils/helpers.py
@@ -12,6 +12,7 @@ from django.conf import settings
 from django.utils.translation import get_language
 
 from dotlang import translate, lang_file_has_tag
+from gettext import template_has_tag
 
 
 def install_lang_files(ctx):
@@ -71,9 +72,11 @@ def js_escape(string):
 @jingo.register.function
 @jinja2.contextfunction
 def l10n_has_tag(ctx, tag, langfile=None):
-    """Return boolean whether the given lang file has the given tag."""
-    langfile = langfile or ctx.get('langfile')
-    return lang_file_has_tag(langfile, tag=tag)
+    """Return boolean whether the given template's lang files have the given tag."""
+    if langfile:
+        return lang_file_has_tag(langfile, tag=tag)
+    else:
+        return template_has_tag(ctx['template'], ctx['LANG'], tag)
 
 
 def get_locale(lang):

--- a/lib/l10n_utils/tests/test_dotlang.py
+++ b/lib/l10n_utils/tests/test_dotlang.py
@@ -32,6 +32,7 @@ LANG_FILES = 'test_file'
 TEMPLATE_DIRS = (os.path.join(ROOT, 'templates'),)
 
 
+@override_settings(DEV=False, LANGUAGE_CODE='en-US')
 @patch.object(env, 'loader', FileSystemLoader(TEMPLATE_DIRS))
 @patch.object(settings, 'ROOT_URLCONF', 'lib.l10n_utils.tests.test_files.urls')
 @patch.object(settings, 'ROOT', ROOT)
@@ -39,7 +40,6 @@ class TestLangFilesActivation(TestCase):
     def setUp(self):
         clear_url_caches()
 
-    @override_settings(DEV=False)
     def test_lang_file_is_active(self):
         """
         `lang_file_is_active` should return true if lang file has the
@@ -65,7 +65,6 @@ class TestLangFilesActivation(TestCase):
         ok_(not lang_file_has_tag('main', 'de', 'tag_after_non_tag_lines'))
         ok_(not lang_file_has_tag('main', 'de', 'no_such_tag'))
 
-    @override_settings(DEV=False)
     def test_active_locale_not_redirected(self):
         """ Active lang file should render correctly.
 
@@ -77,7 +76,6 @@ class TestLangFilesActivation(TestCase):
         doc = pq(response.content)
         eq_(doc('h1').text(), 'Die Lage von Mozilla')
 
-    @override_settings(DEV=False, LANGUAGE_CODE='en-US')
     def test_inactive_locale_redirected(self):
         """ Inactive locale should redirect to en-US. """
         response = self.client.get('/de/inactive-de-lang-file/')
@@ -98,7 +96,6 @@ class TestLangFilesActivation(TestCase):
         doc = pq(response.content)
         eq_(doc('h1').text(), 'Die Lage von Mozilla')
 
-    @override_settings(DEV=False)
     def test_active_alternate_lang_file(self):
         """Template with active alternate lang file should activate from it."""
         response = self.client.get('/de/state-of-mozilla/')

--- a/lib/l10n_utils/tests/test_helpers.py
+++ b/lib/l10n_utils/tests/test_helpers.py
@@ -13,13 +13,18 @@ from l10n_utils import helpers
 
 @patch.object(helpers, 'lang_file_has_tag')
 class TestL10nHasTag(TestCase):
-    def test_gets_right_langfile(self, lfht_mock):
-        helpers.l10n_has_tag({'langfile': 'dude'}, 'abide')
-        lfht_mock.assert_called_with('dude', tag='abide')
-
-    def test_override_langfile(self, lfht_mock):
-        helpers.l10n_has_tag({'langfile': 'dude'}, 'abide', 'uli')
+    def test_uses_langfile(self, lfht_mock):
+        """If langfile param specified should only check that file."""
+        helpers.l10n_has_tag({'langfile': 'dude'}, 'abide', langfile='uli')
         lfht_mock.assert_called_with('uli', tag='abide')
+
+    @patch.object(helpers, 'template_has_tag')
+    def test_checks_template_by_default(self, tht_mock, lfht_mock):
+        helpers.l10n_has_tag({'langfile': 'dude',
+                              'template': 'home.html',
+                              'LANG': 'de'}, 'abide')
+        tht_mock.assert_called_with('home.html', 'de', 'abide')
+        self.assertFalse(lfht_mock.called)
 
 
 class TestCurrentLocale(TestCase):


### PR DESCRIPTION
Tags (including "active") should be from all .lang files associated with
a template. So l10n_has_tag() as well as the active state of a page
should include information from all included .lang files from
add_lang_file and set_lang_files calls.

This also moves the check for DEV==True to the helpers, so checking
settings.DEV in templates is no longer necessary.
