### PR TITLE
Bug 1205265 - Use proper quotes for Romanian in privacy/tips

### DIFF
--- a/media/css/privacy/privacy-day.less
+++ b/media/css/privacy/privacy-day.less
@@ -269,8 +269,19 @@ html[lang^='en'] #tips-nav-direct li a span:after {
         content: "« ";
         left: -1em;
     }
+    
     &:after {
         content: " »";
+    }
+}
+
+[lang="ro"] .tip aside .quote {
+    &:before{
+        content: "„";
+    }
+    
+    &:after {
+        content: "”";
     }
 }
 


### PR DESCRIPTION
If you look at this page: https://www.mozilla.org/ro/privacy/tips/  the right side quote in green and italic has English-style quotemarks, and they should be Romanian: „”

The en-US page: https://www.mozilla.org/en-US/privacy/tips/

Probably some other locales also need their own specific quote marks in that less rule (German or Russian):

https://www.mozilla.org/ru/privacy/tips/ (should be « » like in French)

https://www.mozilla.org/de/privacy/tips/ (should be „ “ for Germany and Austria)

Honorable mention to [Cristi Silaghi](https://twitter.com/cristi_silaghi_) for bringing this matter to my attention!