### PR TITLE
[fix bug 1198671] Update Hello FTU share URL to point to Hello product page

### DIFF
--- a/bedrock/base/templates/base-resp.html
+++ b/bedrock/base/templates/base-resp.html
@@ -37,7 +37,7 @@
     <link rel="apple-touch-icon" type="image/png" sizes="180x180" href="{% block page_ios_icon %}{{ static('img/favicon/apple-touch-icon-180x180.png') }}{% endblock %}">
     <link rel="icon" type="image/png" sizes="196x196" href="{% block page_favicon_large %}{{ static('img/favicon/favicon-196x196.png') }}{% endblock %}">
     <link rel="shortcut icon" href="{% block page_favicon %}{{ static('img/favicon.ico') }}{% endblock %}">
-    {% include 'includes/canonical-url.html' %}
+    {% block canonical_urls %}{% include 'includes/canonical-url.html' %}{% endblock %}
     {% endblock shared_meta %}
 
     {{ l10n_css() }}

--- a/bedrock/base/templates/base.html
+++ b/bedrock/base/templates/base.html
@@ -36,7 +36,7 @@
     <link rel="apple-touch-icon" type="image/png" sizes="180x180" href="{% block page_ios_icon %}{{ static('img/favicon/apple-touch-icon-180x180.png') }}{% endblock %}">
     <link rel="icon" type="image/png" sizes="196x196" href="{% block page_favicon_large %}{{ static('img/favicon/favicon-196x196.png') }}{% endblock %}">
     <link rel="shortcut icon" href="{% block page_favicon %}{{ static('img/favicon.ico') }}{% endblock %}">
-    {% include 'includes/canonical-url.html' %}
+    {% block canonical_urls %}{% include 'includes/canonical-url.html' %}{% endblock %}
     {% endblock shared_meta %}
 
     {{ l10n_css() }}

--- a/bedrock/firefox/templates/firefox/hello/start-40.0.html
+++ b/bedrock/firefox/templates/firefox/hello/start-40.0.html
@@ -12,6 +12,10 @@
   {% stylesheet 'firefox_hello_start' %}
 {% endblock %}
 
+{# Override canonical URLs so callers can share the Hello product page. #}
+{% block page_og_url %}{{ url('firefox.hello') }}{% endblock %}
+{% block canonical_urls %}{% endblock %}
+
 {% block page_title_prefix %}{% endblock %}
 {% block page_title %}{{ _('Firefox Hello') }}{% endblock %}
 {% block page_title_suffix %}{% endblock %}


### PR DESCRIPTION
While we're waiting on the status of #3198, I'd still like to get this into the existing page for Firefox 40.