### PR TITLE
[fix bug 1271702] Add Optimizely snippet to new /new pages.

### DIFF
--- a/bedrock/firefox/templates/firefox/new/redesign/base.html
+++ b/bedrock/firefox/templates/firefox/new/redesign/base.html
@@ -25,6 +25,12 @@
   {{ static('img/firefox/firefox-independent-1200.jpg') }}
 {% endblock %}
 
+{% block optimizely %}
+  {% if waffle.switch('firefox-new-optimizely') %}
+    {% include 'includes/optimizely.html' %}
+  {% endif %}
+{% endblock %}
+
 {% block body_id %}{% endblock %}
 {% block body_class %}{% endblock %}
 


### PR DESCRIPTION
## Description

Just get the ol' Optimizely up on them thar fancy, city-slicker /new pages. I reckon it should be a quick review.

## Bugzilla link

[bug 1271702](https://bugzilla.mozilla.org/show_bug.cgi?id=1271702)


