### PR TITLE
[fix bug 1279222] Update GTM on homepage prototpye A.

### DIFF
--- a/bedrock/mozorg/templates/mozorg/home/home-a.html
+++ b/bedrock/mozorg/templates/mozorg/home/home-a.html
@@ -73,7 +73,7 @@
     <ul id="nav-page-primary" class="primary">
       <li id="nav-primary-action"><a href="#action" data-link-type="nav" data-link-name="Mozilla in Action"><span>{{ _('Mozilla In Action') }}</span></a></li>
       <li id="nav-primary-innovation"><a href="#innovation" data-link-type="nav" data-link-name="Web Innovation"><span>{{ _('Web Innovations') }}</span></a></li>
-      <li id="nav-primary-firefox"><a href="#firefox" data-link-type="nav" data-link-name="Firefox"><span>{{ _('Firefox') }}</span></a></li>
+      <li id="nav-primary-firefox"><a href="#firefox" data-link-type="nav" data-link-name="Firefox anchor"><span>{{ _('Firefox') }}</span></a></li>
     </ul>
 
     <ul id="nav-page-secondary" class="secondary">

--- a/media/js/mozorg/home/home-a.js
+++ b/media/js/mozorg/home/home-a.js
@@ -146,6 +146,9 @@
                     // highlight the appropriate nav item
                     $navPrimary.addClass('current');
 
+                    // remove ' anchor' text from data-link-name for scrolling event
+                    gtmSection = gtmSection.replace(/ anchor/, '');
+
                     // track scrolling to sections
                     window.dataLayer.push({
                         'event': 'scroll-section',


### PR DESCRIPTION
## Description

Update `data-link-name` attribute on Firefox in-page nav item to distinguish from Firefox primary nav item.

## Bugzilla link

https://bugzilla.mozilla.org/show_bug.cgi?id=1279222

## Testing

Can add the following after line 156 in `home-a.js` to verify correct value is being logged to GA on scroll:

```
console.log({
    'event': 'scroll-section',
    'section': gtmSection
});
```

On click, `data-link-name` and `data-link-type` are automatically transmitted to GTM.

## Checklist
- [ ] Related functional & integration tests passing.

