### PR TITLE
[fix bug 1190614] Fix footer on /firefox/new/2/.

### DIFF
--- a/bedrock/settings/static_media.py
+++ b/bedrock/settings/static_media.py
@@ -438,7 +438,7 @@ PIPELINE_CSS = {
         'source_filenames': (
             'css/sandstone/sandstone-resp.less',
             'css/tabzilla/tabzilla-static.less',
-            'css/firefox/simple_footer-resp.less',
+            'css/base/simple_footer-resp.less',
             'css/firefox/new2.less',
         ),
         'output_filename': 'css/firefox_new2-bundle.css',


### PR DESCRIPTION
The [merge that happened just before PR #3232 merged](https://github.com/mozilla/bedrock/commit/33a5ff3eaa43b24cc1a502b6cab47fb5ad7cdc79) moved the `simple_footer-resp.less` file, which meant PR #3232 (previously r+'d) was (unknowingly) referencing the file in the wrong spot. What a coincidence!

Anyway, this fixes that. 