### PR TITLE
Fix Bug 1256668, update newsletter button styles site wide

### DIFF
--- a/bedrock/firefox/templates/firefox/android/index.html
+++ b/bedrock/firefox/templates/firefox/android/index.html
@@ -413,9 +413,9 @@
       <div id="subscribe-wrapper" class="floating">
       {% if LANG.startswith('en-') %}
         {# L10n: Line break for visual formatting. #}
-        {{ email_newsletter_form(title=_('Keep up with<br> all things Firefox.')) }}
+        {{ email_newsletter_form(title=_('Keep up with<br> all things Firefox.'), button_class='white') }}
       {% else %}
-        {{ email_newsletter_form(title=_('Get Firefox news')) }}
+        {{ email_newsletter_form(title=_('Get Firefox news'), button_class='white') }}
       {% endif %}
       </div>
     {% endblock %}

--- a/bedrock/firefox/templates/firefox/desktop/desktop-base.html
+++ b/bedrock/firefox/templates/firefox/desktop/desktop-base.html
@@ -30,9 +30,9 @@
       <div id="subscribe-wrapper">
       {% if LANG.startswith('en-') %}
         {# L10n: Line break for visual formatting. #}
-        {{ email_newsletter_form(title=_('Keep up with<br> all things Firefox.')) }}
+        {{ email_newsletter_form(title=_('Keep up with<br> all things Firefox.'), button_class='white') }}
       {% else %}
-        {{ email_newsletter_form(title=_('Get Firefox news')) }}
+        {{ email_newsletter_form(title=_('Get Firefox news'), button_class='white') }}
       {% endif %}
       </div>
       <div id="download-wrapper">

--- a/bedrock/firefox/templates/firefox/developer.html
+++ b/bedrock/firefox/templates/firefox/developer.html
@@ -232,9 +232,9 @@
     </div>
     {# See Bug 1095176 #}
     {% if LANG.startswith('en-') %}
-      {{ email_newsletter_form('app-dev', 'Firefox Apps & Hacks') }}
+      {{ email_newsletter_form('app-dev', 'Firefox Apps & Hacks', button_class='white') }}
     {% elif LANG.startswith('es-') %}
-      {{ email_newsletter_form('app-dev', 'Firefox Apps y Hacks') }}
+      {{ email_newsletter_form('app-dev', 'Firefox Apps y Hacks', button_class='white') }}
     {% else %}
       {{ super() }}
     {% endif %}

--- a/bedrock/firefox/templates/firefox/family/index.html
+++ b/bedrock/firefox/templates/firefox/family/index.html
@@ -162,9 +162,9 @@
     <div class="content container">
       {% if LANG.startswith('en-') %}
         {# L10n: Line break for visual formatting. #}
-        {{ email_newsletter_form(title=_('Keep up with<br> all things Firefox.')) }}
+        {{ email_newsletter_form(title=_('Keep up with<br> all things Firefox.'), button_class='white') }}
       {% else %}
-        {{ email_newsletter_form(title=_('Get Firefox news')) }}
+        {{ email_newsletter_form(title=_('Get Firefox news'), button_class='white') }}
       {% endif %}
     </div>
   </aside>

--- a/bedrock/firefox/templates/firefox/hello/index-b.html
+++ b/bedrock/firefox/templates/firefox/hello/index-b.html
@@ -11,9 +11,9 @@
     <div class="container">
       {% if LANG.startswith('en-') %}
         {# L10n: Line break for visual formatting. #}
-        {{ email_newsletter_form(title=_('Keep up with<br> all things Firefox.')) }}
+        {{ email_newsletter_form(title=_('Keep up with<br> all things Firefox.'), button_class='white') }}
       {% else %}
-        {{ email_newsletter_form(title=_('Get Firefox news')) }}
+        {{ email_newsletter_form(title=_('Get Firefox news'), button_class='white') }}
       {% endif %}
     </div>
   </aside>

--- a/bedrock/firefox/templates/firefox/hello/index.html
+++ b/bedrock/firefox/templates/firefox/hello/index.html
@@ -121,7 +121,7 @@
     {% if LANG.startswith('en-') %}
     <aside id="newsletter-subscribe" class="compact ga-section" data-ga-label="Discover more ways to stay connected with Firefox.">
       <div class="container">
-        {{ email_newsletter_form(title=_('Discover more ways to stay connected<br> with Firefox.')) }}
+        {{ email_newsletter_form(title=_('Discover more ways to stay connected<br> with Firefox.'), button_class='white') }}
       </div>
     </aside>
     {% endif %}

--- a/bedrock/firefox/templates/firefox/ios.html
+++ b/bedrock/firefox/templates/firefox/ios.html
@@ -155,10 +155,11 @@
     <div class="container">
       {% if LANG.startswith('en-') %}
         {# L10n: Line break for visual formatting. #}
-        {{ email_newsletter_form(title=_('Keep up with<br> all things Firefox.')) }}
+        {{ email_newsletter_form(title=_('Keep up with<br> all things Firefox.'), button_class='dark') }}
       {% else %}
-        {{ email_newsletter_form(title=_('Get Firefox news')) }}
-      {% endif %}    </div>
+        {{ email_newsletter_form(title=_('Get Firefox news'), button_class='dark') }}
+      {% endif %}
+    </div>
   </aside>
 {% endblock %}
 

--- a/bedrock/firefox/templates/firefox/os/index.html
+++ b/bedrock/firefox/templates/firefox/os/index.html
@@ -45,7 +45,7 @@
 {% block site_header_unwrapped %}
   {% call fxfamilynav('os', 'index') %}
     <div id="cta-sticky">
-      <a href="#email-form-wrapper" class="primary-cta-signup cta-button-small newsletter-signup-toggle hidden" role="button" aria-haspopup="true">{{_('Sign me up')}}</a>
+      <a href="#email-form-wrapper" class="primary-cta-signup cta-button-small newsletter-signup-toggle hidden" role="button" aria-haspopup="true">{% if LANG.startswith('en-') %}{{ _('Sign Up Now') }}{% else %}{{ _('Sign me up') }}{% endif %}</a>
       <a href="#get-device" class="primary-cta-phone cta-button-small hidden" role="button" aria-haspopup="true">{{_('Get a phone')}}</a>
     </div>
   {% endcall %}

--- a/bedrock/firefox/templates/firefox/pocket.html
+++ b/bedrock/firefox/templates/firefox/pocket.html
@@ -81,9 +81,9 @@
   <div class="content container">
     {% if LANG.startswith('en-') %}
       {# L10n: Line break for visual formatting. #}
-      {{ email_newsletter_form(title=_('Keep up with<br> all things Firefox.')) }}
+      {{ email_newsletter_form(title=_('Keep up with<br> all things Firefox.'), button_class='dark') }}
     {% else %}
-      {{ email_newsletter_form(title=_('Get Firefox news')) }}
+      {{ email_newsletter_form(title=_('Get Firefox news'), button_class='dark') }}
     {% endif %}
   </div>
 </aside>

--- a/bedrock/firefox/templates/firefox/private-browsing.html
+++ b/bedrock/firefox/templates/firefox/private-browsing.html
@@ -129,9 +129,9 @@
     <div class="container">
       {% if LANG.startswith('en-') %}
         {# L10n: Line break for visual formatting. #}
-        {{ email_newsletter_form(title=_('Keep up with<br> all things Firefox.')) }}
+        {{ email_newsletter_form(title=_('Keep up with<br> all things Firefox.'), button_class='dark') }}
       {% else %}
-        {{ email_newsletter_form(title=_('Get Firefox news')) }}
+        {{ email_newsletter_form(title=_('Get Firefox news'), button_class='dark') }}
       {% endif %}
     </div>
   </aside>

--- a/bedrock/firefox/templates/firefox/sync.html
+++ b/bedrock/firefox/templates/firefox/sync.html
@@ -270,9 +270,9 @@
     <div class="inner-wrapper container">
       {% if LANG.startswith('en-') %}
         {# L10n: Line break for visual formatting. #}
-        {{ email_newsletter_form(title=_('Keep up with<br> all things Firefox.')) }}
+        {{ email_newsletter_form(title=_('Keep up with<br> all things Firefox.'), button_class='dark') }}
       {% else %}
-        {{ email_newsletter_form(title=_('Get Firefox news')) }}
+        {{ email_newsletter_form(title=_('Get Firefox news'), button_class='dark') }}
       {% endif %}
     </div>
   </aside>

--- a/bedrock/mozorg/templates/mozorg/contribute/signup.html
+++ b/bedrock/mozorg/templates/mozorg/contribute/signup.html
@@ -164,7 +164,7 @@
           <label class="inline" for="id_newsletter">
             {{ form.newsletter }}
             {{ form.newsletter.errors }}
-            {{ _('Sign me up for community updates') }}
+            {{ _('Sign up now for community updates') }}
             {% if not LANG.startswith('en') %}{{ _('(English)') }}{% endif %}
           </label>
         </p>

--- a/bedrock/mozorg/templates/mozorg/contribute/studentambassadors/join.html
+++ b/bedrock/mozorg/templates/mozorg/contribute/studentambassadors/join.html
@@ -143,7 +143,7 @@
           </div>
         </section>
         <div class="form-submit">
-          <input type="submit" class="button" id="form-submit" value="{{_('Sign me up!')}}">
+          <input type="submit" class="button-newsletter" id="form-submit" value="{{_('Sign Up Now')}}">
         </div>
       </div>
   </form>

--- a/bedrock/mozorg/templates/mozorg/home/home-b.html
+++ b/bedrock/mozorg/templates/mozorg/home/home-b.html
@@ -8,15 +8,14 @@
   {% if LANG.startswith('en-') %}
   <section class="module" id="newsletter-subscribe" data-ga-label="Love the Web? Get the Mozilla newsletter and help us keep it open and free.">
     <div class="container">
-      {{ email_newsletter_form(newsletters='mozilla-foundation', title=_('Love the Web?'), subtitle=_('Get the Mozilla newsletter and help us keep it open and free.')) }}
+      {{ email_newsletter_form(newsletters='mozilla-foundation', title=_('Love the Web?'), subtitle=_('Get the Mozilla newsletter and help us keep it open and free.'), button_class='white') }}
     </div>
   </section>
   {% else %}
   <section class="module" id="newsletter-signup">
     <div class="container">
-      {{ email_newsletter_form() }}
+      {{ email_newsletter_form(button_class='dark') }}
     </div>
   </section>
   {% endif %}
 {% endblock %}
-

--- a/bedrock/mozorg/templates/mozorg/home/home.html
+++ b/bedrock/mozorg/templates/mozorg/home/home.html
@@ -351,9 +351,9 @@
   <section class="module" id="newsletter-signup" data-ga-label="Get Mozilla updates">
     <div class="container">
       {% if LANG.startswith('en-') %}
-        {{ email_newsletter_form(newsletters='mozilla-foundation', title=_('Get Mozilla updates')) }}
+        {{ email_newsletter_form(newsletters='mozilla-foundation', title=_('Get Mozilla updates'), button_class='dark') }}
       {% else %}
-        {{ email_newsletter_form() }}
+        {{ email_newsletter_form(button_class='dark') }}
       {% endif %}
     </div>
   </section>

--- a/bedrock/mozorg/templates/mozorg/plugincheck-b.html
+++ b/bedrock/mozorg/templates/mozorg/plugincheck-b.html
@@ -102,9 +102,9 @@
         <h3>{{ _('<span class="firefox">Firefox</span> + You') }}</h3>
         <h4>{{ _('Get Firefox tips, tricks, news and more') }}</h4>
       </header>
-      {{ email_newsletter_form() }}
+      {{ email_newsletter_form(button_class='white') }}
     {% else %}
-      {{ email_newsletter_form() }}
+      {{ email_newsletter_form(button_class='white') }}
     {% endif %}
   </section>
 

--- a/bedrock/mozorg/templates/mozorg/plugincheck-c.html
+++ b/bedrock/mozorg/templates/mozorg/plugincheck-c.html
@@ -192,9 +192,9 @@
       <h3>{{ _('<span class="firefox">Firefox</span> + You') }}</h3>
       <h4>{{ _('Get Firefox tips, tricks, news and more') }}</h4>
     </header>
-    {{ email_newsletter_form() }}
+    {{ email_newsletter_form(button_class='white') }}
   {% else %}
-    {{ email_newsletter_form() }}
+    {{ email_newsletter_form(button_class='white') }}
   {% endif %}
 </section>
 

--- a/bedrock/mozorg/templates/mozorg/plugincheck-d.html
+++ b/bedrock/mozorg/templates/mozorg/plugincheck-d.html
@@ -179,9 +179,9 @@
       <h3>{{ _('<span class="firefox">Firefox</span> + You') }}</h3>
       <h4>{{ _('Get Firefox tips, tricks, news and more') }}</h4>
     </header>
-    {{ email_newsletter_form() }}
+    {{ email_newsletter_form(button_class='white') }}
   {% else %}
-    {{ email_newsletter_form() }}
+    {{ email_newsletter_form(button_class='white') }}
   {% endif %}
 </section>
 

--- a/bedrock/newsletter/helpers.py
+++ b/bedrock/newsletter/helpers.py
@@ -22,7 +22,7 @@ def email_newsletter_form(ctx, newsletters='mozilla-and-you', title=None,
                           use_thankyou=True, thankyou_head=None,
                           thankyou_content=None, footer=True,
                           process_form=True, include_title=None,
-                          submit_text=None):
+                          submit_text=None, button_class=None):
     request = ctx['request']
     context = ctx.get_all()
 
@@ -48,6 +48,7 @@ def email_newsletter_form(ctx, newsletters='mozilla-and-you', title=None,
         include_title=include_title if include_title is not None else footer,
         form=form,
         submit_text=submit_text,
+        button_class=button_class,
         success=success,
     ))
 

--- a/bedrock/newsletter/templates/newsletter/includes/form.html
+++ b/bedrock/newsletter/templates/newsletter/includes/form.html
@@ -72,7 +72,7 @@
 
     <div class="form-submit">
       <input type="submit" id="footer_email_submit"
-             value="{% if submit_text %}{{ submit_text }}{% else %}{{ _('Sign me up') }} »{% endif %}" class="button">
+             value="{% if submit_text %}{{ submit_text }}{% else %}{% if LANG.startswith('en-') %}{{ _('Sign Up Now') }}{% else %}{{ _('Sign me up') }}{% endif %}{% endif %}" class="button-newsletter {{ button_class }}">
 
       {% if details %}
         <p class="form-details">

--- a/bedrock/teach/templates/teach/smarton/base.html
+++ b/bedrock/teach/templates/teach/smarton/base.html
@@ -47,9 +47,9 @@
   <div class="footer-cta" id="footer-cta">
     <div id="smarton-foot-newsletter" class="foot-newsletter content" data-footer-name="Newsletter signup">
       {% if LANG.startswith('en') %}
-        {{ email_newsletter_form(newsletters='mozilla-foundation', title=_('Stay in control'), subtitle=_('Get tips and more from Mozilla')) }}
+        {{ email_newsletter_form(newsletters='mozilla-foundation', title=_('Stay in control'), subtitle=_('Get tips and more from Mozilla'), button_class='white') }}
       {% else %}
-        {{ email_newsletter_form() }}
+        {{ email_newsletter_form(button_class='white') }}
       {% endif %}
     </div>
 

--- a/docs/newsletters.rst
+++ b/docs/newsletters.rst
@@ -149,6 +149,31 @@ include_language=[True|False] and/or include_country=[True|False].
 You can also use the same form outside a page footer by passing ``footer=False``
 to the macro.
 
+You can also specify one of three color variants for the "Sign Up Now" button. The options are:
+
+* default - Which sets the border and font color to a light blue [#00afe5]
+* dark - Which sets the border and font color to the dark Firefox blue [00539F]
+* white - Which sets the border and font color to white [#fff]
+
+This is done in a template as follows:
+
+.. code-block:: jinja
+
+    # default
+    {% block email_form %}
+        {{ email_newsletter_form() }}
+    {% endblock %}
+
+    # dark
+    {% block email_form %}
+        {{ email_newsletter_form(button_class='dark') }}
+    {% endblock %}
+
+    # white
+    {% block email_form %}
+        {{ email_newsletter_form(button_class='white') }}
+    {% endblock %}
+
 Creating a signup page
 ----------------------
 
@@ -180,4 +205,3 @@ Then add a url to ``newsletter/urls.py``:
 
     # "about:mobile"
     page('newsletter/about_mobile', 'newsletter/mobile.html'),
-

--- a/media/css/firefox/android.less
+++ b/media/css/firefox/android.less
@@ -845,17 +845,6 @@ html[dir="rtl"] #phone-wrapper figure {
     }
 }
 
-#footer_email_submit {
-    display: block;
-    width: 100%;
-    background: #0092db;
-    border: 2px solid #fff;
-    padding: 15px 0;
-    text-transform: uppercase;
-    border-radius: 3px;
-    box-shadow: none;
-}
-
 #colophon {
     margin: 0;
 }

--- a/media/css/mozorg/contribute/contribute-2015.less
+++ b/media/css/mozorg/contribute/contribute-2015.less
@@ -929,6 +929,10 @@ textarea:focus {
         margin: 0;
     }
 
+    .form-submit {
+        width: 80%;
+    }
+
     .button {
         .button-flat;
         background-image: none;

--- a/media/css/mozorg/contribute/friends.less
+++ b/media/css/mozorg/contribute/friends.less
@@ -241,6 +241,7 @@
 
         // override default styling on email & country fields
         input[type="email"] {
+            padding: 4px 10px;
             width: auto;
 
             @media only screen and (max-width: @breakMobileLandscape) {

--- a/media/css/mozorg/home/home.less
+++ b/media/css/mozorg/home/home.less
@@ -740,24 +740,6 @@ h1, h2, h3, h4, h5, h6 {
     .form-submit {
         width: 50%;
         margin: 0;
-
-        input[type="submit"] {
-            width: 100%;
-            min-height: 45px;
-            background: #0095dd;
-            .font-size(18px);
-            font-weight: normal;
-            text-shadow: none;
-            text-transform: uppercase;
-            box-shadow: none;
-            border-radius: 7px;
-            -webkit-appearance: none;
-
-            &:hover,
-            &:focus {
-                background: lighten(#0095dd, 5%);
-            }
-        }
     }
 
     .privacy-check-label .title {

--- a/media/css/newsletter/newsletter.less
+++ b/media/css/newsletter/newsletter.less
@@ -231,6 +231,10 @@
             .span(6);
             clear: left;
         }
+
+        input[type="submit"] {
+            width: 85%;
+        }
     }
 }
 

--- a/media/css/plugincheck/plugincheck.less
+++ b/media/css/plugincheck/plugincheck.less
@@ -358,26 +358,6 @@ html[dir="rtl"] {
             margin: 0 auto;
             width: 90%;
         }
-
-        input[type="submit"] {
-            width: 100%;
-            min-height: 45px;
-            background: #0095dd;
-            .font-size(18px);
-            font-weight: normal;
-            text-shadow: none;
-            text-transform: uppercase;
-            text-align: center;
-            box-shadow: none;
-            border-radius: 7px;
-            -webkit-appearance: none;
-            -moz-appearance: none;
-
-            &:hover,
-            &:focus {
-                background: lighten(#0095dd, 5%);
-            }
-        }
     }
 
     .privacy-check-label .title {
@@ -526,17 +506,6 @@ html[lang="de"] #newsletter-form input[type="submit"] {
 
             @media only screen and (max-width: @breakMobileLandscape) {
                 width: 90%;
-            }
-        }
-
-        input[type="submit"] {
-            background-color: transparent;
-            border: 2px solid #fff;
-            border-radius: 3px;
-
-            &:hover,
-            &:focus {
-                background-color: transparent;
             }
         }
     }

--- a/media/css/sandstone/buttons-new.less
+++ b/media/css/sandstone/buttons-new.less
@@ -1,0 +1,62 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+@import "../sandstone/lib.less";
+
+@default: #0095dd;
+@defaultHover: #00afe5;
+@dark: #00539F;
+@darkHover: #0095DD;
+@white: #fff;
+@whiteHover: #f4f4f4;
+
+input[type="submit"].button-newsletter,
+.button-newsletter {
+
+    background: none;
+    color: @default;
+    border: 2px solid @default;
+    border-radius: 4px;
+    width: 100%;
+    min-height: 45px;
+    .font-size(18px);
+    font-weight: normal;
+    text-shadow: none;
+    box-shadow: none;
+    -webkit-appearance: none;
+    cursor: pointer;
+
+    &:hover,
+    &:focus {
+        color: @defaultHover;
+        border-color: @defaultHover;
+    }
+
+    &:active {
+        position: relative;
+        top: 1px;
+    }
+
+    &.dark {
+        color: @dark;
+        border-color: @dark;
+
+        &:hover,
+        &:focus {
+            color: @darkHover;
+            border-color: @darkHover;
+        }
+    }
+
+    &.white {
+        color: @white;
+        border-color: @white;
+
+        &:hover,
+        &:focus {
+            color: @whiteHover;
+            border-color: @whiteHover;
+        }
+    }
+}

--- a/media/css/sandstone/sandstone-resp.less
+++ b/media/css/sandstone/sandstone-resp.less
@@ -2,6 +2,7 @@
 @import "reset.less";
 @import "fonts.less";
 @import "buttons.less";
+@import "buttons-new.less";
 @import "animations.less";
 
 /* {{{ Basic Colors, Text, Links */
@@ -894,6 +895,7 @@ nav.menu-bar {
 
     input[type=email] {
         width: 80%;
+        padding: 15px 10px;
     }
 
     .field-privacy {

--- a/media/css/sandstone/sandstone.less
+++ b/media/css/sandstone/sandstone.less
@@ -2,6 +2,7 @@
 @import "reset.less";
 @import "fonts.less";
 @import "buttons.less";
+@import "buttons-new.less";
 @import "animations.less";
 
 /* {{{ Basic Colors, Text, Links */


### PR DESCRIPTION
## Description
Updates the button style for all newsletter buttons across the mozilla.org site.

## Bugzilla
https://bugzilla.mozilla.org/show_bug.cgi?id=1256668

## Testing
We do not have a public style reference yet, but you can use https://jsfiddle.net/71cewubk/15/ as a general resource here.

Navigate around the site and ensure that all newsletter buttons use a similar style. Also not that the copy for the buttons has changed from "Sign Me Up" to "Sign Up Now"

## Checklist
- [x] Requires l10n changes.
- [x] Related functional & integration tests passing.

