### PR TITLE
Fix bug 1135693: Add update scripts to repo.

### DIFF
--- a/bin/update-scripts/dev/update-dev-django.sh
+++ b/bin/update-scripts/dev/update-dev-django.sh
@@ -41,4 +41,3 @@ echo "Calling Chief for '$WEBAPP' to deploy '${SHAAVAILABLE:0:8}'"
 # This just creates a POST event to the Chief app. We populate the form fields with the information gathered above ($SHAAVAILABLE, $PASSWORD, $WEBAPP)
 curl -s -F 'who=web-ops_cli_script' -F "password=$PASSWORD" -F "ref=$SHAAVAILABLE" http://$(hostname)/chief/$WEBAPP -o /dev/null
 checkretval
-

--- a/bin/update-scripts/prod/update-prod-locale-cron.sh
+++ b/bin/update-scripts/prod/update-prod-locale-cron.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# script to push out svn locale updates via cron
+
+/data/bedrock/src/www.mozilla.org-django/bedrock/bin/update-scripts/prod/update-prod-locale.sh && \
+/data/bedrock/deploy www.mozilla.org-django/bedrock/locale

--- a/bin/update-scripts/prod/update-prod-locale.sh
+++ b/bin/update-scripts/prod/update-prod-locale.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+UPSTREAM=$(svn info https://svn.mozilla.org/projects/mozilla.com/trunk/locales | grep Revision | cut -f2 -d' ')
+cd /data/bedrock/src/www.mozilla.org-django/bedrock
+
+pushd locale > /dev/null
+RUNNING=$(svnversion ./ | tr -d '[A-Z]')
+if [ "$RUNNING" != "$UPSTREAM" ]; then
+    svn -q up
+    echo -e "finished at $(date)" > /data/bedrock/src/www.mozilla.org-django/bedrock/media/locale_finished.txt
+    exit 0
+fi
+popd > /dev/null
+
+exit 1

--- a/bin/update-scripts/prod/update-prod-php.sh
+++ b/bin/update-scripts/prod/update-prod-php.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+UPSTREAM=$(svn info http://svn.mozilla.org/projects/mozilla.com/tags/production | grep Revision | cut -f2 -d' ')
+cd /data/bedrock/src/www.mozilla.org
+
+RUNNING=$(svnversion ./ | tr -d '[A-Z]')
+UPDATED=0
+if [ $RUNNING -ne $UPSTREAM ]; then
+    svn -q up
+    UPDATED=1
+fi
+
+cd org
+RUNNING=$(svnversion ./ | tr -d '[A-Z]')
+if [ $RUNNING -ne $UPSTREAM ]; then
+    svn -q up
+    UPDATED=1
+fi
+
+if [ $UPDATED = 1 ]; then
+    /data/bedrock/deploy www.mozilla.org > /dev/null 2>&1
+else
+#    echo "Nothing to deploy."
+    exit 0
+fi

--- a/bin/update-scripts/prod/update-prod-product-details.sh
+++ b/bin/update-scripts/prod/update-prod-product-details.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+cd /data/bedrock/src/www.mozilla.org-django
+
+venv/bin/python bedrock/manage.py update_product_details
+
+echo -e "finished at $(date)" > /data/bedrock/src/www.mozilla.org-django/bedrock/media/product_details_finished.txt
+echo -e "finished at $(date)" > /data/bedrock/www/www.mozilla.org-django/bedrock/media/product_details_finished.txt
+/data/bedrock/deploy www.mozilla.org-django/bedrock/lib/product_details_json &> /dev/null
+exit 0

--- a/bin/update-scripts/stage/update-stage-locale.sh
+++ b/bin/update-scripts/stage/update-stage-locale.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+UPSTREAM=$(svn info https://svn.mozilla.org/projects/mozilla.com/trunk/locales | grep Revision | cut -f2 -d' ')
+cd /data/bedrock-stage/src/www.allizom.org-django/bedrock
+
+pushd locale > /dev/null
+RUNNING=$(svnversion ./ | tr -d '[A-Z]')
+UPDATED=0
+if [ "$RUNNING" != "$UPSTREAM" ]; then
+    svn -q up
+    UPDATED=1
+fi
+popd > /dev/null
+
+if [ $UPDATED -eq 1 ]; then
+    /data/bedrock-stage/deploy -q www.allizom.org-django/bedrock/locale
+else
+#    echo "Nothing to deploy."
+    exit 0
+fi

--- a/bin/update-scripts/stage/update-stage-php.sh
+++ b/bin/update-scripts/stage/update-stage-php.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+UPSTREAM=$(svn info http://svn.mozilla.org/projects/mozilla.com/tags/stage | grep Revision | cut -f2 -d' ')
+cd /data/bedrock-stage/src/www.allizom.org
+
+RUNNING=$(svnversion ./ | tr -d '[A-Z]')
+UPDATED=0
+if [ $RUNNING -ne $UPSTREAM ]; then
+    svn -q up
+    UPDATED=1
+fi
+
+cd org
+RUNNING=$(svnversion ./ | tr -d '[A-Z]')
+if [ $RUNNING -ne $UPSTREAM ]; then
+    svn -q up
+    UPDATED=1
+fi
+
+if [ $UPDATED = 1 ]; then
+    /data/bedrock-stage/deploy www.allizom.org > /dev/null 2>&1
+else
+    # removed per bug 1087514
+    # echo "Nothing to deploy."
+    exit 0
+fi

--- a/bin/update/deploy-product-details.py
+++ b/bin/update/deploy-product-details.py
@@ -1,0 +1,34 @@
+"""
+Deployment for Bedrock in production.
+
+Requires commander (https://github.com/oremj/commander) which is installed on
+the systems that need it.
+"""
+
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.abspath(__file__)))
+
+from commander.deploy import task, hostgroups
+
+import commander_settings as settings
+
+
+# Functions below called by chief in this order
+
+
+@task
+def pre_update(ctx, ref=settings.UPDATE_REF):
+    print "done"
+
+
+@task
+def update(ctx):
+    with ctx.lcd(settings.SRC_DIR):
+        ctx.local('bin/update-scripts/prod/update-prod-product-details.sh')
+
+
+@hostgroups(settings.WEB_HOSTGROUP, remote_kwargs={'ssh_key': settings.SSH_KEY})
+def deploy(ctx):
+    ctx.remote("service httpd graceful")

--- a/etc/cron.d/bedrock-dev.tmpl
+++ b/etc/cron.d/bedrock-dev.tmpl
@@ -8,7 +8,7 @@ MAILTO="webops-cron@mozilla.com,cron-bedrock@mozilla.com"
 */20 * * * * {{ user }} {{ source }}/bin/update-scripts/dev/update-dev-django.sh
 */15 * * * * {{ user }} {{ source }}/bin/update-scripts/dev/update-dev-locale.sh
 
-*/5    * * * * {{ django_manage }} rnasync > /dev/null 2>&1
+*/5  * * * * {{ django_manage }} rnasync > /dev/null 2>&1
 
 # bug 1014586
 3 */2 * * * {{ django_cron }} update_tweets > /dev/null 2>&1

--- a/etc/cron.d/bedrock-prod.tmpl
+++ b/etc/cron.d/bedrock-prod.tmpl
@@ -4,14 +4,10 @@
 
 MAILTO="webops-cron@mozilla.com,cron-bedrock@mozilla.com"
 
-*/10 * * * * root /data/bedrock/src/update-www.mozilla.org.sh
+*/10 * * * * {{ user }} {{ source }}/bin/update-scripts/prod/update-prod-php.sh
+*/15 * * * * {{ user }} {{ source }}/bin/update-scripts/prod/update-prod-locale-cron.sh
 
 */5  * * * * {{ django_manage }} rnasync > /dev/null 2>&1
-*/15 * * * * {{ user }} /data/bedrock/src/update-www.mozilla.org-cron-svn-locale.sh &> /dev/null
-# outputs when the run completed to http://www.mozilla.org/media/locale_finished.txt
-
-# disabled per bug 1042074
-#1-59/15 * * * * {{ user }} /data/bedrock/src/update-www.mozilla.org-product-details.sh
 
 # bug 996144 & 1014586
 2 */6 * * * {{ django_cron }} update_tweets > /dev/null 2>&1

--- a/etc/cron.d/bedrock-stage.tmpl
+++ b/etc/cron.d/bedrock-stage.tmpl
@@ -4,16 +4,9 @@
 
 MAILTO="webops-cron@mozilla.com,cron-bedrock@mozilla.com"
 
-*/10 * * * * {{ user }} /data/bedrock-stage/src/update-www.allizom.org.sh
+*/10 * * * * {{ user }} {{ source }}/bin/update-scripts/stage/update-stage-php.sh
+*/15 * * * * {{ user }} {{ source }}/bin/update-scripts/stage/update-stage-locale.sh
 
-*/15 * * * * {{ user }} /data/bedrock-stage/src/update-www.allizom.org-svn-locale.sh
-# outputs when the run completed to http://www.allizom.org/media/locale_finished.txt
-
-# In testing for bug 753566 resolution...
-# not completely sure how I want to solve this yet
-#
-# run the crons from the admin node, but on the web nodes... does extra work, but works
-#0 * * * * *  {{ user }} echo "cd /data/www/www.allizom.org-django/bedrock; python manage.py cron update_feeds | /usr/bin/issue-multi-command bedrock-stage
 */5    * * * * {{ django_manage }} rnasync > /dev/null 2>&1
 
 # bug 996144


### PR DESCRIPTION
Moves the scripts run by cron to this repo. Also included is the script to update product-details, but I believe we have to alter chief to have it be the one that is run, or at least symlink to this one from the original path.