### PR TITLE
Bug 1182126: Increase fonts cache header to one month.

### DIFF
--- a/bedrock/base/static.py
+++ b/bedrock/base/static.py
@@ -1,0 +1,17 @@
+from whitenoise.django import DjangoWhiteNoise
+
+
+class BedrockWhiteNoise(DjangoWhiteNoise):
+    """WhiteNoise class for modifying default cache headers."""
+    ONE_MONTH = 30 * 24 * 60 * 60
+
+    def add_cache_headers(self, static_file, url):
+        if self.is_immutable_file(static_file, url):
+            max_age = self.FOREVER
+        elif '/fonts/' in url:
+            max_age = self.ONE_MONTH
+        else:
+            max_age = self.max_age
+        if max_age is not None:
+            cache_control = 'public, max-age={}'.format(max_age)
+            static_file.headers['Cache-Control'] = cache_control

--- a/bedrock/base/tests/test_static.py
+++ b/bedrock/base/tests/test_static.py
@@ -1,0 +1,38 @@
+from django.test import TestCase
+
+from mock import Mock, patch
+
+from bedrock.base.static import BedrockWhiteNoise
+
+
+class TestBedrockWhiteNoise(TestCase):
+    def setUp(self):
+        self.wn = BedrockWhiteNoise(Mock())
+
+    def test_immutable_files(self):
+        with patch.object(self.wn, 'is_immutable_file', return_value=True):
+            static_file = Mock(headers={})
+            self.wn.add_cache_headers(static_file, 'dude.txt')
+            self.assertTrue(static_file.headers['Cache-Control'].endswith(
+                'max-age={}'.format(self.wn.FOREVER)))
+
+    def test_font_files(self):
+        with patch.object(self.wn, 'is_immutable_file', return_value=False):
+            static_file = Mock(headers={})
+            self.wn.add_cache_headers(static_file, 'media/fonts/dude.txt')
+            self.assertTrue(static_file.headers['Cache-Control'].endswith(
+                'max-age={}'.format(self.wn.ONE_MONTH)))
+
+    def test_immutable_font_files(self):
+        with patch.object(self.wn, 'is_immutable_file', return_value=True):
+            static_file = Mock(headers={})
+            self.wn.add_cache_headers(static_file, 'media/fonts/dude.txt')
+            self.assertTrue(static_file.headers['Cache-Control'].endswith(
+                'max-age={}'.format(self.wn.FOREVER)))
+
+    def test_other_files(self):
+        with patch.object(self.wn, 'is_immutable_file', return_value=False):
+            static_file = Mock(headers={})
+            self.wn.add_cache_headers(static_file, 'media/dude.txt')
+            self.assertTrue(static_file.headers['Cache-Control'].endswith(
+                'max-age={}'.format(self.wn.max_age)))

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -263,6 +263,7 @@ PIPELINE_COMPILERS = (
 PIPELINE_LESS_BINARY = path('node_modules', 'less', 'bin', 'lessc')
 PIPELINE_LESS_ARGUMENTS = '-s'
 WHITENOISE_ROOT = path('root_files')
+WHITENOISE_MAX_AGE = 6 * 60 * 60  # 6 hours
 PIPELINE_JS_COMPRESSOR = 'pipeline.compressors.uglifyjs.UglifyJSCompressor'
 PIPELINE_UGLIFYJS_BINARY = path('node_modules', 'uglify-js', 'bin', 'uglifyjs')
 PIPELINE_CSS_COMPRESSOR = 'pipeline.compressors.cssmin.CSSMinCompressor'

--- a/wsgi/playdoh.wsgi
+++ b/wsgi/playdoh.wsgi
@@ -19,10 +19,10 @@ os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'bedrock.settings')
 
 # must be imported after env var is set above.
 from django.core.wsgi import get_wsgi_application
-from whitenoise.django import DjangoWhiteNoise
+from bedrock.base.static import BedrockWhiteNoise
 
 application = get_wsgi_application()
-application = DjangoWhiteNoise(application)
+application = BedrockWhiteNoise(application)
 
 if newrelic:
     application = newrelic.agent.wsgi_application()(application)


### PR DESCRIPTION
Also increase default cache header expiry to 6 hours from 1 minute.
The majority of files used on bedrock are immutable (include the
file content hash) and will be unaffected by this change.