### PR TITLE
Lint Firefox /whatsnew, /firstrun and /tour related JS files

### DIFF
--- a/bedrock/settings/static_media.py
+++ b/bedrock/settings/static_media.py
@@ -1033,7 +1033,7 @@ PIPELINE_JS = {
     'firefox_accounts': {
         'source_filenames': (
             'js/base/search-params.js',
-            'js/firefox/australis/australis-uitour.js',
+            'js/base/uitour-lib.js',
             'js/firefox/sync-animation.js',
             'js/firefox/accounts.js',
         ),
@@ -1141,7 +1141,7 @@ PIPELINE_JS = {
     },
     'firefox_fx38_0_5_firstrun': {
         'source_filenames': (
-            'js/firefox/australis/australis-uitour.js',
+            'js/base/uitour-lib.js',
             'js/firefox/australis/fx38_0_5/firstrun.js',
         ),
         'output_filename': 'js/firefox_fx38_0_5_firstrun-bundle.js',
@@ -1154,7 +1154,7 @@ PIPELINE_JS = {
     },
     'firefox_developer_firstrun': {
         'source_filenames': (
-            'js/firefox/australis/australis-uitour.js',
+            'js/base/uitour-lib.js',
             'js/base/mozilla-modal.js',
             'js/firefox/dev-firstrun.js',
         ),
@@ -1195,14 +1195,14 @@ PIPELINE_JS = {
     },
     'firefox_pocket': {
         'source_filenames': (
-            'js/firefox/australis/australis-uitour.js',
+            'js/base/uitour-lib.js',
             'js/firefox/pocket.js',
         ),
         'output_filename': 'js/firefox_pocket-bundle.js',
     },
     'firefox_private_browsing': {
         'source_filenames': (
-            'js/firefox/australis/australis-uitour.js',
+            'js/base/uitour-lib.js',
             'js/base/mozilla-highlight-target.js',
             'js/libs/jquery.waypoints.min.js',
             'js/libs/jquery.waypoints-sticky.min.js',
@@ -1281,14 +1281,14 @@ PIPELINE_JS = {
             'js/libs/jquery.waypoints-sticky.min.js',
             'js/firefox/family-nav.js',
             'js/firefox/sync-animation.js',
-            'js/firefox/australis/australis-uitour.js',
+            'js/base/uitour-lib.js',
             'js/firefox/sync.js',
         ),
         'output_filename': 'js/firefox_sync-bundle.js',
     },
     'firefox_tour': {
         'source_filenames': (
-            'js/firefox/australis/australis-uitour.js',
+            'js/base/uitour-lib.js',
             'js/firefox/australis/browser-tour.js',
             'js/firefox/australis/fx36/tour.js',
         ),
@@ -1302,7 +1302,7 @@ PIPELINE_JS = {
     },
     'firefox_hello_start': {
         'source_filenames': (
-            'js/firefox/australis/australis-uitour.js',
+            'js/base/uitour-lib.js',
             'js/firefox/hello/hello-ftu.js',
             'js/firefox/hello/start-ftu.js',
         ),
@@ -1311,14 +1311,14 @@ PIPELINE_JS = {
     'firefox_hello_start_45': {
         'source_filenames': (
             'js/base/search-params.js',
-            'js/firefox/australis/australis-uitour.js',
+            'js/base/uitour-lib.js',
             'js/firefox/hello/start-45.js',
         ),
         'output_filename': 'js/firefox_hello_start_45-bundle.js',
     },
     'firefox_hello': {
         'source_filenames': (
-            'js/firefox/australis/australis-uitour.js',
+            'js/base/uitour-lib.js',
             'js/libs/jquery.waypoints.min.js',
             'js/libs/jquery.waypoints-sticky.min.js',
             'js/firefox/family-nav.js',
@@ -1333,7 +1333,7 @@ PIPELINE_JS = {
             'js/base/mozilla-modal.js',
             'js/base/search-params.js',
             'js/base/send-to-device.js',
-            'js/firefox/australis/australis-uitour.js',
+            'js/base/uitour-lib.js',
             'js/libs/jquery.waypoints.min.js',
             'js/libs/jquery.waypoints-sticky.min.js',
             'js/firefox/family-nav.js',
@@ -1344,7 +1344,7 @@ PIPELINE_JS = {
     'firefox_tour_none': {
         'source_filenames': (
             'js/libs/jquery.waypoints.min.js',
-            'js/firefox/australis/australis-uitour.js',
+            'js/base/uitour-lib.js',
             'js/firefox/australis/common.js',
             'js/firefox/australis/no-tour.js',
         ),
@@ -1360,7 +1360,7 @@ PIPELINE_JS = {
     'firefox_whatsnew_38_pocket': {
         'source_filenames': (
             'js/base/mozilla-modal.js',
-            'js/firefox/australis/australis-uitour.js',
+            'js/base/uitour-lib.js',
             'js/firefox/whatsnew_38/pocket-uitour.js',
             'js/firefox/whatsnew_38/whatsnew-pocket.js',
         ),
@@ -1368,7 +1368,7 @@ PIPELINE_JS = {
     },
     'firefox_whatsnew_42_a': {
         'source_filenames': (
-            'js/firefox/australis/australis-uitour.js',
+            'js/base/uitour-lib.js',
             'js/base/mozilla-highlight-target.js',
             'js/firefox/whatsnew_42/variant-a.js',
         ),
@@ -1376,7 +1376,7 @@ PIPELINE_JS = {
     },
     'firefox_firstrun_42_learnmore': {
         'source_filenames': (
-            'js/firefox/australis/australis-uitour.js',
+            'js/base/uitour-lib.js',
             'js/base/mozilla-highlight-target.js',
             'js/firefox/firstrun/learnmore/learnmore.js',
         ),
@@ -1384,14 +1384,14 @@ PIPELINE_JS = {
     },
     'firefox_firstrun_learnmore_yahoo_search': {
         'source_filenames': (
-            'js/firefox/australis/australis-uitour.js',
+            'js/base/uitour-lib.js',
             'js/firefox/firstrun/learnmore/yahoo-search.js',
         ),
         'output_filename': 'js/firefox_firstrun_learnmore_yahoo_search-bundle.js',
     },
     'firefox_win10_welcome': {
         'source_filenames': (
-            'js/firefox/australis/australis-uitour.js',
+            'js/base/uitour-lib.js',
             'js/base/mozilla-firefox-default.js',
             'js/firefox/win10-welcome.js',
             'js/firefox/win10-welcome-init.js',
@@ -1549,7 +1549,7 @@ PIPELINE_JS = {
     'tracking-protection-tour': {
         'source_filenames': (
             'js/libs/jquery-1.11.3.min.js',
-            'js/firefox/australis/australis-uitour.js',
+            'js/base/uitour-lib.js',
             'js/firefox/tracking-protection-tour.js',
             'js/firefox/tracking-protection-tour-init.js',
         ),

--- a/media/js/base/uitour-lib.js
+++ b/media/js/base/uitour-lib.js
@@ -7,7 +7,7 @@ if (typeof Mozilla == 'undefined') {
     var Mozilla = {};
 }
 
-;(function($) {
+(function() {
     'use strict';
 
     // create namespace
@@ -43,10 +43,12 @@ if (typeof Mozilla == 'undefined') {
         var id = _generateCallbackID();
 
         function listener(event) {
-            if (typeof event.detail != 'object')
+            if (typeof event.detail != 'object') {
                 return;
-            if (event.detail.callbackID != id)
+            }
+            if (event.detail.callbackID !== id) {
                 return;
+            }
 
             document.removeEventListener('mozUITourResponse', listener);
             callback(event.detail.data);
@@ -88,11 +90,14 @@ if (typeof Mozilla == 'undefined') {
             }
         }
 
-        var closeButtonCallbackID, targetCallbackID;
-        if (options && options.closeButtonCallback)
+        var closeButtonCallbackID;
+        var targetCallbackID;
+        if (options && options.closeButtonCallback) {
             closeButtonCallbackID = _waitForCallback(options.closeButtonCallback);
-        if (options && options.targetCallback)
+        }
+        if (options && options.targetCallback) {
             targetCallbackID = _waitForCallback(options.targetCallback);
+        }
 
         _sendEvent('showInfo', {
             target: target,

--- a/media/js/firefox/accounts.js
+++ b/media/js/firefox/accounts.js
@@ -2,7 +2,7 @@
 * License, v. 2.0. If a copy of the MPL was not distributed with this
 * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-;(function(Mozilla, $) {
+(function(Mozilla, $) {
     'use strict';
 
     var params = new window._SearchParams();

--- a/media/js/firefox/android.js
+++ b/media/js/firefox/android.js
@@ -2,7 +2,7 @@
 * License, v. 2.0. If a copy of the MPL was not distributed with this
 * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-;(function($, Mozilla) {
+(function($, Mozilla) {
     'use strict';
 
     var isOldIE = (/MSIE\s[1-7]\./.test(navigator.userAgent));

--- a/media/js/firefox/australis/browser-tour.js
+++ b/media/js/firefox/australis/browser-tour.js
@@ -7,7 +7,7 @@ if (typeof Mozilla == 'undefined') {
     var Mozilla = {};
 }
 
-;(function($, Mozilla) {
+(function($, Mozilla) {
     'use strict';
 
     function BrowserTour (options) {
@@ -88,7 +88,6 @@ if (typeof Mozilla == 'undefined') {
     BrowserTour.prototype.init = function () {
         var that = this;
         var $p = this.$maskInner.find('p');
-        var $main = this.$maskInner.find('.main');
         var words = $p.text().split(' ');
         var delay = $('body').hasClass('html-ltr') ? 100 : 0;
         var $tempEl = $('<div>');

--- a/media/js/firefox/australis/common.js
+++ b/media/js/firefox/australis/common.js
@@ -1,4 +1,8 @@
-;(function($, Mozilla) {
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+(function($, Mozilla) {
     'use strict';
 
     var pageId = $('body').prop('id');
@@ -42,7 +46,7 @@
     }
 
     // link directly to Firefox Accounts when clicking the Sync CTA button
-    Mozilla.UITour.getConfiguration('sync', function (config) {
+    Mozilla.UITour.getConfiguration('sync', function () {
         $('.sync-cta .button').each(function() {
             $(this).attr({
                 'data-page-name': pageId,

--- a/media/js/firefox/australis/fx36/tour.js
+++ b/media/js/firefox/australis/fx36/tour.js
@@ -1,21 +1,12 @@
-;(function($, Mozilla) {
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+(function($, Mozilla) {
     'use strict';
 
     var client = Mozilla.Client;
-
     var helloAnimationStage = $('#hello-animation-stage');
-
-    //track if this is the first time a user has seen tour
-    function trackFirstTimeUse() {
-        var firstTime = 'True';
-        try {
-            if (localStorage.getItem('mozUITourGlobalFlag') === 'taken') {
-                firstTime = 'False';
-            } else {
-                localStorage.setItem('mozUITourGlobalFlag', 'taken');
-            }
-        } catch (e) {}
-    }
 
     function triggerHelloAnimation() {
         helloAnimationStage.addClass('animate');
@@ -25,7 +16,7 @@
     if (client.isFirefoxDesktop && client.FirefoxMajorVersion >= 36) {
 
         // Query if the UITour API is working before we start the tour
-        Mozilla.UITour.getConfiguration('sync', function (config) {
+        Mozilla.UITour.getConfiguration('sync', function () {
 
             var tour = new Mozilla.BrowserTour({
                 id: $('#tour-page').data('telemetry'),
@@ -36,8 +27,6 @@
             });
 
             tour.init();
-
-            trackFirstTimeUse();
         });
     }
 

--- a/media/js/firefox/australis/fx38_0_5/firstrun.js
+++ b/media/js/firefox/australis/fx38_0_5/firstrun.js
@@ -1,4 +1,4 @@
-;(function($, Mozilla) {
+(function($, Mozilla) {
     'use strict';
 
     var client = Mozilla.Client;

--- a/media/js/firefox/australis/no-tour.js
+++ b/media/js/firefox/australis/no-tour.js
@@ -1,4 +1,4 @@
-;(function($, Mozilla) {
+(function($, Mozilla) {
     'use strict';
 
     var client = Mozilla.Client;

--- a/media/js/firefox/dev-firstrun.js
+++ b/media/js/firefox/dev-firstrun.js
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 /* global YT */
+/* eslint no-unused-vars: ["error", { "varsIgnorePattern": "onYouTubeIframeAPIReady" }] */
 
 // YouTube API hook has to be in global scope
 function onYouTubeIframeAPIReady() {
@@ -11,7 +12,7 @@ function onYouTubeIframeAPIReady() {
     Mozilla.firstRunOnYouTubeIframeAPIReady();
 }
 
-;(function($, Mozilla) {
+(function($, Mozilla) {
     'use strict';
 
     window.dataLayer = window.dataLayer || [];
@@ -23,7 +24,6 @@ function onYouTubeIframeAPIReady() {
 
     var $window = $(window);
     var $document = $(document);
-    var $main = $('main');
     var TARGET_1 = 'devtools';
     var TARGET_2 = 'webide';
     var TARGET_3 = 'appMenu';

--- a/media/js/firefox/dev-whatsnew.js
+++ b/media/js/firefox/dev-whatsnew.js
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 /* global YT */
+/* eslint no-unused-vars: ["error", { "varsIgnorePattern": "onYouTubeIframeAPIReady" }] */
 
 // YouTube API hook has to be in global scope
 
@@ -16,7 +17,7 @@ function onYouTubeIframeAPIReady() {
     Mozilla.firstRunOnYouTubeIframeAPIReady();
 }
 
-;(function($, Mozilla) {
+(function($, Mozilla) {
     'use strict';
 
     var tag = document.createElement('script');

--- a/media/js/firefox/firstrun/firstrun.js
+++ b/media/js/firefox/firstrun/firstrun.js
@@ -1,4 +1,8 @@
-;(function($) {
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+(function($) {
     'use strict';
 
     var $fxaFrame = $('#fxa');

--- a/media/js/firefox/firstrun/learnmore/learnmore.js
+++ b/media/js/firefox/firstrun/learnmore/learnmore.js
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-;(function(Mozilla) {
+(function(Mozilla) {
     'use strict';
 
     var $shield = $('#tracking-protection-animation');

--- a/media/js/firefox/hello/hello-ftu.js
+++ b/media/js/firefox/hello/hello-ftu.js
@@ -446,7 +446,9 @@ if (typeof Mozilla === 'undefined') {
         });
         try {
             localStorage.removeItem('hello_ftu_tour_source');
-        } catch (ex) { }
+        } catch (ex) {
+            //empty block
+        }
     };
 
     HelloFTU.getTourSourceFromStorage = function() {
@@ -463,7 +465,9 @@ if (typeof Mozilla === 'undefined') {
     HelloFTU.setTourSourceToStorage = function(tourSource) {
         try {
             localStorage.setItem('hello_ftu_tour_source', tourSource);
-        } catch (ex) { }
+        } catch (ex) {
+            // empty block
+        }
     };
 
     window.Mozilla.HelloFTU = HelloFTU;

--- a/media/js/firefox/hello/start-45.js
+++ b/media/js/firefox/hello/start-45.js
@@ -4,7 +4,7 @@
 
  /* globals Promise */
 
-;(function($, Mozilla) {
+(function($, Mozilla) {
     'use strict';
 
     var $window = $(window);

--- a/media/js/firefox/hello/start-ftu.js
+++ b/media/js/firefox/hello/start-ftu.js
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-;(function($, Mozilla) {
+(function($, Mozilla) {
     'use strict';
 
     var client = Mozilla.Client;

--- a/media/js/firefox/tracking-protection-tour.js
+++ b/media/js/firefox/tracking-protection-tour.js
@@ -31,14 +31,14 @@ if (typeof Mozilla === 'undefined') {
     TPTour.step1 = function() {
         var buttons = [
             {
-              label: _step1.stepText,
-              style: 'text',
+                label: _step1.stepText,
+                style: 'text'
             },
             {
-              callback: TPTour.step2,
-              label: _step1.buttonText,
-              style: 'primary',
-            },
+                callback: TPTour.step2,
+                label: _step1.buttonText,
+                style: 'primary'
+            }
         ];
 
         var options = {
@@ -69,13 +69,13 @@ if (typeof Mozilla === 'undefined') {
         var buttons = [
             {
                 label: _step3.stepText,
-                style: 'text',
+                style: 'text'
             },
             {
                 callback: TPTour.shouldCloseTab,
                 label: _step3.buttonText,
-                style: 'primary',
-            },
+                style: 'primary'
+            }
         ];
 
         var options = {

--- a/media/js/firefox/whatsnew_38/pocket-uitour.js
+++ b/media/js/firefox/whatsnew_38/pocket-uitour.js
@@ -2,7 +2,7 @@
 * License, v. 2.0. If a copy of the MPL was not distributed with this
 * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-;(function($, Mozilla) {
+(function($, Mozilla) {
     'use strict';
 
     var client = Mozilla.Client;

--- a/media/js/firefox/whatsnew_38/whatsnew-pocket.js
+++ b/media/js/firefox/whatsnew_38/whatsnew-pocket.js
@@ -2,7 +2,7 @@
 * License, v. 2.0. If a copy of the MPL was not distributed with this
 * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-;(function($, Mozilla) {
+(function($, Mozilla) {
     'use strict';
 
     var $pageContent = $('#outer-wrapper');
@@ -29,7 +29,7 @@
                     'videoTitle': 'When its Personal Campaign Video'
                 });
             }, 1000);
-         });
+        });
 
         // hide thumbnail and play video on click
         $videoThumbnail.on('click', function (e) {

--- a/media/js/firefox/whatsnew_38/whatsnew-video.js
+++ b/media/js/firefox/whatsnew_38/whatsnew-video.js
@@ -2,7 +2,7 @@
 * License, v. 2.0. If a copy of the MPL was not distributed with this
 * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-;(function($, Mozilla) {
+(function($, Mozilla) {
     'use strict';
 
     var $videoContent = $('#video-content');
@@ -39,6 +39,6 @@
                 'videoTitle': 'When its Personal Campaign Video'
             });
         }, 1000);
-     });
+    });
 
- })(window.jQuery, window.Mozilla);
+})(window.jQuery, window.Mozilla);

--- a/media/js/firefox/whatsnew_42/variant-a.js
+++ b/media/js/firefox/whatsnew_42/variant-a.js
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-;(function(Mozilla) {
+(function(Mozilla) {
     'use strict';
 
     var $shield = $('#tracking-protection-animation');

--- a/media/js/firefox/win10-welcome-init.js
+++ b/media/js/firefox/win10-welcome-init.js
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-;(function(Mozilla) {
+(function(Mozilla) {
     'use strict';
 
     var client = Mozilla.Client;

--- a/media/js/firefox/win10-welcome.js
+++ b/media/js/firefox/win10-welcome.js
@@ -48,7 +48,7 @@ if (typeof Mozilla === 'undefined') {
 
         window.dataLayer.push({
             'event': 'windows-10-welcome',
-            'interaction': 'default-set',
+            'interaction': 'default-set'
         });
     };
 
@@ -75,7 +75,7 @@ if (typeof Mozilla === 'undefined') {
 
         window.dataLayer.push({
             'event': 'windows-10-welcome',
-            'interaction': 'set-default-cta-click',
+            'interaction': 'set-default-cta-click'
         });
     };
 
@@ -97,7 +97,7 @@ if (typeof Mozilla === 'undefined') {
 
         window.dataLayer.push({
             'event': 'windows-10-welcome',
-            'interaction': 'tab-visible',
+            'interaction': 'tab-visible'
         });
     };
 


### PR DESCRIPTION
## Description
- Lint JS files related to /whatsnew, /firstrun, and UITour related files.
- Renames `australis-uitour.js` to `uitour-lib.js` and moves to `/js/base/`, as much of the site now uses this file.

## Bugzilla
N/A

## Testing
Mostly small changes, but some manual testing of pages would be appreciated for good measure.

## Checklist
- [ ] Requires l10n changes.
- [ ] Related functional & integration tests passing (none for these pages)

