### PR TITLE
[fix bug 1253599] Broken links on Mozilla manifesto page

### DIFF
--- a/bedrock/mozorg/templates/mozorg/about/manifesto.html
+++ b/bedrock/mozorg/templates/mozorg/about/manifesto.html
@@ -75,9 +75,9 @@
                 <section>
                   <h4>{{ _('Learn more') }}</h4>
                   <ul class="resources">
-                    <li><a href="http://www.openbadges.org/">{{ _('Use Open Badges to share your skills and interests') }}</a></li>
+                    <li><a href="http://openbadges.org/">{{ _('Use Open Badges to share your skills and interests') }}</a></li>
                     <li><a href="http://mozillascience.org/">{{ _('Explore how the Web impacts science') }}</a></li>
-                    <li><a href="http://opennews.org/getinvolved.html">{{ _('Learn about open source code in journalism') }}</a></li>
+                    <li><a href="https://opennews.org/getinvolved/">{{ _('Learn about open source code in journalism') }}</a></li>
                   </ul>
                   <ul class="videos">
                     <li><a href="https://www.youtube.com/watch?v=blnKhjlxJlM"><img src="{{ static('img/mozorg/about/manifesto/videos/blnKhjlxJlM.jpg') }}" alt=""> {{ _('Making to learn in the digital world') }}</a></li>
@@ -98,7 +98,7 @@
                   <h4>{{ _('Learn more') }}</h4>
                   <ul class="resources">
                     <li><a href="https://blog.mozilla.org/netpolicy/">{{ _('Read about open Internet policy initiatives and developments') }}</a></li>
-                    <li><a href="https://webmaker.org/resources/literacy/weblit-OpenPractices">{{ _('Explore how to help keep the Web open') }}</a></li>
+                    <li><a href="https://teach.mozilla.org/web-literacy/participate/open-practice/">{{ _('Explore how to help keep the Web open') }}</a></li>
                   </ul>
                   <ul class="videos">
                     <li><a href="https://www.youtube.com/watch?v=Pzj-h7gzn_c"><img src="{{ static('img/mozorg/about/manifesto/videos/Pzj-h7gzn_c.jpg') }}" alt=""> {{ _('Mozilla story') }}</a></li>
@@ -122,7 +122,7 @@
                   <h4>{{ _('Learn more') }}</h4>
                   <ul class="resources">
                     <li><a href="https://blog.mozilla.org/blog/2014/04/09/firefox-os-and-medic-mobile-use-the-web-to-connect-the-world-to-healthcare/">{{ _('See how the Web can connect the world to healthcare') }}</a></li>
-                    <li><a href="https://webmaker.org/resources/literacy/weblit-Infrastructure">{{ _('Explore how the Web works') }}</a></li>
+                    <li><a href="https://teach.mozilla.org/web-literacy/read/navigate/">{{ _('Explore how the Web works') }}</a></li>
                   </ul>
                   <ul class="videos">
                     <li><a href="https://www.youtube.com/watch?v=FOad5yki-dU"><img src="{{ static('img/mozorg/about/manifesto/videos/FOad5yki-dU.jpg') }}" alt=""> {{ _('Medic Mobile') }}</a></li>
@@ -143,7 +143,7 @@
                   <ul class="resources">
                     <li><a href="{{ url('teach.smarton.index') }}">{{ _('See how Mozilla works to put your privacy first') }}</a></li>
                     <li><a href="https://blog.mozilla.org/netpolicy/">{{ _('Read about developments in privacy and data safety') }}</a></li>
-                    <li><a href="https://webmaker.org/resources/literacy/weblit-Security">{{ _('Learn more about how to protect yourself online') }}</a></li>
+                    <li><a href="https://teach.mozilla.org/web-literacy/participate/protect/">{{ _('Learn more about how to protect yourself online') }}</a></li>
                   </ul>
                   <ul class="videos">
                     <li><a href="https://www.youtube.com/watch?v=Xm5i5kbIXzc"><img src="{{ static('img/mozorg/about/manifesto/videos/Xm5i5kbIXzc.jpg') }}" alt=""> {{ _('The Web We Want: An Open Letter') }}</a></li>
@@ -163,7 +163,7 @@
                   <h4>{{ _('Learn more') }}</h4>
                   <ul class="resources">
                     <li><a href="https://teach.mozilla.org/tools/">{{ _('Use these free tools to teach the Web') }}</a></li>
-                    <li><a href="https://webmaker.org/resources/literacy/weblit-Composing">{{ _('Learn about creating and curating content for the Web') }}</a></li>
+                    <li><a href="https://teach.mozilla.org/web-literacy/write/compose/">{{ _('Learn about creating and curating content for the Web') }}</a></li>
                   </ul>
                   <ul class="videos">
                     <li><a href="https://www.youtube.com/watch?v=N71JmJZc3F4"><img src="{{ static('img/mozorg/about/manifesto/videos/N71JmJZc3F4.jpg') }}" alt=""> {{ _('Teaching the Web') }}</a></li>
@@ -185,7 +185,7 @@
                   <ul class="resources">
                     <li><a href="http://ascendproject.org/">{{ _('Add new voices to open source technology') }}</a></li>
                     <li><a href="{{ url('firefox.dnt') }}">{{ _('Set your Do Not Track preference') }}</a></li>
-                    <li><a href="https://webmaker.org/resources/literacy/weblit-WebMechanics">{{ _('Understand the Web ecosystem') }}</a></li>
+                    <li><a href="https://teach.mozilla.org/web-literacy/read/navigate/">{{ _('Understand the Web ecosystem') }}</a></li>
                   </ul>
                   <ul class="videos">
                     <li><a href="https://www.youtube.com/watch?v=Xrh2FN1y8CY"><img src="{{ static('img/mozorg/about/manifesto/videos/Xrh2FN1y8CY.jpg') }}" alt=""> {{ _('Who is Mozilla?') }}</a></li>
@@ -204,9 +204,9 @@
                 <section>
                   <h4>{{ _('Learn more') }}</h4>
                   <ul class="resources">
-                    <li><a href="https://webmaker.org/resources/literacy/weblit-OpenPractices">{{ _('Explore how open practices keep the Web accessible') }}</a></li>
-                    <li><a href="https://webmaker.org/resources/literacy/weblit-Remix">{{ _('Learn how to remix content to create something new') }}</a></li>
-                    <li><a href="https://webmaker.org/resources/literacy/weblit-CodingScripting">{{ _('Learn how to maximize the interactive potential of the Web') }}</a></li>
+                    <li><a href="https://teach.mozilla.org/web-literacy/participate/open-practice/">{{ _('Explore how open practices keep the Web accessible') }}</a></li>
+                    <li><a href="https://teach.mozilla.org/web-literacy/write/remix/">{{ _('Learn how to remix content to create something new') }}</a></li>
+                    <li><a href="https://teach.mozilla.org/web-literacy/write/code/">{{ _('Learn how to maximize the interactive potential of the Web') }}</a></li>
                   </ul>
                   <ul class="videos">
                     <li><a href="https://www.youtube.com/watch?v=a6cc43X2zH8"><img src="{{ static('img/mozorg/about/manifesto/videos/a6cc43X2zH8.jpg') }}" alt=""> {{ _('Contributing to Open Source Software') }}</a></li>
@@ -234,7 +234,7 @@
                       <li>{{ _('Join us as a <a href="%(volunteer)s">volunteer</a> or <a href="%(ambassador)s">student ambassador</a>')|format(volunteer=url('mozorg.contribute'), ambassador=url('mozorg.contribute.studentambassadors.landing')) }}</li>
                     {% endif %}
 
-                    <li><a href="https://webmaker.org/resources/literacy/weblit-Community">{{ _('Learn how to collaborate online') }}</a></li>
+                    <li><a href="https://teach.mozilla.org/web-literacy/skills/">{{ _('Learn how to collaborate online') }}</a></li>
                   </ul>
                   <ul class="videos">
                     <li><a href="https://www.youtube.com/watch?v=LuyBGkbzTjs"><img src="{{ static('img/mozorg/about/manifesto/videos/LuyBGkbzTjs.jpg') }}" alt="">{{ _('I am a Mozillian') }}</a></li>
@@ -255,7 +255,7 @@
                   <ul class="resources">
                     <li><a href="{{ url('lightbeam.lightbeam') }}">{{ _('Visualize who you interact with on the Web with Lightbeam') }}</a></li>
                     <li><a href="{{ url('firefox.os.index') }}">{{ _('See how Firefox phones seek to balance the mobile ecosystem') }}</a></li>
-                    <li><a href="https://webmaker.org/resources/literacy/weblit-Sharing">{{ _('Learn about creating Web resources with others') }}</a></li>
+                    <li><a href="https://teach.mozilla.org/web-literacy/participate/share/">{{ _('Learn about creating Web resources with others') }}</a></li>
                   </ul>
                   <ul class="videos">
                     <li><a href="https://www.youtube.com/watch?v=PvqGy9wz_wA"><img src="{{ static('img/mozorg/about/manifesto/videos/PvqGy9wz_wA.jpg') }}" alt=""> {{ _('Lightbeam for Firefox') }}</a></li>
@@ -275,7 +275,7 @@
                   <h4>{{ _('Learn more') }}</h4>
                   <ul class="resources">
                     <li><a href="http://party.webmaker.org/">{{ _('Host or join a Maker Party') }}</a></li>
-                    <li><a href="https://webmaker.org/resources/literacy/weblit-Collaborating">{{ _('Learn how to build online collaboration skills') }}</a></li>
+                    <li><a href="https://teach.mozilla.org/web-literacy/skills/">{{ _('Learn how to build online collaboration skills') }}</a></li>
                   </ul>
                   <ul class="videos">
                     <li><a href="https://www.youtube.com/watch?v=SqEQCU_pvKs"><img src="{{ static('img/mozorg/about/manifesto/videos/SqEQCU_pvKs.jpg') }}" alt=""> {{ _('What is MozFest?') }}</a></li>


### PR DESCRIPTION
## Description
- Fixes a bunch of broken and outdated links on the Mozilla manifesto. I tried to find suitable alternatives, most of the Webmaker resources seem to have moved to https://teach.mozilla.org.

## Bugzilla
https://bugzilla.mozilla.org/show_bug.cgi?id=1253599

