### PR TITLE
[fix bug 1275431] Add language switcher to product page footer

### DIFF
--- a/bedrock/firefox/templates/firefox/family/index.html
+++ b/bedrock/firefox/templates/firefox/family/index.html
@@ -173,6 +173,9 @@
 
     <ul>
       <li>
+        {% include 'includes/lang_switcher.html' %}
+      </li>
+      <li>
         <a href="{{ url('privacy') }}" data-link-type="footer" data-link-name="Privacy Policy">{{ _('Privacy Policy') }}</a>
       </li>
       <li>

--- a/media/css/firefox/family/index.less
+++ b/media/css/firefox/family/index.less
@@ -89,7 +89,7 @@
 
     .download-button {
         vertical-align: baseline;
-        
+
         .fx-privacy-link {
             display: none;
         }
@@ -608,6 +608,14 @@ html[dir='rtl'] {
             &:last-child:after {
                 content: '';
             }
+        }
+    }
+
+    form {
+        display: inline-block;
+
+        label {
+            color: @textColorTertiary;
         }
     }
 }


### PR DESCRIPTION
## Description
Adds our standard language switcher to the footer of /products

## Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1275431
