### PR TITLE
Bug 1191923 - remove waffle switch for Pocket page

### DIFF
--- a/bedrock/firefox/urls.py
+++ b/bedrock/firefox/urls.py
@@ -88,11 +88,9 @@ urlpatterns = patterns('',
         decorators=waffle_switch('mwc-2015-preview')),
 
     page('firefox/os/devices', 'firefox/os/devices.html'),
-    page('firefox/os/devices/tv', 'firefox/os/tv.html',
-        decorators=waffle_switch('firefox-os-tv')),
+    page('firefox/os/devices/tv', 'firefox/os/tv.html'),
 
-    page('firefox/pocket', 'firefox/pocket.html',
-        decorators=waffle_switch('pocket-active')),
+    page('firefox/pocket', 'firefox/pocket.html'),
 
     page('firefox/independent', 'firefox/independent.html'),
     redirect('^firefox/windows-10/welcome/$', 'firefox.desktop.customize',


### PR DESCRIPTION
The Firefox OS TV page, too. We no longer need to waffle these pages. Eliminating some debt.

https://bugzilla.mozilla.org/show_bug.cgi?id=1191923