### PR TITLE
[fix bug 1106065] Add version check for getConfiguration('selectedSearchEngine') on firstrun

### DIFF
--- a/bedrock/firefox/templates/firefox/australis/firstrun-34-tour.html
+++ b/bedrock/firefox/templates/firefox/australis/firstrun-34-tour.html
@@ -43,7 +43,7 @@
             </div>
             {{ high_res_img('img/firefox/australis/diag-menu-bar.jpg?03-2014', {'alt': _('The features you use most, all in one place'), 'width': '300', 'height': '188'}) }}
           </li>
-          <li class="tour-step app-menu" data-step="2" data-tip-prev="{{ _('<span>Previous:</span> Menu') }}" data-tip-next="{{ _('<span>Next:</span> Search') }}">
+          <li class="tour-step" data-step="2" data-tip-prev="{{ _('<span>Previous:</span> Menu') }}" data-tip-next="{{ _('<span>Next:</span> Search') }}">
             <div class="tour-item">
               {# L10n: <br> tag below used for formatting only. #}
               <h2 class="tour-highlight step-target" data-target="customize" data-effect="wobble">

--- a/bedrock/firefox/templates/firefox/australis/firstrun-tour.html
+++ b/bedrock/firefox/templates/firefox/australis/firstrun-tour.html
@@ -77,7 +77,7 @@
             </div>
             {{ high_res_img('img/firefox/australis/diag-menu-bar.jpg?03-2014', {'alt': _('The features you use most, all in one place'), 'width': '300', 'height': '188'}) }}
           </li>
-          <li class="tour-step app-menu" data-step="2" data-tip-prev="{{ _('<span>Previous:</span> Menu') }}" data-tip-next="{{ _('<span>Next:</span> Add-ons') }}">
+          <li class="tour-step" data-step="2" data-tip-prev="{{ _('<span>Previous:</span> Menu') }}" data-tip-next="{{ _('<span>Next:</span> Add-ons') }}">
             <div class="tour-item">
               {# L10n: <br> tag below used for formatting only. #}
               <h2 class="tour-highlight step-target" data-target="customize" data-effect="wobble">
@@ -91,7 +91,7 @@
             </div>
             {{ high_res_img('img/firefox/australis/diag-customize.jpg?03-2014', {'alt': _('Learn how to customize your Firefox'), 'width': '300', 'height': '188'}) }}
           </li>
-          <li class="tour-step app-menu" data-step="3" data-tip-prev="{{ _('<span>Previous:</span> Customize') }}" data-tip-next="{{ _('<span>Next:</span> Bookmarks') }}">
+          <li class="tour-step" data-step="3" data-tip-prev="{{ _('<span>Previous:</span> Customize') }}" data-tip-next="{{ _('<span>Next:</span> Bookmarks') }}">
             <div class="tour-item">
               {# L10n: <br> tag below used for formatting only. #}
               <h2 class="tour-highlight step-target" data-target="addons" data-effect="wobble">

--- a/media/js/firefox/australis/tour.js
+++ b/media/js/firefox/australis/tour.js
@@ -50,23 +50,25 @@
         } catch (e) {}
 
         // track default search engine for Firefox 34
-        Mozilla.UITour.getConfiguration('selectedSearchEngine', function (data) {
-            var selectedEngineID = data.searchEngineIdentifier;
+        if (window.getFirefoxMasterVersion() >= 34) {
+            Mozilla.UITour.getConfiguration('selectedSearchEngine', function (data) {
+                var selectedEngineID = data.searchEngineIdentifier;
 
-            if (!selectedEngineID) {
-                return;
-            }
+                if (!selectedEngineID) {
+                    return;
+                }
 
-            if (selectedEngineID === 'yahoo') {
-                Mozilla.UITour.setTreatmentTag('srch-chg-treatment', 'firstrun_yahooDefault');
-                Mozilla.UITour.setTreatmentTag('srch-chg-action', 'ViewPage');
-                gaTrack(['_trackEvent', 'firstrun srch-chg interactions', 'yahooDefault', 'ViewPage']);
-            } else {
-                Mozilla.UITour.setTreatmentTag('srch-chg-treatment', 'firstrun_otherDefault');
-                Mozilla.UITour.setTreatmentTag('srch-chg-action', 'ViewPage');
-                gaTrack(['_trackEvent', 'firstrun srch-chg interactions', 'otherDefault', 'ViewPage']);
-            }
-        });
+                if (selectedEngineID === 'yahoo') {
+                    Mozilla.UITour.setTreatmentTag('srch-chg-treatment', 'firstrun_yahooDefault');
+                    Mozilla.UITour.setTreatmentTag('srch-chg-action', 'ViewPage');
+                    gaTrack(['_trackEvent', 'firstrun srch-chg interactions', 'yahooDefault', 'ViewPage']);
+                } else {
+                    Mozilla.UITour.setTreatmentTag('srch-chg-treatment', 'firstrun_otherDefault');
+                    Mozilla.UITour.setTreatmentTag('srch-chg-action', 'ViewPage');
+                    gaTrack(['_trackEvent', 'firstrun srch-chg interactions', 'otherDefault', 'ViewPage']);
+                }
+            });
+        }
 
     }
 


### PR DESCRIPTION
This PR is just tying up a couple of loose ends on /firstrun. I don't really consider any of this urgent and it can wait until after Mon 1 Dec.
- Adds a version check when calling `getConfiguration('selectedSearchEngine')` to suppress an error in the Browser Console on older Firefox versions (note this is not the regular Web Console). The error does not impact anything functionally.
- This PR also removes some now redundant `appMenu` CSS class names from /firstrun which are no longer needed (I didn't consider this to warrant creating a separate bug for).
