### PR TITLE
Fix Bug 1263193 - www.mozilla.org redirected to zh-CN page in zh-TW Edge and IE 11 on Win 10

### DIFF
--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -159,6 +159,8 @@ CANONICAL_LOCALES = {
     'no': 'nb-NO',
     'pt': 'pt-BR',
     'sv': 'sv-SE',
+    'zh-hant': 'zh-TW',  # Bug 1263193
+    'zh-hant-tw': 'zh-TW',  # Bug 1263193
 }
 
 # Unlocalized pages are usually redirected to the English (en-US) equivalent,

--- a/tests/redirects/map_locales.py
+++ b/tests/redirects/map_locales.py
@@ -20,7 +20,9 @@ LOCALE_VARIANTS = {
     'fr': ['fr-FR'],
     'ja': ['ja-JP-mac'],
     'pt-BR': ['pt'],
-    'ta': ['ta-LK']}
+    'ta': ['ta-LK'],
+    'zh-TW': ['zh-Hant', 'zh-Hant-TW'],  # Bug 1263193
+}
 
 _urls = []
 for locale in LOCALES:


### PR DESCRIPTION
The tests passed, and manual test also works well.