### PR TITLE
Bug 1217971 - Add lang file directive to firefox/choose

### DIFF
--- a/bedrock/firefox/templates/firefox/choose.html
+++ b/bedrock/firefox/templates/firefox/choose.html
@@ -4,6 +4,8 @@
 
 {% extends "firefox/base-resp.html" %}
 
+{% add_lang_files "firefox/choose" %}
+
 {% block page_title_prefix %}{{_('Firefox Web browser')}} — {% endblock %}
 {% block page_title %}{{_('Keep your identity yours with the new Firefox') }}{% endblock %}
 {% block page_desc %}{{_('Choose Firefox when you want to browse the Web without the Web browsing you.')}}'{% endblock %}


### PR DESCRIPTION
This lets us override strings coming from new.lang (loaded in base-resp.html). Thanks to @pascalchevrel  for the idea.