### PR TITLE
Remove Hello FTU instructions from UITour docs

### DIFF
--- a/docs/uitour.rst
+++ b/docs/uitour.rst
@@ -47,18 +47,6 @@ Note that ``browser.uitour.testingOrigins`` can be a comma separated list of dom
     must also exclude the domain protocol e.g. ``https://``. A browser restart is also required
     after adding a whitelisted domain.
 
-Hello FTU UITour
-----------------
-
-In order to test the Hello FTU tour on a local server or domain other than
-www.mozilla.org, you must first set an additional preference in ``about:config`` in
-addition to white listing UITour for the domain.
-
-* ``loop.gettingStarted.url`` value e.g. ``http://127.0.0.1:8000/%LOCALE%/firefox/%VERSION%/hello/start/``
-
-Once this preference has been set, the tour can be accessed via opening the Firefox Hello
-menu, clicking on the gear icon, and selecting "Tour".
-
 Tracking Protection UITour
 --------------------------
 


### PR DESCRIPTION
Just tidying up after myself (I forgot to remove this when we decommissioned the Hello FTU some time ago).

