### PR TITLE
[fix bug 1199258] Redirect fxa signin users on fx40 firstrun.

### DIFF
--- a/bedrock/firefox/templates/firefox/australis/fx40/firstrun.html
+++ b/bedrock/firefox/templates/firefox/australis/fx40/firstrun.html
@@ -69,7 +69,7 @@
     </div>
 
     <div class="rightcol">
-      <iframe id="fxa" scrolling="no" data-src="{{ settings.FXA_IFRAME_SRC }}?utm_campaign=fxa-embedded-form&amp;utm_medium=referral&amp;utm_source=firstrun&amp;utm_content=fx-{{ version }}&amp;entrypoint=firstrun&amp;service=sync&amp;context=iframe&amp;style=chromeless"></iframe>
+      <iframe id="fxa" scrolling="no" data-src="{{ settings.FXA_IFRAME_SRC }}?utm_campaign=fxa-embedded-form&amp;utm_medium=referral&amp;utm_source=firstrun&amp;utm_content=fx-{{ version }}&amp;entrypoint=firstrun&amp;service=sync&amp;context=iframe&amp;style=chromeless&amp;haltAfterSignIn=true"></iframe>
     </div>
   </div>
 </section>

--- a/media/js/firefox/australis/fx40/firstrun.js
+++ b/media/js/firefox/australis/fx40/firstrun.js
@@ -56,12 +56,14 @@
                 });
 
                 break;
-            // track user with FxA account logging in (very rare for firstrun)
+            // track & redirect user with FxA account logging in
             case 'login':
                 window.dataLayer.push({
                     'event': 'firstrun-fxa',
                     'interaction': 'fxa-login'
                 });
+
+                window.location.href = fxaIframeSrc + '/settings';
 
                 break;
             }


### PR DESCRIPTION
Need to wait until FxA prod is updated (possibly 9/16?) before merging, but should be reviewed and tested on demo4 now.

https://www-demo4.allizom.org/en-US/firefox/40.0/firstrun/

Instructions for testing FxA staging can be found [here](https://gist.github.com/jpetto/f46f1850737b7a838cad).

Summary of problem/fix:

Currently, users signing in to FxA at `/firefox/40.0/firstrun/` get a less than ideal experience, as the links displayed post-login are contained within the iframe. Our short term fix is to immediately redirect users that sign in to their FxA account settings.

This fix requires a change on the FxA side to force the sign in to complete immediately, as opposed to waiting for an XHR request. Without the FxA change, a redirect will invalidate the sign in.

This PR, tested against FxA stage, should redirect users signing in to FxA to the FxA settings screen immediately with no errors, keeping them signed in to FxA.

