### PR TITLE
Fix Bug 1253629 - Adjust timeout for getFirefoxDetails()

### DIFF
--- a/media/js/base/mozilla-client.js
+++ b/media/js/base/mozilla-client.js
@@ -246,8 +246,8 @@ if (typeof Mozilla === 'undefined') {
             return;
         }
 
-        // Fire the fallback function in .2 seconds
-        var timer = window.setTimeout(fallback, 200);
+        // Fire the fallback function in .3 seconds
+        var timer = window.setTimeout(fallback, 300);
 
         // Trigger the API
         document.addEventListener('mozUITourResponse', listener);


### PR DESCRIPTION
Increasing the timeout to 300ms as @alexgibson suggested in the bug.