### PR TITLE
Parameterize newsletter form functional tests

### DIFF
--- a/tests/functional/contribute/test_contribute.py
+++ b/tests/functional/contribute/test_contribute.py
@@ -3,7 +3,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import pytest
-from selenium.common.exceptions import TimeoutException
 
 from pages.contribute.contribute import ContributePage
 
@@ -21,36 +20,3 @@ def test_play_video(base_url, selenium):
 def test_next_event_is_displayed(base_url, selenium):
     page = ContributePage(base_url, selenium).open()
     assert page.next_event_is_displayed
-
-
-@pytest.mark.smoke
-@pytest.mark.nondestructive
-def test_newsletter_default_values(base_url, selenium):
-    page = ContributePage(base_url, selenium).open()
-    page.newsletter.expand_form()
-    assert '' == page.newsletter.email
-    assert 'United States' == page.newsletter.country
-    assert page.newsletter.html_format_selected
-    assert not page.newsletter.text_format_selected
-    assert not page.newsletter.privacy_policy_accepted
-    assert page.newsletter.is_privacy_policy_link_displayed
-
-
-@pytest.mark.flaky(reruns=1, reason='https://bugzilla.mozilla.org/show_bug.cgi?id=1218451')
-def test_newsletter_successful_sign_up(base_url, selenium):
-    page = ContributePage(base_url, selenium).open()
-    page.newsletter.expand_form()
-    page.newsletter.type_email('noreply@mozilla.com')
-    page.newsletter.select_country('United Kingdom')
-    page.newsletter.select_text_format()
-    page.newsletter.accept_privacy_policy()
-    page.newsletter.click_sign_me_up()
-    assert page.newsletter.sign_up_successful
-
-
-@pytest.mark.nondestructive
-def test_newsletter_sign_up_fails_when_missing_required_fields(base_url, selenium):
-    page = ContributePage(base_url, selenium).open()
-    page.newsletter.expand_form()
-    with pytest.raises(TimeoutException):
-        page.newsletter.click_sign_me_up()

--- a/tests/functional/firefox/desktop/test_all.py
+++ b/tests/functional/firefox/desktop/test_all.py
@@ -17,14 +17,3 @@ from pages.firefox.desktop.all import FirefoxDesktopBasePage
 def test_download_button_is_displayed(slug, base_url, selenium):
     page = FirefoxDesktopBasePage(base_url, selenium, slug=slug).open()
     assert page.download_button.is_displayed
-
-
-@pytest.mark.nondestructive
-@pytest.mark.parametrize('slug', [(''), ('customize'), ('fast'), ('trust')])
-def test_newsletter_default_values(slug, base_url, selenium):
-    page = FirefoxDesktopBasePage(base_url, selenium, slug=slug).open()
-    page.newsletter.expand_form()
-    assert '' == page.newsletter.email
-    assert 'United States' == page.newsletter.country
-    assert not page.newsletter.privacy_policy_accepted
-    assert page.newsletter.is_privacy_policy_link_displayed

--- a/tests/functional/firefox/desktop/test_desktop.py
+++ b/tests/functional/firefox/desktop/test_desktop.py
@@ -12,4 +12,5 @@ from pages.firefox.desktop.desktop import DesktopPage
 @pytest.mark.nondestructive
 def test_primary_download_button_displayed(base_url, selenium):
     page = DesktopPage(base_url, selenium).open()
+    page.wait_for_download_button_to_display()
     assert page.primary_download_button.is_displayed

--- a/tests/functional/firefox/test_all.py
+++ b/tests/functional/firefox/test_all.py
@@ -15,13 +15,3 @@ def test_search_language(base_url, selenium):
     page.search_for(language)
     for build in page.displayed_builds:
         assert language in build.language.lower()
-
-
-@pytest.mark.nondestructive
-def test_newsletter_default_values(base_url, selenium):
-    page = FirefoxAllPage(base_url, selenium).open()
-    page.newsletter.expand_form()
-    assert '' == page.newsletter.email
-    assert 'United States' == page.newsletter.country
-    assert not page.newsletter.privacy_policy_accepted
-    assert page.newsletter.is_privacy_policy_link_displayed

--- a/tests/functional/firefox/test_sync.py
+++ b/tests/functional/firefox/test_sync.py
@@ -20,14 +20,3 @@ def test_app_store_buttons_displayed(base_url, selenium):
     page = FirefoxSyncPage(base_url, selenium).open()
     assert page.is_play_store_button_displayed
     assert page.is_app_store_button_displayed
-
-
-@pytest.mark.smoke
-@pytest.mark.nondestructive
-def test_newsletter_default_values(base_url, selenium):
-    page = FirefoxSyncPage(base_url, selenium).open()
-    page.newsletter.expand_form()
-    assert '' == page.newsletter.email
-    assert 'United States' == page.newsletter.country
-    assert not page.newsletter.privacy_policy_accepted
-    assert page.newsletter.is_privacy_policy_link_displayed

--- a/tests/functional/smarton/test_all.py
+++ b/tests/functional/smarton/test_all.py
@@ -16,18 +16,3 @@ from pages.smarton.base import SmartOnBasePage
 def test_download_button_displayed(slug, base_url, selenium):
     page = SmartOnBasePage(base_url, selenium, slug=slug).open()
     assert page.download_button.is_displayed
-
-
-@pytest.mark.skip_if_not_firefox(reason='Newsletter is only shown to Firefox browsers.')
-@pytest.mark.nondestructive
-@pytest.mark.parametrize('slug', [
-    pytest.mark.smoke(('tracking')),
-    ('security'),
-    ('surveillance')])
-def test_newsletter_default_values(slug, base_url, selenium):
-    page = SmartOnBasePage(base_url, selenium, slug=slug).open()
-    page.newsletter.expand_form()
-    assert '' == page.newsletter.email
-    assert 'United States' == page.newsletter.country
-    assert not page.newsletter.privacy_policy_accepted
-    assert page.newsletter.is_privacy_policy_link_displayed

--- a/tests/functional/smarton/test_landing.py
+++ b/tests/functional/smarton/test_landing.py
@@ -20,14 +20,3 @@ def test_navigation(base_url, selenium):
     page.open()
     surveillance_page = page.open_surveillance()
     assert surveillance_page.url in selenium.current_url
-
-
-@pytest.mark.smoke
-@pytest.mark.nondestructive
-def test_newsletter_default_values(base_url, selenium):
-    page = SmartOnLandingPage(base_url, selenium).open()
-    page.newsletter.expand_form()
-    assert '' == page.newsletter.email
-    assert 'United States' == page.newsletter.country
-    assert not page.newsletter.privacy_policy_accepted
-    assert page.newsletter.is_privacy_policy_link_displayed

--- a/tests/functional/test_about.py
+++ b/tests/functional/test_about.py
@@ -21,14 +21,3 @@ def test_play_video(base_url, selenium):
     page.play_video()
     assert not page.is_video_overlay_displayed
     assert page.is_video_displayed
-
-
-@pytest.mark.smoke
-@pytest.mark.nondestructive
-def test_newsletter_default_values(base_url, selenium):
-    page = AboutPage(base_url, selenium).open()
-    page.newsletter.expand_form()
-    assert '' == page.newsletter.email
-    assert 'United States' == page.newsletter.country
-    assert not page.newsletter.privacy_policy_accepted
-    assert page.newsletter.is_privacy_policy_link_displayed

--- a/tests/functional/test_home.py
+++ b/tests/functional/test_home.py
@@ -3,7 +3,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import pytest
-from selenium.common.exceptions import TimeoutException
 
 from pages.home import HomePage
 
@@ -47,35 +46,3 @@ def test_upcoming_events_are_displayed(base_url, selenium):
     events = page.upcoming_events
     assert events.is_next_event_displayed
     assert events.is_events_list_displayed
-
-
-@pytest.mark.smoke
-@pytest.mark.nondestructive
-def test_newsletter_default_values(base_url, selenium):
-    page = HomePage(base_url, selenium).open()
-    page.newsletter.expand_form()
-    assert '' == page.newsletter.email
-    assert 'United States' == page.newsletter.country
-    assert not page.newsletter.privacy_policy_accepted
-    assert page.newsletter.is_privacy_policy_link_displayed
-
-
-@pytest.mark.flaky(reruns=1, reason='https://bugzilla.mozilla.org/show_bug.cgi?id=1218451')
-def test_newsletter_successful_sign_up(base_url, selenium):
-    page = HomePage(base_url, selenium).open()
-    newsletter = page.newsletter
-    newsletter.expand_form()
-    newsletter.type_email('noreply@mozilla.com')
-    newsletter.select_country('United Kingdom')
-    newsletter.select_text_format()
-    newsletter.accept_privacy_policy()
-    newsletter.click_sign_me_up()
-    assert newsletter.sign_up_successful
-
-
-@pytest.mark.nondestructive
-def test_newsletter_sign_up_fails_when_missing_required_fields(base_url, selenium):
-    page = HomePage(base_url, selenium).open()
-    page.newsletter.expand_form()
-    with pytest.raises(TimeoutException):
-        page.newsletter.click_sign_me_up()

--- a/tests/functional/test_mission.py
+++ b/tests/functional/test_mission.py
@@ -21,14 +21,3 @@ def test_play_video(base_url, selenium):
     page.play_video()
     assert not page.is_video_overlay_displayed
     assert page.is_video_displayed
-
-
-@pytest.mark.smoke
-@pytest.mark.nondestructive
-def test_newsletter_default_values(base_url, selenium):
-    page = MissionPage(base_url, selenium).open()
-    page.newsletter.expand_form()
-    assert '' == page.newsletter.email
-    assert 'United States' == page.newsletter.country
-    assert not page.newsletter.privacy_policy_accepted
-    assert page.newsletter.is_privacy_policy_link_displayed

--- a/tests/functional/test_newsletter_embed.py
+++ b/tests/functional/test_newsletter_embed.py
@@ -1,0 +1,72 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import pytest
+from selenium.common.exceptions import TimeoutException
+
+from pages.home import HomePage
+from pages.about import AboutPage
+from pages.contribute.contribute import ContributePage
+from pages.mission import MissionPage
+from pages.firefox.all import FirefoxAllPage
+from pages.firefox.desktop.desktop import DesktopPage
+from pages.firefox.desktop.customize import CustomizePage
+from pages.firefox.desktop.all import FirefoxDesktopBasePage
+from pages.firefox.sync import FirefoxSyncPage
+from pages.plugincheck import PluginCheckPage
+from pages.smarton.landing import SmartOnLandingPage
+from pages.smarton.base import SmartOnBasePage
+
+
+@pytest.mark.nondestructive
+@pytest.mark.parametrize(('page_class', 'url_kwargs'), [
+    pytest.mark.smoke((HomePage, None)),
+    (AboutPage, None),
+    pytest.mark.smoke((ContributePage, None)),
+    (MissionPage, None),
+    (FirefoxAllPage, None),
+    pytest.mark.smoke((DesktopPage, None)),
+    (CustomizePage, None),
+    (FirefoxDesktopBasePage, {'slug': 'fast'}),
+    (FirefoxDesktopBasePage, {'slug': 'trust'}),
+    (FirefoxSyncPage, None),
+    pytest.mark.skip_if_not_firefox((PluginCheckPage, None),
+        reason='https://bugzilla.mozilla.org/show_bug.cgi?id=1245208'),
+    (SmartOnLandingPage, None),
+    pytest.mark.skip_if_not_firefox((SmartOnBasePage, {'slug': 'tracking'}),
+        reason='Newsletter is only shown to Firefox browsers.'),
+    pytest.mark.skip_if_not_firefox((SmartOnBasePage, {'slug': 'security'}),
+        reason='Newsletter is only shown to Firefox browsers.'),
+    pytest.mark.skip_if_not_firefox((SmartOnBasePage, {'slug': 'surveillance'}),
+        reason='Newsletter is only shown to Firefox browsers.')])
+def test_newsletter_default_values(page_class, url_kwargs, base_url, selenium):
+    url_kwargs = url_kwargs or {}
+    page = page_class(base_url, selenium, **url_kwargs).open()
+    page.newsletter.expand_form()
+    assert '' == page.newsletter.email
+    assert 'United States' == page.newsletter.country
+    assert not page.newsletter.privacy_policy_accepted
+    assert page.newsletter.is_privacy_policy_link_displayed
+
+
+@pytest.mark.flaky(reruns=1, reason='https://bugzilla.mozilla.org/show_bug.cgi?id=1218451')
+@pytest.mark.parametrize('page_class', [HomePage, ContributePage])
+def test_newsletter_successful_sign_up(page_class, base_url, selenium):
+    page = page_class(base_url, selenium).open()
+    page.newsletter.expand_form()
+    page.newsletter.type_email('noreply@mozilla.com')
+    page.newsletter.select_country('United Kingdom')
+    page.newsletter.select_text_format()
+    page.newsletter.accept_privacy_policy()
+    page.newsletter.click_sign_me_up()
+    assert page.newsletter.sign_up_successful
+
+
+@pytest.mark.nondestructive
+@pytest.mark.parametrize('page_class', [HomePage, ContributePage])
+def test_newsletter_sign_up_fails_when_missing_required_fields(page_class, base_url, selenium):
+    page = page_class(base_url, selenium).open()
+    page.newsletter.expand_form()
+    with pytest.raises(TimeoutException):
+        page.newsletter.click_sign_me_up()

--- a/tests/functional/test_plugincheck.py
+++ b/tests/functional/test_plugincheck.py
@@ -12,15 +12,3 @@ from pages.plugincheck import PluginCheckPage
 def test_not_supported_message(base_url, selenium):
     page = PluginCheckPage(base_url, selenium).open()
     assert page.is_not_supported_message_displayed
-
-
-@pytest.mark.skip_if_not_firefox(reason='https://bugzilla.mozilla.org/show_bug.cgi?id=1245208')
-@pytest.mark.smoke
-@pytest.mark.nondestructive
-def test_newsletter_default_values(base_url, selenium):
-    page = PluginCheckPage(base_url, selenium).open()
-    page.newsletter.expand_form()
-    assert '' == page.newsletter.email
-    assert 'United States' == page.newsletter.country
-    assert not page.newsletter.privacy_policy_accepted
-    assert page.newsletter.is_privacy_policy_link_displayed

--- a/tests/pages/firefox/desktop/desktop.py
+++ b/tests/pages/firefox/desktop/desktop.py
@@ -20,7 +20,9 @@ class DesktopPage(FirefoxDesktopBasePage):
         el = self.find_element(self._primary_download_locator)
         return DownloadButton(self, root=el)
 
+    def wait_for_download_button_to_display(self):
+        self.wait.until(lambda s: self.primary_download_button.is_displayed)
+
     def wait_for_page_to_load(self):
         super(FirefoxDesktopBasePage, self).wait_for_page_to_load()
-        self.wait.until(lambda s: self.primary_download_button.is_displayed)
         return self


### PR DESCRIPTION
## Description
Makes newsletter functional tests parameterized in order to reduce code duplication and allow for easier testing across multiple pages.

## Checklist
- [ ] Requires l10n changes.
- [x] Related functional & integration tests passing.

Thoughts @davehunt?

