### PR TITLE
Fix bug 1171183 in LocaleURLMiddleware

### DIFF
--- a/bedrock/base/middleware.py
+++ b/bedrock/base/middleware.py
@@ -10,7 +10,7 @@ from warnings import warn
 
 from django.conf import settings
 from django.http import HttpResponsePermanentRedirect
-from django.utils.encoding import smart_str
+from django.utils.encoding import smart_str, force_text
 
 import tower
 
@@ -59,7 +59,8 @@ class LocaleURLMiddleware(object):
             full_path = urllib.quote(full_path.encode('utf-8'))
 
             if query_string:
-                full_path = '%s?%s' % (full_path, query_string)
+                full_path = '?'.join(
+                    [full_path, force_text(query_string, errors='ignore')])
 
             response = HttpResponsePermanentRedirect(full_path)
 

--- a/bedrock/base/tests/test_middleware.py
+++ b/bedrock/base/tests/test_middleware.py
@@ -46,3 +46,16 @@ class TestLocaleURLMiddleware(TestCase):
         req = self.rf.get(path, {'lang': 'de'})
         resp = LocaleURLMiddleware().process_request(req)
         self.assertIs(resp, None)  # no redirect
+
+    @override_settings(DEV_LANGUAGES=('de', 'fr'),
+                       FF_EXEMPT_LANG_PARAM_URLS=())
+    def test_redirects_to_correct_language_despite_unicode_errors(self):
+        """Should redirect to lang prefixed url, stripping invalid chars."""
+        path = '/the/dude/'
+        corrupt_querystring = '?a\xa4\x91b\xa4\x91i\xc0de=s'
+        corrected_querystring = '?abide=s'
+        req = self.rf.get(path + corrupt_querystring,
+                          HTTP_ACCEPT_LANGUAGE='de')
+        resp = LocaleURLMiddleware().process_request(req)
+        self.assertEqual(resp['Location'],
+                         '/de' + path + corrected_querystring)


### PR DESCRIPTION
Strip characters from url params that cannot be encoded in utf-8