### PR TITLE
Enable deployment of demo instances via git push to origin

### DIFF
--- a/.bedrock_demo_env
+++ b/.bedrock_demo_env
@@ -1,0 +1,8 @@
+LOGLEVEL=info
+ENABLE_CSP_MIDDLEWARE=True
+DEBUG=False
+DATABASE_URL=sqlite:///bedrock.db
+DEV=True
+DISABLE_SSL=False
+SECRET_KEY=itsasekrit
+ALLOWED_HOSTS=*

--- a/bin/circleci-demo-deploy.sh
+++ b/bin/circleci-demo-deploy.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -e
+
+echo "Logging into the Docker Hub"
+docker login -e "$DOCKER_EMAIL" -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD"
+echo "Pushing ${DOCKER_IMAGE_TAG} to Docker hub"
+docker push ${DOCKER_IMAGE_TAG}
+
+# Install deis client
+echo "Installing Deis client"
+curl -sSL http://deis.io/deis-cli/install.sh | sh
+
+DEIS_APP_NAME="bedrock-demo-${CIRCLE_BRANCH#demo__}"
+echo "Logging into the Deis Controller at $DEIS_CONTROLLER"
+./deis login "$DEIS_CONTROLLER" --username "$DEIS_USERNAME" --password "$DEIS_PASSWORD"
+echo "Creating the demo app $DEIS_APP_NAME"
+if ./deis apps:create "$DEIS_APP_NAME" --no-remote; then
+  echo "Giving github user $CIRCLE_USERNAME perms for the app"
+  ./deis perms:create "$CIRCLE_USERNAME" -a "$DEIS_APP_NAME" || true
+  echo "Configuring the new demo app"
+  ./deis config:push -a "$DEIS_APP_NAME" -p .bedrock_demo_env
+fi
+echo "Pulling $DOCKER_IMAGE_TAG into Deis app $DEIS_APP_NAME"
+./deis pull "$DOCKER_IMAGE_TAG" -a "$DEIS_APP_NAME"

--- a/bin/circleci-demo-sync.sh
+++ b/bin/circleci-demo-sync.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+set -ex
+
+[[ "$CIRCLE_BRANCH" != demo__* ]] && exit 0
+
+DATABASE_URL=sqlite:///bedrock.db
+DOCKER_CACHE_PATH=~/docker
+MOFO_SECURITY_ADVISORIES_PATH=$DOCKER_CACHE_PATH/security_advisories
+
+mkdir -p $DOCKER_CACHE_PATH
+
+if [[ -f $DOCKER_CACHE_PATH/bedrock.db ]]; then
+  cp $DOCKER_CACHE_PATH/bedrock.db ./
+fi
+
+./manage.py migrate --noinput
+./manage.py rnasync
+./manage.py cron update_ical_feeds
+./manage.py update_product_details
+./manage.py update_externalfiles
+./manage.py update_security_advisories
+
+cp -f bedrock.db $DOCKER_CACHE_PATH/
+
+if [[ -e $DOCKER_CACHE_PATH/image.tar ]]; then docker load --input ~/docker/image.tar; fi
+echo "ENV GIT_SHA ${CIRCLE_SHA1}" >> Dockerfile
+docker build -t "$DOCKER_IMAGE_TAG" --pull=true .
+docker save "$DOCKER_IMAGE_TAG" > $DOCKER_CACHE_PATH/image.tar

--- a/circle.yml
+++ b/circle.yml
@@ -1,9 +1,12 @@
 machine:
+  services:
+    - docker
   python:
     version: 2.7.10
   node:
     version: 0.12.0
   environment:
+    # Django
     PIP_DISABLE_PIP_VERSION_CHECK: true
     NOSE_WITH_XUNIT: true
     NOSE_XUNIT_FILE: "$CIRCLE_TEST_REPORTS/django/nosetests.xml"
@@ -11,6 +14,14 @@ machine:
     LOG_LEVEL: 40
     ADMINS: '["thedude@example.com"]'
     HMAC_KEYS: '{"2013-01-01": "prositneujahr"}'
+    # Deis
+    DEIS_CONTROLLER: https://deis.us-west.moz.works
+    DEIS_USERNAME: circleci
+    # Docker
+    DOCKER_REPOSITORY: mozorg/bedrock
+    DOCKER_IMAGE_TAG: "$DOCKER_REPOSITORY:demo-$CIRCLE_SHA1"
+    DOCKER_EMAIL: foo@example.com
+    DOCKER_USERNAME: moztravis
 
 checkout:
   post:
@@ -20,6 +31,7 @@ checkout:
 dependencies:
   cache_directories:
     - node_modules
+    - "~/docker"
   override:
     - npm install
     - pip install -r requirements/pip.txt
@@ -27,6 +39,7 @@ dependencies:
     - python bin/peep.py install -r requirements/prod.txt --no-use-wheel
     - python bin/peep.py install -r requirements/docker.txt --no-use-wheel
     - python bin/peep.py install -r requirements/test.txt --no-use-wheel
+    - bin/circleci-demo-sync.sh
 
 test:
   pre:
@@ -40,3 +53,10 @@ test:
     - grunt test
     - python manage.py test
     - py.test --junitxml="$CIRCLE_TEST_REPORTS/redirects.xml" -r a -m smoke tests/redirects
+
+deployment:
+  demo:
+    branch: /demo__.+/
+    owner: mozilla
+    commands:
+      - bin/circleci-demo-deploy.sh


### PR DESCRIPTION
In order to be deployed a branch must be pushed to mozilla/bedrock and be named "demo__*". If the tests pass the new app will be deployed. The new app will be named after the branch. For example, a branch pushed named "demo__test-whatsnew" will generate an app named "bedrock-demo-test-whatsnew".

I think we should recommend devs mostly use a single branch named for themselves to encourage reuse (e.g. demo__pmac).