### PR TITLE
Fix Bug 1289796 - default ios version should be 5.0 instead of 4.0 in release notes

### DIFF
--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -1056,7 +1056,7 @@ NEWRELIC_BROWSER_LICENSE_KEY = config('NEWRELIC_BROWSER_LICENSE_KEY', default=''
 NEWRELIC_APP_ID = config('NEWRELIC_APP_ID', default='')
 
 # temporary home until product details is updated
-FIREFOX_IOS_RELEASE_VERSION = '4.0'
+FIREFOX_IOS_RELEASE_VERSION = '5.0'
 
 FIREFOX_MOBILE_SYSREQ_URL = 'https://support.mozilla.org/kb/will-firefox-work-my-mobile-device'
 


### PR DESCRIPTION
Hope this would be the last time to hardcode the version on Bedrock ;-)