### PR TITLE
Update CORS handling to work with preflight

### DIFF
--- a/bedrock/mozorg/middleware.py
+++ b/bedrock/mozorg/middleware.py
@@ -4,7 +4,6 @@
 
 import datetime
 from email.utils import formatdate
-import re
 import time
 
 from django.conf import settings
@@ -38,20 +37,6 @@ class MozorgRequestTimingMiddleware(GraphiteRequestTimingMiddleware):
         else:
             f = super(MozorgRequestTimingMiddleware, self)
             f.process_view(request, view, view_args, view_kwargs)
-
-
-class CrossOriginResourceSharingMiddleware(object):
-
-    def process_response(self, request, response):
-        """
-        If the URL pattern for the request matches one of those
-        in the CORS_URLS setting, apply the matching
-        Access-Control-Allow-Origin header to the response.
-        """
-        for pattern, origin in settings.CORS_URLS.items():
-            if re.search(pattern, request.path):
-                response['Access-Control-Allow-Origin'] = origin
-        return response
 
 
 class ClacksOverheadMiddleware(object):

--- a/bedrock/mozorg/tests/test_middleware.py
+++ b/bedrock/mozorg/tests/test_middleware.py
@@ -5,9 +5,7 @@ from django.conf import settings
 from django.http import HttpRequest, HttpResponse
 from django.test.utils import override_settings
 
-from bedrock.mozorg.middleware import (ClacksOverheadMiddleware,
-                                       CrossOriginResourceSharingMiddleware,
-                                       HostnameMiddleware)
+from bedrock.mozorg.middleware import ClacksOverheadMiddleware, HostnameMiddleware
 from bedrock.mozorg.tests import TestCase
 
 
@@ -30,38 +28,6 @@ class TestClacksOverheadMiddleware(TestCase):
         self.response.status_code = 404
         self.middleware.process_response(self.request, self.response)
         self.assertNotIn('X-Clacks-Overhead', self.response)
-
-
-class TestCrossOriginResourceSharingMiddleware(TestCase):
-    def setUp(self):
-        self.middleware = CrossOriginResourceSharingMiddleware()
-        self.request = HttpRequest()
-        self.response = HttpResponse()
-
-    def test_match(self):
-        self.request.path = '/foo/bar/baz/'
-
-        cors_urls = {r'^/foo/bar': '*'}
-        with self.settings(CORS_URLS=cors_urls):
-            self.middleware.process_response(self.request, self.response)
-            self.assertEqual(self.response['Access-Control-Allow-Origin'], '*')
-
-    def test_middle_match(self):
-        # Ensure that matches in the middle of the URL work.
-        self.request.path = '/foo/bar/baz/'
-
-        cors_urls = {r'/bar': '*'}
-        with self.settings(CORS_URLS=cors_urls):
-            self.middleware.process_response(self.request, self.response)
-            self.assertEqual(self.response['Access-Control-Allow-Origin'], '*')
-
-    def test_no_match(self):
-        self.request.path = '/foo/bar/baz/'
-
-        cors_urls = {r'^/biff/bak': '*'}
-        with self.settings(CORS_URLS=cors_urls):
-            self.middleware.process_response(self.request, self.response)
-            self.assertFalse('Access-Control-Allow-Origin' in self.response)
 
 
 class TestHostnameMiddleware(TestCase):

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -324,6 +324,7 @@ MIDDLEWARE_CLASSES = [middleware for middleware in (
     'sslify.middleware.SSLifyMiddleware',
     'bedrock.mozorg.middleware.MozorgRequestTimingMiddleware',
     'django_statsd.middleware.GraphiteMiddleware',
+    'corsheaders.middleware.CorsMiddleware',
     'bedrock.mozorg.middleware.VaryNoCacheMiddleware' if ENABLE_VARY_NOCACHE_MIDDLEWARE else False,
     # must come before LocaleURLMiddleware
     'bedrock.redirects.middleware.RedirectsMiddleware',
@@ -336,7 +337,6 @@ MIDDLEWARE_CLASSES = [middleware for middleware in (
     'bedrock.mozorg.middleware.CacheMiddleware',
     'dnt.middleware.DoNotTrackMiddleware',
     'lib.l10n_utils.middleware.FixLangFileTranslationsMiddleware',
-    'bedrock.mozorg.middleware.CrossOriginResourceSharingMiddleware',
 ) if middleware]
 
 INSTALLED_APPS = (
@@ -959,9 +959,8 @@ MOFO_SECURITY_ADVISORIES_PATH = config('MOFO_SECURITY_ADVISORIES_PATH',
                                        default=path('mofo_security_advisories'))
 MOFO_SECURITY_ADVISORIES_REPO = 'https://github.com/mozilla/foundation-security-advisories.git'
 
-CORS_URLS = {
-    r'^/([a-zA-Z-]+/)?shapeoftheweb': '*',
-}
+CORS_ORIGIN_ALLOW_ALL = True
+CORS_URLS_REGEX = r'^/([a-zA-Z-]+/)?(shapeoftheweb|newsletter)/'
 
 LOGGING = {
     'root': {

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -123,3 +123,5 @@ South==1.0.2 \
 basket-client==0.3.12 \
     --hash=sha256:d7aa5e6208eeeabb8f1387a7cbb2d0f2b35dfa889c1f034c86a88b4968db3bfe \
     --hash=sha256:2dd953cd03b3068d0e596aa32224488c486b1170e46387c5bc14f20737d6a2d8
+django-cors-headers==1.1.0 \
+    --hash=sha256:fcd96e2be47c8eef34c650e007a6d546e19e7ee61041b89edbbbbe7619aa3987


### PR DESCRIPTION
Also enable CORS support for newsletter view. This should help static sites like for Viewsource to fully support newsletter signups with decent fallback for non-ajax posts.