### PR TITLE
Fix bug 1093784: Remove locale URL exemption from security pages.

### DIFF
--- a/bedrock/security/tests/test_views.py
+++ b/bedrock/security/tests/test_views.py
@@ -146,7 +146,8 @@ class TestLastModified(TestCase):
 
 class TestKVRedirects(TestCase):
     def _test_names(self, url_component, expected):
-        path = '/security/known-vulnerabilities/{0}.html'.format(url_component)
+        # old urls lack '/en-US' prefix, but that will be the first redirect.
+        path = '/en-US/security/known-vulnerabilities/{0}.html'.format(url_component)
         resp = self.client.get(path)
         eq_(resp.status_code, 301)
         eq_(expected, resp['Location'].split('/')[-2])

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -68,7 +68,6 @@ SUPPORTED_NONLOCALES += [
     'gameon',
     'robots.txt',
     'credits',
-    'security',
     'contribute.json',
 ]
 

--- a/etc/httpd/global.conf
+++ b/etc/httpd/global.conf
@@ -823,12 +823,12 @@ RewriteRule ^/mozillacareers$ https://wiki.mozilla.org/People/mozillacareers?utm
 # Bug 1026184
 # TODO: enable this after testing and porting/archiving all pages
 #RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?security(/?|/.+)$ /b/$1security$2 [PT]
-RewriteRule ^/security(/?)$ /b/security$1 [PT]
-RewriteRule ^/security/bug-bounty(.*)\.html$ /security/bug-bounty$1/ [L,R=301]
-RewriteRule ^/security/bug-bounty(.*)$ /b/security/bug-bounty$1 [PT]
-RewriteRule ^/security/advisories(.*)$ /b/security/advisories$1 [PT]
-RewriteRule ^/security/announce(.*)$ /b/security/announce$1 [PT]
-RewriteRule ^/security/known-vulnerabilities(.*)$ /b/security/known-vulnerabilities$1 [PT]
+RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?security(/?)$ /b/$1security$2 [PT]
+RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?security/bug-bounty(.*)\.html$ /$1security/bug-bounty$2/ [L,R=301]
+RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?security/bug-bounty(.*)$ /b/$1security/bug-bounty$2 [PT]
+RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?security/advisories(.*)$ /b/$1security/advisories$2 [PT]
+RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?security/announce(.*)$ /b/$1security/announce$2 [PT]
+RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?security/known-vulnerabilities(.*)$ /b/$1security/known-vulnerabilities$2 [PT]
 
 # Bug 1066629
 RewriteRule ^/contribute\.json$ /b/contribute.json [PT]


### PR DESCRIPTION
I can't see any issue this would cause. It fixes the bug because the page was being cached
without varying on locale since the locale wasn't in the URL. However, bedrock was still making a guess
on the best locale for the Accept-Language header of the user that hit the non-cached page, which made
the URL for tabzilla use that locale. Subsequent visitors would get the cached page with whichever tabzilla locale the first user got. There doesn't seem to be a reason to avoid the locale in the URL for /security other than it'll likely never be localized.
