### PR TITLE
Bug #1236432 - Miswording in Windows 10 welcome page

### DIFF
--- a/bedrock/firefox/templates/firefox/win10-welcome.html
+++ b/bedrock/firefox/templates/firefox/win10-welcome.html
@@ -51,7 +51,7 @@
     <button id="set-default" type="button" class="button-flat-dark">{{ _('Let’s do it') }}</button>
     <h2>{{ _('Make Firefox your default in 3 easy steps:') }}</h2>
     <ol>
-      <li>{{ _('Click the button below') }}</li>
+      <li>{{ _('Click the button above') }}</li>
       <li>{{ _('Scroll down to “Web browser”') }}</li>
       <li>{{ _('Choose Firefox') }}</li>
     </ol>

--- a/bedrock/firefox/templates/firefox/win10-welcome.html
+++ b/bedrock/firefox/templates/firefox/win10-welcome.html
@@ -51,7 +51,11 @@
     <button id="set-default" type="button" class="button-flat-dark">{{ _('Let’s do it') }}</button>
     <h2>{{ _('Make Firefox your default in 3 easy steps:') }}</h2>
     <ol>
-      <li>{{ _('Click the button above') }}</li>
+      {% if l10n_has_tag('win10_button_update') %}
+        <li>{{ _('Click the button above') }}</li>
+      {% else %}
+        <li>{{ _('Click the button below') }}</li>
+      {% endif %}
       <li>{{ _('Scroll down to “Web browser”') }}</li>
       <li>{{ _('Choose Firefox') }}</li>
     </ol>


### PR DESCRIPTION
As reported by @darchons . The button is located above the text "Click the button below"

Here's the fix for the typo.