### PR TITLE
[fix bug 1291909] broken mosaic on manifesto page

### DIFF
--- a/media/css/mozorg/manifesto.less
+++ b/media/css/mozorg/manifesto.less
@@ -468,9 +468,19 @@
     height: 3060px;
 
     ul li {
+        float: left;
+        list-style: none;
+        position: relative;
         margin: 0 20px 20px 0;
         width: 140px !important; /* Override the setting by Grid Rorator */
         height: 140px !important; /* Override the setting by Grid Rorator */
+
+        a {
+            display: block;
+            height: 100%;
+            position: absolute;
+            width: 100%;
+        }
     }
 
     &.loaded {


### PR DESCRIPTION
## Description
Minor regression from deleting mosaic.less in bfe0591cb5cd46d53ba335227e8116149040e124 which was easy to miss in review thanks to cached files; the breakage doesn't appear until you reprocess the manifesto CSS bundle without the mosaic styles.

## Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1291909

## Testing
For local testing, delete your local files from /static/css and rerun collectstatic to ensure you're seeing the changes and not a old file.