### PR TITLE
[fix bug 1275509] Privacy link text on 404 page lacks sufficient contrast

### DIFF
--- a/media/css/base/page-not-found.less
+++ b/media/css/base/page-not-found.less
@@ -22,6 +22,19 @@
     float: right;
 }
 
+.fx-privacy-link {
+    a:link,
+    a:visited {
+        color: @linkBlue;
+    }
+
+    a:hover,
+    a:active,
+    a:focus {
+        color: @linkBlueHover;
+    }
+}
+
 /* {{{ Tablet  Layout: 768px */
 
 @media only screen and (min-width: @widthTablet) and (max-width: @widthDesktop) {
@@ -37,7 +50,7 @@
     #error-content {
         .span-all();
     }
-    #download {
+    .download-button {
         .span-all();
     }
 }


### PR DESCRIPTION
## Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1275509