### PR TITLE
[fix bug 1249726] Add iOS link to Firefox top menu navigation

### DIFF
--- a/bedrock/firefox/templates/firefox/includes/top-menu.html
+++ b/bedrock/firefox/templates/firefox/includes/top-menu.html
@@ -5,6 +5,7 @@
       <ul aria-expanded="false" id="nav-main-features-submenu" class="submenu">
         <li class="first"><a href="{{ url('firefox.desktop.index') }}" tabindex="-1" data-link-type="nav" data-link-name="Firefox: Desktop">{{_('Desktop')}}</a></li>
         <li><a href="{{ url('firefox.android.index') }}" tabindex="-1" data-link-type="nav" data-link-name="Firefox: Android">{{_('Android')}}</a></li>
+        <li><a href="{{ url('firefox.ios') }}" tabindex="-1" data-link-type="nav" data-link-name="Firefox: iOS">{{_('iOS')}}</a></li>
         <li><a href="{{ url('firefox.developer') }}" tabindex="-1" data-link-type="nav" data-link-name="Firefox: Developer Edition">{{ _('Developer Edition') }}</a></li>
         <li>
           <hr>{# <hr> before first sub/minor link #}


### PR DESCRIPTION
## Description
Adda missing link to Firefox iOS page on Firefox top menu navigation.

## Bugzilla
https://bugzilla.mozilla.org/show_bug.cgi?id=1249726

## Testing
This older style of navigation is still displayed on pages such as `/firefox/all/`

## Checklist
- [ ] Requires l10n changes (don't think so, but need to double-check)
- [x] Related functional & integration tests passing.

