### PR TITLE
Add main site navigation tests for desktop and mobile views

### DIFF
--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -4,6 +4,10 @@
 
 import pytest
 
+VIEWPORT = {
+    'desktop': {'width': 1280, 'height': 1024},
+    'mobile': {'width': 320, 'height': 480}}
+
 
 @pytest.fixture(scope='session')
 def capabilities(capabilities):
@@ -12,6 +16,9 @@ def capabilities(capabilities):
 
 
 @pytest.fixture
-def selenium(selenium):
-    selenium.set_window_size(1280, 1024)
+def selenium(request, selenium):
+    viewport = VIEWPORT['desktop']
+    if request.keywords.get('viewport') is not None:
+        viewport = VIEWPORT[request.keywords.get('viewport').args[0]]
+    selenium.set_window_size(viewport['width'], viewport['height'])
     return selenium

--- a/tests/functional/test_navigation.py
+++ b/tests/functional/test_navigation.py
@@ -1,0 +1,40 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import pytest
+
+from pages.home import HomePage
+
+
+@pytest.mark.nondestructive
+def test_navigation(base_url, selenium):
+    page = HomePage(base_url, selenium).open()
+    about_page = page.navigation.open_about()
+    assert about_page.url in selenium.current_url
+
+    page.open()
+    participate_page = page.navigation.open_participate()
+    assert participate_page.url in selenium.current_url
+
+    page.open()
+    firefox_page = page.navigation.open_firefox()
+    assert firefox_page.url in selenium.current_url
+
+
+@pytest.mark.sanity
+@pytest.mark.nondestructive
+@pytest.mark.viewport('mobile')
+def test_mobile_navigation(base_url, selenium):
+    page = HomePage(base_url, selenium).open()
+    page.navigation.show()
+    about_page = page.navigation.open_about()
+    assert about_page.url in selenium.current_url
+
+    page.open().navigation.show()
+    participate_page = page.navigation.open_participate()
+    assert participate_page.url in selenium.current_url
+
+    page.open().navigation.show()
+    firefox_page = page.navigation.open_firefox()
+    assert firefox_page.url in selenium.current_url

--- a/tests/pages/about.py
+++ b/tests/pages/about.py
@@ -1,0 +1,10 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from base import BasePage
+
+
+class AboutPage(BasePage):
+
+    _url = '{base_url}/{locale}/about'

--- a/tests/pages/base.py
+++ b/tests/pages/base.py
@@ -22,6 +22,10 @@ class BasePage(Page):
         return self
 
     @property
+    def navigation(self):
+        return self.Navigation(self.base_url, self.selenium)
+
+    @property
     def footer(self):
         return self.Footer(self.base_url, self.selenium)
 
@@ -32,6 +36,42 @@ class BasePage(Page):
     @property
     def mozilla_newsletter(self):
         return MozillaNewsletterEmbedForm(self.base_url, self.selenium)
+
+    class Navigation(PageRegion):
+
+        _root_locator = (By.ID, 'nav-main')
+        _toggle_locator = (By.CLASS_NAME, 'toggle')
+        _menu_locator = (By.ID, 'nav-main-menu')
+        _about_locator = (By.CSS_SELECTOR, 'a[data-link-type="about"]')
+        _participate_locator = (By.CSS_SELECTOR, 'a[data-link-type="participate"]')
+        _firefox_locator = (By.CSS_SELECTOR, 'a[data-link-type="firefox"]')
+
+        def show(self):
+            assert not self.is_displayed, 'Menu is already displayed'
+            self.find_element(self._toggle_locator).click()
+            self.wait.until(lambda s: self.is_displayed)
+            return self
+
+        @property
+        def is_displayed(self):
+            toggle = self.find_element(self._toggle_locator)
+            return (self.find_element(self._menu_locator).is_displayed() and
+                toggle.get_attribute('aria-expanded') == 'true')
+
+        def open_about(self):
+            self.find_element(self._about_locator).click()
+            from about import AboutPage
+            return AboutPage(self.base_url, self.selenium).wait_for_page_to_load()
+
+        def open_participate(self):
+            self.find_element(self._participate_locator).click()
+            from contribute.contribute import ContributePage
+            return ContributePage(self.base_url, self.selenium).wait_for_page_to_load()
+
+        def open_firefox(self):
+            self.find_element(self._firefox_locator).click()
+            from firefox.products import ProductsPage
+            return ProductsPage(self.base_url, self.selenium).wait_for_page_to_load()
 
     class Footer(PageRegion):
 

--- a/tests/pages/contribute/base.py
+++ b/tests/pages/contribute/base.py
@@ -4,7 +4,7 @@
 
 from selenium.webdriver.common.by import By
 
-from ..base import BasePage
+from pages.base import BasePage
 
 
 class ContributeBasePage(BasePage):

--- a/tests/pages/contribute/contribute.py
+++ b/tests/pages/contribute/contribute.py
@@ -4,8 +4,8 @@
 
 from selenium.webdriver.common.by import By
 
-from .base import ContributeBasePage
-from ..regions.modal import Modal
+from pages.contribute.base import ContributeBasePage
+from pages.regions.modal import Modal
 
 
 class ContributePage(ContributeBasePage):

--- a/tests/pages/contribute/events.py
+++ b/tests/pages/contribute/events.py
@@ -4,7 +4,7 @@
 
 from selenium.webdriver.common.by import By
 
-from .base import ContributeBasePage
+from pages.contribute.base import ContributeBasePage
 
 
 class ContributeEventsPage(ContributeBasePage):

--- a/tests/pages/contribute/signup.py
+++ b/tests/pages/contribute/signup.py
@@ -5,7 +5,7 @@
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support.select import Select
 
-from .base import ContributeBasePage
+from pages.contribute.base import ContributeBasePage
 
 
 class ContributeSignUpPage(ContributeBasePage):

--- a/tests/pages/contribute/stories.py
+++ b/tests/pages/contribute/stories.py
@@ -4,7 +4,7 @@
 
 from selenium.webdriver.common.by import By
 
-from .base import ContributeBasePage
+from pages.contribute.base import ContributeBasePage
 
 
 class ContributeStoriesPage(ContributeBasePage):

--- a/tests/pages/firefox/products.py
+++ b/tests/pages/firefox/products.py
@@ -1,0 +1,10 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from pages.base import BasePage
+
+
+class ProductsPage(BasePage):
+
+    _url = '{base_url}/{locale}/firefox/products'


### PR DESCRIPTION
This replaces the following tests from https://github.com/mozilla/mcom-tests:
* [test_about > test_navbar_links_are_visible](https://github.com/mozilla/mcom-tests/blob/c9eacd8f62b11d4a2ab70a230db779932235c801/tests/test_about.py#L36)
* [test_about > test_navbar_link_destinations_are_correct](https://github.com/mozilla/mcom-tests/blob/c9eacd8f62b11d4a2ab70a230db779932235c801/tests/test_about.py#L45)
* [test_about > test_navbar_link_urls_are_valid](https://github.com/mozilla/mcom-tests/blob/c9eacd8f62b11d4a2ab70a230db779932235c801/tests/test_about.py#L56)
* [test_mozillabased > test_navbar_links_are_visible](https://github.com/mozilla/mcom-tests/blob/c9eacd8f62b11d4a2ab70a230db779932235c801/tests/test_mozillabased.py#L92)

The main differences are:
* These tests check the main navigation links from the __home__ page instead of the __about__ and __mozilla-based__ pages. We could easily parameterise these tests if we wanted to run them from multiple initial pages.
* The tests these replace were checking the links were visible, destination URLs were correct, and destination URLs responded with an OK response code. The new tests click the links (would throw if they were not visible), and check the destination URL is accurate for the expected page.
* The new tests also check the navigation for small screens by restricting the viewport.