### PR TITLE
Bug 1180325 - Grammar error on the sync feature page

### DIFF
--- a/bedrock/firefox/templates/firefox/sync.html
+++ b/bedrock/firefox/templates/firefox/sync.html
@@ -187,7 +187,7 @@
         <div class="feature-home">
           <h3>{{ _('At home') }}</h3>
           <p>
-            {{ _('Move from your desk to the couch without skipping a beat. Access your open tabs on your smartphone, or keeping browsing your bookmarks right on your tablet.') }}
+            {{ _('Move from your desk to the couch without skipping a beat. Access your open tabs on your smartphone, or keep browsing your bookmarks right on your tablet.') }}
           </p>
         </div>
         <div class="feature-work">


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1180325