### PR TITLE
Update links and wording

### DIFF
--- a/bedrock/mozorg/templates/mozorg/emails/documentation.txt
+++ b/bedrock/mozorg/templates/mozorg/emails/documentation.txt
@@ -1,16 +1,13 @@
-Thanks for your interest in helping with Mozilla's documentation and other writing activities. There are several ways you can help:
+Thanks for your interest in helping with Mozilla's documentation and other writing activities. There are a couple of ways you can help:
 
-Write Knowledge Base articles
-http://support.mozilla.com/kb/improve-knowledge-base
+Write Knowledge Base articles to help users
+https://support.mozilla.org/en-US/get-involved/kb
 
-Help with Mozilla Developer Network docs
-http://developer.mozilla.org/Project:en/How_to_Help 
+Help with Mozilla Developer Network docs for web developers
+https://developer.mozilla.org/en-US/docs/MDN/Getting_started
 
-Write about Mozilla-related topics on Wikipedia
-https://en.wikipedia.org/wiki/Wikipedia:WikiProject_Mozilla
 
 Thanks again for your interest and let me know if you have any questions about how to get started.
 
 Janet Swisher, jswisher@mozilla.com
-Technical Writer/Community Steward
-Mozilla Developer Network, https://developer.mozilla.org
+MDN Community Manager


### PR DESCRIPTION
## Description
Updated links to SUMO and MDN, and removed link to the Wikipedia project, which is not supported in any way.

## Bugzilla
https://bugzilla.mozilla.org/show_bug.cgi?id=1258442

## Testing
This is a text-only change that does not affect functionality.


## Checklist
- [x] Requires l10n changes, if this message has been localized.
- [ ] Related functional & integration tests passing.

