### PR TITLE
Fix bug 1189856 fix overflowing text on mobile release notes

### DIFF
--- a/media/css/firefox/releasenotes.less
+++ b/media/css/firefox/releasenotes.less
@@ -444,11 +444,14 @@ article {
         margin: @baseLine 10px;
     }
 
-    .section-items {
+    .section-items.tagged {
         > li {
-            padding-left: 0;
+            padding-left: 0px;
+            display:block;
+            word-wrap:break-word;
+            width:auto;
             span {
-                word-break: break-all;
+            word-wrap:break-word;
             }
         }
 
@@ -459,4 +462,6 @@ article {
             margin: 0 0 .75em;
         }
     }
+
+
 }


### PR DESCRIPTION
Submitting this instead previous pull request https://github.com/mozilla/bedrock/pull/3172 