### PR TITLE
Fix Bug 1272030, stumbler task now shows thank you message

### DIFF
--- a/bedrock/mozorg/templates/mozorg/contribute/tasks/stumbler.html
+++ b/bedrock/mozorg/templates/mozorg/contribute/tasks/stumbler.html
@@ -21,7 +21,7 @@
       <div class="step-content">
         {{ high_res_img('contribute/signup/stumbler.png', {'alt': '', 'width': '620', 'class': 'feature-img'}) }}
         <a rel="external" class="stumbler-button" href="{{ settings.GOOGLE_PLAY_FIREFOX_LINK }}" target="_blank" data-action="install" data-task="stumbler" data-step="one" data-complete="true">
-          {{ high_res_img('firefox/android/btn-google-play.png', {'alt': _('Get it on Google Play'), 'width': '152', 'height': '45', 'l10n': True}) }}
+          {{ high_res_img('firefox/android/btn-google-play.png', {'alt': _('Get it on Google Play'), 'width': '152', 'height': '45', 'l10n': True, 'data-action': 'install', 'data-task': 'stumbler', 'data-step': 'one', 'data-complete': 'true'}) }}
         </a>
       </div>
     </li>


### PR DESCRIPTION
## Description

Ensures that thank you message is shown once the new tab to Google Play is closed.

## Bugzilla link

https://bugzilla.mozilla.org/show_bug.cgi?id=1272030

## Testing

Click on Google Play badge on stumbler task page. Close new tab. Message should be shown.

## Checklist
- [ ] Requires l10n changes.
- [ ] Related functional & integration tests passing.

