### PR TITLE
[fix bug 1231785] TP UI Tour does not allow linking to step 2

### DIFF
--- a/media/js/firefox/tracking-protection-tour.js
+++ b/media/js/firefox/tracking-protection-tour.js
@@ -51,6 +51,7 @@ if (typeof Mozilla === 'undefined') {
             }
         });
 
+        TPTour.replaceURLState('1');
         TPTour.state = 'step1';
     };
 
@@ -58,6 +59,7 @@ if (typeof Mozilla === 'undefined') {
         _$step2Panel.removeClass('hidden');
         _$step2Panel.find('header').focus();
         _$tracker.addClass('fade-out');
+        TPTour.replaceURLState('2');
         TPTour.state = 'step2';
     };
 
@@ -274,16 +276,23 @@ if (typeof Mozilla === 'undefined') {
     };
 
     TPTour.init = function() {
+        var delay = 500;
+        var step = TPTour.getParameterByName('step');
+
         TPTour.getStrings();
         TPTour.bindEvents();
 
         // TODO - Once Bug 988151 is fixed we can poll for target visibility instead of use a timeout.
-        if (TPTour.getParameterByName('step') === '3') {
-            setTimeout(TPTour.step3, 500);
-        } else {
-            setTimeout(TPTour.step1, 500);
+        switch(step) {
+        case '2':
+            setTimeout(TPTour.step2, delay);
+            break;
+        case '3':
+            setTimeout(TPTour.step3, delay);
+            break;
+        default:
+            setTimeout(TPTour.step1, delay);
         }
-
     };
 
     window.Mozilla.TPTour = TPTour;

--- a/tests/unit/spec/firefox/tracking-protection-tour.js
+++ b/tests/unit/spec/firefox/tracking-protection-tour.js
@@ -72,6 +72,18 @@ describe('tracking-protection-tour.js', function() {
             expect(Mozilla.TPTour.step1).toHaveBeenCalled();
         });
 
+        it('shoud show the second tour step when needed', function() {
+            spyOn(Mozilla.TPTour, 'getParameterByName').and.callFake(function() {
+                return '2';
+            });
+            spyOn(Mozilla.TPTour, 'step2');
+            Mozilla.TPTour.init();
+            expect(Mozilla.TPTour.getStrings).toHaveBeenCalled();
+            expect(Mozilla.TPTour.bindEvents).toHaveBeenCalled();
+            clock.tick(600);
+            expect(Mozilla.TPTour.step2).toHaveBeenCalled();
+        });
+
         it('shoud show the third tour step when needed', function() {
             spyOn(Mozilla.TPTour, 'getParameterByName').and.callFake(function() {
                 return '3';


### PR DESCRIPTION
To test this PR please first:

* [Configure UITour for local development](http://bedrock.readthedocs.org/en/latest/uitour.html#local-development).
* [Set the Tracking Protection tour URL](http://bedrock.readthedocs.org/en/latest/uitour.html#tracking-protection-uitour) to point to your local bedrock instance.