### PR TITLE
[fix bug 1261017] Issues with Mozilla.Modal in Firefox 47 at small viewports

### DIFF
--- a/media/css/base/mozilla-modal.less
+++ b/media/css/base/mozilla-modal.less
@@ -4,10 +4,6 @@
 
 @import "../sandstone/lib.less";
 
-html.noscroll body {
-    overflow: hidden;
-}
-
 #modal {
     background: #000;
     background: rgba(0, 0, 0, 0.85);
@@ -131,18 +127,6 @@ html[dir="rtl"] {
 }
 
 @media only screen and (max-width: @breakTablet) {
-    html.noscroll {
-        overflow: hidden;
-        height: 100%;
-        body {
-            height: 100%;
-            overflow: hidden;
-        }
-        #modal {
-            position: absolute;
-        }
-    }
-
     #modal .window {
         margin: 0 auto;
 

--- a/media/css/firefox/ios.less
+++ b/media/css/firefox/ios.less
@@ -746,6 +746,19 @@ a.go {
     display: block;
 }
 
+// used for Firefox on iOS Sync instructions overlay
+html.noscroll {
+    overflow: hidden;
+    height: 100%;
+    body {
+        height: 100%;
+        overflow: hidden;
+    }
+    #modal {
+        position: absolute;
+    }
+}
+
 
 
 // Footer

--- a/media/js/base/mozilla-modal.js
+++ b/media/js/base/mozilla-modal.js
@@ -8,7 +8,6 @@ Mozilla.Modal = (function(w, $) {
 
     var open = false;
     var $body = $('body');
-    var $html = $('html');
     var options = {};
     var $d = $(w.document);
     var evtNamespace = 'moz-modal';
@@ -25,12 +24,9 @@ Mozilla.Modal = (function(w, $) {
         title: title to display at the top of the modal
         onCreate: function to fire after modal has been created
         onDestroy: function to fire after modal has been closed
-        allowScroll: boolean - allow/restrict page scrolling when modal is open
     */
     var _createModal = function(origin, content, opts) {
         options = opts;
-
-        var isSmallViewport = $(w).width() < 760;
 
         // Make sure modal is closed (if one exists)
         if (open) {
@@ -52,12 +48,6 @@ Mozilla.Modal = (function(w, $) {
             '    </div>' +
             '  </div>' +
             '</div>');
-
-        if ((options && !options.allowScroll) || isSmallViewport) {
-            $html.addClass('noscroll');
-        } else {
-            $html.removeClass('noscroll');
-        }
 
         // Add modal to page
         $body.append($modal);
@@ -113,9 +103,6 @@ Mozilla.Modal = (function(w, $) {
 
         $contentParent.append($content);
         $('#modal').remove();
-
-        // allow page to scroll again
-        $html.removeClass('noscroll');
 
         // restore focus to element that opened the modal
         $('.modal-origin').focus().removeClass('modal-origin');

--- a/media/js/firefox/installer-help.js
+++ b/media/js/firefox/installer-help.js
@@ -11,9 +11,7 @@
         $('aside.survey').show();
         $('#launch-survey').on('click', function(e) {
             e.preventDefault();
-            Mozilla.Modal.createModal(this, $surveyContent, {
-                allowScroll: false
-            });
+            Mozilla.Modal.createModal(this, $surveyContent);
         });
     }
 

--- a/media/js/firefox/os/devices.js
+++ b/media/js/firefox/os/devices.js
@@ -121,7 +121,6 @@ if (typeof window.Mozilla === 'undefined') {
         e.preventDefault();
 
         Mozilla.Modal.createModal(this, $('#get-device'), {
-            allowScroll: false,
             title: '<img src="/media/img/firefox/os/logo/firefox-os-white.png" alt="mozilla" />'
         });
     });


### PR DESCRIPTION
## Description
- Removes the `noscroll` option that is currently used on smaller viewports from `Mozilla.Modal`, as it causes issues in newer versions of Firefox (see bug link below for STR).

## Bugzilla
https://bugzilla.mozilla.org/show_bug.cgi?id=1261017

## Testing
If memory serves me correctly, I think the `noscroll` option was added as a hack for early versions of Firefox OS due to some viewport bug. But honestly, I'm not quite sure. I think most browsers we care about today should be up to handling `position: fixed;`.

## Checklist
- [ ] Requires l10n changes.
- [ ] Related functional & integration tests passing.