### PR TITLE
Fix 1295691: Bedrock process starts without database

### DIFF
--- a/bedrock/base/database.py
+++ b/bedrock/base/database.py
@@ -1,0 +1,7 @@
+# coding: utf8
+
+
+class BedrockRouter(object):
+    """A database router to use a single non-default db"""
+    db_for_read = db_for_write = lambda *a, **kw: 'bedrock'
+    allow_relation = allow_migrate = lambda *a, **kw: True

--- a/bedrock/events/utils.py
+++ b/bedrock/events/utils.py
@@ -2,6 +2,7 @@ from functools import wraps
 
 from django.conf import settings
 from django.core.cache import cache
+from django.db import DatabaseError
 
 from bedrock.events.models import Event
 
@@ -33,27 +34,42 @@ def cache_memoized(obj):
 
 @cache_memoized
 def current_and_future_event_count():
-    return Event.objects.current_and_future().count()
+    try:
+        return Event.objects.current_and_future().count()
+    except DatabaseError:
+        return 0
 
 
 @cache_memoized
 def current_and_future_events():
-    return list(Event.objects.current_and_future())
+    try:
+        return list(Event.objects.current_and_future())
+    except DatabaseError:
+        return []
 
 
 @cache_memoized
 def future_event_count():
-    return Event.objects.future().count()
+    try:
+        return Event.objects.future().count()
+    except DatabaseError:
+        return 0
 
 
 @cache_memoized
 def future_events():
-    return list(Event.objects.future())
+    try:
+        return list(Event.objects.future())
+    except DatabaseError:
+        return []
 
 
 @cache_memoized
 def next_few_events(count):
-    return list(Event.objects.future()[:count])
+    try:
+        return list(Event.objects.future()[:count])
+    except DatabaseError:
+        return []
 
 
 def next_event():

--- a/bedrock/mozorg/templates/mozorg/contribute/contribute-base.html
+++ b/bedrock/mozorg/templates/mozorg/contribute/contribute-base.html
@@ -58,8 +58,10 @@
       <ul class="head-stats">
         {# L10n: This label accompanies a numeric count. The number appears first so phrase translations accordingly. #}
         <li class="stat-worldwide"><strong>{{ num_mozillians|l10n_format_number }}</strong> {{ _('active Mozillians worldwide') }}</li>
+        {% if events_count() %}
         {# L10n: This label accompanies a numeric count. The number appears first so phrase translations accordingly. #}
         <li class="stat-events"><strong>{{ events_count()|l10n_format_number }}</strong> {{ _('upcoming events around the globe') }}</li>
+        {% endif %}
         {# L10n: This label accompanies a numeric count. The number appears first so phrase translations accordingly. The phrase "and counting" means there are always more being added; not sure how that idiom might translate so do your best :) #}
         <li class="stat-local"><strong>{{ num_languages|l10n_format_number }}</strong> {{ _('languages and counting, on every continent') }}</li>
       </ul>

--- a/bedrock/mozorg/templates/mozorg/home/home.html
+++ b/bedrock/mozorg/templates/mozorg/home/home.html
@@ -303,12 +303,14 @@
           {# L10n: Line break below is for visual formatting only. #}
           <span>{{ _('active Mozillians <br>worldwide') }}</span>
         </li>
+        {% if events_count() %}
         <li>
           <span class="stat organizations">{{ events_count()|l10n_format_number }}</span>
           {# L10n: This label is preceeded by a numeric count before the translation. #}
           {# L10n: Line break below is for visual formatting only. #}
           <span>{{ _('upcoming events <br>around the globe') }}</span>
         </li>
+        {% endif %}
         <li>
           <span class="stat countries">{{ num_languages|l10n_format_number }}</span>
           {# L10n: This label is preceeded by a numeric count before the translation. #}

--- a/bedrock/settings/__init__.py
+++ b/bedrock/settings/__init__.py
@@ -76,3 +76,8 @@ if (len(sys.argv) > 1 and sys.argv[1] == 'test') or sys.argv[0].endswith('py.tes
     TEMPLATES[0]['OPTIONS']['debug'] = True
     # use default product-details data
     PROD_DETAILS_STORAGE = 'product_details.storage.PDFileStorage'
+
+    if not DATABASES['default']:
+        # tests do not like empty default db
+        DATABASES['default'] = DATABASES['bedrock']
+        DATABASE_ROUTERS = []

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -31,19 +31,23 @@ PROD = config('PROD', cast=bool, default=False)
 
 DEBUG = config('DEBUG', cast=bool, default=False)
 
-# Production uses MySQL, but Sqlite should be sufficient for local development.
-# Our CI server tests against MySQL.
-DATABASES = config(
-    'DATABASES',
-    cast=json.loads,
-    default=json.dumps(
-        {'default': config('DATABASE_URL',
-                           cast=dj_database_url.parse,
-                           default='sqlite:///bedrock.db')}))
-
-if DATABASES['default']['ENGINE'].endswith('psycopg2'):
-    # let the DB handle connection killing
-    DATABASES['default']['CONN_MAX_AGE'] = None
+# Production uses PostgreSQL, but Sqlite should be sufficient for local development.
+db_url = config('DATABASE_URL', default='sqlite:///bedrock.db')
+DATABASES = {
+    # leave 'default' empty so that Django will start even
+    # if it can't connect to the DB at boot time
+    'default': {},
+    'bedrock': dj_database_url.parse(db_url)
+}
+if db_url.startswith('sqlite'):
+    # no server, can use 'default'
+    DATABASES['default'] = DATABASES['bedrock']
+    # leave the config in 'bedrock' as well so scripts
+    # hardcoded for 'bedrock' will continue to work
+else:
+    # settings specific to db server environments
+    DATABASES['bedrock']['CONN_MAX_AGE'] = None
+    DATABASE_ROUTERS = ['bedrock.base.database.BedrockRouter']
 
 CACHES = config(
     'CACHES',

--- a/bin/circleci-demo-sync.sh
+++ b/bin/circleci-demo-sync.sh
@@ -26,7 +26,7 @@ fi
 # use settings in manage.py runs
 cp .bedrock_demo_env .env
 
-./manage.py migrate --noinput
+./manage.py migrate --noinput --database bedrock
 ./manage.py l10n_update
 ./manage.py rnasync
 ./manage.py cron update_ical_feeds

--- a/bin/sync_all
+++ b/bin/sync_all
@@ -5,7 +5,7 @@ if [ ! -e ./manage.py ]; then
     script_parent_dir=${0%/*}/..
     cd $script_parent_dir
 fi
-./manage.py migrate --noinput
+./manage.py migrate --noinput --database bedrock
 ./manage.py rnasync
 ./manage.py cron update_ical_feeds
 ./manage.py update_product_details

--- a/circle.yml
+++ b/circle.yml
@@ -52,7 +52,7 @@ test:
     - gulp js:lint
     - python manage.py runscript check_calendars
     - python manage.py version
-    - python manage.py migrate --noinput
+    - python manage.py migrate --noinput --database bedrock
     - python manage.py collectstatic --noinput -v 0
     - mkdir -p "$CIRCLE_TEST_REPORTS/django"
   override:

--- a/docker/run-common.sh
+++ b/docker/run-common.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-./manage.py syncdb --noinput
+./manage.py migrate --noinput --database bedrock

--- a/docker/run-common.sh
+++ b/docker/run-common.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-./manage.py migrate --noinput --database bedrock

--- a/docker/run-dev.sh
+++ b/docker/run-dev.sh
@@ -1,4 +1,0 @@
-#!/bin/sh
-
-./docker/run-common.sh
-./manage.py runserver 0.0.0.0:8000

--- a/docker/run-prod.sh
+++ b/docker/run-prod.sh
@@ -1,3 +1,2 @@
 #!/bin/bash -xe
-./docker/run-common.sh
 gunicorn wsgi.app:application -b 0.0.0.0:${PORT:-8000} -w ${WEB_CONCURRENCY:-2} --error-logfile - --access-logfile - --log-level ${LOGLEVEL:-info}


### PR DESCRIPTION
* Alter config to start wsgi process even without database server
* Change some templates to avoid relying on db data
* No longer run migrations on container start