### PR TITLE
Fix bug 1204652 - Firefox for iOS available in Canada

### DIFF
--- a/media/js/firefox/ios.js
+++ b/media/js/firefox/ios.js
@@ -21,7 +21,7 @@ if (typeof window.Mozilla === 'undefined') {
     // Add two-letter country codes (lowercase) to this array to
     // to expand the market. We'll remove this logic for wide release.
     // Note: This is the country code, NOT locale code; they often differ.
-    var marketCountries = ['nz', 'au', 'at'];
+    var marketCountries = ['nz', 'au', 'at', 'ca'];
 
     var COUNTRY_CODE = '';
     var marketState = 'Unknown';


### PR DESCRIPTION
We should hold off merging this until we're pretty confident we won't need to do any other pushes (though it's also easy to revert if we have to). This update should not push to prod until we get confirmation that FxiOS is available in the Canada App Store.