### PR TITLE
[bug 1266576] Update dataLayer push to add newClickHref on link click…

### DIFF
--- a/media/js/base/core-datalayer-init.js
+++ b/media/js/base/core-datalayer-init.js
@@ -11,5 +11,7 @@ $(function() {
             'event': 'core-datalayer-loaded',
             'pageId': Mozilla.Analytics.getPageId()
         });
+
+        Mozilla.Analytics.updateDataLayerPush();
     }
 });

--- a/tests/unit/spec/base/core-datalayer.js
+++ b/tests/unit/spec/base/core-datalayer.js
@@ -7,7 +7,7 @@
 
 describe('core-datalayer.js', function() {
 
-    describe('PageId', function(){
+    describe('getPageId', function(){
         var html = document.documentElement;
 
         afterEach(function() {
@@ -25,6 +25,61 @@ describe('core-datalayer.js', function() {
         });
     });
 
+    describe('updateDataLayerPush', function() {
+        var linkElement;
+
+        beforeEach(function() {
+            var link = '<a id="link" href="https://www.mozilla.org/en-US/firefox/new/">';
+            $(link).appendTo('body');
+            linkElement = $('#link')[0];
+
+            window.dataLayer = [];
+            Mozilla.Analytics.updateDataLayerPush();
+        });
+
+        afterEach(function() {
+            $('body').remove('#link');
+            delete window.dataLayer;
+        });
+
+        it('will add newClickHref property to link click object when pushed to the dataLayer', function() {
+            window.dataLayer.push({
+                'event': 'gtm.linkClick',
+                'gtm.element': linkElement
+            });
+
+            expect(window.dataLayer[0].newClickHref).toBeDefined();
+        });
+
+        it('will not add newClickHref property to object pushed to dataLayer if not a link click object', function() {
+            window.dataLayer.push({
+                'event': 'gtm.click',
+                'gtm.element': linkElement
+            });
+
+            expect(window.dataLayer[0].newClickHref).toBeUndefined();
+        });
+
+        it('will keep host in newClickHref when clicked link\'s href host value is different thatn the page\'s', function() {
+            window.dataLayer.push({
+                'event': 'gtm.linkClick',
+                'gtm.element': linkElement
+            });
+
+            expect(window.dataLayer[0].newClickHref).toEqual('https://www.mozilla.org/en-US/firefox/new/');
+        });
+
+        it('will remove host  and locale in newClickHref when clicked link\'s href value matches the page\'s', function() {
+            linkElement.host = document.location.host;
+
+            window.dataLayer.push({
+                'event': 'gtm.linkClick',
+                'gtm.element': linkElement
+            });
+
+            expect(window.dataLayer[0].newClickHref).toEqual('/firefox/new/');
+        });
+    });
 });
 
 


### PR DESCRIPTION
## Description
Adds updateDataLayerPush function that is called during the core dataLayer init so when a link click object is pushed to the dataLayer a new newClickHref property with the link's href value is added to the object. If the link's host matches the page's, then the host and locale are stripped before setting the newClickHref property.

## Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1266576