### PR TITLE
[fix bug 1272030] Update /contribute/signup task event handling.

### DIFF
--- a/bedrock/mozorg/templates/mozorg/contribute/tasks/stumbler.html
+++ b/bedrock/mozorg/templates/mozorg/contribute/tasks/stumbler.html
@@ -20,8 +20,8 @@
       </header>
       <div class="step-content">
         {{ high_res_img('contribute/signup/stumbler.png', {'alt': '', 'width': '620', 'class': 'feature-img'}) }}
-        <a rel="external" class="stumbler-button" href="{{ settings.GOOGLE_PLAY_FIREFOX_LINK }}" target="_blank" data-action="install" data-task="stumbler" data-step="one" data-complete="true">
-          {{ high_res_img('firefox/android/btn-google-play.png', {'alt': _('Get it on Google Play'), 'width': '152', 'height': '45', 'l10n': True}) }}
+        <a rel="external" class="stumbler-button" href="{{ settings.GOOGLE_PLAY_FIREFOX_LINK }}" target="_blank">
+          {{ high_res_img('firefox/android/btn-google-play.png', {'alt': _('Get it on Google Play'), 'width': '152', 'height': '45', 'l10n': True, 'data-action': 'install', 'data-task': 'stumbler', 'data-step': 'one', 'data-complete': 'true'}) }}
         </a>
       </div>
     </li>


### PR DESCRIPTION
## Description

Improve stability of delegated click handling on various contribute tasks.

## Bugzilla link

[bug 1272030](https://bugzilla.mozilla.org/show_bug.cgi?id=1272030)

## Testing

Make sure task completion functions as expected in A-grade browsers and IE 10+. Make sure non-completion events (e.g. clicking "Learn more about encryption" link) work normally and do not initiate a task completion event.

IE 9 and below do not support `visibilityChange`, and thus do not visually indicate task completion. I could find no support for `document.msHidden` when testing IE 8 and 9, so I removed that conditional from the code.

## Checklist
- [ ] Related functional & integration tests passing.

