### PR TITLE
Fix bug 1142850: Add cron job to update external files hourly.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ python:
 env:
   global:
     - PIP_DOWNLOAD_CACHE="pip_cache"
-    - CRON_LOG_DIR="/tmp/bedrock-cron-log"
 branches:
   only:
     - master

--- a/bedrock/externalfiles/management/commands/update_externalfiles.py
+++ b/bedrock/externalfiles/management/commands/update_externalfiles.py
@@ -22,13 +22,19 @@ class Command(BaseCommand):
                     dest='quiet',
                     default=False,
                     help='Do not print output to stdout.'),
+        make_option('--status',
+                    action='store_true',
+                    dest='status',
+                    default=False,
+                    help='Print only a final status to stdout. Mostly for scripts.')
     )
 
     def handle(self, *args, **options):
         file_ids = args or settings.EXTERNAL_FILES.keys()
+        updated = False
 
         def printout(msg, ending=None):
-            if not options['quiet']:
+            if not (options['quiet'] or options['status']):
                 self.stdout.write(msg, ending=ending)
 
         for fid in file_ids:
@@ -42,4 +48,11 @@ class Command(BaseCommand):
             if result is None:
                 printout('already up-to-date')
             else:
+                updated = True
                 printout('done')
+
+        if options['status']:
+            if updated:
+                self.stdout.write('updated')
+            else:
+                self.stdout.write('up-to-date')

--- a/bedrock/mozorg/tests/test_credits.py
+++ b/bedrock/mozorg/tests/test_credits.py
@@ -13,6 +13,7 @@ from bedrock.mozorg.tests import TestCase
 class TestCredits(TestCase):
     def setUp(self):
         self.credits_file = credits.CreditsFile('credits')
+        self.credits_file.clear_cache()
 
     def test_credits_list(self):
         self.credits_file.readlines = Mock(return_value=[

--- a/bin/update-scripts/prod/update-externalfiles.sh
+++ b/bin/update-scripts/prod/update-externalfiles.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+cd /data/bedrock/src/www.mozilla.org-django
+
+return_value=$(venv/bin/python bedrock/manage.py update_externalfiles --status)
+
+if [ "$return_value" = "updated" ]; then
+    # file was updated, deploy
+    /data/bedrock/deploy www.mozilla.org-django/bedrock/bedrock/externalfiles/files_cache > /dev/null
+    echo "Successfully updated externalfiles."
+fi

--- a/bin/update-scripts/stage/update-externalfiles.sh
+++ b/bin/update-scripts/stage/update-externalfiles.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+cd /data/bedrock-stage/src/www.allizom.org-django
+
+return_value=$(venv/bin/python bedrock/manage.py update_externalfiles --status)
+
+if [ "$return_value" = "updated" ]; then
+    # file was updated, deploy
+    /data/bedrock/deploy www.allizom.org-django/bedrock/bedrock/externalfiles/files_cache > /dev/null
+    echo "Successfully updated externalfiles."
+fi

--- a/bin/update/deploy_base.py
+++ b/bin/update/deploy_base.py
@@ -19,6 +19,7 @@ NEW_RELIC_API_KEY = getattr(settings, 'NEW_RELIC_API_KEY', None)
 NEW_RELIC_APP_ID = getattr(settings, 'NEW_RELIC_APP_ID', None)
 NEW_RELIC_URL = 'https://rpm.newrelic.com/deployments.xml'
 GITHUB_URL = 'https://github.com/mozilla/bedrock/compare/{oldrev}...{newrev}'
+CRON_LOG_DIR = '/var/log/bedrock'
 
 
 # ########## Commands run by chief ##############
@@ -212,8 +213,9 @@ def generate_desc(from_commit, to_commit, changelog):
 
 def generate_cron_file(ctx, tmpl_name):
     with ctx.lcd(settings.WWW_DIR):
-        ctx.local("{python} bin/gen-crons.py -p {python} -s {src_dir} -w {www_dir} "
+        ctx.local("{python} bin/gen-crons.py -p {python} -s {src_dir} -w {www_dir} -l {log_dir}"
                   "-t {template}".format(python=PYTHON,
                                          src_dir=settings.SRC_DIR,
                                          www_dir=settings.WWW_DIR,
+                                         log_dir=CRON_LOG_DIR,
                                          template=tmpl_name))

--- a/etc/cron.d/bedrock-prod.tmpl
+++ b/etc/cron.d/bedrock-prod.tmpl
@@ -10,6 +10,9 @@ MAILTO="webops-cron@mozilla.com,cron-bedrock@mozilla.com"
 */10 * * * * {{ user }} {{ source }}/bin/update-scripts/prod/update-prod-php.sh {{ log }}
 */15 * * * * {{ user }} {{ source }}/bin/update-scripts/prod/update-prod-locale-cron.sh {{ log }}
 
+# bug 1142850
+0    * * * * {{ user }} {{ source }}/bin/update-scripts/prod/update-externalfiles.sh {{ log }}
+
 */5  * * * * {{ django_manage }} rnasync {{ log }}
 
 # bug 996144 & 1014586

--- a/etc/cron.d/bedrock-stage.tmpl
+++ b/etc/cron.d/bedrock-stage.tmpl
@@ -10,6 +10,9 @@ MAILTO="webops-cron@mozilla.com,cron-bedrock@mozilla.com"
 */10 * * * * {{ user }} {{ source }}/bin/update-scripts/stage/update-stage-php.sh {{ log }}
 */15 * * * * {{ user }} {{ source }}/bin/update-scripts/stage/update-stage-locale.sh {{ log }}
 
+# bug 1142850
+0    * * * * {{ user }} {{ source }}/bin/update-scripts/stage/update-externalfiles.sh {{ log }}
+
 */5  * * * * {{ django_manage }} rnasync {{ log }}
 
 # bug 996144


### PR DESCRIPTION
Also alter the `gen-crons.py` script to have an option to disable creation of the log dir for local test runs. This still runs the check when testing while there is a value in the env var CRON_LOG_DIR, so Travis will still hit that branch of the code.