### PR TITLE
[fix bug 1271424] Improve copy and UX on some /contribute/signup tasks

### DIFF
--- a/bedrock/mozorg/templates/mozorg/contribute/index.html
+++ b/bedrock/mozorg/templates/mozorg/contribute/index.html
@@ -108,6 +108,7 @@
 
   <section id="landing-howto" class="section landing-howto">
     <div class="container">
+      {# Hiding steps until we re-instate email signups
       <h2 class="section-title">{{ _('Want to get involved? Here’s how.') }}</h2>
       <ol class="steps">
         <li class="step1">{{ _('Choose what interests you and tell us how you’d like to help') }}</li>
@@ -115,6 +116,9 @@
         <li class="step3">{{ _('Create your Mozillians account and share your contributions with the world') }}</li>
       </ol>
       <p class="cta"><a href="{{ url('mozorg.contribute.signup') }}" class="button" data-link-type="button" data-link-name="Get started">{{ _('Get started') }}</a></p>
+      #}
+      <h2 class="section-title">{{ _('Join a global community of game-changers.') }}</h2>
+      <p class="cta"><a href="{{ url('mozorg.contribute.signup') }}" class="button" data-link-type="button" data-link-name="Get Involved">{{ _('Get Involved') }}</a></p>
     </div>
   </section>
 

--- a/bedrock/mozorg/templates/mozorg/contribute/tasks/devtools-challenger.html
+++ b/bedrock/mozorg/templates/mozorg/contribute/tasks/devtools-challenger.html
@@ -24,7 +24,13 @@
       </header>
       <div class="step-content">
         <img src="{{ static('img/contribute/signup/devtools.png') }}" width="620" class="feature-img" alt="" />
-        <a href="http://devtoolschallenger.com/" rel="external" class="button-blue action" data-action="challenger" data-task="devtools" data-step="one" data-complete="true" target="_blank">{{ _('Learn More') }}</a>
+        <a href="http://devtoolschallenger.com/" rel="external" class="button-blue action" data-action="challenger" data-task="devtools" data-step="one" data-complete="true" target="_blank">
+          {% if l10n_has_tag('contribute-tasks-0516') %}
+            {{ _('Visit Dev Tools Challenger') }}
+          {% else %}
+            {{ _('Learn More') }}
+          {% endif %}
+        </a>
         <h4>{{ _('Get involved') }}</h4>
         {{ _('<a href="%s" id="get-involved" target="_blank">Join the Webdev Contribute Group</a>  and start collaborating with other Mozillians around the world.')|format('https://wiki.mozilla.org/Contribute/Webdev') }}
       </div>

--- a/bedrock/mozorg/templates/mozorg/contribute/tasks/encryption.html
+++ b/bedrock/mozorg/templates/mozorg/contribute/tasks/encryption.html
@@ -15,7 +15,11 @@
 <ol class="task-steps">
   <li>
     <header id="step_one" class="one">
-      <h3>{{ _('Take the pledge') }}</h3>
+      {% if l10n_has_tag('contribute-tasks-0516') %}
+        <h3>{{ _('Become an encryption champion') }}</h3>
+      {% else %}
+        <h3>{{ _('Take the pledge') }}</h3>
+      {% endif %}
     </header>
     <div class="step-content">
       {{ high_res_img('contribute/signup/encryption.png', {'alt': '', 'width': '620', 'class': 'feature-img'}) }}

--- a/bedrock/mozorg/templates/mozorg/contribute/tasks/firefox-mobile.html
+++ b/bedrock/mozorg/templates/mozorg/contribute/tasks/firefox-mobile.html
@@ -23,7 +23,7 @@
           <a rel="external" class="download-link" href="{{ settings.GOOGLE_PLAY_FIREFOX_LINK }}" target="_blank" data-link-type="download" data-download-os="Android">
             {{ high_res_img('firefox/android/btn-google-play.png', {'alt': _('Get it on Google Play'), 'width': '152', 'height': '45', 'l10n': True, 'data-action': 'install', 'data-task': 'firefox-mobile', 'data-step': 'one', 'data-complete': 'true', 'data-mobileversion': 'Android'}) }}
           </a>
-          <a rel="external" class="download-link" href="{{settings.APPLE_APPSTORE_FIREFOX_LINK}}" target="_blank">
+          <a rel="external" class="download-link" href="{{ firefox_ios_url('mozorg-contribute_page-appstore-button') }}" target="_blank">
             <img src="{{ l10n_img('firefox/ios/btn-app-store.svg') }}" alt="{{ _('Download on the App Store') }}" width="152" height="45" data-action="install" data-task="firefox-mobile" data-step="one" data-complete="true" data-mobileversion="iOS">
           </a>
         </div>

--- a/bedrock/mozorg/templates/mozorg/contribute/tasks/joy-of-coding.html
+++ b/bedrock/mozorg/templates/mozorg/contribute/tasks/joy-of-coding.html
@@ -23,6 +23,11 @@
           <source src="https://videos.cdn.mozilla.net/uploads/Videos%20creative/joc-video.mp4" type="video/mp4" />
         </video>
         <button type="button" class="button-blue watch" data-action="play" data-task="joyofcoding" data-step="one" data-complete="true">{{ _('Watch the video') }}</button>
+        {% if l10n_has_tag('contribute-tasks-0516') %}
+          <p><a class="more" rel="external" href="https://air.mozilla.org/channels/livehacking/">
+            {{ _('View more <em>Joy of Coding</em> videos on Air Mozilla') }}
+          </a></p>
+        {% endif %}
         <h4>{{ _('Get involved') }}</h4>
         {{ _('<a href="%s" id="get-involved" target="_blank">Join the Coding Community</a> and start collaborating with other Mozillians around the world.')|format('https://wiki.mozilla.org/Contribute/Coding') }}
       </div>
@@ -31,5 +36,9 @@
 {% endblock %}
 
 {% block thank_you_msg %}
-  {{ _('Thanks for getting involved') }}
+  {% if l10n_has_tag('contribute-tasks-0516') %}
+    {{ _('Thanks for watching') }}
+  {% else %}
+    {{ _('Thanks for getting involved') }}
+  {% endif %}
 {% endblock %}

--- a/bedrock/mozorg/templates/mozorg/contribute/tasks/stumbler.html
+++ b/bedrock/mozorg/templates/mozorg/contribute/tasks/stumbler.html
@@ -16,13 +16,13 @@
     <li>
       <header id="step_one" class="one">
         <h3>{{ _('Install Mozilla Stumbler') }}</h3>
-        <p>{{ _('<a href="%s" target="_blank">Learn more about Mozilla Location Services</a> and discover more ways to get involved.')|format('https://location.services.mozilla.com/') }}</p>
       </header>
       <div class="step-content">
         {{ high_res_img('contribute/signup/stumbler.png', {'alt': '', 'width': '620', 'class': 'feature-img'}) }}
         <a rel="external" class="stumbler-button" href="{{ settings.GOOGLE_PLAY_FIREFOX_LINK }}" target="_blank">
           {{ high_res_img('firefox/android/btn-google-play.png', {'alt': _('Get it on Google Play'), 'width': '152', 'height': '45', 'l10n': True, 'data-action': 'install', 'data-task': 'stumbler', 'data-step': 'one', 'data-complete': 'true'}) }}
         </a>
+        <p>{{ _('<a href="%s" target="_blank">Learn more about Mozilla Location Services</a> and discover more ways to get involved.')|format('https://location.services.mozilla.com/') }}</p>
       </div>
     </li>
   </ol>

--- a/bedrock/mozorg/views.py
+++ b/bedrock/mozorg/views.py
@@ -247,7 +247,7 @@ class ContributeSignupNew(TemplateView):
         return [template]
 
 
-class ContributeTaskView(TemplateView):
+class ContributeTaskView(l10n_utils.LangFilesMixin, TemplateView):
 
     tasks = [
         'devtools-challenger',

--- a/media/css/mozorg/contribute/taskview.less
+++ b/media/css/mozorg/contribute/taskview.less
@@ -258,7 +258,7 @@ main {
 
     .stumbler-button {
         display: block;
-        margin: @baseLine auto 10px;
+        margin: (@baseLine * 2) 0 @baseLine;
         width: 200px;
     }
 
@@ -303,6 +303,18 @@ video {
 
     h3 {
         .font-size(60px);
+
+        @media only screen and (max-width: @breakDesktop) {
+            .font-size(54px);
+        }
+
+        @media only screen and (max-width: @breakTablet) {
+            .font-size(48px);
+        }
+
+        @media only screen and (max-width: @breakMobileLandscape) {
+            .font-size(40px);
+        }
     }
 
     p {
@@ -396,7 +408,7 @@ a[role="button"] {
 
     /* watch video play button on joy of coding task */
     &.watch {
-        margin: 0 auto;
+        margin-bottom: @baseLine * 2;
         width: 100%;
     }
 
@@ -409,12 +421,19 @@ a[role="button"] {
 /* download Firefox conditional content */
 .get-firefox {
     margin: 30px auto;
-    width: 400px;
-    max-width: 400px;
+    width: 480px;
     text-align: center;
 
     p {
         .font-size(16px);
+    }
+
+    @media only screen and (max-width: @breakTablet) {
+        width: 400px;
+    }
+
+    @media only screen and (max-width: @breakMobileLandscape) {
+        width: auto;
     }
 }
 


### PR DESCRIPTION
## Description
1.) Hides the "Want to get involved? Here’s how." steps on /contribute until we have email signups again. Shows a simple "Get Involved" CTA reusing existing strings.
2.) Adds a link underneath the Joy of Coding video that says "View more Joy of Coding videos on Air Mozilla" (since the video suggests there are links below on the page)
3.) Changes the Joy of Coding thank you message from "Thanks for getting involved" to "Thanks for watching".
4.) Changes the Dev Tools Challenger CTA button from "Learn More" to "Visit Dev Tools Challenger".
5.) Fixes the broken App Store button link on the firefox mobile task page.
6.) Changes the encryption task title from "Take the pledge" to "Become an encryption champion". See [Bug 1272023](https://bugzilla.mozilla.org/show_bug.cgi?id=1272023) for context.
7.) Moves the Stumbler "Learn more" copy from above the CTA to below.

## Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1271424

## Checklist
- [x] Requires l10n changes.
- [x] Related functional & integration tests passing.

