### PR TITLE
Fix Bug 1199621, reduce bottom padding of heading on thunderbird email providers page

### DIFF
--- a/media/css/thunderbird/features.less
+++ b/media/css/thunderbird/features.less
@@ -8,6 +8,12 @@
     line-height: 1.3;
 }
 
+#email-providers {
+    main > section {
+        margin-top: 0;
+    }
+}
+
 [role="directory"] ul {
     display: block;
     overflow: hidden;


### PR DESCRIPTION
@jpetto r? I generally do not like to use id's in CSS but, in this case it is the only way to target the specific page, as it is used by the thunderbird/features page as well.