### PR TITLE
Bug 669608 - Change link to Creative Commons Attribution Share-Alike v3.0

### DIFF
--- a/bedrock/foundation/templates/foundation/licensing/website-content.html
+++ b/bedrock/foundation/templates/foundation/licensing/website-content.html
@@ -18,16 +18,16 @@
   {% endtrans %}
   </p>
   <p>
-    <a rel="license" href="https://creativecommons.org/licenses/by-sa/3.0/">
+    <a rel="license" href="https://creativecommons.org/licenses/by-sa/3.0/deed.locale">
       <img alt="{{ _('Creative Commons License') }}"src="https://creativecommons.org/images/public/somerights20.gif" />
     </a>
   </p>
   <p>
   {% trans
-    license3='https://creativecommons.org/licenses/by-sa/3.0/',
+    license3='https://creativecommons.org/licenses/by-sa/3.0/deed.locale',
     legalcode='https://creativecommons.org/licenses/by-sa/3.0/legalcode'
   %}
-    A <a href="{{ license3 }}">summary</a> of the terms of this license is available, as well as it’s <a href="{{ legalcode }}">detailed terms</a>.
+    A <a href="{{ license3 }}">summary</a> of the terms of this license is available, as well as its <a href="{{ legalcode }}">detailed terms</a>.
   {% endtrans %}
   </p>
   <p>


### PR DESCRIPTION
This also fixes a typo found in Bug 1202557. No l10n affected.