### PR TITLE
Bug1208358: Fix redirection problem in /ja/about

### DIFF
--- a/etc/httpd/global.conf
+++ b/etc/httpd/global.conf
@@ -186,10 +186,9 @@ RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/toolkit/download-to-your-devices(.*)
 # bug 921564
 RewriteRule ^/(ach|af|ak|an|ar|as|ast|az|be|bg|bn-BD|bn-IN|br|brx|bs|ca|cs|csb|cy|da|de|dsb|ee|el|en-GB|en-US|en-ZA|eo|es-AR|es-CL|es-ES|es-MX|et|eu|fa|ff|fi|fr|fy-NL|ga-IE|gd|gl|gu-IN|ha|he|hi-IN|hr|hsb|hu|hy-AM|id|ig|is|it|ja|ja-JP-mac|ka|kk|km|kn|ko|ku|lg|lij|ln|lt|lv|mai|mk|ml|mn|mr|ms|my|nb-NO|nl|nn-NO|nso|oc|or|pa-IN|pl|pt-BR|pt-PT|rm|ro|ru|sah|sat|si|sk|sl|son|sq|sr|sv-SE|sw|ta|ta-LK|te|th|tr|uk|ur|uz|vi|wo|xh|yo|zh-CN|zh-TW|zu)(/?)$ /b/$1$2 [PT]
 
-# bug 987059, 1050149, 1072170
-RewriteCond %{REQUEST_URI} !^/ja/about/manifesto
-RewriteCond %{REQUEST_URI} !^/ja/about/legal
-RewriteRule ^/ja/about(/?|/.+)$ http://www.mozilla.jp/about/mozilla/ [L,R=301]
+# bug 987059, 1050149, 1072170, 1208358
+RewriteRule ^/ja/about/?$ http://www.mozilla.jp/about/mozilla/ [L,R=301]
+RewriteRule ^/ja/about/japan/?$ http://www.mozilla.jp/about/japan/ [L,R=301]
 
 # bug 1091977
 RewriteRule ^/ja/contribute(/?|/.+)$ http://www.mozilla.jp/community/ [L,R=301]


### PR DESCRIPTION
ja-locale users can not access some resources served under /ja/about, due to redirection rules. 
This issue is filed as Bug 1208358. Please refer it for details.