### PR TITLE
Don't generate headless tests when running IE SauceLabs jobs

### DIFF
--- a/docker/jenkins/properties/integration_tests/per_tag/ie6.properties
+++ b/docker/jenkins/properties/integration_tests/per_tag/ie6.properties
@@ -2,4 +2,4 @@ DRIVER=SauceLabs
 BROWSER_NAME=internet explorer
 BROWSER_VERSION=6.0
 PLATFORM=Windows XP
-MARK_EXPRESSION=sanity
+MARK_EXPRESSION=sanity and not headless

--- a/docker/jenkins/properties/integration_tests/per_tag/ie7.properties
+++ b/docker/jenkins/properties/integration_tests/per_tag/ie7.properties
@@ -2,4 +2,4 @@ DRIVER=SauceLabs
 BROWSER_NAME=internet explorer
 BROWSER_VERSION=7.0
 PLATFORM=Windows XP
-MARK_EXPRESSION=sanity
+MARK_EXPRESSION=sanity and not headless


### PR DESCRIPTION
This should avoid generating headless tests before collection when they're not needed. e.g:

https://ci.us-west.moz.works/job/bedrock_integration_tests_runner/6822/

