### PR TITLE
Fix Bug 1139961 - Update universal download button to add link to App Store for iOS

### DIFF
--- a/bedrock/firefox/firefox_details.py
+++ b/bedrock/firefox/firefox_details.py
@@ -259,5 +259,11 @@ class FirefoxAndroid(ProductDetails):
         return self.store_url
 
 
+class FirefoxIOS:
+    def get_download_url(self):
+        return settings.APP_STORE_FIREFOX_LINK
+
+
 firefox_desktop = FirefoxDesktop()
 firefox_android = FirefoxAndroid()
+firefox_ios = FirefoxIOS()

--- a/bedrock/firefox/helpers.py
+++ b/bedrock/firefox/helpers.py
@@ -7,7 +7,7 @@ import jingo
 import jinja2
 
 from bedrock.firefox.models import FirefoxOSFeedLink
-from bedrock.firefox.firefox_details import firefox_desktop, firefox_android
+from bedrock.firefox.firefox_details import firefox_desktop, firefox_android, firefox_ios
 from bedrock.base.urlresolvers import reverse
 from lib.l10n_utils import get_locale
 
@@ -50,7 +50,7 @@ def download_firefox(ctx, channel='release', small=False, icon=True,
     :param channel: name of channel: 'release', 'beta' or 'alpha'.
     :param small: Display the small button if True.
     :param icon: Display the Fx icon on the button if True.
-    :param platform: Target platform: 'desktop', 'android' or 'all'.
+    :param platform: Target platform: 'desktop', 'android', 'ios' or 'all'.
     :param dom_id: Use this string as the id attr on the element.
     :param locale: The locale of the download. Default to locale of request.
     :param simple: Display button with text only if True. Will not display
@@ -69,6 +69,7 @@ def download_firefox(ctx, channel='release', small=False, icon=True,
     """
     show_desktop = platform in ['all', 'desktop']
     show_android = platform in ['all', 'android']
+    show_ios = platform in ['all', 'ios']
     alt_channel = '' if channel == 'release' else channel
     locale = locale or get_locale(ctx['request'])
     funnelcake_id = ctx.get('funnelcake_id', False)
@@ -125,8 +126,14 @@ def download_firefox(ctx, channel='release', small=False, icon=True,
                            'os_pretty': plat_os_pretty,
                            'download_link': download_link,
                            'download_link_direct': download_link_direct})
+
     if show_android:
         builds = android_builds(channel, builds)
+
+    if show_ios:
+        builds.append({'os': 'ios',
+                       'os_pretty': 'iOS',
+                       'download_link': firefox_ios.get_download_url()})
 
     # Get the native name for current locale
     langs = firefox_desktop.languages
@@ -135,14 +142,15 @@ def download_firefox(ctx, channel='release', small=False, icon=True,
     data = {
         'locale_name': locale_name,
         'version': version,
-        'product': 'firefox-android' if platform == 'android' else 'firefox',
+        'product': 'firefox-%s' % platform,
         'builds': builds,
         'id': dom_id,
         'small': small,
         'simple': simple,
         'channel': alt_channel,
-        'show_android': show_android,
         'show_desktop': show_desktop,
+        'show_android': show_android,
+        'show_ios': show_ios,
         'icon': icon,
         'check_old_fx': check_old_fx and simple,
     }
@@ -167,6 +175,7 @@ def firefox_url(platform, page, channel=None):
         {{ firefox_url('desktop', 'all', 'organizations') }}
         {{ firefox_url('desktop', 'sysreq', channel) }}
         {{ firefox_url('android', 'notes') }}
+        {{ firefox_url('ios', 'notes') }}
     """
 
     kwargs = {}

--- a/bedrock/firefox/templates/firefox/includes/download-button.html
+++ b/bedrock/firefox/templates/firefox/includes/download-button.html
@@ -15,8 +15,9 @@
 
 {% set download_class = 'download-button' %}
 {% set download_class = download_class ~ ' download-button-' ~ channel if channel else download_class %}
-{% set download_class = download_class ~ ' download-button-android' if not show_desktop else download_class %}
-{% set download_class = download_class ~ ' download-button-desktop' if not show_android else download_class %}
+{% set download_class = download_class ~ ' download-button-desktop' if show_desktop else download_class %}
+{% set download_class = download_class ~ ' download-button-android' if show_android else download_class %}
+{% set download_class = download_class ~ ' download-button-ios' if show_ios else download_class %}
 {% set download_class = download_class ~ ' download-button-small' if small else download_class %}
 {% set download_class = download_class ~ ' download-button-noicon' if not icon else download_class %}
 {% set download_class = download_class ~ ' download-button-simple' if simple else download_class %}
@@ -36,15 +37,6 @@
     <p class="linux-arm-download">
       {{ _('Please follow <a href="%(url)s">these instructions</a> to install Firefox.')|format(url='https://support.mozilla.org/kb/install-firefox-linux') }}
     </p>
-    {% if l10n_has_tag('ios_announce', 'firefox/new') %}
-      <p class="ios-download">
-        {{_('Firefox is coming soon to iOS! <a href="{url}">Sign up to learn more</a>.').format(url=url('newsletter.ios'))|safe }}
-      </p>
-    {% else %}
-      <p class="ios-download">
-        {{ _("Your system doesn't meet the <a href=\"%(url)s\">requirements</a> to run Firefox.")|format( url=firefox_url('desktop', 'sysreq', build)) }}
-      </p>
-    {% endif %}
   {% endif %}
   <ul class="download-list">
     {% for plat in builds %}
@@ -96,6 +88,13 @@
       <a href="https://support.mozilla.org/kb/will-firefox-work-my-mobile-device">{{ _('Supported Devices') }}</a>
       {%- if channel == 'alpha' %}<br>{% else %} |{% endif %}
       <a href="{{ firefox_url('android', 'notes', channel) }}">{{ _('What’s New') }}</a> |
+      <a href="{{ url('privacy.notices.firefox') }}">{{ _('Privacy') }}</a>
+    </small>
+  {% endif %}
+  {% if show_ios and waffle.switch('ios-active') %}
+    <small class="download-other os_ios">
+      <a href="https://support.mozilla.org/kb/will-firefox-work-my-mobile-device">{{ _('Supported Devices') }}</a> |
+      <a href="{{ firefox_url('ios', 'notes', channel) }}">{{ _('What’s New') }}</a> |
       <a href="{{ url('privacy.notices.firefox') }}">{{ _('Privacy') }}</a>
     </small>
   {% endif %}

--- a/bedrock/firefox/templates/firefox/new.html
+++ b/bedrock/firefox/templates/firefox/new.html
@@ -53,20 +53,17 @@
 
 <main role="main">
   <div class="version-message-container">
-    {% if l10n_has_tag('ios_announce') %}
-      <div id="version-message-ios" class="version-message">
-        {{_('Firefox is coming soon to iOS! <a href="{url}">Sign up to learn more</a>.').format(url=url('newsletter.ios'))|safe }}
-      </div>
-    {% else %}
-      <div id="version-message-ios" class="version-message">
-        {{_('Sorry, Firefox is currently unsupported by iOS devices.')}}
-      </div>
-    {% endif %}
     <div id="version-message-android-latest" class="version-message">
       {{_('Congrats! You’re using the latest version of Firefox.')}}
     </div>
     <div id="version-message-android-old" class="version-message">
       {{_('Looks like you’re using an older version of Firefox. Update on Google Play.')}}
+    </div>
+    <div id="version-message-ios-latest" class="version-message">
+      {{_('Congrats! You’re using the latest version of Firefox.')}}
+    </div>
+    <div id="version-message-ios-old" class="version-message">
+      {{_('Looks like you’re using an older version of Firefox. Update on the App Store.')}}
     </div>
     <div id="version-message-desktop-latest" class="version-message">
       {{_('Congrats! You’re using the latest version of Firefox.')}}
@@ -115,11 +112,11 @@
           <div class="desktop download-button-wrapper">
             {{ download_firefox(force_direct=true, simple=true) }}
           </div>
-          <div class="mobile download-button-wrapper">
-            {{ download_firefox(platform='android') }}
-          </div>
           <div class="android download-button-wrapper" data-upgrade-subtitle="{{_('Get it free on Google Play')}}">
             {{ download_firefox(platform='android', small=True, icon=False, dom_id='download-button-android') }}
+          </div>
+          <div class="ios download-button-wrapper" data-upgrade-subtitle="{{_('Get it free from the App Store')}}">
+            {{ download_firefox(platform='ios', small=True, icon=False, dom_id='download-button-ios') }}
           </div>
           <div class="desktop-latest-links-wrapper latest-links-wrapper">
             <ul>
@@ -127,6 +124,7 @@
               <li><a href="https://support.mozilla.org/products/firefox">{{_('Need help?')}}</a></li>
               {% if l10n_has_tag('mobile_links') %}
               <li class="hide-for-refresh"><a href="{{settings.GOOGLE_PLAY_FIREFOX_LINK }}">{{_('Get Firefox on your Android device')}}</a></li>
+              <li class="hide-for-refresh"><a href="{{settings.APP_STORE_FIREFOX_LINK }}">{{_('Get Firefox on your iOS device')}}</a></li>
               <li class="hide-for-refresh"><a href="{{ url('firefox.os.index') }}">{{_('Learn about Firefox OS')}}</a></li>
               {% endif %}
               <li><a href="{{ url('firefox.all') }}">{{_('Download a fresh copy')}}</a></li>
@@ -134,30 +132,18 @@
           </div>
           <div class="android-latest-links-wrapper latest-links-wrapper">
             <ul>
-              <li><a href="{{ url('firefox.android.index') }}">{{_('Learn more about Firefox for Mobile')}}</a></li>
+              <li><a href="{{ url('firefox.android.index') }}">{{_('Learn more about Firefox for Android')}}</a></li>
+            </ul>
+          </div>
+          <div class="ios-latest-links-wrapper latest-links-wrapper">
+            <ul>
+              <li><a href="{{ url('firefox.ios.index') }}">{{_('Learn more about Firefox for iOS')}}</a></li>
             </ul>
           </div>
           <div class="fxos-latest-links-wrapper latest-links-wrapper">
             <ul>
               <li><a href="{{ url('firefox.os.index') }}">{{_('Learn about Firefox OS')}}</a></li>
               <li><a href="{{ settings.GOOGLE_PLAY_FIREFOX_LINK }}">{{_('Discover all the ways to take Firefox on the go')}}</a></li>
-            </ul>
-          </div>
-          <div class="ios-links-wrapper latest-links-wrapper">
-            <ul>
-              {% if l10n_has_tag('ios_announce') %}
-                <li><a href="{{ url('newsletter.ios') }}">{{_('Learn more about Firefox on iOS')}}</a></li>
-              {% elif l10n_has_tag('mobile_links') %}
-                <li>
-                  <a href="{{ settings.GOOGLE_PLAY_FIREFOX_LINK }}">{{_('Get Firefox on your Android device')}}</a>
-                </li>
-                <li>
-                  <a href="{{ url('firefox.os.index') }}">{{_('Learn about Firefox OS')}}</a>
-                </li>
-                <li>
-                  <a href="https://support.mozilla.org/kb/is-firefox-available-iphone-or-ipad">{{_('Why don’t we offer an iOS version?')}}</a>
-                </li>
-              {% endif %}
             </ul>
           </div>
         </div>
@@ -234,6 +220,7 @@
   <meta itemprop="operatingSystem" content="Mac">
   <meta itemprop="operatingSystem" content="Linux">
   <meta itemprop="operatingSystem" content="Android">
+  <meta itemprop="operatingSystem" content="iOS">
 </div>
 
 <div itemscope itemtype="http://schema.org/Product">

--- a/bedrock/firefox/tests/test_base.py
+++ b/bedrock/firefox/tests/test_base.py
@@ -17,7 +17,7 @@ from nose.tools import eq_, ok_
 from pyquery import PyQuery as pq
 
 from bedrock.firefox import views as fx_views
-from bedrock.firefox.firefox_details import FirefoxDesktop, FirefoxAndroid
+from bedrock.firefox.firefox_details import FirefoxDesktop, FirefoxAndroid, FirefoxIOS
 from bedrock.firefox.utils import product_details
 from bedrock.mozorg.tests import TestCase
 
@@ -29,6 +29,7 @@ GOOD_PLATS = {'Windows': {}, 'OS X': {}, 'Linux': {}}
 with patch.object(settings, 'PROD_DETAILS_DIR', PROD_DETAILS_DIR):
     firefox_desktop = FirefoxDesktop()
     firefox_android = FirefoxAndroid()
+    firefox_ios = FirefoxIOS()
 
 
 class TestInstallerHelp(TestCase):

--- a/bedrock/firefox/tests/test_firefox_details.py
+++ b/bedrock/firefox/tests/test_firefox_details.py
@@ -11,7 +11,7 @@ from django.test.utils import override_settings
 from mock import patch
 from nose.tools import eq_, ok_
 
-from bedrock.firefox.firefox_details import FirefoxDesktop, FirefoxAndroid
+from bedrock.firefox.firefox_details import FirefoxDesktop, FirefoxAndroid, FirefoxIOS
 from bedrock.mozorg.tests import TestCase
 
 
@@ -22,6 +22,7 @@ PROD_DETAILS_DIR = os.path.join(TEST_DATA_DIR, 'product_details_json')
 with patch.object(settings, 'PROD_DETAILS_DIR', PROD_DETAILS_DIR):
     firefox_desktop = FirefoxDesktop()
     firefox_android = FirefoxAndroid()
+    firefox_ios = FirefoxIOS()
 
 
 GOOD_PLATS = {'Windows': {}, 'OS X': {}, 'Linux': {}}

--- a/bedrock/firefox/tests/test_helpers.py
+++ b/bedrock/firefox/tests/test_helpers.py
@@ -40,12 +40,13 @@ class TestDownloadButtons(TestCase):
     def check_dumb_button(self, doc):
         # Make sure 5 links are present
         links = doc('li a')
-        eq_(links.length, 5)
+        eq_(links.length, 6)
 
         self.check_desktop_links(links[:4])
 
-        # Check that last link is Android
+        # Check that the rest of the links are Android and iOS
         eq_(pq(links[4]).attr('href'), settings.GOOGLE_PLAY_FIREFOX_LINK)
+        eq_(pq(links[5]).attr('href'), settings.APP_STORE_FIREFOX_LINK)
 
     def test_button_force_direct(self):
         """
@@ -218,6 +219,17 @@ class TestDownloadButtons(TestCase):
         list = doc('.download-other .arch')
         eq_(list.length, 0)
 
+    def test_ios(self):
+        rf = RequestFactory()
+        get_request = rf.get('/fake')
+        get_request.locale = 'en-US'
+        doc = pq(render("{{ download_firefox(platform='ios') }}",
+                        {'request': get_request}))
+
+        list = doc('.download-list li')
+        eq_(list.length, 1)
+        eq_(pq(list[0]).attr('class'), 'os_ios')
+
     def test_check_old_firefox(self):
         """
         Make sure check_old_fx class is only applied if both check_old_fx=True
@@ -317,6 +329,13 @@ class TestFirefoxURL(TestCase):
             '/en-US/firefox/android/beta/notes/')
         eq_(self._render('android', 'notes', 'alpha'),
             '/en-US/firefox/android/aurora/notes/')
+
+    def test_ios_notes(self):
+        """Should return a reversed path for the iOS notes page"""
+        eq_(self._render('ios', 'notes'),
+            '/en-US/firefox/ios/notes/')
+        eq_(self._render('ios', 'notes', 'release'),
+            '/en-US/firefox/ios/notes/')
 
 
 @override_settings(FIREFOX_OS_FEED_LOCALES=['xx'])

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -691,6 +691,9 @@ GOOGLE_PLAY_FIREFOX_LINK = ('https://play.google.com/store/apps/details?' +
                             urlquote('utm_source=mozilla&utm_medium=Referral&'
                                         'utm_campaign=mozilla-org'))
 
+# Link to Firefox for iOS on the App Store
+APP_STORE_FIREFOX_LINK = 'http://appstore.com/firefox'
+
 # Use bedrock Gruntfile.js for live reload
 USE_GRUNT_LIVERELOAD = False
 

--- a/media/css/firefox/developer.less
+++ b/media/css/firefox/developer.less
@@ -90,9 +90,10 @@
     }
 }
 
-.android {
+.android,
+.ios {
     .download-button {
-        // hide download button on Android until download button is smarter
+        // hide download button on Android and iOS until download button is smarter
         display: none;
     }
     .intro h2 {

--- a/media/css/firefox/new.less
+++ b/media/css/firefox/new.less
@@ -106,33 +106,6 @@ html.oldwin {
     }
 }
 
-/* iOS */
-html.ios {
-    .version-message-container {
-        display: block;
-    }
-
-    #version-message-ios {
-        display: inline;
-
-        &:before {
-            background-image: url(/media/img/firefox/new/icon-mobile.svg);
-        }
-    }
-
-    .desktop.download-button-wrapper {
-        display: none;
-    }
-
-    .ios-links-wrapper {
-        display: block;
-        padding-top: 26px;
-    }
-    .desktop-latest-links-wrapper {
-        display: none;
-    }
-}
-
 /* desktop version (with Firefox) */
 html.firefox-latest {
     .version-message-container {
@@ -291,6 +264,67 @@ html.android {
     }
 }
 
+/* iOS version message (with Firefox) */
+html.ios {
+    &.firefox-latest {
+        .version-message-container {
+            display: block;
+        }
+
+        #version-message-ios-latest {
+            display: inline;
+
+            &:before {
+                background-image: url(/media/img/firefox/new/icon-check.svg);
+            }
+        }
+
+        #version-message-desktop-latest {
+            display: none;
+        }
+
+        /* hide download button */
+       .ios.download-button-wrapper {
+            display: none;
+        }
+
+        /* show helpful links */
+        .ios-latest-links-wrapper {
+            display: block;
+            padding-top: 38px;
+        }
+        .desktop-latest-links-wrapper {
+            display: none;
+        }
+    }
+
+    &.firefox-old {
+        .version-message-container {
+            display: block;
+        }
+
+        #version-message-ios-old {
+            display: inline;
+        }
+
+        #version-message-desktop-old {
+            display: none;
+        }
+    }
+
+    .download-button-wrapper {
+        display: none;
+        width: 250px;
+        margin: 0 auto;
+        text-align: center;
+
+        &.ios {
+            display: block;
+            margin-top: 22px;
+        }
+    }
+}
+
 /* FxOS */
 html.fxos {
     // hide conditional messaging for firefox users,
@@ -360,7 +394,8 @@ html[lang|="en"] #main-feature h1.large span:first-child {
     width: 100%;
 }
 
-.download-button-wrapper.android {
+.download-button-wrapper.android,
+.download-button-wrapper.ios {
     display: none;
 }
 
@@ -444,15 +479,9 @@ html[lang|="en"] #main-feature h1.large span:first-child {
     }
 }
 
-.mobile {
-    display: none;
-}
-
-// android view
-.android {
-    .mobile {
-        display: none;
-    }
+// Android and iOS view
+.android,
+.ios {
     .desktop {
         display: block;
     }
@@ -687,10 +716,8 @@ noscript {
         }
     }
 
-    html.android {
-        .mobile {
-            display: none;
-        }
+    html.android,
+    html.ios {
         .desktop {
             display: none;
         }
@@ -699,10 +726,11 @@ noscript {
         .theater {
             height: 200px;
         }
+    }
 
-        &.firefox-latest .android-latest-links-wrapper {
-            padding: 0;
-        }
+    html.android.firefox-latest .android-latest-links-wrapper,
+    html.ios.firefox-latest .ios-latest-links-wrapper, {
+        padding: 0;
     }
 
     html.fxos {

--- a/media/css/firefox/sync.less
+++ b/media/css/firefox/sync.less
@@ -348,11 +348,6 @@
     display: block;
 }
 
-// also add a line break in .ios message
-.ios-download {
-    text-align: center;
-}
-
 .state-fx-android {
     .cta {
         h3,

--- a/media/css/mozorg/home/home-promo.less
+++ b/media/css/mozorg/home/home-promo.less
@@ -581,7 +581,6 @@ html[lang|="en"] {
             }
         }
 
-        .ios-download,
         .linux-arm-download,
         .unsupported-download {
             color: #4c781c;

--- a/media/css/sandstone/buttons.less
+++ b/media/css/sandstone/buttons.less
@@ -299,7 +299,6 @@ html[lang^='en'] {
 
 // Product download buttons
 
-.download-button .ios-download,
 .download-button .linux-arm-download,
 .download-button .unrecognized-download,
 .download-button .unsupported-download {
@@ -583,18 +582,19 @@ html[lang^='en'] {
 // Uncomment this to enable the win64 download buttons:
 // .win7up.x86.x64 .download-button-aurora .os_win,
 .android .download-button-desktop,
+.ios .download-button-desktop,
 .windows.arm .download-button .os_win,
 .linux.arm .download-button .os_linux,
 .linux.x86.x64 .download-list .os_linux,
 .download-button .os_win,
 .download-button .os_osx,
 .download-button .os_android,
+.download-button .os_ios,
 .no-js .download-list,
 .other .download-list {
     display: none !important;
 }
 
-.ios .download-button .ios-download,
 // Uncomment this to enable the win64 download buttons:
 // .win7up.x86.x64 .download-button-aurora .os_win64,
 .linux .download-button .os_linux,
@@ -602,11 +602,17 @@ html[lang^='en'] {
 .windows .download-button .os_win,
 .osx .download-button .os_osx,
 .android .download-button .os_android,
+.ios .download-button .os_ios,
 .download-button-android .os_android,
+.download-button-ios .os_ios,
 .android .download-button-desktop .download-list,
+.ios .download-button-desktop .download-list,
 .android .download-button-desktop small.os_win,
+.ios .download-button-desktop small.os_win,
 .no-js .download-button-android .download-list,
+.no-js .download-button-ios .download-list,
 .other .download-button-android .download-list,
+.other .download-button-ios .download-list,
 .other .download-button small.os_win {
     display: block !important;
 }
@@ -623,7 +629,9 @@ html[lang^='en'] {
 
 .download-button small.download-other,
 .other .download-button-android small.download-other,
-.android .download-button-desktop small.download-other {
+.other .download-button-ios small.download-other,
+.android .download-button-desktop small.download-other,
+.ios .download-button-desktop small.download-other {
     .open-sans;
     display: block;
     .font-size(11px);
@@ -639,12 +647,14 @@ html[lang^='en'] {
 
 .no-js .download-button small.download-other,
 .other .download-button small.download-other,
-.android .download-button-desktop small.download-other {
+.android .download-button-desktop small.download-other,
+.ios .download-button-desktop small.download-other {
     text-align: left;
 }
 
 .other .download-button,
-.android .download-button-desktop {
+.android .download-button-desktop,
+.ios .download-button-desktop {
     .unrecognized-download {
         display: block;
     }
@@ -674,17 +684,12 @@ html[lang^='en'] {
 
 }
 
-// ios tweaks
-
-.ios-download a:before {
-    content: '\A';
-    white-space: pre;
-}
-
 // Mobile download buttons
 
 .download-button .download-list .os_android,
-.download-button-android {
+.download-button .download-list .os_ios,
+.download-button-android,
+.download-button-ios {
     .download-link {
        .download-title {
             padding-top: 0;
@@ -708,7 +713,9 @@ html[lang^='en'] {
 }
 
 .download-button.download-button-small .download-list .os_android,
-.download-button.download-button-small.download-button-android {
+.download-button.download-button-small .download-list .os_ios,
+.download-button.download-button-small.download-button-android,
+.download-button.download-button-small.download-button-ios {
     .download-link {
        .download-title {
             padding-top: 0;


### PR DESCRIPTION
WIP. Do not merge.

* We don't know the download URL yet
* We don't know the versioning scheme yet
* We don't know if Tim Cook would love Firefox yet
* The tests are still failing because the iOS release notes are not ready yet