### PR TITLE
[fix bug 1266481]  Add a maintenance message when email pref center is unavailable

### DIFF
--- a/bedrock/newsletter/templates/newsletter/existing.html
+++ b/bedrock/newsletter/templates/newsletter/existing.html
@@ -14,14 +14,23 @@
   {% block main_feature %}
     <div id="main-feature">
       <h1>{{ _('Manage your Email Preferences') }}</h1>
+
+    {% if waffle.switch('newsletter-maintenance-mode') %}
+      <p class="billboard">
+        {{ _('This page is in maintenance mode and is temporarily unavailable.') }}<br>
+        {{ _('To update your email preferences, please check back in a little while. Thanks!') }}
+      </p>
+    {% else %}
       <p>
         {{ _('We love sharing updates about all the awesome things happening at Mozilla.') }}<br>
         {{ _('Set your preferences below to make sure you always receive the news you want.') }}
       </p>
+    {% endif %}
+
     </div>
   {% endblock %}
 
-  {% if formset %}
+  {% if formset and not waffle.switch('newsletter-maintenance-mode') %}
     <form method="post" action="{{ secure_url() }}" id="existing-newsletter-form" class="container billboard"
         data-initial-newsletters='{{ newsletters_subscribed }}'>
       {{ formset.management_form }}


### PR DESCRIPTION
## Description
Hides the form and adds a short maintenance message behind the waffle switch `newsletter-maintenance-mode`

@flodolo These are new strings so it may be better to put them in an l10n tag, but we don't have any useful fallback content to show if they aren't localized so maybe showing English is better than nothing? But I believe the plan is to get good locale coverage before we merge this. Let me know if a tag is preferable.

## Bugzilla
https://bugzilla.mozilla.org/show_bug.cgi?id=1266481

## Checklist
- [ ] Requires l10n changes.
- [ ] Related functional & integration tests passing. 