### PR TITLE
Bug 1142510 - Update credits FAQ to fix inaccuracies and bad URL

### DIFF
--- a/bedrock/mozorg/templates/mozorg/credits-faq.html
+++ b/bedrock/mozorg/templates/mozorg/credits-faq.html
@@ -19,7 +19,7 @@
 
 <h1>Credits FAQ</h1>
 
-<p>The appropriate giving of credit can be a controversial subject in free software projects. At Mozilla, for our code products, we do it with a <a href="{{ url('mozorg.credits') }}">single global credits list</a>.</p>
+<p>The appropriate giving of credit can be a controversial subject in free software projects. At Mozilla, we do it with a <a href="{{ url('mozorg.credits') }}">single global credits list</a>.</p>
 
 <p>This document explains a bit about how we process applications. The overarching principle is that as far as possible everyone who applies to be included should be treated equally, no matter in what way they contributed, or who they work for.</p>
 
@@ -41,7 +41,7 @@
 
 <h2>How do I get added?</h2>
 
-<p>See the bottom of <a href="{{ url('mozorg.credits') }}">about:credits</a>, and click the email link there. Remember to include a citation.</p>
+<p>See the bottom of <a href="{{ url('mozorg.credits') }}">about:credits</a>, and click the link there. Remember to include a citation.</p>
 
 <p>It is possible to nominate someone else for inclusion, but we encourage people to nominate themselves. There are several good reasons for this - they can confirm they are not the same Dave Jones who is already on there, they can tell us (for more complex names) how they like to be sorted, and they can write their own citation. So if you know someone who you think should be on the list, tell them about it.</p>
 
@@ -51,7 +51,7 @@
 
 <h2>When will I get added, and how do I know?</h2>
 
-<p>Additions are normally done in batches, a few months apart. You will receive an email when your name is added, or requesting more information if there has been a problem with your application (e.g. additional verification is needed). When you have been added, you will see your name and citation in <a href="http://viewvc.svn.mozilla.org/vc/projects/mozilla.org/trunk/credits/index.html?view=log">the log</a>.</p>
+<p>Additions are normally done in batches, a few months apart. You will receive an email when your name is added, or requesting more information if there has been a problem with your application (e.g. additional verification is needed). When you have been added, you will see your name and citation in <a href="http://viewvc.svn.mozilla.org/vc/projects/mozilla.org/trunk/credits/names.csv?view=log">the log</a>.</p>
 
 </div>
 


### PR DESCRIPTION
index.html in SVN no longer gets updated per-checkin, so the URL to see recent checkins is wrong. Also a few textual updates.