### PR TITLE
[bug 1266553] Add core dataLayer object and page ID data attributes

### DIFF
--- a/bedrock/base/templates/404.html
+++ b/bedrock/base/templates/404.html
@@ -5,6 +5,8 @@
 
 {% extends "base-resp.html" %}
 
+{% block gtm_page_id %}data-gtm-page-id="404"{% endblock %}
+
 {% block page_title %}{{ _('404: Page Not Found') }}{% endblock %}
 
 {% block extrahead %}

--- a/bedrock/base/templates/base-resp.html
+++ b/bedrock/base/templates/base-resp.html
@@ -3,7 +3,7 @@
 <!doctype html>
 {# Note the "windows" class, without javascript platform-specific
      assets default to windows #}
-<html class="windows x86 no-js" lang="{{ LANG|replace('en-US', 'en') }}" dir="{{ DIR }}" data-latest-firefox="{{ latest_firefox_version }}" data-esr-versions="{{ esr_firefox_versions|join(' ') }}">
+<html class="windows x86 no-js" lang="{{ LANG|replace('en-US', 'en') }}" dir="{{ DIR }}" data-latest-firefox="{{ latest_firefox_version }}" data-esr-versions="{{ esr_firefox_versions|join(' ') }}" {% block gtm_page_id %}{% endblock %}>
   <head>
     <meta charset="utf-8">{# Note: Must be within first 512 bytes of page #}
 

--- a/bedrock/base/templates/base.html
+++ b/bedrock/base/templates/base.html
@@ -3,7 +3,7 @@
 <!doctype html>
 {# Note the "windows" class, without javascript platform-specific
      assets default to windows #}
-<html class="windows x86 no-js" lang="{{ LANG|replace('en-US', 'en') }}" dir="{{ DIR }}" data-latest-firefox="{{ latest_firefox_version }}" data-esr-versions="{{ esr_firefox_versions|join(' ') }}">
+<html class="windows x86 no-js" lang="{{ LANG|replace('en-US', 'en') }}" dir="{{ DIR }}" data-latest-firefox="{{ latest_firefox_version }}" data-esr-versions="{{ esr_firefox_versions|join(' ') }}" {% block gtm_page_id %}{% endblock %}>
   <head>
     <meta charset="utf-8">{# Note: Must be within first 512 bytes of page #}
 

--- a/bedrock/firefox/templates/firefox/australis/fx36/tour.html
+++ b/bedrock/firefox/templates/firefox/australis/fx36/tour.html
@@ -6,6 +6,8 @@
 
 {% set_lang_files "firefox/australis/fx36_tour" %}
 
+{% block gtm_page_id %}data-gtm-page-id="/firefox/tour/"{% endblock %}
+
 {% block extra_meta %}<meta name="robots" content="noindex">{% endblock %}
 
 {#- This will appear as <meta property="og:title"> which can be used for social share -#}

--- a/bedrock/firefox/templates/firefox/australis/fx38_0_5/firstrun.html
+++ b/bedrock/firefox/templates/firefox/australis/fx38_0_5/firstrun.html
@@ -6,6 +6,8 @@
 
 {% extends "firefox/base.html" %}
 
+{% block gtm_page_id %}data-gtm-page-id="/firefox/firstrun/"{% endblock %}
+
 {% block extra_meta %}<meta name="robots" content="noindex">{% endblock %}
 
 {#- This will appear as <meta property="og:title"> which can be used for social share -#}

--- a/bedrock/firefox/templates/firefox/dev-firstrun.html
+++ b/bedrock/firefox/templates/firefox/dev-firstrun.html
@@ -6,6 +6,8 @@
 
 {% extends "/firefox/base-resp.html" %}
 
+{% block gtm_page_id %}data-gtm-page-id="/firefox/dev-firstrun/"{% endblock %}
+
 {% block extra_meta %}<meta name="robots" content="noindex">{% endblock %}
 
 {% block page_css %}

--- a/bedrock/firefox/templates/firefox/dev-whatsnew.html
+++ b/bedrock/firefox/templates/firefox/dev-whatsnew.html
@@ -6,6 +6,8 @@
 
 {% extends "/firefox/base-resp.html" %}
 
+{% block gtm_page_id %}data-gtm-page-id="/firefox/dev-whatsnew/"{% endblock %}
+
 {% block extra_meta %}<meta name="robots" content="noindex">{% endblock %}
 
 {% block page_css %}

--- a/bedrock/firefox/templates/firefox/firstrun/firstrun.html
+++ b/bedrock/firefox/templates/firefox/firstrun/firstrun.html
@@ -6,6 +6,14 @@
 
 {% extends "firefox/base.html" %}
 
+{% block gtm_page_id %}
+  {% if 'secondrun' in request.path %}
+    data-gtm-page-id="/firefox/secondrun/"
+  {% else %}
+    data-gtm-page-id="/firefox/firstrun/"
+  {% endif %}
+{% endblock %}
+
 {% block extra_meta %}<meta name="robots" content="noindex">{% endblock %}
 
 {#- This will appear as <meta property="og:title"> which can be used for social share -#}

--- a/bedrock/firefox/templates/firefox/firstrun/learnmore/learnmore.html
+++ b/bedrock/firefox/templates/firefox/firstrun/learnmore/learnmore.html
@@ -4,6 +4,8 @@
 
 {% extends "firefox/whatsnew_42/base.html" %}
 
+{% block gtm_page_id %}data-gtm-page-id="/firefox/firstrun/learnmore/"{% endblock %}
+
 {% add_lang_files "firefox/whatsnew_42" %}
 
 {% block body_class %}firefox-up-to-date{% endblock %}

--- a/bedrock/firefox/templates/firefox/firstrun/learnmore/yahoo-search.html
+++ b/bedrock/firefox/templates/firefox/firstrun/learnmore/yahoo-search.html
@@ -4,6 +4,8 @@
 
 {% extends "firefox/base-resp.html" %}
 
+{% block gtm_page_id %}data-gtm-page-id="/firefox/firstrun/learnmore/"{% endblock %}
+
 {% block extra_meta %}<meta name="robots" content="noindex">{% endblock %}
 
 {#- This will appear as <meta property="og:title"> which can be used for social share -#}

--- a/bedrock/firefox/templates/firefox/onboarding/onboarding-base.html
+++ b/bedrock/firefox/templates/firefox/onboarding/onboarding-base.html
@@ -4,6 +4,14 @@
 
 {% extends "firefox/base-resp.html" %}
 
+{% block gtm_page_id %}
+  {% if 'secondrun' in request.path %}
+    data-gtm-page-id="/firefox/secondrun/"
+  {% else %}
+    data-gtm-page-id="/firefox/firstrun/"
+  {% endif %}
+{% endblock %}
+
 {% block extra_meta %}<meta name="robots" content="noindex">{% endblock %}
 
 {#- This will appear as <meta property="og:title"> which can be used for social share -#}

--- a/bedrock/firefox/templates/firefox/releases/aurora-notes.html
+++ b/bedrock/firefox/templates/firefox/releases/aurora-notes.html
@@ -4,6 +4,8 @@
 
 {% extends "firefox/releases/release-notes.html" %}
 
+{% block gtm_page_id %}data-gtm-page-id="/firefox/android/auroranotes/"{% endblock %}
+
 {% block page_css %}
   {% stylesheet 'firefox_releasenotes_firefox' %}
 {% endblock %}

--- a/bedrock/firefox/templates/firefox/releases/beta-notes.html
+++ b/bedrock/firefox/templates/firefox/releases/beta-notes.html
@@ -4,6 +4,14 @@
 
 {% extends "firefox/releases/release-notes.html" %}
 
+{% block gtm_page_id %}
+    {% if release.product == 'Firefox for Android' %}
+        data-gtm-page-id="/firefox/android/beta/releasenotes/"
+    {% else %}
+        data-gtm-page-id="/firefox/beta/releasenotes/"
+    {% endif %}
+{% endblock %}
+
 {% set channel_name = 'Beta' %}
 
 {% block platform_switch %}

--- a/bedrock/firefox/templates/firefox/releases/dev-browser-notes.html
+++ b/bedrock/firefox/templates/firefox/releases/dev-browser-notes.html
@@ -1,5 +1,7 @@
 {% extends "firefox/releases/aurora-notes.html" %}
 
+{% block gtm_page_id %}data-gtm-page-id="/firefox/auroranotes/"{% endblock %}
+
 {% block site_header_logo %}
   <h2>{{ high_res_img('firefox/developer/title-inverse.png', {'alt': _('Firefox Developer Edition'), 'width': '220', 'height': '84'}) }}</h2>
 {% endblock %}

--- a/bedrock/firefox/templates/firefox/releases/esr-notes.html
+++ b/bedrock/firefox/templates/firefox/releases/esr-notes.html
@@ -3,3 +3,5 @@
  # file, You can obtain one at http://mozilla.org/MPL/2.0/. #}
 
 {% extends "firefox/releases/release-notes.html" %}
+
+{% block gtm_page_id %}data-gtm-page-id="/firefox/esr/releasenotes/"{% endblock %}

--- a/bedrock/firefox/templates/firefox/releases/release-notes.html
+++ b/bedrock/firefox/templates/firefox/releases/release-notes.html
@@ -4,6 +4,16 @@
 
 {% extends "firefox/base-resp.html" %}
 
+{% block gtm_page_id %}
+    {% if release.product == 'Firefox for Android' %}
+        data-gtm-page-id="/firefox/android/releasenotes/"
+    {% elif release.product == 'Firefox for iOS' %}
+        data-gtm-page-id="/firefox/ios/releasenotes/"
+    {% else %}
+        data-gtm-page-id="/firefox/releasenotes/"
+    {% endif %}
+{% endblock %}
+
 {% block page_title_prefix %}{% endblock %}
 {% block page_title %}{{ _('{product} — {channel} Notes ({version})')|f(product=release.product, channel=channel_name, version=release.version) }}{% endblock %}
 

--- a/bedrock/firefox/templates/firefox/releases/system_requirements.html
+++ b/bedrock/firefox/templates/firefox/releases/system_requirements.html
@@ -4,6 +4,8 @@
 
 {% extends "firefox/base-resp.html" %}
 
+{% block gtm_page_id %}data-gtm-page-id="/firefox/system-requirements/"{% endblock %}
+
 {% block page_title_prefix %}{% endblock %}
 {% block page_title %}{{ _('Firefox — {version} System Requirements')|f(version=version) }}{% endblock %}
 

--- a/bedrock/firefox/templates/firefox/whatsnew_38/whatsnew-base.html
+++ b/bedrock/firefox/templates/firefox/whatsnew_38/whatsnew-base.html
@@ -6,6 +6,8 @@
 
 {% add_lang_files "firefox/whatsnew_38" %}
 
+{% block gtm_page_id %}data-gtm-page-id="/firefox/whatsnew/"{% endblock %}
+
 {% block extra_meta %}<meta name="robots" content="noindex">{% endblock %}
 
 {#- This will appear as <meta property="og:title"> which can be used for social share -#}

--- a/bedrock/firefox/templates/firefox/whatsnew_42/base.html
+++ b/bedrock/firefox/templates/firefox/whatsnew_42/base.html
@@ -6,6 +6,8 @@
 
 {% add_lang_files "firefox/whatsnew_42" %}
 
+{% block gtm_page_id %}data-gtm-page-id="/firefox/whatsnew/"{% endblock %}
+
 {% block extra_meta %}<meta name="robots" content="noindex">{% endblock %}
 
 {#- This will appear as <meta property="og:title"> which can be used for social share -#}

--- a/bedrock/mozorg/templates/mozorg/home/home.html
+++ b/bedrock/mozorg/templates/mozorg/home/home.html
@@ -6,6 +6,8 @@
 
 {% add_lang_files "mozorg/home/index" %}
 
+{% block gtm_page_id %}data-gtm-page-id="Homepage"{% endblock %}
+
 {% block page_image %}{{ static('img/home/page-image.png') }}{% endblock %}
 
 {% block page_title %}

--- a/bedrock/newsletter/templates/newsletter/confirm.html
+++ b/bedrock/newsletter/templates/newsletter/confirm.html
@@ -2,6 +2,8 @@
 
 {% set_lang_files "mozorg/newsletters" %}
 
+{% block gtm_page_id %}data-gtm-page-id="/newsletter/confirm/"{% endblock %}
+
 {% block extra_meta %}<meta name="robots" content="noindex">{% endblock %}
 
 {% block body_id %}newsletter-confirm{% endblock body_id %}

--- a/bedrock/newsletter/templates/newsletter/existing.html
+++ b/bedrock/newsletter/templates/newsletter/existing.html
@@ -4,6 +4,8 @@
 
 {# Template used for a user to manage their subscriptions #}
 
+{% block gtm_page_id %}data-gtm-page-id="/newsletter/existing/"{% endblock %}
+
 {% block extra_meta %}<meta name="robots" content="noindex">{% endblock %}
 
 {% block body_id %}newsletter-existing{% endblock body_id %}

--- a/bedrock/settings/static_media.py
+++ b/bedrock/settings/static_media.py
@@ -961,6 +961,8 @@ PIPELINE_JS = {
             'js/base/mozilla-client.js',
             'js/base/mozilla-image-helper.js',
             'js/base/nav-main-resp.js',
+            'js/base/core-datalayer.js',
+            'js/base/core-datalayer-init.js',
         ),
         'output_filename': 'js/common-bundle.js',
     },

--- a/bedrock/thunderbird/templates/thunderbird/releases/beta-notes.html
+++ b/bedrock/thunderbird/templates/thunderbird/releases/beta-notes.html
@@ -4,4 +4,6 @@
 
 {% extends "thunderbird/releases/release-notes.html" %}
 
+{% block gtm_page_id %}data-gtm-page-id="/thunderbird/beta/releasenotes/"{% endblock %}
+
 {% set channel_name = 'Beta' %}

--- a/bedrock/thunderbird/templates/thunderbird/releases/index.html
+++ b/bedrock/thunderbird/templates/thunderbird/releases/index.html
@@ -4,6 +4,8 @@
 
 {% extends "thunderbird/base-resp.html" %}
 
+{% block gtm_page_id %}data-gtm-page-id="/thunderbird/releases/"{% endblock %}
+
 {% block page_title %}{{ _('Mozilla Thunderbird Release Notes') }}{% endblock %}
 {% block page_desc %}{{ _('Release notes for each version of Thunderbird.') }}{% endblock %}
 {% block body_id %}thunderbird-releases-index{% endblock %}

--- a/bedrock/thunderbird/templates/thunderbird/releases/release-notes.html
+++ b/bedrock/thunderbird/templates/thunderbird/releases/release-notes.html
@@ -4,6 +4,8 @@
 
 {% extends "thunderbird/base-resp.html" %}
 
+{% block gtm_page_id %}data-gtm-page-id="/thunderbird/releasenotes/"{% endblock %}
+
 {% block page_title_prefix %}{% endblock %}
 {% block page_title %}{{ _('Thunderbird — {channel} Notes ({version})')|f(channel=channel_name, version=release.version) }}{% endblock %}
 

--- a/bedrock/thunderbird/templates/thunderbird/releases/system_requirements.html
+++ b/bedrock/thunderbird/templates/thunderbird/releases/system_requirements.html
@@ -4,6 +4,8 @@
 
 {% extends "thunderbird/base-resp.html" %}
 
+{% block gtm_page_id %}data-gtm-page-id="/thunderbird/system-requirements/"{% endblock %}
+
 {% block page_title_prefix %}{% endblock %}
 {% block page_title %}{{ _('Thunderbird — {version} System Requirements')|f(version=version) }}{% endblock %}
 

--- a/media/js/base/core-datalayer-init.js
+++ b/media/js/base/core-datalayer-init.js
@@ -1,0 +1,15 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// init core dataLayer object and push into dataLayer
+$(function() {
+    if (Mozilla && Mozilla.Analytics) {
+        var dataLayer = window.dataLayer = window.dataLayer || [];
+
+        dataLayer.push({
+            'event': 'core-datalayer-loaded',
+            'pageId': Mozilla.Analytics.getPageId()
+        });
+    }
+});

--- a/media/js/base/core-datalayer.js
+++ b/media/js/base/core-datalayer.js
@@ -1,0 +1,31 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// create namespace
+if (typeof Mozilla == 'undefined') {
+    var Mozilla = {};
+}
+
+/**
+* Utility class for core dataLayer object to track contextual user and page data
+*/
+
+(function() {
+    var Analytics = {};
+
+    /** Returns page ID used in Event Category for GA events tracked on page.
+    * @param {String} path - URL path name fallback if page ID does not exist.
+    * @return {String} GTM page ID.
+    */
+    Analytics.getPageId = function(path) {
+        var pageId = $('html').attr('data-gtm-page-id');
+        var pathName = path ? path : document.location.pathname;
+
+        return pageId ? pageId : pathName.replace(/\/[^\/]*/, '');
+    };
+
+    Mozilla.Analytics = Analytics;
+
+})();
+

--- a/tests/unit/karma.conf.js
+++ b/tests/unit/karma.conf.js
@@ -39,6 +39,7 @@ module.exports = function(config) {
             'media/js/plugincheck/lib/version-compare.js',
             'media/js/plugincheck/lib/plugincheck.js',
             'media/js/base/send-to-device.js',
+            'media/js/base/core-datalayer.js',
             'tests/unit/spec/base/site.js',
             'tests/unit/spec/base/global.js',
             'tests/unit/spec/base/dnt-helper.js',
@@ -60,6 +61,7 @@ module.exports = function(config) {
             'tests/unit/spec/plugincheck/lib/version-compare.js',
             'tests/unit/spec/plugincheck/lib/plugincheck.js',
             'tests/unit/spec/base/send-to-device.js',
+            'tests/unit/spec/base/core-datalayer.js',
             {
                 pattern: 'node_modules/sinon/pkg/sinon.js',
                 watched: false,

--- a/tests/unit/spec/base/core-datalayer.js
+++ b/tests/unit/spec/base/core-datalayer.js
@@ -1,0 +1,30 @@
+/* For reference read the Jasmine and Sinon docs
+ * Jasmine docs: http://pivotal.github.io/jasmine/
+ * Sinon docs: http://sinonjs.org/docs/
+ */
+
+/* global describe, beforeEach, afterEach, it, expect */
+
+describe('core-datalayer.js', function() {
+
+    describe('PageId', function(){
+        var html = document.documentElement;
+
+        afterEach(function() {
+            html.removeAttribute('data-gtm-page-id');
+        });
+
+        it('will grab data-gtm-page-id value if present on <html> element', function(){
+            html.setAttribute('data-gtm-page-id', 'test');
+
+            expect(Mozilla.Analytics.getPageId('/en-US/firefox/new/')).toBe('test');
+        });
+
+        it('will grab the pathname minus the first directory if no data-gtm-page-id value is present on <html> element', function(){
+            expect(Mozilla.Analytics.getPageId('/en-US/firefox/new/')).toBe('/firefox/new/');
+        });
+    });
+
+});
+
+


### PR DESCRIPTION
bug 1266553 - https://bugzilla.mozilla.org/show_bug.cgi?id=1266553

-Updated those pages discussed with the data-gtm-page-id attribute.
-Added the core-datalayer.js file to house the library that will be built out for the core dataLayer object.
-Added Jasmine test for core-datalayer.js.