### PR TITLE
Bug 1136436 - remove waffle switch for iOS page

### DIFF
--- a/bedrock/firefox/urls.py
+++ b/bedrock/firefox/urls.py
@@ -12,7 +12,6 @@ import views
 import bedrock.releasenotes.views
 from bedrock.releasenotes import version_re
 
-from waffle.decorators import waffle_switch
 
 latest_re = r'^firefox(?:/(?P<version>%s))?/%s/$'
 firstrun_re = latest_re % (version_re, 'firstrun')
@@ -44,9 +43,7 @@ urlpatterns = patterns('',
     page('firefox/interest-dashboard', 'firefox/interest-dashboard.html'),
     page('firefox/android', 'firefox/android/index.html'),
     page('firefox/android/faq', 'firefox/android/faq.html'),
-    page('firefox/ios', 'firefox/ios.html',
-        decorators=waffle_switch('ios-active')),
-
+    page('firefox/ios', 'firefox/ios.html'),
     page('firefox/os/faq', 'firefox/os/faq.html'),
     page('firefox/products', 'firefox/family/index.html'),
     url('^firefox/send-to-device-post/$', views.send_to_device_ajax,

--- a/media/css/firefox/ios.less
+++ b/media/css/firefox/ios.less
@@ -400,9 +400,9 @@ a.go {
             display: inline-block;
             width: 26px;
             height: 26px;
-            margin: 0 10px;
+            margin: -5px 10px 0;
             vertical-align: middle;
-            background-position: -142px -390px;
+            background-position: -142px -388px;
             background-repeat: no-repeat;
             .at2x('/media/img/firefox/ios/sync-icon-sprite.png', 292px, 426px);
         }


### PR DESCRIPTION
Also sneaking in a fix for a minor display bug on the sync signed in icon.