### PR TITLE
Bug 1164300 - Remove/Update Affiliates Links on moz.org properties, part 1

### DIFF
--- a/bedrock/base/templates/includes/site-footer.html
+++ b/bedrock/base/templates/includes/site-footer.html
@@ -15,7 +15,7 @@
               <li><a href="{{ url('mozorg.contact.spaces.spaces-landing') }}">{{ _('Contact Us') }}</a></li>
               <li class="wrap"><a href="{{ url('mozorg.partnerships') }}">{{ _('Partner with Us' ) }}</a></li>
               <li class="clear"><a href="{{ donate_url('mozillaorg_footer') }}" class="donate">{{ _('Donate') }}</a></li>
-              <li class="wrap"><a href="https://affiliates.mozilla.org/">{{ _('Firefox Affiliates') }}</a></li>
+              <li class="wrap"><a href="{{ url('mozorg.contribute.friends') }}">{{ _('Firefox Friends') }}</a></li>
               <li class="clear"><a href="https://wiki.mozilla.org/Webdev/GetInvolved/mozilla.org">{{ _('Contribute to this site') }}</a></li>
             </ul>
             <ul class="links-legal">

--- a/bedrock/mozorg/templates/mozorg/contribute/studentambassadors/landing.html
+++ b/bedrock/mozorg/templates/mozorg/contribute/studentambassadors/landing.html
@@ -51,7 +51,7 @@
         <section id="sec-what">
           <h2>{{ _('What We Do') }}</h2>
           <ul>
-            <li>{{ _('<a href="%s">Promote Firefox</a> for Desktop and Android')|format('https://affiliates.mozilla.org/') }}</li>
+            <li>{{ _('<a href="%s">Promote Firefox</a> for Desktop and Android')|format(url('mozorg.contribute.friends')) }}</li>
             <li>{{ _('Support the successful launch of <a href="%s">Firefox&nbsp;OS</a> in communities (and campuses!) around the world')|format(url('firefox.os.index')) }}</li>
             <li>{{ _('Educate others about Mozilla’s mission') }}</li>
             <li>{{ _('Grow the Mozilla Community') }}</li>

--- a/bedrock/mozorg/templates/mozorg/plugincheck.html
+++ b/bedrock/mozorg/templates/mozorg/plugincheck.html
@@ -198,8 +198,6 @@
         <li>{{_('Choose Add-ons.')}}</li>
         <li>{{_('Click the plugins tab.')}}</li>
       </ol>
-      <h3>{{ _('Want to spread the word?') }}</h3>
-      <p>{{ _('Help your friends stay safe online! Visit <a href="%(url)s">Firefox Affiliates</a> to get a plugin check badge for your site.') |format(url="https://affiliates.mozilla.org") }}</p>
       <h3>{{_('How do I disable a plugin?')}}</h3>
       <p>{{_('In Firefox:')}}</p>
       <ol>


### PR DESCRIPTION
The rest of the links may be updated later once the legal team decides what should they do.

"Firefox Friends" won't probably be localized so l10n shouldn't be a blocker here.