### PR TITLE
Fix Bug 1097297 - Link to other systems & languages on the Firefox Developer Edition page

### DIFF
--- a/bedrock/firefox/templates/firefox/developer.html
+++ b/bedrock/firefox/templates/firefox/developer.html
@@ -31,7 +31,6 @@
   <h1>{{ _('Built for those who build the Web') }}</h1>
   <h2>{{ _('Introducing the only browser made for developers like you.') }}</h2>
   {{ download_firefox('aurora', icon=False, small=True, simple=True) }}
-  <p class="privacy"><a href="{{ url('privacy.notices.firefox') }}">{{ _('Privacy') }}</a></p>
 
   {% if l10n_has_tag('new_doorhanger') %}
   <p class="feedback-note">

--- a/bedrock/mozorg/templates/mozorg/download_firefox_button.html
+++ b/bedrock/mozorg/templates/mozorg/download_firefox_button.html
@@ -88,7 +88,7 @@
     </small>
   {% endif %}
   {% if show_desktop %}
-    <small class="download-other download-other-desktop os_linux os_linux64 os_osx os_windows"{% if simple %} style="display: none !important;"{% endif %}>
+    <small class="download-other download-other-desktop os_linux os_linux64 os_osx os_windows">
       <a href="{{ product_url('firefox', 'all', build) }}">{{ _('Systems &amp; Languages') }}</a> |
       <a href="{{ product_url('firefox', 'notes', build) }}">{{ _('What’s New') }}</a> |
       <a href="{{ url('privacy.notices.firefox') }}">{{ _('Privacy') }}</a>

--- a/media/css/firefox/developer.less
+++ b/media/css/firefox/developer.less
@@ -78,16 +78,16 @@
         border-radius: 4px;
         box-shadow: 0 4px 10px #000;
     }
-    .privacy {
-        margin: @baseLine/2 auto 0;
-        .font-size(@smallFontSize);
-        opacity: .8;
-    }
 }
 
-.download-button .download-link {
-    .button-flat;
-    line-height: inherit;
+.download-button {
+    .download-link {
+        .button-flat;
+        line-height: inherit;
+    }
+    small.download-other.download-other-desktop {
+        display: block !important;
+    }
 }
 
 .android {

--- a/media/css/sandstone/buttons.less
+++ b/media/css/sandstone/buttons.less
@@ -506,6 +506,10 @@
         }
     }
 
+    small.download-other {
+        display: none !important;
+    }
+
     &.download-button-small {
         .download-link {
             width: 210px;


### PR DESCRIPTION
Simply use the non-simple button, maybe?