### PR TITLE
fixes bug1250519 - Remove BSD newsletters subscribe

### DIFF
--- a/bedrock/mozorg/email_contribute.py
+++ b/bedrock/mozorg/email_contribute.py
@@ -8,7 +8,6 @@ from django.core.mail import EmailMessage
 
 import basket
 import jingo
-import requests
 from jinja2.exceptions import TemplateNotFound
 
 from lib.l10n_utils.dotlang import _lazy as _
@@ -144,12 +143,10 @@ def handle_form(request, form):
 
         if data.get('newsletter', False):
             if data.get('interest', False) == 'education':
-                # custom-1788 is the privacy policy checkbox on this page
-                payload = {'email': data['email'], 'custom-1788': '1'}
                 try:
-                    requests.post('https://sendto.mozilla.org/page/s/mentor-signup',
-                                  data=payload, timeout=2)
-                except requests.exceptions.RequestException:
+                    basket.subscribe(data['email'], 'mozilla-learning-network',
+                                     source_url=request.build_absolute_uri())
+                except basket.BasketException:
                     pass
             else:
                 try:

--- a/bedrock/mozorg/tests/test_views.py
+++ b/bedrock/mozorg/tests/test_views.py
@@ -17,7 +17,6 @@ from django.test.utils import override_settings
 from captcha.fields import ReCaptchaField
 from bedrock.base.urlresolvers import reverse
 from jinja2.exceptions import TemplateNotFound
-from requests.exceptions import Timeout
 from mock import ANY, Mock, patch
 from nose.tools import assert_false, eq_, ok_
 
@@ -426,49 +425,38 @@ class TestContributeOldPage(TestCase):
 
     @patch.object(ReCaptchaField, 'clean', Mock())
     @patch('bedrock.mozorg.email_contribute.basket.subscribe')
-    @patch('bedrock.mozorg.email_contribute.requests.post')
-    def test_webmaker_mentor_signup(self, mock_post, mock_subscribe):
+    def test_webmaker_mentor_signup(self, mock_subscribe):
         """Test Webmaker Mentor signup form for education functional area"""
         self.data.update(interest='education', newsletter=True)
         self.client.post(self.url_en, self.data)
 
-        assert_false(mock_subscribe.called)
-        payload = {'email': self.contact, 'custom-1788': '1'}
-        mock_post.assert_called_with('https://sendto.mozilla.org/page/s/mentor-signup',
-                                     data=payload, timeout=2)
+        mock_subscribe.assert_called_with(self.contact, 'mozilla-learning-network', source_url=ANY)
 
     @patch.object(ReCaptchaField, 'clean', Mock())
     @patch('bedrock.mozorg.email_contribute.basket.subscribe')
-    @patch('bedrock.mozorg.email_contribute.requests.post')
-    def test_webmaker_mentor_signup_newsletter_fail(self, mock_post, mock_subscribe):
+    def test_webmaker_mentor_signup_newsletter_fail(self, mock_subscribe):
         """Test Webmaker Mentor signup form when newsletter is not selected"""
         self.data.update(interest='education', newsletter=False)
         self.client.post(self.url_en, self.data)
 
         assert_false(mock_subscribe.called)
-        assert_false(mock_post.called)
 
     @patch.object(ReCaptchaField, 'clean', Mock())
     @patch('bedrock.mozorg.email_contribute.basket.subscribe')
-    @patch('bedrock.mozorg.email_contribute.requests.post')
-    def test_webmaker_mentor_signup_functional_area_fail(self, mock_post, mock_subscribe):
+    def test_webmaker_mentor_signup_functional_area_fail(self, mock_subscribe):
         """Test Webmaker Mentor signup form when functional area is not education"""
         self.data.update(interest='coding', newsletter=True)
         self.client.post(self.url_en, self.data)
 
         mock_subscribe.assert_called_with(self.contact, 'about-mozilla', source_url=ANY)
-        assert_false(mock_post.called)
 
     @patch.object(ReCaptchaField, 'clean', Mock())
     @patch('bedrock.mozorg.email_contribute.basket.subscribe')
-    @patch('bedrock.mozorg.email_contribute.requests.post')
-    def test_webmaker_mentor_signup_timeout_fail(self, mock_post, mock_subscribe):
+    def test_webmaker_mentor_signup_timeout_fail(self, mock_subscribe):
         """Test Webmaker Mentor signup form when request times out"""
-        mock_post.side_effect = Timeout('Timeout')
         self.data.update(interest='education', newsletter=True)
         res = self.client.post(self.url_en, self.data)
 
-        assert_false(mock_subscribe.called)
         eq_(res.status_code, 200)
 
     @patch.object(ReCaptchaField, 'clean', Mock())
@@ -583,49 +571,38 @@ class TestContribute(TestCase):
 
     @patch.object(ReCaptchaField, 'clean', Mock())
     @patch('bedrock.mozorg.email_contribute.basket.subscribe')
-    @patch('bedrock.mozorg.email_contribute.requests.post')
-    def test_webmaker_mentor_signup(self, mock_post, mock_subscribe):
+    def test_webmaker_mentor_signup(self, mock_subscribe):
         """Test Webmaker Mentor signup form for education functional area"""
         self.data.update(interest='education', newsletter=True)
         self.client.post(self.url_en, self.data)
 
-        assert_false(mock_subscribe.called)
-        payload = {'email': self.contact, 'custom-1788': '1'}
-        mock_post.assert_called_with('https://sendto.mozilla.org/page/s/mentor-signup',
-                                     data=payload, timeout=2)
+        mock_subscribe.assert_called_with(self.contact, 'mozilla-learning-network', source_url=ANY)
 
     @patch.object(ReCaptchaField, 'clean', Mock())
     @patch('bedrock.mozorg.email_contribute.basket.subscribe')
-    @patch('bedrock.mozorg.email_contribute.requests.post')
-    def test_webmaker_mentor_signup_newsletter_fail(self, mock_post, mock_subscribe):
+    def test_webmaker_mentor_signup_newsletter_fail(self, mock_subscribe):
         """Test Webmaker Mentor signup form when newsletter is not selected"""
         self.data.update(interest='education', newsletter=False)
         self.client.post(self.url_en, self.data)
 
         assert_false(mock_subscribe.called)
-        assert_false(mock_post.called)
 
     @patch.object(ReCaptchaField, 'clean', Mock())
     @patch('bedrock.mozorg.email_contribute.basket.subscribe')
-    @patch('bedrock.mozorg.email_contribute.requests.post')
-    def test_webmaker_mentor_signup_functional_area_fail(self, mock_post, mock_subscribe):
+    def test_webmaker_mentor_signup_functional_area_fail(self, mock_subscribe):
         """Test Webmaker Mentor signup form when functional area is not education"""
         self.data.update(interest='coding', newsletter=True)
         self.client.post(self.url_en, self.data)
 
         mock_subscribe.assert_called_with(self.contact, 'about-mozilla', source_url=ANY)
-        assert_false(mock_post.called)
 
     @patch.object(ReCaptchaField, 'clean', Mock())
     @patch('bedrock.mozorg.email_contribute.basket.subscribe')
-    @patch('bedrock.mozorg.email_contribute.requests.post')
-    def test_webmaker_mentor_signup_timeout_fail(self, mock_post, mock_subscribe):
+    def test_webmaker_mentor_signup_timeout_fail(self, mock_subscribe):
         """Test Webmaker Mentor signup form when request times out"""
-        mock_post.side_effect = Timeout('Timeout')
         self.data.update(interest='education', newsletter=True)
         res = self.client.post(self.url_en, self.data)
 
-        assert_false(mock_subscribe.called)
         eq_(res.status_code, 302)  # redirect to thankyou page
 
     @patch.object(ReCaptchaField, 'clean', Mock())


### PR DESCRIPTION
This patch basically replace the BSD newsletters and replace it with Basket and it is a part of this sec-bug on bugzilla: https://bugzilla.mozilla.org/show_bug.cgi?id=1172325