### PR TITLE
Skip partnerships form submission test

### DIFF
--- a/tests/functional/test_partnerships.py
+++ b/tests/functional/test_partnerships.py
@@ -8,6 +8,7 @@ from selenium.common.exceptions import TimeoutException
 from pages.partnerships import PartnershipsPage
 
 
+@pytest.mark.skipif(reason='Need to find a non-destructive solution for testing submission of form')
 @pytest.mark.nondestructive
 def test_request_partnership(base_url, selenium):
     page = PartnershipsPage(selenium, base_url).open()


### PR DESCRIPTION
## Description
- Skips the `/about/partnerships` form submission test since this is now routed to a Google Group and can't be filtered. When time allows I'd like to find a solution (similar to our basket functional tests perhaps) that allow us to non-destructively test this form so we don't lose coverage for this page.

