### PR TITLE
[fix bug 1277964] Fix Stumbler app store link.

### DIFF
--- a/bedrock/mozorg/templates/mozorg/contribute/tasks/stumbler.html
+++ b/bedrock/mozorg/templates/mozorg/contribute/tasks/stumbler.html
@@ -19,7 +19,7 @@
       </header>
       <div class="step-content">
         {{ high_res_img('contribute/signup/stumbler.png', {'alt': '', 'width': '620', 'class': 'feature-img'}) }}
-        <a rel="external" class="stumbler-button" href="{{ settings.GOOGLE_PLAY_FIREFOX_LINK }}" target="_blank">
+        <a rel="external" class="stumbler-button" href="https://play.google.com/store/apps/details?id=org.mozilla.mozstumbler" target="_blank">
           {{ high_res_img('firefox/android/btn-google-play.png', {'alt': _('Get it on Google Play'), 'width': '152', 'height': '45', 'l10n': True, 'data-action': 'install', 'data-task': 'stumbler', 'data-step': 'one', 'data-complete': 'true'}) }}
         </a>
         <p>{{ _('<a href="%s" target="_blank">Learn more about Mozilla Location Services</a> and discover more ways to get involved.')|format('https://location.services.mozilla.com/') }}</p>


### PR DESCRIPTION
## Description

Point Play Store button to the Stumbler app instead of the Fx for Android app.

## Bugzilla link

https://bugzilla.mozilla.org/show_bug.cgi?id=1277964

## Testing

Make sure the link works?

