### PR TITLE
Bug 1137904 mwc page headlines

### DIFF
--- a/bedrock/firefox/templates/firefox/os/mwc-2015-preview.html
+++ b/bedrock/firefox/templates/firefox/os/mwc-2015-preview.html
@@ -65,6 +65,27 @@
     </div>
   </section>
 
+  <section id="news">
+    <div class="container">
+      <div class="left">
+        <h3>{{ _('In the news') }}</h3>
+        <a href="">{{ _('See all press') }}</a>
+      </div>
+
+      <div class="right">
+      {% set feed_links = firefox_os_feed_links(LANG) %}
+      {% if feed_links %}
+        <ul>
+        {% for link, title in feed_links[:3] %}
+          <li><a rel="external" href="{{ link }}">{{ title }}</a></li>
+        {% endfor %}
+        </ul>
+      {% endif %}
+        </ul>
+      </div>
+    </div>
+  </section>
+
   <section id="info">
     <div class="container">
       <h3>{{ _('Be part of our growing family of partners') }}</h3>

--- a/bedrock/firefox/templates/firefox/os/mwc-2015-preview.html
+++ b/bedrock/firefox/templates/firefox/os/mwc-2015-preview.html
@@ -69,7 +69,7 @@
     <div class="container">
       <div class="left">
         <h3>{{ _('In the news') }}</h3>
-        <a href="">{{ _('See all press') }}</a>
+        <a href="https://blog.mozilla.org/press/category/firefox-os/">{{ _('See all press') }}</a>
       </div>
 
       <div class="right">

--- a/media/css/firefox/os/mwc-2015-preview.less
+++ b/media/css/firefox/os/mwc-2015-preview.less
@@ -128,6 +128,49 @@ html, body {
     }
 }
 
+#news {
+    position: relative;
+    background: #fff;
+    padding: (@baseLine * 3) 0;
+
+    .container {
+        .clearfix();
+    }
+
+    h3 {
+        .font-size(48px);
+    }
+
+    a {
+        color: #2bb8a0;
+        .trailing-arrow();
+    }
+
+    .left,
+    .right {
+        float: left;
+        width: 50%;
+    }
+
+    .left a {
+        .font-size(@largeFontSize);
+    }
+
+    ul {
+        margin: 0;
+    }
+
+    li {
+        list-style-type: none;
+        margin: 0 0 @baseLine;
+
+        a {
+            .font-size(20px);
+            font-style: italic;
+        }
+    }
+}
+
 #info {
     position: relative;
     background: #eaeff2;
@@ -550,6 +593,28 @@ html, body {
         }
     }
 
+    #news {
+        text-align: center;
+
+        h3 {
+            .font-size(28px);
+        }
+
+        .left,
+        .right {
+            float: none;
+            width: auto;
+        }
+
+        ul {
+            margin-top: @baseLine * 2;
+        }
+
+        li a {
+            .font-size(@largeFontSize);
+        }
+    }
+
     #info {
         h3 {
             .font-size(28px);
@@ -672,6 +737,28 @@ html, body {
             height: 166px;
             left: 8px;
             top: 121px;
+        }
+    }
+
+    #news {
+        text-align: center;
+
+        h3 {
+            .font-size(28px);
+        }
+
+        .left,
+        .right {
+            float: none;
+            width: auto;
+        }
+
+        ul {
+            margin-top: @baseLine * 2;
+        }
+
+        li a {
+            .font-size(@largeFontSize);
         }
     }
 


### PR DESCRIPTION
This replaces #2791. It turns out the "All press" link can be en-US only, since this page isn't localized.