### PR TITLE
Update Tabzilla document to recommend using https, not protocol relative URLs

### DIFF
--- a/docs/tabzilla.rst
+++ b/docs/tabzilla.rst
@@ -19,15 +19,15 @@ Adding the universal tab to a site requires:
 
 2. Include the tabzilla CSS by adding the following tag inside the ``<head>`` of your template::
 
-    <link href="//mozorg.cdn.mozilla.net/media/css/tabzilla-min.css" rel="stylesheet" />
+    <link href="https://mozorg.cdn.mozilla.net/media/css/tabzilla-min.css" rel="stylesheet" />
 
 3. Include the tabzilla.js file in your template (preferably just before the ``</body>``)::
 
-    <script src="//mozorg.cdn.mozilla.net/tabzilla/tabzilla.js"></script>
+    <script src="https://mozorg.cdn.mozilla.net/tabzilla/tabzilla.js"></script>
 
    This will choose the best locale for your visitor. If you prefer to force the locale, you can use::
 
-    <script src="//mozorg.cdn.mozilla.net/{locale}/tabzilla/tabzilla.js"></script>
+    <script src="https://mozorg.cdn.mozilla.net/{locale}/tabzilla/tabzilla.js"></script>
 
    Where ``{locale}`` is the language in which you'd like Tabzilla to be loaded (e.g. fr or de).
    If Tabzilla is not yet translated into said locale the user will get the en-US version.


### PR DESCRIPTION
Part of [Bug 1147139](https://bugzilla.mozilla.org/show_bug.cgi?id=1147139). mozilla.org is no longer serving content via http.