### PR TITLE
Fix bug 1226329: Improve x-backend-server header

### DIFF
--- a/bedrock/mozorg/middleware.py
+++ b/bedrock/mozorg/middleware.py
@@ -72,6 +72,10 @@ class ClacksOverheadMiddleware(object):
 
 
 class HostnameMiddleware(object):
+    def __init__(self):
+        values = [getattr(settings, x) for x in ['HOSTNAME', 'DEIS_APP', 'DEIS_DOMAIN']]
+        self.backend_server = '.'.join(x for x in values if x)
+
     def process_response(self, request, response):
-        response['X-Backend-Server'] = settings.HOSTNAME
+        response['X-Backend-Server'] = self.backend_server
         return response

--- a/bedrock/mozorg/tests/test_middleware.py
+++ b/bedrock/mozorg/tests/test_middleware.py
@@ -65,18 +65,18 @@ class TestCrossOriginResourceSharingMiddleware(TestCase):
 
 
 class TestHostnameMiddleware(TestCase):
-    @override_settings(HOSTNAME='foobar')
+    @override_settings(HOSTNAME='foobar', DEIS_APP='bedrock-dev', DEIS_DOMAIN='example.com')
     def test_base(self):
         self.middleware = HostnameMiddleware()
         self.request = HttpRequest()
         self.response = HttpResponse()
 
         self.middleware.process_response(self.request, self.response)
-        self.assertEqual(self.response['X-Backend-Server'], 'foobar')
+        self.assertEqual(self.response['X-Backend-Server'], 'foobar.bedrock-dev.example.com')
 
     @override_settings(MIDDLEWARE_CLASSES=(list(settings.MIDDLEWARE_CLASSES) +
                                            ['bedrock.mozorg.middleware.HostnameMiddleware']),
-                       HOSTNAME='foobar')
+                       HOSTNAME='foobar', DEIS_APP='el-dudarino')
     def test_request(self):
         response = self.client.get('/en-US/')
-        self.assertEqual(response['X-Backend-Server'], 'foobar')
+        self.assertEqual(response['X-Backend-Server'], 'foobar.el-dudarino')

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -302,7 +302,11 @@ DOMAIN_METHODS = {
     ],
 }
 
-ENABLE_HOSTNAME_MIDDLEWARE = config('ENABLE_HOSTNAME_MIDDLEWARE', default=False, cast=bool)
+HOSTNAME = platform.node()
+DEIS_APP = config('DEIS_APP', default=None)
+DEIS_DOMAIN = config('DEIS_DOMAIN', default=None)
+ENABLE_HOSTNAME_MIDDLEWARE = config('ENABLE_HOSTNAME_MIDDLEWARE',
+                                    default=bool(DEIS_APP), cast=bool)
 
 MIDDLEWARE_CLASSES = [middleware for middleware in (
     'sslify.middleware.SSLifyMiddleware',
@@ -891,5 +895,3 @@ if not SSLIFY_DISABLE:
 SSLIFY_DISABLE_FOR_REQUEST = [
     lambda request: request.get_full_path() == '/healthz/'
 ]
-
-HOSTNAME = platform.node()


### PR DESCRIPTION
This will turn on x-backend-server for every instance with a DEIS_APP
env var (which should be all of them running on Deis). It also adds the
value of said var to the header response. Also if DEIS_DOMAIN env var is set
that will be added to the end of that.