### PR TITLE
Fix Bug 1131309 - Add share buttons to 'Check your plugins' page

### DIFF
--- a/bedrock/base/templates/macros.html
+++ b/bedrock/base/templates/macros.html
@@ -357,15 +357,15 @@
   </section>
 {%- endmacro %}
 
-{% macro share_cta(cta_text, share_urls, share_text, id) %}
-<div class="mozilla-share-cta" tabindex="0"{% if id %} id="{{ id }}"{% endif -%}>
+{% macro share_cta(cta_text, share_urls, share_text, id, class) %}
+<aside class="mozilla-share-cta{% if class %} {{ class }}{% endif %}" tabindex="0"{% if id %} id="{{ id }}"{% endif -%}>
   <h3>{{ cta_text }}</h3>
   <ul>
-    <li><a class="twitter" href="{{ 'https://www.twitter.com/intent/tweet?url=%s&amp;text=%s'|format(share_urls.get('twitter')|urlencode, share_text|urlencode)|e }}" title="Twitter">Twitter</a></li>
+    <li><a class="twitter" href="{{ 'https://www.twitter.com/intent/tweet?url=%s&text=%s'|format(share_urls.get('twitter')|urlencode, share_text|urlencode)|e }}" title="Twitter">Twitter</a></li>
     <li><a class="facebook" href="{{ 'https://www.facebook.com/sharer/sharer.php?u=%s'|format(share_urls.get('facebook')|urlencode)|e }}" title="Facebook">Facebook</a></li>
-    <li><a class="g-plus" href="{{ 'https://plus.google.com/share?url=%s&amp;hl=%s'|format(share_urls.get('googleplus')|urlencode, LANG)|e }}" title="Google+">Google+</a></li>
+    <li><a class="g-plus" href="{{ 'https://plus.google.com/share?url=%s&hl=%s'|format(share_urls.get('googleplus')|urlencode, LANG)|e }}" title="Google+">Google+</a></li>
   </ul>
-</div>
+</aside>
 {%- endmacro %}
 
 {% macro anniversary_video(buttons_overlay, button_footer, embed_video) %}

--- a/bedrock/firefox/templates/firefox/hello/index.html
+++ b/bedrock/firefox/templates/firefox/hello/index.html
@@ -47,7 +47,7 @@
             'facebook': 'https://www.mozilla.org/firefox/hello/?utm_source=Facebook&utm_medium=social&utm_campaign=Hello&utm_content=WebsiteShare'
           }
           %}
-          {{ share_cta(_('Share'), share_urls, _('Meet Firefox Hello, the easiest way to connect for free over video with anyone, anywhere.'), 'spread-hello') }}
+          {{ share_cta(_('Share'), share_urls, _('Meet Firefox Hello, the easiest way to connect for free over video with anyone, anywhere.'), 'spread-hello', 'sky mini') }}
         </div>
       {% endblock %}
     </div>

--- a/bedrock/mozorg/templates/mozorg/plugincheck.html
+++ b/bedrock/mozorg/templates/mozorg/plugincheck.html
@@ -4,6 +4,8 @@
 
 {% extends "base-resp.html" %}
 
+{% from "macros.html" import share_cta with context %}
+
 {% block body_id %}plugincheck{% endblock %}
 
 {% block page_title %}{{_('Plugin Check &amp; Updates')}}{% endblock %}
@@ -54,6 +56,14 @@
       {{ download_firefox(small=True) }}
       <h1 class="large">{{_('Check Your Plugins')}}</h1>
       <p class="preamble">{{_('Keeping your plugins up to date helps Firefox run safely and smoothly.')}}</p>
+      {% set share_urls = { 'twitter': 'http://mzl.la/17aqnLZ', 'googleplus': 'http://mzl.la/1FuAhTS', 'facebook': 'http://mzl.la/1z4Noqm' } -%}
+      {% if l10n_has_tag('share_cta') -%}
+        {% set share_text = _('Plugins don’t always update automatically. Check yours now to stay safe and browse without interruption!') %}
+      {%- else -%}
+        {# If the new copy is not localized yet, just use the same text as the existing preamble #}
+        {% set share_text = _('Keeping your plugins up to date helps Firefox run safely and smoothly.') %}
+      {% endif -%}
+      {{ share_cta(_('Share'), share_urls, share_text, 'spread-plugincheck', 'sky mini') }}
   </header>
 
   <section class="plugin-status-container billboard">

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -802,6 +802,7 @@ PIPELINE_CSS = {
     },
     'plugincheck': {
         'source_filenames': (
+            'css/base/mozilla-share-cta.less',
             'css/plugincheck/plugincheck.less',
             'css/plugincheck/qtip.css',
         ),
@@ -1538,6 +1539,7 @@ PIPELINE_JS = {
     },
     'plugincheck': {
         'source_filenames': (
+            'js/base/mozilla-share-cta.js',
             'js/plugincheck/lib/mustache.js',
             'js/plugincheck/tmpl/plugincheck.ui.tmpl.js',
             'js/plugincheck/check-plugins.js',

--- a/media/css/base/mozilla-share-cta.less
+++ b/media/css/base/mozilla-share-cta.less
@@ -4,6 +4,15 @@
 
 @import "../sandstone/lib.less";
 
+@font-face {
+    font-family: 'Font Awesome';
+    src: url('/media/fonts/fontawesome-webfont.eot?v4.01#iefix') format('embedded-opentype'),
+         url('/media/fonts/fontawesome-webfont.woff?v4.01') format('woff'),
+         url('/media/fonts/fontawesome-webfont.ttf?v4.01') format('truetype');
+    font-weight: normal;
+    font-style: normal;
+}
+
 // Share button
 .mozilla-share-cta {
     position: relative;
@@ -21,7 +30,7 @@
     }
 
     h3 {
-        display: block;
+        display: none;
         width: 256px;
         padding: 1em 20px;
         margin: 0;
@@ -52,7 +61,7 @@
         padding: 0;
         width: 100%;
         height: 100%;
-        visibility: hidden;
+        visibility: visible;
 
         li {
             display: table-cell;
@@ -61,7 +70,7 @@
             padding: 0;
             text-align: center;
             vertical-align: middle;
-            opacity: 0;
+            opacity: 1;
             .transition(opacity .2s ease-in-out);
 
             a {
@@ -106,10 +115,46 @@
             }
         }
     }
+
+    /* Sky theme: blue buttons & transparent background */
+    &.sky {
+        &,
+        &:hover,
+        &:focus {
+            background: transparent;
+        }
+
+        h3,
+        ul li a,
+        ul li a:hover,
+        ul li a:focus {
+            color: @linkBlue;
+        }
+    }
+
+    /* Mini widget */
+    &.mini {
+        border: 0;
+        border-radius: 0;
+        width: 140px;
+
+        h3 {
+            padding: 15px 10px;
+            width: 120px;
+            height: 13px;
+            .font-size(@smallFontSize);
+        }
+
+        ul li a:before {
+            .font-size(18px);
+            line-height: 43px;
+        }
+    }
 }
 
 .js .mozilla-share-cta {
     h3 {
+        display: block;
         position: absolute;
         top: 0;
         left: 0;
@@ -120,7 +165,15 @@
         }
     }
 
-    ul.in li {
-        opacity: 1;
+    ul {
+        visibility: hidden;
+
+        li {
+            opacity: 0;
+        }
+
+        &.in li {
+            opacity: 1;
+        }
     }
 }

--- a/media/css/firefox/hello/index.less
+++ b/media/css/firefox/hello/index.less
@@ -4,15 +4,6 @@
 
 @import "../../sandstone/lib.less";
 
-@font-face {
-    font-family: 'Font Awesome';
-    src: url('/media/fonts/fontawesome-webfont.eot?v4.01#iefix') format('embedded-opentype'),
-         url('/media/fonts/fontawesome-webfont.woff?v4.01') format('woff'),
-         url('/media/fonts/fontawesome-webfont.ttf?v4.01') format('truetype');
-    font-weight: normal;
-    font-style: normal;
-}
-
 .grainy-sky() {
     background: #cae1f4;
     background: url(/media/img/sandstone/grain.png) repeat,
@@ -122,50 +113,12 @@ main {
 }
 
 #spread-hello {
-    display: none;
     float: right;
     margin-top: 15px;
 }
 
-.js #spread-hello {
-    display: block;
-}
-
 html[dir="rtl"] #spread-hello {
     float: left;
-}
-
-.mozilla-share-cta {
-    border: 0;
-    background: transparent;
-    width: 140px;
-
-    &:hover,
-    &:focus {
-        background: transparent;
-    }
-
-    h3 {
-        .font-size(@smallFontSize);
-        padding-left: @baseLine / 2;
-        padding-right: @baseLine / 2;
-        width: 120px;
-        color: @linkBlue;
-    }
-
-    ul li a {
-        color: @linkBlue;
-
-        &:before {
-            .font-size(18px);
-            line-height: 43px;
-        }
-
-        &:hover,
-        &:focus {
-            color: @linkBlue;
-        }
-    }
 }
 
 // Intro

--- a/media/css/plugincheck/plugincheck.less
+++ b/media/css/plugincheck/plugincheck.less
@@ -26,12 +26,25 @@
         color: rgb(72, 72, 72);
     }
 }
-.html-rtl {
+
+.mozilla-share-cta {
+    position: absolute;
+    top: -43px;
+    right: 24px;
+}
+
+html[dir="rtl"] {
     #main-feature > .download-button {
         right: auto;
         left: 0;
     }
+
+    .mozilla-share-cta {
+        right: auto;
+        left: 24px;
+    }
 }
+
 .billboard {
     padding-top: 42px;
     padding-bottom: 0;
@@ -297,5 +310,22 @@
     #main-feature > .download-button {
         position: relative;
         margin-top: 20px;
+    }
+
+    .mozilla-share-cta {
+        top: -63px;
+        right: 0;
+    }
+
+    html[dir="rtl"] .mozilla-share-cta {
+        right: auto;
+        left: 0;
+    }
+}
+
+/* Mobile Layout: 320px */
+@media only screen and (max-width: @breakMobileLandscape) {
+    .mozilla-share-cta {
+        display: none;
     }
 }

--- a/media/css/privacy/privacy-day.less
+++ b/media/css/privacy/privacy-day.less
@@ -4,15 +4,6 @@
 
 @import '../sandstone/lib.less';
 
-@font-face {
-    font-family: 'Font Awesome';
-    src: url('/media/fonts/fontawesome-webfont.eot?v4.01#iefix') format('embedded-opentype'),
-         url('/media/fonts/fontawesome-webfont.woff?v4.01') format('woff'),
-         url('/media/fonts/fontawesome-webfont.ttf?v4.01') format('truetype');
-    font-weight: normal;
-    font-style: normal;
-}
-
 @privacyGreen:  #00af84;
 @localBlue:     #0c99d5;
 @localBlueDark: darken(#0c99d5, 5%);


### PR DESCRIPTION
Borrowed @jpetto’s work in #2684, includes the following improvements:

* Add the `sky` and `mini` classes to make the styles reusable
* Make the buttons work even when JavaScript is disabled
* Fix the URL encoding
* Use `<aside>`