### PR TITLE
[bug 1108671] Update view logic for showing 34.0.5 whatsnew content

### DIFF
--- a/bedrock/firefox/tests/test_base.py
+++ b/bedrock/firefox/tests/test_base.py
@@ -570,6 +570,22 @@ class TestWhatsNew(TestCase):
         eq_(template, ['firefox/search_tour/tour-34.0.5.html'])
 
     @override_settings(DEV=True)
+    def test_fx_34_0_6_with_oldversion(self, render_mock):
+        """Should use 34.0.5 search tour template for 34.0.6 with old version"""
+        req = self.rf.get('/en-US/firefox/whatsnew/?oldversion=33.0')
+        self.view(req, version='34.0.6')
+        template = render_mock.call_args[0][1]
+        eq_(template, ['firefox/search_tour/tour-34.0.5.html'])
+
+    @override_settings(DEV=True)
+    def test_fx_34_1_with_oldversion(self, render_mock):
+        """Should use 34.0.5 search tour template for 34.1 with old version"""
+        req = self.rf.get('/en-US/firefox/whatsnew/?oldversion=33.0')
+        self.view(req, version='34.1')
+        template = render_mock.call_args[0][1]
+        eq_(template, ['firefox/search_tour/tour-34.0.5.html'])
+
+    @override_settings(DEV=True)
     def test_fx_34_0_5_locale(self, render_mock):
         """Should use australis template for 34.0.5 non en-US locales"""
         req = self.rf.get('/de/firefox/whatsnew/?oldversion=33.0')

--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -283,6 +283,15 @@ def show_search_whatsnew_tour(version, oldversion):
     return oldversion < Version(version)
 
 
+def show_34_0_5_search_template(version):
+    try:
+        version = Version(version)
+    except ValueError:
+        return False
+
+    return version >= Version('34.0.5') and version < Version('36.0')
+
+
 def show_search_firstrun(version):
     try:
         version = Version(version)
@@ -408,7 +417,7 @@ class WhatsnewView(LatestFxView):
             oldversion = oldversion[3:]
         versions = ('29.', '30.', '31.', '32.')
 
-        if version.startswith('35.') or version.startswith('34.0.5'):
+        if show_34_0_5_search_template(version):
             if locale == 'en-US':
                 if show_search_whatsnew_tour('34.0', oldversion):
                     template = 'firefox/search_tour/tour-34.0.5.html'


### PR DESCRIPTION
Updated the Python view logic to make sure the new 34.0.5 /whatsnew page will get shown if there are any future 34.x releases (e.g. chemspill updates). If there's a 34.1 release for example, as it stands the old 34.0 template would get shown.
