### PR TITLE
Add supervisor to Procfile for bug 1266665

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,3 @@
 web: ./docker/run-prod.sh
 clock: ./bin/cron.py
+supervisor: ./docker/run-supervisor.sh


### PR DESCRIPTION
The dev deployments are currently running the `web` process type. After merging we can scale the web workers down and supervisor workers up. The demo environments are already running supervisor via the Dockerfile `CMD`.

@pmclanahan r?