### PR TITLE
[fix bug 1252332] Redirect /sync to /firefox/sync

### DIFF
--- a/bedrock/firefox/redirects.py
+++ b/bedrock/firefox/redirects.py
@@ -299,4 +299,7 @@ redirectpatterns = (
     redirect(r'^firefox/os/2\.5/?$', 'firefox.os.index'),
     redirect(r'^firefox/os/faq/?$',
              'https://support.mozilla.org/products/firefox-os'),
+
+    # Bug 1252332
+    redirect(r'^sync/?$', 'firefox.sync'),
 )

--- a/etc/httpd/global.conf
+++ b/etc/httpd/global.conf
@@ -760,3 +760,6 @@ RewriteRule ^(/(?:\w{2,3}(?:-\w{2})?/)?firefox/beta/feedbackprivacypolicy/?)$ /b
 
 # bug 1149019
 RewriteRule ^(/certs/.*)$ /b$1 [PT]
+
+# bug 1252332
+RewriteRule ^(/(?:\w{2,3}(?:-\w{2})?/)?sync/?)$ /b$1 [PT]

--- a/tests/redirects/map_globalconf.py
+++ b/tests/redirects/map_globalconf.py
@@ -1001,4 +1001,7 @@ URLS = flatten((
     url_test('/firefox/os/1.1/', '/firefox/os/'),
     url_test('/firefox/os/faq/',
              'https://support.mozilla.org/products/firefox-os'),
+
+    # Bug 1252332
+    url_test('/sync/', '/firefox/sync/'),
 ))


### PR DESCRIPTION
## Description
Redirects `/sync/` to `/firefox/sync/`

## Bugzilla
https://bugzilla.mozilla.org/show_bug.cgi?id=1252332

## Checklist
- [ ] Requires l10n changes.
- [x] Related functional & integration tests passing.

