### PR TITLE
Fix Bug 1164424 - Firefox Hello: 'TRY HELLO NOW' button is displayed when using FF38.0esr

### DIFF
--- a/bedrock/firefox/templates/firefox/hello/index.html
+++ b/bedrock/firefox/templates/firefox/hello/index.html
@@ -48,6 +48,10 @@ set share_urls = {
   {% endcall %}
 {% endblock %}
 
+{% block string_data %}
+data-try-now="{{ _('Try it now') }}"
+{% endblock %}
+
 {% block tabzilla_css %}{% endblock %}
 {% block tabzilla_js %}{% endblock %}
 
@@ -218,6 +222,7 @@ set share_urls = {
     <div class="container">
       <div class="ctacopy-wrapper">
         <h2 class="dltry-copy heading-secondary" id="ctacopy-nonfx">{{ _('Get Firefox and start your first conversation') }}</h2>
+        <h2 class="dltry-copy heading-secondary" id="ctacopy-esrfx">{{ _('You need a different version of Firefox to use Hello.') }}</h2>
         <h2 class="dltry-copy heading-secondary" id="ctacopy-oldfx">{{ _('Update your Firefox to start using Hello') }}</h2>
         <h2 class="dltry-copy heading-secondary" id="ctacopy-hellofx">{{ _('Start your first conversation today') }}</h2>
       </div>

--- a/media/css/firefox/hello/index.less
+++ b/media/css/firefox/hello/index.less
@@ -1203,6 +1203,7 @@ main {
 }
 
 // default to showing only non-fx copy/cta
+#ctacopy-esrfx,
 #ctacopy-oldfx,
 #ctacopy-ios,
 #ctacopy-hellofx {

--- a/media/js/firefox/hello/index.js
+++ b/media/js/firefox/hello/index.js
@@ -118,13 +118,46 @@
             showFxFooterMessaging();
         }
         // Hello exists in desktop version 35 and up
-        else if (w.getFirefoxMasterVersion() >= 35) {
+        else if (w.getFirefoxMasterVersion() >= 35 && 'Promise' in window) {
             showFxFooterMessaging();
 
-            // see if Hello is an available target in toolbar/overflow/customize menu
-            Mozilla.UITour.getConfiguration('availableTargets', function(config) {
+            Promise.all([
+                // check for the browser channel info
+                new Promise(function(resolve) {
+                    Mozilla.UITour.getConfiguration('appinfo', function(config) {
+                        resolve(config.defaultUpdateChannel);
+                    });
+                }),
+                // see if Hello is an available target in toolbar/overflow/customize menu
+                new Promise(function(resolve) {
+                    Mozilla.UITour.getConfiguration('availableTargets', function(config) {
+                        resolve(config.targets);
+                    });
+                }),
+            ]).then(function(results) {
+                var channel = results[0];
+                var targets = results[1];
+
+                // Because Hello is disabled on Firefox 38 ESR, we encourage ESR
+                // users to download non-ESR Firefox to try Hello
+                if (channel === 'esr') {
+                    // Change the copy
+                    $('#ctacopy-hellofx').hide();
+                    $('#ctacopy-esrfx').show();
+
+                    // Instead of the "Try Hellow now" button, show the download
+                    // button and change the label to "Try it now"
+                    $('#try-hello-footer').removeClass('active');
+                    $('#download-fx').show();
+                    $('.download-subtitle').text(window.trans('try-now'));
+
+                    addLinkEvent('.download-link', 'ClickDownload');
+
+                    return;
+                }
+
                 // 'loop' is the snazzy internal code name for Hello
-                if (config.targets && config.targets.indexOf('loop') > -1) {
+                if (targets && targets.indexOf('loop') > -1) {
                     // show the intro try hello button
                     $('#try-hello-intro').addClass('active');
 


### PR DESCRIPTION
Tested locally with the `browser.uitour.testingOrigins` pref enabled on 38 ESR .

Because this code is only run by Firefox 35+, it might be safe to use `Promise` here, rather than adding another nested callback.

L10n note: There is one new string: “Sorry, Hello is not yet available in Firefox ESR.” Another one, “Get Firefox” is in firefox/desktop/tips.lang so it’s not new. Given the number of Firefox 38 ESR users who will see this message is very small at this time, I’m not sure if we have to wait for l10n. @flodolo how do you think?