### PR TITLE
Temporarily skip Hello test until FF 45 is available in automation

### DIFF
--- a/tests/functional/firefox/test_hello.py
+++ b/tests/functional/firefox/test_hello.py
@@ -8,6 +8,7 @@ from pages.firefox.hello import HelloPage
 
 
 @pytest.mark.smoke
+@pytest.mark.skipif(reason='Skipped until Firefox 45 is available on Sauce Labs')
 @pytest.mark.skip_if_not_firefox(reason='Hello button is shown only to Firefox browsers.')
 @pytest.mark.nondestructive
 def test_try_hello_button_is_displayed(base_url, selenium):


### PR DESCRIPTION
Going to have to skip this test until Firefox 45 is available in Sauce Labs (I should have thought of this before merging).

