### PR TITLE
[fix bug 1250309] Add lang files to firefox/new separated templates.

### DIFF
--- a/bedrock/firefox/templates/firefox/new/scene1.html
+++ b/bedrock/firefox/templates/firefox/new/scene1.html
@@ -2,6 +2,8 @@
  # License, v. 2.0. If a copy of the MPL was not distributed with this
  # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
 
+{% add_lang_files "firefox/new" %}
+
 {% extends "firefox/base-resp.html" %}
 
 {% block page_title_prefix %}{{_('Download Firefox')}} — {% endblock %}

--- a/bedrock/firefox/templates/firefox/new/scene2.html
+++ b/bedrock/firefox/templates/firefox/new/scene2.html
@@ -2,6 +2,8 @@
  # License, v. 2.0. If a copy of the MPL was not distributed with this
  # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
 
+{% add_lang_files "firefox/new" %}
+
 {% extends "firefox/base-resp.html" %}
 
 {% block page_title_prefix %}{{_('Download Firefox')}} — {% endblock %}


### PR DESCRIPTION
For non en-US visitors, separated templates are currently redirecting to en-US.

