### PR TITLE
Symlink static files.

### DIFF
--- a/docker/bin/softlinkstatic.py
+++ b/docker/bin/softlinkstatic.py
@@ -10,8 +10,9 @@ with open(STATIC) as static_fp:
 for orig, hashed in static_files['paths'].items():
     if '?' in orig:
         continue
-    orig_path = os.path.join('./static', orig)
-    hashed_filename = os.path.split(hashed)[1]
+    hashed_path = os.path.join('./static', hashed)
+    orig_filename = os.path.split(orig)[1]
+
     # no exception handling b/c we want to abort on OS errors here
-    os.unlink(orig_path)
-    os.symlink(hashed_filename, orig_path)
+    os.unlink(hashed_path)
+    os.symlink(orig_filename, hashed_path)

--- a/docker/dockerfiles/bedrock_code
+++ b/docker/dockerfiles/bedrock_code
@@ -3,11 +3,11 @@ FROM ${FROM_DOCKER_REPOSITORY}:${GIT_COMMIT}
 COPY . /app
 
 RUN echo "${GIT_COMMIT}" > static/revision.txt
-RUN ./manage.py collectstatic --noinput
+RUN ./manage.py collectstatic -l --noinput
 RUN ./manage.py update_product_details
 
 # Cleanup
-RUN ./docker/softlinkstatic.py
+RUN ./docker/bin/softlinkstatic.py
 
 # Change User
 RUN chown webdev.webdev -R .


### PR DESCRIPTION
Uses `collectatic -l` and reduces the image size by [~140mb](https://imagelayers.io/?images=mozorg%2Fbedrock:7d1d934dd94d9946fc6ce20f461e5c207edb3ab8,mozorg%2Fbedrock:2725cbd0b0abacb2cac78123a3432c9b0ae48f75)