### PR TITLE
[fix bug 1179790] Header on firefox/desktop page misaligned in IE

### DIFF
--- a/media/css/firefox/desktop/index.less
+++ b/media/css/firefox/desktop/index.less
@@ -6,7 +6,8 @@
 @import 'common.less';
 
 #wrapper {
-    margin-top: -162px; // family nav
+    margin-top: 0;
+    top: -162px; // family nav
 }
 
 // animation defaults


### PR DESCRIPTION
Need to use `top` instead of `margin-top` for this page since the intro container is set to `overflow: hidden;` (which makes IE have a sad when it comes to applying negative margin values).