### PR TITLE
Bug 1282494 - Use SVN default URL for product-details for Firefox 48 …

### DIFF
--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -103,7 +103,7 @@ LANGUAGE_CODE = 'en-US'
 
 # Use Ship It as the source for product_details
 PROD_DETAILS_URL = config('PROD_DETAILS_URL',
-                          default='https://product-details.mozilla.org/1.0/')
+                          default='https://svn.mozilla.org/libs/product-details/json/')
 
 # Tells the product_details module where to find our local JSON files.
 # This ultimately controls how LANGUAGES are constructed.


### PR DESCRIPTION
In bug 1282494 we asked for the default source of json files for product-details to point to https://product-details.mozilla.org/1.0/ instead of https://svn.mozilla.org/libs/product-details/json/

Several bugs were reported on our data sources since them, I believe we have fixed all of them but not all changes are  deployed yet to the Ship It app.

As much as we'd love in release management to move entirely product-details to the data produced by ship it, we think it would be safer to switch back to the svn source for the Firefox 48 release and move to https://product-details.mozilla.org/1.0/ as a data source after the release.

Sorry for the inconveniences this may cause.