### PR TITLE
Docker Updates

### DIFF
--- a/docker/jenkins/build_image.sh
+++ b/docker/jenkins/build_image.sh
@@ -2,21 +2,18 @@
 #
 set -ex
 DOCKER_IMAGE_TAG=${DOCKER_REPOSITORY}:${GIT_COMMIT}
+TMP_DOCKER_TAG=${JOB_NAME}${BUILD_NUMBER}
 
 # If docker image exists and no force rebuild do nothing
 FORCE_REBUILD=`echo "$FORCE_REBUILD" | tr '[:upper:]' '[:lower:]'`
 if [[ $FORCE_REBUILD != "true" ]];
 then
-    if docker history -q $DOCKER_IMAGE_TAG 2> /dev/null;
+    if docker history -q $DOCKER_IMAGE_TAG > /dev/null;
     then
         echo "Docker image already exists, do nothing"
         exit 0;
     fi
 fi
-
-# Workaround to ignore mtime until we upgrade to Docker 1.8
-# See https://github.com/docker/docker/pull/12031
-find . -newerat 20140101 -exec touch -t 201401010000 {} \;
 
 cat docker/dockerfiles/${DOCKERFILE} | envsubst > Dockerfile
 
@@ -25,17 +22,19 @@ then
     NO_CACHE="true"
 fi;
 
-docker build -t $DOCKER_IMAGE_TAG --pull=${UPDATE_DOCKER_IMAGES:-false} --no-cache=${NO_CACHE:-false} . | tee docker-build.log
+docker build -t ${TMP_DOCKER_TAG} --pull=${UPDATE_DOCKER_IMAGES:-true} --no-cache=${NO_CACHE:-false} . | tee docker-build.log
+
+TAG=`tail -n 1 docker-build.log | awk '{ print $(NF) }'`
 
 if [[ $FORCE_REBUILD != "true" ]];
 then
     if tail -n 3 docker-build.log | grep "Using cache";
     then
         echo "Docker image already squashed, skip squashing";
-        TAG=`tail -n 1 docker-build.log | awk '{ print $(NF) }'`
-        docker tag -f $TAG $DOCKER_IMAGE_TAG
+        docker tag -f ${TAG}-squashed $DOCKER_IMAGE_TAG
         exit 0;
     fi
 fi
 
-docker save $DOCKER_IMAGE_TAG  | sudo docker-squash -t $DOCKER_IMAGE_TAG | docker load
+docker save ${TMP_DOCKER_TAG} | sudo docker-squash -t ${TAG}-squashed | docker load
+docker tag ${TAG}-squashed ${DOCKER_IMAGE_TAG}


### PR DESCRIPTION
The idea is that we're re-using `DOCKER_IMAGE_TAG` in pre-squashed and squashed images and we end up using an unsquashed bedrock image.  This affects image size.

Took the opportunity to update other parts of the script too. I can git squash if that's preferred.

I tested this manually outside the pipeline and seems to be working.