### PR TITLE
[fix bug 1122462] Download Firefox homepage promo missing small links

### DIFF
--- a/media/css/mozorg/home/home-promo.less
+++ b/media/css/mozorg/home/home-promo.less
@@ -583,6 +583,10 @@ html[lang|="en"] {
             a:focus {
                 color: #fff;
             }
+
+            &.download-other-desktop {
+                display: block !important;
+            }
         }
 
         .unsupported-download {
@@ -676,6 +680,10 @@ html[lang|="en"] {
     .promo-small-landscape.firefox-download {
         .fxos-link {
             display: inline-block;
+        }
+
+        .download-other.download-other-desktop {
+            display: none !important;
         }
     }
 }

--- a/media/js/mozorg/home/home.js
+++ b/media/js/mozorg/home/home.js
@@ -10,11 +10,6 @@ $(function () {
     var $downloadPromo = $('.promo-small-landscape.firefox-download');
     var hasTouch = 'ontouchstart' in window || navigator.msMaxTouchPoints || navigator.maxTouchPoints;
 
-    function initFirefoxDownloadPromo() {
-        // show download button small links
-        $downloadPromo.find('.download-other-desktop').show();
-    }
-
     /*
      * For non-touch devices promos are transitioned on hover
      */
@@ -196,7 +191,6 @@ $(function () {
         }
     }
 
-    initFirefoxDownloadPromo();
     initEllipsis();
     initFacesGrid();
 


### PR DESCRIPTION
Minor regression from #2518

As a side-note, I don't feel too great about having to add more instances of `!important` on other pages where this is used. This is ok for now, but perhaps a better long term option might be to show these links using a configurable option passed in with the download button helper?