### PR TITLE
[fix bug 1288517] Test dumb download links in IE <= 8.

### DIFF
--- a/bedrock/firefox/templates/firefox/new/scene1-ie8.html
+++ b/bedrock/firefox/templates/firefox/new/scene1-ie8.html
@@ -1,0 +1,15 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+
+{% add_lang_files "firefox/new/horizon" %}
+
+{% extends "firefox/new/scene1.html" %}
+
+{% block experiments %}
+  {{ super() }}
+  {% javascript 'oldie-nojs' %}
+{% endblock %}
+
+{% block js %}{% endblock %}
+

--- a/bedrock/firefox/templates/firefox/new/scene1.html
+++ b/bedrock/firefox/templates/firefox/new/scene1.html
@@ -9,8 +9,8 @@
 {% extends "firefox/new/base.html" %}
 
 {% block experiments %}
-  {% if switch('experiment-firefox-new-all-links') and LANG == 'en-US' %}
-    {% javascript 'experiment-firefox-new-scene1-all-links' %}
+  {% if switch('experiment-firefox-new-oldie-nojs') %}
+    {% javascript 'experiment_firefox_new_oldie_nojs' %}
   {% endif %}
 {% endblock %}
 
@@ -18,9 +18,6 @@
 {% block extrahead %}
   {% stylesheet 'firefox_new_common' %}
   {% stylesheet 'firefox_new_scene1' %}
-  {% if version in ['1', '2'] %}
-    {% stylesheet 'firefox_new_scene1_variations' %}
-  {% endif %}
 {% endblock %}
 
 {% block body_id %}firefox-new-scene1{% endblock %}
@@ -127,42 +124,9 @@
   </div>
 </main>
 
-{% if version == '2' %}
-  <div id="fx-modal-wrapper">
-    <div id="fx-modal">
-      <div id="fx-modal-content">
-        <section id="fx-modal-primary-ctas" class="fx-modal-section">
-          <h4>Firefox for other platforms</h4>
-
-          <ul id="fx-modal-direct-downloads"></ul>
-
-          <ul id="fx-modal-mobile-downloads">
-            <li class="android">
-              {{ google_play_button() }}
-            </li>
-            <li class="ios">
-              <a href="{{ firefox_ios_url('mozorg-fxnew_page_scene1_modal-appstore-button') }}" data-link-type="download" data-download-os="iOS">
-                <img src="{{ l10n_img('firefox/ios/btn-app-store.svg') }}" alt="{{ _('Download on the App Store') }}" width="152" height="45">
-              </a>
-            </li>
-          </ul>
-        </section>{#-- /#fx-modal-primary-ctas --#}
-
-        <section id="fx-modal-secondary-cta" class="fx-modal-section">
-          <h3>Download Firefox <span id="fx-modal-user-platform"></span></h3>
-          {{ download_firefox(alt_copy=_('Free Download'), dom_id="fx-modal-download") }}
-        </section>{#-- /#fx-modal-secondary-cta --#}
-      </div>{#-- /#fx-modal-content --#}
-    </div>{#-- /#fx-modal --#}
-  </div>{#-- /#fx-modal-wrapper -_#}
-{% endif %}
-
 {% include 'firefox/includes/schemaorg-app.html' %}
 {% endblock %}
 
 {% block js %}
   {% javascript 'firefox_new_scene1' %}
-  {% if version in ['1', '2'] %}
-    {% javascript 'firefox_new_scene1_variations' %}
-  {% endif %}
 {% endblock %}

--- a/bedrock/firefox/tests/test_views.py
+++ b/bedrock/firefox/tests/test_views.py
@@ -8,7 +8,7 @@ from django.test import override_settings
 from django.test.client import RequestFactory
 
 from bedrock.base.urlresolvers import reverse
-from mock import ANY, patch
+from mock import patch
 from nose.tools import eq_, ok_
 
 from bedrock.firefox import views
@@ -172,32 +172,20 @@ class TestFirefoxNew(TestCase):
         req = RequestFactory().get('/firefox/new/')
         req.locale = 'en-US'
         views.new(req)
-        render_mock.assert_called_once_with(req, 'firefox/new/scene1.html', ANY)
+        render_mock.assert_called_once_with(req, 'firefox/new/scene1.html')
 
     def test_scene_2_template(self, render_mock):
         req = RequestFactory().get('/firefox/new/?scene=2')
         req.locale = 'en-US'
         views.new(req)
-        render_mock.assert_called_once_with(req, 'firefox/new/scene2.html', ANY)
+        render_mock.assert_called_once_with(req, 'firefox/new/scene2.html')
 
-    # /all tests (bug 1295181)
-    def test_all_variation_1(self, render_mock):
+    # IE 8 no JS test (bug 1288517)
+    def test_ie8_variation(self, render_mock):
         req = RequestFactory().get('/firefox/new/?v=1')
         req.locale = 'en-US'
         views.new(req)
-        render_mock.assert_called_once_with(req, 'firefox/new/scene1.html', {'version': '1'})
-
-    def test_all_variation_2(self, render_mock):
-        req = RequestFactory().get('/firefox/new/?v=2')
-        req.locale = 'en-US'
-        views.new(req)
-        render_mock.assert_called_once_with(req, 'firefox/new/scene1.html', {'version': '2'})
-
-    def test_all_variation_invalid(self, render_mock):
-        req = RequestFactory().get('/firefox/new/?v=3')
-        req.locale = 'en-US'
-        views.new(req)
-        render_mock.assert_called_once_with(req, 'firefox/new/scene1.html', {'version': None})
+        render_mock.assert_called_once_with(req, 'firefox/new/scene1-ie8.html')
 
 
 class TestWin10WelcomeView(TestCase):

--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -475,7 +475,6 @@ def new(request):
         return HttpResponsePermanentRedirect(reverse('firefox.new'))
 
     scene = request.GET.get('scene', None)
-    version = None
 
     if scene == '2':
         template = 'firefox/new/scene2.html'
@@ -485,16 +484,11 @@ def new(request):
 
         # en-US tests
         locale = l10n_utils.get_locale(request)
-        if locale == 'en-US':
-            version = request.GET.get('v', None)
 
-            # each variation puts a link under the primary dl button
-            # 1. links to /firefox/all
-            # 2. opens modal offering alternate direct & app store downloads
-            if version not in ['1', '2']:
-                version = None
+        if locale == 'en-US' and request.GET.get('v', None) == '1':
+            template = 'firefox/new/scene1-ie8.html'
 
-    return l10n_utils.render(request, template, {'version': version})
+    return l10n_utils.render(request, template)
 
 
 def sync(request):

--- a/bedrock/settings/static_media.py
+++ b/bedrock/settings/static_media.py
@@ -456,13 +456,6 @@ PIPELINE_CSS = {
         ),
         'output_filename': 'css/firefox_new_scene2-bundle.css',
     },
-    'firefox_new_scene1_variations': {
-        'source_filenames': (
-            'css/base/mozilla-modal.less',
-            'css/firefox/new/all-test-variations.less',
-        ),
-        'output_filename': 'css/firefox_new_scene1_variations-bundle.css',
-    },
     'firefox_organizations': {
         'source_filenames': (
             'css/firefox/organizations.less',
@@ -1233,20 +1226,19 @@ PIPELINE_JS = {
         ),
         'output_filename': 'js/firefox_new_scene1-bundle.js',
     },
-    'experiment-firefox-new-scene1-all-links': {
+    'experiment_firefox_new_oldie_nojs': {
         'source_filenames': (
             'js/base/mozilla-cookie-helper.js',
             'js/base/mozilla-traffic-cop.js',
-            'js/firefox/new/experiment-all-links.js',
+            'js/firefox/new/experiment-oldie-nojs.js',
         ),
-        'output_filename': 'js/experiment_firefox_new_scene1_all_links-bundle.js',
+        'output_filename': 'js/experiment_firefox_new_oldie_nojs-bundle.js',
     },
-    'firefox_new_scene1_variations': {
+    'oldie-nojs': {
         'source_filenames': (
-            'js/base/mozilla-modal.js',
-            'js/firefox/new/all-test-variations.js',
+            'js/base/oldie-nojs.js',
         ),
-        'output_filename': 'js/firefox_new_scene1_variations-bundle.js',
+        'output_filename': 'js/oldie-nojs-bundle.js',
     },
     'firefox_new_scene2': {
         'source_filenames': (

--- a/media/css/sandstone/buttons.less
+++ b/media/css/sandstone/buttons.less
@@ -263,7 +263,7 @@ ul.download-list {
         list-style: none;
 
         li {
-            display: inline-block;
+            .inline-block();
             margin: @baseLine 0 0;
 
             .button {

--- a/media/js/base/oldie-nojs.js
+++ b/media/js/base/oldie-nojs.js
@@ -1,0 +1,14 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+(function () {
+    'use strict';
+
+    var h = document.documentElement;
+
+    // remove js class from body if IE 8 or below
+    if (window.site.platform === 'windows' && /MSIE\s8\./.test(navigator.userAgent)) {
+        h.className = h.className.replace(/\bjs\b/, 'no-js');
+    }
+})();

--- a/media/js/firefox/new/experiment-oldie-nojs.js
+++ b/media/js/firefox/new/experiment-oldie-nojs.js
@@ -1,0 +1,18 @@
+(function(Mozilla) {
+    'use strict';
+
+    var cop;
+
+    // run on IE 8 only
+    if (window.site.platform === 'windows' && /MSIE\s8\./.test(navigator.userAgent)) {
+        cop = new Mozilla.TrafficCop({
+            id: 'experiment-firefox-new-oldie-nojs',
+            variations: {
+                'v=1': 25,
+                'v=2': 25 // control (no variation)
+            }
+        });
+
+        cop.init();
+    }
+})(window.Mozilla);


### PR DESCRIPTION
## Description

Prep pages to serve updated/minimal JS to IE <= 8. ~~Traffic will be directed by Optimizely experiment (to be created).~~ Traffic will be directed using our Traffic Cop.

Also removes some of the code (bundles, template & view logic) from the /all test run in early October. (Assets from that test still exist as they will likely be re-purposed for a future test.)

## Bugzilla link

https://bugzilla.mozilla.org/show_bug.cgi?id=1288517

## Testing

~~Test `/firefox/new/?v=2` and `/firefox/new/` in modern browsers and in IE 7 & 8.~~
Make sure `/firefox/new/?v=1` functions correctly in IE 7 (regular download button), IE 8 (no JS download buttons), and modern browsers (regular download button). Make sure Traffic Cop experiment functions as expected.

## Checklist
- [ ] Related functional & integration tests passing.

