### PR TITLE
Add functional test for Firefox Installer Help page

### DIFF
--- a/tests/functional/firefox/test_developer.py
+++ b/tests/functional/firefox/test_developer.py
@@ -7,6 +7,7 @@ import pytest
 from pages.firefox.developer import DeveloperPage
 
 
+@pytest.mark.sanity
 @pytest.mark.smoke
 @pytest.mark.nondestructive
 def test_download_buttons_are_displayed(base_url, selenium):

--- a/tests/functional/firefox/test_installer_help.py
+++ b/tests/functional/firefox/test_installer_help.py
@@ -1,0 +1,17 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import pytest
+
+from pages.firefox.installer_help import InstallerHelpPage
+
+
+@pytest.mark.smoke
+@pytest.mark.sanity
+@pytest.mark.nondestructive
+def test_download_buttons_displayed(base_url, selenium):
+    page = InstallerHelpPage(base_url, selenium).open()
+    assert page.is_firefox_download_button_displayed
+    assert page.is_beta_download_button_displayed
+    assert page.is_dev_edition_download_button_displayed

--- a/tests/pages/base.py
+++ b/tests/pages/base.py
@@ -34,6 +34,15 @@ class BasePage(Page):
     def newsletter(self):
         return NewsletterEmbedForm(self)
 
+    def download_button(self, locator):
+        """Return the displayed download button link determined by platform.
+
+        Only for use by page objects and not directly from tests.
+        """
+        els = [el for el in self.find_elements(locator) if el.is_displayed()]
+        assert len(els) == 1, 'Expected one download button to be displayed'
+        return els[0]
+
     class Navigation(PageRegion):
 
         _root_locator = (By.ID, 'nav-main')

--- a/tests/pages/firefox/developer.py
+++ b/tests/pages/firefox/developer.py
@@ -13,17 +13,17 @@ class DeveloperPage(FirefoxBasePage):
 
     _url = '{base_url}/{locale}/firefox/developer'
 
-    _primary_download_locator = (By.CSS_SELECTOR, '.intro .download-button')
-    _secondary_download_locator = (By.CSS_SELECTOR, '.dev-footer-download .download-button')
+    _primary_download_locator = (By.CSS_SELECTOR, '.intro .download-button .download-link')
+    _secondary_download_locator = (By.CSS_SELECTOR, '.dev-footer-download .download-button .download-link')
     _videos_locator = (By.CSS_SELECTOR, '.features > .feature > .video-play')
 
     @property
     def is_primary_download_button_displayed(self):
-        return self.is_element_displayed(self._primary_download_locator)
+        return self.download_button(self._primary_download_locator).is_displayed()
 
     @property
     def is_secondary_download_button_displayed(self):
-        return self.is_element_displayed(self._secondary_download_locator)
+        return self.download_button(self._secondary_download_locator).is_displayed()
 
     @property
     def developer_videos(self):

--- a/tests/pages/firefox/hello.py
+++ b/tests/pages/firefox/hello.py
@@ -14,7 +14,7 @@ class HelloPage(FirefoxBasePage):
 
     _video_locator = (By.ID, 'video-link')
     _try_hello_button_locator = (By.ID, 'try-hello-footer')
-    _download_button_locator = (By.ID, 'download-fx')
+    _download_button_locator = (By.CSS_SELECTOR, '#download-fx .download-link')
 
     @property
     def is_try_hello_button_displayed(self):
@@ -22,7 +22,7 @@ class HelloPage(FirefoxBasePage):
 
     @property
     def is_download_button_displayed(self):
-        return self.is_element_displayed(self._download_button_locator)
+        return self.download_button(self._download_button_locator).is_displayed()
 
     def play_video(self):
         modal = Modal(self)

--- a/tests/pages/firefox/installer_help.py
+++ b/tests/pages/firefox/installer_help.py
@@ -1,0 +1,28 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from selenium.webdriver.common.by import By
+
+from pages.firefox.base import FirefoxBasePage
+
+
+class InstallerHelpPage(FirefoxBasePage):
+
+    _url = '{base_url}/{locale}/firefox/installer-help'
+
+    _firefox_download_button_locator = (By.CSS_SELECTOR, '#download-button-desktop-release .download-link')
+    _beta_download_button_locator = (By.CSS_SELECTOR, '#download-button-desktop-beta .download-link')
+    _dev_edition_download_button_locator = (By.CSS_SELECTOR, '#download-button-desktop-alpha .download-link')
+
+    @property
+    def is_firefox_download_button_displayed(self):
+        return self.download_button(self._firefox_download_button_locator).is_displayed()
+
+    @property
+    def is_beta_download_button_displayed(self):
+        return self.download_button(self._beta_download_button_locator).is_displayed()
+
+    @property
+    def is_dev_edition_download_button_displayed(self):
+        return self.download_button(self._dev_edition_download_button_locator).is_displayed()

--- a/tests/pages/firefox/new.py
+++ b/tests/pages/firefox/new.py
@@ -15,17 +15,11 @@ class FirefoxNewPage(FirefoxBasePage):
     _thank_you_message_locator = (By.ID, 'scene2-main')
 
     @property
-    def _download_button(self):
-        els = [el for el in self.find_elements(self._download_button_locator) if el.is_displayed()]
-        assert len(els) == 1, 'Expected one download button to be displayed'
-        return els[0]
-
-    @property
     def is_download_button_displayed(self):
-        return self._download_button.is_displayed()
+        return self.download_button(self._download_button_locator).is_displayed()
 
     def download_firefox(self):
-        self._download_button.click()
+        self.download_button(self._download_button_locator).click()
         self.wait.until(lambda s: self.is_thank_you_message_displayed)
 
     @property

--- a/tests/pages/firefox/sync.py
+++ b/tests/pages/firefox/sync.py
@@ -11,13 +11,13 @@ class FirefoxSyncPage(FirefoxBasePage):
 
     _url = '{base_url}/{locale}/firefox/sync'
 
-    _primary_download_button_locator = (By.ID, 'download-button-desktop-release')
+    _primary_download_button_locator = (By.CSS_SELECTOR, '#download-button-desktop-release .download-link')
     _play_store_button_locator = (By.ID, 'cta-android-footer')
     _app_store_button_locator = (By.ID, 'cta-ios-footer')
 
     @property
     def is_primary_download_button_displayed(self):
-        return self.is_element_displayed(self._primary_download_button_locator)
+        return self.download_button(self._primary_download_button_locator).is_displayed()
 
     @property
     def is_play_store_button_displayed(self):

--- a/tests/pages/home.py
+++ b/tests/pages/home.py
@@ -14,7 +14,7 @@ class HomePage(BasePage):
     _promo_grid_locator = (By.CSS_SELECTOR, '.promo-grid.reveal')
     _promo_tile_locator = (By.CSS_SELECTOR, '.promo-grid > .item')
     _promo_tweet_locator = (By.ID, 'twt-body')
-    _download_button_locator = (By.ID, 'download-button-desktop-release')
+    _download_button_locator = (By.CSS_SELECTOR, '#download-button-desktop-release .download-link')
 
     @property
     def is_promo_grid_displayed(self):
@@ -31,7 +31,7 @@ class HomePage(BasePage):
 
     @property
     def is_download_button_displayed(self):
-        return self.is_element_displayed(self._download_button_locator)
+        return self.download_button(self._download_button_locator).is_displayed()
 
     @property
     def upcoming_events(self):

--- a/tests/pages/thunderbird/channel.py
+++ b/tests/pages/thunderbird/channel.py
@@ -11,13 +11,13 @@ class ThunderbirdChannelPage(BasePage):
 
     _url = '{base_url}/{locale}/thunderbird/channel'
 
-    _earlybird_download_button_locator = (By.ID, 'download-button-desktop-alpha')
-    _beta_download_button_locator = (By.ID, 'download-button-desktop-beta')
+    _earlybird_download_button_locator = (By.CSS_SELECTOR, '#download-button-desktop-alpha .download-link')
+    _beta_download_button_locator = (By.CSS_SELECTOR, '#download-button-desktop-beta .download-link')
 
     @property
     def is_beta_download_button_displayed(self):
-        return self.is_element_displayed(self._beta_download_button_locator)
+        return self.download_button(self._beta_download_button_locator).is_displayed()
 
     @property
     def is_earlybird_download_button_displayed(self):
-        return self.is_element_displayed(self._earlybird_download_button_locator)
+        return self.download_button(self._earlybird_download_button_locator).is_displayed()

--- a/tests/pages/thunderbird/thunderbird.py
+++ b/tests/pages/thunderbird/thunderbird.py
@@ -11,8 +11,8 @@ class ThunderbirdPage(BasePage):
 
     _url = '{base_url}/{locale}/thunderbird'
 
-    _download_button_locator = (By.ID, 'download-button-desktop-release')
+    _download_button_locator = (By.CSS_SELECTOR, '#download-button-desktop-release .download-link')
 
     @property
     def is_download_button_displayed(self):
-        return self.is_element_displayed(self._download_button_locator)
+        return self.download_button(self._download_button_locator).is_displayed()


### PR DESCRIPTION
Also makes our download button display tests a bit more robust, by ensuring only one download button is displayed (useful for catching visual regressions like in #3782).