### PR TITLE
fix Bug 1250543 - Broken partner links on /firefox/os/devices/ page

### DIFF
--- a/bedrock/firefox/templates/firefox/os/_get_device.html
+++ b/bedrock/firefox/templates/firefox/os/_get_device.html
@@ -45,7 +45,6 @@
         <div class="provider" data-country="de">
           <h3>{{_('Germany')}}</h3>
           <ul>
-            <li><a class="o2" href="http://www.o2online.de/eshop/handy/alcatel-onetouch-fire-e-anthrazit">Alcatel One Touch Fire E</a></li>
             <li><a class="ebay" href="http://www.ebay.de/itm/eBay-Exklusiv-ZTE-OPEN-C-Neuesten-Firefox-OS-DualCore-1-2-GHz-4-0-3G-Smartphone-/131151681046?ssPageName=STRK:MESE:IT">ZTE Open C</a></li>
           </ul>
         </div>
@@ -66,7 +65,6 @@
             <li><a class="cdiscount" href="http://www.cdiscount.com/telephonie/telephone-mobile/zte-open-c-bleu/f-144040207-zteopencbl.html">Cdiscount</a></li>
             <li><a class="rue-du-commerce" href="http://www.rueducommerce.fr/Telephonie/Smartphone/Smartphone-classique/ZTE/4926226-Open-C-bleu.htm">Rue du commerce</a></li>
             <li><a class="webdistrib" href="http://www.webdistrib.com/cat/Smartphone-ZTE-Open-C-Night-Blue-Firefox-OS-__p_925735.html">Webdistrib</a></li>
-            <li><a class="mistergooddeal" href="http://www.mistergooddeal.com/telephone-mobile/telephone/zte-open-c-bleu.htm">Mistergooddeal</a></li>
             <li><a class="topachat" href="http://www.topachat.com/pages/detail2_cat_est_telephonie_puis_rubrique_est_wt_smartp_puis_ref_est_tl10012764.html">Top Achat</a></li>
           </ul>
         </div>
@@ -80,12 +78,6 @@
           <h3>{{ _('Guatemala') }}</h3>
           <ul>
             <li><a class="movistar" href="http://www.movistar.com.gt/tienda_gt/Open-Catalog/Productos/Celulares/Smartphone/ZTE-Open-II/p/ZTE-Open-2">ZTE Open II</a></li>
-          </ul>
-        </div>
-        <div class="provider" data-country="hu">
-          <h3>{{_('Hungary')}}</h3>
-          <ul>
-            <li><a class="t-mobile" href="https://www.telekom.hu/shop/termek/ALCATEL+onetouch+Fire+E+6015--ALCOTFIREE6015SLSLT?contractType=newPostpaid&amp;commitmentPeriod=12&amp;preselectedTariffplanId=prod3220038">Alcatel One Touch Fire E</a></li>
           </ul>
         </div>
         <div class="provider" data-country="in">
@@ -158,12 +150,6 @@
           <h3>{{ _('Romania') }}</h3>
           <ul>
             <li><a class="orange" href="https://www.orange.ro/magazin-online/telefoane/orange-klif">Orange</a></li>
-          </ul>
-        </div>
-        <div class="provider" data-country="rs">
-          <h3>{{_('Serbia')}}</h3>
-          <ul>
-            <li><a class="telenor" href="https://www.telenor.rs/sr/Privatni-korisnici/webshop/Mobilni-telefoni/Alcatel/One_Touch_Fire">Telenor</a></li>
           </ul>
         </div>
         <div class="provider" data-country="ru">

--- a/bedrock/firefox/templates/firefox/os/devices.html
+++ b/bedrock/firefox/templates/firefox/os/devices.html
@@ -75,7 +75,6 @@
               <option value="de">{{ _('Germany') }}</option>
               <option value="gr">{{ _('Greece') }}</option>
               <option value="gt">{{ _('Guatemala') }}</option>
-              <option value="hu">{{ _('Hungary') }}</option>
               <option value="in">{{ _('India') }}</option>
               <option value="ci">{{ _('Ivory Coast') }}</option>
               <option value="jp">{{ _('Japan') }}</option>
@@ -90,7 +89,6 @@
               <option value="ro">{{ _('Romania') }}</option>
               <option value="ru">{{ _('Russia') }}</option>
               <option value="sn">{{ _('Senegal') }}</option>
-              <option value="rs">{{ _('Serbia') }}</option>
               <option value="tn">{{ _('Tunisia') }}</option>
               <option value="uy">{{ _('Uruguay') }}</option>
             </select>
@@ -206,7 +204,6 @@
                     <li>{{ _('Chile') }}</li>
                     <li>{{ _('Colombia') }}</li>
                     <li>{{ _('Mexico') }}</li>
-                    <li>{{ _('Serbia') }}</li>
                   </ul>
 
                   <h5>{{ _('Operators') }}</h5>
@@ -957,7 +954,6 @@
                   <h5>{{ _('Available in') }}</h5>
 
                   <ul class="comma-list">
-                    <li>{{ _('France') }}</li>
                     <li>{{ _('Germany') }}</li>
                     <li>{{ _('Luxembourg') }}</li>
                     <li>{{ _('Uruguay') }}</li>
@@ -1226,15 +1222,12 @@
 
                   <ul class="comma-list">
                     <li>{{ _('Czech Republic') }}</li>
-                    <li>{{ _('Germany') }}</li>
-                    <li>{{ _('Hungary') }}</li>
                     <li>{{ _('Russia') }}</li>
                   </ul>
 
                   <h5>{{ _('Operators') }}</h5>
                   <ul class="comma-list">
                     <li>{{ _('MegaFon') }}</li>
-                    <li>{{ _('O2') }}</li>
                     <li>{{ _('T-Mobile') }}</li>
                   </ul>
                 </div>

--- a/media/js/firefox/os/partner_data.js
+++ b/media/js/firefox/os/partner_data.js
@@ -30,7 +30,7 @@ if (typeof Mozilla === 'undefined') {
         'alcatel_onetouchfire': {
             'type': 'smartphone',
             'display': 'Alcatel One Touch Fire',
-            'countries': ['cl', 'co', 'mx', 'rs']
+            'countries': ['cl', 'co', 'mx']
         },
         'alcatel_onetouchfirec': {
             'type': 'smartphone',
@@ -45,7 +45,7 @@ if (typeof Mozilla === 'undefined') {
         'alcatel_onetouchfiree': {
             'type': 'smartphone',
             'display': 'Alcatel One Touch Fire E',
-            'countries': ['cz', 'de', 'hu', 'ru']
+            'countries': ['cz', 'ru']
         },
         'au_fx0': {
             'type': 'smartphone',
@@ -105,7 +105,7 @@ if (typeof Mozilla === 'undefined') {
         'zte_openc': {
             'type': 'smartphone',
             'display': 'ZTE Open C',
-            'countries': ['de', 'fr', 'lu', 'uy']
+            'countries': ['de', 'lu', 'uy']
         },
         'zte_openc2': {
             'type': 'smartphone',


### PR DESCRIPTION
**summary**
Removed links and data for unavailable phones.

- [x]  Alcatel One Touch Fire E no longer available in hungary.
- [x]  Alcatel One Touch Fire no longer available in Serbia.
- [x]  Alcatel One Touch Fire E no longer available via O2 in Germany
- [x] ZTE Open C also need to be removed from availability in France
- [x] One Touch Fire E should be no longer available in Germany