### PR TITLE
[fix bug 1221739] Add a redirect for Hello's Feedback survey links

### DIFF
--- a/bedrock/firefox/redirects.py
+++ b/bedrock/firefox/redirects.py
@@ -121,6 +121,16 @@ redirectpatterns = (
     # bug 1121082
     redirect(r'^hello/?$', 'firefox.hello'),
 
+    # Bug 1186373
+    redirect(r'^firefox/hello/npssurvey/?$',
+             'https://www.surveygizmo.com/s3/2227372/Firefox-Hello-Product-Survey',
+             permanent=False),
+
+    # Bug 1221739
+    redirect(r'^firefox/hello/feedbacksurvey/?$',
+             'https://www.surveygizmo.com/s3/2319863/d2b7dc4b5687',
+             permanent=False),
+
     # bug 1148127
     redirect(r'^products/?$', 'firefox.family.index'),
 

--- a/bedrock/mozorg/redirects.py
+++ b/bedrock/mozorg/redirects.py
@@ -153,11 +153,6 @@ redirectpatterns = (
              'styleguide.communications.copy-rules'),
     redirect(r'^firefox/brand/downloads/?$', 'styleguide.home'),
 
-    # Bug 1186373
-    redirect(r'^firefox/hello/npssurvey/?$',
-             'https://www.surveygizmo.com/s3/2227372/Firefox-Hello-Product-Survey',
-             permanent=False),
-
     # Bug 1071318
     redirect(r'^firefox/mobile/?$', 'firefox.android.index'),
 

--- a/etc/httpd/global.conf
+++ b/etc/httpd/global.conf
@@ -208,6 +208,9 @@ RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/hello(/?)$ /b/$1firefox/hello$2 [PT]
 # bug 1186373
 RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/hello/npssurvey(/?)$ /b/$1firefox/hello/npssurvey$2 [PT]
 
+# bug 1221739
+RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/hello/feedbacksurvey(/?)$ /b/$1firefox/hello/feedbacksurvey$2 [PT]
+
 # bug 1071074
 RewriteRule ^/(\w{2,3}(?:-\w{2})?/)?firefox/channel(/?)$ /b/$1firefox/channel$2 [PT]
 

--- a/test_redirects/map_globalconf.py
+++ b/test_redirects/map_globalconf.py
@@ -898,4 +898,14 @@ URLS = flatten((
 
     # bug 442671
     url_test('/foundation/trademarks/l10n-policy/', '/foundation/trademarks/'),
+
+    # Bug 1186373
+    url_test('/firefox/hello/npssurvey/',
+             'https://www.surveygizmo.com/s3/2227372/Firefox-Hello-Product-Survey',
+             status_code=302),
+
+    # Bug 1221739
+    url_test('/firefox/hello/feedbacksurvey/',
+             'https://www.surveygizmo.com/s3/2319863/d2b7dc4b5687',
+             status_code=302),
 ))


### PR DESCRIPTION
Moved the existing redirect to `firefox/redirects.py` and added tests for both redirects.