### PR TITLE
[bug 1281230] Remove l10n tags from TestFlight page template

### DIFF
--- a/bedrock/firefox/templates/firefox/testflight.html
+++ b/bedrock/firefox/templates/firefox/testflight.html
@@ -5,21 +5,13 @@
 {% extends "firefox/base-resp.html" %}
 
 {% block page_title_prefix %}
-  {% if l10n_has_tag('testflight_seo_update_082016') %}
-    {{ _('Firefox for iOS Beta') }} —
-  {% else %}
-    {{ _('Firefox for iOS') }} —
-  {% endif %}
+  {{ _('Firefox for iOS Beta') }} —
 {% endblock %}
 
 {% block page_title %}{{ _('TestFlight') }}{% endblock %}
 
 {% block page_desc %}
-  {% if l10n_has_tag('testflight_seo_update_082016') %}
-    {{ _('Sign up to test pre-release beta versions of Firefox for iOS via Apple’s TestFlight program and help make our mobile browser for iPhone, iPad and iPod touch even better.') }}
-  {% else %}
-    {{ _('Sign up to test pre-release versions of Firefox for iOS via Apple’s TestFlight Beta program and help make our mobile browser for iPhone, iPad and iPod touch even better.') }}
-  {% endif %}
+  {{ _('Sign up to test pre-release beta versions of Firefox for iOS via Apple’s TestFlight program and help make our mobile browser for iPhone, iPad and iPod touch even better.') }}
 {% endblock %}
 
 {% block body_id %}firefox-ios-testflight{% endblock %}


### PR DESCRIPTION
## Description
Followup to #4294 to remove superfluous 10n tags, as page is en-US only.

## Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1281230

