### PR TITLE
[fix bug 1278380] Update newsletter thank you message

### DIFF
--- a/bedrock/mozorg/templates/mozorg/contribute/friends.html
+++ b/bedrock/mozorg/templates/mozorg/contribute/friends.html
@@ -94,13 +94,14 @@
   </div>{# /-- .ff-signup-wrapper #}
 
   <div id="newsletter-form-thankyou" class="thank newsletter-form newsletter-form-extra">
-    <h3>{{ _('Thanks! Please check your inbox to confirm your subscription to the Firefox Friends newsletter.') }}</h3>
+    <h3>{{ _('Thanks!') }}</h3>
 
     {# below matches text found in newsletter/includes/macros/email_form_thankyou() #}
     <p>
     {% trans %}
-      You'll receive an email from mozilla@e.mozilla.org to confirm your subscription.
-      If you don't see it, check your spam filter. You must confirm your subscription to receive our newsletter.
+      If you haven’t previously confirmed a subscription to a Mozilla-related
+      newsletter you may have to do so. Please check your inbox or your spam filter
+      for an email from us.
     {% endtrans %}
     </p>
   </div>

--- a/bedrock/newsletter/templates/newsletter/includes/macros.html
+++ b/bedrock/newsletter/templates/newsletter/includes/macros.html
@@ -5,11 +5,12 @@
 {% set_lang_files "mozorg/newsletters" %}
 
 {% macro email_form_thankyou() %}
-  <h3>{{ _('Thanks! Please check your inbox to confirm your subscription.') }}</h3>
+  <h3>{{ _('Thanks!') }}</h3>
   <p>
-    {% trans %}
-      You'll receive an email from mozilla@e.mozilla.org to confirm your subscription.
-      If you don't see it, check your spam filter. You must confirm your subscription to receive our newsletter.
-    {% endtrans %}
+  {% trans %}
+    If you haven’t previously confirmed a subscription to a Mozilla-related
+    newsletter you may have to do so. Please check your inbox or your spam filter
+    for an email from us.
+  {% endtrans %}
   </p>
 {% endmacro %}

--- a/bedrock/newsletter/templates/newsletter/mozilla-and-you.html
+++ b/bedrock/newsletter/templates/newsletter/mozilla-and-you.html
@@ -18,6 +18,6 @@
 {% endblock %}
 
 {% block success_confirm %}
-  <p>{% trans %}Thanks! Please check your inbox to confirm your subscription.{% endtrans %}</p>
-  <p>{% trans %}You'll receive an email from mozilla@e.mozilla.org to confirm your subscription. If you don't see it, check your spam filter. You must confirm your subscription to receive our newsletter.{% endtrans %}</p>
+  <h3>{{ _('Thanks!') }}</h3>
+  {{ super() }}
 {% endblock success_confirm %}

--- a/bedrock/newsletter/templates/newsletter/one_newsletter_signup.html
+++ b/bedrock/newsletter/templates/newsletter/one_newsletter_signup.html
@@ -34,12 +34,18 @@
     {% else %}
       {# User has been subscribed #}
       <div id="email-form" class="thank billboard">
-        <h3>{{ _('Thanks for Subscribing!') }}</h3>
-        {# user will have to confirm before starting subscription #}
-        {% block success_confirm %}
-          <p>{% trans %}Thanks! Please check your inbox to confirm your subscription.{% endtrans %}</p>
-          <p>{% trans %}You'll receive an email from mozilla@e.mozilla.org to confirm your subscription. If you don't see it, check your spam filter. You must confirm your subscription to receive our newsletter.{% endtrans %}</p>
-        {% endblock success_confirm %}
+        <h3>{{ _('Thanks!') }}</h3>
+
+      {# user may have to confirm before starting subscription #}
+      {% block success_confirm %}
+        <p>
+        {% trans %}
+          If you haven’t previously confirmed a subscription to a Mozilla-related
+          newsletter you may have to do so. Please check your inbox or your spam filter
+          for an email from us.
+        {% endtrans %}
+        </p>
+      {% endblock success_confirm %}
       </div>
     {% endif %}
   </div><!-- doc -->


### PR DESCRIPTION
## Description
Updates the standard "thank you" message shown when subscribing to a newsletter. This uses the l10n tag "newsletter_thanks_072016" and I think the same string resides in both main.lang and in newsletter.lang. 

## Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1278380

## Checklist
- [x] Requires l10n changes.
- [ ] Related functional & integration tests passing.

