### PR TITLE
Removing hostnames from eligible list. Hosts decomissioned.

### DIFF
--- a/bedrock/security/templates/security/bug-bounty/faq-webapp.html
+++ b/bedrock/security/templates/security/bug-bounty/faq-webapp.html
@@ -134,8 +134,6 @@
           	<li>addons.mozilla.org</li>
           	<li>blocklist.addons.mozilla.org</li>
           	<li>builder.addons.mozilla.org</li>
-          	<li>controller-review.apk.firefox.com</li>
-          	<li>controller.apk.firefox.com</li>
           	<li>services.addons.mozilla.org</li>
           	<li>static.addons.mozilla.net</li>
           	<li>versioncheck-bg.addons.mozilla.org</li>


### PR DESCRIPTION
## Description
Removing hosts from eligible list, they were decomissioned

## Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1295743
## Testing

## Checklist
- [ ] Requires l10n changes.
- [ ] Related functional & integration tests passing.

