### PR TITLE
Modify clock script to just run the jobs instead of the schedule.

### DIFF
--- a/docker/jenkins/periodic_db_update.sh
+++ b/docker/jenkins/periodic_db_update.sh
@@ -7,10 +7,4 @@
 #
 
 deis login $DEIS_CONTROLLER --username=$DEIS_USERNAME --password=$DEIS_PASSWORD
-deis run -a $DEIS_APPLICATION -- '\
-./manage.py rnasync; \
-./manage.py cron update_ical_feeds; \
-./manage.py update_product_details; \
-./manage.py update_externalfiles; \
-./manage.py update_security_advisories; \
-./manage.py cron update_tweets;'
+deis run -a $DEIS_APPLICATION -- './manage.py runscript clock'

--- a/docker/run-common.sh
+++ b/docker/run-common.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-./manage.py syncdb --noinput
+./manage.py migrate --noinput

--- a/requirements/docker.txt
+++ b/requirements/docker.txt
@@ -9,3 +9,7 @@ uwsgi==2.0.11.1
 
 # sha256: JLo_Moq6CNjVBbwqj2ipTr4kqF6Eg2QLZnIhvA79Ox4
 psycopg2==2.5.4
+
+# sha256: QvSTmYsyt2kgwzByXYo3jNKaansazqmAG88MNbvRQY8
+# sha256: yyL3FoLPzSHQy5VId1baaHD3UcyGAUdIB1372oWOiLk
+APScheduler==3.0.3

--- a/scripts/clock.py
+++ b/scripts/clock.py
@@ -6,7 +6,7 @@ from apscheduler.schedulers.blocking import BlockingScheduler
 
 from bedrock.events.cron import cleanup_ical_events, update_ical_feeds
 from bedrock.mozorg.cron import update_tweets
-from scripts import update_firefox_os_feeds, update_tableau_data
+from scripts import update_firefox_os_feeds
 
 
 schedule = BlockingScheduler()
@@ -37,16 +37,6 @@ class scheduled_job(object):
 
     def log(self, message):
         print('Clock job {0}: {1}'.format(self.name, message))
-
-
-@scheduled_job('interval', seconds=5)
-def job_should_pass():
-    print('DO ALL THE THINGS!!!')
-
-
-@scheduled_job('interval', seconds=5)
-def job_raise_exception():
-    raise ValueError("Stuff's broke yo!")
 
 
 @scheduled_job('interval', minutes=30)
@@ -80,13 +70,17 @@ def job_update_firefox_os_feeds():
     update_firefox_os_feeds.run()
 
 
-@scheduled_job('cron', day_of_week='sat', hour=0)
-def job_update_tableau_data():
-    update_tableau_data.run()
-
-
 def run():
-    try:
-        schedule.start()
-    except (KeyboardInterrupt, SystemExit):
-        pass
+    # TODO enable this when we're ready to run a clock process
+    # try:
+    #     schedule.start()
+    # except (KeyboardInterrupt, SystemExit):
+    #     pass
+
+    # For now just run them all and exit
+    for job in schedule.get_jobs():
+        try:
+            job.func()
+        except Exception:
+            # exceptions will be printed
+            pass

--- a/scripts/clock.py
+++ b/scripts/clock.py
@@ -1,0 +1,90 @@
+from __future__ import print_function
+from functools import wraps
+
+from django.core.management import call_command
+
+from apscheduler.schedulers.blocking import BlockingScheduler
+
+from bedrock.events.cron import cleanup_ical_events, update_ical_feeds
+from bedrock.mozorg.cron import update_tweets
+from scripts import update_firefox_os_feeds, update_tableau_data
+
+
+schedule = BlockingScheduler()
+
+
+class scheduled_job(object):
+    def __init__(self, *args, **kwargs):
+        self.args = args
+        self.kwargs = kwargs
+
+    def __call__(self, fn):
+        job_name = fn.__name__
+        self.name = job_name
+
+        @wraps(fn)
+        def wrapped():
+            print('Starting Clock Job: {}'.format(job_name))
+            try:
+                fn()
+            except Exception as e:
+                print('Clock Job CRASHED: {}: {}'.format(job_name, e))
+                raise
+            else:
+                print('Finished Clock Job: {}'.format(job_name))
+
+        schedule.add_job(wrapped, id=job_name, *self.args, **self.kwargs)
+        return wrapped
+
+
+@scheduled_job('interval', seconds=10)
+def job_should_pass():
+    print('DO ALL THE THINGS!!!')
+
+
+@scheduled_job('interval', seconds=10)
+def job_raise_exception():
+    raise ValueError("Stuff's broke yo!")
+
+
+@scheduled_job('interval', minutes=30)
+def job_update_externalfiles():
+    call_command('update_externalfiles')
+
+
+@scheduled_job('interval', minutes=30)
+def job_update_security_advisories():
+    call_command('update_security_advisories')
+
+
+@scheduled_job('interval', minutes=5)
+def job_rnasync():
+    call_command('rnasync')
+
+
+@scheduled_job('interval', hours=6)
+def job_update_tweets():
+    update_tweets()
+
+
+@scheduled_job('interval', hours=1)
+def job_ical_feeds():
+    update_ical_feeds()
+    cleanup_ical_events()
+
+
+@scheduled_job('interval', hours=1)
+def job_update_firefox_os_feeds():
+    update_firefox_os_feeds.run()
+
+
+@scheduled_job('cron', day_of_week='sat', hour=0)
+def job_update_tableau_data():
+    update_tableau_data.run()
+
+
+def run():
+    try:
+        schedule.start()
+    except (KeyboardInterrupt, SystemExit):
+        pass

--- a/scripts/clock.py
+++ b/scripts/clock.py
@@ -1,5 +1,4 @@
 from __future__ import print_function
-from functools import wraps
 
 from django.core.management import call_command
 
@@ -14,6 +13,7 @@ schedule = BlockingScheduler()
 
 
 class scheduled_job(object):
+    """Decorator for scheduled jobs. Takes same args as apscheduler.schedule_job."""
     def __init__(self, *args, **kwargs):
         self.args = args
         self.kwargs = kwargs
@@ -21,28 +21,30 @@ class scheduled_job(object):
     def __call__(self, fn):
         job_name = fn.__name__
         self.name = job_name
+        self.callback = fn
+        schedule.add_job(self.run, id=job_name, *self.args, **self.kwargs)
+        return self.run
 
-        @wraps(fn)
-        def wrapped():
-            print('Starting Clock Job: {}'.format(job_name))
-            try:
-                fn()
-            except Exception as e:
-                print('Clock Job CRASHED: {}: {}'.format(job_name, e))
-                raise
-            else:
-                print('Finished Clock Job: {}'.format(job_name))
+    def run(self):
+        self.log('starting')
+        try:
+            self.callback()
+        except Exception as e:
+            self.log('CRASHED: {}'.format(e))
+            raise
+        else:
+            self.log('finished successfully')
 
-        schedule.add_job(wrapped, id=job_name, *self.args, **self.kwargs)
-        return wrapped
+    def log(self, message):
+        print('Clock job {0}: {1}'.format(self.name, message))
 
 
-@scheduled_job('interval', seconds=10)
+@scheduled_job('interval', seconds=5)
 def job_should_pass():
     print('DO ALL THE THINGS!!!')
 
 
-@scheduled_job('interval', seconds=10)
+@scheduled_job('interval', seconds=5)
 def job_raise_exception():
     raise ValueError("Stuff's broke yo!")
 


### PR DESCRIPTION
Basically the same as #3295, but just runs all the jobs with the enhanced logging insetad of scheduling them. This will make it very easy to enable the scheduler process when deis is ready.