### PR TITLE
Disable call to Mozilla.Analytics.updateDataLayerPush due to test failure

### DIFF
--- a/media/js/base/core-datalayer-init.js
+++ b/media/js/base/core-datalayer-init.js
@@ -11,7 +11,5 @@ $(function() {
             'event': 'core-datalayer-loaded',
             'pageId': Mozilla.Analytics.getPageId()
         });
-
-        Mozilla.Analytics.updateDataLayerPush();
     }
 });


### PR DESCRIPTION
Since I merged this we've had 2 consecutive test failures in the pipeline:

https://ci.us-west.moz.works/job/bedrock_integration_tests_runner/6085/
https://ci.us-west.moz.works/job/bedrock_integration_tests_runner/6084/

I don't yet quite understand the failure, but I'm going to remove the call to it for now until I dig in deeper.