### PR TITLE
Fix Bug 1245567 - Remove Firefox for Android 2.3 Gingerbread from www.mozilla.org

### DIFF
--- a/bedrock/firefox/firefox_details.py
+++ b/bedrock/firefox/firefox_details.py
@@ -309,9 +309,16 @@ class FirefoxAndroid(_ProductDetails):
 
     def platforms(self, channel='release'):
         platforms = self.platform_labels.copy()
+        major_version = int(self.latest_version(channel).split('.', 1)[0])
+
+        # Android Gingerbread (2.3) is no longer supported as of Firefox 48
+        if major_version >= 48:
+            platforms['android'] = _('ARM devices\n(Android 4.0.3+)')
+            platforms['android-x86'] = _('Intel devices\n(Android 4.0.3+ x86 CPU)')
+            del platforms['android-api-9']
 
         # Android Honeycomb (3.x) was supported on Firefox 45 and below
-        if int(self.latest_version(channel).split('.', 1)[0]) < 46:
+        if major_version <= 45:
             platforms['android'] = _('Modern devices\n(Android 3.0+)')
 
         return platforms.items()

--- a/bedrock/firefox/helpers.py
+++ b/bedrock/firefox/helpers.py
@@ -21,7 +21,13 @@ def android_builds(channel, builds=None):
     ])
 
     if channel == 'alpha':
+        version = int(firefox_android.latest_version('alpha').split('.', 1)[0])
+
         for type, arch_pretty in variations.iteritems():
+            # Android Gingerbread (2.3) is no longer supported as of Firefox 48
+            if version >= 48 and type == 'api-9':
+                continue
+
             link = firefox_android.get_download_url('alpha', type)
             builds.append({'os': 'android',
                            'os_pretty': 'Android',

--- a/bedrock/firefox/tests/test_firefox_details.py
+++ b/bedrock/firefox/tests/test_firefox_details.py
@@ -321,6 +321,18 @@ class TestFirefoxAndroid(TestCase):
         """latest_version should return the latest beta version."""
         eq_(firefox_android.latest_version('beta'), '23.0')
 
+    @patch.object(firefox_android, 'latest_version', Mock(return_value='48.0a2'))
+    def test_latest_alpha_platforms(self):
+        """Android Gingerbread (2.3) is no longer supported as of Firefox 48"""
+        platforms = [key for (key, value) in firefox_android.platforms('alpha')]
+        eq_(platforms, ['android', 'android-x86'])
+
+    @patch.object(firefox_android, 'latest_version', Mock(return_value='47.0a2'))
+    def test_legacy_alpha_platforms(self):
+        """Android Gingerbread (2.3) is supported as of Firefox 47"""
+        platforms = [key for (key, value) in firefox_android.platforms('alpha')]
+        eq_(platforms, ['android', 'android-api-9', 'android-x86'])
+
 
 @override_settings(FIREFOX_IOS_RELEASE_VERSION='1.4')
 class TestFirefoxIos(TestCase):


### PR DESCRIPTION
This is due this Friday, April 29.