### PR TITLE
[bug-1222637] Fixed horizontal scrolling on private-browsing.less

### DIFF
--- a/media/css/firefox/private_browsing/private-browsing.less
+++ b/media/css/firefox/private_browsing/private-browsing.less
@@ -7,6 +7,11 @@
 /*-------------------------------------------------------------------------*/
 // Common
 
+html, body{
+    max-width: 100%;
+    overflow-x: hidden;
+}
+
 #wrapper {
     border-top: 2px solid #fff;
     background-color: @mozIDBlue;


### PR DESCRIPTION
[bug-1222637] Fixed horizontal scrolling on private-browsing.less 

@jpetto 

rebase went wrong on the other PR, so it's all fixed here, with one commit. :cake:

Bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1222637 

Old PR: https://github.com/mozilla/bedrock/pull/3554