### PR TITLE
Fix bug 1138169 - MWC partner logo updates

### DIFF
--- a/bedrock/firefox/templates/firefox/os/mwc-2015-preview.html
+++ b/bedrock/firefox/templates/firefox/os/mwc-2015-preview.html
@@ -103,6 +103,7 @@
         <li>{{ high_res_img('img/firefox/os/mwc-2015-preview/partners/huawei.png', {'alt': 'Huawei', 'width': '220', 'height': '100'}) }}</li>
         <li>{{ high_res_img('img/firefox/os/mwc-2015-preview/partners/intex.png', {'alt': 'Intex', 'width': '220', 'height': '100'}) }}</li>
         <li>{{ high_res_img('img/firefox/os/mwc-2015-preview/partners/kddi.png', {'alt': 'KDDI', 'width': '220', 'height': '100'}) }}</li>
+        <li>{{ high_res_img('img/firefox/os/mwc-2015-preview/partners/lg.png', {'alt': 'LG', 'width': '220', 'height': '100'}) }}</li>
         <li>{{ high_res_img('img/firefox/os/mwc-2015-preview/partners/megafon.png', {'alt': 'MegaFon', 'width': '220', 'height': '100'}) }}</li>
         <li>{{ high_res_img('img/firefox/os/mwc-2015-preview/partners/panasonic.png', {'alt': 'Panasonic', 'width': '220', 'height': '100'}) }}</li>
         <li>{{ high_res_img('img/firefox/os/mwc-2015-preview/partners/qualcomm.png', {'alt': 'Qualcomm', 'width': '220', 'height': '100'}) }}</li>
@@ -114,7 +115,6 @@
         <li>{{ high_res_img('img/firefox/os/mwc-2015-preview/partners/telenor.png', {'alt': 'Telenor', 'width': '220', 'height': '100'}) }}</li>
         <li>{{ high_res_img('img/firefox/os/mwc-2015-preview/partners/zen-mobile.png', {'alt': 'ZEN Mobile', 'width': '220', 'height': '100'}) }}</li>
         <li>{{ high_res_img('img/firefox/os/mwc-2015-preview/partners/zte.png', {'alt': 'ZTE', 'width': '220', 'height': '100'}) }}</li>
-        <li>{{ high_res_img('img/firefox/os/mwc-2015-preview/partners/lg.png', {'alt': 'LG', 'width': '220', 'height': '100'}) }}</li>
       </ul>
 
       <h3>{{ _('Here’s how') }}</h3>

--- a/media/css/firefox/os/mwc-2015-preview.less
+++ b/media/css/firefox/os/mwc-2015-preview.less
@@ -636,6 +636,7 @@ html, body {
 
         #list-partners li {
             .span-all();
+            margin-bottom: @baseLine;
         }
 
         #list-how {
@@ -799,7 +800,12 @@ html, body {
         }
 
         #list-partners li {
-            .span-all();
+            .span_narrow(3.5);
+            margin-bottom: @baseLine;
+
+            img {
+                height: auto;
+            }
         }
 
         #list-platform li {


### PR DESCRIPTION
* Move LG into alphabetical order.
* Add bottom margins between logos on mobile.
* Arrange logos two per row for wide mobile.