### PR TITLE
Fix Bug 1150083 - Make Fx38 Win64 build of beta Available on moz.org

### DIFF
--- a/bedrock/firefox/firefox_details.py
+++ b/bedrock/firefox/firefox_details.py
@@ -113,8 +113,8 @@ class FirefoxDesktop(ProductDetails):
 
             for platform, label in self.platform_labels.iteritems():
                 # Windows 64-bit builds are currently available only on the
-                # Aurora channel
-                if platform == 'win64' and channel not in ['alpha']:
+                # Aurora and Beta channel
+                if platform == 'win64' and channel not in ['alpha', 'beta']:
                     continue
 
                 build_info['platforms'][platform] = {

--- a/bedrock/firefox/helpers.py
+++ b/bedrock/firefox/helpers.py
@@ -88,8 +88,8 @@ def download_firefox(ctx, channel='release', small=False, icon=True,
     if show_desktop:
         for plat_os, plat_os_pretty in firefox_desktop.platform_labels.iteritems():
             # Windows 64-bit builds are currently available only on the Aurora
-            # channel
-            if plat_os == 'win64' and channel not in ['alpha']:
+            # and Beta channel
+            if plat_os == 'win64' and channel not in ['alpha', 'beta']:
                 continue
 
             # Fallback to en-US if this plat_os/version isn't available

--- a/bedrock/firefox/templates/firefox/all.html
+++ b/bedrock/firefox/templates/firefox/all.html
@@ -161,7 +161,7 @@
           <tr>
             <th colspan="2" scope="col">{{ _('Language') }}</th>
             <th scope="col">{{ _('Windows') }}</th>
-            {% if channel in ['alpha'] -%}
+            {% if channel in ['alpha', 'beta'] -%}
             <th scope="col">{{ _('Windows 64-bit') }}</th>
             {% endif -%}
             <th scope="col">{{ _('Mac OS X') }}</th>
@@ -185,8 +185,8 @@
     <th scope="row">{{ build.name_en }}</th>
     <td lang="{{ build.locale }}">{{ build.name_native }}</td>
     {{ build_link(build, 'win', _('Download for Windows')) }}
-    {# Windows 64-bit builds are currently available only on the Aurora channel -#}
-    {% if channel in ['alpha'] -%}
+    {# Windows 64-bit builds are currently available only on the Aurora and Beta channel -#}
+    {% if channel in ['alpha', 'beta'] -%}
     {{ build_link(build, 'win64', _('Download for 64-bit Windows')) }}
     {% endif -%}
     {{ build_link(build, 'osx', _('Download for Mac OS X')) }}

--- a/bedrock/firefox/tests/test_firefox_details.py
+++ b/bedrock/firefox/tests/test_firefox_details.py
@@ -217,7 +217,8 @@ class TestFirefoxDesktop(TestCase):
 
         # Beta
         builds = firefox_desktop.get_filtered_full_builds('beta')
-        ok_('win64' not in builds[0]['platforms'])
+        url = builds[0]['platforms']['win64']['download_url']
+        eq_(parse_qsl(urlparse(url).query)[1], ('os', 'win64'))
 
         # Release
         builds = firefox_desktop.get_filtered_full_builds('release')

--- a/bedrock/firefox/tests/test_helpers.py
+++ b/bedrock/firefox/tests/test_helpers.py
@@ -149,11 +149,12 @@ class TestDownloadButtons(TestCase):
                         {'request': get_request}))
 
         list = doc('.download-list li')
-        eq_(list.length, 4)
+        eq_(list.length, 5)
         eq_(pq(list[0]).attr('class'), 'os_win')
-        eq_(pq(list[1]).attr('class'), 'os_osx')
-        eq_(pq(list[2]).attr('class'), 'os_linux')
-        eq_(pq(list[3]).attr('class'), 'os_linux64')
+        eq_(pq(list[1]).attr('class'), 'os_win64')
+        eq_(pq(list[2]).attr('class'), 'os_osx')
+        eq_(pq(list[3]).attr('class'), 'os_linux')
+        eq_(pq(list[4]).attr('class'), 'os_linux64')
 
     def test_firefox_desktop(self):
         """The Release channel should not have Windows 64 build yet"""


### PR DESCRIPTION
Note: this PR changes the download button code as well for consistency, but the win64 buttons are being disabled by CSS for now. So the visible changes is /firefox/beta/all/ only as requested in the bug.