### PR TITLE
[fix bug 1283043] Add survey to en-US home page.

### DIFF
--- a/bedrock/mozorg/templates/mozorg/home/home-a.html
+++ b/bedrock/mozorg/templates/mozorg/home/home-a.html
@@ -270,6 +270,6 @@
   {% javascript 'home-a' %}
 
   {% if LANG == 'en-US' %}
-    {% include 'mozorg/home/includes/survey.html' %}
+    {% include 'mozorg/home/includes/survey-a.html' %}
   {% endif %}
 {% endblock %}

--- a/bedrock/mozorg/templates/mozorg/home/home.html
+++ b/bedrock/mozorg/templates/mozorg/home/home.html
@@ -46,6 +46,10 @@
     {% javascript 'matchmedia_addlistener' %}
   <![endif]-->
   {% javascript 'home' %}
+
+  {% if LANG == 'en-US' %}
+    {% include 'mozorg/home/includes/survey.html' %}
+  {% endif %}
 {% endblock %}
 
 {% block string_data %}

--- a/bedrock/mozorg/templates/mozorg/home/includes/survey-a.html
+++ b/bedrock/mozorg/templates/mozorg/home/includes/survey-a.html
@@ -1,0 +1,6 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+
+{% stylesheet 'home-survey' %}
+{% javascript 'home-survey-a' %}

--- a/bedrock/settings/static_media.py
+++ b/bedrock/settings/static_media.py
@@ -1478,9 +1478,17 @@ PIPELINE_JS = {
     # temporary bundle for survey on ?v=a homepage
     'home-survey': {
         'source_filenames': (
+            'js/mozorg/home/survey-generator.js',
             'js/mozorg/home/survey.js',
         ),
         'output_filename': 'js/home-survey-bundle.js',
+    },
+    'home-survey-a': {
+        'source_filenames': (
+            'js/mozorg/home/survey-generator.js',
+            'js/mozorg/home/survey-a.js',
+        ),
+        'output_filename': 'js/home-survey-bundle-a.js',
     },
     'history-slides': {
         'source_filenames': (

--- a/media/css/mozorg/home/survey.less
+++ b/media/css/mozorg/home/survey.less
@@ -30,7 +30,6 @@
 }
 
 .home-variant-a #survey-message {
-
     &.stuck {
         position: fixed;
         bottom: 0;

--- a/media/js/mozorg/home/survey-a.js
+++ b/media/js/mozorg/home/survey-a.js
@@ -11,8 +11,9 @@ if (typeof Mozilla === 'undefined') {
     'use strict';
 
     new Mozilla.Survey({
-        copyIntro: 'Hello! Would you be willing to take a minute to answer 2 questions for Mozilla?',
+        copyIntro: 'Hello! Would you be willing to take a minute to answer a few questions for Mozilla?',
         copyLink: 'Sure. I\'ll help.',
-        surveyURL: 'https://www.surveygizmo.com/s3/2890025/Help-us-by-sharing-your-feedback-about-Mozilla'
+        surveyURL: 'https://www.surveygizmo.com/s3/2841272/Brand-Perception-Survey-2016-Homepage-Prototype-A-bottom',
+        container: '#footer'
     });
 })(window.Mozilla);

--- a/media/js/mozorg/home/survey-generator.js
+++ b/media/js/mozorg/home/survey-generator.js
@@ -1,0 +1,26 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// create namespace
+if (typeof Mozilla === 'undefined') {
+    var Mozilla = {};
+}
+
+(function($) {
+    'use strict';
+
+    Mozilla.Survey = function(config) {
+        'use strict';
+
+        // make sure we have necessary info to display the survey
+        if (config.copyIntro && config.copyLink && config.surveyURL) {
+            // default to displaying survey at the top of the page
+            var $container = config.container ? $(config.container) : $('#strings');
+
+            var $message = $('<div id="survey-message"><span class="survey-invite">' + config.copyIntro + '</span><a class="survey-button" href="' + config.surveyURL + '">' + config.copyLink + '</a></div>');
+
+            $message.insertBefore($container);
+        }
+    };
+})(window.jQuery);


### PR DESCRIPTION
## Description

Add survey to current homepage for en-US, non-Firefox users.

## Bugzilla link

https://bugzilla.mozilla.org/show_bug.cgi?id=1283043

## Testing

Make sure survey displays on homepage for en-US, non-Fx users. Also ensure no regressions on homepage prototype A (`/?v=a`) survey.

## Checklist
- [ ] Related functional & integration tests passing.

