### PR TITLE
[fix bug 1295554] Firefox iOS page shows both App Store button and Send to Device widget when viewed on iOS

### DIFF
--- a/media/css/firefox/ios.less
+++ b/media/css/firefox/ios.less
@@ -621,7 +621,7 @@ a.go {
     .appstore-badge {
         display: block;
     }
-    .send-to-device,
+    #send-to-device,
     .send-to.button.green  {
         display: none;
     }


### PR DESCRIPTION
## Description
Fixes a minor regression - iOS users visiting /firefox/ios/ should only see an app store badge / link, and not the send to device form as well.

## Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1295554

## Testing
If you can't test on an iOS device changing the class on `<html>` to `ios` should give the same result.