### PR TITLE
[fix bug 1292528] 'Dumb' download link headings should include channe…

### DIFF
--- a/bedrock/firefox/templates/firefox/includes/download-button.html
+++ b/bedrock/firefox/templates/firefox/includes/download-button.html
@@ -4,7 +4,15 @@
 
 {% macro alt_buttons(builds) %}
   <div class="download download-dumb">
-    <p role="heading" class="download-heading">{{ _('Download Firefox') }} — {{ locale_name|safe }}</p>
+    <p role="heading" class="download-heading">
+      {% if channel == 'beta' %}
+        {{ _('Firefox Beta') }}
+      {% elif channel == 'alpha' %}
+        {{ _('<span>Firefox</span> Developer Edition') }}
+      {% else %}
+        {{ _('Download Firefox') }}
+      {% endif %}  — {{ locale_name|safe }}
+    </p>
     <ul>
       {% for plat in builds -%}
         <li><a href="{{ plat.download_link_direct or plat.download_link }}" class="download-link button green">{{ plat.os_arch_pretty or plat.os_pretty }}</a></li>


### PR DESCRIPTION
## Description
- Small improvement to dumb download button links, to show channel description in the headings.
- Reuses existing strings, so no l10n changes needed.

## Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1292528

## Testing
- In Firefox, go to 'about:config' and set 'javascript.enabled' to 'false'.
- Visit `/firefox/installer-help/` and you should now see different headings for each group of download links.

## Checklist
- [ ] Requires l10n changes.
- [ ] Related functional & integration tests passing.