### PR TITLE
Ignore ESR when checking isFirefoxUpToDate. Bug 1122154.

### DIFF
--- a/media/js/base/global.js
+++ b/media/js/base/global.js
@@ -110,10 +110,10 @@ function isFirefox(userAgent) {
     );
 }
 
-function isFirefoxUpToDate(latest, esr) {
+// 2015-01-20: Gives no special consideration to ESR builds
+function isFirefoxUpToDate(latest) {
     var $html = $(document.documentElement);
     var fx_version = getFirefoxMasterVersion();
-    var esrFirefoxVersions = esr || $html.data('esr-versions');
     var latestFirefoxVersion;
 
     if (!latest) {
@@ -123,8 +123,7 @@ function isFirefoxUpToDate(latest, esr) {
         latestFirefoxVersion = parseInt(latest.split('.')[0], 10);
     }
 
-    return ($.inArray(fx_version, esrFirefoxVersions) !== -1 ||
-            latestFirefoxVersion <= fx_version);
+    return (latestFirefoxVersion <= fx_version);
 }
 
 // used in bedrock for desktop specific checks like `isFirefox() && !isFirefoxMobile()`

--- a/media/js/test/spec/global.js
+++ b/media/js/test/spec/global.js
@@ -275,38 +275,30 @@ describe('global.js', function() {
 
     describe('isFirefoxUpToDate', function () {
 
-        it('should consider up to date if latest is equal to firefox version', function() {
+        it('should consider up to date if latest version is equal to user version', function() {
             var result;
             /* Use a stub to return a pre-programmed value
              * from getFirefoxMasterVersion */
             getFirefoxMasterVersion = sinon.stub().returns(21);
-            result = isFirefoxUpToDate('21.0', [10, 17]);
+            result = isFirefoxUpToDate('21.0');
             expect(getFirefoxMasterVersion.called).toBeTruthy();
             expect(result).toBeTruthy();
         });
 
-        it('should consider up to date if latest is less than firefox version', function() {
+        it('should consider up to date if latest version is less than user version', function() {
             var result;
             getFirefoxMasterVersion = sinon.stub().returns(22);
-            result = isFirefoxUpToDate('21.0', [10, 17]);
+            result = isFirefoxUpToDate('21.0');
             expect(getFirefoxMasterVersion.called).toBeTruthy();
             expect(result).toBeTruthy();
         });
 
-        it('should not consider up to date if latest greater than firefox version', function() {
+        it('should not consider up to date if latest version greater than user version', function() {
             var result;
             getFirefoxMasterVersion = sinon.stub().returns(20);
-            result = isFirefoxUpToDate('21.0', [10, 17]);
+            result = isFirefoxUpToDate('21.0');
             expect(getFirefoxMasterVersion.called).toBeTruthy();
             expect(result).not.toBeTruthy();
-        });
-
-        it('should consider esr builds up to date', function() {
-            var result;
-            getFirefoxMasterVersion = sinon.stub().returns(10);
-            result = isFirefoxUpToDate('21.0', [10, 17]);
-            expect(getFirefoxMasterVersion.called).toBeTruthy();
-            expect(result).toBeTruthy();
         });
     });
 


### PR DESCRIPTION
On a related note, it no longer seems that [`data-esr-versions`](https://github.com/mozilla/bedrock/blob/master/bedrock/base/templates/base-resp.html#L6) is used. As it doesn't hurt anything, and may be of use in the future, did not remove from the templates.