### PR TITLE
Bug 1198773 - note Mayo as MoCoSC member on leadership page

### DIFF
--- a/bedrock/foundation/templates/foundation/mocosc.html
+++ b/bedrock/foundation/templates/foundation/mocosc.html
@@ -35,7 +35,7 @@
 
   <p>
     {% trans %}
-      Members of the Steering Committee as of May, 2015 are listed below.
+      Members of the Steering Committee as of August, 2015 are listed below.
     {% endtrans %}
   </p>
 
@@ -45,7 +45,7 @@
     <li><a href="https://blog.mozilla.org/press/bios/david-bryant/">David Bryant, {{ _('Interim CTO and VP, Platform Engineering') }}</a></li>
     <li><a href="https://blog.mozilla.org/press/bios/jim-cook/">Jim Cook, {{ _('Chief Finance Officer') }}</a></li>
     <li><a href="https://blog.mozilla.org/press/bios/denelle-dixon-thayer/">Denelle Dixon-Thayer, {{ _('Chief Legal and Business Officer') }}</a></li>
-    <li><a href="https://blog.mozilla.org/press/bios/david-slater/">David Slater, {{ _('Chief of Staff and SVP of Operations') }}</a></li>
     <li><a href="https://blog.mozilla.org/press/bios/mark-mayo/">Mark Mayo, {{_('Senior Vice President, Firefox')}}</a></li>
+    <li><a href="https://blog.mozilla.org/press/bios/david-slater/">David Slater, {{ _('Chief of Staff and SVP of Operations') }}</a></li>
   </ul>
 {% endblock %}

--- a/bedrock/mozorg/templates/mozorg/about/leadership.html
+++ b/bedrock/mozorg/templates/mozorg/about/leadership.html
@@ -101,6 +101,20 @@
       </li>
 
       <li class="vcard" itemscope itemtype="http://schema.org/Person">
+        <a class="url" itemprop="url" href="https://blog.mozilla.org/press/bios/mark-mayo/">
+          <img class="photo" itemprop="image" alt="" src="{{ static('img/mozorg/about/leadership/mark-mayo.jpg') }}">
+          <span class="fn" itemprop="name">Mark Mayo</span>
+        </a>
+        <span class="title" itemprop="jobTitle">{{ _('Senior Vice President, Firefox') }}</span>
+        <span class="note">{{ _('Steering Committee') }}</span>
+
+        <ul class="elsewhere">
+          <li><a class="url twitter" itemprop="url" href="https://twitter.com/mmayo">@mmayo</a></li>
+          <li><a class="url book" itemprop="url" href="https://mozillians.org/u/mmayo/">{{ _('Mozillians profile') }}</a></li>
+        </ul>
+      </li>
+
+      <li class="vcard" itemscope itemtype="http://schema.org/Person">
         <a class="url" itemprop="url" href="https://blog.mozilla.org/press/bios/david-slater/">
           <img class="photo" itemprop="image" alt="" src="{{ static('img/mozorg/about/leadership/david-slater.jpg') }}">
           <span class="fn" itemprop="name">David Slater</span>
@@ -151,19 +165,6 @@
         <ul class="elsewhere">
           <li><a class="url twitter" itemprop="url" href="https://twitter.com/kaykas">@kaykas</a></li>
           <li><a class="url book" itemprop="url" href="https://mozillians.org/u/kaykas/">{{ _('Mozillians profile') }}</a></li>
-        </ul>
-      </li>
-
-      <li class="vcard" itemscope itemtype="http://schema.org/Person">
-        <a class="url" itemprop="url" href="https://blog.mozilla.org/press/bios/mark-mayo/">
-          <img class="photo" itemprop="image" alt="" src="{{ static('img/mozorg/about/leadership/mark-mayo.jpg') }}">
-          <span class="fn" itemprop="name">Mark Mayo</span>
-        </a>
-        <span class="title" itemprop="jobTitle">{{ _('Senior Vice President, Firefox') }}</span>
-
-        <ul class="elsewhere">
-          <li><a class="url twitter" itemprop="url" href="https://twitter.com/mmayo">@mmayo</a></li>
-          <li><a class="url book" itemprop="url" href="https://mozillians.org/u/mmayo/">{{ _('Mozillians profile') }}</a></li>
         </ul>
       </li>
 


### PR DESCRIPTION
Also put steering committee members in alphabetical order.
Updated date to August, 2015.

This is a followup on #3248 making a few additional fixes, as spotted by @l-hedgehog