### PR TITLE
Fix Bug 1105664 Add a1 to hello/start redirect

### DIFF
--- a/etc/httpd/global.conf
+++ b/etc/httpd/global.conf
@@ -848,4 +848,4 @@ RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/independent(/?.*)$ /b/$1firefox/inde
 
 # bug 1093985, 1105664, remove this once the Firefox Hello product page is ready
 RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/hello(/?.*)$ https://support.mozilla.org/kb/respond-firefox-hello-invitation-guest-mode [L,R=temp]
-RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/([3-9]\d\.\d(?:a2|beta|\.\d)?)/hello/start/?$ https://support.mozilla.org/kb/firefox-hello-make-and-receive-calls-guest-mode [L,R=temp]
+RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/([3-9]\d\.\d(?:a1|a2|beta|\.\d)?)/hello/start/?$ https://support.mozilla.org/kb/firefox-hello-make-and-receive-calls-guest-mode [L,R=temp]


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1105664

@jgmize sorry Josh, we also need to redirect a1 versions.

https://www.mozilla.org/en-US/firefox/36.0a2/hello/start - redirects okay
https://www.mozilla.org/en-US/firefox/36.0a1/hello/start - 404 (this PR will include it)
