### PR TITLE
Remove running selenium containers after local tests only.

### DIFF
--- a/docker/jenkins/cleanup_after_functional_tests.sh
+++ b/docker/jenkins/cleanup_after_functional_tests.sh
@@ -1,13 +1,15 @@
 #!/bin/bash
 
-docker stop bedrock-code-${BUILD_NUMBER}
-docker rm bedrock-code-${BUILD_NUMBER}
+if [ "${DRIVER}" = "Remote" ]; then
+    docker stop bedrock-code-${BUILD_NUMBER}
+    docker rm bedrock-code-${BUILD_NUMBER}
 
-for NODE_NUMBER in `seq ${NUMBER_OF_NODES:-5}`;
-do
-  docker stop bedrock-selenium-node-${NODE_NUMBER}-${BUILD_NUMBER}
-  docker rm bedrock-selenium-node-${NODE_NUMBER}-${BUILD_NUMBER}
-done;
+    for NODE_NUMBER in `seq ${NUMBER_OF_NODES:-5}`;
+    do
+        docker stop bedrock-selenium-node-${NODE_NUMBER}-${BUILD_NUMBER}
+        docker rm bedrock-selenium-node-${NODE_NUMBER}-${BUILD_NUMBER}
+    done;
 
-docker stop bedrock-selenium-hub-${BUILD_NUMBER}
-docker rm bedrock-selenium-hub-${BUILD_NUMBER}
+    docker stop bedrock-selenium-hub-${BUILD_NUMBER}
+    docker rm bedrock-selenium-hub-${BUILD_NUMBER}
+fi


### PR DESCRIPTION
@davehunt when the $DRIVER=Remote it seems that we run the tests [locally on the CI node](https://github.com/mozilla/bedrock/blob/master/docker/jenkins/run_integration_tests.sh#L20-49). Is `Remote` the correct characterization or do we mean `Locally`?