### PR TITLE
Bug 1090933 follow-up, Advisory titles on Product Advisories should be links

### DIFF
--- a/bedrock/security/templates/security/product-advisories.html
+++ b/bedrock/security/templates/security/product-advisories.html
@@ -48,12 +48,11 @@
         </h3>
         <ul>
         {% for advisory in version.advisories.all() %}
-          <li class="level-item"><a class="level {{ advisory.impact_class }}"
-                 href="{{ advisory.get_absolute_url() }}">{{ advisory.id }}</a> {{ advisory.title|safe }}
-          </li>
+          <li class="level-item"><a href="{{ advisory.get_absolute_url() }}">
+            <span class="level {{ advisory.impact_class }}">{{ advisory.id }}</span> {{ advisory.title|safe }}
+          </a></li>
         {% endfor %}
         </ul>
-        </li>
       {% endfor %}
 
     </div>


### PR DESCRIPTION
This was missing in #2437.
