### PR TITLE
[fix bug 1106305] Specify What's New Variant For 35 Beta

### DIFF
--- a/bedrock/firefox/templates/firefox/search_tour/no-tour.html
+++ b/bedrock/firefox/templates/firefox/search_tour/no-tour.html
@@ -4,6 +4,8 @@
 
 {% extends "firefox/search_tour/index.html" %}
 
+{% block body_id %}whatsnew-search-no-tour{% endblock %}
+
 {% block site_css %}
   {{ css('firefox_search_no_tour') }}
 {% endblock %}

--- a/bedrock/firefox/templates/firefox/search_tour/tour-35-beta.html
+++ b/bedrock/firefox/templates/firefox/search_tour/tour-35-beta.html
@@ -1,0 +1,7 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. #}
+
+{% extends "firefox/search_tour/tour.html" %}
+
+{% block body_id %}whatsnew-search-tour-35-beta{% endblock %}

--- a/bedrock/firefox/templates/firefox/search_tour/tour.html
+++ b/bedrock/firefox/templates/firefox/search_tour/tour.html
@@ -8,6 +8,8 @@
   {{ css('firefox_search_tour') }}
 {% endblock %}
 
+{% block body_id %}whatsnew-search-tour-34{% endblock %}
+
 {% block string_data %}
 data-forced-title="{{ _('Searching just got better') }}"
 data-forced-text="{{ _('A new default. A new look. A brand new way to search.') }}"

--- a/bedrock/firefox/tests/test_base.py
+++ b/bedrock/firefox/tests/test_base.py
@@ -535,6 +535,23 @@ class TestWhatsNew(TestCase):
         eq_(template, ['firefox/australis/whatsnew-no-tour.html'])
 
     @override_settings(DEV=True)
+    def test_fx_35_0(self, render_mock):
+        """Should use search tour template for 35.0"""
+        req = self.rf.get('/en-US/firefox/whatsnew/')
+        self.view(req, version='35.0')
+        template = render_mock.call_args[0][1]
+        eq_(template, ['firefox/search_tour/no-tour.html'])
+
+    @override_settings(DEV=True)
+    def test_fx_35_0_locale(self, render_mock):
+        """Should use australis template for 35.0 non en-US locales"""
+        req = self.rf.get('/de/firefox/whatsnew/')
+        req.locale = 'de'
+        self.view(req, version='35.0')
+        template = render_mock.call_args[0][1]
+        eq_(template, ['firefox/australis/whatsnew-no-tour.html'])
+
+    @override_settings(DEV=True)
     def test_rv_prefix(self, render_mock):
         """Prefixed oldversion shouldn't impact version sniffing."""
         req = self.rf.get('/en-US/firefox/whatsnew/?oldversion=rv:10.0')

--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -274,13 +274,13 @@ def show_10th_anniversary(version):
     return version >= Version('33.1')
 
 
-def show_search_whatsnew_tour(oldversion):
+def show_search_whatsnew_tour(version, oldversion):
     try:
         oldversion = Version(oldversion)
     except ValueError:
         return False
 
-    return oldversion < Version('34.0')
+    return oldversion < Version(version)
 
 
 def show_search_firstrun(version):
@@ -408,9 +408,17 @@ class WhatsnewView(LatestFxView):
             oldversion = oldversion[3:]
         versions = ('29.', '30.', '31.', '32.')
 
-        if version.startswith('34.'):
+        if version.startswith('35.'):
             if locale == 'en-US':
-                if show_search_whatsnew_tour(oldversion):
+                if show_search_whatsnew_tour('35.0', oldversion):
+                    template = 'firefox/search_tour/tour-35-beta.html'
+                else:
+                    template = 'firefox/search_tour/no-tour.html'
+            else:
+                template = 'firefox/australis/whatsnew-no-tour.html'
+        elif version.startswith('34.'):
+            if locale == 'en-US':
+                if show_search_whatsnew_tour('34.0', oldversion):
                     template = 'firefox/search_tour/tour.html'
                 else:
                     template = 'firefox/search_tour/no-tour.html'

--- a/media/js/firefox/search_tour/tour.js
+++ b/media/js/firefox/search_tour/tour.js
@@ -13,6 +13,7 @@
     var variants = ['ravioli', 'flare', 'independence'];
     var icon;
     var _trackingID;
+    var pageId = $('body').prop('id');
 
     /*
      * Set the default search provider to Yahoo!
@@ -165,6 +166,11 @@
 
     function determinePageVariation() {
         var rand = variants[Math.floor(Math.random() * variants.length)];
+
+        if (pageId === 'whatsnew-search-tour-35-beta') {
+            rand = 'independence';
+        }
+
         showPageVariant(rand);
     }
 
@@ -175,6 +181,10 @@
     function rollTheDice() {
         var SAMPLE_RATE = 0.5;
         var forced = (Math.random() < SAMPLE_RATE) ? true : false;
+
+        if (pageId === 'whatsnew-search-tour-35-beta') {
+            forced = true;
+        }
 
         if (forced) {
             userForced = true;
@@ -313,7 +323,7 @@
             gaTrack(['_trackEvent', 'whatsnew srch-chg interactions', 'Default', 'ViewPage']);
         }
 
-        Mozilla.UITour.registerPageID('whatsnew-search-tour-34');
+        Mozilla.UITour.registerPageID(pageId);
     }
 
 })(window.jQuery, window.Mozilla);


### PR DESCRIPTION
Users updating to Firefox 35 Beta (due to update Thursday) will see the search /whatsnew page with the following conditions:
- Always see the "forced" door-hanger with "Try it now" if their current default is Google.
- Always see the 'independence' page variation with "Search. Freely" in the title when the door-hanger is shown.
