### PR TITLE
Fix intermittent failure in Android form submission test

### DIFF
--- a/tests/pages/firefox/android.py
+++ b/tests/pages/firefox/android.py
@@ -5,6 +5,7 @@
 from selenium.webdriver.common.by import By
 
 from pages.firefox.base import FirefoxBasePage, FirefoxBasePageRegion
+from pages.regions.send_to_device import SendToDevice
 
 
 class AndroidPage(FirefoxBasePage):
@@ -15,6 +16,10 @@ class AndroidPage(FirefoxBasePage):
     _next_button_locator = (By.ID, 'customize-next')
     _previous_button_locator = (By.ID, 'customize-prev')
     _play_store_button_locator = (By.CSS_SELECTOR, '#intro .dl-button')
+
+    @property
+    def send_to_device(self):
+        return SendToDevice(self)
 
     @property
     def customize_sections(self):

--- a/tests/pages/firefox/base.py
+++ b/tests/pages/firefox/base.py
@@ -18,10 +18,6 @@ class FirefoxBasePage(BasePage):
     def family_navigation(self):
         return self.FamilyNavigation(self)
 
-    @property
-    def send_to_device(self):
-        return self.SendToDevice(self)
-
     def scroll_element_into_view(self, locator):
         return super(FirefoxBasePage, self).scroll_element_into_view(
             locator, y=HEADER_OFFSET)
@@ -39,29 +35,6 @@ class FirefoxBasePage(BasePage):
         @property
         def is_menu_displayed(self):
             return self.is_element_displayed(self._nav_menu_locator)
-
-    class SendToDevice(PageRegion):
-
-        _root_locator = (By.ID, 'send-to-device')
-        _email_locator = (By.ID, 'id-input')
-        _submit_button_locator = (By.CSS_SELECTOR, '.form-submit > button')
-        _thank_you_locator = (By.CSS_SELECTOR, '.thank-you')
-
-        def type_email(self, value):
-            self.find_element(self._email_locator).send_keys(value)
-
-        def click_send(self):
-            self.find_element(self._submit_button_locator).click()
-            self.wait.until(expected.visibility_of_element_located(self._thank_you_locator))
-
-        @property
-        def send_successful(self):
-            el = self.selenium.find_element(*self._thank_you_locator)
-            return el.is_displayed()
-
-        @property
-        def is_displayed(self):
-            return self.is_element_displayed(self._root_locator)
 
 
 class FirefoxBasePageRegion(PageRegion):

--- a/tests/pages/regions/send_to_device.py
+++ b/tests/pages/regions/send_to_device.py
@@ -1,0 +1,32 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support import expected_conditions as expected
+
+from pages.firefox.base import FirefoxBasePageRegion
+
+
+class SendToDevice(FirefoxBasePageRegion):
+
+    _root_locator = (By.ID, 'send-to-device')
+    _email_locator = (By.ID, 'id-input')
+    _submit_button_locator = (By.CSS_SELECTOR, '.form-submit > button')
+    _thank_you_locator = (By.CSS_SELECTOR, '.thank-you')
+
+    def type_email(self, value):
+        self.find_element(self._email_locator).send_keys(value)
+
+    def click_send(self):
+        self.scroll_element_into_view(self._submit_button_locator).click()
+        self.wait.until(expected.visibility_of_element_located(self._thank_you_locator))
+
+    @property
+    def send_successful(self):
+        el = self.selenium.find_element(*self._thank_you_locator)
+        return el.is_displayed()
+
+    @property
+    def is_displayed(self):
+        return self.is_element_displayed(self._root_locator)


### PR DESCRIPTION
@davehunt r?

Looking at the sauce job here it seems IE sometimes triggers a scroll when filling in the form, preventing the submit button from being clicked due to the sticky header. Seen this intermittent a couple of times now.

http://saucelabs.com/jobs/34351f809d864d92acb92918ac205786

This change moves `SendToDevice` into it's own file in `pages.regions`, which I think makes sense as we don't include it in all our Firefox base pages. It also now inherits `FirefoxBasePageRegion` and calls `scroll_element_into_view` before clicking submit, which should hopefully fix the intermittent.