### PR TITLE
Fix Bug 1254938 - Google Play button on /firefox/new/ scene 2 has wrong width

### DIFF
--- a/bedrock/firefox/templates/firefox/new/scene2.html
+++ b/bedrock/firefox/templates/firefox/new/scene2.html
@@ -76,7 +76,7 @@
       <ul>
         <li class="android">
           <a rel="external" href="{{ settings.GOOGLE_PLAY_FIREFOX_LINK }}">
-            {{ high_res_img('firefox/android/btn-google-play.png', {'alt': _('Get it on Google Play'), 'width': '129', 'height': '45', 'l10n': True}) }}
+            {{ high_res_img('firefox/android/btn-google-play.png', {'alt': _('Get it on Google Play'), 'width': '152', 'height': '45', 'l10n': True}) }}
           </a>
         </li>
         <li class="ios">

--- a/media/css/firefox/new/scene2.less
+++ b/media/css/firefox/new/scene2.less
@@ -43,7 +43,7 @@
         margin: @baseLine auto (@baseLine * 2);
         padding: 0;
         list-style: none;
-        width: 361px;
+        width: 384px;
         .clearfix();
     }
 
@@ -51,16 +51,8 @@
         display: inline;
         float: left;
         margin: 0 @baseLine;
+        width: 152px;
         height: 45px;
-
-        // ie8 seems to need widths set to display properly
-        &.android {
-            width: 129px;
-        }
-
-        &.ios {
-            width: 152px;
-        }
     }
 
     a {


### PR DESCRIPTION
Fix a regression introduced since #3806 has landed.