### PR TITLE
Bug 1153523 - Issue with image sprite on /firefox/hello/

### DIFF
--- a/media/css/firefox/hello/index.less
+++ b/media/css/firefox/hello/index.less
@@ -1302,7 +1302,7 @@ main {
 
     #features li {
         background-image: url(/media/img/firefox/hello/sprite-features-high-res.png);
-        .background-size(2300px, 120px);
+        .background-size(1840px, 120px);
     }
 
     // (seems to) remove scaling artifact by changing the scale by .001


### PR DESCRIPTION
Bug 1153523 - Issue with image sprite on /firefox/hello/ 
background-size changed from 2300px to 1840px.