### PR TITLE
[fix bug 1167169] Consistency for .hidden and .visualy-hidden classes

### DIFF
--- a/media/css/sandstone/oldIE.less
+++ b/media/css/sandstone/oldIE.less
@@ -680,3 +680,10 @@ img {
     overflow: hidden;
 }
 
+.visually-hidden {
+    .visually-hidden();
+}
+
+.hidden {
+    .hidden();
+}

--- a/media/css/sandstone/sandstone.less
+++ b/media/css/sandstone/sandstone.less
@@ -799,6 +799,10 @@ nav.menu-bar {
     display: none;
 }
 
+.visually-hidden {
+    .visually-hidden();
+}
+
 .hidden {
     .hidden();
 }


### PR DESCRIPTION
Just some minor housekeeping for our base styles to be consistent with `sandstone-resp.less`