### PR TITLE
Bug 1288360 - Set marker on correct building for Mozilla's London office. r?alexgibson

### DIFF
--- a/bedrock/mozorg/templates/mozorg/contact/spaces/london.html
+++ b/bedrock/mozorg/templates/mozorg/contact/spaces/london.html
@@ -28,7 +28,7 @@
         </ul>
 
         <figure class="feature-img">
-          <img src="//api.tiles.mapbox.com/v4/{{ settings.MAPBOX_TOKEN }}/url-{{ 'mozorg.cdn.mozilla.net/media/img/contact/moz-map-pin.png'|urlencode }}(-0.0972,51.5053)/-0.0972,51.5053,16/460x250.png?access_token={{ settings.MAPBOX_ACCESS_TOKEN }}" alt="">
+          <img src="//api.tiles.mapbox.com/v4/{{ settings.MAPBOX_TOKEN }}/url-{{ 'mozorg.cdn.mozilla.net/media/img/contact/moz-map-pin.png'|urlencode }}(-0.0971,51.5047)/-0.0971,51.5047,16/460x250.png?access_token={{ settings.MAPBOX_ACCESS_TOKEN }}" alt="">
         </figure>
       </div>
 

--- a/media/js/mozorg/contact-data.js
+++ b/media/js/mozorg/contact-data.js
@@ -98,7 +98,7 @@
             },
             geometry: {
                 type: 'Point',
-                coordinates: [-0.0972, 51.5053]
+                coordinates: [-0.0971, 51.5047]
             }
         }, {
             type: 'Feature',


### PR DESCRIPTION
## Description
Actual building of new office is two buildings south, updated the marker position

## Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1282532

## Testing
Tested the image by calling the image url with the new parameters.

## Checklist
- [ ] Requires l10n changes.
- [ ] Related functional & integration tests passing.