### PR TITLE
Bug 1249774: Add SecurityMiddleware and settings for HSTS

### DIFF
--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -305,7 +305,6 @@ BASIC_AUTH_CREDS = config('BASIC_AUTH_CREDS', default=None)
 
 MIDDLEWARE_CLASSES = [
     'django.middleware.security.SecurityMiddleware',
-    'sslify.middleware.SSLifyMiddleware',
     'bedrock.mozorg.middleware.MozorgRequestTimingMiddleware',
     'django_statsd.middleware.GraphiteMiddleware',
     'corsheaders.middleware.CorsMiddleware',
@@ -407,10 +406,18 @@ SESSION_COOKIE_HTTPONLY = not DEBUG
 SESSION_COOKIE_SECURE = not DEBUG
 SESSION_ENGINE = 'django.contrib.sessions.backends.cache'
 
+# legacy setting. backward compat.
+DISABLE_SSL = config('DISABLE_SSL', default=True, cast=bool)
 # SecurityMiddleware settings
 SECURE_HSTS_SECONDS = config('SECURE_HSTS_SECONDS', default='0', cast=int)
 SECURE_HSTS_INCLUDE_SUBDOMAINS = False
 SECURE_BROWSER_XSS_FILTER = config('SECURE_BROWSER_XSS_FILTER', default=False, cast=bool)
+SECURE_SSL_REDIRECT = config('SECURE_SSL_REDIRECT', default=not DISABLE_SSL, cast=bool)
+SECURE_REDIRECT_EXEMPT = [
+    r'^healthz/$',
+]
+if SECURE_SSL_REDIRECT:
+    SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
 
 LOCALE_PATHS = (
     str(LOCALES_PATH),
@@ -1044,13 +1051,6 @@ STATSD_CLIENT = config('STATSD_CLIENT', default='django_statsd.clients.normal')
 STATSD_HOST = config('STATSD_HOST', default='127.0.0.1')
 STATSD_PORT = config('STATSD_PORT', cast=int, default=8125)
 STATSD_PREFIX = config('STATSD_PREFIX', default='bedrock')
-
-SSLIFY_DISABLE = config('DISABLE_SSL', default=True, cast=bool)
-if not SSLIFY_DISABLE:
-    SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
-SSLIFY_DISABLE_FOR_REQUEST = [
-    lambda request: request.get_full_path() == '/healthz/'
-]
 
 FIREFOX_MOBILE_SYSREQ_URL = 'https://support.mozilla.org/kb/will-firefox-work-my-mobile-device'
 

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -304,6 +304,7 @@ ENABLE_VARY_NOCACHE_MIDDLEWARE = config('ENABLE_VARY_NOCACHE_MIDDLEWARE',
 BASIC_AUTH_CREDS = config('BASIC_AUTH_CREDS', default=None)
 
 MIDDLEWARE_CLASSES = [
+    'django.middleware.security.SecurityMiddleware',
     'sslify.middleware.SSLifyMiddleware',
     'bedrock.mozorg.middleware.MozorgRequestTimingMiddleware',
     'django_statsd.middleware.GraphiteMiddleware',
@@ -405,6 +406,11 @@ VARY_NOCACHE_EXEMPT_URL_PREFIXES = (
 SESSION_COOKIE_HTTPONLY = not DEBUG
 SESSION_COOKIE_SECURE = not DEBUG
 SESSION_ENGINE = 'django.contrib.sessions.backends.cache'
+
+# SecurityMiddleware settings
+SECURE_HSTS_SECONDS = config('SECURE_HSTS_SECONDS', default='0', cast=int)
+SECURE_HSTS_INCLUDE_SUBDOMAINS = False
+SECURE_BROWSER_XSS_FILTER = config('SECURE_BROWSER_XSS_FILTER', default=False, cast=bool)
 
 LOCALE_PATHS = (
     str(LOCALES_PATH),

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -91,8 +91,6 @@ dj-database-url==0.3.0 \
     --hash=sha256:ca01768fdecde134301f3170743226f60edff5c3935f12437378ebd911506353
 python-decouple==2.3 \
     --hash=sha256:b9fbf747fa8e711d330f2f436b9b2ecf5eed9eb67a637ca81abcd11c2abedec8
-django-sslify==0.2.7 \
-    --hash=sha256:f6bfd21048c7dfc95b39659a3da77775d6db1c1f7a745805ccc6c6138f783b6d
 basket-client==0.3.12 \
     --hash=sha256:d7aa5e6208eeeabb8f1387a7cbb2d0f2b35dfa889c1f034c86a88b4968db3bfe \
     --hash=sha256:2dd953cd03b3068d0e596aa32224488c486b1170e46387c5bc14f20737d6a2d8


### PR DESCRIPTION
Also add setting for XSS filter header. All are disabled by default so that we can turn them on and test. Also remove sslify and replace with SecurityMiddleware