### PR TITLE
[fix bug 1270789] Use embedded version of send-to-device form on /firefox/ios/page

### DIFF
--- a/bedrock/base/templates/macros.html
+++ b/bedrock/base/templates/macros.html
@@ -377,14 +377,14 @@
 </header>{#-- /#fxosnav-header --#}
 {%- endmacro %}
 
-{% macro send_to_device(platform, include_title=True, title_text='', include_logo=False, ios_link='') %}
+{% macro send_to_device(platform, include_title=True, title_text='', include_logo=False, ios_link='', spinner_color='') %}
   {# If no App Store link is specified, use base with default "ct" param value #}
   {# See https://bugzilla.mozilla.org/show_bug.cgi?id=1196310#c23 #}
   {% if ios_link == '' %}
     {% set ios_link = firefox_ios_url('mozorg') %}
   {% endif %}
   {% set android_link = settings.GOOGLE_PLAY_FIREFOX_LINK %}
-  <section id="send-to-device" class="{% if include_logo %}logo {% endif %}{% if include_title %}title{% else %}no-title{% endif %}" data-key="{{ settings.MOZILLA_LOCATION_SERVICES_KEY }}">
+  <section id="send-to-device" class="{% if include_logo %}logo {% endif %}{% if include_title %}title{% else %}no-title{% endif %}" data-key="{{ settings.MOZILLA_LOCATION_SERVICES_KEY }}" {% if spinner_color %}data-spinner-color="{{ spinner_color }}{% endif %}">
     <div class="form-container">
       {% if include_title %}
         <h2 class="form-heading">

--- a/bedrock/firefox/templates/firefox/android/index.html
+++ b/bedrock/firefox/templates/firefox/android/index.html
@@ -59,7 +59,7 @@
       </p>
 
       <div class="{% if has_widget %}show-widget{% endif %}">
-        {{ send_to_device(platform='android', include_logo=False) }}
+        {{ send_to_device(platform='android', include_logo=False, spinner_color='#fff') }}
 
         <a class="dl-button" rel="external" href="{{ settings.GOOGLE_PLAY_FIREFOX_LINK }}" data-link-type="download" data-download-os="Android">
           {{ high_res_img('firefox/android/btn-google-play.png', {'alt': _('Get it on Google Play'), 'width': '152', 'height': '45', 'l10n': True}) }}

--- a/bedrock/firefox/templates/firefox/ios.html
+++ b/bedrock/firefox/templates/firefox/ios.html
@@ -50,9 +50,8 @@
       <p class="appstore-badge">
         <a href="{{ firefox_ios_url('mozorg-ios_page-appstore-button') }}" data-link-type="download" data-download-os="iOS"><img src="{{ l10n_img('firefox/ios/btn-app-store.svg') }}" alt="{{ _('Download on the App Store') }}"></a>
       </p>
-      <p class="send-to-device">
-        <button class="send-to button green" data-button-name="Get it now">{{ _('Get it now') }}</button>
-      </p>
+
+      {{ send_to_device(platform='ios', title_text=_('Send Firefox to your iOS device'), ios_link=firefox_ios_url('mozorg-ios_page-appstore-button_sd'), spinner_color='#fff') }}
     </div>
 
     <p class="android-link">
@@ -134,12 +133,6 @@
     </ul>
   </div>{# /.container #}
 </section>
-{% endif %}
-
-{% if has_widget %}
-  <div id="send-to-modal-container">
-    {{ send_to_device(platform='ios', title_text=_('Send Firefox to your iOS device'), ios_link=firefox_ios_url('mozorg-ios_page-appstore-button_sd')) }}
-  </div>
 {% endif %}
 
 <aside id="sync-instructions">

--- a/bedrock/settings/static_media.py
+++ b/bedrock/settings/static_media.py
@@ -185,7 +185,7 @@ PIPELINE_CSS = {
         'source_filenames': (
             'css/firefox/family-nav.less',
             'css/base/mozilla-modal.less',
-            'css/base/send-to-device.less',
+            'css/base/send-to-device-micro.less',
             'css/base/mozilla-accordion.less',
             'css/firefox/android.less',
         ),
@@ -407,7 +407,7 @@ PIPELINE_CSS = {
         'source_filenames': (
             'css/firefox/family-nav.less',
             'css/base/mozilla-modal.less',
-            'css/base/send-to-device.less',
+            'css/base/send-to-device-micro.less',
             'css/newsletter/fxnewsletter-subscribe.less',
             'css/firefox/ios.less',
         ),
@@ -1342,7 +1342,7 @@ PIPELINE_JS = {
     },
     'firefox_ios': {
         'source_filenames': (
-            'js/libs/script.js',
+            'js/base/mozilla-smoothscroll.js',
             'js/base/mozilla-modal.js',
             'js/base/search-params.js',
             'js/base/send-to-device.js',

--- a/docs/send-to-device.rst
+++ b/docs/send-to-device.rst
@@ -57,7 +57,7 @@ Usage
 
   If you need a customized App Store URL (e.g. including page-specific parameters), you can pass ``ios_link``::
 
-      {{ send_to_device(ios_link=settings.APPLE_APPSTORE_FIREFOX_LINK + '&ct=mozorg-ios_page-appstore-button') }}
+      {{ send_to_device(ios_link=firefox_ios_url('mozorg-ios_page-appstore-button_sd') }}
 
 5. Initialize the widget:
 
@@ -70,3 +70,13 @@ Example
 -------
 
 You can view a simple example by navigating to ``/styleguide/docs/send-to-device/`` in your local development environment (not available in production).
+
+Micro embedded form
+-------------------
+
+A micro embedded version of the send to device form is also available when targeting a
+single platform (e.g. ``platform='android'`` or ``platform='ios'``).
+
+The styles can be applied by using the following LESS file (instead of the regular stylesheet):
+
+  - ``'css/base/send-to-device-micro.less'``

--- a/media/css/base/send-to-device-micro.less
+++ b/media/css/base/send-to-device-micro.less
@@ -1,0 +1,233 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+* License, v. 2.0. If a copy of the MPL was not distributed with this
+* file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+@import "../sandstone/lib.less";
+
+/*
+ * Embedded "micro" version of Send to Device form.
+ * For single platform use only (e.g. either 'platform=android' or 'platform=ios')
+ */
+#send-to-device {
+    background: #005189;
+    border-radius: 6px;
+    color: #fff;
+    text-align: center;
+
+    h2 {
+        .font-size(24px);
+        color: #fff;
+        padding: 0 @baseLine @baseLine;
+        text-shadow: none;
+    }
+
+    ul {
+        list-style-type: none;
+        margin: 0;
+        padding: 0;
+
+        li {
+            margin: 0;
+            padding: 0;
+        }
+    }
+
+    a:link,
+    a:visited {
+        color: #fff;
+        text-decoration: underline;
+    }
+
+    a:hover,
+    a:active,
+    a:focus {
+        color: darken(#fff, 5%);
+        text-decoration: underline;
+    }
+
+    .form-container {
+        padding-top: (@baseLine * 2);
+    }
+
+    footer {
+        .clearfix();
+        background: #005189;
+        border-radius: 0 0 6px 6px;
+        padding: @baseLine (@baseLine / 2);
+
+        ul {
+            position: relative;
+
+            li {
+                display: inline-block;
+
+                a {
+                    .font-size(14px);
+                    display: inline-block;
+                    line-height: 1.5;
+                    padding: (@baseLine / 2) (@baseLine * 2);
+                    text-align: center;
+                }
+            }
+
+            &.ios .google-play {
+                display: none;
+            }
+
+            &.android .app-store {
+                display: none;
+            }
+        }
+    }
+}
+
+#send-to-device-form {
+    padding: 0 @gridGutterWidth;
+    position: relative;
+
+    label {
+        .font-size(@largeFontSize);
+        display: block;
+        margin-bottom: @baseLine / 2;
+        text-align: center;
+    }
+
+    .inline-field {
+        .clearfix();
+        position: relative;
+    }
+
+    #id-input {
+        .border-box();
+        .font-size(@baseFontSize);
+        .transition(none);
+        display: block;
+        height: 32px;
+        line-height: 2;
+        padding: 5px 10px;
+        width: 100%;
+
+        /*
+         * Override CSS input invalid default styling, since the form can be re-submitted
+         * after the browser performs input validation on first submission.
+         */
+        &:-moz-ui-invalid:not(output) {
+            border-color: #D1D2D3;
+            box-shadow: none;
+        }
+
+        &:-moz-ui-invalid:not(output):focus {
+            border-color: #42A4E0;
+            box-shadow: 0px 0px 0px 2px rgba(73, 173, 227, 0.4);
+        }
+    }
+
+    button[type="submit"] {
+        .transition(background-color .1s ease-in-out);
+        background-color: #0c99d5;
+        display: block;
+        margin: @baseLine 0 0;
+        padding: 12px 5px;
+        width: 100%;
+
+        &:hover,
+        &:active,
+        &:focus,
+        &:active {
+            background-color: lighten(#0c99d5, 5%)
+        }
+    }
+
+    ::-moz-placeholder {
+        .open-sans;
+        color: rgba(86, 86, 90, 0.8);
+    }
+
+    ::-webkit-input-placeholder {
+        .open-sans;
+        color: rgba(86, 86, 90, 0.8);
+    }
+
+    :-ms-input-placeholder {
+        .open-sans;
+        color: rgba(86, 86, 90, 0.8);
+    }
+
+    .legal {
+        .font-size(13px);
+        clear: both;
+        margin: (@baseLine * 2) auto @baseLine;
+        max-width: 38em;
+    }
+
+    .error-list {
+        margin-bottom: @baseLine;
+        text-align: left;
+
+        li {
+            background: #c33b32;
+            border-radius: 3px;
+            color: #fff;
+            margin: @baseLine auto;
+            padding: 10px;
+        }
+    }
+
+    .email {
+        display: block;
+    }
+
+    .sms {
+        display: none;
+    }
+
+    &.us {
+        .email {
+            display: none;
+        }
+
+        .sms {
+            display: block;
+        }
+    }
+
+    .loading-spinner {
+        bottom: 0;
+        display: none;
+        left: 0;
+        position: absolute;
+        right: 0;
+        top: 0;
+    }
+
+    &.loading {
+        .transition(opacity .2s ease-in-out);
+        opacity: 0.2;
+    }
+
+    .thank-you {
+        margin: 0 0 (@baseLine * 2);
+
+        p {
+            .font-size(20px);
+            margin-bottom: @baseLine;
+            padding-top: 92px;
+            position: relative;
+
+            &:before {
+                .at2x('/media/img/send-to-device/device-icon.png', 72px, 72px);
+                content: '';
+                height: 72px;
+                left: 50%;
+                margin-left: -36px;
+                position: absolute;
+                top: 0;
+                width: 72px;
+            }
+        }
+
+        a {
+            .font-size(@largeFontSize);
+        }
+    }
+}

--- a/media/css/firefox/android.less
+++ b/media/css/firefox/android.less
@@ -593,119 +593,14 @@ html[dir="rtl"] #phone-wrapper figure {
 .js .show-widget {
     #send-to-device {
         display: block;
-        background: #005189;
-        border-radius: 6px;
-        color: #fff;
-        width: auto;
-        margin-right: @gridGutterWidth;
-
-        // largely appropriated from send-to-device.less
-        h2 {
-            max-width: none;
-            .font-size(24px);
-            padding-bottom: @baseLine;
-            color: #fff;
-        }
-
-        .form-container {
-            width: @widthMobileLandscape - @gridGutterWidth;
-
-            a,
-            a:active,
-            a:focus,
-            a:hover {
-                color: #fff;
-                text-decoration: underline;
-            }
-        }
-
-        footer {
-            padding: 0 (@baseLine / 2);
-            background: #005189;
-            border-radius: 0 0 6px 6px;
-            border-top: none;
-
-            ul.android {
-                text-align: center;
-
-                li {
-
-                    &.android-all,
-                    &.google-play {
-                        display: inline-block;
-                        width: auto;
-                    }
-
-                    &.google-play {
-                        margin-left: @baseLine;
-
-                        @media only screen and (max-width: @breakMobileLandscape) {
-                            margin-left: 0;
-                        }
-                    }
-
-                    a {
-                        display: block;
-                        padding: 0 0 @baseLine;
-                        line-height: 1.5;
-                        color: #fff;
-                        .font-size(14px);
-                        text-decoration: underline;
-                    }
-                }
-            }
-        }
-
-        .form-container {
-            width: auto;
-        }
-
-        #send-to-device-form {
-            .input {
-                label {
-                    text-align: center;
-                }
-
-                .inline-field {
-                    width: auto;
-
-                    .form-input {
-                        float: none;
-                        width: auto;
-                    }
-
-                    .form-submit {
-                        float: none;
-                        width: auto;
-                    }
-                }
-
-                #id-input {
-                    float: none;
-                    .border-box();
-                    display: block;
-                    width: 100%;
-                }
-
-                button[type="submit"] {
-                    display: block;
-                    float: none;
-                    width: 100%;
-                    margin-top: @baseLine;
-                }
-            }
-
-            .error-list li {
-                width: auto;
-            }
-        }
+        margin-right: @baseLine;
     }
 
     // Hide play store button for locales that get the widget
     .dl-button {
         display: none;
     }
-    
+
     #send-to-button-header,
     #send-to-button-footer {
         display: block;

--- a/media/css/firefox/ios.less
+++ b/media/css/firefox/ios.less
@@ -113,28 +113,28 @@ a.go {
         }
     }
 
-    h2 {
-        .font-size(40px);
-        color: #bee1f5;
-        line-height: 1.2;
-        margin: 0 0 1em;
-
-        @media only screen and (max-width: @breakDesktop) {
-            .font-size(32px);
-        }
-
-        @media only screen and (max-width: @breakTablet) {
-            .font-size(22px);
-            text-align: center;
-        }
-    }
-
     a:link,
     a:visited {
         color: #fff;
     }
 
     .get-fxios {
+        & > h2 {
+            .font-size(40px);
+            color: #bee1f5;
+            line-height: 1.2;
+            margin: 0 0 1em;
+
+            @media only screen and (max-width: @breakDesktop) {
+                .font-size(32px);
+            }
+
+            @media only screen and (max-width: @breakTablet) {
+                .font-size(22px);
+                text-align: center;
+            }
+        }
+
         p {
             margin: 0;
         }
@@ -596,32 +596,7 @@ a.go {
 
 
 // Send to Device Widget
-#send-to-device {
-    display: none;
-    border-radius: 6px;
-    margin-top: 15px;
-
-    .form-container {
-        padding-top: 130px;
-        background-position: center 25px;
-        background-repeat: no-repeat;
-        .at2x('/media/img/firefox/ios/send-to-device.png', 201px, 90px);
-    }
-
-    footer {
-        border-radius: 0 0 6px 6px;
-    }
-}
-
-#modal #send-to-device {
-    display: block;
-}
-
-#modal .window .inner #modal-close {
-    top: -30px;
-}
-
-.send-to-device,
+#send-to-device,
 .send-to.button.green {
     display: none;
 }
@@ -632,9 +607,11 @@ a.go {
     .appstore-badge {
         display: none;
     }
-    .send-to-device,
     .send-to.button.green  {
         display: inline;
+    }
+    #send-to-device {
+        display: block;
     }
 }
 

--- a/media/js/base/send-to-device.js
+++ b/media/js/base/send-to-device.js
@@ -28,6 +28,7 @@ if (typeof Mozilla === 'undefined') {
         this.$footerLinks = this.$widget.find('footer > ul');
         this.$sendAnotherLink = this.$form.find('.send-another');
         this.$formHeading = this.$widget.find('.form-heading');
+        this.spinnerColor = this.$widget.data('spinnerColor') || '#000';
 
         this.spinner = new Spinner({
             lines: 12, // The number of lines to draw
@@ -37,7 +38,7 @@ if (typeof Mozilla === 'undefined') {
             corners: 0, // Corner roundness (0..1)
             rotate: 0, // The rotation offset
             direction: 1, // 1: clockwise, -1: counterclockwise
-            color: '#000', // #rgb or #rrggbb or array of colors
+            color: this.spinnerColor, // #rgb or #rrggbb or array of colors
             speed: 1, // Rounds per second
             trail: 60, // Afterglow percentage
             shadow: false, // Whether to render a shadow

--- a/media/js/firefox/ios.js
+++ b/media/js/firefox/ios.js
@@ -14,9 +14,8 @@ if (typeof window.Mozilla === 'undefined') {
     var $html = $('html');
     var $body = $('body');
 
-    // send-to-device form
-    var $widget = $('#send-to-modal-container');
-    var sendToDeviceForm = new Mozilla.SendToDevice();
+    // does page locale have send to device?
+    var hasWidget = $('#intro .get-fxios').hasClass('show-widget');
 
     // Sync instructions
     var $instructions = $('#sync-instructions');
@@ -95,17 +94,33 @@ if (typeof window.Mozilla === 'undefined') {
         $body.addClass(stateClass);
     };
 
+    function initSendToDeviceForm() {
+        // only initialize send to device if locale has the widget
+        if (!hasWidget) {
+            return;
+        }
+
+        var sendToDeviceForm = new Mozilla.SendToDevice();
+        var sendToDeviceWidgetTop = $('#send-to-device').offset().top;
+
+        // initialize send to device form
+        sendToDeviceForm.init();
+
+        // scroll to send to device form when header button is clicked
+        $('.send-to').on('click', function(e) {
+            e.preventDefault();
+
+            Mozilla.smoothScroll({
+                top: sendToDeviceWidgetTop - 100
+            });
+        });
+    }
+
     // initialize page state
     initState();
 
     // initialize send to device form
-    sendToDeviceForm.init();
-
-    // open send to device form in modal
-    $('.send-to').on('click', function(e) {
-        e.preventDefault();
-        Mozilla.Modal.createModal(this, $widget);
-    });
+    initSendToDeviceForm();
 
     // Firefox Sync sign in flow button
     $('.sync-button').on('click', function(e) {

--- a/tests/functional/firefox/test_ios.py
+++ b/tests/functional/firefox/test_ios.py
@@ -11,9 +11,7 @@ from pages.firefox.ios import IOSPage
 @pytest.mark.nondestructive
 def test_send_to_device_sucessful_submission(base_url, selenium):
     page = IOSPage(base_url, selenium).open()
-    page.click_get_it_now()
     send_to_device = page.send_to_device
-    assert page.send_to_device.is_displayed
     send_to_device.type_email('success@example.com')
     send_to_device.click_send()
     assert send_to_device.send_successful
@@ -23,7 +21,6 @@ def test_send_to_device_sucessful_submission(base_url, selenium):
 def test_send_to_device_fails_when_missing_required_fields(base_url, selenium):
     page = IOSPage(base_url, selenium).open()
     with pytest.raises(TimeoutException):
-        page.click_get_it_now()
         page.send_to_device.click_send()
 
 
@@ -31,4 +28,4 @@ def test_send_to_device_fails_when_missing_required_fields(base_url, selenium):
 def test_send_to_device_not_supported_locale(base_url, selenium):
     page = IOSPage(base_url, selenium, locale='it').open()
     assert page.is_app_store_button_displayed
-    assert not page.is_get_it_now_button_displayed
+    assert not page.send_to_device.is_displayed

--- a/tests/pages/firefox/ios.py
+++ b/tests/pages/firefox/ios.py
@@ -5,7 +5,6 @@
 from selenium.webdriver.common.by import By
 
 from pages.firefox.base import FirefoxBasePage
-from pages.regions.modal import Modal
 from pages.regions.send_to_device import SendToDevice
 
 
@@ -14,7 +13,6 @@ class IOSPage(FirefoxBasePage):
     _url = '{base_url}/{locale}/firefox/ios'
 
     _app_store_button_locator = (By.CSS_SELECTOR, '#intro .appstore-badge')
-    _get_it_now_button_locator = (By.CSS_SELECTOR, '#intro .send-to-device .send-to')
 
     @property
     def send_to_device(self):
@@ -23,13 +21,3 @@ class IOSPage(FirefoxBasePage):
     @property
     def is_app_store_button_displayed(self):
         return self.is_element_displayed(self._app_store_button_locator)
-
-    @property
-    def is_get_it_now_button_displayed(self):
-        return self.is_element_displayed(self._get_it_now_button_locator)
-
-    def click_get_it_now(self):
-        modal = Modal(self)
-        self.find_element(self._get_it_now_button_locator).click()
-        self.wait.until(lambda s: modal.is_displayed)
-        return modal


### PR DESCRIPTION
## Description
- Embeds the send-to-device form on `/firefox/ios` instead of requiring a modal.
- Both `/firefox/ios` and `/firefox/android` now use a shared `send-to-device-micro.less` stylesheet.
- Embedded form styles are now standalone, instead of overriding `send-to-device.less`.
- Clicking the "Get Firefox for iOS" button in the nav now scrolls the form into view.
- Updates functional tests for iOS page.

## Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1270789

## Testing
- Test both `/firefox/ios` and `/firefox/android` for regressions (either form styling or display logic).

## Checklist
- [ ] Requires l10n changes.
- [x] Related functional & integration tests passing.