### PR TITLE
Bug 1152501 - remove Patriot Act campaign promo

### DIFF
--- a/bedrock/mozorg/templates/mozorg/home/home.html
+++ b/bedrock/mozorg/templates/mozorg/home/home.html
@@ -122,13 +122,7 @@
             </div>
           </a>
         </li>
-      {% if LANG == 'en-US' %}
-        <li id="promo-2" class="item promo-small-landscape advocacy" data-name="Help end mass surveillance">
-          <a class="panel-link" href="https://sendto.mozilla.org/page/s/section-215-petition?ref=20150414Advocacy_Surveil&amp;utm_campaign=20150414Advocacy_Surveil&amp;utm_source=mozilla.org&amp;utm_medium=referral&amp;utm_content=Advocacy_tile_small">
-            <h2>Help end mass surveillance</h2>
-          </a>
-        </li>
-      {% elif l10n_has_tag('privacy_day') %}
+      {% if l10n_has_tag('privacy_day') %}
         <li id="promo-2" class="item promo-small-landscape advocacy" data-name="Learn about Mozilla Advocacy">
           <a class="panel-link" href="https://advocacy.mozilla.org">
             <h2>{{ _('Learn about Mozilla Advocacy') }}</h2>


### PR DESCRIPTION
Also relates to bug 1192764. This promo used a waffle switch that we shouldn't need to maintain because the whole promo can be removed.