### PR TITLE
Fix incorrect import for FxOS nav tests.

### DIFF
--- a/tests/functional/firefox/os/test_fxos_navigation.py
+++ b/tests/functional/firefox/os/test_fxos_navigation.py
@@ -4,7 +4,7 @@
 
 import pytest
 
-from pages.firefox.fxos_navigation import FirefoxPage
+from pages.firefox.family_navigation import FirefoxPage
 
 
 @pytest.mark.nondestructive


### PR DESCRIPTION
## Description
FxOS nav functional tests are [failing due to a missing import](https://ci.us-west.moz.works/job/bedrock_integration_tests_runner/4776/console).

## Testing
`py.test --base-url http://localhost:8000 --driver Firefox --html tests/functional/results.html tests/functional/firefox/os/test_fxos_navigation.py`

## Checklist
- [x] Related functional & integration tests passing.

