### PR TITLE
Dockerize bedrock for production

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+locale/.svn
+.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,8 +30,9 @@ RUN ./manage.py update_product_details
 # Cleanup
 RUN apt-get purge -y python-dev build-essential libxml2-dev libxslt1-dev libmemcached-dev git
 RUN apt-get autoremove -y
-RUN rm -rf /var/lib/{apt,dpkg,cache,log} /usr/share/doc /usr/share/man /tmp/* /var/cache/* /app/.git /app/media
+RUN rm -rf /var/lib/{apt,dpkg,cache,log} /usr/share/doc /usr/share/man /tmp/* /var/cache/* /app/.git
 RUN find /app -name *.pyc -delete
+RUN ./docker/softlinkstatic.py
 
 # Change User
 RUN chown webdev.webdev -R .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,38 @@
+FROM debian:jessie
+
+WORKDIR /app
+EXPOSE 8000
+CMD ["./docker/run-prod.sh"]
+
+RUN adduser --uid 1000 --disabled-password --gecos '' --no-create-home webdev
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends python2.7 libpython2.7 gettext build-essential libmysqlclient-dev libxml2-dev libxslt1.1 libxslt1-dev python-dev python-pip libmemcached-dev nodejs git
+RUN update-alternatives --install /usr/bin/node node /usr/bin/nodejs 10
+
+
+COPY ./requirements /app/requirements
+
+# Pin a known to work with peep pip version.
+RUN pip install -r requirements/pip.txt
+
+# Install app
+COPY ./bin/peep.py /app/bin/peep.py
+RUN ./bin/peep.py install --no-cache-dir -r requirements/dev.txt
+RUN ./bin/peep.py install --no-cache-dir -r requirements/prod.txt
+COPY . /app
+
+RUN git rev-parse HEAD > static/revision.txt
+RUN ./manage.py collectstatic --noinput
+RUN ./manage.py update_externalfiles
+RUN ./manage.py update_product_details
+
+# Cleanup
+RUN apt-get purge -y python-dev build-essential libxml2-dev libxslt1-dev libmemcached-dev git
+RUN apt-get autoremove -y
+RUN rm -rf /var/lib/{apt,dpkg,cache,log} /usr/share/doc /usr/share/man /tmp/* /var/cache/* /app/.git /app/media
+RUN find /app -name *.pyc -delete
+
+# Change User
+RUN chown webdev.webdev -R .
+USER webdev

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,6 @@ RUN update-alternatives --install /usr/bin/node node /usr/bin/nodejs 10
 
 
 COPY ./requirements /app/requirements
-
 # Pin a known to work with peep pip version.
 RUN pip install -r requirements/pip.txt
 
@@ -20,6 +19,7 @@ RUN pip install -r requirements/pip.txt
 COPY ./bin/peep.py /app/bin/peep.py
 RUN ./bin/peep.py install --no-cache-dir -r requirements/dev.txt
 RUN ./bin/peep.py install --no-cache-dir -r requirements/prod.txt
+RUN ./bin/peep.py install --no-cache-dir -r requirements/docker.txt
 COPY . /app
 
 RUN git rev-parse HEAD > static/revision.txt

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,21 @@
+db:
+  image: mysql:5.5
+  environment:
+    - MYSQL_DATABASE=bedrock
+    - MYSQL_USER=bedrock
+    - MYSQL_PASSWORD=bedrock
+    - MYSQL_ROOT_PASSWORD=root
+web:
+  build: ../
+  ports:
+    - "8000:8000"
+  links:
+    - db
+  environment:
+    - PYTHONDONTWRITEBYTECODE=1
+    - DATABASE_URL=mysql://bedrock:bedrock@db/bedrock
+    - DEBUG=True
+    - ALLOWED_HOSTS=localhost,127.0.0.1,
+    - SECRET_KEY=39114b6a-2858-4caf-8878-482a24ee9542
+    - DOCKER=True
+  command: ./docker/run-dev.sh

--- a/docker/jenkins/postbuild.sh
+++ b/docker/jenkins/postbuild.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -ex
+
+# Docker-Compose does not remove the running database instace. We cannot use docker-compose
+# rm here because we re-tagged the image while uploading to DockerHub.
+docker rm -f `echo jenkins${JOB_NAME}${BUILD_NUMBER}| sed s/_//g`_db_1

--- a/docker/jenkins/push2deis.sh
+++ b/docker/jenkins/push2deis.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Needs DEIS_CONTROLLER URL, DEIS_USERNAME, DEIS_PASSWORD,
+# DOCKER_REPOSITORY and DEIS_APPLICATION environment variables.
+#
+# To set them go to Job -> Configure -> Build Environment -> Inject
+# passwords and Inject env variables
+#
+
+set -ex
+
+# Create a temporary virtualenv to install deis client
+TDIR=`mktemp -d`
+virtualenv $TDIR
+. $TDIR/bin/activate
+pip install deis==1.8.0
+
+
+deis login $DEIS_CONTROLLER  --username $DEIS_USERNAME --password $DEIS_PASSWORD
+deis pull $DOCKER_REPOSITORY:`git rev-parse HEAD` -a $DEIS_APPLICATION

--- a/docker/jenkins/push2dockerhub.sh
+++ b/docker/jenkins/push2dockerhub.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# Needs DOCKER_USERNAME, DOCKER_PASSWORD, DOCKER_REPOSITORY
+# environment variables.
+#
+# To set them go to Job -> Configure -> Build Environment -> Inject
+# passwords and Inject env variables
+#
+set -ex
+
+docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD -e $DOCKER_USERNAME@example.com
+
+# If pull request use $ghprbActualCommit otherwise use $GIT_COMMIT
+COMMIT="${ghprbActualCommit:=$GIT_COMMIT}"
+
+# Tag using git hash
+docker tag -f `echo jenkins${JOB_NAME}${BUILD_NUMBER}| sed s/_//g`_web $DOCKER_REPOSITORY:$COMMIT
+docker push $DOCKER_REPOSITORY:$COMMIT
+
+# Tag as latest
+docker tag -f `echo jenkins${JOB_NAME}${BUILD_NUMBER}| sed s/_//g`_web $DOCKER_REPOSITORY:latest
+docker push $DOCKER_REPOSITORY:latest

--- a/docker/jenkins/runtests.sh
+++ b/docker/jenkins/runtests.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+#
+# Runs unit_tests
+#
+set -ex
+
+# Create a temporary virtualenv to install docker-compose
+TDIR=`mktemp -d`
+virtualenv $TDIR
+. $TDIR/bin/activate
+pip install docker-compose==1.2.0
+
+# Pull locales, we probably need to move this elsewhere.
+git submodule update --init --recursive
+
+set +e
+svn cleanup locale
+set -e
+svn co http://svn.mozilla.org/projects/mozilla.com/trunk/locales/ locale
+
+DOCKER_COMPOSE="docker-compose --project-name jenkins${JOB_NAME}${BUILD_NUMBER} -f docker/docker-compose.yml"
+
+$DOCKER_COMPOSE build
+
+docker save `echo jenkins${JOB_NAME}${BUILD_NUMBER}| sed s/_//g`_web | sudo docker-squash -t `echo jenkins${JOB_NAME}${BUILD_NUMBER}| sed s/_//g`_web | docker load
+
+# Does nothing atm.
+
+# Delete virtualenv
+rm -rf $TDIR

--- a/docker/run-common.sh
+++ b/docker/run-common.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+./manage.py syncdb --noinput

--- a/docker/run-dev.sh
+++ b/docker/run-dev.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+./docker/run-common.sh
+./manage.py runserver 0.0.0.0:8000

--- a/docker/run-prod.sh
+++ b/docker/run-prod.sh
@@ -1,4 +1,13 @@
-#!/bin/sh
+#!/bin/bash
 
-./docker/run-common.sh
-gunicorn wsgi.app:application -b 0.0.0.0:${PORT:-8000} -w 2 --error-logfile - --access-logfile - --log-level ${LOGLEVEL:-info}
+# ./docker/run-common.sh
+server=${WSGI_SERVER:-gunicorn}
+if [[ $server == "gunicorn" ]]
+then
+    gunicorn wsgi.app:application -b 0.0.0.0:${PORT:-8000} -w 2 --error-logfile - --access-logfile - --log-level ${LOGLEVEL:-info}
+elif [[ $server == "uwsgi" ]]
+then
+    uwsgi --master --wsgi wsgi.app:application --http 0.0.0.0:${PORT:-8000}
+else
+    >&2 echo "Unknown wsgi server $server"
+fi

--- a/docker/run-prod.sh
+++ b/docker/run-prod.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+./docker/run-common.sh
+gunicorn wsgi.app:application -b 0.0.0.0:${PORT:-8000} -w 2 --error-logfile - --access-logfile - --log-level ${LOGLEVEL:-info}

--- a/docker/softlinkstatic.py
+++ b/docker/softlinkstatic.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python
+import json
+import os
+
+STATIC = './static/staticfiles.json'
+
+with open(STATIC) as static_fp:
+    static_files = json.load(static_fp)
+
+for path in static_files['paths']:
+    full_path = os.path.join('./static', path)
+
+    try:
+        os.unlink(full_path)
+    except OSError:
+        pass

--- a/requirements/docker.txt
+++ b/requirements/docker.txt
@@ -1,0 +1,8 @@
+# Python requirements needed in docker images
+
+# sha256: pRec3pItK04EXuWxHocyPud9NjrkApT8glLyXWoOrwY
+# sha256: i8g1CCiCrZoBLNeQxGABHk2WvzUS2YoE09q75FOToIk
+gunicorn==19.3.0
+
+# sha256: dafTE4z6nNgadgwvikPz2Alh7cjk8nBD3BQSIGySYoc
+uwsgi==2.0.11.1

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -18,3 +18,7 @@ django-pylibmc==0.6.0
 
 # sha256: MOGaBuZQ_eMfQKYtsKPaN6HK2WFuHP0EuOJI-0vV9KE
 pylibmc==1.4.2
+
+# sha256: pRec3pItK04EXuWxHocyPud9NjrkApT8glLyXWoOrwY
+# sha256: i8g1CCiCrZoBLNeQxGABHk2WvzUS2YoE09q75FOToIk
+gunicorn==19.3.0

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -18,7 +18,3 @@ django-pylibmc==0.6.0
 
 # sha256: MOGaBuZQ_eMfQKYtsKPaN6HK2WFuHP0EuOJI-0vV9KE
 pylibmc==1.4.2
-
-# sha256: pRec3pItK04EXuWxHocyPud9NjrkApT8glLyXWoOrwY
-# sha256: i8g1CCiCrZoBLNeQxGABHk2WvzUS2YoE09q75FOToIk
-gunicorn==19.3.0


### PR DESCRIPTION
* ~~I'm waiting for #3107 to get merged. Then I will rebase.~~ Rebased of #3107.
* There is a jenkins job that builds against my repository atm https://ci.masterfirefoxos.com/view/www.mozilla.org/job/mozilla_bedrock_docker/ and automatically deploys to
* http://bedrock.masterfirefoxos.com demo
* Everything docker related is under `docker` directory except `Dockerfile`, which we can move when we upgrade to recent docker engine versions 
* Bedrock weights a lot due to static media and locales. Multiple optimizations to bring the image size down to ~550mb. See https://github.com/mozilla/bedrock/pull/3119/files#diff-3254677a7917c6c01f55212f86c57fbfR35