### PR TITLE
[fix bug 1239732] Developer page shows both Desktop and Android downoad buttons on IE6

### DIFF
--- a/bedrock/firefox/templates/firefox/developer.html
+++ b/bedrock/firefox/templates/firefox/developer.html
@@ -40,7 +40,7 @@
 
   <h1>{{ _('Built for those who build the Web') }}</h1>
   <h2>{{ _('The only browser made for developers like you.') }}</h2>
-  {{ download_firefox('alpha', icon=False, small=True, simple=True) }}
+  {{ download_firefox('alpha', platform='desktop', icon=False, small=True, simple=True) }}
 
   <p class="feedback-note">
     {{ _('Firefox Developer Edition automatically sends feedback to Mozilla.') }}
@@ -228,7 +228,7 @@
   <div class="container">
     <div class="dev-footer-download">
       <h3>{{ _('Choose Firefox') }}</h3>
-      {{ download_firefox('alpha', icon=False, small=True, simple=True) }}
+      {{ download_firefox('alpha', platform='desktop', icon=False, small=True, simple=True) }}
     </div>
     {# See Bug 1095176 #}
     {% if LANG.startswith('en-') %}

--- a/bedrock/firefox/templates/firefox/installer-help.html
+++ b/bedrock/firefox/templates/firefox/installer-help.html
@@ -67,7 +67,7 @@
       </div>
 
       <div class="download-box" id="aurora-desktop">
-        {{ download_firefox('alpha', small=True, force_direct=True, force_full_installer=True, icon=False, locale=installer_lang) }}
+        {{ download_firefox('alpha', platform='desktop', small=True, force_direct=True, force_full_installer=True, icon=False, locale=installer_lang) }}
       </div>
     {% endif %}
   </div>

--- a/bedrock/firefox/tests/test_base.py
+++ b/bedrock/firefox/tests/test_base.py
@@ -57,7 +57,7 @@ class TestInstallerHelp(TestCase):
             call('beta', small=ANY, force_direct=True,
                  force_full_installer=True, icon=ANY, locale='fr'),
             call('alpha', small=ANY, force_direct=True,
-                 force_full_installer=True, icon=ANY, locale='fr'),
+                 force_full_installer=True, icon=ANY, locale='fr', platform='desktop'),
         ])
 
     def test_buttons_ignore_non_lang(self):
@@ -72,7 +72,7 @@ class TestInstallerHelp(TestCase):
             call('beta', small=ANY, force_direct=True,
                  force_full_installer=True, icon=ANY, locale=None),
             call('alpha', small=ANY, force_direct=True,
-                 force_full_installer=True, icon=ANY, locale=None),
+                 force_full_installer=True, icon=ANY, locale=None, platform='desktop'),
         ])
 
     def test_invalid_channel_specified(self):
@@ -87,7 +87,7 @@ class TestInstallerHelp(TestCase):
             call('beta', small=ANY, force_direct=True,
                  force_full_installer=True, icon=ANY, locale=None),
             call('alpha', small=ANY, force_direct=True,
-                 force_full_installer=True, icon=ANY, locale=None),
+                 force_full_installer=True, icon=ANY, locale=None, platform='desktop'),
         ])
 
     def test_one_button_when_channel_specified(self):


### PR DESCRIPTION
Note: Dev Edition downloads are currently 404 on XP, but hopefully that will be fixed very shortly in [bug 1239685](https://bugzilla.mozilla.org/show_bug.cgi?id=1239685)