### PR TITLE
[fix bug 1281045] Remove 'hu' from send to device locales

### DIFF
--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -957,7 +957,7 @@ from .appstores import (GOOGLE_PLAY_FIREFOX_LINK,  # noqa
 # Locales that should display the 'Send to Device' widget
 SEND_TO_DEVICE_LOCALES = ['de', 'en-GB', 'en-US', 'en-ZA',
                           'es-AR', 'es-CL', 'es-ES', 'es-MX',
-                          'fr', 'hu', 'id', 'pl', 'pt-BR', 'ru']
+                          'fr', 'id', 'pl', 'pt-BR', 'ru']
 
 # Publishing system config
 RNA = {


### PR DESCRIPTION
## Description
- Removes 'hu' from the list of send to device locales.

## Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1281045

## Testing
- Verify that both `/hu/firefox/ios/` and `/hu/firefox/android/` should display app store badges instead of the send to device form.

 ## Checklist
- [ ] Requires l10n changes.
- [x] Related functional & integration tests passing.

