### PR TITLE
Bug 1128957 - Fix block parsing errors in jinja templates

### DIFF
--- a/bedrock/firefox/templates/firefox/nightly_firstrun.html
+++ b/bedrock/firefox/templates/firefox/nightly_firstrun.html
@@ -75,7 +75,7 @@
     {% if l10n_has_tag('promo_locale') %}
     {# The following block is entirely defined by locales, and the placeholder in en-US here will never be exposed to production #}
       <div class="blue-box l10n">
-        {% l10n promo_locale %}
+        {% l10n promo_locale 20150101 %}
           <h3>Learn more about your local Mozilla community</h3>
           <ul class="unstyled">
             <li><a href="http://www.example.com">Meet our community</a></li>

--- a/bedrock/mozorg/templates/mozorg/about/governance/policies/commit.html
+++ b/bedrock/mozorg/templates/mozorg/about/governance/policies/commit.html
@@ -23,7 +23,7 @@
 
 <h2 id="procedure">{{ _('Procedure') }}</h2>
 
-<p>{{ _('Here is a list of the steps that need to happen to become a Mozilla committer. Employment with any particular entity (including the Mozilla Foundation or Corporation) does not change the need to follow these steps.') }}</p> 
+<p>{{ _('Here is a list of the steps that need to happen to become a Mozilla committer. Employment with any particular entity (including the Mozilla Foundation or Corporation) does not change the need to follow these steps.') }}</p>
 
 <ol>
   <li>{% trans policy=url('mozorg.about.governance.policies.commit.access-policy') %}
@@ -62,7 +62,7 @@ You will need one or more vouchers. The <a href="{{ policy }}">Commit Access Pol
 {% endtrans %}</p>
 
 <h2 id="revoking-commit-access">{{ _('Revoking Commit Access') }}</h2>
-<p>{{ _('If someone consistently causes difficulties with these source repositories due to poor behavior or other serious problems then commit access may be revoked. We have no precise process for this as it has been a rare or nonexistent problem to date. The process for this is for one or more committers with concerns to notify the owner of the Commit Access Policy sub-module if you have clear examples of someone whom you believe has reached this level of problem. Do not do so carelessly, or based on passing irritation or without a sense that you are not alone in your concerns. The Commit Access Policy owner will investigate or cause an investigation to occur, privately at first and perhaps completely privately.') }}</p> 
+<p>{{ _('If someone consistently causes difficulties with these source repositories due to poor behavior or other serious problems then commit access may be revoked. We have no precise process for this as it has been a rare or nonexistent problem to date. The process for this is for one or more committers with concerns to notify the owner of the Commit Access Policy sub-module if you have clear examples of someone whom you believe has reached this level of problem. Do not do so carelessly, or based on passing irritation or without a sense that you are not alone in your concerns. The Commit Access Policy owner will investigate or cause an investigation to occur, privately at first and perhaps completely privately.') }}</p>
 
 <h2 id="dormant-accounts">{{ _('Dormant Accounts') }}</h2>
 <p>{{ _('If your account in a particular SCM is inactive for more than 6 months, it may be deactivated. However, the knowledge that you have achieved a particular level of access is retained. Therefore, getting your account reactivated is a simple matter of filing a bug asking IT to turn it back on. Such bugs should be dealt with extremely quickly.') }}</p>
@@ -77,4 +77,4 @@ You will need one or more vouchers. The <a href="{{ policy }}">Commit Access Pol
   {% endtrans %}</li>
 </ul>
 
-{%endblock%}
+{% endblock %}

--- a/bedrock/mozorg/templates/mozorg/about/governance/policies/commit/access-policy.html
+++ b/bedrock/mozorg/templates/mozorg/about/governance/policies/commit/access-policy.html
@@ -179,4 +179,4 @@ projects/firefox-lorentz
 
 <p>{{ _('...plus any other repo from which code is merged to any of the above without a thorough review at merge time.') }}</p>
 
-{%endblock%}
+{% endblock %}

--- a/bedrock/mozorg/templates/mozorg/about/governance/policies/commit/requirements.html
+++ b/bedrock/mozorg/templates/mozorg/about/governance/policies/commit/requirements.html
@@ -80,4 +80,4 @@ came from such a repository; and') }}</li>
 conforms to sections 2 and 3 of this document.') }}</li>
 </ol>
 
-{%endblock%}
+{% endblock %}

--- a/bedrock/mozorg/templates/mozorg/about/governance/policies/participation.html
+++ b/bedrock/mozorg/templates/mozorg/about/governance/policies/participation.html
@@ -67,4 +67,4 @@
 
 <p>{{_('Engaging the <a href="https://wiki.mozilla.org/Conductors">Conductors Group</a>. The Conductors group was formed to deal with difficult communications; and with helping people learn how to communicate in a more productive way. The conductors are a good place to ask for advice in how to raise a topic directly, and what sorts of other interventions may be possible and appropriate. You can contact the group, or any member of it. If you don’t know anyone in the group ask people you trust for a recommendation to someone in the group. Or you can talk to the module owner Stormy Peters. Stormy is the module owner because she has a lot of experience but also because of her discretion. If you don’t know any of the conductors then ask people you do know and trust for a recommendation, or start with Stormy. If you know a lot of the conductors but have reasons that make you uncomfortable with anyone in the Conductors group, then you have an issue for the Module Ownership peers. Once again you can contact the group or any particular member of it.')}}</p>
 
-{%endblock%}
+{% endblock %}

--- a/bedrock/mozorg/templates/mozorg/about/governance/policies/policies.html
+++ b/bedrock/mozorg/templates/mozorg/about/governance/policies/policies.html
@@ -72,4 +72,4 @@
   <li><a href="{{ url('foundation.licensing.website-markup') }}">{{ _('Website Markup Usage Policy') }}</a></li>
   <li><a href="{{ url('foundation.licensing.website-content') }}">{{ _('Mozilla.org Site Licensing Policies') }}</a></li>
 </ul>
-{%endblock%}
+{% endblock %}

--- a/bedrock/mozorg/templates/mozorg/about/governance/policies/security/bugs.html
+++ b/bedrock/mozorg/templates/mozorg/about/governance/policies/security/bugs.html
@@ -14,7 +14,6 @@
   <h1 class="title-banner">{{ _('Handling Mozilla Security Bugs') }}</h1>
 
   <p>{{ _(' Version 1.1') }}</p>
-  <p>{{ _('') }}</p>
 
   <p><strong>{% trans mail='mailto:security@mozilla.org?subject=Mozilla%20security%20bug%20report' %}
     IMPORTANT: Anyone who believes they have found a Mozilla-related security vulnerability can and should report

--- a/bedrock/mozorg/templates/mozorg/about/governance/policies/security/certs/inclusion.html
+++ b/bedrock/mozorg/templates/mozorg/about/governance/policies/security/certs/inclusion.html
@@ -141,4 +141,4 @@
 <p>{{ _('Please contact Mozilla at <a href="mailto:certificates@mozilla.org">certificates@mozilla.org</a> for more information about this policy and answers to related questions.') }}</p>
 <p>{{ _('We reserve the right to change this policy in the future. We will do so only after consulting with the public Mozilla community, in order to ensure that all views are taken into account.') }}</p>
 
-{%endblock%}
+{% endblock %}

--- a/bedrock/mozorg/templates/mozorg/about/governance/policies/security/certs/maintenance.html
+++ b/bedrock/mozorg/templates/mozorg/about/governance/policies/security/certs/maintenance.html
@@ -90,4 +90,4 @@
 
 <p>{{ _('We reserve the right to change this policy in the future. We will do so only after consulting with the public Mozilla community, in order to ensure that all views are taken into account.') }}</p>
 
-{%endblock%}
+{% endblock %}


### PR DESCRIPTION
- replace {%endblock%} by {% endblock %}
- fix a bug in nightly firefox firstrun page which didn't have a date set for the promo_locale l10n block

The issues above were causing parsing errors of templates when using the './manage.py l10n_check' command

- remove empty <p>{{ _('') }}</p> (no visual impact on the page after removing it)
This issue was causing a warning in the logs:
"warning: Empty msgid.  It is reserved by GNU gettext: gettext("") returns the header entry with meta information, not the empty string."

Note that a couple of trailing spaces in the templates were removed.