### PR TITLE
Fix Bug 1219957 - Move browser detection code from global.js to mozilla-client.js

### DIFF
--- a/media/js/base/global.js
+++ b/media/js/base/global.js
@@ -34,14 +34,16 @@ function init_download_links() {
 }
 
 function update_download_text_for_old_fx() {
+    var client = window.Mozilla.Client;
+
     // if using Firefox
-    if (isFirefox()) {
+    if (client.isFirefoxDesktop || client.isFirefoxAndroid) {
         // look at each button to see if it's set to check for old firefox
         var $buttons = $('.download-button-check-old-fx');
 
         // if the page has download buttons
         if ($buttons.length) {
-            window.Mozilla.Client.getFirefoxDetails(function(data) {
+            client.getFirefoxDetails(function(data) {
                 // if using an out of date firefox
                 if (!data.isUpToDate) {
                     // replace subtitle copy
@@ -83,71 +85,6 @@ function init_lang_switcher() {
         });
         $('#lang_form').submit();
     });
-}
-
-//get Master firefox version
-// TODO: Move this to Mozilla.Client
-function getFirefoxMasterVersion(userAgent) {
-    var version = 0;
-    var ua = userAgent || navigator.userAgent;
-
-    var matches = /Firefox\/([0-9]+).[0-9]+(?:.[0-9]+)?/.exec(
-        ua
-    );
-
-    if (matches !== null && matches.length > 0) {
-        version = parseInt(matches[1], 10);
-    }
-
-    return version;
-}
-
-// Used on the plugincheck page to also support all browsers based on Gecko.
-// TODO: Move this to Mozilla.Client
-function isLikeFirefox(userAgent) {
-    var ua = userAgent || navigator.userAgent;
-    return (/Iceweasel/i).test(ua) || (/IceCat/i).test(ua) ||
-        (/SeaMonkey/i).test(ua) || (/Camino/i).test(ua) ||
-        (/like Firefox/i).test(ua);
-}
-
-// TODO: Move this to Mozilla.Client
-function isFirefox(userAgent) {
-    var ua = userAgent || navigator.userAgent;
-    return (/\sFirefox/).test(ua) && !isLikeFirefox(ua);
-}
-
-// 2015-01-20: Gives no special consideration to ESR builds
-// TODO: Move this to Mozilla.Client
-function isFirefoxUpToDate(latest) {
-    var $html = $(document.documentElement);
-    var fx_version = getFirefoxMasterVersion();
-    var latestFirefoxVersion;
-
-    if (!latest) {
-        latestFirefoxVersion = $html.attr('data-latest-firefox');
-        latestFirefoxVersion = parseInt(latestFirefoxVersion.split('.')[0], 10);
-    } else {
-        latestFirefoxVersion = parseInt(latest.split('.')[0], 10);
-    }
-
-    return (latestFirefoxVersion <= fx_version);
-}
-
-// used in bedrock for desktop specific checks like `isFirefox() && !isFirefoxMobile()`
-// reference https://developer.mozilla.org/en-US/docs/Gecko_user_agent_string_reference
-// TODO: Move this to Mozilla.Client
-function isFirefoxMobile(userAgent) {
-    var ua = userAgent || navigator.userAgent;
-    return /Mobile|Tablet|Fennec/.test(ua);
-}
-
-// iOS does not follow same version numbers as desktop & Android, so may not be safe to
-// simply add this check to isFirefox. Will require further investigation/testing.
-// TODO: Move this to Mozilla.Client
-function isFirefoxiOS(userAgent) {
-    var ua = userAgent || navigator.userAgent;
-    return /FxiOS/.test(ua);
 }
 
 // Create text translation function using #strings element.

--- a/media/js/firefox/accounts.js
+++ b/media/js/firefox/accounts.js
@@ -111,7 +111,7 @@
     }
 
     // if user is not on Firefox for Desktop, redirect to the /firefox/sync/ page.
-    if (window.isFirefox() && !window.isFirefoxMobile() && !window.isFirefoxiOS()) {
+    if (window.Mozilla.Client.isFirefoxDesktop) {
         // if uitour callback does not fire in 500ms, load the iframe anyway.
         _uitourTimeout = setTimeout(loadFxAccountsForm, 500);
         // if user is signed into sync, redirect the /firefox/sync/ page,

--- a/media/js/firefox/android.js
+++ b/media/js/firefox/android.js
@@ -32,7 +32,7 @@
     $screencastImages.append($('#screencast .media-desktop').html());
 
     // hide download buttons from Android users
-    if (window.isFirefox() && window.site.platform === 'android') {
+    if (Mozilla.Client.isFirefoxAndroid) {
         $('.dl-button-wrapper').hide();
 
         $('#subscribe-wrapper').removeClass('floating');

--- a/media/js/firefox/australis/common.js
+++ b/media/js/firefox/australis/common.js
@@ -57,7 +57,7 @@
                     'event': 'first-run-sync'
                 });
 
-                if (window.getFirefoxMasterVersion() >= 31) {
+                if (Mozilla.Client.FirefoxMajorVersion >= 31) {
                     Mozilla.UITour.showFirefoxAccounts();
                 } else {
                     window.open(this.href, '_blank');

--- a/media/js/firefox/australis/fx36/firstrun.js
+++ b/media/js/firefox/australis/fx36/firstrun.js
@@ -1,6 +1,8 @@
 ;(function($, Mozilla) {
     'use strict';
 
+    var client = Mozilla.Client;
+
     var helloAnimationStage = $('#hello-animation-stage');
 
     //track if this is the first time a user has seen tour
@@ -20,7 +22,7 @@
     }
 
     //Only run the tour if user is on Firefox 29 for desktop.
-    if (window.isFirefox() && !window.isFirefoxMobile() && window.getFirefoxMasterVersion() >= 36) {
+    if (client.isFirefoxDesktop && client.FirefoxMajorVersion >= 36) {
 
         // Query if the UITour API is working before we start the tour
         Mozilla.UITour.getConfiguration('sync', function (config) {

--- a/media/js/firefox/australis/fx36/whatsnew.js
+++ b/media/js/firefox/australis/fx36/whatsnew.js
@@ -1,6 +1,8 @@
 ;(function($, Mozilla) {
     'use strict';
 
+    var client = Mozilla.Client;
+
     var $tourStrings = $('#strings');
     var helloAnimationStage = $('#hello-animation-stage');
 
@@ -21,7 +23,7 @@
     }
 
     //Only run the tour if user is on Firefox 29 for desktop.
-    if (window.isFirefox() && !window.isFirefoxMobile() && window.getFirefoxMasterVersion() >= 36) {
+    if (client.isFirefoxDesktop && client.FirefoxMajorVersion >= 36) {
 
         // Query if the UITour API is working before we start the tour
         Mozilla.UITour.getConfiguration('availableTargets', function (config) {

--- a/media/js/firefox/australis/fx38_0_5/firstrun.js
+++ b/media/js/firefox/australis/fx38_0_5/firstrun.js
@@ -1,10 +1,12 @@
 ;(function($, Mozilla) {
     'use strict';
 
+    var client = Mozilla.Client;
+
     var $document;
 
     // to be safe, make sure user is on desktop firefox version 38 or higher
-    if (window.isFirefox() && !window.isFirefoxMobile() && window.getFirefoxMasterVersion() >= 38) {
+    if (client.isFirefoxDesktop && client.FirefoxMajorVersion >= 38) {
         // Query if the UITour API is working before binding click handler.
         // If this fails, CTA falls back to linking to /firefox/sync/.
         Mozilla.UITour.getConfiguration('sync', function() {

--- a/media/js/firefox/australis/no-tour.js
+++ b/media/js/firefox/australis/no-tour.js
@@ -1,8 +1,10 @@
 ;(function($, Mozilla) {
     'use strict';
 
+    var client = Mozilla.Client;
+
     // Mozilla.UITour should run on Firefox 29 and above for Desktop only.
-    if (window.isFirefox() && !window.isFirefoxMobile() && window.getFirefoxMasterVersion() >= 29) {
+    if (client.isFirefoxDesktop && client.FirefoxMajorVersion >= 29) {
         // Register page id for Telemetry
         Mozilla.UITour.registerPageID($('#tour-page').data('telemetry'));
 

--- a/media/js/firefox/australis/tour.js
+++ b/media/js/firefox/australis/tour.js
@@ -3,6 +3,7 @@
 
     window.dataLayer = window.dataLayer || [];
 
+    var client = Mozilla.Client;
     var firstTime = 'True';
 
     // GA tracking for Firstrun tests
@@ -16,7 +17,7 @@
     }
 
     //Only run the tour if user is on Firefox 29 for desktop.
-    if (window.isFirefox() && !window.isFirefoxMobile() && window.getFirefoxMasterVersion() >= 29) {
+    if (client.isFirefoxDesktop && client.FirefoxMajorVersion >= 29) {
 
         // Query if the UITour API is working before we start the tour
         Mozilla.UITour.getConfiguration('sync', function (config) {
@@ -62,7 +63,7 @@
         } catch (e) {}
 
         // track default search engine for Firefox 34
-        if (window.getFirefoxMasterVersion() >= 34) {
+        if (client.FirefoxMajorVersion >= 34) {
             Mozilla.UITour.getConfiguration('selectedSearchEngine', function (data) {
                 var selectedEngineID = data.searchEngineIdentifier;
 

--- a/media/js/firefox/desktop/common.js
+++ b/media/js/firefox/desktop/common.js
@@ -5,6 +5,8 @@
 (function(w, $) {
     'use strict';
 
+    var client = w.Mozilla.Client;
+
     var $mastheadDownloadFirefox = $('#masthead-download-firefox');
     var $html = $('html');
 
@@ -40,9 +42,9 @@
 
     // only show download buttons for users on desktop platforms, using either a non-Firefox browser
     // or an out of date version of Firefox
-    if (!window.site.platform.match(/^(android|ios|fxos)$/)) {
-        if (w.isFirefox()) {
-            w.Mozilla.Client.getFirefoxDetails(function(data) {
+    if (client.isDesktop) {
+        if (client.isFirefox) {
+            client.getFirefoxDetails(function(data) {
                 if (!data.isUpToDate) {
                     showDownloadButtons();
                 }

--- a/media/js/firefox/desktop/index.js
+++ b/media/js/firefox/desktop/index.js
@@ -5,6 +5,7 @@
 (function($) {
     'use strict';
 
+    var client = window.Mozilla.Client;
     var isDesktopViewport = $(window).width() >= 1000;
 
     var $customizeStage = $('#customize .stage');
@@ -41,8 +42,8 @@
         });
     }
 
-    if (window.isFirefox()) {
-        window.Mozilla.Client.getFirefoxDetails(function(data) {
+    if (client.isFirefoxDesktop || client.isFirefoxAndroid) {
+        client.getFirefoxDetails(function(data) {
             if (data.isUpToDate) {
                 $('#overview-intro-up-to-date').addClass('active');
             }

--- a/media/js/firefox/desktop/intro-anim.js
+++ b/media/js/firefox/desktop/intro-anim.js
@@ -5,16 +5,7 @@
 (function(Mozilla, $) {
     'use strict';
 
-    function cutsTheMustard() {
-        // Bug (1083079) fixed but effects Firefox 35
-        if (window.isFirefox() && window.getFirefoxMasterVersion() === 35 && $('html').hasClass('osx')) {
-            return false;
-        }
-
-        return Mozilla.SVGAnimCheck();
-    }
-
-    if (!cutsTheMustard()) {
+    if (!Mozilla.SVGAnimCheck()) {
         // use fallback browser image
         $('body').addClass('no-svg-anim');
     } else {

--- a/media/js/firefox/desktop/tips.js
+++ b/media/js/firefox/desktop/tips.js
@@ -5,6 +5,8 @@
 ;(function($, Hammer) {
     'use strict';
 
+    var client = window.Mozilla.Client;
+
     var $html = $('html');
     var $window = $(window);
     var $tipPrev = $('#tip-prev');
@@ -15,13 +17,13 @@
 
     // only show download button for users on desktop platforms, using either a non-Firefox browser
     // or an out of date version of Firefox
-    if (window.isFirefox()) {
-        window.Mozilla.Client.getFirefoxDetails(function(data) {
+    if (client.isFirefoxDesktop) {
+        client.getFirefoxDetails(function(data) {
             if (data.isUpToDate) {
                 $('#footer').addClass('hide-download');
             }
         });
-    } else if (window.site.platform.match(/^(android|ios|fxos)$/)) {
+    } else if (client.isMobile) {
         $('#footer').addClass('hide-download');
     }
 

--- a/media/js/firefox/dev-firstrun.js
+++ b/media/js/firefox/dev-firstrun.js
@@ -31,6 +31,7 @@ function onYouTubeIframeAPIReady() {
     var highlightTimeout;
     var queryIsLargeScreen = matchMedia('(min-width: 900px)');
     var isHighRes = Mozilla.ImageHelper.isHighDpi();
+    var client = Mozilla.Client;
 
     function onYouTubeIframeAPIReady() {
 
@@ -383,7 +384,7 @@ function onYouTubeIframeAPIReady() {
     }
 
     //Only run the tour if user is on Firefox 35 for desktop.
-    if (window.isFirefox() && !window.isFirefoxMobile() && window.getFirefoxMasterVersion() >= 35) {
+    if (client.isFirefoxDesktop && client.FirefoxMajorVersion >= 35) {
 
         // if viewport is wider than 900px show the tour doorhanger
         if(queryIsLargeScreen.matches) {

--- a/media/js/firefox/family-index.js
+++ b/media/js/firefox/family-index.js
@@ -5,6 +5,8 @@
 ;(function($) {
     'use strict';
 
+    var client = window.Mozilla.Client;
+
     var $html = $(document.documentElement);
     var $downloadbar = $('#conditional-download-bar');
 
@@ -23,8 +25,8 @@
     });
 
     // Check Firefox version
-    if (isFirefox()) {
-        window.Mozilla.Client.getFirefoxDetails(function(data) {
+    if (client.isFirefoxDesktop || client.isFirefoxAndroid) {
+        client.getFirefoxDetails(function(data) {
             $html.addClass(data.isUpToDate ? 'firefox-latest' : 'firefox-old');
         });
     } else {

--- a/media/js/firefox/hello/index.js
+++ b/media/js/firefox/hello/index.js
@@ -15,6 +15,7 @@
     var $videoContainer = $('#video-modal');
     var $video = $('#hello-video');
 
+    var client = Mozilla.Client;
     var supportsHTML5Video = !!document.createElement('video').canPlayType;
     var mqIsWide;
     var tourSource = getParameterByName('utm_source');
@@ -110,17 +111,17 @@
         return results === null ? 'none' : decodeURIComponent(results[1].replace(/\+/g, ' '));
     }
 
-    if (w.isFirefox()) {
+    if (client.isFirefoxDesktop || client.isFirefoxAndroid) {
         // if Fx, hide all footer messaging
         // (correct messaging to display determined below)
         $('.dltry-copy').hide();
 
         // mobile Fx shouldn't see dl button, so best fallback is 'Try Hello' link to SUMO
-        if (w.isFirefoxMobile()) {
+        if (client.isFirefoxAndroid) {
             showFxFooterMessaging();
         }
         // Hello exists in desktop version 35 and up
-        else if (w.getFirefoxMasterVersion() >= 35) {
+        else if (client.FirefoxMajorVersion >= 35) {
             showFxFooterMessaging();
 
             if (!'Promise' in window) {

--- a/media/js/firefox/hello/start-ftu.js
+++ b/media/js/firefox/hello/start-ftu.js
@@ -5,6 +5,8 @@
 ;(function($, Mozilla) {
     'use strict';
 
+    var client = Mozilla.Client;
+
     var $main = $('main');
 
     // use a slight delay for showing the main page content
@@ -14,7 +16,7 @@
     }, 500);
 
     // FTE will only run on Firefox Desktop 35 and above
-    if (window.isFirefox() && !window.isFirefoxMobile() && window.getFirefoxMasterVersion() >= 35) {
+    if (client.isFirefoxDesktop && client.FirefoxMajorVersion >= 35) {
         Mozilla.HelloFTU.init();
     }
 

--- a/media/js/firefox/ios-geo.js
+++ b/media/js/firefox/ios-geo.js
@@ -30,28 +30,27 @@ if (typeof window.Mozilla === 'undefined') {
     var $instructions = $('#sync-instructions');
     var $fill = $('<div id="modal" role="dialog" tabindex="-1"></div>');
 
-    // Sniff UA for Firefox for iOS
-    var isFirefoxiOS = function(userAgent) {
-        var ua = userAgent || navigator.userAgent;
-        return /FxiOS/.test(ua);
-    };
-
     // initialize state - runs after geolocation has completed
     var initState = function() {
+        var client = Mozilla.Client;
         var state = 'Unknown';
         var syncCapable = false;
-        var fxMasterVersion = window.getFirefoxMasterVersion();
 
-        if (window.isFirefox()) {
+        if (client.isFirefox) {
             // Firefox for Android
-            if (window.isFirefoxMobile()) {
+            if (client.isFirefoxAndroid) {
                 swapState('state-fx-android');
                 state = 'Firefox Android: ' + marketState;
+
+            // Firefox for iOS
+            } else if (client.isFirefoxiOS) {
+                swapState('state-fx-ios');
+                state = 'Firefox iOS: ' + marketState;
 
             // Firefox for Desktop
             } else {
 
-                if (fxMasterVersion >= 31) {
+                if (client.FirefoxMajorVersion >= 31) {
 
                     // Set syncCapable so we know not to send tracking info
                     // again later
@@ -82,11 +81,6 @@ if (typeof window.Mozilla === 'undefined') {
                 }
 
             }
-
-        // Firefox for iOS
-        } else if (isFirefoxiOS()) {
-            swapState('state-fx-ios');
-            state = 'Firefox iOS: ' + marketState;
 
         // Not Firefox
         } else {

--- a/media/js/firefox/ios.js
+++ b/media/js/firefox/ios.js
@@ -23,20 +23,25 @@ if (typeof window.Mozilla === 'undefined') {
 
     // initialize state - runs after geolocation has completed
     var initState = function() {
+        var client = Mozilla.Client;
         var state = 'Unknown';
         var syncCapable = false;
-        var fxMasterVersion = window.getFirefoxMasterVersion();
 
-        if (window.isFirefox()) {
+        if (client.isFirefox) {
             // Firefox for Android
-            if (window.isFirefoxMobile()) {
+            if (client.isFirefoxAndroid) {
                 swapState('state-fx-android');
                 state = 'Firefox Android';
+
+            // Firefox for iOS
+            } else if (client.isFirefoxiOS) {
+                swapState('state-fx-ios');
+                state = 'Firefox iOS';
 
             // Firefox for Desktop
             } else {
 
-                if (fxMasterVersion >= 31) {
+                if (client.FirefoxMajorVersion >= 31) {
 
                     // Set syncCapable so we know not to send tracking info
                     // again later
@@ -67,11 +72,6 @@ if (typeof window.Mozilla === 'undefined') {
                 }
 
             }
-
-        // Firefox for iOS
-        } else if (window.isFirefoxiOS()) {
-            swapState('state-fx-ios');
-            state = 'Firefox iOS';
 
         // Not Firefox
         } else {

--- a/media/js/firefox/pocket.js
+++ b/media/js/firefox/pocket.js
@@ -8,6 +8,8 @@
     var $window = $(window);
     var $document = $(document);
     var $html = $(document.documentElement);
+
+    var client = Mozilla.Client;
     var supportsPromises = 'Promise' in window;
 
     function closePocketMenu() {
@@ -50,7 +52,7 @@
         });
     }
 
-    if (supportsPromises && window.isFirefox() && !window.isFirefoxMobile() && window.getFirefoxMasterVersion() >= 38) {
+    if (supportsPromises && client.isFirefoxDesktop && client.FirefoxMajorVersion >= 38) {
         // only bind click event if UITour is working
         Mozilla.UITour.ping(function() {
             $('.try-pocket').on('click.pocket', openPocketMenu);

--- a/media/js/firefox/private-browsing.js
+++ b/media/js/firefox/private-browsing.js
@@ -5,6 +5,8 @@
 ;(function($) {
     'use strict';
 
+    var client = window.Mozilla.Client;
+
     var $html = $('html');
     var $shield = $('#tracking-protection-animation');
     var $tryPBButtons = $('.try-pb-button');
@@ -30,9 +32,9 @@
         });
     }
 
-    if (window.isFirefox() || window.isFirefoxiOS()) {
+    if (client.isFirefox) {
         // iOS
-        if ($html.hasClass('ios')) {
+        if (client.isFirefoxiOS) {
             // all iOS users have private browsing
             $html.addClass('firefox-up-to-date');
 
@@ -41,11 +43,11 @@
         // Android or desktop
         } else {
             // desktop & Android version numbers match
-            if (window.getFirefoxMasterVersion() >= 42)  {
+            if (client.FirefoxMajorVersion >= 42)  {
                 // try private browsing button is available
                 $html.addClass('firefox-up-to-date');
 
-                if ($html.hasClass('android')) {
+                if (client.isFirefoxAndroid) {
                     // update SUMO link
                     $tryPBButtons.attr('href', 'https://support.mozilla.org/kb/private-browsing-firefox-android');
                 } else {

--- a/media/js/firefox/releasenotes.js
+++ b/media/js/firefox/releasenotes.js
@@ -5,6 +5,7 @@
 ;(function($, Mozilla, Waypoint) {
     'use strict';
 
+    var client = Mozilla.Client;
     var $html = $('html');
     var $nav = $('#nav');
 
@@ -20,15 +21,15 @@
         }
     });
 
-    if (window.isFirefox() || window.isFirefoxiOS()) {
+    if (client.isFirefox) {
         // iOS
-        if ($html.hasClass('ios')) {
+        if (client.isFirefoxiOS) {
             $html.addClass('firefox-up-to-date');
 
         // Android or desktop
         } else {
             // desktop & Android version numbers match
-            if (window.getFirefoxMasterVersion() >= 42)  {
+            if (client.FirefoxMajorVersion >= 42)  {
                 $html.addClass('firefox-up-to-date');
             } else {
                 $html.addClass('firefox-old');

--- a/media/js/firefox/releasenotes.js
+++ b/media/js/firefox/releasenotes.js
@@ -28,12 +28,9 @@
 
         // Android or desktop
         } else {
-            // desktop & Android version numbers match
-            if (client.FirefoxMajorVersion >= 42)  {
-                $html.addClass('firefox-up-to-date');
-            } else {
-                $html.addClass('firefox-old');
-            }
+            client.getFirefoxDetails(function(data) {
+                $html.addClass(data.isUpToDate ? 'firefox-up-to-date' : 'firefox-old');
+            });
         }
     } else {
         $html.addClass('non-firefox');

--- a/media/js/firefox/sync.js
+++ b/media/js/firefox/sync.js
@@ -21,7 +21,8 @@
     // Variation #1: Firefox 31+ signed-in to Sync
     // Default (do nothing)
 
-    var fxMasterVersion = window.getFirefoxMasterVersion();
+    var client = window.Mozilla.Client;
+    var fxMasterVersion = client.FirefoxMajorVersion;
     var state = 'Unknown';
     var syncCapable = false;
     var body = $('body');
@@ -32,15 +33,15 @@
     };
 
     // Variations 1-5 are Firefox
-    if (window.isFirefox()) {
+    if (client.isFirefox) {
         // Variation #5: Firefox for Android
-        if (window.isFirefoxMobile()) {
+        if (client.isFirefoxAndroid) {
 
             swapState('state-fx-android');
             state = 'Firefox for Android';
 
         // Variation #1-4: Firefox for Desktop
-        } else {
+        } else if (client.isFirefoxDesktop) {
 
             if (fxMasterVersion >= 31) {
 

--- a/media/js/firefox/whatsnew_38/pocket-uitour.js
+++ b/media/js/firefox/whatsnew_38/pocket-uitour.js
@@ -5,6 +5,8 @@
 ;(function($, Mozilla) {
     'use strict';
 
+    var client = Mozilla.Client;
+
     var $window = $(window);
     var $document = $(document);
     var supportsPromises = 'Promise' in window;
@@ -49,7 +51,7 @@
         });
     }
 
-    if (supportsPromises && window.isFirefox() && !window.isFirefoxMobile() && window.getFirefoxMasterVersion() >= 38) {
+    if (supportsPromises && client.isFirefoxDesktop && client.FirefoxMajorVersion >= 38) {
         // only bind click event if UITour is working
         Mozilla.UITour.ping(function() {
             $('.try-pocket').on('click.pocket', openPocketMenu);

--- a/media/js/firefox/win10-welcome-init.js
+++ b/media/js/firefox/win10-welcome-init.js
@@ -5,8 +5,10 @@
 ;(function(Mozilla) {
     'use strict';
 
+    var client = Mozilla.Client;
+
     // Conditional content for Firefox Desktop 40 and above only.
-    if (window.isFirefox() && !window.isFirefoxMobile() && window.getFirefoxMasterVersion() >= 40) {
+    if (client.isFirefoxDesktop && client.FirefoxMajorVersion >= 40) {
         Mozilla.Win10Welcome.initPage();
     } else {
         // We're not concerned about non-Firefox browsers for this page, but we need to

--- a/media/js/mozorg/home/takeover.js
+++ b/media/js/mozorg/home/takeover.js
@@ -111,7 +111,7 @@ $(function () {
             // only show the takeover modal if this is not Firefox for iOS and the
             // user has not already seen it during this session.
             var takeoverSeen = sessionStorage.getItem('mozorg.takeover.seen');
-            if (!window.isFirefoxiOS() && takeoverSeen !== 'true') {
+            if (!window.Mozilla.Client.isFirefoxiOS && takeoverSeen !== 'true') {
                 initTakeOver();
             }
         } catch (ex) {}

--- a/media/js/plugincheck/check-plugins.js
+++ b/media/js/plugincheck/check-plugins.js
@@ -1,6 +1,8 @@
 $(function() {
     'use strict';
 
+    var client = window.Mozilla.Client;
+
     var outdatedFx = $('.version-message-container');
     var wrapper = $('#wrapper');
     var $loader = $('.plugincheck-loader');
@@ -157,13 +159,13 @@ $(function() {
     }
 
     // show main download button to non Fx traffic
-    if(!isFirefox() && !isLikeFirefox() ) {
+    if(!client.isFirefox && !client.isLikeFirefox) {
         wrapper.addClass('non-fx');
     }
 
     // show for outdated Fx versions
-    if (isFirefox()) {
-        window.Mozilla.Client.getFirefoxDetails(function(data) {
+    if (client.isFirefoxDesktop || client.isFirefoxAndroid) {
+        client.getFirefoxDetails(function(data) {
             if (!data.isUpToDate && !data.isESR) {
                 outdatedFx.show();
             }
@@ -171,7 +173,7 @@ $(function() {
     }
 
     // only execute the plugincheck code if this is Firefox
-    if (isFirefox() || isLikeFirefox()) {
+    if (client.isFirefoxDesktop || client.isFirefoxAndroid || client.isLikeFirefox) {
 
         $loader.removeClass('hidden');
 

--- a/media/js/teach/smarton.js
+++ b/media/js/teach/smarton.js
@@ -8,7 +8,7 @@
     var $document = $(document);
     var $body = $('body');
 
-    if (window.isFirefox()) {
+    if (window.Mozilla.Client.isFirefox) {
         $body.addClass('is-firefox');
     } else {
         $body.addClass('not-firefox');

--- a/tests/unit/spec/base/global.js
+++ b/tests/unit/spec/base/global.js
@@ -116,7 +116,7 @@ describe('global.js', function() {
         });
 
         it('should change the button text when using old fx', function () {
-            isFirefoxStub = sinon.stub(window, 'isFirefox').returns(true);
+            isFirefoxStub = sinon.stub(window.Mozilla.Client, '_isFirefox').returns(true);
             spyOn(window.Mozilla.Client, 'getFirefoxDetails').and.callFake(function(callback) {
                 callback({ version: '40.0', channel: 'release', isUpToDate: false, isESR: false });
             });
@@ -128,7 +128,7 @@ describe('global.js', function() {
         });
 
         it('should not change the button text when not using fx', function () {
-            isFirefoxStub = sinon.stub(window, 'isFirefox').returns(false);
+            isFirefoxStub = sinon.stub(window.Mozilla.Client, '_isFirefox').returns(false);
 
             update_download_text_for_old_fx();
 
@@ -137,7 +137,7 @@ describe('global.js', function() {
         });
 
         it('should not change the button text when using up to date fx', function () {
-            isFirefoxStub = sinon.stub(window, 'isFirefox').returns(true);
+            isFirefoxStub = sinon.stub(window.Mozilla.Client, '_isFirefox').returns(true);
             spyOn(window.Mozilla.Client, 'getFirefoxDetails').and.callFake(function(callback) {
                 callback({ version: '41.0', channel: 'release', isUpToDate: true, isESR: false });
             });
@@ -174,216 +174,4 @@ describe('global.js', function() {
 
     });
 
-    describe('getFirefoxMasterVersion', function () {
-
-        it('should return the firefox master version number', function () {
-            var result;
-            // Pretend to be Firefox 23
-            var ua = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.8; rv:23.0) Gecko/20100101 Firefox/23.0';
-            result = getFirefoxMasterVersion(ua);
-            expect(result).toEqual(23);
-        });
-
-        it('should return 0 for non Firefox browsers', function () {
-            var result;
-            var ua = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/28.0.1500.71 Safari/537.36';
-            result = getFirefoxMasterVersion(ua);
-            expect(result).toEqual(0);
-        });
-    });
-
-    describe('isFirefox', function() {
-        it('should consider Firefox to be Firefox', function() {
-            var ua = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.8; rv:23.0) Gecko/20100101 Firefox/23.0';
-            var result = isFirefox(ua);
-            expect(result).toBeTruthy();
-        });
-
-        it('should not consider Camino to be Firefox', function() {
-            var ua = 'Mozilla/5.0 (Macintosh; U; PPC Mac OS X 10.4; en; rv:1.9.2.24) Gecko/20111114 Camino/2.1 (like Firefox/3.6.24)';
-            var result = isFirefox(ua);
-            expect(result).not.toBeTruthy();
-        });
-
-        it('should not consider Chrome to be Firefox', function() {
-            var ua = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/29.0.1547.57 Safari/537.36';
-            var result = isFirefox(ua);
-            expect(result).not.toBeTruthy();
-        });
-
-        it('should not consider Safari to be Firefox', function() {
-            var ua = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_6_8) AppleWebKit/537.13+ (KHTML, like Gecko) Version/5.1.7 Safari/534.57.2';
-            var result = isFirefox(ua);
-            expect(result).not.toBeTruthy();
-        });
-
-        it('should not consider IE to be Firefox', function() {
-            var ua = 'Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 5.1; Trident/4.0; .NET CLR 2.0.50727; .NET CLR 3.0.04506.648; .NET CLR 3.5.21022; .NET CLR 3.0.4506.2152; .NET CLR 3.5.30729)';
-            var result = isFirefox(ua);
-            expect(result).not.toBeTruthy();
-        });
-
-        it('should not consider SeaMonkey to be Firefox', function() {
-            var ua = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.9; rv:25.0) Gecko/20100101 Firefox/25.0 SeaMonkey/2.22.1';
-            var result = isFirefox(ua);
-            expect(result).not.toBeTruthy();
-        });
-
-        it('should not consider Iceweasel to be Firefox', function() {
-            var ua = 'Mozilla/5.0 (X11; Linux x86_64; rv:17.0) Gecko/20121202 Firefox/17.0 Iceweasel/17.0.1';
-            var result = isFirefox(ua);
-            expect(result).not.toBeTruthy();
-        });
-    });
-
-    describe('isFirefoxMobile', function () {
-
-        it('should return false for Firefox on Desktop', function() {
-            expect(isFirefoxMobile('Mozilla/5.0 (Windows NT x.y; rv:10.0) Gecko/20100101 Firefox/10.0')).not.toBeTruthy();
-            expect(isFirefoxMobile('Mozilla/5.0 (Macintosh; Intel Mac OS X x.y; rv:10.0) Gecko/20100101 Firefox/10.0')).not.toBeTruthy();
-            expect(isFirefoxMobile('Mozilla/5.0 (X11; Linux i686; rv:10.0) Gecko/20100101 Firefox/10.0')).not.toBeTruthy();
-        });
-
-        it('should return true for Firefox Android on Phone', function() {
-            var ua = 'Mozilla/5.0 (Android; Mobile; rv:26.0) Gecko/26.0 Firefox/26.0';
-            var result = isFirefoxMobile(ua);
-            expect(result).toBeTruthy();
-        });
-
-        it('should return true for Firefox Android on Tablet', function() {
-            var ua = 'Mozilla/5.0 (Android; Tablet; rv:26.0) Gecko/26.0 Firefox/26.0';
-            var result = isFirefoxMobile(ua);
-            expect(result).toBeTruthy();
-        });
-
-        it('should return true for Firefox OS on Phone', function() {
-            var ua = 'Mozilla/5.0 (Mobile; rv:26.0) Gecko/26.0 Firefox/26.0';
-            var result = isFirefoxMobile(ua);
-            expect(result).toBeTruthy();
-        });
-
-        it('should return true for Firefox OS on Tablet', function() {
-            var ua = 'Mozilla/5.0 (Tablet; rv:26.0) Gecko/26.0 Firefox/26.0';
-            var result = isFirefoxMobile(ua);
-            expect(result).toBeTruthy();
-        });
-
-        it('should return true for Firefox for Maemo (Nokia N900)', function() {
-            var ua = 'Mozilla/5.0 (Maemo; Linux armv7l; rv:10.0.1) Gecko/20100101 Firefox/10.0.1 Fennec/10.0.1';
-            var result = isFirefoxMobile(ua);
-            expect(result).toBeTruthy();
-        });
-
-    });
-
-    describe('isFirefoxiOS', function () {
-
-        it('should return false for Firefox on Desktop', function() {
-            expect(isFirefoxiOS('Mozilla/5.0 (Windows NT x.y; rv:10.0) Gecko/20100101 Firefox/10.0')).not.toBeTruthy();
-            expect(isFirefoxiOS('Mozilla/5.0 (Macintosh; Intel Mac OS X x.y; rv:10.0) Gecko/20100101 Firefox/10.0')).not.toBeTruthy();
-            expect(isFirefoxiOS('Mozilla/5.0 (X11; Linux i686; rv:10.0) Gecko/20100101 Firefox/10.0')).not.toBeTruthy();
-        });
-
-        it('should return false for Firefox Android', function() {
-            expect(isFirefoxiOS('Mozilla/5.0 (Android; Mobile; rv:26.0) Gecko/26.0 Firefox/26.0')).not.toBeTruthy();
-        });
-
-        it('should return true for Firefox on iPhone', function() {
-            var ua = 'Mozilla/5.0 (iPhone; CPU iPhone OS 8_3 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) FxiOS/1.1 Mobile/12F69 Safari/600.1.4';
-            var result = isFirefoxiOS(ua);
-            expect(result).toBeTruthy();
-        });
-
-        it('should return true for Firefox on iPad', function() {
-            var ua = 'Mozilla/5.0 (iPad; CPU iPhone OS 8_3 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) FxiOS/1.0 Mobile/12F69 Safari/600.1.4';
-            var result = isFirefoxiOS(ua);
-            expect(result).toBeTruthy();
-        });
-    });
-
-    describe('isFirefoxUpToDate', function () {
-
-        it('should consider up to date if latest version is equal to user version', function() {
-            var result;
-            /* Use a stub to return a pre-programmed value
-             * from getFirefoxMasterVersion */
-            getFirefoxMasterVersion = sinon.stub().returns(21);
-            result = isFirefoxUpToDate('21.0');
-            expect(getFirefoxMasterVersion.called).toBeTruthy();
-            expect(result).toBeTruthy();
-        });
-
-        it('should consider up to date if latest version is less than user version', function() {
-            var result;
-            getFirefoxMasterVersion = sinon.stub().returns(22);
-            result = isFirefoxUpToDate('21.0');
-            expect(getFirefoxMasterVersion.called).toBeTruthy();
-            expect(result).toBeTruthy();
-        });
-
-        it('should not consider up to date if latest version greater than user version', function() {
-            var result;
-            getFirefoxMasterVersion = sinon.stub().returns(20);
-            result = isFirefoxUpToDate('21.0');
-            expect(getFirefoxMasterVersion.called).toBeTruthy();
-            expect(result).not.toBeTruthy();
-        });
-    });
-
-    describe('isLikeFirefox', function() {
-
-        it('should consider SeaMonkey to be like Firefox', function() {
-            var ua = 'Mozilla/5.0 (Windows NT 6.1; WOW64; rv:40.0) Gecko/20100101 Firefox/40.0 SeaMonkey/2.37a1';
-            var result = isLikeFirefox(ua);
-            expect(result).toBeTruthy();
-        });
-
-        it('should consider IceWeasel to be like Firefox', function() {
-            var ua = 'Mozilla/5.0 (X11; Linux x86_64; rv:17.0) Gecko/20121202 Firefox/17.0 Iceweasel/17.0.1';
-            var result = isLikeFirefox(ua);
-            expect(result).toBeTruthy();
-        });
-
-        it('should consider IceCat to be like Firefox', function() {
-            var ua = 'Mozilla/5.0 (X11; Linux x86_64; rv:17.0) Gecko/20121201 icecat/17.0.1';
-            var result = isLikeFirefox(ua);
-            expect(result).toBeTruthy();
-        });
-
-        it('should consider Camino to be like Firefox', function() {
-            var ua = 'Mozilla/5.0 (Macintosh; U; PPC Mac OS X 10.4; en; rv:1.9.2.24) Gecko/20111114 Camino/2.1 (like Firefox/3.6.24)';
-            var result = isLikeFirefox(ua);
-            expect(result).toBeTruthy();
-        });
-
-        it('should consider Camino like userAgent to be like Firefox', function() {
-            var ua = 'Mozilla/5.0 (Macintosh; U; PPC Mac OS X 10.4; en; rv:1.9.2.24) Gecko/20111114 (like Firefox/3.6.24)';
-            var result = isLikeFirefox(ua);
-            expect(result).toBeTruthy();
-        });
-
-        it('should not consider Firefox to be "like" Firefox', function() {
-            var ua = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.8; rv:23.0) Gecko/20100101 Firefox/23.0';
-            var result = isLikeFirefox(ua);
-            expect(result).not.toBeTruthy();
-        });
-
-        it('should not consider Chrome to be like Firefox', function() {
-            var ua = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/29.0.1547.57 Safari/537.36';
-            var result = isLikeFirefox(ua);
-            expect(result).not.toBeTruthy();
-        });
-
-        it('should not consider Safari to be like Firefox', function() {
-            var ua = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_6_8) AppleWebKit/537.13+ (KHTML, like Gecko) Version/5.1.7 Safari/534.57.2';
-            var result = isLikeFirefox(ua);
-            expect(result).not.toBeTruthy();
-        });
-
-        it('should not consider IE to be like Firefox', function() {
-            var ua = 'Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 5.1; Trident/4.0; .NET CLR 2.0.50727; .NET CLR 3.0.04506.648; .NET CLR 3.5.21022; .NET CLR 3.0.4506.2152; .NET CLR 3.5.30729)';
-            var result = isLikeFirefox(ua);
-            expect(result).not.toBeTruthy();
-        });
-    });
 });

--- a/tests/unit/spec/base/mozilla-client.js
+++ b/tests/unit/spec/base/mozilla-client.js
@@ -9,14 +9,411 @@ describe('mozilla-client.js', function() {
 
     'use strict';
 
-    describe('_getFirefoxVersion', function () {
+    // User-agent strings for the most of the following tests
+    var uas = {
+        // Firefox family
+        'firefox': {
+            'windows': 'Mozilla/5.0 (Windows NT x.y; rv:10.0) Gecko/20100101 Firefox/10.0',
+            'osx': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.8; rv:23.0) Gecko/20100101 Firefox/23.0',
+            'linux': 'Mozilla/5.0 (X11; Linux i686; rv:10.0) Gecko/20100101 Firefox/10.0',
+            'maemo': 'Mozilla/5.0 (Maemo; Linux armv7l; rv:10.0.1) Gecko/20100101 Firefox/10.0.1 Fennec/10.0.1',
+            'android': {
+                'mobile': 'Mozilla/5.0 (Android; Mobile; rv:26.0) Gecko/26.0 Firefox/26.0',
+                'tablet': 'Mozilla/5.0 (Android; Tablet; rv:26.0) Gecko/26.0 Firefox/26.0',
+            },
+            'ios': {
+                'mobile': 'Mozilla/5.0 (iPhone; CPU iPhone OS 8_3 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) FxiOS/1.1 Mobile/12F69 Safari/600.1.4',
+                'tablet': 'Mozilla/5.0 (iPad; CPU iPhone OS 8_3 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) FxiOS/1.0 Mobile/12F69 Safari/600.1.4',
+            },
+            'fxos': {
+                'mobile': 'Mozilla/5.0 (Mobile; rv:26.0) Gecko/26.0 Firefox/26.0',
+                'tablet': 'Mozilla/5.0 (Tablet; rv:26.0) Gecko/26.0 Firefox/26.0',
+            },
+        },
+        // Other Gecko browsers
+        'camino': 'Mozilla/5.0 (Macintosh; U; PPC Mac OS X 10.4; en; rv:1.9.2.24) Gecko/20111114 Camino/2.1 (like Firefox/3.6.24)',
+        'caminolikefx': 'Mozilla/5.0 (Macintosh; U; PPC Mac OS X 10.4; en; rv:1.9.2.24) Gecko/20111114 (like Firefox/3.6.24)',
+        'seamonkey': 'Mozilla/5.0 (Windows NT 6.1; WOW64; rv:40.0) Gecko/20100101 Firefox/40.0 SeaMonkey/2.37a1',
+        'icecat': 'Mozilla/5.0 (X11; Linux x86_64; rv:17.0) Gecko/20121201 icecat/17.0.1',
+        'iceweasel': 'Mozilla/5.0 (X11; Linux x86_64; rv:17.0) Gecko/20121202 Firefox/17.0 Iceweasel/17.0.1',
+        // Non-Gecko browsers
+        'chrome': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/29.0.1547.57 Safari/537.36',
+        'safari': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_6_8) AppleWebKit/537.13+ (KHTML, like Gecko) Version/5.1.7 Safari/534.57.2',
+        'ie': 'Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 5.1; Trident/4.0; .NET CLR 2.0.50727; .NET CLR 3.0.04506.648; .NET CLR 3.5.21022; .NET CLR 3.0.4506.2152; .NET CLR 3.5.30729)',
+    };
 
-        it('should return the firefox version number as a string', function () {
-            expect(window.Mozilla.Client._getFirefoxVersion('Mozilla/5.0 (Macintosh; Intel Mac OS X 10.8; rv:23.0) Gecko/20100101 Firefox/23.0')).toEqual('23.0');
+    describe('_isFirefox', function() {
+
+        var test = function(ua) {
+            return expect(window.Mozilla.Client._isFirefox(ua));
+        };
+
+        it('should return true for Firefox on desktop', function() {
+            test(uas.firefox.windows).toBeTruthy();
+            test(uas.firefox.osx).toBeTruthy();
+            test(uas.firefox.linux).toBeTruthy();
         });
 
-        it('should return 0 for non Firefox browsers', function () {
-            expect(window.Mozilla.Client._getFirefoxVersion('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/28.0.1500.71 Safari/537.36')).toEqual('0');
+        it('should return true for Firefox on Maemo', function() {
+            test(uas.firefox.maemo).toBeTruthy();
+        });
+
+        it('should return true for Firefox on Android', function() {
+            test(uas.firefox.android.mobile).toBeTruthy();
+            test(uas.firefox.android.tablet).toBeTruthy();
+        });
+
+        it('should return true for Firefox on iOS', function() {
+            test(uas.firefox.ios.mobile).toBeTruthy();
+            test(uas.firefox.ios.tablet).toBeTruthy();
+        });
+
+        it('should return true for Firefox OS', function() {
+            test(uas.firefox.fxos.mobile).toBeTruthy();
+            test(uas.firefox.fxos.tablet).toBeTruthy();
+        });
+
+        it('should return false for other Gecko browsers', function() {
+            test(uas.camino).toBeFalsy();
+            test(uas.caminolikefx).toBeFalsy();
+            test(uas.seamonkey).toBeFalsy();
+            test(uas.icecat).toBeFalsy();
+            test(uas.iceweasel).toBeFalsy();
+        });
+
+        it('should return false for non-Gecko browsers', function() {
+            test(uas.chrome).toBeFalsy();
+            test(uas.safari).toBeFalsy();
+            test(uas.ie).toBeFalsy();
+        });
+
+    });
+
+    describe('_isFirefoxDesktop', function () {
+
+        var test = function(ua) {
+            return expect(window.Mozilla.Client._isFirefoxDesktop(ua));
+        };
+
+        it('should return true for Firefox on desktop', function() {
+            test(uas.firefox.windows).toBeTruthy();
+            test(uas.firefox.osx).toBeTruthy();
+            test(uas.firefox.linux).toBeTruthy();
+        });
+
+        it('should return false for Firefox on Maemo', function() {
+            test(uas.firefox.maemo).toBeFalsy();
+        });
+
+        it('should return false for Firefox on Android', function() {
+            test(uas.firefox.android.mobile).toBeFalsy();
+            test(uas.firefox.android.tablet).toBeFalsy();
+        });
+
+        it('should return false for Firefox on iOS', function() {
+            test(uas.firefox.ios.mobile).toBeFalsy();
+            test(uas.firefox.ios.tablet).toBeFalsy();
+        });
+
+        it('should return false for Firefox OS', function() {
+            test(uas.firefox.fxos.mobile).toBeFalsy();
+            test(uas.firefox.fxos.tablet).toBeFalsy();
+        });
+
+        it('should return false for other Gecko browsers', function() {
+            test(uas.camino).toBeFalsy();
+            test(uas.caminolikefx).toBeFalsy();
+            test(uas.seamonkey).toBeFalsy();
+            test(uas.icecat).toBeFalsy();
+            test(uas.iceweasel).toBeFalsy();
+        });
+
+        it('should return false for non-Gecko browsers', function() {
+            test(uas.chrome).toBeFalsy();
+            test(uas.safari).toBeFalsy();
+            test(uas.ie).toBeFalsy();
+        });
+
+    });
+
+    describe('_isFirefoxAndroid', function () {
+
+        var test = function(ua) {
+            return expect(window.Mozilla.Client._isFirefoxAndroid(ua));
+        };
+
+        it('should return false for Firefox on desktop', function() {
+            test(uas.firefox.windows).toBeFalsy();
+            test(uas.firefox.osx).toBeFalsy();
+            test(uas.firefox.linux).toBeFalsy();
+        });
+
+        it('should return false for Firefox on Maemo', function() {
+            test(uas.firefox.maemo).toBeFalsy();
+        });
+
+        it('should return true for Firefox on Android', function() {
+            test(uas.firefox.android.mobile).toBeTruthy();
+            test(uas.firefox.android.tablet).toBeTruthy();
+        });
+
+        it('should return false for Firefox on iOS', function() {
+            test(uas.firefox.ios.mobile).toBeFalsy();
+            test(uas.firefox.ios.tablet).toBeFalsy();
+        });
+
+        it('should return false for Firefox OS', function() {
+            test(uas.firefox.fxos.mobile).toBeFalsy();
+            test(uas.firefox.fxos.tablet).toBeFalsy();
+        });
+
+        it('should return false for other Gecko browsers', function() {
+            test(uas.camino).toBeFalsy();
+            test(uas.caminolikefx).toBeFalsy();
+            test(uas.seamonkey).toBeFalsy();
+            test(uas.icecat).toBeFalsy();
+            test(uas.iceweasel).toBeFalsy();
+        });
+
+        it('should return false for non-Gecko browsers', function() {
+            test(uas.chrome).toBeFalsy();
+            test(uas.safari).toBeFalsy();
+            test(uas.ie).toBeFalsy();
+        });
+
+    });
+
+    describe('_isFirefoxiOS', function () {
+
+        var test = function(ua) {
+            return expect(window.Mozilla.Client._isFirefoxiOS(ua));
+        };
+
+        it('should return false for Firefox on desktop', function() {
+            test(uas.firefox.windows).toBeFalsy();
+            test(uas.firefox.osx).toBeFalsy();
+            test(uas.firefox.linux).toBeFalsy();
+        });
+
+        it('should return false for Firefox on Maemo', function() {
+            test(uas.firefox.maemo).toBeFalsy();
+        });
+
+        it('should return false for Firefox on Android', function() {
+            test(uas.firefox.android.mobile).toBeFalsy();
+            test(uas.firefox.android.tablet).toBeFalsy();
+        });
+
+        it('should return true for Firefox on iOS', function() {
+            test(uas.firefox.ios.mobile).toBeTruthy();
+            test(uas.firefox.ios.tablet).toBeTruthy();
+        });
+
+        it('should return false for Firefox OS', function() {
+            test(uas.firefox.fxos.mobile).toBeFalsy();
+            test(uas.firefox.fxos.tablet).toBeFalsy();
+        });
+
+        it('should return false for other Gecko browsers', function() {
+            test(uas.camino).toBeFalsy();
+            test(uas.caminolikefx).toBeFalsy();
+            test(uas.seamonkey).toBeFalsy();
+            test(uas.icecat).toBeFalsy();
+            test(uas.iceweasel).toBeFalsy();
+        });
+
+        it('should return false for non-Gecko browsers', function() {
+            test(uas.chrome).toBeFalsy();
+            test(uas.safari).toBeFalsy();
+            test(uas.ie).toBeFalsy();
+        });
+
+    });
+
+    describe('_isFirefoxFxOS', function () {
+
+        var test = function(ua, pf) {
+            return expect(window.Mozilla.Client._isFirefoxFxOS(ua, pf));
+        };
+
+        it('should return false for Firefox on desktop', function() {
+            test(uas.firefox.windows, 'Win32').toBeFalsy();
+            test(uas.firefox.osx, 'MacIntel').toBeFalsy();
+            test(uas.firefox.linux, 'Linux i686').toBeFalsy();
+        });
+
+        it('should return false for Firefox on Maemo', function() {
+            test(uas.firefox.maemo, 'Linux armv6l').toBeFalsy();
+        });
+
+        it('should return false for Firefox on Android', function() {
+            test(uas.firefox.android.mobile, 'Android').toBeFalsy();
+            test(uas.firefox.android.tablet, 'Android').toBeFalsy();
+        });
+
+        it('should return false for Firefox on iOS', function() {
+            test(uas.firefox.ios.mobile, 'iPhone').toBeFalsy();
+            test(uas.firefox.ios.tablet, 'iPod').toBeFalsy();
+        });
+
+        it('should return false for Firefox OS', function() {
+            test(uas.firefox.fxos.mobile, '').toBeTruthy();
+            test(uas.firefox.fxos.tablet, '').toBeTruthy();
+        });
+
+        it('should return false for other Gecko browsers', function() {
+            test(uas.camino, 'MacIntel').toBeFalsy();
+            test(uas.caminolikefx, 'MacIntel').toBeFalsy();
+            test(uas.seamonkey, 'Win32').toBeFalsy();
+            test(uas.icecat, 'Linux i686').toBeFalsy();
+            test(uas.iceweasel, 'Linux i686').toBeFalsy();
+        });
+
+        it('should return false for non-Gecko browsers', function() {
+            test(uas.chrome, 'Win32').toBeFalsy();
+            test(uas.safari, 'MacIntel').toBeFalsy();
+            test(uas.ie, 'Win32').toBeFalsy();
+        });
+
+    });
+
+    describe('_isLikeFirefox', function() {
+
+        var test = function(ua) {
+            return expect(window.Mozilla.Client._isLikeFirefox(ua));
+        };
+
+        it('should return false for Firefox on desktop', function() {
+            test(uas.firefox.windows).toBeFalsy();
+            test(uas.firefox.osx).toBeFalsy();
+            test(uas.firefox.linux).toBeFalsy();
+        });
+
+        it('should return false for Firefox on Maemo', function() {
+            test(uas.firefox.maemo).toBeFalsy();
+        });
+
+        it('should return false for Firefox on Android', function() {
+            test(uas.firefox.android.mobile).toBeFalsy();
+            test(uas.firefox.android.tablet).toBeFalsy();
+        });
+
+        it('should return false for Firefox on iOS', function() {
+            test(uas.firefox.ios.mobile).toBeFalsy();
+            test(uas.firefox.ios.tablet).toBeFalsy();
+        });
+
+        it('should return false for Firefox OS', function() {
+            test(uas.firefox.fxos.mobile).toBeFalsy();
+            test(uas.firefox.fxos.tablet).toBeFalsy();
+        });
+
+        it('should return true for other Gecko browsers', function() {
+            test(uas.camino).toBeTruthy();
+            test(uas.caminolikefx).toBeTruthy();
+            test(uas.seamonkey).toBeTruthy();
+            test(uas.icecat).toBeTruthy();
+            test(uas.iceweasel).toBeTruthy();
+        });
+
+        it('should return false for non-Gecko browsers', function() {
+            test(uas.chrome).toBeFalsy();
+            test(uas.safari).toBeFalsy();
+            test(uas.ie).toBeFalsy();
+        });
+
+    });
+
+    describe('_getFirefoxVersion', function () {
+
+        var test = function(ua) {
+            return expect(window.Mozilla.Client._getFirefoxVersion(ua));
+        };
+
+        it('should return a version number for Firefox on desktop', function() {
+            test(uas.firefox.windows).toEqual('10.0');
+            test(uas.firefox.osx).toEqual('23.0');
+            test(uas.firefox.linux).toEqual('10.0');
+        });
+
+        it('should return a version number for Firefox on Maemo', function() {
+            test(uas.firefox.maemo).toEqual('10.0.1');
+        });
+
+        it('should return a version number for Firefox on Android', function() {
+            test(uas.firefox.android.mobile).toEqual('26.0');
+            test(uas.firefox.android.tablet).toEqual('26.0');
+        });
+
+        it('should return 0 for Firefox on iOS', function() {
+            test(uas.firefox.ios.mobile).toEqual('0');
+            test(uas.firefox.ios.tablet).toEqual('0');
+        });
+
+        it('should return a version number for Firefox OS', function() {
+            test(uas.firefox.fxos.mobile).toEqual('26.0');
+            test(uas.firefox.fxos.tablet).toEqual('26.0');
+        });
+
+        it('should return 0 for other Gecko browsers', function() {
+            test(uas.camino).toEqual('0');
+            test(uas.caminolikefx).toEqual('0');
+            test(uas.seamonkey).toEqual('0');
+            test(uas.icecat).toEqual('0');
+            test(uas.iceweasel).toEqual('0');
+        });
+
+        it('should return 0 for non-Gecko browsers', function() {
+            test(uas.chrome).toEqual('0');
+            test(uas.safari).toEqual('0');
+            test(uas.ie).toEqual('0');
+        });
+
+    });
+
+    describe('_getFirefoxMajorVersion', function () {
+
+        var test = function(ua) {
+            return expect(window.Mozilla.Client._getFirefoxMajorVersion(ua));
+        };
+
+        it('should return a version number for Firefox on desktop', function() {
+            test(uas.firefox.windows).toEqual(10);
+            test(uas.firefox.osx).toEqual(23);
+            test(uas.firefox.linux).toEqual(10);
+        });
+
+        it('should return a version number for Firefox on Maemo', function() {
+            test(uas.firefox.maemo).toEqual(10);
+        });
+
+        it('should return a version number for Firefox on Android', function() {
+            test(uas.firefox.android.mobile).toEqual(26);
+            test(uas.firefox.android.tablet).toEqual(26);
+        });
+
+        it('should return 0 for Firefox on iOS', function() {
+            test(uas.firefox.ios.mobile).toEqual(0);
+            test(uas.firefox.ios.tablet).toEqual(0);
+        });
+
+        it('should return a version number for Firefox OS', function() {
+            test(uas.firefox.fxos.mobile).toEqual(26);
+            test(uas.firefox.fxos.tablet).toEqual(26);
+        });
+
+        it('should return 0 for other Gecko browsers', function() {
+            test(uas.camino).toEqual(0);
+            test(uas.caminolikefx).toEqual(0);
+            test(uas.seamonkey).toEqual(0);
+            test(uas.icecat).toEqual(0);
+            test(uas.iceweasel).toEqual(0);
+        });
+
+        it('should return 0 for non-Gecko browsers', function() {
+            test(uas.chrome).toEqual(0);
+            test(uas.safari).toEqual(0);
+            test(uas.ie).toEqual(0);
         });
 
     });
@@ -24,6 +421,10 @@ describe('mozilla-client.js', function() {
     describe('_isFirefoxUpToDate', function () {
 
         var h = document.documentElement;
+
+        var test = function(strict, isESR, userVer) {
+            return expect(window.Mozilla.Client._isFirefoxUpToDate(strict, isESR, userVer));
+        };
 
         beforeEach(function () {
             h.setAttribute('data-latest-firefox', '46.0.2');
@@ -36,37 +437,37 @@ describe('mozilla-client.js', function() {
         });
 
         it('should consider up to date if user version is equal to latest version', function() {
-            expect(window.Mozilla.Client._isFirefoxUpToDate(true, false, '46.0.2')).toBeTruthy();
-            expect(window.Mozilla.Client._isFirefoxUpToDate(true, true, '38.8.0')).toBeTruthy();
-            expect(window.Mozilla.Client._isFirefoxUpToDate(true, true, '45.1.0')).toBeTruthy();
+            test(true, false, '46.0.2').toBeTruthy();
+            test(true, true, '38.8.0').toBeTruthy();
+            test(true, true, '45.1.0').toBeTruthy();
         });
 
         it('should consider up to date if user version is greater than latest version', function() {
-            expect(window.Mozilla.Client._isFirefoxUpToDate(true, false, '46.0.3')).toBeTruthy();
-            expect(window.Mozilla.Client._isFirefoxUpToDate(true, false, '47.0')).toBeTruthy();
-            expect(window.Mozilla.Client._isFirefoxUpToDate(true, true, '38.9.0')).toBeTruthy();
-            expect(window.Mozilla.Client._isFirefoxUpToDate(true, true, '45.2.0')).toBeTruthy();
+            test(true, false, '46.0.3').toBeTruthy();
+            test(true, false, '47.0').toBeTruthy();
+            test(true, true, '38.9.0').toBeTruthy();
+            test(true, true, '45.2.0').toBeTruthy();
         });
 
         it('should consider up to date if user version is slightly less than latest version but strict option is false', function() {
-            expect(window.Mozilla.Client._isFirefoxUpToDate(false, false, '46.0.1')).toBeTruthy();
-            expect(window.Mozilla.Client._isFirefoxUpToDate(false, false, '46.0')).toBeTruthy();
-            expect(window.Mozilla.Client._isFirefoxUpToDate(false, true, '38.7.0')).toBeTruthy();
-            expect(window.Mozilla.Client._isFirefoxUpToDate(false, true, '45.0')).toBeTruthy();
+            test(false, false, '46.0.1').toBeTruthy();
+            test(false, false, '46.0').toBeTruthy();
+            test(false, true, '38.7.0').toBeTruthy();
+            test(false, true, '45.0').toBeTruthy();
         });
 
         it('should consider outdated if user version is slightly less than latest version and strict option is true', function() {
-            expect(window.Mozilla.Client._isFirefoxUpToDate(true, false, '46.0.1')).toBeFalsy();
-            expect(window.Mozilla.Client._isFirefoxUpToDate(true, false, '45.0')).toBeFalsy();
-            expect(window.Mozilla.Client._isFirefoxUpToDate(true, false, '38.7.0')).toBeFalsy();
-            expect(window.Mozilla.Client._isFirefoxUpToDate(true, false, '45.0')).toBeFalsy();
+            test(true, false, '46.0.1').toBeFalsy();
+            test(true, false, '45.0').toBeFalsy();
+            test(true, false, '38.7.0').toBeFalsy();
+            test(true, false, '45.0').toBeFalsy();
         });
 
         it('should consider outdated if user version is much less than latest version, regardless of strict option', function() {
-            expect(window.Mozilla.Client._isFirefoxUpToDate(true, false, '40.0.2')).toBeFalsy();
-            expect(window.Mozilla.Client._isFirefoxUpToDate(false, false, '40.0.2')).toBeFalsy();
-            expect(window.Mozilla.Client._isFirefoxUpToDate(true, true, '31.7.0')).toBeFalsy();
-            expect(window.Mozilla.Client._isFirefoxUpToDate(false, true, '31.7.0')).toBeFalsy();
+            test(true, false, '40.0.2').toBeFalsy();
+            test(false, false, '40.0.2').toBeFalsy();
+            test(true, true, '31.7.0').toBeFalsy();
+            test(false, true, '31.7.0').toBeFalsy();
         });
 
     });


### PR DESCRIPTION
Move the browser detecting functions to the new Mozilla Client module and offer each static properties for faster access. This PR also removes GA events added in #3451.