### PR TITLE
Fix Bug 1282173 - Changes to 2 Legal docs

### DIFF
--- a/bedrock/privacy/templates/privacy/notices/firefox.html
+++ b/bedrock/privacy/templates/privacy/notices/firefox.html
@@ -24,7 +24,8 @@
       {% endif %}
     </header>
     <div itemprop="articleBody">
-      {{ doc.select('body > section > section')|htmlattr(class='highlight accordion')|join|safe }}
+      {{ doc.select('body > section > section:nth-of-type(1)')|htmlattr(class='highlight accordion')|join|safe }}
+      {{ doc.select('body > section > section:nth-of-type(1) ~ *')|join|safe }}
     </div>
   </article>
 {% endblock %}


### PR DESCRIPTION
Modified a selector in the template to accommodate a new paragraph outside of the expanding "Things you should know" section, as [requested in the bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1282173#c1).