### PR TITLE
[fix bug 1275629] Add survey to home prototype B.

### DIFF
--- a/bedrock/mozorg/templates/mozorg/home/home-b.html
+++ b/bedrock/mozorg/templates/mozorg/home/home-b.html
@@ -262,4 +262,7 @@
 
 {% block js %}
   {% javascript 'home-b' %}
+
+  {# survey is en-US only - enforced via optimizely audience segmentation #}
+  {% include 'mozorg/home/includes/survey-b.html' %}
 {% endblock %}

--- a/bedrock/mozorg/templates/mozorg/home/includes/survey-b.html
+++ b/bedrock/mozorg/templates/mozorg/home/includes/survey-b.html
@@ -1,0 +1,6 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+
+{% stylesheet 'home-survey' %}
+{% javascript 'home-survey-b' %}

--- a/bedrock/settings/static_media.py
+++ b/bedrock/settings/static_media.py
@@ -1471,6 +1471,7 @@ PIPELINE_JS = {
     },
     'home-b': {
         'source_filenames': (
+            'js/libs/jquery.waypoints.min.js',
             'js/mozorg/home/home-b.js',
         ),
         'output_filename': 'js/home_b-bundle.js',
@@ -1489,6 +1490,13 @@ PIPELINE_JS = {
             'js/mozorg/home/survey-a.js',
         ),
         'output_filename': 'js/home-survey-bundle-a.js',
+    },
+    'home-survey-b': {
+        'source_filenames': (
+            'js/mozorg/home/survey-generator.js',
+            'js/mozorg/home/survey-b.js',
+        ),
+        'output_filename': 'js/home-survey-bundle-b.js',
     },
     'history-slides': {
         'source_filenames': (

--- a/media/css/mozorg/home/survey.less
+++ b/media/css/mozorg/home/survey.less
@@ -29,13 +29,15 @@
     }
 }
 
-.home-variant-a #survey-message {
+.home-variant #survey-message {
     &.stuck {
         position: fixed;
         bottom: 0;
         z-index: 90;
     }
+}
 
+.home-variant-a #survey-message {
     @media only @mq-tablet and (min-height: 500px) {
         padding-left: 260px;
     }

--- a/media/js/mozorg/home/home-b.js
+++ b/media/js/mozorg/home/home-b.js
@@ -2,10 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-(function($) {
+(function($, Waypoint) {
     'use strict';
 
     var mozClient = window.Mozilla.Client;
+
+    var surveyWaypoint;
+    var $surveyMsg;
 
     var $toggleInnovate = $('.toggle-innovate');
     var $toggleWho = $('.toggle-who');
@@ -18,6 +21,24 @@
             'event': 'widget-action',
             'widget-name': name,
             'widget-action': action
+        });
+    }
+
+    function enableWaypoints() {
+        surveyWaypoint = new Waypoint({
+            element: '#firefox',
+            handler: function(direction) {
+                if (direction === 'down') {
+                    // slide up when scrolling down
+                    $surveyMsg.addClass('stuck').css({ bottom: '-90px' }).animate({ bottom: '0' }, 500);
+                } else if (direction === 'up') {
+                    // slide down when scrolling up, then unstick
+                    $surveyMsg.animate({ bottom: '-90px' }, 500, function() {
+                        $surveyMsg.removeClass('stuck');
+                    });
+                }
+            },
+            offset: '60%'
         });
     }
 
@@ -45,4 +66,34 @@
 
         trackCollapseExpand('Our Innovations', $innovate.hasClass('open') ? 'Expose' : 'Close');
     });
-})(window.jQuery);
+
+    // set up waypoints if survey is present & media queries supported
+    // must be in doc.ready as #survey-message is added in another script
+    $(function() {
+        var mqIsTablet;
+
+        // test for matchMedia
+        if ('matchMedia' in window) {
+            mqIsTablet = matchMedia('(min-width: 760px)');
+        }
+
+        $surveyMsg = $('#survey-message');
+
+        if ($surveyMsg.length && mqIsTablet) {
+            if (mqIsTablet.matches) {
+                enableWaypoints();
+            }
+
+            mqIsTablet.addListener(function(mq) {
+                if (mq.matches) {
+                    enableWaypoints();
+                } else {
+                    surveyWaypoint.destroy();
+
+                    // reset survey positioning
+                    $surveyMsg.css('bottom', '-90px').removeClass('stuck');
+                }
+            });
+        }
+    });
+})(window.jQuery, window.Waypoint);

--- a/media/js/mozorg/home/survey-b.js
+++ b/media/js/mozorg/home/survey-b.js
@@ -1,0 +1,19 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// create namespace
+if (typeof Mozilla === 'undefined') {
+    var Mozilla = {};
+}
+
+(function(Mozilla) {
+    'use strict';
+
+    new Mozilla.Survey({
+        copyIntro: 'Hello! Would you be willing to take a minute to answer a few questions for Mozilla?',
+        copyLink: 'Sure. I\'ll help.',
+        surveyURL: 'https://www.surveygizmo.com/s3/2900951/Help-us-by-sharing-your-feedback-about-Mozilla',
+        container: '#footer'
+    });
+})(window.Mozilla);


### PR DESCRIPTION
## Description

Adds a survey to homepage prototype B. 

## Bugzilla link

https://bugzilla.mozilla.org/show_bug.cgi?id=1275629#c15

## Testing

Survey should appear after scrolling to the Firefox section. Survey should not be shown below 760px wide. Make sure no regressions on prototype A survey.

## Checklist
- [ ] Related functional & integration tests passing.

