### PR TITLE
fix Bug 1108278: congstar link is incorrect

### DIFF
--- a/bedrock/firefox/templates/firefox/os/_get_device.html
+++ b/bedrock/firefox/templates/firefox/os/_get_device.html
@@ -64,7 +64,7 @@
           <h3>{{_('Germany')}}</h3>
           <ul>
             <li><a class="alcatel-one-touch-fire" href="http://aktion.congstar.de/firefox-os">Alcatel One Touch Fire</a></li>
-            <li><a class="alcatel-one-touch-fire-e" href="http://www.congstar.de/handy/alcatel-one-touch-fire-e-braun/">Alcatel One Touch Fire E</a></li>
+            <li><a class="alcatel-one-touch-fire-e" href="http://www.congstar.de/handy/alcatel-onetouch-fire-e-braun/">Alcatel One Touch Fire E</a></li>
             <li><a class="alcatel-one-touch-fire o2" href="http://www.o2online.de/handy/alcatel-onetouch-fire-e/">Alcatel One Touch Fire E</a></li>
             <li><a class="zte-open-c" href="http://www.ebay.de/itm/eBay-Exklusiv-ZTE-OPEN-C-Neuesten-Firefox-OS-DualCore-1-2-GHz-4-0-3G-Smartphone-/131151681046?ssPageName=STRK:MESE:IT">ZTE Open C</a></li>
           </ul>


### PR DESCRIPTION
A hyphen needs to be removed from the link to point to the proper product page for the ONETOUCH Fire E.