### PR TITLE
[fix bug 1205282] Enable auto-downloads for IE 9 and above on scene 2 of /firefox/new/

### DIFF
--- a/media/js/base/global.js
+++ b/media/js/base/global.js
@@ -6,16 +6,16 @@
 // download buttons
 
 /**
- * A special function for IE.  Without this hack there is no prompt to download after they click.  sigh.
- * bug 393263
- * Note IE has since removed the 'MSIE' token in version 11. The hack is no longer needed for IE11.
- * http://msdn.microsoft.com/en-us/library/ie/bg182625%28v=vs.85%29.aspx#uaString
- * @param string direct link to download URL
+ * Bug 393263 A special function for IE < 9.
+ * Without this hack there is no prompt to download after they click. sigh.
+ * @param {link} direct link to download URL
+ * @param {userAgent} optional UA string for testing purposes.
  */
-function trigger_ie_download(link, appVersion) {
-    var version = appVersion || navigator.appVersion;
-    // Only open if we got a link and this is IE < 11.
-    if (link && version.indexOf('MSIE') !== -1) {
+function trigger_ie_download(link, userAgent) {
+    'use strict';
+    var ua = userAgent !== undefined ? userAgent : navigator.userAgent;
+    // Only open if we got a link and this is IE < 9.
+    if (link && window.site.platform === 'windows' && /MSIE\s[1-8]\./.test(ua)) {
         window.open(link, 'download_window', 'toolbar=0,location=no,directories=0,status=0,scrollbars=0,resizeable=0,width=1,height=1,top=0,left=0');
         window.focus();
     }

--- a/media/js/firefox/new.js
+++ b/media/js/firefox/new.js
@@ -292,14 +292,10 @@
                     }
                 } else {
                     showScene(2);
-                    // For IE < 11 we supress the auto-download since this
+                    // For IE < 9 we supress the auto-download since this
                     // will soon be triggered using a popup on bedrock prior
-                    // to landing on /firefox/download/#download-fx. This
-                    // check reflects the current logic on bedrock and the old
-                    // PHP download pages (which also only check for `MSIE`).
-                    // Once all buttons point to this page on all locales,
-                    // we can switch this check to IE < 9.
-                    if (navigator.appVersion.indexOf('MSIE') !== -1) {
+                    // to landing on /firefox/download/#download-fx.
+                    if (isIELT9) {
                         return;
                     }
 

--- a/tests/unit/spec/base/global.js
+++ b/tests/unit/spec/base/global.js
@@ -11,34 +11,32 @@ describe('global.js', function() {
 
     describe('trigger_ie_download', function () {
 
-        it('should open a popup for IE < 11', function () {
-            // Let's pretend to be IE version 9 just for this individual test
-            var appVersion = '5.0 (compatible; MSIE 9.0; Windows NT 6.1; WOW64; Trident/5.0)';
+        beforeEach(function() {
+            window.site.platform = 'windows';
+        });
 
-            /* Wrap window.open with a stub function, since all we need
-             * to know is that window.open gets called. We do not need
-             * window.open to execute to satisfy the test. We can also
-             * spy on this stub to see if it gets called successfully. */
+        afterEach(function() {
+            window.site.platform = 'other';
+        });
+
+        it('should open a popup for IE < 9', function () {
+            var userAgent = 'Mozilla/5.0 (compatible; MSIE 8.0; Windows NT 6.1; Trident/4.0; GTB7.4; InfoPath.2; SV1; .NET CLR 3.3.69573; WOW64; en-US)';
             window.open = sinon.stub();
-            trigger_ie_download('foo', appVersion);
+            trigger_ie_download('foo', userAgent);
             expect(window.open.called).toBeTruthy();
         });
 
-        it('should not open a popup for IE 11', function () {
-            // Let's pretend to be IE version 11
-            var appVersion = '5.0 (Windows NT 6.3; WOW64; Trident/7.0; .NET4.0E; .NET4.0C; .NET CLR 3.5.30729; .NET CLR 2.0.50727; .NET CLR 3.0.30729; rv:11.0) like Gecko';
-
+        it('should not open a popup for IE 9', function () {
+            var userAgent = 'Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 7.1; Trident/5.0)';
             window.open = sinon.stub();
-            trigger_ie_download('foo', appVersion);
+            trigger_ie_download('foo', userAgent);
             expect(window.open.called).not.toBeTruthy();
         });
 
         it('should not open a popup for other browsers', function () {
-            // Let's pretend to be a non IE browser
-            var appVersion = '5.0 (Macintosh)';
-
+            var userAgent = 'Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2228.0 Safari/537.36';
             window.open = sinon.stub();
-            trigger_ie_download('foo', appVersion);
+            trigger_ie_download('foo', userAgent);
             expect(window.open.called).not.toBeTruthy();
         });
 
@@ -153,17 +151,13 @@ describe('global.js', function() {
     describe('init_android_download_links', function () {
 
         beforeEach(function () {
-            // Pretend we're on Android
-            window.site = {
-                platform: 'android'
-            };
+            window.site.platform = 'android';
             //create an HTML fixture to test against
             $('<a class="download-link" href="https://play.google.com/store/apps/details?id=org.mozilla.firefox">foo</a>').appendTo('body');
         });
 
         afterEach(function(){
-            // Tidy up after each test
-            window.site = null;
+            window.site.platform = 'other';
             $('.download-link').remove();
         });
 


### PR DESCRIPTION
Still need to push this to a demo for testing, so marking as do-not-merge for now.