### PR TITLE
Fix Bug 1133780 - Update social sharing on firefox/sms

### DIFF
--- a/bedrock/firefox/templates/firefox/android/sms-thankyou.html
+++ b/bedrock/firefox/templates/firefox/android/sms-thankyou.html
@@ -6,6 +6,12 @@
 
 {% block extra_meta %}<meta name="robots" content="noindex">{% endblock %}
 
+{% block site_header_share %}
+  {% set share_urls = { 'twitter': 'http://mzl.la/1wuPaWo', 'googleplus': 'http://mzl.la/1DhUfhK', 'facebook': 'http://mzl.la/185Xdgo' } -%}
+  {% set share_text = _('For faster, better mobile browsing on your Android device, get Firefox for free today.') %}
+  {{ share_cta(_('Share'), share_urls, share_text, 'spread-firefox-android', 'sky mini') }}
+{% endblock %}
+
 {% block content %}
 
 <div id="main-feature">
@@ -27,10 +33,6 @@
         data-overlay-hidden-text="{{_('Play video')}}">
         <source src="//videos.cdn.mozilla.net/serv/marketing/fxforandroid/10-07-12_firefox_for_android_american-640x360 Video Sharing.webm">
       </video>
-    </div>
-
-    <div class="share">
-      {% include 'firefox/includes/social-share.html' %}
     </div>
 
   </div>

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -389,7 +389,7 @@ PIPELINE_CSS = {
     'firefox_sms': {
         'source_filenames': (
             'css/sandstone/sandstone-resp.less',
-            'css/libs/socialshare/socialshare.less',
+            'css/base/mozilla-share-cta.less',
             'css/firefox/template-resp.less',
             'css/sandstone/video-resp.less',
             'css/firefox/mobile-sms.less',
@@ -1498,7 +1498,7 @@ PIPELINE_JS = {
     'firefox_sms': {
         'source_filenames': (
             'js/firefox/sms.js',
-            'js/libs/socialshare.min.js',
+            'js/base/mozilla-share-cta.js',
         ),
         'output_filename': 'js/firefox_sms-bundle.js',
     },

--- a/media/css/firefox/mobile-sms.less
+++ b/media/css/firefox/mobile-sms.less
@@ -175,18 +175,13 @@
   margin: 1em 0 2em;
 }
 
-#sms-send .also,
-#sms-sent .share {
+#sms-send .also {
   .open-sans-light;
   clear: both;
   .font-size(1em);
   font-style: italic;
   padding: 20px 140px 0 0;
   border-top: 1px dotted #ccc;
-}
-
-#sms-sent .share {
-  padding-right: 0;
 }
 
 .also a:link,
@@ -238,15 +233,6 @@
   padding: 20px;
   border: 1px solid #efefef;
   box-shadow: inset 0 0 6px rgba(0,0,0,.05);
-}
-
-#mobile-sms #share-options {
-  background: #f8fafb;
-}
-
-.socialshare {
-  float: right;
-  margin: 0;
 }
 
 a.mozilla-video-control-overlay {


### PR DESCRIPTION
Replacing the current Share widget with the new one. This page is en-US only, no l10n required.
https://www.mozilla.org/en-US/firefox/sms/sent/