### PR TITLE
Fix a potential error in the TwitterCacheManager.

### DIFF
--- a/bedrock/mozorg/models.py
+++ b/bedrock/mozorg/models.py
@@ -12,7 +12,7 @@ class TwitterCacheManager(models.Manager):
         tweets = cache.get(cache_key)
         if tweets is None:
             try:
-                tweets = TwitterCache.objects.get(account=account).tweets
+                tweets = self.get(account=account).tweets
             except (TwitterCache.DoesNotExist, DatabaseError):
                 # TODO: see if we should catch other errors
                 tweets = []


### PR DESCRIPTION
This looks like it would fail at some point. Python
magic is keeping it going I guess. Referencing the manager
instance from the manager class seems bad though.