### PR TITLE
[bug 787269] Redirect signed-script pages to MDN article

### DIFF
--- a/etc/httpd/global.conf
+++ b/etc/httpd/global.conf
@@ -82,6 +82,9 @@ RewriteRule ^/projects/index\.(de|fr|hr|sq)\.html$ /$1/products/ [L,R=301]
 # bug 856075
 RewriteRule ^/projects/technologies\.html$ https://developer.mozilla.org/docs/Mozilla/Using_Mozilla_code_in_other_projects [L,R=301]
 
+# bug 787269
+RewriteRule ^/projects/security/components/signed-script(?:s|-example)\.html$ https://developer.mozilla.org/docs/Bypassing_Security_Restrictions_and_Signing_Code [L,R=301]
+
 # bug 874526, 877698
 RewriteRule ^/projects/security/components(.*)$ http://www-archive.mozilla.org/projects/security/components$1 [L,R=301]
 
@@ -536,9 +539,6 @@ RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?projects/mathml/demo/texvsmml.html$ https://
 RewriteRule ^/projects/mathml(?:/(?:index.html|demo(?:/(?:index.html)?)?)?)?$ https://developer.mozilla.org/en-US/docs/Mozilla/MathML_Project [L,R=301]
 RewriteRule ^/projects/mathml/fonts(?:/(?:index.html)?)?$ https://developer.mozilla.org/Mozilla_MathML_Project/Fonts [L,R=301]
 RewriteRule ^/projects/mathml/screenshots(?:/(?:index.html)?)?$ https://developer.mozilla.org/Mozilla_MathML_Project/Screenshots [L,R=301]
-
-# bug 787269
-RewriteRule ^/projects/security/components/signed-script(?:s|-example)\.html$ https://developer.mozilla.org/docs/Bypassing_Security_Restrictions_and_Signing_Code [L,R=301]
 
 # bug 878039
 RewriteRule ^/access/architecture.html$ https://developer.mozilla.org/en-US/docs/Mozilla/Accessibility/Accessibility_architecture [L,R=301]


### PR DESCRIPTION
Checking on dev, it looks like the redirect in #2645 didn't work correctly. I think this is just because it needs to be above the rule on Line 89. @jgmize r?