### PR TITLE
[fix bug 1171216] Campaign landing page footer off on Chrome at 760px breakpoint

### DIFF
--- a/media/css/firefox/personal.less
+++ b/media/css/firefox/personal.less
@@ -261,7 +261,7 @@ main {
         height: 29px;
 
         @media only screen and (max-width: @breakTablet) {
-            margin-bottom: 15px;
+            margin: 0 0 15px;
         }
     }
 
@@ -291,7 +291,7 @@ main {
             }
 
             &:last-child:after {
-                content: '';
+                content: none;
             }
         }
     }


### PR DESCRIPTION
TIL: Chrome still considers `content: '';` as valid content on pseudo elements, needs `content: none;` instead.