### PR TITLE
Bug 1132231 - fix copy for Webmaker and Hello promos

### DIFF
--- a/bedrock/mozorg/templates/mozorg/home/home-new.html
+++ b/bedrock/mozorg/templates/mozorg/home/home-new.html
@@ -99,7 +99,7 @@
           <h2 class="primary go">{{ _('Meet<br> Firefox Hello') }}</h2>
           <a class="panel-link" href="{{ url('firefox.hello') }}">
             <div class="secondary">
-              <h3>{{ _('The easiest way to connect for free over video') }}</h3>
+              <h3>{{ _('The easiest way to connect for free over video.') }}</h3>
               <p class="more">{{ _('Try Firefox Hello') }}</p>
             </div>
           </a>
@@ -155,7 +155,7 @@
           <h2 class="primary go">{{ _('Make the Web you want') }}</h2>
           <a class="panel-link" rel="external" href="https://webmaker.org/">
             <div class="secondary">
-              <h3>{{ _('Build a webpage or app in minutes<br> — no coding required') }}</h3>
+              <h3>{{ _('Build a Web page or app in minutes<br> — no coding required.') }}</h3>
               <p class="more">{{ _('Become a Webmaker') }}</p>
             </div>
           </a>


### PR DESCRIPTION
Per Matej on IRC, I messed up the copy on the Webmaker and Hello promos (small errors, but annoying, and totally my fault).

@flodolo: I am really REALLY sorry about this. If necessary I can wrap these altered strings in yet another tag, if any locales have already updated based on the strings from yesterday. Please tell me what I can do to earn your forgiveness.