### PR TITLE
Fix Bug 1226012 - Broken GitHub tutorial link on commit access policy page

### DIFF
--- a/bedrock/mozorg/templates/mozorg/about/governance/policies/commit.html
+++ b/bedrock/mozorg/templates/mozorg/about/governance/policies/commit.html
@@ -40,7 +40,7 @@
   </li>
   <li>{{ _('Attach your SSH <em>public</em> key to the bug - a file with extension ".pub". (Please mark it as <code>text/plain</code> when attaching it!)') }}
     <ul>
-      <li>{% trans policy='https://help.github.com/articles/generating-ssh-keys/' %}
+      <li>{% trans tutorial='https://help.github.com/articles/generating-ssh-keys/' %}
       GitHub has a <a href="{{ tutorial }}">useful tutorial on generating SSH keys</a>.
       {% endtrans %}</li>
     </ul>


### PR DESCRIPTION
Fixing my mistake in #3557  :grimacing: