### PR TITLE
Update static files, product-details, and external files in SRC dir.

### DIFF
--- a/bin/update/deploy_base.py
+++ b/bin/update/deploy_base.py
@@ -32,10 +32,11 @@ def pre_update(ctx, ref=settings.UPDATE_REF):
 
 @task
 def update(ctx):
+    commands['update_assets']()
     commands['update_revision_file']()
+    # moves files from SRC_DIR to WWW_DIR
     commands['checkin_changes']()
     commands['database']()
-    commands['update_assets']()
     if 'update_cron' in commands:
         commands['update_cron']()
         commands['reload_crond']()
@@ -77,9 +78,9 @@ def update_code(ctx, tag):
 @task
 def update_assets(ctx):
     """Compile/compress static assets and fetch external data."""
-    management_cmd(ctx, 'collectstatic --noinput')
-    management_cmd(ctx, 'update_product_details')
-    management_cmd(ctx, 'update_externalfiles')
+    management_cmd(ctx, 'collectstatic --noinput', use_src_dir=True)
+    management_cmd(ctx, 'update_product_details', use_src_dir=True)
+    management_cmd(ctx, 'update_externalfiles', use_src_dir=True)
 
 
 @task


### PR DESCRIPTION
This will keep older static files around so that pushes _should_ be
less error prone.