### PR TITLE
Add sslify for Deis deployments.

### DIFF
--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -294,6 +294,7 @@ DOMAIN_METHODS = {
 }
 
 MIDDLEWARE_CLASSES = (
+    'sslify.middleware.SSLifyMiddleware',
     'bedrock.mozorg.middleware.MozorgRequestTimingMiddleware',
     'django_statsd.middleware.GraphiteMiddleware',
     'bedrock.tabzilla.middleware.TabzillaLocaleURLMiddleware',
@@ -847,3 +848,8 @@ STATSD_CLIENT = config('STATSD_CLIENT', default='django_statsd.clients.normal')
 STATSD_HOST = config('STATSD_HOST', default='127.0.0.1')
 STATSD_PORT = config('STATSD_PORT', cast=int, default=8125)
 STATSD_PREFIX = config('STATSD_PREFIX', default='bedrock')
+
+SSLIFY_DISABLE = config('DISABLE_SSL', default=True, cast=bool)
+if not SSLIFY_DISABLE:
+    SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
+    USE_X_FORWARDED_HOST = True

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -187,3 +187,6 @@ dj-database-url==0.3.0
 
 # sha256: ufv3R_qOcR0zDy9Da5suz17tnrZ6Y3yoGrzRHCq-3sg
 python-decouple==2.3
+
+# sha256: 9r_SEEjH38lbOWWaPad3ddbbHB96dFgFzMbGE494O20
+django-sslify==0.2.7


### PR DESCRIPTION
When SSLify is enabled (disabled by default) will redirect http requests
to https.

@pmclanahan or @jgmize r?