### PR TITLE
Bug 1120689 Update title on MWC preview for 2015

### DIFF
--- a/bedrock/firefox/templates/firefox/os/mwc-2015-preview.html
+++ b/bedrock/firefox/templates/firefox/os/mwc-2015-preview.html
@@ -5,7 +5,7 @@
 {% extends "firefox/base-resp.html" %}
 
 {% block page_title_prefix %}{% endblock %}
-{% block page_title %}{{_('Blaze Your Own Path - Mozilla at MWC 2015')}}{% endblock %}
+{% block page_title %}{{_('Unleash the future - Firefox OS - MWC 2015')}}{% endblock %}
 
 {% block body_id %}firefox-os{% endblock %}
 {% block body_class %}firefox-os{% endblock %}


### PR DESCRIPTION
Nothing on the bug for this - it's a direct request from Matej on IRC:

> *matej:* I should have caught this sooner, but can we update the title?
> *matej:* should be "Unleash the Future — Firefox OS — MWC 2015 — Mozilla"