### PR TITLE
Fix bug 1156822 - update contact info in participation guidelines

### DIFF
--- a/bedrock/mozorg/templates/mozorg/about/governance/policies/participation.html
+++ b/bedrock/mozorg/templates/mozorg/about/governance/policies/participation.html
@@ -10,7 +10,7 @@
 
 {% block article %}
 <h1 class="title-shadow-box">{{_('Mozilla Community Participation Guidelines')}}</h1>
-<h4>{{_('Version 1.0. Last updated: January 7,2013')}}</h4>
+<h4>{{_('Version 1.0. Last updated: May 5, 2015')}}</h4>
 
 <h2>{{_('Community Participation Guidelines')}}</h2>
 
@@ -37,9 +37,7 @@
         </ul>
     </li>
     <li><h4>{{_('Raising Issues Related to Inclusion and Diversity')}}</h4>
-        <p>{{_('If you believe you’re experiencing practices which don’t meet the Inclusion and Diversity policy, please contact Dino Anderson who leads our Inclusion and Diversity Program - dino@mozilla.com . Dino can provide a range of resources, from a private consultation to other community resources, and of course cover the legal aspects the Mozilla organization should address.')}}</p>
-
-        <p>{{_('In addition, Dino Anderson is creating educational resources that teach Mozillians skills and tactics on how to respond to questions and issues. Leadership training for those wanting to facilitate inclusion and diversity issues will also be offered. This leadership group, called Inclusion and Diversity Champions, will be found on mozillians.org at the start of 2015. This group may serve as either an informal channel for getting started in raising an issue, or a formal channel to request specific services (i.e., education, mentoring, counseling, conflict resolution). The additional people are to provide a way to get one’s ideas out, see how it feels to raise them, see what kinds of questions or conversations might result, before going to Dino or Mitchell.')}}</p>
+        <p>{{_('If you believe you’re experiencing practices which don’t meet the Inclusion and Diversity policy, please contact Allison Banks who leads our Inclusion and Diversity Program - abanks@mozilla.com. Allison can provide a range of resources, from a private consultation to other community resources, and of course cover the legal aspects the Mozilla organization should address.')}}</p>
 
         <p>{{_('Intentional efforts to exclude people from Mozilla activities are not acceptable and will be dealt with appropriately. It’s hard to imagine how one might unintentionally do this, but if this happens we will figure out how to make it not happen again. I suspect there will be some questions about when and if something moves from a private to a public matter, which we’ll have to sort out.')}}</p>
     </li>


### PR DESCRIPTION
Also removed some outdated content (doesn't impact the overall guidelines)

@flodolo: This page doesn't seem to be localized so these content changes shouldn't need an l10n flag. Can you verify?