### PR TITLE
Fix "Try Hello" link visited color.

### DIFF
--- a/media/css/firefox/hello/index.less
+++ b/media/css/firefox/hello/index.less
@@ -71,6 +71,10 @@ main {
     cursor: pointer;
     .transition(all 0.3s ease);
 
+    &:visited {
+        color: #fff;
+    }
+
     &:hover {
         text-decoration: none;
     }


### PR DESCRIPTION
Text of "Try Hello Now" secondary (bottom) CTA on /firefox/hello/ is blue (and not very readable) if the link has been visited. This PR keeps the text white.