### PR TITLE
Fix CTA alignment on firefox/ios/ mobile viewports.

### DIFF
--- a/media/css/firefox/ios.less
+++ b/media/css/firefox/ios.less
@@ -713,7 +713,7 @@ a.go {
     }
     .send-to-device,
     .send-to {
-        display: block;
+        display: inline;
     }
 }
 


### PR DESCRIPTION
Didn't file a bug, but can if needed. Tested on IE 9 & 10, Fx, Chrome, Safari.

![screen shot 2015-11-17 at 3 26 47 pm](https://cloud.githubusercontent.com/assets/317532/11225442/c41609d6-8d3f-11e5-88b9-4b74e2c371db.png)
