### PR TITLE
Return exit code 0 when checking for tag commit

### DIFF
--- a/docker/jenkins/push2dockerhub.sh
+++ b/docker/jenkins/push2dockerhub.sh
@@ -18,7 +18,7 @@ docker tag -f $FROM_DOCKER_REPOSITORY:$COMMIT $DOCKER_REPOSITORY:$COMMIT
 # Push to docker hub
 docker push $DOCKER_REPOSITORY:$COMMIT
 
-GIT_TAG="$(git describe --tags --exact-match $GIT_COMMIT 2> /dev/null)"
+GIT_TAG="$(git describe --tags --exact-match $GIT_COMMIT 2> /dev/null || true)"
 if [[ ! -z $GIT_TAG ]]; then
     docker tag -f $FROM_DOCKER_REPOSITORY:$COMMIT $DOCKER_REPOSITORY:$GIT_TAG
     docker push $DOCKER_REPOSITORY:$GIT_TAG


### PR DESCRIPTION
Prevent Jenkins from incorrectly reporting a failed job