### PR TITLE
fix bug 1224060

### DIFF
--- a/bedrock/firefox/redirects.py
+++ b/bedrock/firefox/redirects.py
@@ -241,4 +241,8 @@ redirectpatterns = (
 
     # bug 960543
     redirect(r'^firefox/(?P<vers>[23])\.0/eula', '/legal/eula/firefox-{vers}/'),
+
+    # bug 1224060
+    redirect(r'^ja/firefox/ios/(?P<vers>[0-9]+(\.[0-9]+)*)/(?P<file>releasenotes|system-requirements)',
+             'http://www.mozilla.jp/firefox/ios/{vers}/{file}/', locale_prefix=False),
 )


### PR DESCRIPTION
This pull request will add a redirection rule to navigate Japanese users, who access to releasenotes of Firefox for iOS, to Japanese version of the releasenotes they want to read.