### PR TITLE
Bug 1150713 Remove straggler SMS page references

### DIFF
--- a/bedrock/firefox/templates/firefox/feedback/happy.html
+++ b/bedrock/firefox/templates/firefox/feedback/happy.html
@@ -4,7 +4,7 @@
 
 {% extends "firefox/base-resp.html" %}
 
-{% set_lang_files "firefox/feedback" %}
+{% set_lang_files "firefox/feedback" "firefox/sendto" %}
 
 {% block page_title_prefix %}{% endblock %}
 {% block page_title %}{{_('Firefox Feedback')}}{% endblock %}
@@ -54,9 +54,9 @@
     </aside>
 
     <aside class="action-secondary cta-android">
-      <a data-name="CTA Firefox for Android" href="{{ url('firefox.sms') }}?utm_source=happyheartbeat&amp;utm_medium=heartbeat&amp;utm_content=AndroidCTA&amp;utm_campaign=FirefoxforAndroid">
-        <h2>{{ _('Get Firefox on your Android') }}</h2>
-        <p>{{ _('Send yourself a text to download Firefox for Android, a better mobile browser.') }}</p>
+      <a data-name="CTA Firefox for Android" href="{{ url('firefox.android.index') }}?utm_source=happyheartbeat&amp;utm_medium=heartbeat&amp;utm_content=AndroidCTA&amp;utm_campaign=FirefoxforAndroid">
+        <h2>{{ _('Get Firefox for Android') }}</h2>
+        <p>{{ _('Send Firefox to your smartphone or tablet') }}</p>
       </a>
     </aside>
 
@@ -72,4 +72,3 @@
 {% endblock %}
 
 {% block email_form %}{% endblock %}
-

--- a/bedrock/firefox/templates/firefox/whatsnew-fx37.html
+++ b/bedrock/firefox/templates/firefox/whatsnew-fx37.html
@@ -45,10 +45,10 @@
 {% endblock %}
 
 {% macro thank_you_message() %}
-  {# L10n: Thank you message after sending the SMS/email #}
+  {# L10n: Thank you message after sending the email #}
   {{_('Check your device to start downloading.') }}
   <p><a role="button" href="#send-another" class="send-another more">
-    {# L10n: Thank you message after sending the SMS/email #}
+    {# L10n: Thank you message after sending the email #}
     {{ _('Send to another device') }}
   </a></p>
 {%- endmacro %}
@@ -62,9 +62,6 @@
   </header>
   <nav class="toggle">
     <ul role="tablist">
-      <li role="presentation" class="sms-tab">
-        <a id="tab-sms" role="tab" aria-controls="send-sms" href="#send-sms">{{ _('Send by text message') }}</a>
-      </li>
       <li role="presentation" class="email-tab">
         <a id="tab-email" role="tab" aria-controls="send-email" href="#send-email">{{ _('Send by email') }}</a>
       </li>
@@ -86,39 +83,6 @@
           {% endtrans %}
           <br>{{ _('The intended recipient of the email must have consented.') }} <a href="{{ url('privacy.notices.websites') }}#campaigns">{{ _('Learn more') }}</a>
         </footer>
-      </section>
-      <section id="send-sms" class="tab-content">
-        <div class="inner-wrapper">
-          <div class="sms-form-wrapper">
-            <h3>{{ _('Send Firefox to your Android phone') }}</h3>
-            <form id="sms-form" method="post" action="{{ secure_url('firefox.sms') }}">
-              <div class="input">
-                <label for="number">{{ _('Enter your 10-digit phone number') }}</label>
-                <input type="tel"
-                       maxlength="14"
-                       id="number"
-                       name="number"
-                       placeholder="{{ _('Enter your 10-digit phone number') }}"
-                       value=""
-                       required>
-                <p class="error hidden">{{ _('An error occurred in our system. Please try again later.') }}</p>
-              </div>
-              <button type="submit">{{ _('Send') }}</button>
-            </form>
-            <div id="sms-form-thank-you">
-              <h3>{{ _('Your link has been sent!') }}</h3>
-              <p>{{ thank_you_message() }}</p>
-            </div>
-            <div id="sms-spinner" class="hidden"></div>
-          </div>
-          <footer>
-            {% trans url=settings.GOOGLE_PLAY_FIREFOX_LINK %}
-              Also available from <a href="{{ url }}">Google Play</a>.
-            {% endtrans %}
-            <br>
-            {{ _('SMS service available in the U.S. only.') }} {{ _('SMS & data rates may apply. The intended recipient of the SMS must have consented.') }} <a href="{{ url('privacy.notices.websites') }}#campaigns">{{ _('Learn more') }}</a>
-          </footer>
-        </div>
       </section>
     </div>
   </div>

--- a/media/css/firefox/whatsnew-fx37.less
+++ b/media/css/firefox/whatsnew-fx37.less
@@ -207,15 +207,6 @@ html[lang|="en"] .toggle ul li {
     .font-size(@largeFontSize);
 }
 
-#send-sms {
-    .inner-wrapper {
-        padding-bottom: (@baseLine * 3);
-    }
-    label {
-        .visually-hidden();
-    }
-}
-
 .newsletter-form {
     border: none;
     padding: 0 0 (@baseLine * 2.5) 0;
@@ -253,65 +244,6 @@ html[lang|="en"] .toggle ul li {
     margin-bottom: @baseLine;
 }
 
-#sms-form {
-    padding-bottom: @baseLine * 2.5;
-
-    .input {
-        float: left;
-        width: 390px;
-        background-image: url(/media/img/firefox/whatsnew-fx37/lock.png);
-        background-position: right 16px;
-        background-repeat: no-repeat;
-    }
-
-    input[type="tel"] {
-        width: 89%;
-    }
-
-    button[type="submit"] {
-        .open-sans;
-        float: right;
-    }
-
-    p {
-        margin: @baseLine 0;
-    }
-}
-
-.sms-form-wrapper {
-    position: relative;
-    .clearfix();
-
-    &.loading {
-        h3, form {
-            .transition(opacity .2s ease-in-out);
-            opacity: 0.2;
-        }
-    }
-}
-
-#sms-spinner {
-    display: none;
-    position: absolute;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-}
-
-#sms-form-thank-you {
-    display: none;
-    overflow: hidden;
-    h3 {
-        width: auto;
-        float: none;
-        .animation(sand-bounce-down 0.7s ease-in 0.2s 1 normal both);
-    }
-    p {
-        .animation(sand-fade-in 0.5s ease-in 0.8s 1 normal both);
-    }
-}
-
 .html-rtl {
     .newsletter-form {
         .field-email {
@@ -321,22 +253,10 @@ html[lang|="en"] .toggle ul li {
             float: left;
         }
     }
-    #sms-form {
-        .input {
-            float: right;
-            background-position: left 16px;
-        }
-        button[type="submit"] {
-            float: left;
-        }
-    }
 }
 
 main[data-active="email-only"] {
     .toggle {
-        display: none;
-    }
-    #send-sms {
         display: none;
     }
 }
@@ -346,21 +266,7 @@ main[data-active="email-only"] {
         #send-email {
             display: block;
         }
-        #send-sms {
-            display: none;
-        }
         .email-tab {
-            .active-tab();
-        }
-    }
-    main[data-active="sms"] {
-        #send-email {
-            display: none;
-        }
-        #send-sms {
-            display: block;
-        }
-        .sms-tab {
             .active-tab();
         }
     }
@@ -422,18 +328,6 @@ main[data-active="email-only"] {
         }
     }
 
-    #sms-form {
-        float: left;
-        width: 460px;
-
-        .input {
-            float: right;
-            margin-bottom: @baseLine;
-            background-position: left 16px;
-            text-align: right;
-        }
-    }
-
     .html-rtl {
         .tab-content {
             h3 {
@@ -445,16 +339,6 @@ main[data-active="email-only"] {
             .form-title,
             .form-contents {
                 float: right;
-            }
-        }
-
-        #sms-form {
-            float: right;
-
-            .input {
-                float: left;
-                background-position: right 16px;
-                text-align: left;
             }
         }
     }
@@ -493,25 +377,6 @@ main[data-active="email-only"] {
         }
     }
 
-    #sms-form {
-        float: none;
-        width: 100%;
-
-        .input {
-            width: 100%;
-            text-align: left;
-            background-position: right 16px;
-        }
-
-        input[type="tel"] {
-            width: 84%;
-        }
-
-        button[type="submit"] {
-            float: none;
-        }
-    }
-
     .tab-content {
         h3 {
             width: auto;
@@ -532,20 +397,6 @@ main[data-active="email-only"] {
         #newsletter-form {
             .form-title,
             .form-contents {
-                float: none;
-            }
-        }
-
-        #sms-form {
-            float: none;
-
-            .input {
-                float: none;
-                background-position: left 16px;
-                text-align: right;
-            }
-
-            button[type="submit"] {
                 float: none;
             }
         }

--- a/media/js/firefox/whatsnew-fx37.js
+++ b/media/js/firefox/whatsnew-fx37.js
@@ -9,10 +9,6 @@
     var COUNTRY_CODE = '';
 
     var $main = $('main');
-    var $smsForm = $('#sms-form');
-    var $smsFormHeading = $('.sms-form-wrapper > h3');
-    var $smsThankYou = $('#sms-form-thank-you');
-    var $smsInput = $('#number');
 
     var $emailForm = $('#newsletter-form');
     var $emailThankYou = $('#newsletter-form-thankyou');
@@ -20,8 +16,6 @@
 
     /*
      * Initializes the page form based on the user's geo location.
-     * Visitors in the US will be shown both the sms form and the email form.
-     * Visitors in all other countries will get only the email form
      */
     function initGeoLocation() {
         // should geo.mozilla.org be slow to load for some reason,
@@ -53,53 +47,11 @@
             }
             formLoaded = true;
 
-            // if the page visitor is in the US, show the SMS form and set as active.
-            // can also append '?geo=us' query param for easier testing/debugging
-            if (COUNTRY_CODE === 'us' || window.location.href.indexOf('?geo=us') !== -1) {
-                bindFormNavigation();
-                $main.attr('data-active', 'sms');
-            }
             // now we're all set, show the form panel.
             $('.tab-container .inner-wrapper').show();
 
             setNewsletterDefaults();
         }
-    }
-
-    /*
-     * Bind form tabbed navigation
-     */
-    function bindFormNavigation() {
-        var $emailTab = $('#send-email');
-        var $smsTab = $('#send-sms');
-
-        $emailTab.attr('aria-selected', false);
-        $smsTab.attr('aria-selected', true);
-
-        $('.toggle > ul > li > a').on('click', function(e) {
-            e.preventDefault();
-            var id = e.target.id;
-
-            if (id === 'tab-sms') {
-                $main.attr('data-active', 'sms');
-                $emailTab.attr('aria-selected', false);
-                $smsTab.attr('aria-selected', true);
-            } else if (id === 'tab-email') {
-                $main.attr('data-active', 'email');
-                $smsTab.attr('aria-selected', false);
-                $emailTab.attr('aria-selected', true);
-            }
-        });
-
-        $emailTab.attr({
-            'role': 'tab-panel',
-            'aria-labelledby': 'tab-email'
-        });
-
-        $smsTab.attr({
-            'role': 'tab-panel',
-            'aria-labelledby': 'tab-sms'
-        });
     }
 
     function setNewsletterDefaults () {
@@ -112,82 +64,6 @@
             $countrySelection.prop('selected', true);
         }
     }
-
-    /*
-     * SMS form submission
-     */
-    $smsForm.on('submit', function(e) {
-        e.preventDefault();
-
-        var $self = $(this);
-        var action = $self.attr('action');
-        var formData = $self.serialize();
-        var $spinnerTarget = $('#sms-spinner');
-        var $smsFormWrapper = $('.sms-form-wrapper');
-        var spinner = new Spinner({
-            lines: 12, // The number of lines to draw
-            length: 4, // The length of each line
-            width: 2, // The line thickness
-            radius: 4, // The radius of the inner circle
-            corners: 0, // Corner roundness (0..1)
-            rotate: 0, // The rotation offset
-            direction: 1, // 1: clockwise, -1: counterclockwise
-            color: '#000', // #rgb or #rrggbb or array of colors
-            speed: 1, // Rounds per second
-            trail: 60, // Afterglow percentage
-            shadow: false, // Whether to render a shadow
-            hwaccel: true // Whether to use hardware acceleration
-        });
-
-        disableForm();
-
-        $.post(action, formData)
-            .done(function(data) {
-                enableForm();
-                if (data.success) {
-                    $smsFormHeading.hide();
-                    $self.hide();
-                    $smsThankYou.show();
-
-                    window.dataLayer.push({
-                        'event': 'whatsnew-37'
-                    });
-                } else if (data.error) {
-                    $self.find('.error').html(data.error).show();
-                }
-            })
-            .fail(function() {
-                enableForm();
-                $self.find('.error').show();
-            });
-
-        function disableForm() {
-            $smsFormWrapper.addClass('loading');
-            $self.find('input').prop('disabled', true);
-            spinner.spin($spinnerTarget.show()[0]);
-        }
-
-        function enableForm() {
-            $smsFormWrapper.removeClass('loading');
-            $self.find('input').prop('disabled', false);
-            spinner.stop();
-            $spinnerTarget.hide();
-        }
-    });
-
-    /*
-     * Once the user has submitted the SMS form,
-     * it can be shown again via clicking the link in the thank you page.
-     */
-    $smsThankYou.find('.send-another').on('click', function(e) {
-        e.preventDefault();
-        $smsInput.val('');
-        $smsForm.find('.error').hide();
-        $smsThankYou.hide();
-        $smsFormHeading.show();
-        $smsForm.show();
-        $smsInput.focus();
-    });
 
     /*
      * Once the user has submitted the email form,


### PR DESCRIPTION
Bug 1150713

 * Update link and content on happy feedback page
 * Remove SMS form from FX37 welcome page

Feedback page visible at `/firefox/feedback?score=4`

Welcome page visible at `/firefox/37.0/whatsnew/`

The current welcome page does geolocation to see if SMS is available. This can be triggered manually using `/firefox/37.0/whatsnew/?geo=us`. The updated page still does geolocation to populate the country flydown for the newsletter.