### PR TITLE
No longer gzip compress static assets in app

### DIFF
--- a/bedrock/base/storage.py
+++ b/bedrock/base/storage.py
@@ -2,13 +2,12 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-# This is here so that we can mix storages as we need. We'll do this for pipeline
-# and whitenoise with hashing and gzip when we get those both working.
+# This is here so that we can mix storages as we need.
+
+from django.contrib.staticfiles.storage import ManifestStaticFilesStorage
 
 from pipeline.storage import PipelineMixin
-# This part of whitenoise is Python 2.6 compatible
-from whitenoise.django import GzipManifestStaticFilesStorage
 
 
-class ManifestPipelineStorage(PipelineMixin, GzipManifestStaticFilesStorage):
+class ManifestPipelineStorage(PipelineMixin, ManifestStaticFilesStorage):
     pass


### PR DESCRIPTION
Our CDN does it for us so the .gz files were unused.

https://support.cloudflare.com/hc/en-us/articles/200168086-Does-CloudFlare-gzip-resources