### PR TITLE
[fix bug 1260370] Update Hello copy on /firefox/products/ page

### DIFF
--- a/bedrock/firefox/templates/firefox/family/index.html
+++ b/bedrock/firefox/templates/firefox/family/index.html
@@ -130,7 +130,11 @@
       <li class="product" id="product-hello">
         <a href="{{ url('firefox.hello') }}" data-link-type="button" data-link-name="Firefox Hello">
           <h2>{{ _('Firefox Hello') }}</h2>
-          <p>{{ _('Free, easy video conversations.') }}</p>
+          {% if l10n_has_tag('hello-copy-update') %}
+            <p>{{ _('Browse the Web with friends.') }}</p>
+          {% else %}
+            <p>{{ _('Free, easy video conversations.') }}</p>
+          {% endif %}
         </a>
       </li>
 


### PR DESCRIPTION
## Description
Updates the line of Hello copy on the /firefox/products page to better describe what the product now delivers.

## Bugzilla
https://bugzilla.mozilla.org/show_bug.cgi?id=1260370

## Checklist
- [x] Requires l10n changes.

