### PR TITLE
Mark bedrock-prod as sensitive URL for functional tests

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -12,4 +12,4 @@ exclude-dir=tests/redirects
 [pytest]
 addopts = --showlocals -r a --ignore=node_modules
 DJANGO_SETTINGS_MODULE = bedrock.settings
-sensitive_url = mozilla\.(com|org)
+sensitive_url = (mozilla\.(com|org)|bedrock-prod)


### PR DESCRIPTION
## Description
I noticed we're currently running form submission destructive tests against `bedrock-prod-deis` URLs, which we probably should not be doing.

@davehunt r?

