### PR TITLE
[fix bug 1233773] TP UITour should close tab when not invoked from Private Window

### DIFF
--- a/docs/uitour.rst
+++ b/docs/uitour.rst
@@ -638,6 +638,21 @@ Accepts one of the following options to be passed as an `id`:
 
     Only available in Firefox 42 onward.
 
+closeTab();
+^^^^^^^^^^^
+
+Closes the current tab.
+
+.. code-block:: javascript
+
+    Mozilla.UITour.closeTab();
+
+.. Important::
+
+    This function will do nothing when called from the last browser window when it contains
+    only one tab. You may need to provide a work around for this edge case in your code.
+    This function is also only available in Firefox 46 onward.
+
 .. _Mozilla Central: http://dxr.mozilla.org/mozilla-central/source/browser/components/uitour/UITour-lib.js
 .. _Telemetry: https://wiki.mozilla.org/Telemetry
 .. _FHR: https://support.mozilla.org/en-US/kb/firefox-health-report-understand-your-browser-perf

--- a/media/js/firefox/australis/australis-uitour.js
+++ b/media/js/firefox/australis/australis-uitour.js
@@ -260,4 +260,8 @@ if (typeof Mozilla == 'undefined') {
 		});
 	};
 
+    Mozilla.UITour.closeTab = function() {
+        _sendEvent('closeTab');
+    };
+
 })();

--- a/media/js/firefox/tracking-protection-tour.js
+++ b/media/js/firefox/tracking-protection-tour.js
@@ -72,14 +72,14 @@ if (typeof Mozilla === 'undefined') {
                 style: 'text',
             },
             {
-                callback: TPTour.step4,
+                callback: TPTour.shouldCloseTab,
                 label: _step3.buttonText,
                 style: 'primary',
             },
         ];
 
         var options = {
-            closeButtonCallback: TPTour.step4
+            closeButtonCallback: TPTour.shouldCloseTab
         };
 
         Mozilla.UITour.showMenu('controlCenter', function() {
@@ -96,6 +96,27 @@ if (typeof Mozilla === 'undefined') {
 
         TPTour.replaceURLState('3');
         TPTour.state = 'step3';
+    };
+
+    TPTour.shouldCloseTab = function() {
+        var newTab = TPTour.getParameterByName('newtab');
+
+        if (newTab === 'true') {
+            TPTour.tryCloseTab();
+        } else {
+            TPTour.step4();
+        }
+    };
+
+    /**
+     * Mozilla.UITour.closeTab will only work if there is more than one open tab
+     * in the browser window, so we fall back to showing step 4 of the tour
+     * after a short delay.
+     */
+    TPTour.tryCloseTab = function() {
+        setTimeout(TPTour.step4, 400);
+        TPTour.hidePanels();
+        Mozilla.UITour.closeTab();
     };
 
     TPTour.step4 = function() {


### PR DESCRIPTION
setup
-------

* This needs testing using the latest Nightly, at least `46.0a1 (2016-01-17)`.
* Please make sure set Tracking Protection to `Always` in `about:preferences#privacy` (not just in Private Browsing mode).
* Make sure you have [UITour working locally](http://bedrock.readthedocs.org/en/latest/uitour.html#local-development).

URL to test locally: `/firefox/46.01a/tracking-protection/start/?newtab=true`

To test behavior 1:

1.) Open a new tab (make sure you have more than one tab open).
2.) When you get to step 3 of the tour, click "Got it".
Expected result: The tab should close.

To test behavior 2:

1.) Open a single tab (the tour URL being the only tab in the active window).
2.) When you get to step 3 of the tour, click "Got it".
Expected result: Step 4 should be shown

Extra test for good measure:

Load the URL without `?newtab=true`.
Expected result: Step 4 should always be shown.
