### PR TITLE
Bug 1295618 - update Level 3 policy to match agreement in mozilla.governance.

### DIFF
--- a/bedrock/mozorg/templates/mozorg/about/governance/policies/commit/access-policy.html
+++ b/bedrock/mozorg/templates/mozorg/about/governance/policies/commit/access-policy.html
@@ -134,7 +134,7 @@ This is the lowest level of access. It allows someone to check in to the <a href
 
 <h2 id="Level3">{{ _('Level 3 - Core Product Access') }}</h2>
 
-<p>{{ _('Requirements: two vouchers - module owners or peers of code stored at this level') }}</p>
+<p>{{ _('Requirements: two vouchers - module owners or peers of code stored at this level, or owners or peers of the "Tree Sheriffs" module') }}</p>
 
 <p>{{ _('This permission gives access to check into any tree from which executable code becomes part of our core products - Firefox, Firefox for Android and Thunderbird. To put it another way, the unifying factor is that it should not be possible to break core product tinderboxes unless you have this access. This is fundamentally a statement of trust in and familiarity with an individual, and so access to one such tree gives access to all such trees, although social controls may prevent people checking in to certain ones. (Peers can vouch because the number of modules at this level is smaller, and because if you are working only in a single area of the code, there may not be multiple module owners familiar with your work.)') }}</p>
 


### PR DESCRIPTION
## Description
Update Level 3 policy to match agreement in mozilla.governance.

## Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1295618

## Testing
Textual change only; getting bedrock running is a PITA. Can we have a CMS, please?

module.js:340
    throw err;
          ^
Error: Cannot find module 'readable-stream/duplex'
...

## Checklist
- [X] Requires l10n changes.
- [ ] Related functional & integration tests passing.
