### PR TITLE
[bug 1239863] Hide Firefox OS on Family navigation

### DIFF
--- a/bedrock/base/templates/macros.html
+++ b/bedrock/base/templates/macros.html
@@ -234,7 +234,8 @@
             <li><a href="{{ url('firefox.private-browsing') }}"{% if activesub == 'private-browsing' %} class="selected"{% endif %}><div>{{ _('Private Browsing') }}</div></a></li>
           </ul>
         </li>
-        <li{% if activeprimary == 'os' %} class="active"{% endif %}>
+        {% if activeprimary == 'os' %}
+        <li class="active">
           <a data-id="os" href="{{ url('firefox.os.index') }}" class="primary-link" data-link-type="nav" data-link-name="Firefox OS"><div>{{ _('Firefox OS') }}</div></a>
 
           <ul class="subnav" id="os-subnav">
@@ -243,6 +244,7 @@
             <li><a data-id="os-marketplace" rel="external" href="https://marketplace.firefox.com/"><div>{{ _('Marketplace') }}<i class="icon-external"></i></div></a></li>
           </ul>
         </li>
+        {% endif %}
       </ul>
     </nav>{#-- /#fxfamillynav --#}
 


### PR DESCRIPTION
## Description
- Hides Firefox OS on Family Navigation menu
- Only shows Firefox OS in the navigation should the user already be on a Firefox OS page.

Note: this is a temporary hack, until we no longer have the /firefox/os and /firefox/os/ devices pages. I still need to get clarification if this is the correct solution, so marking as do-not-merge for now.

## Bugzilla
https://bugzilla.mozilla.org/show_bug.cgi?id=1239863

## Testing
Firefox OS primary link should not be displayed on any pages aside from the Firefox OS pages themselves. This should apply to both desktop and mobile viewports.

## Checklist
- [ ] Requires l10n changes.
- [x] Related functional & integration tests passing.

