### PR TITLE
Fix bug 1099184 - Revert "Remove 'websites' from 'testing' category for ...

### DIFF
--- a/bedrock/mozorg/forms.py
+++ b/bedrock/mozorg/forms.py
@@ -139,6 +139,7 @@ class ContributeSignupForm(forms.Form):
         ('testing-firefox', _lazy('Firefox and Firefox OS')),
         ('testing-addons', _lazy('Firefox add-ons')),
         ('testing-marketplace', _lazy('HTML5 apps')),
+        ('testing-websites', _lazy('Websites')),
         ('testing-webcompat', _lazy('Web compatibility')),
     )
     translating_choices = (


### PR DESCRIPTION
...contribute."

Attention @pmclanahan: do you recall why this was removed in ae313fa5e5d? 

And is this really all we have to do to restore it? I'm sure there's some stuff to do in ExactTarget to send the appropriate emails but maybe this is the only change on the bedrock side. Should we block this until we have the email stuff set up?
