### PR TITLE
[fix bug 1106279] Only show dev-edition firstrun doorhanger if tab is visible on page load

### DIFF
--- a/media/js/firefox/dev-firstrun.js
+++ b/media/js/firefox/dev-firstrun.js
@@ -383,9 +383,13 @@ function onYouTubeIframeAPIReady() {
     // shows the current tour step and binds event listeners
     function bindTour() {
         clearTimeout(highlightTimeout);
-        highlightTimeout = setTimeout(function () {
-            showTourStep();
-        }, 900);
+
+        if (!document.hidden) {
+            highlightTimeout = setTimeout(function () {
+                showTourStep();
+            }, 900);
+        }
+
         $document.on('visibilitychange', handleVisibilityChange);
         $window.on('beforeunload', hideAppMenu);
     }


### PR DESCRIPTION
Again nothing urgent, this can wait until after Dec 1.
