### PR TITLE
Update home-promo.less

### DIFF
--- a/media/css/mozorg/home/home-promo.less
+++ b/media/css/mozorg/home/home-promo.less
@@ -951,7 +951,7 @@ html[lang|="en"] {
 /****************************************************************************/
 // Firefox Developer Edition
 .promo-large-portrait.firefox-developer {
-    background: #005da5; // dark blue
+    background: #000; // solid black
 
     h2 {
         padding-top: 145px;


### PR DESCRIPTION
It would be better to change the background color of the firefox developer edition tile into black. Because, most of the developers would like to see their working window with a black background.