### PR TITLE
Bug 1117893 - Enable 'ee' and 'yo' on prod

### DIFF
--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -35,7 +35,7 @@ LANGUAGE_CODE = 'en-US'
 # Accepted locales
 PROD_LANGUAGES = ('ach', 'af', 'an', 'ar', 'as', 'ast', 'az', 'be', 'bg',
                   'bn-BD', 'bn-IN', 'br', 'bs', 'ca', 'cs', 'cy',
-                  'da', 'de', 'dsb', 'el', 'en-GB', 'en-US', 'en-ZA',
+                  'da', 'de', 'dsb', 'ee', 'el', 'en-GB', 'en-US', 'en-ZA',
                   'eo', 'es-AR', 'es-CL', 'es-ES', 'es-MX', 'et', 'eu',
                   'fa', 'ff', 'fi', 'fr', 'fy-NL', 'ga-IE', 'gd', 'gl',
                   'gu-IN', 'ha', 'he', 'hi-IN', 'hr', 'hsb', 'hu',
@@ -45,7 +45,7 @@ PROD_LANGUAGES = ('ach', 'af', 'an', 'ar', 'as', 'ast', 'az', 'be', 'bg',
                   'nn-NO', 'oc', 'or', 'pa-IN', 'pl', 'pt-BR', 'pt-PT',
                   'rm', 'ro', 'ru', 'sat', 'si', 'sk', 'sl', 'son', 'sq', 'sr',
                   'sv-SE', 'sw', 'ta', 'te', 'th', 'tr', 'uk', 'ur',
-                  'uz', 'vi', 'wo', 'xh', 'zh-CN', 'zh-TW', 'zu')
+                  'uz', 'vi', 'wo', 'xh', 'yo', 'zh-CN', 'zh-TW', 'zu')
 DEV_LANGUAGES = list(DEV_LANGUAGES) + ['en-US']
 
 # Map short locale names to long, preferred locale names. This overrides the

--- a/etc/httpd/global.conf
+++ b/etc/httpd/global.conf
@@ -206,7 +206,7 @@ RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/toolkit/download-to-your-devices(.*)
 # Has to be this way because of old
 # legacy platform url conflicts.
 # bug 921564
-RewriteRule ^/(ach|af|ak|an|ar|as|ast|az|be|bg|bn-BD|bn-IN|br|bs|ca|cs|csb|cy|da|de|dsb|el|en-GB|en-US|en-ZA|eo|es-AR|es-CL|es-ES|es-MX|et|eu|fa|ff|fi|fr|fy-NL|ga-IE|gd|gl|gu-IN|ha|he|hi-IN|hr|hsb|hu|hy-AM|id|ig|is|it|ja|ja-JP-mac|ka|kk|km|kn|ko|ku|lg|lij|lt|lv|mai|mk|ml|mn|mr|ms|my|nb-NO|nl|nn-NO|nso|oc|or|pa-IN|pl|pt-BR|pt-PT|rm|ro|ru|sah|sat|si|sk|sl|son|sq|sr|sv-SE|sw|ta|ta-LK|te|th|tr|uk|ur|uz|vi|wo|xh|zh-CN|zh-TW|zu)(/?)$ /b/$1$2 [PT]
+RewriteRule ^/(ach|af|ak|an|ar|as|ast|az|be|bg|bn-BD|bn-IN|br|bs|ca|cs|csb|cy|da|de|dsb|ee|el|en-GB|en-US|en-ZA|eo|es-AR|es-CL|es-ES|es-MX|et|eu|fa|ff|fi|fr|fy-NL|ga-IE|gd|gl|gu-IN|ha|he|hi-IN|hr|hsb|hu|hy-AM|id|ig|is|it|ja|ja-JP-mac|ka|kk|km|kn|ko|ku|lg|lij|lt|lv|mai|mk|ml|mn|mr|ms|my|nb-NO|nl|nn-NO|nso|oc|or|pa-IN|pl|pt-BR|pt-PT|rm|ro|ru|sah|sat|si|sk|sl|son|sq|sr|sv-SE|sw|ta|ta-LK|te|th|tr|uk|ur|uz|vi|wo|xh|yo|zh-CN|zh-TW|zu)(/?)$ /b/$1$2 [PT]
 
 # bug 987059, 1050149, 1072170
 RewriteCond %{REQUEST_URI} !^/ja/about/manifesto


### PR DESCRIPTION
We have enough content for these locales to enable them on production.