### PR TITLE
[fix bug 1273071] Newsletter signup forms on /contribute task pages have non-responsive styling

### DIFF
--- a/bedrock/mozorg/templates/mozorg/contribute/tasks/devtools-challenger.html
+++ b/bedrock/mozorg/templates/mozorg/contribute/tasks/devtools-challenger.html
@@ -14,7 +14,7 @@
 {% block task_content %}
   <section class="get-firefox">
     <p>{{ _('Dev Tools requires Firefox Developer Edition desktop browser. To try this task, download Firefox Developer Edition first.') }}</p>
-    <a href="{{ url('firefox.developer') }}" class="button-blue dev-edition">{{ _('Download Firefox Dev Edition') }}</a>
+    {{ download_firefox('alpha', platform='desktop', alt_copy=_('Download Firefox Dev Edition')) }}
   </section>
 
   <ol class="task-steps">

--- a/bedrock/mozorg/templates/mozorg/contribute/tasks/taskview-base.html
+++ b/bedrock/mozorg/templates/mozorg/contribute/tasks/taskview-base.html
@@ -44,7 +44,7 @@
 {% block email_form %}{% endblock %}
 
 {% block email_form_unwrapped %}
-  <section class="newsletter-module">
+  <section id="newsletter-subscribe" class="light">
     <div class="container">
       {{ email_newsletter_form(newsletters='mozilla-foundation', title=_('Keep in touch with Mozilla. Sign up for our newsletter.'), button_class='dark') }}
     </div>

--- a/bedrock/settings/static_media.py
+++ b/bedrock/settings/static_media.py
@@ -859,6 +859,7 @@ PIPELINE_CSS = {
     },
     'contribute-taskview': {
         'source_filenames': (
+            'css/newsletter/moznewsletter-subscribe.less',
             'css/mozorg/contribute/taskview.less',
         ),
         'output_filename': 'css/contribute-taskview-bundle.css',

--- a/media/css/mozorg/contribute/taskview.less
+++ b/media/css/mozorg/contribute/taskview.less
@@ -51,14 +51,6 @@ h1 {
     .font-size(36px);
 }
 
-p {
-    .font-size(21px);
-
-    @media only screen and (max-width: @breakMobileLandscape) {
-        .font-size(19px);
-    }
-}
-
 a:link,
 a:visited {
     color: @linkColor;
@@ -86,6 +78,14 @@ main {
     @media only screen and (max-width: @breakMobileLandscape) {
         padding-left: 10px;
         padding-right: 10px;
+    }
+
+    p {
+        .font-size(21px);
+
+        @media only screen and (max-width: @breakMobileLandscape) {
+            .font-size(19px);
+        }
     }
 
     .task-heading {
@@ -444,50 +444,6 @@ a[role="button"] {
 
 .hidden {
     display: none;
-}
-
-/* newsletter module styles */
-.newsletter-module {
-    background: #fff;
-    color: @textColorPrimary;
-    margin-top: @baseLine * 4;
-
-    .container {
-        margin: 0 auto;
-        padding: (@baseLine * 2) 0 @baseLine;
-        width: @widthDesktop;
-    }
-
-    .billboard {
-        padding-bottom: 0;
-        border: 0;
-    }
-
-    .form-title {
-        .span(6);
-        min-height: 200px;
-
-        &:before {
-            float: left;
-            content: '';
-            background: @mozillaRed url(/media/img/newsletter/mozorg-newsletter.svg) 23px 23px no-repeat;
-            .background-size(105px, 105px);
-            margin-top: -20px;
-            margin-right: @baseLine;
-            border-radius: 50%;
-            width: 150px;
-            height: 150px;
-        }
-    }
-
-    .form-contents,
-    .form-submit {
-        .span(6);
-    }
-
-    input[type="email"] {
-        width: 100%;
-    }
 }
 
 .notices {

--- a/media/css/mozorg/contribute/taskview.less
+++ b/media/css/mozorg/contribute/taskview.less
@@ -63,6 +63,10 @@ a.back {
     .leading-arrow;
 }
 
+.taskview .fx-privacy-link a {
+    color: @linkColor;
+}
+
 main {
     position: relative;
     display: block;
@@ -375,9 +379,8 @@ a[role="button"] {
     border-radius: 6px;
     width: auto;
     max-width: 300px;
-    .font-size(14px);
+    .font-size(@largeFontSize);
     font-weight: bold;
-    text-transform: uppercase;
     text-align: center;
     cursor: pointer;
     transition: background-color 0.3s ease 0s;
@@ -410,11 +413,6 @@ a[role="button"] {
     &.watch {
         margin-bottom: @baseLine * 2;
         width: 100%;
-    }
-
-    /* we need to center the download button for dev edition */
-    &.dev-edition {
-        margin: 0 auto;
     }
 }
 

--- a/media/css/newsletter/moznewsletter-subscribe.less
+++ b/media/css/newsletter/moznewsletter-subscribe.less
@@ -4,7 +4,7 @@
 
 @import '../sandstone/lib.less';
 
-// Newsletter signup testing - bug 1253413
+// Redesigned Mozilla newsletter form - bug 126396
 #newsletter-subscribe {
     background: @mozillaRed;
     color: #fff;
@@ -162,6 +162,7 @@
 
     #footer-email-errors {
         .span-all;
+        margin-bottom: @baseLine;
 
         .errorlist {
             background: #fff;
@@ -176,6 +177,10 @@
         h3 {
             color: #fff;
         }
+    }
+
+    @media (max-width: @breakTablet) {
+        margin-bottom: 0;
     }
 }
 
@@ -206,5 +211,73 @@
            color: #ccc;
            font-weight: normal;
         }
+    }
+}
+
+/*
+ * A 'light' Mozilla newsletter theme style.
+ * Features a white background, dark text and a red, circular graphic.
+ * Currently in use on /contribute task pages.
+ */
+#newsletter-subscribe.light {
+    background: #fff;
+    color: @textColorPrimary;
+    margin-bottom: 0;
+
+    h3,
+    h4 {
+        color: @textColorPrimary;
+    }
+
+    .form-title {
+        position: relative;
+        background: none;
+        width: 500px;
+        padding-left: 170px;
+
+        &:before {
+            position: absolute;
+            top: 0;
+            left: 0;
+            content: '';
+            background: @mozillaRed url('/media/img/newsletter/mozorg-newsletter.svg') 23px 23px no-repeat;
+            .background-size(105px, 105px);
+            border-radius: 50%;
+            width: 150px;
+            height: 150px;
+        }
+
+        @media (max-width: @breakDesktop) {
+            width: 380px;
+        }
+
+        @media (max-width: @breakTablet) {
+            width: auto;
+            padding-left: 0;
+            padding-top: 170px;
+
+            &:before {
+                left: 50%;
+                margin-left: -75px;
+            }
+
+        }
+    }
+
+    input[type="email"] {
+        border: 1px solid #b2b2b2;
+    }
+
+    #newsletter-form-thankyou {
+        color: @textColorPrimary;
+
+        h3 {
+            color: @textColorPrimary;
+        }
+    }
+
+    #footer-email-errors .errorlist {
+        background: #af3232;
+        color: #fff;
     }
 }

--- a/media/js/mozorg/contribute/taskview.js
+++ b/media/js/mozorg/contribute/taskview.js
@@ -8,7 +8,6 @@
     var $document = $(document);
     var $taskSteps = $('.task-steps');
     var $thankYou = $('#thankyou');
-    var $downloadDevTools = $('.dev-edition');
     var $tryAnotherTask = $('.try-another');
     var $findCommunity = $('#communities');
     var $getInvolved = $('#get-involved');
@@ -238,13 +237,6 @@
             trackInteraction('play joy of coding');
             markAsWatched($jocVideo);
         }
-    }
-
-    // send GA events for clicks on the dev edition download button
-    if ($downloadDevTools.length > 0) {
-        $downloadDevTools.on('click', function() {
-            trackInteraction('download firefox dev edition');
-        });
     }
 
     // send GA events for clicks on the back and try another task links


### PR DESCRIPTION
## Description
- Switches /contribute task pages to use `moznewsletter-subscribe.less`.
- Adds a reusable "light" theme style based on existing work.
- Updates the button CSS styling on task pages as per [bug 1270200](https://bugzilla.mozilla.org/show_bug.cgi?id=1270200).

## Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1273071
https://bugzilla.mozilla.org/show_bug.cgi?id=1270200

## Testing
Nothing too specific, just test general responsiveness. Also make sure no visual regressions introduced in other Mozilla newsletter pages.

## Checklist
- [ ] Requires l10n changes.
- [ ] Related functional & integration tests passing (none yet for these pages).