### PR TITLE
Fix bug 1155810: Remove funfactory.

### DIFF
--- a/bedrock/base/context_processors.py
+++ b/bedrock/base/context_processors.py
@@ -1,0 +1,20 @@
+# from bedrock.base
+
+from django.conf import settings
+from django.utils import translation
+
+
+def i18n(request):
+    return {
+        'LANGUAGES': settings.LANGUAGES,
+        'LANG': (settings.LANGUAGE_URL_MAP.get(translation.get_language()) or
+                 translation.get_language()),
+        'DIR': 'rtl' if translation.get_language_bidi() else 'ltr',
+    }
+
+
+def globals(request):
+    return {
+        'request': request,
+        'settings': settings,
+    }

--- a/bedrock/base/helpers.py
+++ b/bedrock/base/helpers.py
@@ -1,0 +1,73 @@
+import datetime
+import urllib
+import urlparse
+
+from django.contrib.staticfiles.storage import staticfiles_storage
+from django.template import defaultfilters
+from django.utils.encoding import smart_str
+from django.utils.html import strip_tags
+
+from jingo import register
+import jinja2
+
+from .urlresolvers import reverse
+
+# Yanking filters from Django.
+register.filter(strip_tags)
+register.filter(defaultfilters.timesince)
+register.filter(defaultfilters.truncatewords)
+
+
+@register.function
+def thisyear():
+    """The current year."""
+    return jinja2.Markup(datetime.date.today().year)
+
+
+@register.function
+def url(viewname, *args, **kwargs):
+    """Helper for Django's ``reverse`` in templates."""
+    return reverse(viewname, args=args, kwargs=kwargs)
+
+
+@register.filter
+def urlparams(url_, hash=None, **query):
+    """Add a fragment and/or query paramaters to a URL.
+
+    New query params will be appended to exising parameters, except duplicate
+    names, which will be replaced.
+    """
+    url = urlparse.urlparse(url_)
+    fragment = hash if hash is not None else url.fragment
+
+    # Use dict(parse_qsl) so we don't get lists of values.
+    q = url.query
+    query_dict = dict(urlparse.parse_qsl(smart_str(q))) if q else {}
+    query_dict.update((k, v) for k, v in query.items())
+
+    query_string = _urlencode([(k, v) for k, v in query_dict.items()
+                               if v is not None])
+    new = urlparse.ParseResult(url.scheme, url.netloc, url.path, url.params,
+                               query_string, fragment)
+    return new.geturl()
+
+
+def _urlencode(items):
+    """A Unicode-safe URLencoder."""
+    try:
+        return urllib.urlencode(items)
+    except UnicodeEncodeError:
+        return urllib.urlencode([(k, smart_str(v)) for k, v in items])
+
+
+@register.filter
+def urlencode(txt):
+    """Url encode a path."""
+    if isinstance(txt, unicode):
+        txt = txt.encode('utf-8')
+    return urllib.quote_plus(txt)
+
+
+@register.function
+def static(path):
+    return staticfiles_storage.url(path)

--- a/bedrock/base/log_settings.py
+++ b/bedrock/base/log_settings.py
@@ -1,0 +1,102 @@
+import logging
+import logging.handlers
+import socket
+
+from django.conf import settings
+
+import commonware.log
+import cef
+import dictconfig
+
+
+class NullHandler(logging.Handler):
+    def emit(self, record):
+        pass
+
+
+base_fmt = ('%(name)s:%(levelname)s %(message)s '
+            ':%(pathname)s:%(lineno)s')
+use_syslog = settings.HAS_SYSLOG and not settings.DEBUG
+
+if use_syslog:
+    hostname = socket.gethostname()
+else:
+    hostname = 'localhost'
+
+cfg = {
+    'version': 1,
+    'filters': {},
+    'formatters': {
+        'debug': {
+            '()': commonware.log.Formatter,
+            'datefmt': '%H:%M:%s',
+            'format': '%(asctime)s ' + base_fmt,
+        },
+        'prod': {
+            '()': commonware.log.Formatter,
+            'datefmt': '%H:%M:%s',
+            'format': '%s %s: [%%(REMOTE_ADDR)s] %s' % (hostname,
+                                                        settings.SYSLOG_TAG,
+                                                        base_fmt),
+        },
+        'cef': {
+            '()': cef.SysLogFormatter,
+            'datefmt': '%H:%M:%s',
+        },
+    },
+    'handlers': {
+        'console': {
+            '()': logging.StreamHandler,
+            'formatter': 'debug',
+        },
+        'syslog': {
+            '()': logging.handlers.SysLogHandler,
+            'facility': logging.handlers.SysLogHandler.LOG_LOCAL7,
+            'formatter': 'prod',
+        },
+        'mail_admins': {
+            'level': 'ERROR',
+            'class': 'django.utils.log.AdminEmailHandler',
+        },
+        'cef_syslog': {
+            '()': logging.handlers.SysLogHandler,
+            'facility': logging.handlers.SysLogHandler.LOG_LOCAL4,
+            'formatter': 'cef',
+        },
+        'cef_console': {
+            '()': logging.StreamHandler,
+            'formatter': 'cef',
+        },
+        'null': {
+            '()': NullHandler,
+        }
+    },
+    'loggers': {
+        'django.request': {
+            'handlers': ['mail_admins'],
+            'level': 'ERROR',
+            'propagate': False,
+        },
+        'cef': {
+            'handlers': ['cef_syslog' if use_syslog else 'cef_console'],
+        }
+    },
+    'root': {},
+}
+
+for key, value in settings.LOGGING.items():
+    if hasattr(cfg[key], 'update'):
+        cfg[key].update(value)
+    else:
+        cfg[key] = value
+
+# Set the level and handlers for all loggers.
+for logger in cfg['loggers'].values() + [cfg['root']]:
+    if 'handlers' not in logger:
+        logger['handlers'] = ['syslog' if use_syslog else 'console']
+    if 'level' not in logger:
+        logger['level'] = settings.LOG_LEVEL
+    if logger is not cfg['root'] and 'propagate' not in logger:
+        logger['propagate'] = False
+
+dictconfig.dictConfig(cfg)

--- a/bedrock/base/middleware.py
+++ b/bedrock/base/middleware.py
@@ -1,0 +1,76 @@
+"""
+Taken from zamboni.amo.middleware.
+
+This is django-localeurl, but with mozilla style capital letters in
+the locale codes.
+"""
+
+import urllib
+from warnings import warn
+
+from django.conf import settings
+from django.http import HttpResponsePermanentRedirect
+from django.utils.encoding import smart_str
+
+import tower
+
+from . import urlresolvers
+from .helpers import urlparams
+
+
+class LocaleURLMiddleware(object):
+    """
+    1. Search for the locale.
+    2. Save it in the request.
+    3. Strip them from the URL.
+    """
+
+    def __init__(self):
+        if not settings.USE_I18N or not settings.USE_L10N:
+            warn("USE_I18N or USE_L10N is False but LocaleURLMiddleware is "
+                 "loaded. Consider removing bedrock.base.middleware."
+                 "LocaleURLMiddleware from your MIDDLEWARE_CLASSES setting.")
+
+        self.exempt_urls = getattr(settings, 'FF_EXEMPT_LANG_PARAM_URLS', ())
+
+    def _is_lang_change(self, request):
+        """Return True if the lang param is present and URL isn't exempt."""
+        if 'lang' not in request.GET:
+            return False
+
+        return not any(request.path.endswith(url) for url in self.exempt_urls)
+
+    def process_request(self, request):
+        prefixer = urlresolvers.Prefixer(request)
+        urlresolvers.set_url_prefix(prefixer)
+        full_path = prefixer.fix(prefixer.shortened_path)
+
+        if self._is_lang_change(request):
+            # Blank out the locale so that we can set a new one. Remove lang
+            # from the query params so we don't have an infinite loop.
+            prefixer.locale = ''
+            new_path = prefixer.fix(prefixer.shortened_path)
+            query = dict((smart_str(k), request.GET[k]) for k in request.GET)
+            query.pop('lang')
+            return HttpResponsePermanentRedirect(urlparams(new_path, **query))
+
+        if full_path != request.path:
+            query_string = request.META.get('QUERY_STRING', '')
+            full_path = urllib.quote(full_path.encode('utf-8'))
+
+            if query_string:
+                full_path = '%s?%s' % (full_path, query_string)
+
+            response = HttpResponsePermanentRedirect(full_path)
+
+            # Vary on Accept-Language if we changed the locale
+            old_locale = prefixer.locale
+            new_locale, _ = urlresolvers.split_path(full_path)
+            if old_locale != new_locale:
+                response['Vary'] = 'Accept-Language'
+
+            return response
+
+        request.path_info = '/' + prefixer.shortened_path
+        request.locale = prefixer.locale
+        tower.activate(prefixer.locale)

--- a/bedrock/base/monkeypatches.py
+++ b/bedrock/base/monkeypatches.py
@@ -1,0 +1,32 @@
+import logging
+
+
+__all__ = ['patch']
+
+# Idempotence! http://en.wikipedia.org/wiki/Idempotence
+_has_patched = False
+
+
+def patch():
+    global _has_patched
+    if _has_patched:
+        return
+
+    # Import for side-effect: configures logging handlers.
+    # pylint: disable-msg=W0611
+    from . import log_settings  # noqa
+
+    # Monkey-patch django forms to avoid having to use Jinja2's |safe
+    # everywhere.
+    try:
+        import jingo.monkey
+        jingo.monkey.patch()
+    except ImportError:
+        # If we can't import jingo.monkey, then it's an older jingo,
+        # so we go back to the old ways.
+        import safe_django_forms
+        safe_django_forms.monkeypatch()
+    logging.debug("Note: bedrock monkey patches executed in %s" % __file__)
+
+    # prevent it from being run again later
+    _has_patched = True

--- a/bedrock/base/tests.py
+++ b/bedrock/base/tests.py
@@ -4,14 +4,15 @@
 
 import os
 from subprocess import call
+
 from django.test.utils import override_settings
-from mock import patch
 
 import chkcrontab_lib as chkcrontab
-from funfactory.settings_base import path
+from mock import patch
 
 from bedrock.base import geo
 from bedrock.mozorg.tests import TestCase
+from bedrock.settings.base import path
 
 
 CRONTAB_FILE_NAMES = ['bedrock-dev', 'bedrock-stage', 'bedrock-prod']

--- a/bedrock/base/tests/test_accepted_locales.py
+++ b/bedrock/base/tests/test_accepted_locales.py
@@ -1,0 +1,94 @@
+import os
+import shutil
+
+from django.conf import settings
+import test_utils
+
+from bedrock.settings.base import get_dev_languages, path
+
+
+class AcceptedLocalesTest(test_utils.TestCase):
+    """Test lazy evaluation of locale related settings.
+
+    Verify that some localization-related settings are lazily evaluated based
+    on the current value of the DEV variable.  Depending on the value,
+    DEV_LANGUAGES or PROD_LANGUAGES should be used.
+
+    """
+    locale = path('locale')
+    locale_bkp = path('locale_bkp')
+
+    @classmethod
+    def setup_class(cls):
+        """Create a directory structure for locale/.
+
+        Back up the existing project/locale/ directory and create the following
+        hierarchy in its place:
+
+            - project/locale/en-US/LC_MESSAGES
+            - project/locale/fr/LC_MESSAGES
+            - project/locale/templates/LC_MESSAGES
+            - project/locale/empty_file
+
+        Also, set PROD_LANGUAGES to ('en-US',).
+
+        """
+        if os.path.exists(cls.locale_bkp):
+            raise Exception('A backup of locale/ exists at %s which might '
+                            'mean that previous tests didn\'t end cleanly. '
+                            'Skipping the test suite.' % cls.locale_bkp)
+        cls.DEV = settings.DEV
+        cls.PROD_LANGUAGES = settings.PROD_LANGUAGES
+        cls.DEV_LANGUAGES = settings.DEV_LANGUAGES
+        settings.PROD_LANGUAGES = ('en-US',)
+        os.rename(cls.locale, cls.locale_bkp)
+        for loc in ('en-US', 'fr', 'templates'):
+            os.makedirs(os.path.join(cls.locale, loc, 'LC_MESSAGES'))
+        open(os.path.join(cls.locale, 'empty_file'), 'w').close()
+
+    @classmethod
+    def teardown_class(cls):
+        """Remove the testing locale/ dir and bring back the backup."""
+
+        settings.DEV = cls.DEV
+        settings.PROD_LANGUAGES = cls.PROD_LANGUAGES
+        settings.DEV_LANGUAGES = cls.DEV_LANGUAGES
+        shutil.rmtree(cls.locale)
+        os.rename(cls.locale_bkp, cls.locale)
+
+    def test_build_dev_languages(self):
+        """Test that the list of dev locales is built properly.
+
+        On dev instances, the list of accepted locales should correspond to
+        the per-locale directories in locale/.
+
+        """
+        settings.DEV = True
+        langs = get_dev_languages()
+        assert (langs == ['en-US', 'fr'] or langs == ['fr', 'en-US'],
+                'DEV_LANGUAGES do not correspond to the contents of locale/.')
+
+    def test_dev_languages(self):
+        """Test the accepted locales on dev instances.
+
+        On dev instances, allow locales defined in DEV_LANGUAGES.
+
+        """
+        settings.DEV = True
+        # simulate the successful result of the DEV_LANGUAGES list
+        # comprehension defined in settings.
+        settings.DEV_LANGUAGES = ['en-US', 'fr']
+        assert settings.LANGUAGE_URL_MAP == {'en-us': 'en-US', 'fr': 'fr'}, \
+               ('DEV is True, but DEV_LANGUAGES are not used to define the '
+                'allowed locales.')
+
+    def test_prod_languages(self):
+        """Test the accepted locales on prod instances.
+
+        On stage/prod instances, allow locales defined in PROD_LANGUAGES.
+
+        """
+        settings.DEV = False
+        assert (settings.LANGUAGE_URL_MAP == {'en-us': 'en-US'},
+                'DEV is False, but PROD_LANGUAGES are not used to define the '
+                'allowed locales.')

--- a/bedrock/base/tests/test_context_processors.py
+++ b/bedrock/base/tests/test_context_processors.py
@@ -1,0 +1,37 @@
+import jingo
+import jinja2
+from nose.tools import eq_
+from django.test import TestCase, RequestFactory
+
+from mock import patch
+
+from bedrock.base import context_processors
+
+
+class TestContext(TestCase):
+
+    def setUp(self):
+        self.factory = RequestFactory()
+
+    def render(self, content, request=None):
+        if not request:
+            request = self.factory.get('/')
+        tpl = jinja2.Template(content)
+        return jingo.render_to_string(request, tpl)
+
+    def test_request(self):
+        eq_(self.render('{{ request.path }}'), '/')
+
+    def test_settings(self):
+        eq_(self.render('{{ settings.SITE_ID }}'), '1')
+
+    def test_languages(self):
+        eq_(self.render("{{ LANGUAGES['en-us'] }}"), 'English (US)')
+
+    @patch.object(context_processors, 'translation')
+    def test_lang_setting(self, translation):
+        translation.get_language.return_value = 'en-US'
+        eq_(self.render("{{ LANG }}"), 'en-US')
+
+    def test_lang_dir(self):
+        eq_(self.render("{{ DIR }}"), 'ltr')

--- a/bedrock/base/tests/test_crontab.py
+++ b/bedrock/base/tests/test_crontab.py
@@ -1,0 +1,44 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import os
+from subprocess import call
+
+import chkcrontab_lib as chkcrontab
+
+from bedrock.mozorg.tests import TestCase
+from bedrock.settings.base import path
+
+
+CRONTAB_FILE_NAMES = ['bedrock-dev', 'bedrock-stage', 'bedrock-prod']
+CRONTAB_FILES = [path('etc', 'cron.d', cf) for cf in CRONTAB_FILE_NAMES]
+
+
+class TestCrontabFiles(TestCase):
+    files_generated = False
+
+    @classmethod
+    def setUpClass(cls):
+        for cron_file in CRONTAB_FILE_NAMES:
+            call([path('bin', 'gen-crons.py'), '-t', cron_file, '-w', '/path/to/www',
+                  '-s', '/path/to/src'])
+
+    @classmethod
+    def tearDownClass(cls):
+        for cron_file in CRONTAB_FILE_NAMES:
+            os.remove(path('etc', 'cron.d', cron_file))
+
+    def test_crontab_files_have_newlines(self):
+        """Crontab files should end with newline character."""
+        for filename in CRONTAB_FILES:
+            with open(filename) as cronfile:
+                self.assertTrue(cronfile.read().endswith('\n'),
+                                'No newline at end of ' + filename)
+
+    def test_crontab_files_valid(self):
+        """Crontab files should pass validation."""
+        for filename in CRONTAB_FILES:
+            cronlog = chkcrontab.LogCounter()
+            return_value = chkcrontab.check_crontab(filename, cronlog)
+            self.assertEqual(return_value, 0, 'Problem with ' + filename)

--- a/bedrock/base/tests/test_geo.py
+++ b/bedrock/base/tests/test_geo.py
@@ -2,50 +2,12 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-import os
-from subprocess import call
-
 from django.test.utils import override_settings
 
-import chkcrontab_lib as chkcrontab
 from mock import patch
 
 from bedrock.base import geo
 from bedrock.mozorg.tests import TestCase
-from bedrock.settings.base import path
-
-
-CRONTAB_FILE_NAMES = ['bedrock-dev', 'bedrock-stage', 'bedrock-prod']
-CRONTAB_FILES = [path('etc', 'cron.d', cf) for cf in CRONTAB_FILE_NAMES]
-
-
-class TestCrontabFiles(TestCase):
-    files_generated = False
-
-    @classmethod
-    def setUpClass(cls):
-        for cron_file in CRONTAB_FILE_NAMES:
-            call([path('bin', 'gen-crons.py'), '-t', cron_file, '-w', '/path/to/www',
-                  '-s', '/path/to/src'])
-
-    @classmethod
-    def tearDownClass(cls):
-        for cron_file in CRONTAB_FILE_NAMES:
-            os.remove(path('etc', 'cron.d', cron_file))
-
-    def test_crontab_files_have_newlines(self):
-        """Crontab files should end with newline character."""
-        for filename in CRONTAB_FILES:
-            with open(filename) as cronfile:
-                self.assertTrue(cronfile.read().endswith('\n'),
-                                'No newline at end of ' + filename)
-
-    def test_crontab_files_valid(self):
-        """Crontab files should pass validation."""
-        for filename in CRONTAB_FILES:
-            cronlog = chkcrontab.LogCounter()
-            return_value = chkcrontab.check_crontab(filename, cronlog)
-            self.assertEqual(return_value, 0, 'Problem with ' + filename)
 
 
 @patch('bedrock.base.geo.geo')

--- a/bedrock/base/tests/test_helpers.py
+++ b/bedrock/base/tests/test_helpers.py
@@ -1,0 +1,19 @@
+from nose.tools import eq_
+from django.test import TestCase
+import jingo
+
+
+def render(s, context={}):
+    t = jingo.env.from_string(s)
+    return t.render(context)
+
+
+class HelpersTests(TestCase):
+
+    def test_urlencode_with_unicode(self):
+        template = '<a href="?var={{ key|urlencode }}">'
+        context = {'key': '?& /()'}
+        eq_(render(template, context), '<a href="?var=%3F%26+%2F%28%29">')
+        # non-ascii
+        context = {'key': u'\xe4'}
+        eq_(render(template, context), '<a href="?var=%C3%A4">')

--- a/bedrock/base/tests/test_middleware.py
+++ b/bedrock/base/tests/test_middleware.py
@@ -1,0 +1,48 @@
+from django.test import TestCase, RequestFactory
+from django.test.utils import override_settings
+
+from bedrock.base.middleware import LocaleURLMiddleware
+
+
+@override_settings(DEV=True)
+class TestLocaleURLMiddleware(TestCase):
+    def setUp(self):
+        self.rf = RequestFactory()
+        self.middleware = LocaleURLMiddleware()
+
+    @override_settings(DEV_LANGUAGES=('de', 'fr'),
+                       FF_EXEMPT_LANG_PARAM_URLS=())
+    def test_redirects_to_correct_language(self):
+        """Should redirect to lang prefixed url."""
+        path = '/the/dude/'
+        req = self.rf.get(path, HTTP_ACCEPT_LANGUAGE='de')
+        resp = LocaleURLMiddleware().process_request(req)
+        self.assertEqual(resp['Location'], '/de' + path)
+
+    @override_settings(DEV_LANGUAGES=('es', 'fr'),
+                       LANGUAGE_CODE='en-US',
+                       FF_EXEMPT_LANG_PARAM_URLS=())
+    def test_redirects_to_default_language(self):
+        """Should redirect to default lang if not in settings."""
+        path = '/the/dude/'
+        req = self.rf.get(path, HTTP_ACCEPT_LANGUAGE='de')
+        resp = LocaleURLMiddleware().process_request(req)
+        self.assertEqual(resp['Location'], '/en-US' + path)
+
+    @override_settings(DEV_LANGUAGES=('de', 'fr'),
+                       FF_EXEMPT_LANG_PARAM_URLS=('/other/',))
+    def test_redirects_lang_param(self):
+        """Middleware should remove the lang param on redirect."""
+        path = '/fr/the/dude/'
+        req = self.rf.get(path, {'lang': 'de'})
+        resp = LocaleURLMiddleware().process_request(req)
+        self.assertEqual(resp['Location'], '/de/the/dude/')
+
+    @override_settings(DEV_LANGUAGES=('de', 'fr'),
+                       FF_EXEMPT_LANG_PARAM_URLS=('/dude/',))
+    def test_no_redirect_lang_param(self):
+        """Middleware should not redirect when exempt."""
+        path = '/fr/the/dude/'
+        req = self.rf.get(path, {'lang': 'de'})
+        resp = LocaleURLMiddleware().process_request(req)
+        self.assertIs(resp, None)  # no redirect

--- a/bedrock/base/tests/test_urlresolvers.py
+++ b/bedrock/base/tests/test_urlresolvers.py
@@ -1,0 +1,173 @@
+# -*- coding: utf-8 -*-
+from django.conf import settings
+from django.conf.urls import patterns, url
+from django.test import TestCase
+from django.test.client import RequestFactory
+from django.test.utils import override_settings
+
+from bedrock.base.urlresolvers import reverse, split_path, Prefixer
+from mock import patch, Mock
+from nose.tools import eq_, ok_
+
+
+# split_path tests use a test generator, which cannot be used inside of a
+# TestCase class
+def test_split_path():
+    testcases = [
+        # Basic
+        ('en-US/some/action', ('en-US', 'some/action')),
+        # First slash doesn't matter
+        ('/en-US/some/action', ('en-US', 'some/action')),
+        # Nor does capitalization
+        ('En-uS/some/action', ('en-US', 'some/action')),
+        # Unsupported languages return a blank language
+        ('unsupported/some/action', ('', 'unsupported/some/action')),
+    ]
+
+    for tc in testcases:
+        yield check_split_path, tc[0], tc[1]
+
+
+def check_split_path(path, result):
+    res = split_path(path)
+    eq_(res, result)
+
+
+# Test urlpatterns
+urlpatterns = patterns('',
+    url(r'^test/$', lambda r: None, name='test.view')
+)
+
+
+class FakePrefixer(object):
+    def __init__(self, fix):
+        self.fix = fix
+
+
+@patch('bedrock.base.urlresolvers.get_url_prefix')
+class TestReverse(TestCase):
+    urls = 'bedrock.base.tests.test_urlresolvers'
+
+    def test_unicode_url(self, get_url_prefix):
+        # If the prefixer returns a unicode URL it should be escaped and cast
+        # as a str object.
+        get_url_prefix.return_value = FakePrefixer(lambda p: u'/Françoi%s' % p)
+        result = reverse('test.view')
+
+        # Ensure that UTF-8 characters are escaped properly.
+        self.assertEqual(result, '/Fran%C3%A7oi/test/')
+        self.assertEqual(type(result), str)
+
+
+class TestPrefixer(TestCase):
+    def setUp(self):
+        self.factory = RequestFactory()
+
+    @override_settings(LANGUAGE_CODE='en-US')
+    def test_get_language_default_language_code(self):
+        """
+        Should return default set by settings.LANGUAGE_CODE if no 'lang'
+        url parameter and no Accept-Language header
+        """
+        request = self.factory.get('/')
+        self.assertFalse('lang' in request.GET)
+        self.assertFalse(request.META.get('HTTP_ACCEPT_LANGUAGE'))
+        prefixer = Prefixer(request)
+        eq_(prefixer.get_language(), 'en-US')
+
+    @override_settings(LANGUAGE_URL_MAP={'en-us': 'en-US', 'de': 'de'})
+    def test_get_language_valid_lang_param(self):
+        """
+        Should return lang param value if it is in settings.LANGUAGE_URL_MAP
+        """
+        request = self.factory.get('/?lang=de')
+        eq_(request.GET.get('lang'), 'de')
+        ok_('de' in settings.LANGUAGE_URL_MAP)
+        prefixer = Prefixer(request)
+        eq_(prefixer.get_language(), 'de')
+
+    @override_settings(LANGUAGE_CODE='en-US',
+                       LANGUAGE_URL_MAP={'en-us': 'en-US'})
+    def test_get_language_invalid_lang_param(self):
+        """
+        Should return default set by settings.LANGUAGE_CODE if lang
+        param value is not in settings.LANGUAGE_URL_MAP
+        """
+        request = self.factory.get('/?lang=de')
+        ok_('lang' in request.GET)
+        self.assertFalse('de' in settings.LANGUAGE_URL_MAP)
+        prefixer = Prefixer(request)
+        eq_(prefixer.get_language(), 'en-US')
+
+    def test_get_language_returns_best(self):
+        """
+        Should pass Accept-Language header value to get_best_language
+        and return result
+        """
+        request = self.factory.get('/')
+        request.META['HTTP_ACCEPT_LANGUAGE'] = 'de, es'
+        prefixer = Prefixer(request)
+        prefixer.get_best_language = Mock(return_value='de')
+        eq_(prefixer.get_language(), 'de')
+        prefixer.get_best_language.assert_called_once_with('de, es')
+
+    @override_settings(LANGUAGE_CODE='en-US')
+    def test_get_language_no_best(self):
+        """
+        Should return default set by settings.LANGUAGE_CODE if
+        get_best_language return value is None
+        """
+        request = self.factory.get('/')
+        request.META['HTTP_ACCEPT_LANGUAGE'] = 'de, es'
+        prefixer = Prefixer(request)
+        prefixer.get_best_language = Mock(return_value=None)
+        eq_(prefixer.get_language(), 'en-US')
+        prefixer.get_best_language.assert_called_once_with('de, es')
+
+    @override_settings(LANGUAGE_URL_MAP={'en-us': 'en-US', 'de': 'de'})
+    def test_get_best_language_exact_match(self):
+        """
+        Should return exact match if it is in settings.LANGUAGE_URL_MAP
+        """
+        request = self.factory.get('/')
+        prefixer = Prefixer(request)
+        eq_(prefixer.get_best_language('de, es'), 'de')
+
+    @override_settings(LANGUAGE_URL_MAP={'en-us': 'en-US', 'es-ar': 'es-AR'},
+                       CANONICAL_LOCALES={'es': 'es-ES', 'en': 'en-US'})
+    def test_get_best_language_prefix_match(self):
+        """
+        Should return a language with a matching prefix from
+        settings.LANGUAGE_URL_MAP + settings.CANONICAL_LOCALES if it exists but
+        no exact match does
+        """
+        request = self.factory.get('/')
+        prefixer = Prefixer(request)
+        eq_(prefixer.get_best_language('en'), 'en-US')
+        eq_(prefixer.get_best_language('en-CA'), 'en-US')
+        eq_(prefixer.get_best_language('en-GB'), 'en-US')
+        eq_(prefixer.get_best_language('en-US'), 'en-US')
+        eq_(prefixer.get_best_language('es'), 'es-ES')
+        eq_(prefixer.get_best_language('es-AR'), 'es-AR')
+        eq_(prefixer.get_best_language('es-CL'), 'es-ES')
+        eq_(prefixer.get_best_language('es-MX'), 'es-ES')
+
+    @override_settings(LANGUAGE_URL_MAP={'en-us': 'en-US'})
+    def test_get_best_language_no_match(self):
+        """
+        Should return None if there is no exact match or matching
+        prefix
+        """
+        request = self.factory.get('/')
+        prefixer = Prefixer(request)
+        eq_(prefixer.get_best_language('de'), None)
+
+    @override_settings(LANGUAGE_URL_MAP={'en-us': 'en-US'})
+    def test_get_best_language_handles_parse_accept_lang_header_error(self):
+        """
+        Should return None despite error raised by bug described in
+        https://code.djangoproject.com/ticket/21078
+        """
+        request = self.factory.get('/')
+        prefixer = Prefixer(request)
+        eq_(prefixer.get_best_language('en; q=1,'), None)

--- a/bedrock/base/urlresolvers.py
+++ b/bedrock/base/urlresolvers.py
@@ -1,0 +1,127 @@
+from threading import local
+
+from django.conf import settings
+from django.core.urlresolvers import reverse as django_reverse
+from django.utils.encoding import iri_to_uri
+from django.utils.functional import lazy
+from django.utils.translation.trans_real import parse_accept_lang_header
+
+
+# Thread-local storage for URL prefixes. Access with (get|set)_url_prefix.
+_local = local()
+
+
+def set_url_prefix(prefix):
+    """Set the ``prefix`` for the current thread."""
+    _local.prefix = prefix
+
+
+def get_url_prefix():
+    """Get the prefix for the current thread, or None."""
+    return getattr(_local, 'prefix', None)
+
+
+def reverse(viewname, urlconf=None, args=None, kwargs=None, prefix=None):
+    """Wraps Django's reverse to prepend the correct locale."""
+    prefixer = get_url_prefix()
+
+    if prefixer:
+        prefix = prefix or '/'
+    url = django_reverse(viewname, urlconf, args, kwargs, prefix)
+    if prefixer:
+        url = prefixer.fix(url)
+
+    # Ensure any unicode characters in the URL are escaped.
+    return iri_to_uri(url)
+
+
+reverse_lazy = lazy(reverse, str)
+
+
+def find_supported(test):
+    return [settings.LANGUAGE_URL_MAP[x] for
+            x in settings.LANGUAGE_URL_MAP if
+            x.split('-', 1)[0] == test.lower().split('-', 1)[0]]
+
+
+def split_path(path_):
+    """
+    Split the requested path into (locale, path).
+
+    locale will be empty if it isn't found.
+    """
+    path = path_.lstrip('/')
+
+    # Use partitition instead of split since it always returns 3 parts
+    first, _, rest = path.partition('/')
+
+    lang = first.lower()
+    if lang in settings.LANGUAGE_URL_MAP:
+        return settings.LANGUAGE_URL_MAP[lang], rest
+    else:
+        supported = find_supported(first)
+        if len(supported):
+            return supported[0], rest
+        else:
+            return '', path
+
+
+class Prefixer(object):
+
+    def __init__(self, request):
+        self.request = request
+        split = split_path(request.path_info)
+        self.locale, self.shortened_path = split
+
+    def get_language(self):
+        """
+        Return a locale code we support on the site using the
+        user's Accept-Language header to determine which is best. This
+        mostly follows the RFCs but read bug 439568 for details.
+        """
+        if 'lang' in self.request.GET:
+            lang = self.request.GET['lang'].lower()
+            if lang in settings.LANGUAGE_URL_MAP:
+                return settings.LANGUAGE_URL_MAP[lang]
+
+        if self.request.META.get('HTTP_ACCEPT_LANGUAGE'):
+            best = self.get_best_language(
+                self.request.META['HTTP_ACCEPT_LANGUAGE'])
+            if best:
+                return best
+        return settings.LANGUAGE_CODE
+
+    def get_best_language(self, accept_lang):
+        """Given an Accept-Language header, return the best-matching language."""
+        LUM = settings.LANGUAGE_URL_MAP
+        langs = dict(LUM.items() + settings.CANONICAL_LOCALES.items())
+        # Add missing short locales to the list. This will automatically map
+        # en to en-GB (not en-US), es to es-AR (not es-ES), etc. in alphabetical
+        # order. To override this behavior, explicitly define a preferred locale
+        # map with the CANONICAL_LOCALES setting.
+        langs.update((k.split('-')[0], v) for k, v in LUM.items() if
+                     k.split('-')[0] not in langs)
+        try:
+            ranked = parse_accept_lang_header(accept_lang)
+        except ValueError:  # see https://code.djangoproject.com/ticket/21078
+            return
+        else:
+            for lang, _ in ranked:
+                lang = lang.lower()
+                if lang in langs:
+                    return langs[lang]
+                pre = lang.split('-')[0]
+                if pre in langs:
+                    return langs[pre]
+
+    def fix(self, path):
+        path = path.lstrip('/')
+        url_parts = [self.request.META['SCRIPT_NAME']]
+
+        if path.partition('/')[0] not in settings.SUPPORTED_NONLOCALES:
+            locale = self.locale if self.locale else self.get_language()
+            url_parts.append(locale)
+
+        url_parts.append(path)
+
+        return '/'.join(url_parts)

--- a/bedrock/facebookapps/decorators.py
+++ b/bedrock/facebookapps/decorators.py
@@ -8,7 +8,7 @@ from functools import wraps
 from django.shortcuts import redirect
 from django.utils.decorators import available_attrs
 
-from funfactory import urlresolvers
+from bedrock.base import urlresolvers
 
 from bedrock.facebookapps import utils
 

--- a/bedrock/facebookapps/tests/test_views.py
+++ b/bedrock/facebookapps/tests/test_views.py
@@ -8,7 +8,7 @@ import urllib
 
 from django.conf import settings
 
-from funfactory.urlresolvers import reverse
+from bedrock.base.urlresolvers import reverse
 from mock import patch
 from nose.tools import eq_, ok_
 from pyquery import PyQuery as pq

--- a/bedrock/firefox/helpers.py
+++ b/bedrock/firefox/helpers.py
@@ -8,7 +8,7 @@ import jinja2
 
 from bedrock.firefox.models import FirefoxOSFeedLink
 from bedrock.firefox.firefox_details import firefox_desktop, firefox_android
-from funfactory.urlresolvers import reverse
+from bedrock.base.urlresolvers import reverse
 from lib.l10n_utils import get_locale
 
 

--- a/bedrock/firefox/tests/test_base.py
+++ b/bedrock/firefox/tests/test_base.py
@@ -9,9 +9,9 @@ from django.conf import settings
 from django.http import HttpResponse
 from django.test.client import Client, RequestFactory
 from django.test.utils import override_settings
-from funfactory.helpers import static
+from bedrock.base.helpers import static
 
-from funfactory.urlresolvers import reverse
+from bedrock.base.urlresolvers import reverse
 from mock import ANY, call, Mock, patch
 from nose.tools import eq_, ok_
 from pyquery import PyQuery as pq

--- a/bedrock/firefox/tests/test_views.py
+++ b/bedrock/firefox/tests/test_views.py
@@ -7,7 +7,7 @@ import json
 from django.test.client import RequestFactory
 from django.test.utils import override_settings
 
-from funfactory.urlresolvers import reverse
+from bedrock.base.urlresolvers import reverse
 from mock import patch
 from nose.tools import eq_, ok_
 

--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -16,8 +16,8 @@ from django.views.decorators.vary import vary_on_headers
 from django.views.generic.base import TemplateView
 
 import basket
-from funfactory.helpers import static
-from funfactory.urlresolvers import reverse
+from bedrock.base.helpers import static
+from bedrock.base.urlresolvers import reverse
 from lib import l10n_utils
 from lib.l10n_utils.dotlang import _
 from product_details.version_compare import Version

--- a/bedrock/legal/tests.py
+++ b/bedrock/legal/tests.py
@@ -6,7 +6,7 @@
 from django.core import mail
 from django.test.client import RequestFactory
 
-from funfactory.urlresolvers import reverse
+from bedrock.base.urlresolvers import reverse
 from mock import Mock, patch
 from nose.tools import eq_, ok_
 

--- a/bedrock/legal/views.py
+++ b/bedrock/legal/views.py
@@ -9,7 +9,7 @@ from django.core.mail import EmailMessage
 from django.shortcuts import redirect
 from django.views.decorators.csrf import csrf_protect
 
-from funfactory.urlresolvers import reverse
+from bedrock.base.urlresolvers import reverse
 
 from forms import FraudReportForm
 

--- a/bedrock/mozorg/helpers/misc.py
+++ b/bedrock/mozorg/helpers/misc.py
@@ -12,8 +12,8 @@ from django.template.defaultfilters import slugify as django_slugify
 import bleach
 import jingo
 import jinja2
-from funfactory.urlresolvers import reverse
-from funfactory.helpers import static
+from bedrock.base.urlresolvers import reverse
+from bedrock.base.helpers import static
 
 
 ALL_FX_PLATFORMS = ('windows', 'linux', 'mac', 'android', 'ios')

--- a/bedrock/mozorg/hierarchy.py
+++ b/bedrock/mozorg/hierarchy.py
@@ -4,7 +4,7 @@
 
 from django.conf.urls import patterns
 
-from funfactory.urlresolvers import reverse
+from bedrock.base.urlresolvers import reverse
 
 from bedrock.mozorg.util import page
 

--- a/bedrock/mozorg/tests/__init__.py
+++ b/bedrock/mozorg/tests/__init__.py
@@ -9,7 +9,7 @@ from django.utils.translation import get_language
 
 import test_utils
 from tower import activate
-from funfactory.urlresolvers import (get_url_prefix, Prefixer, set_url_prefix)
+from bedrock.base.urlresolvers import (get_url_prefix, Prefixer, set_url_prefix)
 
 
 class TestCase(TestCase):

--- a/bedrock/mozorg/tests/test_context_processors.py
+++ b/bedrock/mozorg/tests/test_context_processors.py
@@ -3,7 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 from django.test.client import RequestFactory
-from funfactory.urlresolvers import reverse
+from bedrock.base.urlresolvers import reverse
 
 from nose.tools import eq_
 

--- a/bedrock/mozorg/tests/test_helper_misc.py
+++ b/bedrock/mozorg/tests/test_helper_misc.py
@@ -5,10 +5,10 @@ from mock import patch
 from django.conf import settings
 from django.test.client import RequestFactory
 from django.test.utils import override_settings
-from funfactory.helpers import static
+from bedrock.base.helpers import static
 
 import jingo
-from funfactory.urlresolvers import reverse
+from bedrock.base.urlresolvers import reverse
 from nose.tools import eq_, ok_
 from pyquery import PyQuery as pq
 from rna.models import Release

--- a/bedrock/mozorg/tests/test_views.py
+++ b/bedrock/mozorg/tests/test_views.py
@@ -15,7 +15,7 @@ from django.test.utils import override_settings
 from django.utils import simplejson
 
 from captcha.fields import ReCaptchaField
-from funfactory.urlresolvers import reverse
+from bedrock.base.urlresolvers import reverse
 from jinja2.exceptions import TemplateNotFound
 from requests.exceptions import Timeout
 from mock import ANY, Mock, patch

--- a/bedrock/mozorg/views.py
+++ b/bedrock/mozorg/views.py
@@ -16,11 +16,11 @@ from django.views.generic import FormView, TemplateView
 from django.shortcuts import redirect, render as django_render
 
 import basket
-from funfactory.helpers import static
+from bedrock.base.helpers import static
 import requests
 from lib import l10n_utils
 from commonware.decorators import xframe_allow
-from funfactory.urlresolvers import reverse
+from bedrock.base.urlresolvers import reverse
 from lib.l10n_utils.dotlang import _, lang_file_is_active, lang_file_has_tag
 
 from bedrock.mozorg import email_contribute

--- a/bedrock/newsletter/tests/test_footer_form.py
+++ b/bedrock/newsletter/tests/test_footer_form.py
@@ -1,4 +1,4 @@
-from funfactory.urlresolvers import reverse
+from bedrock.base.urlresolvers import reverse
 from mock import patch
 from nose.tools import eq_
 from pyquery import PyQuery as pq

--- a/bedrock/newsletter/tests/test_views.py
+++ b/bedrock/newsletter/tests/test_views.py
@@ -8,7 +8,7 @@ from django.http import HttpResponse
 from django.test.client import RequestFactory
 
 import basket
-from funfactory.urlresolvers import reverse
+from bedrock.base.urlresolvers import reverse
 from mock import DEFAULT, Mock, patch
 from nose.tools import eq_, ok_
 from pyquery import PyQuery as pq

--- a/bedrock/newsletter/views.py
+++ b/bedrock/newsletter/views.py
@@ -21,7 +21,7 @@ import lib.l10n_utils as l10n_utils
 import requests
 from lib.l10n_utils.dotlang import _, _lazy
 from commonware.decorators import xframe_allow
-from funfactory.urlresolvers import reverse
+from bedrock.base.urlresolvers import reverse
 
 from .forms import (EmailForm, ManageSubscriptionsForm, NewsletterForm, NewsletterFooterForm)
 # Cannot use short "from . import utils" because we need to mock

--- a/bedrock/press/tests.py
+++ b/bedrock/press/tests.py
@@ -8,7 +8,7 @@ import datetime
 from django.core import mail
 from django.test.client import RequestFactory
 
-from funfactory.urlresolvers import reverse
+from bedrock.base.urlresolvers import reverse
 from mock import Mock, patch
 from nose.tools import eq_, ok_
 

--- a/bedrock/press/views.py
+++ b/bedrock/press/views.py
@@ -9,7 +9,7 @@ from django.utils.decorators import method_decorator
 from django.views.decorators.csrf import csrf_protect
 from django.views.generic.edit import FormView
 
-from funfactory.urlresolvers import reverse
+from bedrock.base.urlresolvers import reverse
 
 from .forms import SpeakerRequestForm
 from lib import l10n_utils

--- a/bedrock/redirects/tests/test_util.py
+++ b/bedrock/redirects/tests/test_util.py
@@ -101,7 +101,7 @@ class TestRedirectUrlPattern(TestCase):
     @patch('bedrock.redirects.util.reverse')
     def test_to_view(self, mock_reverse):
         """
-        Should use return value of funfactory reverse as redirect location
+        Should use return value of our locale-aware reverse as redirect location
         """
         mock_reverse.return_value = '/just/your/opinion/man'
         pattern, view = redirect(r'^the/dude$', 'yeah.well.you.know.thats')

--- a/bedrock/redirects/urls.py
+++ b/bedrock/redirects/urls.py
@@ -5,7 +5,7 @@
 from django.conf import settings
 from django.conf.urls import patterns
 
-from funfactory.helpers import static
+from bedrock.base.helpers import static
 from pipeline.collector import default_collector
 from pipeline.packager import Packager
 

--- a/bedrock/redirects/util.py
+++ b/bedrock/redirects/util.py
@@ -8,14 +8,14 @@ from django.core.urlresolvers import NoReverseMatch
 from django.conf.urls import url
 from django.http import HttpResponsePermanentRedirect, HttpResponseRedirect
 
-from funfactory.urlresolvers import reverse
+from bedrock.base.urlresolvers import reverse
 
 
 def redirect(pattern, to, permanent=True, anchor=None, name='', query=None):
     """
     Return a tuple suited for urlpatterns.
 
-    This will redirect the pattern to the viewname by applying funfactory's
+    This will redirect the pattern to the viewname by applying our
     locale-aware reverse to the given string.
 
     If a url is given instead of a viewname, the redirect will go directly to

--- a/bedrock/releasenotes/tests/test_base.py
+++ b/bedrock/releasenotes/tests/test_base.py
@@ -5,7 +5,7 @@ from django.http import Http404
 from django.test.client import RequestFactory
 from django.test.utils import override_settings
 
-from funfactory.urlresolvers import reverse
+from bedrock.base.urlresolvers import reverse
 from mock import patch, Mock
 from nose.tools import eq_
 from rna.models import Release

--- a/bedrock/releasenotes/views.py
+++ b/bedrock/releasenotes/views.py
@@ -8,7 +8,7 @@ from django.db.models import Q
 from django.http import Http404, HttpResponseRedirect
 from django.shortcuts import get_object_or_404
 
-from funfactory.urlresolvers import reverse
+from bedrock.base.urlresolvers import reverse
 from lib import l10n_utils
 from rna.models import Release
 from product_details import product_details

--- a/bedrock/security/models.py
+++ b/bedrock/security/models.py
@@ -8,7 +8,7 @@ from django.utils.functional import total_ordering
 
 from django_extensions.db.fields import ModificationDateTimeField
 from django_extensions.db.fields.json import JSONField
-from funfactory.urlresolvers import reverse
+from bedrock.base.urlresolvers import reverse
 from product_details.version_compare import Version
 
 

--- a/bedrock/security/views.py
+++ b/bedrock/security/views.py
@@ -8,7 +8,7 @@ from django.utils.decorators import method_decorator
 from django.views.decorators.http import last_modified
 from django.views.generic import DetailView, ListView, RedirectView
 
-from funfactory.urlresolvers import reverse
+from bedrock.base.urlresolvers import reverse
 from product_details import product_details
 from product_details.version_compare import Version
 from lib.l10n_utils import LangFilesMixin

--- a/bedrock/settings/__init__.py
+++ b/bedrock/settings/__init__.py
@@ -30,7 +30,7 @@ if DEV:
 WAFFLE_FLAG_DEFAULT = WAFFLE_SWITCH_DEFAULT = WAFFLE_SAMPLE_DEFAULT = DEV
 
 # Any databases configured other than "default" should be
-# read-only slaves, which funfactory's default router
+# read-only slaves, which our default router
 # should use with this setting.
 if 'manage.py' not in sys.argv:
     SLAVE_DATABASES = [db for db in DATABASES if db != 'default']

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -115,13 +115,18 @@ PROD_LANGUAGES = ('ach', 'af', 'an', 'ar', 'as', 'ast', 'az', 'be', 'bg',
                   'uz', 'vi', 'wo', 'xh', 'yo', 'zh-CN', 'zh-TW', 'zu')
 
 LOCALES_PATH = ROOT_PATH / 'locale'
-try:
-    DEV_LANGUAGES = [lang.name for lang in LOCALES_PATH.iterdir()
-                     if lang.is_dir() and lang.name != 'templates']
-except OSError:
-    # no locale dir
-    DEV_LANGUAGES = []
 
+
+def get_dev_languages():
+    try:
+        return [lang.name for lang in LOCALES_PATH.iterdir()
+                if lang.is_dir() and lang.name != 'templates']
+    except OSError:
+        # no locale dir
+        return []
+
+
+DEV_LANGUAGES = get_dev_languages()
 DEV_LANGUAGES.append('en-US')
 
 # Map short locale names to long, preferred locale names. This

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -2,12 +2,32 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-# Django settings file for bedrock.
-
+import logging
+import os
 from os.path import abspath
 
-from funfactory.settings_base import *  # noqa
+from django.utils.functional import lazy
 from django.utils.http import urlquote
+
+from pathlib import Path
+
+from .static_media import PIPELINE_CSS, PIPELINE_JS  # noqa
+
+
+# ROOT path of the project. A pathlib.Path object.
+ROOT_PATH = Path(__file__).resolve().parents[2]
+ROOT = str(ROOT_PATH)
+
+
+def path(*args):
+    return abspath(str(ROOT_PATH.joinpath(*args)))
+
+
+# Is this a dev instance?
+DEV = False
+
+DEBUG = False
+TEMPLATE_DEBUG = DEBUG
 
 # Production uses MySQL, but Sqlite should be sufficient for local development.
 # Our CI server tests against MySQL.
@@ -17,6 +37,8 @@ DATABASES = {
         'NAME': 'bedrock.db',
     }
 }
+SLAVE_DATABASES = []
+DATABASE_ROUTERS = ('multidb.PinningMasterSlaveRouter',)
 
 # Override in local.py for memcached.
 CACHES = {
@@ -26,11 +48,56 @@ CACHES = {
     }
 }
 
+# Site ID is used by Django's Sites framework.
+SITE_ID = 1
+
+# Logging
+LOG_LEVEL = logging.INFO
+HAS_SYSLOG = True
+SYSLOG_TAG = "http_app_playdoh"  # Change this after you fork.
+LOGGING_CONFIG = None
+
+# CEF Logging
+CEF_PRODUCT = 'Playdoh'
+CEF_VENDOR = 'Mozilla'
+CEF_VERSION = '0'
+CEF_DEVICE_VERSION = '0'
+
+
+# Internationalization.
+
+# Local time zone for this installation. Choices can be found here:
+# http://en.wikipedia.org/wiki/List_of_tz_zones_by_name
+# although not all choices may be available on all operating systems.
+# On Unix systems, a value of None will cause Django to use the same
+# timezone as the operating system.
+# If running in a Windows environment this must be set to the same as your
+# system time zone.
+TIME_ZONE = 'America/Los_Angeles'
+
+# If you set this to False, Django will make some optimizations so as not
+# to load the internationalization machinery.
+USE_I18N = True
+
+# If you set this to False, Django will not format dates, numbers and
+# calendars according to the current locale
+USE_L10N = True
+
 USE_TZ = True
+
+# Gettext text domain
+TEXT_DOMAIN = 'messages'
+STANDALONE_DOMAINS = [TEXT_DOMAIN, 'javascript']
+TOWER_KEYWORDS = {'_lazy': None}
+TOWER_ADD_HEADERS = True
 
 # Language code for this installation. All choices can be found here:
 # http://www.i18nguy.com/unicode/language-identifiers.html
 LANGUAGE_CODE = 'en-US'
+
+# Tells the product_details module where to find our local JSON files.
+# This ultimately controls how LANGUAGES are constructed.
+PROD_DETAILS_DIR = path('lib', 'product_details_json')
 
 # Accepted locales
 PROD_LANGUAGES = ('ach', 'af', 'an', 'ar', 'as', 'ast', 'az', 'be', 'bg',
@@ -46,10 +113,19 @@ PROD_LANGUAGES = ('ach', 'af', 'an', 'ar', 'as', 'ast', 'az', 'be', 'bg',
                   'rm', 'ro', 'ru', 'sat', 'si', 'sk', 'sl', 'son', 'sq', 'sr',
                   'sv-SE', 'sw', 'ta', 'te', 'th', 'tr', 'uk', 'ur',
                   'uz', 'vi', 'wo', 'xh', 'yo', 'zh-CN', 'zh-TW', 'zu')
-DEV_LANGUAGES = list(DEV_LANGUAGES) + ['en-US']
 
-# Map short locale names to long, preferred locale names. This overrides the
-# setting in funfactory and will be used in urlresolvers to determine the
+LOCALES_PATH = ROOT_PATH / 'locale'
+try:
+    DEV_LANGUAGES = [lang.name for lang in LOCALES_PATH.iterdir()
+                     if lang.is_dir() and lang.name != 'templates']
+except OSError:
+    # no locale dir
+    DEV_LANGUAGES = []
+
+DEV_LANGUAGES.append('en-US')
+
+# Map short locale names to long, preferred locale names. This
+# will be used in urlresolvers to determine the
 # best-matching locale from the user's Accept-Language header.
 CANONICAL_LOCALES = {
     'en': 'en-US',
@@ -60,6 +136,27 @@ CANONICAL_LOCALES = {
     'sv': 'sv-SE',
 }
 
+
+def lazy_lang_url_map():
+    from django.conf import settings
+
+    langs = settings.DEV_LANGUAGES if settings.DEV else settings.PROD_LANGUAGES
+    return {i.lower(): i for i in langs}
+
+
+# Override Django's built-in with our native names
+def lazy_langs():
+    from django.conf import settings
+    from product_details import product_details
+
+    langs = DEV_LANGUAGES if settings.DEV else settings.PROD_LANGUAGES
+    return {lang.lower(): product_details.languages[lang]['native']
+            for lang in langs if lang in product_details.languages}
+
+
+LANGUAGE_URL_MAP = lazy(lazy_lang_url_map, dict)()
+LANGUAGES = lazy(lazy_langs, dict)()
+
 FEED_CACHE = 3900
 DOTLANG_CACHE = 600
 
@@ -67,8 +164,10 @@ DOTLANG_FILES = ['main', 'download_button', 'newsletter']
 
 # Paths that don't require a locale code in the URL.
 # matches the first url component (e.g. mozilla.org/gameon/)
-SUPPORTED_NONLOCALES += [
+SUPPORTED_NONLOCALES = [
     # from redirects.urls
+    'media',
+    'static',
     'admin',
     'contribute.json',
     'credits',
@@ -112,7 +211,9 @@ def JINJA_CONFIG():
         'auto_reload': True,
     }
 
+
 MEDIA_URL = '/user-media/'
+MEDIA_ROOT = path('media')
 STATIC_URL = '/media/'
 STATIC_ROOT = path('static')
 STATICFILES_STORAGE = 'bedrock.base.storage.ManifestPipelineStorage'
@@ -127,7 +228,12 @@ STATICFILES_DIRS = (
 )
 
 JINGO_EXCLUDE_APPS = (
-    'admin', 'registration', 'rest_framework', 'rna', 'waffle')
+    'admin',
+    'registration',
+    'rest_framework',
+    'rna',
+    'waffle',
+)
 
 PIPELINE_DISABLE_WRAPPER = True
 PIPELINE_COMPILERS = (
@@ -140,1792 +246,6 @@ PIPELINE_JS_COMPRESSOR = 'pipeline.compressors.uglifyjs.UglifyJSCompressor'
 PIPELINE_UGLIFYJS_BINARY = path('node_modules', 'uglify-js', 'bin', 'uglifyjs')
 PIPELINE_CSS_COMPRESSOR = 'pipeline.compressors.cssmin.CSSMinCompressor'
 PIPELINE_CSSMIN_BINARY = path('node_modules', 'cssmin', 'bin', 'cssmin')
-
-# Bundles is a dictionary of two dictionaries, css and js, which list css files
-# and js files that can be bundled together by the minify app.
-PIPELINE_CSS = {
-    'csrf-failure': {
-        'source_filenames': (
-            'css/sandstone/sandstone-resp.less',
-            'css/csrf-failure.less',
-        ),
-        'output_filename': 'css/csrf-failure-bundle.css',
-    },
-    'about': {
-        'source_filenames': (
-            'css/sandstone/video-resp.less',
-            'css/mozorg/about-base.less',
-            'css/mozorg/mosaic.less',
-        ),
-        'output_filename': 'css/about-bundle.css',
-    },
-    'about-base': {
-        'source_filenames': (
-            'css/mozorg/about-base.less',
-        ),
-        'output_filename': 'css/about-base-bundle.css',
-    },
-    'credits-faq': {
-        'source_filenames': (
-            'css/mozorg/credits-faq.less',
-        ),
-        'output_filename': 'css/credits-faq-bundle.css',
-    },
-    'commit-access-policy': {
-        'source_filenames': (
-            'css/mozorg/commit-access-policy.less',
-        ),
-        'output_filename': 'css/commit-access-policy-bundle.css',
-    },
-    'commit-access-requirements': {
-        'source_filenames': (
-            'css/mozorg/commit-access-requirements.less',
-        ),
-        'output_filename': 'css/commit-access-requirements.css',
-    },
-    'about-forums': {
-        'source_filenames': (
-            'css/mozorg/about-forums.less',
-        ),
-        'output_filename': 'css/about-forums-bundle.css',
-    },
-    'foundation': {
-        'source_filenames': (
-            'css/foundation/foundation.less',
-        ),
-        'output_filename': 'css/foundation-bundle.css',
-    },
-    'gigabit': {
-        'source_filenames': (
-            'css/gigabit/gigabit.less',
-        ),
-        'output_filename': 'css/gigabit-bundle.css',
-    },
-    'grants': {
-        'source_filenames': (
-            'css/grants/grants.less',
-        ),
-        'output_filename': 'css/grants-bundle.css',
-    },
-    'lightbeam': {
-        'source_filenames': (
-            'css/lightbeam/lightbeam.less',
-        ),
-        'output_filename': 'css/lightbeam-bundle.css',
-    },
-    'itu': {
-        'source_filenames': (
-            'css/mozorg/itu.less',
-        ),
-        'output_filename': 'css/itu-bundle.css',
-    },
-    'common': {
-        'source_filenames': (
-            'css/sandstone/sandstone.less',
-        ),
-        'output_filename': 'css/common-bundle.css',
-    },
-    'responsive': {
-        'source_filenames': (
-            'css/sandstone/sandstone-resp.less',
-        ),
-        'output_filename': 'css/responsive-bundle.css',
-    },
-    'oldIE': {
-        'source_filenames': (
-            'css/sandstone/oldIE.less',
-        ),
-        'output_filename': 'css/oldIE-bundle.css',
-    },
-    'newsletter': {
-        'source_filenames': (
-            'css/newsletter/newsletter.less',
-        ),
-        'output_filename': 'css/newsletter-bundle.css',
-    },
-    'contact-spaces': {
-        'source_filenames': (
-            'css/libs/mapbox-2.1.5.css',
-            'css/libs/magnific-popup.css',
-            'css/base/mozilla-video-poster.less',
-            'css/mozorg/contact-spaces.less',
-        ),
-        'output_filename': 'css/contact-spaces-bundle.css',
-    },
-    'contact-spaces-ie7': {
-        'source_filenames': (
-            'css/mozorg/contact-spaces-ie7.less',
-        ),
-        'output_filename': 'css/contact-spaces-ie7-bundle.css',
-    },
-    'contribute-old': {
-        'source_filenames': (
-            'css/mozorg/contribute/contribute-form.less',
-            'css/mozorg/contribute/contribute-old.less',
-            'css/sandstone/video-resp.less',
-        ),
-        'output_filename': 'css/contribute-old-bundle.css',
-    },
-    'contribute-studentambassadors-landing': {
-        'source_filenames': (
-            'css/base/social-widgets.less',
-            'css/mozorg/contribute/studentambassadors/landing.less',
-        ),
-        'output_filename': 'css/contribute-studentambassadors-landing-bundle.css',
-    },
-    'contribute-studentambassadors-join': {
-        'source_filenames': (
-            'css/mozorg/contribute/studentambassadors/join.less',
-        ),
-        'output_filename': 'css/contribute-studentambassadors-join-bundle.css',
-    },
-    'dnt': {
-        'source_filenames': (
-            'css/sandstone/sandstone-resp.less',
-            'css/firefox/family-nav.less',
-            'css/base/mozilla-accordion.less',
-            'css/firefox/dnt.less',
-        ),
-        'output_filename': 'css/dnt-bundle.css',
-    },
-    'firefox': {
-        'source_filenames': (
-            'css/sandstone/sandstone.less',
-            'css/firefox/menu.less',
-            'css/firefox/template.less',
-        ),
-        'output_filename': 'css/firefox-bundle.css',
-    },
-    'firefox_all': {
-        'source_filenames': (
-            'css/base/mozilla-share-cta.less',
-            'css/sandstone/sandstone-resp.less',
-            'css/firefox/menu-resp.less',
-            'css/firefox/all.less',
-        ),
-        'output_filename': 'css/firefox_all-bundle.css',
-    },
-    'firefox_android': {
-        'source_filenames': (
-            'css/sandstone/sandstone-resp.less',
-            'css/firefox/family-nav.less',
-            'css/base/mozilla-accordion.less',
-            'css/firefox/android.less',
-        ),
-        'output_filename': 'css/firefox_android-bundle.css',
-    },
-    'firefox_unsupported': {
-        'source_filenames': (
-            'css/firefox/unsupported.less',
-        ),
-        'output_filename': 'css/firefox_unsupported-bundle.css',
-    },
-    'firefox_unsupported_systems': {
-        'source_filenames': (
-            'css/firefox/unsupported-systems.less',
-        ),
-        'output_filename': 'css/firefox_unsupported_systems-bundle.css',
-    },
-    'firefox-resp': {
-        'source_filenames': (
-            'css/sandstone/sandstone-resp.less',
-            'css/firefox/template-resp.less',
-        ),
-        'output_filename': 'css/firefox-resp-bundle.css',
-    },
-    'firefox_channel': {
-        'source_filenames': (
-            'css/firefox/channel.less',
-        ),
-        'output_filename': 'css/firefox_channel-bundle.css',
-    },
-    'firefox-dashboard': {
-        'source_filenames': (
-            'css/sandstone/sandstone-resp.less',
-            'css/firefox/template-resp.less',
-            'css/base/mozilla-accordion.less',
-            'css/firefox/menu-resp.less',
-            'css/firefox/dashboard.less',
-        ),
-        'output_filename': 'css/firefox-dashboard-bundle.css',
-    },
-    'firefox_desktop': {
-        'source_filenames': (
-            'css/sandstone/sandstone-resp.less',
-            'css/firefox/family-nav.less',
-            'css/firefox/desktop/intro-anim.less',
-            'css/base/svg-animation-check.less',
-            'css/firefox/desktop/index.less',
-        ),
-        'output_filename': 'css/firefox_desktop-bundle.css',
-    },
-    'firefox_desktop_fast': {
-        'source_filenames': (
-            'css/sandstone/sandstone-resp.less',
-            'css/firefox/family-nav.less',
-            'css/firefox/desktop/fast.less',
-        ),
-        'output_filename': 'css/firefox_desktop_fast-bundle.css',
-    },
-    'firefox_desktop_customize': {
-        'source_filenames': (
-            'css/sandstone/sandstone-resp.less',
-            'css/firefox/family-nav.less',
-            'css/firefox/desktop/customize.less',
-        ),
-        'output_filename': 'css/firefox_desktop_customize-bundle.css',
-    },
-    'firefox_desktop_tips': {
-        'source_filenames': (
-            'css/sandstone/sandstone-resp.less',
-            'css/libs/socialshare/socialshare.less',
-            'css/firefox/desktop/tips.less',
-        ),
-        'output_filename': 'css/firefox_desktop_tips-bundle.css',
-    },
-    'firefox_desktop_trust': {
-        'source_filenames': (
-            'css/sandstone/sandstone-resp.less',
-            'css/firefox/family-nav.less',
-            'css/firefox/desktop/trust.less',
-        ),
-        'output_filename': 'css/firefox_desktop_trust-bundle.css',
-    },
-    'firefox_sms': {
-        'source_filenames': (
-            'css/sandstone/sandstone-resp.less',
-            'css/base/mozilla-share-cta.less',
-            'css/firefox/template-resp.less',
-            'css/sandstone/video-resp.less',
-            'css/firefox/mobile-sms.less',
-        ),
-        'output_filename': 'css/firefox_sms-bundle.css',
-    },
-    'firefox-interest-dashboard': {
-        'source_filenames': (
-            'css/firefox/family-nav.less',
-            'css/firefox/interest-dashboard.less',
-        ),
-        'output_filename': 'css/firefox-interest-dashboard-bundle.css',
-    },
-    'firefox-tiles': {
-        'source_filenames': (
-            'css/firefox/family-nav.less',
-            'css/firefox/tiles.less',
-        ),
-        'output_filename': 'css/firefox-tiles-bundle.css',
-    },
-    'firefox_family': {
-        'source_filenames': (
-            'css/sandstone/sandstone-resp.less',
-            'css/tabzilla/tabzilla-static.less',
-            'css/firefox/family/index.less',
-        ),
-        'output_filename': 'css/firefox-family-bundle.css',
-    },
-    'firefox_family_ie': {
-        'source_filenames': (
-            'css/firefox/family/index-ie.less',
-        ),
-        'output_filename': 'css/firefox-family-ie-bundle.css',
-    },
-    'firefox_faq': {
-        'source_filenames': (
-            'css/sandstone/sandstone-resp.less',
-            'css/firefox/menu-resp.less',
-            'css/firefox/faq.less',
-            'css/firefox/template-resp.less',
-            'css/base/mozilla-accordion.less',
-        ),
-        'output_filename': 'css/firefox_faq-bundle.css',
-    },
-    'firefox_firstrun': {
-        'source_filenames': (
-            'css/sandstone/sandstone-resp.less',
-            'css/firefox/template-resp.less',
-            'css/sandstone/video.less',
-            'css/base/mozilla-modal.less',
-            'css/firefox/firstrun.less',
-        ),
-        'output_filename': 'css/firefox_firstrun-bundle.css',
-    },
-    'firefox_fx36_firstrun': {
-        'source_filenames': (
-            'css/sandstone/sandstone.less',
-            'css/firefox/australis/australis-ui-tour.less',
-            'css/firefox/hello-animation.less',
-            'css/firefox/australis/fx36/common.less',
-        ),
-        'output_filename': 'css/firefox_fx36_firstrun-bundle.css',
-    },
-    'firefox_fx36_whatsnew': {
-        'source_filenames': (
-            'css/sandstone/sandstone.less',
-            'css/firefox/australis/australis-ui-tour.less',
-            'css/firefox/hello-animation.less',
-            'css/firefox/australis/fx36/common.less',
-        ),
-        'output_filename': 'css/firefox_fx36_whatsnew-bundle.css',
-    },
-    'firefox_fx36_whatsnew_no_tour': {
-        'source_filenames': (
-            'css/sandstone/sandstone.less',
-            'css/firefox/hello-animation.less',
-            'css/firefox/australis/fx36/common.less',
-        ),
-        'output_filename': 'css/firefox_fx36_whatsnew_no_tour-bundle.css',
-    },
-    'firefox_developer_firstrun': {
-        'source_filenames': (
-            'css/sandstone/sandstone-resp.less',
-            'css/firefox/template-resp.less',
-            'css/base/mozilla-modal.less',
-            'css/firefox/dev-firstrun.less',
-        ),
-        'output_filename': 'css/firefox_developer_firstrun-bundle.css',
-    },
-    'nightly_firstrun': {
-        'source_filenames': (
-            'css/sandstone/sandstone-resp.less',
-            'css/firefox/template-resp.less',
-            'css/firefox/nightly_firstrun.less',
-        ),
-        'output_filename': 'css/nightly_firstrun-bundle.css',
-    },
-    'firefox_feedback': {
-        'source_filenames': (
-            'css/sandstone/sandstone-resp.less',
-            'css/base/mozilla-share-cta.less',
-            'css/firefox/feedback.less',
-        ),
-        'output_filename': 'css/firefox_feedback-bundle.css',
-    },
-    'firefox_geolocation': {
-        'source_filenames': (
-            'css/sandstone/sandstone-resp.less',
-            'css/firefox/template-resp.less',
-            'css/firefox/menu-resp.less',
-            'css/base/mozilla-accordion.less',
-            'css/base/mozilla-modal.less',
-            'css/libs/mapbox-2.1.5.css',
-            'css/firefox/geolocation.less'
-        ),
-        'output_filename': 'css/firefox_geolocation-bundle.css',
-    },
-    'firefox_developer': {
-        'source_filenames': (
-            'css/sandstone/sandstone-resp.less',
-            'css/firefox/template-resp.less',
-            'css/base/mozilla-modal.less',
-            'css/base/mozilla-share-cta.less',
-            'css/firefox/menu-resp.less',
-            'css/firefox/developer.less',
-        ),
-        'output_filename': 'css/firefox_developer-bundle.css',
-    },
-    'firefox_hello_start': {
-        'source_filenames': (
-            'css/sandstone/sandstone-resp.less',
-            'css/firefox/hello/start.less',
-        ),
-        'output_filename': 'css/firefox_hello_start-bundle.css',
-    },
-    'firefox_hello': {
-        'source_filenames': (
-            'css/sandstone/sandstone-resp.less',
-            'css/firefox/family-nav.less',
-            'css/base/mozid-modal.less',
-            'css/base/svg-animation-check.less',
-            'css/base/mozilla-share-cta.less',
-            'css/firefox/hello/index.less',
-        ),
-        'output_filename': 'css/firefox_hello-bundle.css',
-    },
-    'firefox_new': {
-        'source_filenames': (
-            'css/sandstone/sandstone-resp.less',
-            'css/firefox/template-resp.less',
-            'css/libs/socialshare/socialshare.less',
-            'css/firefox/simple_footer-resp.less',
-            'css/firefox/new.less',
-        ),
-        'output_filename': 'css/firefox_new-bundle.css',
-    },
-    'firefox_organizations': {
-        'source_filenames': (
-            'css/sandstone/sandstone-resp.less',
-            'css/firefox/template-resp.less',
-            'css/firefox/organizations.less',
-        ),
-        'output_filename': 'css/firefox_organizations-bundle.css',
-    },
-    'firefox_os': {
-        'source_filenames': (
-            'css/sandstone/sandstone-resp.less',
-            'css/base/mozilla-modal.less',
-            'css/libs/jquery.pageslide.css',
-            'css/firefox/os/get_device.less',
-            'css/firefox/os/firefox-os.less',
-        ),
-        'output_filename': 'css/firefox_os-bundle.css',
-    },
-    'firefox_os_new': {
-        'source_filenames': (
-            'css/sandstone/sandstone-resp.less',
-            'css/base/mozilla-modal.less',
-            'css/firefox/family-nav.less',
-            'css/firefox/os/get_device.less',
-            'css/firefox/os/firefox-os-new.less',
-        ),
-        'output_filename': 'css/firefox_os_new-bundle.css',
-    },
-    'firefox_os_ie': {
-        'source_filenames': (
-            'css/firefox/os/firefox-os-ie.less',
-        ),
-        'output_filename': 'css/firefox_os_ie-bundle.css',
-    },
-    'firefox_os_devices': {
-        'source_filenames': (
-            'css/libs/tipsy.css',
-            'css/sandstone/sandstone-resp.less',
-            'css/firefox/family-nav.less',
-            'css/base/mozilla-modal.less',
-            'css/firefox/os/get_device.less',
-            'css/firefox/os/devices.less',
-        ),
-        'output_filename': 'css/firefox_os_devices-bundle.css',
-    },
-    'firefox_os_devices_ie': {
-        'source_filenames': (
-            'css/firefox/os/devices-ie.less',
-        ),
-        'output_filename': 'css/firefox_os_devices_ie-bundle.css',
-    },
-    'firefox_os_mwc_2015_preview': {
-        'source_filenames': (
-            'css/sandstone/sandstone-resp.less',
-            'css/base/mozilla-modal.less',
-            'css/firefox/family-nav.less',
-            'css/firefox/os/mwc-2015-preview.less',
-        ),
-        'output_filename': 'css/firefox_os_mwc_2015_preview-bundle.css',
-    },
-    'firefox_os_tv': {
-        'source_filenames': (
-            'css/sandstone/sandstone-resp.less',
-            'css/firefox/template-resp.less',
-            'css/firefox/os/tv.less',
-        ),
-        'output_filename': 'css/firefox_os_tv-bundle.css',
-    },
-    'firefox_releases_index': {
-        'source_filenames': (
-            'css/sandstone/sandstone-resp.less',
-            'css/firefox/template-resp.less',
-            'css/firefox/menu-resp.less',
-            'css/firefox/releases-index.less',
-        ),
-        'output_filename': 'css/firefox_releases_index-bundle.css',
-    },
-    'firefox_privacy_tour': {
-        'source_filenames': (
-            'css/sandstone/sandstone.less',
-            'css/base/mozilla-modal.less',
-            'css/base/mozilla-share-cta.less',
-            'css/firefox/independent-splash.less',
-            'css/firefox/australis/australis-ui-tour.less',
-            'css/firefox/privacy_tour/common.less',
-            'css/firefox/privacy_tour/tour.less',
-        ),
-        'output_filename': 'css/firefox_privacy_tour-bundle.css',
-    },
-    'firefox_privacy_no_tour': {
-        'source_filenames': (
-            'css/sandstone/sandstone.less',
-            'css/base/mozilla-modal.less',
-            'css/base/mozilla-share-cta.less',
-            'css/firefox/independent-splash.less',
-            'css/firefox/privacy_tour/common.less',
-            'css/firefox/privacy_tour/no-tour.less',
-        ),
-        'output_filename': 'css/firefox_privacy_no_tour-bundle.css',
-    },
-    'firefox_search_tour': {
-        'source_filenames': (
-            'css/sandstone/sandstone.less',
-            'css/firefox/search_tour/common.less',
-            'css/firefox/search_tour/tour.less',
-        ),
-        'output_filename': 'css/firefox_search_tour-bundle.css',
-    },
-    'firefox_search_no_tour': {
-        'source_filenames': (
-            'css/sandstone/sandstone.less',
-            'css/firefox/search_tour/common.less',
-        ),
-        'output_filename': 'css/firefox_search_no_tour-bundle.css',
-    },
-    'firefox_tour': {
-        'source_filenames': (
-            'css/sandstone/sandstone.less',
-            'css/firefox/australis/australis-ui-tour.less',
-            'css/firefox/australis/australis-page-common.less',
-            'css/firefox/sync-animation.less',
-            'css/firefox/australis/australis-page-stacked.less',
-        ),
-        'output_filename': 'css/firefox_tour-bundle.css',
-    },
-    'firefox_whatsnew': {
-        'source_filenames': (
-            'css/sandstone/sandstone-resp.less',
-            'css/firefox/template-resp.less',
-            'css/sandstone/video.less',
-            'css/firefox/whatsnew.less',
-            'css/firefox/whatsnew-android.less',
-        ),
-        'output_filename': 'css/firefox_whatsnew-bundle.css',
-    },
-    'firefox_whatsnew_37': {
-        'source_filenames': (
-            'css/sandstone/sandstone-resp.less',
-            'css/firefox/template-resp.less',
-            'css/firefox/whatsnew-fx37.less',
-        ),
-        'output_filename': 'css/firefox_whatsnew_37-bundle.css',
-    },
-    'firefox_whatsnew_fxos': {
-        'source_filenames': (
-            'css/sandstone/sandstone.less',
-            'css/firefox/simple_footer.less',
-            'css/firefox/whatsnew-fxos.less',
-        ),
-        'output_filename': 'css/firefox_whatsnew_fxos-bundle.css',
-    },
-    'firefox_releasenotes': {
-        'source_filenames': (
-            'css/sandstone/sandstone-resp.less',
-            'css/firefox/template-resp.less',
-            'css/firefox/menu-resp.less',
-            'css/firefox/releasenotes.less',
-        ),
-        'output_filename': 'css/firefox_releasenotes-bundle.css',
-    },
-    'firefox_sync': {
-        'source_filenames': (
-            'css/sandstone/sandstone-resp.less',
-            'css/firefox/family-nav.less',
-            'css/firefox/sync.less',
-        ),
-        'output_filename': 'css/firefox_sync-bundle.css',
-    },
-    'firefox_sync_old': {
-        'source_filenames': (
-            'css/sandstone/sandstone-resp.less',
-            'css/firefox/family-nav.less',
-            'css/firefox/sync-old.less',
-        ),
-        'output_filename': 'css/firefox_sync_old-bundle.css',
-    },
-    'firefox_sync_anim': {
-        'source_filenames': (
-            'css/firefox/sync-animation.less',
-        ),
-        'output_filename': 'css/firefox_sync_anim-bundle.css',
-    },
-    'firefox_independent': {
-        'source_filenames': (
-            'css/sandstone/sandstone-resp.less',
-            'css/base/mozilla-share-cta.less',
-            'css/firefox/independent-splash.less',
-            'css/firefox/independent.less',
-        ),
-        'output_filename': 'css/firefox_independent-bundle.css',
-    },
-    'installer_help': {
-        'source_filenames': (
-            'css/sandstone/sandstone-resp.less',
-            'css/firefox/template-resp.less',
-            'css/firefox/menu-resp.less',
-            'css/base/mozilla-modal.less',
-            'css/firefox/installer-help.less',
-        ),
-        'output_filename': 'css/installer_help-bundle.css',
-    },
-    'growth_firstrun_test1': {
-        'source_filenames': (
-            'css/sandstone/sandstone.less',
-            'css/firefox/australis/australis-page-common.less',
-            'css/firefox/sync-animation.less',
-            'css/firefox/australis/australis-page-stacked.less',
-            'css/firefox/australis/growth-firstrun-test-common.less',
-            'css/firefox/australis/growth-firstrun-test1.less',
-        ),
-        'output_filename': 'css/growth-firstrun-test1-bundle.css'
-    },
-    'growth_firstrun_test2': {
-        'source_filenames': (
-            'css/sandstone/sandstone.less',
-            'css/firefox/australis/australis-page-common.less',
-            'css/firefox/sync-animation.less',
-            'css/firefox/australis/australis-page-stacked.less',
-            'css/firefox/australis/growth-firstrun-test-common.less',
-            'css/firefox/australis/growth-firstrun-test2.less',
-        ),
-        'output_filename': 'css/growth-firstrun-test2-bundle.css'
-    },
-    'history-slides': {
-        'source_filenames': (
-            'css/mozorg/history-slides.less',
-        ),
-        'output_filename': 'css/history-slides-bundle.css',
-    },
-    'home': {
-        'source_filenames': (
-            'css/mozorg/home.less',
-            'css/mozorg/home-promo.less',
-        ),
-        'output_filename': 'css/home-bundle.css',
-    },
-    'home-ie9': {
-        'source_filenames': (
-            'css/mozorg/home-ie9.less',
-        ),
-        'output_filename': 'css/home-ie9-bundle.css',
-    },
-    'home-ie8': {
-        'source_filenames': (
-            'css/mozorg/home-ie8.less',
-        ),
-        'output_filename': 'css/home-ie8-bundle.css',
-    },
-    'home-ie': {
-        'source_filenames': (
-            'css/mozorg/home-ie.less',
-        ),
-        'output_filename': 'css/home-ie-bundle.css',
-    },
-    'home-2015': {
-        'source_filenames': (
-            'css/mozorg/home/home.less',
-            'css/mozorg/home/home-promo.less',
-        ),
-        'output_filename': 'css/home-2015-bundle.css',
-    },
-    'home-2015-ie8': {
-        'source_filenames': (
-            'css/mozorg/home/home-ie8.less',
-        ),
-        'output_filename': 'css/home-2015-ie8-bundle.css',
-    },
-    'legal': {
-        'source_filenames': (
-            'css/sandstone/sandstone-resp.less',
-            'css/legal/legal.less',
-        ),
-        'output_filename': 'css/legal-bundle.css',
-    },
-    'legal-eula': {
-        'source_filenames': (
-            'css/legal/eula.less',
-        ),
-        'output_filename': 'css/legal-eula-bundle.css',
-    },
-    'legal_fraud_report': {
-        'source_filenames': (
-            'css/sandstone/sandstone-resp.less',
-            'css/legal/fraud-report.less',
-        ),
-        'output_filename': 'css/legal_fraud_report-bundle.css',
-    },
-    'manifesto': {
-        'source_filenames': (
-            'css/base/mozilla-modal.less',
-            'css/libs/socialshare/socialshare.less',
-            'css/mozorg/mosaic.less',
-            'css/mozorg/manifesto.less',
-        ),
-        'output_filename': 'css/manifesto-bundle.css',
-    },
-    'mission': {
-        'source_filenames': (
-            'css/sandstone/video-resp.less',
-            'css/mozorg/mosaic.less',
-            'css/mozorg/mission.less',
-        ),
-        'output_filename': 'css/mission-bundle.css',
-    },
-    'mozilla_accordion': {
-        'source_filenames': (
-            'css/base/mozilla-accordion.less',
-        ),
-        'output_filename': 'css/mozilla_accordion-bundle.css',
-    },
-    'newsletter_ios': {
-        'source_filenames': (
-            'css/sandstone/sandstone-resp.less',
-            'css/newsletter/ios.less',
-        ),
-        'output_filename': 'css/newsletter_ios-bundle.css',
-    },
-    'partnerships': {
-        'source_filenames': (
-            'css/mozorg/partnerships.less',
-        ),
-        'output_filename': 'css/partnerships-bundle.css',
-    },
-    'persona': {
-        'source_filenames': (
-            'css/persona/persona.less',
-        ),
-        'output_filename': 'css/persona-bundle.css',
-    },
-    'powered-by': {
-        'source_filenames': (
-            'css/sandstone/sandstone-resp.less',
-            'css/mozorg/powered-by.less',
-        ),
-        'output_filename': 'css/powered-by-bundle.css',
-    },
-    'plugincheck': {
-        'source_filenames': (
-            'css/base/mozilla-share-cta.less',
-            'css/plugincheck/plugincheck.less',
-        ),
-        'output_filename': 'css/plugincheck-bundle.css',
-    },
-    'press_speaker_request': {
-        'source_filenames': (
-            'css/sandstone/sandstone-resp.less',
-            'css/press/speaker-request.less',
-        ),
-        'output_filename': 'css/press_speaker_request-bundle.css',
-    },
-    'privacy': {
-        'source_filenames': (
-            'css/privacy/privacy.less',
-        ),
-        'output_filename': 'css/privacy-bundle.css',
-    },
-    'privacy-day': {
-        'source_filenames': (
-            'css/sandstone/sandstone-resp.less',
-            'css/base/mozilla-share-cta.less',
-            'css/privacy/privacy-day.less',
-        ),
-        'output_filename': 'css/privacy-day-bundle.css',
-    },
-    'fb_privacy': {
-        'source_filenames': (
-            'css/privacy/fb-privacy.less',
-        ),
-        'output_filename': 'css/fb_privacy-bundle.css',
-    },
-    'projects_mozilla_based': {
-        'source_filenames': (
-            'css/mozorg/projects/mozilla-based.less',
-        ),
-        'output_filename': 'css/projects_mozilla_based-bundle.css',
-    },
-    'projects-calendar': {
-        'source_filenames': (
-            'css/mozorg/projects/calendar.less',
-        ),
-        'output_filename': 'css/projects-calendar-bundle.css',
-    },
-    'research': {
-        'source_filenames': (
-            'css/research/research.less',
-        ),
-        'output_filename': 'css/research-bundle.css',
-    },
-    'security': {
-        'source_filenames': (
-            'css/sandstone/sandstone-resp.less',
-            'css/security/security.less',
-        ),
-        'output_filename': 'css/security-bundle.css',
-    },
-    'security-bug-bounty-hall-of-fame': {
-        'source_filenames': (
-            'css/security/hall-of-fame.less',
-            'css/base/mozilla-accordion.less',
-        ),
-        'output_filename': 'css/security-bug-bounty-hall-of-fame-bundle.css',
-    },
-    'security-tld-idn': {
-        'source_filenames': (
-            'css/mozorg/security-tld-idn.less',
-        ),
-        'output_filename': 'css/security-tld-idn-bundle.css',
-    },
-    'styleguide': {
-        'source_filenames': (
-            'css/sandstone/fonts.less',
-            'css/styleguide/styleguide.less',
-            'css/styleguide/websites-sandstone.less',
-            'css/styleguide/identity-mozilla.less',
-            'css/styleguide/identity-firefox.less',
-            'css/styleguide/identity-firefox-family.less',
-            'css/styleguide/identity-firefoxos.less',
-            'css/styleguide/identity-marketplace.less',
-            'css/styleguide/identity-thunderbird.less',
-            'css/styleguide/identity-webmaker.less',
-            'css/styleguide/communications.less',
-            'css/styleguide/products-firefox-os.less',
-        ),
-        'output_filename': 'css/styleguide-bundle.css',
-    },
-    'styleguide-docs-mozilla-accordion': {
-        'source_filenames': (
-            'css/base/mozilla-accordion.less',
-            'css/sandstone/sandstone-resp.less',
-        ),
-        'output_filename': 'css/styleguide-docs-mozilla-accordion-bundle.css',
-    },
-    'styleguide-docs-mozilla-pager': {
-        'source_filenames': (
-            'css/sandstone/sandstone-resp.less',
-            'css/styleguide/docs/mozilla-pager.less',
-        ),
-        'output_filename': 'css/styleguide-docs-mozilla-pager-bundle.css',
-    },
-    'tabzilla': {
-        'source_filenames': (
-            'css/tabzilla/tabzilla.less',
-        ),
-        'output_filename': 'css/tabzilla-min.css',
-    },
-    'contribute-2015': {
-        'source_filenames': (
-            'css/base/mozilla-modal.less',
-            'css/mozorg/contribute/contribute-2015.less',
-        ),
-        'output_filename': 'css/contribute-2015-bundle.css',
-    },
-    'video': {
-        'source_filenames': (
-            'css/sandstone/video.less',
-        ),
-        'output_filename': 'css/video-bundle.css',
-    },
-    'video-resp': {
-        'source_filenames': (
-            'css/sandstone/video-resp.less',
-        ),
-        'output_filename': 'css/video-resp-bundle.css',
-    },
-    'page_not_found': {
-        'source_filenames': (
-            'css/base/page-not-found.less',
-        ),
-        'output_filename': 'css/page_not_found-bundle.css',
-    },
-    'annual_2011': {
-        'source_filenames': (
-            'css/foundation/annual2011.less',
-        ),
-        'output_filename': 'css/annual_2011-bundle.css',
-    },
-    'annual_2012': {
-        'source_filenames': (
-            'css/base/mozilla-modal.less',
-            'css/foundation/annual2012.less',
-        ),
-        'output_filename': 'css/annual_2012-bundle.css',
-    },
-    'annual_2013': {
-        'source_filenames': (
-            'css/base/mozilla-modal.less',
-            'css/foundation/annual2013.less',
-        ),
-        'output_filename': 'css/annual_2013-bundle.css',
-    },
-    'partners': {
-        'source_filenames': (
-            'css/base/mozilla-modal.less',
-            'css/libs/jquery.pageslide.css',
-            'css/firefox/partners.less',
-            'css/firefox/family-nav.less',
-            'css/firefox/mwc-2015-schedule.less',
-            'css/firefox/mwc-2015-map.less',
-        ),
-        'output_filename': 'css/partners-bundle.css',
-    },
-    'partners-ie7': {
-        'source_filenames': (
-            'css/firefox/partners/ie7.less',
-        ),
-        'output_filename': 'css/partners-ie7-bundle.css',
-    },
-    'facebookapps_downloadtab': {
-        'source_filenames': (
-            'css/libs/h5bp_main.css',
-            'css/facebookapps/downloadtab.less',
-        ),
-        'output_filename': 'css/facebookapps_downloadtab-bundle.css',
-    },
-    'thunderbird-start': {
-        'source_filenames': (
-            'css/sandstone/fonts.less',
-            'css/thunderbird/start.less',
-        ),
-        'output_filename': 'css/thunderbird-start-bundle.css',
-    },
-}
-
-PIPELINE_JS = {
-    'site': {
-        'source_filenames': (
-            'js/base/site.js',  # this is automatically included on every page
-        ),
-        'output_filename': 'js/site-bundle.js',
-    },
-    'lightbeam': {
-        'source_filenames': (
-            'js/lightbeam/d3.v3.min.js',
-            'js/lightbeam/rAF.js',
-            'js/lightbeam/lightbeam.js',
-            'js/lightbeam/ui.js',
-            'js/libs/jquery.validate.js',
-        ),
-        'output_filename': 'js/lightbeam-bundle.js',
-    },
-    'projects-calendar': {
-        'source_filenames': (
-            'js/mozorg/calendar.js',
-        ),
-        'output_filename': 'js/projects-calendar-bundle.js',
-    },
-    'common': {
-        'source_filenames': (
-            'js/libs/jquery-1.11.0.min.js',
-            'js/libs/spin.min.js',
-            'js/base/global.js',
-            'js/base/global-init.js',
-            'js/newsletter/form.js',
-            'js/base/mozilla-input-placeholder.js',
-            'js/base/mozilla-image-helper.js',
-        ),
-        'output_filename': 'js/common-bundle.js',
-    },
-    'common-resp': {
-        'source_filenames': (
-            'js/libs/jquery-1.11.0.min.js',
-            'js/libs/spin.min.js',
-            'js/base/global.js',
-            'js/base/global-init.js',
-            'js/newsletter/form.js',
-            'js/base/nav-main-resp.js',
-            'js/base/mozilla-input-placeholder.js',
-            'js/base/mozilla-image-helper.js',
-        ),
-        'output_filename': 'js/common-resp-bundle.js',
-    },
-    'contact-spaces': {
-        'source_filenames': (
-            'js/libs/mapbox-2.1.5.js',
-            'js/libs/jquery.history.js',
-            'js/mozorg/contact-data.js',
-            'js/libs/jquery.magnific-popup.min.js',
-            'js/base/mozilla-video-poster.js',
-            'js/mozorg/contact-spaces.js',
-        ),
-        'output_filename': 'js/contact-spaces-bundle.js',
-    },
-    'contact-spaces-ie7': {
-        'source_filenames': (
-            'js/mozorg/contact-spaces-ie7.js',
-        ),
-        'output_filename': 'js/contact-spaces-ie7-bundle.js',
-    },
-    'contribute-faces': {
-        'source_filenames': (
-            'js/mozorg/contribute/contribute-faces.js',
-        ),
-        'output_filename': 'js/contribute-faces-bundle.js',
-    },
-    'contribute-form': {
-        'source_filenames': (
-            'js/mozorg/contribute/contribute-form.js',
-            'js/base/mozilla-input-placeholder.js',
-        ),
-        'output_filename': 'js/contribute-form-bundle.js',
-    },
-    'contribute-studentambassadors-landing': {
-        'source_filenames': (
-            'js/base/social-widgets.js',
-        ),
-        'output_filename': 'js/contribute-studentambassadors-landing-bundle.js',
-    },
-    'contribute-studentambassadors-join': {
-        'source_filenames': (
-            'js/mozorg/contribute/contribute-studentambassadors-join.js',
-            'js/base/mozilla-input-placeholder.js',
-        ),
-        'output_filename': 'js/contribute-studentambassadors-join-bundle.js',
-    },
-    'existing': {
-        'source_filenames': (
-            'js/newsletter/existing.js',
-        ),
-        'output_filename': 'js/existing-bundle.js',
-    },
-    'accordion': {
-        'source_filenames': (
-            'js/base/mozilla-accordion.js',
-            'js/base/mozilla-accordion-gatrack.js',
-        ),
-        'output_filename': 'js/accordion-bundle.js',
-    },
-    'dnt': {
-        'source_filenames': (
-            'js/base/mozilla-accordion.js',
-            'js/base/mozilla-accordion-gatrack.js',
-            'js/libs/jquery.waypoints.min.js',
-            'js/libs/jquery.waypoints-sticky.min.js',
-            'js/firefox/family-nav.js',
-            'js/firefox/dnt.js',
-        ),
-        'output_filename': 'js/firefox_dnt-bundle.js',
-    },
-    'firefox': {
-        'source_filenames': (
-            'js/libs/jquery-1.11.0.min.js',
-            'js/libs/spin.min.js',
-            'js/base/global.js',
-            'js/base/global-init.js',
-            'js/newsletter/form.js',
-            'js/base/nav-main.js',
-            'js/base/mozilla-input-placeholder.js',
-            'js/base/mozilla-image-helper.js',
-        ),
-        'output_filename': 'js/firefox-bundle.js',
-    },
-    'firefox_all': {
-        'source_filenames': (
-            'js/base/mozilla-share-cta.js',
-            'js/base/mozilla-pager.js',
-            'js/firefox/firefox-language-search.js',
-        ),
-        'output_filename': 'js/firefox_all-bundle.js',
-    },
-    'firefox_android': {
-        'source_filenames': (
-            'js/base/mozilla-accordion.js',
-            'js/libs/jquery.waypoints.min.js',
-            'js/libs/jquery.cycle2.min.js',
-            'js/libs/jquery.waypoints.min.js',
-            'js/libs/jquery.waypoints-sticky.min.js',
-            'js/firefox/family-nav.js',
-            'js/firefox/sync-animation.js',
-            'js/firefox/android.js',
-        ),
-        'output_filename': 'js/firefox_android-bundle.js',
-    },
-    'firefox-resp': {
-        'source_filenames': (
-            'js/libs/jquery-1.11.0.min.js',
-            'js/libs/spin.min.js',
-            'js/base/global.js',
-            'js/base/global-init.js',
-            'js/newsletter/form.js',
-            'js/base/nav-main-resp.js',
-            'js/base/mozilla-input-placeholder.js',
-            'js/base/mozilla-image-helper.js',
-        ),
-        'output_filename': 'js/firefox-resp-bundle.js',
-    },
-    'firefox_channel': {
-        'source_filenames': (
-            'js/base/mozilla-pager.js',
-            'js/firefox/channel.js',
-        ),
-        'output_filename': 'js/firefox_channel-bundle.js',
-    },
-    'firefox_desktop_customize': {
-        'source_filenames': (
-            'js/libs/jquery.waypoints.min.js',
-            'js/libs/jquery.waypoints-sticky.min.js',
-            'js/firefox/family-nav.js',
-            'js/firefox/sync-animation.js',
-            'js/firefox/desktop/common.js',
-            'js/firefox/desktop/customize.js',
-        ),
-        'output_filename': 'js/firefox_desktop_customize-bundle.js',
-    },
-    'firefox_desktop_fast': {
-        'source_filenames': (
-            'js/libs/jquery.waypoints.min.js',
-            'js/libs/jquery.waypoints-sticky.min.js',
-            'js/firefox/family-nav.js',
-            'js/firefox/desktop/common.js',
-            'js/firefox/desktop/speed-graph.js',
-            'js/firefox/desktop/fast.js',
-        ),
-        'output_filename': 'js/firefox_desktop_fast-bundle.js',
-    },
-    'firefox_desktop_index': {
-        'source_filenames': (
-            'js/libs/jquery.waypoints.min.js',
-            'js/libs/jquery.waypoints-sticky.min.js',
-            'js/firefox/family-nav.js',
-            'js/firefox/desktop/common.js',
-            'js/firefox/desktop/speed-graph.js',
-            'js/base/svg-animation-check.js',
-            'js/firefox/desktop/intro-anim.js',
-            'js/firefox/desktop/index.js',
-        ),
-        'output_filename': 'js/firefox_desktop_index-bundle.js',
-    },
-    'firefox_desktop_tips': {
-        'source_filenames': (
-            'js/base/mozilla-pager.js',
-            'js/libs/hammer.1.1.2.min.js',
-            'js/libs/socialshare.min.js',
-            'js/firefox/desktop/tips.js',
-        ),
-        'output_filename': 'js/firefox_desktop_tips-bundle.js',
-    },
-    'firefox_desktop_trust': {
-        'source_filenames': (
-            'js/libs/jquery.waypoints.min.js',
-            'js/libs/jquery.waypoints-sticky.min.js',
-            'js/firefox/family-nav.js',
-            'js/firefox/desktop/common.js',
-            'js/firefox/desktop/trust.js',
-        ),
-        'output_filename': 'js/firefox_desktop_trust-bundle.js',
-    },
-    'firefox_developer': {
-        'source_filenames': (
-            'js/firefox/developer.js',
-            'js/base/mozilla-modal.js',
-            'js/base/mozilla-share-cta.js',
-        ),
-        'output_filename': 'js/firefox_developer-bundle.js',
-    },
-    'firefox_firstrun': {
-        'source_filenames': (
-            'js/base/mozilla-modal.js',
-            'js/firefox/firstrun/firstrun.js',
-        ),
-        'output_filename': 'js/firefox_firstrun-bundle.js',
-    },
-    'firefox_fx36_firstrun': {
-        'source_filenames': (
-            'js/firefox/australis/australis-uitour.js',
-            'js/firefox/australis/browser-tour.js',
-            'js/firefox/australis/fx36/common.js',
-            'js/firefox/australis/fx36/firstrun.js',
-        ),
-        'output_filename': 'js/firefox_fx36_firstrun-bundle.js',
-    },
-    'firefox_fx36_whatsnew': {
-        'source_filenames': (
-            'js/firefox/australis/australis-uitour.js',
-            'js/firefox/australis/browser-tour.js',
-            'js/firefox/australis/fx36/common.js',
-            'js/firefox/australis/fx36/whatsnew.js',
-        ),
-        'output_filename': 'js/firefox_fx36_whatsnew-bundle.js',
-    },
-    'firefox_fx36_whatsnew_no_tour': {
-        'source_filenames': (
-            'js/firefox/australis/fx36/common.js',
-            'js/firefox/australis/fx36/whatsnew-notour.js',
-        ),
-        'output_filename': 'js/firefox_fx36_whatsnew_no_tour-bundle.js',
-    },
-    'firefox_developer_firstrun': {
-        'source_filenames': (
-            'js/firefox/australis/australis-uitour.js',
-            'js/base/mozilla-modal.js',
-            'js/firefox/dev-firstrun.js',
-        ),
-        'output_filename': 'js/firefox_developer_firstrun-bundle.js',
-    },
-    'firefox_new': {
-        'source_filenames': (
-            'js/libs/jquery-1.11.0.min.js',
-            'js/libs/spin.min.js',
-            'js/base/global.js',
-            'js/base/global-init.js',
-            'js/base/search-params.js',
-            'js/newsletter/form.js',
-            'js/base/mozilla-input-placeholder.js',
-            'js/base/mozilla-image-helper.js',
-            'js/libs/socialshare.min.js',
-            'js/libs/modernizr.custom.csstransitions.js',
-            'js/firefox/new.js',
-        ),
-        'output_filename': 'js/firefox_new-bundle.js',
-    },
-    'firefox_independent': {
-        'source_filenames': (
-            'js/base/mozilla-share-cta.js',
-            'js/base/firefox-anniversary-video.js',
-            'js/firefox/independent.js',
-        ),
-        'output_filename': 'js/firefox_independent-bundle.js',
-    },
-    'firefox_os': {
-        'source_filenames': (
-            'js/base/mozilla-modal.js',
-            'js/libs/jquery.waypoints.min.js',
-            'js/libs/jquery.waypoints-sticky.min.js',
-            'js/libs/tweenmax.1.9.7.min.js',
-            'js/libs/superscrollorama-1.0.1.js',
-            'js/libs/jquery.plusslider.js',
-            'js/libs/jquery.color.js',
-            'js/libs/script.js',
-            'js/libs/socialshare.min.js',
-            'js/firefox/os/firefox-os.js',
-            'js/firefox/os/desktop.js',
-            'js/firefox/os/have-it.js',
-        ),
-        'output_filename': 'js/firefox_os-bundle.js',
-    },
-    'firefox_os_new': {
-        'source_filenames': (
-            'js/base/mozilla-modal.js',
-            'js/libs/jquery.waypoints.min.js',
-            'js/libs/jquery.waypoints-sticky.min.js',
-            'js/libs/script.js',
-            'js/firefox/family-nav.js',
-            'js/firefox/os/firefox-os-new.js',
-        ),
-        'output_filename': 'js/firefox_os_new-bundle.js',
-    },
-    'firefox_os_ie9': {
-        'source_filenames': (
-            'js/libs/matchMedia.addListener.js',
-        ),
-        'output_filename': 'js/firefox_os_ie9-bundle.js',
-    },
-    'firefox_os_devices': {
-        'source_filenames': (
-            'js/libs/jquery.tipsy.js',
-            'js/libs/jquery.waypoints.min.js',
-            'js/libs/jquery.waypoints-sticky.min.js',
-            'js/base/mozilla-pager.js',
-            'js/base/mozilla-modal.js',
-            'js/firefox/family-nav.js',
-            'js/firefox/os/partner_data.js',
-            'js/firefox/os/devices.js',
-        ),
-        'output_filename': 'js/firefox_os_devices-bundle.js',
-    },
-    'firefox_os_mwc_2015_preview': {
-        'source_filenames': (
-            'js/base/mozilla-modal.js',
-            'js/libs/jquery.waypoints.min.js',
-            'js/libs/jquery.waypoints-sticky.min.js',
-            'js/firefox/family-nav.js',
-            'js/firefox/mwc-2015-map.js',
-            'js/firefox/os/mwc-2015-preview.js',
-        ),
-        'output_filename': 'js/firefox_os_mwc_2015_preview-bundle.js',
-    },
-    'firefox_os_tv': {
-        'source_filenames': (
-            'js/base/mozilla-pager.js',
-        ),
-        'output_filename': 'js/firefox_os_tv-bundle.js',
-    },
-    'firefox_interest_dashboard': {
-        'source_filenames': (
-            'js/libs/jquery.waypoints.min.js',
-            'js/libs/jquery.waypoints-sticky.min.js',
-            'js/firefox/family-nav.js',
-            'js/firefox/interest-dashboard.js',
-        ),
-        'output_filename': 'js/firefox_interest_dashboard-bundle.js',
-    },
-    'firefox_tiles': {
-        'source_filenames': (
-            'js/libs/jquery.waypoints.min.js',
-            'js/libs/jquery.waypoints-sticky.min.js',
-            'js/firefox/family-nav.js',
-            'js/firefox/tiles.js',
-        ),
-        'output_filename': 'js/firefox_tiles-bundle.js',
-    },
-    'firefox_family_index': {
-        'source_filenames': (
-            'js/firefox/family-index.js',
-        ),
-        'output_filename': 'js/firefox_family_index-bundle.js',
-    },
-    'firefox_faq': {
-        'source_filenames': (
-            'js/base/mozilla-accordion.js',
-            'js/base/mozilla-accordion-gatrack.js',
-        ),
-        'output_filename': 'js/firefox_faq-bundle.js',
-    },
-    'firefox_sync': {
-        'source_filenames': (
-            'js/libs/jquery.waypoints.min.js',
-            'js/libs/jquery.waypoints-sticky.min.js',
-            'js/firefox/family-nav.js',
-            'js/firefox/sync-animation.js',
-            'js/firefox/australis/australis-uitour.js',
-            'js/firefox/sync.js',
-        ),
-        'output_filename': 'js/firefox_sync-bundle.js',
-    },
-    'firefox_sync_old': {
-        'source_filenames': (
-            'js/libs/jquery.waypoints.min.js',
-            'js/libs/jquery.waypoints-sticky.min.js',
-            'js/firefox/family-nav.js',
-            'js/firefox/sync-animation.js',
-            'js/firefox/sync-old.js',
-        ),
-        'output_filename': 'js/firefox_sync_old-bundle.js',
-    },
-    'firefox_feedback': {
-        'source_filenames': (
-            'js/base/mozilla-share-cta.js',
-            'js/firefox/feedback-ga-tracking.js',
-        ),
-        'output_filename': 'js/firefox_feedback-bundle.js',
-    },
-    'firefox_hello_start': {
-        'source_filenames': (
-            'js/firefox/australis/australis-uitour.js',
-            'js/firefox/hello/start.js',
-        ),
-        'output_filename': 'js/firefox_hello_start-bundle.js',
-    },
-    'firefox_hello': {
-        'source_filenames': (
-            'js/firefox/australis/australis-uitour.js',
-            'js/base/mozilla-modal.js',
-            'js/base/svg-animation-check.js',
-            'js/base/mozilla-share-cta.js',
-            'js/libs/jquery.waypoints.min.js',
-            'js/libs/jquery.waypoints-sticky.min.js',
-            'js/firefox/family-nav.js',
-            'js/firefox/hello/index.js',
-        ),
-        'output_filename': 'js/firefox_hello-bundle.js',
-    },
-    'firefox_hello_ie9': {
-        'source_filenames': (
-            'js/libs/matchMedia.js',
-            'js/libs/matchMedia.addListener.js',
-        ),
-        'output_filename': 'js/firefox_hello_ie9-bundle.js',
-    },
-    'firefox_privacy_tour': {
-        'source_filenames': (
-            'js/base/mozilla-modal.js',
-            'js/base/mozilla-share-cta.js',
-            'js/base/firefox-anniversary-video.js',
-            'js/firefox/australis/australis-uitour.js',
-            'js/firefox/australis/browser-tour.js',
-            'js/firefox/privacy_tour/common.js',
-            'js/firefox/privacy_tour/tour.js',
-        ),
-        'output_filename': 'js/firefox_privacy_tour-bundle.js',
-    },
-    'firefox_privacy_no_tour': {
-        'source_filenames': (
-            'js/base/mozilla-modal.js',
-            'js/base/mozilla-share-cta.js',
-            'js/base/firefox-anniversary-video.js',
-            'js/firefox/privacy_tour/common.js',
-            'js/firefox/privacy_tour/no-tour.js',
-        ),
-        'output_filename': 'js/firefox_privacy_no_tour-bundle.js',
-    },
-    'firefox_search_tour': {
-        'source_filenames': (
-            'js/firefox/australis/australis-uitour.js',
-            'js/firefox/search_tour/common.js',
-            'js/firefox/search_tour/tour.js',
-        ),
-        'output_filename': 'js/firefox_search_tour-bundle.js',
-    },
-    'firefox_search_tour_34.0.5': {
-        'source_filenames': (
-            'js/firefox/australis/australis-uitour.js',
-            'js/firefox/search_tour/common.js',
-            'js/firefox/search_tour/tour-34.0.5.js',
-        ),
-        'output_filename': 'js/firefox_search_tour_34.0.5-bundle.js',
-    },
-    'firefox_search_no_tour': {
-        'source_filenames': (
-            'js/firefox/australis/australis-uitour.js',
-            'js/firefox/search_tour/common.js',
-        ),
-        'output_filename': 'js/firefox_search_no_tour-bundle.js',
-    },
-    'firefox_tour': {
-        'source_filenames': (
-            'js/libs/jquery.waypoints.min.js',
-            'js/firefox/australis/australis-uitour.js',
-            'js/firefox/australis/browser-tour.js',
-            'js/firefox/australis/common.js',
-            'js/firefox/australis/tour.js',
-        ),
-        'output_filename': 'js/firefox_tour-bundle.js',
-    },
-    'firefox_tour_none': {
-        'source_filenames': (
-            'js/libs/jquery.waypoints.min.js',
-            'js/firefox/australis/australis-uitour.js',
-            'js/firefox/australis/common.js',
-            'js/firefox/australis/no-tour.js',
-        ),
-        'output_filename': 'js/firefox_tour_none-bundle.js',
-    },
-    'firefox_sms': {
-        'source_filenames': (
-            'js/firefox/sms.js',
-            'js/base/mozilla-share-cta.js',
-        ),
-        'output_filename': 'js/firefox_sms-bundle.js',
-    },
-    'firefox_whatsnew_fx37': {
-        'source_filenames': (
-            'js/firefox/whatsnew-fx37.js',
-        ),
-        'output_filename': 'js/firefox_whatsnew_fx37-bundle.js',
-    },
-    'firefox_whatsnew_fxos': {
-        'source_filenames': (
-            'js/firefox/whatsnew-fxos.js',
-        ),
-        'output_filename': 'js/firefox_whatsnew_fxos-bundle.js',
-    },
-    'geolocation': {
-        'source_filenames': (
-            'js/libs/mapbox-2.1.5.js',
-            'js/base/mozilla-accordion.js',
-            'js/base/mozilla-accordion-gatrack.js',
-            'js/firefox/geolocation-demo.js',
-            'js/base/mozilla-modal.js',
-        ),
-        'output_filename': 'js/geolocation-bundle.js',
-    },
-    'home': {
-        'source_filenames': (
-            'js/libs/jquery.ellipsis.min.js',
-            'js/libs/jquery.cycle2.min.js',
-            'js/libs/jquery.cycle2.carousel.min.js',
-            'js/mozorg/home.js',
-        ),
-        'output_filename': 'js/home-bundle.js',
-    },
-    'growth_firstrun_test1': {
-        'source_filenames': (
-            'js/firefox/australis/australis-uitour.js',
-            'js/firefox/australis/growth-browser-tour.js',
-            'js/libs/fxa-relier-client.min.js',
-            'js/firefox/sync-animation.js',
-            'js/firefox/australis/growth-firstrun-test1.js',
-        ),
-        'output_filename': 'js/growth-firstrun-test1-bundle.js',
-    },
-    'growth_firstrun_test2': {
-        'source_filenames': (
-            'js/firefox/australis/australis-uitour.js',
-            'js/firefox/australis/growth-browser-tour.js',
-            'js/firefox/sync-animation.js',
-            'js/firefox/australis/growth-firstrun-test2.js',
-        ),
-        'output_filename': 'js/growth-firstrun-test2-bundle.js',
-    },
-    'home-2015': {
-        'source_filenames': (
-            'js/base/mozilla-share-cta.js',
-            'js/base/firefox-anniversary-video.js',
-            'js/libs/jquery.waypoints.min.js',
-            'js/mozorg/home/home.js',
-            'js/mozorg/home/ga-tracking.js',
-            'js/mozorg/home/scroll-prompt.js',
-        ),
-        'output_filename': 'js/home-2015-bundle.js',
-    },
-    'home-2015-ie9': {
-        'source_filenames': (
-            'js/libs/matchMedia.addListener.js',
-        ),
-        'output_filename': 'js/home-2015-ie9-bundle.js',
-    },
-    'history-slides': {
-        'source_filenames': (
-            'js/libs/jquery.sequence.js',
-            'js/mozorg/history-slides.js',
-        ),
-        'output_filename': 'js/history-slides-bundle.js',
-    },
-    'installer_help': {
-        'source_filenames': (
-            'js/base/mozilla-modal.js',
-            'js/firefox/installer-help.js',
-        ),
-        'output_filename': 'js/installer_help-bundle.js',
-    },
-    'legal_fraud_report': {
-        'source_filenames': (
-            'js/libs/jquery.validate.js',
-            'js/legal/fraud-report.js',
-            'js/base/mozilla-input-placeholder.js',
-        ),
-        'output_filename': 'js/legal_fraud_report-bundle.js',
-    },
-    'manifesto': {
-        'source_filenames': (
-            'js/base/mozilla-modal.js',
-            'js/libs/socialshare.min.js',
-            'js/mozorg/manifesto.js',
-        ),
-        'output_filename': 'js/manifesto-bundle.js',
-    },
-    'manifesto_ie9': {
-        'source_filenames': (
-            'js/libs/matchMedia.addListener.js',
-        ),
-        'output_filename': 'js/manifesto_ie9-bundle.js',
-    },
-    'mozorg-resp': {
-        'source_filenames': (
-            'js/libs/jquery-1.11.0.min.js',
-            'js/libs/spin.min.js',
-            'js/base/global.js',
-            'js/base/global-init.js',
-            'js/newsletter/form.js',
-            'js/base/nav-main-resp.js',
-            'js/base/mozilla-image-helper.js',
-        ),
-        'output_filename': 'js/mozorg-resp-bundle.js',
-    },
-    'nightly-firstrun': {
-        'source_filenames': (
-            'js/firefox/firstrun/nightly-firstrun.js',
-        ),
-        'output_filename': 'js/nightly-firstrun-bundle.js',
-    },
-    'partnerships': {
-        'source_filenames': (
-            'js/libs/jquery.validate.js',
-            'js/base/mozilla-form-helper.js',
-            'js/mozorg/partnerships.js',
-            'js/base/mozilla-input-placeholder.js',
-        ),
-        'output_filename': 'js/partnerships-bundle.js',
-    },
-    'plugincheck': {
-        'source_filenames': (
-            'js/plugincheck/lib/mustache.js',
-            'js/base/mozilla-share-cta.js',
-            'js/plugincheck/tmpl/plugincheck.ui.tmpl.js',
-            'js/plugincheck/lib/utils.js',
-            'js/plugincheck/lib/version-compare.js',
-            'js/plugincheck/lib/plugincheck.js',
-            'js/plugincheck/check-plugins.js',
-        ),
-        'output_filename': 'js/plugincheck-bundle.js',
-    },
-    'press_speaker_request': {
-        'source_filenames': (
-            'js/libs/jquery.validate.js',
-            'js/libs/modernizr.custom.inputtypes.js',
-            'js/press/speaker-request.js',
-            'js/base/mozilla-input-placeholder.js',
-        ),
-        'output_filename': 'js/press_speaker_request-bundle.js',
-    },
-    'privacy': {
-        'source_filenames': (
-            'js/privacy/privacy.js',
-        ),
-        'output_filename': 'js/privacy-bundle.js',
-    },
-    'privacy-day': {
-        'source_filenames': (
-            'js/base/mozilla-pager.js',
-            'js/base/mozilla-share-cta.js',
-            'js/libs/jquery.waypoints.min.js',
-            'js/libs/jquery.waypoints-sticky.min.js',
-            'js/privacy/privacy-day.js',
-        ),
-        'output_filename': 'js/privacy-day-bundle.js',
-    },
-    'products': {
-        'source_filenames': (
-            'js/libs/jquery.waypoints.min.js',
-            'js/libs/jquery.waypoints-sticky.min.js',
-            'js/mozorg/products.js',
-        ),
-        'output_filename': 'js/products-bundle.js',
-    },
-    'styleguide': {
-        'source_filenames': (
-            'js/styleguide/styleguide.js',
-        ),
-        'output_filename': 'js/styleguide-bundle.js',
-    },
-    'styleguide-docs-mozilla-accordion': {
-        'source_filenames': (
-            'js/base/mozilla-accordion.js',
-            'js/styleguide/docs/mozilla-accordion.js',
-        ),
-        'output_filename': 'js/styleguide-docs-mozilla-accordion-bundle.js',
-    },
-    'styleguide-docs-mozilla-pager': {
-        'source_filenames': (
-            'js/base/mozilla-pager.js',
-            'js/styleguide/docs/mozilla-pager.js',
-        ),
-        'output_filename': 'js/styleguide-docs-mozilla-pager-bundle.js',
-    },
-    'video': {
-        'source_filenames': (
-            'js/base/mozilla-video-tools.js',
-        ),
-        'output_filename': 'js/video-bundle.js',
-    },
-    'contribute-2015': {
-        'source_filenames': (
-            'js/mozorg/contribute/contribute-2015-ga.js',
-            'js/mozorg/contribute/contribute-2015.js',
-        ),
-        'output_filename': 'js/contribute-2015-bundle.js',
-    },
-    'contribute-2015-landing': {
-        'source_filenames': (
-            'js/libs/jquery.waypoints.min.js',
-            'js/libs/jquery.cycle2.min.js',
-            'js/base/mozilla-modal.js',
-        ),
-        'output_filename': 'js/contribute-2015-landing-bundle.js',
-    },
-    'mosaic': {
-        'source_filenames': (
-            'js/libs/modernizr.custom.26887.js',
-            'js/libs/jquery.transit.min.js',
-            'js/libs/jquery.gridrotator.js',
-        ),
-        'output_filename': 'js/mosaic-bundle.js',
-    },
-    'annual_2011_ie9': {
-        'source_filenames': (
-            'js/libs/matchMedia.addListener.js',
-        ),
-        'output_filename': 'js/annual_2011_ie9-bundle.js',
-    },
-    'annual_2011': {
-        'source_filenames': (
-            'js/libs/jquery.hoverIntent.minified.js',
-            'js/libs/jquery.waypoints.min.js',
-            'js/libs/jquery.jcarousel.min.js',
-            'js/foundation/annual2011.js',
-        ),
-        'output_filename': 'js/annual_2011-bundle.js',
-    },
-    'annual_2012': {
-        'source_filenames': (
-            'js/base/mozilla-modal.js',
-            'js/foundation/annual2012.js',
-        ),
-        'output_filename': 'js/annual_2012-bundle.js',
-    },
-    'annual_2013': {
-        'source_filenames': (
-            'js/base/mozilla-modal.js',
-            'js/foundation/annual2013.js',
-        ),
-        'output_filename': 'js/annual_2013-bundle.js',
-    },
-    'logo-prototype': {
-        'source_filenames': (
-            'js/styleguide/logo-prototype/vendor/raf.polyfill.js',
-            'js/styleguide/logo-prototype/vendor/tween.js',
-            'js/styleguide/logo-prototype/vendor/lodash.compat.min.js',
-            'js/styleguide/logo-prototype/vendor/perlin.js',
-            'js/styleguide/logo-prototype/vendor/dat.gui.js',
-            'js/libs/jquery-1.11.0.min.js',
-            'js/styleguide/logo-prototype/clock-data.js',
-        ),
-        'output_filename': 'js/logo-prototype-bundle.js',
-    },
-    'partners': {
-        'source_filenames': (
-            'js/libs/modernizr.custom.shiv-load.js',
-            'js/base/mozilla-input-placeholder.js',
-            'js/libs/jquery.waypoints.min.js',
-            'js/libs/jquery.waypoints-sticky.min.js',
-            'js/firefox/family-nav.js',
-            'js/base/mozilla-pager.js',
-            'js/base/mozilla-modal.js',
-            'js/firefox/partners.js',
-        ),
-        'output_filename': 'js/partners-bundle.js',
-    },
-    'partners_common': {
-        'source_filenames': (
-            'js/libs/enquire.min.js',
-            'js/base/mozilla-form-helper.js',
-            'js/firefox/partners/common.js',
-        ),
-        'output_filename': 'js/partners_common-bundle.js',
-    },
-    'partners_mobile': {
-        'source_filenames': (
-            'js/firefox/partners/mobile.js',
-        ),
-        'output_filename': 'js/partners_mobile-bundle.js',
-    },
-    'partners_desktop': {
-        'source_filenames': (
-            'js/libs/jquery.pageslide.min.js',
-            'js/libs/jquery.waypoints.min.js',
-            'js/libs/tweenmax.1.9.7.min.js',
-            'js/libs/jquery.spritely-0.6.7.js',
-            'js/firefox/partners/desktop.js',
-        ),
-        'output_filename': 'js/partners_desktop-bundle.js',
-    },
-    'facebookapps_redirect': {
-        'source_filenames': (
-            'js/libs/jquery-1.11.0.min.js',
-            'js/facebookapps/redirect.js',
-        ),
-        'output_filename': 'js/facebookapps_redirect-bundle.js',
-    },
-    'facebookapps_downloadtab': {
-        'source_filenames': (
-            'js/facebookapps/downloadtab-init.js',
-            'js/facebookapps/Base.js',
-            'js/facebookapps/Facebook.js',
-            'js/facebookapps/Theater.js',
-            'js/facebookapps/Slider.js',
-            'js/facebookapps/App.js',
-            'js/facebookapps/downloadtab.js',
-        ),
-        'output_filename': 'js/facebookapps_downloadtab-bundle.js',
-    },
-    'newsletter_form': {
-        'source_filenames': (
-            'js/libs/jquery-1.11.0.min.js',
-            'js/libs/spin.min.js',
-            'js/newsletter/form.js',
-        ),
-        'output_filename': 'js/newsletter_form-bundle.js',
-    },
-    'matchmedia_addlistener': {
-        'source_filenames': (
-            'js/libs/matchMedia.addListener.js',
-        ),
-        'output_filename': 'js/matchmedia_addlistener-bundle.js',
-    },
-}
 
 PROJECT_MODULE = 'bedrock'
 
@@ -1946,43 +266,41 @@ DOMAIN_METHODS = {
     ],
 }
 
-# Dynamically process LESS server-side? (usually true to local
-# development)
-LESS_PREPROCESS = False
-LESS_BIN = 'lessc'
-
 MIDDLEWARE_CLASSES = (
     'bedrock.mozorg.middleware.MozorgRequestTimingMiddleware',
     'django_statsd.middleware.GraphiteMiddleware',
     'bedrock.tabzilla.middleware.TabzillaLocaleURLMiddleware',
     'commonware.middleware.RobotsTagHeader',
     'bedrock.mozorg.middleware.ClacksOverheadMiddleware',
-) + get_middleware(exclude=(
-    'funfactory.middleware.LocaleURLMiddleware',
-    'multidb.middleware.PinningRouterMiddleware',
-    'django.contrib.auth.middleware.AuthenticationMiddleware',
-    'session_csrf.CsrfMiddleware',
-    'mobility.middleware.DetectMobileMiddleware',
-    'mobility.middleware.XMobileMiddleware',
-), append=(
+    'django.middleware.common.CommonMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
+    'commonware.middleware.FrameOptionsHeader',
     'bedrock.mozorg.middleware.CacheMiddleware',
     'dnt.middleware.DoNotTrackMiddleware',
     'lib.l10n_utils.middleware.FixLangFileTranslationsMiddleware',
     'bedrock.mozorg.middleware.ConditionalAuthMiddleware',
     'bedrock.mozorg.middleware.CrossOriginResourceSharingMiddleware',
-))
+)
 
 AUTHENTICATED_URL_PREFIXES = ('/admin/', '/rna/')
 
-INSTALLED_APPS = get_apps(exclude=(
-    'compressor',
-    'django_browserid',
-    'django.contrib.sessions',
-    'session_csrf',
-    'djcelery',
-), append=(
+INSTALLED_APPS = (
+    'cronjobs',  # for ./manage.py cron * cmd line tasks
+
+    # Django contrib apps
+    'django.contrib.auth',
+    'django.contrib.contenttypes',
+    'django.contrib.staticfiles',
+
+    # Third-party apps, patches, fixes
+    'commonware.response.cookies',
+    'django_nose',
+
+    # L10n
+    'tower',  # for ./manage.py extract
+    'product_details',
+
     # third-party apps
     'jingo_markdown',
     # 'jingo_minify',
@@ -1995,7 +313,6 @@ INSTALLED_APPS = get_apps(exclude=(
 
     # Django contrib apps
     'django.contrib.admin',
-    'django_sha2',  # Load after auth to monkey-patch it.
     'django.contrib.contenttypes',
     'django.contrib.messages',
 
@@ -2029,17 +346,35 @@ INSTALLED_APPS = get_apps(exclude=(
     'lib.l10n_utils',
     'captcha',
     'rna',
-))
+)
 
+# Sessions
+#
+# By default, be at least somewhat secure with our session cookies.
+SESSION_COOKIE_HTTPONLY = not DEBUG
+SESSION_COOKIE_SECURE = not DEBUG
 SESSION_ENGINE = 'django.contrib.sessions.backends.cache'
 
 LOCALE_PATHS = (
-    path('locale'),
+    str(LOCALES_PATH),
 )
 
-TEMPLATE_CONTEXT_PROCESSORS = get_template_context_processors(append=(
+# List of callables that know how to import templates from various sources.
+TEMPLATE_LOADERS = (
+    'jingo.Loader',
+    'django.template.loaders.filesystem.Loader',
+    'django.template.loaders.app_directories.Loader',
+)
+
+TEMPLATE_CONTEXT_PROCESSORS = (
+    'django.contrib.auth.context_processors.auth',
     'django.core.context_processors.csrf',
+    'django.core.context_processors.debug',
+    'django.core.context_processors.media',
+    'django.core.context_processors.request',
     'django.contrib.messages.context_processors.messages',
+    'bedrock.base.context_processors.i18n',
+    'bedrock.base.context_processors.globals',
     'bedrock.mozorg.context_processors.canonical_path',
     'bedrock.mozorg.context_processors.contrib_numbers',
     'bedrock.mozorg.context_processors.current_year',
@@ -2047,13 +382,7 @@ TEMPLATE_CONTEXT_PROCESSORS = get_template_context_processors(append=(
     'bedrock.mozorg.context_processors.facebook_locale',
     'bedrock.firefox.context_processors.latest_firefox_versions',
     'jingo_minify.helpers.build_ids',
-), exclude=('session_csrf.context_processor',))
-
-# Auth
-PWD_ALGORITHM = 'bcrypt'
-HMAC_KEYS = {
-    # '2011-01-01': 'cheesecake',
-}
+)
 
 FEEDS = {
     'mozilla': 'https://blog.mozilla.org/feed/'
@@ -2368,7 +697,7 @@ RNA = {
     'VERIFY_SSL_CERT': os.environ.get('VERIFY_SSL_CERT', False),
 }
 
-MOFO_SECURITY_ADVISORIES_PATH = abspath(path('..', 'mofo_security_advisories'))
+MOFO_SECURITY_ADVISORIES_PATH = path('..', 'mofo_security_advisories')
 MOFO_SECURITY_ADVISORIES_REPO = 'https://github.com/mozilla/foundation-security-advisories.git'
 
 CORS_URLS = {
@@ -2474,5 +803,5 @@ FIREFOX_OS_COUNTRY_VERSIONS = {
 
 TABLEAU_DB_URL = None
 
-MAXMIND_DB_PATH = os.getenv('MAXMIND_DB_PATH', abspath(path('..', 'GeoIP2-Country.mmdb')))
+MAXMIND_DB_PATH = os.getenv('MAXMIND_DB_PATH', path('..', 'GeoIP2-Country.mmdb'))
 MAXMIND_DEFAULT_COUNTRY = os.getenv('MAXMIND_DEFAULT_COUNTRY', 'US')

--- a/bedrock/settings/static_media.py
+++ b/bedrock/settings/static_media.py
@@ -1,0 +1,1785 @@
+# Static media bundle definitions.
+
+PIPELINE_CSS = {
+    'csrf-failure': {
+        'source_filenames': (
+            'css/sandstone/sandstone-resp.less',
+            'css/csrf-failure.less',
+        ),
+        'output_filename': 'css/csrf-failure-bundle.css',
+    },
+    'about': {
+        'source_filenames': (
+            'css/sandstone/video-resp.less',
+            'css/mozorg/about-base.less',
+            'css/mozorg/mosaic.less',
+        ),
+        'output_filename': 'css/about-bundle.css',
+    },
+    'about-base': {
+        'source_filenames': (
+            'css/mozorg/about-base.less',
+        ),
+        'output_filename': 'css/about-base-bundle.css',
+    },
+    'credits-faq': {
+        'source_filenames': (
+            'css/mozorg/credits-faq.less',
+        ),
+        'output_filename': 'css/credits-faq-bundle.css',
+    },
+    'commit-access-policy': {
+        'source_filenames': (
+            'css/mozorg/commit-access-policy.less',
+        ),
+        'output_filename': 'css/commit-access-policy-bundle.css',
+    },
+    'commit-access-requirements': {
+        'source_filenames': (
+            'css/mozorg/commit-access-requirements.less',
+        ),
+        'output_filename': 'css/commit-access-requirements.css',
+    },
+    'about-forums': {
+        'source_filenames': (
+            'css/mozorg/about-forums.less',
+        ),
+        'output_filename': 'css/about-forums-bundle.css',
+    },
+    'foundation': {
+        'source_filenames': (
+            'css/foundation/foundation.less',
+        ),
+        'output_filename': 'css/foundation-bundle.css',
+    },
+    'gigabit': {
+        'source_filenames': (
+            'css/gigabit/gigabit.less',
+        ),
+        'output_filename': 'css/gigabit-bundle.css',
+    },
+    'grants': {
+        'source_filenames': (
+            'css/grants/grants.less',
+        ),
+        'output_filename': 'css/grants-bundle.css',
+    },
+    'lightbeam': {
+        'source_filenames': (
+            'css/lightbeam/lightbeam.less',
+        ),
+        'output_filename': 'css/lightbeam-bundle.css',
+    },
+    'itu': {
+        'source_filenames': (
+            'css/mozorg/itu.less',
+        ),
+        'output_filename': 'css/itu-bundle.css',
+    },
+    'common': {
+        'source_filenames': (
+            'css/sandstone/sandstone.less',
+        ),
+        'output_filename': 'css/common-bundle.css',
+    },
+    'responsive': {
+        'source_filenames': (
+            'css/sandstone/sandstone-resp.less',
+        ),
+        'output_filename': 'css/responsive-bundle.css',
+    },
+    'oldIE': {
+        'source_filenames': (
+            'css/sandstone/oldIE.less',
+        ),
+        'output_filename': 'css/oldIE-bundle.css',
+    },
+    'newsletter': {
+        'source_filenames': (
+            'css/newsletter/newsletter.less',
+        ),
+        'output_filename': 'css/newsletter-bundle.css',
+    },
+    'contact-spaces': {
+        'source_filenames': (
+            'css/libs/mapbox-2.1.5.css',
+            'css/libs/magnific-popup.css',
+            'css/base/mozilla-video-poster.less',
+            'css/mozorg/contact-spaces.less',
+        ),
+        'output_filename': 'css/contact-spaces-bundle.css',
+    },
+    'contact-spaces-ie7': {
+        'source_filenames': (
+            'css/mozorg/contact-spaces-ie7.less',
+        ),
+        'output_filename': 'css/contact-spaces-ie7-bundle.css',
+    },
+    'contribute-old': {
+        'source_filenames': (
+            'css/mozorg/contribute/contribute-form.less',
+            'css/mozorg/contribute/contribute-old.less',
+            'css/sandstone/video-resp.less',
+        ),
+        'output_filename': 'css/contribute-old-bundle.css',
+    },
+    'contribute-studentambassadors-landing': {
+        'source_filenames': (
+            'css/base/social-widgets.less',
+            'css/mozorg/contribute/studentambassadors/landing.less',
+        ),
+        'output_filename': 'css/contribute-studentambassadors-landing-bundle.css',
+    },
+    'contribute-studentambassadors-join': {
+        'source_filenames': (
+            'css/mozorg/contribute/studentambassadors/join.less',
+        ),
+        'output_filename': 'css/contribute-studentambassadors-join-bundle.css',
+    },
+    'dnt': {
+        'source_filenames': (
+            'css/sandstone/sandstone-resp.less',
+            'css/firefox/family-nav.less',
+            'css/base/mozilla-accordion.less',
+            'css/firefox/dnt.less',
+        ),
+        'output_filename': 'css/dnt-bundle.css',
+    },
+    'firefox': {
+        'source_filenames': (
+            'css/sandstone/sandstone.less',
+            'css/firefox/menu.less',
+            'css/firefox/template.less',
+        ),
+        'output_filename': 'css/firefox-bundle.css',
+    },
+    'firefox_all': {
+        'source_filenames': (
+            'css/base/mozilla-share-cta.less',
+            'css/sandstone/sandstone-resp.less',
+            'css/firefox/menu-resp.less',
+            'css/firefox/all.less',
+        ),
+        'output_filename': 'css/firefox_all-bundle.css',
+    },
+    'firefox_android': {
+        'source_filenames': (
+            'css/sandstone/sandstone-resp.less',
+            'css/firefox/family-nav.less',
+            'css/base/mozilla-accordion.less',
+            'css/firefox/android.less',
+        ),
+        'output_filename': 'css/firefox_android-bundle.css',
+    },
+    'firefox_unsupported': {
+        'source_filenames': (
+            'css/firefox/unsupported.less',
+        ),
+        'output_filename': 'css/firefox_unsupported-bundle.css',
+    },
+    'firefox_unsupported_systems': {
+        'source_filenames': (
+            'css/firefox/unsupported-systems.less',
+        ),
+        'output_filename': 'css/firefox_unsupported_systems-bundle.css',
+    },
+    'firefox-resp': {
+        'source_filenames': (
+            'css/sandstone/sandstone-resp.less',
+            'css/firefox/template-resp.less',
+        ),
+        'output_filename': 'css/firefox-resp-bundle.css',
+    },
+    'firefox_channel': {
+        'source_filenames': (
+            'css/firefox/channel.less',
+        ),
+        'output_filename': 'css/firefox_channel-bundle.css',
+    },
+    'firefox-dashboard': {
+        'source_filenames': (
+            'css/sandstone/sandstone-resp.less',
+            'css/firefox/template-resp.less',
+            'css/base/mozilla-accordion.less',
+            'css/firefox/menu-resp.less',
+            'css/firefox/dashboard.less',
+        ),
+        'output_filename': 'css/firefox-dashboard-bundle.css',
+    },
+    'firefox_desktop': {
+        'source_filenames': (
+            'css/sandstone/sandstone-resp.less',
+            'css/firefox/family-nav.less',
+            'css/firefox/desktop/intro-anim.less',
+            'css/base/svg-animation-check.less',
+            'css/firefox/desktop/index.less',
+        ),
+        'output_filename': 'css/firefox_desktop-bundle.css',
+    },
+    'firefox_desktop_fast': {
+        'source_filenames': (
+            'css/sandstone/sandstone-resp.less',
+            'css/firefox/family-nav.less',
+            'css/firefox/desktop/fast.less',
+        ),
+        'output_filename': 'css/firefox_desktop_fast-bundle.css',
+    },
+    'firefox_desktop_customize': {
+        'source_filenames': (
+            'css/sandstone/sandstone-resp.less',
+            'css/firefox/family-nav.less',
+            'css/firefox/desktop/customize.less',
+        ),
+        'output_filename': 'css/firefox_desktop_customize-bundle.css',
+    },
+    'firefox_desktop_tips': {
+        'source_filenames': (
+            'css/sandstone/sandstone-resp.less',
+            'css/libs/socialshare/socialshare.less',
+            'css/firefox/desktop/tips.less',
+        ),
+        'output_filename': 'css/firefox_desktop_tips-bundle.css',
+    },
+    'firefox_desktop_trust': {
+        'source_filenames': (
+            'css/sandstone/sandstone-resp.less',
+            'css/firefox/family-nav.less',
+            'css/firefox/desktop/trust.less',
+        ),
+        'output_filename': 'css/firefox_desktop_trust-bundle.css',
+    },
+    'firefox_sms': {
+        'source_filenames': (
+            'css/sandstone/sandstone-resp.less',
+            'css/base/mozilla-share-cta.less',
+            'css/firefox/template-resp.less',
+            'css/sandstone/video-resp.less',
+            'css/firefox/mobile-sms.less',
+        ),
+        'output_filename': 'css/firefox_sms-bundle.css',
+    },
+    'firefox-interest-dashboard': {
+        'source_filenames': (
+            'css/firefox/family-nav.less',
+            'css/firefox/interest-dashboard.less',
+        ),
+        'output_filename': 'css/firefox-interest-dashboard-bundle.css',
+    },
+    'firefox-tiles': {
+        'source_filenames': (
+            'css/firefox/family-nav.less',
+            'css/firefox/tiles.less',
+        ),
+        'output_filename': 'css/firefox-tiles-bundle.css',
+    },
+    'firefox_family': {
+        'source_filenames': (
+            'css/sandstone/sandstone-resp.less',
+            'css/tabzilla/tabzilla-static.less',
+            'css/firefox/family/index.less',
+        ),
+        'output_filename': 'css/firefox-family-bundle.css',
+    },
+    'firefox_family_ie': {
+        'source_filenames': (
+            'css/firefox/family/index-ie.less',
+        ),
+        'output_filename': 'css/firefox-family-ie-bundle.css',
+    },
+    'firefox_faq': {
+        'source_filenames': (
+            'css/sandstone/sandstone-resp.less',
+            'css/firefox/menu-resp.less',
+            'css/firefox/faq.less',
+            'css/firefox/template-resp.less',
+            'css/base/mozilla-accordion.less',
+        ),
+        'output_filename': 'css/firefox_faq-bundle.css',
+    },
+    'firefox_firstrun': {
+        'source_filenames': (
+            'css/sandstone/sandstone-resp.less',
+            'css/firefox/template-resp.less',
+            'css/sandstone/video.less',
+            'css/base/mozilla-modal.less',
+            'css/firefox/firstrun.less',
+        ),
+        'output_filename': 'css/firefox_firstrun-bundle.css',
+    },
+    'firefox_fx36_firstrun': {
+        'source_filenames': (
+            'css/sandstone/sandstone.less',
+            'css/firefox/australis/australis-ui-tour.less',
+            'css/firefox/hello-animation.less',
+            'css/firefox/australis/fx36/common.less',
+        ),
+        'output_filename': 'css/firefox_fx36_firstrun-bundle.css',
+    },
+    'firefox_fx36_whatsnew': {
+        'source_filenames': (
+            'css/sandstone/sandstone.less',
+            'css/firefox/australis/australis-ui-tour.less',
+            'css/firefox/hello-animation.less',
+            'css/firefox/australis/fx36/common.less',
+        ),
+        'output_filename': 'css/firefox_fx36_whatsnew-bundle.css',
+    },
+    'firefox_fx36_whatsnew_no_tour': {
+        'source_filenames': (
+            'css/sandstone/sandstone.less',
+            'css/firefox/hello-animation.less',
+            'css/firefox/australis/fx36/common.less',
+        ),
+        'output_filename': 'css/firefox_fx36_whatsnew_no_tour-bundle.css',
+    },
+    'firefox_developer_firstrun': {
+        'source_filenames': (
+            'css/sandstone/sandstone-resp.less',
+            'css/firefox/template-resp.less',
+            'css/base/mozilla-modal.less',
+            'css/firefox/dev-firstrun.less',
+        ),
+        'output_filename': 'css/firefox_developer_firstrun-bundle.css',
+    },
+    'nightly_firstrun': {
+        'source_filenames': (
+            'css/sandstone/sandstone-resp.less',
+            'css/firefox/template-resp.less',
+            'css/firefox/nightly_firstrun.less',
+        ),
+        'output_filename': 'css/nightly_firstrun-bundle.css',
+    },
+    'firefox_feedback': {
+        'source_filenames': (
+            'css/sandstone/sandstone-resp.less',
+            'css/base/mozilla-share-cta.less',
+            'css/firefox/feedback.less',
+        ),
+        'output_filename': 'css/firefox_feedback-bundle.css',
+    },
+    'firefox_geolocation': {
+        'source_filenames': (
+            'css/sandstone/sandstone-resp.less',
+            'css/firefox/template-resp.less',
+            'css/firefox/menu-resp.less',
+            'css/base/mozilla-accordion.less',
+            'css/base/mozilla-modal.less',
+            'css/libs/mapbox-2.1.5.css',
+            'css/firefox/geolocation.less'
+        ),
+        'output_filename': 'css/firefox_geolocation-bundle.css',
+    },
+    'firefox_developer': {
+        'source_filenames': (
+            'css/sandstone/sandstone-resp.less',
+            'css/firefox/template-resp.less',
+            'css/base/mozilla-modal.less',
+            'css/base/mozilla-share-cta.less',
+            'css/firefox/menu-resp.less',
+            'css/firefox/developer.less',
+        ),
+        'output_filename': 'css/firefox_developer-bundle.css',
+    },
+    'firefox_hello_start': {
+        'source_filenames': (
+            'css/sandstone/sandstone-resp.less',
+            'css/firefox/hello/start.less',
+        ),
+        'output_filename': 'css/firefox_hello_start-bundle.css',
+    },
+    'firefox_hello': {
+        'source_filenames': (
+            'css/sandstone/sandstone-resp.less',
+            'css/firefox/family-nav.less',
+            'css/base/mozid-modal.less',
+            'css/base/svg-animation-check.less',
+            'css/base/mozilla-share-cta.less',
+            'css/firefox/hello/index.less',
+        ),
+        'output_filename': 'css/firefox_hello-bundle.css',
+    },
+    'firefox_new': {
+        'source_filenames': (
+            'css/sandstone/sandstone-resp.less',
+            'css/firefox/template-resp.less',
+            'css/libs/socialshare/socialshare.less',
+            'css/firefox/simple_footer-resp.less',
+            'css/firefox/new.less',
+        ),
+        'output_filename': 'css/firefox_new-bundle.css',
+    },
+    'firefox_organizations': {
+        'source_filenames': (
+            'css/sandstone/sandstone-resp.less',
+            'css/firefox/template-resp.less',
+            'css/firefox/organizations.less',
+        ),
+        'output_filename': 'css/firefox_organizations-bundle.css',
+    },
+    'firefox_os': {
+        'source_filenames': (
+            'css/sandstone/sandstone-resp.less',
+            'css/base/mozilla-modal.less',
+            'css/libs/jquery.pageslide.css',
+            'css/firefox/os/get_device.less',
+            'css/firefox/os/firefox-os.less',
+        ),
+        'output_filename': 'css/firefox_os-bundle.css',
+    },
+    'firefox_os_new': {
+        'source_filenames': (
+            'css/sandstone/sandstone-resp.less',
+            'css/base/mozilla-modal.less',
+            'css/firefox/family-nav.less',
+            'css/firefox/os/get_device.less',
+            'css/firefox/os/firefox-os-new.less',
+        ),
+        'output_filename': 'css/firefox_os_new-bundle.css',
+    },
+    'firefox_os_ie': {
+        'source_filenames': (
+            'css/firefox/os/firefox-os-ie.less',
+        ),
+        'output_filename': 'css/firefox_os_ie-bundle.css',
+    },
+    'firefox_os_devices': {
+        'source_filenames': (
+            'css/libs/tipsy.css',
+            'css/sandstone/sandstone-resp.less',
+            'css/firefox/family-nav.less',
+            'css/base/mozilla-modal.less',
+            'css/firefox/os/get_device.less',
+            'css/firefox/os/devices.less',
+        ),
+        'output_filename': 'css/firefox_os_devices-bundle.css',
+    },
+    'firefox_os_devices_ie': {
+        'source_filenames': (
+            'css/firefox/os/devices-ie.less',
+        ),
+        'output_filename': 'css/firefox_os_devices_ie-bundle.css',
+    },
+    'firefox_os_mwc_2015_preview': {
+        'source_filenames': (
+            'css/sandstone/sandstone-resp.less',
+            'css/base/mozilla-modal.less',
+            'css/firefox/family-nav.less',
+            'css/firefox/os/mwc-2015-preview.less',
+        ),
+        'output_filename': 'css/firefox_os_mwc_2015_preview-bundle.css',
+    },
+    'firefox_os_tv': {
+        'source_filenames': (
+            'css/sandstone/sandstone-resp.less',
+            'css/firefox/template-resp.less',
+            'css/firefox/os/tv.less',
+        ),
+        'output_filename': 'css/firefox_os_tv-bundle.css',
+    },
+    'firefox_releases_index': {
+        'source_filenames': (
+            'css/sandstone/sandstone-resp.less',
+            'css/firefox/template-resp.less',
+            'css/firefox/menu-resp.less',
+            'css/firefox/releases-index.less',
+        ),
+        'output_filename': 'css/firefox_releases_index-bundle.css',
+    },
+    'firefox_privacy_tour': {
+        'source_filenames': (
+            'css/sandstone/sandstone.less',
+            'css/base/mozilla-modal.less',
+            'css/base/mozilla-share-cta.less',
+            'css/firefox/independent-splash.less',
+            'css/firefox/australis/australis-ui-tour.less',
+            'css/firefox/privacy_tour/common.less',
+            'css/firefox/privacy_tour/tour.less',
+        ),
+        'output_filename': 'css/firefox_privacy_tour-bundle.css',
+    },
+    'firefox_privacy_no_tour': {
+        'source_filenames': (
+            'css/sandstone/sandstone.less',
+            'css/base/mozilla-modal.less',
+            'css/base/mozilla-share-cta.less',
+            'css/firefox/independent-splash.less',
+            'css/firefox/privacy_tour/common.less',
+            'css/firefox/privacy_tour/no-tour.less',
+        ),
+        'output_filename': 'css/firefox_privacy_no_tour-bundle.css',
+    },
+    'firefox_search_tour': {
+        'source_filenames': (
+            'css/sandstone/sandstone.less',
+            'css/firefox/search_tour/common.less',
+            'css/firefox/search_tour/tour.less',
+        ),
+        'output_filename': 'css/firefox_search_tour-bundle.css',
+    },
+    'firefox_search_no_tour': {
+        'source_filenames': (
+            'css/sandstone/sandstone.less',
+            'css/firefox/search_tour/common.less',
+        ),
+        'output_filename': 'css/firefox_search_no_tour-bundle.css',
+    },
+    'firefox_tour': {
+        'source_filenames': (
+            'css/sandstone/sandstone.less',
+            'css/firefox/australis/australis-ui-tour.less',
+            'css/firefox/australis/australis-page-common.less',
+            'css/firefox/sync-animation.less',
+            'css/firefox/australis/australis-page-stacked.less',
+        ),
+        'output_filename': 'css/firefox_tour-bundle.css',
+    },
+    'firefox_whatsnew': {
+        'source_filenames': (
+            'css/sandstone/sandstone-resp.less',
+            'css/firefox/template-resp.less',
+            'css/sandstone/video.less',
+            'css/firefox/whatsnew.less',
+            'css/firefox/whatsnew-android.less',
+        ),
+        'output_filename': 'css/firefox_whatsnew-bundle.css',
+    },
+    'firefox_whatsnew_37': {
+        'source_filenames': (
+            'css/sandstone/sandstone-resp.less',
+            'css/firefox/template-resp.less',
+            'css/firefox/whatsnew-fx37.less',
+        ),
+        'output_filename': 'css/firefox_whatsnew_37-bundle.css',
+    },
+    'firefox_whatsnew_fxos': {
+        'source_filenames': (
+            'css/sandstone/sandstone.less',
+            'css/firefox/simple_footer.less',
+            'css/firefox/whatsnew-fxos.less',
+        ),
+        'output_filename': 'css/firefox_whatsnew_fxos-bundle.css',
+    },
+    'firefox_releasenotes': {
+        'source_filenames': (
+            'css/sandstone/sandstone-resp.less',
+            'css/firefox/template-resp.less',
+            'css/firefox/menu-resp.less',
+            'css/firefox/releasenotes.less',
+        ),
+        'output_filename': 'css/firefox_releasenotes-bundle.css',
+    },
+    'firefox_sync': {
+        'source_filenames': (
+            'css/sandstone/sandstone-resp.less',
+            'css/firefox/family-nav.less',
+            'css/firefox/sync.less',
+        ),
+        'output_filename': 'css/firefox_sync-bundle.css',
+    },
+    'firefox_sync_old': {
+        'source_filenames': (
+            'css/sandstone/sandstone-resp.less',
+            'css/firefox/family-nav.less',
+            'css/firefox/sync-old.less',
+        ),
+        'output_filename': 'css/firefox_sync_old-bundle.css',
+    },
+    'firefox_sync_anim': {
+        'source_filenames': (
+            'css/firefox/sync-animation.less',
+        ),
+        'output_filename': 'css/firefox_sync_anim-bundle.css',
+    },
+    'firefox_independent': {
+        'source_filenames': (
+            'css/sandstone/sandstone-resp.less',
+            'css/base/mozilla-share-cta.less',
+            'css/firefox/independent-splash.less',
+            'css/firefox/independent.less',
+        ),
+        'output_filename': 'css/firefox_independent-bundle.css',
+    },
+    'installer_help': {
+        'source_filenames': (
+            'css/sandstone/sandstone-resp.less',
+            'css/firefox/template-resp.less',
+            'css/firefox/menu-resp.less',
+            'css/base/mozilla-modal.less',
+            'css/firefox/installer-help.less',
+        ),
+        'output_filename': 'css/installer_help-bundle.css',
+    },
+    'growth_firstrun_test1': {
+        'source_filenames': (
+            'css/sandstone/sandstone.less',
+            'css/firefox/australis/australis-page-common.less',
+            'css/firefox/sync-animation.less',
+            'css/firefox/australis/australis-page-stacked.less',
+            'css/firefox/australis/growth-firstrun-test-common.less',
+            'css/firefox/australis/growth-firstrun-test1.less',
+        ),
+        'output_filename': 'css/growth-firstrun-test1-bundle.css'
+    },
+    'growth_firstrun_test2': {
+        'source_filenames': (
+            'css/sandstone/sandstone.less',
+            'css/firefox/australis/australis-page-common.less',
+            'css/firefox/sync-animation.less',
+            'css/firefox/australis/australis-page-stacked.less',
+            'css/firefox/australis/growth-firstrun-test-common.less',
+            'css/firefox/australis/growth-firstrun-test2.less',
+        ),
+        'output_filename': 'css/growth-firstrun-test2-bundle.css'
+    },
+    'history-slides': {
+        'source_filenames': (
+            'css/mozorg/history-slides.less',
+        ),
+        'output_filename': 'css/history-slides-bundle.css',
+    },
+    'home': {
+        'source_filenames': (
+            'css/mozorg/home.less',
+            'css/mozorg/home-promo.less',
+        ),
+        'output_filename': 'css/home-bundle.css',
+    },
+    'home-ie9': {
+        'source_filenames': (
+            'css/mozorg/home-ie9.less',
+        ),
+        'output_filename': 'css/home-ie9-bundle.css',
+    },
+    'home-ie8': {
+        'source_filenames': (
+            'css/mozorg/home-ie8.less',
+        ),
+        'output_filename': 'css/home-ie8-bundle.css',
+    },
+    'home-ie': {
+        'source_filenames': (
+            'css/mozorg/home-ie.less',
+        ),
+        'output_filename': 'css/home-ie-bundle.css',
+    },
+    'home-2015': {
+        'source_filenames': (
+            'css/mozorg/home/home.less',
+            'css/mozorg/home/home-promo.less',
+        ),
+        'output_filename': 'css/home-2015-bundle.css',
+    },
+    'home-2015-ie8': {
+        'source_filenames': (
+            'css/mozorg/home/home-ie8.less',
+        ),
+        'output_filename': 'css/home-2015-ie8-bundle.css',
+    },
+    'legal': {
+        'source_filenames': (
+            'css/sandstone/sandstone-resp.less',
+            'css/legal/legal.less',
+        ),
+        'output_filename': 'css/legal-bundle.css',
+    },
+    'legal-eula': {
+        'source_filenames': (
+            'css/legal/eula.less',
+        ),
+        'output_filename': 'css/legal-eula-bundle.css',
+    },
+    'legal_fraud_report': {
+        'source_filenames': (
+            'css/sandstone/sandstone-resp.less',
+            'css/legal/fraud-report.less',
+        ),
+        'output_filename': 'css/legal_fraud_report-bundle.css',
+    },
+    'manifesto': {
+        'source_filenames': (
+            'css/base/mozilla-modal.less',
+            'css/libs/socialshare/socialshare.less',
+            'css/mozorg/mosaic.less',
+            'css/mozorg/manifesto.less',
+        ),
+        'output_filename': 'css/manifesto-bundle.css',
+    },
+    'mission': {
+        'source_filenames': (
+            'css/sandstone/video-resp.less',
+            'css/mozorg/mosaic.less',
+            'css/mozorg/mission.less',
+        ),
+        'output_filename': 'css/mission-bundle.css',
+    },
+    'mozilla_accordion': {
+        'source_filenames': (
+            'css/base/mozilla-accordion.less',
+        ),
+        'output_filename': 'css/mozilla_accordion-bundle.css',
+    },
+    'newsletter_ios': {
+        'source_filenames': (
+            'css/sandstone/sandstone-resp.less',
+            'css/newsletter/ios.less',
+        ),
+        'output_filename': 'css/newsletter_ios-bundle.css',
+    },
+    'partnerships': {
+        'source_filenames': (
+            'css/mozorg/partnerships.less',
+        ),
+        'output_filename': 'css/partnerships-bundle.css',
+    },
+    'persona': {
+        'source_filenames': (
+            'css/persona/persona.less',
+        ),
+        'output_filename': 'css/persona-bundle.css',
+    },
+    'powered-by': {
+        'source_filenames': (
+            'css/sandstone/sandstone-resp.less',
+            'css/mozorg/powered-by.less',
+        ),
+        'output_filename': 'css/powered-by-bundle.css',
+    },
+    'plugincheck': {
+        'source_filenames': (
+            'css/base/mozilla-share-cta.less',
+            'css/plugincheck/plugincheck.less',
+        ),
+        'output_filename': 'css/plugincheck-bundle.css',
+    },
+    'press_speaker_request': {
+        'source_filenames': (
+            'css/sandstone/sandstone-resp.less',
+            'css/press/speaker-request.less',
+        ),
+        'output_filename': 'css/press_speaker_request-bundle.css',
+    },
+    'privacy': {
+        'source_filenames': (
+            'css/privacy/privacy.less',
+        ),
+        'output_filename': 'css/privacy-bundle.css',
+    },
+    'privacy-day': {
+        'source_filenames': (
+            'css/sandstone/sandstone-resp.less',
+            'css/base/mozilla-share-cta.less',
+            'css/privacy/privacy-day.less',
+        ),
+        'output_filename': 'css/privacy-day-bundle.css',
+    },
+    'fb_privacy': {
+        'source_filenames': (
+            'css/privacy/fb-privacy.less',
+        ),
+        'output_filename': 'css/fb_privacy-bundle.css',
+    },
+    'projects_mozilla_based': {
+        'source_filenames': (
+            'css/mozorg/projects/mozilla-based.less',
+        ),
+        'output_filename': 'css/projects_mozilla_based-bundle.css',
+    },
+    'projects-calendar': {
+        'source_filenames': (
+            'css/mozorg/projects/calendar.less',
+        ),
+        'output_filename': 'css/projects-calendar-bundle.css',
+    },
+    'research': {
+        'source_filenames': (
+            'css/research/research.less',
+        ),
+        'output_filename': 'css/research-bundle.css',
+    },
+    'security': {
+        'source_filenames': (
+            'css/sandstone/sandstone-resp.less',
+            'css/security/security.less',
+        ),
+        'output_filename': 'css/security-bundle.css',
+    },
+    'security-bug-bounty-hall-of-fame': {
+        'source_filenames': (
+            'css/security/hall-of-fame.less',
+            'css/base/mozilla-accordion.less',
+        ),
+        'output_filename': 'css/security-bug-bounty-hall-of-fame-bundle.css',
+    },
+    'security-tld-idn': {
+        'source_filenames': (
+            'css/mozorg/security-tld-idn.less',
+        ),
+        'output_filename': 'css/security-tld-idn-bundle.css',
+    },
+    'styleguide': {
+        'source_filenames': (
+            'css/sandstone/fonts.less',
+            'css/styleguide/styleguide.less',
+            'css/styleguide/websites-sandstone.less',
+            'css/styleguide/identity-mozilla.less',
+            'css/styleguide/identity-firefox.less',
+            'css/styleguide/identity-firefox-family.less',
+            'css/styleguide/identity-firefoxos.less',
+            'css/styleguide/identity-marketplace.less',
+            'css/styleguide/identity-thunderbird.less',
+            'css/styleguide/identity-webmaker.less',
+            'css/styleguide/communications.less',
+            'css/styleguide/products-firefox-os.less',
+        ),
+        'output_filename': 'css/styleguide-bundle.css',
+    },
+    'styleguide-docs-mozilla-accordion': {
+        'source_filenames': (
+            'css/base/mozilla-accordion.less',
+            'css/sandstone/sandstone-resp.less',
+        ),
+        'output_filename': 'css/styleguide-docs-mozilla-accordion-bundle.css',
+    },
+    'styleguide-docs-mozilla-pager': {
+        'source_filenames': (
+            'css/sandstone/sandstone-resp.less',
+            'css/styleguide/docs/mozilla-pager.less',
+        ),
+        'output_filename': 'css/styleguide-docs-mozilla-pager-bundle.css',
+    },
+    'tabzilla': {
+        'source_filenames': (
+            'css/tabzilla/tabzilla.less',
+        ),
+        'output_filename': 'css/tabzilla-min.css',
+    },
+    'contribute-2015': {
+        'source_filenames': (
+            'css/base/mozilla-modal.less',
+            'css/mozorg/contribute/contribute-2015.less',
+        ),
+        'output_filename': 'css/contribute-2015-bundle.css',
+    },
+    'video': {
+        'source_filenames': (
+            'css/sandstone/video.less',
+        ),
+        'output_filename': 'css/video-bundle.css',
+    },
+    'video-resp': {
+        'source_filenames': (
+            'css/sandstone/video-resp.less',
+        ),
+        'output_filename': 'css/video-resp-bundle.css',
+    },
+    'page_not_found': {
+        'source_filenames': (
+            'css/base/page-not-found.less',
+        ),
+        'output_filename': 'css/page_not_found-bundle.css',
+    },
+    'annual_2011': {
+        'source_filenames': (
+            'css/foundation/annual2011.less',
+        ),
+        'output_filename': 'css/annual_2011-bundle.css',
+    },
+    'annual_2012': {
+        'source_filenames': (
+            'css/base/mozilla-modal.less',
+            'css/foundation/annual2012.less',
+        ),
+        'output_filename': 'css/annual_2012-bundle.css',
+    },
+    'annual_2013': {
+        'source_filenames': (
+            'css/base/mozilla-modal.less',
+            'css/foundation/annual2013.less',
+        ),
+        'output_filename': 'css/annual_2013-bundle.css',
+    },
+    'partners': {
+        'source_filenames': (
+            'css/base/mozilla-modal.less',
+            'css/libs/jquery.pageslide.css',
+            'css/firefox/partners.less',
+            'css/firefox/family-nav.less',
+            'css/firefox/mwc-2015-schedule.less',
+            'css/firefox/mwc-2015-map.less',
+        ),
+        'output_filename': 'css/partners-bundle.css',
+    },
+    'partners-ie7': {
+        'source_filenames': (
+            'css/firefox/partners/ie7.less',
+        ),
+        'output_filename': 'css/partners-ie7-bundle.css',
+    },
+    'facebookapps_downloadtab': {
+        'source_filenames': (
+            'css/libs/h5bp_main.css',
+            'css/facebookapps/downloadtab.less',
+        ),
+        'output_filename': 'css/facebookapps_downloadtab-bundle.css',
+    },
+    'thunderbird-start': {
+        'source_filenames': (
+            'css/sandstone/fonts.less',
+            'css/thunderbird/start.less',
+        ),
+        'output_filename': 'css/thunderbird-start-bundle.css',
+    },
+}
+
+PIPELINE_JS = {
+    'site': {
+        'source_filenames': (
+            'js/base/site.js',  # this is automatically included on every page
+        ),
+        'output_filename': 'js/site-bundle.js',
+    },
+    'lightbeam': {
+        'source_filenames': (
+            'js/lightbeam/d3.v3.min.js',
+            'js/lightbeam/rAF.js',
+            'js/lightbeam/lightbeam.js',
+            'js/lightbeam/ui.js',
+            'js/libs/jquery.validate.js',
+        ),
+        'output_filename': 'js/lightbeam-bundle.js',
+    },
+    'projects-calendar': {
+        'source_filenames': (
+            'js/mozorg/calendar.js',
+        ),
+        'output_filename': 'js/projects-calendar-bundle.js',
+    },
+    'common': {
+        'source_filenames': (
+            'js/libs/jquery-1.11.0.min.js',
+            'js/libs/spin.min.js',
+            'js/base/global.js',
+            'js/base/global-init.js',
+            'js/newsletter/form.js',
+            'js/base/mozilla-input-placeholder.js',
+            'js/base/mozilla-image-helper.js',
+        ),
+        'output_filename': 'js/common-bundle.js',
+    },
+    'common-resp': {
+        'source_filenames': (
+            'js/libs/jquery-1.11.0.min.js',
+            'js/libs/spin.min.js',
+            'js/base/global.js',
+            'js/base/global-init.js',
+            'js/newsletter/form.js',
+            'js/base/nav-main-resp.js',
+            'js/base/mozilla-input-placeholder.js',
+            'js/base/mozilla-image-helper.js',
+        ),
+        'output_filename': 'js/common-resp-bundle.js',
+    },
+    'contact-spaces': {
+        'source_filenames': (
+            'js/libs/mapbox-2.1.5.js',
+            'js/libs/jquery.history.js',
+            'js/mozorg/contact-data.js',
+            'js/libs/jquery.magnific-popup.min.js',
+            'js/base/mozilla-video-poster.js',
+            'js/mozorg/contact-spaces.js',
+        ),
+        'output_filename': 'js/contact-spaces-bundle.js',
+    },
+    'contact-spaces-ie7': {
+        'source_filenames': (
+            'js/mozorg/contact-spaces-ie7.js',
+        ),
+        'output_filename': 'js/contact-spaces-ie7-bundle.js',
+    },
+    'contribute-faces': {
+        'source_filenames': (
+            'js/mozorg/contribute/contribute-faces.js',
+        ),
+        'output_filename': 'js/contribute-faces-bundle.js',
+    },
+    'contribute-form': {
+        'source_filenames': (
+            'js/mozorg/contribute/contribute-form.js',
+            'js/base/mozilla-input-placeholder.js',
+        ),
+        'output_filename': 'js/contribute-form-bundle.js',
+    },
+    'contribute-studentambassadors-landing': {
+        'source_filenames': (
+            'js/base/social-widgets.js',
+        ),
+        'output_filename': 'js/contribute-studentambassadors-landing-bundle.js',
+    },
+    'contribute-studentambassadors-join': {
+        'source_filenames': (
+            'js/mozorg/contribute/contribute-studentambassadors-join.js',
+            'js/base/mozilla-input-placeholder.js',
+        ),
+        'output_filename': 'js/contribute-studentambassadors-join-bundle.js',
+    },
+    'existing': {
+        'source_filenames': (
+            'js/newsletter/existing.js',
+        ),
+        'output_filename': 'js/existing-bundle.js',
+    },
+    'accordion': {
+        'source_filenames': (
+            'js/base/mozilla-accordion.js',
+            'js/base/mozilla-accordion-gatrack.js',
+        ),
+        'output_filename': 'js/accordion-bundle.js',
+    },
+    'dnt': {
+        'source_filenames': (
+            'js/base/mozilla-accordion.js',
+            'js/base/mozilla-accordion-gatrack.js',
+            'js/libs/jquery.waypoints.min.js',
+            'js/libs/jquery.waypoints-sticky.min.js',
+            'js/firefox/family-nav.js',
+            'js/firefox/dnt.js',
+        ),
+        'output_filename': 'js/firefox_dnt-bundle.js',
+    },
+    'firefox': {
+        'source_filenames': (
+            'js/libs/jquery-1.11.0.min.js',
+            'js/libs/spin.min.js',
+            'js/base/global.js',
+            'js/base/global-init.js',
+            'js/newsletter/form.js',
+            'js/base/nav-main.js',
+            'js/base/mozilla-input-placeholder.js',
+            'js/base/mozilla-image-helper.js',
+        ),
+        'output_filename': 'js/firefox-bundle.js',
+    },
+    'firefox_all': {
+        'source_filenames': (
+            'js/base/mozilla-share-cta.js',
+            'js/base/mozilla-pager.js',
+            'js/firefox/firefox-language-search.js',
+        ),
+        'output_filename': 'js/firefox_all-bundle.js',
+    },
+    'firefox_android': {
+        'source_filenames': (
+            'js/base/mozilla-accordion.js',
+            'js/libs/jquery.waypoints.min.js',
+            'js/libs/jquery.cycle2.min.js',
+            'js/libs/jquery.waypoints.min.js',
+            'js/libs/jquery.waypoints-sticky.min.js',
+            'js/firefox/family-nav.js',
+            'js/firefox/sync-animation.js',
+            'js/firefox/android.js',
+        ),
+        'output_filename': 'js/firefox_android-bundle.js',
+    },
+    'firefox-resp': {
+        'source_filenames': (
+            'js/libs/jquery-1.11.0.min.js',
+            'js/libs/spin.min.js',
+            'js/base/global.js',
+            'js/base/global-init.js',
+            'js/newsletter/form.js',
+            'js/base/nav-main-resp.js',
+            'js/base/mozilla-input-placeholder.js',
+            'js/base/mozilla-image-helper.js',
+        ),
+        'output_filename': 'js/firefox-resp-bundle.js',
+    },
+    'firefox_channel': {
+        'source_filenames': (
+            'js/base/mozilla-pager.js',
+            'js/firefox/channel.js',
+        ),
+        'output_filename': 'js/firefox_channel-bundle.js',
+    },
+    'firefox_desktop_customize': {
+        'source_filenames': (
+            'js/libs/jquery.waypoints.min.js',
+            'js/libs/jquery.waypoints-sticky.min.js',
+            'js/firefox/family-nav.js',
+            'js/firefox/sync-animation.js',
+            'js/firefox/desktop/common.js',
+            'js/firefox/desktop/customize.js',
+        ),
+        'output_filename': 'js/firefox_desktop_customize-bundle.js',
+    },
+    'firefox_desktop_fast': {
+        'source_filenames': (
+            'js/libs/jquery.waypoints.min.js',
+            'js/libs/jquery.waypoints-sticky.min.js',
+            'js/firefox/family-nav.js',
+            'js/firefox/desktop/common.js',
+            'js/firefox/desktop/speed-graph.js',
+            'js/firefox/desktop/fast.js',
+        ),
+        'output_filename': 'js/firefox_desktop_fast-bundle.js',
+    },
+    'firefox_desktop_index': {
+        'source_filenames': (
+            'js/libs/jquery.waypoints.min.js',
+            'js/libs/jquery.waypoints-sticky.min.js',
+            'js/firefox/family-nav.js',
+            'js/firefox/desktop/common.js',
+            'js/firefox/desktop/speed-graph.js',
+            'js/base/svg-animation-check.js',
+            'js/firefox/desktop/intro-anim.js',
+            'js/firefox/desktop/index.js',
+        ),
+        'output_filename': 'js/firefox_desktop_index-bundle.js',
+    },
+    'firefox_desktop_tips': {
+        'source_filenames': (
+            'js/base/mozilla-pager.js',
+            'js/libs/hammer.1.1.2.min.js',
+            'js/libs/socialshare.min.js',
+            'js/firefox/desktop/tips.js',
+        ),
+        'output_filename': 'js/firefox_desktop_tips-bundle.js',
+    },
+    'firefox_desktop_trust': {
+        'source_filenames': (
+            'js/libs/jquery.waypoints.min.js',
+            'js/libs/jquery.waypoints-sticky.min.js',
+            'js/firefox/family-nav.js',
+            'js/firefox/desktop/common.js',
+            'js/firefox/desktop/trust.js',
+        ),
+        'output_filename': 'js/firefox_desktop_trust-bundle.js',
+    },
+    'firefox_developer': {
+        'source_filenames': (
+            'js/firefox/developer.js',
+            'js/base/mozilla-modal.js',
+            'js/base/mozilla-share-cta.js',
+        ),
+        'output_filename': 'js/firefox_developer-bundle.js',
+    },
+    'firefox_firstrun': {
+        'source_filenames': (
+            'js/base/mozilla-modal.js',
+            'js/firefox/firstrun/firstrun.js',
+        ),
+        'output_filename': 'js/firefox_firstrun-bundle.js',
+    },
+    'firefox_fx36_firstrun': {
+        'source_filenames': (
+            'js/firefox/australis/australis-uitour.js',
+            'js/firefox/australis/browser-tour.js',
+            'js/firefox/australis/fx36/common.js',
+            'js/firefox/australis/fx36/firstrun.js',
+        ),
+        'output_filename': 'js/firefox_fx36_firstrun-bundle.js',
+    },
+    'firefox_fx36_whatsnew': {
+        'source_filenames': (
+            'js/firefox/australis/australis-uitour.js',
+            'js/firefox/australis/browser-tour.js',
+            'js/firefox/australis/fx36/common.js',
+            'js/firefox/australis/fx36/whatsnew.js',
+        ),
+        'output_filename': 'js/firefox_fx36_whatsnew-bundle.js',
+    },
+    'firefox_fx36_whatsnew_no_tour': {
+        'source_filenames': (
+            'js/firefox/australis/fx36/common.js',
+            'js/firefox/australis/fx36/whatsnew-notour.js',
+        ),
+        'output_filename': 'js/firefox_fx36_whatsnew_no_tour-bundle.js',
+    },
+    'firefox_developer_firstrun': {
+        'source_filenames': (
+            'js/firefox/australis/australis-uitour.js',
+            'js/base/mozilla-modal.js',
+            'js/firefox/dev-firstrun.js',
+        ),
+        'output_filename': 'js/firefox_developer_firstrun-bundle.js',
+    },
+    'firefox_new': {
+        'source_filenames': (
+            'js/libs/jquery-1.11.0.min.js',
+            'js/libs/spin.min.js',
+            'js/base/global.js',
+            'js/base/global-init.js',
+            'js/base/search-params.js',
+            'js/newsletter/form.js',
+            'js/base/mozilla-input-placeholder.js',
+            'js/base/mozilla-image-helper.js',
+            'js/libs/socialshare.min.js',
+            'js/libs/modernizr.custom.csstransitions.js',
+            'js/firefox/new.js',
+        ),
+        'output_filename': 'js/firefox_new-bundle.js',
+    },
+    'firefox_independent': {
+        'source_filenames': (
+            'js/base/mozilla-share-cta.js',
+            'js/base/firefox-anniversary-video.js',
+            'js/firefox/independent.js',
+        ),
+        'output_filename': 'js/firefox_independent-bundle.js',
+    },
+    'firefox_os': {
+        'source_filenames': (
+            'js/base/mozilla-modal.js',
+            'js/libs/jquery.waypoints.min.js',
+            'js/libs/jquery.waypoints-sticky.min.js',
+            'js/libs/tweenmax.1.9.7.min.js',
+            'js/libs/superscrollorama-1.0.1.js',
+            'js/libs/jquery.plusslider.js',
+            'js/libs/jquery.color.js',
+            'js/libs/script.js',
+            'js/libs/socialshare.min.js',
+            'js/firefox/os/firefox-os.js',
+            'js/firefox/os/desktop.js',
+            'js/firefox/os/have-it.js',
+        ),
+        'output_filename': 'js/firefox_os-bundle.js',
+    },
+    'firefox_os_new': {
+        'source_filenames': (
+            'js/base/mozilla-modal.js',
+            'js/libs/jquery.waypoints.min.js',
+            'js/libs/jquery.waypoints-sticky.min.js',
+            'js/libs/script.js',
+            'js/firefox/family-nav.js',
+            'js/firefox/os/firefox-os-new.js',
+        ),
+        'output_filename': 'js/firefox_os_new-bundle.js',
+    },
+    'firefox_os_ie9': {
+        'source_filenames': (
+            'js/libs/matchMedia.addListener.js',
+        ),
+        'output_filename': 'js/firefox_os_ie9-bundle.js',
+    },
+    'firefox_os_devices': {
+        'source_filenames': (
+            'js/libs/jquery.tipsy.js',
+            'js/libs/jquery.waypoints.min.js',
+            'js/libs/jquery.waypoints-sticky.min.js',
+            'js/base/mozilla-pager.js',
+            'js/base/mozilla-modal.js',
+            'js/firefox/family-nav.js',
+            'js/firefox/os/partner_data.js',
+            'js/firefox/os/devices.js',
+        ),
+        'output_filename': 'js/firefox_os_devices-bundle.js',
+    },
+    'firefox_os_mwc_2015_preview': {
+        'source_filenames': (
+            'js/base/mozilla-modal.js',
+            'js/libs/jquery.waypoints.min.js',
+            'js/libs/jquery.waypoints-sticky.min.js',
+            'js/firefox/family-nav.js',
+            'js/firefox/mwc-2015-map.js',
+            'js/firefox/os/mwc-2015-preview.js',
+        ),
+        'output_filename': 'js/firefox_os_mwc_2015_preview-bundle.js',
+    },
+    'firefox_os_tv': {
+        'source_filenames': (
+            'js/base/mozilla-pager.js',
+        ),
+        'output_filename': 'js/firefox_os_tv-bundle.js',
+    },
+    'firefox_interest_dashboard': {
+        'source_filenames': (
+            'js/libs/jquery.waypoints.min.js',
+            'js/libs/jquery.waypoints-sticky.min.js',
+            'js/firefox/family-nav.js',
+            'js/firefox/interest-dashboard.js',
+        ),
+        'output_filename': 'js/firefox_interest_dashboard-bundle.js',
+    },
+    'firefox_tiles': {
+        'source_filenames': (
+            'js/libs/jquery.waypoints.min.js',
+            'js/libs/jquery.waypoints-sticky.min.js',
+            'js/firefox/family-nav.js',
+            'js/firefox/tiles.js',
+        ),
+        'output_filename': 'js/firefox_tiles-bundle.js',
+    },
+    'firefox_family_index': {
+        'source_filenames': (
+            'js/firefox/family-index.js',
+        ),
+        'output_filename': 'js/firefox_family_index-bundle.js',
+    },
+    'firefox_faq': {
+        'source_filenames': (
+            'js/base/mozilla-accordion.js',
+            'js/base/mozilla-accordion-gatrack.js',
+        ),
+        'output_filename': 'js/firefox_faq-bundle.js',
+    },
+    'firefox_sync': {
+        'source_filenames': (
+            'js/libs/jquery.waypoints.min.js',
+            'js/libs/jquery.waypoints-sticky.min.js',
+            'js/firefox/family-nav.js',
+            'js/firefox/sync-animation.js',
+            'js/firefox/australis/australis-uitour.js',
+            'js/firefox/sync.js',
+        ),
+        'output_filename': 'js/firefox_sync-bundle.js',
+    },
+    'firefox_sync_old': {
+        'source_filenames': (
+            'js/libs/jquery.waypoints.min.js',
+            'js/libs/jquery.waypoints-sticky.min.js',
+            'js/firefox/family-nav.js',
+            'js/firefox/sync-animation.js',
+            'js/firefox/sync-old.js',
+        ),
+        'output_filename': 'js/firefox_sync_old-bundle.js',
+    },
+    'firefox_feedback': {
+        'source_filenames': (
+            'js/base/mozilla-share-cta.js',
+            'js/firefox/feedback-ga-tracking.js',
+        ),
+        'output_filename': 'js/firefox_feedback-bundle.js',
+    },
+    'firefox_hello_start': {
+        'source_filenames': (
+            'js/firefox/australis/australis-uitour.js',
+            'js/firefox/hello/start.js',
+        ),
+        'output_filename': 'js/firefox_hello_start-bundle.js',
+    },
+    'firefox_hello': {
+        'source_filenames': (
+            'js/firefox/australis/australis-uitour.js',
+            'js/base/mozilla-modal.js',
+            'js/base/svg-animation-check.js',
+            'js/base/mozilla-share-cta.js',
+            'js/libs/jquery.waypoints.min.js',
+            'js/libs/jquery.waypoints-sticky.min.js',
+            'js/firefox/family-nav.js',
+            'js/firefox/hello/index.js',
+        ),
+        'output_filename': 'js/firefox_hello-bundle.js',
+    },
+    'firefox_hello_ie9': {
+        'source_filenames': (
+            'js/libs/matchMedia.js',
+            'js/libs/matchMedia.addListener.js',
+        ),
+        'output_filename': 'js/firefox_hello_ie9-bundle.js',
+    },
+    'firefox_privacy_tour': {
+        'source_filenames': (
+            'js/base/mozilla-modal.js',
+            'js/base/mozilla-share-cta.js',
+            'js/base/firefox-anniversary-video.js',
+            'js/firefox/australis/australis-uitour.js',
+            'js/firefox/australis/browser-tour.js',
+            'js/firefox/privacy_tour/common.js',
+            'js/firefox/privacy_tour/tour.js',
+        ),
+        'output_filename': 'js/firefox_privacy_tour-bundle.js',
+    },
+    'firefox_privacy_no_tour': {
+        'source_filenames': (
+            'js/base/mozilla-modal.js',
+            'js/base/mozilla-share-cta.js',
+            'js/base/firefox-anniversary-video.js',
+            'js/firefox/privacy_tour/common.js',
+            'js/firefox/privacy_tour/no-tour.js',
+        ),
+        'output_filename': 'js/firefox_privacy_no_tour-bundle.js',
+    },
+    'firefox_search_tour': {
+        'source_filenames': (
+            'js/firefox/australis/australis-uitour.js',
+            'js/firefox/search_tour/common.js',
+            'js/firefox/search_tour/tour.js',
+        ),
+        'output_filename': 'js/firefox_search_tour-bundle.js',
+    },
+    'firefox_search_tour_34.0.5': {
+        'source_filenames': (
+            'js/firefox/australis/australis-uitour.js',
+            'js/firefox/search_tour/common.js',
+            'js/firefox/search_tour/tour-34.0.5.js',
+        ),
+        'output_filename': 'js/firefox_search_tour_34.0.5-bundle.js',
+    },
+    'firefox_search_no_tour': {
+        'source_filenames': (
+            'js/firefox/australis/australis-uitour.js',
+            'js/firefox/search_tour/common.js',
+        ),
+        'output_filename': 'js/firefox_search_no_tour-bundle.js',
+    },
+    'firefox_tour': {
+        'source_filenames': (
+            'js/libs/jquery.waypoints.min.js',
+            'js/firefox/australis/australis-uitour.js',
+            'js/firefox/australis/browser-tour.js',
+            'js/firefox/australis/common.js',
+            'js/firefox/australis/tour.js',
+        ),
+        'output_filename': 'js/firefox_tour-bundle.js',
+    },
+    'firefox_tour_none': {
+        'source_filenames': (
+            'js/libs/jquery.waypoints.min.js',
+            'js/firefox/australis/australis-uitour.js',
+            'js/firefox/australis/common.js',
+            'js/firefox/australis/no-tour.js',
+        ),
+        'output_filename': 'js/firefox_tour_none-bundle.js',
+    },
+    'firefox_sms': {
+        'source_filenames': (
+            'js/firefox/sms.js',
+            'js/base/mozilla-share-cta.js',
+        ),
+        'output_filename': 'js/firefox_sms-bundle.js',
+    },
+    'firefox_whatsnew_fx37': {
+        'source_filenames': (
+            'js/firefox/whatsnew-fx37.js',
+        ),
+        'output_filename': 'js/firefox_whatsnew_fx37-bundle.js',
+    },
+    'firefox_whatsnew_fxos': {
+        'source_filenames': (
+            'js/firefox/whatsnew-fxos.js',
+        ),
+        'output_filename': 'js/firefox_whatsnew_fxos-bundle.js',
+    },
+    'geolocation': {
+        'source_filenames': (
+            'js/libs/mapbox-2.1.5.js',
+            'js/base/mozilla-accordion.js',
+            'js/base/mozilla-accordion-gatrack.js',
+            'js/firefox/geolocation-demo.js',
+            'js/base/mozilla-modal.js',
+        ),
+        'output_filename': 'js/geolocation-bundle.js',
+    },
+    'home': {
+        'source_filenames': (
+            'js/libs/jquery.ellipsis.min.js',
+            'js/libs/jquery.cycle2.min.js',
+            'js/libs/jquery.cycle2.carousel.min.js',
+            'js/mozorg/home.js',
+        ),
+        'output_filename': 'js/home-bundle.js',
+    },
+    'growth_firstrun_test1': {
+        'source_filenames': (
+            'js/firefox/australis/australis-uitour.js',
+            'js/firefox/australis/growth-browser-tour.js',
+            'js/libs/fxa-relier-client.min.js',
+            'js/firefox/sync-animation.js',
+            'js/firefox/australis/growth-firstrun-test1.js',
+        ),
+        'output_filename': 'js/growth-firstrun-test1-bundle.js',
+    },
+    'growth_firstrun_test2': {
+        'source_filenames': (
+            'js/firefox/australis/australis-uitour.js',
+            'js/firefox/australis/growth-browser-tour.js',
+            'js/firefox/sync-animation.js',
+            'js/firefox/australis/growth-firstrun-test2.js',
+        ),
+        'output_filename': 'js/growth-firstrun-test2-bundle.js',
+    },
+    'home-2015': {
+        'source_filenames': (
+            'js/base/mozilla-share-cta.js',
+            'js/base/firefox-anniversary-video.js',
+            'js/libs/jquery.waypoints.min.js',
+            'js/mozorg/home/home.js',
+            'js/mozorg/home/ga-tracking.js',
+            'js/mozorg/home/scroll-prompt.js',
+        ),
+        'output_filename': 'js/home-2015-bundle.js',
+    },
+    'home-2015-ie9': {
+        'source_filenames': (
+            'js/libs/matchMedia.addListener.js',
+        ),
+        'output_filename': 'js/home-2015-ie9-bundle.js',
+    },
+    'history-slides': {
+        'source_filenames': (
+            'js/libs/jquery.sequence.js',
+            'js/mozorg/history-slides.js',
+        ),
+        'output_filename': 'js/history-slides-bundle.js',
+    },
+    'installer_help': {
+        'source_filenames': (
+            'js/base/mozilla-modal.js',
+            'js/firefox/installer-help.js',
+        ),
+        'output_filename': 'js/installer_help-bundle.js',
+    },
+    'legal_fraud_report': {
+        'source_filenames': (
+            'js/libs/jquery.validate.js',
+            'js/legal/fraud-report.js',
+            'js/base/mozilla-input-placeholder.js',
+        ),
+        'output_filename': 'js/legal_fraud_report-bundle.js',
+    },
+    'manifesto': {
+        'source_filenames': (
+            'js/base/mozilla-modal.js',
+            'js/libs/socialshare.min.js',
+            'js/mozorg/manifesto.js',
+        ),
+        'output_filename': 'js/manifesto-bundle.js',
+    },
+    'manifesto_ie9': {
+        'source_filenames': (
+            'js/libs/matchMedia.addListener.js',
+        ),
+        'output_filename': 'js/manifesto_ie9-bundle.js',
+    },
+    'mozorg-resp': {
+        'source_filenames': (
+            'js/libs/jquery-1.11.0.min.js',
+            'js/libs/spin.min.js',
+            'js/base/global.js',
+            'js/base/global-init.js',
+            'js/newsletter/form.js',
+            'js/base/nav-main-resp.js',
+            'js/base/mozilla-image-helper.js',
+        ),
+        'output_filename': 'js/mozorg-resp-bundle.js',
+    },
+    'nightly-firstrun': {
+        'source_filenames': (
+            'js/firefox/firstrun/nightly-firstrun.js',
+        ),
+        'output_filename': 'js/nightly-firstrun-bundle.js',
+    },
+    'partnerships': {
+        'source_filenames': (
+            'js/libs/jquery.validate.js',
+            'js/base/mozilla-form-helper.js',
+            'js/mozorg/partnerships.js',
+            'js/base/mozilla-input-placeholder.js',
+        ),
+        'output_filename': 'js/partnerships-bundle.js',
+    },
+    'plugincheck': {
+        'source_filenames': (
+            'js/plugincheck/lib/mustache.js',
+            'js/base/mozilla-share-cta.js',
+            'js/plugincheck/tmpl/plugincheck.ui.tmpl.js',
+            'js/plugincheck/lib/utils.js',
+            'js/plugincheck/lib/version-compare.js',
+            'js/plugincheck/lib/plugincheck.js',
+            'js/plugincheck/check-plugins.js',
+        ),
+        'output_filename': 'js/plugincheck-bundle.js',
+    },
+    'press_speaker_request': {
+        'source_filenames': (
+            'js/libs/jquery.validate.js',
+            'js/libs/modernizr.custom.inputtypes.js',
+            'js/press/speaker-request.js',
+            'js/base/mozilla-input-placeholder.js',
+        ),
+        'output_filename': 'js/press_speaker_request-bundle.js',
+    },
+    'privacy': {
+        'source_filenames': (
+            'js/privacy/privacy.js',
+        ),
+        'output_filename': 'js/privacy-bundle.js',
+    },
+    'privacy-day': {
+        'source_filenames': (
+            'js/base/mozilla-pager.js',
+            'js/base/mozilla-share-cta.js',
+            'js/libs/jquery.waypoints.min.js',
+            'js/libs/jquery.waypoints-sticky.min.js',
+            'js/privacy/privacy-day.js',
+        ),
+        'output_filename': 'js/privacy-day-bundle.js',
+    },
+    'products': {
+        'source_filenames': (
+            'js/libs/jquery.waypoints.min.js',
+            'js/libs/jquery.waypoints-sticky.min.js',
+            'js/mozorg/products.js',
+        ),
+        'output_filename': 'js/products-bundle.js',
+    },
+    'styleguide': {
+        'source_filenames': (
+            'js/styleguide/styleguide.js',
+        ),
+        'output_filename': 'js/styleguide-bundle.js',
+    },
+    'styleguide-docs-mozilla-accordion': {
+        'source_filenames': (
+            'js/base/mozilla-accordion.js',
+            'js/styleguide/docs/mozilla-accordion.js',
+        ),
+        'output_filename': 'js/styleguide-docs-mozilla-accordion-bundle.js',
+    },
+    'styleguide-docs-mozilla-pager': {
+        'source_filenames': (
+            'js/base/mozilla-pager.js',
+            'js/styleguide/docs/mozilla-pager.js',
+        ),
+        'output_filename': 'js/styleguide-docs-mozilla-pager-bundle.js',
+    },
+    'video': {
+        'source_filenames': (
+            'js/base/mozilla-video-tools.js',
+        ),
+        'output_filename': 'js/video-bundle.js',
+    },
+    'contribute-2015': {
+        'source_filenames': (
+            'js/mozorg/contribute/contribute-2015-ga.js',
+            'js/mozorg/contribute/contribute-2015.js',
+        ),
+        'output_filename': 'js/contribute-2015-bundle.js',
+    },
+    'contribute-2015-landing': {
+        'source_filenames': (
+            'js/libs/jquery.waypoints.min.js',
+            'js/libs/jquery.cycle2.min.js',
+            'js/base/mozilla-modal.js',
+        ),
+        'output_filename': 'js/contribute-2015-landing-bundle.js',
+    },
+    'mosaic': {
+        'source_filenames': (
+            'js/libs/modernizr.custom.26887.js',
+            'js/libs/jquery.transit.min.js',
+            'js/libs/jquery.gridrotator.js',
+        ),
+        'output_filename': 'js/mosaic-bundle.js',
+    },
+    'annual_2011_ie9': {
+        'source_filenames': (
+            'js/libs/matchMedia.addListener.js',
+        ),
+        'output_filename': 'js/annual_2011_ie9-bundle.js',
+    },
+    'annual_2011': {
+        'source_filenames': (
+            'js/libs/jquery.hoverIntent.minified.js',
+            'js/libs/jquery.waypoints.min.js',
+            'js/libs/jquery.jcarousel.min.js',
+            'js/foundation/annual2011.js',
+        ),
+        'output_filename': 'js/annual_2011-bundle.js',
+    },
+    'annual_2012': {
+        'source_filenames': (
+            'js/base/mozilla-modal.js',
+            'js/foundation/annual2012.js',
+        ),
+        'output_filename': 'js/annual_2012-bundle.js',
+    },
+    'annual_2013': {
+        'source_filenames': (
+            'js/base/mozilla-modal.js',
+            'js/foundation/annual2013.js',
+        ),
+        'output_filename': 'js/annual_2013-bundle.js',
+    },
+    'logo-prototype': {
+        'source_filenames': (
+            'js/styleguide/logo-prototype/vendor/raf.polyfill.js',
+            'js/styleguide/logo-prototype/vendor/tween.js',
+            'js/styleguide/logo-prototype/vendor/lodash.compat.min.js',
+            'js/styleguide/logo-prototype/vendor/perlin.js',
+            'js/styleguide/logo-prototype/vendor/dat.gui.js',
+            'js/libs/jquery-1.11.0.min.js',
+            'js/styleguide/logo-prototype/clock-data.js',
+        ),
+        'output_filename': 'js/logo-prototype-bundle.js',
+    },
+    'partners': {
+        'source_filenames': (
+            'js/libs/modernizr.custom.shiv-load.js',
+            'js/base/mozilla-input-placeholder.js',
+            'js/libs/jquery.waypoints.min.js',
+            'js/libs/jquery.waypoints-sticky.min.js',
+            'js/firefox/family-nav.js',
+            'js/base/mozilla-pager.js',
+            'js/base/mozilla-modal.js',
+            'js/firefox/partners.js',
+        ),
+        'output_filename': 'js/partners-bundle.js',
+    },
+    'partners_common': {
+        'source_filenames': (
+            'js/libs/enquire.min.js',
+            'js/base/mozilla-form-helper.js',
+            'js/firefox/partners/common.js',
+        ),
+        'output_filename': 'js/partners_common-bundle.js',
+    },
+    'partners_mobile': {
+        'source_filenames': (
+            'js/firefox/partners/mobile.js',
+        ),
+        'output_filename': 'js/partners_mobile-bundle.js',
+    },
+    'partners_desktop': {
+        'source_filenames': (
+            'js/libs/jquery.pageslide.min.js',
+            'js/libs/jquery.waypoints.min.js',
+            'js/libs/tweenmax.1.9.7.min.js',
+            'js/libs/jquery.spritely-0.6.7.js',
+            'js/firefox/partners/desktop.js',
+        ),
+        'output_filename': 'js/partners_desktop-bundle.js',
+    },
+    'facebookapps_redirect': {
+        'source_filenames': (
+            'js/libs/jquery-1.11.0.min.js',
+            'js/facebookapps/redirect.js',
+        ),
+        'output_filename': 'js/facebookapps_redirect-bundle.js',
+    },
+    'facebookapps_downloadtab': {
+        'source_filenames': (
+            'js/facebookapps/downloadtab-init.js',
+            'js/facebookapps/Base.js',
+            'js/facebookapps/Facebook.js',
+            'js/facebookapps/Theater.js',
+            'js/facebookapps/Slider.js',
+            'js/facebookapps/App.js',
+            'js/facebookapps/downloadtab.js',
+        ),
+        'output_filename': 'js/facebookapps_downloadtab-bundle.js',
+    },
+    'newsletter_form': {
+        'source_filenames': (
+            'js/libs/jquery-1.11.0.min.js',
+            'js/libs/spin.min.js',
+            'js/newsletter/form.js',
+        ),
+        'output_filename': 'js/newsletter_form-bundle.js',
+    },
+    'matchmedia_addlistener': {
+        'source_filenames': (
+            'js/libs/matchMedia.addListener.js',
+        ),
+        'output_filename': 'js/matchmedia_addlistener-bundle.js',
+    },
+}

--- a/bedrock/tabzilla/middleware.py
+++ b/bedrock/tabzilla/middleware.py
@@ -4,7 +4,7 @@
 
 from django.conf import settings
 
-from funfactory.middleware import LocaleURLMiddleware
+from bedrock.base.middleware import LocaleURLMiddleware
 
 
 class TabzillaLocaleURLMiddleware(LocaleURLMiddleware):

--- a/bedrock/tabzilla/tests.py
+++ b/bedrock/tabzilla/tests.py
@@ -11,7 +11,7 @@ from django.test import RequestFactory
 from django.test.utils import override_settings
 from django.utils.http import parse_http_date
 
-from funfactory.urlresolvers import reverse
+from bedrock.base.urlresolvers import reverse
 from mock import patch
 from nose.tools import eq_, ok_
 

--- a/bedrock/urls.py
+++ b/bedrock/urls.py
@@ -6,7 +6,7 @@ from django.conf import settings
 from django.conf.urls import handler404, include, patterns
 from django.contrib import admin
 
-from funfactory.monkeypatches import patch
+from bedrock.base.monkeypatches import patch
 
 
 patch()

--- a/lib/l10n_utils/__init__.py
+++ b/lib/l10n_utils/__init__.py
@@ -10,7 +10,7 @@ from django.shortcuts import render as django_render
 from django.template import TemplateDoesNotExist
 from django.utils.translation.trans_real import parse_accept_lang_header
 
-from funfactory.urlresolvers import split_path
+from bedrock.base.urlresolvers import split_path
 
 from .dotlang import get_lang_path
 from .gettext import template_is_active, translations_for_template

--- a/manage.py
+++ b/manage.py
@@ -1,17 +1,10 @@
 #!/usr/bin/env python
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, You can obtain one at http://mozilla.org/MPL/2.0/.
-
 import os
-
-from funfactory import manage
-
-# Edit this if necessary or override the variable in your environment.
-os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'bedrock.settings')
-
-
-manage.setup_environ(__file__, more_pythonic=True)
+import sys
 
 if __name__ == "__main__":
-    manage.main()
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "bedrock.settings")
+
+    from django.core.management import execute_from_command_line
+
+    execute_from_command_line(sys.argv)

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -138,14 +138,6 @@ https://github.com/kennethreitz/requests/archive/46d646064ca0836a7d7b4d50ea2c762
 
 ###### FROM PLAYDOH-LIB ######
 
-# django-sha2: master~1
-# sha256: TBUJueJfjaBHp4GeUtY0o_IaGHk4DOUf0ZbJZ4YXPPM
-https://github.com/fwenzel/django-sha2/archive/3ba2b4771056fb722bc9fe52cf26918a3f0388bb.tar.gz#egg=django-sha2
-
-# django-mobility: master
-# sha256: vWKlBersFicnz_K9LUwnYlm1HhXt9bgxvWKB915vfog
-https://github.com/jbalogh/django-mobility/archive/e2b60a1f96e4c4aed736395c01bf707e969d8e83.tar.gz#egg=django-mobility
-
 # django-product-details: master
 # sha256: tLy18AIevr3_Rd7saf4cKuq_W1M3zpKFVOLBmggiCck
 https://github.com/mozilla/django-product-details/archive/d168ab2e689a1b54a30a923386fe7948a74ff334.tar.gz#egg=django-mozilla-product-details
@@ -157,10 +149,6 @@ https://github.com/jezdez/django-appconf/archive/d7ff3bb0c35a0c2ec83afdb31f7bb79
 # django-multidb-router: tags/v0.5.1~4
 # sha256: I0E4DVGgHJ6DNZiKaPGiZ1s59QAG7iRC9GP_sTDG_Vg
 https://github.com/jbalogh/django-multidb-router/archive/4f78662026b21cfff1ecfddc487fa0f0c31a0215.tar.gz#egg=django-multidb-router
-
-# funfactory: tags/2.3.0~2
-# sha256: WZK7DOHqxxCVXMeEXbN4GqjK7Nc7zRFW-83LKRO2PA4
-https://github.com/mozilla/funfactory/archive/0caf8b6cb3d583301192651b4fc20df20dd82f00.tar.gz#egg=funfactory
 
 # commonware: tags/v0.4.2
 # sha256: k9gjEUXUPKAuHsPO41UzOvqOcq25z4FXZ-F1lXSXdNQ
@@ -182,11 +170,11 @@ https://github.com/jsocol/django-cronjobs/archive/cfda8176c5c3a50d1b58fcf57e87e2
 # sha256: eeq_z415NQPBF3j59fmy6JGjtnpDgVQxwwvFKxnDQx0
 https://github.com/mozilla/nuggets/archive/ce506882b6943ea45ea4f98290fc4ef23e09a083.tar.gz#egg=nuggets
 
-# because funfactory
-# TODO move back to dev.txt
-
 # sha256: D41ubgIjuPsEEUtKcgk4DhrPJ-Ch3Rq5j-zghafDxSU
 nose==1.0.0
 
 # sha256: NmfSakH-wwNkoO9yWAgyylMogC1VP21ucq9awhyzY2U
 django-nose==1.3
+
+# sha256: aUBxjfw-_0JYIDrVAhCQkz5cBHB9XKjMnnPJSniU6p8
+pathlib==1.0.1

--- a/wsgi/playdoh.wsgi
+++ b/wsgi/playdoh.wsgi
@@ -1,7 +1,6 @@
 # flake8: noqa
 
 import os
-import site
 
 try:
     import newrelic.agent
@@ -16,22 +15,14 @@ if newrelic:
     else:
         newrelic = False
 
-os.environ.setdefault('CELERY_LOADER', 'django')
-# NOTE: you can also set DJANGO_SETTINGS_MODULE in your environment to override
-# the default value in manage.py
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'bedrock.settings')
 
-# Add the app dir to the python path so we can import manage.
-wsgidir = os.path.dirname(__file__)
-site.addsitedir(os.path.abspath(os.path.join(wsgidir, '../')))
-
-# manage adds /apps, /lib, and /vendor to the Python path.
-import manage
-
+# must be imported after env var is set above.
 from django.core.wsgi import get_wsgi_application
 from whitenoise.django import DjangoWhiteNoise
 
-application = DjangoWhiteNoise(get_wsgi_application())
+application = get_wsgi_application()
+application = DjangoWhiteNoise(application)
 
 if newrelic:
     application = newrelic.agent.wsgi_application()(application)


### PR DESCRIPTION
Well... actually it mostly just moves most of funfactory
from an external lib to bedrock.base. But at least this way
we can remove the bits we don't need and be ready to make
the changes we need to upgrade to Django 1.8.

I can't come close to writing as perfect a commit message
for this as @willkg did for fjord, so I'll just leave this here.

https://github.com/mozilla/fjord/commit/9d7c97b