### PR TITLE
Rename sanity functional tests to smoke tests

### DIFF
--- a/docker/dockerfiles/bedrock_functional_tests
+++ b/docker/dockerfiles/bedrock_functional_tests
@@ -10,7 +10,7 @@ RUN apt-get update && \
 
 # Defaults
 ENV PYTEST_PROCESSES 5
-ENV MARK_EXPRESSION sanity
+ENV MARK_EXPRESSION smoke
 ENV PRIVACY "public restricted"
 ENV TESTS_PATH /app/tests/functional
 ENV RESULTS_PATH /app/results

--- a/docker/jenkins/run_functional_tests.sh
+++ b/docker/jenkins/run_functional_tests.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
 # Starts Selenium Hub and NUMBER_OF_NODES (default 5) firefox nodes.
-# Waits until at least one node is ready and then runs sanity tests
+# Waits until at least one node is ready and then runs smoke tests
 # only against a local bedrock instance started for this job.
 #
 set -xe

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -154,20 +154,20 @@ you can also read the `pytest markers`_ documentation for more options.
         assert not page.text_format_selected
         assert not page.privacy_policy_accepted
 
-Sanity tests
-~~~~~~~~~~~~
+Smoke tests
+~~~~~~~~~~~
 
-Sanity tests are run as part of bedrocks deployment pipeline. These should be considered
+Smoke tests are run as part of bedrocks deployment pipeline. These should be considered
 to be critical tests which benefit from being run automatically after every commit to
 master. Only the full suite of functional tests are run after deployment to staging. If
-your test should be marked as a santity test you will need to apply a ``santiy`` marker
+your test should be marked as a smoke test you will need to apply a ``smoke`` marker
 to it.
 
 .. code-block:: python
 
     import pytest
 
-    @pytest.mark.sanity
+    @pytest.mark.smoke
     @pytest.mark.nondestructive
     def test_newsletter_default_values(base_url, selenium):
         page = NewsletterPage(base_url, selenium).open()
@@ -178,15 +178,38 @@ to it.
         assert not page.text_format_selected
         assert not page.privacy_policy_accepted
 
-You can run sanity tests only by adding ``-m sanity`` when running the test suite on the
+You can run smoke tests only by adding ``-m smoke`` when running the test suite on the
 command line.
 
 .. Note::
 
   Tests that rely on long-running timeouts, cron jobs, or that test for locale specific
-  interactions should not be marked as a sanity test. We should try and ensure that the
-  suite of sanity tests are quick to run, and they should not have a dependency on
+  interactions should not be marked as a smoke test. We should try and ensure that the
+  suite of smoke tests are quick to run, and they should not have a dependency on
   checking out and building the full site.
+
+Sanity tests
+~~~~~~~~~~~~
+
+Sanity tests are considered to be our most critical tests that must pass in a wide range
+of web browsers, including old versions of Internet Explorer. Sanity tests are run
+automatically post deployment on a wider range of browsers & platforms than we run the
+full suite against. The number of sanity tests we run should remain small, but cover our
+most critical pages where legacy browser support is important.
+
+.. code-block:: python
+
+    import pytest
+
+    @pytest.mark.sanity
+    @pytest.mark.nondestructive
+    def test_click_download_button(base_url, selenium):
+        page = FirefoxNewPage(base_url, selenium).open()
+        page.download_firefox()
+        assert page.is_thank_you_message_displayed
+
+You can run sanity tests only by adding ``-m sanity`` when running the test suite on the
+command line.
 
 Waits and Expected Conditions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests/functional/contribute/test_contribute.py
+++ b/tests/functional/contribute/test_contribute.py
@@ -8,7 +8,7 @@ from selenium.common.exceptions import TimeoutException
 from pages.contribute.contribute import ContributePage
 
 
-@pytest.mark.sanity
+@pytest.mark.smoke
 @pytest.mark.nondestructive
 def test_play_video(base_url, selenium):
     page = ContributePage(base_url, selenium).open()
@@ -23,7 +23,7 @@ def test_next_event_is_displayed(base_url, selenium):
     assert page.next_event_is_displayed
 
 
-@pytest.mark.sanity
+@pytest.mark.smoke
 @pytest.mark.nondestructive
 def test_newsletter_default_values(base_url, selenium):
     page = ContributePage(base_url, selenium).open()

--- a/tests/functional/contribute/test_signup.py
+++ b/tests/functional/contribute/test_signup.py
@@ -8,7 +8,7 @@ from selenium.common.exceptions import TimeoutException
 from pages.contribute.signup import ContributeSignUpPage
 
 
-@pytest.mark.sanity
+@pytest.mark.smoke
 @pytest.mark.nondestructive
 def test_toggle_category_with_areas(base_url, selenium):
     page = ContributeSignUpPage(base_url, selenium).open()
@@ -18,7 +18,7 @@ def test_toggle_category_with_areas(base_url, selenium):
     assert page.is_coding_area_required
 
 
-@pytest.mark.sanity
+@pytest.mark.smoke
 @pytest.mark.nondestructive
 def test_toggle_category_without_areas(base_url, selenium):
     page = ContributeSignUpPage(base_url, selenium).open()

--- a/tests/functional/contribute/test_stories.py
+++ b/tests/functional/contribute/test_stories.py
@@ -7,7 +7,7 @@ import pytest
 from pages.contribute.stories import ContributeStoriesPage
 
 
-@pytest.mark.sanity
+@pytest.mark.smoke
 @pytest.mark.nondestructive
 def test_show_hide_story(base_url, selenium):
     page = ContributeStoriesPage(base_url, selenium).open()

--- a/tests/functional/firefox/os/test_devices.py
+++ b/tests/functional/firefox/os/test_devices.py
@@ -7,7 +7,7 @@ import pytest
 from pages.firefox.os.devices import DevicesPage
 
 
-@pytest.mark.sanity
+@pytest.mark.smoke
 @pytest.mark.nondestructive
 def test_family_navigation(base_url, selenium):
     page = DevicesPage(base_url, selenium).open()
@@ -15,7 +15,7 @@ def test_family_navigation(base_url, selenium):
     assert page.family_navigation.is_menu_displayed
 
 
-@pytest.mark.sanity
+@pytest.mark.smoke
 @pytest.mark.nondestructive
 def test_open_close_modal(base_url, selenium):
     page = DevicesPage(base_url, selenium).open()
@@ -25,7 +25,7 @@ def test_open_close_modal(base_url, selenium):
     modal.close()
 
 
-@pytest.mark.sanity
+@pytest.mark.smoke
 @pytest.mark.nondestructive
 def test_open_close_phone(base_url, selenium):
     page = DevicesPage(base_url, selenium).open()
@@ -37,7 +37,7 @@ def test_open_close_phone(base_url, selenium):
     assert not phone.is_features_displayed
 
 
-@pytest.mark.sanity
+@pytest.mark.smoke
 @pytest.mark.nondestructive
 def test_open_close_tv(base_url, selenium):
     page = DevicesPage(base_url, selenium).open()
@@ -49,7 +49,7 @@ def test_open_close_tv(base_url, selenium):
     assert not tv.is_features_displayed
 
 
-@pytest.mark.sanity
+@pytest.mark.smoke
 @pytest.mark.nondestructive
 def test_toggle_detail_tabs(base_url, selenium):
     page = DevicesPage(base_url, selenium).open()

--- a/tests/functional/firefox/os/test_tv.py
+++ b/tests/functional/firefox/os/test_tv.py
@@ -7,7 +7,7 @@ import pytest
 from pages.firefox.os.tv import TVPage
 
 
-@pytest.mark.sanity
+@pytest.mark.smoke
 @pytest.mark.nondestructive
 def test_next_previous_buttons(base_url, selenium):
     page = TVPage(base_url, selenium).open()
@@ -28,7 +28,7 @@ def test_next_previous_buttons(base_url, selenium):
     assert thumbnails[0].is_selected
 
 
-@pytest.mark.sanity
+@pytest.mark.smoke
 @pytest.mark.nondestructive
 def test_click_thumbnails(base_url, selenium):
     page = TVPage(base_url, selenium).open()

--- a/tests/functional/firefox/os/version/test_2_0.py
+++ b/tests/functional/firefox/os/version/test_2_0.py
@@ -7,7 +7,7 @@ import pytest
 from pages.firefox.os.version.v2_0 import FirefoxOSPage
 
 
-@pytest.mark.sanity
+@pytest.mark.smoke
 @pytest.mark.nondestructive
 def test_app_category_selector(base_url, selenium):
     page = FirefoxOSPage(base_url, selenium).open()

--- a/tests/functional/firefox/os/version/test_2_5.py
+++ b/tests/functional/firefox/os/version/test_2_5.py
@@ -7,7 +7,7 @@ import pytest
 from pages.firefox.os.version.v2_5 import FirefoxOSPage
 
 
-@pytest.mark.sanity
+@pytest.mark.smoke
 @pytest.mark.nondestructive
 def test_download_buttons_are_displayed(base_url, selenium):
     page = FirefoxOSPage(base_url, selenium).open()

--- a/tests/functional/firefox/os/version/test_all.py
+++ b/tests/functional/firefox/os/version/test_all.py
@@ -9,8 +9,8 @@ from pages.firefox.os.version.all import FirefoxOSBasePage
 
 @pytest.mark.nondestructive
 @pytest.mark.parametrize('version', [
-    pytest.mark.sanity(('2.5')),
-    pytest.mark.sanity(('2.0')),
+    pytest.mark.smoke(('2.5')),
+    pytest.mark.smoke(('2.0')),
     ('1.4'),
     ('1.3t'),
     ('1.3'),
@@ -30,7 +30,7 @@ def test_news_is_displayed(version, base_url, selenium):
 
 @pytest.mark.nondestructive
 @pytest.mark.parametrize('version', [
-    pytest.mark.sanity(('2.0')),
+    pytest.mark.smoke(('2.0')),
     ('1.4'),
     ('1.3t'),
     ('1.3'),

--- a/tests/functional/firefox/test_android.py
+++ b/tests/functional/firefox/test_android.py
@@ -7,7 +7,7 @@ import pytest
 from pages.firefox.android import AndroidPage
 
 
-@pytest.mark.sanity
+@pytest.mark.smoke
 @pytest.mark.nondestructive
 def test_family_navigation(base_url, selenium):
     page = AndroidPage(base_url, selenium).open()
@@ -16,7 +16,7 @@ def test_family_navigation(base_url, selenium):
 
 
 @pytest.mark.skipif(reason='https://webqa-ci.mozilla.com/job/bedrock.dev.win10.ie/120/')
-@pytest.mark.sanity
+@pytest.mark.smoke
 @pytest.mark.nondestructive
 def test_open_close_accordion(base_url, selenium):
     page = AndroidPage(base_url, selenium).open()

--- a/tests/functional/firefox/test_developer.py
+++ b/tests/functional/firefox/test_developer.py
@@ -7,7 +7,7 @@ import pytest
 from pages.firefox.developer import DeveloperPage
 
 
-@pytest.mark.sanity
+@pytest.mark.smoke
 @pytest.mark.nondestructive
 def test_download_buttons_are_displayed(base_url, selenium):
     page = DeveloperPage(base_url, selenium).open()
@@ -16,7 +16,7 @@ def test_download_buttons_are_displayed(base_url, selenium):
 
 
 @pytest.mark.skipif(reason='https://bugzilla.mozilla.org/show_bug.cgi?id=1219251')
-@pytest.mark.sanity
+@pytest.mark.smoke
 @pytest.mark.nondestructive
 def test_play_video(base_url, selenium):
     page = DeveloperPage(base_url, selenium).open()

--- a/tests/functional/firefox/test_do_not_track.py
+++ b/tests/functional/firefox/test_do_not_track.py
@@ -7,7 +7,7 @@ import pytest
 from pages.firefox.do_not_track import DoNotTrackPage
 
 
-@pytest.mark.sanity
+@pytest.mark.smoke
 @pytest.mark.nondestructive
 def test_family_navigation(base_url, selenium):
     page = DoNotTrackPage(base_url, selenium).open()
@@ -15,14 +15,14 @@ def test_family_navigation(base_url, selenium):
     assert page.family_navigation.is_menu_displayed
 
 
-@pytest.mark.sanity
+@pytest.mark.smoke
 @pytest.mark.nondestructive
 def test_dnt_status(base_url, selenium):
     page = DoNotTrackPage(base_url, selenium).open()
     assert page.is_do_not_track_status_displayed
 
 
-@pytest.mark.sanity
+@pytest.mark.smoke
 @pytest.mark.nondestructive
 def test_open_and_close_faq_panel(base_url, selenium):
     page = DoNotTrackPage(base_url, selenium).open()

--- a/tests/functional/firefox/test_new.py
+++ b/tests/functional/firefox/test_new.py
@@ -10,6 +10,7 @@ from pages.firefox.new import FirefoxNewPage, FirefoxNewThankYouPage
 # We don't currently show the download button for up-to-date Firefox users.
 # TODO explore how could we run this test using a known out-of-date Firefox?
 @pytest.mark.skip_if_firefox
+@pytest.mark.smoke
 @pytest.mark.sanity
 @pytest.mark.nondestructive
 def test_click_download_button(base_url, selenium):
@@ -18,6 +19,7 @@ def test_click_download_button(base_url, selenium):
     assert page.is_thank_you_message_displayed
 
 
+@pytest.mark.smoke
 @pytest.mark.sanity
 @pytest.mark.nondestructive
 def test_directly_load_thank_you(base_url, selenium):

--- a/tests/functional/firefox/test_nightly.py
+++ b/tests/functional/firefox/test_nightly.py
@@ -7,7 +7,7 @@ import pytest
 from pages.firefox.nightly import FirstRunPage
 
 
-@pytest.mark.sanity
+@pytest.mark.smoke
 @pytest.mark.nondestructive
 def test_first_run(base_url, selenium):
     page = FirstRunPage(base_url, selenium).open()

--- a/tests/functional/test_home.py
+++ b/tests/functional/test_home.py
@@ -8,7 +8,7 @@ from selenium.common.exceptions import TimeoutException
 from pages.home import HomePage
 
 
-@pytest.mark.sanity
+@pytest.mark.smoke
 @pytest.mark.nondestructive
 def test_promo_grid_is_displayed(base_url, selenium):
     page = HomePage(base_url, selenium).open()
@@ -33,7 +33,7 @@ def test_tweet_is_not_present(base_url, selenium):
     assert not page.is_tweet_promo_present
 
 
-@pytest.mark.sanity
+@pytest.mark.smoke
 @pytest.mark.nondestructive
 def test_download_button_is_displayed(base_url, selenium):
     page = HomePage(base_url, selenium).open()
@@ -49,7 +49,7 @@ def test_upcoming_events_are_displayed(base_url, selenium):
 
 
 @pytest.mark.skipif(reason='https://bugzilla.mozilla.org/show_bug.cgi?id=1214038')
-@pytest.mark.sanity
+@pytest.mark.smoke
 @pytest.mark.nondestructive
 def test_newsletter_default_values(base_url, selenium):
     page = HomePage(base_url, selenium).open()

--- a/tests/functional/test_mission.py
+++ b/tests/functional/test_mission.py
@@ -7,14 +7,14 @@ import pytest
 from pages.mission import MissionPage
 
 
-@pytest.mark.sanity
+@pytest.mark.smoke
 @pytest.mark.nondestructive
 def test_is_mosaic_displayed(base_url, selenium):
     page = MissionPage(base_url, selenium).open()
     assert page.is_mosaic_displayed
 
 
-@pytest.mark.sanity
+@pytest.mark.smoke
 @pytest.mark.nondestructive
 def test_play_video(base_url, selenium):
     page = MissionPage(base_url, selenium).open()
@@ -23,7 +23,7 @@ def test_play_video(base_url, selenium):
     assert page.is_video_displayed
 
 
-@pytest.mark.sanity
+@pytest.mark.smoke
 @pytest.mark.nondestructive
 def test_newsletter_default_values(base_url, selenium):
     page = MissionPage(base_url, selenium).open()

--- a/tests/functional/test_navigation.py
+++ b/tests/functional/test_navigation.py
@@ -24,7 +24,7 @@ def test_navigation(base_url, selenium):
 
 
 @pytest.mark.skipif(reason='https://bugzilla.mozilla.org/show_bug.cgi?id=1214038')
-@pytest.mark.sanity
+@pytest.mark.smoke
 @pytest.mark.nondestructive
 @pytest.mark.viewport('mobile')
 def test_mobile_navigation(base_url, selenium):

--- a/tests/functional/test_newsletter.py
+++ b/tests/functional/test_newsletter.py
@@ -8,7 +8,7 @@ from selenium.common.exceptions import TimeoutException
 from pages.newsletter import NewsletterPage
 
 
-@pytest.mark.sanity
+@pytest.mark.smoke
 @pytest.mark.nondestructive
 def test_default_values(base_url, selenium):
     page = NewsletterPage(base_url, selenium).open()

--- a/tests/functional/test_styleguide.py
+++ b/tests/functional/test_styleguide.py
@@ -8,7 +8,7 @@ from pages.styleguide import StyleGuidePage
 
 
 @pytest.mark.skipif(reason='https://webqa-ci.mozilla.com/job/bedrock.dev.win10.ie/102/')
-@pytest.mark.sanity
+@pytest.mark.smoke
 @pytest.mark.nondestructive
 def test_open_close_navigation(base_url, selenium):
     page = StyleGuidePage(base_url, selenium).open()


### PR DESCRIPTION
This PR changes sanity tests to use `smoke` markers, and leaves the two new `/firefox/new/` tests marked as both `sanity` and `smoke`.