### PR TITLE
[fix bug 1287390] Updates to sunrise animation on firefox download page

### DIFF
--- a/media/css/firefox/new/horizon/scene1.less
+++ b/media/css/firefox/new/horizon/scene1.less
@@ -31,25 +31,25 @@
     // wait until window has loaded before animating.
     .loaded main[data-version="1"] {
         .horizon {
-            animation: sky 5s ease-out 1s both;
+            animation: sky 3.5s ease-out 0s both;
         }
         .mountains-svg-wrapper {
-            animation: sunlight 4s ease-out 2s both;
+            animation: sunlight 1.5s ease-out .5s both;
         }
         .sun {
-            animation: sunrise 6s ease-out 0s both;
+            animation: sunrise 3.5s ease-out 0s both;
         }
         .mountains-container .highlight {
-            animation: highlight 4s ease-out 2s both;
+            animation: highlight 2.5s ease-out .7s both;
 
             &.delay-1 {
-                animation-delay: 2.7s;
-                animation-duration: 3.3s;
+                animation-delay: 1.3s;
+                animation-duration: 2s;
             }
 
             &.delay-2 {
-                animation-delay: 3.4s;
-                animation-duration: 2.6s;
+                animation-delay: 1.8s;
+                animation-duration: 2s;
             }
         }
     }


### PR DESCRIPTION
## Description
- Some minor tweaks to speed up the sunrise animation. ~~Marking as do-not-merge for now until we've had feedback from Ty~~.

## Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1287390

## Testing
- `/en-US/firefox/new/?v=1`

