### PR TITLE
Fix Bug 1130160 - Extra '#' in section headers for roll up pages

### DIFF
--- a/bedrock/security/templates/security/product-advisories.html
+++ b/bedrock/security/templates/security/product-advisories.html
@@ -42,10 +42,10 @@
       {% include "security/partials/impact_key.html" %}
 
       {% for version in product_versions %}
-        <h3 id="{{ version.html_id }}" class="level-heading">
-          <a class="anchor" href="#{{ version.html_id }}">#</a>
+        <h3 id="{{ version.html_id }}" class="level-heading"><a href="#{{ version.html_id }}">
+          <span class="anchor">#</span>
           Fixed in {{ version.name }}
-        </h3>
+        </a></h3>
         <ul>
         {% for advisory in version.advisories.all() %}
           <li class="level-item"><a href="{{ advisory.get_absolute_url() }}">

--- a/media/css/security/security.less
+++ b/media/css/security/security.less
@@ -106,9 +106,25 @@ p.note {
 
 .level-heading {
     position: relative;
+
+    a {
+        color: inherit;
+        text-decoration: none;
+
+        &:hover,
+        &:focus,
+        &:active {
+            .anchor {
+                visibility: visible;
+            }
+        }
+    }
+
     .anchor {
         position: absolute;
         left: -1em;
+        width: 1em;
+        visibility: hidden;
         .font-size(@baseFontSize);
         color: @textColorLight;
         vertical-align: middle;


### PR DESCRIPTION
I pushed -f the branch before committing and #2710 was automatically closed :confused: I cannot reopen the PR so let me try again... :abillings agreed in the [bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1130160) to use hidden anchors I proposed, rather than removing those # signs entirely.