### PR TITLE
[bug 1270316] Core DataLayer Additions

### DIFF
--- a/media/js/base/core-datalayer-init.js
+++ b/media/js/base/core-datalayer-init.js
@@ -4,14 +4,32 @@
 
 // init core dataLayer object and push into dataLayer
 $(function() {
-    if (Mozilla && Mozilla.Analytics) {
-        var dataLayer = window.dataLayer = window.dataLayer || [];
+    var analytics = Mozilla.Analytics;
+    var client = Mozilla.Client;
+    var dataLayer = window.dataLayer;
 
-        dataLayer.push({
+    function sendCoreDataLayer() {
+        var dataLayerCore = {
             'event': 'core-datalayer-loaded',
-            'pageId': Mozilla.Analytics.getPageId()
-        });
+            'pageId': analytics.getPageId(),
+            'pageHasDownload': analytics.pageHasDownload(),
+            'pageHasVideo': analytics.pageHasVideo(),
+            'pageVersion': analytics.getPageVersion(),
+            // white listed for www.mozill.org, will always return false on other domains
+            'testPilotUser': 'testpilotAddon' in navigator ? 'true' : 'false'
+        };
+
+        dataLayer.push(dataLayerCore);
     }
 
-    Mozilla.Analytics.updateDataLayerPush();
+    if (client.isFirefoxDesktop || client.isFirefoxAndroid) {
+        client.getFirefoxDetails(function(details) {
+            dataLayer.push(details);
+            sendCoreDataLayer();
+        });
+    } else {
+        sendCoreDataLayer();
+    }
+
+    analytics.updateDataLayerPush();
 });

--- a/media/js/base/core-datalayer.js
+++ b/media/js/base/core-datalayer.js
@@ -25,6 +25,33 @@ if (typeof Mozilla == 'undefined') {
         return pageId ? pageId : pathName.replace(/\/[^\/]*/, '');
     };
 
+    /** Returns whether page has download button.
+    * @param {String} path - URL path name fallback if page ID does not exist.
+    * @return {String} string.
+    */
+    Analytics.pageHasDownload = function() {
+        return $('[data-download-os]').length ? 'true' : 'false';
+    };
+
+    /** Returns whether page has video.
+    * @param {String} path - URL path name fallback if page ID does not exist.
+    * @return {String} string.
+    */
+    Analytics.pageHasVideo = function() {
+        return ($('video').length || $('iframe[src^="https://www.youtube"]').length) ? 'true' : 'false';
+    };
+
+    /** Returns page version.
+    * @param {String} path - URL path name fallback if page ID does not exist.
+    * @return {String} version number from URL.
+    */
+    Analytics.getPageVersion = function(path) {
+        var pathName = path ? path : document.location.pathname;
+        var versionResults = /firefox\/(\d+(?:\.\d+)?\.\da?\d?)/.exec(pathName);
+
+        return versionResults ? versionResults[1] : null;
+    };
+
     /** Monkey patch for dataLayer.push
     *   Adds href stripped of locale to link click objects when pushed to the dataLayer,
     *   also removes protocol and host if same as parent page from href.

--- a/media/js/base/mozilla-client.js
+++ b/media/js/base/mozilla-client.js
@@ -222,17 +222,6 @@ if (typeof Mozilla === 'undefined') {
             };
 
             callback(details);
-
-            // Log the info with GA. Remove this once we have sufficient data
-            window.dataLayer = window.dataLayer || [];
-            window.dataLayer.push({
-                'event': 'firefox-details-retrieved',
-                'accurate': accurate,
-                'version': version,
-                'channel': channel,
-                'isUpToDate': isUpToDate,
-                'isESR': isESR
-            });
         };
 
         // Prepare fallback function in case the API doesn't work
@@ -246,8 +235,8 @@ if (typeof Mozilla === 'undefined') {
             return;
         }
 
-        // Fire the fallback function in .3 seconds
-        var timer = window.setTimeout(fallback, 300);
+        // Fire the fallback function in .4 seconds
+        var timer = window.setTimeout(fallback, 400);
 
         // Trigger the API
         document.addEventListener('mozUITourResponse', listener);

--- a/media/js/base/mozilla-fxa-iframe.js
+++ b/media/js/base/mozilla-fxa-iframe.js
@@ -72,6 +72,7 @@ Mozilla.FxaIframe = (function() {
     };
 
     var _sendGAEvent = function(type, extra) {
+        var dataLayer = window.dataLayer || [];
         var data = {
             'event': _gaEventName, // user-configurable, defaults to 'fxa'
             'interaction': type
@@ -82,7 +83,7 @@ Mozilla.FxaIframe = (function() {
             $.extend(data, extra);
         }
 
-        window.dataLayer.push(data);
+        dataLayer.push(data);
     };
 
     var _userCallback = function(callbackName, data) {

--- a/tests/unit/spec/base/core-datalayer.js
+++ b/tests/unit/spec/base/core-datalayer.js
@@ -25,6 +25,66 @@ describe('core-datalayer.js', function() {
         });
     });
 
+    describe('pageHasDownload', function() {
+
+        afterEach(function() {
+            $('.download').remove();
+        });
+
+        it('will return "true" when download button is present on page.', function() {
+            var downloadMarkup = '<a class="download" href="#" data-link-type="download" data-download-os="Desktop">';
+
+            $(downloadMarkup).appendTo('body');
+            expect(Mozilla.Analytics.pageHasDownload()).toBe('true');
+        });
+
+        it('will return "false" when download button is not present on page.', function() {
+            expect(Mozilla.Analytics.pageHasDownload()).toBe('false');
+        });
+    });
+
+    describe('pageHasVideo', function() {
+
+        afterEach(function() {
+            $('#htmlPlayer').remove();
+            $('#iframePlayer').remove();
+        });
+
+        it('will return "true" when HTML5 video is present on page.', function() {
+            var videoMarkup = '<video id="htmlPlayer"></video>';
+
+            $(videoMarkup).appendTo('body');
+            expect(Mozilla.Analytics.pageHasVideo()).toBe('true');
+        });
+
+        it('will return "true" when YouTube iframe video is present on page.', function() {
+            var videoMarkup = '<iframe id="iframePlayer" src="https://www.youtube-nocookie.com/embed/NqxUdc0P6YE?rel=0"></iframe>';
+
+            $(videoMarkup).appendTo('body');
+            expect(Mozilla.Analytics.pageHasVideo()).toBe('true');
+        });
+
+        it('will return "false" when download button is not present on page.', function() {
+            expect(Mozilla.Analytics.pageHasVideo()).toBe('false');
+        });
+    });
+
+    describe('getPageVersion', function() {
+        it('will return the Firefox version number form the URL if present', function() {
+            expect(Mozilla.Analytics.getPageVersion('https://www.mozilla.org/en-US/firefox/107.0.11/firstrun/')).toBe('107.0.11');
+            expect(Mozilla.Analytics.getPageVersion('https://www.mozilla.org/en-US/firefox/46.0.1/firstrun/learnmore/')).toBe('46.0.1');
+            expect(Mozilla.Analytics.getPageVersion('https://www.mozilla.org/en-US/firefox/11.0/whatsnew/')).toBe('11.0');
+            expect(Mozilla.Analytics.getPageVersion('https://www.mozilla.org/en-US/firefox/46.0.1a2/firstrun/')).toBe('46.0.1a2');
+            expect(Mozilla.Analytics.getPageVersion('https://www.mozilla.org/en-US/firefox/46.0a1/whatsnew/')).toBe('46.0a1');
+        });
+
+        it('will return null if no version number present in URL', function() {
+            expect(Mozilla.Analytics.getPageVersion('https://www.mozilla.org/en-US/')).toBeNull();
+            expect(Mozilla.Analytics.getPageVersion('https://www.mozilla.org/en-US/firefox/new')).toBeNull();
+            expect(Mozilla.Analytics.getPageVersion('https://www.mozilla.org/en-US/firefox/whatsnew')).toBeNull();
+        });
+    });
+
     describe('updateDataLayerPush', function() {
         var linkElement;
 


### PR DESCRIPTION
## Description
Additions to the Core DataLayer Object, including making sure that the Firefox and plugin details have been pushed to the dataLayer before the Core DataLayer Object is pushed to ensure that data is available when a pageview is triggered.

## Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1270316


