### PR TITLE
Fix Bug 1245839 - Aurora mobile download link 404

### DIFF
--- a/bedrock/firefox/firefox_details.py
+++ b/bedrock/firefox/firefox_details.py
@@ -296,11 +296,11 @@ class FirefoxAndroid(_ProductDetails):
     }
 
     store_url = settings.GOOGLE_PLAY_FIREFOX_LINK
-    aurora_url_base = ('https://ftp.mozilla.org/pub/mozilla.org/mobile/nightly/'
+    aurora_url_base = ('https://archive.mozilla.org/pub/mobile/nightly/'
                        'latest-mozilla-aurora-android')
     aurora_urls = {
         'api-9': aurora_url_base + '-api-9/fennec-%s.multi.android-arm.apk',
-        'api-11': aurora_url_base + '-api-11/fennec-%s.multi.android-arm.apk',
+        'api-15': aurora_url_base + '-api-15/fennec-%s.multi.android-arm.apk',
         'x86': aurora_url_base + '-x86/fennec-%s.multi.android-i386.apk',
     }
 

--- a/bedrock/firefox/helpers.py
+++ b/bedrock/firefox/helpers.py
@@ -16,7 +16,7 @@ def android_builds(channel, builds=None):
     builds = builds or []
     variations = OrderedDict([
         ('api-9', 'Gingerbread'),
-        ('api-11', 'Honeycomb+ ARMv7+'),
+        ('api-15', 'Ice Cream Sandwich+'),
         ('x86', 'x86'),
     ])
 

--- a/bedrock/firefox/tests/test_helpers.py
+++ b/bedrock/firefox/tests/test_helpers.py
@@ -184,13 +184,13 @@ class TestDownloadButtons(TestCase):
         list = doc('.download-list li')
         eq_(list.length, 3)
         eq_(pq(list[0]).attr('class'), 'os_android armv7up api-9')
-        eq_(pq(list[1]).attr('class'), 'os_android armv7up api-11')
+        eq_(pq(list[1]).attr('class'), 'os_android armv7up api-15')
         eq_(pq(list[2]).attr('class'), 'os_android x86')
 
         list = doc('.download-other .arch')
         eq_(list.length, 3)
         eq_(pq(list[0]).attr('class'), 'arch armv7up api-9')
-        eq_(pq(list[1]).attr('class'), 'arch armv7up api-11')
+        eq_(pq(list[1]).attr('class'), 'arch armv7up api-15')
         eq_(pq(list[2]).attr('class'), 'arch x86')
 
     def test_beta_mobile(self):

--- a/media/css/sandstone/buttons.less
+++ b/media/css/sandstone/buttons.less
@@ -785,8 +785,8 @@ html[lang^='en'] {
 
 .download-button .download-list .os_android.api-9,
 .download-button .download-list .os_android.x86,
-.download-button .download-other.os_android .api-11,
-.android.gingerbread .download-button .download-list .os_android.api-11,
+.download-button .download-other.os_android .api-15,
+.android.gingerbread .download-button .download-list .os_android.api-15,
 .android.gingerbread .download-button .download-other.os_android .api-9,
 .android.x86 .download-button .download-list .os_android.armv7up,
 .android.x86 .download-button .download-other.os_android .x86 {
@@ -798,7 +798,7 @@ html[lang^='en'] {
     display: block !important;
 }
 
-.android.gingerbread .download-button .download-other.os_android .api-11,
+.android.gingerbread .download-button .download-other.os_android .api-15,
 .android.x86 .download-button .download-other.os_android .armv7up {
     display: inline !important;
 }


### PR DESCRIPTION
Android download button is a total mess, but soon we can improve it… by [dropping the Gingerbread support](https://bugzilla.mozilla.org/show_bug.cgi?id=1245567) and migrating to the new product-details lib.