### PR TITLE
[bug 1245208] Temporarily skip plugincheck newsletter test on non-Firefox browsers

### DIFF
--- a/tests/functional/test_plugincheck.py
+++ b/tests/functional/test_plugincheck.py
@@ -14,6 +14,7 @@ def test_not_supported_message(base_url, selenium):
     assert page.is_not_supported_message_displayed
 
 
+@pytest.mark.skip_if_not_firefox(reason='https://bugzilla.mozilla.org/show_bug.cgi?id=1245208')
 @pytest.mark.smoke
 @pytest.mark.nondestructive
 def test_newsletter_default_values(base_url, selenium):


### PR DESCRIPTION
@schalkneethling r? This test fails in non-firefox browsers as the newsletter is no longer visible on the testing variations if the user does not use Firefox.