### PR TITLE
Switch from django-nose to py.test

### DIFF
--- a/bedrock/base/tests/test_accepted_locales.py
+++ b/bedrock/base/tests/test_accepted_locales.py
@@ -2,12 +2,12 @@ import os
 import shutil
 
 from django.conf import settings
-import test_utils
+from django.test import TestCase
 
 from bedrock.settings.base import get_dev_languages, path
 
 
-class AcceptedLocalesTest(test_utils.TestCase):
+class AcceptedLocalesTest(TestCase):
     """Test lazy evaluation of locale related settings.
 
     Verify that some localization-related settings are lazily evaluated based

--- a/bedrock/base/tests/test_context_processors.py
+++ b/bedrock/base/tests/test_context_processors.py
@@ -1,16 +1,16 @@
+from django.test import TestCase, RequestFactory
+
 import jingo
 import jinja2
 from nose.tools import eq_
-from django.test import TestCase, RequestFactory
 
-from mock import patch
-
-from bedrock.base import context_processors
+from lib.l10n_utils import translation
 
 
 class TestContext(TestCase):
 
     def setUp(self):
+        translation.activate('en-US')
         self.factory = RequestFactory()
 
     def render(self, content, request=None):
@@ -28,9 +28,7 @@ class TestContext(TestCase):
     def test_languages(self):
         eq_(self.render("{{ LANGUAGES['en-us'] }}"), 'English (US)')
 
-    @patch.object(context_processors, 'translation')
-    def test_lang_setting(self, translation):
-        translation.get_language.return_value = 'en-US'
+    def test_lang_setting(self):
         eq_(self.render("{{ LANG }}"), 'en-US')
 
     def test_lang_dir(self):

--- a/bedrock/mozorg/tests/__init__.py
+++ b/bedrock/mozorg/tests/__init__.py
@@ -4,14 +4,13 @@
 
 from contextlib import contextmanager
 
-from django.test import TestCase
+from django.test import RequestFactory, TestCase as DjTestCase
 
-import test_utils
 from bedrock.base.urlresolvers import (get_url_prefix, Prefixer, set_url_prefix)
 from lib.l10n_utils import translation
 
 
-class TestCase(TestCase):
+class TestCase(DjTestCase):
     """Base class for Bedrock test cases."""
     def shortDescription(self):
         # Stop nose using the test docstring and instead the test method name.
@@ -22,7 +21,7 @@ class TestCase(TestCase):
         """Context manager that temporarily activates a locale."""
         old_prefix = get_url_prefix()
         old_locale = translation.get_language()
-        rf = test_utils.RequestFactory()
+        rf = RequestFactory()
         set_url_prefix(Prefixer(rf.get('/%s/' % (locale,))))
         translation.activate(locale)
         yield

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -354,7 +354,6 @@ INSTALLED_APPS = (
 
     # Third-party apps, patches, fixes
     'commonware.response.cookies',
-    'django_nose',
 
     # L10n
     'puente',  # for ./manage.py extract
@@ -494,9 +493,6 @@ FORCE_SLASH_B = False
 RECAPTCHA_PUBLIC_KEY = config('RECAPTCHA_PUBLIC_KEY', default='')
 RECAPTCHA_PRIVATE_KEY = config('RECAPTCHA_PRIVATE_KEY', default='')
 RECAPTCHA_USE_SSL = config('RECAPTCHA_USE_SSL', cast=bool, default=True)
-
-TEST_RUNNER = 'django_nose.NoseTestSuiteRunner'
-NOSE_ARGS = config('NOSE_ARGS', default='', cast=Csv())
 
 # Use a message storage mechanism that doesn't need a database.
 # This can be changed to use session once we do add a database.

--- a/bedrock/settings/jenkins.py
+++ b/bedrock/settings/jenkins.py
@@ -34,4 +34,3 @@ HMAC_KEYS = {
 # signal which Django's test client uses to save away the contexts for your
 # test to look at later.
 TEMPLATE_DEBUG = True
-NOSE_ARGS = ['--with-xunit']

--- a/bin/jenkins.sh
+++ b/bin/jenkins.sh
@@ -59,7 +59,7 @@ flake8 bedrock lib
 
 echo "Starting tests..."
 export FORCE_DB=1
-coverage run manage.py test --noinput
+coverage run py.test lib bedrock
 coverage xml $(find bedrock lib -name '*.py')
 
 echo "FIN"

--- a/circle.yml
+++ b/circle.yml
@@ -57,7 +57,7 @@ test:
     - mkdir -p "$CIRCLE_TEST_REPORTS/django"
   override:
     - gulp js:test
-    - python manage.py test
+    - py.test lib bedrock
     - py.test --junitxml="$CIRCLE_TEST_REPORTS/redirects.xml" -r a -m smoke tests/redirects
 
 deployment:

--- a/docker/jenkins/run_tests.sh
+++ b/docker/jenkins/run_tests.sh
@@ -12,4 +12,4 @@ SECRET_KEY=39114b6a-2858-4caf-8878-482a24ee9542
 ADMINS=["thedude@example.com"]
 EOF
 
-docker run --env-file $ENV_FILE ${DOCKER_REPOSITORY}:${GIT_COMMIT:-$(git rev-parse HEAD)} ./manage.py test
+docker run --env-file $ENV_FILE ${DOCKER_REPOSITORY}:${GIT_COMMIT:-$(git rev-parse HEAD)} py.test lib bedrock

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -77,7 +77,7 @@ This will be important during development so that you can easily know when
 you've broken something with a change. You should still have your virtualenv
 activated, so running the tests is as simple as::
 
-    $ ./manage.py test
+    $ py.test lib bedrock
 
 .. note::
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -97,11 +97,6 @@ https://github.com/mozilla/nuggets/archive/ce506882b6943ea45ea4f98290fc4ef23e09a
 nose==1.3.6 \
     --hash=sha256:4772ab5189229392d16c70ba7b8bb66b5d3c18076694c55347afb98c950b283c \
     --hash=sha256:f61e0909a743eed37b1207e38a8e7b4a2fe0a82185e36f2be252ef1b3f901758
-nose-exclude==0.4.1 \
-    --hash=sha256:44466a9bcb56d2e568750f91504d1278c74eabb259a305b06e975b87b51635da
-django-nose==1.4 \
-    --hash=sha256:ed90a6ed8825a516c653fc9099c053be335b64fa004a903a181b7e01488ec5d4 \
-    --hash=sha256:26cef3c6f62df2eee955a25195de6f793881317c0f5fd1a1c6f9e22f351a9313
 pathlib==1.0.1 \
     --hash=sha256:6940718dfc3eff4258203ad5021090933e5c04707d5ca8cc9e73c94a7894ea9f
 dj-database-url==0.3.0 \

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -22,8 +22,6 @@ pyflakes==0.8.1 \
 mock==2.0.0 \
     --hash=sha256:5ce3c71c5545b472da17b72268978914d0252980348636840bd34a00b5cc96c1 \
     --hash=sha256:b158b6df76edd239b8208d481dc46b6afd45a846b7812ff0ce58971cf5bc8bba
-https://github.com/jbalogh/test-utils/archive/e42e031d31ea63d593e47d564545149a0f30b95f.tar.gz#egg=test-utils \
-    --hash=sha256:89f0058a6c7ed72e6ac299b2b8347acddfd5cccd60dd8fd30a4a031df091cb9b
 pyquery==1.0 \
     --hash=sha256:fb2345065647211507d23355b1026d995ded40e088d86fcae262562921d80408
 factory-boy==2.2.1 \


### PR DESCRIPTION
Remove most of nose libs. Nose itself is still required for nose.tools functions.