### PR TITLE
Bug 1120700 - Fx OS consumer page: restore page title on old template

### DIFF
--- a/bedrock/firefox/templates/firefox/os/index.html
+++ b/bedrock/firefox/templates/firefox/os/index.html
@@ -7,8 +7,8 @@
 {% add_lang_files "firefox/os/devices" %}
 
 {% block page_title_prefix %}{% endblock %}
-{% block page_title %}{{_('Firefox OS — Just what you need — Great smartphone features, apps and more — Mozilla')}}{% endblock %}
-{% block page_desc %}{{_('Firefox OS is designed to give you just what you need, just when you need it. It comes with apps for all you do and you can download more of your favorites from the Firefox Marketplace. Smart has never been so simple.')}}{% endblock %}
+{% block page_title %}{{_('Firefox OS — The Adaptive Phone — Great Smartphone Features, Apps and More')}}{% endblock %}
+{% block page_desc %}{{_('Firefox OS smartphones give you great adaptive features and apps that let you live every moment to its fullest and build a brighter future for the Web.')}}{% endblock %}
 
 {% block body_id %}firefox-os{% endblock %}
 {% block body_class %}firefox-os{% endblock %}


### PR DESCRIPTION
The title was changed for the old template, not the new one.

At this point we can't add the new one to the new template without breaking all locales (strings are missing). I suggest waiting for the next update of the page to fix it, since it shouldn't be too far ahead.

This PR restores the existing title for the old template: for locales using the old template, we're currently showing English text.