### PR TITLE
[bug 1236045] Update Earlybird FTP directory to use latest-comm-aurora

### DIFF
--- a/bedrock/thunderbird/details.py
+++ b/bedrock/thunderbird/details.py
@@ -158,7 +158,7 @@ class ThunderbirdDesktop(ProductDetails):
 
         # Point the FTP server for Earlybird
         if channel == 'alpha':
-            return '%snightly/latest-earlybird%s/thunderbird-%s.%s.%s' % (
+            return '%snightly/latest-comm-aurora%s/thunderbird-%s.%s.%s' % (
                 self.download_base_url_ftp,
                 '' if locale == 'en-US' else '-l10n',
                 _version, _locale, self.file_suffixes[platform])


### PR DESCRIPTION
See this [bug for discussion](https://bugzilla.mozilla.org/show_bug.cgi?id=1236045). This PR points to use the new FTP directory for Earlybird, but the l10n builds are still missing.

This should at least fix the download on the `thunderbird/channel` page for en-US.