### PR TITLE
Fix bug 988046: Remove query params from redirect.

### DIFF
--- a/bedrock/mozorg/redirects.py
+++ b/bedrock/mozorg/redirects.py
@@ -27,7 +27,7 @@ redirectpatterns = (
              locale_prefix=False),
 
     # bug 874913
-    redirect(r'products/download.html', 'firefox.new', anchor='download-fx'),
+    redirect(r'products/download.html', 'firefox.new', query=''),
 
     # bug 845580
     redirect(r'^home/?$', 'firefox.new'),

--- a/test_redirects/map_globalconf.py
+++ b/test_redirects/map_globalconf.py
@@ -40,7 +40,7 @@ URLS = flatten((
     url_test('/zh-TW/download/', 'http://mozilla.com.tw/firefox/download/'),
 
     # bug 874913
-    url_test('/en-US/products/download.html', '/en-US/firefox/new/#download-fx'),
+    url_test('/en-US/products/download.html{,?stuff=whatnot}', '/en-US/firefox/new/'),
 
     # bug 845580
     url_test('/en-US/home/', '/en-US/firefox/new/'),


### PR DESCRIPTION
For products/download.html.