### PR TITLE
Bug 1226476 - Convert android/all/ to the same format as desktop uses

### DIFF
--- a/bedrock/firefox/templates/firefox/android/all.html
+++ b/bedrock/firefox/templates/firefox/android/all.html
@@ -42,15 +42,15 @@
         <tbody>
           <tr>
             <td>{{ _('android-api-9') }}</td>
-            <td class="download"><a href="https://ftp.mozilla.org/pub/mozilla.org/mobile/releases/latest/android-api-9/">{{ _('Download') }}</a></td>
+            <td class="download"><a href="http://download.mozilla.org/?product=fennec-latest&os=android-api-9&lang=multi">{{ _('Download') }}</a></td>
           </tr>
           <tr>
             <td>{{ _('android-api-11') }}</td>
-            <td class="download"><a href="https://ftp.mozilla.org/pub/mozilla.org/mobile/releases/latest/android-api-11/">{{ _('Download') }}</a></td>
+            <td class="download"><a href="http://download.mozilla.org/?product=fennec-latest&os=android&lang=multi">{{ _('Download') }}</a></td>
           </tr>
           <tr>
             <td>{{ _('android-x86') }}</td>
-            <td class="download"><a href="https://ftp.mozilla.org/pub/mozilla.org/mobile/releases/latest/android-x86/">{{ _('Download') }}</a></td>
+            <td class="download"><a href="http://download.mozilla.org/?product=fennec-latest&os=android-x86&lang=multi">{{ _('Download') }}</a></td>
           </tr>
         </tbody>
       </table>


### PR DESCRIPTION
Replaced old links with bouncer links.