### PR TITLE
Fix Bug 1151538 - Execute callback in tabzilla when GA isn't defined

### DIFF
--- a/bedrock/tabzilla/templates/tabzilla/tabzilla.js
+++ b/bedrock/tabzilla/templates/tabzilla/tabzilla.js
@@ -352,6 +352,10 @@ var Tabzilla = (function (Tabzilla) {
     Infobar.prototype.trackEvent = function (action, label, value,
                                              nonInteraction, callback) {
         if (typeof(_gaq) !== 'object') {
+            if (callback) {
+                callback();
+            }
+
             return;
         }
 


### PR DESCRIPTION
Currently the language switcher will not work, if a site using tabzilla doesn't have Google Analytics, since the actual event action will never be executed.

See https://bugzilla.mozilla.org/show_bug.cgi?id=1151538

See also #2893