### PR TITLE
Fix Bug 1129624 - Update Firefox Developer Edition download links

### DIFF
--- a/bedrock/firefox/firefox_details.py
+++ b/bedrock/firefox/firefox_details.py
@@ -8,9 +8,6 @@ from product_details import ProductDetails
 # TODO: port this to django-mozilla-product-details
 class FirefoxDetails(ProductDetails):
     download_base_url_direct = 'https://download.mozilla.org/'
-    download_base_url_transition = '/products/download.html'
-    download_base_url_aurora = 'http://ftp.mozilla.org/pub/mozilla.org/firefox/' \
-                               'nightly/latest-mozilla-aurora'
 
     platform_info = {
         'Windows': {
@@ -168,16 +165,22 @@ class FirefoxDetails(ProductDetails):
                          ])])
 
     def _get_aurora_download_url(self, platform, language, version):
-        base_url = self.download_base_url_aurora
-        if language != 'en-US':
-            base_url += '-l10n'
+        # Download links are different for localized versions
+        if language == 'en-US':
+            if platform == 'Windows':
+                product = 'firefox-aurora-stub'
+            else:
+                product = 'firefox-aurora-latest-ssl'
+        else:
+            product = 'firefox-aurora-latest-l10n'
 
-        return '{base_url}/firefox-{version}.{lang}.{file_ext}'.format(
-            base_url=base_url,
-            version=version,
-            lang=language,
-            file_ext=self.platform_info[platform]['file_ext']
-        )
+        return '?'.join([self.download_base_url_direct,
+                         urlencode([
+                             ('product', product),
+                             ('os', self.platform_info[platform]['id']),
+                             # Order matters, lang must be last for bouncer.
+                             ('lang', language),
+                         ])])
 
 
 class MobileDetails(ProductDetails):

--- a/bedrock/firefox/tests/test_base.py
+++ b/bedrock/firefox/tests/test_base.py
@@ -122,19 +122,45 @@ class TestFirefoxDetails(TestCase):
     @patch.dict(firefox_details.firefox_versions,
                 FIREFOX_AURORA='28.0a2')
     def test_get_download_url_aurora(self):
-        """The Aurora version should give us an FTP url."""
+        """
+        The Aurora version should give us a permanent url. For Windows, a url of
+        the stub installer is used.
+        """
+        url = firefox_details.get_download_url('Windows', 'en-US', '28.0a2')
+        self.assertListEqual(parse_qsl(urlparse(url).query),
+                             [('product', 'firefox-aurora-stub'),
+                              ('os', 'win'),
+                              ('lang', 'en-US')])
         url = firefox_details.get_download_url('OS X', 'en-US', '28.0a2')
-        self.assertIn('ftp.mozilla.org', url)
-        self.assertIn('latest-mozilla-aurora/firefox-28.0a2.en-US.mac.dmg', url)
+        self.assertListEqual(parse_qsl(urlparse(url).query),
+                             [('product', 'firefox-aurora-latest-ssl'),
+                              ('os', 'osx'),
+                              ('lang', 'en-US')])
+        url = firefox_details.get_download_url('Linux', 'en-US', '28.0a2')
+        self.assertListEqual(parse_qsl(urlparse(url).query),
+                             [('product', 'firefox-aurora-latest-ssl'),
+                              ('os', 'linux'),
+                              ('lang', 'en-US')])
 
     @patch.dict(firefox_details.firefox_versions,
                 FIREFOX_AURORA='28.0a2')
     def test_get_download_url_aurora_l10n(self):
-        """Aurora non en-US should have a slightly different path."""
+        """Aurora non en-US should have a different product name."""
+        url = firefox_details.get_download_url('Windows', 'pt-BR', '28.0a2')
+        self.assertListEqual(parse_qsl(urlparse(url).query),
+                             [('product', 'firefox-aurora-latest-l10n'),
+                              ('os', 'win'),
+                              ('lang', 'pt-BR')])
+        url = firefox_details.get_download_url('OS X', 'pt-BR', '28.0a2')
+        self.assertListEqual(parse_qsl(urlparse(url).query),
+                             [('product', 'firefox-aurora-latest-l10n'),
+                              ('os', 'osx'),
+                              ('lang', 'pt-BR')])
         url = firefox_details.get_download_url('Linux', 'pt-BR', '28.0a2')
-        self.assertIn('ftp.mozilla.org', url)
-        self.assertIn('latest-mozilla-aurora-l10n/firefox-28.0a2.pt-BR.linux-i686.tar.bz2',
-                      url)
+        self.assertListEqual(parse_qsl(urlparse(url).query),
+                             [('product', 'firefox-aurora-latest-l10n'),
+                              ('os', 'linux'),
+                              ('lang', 'pt-BR')])
 
     @override_settings(STUB_INSTALLER_LOCALES={'win': settings.STUB_INSTALLER_ALL})
     def get_download_url_ssl(self):

--- a/bedrock/mozorg/tests/test_helper_download_buttons.py
+++ b/bedrock/mozorg/tests/test_helper_download_buttons.py
@@ -50,9 +50,6 @@ GOOD_VERSIONS = {
     'FIREFOX_ESR': '24.1.0esr',
 }
 
-AURORA_DIR = ('https://ftp.mozilla.org/pub/mozilla.org/firefox/nightly/'
-              'latest-mozilla-aurora')
-
 mkln = make_download_link
 
 


### PR DESCRIPTION
Remove unused code in the download buttons as well.