### PR TITLE
[fix bug 1260541] Pass funnelcake ID to /new/?scene=2.

### DIFF
--- a/bedrock/firefox/firefox_details.py
+++ b/bedrock/firefox/firefox_details.py
@@ -254,7 +254,13 @@ class FirefoxDesktop(_ProductDetails):
                              ])])
         else:
             # build a link to the transition page
-            return self.download_base_url_transition
+
+            if funnelcake_id:
+                # include funnelcake in scene 2 URL
+                return '&f='.join([self.download_base_url_transition,
+                                   funnelcake_id])
+            else:
+                return self.download_base_url_transition
 
 
 class FirefoxAndroid(_ProductDetails):

--- a/bedrock/firefox/tests/test_firefox_details.py
+++ b/bedrock/firefox/tests/test_firefox_details.py
@@ -151,6 +151,13 @@ class TestFirefoxDesktop(TestCase):
                               ('os', 'linux64'),
                               ('lang', 'pt-BR')])
 
+    def test_get_download_url_scene2_funnelcake(self):
+        scene2 = firefox_desktop.download_base_url_transition
+        url = firefox_desktop.get_download_url('release', '45.0', 'win', 'en-US')
+        self.assertEqual(url, scene2)
+        url = firefox_desktop.get_download_url('release', '45.0', 'win', 'en-US', funnelcake_id='64')
+        self.assertEqual(url, scene2 + '&f=64')
+
     @override_settings(STUB_INSTALLER_LOCALES={'win': settings.STUB_INSTALLER_ALL})
     def get_download_url_ssl(self):
         """


### PR DESCRIPTION
## Description
Ensure funnelcake ID is passed to scene 2 if present in scene 1.

## Bugzilla
[bug 1260541](https://bugzilla.mozilla.org/show_bug.cgi?id=1260541)

## Testing
Navigate to `/firefox/new/?f=42` and click "Free Download". Ensure resulting scene 2 URL includes `f=42`.

## Checklist
- [ ] Related functional & integration tests passing.

