### PR TITLE
Use absolute imports for page objects

### DIFF
--- a/tests/functional/contribute/test_contribute.py
+++ b/tests/functional/contribute/test_contribute.py
@@ -5,7 +5,7 @@
 import pytest
 from selenium.common.exceptions import TimeoutException
 
-from ...pages.contribute.contribute import ContributePage
+from pages.contribute.contribute import ContributePage
 
 
 @pytest.mark.sanity

--- a/tests/functional/contribute/test_events.py
+++ b/tests/functional/contribute/test_events.py
@@ -4,7 +4,7 @@
 
 import pytest
 
-from ...pages.contribute.events import ContributeEventsPage
+from pages.contribute.events import ContributeEventsPage
 
 
 @pytest.mark.nondestructive

--- a/tests/functional/contribute/test_signup.py
+++ b/tests/functional/contribute/test_signup.py
@@ -5,7 +5,7 @@
 import pytest
 from selenium.common.exceptions import TimeoutException
 
-from ...pages.contribute.signup import ContributeSignUpPage
+from pages.contribute.signup import ContributeSignUpPage
 
 
 @pytest.mark.sanity

--- a/tests/functional/contribute/test_stories.py
+++ b/tests/functional/contribute/test_stories.py
@@ -4,7 +4,7 @@
 
 import pytest
 
-from ...pages.contribute.stories import ContributeStoriesPage
+from pages.contribute.stories import ContributeStoriesPage
 
 
 @pytest.mark.sanity

--- a/tests/functional/firefox/test_developer.py
+++ b/tests/functional/firefox/test_developer.py
@@ -4,7 +4,7 @@
 
 import pytest
 
-from ...pages.firefox.developer import DeveloperPage
+from pages.firefox.developer import DeveloperPage
 
 
 @pytest.mark.sanity

--- a/tests/functional/firefox/test_do_not_track.py
+++ b/tests/functional/firefox/test_do_not_track.py
@@ -4,7 +4,7 @@
 
 import pytest
 
-from ...pages.firefox.do_not_track import DoNotTrackPage
+from pages.firefox.do_not_track import DoNotTrackPage
 
 
 @pytest.mark.sanity

--- a/tests/functional/test_home.py
+++ b/tests/functional/test_home.py
@@ -5,7 +5,7 @@
 import pytest
 from selenium.common.exceptions import TimeoutException
 
-from ..pages.home import HomePage
+from pages.home import HomePage
 
 
 @pytest.mark.sanity

--- a/tests/functional/test_l10n.py
+++ b/tests/functional/test_l10n.py
@@ -6,7 +6,7 @@ import random
 
 import pytest
 
-from ..pages.home import HomePage
+from pages.home import HomePage
 
 
 @pytest.mark.nondestructive

--- a/tests/functional/test_newsletter.py
+++ b/tests/functional/test_newsletter.py
@@ -5,7 +5,7 @@
 import pytest
 from selenium.common.exceptions import TimeoutException
 
-from ..pages.newsletter import NewsletterPage
+from pages.newsletter import NewsletterPage
 
 
 @pytest.mark.sanity

--- a/tests/pages/base.py
+++ b/tests/pages/base.py
@@ -6,8 +6,8 @@ from selenium.webdriver.common.by import By
 from selenium.webdriver.support.select import Select
 from selenium.webdriver.support.ui import WebDriverWait as Wait
 
-from .page import Page, PageRegion
-from .regions.newsletter import NewsletterEmbedForm, MozillaNewsletterEmbedForm
+from page import Page, PageRegion
+from regions.newsletter import NewsletterEmbedForm, MozillaNewsletterEmbedForm
 
 
 class BasePage(Page):

--- a/tests/pages/firefox/base.py
+++ b/tests/pages/firefox/base.py
@@ -6,8 +6,8 @@ from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as expected
 from selenium.webdriver.support.ui import WebDriverWait as Wait
 
-from ..base import BasePage
-from ..page import PageRegion
+from pages.base import BasePage
+from pages.page import PageRegion
 
 
 class FirefoxBasePage(BasePage):

--- a/tests/pages/firefox/developer.py
+++ b/tests/pages/firefox/developer.py
@@ -5,9 +5,9 @@
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support.ui import WebDriverWait as Wait
 
-from .base import FirefoxBasePage
-from ..page import PageRegion
-from ..regions.modal import Modal
+from pages.page import PageRegion
+from pages.firefox.base import FirefoxBasePage
+from pages.regions.modal import Modal
 
 
 class DeveloperPage(FirefoxBasePage):
@@ -29,7 +29,7 @@ class DeveloperPage(FirefoxBasePage):
     @property
     def developer_videos(self):
         return [Video(self.selenium, root=el) for el in
-                   self.selenium.find_elements(*self._videos_locator)]
+                self.selenium.find_elements(*self._videos_locator)]
 
 
 class Video(PageRegion):

--- a/tests/pages/firefox/do_not_track.py
+++ b/tests/pages/firefox/do_not_track.py
@@ -5,8 +5,8 @@
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support.ui import WebDriverWait as Wait
 
-from .base import FirefoxBasePage
-from ..page import PageRegion
+from pages.page import PageRegion
+from pages.firefox.base import FirefoxBasePage
 
 
 class DoNotTrackPage(FirefoxBasePage):
@@ -19,7 +19,7 @@ class DoNotTrackPage(FirefoxBasePage):
     @property
     def frequently_asked_questions(self):
         return [FrequentlyAskedQuestion(self.selenium, root=el) for el in
-                   self.selenium.find_elements(*self._faqs_locator)]
+                self.selenium.find_elements(*self._faqs_locator)]
 
     @property
     def is_do_not_track_status_displayed(self):

--- a/tests/pages/home.py
+++ b/tests/pages/home.py
@@ -6,8 +6,8 @@ from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as expected
 from selenium.webdriver.support.ui import WebDriverWait as Wait
 
-from .base import BasePage
-from .page import PageRegion
+from base import BasePage
+from page import PageRegion
 
 
 class HomePage(BasePage):

--- a/tests/pages/newsletter.py
+++ b/tests/pages/newsletter.py
@@ -7,7 +7,7 @@ from selenium.webdriver.support import expected_conditions as expected
 from selenium.webdriver.support.select import Select
 from selenium.webdriver.support.ui import WebDriverWait as Wait
 
-from .base import BasePage
+from base import BasePage
 
 
 class NewsletterPage(BasePage):

--- a/tests/pages/regions/modal.py
+++ b/tests/pages/regions/modal.py
@@ -6,7 +6,7 @@ from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as expected
 from selenium.webdriver.support.ui import WebDriverWait as Wait
 
-from ..page import PageRegion
+from pages.page import PageRegion
 
 
 class Modal(PageRegion):

--- a/tests/pages/regions/newsletter.py
+++ b/tests/pages/regions/newsletter.py
@@ -7,7 +7,7 @@ from selenium.webdriver.support import expected_conditions as expected
 from selenium.webdriver.support.select import Select
 from selenium.webdriver.support.ui import WebDriverWait as Wait
 
-from ..page import PageRegion
+from pages.page import PageRegion
 
 
 class NewsletterEmbedForm(PageRegion):


### PR DESCRIPTION
This removes the need for the rather ugly relative imports.