### PR TITLE
Bug 1139654 - use sentence case for iOS home promo button

### DIFF
--- a/media/css/mozorg/home/home-promo.less
+++ b/media/css/mozorg/home/home-promo.less
@@ -1049,6 +1049,10 @@ html[lang|="en"] {
         padding-top: 180px;
         background: url(/media/img/home/voices/promos/ios/icon-ios.svg) center 50px no-repeat;
     }
+
+    p.more {
+        text-transform: none;
+    }
 }
 
 html[lang|="en"] {


### PR DESCRIPTION
Apple's brand guidelines frown upon the uppercase I so we'll override the `text-transform` for just this promo.