### PR TITLE
Fix Bug 1249610, add new infobar to bedrock

### DIFF
--- a/bedrock/base/templates/base-resp.html
+++ b/bedrock/base/templates/base-resp.html
@@ -92,6 +92,16 @@
       {% block string_data %}{% endblock %}></div>
     <div id="outer-wrapper">
 
+    {% block infobar %}
+      <div id="mozilla-infobar" class="mozilla-infobar hidden" role="dialog" aria-hidden="true" data-infobar="{% block infobar_bars %}update translate{% endblock %}">
+        <p></p>
+        <ul>
+          <li><a href="https://support.mozilla.org/kb/update-firefox-latest-version" class="btn-accept button-flat-green"></a></li>
+          <li><button class="btn-cancel" type="button"></button></li>
+        </ul>
+      </div>
+    {% endblock %}
+
     {# for headers not to be confined by #wrapper (like fx family nav) #}
     {% block site_header_unwrapped %}{% endblock %}
 

--- a/bedrock/base/templates/base.html
+++ b/bedrock/base/templates/base.html
@@ -90,6 +90,17 @@
       data-global-previous="{{ _('Previous') }}"
       data-global-update-firefox="{{ _('Update your Firefox') }}"
       {% block string_data %}{% endblock %}></div>
+
+      {% block infobar %}
+        <div id="mozilla-infobar" class="mozilla-infobar hidden" role="dialog" aria-hidden="true" data-infobar="{% block infobar_bars %}update translate{% endblock %}">
+          <p></p>
+          <ul>
+            <li><a href="https://support.mozilla.org/kb/update-firefox-latest-version" class="btn-accept button-flat-green"></a></li>
+            <li><button class="btn-cancel" type="button"></button></li>
+          </ul>
+        </div>
+      {% endblock %}
+
     <div id="outer-wrapper">
     <div id="wrapper">
 

--- a/bedrock/firefox/templates/firefox/australis/firstrun.html
+++ b/bedrock/firefox/templates/firefox/australis/firstrun.html
@@ -22,6 +22,8 @@
   {% javascript 'firefox_tour_none' %}
 {% endblock %}
 
+{% block infobar %}{% endblock %}
+
 {% block main_heading %}
   <header role="banner">
     <div class="logo"></div>

--- a/bedrock/firefox/templates/firefox/australis/fx36/tour.html
+++ b/bedrock/firefox/templates/firefox/australis/fx36/tour.html
@@ -52,6 +52,8 @@ data-step3="{{ _('3/4') }}"
 data-step4="{{ _('4/4') }}"
 {% endblock %}
 
+{% block infobar %}{% endblock %}
+
 {% block site_header %}
   <header id="masthead">
     <div id="tabzilla">

--- a/bedrock/firefox/templates/firefox/dev-firstrun.html
+++ b/bedrock/firefox/templates/firefox/dev-firstrun.html
@@ -51,6 +51,8 @@ data-sync-reminder-text="{{ _('If you continue without syncing your new Develope
 
 {% endblock %}
 
+{% block infobar %}{% endblock %}
+
 {% block site_header_nav %}{% endblock %}
 {% block site_header_logo %}
   <h2>{{ high_res_img('firefox/firstrun/dev/title.png', {'alt': _('Firefox Developer Edition'), 'width': '220', 'height': '84'}) }}</h2>

--- a/bedrock/firefox/templates/firefox/family/index.html
+++ b/bedrock/firefox/templates/firefox/family/index.html
@@ -33,6 +33,8 @@
 
 {% block body_class %}mozid{% endblock %}
 
+{% block infobar_bars %}translate{% endblock %}
+
 {% block site_header %}
   <div id="conditional-download-bar">
     <div class="content">

--- a/bedrock/firefox/templates/firefox/hello/index-2016.html
+++ b/bedrock/firefox/templates/firefox/hello/index-2016.html
@@ -25,6 +25,8 @@
   {% endif %}
 {% endblock %}
 
+{% block infobar_bars %}translate{% endblock %}
+
 {% block site_header %}{% endblock %}
 
 {% block site_header_unwrapped %}

--- a/bedrock/firefox/templates/firefox/hello/index.html
+++ b/bedrock/firefox/templates/firefox/hello/index.html
@@ -40,6 +40,8 @@ set share_urls = {
 }
 %}
 
+{% block infobar_bars %}translate{% endblock %}
+
 {% block site_header %}{% endblock %}
 
 {% block site_header_unwrapped %}

--- a/bedrock/firefox/templates/firefox/new.html
+++ b/bedrock/firefox/templates/firefox/new.html
@@ -51,6 +51,8 @@
   {% endif %}
 {% endblock %}
 
+{% block infobar_bars %}translate{% endblock %}
+
 {% block content %}
 
 <main role="main">

--- a/bedrock/firefox/templates/firefox/new/scene1.html
+++ b/bedrock/firefox/templates/firefox/new/scene1.html
@@ -27,6 +27,8 @@
 
 {% block body_id %}firefox-new-scene1{% endblock %}
 
+{% block infobar_bars %}translate{% endblock %}
+
 {% block site_header_nav %}{% endblock %}
 {% block site_header_logo %}
   <h2>{{ high_res_img('firefox/new/header-firefox.png', {'alt': _('Firefox for desktop'), 'width': '223', 'height': '84'}) }}</h2>

--- a/bedrock/firefox/templates/firefox/new/scene2.html
+++ b/bedrock/firefox/templates/firefox/new/scene2.html
@@ -27,6 +27,8 @@
 
 {% block body_id %}firefox-new-scene2{% endblock %}
 
+{% block infobar_bars %}translate{% endblock %}
+
 {% block site_header_nav %}{% endblock %}
 {% block site_header_logo %}
   <h2>{{ high_res_img('firefox/new/header-firefox.png', {'alt': _('Firefox for desktop'), 'width': '223', 'height': '84'}) }}</h2>

--- a/bedrock/firefox/templates/firefox/private-browsing.html
+++ b/bedrock/firefox/templates/firefox/private-browsing.html
@@ -18,6 +18,8 @@
 
 {% block site_header %}{% endblock %}
 
+{% block infobar_bars %}translate{% endblock %}
+
 {% block site_header_unwrapped %}
   {{ fxfamilynav('desktop', 'private-browsing') }}
 {% endblock %}

--- a/bedrock/firefox/templates/firefox/sync.html
+++ b/bedrock/firefox/templates/firefox/sync.html
@@ -22,6 +22,8 @@
 
 {% block site_header %}{% endblock %}
 
+{% block infobar_bars %}translate{% endblock %}
+
 {% block site_header_unwrapped %}
   {{ fxfamilynav('desktop', 'sync', 'dark') }}
 {% endblock %}

--- a/bedrock/firefox/templates/firefox/tracking-protection-tour.html
+++ b/bedrock/firefox/templates/firefox/tracking-protection-tour.html
@@ -53,6 +53,8 @@ data-panel3-button="{{ _('Got it!') }}"
 {% block body_id %}tracking-protection-tour{% endblock %}
 {% block body_class %}{% endblock %}
 
+{% block infobar_bars %}update{% endblock %}
+
 {% block site_header %}{% endblock %}
 
 {% block content %}

--- a/bedrock/mozorg/templates/mozorg/plugincheck-b.html
+++ b/bedrock/mozorg/templates/mozorg/plugincheck-b.html
@@ -75,6 +75,8 @@
   data-media-url="{{ static('') }}"
 {% endblock %}
 
+{% block infobar_bars %}translate{% endblock %}
+
 {% block site_header_logo %}{% endblock %}
 
 {% block site_header_share %}

--- a/bedrock/mozorg/templates/mozorg/plugincheck-c.html
+++ b/bedrock/mozorg/templates/mozorg/plugincheck-c.html
@@ -75,6 +75,8 @@
   data-media-url="{{ static('') }}"
 {% endblock %}
 
+{% block infobar_bars %}translate{% endblock %}
+
 {% block site_header_logo %}{% endblock %}
 
 {% block site_header_share %}

--- a/bedrock/mozorg/templates/mozorg/plugincheck-d.html
+++ b/bedrock/mozorg/templates/mozorg/plugincheck-d.html
@@ -75,6 +75,8 @@
   data-media-url="{{ static('') }}"
 {% endblock %}
 
+{% block infobar_bars %}translate{% endblock %}
+
 {% block site_header_logo %}{% endblock %}
 
 {% block site_header_share %}

--- a/bedrock/mozorg/templates/mozorg/plugincheck.html
+++ b/bedrock/mozorg/templates/mozorg/plugincheck.html
@@ -75,6 +75,8 @@
   data-media-url="{{ static('') }}"
 {% endblock %}
 
+{% block infobar_bars %}translate{% endblock %}
+
 {% block site_header_share %}
   {% set share_urls = { 'twitter': 'http://mzl.la/17aqnLZ', 'googleplus': 'http://mzl.la/1FuAhTS', 'facebook': 'http://mzl.la/1z4Noqm' } -%}
   {% if l10n_has_tag('plugincheck_nosupport') -%}

--- a/bedrock/settings/static_media.py
+++ b/bedrock/settings/static_media.py
@@ -100,6 +100,7 @@ PIPELINE_CSS = {
         'source_filenames': (
             'css/sandstone/sandstone-resp.less',
             'css/tabzilla/tabzilla-static.less',
+            'css/infobar/infobar.less',
         ),
         'output_filename': 'css/responsive-bundle.css',
     },
@@ -141,6 +142,7 @@ PIPELINE_CSS = {
     'contribute-friends': {
         'source_filenames': (
             'css/mozorg/contribute/friends.less',
+            'css/infobar/infobar.less',
         ),
         'output_filename': 'css/contribute-friends-bundle.css',
     },
@@ -301,6 +303,7 @@ PIPELINE_CSS = {
         'source_filenames': (
             'css/base/mozilla-modal.less',
             'css/firefox/dev-firstrun.less',
+            'css/infobar/infobar.less',
         ),
         'output_filename': 'css/firefox_developer_firstrun-bundle.css',
     },
@@ -442,6 +445,7 @@ PIPELINE_CSS = {
             'css/firefox/family-nav.less',
             'css/firefox/os/in-the-news.less',
             'css/firefox/os/firefox-os-2-5.less',
+            'css/infobar/infobar.less',
         ),
         'output_filename': 'css/firefox_os_2_5-bundle.css',
     },
@@ -510,6 +514,7 @@ PIPELINE_CSS = {
             'css/firefox/australis/australis-page-common.less',
             'css/firefox/sync-animation.less',
             'css/firefox/australis/australis-page-stacked.less',
+            'css/infobar/infobar.less',
         ),
         'output_filename': 'css/firefox_tour_none-bundle.css',
     },
@@ -778,6 +783,7 @@ PIPELINE_CSS = {
             'css/styleguide/identity-webmaker.less',
             'css/styleguide/communications.less',
             'css/styleguide/products-firefox-os.less',
+            'css/infobar/infobar.less',
         ),
         'output_filename': 'css/styleguide-bundle.css',
     },
@@ -816,6 +822,7 @@ PIPELINE_CSS = {
         'source_filenames': (
             'css/base/mozilla-modal.less',
             'css/mozorg/contribute/contribute-2015.less',
+            'css/infobar/infobar.less',
         ),
         'output_filename': 'css/contribute-2015-bundle.css',
     },
@@ -938,6 +945,7 @@ PIPELINE_JS = {
             'js/libs/spin.min.js',  # used by js/newsletter/form.js
             'js/base/global.js',
             'js/base/global-init.js',
+            'js/infobar/infobar.js',
             'js/newsletter/form.js',
             'js/base/mozilla-client.js',
             'js/base/mozilla-input-placeholder.js',
@@ -980,6 +988,7 @@ PIPELINE_JS = {
         'source_filenames': (
             'js/libs/jquery-1.11.3.min.js',
             'js/mozorg/contribute/friends.js',
+            'js/infobar/infobar.js',
         ),
         'output_filename': 'js/contribute-friends-bundle.js'
     },
@@ -1517,6 +1526,7 @@ PIPELINE_JS = {
     'styleguide': {
         'source_filenames': (
             'js/styleguide/styleguide.js',
+            'js/infobar/infobar.js',
         ),
         'output_filename': 'js/styleguide-bundle.js',
     },
@@ -1560,6 +1570,7 @@ PIPELINE_JS = {
         'source_filenames': (
             'js/mozorg/contribute/contribute-2015-ga.js',
             'js/mozorg/contribute/contribute-2015.js',
+            'js/infobar/infobar.js',
         ),
         'output_filename': 'js/contribute-2015-bundle.js',
     },

--- a/media/css/infobar/infobar.less
+++ b/media/css/infobar/infobar.less
@@ -1,0 +1,54 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+@import "../sandstone/lib.less";
+
+.mozilla-infobar {
+    position: relative;;
+    background-color: #fff;
+    color: #333;
+    padding: @baseLine / 2;
+    width: 100%;
+    height: 70px;
+    .font-size(1rem);
+    line-height: 1.5;
+    text-align: center;
+    .border-box;
+
+    * {
+        .border-box;
+    }
+
+    p,
+    li {
+        display: inline;
+        margin: 0 (@baseLine / 2) 0 0;
+        .font-size(1rem);
+    }
+
+    ul {
+        display: inline;
+        margin: 0;
+        list-style-type: none;
+    }
+
+    button.btn-cancel {
+        display: inline-block;
+        background-color: #fff;
+        margin-top: 0;
+        padding: @baseLine / 2;
+        border: 0;
+        width: auto;
+        .font-size(.8rem);
+        cursor: pointer;
+        white-space: nowrap;
+    }
+}
+
+[dir="rtl"] {
+    .mozilla-infobar p,
+    .mozilla-infobar li {
+        margin: 0 0 0 (@baseLine / 2);
+    }
+}

--- a/media/js/infobar/infobar.js
+++ b/media/js/infobar/infobar.js
@@ -187,25 +187,17 @@
      */
     InfoBar.prototype.getAcceptLangs = function(userLangs) {
         var userAcceptLangs;
-        userLangs = userLangs || navigator.languages || navigator.browserLanguage;
-
         // Note that navigator.language doesn't always work because it's just
         // the application's locale on some browsers. navigator.languages has
         // not been widely implemented yet, but the new property provides an
         // array of the user's accept languages that we'd like to see.
         // navigator.languages are only supported from Firefox/Chrome 32 and
-        // not at all by IE, Safari, Opera. navigator.language is not supported
-        // by IE so, we need to fallback to navigator.browserLanguage
-        if (navigator.languages) {
-            // Normalize all language strings for easier comparison.
-            userAcceptLangs = $.map(userLangs, function (lang) {
-                return InfoBar.prototype.normalize(lang);
-            });
-        } else if (navigator.browserLanguage) {
-            // the above properties only return one item but we need
-            // this as an array in the getOfferedLang function.
-            userAcceptLangs = [userLangs];
-        }
+        // not at all by IE, Safari, Opera.
+        userLangs = userLangs || navigator.languages;
+
+        userAcceptLangs = $.map(userLangs, function (lang) {
+            return InfoBar.prototype.normalize(lang);
+        });
 
         return userAcceptLangs;
     };
@@ -330,10 +322,10 @@
         }
 
         if (config.opened) {
-            config.bar.toggleClass('hidden');
+            config.bar.toggleClass('infobar-hidden');
             config.bar.attr('aria-hidden', true);
         } else {
-            config.bar.toggleClass('hidden');
+            config.bar.toggleClass('infobar-hidden');
             config.bar.attr('aria-hidden', false);
         }
 
@@ -494,14 +486,18 @@
 
     // expose InfoBar to the global scope
     window.InfoBar = InfoBar;
+    // get the user's acceptLanguages
+    config.acceptLangs = InfoBar.prototype.getAcceptLangs();
 
-    if (config.$infoBar.length === 0) {
-        // No $infoBar element exists, return false;
+    //getAcceptLangs uses navigator.languages which is currently only supported by
+    // Firefox and Chrome. For the translation bar, we need this property so, if the
+    // above returned undefined, no need to proceed any further.
+    // Note: As the Update Bar only targets Firefox desktop, this check will not affect
+    // it's functionality, so this is safe.
+    if (config.$infoBar.length === 0 || typeof config.acceptLangs === 'undefined') {
         return false;
     }
 
-    // get the user's acceptLanguages
-    config.acceptLangs = InfoBar.prototype.getAcceptLangs();
     // get the current page's language
     config.pageLang = InfoBar.prototype.normalize(document.documentElement.lang);
     // $infoBar exists, call setup

--- a/media/js/infobar/infobar.js
+++ b/media/js/infobar/infobar.js
@@ -1,0 +1,509 @@
+(function() {
+
+    'use strict';
+
+    var config = {
+        // The $infoBar HTML element
+        $infoBar: {},
+        $message: {},
+        $acceptButton: {},
+        $cancelButton: {},
+        // info bar(s) the user wish to use
+        bars: [],
+        // The current instance of an InfoBar
+        bar: {},
+        opened: false,
+        json: {},
+        pageLang: '',
+        // list of available languags from either a list of hreflang links
+        // or options from a select element. Populated by @getAvailableLangs
+        availableLangs: {},
+        // Array of one or more user languages as exposed by the user agent
+        acceptLangs:[],
+        // The language used to load the strings and data for the InfoBar
+        offeredLang: ''
+    };
+
+    var InfoBar = function (id, name) {
+        this.id = id;
+        this.name = name;
+        this.disabled = false;
+        this.prefName = 'infobar.' + id + '.disabled';
+
+        // Read the preference
+        try {
+            if (sessionStorage.getItem(this.prefName) === 'true') {
+                this.disabled = true;
+            }
+        } catch (ex) {
+            console.log('Error thrown while getting disabled state from sessionStorage: ', ex);
+        }
+
+        // If there is already another $infoBar, don't show this
+        if (config.$infoBar.filter(':visible').length) {
+            this.disabled = true;
+        }
+    };
+
+    /**
+     * Returns selected language's BiDi layout.
+     * False = left-to-right layout
+     * True = right-to-left layout
+     * @param {sting} lang - A language string such as en-US
+     */
+    InfoBar.prototype.getLanguageBidi = function(lang) {
+        // Languages using BiDi (right-to-left) layout
+        var LANGUAGES_BIDI = ['he', 'ar', 'fa', 'ur'];
+
+        if (!lang) {
+            return false;
+        }
+
+        var baseLang = lang.split('-')[0];
+        return $.inArray(baseLang, LANGUAGES_BIDI) > -1;
+    };
+
+    /**
+     * Normalize the user language in the form of ab or ab-CD
+     * @param {string} lang - The language string to be normalized
+     */
+    InfoBar.prototype.normalize = function (lang) {
+        return lang.replace(/^(\w+)(?:-(\w+))?$/, function (m, p1, p2) {
+            return p1.toLowerCase() + ((p2) ? '-' + p2.toUpperCase() : '');
+        });
+    };
+
+    /**
+     * Gets and sets the list of available languags from either a list of hreflang links
+     * or options from a select element. If neither is found, it simply returns false.
+     */
+    InfoBar.prototype.getAvailableLangs = function() {
+        var $links = $('link[hreflang]');
+        var $options = $('#page-language-select option');
+        var availableLangs = {};
+
+        // Make a dictionary from alternate URLs or a language selector. The key
+        // is a language, the value is the relevant <link> or <option> element.
+        if ($links.length) {
+            $links.each(function () {
+                availableLangs[InfoBar.prototype.normalize(this.hreflang)] = this;
+            });
+            return availableLangs;
+        } else if ($options.length) {
+            $options.each(function () {
+                availableLangs[InfoBar.prototype.normalize(this.value.match(/^\/?([\w\-]+)/)[1])] = this;
+            });
+            return availableLangs;
+        } else {
+            // If those lists cannot be found, there is nothing to do
+            return false;
+        }
+    };
+
+    /**
+     * Determines whether the users accept language(s) match the current
+     * page language.
+     * @param {array} acceptLangs - Array of user accept languages
+     * @param {string} [pageLang] - The current page language
+     */
+    InfoBar.prototype.userLangPageLangMatch = function(acceptLangs, pageLang) {
+
+        var match = false;
+        config.pageLang = pageLang || config.pageLang;
+
+        $.each(acceptLangs, function(index, userLang) {
+            if (config.pageLang === userLang || config.pageLang === userLang.split('-')[0]) {
+                match = true;
+            }
+        });
+
+        return match;
+    };
+
+    /**
+     * Compares the user’s accept languages against the page’s current
+     * language and other available languages to find the best language.
+     * @param {array} acceptLangs - Array of user accept languages
+     * @param {string} pageLang - The current page language
+     */
+    InfoBar.prototype.getOfferedLang = function(acceptLangs, pageLang) {
+        var shortUserLang = '';
+        var offeredLang;
+
+        config.pageLang = pageLang || config.pageLang;
+        config.availableLangs = InfoBar.prototype.getAvailableLangs();
+
+        // If there are no available languages, we have nothing to do.
+        if (!config.availableLangs) {
+            return false;
+        }
+
+        // If the users accept language(s) match page lang, we are done.
+        if (InfoBar.prototype.userLangPageLangMatch(acceptLangs)) {
+            return false;
+        }
+
+        // Compare the user's accept languages against available
+        // languages to find the best language
+        $.each(acceptLangs, function(index, userLang) {
+
+            shortUserLang = userLang.split('-')[0];
+
+            if (userLang in config.availableLangs || shortUserLang in config.availableLangs) {
+                offeredLang = userLang;
+            }
+        });
+
+        // If there is no offered language return false, else true
+        return !offeredLang ? false : offeredLang;
+    };
+
+    /**
+     * Get's the list of the user's acceptLanguages as appropriate for the
+     * current browser.
+     * @param {array} userLangs - Array of user accept languages
+     */
+    InfoBar.prototype.getAcceptLangs = function(userLangs) {
+        var userAcceptLangs;
+        userLangs = userLangs || navigator.languages || navigator.language || navigator.browserLanguage;
+
+        // Note that navigator.language doesn't always work because it's just
+        // the application's locale on some browsers. navigator.languages has
+        // not been widely implemented yet, but the new property provides an
+        // array of the user's accept languages that we'd like to see.
+        // navigator.languages are only supported from Firefox/Chrome 32 and
+        // not at all by IE, Safari, Opera. navigator.language is not supported
+        // by IE so, we need to fallback to navigator.browserLanguage
+        if (navigator.languages) {
+            // Normalize all language strings for easier comparison.
+            userAcceptLangs = $.map(userLangs, function (lang) {
+                return InfoBar.prototype.normalize(lang);
+            });
+        } else if (navigator.language || navigator.browserLanguage) {
+            // the above properties only return one item but we need
+            // this as an array in the getOfferedLang function.
+            userAcceptLangs = [userLangs];
+        }
+
+        return userAcceptLangs;
+    };
+
+    /**
+     * Calls each configured bar's main function
+     */
+     InfoBar.prototype.call = function() {
+         $(config.bars).each(function(index, value) {
+             InfoBar[value].call();
+         });
+     };
+
+    /**
+     * Main function called afer document.ready
+     * @param {array} acceptLangs - Array of user accept languages
+     * @param {string} pageLang - The current page language
+     */
+    InfoBar.prototype.setup = function(acceptLangs, pageLang) {
+        // we want to load the strings for the InfoBar based on the user's acceptLangs
+        // if we support the locale. We therefore first see if there is an offered language,
+        // else we fall back to the current page language for the strings.
+        config.offeredLang = InfoBar.prototype.getOfferedLang(acceptLangs) || pageLang;
+
+        // get and cache all the DOM elements we will need
+        config.$message = $('p', config.$infoBar);
+        config.$acceptButton = $('.btn-accept', config.$infoBar);
+        config.$cancelButton = $('.btn-cancel', config.$infoBar);
+
+        // get the info bar(s) the user wish to apply
+        config.bars = config.$infoBar.data('infobar').split(' ');
+
+        try {
+            config.json = JSON.parse(sessionStorage.getItem('infobar.json'));
+        } catch (ex) {
+            console.log('Error thrown while getting json from sessionStorage: ', ex);
+        }
+
+        // check if the JSON exists in sessionStorage
+        if (!config.json) {
+            var jsonURL = 'https://www.mozilla.org/' + config.offeredLang + '/infobar/infobar.jsonp';
+             // This loads the data for the transbar which also contains the latest fx version string.
+             $.ajax({
+                 url: jsonURL,
+                 cache: true,
+                 crossDomain: true,
+                 dataType: 'jsonp',
+                 jsonpCallback: '_',
+                 success: function(data) {
+                     // store the returned JSON in sessionStorage to avoid additional Ajax calls
+                     // during this user session.
+                     try {
+                         sessionStorage.setItem('infobar.json', JSON.stringify(data));
+                     } catch(ex) {
+                         console.log('Error while storing JSON in sessionStorage: ', ex);
+                     }
+
+                     config.json = data;
+                     InfoBar.prototype.call();
+                 }
+             }).fail(function(jqXHR, textStatus, errorThrown) {
+                 console.log('Error thrown while loading JSON:');
+                 console.log('textStatus: ', textStatus);
+                 console.log('errorThrown: ', errorThrown);
+             });
+        } else {
+            // the JSON has already been loaded earlier in this session.
+            InfoBar.prototype.call();
+        }
+    };
+
+    InfoBar.prototype.onshow = {};
+    InfoBar.prototype.onaccept = {};
+    InfoBar.prototype.oncancel = {};
+
+    /**
+     * Attempts to store the disabled status of the specified InfoBar in sessionStorage
+     * @param {string} prefName - The stored preference name for this InfoBar
+     */
+    InfoBar.prototype.setDisabledStatus = function(prefName) {
+        try {
+            sessionStorage.setItem(prefName, 'true');
+        } catch (ex) {
+            console.log('oncancel: Error while setting didabled status of InfoBar in sessionStorage');
+        }
+    };
+
+    /**
+     * Shows the relevant bar, binding events to the buttons.
+     */
+    InfoBar.prototype.show = function () {
+
+        // An infobar can be disabled by pref.
+        // Also, ensure there is no current active infobar
+        if (this.disabled || config.$infoBar.filter(':visible').length) {
+            return;
+        }
+
+        var self = this;
+        config.bar = self.element = config.$infoBar;
+
+        config.bar.find('.btn-accept').click(function (event) {
+            event.preventDefault();
+
+            if (self.onaccept.callback) {
+                self.onaccept.callback();
+            }
+
+            InfoBar.prototype.setDisabledStatus(self.prefName);
+            self.hide();
+        });
+
+        config.bar.find('.btn-cancel').click(function (event) {
+            event.preventDefault();
+
+            if (self.oncancel.callback) {
+                self.oncancel.callback();
+            }
+
+            InfoBar.prototype.setDisabledStatus(self.prefName);
+            self.hide();
+        });
+
+        if (self.onshow.callback) {
+            self.onshow.callback();
+        }
+
+        if (config.opened) {
+            config.bar.toggleClass('hidden');
+            config.bar.attr('aria-hidden', true);
+        } else {
+            config.bar.toggleClass('hidden');
+            config.bar.attr('aria-hidden', false);
+        }
+
+        return config.bar;
+    };
+
+    /**
+     * Hides the currently visible infoBar
+     */
+    InfoBar.prototype.hide = function () {
+        var self = this;
+        var target = (config.opened) ? self.element : config.bar;
+
+        target.animate({'height': 0}, 200, function () {
+            self.element.hide();
+            config.bar.attr('aria-hidden', true);
+        });
+    };
+
+    /**
+     * Populates the bar template with the relevant strings.
+     * @param {object} content - An object containing the template strings.
+     */
+    InfoBar.prototype.populateTmpl = function(content) {
+        config.$message.text(content.msg);
+        config.$acceptButton.text(content.accept);
+        config.$cancelButton.text(content.cancel);
+    };
+
+    /**
+     * Returns true if the current UA is one of the user agents based
+     * on Firefox.
+     */
+    InfoBar.prototype.isLikeFirefox = function(userAgent) {
+        var ua = userAgent || navigator.userAgent;
+        return (/Iceweasel/i).test(ua) || (/IceCat/i).test(ua) ||
+            (/SeaMonkey/i).test(ua) || (/Camino/i).test(ua) ||
+            (/like Firefox/i).test(ua);
+    };
+
+    /**
+     * Rturns true if this is a version of Firefox mobile excluding Firefox for iOS
+     */
+    InfoBar.prototype.isFirefoxMobile = function(userAgent) {
+        var ua = userAgent || navigator.userAgent;
+        return /Mobile|Tablet|Fennec/.test(ua);
+    };
+
+    /**
+     * Returns true if this is *the* Fox
+     */
+    InfoBar.prototype.isFirefox = function(userAgent) {
+        var ua = userAgent || navigator.userAgent;
+        return (/\sFirefox/).test(ua) && !InfoBar.prototype.isLikeFirefox(ua);
+    };
+
+    /**
+     * Returns the users current Firefox version
+     */
+    InfoBar.prototype.getUserVersion = function(userAgent) {
+        var ua = userAgent || navigator.userAgent;
+        return parseInt(ua.match(/Firefox\/(\d+)/)[1], 10);
+    };
+
+    /**
+     * This implements the update bar, shown for Firefox desktop users that has a version
+     * installed two major versions older than the latest.
+     * @param latestVersion {string} - Latest major version of Firefox (optional)
+     * @param buildID {int} - The UA buildID (optional)
+     */
+    InfoBar.update = function(latestVersion, buildID) {
+
+        var content = {};
+
+        latestVersion = parseInt(latestVersion || config.json.latestfx, 10);
+        buildID = buildID || navigator.buildID;
+
+        var updateBar = new InfoBar('update', 'Update Bar');
+
+        var isFirefox = InfoBar.prototype.isFirefox();
+        var isMobile = InfoBar.prototype.isFirefoxMobile();
+        var isFirefox31ESR = !isMobile && userVersion === 31 && buildID && buildID !== '20140716183446';
+        var isNewer = false;
+        var userVersion;
+
+        if (isFirefox) {
+            userVersion = InfoBar.prototype.getUserVersion();
+            isNewer = userVersion > latestVersion;
+        }
+
+        if (updateBar.disabled || !isFirefox || isMobile || isFirefox31ESR || isNewer) {
+            return false;
+        }
+
+        // Show the Update Bar if the user's major version is older than 3 major
+        // versions. Once the Mozilla.UITour API starts providing the channel
+        // info (Bug 1065525, Firefox 35+), we can show the Bar only to Release
+        // channel users. 31 ESR can be detected only with the navigator.buildID
+        // property. 20140716183446 is the non-ESR build ID that can be found at
+        // https://wiki.mozilla.org/Releases/Firefox_31/Test_Plan
+        if (userVersion < latestVersion - 2) {
+
+            content = {
+                msg: config.json.update_message,
+                accept: config.json.update_accept,
+                cancel: config.json.update_cancel
+            };
+
+            updateBar.populateTmpl(content);
+            updateBar.show();
+
+            // If the user accepts, show the SUMO article
+            updateBar.onaccept.callback = function () {
+                // leaving this as is for now, in case we want to do some GA measurements later on.
+                location.href = 'https://support.mozilla.org/kb/update-firefox-latest-version';
+            };
+
+            return true;
+        }
+    };
+
+    /**
+     * Offers the user a link to the current page in their language based on locale.
+     * @param {string} pageLang - The current page language
+     */
+    InfoBar.translate = function(pageLang) {
+
+        var content = {};
+        var translationBar = new InfoBar('transbar', 'Translation Bar');
+        var isMatch = InfoBar.prototype.userLangPageLangMatch(config.acceptLangs);
+
+        // if the users acceptLangs match the page or, the translationBar is disabled,
+        // or there is no config.pageLang set, there is nothing to do.
+        if (isMatch || translationBar.disabled || !config.pageLang) {
+            return false;
+        }
+
+        // Do not show Chrome's built-in Translation Bar
+        $('head').append('<meta name="google" value="notranslate">');
+
+        // clear the href of the $acceptButton
+        config.$acceptButton.attr('href', '');
+
+        // If the user selects Yes, show the translated page
+        translationBar.onaccept = {
+            callback: function () {
+
+                // en-US has an hreflang of "en" not "en-US" so, if the user's
+                // lang is en-US, shorten it to just "en"
+                config.offeredLang = config.offeredLang === 'en-US' ? 'en' : config.offeredLang;
+                var element = config.availableLangs[config.offeredLang];
+
+                if (element.form) { // <option>
+                    element.selected = true;
+                    element.form.submit();
+                } else { // <link>
+                    location.href = element.href;
+                }
+            }
+        };
+
+        content = {
+            msg: config.json.message,
+            accept: config.json.accept,
+            cancel: config.json.cancel
+        };
+
+        translationBar.populateTmpl(content);
+        translationBar.show().attr({
+            'lang': config.offeredLang,
+            'dir': translationBar.getLanguageBidi(config.offeredLang) ? 'rtl' : 'ltr'
+        });
+    };
+
+    config.$infoBar = $('#mozilla-infobar');
+    if (config.$infoBar.length === 0) {
+        // No $infoBar element exists, return false;
+        return false;
+    }
+
+    // get the user's acceptLanguages
+    config.acceptLangs = InfoBar.prototype.getAcceptLangs();
+    // get the current page's language
+    config.pageLang = InfoBar.prototype.normalize(document.documentElement.lang);
+    // $infoBar exists, call setup
+    InfoBar.prototype.setup(config.acceptLangs, config.pageLang);
+
+    // expose InfoBar to the global scope
+    window.InfoBar = InfoBar;
+
+})();

--- a/media/js/infobar/infobar.js
+++ b/media/js/infobar/infobar.js
@@ -41,7 +41,7 @@
         } catch (ex) {}
 
         // If there is already another $infoBar, don't show this
-        if (config.$infoBar.filter(':visible').length) {
+        if (!this.disabled && config.$infoBar.filter(':visible').length) {
             this.disabled = true;
         }
     };
@@ -118,6 +118,7 @@
 
             if (config.pageLang === value || config.pageLang === langCode) {
                 match = true;
+                return false;
             }
         });
 
@@ -158,7 +159,7 @@
 
             if (indexMatch || langCodeMatch) {
                 offeredLang = acceptLangs[index];
-                return;
+                return false;
             }
         });
 
@@ -171,7 +172,7 @@
 
                 if (indexMatch || langCodeMatch) {
                     offeredLang = index;
-                    return;
+                    return false;
                 }
             });
         }

--- a/media/js/infobar/infobar.js
+++ b/media/js/infobar/infobar.js
@@ -38,9 +38,7 @@
             if (sessionStorage.getItem(this.prefName) === 'true') {
                 this.disabled = true;
             }
-        } catch (ex) {
-            console.log('Error thrown while getting disabled state from sessionStorage: ', ex);
-        }
+        } catch (ex) {}
 
         // If there is already another $infoBar, don't show this
         if (config.$infoBar.filter(':visible').length) {
@@ -229,9 +227,7 @@
 
         try {
             config.json = JSON.parse(sessionStorage.getItem('infobar.json'));
-        } catch (ex) {
-            console.log('Error thrown while getting json from sessionStorage: ', ex);
-        }
+        } catch (ex) {}
 
         // check if the JSON exists in sessionStorage
         if (!config.json) {
@@ -248,17 +244,11 @@
                      // during this user session.
                      try {
                          sessionStorage.setItem('infobar.json', JSON.stringify(data));
-                     } catch(ex) {
-                         console.log('Error while storing JSON in sessionStorage: ', ex);
-                     }
+                     } catch(ex) {}
 
                      config.json = data;
                      InfoBar.prototype.call();
                  }
-             }).fail(function(jqXHR, textStatus, errorThrown) {
-                 console.log('Error thrown while loading JSON:');
-                 console.log('textStatus: ', textStatus);
-                 console.log('errorThrown: ', errorThrown);
              });
         } else {
             // the JSON has already been loaded earlier in this session.
@@ -277,9 +267,7 @@
     InfoBar.prototype.setDisabledStatus = function(prefName) {
         try {
             sessionStorage.setItem(prefName, 'true');
-        } catch (ex) {
-            console.log('oncancel: Error while setting didabled status of InfoBar in sessionStorage');
-        }
+        } catch (ex) {}
     };
 
     /**

--- a/media/js/infobar/infobar.js
+++ b/media/js/infobar/infobar.js
@@ -136,7 +136,7 @@
         var langCode = '';
         var indexMatch = false;
         var langCodeMatch = false;
-        var offeredLang;
+        var offeredLang = false;
 
         config.pageLang = pageLang || config.pageLang;
         config.availableLangs = InfoBar.prototype.getAvailableLangs();
@@ -160,6 +160,7 @@
 
             if (indexMatch || langCodeMatch) {
                 offeredLang = acceptLangs[index];
+                return;
             }
         });
 
@@ -172,12 +173,12 @@
 
                 if (indexMatch || langCodeMatch) {
                     offeredLang = index;
+                    return;
                 }
             });
         }
 
-        // If there is no offered language return false, else true
-        return !offeredLang ? false : offeredLang;
+        return offeredLang;
     };
 
     /**
@@ -392,7 +393,7 @@
      */
     InfoBar.update = function(latestVersion, userAgent, buildID) {
 
-        var ua = userAgent || config.userAgent
+        var ua = userAgent || config.userAgent;
 
         latestVersion = parseInt(latestVersion || config.json.latestfx, 10);
         buildID = buildID || navigator.buildID;
@@ -407,7 +408,7 @@
         var userVersion;
 
         if (isFirefox) {
-            userVersion = parseInt(ua.match(/Firefox\/(\d+)/)[1], 10);;
+            userVersion = parseInt(ua.match(/Firefox\/(\d+)/)[1], 10);
             isNewer = userVersion > latestVersion;
         }
 

--- a/media/js/infobar/infobar.js
+++ b/media/js/infobar/infobar.js
@@ -111,11 +111,10 @@
         var match = false;
         config.pageLang = pageLang || config.pageLang;
 
-        $.each(acceptLangs, function(index, userLang) {
-            if (config.pageLang === userLang || config.pageLang === userLang.split('-')[0]) {
-                match = true;
-            }
-        });
+        // use the first item in the array to determine the match
+        if (config.pageLang === acceptLangs[0] || config.pageLang === acceptLangs[0].split('-')[0]) {
+            match = true;
+        }
 
         return match;
     };
@@ -143,16 +142,13 @@
             return false;
         }
 
-        // Compare the user's accept languages against available
+        // Compare the first entry in the user's accept languages against available
         // languages to find the best language
-        $.each(acceptLangs, function(index, userLang) {
+        shortUserLang = acceptLangs[0].split('-')[0];
 
-            shortUserLang = userLang.split('-')[0];
-
-            if (userLang in config.availableLangs || shortUserLang in config.availableLangs) {
-                offeredLang = userLang;
-            }
-        });
+        if (acceptLangs[0] in config.availableLangs || shortUserLang in config.availableLangs) {
+            offeredLang = acceptLangs[0];
+        }
 
         // If there is no offered language return false, else true
         return !offeredLang ? false : offeredLang;

--- a/media/js/infobar/infobar.js
+++ b/media/js/infobar/infobar.js
@@ -15,7 +15,7 @@
         opened: false,
         json: {},
         pageLang: '',
-        // list of available languags from either a list of hreflang links
+        // list of available languages from either a list of hreflang links
         // or options from a select element. Populated by @getAvailableLangs
         availableLangs: {},
         // Array of one or more user languages as exposed by the user agent
@@ -53,7 +53,7 @@
      */
     InfoBar.prototype.getLanguageBidi = function(lang) {
         // Languages using BiDi (right-to-left) layout
-        var LANGUAGES_BIDI = ['he', 'ar', 'fa', 'ur'];
+        var LANGUAGES_BIDI = ['ar', 'fa', 'he', 'ur'];
 
         if (!lang) {
             return false;
@@ -74,7 +74,7 @@
     };
 
     /**
-     * Gets and sets the list of available languags from either a list of hreflang links
+     * Gets and sets the list of available languages from either a list of hreflang links
      * or options from a select element. If neither is found, it simply returns false.
      */
     InfoBar.prototype.getAvailableLangs = function() {
@@ -101,7 +101,7 @@
     };
 
     /**
-     * Determines whether the users accept language(s) match the current
+     * Determines whether the user's accept language list matches the current
      * page language.
      * @param {array} acceptLangs - Array of user accept languages
      * @param {string} [pageLang] - The current page language
@@ -155,13 +155,13 @@
     };
 
     /**
-     * Get's the list of the user's acceptLanguages as appropriate for the
+     * Gets the list of the user's acceptLanguages as appropriate for the
      * current browser.
      * @param {array} userLangs - Array of user accept languages
      */
     InfoBar.prototype.getAcceptLangs = function(userLangs) {
         var userAcceptLangs;
-        userLangs = userLangs || navigator.languages || navigator.language || navigator.browserLanguage;
+        userLangs = userLangs || navigator.languages || navigator.browserLanguage;
 
         // Note that navigator.language doesn't always work because it's just
         // the application's locale on some browsers. navigator.languages has
@@ -175,7 +175,7 @@
             userAcceptLangs = $.map(userLangs, function (lang) {
                 return InfoBar.prototype.normalize(lang);
             });
-        } else if (navigator.language || navigator.browserLanguage) {
+        } else if (navigator.browserLanguage) {
             // the above properties only return one item but we need
             // this as an array in the getOfferedLang function.
             userAcceptLangs = [userLangs];
@@ -353,7 +353,7 @@
     };
 
     /**
-     * Rturns true if this is a version of Firefox mobile excluding Firefox for iOS
+     * Returns true if this is a version of Firefox mobile excluding Firefox for iOS
      */
     InfoBar.prototype.isFirefoxMobile = function(userAgent) {
         var ua = userAgent || navigator.userAgent;

--- a/tests/unit/karma.conf.js
+++ b/tests/unit/karma.conf.js
@@ -40,6 +40,7 @@ module.exports = function(config) {
             'media/js/plugincheck/lib/utils.js',
             'media/js/plugincheck/lib/version-compare.js',
             'media/js/plugincheck/lib/plugincheck.js',
+            'media/js/infobar/infobar.js',
             'media/js/base/send-to-device.js',
             'tests/unit/spec/base/site.js',
             'tests/unit/spec/base/global.js',
@@ -61,6 +62,7 @@ module.exports = function(config) {
             'tests/unit/spec/plugincheck/lib/utils.js',
             'tests/unit/spec/plugincheck/lib/version-compare.js',
             'tests/unit/spec/plugincheck/lib/plugincheck.js',
+            'tests/unit/spec/infobar/infobar.js',
             'tests/unit/spec/base/send-to-device.js',
             {
                 pattern: 'node_modules/sinon/pkg/sinon.js',

--- a/tests/unit/spec/infobar/infobar.js
+++ b/tests/unit/spec/infobar/infobar.js
@@ -1,0 +1,207 @@
+/* For reference read the Jasmine and Sinon docs
+ * Jasmine docs: http://pivotal.github.io/jasmine/
+ * Sinon docs: http://sinonjs.org/docs/
+ */
+
+/* global describe, beforeEach, afterEach, it, expect, sinon, spyOn */
+
+describe('infobar.js', function() {
+
+    'use strict';
+
+    describe('InfoBar.prototype.getLanguageBidi', function () {
+        it('should return true for a rtl language', function() {
+            expect(InfoBar.prototype.getLanguageBidi('he')).toBeTruthy();
+        });
+
+        it('should return false for a ltr language', function() {
+            expect(InfoBar.prototype.getLanguageBidi('en-US')).toBeFalsy();
+        });
+    });
+
+    describe('InfoBar.prototype.normalize', function () {
+        it('should return en-US when en-us is specified', function() {
+            expect(InfoBar.prototype.normalize('en-us')).toBe('en-US');
+        });
+
+        it('should return ca when CA is specified', function() {
+            expect(InfoBar.prototype.normalize('CA')).toBe('ca');
+        });
+    });
+
+    describe('InfoBar.prototype.getAvailableLangs - hreflang', function () {
+
+        beforeEach(function() {
+            var hreflangLinks = [
+                '<link rel="alternate" hreflang="es-ES" href="http://www.mozilla.org/es-ES/firefox/new/" />',
+                '<link rel="alternate" hreflang="fr" href="http://www.mozilla.org/fr/firefox/new/" />'
+            ].join();
+
+            $(hreflangLinks).appendTo('head');
+        });
+
+        afterEach(function() {
+            $('link[hreflang]').remove();
+        });
+
+        it('should populate the availableLangs object with two elements', function() {
+            var availableLangs = InfoBar.prototype.getAvailableLangs();
+            expect(Object.keys(availableLangs).length).toBe(2);
+        });
+
+        it('should have es-ES entry in availableLangs array', function() {
+            var availableLangs = InfoBar.prototype.getAvailableLangs();
+            expect(availableLangs['es-ES']).toBeDefined();
+        });
+    });
+
+    describe('InfoBar.prototype.getAvailableLangs - language selector', function() {
+
+        beforeEach(function() {
+            var select = [
+                '<select id="page-language-select" name="lang" dir="ltr">',
+                  '<option value="es-ES" lang="es-ES">Español (de España)</option>',
+                  '<option value="fr" lang="fr">Français</option>',
+                 '</select>'
+            ].join();
+
+            $(select).appendTo('body');
+        });
+
+        afterEach(function() {
+            $('#page-language-select').remove();
+        });
+
+        it('should populate the availableLangs object with two elements', function() {
+            var availableLangs = InfoBar.prototype.getAvailableLangs();
+            expect(Object.keys(availableLangs).length).toBe(2);
+        });
+
+        it('should have fr entry in availableLangs', function() {
+            var availableLangs = InfoBar.prototype.getAvailableLangs();
+            expect(availableLangs['fr']).toBeDefined();
+        });
+    });
+
+    describe('InfoBar.prototype.getAvailableLangs - no translations', function() {
+        it('should return false if no alternate translations exist', function() {
+            var isAvailableLangs = InfoBar.prototype.getAvailableLangs();
+            expect(isAvailableLangs).toBeFalsy();
+        });
+    });
+
+    describe('InfoBar.prototype.userLangPageLangMatch', function() {
+        it('should return true if the accept language match the page language', function() {
+            var acceptLangs = ['en-US', 'en'];
+            var match = InfoBar.prototype.userLangPageLangMatch(acceptLangs, 'en');
+            expect(match).toBeTruthy();
+        });
+
+        it('should return true if the accept language array contains the page language', function() {
+            var match = InfoBar.prototype.userLangPageLangMatch;
+            expect(match(['en-US'], 'en-US')).toBeTruthy();
+            expect(match(['en-US', 'en', 'fr'], 'en-US')).toBeTruthy();
+            expect(match(['fr', 'de'], 'fr')).toBeTruthy();
+            expect(match(['de', 'fr', 'en'], 'fr')).toBeTruthy();
+            expect(match(['ja', 'pt-PT', 'el', 'fr', 'en'], 'el')).toBeTruthy();
+            expect(match(['en-ZA', 'en-GB', 'en'], 'en-GB')).toBeTruthy();
+            expect(match(['fr-FR'], 'fr')).toBeTruthy();
+            expect(match(['el-GR'], 'el')).toBeTruthy();
+        });
+
+        it('should return false if the users language does not match the page language', function() {
+            var acceptLangs = ['en-US', 'en'];
+            var match = InfoBar.prototype.userLangPageLangMatch(acceptLangs, 'es-ES');
+            expect(match).toBeFalsy();
+        });
+    });
+
+    describe('InfoBar.prototype.getOfferedLang', function() {
+        it('should return false if there are no alternate languages', function() {
+            var offeredLang = InfoBar.prototype.getOfferedLang;
+            expect(offeredLang(['en-US', 'en'], 'es-ES')).toBeFalsy();
+        });
+    });
+
+    describe('InfoBar.prototype.getOfferedLang', function() {
+
+        beforeEach(function() {
+            var hreflangLinks = [
+                '<link rel="alternate" hreflang="es-ES" href="http://www.mozilla.org/es-ES/firefox/new/" />',
+                '<link rel="alternate" hreflang="fr" href="http://www.mozilla.org/fr/firefox/new/" />'
+            ].join();
+
+            $(hreflangLinks).appendTo('head');
+        });
+
+        afterEach(function() {
+            $('link[hreflang]').remove();
+        });
+
+        it('should return false if the page language matches the user\'s primary language', function() {
+            var offeredLang = InfoBar.prototype.getOfferedLang;
+            expect(offeredLang(['es-ES', 'es'], 'es-ES')).toBeFalsy();
+        });
+
+        it('should return the available offered language', function() {
+            var offeredLang = InfoBar.prototype.getOfferedLang;
+            expect(offeredLang(['de', 'fr'], 'en-US')).toBe('fr');
+            expect(offeredLang(['de', 'it', 'pt-PT', 'es'], 'en-US')).toBe('es-ES');
+        });
+
+        it('should return false if no primary language match, nor available language match were found', function() {
+            var offeredLang = InfoBar.prototype.getOfferedLang;
+            expect(offeredLang(['de', 'it'], 'en-US')).toBeFalsy();
+        });
+    });
+
+    describe("infobar.update", function () {
+
+        var setup = function (ua, buildID) {
+            // Test a case where the latest version is a non-dot release
+            var result1 = InfoBar.update('35.0', ua, buildID);
+            // Test a case where the latest version is a dot release
+            var result2 = InfoBar.update('35.0.1', ua, buildID);
+            return result1 && result2;
+        }
+
+        it('should return false if the user agent is not Firefox', function () {
+            expect(setup('Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Trident/5.0)')).toBeFalsy();
+            expect(setup('Mozilla/5.0 (Macintosh; U; PPC Mac OS X 10.4; en; rv:1.9.2.24) Gecko/20111114 Camino/2.1 (like Firefox/3.6.24)')).toBeFalsy();
+            expect(setup('Mozilla/5.0 (X11; Linux i686; rv:10.0.1) Gecko/20100101 Firefox/10.0.1 SeaMonkey/2.7.1')).toBeFalsy();
+            expect(setup('Mozilla/5.0 (Windows NT 5.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1650.16 Safari/537.36')).toBeFalsy();
+        });
+
+        it('should return false if the user agent is a latest Firefox version', function () {
+            expect(setup('Mozilla/5.0 (Macintosh; Intel Mac OS X 10.9; rv:39.0) Gecko/20100101 Firefox/39.0')).toBeFalsy();
+            expect(setup('Mozilla/5.0 (Windows NT 6.1; Win64; x64; rv:36.0) Gecko/20100101 Firefox/36.0')).toBeFalsy();
+            expect(setup('Mozilla/5.0 (Macintosh; Intel Mac OS X 10.8; rv:34.0) Gecko/20100101 Firefox/34.0')).toBeFalsy();
+        });
+
+        it('should return false if the user agent is Firefox for mobile', function () {
+            // Nokia N900 Linux mobile, on the Fennec browser
+            expect(setup('Mozilla/5.0 (Maemo; Linux armv7l; rv:10.0) Gecko/20100101 Firefox/10.0 Fennec/10.0')).toBeFalsy();
+            // Android phone and tablet
+            expect(setup('Mozilla/5.0 (Android; Mobile; rv:26.0) Gecko/26.0 Firefox/26.0')).toBeFalsy();
+            expect(setup('Mozilla/5.0 (Android; Tablet; rv:26.0) Gecko/26.0 Firefox/26.0')).toBeFalsy();
+            // Firefox OS phone and tablet
+            expect(setup('Mozilla/5.0 (Mobile; rv:26.0) Gecko/26.0 Firefox/26.0')).toBeFalsy();
+            expect(setup('Mozilla/5.0 (Tablet; rv:26.0) Gecko/26.0 Firefox/26.0')).toBeFalsy();
+        });
+
+        it('should return false if the user agent is Firefox ESR', function () {
+            // Firefox 31 ESR
+            expect(setup('Mozilla/5.0 (Windows NT 6.1; Win64; x64; rv:31.0) Gecko/20100101 Firefox/31.0', '20140717132905')).toBeFalsy();
+            // Firefox 31.4.0 ESR
+            expect(setup('Mozilla/5.0 (Windows NT 6.1; Win64; x64; rv:31.0) Gecko/20100101 Firefox/31.0', '20150105205548')).toBeFalsy();
+        });
+
+        it('should return true if the user agent is an outdated Firefox version', function () {
+            expect(setup('Mozilla/5.0 (Windows NT 6.1; Win64; x64; rv:22.0) Gecko/20100101 Firefox/22.0')).toBeTruthy();
+            expect(setup('Mozilla/5.0 (Windows NT 6.2; WOW64; rv:16.0.1) Gecko/20121011 Firefox/16.0.1')).toBeTruthy();
+            expect(setup('Mozilla/5.0 (X11; U; Linux x86_64; en-US; rv:1.9.2.9) Gecko/20100915 Gentoo Firefox/3.6.9')).toBeTruthy();
+            // Firefox 31 non-ESR
+            expect(setup('Mozilla/5.0 (Windows NT 6.1; Win64; x64; rv:31.0) Gecko/20100101 Firefox/31.0', '20140716183446')).toBeTruthy();
+        });
+    });
+});


### PR DESCRIPTION
Couple of notes:

The code for the new infobar lives at:
https://github.com/mozilla/mozilla-infobar/

I am mentioning that, because the code has thus already been reviewed. With that said though, I have made some changes based on bugs and edge cases I ran into whilst integrating it into Bedrock so, looking over the code during this pull request works for me.

Next thing, I have spot checked a bunch of pages (I will be sharing a Google Sheet with the details).

I tested the translation bar using en-US, de and fr. I switched locales using about:config in Fx, as I cannot find an addon that actually works.

I did not test this in any other browsers. The only bar that should appear in these will be the Translation Bar. I did test that the update bar does not show.

As with Fx, I cannot find a language switcher that works as advertised. I did attempt to adjust the language setting using Language and input settings in Chrome but, this does not have the desired effect. Any suggestions here are welcome.

@alexgibson @craigcook @jpetto @kyoshino 
