### PR TITLE
Bug 1132323: change Tabzilla heading ID

### DIFF
--- a/bedrock/styleguide/templates/styleguide/communications/copy-rules.html
+++ b/bedrock/styleguide/templates/styleguide/communications/copy-rules.html
@@ -166,7 +166,7 @@
     <dd>capitalized when talking about the feature in Firefox, lowercase when using it only as a descriptive term; avoid “Firefox Sync” where possible</dd>
     <dt id="tablet">tablet</dt>
     <dd>use primarily to differentiate from a phone, otherwise use “mobile device” where possible</dd>
-    <dt id="tabzilla">Tabzilla</dt>
+    <dt id="tabzilla-heading">Tabzilla</dt>
     <dd>our internal name for the Mozilla universal tab that appears at the top of our sites; avoid using in user-facing communications or explain on first reference</dd>
     <dt id="themes">themes</dt>
     <dd>see “Firefox Themes”</dd>


### PR DESCRIPTION
As I described in the bug [1], the heading ID for Tabzilla causes the menu to show up in the middle of the copy rules page [2] instead of the actual "Tabzilla" heading. This commit changes the ID to "tabzilla-heading" so as to not conflict with the Tabzilla CSS.

[1] https://bugzilla.mozilla.org/show_bug.cgi?id=1132323
[2] https://www.mozilla.org/en-US/styleguide/communications/copy-rules/