### PR TITLE
Remove unused button URL

### DIFF
--- a/bedrock/mozorg/urls.py
+++ b/bedrock/mozorg/urls.py
@@ -32,7 +32,6 @@ urlpatterns = (
     # Bug 981063, catch all for old calendar urls.
     # must be here to avoid overriding the above
     redirect(r'^projects/calendar/', 'mozorg.projects.calendar', locale_prefix=False),
-    page('button', 'mozorg/button.html'),
     page('mission', 'mozorg/mission.html'),
     page('ITU', 'mozorg/itu.html'),
     page('about/powered-by', 'mozorg/powered-by.html'),


### PR DESCRIPTION
`mozorg/button.html` was removed in d8921e105bb6a77ebc2654dbcb2bf876b7244e43 but `mozorg/urls.py` still has the URL which is 404. This PR will simply remove it. No bug.