### PR TITLE
Add optimizely to firstrun: fix bug 1128708

### DIFF
--- a/bedrock/firefox/templates/firefox/australis/fx36/firstrun-tour.html
+++ b/bedrock/firefox/templates/firefox/australis/fx36/firstrun-tour.html
@@ -16,6 +16,12 @@
   {% javascript 'firefox_fx36_firstrun' %}
 {% endblock %}
 
+{% block optimizely %}
+  {% if waffle.switch('firefox-firstrun-optimizely') %}
+    {% include 'includes/optimizely.html' %}
+  {% endif %}
+{% endblock %}
+
 {% block string_data %}
 data-open="{{ _('Open tour') }}"
 data-close="{{ _('Close tour') }}"


### PR DESCRIPTION
Add waffle switch 'firefox-firstrun-optimizely'