### PR TITLE
Default GIT_COMMIT to HEAD running tests

### DIFF
--- a/docker/jenkins/run_functional_tests.sh
+++ b/docker/jenkins/run_functional_tests.sh
@@ -7,6 +7,7 @@
 set -xe
 
 SELENIUM_VERSION=${SELENIUM_VERSION:-2.48.2}
+GIT_COMMIT=${GIT_COMMIT:-$(git rev-parse HEAD)}
 
 cp docker/dockerfiles/bedrock_functional_tests Dockerfile
 docker build -t bedrock_functional_tests:$GIT_COMMIT --pull=true .

--- a/docker/jenkins/run_linkchecker.sh
+++ b/docker/jenkins/run_linkchecker.sh
@@ -1,4 +1,5 @@
 #!/bin/bash -xe
+GIT_COMMIT=${GIT_COMMIT:-$(git rev-parse HEAD)}
 cp docker/dockerfiles/bedrock_linkchecker Dockerfile
 docker build -t bedrock_linkchecker:${GIT_COMMIT} --pull=true .
 docker run -v `pwd`/results:/results -e URLS="${URLS}" -e THREADS=${THREADS} -e RECURSION_LEVEL=${RECURSION_LEVEL} -e CHECK_EXTERNAL=${CHECK_EXTERNAL} -e VERBOSE=${VERBOSE} bedrock_linkchecker:${GIT_COMMIT}

--- a/docker/jenkins/run_tests.sh
+++ b/docker/jenkins/run_tests.sh
@@ -12,4 +12,4 @@ SECRET_KEY=39114b6a-2858-4caf-8878-482a24ee9542
 ADMINS=["thedude@example.com"]
 EOF
 
-docker run --env-file $ENV_FILE ${DOCKER_REPOSITORY}:${GIT_COMMIT} ./manage.py test
+docker run --env-file $ENV_FILE ${DOCKER_REPOSITORY}:${GIT_COMMIT:-$(git rev-parse HEAD)} ./manage.py test


### PR DESCRIPTION
This is mainly to make things more convenient when running locally.