### PR TITLE
[fix bug 1278426] IE Download events broken in IE9 and below

### DIFF
--- a/media/js/base/core-datalayer.js
+++ b/media/js/base/core-datalayer.js
@@ -29,8 +29,9 @@ if (typeof Mozilla == 'undefined') {
     *   Adds href stripped of locale to link click objects when pushed to the dataLayer,
     *   also removes protocol and host if same as parent page from href.
     */
-    Analytics.updateDataLayerPush = function() {
+    Analytics.updateDataLayerPush = function(host) {
         var dataLayer = window.dataLayer = window.dataLayer || [];
+        var hostname = host || document.location.hostname;
 
         dataLayer.defaultPush = dataLayer.push;
         dataLayer.push = function() {
@@ -39,11 +40,13 @@ if (typeof Mozilla == 'undefined') {
                     var element = arguments[i]['gtm.element'];
                     var href = element.href;
 
-                    if (element.hostname === document.location.hostname) {
-                        var path = href.split(element.host)[1];
-                        var locale = path.split('/')[1];
+                    if (element.hostname === hostname) {
+                        // remove host and locale from internal links
+                        var path = href.replace(/^(?:https?\:\/\/)(?:[^\/])*/, '');
+                        var locale = path.match(/^(\/\w{2}\-\w{2}\/|\/\w{2,3}\/)/);
 
-                        arguments[i].newClickHref = path.replace('/' + locale, '');
+                        path = locale ? path.replace(locale[0], '/') : path;
+                        arguments[i].newClickHref = path;
                     } else {
                         arguments[i].newClickHref = href;
                     }
@@ -59,4 +62,3 @@ if (typeof Mozilla == 'undefined') {
     Mozilla.Analytics = Analytics;
 
 })();
-

--- a/tests/unit/spec/base/core-datalayer.js
+++ b/tests/unit/spec/base/core-datalayer.js
@@ -34,7 +34,6 @@ describe('core-datalayer.js', function() {
             linkElement = $('#link')[0];
 
             window.dataLayer = [];
-            Mozilla.Analytics.updateDataLayerPush();
         });
 
         afterEach(function() {
@@ -43,6 +42,8 @@ describe('core-datalayer.js', function() {
         });
 
         it('will add newClickHref property to link click object when pushed to the dataLayer', function() {
+            Mozilla.Analytics.updateDataLayerPush('www.allizom.org');
+
             window.dataLayer.push({
                 'event': 'gtm.linkClick',
                 'gtm.element': linkElement
@@ -52,6 +53,8 @@ describe('core-datalayer.js', function() {
         });
 
         it('will not add newClickHref property to object pushed to dataLayer if not a link click object', function() {
+            Mozilla.Analytics.updateDataLayerPush('www.allizom.org');
+
             window.dataLayer.push({
                 'event': 'gtm.click',
                 'gtm.element': linkElement
@@ -61,6 +64,8 @@ describe('core-datalayer.js', function() {
         });
 
         it('will keep host in newClickHref when clicked link\'s href host value is different thatn the page\'s', function() {
+            Mozilla.Analytics.updateDataLayerPush('www.allizom.org');
+
             window.dataLayer.push({
                 'event': 'gtm.linkClick',
                 'gtm.element': linkElement
@@ -69,8 +74,37 @@ describe('core-datalayer.js', function() {
             expect(window.dataLayer[0].newClickHref).toEqual('https://www.mozilla.org/en-US/firefox/new/');
         });
 
-        it('will remove host  and locale in newClickHref when clicked link\'s href value matches the page\'s', function() {
-            linkElement.host = document.location.host;
+        it('will remove host and locale in newClickHref when clicked link\'s href value matches the page\'s', function() {
+            Mozilla.Analytics.updateDataLayerPush('www.mozilla.org');
+
+            // Bug 1278426
+            linkElement.href = 'https://www.mozilla.org:443/en-US/firefox/new/';
+
+            window.dataLayer.push({
+                'event': 'gtm.linkClick',
+                'gtm.element': linkElement
+            });
+
+            expect(window.dataLayer[0].newClickHref).toEqual('/firefox/new/');
+        });
+
+        it('will remove host and non-en-US locale', function() {
+            Mozilla.Analytics.updateDataLayerPush('www.mozilla.org');
+
+            linkElement.href = 'https://www.mozilla.org:443/de/firefox/new/';
+
+            window.dataLayer.push({
+                'event': 'gtm.linkClick',
+                'gtm.element': linkElement
+            });
+
+            expect(window.dataLayer[0].newClickHref).toEqual('/firefox/new/');
+        });
+
+        it('will not remove locale if absent from the URL', function() {
+            Mozilla.Analytics.updateDataLayerPush('www.mozilla.org');
+
+            linkElement.href = 'https://www.mozilla.org/firefox/new/';
 
             window.dataLayer.push({
                 'event': 'gtm.linkClick',
@@ -81,5 +115,3 @@ describe('core-datalayer.js', function() {
         });
     });
 });
-
-


### PR DESCRIPTION
## Description
- Fixes a bug where internal links we're being reported incorrectly in IE9. I had trouble reproducing this locally, but James seems confident this should fix the issue.

## Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1278426

## Testing
Visit `/firefox/new` and click the download button. The `href` that gets passed in `Analytics.updateDataLayerPush()` should be `/firefox/new/?scene=2` (omitting the host and locale). The same applies to any internal link.

