### PR TITLE
Fix Bug 1102367 - CMD+Click does not open a new tab on dev edition download/firstrun page

### DIFF
--- a/media/js/firefox/dev-firstrun.js
+++ b/media/js/firefox/dev-firstrun.js
@@ -31,10 +31,13 @@ function onYouTubeIframeAPIReady() {
     var isHighRes = Mozilla.ImageHelper.isHighDpi();
 
     var trackClick = function (gaArgs, href, event) {
-        event.preventDefault();
-        gaTrack(gaArgs, function() {
-            window.location = href;
-        });
+        if (event.metaKey || event.ctrlKey) {
+            // Open link in new tab
+            gaTrack(gaArgs);
+        } else {
+            event.preventDefault();
+            gaTrack(gaArgs, function() { window.location = href; });
+        }
     };
 
     // Setup GA tracking for misc links

--- a/media/js/firefox/developer.js
+++ b/media/js/firefox/developer.js
@@ -18,10 +18,13 @@ function onYouTubeIframeAPIReady() {
 
 
     var trackClick = function (gaArgs, href, event) {
-        event.preventDefault();
-        gaTrack(gaArgs, function() {
-            window.location = href;
-        });
+        if (event.metaKey || event.ctrlKey) {
+            // Open link in new tab
+            gaTrack(gaArgs);
+        } else {
+            event.preventDefault();
+            gaTrack(gaArgs, function() { window.location = href; });
+        }
     };
 
     // Setup GA tracking for misc links


### PR DESCRIPTION
This is a common issue in our JS code so I'll send a separate PR to add the generic `track_and_redirect` function, which is currently in the [bug-872740-download-btn-ga](https://github.com/kyoshino/bedrock/compare/bug-872740-download-btn-ga) WIP branch.
