### PR TITLE
Bug 987852 Add redirects for archived MPL pages

### DIFF
--- a/etc/httpd/global.conf
+++ b/etc/httpd/global.conf
@@ -587,6 +587,13 @@ RewriteRule ^/access/windows/at-apis.html$ https://developer.mozilla.org/en-US/d
 RewriteRule ^/access/windows/msaa-server.html$ https://developer.mozilla.org/en-US/docs/Web/Accessibility/Implementing_MSAA_server [L,R=301]
 RewriteRule ^/access/windows/zoomtext.html$ https://developer.mozilla.org/en-US/docs/Mozilla/Accessibility/ZoomText [L,R=301]
 
+# bug 987852
+RewriteRule ^/MPL/0\.95/(.*) http://website-archive.mozilla.org/www.mozilla.org/mpl/MPL/0\.95/$1 [L,R=301]
+RewriteRule ^/MPL/1\.0/(.*) http://website-archive.mozilla.org/www.mozilla.org/mpl/MPL/1\.0/$1 [L,R=301]
+RewriteRule ^/MPL/2\.0/process/(.*) http://website-archive.mozilla.org/www.mozilla.org/mpl/MPL/2\.0/process/$1 [L,R=301]
+RewriteRule ^/MPL/NPL/(.*) http://website-archive.mozilla.org/www.mozilla.org/mpl/MPL/NPL/$1 [L,R=301]
+RewriteRule ^/MPL/boilerplate-1\.1/(.*) http://website-archive.mozilla.org/www.mozilla.org/mpl/MPL/boilerplate-1\.1/$1 [L,R=301]
+
 # bug 1148187
 RewriteRule ^/access/(.*) http://website-archive.mozilla.org/www.mozilla.org/access/access/$1 [L,R=301]
 


### PR DESCRIPTION
These redirects are for this set of pages moved to the website-archive server in this commit: https://viewvc.svn.mozilla.org/vc?revision=145674&view=revision