### PR TITLE
Add Mozilla Foundation strategy document to Foundation page

### DIFF
--- a/bedrock/foundation/templates/foundation/base-resp.html
+++ b/bedrock/foundation/templates/foundation/base-resp.html
@@ -15,6 +15,7 @@
 {% set navigation_bar = [
     (url('foundation.index'), 'index', 'The Mozilla Foundation'),
     (url('foundation.about'), 'about', 'About the Foundation'),
+    ('https://mzl.la/foundation-strategy', 'strategy', '2016-2018 Strategy'),
     (url('foundation.annualreport'), 'report', 'Annual Report'),
     ('https://careers.mozilla.org/', 'careers', 'Careers'),
     (donate_url('foundation_nav'), 'donate', 'Donate'),

--- a/bedrock/foundation/templates/foundation/index.html
+++ b/bedrock/foundation/templates/foundation/index.html
@@ -32,6 +32,12 @@
   {% endtrans %}
   </p>
 
+  <p>
+    {% trans url_open_strategy_document='https://mzl.la/foundation-strategy' %}
+      <strong><a href="{{ url_open_strategy_document }}" class="go">Read the Mozilla Foundation’s 2016-2018 Strategy</a></strong>
+    {% endtrans %}
+  </p>
+
   <h2>{{ _('Foundation Programs') }}</h2>
   <p>
   {% trans %}

--- a/bedrock/foundation/templates/foundation/index.html
+++ b/bedrock/foundation/templates/foundation/index.html
@@ -33,9 +33,7 @@
   </p>
 
   <p>
-    {% trans url_open_strategy_document='https://mzl.la/foundation-strategy' %}
-      <strong><a href="{{ url_open_strategy_document }}" class="go">Read the Mozilla Foundation’s 2016-2018 Strategy</a></strong>
-    {% endtrans %}
+    <strong><a href="https://mzl.la/foundation-strategy" class="go">{{ _('Read the Mozilla Foundation’s 2016-2018 Strategy') }}</a></strong>
   </p>
 
   <h2>{{ _('Foundation Programs') }}</h2>


### PR DESCRIPTION
## Description
Add a link to the Mozilla Foundation strategy PDF to the Foundation page

## Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1292658

## Testing
Didn't add/change any tests. Just a text/url change. Needed?

## Checklist
- [ ] Requires l10n changes.
- [ ] Related functional & integration tests passing.

1. Added link to document in side panel in base-resp.html.
2. Added link to document in body in index.html.