### PR TITLE
Fix Bug 1121714 - Firefox Desktop Privacy Notice Change (Telemetry Experiments & Domains / Flash)

### DIFF
--- a/bedrock/legal/templates/legal/base-resp.html
+++ b/bedrock/legal/templates/legal/base-resp.html
@@ -2,6 +2,7 @@
  # License, v. 2.0. If a copy of the MPL was not distributed with this
  # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
 
+{% add_lang_files "legal/index" %}
 {% extends "base-resp.html" %}
 
 {% block page_css %}

--- a/bedrock/privacy/templates/privacy/base-resp.html
+++ b/bedrock/privacy/templates/privacy/base-resp.html
@@ -2,6 +2,7 @@
  # License, v. 2.0. If a copy of the MPL was not distributed with this
  # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
 
+{% add_lang_files "privacy/index" %}
 {% extends "base-resp.html" %}
 
 {% block extrahead %}


### PR DESCRIPTION
* Update Firefox Desktop Privacy Notice ([Bug 1121714](https://bugzilla.mozilla.org/show_bug.cgi?id=1121714))
* Load Firefox Hello docs of es-ES, ja and sr locales ([Bug 1121091](https://bugzilla.mozilla.org/show_bug.cgi?id=1121091))
* Include the `add_lang_files` flags to make l10n process easier ([Bug 1121091](https://bugzilla.mozilla.org/show_bug.cgi?id=1121091))