### PR TITLE
[fix bug 1257796] Make scene2 of /firefox/new more resilient to unknown platforms

### DIFF
--- a/bedrock/firefox/templates/firefox/new/redesign/scene2.html
+++ b/bedrock/firefox/templates/firefox/new/redesign/scene2.html
@@ -32,7 +32,11 @@
           </div>
 
           <p class="help">
-            {{_('Your Firefox should begin downloading automatically. If not, <a id="%s" href="">click here</a>.')|format('direct-download-link')}}
+            {# fallback_url is replaced by the platform download link via JS, but if
+               something fails the user should still get a link to a working download path. #}
+            {% trans id='direct-download-link', fallback_url=url('firefox.all') %}
+              Your Firefox should begin downloading automatically. If not, <a id="{{ id }}" href="{{ fallback_url }}">click here</a>.
+            {% endtrans %}
           </p>
 
           <aside id="mobile-download">

--- a/media/css/firefox/new/redesign/scene2.less
+++ b/media/css/firefox/new/redesign/scene2.less
@@ -116,6 +116,11 @@ main {
 }
 
 .help {
+    display: none;
+}
+
+.js .help {
+    display: block;
     margin-top: @baseLine * 2;
     .open-sans-light;
     .font-size(20px);
@@ -123,7 +128,7 @@ main {
 
 // keep the button technically visible to grab correct download link for
 // backup download link
-#download-button-wrapper-desktop {
+.js #download-button-wrapper-desktop {
     position: absolute;
     width: 1px;
     height: 1px;

--- a/media/css/firefox/new/scene2.less
+++ b/media/css/firefox/new/scene2.less
@@ -4,9 +4,13 @@
 
 @import "../../sandstone/lib.less";
 
+#download-button-wrapper-desktop {
+    text-align: center;
+}
+
 // keep the button technically visible to grab correct download link for
 // backup download link
-#download-button-wrapper-desktop {
+.js #download-button-wrapper-desktop {
     position: absolute;
     width: 1px;
     height: 1px;
@@ -30,6 +34,11 @@
 }
 
 .help {
+    display: none;
+}
+
+.js .help {
+    display: block;
     padding: 0 190px;
     margin-bottom: @baseLine * 2;
     text-align: center;

--- a/media/js/firefox/new/scene2.js
+++ b/media/js/firefox/new/scene2.js
@@ -7,6 +7,7 @@
 
     var isIELT9 = window.Mozilla.Client.platform === 'windows' && /MSIE\s[1-8]\./.test(navigator.userAgent);
     var $directDownloadLink = $('#direct-download-link');
+    var $platformLink = $('#download-button-wrapper-desktop .download-list li:visible .download-link');
     var $stage = $('#stage');
 
     // build virtualUrl for GA
@@ -32,12 +33,12 @@
         }
     }
 
-    // Pull download link from the download button and add to the
-    // 'click here' link.
-    // TODO: Remove and generate link in bedrock.
-    $directDownloadLink.attr(
-        'href', $('#download-button-wrapper-desktop .download-list li:visible .download-link').attr('href')
-    );
+    if ($platformLink.length) {
+        // Pull download link from the download button and add to the
+        // 'click here' link.
+        // TODO: Remove and generate link in bedrock.
+        $directDownloadLink.attr('href', $platformLink.attr('href'));
+    }
 
     // #direct-download-link = "click here" text on page
     // .download-link = any links in download button (which are effectively
@@ -61,8 +62,9 @@
     addPixel();
 
     // if user is not on an IE that blocks JS triggered downloads, start the
-    // platform-detected download after window (read: images) have loaded
-    if (!isIELT9) {
+    // platform-detected download after window (read: images) have loaded.
+    // only auto-start the download if a visible platform link is detected.
+    if (!isIELT9 && $platformLink.length) {
         $(window).on('load', function() {
             $directDownloadLink.trigger('click');
         });


### PR DESCRIPTION
## Description
- Adds a fallback `href` for the direct download link on scene2 that points to `/firefox/all/`, should the JS fail to update the direct download link.
- Only trigger the auto-download click if a supported visible platform link is detected.
- If a user lands directly on scene 2 with JS disabled, show all the download buttons and hide the (JS dependent) direct download link.

## Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1257796

## Testing
- Test both the old and new scene2 templates with JS disabled.
- Test landing directly on scene2 with an unknown user agent (set `site.platform` to `other`). The page should no longer go into an infinite redirect loop by clicking the empty direct download link.

**Note:** I've only updated the `href` fallback link on the new template design, since this is en-US only and means we don't need to incur a string change. Hopefully soon we can start localization and migrate locales to a single design.

## Checklist
- [ ] Requires l10n changes.
- [x] Related functional & integration tests passing.