### PR TITLE
Fix Bug 1181422 - Plugincheck says ESR 38.1.0 is out of date

### DIFF
--- a/media/js/base/global.js
+++ b/media/js/base/global.js
@@ -138,6 +138,17 @@ function isFirefox31ESR(userAgent, buildID) {
         buildID && buildID !== '20140716183446';
 }
 
+// Detect Firefox 38 ESR by the *non-ESR* build IDs.
+// 38.0: 20150508094354, 38.0.1: 20150513174244, 38.0.5: 20150525141253
+// https://wiki.mozilla.org/Releases/Firefox_38/Test_Plan
+function isFirefox38ESR(userAgent, buildID) {
+    userAgent = userAgent || navigator.userAgent;
+    buildID = buildID || navigator.buildID;
+
+    return !isFirefoxMobile(userAgent) &&
+        getFirefoxMasterVersion(userAgent) === 38 && buildID &&
+        ['20150508094354', '20150513174244', '20150525141253'].indexOf(buildID) === -1;
+}
 
 // Create text translation function using #strings element.
 // TODO: Move to docs

--- a/media/js/plugincheck/check-plugins.js
+++ b/media/js/plugincheck/check-plugins.js
@@ -158,7 +158,7 @@ $(function() {
     }
 
     // show for outdated Fx versions
-    if (isFirefox() && !isFirefoxUpToDate() && !isFirefox31ESR()) {
+    if (isFirefox() && !isFirefoxUpToDate() && !isFirefox31ESR() && !isFirefox38ESR()) {
         outdatedFx.show();
     }
 

--- a/tests/unit/spec/global.js
+++ b/tests/unit/spec/global.js
@@ -294,6 +294,28 @@ describe('global.js', function() {
 
     });
 
+    describe('isFirefox38ESR', function () {
+
+        it('should return true for Firefox ESR', function () {
+            // Firefox 38.0 ESR
+            expect(isFirefox38ESR('Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:38.0) Gecko/20100101 Firefox/38.0', '20150505103531')).toBeTruthy();
+            // Firefox 38.0.1 ESR
+            expect(isFirefox38ESR('Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:38.0) Gecko/20100101 Firefox/38.0', '20150514102509')).toBeTruthy();
+            // Firefox 38.1.0 ESR
+            expect(isFirefox38ESR('Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:38.0) Gecko/20100101 Firefox/38.0', '20150624141534')).toBeTruthy();
+        });
+
+        it('should return false for Firefox non-ESR', function () {
+            // Firefox 38.0 non-ESR
+            expect(isFirefox38ESR('Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:38.0) Gecko/20100101 Firefox/38.0', '20150508094354')).toBeFalsy();
+            // Firefox 38.0.1 non-ESR
+            expect(isFirefox38ESR('Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:38.0) Gecko/20100101 Firefox/38.0', '20150513174244')).toBeFalsy();
+            // Firefox 38.0.5 non-ESR
+            expect(isFirefox38ESR('Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:38.0) Gecko/20100101 Firefox/38.0', '20150525141253')).toBeFalsy();
+        });
+
+    });
+
     describe('isFirefoxUpToDate', function () {
 
         it('should consider up to date if latest version is equal to user version', function() {


### PR DESCRIPTION
I’ll implement a new solution using the Tour API as part of Bug 939470, but this is still required.