### PR TITLE
[fix bug 1168744] Remove jQuery animations from mozilla modal

### DIFF
--- a/media/css/base/mozid-modal.less
+++ b/media/css/base/mozid-modal.less
@@ -20,6 +20,7 @@ html.noscroll body {
     left: 0;
     z-index: 9999999;
     overflow: auto;
+    .animation(sand-fade-in 0.3s ease-in 0s 1 normal both);
 
     .window {
         padding: 20px;

--- a/media/css/base/mozilla-modal.less
+++ b/media/css/base/mozilla-modal.less
@@ -20,6 +20,7 @@ html.noscroll body {
     left: 0;
     z-index: 9999999;
     overflow: auto;
+    .animation(sand-fade-in 0.3s ease-in 0s 1 normal both);
 
     .window {
         padding: 20px;

--- a/media/js/base/mozilla-modal.js
+++ b/media/js/base/mozilla-modal.js
@@ -78,10 +78,7 @@ Mozilla.Modal = (function(w, $) {
             }
         });
 
-        $modal.hide();
-        $modal.fadeIn('fast', function() {
-            $modal.focus();
-        });
+        $modal.focus();
 
         // close with escape key
         $d.on('keyup.' + evtNamespace, function(e) {
@@ -115,16 +112,14 @@ Mozilla.Modal = (function(w, $) {
             e.preventDefault();
         }
 
-        $('#modal').fadeOut('fast', function() {
-            $contentParent.append($content);
-            $(this).remove();
+        $contentParent.append($content);
+        $('#modal').remove();
 
-            // allow page to scroll again
-            $html.removeClass('noscroll');
+        // allow page to scroll again
+        $html.removeClass('noscroll');
 
-            // restore focus to element that opened the modal
-            $('.modal-origin').focus().removeClass('modal-origin');
-        });
+        // restore focus to element that opened the modal
+        $('.modal-origin').focus().removeClass('modal-origin');
 
         open = false;
         $modal = null;


### PR DESCRIPTION
@jpetto r?

A small but worthwhile perf improvement I think. Thoughts? 

I noticed Chrome shows a fair amount of jank opening the modal on /firefox/hello/, and exhibits the same perf on other pages where the new mozid modal styling is going to be used.