### PR TITLE
Augment home focus handler for IE 11/video splash. Bug 1101964.

### DIFF
--- a/media/js/mozorg/home/home.js
+++ b/media/js/mozorg/home/home.js
@@ -5,6 +5,7 @@
 $(function () {
     'use strict';
 
+    var $allElements = $('*');
     var $promos = $('.promo-grid');
     var $promoLarge = $('.promo-large-landscape, .promo-large-portrait');
     var $downloadPromo = $('.promo-small-landscape.firefox-download');
@@ -239,9 +240,14 @@ $(function () {
         });
 
         // close when something outside the takeover gets focus
-        $('a, input, textarea, button, :focus').bind('focus.splash', function(e) {
+        $allElements.on('focus.splash', function(e) {
             var $focused = $(e.target);
-            if (!$focused.parents().is($splash)) {
+
+            // make sure focused element is not within the splash screen
+            // also make sure it's not the body that has focus (IE 11 seems to give body focus
+            // automatically sometimes? bug 1101964)
+            if (!$focused.parents().is($splash) && $focused[0].tagName.toLowerCase() !== 'body') {
+                $allElements.off('focus.splash');
                 closeSplash();
             }
         });


### PR DESCRIPTION
Debugging through IE 11 dev tools, it appears the `<body>` on the home page on production is getting focus on page load, which is odd, because I don't think `<body>` is supposed to get focus?

![body-focus](https://cloud.githubusercontent.com/assets/317532/5117632/e5fa31bc-701c-11e4-8719-df523f0a922b.png)

I can't reproduce the error from my local instance.

I tried on demo3 (which had a couple day old rebased branch) and was able to reproduce. I added a bit of debugging code and pushed to demo3 to test again. After that push, I could no longer reproduce the error.

This branch is currently on [demo2](https://www-demo2.allizom.org/), but I still can't reproduce the error. The code here works, but since I can't reproduce the error, I'm not 100% certain it's an actual fix. (It does improve things a little by removing the focus handler though.)

I'm wondering if there is some issue with the minified JS file on the CDN?
