### PR TITLE
Add defaultUpdateChannel info to UITour docs.

### DIFF
--- a/docs/uitour.rst
+++ b/docs/uitour.rst
@@ -317,6 +317,14 @@ If ``'appinfo'`` is queried the object returned gives information on the users c
         console.dir(config); //{defaultUpdateChannel: "nightly", version: "36.0a1"}
     });
 
+The ``defaultUpdateChannel`` key has many possible values, the most important being:
+
+* ``'release'``
+* ``'beta'``
+* ``'aurora'``
+* ``'nightly'``
+* ``'default'`` (self-build or automated testing builds)
+
 .. Important::
 
     ``appinfo`` is only available in Firefox 35 onward.


### PR DESCRIPTION
Channel names [provided by MattN](https://bugzilla.mozilla.org/show_bug.cgi?id=1065525#c23).