### PR TITLE
[fix bug 1250758] Add utm_ params to about:accounts.

### DIFF
--- a/bedrock/settings/static_media.py
+++ b/bedrock/settings/static_media.py
@@ -1228,6 +1228,7 @@ PIPELINE_JS = {
     },
     'firefox_sync': {
         'source_filenames': (
+            'js/base/search-params.js',
             'js/libs/jquery.waypoints.min.js',
             'js/libs/jquery.waypoints-sticky.min.js',
             'js/firefox/family-nav.js',
@@ -1302,6 +1303,7 @@ PIPELINE_JS = {
         'source_filenames': (
             'js/libs/script.js',
             'js/base/mozilla-modal.js',
+            'js/base/search-params.js',
             'js/base/send-to-device.js',
             'js/firefox/australis/australis-uitour.js',
             'js/libs/jquery.waypoints.min.js',

--- a/docs/uitour.rst
+++ b/docs/uitour.rst
@@ -428,18 +428,43 @@ Passing ``defaultBrowser`` will set Firefox as the default web browser.
 
     ``setConfiguration('defaultBrowser')`` is only available in Firefox 40 onward.
 
-showFirefoxAccounts();
+showFirefoxAccounts(extraURLCampaignParams);
 ^^^^^^^^^^^^^^^^^^^^^^
 
-Allows a web page to navigate directly to ``about:accounts?action=signup``
+Allows a web page to navigate directly to
+``about:accounts?action=signup&entrypoint=uitour``. In Firefox 47 and beyond,
+optionally accepts an object of ``utm_*`` key/values, which will be encoded and
+appended to the ``about:accounts`` querystring.
+
+.. Important::
+
+    All keys in ``extraURLCampaignParams`` must begin with ``utm_``. If an
+    invalid key is present, the call to ``showFirefoxAccounts`` will fail.
 
 .. code-block:: javascript
 
+    // no extra utm_ campaign params. will open
+    // about:accounts?action=signup&entrypoint=uitour
     Mozilla.UITour.showFirefoxAccounts();
+
+    // with extra utm_ campaign params. will open
+    // about:accounts?action=signup&entrypoint=uitour&utm_foo=bar&utm_bar=baz
+    Mozilla.UITour.showFirefoxAccounts({
+        'utm_foo': 'bar',
+        'utm_bar': 'baz'
+    });
 
 .. Important::
 
     ``showFirefoxAccounts()`` is only available in Firefox 31 onward.
+    ``extraURLCampaignParams`` parameter only functional in Firefox 47 onward.
+
+.. note::
+
+    A convenience method named ``utmParamsFxA`` exists in
+    ``js/base/search-params.js`` that pulls all ``utm_`` params from the current
+    page's URL and places them in an object (along with pre-defined defaults)
+    ready to pass to ``showFirefoxAccounts``.
 
 resetFirefox();
 ^^^^^^^^^^^^^^^

--- a/media/js/base/search-params.js
+++ b/media/js/base/search-params.js
@@ -42,3 +42,40 @@ _SearchParams.prototype.toString = function () {
         return [encodeURIComponent(key), encodeURIComponent(value)].join('=');
     }).join('&');
 };
+
+_SearchParams.prototype.utmParams = function() {
+    var utms = {};
+
+    $.each(this.params, function (key, val) {
+        if (key.indexOf('utm_') === 0) {
+            utms[key] = val;
+        }
+    });
+
+    return utms;
+};
+
+_SearchParams.prototype.utmParamsFxA = function(pathname) {
+    pathname = pathname || window.location.pathname || '';
+
+    var utms = this.utmParams();
+
+    // set to default value if not specified in URL
+    if (!utms.utm_campaign) {
+        // utm_* values will be encoded on the product side, so no need to
+        // pre-emptively encode here
+        utms.utm_campaign = 'page referral - not part of a campaign';
+    }
+
+    // remove locale from pathname and store result in utm_content
+    // e.g. https://www.mozilla.org/it/firefox/sync/?foo=bar should
+    // have utm_content value of /firefox/sync/.
+    var matches = pathname.match(/\/[\w-]+(\/.*)$/);
+
+    if (matches && matches.length > 1) {
+        // no need to encode - will be done on product side
+        utms.utm_content = matches[1];
+    }
+
+    return utms;
+};

--- a/media/js/firefox/australis/australis-uitour.js
+++ b/media/js/firefox/australis/australis-uitour.js
@@ -177,8 +177,21 @@ if (typeof Mozilla == 'undefined') {
         });
     };
 
-    Mozilla.UITour.showFirefoxAccounts = function() {
-        _sendEvent('showFirefoxAccounts');
+    /**
+    * Request the browser open the Firefox Accounts page.
+    *
+    * @param {Object} extraURLCampaignParams - An object containing additional
+    * paramaters for the URL opened by the browser for reasons of promotional
+    * campaign tracking. Each attribute of the object must have a name that
+    * begins with "utm_" and a value that is a string. The name must contain
+    * only alphanumeric characters, dashes or underscores (meaning
+    * that you are limited to values that don't need encoding, as any such
+    * characters in the name will be rejected.)
+   */
+    Mozilla.UITour.showFirefoxAccounts = function(extraURLCampaignParams) {
+        _sendEvent('showFirefoxAccounts', {
+            extraURLCampaignParams: JSON.stringify(extraURLCampaignParams)
+        });
     };
 
     Mozilla.UITour.resetFirefox = function() {
@@ -255,10 +268,10 @@ if (typeof Mozilla == 'undefined') {
     };
 
     Mozilla.UITour.openPreferences = function(pane) {
-		_sendEvent('openPreferences', {
-			pane: pane
-		});
-	};
+        _sendEvent('openPreferences', {
+            pane: pane
+        });
+    };
 
     Mozilla.UITour.closeTab = function() {
         _sendEvent('closeTab');

--- a/media/js/firefox/ios.js
+++ b/media/js/firefox/ios.js
@@ -10,6 +10,7 @@ if (typeof window.Mozilla === 'undefined') {
 ;(function($, Mozilla) {
     'use strict';
 
+    var params = new window._SearchParams();
     var $html = $('html');
     var $body = $('body');
 
@@ -109,7 +110,7 @@ if (typeof window.Mozilla === 'undefined') {
     // Firefox Sync sign in flow button
     $('.sync-button').on('click', function(e) {
         e.preventDefault();
-        Mozilla.UITour.showFirefoxAccounts();
+        Mozilla.UITour.showFirefoxAccounts(params.utmParamsFxA());
     });
 
     // Show Sync instructions in a modal doorhanger

--- a/media/js/firefox/sync.js
+++ b/media/js/firefox/sync.js
@@ -21,6 +21,7 @@
     // Variation #1: Firefox 31+ signed-in to Sync
     // Default (do nothing)
 
+    var params = new window._SearchParams();
     var client = window.Mozilla.Client;
     var fxMasterVersion = client.FirefoxMajorVersion;
     var state = 'Unknown';
@@ -141,7 +142,7 @@
             'browser': state
         });
 
-        Mozilla.UITour.showFirefoxAccounts();
+        Mozilla.UITour.showFirefoxAccounts(params.utmParamsFxA());
     });
 
     // v2/3 variations only for Fx 31+ signed out of sync

--- a/tests/unit/spec/base/search-params.js
+++ b/tests/unit/spec/base/search-params.js
@@ -42,6 +42,29 @@ describe('search-params.js', function() {
             expect(params.toString()).toEqual('scene=3&source=getfirefox');
         });
 
+        it('should return an object of utm_ values', function () {
+            var sp = new _SearchParams('utm_dude=lebowski&utm_sport=bowling&source=getfirefox');
+            var utms = sp.utmParams();
+            var keys = Object.keys(utms);
+            expect(keys).toEqual(['utm_dude', 'utm_sport']);
+            expect(utms.utm_dude).toEqual('lebowski');
+            expect(utms.utm_sport).toEqual('bowling');
+        });
+
+        it('should return an object of utm_ values with defaults for FxA', function () {
+            var sp = new _SearchParams('utm_dude=lebowski&utm_sport=bowling&source=getfirefox');
+            var utms = sp.utmParamsFxA('/es-ES/firefox/sync/');
+            expect(utms.utm_dude).toEqual('lebowski');
+            expect(utms.utm_campaign).toEqual('page referral - not part of a campaign');
+            expect(utms.utm_content).toEqual('/firefox/sync/');
+        });
+
+        it('should not override utm_campaign when set in URL', function () {
+            var sp = new _SearchParams('utm_dude=lebowski&utm_campaign=bowling&source=getfirefox');
+            var utms = sp.utmParamsFxA();
+            expect(utms.utm_campaign).toEqual('bowling');
+        });
+
     });
 
 });


### PR DESCRIPTION
## Description
To improve analytics on pages that open `about:accounts` using the `UITour.showFirefoxAccounts` method, we want to pass `utm_` params in to the privileged `about:accounts` tab.

## Bugzilla
[bug 1250758](https://bugzilla.mozilla.org/show_bug.cgi?id=1250758)

## Testing
~~**As of 2016-03-03, testing is broken in Nightly. This will be fixed when [bug 1253120](https://bugzilla.mozilla.org/show_bug.cgi?id=1253120) lands. (2016-03-04?)**~~

In Nightly and signed out of Sync, visit [`/firefox/sync/` on demo5](http://www-demo5.allizom.org/firefox/sync/) and click the "Get started with Sync" CTA. This should open `about:accounts` with two default `utm_` parameters added to the URL - `utm_campaign=page referral - not part of a campaign` (URL encoded) and `utm_content=/firefox/sync/`. Visiting [`/firefox/sync/?utm_foo=bar`](http://www-demo5.allizom.org/firefox/sync/?utm_foo=bar) and clicking the CTA should persist the `utm_foo=bar` query param to `about:accounts`.

## Checklist
- [ ] Related functional & integration tests passing.

