### PR TITLE
[fix bug 1171652] /firefox/tour/ should still show the older firstrun on-boarding tour

### DIFF
--- a/bedrock/firefox/tests/test_base.py
+++ b/bedrock/firefox/tests/test_base.py
@@ -494,14 +494,6 @@ class TestTourView(TestCase):
         template = render_mock.call_args[0][1]
         eq_(template, ['firefox/australis/fx36/help-menu-36-tour.html'])
 
-    @override_settings(DEV=True)
-    def test_fx_search_tour_38_0_5(self, render_mock):
-        """Should use fx38.0.5 firstrun template for 38.0.5"""
-        req = self.rf.get('/en-US/firefox/tour/')
-        self.view(req, version='38.0.5')
-        template = render_mock.call_args[0][1]
-        eq_(template, ['firefox/australis/fx38_0_5/firstrun.html'])
-
     @override_settings(DEV=False)
     def test_fx_australis_secure_redirect(self, render_mock):
         """Should redirect to https"""

--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -573,8 +573,6 @@ class TourView(LatestFxView):
                 template = 'firefox/dev-firstrun-spring-campaign.html'
             else:
                 template = 'firefox/dev-firstrun.html'
-        elif show_38_0_5_firstrun_or_whatsnew(version):
-            template = 'firefox/australis/fx38_0_5/firstrun.html'
         elif show_36_firstrun(version):
             template = 'firefox/australis/fx36/help-menu-36-tour.html'
         elif show_search_firstrun(version) and locale == 'en-US':


### PR DESCRIPTION
Request has been made to show the older /firstrun tour at /firefox/tour/, at least until we revise what content to show there.