### PR TITLE
Add functional tests for redesigned Firefox Hello page

### DIFF
--- a/tests/functional/firefox/test_hello.py
+++ b/tests/functional/firefox/test_hello.py
@@ -1,0 +1,25 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import pytest
+
+from pages.firefox.hello import HelloPage
+
+
+@pytest.mark.smoke
+@pytest.mark.skip_if_not_firefox(reason='Hello button is shown only to Firefox browsers.')
+@pytest.mark.nondestructive
+def test_try_hello_button_is_displayed(base_url, selenium):
+    page = HelloPage(base_url, selenium).open()
+    assert page.is_try_hello_header_button_displayed
+    assert page.is_try_hello_footer_button_displayed
+
+
+@pytest.mark.smoke
+@pytest.mark.skip_if_firefox(reason='Download button is not shown for Firefox browsers.')
+@pytest.mark.nondestructive
+def test_download_button_is_displayed(base_url, selenium):
+    page = HelloPage(base_url, selenium).open()
+    assert page.primary_download_button.is_displayed
+    assert page.secondary_download_button.is_displayed

--- a/tests/functional/test_newsletter_embed.py
+++ b/tests/functional/test_newsletter_embed.py
@@ -13,6 +13,7 @@ from pages.firefox.all import FirefoxAllPage
 from pages.firefox.desktop.desktop import DesktopPage
 from pages.firefox.desktop.customize import CustomizePage
 from pages.firefox.desktop.all import FirefoxDesktopBasePage
+from pages.firefox.hello import HelloPage
 from pages.firefox.sync import FirefoxSyncPage
 from pages.plugincheck import PluginCheckPage
 from pages.smarton.landing import SmartOnLandingPage
@@ -31,6 +32,7 @@ from pages.smarton.base import SmartOnBasePage
     (FirefoxDesktopBasePage, {'slug': 'fast'}),
     (FirefoxDesktopBasePage, {'slug': 'trust'}),
     (FirefoxSyncPage, None),
+    (HelloPage, None),
     pytest.mark.skip_if_not_firefox((PluginCheckPage, None),
         reason='https://bugzilla.mozilla.org/show_bug.cgi?id=1245208'),
     (SmartOnLandingPage, None),

--- a/tests/pages/firefox/hello.py
+++ b/tests/pages/firefox/hello.py
@@ -1,0 +1,36 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from selenium.webdriver.common.by import By
+
+from pages.firefox.base import FirefoxBasePage
+from pages.regions.download_button import DownloadButton
+
+
+class HelloPage(FirefoxBasePage):
+
+    _url = '{base_url}/{locale}/firefox/hello'
+
+    _try_hello_header_locator = (By.CSS_SELECTOR, '#try-hello .try-hello-button')
+    _try_hello_footer_locator = (By.CSS_SELECTOR, '#share-hello .try-hello-button')
+    _primary_download_locator = (By.ID, 'download-fx-primary')
+    _secondary_download_locator = (By.ID, 'download-fx-secondary')
+
+    @property
+    def is_try_hello_header_button_displayed(self):
+        return self.is_element_displayed(self._try_hello_header_locator)
+
+    @property
+    def is_try_hello_footer_button_displayed(self):
+        return self.is_element_displayed(self._try_hello_footer_locator)
+
+    @property
+    def primary_download_button(self):
+        el = self.find_element(self._primary_download_locator)
+        return DownloadButton(self, root=el)
+
+    @property
+    def secondary_download_button(self):
+        el = self.find_element(self._secondary_download_locator)
+        return DownloadButton(self, root=el)


### PR DESCRIPTION
## Description
Adds functional tests for redesigned `/firefox/hello/` product page.

## Testing
Note: this page is not yet live in production, so is currently only visible on dev: https://www-dev.allizom.org/en-US/firefox/hello/

Adding a blocker to merging this which can be removed after the page goes live on March 8.

## Checklist
- [ ] Requires l10n changes.
- [x] Related functional & integration tests passing.

