### PR TITLE
Bug 1234166 - Fix typo for broken asset link

### DIFF
--- a/bedrock/styleguide/templates/styleguide/products/firefox-os/icons.html
+++ b/bedrock/styleguide/templates/styleguide/products/firefox-os/icons.html
@@ -212,7 +212,7 @@ as in the following examples.</p>
   <div class="download-group" id="icon-square">
     <p>Icon (square)</p>
     <ul class="button-list">
-      <li><a href="hhttps://assets.mozilla.org/portal/assets/#asset/599" class="button-sand">PSD</a></li>
+      <li><a href="https://assets.mozilla.org/portal/assets/#asset/599" class="button-sand">PSD</a></li>
       <li><a href="https://assets.mozilla.org/portal/assets/#asset/595" class="button-sand">PNG</a></li>
     </ul>
   </div>


### PR DESCRIPTION
Fix for https://bugzilla.mozilla.org/show_bug.cgi?id=1234166