### PR TITLE
[fix bug 1249752] Test FxA email field on /firefox/sync/.

### DIFF
--- a/bedrock/firefox/templates/firefox/sync.html
+++ b/bedrock/firefox/templates/firefox/sync.html
@@ -74,15 +74,20 @@
 
       <div class="buttons">
         <div class="show-fx-31-signed-in">
+        {% if l10n_has_tag('firefox_sync_mobile_buttons_update') %}
+          <p>
+            {{ _('Now sync Firefox with your iOS and Android devices.') }}
+          </p>
+        {% endif %}
           <ul class="primary-buttons">
             <li>
-              <a href="{{ settings.GOOGLE_PLAY_FIREFOX_LINK }}" class="sync-button green" data-interaction="button click" data-element-action="Sync CTA" id="cta-android">
-                {{ _('Get Firefox for Android') }}
+              <a href="{{ settings.GOOGLE_PLAY_FIREFOX_LINK }}" data-interaction="button click" data-element-action="Sync CTA" id="cta-android">
+                {{ high_res_img('firefox/android/btn-google-play.png', {'alt': _('Get it on Google Play'), 'width': '152', 'height': '45', 'l10n': True}) }}
               </a>
             </li>
             <li>
-              <a href="{{ firefox_ios_url('mozorg-sync_page-appstore-button') }}" class="sync-button green" data-interaction="button click" data-element-action="Sync CTA" id="cta-ios">
-                {{ _('Get Firefox for iOS') }}
+              <a href="{{ firefox_ios_url('mozorg-sync_page-appstore-button') }}" data-interaction="button click" data-element-action="Sync CTA" id="cta-ios">
+                <img src="{{ l10n_img('firefox/ios/btn-app-store.svg') }}" alt="{{ _('Download on the App Store') }}" width="152" height="45">
               </a>
             </li>
           </ul>
@@ -94,9 +99,30 @@
         </div>
 
         <div class="show-fx-31-signed-out">
+        {% if not version %}
           <button class="sync-button" data-interaction="button click" data-element-action="Sync CTA"  id="cta-sync">
             {{ _('Get started with Sync') }}
           </button>
+        {% else %}
+          <form id="fxa-email-form" action="{{ url('firefox.accounts') }}" method="get">
+            <input type="hidden" id="variation" name="v" value="{{ version }}">
+            <label for="fxa-email" class="fxa-email">
+            {% if version == '2' %}
+              {{ _('Enter your email to begin.') }}
+            {% elif version == '3' %}
+              {{ _('Create a Firefox account to begin.') }}
+            {% endif %}
+            </label>
+            <input type="email" id="fxa-email" class="fxa-email" placeholder="{{ _('YOUR EMAIL HERE') }}">
+            <button type="submit" class="sync-button" data-interaction="button click" data-element-action="Sync CTA" id="cta-sync-variation">
+            {% if version == '2' %}
+              {{ _('Get started with Sync') }}
+            {% elif version == '3' %}
+              {{ _('Set up Sync') }}
+            {% endif %}
+            </button>
+          </form>
+        {% endif %}
         </div>
 
         <div class="show-fx-29-30">

--- a/bedrock/firefox/urls.py
+++ b/bedrock/firefox/urls.py
@@ -52,7 +52,7 @@ urlpatterns = (
     page('firefox/private-browsing', 'firefox/private-browsing.html'),
     url('^firefox/send-to-device-post/$', views.send_to_device_ajax,
         name='firefox.send-to-device-post'),
-    page('firefox/sync', 'firefox/sync.html'),
+    url(r'^firefox/sync/$', views.sync, name='firefox.sync'),
     page('firefox/unsupported-systems', 'firefox/unsupported-systems.html'),
     url(r'^firefox/new/$', views.new, name='firefox.new'),
     page('firefox/organizations/faq', 'firefox/organizations/faq.html'),

--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -521,3 +521,13 @@ def new(request):
             template = 'firefox/new/scene1.html'
 
     return l10n_utils.render(request, template)
+
+
+def sync(request):
+    locale = l10n_utils.get_locale(request)
+    version = request.GET.get('v', None)
+
+    if (locale != 'en-US' or version not in ['2', '3']):
+        version = None
+
+    return l10n_utils.render(request, 'firefox/sync.html', {'version': version})

--- a/bedrock/settings/static_media.py
+++ b/bedrock/settings/static_media.py
@@ -1028,6 +1028,7 @@ PIPELINE_JS = {
     },
     'firefox_accounts': {
         'source_filenames': (
+            'js/base/search-params.js',
             'js/firefox/australis/australis-uitour.js',
             'js/firefox/sync-animation.js',
             'js/firefox/accounts.js',

--- a/media/css/firefox/sync.less
+++ b/media/css/firefox/sync.less
@@ -48,6 +48,8 @@
     .font-size(@largeFontSize);
     text-transform: uppercase;
     .transition();
+    width: 60%;
+    margin: 0 auto;
     &:focus,
     &:active,
     &:hover {
@@ -67,7 +69,6 @@
 }
 
 .sky button.sync-button {
-    width: 100%;
     border: none;
     cursor: pointer;
 }
@@ -95,16 +96,24 @@
         padding-bottom: @baseLine * 2;
     }
     .buttons {
-        .span(8);
-        .offset(2);
+        .span(10);
+        .offset(1);
+        float: none;
         clear: both;
 
         > div {
             padding: 0 (@baseLine * 5) @baseLine;
         }
 
-        > div.show-fx-31-signed-in {
+        > div.show-fx-31-signed-in,
+        > div.show-fx-31-signed-out {
             padding: 0 @baseLine @baseLine;
+        }
+
+        > .show-fx-31-signed-in p {
+            .font-size(18px);
+            .open-sans-light();
+            text-align: center;
         }
     }
     .warning {
@@ -139,13 +148,47 @@
 
 .primary-buttons {
     .flexbox();
-    .justify-content(space-around);
+    .justify-content(center);
     list-style-type: none;
 
     & > li {
-        flex-basis: 46%;
         margin: 0;
+        padding: 0 @baseLine;
         text-align: center;
+    }
+}
+
+#fxa-email-form {
+    .flexbox();
+    .justify-content(center);
+    .flex-wrap(wrap);
+
+    label {
+        display: block;
+        flex-basis: 100%;
+        margin-bottom: @baseLine;
+        text-align: center;
+        .font-size(18px);
+        .open-sans-light();
+    }
+
+    .fxa-email {
+        display: none;
+
+        &.active {
+            display: block
+        }
+    }
+
+    button,
+    input {
+        .flex(1);
+        margin: 0 (@baseLine / 2);
+    }
+
+    input {
+        .border-box();
+        padding: 15px 10px;
     }
 }
 
@@ -460,6 +503,7 @@ html[dir="rtl"] {
 
         .buttons {
             margin-left: 50px;
+            .span(9);
         }
     }
 
@@ -570,6 +614,10 @@ html[dir="rtl"] {
         margin: 0 auto @baseLine auto;
     }
 
+    .sky .sync-button {
+        width: 100%;
+    }
+
     .primary {
         .warning,
         .buttons {
@@ -593,6 +641,21 @@ html[dir="rtl"] {
         display: block;
 
         li {
+            margin-bottom: @baseLine;
+        }
+    }
+
+    #fxa-email-form {
+        display: block;
+
+        button,
+        input {
+            margin: 0;
+        }
+
+        input {
+            display: block;
+            width: 100%;
             margin-bottom: @baseLine;
         }
     }

--- a/media/css/sandstone/lib.less
+++ b/media/css/sandstone/lib.less
@@ -272,6 +272,13 @@
     flex: @values;
 }
 
+.flex-wrap(@value: wrap) {
+    -webkit-flex-wrap: wrap;
+    -moz-flex-wrap: wrap;
+    -ms-flex-wrap: wrap;
+    flex-wrap: wrap;
+}
+
 .align-items(@align: stretch) {
     -webkit-align-items: @align;
        -moz-align-items: @align;


### PR DESCRIPTION
## Description
Add an email field to /firefox/sync/ for Fx users *not* signed in to Sync. This field will propagate to the FxA email field on /firefox/accounts/.

## Bugzilla
[bug 1249752](https://bugzilla.mozilla.org/show_bug.cgi?id=1249752)

## Testing
Must have a [profile configured for local or demo testing](http://bedrock.readthedocs.org/en/latest/firefox-accounts.html) and be signed out of Sync. Hit /firefox/sync/, enter an email, click the button, and notice the email field in the FxA iframe is populated.

Variations are currently on demo5 - [v2](https://www-demo5.allizom.org/en-US/firefox/sync/?v=2) and [v3](https://www-demo5.allizom.org/en-US/firefox/sync/?v=3).

Variations are only running for en-US, so no L10n impact.

Waiting on GA confirmation, but code should be ready for review.

