### PR TITLE
Fix languages not recognized by Django

### DIFF
--- a/bedrock/base/context_processors.py
+++ b/bedrock/base/context_processors.py
@@ -1,7 +1,8 @@
 # from bedrock.base
 
 from django.conf import settings
-from django.utils import translation
+
+from lib.l10n_utils import translation
 
 
 def i18n(request):

--- a/bedrock/base/middleware.py
+++ b/bedrock/base/middleware.py
@@ -11,11 +11,11 @@ from warnings import warn
 from django.conf import settings
 from django.core.exceptions import MiddlewareNotUsed
 from django.http import HttpResponsePermanentRedirect, HttpResponse
-from django.utils import translation
 from django.utils.encoding import smart_str, force_text
 
 from . import urlresolvers
 from .helpers import urlparams
+from lib.l10n_utils import translation
 
 
 class LocaleURLMiddleware(object):

--- a/bedrock/mozorg/tests/__init__.py
+++ b/bedrock/mozorg/tests/__init__.py
@@ -5,10 +5,10 @@
 from contextlib import contextmanager
 
 from django.test import TestCase
-from django.utils.translation import activate, get_language
 
 import test_utils
 from bedrock.base.urlresolvers import (get_url_prefix, Prefixer, set_url_prefix)
+from lib.l10n_utils import translation
 
 
 class TestCase(TestCase):
@@ -21,10 +21,10 @@ class TestCase(TestCase):
     def activate(self, locale):
         """Context manager that temporarily activates a locale."""
         old_prefix = get_url_prefix()
-        old_locale = get_language()
+        old_locale = translation.get_language()
         rf = test_utils.RequestFactory()
         set_url_prefix(Prefixer(rf.get('/%s/' % (locale,))))
-        activate(locale)
+        translation.activate(locale)
         yield
         set_url_prefix(old_prefix)
-        activate(old_locale)
+        translation.activate(old_locale)

--- a/lib/l10n_utils/dotlang.py
+++ b/lib/l10n_utils/dotlang.py
@@ -18,11 +18,11 @@ from functools import partial
 
 from django.conf import settings
 from django.core.cache import get_cache
-from django.utils import translation
 from django.utils.functional import lazy
 from jinja2 import Markup
 from product_details import product_details
 
+from lib.l10n_utils import translation
 from lib.l10n_utils.utils import ContainsEverything, strip_whitespace
 
 ALL_THE_THINGS = ContainsEverything()

--- a/lib/l10n_utils/helpers.py
+++ b/lib/l10n_utils/helpers.py
@@ -9,9 +9,9 @@ from babel.dates import format_date
 from babel.numbers import format_number
 
 from django.conf import settings
-from django.utils.translation import get_language
 
 from dotlang import translate, lang_file_has_tag
+from lib.l10n_utils.translation import get_language
 from gettext import template_has_tag
 
 

--- a/lib/l10n_utils/translation.py
+++ b/lib/l10n_utils/translation.py
@@ -1,0 +1,35 @@
+# mimic django's language activation machinery. it checks for .mo files
+# and we don't need anything nearly as complex.
+
+from _threading_local import local
+
+from django.conf import settings
+
+
+_active = local()
+
+
+def activate(language):
+    # coppied from Django
+    _active.value = language
+
+
+def get_language():
+    # coppied from Django
+    l = getattr(_active, "value", None)
+    if l is None:
+        return settings.LANGUAGE_CODE
+
+    return l
+
+
+def get_language_bidi():
+    """
+    Returns selected language's BiDi layout.
+
+    * False = left-to-right layout
+    * True = right-to-left layout
+    """
+    # coppied from Django
+    base_lang = get_language().split('-')[0]
+    return base_lang in settings.LANGUAGES_BIDI


### PR DESCRIPTION
Using Django's i18n infra for activation of translation means that it looks for .mo files to decide whether to activate it. This means that only those languages that ship with Django will activate. Since we have our own i18n system anyway we can copy their mechnics with a much more simple system.