### PR TITLE
Add functional tests for /firefox/channel/ page

### DIFF
--- a/tests/functional/firefox/test_channel.py
+++ b/tests/functional/firefox/test_channel.py
@@ -1,0 +1,45 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import pytest
+
+from pages.firefox.channel import ChannelPage
+
+
+@pytest.mark.smoke
+@pytest.mark.nondestructive
+def test_download_carousel_buttons(base_url, selenium):
+    page = ChannelPage(base_url, selenium, hash='').open()
+    assert page.desktop_beta_download_button.is_displayed
+    assert page.android_beta_download_button.is_displayed
+    page.click_next()
+    assert page.desktop_release_download_button.is_displayed
+    assert page.android_release_download_button.is_displayed
+    page.click_next()
+    assert page.desktop_developer_download_button.is_displayed
+    assert page.android_aurora_download_button.is_displayed
+    page.click_previous()
+    assert page.desktop_release_download_button.is_displayed
+    assert page.android_release_download_button.is_displayed
+
+
+@pytest.mark.nondestructive
+def test_download_beta_url_hash(base_url, selenium):
+    page = ChannelPage(base_url, selenium, hash='#beta').open()
+    assert page.desktop_beta_download_button.is_displayed
+    assert page.android_beta_download_button.is_displayed
+
+
+@pytest.mark.nondestructive
+def test_download_release_url_hash(base_url, selenium):
+    page = ChannelPage(base_url, selenium, hash='#firefox').open()
+    assert page.desktop_release_download_button.is_displayed
+    assert page.android_release_download_button.is_displayed
+
+
+@pytest.mark.nondestructive
+def test_download_developer_url_hash(base_url, selenium):
+    page = ChannelPage(base_url, selenium, hash='#developer').open()
+    assert page.desktop_developer_download_button.is_displayed
+    assert page.android_aurora_download_button.is_displayed

--- a/tests/pages/firefox/channel.py
+++ b/tests/pages/firefox/channel.py
@@ -1,0 +1,76 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from selenium.webdriver.common.by import By
+
+from pages.firefox.base import FirefoxBasePage, FirefoxBasePageRegion
+from pages.regions.download_button import DownloadButton
+
+
+class ChannelPage(FirefoxBasePage):
+
+    _url = '{base_url}/{locale}/firefox/channel/{hash}'
+
+    _desktop_release_download_locator = (By.ID, 'download-button-desktop-release')
+    _android_release_download_locator = (By.ID, 'download-button-android-release')
+    _desktop_beta_download_locator = (By.ID, 'download-button-desktop-beta')
+    _android_beta_download_locator = (By.ID, 'download-button-android-beta')
+    _desktop_developer_download_locator = (By.ID, 'download-button-desktop-alpha')
+    _android_aurora_download_locator = (By.ID, 'download-button-android-alpha')
+    _right_carousel_button_locator = (By.ID, 'carousel-right')
+    _left_carousel_button_locator = (By.ID, 'carousel-left')
+    _channels_locator = (By.CLASS_NAME, 'pager-page')
+
+    @property
+    def _channels(self):
+        return [Channel(self, root=el) for el in
+                self.find_elements(self._channels_locator)]
+
+    @property
+    def desktop_release_download_button(self):
+        el = self.find_element(self._desktop_release_download_locator)
+        return DownloadButton(self, root=el)
+
+    @property
+    def android_release_download_button(self):
+        el = self.find_element(self._android_release_download_locator)
+        return DownloadButton(self, root=el)
+
+    @property
+    def desktop_beta_download_button(self):
+        el = self.find_element(self._desktop_beta_download_locator)
+        return DownloadButton(self, root=el)
+
+    @property
+    def android_beta_download_button(self):
+        el = self.find_element(self._android_beta_download_locator)
+        return DownloadButton(self, root=el)
+
+    @property
+    def desktop_developer_download_button(self):
+        el = self.find_element(self._desktop_developer_download_locator)
+        return DownloadButton(self, root=el)
+
+    @property
+    def android_aurora_download_button(self):
+        el = self.find_element(self._android_aurora_download_locator)
+        return DownloadButton(self, root=el)
+
+    def click_next(self):
+        channel = next(c for c in self._channels if c.is_selected)
+        self.find_element(self._right_carousel_button_locator).click()
+        self.wait.until(lambda s: not channel.is_selected)
+
+    def click_previous(self):
+        channel = next(c for c in self._channels if c.is_selected)
+        self.find_element(self._left_carousel_button_locator).click()
+        self.wait.until(lambda s: not channel.is_selected)
+
+
+class Channel(FirefoxBasePageRegion):
+
+    @property
+    def is_selected(self):
+        return (self._root.get_attribute('aria-hidden') == 'false' and
+                self._root.is_displayed())


### PR DESCRIPTION
## Description
Adds functional tests for the `/firefox/channel/` page.

## Testing
One thing I'm unsure on is if it's safe to use the normal `wait_for_page_to_load()` here when testing URL's that contain hashes (e.g. `#developer`), or whether it would be safer to use a custom method which can check for the correct HTML class to be added to the content before doing an assert. Tests seem to pass OK without anything extra, but I'm unsure if it's adequate enough.

## Checklist
- [ ] Requires l10n changes.
- [x] Related functional & integration tests passing.

