### PR TITLE
Lint Mozilla Annual Report JS files

### DIFF
--- a/media/js/foundation/annual2011.js
+++ b/media/js/foundation/annual2011.js
@@ -3,10 +3,9 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 (function() {
-    "use strict";
+    'use strict';
 
     var $window = $(window);
-    var $sliderPrime = $("#story-slider");
     var wideMode = false;
     var $nav = $('#page-nav');
     var $head = $('#masthead');
@@ -18,71 +17,91 @@
 
     setupThumbnails();
 
-    if(queryTablet.matches) {
+    if (queryTablet.matches) {
         wideMode = true;
         setupCarousel();
         setStage();
-        $("#video-stage").show();
+        $('#video-stage').show();
     } else {
         wideMode = false;
-        $("#video-stage").hide();
+        $('#video-stage').hide();
     }
 
-    queryTablet.addListener(function(mq){
-        if(mq.matches) {
+    queryTablet.addListener(function(mq) {
+        if (mq.matches) {
             wideMode = true;
             setupCarousel();
             setStage();
-            $("#video-stage").show();
+            $('#video-stage').show();
         } else {
             wideMode = false;
-            $("#video-stage").hide();
+            $('#video-stage').hide();
         }
     });
 
     // Add the read buttons
-    $("button.read").clone().insertBefore(".overlay").attr({'aria-pressed':"false",'aria-label':ARIASHOW});
+    $('button.read').clone().insertBefore('.overlay').attr({
+        'aria-pressed': 'false',
+        'aria-label': ARIASHOW
+    });
 
     // Reveal text overlays when hovering over a block
     // @Uses hoverIntent plugin: http://cherne.net/brian/resources/jquery.hoverIntent.html
-    $(".overlay-wrap").hoverIntent(
-        function() {
-            if (wideMode) {
-                var overlayheight = $(this).height() - 80;
-                $(this).find(".overlay").css({
-                    'minHeight' : overlayheight
-                }).fadeIn(200);
-                $(this).find('button.read').attr({'aria-pressed':"true"});
-            }
-        },
-        function() {
-            if (wideMode) {
-                $(this).find(".overlay").delay(300).fadeOut(600, function(){
-                    $(this).removeAttr('style');
-                    $(this).prev('button.read').attr({'aria-pressed':"false"});
-                });
-            }
+    $('.overlay-wrap').hoverIntent(function() {
+        if (wideMode) {
+            var overlayHeight = $(this).height() - 80;
+            $(this).find('.overlay').css({
+                'minHeight' : overlayHeight
+            }).fadeIn(200);
+            $(this).find('button.read').attr({
+                'aria-pressed':'true'
+            });
         }
-    );
+    }, function() {
+        if (wideMode) {
+            $(this).find('.overlay').delay(300).fadeOut(600, function() {
+                $(this).removeAttr('style');
+                $(this).prev('button.read').attr({
+                    'aria-pressed':'false'
+                });
+            });
+        }
+    });
 
     // Reveal overlays when buttons are activated (for keyboard, touch, and screen readers)
-    $(".overlay-wrap .read").bind("click", function() {
+    $('.overlay-wrap .read').bind('click', function() {
+
         if (wideMode) {
-            $(".overlay[style]").stop().delay(300).fadeOut(600, function(){ // First hide any visible overlays
-                $(this).removeAttr('style'); // Then reset them to normal (hidden in the style sheet)
-                $(this).prev('button.read').attr({'aria-pressed':"false"});
+            // First hide any visible overlays
+            $('.overlay[style]').stop().delay(300).fadeOut(600, function() {
+                // Then reset them to normal (hidden in the style sheet)
+                $(this).removeAttr('style');
+                $(this).prev('button.read').attr({
+                    'aria-pressed':'false'
+                });
             });
-            if($(this).attr('aria-pressed') === "false"){
-                $(this).attr({'aria-pressed':"true",'aria-label':ARIAHIDE});
-                var overlayheight = $(this).parents(".overlay-wrap").height() - 80;
-                $(this).parents(".overlay-wrap").find(".overlay").css({
-                    'minHeight' : overlayheight
+
+            if ($(this).attr('aria-pressed') === 'false') {
+
+                $(this).attr({
+                    'aria-pressed': 'true',
+                    'aria-label': ARIAHIDE
+                });
+
+                var overlayHeight = $(this).parents('.overlay-wrap').height() - 80;
+
+                $(this).parents('.overlay-wrap').find('.overlay').css({
+                    'minHeight' : overlayHeight
                 }).fadeIn(200);
+
                 $('html, body').animate({
-                    scrollTop: $(this).parents(".overlay-wrap").offset().top -40
+                    scrollTop: $(this).parents('.overlay-wrap').offset().top -40
                 }, 300);
             } else {
-                $(this).attr({'aria-pressed':"false",'aria-label':ARIASHOW});
+                $(this).attr({
+                    'aria-pressed': 'false',
+                    'aria-label': ARIASHOW
+                });
             }
         }
     });
@@ -98,7 +117,7 @@
 
     $(document).ready(function() {
         var scrollTop = $window.scrollTop();
-        if ( scrollTop >= navTop.top ) {
+        if (scrollTop >= navTop.top) {
             didScroll = true;
         }
     });
@@ -107,17 +126,21 @@
         if (didScroll) {
             didScroll = false;
             var scrollTop = $window.scrollTop();
-            if( scrollTop >= navTop.top ) {
-                if(!fixed) {
+            if (scrollTop >= navTop.top) {
+                if (!fixed) {
                     fixed = true;
-                    $nav.addClass("fixed");
-                    $head.css({ "margin-bottom" : navHeight });
+                    $nav.addClass('fixed');
+                    $head.css({
+                        'margin-bottom' : navHeight
+                    });
                 }
             } else {
-                if(fixed) {
+                if (fixed) {
                     fixed = false;
-                    $nav.removeAttr("class");
-                    $head.css({ "margin-bottom" : "0" });
+                    $nav.removeAttr('class');
+                    $head.css({
+                        'margin-bottom' : '0'
+                    });
                 }
             }
         }
@@ -128,11 +151,13 @@
 
     // Show/hide the navigation in small viewports
     if (!wideMode) {
-        $nav.click(function(){
-            $(this).animate({ top: "0" }, 'fast'); // Slide down
-            $(this).mouseleave(function(){ $(this).removeAttr("style"); });
-            $("body").bind('click', function(){
-                $nav.removeAttr("style");
+        $nav.click(function() {
+            $(this).animate({ 'top': '0' }, 'fast'); // Slide down
+            $(this).mouseleave(function() {
+                $(this).removeAttr('style');
+            });
+            $('body').bind('click', function() {
+                $nav.removeAttr('style');
             });
         });
     }
@@ -143,13 +168,13 @@
             if (fixed) {
                 if (dir === 'down') {
                     $nav.attr('class', 'fixed ' + current);
-                    $nav.find("li").removeClass();
-                    $("#nav-" + current).addClass("current");
+                    $nav.find('li').removeClass();
+                    $('#nav-' + current).addClass('current');
                 }
                 else {
                     $nav.attr('class', 'fixed ' + previous);
-                    $nav.find("li").removeClass();
-                    $("#nav-" + previous).addClass("current");
+                    $nav.find('li').removeClass();
+                    $('#nav-' + previous).addClass('current');
                 }
             }
         };
@@ -168,37 +193,39 @@
     $window.on('click', '#page-nav a[href^="#"]', function(e) {
         e.preventDefault();
         // Extract the target element's ID from the link's href.
-        var elem = $(this).attr("href").replace( /.*?(#.*)/g, "$1" );
+        var elem = $(this).attr('href').replace( /.*?(#.*)/g, '$1' );
+
         $('html, body').animate({
             scrollTop: $(elem).offset().top - 35
         }, 1000, function() {
             $(elem).attr('tabindex','100').focus().removeAttr('tabindex');
-            if (!wideMode) { $nav.removeAttr("style"); }
+            if (!wideMode) {
+                $nav.removeAttr('style');
+            }
         });
     });
 
     // Load links in new tab/window
-    $("a[rel='external']").click( function(e) {
+    $('a[rel="external"]').click(function(e) {
         e.preventDefault();
         window.open(this.href);
     });
 
     // Load videos in a full-page modal
-    $("a.video-play").click( function(e) {
+    $('a.video-play').click(function(e) {
         e.preventDefault();
         var $origin = $(this);
-        var video = $origin.data("videoSource");
-        var poster = $(this).children("img").attr("src");
-        var content =
-          '<video id="video" poster="'+poster+'" controls>'+
-          ' <source src="'+video+'.mp4" type="video/mp4">'+
-          ' <source src="'+video+'.webm" type="video/webm">'+
-          '</video>';
+        var video = $origin.data('videoSource');
+        var poster = $(this).children('img').attr('src');
+        var content = '<video id="video" poster="' + poster + '" controls>' +
+                      '<source src="' + video + '.mp4" type="video/mp4">' +
+                      '<source src="' + video + '.webm" type="video/webm">' +
+                      '</video>';
         createModal($origin, content);
     });
 
     // Load the YouTube video in a full-page modal
-    $("a.vid-youtube").click( function(e) {
+    $('a.vid-youtube').click(function(e) {
         e.preventDefault();
         var $origin = $(this);
         var content = '<iframe width="640" height="360" src="//www.youtube-nocookie.com/embed/f_f5wNw-2c0?rel=0" frameborder="0" allowfullscreen></iframe>';
@@ -207,7 +234,7 @@
 
     // Set up the contributor stories carousel
     function setupCarousel() {
-        $(".jcarousel-clip").jcarousel({
+        $('.jcarousel-clip').jcarousel({
             scroll: 4,
             visible: 4,
             buttonNextHTML: null,
@@ -216,9 +243,11 @@
             itemLastInCallback: { onAfterAnimation: disableButtons },
             initCallback: controlButtons
         });
-        if ( $("#story-vid").length > 0 ) {
-            $("#story-vid")[0].pause();
+
+        if ($('#story-vid').length > 0) {
+            $('#story-vid')[0].pause();
         }
+
         setStage();
         setupThumbnails();
         controlButtons();
@@ -226,49 +255,49 @@
 
     // Set up video stage
     function setStage() {
-        var video = $("#story-slider a.contributor:first").attr("href");
-        var poster = $("#story-slider a.contributor:first").data("poster");
-        var desc = $("#story-slider .vcard:first .note").html();
-        if ( $("#story-vid").length > 0) {
-            $("#story-vid").attr('poster', poster).attr('src', video);
+        var video = $('#story-slider a.contributor:first').attr('href');
+        var poster = $('#story-slider a.contributor:first').data('poster');
+        var desc = $('#story-slider .vcard:first .note').html();
+
+        if ($('#story-vid').length > 0) {
+            $('#story-vid').attr('poster', poster).attr('src', video);
         }
-        if ($("#video-stage figcaption").length > 0) {
-            $("#video-stage figcaption").remove();
+
+        if ($('#video-stage figcaption').length > 0) {
+            $('#video-stage figcaption').remove();
         }
-        $("#video-stage").append('<figcaption>'+desc+'</figcaption>');
+
+        $('#video-stage').append('<figcaption>' + desc + '</figcaption>');
 
         // Add a play button overlay
-        if ($("span.btn-play").length > 0) {
-            $("span.btn-play").remove();
+        if ($('span.btn-play').length > 0) {
+            $('span.btn-play').remove();
         }
+
         $('<span class="btn-play"></span>').appendTo('#video-stage .player').click(function() {
-            $("#story-vid").attr('controls','controls')[0].play();
-            $(this).fadeOut('fast', function(){ $(this).remove(); });
+            $('#story-vid').attr('controls','controls')[0].play();
+            $(this).fadeOut('fast', function() {
+                $(this).remove();
+            });
         });
     }
 
     // Add the left and right control buttons
-    function controlButtons(carousel) {
-        $('.btn-prev')
-            .on('jcarouselcontrol:active', function() {
-                $(this).removeClass('inactive');
-            })
-            .on('jcarouselcontrol:inactive', function() {
-                $(this).addClass('inactive');
-            })
-            .jcarouselControl({
-                target: '-=1'
+    function controlButtons() {
+        $('.btn-prev').on('jcarouselcontrol:active', function() {
+            $(this).removeClass('inactive');
+        }).on('jcarouselcontrol:inactive', function() {
+            $(this).addClass('inactive');
+        }).jcarouselControl({
+            target: '-=1'
         });
 
-        $('.btn-next')
-            .on('jcarouselcontrol:active', function() {
-                $(this).removeClass('inactive');
-            })
-            .on('jcarouselcontrol:inactive', function() {
-                $(this).addClass('inactive');
-            })
-            .jcarouselControl({
-                target: '+=1'
+        $('.btn-next').on('jcarouselcontrol:active', function() {
+            $(this).removeClass('inactive');
+        }).on('jcarouselcontrol:inactive', function() {
+            $(this).addClass('inactive');
+        }).jcarouselControl({
+            target: '+=1'
         });
     }
 
@@ -279,6 +308,7 @@
         } else {
             $('.btn-prev').removeAttr('disabled').removeClass('disabled');
         }
+
         if (carousel.last === carousel.size()) {
             $('.btn-next').attr('disabled','disabled').addClass('disabled');
         } else {
@@ -288,29 +318,34 @@
 
     // Contributor story thumbnails play the corresponding video
     function setupThumbnails() {
-        $("a.contributor").click(function(e) {
+        $('a.contributor').click(function(e) {
             e.preventDefault();
-            var video = $(this).attr("href");
-            var poster = $(this).attr("data-poster");
-            var desc = $(this).find(".note").html();
+            var video = $(this).attr('href');
+            var poster = $(this).attr('data-poster');
+            var desc = $(this).find('.note').html();
 
             if (wideMode) {
-                $("#story-vid")[0].pause();
-                if ( $("span.btn-play").length > 0 ) {
-                    $("span.btn-play").remove();
+                $('#story-vid')[0].pause();
+
+                if ($('span.btn-play').length > 0) {
+                    $('span.btn-play').remove();
                 }
-                $("#video-stage figcaption").fadeOut('fast', function(){ $(this).html(desc).fadeIn('fast'); });
-                $("#story-vid").attr('controls','controls').attr('src', video)[0].play();
+
+                $('#video-stage figcaption').fadeOut('fast', function() {
+                    $(this).html(desc).fadeIn('fast');
+                });
+
+                $('#story-vid').attr('controls','controls').attr('src', video)[0].play();
+
                 $('html, body').animate({
-                    scrollTop: $("#video-stage").offset().top - 80
+                    scrollTop: $('#video-stage').offset().top - 80
                 }, 200, function() {
-                    $("#story-vid").focus();
+                    $('#story-vid').focus();
                 });
             } else {
                 var $origin = $(this);
-                var content =
-                  '<video id="video" poster="'+poster+'" src="'+video+'" controls autoplay type="video/webm">'+
-                  '<p class="desc">'+desc+'</p>';
+                var content = '<video id="video" poster="'+poster+'" src="'+video+'" controls autoplay type="video/webm">'+
+                              '<p class="desc">'+desc+'</p>';
                 createModal($origin, content);
             }
         });
@@ -318,38 +353,37 @@
 
     // Create a full-page overlay and append the content
     function createModal(origin, content) {
-        if ($("#fill").length > 0) {
-            $("#video")[0].pause();
-            $("#fill").remove();
+        if ($('#fill').length > 0) {
+            $('#video')[0].pause();
+            $('#fill').remove();
         }
-        $('body').addClass("noscroll").append('<div id="fill"><div id="inner"></div></div>');
-        $("#inner").append(content);
+        $('body').addClass('noscroll').append('<div id="fill"><div id="inner"></div></div>');
+        $('#inner').append(content);
 
-        if ($("#inner #video").length > 0) {
-            $("#video").focus()[0].play();
+        if ($('#inner #video').length > 0) {
+            $('#video').focus()[0].play();
         }
 
         // Add the close button
-        $("#done").clone().appendTo("#inner");
-        $("#fill #done").bind('click', function() {
-            if ($("#inner #video").length > 0) {
-                $("#video")[0].pause();
+        $('#done').clone().appendTo('#inner');
+        $('#fill #done').bind('click', function() {
+            if ($('#inner #video').length > 0) {
+                $('#video')[0].pause();
             }
-            $("#fill").remove();
-            $("body").removeClass("noscroll");
+            $('#fill').remove();
+            $('body').removeClass('noscroll');
         });
 
         // Close on escape
-        $("#fill").bind('keyup', function(e) {
+        $('#fill').bind('keyup', function(e) {
             if (e.keyCode === 27) { // esc
-                if ($("#inner #video").length > 0) {
-                    $("#video")[0].pause();
+                if ($('#inner #video').length > 0) {
+                    $('#video')[0].pause();
                 }
-                $("#fill").remove();
-                $("body").removeClass("noscroll");
+                $('#fill').remove();
+                $('body').removeClass('noscroll');
                 origin.focus();
             }
         });
     }
-
 })();

--- a/media/js/foundation/annual2012.js
+++ b/media/js/foundation/annual2012.js
@@ -2,26 +2,27 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-;(function($) {
-	'use strict';
+(function($) {
+    'use strict';
 
-	$('a.video-play').attr('role', 'button').click(function(e) {
-    e.preventDefault();
+    $('a.video-play').attr('role', 'button').click(function(e) {
+        e.preventDefault();
 
-    var $this = $(this);
+        var $this = $(this);
 
-    Mozilla.Modal.createModal(this, $this.next(), {
-      title: $this.attr('data-title'),
-      onCreate: function() {
-        play_video();
-      }
+        Mozilla.Modal.createModal(this, $this.next(), {
+            title: $this.attr('data-title'),
+            onCreate: function() {
+                playVideo();
+            }
+        });
     });
-	});
 
-  var play_video = function() {
-    // give the modal a chance to open before playing
-    setTimeout(function() {
-      $('#modal video:first')[0].play();
-    }, 400);
-  };
+    var playVideo = function() {
+        // give the modal a chance to open before playing
+        setTimeout(function() {
+            $('#modal video:first')[0].play();
+        }, 400);
+    };
+
 })(window.jQuery);

--- a/media/js/foundation/annual2013.js
+++ b/media/js/foundation/annual2013.js
@@ -2,28 +2,28 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-;(function($) {
-  'use strict';
+(function($) {
+    'use strict';
 
-  $('a.video-play').attr('role', 'button').click(function(e) {
-    e.preventDefault();
+    $('a.video-play').attr('role', 'button').click(function(e) {
+        e.preventDefault();
 
-    var $this = $(this);
+        var $this = $(this);
 
-    Mozilla.Modal.createModal(this, $this.next(), {
-      title: $this.attr('data-title'),
-      onCreate: function() {
-        play_video();
-      }
+        Mozilla.Modal.createModal(this, $this.next(), {
+            title: $this.attr('data-title'),
+            onCreate: function() {
+                playVideo();
+            }
+        });
     });
-  });
 
-  var play_video = function() {
-    if (!!document.createElement('video').canPlayType) {
-      // give the modal a chance to open before playing
-      setTimeout(function() {
-        $('#modal video:first')[0].play();
-      }, 400);
-    }
-  };
+    var playVideo = function() {
+        if (document.createElement('video').canPlayType) {
+            // give the modal a chance to open before playing
+            setTimeout(function() {
+                $('#modal video:first')[0].play();
+            }, 400);
+        }
+    };
 })(window.jQuery);


### PR DESCRIPTION
## Description
Lint JS files for annual report pages. This is mainly indentation and single quote changes.

- /foundation/annualreport/2011/
- /foundation/annualreport/2012/
- /foundation/annualreport/2013/

Note: There is some cleanup we could do with regard to DOM querying & caching selectors on the older 2011 page, but that's not the aim right now.

## Bugzilla
N/A

## Testing
Should be a fairly safe change, mostly style related as opposed to changing any logic. Just a quick test to make sure there are no obvious regressions should be enough.

## Checklist
- [ ] Requires l10n changes.
- [ ] Related functional & integration tests passing (none for these pages)

