### PR TITLE
Update the cache date of the legal icon set (Bug 1101126)

### DIFF
--- a/media/css/legal/legal.less
+++ b/media/css/legal/legal.less
@@ -186,7 +186,7 @@
             content: " ";
             display: block;
             position: absolute;
-            background-image: url(/media/img/legal/icons.png);
+            background-image: url(/media/img/legal/icons.png?2014-11);
             background-repeat: no-repeat;
             height: 40px;
             width: 40px;

--- a/media/css/privacy/privacy.less
+++ b/media/css/privacy/privacy.less
@@ -164,7 +164,7 @@
     a {
       display: table-cell;
       padding: 0 0 0 48px;
-      background-image: url(/media/img/legal/icons.png);
+      background-image: url(/media/img/legal/icons.png?2014-11);
       background-repeat: no-repeat;
       line-height: 1.2;
       vertical-align: middle;


### PR DESCRIPTION
I forgot to update the cache date. The Firefox Hello icon on [/privacy/](https://www.mozilla.org/en-US/privacy/) and [/about/legal/](https://www.mozilla.org/en-US/about/legal/) is not being displayed.
