### PR TITLE
Revert "[Bug 1241969] don't ignore the requested language when opening /ab-CD/firefox/"

### DIFF
--- a/bedrock/firefox/urls.py
+++ b/bedrock/firefox/urls.py
@@ -29,12 +29,12 @@ ios_sysreq_re = sysreq_re.replace('firefox', 'firefox/ios')
 
 
 urlpatterns = (
-    redirect(r'^firefox/$', 'firefox.new', name='firefox'),
+    redirect(r'^firefox/$', 'firefox.new', name='firefox', locale_prefix=False),
     url(r'^firefox/(?:%s/)?(?:%s/)?all/$' % (platform_re, channel_re),
         views.all_downloads, name='firefox.all'),
     page('firefox/accounts', 'firefox/accounts.html'),
     page('firefox/channel', 'firefox/channel.html'),
-    redirect('^firefox/channel/android/$', 'firefox.channel'),
+    redirect('^firefox/channel/android/$', 'firefox.channel', locale_prefix=False),
     page('firefox/desktop', 'firefox/desktop/index.html'),
     page('firefox/desktop/fast', 'firefox/desktop/fast.html'),
     page('firefox/desktop/customize', 'firefox/desktop/customize.html'),


### PR DESCRIPTION
Reverts mozilla/bedrock#4133

After merging and deploying this to dev, we found that (for example) https://bedrock-dev.us-west.moz.works/it/firefox/ would still redirect to https://bedrock-dev.us-west.moz.works/en-US/firefox/new/