### PR TITLE
fix the position of the plus sign in the private browsing page

### DIFF
--- a/media/css/firefox/private_browsing/private-browsing.less
+++ b/media/css/firefox/private_browsing/private-browsing.less
@@ -593,3 +593,21 @@ html[lang^='en'] {
         width: @widthMobile;
     }
 }
+
+/* RTL support */
+html[dir="rtl"] {
+    .private-browsing:after {
+        content:none
+    }
+    .with-tracking:after {
+        color: #6fbf4a;
+        content:'+';
+        .open-sans-extrabold();
+        .font-size(100px);
+        height: 100px;
+        width: 100px;
+        position: absolute;
+        right: -50px;
+        top: 0;
+    }
+}


### PR DESCRIPTION
the plus sign in the RTL pages is not in the right place:
![before](https://cloud.githubusercontent.com/assets/1019873/14556690/58ade5a6-02f1-11e6-8c0c-3819060f338d.png)


and should appear like this:
![fixed](https://cloud.githubusercontent.com/assets/1019873/14556699/648387f0-02f1-11e6-9528-006256145de9.png)
