### PR TITLE
Update some php_url links

### DIFF
--- a/bedrock/firefox/templates/firefox/channel.html
+++ b/bedrock/firefox/templates/firefox/channel.html
@@ -87,7 +87,7 @@
       <div class="download-box android" id="firefox-android">
         {{ download_firefox(icon=False, platform='android', small=True) }}
       </div>
-      <p class="more"><a href="{{ php_url('/firefox/') }}">{{_('Learn more about Firefox')}}</a></p>
+      <p class="more"><a href="{{ url('firefox') }}">{{_('Learn more about Firefox')}}</a></p>
     </div>
 
     <div id="developer" class="pager-page">

--- a/bedrock/firefox/templates/firefox/whatsnew.html
+++ b/bedrock/firefox/templates/firefox/whatsnew.html
@@ -17,12 +17,6 @@
 {% endblock %}
 
 {% block content %}
-{% if request.locale.startswith('en') %}
-  {% set mobile_link = url('firefox.android.index') %}
-{% else %}
-  {% set mobile_link = php_url('/mobile/') %}
-{% endif %}
-
 <h1 id="whatsnew-header">{{ _('Hooray! Your Firefox is up to date.') }}</h1>
 
 <article id="main-content" class="billboard">
@@ -43,7 +37,7 @@
 
 {% if request.locale not in locales_with_video.keys() %}
   <div id="promo-android">
-    <a href="{{ mobile_link }}" class="container">
+    <a href="{{ url('firefox.android.index') }}" class="container">
       <img src="{{ static('img/firefox/whatsnew/android-promo.jpg') }}" alt="{{ _('Firefox for Android artwork') }}">
       <div>
         <h3>{{ _('Fast. Smart. Safe.') }}</h3>

--- a/bedrock/foundation/templates/foundation/feed-icon-guidelines/faq.html
+++ b/bedrock/foundation/templates/foundation/feed-icon-guidelines/faq.html
@@ -25,7 +25,7 @@
 
   <dl class="faq">
     <dt>{% trans %}What is the feed icon?{% endtrans %}</dt>
-    <dd><p>{% trans link=php_url('/firefox/livebookmarks.html') %}
+    <dd><p>{% trans link='https://support.mozilla.org/kb/Live+Bookmarks' %}
     The feed icon was created originally for
     use with the <a href="{{ link }}">Live Bookmarks</a>
     feature of the Mozilla Firefox browser. In that context the

--- a/bedrock/foundation/templates/foundation/trademarks/policy.html
+++ b/bedrock/foundation/templates/foundation/trademarks/policy.html
@@ -192,7 +192,7 @@
 
   <h2>{{ _('Reporting Trademark Abuse') }}</h2>
 
-  <p>{% trans report=php_url('/legal/fraud-report/index.html') %}We have a <a href="{{ report }}">central place</a> for everyone to report any misuse of the Mozilla Marks.  All you have to do is fill out the relevant information on the web form.  The more information you supply when you file the report, the easier it is for us to evaluate and respond appropriately.  Having the support and help of our community makes our work easier and more worthwhile.{% endtrans %}</p>
+  <p>{% trans report=url('legal.fraud-report') %}We have a <a href="{{ report }}">central place</a> for everyone to report any misuse of the Mozilla Marks.  All you have to do is fill out the relevant information on the web form.  The more information you supply when you file the report, the easier it is for us to evaluate and respond appropriately.  Having the support and help of our community makes our work easier and more worthwhile.{% endtrans %}</p>
 
   <h2>{{ _('Questions') }}</h2>
 

--- a/bedrock/foundation/templates/foundation/trademarks/poweredby/faq.html
+++ b/bedrock/foundation/templates/foundation/trademarks/poweredby/faq.html
@@ -191,7 +191,7 @@
 
     <dt id="comments">{{ _('How can I provide comments about this program?') }}</dt>
     <dd>
-      <p>{% trans contact=php_url('/contact') %}We've been able to put these guidelines
+      <p>{% trans contact="mailto:trademarks@mozilla.com" %}We've been able to put these guidelines
         together because of the feedback community members have provided and
         we welcome further discussions. If you have any additional comments or questions,
         feel free to post on your blog or <a href="{{ contact }}">let us know</a>.{% endtrans %}</p>

--- a/bedrock/press/templates/press/speaker-request.html
+++ b/bedrock/press/templates/press/speaker-request.html
@@ -267,11 +267,11 @@
       #}
       <h2>{{ _('Resources') }}</h2>
       <ul>
-        <li><a href="{{ php_url('/press/ataglance') }}">{{ _('Mozilla at a Glance') }}</a></li>
-        <li><a href="{{ php_url('/press/media') }}">{{ _('Media Library') }}</a></li>
-        <li><a href="{{ php_url('/press/awards') }}">{{ _('Awards') }}</a></li>
-        <li><a href="{{ php_url('/press/kits') }}">{{ _('Firefox Press Kits') }}</a></li>
-        <li><a href="{{ php_url('/press/bios') }}">{{ _('Speaker Bios') }}</a></li>
+        <li><a href="https://blog.mozilla.org/press/ataglance/">{{ _('Mozilla at a Glance') }}</a></li>
+        <li><a href="https://blog.mozilla.org/press/media-library/">{{ _('Media Library') }}</a></li>
+        <li><a href="https://blog.mozilla.org/press/awards/">{{ _('Awards') }}</a></li>
+        <li><a href="https://blog.mozilla.org/press/kits/">{{ _('Firefox Press Kits') }}</a></li>
+        <li><a href="https://blog.mozilla.org/press/bios/">{{ _('Speaker Bios') }}</a></li>
         <li><a href="{{ url('press.speaker-request') }}">{{ _('Speaker Request Form') }}</a></li>
       </ul>
     </aside>


### PR DESCRIPTION
While looking at [Bug 1146683](https://bugzilla.mozilla.org/show_bug.cgi?id=1146683) I have noticed that some links using `php_url` can be updated. The rest of the links are /MPL/ and /thunderbird/, but as I mentioned in the bug, this function could be retired now.