### PR TITLE
[fix bug 1275770] Update headline + value proposition copy on download page

### DIFF
--- a/bedrock/firefox/templates/firefox/new/redesign/scene1.html
+++ b/bedrock/firefox/templates/firefox/new/redesign/scene1.html
@@ -53,7 +53,7 @@
           </div>{#-- /.version-message-container --#}
 
           <div id="main-feature" class="hide-for-refresh">
-            <h1>{{ _('Go beyond the others. <br>Choose Firefox.') }}</h1>
+            <h1>{{ _('Browse Freely') }}</h1>
           </div>{#-- /#main-feature --#}
 
           <div class="desktop-latest-links-wrapper latest-links-wrapper">
@@ -102,16 +102,16 @@
     <section id="benefits">
       <ul>
         <li>
-          <h2 class="performance">{{_('Performance') }}</h2>
-          <p>{{_('Get where you need to go, quickly and reliably, with our best Firefox yet.') }}</p>
+          <h2 class="performance">{{_('Fly Fast') }}</h2>
+          <p>{{_('Go anywhere you want on the Web – with a quickness.') }}</p>
         </li>
         <li>
-          <h2 class="privacy">{{_('Privacy') }}</h2>
-          <p>{{_('With the most built-in privacy features, Firefox keeps you in control of your life online.') }}</p>
+          <h2 class="privacy">{{_('Fly Safe') }}</h2>
+          <p>{{_('Take advantage of more built-in privacy tools than any other browser.') }}</p>
         </li>
         <li>
-          <h2 class="good">{{_('Public Good') }}</h2>
-          <p>{{_('Firefox is made by Mozilla, the proudly non-profit defender of the free and open Internet.') }}</p>
+          <h2 class="good">{{_('Fly Free') }}</h2>
+          <p>{{_('Use the only browser built for freedom, not profit.') }}</p>
         </li>
       </ul>
     </section>


### PR DESCRIPTION
## Description
- Updates download page copy on scene 1 for en-US version of the page.

## Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1275770
