### PR TITLE
Bug 1172673 - Update Webmaker promo copy

### DIFF
--- a/bedrock/mozorg/templates/mozorg/home/home.html
+++ b/bedrock/mozorg/templates/mozorg/home/home.html
@@ -187,10 +187,10 @@
         <li id="promo-7" class="item promo-face">
           {{ promo_face(3) }}
         </li>
-      {% if l10n_has_tag('webmaker_promo_makerparty2015') %}
-        <li id="promo-8" class="item promo-small-landscape webmaker" data-name="Create. Share. Discover.">
+      {% if l10n_has_tag('webmaker_promo_makerparty2015b') %}
+        <li id="promo-8" class="item promo-small-landscape webmaker" data-name="Try the new Webmaker">
           <a class="panel-link" rel="external" href="https://beta.webmaker.org">
-            <h2>{{ _('Create. Share. Discover.') }}</h2>
+            <h2>{{ _('Try the new Webmaker') }}</h2>
           </a>
         </li>
       {% else %}


### PR DESCRIPTION
There was a late copy change that I missed.

@flodolo had you already exposed strings from the previous PR? If so, I'm really sorry.