### PR TITLE
[fix bug 1250225] Use srcset for high res images.

### DIFF
--- a/bedrock/mozorg/helpers/misc.py
+++ b/bedrock/mozorg/helpers/misc.py
@@ -231,15 +231,11 @@ def high_res_img(ctx, url, optional_attributes=None):
         class_name = ''
         attrs = ''
 
-    # Don't download any image until the javascript sets it based on
-    # data-src so we can do high-dpi detection. If no js, show the
-    # normal-res version.
-    markup = ('<img class="js {class_name}" src="" data-processed="false" '
-              'data-src="{url}" data-high-res="true" '
-              'data-high-res-src="{url_high_res}"{attrs}><noscript>'
-              '<img class="{class_name}" src="{url}"{attrs}>'
-              '</noscript>').format(url=url, url_high_res=url_high_res,
-                                    attrs=attrs, class_name=class_name)
+    # Use native srcset attribute for high res images
+    markup = ('<img class="{class_name}" src="{url}" '
+              'srcset="{url_high_res} 1.5x"'
+              '{attrs}>').format(url=url, url_high_res=url_high_res,
+                                 attrs=attrs, class_name=class_name)
 
     return jinja2.Markup(markup)
 

--- a/bedrock/mozorg/tests/test_helper_misc.py
+++ b/bedrock/mozorg/tests/test_helper_misc.py
@@ -472,19 +472,17 @@ class TestHighResImg(TestCase):
         """Should return expected markup without optional attributes"""
         markup = self._render('test.png')
         expected = (
-            u'<img class="js " src="" data-processed="false" data-src="/media/img/test.png" '
-            u'data-high-res="true" data-high-res-src="/media/img/test-high-res.png">'
-            u'<noscript><img class="" src="/media/img/test.png"></noscript>')
+            u'<img class="" src="/media/img/test.png" '
+            u'srcset="/media/img/test-high-res.png 1.5x">')
         self.assertEqual(markup, expected)
 
     def test_high_res_img_with_optional_attributes(self):
         """Should return expected markup with optional attributes"""
         markup = self._render('test.png', {'data-test-attr': 'test', 'class': 'logo'})
         expected = (
-            u'<img class="js logo" src="" data-processed="false" data-src="/media/img/test.png" '
-            u'data-high-res="true" data-high-res-src="/media/img/test-high-res.png" '
-            u'data-test-attr="test"><noscript>'
-            u'<img class="logo" src="/media/img/test.png" data-test-attr="test"></noscript>')
+            u'<img class="logo" src="/media/img/test.png" '
+            u'srcset="/media/img/test-high-res.png 1.5x" '
+            u'data-test-attr="test">')
         self.assertEqual(markup, expected)
 
     def test_high_res_img_with_l10n(self):
@@ -493,9 +491,8 @@ class TestHighResImg(TestCase):
         l10n_hr_url = convert_to_high_res(l10n_url)
         markup = self._render('test.png', {'l10n': True})
         expected = (
-            u'<img class="js " src="" data-processed="false" data-src="' + l10n_url + '" '
-            u'data-high-res="true" data-high-res-src="' + l10n_hr_url + '">'
-            u'<noscript><img class="" src="' + l10n_url + '"></noscript>')
+            u'<img class="" src="' + l10n_url + '" '
+            u'srcset="' + l10n_hr_url + ' 1.5x">')
         self.assertEqual(markup, expected)
 
     def test_high_res_img_with_l10n_and_optional_attributes(self):
@@ -504,10 +501,8 @@ class TestHighResImg(TestCase):
         l10n_hr_url = convert_to_high_res(l10n_url)
         markup = self._render('test.png', {'l10n': True, 'data-test-attr': 'test'})
         expected = (
-            u'<img class="js " src="" data-processed="false" data-src="' + l10n_url + '" '
-            u'data-high-res="true" data-high-res-src="' + l10n_hr_url + '" data-test-attr="test">'
-            u'<noscript><img class="" src="' + l10n_url + '" data-test-attr="test">'
-            u'</noscript>')
+            u'<img class="" src="' + l10n_url + '" '
+            u'srcset="' + l10n_hr_url + ' 1.5x" data-test-attr="test">')
         self.assertEqual(markup, expected)
 
 

--- a/media/js/base/mozilla-image-helper.js
+++ b/media/js/base/mozilla-image-helper.js
@@ -11,7 +11,6 @@
 
 $(document).ready(function() {
     Mozilla.ImageHelper.initPlatformImages();
-    Mozilla.ImageHelper.initHighResImages();
 });
 
 // create namespace
@@ -24,10 +23,7 @@ if (typeof Mozilla == 'undefined') {
 /**
  * ImageHelper object
  */
-Mozilla.ImageHelper = function() {
-};
-
-Mozilla.ImageHelper.is_high_dpi = null;
+Mozilla.ImageHelper = function() {};
 
 // }}}
 
@@ -38,8 +34,7 @@ Mozilla.ImageHelper.initPlatformImages = function() {
     $('.platform-img').each(function() {
         var $img = $(this);
         var data_attribute = 'src-';
-        var is_high_res = $img.data('high-res') && Mozilla.ImageHelper.isHighDpi();
-        var suffix;
+        var is_high_res = $img.data('high-res');
         var new_src;
 
         if (site.platform == 'oldwin') {
@@ -52,57 +47,25 @@ Mozilla.ImageHelper.initPlatformImages = function() {
             data_attribute += site.platform;
         }
 
-        if (is_high_res) {
-            suffix = '-high-res';
-        }
-        else {
-            suffix = '';
-        }
+        new_src = $img.data(data_attribute);
 
-        new_src = $img.data(data_attribute + suffix);
         if (!new_src) {
             // fall back to windows
-            new_src = $img.data('src-windows' + suffix);
+            data_attribute = 'src-windows';
+            new_src = $img.data(data_attribute);
+        }
+
+        // if high res requested and path provided, set srcset attribute
+        // needs to be set prior to src to avoid downloading standard res image
+        // on high-res screens
+        if (is_high_res && $img.data(data_attribute + '-high-res')) {
+            $img.attr('srcset', $img.data(data_attribute + '-high-res') + ' 1.5x');
         }
 
         this.src = new_src;
-        $img.attr('data-processed', 'true');
+
         $img.addClass(site.platform);
     });
-};
-
-// }}}
-
-// High Resolution Images
-// {{{ initHighResImages()
-
-Mozilla.ImageHelper.initHighResImages = function() {
-    $('img[data-src][data-high-res="true"][data-processed="false"]').each(function() {
-        var $img = $(this);
-        var src = $img.data('src');
-        if (Mozilla.ImageHelper.isHighDpi()) {
-            src = $img.data('high-res-src');
-        }
-        this.src = src;
-        $img.attr('data-processed', 'true');
-    });
-};
-
-// }}}
-// {{{ isHighDpi()
-
-Mozilla.ImageHelper.isHighDpi = function() {
-    if (Mozilla.ImageHelper.is_high_dpi === null) {
-        var media_query = '(-webkit-min-device-pixel-ratio: 1.5),' +
-                          '(-o-min-device-pixel-ratio: 3/2),' +
-                          '(min--moz-device-pixel-ratio: 1.5),' +
-                          '(min-resolution: 1.5dppx)';
-
-        Mozilla.ImageHelper.is_high_dpi = (window.devicePixelRatio > 1 ||
-               (window.matchMedia && window.matchMedia(media_query).matches));
-    }
-
-    return Mozilla.ImageHelper.is_high_dpi;
 };
 
 // }}}

--- a/tests/unit/spec/base/mozilla-image-helper.js
+++ b/tests/unit/spec/base/mozilla-image-helper.js
@@ -28,7 +28,6 @@ describe('mozilla-image-helper.js', function() {
                             'data-src-ios="/img/browser-ios.png"' +
                             'data-src-ios-high-res="/img/browser-ios-high-res.png">';
 
-            stub = sinon.stub(Mozilla.ImageHelper, 'isHighDpi').returns(false);
             window.site = {
                 platform: 'other'
             };
@@ -37,7 +36,6 @@ describe('mozilla-image-helper.js', function() {
         });
 
         afterEach(function(){
-            Mozilla.ImageHelper.isHighDpi.restore();
             window.site.platform = null;
             $img.remove();
         });
@@ -75,13 +73,6 @@ describe('mozilla-image-helper.js', function() {
             Mozilla.ImageHelper.initPlatformImages();
             expect($img.attr('src')).toEqual('/img/browser-android.png');
             expect($img.hasClass('android')).toBeTruthy();
-        });
-
-        it('should flag when a platform image been processed', function () {
-            window.site.platform = 'windows';
-            expect($img.attr('data-processed')).toEqual('false');
-            Mozilla.ImageHelper.initPlatformImages();
-            expect($img.attr('data-processed')).toEqual('true');
         });
 
         it('should fall back to Windows if no appropriate platform image is found', function () {
@@ -122,73 +113,46 @@ describe('mozilla-image-helper.js', function() {
         });
 
         afterEach(function(){
-            Mozilla.ImageHelper.isHighDpi.restore();
             window.site.platform = null;
             $img.remove();
         });
 
-        it('should update platform image url for high resolution devices', function () {
-            stub = sinon.stub(Mozilla.ImageHelper, 'isHighDpi').returns(true);
-            window.site.platform = 'osx';
-            Mozilla.ImageHelper.initPlatformImages();
-            expect($img.attr('src')).toEqual('/img/browser-mac-high-res.png');
-            expect($img.hasClass('osx')).toBeTruthy();
-        });
-
-        it('should not update platform image url for low resolution devices', function () {
-            stub = sinon.stub(Mozilla.ImageHelper, 'isHighDpi').returns(false);
+        it('should add srcset attribute when data-high-res is true', function () {
             window.site.platform = 'osx';
             Mozilla.ImageHelper.initPlatformImages();
             expect($img.attr('src')).toEqual('/img/browser-mac.png');
+            expect($img.attr('srcset')).toEqual('/img/browser-mac-high-res.png 1.5x');
             expect($img.hasClass('osx')).toBeTruthy();
         });
-    });
 
-    describe('Mozilla.ImageHelper.initHighResImages', function() {
+        it('should not add srcset when data-high-res is not present', function () {
+            $img.removeAttr('data-high-res');
 
-        var stub;
-        var $img;
-
-        beforeEach(function () {
-            var tpl = '<img class="js" src=""' +
-                            'data-high-res="true"' +
-                            'data-processed="false"' +
-                            'data-src="/img/low-res.png"' +
-                            'data-high-res-src="/img/high-res.png">';
-            $img = $(tpl);
-            $img.appendTo('body');
+            window.site.platform = 'osx';
+            Mozilla.ImageHelper.initPlatformImages();
+            expect($img.attr('src')).toEqual('/img/browser-mac.png');
+            expect($img[0].hasAttribute('srcset')).toBeFalsy();
+            expect($img.hasClass('osx')).toBeTruthy();
         });
 
-        afterEach(function(){
-            Mozilla.ImageHelper.isHighDpi.restore();
-            $img.remove();
+        it('should not add srcset when high res platform path is not present', function () {
+            $img.removeAttr('data-src-mac-high-res');
+
+            window.site.platform = 'osx';
+            Mozilla.ImageHelper.initPlatformImages();
+            expect($img.attr('src')).toEqual('/img/browser-mac.png');
+            expect($img[0].hasAttribute('srcset')).toBeFalsy();
+            expect($img.hasClass('osx')).toBeTruthy();
         });
 
-        it('should update image url for high resolution devices', function() {
-            stub = sinon.stub(Mozilla.ImageHelper, 'isHighDpi').returns(true);
-            Mozilla.ImageHelper.initHighResImages();
-            expect($img.attr('src')).toEqual('/img/high-res.png');
-        });
+        it('should fall back to Windows high res if no appropriate platform image is found', function () {
+            $img.removeAttr('data-src-mac');
 
-        it('should not update image url for low resolution devices', function () {
-            stub = sinon.stub(Mozilla.ImageHelper, 'isHighDpi').returns(false);
-            Mozilla.ImageHelper.initHighResImages();
-            expect($img.attr('src')).toEqual('/img/low-res.png');
-        });
-
-        it('should flag when an image has been processed', function () {
-            stub = sinon.stub(Mozilla.ImageHelper, 'isHighDpi').returns(true);
-            expect($img.attr('data-processed')).toEqual('false');
-            Mozilla.ImageHelper.initHighResImages();
-            expect($img.attr('data-processed')).toEqual('true');
-        });
-
-        it('should not change the src of an image that is already processed', function () {
-            stub = sinon.stub(Mozilla.ImageHelper, 'isHighDpi').returns(true);
-            $img.attr('src', '/img/foo.png');
-            $img.attr('data-processed', 'true');
-            Mozilla.ImageHelper.initHighResImages();
-            expect($img.attr('src')).toEqual('/img/foo.png');
+            window.site.platform = 'osx';
+            Mozilla.ImageHelper.initPlatformImages();
+            expect($img.attr('src')).toEqual('/img/browser-windows.png');
+            expect($img.attr('srcset')).toEqual('/img/browser-windows-high-res.png 1.5x');
+            expect($img.hasClass('osx')).toBeTruthy();
         });
     });
 


### PR DESCRIPTION
## Description
As `srcset` is now widely supported, we'd prefer to let browsers handle when to load high resolution images rather than using our own custom JS.

## Bugzilla
[bug 1250225](https://bugzilla.mozilla.org/show_bug.cgi?id=1250225)

## Testing
If possible, test on both standard and high-resolution screens. Also, check/run Jasmine tests.

## Checklist
- [x] Related functional & integration tests passing.

