### PR TITLE
Fix Bug 1134058: Show .form-details when form has focus

### DIFF
--- a/media/css/sandstone/sandstone-resp.less
+++ b/media/css/sandstone/sandstone-resp.less
@@ -898,7 +898,6 @@ nav.menu-bar {
     p.form-details {
         margin-top: 8px;
         line-height: 1;
-        color: @textColorSecondary;
     }
 }
 

--- a/media/js/newsletter/form.js
+++ b/media/js/newsletter/form.js
@@ -11,10 +11,12 @@ $(function () {
     function initFooterEmailForm () {
         var $submitButton = $('.footer-newsletter-form input[type=submit]');
         var $formDetails = $('.footer-newsletter-form #form-details');
+        var $formDetailsSecondary = $('.footer-newsletter-form .form-details');
 
         function footerEmailFormShowDetails() {
             if (!$formDetails.is(':visible')) {
                 $formDetails.slideDown('normal');
+                $formDetailsSecondary.slideDown('normal');
             }
         }
 


### PR DESCRIPTION
Fix .form-details not expanding when .footer-newsletter-form gets focus and let the .form-details inherit the text colour of what it's inside of.