### PR TITLE
[fix bug 1243890] Update FxA iframe param for Fx46.

### DIFF
--- a/bedrock/firefox/templates/firefox/accounts.html
+++ b/bedrock/firefox/templates/firefox/accounts.html
@@ -28,7 +28,7 @@
 {% block site_header_nav %}{% endblock %}
 
 {% block content %}
-<main role="main" data-fxa-iframe-src="{{ settings.FXA_IFRAME_SRC }}">
+<main role="main" data-fxa-iframe-host="{{ settings.FXA_IFRAME_SRC }}">
   <h1>{{_('Your Firefox. Anywhere. Anytime.')}}</h1>
   <div class="main-copy">
     {% include 'firefox/includes/sync-animation.html' %}

--- a/bedrock/firefox/templates/firefox/firstrun/firstrun.html
+++ b/bedrock/firefox/templates/firefox/firstrun/firstrun.html
@@ -47,7 +47,7 @@
 {% endblock %}
 
 {% block content %}
-<section id="intro" data-fxa-iframe-src="{{ settings.FXA_IFRAME_SRC }}">
+<section id="intro" data-fxa-iframe-host="{{ settings.FXA_IFRAME_SRC }}">
   <div class="container">
     <header>
       <h1>{{ _('Almost done!') }}</h1>

--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -336,10 +336,9 @@ class FirstrunView(LatestFxView):
 
     def get_context_data(self, **kwargs):
         ctx = super(FirstrunView, self).get_context_data(**kwargs)
-        version = self.kwargs.get('version') or ''
 
         # add version to context for use in templates
-        ctx['version'] = version
+        ctx['version'] = self.kwargs.get('version') or ''
 
         return ctx
 

--- a/docs/firefox-accounts.rst
+++ b/docs/firefox-accounts.rst
@@ -18,30 +18,31 @@ a non-production environment requires some additional Firefox profile configurat
 Local Development
 -----------------
 
-#. Set ``FXA_IFRAME_SRC`` in your ``local.py`` to point to the FXA development server
+#. Set ``FXA_IFRAME_SRC`` in your ``local.py`` to point to the FXA development server:
 
     ``FXA_IFRAME_SRC = 'https://stomlinson.dev.lcip.org/'``
 
-#. Quit Firefox
+#. Set your local development server to run on ``127.0.0.1:8111``.
+#. Quit Firefox.
 #. Create a new profile for testing called ``FxA Test Local`` by following the
    `instructions here`_.
 #. In the new profile folder, create a file called ``user.js`` and paste in the
-   following content
+   following content:
 
-.. code-block:: javascript
+    .. code-block:: javascript
 
-    user_pref("services.sync.log.appender.file.logOnSuccess", true);
-    user_pref("identity.fxaccounts.auth.uri", "https://stomlinson.dev.lcip.org/auth/v1");
-    user_pref("identity.fxaccounts.remote.force_auth.uri", "https://stomlinson.dev.lcip.org/force_auth?service=sync&context=fx_desktop_v1");
-    user_pref("identity.fxaccounts.remote.signin.uri", "https://stomlinson.dev.lcip.org/signin?service=sync&context=fx_desktop_v1");
-    user_pref("identity.fxaccounts.remote.signup.uri", "https://stomlinson.dev.lcip.org/signup?service=sync&context=fx_desktop_v1");
-    user_pref("identity.fxaccounts.settings.uri", "https://stomlinson.dev.lcip.org/settings");
-    user_pref("identity.fxaccounts.remote.webchannel.uri", "https://stomlinson.dev.lcip.org/");
-    user_pref("services.sync.tokenServerURI", "https://stomlinson.dev.lcip.org/syncserver/token/1.0/sync/1.5");
+        user_pref("services.sync.log.appender.file.logOnSuccess", true);
+        user_pref("identity.fxaccounts.auth.uri", "https://stomlinson.dev.lcip.org/auth/v1");
+        user_pref("identity.fxaccounts.remote.force_auth.uri", "https://stomlinson.dev.lcip.org/force_auth?service=sync&context=fx_desktop_v1");
+        user_pref("identity.fxaccounts.remote.signin.uri", "https://stomlinson.dev.lcip.org/signin?service=sync&context=fx_desktop_v1");
+        user_pref("identity.fxaccounts.remote.signup.uri", "https://stomlinson.dev.lcip.org/signup?service=sync&context=fx_desktop_v1");
+        user_pref("identity.fxaccounts.settings.uri", "https://stomlinson.dev.lcip.org/settings");
+        user_pref("identity.fxaccounts.remote.webchannel.uri", "https://stomlinson.dev.lcip.org/");
+        user_pref("services.sync.tokenServerURI", "https://stomlinson.dev.lcip.org/syncserver/token/1.0/sync/1.5");
 
-    user_pref("general.warnOnAboutConfig", false);
-    user_pref("devtools.chrome.enabled", true);
-    user_pref("devtools.debugger.remote-enabled", true);
+        user_pref("general.warnOnAboutConfig", false);
+        user_pref("devtools.chrome.enabled", true);
+        user_pref("devtools.debugger.remote-enabled", true);
 
 #. Start Firefox using the new profile created in step 3.
 #. Verify the FxA settings look correct by opening ``about:config`` and searching for
@@ -55,22 +56,22 @@ Demo Server Testing
 #. Create a new profile for testing called ``FxA Test Demo`` by following the
    `instructions here`_.
 #. In the new profile folder, create a file called ``user.js`` and paste in the
-   following content.
+   following content:
 
-.. code-block:: javascript
+    .. code-block:: javascript
 
-    user_pref("services.sync.log.appender.file.logOnSuccess", true);
-    user_pref("identity.fxaccounts.auth.uri", "https://api-accounts.stage.mozaws.net/v1");
-    user_pref("identity.fxaccounts.remote.force_auth.uri", "https://accounts.stage.mozaws.net/force_auth?service=sync&context=fx_desktop_v1");
-    user_pref("identity.fxaccounts.remote.signin.uri", "https://accounts.stage.mozaws.net/signin?service=sync&context=fx_desktop_v1");
-    user_pref("identity.fxaccounts.remote.signup.uri", "https://accounts.stage.mozaws.net/signup?service=sync&context=fx_desktop_v1");
-    user_pref("identity.fxaccounts.settings.uri", "https://accounts.stage.mozaws.net/settings");
-    user_pref("identity.fxaccounts.remote.webchannel.uri", "https://accounts.stage.mozaws.net/");
-    user_pref("services.sync.tokenServerURI", "https://token.stage.mozaws.net/1.0/sync/1.5");
+        user_pref("services.sync.log.appender.file.logOnSuccess", true);
+        user_pref("identity.fxaccounts.auth.uri", "https://api-accounts.stage.mozaws.net/v1");
+        user_pref("identity.fxaccounts.remote.force_auth.uri", "https://accounts.stage.mozaws.net/force_auth?service=sync&context=fx_desktop_v1");
+        user_pref("identity.fxaccounts.remote.signin.uri", "https://accounts.stage.mozaws.net/signin?service=sync&context=fx_desktop_v1");
+        user_pref("identity.fxaccounts.remote.signup.uri", "https://accounts.stage.mozaws.net/signup?service=sync&context=fx_desktop_v1");
+        user_pref("identity.fxaccounts.settings.uri", "https://accounts.stage.mozaws.net/settings");
+        user_pref("identity.fxaccounts.remote.webchannel.uri", "https://accounts.stage.mozaws.net/");
+        user_pref("services.sync.tokenServerURI", "https://token.stage.mozaws.net/1.0/sync/1.5");
 
-    user_pref("general.warnOnAboutConfig", false);
-    user_pref("devtools.chrome.enabled", true);
-    user_pref("devtools.debugger.remote-enabled", true);
+        user_pref("general.warnOnAboutConfig", false);
+        user_pref("devtools.chrome.enabled", true);
+        user_pref("devtools.debugger.remote-enabled", true);
 
 #. Start Firefox using the new profile you created in step 2.
 #. Verify the FxA settings look correct by opening ``about:config`` and searching for


### PR DESCRIPTION
Have not yet updated `firefox/accounts.js` as I wanted to first get a sanity check on the approach.

Code is up on demo5:

[https://www-demo5.allizom.org/en-US/firefox/46.0/firstrun/](https://www-demo5.allizom.org/en-US/firefox/46.0/firstrun/)

Change isn't immediately obvious, so I'm logging the FxA iframe `src` to the console. If Fx 46+, `src` string should contain `context=fx_firstrun_v2`. Otherwise, `context=iframe`.

Actual change - after verifying email, Fx 46+ users see a blue "Sync Preferences" button in the iframe. Fx < 46 users do not get this button.

@alexgibson - Pre-review on approach? What do you think about the UITour fallback and timing?