### PR TITLE
Change caldata and font cache headers to one week

### DIFF
--- a/bedrock/base/static.py
+++ b/bedrock/base/static.py
@@ -7,7 +7,7 @@ from whitenoise.django import DjangoWhiteNoise
 
 class BedrockWhiteNoise(DjangoWhiteNoise):
     """WhiteNoise class for modifying default cache headers."""
-    ONE_MONTH = 30 * 24 * 60 * 60
+    ONE_WEEK = 7 * 24 * 60 * 60
 
     def __init__(self, application):
         super(BedrockWhiteNoise, self).__init__(application)
@@ -23,7 +23,7 @@ class BedrockWhiteNoise(DjangoWhiteNoise):
             max_age = self.FOREVER
         # files typically accessed not by hashed name
         elif '/fonts/' in url or '/caldata/' in url:
-            max_age = self.ONE_MONTH
+            max_age = self.ONE_WEEK
         else:
             max_age = self.max_age
         if max_age is not None:

--- a/bedrock/base/tests/test_static.py
+++ b/bedrock/base/tests/test_static.py
@@ -21,19 +21,19 @@ class TestBedrockWhiteNoise(TestCase):
             static_file = Mock(headers={})
             self.wn.add_cache_headers(static_file, 'media/fonts/dude.txt')
             self.assertTrue(static_file.headers['Cache-Control'].endswith(
-                'max-age={}'.format(self.wn.ONE_MONTH)))
+                'max-age={}'.format(self.wn.ONE_WEEK)))
 
     def test_caldata_files(self):
         with patch.object(self.wn, 'is_immutable_file', return_value=False):
             static_file = Mock(headers={})
             self.wn.add_cache_headers(static_file, 'media/caldata/ThaiHolidays.ics')
             self.assertTrue(static_file.headers['Cache-Control'].endswith(
-                'max-age={}'.format(self.wn.ONE_MONTH)))
+                'max-age={}'.format(self.wn.ONE_WEEK)))
 
             # also at alternate path
             self.wn.add_cache_headers(static_file, 'project/calendar/caldata/ThaiHolidays.ics')
             self.assertTrue(static_file.headers['Cache-Control'].endswith(
-                'max-age={}'.format(self.wn.ONE_MONTH)))
+                'max-age={}'.format(self.wn.ONE_WEEK)))
 
     def test_immutable_font_files(self):
         with patch.object(self.wn, 'is_immutable_file', return_value=True):


### PR DESCRIPTION
The previous timeout of one month was a bit much and caused a problem with a holiday calendar update.