### PR TITLE
[bug 1100861] Temporarily disable firefox desktop intro anim on Firefox 35 (OSX)

### DIFF
--- a/media/js/firefox/desktop/intro-anim.js
+++ b/media/js/firefox/desktop/intro-anim.js
@@ -8,7 +8,15 @@
     var isIE = /MSIE/.test(navigator.userAgent);
     var isTrident = /Trident/.test(navigator.userAgent);
     var isOldOpera= /Presto/.test(navigator.userAgent);
-    var $logo = $('#intro-firefox-logo');
+
+    function cutsTheMustard() {
+        // temporarily disable on Firefox OSX until graphics bug (1083079) is fixed
+        if (window.isFirefox() && window.getFirefoxMasterVersion() >= 35 && $('html').hasClass('osx')) {
+            return false;
+        }
+
+        return supportsInlineSVG() && !isIE && !isTrident && !isOldOpera;
+    }
 
     function supportsInlineSVG () {
         var div = document.createElement('div');
@@ -16,26 +24,12 @@
         return (div.firstChild && div.firstChild.namespaceURI) == 'http://www.w3.org/2000/svg';
     }
 
-    if (isIE || isTrident || isOldOpera || !supportsInlineSVG()) {
+    if (!cutsTheMustard()) {
         // use fallback browser image
         $('body').addClass('no-svg-anim');
     } else {
-
-        // listen for the load event on Firefox logo image
-        // before starting the animation.
-        $logo.one('load', function () {
-            $('body').addClass('svg-anim');
-        }).each(function () {
-            // if the image is already loaded or cached,
-            // call the load event handler.
-            if (this.complete) {
-                $(this).load();
-            }
-        });
-
-        // if there's an error loading the image,
-        // run the animation anyway
-        $logo.one('error', function () {
+        // show svg anim
+        $(window).on('load', function() {
             $('body').addClass('svg-anim');
         });
     }


### PR DESCRIPTION
Due to a Firefox graphics bug on OSX, the /firefox/desktop SVG/CSS intro animation is currently a bit broken on version 35 and up.

I filed [bug 1083079](https://bugzilla.mozilla.org/show_bug.cgi?id=1083079) a while ago and we found the cause of the regression. The bug is being worked on, but in the mean time this disables the animation for OSX users on Firefox 35 or greater. Hopefully it can be resolved soon and we can enable it again.

I also took this opportunity to simplify the animation loading, by using the regular window `load` event instead of waiting for the individual logo to load.
