### PR TITLE
Bug 1120686 Fix overlaping menus

### DIFF
--- a/media/css/firefox/partners.less
+++ b/media/css/firefox/partners.less
@@ -202,7 +202,7 @@
 
 #partner-nav {
     position: absolute;
-    z-index: 1000;
+    z-index: 9;
     top: 20px;
     left: 50%;
     width: auto;
@@ -878,7 +878,6 @@
 
     #partner-nav {
         position: absolute;
-        z-index: 1000;
         top: 60px;
         left: 50%;
         padding: 0 10px;


### PR DESCRIPTION
Mobile partners nav was overlapping family nav submneu due to excessive z-index

See: https://bug1120686.bugzilla.mozilla.org/attachment.cgi?id=8570829&t=7CniihHlyO