### PR TITLE
Fix Bug 1262099, update button style for general cta buttons

### DIFF
--- a/bedrock/firefox/templates/firefox/hello/index.html
+++ b/bedrock/firefox/templates/firefox/hello/index.html
@@ -29,8 +29,14 @@
 
 {% block site_header_unwrapped %}
   {% call fxfamilynav('features') %}
-    <a class="try-hello-button" href="https://support.mozilla.org/kb/where-firefox-hello-button">{{ _('Try Hello now') }}</a>
-    <a class="nav-download-button button-flat-dark" href="{{ url('firefox.new') }}">{{ _('Download now') }}</a>
+    <a class="feature-button dark try-hello-button" href="https://support.mozilla.org/kb/where-firefox-hello-button">
+      {% if l10n_has_tag('new_cta_style') %}
+        {{ _('Try It Now') }}
+      {% else %}
+        {{ _('Try Hello now') }}
+      {% endif %}
+    </a>
+    <a class="nav-download-button feature-button dark" href="{{ url('firefox.new') }}">{{ _('Download now') }}</a>
   {% endcall %}
 {% endblock %}
 
@@ -44,7 +50,7 @@
           <h1>{{ _('Plan. Shop. Decide. Together.') }}</h1>
         {% endif %}
         <p class="tagline fx-up-to-date">{{ _('Instantly browse any Web page with a friend.') }}</p>
-        <a class="try-hello-button" href="https://support.mozilla.org/kb/where-firefox-hello-button">{{ _('Try Firefox Hello') }}</a>
+        <a class="feature-button dark try-hello-button" href="https://support.mozilla.org/kb/where-firefox-hello-button">{{ _('Try Firefox Hello') }}</a>
         <img src="{{ static('img/firefox/hello/firefox-hello-logo-white.svg') }}" class="hello-wordmark" alt="Firefox Hello" width="380" data-fallback="true" data-png="{{ static('img/firefox/hello/firefox-hello-logo-white.png') }}">
       </header>
     </div>
@@ -103,7 +109,7 @@
     <div class="container">
       <div class="fx-up-to-date">
         <h2>{{ _('Share this page with a friend.') }}</h2>
-        <a class="try-hello-button" href="https://support.mozilla.org/kb/where-firefox-hello-button">{{ _('Try Hello now') }}</a>
+        <a class="feature-button dark try-hello-button" href="https://support.mozilla.org/kb/where-firefox-hello-button">{{ _('Try Firefox Hello') }}</a>
       </div>
       <h2 class="fx-out-of-date">{{ _('Get the latest version of Firefox to start browsing Web pages with your friends.') }}</h2>
       <h2 class="non-fx">{{ _('Get Firefox to start browsing Web pages with your friends.') }}</h2>

--- a/bedrock/firefox/templates/firefox/os/index.html
+++ b/bedrock/firefox/templates/firefox/os/index.html
@@ -59,7 +59,7 @@
           <h1>{{ _('Experience Firefox OS on your Android device')}}</h1>
           <p>{{_('Introducing Firefox OS 2.5 Developer Preview, an experimental app that lets you use Firefox OS on your Android device.')}}</p>
           <div class="primary-cta">
-            <a href="{{ settings.B2G_DROID_URL }}" class="cta-button" data-pixel="52161" data-id="Mozilla_B2G_Activity_Tag_1">{{_('Get the Android App')}}</a>
+            <a href="{{ settings.B2G_DROID_URL }}" class="cta-button feature-button dark" data-pixel="52161" data-id="Mozilla_B2G_Activity_Tag_1">{{_('Get the Android App')}}</a>
           </div>
         </div>
         <div class="hero-image">
@@ -116,7 +116,7 @@
       <div class="content-wrapper">
         <h2>{{_('Ready to try Firefox OS 2.5 Developer Preview on your Android device?')}}</h2>
         <div class="primary-cta">
-          <a href="{{ settings.B2G_DROID_URL }}" class="cta-button" data-pixel="52162" data-id="Mozilla_B2G_Activity_Tag_2">{{_('Get the Android App')}}</a>
+          <a href="{{ settings.B2G_DROID_URL }}" class="cta-button feature-button" data-pixel="52162" data-id="Mozilla_B2G_Activity_Tag_2">{{_('Get the Android App')}}</a>
           <p>{{_('Want the full Firefox OS 2.5 experience?')}} <a href="https://firefoxos.mozilla.community/devices/" class="more" rel="external">{{_('Flash your phone')}}</a></p>
         </div>
       </div>

--- a/bedrock/firefox/templates/firefox/private-browsing.html
+++ b/bedrock/firefox/templates/firefox/private-browsing.html
@@ -31,7 +31,7 @@
         <h1>{{ _('More protection. <br>The most privacy. <br>Only from Firefox.') }}</h1>
         <div class="download-buttons">
           <div class="firefox-latest-cta">
-            <a class="try-pb-button button-flat-dark" data-highlight="privateWindow" href="https://support.mozilla.org/kb/private-browsing-use-firefox-without-history/">{{ _('Try Private Browsing') }}</a>
+            <a class="try-pb-button feature-button dark" data-highlight="privateWindow" href="https://support.mozilla.org/kb/private-browsing-use-firefox-without-history/">{{ _('Try Private Browsing') }}</a>
           </div>
           <div class="non-firefox-cta">
             <p>{{ _('To give the new Private Browsing a try, download Firefox.') }}</p>
@@ -142,7 +142,7 @@
       <div class="download-buttons">
         <div class="firefox-latest-cta">
           <h2>{{ _('Try it now to stay in control') }}</h2>
-          <a class="try-pb-button button-flat-dark" data-highlight="privateWindow" href="https://support.mozilla.org/kb/private-browsing-use-firefox-without-history/">{{ _('Try Private Browsing') }}</a>
+          <a class="try-pb-button feature-button dark" data-highlight="privateWindow" href="https://support.mozilla.org/kb/private-browsing-use-firefox-without-history/">{{ _('Try Private Browsing') }}</a>
         </div>
         <div class="non-firefox-cta">
           <h2>{{ _('To give the new Private Browsing a try, download Firefox.') }}</h2>

--- a/bedrock/mozorg/templates/mozorg/about/policy/lean-data.html
+++ b/bedrock/mozorg/templates/mozorg/about/policy/lean-data.html
@@ -20,7 +20,7 @@
     <h2 class="title-shadow-box">{{ _('Lean Data Practices') }}</h2>
     <p class="lead-in">{{ _('Staying lean and being smart about how you collect data can build trust with your users and ultimately help grow your business.') }}</p>
 
-    <a href="https://github.com/mozilla/lean-data-practices" class="github-button more" rel="external"  target="_blank">{{ _('Get the toolkit') }}</a>
+    <a href="https://github.com/mozilla/lean-data-practices" class="github-button feature-button" rel="external"  target="_blank">{{ _('Get the toolkit') }}</a>
 
     <section class="why">
       <h3>{{ ('How Lean Data Practices build strong brands') }}</h3>
@@ -72,7 +72,7 @@
     <section class="toolkit">
       <h3>{{ _('Get the toolkit') }}</h3>
       <p>{{ _('We’ve put together a toolkit to help you implement Lean Data Practices at your company.') }}</p>
-      <a href="https://github.com/mozilla/lean-data-practices" class="github-button more" rel="external"  target="_blank">{{ _('Get the toolkit') }}</a>
+      <a href="https://github.com/mozilla/lean-data-practices" class="github-button feature-button" rel="external"  target="_blank">{{ _('Get the toolkit') }}</a>
     </section>
   </main>
 {% endblock %}

--- a/media/css/firefox/hello/index.less
+++ b/media/css/firefox/hello/index.less
@@ -37,69 +37,14 @@ h1, h2, h3, h4, h5, h6 {
     }
 }
 
-.try-hello-button,
-.try-hello-button:link,
-.try-hello-button:visited {
-    .inline-block;
+a.try-hello-button,
+a.try-hello-button:link,
+a.try-hello-button:visited {
     padding: 12px (@baseLine * 2) 12px 85px;
     margin-bottom: @baseLine;
-    .open-sans-light;
-    .font-size(30px);
-    color: #fff;
-    text-align: center;
     .at2x('/media/img/firefox/hello/hello-smiley.png', 40px, 38px);
     background-position: 32px center;
     background-repeat: no-repeat;
-    background-color: #005189;
-    border-radius: 6px;
-    border: none;
-    cursor: pointer;
-    .transition(background-color .1s ease-in-out);
-
-    @media only screen and (max-width: @breakDesktop) {
-        .font-size(26px);
-    }
-
-    @media only screen and (max-width: @breakTablet) {
-        .font-size(24px);
-    }
-
-    @media only screen and (max-width: @breakMobileLandscape) {
-        .font-size(20px);
-    }
-
-    &:hover,
-    &:focus {
-        text-decoration: none;
-        background-color: lighten(#005189, 3%);
-        color: #fff;
-    }
-}
-
-#fxfamilynav-header {
-    .try-hello-button,
-    .nav-download-button {
-        .open-sans;
-        .font-size(@smallFontSize);
-        padding: 12px (@baseLine / 2);
-        background: #005189;
-        margin-bottom: 0;
-        text-transform: none;
-
-        &:hover,
-        &:focus {
-            background: lighten(#005189, 3%);
-        }
-    }
-}
-
-html[lang^='en'] {
-    #fxfamilynav-header {
-        .try-hello-button,
-        .nav-download-button {
-            text-transform: uppercase;
-        }
-    }
 }
 
 /**
@@ -119,7 +64,7 @@ html[lang^='en'] {
 
     .fx-up-to-date,
     .fx-out-of-date,
-    .try-hello-button,
+    a.try-hello-button,
     .mobile {
         display: none;
     }
@@ -156,7 +101,7 @@ html[lang^='en'] {
     .mobile,
     .download-button,
     .hello-wordmark,
-    .nav-download-button,
+    a.nav-download-button,
     #conditional-download-bar {
         display: none;
     }
@@ -164,7 +109,7 @@ html[lang^='en'] {
 
 .firefox-out-of-date {
     .fx-out-of-date,
-    .nav-download-button,
+    a.nav-download-button,
     #conditional-download-bar {
         display: block;
     }
@@ -177,7 +122,7 @@ html[lang^='en'] {
     .fx-up-to-date,
     .non-fx,
     .mobile,
-    .try-hello-button {
+    a.try-hello-button {
         display: none;
     }
 }
@@ -197,7 +142,7 @@ html[lang^='en'] {
     .fx-up-to-date,
     .fx-out-of-date,
     .mobile,
-    .try-hello-button {
+    a.try-hello-button {
         display: none;
     }
 }
@@ -207,8 +152,8 @@ html[lang^='en'] {
     .fx-out-of-date,
     .non-fx,
     .download-button,
-    .nav-download-button,
-    .try-hello-button {
+    a.nav-download-button,
+    a.try-hello-button {
         display: none;
     }
 

--- a/media/css/firefox/os/firefox-os-2-5.less
+++ b/media/css/firefox/os/firefox-os-2-5.less
@@ -67,10 +67,6 @@ section {
         color: #fff;
         text-shadow: none;
     }
-
-    a {
-       .font-size(20px);
-    }
 }
 
 .fxos-hero-space {
@@ -286,10 +282,21 @@ section {
     }
 }
 
+a.feature-button:link,
+a.feature-button:visited {
+    padding-left: 55px;
+}
+
+.fxos-try {
+    a.feature-button {
+        margin-bottom: (@baseLine / 2);
+    }
+}
+
 .cta-button:before {
     position: absolute;
-    top: 15px;
-    left: 22px;
+    top: 13px;
+    left: 15px;
     width: 30px;
     height: 30px;
     content: '';
@@ -298,13 +305,7 @@ section {
     background-repeat: no-repeat;
 }
 
-.fxos-try .cta-button {
-    background-color: #0c99d5;
-    color: #fff;
-}
-
-.newsletter-form .button,
-.cta-button {
+.newsletter-form .button {
     position: relative;
     display: inline-block;
     background-color: #005189;

--- a/media/css/firefox/private_browsing/private-browsing-conditionals.less
+++ b/media/css/firefox/private_browsing/private-browsing-conditionals.less
@@ -127,7 +127,7 @@
 @media only screen and (max-width: @breakDesktop) {
     .cta {
         .firefox-latest-cta h2 {
-            width: 450px;
+            width: 430px;
         }
         .firefox-old-cta h2 {
             width: 430px;

--- a/media/css/firefox/private_browsing/private-browsing.less
+++ b/media/css/firefox/private_browsing/private-browsing.less
@@ -88,13 +88,6 @@ html, body {
     }
 }
 
-.button-flat-dark {
-    .open-sans-light;
-    .font-size(24px);
-    padding: 12px @baseLine;
-    .transition(background-color 250ms linear 0s);
-}
-
 .download-buttons  {
     p {
         color: #fff;
@@ -250,11 +243,11 @@ html, body {
         float: left;
         width: 100%;
 
-        .button-flat-dark {
+        .feature-button {
             max-width: 340px;
         }
 
-        .button-flat-dark,
+        .feature-button,
         .dl-button,
         .desktop-download-button,
         .ios-download-button a {
@@ -319,12 +312,6 @@ html.ios[lang^='es-ES']{
         width: 465px;
     }
 }
-html[lang^='en'] {
-    .button-flat-dark {
-        text-transform: none;
-        margin-bottom: 0;
-    }
-}
 
 @media only screen and (max-width: @breakDesktop) {
     html[lang^='de'],
@@ -352,9 +339,6 @@ html[lang^='en'] {
             width: 350px;
         }
      }
-    .button-flat-dark {
-        .font-size(20px);
-    }
     .container {
         width: @widthTablet;
 
@@ -362,7 +346,7 @@ html[lang^='en'] {
             .font-size(44px);
         }
         h2 {
-            .font-size(38px);
+            .font-size(36px);
             margin-bottom: 25px;
         }
         h3 {
@@ -423,7 +407,7 @@ html[lang^='en'] {
             padding-top: 75px;
             padding-bottom: 75px;
         }
-        .download-buttons .button-flat-dark {
+        .download-buttons .feature-button {
             max-width: 220px;
         }
         h2 {
@@ -454,12 +438,9 @@ html[lang^='en'] {
         }
     }
     html[lang^='pl']{
-        .button-flat-dark {
+        .feature-button {
             .font-size(16px);
         }
-    }
-    .button-flat-dark {
-        .font-size(18px);
     }
     .container {
         width: @widthMobile;
@@ -567,13 +548,13 @@ html[lang^='en'] {
 
         .download-buttons {
             text-align: center;
-            .button-flat-dark,
+            .feature-button,
             .android-download-button a,
             .desktop-download-button,
             .ios-download-button a {
                 float: none;
             }
-            .button-flat-dark {
+            .feature-button {
                 max-width: 100%;
             }
         }
@@ -585,9 +566,6 @@ html[lang^='en'] {
          #tracking-protection-animation .shield-container {
             margin: 0 auto;
         }
-    }
-    .button-flat-dark {
-        .font-size(@largeFontSize);
     }
     .container {
         width: @widthMobile;

--- a/media/css/mozorg/about-lean-data.less
+++ b/media/css/mozorg/about-lean-data.less
@@ -30,6 +30,7 @@ main {
     margin: 0 auto;
     padding: 0px 30px;
     width: 1000px;
+    text-align: center;
 
     @media only screen and (min-width: @breakTablet) and (max-width: @breakDesktop) {
         width: 780px;
@@ -47,6 +48,7 @@ main {
     .title-shadow-box {
         width: 360px;
         min-height: 80px;
+        text-align: left;
 
         @media only screen and (max-width: @breakTablet) {
             .font-size(2rem);
@@ -75,42 +77,15 @@ main {
     }
 }
 
-.github-button {
-    display: block;
-    background-color: #0C99D5;
-    color: #fff;
-    margin: 0 auto;
-    padding: 10px 4px;
-    border: none;
-    border-radius: 6px;
-    width: 250px;
-    .font-size(0.875rem);
-    font-weight: bold;
-    text-transform: uppercase;
-    text-align: center;
-    transition: background-color 0.3s ease 0s;
-
-    &:link,
-    &:visited {
-        color: #fff;
-        text-decoration: none;
-    }
-
-    &:hover,
-    &:focus {
-        background-color: #2165A9;
-    }
-
-    &:before {
-        display: inline-block;
-        content: '';
-        .at2x('/media/img/mozorg/about/lean-data/github-icon.png', 40px, 40px);
-        background-repeat: no-repeat;
-        margin-right: 10px;
-        width: 40px;
-        height: 40px;
-        vertical-align: middle;
-    }
+a.github-button:before {
+    display: inline-block;
+    content: '';
+    .at2x('/media/img/mozorg/about/lean-data/github-icon.png', 40px, 40px);
+    background-repeat: no-repeat;
+    margin-right: 10px;
+    width: 40px;
+    height: 40px;
+    vertical-align: middle;
 }
 
 .box-container {

--- a/media/css/sandstone/buttons-new.less
+++ b/media/css/sandstone/buttons-new.less
@@ -4,19 +4,27 @@
 
 @import "../sandstone/lib.less";
 
-@default: #0095dd;
-@defaultHover: #00afe5;
-@dark: #00539F;
-@darkHover: #0095DD;
-@white: #fff;
-@whiteHover: #f4f4f4;
+@light: #fff;
+@lightHover: #f4f4f4;
+
+@mozGreen: #4caf50;
+@mozGreenHover: #66bb6a;
+@mozGreenBorder: #4aa84a;
+
+@mozBlue: #0095dd;
+@mozBlueHover: #33aae4;
+@mozBlueBorder: #0092cc;
+
+@mozDark: #00539F;
+@mozDarkHover: #0060a8;
+@mozDarkBorder: #005493;
 
 input[type="submit"].button-newsletter,
 .button-newsletter {
 
     background: none;
-    color: @default;
-    border: 2px solid @default;
+    color: @mozBlue;
+    border: 2px solid @mozBlue;
     border-radius: 4px;
     width: 100%;
     min-height: 45px;
@@ -29,8 +37,8 @@ input[type="submit"].button-newsletter,
 
     &:hover,
     &:focus {
-        color: @defaultHover;
-        border-color: @defaultHover;
+        color: @mozBlueHover;
+        border-color: @mozBlueHover;
     }
 
     &:active {
@@ -39,24 +47,90 @@ input[type="submit"].button-newsletter,
     }
 
     &.dark {
-        color: @dark;
-        border-color: @dark;
+        color: @mozDark;
+        border-color: @mozDark;
 
         &:hover,
         &:focus {
-            color: @darkHover;
-            border-color: @darkHover;
+            color: @mozDarkHover;
+            border-color: @mozDarkHover;
         }
     }
 
     &.white {
-        color: @white;
-        border-color: @white;
+        color: @light;
+        border-color: @light;
 
         &:hover,
         &:focus {
-            color: @whiteHover;
-            border-color: @whiteHover;
+            color: @lightHover;
+            border-color: @lightHover;
         }
+    }
+}
+
+.opaque-button {
+    position: relative;
+    .inline-block;
+    padding: (@baseLine / 2) 36px;
+    border: 2px solid @light;
+    border-radius: 4px;
+    .font-size(24px);
+    text-align: center;
+    cursor: pointer;
+    .transition(background-color 250ms linear 0s);
+
+    &:active {
+        position: relative;
+        top: 1px;
+    }
+
+    &:hover,
+    &:focus {
+        text-decoration: none;
+    }
+}
+
+.feature-button,
+a.feature-button:link,
+a.feature-button:visited {
+    .opaque-button;
+    background-color: @mozBlue;
+    color: @light;
+    border: 2px solid @mozBlueBorder;
+
+    @media only screen and (max-width: @breakDesktop) {
+        .font-size(21px);
+    }
+
+    @media only screen and (max-width: @breakMobileLandscape) {
+        .font-size(18px);
+    }
+
+    &:hover,
+    &:focus {
+        background-color: @mozBlueHover;
+        color: @light;
+    }
+
+    &.dark {
+        background-color: @mozDark;
+        color: @light;
+        border: 2px solid @mozDarkBorder;
+
+        &:hover,
+        &:focus {
+            background-color: @mozDarkHover;
+        }
+    }
+}
+
+#fxfamilynav-header {
+    .feature-button,
+    a.feature-button {
+        padding: 12px (@baseLine / 2);
+        background-image: none;
+        margin-bottom: 0;
+        .font-size(14px);
     }
 }


### PR DESCRIPTION
## Description
This changes the CTA button styles on a couple of pages:

/firefox/hello/
/firefox/private-browsing/
/firefox/os/
/about/policy/lean-data/

I did notice that there seems to be a regression on the private browsing  page. At exactly 1000px the hero area layout breaks. At 999px and smaller or 1001px and larger, all id fine. I have not dug into this but, it is currently like this on master.

There may be some l10n changes not sure, but added the flag to ping @flodolo for review.

The color vars are a bit of a mess at the moment but, I am discussing these with Michael and will clean it up in the upcoming download button PR

## Bugzilla
https://bugzilla.mozilla.org/show_bug.cgi?id=1262099

## Testing
I tested the various states of these pages but, I might have missed something so good idea to double check those.

## Checklist
- [x] Requires l10n changes.
- [ ] Related functional & integration tests passing.

