### PR TITLE
Fix Bug 1262603 - remove "friends" and "partner" links from footer site wide

### DIFF
--- a/bedrock/base/templates/includes/site-footer.html
+++ b/bedrock/base/templates/includes/site-footer.html
@@ -13,9 +13,7 @@
           <div class="col col-2">
             <ul class="links-join">
               <li><a href="{{ url('mozorg.contact.contact-landing') }}" data-link-type="footer" data-link-name="Contact Us">{{ _('Contact Us') }}</a></li>
-              <li class="wrap"><a href="{{ url('mozorg.partnerships') }}" data-link-type="footer" data-link-name="Partner with Us">{{ _('Partner with Us' ) }}</a></li>
-              <li class="clear"><a href="{{ donate_url('footer') }}" class="donate" data-link-type="footer" data-link-name="Donate">{{ _('Donate') }}</a></li>
-              <li class="wrap"><a href="{{ url('mozorg.contribute.friends') }}" data-link-type="footer" data-link-name="Firefox Friends">{{ _('Firefox Friends') }}</a></li>
+              <li class="wrap"><a href="{{ donate_url('footer') }}" class="donate" data-link-type="footer" data-link-name="Donate">{{ _('Donate') }}</a></li>
               <li class="clear"><a href="https://wiki.mozilla.org/Webdev/GetInvolved/mozilla.org" data-link-type="footer" data-link-name="Contribute to this site">{{ _('Contribute to this site') }}</a></li>
             </ul>
             <ul class="links-legal">

--- a/bedrock/mozorg/templates/mozorg/contribute/studentambassadors/landing.html
+++ b/bedrock/mozorg/templates/mozorg/contribute/studentambassadors/landing.html
@@ -51,7 +51,6 @@
         <section id="sec-what">
           <h2>{{ _('What We Do') }}</h2>
           <ul>
-            <li>{{ _('<a href="%s">Support Firefox</a> for Desktop and Android')|format(url('mozorg.contribute.friends')) }}</li>
             <li>{{ _('Support the successful launch of <a href="%s">Firefox&nbsp;OS</a> in communities (and campuses!) around the world')|format(url('firefox.os.index')) }}</li>
             <li>{{ _('Educate others about Mozilla’s mission') }}</li>
             <li>{{ _('Grow the Mozilla Community') }}</li>


### PR DESCRIPTION
This also removes a Firefox Friends link on the Firefox Student Ambassadors page, as requested in Bug 1249419.