### PR TITLE
[bug 1171928] Fix static tabzilla on Firefox 36 tour pages

### DIFF
--- a/bedrock/firefox/templates/firefox/australis/fx36/firstrun-tour.html
+++ b/bedrock/firefox/templates/firefox/australis/fx36/firstrun-tour.html
@@ -8,7 +8,7 @@
 
 {% block telemetry_id %}firstrun-tour-36-release{% endblock %}
 
-{% block site_css %}
+{% block page_css %}
   {% stylesheet 'firefox_fx36_firstrun' %}
 {% endblock %}
 

--- a/bedrock/firefox/templates/firefox/australis/fx36/tour-base.html
+++ b/bedrock/firefox/templates/firefox/australis/fx36/tour-base.html
@@ -23,13 +23,15 @@
 
 {% block body_class %}sky{% endblock %}
 
-{% block site_css %}{% endblock %}
+{% block page_css %}{% endblock %}
 
 {% block string_data %}{% endblock %}
 
 {% block site_header %}
   <header id="masthead">
-    <a href="{{ url('mozorg.home') }}" id="tabzilla">Mozilla</a>
+    <div id="tabzilla">
+      <a href="{{ url('mozorg.home') }}">Mozilla</a>
+    </div>
     {% block site_header_nav %}{% endblock %}
     {% block site_header_logo %}{% endblock %}
     {% block breadcrumbs %}{% endblock %}

--- a/bedrock/firefox/templates/firefox/australis/fx36/whatsnew-no-tour.html
+++ b/bedrock/firefox/templates/firefox/australis/fx36/whatsnew-no-tour.html
@@ -8,7 +8,7 @@
 
 {% block telemetry_id %}whatsnew-no-tour-36-release{% endblock %}
 
-{% block site_css %}
+{% block page_css %}
   {% stylesheet 'firefox_fx36_whatsnew_no_tour' %}
 {% endblock %}
 

--- a/bedrock/firefox/templates/firefox/australis/fx36/whatsnew-tour.html
+++ b/bedrock/firefox/templates/firefox/australis/fx36/whatsnew-tour.html
@@ -8,7 +8,7 @@
 
 {% block telemetry_id %}whatsnew-tour-36-release{% endblock %}
 
-{% block site_css %}
+{% block page_css %}
   {% stylesheet 'firefox_fx36_whatsnew' %}
 {% endblock %}
 

--- a/bedrock/settings/static_media.py
+++ b/bedrock/settings/static_media.py
@@ -319,7 +319,6 @@ PIPELINE_CSS = {
     },
     'firefox_fx36_firstrun': {
         'source_filenames': (
-            'css/sandstone/sandstone.less',
             'css/firefox/australis/australis-ui-tour.less',
             'css/firefox/hello-animation.less',
             'css/firefox/australis/fx36/common.less',
@@ -328,7 +327,6 @@ PIPELINE_CSS = {
     },
     'firefox_fx36_whatsnew': {
         'source_filenames': (
-            'css/sandstone/sandstone.less',
             'css/firefox/australis/australis-ui-tour.less',
             'css/firefox/hello-animation.less',
             'css/firefox/australis/fx36/common.less',
@@ -337,7 +335,6 @@ PIPELINE_CSS = {
     },
     'firefox_fx36_whatsnew_no_tour': {
         'source_filenames': (
-            'css/sandstone/sandstone.less',
             'css/firefox/hello-animation.less',
             'css/firefox/australis/fx36/common.less',
         ),


### PR DESCRIPTION
* `/firefox/36.0/whatsnew/`
* `/firefox/36.0/firstrun/`
* `/firefox/36.0/tour/`