### PR TITLE
Fix Bug 1231630 - Remove 10th anniversary promo from Thunderbird start page

### DIFF
--- a/bedrock/thunderbird/templates/thunderbird/start/release.html
+++ b/bedrock/thunderbird/templates/thunderbird/start/release.html
@@ -13,10 +13,6 @@
       </header>
       <div>
         <section>
-          <h2>{{ _('Happy 10th Birthday Thunderbird!') }}</h2>
-          <p>{{ _('Mozilla announced Thunderbird version 1.0 ten years ago. Can you imagine the last ten years without e-mail? Can you imagine e-mail without Thunderbird? We can’t!') }}</p>
-        </section>
-        <section>
           <h2>{{ _('Contribute to Thunderbird') }}</h2>
           <p>{{ _('To ensure that Thunderbird continues to improve, as it has for the last ten years, active contributors <a href="%s">recently organized</a> to focus on the future.')|format('https://blog.mozilla.org/thunderbird/2014/11/thunderbird-reorganizes-at-2014-toronto-summit/') }}
              {{ _('Now is a great time for you to <a href="%s" class="iconic">get involved</a>.')|format('https://wiki.mozilla.org/Thunderbird#Contributing') }}


### PR DESCRIPTION
The promo is outdated as Thunderbird is now 11yo.