### PR TITLE
Add a link to Firefox OS Security Advisories

### DIFF
--- a/bedrock/security/templates/security/known-vulnerabilities.html
+++ b/bedrock/security/templates/security/known-vulnerabilities.html
@@ -31,6 +31,7 @@
       <ul>
         <li><a href="{{ url('security.product-advisories', slug='firefox') }}">Firefox</a></li>
         <li><a href="{{ url('security.product-advisories', slug='firefox-esr') }}">Firefox ESR</a></li>
+        <li><a href="{{ url('security.product-advisories', slug='firefox-os') }}">Firefox OS</a></li>
         <li><a href="{{ url('security.product-advisories', slug='thunderbird') }}">Thunderbird</a></li>
         <li><a href="{{ url('security.product-advisories', slug='thunderbird-esr') }}">Thunderbird ESR</a></li>
         <li><a href="{{ url('security.product-advisories', slug='seamonkey') }}">SeaMonkey</a></li>


### PR DESCRIPTION
https://github.com/mozilla/foundation-security-advisories/pull/5 added Security Advisories for Firefox OS. We need a link to the index page. No bug. Tested locally.