### PR TITLE
[fix bug 1282903] Swap system font for Open Sans on buttons.

### DIFF
--- a/media/css/sandstone/sandstone-resp.less
+++ b/media/css/sandstone/sandstone-resp.less
@@ -366,12 +366,18 @@ input[type=time] {
     border-width: 1px;
     @shadow: 0 1px rgba(255,255,255,0.5);
     .font-size(@smallFontSize);
-    font-family: inherit;
     padding: (@baseLine / 5)  (@baseLine / 2);
     .border-radius(3px);
     .box-shadow(@shadow);
     .transition(all linear .1s);
     line-height: 1.1;
+}
+
+button,
+input,
+select,
+textarea {
+    font-family: inherit; // must inherit or falls back to UA stylesheet/system font
 }
 
 textarea { height: auto; }

--- a/media/css/sandstone/sandstone.less
+++ b/media/css/sandstone/sandstone.less
@@ -333,6 +333,13 @@ input[type=tel] {
     .transition(all linear .1s);
 }
 
+button,
+input,
+select,
+textarea {
+    font-family: inherit; // must inherit or falls back to UA stylesheet/system font
+}
+
 textarea { height: auto; }
 
 textarea:focus,


### PR DESCRIPTION
## Description

Without a specific `font-family` set on `<input>` and `<button>` elements, the font falls back to that dictated by the UA stylesheet. It appears simply adding `font-family: inherit;` to the `.base-button` class fixes the issue.

## Bugzilla link

https://bugzilla.mozilla.org/show_bug.cgi?id=1282903

## Testing

Check instances of `class="button"`. Specific examples are:

- `/about/`
- `/firefox/ios/`
- `/firefox/ios/testflight/`
- `/firefox/new/?v=1` (with Fx)
- `/firefox/new/` (with up-to-date Fx)

## Checklist
- [ ] Related functional & integration tests passing.

