### PR TITLE
[fix bug 1245573] Remove padding on firstrun FxA iframe.

### DIFF
--- a/media/css/firefox/firstrun/firstrun.less
+++ b/media/css/firefox/firstrun/firstrun.less
@@ -99,7 +99,6 @@ main p {
 .fxaccounts {
     background-color: #fff;
     margin: 0 auto;
-    padding: @baseLine;
     border-radius: 8px;
     width: 400px;
 


### PR DESCRIPTION
Removing padding improves iframe UI after account confirmation. With padding, grey bottom half of iframe is "floating". Without padding, grey bottom half is butted up against border. (See [the GitHub issue](https://github.com/mozilla/fxa-content-server/issues/3471) for screenshot.)

@alexgibson r?