### PR TITLE
Fix Bug 1255518 - Firefox download buttons: drop support for OS X 10.6-10.8, take 2

### DIFF
--- a/bedrock/firefox/helpers.py
+++ b/bedrock/firefox/helpers.py
@@ -177,6 +177,9 @@ def download_firefox(ctx, channel='release', platform='all',
     langs = firefox_desktop.languages
     locale_name = langs[locale]['native'] if locale in langs else locale
 
+    # Firefox 49+ requires OS X 10.9 Mavericks and later
+    mavericks_required = show_desktop and int(version.split('.', 1)[0]) >= 49
+
     data = {
         'locale_name': locale_name,
         'version': version,
@@ -189,6 +192,7 @@ def download_firefox(ctx, channel='release', platform='all',
         'show_ios': show_ios,
         'alt_copy': alt_copy,
         'button_color': button_color,
+        'mavericks_required': mavericks_required,
     }
 
     html = jingo.render_to_string(ctx['request'],

--- a/bedrock/firefox/templates/firefox/includes/download-button.html
+++ b/bedrock/firefox/templates/firefox/includes/download-button.html
@@ -19,6 +19,7 @@
 {% set download_class = download_class ~ ' download-button-android' if not (show_desktop or show_ios) else download_class %}
 {% set download_class = download_class ~ ' download-button-desktop' if not (show_android or show_ios) else download_class %}
 {% set download_class = download_class ~ ' download-button-ios' if not (show_desktop or show_android) else download_class %}
+{% set download_class = download_class ~ ' mavericks-required' if mavericks_required else download_class %}
 
 <div id="{{ id }}" class="{{ download_class }}">
   {# no JS #}
@@ -33,6 +34,9 @@
     </div>
     <p class="unsupported-download">
       {{ _("Your system doesn't meet the <a href=\"%(url)s\">requirements</a> to run Firefox.")|format(url=firefox_url('desktop', 'sysreq', channel)) }}
+    </p>
+    <p class="unsupported-download-osx">
+      {{ _("Your system doesn't meet the <a href=\"%(url)s\">requirements</a> to run Firefox.")|format(url='https://support.mozilla.org/kb/firefox-osx') }}
     </p>
     <p class="linux-arm-download">
       {{ _('Please follow <a href="%(url)s">these instructions</a> to install Firefox.')|format(url='https://support.mozilla.org/kb/install-firefox-linux') }}

--- a/media/css/sandstone/buttons.less
+++ b/media/css/sandstone/buttons.less
@@ -291,6 +291,7 @@ ul.download-list {
 .download-button .linux-arm-download,
 .download-button .unrecognized-download,
 .download-button .unsupported-download,
+.download-button .unsupported-download-osx,
 .download-button .nojs-download {
     display: none;
 }
@@ -319,7 +320,6 @@ ul.download-list {
 .linux .download-button .os_linux,
 .linux.x86.x64 .download-button .os_linux64,
 .windows .download-button .os_win,
-.osx .download-button .os_osx,
 .android .download-button .os_android,
 .download-button-android .os_android,
 .android .download-button-desktop .download-list,
@@ -333,6 +333,15 @@ ul.download-list {
     display: block !important;
 }
 
+// Add another rule for old browsers where :not isn't supported. If this is
+// mixed with the rule above, the entire rule will be invalid on those legacy
+// environments and some tests will fail.
+.osx:not(.pre-mavericks) .download-button .os_osx,
+.osx.pre-mavericks .download-button:not(.mavericks-required) .os_osx {
+    display: block !important;
+}
+
+.osx.pre-mavericks .download-button.mavericks-required .unsupported-download-osx,
 .windows.arm .download-button .unsupported-download,
 .linux.arm .download-button .linux-arm-download,
 .oldwin .download-button .unsupported-download,
@@ -342,6 +351,7 @@ ul.download-list {
 }
 
 // Hide the privacy link if platform is unsupported.
+.osx.pre-mavericks .download-button.mavericks-required .fx-privacy-link,
 .windows.arm .download-button .fx-privacy-link,
 .linux.arm .download-button .fx-privacy-link,
 .oldwin .download-button .fx-privacy-link,

--- a/media/js/base/site.js
+++ b/media/js/base/site.js
@@ -155,6 +155,13 @@
         } else {
             h.className = h.className.replace('windows', platform);
 
+            // Firefox 49 has dropped the support for OS X 10.6-10.8. Add a class name to show an unsupported platform
+            // message to people using those older versions. Once Firefox 49 hits the Release channel, update the
+            // "oldmac" platform detection above and remove this.
+            if (platform === 'osx' && version && version.match(/^10\.[678]$/)) {
+                h.className += ' pre-mavericks';
+            }
+
             // Add class to support downloading Firefox Aurora for Android Gingerbread
             if (platform === 'android' && version && parseFloat(version) === 2.3) {
                 h.className += ' gingerbread';


### PR DESCRIPTION
#4174 was reverted in #4179. This fixes the CSS rule as discussed on IRC.