### PR TITLE
Fix Bug 1132956 - Legal-docs pages for hu and hr throwing errors.

### DIFF
--- a/bedrock/privacy/views.py
+++ b/bedrock/privacy/views.py
@@ -37,6 +37,8 @@ def process_legal_doc(content):
 
         # Append elements to <header> or <div>
         for tag in section.children:
+            if not tag.name:
+                continue
             match = HN_PATTERN.match(tag.name)
             if match:
                 header.append(tag)


### PR DESCRIPTION
This issue is caused by a common Markdown error where localized dates are not properly formatted. Continue the loop if `tag.name` doesn't exist. In such cases, dates like `08. svibnja 2013.` will just be `svibnja 2013.` so it should be safe.

This includes a legal-docs submodule update from https://github.com/mozilla/legal-docs/pull/289.