### PR TITLE
[fix bug 1242610] Update send to device widget to use Mozilla Location Services

### DIFF
--- a/bedrock/base/templates/macros.html
+++ b/bedrock/base/templates/macros.html
@@ -307,7 +307,7 @@
     {% set ios_link = firefox_ios_url('mozorg') %}
   {% endif %}
   {% set android_link = settings.GOOGLE_PLAY_FIREFOX_LINK %}
-  <section id="send-to-device" class="{% if include_logo %}logo {% endif %}{% if include_title %}title{% else %}no-title{% endif %}">
+  <section id="send-to-device" class="{% if include_logo %}logo {% endif %}{% if include_title %}title{% else %}no-title{% endif %}" data-key="{{ settings.MOZILLA_LOCATION_SERVICES_KEY }}">
     <div class="form-container">
       {% if include_title %}
         <h2 class="form-heading">

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -1055,3 +1055,5 @@ FIREFOX_IOS_RELEASE_VERSION = '2.0'
 FIREFOX_MOBILE_SYSREQ_URL = 'https://support.mozilla.org/kb/will-firefox-work-my-mobile-device'
 
 B2G_DROID_URL = 'https://d2yw7jilxa8093.cloudfront.net/B2GDroid-mozilla-central-nightly-latest.apk'
+
+MOZILLA_LOCATION_SERVICES_KEY = 'ec4d0c4b-b9ac-4d72-9197-289160930e14'

--- a/media/js/base/send-to-device.js
+++ b/media/js/base/send-to-device.js
@@ -60,22 +60,20 @@ if (typeof Mozilla === 'undefined') {
 
     /**
      * Checks to see if the visitor is located in the US
-     * using GeoDude https://github.com/mozilla/geodude
+     * using MLS https://location.services.mozilla.com/api
      */
     SendToDevice.prototype.checkLocation = function() {
         var self = this;
-        // should geo.mozilla.org be slow to load for some reason,
+        var key = this.$widget.data('key');
+
+        // should location.services.mozilla.com be slow to load,
         // just show the email messaging after 5 seconds waiting.
         this.formTimeout = setTimeout(self.updateMessaging, 5000);
 
-        $.getScript('https://geo.mozilla.org/country.js')
-            .done(function(script, textStatus) {
-                if (textStatus === 'success') {
-                    try {
-                        SendToDevice.COUNTRY_CODE = geoip_country_code().toLowerCase();
-                    } catch (e) {
-                        SendToDevice.COUNTRY_CODE = '';
-                    }
+        $.get('https://location.services.mozilla.com/v1/country?key=' + key)
+            .done(function(data) {
+                if (data && data.country_code) {
+                    SendToDevice.COUNTRY_CODE = data.country_code.toLowerCase();
                 }
                 self.updateMessaging();
             })


### PR DESCRIPTION
Note: because the new MSL API requires CORS, the geo lookup will no longer work in IE9 and below. In the case of this widget this should still be fine I think, as the form degrades gracefully to email only (the geo request is only responsible for updating messaging related to SMS).