### PR TITLE
[fix Bug 1220138 - Adding Mozilla Sweden website link to community page]

### DIFF
--- a/bedrock/mozorg/templates/mozorg/contact/communities/sweden.html
+++ b/bedrock/mozorg/templates/mozorg/contact/communities/sweden.html
@@ -13,6 +13,7 @@
         <h2>{{ _('Sweden') }}</h2>
 
         <ul class="extra">
+          <li><a href="http://www.mozilla.ch" class="website">www.mozilla.ch</a></li>
           <li><a href="https://lists.mozilla.org/listinfo/community-sweden" class="email">{{ _('Mailing list') }}</a></li>
           <li><a href="https://twitter.com/MozillaSweden" class="twitter">@MozillaSweden</a></li>
           <li><a href="irc://irc.mozilla.org/mozilla.se" class="irc">IRC: #mozilla.se</a></li>


### PR DESCRIPTION
Adding mozilla.ch on community page.