### PR TITLE
Convert cron script to just call management commands

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
 web: ./docker/run-prod.sh
-clock: ./manage.py runscript cron
+clock: ./bin/cron.py


### PR DESCRIPTION
Currently it imports the whole django setup and commands and runs those functions, but we've run into issues as some of these commands don't expect for the process to persist. This change makes the cron script simply call the same commands in a subshell.