### PR TITLE
Bug 1221167 - Make alt text on Google Play button localizable

### DIFF
--- a/bedrock/firefox/templates/firefox/android/index.html
+++ b/bedrock/firefox/templates/firefox/android/index.html
@@ -35,7 +35,7 @@
   {% call fxfamilynav('android', 'index') %}
     <div class="{% if has_widget %}show-widget{% endif %}">
       <a class="dl-button" rel="external" href="{{ settings.GOOGLE_PLAY_FIREFOX_LINK }}">
-        {{ high_res_img('firefox/android/btn-google-play.png', {'alt': 'Get it on Google Play', 'width': '129', 'height': '45', 'l10n': True}) }}
+        {{ high_res_img('firefox/android/btn-google-play.png', {'alt': _('Get it on Google Play'), 'width': '129', 'height': '45', 'l10n': True}) }}
       </a>
       <button class="send-to button-flat-dark" type="button">{{ _('Get Firefox for Android') }}</button>
     </div>
@@ -60,7 +60,7 @@
 
       <div class="send-to-device-variant dl-button-wrapper {% if has_widget %}show-widget{% endif %}" id="send-to-device-default">
         <a class="dl-button" rel="external" href="{{ settings.GOOGLE_PLAY_FIREFOX_LINK }}" data-button-type="download" data-interaction="download click" data-download-version="Firefox for Android">
-          {{ high_res_img('firefox/android/btn-google-play.png', {'alt': 'Get it on Google Play', 'width': '129', 'height': '45', 'l10n': True}) }}
+          {{ high_res_img('firefox/android/btn-google-play.png', {'alt': _('Get it on Google Play'), 'width': '129', 'height': '45', 'l10n': True}) }}
         </a>
         <small class="download-other">
           <a class="dl-button" href="{{ url('firefox.android.all') }}">{{_('Systems &amp; Languages')}}</a>
@@ -77,7 +77,7 @@
 
       <div class="send-to-device-variant" id="send-to-device-google-play">
         <a class="dl-button" rel="external" href="{{ settings.GOOGLE_PLAY_FIREFOX_LINK }}" data-button-type="download" data-interaction="download click" data-download-version="Firefox for Android">
-          {{ high_res_img('firefox/android/test/btn-google-play.png', {'alt': 'Get it on Google Play', 'width': '200', 'height': '69'}) }}
+          {{ high_res_img('firefox/android/test/btn-google-play.png', {'alt': _('Get it on Google Play'), 'width': '200', 'height': '69'}) }}
         </a>
       </div>
 
@@ -409,7 +409,7 @@
           <h3>{{ _('Choose Firefox') }}</h3>
           <div id="send-to-device-footer">
             <a class="dl-button" rel="external" href="{{ settings.GOOGLE_PLAY_FIREFOX_LINK }}" data-button-type="download" data-interaction="button download click" data-download-version="Firefox for Android" data-alt="{{ _('Get Firefox for Android') }}">
-              {{ high_res_img('firefox/android/btn-google-play.png', {'alt': 'Get it on Google Play', 'width': '129', 'height': '45', 'l10n': True}) }}
+              {{ high_res_img('firefox/android/btn-google-play.png', {'alt': _('Get it on Google Play'), 'width': '129', 'height': '45', 'l10n': True}) }}
             </a>
             <button class="send-to button-flat-dark" type="button">{{ _('Get Firefox for Android') }}</button>
           </div>

--- a/bedrock/firefox/templates/firefox/family/index.html
+++ b/bedrock/firefox/templates/firefox/family/index.html
@@ -97,7 +97,7 @@
 
         <div class="btn-google-play">
           <a rel="external" href="{{ settings.GOOGLE_PLAY_FIREFOX_LINK }}" data-product="Firefox for Android, Google Play">
-            {{ high_res_img('firefox/android/btn-google-play.png', {'alt': 'Get it on Google Play', 'width': '129', 'height': '45', 'l10n': True}) }}
+            {{ high_res_img('firefox/android/btn-google-play.png', {'alt': _('Get it on Google Play'), 'width': '129', 'height': '45', 'l10n': True}) }}
           </a>
           <small class="download-other">
             <a href="{{ url('firefox.android.all') }}">{{_('Systems &amp; Languages')}}</a>

--- a/bedrock/firefox/templates/firefox/private-browsing.html
+++ b/bedrock/firefox/templates/firefox/private-browsing.html
@@ -39,7 +39,7 @@
             </div>
             <div class="android-download-button">
               <a rel="external" href="{{ settings.GOOGLE_PLAY_FIREFOX_LINK }}" data-button-type="download" data-interaction="download click" data-download-version="Firefox for Android">
-                {{ high_res_img('firefox/android/btn-google-play.png', {'alt': 'Get it on Google Play', 'width': '129', 'height': '45', 'l10n': True}) }}
+                {{ high_res_img('firefox/android/btn-google-play.png', {'alt': _('Get it on Google Play'), 'width': '129', 'height': '45', 'l10n': True}) }}
               </a>
             </div>
             <div class="ios-download-button">
@@ -51,8 +51,8 @@
           <div class="firefox-old-cta">
             <p>{{ _('Your Firefox is not up to date. Download the latest version to use the new Private Browsing.') }}</p>
             {{ download_firefox(small=True, icon=False) }}
-          </div>        
-        </div>        
+          </div>
+        </div>
       </header>
       <div class="critter-animation">
           {% include 'firefox/includes/tracking-protection-animation.html' %}
@@ -117,7 +117,7 @@
           <a class="android-link" href="https://support.mozilla.org/kb/mixed-content-blocker-firefox-android">{{ _('Learn more about the Control Center') }}</a>
           <a class="desktop-link" href="https://support.mozilla.org/kb/control-center-site-privacy-and-security-firefox">{{ _('Learn more about the Control Center') }}</a>
         </strong>
-        <small id="control-center-caveat"> 
+        <small id="control-center-caveat">
         {{ _('Control Center is not available on Android devices, but a shield will still be displayed to let you know when you are protected.') }}</small>
       </p>
     </div>
@@ -137,7 +137,7 @@
           </div>
           <div class="android-download-button">
             <a rel="external" href="{{ settings.GOOGLE_PLAY_FIREFOX_LINK }}" data-button-type="download" data-interaction="download click" data-download-version="Firefox for Android">
-              {{ high_res_img('firefox/android/btn-google-play.png', {'alt': 'Get it on Google Play', 'width': '129', 'height': '45', 'l10n': True}) }}
+              {{ high_res_img('firefox/android/btn-google-play.png', {'alt': _('Get it on Google Play'), 'width': '129', 'height': '45', 'l10n': True}) }}
             </a>
           </div>
           <div class="ios-download-button">
@@ -149,8 +149,8 @@
         <div class="firefox-old-cta">
           <h2>{{ _('Your Firefox is not up to date. Download the latest version to use the new Private Browsing.') }}</h2>
           {{ download_firefox(small=True, icon=False) }}
-        </div>        
-      </div>        
+        </div>
+      </div>
     </div>
   </section>
 


### PR DESCRIPTION
Tested locally Android and Family page, not sure how to check the PB one.