### PR TITLE
[fix bug 1121209] whatsnew page for ESR24 -> ESR31 updates doesn't show Australis tour

### DIFF
--- a/bedrock/firefox/tests/test_base.py
+++ b/bedrock/firefox/tests/test_base.py
@@ -641,6 +641,26 @@ class TestWhatsNew(TestCase):
 
     # end 34.0.5 search tour tests
 
+    # ESR31 whatsnew tests
+
+    @override_settings(DEV=True)
+    def test_fx_esr_31_4_0_with_oldversion(self, render_mock):
+        """Should use australis tour template for 31.4.0 with old version"""
+        req = self.rf.get('/en-US/firefox/whatsnew/?oldversion=24.8.0')
+        self.view(req, version='31.4.0')
+        template = render_mock.call_args[0][1]
+        eq_(template, ['firefox/australis/whatsnew-tour.html'])
+
+    @override_settings(DEV=True)
+    def test_fx_esr_31_4_0_with_wrong_oldversion(self, render_mock):
+        """Should not show tour for 31.4.0 with wrong old version"""
+        req = self.rf.get('/en-US/firefox/whatsnew/?oldversion=30.0')
+        self.view(req, version='31.4.0')
+        template = render_mock.call_args[0][1]
+        eq_(template, ['firefox/australis/whatsnew-no-tour.html'])
+
+    # end ESR31 whatsnew tests
+
     @override_settings(DEV=True)
     def test_rv_prefix(self, render_mock):
         """Prefixed oldversion shouldn't impact version sniffing."""

--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -257,6 +257,15 @@ def show_devbrowser_firstrun(version):
     return False
 
 
+def show_australis_whatsnew_tour(oldversion):
+    try:
+        oldversion = Version(oldversion)
+    except ValueError:
+        return False
+
+    return oldversion < Version('29.0')
+
+
 def show_whatsnew_tour(oldversion):
     try:
         oldversion = Version(oldversion)
@@ -416,7 +425,7 @@ class WhatsnewView(LatestFxView):
         # old versions of Firefox sent a prefixed version
         if oldversion.startswith('rv:'):
             oldversion = oldversion[3:]
-        versions = ('29.', '30.', '31.', '32.')
+        versions = ('29.', '30.', '32.')
 
         if show_34_0_5_search_template(version):
             if locale == 'en-US':
@@ -445,6 +454,12 @@ class WhatsnewView(LatestFxView):
                     template = 'firefox/privacy_tour/tour.html'
                 else:
                     template = 'firefox/privacy_tour/no-tour.html'
+            else:
+                template = 'firefox/australis/whatsnew-no-tour.html'
+        # show australis tour for ESR 31 updates
+        elif version.startswith('31.'):
+            if show_australis_whatsnew_tour(oldversion):
+                template = 'firefox/australis/whatsnew-tour.html'
             else:
                 template = 'firefox/australis/whatsnew-no-tour.html'
         elif version.startswith(versions):


### PR DESCRIPTION
Adding back in a special exception to show the original Australis /whatsnew tour for ESR31 users updating from ESR24. I've manually downloaded and tested that the /whatsnew tour still runs fine on ESR31