### PR TITLE
[fix bug 1164371] Broken links on /firefox/os/ 'Get a phone' CTA

### DIFF
--- a/bedrock/firefox/templates/firefox/os/_get_device.html
+++ b/bedrock/firefox/templates/firefox/os/_get_device.html
@@ -163,8 +163,8 @@
         <div class="provider" data-country="me">
           <h3>{{_('Montenegro')}}</h3>
           <ul>
-            <li><a class="telenor" href="http://www.telenor.me/sr/Privatni-korisnici/Uredjaji/Mobilni-telefoni/Alcatel/OT_Fire">Alcatel One Touch Fire</a></li>
-            <li><a class="t-mobile" href="http://www.telekom.me/product-details-updated.nspx?phoneid=673&amp;userType=2">Alcatel One Touch Fire C</a></li>
+            <li><a class="telenor" href="http://www.telenor.me/cg/Privatni-korisnici/Uredjaji/Mobilni-telefoni/Alcatel/OT_Fire">Alcatel One Touch Fire</a></li>
+            <li><a class="t-mobile" href="http://telekom.me/alcatel-firefox-c.nspx">Alcatel One Touch Fire C</a></li>
           </ul>
         </div>
         <div class="provider" data-country="mg">
@@ -190,12 +190,6 @@
           <ul>
             <li><a class="movistar" href="https://www.movistar.com.mx/catalogo">Movistar</a></li>
             <li><a class="telcel" href="http://www.telcel.com/portal/equipos/begin.do?idEquipo=3618">Telcel</a></li>
-          </ul>
-        </div>
-        <div class="provider" data-country="ni">
-          <h3>{{ _('Nicaragua') }}</h3>
-          <ul>
-            <li><a class="movistar" href="http://www.movistar.com.ni/Personas/Equipos/DetalleEquipo.aspx?Model=361">ZTE Open II</a></li>
           </ul>
         </div>
         <div class="provider" data-country="pa">

--- a/bedrock/firefox/templates/firefox/os/devices.html
+++ b/bedrock/firefox/templates/firefox/os/devices.html
@@ -92,7 +92,6 @@
               <option value="mx">{{ _('Mexico') }}</option>
               <option value="me">{{ _('Montenegro') }}</option>
               <option value="mm">{{ _('Myanmar') }}</option>
-              <option value="ni">{{ _('Nicaragua') }}</option>
               <option value="pa">{{ _('Panama') }}</option>
               <option value="pe">{{ _('Peru') }}</option>
               <option value="ph">{{ _('Philippines') }}</option>
@@ -1138,7 +1137,6 @@
                     <li>{{ _('Argentina') }}</li>
                     <li>{{ _('Colombia') }}</li>
                     <li>{{ _('Guatemala') }}</li>
-                    <li>{{ _('Nicaragua') }}</li>
                     <li>{{ _('Panama') }}</li>
                     <li>{{ _('Peru') }}</li>
                     <li>{{ _('Uruguay') }}</li>

--- a/media/js/firefox/os/partner_data.js
+++ b/media/js/firefox/os/partner_data.js
@@ -110,7 +110,7 @@ if (typeof Mozilla == 'undefined') {
         'zte_open2': {
             'type': 'smartphone',
             'display': 'ZTE Open II',
-            'countries': ['ar', 'co', 'gt', 'ni', 'pa', 'pe', 'uy']
+            'countries': ['ar', 'co', 'gt', 'pa', 'pe', 'uy']
         }
     };
 })(window.jQuery);


### PR DESCRIPTION
* Updates links for Montenegro
* Remove purchase link for Nicaragua