### PR TITLE
Allow LinkChecker to crawl the site for broken links

### DIFF
--- a/bedrock/mozorg/templates/mozorg/robots.txt
+++ b/bedrock/mozorg/templates/mozorg/robots.txt
@@ -1,3 +1,6 @@
+user-agent: LinkChecker
+disallow:
+crawl-delay: 1
 user-agent: *
 {% if disallow_all -%}
 disallow: /


### PR DESCRIPTION
This change allows the [LinkChecker](http://wummel.github.io/linkchecker/) tool to run against the site and report any broken links. This is much more thorough than the link checking performed in https://github.com/mozilla/mcom-tests/ and can be run as a separate scheduled job that would not necessarily block a deploy due to the unavailability of external sites.

With this change I'm able to run LinkChecker locally (still going strong after 20 minutes). If this is merged and deployed to any environment I'd be happy to set up a Jenkins job to run once a week (alternative suggestions welcome) and send the results to whomever may be interested (again, suggestions?). I'd then like to use this as an opportunity to remove all the link checking from mcom-tests. :link: :smile:

/cc @alexgibson @jgmize @pmclanahan 