### PR TITLE
Move Clacks-Overhead handling to bedrock.

### DIFF
--- a/bedrock/mozorg/middleware.py
+++ b/bedrock/mozorg/middleware.py
@@ -60,3 +60,12 @@ class CrossOriginResourceSharingMiddleware(object):
             if re.search(pattern, request.path):
                 response['Access-Control-Allow-Origin'] = origin
         return response
+
+
+class ClacksOverheadMiddleware(object):
+    # bug 1144901
+    @staticmethod
+    def process_response(request, response):
+        if response.status_code == 200:
+            response['X-Clacks-Overhead'] = 'GNU Terry Pratchett'
+        return response

--- a/bedrock/mozorg/tests/test_middleware.py
+++ b/bedrock/mozorg/tests/test_middleware.py
@@ -3,8 +3,30 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 from django.http import HttpRequest, HttpResponse
 
-from bedrock.mozorg.middleware import CrossOriginResourceSharingMiddleware
+from bedrock.mozorg.middleware import (ClacksOverheadMiddleware,
+                                       CrossOriginResourceSharingMiddleware)
 from bedrock.mozorg.tests import TestCase
+
+
+class TestClacksOverheadMiddleware(TestCase):
+    def setUp(self):
+        self.middleware = ClacksOverheadMiddleware()
+        self.request = HttpRequest()
+        self.response = HttpResponse()
+
+    def test_good_response_has_header(self):
+        self.response.status_code = 200
+        self.middleware.process_response(self.request, self.response)
+        self.assertEqual(self.response['X-Clacks-Overhead'], 'GNU Terry Pratchett')
+
+    def test_other_response_has_no_header(self):
+        self.response.status_code = 301
+        self.middleware.process_response(self.request, self.response)
+        self.assertNotIn('X-Clacks-Overhead', self.response)
+
+        self.response.status_code = 404
+        self.middleware.process_response(self.request, self.response)
+        self.assertNotIn('X-Clacks-Overhead', self.response)
 
 
 class TestCrossOriginResourceSharingMiddleware(TestCase):

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -1866,6 +1866,7 @@ MIDDLEWARE_CLASSES = (
     'django_statsd.middleware.GraphiteMiddleware',
     'bedrock.tabzilla.middleware.TabzillaLocaleURLMiddleware',
     'commonware.middleware.RobotsTagHeader',
+    'bedrock.mozorg.middleware.ClacksOverheadMiddleware',
 ) + get_middleware(exclude=(
     'funfactory.middleware.LocaleURLMiddleware',
     'multidb.middleware.PinningRouterMiddleware',

--- a/etc/httpd/global.conf
+++ b/etc/httpd/global.conf
@@ -2,11 +2,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-# bug 1144901
-<IfModule headers_module>
-  header set X-Clacks-Overhead "GNU Terry Pratchett"
-</IfModule>
-
 # Static Media
 RewriteRule ^/media/(.*)$ /b/media/$1 [L,PT]
 


### PR DESCRIPTION
Also only include the header when response is a 200
and for a page.