### PR TITLE
Separate l10n dockerfile.

### DIFF
--- a/docker/DockerfileL10n
+++ b/docker/DockerfileL10n
@@ -1,0 +1,2 @@
+FROM $FROM_DOCKER_REPOSITORY:latest
+COPY . /app/locale

--- a/docker/jenkins/includeL10N.sh
+++ b/docker/jenkins/includeL10N.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# Needs DOCKER_REPOSITORY and FROM_DOCKER_REPOSITORY
+#
+# To set them go to Job -> Configure -> Build Environment -> Inject
+# passwords and Inject env variables
+#
+set -xe
+
+# Used to trigger downstream Jenkins jobs
+TRIGGER_FILE=locale/.docker-updated
+rm -rf $TRIGGER_FILE
+
+if [[ $BUILD_CAUSE == "TIMERTRIGGER" ]]
+then
+    SVN_STATUS=`svn status -uq locale | wc -l`
+    if [[ $SVN_STATUS == "0" ]]
+    then
+        # No updates, just exit
+        echo "No locale updates"
+        exit 0;
+    fi
+fi
+
+touch $TRIGGER_FILE
+
+set +e
+svn cleanup locale
+set -e
+svn co http://svn.mozilla.org/projects/mozilla.com/trunk/locales/ locale
+
+
+cat docker/DockerfileL10n | envsubst > ./locale/Dockerfile
+echo ".svn" > ./locale/.dockerignore
+
+docker build -f locale/Dockerfile -t $DOCKER_REPOSITORY:$GIT_COMMIT locale
+docker tag -f $DOCKER_REPOSITORY:$GIT_COMMIT $DOCKER_REPOSITORY:latest

--- a/docker/jenkins/push2dockerhub.sh
+++ b/docker/jenkins/push2dockerhub.sh
@@ -12,10 +12,5 @@ docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD -e $DOCKER_USERNAME@example
 # If pull request use $ghprbActualCommit otherwise use $GIT_COMMIT
 COMMIT="${ghprbActualCommit:=$GIT_COMMIT}"
 
-# Tag using git hash
-docker tag -f `echo jenkins${JOB_NAME}${BUILD_NUMBER}| sed s/_//g`_web $DOCKER_REPOSITORY:$COMMIT
 docker push $DOCKER_REPOSITORY:$COMMIT
-
-# Tag as latest
-docker tag -f `echo jenkins${JOB_NAME}${BUILD_NUMBER}| sed s/_//g`_web $DOCKER_REPOSITORY:latest
 docker push $DOCKER_REPOSITORY:latest

--- a/docker/jenkins/runtests.sh
+++ b/docker/jenkins/runtests.sh
@@ -2,6 +2,11 @@
 #
 # Runs unit_tests
 #
+# Needs DOCKER_REPOSITORY
+#
+# To set them go to Job -> Configure -> Build Environment -> Inject
+# passwords and Inject env variables
+#
 set -ex
 
 # Create a temporary virtualenv to install docker-compose
@@ -33,3 +38,9 @@ $DOCKER_COMPOSE run -T web ./manage.py test
 # Cleanup
 $DOCKER_COMPOSE stop
 rm -rf $TDIR
+
+# Tag docker image. This intentionally goes after cleanup to allow
+# docker-compose to stop containers.
+CURRENT_TAG=`echo jenkins${JOB_NAME}${BUILD_NUMBER}| sed s/_//g`_web
+docker tag -f $CURRENT_TAG $DOCKER_REPOSITORY:$GIT_COMMIT
+docker tag -f $CURRENT_TAG $DOCKER_REPOSITORY:latest

--- a/docker/jenkins/runtests.sh
+++ b/docker/jenkins/runtests.sh
@@ -18,11 +18,6 @@ pip install docker-compose==1.2.0
 # Pull locales, we probably need to move this elsewhere.
 git submodule update --init --recursive
 
-set +e
-svn cleanup locale
-set -e
-svn co http://svn.mozilla.org/projects/mozilla.com/trunk/locales/ locale
-
 DOCKER_COMPOSE="docker-compose --project-name jenkins${JOB_NAME}${BUILD_NUMBER} -f docker/docker-compose.yml"
 
 $DOCKER_COMPOSE build


### PR DESCRIPTION
A jenkins script `includeL10N.sh` will fetch updates from SVN and build a docker image based on the base bedrock docker image and will add the `locales` directory. 

- The Jenkins job will always produce a new docker image if triggered by other jobs and will in turn trigger downstream jobs. 

- If the job is triggered by Jenkins cron and there are no updates in the SVN repo it will not build a new image and will not trigger downstream jobs.

Tagged "Do not Merge" because I need to make changes to Jenkins before merging.

For demo see:
- https://ci.us-west.moz.works/view/giorgos-test/job/mozilla_bedrock_giorgos/
- https://ci.us-west.moz.works/view/giorgos-test/job/bedrock_giorgos_l10n/
- https://ci.us-west.moz.works/view/giorgos-test/job/bedrock_giorgos_pushtodockerhub/

This is ready for r? @pmclanahan or @jgmize 