### PR TITLE
Fix Bug 1199916 - Make image helpers always work without img prefix

### DIFF
--- a/bedrock/base/templates/base-resp.html
+++ b/bedrock/base/templates/base-resp.html
@@ -112,7 +112,7 @@
         {% endblock %}
 
         {% block site_header_logo %}
-          <h2><a href="{{ url('mozorg.home') }}">{{ high_res_img('img/sandstone/header-mozilla-stone.png', {'alt': 'Mozilla', 'width': '170', 'height': '45'}) }}</a></h2>
+          <h2><a href="{{ url('mozorg.home') }}">{{ high_res_img('sandstone/header-mozilla-stone.png', {'alt': 'Mozilla', 'width': '170', 'height': '45'}) }}</a></h2>
         {% endblock %}
 
         {% block alt_header %}{% endblock %}

--- a/bedrock/base/templates/base.html
+++ b/bedrock/base/templates/base.html
@@ -107,7 +107,7 @@
         {% endblock %}
 
         {% block site_header_logo %}
-        <h2><a href="{{ url('mozorg.home') }}">{{ high_res_img('img/sandstone/header-mozilla-stone.png', {'alt': 'Mozilla', 'width': '170', 'height': '45'}) }}</a></h2>
+        <h2><a href="{{ url('mozorg.home') }}">{{ high_res_img('sandstone/header-mozilla-stone.png', {'alt': 'Mozilla', 'width': '170', 'height': '45'}) }}</a></h2>
         {% endblock %}
 
         {% block breadcrumbs %}{% endblock %}

--- a/bedrock/firefox/templates/firefox/all.html
+++ b/bedrock/firefox/templates/firefox/all.html
@@ -36,7 +36,7 @@
 
 {% block site_header_logo %}
   {% if channel == 'alpha' %}
-    <h2><a href="{{ url('firefox.developer') }}">{{ high_res_img('img/firefox/developer/title.png', {'alt': _('Firefox Developer Edition'), 'width': '220', 'height': '84'}) }}</a></h2>
+    <h2><a href="{{ url('firefox.developer') }}">{{ high_res_img('firefox/developer/title.png', {'alt': _('Firefox Developer Edition'), 'width': '220', 'height': '84'}) }}</a></h2>
   {% else %}
     {{ super() }}
   {% endif %}

--- a/bedrock/firefox/templates/firefox/android/index.html
+++ b/bedrock/firefox/templates/firefox/android/index.html
@@ -263,12 +263,12 @@
 
             <figure>
               <div class="media-desktop">
-                {{ high_res_img('img/firefox/android/customize/desktop-stream1.jpg', { 'alt': 'Send video content from Firefox for Android to any TV with supported streaming capabilities.'}) }}
-                {{ high_res_img('img/firefox/android/customize/desktop-stream2.jpg', { 'alt': 'Tap the screencast icon in the lower left corner of a video to begin playing it on your TV.'}) }}
-                {{ high_res_img('img/firefox/android/customize/desktop-stream3.jpg', { 'alt': 'Watch the content from your phone on your big screen TV.'}) }}
+                {{ high_res_img('firefox/android/customize/desktop-stream1.jpg', { 'alt': 'Send video content from Firefox for Android to any TV with supported streaming capabilities.'}) }}
+                {{ high_res_img('firefox/android/customize/desktop-stream2.jpg', { 'alt': 'Tap the screencast icon in the lower left corner of a video to begin playing it on your TV.'}) }}
+                {{ high_res_img('firefox/android/customize/desktop-stream3.jpg', { 'alt': 'Watch the content from your phone on your big screen TV.'}) }}
               </div>
               <div class="media-mobile">
-                {{ high_res_img('img/firefox/android/customize/mobile-stream.jpg', { 'alt': 'Send video content from Firefox for Android to any TV with supported streaming capabilities.'}) }}
+                {{ high_res_img('firefox/android/customize/mobile-stream.jpg', { 'alt': 'Send video content from Firefox for Android to any TV with supported streaming capabilities.'}) }}
               </div>
             </figure>
 
@@ -391,7 +391,7 @@
   <div id="subscribe-download-wrapper" class="ga-section" data-ga-label="Get Firefox news">
     <div class="container">
       <div id="download-wrapper" class="dl-button-wrapper {% if has_widget %}show-widget{% endif %}">
-        {{ high_res_img('img/firefox/android/firefox-logo-footer.png', { 'id': 'footer-logo' }) }}
+        {{ high_res_img('firefox/android/firefox-logo-footer.png', { 'id': 'footer-logo' }) }}
 
         <div id="download-content">
           <h3>{{ _('Choose Firefox') }}</h3>

--- a/bedrock/firefox/templates/firefox/australis/firstrun-34-tour.html
+++ b/bedrock/firefox/templates/firefox/australis/firstrun-34-tour.html
@@ -41,7 +41,7 @@
                 <li><a href="#" role="button" class="more">{{ _('Learn how to customize your Firefox') }}</a></li>
               </ul>
             </div>
-            {{ high_res_img('img/firefox/australis/diag-menu-bar.jpg', {'alt': _('The features you use most, all in one place'), 'width': '300', 'height': '188'}) }}
+            {{ high_res_img('firefox/australis/diag-menu-bar.jpg', {'alt': _('The features you use most, all in one place'), 'width': '300', 'height': '188'}) }}
           </li>
           <li class="tour-step" data-step="2" data-tip-prev="{{ _('<span>Previous:</span> Menu') }}" data-tip-next="{{ _('<span>Next:</span> Search') }}">
             <div class="tour-item">
@@ -55,7 +55,7 @@
                 <li><a href="#" role="button" class="more">{{ _('Choose how you want to search') }}</a></li>
               </ul>
             </div>
-            {{ high_res_img('img/firefox/australis/diag-customize.jpg', {'alt': _('Learn how to customize your Firefox'), 'width': '300', 'height': '188'}) }}
+            {{ high_res_img('firefox/australis/diag-customize.jpg', {'alt': _('Learn how to customize your Firefox'), 'width': '300', 'height': '188'}) }}
           </li>
           <li class="tour-step" data-step="3" data-tip-prev="{{ _('<span>Previous:</span> Customize') }}" data-tip-next="{{ _('<span>Next:</span> Bookmarks') }}">
             <div class="tour-item">
@@ -69,7 +69,7 @@
                 <li><a href="#" role="button" class="more">{{ _('Use the star to create bookmarks') }}</a></li>
               </ul>
             </div>
-            {{ high_res_img('img/firefox/australis/diag-search.jpg', {'alt': _('Search suggestions appear as you type'), 'width': '300', 'height': '188'}) }}
+            {{ high_res_img('firefox/australis/diag-search.jpg', {'alt': _('Search suggestions appear as you type'), 'width': '300', 'height': '188'}) }}
           </li>
           <li class="tour-step" data-step="4" data-tip-prev="{{ _('<span>Previous:</span> Search') }}">
             <div class="tour-item">
@@ -83,7 +83,7 @@
                 <li id="sync-link"><a href="#" role="button" class="more">{{ _('Enjoy seamless browsing between devices with Sync') }}</a></li>
               </ul>
             </div>
-            {{ high_res_img('img/firefox/australis/diag-bookmarks.jpg', {'alt': _('Use the star to create bookmarks'), 'width': '300', 'height': '188'}) }}
+            {{ high_res_img('firefox/australis/diag-bookmarks.jpg', {'alt': _('Use the star to create bookmarks'), 'width': '300', 'height': '188'}) }}
           </li>
         </ul>
         <div class="compact-title"></div>

--- a/bedrock/firefox/templates/firefox/australis/firstrun-tour.html
+++ b/bedrock/firefox/templates/firefox/australis/firstrun-tour.html
@@ -75,7 +75,7 @@
                 <li><a href="#" role="button" class="more">{{ _('Learn how to customize your Firefox') }}</a></li>
               </ul>
             </div>
-            {{ high_res_img('img/firefox/australis/diag-menu-bar.jpg', {'alt': _('The features you use most, all in one place'), 'width': '300', 'height': '188'}) }}
+            {{ high_res_img('firefox/australis/diag-menu-bar.jpg', {'alt': _('The features you use most, all in one place'), 'width': '300', 'height': '188'}) }}
           </li>
           <li class="tour-step" data-step="2" data-tip-prev="{{ _('<span>Previous:</span> Menu') }}" data-tip-next="{{ _('<span>Next:</span> Add-ons') }}">
             <div class="tour-item">
@@ -89,7 +89,7 @@
                 <li><a href="#" role="button" class="more">{{ _('Add features and styles with add-ons') }}</a></li>
               </ul>
             </div>
-            {{ high_res_img('img/firefox/australis/diag-customize.jpg', {'alt': _('Learn how to customize your Firefox'), 'width': '300', 'height': '188'}) }}
+            {{ high_res_img('firefox/australis/diag-customize.jpg', {'alt': _('Learn how to customize your Firefox'), 'width': '300', 'height': '188'}) }}
           </li>
           <li class="tour-step" data-step="3" data-tip-prev="{{ _('<span>Previous:</span> Customize') }}" data-tip-next="{{ _('<span>Next:</span> Bookmarks') }}">
             <div class="tour-item">
@@ -103,7 +103,7 @@
                 <li><a href="#" role="button" class="more">{{ _('Use the star to create bookmarks') }}</a></li>
               </ul>
             </div>
-            {{ high_res_img('img/firefox/australis/diag-addons.jpg', {'alt': _('Add features and styles with add-ons'), 'width': '300', 'height': '188'}) }}
+            {{ high_res_img('firefox/australis/diag-addons.jpg', {'alt': _('Add features and styles with add-ons'), 'width': '300', 'height': '188'}) }}
           </li>
           <li class="tour-step" data-step="4" data-tip-prev="{{ _('<span>Previous:</span> Add-ons') }}">
             <div class="tour-item">
@@ -117,7 +117,7 @@
                 <li id="sync-link"><a href="#" role="button" class="more">{{ _('Enjoy seamless browsing between devices with Sync') }}</a></li>
               </ul>
             </div>
-            {{ high_res_img('img/firefox/australis/diag-bookmarks.jpg', {'alt': _('Use the star to create bookmarks'), 'width': '300', 'height': '188'}) }}
+            {{ high_res_img('firefox/australis/diag-bookmarks.jpg', {'alt': _('Use the star to create bookmarks'), 'width': '300', 'height': '188'}) }}
           </li>
         </ul>
         <div class="compact-title"></div>

--- a/bedrock/firefox/templates/firefox/australis/fx36/firstrun-tour.html
+++ b/bedrock/firefox/templates/firefox/australis/fx36/firstrun-tour.html
@@ -57,7 +57,7 @@ data-step4="{{ _('4/4') }}"
       <h2>{{ _('Get to know Hello') }}</h2>
       <p>{{ _('Firefox Hello is the easiest way to connect with friends and family for free over video.') }}</p>
       <a id="learn-more" href="{{ url('firefox.hello') }}" class="button-flat">{{ _('Learn more') }}</a>
-      <p id="powered-by">{{ _('Powered by %s')|format(high_res_img('img/firefox/hello/tef-logo.png', {'alt': 'Telefonica', 'width': '106', 'height': '29'})) }}</p>
+      <p id="powered-by">{{ _('Powered by %s')|format(high_res_img('firefox/hello/tef-logo.png', {'alt': 'Telefonica', 'width': '106', 'height': '29'})) }}</p>
     </div>
     <div class="promo-media">
       {% include 'firefox/includes/hello-animation.html' %}
@@ -98,7 +98,7 @@ data-step4="{{ _('4/4') }}"
                 <li><a href="#" role="button" class="more">{{ _('Connect with anyone over video right from Firefox') }}</a></li>
               </ul>
             </div>
-            {{ high_res_img('img/firefox/australis/diag-menu-bar.jpg', {'alt': _('The features you use most, all in one place'), 'width': '300', 'height': '188'}) }}
+            {{ high_res_img('firefox/australis/diag-menu-bar.jpg', {'alt': _('The features you use most, all in one place'), 'width': '300', 'height': '188'}) }}
           </li>
           <li class="tour-step" data-step="2" data-tip-prev="{{ _('<span>Previous:</span> Menu') }}" data-tip-next="{{ _('<span>Next:</span> Search') }}">
             <div class="tour-item">
@@ -111,7 +111,7 @@ data-step4="{{ _('4/4') }}"
                 <li><a href="#" role="button" class="more">{{ _('Choose how you want to search') }}</a></li>
               </ul>
             </div>
-            {{ high_res_img('img/firefox/australis/hello-1.png', {'alt': _('Connect with anyone over video right from Firefox'), 'width': '240', 'height': '178', 'id': 'hello-img-1'}) }}
+            {{ high_res_img('firefox/australis/hello-1.png', {'alt': _('Connect with anyone over video right from Firefox'), 'width': '240', 'height': '178', 'id': 'hello-img-1'}) }}
           </li>
           <li class="tour-step" data-step="3" data-tip-prev="{{ _('<span>Previous:</span> Firefox Hello') }}" data-tip-next="{{ _('<span>Next:</span> Bookmarks') }}">
             <div class="tour-item">
@@ -125,7 +125,7 @@ data-step4="{{ _('4/4') }}"
                 <li><a href="#" role="button" class="more">{{ _('Use the star to create bookmarks') }}</a></li>
               </ul>
             </div>
-            {{ high_res_img('img/firefox/australis/diag-search.jpg', {'alt': _('Search suggestions appear as you type'), 'width': '300', 'height': '188'}) }}
+            {{ high_res_img('firefox/australis/diag-search.jpg', {'alt': _('Search suggestions appear as you type'), 'width': '300', 'height': '188'}) }}
           </li>
           <li class="tour-step" data-step="4" data-tip-prev="{{ _('<span>Previous:</span> Search') }}">
             <div class="tour-item">
@@ -138,7 +138,7 @@ data-step4="{{ _('4/4') }}"
                 <li>{{ _('Save sites with a single click') }}</li>
               </ul>
             </div>
-            {{ high_res_img('img/firefox/australis/diag-bookmarks.jpg', {'alt': _('Use the star to create bookmarks'), 'width': '300', 'height': '188'}) }}
+            {{ high_res_img('firefox/australis/diag-bookmarks.jpg', {'alt': _('Use the star to create bookmarks'), 'width': '300', 'height': '188'}) }}
           </li>
         </ul>
         <div class="compact-title"></div>

--- a/bedrock/firefox/templates/firefox/australis/fx36/whatsnew-tour.html
+++ b/bedrock/firefox/templates/firefox/australis/fx36/whatsnew-tour.html
@@ -52,7 +52,7 @@ data-has-tour="True"
   <article class="promo whatsnew">
     <div class="promo-copy">
       <a id="learn-more" href="{{ url('firefox.hello') }}" class="button-flat">{{ _('Learn more') }}</a>
-      <p id="powered-by">{{ _('Powered by %s')|format(high_res_img('img/firefox/hello/tef-logo.png', {'alt': 'Telefonica', 'width': '106', 'height': '29'})) }}</p>
+      <p id="powered-by">{{ _('Powered by %s')|format(high_res_img('firefox/hello/tef-logo.png', {'alt': 'Telefonica', 'width': '106', 'height': '29'})) }}</p>
     </div>
     <div class="promo-media">
       {% include 'firefox/includes/hello-animation.html' %}
@@ -96,7 +96,7 @@ data-has-tour="True"
               <div class="hello-added-door-hanger" data-title="{{ _('Perfect!') }}" data-text="{{ _('Now using Hello will be even easier. To move or remove the icon, just open the menu and select Customize.') }}" data-try="{{ _('Try it now') }}"></div>
               <div class="hello-later-door-hanger" data-title="{{ _('Want to add it later?') }}" data-text="{{ _('No problem. Just open this menu, select Customize and simply drag the Hello icon into your toolbar.') }}"></div>
             </div>
-            {{ high_res_img('img/firefox/australis/hello-1.png', {'alt': '', 'width': '240', 'height': '178', 'id': 'hello-img-1'}) }}
+            {{ high_res_img('firefox/australis/hello-1.png', {'alt': '', 'width': '240', 'height': '178', 'id': 'hello-img-1'}) }}
           </li>
           <li class="tour-step" data-step="2" data-tip-prev="{{ _('<span>Previous:</span> Firefox Hello') }}">
             <div class="tour-item">
@@ -110,7 +110,7 @@ data-has-tour="True"
               </ul>
               <div class="hello-reminder-door-hanger step-target" data-title="{{ _('Here when you need it') }}" data-text="{{ _('Start and join conversations right from your toolbar.') }}"></div>
             </div>
-            {{ high_res_img('img/firefox/australis/hello-2.png', {'alt': '', 'width': '240', 'height': '178', 'id': 'hello-img-2'}) }}
+            {{ high_res_img('firefox/australis/hello-2.png', {'alt': '', 'width': '240', 'height': '178', 'id': 'hello-img-2'}) }}
           </li>
         </ul>
         <div class="compact-title"></div>

--- a/bedrock/firefox/templates/firefox/australis/fx38_0_5/firstrun.html
+++ b/bedrock/firefox/templates/firefox/australis/fx38_0_5/firstrun.html
@@ -50,7 +50,7 @@
 <section id="intro">
   <div class="container">
     <div id="logo">
-      {{ high_res_img('img/firefox/australis/fx38.0.5/firefox-logo.png', {'alt': 'Firefox', 'width': '142', 'height': '147'}) }}
+      {{ high_res_img('firefox/australis/fx38.0.5/firefox-logo.png', {'alt': 'Firefox', 'width': '142', 'height': '147'}) }}
     </div>
 
     <div class="leftcol">
@@ -69,7 +69,7 @@
     </div>
 
     <div class="rightcol">
-      {{ high_res_img('img/firefox/australis/fx38.0.5/sync.png', {'alt': 'Firefox Sync', 'width': '219', 'height': '118'}) }}
+      {{ high_res_img('firefox/australis/fx38.0.5/sync.png', {'alt': 'Firefox Sync', 'width': '219', 'height': '118'}) }}
       <a href="{{ url('firefox.sync') }}" id="cta-signup" class="button-flat-green">{{ _('Create a Firefox Account') }}</a>
       <a id="cta-signin" rel="external" href="https://support.mozilla.org/kb/how-do-i-set-up-firefox-sync">{{ _('Already have one? Sign in.') }}</a>
     </div>

--- a/bedrock/firefox/templates/firefox/australis/fx40/firstrun.html
+++ b/bedrock/firefox/templates/firefox/australis/fx40/firstrun.html
@@ -50,7 +50,7 @@
 <section id="intro" data-fxa-iframe-src="{{ settings.FXA_IFRAME_SRC }}">
   <div class="container">
     <div id="logo">
-      {{ high_res_img('img/firefox/australis/fx38.0.5/firefox-logo.png', {'alt': 'Firefox', 'width': '142', 'height': '147'}) }}
+      {{ high_res_img('firefox/australis/fx38.0.5/firefox-logo.png', {'alt': 'Firefox', 'width': '142', 'height': '147'}) }}
     </div>
 
     <div class="leftcol">

--- a/bedrock/firefox/templates/firefox/australis/whatsnew-tour.html
+++ b/bedrock/firefox/templates/firefox/australis/whatsnew-tour.html
@@ -75,7 +75,7 @@
                 <li><a href="#" role="button" class="more">{{ _('Learn how to customize your Firefox') }}</a></li>
               </ul>
             </div>
-            {{ high_res_img('img/firefox/australis/diag-menu-bar.jpg', {'alt': _('Your favorite features, all in one place'), 'width': '300', 'height': '188'}) }}
+            {{ high_res_img('firefox/australis/diag-menu-bar.jpg', {'alt': _('Your favorite features, all in one place'), 'width': '300', 'height': '188'}) }}
           </li>
           <li class="tour-step app-menu" data-step="2" data-tip-prev="{{ _('<span>Previous:</span> Menu') }}" data-tip-next="{{ _('<span>Next:</span> Add-ons') }}">
             <div class="tour-item">
@@ -89,7 +89,7 @@
                 <li><a href="#" role="button" class="more">{{ _('Add features and styles with add-ons') }}</a></li>
               </ul>
             </div>
-            {{ high_res_img('img/firefox/australis/diag-customize.jpg', {'alt': _('Learn how to customize your Firefox'), 'width': '300', 'height': '188'}) }}
+            {{ high_res_img('firefox/australis/diag-customize.jpg', {'alt': _('Learn how to customize your Firefox'), 'width': '300', 'height': '188'}) }}
           </li>
           <li class="tour-step app-menu" data-step="3" data-tip-prev="{{ _('<span>Previous:</span> Customize') }}" data-tip-next="{{ _('<span>Next:</span> Bookmarks') }}">
             <div class="tour-item">
@@ -103,7 +103,7 @@
                 <li><a href="#" role="button" class="more">{{ _('Use the star to create bookmarks') }}</a></li>
               </ul>
             </div>
-            {{ high_res_img('img/firefox/australis/diag-addons.jpg', {'alt': _('Add features and styles with add-ons'), 'width': '300', 'height': '188'}) }}
+            {{ high_res_img('firefox/australis/diag-addons.jpg', {'alt': _('Add features and styles with add-ons'), 'width': '300', 'height': '188'}) }}
           </li>
           <li class="tour-step" data-step="4" data-tip-prev="{{ _('<span>Previous:</span> Add-ons') }}">
             <div class="tour-item">
@@ -117,7 +117,7 @@
                 <li id="sync-link"><a href="#" role="button" class="more">{{ _('Enjoy seamless browsing between devices with Sync') }}</a></li>
               </ul>
             </div>
-            {{ high_res_img('img/firefox/australis/diag-bookmarks.jpg', {'alt': _('Use the star to create bookmarks'), 'width': '300', 'height': '188'}) }}
+            {{ high_res_img('firefox/australis/diag-bookmarks.jpg', {'alt': _('Use the star to create bookmarks'), 'width': '300', 'height': '188'}) }}
           </li>
         </ul>
         <div class="compact-title"></div>

--- a/bedrock/firefox/templates/firefox/base-resp.html
+++ b/bedrock/firefox/templates/firefox/base-resp.html
@@ -26,7 +26,7 @@
 {% endblock %}
 
 {% block site_header_logo %}
-<h2><a href="{{ url('firefox') }}">{{ high_res_img('img/firefox/template/header-logo.png', {'alt': 'Mozilla Firefox', 'width': '185', 'height': '70'}) }}</a></h2>
+<h2><a href="{{ url('firefox') }}">{{ high_res_img('firefox/template/header-logo.png', {'alt': 'Mozilla Firefox', 'width': '185', 'height': '70'}) }}</a></h2>
 {% endblock %}
 
 {% block site_js %}

--- a/bedrock/firefox/templates/firefox/base.html
+++ b/bedrock/firefox/templates/firefox/base.html
@@ -24,7 +24,7 @@
 {% endblock %}
 
 {% block site_header_logo %}
-<h2><a href="{{ url('firefox') }}">{{ high_res_img('img/firefox/template/header-logo.png', {'alt': 'Mozilla Firefox', 'width': '185', 'height': '70'}) }}</a></h2>
+<h2><a href="{{ url('firefox') }}">{{ high_res_img('firefox/template/header-logo.png', {'alt': 'Mozilla Firefox', 'width': '185', 'height': '70'}) }}</a></h2>
 {% endblock %}
 
 {% block site_js %}

--- a/bedrock/firefox/templates/firefox/channel.html
+++ b/bedrock/firefox/templates/firefox/channel.html
@@ -29,7 +29,7 @@
 {% endblock %}
 
 {% block site_header_logo %}
-<h2><a href="{{ url('firefox') }}">{{ high_res_img('img/firefox/template/header-logo.png', {
+<h2><a href="{{ url('firefox') }}">{{ high_res_img('firefox/template/header-logo.png', {
   'alt': 'Mozilla Firefox',
   'width': '185',
   'height': '70',
@@ -54,7 +54,7 @@
   <div class="pager-content">
 
     <div id="beta" class="pager-page">
-      <h2 class="channel-title channel-title-beta">{{ high_res_img('img/firefox/channel/title-beta.png', {'alt': 'Firefox Beta', 'width': '441', 'height': '74'}) }}</h2>
+      <h2 class="channel-title channel-title-beta">{{ high_res_img('firefox/channel/title-beta.png', {'alt': 'Firefox Beta', 'width': '441', 'height': '74'}) }}</h2>
       {# L10n: This description applies to Firefox Beta #}
       <h3>{{_('The latest features in a more stable environment')}}</h3>
       <div class="download-box" id="beta-desktop">
@@ -78,7 +78,7 @@
     </div>
 
     <div id="firefox" class="pager-page">
-      <h2 class="channel-title channel-title-firefox">{{ high_res_img('img/firefox/channel/title-firefox.png', {'alt': 'Firefox', 'width': '258', 'height': '74'}) }}</h2>
+      <h2 class="channel-title channel-title-firefox">{{ high_res_img('firefox/channel/title-firefox.png', {'alt': 'Firefox', 'width': '258', 'height': '74'}) }}</h2>
       {# L10n: This description applies to Firefox on the Release channel #}
       <h3>{{_('Tried, tested and used by millions around the world')}}</h3>
       <div class="download-box" id="firefox-desktop">
@@ -91,7 +91,7 @@
     </div>
 
     <div id="developer" class="pager-page">
-      <h2 class="channel-title channel-title-aurora">{{ high_res_img('img/firefox/channel/title-dev.png', {'alt': 'Firefox Developer Edition', 'width': '214', 'height': '100'}) }}</h2>
+      <h2 class="channel-title channel-title-aurora">{{ high_res_img('firefox/channel/title-dev.png', {'alt': 'Firefox Developer Edition', 'width': '214', 'height': '100'}) }}</h2>
       {# L10n: This description applies to Firefox Developer Edition #}
       {% if l10n_has_tag('channel_dev_edition') %}
         <h3>{{_('Built for those who build the Web')}}</h3>

--- a/bedrock/firefox/templates/firefox/desktop/customize.html
+++ b/bedrock/firefox/templates/firefox/desktop/customize.html
@@ -55,7 +55,7 @@
           {{ _('Keep your favorite features — add-ons, private browsing, Sync and more — one quick click away.') }}
         </p>
 
-        {{ high_res_img('img/firefox/desktop/customize/designed-redesigned.png', { 'alt': '', 'id': 'designed-mobile'}) }}
+        {{ high_res_img('firefox/desktop/customize/designed-redesigned.png', { 'alt': '', 'id': 'designed-mobile'}) }}
       </div>
       <div class="animation-wrapper" id="flexible-bottom-animation">
         <img src="{{ static('img/firefox/desktop/customize/animations/flexible-bottom-fallback.png') }}" class="fallback" alt="">

--- a/bedrock/firefox/templates/firefox/dev-firstrun.html
+++ b/bedrock/firefox/templates/firefox/dev-firstrun.html
@@ -65,7 +65,7 @@ data-sync-icon-high-res="{{ static('img/firefox/dev-firstrun/sync-blue-high-res.
 
 {% block site_header_nav %}{% endblock %}
 {% block site_header_logo %}
-  <h2>{{ high_res_img('img/firefox/firstrun/dev/title.png', {'alt': _('Firefox Developer Edition'), 'width': '220', 'height': '84'}) }}</h2>
+  <h2>{{ high_res_img('firefox/firstrun/dev/title.png', {'alt': _('Firefox Developer Edition'), 'width': '220', 'height': '84'}) }}</h2>
 {% endblock %}
 
 {% block content %}

--- a/bedrock/firefox/templates/firefox/dev-whatsnew.html
+++ b/bedrock/firefox/templates/firefox/dev-whatsnew.html
@@ -31,7 +31,7 @@
 
 {% block site_header_nav %}{% endblock %}
 {% block site_header_logo %}
-  <h2>{{ high_res_img('img/firefox/firstrun/dev/title.png', {'alt': _('Firefox Developer Edition'), 'width': '220', 'height': '84'}) }}</h2>
+  <h2>{{ high_res_img('firefox/firstrun/dev/title.png', {'alt': _('Firefox Developer Edition'), 'width': '220', 'height': '84'}) }}</h2>
 {% endblock %}
 
 {% block content %}

--- a/bedrock/firefox/templates/firefox/developer.html
+++ b/bedrock/firefox/templates/firefox/developer.html
@@ -20,7 +20,7 @@
 {% block body_class %}blueprint{% endblock %}
 
 {% block site_header_logo %}
-  <h2>{{ high_res_img('img/firefox/developer/title.png', {'alt': _('Firefox Developer Edition'), 'width': '220', 'height': '84'}) }}</h2>
+  <h2>{{ high_res_img('firefox/developer/title.png', {'alt': _('Firefox Developer Edition'), 'width': '220', 'height': '84'}) }}</h2>
 {% endblock %}
 
 

--- a/bedrock/firefox/templates/firefox/family/index.html
+++ b/bedrock/firefox/templates/firefox/family/index.html
@@ -69,9 +69,9 @@
   <div class="content">
     <h1>
     {% if LANG.startswith('en') %}
-      <span><b>Free</b> yourself</span> with {{ high_res_img('img/firefox/family/index/firefox-wordmark.png', {'alt': 'Firefox', 'width': '330', 'height': '95'}) }}
+      <span><b>Free</b> yourself</span> with {{ high_res_img('firefox/family/index/firefox-wordmark.png', {'alt': 'Firefox', 'width': '330', 'height': '95'}) }}
     {% else %}
-      {{ _('Free yourself with %s')|format(high_res_img('img/firefox/family/index/firefox-wordmark.png', {'alt': 'Firefox', 'width': '330', 'height': '95'})) }}
+      {{ _('Free yourself with %s')|format(high_res_img('firefox/family/index/firefox-wordmark.png', {'alt': 'Firefox', 'width': '330', 'height': '95'})) }}
     {% endif %}
     </h1>
   </div>{#-- /.content --#}

--- a/bedrock/firefox/templates/firefox/hello/index.html
+++ b/bedrock/firefox/templates/firefox/hello/index.html
@@ -134,7 +134,7 @@ data-try-now="{{ _('Try it now') }}"
       <button class="try-hello" id="try-hello-intro">{{ _('Try Firefox Hello') }}</button>
 
       <aside id="powered-by">
-        {{ _('Powered by %s')|format(high_res_img('img/firefox/hello/tef-logo.png', {'alt': 'Telefonica', 'width': '106', 'height': '29'})) }}
+        {{ _('Powered by %s')|format(high_res_img('firefox/hello/tef-logo.png', {'alt': 'Telefonica', 'width': '106', 'height': '29'})) }}
       </aside>
 
       {{ share_cta(_('Share'), share_urls, _('Meet Firefox Hello, the easiest way to connect for free over video with anyone, anywhere.'), 'spread-hello', 'sky mini') }}

--- a/bedrock/firefox/templates/firefox/includes/hello-animation.html
+++ b/bedrock/firefox/templates/firefox/includes/hello-animation.html
@@ -1,5 +1,5 @@
 <div id="hello-animation-stage">
-  {{ high_res_img('img/firefox/australis/hello-2.png', {'alt': 'Firefox Hello', 'width': '300', 'height': '188', 'id': 'hello-animation-fallback'}) }}
+  {{ high_res_img('firefox/australis/hello-2.png', {'alt': 'Firefox Hello', 'width': '300', 'height': '188', 'id': 'hello-animation-fallback'}) }}
 
   <div id="hello-conversation">
     <div class="hello-sprite hello-message" id="hello-message-blue1"></div>

--- a/bedrock/firefox/templates/firefox/independent.html
+++ b/bedrock/firefox/templates/firefox/independent.html
@@ -67,7 +67,7 @@
     <div class="container">
 
       <div class="accolade pcworld">
-        {{ high_res_img('img/firefox/independent/logo-pcworld.png', {'alt': 'PC World', 'width': '184', 'height': '54'}) }}
+        {{ high_res_img('firefox/independent/logo-pcworld.png', {'alt': 'PC World', 'width': '184', 'height': '54'}) }}
         {# L10n: This will be used for image alt text. #}
         <p class="stars stars-four">{{ _('Four stars') }}</p>
         <p class="quote">{{ _('“Magnificent”') }}</p>
@@ -78,7 +78,7 @@
       </div>
 
       <div class="accolade cnet">
-        {{ high_res_img('img/firefox/independent/logo-cnet.png', {'alt': 'C|Net', 'width': '147', 'height': '147'}) }}
+        {{ high_res_img('firefox/independent/logo-cnet.png', {'alt': 'C|Net', 'width': '147', 'height': '147'}) }}
         {# L10n: This will be used for image alt text. #}
         <p class="stars stars-five">{{ _('Five stars') }}</p>
         <p class="quote">{{ _('“Spectacular”') }}</p>

--- a/bedrock/firefox/templates/firefox/new.html
+++ b/bedrock/firefox/templates/firefox/new.html
@@ -29,7 +29,7 @@
 
 {% block site_header_nav %}{% endblock %}
 {% block site_header_logo %}
-  <h2>{{ high_res_img('img/firefox/new/header-firefox.png', {'alt': _('Firefox for desktop'), 'width': '223', 'height': '84'}) }}</h2>
+  <h2>{{ high_res_img('firefox/new/header-firefox.png', {'alt': _('Firefox for desktop'), 'width': '223', 'height': '84'}) }}</h2>
 {% endblock %}
 
 {% block site_css %}{% endblock %}
@@ -157,7 +157,7 @@
         </div>
 
         <div class="desktop" id="firefox-screenshot">
-          {{ platform_img('img/firefox/new/browser.png', {'alt': _('Firefox screenshot'), 'high-res': True}) }}
+          {{ platform_img('firefox/new/browser.png', {'alt': _('Firefox screenshot'), 'high-res': True}) }}
         </div>
 
         <div id="newsletter-latest">

--- a/bedrock/firefox/templates/firefox/new2.html
+++ b/bedrock/firefox/templates/firefox/new2.html
@@ -31,7 +31,7 @@
 
 {% block site_header_nav %}{% endblock %}
 {% block site_header_logo %}
-  <h2>{{ high_res_img('img/firefox/new/header-firefox.png', {'alt': _('Firefox for desktop'), 'width': '223', 'height': '84'}) }}</h2>
+  <h2>{{ high_res_img('firefox/new/header-firefox.png', {'alt': _('Firefox for desktop'), 'width': '223', 'height': '84'}) }}</h2>
 {% endblock %}
 
 {# all CSS must be in extrahead block for old IE #}
@@ -160,7 +160,7 @@
       </div>
 
       <div class="desktop" id="firefox-screenshot">
-        {{ platform_img('img/firefox/new/2/browser.png', {'alt': _('Firefox screenshot'), 'high-res': True}) }}
+        {{ platform_img('firefox/new/2/browser.png', {'alt': _('Firefox screenshot'), 'high-res': True}) }}
       </div>
 
       <div id="newsletter-latest">

--- a/bedrock/firefox/templates/firefox/organizations/faq.html
+++ b/bedrock/firefox/templates/firefox/organizations/faq.html
@@ -9,7 +9,7 @@
 {% block body_id %}organizations-faq{% endblock %}
 
 {% block site_header_logo %}
-<h1><a href="{{ url('firefox.organizations.organizations') }}">{{ high_res_img('img/firefox/organizations/title.png', {'alt': _('Firefox ESR'), 'width': '253', 'height': '70'}) }}</a></h1>
+<h1><a href="{{ url('firefox.organizations.organizations') }}">{{ high_res_img('firefox/organizations/title.png', {'alt': _('Firefox ESR'), 'width': '253', 'height': '70'}) }}</a></h1>
 {% endblock %}
 
 {% block main_feature %}
@@ -58,7 +58,7 @@
 {% endtrans %}
 </p>
 
-<p><a href="{{ static('img/firefox/organizations/release-overview-high-res.png') }}">{{ high_res_img('img/firefox/organizations/release-overview.png', {'alt': _('Firefox ESR Release Overview'), 'width': '832', 'height': '384', 'id': 'release-overview'}) }}</a></p>
+<p><a href="{{ static('img/firefox/organizations/release-overview-high-res.png') }}">{{ high_res_img('firefox/organizations/release-overview.png', {'alt': _('Firefox ESR Release Overview'), 'width': '832', 'height': '384', 'id': 'release-overview'}) }}</a></p>
 
 <p>
 {% trans %}

--- a/bedrock/firefox/templates/firefox/organizations/organizations.html
+++ b/bedrock/firefox/templates/firefox/organizations/organizations.html
@@ -17,7 +17,7 @@
 {% endblock %}
 
 {% block site_header_logo %}
-<h2><a href="{{ url('firefox.organizations.organizations') }}">{{ high_res_img('img/firefox/organizations/title.png', {'alt': _('Firefox ESR'), 'width': '253', 'height': '70'}) }}</a></h2>
+<h2><a href="{{ url('firefox.organizations.organizations') }}">{{ high_res_img('firefox/organizations/title.png', {'alt': _('Firefox ESR'), 'width': '253', 'height': '70'}) }}</a></h2>
 {% endblock %}
 
 

--- a/bedrock/firefox/templates/firefox/os/index.html
+++ b/bedrock/firefox/templates/firefox/os/index.html
@@ -129,63 +129,63 @@
         </ul>
         <ul class="apps">
           <li class="connected entertained">
-            {{ high_res_img('img/firefox/os-new/icons/browser.png', {'alt': '', 'width': '142', 'height': '142'}) }}
+            {{ high_res_img('firefox/os-new/icons/browser.png', {'alt': '', 'width': '142', 'height': '142'}) }}
             <span>{{_('Browser')}}</span>
           </li>
           <li class="organized">
-            {{ high_res_img('img/firefox/os-new/icons/calendar.png', {'alt': '', 'width': '142', 'height': '142'}) }}
+            {{ high_res_img('firefox/os-new/icons/calendar.png', {'alt': '', 'width': '142', 'height': '142'}) }}
             <span>{{_('Calendar')}}</span>
           </li>
           <li class="entertained">
-            {{ high_res_img('img/firefox/os-new/icons/camera.png', {'alt': '', 'width': '142', 'height': '142'}) }}
+            {{ high_res_img('firefox/os-new/icons/camera.png', {'alt': '', 'width': '142', 'height': '142'}) }}
             <span>{{_('Camera')}}</span>
           </li>
           <li class="organized">
-            {{ high_res_img('img/firefox/os-new/icons/clock.png', {'alt': '', 'width': '142', 'height': '142'}) }}
+            {{ high_res_img('firefox/os-new/icons/clock.png', {'alt': '', 'width': '142', 'height': '142'}) }}
             <span>{{_('Clock')}}</span>
           </li>
           <li class="connected organized">
-            {{ high_res_img('img/firefox/os-new/icons/contacts.png', {'alt': '', 'width': '142', 'height': '142'}) }}
+            {{ high_res_img('firefox/os-new/icons/contacts.png', {'alt': '', 'width': '142', 'height': '142'}) }}
             <span>{{_('Contacts')}}</span>
           </li>
           <li class="connected">
-            {{ high_res_img('img/firefox/os-new/icons/email.png', {'alt': '', 'width': '142', 'height': '142'}) }}
+            {{ high_res_img('firefox/os-new/icons/email.png', {'alt': '', 'width': '142', 'height': '142'}) }}
             <span>{{_('E-Mail')}}</span>
           </li>
           <li class="entertained">
-            {{ high_res_img('img/firefox/os-new/icons/fmradio.png', {'alt': '', 'width': '142', 'height': '142'}) }}
+            {{ high_res_img('firefox/os-new/icons/fmradio.png', {'alt': '', 'width': '142', 'height': '142'}) }}
             <span>{{_('FM Radio')}}</span>
           </li>
           <li class="entertained organized">
-            {{ high_res_img('img/firefox/os-new/icons/gallery.png', {'alt': '', 'width': '142', 'height': '142'}) }}
+            {{ high_res_img('firefox/os-new/icons/gallery.png', {'alt': '', 'width': '142', 'height': '142'}) }}
             <span>{{_('Gallery')}}</span>
           </li>
           <li class="connected entertained organized">
-            {{ high_res_img('img/firefox/os-new/icons/marketplace.png', {'alt': '', 'width': '142', 'height': '142'}) }}
+            {{ high_res_img('firefox/os-new/icons/marketplace.png', {'alt': '', 'width': '142', 'height': '142'}) }}
             <span>{{_('Marketplace')}}</span>
           </li>
           <li class="connected">
-            {{ high_res_img('img/firefox/os-new/icons/sms.png', {'alt': '', 'width': '142', 'height': '142'}) }}
+            {{ high_res_img('firefox/os-new/icons/sms.png', {'alt': '', 'width': '142', 'height': '142'}) }}
             <span>{{_('Messages')}}</span>
           </li>
           <li class="entertained">
-            {{ high_res_img('img/firefox/os-new/icons/music.png', {'alt': '', 'width': '142', 'height': '142'}) }}
+            {{ high_res_img('firefox/os-new/icons/music.png', {'alt': '', 'width': '142', 'height': '142'}) }}
             <span>{{_('Music')}}</span>
           </li>
           <li class="connected">
-            {{ high_res_img('img/firefox/os-new/icons/dialer.png', {'alt': '', 'width': '142', 'height': '142'}) }}
+            {{ high_res_img('firefox/os-new/icons/dialer.png', {'alt': '', 'width': '142', 'height': '142'}) }}
             <span>{{_('Phone')}}</span>
           </li>
           <li class="organized">
-            {{ high_res_img('img/firefox/os-new/icons/settings.png', {'alt': '', 'width': '142', 'height': '142'}) }}
+            {{ high_res_img('firefox/os-new/icons/settings.png', {'alt': '', 'width': '142', 'height': '142'}) }}
             <span>{{_('Settings')}}</span>
           </li>
           <li class="organized">
-            {{ high_res_img('img/firefox/os-new/icons/usage.png', {'alt': '', 'width': '142', 'height': '142'}) }}
+            {{ high_res_img('firefox/os-new/icons/usage.png', {'alt': '', 'width': '142', 'height': '142'}) }}
             <span>{{_('Usage')}}</span>
           </li>
           <li class="entertained">
-            {{ high_res_img('img/firefox/os-new/icons/video.png', {'alt': '', 'width': '142', 'height': '142'}) }}
+            {{ high_res_img('firefox/os-new/icons/video.png', {'alt': '', 'width': '142', 'height': '142'}) }}
             <span>{{_('Video')}}</span>
           </li>
         </ul>
@@ -227,7 +227,7 @@
 
     <section class="fxos-community">
       <div class="content-wrapper">
-        {{ high_res_img('img/firefox/os-new/mozilla-groupshot.png', {'alt': '', 'width': '260', 'height': '260'}) }}
+        {{ high_res_img('firefox/os-new/mozilla-groupshot.png', {'alt': '', 'width': '260', 'height': '260'}) }}
         <h2>{{_('Powered by the Mozilla community')}}</h2>
         <p>{{_('Mozilla is a non-profit organization fueled by a passionate global community. Together, we’re able to create and innovate with local interests in mind, while making the Web better and more accessible for everyone everywhere.')}}</p>
         <p><a class="more" href="{{ url('mozorg.home') }}">{{_('Learn more about Mozilla')}}</a></p>

--- a/bedrock/firefox/templates/firefox/os/mwc-2015-preview.html
+++ b/bedrock/firefox/templates/firefox/os/mwc-2015-preview.html
@@ -49,7 +49,7 @@
           {{ _('Come and partner with Firefox OS — the most exciting new platform in mobile.') }}
         </p>
 
-        {{ high_res_img('img/firefox/os/mwc-2015-preview/mwc-logo.png', {'alt': 'Mobile World Congress', 'width': '168', 'height': '68'}) }}
+        {{ high_res_img('firefox/os/mwc-2015-preview/mwc-logo.png', {'alt': 'Mobile World Congress', 'width': '168', 'height': '68'}) }}
       </div>
       <div id="intro-phone">
         <img src="{{ static('img/firefox/os/mwc-2015-preview/phone-fox.png') }}" alt="" />
@@ -91,29 +91,29 @@
     <div class="container">
       <h3>{{ _('Be part of our growing family of partners') }}</h3>
       <ul id="list-partners">
-        <li>{{ high_res_img('img/firefox/os/mwc-2015-preview/partners/orange.png', {'alt': 'Orange', 'width': '220', 'height': '100'}) }}</li>
-        <li>{{ high_res_img('img/firefox/os/mwc-2015-preview/partners/verizon.png', {'alt': 'Verizon', 'width': '220', 'height': '100'}) }}</li>
-        <li>{{ high_res_img('img/firefox/os/mwc-2015-preview/partners/mtn.png', {'alt': 'MTN', 'width': '220', 'height': '100'}) }}</li>
-        <li>{{ high_res_img('img/firefox/os/mwc-2015-preview/partners/alcatel.png', {'alt': 'Alcatel OneTouch', 'width': '220', 'height': '100'}) }}</li>
-        <li>{{ high_res_img('img/firefox/os/mwc-2015-preview/partners/america-movil.png', {'alt': 'America Movil', 'width': '220', 'height': '100'}) }}</li>
-        <li>{{ high_res_img('img/firefox/os/mwc-2015-preview/partners/cherry-mobile.png', {'alt': 'Cherry Mobile', 'width': '220', 'height': '100'}) }}</li>
-        <li>{{ high_res_img('img/firefox/os/mwc-2015-preview/partners/deutsche-telekom.png', {'alt': 'Deutsche Telekom', 'width': '220', 'height': '100'}) }}</li>
-        <li>{{ high_res_img('img/firefox/os/mwc-2015-preview/partners/grameenphone.png', {'alt': 'GrameenPhone', 'width': '220', 'height': '100'}) }}</li>
-        <li>{{ high_res_img('img/firefox/os/mwc-2015-preview/partners/huawei.png', {'alt': 'Huawei', 'width': '220', 'height': '100'}) }}</li>
-        <li>{{ high_res_img('img/firefox/os/mwc-2015-preview/partners/intex.png', {'alt': 'Intex', 'width': '220', 'height': '100'}) }}</li>
-        <li>{{ high_res_img('img/firefox/os/mwc-2015-preview/partners/kddi.png', {'alt': 'KDDI', 'width': '220', 'height': '100'}) }}</li>
-        <li>{{ high_res_img('img/firefox/os/mwc-2015-preview/partners/lg.png', {'alt': 'LG', 'width': '220', 'height': '100'}) }}</li>
-        <li>{{ high_res_img('img/firefox/os/mwc-2015-preview/partners/megafon.png', {'alt': 'MegaFon', 'width': '220', 'height': '100'}) }}</li>
-        <li>{{ high_res_img('img/firefox/os/mwc-2015-preview/partners/panasonic.png', {'alt': 'Panasonic', 'width': '220', 'height': '100'}) }}</li>
-        <li>{{ high_res_img('img/firefox/os/mwc-2015-preview/partners/qualcomm.png', {'alt': 'Qualcomm', 'width': '220', 'height': '100'}) }}</li>
-        <li>{{ high_res_img('img/firefox/os/mwc-2015-preview/partners/spice.png', {'alt': 'Spice', 'width': '220', 'height': '100'}) }}</li>
-        <li>{{ high_res_img('img/firefox/os/mwc-2015-preview/partners/spreadtrum.png', {'alt': 'Spreadtrum', 'width': '220', 'height': '100'}) }}</li>
-        <li>{{ high_res_img('img/firefox/os/mwc-2015-preview/partners/symphony.png', {'alt': 'Symphony', 'width': '220', 'height': '100'}) }}</li>
-        <li>{{ high_res_img('img/firefox/os/mwc-2015-preview/partners/telecom-italia.png', {'alt': 'Telecom Italia', 'width': '220', 'height': '100'}) }}</li>
-        <li>{{ high_res_img('img/firefox/os/mwc-2015-preview/partners/telefonica.png', {'alt': 'Telefonica', 'width': '220', 'height': '100'}) }}</li>
-        <li>{{ high_res_img('img/firefox/os/mwc-2015-preview/partners/telenor.png', {'alt': 'Telenor', 'width': '220', 'height': '100'}) }}</li>
-        <li>{{ high_res_img('img/firefox/os/mwc-2015-preview/partners/zen-mobile.png', {'alt': 'ZEN Mobile', 'width': '220', 'height': '100'}) }}</li>
-        <li>{{ high_res_img('img/firefox/os/mwc-2015-preview/partners/zte.png', {'alt': 'ZTE', 'width': '220', 'height': '100'}) }}</li>
+        <li>{{ high_res_img('firefox/os/mwc-2015-preview/partners/orange.png', {'alt': 'Orange', 'width': '220', 'height': '100'}) }}</li>
+        <li>{{ high_res_img('firefox/os/mwc-2015-preview/partners/verizon.png', {'alt': 'Verizon', 'width': '220', 'height': '100'}) }}</li>
+        <li>{{ high_res_img('firefox/os/mwc-2015-preview/partners/mtn.png', {'alt': 'MTN', 'width': '220', 'height': '100'}) }}</li>
+        <li>{{ high_res_img('firefox/os/mwc-2015-preview/partners/alcatel.png', {'alt': 'Alcatel OneTouch', 'width': '220', 'height': '100'}) }}</li>
+        <li>{{ high_res_img('firefox/os/mwc-2015-preview/partners/america-movil.png', {'alt': 'America Movil', 'width': '220', 'height': '100'}) }}</li>
+        <li>{{ high_res_img('firefox/os/mwc-2015-preview/partners/cherry-mobile.png', {'alt': 'Cherry Mobile', 'width': '220', 'height': '100'}) }}</li>
+        <li>{{ high_res_img('firefox/os/mwc-2015-preview/partners/deutsche-telekom.png', {'alt': 'Deutsche Telekom', 'width': '220', 'height': '100'}) }}</li>
+        <li>{{ high_res_img('firefox/os/mwc-2015-preview/partners/grameenphone.png', {'alt': 'GrameenPhone', 'width': '220', 'height': '100'}) }}</li>
+        <li>{{ high_res_img('firefox/os/mwc-2015-preview/partners/huawei.png', {'alt': 'Huawei', 'width': '220', 'height': '100'}) }}</li>
+        <li>{{ high_res_img('firefox/os/mwc-2015-preview/partners/intex.png', {'alt': 'Intex', 'width': '220', 'height': '100'}) }}</li>
+        <li>{{ high_res_img('firefox/os/mwc-2015-preview/partners/kddi.png', {'alt': 'KDDI', 'width': '220', 'height': '100'}) }}</li>
+        <li>{{ high_res_img('firefox/os/mwc-2015-preview/partners/lg.png', {'alt': 'LG', 'width': '220', 'height': '100'}) }}</li>
+        <li>{{ high_res_img('firefox/os/mwc-2015-preview/partners/megafon.png', {'alt': 'MegaFon', 'width': '220', 'height': '100'}) }}</li>
+        <li>{{ high_res_img('firefox/os/mwc-2015-preview/partners/panasonic.png', {'alt': 'Panasonic', 'width': '220', 'height': '100'}) }}</li>
+        <li>{{ high_res_img('firefox/os/mwc-2015-preview/partners/qualcomm.png', {'alt': 'Qualcomm', 'width': '220', 'height': '100'}) }}</li>
+        <li>{{ high_res_img('firefox/os/mwc-2015-preview/partners/spice.png', {'alt': 'Spice', 'width': '220', 'height': '100'}) }}</li>
+        <li>{{ high_res_img('firefox/os/mwc-2015-preview/partners/spreadtrum.png', {'alt': 'Spreadtrum', 'width': '220', 'height': '100'}) }}</li>
+        <li>{{ high_res_img('firefox/os/mwc-2015-preview/partners/symphony.png', {'alt': 'Symphony', 'width': '220', 'height': '100'}) }}</li>
+        <li>{{ high_res_img('firefox/os/mwc-2015-preview/partners/telecom-italia.png', {'alt': 'Telecom Italia', 'width': '220', 'height': '100'}) }}</li>
+        <li>{{ high_res_img('firefox/os/mwc-2015-preview/partners/telefonica.png', {'alt': 'Telefonica', 'width': '220', 'height': '100'}) }}</li>
+        <li>{{ high_res_img('firefox/os/mwc-2015-preview/partners/telenor.png', {'alt': 'Telenor', 'width': '220', 'height': '100'}) }}</li>
+        <li>{{ high_res_img('firefox/os/mwc-2015-preview/partners/zen-mobile.png', {'alt': 'ZEN Mobile', 'width': '220', 'height': '100'}) }}</li>
+        <li>{{ high_res_img('firefox/os/mwc-2015-preview/partners/zte.png', {'alt': 'ZTE', 'width': '220', 'height': '100'}) }}</li>
       </ul>
 
       <h3>{{ _('Here’s how') }}</h3>
@@ -148,7 +148,7 @@
       <ul id="list-platform">
         <li id="platform-firefoxos">
           <h4>
-            {{ high_res_img('img/firefox/os/mwc-2015-preview/platform-firefox-os.png', {'alt': 'Firefox OS', 'width': '262', 'height': '76'}) }}
+            {{ high_res_img('firefox/os/mwc-2015-preview/platform-firefox-os.png', {'alt': 'Firefox OS', 'width': '262', 'height': '76'}) }}
           </h4>
 
           <p>
@@ -161,7 +161,7 @@
         </li>
         <li>
           <h4>
-            {{ high_res_img('img/firefox/os/mwc-2015-preview/platform-firefox-marketplace.png', {'alt': 'Firefox Marketplace', 'width': '436', 'height': '76'}) }}
+            {{ high_res_img('firefox/os/mwc-2015-preview/platform-firefox-marketplace.png', {'alt': 'Firefox Marketplace', 'width': '436', 'height': '76'}) }}
           </h4>
 
           <p>

--- a/bedrock/firefox/templates/firefox/os/tv.html
+++ b/bedrock/firefox/templates/firefox/os/tv.html
@@ -20,7 +20,7 @@
 
 {% block site_header_logo %}
   <h2><a href="{{ url('firefox.os.index') }}">
-  {{ high_res_img('img/firefox/os/devices/tv/logo.png', {'alt': 'Firefox OS', 'width': '221', 'height': '67'}) }}</a></h2>
+  {{ high_res_img('firefox/os/devices/tv/logo.png', {'alt': 'Firefox OS', 'width': '221', 'height': '67'}) }}</a></h2>
 {% endblock %}
 
 {% block content %}
@@ -37,16 +37,16 @@
     <div class="tv">
       <div class="pager-content" id="mozilla-pager-tv-pages">
         <div id="tv1" class="pager-page">
-          {{ high_res_img('img/firefox/os/devices/tv/screen1.jpg', {'alt': _('Screenshot'), 'width': '796', 'height': '448'}) }}
+          {{ high_res_img('firefox/os/devices/tv/screen1.jpg', {'alt': _('Screenshot'), 'width': '796', 'height': '448'}) }}
         </div>
         <div id="tv2" class="pager-page">
-          {{ high_res_img('img/firefox/os/devices/tv/screen2.jpg', {'alt': _('Screenshot'), 'width': '796', 'height': '448'}) }}
+          {{ high_res_img('firefox/os/devices/tv/screen2.jpg', {'alt': _('Screenshot'), 'width': '796', 'height': '448'}) }}
         </div>
         <div id="tv3" class="pager-page">
-          {{ high_res_img('img/firefox/os/devices/tv/screen3.jpg', {'alt': _('Screenshot'), 'width': '796', 'height': '448'}) }}
+          {{ high_res_img('firefox/os/devices/tv/screen3.jpg', {'alt': _('Screenshot'), 'width': '796', 'height': '448'}) }}
         </div>
         <div id="tv4" class="pager-page">
-          {{ high_res_img('img/firefox/os/devices/tv/screen4.jpg', {'alt': _('Screenshot'), 'width': '796', 'height': '448'}) }}
+          {{ high_res_img('firefox/os/devices/tv/screen4.jpg', {'alt': _('Screenshot'), 'width': '796', 'height': '448'}) }}
         </div>
       </div>
     </div>

--- a/bedrock/firefox/templates/firefox/partners/index.html
+++ b/bedrock/firefox/templates/firefox/partners/index.html
@@ -129,49 +129,49 @@
               <div class="pager-content">
                 <div class="pager-page default-page">
                   <ul class="logos">
-                    <li>{{ high_res_img('img/firefox/partners/logos/light/orange.png', {'alt': 'Orange', 'width': '120', 'height': '60'}) }}</li>
-                    <li>{{ high_res_img('img/firefox/partners/logos/light/kddi.png', {'alt': 'KDDI', 'width': '120', 'height': '60'}) }}</li>
-                    <li>{{ high_res_img('img/firefox/partners/logos/light/telefonica.png', {'alt': 'Telefonica', 'width': '120', 'height': '60'}) }}</li>
-                    <li>{{ high_res_img('img/firefox/partners/logos/light/telenor.png', {'alt': 'Telenor', 'width': '120', 'height': '60'}) }}</li>
-                    <li>{{ high_res_img('img/firefox/partners/logos/light/deutsche-telekom.png', {'alt': 'Deutsche Telekom', 'width': '120', 'height': '60'}) }}</li>
-                    <li>{{ high_res_img('img/firefox/partners/logos/light/verizon.png', {'alt': 'Verizon', 'width': '120', 'height': '60'}) }}</li>
-                    <li>{{ high_res_img('img/firefox/partners/logos/light/panasonic.png', {'alt': 'Panasonic', 'width': '120', 'height': '60'}) }}</li>
-                    <li>{{ high_res_img('img/firefox/partners/logos/light/alcatel.png', {'alt': 'Alcatel ONETOUCH', 'width': '120', 'height': '60'}) }}</li>
-                    <li>{{ high_res_img('img/firefox/partners/logos/light/spreadtrum.png', {'alt': 'Spreadtrum', 'width': '120', 'height': '60'}) }}</li>
-                    <li>{{ high_res_img('img/firefox/partners/logos/light/qualcomm.png', {'alt': 'Qualcomm', 'width': '120', 'height': '60'}) }}</li>
-                    <li>{{ high_res_img('img/firefox/partners/logos/light/america-movil.png', {'alt': 'America Movil', 'width': '120', 'height': '60'}) }}</li>
+                    <li>{{ high_res_img('firefox/partners/logos/light/orange.png', {'alt': 'Orange', 'width': '120', 'height': '60'}) }}</li>
+                    <li>{{ high_res_img('firefox/partners/logos/light/kddi.png', {'alt': 'KDDI', 'width': '120', 'height': '60'}) }}</li>
+                    <li>{{ high_res_img('firefox/partners/logos/light/telefonica.png', {'alt': 'Telefonica', 'width': '120', 'height': '60'}) }}</li>
+                    <li>{{ high_res_img('firefox/partners/logos/light/telenor.png', {'alt': 'Telenor', 'width': '120', 'height': '60'}) }}</li>
+                    <li>{{ high_res_img('firefox/partners/logos/light/deutsche-telekom.png', {'alt': 'Deutsche Telekom', 'width': '120', 'height': '60'}) }}</li>
+                    <li>{{ high_res_img('firefox/partners/logos/light/verizon.png', {'alt': 'Verizon', 'width': '120', 'height': '60'}) }}</li>
+                    <li>{{ high_res_img('firefox/partners/logos/light/panasonic.png', {'alt': 'Panasonic', 'width': '120', 'height': '60'}) }}</li>
+                    <li>{{ high_res_img('firefox/partners/logos/light/alcatel.png', {'alt': 'Alcatel ONETOUCH', 'width': '120', 'height': '60'}) }}</li>
+                    <li>{{ high_res_img('firefox/partners/logos/light/spreadtrum.png', {'alt': 'Spreadtrum', 'width': '120', 'height': '60'}) }}</li>
+                    <li>{{ high_res_img('firefox/partners/logos/light/qualcomm.png', {'alt': 'Qualcomm', 'width': '120', 'height': '60'}) }}</li>
+                    <li>{{ high_res_img('firefox/partners/logos/light/america-movil.png', {'alt': 'America Movil', 'width': '120', 'height': '60'}) }}</li>
                   </ul>
                 </div>
                 <div class="pager-page">
                   <ul class="logos">
-                    <li>{{ high_res_img('img/firefox/partners/logos/light/grameenphone.png', {'alt': 'GrameenPhone', 'width': '120', 'height': '60'}) }}</li>
-                    <li>{{ high_res_img('img/firefox/partners/logos/light/telecom-italia.png', {'alt': 'Telecom Italia', 'width': '120', 'height': '60'}) }}</li>
-                    <li>{{ high_res_img('img/firefox/partners/logos/light/huawei.png', {'alt': 'Huawei', 'width': '120', 'height': '60'}) }}</li>
-                    <li>{{ high_res_img('img/firefox/partners/logos/light/zte.png', {'alt': 'ZTE', 'width': '120', 'height': '60'}) }}</li>
-                    <li>{{ high_res_img('img/firefox/partners/logos/light/symphony.png', {'alt': 'Symphony', 'width': '120', 'height': '60'}) }}</li>
-                    <li>{{ high_res_img('img/firefox/partners/logos/light/mtn.png', {'alt': 'MTN', 'width': '120', 'height': '60'}) }}</li>
-                    <li>{{ high_res_img('img/firefox/partners/logos/light/cherry-mobile.png', {'alt': 'Cherry Mobile', 'width': '120', 'height': '60'}) }}</li>
-                    <li>{{ high_res_img('img/firefox/partners/logos/light/intex.png', {'alt': 'Intex', 'width': '120', 'height': '60'}) }}</li>
-                    <li>{{ high_res_img('img/firefox/partners/logos/light/zen-mobile.png', {'alt': 'ZEN Mobile', 'width': '120', 'height': '60'}) }}</li>
-                    <li>{{ high_res_img('img/firefox/partners/logos/light/megafon.png', {'alt': 'MegaFon', 'width': '120', 'height': '60'}) }}</li>
-                    <li>{{ high_res_img('img/firefox/partners/logos/light/spice.png', {'alt': 'Spice', 'width': '120', 'height': '60'}) }}</li>
-                    <li>{{ high_res_img('img/firefox/partners/logos/light/lg.png', {'alt': 'LG', 'width': '120', 'height': '60'}) }}</li>
+                    <li>{{ high_res_img('firefox/partners/logos/light/grameenphone.png', {'alt': 'GrameenPhone', 'width': '120', 'height': '60'}) }}</li>
+                    <li>{{ high_res_img('firefox/partners/logos/light/telecom-italia.png', {'alt': 'Telecom Italia', 'width': '120', 'height': '60'}) }}</li>
+                    <li>{{ high_res_img('firefox/partners/logos/light/huawei.png', {'alt': 'Huawei', 'width': '120', 'height': '60'}) }}</li>
+                    <li>{{ high_res_img('firefox/partners/logos/light/zte.png', {'alt': 'ZTE', 'width': '120', 'height': '60'}) }}</li>
+                    <li>{{ high_res_img('firefox/partners/logos/light/symphony.png', {'alt': 'Symphony', 'width': '120', 'height': '60'}) }}</li>
+                    <li>{{ high_res_img('firefox/partners/logos/light/mtn.png', {'alt': 'MTN', 'width': '120', 'height': '60'}) }}</li>
+                    <li>{{ high_res_img('firefox/partners/logos/light/cherry-mobile.png', {'alt': 'Cherry Mobile', 'width': '120', 'height': '60'}) }}</li>
+                    <li>{{ high_res_img('firefox/partners/logos/light/intex.png', {'alt': 'Intex', 'width': '120', 'height': '60'}) }}</li>
+                    <li>{{ high_res_img('firefox/partners/logos/light/zen-mobile.png', {'alt': 'ZEN Mobile', 'width': '120', 'height': '60'}) }}</li>
+                    <li>{{ high_res_img('firefox/partners/logos/light/megafon.png', {'alt': 'MegaFon', 'width': '120', 'height': '60'}) }}</li>
+                    <li>{{ high_res_img('firefox/partners/logos/light/spice.png', {'alt': 'Spice', 'width': '120', 'height': '60'}) }}</li>
+                    <li>{{ high_res_img('firefox/partners/logos/light/lg.png', {'alt': 'LG', 'width': '120', 'height': '60'}) }}</li>
                   </ul>
                 </div>
                 <div class="pager-page">
                   <ul class="logos">
-                    <li>{{ high_res_img('img/firefox/partners/logos/light/youtube.png', {'alt': 'YouTube', 'width': '120', 'height': '60'}) }}</li>
-                    <li>{{ high_res_img('img/firefox/partners/logos/light/twitter.png', {'alt': 'Twitter', 'width': '120', 'height': '60'}) }}</li>
-                    <li>{{ high_res_img('img/firefox/partners/logos/light/pinterest.png', {'alt': 'Pinterest', 'width': '120', 'height': '60'}) }}</li>
-                    <li>{{ high_res_img('img/firefox/partners/logos/light/disney.png', {'alt': 'Disney', 'width': '120', 'height': '60'}) }}</li>
-                    <li>{{ high_res_img('img/firefox/partners/logos/light/wikimedia.png', {'alt': 'Wikimedia', 'width': '120', 'height': '60'}) }}</li>
-                    <li>{{ high_res_img('img/firefox/partners/logos/light/soundcloud.png', {'alt': 'SoundCloud', 'width': '120', 'height': '60'}) }}</li>
-                    <li>{{ high_res_img('img/firefox/partners/logos/light/line.png', {'alt': 'Line', 'width': '120', 'height': '60'}) }}</li>
-                    <li>{{ high_res_img('img/firefox/partners/logos/light/the-weather-channel.png', {'alt': 'The Weather Channel', 'width': '120', 'height': '60'}) }}</li>
-                    <li>{{ high_res_img('img/firefox/partners/logos/light/here-maps.png', {'alt': 'Here Maps', 'width': '120', 'height': '60'}) }}</li>
-                    <li>{{ high_res_img('img/firefox/partners/logos/light/kobo.png', {'alt': 'Kobo', 'width': '120', 'height': '60'}) }}</li>
-                    <li>{{ high_res_img('img/firefox/partners/logos/light/outlook.png', {'alt': 'Outlook', 'width': '120', 'height': '60'}) }}</li>
-                    <li>{{ high_res_img('img/firefox/partners/logos/light/ebay-india.png', {'alt': 'eBay India', 'width': '120', 'height': '60'}) }}</li>
+                    <li>{{ high_res_img('firefox/partners/logos/light/youtube.png', {'alt': 'YouTube', 'width': '120', 'height': '60'}) }}</li>
+                    <li>{{ high_res_img('firefox/partners/logos/light/twitter.png', {'alt': 'Twitter', 'width': '120', 'height': '60'}) }}</li>
+                    <li>{{ high_res_img('firefox/partners/logos/light/pinterest.png', {'alt': 'Pinterest', 'width': '120', 'height': '60'}) }}</li>
+                    <li>{{ high_res_img('firefox/partners/logos/light/disney.png', {'alt': 'Disney', 'width': '120', 'height': '60'}) }}</li>
+                    <li>{{ high_res_img('firefox/partners/logos/light/wikimedia.png', {'alt': 'Wikimedia', 'width': '120', 'height': '60'}) }}</li>
+                    <li>{{ high_res_img('firefox/partners/logos/light/soundcloud.png', {'alt': 'SoundCloud', 'width': '120', 'height': '60'}) }}</li>
+                    <li>{{ high_res_img('firefox/partners/logos/light/line.png', {'alt': 'Line', 'width': '120', 'height': '60'}) }}</li>
+                    <li>{{ high_res_img('firefox/partners/logos/light/the-weather-channel.png', {'alt': 'The Weather Channel', 'width': '120', 'height': '60'}) }}</li>
+                    <li>{{ high_res_img('firefox/partners/logos/light/here-maps.png', {'alt': 'Here Maps', 'width': '120', 'height': '60'}) }}</li>
+                    <li>{{ high_res_img('firefox/partners/logos/light/kobo.png', {'alt': 'Kobo', 'width': '120', 'height': '60'}) }}</li>
+                    <li>{{ high_res_img('firefox/partners/logos/light/outlook.png', {'alt': 'Outlook', 'width': '120', 'height': '60'}) }}</li>
+                    <li>{{ high_res_img('firefox/partners/logos/light/ebay-india.png', {'alt': 'eBay India', 'width': '120', 'height': '60'}) }}</li>
                   </ul>
                 </div>
               </div><!--/pager-content-->
@@ -355,41 +355,41 @@
             <div class="pager-content">
               <div class="pager-page default-page">
                 <ul class="logos">
-                  <li>{{ high_res_img('img/firefox/partners/logos/light/disney.png', {'alt': 'Disney', 'width': '120', 'height': '60'}) }}</li>
-                  <li>{{ high_res_img('img/firefox/partners/logos/light/box.png', {'alt': 'BOX', 'width': '120', 'height': '60'}) }}</li>
-                  <li>{{ high_res_img('img/firefox/partners/logos/light/line.png', {'alt': 'LINE', 'width': '120', 'height': '60'}) }}</li>
-                  <li>{{ high_res_img('img/firefox/partners/logos/light/twitter.png', {'alt': 'Twitter', 'width': '120', 'height': '60'}) }}</li>
-                  <li>{{ high_res_img('img/firefox/partners/logos/light/yelp.png', {'alt': 'Yelp', 'width': '120', 'height': '60'}) }}</li>
-                  <li>{{ high_res_img('img/firefox/partners/logos/light/cut-the-rope.png', {'alt': 'Cut the Rope', 'width': '120', 'height': '60'}) }}</li>
-                  <li>{{ high_res_img('img/firefox/partners/logos/light/zedge.png', {'alt': 'Zedge', 'width': '120', 'height': '60'}) }}</li>
-                  <li>{{ high_res_img('img/firefox/partners/logos/light/here-maps.png', {'alt': 'HERE Maps', 'width': '120', 'height': '60'}) }}</li>
-                  <li>{{ high_res_img('img/firefox/partners/logos/light/the-weather-channel.png', {'alt': 'The Weather Channel', 'width': '120', 'height': '60'}) }}</li>
-                  <li>{{ high_res_img('img/firefox/partners/logos/light/khan-academy.png', {'alt': 'Khan Academy', 'width': '120', 'height': '60'}) }}</li>
-                  <li>{{ high_res_img('img/firefox/partners/logos/light/wikimedia.png', {'alt': 'Wikimedia', 'width': '120', 'height': '60'}) }}</li>
-                  <li>{{ high_res_img('img/firefox/partners/logos/light/8tracks.png', {'alt': '8tracks', 'width': '120', 'height': '60'}) }}</li>
+                  <li>{{ high_res_img('firefox/partners/logos/light/disney.png', {'alt': 'Disney', 'width': '120', 'height': '60'}) }}</li>
+                  <li>{{ high_res_img('firefox/partners/logos/light/box.png', {'alt': 'BOX', 'width': '120', 'height': '60'}) }}</li>
+                  <li>{{ high_res_img('firefox/partners/logos/light/line.png', {'alt': 'LINE', 'width': '120', 'height': '60'}) }}</li>
+                  <li>{{ high_res_img('firefox/partners/logos/light/twitter.png', {'alt': 'Twitter', 'width': '120', 'height': '60'}) }}</li>
+                  <li>{{ high_res_img('firefox/partners/logos/light/yelp.png', {'alt': 'Yelp', 'width': '120', 'height': '60'}) }}</li>
+                  <li>{{ high_res_img('firefox/partners/logos/light/cut-the-rope.png', {'alt': 'Cut the Rope', 'width': '120', 'height': '60'}) }}</li>
+                  <li>{{ high_res_img('firefox/partners/logos/light/zedge.png', {'alt': 'Zedge', 'width': '120', 'height': '60'}) }}</li>
+                  <li>{{ high_res_img('firefox/partners/logos/light/here-maps.png', {'alt': 'HERE Maps', 'width': '120', 'height': '60'}) }}</li>
+                  <li>{{ high_res_img('firefox/partners/logos/light/the-weather-channel.png', {'alt': 'The Weather Channel', 'width': '120', 'height': '60'}) }}</li>
+                  <li>{{ high_res_img('firefox/partners/logos/light/khan-academy.png', {'alt': 'Khan Academy', 'width': '120', 'height': '60'}) }}</li>
+                  <li>{{ high_res_img('firefox/partners/logos/light/wikimedia.png', {'alt': 'Wikimedia', 'width': '120', 'height': '60'}) }}</li>
+                  <li>{{ high_res_img('firefox/partners/logos/light/8tracks.png', {'alt': '8tracks', 'width': '120', 'height': '60'}) }}</li>
                 </ul>
               </div><!--/.pager-page-->
               <div class="pager-page">
                 <ul class="logos">
-                  <li>{{ high_res_img('img/firefox/partners/logos/light/outlook.png', {'alt': 'Outlook', 'width': '120', 'height': '60'}) }}</li>
-                  <li>{{ high_res_img('img/firefox/partners/logos/light/bandai-namco.png', {'alt': 'Bandai Namco', 'width': '120', 'height': '60'}) }}</li>
-                  <li>{{ high_res_img('img/firefox/partners/logos/light/pinterest.png', {'alt': 'Pinterest', 'width': '120', 'height': '60'}) }}</li>
-                  <li>{{ high_res_img('img/firefox/partners/logos/light/rakuten.png', {'alt': 'Rakuten', 'width': '120', 'height': '60'}) }}</li>
-                  <li>{{ high_res_img('img/firefox/partners/logos/light/soundcloud.png', {'alt': 'Soundcloud', 'width': '120', 'height': '60'}) }}</li>
-                  <li>{{ high_res_img('img/firefox/partners/logos/light/jalan.png', {'alt': 'Jalan', 'width': '120', 'height': '60'}) }}</li>
-                  <li>{{ high_res_img('img/firefox/partners/logos/light/tresensa.png', {'alt': 'Tresensa', 'width': '120', 'height': '60'}) }}</li>
-                  <li>{{ high_res_img('img/firefox/partners/logos/light/vuclip.png', {'alt': 'Vuclip', 'width': '120', 'height': '60'}) }}</li>
-                  <li>{{ high_res_img('img/firefox/partners/logos/light/kobo.png', {'alt': 'Kobo', 'width': '120', 'height': '60'}) }}</li>
-                  <li>{{ high_res_img('img/firefox/partners/logos/light/aviary.png', {'alt': 'Aviary', 'width': '120', 'height': '60'}) }}</li>
-                  <li>{{ high_res_img('img/firefox/partners/logos/light/youtube.png', {'alt': 'YouTube', 'width': '120', 'height': '60'}) }}</li>
-                  <li>{{ high_res_img('img/firefox/partners/logos/light/easy-taxi.png', {'alt': 'Easy Taxi', 'width': '120', 'height': '60'}) }}</li>
+                  <li>{{ high_res_img('firefox/partners/logos/light/outlook.png', {'alt': 'Outlook', 'width': '120', 'height': '60'}) }}</li>
+                  <li>{{ high_res_img('firefox/partners/logos/light/bandai-namco.png', {'alt': 'Bandai Namco', 'width': '120', 'height': '60'}) }}</li>
+                  <li>{{ high_res_img('firefox/partners/logos/light/pinterest.png', {'alt': 'Pinterest', 'width': '120', 'height': '60'}) }}</li>
+                  <li>{{ high_res_img('firefox/partners/logos/light/rakuten.png', {'alt': 'Rakuten', 'width': '120', 'height': '60'}) }}</li>
+                  <li>{{ high_res_img('firefox/partners/logos/light/soundcloud.png', {'alt': 'Soundcloud', 'width': '120', 'height': '60'}) }}</li>
+                  <li>{{ high_res_img('firefox/partners/logos/light/jalan.png', {'alt': 'Jalan', 'width': '120', 'height': '60'}) }}</li>
+                  <li>{{ high_res_img('firefox/partners/logos/light/tresensa.png', {'alt': 'Tresensa', 'width': '120', 'height': '60'}) }}</li>
+                  <li>{{ high_res_img('firefox/partners/logos/light/vuclip.png', {'alt': 'Vuclip', 'width': '120', 'height': '60'}) }}</li>
+                  <li>{{ high_res_img('firefox/partners/logos/light/kobo.png', {'alt': 'Kobo', 'width': '120', 'height': '60'}) }}</li>
+                  <li>{{ high_res_img('firefox/partners/logos/light/aviary.png', {'alt': 'Aviary', 'width': '120', 'height': '60'}) }}</li>
+                  <li>{{ high_res_img('firefox/partners/logos/light/youtube.png', {'alt': 'YouTube', 'width': '120', 'height': '60'}) }}</li>
+                  <li>{{ high_res_img('firefox/partners/logos/light/easy-taxi.png', {'alt': 'Easy Taxi', 'width': '120', 'height': '60'}) }}</li>
                 </ul>
               </div>
               <div class="pager-page">
                 <ul class="logos">
-                  <li>{{ high_res_img('img/firefox/partners/logos/light/ebay-india.png', {'alt': 'Ebay India', 'width': '120', 'height': '60'}) }}</li>
-                  <li>{{ high_res_img('img/firefox/partners/logos/light/espn-cricinfo.png', {'alt': 'ESPNcricinfo', 'width': '120', 'height': '60'}) }}</li>
-                  <li>{{ high_res_img('img/firefox/partners/logos/light/enclave-games.png', {'alt': 'Enclave Games', 'width': '120', 'height': '60'}) }}</li>
+                  <li>{{ high_res_img('firefox/partners/logos/light/ebay-india.png', {'alt': 'Ebay India', 'width': '120', 'height': '60'}) }}</li>
+                  <li>{{ high_res_img('firefox/partners/logos/light/espn-cricinfo.png', {'alt': 'ESPNcricinfo', 'width': '120', 'height': '60'}) }}</li>
+                  <li>{{ high_res_img('firefox/partners/logos/light/enclave-games.png', {'alt': 'Enclave Games', 'width': '120', 'height': '60'}) }}</li>
                 </ul>
               </div>
             </div><!--/.pager-content-->

--- a/bedrock/firefox/templates/firefox/releases/aurora-notes.html
+++ b/bedrock/firefox/templates/firefox/releases/aurora-notes.html
@@ -9,7 +9,7 @@
 {% set channel_name = 'Aurora' %}
 
 {% block site_header_logo %}
-    <h2><a href="{{ url('firefox') }}">{{ high_res_img('img/firefox/template/header-logo-inverse.png', {'alt': 'Mozilla Firefox', 'width': '185', 'height': '70'}) }}</a></h2>
+    <h2><a href="{{ url('firefox') }}">{{ high_res_img('firefox/template/header-logo-inverse.png', {'alt': 'Mozilla Firefox', 'width': '185', 'height': '70'}) }}</a></h2>
 {% endblock %}
 
 {% block platform_switch %}

--- a/bedrock/firefox/templates/firefox/releases/dev-browser-notes.html
+++ b/bedrock/firefox/templates/firefox/releases/dev-browser-notes.html
@@ -3,7 +3,7 @@
 {% block body_class %}fx-notes blueprint{% endblock %}
 
 {% block site_header_logo %}
-  <h2>{{ high_res_img('img/firefox/developer/title.png', {'alt': _('Firefox Developer Edition'), 'width': '220', 'height': '84'}) }}</h2>
+  <h2>{{ high_res_img('firefox/developer/title.png', {'alt': _('Firefox Developer Edition'), 'width': '220', 'height': '84'}) }}</h2>
 {% endblock %}
 
 {% block notes_heading_primary %}

--- a/bedrock/firefox/templates/firefox/tiles.html
+++ b/bedrock/firefox/templates/firefox/tiles.html
@@ -54,7 +54,7 @@
   </p>
   <ol>
     <li>{{ _('Drag a site to exactly where you want it.') }}
-      {{ high_res_img('img/firefox/tiles/drag-site.png', {'alt': ''}) }}
+      {{ high_res_img('firefox/tiles/drag-site.png', {'alt': ''}) }}
     </li>
     <li>{{ _('Once you’ve found the perfect spot for your site, pin it to make it stay.') }}
       <img src="{{ static('img/firefox/tiles/pin-site.png') }}" alt="">
@@ -91,7 +91,7 @@
     {{ _('If you’re using Firefox for the first time, the New Tab page is already populated with useful and interesting sites and content.') }}
     {{ _('This includes both referrals to sponsored sites from commercial partners, labeled as “Sponsored,” and content we consider important to our mission of advancing the public benefit of the Internet.') }}
   </p>
-  {{ high_res_img('img/firefox/tiles/discover-sites.png', {'alt': ''}) }}
+  {{ high_res_img('firefox/tiles/discover-sites.png', {'alt': ''}) }}
 </section>
 
 <section class="tls-privacy">
@@ -117,7 +117,7 @@
 #}
 
 {% block dashboard_sidebar_contents %}
-  {{ high_res_img('img/firefox/tiles/new-tab-enhanced.png', {'alt': _('Screenshot of the Firefox New Tab page'), 'class': 'tab'}) }}
+  {{ high_res_img('firefox/tiles/new-tab-enhanced.png', {'alt': _('Screenshot of the Firefox New Tab page'), 'class': 'tab'}) }}
   <img class="tab-preferences" src="{{ static('img/firefox/tiles/tab-preferences.png') }}" alt="{{ _('Screenshot of New Tab preferences') }}">
 {% endblock %}
 

--- a/bedrock/firefox/templates/firefox/whatsnew-fx37.html
+++ b/bedrock/firefox/templates/firefox/whatsnew-fx37.html
@@ -36,7 +36,7 @@
 {% block site_header_nav %}{% endblock %}
 {% block site_header_logo %}
   <h2><a href="{{ url('firefox') }}">
-    {{ high_res_img('img/firefox/whatsnew-fx37/firefox-wordmark.png', {'alt': 'Mozilla Firefox', 'width': '220', 'height': '90'}) }}
+    {{ high_res_img('firefox/whatsnew-fx37/firefox-wordmark.png', {'alt': 'Mozilla Firefox', 'width': '220', 'height': '90'}) }}
   </a></h2>
 {% endblock %}
 

--- a/bedrock/firefox/templates/firefox/whatsnew-nightly-29.html
+++ b/bedrock/firefox/templates/firefox/whatsnew-nightly-29.html
@@ -13,7 +13,7 @@
       <p><a href="http://www.surveygizmo.com/s3/1470920/Survey-Nightly-29" class="button">{{ _('Start the survey') }}</a></p>
     </div>
     <div class="image-column">
-      {{ platform_img('img/firefox/whatsnew/australis.png', {'alt': _('New Firefox interface')}) }}
+      {{ platform_img('firefox/whatsnew/australis.png', {'alt': _('New Firefox interface')}) }}
     </div>
   </article>
 {% endblock %}

--- a/bedrock/mozorg/helpers/misc.py
+++ b/bedrock/mozorg/helpers/misc.py
@@ -187,6 +187,8 @@ def platform_img(ctx, url, optional_attributes=None):
     for platform, image in img_urls.iteritems():
         if is_l10n:
             image = l10n_img_file_name(ctx, image)
+        else:
+            image = path.join('img', image)
 
         if find_static(image):
             key = 'data-src-' + platform
@@ -217,8 +219,8 @@ def high_res_img(ctx, url, optional_attributes=None):
         url = l10n_img(ctx, url)
         url_high_res = l10n_img(ctx, url_high_res)
     else:
-        url = static(url)
-        url_high_res = static(url_high_res)
+        url = static(path.join('img', url))
+        url_high_res = static(path.join('img', url_high_res))
 
     if optional_attributes:
         class_name = optional_attributes.pop('class', '')

--- a/bedrock/mozorg/templates/mozorg/contentservices/tiles.html
+++ b/bedrock/mozorg/templates/mozorg/contentservices/tiles.html
@@ -35,7 +35,7 @@
   </p>
 
   <p>
-    {{ high_res_img('img/contentservices/directory-tiles.jpg', {'alt': 'Directory Tiles screenshot', 'width': '620'}) }}
+    {{ high_res_img('contentservices/directory-tiles.jpg', {'alt': 'Directory Tiles screenshot', 'width': '620'}) }}
   </p>
 
   <h3 id="suggested-tiles">{{ _('Suggested Tiles') }}</h3>
@@ -49,7 +49,7 @@
   </p>
 
   <p>
-    {{ high_res_img('img/contentservices/suggested-tiles.jpg', {'alt': 'Suggested Tiles screenshot', 'width': '620'}) }}
+    {{ high_res_img('contentservices/suggested-tiles.jpg', {'alt': 'Suggested Tiles screenshot', 'width': '620'}) }}
   </p>
 
   <p>
@@ -62,7 +62,7 @@
   </p>
 
   <p>
-    {{ high_res_img('img/contentservices/tiles-settings.jpg', {'alt': 'Tiles settings screenshot', 'width': '620'}) }}
+    {{ high_res_img('contentservices/tiles-settings.jpg', {'alt': 'Tiles settings screenshot', 'width': '620'}) }}
   </p>
 
   <h3 id="partnering">{{ _('Partnering with Mozilla') }}</h3>

--- a/bedrock/mozorg/templates/mozorg/contribute/studentambassadors/join.html
+++ b/bedrock/mozorg/templates/mozorg/contribute/studentambassadors/join.html
@@ -15,7 +15,7 @@
 
 {% block site_header_nav %}{% endblock %}
 {% block site_header_logo %}
-  <h2><a href="{{ url('mozorg.contribute.studentambassadors.landing') }}">{{ high_res_img('img/contribute/studentambassadors/logo.png', {'alt': 'Firefox Student Ambassadors', 'width': '323'}) }}</a></h2>
+  <h2><a href="{{ url('mozorg.contribute.studentambassadors.landing') }}">{{ high_res_img('contribute/studentambassadors/logo.png', {'alt': 'Firefox Student Ambassadors', 'width': '323'}) }}</a></h2>
 {% endblock %}
 
 {% block content %}

--- a/bedrock/mozorg/templates/mozorg/contribute/studentambassadors/landing.html
+++ b/bedrock/mozorg/templates/mozorg/contribute/studentambassadors/landing.html
@@ -16,7 +16,7 @@
 
 {% block site_header_nav %}{% endblock %}
 {% block site_header_logo %}
-  <h2>{{ high_res_img('img/contribute/studentambassadors/logo.png', {'alt': 'Firefox Student Ambassadors', 'width': '323'}) }}</h2>
+  <h2>{{ high_res_img('contribute/studentambassadors/logo.png', {'alt': 'Firefox Student Ambassadors', 'width': '323'}) }}</h2>
 {% endblock %}
 
 {% block content %}

--- a/bedrock/mozorg/templates/mozorg/home/home.html
+++ b/bedrock/mozorg/templates/mozorg/home/home.html
@@ -105,7 +105,7 @@
 <main role="main">
   <header class="main-header">
     <div class="container">
-      <h1>{{ high_res_img('img/home/voices/mozilla-wordmark-white.png', {'alt': 'Mozilla', 'width': '313', 'height': '82'}) }}</h1>
+      <h1>{{ high_res_img('home/voices/mozilla-wordmark-white.png', {'alt': 'Mozilla', 'width': '313', 'height': '82'}) }}</h1>
     </div>
   </header>
 
@@ -305,7 +305,7 @@
     <div class="container">
       <header>
         <a href="{{ url('firefox') }}" id="firefox-promo-link">
-          <h3>{{ high_res_img('img/home/voices/firefox-logo-wordmark-white.png', {'alt': 'Firefox'}) }}</h3>
+          <h3>{{ high_res_img('home/voices/firefox-logo-wordmark-white.png', {'alt': 'Firefox'}) }}</h3>
           {# L10n: <strong> tags below are for visual formatting only. #}
           <h4>{{_('Committed to <strong>you, your privacy</strong> and an <strong>open Web</strong>')}}</h4>
         </a>

--- a/bedrock/mozorg/tests/test_helper_misc.py
+++ b/bedrock/mozorg/tests/test_helper_misc.py
@@ -283,8 +283,8 @@ class TestPlatformImg(TestCase):
     def test_platform_img_no_optional_attributes(self, find_static):
         """Should return expected markup without optional attributes"""
         markup = self._render('test.png')
-        self.assertIn(u'data-src-windows="/media/test-windows.png"', markup)
-        self.assertIn(u'data-src-mac="/media/test-mac.png"', markup)
+        self.assertIn(u'data-src-windows="/media/img/test-windows.png"', markup)
+        self.assertIn(u'data-src-mac="/media/img/test-mac.png"', markup)
 
     def test_platform_img_with_optional_attributes(self, find_static):
         """Should return expected markup with optional attributes"""
@@ -294,8 +294,8 @@ class TestPlatformImg(TestCase):
     def test_platform_img_with_high_res(self, find_static):
         """Should return expected markup with high resolution image attrs"""
         markup = self._render('test.png', {'high-res': True})
-        self.assertIn(u'data-src-windows-high-res="/media/test-windows-high-res.png"', markup)
-        self.assertIn(u'data-src-mac-high-res="/media/test-mac-high-res.png"', markup)
+        self.assertIn(u'data-src-windows-high-res="/media/img/test-windows-high-res.png"', markup)
+        self.assertIn(u'data-src-mac-high-res="/media/img/test-mac-high-res.png"', markup)
         self.assertIn(u'data-high-res="true"', markup)
 
     def test_platform_img_with_l10n(self, find_static):
@@ -462,19 +462,19 @@ class TestHighResImg(TestCase):
         """Should return expected markup without optional attributes"""
         markup = self._render('test.png')
         expected = (
-            u'<img class="js " src="" data-processed="false" data-src="/media/test.png" '
-            u'data-high-res="true" data-high-res-src="/media/test-high-res.png">'
-            u'<noscript><img class="" src="/media/test.png"></noscript>')
+            u'<img class="js " src="" data-processed="false" data-src="/media/img/test.png" '
+            u'data-high-res="true" data-high-res-src="/media/img/test-high-res.png">'
+            u'<noscript><img class="" src="/media/img/test.png"></noscript>')
         self.assertEqual(markup, expected)
 
     def test_high_res_img_with_optional_attributes(self):
         """Should return expected markup with optional attributes"""
         markup = self._render('test.png', {'data-test-attr': 'test', 'class': 'logo'})
         expected = (
-            u'<img class="js logo" src="" data-processed="false" data-src="/media/test.png" '
-            u'data-high-res="true" data-high-res-src="/media/test-high-res.png" '
+            u'<img class="js logo" src="" data-processed="false" data-src="/media/img/test.png" '
+            u'data-high-res="true" data-high-res-src="/media/img/test-high-res.png" '
             u'data-test-attr="test"><noscript>'
-            u'<img class="logo" src="/media/test.png" data-test-attr="test"></noscript>')
+            u'<img class="logo" src="/media/img/test.png" data-test-attr="test"></noscript>')
         self.assertEqual(markup, expected)
 
     def test_high_res_img_with_l10n(self):

--- a/bedrock/thunderbird/templates/thunderbird/base-resp.html
+++ b/bedrock/thunderbird/templates/thunderbird/base-resp.html
@@ -76,7 +76,7 @@
 {% endblock email_form %}
 
 {% block site_header_logo %}
-<h2><a href="{{ url('thunderbird.index') }}">{{ high_res_img('img/thunderbird/template/logo-wordmark.png', {'alt': 'Thunderbird', 'width': '260', 'height': '72'}) }}</a></h2>
+<h2><a href="{{ url('thunderbird.index') }}">{{ high_res_img('thunderbird/template/logo-wordmark.png', {'alt': 'Thunderbird', 'width': '260', 'height': '72'}) }}</a></h2>
 {% endblock %}
 
 {% block site_js %}

--- a/bedrock/thunderbird/templates/thunderbird/index.html
+++ b/bedrock/thunderbird/templates/thunderbird/index.html
@@ -12,7 +12,7 @@
 
 {% block site_header_nav %}{% endblock %}
 {% block site_header_logo %}
-  <h2>{{ high_res_img('img/thunderbird/landing/wordmark.png', {'alt': _('Thunderbird'), 'width': '304', 'height': '84'}) }}</h2>
+  <h2>{{ high_res_img('thunderbird/landing/wordmark.png', {'alt': _('Thunderbird'), 'width': '304', 'height': '84'}) }}</h2>
 {% endblock %}
 
 {% block site_css %}{% endblock %}
@@ -26,7 +26,7 @@
 <main role="main">
   <div id="main-feature">
     <div class="row">
-      {{ high_res_img('img/thunderbird/landing/logo.png', {'alt': _('Thunderbird'), 'width': '120', 'height': '120'}) }}
+      {{ high_res_img('thunderbird/landing/logo.png', {'alt': _('Thunderbird'), 'width': '120', 'height': '120'}) }}
       <h1 class="large">{{ self.page_title() }}</h1>
       <p class="large">{{ self.page_desc() }}</p>
       <div class="download-button-wrapper">

--- a/docs/coding.rst
+++ b/docs/coding.rst
@@ -52,13 +52,13 @@ high_res_img()
 ^^^^^^^^^^^^^^
 For images that include a high-resolution alternative for displays with a high pixel density, use the `high_res_img()` function::
 
-    high_res_img('img/firefox/new/firefox-logo.png', {'alt': 'Firefox', 'width': '200', 'height': '100'})
+    high_res_img('firefox/new/firefox-logo.png', {'alt': 'Firefox', 'width': '200', 'height': '100'})
 
-The `high_res_img()` function will automatically look for the image in the URL parameter suffixed with `'-high-res'`, e.g. `img/firefox/new/firefox-logo-high-res.png` and switch to it if the display has high pixel density.
+The `high_res_img()` function will automatically look for the image in the URL parameter suffixed with `'-high-res'`, e.g. `firefox/new/firefox-logo-high-res.png` and switch to it if the display has high pixel density.
 
 `high_res_img()` supports localized images by setting the `'l10n'` parameter to `True`::
 
-    high_res_img('img/firefox/new/firefox-logo.png', {'l10n': True, 'alt': 'Firefox', 'width': '200', 'height': '100'})
+    high_res_img('firefox/new/firefox-logo.png', {'l10n': True, 'alt': 'Firefox', 'width': '200', 'height': '100'})
 
 When using localization, `high_res_img()` will look for images in the appropriate locale folder. In the above example, for the `de` locale, both standard and high-res versions of the image should be located at `media/img/l10n/de/firefox/new/`.
 
@@ -74,13 +74,13 @@ platform_img()
 ^^^^^^^^^^^^^^
 Finally, for outputting an image that differs depending on the platform being used, the `platform_img()` function will automatically display the image for the user's browser::
 
-    platform_img('img/firefox/new/browser.png', {'alt': 'Firefox screenshot'})
+    platform_img('firefox/new/browser.png', {'alt': 'Firefox screenshot'})
 
 `platform_img()` will automatically look for the images `browser-mac.png`, `browser-win.png`, `browser-linux.png`, etc. Platform image also supports hi-res images by adding `'high-res': True` to the list of optional attributes.
 
 `platform_img()` supports localized images by setting the `'l10n'` parameter to `True`::
 
-    platform_img('img/firefox/new/firefox-logo.png', {'l10n': True, 'alt': 'Firefox screenshot'})
+    platform_img('firefox/new/firefox-logo.png', {'l10n': True, 'alt': 'Firefox screenshot'})
 
 When using localization, `platform_img()` will look for images in the appropriate locale folder. In the above example, for the `es-ES` locale, all platform versions of the image should be located at `media/img/l10n/es-ES/firefox/new/`.
 


### PR DESCRIPTION
See the second commit in #3217 for why this should be fixed.