### PR TITLE
Bug 1183218. Add logic to plugincheck to handle empty latest array.

### DIFF
--- a/bedrock/mozorg/templates/mozorg/plugincheck.html
+++ b/bedrock/mozorg/templates/mozorg/plugincheck.html
@@ -106,6 +106,13 @@
         <li>{{_('Step 2: Complete all recommended updates before restarting your browser.')}}</li>
       </ul>
 
+      <div class="flash-warning">
+        <p>
+          All versions of Adobe’s Flash Player plugin are currently vulnerable.
+        </p>
+        <a rel="external" href="https://support.mozilla.org/kb/set-adobe-flash-click-play-firefox">Learn more</a>
+      </div>
+
       <div class="plugincheck-loader"></div>
 
       <div id="sec-plugin-vulnerable">
@@ -250,8 +257,8 @@
 <!-- dislayed to nonFx users -->
 <div class="not-supported">
   <header id="main-feature">
-      <h1 class="large">{{_('Check Your Plugins')}}</h1>
-      <p class="preamble">{{_('Keeping your plugins up to date helps Firefox run safely and smoothly.')}}</p>
+    <h1 class="large">{{_('Check Your Plugins')}}</h1>
+    <p class="preamble">{{_('Keeping your plugins up to date helps Firefox run safely and smoothly.')}}</p>
   </header>
 
   <section>
@@ -259,6 +266,13 @@
       <p>{{_('Currently the plugin check service is only available to Firefox users.')}}</p>
     {% endif %}
     {{ download_firefox(small=True) }}
+
+    <div class="flash-warning">
+      <p>
+        All versions of Adobe’s Flash Player plugin are currently vulnerable.
+      </p>
+      <a rel="external" href="https://support.mozilla.org/kb/set-adobe-flash-click-play-firefox">Learn more</a>
+    </div>
   </section>
 </div>
 {% endblock %}

--- a/media/css/plugincheck/plugincheck.less
+++ b/media/css/plugincheck/plugincheck.less
@@ -304,6 +304,32 @@ html[dir="rtl"] {
     }
 }
 
+// Flash exploit notice
+.flash-warning {
+    .warning;
+    color: #fff;
+    background-color: #a91300;
+    #gradient > .vertical(#da5132, #a91300);
+    padding: 20px;
+    font-style: normal;
+    margin: 20px auto;
+    display: block;
+    width: 80%;
+    border-radius: 8px;
+
+    a,
+    a:active,
+    a:hover,
+    a:link {
+        color: #fff;
+        .trailing-arrow();
+    }
+
+    @media (max-width: @breakDesktop) {
+        width: auto;
+    }
+}
+
 /* Tablet Layout: 760px */
 @media only screen and (min-width: @breakTablet) and (max-width: @breakDesktop) {
     #main-feature > .download-button {


### PR DESCRIPTION
- Adds big red alert telling users Flash is currently vulnerable.
  Will need to manually remove this alert when Flash is patched.