### PR TITLE
Fix bug 1131738: Mark advisory reporter as safe.

### DIFF
--- a/bedrock/security/management/commands/update_security_advisories.py
+++ b/bedrock/security/management/commands/update_security_advisories.py
@@ -13,7 +13,6 @@ from subprocess import check_call, Popen, PIPE, STDOUT
 from django.conf import settings
 from django.core.cache import cache
 from django.core.management.base import NoArgsCommand, BaseCommand
-from django.db import transaction
 
 from dateutil.parser import parse as parsedate
 
@@ -97,7 +96,6 @@ def get_current_git_hash():
     return p.communicate()[0].strip()
 
 
-@transaction.commit_on_success
 def delete_files(filenames):
     ids = []
     for filename in filenames:
@@ -107,7 +105,6 @@ def delete_files(filenames):
     SecurityAdvisory.objects.filter(id__in=ids).delete()
 
 
-@transaction.commit_on_success
 def add_or_update_advisory(data, html):
     """
     Add or update an advisory in the database.

--- a/bedrock/security/templates/security/advisory.html
+++ b/bedrock/security/templates/security/advisory.html
@@ -27,7 +27,7 @@
         {% endif %}
         {% if advisory.reporter %}
           <dt>Reporter</dt>
-          <dd>{{ advisory.reporter }}</dd>
+          <dd>{{ advisory.reporter|safe }}</dd>
         {% endif %}
         {% if 'risk' in advisory.extra_data %}
           <dt>Risk</dt>


### PR DESCRIPTION
Also remove transaction management from update
advisories command as it breaks things in dev
mode (sqlite) and isn't necessary for this.