### PR TITLE
Standardize/simplify LESS @imports.

### DIFF
--- a/bedrock/firefox/templates/firefox/all.html
+++ b/bedrock/firefox/templates/firefox/all.html
@@ -42,7 +42,7 @@
     </p>
   </header>
 
-  <form id="language-search" method="get">
+  <form id="language-search" class="billboard" method="get">
     <div class="search-column">
       <input type="search"
              placeholder="{{ _('Search languages') }}"
@@ -134,7 +134,7 @@
 {% macro build_table(builds, title, description) %}
   <div class="build-table-container">
     {% if builds %}
-      <table class="build-table">
+      <table class="table build-table">
         <caption>
           <h3>{{ title }}</h3>
             {% if description %}

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -110,11 +110,13 @@ CACHEBUST_IMGS = False
 MINIFY_BUNDLES = {
     'css': {
         'csrf-failure': (
+            'css/sandstone/sandstone-resp.less',
             'css/csrf-failure.less',
         ),
         'about': (
             'css/sandstone/video-resp.less',
-            'css/mozorg/about.less',
+            'css/mozorg/about-base.less',
+            'css/mozorg/mosaic.less',
         ),
         'about-base': (
             'css/mozorg/about-base.less',
@@ -165,10 +167,12 @@ MINIFY_BUNDLES = {
             'css/mozorg/contact-spaces-ie7.less',
         ),
         'contribute-old': (
+            'css/mozorg/contribute/contribute-form.less',
             'css/mozorg/contribute/contribute-old.less',
             'css/sandstone/video-resp.less',
         ),
         'contribute-page': (
+            'css/mozorg/contribute/contribute-form.less',
             'css/mozorg/contribute/contribute-page.less',
         ),
         'contribute-studentambassadors-landing': (
@@ -179,16 +183,24 @@ MINIFY_BUNDLES = {
             'css/mozorg/contribute/studentambassadors/join.less',
         ),
         'dnt': (
+            'css/sandstone/sandstone-resp.less',
+            'css/firefox/menu-resp.less',
             'css/base/mozilla-accordion.less',
             'css/firefox/dnt.less',
         ),
         'firefox': (
+            'css/sandstone/sandstone.less',
+            'css/firefox/menu.less',
             'css/firefox/template.less',
         ),
         'firefox_all': (
+            'css/sandstone/sandstone-resp.less',
+            'css/firefox/menu-resp.less',
             'css/firefox/all.less',
         ),
         'firefox_android': (
+            'css/sandstone/sandstone-resp.less',
+            'css/firefox/menu-resp.less',
             'css/base/mozilla-accordion.less',
             'css/firefox/android.less',
         ),
@@ -205,7 +217,10 @@ MINIFY_BUNDLES = {
             'css/firefox/channel.less',
         ),
         'firefox-dashboard': (
+            'css/sandstone/sandstone-resp.less',
+            'css/firefox/template-resp.less',
             'css/base/mozilla-accordion.less',
+            'css/firefox/menu-resp.less',
             'css/firefox/dashboard.less',
         ),
         'firefox_desktop': (
@@ -231,6 +246,7 @@ MINIFY_BUNDLES = {
             'css/firefox/desktop/trust.less',
         ),
         'firefox_sms': (
+            'css/sandstone/sandstone-resp.less',
             'css/libs/socialshare/socialshare.less',
             'css/firefox/template-resp.less',
             'css/sandstone/video-resp.less',
@@ -245,37 +261,56 @@ MINIFY_BUNDLES = {
             'css/base/mozilla-accordion.less',
         ),
         'firefox_firstrun': (
+            'css/sandstone/sandstone-resp.less',
+            'css/firefox/template-resp.less',
             'css/sandstone/video.less',
             'css/base/mozilla-modal.less',
             'css/firefox/firstrun.less',
         ),
         'firefox_developer_firstrun': (
+            'css/sandstone/sandstone-resp.less',
+            'css/firefox/template-resp.less',
             'css/base/mozilla-modal.less',
             'css/firefox/dev-firstrun.less',
         ),
         'nightly_firstrun': (
+            'css/sandstone/sandstone-resp.less',
+            'css/firefox/template-resp.less',
             'css/firefox/nightly_firstrun.less',
         ),
         'firefox_geolocation': (
+            'css/sandstone/sandstone-resp.less',
+            'css/firefox/template-resp.less',
+            'css/firefox/menu-resp.less',
             'css/base/mozilla-accordion.less',
             'css/base/mozilla-modal.less',
             'css/libs/mapbox-1.6.3.css',
             'css/firefox/geolocation.less'
         ),
         'firefox_developer': (
+            'css/sandstone/sandstone-resp.less',
+            'css/firefox/template-resp.less',
             'css/base/mozilla-modal.less',
+            'css/firefox/menu-resp.less',
             'css/firefox/developer.less',
         ),
         'firefox_new': (
+            'css/sandstone/sandstone-resp.less',
+            'css/firefox/template-resp.less',
             'css/libs/socialshare/socialshare.less',
+            'css/firefox/simple_footer-resp.less',
             'css/firefox/new.less',
         ),
         'firefox_organizations': (
+            'css/sandstone/sandstone-resp.less',
+            'css/firefox/template-resp.less',
             'css/firefox/organizations.less',
         ),
         'firefox_os': (
+            'css/sandstone/sandstone-resp.less',
             'css/base/mozilla-modal.less',
             'css/libs/jquery.pageslide.css',
+            'css/firefox/os/get_device.less',
             'css/firefox/os/firefox-os.less',
         ),
         'firefox_os_ie': (
@@ -284,6 +319,7 @@ MINIFY_BUNDLES = {
         'firefox_os_devices': (
             'css/libs/tipsy.css',
             'css/base/mozilla-modal.less',
+            'css/firefox/os/get_device.less',
             'css/firefox/os/devices.less',
         ),
         'firefox_os_devices_ie': (
@@ -297,9 +333,13 @@ MINIFY_BUNDLES = {
             'css/firefox/os/mwc-2014-preview-ie7.less',
         ),
         'firefox_releases_index': (
+            'css/sandstone/sandstone-resp.less',
+            'css/firefox/template-resp.less',
+            'css/firefox/menu-resp.less',
             'css/firefox/releases-index.less',
         ),
         'firefox_privacy_tour': (
+            'css/sandstone/sandstone.less',
             'css/base/mozilla-modal.less',
             'css/firefox/independent-splash.less',
             'css/firefox/australis/australis-ui-tour.less',
@@ -313,6 +353,7 @@ MINIFY_BUNDLES = {
             'css/firefox/privacy_tour/no-tour.less',
         ),
         'firefox_search_tour': (
+            'css/sandstone/sandstone.less',
             'css/firefox/search_tour/common.less',
             'css/firefox/search_tour/tour.less',
         ),
@@ -320,20 +361,28 @@ MINIFY_BUNDLES = {
             'css/firefox/search_tour/common.less',
         ),
         'firefox_tour': (
+            'css/sandstone/sandstone.less',
             'css/firefox/australis/australis-ui-tour.less',
             'css/firefox/australis/australis-page-common.less',
             'css/firefox/sync-animation.less',
             'css/firefox/australis/australis-page-stacked.less',
         ),
         'firefox_whatsnew': (
+            'css/sandstone/sandstone-resp.less',
+            'css/firefox/template-resp.less',
             'css/sandstone/video.less',
             'css/firefox/whatsnew.less',
             'css/firefox/whatsnew-android.less',
         ),
         'firefox_whatsnew_fxos': (
+            'css/sandstone/sandstone.less',
+            'css/firefox/simple_footer.less',
             'css/firefox/whatsnew-fxos.less',
         ),
         'firefox_releasenotes': (
+            'css/sandstone/sandstone-resp.less',
+            'css/firefox/template-resp.less',
+            'css/firefox/menu-resp.less',
             'css/firefox/releasenotes.less',
         ),
         'firefox_sync': (
@@ -350,8 +399,10 @@ MINIFY_BUNDLES = {
             'css/firefox/independent.less',
         ),
         'installer_help': (
-            'css/base/mozilla-modal.less',
+            'css/sandstone/sandstone-resp.less',
             'css/firefox/template-resp.less',
+            'css/firefox/menu-resp.less',
+            'css/base/mozilla-modal.less',
             'css/firefox/installer-help.less',
         ),
         'history-slides': (
@@ -378,21 +429,25 @@ MINIFY_BUNDLES = {
             'css/mozorg/home/home-ie8.less',
         ),
         'legal': (
+            'css/sandstone/sandstone-resp.less',
             'css/legal/legal.less',
         ),
         'legal-eula': (
             'css/legal/eula.less',
         ),
         'legal_fraud_report': (
+            'css/sandstone/sandstone-resp.less',
             'css/legal/fraud-report.less',
         ),
         'manifesto': (
             'css/base/mozilla-modal.less',
             'css/libs/socialshare/socialshare.less',
+            'css/mozorg/mosaic.less',
             'css/mozorg/manifesto.less',
         ),
         'mission': (
             'css/sandstone/video-resp.less',
+            'css/mozorg/mosaic.less',
             'css/mozorg/mission.less',
         ),
         'mozilla_accordion': (
@@ -405,6 +460,7 @@ MINIFY_BUNDLES = {
             'css/persona/persona.less',
         ),
         'powered-by': (
+            'css/sandstone/sandstone-resp.less',
             'css/mozorg/powered-by.less',
         ),
         'plugincheck': (
@@ -412,6 +468,7 @@ MINIFY_BUNDLES = {
             'css/plugincheck/qtip.css',
         ),
         'press_speaker_request': (
+            'css/sandstone/sandstone-resp.less',
             'css/press/speaker-request.less',
         ),
         'privacy': (
@@ -436,6 +493,7 @@ MINIFY_BUNDLES = {
             'css/research/research.less',
         ),
         'security': (
+            'css/sandstone/sandstone-resp.less',
             'css/security/security.less',
         ),
         'security-bug-bounty-hall-of-fame': (
@@ -446,6 +504,7 @@ MINIFY_BUNDLES = {
             'css/mozorg/security-tld-idn.less',
         ),
         'styleguide': (
+            'css/sandstone/fonts.less',
             'css/styleguide/styleguide.less',
             'css/styleguide/websites-sandstone.less',
             'css/styleguide/identity-mozilla.less',
@@ -463,6 +522,7 @@ MINIFY_BUNDLES = {
             'css/sandstone/sandstone-resp.less',
         ),
         'styleguide-docs-mozilla-pager': (
+            'css/sandstone/sandstone-resp.less',
             'css/styleguide/docs/mozilla-pager.less',
         ),
         'tabzilla': (

--- a/media/css/base/mozilla-modal.less
+++ b/media/css/base/mozilla-modal.less
@@ -138,7 +138,7 @@ html[dir="rtl"] {
         .inner header {
             // remove left/right padding so the .image-replaced works as expected
             padding: 10px 0;
-            .image-replaced;
+            .image-replaced();
         }
     }
 }

--- a/media/css/csrf-failure.less
+++ b/media/css/csrf-failure.less
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-@import "sandstone/sandstone-resp.less";
+@import "sandstone/lib.less";
 
 #wrapper {
   width: 100%;

--- a/media/css/firefox/all.less
+++ b/media/css/firefox/all.less
@@ -1,4 +1,4 @@
-@import "template-resp.less";
+@import "../sandstone/lib.less";
 
 .build-table-container {
     .hide {
@@ -28,7 +28,6 @@
 }
 
 #language-search {
-    .billboard();
     padding-top: @baseLine;
     padding-bottom: @baseLine;
     margin-left: @gridGutterWidth * 1.5;
@@ -74,7 +73,6 @@
         margin-top: @baseLine * 2;
     }
     table {
-        .table;
         width: 100%;
         thead {
             th {

--- a/media/css/firefox/android.less
+++ b/media/css/firefox/android.less
@@ -2,8 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-@import '../sandstone/sandstone-resp.less';
-@import 'menu-resp.less';
+@import '../sandstone/lib.less';
 
 // Base template overrides
 

--- a/media/css/firefox/australis/australis-page-common.less
+++ b/media/css/firefox/australis/australis-page-common.less
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-@import "../../sandstone/sandstone.less";
+@import "../../sandstone/lib.less";
 
 html,
 body {

--- a/media/css/firefox/dashboard.less
+++ b/media/css/firefox/dashboard.less
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 @import "../sandstone/lib.less";
-@import "template-resp.less";
 
 #main-feature {
     padding-bottom: @baseLine;

--- a/media/css/firefox/desktop/tips.less
+++ b/media/css/firefox/desktop/tips.less
@@ -362,6 +362,7 @@ html[lang^='en'] #tips-nav-direct li a span:after {
 
         button {
             .transition(color .2s ease);
+            .link-button();
         }
 
         button:disabled {

--- a/media/css/firefox/dev-firstrun.less
+++ b/media/css/firefox/dev-firstrun.less
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-@import "template-resp.less";
+@import "../sandstone/lib.less";
 
 #wrapper {
     width: 100%;

--- a/media/css/firefox/developer.less
+++ b/media/css/firefox/developer.less
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-@import "template-resp.less";
+@import "../sandstone/lib.less";
 
 // Some common classes/mixins
 @buttonGreen: #14c329;

--- a/media/css/firefox/dnt.less
+++ b/media/css/firefox/dnt.less
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 @import "../sandstone/lib.less";
-@import "template-resp.less";
 
 #main-feature {
     padding-bottom: @baseLine;

--- a/media/css/firefox/firstrun.less
+++ b/media/css/firefox/firstrun.less
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-@import "template-resp.less";
+@import "../sandstone/lib.less";
 
 #wrapper {
     padding-bottom: 0;

--- a/media/css/firefox/geolocation.less
+++ b/media/css/firefox/geolocation.less
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-@import "template-resp.less";
+@import "../sandstone/lib.less";
 
 #main-feature {
     h1,

--- a/media/css/firefox/installer-help.less
+++ b/media/css/firefox/installer-help.less
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 @import "../sandstone/lib.less";
-@import "../sandstone/buttons.less";
 
 #main-content {
   background: #fff;

--- a/media/css/firefox/menu-resp.less
+++ b/media/css/firefox/menu-resp.less
@@ -2,6 +2,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+@import "../sandstone/lib.less";
+
 /* Top Level Menu Items */
 
 #nav-main-menu {

--- a/media/css/firefox/menu.less
+++ b/media/css/firefox/menu.less
@@ -2,6 +2,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+@import "../sandstone/lib.less";
+
 /* Top Level Menu Items */
 
 #nav-main ul {

--- a/media/css/firefox/mobile-sms.less
+++ b/media/css/firefox/mobile-sms.less
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 @import "../sandstone/lib.less";
-@import "../sandstone/buttons.less";
 
 #mobile-sms #main-feature {
   text-align: center;

--- a/media/css/firefox/mwc-2014-map.less
+++ b/media/css/firefox/mwc-2014-map.less
@@ -1,3 +1,5 @@
+@import "../sandstone/lib.less";
+
 #map-container {
   width: 100%;
   height: 394px;

--- a/media/css/firefox/mwc-2014-schedule.less
+++ b/media/css/firefox/mwc-2014-schedule.less
@@ -1,3 +1,5 @@
+@import "../sandstone/lib.less";
+
 .schedule-header {
   .clearfix;
 }

--- a/media/css/firefox/new.less
+++ b/media/css/firefox/new.less
@@ -2,8 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-@import "template-resp.less";
-@import "simple_footer-resp.less";
+@import "../sandstone/lib.less";
 
 .sky #outer-wrapper {
     background: #eaeff2;

--- a/media/css/firefox/nightly_firstrun.less
+++ b/media/css/firefox/nightly_firstrun.less
@@ -2,7 +2,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-@import "template-resp.less";
 @import '../sandstone/lib.less';
 
 html {

--- a/media/css/firefox/organizations.less
+++ b/media/css/firefox/organizations.less
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-@import "template-resp.less";
+@import "../sandstone/lib.less";
 
 #main-feature {
     h1,
@@ -16,7 +16,7 @@
     input[type="text"] {
         max-width: 90%;
     }
-     
+
 }
 
 @media only screen and (min-width: @breakDesktop) {

--- a/media/css/firefox/os/devices.less
+++ b/media/css/firefox/os/devices.less
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 @import "../../sandstone/lib.less";
-@import "get_device.less";
 
 /* {{{ Template overrides */
 
@@ -275,7 +274,7 @@ html, body {
     cursor: pointer;
     float: right;
     margin: 5px 25px 0 0;
-    .image-replaced;
+    .image-replaced();
     background: url(/media/img/firefox/os/devices/close.png) center center no-repeat;
     width: 25px;
     height: 26px;
@@ -750,14 +749,14 @@ html, body {
                 .is-available, .coming-soon {
                     width: 20px;
                     padding: 0;
-                    .image-replaced;
+                    .image-replaced();
                     background-position: center center;
                 }
             }
         }
 
         .device-name {
-            .visually-hidden;
+            .visually-hidden();
         }
     }
 

--- a/media/css/firefox/os/firefox-os.less
+++ b/media/css/firefox/os/firefox-os.less
@@ -2,8 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-@import "../../sandstone/sandstone-resp.less";
-@import "get_device.less";
+@import "../../sandstone/lib.less";
 
 html {
   overflow: auto;

--- a/media/css/firefox/os/get_device.less
+++ b/media/css/firefox/os/get_device.less
@@ -1,3 +1,5 @@
+@import "../../sandstone/lib.less";
+
 // get phone default no-JS styles
 #get-device-wrapper {
     position: relative;

--- a/media/css/firefox/privacy_tour/common.less
+++ b/media/css/firefox/privacy_tour/common.less
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-@import "../../sandstone/sandstone.less";
+@import "../../sandstone/lib.less";
 
 html, body {
     height: 100%;

--- a/media/css/firefox/releasenotes.less
+++ b/media/css/firefox/releasenotes.less
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-@import "template-resp.less";
+@import "../sandstone/lib.less";
 
 .space #wrapper {
     background-repeat: no-repeat;

--- a/media/css/firefox/releases-index.less
+++ b/media/css/firefox/releases-index.less
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-@import "template-resp.less";
+@import "../sandstone/lib.less";
 
 #main-feature {
     h1,

--- a/media/css/firefox/search_tour/common.less
+++ b/media/css/firefox/search_tour/common.less
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-@import "../../sandstone/sandstone.less";
+@import "../../sandstone/lib.less";
 
 html,
 body {

--- a/media/css/firefox/simple_footer.less
+++ b/media/css/firefox/simple_footer.less
@@ -1,3 +1,5 @@
+@import "../sandstone/lib.less";
+
 #colophon {
     z-index: 1;
     margin-top: 0;

--- a/media/css/firefox/template-resp.less
+++ b/media/css/firefox/template-resp.less
@@ -2,8 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-@import "../sandstone/sandstone-resp.less";
-@import "menu-resp.less";
+@import "../sandstone/lib.less";
 
 #masthead h1 {
     padding: @baseLine 0;

--- a/media/css/firefox/template.less
+++ b/media/css/firefox/template.less
@@ -2,8 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-@import "../sandstone/sandstone.less";
-@import "menu.less";
+@import "../sandstone/lib.less";
 
 #masthead h1 {
     padding: @baseLine 0;

--- a/media/css/firefox/whatsnew-fxos.less
+++ b/media/css/firefox/whatsnew-fxos.less
@@ -2,8 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-@import "template.less";
-@import "simple_footer.less";
+@import "../sandstone/lib.less";
 
 @wrapper_width: 992px;
 
@@ -59,7 +58,7 @@
     margin: 0 auto;
     padding-top: 0;
     padding-bottom: 0;
-    
+
     .billboard {
         background: #fafafa;
         border: 1px solid #efefef;

--- a/media/css/firefox/whatsnew.less
+++ b/media/css/firefox/whatsnew.less
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-@import "template-resp.less";
+@import "../sandstone/lib.less";
 
 #wrapper {
     padding-bottom: 0;

--- a/media/css/foundation/annual2012.less
+++ b/media/css/foundation/annual2012.less
@@ -168,7 +168,7 @@ body {
 			background-repeat: no-repeat;
 			// hide descriptive link text
 			span {
-				.visually-hidden;
+				.visually-hidden();
 			}
 			&:hover, &:focus {
 				background-color: rgba(0, 0, 0, 0.25);
@@ -260,7 +260,7 @@ dl.faq dt {
 
 html[lang|="en"] {
 	.banner h1 span {
-		.image-replaced;
+		.image-replaced();
 		display: block;
 		border-radius: 0;
 		background: url(/media/img/foundation/annualreport/2012/state-of-mozilla.png) left top no-repeat;

--- a/media/css/foundation/annual2013.less
+++ b/media/css/foundation/annual2013.less
@@ -139,7 +139,7 @@ body {
             background-repeat: no-repeat;
             // hide descriptive link text
             span {
-                .visually-hidden;
+                .visually-hidden();
             }
             &:hover, &:focus {
                 background-color: rgba(0, 0, 0, 0.25);
@@ -210,7 +210,7 @@ dl.faq dt {
 
 html[lang|="en"] {
     .banner h1 span {
-        .image-replaced;
+        .image-replaced();
         display: block;
         border-radius: 0;
         background: url(/media/img/foundation/annualreport/2013/state-of-mozilla.png) left top no-repeat;

--- a/media/css/legal/fraud-report.less
+++ b/media/css/legal/fraud-report.less
@@ -2,10 +2,10 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-@import "../sandstone/sandstone-resp.less";
+@import "../sandstone/lib.less";
 
 #main-content {
-    .callout-content;
+    .callout-content();
     margin-top: 100px;
 }
 
@@ -34,7 +34,7 @@
     margin-top: @baseLine;
 
     label.error {
-        .visually-hidden;
+        .visually-hidden();
     }
 
     textarea {

--- a/media/css/legal/legal.less
+++ b/media/css/legal/legal.less
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-@import "../sandstone/sandstone-resp.less";
+@import "../sandstone/lib.less";
 
 #outer-wrapper {
     overflow: hidden; /* Fix the layout on IE */
@@ -33,9 +33,9 @@
     th {
       text-align: left;
       font-weight: normal;
-    } 
+    }
   }
-  
+
   #other {
     clear: both;
   }
@@ -139,7 +139,7 @@
                 display: none;
             }
         }
-    }    
+    }
 }
 
 

--- a/media/css/mozorg/about.less
+++ b/media/css/mozorg/about.less
@@ -1,6 +1,0 @@
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/.
-
-@import "about-base.less";
-@import "mosaic.less";

--- a/media/css/mozorg/contact-spaces.less
+++ b/media/css/mozorg/contact-spaces.less
@@ -375,7 +375,7 @@
             text-shadow: none;
 
             span {
-                .visually-hidden;
+                .visually-hidden();
             }
         }
 

--- a/media/css/mozorg/contribute/contribute-2015.less
+++ b/media/css/mozorg/contribute/contribute-2015.less
@@ -276,7 +276,7 @@ textarea:focus {
     }
 
     label {
-        .visually-hidden;
+        .visually-hidden();
     }
 
     .select select {
@@ -285,7 +285,7 @@ textarea:focus {
 }
 
 .js .country-form button {
-    .visually-hidden;
+    .visually-hidden();
 }
 
 // @Navigation
@@ -977,7 +977,7 @@ textarea:focus {
         border-radius: 6px;
 
         .section-title {
-            .visually-hidden;
+            .visually-hidden();
         }
 
         label {
@@ -1123,7 +1123,7 @@ textarea:focus {
     }
 
     input {
-        .visually-hidden;
+        .visually-hidden();
     }
 
     label {
@@ -1679,7 +1679,7 @@ textarea:focus {
         width: 55px;
         height: 55px;
         display: block;
-        .image-replaced;
+        .image-replaced();
         border: 2px solid @darkbeige;
         border-radius: 100%;
         position: relative;

--- a/media/css/mozorg/contribute/contribute-form.less
+++ b/media/css/mozorg/contribute/contribute-form.less
@@ -2,6 +2,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+@import "../../sandstone/lib.less";
+
 #help-form {
     padding-top: @baseLine;
     padding-bottom: @baseLine;

--- a/media/css/mozorg/contribute/contribute-old.less
+++ b/media/css/mozorg/contribute/contribute-old.less
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 @import "../../sandstone/lib.less";
-@import "contribute-form.less";
 
 .page-title {
     text-align: center;
@@ -84,7 +83,7 @@ header {
     }
 
     figcaption {
-        .visually-hidden;
+        .visually-hidden();
     }
 
     // Control buttons

--- a/media/css/mozorg/contribute/contribute-page.less
+++ b/media/css/mozorg/contribute/contribute-page.less
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 @import "../../sandstone/lib.less";
-@import "contribute-form.less";
 
 #contribute-page {
     #main-feature {

--- a/media/css/mozorg/contribute/studentambassadors/landing.less
+++ b/media/css/mozorg/contribute/studentambassadors/landing.less
@@ -165,7 +165,7 @@
     .multi-column(auto, 2, 20px);
 
     article {
-      .multi-column-avoid-break;
+      .multi-column-avoid-break();
     }
   }
 }
@@ -232,7 +232,7 @@
 
   #twitter-timeline-widget {
     .tweets {
-      .multi-column-clear;
+      .multi-column-clear();
     }
   }
 }

--- a/media/css/mozorg/home/home-promo.less
+++ b/media/css/mozorg/home/home-promo.less
@@ -427,7 +427,7 @@ html[lang|="en"] {
         height: 130px;
         border: 5px solid transparent;
         .transition(border .3s ease-in-out);
-        .image-replaced;
+        .image-replaced();
         cursor: pointer;
 
         &:hover,

--- a/media/css/mozorg/home/home.less
+++ b/media/css/mozorg/home/home.less
@@ -790,7 +790,7 @@ h1, h2, h3, h4, h5, h6 {
         width: 88px;
         height: 24px;
         background-image: url(/media/img/sandstone/footer-mozilla-white.png);
-        .image-replaced;
+        .image-replaced();
     }
 }
 

--- a/media/css/mozorg/manifesto.less
+++ b/media/css/mozorg/manifesto.less
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 @import "../sandstone/lib.less";
-@import "mosaic.less";
 
 @font-face {
     font-family: "Open Sans Extrabold";

--- a/media/css/mozorg/mission.less
+++ b/media/css/mozorg/mission.less
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 @import "../sandstone/sandstone-resp.less";
-@import "mosaic.less";
 
 #wrapper {
   width: 100%;

--- a/media/css/mozorg/powered-by.less
+++ b/media/css/mozorg/powered-by.less
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-@import "../sandstone/sandstone-resp.less";
+@import "../sandstone/lib.less";
 
 #wrapper {
   width: 100%;

--- a/media/css/press/speaker-request.less
+++ b/media/css/press/speaker-request.less
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-@import "../sandstone/sandstone-resp.less";
+@import "../sandstone/lib.less";
 
 #main-content {
     .callout-content;
@@ -80,7 +80,7 @@ fieldset {
     margin-top: @baseLine;
 
     label.error {
-        .visually-hidden;
+        .visually-hidden();
     }
 
     textarea {

--- a/media/css/sandstone/lib.less
+++ b/media/css/sandstone/lib.less
@@ -1,3 +1,11 @@
+// THIS FILE SHOULD OUTPUT NOTHING!
+//
+// As this file is included in many places (for variable/mixin access),
+// it must output nothing for performance reasons.
+//
+// IF IT'S NOT A MIXIN OR VARIABLE, IT DOESN'T GO HERE!
+
+
 // Fonts and color
 
 // The custom X-LocaleSpecific font family is defined with a @font-face rule in
@@ -144,8 +152,6 @@
 @widthMobileLandscape:    440px;
 @widthMobile:             320px;
 
-
-
 .clearfix() {
     zoom: 1;
     &:after {
@@ -237,6 +243,20 @@
   box-sizing: border-box;
 }
 
+// White content box, often used with .title-shadow-box
+// See /about/powered-by for example.
+.callout-content() {
+    .clearfix;
+    display: block;
+    @shadow: 0 0 0 1px #fff inset;
+    .box-shadow(@shadow);
+    background: #fff;
+    border-bottom: 1px solid #ddd;
+    margin: 0 auto @baseLine;
+    padding-left: @gridGutterWidth;
+    padding-right: @gridGutterWidth;
+}
+
 // Gradients
 #gradient {
   .horizontal (@startColor: #555, @endColor: #333) {
@@ -317,9 +337,9 @@
 @formFieldErrorShadow:       0 0 0 2px rgba(175, 50, 50, .4);
 @formFieldSelectErrorShadow: 0 0 0 3px rgba(175, 50, 50, .4);
 
-.form-field-error {
-  border-color: rgb(175,50,50);
-  .box-shadow(@formFieldErrorShadow);
+.form-field-error() {
+    border-color: rgb(175,50,50);
+    .box-shadow(@formFieldErrorShadow);
 }
 
 .required-star() {
@@ -333,7 +353,7 @@
 // Classes used to hide content from users. Choose wisely!
 
 // Hide visually, but not to screen readers
-.visually-hidden {
+.visually-hidden() {
     position: absolute!important;
     height: 1px;
     width: 1px;
@@ -345,14 +365,14 @@
 }
 
 // Hide visually & from screen readers
-.hidden {
+.hidden() {
     display: none;
 }
 
 /****************************************************************************/
 
 // not the most up to date method, but works in IE7
-.image-replaced {
+.image-replaced() {
     text-indent: 120%; // extra 20% to account for fancy fonts that may overhang
     white-space: nowrap;
     overflow: hidden;
@@ -372,6 +392,28 @@
     }
 }
 
+// Make a button look like an anchor
+.link-button() {
+    border: none;
+    background: transparent;
+    color: @linkBlue;
+    .font-size(@baseFontSize);
+    padding: 0;
+    margin: 0;
+    line-height: 1.5;
+    .open-sans();
+    cursor: pointer;
+
+    &:hover {
+        text-decoration: underline;
+        color: darken(@linkBlue, 10%);
+    }
+
+    &:focus {
+        outline: 0;
+    }
+}
+
 .multi-column(@width: auto, @count: auto, @gap: normal) {
   -webkit-column-width: @width;
      -moz-column-width: @width;
@@ -387,11 +429,11 @@
             column-gap: @gap;
 }
 
-.multi-column-clear {
+.multi-column-clear() {
   .multi-column(auto, auto, normal);
 }
 
-.multi-column-avoid-break {
+.multi-column-avoid-break() {
             page-break-inside: avoid;
   -webkit-column-break-inside: avoid;
      -moz-column-break-inside: avoid;

--- a/media/css/sandstone/sandstone-resp.less
+++ b/media/css/sandstone/sandstone-resp.less
@@ -52,28 +52,6 @@ a.more {
     .trailing-arrow();
 }
 
-// Make a button look like an anchor
-.link-button {
-    border: none;
-    background: transparent;
-    color: @linkBlue;
-    .font-size(@baseFontSize);
-    padding: 0;
-    margin: 0;
-    line-height: 1.5;
-    .open-sans();
-    cursor: pointer;
-
-    &:hover {
-        text-decoration: underline;
-        color: darken(@linkBlue, 10%);
-    }
-
-    &:focus {
-        outline: 0;
-    }
-}
-
 .sand #outer-wrapper {
     background: #f5f1e8 url(/media/img/sandstone/bg-gradient-sand.png) repeat-x;
     background: url(/media/img/sandstone/bg-gradient-sand.png) repeat-x,
@@ -459,7 +437,7 @@ input.invalid {
     input[type=email],
     input[type=password],
     input[type=text] {
-        .form-field-error;
+        .form-field-error();
     }
     select {
         .box-shadow(@formFieldSelectErrorShadow);
@@ -471,7 +449,7 @@ input.invalid {
 
 input[type=email], input[type=password], input[type=text] {
     &.error {
-        .form-field-error;
+        .form-field-error();
     }
 }
 
@@ -578,20 +556,6 @@ label.error {
     padding-right: @gridGutterWidth;
     position: relative;
     .clearfix;
-}
-
-// White content box, often used with .title-shadow-box
-// See /about/powered-by for example.
-.callout-content {
-    .clearfix;
-    display: block;
-    @shadow: 0 0 0 1px #fff inset;
-    .box-shadow(@shadow);
-    background: #fff;
-    border-bottom: 1px solid #ddd;
-    margin: 0 auto @baseLine;
-    padding-left: @gridGutterWidth;
-    padding-right: @gridGutterWidth;
 }
 
 /* }}} */
@@ -1051,7 +1015,7 @@ nav.menu-bar {
             }
 
             span {
-                .visually-hidden; /* for a11y */
+                .visually-hidden(); /* for a11y */
             }
         }
     }
@@ -1061,6 +1025,10 @@ nav.menu-bar {
     .col, .col-2 ul li {
         float: right;
     }
+}
+
+.hidden {
+    .hidden();
 }
 
 .invert {

--- a/media/css/sandstone/sandstone.less
+++ b/media/css/sandstone/sandstone.less
@@ -46,28 +46,6 @@ a.more {
     .trailing-arrow();
 }
 
-// Make a button look like an anchor
-.link-button {
-    border: none;
-    background: transparent;
-    color: @linkBlue;
-    .font-size(@baseFontSize);
-    padding: 0;
-    margin: 0;
-    line-height: 1.5;
-    .open-sans();
-    cursor: pointer;
-
-    &:hover {
-        text-decoration: underline;
-        color: darken(@linkBlue, 10%);
-    }
-
-    &:focus {
-        outline: 0;
-    }
-}
-
 .sand #outer-wrapper {
     background: #f5f1e8 url(/media/img/sandstone/bg-gradient-sand.png) repeat-x;
     background: url(/media/img/sandstone/bg-gradient-sand.png) repeat-x,
@@ -789,7 +767,7 @@ nav.menu-bar {
             }
 
             span {
-                .visually-hidden; /* for a11y */
+                .visually-hidden(); /* for a11y */
             }
         }
     }
@@ -807,6 +785,10 @@ nav.menu-bar {
 // because the ones in the noscript tag will be shown
 .no-js .platform-img.js {
     display: none;
+}
+
+.hidden {
+    .hidden();
 }
 
 /* }}} */

--- a/media/css/security/security.less
+++ b/media/css/security/security.less
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-@import "../sandstone/sandstone-resp.less";
+@import "../sandstone/lib.less";
 
 // Security impact levels
 

--- a/media/css/styleguide/communications.less
+++ b/media/css/styleguide/communications.less
@@ -2,7 +2,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-@import "../styleguide/styleguide.less";
+@import "styleguide-lib.less";
+
 /* {{{ Communications - Presentations */
 
 .communications-presentations {

--- a/media/css/styleguide/docs/mozilla-pager.less
+++ b/media/css/styleguide/docs/mozilla-pager.less
@@ -1,4 +1,4 @@
-@import '../../sandstone/sandstone-resp.less';
+@import '../../sandstone/lib.less';
 
 .example {
     margin: (@baseLine * 2) 0;

--- a/media/css/styleguide/identity-firefox-family.less
+++ b/media/css/styleguide/identity-firefox-family.less
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-@import "../styleguide/styleguide.less";
+@import "styleguide-lib.less";
 
 /* {{{ Firefox Family - Overview  */
 

--- a/media/css/styleguide/identity-firefox.less
+++ b/media/css/styleguide/identity-firefox.less
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-@import "../styleguide/styleguide.less";
+@import "styleguide-lib.less";
 
 /* {{{ Firefox - Branding  */
 

--- a/media/css/styleguide/identity-firefoxos.less
+++ b/media/css/styleguide/identity-firefoxos.less
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-@import "../styleguide/styleguide.less";
+@import "styleguide-lib.less";
 
 /* {{{ Firefox OS - Common (Partners & Community so far...)  */
 

--- a/media/css/styleguide/identity-marketplace.less
+++ b/media/css/styleguide/identity-marketplace.less
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-@import "../styleguide/styleguide.less";
+@import "styleguide-lib.less";
 
 /* {{{ Marketplace - Branding  */
 

--- a/media/css/styleguide/identity-mozilla.less
+++ b/media/css/styleguide/identity-mozilla.less
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-@import "../styleguide/styleguide.less";
+@import "styleguide-lib.less";
 
 /* {{{ Mozilla - Branding  */
 

--- a/media/css/styleguide/identity-persona.less
+++ b/media/css/styleguide/identity-persona.less
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-@import "../styleguide/styleguide.less";
+@import "styleguide-lib.less";
 
 /* {{{ Marketplace - Branding  */
 

--- a/media/css/styleguide/identity-thunderbird.less
+++ b/media/css/styleguide/identity-thunderbird.less
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-@import "../styleguide/styleguide.less";
+@import "styleguide-lib.less";
 
 /* {{{ Thunderbird - Logo */
 

--- a/media/css/styleguide/identity-webmaker.less
+++ b/media/css/styleguide/identity-webmaker.less
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-@import "../styleguide/styleguide.less";
+@import "styleguide-lib.less";
 
 /* {{{ Webmaker - Branding  */
 

--- a/media/css/styleguide/products-firefox-os.less
+++ b/media/css/styleguide/products-firefox-os.less
@@ -1,4 +1,4 @@
-@import "../styleguide/styleguide.less";
+@import "styleguide-lib.less";
 
 .blue-circle-list() {
     ol {

--- a/media/css/styleguide/products-firefox.less
+++ b/media/css/styleguide/products-firefox.less
@@ -1,4 +1,4 @@
-@import "../styleguide/styleguide.less";
+@import "styleguide-lib.less";
 
 /* {{{ Firefox Desktop for Windows 7 (sample dark theme page) */
 

--- a/media/css/styleguide/styleguide-lib.less
+++ b/media/css/styleguide/styleguide-lib.less
@@ -1,0 +1,48 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+@import "../sandstone/lib.less";
+
+@darkThemeText: #9a9ea1;
+
+.divider() {
+    padding-bottom: @baseLine * 3;
+    margin-bottom: @baseLine * 2;
+    background: url(/media/img/styleguide/divider.png) 50% 100% no-repeat;
+}
+
+.divider-dark() {
+    .divider();
+    background-image: url(/media/img/styleguide/divider-dark.png);
+}
+
+/* {{{ Grid setup */
+
+// Desktop:
+//           (16cols ✕ 60px) =  960
+// +     (15 gutters ✕ 20px) =  300
+// + (2 page gutters ✕ 20px) =   40
+// --------------------------------
+//                           = 1300px
+
+@widthDesktop:            1300px;
+
+// Gutter width remains the same for all grids
+@gridGutterWidth:         20px;
+
+// Default grid: 12 columns at 60px
+@gridColumns:             16;
+@gridColumnWidth:         60px;
+@gridRowWidth:            (@gridColumns * @gridColumnWidth) + (@gridGutterWidth * (@gridColumns - 1));
+
+// Column spans for style guide column widths
+.span_guide(@columns) {
+    float: left;
+    width: (@gridColumnWidth * @columns) + (@gridGutterWidth * (@columns - 1));
+    margin: 0 (@gridGutterWidth / 2);
+}
+
+.offset_guide(@columns) {
+    margin-left: ((@gridColumnWidth + @gridGutterWidth) * @columns) + (@gridGutterWidth * 0.5);
+}

--- a/media/css/styleguide/styleguide.less
+++ b/media/css/styleguide/styleguide.less
@@ -2,8 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-@import "../sandstone/fonts.less";
-@import "../sandstone/lib.less";
+@import "styleguide-lib.less";
 
 @font-face {
     font-family: 'Open Sans';
@@ -27,55 +26,12 @@
     font-style: italic;
 }
 
-@darkThemeText: #9a9ea1;
-
-.divider() {
-    padding-bottom: @baseLine * 3;
-    margin-bottom: @baseLine * 2;
-    background: url(/media/img/styleguide/divider.png) 50% 100% no-repeat;
-}
-
-.divider-dark() {
-    .divider();
-    background-image: url(/media/img/styleguide/divider-dark.png);
-}
-
 a[href="#TODO"] { color: #f00 !important; }
 
 .copyright-note {
   clear: both;
   padding-top: 20px;
   .offset(3);
-}
-
-/* {{{ Grid setup */
-
-// Desktop:
-//           (16cols ✕ 60px) =  960
-// +     (15 gutters ✕ 20px) =  300
-// + (2 page gutters ✕ 20px) =   40
-// --------------------------------
-//                           = 1300px
-
-@widthDesktop:            1300px;
-
-// Gutter width remains the same for all grids
-@gridGutterWidth:         20px;
-
-// Default grid: 12 columns at 60px
-@gridColumns:             16;
-@gridColumnWidth:         60px;
-@gridRowWidth:            (@gridColumns * @gridColumnWidth) + (@gridGutterWidth * (@gridColumns - 1));
-
-// Column spans for style guide column widths
-.span_guide(@columns) {
-    float: left;
-    width: (@gridColumnWidth * @columns) + (@gridGutterWidth * (@columns - 1));
-    margin: 0 (@gridGutterWidth / 2);
-}
-
-.offset_guide(@columns) {
-    margin-left: ((@gridColumnWidth + @gridGutterWidth) * @columns) + (@gridGutterWidth * 0.5);
 }
 
 #outer-wrapper {

--- a/media/css/styleguide/websites-sandstone.less
+++ b/media/css/styleguide/websites-sandstone.less
@@ -2,7 +2,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-@import "../styleguide/styleguide.less";
+@import "styleguide-lib.less";
+
 /* {{{ Sandstone - Intro  */
 
 .sandstone-intro {


### PR DESCRIPTION
Aside from a few outliers, this PR makes `lib.less` the _only_ file imported. All other `.less` files are included in CSS bundles.
