### PR TITLE
Update Firefox OS 2.5 page functional test for news feed

### DIFF
--- a/tests/functional/firefox/os/version/test_all.py
+++ b/tests/functional/firefox/os/version/test_all.py
@@ -22,7 +22,7 @@ def test_family_navigation(version, base_url, selenium):
 
 
 @pytest.mark.nondestructive
-@pytest.mark.parametrize('version', [('2.0'), ('1.4'), ('1.3t'), ('1.3'), ('1.1')])
+@pytest.mark.parametrize('version', [('2.5'), ('2.0'), ('1.4'), ('1.3t'), ('1.3'), ('1.1')])
 def test_news_is_displayed(version, base_url, selenium):
     page = FirefoxOSBasePage(base_url, selenium, version=version).open()
     assert page.is_news_displayed


### PR DESCRIPTION
Adding a test for displaying the news feed, now that #3709 is merged and live.