### PR TITLE
Make contribute.json participate.home more useful.

### DIFF
--- a/contribute.json
+++ b/contribute.json
@@ -7,7 +7,7 @@
         "tests": "https://travis-ci.org/mozilla/bedrock/"
     },
     "participate": {
-        "home": "https://wiki.mozilla.org/Mozilla.org",
+        "home": "https://wiki.mozilla.org/Webdev/GetInvolved/mozilla.org",
         "docs": "http://bedrock.readthedocs.org/",
         "mailing-list": "https://www.mozilla.org/about/forums/#dev-mozilla-org",
         "irc": "irc://irc.mozilla.org/#www",


### PR DESCRIPTION
Looking at @Osmose's awesome new https://mozilla.github.io/webdev/ it's clear that our old url for `participate.home` isn't that useful. This should be better.