### PR TITLE
Add functional tests for /contribute tasks

### DIFF
--- a/bedrock/mozorg/templates/mozorg/contribute/tasks/firefox-mobile.html
+++ b/bedrock/mozorg/templates/mozorg/contribute/tasks/firefox-mobile.html
@@ -23,7 +23,7 @@
           <a rel="external" class="download-link" href="{{ settings.GOOGLE_PLAY_FIREFOX_LINK }}" target="_blank" data-link-type="download" data-download-os="Android">
             {{ high_res_img('firefox/android/btn-google-play.png', {'alt': _('Get it on Google Play'), 'width': '152', 'height': '45', 'l10n': True, 'data-action': 'install', 'data-task': 'firefox-mobile', 'data-step': 'one', 'data-complete': 'true', 'data-mobileversion': 'Android'}) }}
           </a>
-          <a rel="external" class="download-link" href="{{ firefox_ios_url('mozorg-contribute_page-appstore-button') }}" target="_blank">
+          <a rel="external" class="download-link" href="{{ firefox_ios_url('mozorg-contribute_page-appstore-button') }}" target="_blank" data-link-type="download" data-download-os="iOS">
             <img src="{{ l10n_img('firefox/ios/btn-app-store.svg') }}" alt="{{ _('Download on the App Store') }}" width="152" height="45" data-action="install" data-task="firefox-mobile" data-step="one" data-complete="true" data-mobileversion="iOS">
           </a>
         </div>

--- a/tests/functional/contribute/test_tasks.py
+++ b/tests/functional/contribute/test_tasks.py
@@ -1,0 +1,61 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import pytest
+
+from pages.contribute.tasks import ContributeSignUpPage
+
+
+@pytest.mark.smoke
+@pytest.mark.nondestructive
+def test_contribute_task_twitter(base_url, selenium):
+    page = ContributeSignUpPage(selenium, base_url).open()
+    twitter_task_page = page.open_twitter_task()
+    assert twitter_task_page.seed_url in selenium.current_url
+    assert twitter_task_page.is_share_button_displayed
+    assert twitter_task_page.is_follow_button_displayed
+
+
+@pytest.mark.smoke
+@pytest.mark.nondestructive
+def test_contribute_task_firefox_mobile(base_url, selenium):
+    page = ContributeSignUpPage(selenium, base_url).open()
+    mobile_task_page = page.open_mobile_task()
+    assert mobile_task_page.seed_url in selenium.current_url
+    assert mobile_task_page.is_android_download_button_displayed
+    assert mobile_task_page.is_ios_download_button_displayed
+
+
+@pytest.mark.nondestructive
+def test_contribute_task_encryption(base_url, selenium):
+    page = ContributeSignUpPage(selenium, base_url).open()
+    encryption_task_page = page.open_encryption_task()
+    assert encryption_task_page.seed_url in selenium.current_url
+    assert encryption_task_page.is_take_the_pledge_button_displayed
+
+
+@pytest.mark.nondestructive
+def test_contribute_task_joy_of_coding(base_url, selenium):
+    page = ContributeSignUpPage(selenium, base_url).open()
+    joy_of_coding_task_page = page.open_joy_of_coding_task()
+    assert joy_of_coding_task_page.seed_url in selenium.current_url
+    assert joy_of_coding_task_page.is_video_displayed
+    assert joy_of_coding_task_page.is_watch_the_video_button_displayed
+
+
+@pytest.mark.nondestructive
+def test_contribute_task_dev_tools_challenger(base_url, selenium):
+    page = ContributeSignUpPage(selenium, base_url).open()
+    dev_tools_challenger_task_page = page.open_dev_tools_challenger_task()
+    assert dev_tools_challenger_task_page.seed_url in selenium.current_url
+    assert dev_tools_challenger_task_page.download_button.is_displayed
+    assert dev_tools_challenger_task_page.is_visit_dev_tools_challenger_button_displayed
+
+
+@pytest.mark.nondestructive
+def test_contribute_task_stumbler(base_url, selenium):
+    page = ContributeSignUpPage(selenium, base_url).open()
+    stumbler_task_page = page.open_stumbler_task()
+    assert stumbler_task_page.seed_url in selenium.current_url
+    assert stumbler_task_page.is_stumbler_button_displayed

--- a/tests/functional/test_newsletter_embed.py
+++ b/tests/functional/test_newsletter_embed.py
@@ -8,6 +8,12 @@ from selenium.common.exceptions import TimeoutException
 from pages.home import HomePage
 from pages.about import AboutPage
 from pages.contribute.contribute import ContributePage
+from pages.contribute.task.twitter import TwitterTaskPage
+from pages.contribute.task.mobile import MobileTaskPage
+from pages.contribute.task.encryption import EncryptionTaskPage
+from pages.contribute.task.joy_of_coding import JoyOfCodingTaskPage
+from pages.contribute.task.dev_tools_challenger import DevToolsChallengerTaskPage
+from pages.contribute.task.stumbler import StumblerTaskPage
 from pages.mission import MissionPage
 from pages.firefox.all import FirefoxAllPage
 from pages.firefox.desktop.desktop import DesktopPage
@@ -25,6 +31,12 @@ from pages.smarton.base import SmartOnBasePage
     pytest.mark.smoke((HomePage, None)),
     (AboutPage, None),
     pytest.mark.smoke((ContributePage, None)),
+    (TwitterTaskPage, None),
+    (MobileTaskPage, None),
+    (EncryptionTaskPage, None),
+    (JoyOfCodingTaskPage, None),
+    (DevToolsChallengerTaskPage, None),
+    (StumblerTaskPage, None),
     (MissionPage, None),
     (FirefoxAllPage, None),
     pytest.mark.smoke((DesktopPage, None)),

--- a/tests/pages/contribute/task/dev_tools_challenger.py
+++ b/tests/pages/contribute/task/dev_tools_challenger.py
@@ -1,0 +1,25 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from selenium.webdriver.common.by import By
+
+from pages.contribute.base import ContributeBasePage
+from pages.regions.download_button import DownloadButton
+
+
+class DevToolsChallengerTaskPage(ContributeBasePage):
+
+    URL_TEMPLATE = '/{locale}/contribute/task/devtools-challenger'
+
+    _download_button_locator = (By.ID, 'download-button-desktop-alpha')
+    _visit_dev_tools_challenger_locator = (By.CSS_SELECTOR, 'a[data-task="devtools"]')
+
+    @property
+    def download_button(self):
+        el = self.find_element(*self._download_button_locator)
+        return DownloadButton(self, root=el)
+
+    @property
+    def is_visit_dev_tools_challenger_button_displayed(self):
+        return self.is_element_displayed(*self._visit_dev_tools_challenger_locator)

--- a/tests/pages/contribute/task/encryption.py
+++ b/tests/pages/contribute/task/encryption.py
@@ -1,0 +1,18 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from selenium.webdriver.common.by import By
+
+from pages.contribute.base import ContributeBasePage
+
+
+class EncryptionTaskPage(ContributeBasePage):
+
+    URL_TEMPLATE = '/{locale}/contribute/task/encryption'
+
+    _take_the_pledge_button_locator = (By.CSS_SELECTOR, 'a[data-task="encryption"]')
+
+    @property
+    def is_take_the_pledge_button_displayed(self):
+        return self.is_element_displayed(*self._take_the_pledge_button_locator)

--- a/tests/pages/contribute/task/joy_of_coding.py
+++ b/tests/pages/contribute/task/joy_of_coding.py
@@ -1,0 +1,23 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from selenium.webdriver.common.by import By
+
+from pages.contribute.base import ContributeBasePage
+
+
+class JoyOfCodingTaskPage(ContributeBasePage):
+
+    URL_TEMPLATE = '/{locale}/contribute/task/joy-of-coding'
+
+    _video_locator = (By.ID, 'joc')
+    _watch_the_video_button_locator = (By.CSS_SELECTOR, 'button[data-task="joyofcoding"]')
+
+    @property
+    def is_video_displayed(self):
+        return self.is_element_displayed(*self._video_locator)
+
+    @property
+    def is_watch_the_video_button_displayed(self):
+        return self.is_element_displayed(*self._watch_the_video_button_locator)

--- a/tests/pages/contribute/task/mobile.py
+++ b/tests/pages/contribute/task/mobile.py
@@ -1,0 +1,23 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from selenium.webdriver.common.by import By
+
+from pages.contribute.base import ContributeBasePage
+
+
+class MobileTaskPage(ContributeBasePage):
+
+    URL_TEMPLATE = '/{locale}/contribute/task/firefox-mobile'
+
+    _android_download_button_locator = (By.CSS_SELECTOR, 'a[data-download-os="Android"]')
+    _ios_download_button_locator = (By.CSS_SELECTOR, 'a[data-download-os="iOS"]')
+
+    @property
+    def is_android_download_button_displayed(self):
+        return self.is_element_displayed(*self._android_download_button_locator)
+
+    @property
+    def is_ios_download_button_displayed(self):
+        return self.is_element_displayed(*self._ios_download_button_locator)

--- a/tests/pages/contribute/task/stumbler.py
+++ b/tests/pages/contribute/task/stumbler.py
@@ -1,0 +1,18 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from selenium.webdriver.common.by import By
+
+from pages.contribute.base import ContributeBasePage
+
+
+class StumblerTaskPage(ContributeBasePage):
+
+    URL_TEMPLATE = '/{locale}/contribute/task/stumbler'
+
+    _stumbler_button_locator = (By.CLASS_NAME, 'stumbler-button')
+
+    @property
+    def is_stumbler_button_displayed(self):
+        return self.is_element_displayed(*self._stumbler_button_locator)

--- a/tests/pages/contribute/task/twitter.py
+++ b/tests/pages/contribute/task/twitter.py
@@ -1,0 +1,23 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from selenium.webdriver.common.by import By
+
+from pages.contribute.base import ContributeBasePage
+
+
+class TwitterTaskPage(ContributeBasePage):
+
+    URL_TEMPLATE = '/{locale}/contribute/task/follow-mozilla'
+
+    _share_button_locator = (By.CSS_SELECTOR, 'a[data-action="tweet"]')
+    _follow_button_locator = (By.CSS_SELECTOR, 'a[data-action="follow"]')
+
+    @property
+    def is_share_button_displayed(self):
+        return self.is_element_displayed(*self._share_button_locator)
+
+    @property
+    def is_follow_button_displayed(self):
+        return self.is_element_displayed(*self._follow_button_locator)

--- a/tests/pages/contribute/tasks.py
+++ b/tests/pages/contribute/tasks.py
@@ -1,0 +1,49 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from selenium.webdriver.common.by import By
+
+from pages.contribute.base import ContributeBasePage
+
+
+class ContributeSignUpPage(ContributeBasePage):
+
+    URL_TEMPLATE = '/{locale}/contribute/signup'
+
+    _twitter_task_locator = (By.CSS_SELECTOR, 'a[data-task="Connect with Mozilla on Twitter"]')
+    _mobile_task_locator = (By.CSS_SELECTOR, 'a[data-task="Get Firefox on Your Phone"]')
+    _encryption_task_locator = (By.CSS_SELECTOR, 'a[data-task="encryption"]')
+    _joy_of_coding_task_locator = (By.CSS_SELECTOR, 'a[data-task="Joy of Coding"]')
+    _dev_tools_challenger_task_locator = (By.CSS_SELECTOR, 'a[data-task="Learn about Coding"]')
+    _stumbler_task_locator = (By.CSS_SELECTOR, 'a[data-task="Get Mozilla Stumbler"]')
+
+    def open_twitter_task(self):
+        self.find_element(*self._twitter_task_locator).click()
+        from pages.contribute.task.twitter import TwitterTaskPage
+        return TwitterTaskPage(self.selenium, self.base_url).wait_for_page_to_load()
+
+    def open_mobile_task(self):
+        self.find_element(*self._mobile_task_locator).click()
+        from pages.contribute.task.mobile import MobileTaskPage
+        return MobileTaskPage(self.selenium, self.base_url).wait_for_page_to_load()
+
+    def open_encryption_task(self):
+        self.find_element(*self._encryption_task_locator).click()
+        from pages.contribute.task.encryption import EncryptionTaskPage
+        return EncryptionTaskPage(self.selenium, self.base_url).wait_for_page_to_load()
+
+    def open_joy_of_coding_task(self):
+        self.find_element(*self._joy_of_coding_task_locator).click()
+        from pages.contribute.task.joy_of_coding import JoyOfCodingTaskPage
+        return JoyOfCodingTaskPage(self.selenium, self.base_url).wait_for_page_to_load()
+
+    def open_dev_tools_challenger_task(self):
+        self.find_element(*self._dev_tools_challenger_task_locator).click()
+        from pages.contribute.task.dev_tools_challenger import DevToolsChallengerTaskPage
+        return DevToolsChallengerTaskPage(self.selenium, self.base_url).wait_for_page_to_load()
+
+    def open_stumbler_task(self):
+        self.find_element(*self._stumbler_task_locator).click()
+        from pages.contribute.task.stumbler import StumblerTaskPage
+        return StumblerTaskPage(self.selenium, self.base_url).wait_for_page_to_load()


### PR DESCRIPTION
## Description
- Adds functional tests for the new `/contribute` task pages.
- Adds task pages to parameterized newsletter tests.

Note: I decided against clicking the actual task CTA buttons that open new tabs, since it would introduce a dependency on loading third-party sites in our tests. I think asserting that our own pages look/function as expected is probably enough here. 

It would have been nice to test the "thank you" message after switching tabs, but I think this would likely prove to be more trouble in the long run that it is beneficial. The "thank you" message is only a piece of text, and not something I would class as critical to the page (i.e. even if it broke, people could still complete the tasks as normal).

## Bugzilla link
- N/A

## Testing
- I had to add a new selector for one of the firefox-mobile task page as a test hook. As such, this particular tests needs to be run locally to pass.

## Checklist
- [ ] Requires l10n changes.
- [x] Related functional & integration tests passing.

