### PR TITLE
Replace history when languages are filtered on download pages, instead of appending (Bug 1134936 follow-up)

### DIFF
--- a/media/js/firefox/firefox-language-search.js
+++ b/media/js/firefox/firefox-language-search.js
@@ -18,9 +18,18 @@
 
         function filter (e) {
             e.preventDefault();
+
+            var historyEnabled = typeof history.replaceState === 'function' && e.originalEvent;
             var search_q = $.trim($input.val());  // trim whitespace
+
             if (!search_q) {
                 show_all();
+
+                // Replace the browser history to clear the search query
+                if (historyEnabled) {
+                    history.replaceState({}, document.title, '.');
+                }
+
                 return;
             }
 
@@ -56,9 +65,9 @@
             });
 
             // Replace the browser history to save the search query
-            if (typeof history.pushState === 'function' && e.originalEvent) {
-                history.pushState({ query: search_q }, document.title,
-                                  '?q=' + encodeURI(search_q));
+            if (historyEnabled) {
+                history.replaceState({ query: search_q }, document.title,
+                                     '?q=' + encodeURI(search_q));
             }
         }
 


### PR DESCRIPTION
A UX improvement to follow up #2756 that implemented incremental language search on the Firefox download pages.

I have noticed that I cannot go back to the previous page after filtering, because a new history entry is added as I type. It’s actually annoying. It may be better to use `history.replaceState` rather than `history.pushState`. Also, the query param should be removed when the search term is cleared.