### PR TITLE
Add strings for iOS download button, part of Bug 1139961

### DIFF
--- a/bedrock/firefox/templates/firefox/includes/download-button.html
+++ b/bedrock/firefox/templates/firefox/includes/download-button.html
@@ -64,6 +64,9 @@
               {% if channel != 'alpha' %}
                 <span class="download-subtitle">{{ _('Get it free on Google Play') }}</span>
               {% endif %}
+            {% elif plat.os == 'ios' and waffle.switch('ios-active') %}
+              <strong class="download-title">{{ _('<span>Firefox</span> for iOS') }}</strong>
+              <span class="download-subtitle">{{ _('Get it free from the App Store') }}</span>
             {% else %}
               {% if channel == 'beta' %}
                 <strong class="download-title">{{ _('Firefox Beta') }}</strong>


### PR DESCRIPTION
We need to expose those strings to meet the l10n string freeze on April 23. The logic behind the button is coming later.