### PR TITLE
Bug 1244200 - update privacy link in newsletter forms

### DIFF
--- a/bedrock/mozorg/forms.py
+++ b/bedrock/mozorg/forms.py
@@ -58,13 +58,13 @@ class PrivacyWidget(widgets.CheckboxInput):
         input_txt = super(PrivacyWidget, self).render(name, value, attrs)
 
         policy_txt = _(u'I’m okay with Mozilla handling my info as explained '
-                       u'in <a href="%s">this Privacy Policy</a>')
+                       u'in <a href="%s">this Privacy Notice</a>')
         return mark_safe(
             '<label for="%s" class="privacy-check-label">'
             '%s '
             '<span class="title">%s</span></label>'
             % (attrs['id'], input_txt,
-               policy_txt % reverse('privacy'))
+               policy_txt % reverse('privacy.notices.websites'))
         )
 
 

--- a/bedrock/newsletter/templates/newsletter/includes/form.html
+++ b/bedrock/newsletter/templates/newsletter/includes/form.html
@@ -21,7 +21,7 @@
         {% endif %}
 
         {% if form.privacy.errors %}
-          <li>{{ _('You must agree to the privacy policy') }}</li>
+          <li>{{ _('You must agree to the privacy notice') }}</li>
         {% endif %}
       </ul>
     </div>

--- a/bedrock/newsletter/views.py
+++ b/bedrock/newsletter/views.py
@@ -610,7 +610,7 @@ def newsletter_subscribe(request):
             if 'email' in form.errors:
                 errors.append(_('Please enter a valid email address'))
             if 'privacy' in form.errors:
-                errors.append(_('You must agree to the privacy policy'))
+                errors.append(_('You must agree to the privacy notice'))
             for fieldname in ('fmt', 'lang', 'country'):
                 if fieldname in form.errors:
                     errors.extend(form.errors[fieldname])


### PR DESCRIPTION
Changes "privacy policy" to "privacy notice" and updates the link.

@flodolo and @pmclanahan - This changes some strings but I'm unsure how to use an l10n tag in a .py file, or if that's even possible. I was unable to find any examples; I suspect that helper is just for templates.