### PR TITLE
Bug 1201914 Fix MPL URLs that include .html suffix

### DIFF
--- a/etc/httpd/global.conf
+++ b/etc/httpd/global.conf
@@ -875,10 +875,10 @@ RewriteRule ^/media/flash/playerWithControls.swf - [F]
 # Bug 896474
 RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?about(/?|/.+)$ /b/$1about$2 [PT]
 
-# Bug 987852
-RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?MPL(/?|/.+)$ /b/$1MPL$2 [PT]
-RewriteRule ^/MPL/1.1/index\.txt /media/MPL/1.1/index.txt [L,PT]
+# Bug 987852 & 1201914
+RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?MPL/(.+).html$ /$1MPL/$2/ [L,R=301]
 RewriteRule ^/MPL/2.0/index\.txt /media/MPL/2.0/index.txt [L,PT]
+RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?MPL(/?|/.+)$ /b/$1MPL$2 [PT]
 
 # Bug 1040970
 RewriteRule ^/mozillacareers$ https://wiki.mozilla.org/People/mozillacareers?utm_medium=redirect&utm_source=mozillacareers-vanity [L,R=301]

--- a/etc/httpd/global.conf
+++ b/etc/httpd/global.conf
@@ -596,6 +596,7 @@ RewriteRule ^/MPL/1\.0/(.*) http://website-archive.mozilla.org/www.mozilla.org/m
 RewriteRule ^/MPL/2\.0/process/(.*) http://website-archive.mozilla.org/www.mozilla.org/mpl/MPL/2\.0/process/$1 [L,R=301]
 RewriteRule ^/MPL/NPL/(.*) http://website-archive.mozilla.org/www.mozilla.org/mpl/MPL/NPL/$1 [L,R=301]
 RewriteRule ^/MPL/boilerplate-1\.1/(.*) http://website-archive.mozilla.org/www.mozilla.org/mpl/MPL/boilerplate-1\.1/$1 [L,R=301]
+RewriteRule ^/MPL/missing.html http://website-archive.mozilla.org/www.mozilla.org/mpl/MPL/missing.html [L,R=301]
 
 # bug 1148187
 RewriteRule ^/access/(.*) http://website-archive.mozilla.org/www.mozilla.org/access/access/$1 [L,R=301]


### PR DESCRIPTION
Also fix the order of the rules, and add a missing archive redirect for missing.html (get it?).