### PR TITLE
Fix 1169026: Update SMS message IDs for widget

### DIFF
--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -102,7 +102,9 @@ INSTALLER_CHANNElS = [
 ]
 
 SMS_MESSAGES = {
-    'android': 'SMS_Android',
+    'android': 'android',
+    'ios': 'ios',
+    'all': 'mobile',
 }
 
 EMAIL_MESSAGES = {
@@ -156,7 +158,7 @@ def sms_send(request):
         if form.is_valid():
             try:
                 basket.send_sms(form.cleaned_data['number'],
-                                SMS_MESSAGES['android'],
+                                'SMS_Android',
                                 form.cleaned_data['optin'])
             except basket.BasketException:
                 error = error_msg


### PR DESCRIPTION
Leaves old sms view to send the old message ID.

Have to wait for the basket changes to go live to merge this.