### PR TITLE
Fix bug 1152344: Use django-pylibmc for default cache backend.

### DIFF
--- a/bedrock/settings/__init__.py
+++ b/bedrock/settings/__init__.py
@@ -45,6 +45,13 @@ if len(sys.argv) > 1 and sys.argv[1] == 'test':
     # test to look at later.
     TEMPLATE_DEBUG = True
 
+if CACHES['default']['BACKEND'] == 'django_pylibmc.memcached.PyLibMCCache':
+    CACHES['default']['BINARY'] = True
+    CACHES['default']['OPTIONS'] = {  # Maps to pylibmc "behaviors"
+        'tcp_nodelay': True,
+        'ketama': True,
+    }
+
 # cache for lang files
 CACHES['l10n'] = {
     'BACKEND': 'lib.l10n_utils.cache.L10nCache',

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -48,6 +48,10 @@ CACHES = {
     }
 }
 
+# in case django-pylibmc is in use
+PYLIBMC_MIN_COMPRESS_LEN = 150 * 1024
+PYLIBMC_COMPRESS_LEVEL = 1  # zlib.Z_BEST_SPEED
+
 # Site ID is used by Django's Sites framework.
 SITE_ID = 1
 

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -11,3 +11,10 @@ maxminddb==1.1.1
 
 # sha256: _d1HqNBI4MX0Lu5RGoqvNYkcmW1slZVTx77Is6x0s8s
 newrelic==2.50.0.39
+
+# sha256: VZxCRyjkBCDajJmLE8PE8IYbR1JpoKh2-xcY__J20QY
+# sha256: YhN9U7WsovukJHRLobsw6SoRXZqGgcvmpkEdskGx0a0
+django-pylibmc==0.6.0
+
+# sha256: MOGaBuZQ_eMfQKYtsKPaN6HK2WFuHP0EuOJI-0vV9KE
+pylibmc==1.4.2


### PR DESCRIPTION
This will not change anything immediately. We still need
to change the local settings in the environments after
deployment of the changes.