### PR TITLE
Add woff2 config to .htaccess

### DIFF
--- a/static/.htaccess
+++ b/static/.htaccess
@@ -2,6 +2,7 @@
 AddType image/svg+xml .svg
 AddType application/octet-stream .exe
 AddType application/font-woff .woff
+AddType application/font-woff2 .woff2
 AddType application/vnd.ms-fontobject .eot
 AddType application/octet-stream .ttf
 
@@ -33,7 +34,7 @@ FileETag MTime
 </FilesMatch>
 
 # fonts
-<FilesMatch "\.(eot|svg|ttf|woff)$">
+<FilesMatch "\.(eot|svg|ttf|woff|woff2)$">
     ExpiresByType application/octet-stream "access plus 1 year"
 </FilesMatch>
 


### PR DESCRIPTION
Fwiw, we're only using `.woff2` fonts on [one page](https://www.mozilla.org/firefox/windows-10/welcome/) so far, which is only being shown a single time to Firefox users on Windows 10. But we should still add this going forward?