### PR TITLE
Fix Bug 1098535 - Replace lang="en-US" with lang="en" to make the content region-neutral

### DIFF
--- a/bedrock/base/templates/base-resp.html
+++ b/bedrock/base/templates/base-resp.html
@@ -3,7 +3,7 @@
 <!doctype html>
 {# Note the "windows" class, without javascript platform-specific
      assets default to windows #}
-<html class="windows x86 no-js" lang="{{ LANG }}" dir="{{ DIR }}" data-latest-firefox="{{ latest_firefox_version }}" data-esr-versions="{{ esr_firefox_versions }}">
+<html class="windows x86 no-js" lang="{{ LANG|replace('en-US', 'en') }}" dir="{{ DIR }}" data-latest-firefox="{{ latest_firefox_version }}" data-esr-versions="{{ esr_firefox_versions }}">
   <head>
     <meta charset="utf-8">{# Note: Must be within first 512 bytes of page #}
 

--- a/bedrock/base/templates/base.html
+++ b/bedrock/base/templates/base.html
@@ -2,7 +2,7 @@
 <!doctype html>
 {# Note the "windows" class, without javascript platform-specific
      assets default to windows #}
-<html class="windows x86 no-js" lang="{{ LANG }}" dir="{{ DIR }}" data-latest-firefox="{{ latest_firefox_version }}" data-esr-versions="{{ esr_firefox_versions }}">
+<html class="windows x86 no-js" lang="{{ LANG|replace('en-US', 'en') }}" dir="{{ DIR }}" data-latest-firefox="{{ latest_firefox_version }}" data-esr-versions="{{ esr_firefox_versions }}">
   <head>
     <meta charset="utf-8">{# Note: Must be within first 512 bytes of page #}
 

--- a/bedrock/base/templates/includes/canonical-url.html
+++ b/bedrock/base/templates/includes/canonical-url.html
@@ -1,7 +1,7 @@
-    <link rel="canonical" hreflang="{{ LANG }}" href="{{ settings.CANONICAL_URL + '/' + LANG + canonical_path }}">
+    <link rel="canonical" hreflang="{{ LANG|replace('en-US', 'en') }}" href="{{ settings.CANONICAL_URL + '/' + LANG + canonical_path }}">
     <link rel="alternate" hreflang="x-default" href="{{ settings.CANONICAL_URL + canonical_path }}">
     {% if translations -%}
     {% for code, label in translations|dictsort -%}
-    <link rel="alternate" hreflang="{{ code }}" href="{{ settings.CANONICAL_URL + '/' + code + canonical_path }}" title="{{ label|safe }}">
+    <link rel="alternate" hreflang="{{ code|replace('en-US', 'en') }}" href="{{ settings.CANONICAL_URL + '/' + code + canonical_path }}" title="{{ label|safe|replace('English (US)', 'English') }}">
     {% endfor -%}
     {% endif %}

--- a/bedrock/base/templates/includes/lang_switcher.html
+++ b/bedrock/base/templates/includes/lang_switcher.html
@@ -9,7 +9,7 @@
     {% for code, label in translations|dictsort -%}
       {# Don't escape the label as it may include entity references
        # like "Português (do&nbsp;Brasil)" (Bug 861149) #}
-      <option lang="{{ code }}" value="{{ code }}"{{ code|ifeq(LANG, " selected") }}>{{ label|safe }}</option>
+      <option lang="{{ code }}" value="{{ code }}"{{ code|ifeq(LANG, " selected") }}>{{ label|safe|replace('English (US)', 'English') }}</option>
     {% endfor %}
   </select>
   <noscript>

--- a/media/css/firefox/os/firefox-os-ie.less
+++ b/media/css/firefox/os/firefox-os-ie.less
@@ -50,7 +50,7 @@
   z-index: -10 !important;
 }
 
-html[lang="en-US"] {
+html[lang|="en"] {
   #get-firefox-os #adaptive-wrapper.scroller-on {
     #adapt-feature-sprite-plus {
       top: 286px;

--- a/media/css/firefox/os/firefox-os.less
+++ b/media/css/firefox/os/firefox-os.less
@@ -646,7 +646,7 @@ section p, header p {
 }
 
 // sprites (dotted lines/plus) should essentially only show for English language pages
-html[lang="en-US"] #get-firefox-os {
+html[lang|="en"] #get-firefox-os {
   #adapt-features .content {
     top: 105px;
   }
@@ -771,7 +771,7 @@ html[lang="en-US"] #get-firefox-os {
 }
 
 // hack for en-US visitors in India
-html[lang='en-US'].en-IN {
+html[lang|="en"].en-IN {
   .phone-wrapper .screen {
     background-image: url('/media/img/firefox/os/phone/screens-en-in.jpg?2013-09');
   }
@@ -1529,7 +1529,7 @@ html[lang="pl"] {
 }
 
 // get sprites (dotted lines) to sit on top of phone
-html[lang="en-US"].js {
+html[lang|="en"].js {
   #get-firefox-os {
     .adapt-feature-sprite {
       display: block;
@@ -1751,7 +1751,7 @@ html[lang="en-US"].js {
       }
     }
   }
-  html[lang="en-US"] {
+  html[lang|="en"] {
     #masthead {
       ul li {
         margin: 0 10px;
@@ -1900,7 +1900,7 @@ html[lang="en-US"].js {
     }
   }
   // content top pos for en-US only
-  html[lang="en-US"] {
+  html[lang|="en"] {
     #get-firefox-os {
       .content {
         left: 80px;
@@ -2126,7 +2126,7 @@ html[lang="en-US"].js {
     }
   }
   // content top pos for en-US only
-  html[lang="en-US"] #get-firefox-os {
+  html[lang|="en"] #get-firefox-os {
     .content {
       left: 65px;
     }

--- a/media/css/foundation/annual2012.less
+++ b/media/css/foundation/annual2012.less
@@ -258,7 +258,7 @@ dl.faq dt {
 	margin-bottom: @baseLine;
 }
 
-html[lang="en-US"] {
+html[lang|="en"] {
 	.banner h1 span {
 		.image-replaced;
 		display: block;
@@ -322,7 +322,7 @@ html[dir="rtl"] {
 }
 
 @media (-webkit-min-device-pixel-ratio: 2), (min-resolution: 192dpi) {
-	html[lang="en-US"] {
+	html[lang|="en"] {
 		.banner h1 span {
 			background-image: url(/media/img/foundation/annualreport/2012/state-of-mozilla-high-res.png);
 		}
@@ -610,7 +610,7 @@ html[lang="ar"] {
 }
 
 /* Larger font size in English */
-html[lang="en-US"] .banner blockquote {
+html[lang|="en"] .banner blockquote {
   font-size: 48px;
   line-height: 1.1;
 }

--- a/media/css/mozorg/home/home-promo.less
+++ b/media/css/mozorg/home/home-promo.less
@@ -287,9 +287,7 @@
     }
 }
 
-.lang-en-US,
-.lang-en-GB,
-.lang-en-ZA {
+html[lang|="en"] {
     .promo-large-landscape,
     .promo-large-portrait {
         h3 {
@@ -682,9 +680,7 @@
     }
 }
 
-.lang-en-US,
-.lang-en-GB,
-.lang-en-ZA {
+html[lang|="en"] {
     .promo-small-landscape.firefox-download {
         .secondary .download-link .download-subtitle {
             font-size: 18px;
@@ -755,9 +751,7 @@
     }
 }
 
-.lang-en-US,
-.lang-en-GB,
-.lang-en-ZA {
+html[lang|="en"] {
     .promo-small-landscape.privacy {
         background-position: bottom left;
         h2 {
@@ -780,9 +774,7 @@
     }
 }
 
-.lang-en-US,
-.lang-en-GB,
-.lang-en-ZA {
+html[lang|="en"] {
     .promo-small-landscape.appmaker {
         background-position: 15px 15px;
         h2 {
@@ -805,9 +797,7 @@
     }
 }
 
-.lang-en-US,
-.lang-en-GB,
-.lang-en-ZA {
+html[lang|="en"] {
     .promo-small-landscape.volunteer {
         h2 {
             padding: 34px @baseLine @baseLine 135px;
@@ -865,9 +855,7 @@
     }
 }
 
-.lang-en-US,
-.lang-en-GB,
-.lang-en-ZA {
+html[lang|="en"] {
     .promo-large-landscape.webmaker {
         h3 {
             padding: (@baseLine * 3) @baseLine 0 @baseLine;
@@ -914,9 +902,7 @@
     }
 }
 
-.lang-en-US,
-.lang-en-GB,
-.lang-en-ZA {
+html[lang|="en"] {
     .promo-large-portrait.firefox-desktop {
         h3 {
             padding: (@baseLine * 5) @baseLine 0 @baseLine;
@@ -964,9 +950,7 @@
     }
 }
 
-.lang-en-US,
-.lang-en-GB,
-.lang-en-ZA {
+html[lang|="en"] {
     .promo-large-portrait.firefox-android {
         h3 {
             padding: (@baseLine * 4) @baseLine 0 @baseLine;
@@ -1310,9 +1294,7 @@
         }
     }
 
-    .lang-en-US,
-    .lang-en-GB,
-    .lang-en-ZA {
+    html[lang|="en"] {
         // force "Teach the Web" to break onto 2 lines in Engligh only.
         .promo-large-landscape.webmaker {
             h2 {

--- a/media/js/firefox/android.js
+++ b/media/js/firefox/android.js
@@ -35,7 +35,7 @@
     }
 
     // show SMS link for all desktop users (en-US only for now)
-    if ($html.attr('lang') === 'en-US' && !$html.hasClass('android') && !$html.hasClass('ios') && !$html.hasClass('fxos')) {
+    if ($html.is('[lang|="en"]') && !$html.hasClass('android') && !$html.hasClass('ios') && !$html.hasClass('fxos')) {
         $.getScript('//geo.mozilla.org/country.js', function() {
             try {
                 if (geoip_country_code().toLowerCase() === 'us') {

--- a/media/js/firefox/os/desktop.js
+++ b/media/js/firefox/os/desktop.js
@@ -6,7 +6,7 @@
 
   var $w = $(window);
 
-  var isUS = $('html').attr('lang') === 'en-US';
+  var isUS = $('html').is('[lang|="en"]');
 
   var isSmallViewport = $w.width() < 760;
   var isTouch = 'ontouchstart' in window || navigator.msMaxTouchPoints || navigator.maxTouchPoints || isSmallViewport;

--- a/media/js/firefox/os/firefox-os.js
+++ b/media/js/firefox/os/firefox-os.js
@@ -29,7 +29,7 @@
         var $provider = $('#provider-links').find('.provider[data-country="' + COUNTRY_CODE + '"]');
 
         // show language content selector if user is in india visiting the en-US/en-GB page
-        if (COUNTRY_CODE.toLowerCase() === 'in' && /en-US|en-GB/.test($('html').attr('lang'))) {
+        if (COUNTRY_CODE.toLowerCase() === 'in' && $('html').is('[lang|="en"]')) {
             var suppressLangContentSelector = false;
 
             // if user has already selected en-IN, don't bug them a second time


### PR DESCRIPTION
Let search engines know the content is not specific to the U.S. The URLs will be kept as-is to avoid further redirections.
