### PR TITLE
Provide PageRegions with a reference to the page they are instantiated from

### DIFF
--- a/tests/functional/firefox/os/test_tv.py
+++ b/tests/functional/firefox/os/test_tv.py
@@ -37,11 +37,11 @@ def test_click_thumbnails(base_url, selenium):
     assert screens[0].is_displayed
     assert thumbnails[0].is_selected
     for i in range(1, len(thumbnails)):
-        page.click_thumbnail(i)
+        thumbnails[i].click()
         assert screens[i].is_displayed
         assert thumbnails[i].is_selected
     for i in range(len(thumbnails) - 2, -1, -1):
-        page.click_thumbnail(i)
+        thumbnails[i].click()
         assert screens[i].is_displayed
         assert thumbnails[i].is_selected
     assert screens[0].is_displayed

--- a/tests/pages/base.py
+++ b/tests/pages/base.py
@@ -24,15 +24,15 @@ class BasePage(Page):
 
     @property
     def navigation(self):
-        return self.Navigation(self.base_url, self.selenium)
+        return self.Navigation(self)
 
     @property
     def footer(self):
-        return self.Footer(self.base_url, self.selenium)
+        return self.Footer(self)
 
     @property
     def newsletter(self):
-        return NewsletterEmbedForm(self.base_url, self.selenium)
+        return NewsletterEmbedForm(self)
 
     class Navigation(PageRegion):
 

--- a/tests/pages/contribute/contribute.py
+++ b/tests/pages/contribute/contribute.py
@@ -15,7 +15,7 @@ class ContributePage(ContributeBasePage):
     _video_play_locator = (By.CSS_SELECTOR, '.video-play')
 
     def play_video(self):
-        modal = Modal(self.base_url, self.selenium)
+        modal = Modal(self)
         self.find_element(self._video_play_locator).click()
         self.wait.until(lambda s: modal.is_displayed)
         return modal

--- a/tests/pages/firefox/android.py
+++ b/tests/pages/firefox/android.py
@@ -17,7 +17,7 @@ class AndroidPage(FirefoxBasePage):
 
     @property
     def customize_sections(self):
-        return [CustomizeSection(self.base_url, self.selenium, root=el) for el in
+        return [CustomizeSection(self, root=el) for el in
                 self.find_elements(self._customize_locator)]
 
     @property

--- a/tests/pages/firefox/base.py
+++ b/tests/pages/firefox/base.py
@@ -16,7 +16,7 @@ class FirefoxBasePage(BasePage):
 
     @property
     def family_navigation(self):
-        return self.FamilyNavigation(self.base_url, self.selenium)
+        return self.FamilyNavigation(self)
 
     def scroll_element_into_view(self, locator):
         return super(FirefoxBasePage, self).scroll_element_into_view(

--- a/tests/pages/firefox/developer.py
+++ b/tests/pages/firefox/developer.py
@@ -27,14 +27,14 @@ class DeveloperPage(FirefoxBasePage):
 
     @property
     def developer_videos(self):
-        return [Video(self.base_url, self.selenium, root=el) for el in
+        return [Video(self, root=el) for el in
                 self.find_elements(self._videos_locator)]
 
 
 class Video(PageRegion):
 
     def play(self):
-        modal = Modal(self.base_url, self.selenium)
+        modal = Modal(self)
         self._root.click()
         self.wait.until(lambda s: modal.is_displayed)
         return modal

--- a/tests/pages/firefox/do_not_track.py
+++ b/tests/pages/firefox/do_not_track.py
@@ -16,7 +16,7 @@ class DoNotTrackPage(FirefoxBasePage):
 
     @property
     def frequently_asked_questions(self):
-        return [FrequentlyAskedQuestion(self.base_url, self.selenium, root=el) for el in
+        return [FrequentlyAskedQuestion(self, root=el) for el in
                 self.find_elements(self._faqs_locator)]
 
     @property

--- a/tests/pages/firefox/os/devices.py
+++ b/tests/pages/firefox/os/devices.py
@@ -30,7 +30,7 @@ class DevicesPage(FirefoxBasePage):
         return self.find_element(self._get_phone_button_locator).is_enabled()
 
     def get_a_phone(self):
-        modal = Modal(self.base_url, self.selenium)
+        modal = Modal(self)
         self.find_element(self._get_phone_button_locator).click()
         self.wait.until(lambda s: modal.is_displayed)
         return modal
@@ -38,7 +38,7 @@ class DevicesPage(FirefoxBasePage):
     def open_phone_detail(self):
         self.scroll_element_into_view(self._phone_thumbnail_locator).click()
         el = self.find_element(self._phone_detail_locator)
-        detail = DeviceDetail(self.base_url, self.selenium, root=el)
+        detail = DeviceDetail(self, root=el)
         # wait until close button is displayed for detail pane to initialize
         self.wait.until(lambda s: detail.is_close_displayed)
         return detail
@@ -46,7 +46,7 @@ class DevicesPage(FirefoxBasePage):
     def open_tv_detail(self):
         self.scroll_element_into_view(self._tv_thumbnail_locator).click()
         el = self.find_element(self._tv_detail_locator)
-        detail = DeviceDetail(self.base_url, self.selenium, root=el)
+        detail = DeviceDetail(self, root=el)
         self.find_element(self._tv_thumbnail_locator).click()
         # wait until close button is displayed for detail pane to initialize
         self.wait.until(lambda s: detail.is_close_displayed)

--- a/tests/pages/firefox/os/tv.py
+++ b/tests/pages/firefox/os/tv.py
@@ -18,12 +18,12 @@ class TVPage(FirefoxBasePage):
 
     @property
     def screens(self):
-        return [Screens(self.base_url, self.selenium, root=el) for el in
+        return [Screens(self, root=el) for el in
                 self.find_elements(self._screens_locator)]
 
     @property
     def thumbnails(self):
-        return [Thumbnails(self.base_url, self.selenium, root=el) for el in
+        return [Thumbnails(self, root=el) for el in
                 self.find_elements(self._thumbnails_locator)]
 
     def show_next_screen(self):
@@ -34,14 +34,6 @@ class TVPage(FirefoxBasePage):
     def show_previous_screen(self):
         screen = next(s for s in self.screens if s.is_displayed)
         self.find_element(self._previous_button_locator).click()
-        self.wait.until(lambda s: not screen.is_displayed)
-
-    # This method is necessary because the Thumbnails page region
-    # does not have a reference to the page object. Perhaps we can
-    # improve this in the future.
-    def click_thumbnail(self, index):
-        screen = next(s for s in self.screens if s.is_displayed)
-        self.thumbnails[index].click()
         self.wait.until(lambda s: not screen.is_displayed)
 
     @property
@@ -71,5 +63,6 @@ class Thumbnails(FirefoxBasePageRegion):
         return self.find_element(self._link_locator).get_attribute('class') == 'selected'
 
     def click(self):
+        screen = next(s for s in self.page.screens if s.is_displayed)
         self.find_element(self._link_locator).click()
-        self.wait.until(lambda s: self.is_selected)
+        self.wait.until(lambda s: self.is_selected and not screen.is_displayed)

--- a/tests/pages/firefox/os/version/v2_0.py
+++ b/tests/pages/firefox/os/version/v2_0.py
@@ -16,7 +16,7 @@ class FirefoxOSPage(FirefoxOSBasePage):
 
     @property
     def app_groups(self):
-        return [AppGroup(self.base_url, self.selenium, root=el) for el in
+        return [AppGroup(self, root=el) for el in
                 self.find_elements(self._app_group_buttons_locator)]
 
 

--- a/tests/pages/home.py
+++ b/tests/pages/home.py
@@ -35,7 +35,7 @@ class HomePage(BasePage):
 
     @property
     def upcoming_events(self):
-        return UpcomingEvents(self.base_url, self.selenium)
+        return UpcomingEvents(self)
 
 
 class UpcomingEvents(PageRegion):

--- a/tests/pages/page.py
+++ b/tests/pages/page.py
@@ -69,9 +69,10 @@ class PageRegion(WebView):
 
     _root_locator = None
 
-    def __init__(self, base_url, selenium, root=None, **kwargs):
-        super(PageRegion, self).__init__(base_url, selenium, **kwargs)
+    def __init__(self, page, root=None, **kwargs):
+        super(PageRegion, self).__init__(page.base_url, page.selenium, **kwargs)
         self._root_element = root
+        self.page = page
 
     @property
     def _root(self):

--- a/tests/pages/styleguide.py
+++ b/tests/pages/styleguide.py
@@ -16,7 +16,7 @@ class StyleGuidePage(BasePage):
 
     @property
     def menu(self):
-        return [NavigationMenu(self.base_url, self.selenium, root=el) for el in
+        return [NavigationMenu(self, root=el) for el in
                 self.find_elements(self._sidebar_locator)]
 
 
@@ -28,7 +28,7 @@ class NavigationMenu(PageRegion):
 
     @property
     def sub_menu(self):
-        return [NavigationMenu(self.base_url, self.selenium, root=el) for el in
+        return [NavigationMenu(self, root=el) for el in
                 self.find_elements(self._sub_menu_locator)]
 
     def expand(self):


### PR DESCRIPTION
Addressing a limitation where page regions cannot locate and interact with elements outside of their scope. This allows us to avoid passing the base URL and selenium object for every page region (they're now extracted from the page object) and also solves the problem of referencing page methods/properties from a page region.