### PR TITLE
Bug 1131060 - Mozilla Myanmar Community's Facebook Page Link Update

### DIFF
--- a/bedrock/mozorg/templates/mozorg/contact/communities/myanmar.html
+++ b/bedrock/mozorg/templates/mozorg/contact/communities/myanmar.html
@@ -18,7 +18,7 @@
           <li><a href="https://lists.mozilla.org/listinfo/dev-l10n-my" class="email">{{ _('Mailing list') }}</a></li>
           <li><a href="irc://irc.mozilla.org/mozmm" class="irc">IRC: #mozmm</a></li>
           <li><a href="https://twitter.com/MozillaMyanmar" class="twitter">@MozillaMyanmar</a></li>
-          <li><a href="https://www.facebook.com/MozillaMM" class="facebook">Facebook</a></li>
+          <li><a href="https://www.facebook.com/mozillamyanmar" class="facebook">Facebook</a></li>
         </ul>
 
         <figure class="feature-img">


### PR DESCRIPTION
We have shut down our old Facebook page and now we are using the new one to post community updates.

Facebook Link: https://www.facebook.com/mozillamyanmar