### PR TITLE
[Bug 1279463]

### DIFF
--- a/media/css/firefox/releasenotes-firefox.less
+++ b/media/css/firefox/releasenotes-firefox.less
@@ -571,6 +571,7 @@ ul.section-items {
        display: block;
     }
 }
+
 .non-firefox {
     .download-buttons .non-firefox-cta {
         display: block;

--- a/media/css/firefox/releasenotes-firefox.less
+++ b/media/css/firefox/releasenotes-firefox.less
@@ -566,8 +566,11 @@ ul.section-items {
         display: none;
     }
 }
-
-.windows,
+.firefox-old {
+    .download-buttons .firefox-old-cta {
+       display: block;
+    }
+}
 .non-firefox {
     .download-buttons .non-firefox-cta {
         display: block;

--- a/media/css/firefox/releasenotes-firefox.less
+++ b/media/css/firefox/releasenotes-firefox.less
@@ -566,11 +566,6 @@ ul.section-items {
         display: none;
     }
 }
-.firefox-old {
-    .download-buttons .firefox-old-cta {
-       display: block;
-    }
-}
 
 .windows,
 .non-firefox {


### PR DESCRIPTION
## Description
**[Bug 1279463] - [windows] Two download buttons displayed in release notes footer**
## Bugzilla link
*https://bugzilla.mozilla.org/show_bug.cgi?id=1279463*
## Testing

## Checklist
- [ ] Requires l10n changes.
- [ ] Related functional & integration tests passing.

