### PR TITLE
[fix bug 1228341] - Fix protocol relative links on annual report pages

### DIFF
--- a/bedrock/foundation/templates/foundation/annualreport/2009/a-competitive-world.html
+++ b/bedrock/foundation/templates/foundation/annualreport/2009/a-competitive-world.html
@@ -103,6 +103,6 @@
     {{ video('Firefox_global_final.mp4',
             'Firefox_global_final.webm',
             'Firefox_global_final.theora.ogv',
-            prefix='//videos.cdn.mozilla.net/serv/mozillaorg/') }}
+            prefix='https://videos.cdn.mozilla.net/serv/mozillaorg/') }}
 
 {% endblock %}

--- a/bedrock/foundation/templates/foundation/annualreport/2009/broadening-our-scope.html
+++ b/bedrock/foundation/templates/foundation/annualreport/2009/broadening-our-scope.html
@@ -30,8 +30,8 @@
 
       <p>
         {% trans
-          maemo="//blog.mozilla.org/blog/2010/01/29/firefox-for-maemo-now-available/",
-          android="//blog.mozilla.org/blog/2010/11/04/firefox-4-beta-for-mobile-is-now-faster-and-sleeker/"
+          maemo="https://blog.mozilla.org/blog/2010/01/29/firefox-for-maemo-now-available/",
+          android="https://blog.mozilla.org/blog/2010/11/04/firefox-4-beta-for-mobile-is-now-faster-and-sleeker/"
         %}
           Mobile is a critical and growing piece of Internet life. It's important
           to provide people with products that embody Mozilla values of openness,
@@ -52,8 +52,8 @@
 
       <p>
         {% trans
-           home="//blog.mozilla.org/blog/2010/07/15/get-firefox-home-on-your-iphone/",
-           nytimes="//www.nytimes.com/2010/11/11/technology/personaltech/11smart.html"
+           home="https://blog.mozilla.org/blog/2010/07/15/get-firefox-home-on-your-iphone/",
+           nytimes="http://www.nytimes.com/2010/11/11/technology/personaltech/11smart.html"
           %}
           We also created "Firefox Home" -- an app for the iphone that brings a
           range of useful Firefox information and features to iphone users.
@@ -70,18 +70,18 @@
       <figure class="figure">
         <div class="mozilla-video-control">
           <video width="640" height="360" controls="controls" preload="metadata">
-            <source src="//videos.cdn.mozilla.net/serv/mobile/meetFFXmobile2-640x360.webm" type="video/webm"/>
-            <source src="//videos.cdn.mozilla.net/serv/mobile/meetFFXmobile2-640x360.theora.ogv" type="video/ogg"/>
-            <source src="//videos.cdn.mozilla.net/serv/mobile/meetFFXmobile2-640x360.mp4" type="video/mp4"/>
+            <source src="https://videos.cdn.mozilla.net/serv/mobile/meetFFXmobile2-640x360.webm" type="video/webm"/>
+            <source src="https://videos.cdn.mozilla.net/serv/mobile/meetFFXmobile2-640x360.theora.ogv" type="video/ogg"/>
+            <source src="https://videos.cdn.mozilla.net/serv/mobile/meetFFXmobile2-640x360.mp4" type="video/mp4"/>
           </video>
         </div>
       </figure>
       <div class="video-description">
         <p class="download">{{ _('Download this video:') }}</p>
         <ul class="download">
-          <li><a href="//videos.cdn.mozilla.net/serv/mobile/meetFFXmobile2-640x360.webm">{{ _('WebM format') }}</a></li>
-          <li><a href="//videos.cdn.mozilla.net/serv/mobile/meetFFXmobile2-640x360.theora.ogv">{{ _('Ogg Theora format') }}</a></li>
-          <li><a href="//videos.cdn.mozilla.net/serv/mobile/meetFFXmobile2-640x360.mp4">{{ _('MPEG-4 format') }}</a></li>
+          <li><a href="https://videos.cdn.mozilla.net/serv/mobile/meetFFXmobile2-640x360.webm">{{ _('WebM format') }}</a></li>
+          <li><a href="https://videos.cdn.mozilla.net/serv/mobile/meetFFXmobile2-640x360.theora.ogv">{{ _('Ogg Theora format') }}</a></li>
+          <li><a href="https://videos.cdn.mozilla.net/serv/mobile/meetFFXmobile2-640x360.mp4">{{ _('MPEG-4 format') }}</a></li>
         </ul>
       </div>
     </li>
@@ -119,16 +119,16 @@
       <figure class="figure">
         <div class="mozilla-video-control">
           <video width="640" height="360" controls="controls" preload="metadata">
-            <source src="//videos.cdn.mozilla.net/labs/openwebapps/openwebapps.webm" type="video/webm"/>
-            <source src="//videos.cdn.mozilla.net/labs/openwebapps/openwebapps.ogv" type="video/ogg"/>
+            <source src="https://videos.cdn.mozilla.net/labs/openwebapps/openwebapps.webm" type="video/webm"/>
+            <source src="https://videos.cdn.mozilla.net/labs/openwebapps/openwebapps.ogv" type="video/ogg"/>
           </video>
         </div>
       </figure>
       <div class="video-description">
         <p class="download">{{ _('Download this video:') }}</p>
         <ul class="download">
-          <li><a href="//videos.cdn.mozilla.net/labs/openwebapps/openwebapps.webm">{{ _('WebM format') }}</a></li>
-          <li><a href="//videos.cdn.mozilla.net/labs/openwebapps/openwebapps.ogv">{{ _('Ogg Theora format') }}</a></li>
+          <li><a href="https://videos.cdn.mozilla.net/labs/openwebapps/openwebapps.webm">{{ _('WebM format') }}</a></li>
+          <li><a href="https://videos.cdn.mozilla.net/labs/openwebapps/openwebapps.ogv">{{ _('Ogg Theora format') }}</a></li>
         </ul>
       </div>
     </li>
@@ -137,7 +137,7 @@
       <h4 class="section-title" id="services">{{ _('Sharing, Data and Services') }}</h4>
 
       <p>
-        {% trans f1="//f1.mozillamessaging.com/" %}
+        {% trans f1="http://f1.mozillamessaging.com/" %}
         People are generating immense amounts of digital information about
         themselves. Right now there's no good way for an individual to control
         or manage the information we generate other than to rely on the
@@ -159,18 +159,18 @@
       <figure class="figure">
         <div class="mozilla-video-control">
           <video width="640" height="360" controls="controls" preload="metadata">
-            <source src="//videos.cdn.mozilla.net/serv/firefox4beta/syncvideo5final640x360.webm" type="video/webm"/>
-            <source src="//videos.cdn.mozilla.net/serv/firefox4beta/syncvideo5final640x3%23161DA3.ogv" type="video/ogg"/>
-            <source src="//videos.cdn.mozilla.net/serv/firefox4beta/syncvideo5final640x360.mp4" type="video/mp4"/>
+            <source src="https://videos.cdn.mozilla.net/serv/firefox4beta/syncvideo5final640x360.webm" type="video/webm"/>
+            <source src="https://videos.cdn.mozilla.net/serv/firefox4beta/syncvideo5final640x3%23161DA3.ogv" type="video/ogg"/>
+            <source src="https://videos.cdn.mozilla.net/serv/firefox4beta/syncvideo5final640x360.mp4" type="video/mp4"/>
           </video>
         </div>
       </figure>
       <div class="video-description">
         <p class="download">{{ _('Download this video:') }}</p>
         <ul class="download">
-          <li><a href="//videos.cdn.mozilla.net/serv/firefox4beta/syncvideo5final640x360.webm">{{ _('WebM format') }}</a></li>
-          <li><a href="//videos.cdn.mozilla.net/serv/firefox4beta/syncvideo5final640x3%23161DA3.ogv">{{ _('Ogg Theora format') }}</a></li>
-          <li><a href="//videos.cdn.mozilla.net/serv/firefox4beta/syncvideo5final640x360.mp4">{{ _('MPEG-4 format') }}</a></li>
+          <li><a href="https://videos.cdn.mozilla.net/serv/firefox4beta/syncvideo5final640x360.webm">{{ _('WebM format') }}</a></li>
+          <li><a href="https://videos.cdn.mozilla.net/serv/firefox4beta/syncvideo5final640x3%23161DA3.ogv">{{ _('Ogg Theora format') }}</a></li>
+          <li><a href="https://videos.cdn.mozilla.net/serv/firefox4beta/syncvideo5final640x360.mp4">{{ _('MPEG-4 format') }}</a></li>
         </ul>
       </div>
     </li>
@@ -183,11 +183,11 @@
       <p>
         {% trans
           logo=static('img/foundation/annualreport/2009/drumbeat-logo.jpg'),
-          webcraft="//www.drumbeat.org/webcraft",
-          festival="//www.drumbeat.org/festival",
-          movies="//www.drumbeat.org/webmademovies",
-          subtitles="//www.drumbeat.org/universal-subtitles/",
-          fund="https://sendto.mozilla.org/"
+          webcraft="http://www.drumbeat.org/",
+          festival="http://www.drumbeat.org/",
+          movies="http://www.drumbeat.org/",
+          subtitles="http://www.drumbeat.org/",
+          fund="https://donate.mozilla.org/"
         %}
           <img src="{{ logo }}" width="100" height="95" align="left" alt="">
           Mozilla's work to build openness and empowerment into the Internet has historically

--- a/bedrock/foundation/templates/foundation/annualreport/2009/index.html
+++ b/bedrock/foundation/templates/foundation/annualreport/2009/index.html
@@ -70,9 +70,9 @@
       2010</cite>{% endtrans %}</p>
   </blockquote>
 
-  <a href="//www.flickr.com/photos/gen/4784616521/"
+  <a href="https://www.flickr.com/photos/gen/4784616521/"
      title="Mozilla Summit 2010 by Gen Kanai, on Flickr"><img
-      src="//farm5.static.flickr.com/4138/4784616521_abb49923c7_z.jpg"
+      src="https://farm5.static.flickr.com/4138/4784616521_abb49923c7_z.jpg"
       width="610" height="443" alt="Mozilla Summit 2010"/></a>
 
 {% endblock %}

--- a/bedrock/foundation/templates/foundation/annualreport/2010/ahead.html
+++ b/bedrock/foundation/templates/foundation/annualreport/2010/ahead.html
@@ -17,9 +17,9 @@
   <figure class="figure">
     <div class="mozilla-video-control">
       <video width="640" height="360" controls="controls" poster="{{ static('img/foundation/annualreport/2010/poster-ahead.jpg') }}">
-        <source src="//videos.cdn.mozilla.net/serv/brand/State%20of%20Mozilla%202011%20(fcp2)-RC%20-%20720p%20-%20MPEG-4.webm" type='video/webm; codecs="vp8, vorbis"' />
-        <source src="//videos.cdn.mozilla.net/serv/brand/State%20of%20Mozilla%202011%20(fcp2)-RC%20-%20720p%20-%20MPEG-4.mp4" type='video/mp4; codecs="avc1.42E01E, mp4a.40.2"' />
-        <source src="//videos.cdn.mozilla.net/serv/brand/State%20of%20Mozilla%202011%20(fcp2)-RC%20-%20720p%20-%20MPEG-4.theora%202.ogv" type='video/ogg; codecs="theora, vorbis"' />
+        <source src="https://videos.cdn.mozilla.net/serv/brand/State%20of%20Mozilla%202011%20(fcp2)-RC%20-%20720p%20-%20MPEG-4.webm" type='video/webm; codecs="vp8, vorbis"' />
+        <source src="https://videos.cdn.mozilla.net/serv/brand/State%20of%20Mozilla%202011%20(fcp2)-RC%20-%20720p%20-%20MPEG-4.mp4" type='video/mp4; codecs="avc1.42E01E, mp4a.40.2"' />
+        <source src="https://videos.cdn.mozilla.net/serv/brand/State%20of%20Mozilla%202011%20(fcp2)-RC%20-%20720p%20-%20MPEG-4.theora%202.ogv" type='video/ogg; codecs="theora, vorbis"' />
       </video>
     </div>
   </figure>
@@ -30,10 +30,10 @@
 
     <p class="download">{{ _('Download this video:') }}</p>
     <ul class="download">
-      <li><a href="//videos.mozilla.net/serv/brand/State%20of%20Mozilla%202011%20(fcp2)-RC%20-%20720p%20-%20MPEG-4.webm">{{ _('WebM format') }}</a></li>
-      <li><a href="//videos.mozilla.net/serv/brand/State%20of%20Mozilla%202011%20(fcp2)-RC%20-%20720p%20-%20MPEG-4.theora%202.ogv">{{ _('Ogg Theora format') }}</a></li>
-      <li><a href="//videos.mozilla.net/serv/brand/State%20of%20Mozilla%202011%20(fcp2)-RC%20-%20720p%20-%20MPEG-4.mp4">{{ _('MPEG-4 format') }}</a></li>
-      <li><a href="//www.universalsubtitles.org/en/videos/6rwEfcRrITSP/">{{ _('Other languages & sharing') }}</a></li>
+      <li><a href="https://videos.cdn.mozilla.net/serv/brand/State%20of%20Mozilla%202011%20(fcp2)-RC%20-%20720p%20-%20MPEG-4.webm">{{ _('WebM format') }}</a></li>
+      <li><a href="https://videos.cdn.mozilla.net/serv/brand/State%20of%20Mozilla%202011%20(fcp2)-RC%20-%20720p%20-%20MPEG-4.theora%202.ogv">{{ _('Ogg Theora format') }}</a></li>
+      <li><a href="https://videos.cdn.mozilla.net/serv/brand/State%20of%20Mozilla%202011%20(fcp2)-RC%20-%20720p%20-%20MPEG-4.mp4">{{ _('MPEG-4 format') }}</a></li>
+      <li><a href="http://www.universalsubtitles.org/en/videos/6rwEfcRrITSP/">{{ _('Other languages & sharing') }}</a></li>
     </ul>
   </div>
 

--- a/bedrock/foundation/templates/foundation/annualreport/2010/faq.html
+++ b/bedrock/foundation/templates/foundation/annualreport/2010/faq.html
@@ -45,12 +45,12 @@
   <div class="content-block pdf">
       <div>
         {{ _('2010 Audited Financial Statement') }}<br/>
-        <a href="http://static.mozilla.com/moco/en-US/pdf/Mozilla%20Foundation%20and%20Subsidiaries%202010%20Audited%20Financial%20Statement.pdf" class="button">{{ _('Download PDF') }}</a>
+        <a href="https://static.mozilla.com/moco/en-US/pdf/Mozilla%20Foundation%20and%20Subsidiaries%202010%20Audited%20Financial%20Statement.pdf" class="button">{{ _('Download PDF') }}</a>
       </div>
 
       <div>
         {{ _('2010 Form 990') }}<br/>
-        <a href="http://static.mozilla.com/moco/en-US/pdf/Mozilla%20Foundation%20-%202010%20Public%20Disclosure%20990.pdf" class="button">{{ _('Download PDF') }}</a>
+        <a href="https://static.mozilla.com/moco/en-US/pdf/Mozilla%20Foundation%20-%202010%20Public%20Disclosure%20990.pdf" class="button">{{ _('Download PDF') }}</a>
       </div>
   </div>
 

--- a/bedrock/foundation/templates/foundation/annualreport/2010/index.html
+++ b/bedrock/foundation/templates/foundation/annualreport/2010/index.html
@@ -14,9 +14,9 @@
   <figure class="figure">
     <div class="mozilla-video-control">
       <video width="640" height="360" controls="controls" poster="{{ static('img/foundation/annualreport/2010/poster-manifesto.jpg') }}">
-        <source src="//videos.cdn.mozilla.net/brand/Mozilla_Firefox_Manifesto_v0.2_640.webm" type='video/webm; codecs="vp8, vorbis"' />
-        <source src="//videos.cdn.mozilla.net/brand/Mozilla_Firefox_Manifesto_v0.2_640.mp4" type='video/mp4; codecs="avc1.42E01E, mp4a.40.2"' />
-        <source src="//videos.cdn.mozilla.net/brand/Mozilla_Firefox_Manifesto_v0.2_640.theora.ogv" type='video/ogg; codecs="theora, vorbis"' />
+        <source src="https://videos.cdn.mozilla.net/brand/Mozilla_Firefox_Manifesto_v0.2_640.webm" type='video/webm; codecs="vp8, vorbis"' />
+        <source src="https://videos.cdn.mozilla.net/brand/Mozilla_Firefox_Manifesto_v0.2_640.mp4" type='video/mp4; codecs="avc1.42E01E, mp4a.40.2"' />
+        <source src="https://videos.cdn.mozilla.net/brand/Mozilla_Firefox_Manifesto_v0.2_640.theora.ogv" type='video/ogg; codecs="theora, vorbis"' />
       </video>
     </div>
   </figure>
@@ -26,10 +26,10 @@
     <p>{{ _('What’s Mozilla all about? Why are we doing this? We’re glad you asked.') }}</p>
     <p class="download">{{ _('Download this video:') }}</p>
     <ul class="download">
-      <li><a href="//videos.cdn.mozilla.net/brand/Mozilla_Firefox_Manifesto_v0.2_640.webm">{{ _('WebM format') }}</a></li>
-      <li><a href="//videos.cdn.mozilla.net/brand/Mozilla_Firefox_Manifesto_v0.2_640.theora.ogv">{{ _('Ogg Theora format') }}</a></li>
-      <li><a href="//videos.cdn.mozilla.net/brand/Mozilla_Firefox_Manifesto_v0.2_640.mp4">{{ _('MPEG-4 format') }}</a></li>
-      <li><a href="//www.universalsubtitles.org/en/videos/NNxEqfuQSaPN/">{{ _('Other languages & sharing') }}</a></li>
+      <li><a href="https://videos.cdn.mozilla.net/brand/Mozilla_Firefox_Manifesto_v0.2_640.webm">{{ _('WebM format') }}</a></li>
+      <li><a href="https://videos.cdn.mozilla.net/brand/Mozilla_Firefox_Manifesto_v0.2_640.theora.ogv">{{ _('Ogg Theora format') }}</a></li>
+      <li><a href="https://videos.cdn.mozilla.net/brand/Mozilla_Firefox_Manifesto_v0.2_640.mp4">{{ _('MPEG-4 format') }}</a></li>
+      <li><a href="http://www.universalsubtitles.org/en/videos/NNxEqfuQSaPN/">{{ _('Other languages & sharing') }}</a></li>
     </ul>
   </div>
 

--- a/bedrock/foundation/templates/foundation/annualreport/2010/opportunities.html
+++ b/bedrock/foundation/templates/foundation/annualreport/2010/opportunities.html
@@ -66,12 +66,12 @@
 
     <h3>{{ _('Identity') }}</h3>
 
-    <p>{% trans identity="//identity.mozilla.com/" %}Today’s Web needs an open source, standards-based platform for universally accessible, decentralized, customized <a href="{{ identity }}">identity</a> on the Web. Mozilla has set about building it, with the BrowserID project as a first step. Browser ID is a secure, decentralized, open source, cross-browser way to sign onto websites using your email address.{% endtrans %}</p>
+    <p>{% trans identity="http://identity.mozilla.com/" %}Today’s Web needs an open source, standards-based platform for universally accessible, decentralized, customized <a href="{{ identity }}">identity</a> on the Web. Mozilla has set about building it, with the BrowserID project as a first step. Browser ID is a secure, decentralized, open source, cross-browser way to sign onto websites using your email address.{% endtrans %}</p>
 
     <h3>{{ _('Apps') }}</h3>
 
     <p>
-      {% trans apps="https://apps.mozillalabs.com/", features="//blog.lizardwrangler.com/2011/08/09/the-app-model-and-the-web/" %}
+      {% trans apps="https://marketplace.firefox.com/", features="https://blog.lizardwrangler.com/2011/08/09/the-app-model-and-the-web/" %}
           <a href="{{ apps }}">Apps</a> represent a new, convenient way of interacting with the Internet,
           but they lack <a href="{{ features }}">a number of the features</a> that are great about the Web.
           The Mozilla open app ecosystem will let users take their apps with them across platforms and devices.
@@ -79,11 +79,11 @@
 
     <h3>{{ _('Education') }}</h3>
 
-    <p>{% trans webcraft="//p2pu.org/webcraft", hack="//hackasaurus.org/", badges="//openbadges.org/" %}Mozilla’s education programs are designed to inspire a new generation of Webmakers. The <a href="{{ webcraft }}">School of Webcraft</a> teaches open Web development skills through peer-to-peer collaboration, community and mentorship. The <a href="{{ hack }}">Mozilla Hackasaurus</a> program teaches youth the building blocks of Web technology and development. Mozilla is also developing new approaches to recognizing online learning through our <a href="{{ badges }}">Open Badges</a> project.{% endtrans %}</p>
+    <p>{% trans webcraft="https://p2pu.org/webcraft", hack="http://hackasaurus.org/", badges="http://openbadges.org/" %}Mozilla’s education programs are designed to inspire a new generation of Webmakers. The <a href="{{ webcraft }}">School of Webcraft</a> teaches open Web development skills through peer-to-peer collaboration, community and mentorship. The <a href="{{ hack }}">Mozilla Hackasaurus</a> program teaches youth the building blocks of Web technology and development. Mozilla is also developing new approaches to recognizing online learning through our <a href="{{ badges }}">Open Badges</a> project.{% endtrans %}</p>
 
     <h3>{{ _('Media') }}</h3>
 
-    <p>{% trans movies="//webmademovies.org/", journalism="//drumbeat.org/journalism", subtitles="//www.universalsubtitles.org", openvideo="//openvideoalliance.org/", bavc="//www.bavc.org/" %}Mozilla supports programs and tools that bring openness and innovation to online media. These include <a href="{{ movies }}">Web Made Movies</a>, an open video lab joining filmmakers and Web developers. Mozilla’s partnership with the Knight Foundation similarly brings together Web innovators, journalists and respected news organizations to drive <a href="{{ journalism }}">innovation in journalism</a>. Mozilla also supports projects like <a href="{{ subtitles }}">Universal Subtitles</a>, the <a href="{{ openvideo }}">Open Video Alliance</a> and the <a href="{{ bavc }}">Bay Area Video Coalition</a>.{% endtrans %}</p>
+    <p>{% trans movies="https://popcorn.webmaker.org/", journalism="http://drumbeat.org/journalism", subtitles="https://www.universalsubtitles.org", openvideo="http://openvideoalliance.org/", bavc="https://www.bavc.org/" %}Mozilla supports programs and tools that bring openness and innovation to online media. These include <a href="{{ movies }}">Web Made Movies</a>, an open video lab joining filmmakers and Web developers. Mozilla’s partnership with the Knight Foundation similarly brings together Web innovators, journalists and respected news organizations to drive <a href="{{ journalism }}">innovation in journalism</a>. Mozilla also supports projects like <a href="{{ subtitles }}">Universal Subtitles</a>, the <a href="{{ openvideo }}">Open Video Alliance</a> and the <a href="{{ bavc }}">Bay Area Video Coalition</a>.{% endtrans %}</p>
 
     <h3>{{ _('WebFWD') }}</h3>
 

--- a/bedrock/foundation/templates/foundation/annualreport/2010/people.html
+++ b/bedrock/foundation/templates/foundation/annualreport/2010/people.html
@@ -27,21 +27,21 @@
       <img src="{{ static('img/foundation/annualreport/2010/photo-arabic-mozilla.jpg') }}" width="425" height="275" alt="{{ _('Arabic Mozilla') }}" />
       <p>{{ _('Arabic Mozilla') }}</p>
     </div>
-    <p>{% trans arabicmozilla="//www.arabicmozilla.org/", inaugural="//pierros.papadeas.gr/?p=253" %}Communities and locales in the Arabic-speaking world experienced inspiring growth this year and came together to form a collective community called <a href="{{ arabicmozilla }}">ArabicMozilla</a>. Participating countries include Egypt, Jordan, Tunisia, Algeria, Lebanon, Palestine, Syria, Morocco and Sudan. In July, Mozilla Jordan hosted the region’s <a href="{{ inaugural }}">inaugural inter-community meetup</a> in Amman.{% endtrans %}</p>
+    <p>{% trans arabicmozilla="http://www.arabicmozilla.org/", inaugural="http://pierros.papadeas.gr/?p=253" %}Communities and locales in the Arabic-speaking world experienced inspiring growth this year and came together to form a collective community called <a href="{{ arabicmozilla }}">ArabicMozilla</a>. Participating countries include Egypt, Jordan, Tunisia, Algeria, Lebanon, Palestine, Syria, Morocco and Sudan. In July, Mozilla Jordan hosted the region’s <a href="{{ inaugural }}">inaugural inter-community meetup</a> in Amman.{% endtrans %}</p>
 
     <div class="img-left">
       <img src="{{ static('img/foundation/annualreport/2010/photo-mozilla-kenya.jpg') }}" width="294" height="198" alt="{{ _('Mozilla Kenya') }}" />
       <p>{{ _('Mozilla Kenya') }}</p>
     </div>
-    <p>{% trans ghana="//mozilla-ghana.org", kenya="//www.mozilla-kenya.org/", outreach="//www.mozilla-kenya.org/blog/18-road-trip" %}Representatives from <a href="{{ ghana }}">Mozilla Ghana</a> have begun participating in technical events and <a href="{{ kenya }}">Mozilla Kenya’s</a> community coordinator Alex Wafula has started an <a href="{{ outreach }}">outreach project</a> with universities across the country.{% endtrans %}</p>
+    <p>{% trans ghana="http://mozilla-ghana.org", kenya="http://www.mozilla-kenya.org/", outreach="http://www.mozilla-kenya.org/blog/18-road-trip" %}Representatives from <a href="{{ ghana }}">Mozilla Ghana</a> have begun participating in technical events and <a href="{{ kenya }}">Mozilla Kenya’s</a> community coordinator Alex Wafula has started an <a href="{{ outreach }}">outreach project</a> with universities across the country.{% endtrans %}</p>
 
-    <p>{% trans hispano="//www.mozilla-hispano.org", local=url('mozorg.contribute') %}Mozilla Cuba and Mozilla Nicaragua were organized and launched by local volunteers. At the same time, our <a href="{{ hispano }}">Mozilla Hispano</a> community has continued to thrive, expanding its ranks to 11 Spanish-speaking countries (find <a href="{{ local }}#location">full list of local communities here</a>).{% endtrans %}</p>
+    <p>{% trans hispano="http://www.mozilla-hispano.org", local=url('mozorg.contribute') %}Mozilla Cuba and Mozilla Nicaragua were organized and launched by local volunteers. At the same time, our <a href="{{ hispano }}">Mozilla Hispano</a> community has continued to thrive, expanding its ranks to 11 Spanish-speaking countries (find <a href="{{ local }}#location">full list of local communities here</a>).{% endtrans %}</p>
 
     <div class="img-right">
       <img src="{{ static('img/foundation/annualreport/2010/photo-mozilla-indonesia.jpg') }}" width="187" height="249" alt="{{ _('Mozilla Indonesia') }}" />
       <p>{{ _('Mozilla Indonesia') }}</p>
     </div>
-    <p>{% trans indonesia="//www.mozilla.web.id/" %}The <a href="{{ indonesia }}">Mozilla community in Indonesia</a> has developed an Indonesian mascot character, “Kumi,” which  has been  celebrated and distributed as a paper toy at many of this  year’s  events. The community now has regional leaders in the five largest cities in Indonesia, which have been actively promoting Mozilla and Firefox. Thanks to the enthusiasm and passion of this community, Firefox enjoys the largest market share in the world in Indonesia.{% endtrans %}</p>
+    <p>{% trans indonesia="http://www.mozilla.web.id/" %}The <a href="{{ indonesia }}">Mozilla community in Indonesia</a> has developed an Indonesian mascot character, “Kumi,” which  has been  celebrated and distributed as a paper toy at many of this  year’s  events. The community now has regional leaders in the five largest cities in Indonesia, which have been actively promoting Mozilla and Firefox. Thanks to the enthusiasm and passion of this community, Firefox enjoys the largest market share in the world in Indonesia.{% endtrans %}</p>
 
     <img src="{{ static('img/foundation/annualreport/2010/kumi.png') }}" width="134" height="104" style="margin-left: 150px" alt="Kumi" />
 
@@ -63,9 +63,9 @@
     <figure class="figure">
       <div class="mozilla-video-control">
         <video width="640" height="360" controls="controls" poster="{{ static('img/foundation/annualreport/2010/poster-getinvolved.jpg') }}">
-            <source src="//videos.cdn.mozilla.net/serv/webmademovies/Moz_Doc_0329_GetInvolved_ST.webm" type='video/webm; codecs="vp8, vorbis"' />
-            <source src="//videos.cdn.mozilla.net/serv/webmademovies/Moz_Doc_0329_GetInvolved_ST.mp4" type='video/mp4; codecs="avc1.42E01E, mp4a.40.2"' />
-            <source src="//videos.cdn.mozilla.net/serv/webmademovies/Moz_Doc_0329_GetInvolved_ST.ogv" type='video/ogg; codecs="theora, vorbis"' />
+            <source src="https://videos.cdn.mozilla.net/serv/webmademovies/Moz_Doc_0329_GetInvolved_ST.webm" type='video/webm; codecs="vp8, vorbis"' />
+            <source src="https://videos.cdn.mozilla.net/serv/webmademovies/Moz_Doc_0329_GetInvolved_ST.mp4" type='video/mp4; codecs="avc1.42E01E, mp4a.40.2"' />
+            <source src="https://videos.cdn.mozilla.net/serv/webmademovies/Moz_Doc_0329_GetInvolved_ST.ogv" type='video/ogg; codecs="theora, vorbis"' />
         </video>
       </div>
     </figure>
@@ -74,10 +74,10 @@
       <p>{{ _('Mozilla is a fun, diverse community of people from around the world.') }}</p>
       <p class="download">{{ _('Download this video:') }}</p>
       <ul class="download">
-        <li><a href="//videos.cdn.mozilla.net/serv/webmademovies/Moz_Doc_0329_GetInvolved_ST.webm">{{ _('WebM format') }}</a></li>
-        <li><a href="//videos.cdn.mozilla.net/serv/webmademovies/Moz_Doc_0329_GetInvolved_ST.ogv">{{ _('Ogg Theora format') }}</a></li>
-        <li><a href="//videos.cdn.mozilla.net/serv/webmademovies/Moz_Doc_0329_GetInvolved_ST.mp4">{{ _('MPEG-4 format') }}</a></li>
-        <li><a href="//www.universalsubtitles.org/en/videos/VPRyx1WZwY6Z/">{{ _('Other languages & sharing') }}</a></li>
+        <li><a href="https://videos.cdn.mozilla.net/serv/webmademovies/Moz_Doc_0329_GetInvolved_ST.webm">{{ _('WebM format') }}</a></li>
+        <li><a href="https://videos.cdn.mozilla.net/serv/webmademovies/Moz_Doc_0329_GetInvolved_ST.ogv">{{ _('Ogg Theora format') }}</a></li>
+        <li><a href="https://videos.cdn.mozilla.net/serv/webmademovies/Moz_Doc_0329_GetInvolved_ST.mp4">{{ _('MPEG-4 format') }}</a></li>
+        <li><a href="http://www.universalsubtitles.org/en/videos/VPRyx1WZwY6Z/">{{ _('Other languages & sharing') }}</a></li>
       </ul>
     </div>
   </div>

--- a/bedrock/foundation/templates/foundation/annualreport/2011.html
+++ b/bedrock/foundation/templates/foundation/annualreport/2011.html
@@ -58,7 +58,7 @@
     <section id="welcome" class="section">
 
       <figure class="right video">
-        <a class="video-play" href="//videos.cdn.mozilla.net/brand/Mozilla_2011_Story.webm" data-video-source="//videos.cdn.mozilla.net/brand/Mozilla_2011_Story" title="{{ _('Click to play this video') }}">
+        <a class="video-play" href="https://videos.cdn.mozilla.net/brand/Mozilla_2011_Story.webm" data-video-source="https://videos.cdn.mozilla.net/brand/Mozilla_2011_Story" title="{{ _('Click to play this video') }}">
           <img src="{{ static('img/foundation/annualreport/2011/vid-welcome.jpg') }}" alt="{{ _('Watch a brief video about Mozilla and our mission') }}" width="380">
         </a>
       </figure>
@@ -158,7 +158,7 @@
 
           <div class="overlay">
             <p>
-            {% trans fxos_url='//www.mozilla.org/firefoxos/' %}
+            {% trans fxos_url=url('firefox.os.index') %}
               Just like we did on the desktop, Mozilla is setting out to
               ensure that the mobile Web is full of freedom, choice and
               opportunity and that it has the ability for users to create
@@ -182,7 +182,7 @@
             </p>
 
             <p>
-            {% trans telefonica_url='//www.telefonica.com' %}
+            {% trans telefonica_url='http://www.telefonica.com' %}
               Firefox OS devices will launch in early 2013 through <a href="{{ telefonica_url }}" rel="external">Telefónica</a>,
               establishing HTML5 as a viable platform for the mobile industry.
               The Web as the platform will free developers to create groundbreaking
@@ -293,7 +293,7 @@
 
           <div class="overlay">
             <p>
-            {% trans webmaker_url='//webmaker.org' %}
+            {% trans webmaker_url='https://webmaker.org' %}
               The unique power of the Web means that anyone can make and build
               with it. Our new educational offering, <a href="{{ webmaker_url }}" rel="external">Mozilla Webmaker</a>,
               will place that power in the hands of millions of new creators everywhere.
@@ -302,8 +302,8 @@
 
             <p>
             {% trans
-                popcorn_url='//mozillapopcorn.org/',
-                thimble_url='//thimble.webmaker.org/' %}
+                popcorn_url='https://popcorn.webmaker.org/',
+                thimble_url='https://thimble.webmaker.org/' %}
               Webmaker tools, projects and events help educators, youth, media-makers
               and everyday consumers around the world move from using the Web to
               making the Web. In 2013, Webmaker will mobilize a global community of
@@ -322,7 +322,7 @@
       <aside class="left video mob-webmakervideo">
         <h3>{{ _('Webmaker: Video') }}</h3>
         <figure class="video">
-          <a class="video-play" href="https://webmaker.org/videos/" data-video-source="//videos.cdn.mozilla.net/serv/webmademovies/webmakers-instructors" title="{{ _('Click to view this video') }}">
+          <a class="video-play" href="https://webmaker.org/videos/" data-video-source="https://videos.cdn.mozilla.net/serv/webmademovies/webmakers-instructors" title="{{ _('Click to view this video') }}">
             <img src="{{ static('img/foundation/annualreport/2011/vid-webmaker.jpg') }}" alt="{{ _('Watch this video about teaching the next generation of Webmakers') }}">
           </a>
         </figure>
@@ -342,12 +342,12 @@
           <div class="overlay">
             <p>
             {% trans
-                cofound_url='//brendaneich.com/2004/06/the-non-world-non-wide-non-web/',
-                whatwg_url='//www.whatwg.org/',
-                html5_url='//dev.w3.org/html5/spec/Overview.html',
-                javascript_url='//ecmascript.org/',
-                dbaron_url='//dbaron.org/',
-                ocallahan_url='//robert.ocallahan.org/' %}
+                cofound_url='https://brendaneich.com/2004/06/the-non-world-non-wide-non-web/',
+                whatwg_url='https://whatwg.org/',
+                html5_url='http://dev.w3.org/html5/spec/Overview.html',
+                javascript_url='http://ecmascript.org/',
+                dbaron_url='http://dbaron.org/',
+                ocallahan_url='http://robert.ocallahan.org/' %}
               Mozilla has always contributed to Web standards, going back
               as far as the start of the project, and we will continue to do
               that moving forward. We <a href="{{ cofound_url }}" rel="external" hreflang="en-US">co-founded</a>
@@ -623,7 +623,7 @@
 
         <aside class="video left">
           <img src="{{ static('img/foundation/annualreport/2011/logo-mozcamp.png') }}" alt="">
-          <a class="video-play" href="//videos.cdn.mozilla.net/serv/drafts/MozCamp-Latam.webm" data-video-source="//videos.cdn.mozilla.net/serv/drafts/MozCamp-Latam" title="{{ _('Click to play this video') }}">
+          <a class="video-play" href="https://videos.cdn.mozilla.net/serv/drafts/MozCamp-Latam.webm" data-video-source="https://videos.cdn.mozilla.net/serv/drafts/MozCamp-Latam" title="{{ _('Click to play this video') }}">
             <img src="{{ static('img/foundation/annualreport/2011/vid-mozcamp.jpg') }}" alt="{{ _('Watch this video showing some of the activities from MozCamp in Latin America') }}">
           </a>
         </aside>
@@ -669,10 +669,10 @@
           <div class="overlay">
             <p>
             {% trans
-                tunisia_url='//mozilla-tunisia.org/',
-                kenya_url='//www.mozilla-kenya.org/',
-                philippines_url='//www.mozillaphilippines.org/',
-                myanmar_url='//mozillamyanmar.org/' %}
+                tunisia_url='http://mozilla-tunisia.org/',
+                kenya_url='http://www.mozilla-kenya.org/',
+                philippines_url='http://www.mozillaphilippines.org/',
+                myanmar_url='http://mozillamyanmar.org/' %}
               Some of the fastest growing and most dynamic communities are some
               of our youngest communities. They can be found in the Middle East,
               Africa and South East Asia and many of their members have been invited
@@ -707,7 +707,7 @@
           <div class="jcarousel-clip">
             <ul id="story-slider">
               <li id="story-chit" class="vcard">
-                <a class="contributor contrib-play" href="//videos.cdn.mozilla.net/serv/drafts/Contributorstory1.webm" data-poster="{{ static('img/foundation/annualreport/2011/contributors/chit-poster.jpg') }}">
+                <a class="contributor contrib-play" href="https://videos.cdn.mozilla.net/serv/drafts/Contributorstory1.webm" data-poster="{{ static('img/foundation/annualreport/2011/contributors/chit-poster.jpg') }}">
                   <hgroup>
                     <h4 class="fn">{{ _('Chit Thiri Maung') }}</h4>
                     <h5>
@@ -726,7 +726,7 @@
               </li>
 
               <li id="story-viking" class="vcard">
-                <a class="contributor contrib-play" href="//videos.cdn.mozilla.net/serv/drafts/Contributorstory2.webm" data-poster="{{ static('img/foundation/annualreport/2011/contributors/viking-poster.jpg') }}">
+                <a class="contributor contrib-play" href="https://videos.cdn.mozilla.net/serv/drafts/Contributorstory2.webm" data-poster="{{ static('img/foundation/annualreport/2011/contributors/viking-poster.jpg') }}">
                   <hgroup>
                     <h4 class="fn">{{ _('Viking Karwur') }}</h4>
                     <h5>
@@ -746,7 +746,7 @@
               </li>
 
               <li id="story-keng" class="vcard">
-                <a class="contributor contrib-play" href="//videos.cdn.mozilla.net/serv/drafts/Contributorstory4.webm" data-poster="{{ static('img/foundation/annualreport/2011/contributors/keng-poster.jpg') }}">
+                <a class="contributor contrib-play" href="https://videos.cdn.mozilla.net/serv/drafts/Contributorstory4.webm" data-poster="{{ static('img/foundation/annualreport/2011/contributors/keng-poster.jpg') }}">
                   <hgroup>
                     <h4 class="fn">{{ _('Patipat “Keng” Susumpow') }}</h4>
                     <h5>
@@ -765,7 +765,7 @@
               </li>
 
               <li id="story-claire" class="vcard">
-                <a class="contributor contrib-play" href="//videos.cdn.mozilla.net/serv/drafts/Contributorstory5.webm" data-poster="{{ static('img/foundation/annualreport/2011/contributors/claire-poster.jpg') }}">
+                <a class="contributor contrib-play" href="https://videos.cdn.mozilla.net/serv/drafts/Contributorstory5.webm" data-poster="{{ static('img/foundation/annualreport/2011/contributors/claire-poster.jpg') }}">
                   <hgroup>
                     <h4 class="fn">{{ _('Claire Corgnou') }}</h4>
                     <h5>
@@ -784,7 +784,7 @@
               </li>
 
               <li id="story-haitham" class="vcard">
-                <a class="contributor contrib-play" href="//videos.cdn.mozilla.net/serv/drafts/Contributorstory6.webm" data-poster="{{ static('img/foundation/annualreport/2011/contributors/haitham-poster.jpg') }}">
+                <a class="contributor contrib-play" href="https://videos.cdn.mozilla.net/serv/drafts/Contributorstory6.webm" data-poster="{{ static('img/foundation/annualreport/2011/contributors/haitham-poster.jpg') }}">
                   <hgroup>
                     <h4 class="fn">{{ _('Haitham El-Ghareeb') }}</h4>
                     <h5>
@@ -803,7 +803,7 @@
               </li>
 
               <li id="story-ioana" class="vcard">
-                <a class="contributor contrib-play" href="//videos.cdn.mozilla.net/serv/drafts/Contributorstory7.webm" data-poster="{{ static('img/foundation/annualreport/2011/contributors/ioana-poster.jpg') }}">
+                <a class="contributor contrib-play" href="https://videos.cdn.mozilla.net/serv/drafts/Contributorstory7.webm" data-poster="{{ static('img/foundation/annualreport/2011/contributors/ioana-poster.jpg') }}">
                   <hgroup>
                     <h4 class="fn">{{ _('Ioana Chiorean') }}</h4>
                     <h5>
@@ -822,7 +822,7 @@
               </li>
 
               <li id="story-brian" class="vcard">
-                <a class="contributor contrib-play" href="//videos.cdn.mozilla.net/serv/drafts/Contributorstory8.webm" data-poster="{{ static('img/foundation/annualreport/2011/contributors/brian-poster.jpg') }}">
+                <a class="contributor contrib-play" href="https://videos.cdn.mozilla.net/serv/drafts/Contributorstory8.webm" data-poster="{{ static('img/foundation/annualreport/2011/contributors/brian-poster.jpg') }}">
                   <hgroup>
                     <h4 class="fn">{{ _('Brian King') }}</h4>
                     <h5>
@@ -841,7 +841,7 @@
               </li>
 
               <li id="story-mohomodou" class="vcard">
-                <a class="contributor contrib-play" href="//videos.cdn.mozilla.net/serv/drafts/Contributorstory9.webm" data-poster="{{ static('img/foundation/annualreport/2011/contributors/mohomodou-poster.jpg') }}">
+                <a class="contributor contrib-play" href="https://videos.cdn.mozilla.net/serv/drafts/Contributorstory9.webm" data-poster="{{ static('img/foundation/annualreport/2011/contributors/mohomodou-poster.jpg') }}">
                   <hgroup>
                     <h4 class="fn">{{ _('Mohomodou Houssouba') }}</h4>
                     <h5>
@@ -909,8 +909,8 @@
       <section class="sus-links">
         <ul>
           <li><a class="sus-faq" href="{{ url('foundation.annualreport.2011faq') }}">{{ _('FAQ') }}</a></li>
-          <li><a class="sus-fin" href="//static.mozilla.com/moco/en-US/pdf/Mozilla%20Foundation%20and%20Subsidiaries%202011%20Audited%20Financial%20Statement.pdf" hreflang="en-US">{{ _('2011 Audited Financial Statement') }} <small>{{ _('Download PDF') }}</small></a></li>
-          <li><a class="sus-990" href="//static.mozilla.com/moco/en-US/pdf/Mozilla%20Foundation%20-%202011%20Public%20Disclosure%20990.pdf" hreflang="en-US">{{ _('2011 Form 990') }} <small>{{ _('Download PDF') }}</small></a></li>
+          <li><a class="sus-fin" href="https://static.mozilla.com/moco/en-US/pdf/Mozilla%20Foundation%20and%20Subsidiaries%202011%20Audited%20Financial%20Statement.pdf" hreflang="en-US">{{ _('2011 Audited Financial Statement') }} <small>{{ _('Download PDF') }}</small></a></li>
+          <li><a class="sus-990" href="https://static.mozilla.com/moco/en-US/pdf/Mozilla%20Foundation%20-%202011%20Public%20Disclosure%20990.pdf" hreflang="en-US">{{ _('2011 Form 990') }} <small>{{ _('Download PDF') }}</small></a></li>
         </ul>
       </section>
 


### PR DESCRIPTION
This fixes most links on these old pages (at least the insecure warnings introduced by the protocol relative URLs). Also explicitly makes links secure than can/should be.