### PR TITLE
[fix bug 1234136] App Store button on release notes page is 404

### DIFF
--- a/bedrock/firefox/templates/firefox/family/index.html
+++ b/bedrock/firefox/templates/firefox/family/index.html
@@ -134,7 +134,7 @@
           {% endif %}
           </a>
 
-          <a rel="external" href="{{ firefox_ios_url() }}" class="btn-apple-appstore" data-product="Firefox for iOS, App Store">
+          <a rel="external" href="{{ firefox_ios_url('mozorg-products_page-appstore-button') }}" class="btn-apple-appstore" data-product="Firefox for iOS, App Store">
             <img src="{{ l10n_img('firefox/ios/btn-app-store.svg') }}" alt="{{ _('Download on the App Store') }}" width="135" height="40">
           </a>
         </div>

--- a/bedrock/firefox/templates/firefox/ios.html
+++ b/bedrock/firefox/templates/firefox/ios.html
@@ -35,7 +35,7 @@
   {% if waffle.switch('firefox-ios-global') %}
     {% call fxfamilynav('ios', 'index') %}
       <div class="{% if has_widget %}show-widget{% endif %}">
-        <a class="dl-button" rel="external" href="{{ firefox_ios_url() }}">
+        <a class="dl-button" rel="external" href="{{ firefox_ios_url('mozorg-ios_page-appstore-button') }}">
           <img src="{{ l10n_img('firefox/ios/btn-app-store.svg') }}" alt="{{ _('Download on the App Store') }}">
         </a>
         <button class="send-to button-flat-dark" type="button">{{ _('Get Firefox for iOS') }}</button>

--- a/bedrock/firefox/templates/firefox/releases/release-notes.html
+++ b/bedrock/firefox/templates/firefox/releases/release-notes.html
@@ -269,7 +269,7 @@
               </a>
             </div>
             <div class="ios-download-button">
-              <a href="{{ settings.APPLE_APPSTORE_FIREFOX_LINK }}&amp;ct=mozorg-ios_page-appstore-button">
+              <a rel="external" href="{{ firefox_ios_url('mozorg-releasenotes_page-appstore-button') }}">
                 <img src="{{ l10n_img('firefox/ios/btn-app-store.svg') }}" alt="{{ _('Download on the App Store') }}">
               </a>
             </div>


### PR DESCRIPTION
* Also added missing query param to a couple of buttons on other pages.