### PR TITLE
Clean up/optimize Fx desktop page templates.

### DIFF
--- a/bedrock/firefox/templates/firefox/desktop/customize.html
+++ b/bedrock/firefox/templates/firefox/desktop/customize.html
@@ -15,8 +15,6 @@
 
 {% block body_id %}firefox-desktop-customize{% endblock %}
 
-{% block site_header %}{% endblock %}
-
 {% block site_header_unwrapped %}
   {{ fxfamilynav('desktop', 'customize', 'dark') }}
 {% endblock %}

--- a/bedrock/firefox/templates/firefox/desktop/desktop-base.html
+++ b/bedrock/firefox/templates/firefox/desktop/desktop-base.html
@@ -14,33 +14,7 @@
   <script src="{{ static('js/libs/modernizr.custom.cssanimations.js') }}"></script>
 {% endblock %}
 
-{% block site_header %}
-  <header id="masthead">
-    <div class="container">
-      <div id="tabzilla">
-        <a href="{{ url('mozorg.home') }}">Mozilla</a>
-      </div>
-      <div id="masthead-logo-nav">
-      {% block site_header_logo %}
-        <a id="site-header-logo" href="{{ url('firefox.desktop.index') }}">{{ high_res_img('img/firefox/desktop/firefox-header.png', {'alt': 'Firefox', 'width': '132', 'height': '49'}) }}</a>
-      {% endblock %}
-      {% block site_header_nav %}
-        <nav id="nav-main" role="navigation">
-          <span class="toggle" role="button" aria-controls="nav-main-menu" aria-expanded="false" tabindex="0">{{_('Menu')}}</span>
-          <ul id="nav-main-menu">
-            <li class="first"><a id="nav-main-trust" href="{{ url('firefox.desktop.trust') }}">{{ _('Trusted') }}</a></li>
-            <li><a id="nav-main-customize" href="{{ url('firefox.desktop.customize') }}">{{ _('Flexible') }}</a></li>
-            <li class="last"><a id="nav-main-fast" href="{{ url('firefox.desktop.fast') }}">{{ _('Fast') }}</a></li>
-          </ul>
-        </nav>
-      {% endblock %}
-      {% block site_header_download_button %}
-        <a href="{{ url('firefox.new') }}" class="button button-green" id="masthead-download-firefox">{{ _('Download') }}</a>
-      {% endblock %}
-      </div>
-    </div>
-  </header>
-{% endblock %}
+{% block site_header %}{% endblock %}
 
 {% block content %}{% endblock %}
 

--- a/bedrock/firefox/templates/firefox/desktop/fast.html
+++ b/bedrock/firefox/templates/firefox/desktop/fast.html
@@ -15,8 +15,6 @@
 
 {% block body_id %}firefox-desktop-fast{% endblock %}
 
-{% block site_header %}{% endblock %}
-
 {% block site_header_unwrapped %}
   {{ fxfamilynav('desktop', 'fast', 'dark') }}
 {% endblock %}

--- a/bedrock/firefox/templates/firefox/desktop/index.html
+++ b/bedrock/firefox/templates/firefox/desktop/index.html
@@ -25,8 +25,6 @@
   {% stylesheet 'firefox_desktop' %}
 {% endblock %}
 
-{% block site_header %}{% endblock %}
-
 {% block site_header_unwrapped %}
   {% call fxfamilynav('desktop', 'index', 'dark') %}
     {{ download_firefox(simple=True, small=True, dom_id="sticky-download-desktop") }}

--- a/bedrock/firefox/templates/firefox/desktop/trust.html
+++ b/bedrock/firefox/templates/firefox/desktop/trust.html
@@ -15,8 +15,6 @@
 
 {% block body_id %}firefox-desktop-trust{% endblock %}
 
-{% block site_header %}{% endblock %}
-
 {% block site_header_unwrapped %}
   {{ fxfamilynav('desktop', 'trust', 'dark') }}
 {% endblock %}


### PR DESCRIPTION
Noticed while reviewing PR #3125 that `site_header` in `desktop-base.html` isn't needed anymore (due to family nav).

Didn't think a bug was warranted.