### PR TITLE
Add sanity markers to Python functional tests

### DIFF
--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -145,6 +145,40 @@ you can also read the `pytest markers`_ documentation for more options.
         assert not page.text_format_selected
         assert not page.privacy_policy_accepted
 
+Sanity tests
+~~~~~~~~~~~~
+
+Sanity tests are run as part of bedrocks deployment pipeline. These should be considered
+to be critical tests which benefit from being run automatically after every commit to
+master. Only the full suite of functional tests are run after deployment to staging. If
+your test should be marked as a santity test you will need to apply a ``santiy`` marker
+to it.
+
+.. code-block:: python
+
+    import pytest
+
+    @pytest.mark.sanity
+    @pytest.mark.nondestructive
+    def test_newsletter_default_values(base_url, selenium):
+        page = NewsletterPage(base_url, selenium).open()
+        assert '' == page.email
+        assert 'United States' == page.country
+        assert 'English' == page.language
+        assert page.html_format_selected
+        assert not page.text_format_selected
+        assert not page.privacy_policy_accepted
+
+You can run sanity tests only by adding ``-m sanity`` when running the test suite on the
+command line.
+
+.. Note::
+
+  Tests that rely on long-running timeouts, cron jobs, or that test for locale specific
+  interactions should not be marked as a sanity test. We should try and ensure that the
+  suite of sanity tests are quick to run, and they should not have a dependency on
+  checking out and building the full site.
+
 Waits and Expected Conditions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/tests/functional/firefox/test_do_not_track.py
+++ b/tests/functional/firefox/test_do_not_track.py
@@ -7,6 +7,7 @@ import pytest
 from ...pages.firefox.do_not_track import DoNotTrackPage
 
 
+@pytest.mark.sanity
 @pytest.mark.nondestructive
 def test_family_navigation(base_url, selenium):
     page = DoNotTrackPage(base_url, selenium).open()
@@ -14,12 +15,14 @@ def test_family_navigation(base_url, selenium):
     assert menu.is_displayed
 
 
+@pytest.mark.sanity
 @pytest.mark.nondestructive
 def test_dnt_status(base_url, selenium):
     page = DoNotTrackPage(base_url, selenium).open()
     assert page.is_do_not_track_status_displayed
 
 
+@pytest.mark.sanity
 @pytest.mark.nondestructive
 def test_open_and_close_faq_panel(base_url, selenium):
     page = DoNotTrackPage(base_url, selenium).open()

--- a/tests/functional/test_contribute.py
+++ b/tests/functional/test_contribute.py
@@ -8,6 +8,7 @@ from selenium.common.exceptions import TimeoutException
 from ..pages.contribute import ContributePage
 
 
+@pytest.mark.sanity
 @pytest.mark.nondestructive
 def test_play_video(base_url, selenium):
     page = ContributePage(base_url, selenium).open()
@@ -22,6 +23,7 @@ def test_next_event_is_displayed(base_url, selenium):
     assert page.next_event_is_displayed
 
 
+@pytest.mark.sanity
 @pytest.mark.nondestructive
 def test_newsletter_default_values(base_url, selenium):
     page = ContributePage(base_url, selenium).open()

--- a/tests/functional/test_home.py
+++ b/tests/functional/test_home.py
@@ -8,6 +8,7 @@ from selenium.common.exceptions import TimeoutException
 from ..pages.home import HomePage
 
 
+@pytest.mark.sanity
 @pytest.mark.nondestructive
 def test_promo_grid_is_displayed(base_url, selenium):
     page = HomePage(base_url, selenium).open()
@@ -32,6 +33,7 @@ def test_tweet_is_not_present(base_url, selenium):
     assert not page.is_tweet_promo_present
 
 
+@pytest.mark.sanity
 @pytest.mark.nondestructive
 def test_download_button_is_displayed(base_url, selenium):
     page = HomePage(base_url, selenium).open()
@@ -46,6 +48,7 @@ def test_upcoming_events_are_displayed(base_url, selenium):
     assert events.is_events_list_displayed
 
 
+@pytest.mark.sanity
 @pytest.mark.nondestructive
 def test_mozilla_newsletter_default_values(base_url, selenium):
     page = HomePage(base_url, selenium).open()

--- a/tests/functional/test_newsletter.py
+++ b/tests/functional/test_newsletter.py
@@ -8,6 +8,7 @@ from selenium.common.exceptions import TimeoutException
 from ..pages.newsletter import NewsletterPage
 
 
+@pytest.mark.sanity
 @pytest.mark.nondestructive
 def test_default_values(base_url, selenium):
     page = NewsletterPage(base_url, selenium).open()


### PR DESCRIPTION
Adds `sanity` markers to functional tests, and adds some basic documentation to help explain their purpose.

I have left out certain tests from the sanity suite, including:

* Tests that submit newsletters.
* Tests that rely on long-running timeouts.
* Tests that rely on specific locales being available.
* Tests that rely on cron jobs (e.g. event ical feeds, tweets etc).

Not sure if this is all correct, or if we should tweak things further. But this is good for discussion.