### PR TITLE
Exclude redirected locales from homepage language selector functional tests

### DIFF
--- a/tests/functional/test_l10n.py
+++ b/tests/functional/test_l10n.py
@@ -13,9 +13,10 @@ from ..pages.home import HomePage
 def test_change_language(base_url, selenium):
     page = HomePage(base_url, selenium).open()
     initial = page.footer.language
-    available = page.footer.languages
-    available.remove(initial)  # avoid selecting the same language
-    new = random.choice(available)  # pick a random lanugage
+    # avoid selecting the same language or locales that have homepage redirects
+    excluded = [initial, 'ja', 'zh-TW', 'zh-CN']
+    available = [l for l in page.footer.languages if l not in excluded]
+    new = random.choice(available)
     page.footer.select_language(new)
     assert new in selenium.current_url, 'Language is not in URL'
     assert new == page.footer.language, 'Language has not been selected'


### PR DESCRIPTION
This should avoid intermittent failures like this https://webqa-ci.mozilla.com/job/bedrock.dev.win10.ie/14/HTML_Report/

For reference, said redirects are here: https://github.com/mozilla/bedrock/blob/master/bedrock/mozorg/redirects.py#L13-L20