### PR TITLE
[bug 1248040] Update GTM data attributes on /firefox/new/

### DIFF
--- a/bedrock/base/templates/base-resp.html
+++ b/bedrock/base/templates/base-resp.html
@@ -102,7 +102,7 @@
 
         {% block tabzilla_tab %}
           <div id="tabzilla">
-            <a href="{{ url('mozorg.home') }}">Mozilla</a>
+            <a href="{{ url('mozorg.home') }}" data-link-type="nav" data-link-name="tabzilla">Mozilla</a>
           </div>
         {% endblock %}
 

--- a/bedrock/base/templates/base.html
+++ b/bedrock/base/templates/base.html
@@ -98,7 +98,7 @@
 
         {% block tabzilla_tab %}
         <div id="tabzilla">
-          <a href="{{ url('mozorg.home') }}">Mozilla</a>
+          <a href="{{ url('mozorg.home') }}" data-link-type="nav" data-link-name="tabzilla">Mozilla</a>
         </div>
         {% endblock %}
 

--- a/bedrock/firefox/templates/firefox/includes/simple_footer.html
+++ b/bedrock/firefox/templates/firefox/includes/simple_footer.html
@@ -12,9 +12,9 @@
       <li>{% include 'includes/lang_switcher.html' %}</li>
     </ul>
     <ul class="secondary">
-      <li><a href="{{ url('privacy') }}">{{_('Privacy')}}</a></li>
-      <li><a href="{{ url('privacy.notices.websites') }}#cookies">{{ _('Cookies') }}</a></li>
-      <li><a href="{{ url('legal.index') }}">{{_('Legal')}}</a></li>
+      <li><a href="{{ url('privacy') }}" data-link-type="footer" data-link-name="Privacy">{{_('Privacy')}}</a></li>
+      <li><a href="{{ url('privacy.notices.websites') }}#cookies" data-link-type="footer" data-link-name="Cookies">{{ _('Cookies') }}</a></li>
+      <li><a href="{{ url('legal.index') }}" data-link-type="footer" data-link-name="Legal">{{_('Legal')}}</a></li>
     </ul>
   </div>
 </footer>


### PR DESCRIPTION
Added attributes to tabzilla, simple footer, and 'click here' link.