### PR TITLE
Add periodic db update script for jenkins

### DIFF
--- a/docker/jenkins/periodic_db_update.sh
+++ b/docker/jenkins/periodic_db_update.sh
@@ -1,0 +1,16 @@
+#!/bin/bash -ex
+# Needs DEIS_CONTROLLER URL, DEIS_USERNAME, DEIS_PASSWORD,
+# DEIS_PROFILE, and DEIS_APPLICATION environment variables.
+#
+# To set them go to Job -> Configure -> Build Environment -> Inject
+# passwords and Inject env variables
+#
+
+deis login $DEIS_CONTROLLER --username=$DEIS_USERNAME --password=$DEIS_PASSWORD
+deis run -a $DEIS_APPLICATION -- '\
+./manage.py rnasync; \
+./manage.py cron update_ical_feeds; \
+./manage.py update_product_details; \
+./manage.py update_externalfiles; \
+./manage.py update_security_advisories; \
+./manage.py cron update_tweets;'


### PR DESCRIPTION
I've set up an example of this approach at https://ci.us-west.moz.works/view/Bedrock/job/bedrock_periodic_db_update_dev_us_west/ -- to use this, we would set up a periodic job executing this new script for each app and cluster that needed it.