### PR TITLE
[fix bug 1281951] patent page title formatting

### DIFF
--- a/media/css/mozorg/about-patents.less
+++ b/media/css/mozorg/about-patents.less
@@ -13,6 +13,11 @@ ol li ol {
     margin-bottom: 0;
 }
 
+.title-shadow-box {
+    float: none;
+    margin: 0 0 @baseLine * 2;
+}
+
 #faq {
     .span(8);
 
@@ -37,7 +42,7 @@ ol li ol {
     }
 
     li {
-        display: inline;
+        display: inline-block;
         margin: 0 10px;
     }
 }


### PR DESCRIPTION
## Description
The red title box wasn't playing well with adjacent content. Looks like a minor regression, just needed some CSS fixes.

## Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1281951

