### PR TITLE
Bug 1230334 - Private Browsing: fix CTA button alignment for longer translations

### DIFF
--- a/media/css/firefox/private_browsing/private-browsing.less
+++ b/media/css/firefox/private_browsing/private-browsing.less
@@ -250,6 +250,10 @@ html, body{
         float: left;
         width: 100%;
 
+        .button-flat-dark {
+            max-width: 340px;
+        }
+
         .button-flat-dark,
         .dl-button,
         .desktop-download-button,
@@ -386,6 +390,9 @@ html[lang^='en'] {
         .container {
             padding-top: 75px;
             padding-bottom: 75px;
+        }
+        .download-buttons .button-flat-dark {
+            max-width: 220px;
         }
         h2 {
             margin-bottom: 0;
@@ -533,6 +540,9 @@ html[lang^='en'] {
             .desktop-download-button,
             .ios-download-button a {
                 float: none;
+            }
+            .button-flat-dark {
+                max-width: 100%;
             }
         }
     }


### PR DESCRIPTION
See bottom of the page at
https://www.mozilla.org/et/firefox/private-browsing/