### PR TITLE
Bug 1115066 - Thunderbird start page: add redirect to Bedrock for locales

### DIFF
--- a/etc/httpd/global.conf
+++ b/etc/httpd/global.conf
@@ -582,8 +582,8 @@ RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?thunderbird/releases/(.*)$ http://w
 RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?thunderbird/(.*)/releasenotes(.*)$ http://website-archive.mozilla.org/www.mozilla.org/thunderbird_releasenotes/en-US/thunderbird/$2/releasenotes$3 [L,R=301]
 RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?thunderbird/(.*)/system-requirements(.*)$ http://website-archive.mozilla.org/www.mozilla.org/thunderbird_releasenotes/en-US/thunderbird/$2/system-requirements$3 [L,R=301]
 
-# bug 1103396, more locales to come
-RewriteRule ^/en-US/thunderbird/release/start(/)?$ /b/en-US/thunderbird/release/start$1 [L,PT]
+# bug 1103396 for en-US, bug 1115066 for other locales
+RewriteRule ^/(ca|cs|de|en-US|es-ES|fr|fy-NL|gd|hr|hy-AM|it|nl|pt-BR|ru|sk|sl|sq|uk|zh-TW)/thunderbird/release/start(/)?$ /b/$1/thunderbird/release/start$2 [L,PT]
 
 # bug 1090468
 RewriteRule ^/security/older-alerts\.html http://website-archive.mozilla.org/www.mozilla.org/security/security/older-alerts.html [L,R=301]


### PR DESCRIPTION
Add locales currently [completely localized](https://l10n.mozilla-community.org/~pascalc/langchecker/?locale=all&website=0&file=thunderbird/start/release.lang).
