### PR TITLE
Get current hash from local file and run dev autodeploy every 20min.

### DIFF
--- a/bin/update-scripts/dev/update-dev-django.sh
+++ b/bin/update-scripts/dev/update-dev-django.sh
@@ -19,12 +19,10 @@ SHAAVAILABLE=$(git ls-remote git://github.com/mozilla/bedrock.git master | awk '
 # Nix the 4 bytes before the sha because it's http smart protocol
 #SHAAVAILABLE="${SHAAVAILABLE:4}"
 
-echo "We have ${SHADEPLOYED:0:8} and ${SHAAVAILABLE:0:8} is available."
 
 if [ "$SHADEPLOYED" = "$SHAAVAILABLE" ];
 then
     # Nothing to deploy
-    echo "Nothing to deploy."
     exit 0
 fi
 
@@ -37,6 +35,7 @@ if [ $? != 0 ]; then
     exit 1
 fi
 
+echo "We have ${SHADEPLOYED:0:8} and ${SHAAVAILABLE:0:8} is available."
 echo "Calling Chief for '$WEBAPP' to deploy '${SHAAVAILABLE:0:8}'"
 
 # This just creates a POST event to the Chief app. We populate the form fields with the information gathered above ($SHAAVAILABLE, $PASSWORD, $WEBAPP)

--- a/bin/update-scripts/dev/update-dev-django.sh
+++ b/bin/update-scripts/dev/update-dev-django.sh
@@ -3,6 +3,7 @@
 # This must match the name of the webapp in the Chief configs (/var/www/chief/settings.py)
 # This should be the only change you need to make.
 WEBAPP="bedrock.dev"
+WEBAPP_DIR=/data/bedrock-dev/src/www-dev.allizom.org-django
 
 function checkretval(){
     retval=$?
@@ -13,7 +14,7 @@ function checkretval(){
 }
 
 # Get the sha currently deployed
-SHADEPLOYED=$(curl -s -XGET https://www-dev.allizom.org/media/revision.txt)
+SHADEPLOYED=$(cat ${WEBAPP_DIR}/bedrock/media/revision.txt)
 SHAAVAILABLE=$(git ls-remote git://github.com/mozilla/bedrock.git master | awk '{print $1;}')
 # Nix the 4 bytes before the sha because it's http smart protocol
 #SHAAVAILABLE="${SHAAVAILABLE:4}"
@@ -28,7 +29,7 @@ then
 fi
 
 # Here we will load the WEBAPPS object from the Chief configs and grab the update password for our $WEBAPP
-PASSWORD=$(/data/bedrock-dev/src/www-dev.allizom.org-django/password.py)
+PASSWORD=$(${WEBAPP_DIR}/password.py)
 
 # If there was an error in the python we will raise it here ($PASSWORD contains the error in this case)
 if [ $? != 0 ]; then

--- a/etc/cron.d/bedrock-dev.tmpl
+++ b/etc/cron.d/bedrock-dev.tmpl
@@ -5,7 +5,7 @@
 MAILTO="webops-cron@mozilla.com,cron-bedrock@mozilla.com"
 
 */10 * * * * {{ user }} {{ source }}/bin/update-scripts/dev/update-dev-php.sh
-*/10 * * * * {{ user }} {{ source }}/bin/update-scripts/dev/update-dev-django.sh
+*/20 * * * * {{ user }} {{ source }}/bin/update-scripts/dev/update-dev-django.sh
 */15 * * * * {{ user }} {{ source }}/bin/update-scripts/dev/update-dev-locale.sh
 
 */5    * * * * {{ django_manage }} rnasync > /dev/null 2>&1


### PR DESCRIPTION
I looked at the logs and dev was being deployed more often
than it should have based on changes in master. This is due
to the request to www-dev.m.o/media/revision.txt sometimes
returning a 500 page. This is seen by the script as different
from the hash on github, and thus it deploys. The problem is that
this error is most likely just the previous deploy finishing up since
deploys now take longer than before. This change both reduces the
frequency of autodeploys to every 20 min and checks the local
revision.txt for what is currently deployed. We might consider
moving to a python-based autodeploy script in future for more
flexibility in checking things on the dev server and github.