### PR TITLE
Use Firefox latest ESR to run JS tests in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,4 +40,4 @@ notifications:
     on_failure: always
     use_notice: true
 addons:
-  firefox: "35.0"
+  firefox: "latest-esr"


### PR DESCRIPTION
Puts us onto a rolling FF version for running the JS tests in PR's, while still ensuring some level of legacy coverage.