### PR TITLE
Update search tour for 34.0.5 users. Bug 1108671.

### DIFF
--- a/bedrock/firefox/templates/firefox/search_tour/tour-34.0.5.html
+++ b/bedrock/firefox/templates/firefox/search_tour/tour-34.0.5.html
@@ -1,0 +1,11 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. #}
+
+{% extends "firefox/search_tour/tour.html" %}
+
+{% block body_id %}whatsnew-search-tour-34-0-5{% endblock %}
+
+{% block js %}
+  {{ js('firefox_search_tour_34.0.5') }}
+{% endblock %}

--- a/bedrock/firefox/tests/test_base.py
+++ b/bedrock/firefox/tests/test_base.py
@@ -503,11 +503,19 @@ class TestWhatsNew(TestCase):
 
     @override_settings(DEV=True)
     def test_fx_34_0(self, render_mock):
-        """Should use search tour template for 34.0"""
+        """Should use no tour template for 34.0"""
         req = self.rf.get('/en-US/firefox/whatsnew/')
         self.view(req, version='34.0')
         template = render_mock.call_args[0][1]
         eq_(template, ['firefox/search_tour/no-tour.html'])
+
+    @override_settings(DEV=True)
+    def test_fx_34_0_with_oldversion(self, render_mock):
+        """Should use search tour template for 34.0 with old version"""
+        req = self.rf.get('/en-US/firefox/whatsnew/?oldversion=33.0')
+        self.view(req, version='34.0')
+        template = render_mock.call_args[0][1]
+        eq_(template, ['firefox/search_tour/tour.html'])
 
     @override_settings(DEV=True)
     def test_fx_34_0_1(self, render_mock):
@@ -519,7 +527,7 @@ class TestWhatsNew(TestCase):
 
     @override_settings(DEV=True)
     def test_fx_34_1(self, render_mock):
-        """Should use search tour template for 34.1"""
+        """Should use no tour template for 34.1"""
         req = self.rf.get('/en-US/firefox/whatsnew/')
         self.view(req, version='34.1')
         template = render_mock.call_args[0][1]
@@ -535,14 +543,6 @@ class TestWhatsNew(TestCase):
         eq_(template, ['firefox/australis/whatsnew-no-tour.html'])
 
     @override_settings(DEV=True)
-    def test_fx_35_0(self, render_mock):
-        """Should use search tour template for 35.0"""
-        req = self.rf.get('/en-US/firefox/whatsnew/')
-        self.view(req, version='35.0')
-        template = render_mock.call_args[0][1]
-        eq_(template, ['firefox/search_tour/no-tour.html'])
-
-    @override_settings(DEV=True)
     def test_fx_35_0_locale(self, render_mock):
         """Should use australis template for 35.0 non en-US locales"""
         req = self.rf.get('/de/firefox/whatsnew/')
@@ -550,6 +550,60 @@ class TestWhatsNew(TestCase):
         self.view(req, version='35.0')
         template = render_mock.call_args[0][1]
         eq_(template, ['firefox/australis/whatsnew-no-tour.html'])
+
+    # 34.0.5 search tour tests
+
+    @override_settings(DEV=True)
+    def test_fx_34_0_5(self, render_mock):
+        """Should use no tour template for 34.0.5"""
+        req = self.rf.get('/en-US/firefox/whatsnew/')
+        self.view(req, version='34.0.5')
+        template = render_mock.call_args[0][1]
+        eq_(template, ['firefox/search_tour/no-tour.html'])
+
+    @override_settings(DEV=True)
+    def test_fx_34_0_5_with_oldversion(self, render_mock):
+        """Should use 34.0.5 search tour template for 34.0.5 with old version"""
+        req = self.rf.get('/en-US/firefox/whatsnew/?oldversion=33.0')
+        self.view(req, version='34.0.5')
+        template = render_mock.call_args[0][1]
+        eq_(template, ['firefox/search_tour/tour-34.0.5.html'])
+
+    @override_settings(DEV=True)
+    def test_fx_34_0_5_locale(self, render_mock):
+        """Should use australis template for 34.0.5 non en-US locales"""
+        req = self.rf.get('/de/firefox/whatsnew/?oldversion=33.0')
+        req.locale = 'de'
+        self.view(req, version='34.0.5')
+        template = render_mock.call_args[0][1]
+        eq_(template, ['firefox/australis/whatsnew-no-tour.html'])
+
+    @override_settings(DEV=True)
+    def test_fx_35_0(self, render_mock):
+        """Should use no tour template for 35.0 with no old version"""
+        req = self.rf.get('/en-US/firefox/whatsnew/')
+        self.view(req, version='35.0')
+        template = render_mock.call_args[0][1]
+        eq_(template, ['firefox/search_tour/no-tour.html'])
+
+    @override_settings(DEV=True)
+    def test_fx_35_0_with_oldversion(self, render_mock):
+        """Should use 34.0.5 search tour template for 35.0 with old version"""
+        req = self.rf.get('/en-US/firefox/whatsnew/?oldversion=33.0')
+        self.view(req, version='35.0')
+        template = render_mock.call_args[0][1]
+        eq_(template, ['firefox/search_tour/tour-34.0.5.html'])
+
+    @override_settings(DEV=True)
+    def test_fx_35_locale(self, render_mock):
+        """Should use australis template for 35 non en-US locales"""
+        req = self.rf.get('/de/firefox/whatsnew/?oldversion=33.0')
+        req.locale = 'de'
+        self.view(req, version='35.0')
+        template = render_mock.call_args[0][1]
+        eq_(template, ['firefox/australis/whatsnew-no-tour.html'])
+
+    # end 34.0.5 search tour tests
 
     @override_settings(DEV=True)
     def test_rv_prefix(self, render_mock):

--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -408,10 +408,10 @@ class WhatsnewView(LatestFxView):
             oldversion = oldversion[3:]
         versions = ('29.', '30.', '31.', '32.')
 
-        if version.startswith('35.'):
+        if version.startswith('35.') or version.startswith('34.0.5'):
             if locale == 'en-US':
-                if show_search_whatsnew_tour('35.0', oldversion):
-                    template = 'firefox/search_tour/tour-35-beta.html'
+                if show_search_whatsnew_tour('34.0', oldversion):
+                    template = 'firefox/search_tour/tour-34.0.5.html'
                 else:
                     template = 'firefox/search_tour/no-tour.html'
             else:

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -724,6 +724,11 @@ MINIFY_BUNDLES = {
             'js/firefox/search_tour/common.js',
             'js/firefox/search_tour/tour.js',
         ),
+        'firefox_search_tour_34.0.5': (
+            'js/firefox/australis/australis-uitour.js',
+            'js/firefox/search_tour/common.js',
+            'js/firefox/search_tour/tour-34.0.5.js',
+        ),
         'firefox_search_no_tour': (
             'js/firefox/australis/australis-uitour.js',
             'js/firefox/search_tour/common.js',

--- a/media/js/firefox/search_tour/tour-34.0.5.js
+++ b/media/js/firefox/search_tour/tour-34.0.5.js
@@ -1,0 +1,200 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+;(function($, Mozilla) {
+    'use strict';
+
+    var $document = $(document);
+    var doorhangerClosed = false;
+    var queryIsLargeScreen = matchMedia('(min-width: 600px)');
+    var highlightTimeout;
+    var variants = ['ravioli', 'flare', 'independence'];
+    var icon;
+    var _trackingID;
+    var pageId = $('body').prop('id');
+
+    /*
+     * Doorhanger for users who were brute forced
+     * into having their default set to Yahoo!
+     */
+    function showForcedDoorhanger() {
+
+        var buttons = [
+            {
+                label: window.trans('later'),
+                callback: closeForcedDoorhanger
+            },
+            {
+                label: window.trans('forcedCta'),
+                style: 'primary',
+                callback: trySearch
+            }
+        ];
+
+        var options = {
+            closeButtonCallback: closeForcedDoorhanger
+        };
+
+        if (queryIsLargeScreen.matches && !document.hidden) {
+            Mozilla.UITour.showInfo(
+                'search',
+                window.trans('forcedTitle'),
+                window.trans('forcedText'),
+                icon,
+                buttons,
+                options
+            );
+        }
+    }
+
+    function trySearch() {
+        doorhangerClosed = true;
+        Mozilla.UITour.setSearchTerm('Firefox');
+        Mozilla.UITour.openSearchPanel(function() {});
+        Mozilla.UITour.setTreatmentTag('srch-chg-action', 'Try');
+        gaTrack(['_trackEvent', 'whatsnew srch-chg interactions', _trackingID, 'Try']);
+    }
+
+    /*
+     * User closes brute forced doorhanger
+     */
+    function closeForcedDoorhanger() {
+        doorhangerClosed = true;
+        $document.off('visibilitychange', handleVisibilityChange);
+        Mozilla.UITour.setTreatmentTag('srch-chg-action', 'Close');
+        gaTrack(['_trackEvent', 'whatsnew srch-chg interactions', _trackingID, 'Close']);
+    }
+
+    function showPageVariant(variant) {
+        $('header > .default').hide();
+        $('.features.default').hide();
+        $('header > .' + variant).show();
+        $('.features.' + variant).css('display', 'table');
+
+        trackPageVariant(variant);
+    }
+
+    function trackPageVariant(variant) {
+        var id;
+
+        switch(variant) {
+        case 'ravioli':
+            id = 'A';
+            break;
+        case 'flare':
+            id = 'B';
+            break;
+        case 'independence':
+            id = 'C';
+            break;
+        default:
+            id = 'Unknown';
+        }
+
+        // '1' is code for user forced to Yahoo!, which is done in-product
+        _trackingID = '1' + id;
+
+        Mozilla.UITour.setTreatmentTag('srch-chg-treatment', 'whatsnew_' + _trackingID);
+        Mozilla.UITour.setTreatmentTag('srch-chg-action', 'ShowHanger');
+        gaTrack(['_trackEvent', 'whatsnew srch-chg interactions', _trackingID, 'ShowHanger']);
+    }
+
+    function determinePageVariation() {
+        var rand = variants[Math.floor(Math.random() * variants.length)];
+
+        showPageVariant(rand);
+    }
+
+    /*
+     * Handle page visibility events to hide/show the doorhanger
+     */
+    function handleVisibilityChange() {
+        if (document.hidden) {
+            Mozilla.UITour.hideInfo();
+        } else {
+            reShowDoorhanger();
+        }
+    }
+
+    /*
+     * Reshows the doorhanger
+     */
+    function reShowDoorhanger() {
+        if (doorhangerClosed) {
+            return;
+        }
+        clearInterval(highlightTimeout);
+        highlightTimeout = setTimeout(function() {
+            Mozilla.UITour.getConfiguration('availableTargets', function (config) {
+                if (config.targets && $.inArray('search', config.targets) !== -1 && $.inArray('searchEngine-yahoo', config.targets) !== -1) {
+                    showForcedDoorhanger();
+                }
+            });
+        }, 900);
+    }
+
+    function bindEvents() {
+        queryIsLargeScreen.addListener(function(mq) {
+            if (mq.matches) {
+                reShowDoorhanger();
+            } else {
+                Mozilla.UITour.hideInfo();
+            }
+        });
+
+        $document.on('visibilitychange', handleVisibilityChange);
+    }
+
+    // use a slight delay for showing the main page content
+    // to allow variation to be set first.
+    setTimeout(function() {
+        $('main').css('visibility', 'visible');
+    }, 500);
+
+    //Only run the tour if user is on Firefox 34 and in US timezone.
+    if (window.isFirefox() && !window.isFirefoxMobile() && window.getFirefoxMasterVersion() >= 34) {
+        // set search doorhanger icon
+        icon = Mozilla.ImageHelper.isHighDpi() ? window.trans('iconHighRes') : window.trans('icon');
+
+        // query available UITour highlight targets
+        Mozilla.UITour.getConfiguration('availableTargets', function (config) {
+            if (config.targets) {
+
+                // check if search bar target is available in the UI and Yahoo is a search provider
+                if ($.inArray('search', config.targets) !== -1 && $.inArray('searchEngine-yahoo', config.targets) !== -1) {
+                    // get the user's currently selected search engine
+                    Mozilla.UITour.getConfiguration('selectedSearchEngine', function (data) {
+                        var selectedEngineID = data.searchEngineIdentifier;
+
+                        // clear the current search term if any
+                        Mozilla.UITour.setSearchTerm('');
+
+                        // check if user has yahoo as default already (should be true for all en-US users)
+                        if (selectedEngineID && selectedEngineID === 'yahoo') {
+                            determinePageVariation();
+
+                            gaTrack(['_trackEvent', 'whatsnew srch-chg interactions', 'All', 'yahooDefault']);
+                        } else {
+                            // user does not have Yahoo! as default (en-US build user outside of US timezone)
+                            Mozilla.UITour.setTreatmentTag('srch-chg-treatment', 'whatsnew_Default');
+                            Mozilla.UITour.setTreatmentTag('srch-chg-action', 'ViewPage');
+                            gaTrack(['_trackEvent', 'whatsnew srch-chg interactions', 'All', 'otherDefault']);
+                        }
+
+                        showForcedDoorhanger();
+                        bindEvents();
+                    });
+                } else {
+                    // searchbar is not present in main browser toolbar
+                    Mozilla.UITour.setTreatmentTag('srch-chg-treatment', 'whatsnew_Default');
+                    Mozilla.UITour.setTreatmentTag('srch-chg-action', 'ViewPage');
+                    gaTrack(['_trackEvent', 'whatsnew srch-chg interactions', 'All', 'noSearchbox']);
+                }
+            }
+        });
+
+        Mozilla.UITour.registerPageID(pageId);
+    }
+
+})(window.jQuery, window.Mozilla);


### PR DESCRIPTION
To test, use version 34.0 or greater:

In `about:config`, add local testing URL to `browser.uitour.testingOrigins` and set `browser.uitour.requireSecure` to `false`.

Then, hit the following URLs:
- /en-US/firefox/34.0.5/whatsnew/?oldversion=33.0 - should show doorhanger for all search engines, Sync promo if Yahoo! not default search, search messaging (1 of 3 variants) if Yahoo! is default search
- /en-US/firefox/35.0/whatsnew/?oldversion=33.0 - same as above
- /en-US/firefox/34.0.5/whatsnew/?oldversion=35.0 - should show Sync promo and _no_ doorhanger
- /en-US/firefox/34.0/whatsnew/?oldversion=33.0 - if Google is default search, should show doorhanger and 1 of 3 search messaging variants (current production functionality)
