### PR TITLE
Fix intermittent failure in l10n language selector test

### DIFF
--- a/tests/functional/test_l10n.py
+++ b/tests/functional/test_l10n.py
@@ -18,5 +18,5 @@ def test_change_language(base_url, selenium):
     available = [l for l in page.footer.languages if l not in excluded]
     new = random.choice(available)
     page.footer.select_language(new)
-    assert new in selenium.current_url, 'Language is not in URL'
+    assert '/{0}/'.format(new) in selenium.current_url, 'Language is not in URL'
     assert new == page.footer.language, 'Language has not been selected'


### PR DESCRIPTION
https://webqa-ci.mozilla.com/job/bedrock.dev.win10.ie/34/
https://webqa-ci.mozilla.com/job/bedrock.dev.win10.ie/23/

I noticed these two failures both happen when redirected to the `or` locale. My hunch is that IE is matching the URL (www-dev.allizom.**or**g) before the page is redirected, resulting in the last assert failing when the selector becomes stale.