### PR TITLE
Fix bug 1210980: Do not redirect Fx 28.0 release notes to archive.

### DIFF
--- a/bedrock/firefox/redirects.py
+++ b/bedrock/firefox/redirects.py
@@ -188,7 +188,7 @@ redirectpatterns = (
              'http://website-archive.mozilla.org/www.mozilla.org/devpreview_releasenotes/projects/devpreview/{page}'),
 
     # bug 1001238, 1025056
-    no_redirect(r'^firefox/24\.[5678]\.\d/releasenotes/?$'),
+    no_redirect(r'^firefox/(24\.[5678]\.\d|28\.0)/releasenotes/?$'),
 
     # bug 947890, 1069902
     redirect(r'^firefox/releases/(?P<v>[01]\.(?:.*))$',


### PR DESCRIPTION
From IRC:

```
<CamJN> Hey all, https://www.mozilla.org/en-US/firefox/28.0/releasenotes/ is 404ing
```

28.0beta is in the archive, but 28.0 should be served by bedrock.