### PR TITLE
[fix bug 1191522] Enable Optimizely on /firefox/desktop/ pages.

### DIFF
--- a/bedrock/firefox/templates/firefox/desktop/desktop-base.html
+++ b/bedrock/firefox/templates/firefox/desktop/desktop-base.html
@@ -14,6 +14,12 @@
   <script src="{{ static('js/libs/modernizr.custom.cssanimations.js') }}"></script>
 {% endblock %}
 
+{% block optimizely %}
+  {% if waffle.switch('firefox-desktop-optimizely') %}
+    {% include 'includes/optimizely.html' %}
+  {% endif %}
+{% endblock %}
+
 {% block site_header %}{% endblock %}
 
 {% block content %}{% endblock %}

--- a/bedrock/firefox/templates/firefox/desktop/index.html
+++ b/bedrock/firefox/templates/firefox/desktop/index.html
@@ -15,12 +15,6 @@
   {% endif %}
 {% endblock %}
 
-{% block optimizely %}
-  {% if waffle.switch('firefox-desktop-optimizely') %}
-     {% include 'includes/optimizely.html' %}
-  {% endif %}
-{% endblock %}
-
 {% block page_css %}
   {% stylesheet 'firefox_desktop' %}
 {% endblock %}


### PR DESCRIPTION
As [commented in the bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1191522#c4), one switch for all `/firefox/desktop/` pages should be sufficient.

Will need to add to [the wiki page](https://wiki.mozilla.org/Mozilla.org/Optimizely) after merge.