### PR TITLE
Skip thank you page test due to flakyness in the pipeline

### DIFF
--- a/tests/functional/firefox/new/test_thank_you.py
+++ b/tests/functional/firefox/new/test_thank_you.py
@@ -7,6 +7,7 @@ import pytest
 from pages.firefox.new.thank_you import ThankYouPage
 
 
+@pytest.mark.skipif(reason='https://ci.us-west.moz.works/job/bedrock_integration_tests_runner/6087/')
 @pytest.mark.skip_if_internet_explorer(reason='https://github.com/SeleniumHQ/selenium/issues/448')
 @pytest.mark.smoke
 @pytest.mark.sanity


### PR DESCRIPTION
@davehunt r?

https://ci.us-west.moz.works/job/bedrock_integration_tests_runner/6087/

I think this test is failing due to some kind of slight change in timing. It passes for me locally, and the page still works as expected when manual testing. But for some reason it is now failing in the pipeline. I need some time to try and figure it out and debug the issue, but for now I think we might need to skip this test :/