### PR TITLE
Bug 1255882: Fix kodak addon redirect

### DIFF
--- a/bedrock/mozorg/redirects.py
+++ b/bedrock/mozorg/redirects.py
@@ -601,6 +601,10 @@ redirectpatterns = (
     redirect(r'^projects/bonecho/anti-phishing/?$',
              'https://support.mozilla.org/kb/how-does-phishing-and-malware-protection-work'),
 
+    # Bug 453876, 840416
+    redirect(r'^add-ons/kodak', 'https://addons.mozilla.org/en-US/firefox/addon/4441'),
+
+
     # bug 832348 **/index.html -> **/
     # leave this at the bottom
     redirect(r'^(.*)/index\.html$', '/{}/', locale_prefix=False),

--- a/tests/redirects/map_htaccess.py
+++ b/tests/redirects/map_htaccess.py
@@ -139,4 +139,7 @@ URLS = flatten((
     # bug 726217, 1255882
     url_test('/projects/bonecho/anti-phishing/',
              'https://support.mozilla.org/kb/how-does-phishing-and-malware-protection-work'),
+
+    # Bug 453876, 840416
+    url_test('/add-ons/kodakcd', 'https://addons.mozilla.org/en-US/firefox/addon/4441'),
 ))


### PR DESCRIPTION
Fixes a lot of 404s to the following URL:

/en-US/add-ons/kodakcd

Original redirect from .htaccess in the .com svn repo.