### PR TITLE
Add a script for running the functional tests in Sauce Labs

### DIFF
--- a/docker/dockerfiles/bedrock_functional_tests
+++ b/docker/dockerfiles/bedrock_functional_tests
@@ -10,7 +10,6 @@ RUN apt-get update && \
 
 # Defaults
 ENV PYTEST_PROCESSES 5
-ENV MARK_EXPRESSION smoke
 ENV PRIVACY "public restricted"
 ENV TESTS_PATH /app/tests/functional
 ENV RESULTS_PATH /app/results

--- a/docker/jenkins/properties/functional_tests/full/chrome.properties
+++ b/docker/jenkins/properties/functional_tests/full/chrome.properties
@@ -1,0 +1,2 @@
+BROWSER_NAME=chrome
+PLATFORM=Windows 10

--- a/docker/jenkins/properties/functional_tests/full/firefox.properties
+++ b/docker/jenkins/properties/functional_tests/full/firefox.properties
@@ -1,0 +1,2 @@
+BROWSER_NAME=firefox
+PLATFORM=Windows 10

--- a/docker/jenkins/properties/functional_tests/full/ie.properties
+++ b/docker/jenkins/properties/functional_tests/full/ie.properties
@@ -1,0 +1,2 @@
+BROWSER_NAME=internet explorer
+PLATFORM=Windows 10

--- a/docker/jenkins/properties/functional_tests/sanity/ie6.properties
+++ b/docker/jenkins/properties/functional_tests/sanity/ie6.properties
@@ -1,0 +1,3 @@
+BROWSER_NAME=internet explorer
+BROWSER_VERSION=6.0
+PLATFORM=Windows XP

--- a/docker/jenkins/properties/functional_tests/sanity/ie7.properties
+++ b/docker/jenkins/properties/functional_tests/sanity/ie7.properties
@@ -1,0 +1,3 @@
+BROWSER_NAME=internet explorer
+BROWSER_VERSION=7.0
+PLATFORM=Windows XP

--- a/docker/jenkins/run_functional_tests.sh
+++ b/docker/jenkins/run_functional_tests.sh
@@ -36,4 +36,10 @@ do
     done;
 done;
 
-docker run -v `pwd`/results:/app/results --link bedrock-selenium-hub-${BUILD_NUMBER}:hub --link bedrock-code-${BUILD_NUMBER}:bedrock -e SELENIUM_HOST=hub -e BASE_URL=http://bedrock:8000 bedrock_functional_tests:$GIT_COMMIT
+docker run -v `pwd`/results:/app/results \
+  --link bedrock-selenium-hub-${BUILD_NUMBER}:hub \
+  --link bedrock-code-${BUILD_NUMBER}:bedrock \
+  -e SELENIUM_HOST=hub \
+  -e BASE_URL=http://bedrock:8000 \
+  -e MARK_EXPRESSION=${MARK_EXPRESSION} \
+  bedrock_functional_tests:$GIT_COMMIT

--- a/docker/jenkins/run_functional_tests_sauce.sh
+++ b/docker/jenkins/run_functional_tests_sauce.sh
@@ -1,0 +1,16 @@
+#!/bin/bash -xe
+cp docker/dockerfiles/bedrock_functional_tests Dockerfile
+docker build -t bedrock_functional_tests:${GIT_COMMIT} --pull=true .
+docker run -v `pwd`/results:/app/results \
+  -e BASE_URL=${BASE_URL} \
+  -e DRIVER=SauceLabs \
+  -e SAUCELABS_USERNAME=${SAUCELABS_USERNAME} \
+  -e SAUCELABS_API_KEY=${SAUCELABS_API_KEY} \
+  -e BROWSER_NAME="${BROWSER_NAME}" \
+  -e BROWSER_VERSION=${BROWSER_VERSION} \
+  -e PLATFORM="${PLATFORM}" \
+  -e SELENIUM_VERSION=${SELENIUM_VERSION} \
+  -e BUILD_TAG=${BUILD_TAG} \
+  -e SCREEN_RESOLUTION=${SCREEN_RESOLUTION} \
+  -e MARK_EXPRESSION="${MARK_EXPRESSION}" \
+  bedrock_functional_tests:${GIT_COMMIT}


### PR DESCRIPTION
This removes the default mark expression so that it's possible to run the full suite. It also allows us to run the functional tests against Sauce Labs. @glogiotatidis r?