### PR TITLE
Add phantomas perf monitoring grunt task

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ node_modules
 bedrock/externalfiles/files_cache
 mofo_security_advisories
 .idea
+phantomas

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -63,7 +63,78 @@ module.exports = function (grunt) {
             configFile: 'media/js/test/karma.conf.js'
           }
         },
-        clean: ['media/css/**/*.less.css']
+        clean: ['media/css/**/*.less.css'],
+        phantomas: {
+            options: {
+                group: {
+                    'REQUESTS' : [
+                        'requests',
+                        'gzipRequests',
+                        'notFound',
+                        'multipleRequests',
+                        'assetsNotGzipped'
+                    ],
+                    'TIMINGS' : [
+                        'timeToFirstByte',
+                        'timeToLastByte',
+                        'timeToFirstCss',
+                        'timeToFirstJs',
+                        'timeToFirstImage',
+                        'fastestResponse',
+                        'slowestResponse',
+                        'onDOMReadyTime',
+                        'onDOMReadyTimeEnd',
+                        'windowOnLoadTime',
+                        'windowOnLoadTimeEnd'
+                    ],
+                    'HTML' : [
+                        'bodyHTMLSize',
+                        'hiddenContentSize',
+                        'whiteSpacesSize',
+                        'DOMelementsCount',
+                        'DOMelementMaxDepth'
+                    ],
+                    'JAVASCRIPT' : [
+                        'eventsBound',
+                        'jsErrors',
+                        'consoleMessages',
+                        'globalVariables',
+                        'localStorageEntries'
+                    ],
+                    'COUNTS & SIZES' : [
+                        'contentLength',
+                        'bodySize',
+                        'htmlSize',
+                        'htmlCount',
+                        'cssSize',
+                        'cssCount',
+                        'jsSize',
+                        'jsCount',
+                        'imageSize',
+                        'imageCount',
+                        'webfontSize',
+                        'webfontCount'
+                    ]
+                },
+                options: {
+                    'film-strip': false,
+                    'timeout': 60
+                },
+                buildUi: true
+            },
+            homepage: {
+                options: {
+                    indexPath: './phantomas/home/',
+                    url: 'https://www.allizom.org/en-US/'
+                }
+            },
+            firefoxnew: {
+                options: {
+                    indexPath: './phantomas/firefoxnew/',
+                    url: 'https://www.allizom.org/en-US/firefox/new/'
+                }
+            }
+        }
     });
 
     // Update the config to only build the changed files.

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "grunt-contrib-watch": "~0.5.3",
     "grunt-jsonlint": "^1.0.4",
     "grunt-karma": "~0.6.2",
+    "grunt-phantomas": "^0.11.0",
     "karma": "~0.10.9",
     "karma-chrome-launcher": "~0.1.2",
     "karma-coffee-preprocessor": "~0.1.3",


### PR DESCRIPTION
- Adds a grunt task to run [phantomas](https://github.com/macbre/phantomas) performance monitoring against the homepage and /firefox/new/ on www.allizom.org
- Outputs & updates pretty graphs & json data when run locally to */phantomas/

This is just a first step, we still need to figure out how to make this data more easily available to everyone when run (e.g. when we push to stage).
