### PR TITLE
[fix bug 1262892] Add origin param to FxA iframe src.

### DIFF
--- a/docs/firefox-accounts.rst
+++ b/docs/firefox-accounts.rst
@@ -22,7 +22,7 @@ Local Development
 
     ``FXA_IFRAME_SRC=https://stomlinson.dev.lcip.org/``
 
-#. Set your local development server to run on ``127.0.0.1:8111``.
+#. Set your local development server to run on ``127.0.0.1:8111``, e.g. ``PORT=8111 gulp``.
 #. Quit Firefox.
 #. Create a new profile for testing called ``FxA Test Local`` by following the
    `instructions here`_.

--- a/media/js/base/mozilla-fxa-iframe.js
+++ b/media/js/base/mozilla-fxa-iframe.js
@@ -59,6 +59,9 @@ Mozilla.FxaIframe = (function() {
             _src = _src.replace('context=iframe', 'context=fx_firstrun_v2');
         }
 
+        // add origin (protocol + hostname + (optional) port) for embed authorization
+        _src += '&origin=' + encodeURIComponent(window.location.origin);
+
         // initialize GA event name
         _gaEventName = _config.gaEventName || 'fxa';
 
@@ -160,6 +163,9 @@ Mozilla.FxaIframe = (function() {
     };
 
     var _onLoaded = function(data) {
+        // remember iframe has loaded (new auth flow doesn't fire 'ping')
+        _handshake = true;
+
         _sendGAEvent('fxa-loaded');
         _userCallback('onLoaded', data);
     };


### PR DESCRIPTION
## Description

The FxA team is working on an update to the mechanism that authorizes embedding of their iframe. This change is to allow that team to test their new approach. Functionally, nothing should change on mozilla.org due to this PR.

After the new auth mechanism is fully in place, we will file a follow-up PR to remove the current `ping` postMessage auth.

## Bugzilla link

https://bugzilla.mozilla.org/show_bug.cgi?id=1262892

## Testing

Make sure nothing has changed/no regressions have appeared due to this change. Test locally, on [demo5](https://www-demo5.allizom.org/en-US/firefox/accounts/) (which points to @shane-tomlinson's FxA server for testing the new auth), and on [demo 4](https://www-demo4.allizom.org/en-US/firefox/accounts/) (which points to FxA stage).

(**Reminder:** The iframe only loads on Fx 39+, so shouldn't have to fire up a VM.)

## Checklist
- [ ] Related functional & integration tests passing.

