### PR TITLE
Push to private docker registries.

### DIFF
--- a/docker/jenkins/push2dockerhub.sh
+++ b/docker/jenkins/push2dockerhub.sh
@@ -14,4 +14,6 @@ COMMIT="${ghprbActualCommit:=$GIT_COMMIT}"
 
 # Tag using git hash
 docker tag -f $FROM_DOCKER_REPOSITORY:$COMMIT $DOCKER_REPOSITORY:$COMMIT
+
+# Push to docker hub
 docker push $DOCKER_REPOSITORY:$COMMIT

--- a/docker/jenkins/push2privateregistries.sh
+++ b/docker/jenkins/push2privateregistries.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# Needs PRIVATE_REGISTRIES, DEIS_APPS,
+# FROM_DOCKER_REPOSITORY environment variables.
+#
+# To set them go to Job -> Configure -> Build Environment -> Inject
+# passwords and Inject env variables
+#
+set -ex
+
+# If pull request use $ghprbActualCommit otherwise use $GIT_COMMIT
+COMMIT="${ghprbActualCommit:=$GIT_COMMIT}"
+
+# Push to private registry
+for PRIVATE_REGISTRY in ${PRIVATE_REGISTRIES//,/ };
+do
+    for DEIS_APP in ${DEIS_APPS//,/ };
+    do
+        docker tag -f $FROM_DOCKER_REPOSITORY:$COMMIT $PRIVATE_REGISTRY/$DEIS_APP:$COMMIT
+        docker push $PRIVATE_REGISTRY/$DEIS_APP:$COMMIT
+    done
+done


### PR DESCRIPTION
Script to enable jenkins to push to private registries.

See example run https://ci.us-west.moz.works/job/bedrock_base_image/110/

@jgmize r?

Just before merging enable

https://ci.us-west.moz.works/job/bedrock_registry_upload_us_west/
https://ci.us-west.moz.works/job/bedrock_registry_upload_eu_west/