### PR TITLE
WIP [fix bug 1287200] Begin restricting JS served to old IE.

### DIFF
--- a/bedrock/base/templates/base-resp.html
+++ b/bedrock/base/templates/base-resp.html
@@ -168,7 +168,7 @@
       The logic mess below will be simplified when all pages are refactored
       to behave well in old IE without page-specific JS.
     #}
-    {% if OLDIEJS != True %}
+    {% if force_modern_js != True %}
       {#
         Unless specifically requested by current page, hide first-class
         & page-specific JS from IE 8 and below.
@@ -179,7 +179,7 @@
       {% javascript 'common' %}
     {% endblock %}
     {% block js %}{% endblock %}
-    {% if OLDIEJS != True %}
+    {% if force_modern_js != True %}
       <!--<![endif]-->
 
       {#

--- a/bedrock/base/templates/base-resp.html
+++ b/bedrock/base/templates/base-resp.html
@@ -161,13 +161,36 @@
     </div><!-- close #outer-wrapper -->
 
     <!--[if IE 9]>
-      <script src="{{ static('js/libs/matchMedia.js') }}"></script>
+      {% javascript 'matchmedia' %}
     <![endif]-->
 
+    {#
+      The logic mess below will be simplified when all pages are refactored
+      to behave well in old IE without page-specific JS.
+    #}
+    {% if OLDIEJS != True %}
+      {#
+        Unless specifically requested by current page, hide first-class
+        & page-specific JS from IE 8 and below.
+      #}
+      <!--[if !lte IE 8]><!-->
+    {% endif %}
     {% block site_js %}
       {% javascript 'common' %}
     {% endblock %}
     {% block js %}{% endblock %}
+    {% if OLDIEJS != True %}
+      <!--<![endif]-->
+
+      {#
+        Give old IE a slimmed down bundle with only jQuery, global, and
+        GTM scripts.
+      #}
+      <!--[if lte IE 8]>
+        {% javascript 'common-oldie' %}
+      <![endif]-->
+    {% endif %}
+
     {% if settings.DEV %}
       <script src="https://pontoon.mozilla.org/pontoon.js"></script>
     {% endif %}

--- a/bedrock/base/templates/base-resp.html
+++ b/bedrock/base/templates/base-resp.html
@@ -164,32 +164,18 @@
       {% javascript 'matchmedia' %}
     <![endif]-->
 
-    {#
-      The logic mess below will be simplified when all pages are refactored
-      to behave well in old IE without page-specific JS.
-    #}
-    {% if force_modern_js != True %}
-      {#
-        Unless specifically requested by current page, hide first-class
-        & page-specific JS from IE 8 and below.
-      #}
-      <!--[if !lte IE 8]><!-->
-    {% endif %}
-    {% block site_js %}
-      {% javascript 'common' %}
-    {% endblock %}
-    {% block js %}{% endblock %}
-    {% if force_modern_js != True %}
-      <!--<![endif]-->
+    {# Serve first-class & page-specified JS to IE 9 and up #}
+    <!--[if !lte IE 8]><!-->
+      {% block site_js %}
+        {% javascript 'common' %}
+      {% endblock %}
+      {% block js %}{% endblock %}
+    <!--<![endif]-->
 
-      {#
-        Give old IE a slimmed down bundle with only jQuery, global, and
-        GTM scripts.
-      #}
-      <!--[if lte IE 8]>
-        {% javascript 'common-oldie' %}
-      <![endif]-->
-    {% endif %}
+    {# Serve minimal JS to IE 8 and below #}
+    <!--[if lte IE 8]>
+      {% javascript 'common-oldie' %}
+    <![endif]-->
 
     {% if settings.DEV %}
       <script src="https://pontoon.mozilla.org/pontoon.js"></script>

--- a/bedrock/base/templates/base.html
+++ b/bedrock/base/templates/base.html
@@ -150,7 +150,7 @@
       The logic mess below will be simplified when all pages are refactored
       to behave well in old IE without page-specific JS.
     #}
-    {% if OLDIEJS != True %}
+    {% if force_modern_js != True %}
       {#
         Unless specifically requested by current page, hide first-class
         & page-specific JS from IE 8 and below.
@@ -161,7 +161,7 @@
       {% javascript 'common' %}
     {% endblock %}
     {% block js %}{% endblock %}
-    {% if OLDIEJS != True %}
+    {% if force_modern_js != True %}
       <!--<![endif]-->
 
       {#

--- a/bedrock/base/templates/base.html
+++ b/bedrock/base/templates/base.html
@@ -146,10 +146,33 @@
 
     </div><!-- close #outer-wrapper -->
 
+    {#
+      The logic mess below will be simplified when all pages are refactored
+      to behave well in old IE without page-specific JS.
+    #}
+    {% if OLDIEJS != True %}
+      {#
+        Unless specifically requested by current page, hide first-class
+        & page-specific JS from IE 8 and below.
+      #}
+      <!--[if !lte IE 8]><!-->
+    {% endif %}
     {% block site_js %}
       {% javascript 'common' %}
     {% endblock %}
     {% block js %}{% endblock %}
+    {% if OLDIEJS != True %}
+      <!--<![endif]-->
+
+      {#
+        Give old IE a slimmed down bundle with only jQuery, global, and
+        GTM scripts.
+      #}
+      <!--[if lte IE 8]>
+        {% javascript 'common-oldie' %}
+      <![endif]-->
+    {% endif %}
+
     {% if settings.DEV %}
       <script src="https://pontoon.mozilla.org/pontoon.js"></script>
     {% endif %}

--- a/bedrock/base/templates/includes/lang_switcher.html
+++ b/bedrock/base/templates/includes/lang_switcher.html
@@ -19,8 +19,6 @@
       <option lang="{{ code }}" value="{{ code }}"{{ code|ifeq(LANG, " selected") }}>{{ label|safe|replace('English (US)', 'English') }}</option>
     {% endfor %}
   </select>
-  <noscript>
-    <button type="submit">{{ _('Go') }}</button>
-  </noscript>
+  <button type="submit" id="lang_form_submit">{{ _('Go') }}</button>
 </form>
 {% endif %}

--- a/bedrock/base/templates/macros.html
+++ b/bedrock/base/templates/macros.html
@@ -147,14 +147,6 @@
     'js/libs/jquery.waypoints-sticky.min.js',
     'js/firefox/family-nav.js',
 
-  c. IE 9
-    IE 9 requires the matchMedia.addListener polyfill. If your page doesn't
-    already have a specific IE 9 bundle, you can use the generic one:
-
-    <!--[if IE 9]>
-    {% javascript 'matchmedia_addlistener' %}
-    <![endif]-->
-
 
 
   ## Notes on CTA:
@@ -295,14 +287,6 @@
     'js/libs/jquery.waypoints.min.js',
     'js/libs/jquery.waypoints-sticky.min.js',
     'js/firefox/fxos-nav.js',
-
-  c. IE 9
-    IE 9 requires the matchMedia.addListener polyfill. If your page doesn't
-    already have a specific IE 9 bundle, you can use the generic one:
-
-    <!--[if IE 9]>
-    {% javascript 'matchmedia_addlistener' %}
-    <![endif]-->
 
 
 

--- a/bedrock/firefox/templates/firefox/android/index.html
+++ b/bedrock/firefox/templates/firefox/android/index.html
@@ -406,8 +406,5 @@
 {% endblock %}
 
 {% block js %}
-<!--[if IE 9]>
-  {% javascript 'matchmedia_addlistener' %}
-<![endif]-->
   {% javascript 'firefox_android' %}
 {% endblock %}

--- a/bedrock/firefox/templates/firefox/desktop/customize.html
+++ b/bedrock/firefox/templates/firefox/desktop/customize.html
@@ -255,8 +255,5 @@
 {% endblock %}
 
 {% block js %}
-  <!--[if IE 9]>
-  {% javascript 'matchmedia_addlistener' %}
-  <![endif]-->
   {% javascript 'firefox_desktop_customize' %}
 {% endblock %}

--- a/bedrock/firefox/templates/firefox/desktop/fast.html
+++ b/bedrock/firefox/templates/firefox/desktop/fast.html
@@ -112,8 +112,5 @@
 {% endblock %}
 
 {% block js %}
-  <!--[if IE 9]>
-  {% javascript 'matchmedia_addlistener' %}
-  <![endif]-->
   {% javascript 'firefox_desktop_fast' %}
 {% endblock %}

--- a/bedrock/firefox/templates/firefox/desktop/index.html
+++ b/bedrock/firefox/templates/firefox/desktop/index.html
@@ -169,8 +169,5 @@
 {% endblock %}
 
 {% block js %}
-  <!--[if IE 9]>
-  {% javascript 'matchmedia_addlistener' %}
-  <![endif]-->
   {% javascript 'firefox_desktop_index' %}
 {% endblock %}

--- a/bedrock/firefox/templates/firefox/desktop/trust.html
+++ b/bedrock/firefox/templates/firefox/desktop/trust.html
@@ -167,8 +167,5 @@
 {% endblock %}
 
 {% block js %}
-  <!--[if IE 9]>
-  {% javascript 'matchmedia_addlistener' %}
-  <![endif]-->
   {% javascript 'firefox_desktop_trust' %}
 {% endblock %}

--- a/bedrock/firefox/templates/firefox/dnt.html
+++ b/bedrock/firefox/templates/firefox/dnt.html
@@ -266,9 +266,6 @@
 {% endblock %}
 
 {% block js %}
-  <!--[if IE 9]>
-  {% javascript 'matchmedia_addlistener' %}
-  <![endif]-->
   {% javascript 'dnt' %}
 {% endblock %}
 

--- a/bedrock/firefox/templates/firefox/family/index.html
+++ b/bedrock/firefox/templates/firefox/family/index.html
@@ -25,7 +25,7 @@
 {% block site_header %}
   <div id="conditional-download-bar" class="infobar">
     <div class="content">
-      <div class="message" id="dlbar-oldfx-desktop">
+      <div class="hidden message" id="dlbar-oldfx-desktop">
         {{ _('You’re using an older version of Firefox for desktop.') }}
         {{ _('Update today to stay fast and safe.') }}
         {{ download_firefox(alt_copy=_('Download'), dom_id='download-button-old-fx') }}
@@ -35,16 +35,16 @@
         {{ _('Choose Firefox.') }}
         {{ download_firefox(alt_copy=_('Download'), dom_id='download-button-non-fx') }}
       </div>
-      <div class="message" id="dlbar-nonfx-android">
+      <div class="hidden message" id="dlbar-nonfx-android">
         <a rel="external" href="{{ settings.GOOGLE_PLAY_FIREFOX_LINK }}" data-link-type="download" data-download-os="Android">{{ _('Get Firefox for Android') }}</a>
       </div>
-      <div class="message" id="dlbar-ios">
+      <div class="hidden message" id="dlbar-ios">
       {% if l10n_has_tag('tracking_protection') %}
         <a rel="external" href="{{ firefox_ios_url() }}" data-link-type="download" data-download-os="iOS">{{ _('Get Firefox for iOS') }}</a>
       {% endif %}
       </div>
 
-      <button type="button" class="btn-close button" title="{{ _('Close') }}">{{ _('Close') }}</button>
+      <button type="button" class="btn-close button hidden" title="{{ _('Close') }}">{{ _('Close') }}</button>
     </div>{#-- /.content --#}
   </div>{#-- /#conditional-download-bar --#}
   <header id="masthead">

--- a/bedrock/firefox/templates/firefox/interest-dashboard.html
+++ b/bedrock/firefox/templates/firefox/interest-dashboard.html
@@ -152,8 +152,5 @@ We will continue to add features in future versions that will make you know more
 {% block dashboard_sidebar %}{% endblock %}
 
 {% block js %}
-  <!--[if IE 9]>
-  {% javascript 'matchmedia_addlistener' %}
-  <![endif]-->
   {% javascript 'firefox_interest_dashboard' %}
 {% endblock %}

--- a/bedrock/firefox/templates/firefox/ios.html
+++ b/bedrock/firefox/templates/firefox/ios.html
@@ -22,6 +22,8 @@
   {% stylesheet 'firefox_ios' %}
 {% endblock %}
 
+{% set has_widget = LANG in settings.SEND_TO_DEVICE_LOCALES %}
+
 {% block site_header %}
   {% call fxfamilynav('ios') %}
     <div class="{% if has_widget %}show-widget{% endif %}">
@@ -32,8 +34,6 @@
     </div>
   {% endcall %}
 {% endblock %}
-
-{% set has_widget = LANG in settings.SEND_TO_DEVICE_LOCALES %}
 
 {% block content %}
 <section class="section section-intro" id="intro">
@@ -51,7 +51,9 @@
         <a href="{{ firefox_ios_url('mozorg-ios_page-appstore-button') }}" data-link-type="download" data-download-os="iOS"><img src="{{ l10n_img('firefox/ios/btn-app-store.svg') }}" alt="{{ _('Download on the App Store') }}"></a>
       </p>
 
-      {{ send_to_device(platform='ios', title_text=_('Send Firefox to your iOS device'), ios_link=firefox_ios_url('mozorg-ios_page-appstore-button_sd'), spinner_color='#fff') }}
+      <div id="send-to-device-wrapper" class="hidden">
+        {{ send_to_device(platform='ios', title_text=_('Send Firefox to your iOS device'), ios_link=firefox_ios_url('mozorg-ios_page-appstore-button_sd'), spinner_color='#fff') }}
+      </div>
     </div>
 
     <p class="android-link">
@@ -89,12 +91,12 @@
         <p>{{ _('Already have an account?') }} <a href="https://support.mozilla.org/kb/how-do-i-set-up-firefox-sync" class="go">{{ _('Sign in') }}</a></p>
       </div>
 
-      <div class="fx-signed-in">
+      <div class="fx-signed-in hidden">
         <h3>{{ _('You’re already signed in!') }}</h3>
         <p><a href="{{ url('firefox.sync') }}" class="go" data-link-type="button" data-link-name="Learn more about Sync" data-cta-position="Secondary">{{ _('Learn more about Sync') }}</a></p>
       </div>
 
-      <div class="fx-ios">
+      <div class="fx-ios hidden">
         <h3>{{ _('Sync your Firefox browsing history on iOS') }}</h3>
         <p><button type="button" class="button sync-start-ios" data-button-name="Get started with Sync" data-cta-position="Secondary">{{ _('Get started with Sync') }}</button></p>
         <p><a href="{{ firefox_ios_url() }}" class="go">{{ _('Learn more in the App Store') }}</a></p>
@@ -135,7 +137,7 @@
 </section>
 {% endif %}
 
-<aside id="sync-instructions">
+<aside id="sync-instructions" class="hidden">
   <h4>{{ _('Get started with Sync') }}</h4>
   <p>{{ _('First tap the <b>tab</b> button. Then tap the %(gear_icon)s icon to start using Sync.') | format(gear_icon=high_res_img('firefox/ios/gear-icon.png', {'alt': '', 'width': '20', 'height': '20'})|safe) }}</p>
   <p><button type="button" class="btn-dismiss">{{ _('Not now') }}</button></p>
@@ -159,8 +161,5 @@
 {% endblock %}
 
 {% block js %}
-  <!--[if IE 9]>
-    {% javascript 'matchmedia_addlistener' %}
-  <![endif]-->
   {% javascript 'firefox_ios' %}
 {% endblock %}

--- a/bedrock/firefox/templates/firefox/os/devices.html
+++ b/bedrock/firefox/templates/firefox/os/devices.html
@@ -2875,8 +2875,5 @@
 {% endblock %}
 
 {% block js %}
-  <!--[if IE 9]>
-  {% javascript 'matchmedia_addlistener' %}
-  <![endif]-->
   {% javascript 'firefox_os_devices' %}
 {% endblock %}

--- a/bedrock/firefox/templates/firefox/os/index.html
+++ b/bedrock/firefox/templates/firefox/os/index.html
@@ -125,8 +125,5 @@
 {% block email_form %}{% endblock %}
 
 {% block js %}
-<!--[if IE 9]>
-  {% javascript 'matchmedia_addlistener' %}
-<![endif]-->
   {% javascript 'firefox_os_2_5' %}
 {% endblock %}

--- a/bedrock/firefox/templates/firefox/os/mwc-2015-preview.html
+++ b/bedrock/firefox/templates/firefox/os/mwc-2015-preview.html
@@ -202,8 +202,5 @@
 {% endblock %}
 
 {% block js %}
-  <!--[if IE 9]>
-  {% javascript 'matchmedia_addlistener' %}
-  <![endif]-->
   {% javascript 'firefox_os_mwc_2015_preview' %}
 {% endblock %}

--- a/bedrock/firefox/templates/firefox/private-browsing.html
+++ b/bedrock/firefox/templates/firefox/private-browsing.html
@@ -167,8 +167,5 @@
 {% block email_form %}{% endblock %}
 
 {% block js %}
-  <!--[if IE 9]>
-    {% javascript 'matchmedia_addlistener' %}
-  <![endif]-->
   {% javascript 'firefox_private_browsing' %}
 {% endblock %}

--- a/bedrock/firefox/templates/firefox/sync.html
+++ b/bedrock/firefox/templates/firefox/sync.html
@@ -263,8 +263,5 @@
 {% endblock %}
 
 {% block js %}
-  <!--[if IE 9]>
-    {% javascript 'matchmedia_addlistener' %}
-  <![endif]-->
   {% javascript 'firefox_sync' %}
 {% endblock %}

--- a/bedrock/firefox/urls.py
+++ b/bedrock/firefox/urls.py
@@ -31,7 +31,7 @@ urlpatterns = (
     url(r'^firefox/(?:%s/)?(?:%s/)?all/$' % (platform_re, channel_re),
         views.all_downloads, name='firefox.all'),
     page('firefox/accounts', 'firefox/accounts.html'),
-    page('firefox/channel', 'firefox/channel.html'),
+    page('firefox/channel', 'firefox/channel.html', OLDIEJS=True),
     redirect('^firefox/channel/android/$', 'firefox.channel', locale_prefix=False),
     page('firefox/desktop', 'firefox/desktop/index.html'),
     page('firefox/desktop/fast', 'firefox/desktop/fast.html'),

--- a/bedrock/firefox/urls.py
+++ b/bedrock/firefox/urls.py
@@ -31,7 +31,7 @@ urlpatterns = (
     url(r'^firefox/(?:%s/)?(?:%s/)?all/$' % (platform_re, channel_re),
         views.all_downloads, name='firefox.all'),
     page('firefox/accounts', 'firefox/accounts.html'),
-    page('firefox/channel', 'firefox/channel.html', OLDIEJS=True),
+    page('firefox/channel', 'firefox/channel.html'),
     redirect('^firefox/channel/android/$', 'firefox.channel', locale_prefix=False),
     page('firefox/desktop', 'firefox/desktop/index.html'),
     page('firefox/desktop/fast', 'firefox/desktop/fast.html'),

--- a/bedrock/foundation/templates/foundation/annualreport/2011.html
+++ b/bedrock/foundation/templates/foundation/annualreport/2011.html
@@ -16,9 +16,6 @@
 {% endblock %}
 
 {% block js %}
-  <!--[if IE 9]>
-    {% javascript 'matchmedia_addlistener' %}
-  <![endif]-->
   {% javascript 'annual_2011' %}
 {% endblock %}
 

--- a/bedrock/mozorg/templates/mozorg/about/policy/transparency/index.html
+++ b/bedrock/mozorg/templates/mozorg/about/policy/transparency/index.html
@@ -12,9 +12,6 @@
 {% endblock %}
 
 {% block js %}
-  <!--[if IE 9]>
-  {% javascript 'matchmedia_addlistener' %}
-  <![endif]-->
   {% javascript 'about-transparency' %}
 {% endblock %}
 

--- a/bedrock/mozorg/templates/mozorg/about/policy/transparency/report-base.html
+++ b/bedrock/mozorg/templates/mozorg/about/policy/transparency/report-base.html
@@ -12,9 +12,6 @@
 {% endblock %}
 
 {% block js %}
-  <!--[if IE 9]>
-  {% javascript 'matchmedia_addlistener' %}
-  <![endif]-->
   {% javascript 'about-transparency' %}
 {% endblock %}
 

--- a/bedrock/mozorg/views.py
+++ b/bedrock/mozorg/views.py
@@ -262,7 +262,7 @@ def home(request, template='mozorg/home/home.html'):
 
     return l10n_utils.render(
         request, template, {
-            'OLDIEJS': True,
+            'force_modern_js': True,
             'has_contribute': lang_file_is_active('mozorg/contribute'),
             'tweets': home_tweets(locale),
             'mobilizer_link': settings.MOBILIZER_LOCALE_LINK.get(

--- a/bedrock/mozorg/views.py
+++ b/bedrock/mozorg/views.py
@@ -262,6 +262,7 @@ def home(request, template='mozorg/home/home.html'):
 
     return l10n_utils.render(
         request, template, {
+            'OLDIEJS': True,
             'has_contribute': lang_file_is_active('mozorg/contribute'),
             'tweets': home_tweets(locale),
             'mobilizer_link': settings.MOBILIZER_LOCALE_LINK.get(

--- a/bedrock/settings/static_media.py
+++ b/bedrock/settings/static_media.py
@@ -963,7 +963,7 @@ PIPELINE_JS = {
     # bundle should offset the extra weight.
     'common': {
         'source_filenames': (
-            'js/libs/jquery-1.11.3.min.js', # can now upgrade to jQuery 3?
+            'js/libs/jquery-1.11.3.min.js',  # can now upgrade to jQuery 3?
             'js/libs/spin.min.js',  # used by js/newsletter/form.js
             'js/base/global.js',
             'js/base/global-init.js',
@@ -978,7 +978,7 @@ PIPELINE_JS = {
     },
     'common-oldie': {
         'source_filenames': (
-            'js/libs/jquery-1.11.3.min.js', # upgrade to jQuery 1.12?
+            'js/libs/jquery-1.11.3.min.js',  # upgrade to jQuery 1.12?
             # will need to make sure scripts below are compatible with jQuery 1.12 & 3?
             'js/base/global.js',
             'js/base/global-init.js',

--- a/bedrock/settings/static_media.py
+++ b/bedrock/settings/static_media.py
@@ -980,9 +980,6 @@ PIPELINE_JS = {
         'source_filenames': (
             'js/libs/jquery-1.11.3.min.js',  # upgrade to jQuery 1.12?
             # will need to make sure scripts below are compatible with jQuery 1.12 & 3?
-            'js/base/global.js',
-            'js/base/global-init.js',
-            'js/base/mozilla-client.js',
             'js/base/core-datalayer.js',
             'js/base/core-datalayer-init.js',
         ),

--- a/bedrock/settings/static_media.py
+++ b/bedrock/settings/static_media.py
@@ -963,7 +963,7 @@ PIPELINE_JS = {
     # bundle should offset the extra weight.
     'common': {
         'source_filenames': (
-            'js/libs/jquery-1.11.3.min.js',
+            'js/libs/jquery-1.11.3.min.js', # can now upgrade to jQuery 3?
             'js/libs/spin.min.js',  # used by js/newsletter/form.js
             'js/base/global.js',
             'js/base/global-init.js',
@@ -975,6 +975,18 @@ PIPELINE_JS = {
             'js/base/core-datalayer-init.js',
         ),
         'output_filename': 'js/common-bundle.js',
+    },
+    'common-oldie': {
+        'source_filenames': (
+            'js/libs/jquery-1.11.3.min.js', # upgrade to jQuery 1.12?
+            # will need to make sure scripts below are compatible with jQuery 1.12 & 3?
+            'js/base/global.js',
+            'js/base/global-init.js',
+            'js/base/mozilla-client.js',
+            'js/base/core-datalayer.js',
+            'js/base/core-datalayer-init.js',
+        ),
+        'output_filename': 'js/common-oldie-bundle.js',
     },
     'contact-spaces': {
         'source_filenames': (

--- a/bedrock/teach/templates/teach/smarton/base.html
+++ b/bedrock/teach/templates/teach/smarton/base.html
@@ -65,13 +65,7 @@
 {% block email_form %}{% endblock %}
 
 {% block js %}
-  <!--[if IE 9]>
-    {% javascript 'matchmedia_addlistener' %}
-  <![endif]-->
-
-  <!--[if !lte IE 8]><!-->
-    {% javascript 'smarton' %}
-  <!--<![endif]-->
+  {% javascript 'smarton' %}
 {% endblock %}
 
 {% macro smarton_navbar(title='', share_text='', twitter_url='', googleplus_url='', facebook_url='' ) -%}

--- a/bedrock/teach/templates/teach/smarton/index.html
+++ b/bedrock/teach/templates/teach/smarton/index.html
@@ -80,7 +80,5 @@
 {% endblock %}
 
 {% block js %}
-  <!--[if !lte IE 8]><!-->
-    {% javascript 'smarton-landing' %}
-  <!--<![endif]-->
+  {% javascript 'smarton-landing' %}
 {% endblock %}

--- a/media/css/firefox/ios.less
+++ b/media/css/firefox/ios.less
@@ -603,6 +603,10 @@ a.go {
 
 // Hide app store button for locales that get the send-to-device widget
 .js .show-widget {
+    #send-to-device-wrapper {
+        display: block;
+    }
+
     .dl-button,
     .appstore-badge {
         display: none;
@@ -643,7 +647,6 @@ a.go {
 
 // Sync instructions for iOS users
 #sync-instructions {
-    display: none;
     width: 220px;
     padding: 15px;
     background: #fff;

--- a/media/css/sandstone/sandstone-resp.less
+++ b/media/css/sandstone/sandstone-resp.less
@@ -1095,6 +1095,11 @@ nav.menu-bar {
     }
 }
 
+// hide lang switcher submit button if JS available
+.js #lang_form_submit {
+    display: none;
+}
+
 .visually-hidden {
     .visually-hidden();
 }

--- a/media/css/sandstone/sandstone.less
+++ b/media/css/sandstone/sandstone.less
@@ -847,6 +847,11 @@ nav.menu-bar {
     }
 }
 
+// hide lang switcher submit button if JS available
+.js #lang_form_submit {
+    display: none;
+}
+
 /* }}} */
 
 // Don't display the dynamic platform images when js is disabled

--- a/media/js/base/core-datalayer-init.js
+++ b/media/js/base/core-datalayer-init.js
@@ -5,7 +5,7 @@
 // init core dataLayer object and push into dataLayer
 $(function() {
     var analytics = Mozilla.Analytics;
-    var client = Mozilla.Client;
+    var client = Mozilla.Client || null;
     var dataLayer = window.dataLayer = window.dataLayer || [];
 
     function sendCoreDataLayer() {
@@ -22,7 +22,7 @@ $(function() {
         dataLayer.push(dataLayerCore);
     }
 
-    if (client.isFirefoxDesktop || client.isFirefoxAndroid) {
+    if (client && (client.isFirefoxDesktop || client.isFirefoxAndroid)) {
         client.getFirefoxDetails(function(details) {
             dataLayer.push(details);
             sendCoreDataLayer();

--- a/media/js/base/site.js
+++ b/media/js/base/site.js
@@ -189,7 +189,9 @@
             h.className += ' x64';
         }
 
-        // Add class to reflect javascript availability for CSS
-        h.className = h.className.replace(/\bno-js\b/, 'js');
+        // Add class to reflect javascript availability for CSS (for IE 9 and above)
+        if (!(platform === 'windows' && /MSIE\s[1-8]\./.test(navigator.userAgent))) {
+            h.className = h.className.replace(/\bno-js\b/, 'js');
+        }
     })();
 })();


### PR DESCRIPTION
## Description

Opening for discussion purposes only at this point.
## Bugzilla link

https://bugzilla.mozilla.org/show_bug.cgi?id=1287200
## Testing

For now, only pages updated are:
- / (IE <= 8 gets full JS)
- /firefox/channel/ (IE <= 8 gets minimal JS)
- /firefox/ios/ (IE <= 8 gets minimal JS)
## Checklist
- [ ] Related functional & integration tests passing.
