### PR TITLE
[fix bug 1296114] Add GA to no-JS download links.

### DIFF
--- a/bedrock/firefox/templates/firefox/includes/download-button.html
+++ b/bedrock/firefox/templates/firefox/includes/download-button.html
@@ -15,7 +15,13 @@
     </p>
     <ul>
       {% for plat in builds -%}
-        <li><a href="{{ plat.download_link_direct or plat.download_link }}" class="download-link button green">{{ plat.os_arch_pretty or plat.os_pretty }}</a></li>
+        <li><a href="{{ plat.download_link_direct or plat.download_link }}"
+               class="download-link button green"
+               data-link-type="download"
+               {% if plat.os == 'android' %}data-download-os="Android"
+               {% elif plat.os == 'ios' %}data-download-os="iOS"
+               {% else %}data-download-os="Desktop"{% endif %}>{{ plat.os_arch_pretty or plat.os_pretty }}</a>
+        </li>
       {%- endfor %}
     </ul>
   </div>
@@ -56,9 +62,10 @@
         <a class="download-link button {{button_color}}"
            href="{{ plat.download_link }}"{% if plat.download_link_direct %}
            data-direct-link="{{ plat.download_link_direct }}"{% endif %}
-           {% if plat.os == 'android' %}data-link-type="download" data-download-os="Android"
-           {% elif plat.os == 'ios' %}data-link-type="download" data-download-os="iOS"
-           {% else %}data-link-type="download" data-download-os="Desktop"{% endif %}>
+           data-link-type="download"
+           {% if plat.os == 'android' %}data-download-os="Android"
+           {% elif plat.os == 'ios' %}data-download-os="iOS"
+           {% else %}data-download-os="Desktop"{% endif %}>
           <strong class="download-title">
             {% if alt_copy %}
               {{ alt_copy }}


### PR DESCRIPTION
## Description

Adds the same `data-*` attributes that currently exist on the smart download button to the direct links offered to users with no JS or on an unsupported platform.

## Bugzilla link

https://bugzilla.mozilla.org/show_bug.cgi?id=1296114

## Testing

Make sure no regressions?

## Checklist
- [ ] Related functional & integration tests passing.

