### PR TITLE
Fix Bug 939470 - mozilla.org tells user it has up-to-date Firefox when it doesn't

### DIFF
--- a/bedrock/base/templates/base-resp.html
+++ b/bedrock/base/templates/base-resp.html
@@ -3,7 +3,7 @@
 <!doctype html>
 {# Note the "windows" class, without javascript platform-specific
      assets default to windows #}
-<html class="windows x86 no-js" lang="{{ LANG|replace('en-US', 'en') }}" dir="{{ DIR }}" data-latest-firefox="{{ latest_firefox_version }}" data-esr-versions="{{ esr_firefox_versions }}">
+<html class="windows x86 no-js" lang="{{ LANG|replace('en-US', 'en') }}" dir="{{ DIR }}" data-latest-firefox="{{ latest_firefox_version }}" data-esr-versions="{{ esr_firefox_versions|safe }}">
   <head>
     <meta charset="utf-8">{# Note: Must be within first 512 bytes of page #}
 

--- a/bedrock/base/templates/base.html
+++ b/bedrock/base/templates/base.html
@@ -3,7 +3,7 @@
 <!doctype html>
 {# Note the "windows" class, without javascript platform-specific
      assets default to windows #}
-<html class="windows x86 no-js" lang="{{ LANG|replace('en-US', 'en') }}" dir="{{ DIR }}" data-latest-firefox="{{ latest_firefox_version }}" data-esr-versions="{{ esr_firefox_versions }}">
+<html class="windows x86 no-js" lang="{{ LANG|replace('en-US', 'en') }}" dir="{{ DIR }}" data-latest-firefox="{{ latest_firefox_version }}" data-esr-versions="{{ esr_firefox_versions|safe }}">
   <head>
     <meta charset="utf-8">{# Note: Must be within first 512 bytes of page #}
 

--- a/bedrock/firefox/context_processors.py
+++ b/bedrock/firefox/context_processors.py
@@ -8,5 +8,5 @@ from bedrock.firefox.firefox_details import firefox_desktop
 def latest_firefox_versions(request):
     return {
         'latest_firefox_version': firefox_desktop.latest_version(),
-        'esr_firefox_versions': firefox_desktop.esr_major_versions,
+        'esr_firefox_versions': firefox_desktop.esr_minor_versions,
     }

--- a/bedrock/firefox/firefox_details.py
+++ b/bedrock/firefox/firefox_details.py
@@ -51,10 +51,21 @@ class FirefoxDesktop(ProductDetails):
     @property
     def esr_major_versions(self):
         versions = []
-        for version in ('esr', 'esr_next'):
-            version_int = self.latest_major_version(version)
+        for channel in ('esr', 'esr_next'):
+            version_int = self.latest_major_version(channel)
             if version_int:
                 versions.append(version_int)
+
+        return versions
+
+    @property
+    def esr_minor_versions(self):
+        versions = []
+        for channel in ('esr', 'esr_next'):
+            version = self.latest_version(channel)
+            version_int = self.latest_major_version(channel)
+            if version and version_int:
+                versions.append(str(version).replace('esr', ''))
 
         return versions
 

--- a/bedrock/firefox/tests/test_firefox_details.py
+++ b/bedrock/firefox/tests/test_firefox_details.py
@@ -225,23 +225,26 @@ class TestFirefoxDesktop(TestCase):
 
     @patch.object(firefox_desktop._storage, 'data',
                   Mock(return_value=dict(FIREFOX_ESR='24.2')))
-    def test_esr_major_versions(self):
+    def test_esr_versions(self):
         """ESR versions should be dynamic based on data."""
         eq_(firefox_desktop.esr_major_versions, [24])
+        eq_(firefox_desktop.esr_minor_versions, ['24.2'])
 
     @patch.object(firefox_desktop._storage, 'data',
                   Mock(return_value=dict(FIREFOX_ESR='24.6.0',
                                          FIREFOX_ESR_NEXT='31.0.0')))
-    def test_esr_major_versions_prev(self):
+    def test_esr_versions_prev(self):
         """ESR versions should show previous when available."""
         eq_(firefox_desktop.esr_major_versions, [24, 31])
+        eq_(firefox_desktop.esr_minor_versions, ['24.6.0', '31.0.0'])
 
     @patch.object(firefox_desktop._storage, 'data',
                   Mock(return_value=dict(LATEST_FIREFOX_VERSION='Phoenix',
                                          FIREFOX_ESR='Albuquerque')))
-    def test_esr_major_versions_no_latest(self):
+    def test_esr_versions_no_latest(self):
         """ESR versions should not blow up if current version is broken."""
         eq_(firefox_desktop.esr_major_versions, [])
+        eq_(firefox_desktop.esr_minor_versions, [])
 
     @patch.object(firefox_desktop._storage, 'data',
                   Mock(return_value=dict(LATEST_FIREFOX_VERSION='18.0.1')))

--- a/bedrock/mozorg/templates/mozorg/contribute/contribute-embed.html
+++ b/bedrock/mozorg/templates/mozorg/contribute/contribute-embed.html
@@ -5,7 +5,7 @@
 {% add_lang_files "mozorg/contribute" "mozorg/contribute-form" %}
 {# Note the "windows" class, without javascript platform-specific
      assets default to windows #}
-<html class="windows x86 no-js" lang="{{ LANG }}" dir="{{ DIR }}" data-latest-firefox="{{ latest_firefox_version }}" data-esr-versions="{{ esr_firefox_versions }}">
+<html class="windows x86 no-js" lang="{{ LANG }}" dir="{{ DIR }}" data-latest-firefox="{{ latest_firefox_version }}" data-esr-versions="{{ esr_firefox_versions|safe }}">
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/media/js/base/global.js
+++ b/media/js/base/global.js
@@ -34,15 +34,19 @@ function init_download_links() {
 }
 
 function update_download_text_for_old_fx() {
-    // if using an out of date firefox
-    if (isFirefox() && !isFirefoxUpToDate()) {
-        // look at each button to see if it's set to check for old firefox
-        $('.download-button').each(function() {
-            var $button = $(this);
+    if (isFirefox()) {
+        window.getFirefoxDetails(function(data) {
+            // if using an out of date firefox
+            if (!data.isUpToDate) {
+                // look at each button to see if it's set to check for old firefox
+                $('.download-button').each(function() {
+                    var $button = $(this);
 
-            if ($button.hasClass('download-button-check-old-fx')) {
-                // replace subtitle copy
-                $button.find('.download-subtitle').text(window.trans('global-update-firefox'));
+                    if ($button.hasClass('download-button-check-old-fx')) {
+                        // replace subtitle copy
+                        $button.find('.download-subtitle').text(window.trans('global-update-firefox'));
+                    }
+                });
             }
         });
     }
@@ -74,22 +78,6 @@ function init_lang_switcher() {
     });
 }
 
-//get Master firefox version
-function getFirefoxMasterVersion(userAgent) {
-    var version = 0;
-    var ua = userAgent || navigator.userAgent;
-
-    var matches = /Firefox\/([0-9]+).[0-9]+(?:.[0-9]+)?/.exec(
-        ua
-    );
-
-    if (matches !== null && matches.length > 0) {
-        version = parseInt(matches[1], 10);
-    }
-
-    return version;
-}
-
 // Used on the plugincheck page to also support all browsers based on Gecko.
 function isLikeFirefox(userAgent) {
     var ua = userAgent || navigator.userAgent;
@@ -101,22 +89,6 @@ function isLikeFirefox(userAgent) {
 function isFirefox(userAgent) {
     var ua = userAgent || navigator.userAgent;
     return (/\sFirefox/).test(ua) && !isLikeFirefox(ua);
-}
-
-// 2015-01-20: Gives no special consideration to ESR builds
-function isFirefoxUpToDate(latest) {
-    var $html = $(document.documentElement);
-    var fx_version = getFirefoxMasterVersion();
-    var latestFirefoxVersion;
-
-    if (!latest) {
-        latestFirefoxVersion = $html.attr('data-latest-firefox');
-        latestFirefoxVersion = parseInt(latestFirefoxVersion.split('.')[0], 10);
-    } else {
-        latestFirefoxVersion = parseInt(latest.split('.')[0], 10);
-    }
-
-    return (latestFirefoxVersion <= fx_version);
 }
 
 // used in bedrock for desktop specific checks like `isFirefox() && !isFirefoxMobile()`
@@ -148,6 +120,150 @@ function isFirefoxESR(userAgent, buildID) {
 
     return version in ESRs && ESRs[version].indexOf(buildID) === -1;
 }
+
+/**
+ * Get the user's Firefox version number.
+ *
+ * @param  {String} ua - browser's user agent string, navigator.userAgent is
+ *                  used if not specified
+ * @return {String} version number.
+ */
+function getFirefoxVersion(ua) {
+    ua = ua || navigator.userAgent;
+
+    var matches = /Firefox\/(\d+\.\d+(?:\.\d+)?)/.exec(ua);
+
+    return (matches !== null && matches.length > 0) ? matches[1] : '0';
+};
+
+/**
+ * Get the user's Firefox major version number.
+ *
+ * @param  {String} ua - browser's user agent string, navigator.userAgent is
+ *                  used if not specified
+ * @return {Integer} major version number
+ */
+function getFirefoxMasterVersion(ua) {
+    return parseInt(getFirefoxVersion(ua), 10);
+}
+
+/**
+ * Detect whether the user's Firefox is up to date or outdated. This data is
+ * mainly used for security notifications.
+ *
+ * @param  {Boolean} strict - whether the minor and patch-level version numbers
+ *                   should be compared. Default: true
+ * @param  {Boolean} isESR - whether the Firefox update channel is ESR
+ * @param  {String}  userVer - browser's version number
+ * @return {Boolean} result
+ */
+function isFirefoxUpToDate(strict, isESR, userVer) {
+    strict = strict === undefined ? true : strict;
+    isESR = isESR === undefined ? isFirefoxESR() : isESR;
+    userVer = userVer === undefined ? getFirefoxVersion() : userVer;
+
+    var $html = $(document.documentElement);
+
+    if (!$html.attr('data-esr-versions') || !$html.attr('data-latest-firefox')) {
+        return false;
+    }
+
+    var versions = isESR ? $.parseJSON($html.attr('data-esr-versions').replace(/\'/g, '"'))
+                         : [$html.attr('data-latest-firefox')];
+    var userVerArr = userVer.match(/^(\d+\.\d+(?:\.\d+)?)/)[1].split('.');
+    var isUpToDate = false;
+
+    // Compare the newer version first
+    versions.sort(function(a, b) { return parseFloat(a) < parseFloat(b); });
+
+    // Only check the major version in non-strict comparison mode
+    if (!strict) {
+        userVerArr.length = 1;
+    }
+
+    for (var i = 0; i < versions.length; i++) {
+        var latestVerArr = versions[i].split('.');
+
+        // Only check the major version in non-strict comparison mode
+        if (!strict) {
+            latestVerArr.length = 1;
+        }
+
+        for (var j = 0; j < userVerArr.length; j++) {
+            if (Number(userVerArr[j]) < Number(latestVerArr[j] || 0)) {
+                isUpToDate = false;
+                break;
+            } else {
+                isUpToDate = true;
+            }
+        }
+
+        if (isUpToDate) {
+            break;
+        }
+    }
+
+    return isUpToDate;
+};
+
+/**
+ * Use the async mozUITour API of Firefox to retrieve the user's browser info,
+ * including the update channel and accurate, patch-level version number. This
+ * API is available on Firefox 35 and later.
+ * http://bedrock.readthedocs.org/en/latest/uitour.html
+ *
+ * @param  {Function} callback - callback function to be executed
+ * @return {None}
+ */
+function getFirefoxDetails(callback) {
+    var callbackID = Math.random().toString(36).replace(/[^a-z]+/g, '');
+
+    var listener = function (event) {
+        if (!event.detail || !event.detail.data ||
+                event.detail.callbackID !== callbackID) {
+            return;
+        }
+
+        // Cancel the timer as we've got the data
+        window.clearTimeout(fallback);
+        document.removeEventListener('mozUITourResponse', listener);
+
+        var version = event.detail.data.version;
+        var channel = event.detail.data.defaultUpdateChannel;
+
+        // Fire the callback function with the accurate data
+        callback({
+            version: version,
+            channel: channel,
+            isUpToDate: isFirefoxUpToDate(true, channel === 'esr', version),
+            isESR: channel === 'esr'
+        });
+    };
+
+    // Prepare fallback function in case the API doesn't work
+    var fallback = window.setTimeout(function () {
+        var isESR = isFirefoxESR();
+
+        document.removeEventListener('mozUITourResponse', listener);
+
+        callback({
+            version: getFirefoxVersion(),
+            channel: isESR ? 'esr' : 'release',
+            isUpToDate: isFirefoxUpToDate(false, false, userVer),
+            isESR: isESR
+        });
+    }, 500);
+
+    // Trigger the API
+    document.addEventListener('mozUITourResponse', listener);
+    document.dispatchEvent(new CustomEvent('mozUITour', {
+        bubbles: true,
+        detail: {
+            action: 'getConfiguration',
+            data: { configuration: 'appinfo', callbackID: callbackID }
+        }
+    }));
+};
 
 // Create text translation function using #strings element.
 // TODO: Move to docs

--- a/media/js/firefox/desktop/common.js
+++ b/media/js/firefox/desktop/common.js
@@ -8,9 +8,7 @@
     var $mastheadDownloadFirefox = $('#masthead-download-firefox');
     var $html = $('html');
 
-    // only show download buttons for users on desktop platforms, using either a non-Firefox browser
-    // or an out of date version of Firefox
-    if ((!w.isFirefox() || !w.isFirefoxUpToDate()) && !$html.hasClass('android') && !$html.hasClass('ios') && !$html.hasClass('fxos')) {
+    function showDownloadButton() {
         // if not IE, top nav download button can link directly to scene 2 of /firefox/new/
         if (navigator.appVersion.indexOf('MSIE') === -1) {
             $mastheadDownloadFirefox.attr('href', $mastheadDownloadFirefox.attr('href') + '#download-fx');
@@ -38,6 +36,20 @@
 
         // Track Firefox download click in footer
         $('#subscribe-download-wrapper .download-link').attr({'data-interaction': 'download click - bottom', 'data-download-version': downloadVersion});
+    }
+
+    // only show download buttons for users on desktop platforms, using either a non-Firefox browser
+    // or an out of date version of Firefox
+    if (!$html.hasClass('android') && !$html.hasClass('ios') && !$html.hasClass('fxos')) {
+        if (w.isFirefox()) {
+            w.getFirefoxDetails(function(data) {
+                if (!data.isUpToDate) {
+                    showDownloadButton();
+                }
+            });
+        } else {
+            showDownloadButton();
+        }
     }
 
     $('.ga-section').waypoint(function(dir) {

--- a/media/js/firefox/desktop/index.js
+++ b/media/js/firefox/desktop/index.js
@@ -41,7 +41,11 @@
         });
     }
 
-    if (window.isFirefoxUpToDate()) {
-        $('#overview-intro-up-to-date').addClass('active');
+    if (window.isFirefox()) {
+        window.getFirefoxDetails(function(data) {
+            if (data.isUpToDate) {
+                $('#overview-intro-up-to-date').addClass('active');
+            }
+        });
     }
 })(window.jQuery);

--- a/media/js/firefox/desktop/tips.js
+++ b/media/js/firefox/desktop/tips.js
@@ -15,8 +15,12 @@
 
     // only show download button for users on desktop platforms, using either a non-Firefox browser
     // or an out of date version of Firefox
-    if ((window.isFirefox() && window.isFirefoxUpToDate()) || $html.hasClass('android') || $html.hasClass('ios') || $html.hasClass('fxos')) {
-        $('#footer').addClass('hide-download');
+    if (window.isFirefox() || $html.hasClass('android') || $html.hasClass('ios') || $html.hasClass('fxos')) {
+        window.getFirefoxDetails(function(data) {
+            if (data.isUpToDate) {
+                $('#footer').addClass('hide-download');
+            }
+        });
     }
 
     // mozilla pager stuff must be in doc ready wrapper

--- a/media/js/firefox/family-index.js
+++ b/media/js/firefox/family-index.js
@@ -24,11 +24,9 @@
 
     // Check Firefox version
     if (isFirefox()) {
-        if (isFirefoxUpToDate()) {
-            $html.addClass('firefox-latest');
-        } else {
-            $html.addClass('firefox-old');
-        }
+        window.getFirefoxDetails(function(data) {
+            $html.addClass(data.isUpToDate ? 'firefox-latest' : 'firefox-old');
+        });
     }
 
     // add gtm tracking attributes

--- a/media/js/firefox/new.js
+++ b/media/js/firefox/new.js
@@ -59,14 +59,11 @@
     };
 
     if (window.isFirefox()) {
-        // data-latest-firefox includes point release information
-        var latestFirefoxVersionFull = $html.attr('data-latest-firefox');
-
-        // get latest full version (no point release info) for initial check
-        var latestFirefoxVersion = parseInt(latestFirefoxVersionFull.split('.')[0], 10);
-
-        if (window.isFirefoxUpToDate(latestFirefoxVersion + '')) {
-            if (window.location.hash !== '#download-fx' && params.get('scene') !== 2) {
+        // Get the accurate Firefox version and channel info using the mozUITour API
+        window.getFirefoxDetails(function(data) {
+            if (!data.isUpToDate) {
+                $html.addClass('firefox-old');
+            } else if (window.location.hash !== '#download-fx' && params.get('scene') !== 2) {
                 // the firefox-latest class prevents the download from triggering
                 // and scene 2 from showing, which we want if the user lands on
                 // /firefox/new/ but if the user visits /firefox/new/?scene=2#download-fx
@@ -75,20 +72,16 @@
                 $html.addClass('firefox-latest');
 
                 // if user is on release channel and has latest version, offer refresh button
-                uiTourGetConfiguration('appinfo', function(config) {
-                    if (config.defaultUpdateChannel === 'release' && config.version === latestFirefoxVersionFull) {
-                        $html.addClass('show-refresh');
+                if (data.channel === 'release') {
+                    $html.addClass('show-refresh');
 
-                        // DOM may not be ready yet, so bind filtered click handler to document
-                        $document.on('click', '#refresh-firefox', function() {
-                            uiTourSendEvent('resetFirefox');
-                        });
-                    }
-                });
+                    // DOM may not be ready yet, so bind filtered click handler to document
+                    $document.on('click', '#refresh-firefox', function() {
+                        uiTourSendEvent('resetFirefox');
+                    });
+                }
             }
-        } else {
-            $html.addClass('firefox-old');
-        }
+        });
     }
 
     // Add GA custom tracking and external link tracking

--- a/media/js/plugincheck/check-plugins.js
+++ b/media/js/plugincheck/check-plugins.js
@@ -162,8 +162,12 @@ $(function() {
     }
 
     // show for outdated Fx versions
-    if (isFirefox() && !isFirefoxUpToDate() && !isFirefoxESR()) {
-        outdatedFx.show();
+    if (isFirefox()) {
+        window.getFirefoxDetails(function(data) {
+            if (!data.isUpToDate && !data.isESR) {
+                outdatedFx.show();
+            }
+        });
     }
 
     // only execute the plugincheck code if this is Firefox


### PR DESCRIPTION
Now it works as expected. Please push this to any available test server so we can confirm the new behaviour. But I'm still wondering how to add tests for the `_getFirefoxDetails` method. Any ideas...?