### PR TITLE
[fix bug 1177817] Update 38.0.5 firstrun sign in/up CTAs.

### DIFF
--- a/bedrock/firefox/templates/firefox/australis/fx38_0_5/firstrun.html
+++ b/bedrock/firefox/templates/firefox/australis/fx38_0_5/firstrun.html
@@ -50,7 +50,7 @@
 {% endblock %}
 
 {% block content %}
-<section id="intro" data-funnelcake="{{ funnelcake_id }}">
+<section id="intro">
   <div class="container">
     <div id="logo">
       {{ high_res_img('img/firefox/australis/fx38.0.5/firefox-logo.png', {'alt': 'Firefox', 'width': '142', 'height': '147'}) }}
@@ -62,9 +62,8 @@
       </h1>
 
       <h2>
-        {# L10n: Line breaks below are for visual formatting only. #}
-        <span class="ctaMenu">{{ _('Set up Sync and <br>you’re good to go.') }}</span>
-        <span class="ctaDirect">{{ _('Sign in to Firefox and <br>you’re good to go.') }}</span>
+        {# L10n: Line break below for visual formatting only. #}
+        {{ _('Sign in to Firefox and <br>you’re good to go.') }}
       </h2>
 
       <p>
@@ -74,10 +73,8 @@
 
     <div class="rightcol">
       {{ high_res_img('img/firefox/australis/fx38.0.5/sync.png', {'alt': 'Firefox Sync', 'width': '219', 'height': '118'}) }}
-      <a href="{{ url('firefox.sync') }}" id="cta-signup" class="button-flat-green">
-        <span class="ctaMenu">{{ _('Sign in to get started') }}</span>
-        <span class="ctaDirect">{{ _('Create a Firefox Account') }}</span>
-      </a>
+      <a href="{{ url('firefox.sync') }}" id="cta-signup" class="button-flat-green">{{ _('Create a Firefox Account') }}</a>
+      <a id="cta-signin" rel="external" href="https://support.mozilla.org/kb/how-do-i-set-up-firefox-sync">{{ _('Already have one? Sign in.') }}</a>
     </div>
   </div>
 </section>

--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -455,17 +455,12 @@ class FirstrunView(LatestFxView):
     def get_context_data(self, **kwargs):
         ctx = super(FirstrunView, self).get_context_data(**kwargs)
 
-        # Firstrun 38.0.5 context - can be removed when these tests are complete
-        ctx = funnelcake_param(self.request)
-        funnelcake_id = ctx.get('funnelcake_id', None)
+        # add spring campaign video for 38.0.5
+        version = self.kwargs.get('version') or ''
 
-        # funnelcake 39 prevents video regardless of locale
-        if (funnelcake_id != '39'):
+        if show_38_0_5_firstrun_or_whatsnew(version):
             locale = l10n_utils.get_locale(self.request)
-
             ctx['video_url'] = LOCALE_SPRING_CAMPAIGN_VIDEOS.get(locale, False)
-        else:
-            ctx['video_url'] = False
 
         return ctx
 

--- a/media/js/firefox/australis/fx38_0_5/firstrun.js
+++ b/media/js/firefox/australis/fx38_0_5/firstrun.js
@@ -5,29 +5,20 @@
 
     var hasVideo = $('#video').length > 0;
     var $ctaSignup = $('#cta-signup');
+    var $ctaSignin = $('#cta-signin');
     var $videoFrame = $('#video-frame');
     var $videoTitle = $('#video-title');
     var $video = $('#firstrun-video');
-    var funnelcakeId = parseInt($('#intro').data('funnelcake'), 10);
 
-    var ctaDirect;
     var videoOnLoad = false;
-
-    // ctaDirect var determines text displayed on CTA.
-    // https://bugzilla.mozilla.org/show_bug.cgi?id=1177817#c8
-    if (funnelcakeId === 37) {
-        ctaDirect = false;
-    } else {
-        ctaDirect = true;
-    }
 
     // if locale has video, do A/B test
     if (hasVideo) {
         videoOnLoad = (Math.random() >= 0.5);
 
         // manual override to test videos
-        if (window.location.href.indexOf('&v=') !== -1) {
-            var parts = window.location.href.split('&v=');
+        if (window.location.href.indexOf('v=') !== -1) {
+            var parts = window.location.href.split('v=');
             var variation = parts[1];
 
             if (variation === '1') {
@@ -67,13 +58,6 @@
         });
     }
 
-    // display appropriate copy
-    if (!ctaDirect) {
-        $('.ctaMenu').addClass('visible');
-    } else {
-        $('.ctaDirect').addClass('visible');
-    }
-
     var showVideo = function(origin, autoplay) {
         var opts = {
             title: $videoTitle.text()
@@ -98,10 +82,18 @@
         Mozilla.UITour.getConfiguration('sync', function() {
             $document = $(document);
 
+            // signup CTA opens about:accounts
             $ctaSignup.on('click', function(e) {
                 e.preventDefault();
 
-                // call twice two correctly position highlight
+                Mozilla.UITour.showFirefoxAccounts();
+            });
+
+            // signin CTA opens hamburger menu
+            $ctaSignin.on('click', function(e) {
+                e.preventDefault();
+
+                // call twice to correctly position highlight
                 // https://bugzilla.mozilla.org/show_bug.cgi?id=1049130
                 Mozilla.UITour.showHighlight('accountStatus', 'wobble');
                 Mozilla.UITour.showHighlight('accountStatus', 'wobble');
@@ -109,8 +101,12 @@
                 // allow clicking anywhere in page to hide menu
                 // behind a timeout so event isn't captured with *this* click
                 setTimeout(function() {
-                    $document.one('click.hideHighlight', function() {
-                        Mozilla.UITour.hideHighlight();
+                    $document.one('click.hideHighlight', function(e) {
+                        // don't create race condition if user clicks twice in
+                        // succession on the sign in link
+                        if ($(e.target).prop('id') !== 'cta-signin') {
+                            Mozilla.UITour.hideHighlight();
+                        }
                     });
                 }, 50);
             });


### PR DESCRIPTION
New CTA logic based on discussion in [bug 1177817](https://bugzilla.mozilla.org/show_bug.cgi?id=1177817#c22):

- Sign up CTA opens `about:accounts?action=signup&entrypoint=uitour`
- Sign in CTA resurrected and now highlights Sync in :hamburger: menu