### PR TITLE
Fix Bug 1131304 - Add share buttons to 'Download Firefox in your language' page

### DIFF
--- a/bedrock/base/templates/base-resp.html
+++ b/bedrock/base/templates/base-resp.html
@@ -1,4 +1,4 @@
-{% from "macros.html" import mozorg_newsletter_form with context %}
+{% from "macros.html" import mozorg_newsletter_form, share_cta with context %}
 {% set_lang_files "main" %}
 <!doctype html>
 {# Note the "windows" class, without javascript platform-specific
@@ -116,6 +116,7 @@
 
         {% block breadcrumbs %}{% endblock %}
 
+        {% block site_header_share %}{% endblock %}
       </header>
     {% endblock %}
 

--- a/bedrock/base/templates/base.html
+++ b/bedrock/base/templates/base.html
@@ -1,3 +1,4 @@
+{% from "macros.html" import share_cta with context %}
 {%- set_lang_files "main" -%}
 <!doctype html>
 {# Note the "windows" class, without javascript platform-specific
@@ -109,6 +110,7 @@
 
         {% block breadcrumbs %}{% endblock %}
 
+        {% block site_header_share %}{% endblock %}
       </header>
     {% endblock %}
 

--- a/bedrock/firefox/templates/firefox/all.html
+++ b/bedrock/firefox/templates/firefox/all.html
@@ -13,7 +13,7 @@
   {% elif channel == 'esr' %}
     {{ _('Firefox ESR is intended for groups who deploy and maintain the desktop environment in large organizations. <a href="%s">Learn more.</a>')|format(url('firefox.organizations.organizations')) }}
   {% else %}
-    {{ _('Firefox is available in more than %s languages thanks to the contributions of Mozilla community members from around the world.')|format('80') }}
+    {{ _('Firefox is available in more than 80 languages thanks to the contributions of Mozilla community members from around the world.') }}
   {% endif %}
 {% endblock %}
 
@@ -31,6 +31,14 @@
   {% else %}
     {{ super() }}
   {% endif %}
+{% endblock %}
+
+{% block site_header_share %}
+  {% if channel == 'release' -%}
+    {% set share_urls = { 'twitter': 'http://mzl.la/1IMdR5T', 'googleplus': 'http://mzl.la/1y7TgOf', 'facebook': 'http://mzl.la/1ATF965' } -%}
+    {% set share_text = _('Thanks to contributions of Mozilla community members around the world, Firefox is available in 80 languages:') %}
+    {{ share_cta(_('Share'), share_urls, share_text, 'spread-firefox-all', 'sky mini') }}
+  {% endif -%}
 {% endblock %}
 
 {% block content %}

--- a/bedrock/firefox/templates/firefox/developer.html
+++ b/bedrock/firefox/templates/firefox/developer.html
@@ -24,6 +24,17 @@
   {% javascript 'firefox_developer' %}
 {% endblock %}
 
+{% block site_header_share %}
+  {% set share_urls = { 'twitter': 'http://mzl.la/1KJ1Yct', 'googleplus': 'http://mzl.la/1FuzQJk', 'facebook': 'http://mzl.la/1zTb4Aw' } -%}
+  {% if l10n_has_tag('share_cta') -%}
+    {% set share_text = _('Design, build and debug the Web without ever leaving your browser with the new Firefox Developer Edition!') %}
+  {%- else -%}
+    {# If the new copy is not localized yet, just use the same text as the existing preamble #}
+    {% set share_text = _('Introducing the only browser made for developers like you.') %}
+  {% endif -%}
+  {{ share_cta(_('Share'), share_urls, share_text, 'spread-firefox-developer', 'sky mini') }}
+{% endblock %}
+
 {% block content %}
 
 <section class="intro container">

--- a/bedrock/firefox/templates/firefox/hello/index.html
+++ b/bedrock/firefox/templates/firefox/hello/index.html
@@ -6,8 +6,6 @@
 
 {% set_lang_files "firefox/hello" %}
 
-{% from "macros.html" import share_cta with context %}
-
 {% block page_title_prefix %}{% endblock %}
 {% block page_title %}{{ _('Firefox Hello — Free, easy video conversations') }}{% endblock %}
 {% block page_desc %}{{ _('Learn all about Firefox Hello and see for yourself how easy it is to have a free video conversation with anyone, anywhere, right from your browser') }}{% endblock %}
@@ -25,33 +23,13 @@
   {% javascript 'firefox_hello' %}
 {% endblock %}
 
-{% block site_header %}
-  <header id="masthead">
-    <div class="container">
-      <div id="hello-header-nav">
-        <a href="{{ url('mozorg.home') }}" id="tabzilla" data-infobar="{{ settings.TABZILLA_INFOBAR_OPTIONS }}">Mozilla</a>
-
-        {% block site_header_nav %}
-          {% include 'firefox/includes/top-menu.html' %}
-        {% endblock %}
-      </div>
-
-      {% block site_header_logo %}
-        <div id="hello-logo-wrapper">
-          {{ super() }}
-
-          {%
-          set share_urls = {
-            'twitter': 'http://mzl.la/1wz83AN',
-            'googleplus': 'https://www.mozilla.org/firefox/hello/?utm_source=Google&utm_medium=social&utm_campaign=Hello&utm_content=WebsiteShare',
-            'facebook': 'https://www.mozilla.org/firefox/hello/?utm_source=Facebook&utm_medium=social&utm_campaign=Hello&utm_content=WebsiteShare'
-          }
-          %}
-          {{ share_cta(_('Share'), share_urls, _('Meet Firefox Hello, the easiest way to connect for free over video with anyone, anywhere.'), 'spread-hello', 'sky mini') }}
-        </div>
-      {% endblock %}
-    </div>
-  </header>
+{% block site_header_share %}
+  {% set share_urls = {
+    'twitter': 'http://mzl.la/1wz83AN',
+    'googleplus': 'https://www.mozilla.org/firefox/hello/?utm_source=Google&utm_medium=social&utm_campaign=Hello&utm_content=WebsiteShare',
+    'facebook': 'https://www.mozilla.org/firefox/hello/?utm_source=Facebook&utm_medium=social&utm_campaign=Hello&utm_content=WebsiteShare'
+  } %}
+  {{ share_cta(_('Share'), share_urls, _('Meet Firefox Hello, the easiest way to connect for free over video with anyone, anywhere.'), 'spread-hello', 'sky mini') }}
 {% endblock %}
 
 {% block content %}

--- a/bedrock/mozorg/templates/mozorg/plugincheck.html
+++ b/bedrock/mozorg/templates/mozorg/plugincheck.html
@@ -4,8 +4,6 @@
 
 {% extends "base-resp.html" %}
 
-{% from "macros.html" import share_cta with context %}
-
 {% block body_id %}plugincheck{% endblock %}
 
 {% block page_title %}{{_('Plugin Check &amp; Updates')}}{% endblock %}
@@ -50,20 +48,23 @@
   data-media-url="{{ static('') }}"
 {% endblock %}
 
+{% block site_header_share %}
+  {% set share_urls = { 'twitter': 'http://mzl.la/17aqnLZ', 'googleplus': 'http://mzl.la/1FuAhTS', 'facebook': 'http://mzl.la/1z4Noqm' } -%}
+  {% if l10n_has_tag('share_cta') -%}
+    {% set share_text = _('Plugins don’t always update automatically. Check yours now to stay safe and browse without interruption!') %}
+  {%- else -%}
+    {# If the new copy is not localized yet, just use the same text as the existing preamble #}
+    {% set share_text = _('Keeping your plugins up to date helps Firefox run safely and smoothly.') %}
+  {% endif -%}
+  {{ share_cta(_('Share'), share_urls, share_text, 'spread-plugincheck', 'sky mini') }}
+{% endblock %}
+
 {% block content %}
 <main role="main">
   <header id="main-feature">
       {{ download_firefox(small=True) }}
       <h1 class="large">{{_('Check Your Plugins')}}</h1>
       <p class="preamble">{{_('Keeping your plugins up to date helps Firefox run safely and smoothly.')}}</p>
-      {% set share_urls = { 'twitter': 'http://mzl.la/17aqnLZ', 'googleplus': 'http://mzl.la/1FuAhTS', 'facebook': 'http://mzl.la/1z4Noqm' } -%}
-      {% if l10n_has_tag('share_cta') -%}
-        {% set share_text = _('Plugins don’t always update automatically. Check yours now to stay safe and browse without interruption!') %}
-      {%- else -%}
-        {# If the new copy is not localized yet, just use the same text as the existing preamble #}
-        {% set share_text = _('Keeping your plugins up to date helps Firefox run safely and smoothly.') %}
-      {% endif -%}
-      {{ share_cta(_('Share'), share_urls, share_text, 'spread-plugincheck', 'sky mini') }}
   </header>
 
   <section class="plugin-status-container billboard">

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -487,6 +487,7 @@ PIPELINE_CSS = {
             'css/sandstone/sandstone-resp.less',
             'css/firefox/template-resp.less',
             'css/base/mozilla-modal.less',
+            'css/base/mozilla-share-cta.less',
             'css/firefox/menu-resp.less',
             'css/firefox/developer.less',
         ),
@@ -1235,6 +1236,7 @@ PIPELINE_JS = {
         'source_filenames': (
             'js/firefox/developer.js',
             'js/base/mozilla-modal.js',
+            'js/base/mozilla-share-cta.js',
         ),
         'output_filename': 'js/firefox_developer-bundle.js',
     },

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -302,6 +302,7 @@ PIPELINE_CSS = {
     },
     'firefox_all': {
         'source_filenames': (
+            'css/base/mozilla-share-cta.less',
             'css/sandstone/sandstone-resp.less',
             'css/firefox/menu-resp.less',
             'css/firefox/all.less',
@@ -1137,6 +1138,7 @@ PIPELINE_JS = {
     },
     'firefox_all': {
         'source_filenames': (
+            'js/base/mozilla-share-cta.js',
             'js/base/mozilla-pager.js',
             'js/firefox/firefox-language-search.js',
         ),

--- a/media/css/base/mozilla-share-cta.less
+++ b/media/css/base/mozilla-share-cta.less
@@ -177,3 +177,34 @@
         }
     }
 }
+
+/* For the standard #masthead header, e.g. /firefox/all/ */
+#masthead .mozilla-share-cta {
+    position: absolute;
+    top: 60px;
+    right: 24px;
+}
+
+html[dir="rtl"] #masthead .mozilla-share-cta {
+    right: auto;
+    left: 24px;
+}
+
+/* Wide Mobile Layout: 480px */
+@media only screen and (max-width: @breakTablet) {
+    #masthead .mozilla-share-cta {
+        right: 14px;
+    }
+
+    html[dir="rtl"] #masthead .mozilla-share-cta {
+        right: auto;
+        left: 14px;
+    }
+}
+
+/* Mobile Layout: 320px */
+@media only screen and (max-width: @breakMobileLandscape) {
+    #masthead .mozilla-share-cta {
+        display: none;
+    }
+}

--- a/media/css/firefox/hello/index.less
+++ b/media/css/firefox/hello/index.less
@@ -7,11 +7,15 @@
 .grainy-sky() {
     background: #cae1f4;
     background: url(/media/img/sandstone/grain.png) repeat,
-                    -webkit-linear-gradient(top, #cae1f4, #d9e1e7)
+                    -webkit-linear-gradient(top, #cae1f4, #d9e1e7),
                     #cae1f4;
     background: url(/media/img/sandstone/grain.png) repeat,
                     linear-gradient(to bottom, #cae1f4, #d9e1e7),
                     #cae1f4;
+}
+
+.grainy-sky-solid() {
+    background: url(/media/img/sandstone/grain.png) repeat #cae1f4;
 }
 
 // Base template overrides
@@ -22,31 +26,13 @@
 
 #wrapper {
     width: 100%;
+    padding-bottom: 0;
+    .grainy-sky-solid();
 }
 
 #masthead {
-    position: absolute;
-    top: 0;
-    left: 50%;
-    margin-left: -470px;
-    z-index: 10;
-    padding-left: 0;
-    padding-right: 0;
-
-    .container {
-        overflow: visible;
-        padding: 0;
-    }
-
-    h2 {
-        float: left;
-        padding-top: 0;
-        width: 185px;
-    }
-}
-
-html[dir="rtl"] #masthead h2 {
-    float: right;
+    margin: 0 auto;
+    width: @widthDesktop - (@gridGutterWidth * 2);
 }
 
 // Common styles
@@ -112,25 +98,11 @@ main {
     .clearfix();
 }
 
-#spread-hello {
-    float: right;
-    margin-top: 15px;
-}
-
-html[dir="rtl"] #spread-hello {
-    float: left;
-}
-
 // Intro
 
 #intro {
     .grainy-sky();
     padding-bottom: @baseLine * 2;
-
-    .container {
-        padding-top: 116px; // compensate for pushing up under tabzilla
-        overflow: visible; // allow share widget to bleed over
-    }
 
     .heading-primary,
     .heading-tertiary {
@@ -1342,8 +1314,7 @@ html[lang^="en"] #powered-by {
 // @Tablet Layout: 760px
 @media (max-width: @breakDesktop) and (min-width: (@breakTablet + 1)) {
     #masthead {
-        padding: 0;
-        margin-left: -360px;
+        width: @widthTablet - (@gridGutterWidth * 2);
     }
 
     .container {
@@ -1427,11 +1398,8 @@ html[lang^="en"] #powered-by {
 // @Wide mobile Layout: 480px
 @media (max-width: @breakTablet) {
     #masthead {
-        margin-left: -220px;
-
-        h2 {
-            padding-top: 10px;
-        }
+        padding-bottom: 0;
+        width: @widthMobile - @gridGutterWidth;
     }
 
     .container {
@@ -1452,20 +1420,10 @@ html[lang^="en"] #powered-by {
         .font-size(20px);
     }
 
-    // Share
-
-    #spread-hello {
-        margin-top: 25px;
-    }
-
     // Intro
 
     #intro {
         padding-bottom: @baseLine;
-
-        .container {
-            padding-top: 136px;
-        }
 
         .heading-primary,
         .heading-tertiary {
@@ -1834,6 +1792,14 @@ html[lang^="en"] #powered-by {
 }
 
 /****************************************************************************/
+// @Mobile Layout: 480px
+@media only screen and (min-width: @breakMobileLandscape) and (max-width: @breakTablet) {
+    #masthead {
+        width: @widthMobileLandscape;
+    }
+}
+
+/****************************************************************************/
 // @High resolution images for @retina-type displays
 // Mobile
 @media (max-width: @breakTablet) and (-webkit-min-device-pixel-ratio: 1.5),
@@ -1849,10 +1815,6 @@ html[lang^="en"] #powered-by {
 /****************************************************************************/
 // @Mobile Layout: 320px
 @media (max-width: @breakMobileLandscape) {
-    #masthead {
-        margin-left: -150px;
-    }
-
     .container {
         width: (320px - @baseLine);
         padding-left: @baseLine / 2;
@@ -1873,12 +1835,6 @@ html[lang^="en"] #powered-by {
 
     .heading-tertiary {
         .font-size(20px);
-    }
-
-    // Share
-
-    .js #spread-hello {
-        display: none;
     }
 
     // Intro

--- a/media/css/plugincheck/plugincheck.less
+++ b/media/css/plugincheck/plugincheck.less
@@ -27,21 +27,10 @@
     }
 }
 
-.mozilla-share-cta {
-    position: absolute;
-    top: -43px;
-    right: 24px;
-}
-
 html[dir="rtl"] {
     #main-feature > .download-button {
         right: auto;
         left: 0;
-    }
-
-    .mozilla-share-cta {
-        right: auto;
-        left: 24px;
     }
 }
 
@@ -310,22 +299,5 @@ html[dir="rtl"] {
     #main-feature > .download-button {
         position: relative;
         margin-top: 20px;
-    }
-
-    .mozilla-share-cta {
-        top: -63px;
-        right: 0;
-    }
-
-    html[dir="rtl"] .mozilla-share-cta {
-        right: auto;
-        left: 0;
-    }
-}
-
-/* Mobile Layout: 320px */
-@media only screen and (max-width: @breakMobileLandscape) {
-    .mozilla-share-cta {
-        display: none;
     }
 }


### PR DESCRIPTION
Here’s another optimization. Introducing the new `site_header_share` block to put the button in `#masthead`. The change will affect the existing [/firefox/hello/](https://www.mozilla.org/en-US/firefox/hello/) and [/plugincheck/](https://www.mozilla.org/en-US/plugincheck/) pages.

This [/firefox/all/](https://www.mozilla.org/en-US/firefox/all/) page has been localized into Japanese only and we have almost the same fallback text, so this is good to go.

I have added one more button for [/firefox/developer/](https://www.mozilla.org/en-US/firefox/developer/) because the change is small and similar. This time again, the existing copy will be used as the l10n fallback.

@alexgibson r?