### PR TITLE
[fix bug 1155830] Enable Optimizely on Firefox 37 whatsnew page

### DIFF
--- a/bedrock/firefox/templates/firefox/whatsnew-fx37.html
+++ b/bedrock/firefox/templates/firefox/whatsnew-fx37.html
@@ -21,6 +21,12 @@
 
 {% block page_title_prefix %}{% endblock %}
 
+{% block optimizely %}
+  {% if waffle.switch('firefox-whatsnew-optimizely') %}
+    {% include 'includes/optimizely.html' %}
+  {% endif %}
+{% endblock %}
+
 {# L10n: This string is used in the <title> tag #}
 {% block page_title %}{{ _('Now add Firefox to your Android devices') }}{% endblock %}
 {% block page_title_suffix %}{% endblock %}


### PR DESCRIPTION
Added waffle switch `firefox-whatsnew-optimizely`