### PR TITLE
Fix bug 1136307: Catch all errors and report exceptions for MFSA import.

### DIFF
--- a/bedrock/security/management/commands/update_security_advisories.py
+++ b/bedrock/security/management/commands/update_security_advisories.py
@@ -244,17 +244,23 @@ class Command(NoArgsCommand):
             printout('Updating repository and finding modified files.')
             modified_files, deleted_files = update_repo()
 
+        errors = []
+        updates = 0
         if modified_files:
             for mf in modified_files:
                 try:
                     update_db_from_file(mf)
-                except (KeyError, ValueError) as e:
-                    print 'ERROR parsing %s: %s' % (mf, e)
+                except Exception as e:
+                    errors.append('ERROR parsing %s: %s' % (mf, e))
+                    if not quiet:
+                        sys.stdout.write('E')
+                        sys.stdout.flush()
                     continue
                 if not quiet:
                     sys.stdout.write('.')
                     sys.stdout.flush()
-            printout('\nUpdated {0} files.'.format(len(modified_files)))
+                updates += 1
+            printout('\nUpdated {0} files.'.format(updates))
 
         if deleted_files:
             delete_files(deleted_files)
@@ -262,3 +268,7 @@ class Command(NoArgsCommand):
 
         if not modified_files and not deleted_files:
             printout('Nothing to update.')
+
+        if errors:
+            sys.stderr.write('Encountered {0} errors:\n\n'.format(len(errors)) +
+                             '\n==========\n'.join(errors))

--- a/etc/cron.d/bedrock-prod.tmpl
+++ b/etc/cron.d/bedrock-prod.tmpl
@@ -18,7 +18,7 @@ MAILTO="webops-cron@mozilla.com,cron-bedrock@mozilla.com"
 
 # bug 1072999, 1109344
 # Have to do this in the SRC dir because rsync destroys git repos in WWW dir.
-*/30 * * * * {{ django_src_manage }} update_security_advisories --quiet > /dev/null 2>&1
+*/30 * * * * {{ django_src_manage }} update_security_advisories --quiet > /dev/null
 
 # bug 1087533
 42 * * * * {{ django_cron }} update_reps_ical > /dev/null 2>&1


### PR DESCRIPTION
Reports errors on stderr so we can get cron mail when it happens. The --quiet should mean there's no other output, but we're still sending stdout to /dev/null in the cron.