### PR TITLE
Fix bug 1233860 - tag new string on firstrun page

### DIFF
--- a/bedrock/firefox/templates/firefox/firstrun/firstrun.html
+++ b/bedrock/firefox/templates/firefox/firstrun/firstrun.html
@@ -51,7 +51,14 @@
   <div class="container">
     <header>
       <h1>{{ _('Almost done!') }}</h1>
-      <h2>{{ _('Sign in to Firefox and you’re good to go.') }}</h2>
+      <h2>
+      {% if l10n_has_tag('firstrun_fx43') %}
+        {{ _('Sign in to Firefox and you’re good to go.') }}
+      {% else %}
+        {# L10n: Line break below for visual formatting only. #}
+        {{ _('Sign in to Firefox and <br>you’re good to go.') }}
+      {% endif %}
+      </h2>
     </header>
 
     <main role="main">


### PR DESCRIPTION
Attn @flodolo: Sorry we let this string change slip through code review. The only change was removing the line break so hopefully it'll be quick to update. Let me know if you prefer a different tag.