### PR TITLE
Fix Bug 1164300 - Remove/Update Affiliates Links on moz.org properties

### DIFF
--- a/bedrock/foundation/templates/foundation/trademarks/faq.html
+++ b/bedrock/foundation/templates/foundation/trademarks/faq.html
@@ -82,8 +82,8 @@
       {% endtrans %}</dd>
 
     <dt>{% trans %}Can I put Firefox banners on my website? Can I link to you?{% endtrans %}</dt>
-    <dd>{% trans styleguide=url('styleguide.home'), affiliates="https://affiliates.mozilla.org/" %}
-    Thanks for your support :-) Of course you may. Our <a href="{{ affiliates }}">Firefox Affiliates</a> program is a centralized hub for getting and sharing Firefox and Mozilla download buttons. Our <a href="{{ styleguide }}">style guide</a> has any additional assets you may need: {% endtrans %}<br />
+    <dd>{% trans styleguide=url('styleguide.home') %}
+    Thanks for your support :-) Of course you may. Our <a href="{{ styleguide }}">style guide</a> has additional assets you may need: {% endtrans %}<br />
       <ul>
         <li>
           <a href="{{ url('styleguide.identity.firefox-branding') }}">{{ _('Firefox logo') }}</a>

--- a/bedrock/foundation/templates/foundation/trademarks/policy.html
+++ b/bedrock/foundation/templates/foundation/trademarks/policy.html
@@ -105,44 +105,6 @@
 
   <p>{% trans %}Mozilla products are designed to be extended, and we recognize that community members writing extensions need some way to identify the Mozilla product to which their extensions pertain. Our main concern about extensions is that consumers not be confused as to whether they are official (meaning approved by Mozilla) or not. To address that concern, we request that extension names not include, in whole or in part, the words "Mozilla", "Firefox", or "Thunderbird" in a way that suggests a connection between Mozilla and the extension (e.g., "Frobnicator for Firefox," would be acceptable, but "Firefox Frobnicator" would not).{% endtrans %}</p>
 
-  <h2>{{ _('Linking') }}</h2>
-
-  <p>{% trans %}We invite you to link to Mozilla's website(s) for the purpose of allowing your visitors to download Firefox and Thunderbird, by using the banners and buttons we provide, subject to the restrictions below.{% endtrans %}</p>
-
-  <ul>
-    <li><a href="https://affiliates.mozilla.org">{% trans %}Firefox Banners and Buttons{% endtrans %}</a></li>
-  </ul>
-
-  <p>{{ _('This use is allowed as long as you:') }}</p>
-
-  <ul>
-  <li>{% trans %}Follow the Mozilla Trademark Policy.{% endtrans %}</li>
-
-  <li>{% trans com="/" %}
-      Point the destination URL to the <a href="{{ com }}">official Mozilla product website</a>. You may not use a Mozilla banner or button to point to your own web site and/or to download a modified version of Firefox or Thunderbird.{% endtrans %}</li>
-
-  <li>{% trans %}Don't alter any of the Mozilla Marks including our logos.{% endtrans %}</li>
-
-  <li>{% trans %}Don't do anything that might confuse visitors to your website into mistaking the origin of software being downloaded&mdash;whether the software is Mozilla's or yours.{% endtrans %}</li>
-  </ul>
-
-  <p>{% trans %}You may customize the buttons in the following ways:{% endtrans %}</p>
-
-  <ul>
-
-  <li>{% trans %}Modify the background color of the button or banner.{% endtrans %}</li>
-
-  <li>{% trans %}Localize the text (but not the Mozilla Marks).{% endtrans %}</li>
-
-  <li>{% trans %}Change the size of the button or banner.{% endtrans %}</li>
-  </ul>
-
-  <p>{% trans %}Remember the Mozilla Marks must not be altered in any way. If your use of these banners or buttons violates our Trademark Policy, your use is unauthorized.{% endtrans %}</p>
-
-  <p>{% trans %}<span style="text-decoration: underline;">Best Viewed With Buttons</span>. Also, please remember that we disapprove of and do not provide "Best Viewed With" buttons, when used in connection with the Firefox Internet browser.   We believe the web is best viewed with any standards-compliant browser and do not want to promote browser specific sites.  However, if you must use a statement, please use something like "Try our site using the Firefox web browser" or "We recommend using Firefox web browser or other standards-compliant browsers."{% endtrans %}</p>
-
-  <p>{% trans %}<span style="text-decoration: underline;">Site Icons (favicons)</span>. If you plan to use a Mozilla trademark as a site icon, you need to request permission.{% endtrans %}</p>
-
   <h2>{{ _('Domain Names') }}</h2>
 
   <p>{% trans %}If you want to include all or part of a Mozilla trademark in a domain name, you have to receive written permission from Mozilla. People naturally associate domain names with organizations whose names sound similar. Almost any use of a Mozilla trademark in a domain name is likely to confuse consumers, thus running afoul of the overarching requirement that any use of a Mozilla trademark be non-confusing. If you would like to build a Mozilla, Firefox Internet browser, or Thunderbird e-mail client promotional site for your region, we encourage you to join an existing official localization project.{% endtrans %}</p>

--- a/bedrock/legal/templates/legal/fraud-report.html
+++ b/bedrock/legal/templates/legal/fraud-report.html
@@ -71,13 +71,13 @@
       </ol>
 
       <p>
-      {% trans url1=url('foundation.trademarks.faq'), url2='https://affiliates.mozilla.org/',
+      {% trans url1=url('foundation.trademarks.faq'), url2=url('mozorg.contribute.friends'),
         url3=url('styleguide.home') %}
         While the uses of our trademarks described above are not allowed,
         there are lots of ways our community members can use our
         trademarks without requesting permission. For more information,
         please review our <a href="{{ url1 }}">Trademark FAQs</a> or
-        visit <a href="{{ url2 }}">Firefox Affiliates</a>. Also review the
+        visit <a href="{{ url2 }}">Firefox Friends</a>. Also review the
         <a href="{{ url3 }}">Mozilla Style Guide</a>.
       {% endtrans %}
       </p>


### PR DESCRIPTION
As per the legal team’s directions. Those pages are not localized.