### PR TITLE
Fix Bug 1243240 - Legal would like to have some updates made to https://www.mozilla.org/en-US/about/legal/report-abuse/

### DIFF
--- a/bedrock/legal/redirects.py
+++ b/bedrock/legal/redirects.py
@@ -1,0 +1,7 @@
+from bedrock.redirects.util import redirect
+
+
+redirectpatterns = (
+    # bug 1243240
+    redirect(r'^about/legal/report-abuse/?$', 'legal.report-infringement'),
+)

--- a/bedrock/legal/templates/legal/index.html
+++ b/bedrock/legal/templates/legal/index.html
@@ -59,7 +59,13 @@
   </section>
   <section>
     <h3>{{ _('Takedown requests') }}</h3>
-    <p><a href="{{ url('legal.report-abuse') }}">{{ _('Report abuse of your copyrights and trademarks.') }}</a></p>
+    <p><a href="{{ url('legal.report-infringement') }}">
+      {%- if l10n_has_tag('legal_update_201601') -%}
+        {{ _('Report infringement of your copyrights or trademarks.') }}
+      {%- else -%}
+        {{ _('Report abuse of your copyrights and trademarks.') }}
+      {%- endif -%}
+    </a></p>
     {% if LANG == 'de' %}
     <p><a href="{{ url('legal.impressum') }}">{{ _('Impressum') }}</a></p>
     {% endif %}

--- a/bedrock/legal/templates/legal/report-infringement.html
+++ b/bedrock/legal/templates/legal/report-infringement.html
@@ -4,4 +4,4 @@
 
 {% extends "legal/docs-base.html" %}
 
-{% block page_title %}{{ _('Report Copyright and Trademark Abuse') }}{% endblock %}
+{% block page_title %}{{ _('Report Copyright or Trademark Infringement') }}{% endblock %}

--- a/bedrock/legal/urls.py
+++ b/bedrock/legal/urls.py
@@ -39,8 +39,8 @@ urlpatterns = (
     url(r'^acceptable-use/$', LegalDocView.as_view(template_name='legal/terms/acceptable-use.html', legal_doc_name='acceptable_use_policy'),
         name='legal.terms.acceptable-use'),
 
-    url(r'^report-abuse/$', LegalDocView.as_view(template_name='legal/report-abuse.html', legal_doc_name='report_abuse'),
-        name='legal.report-abuse'),
+    url(r'^report-infringement/$', LegalDocView.as_view(template_name='legal/report-infringement.html', legal_doc_name='report_infringement'),
+        name='legal.report-infringement'),
 
     url('^fraud-report/$', views.fraud_report, name='legal.fraud-report'),
 

--- a/tests/redirects/map_globalconf.py
+++ b/tests/redirects/map_globalconf.py
@@ -825,6 +825,9 @@ URLS = flatten((
     url_test('/about/legal.html', '/about/legal/'),
     url_test('/about/partnerships.html', '/about/partnerships/'),
 
+    # bug 1243240
+    url_test('/about/legal/report-abuse/', '/about/legal/report-infringement/'),
+
     # bug 846362
     url_test('/community/{index{.{de,fr},}.html,}', '/contribute/'),
 


### PR DESCRIPTION
The content has been updated in https://github.com/mozilla/legal-docs/pull/469, https://github.com/mozilla/legal-docs/pull/470 and https://github.com/mozilla/legal-docs/pull/471. Have to change the URL as well.

About `legal/redirects.py`: legal-related redirects are currently written in `mozorg/redirects.py`. I'll file a separate PR to move them to `legal/redirects.py`.