### PR TITLE
Update responsive styling for mozid modal

### DIFF
--- a/media/css/base/mozid-modal.less
+++ b/media/css/base/mozid-modal.less
@@ -28,14 +28,13 @@ html.noscroll body {
         .inner {
             position: relative;
 
-            header {
+            &> header {
                 display: block;
                 height: auto;
                 .font-size(60px);
                 text-align: center;
                 color: #fff;
                 .open-sans-light;
-                .transition;
             }
 
             #modal-close {
@@ -100,7 +99,7 @@ html[dir="rtl"] {
 
 @media only screen and (min-width: @breakDesktop) {
     #modal .inner {
-        width: @widthDesktop;
+        width: @widthDesktop - (@gridGutterWidth * 2);
         margin: 60px auto;
         .footer {
             .clearfix();
@@ -147,7 +146,7 @@ html[dir="rtl"] {
         .inner {
             margin-top: 20px;
 
-            header {
+            &> header {
                 // remove left/right padding so the .image-replaced works as expected
                 padding: 10px 0;
                 .image-replaced();


### PR DESCRIPTION
* Makes the  `.window .inner header` selector less broad, to avoid overriding modal content styles should the content also contain a `header` element.
* Adjusts the desktop `#modal .inner` width to fit the grid, and avoid slight overspill when resizing the browser window.
* Removed extraneous `transition: all` on modal `<header>`