### PR TITLE
Bug 1090468: Move transition.txt to original url.

### DIFF
--- a/bedrock/security/templates/security/index.html
+++ b/bedrock/security/templates/security/index.html
@@ -154,7 +154,7 @@
 
       <p id="pgpkey">The PGP key for security@mozilla.org below can be used to send encrypted mail
         or to verify responses received from that address. We changed keys on October 23, 2014.
-        Please see our signed <a href="/media/security/transition.txt">transition statement</a> for confirmation.</p>
+        Please see our signed <a href="/security/transition.txt">transition statement</a> for confirmation.</p>
 
 <pre class="pgp-key">
 -----BEGIN PGP PUBLIC KEY BLOCK-----

--- a/etc/httpd/global.conf
+++ b/etc/httpd/global.conf
@@ -820,6 +820,9 @@ RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?about(/?|/.+)$ /b/$1about$2 [PT]
 # Bug 1040970
 RewriteRule ^/mozillacareers$ https://wiki.mozilla.org/People/mozillacareers?utm_medium=redirect&utm_source=mozillacareers-vanity [L,R=301]
 
+# Bug 1090468
+RewriteRule ^/security/transition\.txt /media/security/transition.txt [L,PT]
+
 # Bug 1026184
 # TODO: enable this after testing and porting/archiving all pages
 #RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?security(/?|/.+)$ /b/$1security$2 [PT]


### PR DESCRIPTION
This will work for now. Was going to serve from Django but that turns out to be a pain as I didn't want the language URL component but the rest of "/security" does. Refactoring how URL locales work is a task we need to tackle before we move off of apache though.
