### PR TITLE
Fix Bug 1128885 - Plugincheck-site considers 31.4.0ESR out of date

### DIFF
--- a/media/js/base/global.js
+++ b/media/js/base/global.js
@@ -121,6 +121,22 @@ function isFirefoxMobile(userAgent) {
     return /Mobile|Tablet|Fennec/.test(ua);
 }
 
+// Detect Firefox 31 ESR using navigator.buildID. 20140716183446 is the *non-ESR*
+// build ID that can be found at https://wiki.mozilla.org/Releases/Firefox_31/Test_Plan
+// Since this is a simple and only way to detect ESR, there would be some false
+// positives if the browser is a pre-release (Nightly, Aurora, Beta), semi-official
+// (e.g. Ubuntu build by Canonical) or unofficial version of Firefox 31, because
+// those builds have a different build ID from the official non-ESR build.
+function isFirefox31ESR(userAgent, buildID) {
+    userAgent = userAgent || navigator.userAgent;
+    buildID = buildID || navigator.buildID;
+
+    return !isFirefoxMobile(userAgent) &&
+        getFirefoxMasterVersion(userAgent) === 31 &&
+        buildID && buildID !== '20140716183446';
+}
+
+
 // Create text translation function using #strings element.
 // TODO: Move to docs
 // In order to use it, you need a block string_data bit inside your template,

--- a/media/js/plugincheck/check-plugins.js
+++ b/media/js/plugincheck/check-plugins.js
@@ -10,7 +10,7 @@ $(function() {
     }
 
     // show for outdated Fx versions
-    if (isFirefox() &&  !isFirefoxUpToDate()) {
+    if (isFirefox() &&  !isFirefoxUpToDate() && !isFirefox31ESR()) {
         outdatedFx.show();
     }
 

--- a/media/js/test/spec/global.js
+++ b/media/js/test/spec/global.js
@@ -273,6 +273,24 @@ describe('global.js', function() {
 
     });
 
+    describe('isFirefox31ESR', function () {
+
+        it('should return true for Firefox ESR', function () {
+            // Firefox 31 ESR
+            expect(isFirefox31ESR('Mozilla/5.0 (Windows NT 6.1; Win64; x64; rv:31.0) Gecko/20100101 Firefox/31.0', '20140717132905')).toBeTruthy();
+            // Firefox 31.4.0 ESR
+            expect(isFirefox31ESR('Mozilla/5.0 (Windows NT 6.1; Win64; x64; rv:31.0) Gecko/20100101 Firefox/31.0', '20150105205548')).toBeTruthy();
+        });
+
+        it('should return false for Firefox non-ESR', function () {
+            // Firefox 31 non-ESR
+            expect(isFirefox31ESR('Mozilla/5.0 (Windows NT 6.1; Win64; x64; rv:31.0) Gecko/20100101 Firefox/31.0', '20140716183446')).toBeFalsy();
+            // Firefox 35
+            expect(isFirefox31ESR('Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:35.0) Gecko/20100101 Firefox/35.0', '20150122214805')).toBeFalsy();
+        });
+
+    });
+
     describe('isFirefoxUpToDate', function () {
 
         it('should consider up to date if latest version is equal to user version', function() {


### PR DESCRIPTION
This is the same ESR user detection as I recently implemented on Tabzilla in #2680.