### PR TITLE
fix the rtl css on the sync page

### DIFF
--- a/media/css/firefox/sync.less
+++ b/media/css/firefox/sync.less
@@ -409,6 +409,12 @@ html[dir="rtl"] {
         left: 85px;
         right: auto;
     }
+    .instructions {
+        text-align: right;
+        section {
+            float: right;
+        }
+    }
 }
 
 /* Tablet Layout: 760px */


### PR DESCRIPTION
Currently the Arabic Sync page looks like this:
![before](https://cloud.githubusercontent.com/assets/1019873/14554626/1882c146-02e6-11e6-836a-c76e6229052d.png)

but it should look like this:
![fixed](https://cloud.githubusercontent.com/assets/1019873/14554643/2e35eff4-02e6-11e6-9608-6100322080a0.png)
