### PR TITLE
Trigger Jenkins deployment pipeline from CircleCI

### DIFF
--- a/bin/circleci-trigger-jenkins.sh
+++ b/bin/circleci-trigger-jenkins.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -e
+
+curl -d "delay=0" -d "token=$JENKINS_WEBHOOK_TOKEN" \
+  https://ci.us-west.moz.works/job/bedrock_base_image/buildWithParameters

--- a/circle.yml
+++ b/circle.yml
@@ -60,3 +60,8 @@ deployment:
     owner: mozilla
     commands:
       - bin/circleci-demo-deploy.sh
+  jenkins:
+    branch: master
+    owner: mozilla
+    commands:
+      - bin/circleci-trigger-jenkins.sh


### PR DESCRIPTION
Instead of from Github directly since we have a bit more control.
This allows us to be sure that only pushes to master, and no other
branch, will trigger the full build pipeline.