### PR TITLE
[Bug 1241969] don't ignore the requested language when opening /ab-CD/firefox/

### DIFF
--- a/bedrock/firefox/urls.py
+++ b/bedrock/firefox/urls.py
@@ -29,12 +29,12 @@ ios_sysreq_re = sysreq_re.replace('firefox', 'firefox/ios')
 
 
 urlpatterns = (
-    redirect(r'^firefox/$', 'firefox.new', name='firefox', locale_prefix=False),
+    redirect(r'^firefox/$', 'firefox.new', name='firefox'),
     url(r'^firefox/(?:%s/)?(?:%s/)?all/$' % (platform_re, channel_re),
         views.all_downloads, name='firefox.all'),
     page('firefox/accounts', 'firefox/accounts.html'),
     page('firefox/channel', 'firefox/channel.html'),
-    redirect('^firefox/channel/android/$', 'firefox.channel', locale_prefix=False),
+    redirect('^firefox/channel/android/$', 'firefox.channel'),
     page('firefox/desktop', 'firefox/desktop/index.html'),
     page('firefox/desktop/fast', 'firefox/desktop/fast.html'),
     page('firefox/desktop/customize', 'firefox/desktop/customize.html'),


### PR DESCRIPTION
Same applies to /ab-CD/firefox/channel/android/, so fixed it as well.

https://bugzilla.mozilla.org/show_bug.cgi?id=1241969