### PR TITLE
Reorder deployment to keep the git repo clean.

### DIFF
--- a/bin/update/deploy_base.py
+++ b/bin/update/deploy_base.py
@@ -22,19 +22,51 @@ NEW_RELIC_URL = 'https://rpm.newrelic.com/deployments.xml'
 GITHUB_URL = 'https://github.com/mozilla/bedrock/compare/{oldrev}...{newrev}'
 
 
+# ########## Commands run by chief ##############
+# the following 3 tasks are run directly by chief, in order.
+
+@task
+def pre_update(ctx, ref=settings.UPDATE_REF):
+    commands['update_code'](ref)
+    commands['update_locales']()
+    commands['update_revision_file']()
+    commands['update_info']()
+
+
+@task
+def update(ctx):
+    commands['checkin_changes']()
+    commands['database']()
+    commands['update_assets']()
+    if 'update_cron' in commands:
+        commands['update_cron']()
+    commands['reload_crond']()
+
+
+@task
+def deploy(ctx):
+    commands['deploy_app']()
+    commands['ping_newrelic']()
+
+
+# ########## End Commands run by chief ##############
+
+
 def management_cmd(ctx, cmd):
     """Run a Django management command correctly."""
-    with ctx.lcd(settings.SRC_DIR):
+    with ctx.lcd(settings.WWW_DIR):
         ctx.local('LANG=en_US.UTF-8 {0} manage.py {1}'.format(PYTHON, cmd))
 
 
 @task
 def reload_crond(ctx):
+    """Restart cron daemon."""
     ctx.local("killall -SIGHUP crond")
 
 
 @task
 def update_code(ctx, tag):
+    """Update the code via git."""
     with ctx.lcd(settings.SRC_DIR):
         ctx.local("git fetch --all")
         ctx.local("git checkout -f %s" % tag)
@@ -45,12 +77,14 @@ def update_code(ctx, tag):
 
 @task
 def update_locales(ctx):
+    """Update translations via svn."""
     with ctx.lcd(os.path.join(settings.SRC_DIR, 'locale')):
         ctx.local("svn up")
 
 
 @task
 def update_assets(ctx):
+    """Compile/compress static assets and fetch external data."""
     management_cmd(ctx, 'compress_assets')
     management_cmd(ctx, 'update_product_details')
     management_cmd(ctx, 'update_externalfiles')
@@ -59,6 +93,7 @@ def update_assets(ctx):
 
 @task
 def update_revision_file(ctx):
+    """Add a file containing the current git hash to media."""
     with ctx.lcd(settings.SRC_DIR):
         ctx.local("mv media/revision.txt media/prev-revision.txt")
         ctx.local("git rev-parse HEAD > media/revision.txt")
@@ -66,16 +101,19 @@ def update_revision_file(ctx):
 
 @task
 def database(ctx):
+    """Update the database."""
     management_cmd(ctx, 'syncdb --migrate --noinput')
 
 
 @task
 def checkin_changes(ctx):
+    """Sync files from SRC_DIR to WWW_DIR ignoring .git"""
     ctx.local(settings.DEPLOY_SCRIPT)
 
 
 @hostgroups(settings.WEB_HOSTGROUP, remote_kwargs={'ssh_key': settings.SSH_KEY})
 def deploy_app(ctx):
+    """Push code to the webheads"""
     ctx.remote(settings.REMOTE_UPDATE_SCRIPT)
 #    ctx.remote("/bin/touch %s" % settings.REMOTE_WSGI)
     ctx.remote("service httpd graceful")
@@ -83,6 +121,7 @@ def deploy_app(ctx):
 
 @task
 def update_info(ctx):
+    """Add a bunch of info to the deploy log."""
     with ctx.lcd(settings.SRC_DIR):
         ctx.local("date")
         ctx.local("git branch")
@@ -92,13 +131,12 @@ def update_info(ctx):
         with ctx.lcd("locale"):
             ctx.local("svn info")
             ctx.local("svn status")
-    management_cmd(ctx, 'migrate --list')
 
 
 @task
 def ping_newrelic(ctx):
     if NEW_RELIC_API_KEY and NEW_RELIC_APP_ID:
-        with ctx.lcd(settings.SRC_DIR):
+        with ctx.lcd(settings.WWW_DIR):
             oldrev = ctx.local('cat media/prev-revision.txt').out.strip()
             newrev = ctx.local('cat media/revision.txt').out.strip()
             log_cmd = 'git log --oneline {0}..{1}'.format(oldrev, newrev)
@@ -121,30 +159,6 @@ def ping_newrelic(ctx):
             urllib2.urlopen(request)
         except urllib2.URLError as exp:
             print 'Error notifying New Relic: {0}'.format(exp)
-
-
-@task
-def pre_update(ctx, ref=settings.UPDATE_REF):
-    commands['update_code'](ref)
-    commands['update_info']()
-
-
-@task
-def update(ctx):
-    commands['database']()
-    commands['update_assets']()
-    commands['update_locales']()
-    commands['update_revision_file']()
-    commands['reload_crond']()
-
-
-@task
-def deploy(ctx):
-    if 'update_cron' in commands:
-        commands['update_cron']()
-    commands['checkin_changes']()
-    commands['deploy_app']()
-    commands['ping_newrelic']()
 
 
 @task
@@ -193,7 +207,7 @@ def generate_desc(from_commit, to_commit, changelog):
 
 
 def generate_cron_file(ctx, tmpl_name):
-    with ctx.lcd(settings.SRC_DIR):
+    with ctx.lcd(settings.WWW_DIR):
         ctx.local("{python} bin/gen-crons.py -p {python} -s {src_dir} -w {www_dir} "
                   "-t {template}".format(python=PYTHON,
                                          src_dir=settings.SRC_DIR,


### PR DESCRIPTION
Deployment updates the code via git, then syncs
the files to another directory for processing,
then syncs the files to the servers. It was doing
a lot of processing in the git repo thus creating
a lot of extra files that can cause problems. Moving
this creation to the destination dir means rsync will
clean these up every time and the git repo remains
pristine.