### PR TITLE
Start from debian:jessie.

### DIFF
--- a/docker/dockerfiles/bedrock_functional_tests
+++ b/docker/dockerfiles/bedrock_functional_tests
@@ -1,9 +1,12 @@
-FROM python:2-slim
+FROM debian:jessie
 
 WORKDIR /app
-
 # Run the tests
 CMD ["/app/bin/run-functional-tests.sh"]
+
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends build-essential python python-dev python-pip
 
 # Defaults
 ENV PYTEST_PROCESSES 5


### PR DESCRIPTION
Using the python images from registry does not play well with our outdated docker version on the CI server. Debian images are OK for now.

Error https://ci.us-west.moz.works/job/bedrock_functional_tests/65/console

 @davehunt  r?