### PR TITLE
Remove CasperJS test command from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,9 +3,6 @@
   "version": "0.1.0",
   "description": "Making mozilla.org awesome, one pebble at a time",
   "private": true,
-  "scripts": {
-    "test": "PHANTOMJS_EXECUTABLE=./node_modules/.bin/phantomjs ./node_modules/.bin/casperjs test"
-  },
   "dependencies": {
     "cssmin": "0.4.3",
     "less": "2.4.0",


### PR DESCRIPTION
Noticed this in some of the [circleci builds errors](https://circleci.com/gh/mozilla/bedrock/21). Seems I forgot to remove it a while back