### PR TITLE
Bug 1125971 - Fixing quotes on /fr/privacy/tips/ and removing extra spac...

### DIFF
--- a/bedrock/privacy/templates/privacy/privacy-day.html
+++ b/bedrock/privacy/templates/privacy/privacy-day.html
@@ -108,10 +108,7 @@ set share_urls = {
               </p>
             </div>
             <aside>
-              <p class="quote">
-                {{ _('Privacy is at the heart of freedom and autonomy…') }}
-                {{ _('It’s up to all of us to get involved and speak up so that it stays that way.') }}
-              </p>
+              <p class="quote">{{ _('Privacy is at the heart of freedom and autonomy…') }} {{ _('It’s up to all of us to get involved and speak up so that it stays that way.') }}</p>
               <p class="attribute">{{ _('— Michelle De Mooy, Deputy Director, Consumer Privacy Project at the Center for Democracy & Technology') }}</p>
             </aside>
             <ul class="tip-footer">
@@ -155,10 +152,7 @@ Privacy Matters”') }}">
               </div>
             </div>
             <aside>
-              <p class="quote">
-                {{ _('Our online houses are becoming increasingly built of glass… visible to whoever wants to look.') }}
-                {{ _('Let’s ask ourselves: Do we want to live in a house or a fishbowl?') }}
-              </p>
+              <p class="quote">{{ _('Our online houses are becoming increasingly built of glass… visible to whoever wants to look.') }} {{ _('Let’s ask ourselves: Do we want to live in a house or a fishbowl?') }}</p>
               <p class="attribute">{{ _('— Mitchell Baker, Mozilla') }}</p>
             </aside>
             <ul class="tip-footer">
@@ -236,9 +230,7 @@ Privacy Matters”') }}">
               </ul>
             </div>
             <aside>
-              <p class="quote">
-                {{ _('Each of us should have a meaningful choice about where and how our data is stored and managed.') }}
-              </p>
+              <p class="quote">{{ _('Each of us should have a meaningful choice about where and how our data is stored and managed.') }}</p>
               <p class="attribute">{{ _('— Mitchell Baker, Mozilla') }}</p>
             </aside>
             <ul class="tip-footer">

--- a/media/css/privacy/privacy-day.less
+++ b/media/css/privacy/privacy-day.less
@@ -280,6 +280,16 @@ html[lang^='en'] #tips-nav-direct li a span:after {
 }
 
 
+[lang="fr"] .tip aside .quote {
+    &:before{
+        content: "« ";
+        left: -1em;
+    }
+    &:after {
+        content: " »";
+    }
+}
+
 /* 1. ASK section */
 
 .charts {


### PR DESCRIPTION
...e before the closing quotation mark

the <!-- --> are here to remove the extra space between the string and the closing quotation mark. That's a bit of a hack, let me know if you think of something cleaner ;)