### PR TITLE
Bug 1167570 - Add "Source Code" download link to https://www.mozilla.org/firefox/all/

### DIFF
--- a/bedrock/firefox/templates/firefox/all.html
+++ b/bedrock/firefox/templates/firefox/all.html
@@ -62,7 +62,8 @@
     <h1>{{ self.page_title()  }}</h1>
     <h2>{{ self.page_desc() }}</h2>
     <p><a class="sysreq" href="{{ firefox_url(platform, 'sysreq', channel) }}">{{ _('Check the system requirements') }}</a><br />
-    <a class="sysreq" href="{{ firefox_url(platform, 'notes', channel) }}">{{ _('Release notes') }}</a></p>
+    <a class="sysreq" href="{{ firefox_url(platform, 'notes', channel) }}">{{ _('Release notes') }}</a><br />
+    <a class="sysreq" href="https://developer.mozilla.org/docs/Mozilla/Developer_guide/Source_Code">{{ _('Source code') }}</a></p>
   </header>
 
   {{ build_search_box(query, full_builds, test_builds) }}


### PR DESCRIPTION
## Description
LGPL requires us to provide access to source code where we provide access to binaries, and Firefox contains some LGPLed code. It doesn't have to be high profile; here's one suggested way.

## Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1167570

## Testing
Loaded on my machine :-)

## Checklist
- [X] Requires l10n changes.
- [ ] Related functional & integration tests passing.
