### PR TITLE
Separate integration test suites into per push and per tag

### DIFF
--- a/docker/jenkins/properties/integration_tests/per_push/firefox.properties
+++ b/docker/jenkins/properties/integration_tests/per_push/firefox.properties
@@ -1,0 +1,4 @@
+DRIVER=SauceLabs
+BROWSER_NAME=firefox
+PLATFORM=Windows 10
+MARK_EXPRESSION=not headless

--- a/docker/jenkins/properties/integration_tests/per_push/headless.properties
+++ b/docker/jenkins/properties/integration_tests/per_push/headless.properties
@@ -1,0 +1,1 @@
+MARK_EXPRESSION=headless

--- a/docker/jenkins/properties/integration_tests/per_tag/chrome.properties
+++ b/docker/jenkins/properties/integration_tests/per_tag/chrome.properties
@@ -1,0 +1,4 @@
+DRIVER=SauceLabs
+BROWSER_NAME=chrome
+PLATFORM=Windows 10
+MARK_EXPRESSION=not headless

--- a/docker/jenkins/properties/integration_tests/per_tag/ie.properties
+++ b/docker/jenkins/properties/integration_tests/per_tag/ie.properties
@@ -1,0 +1,4 @@
+DRIVER=SauceLabs
+BROWSER_NAME=internet explorer
+PLATFORM=Windows 10
+MARK_EXPRESSION=not headless

--- a/docker/jenkins/properties/integration_tests/per_tag/ie6.properties
+++ b/docker/jenkins/properties/integration_tests/per_tag/ie6.properties
@@ -1,0 +1,5 @@
+DRIVER=SauceLabs
+BROWSER_NAME=internet explorer
+BROWSER_VERSION=6.0
+PLATFORM=Windows XP
+MARK_EXPRESSION=sanity

--- a/docker/jenkins/properties/integration_tests/per_tag/ie7.properties
+++ b/docker/jenkins/properties/integration_tests/per_tag/ie7.properties
@@ -1,0 +1,5 @@
+DRIVER=SauceLabs
+BROWSER_NAME=internet explorer
+BROWSER_VERSION=7.0
+PLATFORM=Windows XP
+MARK_EXPRESSION=sanity


### PR DESCRIPTION
### Guidelines
Before you submit a pull request, please make sure you have done the following:

- [x] Review the guidelines for contributing to this repository (link above in GitHub ^).
- [x] All commit messages should be well written, and reference a Bugzilla bug number where applicable.

Note: If you're unsure about anything here or below, don't worry! Just fill out as much
information as you can.

## Description
This will allow us to configure Jenkins to run certain integration test suites for every push, and others only for every tag. The existing properties files have been left behind so that the Jenkins configuration can be updated before these are removed.

## Bugzilla
N/A

## Testing
N/A

## Checklist
- [ ] Requires l10n changes.
- [ ] Related functional & integration tests passing.

