### PR TITLE
Bug 1282494: Use http://product-details.mozilla.org/ instead of the s…

### DIFF
--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -101,6 +101,10 @@ TEST_RUNNER = 'django.test.runner.DiscoverRunner'
 # http://www.i18nguy.com/unicode/language-identifiers.html
 LANGUAGE_CODE = 'en-US'
 
+# Use Ship It as the source for product_details
+PROD_DETAILS_URL = config('PROD_DETAILS_URL',
+                          default='https://product-details.mozilla.org/1.0/')
+
 # Tells the product_details module where to find our local JSON files.
 # This ultimately controls how LANGUAGES are constructed.
 PROD_DETAILS_CACHE_NAME = 'product-details'


### PR DESCRIPTION
## Description
This patch override the default PROD_DETAILS_URL variable to use https://product-details.mozilla.org/1.0/ as a source for json files

## Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1282494

## Testing
Manual testing of download page

## Checklist
- [ ] Related functional & integration tests passing.

