### PR TITLE
[fix bug 1261078] Add tests to new /contribute/friends/ page

### DIFF
--- a/tests/functional/contribute/test_friends.py
+++ b/tests/functional/contribute/test_friends.py
@@ -4,12 +4,39 @@
 
 import pytest
 
+from selenium.common.exceptions import TimeoutException
 from pages.contribute.friends import ContributeFriendsPage
 
 
 @pytest.mark.smoke
 @pytest.mark.nondestructive
-def test_display_signup_form(base_url, selenium):
+def test_signup_default_values(base_url, selenium):
     page = ContributeFriendsPage(base_url, selenium).open()
     page.click_show_signup_form()
     assert page.is_signup_form_displayed
+    assert '' == page.email
+    assert 'United States' == page.country
+    assert page.html_format_selected
+    assert not page.text_format_selected
+    assert not page.privacy_policy_accepted
+    assert page.is_privacy_policy_link_displayed
+
+
+@pytest.mark.nondestructive
+def test_successful_sign_up(base_url, selenium):
+    page = ContributeFriendsPage(base_url, selenium).open()
+    page.click_show_signup_form()
+    page.type_email('success@example.com')
+    page.select_country('Germany')
+    page.select_text_format()
+    page.accept_privacy_policy()
+    page.click_sign_me_up()
+    assert page.sign_up_successful
+
+
+@pytest.mark.nondestructive
+def test_sign_up_fails_when_missing_required_fields(base_url, selenium):
+    page = ContributeFriendsPage(base_url, selenium).open()
+    page.click_show_signup_form()
+    with pytest.raises(TimeoutException):
+        page.click_sign_me_up()

--- a/tests/pages/contribute/friends.py
+++ b/tests/pages/contribute/friends.py
@@ -3,6 +3,8 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 from selenium.webdriver.common.by import By
+from selenium.webdriver.support import expected_conditions as expected
+from selenium.webdriver.support.select import Select
 
 from pages.contribute.base import ContributeBasePage
 
@@ -11,9 +13,29 @@ class ContributeFriendsPage(ContributeBasePage):
 
     _url = '{base_url}/{locale}/contribute/friends'
 
-    _privacy_policy_link_locator = (By.CSS_SELECTOR, 'label[for="id_privacy"] a')
+    _email_locator = (By.ID, 'id_email')
+    _country_locator = (By.ID, 'id_country')
+    _html_format_locator = (By.ID, 'id_fmt_0')
+    _privacy_policy_checkbox_locator = (By.ID, 'id_privacy')
+    _privacy_policy_link_locator = (By.CSS_SELECTOR, 'label[for="id_privacy"] span a')
     _show_signup_form_button_locator = (By.ID, 'ff-show-signup-form')
     _signup_form_locator = (By.ID, 'newsletter-form')
+    _submit_button_locator = (By.ID, 'footer_email_submit')
+    _text_format_locator = (By.ID, 'id_fmt_1')
+    _thank_you_locator = (By.CSS_SELECTOR, '#newsletter-form-thankyou h3')
+
+    @property
+    def email(self):
+        return self.find_element(self._email_locator).get_attribute('value')
+
+    @property
+    def country(self):
+        el = self.find_element(self._country_locator)
+        return el.find_element(By.CSS_SELECTOR, 'option[selected]').text
+
+    @property
+    def html_format_selected(self):
+        return self.find_element(self._html_format_locator).is_selected()
 
     @property
     def is_signup_form_displayed(self):
@@ -23,7 +45,40 @@ class ContributeFriendsPage(ContributeBasePage):
     def is_privacy_policy_link_displayed(self):
         return self.is_element_displayed(self._privacy_policy_link_locator)
 
+    @property
+    def privacy_policy_accepted(self):
+        el = self.find_element(self._privacy_policy_checkbox_locator)
+        return el.is_selected()
+
+    @property
+    def sign_up_successful(self):
+        return self.is_element_displayed(self._thank_you_locator)
+
+    @property
+    def text_format_selected(self):
+        return self.find_element(self._text_format_locator).is_selected()
+
+    def accept_privacy_policy(self):
+        el = self.find_element(self._privacy_policy_checkbox_locator)
+        assert not el.is_selected(), 'Privacy policy has already been accepted'
+        el.click()
+        assert el.is_selected(), 'Privacy policy has not been accepted'
+
     def click_show_signup_form(self):
         assert not self.is_signup_form_displayed, 'Form is already displayed'
         self.find_element(self._show_signup_form_button_locator).click()
         self.wait.until(lambda s: self.is_privacy_policy_link_displayed)
+
+    def click_sign_me_up(self):
+        self.find_element(self._submit_button_locator).click()
+        self.wait.until(expected.visibility_of_element_located(self._thank_you_locator))
+
+    def select_country(self, value):
+        el = self.find_element(self._country_locator)
+        Select(el).select_by_visible_text(value)
+
+    def select_text_format(self):
+        self.find_element(self._text_format_locator).click()
+
+    def type_email(self, value):
+        self.find_element(self._email_locator).send_keys(value)


### PR DESCRIPTION
## Description
Adding functional tests to recently updated `/contribute/friends/` page. **Heavily** influenced by [existing newsletter tests](https://github.com/mozilla/bedrock/blob/master/tests/functional/test_newsletter.py).

## Bugzilla
[bug 1261078](https://bugzilla.mozilla.org/show_bug.cgi?id=1261078)

## Testing
Just run the tests:

`py.test --base-url http://localhost:8000 --driver Firefox --html tests/functional/results.html tests/functional/contribute/test_friends.py`

## Checklist
- [ ] Related functional & integration tests passing.

