### PR TITLE
Fix Bug 1288647: Bad Mozilla Hacking Links

### DIFF
--- a/bedrock/mozorg/redirects.py
+++ b/bedrock/mozorg/redirects.py
@@ -617,4 +617,7 @@ redirectpatterns = (
     redirect(r'^about/patents/license/1.0/?$', 'mozorg.about.policy.patents.license-1.0'),
 
     redirect(r'^projects/marketing(/.*)?$', 'https://wiki.mozilla.org/MarketingGuide'),
+
+    # bug 1288647
+    redirect(r'^hacking/?$', 'https://developer.mozilla.org/docs/Mozilla/Developer_guide/Introduction'),
 )

--- a/tests/redirects/map_globalconf.py
+++ b/tests/redirects/map_globalconf.py
@@ -1073,4 +1073,7 @@ URLS = flatten((
     url_test('/firefox/pocket', 'https://getpocket.com/firefox/'),
 
     url_test('/firefox/{,46.0/,46.0.1/,47.0/,47.0.1/}secondrun', '/firefox/mobile-download/'),
+
+    # bug 1288647
+    url_test('/hacking', 'https://developer.mozilla.org/docs/Mozilla/Developer_guide/Introduction'),
 ))


### PR DESCRIPTION
## Description

- Adds appropriate redirect for `/hacking/` so a 404 is not returned.

## Bugzilla link

https://bugzilla.mozilla.org/show_bug.cgi?id=1288647

## Testing

## Checklist
- [ ] Requires l10n changes.
- [x] Related functional & integration tests passing.

## Additional Notes

I was not sure how to address the "Testing" and "Checklist" portions of this template. I did follow the [Managing Redirects](http://bedrock.readthedocs.io/en/latest/redirects.html#add-a-redirect) documentation and ran the following tests: `py.test -r a -m smoke tests/redirects/`. This returned the following results: "2033 passed, 37 deselected in 27.98 seconds" which looked good to me!

If there's anything more I can do, let me know.