### PR TITLE
Update home page promos

### DIFF
--- a/bedrock/mozorg/templates/mozorg/home/home-new.html
+++ b/bedrock/mozorg/templates/mozorg/home/home-new.html
@@ -94,13 +94,13 @@
     <div class="promo-grid-inner">
       <ul class="promo-grid {% if tweets %}has-twitter-promo{% endif %}">
       {# L10n: Begin home page promos. Line breaks are for visual formatting only. #}
-      {% if l10n_has_tag('fx10_independent') %}
-        <li id="promo-1" class="item promo-large-portrait firefox-independent" data-name="Firefox: The indepedent choice" tabindex="0">
-          <h2 class="primary go">{{ _('Firefox: The independent choice') }}</h2>
-          <a class="panel-link" href="{{ url('firefox.independent') }}#play">
+      {% if l10n_has_tag('hello_promo') %}
+        <li id="promo-1" class="item promo-large-portrait firefox-hello" data-name="Meet Firefox Hello" tabindex="0">
+          <h2 class="primary go">{{ _('Meet<br> Firefox Hello') }}</h2>
+          <a class="panel-link" href="{{ url('firefox.hello') }}">
             <div class="secondary">
-              <h3>{{ _('Help us celebrate 10 years of choice and independence online.') }}</h3>
-              <p class="more">{{ _('Watch our video') }}</p>
+              <h3>{{ _('The easiest way to connect for free over video') }}</h3>
+              <p class="more">{{ _('Try Firefox Hello') }}</p>
             </div>
           </a>
         </li>
@@ -115,10 +115,16 @@
           </a>
         </li>
       {% endif %}
-      {% if LANG == 'en-US' %}
+      {% if LANG == 'en-US' and waffle.switch('mozorg-home-neutrality-promo') %}
         <li id="promo-2" class="item promo-small-landscape net-neutrality" data-name="Protect net neutrality today">
           <a class="panel-link" href="https://sendto.mozilla.org/page/s/FCCvote-net-neutrality?ref=20150205Advocacy_NN&amp;utm_campaign=20150205Advocacy_NN&amp;utm_source=mozilla.org&amp;utm_medium=referral&amp;utm_content=homepage_promo">
             <h2>Protect net neutrality today</h2>
+          </a>
+        </li>
+      {% elif l10n_has_tag('privacy_day') %}
+        <li id="promo-2" class="item promo-small-landscape advocacy" data-name="Learn about Mozilla Advocacy">
+          <a class="panel-link" href="https://advocacy.mozilla.org">
+            <h2>{{ _('Learn about Mozilla Advocacy') }}</h2>
           </a>
         </li>
       {% else %}
@@ -144,13 +150,13 @@
             <a class="fxos-link" href="{{ url('firefox.desktop.index') }}">{{ _('Learn more') }}</a>
           </div>
         </li>
-      {% if l10n_has_tag('privacy_day') and waffle.switch('mozorg-home-privacy-promo') %}
-        <li id="promo-6" class="item promo-large-landscape privacy-day" tabindex="0" data-name="Get smart on privacy">
-          <h2 class="primary go">{{ _('Get Smart on Privacy') }}</h2>
-          <a class="panel-link" rel="external" href="{{ url('privacy.privacy-day') }}?utm_source=mozorg&amp;utm_medium=tile&amp;utm_campaign=DPD15">
+      {% if l10n_has_tag('webmaker_promo_make') %}
+        <li id="promo-6" class="item promo-large-landscape webmaker" tabindex="0" data-name="Make the Web you want">
+          <h2 class="primary go">{{ _('Make the Web you want') }}</h2>
+          <a class="panel-link" rel="external" href="https://webmaker.org/">
             <div class="secondary">
-              <h3>{{ _('Learn how to give yourself more control online in four easy steps.') }}</h3>
-              <p class="more">{{ _('Get smart on privacy') }}</p>
+              <h3>{{ _('Build a webpage or app in minutes<br> — no coding required') }}</h3>
+              <p class="more">{{ _('Become a Webmaker') }}</p>
             </div>
           </a>
         </li>
@@ -173,22 +179,19 @@
             <h2>{{ _('Build an app <br>in seconds') }}</h2>
           </a>
         </li>
+      {% if l10n_has_tag('gear_store') %}
+        <li id="promo-9" class="item promo-small-landscape gear" data-name="Get gear">
+          <a class="panel-link" href="https://gear.mozilla.org/?utm_source=gear.mozilla.org&amp;utm_medium=referral&amp;utm_content=mozillaorg_smallblock">
+            <h2>{{ _('Official Mozilla gear is here') }}</h2>
+          </a>
+        </li>
+      {% else %}
         <li id="promo-9" class="item promo-small-landscape volunteer" data-name="Volunteer with Mozilla">
           <a class="panel-link" href="{{ url('mozorg.contribute') }}">
             <h2>{{ _('Volunteer <br>with Mozilla') }}</h2>
           </a>
         </li>
-      {% if l10n_has_tag('fx10_independent') %}
-        <li id="promo-10" class="item promo-large-portrait firefox-developer" tabindex="0" data-name="Introducing Firefox Developer Edition">
-          <h2 class="primary go">{{ _('Introducing Firefox Developer Edition') }}</h2>
-          <a class="panel-link" href="{{ url('firefox.developer') }}">
-            <div class="secondary">
-              <h3>{{ _('The only browser made only for developers.') }}</h3>
-              <p class="more">{{ _('Get Firefox Developer Edition') }}</p>
-            </div>
-          </a>
-        </li>
-      {% else %}
+      {% endif %}
         <li id="promo-10" class="item promo-large-portrait firefox-android" tabindex="0" data-name="Put your Firefox on your Android">
           <h2 class="primary go">{{ _('Put your Firefox on your Android') }}</h2>
           <a class="panel-link" href="{{ url('firefox.android.index') }}">
@@ -198,14 +201,13 @@
             </div>
           </a>
         </li>
-      {% endif %}
-      {% if l10n_has_tag('gear_store') %}
-        <li id="promo-11" class="item promo-large-landscape gear" tabindex="0" data-name="Get gear">
-          <h2 class="primary go">{{ _('Official Mozilla gear is here') }}</h2>
-          <a class="panel-link" href="https://gear.mozilla.org/?ref=OMG_launch&amp;utm_campaign=OMG_launch&amp;utm_source=gear.mozilla.org&amp;utm_medium=referral&amp;utm_content=mozillaorg_largeblock">
+      {% if l10n_has_tag('fx10_independent') %}
+        <li id="promo-11" class="item promo-large-landscape firefox-developer" tabindex="0" data-name="Introducing Firefox Developer Edition">
+          <h2 class="primary go">{{ _('Introducing Firefox Developer Edition') }}</h2>
+          <a class="panel-link" href="{{ url('firefox.developer') }}">
             <div class="secondary">
-              <h3>{{ _('Merch with a mission. <br>Products with a purpose. <br>Goods that do good.') }}</h3>
-              <p class="more">{{ _('Get your Mozilla gear') }}</p>
+              <h3>{{ _('The only browser made only for developers.') }}</h3>
+              <p class="more">{{ _('Get Firefox Developer Edition') }}</p>
             </div>
           </a>
         </li>

--- a/media/css/mozorg/home/home-promo.less
+++ b/media/css/mozorg/home/home-promo.less
@@ -758,7 +758,7 @@ html[lang|="en"] {
 /****************************************************************************/
 // Net Neutrality
 .promo-small-landscape.net-neutrality {
-    background-color: #3fa9f1;
+    background-color: #b7bad6; // lavender
     background-image: url(/media/img/home/voices/promos/net-neutrality/net-neutrality-date.svg);
     background-position: 15px 20px;
     background-repeat: no-repeat;
@@ -772,6 +772,27 @@ html[lang|="en"] {
 
 [lang|='en'] {
     .promo-small-landscape.net-neutrality h2 {
+        .font-size(22px);
+    }
+}
+
+/****************************************************************************/
+// Advocacy
+.promo-small-landscape.advocacy {
+    background-color: #b7bad6; // lavender
+    background-image: url(/media/img/home/voices/promos/advocacy/advocacy-logo.png);
+    background-position: 15px 20px;
+    background-repeat: no-repeat;
+    .background-size(100px, 100px);
+
+    h2 {
+        padding: 20px 10px 10px 125px;
+        .font-size(16px);
+    }
+}
+
+[lang|='en'] {
+    .promo-small-landscape.advocacy h2 {
         .font-size(22px);
     }
 }
@@ -865,20 +886,6 @@ html[lang|="en"] {
     }
 }
 
-/****************************************************************************/
-// Privacy Day
-.promo-large-landscape.privacy-day {
-    background: #c33b32; // red
-
-    h2 {
-        padding: 120px @baseLine 0 @baseLine;
-        margin-top: @baseLine;
-        background-image: url(/media/img/home/voices/promos/privacy/privacy-shield.svg?1-27-2015);
-        background-position: top center;
-        background-repeat: no-repeat;
-        .background-size(90px, 103px);
-    }
-}
 
 /****************************************************************************/
 // Support
@@ -911,6 +918,25 @@ html[lang|="en"] {
     }
 }
 
+.promo-small-landscape.gear {
+    background-color: #95368c; // purple
+
+    h2 {
+        padding: @baseLine @baseLine @baseLine 120px;
+        min-height: 80px;
+        background-image: url(/media/img/home/voices/promos/gear/gear.png);
+        background-position: 15px 25px;
+        background-repeat: no-repeat;
+        .background-size(75px, 80px);
+        .font-size(16px);
+    }
+}
+
+[lang|='en'] {
+    .promo-small-landscape.gear h2 {
+        .font-size(22px);
+    }
+}
 
 /****************************************************************************/
 // Firefox Desktop
@@ -937,25 +963,43 @@ html[lang|="en"] {
 
 
 /****************************************************************************/
-// Firefox Independent
-.promo-large-portrait.firefox-independent {
-    background: #e55525; // orange
+// Firefox Hello
+.promo-large-portrait.firefox-hello {
+    background: #00a9dc; // turquoise
 
     h2 {
-        padding-top: 145px;
-        background: url(/media/img/home/voices/promos/independent/independent.png) center 25px no-repeat;
+        padding-top: 220px;
+        background: url(/media/img/home/voices/promos/hello/hello.svg) center 55px no-repeat;
+        .background-size(120px 120px);
+    }
+}
+
+html[lang|="en"] {
+    .promo-large-portrait.firefox-hello {
+        h3 {
+            padding-top: @baseLine * 4;
+        }
     }
 }
 
 
 /****************************************************************************/
 // Firefox Developer Edition
-.promo-large-portrait.firefox-developer {
+.promo-large-landscape.firefox-developer {
     background: #005da5; // dark blue
 
     h2 {
-        padding-top: 145px;
-        background: url(/media/img/home/voices/promos/firefoxdev/firefoxdev.png) center 25px no-repeat;
+        padding-top: 125px;
+        background: url(/media/img/home/voices/promos/firefoxdev/firefoxdev.png) center 15px no-repeat;
+    }
+}
+
+html[lang|='en'] {
+    .promo-large-landscape.firefox-developer {
+        h2 {
+            max-width: 440px;
+            margin: 0 auto;
+        }
     }
 }
 
@@ -1698,6 +1742,12 @@ html[lang|="en"] {
     .promo-small-landscape.privacy {
         background-image: url(/media/img/home/voices/promos/privacy/privacy-high-res.png);
         .background-size(121px, 120px);
+    }
+
+    // Advocacy
+    .promo-small-landscape.advocacy {
+        background-image: url(/media/img/home/voices/promos/advocacy/advocacy-logo-high-res.png);
+        .background-size(100px, 100px);
     }
 
     // Volunteer

--- a/media/img/home/voices/promos/hello/hello.svg
+++ b/media/img/home/voices/promos/hello/hello.svg
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 15.0.2, SVG Export Plug-In  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" [
+	<!ENTITY ns_flows "http://ns.adobe.com/Flows/1.0/">
+]>
+<svg version="1.1"
+	 xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:a="http://ns.adobe.com/AdobeSVGViewerExtensions/3.0/"
+	 x="0px" y="0px" width="120px" height="120px" viewBox="-1.15 -4.46 120 120"
+	 overflow="visible" enable-background="new -1.15 -4.46 120 120" xml:space="preserve">
+<defs>
+</defs>
+<path fill="#FFFFFF" d="M58.66,0C26.31,0,0,23.1,0,51.51c0,14.21,6.51,27.04,17.05,36.3c-1.83,6.42-5.41,15.21-12.65,23.74
+	c1.19,2.2,21.36-5.5,35.56-11.18c5.87,1.74,12.1,2.66,18.61,2.66c32.36,0,58.66-23.1,58.66-51.51C117.32,23.1,91.02,0,58.66,0z
+	 M76.17,30.89c4.31,0,7.79,3.48,7.79,7.79c0,4.31-3.48,7.79-7.79,7.79c-4.31,0-7.79-3.48-7.79-7.79
+	C68.47,34.37,71.95,30.89,76.17,30.89z M40.79,30.89c4.31,0,7.79,3.48,7.79,7.79c0,4.31-3.48,7.79-7.79,7.79
+	c-4.31,0-7.79-3.48-7.79-7.79C33.09,34.37,36.48,30.89,40.79,30.89z M58.75,89.27h-0.27H58.2c-15.67,0-33.18-11.08-37.21-28.23
+	c10.54,4.86,25.39,6.6,37.4,6.6c12.01,0,26.85-1.42,37.4-6.37C91.93,78.41,74.43,89.27,58.75,89.27z"/>
+</svg>


### PR DESCRIPTION
Bug 1126956 - Restore Android and Advocacy promos
Bug 1131854 - Firefox Hello promo
Bug 1132231 - update Webmaker promo

@flodolo: We should be all set to release this in English first and other locales can update at their convenience. There are new l10n tags ('hello_promo' and 'webmaker_promo_make') and some others that are reused. I'm reusing 'privacy_day' for the advocacy promo, which was removed and has come back, but it looks like many locales still have the string under that tag. The dev browser promo has moved but the strings are the same so it can continue using the 'fx10_independent' tag, and the same for 'gear_store'. Let me know if I've missed anything.

@jgmize: The new waffle switch 'mozorg-home-neutrality-promo' should be active when this update goes to prod and deactivate at midnight on Feb 26 (I'll actually delete the promo next week).