### PR TITLE
Fix syntax and deprecation warnings in tests

### DIFF
--- a/bedrock/base/tests/test_accepted_locales.py
+++ b/bedrock/base/tests/test_accepted_locales.py
@@ -65,7 +65,7 @@ class AcceptedLocalesTest(test_utils.TestCase):
         """
         settings.DEV = True
         langs = get_dev_languages()
-        assert (langs == ['en-US', 'fr'] or langs == ['fr', 'en-US'],
+        assert langs == ['en-US', 'fr'] or langs == ['fr', 'en-US'], (
                 'DEV_LANGUAGES do not correspond to the contents of locale/.')
 
     def test_dev_languages(self):
@@ -89,6 +89,6 @@ class AcceptedLocalesTest(test_utils.TestCase):
 
         """
         settings.DEV = False
-        assert (settings.LANGUAGE_URL_MAP == {'en-us': 'en-US'},
+        assert settings.LANGUAGE_URL_MAP == {'en-us': 'en-US'}, (
                 'DEV is False, but PROD_LANGUAGES are not used to define the '
                 'allowed locales.')

--- a/bedrock/mozorg/tests/test_views.py
+++ b/bedrock/mozorg/tests/test_views.py
@@ -12,7 +12,6 @@ from django.db.utils import DatabaseError
 from django.http.response import Http404
 from django.test.client import RequestFactory
 from django.test.utils import override_settings
-from django.utils import simplejson
 
 from captcha.fields import ReCaptchaField
 from bedrock.base.urlresolvers import reverse
@@ -709,7 +708,7 @@ class TestProcessPartnershipForm(TestCase):
                                                       self.view)
 
             # decode JSON response
-            resp_data = simplejson.loads(response.content)
+            resp_data = json.loads(response.content)
 
             self.assertEqual(resp_data['msg'], 'ok')
             self.assertEqual(response.status_code, 200)
@@ -724,7 +723,7 @@ class TestProcessPartnershipForm(TestCase):
                                                       self.view)
 
             # decode JSON response
-            resp_data = simplejson.loads(response.content)
+            resp_data = json.loads(response.content)
 
             self.assertEqual(resp_data['msg'], 'Form invalid')
             self.assertEqual(response.status_code, 400)


### PR DESCRIPTION
Moved parens to eliminate "always true" assertions
Removed deprecated simplejson module