### PR TITLE
[fix bug 1228355] Broken link on SmartOn Tracking page

### DIFF
--- a/bedrock/teach/templates/teach/smarton/tracking.html
+++ b/bedrock/teach/templates/teach/smarton/tracking.html
@@ -135,7 +135,7 @@
             {# L10n: This fragment follows the number '76%' #}
             {{ _('of adults say they are “not too confident” or “not at all confident” that records of their activity maintained by the online advertisers who place ads on the websites they visit will remain private and secure.') }}
             {# L10n: "Pew Research Center" is a proper name and shouldn't be translated #}
-            <cite><a href="https://www.pewinternet.org/2015/05/20/americans-attitudes-about-privacy-security-and-surveillance/">{{ _('(Pew Research Center, May 2015)') }}</a></cite>
+            <cite><a href="http://www.pewinternet.org/2015/05/20/americans-attitudes-about-privacy-security-and-surveillance/">{{ _('(Pew Research Center, May 2015)') }}</a></cite>
           </p>
         </section>
       </aside>


### PR DESCRIPTION
A tiny fix, but worthwhile given this page has a lot of traffic atm.