### PR TITLE
Add Dockerfile and scripts for running LinkChecker

### DIFF
--- a/bin/run-linkchecker.sh
+++ b/bin/run-linkchecker.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+set -xe
+
+CMD="linkchecker"
+CMD="${CMD} -F html/utf8//results/linkchecker-out.html"
+if [ -n "${THREADS}" ]; then CMD="${CMD} -t ${THREADS}"; fi
+if [ -n "${RECURSION_LEVEL}" ]; then CMD="${CMD} -r ${RECURSION_LEVEL}"; fi
+if [ -n "${VERBOSE}" ]; then CMD="${CMD} -v"; fi
+if [ -n "${CHECK_EXTERNAL}" ]; then CMD="${CMD} --check-extern"; fi
+
+CMD="${CMD} ${URLS}"
+eval ${CMD}

--- a/docker/dockerfiles/bedrock_linkchecker
+++ b/docker/dockerfiles/bedrock_linkchecker
@@ -1,0 +1,21 @@
+FROM debian:jessie
+
+RUN apt-get update && apt-get install -y --no-install-recommends build-essential python python-dev python-pip
+
+RUN useradd -ms /bin/bash linkchecker
+COPY ./requirements /home/linkchecker/app/requirements
+COPY ./bin /home/linkchecker/app/bin
+
+RUN chown -R linkchecker:linkchecker /home/linkchecker
+
+WORKDIR /home/linkchecker/app
+
+RUN mkdir /results && chown -R linkchecker:linkchecker /results
+ENV PIP_DISABLE_PIP_VERSION_CHECK=1
+RUN pip install -r requirements/pip.txt
+RUN ./bin/peep.py install --no-cache-dir -r requirements/linkchecker.txt
+
+USER linkchecker
+ENV HOME /home/linkchecker
+
+CMD ["bin/run-linkchecker.sh"]

--- a/docker/jenkins/run_linkchecker.sh
+++ b/docker/jenkins/run_linkchecker.sh
@@ -1,0 +1,4 @@
+#!/bin/bash -xe
+cp docker/dockerfiles/bedrock_linkchecker Dockerfile
+docker build -t bedrock_linkchecker:${GIT_COMMIT} --pull=true .
+docker run -v `pwd`/results:/results -e URLS=${URLS} -e RECURSION_LEVEL=${RECURSION_LEVEL} -e CHECK_EXTERNAL=${CHECK_EXTERNAL} -e VERBOSE=${VERBOSE} bedrock_linkchecker:${GIT_COMMIT}

--- a/requirements/linkchecker.txt
+++ b/requirements/linkchecker.txt
@@ -1,0 +1,2 @@
+# sha256: 7gqmDeRA_c-Fh93r8faRvHd6MtjU8Rm-7WP0BdxWF20
+linkchecker==9.3


### PR DESCRIPTION
First attempt at a Dockerfile for LinkChecker. This should enable me to set up the full/download jobs in the Jenkins pipeline, and to remove all the link checking tests from mcom-tests! :smile:

@glogiotatidis r?