### PR TITLE
Add details of emeritus status for owners and peers

### DIFF
--- a/bedrock/mozorg/templates/mozorg/about/governance/policies/module-ownership.html
+++ b/bedrock/mozorg/templates/mozorg/about/governance/policies/module-ownership.html
@@ -63,4 +63,11 @@
   <h2>{{ _('Poorly Maintained Modules') }}</h2>
   <p>{{ _('Periodically a module is not well maintained and no longer interacts well with the rest of the codebase. This can happen where there is no module owner, or when a designated module owner is too busy with other things to tend to the module. Conceivably it could happen when a module owner is active, but has an approach to a module that the community in general believes is inappropriate. We prefer that the development community identify such modules, propose a solution, and implement improvement. If this can’t happen for some reason then the Module Ownership Peers will get involved to find the best possible resolution.') }}</p>
 </section>
+
+<section>
+  <h2>{{ _('Emeritus Owners and Peers') }}</h2>
+  <p>{{ _('An Emeritus Owner is a former module owner who has handed over ownership to someone new. The ability to develop new leaders is important to health of Mozilla and our mission. It’s also very important to recognize when someone else is the best leader of an area or activity, and then to transfer authority smoothly. This is how we remain robust and relevant as an organization that outlives any one of us. There is a matching status of Emeritus Peer for those who used to be but are no longer peers of a module.') }}</p>
+
+  <p>{{ _('The status of Emeritus Module Owner is a factual status. It is not a qualitative decision about the value of a person’s service as a Module Owner, or about the effectiveness of how ownership of the Module was passed on. Emeritus Module Owners will have varied in their skill in ownership, and in developing and executing a succession plan. When those sort of qualitative understandings are needed then other owners, peers and contributors to the Module should be consulted.') }}</p>
+</section>
 {% endblock %}


### PR DESCRIPTION
Hi,

At Mitchell's request (see mozilla.governance) we've just created a new status of "emeritus owner" or "emeritus peer" for ex module owners. This change documents that.

Gerv