### PR TITLE
Re-enable skipped test and Analytics.updateDataLayerPush

### DIFF
--- a/media/js/base/core-datalayer-init.js
+++ b/media/js/base/core-datalayer-init.js
@@ -12,4 +12,6 @@ $(function() {
             'pageId': Mozilla.Analytics.getPageId()
         });
     }
+
+    Mozilla.Analytics.updateDataLayerPush();
 });

--- a/tests/functional/firefox/new/test_thank_you.py
+++ b/tests/functional/firefox/new/test_thank_you.py
@@ -7,7 +7,6 @@ import pytest
 from pages.firefox.new.thank_you import ThankYouPage
 
 
-@pytest.mark.skipif(reason='https://ci.us-west.moz.works/job/bedrock_integration_tests_runner/6087/')
 @pytest.mark.skip_if_internet_explorer(reason='https://github.com/SeleniumHQ/selenium/issues/448')
 @pytest.mark.smoke
 @pytest.mark.sanity


### PR DESCRIPTION
@davehunt r?

The last pipeline run was [green](https://ci.us-west.moz.works/view/Bedrock%20Pipeline/), so I think [Bug 1275978](https://bugzilla.mozilla.org/show_bug.cgi?id=1275978) may have been resolved. Going to try re-enabling this test and `updateDataLayerPush()` since I believe the failure was likely related to this bug (which explains the randomness of the sudden failure).

