### PR TITLE
Follow up Bug 1261866 - Update links and redirects to mozilla.jp

### DIFF
--- a/bedrock/mozorg/templates/mozorg/contact/communities/japan.html
+++ b/bedrock/mozorg/templates/mozorg/contact/communities/japan.html
@@ -19,6 +19,7 @@
           <li><a href="https://www.facebook.com/mozillajapan" class="facebook">Facebook</a></li>
           <li><a href="https://www.facebook.com/foxkeh.jp" class="facebook">Facebook (Foxkeh)</a></li>
           <li><a href="https://www.youtube.com/user/MozillaJP" class="youtube">YouTube</a></li>
+          <li><a href="https://www.flickr.com/photos/mozillajp" class="flickr">Flickr</a></li>
         </ul>
 
         <figure class="feature-img">


### PR DESCRIPTION
Forgot to add Flickr :camera: as part of #4032.