### PR TITLE
Fix Bug 1129624 - Refactor the function to get download links

### DIFF
--- a/bedrock/firefox/context_processors.py
+++ b/bedrock/firefox/context_processors.py
@@ -2,11 +2,11 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from bedrock.firefox.firefox_details import firefox_details
+from bedrock.firefox.firefox_details import firefox_desktop
 
 
 def latest_firefox_versions(request):
     return {
-        'latest_firefox_version': firefox_details.latest_version('release'),
-        'esr_firefox_versions': firefox_details.esr_major_versions,
+        'latest_firefox_version': firefox_desktop.latest_version('release'),
+        'esr_firefox_versions': firefox_desktop.esr_major_versions,
     }

--- a/bedrock/firefox/templates/firefox/all.html
+++ b/bedrock/firefox/templates/firefox/all.html
@@ -8,7 +8,7 @@
 {% block page_desc %}
   {% if channel == 'beta' %}
     {{ _('Download Firefox Beta in your language and experience cutting edge features before they make it to final release. Provide feedback to help us refine and polish the next version of Firefox.') }}
-  {% elif channel == 'aurora' %}
+  {% elif channel == 'alpha' %}
     {{ _('Download Firefox Developer Edition in your language to experience the newest features and innovations in an unstable environment even before they go to Beta. Give us feedback that will determine what makes it to Final Release and help shape the future of Firefox.') }}
   {% elif channel == 'esr' %}
     {{ _('Firefox ESR is intended for groups who deploy and maintain the desktop environment in large organizations. <a href="%s">Learn more.</a>')|format(url('firefox.organizations.organizations')) }}
@@ -18,7 +18,7 @@
 {% endblock %}
 
 {% block body_class -%}
-  sky firefox-all-{{ channel }} {% if channel == 'aurora' %}blueprint{% endif %}
+  sky firefox-all-{{ channel }} {% if channel == 'alpha' %}blueprint{% endif %}
 {% endblock %}
 
 {% block site_css %}
@@ -26,7 +26,7 @@
 {% endblock %}
 
 {% block site_header_logo %}
-  {% if channel == 'aurora' %}
+  {% if channel == 'alpha' %}
     <h2><a href="{{ url('firefox.developer') }}">{{ high_res_img('img/firefox/developer/title.png', {'alt': _('Firefox Developer Edition'), 'width': '220', 'height': '84'}) }}</a></h2>
   {% else %}
     {{ super() }}
@@ -165,21 +165,21 @@
   <tr id="{{ build.locale }}" data-search="{{ build.name_en|lower }}, {{ build.name_native|lower }}">
     <th scope="row">{{ build.name_en }}</th>
     <td lang="{{ build.locale }}">{{ build.name_native }}</td>
-    {{ build_link(build, 'Windows', _('Download for Windows')) }}
-    {{ build_link(build, 'OS X', _('Download for Mac OS X')) }}
-    {{ build_link(build, 'Linux', _('Download for Linux')) }}
-    {{ build_link(build, 'Linux 64', _('Download for 64-bit Linux')) }}
+    {{ build_link(build, 'win', _('Download for Windows')) }}
+    {{ build_link(build, 'osx', _('Download for Mac OS X')) }}
+    {{ build_link(build, 'linux', _('Download for Linux')) }}
+    {{ build_link(build, 'linux64', _('Download for 64-bit Linux')) }}
   </tr>
 {% endmacro %}
 
 <!--
   build: Locale dictionary from product details.
-  platform: Value in build.platforms to use. One of 'Windows', 'OS X', 'Linux'.
+  platform: Value in build.platforms to use. One of 'win', 'osx', 'linux' and 64-bit variants.
   tooltip: Text to display as tooltip for download link.
 -->
 {% macro build_link(build, platform, tooltip) %}
   {% if build.platforms[platform] %}
-    <td class="download {% if platform == 'Windows' %}win{% elif platform == 'OS X' %}mac{% elif platform == 'Linux' %}linux{% elif platform == 'Linux 64' %}linux64{% endif %}"><a href="{{ build.platforms[platform].download_url }}" title="{{ tooltip }}">{{ _('Download') }}</a></td>
+    <td class="download {{ platform }}"><a href="{{ build.platforms[platform].download_url }}" title="{{ tooltip }}">{{ _('Download') }}</a></td>
   {% else %}
     <td class="unavailable">{{ _('Not Yet Available') }}</td>
   {% endif %}

--- a/bedrock/firefox/templates/firefox/android/faq.html
+++ b/bedrock/firefox/templates/firefox/android/faq.html
@@ -24,7 +24,7 @@
 {% block content %}
 
 <div id="main-feature">
-  {{ download_firefox(mobile=True, small=True) }}
+  {{ download_firefox(platform='android', small=True) }}
   <h1 class="large">{{_('Mobile FAQ')}}</h1>
 </div>
 

--- a/bedrock/firefox/templates/firefox/android/index.html
+++ b/bedrock/firefox/templates/firefox/android/index.html
@@ -348,7 +348,7 @@
               <a rel="external" href="https://support.mozilla.org/kb/will-firefox-work-my-mobile-device">{{ _('Supported devices') }}</a>
             </li>
             <li>
-              <a href="{{ product_url('mobile', 'notes') }}">{{ _('Release notes') }}</a>
+              <a href="{{ product_url('android', 'notes') }}">{{ _('Release notes') }}</a>
             </li>
           </ul>
         </div>{#-- /#download-content --#}

--- a/bedrock/firefox/templates/firefox/channel.html
+++ b/bedrock/firefox/templates/firefox/channel.html
@@ -48,10 +48,10 @@
       {# L10n: This description applies to Firefox Beta #}
       <h3>{{_('The latest features in a more stable environment')}}</h3>
       <div class="download-box" id="beta-desktop">
-        {{ download_firefox('beta', icon=False, small=True, force_direct=True) }}
+        {{ download_firefox('beta', icon=False, platform='desktop', small=True, force_direct=True) }}
       </div>
-      <div class="download-box mobile" id="beta-mobile">
-        {{ download_firefox('beta', icon=False, mobile=True, small=True) }}
+      <div class="download-box android" id="beta-android">
+        {{ download_firefox('beta', icon=False, platform='android', small=True) }}
       </div>
       {% if l10n_has_tag('telemetry_notice') %}
         <p class="warning">
@@ -72,10 +72,10 @@
       {# L10n: This description applies to Firefox on the Release channel #}
       <h3>{{_('Tried, tested and used by millions around the world')}}</h3>
       <div class="download-box" id="firefox-desktop">
-        {{ download_firefox(icon=False, small=True, force_direct=True) }}
+        {{ download_firefox(icon=False, platform='desktop', small=True, force_direct=True) }}
       </div>
-      <div class="download-box mobile" id="firefox-mobile">
-        {{ download_firefox(icon=False, mobile=True, small=True) }}
+      <div class="download-box android" id="firefox-android">
+        {{ download_firefox(icon=False, platform='android', small=True) }}
       </div>
       <p class="more"><a href="{{ php_url('/firefox/') }}">{{_('Learn more about Firefox')}}</a></p>
     </div>
@@ -89,10 +89,10 @@
         <h3>{{_('The newest innovations in an experimental environment')}}</h3>
       {% endif %}
       <div class="download-box" id="aurora-desktop">
-        {{ download_firefox('aurora', icon=False, small=True) }}
+        {{ download_firefox('alpha', icon=False, platform='desktop', small=True) }}
       </div>
-      <div class="download-box mobile" id="aurora-mobile">
-        {{ download_firefox('aurora', icon=False, mobile=True, small=True) }}
+      <div class="download-box android" id="aurora-android">
+        {{ download_firefox('alpha', icon=False, platform='android', small=True) }}
       </div>
       <p class="warning">
         {% if l10n_has_tag('channel_dev_edition') %}

--- a/bedrock/firefox/templates/firefox/developer.html
+++ b/bedrock/firefox/templates/firefox/developer.html
@@ -30,7 +30,7 @@
 
   <h1>{{ _('Built for those who build the Web') }}</h1>
   <h2>{{ _('Introducing the only browser made for developers like you.') }}</h2>
-  {{ download_firefox('aurora', icon=False, small=True, simple=True) }}
+  {{ download_firefox('alpha', icon=False, small=True, simple=True) }}
 
   {% if l10n_has_tag('new_doorhanger') %}
   <p class="feedback-note">
@@ -178,7 +178,7 @@
   <div class="container">
     <div class="dev-footer-download">
       <h3>{{ _('Choose Firefox') }}</h3>
-      {{ download_firefox('aurora', icon=False, small=True, simple=True) }}
+      {{ download_firefox('alpha', icon=False, small=True, simple=True) }}
     </div>
     {# See Bug 1095176 #}
     {% if LANG.startswith('en-') %}

--- a/bedrock/firefox/templates/firefox/installer-help.html
+++ b/bedrock/firefox/templates/firefox/installer-help.html
@@ -67,7 +67,7 @@
       </div>
 
       <div class="download-box" id="aurora-desktop">
-        {{ download_firefox('aurora', small=True, force_direct=True, force_full_installer=True, icon=False, locale=installer_lang) }}
+        {{ download_firefox('alpha', small=True, force_direct=True, force_full_installer=True, icon=False, locale=installer_lang) }}
       </div>
     {% endif %}
   </div>

--- a/bedrock/firefox/templates/firefox/new.html
+++ b/bedrock/firefox/templates/firefox/new.html
@@ -94,10 +94,10 @@
             {{ download_firefox(force_direct=true, simple=true) }}
           </div>
           <div class="mobile download-button-wrapper">
-            {{ download_firefox(mobile=True) }}
+            {{ download_firefox(platform='android') }}
           </div>
           <div class="android download-button-wrapper" data-upgrade-subtitle="{{_('Get it free on Google Play')}}">
-            {{ download_firefox(mobile=True, small=True, icon=False, dom_id='download-button-android') }}
+            {{ download_firefox(platform='android', small=True, icon=False, dom_id='download-button-android') }}
           </div>
           <div class="desktop-latest-links-wrapper latest-links-wrapper">
             <ul>

--- a/bedrock/firefox/templates/firefox/sync-old.html
+++ b/bedrock/firefox/templates/firefox/sync-old.html
@@ -71,7 +71,7 @@
       </p>
     </section>
     <aside role="complimentary">
-      {{ download_firefox(force_direct=True, mobile=True, small=True) }}
+      {{ download_firefox(force_direct=True, platform='android', small=True) }}
     </aside>
   </article>
 </div>

--- a/bedrock/firefox/templates/firefox/whatsnew.html
+++ b/bedrock/firefox/templates/firefox/whatsnew.html
@@ -39,7 +39,7 @@
 
   <h2>{{ _('Now get the mobile browser that’s got your back') }}</h2>
 
-  {{ download_firefox(mobile=True, icon=False, small=True) }}
+  {{ download_firefox(platform='android', icon=False, small=True) }}
 
 {% if request.locale not in locales_with_video.keys() %}
   <div id="promo-android">

--- a/bedrock/firefox/tests/test_firefox_details.py
+++ b/bedrock/firefox/tests/test_firefox_details.py
@@ -1,0 +1,273 @@
+# -*- coding: utf-8 -*-
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+import os
+from urlparse import parse_qsl, urlparse
+
+from django.conf import settings
+from django.test.utils import override_settings
+
+from mock import patch
+from nose.tools import eq_, ok_
+
+from bedrock.firefox.firefox_details import FirefoxDesktop, FirefoxAndroid
+from bedrock.mozorg.tests import TestCase
+
+
+TEST_DATA_DIR = os.path.join(os.path.dirname(__file__), 'test_data')
+PROD_DETAILS_DIR = os.path.join(TEST_DATA_DIR, 'product_details_json')
+
+
+with patch.object(settings, 'PROD_DETAILS_DIR', PROD_DETAILS_DIR):
+    firefox_desktop = FirefoxDesktop()
+    firefox_android = FirefoxAndroid()
+
+
+GOOD_PLATS = {'Windows': {}, 'OS X': {}, 'Linux': {}}
+GOOD_BUILDS = {
+    'en-US': {
+        '25.0': GOOD_PLATS,  # current release
+        '26.0b2': GOOD_PLATS,
+        '27.0a1': GOOD_PLATS,
+    },
+    'de': {
+        '25.0': GOOD_PLATS,
+    },
+    'fr': {
+        '24.0': GOOD_PLATS,  # prev release
+    }
+}
+GOOD_VERSIONS = {
+    'LATEST_FIREFOX_VERSION': '25.0',
+    'LATEST_FIREFOX_DEVEL_VERSION': '26.0b2',
+    'FIREFOX_AURORA': '27.0a1',
+    'FIREFOX_ESR': '24.1.0esr',
+}
+
+
+@patch.object(firefox_desktop, 'firefox_primary_builds', GOOD_BUILDS)
+@patch.object(firefox_desktop, 'firefox_beta_builds', {})
+@patch.dict(firefox_desktop.firefox_versions, GOOD_VERSIONS)
+class TestLatestBuilds(TestCase):
+    def test_latest_builds(self):
+        """Should return platforms if localized build does exist."""
+        result = firefox_desktop.latest_builds('de', 'release')
+        self.assertEqual(result[0], '25.0')
+        self.assertIs(result[1], GOOD_PLATS)
+
+    def test_latest_builds_is_none_if_no_build(self):
+        """Should return None if the localized build for the channel doesn't exist."""
+        result = firefox_desktop.latest_builds('fr', 'release')
+        self.assertIsNone(result)
+
+    def test_latest_builds_channels(self):
+        """Should work with all channels."""
+        result = firefox_desktop.latest_builds('en-US', 'beta')
+        self.assertEqual(result[0], '26.0b2')
+        self.assertIs(result[1], GOOD_PLATS)
+
+        result = firefox_desktop.latest_builds('en-US', 'alpha')
+        self.assertEqual(result[0], '27.0a1')
+        self.assertIs(result[1], GOOD_PLATS)
+
+
+class TestFirefoxDesktop(TestCase):
+
+    def test_get_download_url(self):
+        url = firefox_desktop.get_download_url('release', '17.0.1', 'osx', 'pt-BR', True)
+        self.assertListEqual(parse_qsl(urlparse(url).query),
+                             [('product', 'firefox-17.0.1-SSL'),
+                              ('os', 'osx'),
+                              ('lang', 'pt-BR')])
+        # Linux 64-bit
+        url = firefox_desktop.get_download_url('release', '17.0.1', 'linux64', 'en-US', True)
+        self.assertListEqual(parse_qsl(urlparse(url).query),
+                             [('product', 'firefox-17.0.1-SSL'),
+                              ('os', 'linux64'),
+                              ('lang', 'en-US')])
+
+    @patch.dict(firefox_desktop.firefox_versions,
+                FIREFOX_AURORA='28.0a2')
+    def test_get_download_url_aurora(self):
+        """
+        The Aurora version should give us a permanent url. For Windows, a url of
+        the stub installer is used.
+        """
+        url = firefox_desktop.get_download_url('alpha', '28.0a2', 'win', 'en-US', True)
+        self.assertListEqual(parse_qsl(urlparse(url).query),
+                             [('product', 'firefox-aurora-stub'),
+                              ('os', 'win'),
+                              ('lang', 'en-US')])
+        url = firefox_desktop.get_download_url('alpha', '28.0a2', 'osx', 'en-US', True)
+        self.assertListEqual(parse_qsl(urlparse(url).query),
+                             [('product', 'firefox-aurora-latest-ssl'),
+                              ('os', 'osx'),
+                              ('lang', 'en-US')])
+        url = firefox_desktop.get_download_url('alpha', '28.0a2', 'linux', 'en-US', True)
+        self.assertListEqual(parse_qsl(urlparse(url).query),
+                             [('product', 'firefox-aurora-latest-ssl'),
+                              ('os', 'linux'),
+                              ('lang', 'en-US')])
+
+    @patch.dict(firefox_desktop.firefox_versions,
+                FIREFOX_AURORA='28.0a2')
+    def test_get_download_url_aurora_l10n(self):
+        """Aurora non en-US should have a different product name."""
+        url = firefox_desktop.get_download_url('alpha', '28.0a2', 'win', 'pt-BR', True)
+        self.assertListEqual(parse_qsl(urlparse(url).query),
+                             [('product', 'firefox-aurora-latest-l10n'),
+                              ('os', 'win'),
+                              ('lang', 'pt-BR')])
+        url = firefox_desktop.get_download_url('alpha', '28.0a2', 'osx', 'pt-BR', True)
+        self.assertListEqual(parse_qsl(urlparse(url).query),
+                             [('product', 'firefox-aurora-latest-l10n'),
+                              ('os', 'osx'),
+                              ('lang', 'pt-BR')])
+        url = firefox_desktop.get_download_url('alpha', '28.0a2', 'linux', 'pt-BR', True)
+        self.assertListEqual(parse_qsl(urlparse(url).query),
+                             [('product', 'firefox-aurora-latest-l10n'),
+                              ('os', 'linux'),
+                              ('lang', 'pt-BR')])
+
+    @override_settings(STUB_INSTALLER_LOCALES={'win': settings.STUB_INSTALLER_ALL})
+    def get_download_url_ssl(self):
+        """
+        SSL-enabled links should always be used except Windows stub installers.
+        """
+
+        # SSL-enabled links won't be used for Windows builds (but SSL download
+        # is enabled by default for stub installers)
+        url = firefox_desktop.get_download_url('release', '27.0', 'win', 'pt-BR', True)
+        self.assertListEqual(parse_qsl(urlparse(url).query),
+                             [('product', 'firefox-27.0'),
+                              ('os', 'win'),
+                              ('lang', 'pt-BR')])
+
+        # SSL-enabled links will be used for OS X builds
+        url = firefox_desktop.get_download_url('release', '27.0', 'osx', 'pt-BR', True)
+        self.assertListEqual(parse_qsl(urlparse(url).query),
+                             [('product', 'firefox-27.0-SSL'),
+                              ('os', 'osx'),
+                              ('lang', 'pt-BR')])
+
+        # SSL-enabled links will be used for Linux builds
+        url = firefox_desktop.get_download_url('release', '27.0', 'linux', 'pt-BR', True)
+        self.assertListEqual(parse_qsl(urlparse(url).query),
+                             [('product', 'firefox-27.0-SSL'),
+                              ('os', 'linux'),
+                              ('lang', 'pt-BR')])
+
+    @override_settings(STUB_INSTALLER_LOCALES={'win': ['en-us']})
+    def test_force_funnelcake_en_us_win_only(self):
+        """
+        Ensure that force_funnelcake doesn't affect non configured locale urls
+        """
+        url = firefox_desktop.get_download_url('release', '19.0', 'osx', 'en-US',
+                                               force_funnelcake=True)
+        ok_('product=firefox-latest&' not in url)
+
+        url = firefox_desktop.get_download_url('beta', '20.0b4', 'win', 'fr',
+                                               force_funnelcake=True)
+        ok_('product=firefox-beta-latest&' not in url)
+
+    @override_settings(STUB_INSTALLER_LOCALES={'win': ['en-us']})
+    def test_force_full_installer_en_us_win_only(self):
+        """
+        Ensure that force_full_installer doesn't affect non configured locales
+        """
+        url = firefox_desktop.get_download_url('release', '19.0', 'osx', 'en-US',
+                                               force_full_installer=True)
+        ok_('product=firefox-latest&' not in url)
+
+        url = firefox_desktop.get_download_url('beta', '20.0b4', 'win', 'fr',
+                                               force_full_installer=True)
+        ok_('product=firefox-beta-latest&' not in url)
+
+    @override_settings(STUB_INSTALLER_LOCALES={'win': ['en-us']})
+    def test_stub_installer_en_us_win_only(self):
+        """
+        Ensure that builds not in the setting don't get stub.
+        """
+        url = firefox_desktop.get_download_url('release', '19.0', 'osx', 'en-US')
+        ok_('product=firefox-stub&' not in url)
+
+        url = firefox_desktop.get_download_url('beta', '20.0b4', 'win', 'fr')
+        ok_('product=firefox-beta-stub&' not in url)
+
+    def test_filter_builds_by_locale_name(self):
+        # search english
+        builds = firefox_desktop.get_filtered_full_builds('release', None,
+                                                          'ujara')
+        eq_(len(builds), 1)
+        eq_(builds[0]['name_en'], 'Gujarati')
+
+        # search native
+        builds = firefox_desktop.get_filtered_full_builds('release', None,
+                                                          u'જરા')
+        eq_(len(builds), 1)
+        eq_(builds[0]['name_en'], 'Gujarati')
+
+        # with a space
+        builds = firefox_desktop.get_filtered_full_builds('release', None,
+                                                          'british english')
+        eq_(len(builds), 1)
+        eq_(builds[0]['name_en'], 'English (British)')
+
+        # with a comma
+        builds = firefox_desktop.get_filtered_full_builds('release', None,
+                                                          u'French, Français')
+        eq_(len(builds), 1)
+        eq_(builds[0]['name_en'], 'French')
+
+    def test_linux64_build(self):
+        builds = firefox_desktop.get_filtered_full_builds('release')
+        url = builds[0]['platforms']['linux64']['download_url']
+        eq_(parse_qsl(urlparse(url).query)[1], ('os', 'linux64'))
+
+    @patch.dict(firefox_desktop.firefox_versions,
+                FIREFOX_ESR='24.2')
+    def test_esr_major_versions(self):
+        """ESR versions should be dynamic based on data."""
+        eq_(firefox_desktop.esr_major_versions, [24])
+
+    @patch.dict(firefox_desktop.firefox_versions,
+                FIREFOX_ESR='24.6.0',
+                FIREFOX_ESR_NEXT='31.0.0')
+    def test_esr_major_versions_prev(self):
+        """ESR versions should show previous when available."""
+        eq_(firefox_desktop.esr_major_versions, [24, 31])
+
+    @patch.dict(firefox_desktop.firefox_versions,
+                LATEST_FIREFOX_VERSION='Phoenix',
+                FIREFOX_ESR='Albuquerque')
+    def test_esr_major_versions_no_latest(self):
+        """ESR versions should not blow up if current version is broken."""
+        eq_(firefox_desktop.esr_major_versions, [])
+
+    @patch.dict(firefox_desktop.firefox_versions,
+                LATEST_FIREFOX_VERSION='18.0.1')
+    def test_latest_major_version(self):
+        """latest_major_version should return an int of the major version."""
+        eq_(firefox_desktop.latest_major_version('release'), 18)
+
+    @patch.dict(firefox_desktop.firefox_versions,
+                LATEST_FIREFOX_VERSION='Phoenix')
+    def test_latest_major_version_no_int(self):
+        """latest_major_version should return 0 when no int."""
+        eq_(firefox_desktop.latest_major_version('release'), 0)
+
+
+class TestFirefoxAndroid(TestCase):
+
+    @patch.dict(firefox_android.mobile_details,
+                version='22.0.1')
+    def test_latest_release_version(self):
+        """latest_version should return the latest release version."""
+        eq_(firefox_android.latest_version('release'), '22.0.1')
+
+    @patch.dict(firefox_android.mobile_details,
+                beta_version='23.0')
+    def test_latest_beta_version(self):
+        """latest_version should return the latest beta version."""
+        eq_(firefox_android.latest_version('beta'), '23.0')

--- a/bedrock/firefox/utils.py
+++ b/bedrock/firefox/utils.py
@@ -4,7 +4,7 @@
 
 from product_details import product_details
 from product_details.version_compare import Version
-from bedrock.firefox.firefox_details import firefox_details
+from bedrock.firefox.firefox_details import firefox_desktop
 
 
 def is_current_or_newer(user_version):
@@ -16,7 +16,7 @@ def is_current_or_newer(user_version):
     user = Version(user_version)
 
     # check for ESR
-    if user.major in firefox_details.esr_major_versions:
+    if user.major in firefox_desktop.esr_major_versions:
         return True
 
     # similar to the way comparison is done in the Version class,

--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -22,7 +22,7 @@ from bedrock.releasenotes import version_re
 from bedrock.firefox.forms import SMSSendForm
 from bedrock.mozorg.context_processors import funnelcake_param
 from bedrock.mozorg.views import process_partnership_form
-from bedrock.firefox.firefox_details import firefox_details, mobile_details
+from bedrock.firefox.firefox_details import firefox_desktop
 from lib.l10n_utils.dotlang import _
 from product_details.version_compare import Version
 
@@ -92,7 +92,7 @@ LOCALE_FXOS_HEADLINES = {
 INSTALLER_CHANNElS = [
     'release',
     'beta',
-    'aurora',
+    'alpha',
     # 'nightly',  # soon
 ]
 
@@ -115,16 +115,6 @@ JS_MOBILE = get_js_bundle_files('partners_mobile')
 JS_DESKTOP = get_js_bundle_files('partners_desktop')
 
 
-def get_latest_version(product='firefox', channel='release'):
-    if channel == 'organizations':
-        channel = 'esr'
-
-    if product == 'mobile':
-        return mobile_details.latest_version(channel)
-    else:
-        return firefox_details.latest_version(channel)
-
-
 def installer_help(request):
     installer_lang = request.GET.get('installer_lang', None)
     installer_channel = request.GET.get('channel', None)
@@ -133,7 +123,7 @@ def installer_help(request):
         'installer_channel': None,
     }
 
-    if installer_lang and installer_lang in firefox_details.languages:
+    if installer_lang and installer_lang in firefox_desktop.languages:
         context['installer_lang'] = installer_lang
 
     if installer_channel and installer_channel in INSTALLER_CHANNElS:
@@ -189,37 +179,37 @@ def all_downloads(request, channel):
     if channel is None:
         channel = 'release'
     if channel == 'developer':
-        channel = 'aurora'
+        channel = 'alpha'
     if channel == 'organizations':
         channel = 'esr'
 
-    version = get_latest_version('firefox', channel)
+    version = firefox_desktop.latest_version(channel)
     query = request.GET.get('q')
 
     channel_names = {
         'release': _('Firefox'),
         'beta': _('Firefox Beta'),
-        'aurora': _('Developer Edition'),
+        'alpha': _('Developer Edition'),
         'esr': _('Firefox Extended Support Release'),
     }
 
     context = {
         'full_builds_version': version.split('.', 1)[0],
-        'full_builds': firefox_details.get_filtered_full_builds(version, query),
-        'test_builds': firefox_details.get_filtered_test_builds(version, query),
+        'full_builds': firefox_desktop.get_filtered_full_builds(channel, version, query),
+        'test_builds': firefox_desktop.get_filtered_test_builds(channel, version, query),
         'query': query,
         'channel': channel,
         'channel_name': channel_names[channel]
     }
 
     if channel == 'esr':
-        next_version = get_latest_version('firefox', 'esr_next')
+        next_version = firefox_desktop.latest_version('esr_next')
         if next_version:
             context['full_builds_next_version'] = next_version.split('.', 1)[0]
-            context['full_builds_next'] = firefox_details.get_filtered_full_builds(next_version,
-                                                                                   query)
-            context['test_builds_next'] = firefox_details.get_filtered_test_builds(next_version,
-                                                                                   query)
+            context['full_builds_next'] = firefox_desktop.get_filtered_full_builds('esr_next',
+                                                                                   next_version, query)
+            context['test_builds_next'] = firefox_desktop.get_filtered_test_builds('esr_next',
+                                                                                   next_version, query)
     return l10n_utils.render(request, 'firefox/all.html', context)
 
 

--- a/bedrock/mozorg/helpers/download_buttons.py
+++ b/bedrock/mozorg/helpers/download_buttons.py
@@ -8,174 +8,58 @@ of terms and example values for them:
 
 * product: 'firefox' or 'thunderbird'
 * version: 7.0, 8.0b3, 9.0a2
-* build: 'beta', 'aurora', or None (for latest)
-* platform: 'os_windows', 'os_linux', 'os_linux64', or 'os_osx'
+* channel: 'beta', 'alpha', or None (for latest)
+* platform: 'win', 'osx', 'linux' and 64-bit variants
 * locale: a string in the form of 'en-US'
 """
-
-from django.conf import settings
 
 import jingo
 import jinja2
 
-from bedrock.firefox.firefox_details import firefox_details, mobile_details
+from bedrock.firefox.firefox_details import firefox_desktop, firefox_android
 from lib.l10n_utils import get_locale
 
-nightly_desktop = ('https://ftp.mozilla.org/pub/mozilla.org/firefox/nightly/'
-                   'latest-mozilla-aurora')
-nightly_android = ('https://ftp.mozilla.org/pub/mozilla.org/mobile/nightly/'
-                   'latest-mozilla-aurora-android')
 
-download_urls = {
-    'transition': '/firefox/new/?scene=2#download-fx',
-    'direct': 'https://download.mozilla.org/',
-    'aurora': nightly_desktop,
-    'aurora-l10n': nightly_desktop + '-l10n',
-    'aurora-android-api-9': nightly_android + (
-        '-api-9/fennec-%s.multi.android-arm.apk'),
-    'aurora-android-api-11': nightly_android + (
-        '-api-11/fennec-%s.multi.android-arm.apk'),
-    'aurora-android-x86': nightly_android + (
-        '-x86/fennec-%s.multi.android-i386.apk'),
-}
-
-
-def latest_version(locale, channel='release'):
-    """Return build info for a locale and channel.
-
-    :param locale: locale string of the build
-    :param channel: channel of the build: release, beta, or aurora
-    :return: dict or None
-    """
-    all_builds = (firefox_details.firefox_primary_builds,
-                  firefox_details.firefox_beta_builds)
-    version = firefox_details.latest_version(channel)
-
-    for builds in all_builds:
-        if locale in builds and version in builds[locale]:
-            _builds = builds[locale][version]
-            # Append Linux 64-bit build
-            if 'Linux' in _builds:
-                _builds['Linux 64'] = _builds['Linux']
-            return version, _builds
-
-
-def make_aurora_link(product, version, platform, locale,
-                     force_full_installer=False):
-    # Download links are different for localized versions
-    if locale.lower() == 'en-us':
-        if platform == 'os_windows':
-            product = 'firefox-aurora-stub'
-        else:
-            product = 'firefox-aurora-latest-ssl'
-    else:
-        product = 'firefox-aurora-latest-l10n'
-
-    tmpl = '?'.join([download_urls['direct'],
-                    'product={prod}&os={plat}&lang={locale}'])
-    return tmpl.format(
-        prod=product, locale=locale,
-        plat=platform.replace('os_', '').replace('windows', 'win'))
-
-
-def make_download_link(product, build, version, platform, locale,
-                       force_direct=False, force_full_installer=False,
-                       force_funnelcake=False, funnelcake_id=None):
-    # Aurora has a special download link format
-    if build == 'aurora':
-        return make_aurora_link(product, version, platform, locale,
-                                force_full_installer=force_full_installer)
-
-    # The downloaders expect the platform in a certain format
-    platform = {
-        'os_windows': 'win',
-        'os_linux': 'linux',
-        'os_linux64': 'linux64',
-        'os_osx': 'osx'
-    }[platform]
-
-    # stub installer exceptions
-    # TODO: NUKE FROM ORBIT!
-    stub_langs = settings.STUB_INSTALLER_LOCALES.get(platform, [])
-    if stub_langs and (stub_langs == settings.STUB_INSTALLER_ALL or
-                       locale.lower() in stub_langs):
-        suffix = 'stub'
-        if force_funnelcake or force_full_installer:
-            suffix = 'latest'
-
-        version = ('beta-' if build == 'beta' else '') + suffix
-    elif not funnelcake_id:
-        # Force download via SSL. Stub installers are always downloaded via SSL.
-        # Funnelcakes may not be ready for SSL download
-        version += '-SSL'
-
-    # append funnelcake id to version if we have one
-    if funnelcake_id:
-        version = '{vers}-f{fc}'.format(vers=version, fc=funnelcake_id)
-
-    # Check if direct download link has been requested
-    # (bypassing the transition page)
-    if force_direct:
-        # build a direct download link
-        tmpl = '?'.join([download_urls['direct'],
-                        'product={prod}-{vers}&os={plat}&lang={locale}'])
-
-        return tmpl.format(prod=product, vers=version,
-                           plat=platform, locale=locale)
-    else:
-        # build a link to the transition page
-        return download_urls['transition']
-
-
-def android_builds(build, builds=None):
+def android_builds(channel, builds=None):
     builds = builds or []
-    android_link = settings.GOOGLE_PLAY_FIREFOX_LINK
     variations = {
         'api-9': 'Gingerbread',
         'api-11': 'Honeycomb+ ARMv7',
         'x86': 'x86',
     }
 
-    if build.lower() == 'beta':
-
-        android_link = android_link.replace('org.mozilla.firefox',
-                                            'org.mozilla.firefox_beta')
-
-    if build == 'aurora':
-        for type, arch_pretty in variations.items():
-            link = (download_urls['aurora-android-%s' % type] %
-                    mobile_details.latest_version('aurora'))
-
-            builds.append({'os': 'os_android',
+    if channel == 'alpha':
+        for type, arch_pretty in variations.iteritems():
+            link = firefox_android.get_download_url('alpha', type)
+            builds.append({'os': 'android',
                            'os_pretty': 'Android',
                            'os_arch_pretty': 'Android %s' % arch_pretty,
                            'arch': 'x86' if type == 'x86' else 'armv7 %s' % type,
                            'arch_pretty': arch_pretty,
                            'download_link': link})
 
-    if build != 'aurora':
-        builds.append({'os': 'os_android',
+    if channel != 'alpha':
+        link = firefox_android.get_download_url(channel)
+        builds.append({'os': 'android',
                        'os_pretty': 'Android',
-                       'download_link': android_link})
+                       'download_link': link})
 
     return builds
 
 
 @jingo.register.function
 @jinja2.contextfunction
-def download_firefox(ctx, build='release', small=False, icon=True,
-                     mobile=None, dom_id=None, locale=None, simple=False,
+def download_firefox(ctx, channel='release', small=False, icon=True,
+                     platform='all', dom_id=None, locale=None, simple=False,
                      force_direct=False, force_full_installer=False,
                      force_funnelcake=False, check_old_fx=False):
     """ Output a "download firefox" button.
 
     :param ctx: context from calling template.
-    :param build: name of build: 'release', 'beta' or 'aurora'.
+    :param channel: name of channel: 'release', 'beta' or 'alpha'.
     :param small: Display the small button if True.
     :param icon: Display the Fx icon on the button if True.
-    :param mobile: Display the android download button if True, the desktop
-            button only if False, and by default (None) show whichever
-            is appropriate for the user's system.
+    :param platform: Target platform: 'desktop', 'android' or 'all'.
     :param dom_id: Use this string as the id attr on the element.
     :param locale: The locale of the download. Default to locale of request.
     :param simple: Display button with text only if True. Will not display
@@ -192,46 +76,35 @@ def download_firefox(ctx, build='release', small=False, icon=True,
             'simple' param being true.
     :return: The button html.
     """
-    alt_build = '' if build == 'release' else build
-    platform = 'mobile' if mobile else 'desktop'
+    show_desktop = platform in ['all', 'desktop']
+    show_android = platform in ['all', 'android']
+    alt_channel = '' if channel == 'release' else channel
     locale = locale or get_locale(ctx['request'])
     funnelcake_id = ctx.get('funnelcake_id', False)
-    dom_id = dom_id or 'download-button-%s-%s' % (platform, build)
+    dom_id = dom_id or 'download-button-%s-%s' % (
+        'desktop' if platform == 'all' else platform, channel)
 
-    l_version = latest_version(locale, build)
+    l_version = firefox_desktop.latest_builds(locale, channel)
     if l_version:
         version, platforms = l_version
     else:
         locale = 'en-US'
-        version, platforms = latest_version('en-US', build)
+        version, platforms = firefox_desktop.latest_builds('en-US', channel)
 
     # Gather data about the build for each platform
     builds = []
 
-    if not mobile:
-        for plat_os in ['Windows', 'Linux', 'Linux 64', 'OS X']:
-            # Fallback to en-US if this plat_os/version isn't available
+    if show_desktop:
+        for plat_os, info in firefox_desktop.platform_info.iteritems():
+
+            # Fallback to en-US if this platform/version isn't available
             # for the current locale
-            _locale = locale
-            if plat_os not in platforms:
-                _locale = 'en-US'
-
-            # Special case for the Japanese version for Mac
-            if plat_os == 'OS X' and _locale == 'ja':
-                _locale = 'ja-JP-mac'
-
-            # Normalize the platform os name
-            plat_os = 'os_%s' % plat_os.lower().replace(' ', '')
-            plat_os_pretty = {
-                'os_osx': 'Mac OS X',
-                'os_windows': 'Windows',
-                'os_linux': 'Linux',
-                'os_linux64': 'Linux 64-bit',
-            }[plat_os]
+            plat_os_pretty = info['title']
+            _locale = locale if plat_os_pretty in platforms else 'en-US'
 
             # And generate all the info
-            download_link = make_download_link(
-                'firefox', build, version, plat_os, _locale,
+            download_link = firefox_desktop.get_download_url(
+                channel, version, plat_os, _locale,
                 force_direct=force_direct,
                 force_full_installer=force_full_installer,
                 force_funnelcake=force_funnelcake,
@@ -241,11 +114,11 @@ def download_firefox(ctx, build='release', small=False, icon=True,
             # If download_link_direct is False the data-direct-link attr
             # will not be output, and the JS won't attempt the IE popup.
             if force_direct:
-                # no need to run make_download_link again with the same args
+                # no need to run get_download_url again with the same args
                 download_link_direct = False
             else:
-                download_link_direct = make_download_link(
-                    'firefox', build, version, plat_os, _locale,
+                download_link_direct = firefox_desktop.get_download_url(
+                    channel, version, plat_os, _locale,
                     force_direct=True,
                     force_full_installer=force_full_installer,
                     force_funnelcake=force_funnelcake,
@@ -258,24 +131,24 @@ def download_firefox(ctx, build='release', small=False, icon=True,
                            'os_pretty': plat_os_pretty,
                            'download_link': download_link,
                            'download_link_direct': download_link_direct})
-    if mobile is not False:
-        builds = android_builds(build, builds)
+    if show_android:
+        builds = android_builds(channel, builds)
 
     # Get the native name for current locale
-    langs = firefox_details.languages
+    langs = firefox_desktop.languages
     locale_name = langs[locale]['native'] if locale in langs else locale
 
     data = {
         'locale_name': locale_name,
         'version': version,
-        'product': 'firefox-mobile' if mobile else 'firefox',
+        'product': 'firefox-android' if platform == 'android' else 'firefox',
         'builds': builds,
         'id': dom_id,
         'small': small,
         'simple': simple,
-        'build': alt_build,
-        'show_mobile': mobile is not False,
-        'show_desktop': mobile is not True,
+        'channel': alt_channel,
+        'show_android': show_android,
+        'show_desktop': show_desktop,
         'icon': icon,
         'check_old_fx': check_old_fx and simple,
     }

--- a/bedrock/mozorg/helpers/misc.py
+++ b/bedrock/mozorg/helpers/misc.py
@@ -482,27 +482,30 @@ def product_url(product, page, channel=None):
 
         {{ product_url('firefox', 'all', 'organizations') }}
         {{ product_url('firefox', 'sysreq', channel) }}
-        {{ product_url('mobile', 'notes') }}
+        {{ product_url('android', 'notes') }}
     """
 
     app = product
     kwargs = {}
 
-    if product == 'mobile':
+    if product == 'android':
         app = 'firefox'
 
     # Tweak the channel name for the naming URL pattern in urls.py
     if channel == 'release':
         channel = None
-    if channel == 'aurora' and product == 'firefox':
-        channel = 'developer'
+    if channel == 'alpha':
+        if product == 'firefox':
+            channel = 'developer'
+        if product == 'android':
+            channel = 'aurora'
     if channel == 'esr':
         channel = 'organizations'
 
     if channel:
         kwargs['channel'] = channel
     if page == 'notes':
-        kwargs['product'] = product
+        kwargs['product'] = 'mobile' if product == 'android' else product
 
     return reverse('%s.%s' % (app, page), kwargs=kwargs)
 

--- a/bedrock/mozorg/templates/mozorg/download_buttons/mobile_small_landing.html
+++ b/bedrock/mozorg/templates/mozorg/download_buttons/mobile_small_landing.html
@@ -4,7 +4,7 @@
 
 {% extends "mozorg/download_buttons/mobile_base.html" %}
 
-{% block class %}download-button-mobile-small{% endblock %}
+{% block class %}download-button-android-small{% endblock %}
 
 {% block title %}{{ _('Get Firefox for Android »') }}
   <span class="download-info">

--- a/bedrock/mozorg/templates/mozorg/download_firefox_button.html
+++ b/bedrock/mozorg/templates/mozorg/download_firefox_button.html
@@ -14,9 +14,9 @@
 {% endmacro %}
 
 {% set download_class = 'download-button' %}
-{% set download_class = download_class ~ ' download-button-' ~ build if build else download_class %}
-{% set download_class = download_class ~ ' download-button-mobile' if not show_desktop else download_class %}
-{% set download_class = download_class ~ ' download-button-desktop' if not show_mobile else download_class %}
+{% set download_class = download_class ~ ' download-button-' ~ channel if channel else download_class %}
+{% set download_class = download_class ~ ' download-button-android' if not show_desktop else download_class %}
+{% set download_class = download_class ~ ' download-button-desktop' if not show_android else download_class %}
 {% set download_class = download_class ~ ' download-button-small' if small else download_class %}
 {% set download_class = download_class ~ ' download-button-noicon' if not icon else download_class %}
 {% set download_class = download_class ~ ' download-button-simple' if simple else download_class %}
@@ -31,7 +31,7 @@
       {{ alt_buttons(builds) }}
     </div>
     <p class="unsupported-download">
-      {{ _("Your system doesn't meet the <a href=\"%(url)s\">requirements</a> to run Firefox.")|format(url=product_url('firefox', 'sysreq', build)) }}
+      {{ _("Your system doesn't meet the <a href=\"%(url)s\">requirements</a> to run Firefox.")|format(url=product_url('firefox', 'sysreq', channel)) }}
     </p>
     <p class="linux-arm-download">
       {{ _('Please follow <a href="%(url)s">these instructions</a> to install Firefox.')|format(url='https://support.mozilla.org/kb/install-firefox-linux') }}
@@ -39,26 +39,26 @@
   {% endif %}
   <ul class="download-list">
     {% for plat in builds %}
-      <li class="{{ plat.os }}{% if plat.arch %} {{ plat.arch }}{% endif %}">
+      <li class="os_{{ plat.os }}{% if plat.arch %} {{ plat.arch }}{% endif %}">
         <a class="download-link"
            href="{{ plat.download_link }}"{% if plat.download_link_direct %}
            data-direct-link="{{ plat.download_link_direct }}"{% endif %}>
           <span class="download-content">
-            {% if plat.os == 'os_android' %}
-              {% if build == 'beta' %}
+            {% if plat.os == 'android' %}
+              {% if channel == 'beta' %}
                 <strong class="download-title">{{ _('<span>Firefox Beta</span> for Android') }}</strong>
-              {% elif build == 'aurora' %}
+              {% elif channel == 'alpha' %}
                 <strong class="download-title">{{ _('<span>Firefox Aurora</span> for Android') }} {{ plat.arch_pretty }}</strong>
               {% else %}
                 <strong class="download-title">{{ _('<span>Firefox</span> for Android') }}</strong>
               {% endif %}
-              {% if build != 'aurora' %}
+              {% if channel != 'alpha' %}
                 <span class="download-subtitle">{{ _('Get it free on Google Play') }}</span>
               {% endif %}
             {% else %}
-              {% if build == 'beta' %}
+              {% if channel == 'beta' %}
                 <strong class="download-title">{{ _('Firefox Beta') }}</strong>
-              {% elif build == 'aurora' %}
+              {% elif channel == 'alpha' %}
                 <strong class="download-title">{{ _('<span>Firefox</span> Developer Edition') }}</strong>
               {% else %}
                 <strong class="download-title">{{ _('Firefox') }}</strong>
@@ -72,25 +72,25 @@
       </li>
     {% endfor %}
   </ul>
-  {% if show_mobile %}
+  {% if show_android %}
     <small class="download-other os_android">
-      {% if build == 'aurora' -%}
+      {% if channel == 'alpha' -%}
         {% for plat in builds -%}
-          {% if plat.os == 'os_android' -%}
+          {% if plat.os == 'android' -%}
             <span class="arch {{ plat.arch }}"><a href="{{ plat.download_link }}">{{ plat.arch_pretty }}</a> |</span>
           {% endif -%}
         {% endfor -%}
       {% endif -%}
       <a href="https://support.mozilla.org/kb/will-firefox-work-my-mobile-device">{{ _('Supported Devices') }}</a>
-      {%- if build == 'aurora' %}<br>{% else %} |{% endif %}
-      <a href="{{ product_url('mobile', 'notes', build) }}">{{ _('What’s New') }}</a> |
+      {%- if channel == 'alpha' %}<br>{% else %} |{% endif %}
+      <a href="{{ product_url('android', 'notes', channel) }}">{{ _('What’s New') }}</a> |
       <a href="{{ url('privacy.notices.firefox') }}">{{ _('Privacy') }}</a>
     </small>
   {% endif %}
   {% if show_desktop %}
     <small class="download-other download-other-desktop os_linux os_linux64 os_osx os_windows">
-      <a href="{{ product_url('firefox', 'all', build) }}">{{ _('Systems &amp; Languages') }}</a> |
-      <a href="{{ product_url('firefox', 'notes', build) }}">{{ _('What’s New') }}</a> |
+      <a href="{{ product_url('firefox', 'all', channel) }}">{{ _('Systems &amp; Languages') }}</a> |
+      <a href="{{ product_url('firefox', 'notes', channel) }}">{{ _('What’s New') }}</a> |
       <a href="{{ url('privacy.notices.firefox') }}">{{ _('Privacy') }}</a>
     </small>
   {% endif %}

--- a/bedrock/mozorg/tests/test_helper_download_buttons.py
+++ b/bedrock/mozorg/tests/test_helper_download_buttons.py
@@ -7,79 +7,17 @@ from django.test.client import RequestFactory
 from django.test.utils import override_settings
 
 import jingo
-from mock import patch
 from nose.tools import eq_, ok_
 from product_details import product_details
 from pyquery import PyQuery as pq
 
-from bedrock.mozorg.helpers.download_buttons import (
-    firefox_details,
-    latest_version,
-    make_download_link
-)
 from bedrock.mozorg.tests import TestCase
-
-
-_ALL = settings.STUB_INSTALLER_ALL
 
 
 def render(s, context=None):
     context = context or {}
     t = jingo.env.from_string(s)
     return t.render(context)
-
-
-GOOD_PLATS = {'Windows': {}, 'OS X': {}, 'Linux': {}}
-GOOD_BUILDS = {
-    'en-US': {
-        '25.0': GOOD_PLATS,  # current release
-        '26.0b2': GOOD_PLATS,
-        '27.0a1': GOOD_PLATS,
-    },
-    'de': {
-        '25.0': GOOD_PLATS,
-    },
-    'fr': {
-        '24.0': GOOD_PLATS,  # prev release
-    }
-}
-GOOD_VERSIONS = {
-    'LATEST_FIREFOX_VERSION': '25.0',
-    'LATEST_FIREFOX_DEVEL_VERSION': '26.0b2',
-    'FIREFOX_AURORA': '27.0a1',
-    'FIREFOX_ESR': '24.1.0esr',
-}
-
-AURORA_DIR = ('https://ftp.mozilla.org/pub/mozilla.org/firefox/nightly/'
-              'latest-mozilla-aurora')
-
-mkln = make_download_link
-
-
-@patch.object(firefox_details, 'firefox_primary_builds', GOOD_BUILDS)
-@patch.object(firefox_details, 'firefox_beta_builds', {})
-@patch.dict(firefox_details.firefox_versions, GOOD_VERSIONS)
-class TestLatestVersion(TestCase):
-    def test_latest_version(self):
-        """Should return platforms if localized build does exist."""
-        result = latest_version('de', 'release')
-        self.assertEqual(result[0], '25.0')
-        self.assertIs(result[1], GOOD_PLATS)
-
-    def test_latest_version_is_none_if_no_build(self):
-        """Should return None if the localized build for the channel doesn't exist."""
-        result = latest_version('fr', 'release')
-        self.assertIsNone(result)
-
-    def test_latest_version_channels(self):
-        """Should work with all channels."""
-        result = latest_version('en-US', 'beta')
-        self.assertEqual(result[0], '26.0b2')
-        self.assertIs(result[1], GOOD_PLATS)
-
-        result = latest_version('en-US', 'aurora')
-        self.assertEqual(result[0], '27.0a1')
-        self.assertIs(result[1], GOOD_PLATS)
 
 
 class TestDownloadButtons(TestCase):
@@ -157,7 +95,7 @@ class TestDownloadButtons(TestCase):
         rf = RequestFactory()
         get_request = rf.get('/fake')
         get_request.locale = 'fr'
-        doc = pq(render("{{ download_firefox('aurora') }}",
+        doc = pq(render("{{ download_firefox('alpha') }}",
                         {'request': get_request}))
 
         links = doc('.download-list a')
@@ -169,7 +107,7 @@ class TestDownloadButtons(TestCase):
         rf = RequestFactory()
         get_request = rf.get('/fake')
         get_request.locale = 'fr'
-        doc = pq(render("{{ download_firefox('aurora') }}",
+        doc = pq(render("{{ download_firefox('alpha') }}",
                         {'request': get_request}))
 
         links = doc('.download-list a')[:4]
@@ -181,7 +119,7 @@ class TestDownloadButtons(TestCase):
         rf = RequestFactory()
         get_request = rf.get('/fake')
         get_request.locale = 'fr'
-        doc = pq(render("{{ download_firefox('aurora', "
+        doc = pq(render("{{ download_firefox('alpha', "
                         "force_full_installer=True) }}",
                         {'request': get_request}))
 
@@ -193,7 +131,7 @@ class TestDownloadButtons(TestCase):
         rf = RequestFactory()
         get_request = rf.get('/fake')
         get_request.locale = 'en-US'
-        doc = pq(render("{{ download_firefox('aurora', mobile=True) }}",
+        doc = pq(render("{{ download_firefox('alpha', platform='android') }}",
                         {'request': get_request}))
 
         list = doc('.download-list li')
@@ -212,7 +150,7 @@ class TestDownloadButtons(TestCase):
         rf = RequestFactory()
         get_request = rf.get('/fake')
         get_request.locale = 'en-US'
-        doc = pq(render("{{ download_firefox('beta', mobile=True) }}",
+        doc = pq(render("{{ download_firefox('beta', platform='android') }}",
                         {'request': get_request}))
 
         list = doc('.download-list li')
@@ -226,7 +164,7 @@ class TestDownloadButtons(TestCase):
         rf = RequestFactory()
         get_request = rf.get('/fake')
         get_request.locale = 'en-US'
-        doc = pq(render("{{ download_firefox(mobile=True) }}",
+        doc = pq(render("{{ download_firefox(platform='android') }}",
                         {'request': get_request}))
 
         list = doc('.download-list li')
@@ -266,42 +204,3 @@ class TestDownloadButtons(TestCase):
         # 'download-button-check-old-fx' class should be present
         dlbtn = pq(dlbuttons[0])
         self.assertTrue(dlbtn('.download-button-check-old-fx'))
-
-    @override_settings(STUB_INSTALLER_LOCALES={'win': ['en-us']})
-    def test_force_funnelcake_en_us_win_only(self):
-        """
-        Ensure that force_funnelcake doesn't affect non configured locale urls
-        """
-        url = make_download_link('firefox', 'release', '19.0', 'os_osx',
-                                 'en-US', force_funnelcake=True)
-        ok_('product=firefox-latest&' not in url)
-
-        url = make_download_link('firefox', 'beta', '20.0b4', 'os_windows',
-                                 'fr', force_funnelcake=True)
-        ok_('product=firefox-beta-latest&' not in url)
-
-    @override_settings(STUB_INSTALLER_LOCALES={'win': ['en-us']})
-    def test_force_full_installer_en_us_win_only(self):
-        """
-        Ensure that force_full_installer doesn't affect non configured locales
-        """
-        url = make_download_link('firefox', 'release', '19.0', 'os_osx',
-                                 'en-US', force_full_installer=True)
-        ok_('product=firefox-latest&' not in url)
-
-        url = make_download_link('firefox', 'beta', '20.0b4', 'os_windows',
-                                 'fr', force_full_installer=True)
-        ok_('product=firefox-beta-latest&' not in url)
-
-    @override_settings(STUB_INSTALLER_LOCALES={'win': ['en-us']})
-    def test_stub_installer_en_us_win_only(self):
-        """
-        Ensure that builds not in the setting don't get stub.
-        """
-        url = make_download_link('firefox', 'release', '19.0', 'os_osx',
-                                 'en-US')
-        ok_('product=firefox-stub&' not in url)
-
-        url = make_download_link('firefox', 'beta', '20.0b4', 'os_windows',
-                                 'fr')
-        ok_('product=firefox-beta-stub&' not in url)

--- a/bedrock/mozorg/tests/test_helper_misc.py
+++ b/bedrock/mozorg/tests/test_helper_misc.py
@@ -547,7 +547,7 @@ class TestProductURL(TestCase):
             '/en-US/firefox/all/')
         eq_(self._render('firefox', 'all', 'beta'),
             '/en-US/firefox/beta/all/')
-        eq_(self._render('firefox', 'all', 'aurora'),
+        eq_(self._render('firefox', 'all', 'alpha'),
             '/en-US/firefox/developer/all/')
         eq_(self._render('firefox', 'all', 'esr'),
             '/en-US/firefox/organizations/all/')
@@ -562,7 +562,7 @@ class TestProductURL(TestCase):
             '/en-US/firefox/system-requirements/')
         eq_(self._render('firefox', 'sysreq', 'beta'),
             '/en-US/firefox/beta/system-requirements/')
-        eq_(self._render('firefox', 'sysreq', 'aurora'),
+        eq_(self._render('firefox', 'sysreq', 'alpha'),
             '/en-US/firefox/developer/system-requirements/')
         eq_(self._render('firefox', 'sysreq', 'esr'),
             '/en-US/firefox/organizations/system-requirements/')
@@ -577,7 +577,7 @@ class TestProductURL(TestCase):
             '/en-US/firefox/notes/')
         eq_(self._render('firefox', 'notes', 'beta'),
             '/en-US/firefox/beta/notes/')
-        eq_(self._render('firefox', 'notes', 'aurora'),
+        eq_(self._render('firefox', 'notes', 'alpha'),
             '/en-US/firefox/developer/notes/')
         eq_(self._render('firefox', 'notes', 'esr'),
             '/en-US/firefox/organizations/notes/')
@@ -586,13 +586,13 @@ class TestProductURL(TestCase):
 
     def test_mobile_notes(self):
         """Should return a reversed path for the mobile notes page"""
-        eq_(self._render('mobile', 'notes'),
+        eq_(self._render('android', 'notes'),
             '/en-US/mobile/notes/')
-        eq_(self._render('mobile', 'notes', 'release'),
+        eq_(self._render('android', 'notes', 'release'),
             '/en-US/mobile/notes/')
-        eq_(self._render('mobile', 'notes', 'beta'),
+        eq_(self._render('android', 'notes', 'beta'),
             '/en-US/mobile/beta/notes/')
-        eq_(self._render('mobile', 'notes', 'aurora'),
+        eq_(self._render('android', 'notes', 'alpha'),
             '/en-US/mobile/aurora/notes/')
 
 

--- a/bedrock/releasenotes/views.py
+++ b/bedrock/releasenotes/views.py
@@ -13,8 +13,7 @@ from lib import l10n_utils
 from rna.models import Release
 from product_details import product_details
 
-from bedrock.firefox.firefox_details import firefox_details
-from bedrock.firefox.views import get_latest_version as firefox_get_latest_version
+from bedrock.firefox.firefox_details import firefox_desktop, firefox_android
 from bedrock.mozorg.decorators import cache_control_expires
 from bedrock.mozorg.helpers.misc import releasenotes_url
 from bedrock.mozorg.helpers.download_buttons import android_builds
@@ -71,7 +70,7 @@ def get_download_url(release):
         return android_builds(release.channel)[0]['download_link']
     else:
         if release.channel == 'Aurora':
-            return reverse('firefox.channel') + '#aurora'
+            return reverse('firefox.channel') + '#developer'
         elif release.channel == 'Beta':
             return reverse('firefox.channel') + '#beta'
         else:
@@ -117,19 +116,25 @@ def system_requirements(request, version, product='Firefox'):
 
 def latest_notes(request, product='firefox', channel='release'):
     if product == 'firefox' and channel == 'developer':
-        channel = 'aurora'
+        channel = 'alpha'
+    if product == 'mobile' and channel == 'aurora':
+        channel = 'alpha'
+    if channel == 'organizations':
+        channel = 'esr'
 
     if product == 'thunderbird':
-        version = thunderbird_get_latest_version(product, channel)
+        version = thunderbird_get_latest_version(channel)
+    elif product == 'mobile':
+        version = firefox_android.latest_version(channel)
     else:
-        version = firefox_get_latest_version(product, channel)
+        version = firefox_desktop.latest_version(channel)
 
     if channel == 'beta':
         version = re.sub(r'b\d+$', 'beta', version)
-    if channel == 'organizations':
+    if channel == 'esr':
         version = re.sub(r'esr$', '', version)
 
-    dir = 'auroranotes' if channel == 'aurora' else 'releasenotes'
+    dir = 'auroranotes' if channel == 'alpha' else 'releasenotes'
     path = [product, version, dir]
     locale = getattr(request, 'locale', None)
     if locale:
@@ -139,16 +144,20 @@ def latest_notes(request, product='firefox', channel='release'):
 
 def latest_sysreq(request, channel, product):
     if product == 'firefox' and channel == 'developer':
-        channel = 'aurora'
+        channel = 'alpha'
+    if channel == 'organizations':
+        channel = 'esr'
 
     if product == 'thunderbird':
-        version = thunderbird_get_latest_version(product, channel)
+        version = thunderbird_get_latest_version(channel)
+    elif product == 'mobile':
+        version = firefox_android.latest_version(channel)
     else:
-        version = firefox_get_latest_version(product, channel)
+        version = firefox_desktop.latest_version(channel)
 
     if channel == 'beta':
         version = re.sub(r'b\d+$', 'beta', version)
-    if channel == 'organizations':
+    if channel == 'esr':
         version = re.sub(r'^(\d+).+', r'\1.0', version)
 
     dir = 'system-requirements'
@@ -162,8 +171,8 @@ def latest_sysreq(request, channel, product):
 def releases_index(request, product):
     releases = {}
     if product == 'Firefox':
-        major_releases = firefox_details.firefox_history_major_releases
-        minor_releases = firefox_details.firefox_history_stability_releases
+        major_releases = firefox_desktop.firefox_history_major_releases
+        minor_releases = firefox_desktop.firefox_history_stability_releases
     elif product == 'Thunderbird':
         major_releases = product_details.thunderbird_history_major_releases
         minor_releases = product_details.thunderbird_history_stability_releases

--- a/bedrock/styleguide/templates/styleguide/websites/sandstone-all-download-buttons.html
+++ b/bedrock/styleguide/templates/styleguide/websites/sandstone-all-download-buttons.html
@@ -72,37 +72,37 @@
       <tr>
         <th>Full-size + icon</th>
         <td>
-          {{ download_firefox(mobile=True) }}
+          {{ download_firefox(platform='android') }}
         </td>
         <td>
-          {{ download_firefox(mobile=True, build='beta') }}
+          {{ download_firefox(platform='android', build='beta') }}
         </td>
       </tr>
       <tr>
         <th>Compact + icon</th>
         <td>
-          {{ download_firefox(mobile=True, small=True) }}
+          {{ download_firefox(platform='android', small=True) }}
         </td>
         <td>
-          {{ download_firefox(mobile=True, small=True, build='beta') }}
+          {{ download_firefox(platform='android', small=True, build='beta') }}
         </td>
       </tr>
       <tr>
         <th>Full-size + no icon</th>
         <td>
-          {{ download_firefox(mobile=True, icon=False) }}
+          {{ download_firefox(platform='android', icon=False) }}
         </td>
         <td>
-          {{ download_firefox(mobile=True, icon=False, build='beta') }}
+          {{ download_firefox(platform='android', icon=False, build='beta') }}
         </td>
       </tr>
       <tr>
         <th>Compact + no icon</th>
         <td>
-          {{ download_firefox(mobile=True, small=True, icon=False) }}
+          {{ download_firefox(platform='android', small=True, icon=False) }}
         </td>
         <td>
-          {{ download_firefox(mobile=True, small=True, icon=False, build='beta') }}
+          {{ download_firefox(platform='android', small=True, icon=False, build='beta') }}
         </td>
       </tr>
     </tbody>

--- a/bedrock/styleguide/templates/styleguide/websites/sandstone-buttons.html
+++ b/bedrock/styleguide/templates/styleguide/websites/sandstone-buttons.html
@@ -27,17 +27,17 @@
     <div class="example">{{ download_firefox(small=True) }}</div>
     <div class="example">{{ download_firefox('beta', icon=False) }}</div>
     <div class="example">{{ download_firefox('beta', small=True, icon=False) }}</div>
-    <div class="example">{{ download_firefox('aurora', icon=False) }}</div>
-    <div class="example">{{ download_firefox('aurora', small=True, icon=False) }}</div>
+    <div class="example">{{ download_firefox('alpha', icon=False) }}</div>
+    <div class="example">{{ download_firefox('alpha', small=True, icon=False) }}</div>
   </div>
   <div class="examples">
     <h3>Mobile download</h3>
-    <div class="example">{{ download_firefox(mobile=True) }}</div>
-    <div class="example">{{ download_firefox(small=True, mobile=True) }}</div>
-    <div class="example">{{ download_firefox('beta', mobile=True, icon=False) }}</div>
-    <div class="example">{{ download_firefox('beta', small=True, mobile=True, icon=False) }}</div>
-    <div class="example">{{ download_firefox('aurora', mobile=True, icon=False) }}</div>
-    <div class="example">{{ download_firefox('aurora', small=True, mobile=True, icon=False) }}</div>
+    <div class="example">{{ download_firefox(platform='android') }}</div>
+    <div class="example">{{ download_firefox(small=True, platform='android') }}</div>
+    <div class="example">{{ download_firefox('beta', platform='android', icon=False) }}</div>
+    <div class="example">{{ download_firefox('beta', small=True, platform='android', icon=False) }}</div>
+    <div class="example">{{ download_firefox('alpha', platform='android', icon=False) }}</div>
+    <div class="example">{{ download_firefox('alpha', small=True, platform='android', icon=False) }}</div>
   </div>
   <div class="examples" id="examples-standard">
     <h3>Standard</h3>

--- a/bedrock/thunderbird/utils.py
+++ b/bedrock/thunderbird/utils.py
@@ -6,5 +6,5 @@
 from product_details import product_details
 
 
-def get_latest_version(product='Thunderbird', channel='release'):
+def get_latest_version(channel='release'):
     return product_details.thunderbird_versions.get('LATEST_THUNDERBIRD_VERSION')

--- a/media/css/firefox/all.less
+++ b/media/css/firefox/all.less
@@ -115,7 +115,7 @@
             &.linux64 a {
                 background-position: -900px 50%
             }
-            &.mac a {
+            &.osx a {
                 background-position: -1200px 50%
             }
         }

--- a/media/css/firefox/channel.less
+++ b/media/css/firefox/channel.less
@@ -145,7 +145,7 @@
     text-align: left;
 }
 
-.android .download-box.mobile {
+.android .download-box.android {
     display: none;
 }
 

--- a/media/css/firefox/template-resp.less
+++ b/media/css/firefox/template-resp.less
@@ -9,7 +9,7 @@
 }
 
 #main-feature .download-button-small,
-#main-feature .download-button-mobile-small {
+#main-feature .download-button-android-small {
     position: absolute;
     top: 0;
     right: 30px;
@@ -28,7 +28,7 @@
 @media only screen and (max-width: @breakTablet) {
 
 #main-feature .download-button-small,
-#main-feature .download-button-mobile-small {
+#main-feature .download-button-android-small {
     position: static;
 }
 

--- a/media/css/firefox/template.less
+++ b/media/css/firefox/template.less
@@ -9,7 +9,7 @@
 }
 
 #main-feature .download-button-small,
-#main-feature .download-button-mobile-small {
+#main-feature .download-button-android-small {
     position: absolute;
     top: 0;
     right: 48px;

--- a/media/css/sandstone/buttons.less
+++ b/media/css/sandstone/buttons.less
@@ -365,12 +365,12 @@
 }
 
 .download-button-beta.download-button-small .download-link .download-lang,
-.download-button-aurora.download-button-small .download-link .download-lang {
+.download-button-alpha.download-button-small .download-link .download-lang {
     top: 33px;
 }
 
 .download-button-beta,
-.download-button-aurora {
+.download-button-alpha {
     .download-link .download-title,
     .download-link .download-title span {
         .font-size(24px);
@@ -378,14 +378,14 @@
 }
 
 .download-button-beta.download-button-small,
-.download-button-aurora.download-button-small {
+.download-button-alpha.download-button-small {
     .download-link .download-title,
     .download-link .download-title span {
         .font-size(20px);
     }
 }
 
-.download-button-aurora.download-button-small {
+.download-button-alpha.download-button-small {
     .download-link {
         .download-title {
             .font-size(13px);
@@ -407,7 +407,7 @@
     }
 }
 
-.download-button-aurora.download-button-simple {
+.download-button-alpha.download-button-simple {
     .download-link .download-subtitle {
         // Don't hide the subtitle for Aurora if simple=True
         display: block;
@@ -415,9 +415,9 @@
 }
 
 .download-button.download-button-beta.download-button-small .download-list .os_android,
-.download-button.download-button-aurora.download-button-small .download-list .os_android,
-.download-button.download-button-mobile.download-button-aurora.download-button-small,
-.download-button.download-button-mobile.download-button-beta.download-button-small {
+.download-button.download-button-alpha.download-button-small .download-list .os_android,
+.download-button.download-button-android.download-button-alpha.download-button-small,
+.download-button.download-button-android.download-button-beta.download-button-small {
     .download-link .download-title span {
         .font-size(18px);
         letter-spacing: -0.01em;
@@ -432,11 +432,11 @@
   background-image: url(/media/img/sandstone/buttons/beta-small.png);
 }
 
-.download-button-large.aurora .download-link .download-content {
+.download-button-large.alpha .download-link .download-content {
   background-image: url(/media/img/sandstone/buttons/aurora-large.png);
 }
 
-.download-button-small.aurora .download-link .download-content {
+.download-button-small.alpha .download-link .download-content {
   background-image: url(/media/img/sandstone/buttons/aurora-small.png);
 }
 
@@ -457,7 +457,7 @@
 }
 
 .download-button-noicon .download-list .os_android,
-.download-button-mobile.download-button-noicon {
+.download-button-android.download-button-noicon {
     .download-link .download-title span {
         padding-top: 7px;
     }
@@ -473,7 +473,7 @@
 }
 
 .download-button-small.download-button-noicon .download-list .os_android,
-.download-button-small.download-button-mobile.download-button-noicon {
+.download-button-small.download-button-android.download-button-noicon {
     .download-link .download-title span {
         padding-top: 0;
     }
@@ -535,10 +535,10 @@
 
 .download-button .os_linux,
 .download-button .os_linux64,
-.windows.arm .download-button .os_windows,
+.windows.arm .download-button .os_win,
 .linux.arm .download-button .os_linux,
 .linux.x86.x64 .download-list .os_linux,
-.download-button .os_windows,
+.download-button .os_win,
 .download-button .os_osx,
 .download-button .os_android,
 .no-js .download-list,
@@ -548,15 +548,15 @@
 
 .linux .download-button .os_linux,
 .linux.x86.x64 .download-button .os_linux64,
-.windows .download-button .os_windows,
+.windows .download-button .os_win,
 .osx .download-button .os_osx,
 .android .download-button .os_android,
-.download-button-mobile .os_android,
+.download-button-android .os_android,
 .android .download-button-desktop .download-list,
-.android .download-button-desktop small.os_windows,
-.no-js .download-button-mobile .download-list,
-.other .download-button-mobile .download-list,
-.other .download-button small.os_windows {
+.android .download-button-desktop small.os_win,
+.no-js .download-button-android .download-list,
+.other .download-button-android .download-list,
+.other .download-button small.os_win {
     display: block !important;
 }
 
@@ -572,7 +572,7 @@
 // Small print
 
 .download-button small.download-other,
-.other .download-button-mobile small.download-other,
+.other .download-button-android small.download-other,
 .android .download-button-desktop small.download-other {
     .open-sans;
     display: block;
@@ -627,7 +627,7 @@
 // Mobile download buttons
 
 .download-button .download-list .os_android,
-.download-button-mobile {
+.download-button-android {
     .download-link {
        .download-title {
             padding-top: 0;
@@ -651,7 +651,7 @@
 }
 
 .download-button.download-button-small .download-list .os_android,
-.download-button.download-button-small.download-button-mobile {
+.download-button.download-button-small.download-button-android {
     .download-link {
        .download-title {
             padding-top: 0;
@@ -706,7 +706,7 @@ html[lang="es-ES"],
 html[lang="es-MX"],
 html[lang="pt-BR"],
 html[lang="pt-PT"] {
-    .download-button-aurora.download-button-small .download-link .download-lang,
+    .download-button-alpha.download-button-small .download-link .download-lang,
     .download-button-beta.download-button-small .download-link .download-lang {
         top: 30px;
     }
@@ -714,7 +714,7 @@ html[lang="pt-PT"] {
 
 html[lang="gd"],
 html[lang="mk"] {
-    .download-button-aurora.download-button-small .download-link,
+    .download-button-alpha.download-button-small .download-link,
     .download-button-beta.download-button-small .download-link {
         .download-subtitle {
             padding-right: 50px;
@@ -722,7 +722,7 @@ html[lang="mk"] {
     }
 
     .download-button.download-button-small .download-list .os_android,
-    .download-button.download-button-small.download-button-mobile {
+    .download-button.download-button-small.download-button-android {
         .download-subtitle {
             padding-right: 0;
         }
@@ -754,7 +754,7 @@ html[lang="ml"],
 html[lang="ms"],
 html[lang="ta"],
 html[lang="te"] {
-    .download-button.download-button-beta.download-button-mobile.download-button-small,
+    .download-button.download-button-beta.download-button-android.download-button-small,
     .download-button.download-button-small .download-list .os_android {
         .download-subtitle {
             width: auto;


### PR DESCRIPTION
Refactoring Sunday!

Assumption: Firefox for Windows 64, Firefox for iOS and Thunderbird are all coming to Bedrock sometime soon.

* Merge part of `mozorg/helpers/download_buttons.py` into `firefox/firefox_details.py`
* Rename `FirefoxDetails` to `FirefoxDesktop`, `MobileDetails` to `FirefoxAndroid`
* Change the internal channel name `aurora` to product-neutral `alpha`
* Update the product-related URL functions accordingly
* Update Firefox Developer Edition download links to use the bouncer
* Make it easier to [add Windows 64 builds](https://github.com/kyoshino/bedrock/compare/kyoshino:bug-1129624-refactor-download-links...bug-1126837-win64) (**still need some tests**)