### PR TITLE
Fix bug 1134492 - update templates to new urls on assets.mozilla.org

### DIFF
--- a/bedrock/styleguide/templates/styleguide/communications/presentations.html
+++ b/bedrock/styleguide/templates/styleguide/communications/presentations.html
@@ -22,7 +22,7 @@
   <div class="preview">
     <img src="{{ static('img/styleguide/communications/presentation-standard.png') }}" alt="Standard Sandstone preview" />
     <ul class="button-list">
-      <li><a href="https://assets.mozillalabs.com/Communications/Presentations/Sandstone/" class="button-sand">Keynote / PowerPoint</a></li>
+      <li><a href="https://assets.mozilla.org/portal/assets/#category/83" class="button-sand">Keynote / PowerPoint</a></li>
       <li><a href="https://github.com/codepo8/mozilla-presentation-templates" class="button-sand">HTML</a></li>
     </ul>
   </div>
@@ -33,7 +33,7 @@
   <div class="preview">
     <img src="{{ static('img/styleguide/communications/presentation-firefoxos.png') }}" alt="Firefox OS preview" />
     <ul class="button-list">
-      <li><a href="https://assets.mozillalabs.com/Communications/Presentations/Firefox OS/" class="button-sand">Keynote / PowerPoint</a></li>
+      <li><a href="https://assets.mozilla.org/portal/assets/#category/81" class="button-sand">Keynote / PowerPoint</a></li>
     </ul>
   </div>
 </section>
@@ -43,7 +43,7 @@
   <div class="preview">
     <img src="{{ static('img/styleguide/communications/presentation-firefoxos-developers.png') }}" alt="Firefox OS (for developers) preview" />
     <ul class="button-list">
-      <li><a href="https://assets.mozillalabs.com/Communications/Presentations/Firefox OS Devs/" class="button-sand">Keynote / PowerPoint</a></li>
+      <li><a href="https://assets.mozilla.org/portal/assets/#category/80" class="button-sand">Keynote / PowerPoint</a></li>
     </ul>
   </div>
 </section>

--- a/bedrock/styleguide/templates/styleguide/communications/typefaces.html
+++ b/bedrock/styleguide/templates/styleguide/communications/typefaces.html
@@ -18,7 +18,7 @@
     <h2>Open Sans</h2>
     <p>An open font with 897 characters (and therefore enormous localization potential), Open Sans is our default typeface for websites, print and other materials.</p>
     <div class="download">
-      <a href="https://assets.mozillalabs.com/Communications/Presentations/Open%20Sans.zip" class="button-sand">Download Open Sans</a>
+      <a href="https://assets.mozilla.org/portal/assets/#asset/99" class="button-sand">Download Open Sans</a>
     </div>
   </div>
   <section id="book300">

--- a/bedrock/styleguide/templates/styleguide/communications/video.html
+++ b/bedrock/styleguide/templates/styleguide/communications/video.html
@@ -17,7 +17,7 @@
   <div class="intro">
     <h2>Intro</h2>
     <p>Our standard video intro is based on the Sandstone style to keep a clean, minimalist look. All logos should follow the examples shows here and be centered in the space.</p>
-    <p>You can find these assets in our <a href="https://assets.mozillalabs.com/Communications/Video%20Assets/">assets repository</a>.</p>
+    <p>You can find these assets in our <a href="https://assets.mozilla.org/portal/assets/#category/38">assets repository</a>.</p>
   </div>
   <div class="examples">
     <img src="{{ static('img/styleguide/communications/video-intro-blue.jpg') }}" alt="Video intro" />
@@ -33,7 +33,7 @@
   <div class="intro">
     <h2>Captioning</h2>
     <p>The default font for captions and supers is Open Sans Light (Book 300).</p>
-    <p>You can find these assets in our <a href="https://assets.mozillalabs.com/Communications/Video%20Assets/">assets repository</a>.</p>
+    <p>You can find these assets in our <a href="https://assets.mozilla.org/portal/assets/#category/38">assets repository</a>.</p>
   </div>
   <div class="examples">
     <div id="example-dark">
@@ -48,7 +48,7 @@
   <div class="intro">
     <h2>Outro</h2>
     <p>Similar to the intro, the outro features a centered logo, but adds a URL, again set in Open Sans Light (Book 300).</p>
-    <p>You can find these assets in our <a href="https://assets.mozillalabs.com/Communications/Video%20Assets/">assets repository</a>.</p>
+    <p>You can find these assets in our <a href="https://assets.mozilla.org/portal/assets/#category/38">assets repository</a>.</p>
   </div>
   <div class="examples">
     <img src="{{ static('img/styleguide/communications/video-outro.jpg') }}" alt="Video outro" />

--- a/bedrock/styleguide/templates/styleguide/identity/firefox-branding.html
+++ b/bedrock/styleguide/templates/styleguide/identity/firefox-branding.html
@@ -26,9 +26,9 @@
     <img src="{{ static('img/styleguide/identity/firefox/guidelines-logo.png') }}" alt="Logo" id="guidelines-logo-image" />
     <h3>Download</h3>
     <ul class="button-list">
-      <li><a href="https://assets.mozillalabs.com/Brands-Logos/Firefox/logo-only/firefox_logo-only_CMYK.eps" class="button-sand">EPS</a></li>
-      <li><a href="https://assets.mozillalabs.com/Brands-Logos/Firefox/logo-only/firefox_logo-only_RGB-300dpi.jpg" class="button-sand">JPG (300dpi)</a></li>
-      <li><a href="https://assets.mozillalabs.com/Brands-Logos/Firefox/logo-only/firefox_logo-only_RGB.png" class="button-sand">PNG</a></li>
+      <li><a href="https://assets.mozilla.org/portal/assets/#/asset/204" class="button-sand">EPS</a></li>
+      <li><a href="https://assets.mozilla.org/portal/assets/#/asset/205" class="button-sand">JPG (300dpi)</a></li>
+      <li><a href="https://assets.mozilla.org/portal/assets/#/asset/206" class="button-sand">PNG</a></li>
     </ul>
   </div>
   <p class="copyright-note"><small>The logo files containing our trademarks are available under the following copyright licenses: vector logo files under <a href="https://creativecommons.org/licenses/by-sa/3.0/">CC-BY 3.0</a> or later; bitmap logo files under <a href="http://www.mozilla.org/MPL/2.0/">MPL 2</a>.</small></p>

--- a/bedrock/styleguide/templates/styleguide/identity/firefox-channels.html
+++ b/bedrock/styleguide/templates/styleguide/identity/firefox-channels.html
@@ -22,9 +22,9 @@
   <div class="download">
     <h4>Download</h4>
     <ul class="button-list">
-      <li><a href="https://assets.mozillalabs.com/Brands-Logos/Firefox/logo-only/firefox_logo-only_CMYK.eps" class="button-sand">EPS</a></li>
-      <li><a href="https://assets.mozillalabs.com/Brands-Logos/Firefox/logo-only/firefox_logo-only_RGB-300dpi.jpg" class="button-sand">JPG (300dpi)</a></li>
-      <li><a href="https://assets.mozillalabs.com/Brands-Logos/Firefox/logo-only/firefox_logo-only_RGB.png" class="button-sand">PNG</a></li>
+      <li><a href="https://assets.mozilla.org/portal/assets/#/asset/204" class="button-sand">EPS</a></li>
+      <li><a href="https://assets.mozilla.org/portal/assets/#/asset/205" class="button-sand">JPG (300dpi)</a></li>
+      <li><a href="https://assets.mozilla.org/portal/assets/#asset/206" class="button-sand">PNG</a></li>
     </ul>
   </div>
 </section>
@@ -34,9 +34,9 @@
   <div class="download">
     <h4>Download <span>(with beta sash)</span></h4>
     <ul class="button-list">
-      <li><a href="https://assets.mozillalabs.com/Brands-Logos/Firefox/logo-only/firefox-beta_logo-only_CMYK.eps" class="button-sand">EPS</a></li>
-      <li><a href="https://assets.mozillalabs.com/Brands-Logos/Firefox/logo-only/firefox-beta_logo-only_RGB-300dpi.jpg" class="button-sand">JPG (300dpi)</a></li>
-      <li><a href="https://assets.mozillalabs.com/Brands-Logos/Firefox/logo-only/firefox-beta_logo-only_RGB.png" class="button-sand">PNG</a></li>
+      <li><a href="https://assets.mozilla.org/portal/assets/#asset/197" class="button-sand">EPS</a></li>
+      <li><a href="https://assets.mozilla.org/portal/assets/#asset/198" class="button-sand">JPG (300dpi)</a></li>
+      <li><a href="https://assets.mozilla.org/portal/assets/#asset/199" class="button-sand">PNG</a></li>
     </ul>
       <p>* In contexts where two Firefox logos can be displayed next to each other (ex. mobile desktops), the version with the Beta sash should be used for added clarity.</p>
   </div>
@@ -47,9 +47,9 @@
   <div class="download">
     <h4>Download</h4>
     <ul class="button-list">
-      <li><a href="https://assets.mozillalabs.com/Brands-Logos/Firefox/logo-only/firefox-nightly_logo-only_CMYK.eps" class="button-sand">EPS</a></li>
-      <li><a href="https://assets.mozillalabs.com/Brands-Logos/Firefox/logo-only/firefox-nightly_logo-only_RGB-300dpi.jpg" class="button-sand">JPG (300dpi)</a></li>
-      <li><a href="https://assets.mozillalabs.com/Brands-Logos/Firefox/logo-only/firefox-nightly_logo-only_RGB.png" class="button-sand">PNG</a></li>
+      <li><a href="https://assets.mozilla.org/portal/assets/#asset/200" class="button-sand">EPS</a></li>
+      <li><a href="https://assets.mozilla.org/portal/assets/#asset/201" class="button-sand">JPG (300dpi)</a></li>
+      <li><a href="https://assets.mozilla.org/portal/assets/#asset/202" class="button-sand">PNG</a></li>
     </ul>
   </div>
 </section>
@@ -59,9 +59,9 @@
   <div class="download">
     <h4>Download</h4>
     <ul class="button-list">
-      <li><a href="https://assets.mozillalabs.com/Brands-Logos/Firefox/logo-only/firefox-developer_logo-only_CMYK.eps" class="button-sand">EPS</a></li>
-      <li><a href="https://assets.mozillalabs.com/Brands-Logos/Firefox/logo-only/firefox-developer_logo-only_RGB-300dpi.jpg" class="button-sand">JPG (300dpi)</a></li>
-      <li><a href="https://assets.mozillalabs.com/Brands-Logos/Firefox/logo-only/firefox-developer_logo-only_RGB.png" class="button-sand">PNG</a></li>
+      <li><a href="https://assets.mozilla.org/portal/assets/#asset/1572" class="button-sand">EPS</a></li>
+      <li><a href="https://assets.mozilla.org/portal/assets/#asset/1573" class="button-sand">JPG (300dpi)</a></li>
+      <li><a href="https://assets.mozilla.org/portal/assets/#asset/1574" class="button-sand">PNG</a></li>
     </ul>
   </div>
 </section>

--- a/bedrock/styleguide/templates/styleguide/identity/firefox-wordmarks.html
+++ b/bedrock/styleguide/templates/styleguide/identity/firefox-wordmarks.html
@@ -31,21 +31,21 @@
     <h4>Download</h4>
     <p>Wordmark + logo</p>
     <ul class="button-list">
-      <li><a href="https://assets.mozillalabs.com/Brands-Logos/Firefox/logo-wordmark/firefox_logo-wordmark-horiz_CMYK.eps" class="button-sand">EPS</a></li>
-      <li><a href="https://assets.mozillalabs.com/Brands-Logos/Firefox/logo-wordmark/firefox_logo-wordmark-horiz_RGB-300dpi.jpg" class="button-sand">JPG (300dpi)</a></li>
-      <li><a href="https://assets.mozillalabs.com/Brands-Logos/Firefox/logo-wordmark/firefox_logo-wordmark-horiz_RGB.png" class="button-sand">PNG</a></li>
+      <li><a href="https://assets.mozilla.org/portal/assets/#asset/216" class="button-sand">EPS</a></li>
+      <li><a href="https://assets.mozilla.org/portal/assets/#asset/217" class="button-sand">JPG (300dpi)</a></li>
+      <li><a href="https://assets.mozilla.org/portal/assets/#asset/218" class="button-sand">PNG</a></li>
     </ul>
     <p>Wordmark + logo (vertical)</p>
     <ul class="button-list">
-      <li><a href="https://assets.mozillalabs.com/Brands-Logos/Firefox/logo-wordmark/firefox_logo-wordmark-vert_CMYK.eps" class="button-sand">EPS</a></li>
-      <li><a href="https://assets.mozillalabs.com/Brands-Logos/Firefox/logo-wordmark/firefox_logo-wordmark-vert_RGB-300dpi.jpg" class="button-sand">JPG (300dpi)</a></li>
-      <li><a href="https://assets.mozillalabs.com/Brands-Logos/Firefox/logo-wordmark/firefox_logo-wordmark-vert_RGB.png" class="button-sand">PNG</a></li>
+      <li><a href="https://assets.mozilla.org/portal/assets/#asset/219" class="button-sand">EPS</a></li>
+      <li><a href="https://assets.mozilla.org/portal/assets/#asset/220" class="button-sand">JPG (300dpi)</a></li>
+      <li><a href="https://assets.mozilla.org/portal/assets/#asset/221" class="button-sand">PNG</a></li>
     </ul>
     <p>Wordmark only</p>
     <ul class="button-list">
-      <li><a href="https://assets.mozillalabs.com/Brands-Logos/Firefox/wordmark-only/firefox_wordmark-only_CS4.eps" class="button-sand">EPS</a></li>
-      <li><a href="https://assets.mozillalabs.com/Brands-Logos/Firefox/wordmark-only/firefox_wordmark-only_RGB-300dpi.jpg" class="button-sand">JPG (300dpi)</a></li>
-      <li><a href="https://assets.mozillalabs.com/Brands-Logos/Firefox/wordmark-only/firefox_wordmark-only_RGB.png" class="button-sand">PNG</a></li>
+      <li><a href="https://assets.mozilla.org/portal/assets/#asset/231" class="button-sand">EPS</a></li>
+      <li><a href="https://assets.mozilla.org/portal/assets/#asset/232" class="button-sand">JPG (300dpi)</a></li>
+      <li><a href="https://assets.mozilla.org/portal/assets/#asset/233" class="button-sand">PNG</a></li>
     </ul>
   </div>
 </section>
@@ -63,15 +63,15 @@
     <h4>Download</h4>
     <p>Wordmark + logo</p>
     <ul class="button-list">
-      <li><a href="https://assets.mozillalabs.com/Brands-Logos/Firefox/logo-wordmark/firefox-beta_logo-wordmark-horiz_CMYK.eps" class="button-sand">EPS</a></li>
-      <li><a href="https://assets.mozillalabs.com/Brands-Logos/Firefox/logo-wordmark/firefox-beta_logo-wordmark-horiz_RGB-300dpi.jpg" class="button-sand">JPG (300dpi)</a></li>
-      <li><a href="https://assets.mozillalabs.com/Brands-Logos/Firefox/logo-wordmark/firefox-beta_logo-wordmark-horiz_RGB.png" class="button-sand">PNG</a></li>
+      <li><a href="https://assets.mozilla.org/portal/assets/#asset/210" class="button-sand">EPS</a></li>
+      <li><a href="https://assets.mozilla.org/portal/assets/#asset/211" class="button-sand">JPG (300dpi)</a></li>
+      <li><a href="https://assets.mozilla.org/portal/assets/#asset/212" class="button-sand">PNG</a></li>
     </ul>
     <p>Wordmark only</p>
     <ul class="button-list">
-      <li><a href="https://assets.mozillalabs.com/Brands-Logos/Firefox/wordmark-only/firefox-beta_wordmark-only_CS4.eps" class="button-sand">EPS</a></li>
-      <li><a href="https://assets.mozillalabs.com/Brands-Logos/Firefox/wordmark-only/firefox-beta_wordmark-only_RGB-300dpi.jpg" class="button-sand">JPG (300dpi)</a></li>
-      <li><a href="https://assets.mozillalabs.com/Brands-Logos/Firefox/wordmark-only/firefox-beta_wordmark-only_RGB.png" class="button-sand">PNG</a></li>
+      <li><a href="https://assets.mozilla.org/portal/assets/#asset/225" class="button-sand">EPS</a></li>
+      <li><a href="https://assets.mozilla.org/portal/assets/#asset/226" class="button-sand">JPG (300dpi)</a></li>
+      <li><a href="https://assets.mozilla.org/portal/assets/#asset/227" class="button-sand">PNG</a></li>
     </ul>
   </div>
 </section>
@@ -89,15 +89,15 @@
     <h4>Download</h4>
     <p>Wordmark + logo</p>
     <ul class="button-list">
-      <li><a href="https://assets.mozillalabs.com/Brands-Logos/Firefox/logo-wordmark/firefox-nightly_logo-wordmark_CMYK.eps" class="button-sand">EPS</a></li>
-      <li><a href="https://assets.mozillalabs.com/Brands-Logos/Firefox/logo-wordmark/firefox-nightly_logo-wordmark_RGB-300dpi.jpg" class="button-sand">JPG (300dpi)</a></li>
-      <li><a href="https://assets.mozillalabs.com/Brands-Logos/Firefox/logo-wordmark/firefox-nightly_logo-wordmark_RGB.png" class="button-sand">PNG</a></li>
+      <li><a href="https://assets.mozilla.org/portal/assets/#asset/213" class="button-sand">EPS</a></li>
+      <li><a href="https://assets.mozilla.org/portal/assets/#asset/214" class="button-sand">JPG (300dpi)</a></li>
+      <li><a href="https://assets.mozilla.org/portal/assets/#asset/215" class="button-sand">PNG</a></li>
     </ul>
     <p>Wordmark only</p>
     <ul class="button-list">
-      <li><a href="https://assets.mozillalabs.com/Brands-Logos/Firefox/wordmark-only/firefox-nightly_wordmark-only_CS4.eps" class="button-sand">EPS</a></li>
-      <li><a href="https://assets.mozillalabs.com/Brands-Logos/Firefox/wordmark-only/firefox-nightly_wordmark-only_RGB-300dpi.jpg" class="button-sand">JPG (300dpi)</a></li>
-      <li><a href="https://assets.mozillalabs.com/Brands-Logos/Firefox/wordmark-only/firefox-nightly_wordmark-only_RGB.png" class="button-sand">PNG</a></li>
+      <li><a href="https://assets.mozilla.org/portal/assets/#asset/228" class="button-sand">EPS</a></li>
+      <li><a href="https://assets.mozilla.org/portal/assets/#asset/229" class="button-sand">JPG (300dpi)</a></li>
+      <li><a href="https://assets.mozilla.org/portal/assets/#asset/230" class="button-sand">PNG</a></li>
     </ul>
   </div>
 </section>
@@ -114,15 +114,15 @@
     <h4>Download</h4>
     <p>Wordmark + logo</p>
     <ul class="button-list">
-      <li><a href="https://assets.mozillalabs.com/Brands-Logos/Firefox/logo-wordmark/firefox-developer_logo-wordmark_CMYK.eps" class="button-sand">EPS</a></li>
-      <li><a href="https://assets.mozillalabs.com/Brands-Logos/Firefox/logo-wordmark/firefox-developer_logo-wordmark_RGB-300dpi.jpg" class="button-sand">JPG (300dpi)</a></li>
-      <li><a href="https://assets.mozillalabs.com/Brands-Logos/Firefox/logo-wordmark/firefox-developer_logo-wordmark_RGB.png" class="button-sand">PNG</a></li>
+      <li><a href="https://assets.mozilla.org/portal/assets/#asset/1575" class="button-sand">EPS</a></li>
+      <li><a href="https://assets.mozilla.org/portal/assets/#asset/1576" class="button-sand">JPG (300dpi)</a></li>
+      <li><a href="https://assets.mozilla.org/portal/assets/#asset/1577" class="button-sand">PNG</a></li>
     </ul>
     <p>Wordmark only</p>
     <ul class="button-list">
-      <li><a href="https://assets.mozillalabs.com/Brands-Logos/Firefox/wordmark-only/firefox-developer_wordmark-only_CMYK.eps" class="button-sand">EPS</a></li>
-      <li><a href="https://assets.mozillalabs.com/Brands-Logos/Firefox/wordmark-only/firefox-developer_wordmark-only_RGB-300dpi.jpg" class="button-sand">JPG (300dpi)</a></li>
-      <li><a href="https://assets.mozillalabs.com/Brands-Logos/Firefox/wordmark-only/firefox-developer_wordmark-only_RGB.png" class="button-sand">PNG</a></li>
+      <li><a href="https://assets.mozilla.org/portal/assets/#asset/1578" class="button-sand">EPS</a></li>
+      <li><a href="https://assets.mozilla.org/portal/assets/#asset/1579" class="button-sand">JPG (300dpi)</a></li>
+      <li><a href="https://assets.mozilla.org/portal/assets/#asset/1580" class="button-sand">PNG</a></li>
     </ul>
   </div>
 </section>

--- a/bedrock/styleguide/templates/styleguide/identity/firefoxos-branding.html
+++ b/bedrock/styleguide/templates/styleguide/identity/firefoxos-branding.html
@@ -35,9 +35,9 @@
     <img src="{{ static('img/styleguide/identity/firefoxos/guidelines-logo.png') }}" alt="Guidelines logo">
     <h3>Download</h3>
     <ul class="button-list">
-      <li><a href="https://assets.mozillalabs.com/Brands-Logos/Firefox%20OS/logo-wordmark/firefox-os_logo-wordmark_RGB-vertical.eps" class="button-sand">EPS</a></li>
-      <li><a href="https://assets.mozillalabs.com/Brands-Logos/Firefox%20OS/logo-wordmark/firefox-os_logo-wordmark_RGB-vertical-300dpi.jpg" class="button-sand">JPG (300dpi)</a></li>
-      <li><a href="https://assets.mozillalabs.com/Brands-Logos/Firefox%20OS/logo-wordmark/firefox-os_logo-wordmark_RGB-vertical.png" class="button-sand">PNG</a></li>
+      <li><a href="https://assets.mozilla.org/portal/assets/#asset/183" class="button-sand">EPS</a></li>
+      <li><a href="https://assets.mozilla.org/portal/assets/#asset/182" class="button-sand">JPG (300dpi)</a></li>
+      <li><a href="https://assets.mozilla.org/portal/assets/#asset/184" class="button-sand">PNG</a></li>
     </ul>
   </div>
   <p class="copyright-note"><small>The logo files containing our trademarks are available under the following copyright licenses: vector logo files under <a href="https://creativecommons.org/licenses/by-sa/3.0/">CC-BY 3.0</a> or later; bitmap logo files under <a href="http://www.mozilla.org/MPL/2.0/">MPL 2</a>.</small></p>
@@ -85,14 +85,14 @@
         <h4>Download</h4>
         <h5>Logo + Wordmark &mdash; grey</h5>
         <ul class="button-list">
-          <li><a href="https://assets.mozillalabs.com/Brands-Logos/Firefox%20OS/logo-wordmark/firefox-os_logo-wordmark_CMYK.eps" class="button-sand">EPS</a></li>
-          <li><a href="https://assets.mozillalabs.com/Brands-Logos/Firefox%20OS/logo-wordmark/firefox-os_logo-wordmark_RGB-300dpi.jpg" class="button-sand">JPG (300dpi)</a></li>
-          <li><a href="https://assets.mozillalabs.com/Brands-Logos/Firefox%20OS/logo-wordmark/firefox-os_logo-wordmark_RGB.png" class="button-sand">PNG</a></li>
+          <li><a href="https://assets.mozilla.org/portal/assets/#asset/180" class="button-sand">EPS</a></li>
+          <li><a href="https://assets.mozilla.org/portal/assets/#asset/181" class="button-sand">JPG (300dpi)</a></li>
+          <li><a href="https://assets.mozilla.org/portal/assets/#asset/187" class="button-sand">PNG</a></li>
         </ul>
         <h5>Logo + Wordmark &mdash; white</h5>
         <ul class="button-list">
-          <li><a href="https://assets.mozillalabs.com/Brands-Logos/Firefox%20OS/logo-wordmark/firefox-os_logo-wordmark_CMYK-white.eps" class="button-sand">EPS</a></li>
-          <li><a href="https://assets.mozillalabs.com/Brands-Logos/Firefox%20OS/logo-wordmark/firefox-os_logo-wordmark_RGB-white.png" class="button-sand">PNG</a></li>
+          <li><a href="https://assets.mozilla.org/portal/assets/#asset/179" class="button-sand">EPS</a></li>
+          <li><a href="https://assets.mozilla.org/portal/assets/#asset/186" class="button-sand">PNG</a></li>
         </ul>
       </div>
     </div>
@@ -104,14 +104,14 @@
       <div class="download">
         <h5>Logo + Wordmark (vertical) &mdash; grey</h5>
         <ul class="button-list">
-          <li><a href="https://assets.mozillalabs.com/Brands-Logos/Firefox%20OS/logo-wordmark/firefox-os_logo-wordmark_RGB-vertical.eps" class="button-sand">EPS</a></li>
-          <li><a href="https://assets.mozillalabs.com/Brands-Logos/Firefox%20OS/logo-wordmark/firefox-os_logo-wordmark_RGB-vertical-300dpi.jpg" class="button-sand">JPG (300dpi)</a></li>
-          <li><a href="https://assets.mozillalabs.com/Brands-Logos/Firefox%20OS/logo-wordmark/firefox-os_logo-wordmark_RGB-vertical.png" class="button-sand">PNG</a></li>
+          <li><a href="https://assets.mozilla.org/portal/assets/#asset/183" class="button-sand">EPS</a></li>
+          <li><a href="https://assets.mozilla.org/portal/assets/#asset/182" class="button-sand">JPG (300dpi)</a></li>
+          <li><a href="https://assets.mozilla.org/portal/assets/#asset/184" class="button-sand">PNG</a></li>
         </ul>
         <h5>Logo + Wordmark (vertical) &mdash; white</h5>
         <ul class="button-list">
-          <li><a href="https://assets.mozillalabs.com/Brands-Logos/Firefox%20OS/logo-wordmark/firefox-os_logo-wordmark_CMYK-white-vertical.eps" class="button-sand">EPS</a></li>
-          <li><a href="https://assets.mozillalabs.com/Brands-Logos/Firefox%20OS/logo-wordmark/firefox-os_logo-wordmark_RGB-white-vertical.png" class="button-sand">PNG</a></li>
+          <li><a href="https://assets.mozilla.org/portal/assets/#asset/178" class="button-sand">EPS</a></li>
+          <li><a href="https://assets.mozilla.org/portal/assets/#asset/185" class="button-sand">PNG</a></li>
         </ul>
       </div>
     </div>
@@ -123,15 +123,15 @@
       <div class="download">
         <h5>Wordmark only &mdash; grey</h5>
         <ul class="button-list">
-          <li><a href="https://assets.mozillalabs.com/Brands-Logos/Firefox%20OS/wordmark-only/firefox-os_wordmark-only_CMYK.eps" class="button-sand">EPS</a></li>
-          <li><a href="https://assets.mozillalabs.com/Brands-Logos/Firefox%20OS/wordmark-only/firefox-os_wordmark-only_RGB-300dpi.jpg" class="button-sand">JPG (300dpi)</a></li>
-          <li><a href="https://assets.mozillalabs.com/Brands-Logos/Firefox%20OS/wordmark-only/firefox-os_wordmark-only_RGB.png" class="button-sand">PNG</a></li>
+          <li><a href="https://assets.mozilla.org/portal/assets/#asset/189" class="button-sand">EPS</a></li>
+          <li><a href="https://assets.mozilla.org/portal/assets/#asset/190" class="button-sand">JPG (300dpi)</a></li>
+          <li><a href="https://assets.mozilla.org/portal/assets/#asset/193" class="button-sand">PNG</a></li>
         </ul>
         <h5>Wordmark only &mdash; white</h5>
         <ul class="button-list">
-          <li><a href="https://assets.mozillalabs.com/Brands-Logos/Firefox%20OS/wordmark-only/firefox-os_wordmark-only_CMYK-white.eps" class="button-sand">EPS</a></li>
-          <li><a href="https://assets.mozillalabs.com/Brands-Logos/Firefox%20OS/wordmark-only/firefox-os_wordmark-only_RGB-white.png" class="button-sand">PNG</a></li>
-          <li><a href="https://assets.mozillalabs.com/Brands-Logos/Firefox%20OS/wordmark-only/firefox-os_wordmark-only_RGB-white-5100x2267.png" class="button-sand">PNG (large)</a></li>
+          <li><a href="https://assets.mozilla.org/portal/assets/#asset/188" class="button-sand">EPS</a></li>
+          <li><a href="https://assets.mozilla.org/portal/assets/#asset/192" class="button-sand">PNG</a></li>
+          <li><a href="https://assets.mozilla.org/portal/assets/#asset/191" class="button-sand">PNG (large)</a></li>
         </ul>
       </div>
     </div>

--- a/bedrock/styleguide/templates/styleguide/identity/firefoxos-community.html
+++ b/bedrock/styleguide/templates/styleguide/identity/firefoxos-community.html
@@ -90,15 +90,15 @@
           <li>
             <img src="{{ static('img/styleguide/identity/firefoxos/partners-community-thelook-future.png') }}" alt="{{ _('The Look - Be The Future') }}">
             <ul class="button-list">
-              <li><a href="https://assets.mozillalabs.com/Projects/Firefox%20OS/Engagement/Community/Artwork/Print%20CMYK/The%20Look/" class="button-sand">{{ _('Print') }}</a></li>
-              <li><a href="https://assets.mozillalabs.com/Projects/Firefox%20OS/Engagement/Community/Artwork/Web%20RGB/The%20Look/" class="button-sand">{{ _('Web') }}</a></li>
+              <li><a href="https://assets.mozilla.org/portal/assets/#category/200" class="button-sand">{{ _('Print') }}</a></li>
+              <li><a href="https://assets.mozilla.org/portal/assets/#category/177" class="button-sand">{{ _('Web') }}</a></li>
             </ul>
           </li>
           <li>
             <img src="{{ static('img/styleguide/identity/firefoxos/partners-community-thelook-blaze.png') }}" alt="{{ _('The Look - Blaze Your Own Path') }}">
             <ul class="button-list">
-              <li><a href="https://assets.mozillalabs.com/Projects/Firefox%20OS/Engagement/Community/Artwork/Print%20CMYK/The%20Look/" class="button-sand">{{ _('Print') }}</a></li>
-              <li><a href="https://assets.mozillalabs.com/Projects/Firefox%20OS/Engagement/Community/Artwork/Web%20RGB/The%20Look/" class="button-sand">{{ _('Web') }}</a></li>
+              <li><a href="https://assets.mozilla.org/portal/assets/#category/200" class="button-sand">{{ _('Print') }}</a></li>
+              <li><a href="https://assets.mozilla.org/portal/assets/#category/177" class="button-sand">{{ _('Web') }}</a></li>
             </ul>
           </li>
         </ul>
@@ -110,15 +110,15 @@
           <li>
             <img src="{{ static('img/styleguide/identity/firefoxos/partners-community-thecharge-future.png') }}" alt="{{ _('The Charge - Be The Future') }}">
             <ul class="button-list">
-              <li><a href="https://assets.mozillalabs.com/Projects/Firefox%20OS/Engagement/Community/Artwork/Print%20CMYK/The%20Charge/" class="button-sand">{{ _('Print') }}</a></li>
-              <li><a href="https://assets.mozillalabs.com/Projects/Firefox%20OS/Engagement/Community/Artwork/Web%20RGB/The%20Charge/" class="button-sand">{{ _('Web') }}</a></li>
+              <li><a href="https://assets.mozilla.org/portal/assets/#category/197" class="button-sand">{{ _('Print') }}</a></li>
+              <li><a href="https://assets.mozilla.org/portal/assets/#category/206" class="button-sand">{{ _('Web') }}</a></li>
             </ul>
           </li>
           <li>
             <img src="{{ static('img/styleguide/identity/firefoxos/partners-community-thecharge-blaze.png') }}" alt="{{ _('The Charge - Blaze Your Own Path') }}">
             <ul class="button-list">
-              <li><a href="https://assets.mozillalabs.com/Projects/Firefox%20OS/Engagement/Community/Artwork/Print%20CMYK/The%20Charge/" class="button-sand">{{ _('Print') }}</a></li>
-              <li><a href="https://assets.mozillalabs.com/Projects/Firefox%20OS/Engagement/Community/Artwork/Web%20RGB/The%20Charge/" class="button-sand">{{ _('Web') }}</a></li>
+              <li><a href="https://assets.mozilla.org/portal/assets/#category/197" class="button-sand">{{ _('Print') }}</a></li>
+              <li><a href="https://assets.mozilla.org/portal/assets/#category/206" class="button-sand">{{ _('Web') }}</a></li>
             </ul>
           </li>
         </ul>
@@ -130,15 +130,15 @@
           <li>
             <img src="{{ static('img/styleguide/identity/firefoxos/partners-community-thebolt-future.png') }}" alt="{{ _('The Bolt - Be The Future') }}">
             <ul class="button-list">
-              <li><a href="https://assets.mozillalabs.com/Projects/Firefox%20OS/Engagement/Community/Artwork/Print%20CMYK/The%20Bolt/" class="button-sand">{{ _('Print') }}</a></li>
-              <li><a href="https://assets.mozillalabs.com/Projects/Firefox%20OS/Engagement/Community/Artwork/Web%20RGB/The%20Bolt/" class="button-sand">{{ _('Web') }}</a></li>
+              <li><a href="https://assets.mozilla.org/portal/assets/#category/194" class="button-sand">{{ _('Print') }}</a></li>
+              <li><a href="https://assets.mozilla.org/portal/assets/#category/203" class="button-sand">{{ _('Web') }}</a></li>
             </ul>
           </li>
           <li>
             <img src="{{ static('img/styleguide/identity/firefoxos/partners-community-thebolt-blaze.png') }}" alt="{{ _('The Bolt - Blaze Your Own Path') }}">
             <ul class="button-list">
-              <li><a href="https://assets.mozillalabs.com/Projects/Firefox%20OS/Engagement/Community/Artwork/Print%20CMYK/The%20Bolt/" class="button-sand">{{ _('Print') }}</a></li>
-              <li><a href="https://assets.mozillalabs.com/Projects/Firefox%20OS/Engagement/Community/Artwork/Web%20RGB/The%20Bolt/" class="button-sand">{{ _('Web') }}</a></li>
+              <li><a href="https://assets.mozilla.org/portal/assets/#category/194" class="button-sand">{{ _('Print') }}</a></li>
+              <li><a href="https://assets.mozilla.org/portal/assets/#category/203" class="button-sand">{{ _('Web') }}</a></li>
             </ul>
           </li>
         </ul>

--- a/bedrock/styleguide/templates/styleguide/identity/firefoxos-partners.html
+++ b/bedrock/styleguide/templates/styleguide/identity/firefoxos-partners.html
@@ -18,7 +18,7 @@
   </div>
   <div class="right-col">
     <p>
-      {% trans url1=url('mozorg.partnerships'), url2=node.next.url, url3="https://assets.mozillalabs.com/Brands-Logos/Firefox%20OS/brand-guideline/FirefoxOS_BrandGuidelines_EN.pdf" %}
+      {% trans url1=url('mozorg.partnerships'), url2=node.next.url, url3="https://assets.mozilla.org/portal/assets/#asset/177" %}
       This page contains details on the Firefox OS promotional assets created for both licensed and unlicensed
       commercial use. Please <a href="{{ url1 }}">contact us</a> about partnership opportunities if you're
       interested in using these materials. If you're looking for promotional materials for community and other
@@ -75,21 +75,21 @@
         <h4>Downloads</h4>
         <h5>{{ _('Color') }}</h5>
         <ul class="button-list">
-          <li><a href="https://assets.mozillalabs.com/Projects/Firefox%20OS/Engagement/Unlicensed/firefox-os_unlicensed-based-on-square-red_CMYK.eps" class="button-sand">EPS</a></li>
-          <li><a href="https://assets.mozillalabs.com/Projects/Firefox%20OS/Engagement/Unlicensed/firefox-os_unlicensed-based-on-square-red_RGB-300dpi.jpg" class="button-sand">JPG (300dpi)</a></li>
-          <li><a href="https://assets.mozillalabs.com/Projects/Firefox%20OS/Engagement/Unlicensed/firefox-os_unlicensed-based-on-square-red.png" class="button-sand">PNG</a></li>
+          <li><a href="https://assets.mozilla.org/portal/assets/#asset/470" class="button-sand">EPS</a></li>
+          <li><a href="https://assets.mozilla.org/portal/assets/#asset/471" class="button-sand">JPG (300dpi)</a></li>
+          <li><a href="https://assets.mozilla.org/portal/assets/#asset/469" class="button-sand">PNG</a></li>
         </ul>
         <h5>{{ _('B &amp; W') }}</h5>
         <ul class="button-list">
-          <li><a href="https://assets.mozillalabs.com/Projects/Firefox%20OS/Engagement/Unlicensed/firefox-os_unlicensed-based-on-square-black_CMYK.eps" class="button-sand">EPS</a></li>
-          <li><a href="https://assets.mozillalabs.com/Projects/Firefox%20OS/Engagement/Unlicensed/firefox-os_unlicensed-based-on-square-black_RGB-300dpi.jpg" class="button-sand">JPG (300dpi)</a></li>
-          <li><a href="https://assets.mozillalabs.com/Projects/Firefox%20OS/Engagement/Unlicensed/firefox-os_unlicensed-based-on-square-black.png" class="button-sand">PNG</a></li>
+          <li><a href="https://assets.mozilla.org/portal/assets/#asset/467" class="button-sand">EPS</a></li>
+          <li><a href="https://assets.mozilla.org/portal/assets/#asset/468" class="button-sand">JPG (300dpi)</a></li>
+          <li><a href="https://assets.mozilla.org/portal/assets/#asset/466" class="button-sand">PNG</a></li>
         </ul>
         <h5>{{ _('Wordmark only') }}</h5>
         <ul class="button-list">
-          <li><a href="https://assets.mozillalabs.com/Projects/Firefox%20OS/Engagement/Unlicensed/firefox-os_unlicensed-based-on-wordmark_CMYK.eps" class="button-sand">EPS</a></li>
-          <li><a href="https://assets.mozillalabs.com/Projects/Firefox%20OS/Engagement/Unlicensed/firefox-os_unlicensed-based-on-wordmark_RGB-300dpi.jpg" class="button-sand">JPG (300dpi)</a></li>
-          <li><a href="https://assets.mozillalabs.com/Projects/Firefox%20OS/Engagement/Unlicensed/firefox-os_unlicensed-based-on-wordmark.png" class="button-sand">PNG</a></li>
+          <li><a href="https://assets.mozilla.org/portal/assets/#asset/473" class="button-sand">EPS</a></li>
+          <li><a href="https://assets.mozilla.org/portal/assets/#asset/474" class="button-sand">JPG (300dpi)</a></li>
+          <li><a href="https://assets.mozilla.org/portal/assets/#asset/472" class="button-sand">PNG</a></li>
         </ul>
       </div>
     </div>

--- a/bedrock/styleguide/templates/styleguide/identity/firefoxos-typography.html
+++ b/bedrock/styleguide/templates/styleguide/identity/firefoxos-typography.html
@@ -19,7 +19,7 @@
     <p>An open font with 897 characters (and therefore enormous localization potential), Open Sans is our default typeface for websites, print and other materials. </p>
     <p>The Open Sans type family is used in the four weights shown here for all our communications. Open Sans Extrabold Italic in all caps is used as our display type to capture our bold voice and the spirit of the Firefox OS brand (with approved headlines only). </p>
     <div class="download">
-      <a href="https://assets.mozillalabs.com/Communications/Presentations/Open%20Sans.zip" class="button-sand">Download Open Sans</a>
+      <a href="https://assets.mozilla.org/portal/assets/#asset/99" class="button-sand">Download Open Sans</a>
     </div>
   </div>
   <div id="typeface-content">

--- a/bedrock/styleguide/templates/styleguide/identity/marketplace-branding.html
+++ b/bedrock/styleguide/templates/styleguide/identity/marketplace-branding.html
@@ -30,9 +30,9 @@
     <img src="{{ static('img/styleguide/identity/marketplace/logo.png') }}" alt="Logo" />
     <h3>Download</h3>
     <ul class="button-list">
-      <li><a href="https://assets.mozillalabs.com/Brands-Logos/Firefox%20Marketplace/logo-only/firefox-marketplace_logo-only_CMYK-CS4.eps" class="button-sand">EPS</a></li>
-      <li><a href="https://assets.mozillalabs.com/Brands-Logos/Firefox%20Marketplace/logo-only/firefox-marketplace_logo-only_RGB-300dpi.jpg" class="button-sand">JPG (300dpi)</a></li>
-      <li><a href="https://assets.mozillalabs.com/Brands-Logos/Firefox%20Marketplace/logo-only/firefox-marketplace_logo-only_RGB.png" class="button-sand">PNG</a></li>
+      <li><a href="https://assets.mozilla.org/portal/assets/#asset/156" class="button-sand">EPS</a></li>
+      <li><a href="https://assets.mozilla.org/portal/assets/#asset/157" class="button-sand">JPG (300dpi)</a></li>
+      <li><a href="https://assets.mozilla.org/portal/assets/#asset/158" class="button-sand">PNG</a></li>
     </ul>
   </div>
   <p class="copyright-note"><small>The logo files containing our trademarks are available under the following copyright licenses: vector logo files under <a href="https://creativecommons.org/licenses/by-sa/3.0/">CC-BY 3.0</a> or later; bitmap logo files under <a href="http://www.mozilla.org/MPL/2.0/">MPL 2</a>.</small></p>
@@ -72,15 +72,15 @@
     <h4>Download</h4>
     <p>Wordmark + Logo (Firefox ver.)</p>
     <ul class="button-list">
-      <li><a href="https://assets.mozillalabs.com/Brands-Logos/Firefox%20Marketplace/logo-wordmark/firefox-marketplace_logo-wordmark_CMYK-CS4.eps" class="button-sand">EPS</a></li>
-      <li><a href="https://assets.mozillalabs.com/Brands-Logos/Firefox%20Marketplace/logo-wordmark/firefox-marketplace_logo-wordmark_RGB-300dpi.jpg" class="button-sand">JPG (300dpi)</a></li>
-      <li><a href="https://assets.mozillalabs.com/Brands-Logos/Firefox%20Marketplace/logo-wordmark/firefox-marketplace_logo-wordmark_RGB.png" class="button-sand">PNG</a></li>
+      <li><a href="https://assets.mozilla.org/portal/assets/#asset/165" class="button-sand">EPS</a></li>
+      <li><a href="https://assets.mozilla.org/portal/assets/#asset/166" class="button-sand">JPG (300dpi)</a></li>
+      <li><a href="https://assets.mozilla.org/portal/assets/#asset/167" class="button-sand">PNG</a></li>
     </ul>
     <p>Wordmark only (Firefox ver.)</p>
     <ul class="button-list">
-      <li><a href="https://assets.mozillalabs.com/Brands-Logos/Firefox%20Marketplace/wordmark-only/firefox-marketplace_wordmark-only_CMYK-CS4.eps" class="button-sand">EPS</a></li>
-      <li><a href="https://assets.mozillalabs.com/Brands-Logos/Firefox%20Marketplace/wordmark-only/firefox-marketplace_wordmark-only_RGB-300dpi.jpg" class="button-sand">JPG (300dpi)</a></li>
-      <li><a href="https://assets.mozillalabs.com/Brands-Logos/Firefox%20Marketplace/wordmark-only/firefox-marketplace_wordmark-only_RGB.png" class="button-sand">PNG</a></li>
+      <li><a href="https://assets.mozilla.org/portal/assets/#asset/171" class="button-sand">EPS</a></li>
+      <li><a href="https://assets.mozilla.org/portal/assets/#asset/172" class="button-sand">JPG (300dpi)</a></li>
+      <li><a href="https://assets.mozilla.org/portal/assets/#asset/173" class="button-sand">PNG</a></li>
     </ul>
   </div>
 </section>
@@ -93,15 +93,15 @@
     <h4>Download</h4>
     <p>Wordmark + Logo (generic)</p>
     <ul class="button-list">
-      <li><a href="https://assets.mozillalabs.com/Brands-Logos/Firefox%20Marketplace/logo-wordmark/marketplace_logo-wordmark_CMYK-CS4.eps" class="button-sand">EPS</a></li>
-      <li><a href="https://assets.mozillalabs.com/Brands-Logos/Firefox%20Marketplace/logo-wordmark/marketplace_logo-wordmark_RGB-300dpi.jpg" class="button-sand">JPG (300dpi)</a></li>
-      <li><a href="https://assets.mozillalabs.com/Brands-Logos/Firefox%20Marketplace/logo-wordmark/marketplace_logo-wordmark_RGB.png" class="button-sand">PNG</a></li>
+      <li><a href="https://assets.mozilla.org/portal/assets/#asset/165" class="button-sand">EPS</a></li>
+      <li><a href="https://assets.mozilla.org/portal/assets/#asset/166" class="button-sand">JPG (300dpi)</a></li>
+      <li><a href="https://assets.mozilla.org/portal/assets/#asset/167" class="button-sand">PNG</a></li>
     </ul>
     <p>Wordmark only (generic)</p>
     <ul class="button-list">
-      <li><a href="https://assets.mozillalabs.com/Brands-Logos/Firefox%20Marketplace/wordmark-only/marketplace_wordmark-only_CMYK-CS4.eps" class="button-sand">EPS</a></li>
-      <li><a href="https://assets.mozillalabs.com/Brands-Logos/Firefox%20Marketplace/wordmark-only/marketplace_wordmark-only_RGB-300dpi.jpg" class="button-sand">JPG (300dpi)</a></li>
-      <li><a href="https://assets.mozillalabs.com/Brands-Logos/Firefox%20Marketplace/wordmark-only/marketplace_wordmark-only_RGB.png" class="button-sand">PNG</a></li>
+      <li><a href="https://assets.mozilla.org/portal/assets/#asset/174" class="button-sand">EPS</a></li>
+      <li><a href="https://assets.mozilla.org/portal/assets/#asset/175" class="button-sand">JPG (300dpi)</a></li>
+      <li><a href="https://assets.mozilla.org/portal/assets/#asset/176" class="button-sand">PNG</a></li>
     </ul>
   </div>
 </section>

--- a/bedrock/styleguide/templates/styleguide/identity/mozilla-branding.html
+++ b/bedrock/styleguide/templates/styleguide/identity/mozilla-branding.html
@@ -36,9 +36,9 @@
   <div class="download">
     <h4>Download</h4>
     <ul class="button-list">
-      <li><a href="https://assets.mozillalabs.com/Brands-Logos/Mozilla/mozilla_wordmark_CS4.eps" class="button-sand">EPS</a></li>
-      <li><a href="https://assets.mozillalabs.com/Brands-Logos/Mozilla/mozilla_wordmark_300dpi.jpg" class="button-sand">JPG (300dpi)</a></li>
-      <li><a href="https://assets.mozillalabs.com/Brands-Logos/Mozilla/mozilla_wordmark.png" class="button-sand">PNG</a></li>
+      <li><a href="https://assets.mozilla.org/portal/assets/#asset/64" class="button-sand">EPS</a></li>
+      <li><a href="https://assets.mozilla.org/portal/assets/#asset/63" class="button-sand">JPG (300dpi)</a></li>
+      <li><a href="https://assets.mozilla.org/portal/assets/#asset/62" class="button-sand">PNG</a></li>
     </ul>
   </div>
 </section>

--- a/bedrock/styleguide/templates/styleguide/identity/mozilla-color.html
+++ b/bedrock/styleguide/templates/styleguide/identity/mozilla-color.html
@@ -19,7 +19,7 @@
 <section>
   <div class="swatch-card">
     <h2>Swatches</h2>
-    <a href="https://assets.mozillalabs.com/Brands-Logos/Mozilla/mozilla.ase" class="button-sand">Photoshop/Illustrator (.ASE)</a>
+    <a href="https://assets.mozilla.org/portal/assets/#asset/59" class="button-sand">Photoshop/Illustrator (.ASE)</a>
   </div>
   <div class="swatch-card">
     <h2>Gradients</h2>

--- a/bedrock/styleguide/templates/styleguide/identity/thunderbird-channels.html
+++ b/bedrock/styleguide/templates/styleguide/identity/thunderbird-channels.html
@@ -28,9 +28,9 @@
   <div class="download">
     <h4>Download</h4>
     <ul class="button-list">
-      <li><a href="https://assets.mozillalabs.com/Brands-Logos/Thunderbird/logo-only/thunderbird_logo-only_CS4.eps" class="button-sand">EPS</a></li>
-      <li><a href="https://assets.mozillalabs.com/Brands-Logos/Thunderbird/logo-only/thunderbird_logo-only_RGB-300dpi.jpg" class="button-sand">JPG (300dpi)</a></li>
-      <li><a href="https://assets.mozillalabs.com/Brands-Logos/Thunderbird/logo-only/thunderbird_logo-only_RGB.png" class="button-sand">PNG</a></li>
+      <li><a href="https://assets.mozilla.org/portal/assets/#asset/271" class="button-sand">EPS</a></li>
+      <li><a href="https://assets.mozilla.org/portal/assets/#asset/272" class="button-sand">JPG (300dpi)</a></li>
+      <li><a href="https://assets.mozilla.org/portal/assets/#asset/273" class="button-sand">PNG</a></li>
     </ul>
   </div>
 </section>
@@ -46,9 +46,9 @@
   <div class="download">
     <h4>Download</h4>
     <ul class="button-list">
-      <li><a href="https://assets.mozillalabs.com/Brands-Logos/Thunderbird/logo-only/thunderbird_logo-only_CS4.eps" class="button-sand">EPS</a></li>
-      <li><a href="https://assets.mozillalabs.com/Brands-Logos/Thunderbird/logo-only/thunderbird_logo-only_RGB-300dpi.jpg" class="button-sand">JPG (300dpi)</a></li>
-      <li><a href="https://assets.mozillalabs.com/Brands-Logos/Thunderbird/logo-only/thunderbird_logo-only_RGB.png" class="button-sand">PNG</a></li>
+      <li><a href="https://assets.mozilla.org/portal/assets/#asset/271" class="button-sand">EPS</a></li>
+      <li><a href="https://assets.mozilla.org/portal/assets/#asset/272" class="button-sand">JPG (300dpi)</a></li>
+      <li><a href="https://assets.mozilla.org/portal/assets/#asset/273" class="button-sand">PNG</a></li>
     </ul>
   </div>
 </section>
@@ -64,9 +64,9 @@
   <div class="download">
     <h4>Download</h4>
     <ul class="button-list">
-      <li><a href="https://assets.mozillalabs.com/Brands-Logos/Thunderbird/logo-only/thunderbird-earlybird_logo-only_CS4.eps" class="button-sand">EPS</a></li>
-      <li><a href="https://assets.mozillalabs.com/Brands-Logos/Thunderbird/logo-only/thunderbird-earlybird_logo-only_RGB-300dpi.jpg" class="button-sand">JPG (300dpi)</a></li>
-      <li><a href="https://assets.mozillalabs.com/Brands-Logos/Thunderbird/logo-only/thunderbird-earlybird_logo-only_RGB.png" class="button-sand">PNG</a></li>
+      <li><a href="https://assets.mozilla.org/portal/assets/#asset/268" class="button-sand">EPS</a></li>
+      <li><a href="https://assets.mozilla.org/portal/assets/#asset/269" class="button-sand">JPG (300dpi)</a></li>
+      <li><a href="https://assets.mozilla.org/portal/assets/#asset/270" class="button-sand">PNG</a></li>
     </ul>
   </div>
 </section>
@@ -82,9 +82,9 @@
   <div class="download">
     <h4>Download</h4>
     <ul class="button-list">
-      <li><a href="https://assets.mozillalabs.com/Brands-Logos/Thunderbird/logo-only/thunderbird-daily_logo-only_CS4.eps" class="button-sand">EPS</a></li>
-      <li><a href="https://assets.mozillalabs.com/Brands-Logos/Thunderbird/logo-only/thunderbird-daily_logo-only_RGB-300dpi.jpg" class="button-sand">JPG (300dpi)</a></li>
-      <li><a href="https://assets.mozillalabs.com/Brands-Logos/Thunderbird/logo-only/thunderbird-daily_logo-only_RGB.png" class="button-sand">PNG</a></li>
+      <li><a href="https://assets.mozilla.org/portal/assets/#asset/265" class="button-sand">EPS</a></li>
+      <li><a href="https://assets.mozilla.org/portal/assets/#asset/266" class="button-sand">JPG (300dpi)</a></li>
+      <li><a href="https://assets.mozilla.org/portal/assets/#asset/267" class="button-sand">PNG</a></li>
     </ul>
   </div>
 </section>

--- a/bedrock/styleguide/templates/styleguide/identity/thunderbird-logo.html
+++ b/bedrock/styleguide/templates/styleguide/identity/thunderbird-logo.html
@@ -30,9 +30,9 @@
     <img src="{{ static('img/styleguide/identity/thunderbird/logo.png') }}" alt="Logo" id="guidelines-logo-image" />
     <h3>Download</h3>
     <ul class="button-list">
-      <li><a href="https://assets.mozillalabs.com/Brands-Logos/Thunderbird/logo-only/thunderbird_logo-only_CS4.eps" class="button-sand">EPS</a></li>
-      <li><a href="https://assets.mozillalabs.com/Brands-Logos/Thunderbird/logo-only/thunderbird_logo-only_RGB-300dpi.jpg" class="button-sand">JPG (300dpi)</a></li>
-      <li><a href="https://assets.mozillalabs.com/Brands-Logos/Thunderbird/logo-only/thunderbird_logo-only_RGB.png" class="button-sand">PNG</a></li>
+      <li><a href="https://assets.mozilla.org/portal/assets/#asset/271" class="button-sand">EPS</a></li>
+      <li><a href="https://assets.mozilla.org/portal/assets/#asset/272" class="button-sand">JPG (300dpi)</a></li>
+      <li><a href="https://assets.mozilla.org/portal/assets/#asset/273" class="button-sand">PNG</a></li>
     </ul>
   </div>
   <p  class="copyright-note"><small>The logo files containing our trademarks are available under the following copyright licenses: vector logo files under <a href="https://creativecommons.org/licenses/by-sa/3.0/">CC-BY 3.0</a> or later; bitmap logo files under <a href="http://www.mozilla.org/MPL/2.0/">MPL 2</a>.</small></p>

--- a/bedrock/styleguide/templates/styleguide/identity/thunderbird-wordmarks.html
+++ b/bedrock/styleguide/templates/styleguide/identity/thunderbird-wordmarks.html
@@ -30,15 +30,15 @@
     <h4>Download</h4>
     <p>Wordmark + logo</p>
     <ul class="button-list">
-      <li><a href="https://assets.mozillalabs.com/Brands-Logos/Thunderbird/logo-wordmark/thunderbird_logo-wordmark_CS4.eps" class="button-sand">EPS</a></li>
-      <li><a href="https://assets.mozillalabs.com/Brands-Logos/Thunderbird/logo-wordmark/thunderbird_logo-wordmark_RGB-300dpi.jpg" class="button-sand">JPG (300dpi)</a></li>
-      <li><a href="https://assets.mozillalabs.com/Brands-Logos/Thunderbird/logo-wordmark/thunderbird_logo-wordmark_RGB.png" class="button-sand">PNG</a></li>
+      <li><a href="https://assets.mozilla.org/portal/assets/#asset/283" class="button-sand">EPS</a></li>
+      <li><a href="https://assets.mozilla.org/portal/assets/#asset/284" class="button-sand">JPG (300dpi)</a></li>
+      <li><a href="https://assets.mozilla.org/portal/assets/#asset/285" class="button-sand">PNG</a></li>
     </ul>
     <p>Wordmark only</p>
     <ul class="button-list">
-      <li><a href="https://assets.mozillalabs.com/Brands-Logos/Thunderbird/wordmark-only/thunderbird_logo-wordmark-only_CS4.eps" class="button-sand">EPS</a></li>
-      <li><a href="https://assets.mozillalabs.com/Brands-Logos/Thunderbird/wordmark-only/thunderbird_logo-wordmark-only_RGB-300dpi.jpg" class="button-sand">JPG (300dpi)</a></li>
-      <li><a href="https://assets.mozillalabs.com/Brands-Logos/Thunderbird/wordmark-only/thunderbird_logo-wordmark-only_RGB.png" class="button-sand">PNG</a></li>
+      <li><a href="https://assets.mozilla.org/portal/assets/#asset/295" class="button-sand">EPS</a></li>
+      <li><a href="https://assets.mozilla.org/portal/assets/#asset/296" class="button-sand">JPG (300dpi)</a></li>
+      <li><a href="https://assets.mozilla.org/portal/assets/#asset/297" class="button-sand">PNG</a></li>
     </ul>
   </div>
 </section>
@@ -56,15 +56,15 @@
     <h4>Download</h4>
     <p>Wordmark + logo</p>
     <ul class="button-list">
-      <li><a href="https://assets.mozillalabs.com/Brands-Logos/Thunderbird/logo-wordmark/thunderbird-beta_logo-wordmark_CS4.eps" class="button-sand">EPS</a></li>
-      <li><a href="https://assets.mozillalabs.com/Brands-Logos/Thunderbird/logo-wordmark/thunderbird-beta_logo-wordmark_RGB-300dpi.jpg" class="button-sand">JPG (300dpi)</a></li>
-      <li><a href="https://assets.mozillalabs.com/Brands-Logos/Thunderbird/logo-wordmark/thunderbird-beta_logo-wordmark_RGB.png" class="button-sand">PNG</a></li>
+      <li><a href="https://assets.mozilla.org/portal/assets/#asset/274" class="button-sand">EPS</a></li>
+      <li><a href="https://assets.mozilla.org/portal/assets/#asset/275" class="button-sand">JPG (300dpi)</a></li>
+      <li><a href="https://assets.mozilla.org/portal/assets/#asset/276" class="button-sand">PNG</a></li>
     </ul>
     <p>Wordmark only</p>
     <ul class="button-list">
-      <li><a href="https://assets.mozillalabs.com/Brands-Logos/Thunderbird/wordmark-only/thunderbird-beta_wordmark-only_CS4.eps" class="button-sand">EPS</a></li>
-      <li><a href="https://assets.mozillalabs.com/Brands-Logos/Thunderbird/wordmark-only/thunderbird-beta_wordmark-only_RGB-300dpi.jpg" class="button-sand">JPG (300dpi)</a></li>
-      <li><a href="https://assets.mozillalabs.com/Brands-Logos/Thunderbird/wordmark-only/thunderbird-beta_wordmark-only_RGB.png" class="button-sand">PNG</a></li>
+      <li><a href="https://assets.mozilla.org/portal/assets/#asset/286" class="button-sand">EPS</a></li>
+      <li><a href="https://assets.mozilla.org/portal/assets/#asset/287" class="button-sand">JPG (300dpi)</a></li>
+      <li><a href="https://assets.mozilla.org/portal/assets/#asset/288" class="button-sand">PNG</a></li>
     </ul>
   </div>
 </section>
@@ -82,15 +82,15 @@
     <h4>Download</h4>
     <p>Wordmark + logo</p>
     <ul class="button-list">
-      <li><a href="https://assets.mozillalabs.com/Brands-Logos/Thunderbird/logo-wordmark/thunderbird-earlybird_logo-wordmark_CS4.eps" class="button-sand">EPS</a></li>
-      <li><a href="https://assets.mozillalabs.com/Brands-Logos/Thunderbird/logo-wordmark/thunderbird-earlybird_logo-wordmark_RGB-300dpi.jpg" class="button-sand">JPG (300dpi)</a></li>
-      <li><a href="https://assets.mozillalabs.com/Brands-Logos/Thunderbird/logo-wordmark/thunderbird-earlybird_logo-wordmark_RGB.png" class="button-sand">PNG</a></li>
+      <li><a href="https://assets.mozilla.org/portal/assets/#asset/280" class="button-sand">EPS</a></li>
+      <li><a href="https://assets.mozilla.org/portal/assets/#asset/281" class="button-sand">JPG (300dpi)</a></li>
+      <li><a href="https://assets.mozilla.org/portal/assets/#asset/282" class="button-sand">PNG</a></li>
     </ul>
     <p>Wordmark only</p>
     <ul class="button-list">
-      <li><a href="https://assets.mozillalabs.com/Brands-Logos/Thunderbird/wordmark-only/thunderbird-earlybird_logo-wordmark-only_CS4.eps" class="button-sand">EPS</a></li>
-      <li><a href="https://assets.mozillalabs.com/Brands-Logos/Thunderbird/wordmark-only/thunderbird-earlybird_logo-wordmark-only_RGB-300dpi.jpg" class="button-sand">JPG (300dpi)</a></li>
-      <li><a href="https://assets.mozillalabs.com/Brands-Logos/Thunderbird/wordmark-only/thunderbird-earlybird_logo-wordmark-only_RGB.png" class="button-sand">PNG</a></li>
+      <li><a href="https://assets.mozilla.org/portal/assets/#asset/292" class="button-sand">EPS</a></li>
+      <li><a href="https://assets.mozilla.org/portal/assets/#asset/293" class="button-sand">JPG (300dpi)</a></li>
+      <li><a href="https://assets.mozilla.org/portal/assets/#asset/294" class="button-sand">PNG</a></li>
     </ul>
   </div>
 </section>
@@ -108,15 +108,15 @@
     <h4>Download</h4>
     <p>Wordmark + logo</p>
     <ul class="button-list">
-      <li><a href="https://assets.mozillalabs.com/Brands-Logos/Thunderbird/logo-wordmark/thunderbird-daily_logo-wordmark_CS4.eps" class="button-sand">EPS</a></li>
-      <li><a href="https://assets.mozillalabs.com/Brands-Logos/Thunderbird/logo-wordmark/thunderbird-daily_logo-wordmark_RGB-300dpi.jpg" class="button-sand">JPG (300dpi)</a></li>
-      <li><a href="https://assets.mozillalabs.com/Brands-Logos/Thunderbird/logo-wordmark/thunderbird-daily_logo-wordmark_RGB.png" class="button-sand">PNG</a></li>
+      <li><a href="https://assets.mozilla.org/portal/assets/#asset/277" class="button-sand">EPS</a></li>
+      <li><a href="https://assets.mozilla.org/portal/assets/#asset/278" class="button-sand">JPG (300dpi)</a></li>
+      <li><a href="https://assets.mozilla.org/portal/assets/#asset/279" class="button-sand">PNG</a></li>
     </ul>
     <p>Wordmark only</p>
     <ul class="button-list">
-      <li><a href="https://assets.mozillalabs.com/Brands-Logos/Thunderbird/wordmark-only/thunderbird-daily_logo-wordmark-only_CS4.eps" class="button-sand">EPS</a></li>
-      <li><a href="https://assets.mozillalabs.com/Brands-Logos/Thunderbird/wordmark-only/thunderbird-daily_logo-wordmark-only_RGB-300dpi.jpg" class="button-sand">JPG (300dpi)</a></li>
-      <li><a href="https://assets.mozillalabs.com/Brands-Logos/Thunderbird/wordmark-only/thunderbird-daily_logo-wordmark-only_RGB.png" class="button-sand">PNG</a></li>
+      <li><a href="https://assets.mozilla.org/portal/assets/#asset/277" class="button-sand">EPS</a></li>
+      <li><a href="https://assets.mozilla.org/portal/assets/#asset/278" class="button-sand">JPG (300dpi)</a></li>
+      <li><a href="https://assets.mozilla.org/portal/assets/#asset/279" class="button-sand">PNG</a></li>
     </ul>
   </div>
 </section>

--- a/bedrock/styleguide/templates/styleguide/identity/webmaker-branding.html
+++ b/bedrock/styleguide/templates/styleguide/identity/webmaker-branding.html
@@ -30,9 +30,9 @@
     <img src="{{ static('img/styleguide/identity/webmaker/logo.png') }}" alt="Logo" />
     <h3>Download</h3>
     <ul class="button-list">
-      <li><a href="https://assets.mozillalabs.com/Brands-Logos/Webmaker/mozilla-webmaker_logo-only_CS4.eps" class="button-sand">EPS</a></li>
-      <li><a href="https://assets.mozillalabs.com/Brands-Logos/Webmaker/mozilla-webmaker_logo-only_RGB.jpg" class="button-sand">JPG (300dpi)</a></li>
-      <li><a href="https://assets.mozillalabs.com/Brands-Logos/Webmaker/mozilla-webmaker_logo-only_RGB.png" class="button-sand">PNG</a></li>
+      <li><a href="https://assets.mozilla.org/portal/assets/#asset/76" class="button-sand">EPS</a></li>
+      <li><a href="https://assets.mozilla.org/portal/assets/#asset/77" class="button-sand">JPG (300dpi)</a></li>
+      <li><a href="https://assets.mozilla.org/portal/assets/#asset/78" class="button-sand">PNG</a></li>
     </ul>
   </div>
   <p class="copyright-note"><small>The logo files containing our trademarks are available under the following copyright licenses: vector logo files under <a href="https://creativecommons.org/licenses/by-sa/3.0/">CC-BY 3.0</a> or later; bitmap logo files under <a href="http://www.mozilla.org/MPL/2.0/">MPL 2</a>.</small></p>
@@ -60,15 +60,15 @@
     <h4>Download</h4>
     <p>Wordmark + Logo</p>
     <ul class="button-list">
-      <li><a href="https://assets.mozillalabs.com/Brands-Logos/Webmaker/mozilla-webmaker_logo-wordmark_CS4.eps" class="button-sand">EPS</a></li>
-      <li><a href="https://assets.mozillalabs.com/Brands-Logos/Webmaker/mozilla-webmaker_logo-wordmark_RGB.jpg" class="button-sand">JPG (300dpi)</a></li>
-      <li><a href="https://assets.mozillalabs.com/Brands-Logos/Webmaker/mozilla-webmaker_logo-wordmark_RGB.png" class="button-sand">PNG</a></li>
+      <li><a href="https://assets.mozilla.org/portal/assets/#asset/79" class="button-sand">EPS</a></li>
+      <li><a href="https://assets.mozilla.org/portal/assets/#asset/80" class="button-sand">JPG (300dpi)</a></li>
+      <li><a href="https://assets.mozilla.org/portal/assets/#asset/81" class="button-sand">PNG</a></li>
     </ul>
     <p>Wordmark only</p>
     <ul class="button-list">
-      <li><a href="https://assets.mozillalabs.com/Brands-Logos/Webmaker/mozilla-webmaker_wordmark-only_CS4.eps" class="button-sand">EPS</a></li>
-      <li><a href="https://assets.mozillalabs.com/Brands-Logos/Webmaker/mozilla-webmaker_wordmark-only_RGB.jpg" class="button-sand">JPG (300dpi)</a></li>
-      <li><a href="https://assets.mozillalabs.com/Brands-Logos/Webmaker/mozilla-webmaker_wordmark-only_RGB.png" class="button-sand">PNG</a></li>
+      <li><a href="https://assets.mozilla.org/portal/assets/#asset/82" class="button-sand">EPS</a></li>
+      <li><a href="https://assets.mozilla.org/portal/assets/#asset/83" class="button-sand">JPG (300dpi)</a></li>
+      <li><a href="https://assets.mozilla.org/portal/assets/#asset/84" class="button-sand">PNG</a></li>
     </ul>
   </div>
 </section>

--- a/bedrock/styleguide/templates/styleguide/products/firefox-os/action-icons.html
+++ b/bedrock/styleguide/templates/styleguide/products/firefox-os/action-icons.html
@@ -253,29 +253,29 @@ as in the following examples.') }}</p>
 <section id="downloads">
   <div class="intro">
     <h2>{{ _('Download') }}</h2>
-    <p>{% trans link='href="https://assets.mozillalabs.com/Projects/Firefox%20OS/UX/VsD/v01.0/Action%20Icon%20Templates/PNG/"'|safe %}
+    <p>{% trans link='href="https://assets.mozilla.org/portal/assets/#category/183"'|safe %}
     Download Firefox OS action icons in Photoshop or PNG format, or <a {{link}}>download individual icons</a>.
     {% endtrans %}</p>
   </div>
   <div class="download-group" id="download-primary">
     <h5>{{ _("Primary action icons") }}</h5>
     <ul class="button-list">
-      <li><a href="https://assets.mozillalabs.com/Projects/Firefox%20OS/UX/VsD/v01.0/Action%20Icon%20Templates/PSD/IconsPrimaryAction_20130305.psd" class="button-sand">{{ _('PSD') }}</a></li>
-      <li><a href="https://assets.mozillalabs.com/Projects/Firefox%20OS/UX/VsD/v01.0/Action%20Icon%20Templates/PNG/IconsPrimaryAction_20130305.png" class="button-sand">{{ _('PNG') }}</a></li>
+      <li><a href="https://assets.mozilla.org/portal/assets/#asset/588" class="button-sand">{{ _('PSD') }}</a></li>
+      <li><a href="https://assets.mozilla.org/portal/assets/#asset/585" class="button-sand">{{ _('PNG') }}</a></li>
     </ul>
   </div>
   <div class="download-group" id="download-communication">
     <h5>{{ _("Communication action icons") }}</h5>
     <ul class="button-list">
-      <li><a href="https://assets.mozillalabs.com/Projects/Firefox%20OS/UX/VsD/v01.0/Action%20Icon%20Templates/PSD/IconsCommunications_20130305.psd" class="button-sand">{{ _('PSD') }}</a></li>
-      <li><a href="https://assets.mozillalabs.com/Projects/Firefox%20OS/UX/VsD/v01.0/Action%20Icon%20Templates/PNG/IconsCommunications_20130305.png" class="button-sand">{{ _('PNG') }}</a></li>
+      <li><a href="https://assets.mozilla.org/portal/assets/#asset/586" class="button-sand">{{ _('PSD') }}</a></li>
+      <li><a href="https://assets.mozilla.org/portal/assets/#asset/583" class="button-sand">{{ _('PNG') }}</a></li>
     </ul>
   </div>
   <div class="download-group" id="download-media">
     <h5>{{ _("Media action icons") }}</h5>
     <ul class="button-list">
-      <li><a href="https://assets.mozillalabs.com/Projects/Firefox%20OS/UX/VsD/v01.0/Action%20Icon%20Templates/PSD/IconsMedia_20130305.psd" class="button-sand">{{ _('PSD') }}</a></li>
-      <li><a href="https://assets.mozillalabs.com/Projects/Firefox%20OS/UX/VsD/v01.0/Action%20Icon%20Templates/PNG/IconsMedia_20130305.png" class="button-sand">{{ _('PNG') }}</a></li>
+      <li><a href="https://assets.mozilla.org/portal/assets/#asset/587" class="button-sand">{{ _('PSD') }}</a></li>
+      <li><a href="https://assets.mozilla.org/portal/assets/#asset/584" class="button-sand">{{ _('PNG') }}</a></li>
     </ul>
   </div>
 </section>

--- a/bedrock/styleguide/templates/styleguide/products/firefox-os/icons.html
+++ b/bedrock/styleguide/templates/styleguide/products/firefox-os/icons.html
@@ -197,30 +197,30 @@ as in the following examples.</p>
   <div class="download-group" id="icon-circle">
     <p>Icon (circle)</p>
     <ul class="button-list">
-      <li><a href="https://assets.mozillalabs.com/Projects/Firefox%20OS/UX/VsD/v01.0/Icon%20App%20Templates/PSD/MozillaFXOSIconTemplate1.psd" class="button-sand">PSD</a></li>
-      <li><a href="https://assets.mozillalabs.com/Projects/Firefox%20OS/UX/VsD/v01.0/Icon%20App%20Templates/PNG/MozillaFXOSIconTemplate1.png" class="button-sand">PNG</a></li>
-      <li><a href="https://assets.mozillalabs.com/Projects/Firefox%20OS/UX/VsD/v01.0/Icon%20App%20Templates/PNG/MozillaFXOSIconTemplate1_overlay.png" class="button-sand">PNG (overlay)</a></li>
+      <li><a href="https://assets.mozilla.org/portal/assets/#asset/597" class="button-sand">PSD</a></li>
+      <li><a href="https://assets.mozilla.org/portal/assets/#asset/592" class="button-sand">PNG</a></li>
+      <li><a href="https://assets.mozilla.org/portal/assets/#asset/593" class="button-sand">PNG (overlay)</a></li>
     </ul>
   </div>
   <div class="download-group" id="icon-rounded">
     <p>Icon (rounded)</p>
     <ul class="button-list">
-      <li><a href="https://assets.mozillalabs.com/Projects/Firefox%20OS/UX/VsD/v01.0/Icon%20App%20Templates/PSD/MozillaFXOSIconTemplate2.psd" class="button-sand">PSD</a></li>
-      <li><a href="https://assets.mozillalabs.com/Projects/Firefox%20OS/UX/VsD/v01.0/Icon%20App%20Templates/PNG/MozillaFXOSIconTemplate2.png" class="button-sand">PNG</a></li>
+      <li><a href="https://assets.mozilla.org/portal/assets/#asset/598" class="button-sand">PSD</a></li>
+      <li><a href="https://assets.mozilla.org/portal/assets/#asset/594" class="button-sand">PNG</a></li>
     </ul>
   </div>
   <div class="download-group" id="icon-square">
     <p>Icon (square)</p>
     <ul class="button-list">
-      <li><a href="https://assets.mozillalabs.com/Projects/Firefox%20OS/UX/VsD/v01.0/Icon%20App%20Templates/PSD/MozillaFXOSIconTemplate3.psd" class="button-sand">PSD</a></li>
-      <li><a href="https://assets.mozillalabs.com/Projects/Firefox%20OS/UX/VsD/v01.0/Icon%20App%20Templates/PNG/MozillaFXOSIconTemplate3.png" class="button-sand">PNG</a></li>
+      <li><a href="hhttps://assets.mozilla.org/portal/assets/#asset/599" class="button-sand">PSD</a></li>
+      <li><a href="https://assets.mozilla.org/portal/assets/#asset/595" class="button-sand">PNG</a></li>
     </ul>
   </div>
   <div class="download-group" id="icon-grid">
     <p>Icon grid</p>
     <ul class="button-list">
-      <li><a href="https://assets.mozillalabs.com/Projects/Firefox%20OS/UX/VsD/v01.0/Icon%20App%20Templates/PSD/MozillaFXOSIconGrid.psd" class="button-sand">PSD</a></li>
-      <li><a href="https://assets.mozillalabs.com/Projects/Firefox%20OS/UX/VsD/v01.0/Icon%20App%20Templates/PNG/MozillaFXOSIconGrid.png" class="button-sand">PNG</a></li>
+      <li><a href="https://assets.mozilla.org/portal/assets/#asset/596" class="button-sand">PSD</a></li>
+      <li><a href="https://assets.mozilla.org/portal/assets/#asset/591" class="button-sand">PNG</a></li>
     </ul>
   </div>
 </section>

--- a/bedrock/styleguide/templates/styleguide/websites/sandstone-buttons.html
+++ b/bedrock/styleguide/templates/styleguide/websites/sandstone-buttons.html
@@ -59,7 +59,7 @@
     <h2>Icon style</h2>
     <div>
       <p>Our icons use simple shapes with a distinct embossed effect. Their alternate state features a bold color with subtle gradient. You can download these examples below, along with the layer styles, which you can apply to your own icon designs.</p>
-      <a href="https://assets.mozillalabs.com/Websites/Sandstone/Default%20Icons/marketplace-icons-singles.psd" class="button-sand">Download default PSD styles</a>
+      <a href="https://assets.mozilla.org/portal/assets/#asset/411" class="button-sand">Download default PSD styles</a>
     </div>
   </div>
   <div class="examples">

--- a/bedrock/styleguide/templates/styleguide/websites/sandstone-colors.html
+++ b/bedrock/styleguide/templates/styleguide/websites/sandstone-colors.html
@@ -18,7 +18,7 @@
     <h2>Backgrounds</h2>
     <div>
       <p>These are the default colors and gradients for Mozilla and Firefox sites, along with a few alternates. They are guidelines only, not absolute rules. You can create different color variations within Sandstone as your project or site warrants.</p>
-      <p>The gradients shown are layered behind a default grain texture, which you can <a href="https://assets.mozillalabs.com/Websites/Sandstone/Backgrounds/">download here</a>.</p>
+      <p>The gradients shown are layered behind a default grain texture, which you can <a href="https://assets.mozilla.org/portal/assets/#category/110">download here</a>.</p>
     </div>
   </div>
   <div class="examples">

--- a/bedrock/styleguide/templates/styleguide/websites/sandstone-grids.html
+++ b/bedrock/styleguide/templates/styleguide/websites/sandstone-grids.html
@@ -59,9 +59,9 @@
 <div id="grid-downloads">
   <h4>Download PSDs</h4>
   <ul class="button-list">
-    <li><a href="https://assets.mozillalabs.com/Websites/Sandstone/Default%20PSDs/desktop-60-20-12c-990px.psd" class="button-sand">Desktop</a></li>
-    <li><a href="https://assets.mozillalabs.com/Websites/Sandstone/Default%20PSDs/tablet-40-20-12c-768px.psd" class="button-sand">Tablet</a></li>
-    <li><a href="https://assets.mozillalabs.com/Websites/Sandstone/Default%20PSDs/smartphone-40-20-5c-320px.psd" class="button-sand">Phone</a></li>
+    <li><a href="https://assets.mozilla.org/portal/assets/#asset/414" class="button-sand">Desktop</a></li>
+    <li><a href="https://assets.mozilla.org/portal/assets/#asset/416" class="button-sand">Tablet</a></li>
+    <li><a href="https://assets.mozilla.org/portal/assets/#asset/415" class="button-sand">Phone</a></li>
   </ul>
 </div>
 </section>


### PR DESCRIPTION
Updated the links in the html templates  that pointed towards
assets.mozillalabs.org to point to assets.mozilla.org but to new urls
as the final part of fixing this issue.