### PR TITLE
Add test for Firefox nightly first run page

### DIFF
--- a/tests/functional/firefox/test_nightly.py
+++ b/tests/functional/firefox/test_nightly.py
@@ -1,0 +1,16 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import pytest
+
+from pages.firefox.nightly import FirstRunPage
+
+
+@pytest.mark.sanity
+@pytest.mark.nondestructive
+def test_first_run(base_url, selenium):
+    page = FirstRunPage(base_url, selenium).open()
+    assert page.is_start_testing_displayed
+    assert page.is_start_coding_displayed
+    assert page.is_start_localizing_displayed

--- a/tests/pages/firefox/do_not_track.py
+++ b/tests/pages/firefox/do_not_track.py
@@ -11,7 +11,7 @@ class DoNotTrackPage(FirefoxBasePage):
 
     _url = '{base_url}/{locale}/firefox/dnt'
 
-    _dnt_status = (By.CSS_SELECTOR, '#dnt-status > h5')
+    _dnt_status_locator = (By.CSS_SELECTOR, '#dnt-status > h5')
     _faqs_locator = (By.CSS_SELECTOR, '#faq > section')
 
     @property
@@ -21,7 +21,7 @@ class DoNotTrackPage(FirefoxBasePage):
 
     @property
     def is_do_not_track_status_displayed(self):
-        return self.is_element_displayed(self._dnt_status)
+        return self.is_element_displayed(self._dnt_status_locator)
 
 
 class FrequentlyAskedQuestion(FirefoxBasePageRegion):

--- a/tests/pages/firefox/nightly.py
+++ b/tests/pages/firefox/nightly.py
@@ -1,0 +1,28 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from selenium.webdriver.common.by import By
+
+from pages.base import BasePage
+
+
+class FirstRunPage(BasePage):
+
+    _url = '{base_url}/{locale}/firefox/nightly/firstrun'
+
+    _start_testing_locator = (By.CSS_SELECTOR, '#nightly-box .test .button')
+    _start_coding_locator = (By.CSS_SELECTOR, '#nightly-box .code .button')
+    _start_localizing_locator = (By.CSS_SELECTOR, '#nightly-box .localize .button')
+
+    @property
+    def is_start_testing_displayed(self):
+        return self.is_element_displayed(self._start_testing_locator)
+
+    @property
+    def is_start_coding_displayed(self):
+        return self.is_element_displayed(self._start_coding_locator)
+
+    @property
+    def is_start_localizing_displayed(self):
+        return self.is_element_displayed(self._start_localizing_locator)


### PR DESCRIPTION
MIgrating the nightly first run test from https://github.com/mozilla/mcom-tests/blob/master/tests/test_nightlyfirstrun.py

@alexgibson r?