### PR TITLE
Simplify GitHub pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,23 +1,8 @@
-### Guidelines
-Before you submit a pull request, please make sure you have done the following:
-
-- [ ] Review the guidelines for contributing to this repository (link above in GitHub ^).
-- [ ] All commit messages should be well written, and reference a Bugzilla bug number where applicable.
-
-Note: If you're unsure about anything here or below, don't worry! Just fill out as much
-information as you can.
-
 ## Description
-Please explain the changes you're making, complete with a description of the issue and
-a summary of the proposed solution.
 
-## Bugzilla
-Include a direct link to the associated bug on Bugzilla.
+## Bugzilla link
 
 ## Testing
-Please leave some directions for the reviewer on how to test your pull request. List which
-pages need attention, and what the reviewer should pay close attention to. If the change
-requires testing in any specific browsers or platforms, please provide a list.
 
 ## Checklist
 - [ ] Requires l10n changes.


### PR DESCRIPTION
As mulled over on IRC yesterday:

- Removes guidelines section (people don't read/use it).
- Leaves just the headings for our own use.
- Leaves the checklist for tests/l10n changes.

