### PR TITLE
Fix bug 1206021: Upgrade django-pipeline

### DIFF
--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -226,7 +226,7 @@ def JINJA_CONFIG():
             'jinja2.ext.loopcontrols', 'lib.l10n_utils.template.l10n_blocks',
             'lib.l10n_utils.template.lang_blocks',
             'jingo_markdown.extensions.MarkdownExtension',
-            'pipeline.jinja2.ext.PipelineExtension',
+            'pipeline.templatetags.ext.PipelineExtension',
         ],
         # Make None in templates render as ''
         'finalize': lambda x: x if x is not None else '',

--- a/media/css/firefox/desktop/tips.less
+++ b/media/css/firefox/desktop/tips.less
@@ -3,7 +3,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 @import '../../sandstone/lib.less';
-@import '../menu-resp.less';
+@import '../../base/menu-resp.less';
 
 /* {{{ Template overrides */
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -2,9 +2,9 @@
 # sha256: uTV9LOvmGZcFXUF9YH-cZQ6BfNGjg7mhuIvx7a15fHU
 Django==1.7.10
 
-# sha256: 4h6LijS01EbJtWCQ4yh847Y9GuHPbe8ejb-Ij0DkbMw
-# sha256: Vibe-NP1i9L1ne67vn7-KckiAGpFFQblwH3VtKSQ_8M
-django-pipeline==1.4.7
+# sha256: xxHohhXvN7I1nOMJeOrnxl5UkkrrBDIpZWxeI5Bl5ZY
+# sha256: pakJ9APQ6lbyEWGJSf9ON48W5amWvegZvStbDnqbuP4
+django-pipeline==1.5.4
 
 # sha256: QZSbCQMWEXmRNuAZFouE617Ymcjk5pIRfS04UEZZ_RY
 icalendar==3.8.3


### PR DESCRIPTION
The latest version does error on a broken import in .less files.

I also found and fixed (because it errored) another broken import that
doesn't appear to have been affecting the site.