### PR TITLE
Fix ?v=1 firstrun onboarding test FxA iframe visibility

### DIFF
--- a/bedrock/settings/static_media.py
+++ b/bedrock/settings/static_media.py
@@ -359,6 +359,7 @@ PIPELINE_CSS = {
         'source_filenames': (
             'css/sandstone/sandstone.less',
             'css/tabzilla/tabzilla-static.less',
+            'css/base/mozilla-fxa-iframe.less',
             'css/firefox/onboarding/firstrun-fxa.less',
         ),
         'output_filename': 'css/firefox_onboarding_firstrun_fxa-bundle.css',


### PR DESCRIPTION
## Description

FxA iframe is invisible on https://www.mozilla.org/en-US/firefox/46.0.1/firstrun/?v=1 due to the bundle missing the newly created `mozilla-fxa-iframe.less` file.

## Bugzilla link

N/A

## Testing

Make sure above URL displays FxA iframe.

## Checklist
- [ ] Related functional & integration tests passing.

