### PR TITLE
Bug 1282494: Please use https://product-details.mozilla.org/1.0/ inst…

### DIFF
--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -103,7 +103,7 @@ LANGUAGE_CODE = 'en-US'
 
 # Use Ship It as the source for product_details
 PROD_DETAILS_URL = config('PROD_DETAILS_URL',
-                          default='https://svn.mozilla.org/libs/product-details/json/')
+                          default='https://product-details.mozilla.org/1.0/')
 
 # Tells the product_details module where to find our local JSON files.
 # This ultimately controls how LANGUAGES are constructed.


### PR DESCRIPTION
## Description
Use Ship It generated data for product-details

## Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1282494
## Testing
Manual testing on https://bedrock-demo-new-product-details.us-west.moz.works/

## Checklist
- [ ] Requires l10n changes.
- [ ] Related functional & integration tests passing.
