### PR TITLE
Fix Bug 1196255 - tabzilla invisible on mobile view of /privacy/tips/

### DIFF
--- a/media/css/privacy/privacy-day.less
+++ b/media/css/privacy/privacy-day.less
@@ -882,6 +882,12 @@ html[dir='rtl'] {
         padding-right: 0;
     }
 
+    /* Workaround Bug 1196255 */
+    #main-content {
+        top: -37px;
+        clear: both;
+    }
+
     #page-header {
         width: 100%;
         padding-bottom: 0;


### PR DESCRIPTION
This works on both Firefox 41 and 42 (and later).