### PR TITLE
Remove functional tests properties files

### DIFF
--- a/docker/jenkins/properties/functional_tests/chrome.properties
+++ b/docker/jenkins/properties/functional_tests/chrome.properties
@@ -1,4 +1,0 @@
-DRIVER=SauceLabs
-BROWSER_NAME=chrome
-PLATFORM=Windows 10
-MARK_EXPRESSION=not headless

--- a/docker/jenkins/properties/functional_tests/firefox.properties
+++ b/docker/jenkins/properties/functional_tests/firefox.properties
@@ -1,4 +1,0 @@
-DRIVER=SauceLabs
-BROWSER_NAME=firefox
-PLATFORM=Windows 10
-MARK_EXPRESSION=not headless

--- a/docker/jenkins/properties/functional_tests/headless.properties
+++ b/docker/jenkins/properties/functional_tests/headless.properties
@@ -1,1 +1,0 @@
-MARK_EXPRESSION=headless

--- a/docker/jenkins/properties/functional_tests/ie.properties
+++ b/docker/jenkins/properties/functional_tests/ie.properties
@@ -1,4 +1,0 @@
-DRIVER=SauceLabs
-BROWSER_NAME=internet explorer
-PLATFORM=Windows 10
-MARK_EXPRESSION=not headless

--- a/docker/jenkins/properties/functional_tests/ie6.properties
+++ b/docker/jenkins/properties/functional_tests/ie6.properties
@@ -1,5 +1,0 @@
-DRIVER=SauceLabs
-BROWSER_NAME=internet explorer
-BROWSER_VERSION=6.0
-PLATFORM=Windows XP
-MARK_EXPRESSION=sanity

--- a/docker/jenkins/properties/functional_tests/ie7.properties
+++ b/docker/jenkins/properties/functional_tests/ie7.properties
@@ -1,5 +1,0 @@
-DRIVER=SauceLabs
-BROWSER_NAME=internet explorer
-BROWSER_VERSION=7.0
-PLATFORM=Windows XP
-MARK_EXPRESSION=sanity


### PR DESCRIPTION
These have been moved to docker/jenkins/properties/functional_tests/ and have been split into per-push and per-tag configurations. Jenkins has now been updated so we can remove the old properties files.

@alexgibson @jgmize r?