### PR TITLE
Fix Bug 1204579 - Consolidate Thunderbird rewrite rules and add some redirects

### DIFF
--- a/bedrock/thunderbird/redirects.py
+++ b/bedrock/thunderbird/redirects.py
@@ -29,4 +29,30 @@ redirectpatterns = (
     redirect(r'^thunderbird/releasenotes/?$', 'thunderbird.latest.notes'),
     # bug 1211007
     redirect(r'^thunderbird/download/?', 'thunderbird.index'),
+
+    # bug 1133266
+    redirect(r'^thunderbird/legal/privacy/?$', 'privacy.notices.thunderbird'),
+    redirect(r'^thunderbird/about/privacy-policy/?$',
+             'privacy.archive.thunderbird-2010-06'),
+
+    # bug 1196578
+    redirect(r'^thunderbird/about/legal/eula/?$', 'legal.eula'),
+    redirect(r'^thunderbird/about/legal/eula/thunderbird2',
+             'legal.eula.thunderbird-2-eula'),
+    redirect(r'^thunderbird/about/legal/eula/thunderbird',
+             'legal.eula.thunderbird-1.5-eula'),
+
+    # bug 1204579
+    redirect(r'^thunderbird/2.0.0.0/eula/?$', 'legal.eula.thunderbird-2-eula'),
+    redirect(r'^thunderbird/about/legal/?$', 'legal.terms.mozilla'),
+    redirect(r'^thunderbird/about(/mission)?/?$',
+             'https://wiki.mozilla.org/Thunderbird'),
+    redirect(r'^thunderbird/(about/(careers|contact|get-involved)|community)/?$',
+             'https://wiki.mozilla.org/Thunderbird#Contributing'),
+    redirect(r'^thunderbird/(?P<version>\d\.\d(?:a|b|rc)\d|[6-9]\.0beta)/?$',
+             'http://website-archive.mozilla.org/www.mozilla.org/thunderbird'
+             '/thunderbird/{version}/'),
+    redirect(r'^thunderbird/about/(?P<page>board|press|staff)/',
+             'http://website-archive.mozilla.org/www.mozilla.org/thunderbird'
+             '/thunderbird/about/{page}/'),
 )

--- a/etc/httpd/global.conf
+++ b/etc/httpd/global.conf
@@ -450,10 +450,6 @@ RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?privacy/policies/(facebook|firefox-os|websit
 RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?privacy(.*)$ /b/$1privacy$2 [PT]
 RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?legal/firefox(/?)$ /b/$1legal/firefox$2 [PT]
 
-# bug 1133266
-RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?thunderbird/legal/privacy/?$ /$1privacy/thunderbird/ [L,R=301]
-RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?thunderbird/about/privacy-policy/?$ /$1privacy/archive/thunderbird/2010-06/ [L,R=301]
-
 # bug 1034859
 RewriteRule ^/en-US/about/buttons/(.*) /media/img/careers/buttons/$1 [L,R=301]
 
@@ -471,11 +467,6 @@ RewriteRule ^/de/impressum/?$ /de/about/legal/impressum/ [L,R=301]
 RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/2.0/eula(?:.*) /$1legal/eula/firefox-2/ [L,R=301]
 RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/3.0/eula(?:.*) /$1legal/eula/firefox-3/ [L,R=301]
 RewriteRule ^/en-US/legal/eula(.*)$ /b/en-US/legal/eula$1 [PT]
-
-# bug 1196578
-RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?thunderbird/about/legal/eula/?$ /$1about/legal/eula/ [L,R=301]
-RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?thunderbird/about/legal/eula/thunderbird2 /$1about/legal/eula/thunderbird-2/ [L,R=301]
-RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?thunderbird/about/legal/eula/thunderbird /$1about/legal/eula/thunderbird-1.5/ [L,R=301]
 
 # bug 724633 - Porting foundation pages
 # Add redirects for the pdfs that were under /foundation/documents/
@@ -534,12 +525,6 @@ RewriteRule ^(/(?:\w{2,3}(?:-\w{2}(?:-mac)?)?/)?mobile/(?:2[38]\.0(?:\.\d)?|29\.
 RewriteRule ^(/(?:\w{2,3}(?:-\w{2}(?:-mac)?)?/)?mobile/(?:[3-9]\d\.\d(?:a2|beta|\.\d)?)/(?:aurora|release)notes/?)$ /b$1 [PT]
 RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?firefox/(android/)?(2[38]\.0(?:\.\d)?|29\.0(?:beta|\.\d)?)/releasenotes(/)?$ /b/$1firefox/$2$3/releasenotes$4 [L,PT]
 RewriteRule ^/(\w{2,3}(?:-\w{2}(?:-mac)?)?/)?firefox/(android/)?([3-9]\d\.\d(?:\.\d)?(?:a2|beta)?)/(aurora|release)notes(/)?$ /b/$1firefox/$2$3/$4notes$5 [L,PT]
-
-# bug 1103396 for en-US, bug 1115066 for other locales
-RewriteRule ^/(ar|bg|ca|cs|cy|da|de|dsb|el|en-GB|en-US|es-AR|es-ES|et|eu|fr|fy-NL|ga-IE|gd|hr|hsb|hu|hy-AM|id|is|it|ja|ko|lt|nl|pl|pt-BR|pt-PT|rm|ru|si|sk|sl|sq|sr|sv-SE|tr|uk|zh-CN|zh-TW)/thunderbird/release/start(/)?$ /b/$1/thunderbird/release/start$2 [L,PT]
-
-# bug 1124037
-RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?thunderbird/(beta|earlybird|nightly)/(start|whatsnew)(/)?$ /b/$1thunderbird/$2/$3$4 [L,PT]
 
 # bug 1090468
 RewriteRule ^(/security/(?:older-alerts|security-announcement|phishing-test(-results)?)\.html)$ /b$1 [PT]

--- a/test_redirects/map_globalconf.py
+++ b/test_redirects/map_globalconf.py
@@ -245,6 +245,31 @@ URLS = flatten((
     # bug 1124042
     url_test('/thunderbird/features/email_providers.html', '/thunderbird/email-providers/'),
 
+    # bug 1133266
+    url_test('/thunderbird/legal/privacy/', '/privacy/thunderbird/'),
+    url_test('/thunderbird/about/privacy-policy/', '/privacy/archive/thunderbird/2010-06/'),
+
+    # bug 1196578
+    url_test('/thunderbird/about/legal/eula/', '/about/legal/eula/'),
+    url_test('/thunderbird/about/legal/eula/thunderbird2.html', '/about/legal/eula/thunderbird-2/'),
+    url_test('/thunderbird/about/legal/eula/thunderbird.html', '/about/legal/eula/thunderbird-1.5/'),
+
+    # bug 1204579
+    url_test('/thunderbird/2.0.0.0/eula/', '/about/legal/eula/thunderbird-2/'),
+    url_test('/thunderbird/about/legal/', '/about/legal/terms/mozilla/'),
+    url_test('/thunderbird/download/', '/thunderbird/'),
+    url_test('/thunderbird/about/', 'https://wiki.mozilla.org/Thunderbird'),
+    url_test('/thunderbird/about/mission/', 'https://wiki.mozilla.org/Thunderbird'),
+    url_test('/thunderbird/about/{careers,contact,get-involved}/',
+             'https://wiki.mozilla.org/Thunderbird#Contributing'),
+    url_test('/thunderbird/community/', 'https://wiki.mozilla.org/Thunderbird#Contributing'),
+    url_test('/thunderbird/3.1{a,b,rc}{1,2}/',
+             'http://website-archive.mozilla.org/www.mozilla.org/thunderbird/thunderbird/3.1{a,b,rc}{1,2}/'),
+    url_test('/thunderbird/{6,7,8,9}.0beta/',
+             'http://website-archive.mozilla.org/www.mozilla.org/thunderbird/thunderbird/{6,7,8,9}.0beta/'),
+    url_test('/thunderbird/about/{board,press,staff}/',
+             'http://website-archive.mozilla.org/www.mozilla.org/thunderbird/thunderbird/about/{board,press,staff}/'),
+
     # bug 1121082
     url_test('/hello/', '/firefox/hello/'),
 


### PR DESCRIPTION
I forgot to send this earlier… The most of the work mentioned in the bug has actually been done in #3360. This will remove the rest of the legacy Thunderbird redirect rules so the PHP server can be terminated soon.