### PR TITLE
Run tests against the built docker image.

### DIFF
--- a/bedrock/base/tests/test_accepted_locales.py
+++ b/bedrock/base/tests/test_accepted_locales.py
@@ -41,7 +41,7 @@ class AcceptedLocalesTest(test_utils.TestCase):
         cls.PROD_LANGUAGES = settings.PROD_LANGUAGES
         cls.DEV_LANGUAGES = settings.DEV_LANGUAGES
         settings.PROD_LANGUAGES = ('en-US',)
-        os.rename(cls.locale, cls.locale_bkp)
+        shutil.move(cls.locale, cls.locale_bkp)
         for loc in ('en-US', 'fr', 'templates'):
             os.makedirs(os.path.join(cls.locale, loc, 'LC_MESSAGES'))
         open(os.path.join(cls.locale, 'empty_file'), 'w').close()
@@ -54,7 +54,7 @@ class AcceptedLocalesTest(test_utils.TestCase):
         settings.PROD_LANGUAGES = cls.PROD_LANGUAGES
         settings.DEV_LANGUAGES = cls.DEV_LANGUAGES
         shutil.rmtree(cls.locale)
-        os.rename(cls.locale_bkp, cls.locale)
+        shutil.move(cls.locale_bkp, cls.locale)
 
     def test_build_dev_languages(self):
         """Test that the list of dev locales is built properly.

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,10 +1,5 @@
 db:
-  image: mysql:5.5
-  environment:
-    - MYSQL_DATABASE=bedrock
-    - MYSQL_USER=bedrock
-    - MYSQL_PASSWORD=bedrock
-    - MYSQL_ROOT_PASSWORD=root
+  image: postgres:9.4
 web:
   build: ../
   ports:
@@ -13,7 +8,7 @@ web:
     - db
   environment:
     - PYTHONDONTWRITEBYTECODE=1
-    - DATABASE_URL=mysql://bedrock:bedrock@db/bedrock
+    - DATABASE_URL=postgres://postgres@db/postgres
     - DEBUG=True
     - ALLOWED_HOSTS=localhost,127.0.0.1,
     - SECRET_KEY=39114b6a-2858-4caf-8878-482a24ee9542

--- a/docker/jenkins/runtests.sh
+++ b/docker/jenkins/runtests.sh
@@ -22,9 +22,14 @@ DOCKER_COMPOSE="docker-compose --project-name jenkins${JOB_NAME}${BUILD_NUMBER} 
 
 $DOCKER_COMPOSE build
 
+# Start the database and give it some time to boot up
+$DOCKER_COMPOSE up -d db
+
 docker save `echo jenkins${JOB_NAME}${BUILD_NUMBER}| sed s/_//g`_web | sudo docker-squash -t `echo jenkins${JOB_NAME}${BUILD_NUMBER}| sed s/_//g`_web | docker load
 
-# Does nothing atm.
 
-# Delete virtualenv
+$DOCKER_COMPOSE run -T web ./manage.py test
+
+# Cleanup
+$DOCKER_COMPOSE stop
 rm -rf $TDIR


### PR DESCRIPTION
This runs only `./manage.py test`. I see in `travis.yml` that we run `grunt test` and pre-script linters like `flake8`, `runscript check_calendars`.

We probably want to run all these in docker too.  Thoughts @pmclanahan ?