### PR TITLE
fix bug  1129961, added a try except block to catch exceptions raised by...

### DIFF
--- a/bedrock/events/cron.py
+++ b/bedrock/events/cron.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
@@ -6,13 +7,28 @@ from django.conf import settings
 
 import cronjobs
 import requests
+import logging
 
 from bedrock.events.models import Event
+
+logger = logging.getLogger(__name__)
 
 
 @cronjobs.register
 def update_reps_ical():
     # TODO get dependencies for TLS SNI installed on servers
     # see http://bugzil.la/1080571
-    resp = requests.get(settings.REPS_ICAL_FEED, verify=False)
-    Event.objects.sync_with_ical(resp.text)
+
+    # if the ical feed is down catch the exception, log the error
+    # and fail silently.
+    # http://bugzil.la/1129961
+    try:
+        resp = requests.get(settings.REPS_ICAL_FEED, verify=False)
+        if resp.status_code == 200:
+            Event.objects.sync_with_ical(resp.text)
+            return
+
+        logger.error("Request returned error code: %d and error body: %s" %
+                     (resp.status_code, resp.text))
+    except Exception as e:
+        logger.error("Exception caught: %s" % repr(e))

--- a/root_files/humans.txt
+++ b/root_files/humans.txt
@@ -83,6 +83,7 @@ Developers: jasager
 Developers: meghprkh
 Developers: utkbansal
 Developers: pollti
+Developers: lismanb
 
 Localizers on SVN
 Localize: akilaa@wippies.fi


### PR DESCRIPTION
... the HTTP GET on settings.REPS_ICAL_FEED. Log the exception or the HTTP GET response error message and fail silently