### PR TITLE
[fix bug 1136436] Fix CSS typo on /firefox/ios page.

### DIFF
--- a/media/css/firefox/ios.less
+++ b/media/css/firefox/ios.less
@@ -551,7 +551,7 @@ a.go {
     .form-container {
         padding-top: 130px;
         background-position: center 25px;
-        backdround-repeat: no-repeat;
+        background-repeat: no-repeat;
         .at2x('/media/img/firefox/ios/send-to-device.png', 201px, 90px);
     }
 


### PR DESCRIPTION
@craigcook r? :sos: :swimmer: 