### PR TITLE
Fix bug 1179847: Support pontoon.m.o in dev mode.

### DIFF
--- a/bedrock/base/templates/base-resp.html
+++ b/bedrock/base/templates/base-resp.html
@@ -161,6 +161,9 @@
       <script src="{{ settings.CDN_BASE_URL }}{{ url('tabzilla') }}"></script>
     {% endblock %}
     {% block js %}{% endblock %}
+    {% if settings.DEV %}
+      <script src="https://pontoon.mozilla.org/pontoon.js"></script>
+    {% endif %}
     {% if settings.USE_GRUNT_LIVERELOAD %}
       <script src="//localhost:35729/livereload.js"></script>
     {% endif %}

--- a/bedrock/base/templates/base.html
+++ b/bedrock/base/templates/base.html
@@ -144,6 +144,9 @@
       <script src="{{ settings.CDN_BASE_URL }}{{ url('tabzilla') }}"></script>
     {% endblock %}
     {% block js %}{% endblock %}
+    {% if settings.DEV %}
+      <script src="https://pontoon.mozilla.org/pontoon.js"></script>
+    {% endif %}
     {% if settings.USE_GRUNT_LIVERELOAD %}
       <script src="//localhost:35729/livereload.js"></script>
     {% endif %}

--- a/bedrock/settings/__init__.py
+++ b/bedrock/settings/__init__.py
@@ -25,6 +25,9 @@ else:
 
 if DEV:
     ALLOWED_HOSTS = ['*']
+else:
+    MIDDLEWARE_CLASSES += ('commonware.middleware.FrameOptionsHeader',)
+
 
 # waffle flags, switches, and samples should default to True in DEV mode
 WAFFLE_FLAG_DEFAULT = WAFFLE_SWITCH_DEFAULT = WAFFLE_SAMPLE_DEFAULT = DEV

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -295,7 +295,6 @@ MIDDLEWARE_CLASSES = (
     'django.middleware.common.CommonMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
-    'commonware.middleware.FrameOptionsHeader',
     'bedrock.mozorg.middleware.CacheMiddleware',
     'dnt.middleware.DoNotTrackMiddleware',
     'lib.l10n_utils.middleware.FixLangFileTranslationsMiddleware',


### PR DESCRIPTION
Since "allow-from" [isn't well supported across browsers](https://developer.mozilla.org/en-US/docs/Web/HTTP/X-Frame-Options#Browser_compatibility) I decided to just turn it off on dev (including demos). If anyone knows why this might be a bigger issue, let's discuss it here.