### PR TITLE
Move django-nose and nose to base requirements.

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -182,4 +182,11 @@ https://github.com/jsocol/django-cronjobs/archive/cfda8176c5c3a50d1b58fcf57e87e2
 # sha256: eeq_z415NQPBF3j59fmy6JGjtnpDgVQxwwvFKxnDQx0
 https://github.com/mozilla/nuggets/archive/ce506882b6943ea45ea4f98290fc4ef23e09a083.tar.gz#egg=nuggets
 
+# because funfactory
+# TODO move back to dev.txt
 
+# sha256: D41ubgIjuPsEEUtKcgk4DhrPJ-Ch3Rq5j-zghafDxSU
+nose==1.0.0
+
+# sha256: NmfSakH-wwNkoO9yWAgyylMogC1VP21ucq9awhyzY2U
+django-nose==1.3

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -30,14 +30,8 @@ pep8==1.6.2
 # sha256: P6gKELNtUWhr93RPXcmWIs1cmM6O1kAi5imGiq_Bd2k
 pyflakes==0.8.1
 
-# sha256: D41ubgIjuPsEEUtKcgk4DhrPJ-Ch3Rq5j-zghafDxSU
-nose==1.0.0
-
 # sha256: uDndLZwRfHAUMMFJlWkYpCOphjtIsJyQ4wpgE-fS9E8
 mock==1.0.1
-
-# sha256: NmfSakH-wwNkoO9yWAgyylMogC1VP21ucq9awhyzY2U
-django-nose==1.3
 
 # sha256: ifAFimx-1y5qwpmyuDR6zd_VzM1g3Y_TCkoDHfCRy5s
 https://github.com/jbalogh/test-utils/archive/e42e031d31ea63d593e47d564545149a0f30b95f.tar.gz#egg=test-utils


### PR DESCRIPTION
funfactory adds django_nose to INSTALLED_APPS,
so it has to be installed in all envs.