### PR TITLE
[fix bug 1274207] Download page should only show 'Refresh Firefox' button if reset is supported

### DIFF
--- a/docs/uitour.rst
+++ b/docs/uitour.rst
@@ -285,6 +285,7 @@ Available ``type`` values:
 * ``'selectedSearchEngine'``
 * ``'search'``
 * ``'loop'``
+* ``'canReset'``
 
 Other parameters:
 
@@ -380,6 +381,20 @@ If ``'loop'`` is queried the object returns the boolean value for the ``'loop.ge
 
     ``loop`` is only available in Firefox 36 onward.
 
+**canReset**
+
+If ``'canReset'`` is queried the callback returns a boolean value to indicate if a user can refresh their Firefox profile via ``resetFirefox()``
+
+.. code-block:: javascript
+
+    Mozilla.UITour.getConfiguration('canReset', function (canReset) {
+        console.log(canReset); // true
+    });
+
+.. Important::
+
+    ``canReset`` is only available in Firefox 48 onward.
+
 setConfiguration(name, value);
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -467,7 +482,9 @@ Opens the Firefox reset panel, allowing users to choose to reomve add-ons and cu
 
 .. Important::
 
-    ``showFirefoxAccounts()`` is only available in Firefox 35 onward.
+    ``resetFirefox()`` should be called only in Firefox 48 onwards, and only after
+    first calling ``getConfiguration('canReset')`` to determine if the user profile
+    is eligible.
 
 addNavBarWidget(target, callback);
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/media/js/firefox/new/scene1.js
+++ b/media/js/firefox/new/scene1.js
@@ -21,6 +21,35 @@
         document.dispatchEvent(event);
     };
 
+    var uiTourWaitForCallback = function(callback) {
+        var id = Math.random().toString(36).replace(/[^a-z]+/g, '');
+
+        function listener(event) {
+            if (typeof event.detail != 'object') {
+                return;
+            }
+            if (event.detail.callbackID !== id) {
+                return;
+            }
+
+            document.removeEventListener('mozUITourResponse', listener);
+            callback(event.detail.data);
+        }
+        document.addEventListener('mozUITourResponse', listener);
+
+        return id;
+    };
+
+    var showRefreshButton = function(canReset) {
+        if (canReset) {
+            $html.addClass('show-refresh');
+
+            $('#refresh-firefox').on('click', function() {
+                uiTourSendEvent('resetFirefox');
+            });
+        }
+    };
+
     if (client.isFirefoxDesktop ||client.isFirefoxAndroid) {
         // Detect whether the Firefox is up-to-date in a non-strict way. The minor version and channel are not
         // considered. This can/should be strict, once the UX especially for ESR users is decided. (Bug 939470)
@@ -32,10 +61,10 @@
                 client.getFirefoxDetails(function(data) {
                     // data.accurate will only be true if UITour API is working.
                     if (data.channel === 'release' && data.isUpToDate && data.accurate) {
-                        $html.addClass('show-refresh');
-                        
-                        $('#refresh-firefox').on('click', function() {
-                            uiTourSendEvent('resetFirefox');
+                        // Bug 1274207 only show reset button if user profile supports it.
+                        uiTourSendEvent('getConfiguration', {
+                            callbackID: uiTourWaitForCallback(showRefreshButton),
+                            configuration: 'canReset'
                         });
                     }
                 });


### PR DESCRIPTION
## Description
- A new UITour method was added in Firefox 48 that tells us if the user profile supports the "Reset Firefox" dialog that we show to up-to-date users on /firefox/new/. This prevents edge-case weirdness, like in [bug 1126559](https://bugzilla.mozilla.org/show_bug.cgi?id=1126559).

## Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1274207

## Testing
- Load `/firefox/new/` in Firefox 48 (make sure you update from product details first), with [UITour enabled](http://bedrock.readthedocs.io/en/latest/uitour.html#local-development). You should still see the "Refresh Firefox" button, and clicking it should still open up the dialog.
- Test this is working for both the old and new template designs.

## Checklist
- [ ] Requires l10n changes.
- [ ] Related functional & integration tests passing.