### PR TITLE
Bug 1008100: fix typo in 404 template

### DIFF
--- a/bedrock/base/templates/404.html
+++ b/bedrock/base/templates/404.html
@@ -15,7 +15,7 @@
 <div id="main-feature">
   <div id="error-content">
     <h1>{{ _('Whoops!') }}</h1>
-    <p>{{ _('Did you make a left at that last URL instead of a right? No problem. here are some tips to get you back on your way:') }}</p>
+    <p>{{ _('Did you make a left at that last URL instead of a right? No problem. Here are some tips to get you back on your way:') }}</p>
     <ul>
       <li>{{ _('If you typed in the address, check your spelling. Could just be a typo.') }}</li>
       <li>


### PR DESCRIPTION
Re-using existing bug for reference.

The old PHP template has a slightly different text, “here” came after a
comma, so I guess blind copy and paste.
https://www.mozilla.org/en-US/404