### PR TITLE
Add download link checks

### DIFF
--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -46,12 +46,12 @@ following command:
 See the `Jasmine`_ documentation for tips on how to write JS behavioral or unit
 tests. We also use `Sinon`_ for creating test spies, stubs and mocks.
 
-Running Selenium tests
-----------------------
+Running functional tests
+------------------------
 
 .. Note::
 
-  Before running the Selenium tests, please make sure to follow the bedrock
+  Before running the functional tests, please make sure to follow the bedrock
   :ref:`installation docs<install>`, including the database sync that is needed
   to pull in external data such as event/blog feeds etc. These are required for
   some of the tests to pass.
@@ -64,17 +64,21 @@ To run the full functional test suite against your local bedrock instance:
 
 This will run all test suites found in the ``tests/functional`` directory and
 assumes you have bedrock running at ``localhost`` on port ``8000``. Results will
-be reported in ``tests/functional/results.html`` and tests will run in parallel
-according to the number of cores available.
+be reported in ``tests/functional/results.html``.
+
+By default, tests will run one at a time. This is the safest way to ensure
+predictable results, due to
+`bug 1230105 <https://bugzilla.mozilla.org/show_bug.cgi?id=1230105>`_.
+If you want to run tests in parallel (this should be safe when running against
+a deployed instance), you can add ``-n auto`` to the command line. Replace
+``auto`` with an integer if you want to set the maximum number of concurrent
+processes.
 
 .. Note::
 
-    Tests will run one at a time. This is the safest way to ensure predictable
-    results, due to `bug 1230105 <https://bugzilla.mozilla.org/show_bug.cgi?id=1230105>`_.
-    If you want to run tests in parallel (this should be safe when running
-    against a deployed instance), you can add ``-n auto`` to the command line.
-    Replace ``auto`` with an integer if you want to set the maximum number of
-    concurrent processes.
+    There are some functional tests that do not require a browser. These can
+    take a long time to run, especially if they're not running in parallel.
+    To skip these tests, add ``-m 'not headless'`` to your command line.
 
 To run a single test file you must tell py.test to execute a specific file
 e.g. ``tests/functional/test_newsletter.py``:

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -2,6 +2,11 @@
 # sha256: ZdKqaLKOfTEjO7K6jrMc2kDkZx-KwtayQeNYyWUqdLk
 apipkg==1.4
 
+# sha256: gqJTJFrtmHXxQd2Yp0YlcrypPQZM8xF70z3kth7hjmg
+# sha256: LCZCVPbPzmTDvZ1IiFIICTpzuQlWRfYA3gonfOAeoOU
+# sha256: h9QBPQYl1HiaT1a415oE1c5tsRUrtl8dOXRPdwmjZrQ
+beautifulsoup4==4.4.1
+
 # sha256: 9m3Up1GXJaG34UrZrn09-OCbLaiAYjhuCOlByvwO8-Y
 # sha256: 0rkJx5RYMuHBnPrNlueNpova3GVkQM_H3-WbdmdE64w
 execnet==1.4.1

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -15,16 +15,23 @@ def capabilities(capabilities):
     return capabilities
 
 
+@pytest.fixture
+def firefox(selenium):
+    return selenium.capabilities.get('browserName').lower() == 'firefox'
+
+
+@pytest.fixture
+def internet_explorer(selenium):
+    return selenium.capabilities.get('browserName').lower() == 'internet explorer'
+
+
 @pytest.fixture(autouse=True)
-def filter_capabilities(request, selenium):
-    capabilities = selenium.capabilities
-    firefox = capabilities.get('browserName').lower() == 'firefox'
-    internet_explorer = capabilities.get('browserName').lower() == 'internet explorer'
-    if firefox and 'skip_if_firefox' in request.keywords:
+def filter_capabilities(request):
+    if request.node.get_marker('skip_if_firefox') and request.getfuncargvalue('firefox'):
         pytest.skip('Test must not be run on Firefox')
-    if not firefox and 'skip_if_not_firefox' in request.keywords:
+    if request.node.get_marker('skip_if_not_firefox') and not request.getfuncargvalue('firefox'):
         pytest.skip('Test must only be run on Firefox')
-    if internet_explorer and 'skip_if_internet_explorer' in request.keywords:
+    if request.node.get_marker('skip_if_internet_explorer') and request.getfuncargvalue('internet_explorer'):
         pytest.skip('Test must not be run on Internet Explorer')
 
 

--- a/tests/functional/test_download.py
+++ b/tests/functional/test_download.py
@@ -1,0 +1,27 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from bs4 import BeautifulSoup
+import pytest
+import requests
+
+
+def pytest_generate_tests(metafunc):
+    paths = (
+        '/firefox/new/',
+        '/thunderbird/')
+    argvalues = []
+    for path in paths:
+        r = requests.get(metafunc.config.option.base_url + path)
+        soup = BeautifulSoup(r.content, 'html.parser')
+        urls = [a['href'] for a in soup.find('ul', class_='download-list').find_all('a')]
+        assert len(urls) > 0
+        argvalues.extend(urls)
+    metafunc.parametrize('url', argvalues)
+
+
+@pytest.mark.headless
+def test_download_links(url):
+    r = requests.head(url, allow_redirects=True)
+    assert requests.codes.ok == r.status_code

--- a/tests/functional/test_download_l10n.py
+++ b/tests/functional/test_download_l10n.py
@@ -1,0 +1,33 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from bs4 import BeautifulSoup
+import pytest
+import requests
+
+
+def pytest_generate_tests(metafunc):
+    paths = (
+        '/firefox/all/',
+        '/firefox/beta/all/',
+        '/firefox/developer/all/',
+        '/firefox/organizations/all/',
+        '/thunderbird/all/',
+        '/thunderbird/beta/all/',
+        '/thunderbird/earlybird/all/')
+    argvalues = []
+    for path in paths:
+        r = requests.get(metafunc.config.option.base_url + path)
+        soup = BeautifulSoup(r.content, 'html.parser')
+        table = soup.find('table', class_='build-table')
+        urls = [a['href'] for a in table.find_all('a')]
+        assert len(urls) > 0
+        argvalues.extend(urls)
+    metafunc.parametrize('url', argvalues)
+
+
+@pytest.mark.headless
+def test_localized_download_links(url):
+    r = requests.head(url, allow_redirects=True)
+    assert requests.codes.ok == r.status_code


### PR DESCRIPTION
I'm concerned that if the LinkChecker download jobs failed to find the download links that they could give false confidence that these are not broken. We saw an issue recently where a conditional CSS block caused the LinkChecker to abort early, and the result was success. These tests are an improved version of those in mcom-tests, in that they now check the response code for all platforms and all locales (over 2,300 URLs).

I have not included the 'smoke' marker so these will not be run by the pipeline at this time. I have added a new 'headless' marker, which will allow us to isolate these tests, or to exclude them. It does not make sense, for example, to run these for multiple platforms as we would with the other functional tests.

I suggest replacing the LinkChecker download jobs in the pipeline with these new tests. Having these in the repository also makes it much easy to update the URLs of the download pages that we're testing. We can also add more asserts for these links if any come to mind.

I'm keen to hear your feedback, @alexgibson