### PR TITLE
Fix Bug 1129911 - Text error in https://www.mozilla.org/en-US/about/governance/policies/commit/

### DIFF
--- a/bedrock/mozorg/templates/mozorg/about/governance/policies/commit.html
+++ b/bedrock/mozorg/templates/mozorg/about/governance/policies/commit.html
@@ -42,8 +42,8 @@
   <li>{% trans requirements=url('mozorg.about.governance.policies.commit.requirements') %}
     Make sure you are happy with the <a href="{{ requirements }}">Commit Access Requirements</a>.
   {% endtrans %}</li>
+  <li>{{ _('Add a comment to the bug saying “I have read, and agree to abide by, the Commit Access Requirements.”') }}</li>
   <li>{{ _('Get your voucher(s), and/or the owner of the exception tree you want access for, to add a comment to the bug saying they support your application.') }}</li>
-  <li>{{ _('An appropriate Mozilla representative will update the bug when they have received your signed Agreement.') }}</li>
   <li>{{ _('So, to recap, the bug needs:') }}
     <ul>
       <li>{{ _('Declaration of what level you want and the email address to use') }}


### PR DESCRIPTION
This page has not been localized so no need to wait l10n. Very chore-ish. Such a paragrach. Wow.