### PR TITLE
[fix bug 1261482] Update pin it copy for OS X.

### DIFF
--- a/bedrock/firefox/templates/firefox/onboarding/user-actions-pinsearch.html
+++ b/bedrock/firefox/templates/firefox/onboarding/user-actions-pinsearch.html
@@ -25,7 +25,7 @@
 
       {# OS X specific instructions #}
       <ul class="instructions pinit-mac">
-        <li>{{ _('Click and hold the Firefox icon below') }}</li>
+        <li>{{ _('Click and hold the Firefox icon in your Dock') }}</li>
         <li>{{ _('Drag it to where you want to keep it') }}</li>
       </ul>
     </li>


### PR DESCRIPTION
## Description
Simple copy change proposed by @alexgibson in #4076 and approved by Matej in [the copy bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1259543#c3).

## Bugzilla
[bug 1261482](https://bugzilla.mozilla.org/show_bug.cgi?id=1259543#c3)


