### PR TITLE
Add tests for partnerships page

### DIFF
--- a/tests/functional/test_partnerships.py
+++ b/tests/functional/test_partnerships.py
@@ -1,0 +1,25 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import pytest
+from selenium.common.exceptions import TimeoutException
+
+from pages.partnerships import PartnershipsPage
+
+
+def test_request_partnership(base_url, selenium):
+    page = PartnershipsPage(base_url, selenium).open()
+    page.type_first_name('Automated')
+    page.type_last_name('Test')
+    page.type_company('Mozilla')
+    page.type_email('noreply@mozilla.com')
+    page.submit_request()
+    assert page.request_successful
+
+
+@pytest.mark.nondestructive
+def test_request_fails_when_missing_required_fields(base_url, selenium):
+    page = PartnershipsPage(base_url, selenium).open()
+    with pytest.raises(TimeoutException):
+        page.submit_request()

--- a/tests/pages/partnerships.py
+++ b/tests/pages/partnerships.py
@@ -1,0 +1,39 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from selenium.webdriver.common.by import By
+
+from base import BasePage
+
+
+class PartnershipsPage(BasePage):
+
+    _url = '{base_url}/{locale}/about/partnerships'
+
+    _first_name_locator = (By.ID, 'first_name')
+    _last_name_locator = (By.ID, 'last_name')
+    _company_locator = (By.ID, 'company')
+    _email_locator = (By.ID, 'email')
+    _submit_request_locator = (By.ID, 'sf-form-submit')
+    _thank_you_locator = (By.ID, 'partner-form-success')
+
+    def type_first_name(self, value):
+        self.find_element(self._first_name_locator).send_keys(value)
+
+    def type_last_name(self, value):
+        self.find_element(self._last_name_locator).send_keys(value)
+
+    def type_company(self, value):
+        self.find_element(self._company_locator).send_keys(value)
+
+    def type_email(self, value):
+        self.find_element(self._email_locator).send_keys(value)
+
+    def submit_request(self):
+        self.find_element(self._submit_request_locator).click()
+        self.wait.until(lambda s: self.request_successful)
+
+    @property
+    def request_successful(self):
+        return self.is_element_displayed(self._thank_you_locator)


### PR DESCRIPTION
Simply happy path test for requesting a partnership and a negative test when required fields are missing. This replaces the test in [mcom-tests](https://github.com/mozilla/mcom-tests/blob/56382844fe28c27d285c3aecb7614e31bdf4dd39/tests/test_partnerships.py), which only checked visibility of elements. It may be worth later adding interactions with more form fields, or adding tests for any field validation such as e-mail and website.

@alexgibson r?