### PR TITLE
Bug 1197244 - Newsletters Control Center:  use a separate .lang file …

### DIFF
--- a/bedrock/mozorg/forms.py
+++ b/bedrock/mozorg/forms.py
@@ -31,7 +31,8 @@ from .email_contribute import INTEREST_CHOICES
 FORMATS = (('H', _lazy('HTML')), ('T', _lazy('Text')))
 LANGS_TO_STRIP = ['en-US', 'es']
 PARENTHETIC_RE = re.compile(r' \([^)]+\)$')
-LANG_FILES = ['firefox/partners/index', 'mozorg/contribute', 'mozorg/contribute/index']
+LANG_FILES = ['firefox/partners/index', 'mozorg/contribute',
+              'mozorg/contribute/index', 'mozorg/newsletters']
 
 
 def strip_parenthetical(lang_name):

--- a/bedrock/newsletter/forms.py
+++ b/bedrock/newsletter/forms.py
@@ -20,6 +20,8 @@ from lib.l10n_utils.dotlang import _, _lazy
 
 _newsletters_re = re.compile(r'^[\w,-]+$')
 
+LANG_FILES = ['mozorg/newsletters']
+
 
 def validate_newsletters(newsletters):
     if not newsletters:

--- a/bedrock/newsletter/templates/newsletter/base.html
+++ b/bedrock/newsletter/templates/newsletter/base.html
@@ -1,6 +1,7 @@
 {% extends 'base-resp.html' %}
 
 {# Base template for newsletter pages #}
+{% set_lang_files "mozorg/newsletters" %}
 
 {% block page_title %}{{ _('Newsletter Subscriptions') }}{% endblock page_title %}
 

--- a/bedrock/newsletter/templates/newsletter/confirm.html
+++ b/bedrock/newsletter/templates/newsletter/confirm.html
@@ -1,5 +1,7 @@
 {% extends 'newsletter/base.html' %}
 
+{% set_lang_files "mozorg/newsletters" %}
+
 {% block extra_meta %}<meta name="robots" content="noindex">{% endblock %}
 
 {% block body_id %}newsletter-confirm{% endblock body_id %}

--- a/bedrock/newsletter/templates/newsletter/existing.html
+++ b/bedrock/newsletter/templates/newsletter/existing.html
@@ -1,5 +1,7 @@
 {% extends 'newsletter/base.html' %}
 
+{% set_lang_files "mozorg/newsletters" %}
+
 {# Template used for a user to manage their subscriptions #}
 
 {% block extra_meta %}<meta name="robots" content="noindex">{% endblock %}

--- a/bedrock/newsletter/templates/newsletter/includes/form.html
+++ b/bedrock/newsletter/templates/newsletter/includes/form.html
@@ -2,6 +2,8 @@
  # License, v. 2.0. If a copy of the MPL was not distributed with this
  # file, You can obtain one at http://mozilla.org/MPL/2.0/. #}
 
+{% set_lang_files "mozorg/newsletters" %}
+
 {% from "newsletter/includes/macros.html" import email_form_thankyou with context %}
 
 {% if not success %}

--- a/bedrock/newsletter/templates/newsletter/includes/macros.html
+++ b/bedrock/newsletter/templates/newsletter/includes/macros.html
@@ -2,6 +2,8 @@
  # License, v. 2.0. If a copy of the MPL was not distributed with this
  # file, You can obtain one at http://mozilla.org/MPL/2.0/. #}
 
+{% set_lang_files "mozorg/newsletters" %}
+
 {% macro email_form_thankyou() %}
   <h3>{{ _('Thanks! Please check your inbox to confirm your subscription.') }}</h3>
   <p>

--- a/bedrock/newsletter/templates/newsletter/ios.html
+++ b/bedrock/newsletter/templates/newsletter/ios.html
@@ -4,6 +4,8 @@
 
 {% extends "firefox/base-resp.html" %}
 
+{% set_lang_files "mozorg/newsletters" %}
+
 {% block page_title_prefix %}{% endblock %}
 {% block page_title %}{{ _('Firefox on iOS — Sign up for email updates — Mozilla') }}{% endblock %}
 {% block page_desc %}{{ _('Sign up today to receive email updates about the iOS version of Firefox.') }}{% endblock %}

--- a/bedrock/newsletter/templates/newsletter/mozilla-and-you.html
+++ b/bedrock/newsletter/templates/newsletter/mozilla-and-you.html
@@ -1,5 +1,7 @@
 {% extends 'newsletter/one_newsletter_signup.html' %}
 
+{% set_lang_files "mozorg/newsletters" %}
+
 {% set newsletter_title = _('Mozilla Newsletter') %}
 {% set newsletter_id = 'mozilla-and-you' %}
 

--- a/bedrock/newsletter/templates/newsletter/one_newsletter_signup.html
+++ b/bedrock/newsletter/templates/newsletter/one_newsletter_signup.html
@@ -1,4 +1,7 @@
 {% extends 'base-resp.html' %}
+
+{% set_lang_files "mozorg/newsletters" %}
+
 {#
  Base template for pages used to signup for one particular newsletter.
 

--- a/bedrock/newsletter/templates/newsletter/recovery.html
+++ b/bedrock/newsletter/templates/newsletter/recovery.html
@@ -1,5 +1,7 @@
 {% extends 'newsletter/base.html' %}
 
+{% set_lang_files "mozorg/newsletters" %}
+
 {% block extra_meta %}<meta name="robots" content="noindex">{% endblock %}
 
 {% block body_id %}newsletter-recovery{% endblock body_id %}

--- a/bedrock/newsletter/templates/newsletter/updated.html
+++ b/bedrock/newsletter/templates/newsletter/updated.html
@@ -1,5 +1,7 @@
 {% extends 'newsletter/base.html' %}
 
+{% set_lang_files "mozorg/newsletters" %}
+
 {% block extra_meta %}<meta name="robots" content="noindex">{% endblock %}
 
 {% block body_id %}newsletter-updated{% endblock body_id %}
@@ -65,7 +67,7 @@
       </div>
       <div class="sub-feature" id="about">
         <h4>{{ _('About us') }}</h4>
-        <p>{{ _('What’s  Mozilla all about?') }}</p>
+        <p>{{ _('What’s Mozilla all about?') }}</p>
         <a href="{{ url('mozorg.about') }}" class="link">{{ _('We’re glad you asked!') }}</a>
       </div>
 

--- a/bedrock/newsletter/views.py
+++ b/bedrock/newsletter/views.py
@@ -32,7 +32,7 @@ from bedrock.newsletter import utils
 
 log = commonware.log.getLogger('b.newsletter')
 
-LANG_FILES = ['mozorg/contribute']
+LANG_FILES = ['mozorg/newsletters']
 general_error = _lazy(u'We are sorry, but there was a problem '
                       u'with our system. Please try again later!')
 thank_you = _lazy(u'Thanks for updating your email preferences.')

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -184,7 +184,7 @@ LANGUAGES = lazy(lazy_langs, dict)()
 FEED_CACHE = 3900
 DOTLANG_CACHE = 600
 
-DOTLANG_FILES = ['main', 'download_button', 'newsletter']
+DOTLANG_FILES = ['main', 'download_button']
 
 # Paths that don't require a locale code in the URL.
 # matches the first url component (e.g. mozilla.org/gameon/)

--- a/docs/l10n.rst
+++ b/docs/l10n.rst
@@ -161,7 +161,7 @@ know which one to use when translating a particular string?
 * All translations from Python files are put into main.lang. This
   should be a very limited set of strings and most likely should be
   available to all pages.
-* Templates always load in `main.lang`, `download_button.lang`, and `newsletter.lang`
+* Templates always load in `main.lang` and `download_button.lang`.
 * Additionally, each template has its own .lang file, so a template at
   `mozorg/firefox.html` would use the .lang file at
   `<locale>/mozorg/firefox.lang`.
@@ -175,7 +175,7 @@ know which one to use when translating a particular string?
     {% add_lang_files "foo" "bar" %}
 
 That will make the page load `foo.lang` and `bar.lang` in addition to
-`main.lang`, `download_button.lang`, and `newsletter.lang`.
+`main.lang` and `download_button.lang`.
 
 When strings are extracted from a template, that are added to the
 template-specific .lang file. If the template explicitly specifies
@@ -199,8 +199,8 @@ value should be either a string, or a list of strings, similar to the
     sometext = _('Foo about bar.')
 
 This file's strings would be extracted to `foo.lang`, and the lang files
-`foo.lang`, `bar.lang`, `main.lang`, `download_button.lang`, and `newsletter.lang`
-would be searched for matches in that order.
+`foo.lang`, `bar.lang`, `main.lang` and `download_button.lang`would be
+searched for matches in that order.
 
 l10n blocks
 ------------------

--- a/lib/l10n_utils/tests/test_template.py
+++ b/lib/l10n_utils/tests/test_template.py
@@ -77,7 +77,7 @@ class TestTemplateLangFiles(TestCase):
         request = type('request', (), {})()
         template.render({'request': request})
         eq_(request.langfiles, ['dude', 'walter',
-                                'main', 'download_button', 'newsletter'])
+                                'main', 'download_button'])
 
     @patch.object(env, 'loader', FileSystemLoader(TEMPLATE_DIRS))
     def test_added_lang_files_inheritance(self):
@@ -94,7 +94,7 @@ class TestTemplateLangFiles(TestCase):
         request = type('request', (), {})()
         template.render(request=request)
         eq_(request.langfiles, ['donnie', 'smokey', 'jesus', 'dude', 'walter',
-                                'main', 'download_button', 'newsletter'])
+                                'main', 'download_button'])
 
     @patch.object(env, 'loader', FileSystemLoader(TEMPLATE_DIRS))
     @patch.object(settings, 'ROOT_URLCONF', 'lib.l10n_utils.tests.test_files.urls')
@@ -108,7 +108,7 @@ class TestTemplateLangFiles(TestCase):
         """
         self.client.get('/de/some-lang-files/')
         translate.assert_called_with(ANY, ['dude', 'walter', 'some_lang_files',
-                                           'main', 'download_button', 'newsletter'])
+                                           'main', 'download_button'])
 
     @patch.object(env, 'loader', FileSystemLoader(TEMPLATE_DIRS))
     @patch.object(settings, 'ROOT_URLCONF', 'lib.l10n_utils.tests.test_files.urls')
@@ -121,7 +121,7 @@ class TestTemplateLangFiles(TestCase):
         """
         self.client.get('/de/active-de-lang-file/')
         translate.assert_called_with(ANY, ['inactive_de_lang_file', 'active_de_lang_file',
-                                           'main', 'download_button', 'newsletter'])
+                                           'main', 'download_button'])
 
 
 class TestNoLocale(TestCase):


### PR DESCRIPTION
…for all the newsletter stuff

* newsletter.lang is no longer loaded as a default langfile for all templates (because only 8 locales do the newsletters and default files are assigned to all locales)
* all newsletter templates and newsletter python files except the hacks blog get their strings extracted to mozorg/newsletters.lang
* newsletter/views.py was loading strings from the contribute page, now they are also loaded from mozorg/newsletters.lang
* mozorg/forms.py now also loads strings from mozorg/newsletter.lang
* One string was corrected in a template (2 spaces instead of 1)
* tests and documentation updated

The mozorg/newsletters.lang file already has all the string copied from newsletter.lang and the file is on production on svn for the 8 locales that translate newsletters.

Strings in newsletter.lang that were used outside of newsletters were moved to main.lang

We will remove the old newsletter.lang from svn only once bedrock will run the new code and will no longer include newsletter.lang by default for all pages.