### PR TITLE
[fix bug 1253001] Update partner submission page to use an email instead of salesforce

### DIFF
--- a/bedrock/mozorg/forms.py
+++ b/bedrock/mozorg/forms.py
@@ -498,9 +498,6 @@ class WebToLeadForm(forms.Form):
     )
     # honeypot
     office_fax = forms.CharField(widget=HoneyPotWidget, required=False)
-    # uncomment below to debug salesforce
-    # debug = forms.IntegerField(required=False)
-    # debugEmail = forms.EmailField(required=False)
 
     def __init__(self, *args, **kwargs):
         interest_set = kwargs.pop('interest_set', 'standard')

--- a/bedrock/mozorg/templates/mozorg/emails/partnerships.txt
+++ b/bedrock/mozorg/templates/mozorg/emails/partnerships.txt
@@ -1,0 +1,50 @@
+A new partnerships inquiry form has been submitted with the following information:
+----------------------------------------------------------------------------------
+
++ Firstname
+{{ first_name|bleach_tags|safe }}
+
++ Lastname
+{{ last_name|bleach_tags|safe }}
+
++ Title
+{{ title|bleach_tags|safe }}
+
++ Company
+{{ company|bleach_tags|safe }}
+
++ Website
+{{ URL|bleach_tags|safe }}
+
++ Email
+{{ email|bleach_tags|safe }}
+
++ Phone
+{{ phone|bleach_tags|safe }}
+
++ Mobile
+{{ mobile|bleach_tags|safe }}
+
++ Address
+{{ street|bleach_tags|safe }}
+
++ City
+{{ city|bleach_tags|safe }}
+
++ State / Province
+{{ state|bleach_tags|safe }}
+
++ Country
+{{ country|bleach_tags|safe }}
+
++ Zip
+{{ zip|bleach_tags|safe }}
+
++ Area of interest
+{{ interest|join(', ') }}
+
++ Description
+{{ description|bleach_tags|safe }}
+
++ Lead source
+{{ lead_source|bleach_tags|safe }}


### PR DESCRIPTION
## Description
- Update partner submission page to use an email instead of salesforce

## Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1253001

## Testing
https://bedrock-demo-agibson.us-west.moz.works/en-US/about/partnerships/

## Checklist
- [ ] Requires l10n changes.
- [x] Related functional & integration tests passing.