### PR TITLE
[bug 1272635] Update header on /about and /mission pages

### DIFF
--- a/bedrock/mozorg/templates/mozorg/about.html
+++ b/bedrock/mozorg/templates/mozorg/about.html
@@ -23,96 +23,98 @@
 {% endblock %}
 
 {% block content %}
-<article id="main-content">
-  <h1 class="title-shadow-box">{{ _('Get to know Mozilla') }}</h1>
+<main>
+  <header class="page-header">
+    <h1><span class="content">{{ _('Get to know Mozilla') }}</span></h1>
+  </header>
 
-  <div class="content-wrapper">
-    <p class="intro">{{ _('Learn more about our projects, products and principles designed to help people take control and explore the full potential of their lives online.') }}</p>
+  <div class="section">
+    <div class="content content-main">
+      <p class="intro">{{ _('Learn more about our projects, products and principles designed to help people take control and explore the full potential of their lives online.') }}</p>
 
-    <div class="video">
-      {% if request.locale == 'en-US' %}
-        <div class="moz-video-container">
-          <button class="moz-video-button" type="button" aria-controls="htmlPlayer">{{ _('Play video') }}</button>
-          {{ video('Mozilla_2014_i_am.webm',
-                   'Mozilla_2014_i_am.ogv',
-                   'Mozilla_2014_i_am.mp4',
-                   h=259, w=460,
-                   prefix='//videos.cdn.mozilla.net/uploads/mozillaorg/',
-                   poster=static('img/mozorg/about/poster-i-am.jpg')) }}
-        </div>
-        <p>{{ _('The heart of Mozilla is a global community with a shared mission. Watch the video to meet Mozillians from all over the world and all walks of life.') }}</p>
-      {% else %}
-        <img class="placeholder-img" src="{{ static('img/mozorg/about/poster-i-am.jpg') }}" alt="Mozilla">
-      {% endif %}
-    </div>
-  </div>{#-- /.content-wrapper --#}
-
-  <div class="content-wrapper">
-    <ul class="links">
-      <li>
-        <h4><a href="{{ url('mozorg.mission') }}">{{ _('The Mozilla mission') }}</a></h4>
-        <p>{{ _('What drives us and makes us different') }}</p>
-      </li>
-      <li>
-        <h4><a href="https://careers.mozilla.org/">{{ _('Career center') }}</a></h4>
-        {% if l10n_has_tag('about_links') %}
-        <p>{{ _('Want to work at Mozilla? Apply today!') }}</p>
+      <div class="video">
+        {% if request.locale == 'en-US' %}
+          <div class="moz-video-container">
+            <button class="moz-video-button" type="button" aria-controls="htmlPlayer">{{ _('Play video') }}</button>
+            {{ video('Mozilla_2014_i_am.webm',
+                     'Mozilla_2014_i_am.ogv',
+                     'Mozilla_2014_i_am.mp4',
+                     h=259, w=460,
+                     prefix='//videos.cdn.mozilla.net/uploads/mozillaorg/',
+                     poster=static('img/mozorg/about/poster-i-am.jpg')) }}
+          </div>
+          <p>{{ _('The heart of Mozilla is a global community with a shared mission. Watch the video to meet Mozillians from all over the world and all walks of life.') }}</p>
         {% else %}
-        <p>{{ _('Want to work on Firefox? Apply today!') }}</p>
+          <img class="placeholder-img" src="{{ static('img/mozorg/about/poster-i-am.jpg') }}" alt="Mozilla">
         {% endif %}
-      </li>
-      <li>
-        <h4><a href="https://blog.mozilla.org/">{{ _('Mozilla blog') }}</a></h4>
-        <p>{{ _('News, notes and ramblings from the Mozilla project') }}</p>
-      </li>
-      <li>
-        <h4><a href="/styleguide">{{ _('Mozilla style guide') }}</a></h4>
-        <p>{{ _('Logos, copy rules, visual assets and more') }}</p>
-      </li>
-      <li>
-        <h4><a href="{{ url('mozorg.contact.spaces.spaces-landing') }}">{{ _('Locations & contacts') }}</a></h4>
-        <p>{{ _('Addresses, emails, support and feedback forms') }}</p>
-      </li>
-      {% if l10n_has_tag('about_links') %}
-      <li>
-        <h4><a href="{{ url('foundation.moco') }} ">{{ _('The Mozilla Corporation') }} </a></h4>
-        <p>{{ _('A corporation that serves the public good. Seriously.') }}</p>
-      </li>
-      {% endif %}
-    </ul>
+      </div>
 
-    <ul class="links">
-      {% if l10n_has_tag('about_leadership') %}
-      <li>
-        <h4><a href="{{ url('mozorg.about.leadership') }}">{{ _('Mozilla leadership') }}</a></h4>
-        <p>{{ _('Our Management Teams, Reps Council and Boards of Directors') }}</p>
-      </li>
-      {% endif %}
-      <li>
-        <h4><a href="{{ url('firefox.family.index') }}">{{ _('Our products') }}</a></h4>
-        <p>{{ _('An overview of what we make and what we’re working on') }}</p>
-      </li>
-      <li>
-        <h4><a href="{{ url('mozorg.contribute.index') }}">{{ _('Get involved') }}</a></h4>
-        <p>{{ _('Become a volunteer contributor in a number of different areas') }}</p>
-      </li>
-      <li>
-        <h4><a href="{{ press_blog_url() }}">{{ _('Press center') }}</a></h4>
-        <p>{{ _('Press info and other useful stuff') }}</p>
-      </li>
-      <li>
-        <h4><a href="{{ url('privacy') }}">{{ _('Privacy center') }}</a></h4>
-        <p>{{ _('How Mozilla handles your personal information') }}</p>
-      </li>
-      {% if l10n_has_tag('about_links') %}
-      <li>
-        <h4><a href="{{ url('foundation.index') }}">{{ _('The Mozilla Foundation') }}</a></h4>
-        <p>{{ _('The non-profit organization behind Firefox and all Mozilla products') }}</p>
-      </li>
-       {% endif %}
-    </ul>
-  </div>{#-- /.content-wrapper --#}
-</article>
+      <ul class="links">
+        <li>
+          <h4><a href="{{ url('mozorg.mission') }}">{{ _('The Mozilla mission') }}</a></h4>
+          <p>{{ _('What drives us and makes us different') }}</p>
+        </li>
+        <li>
+          <h4><a href="https://careers.mozilla.org/">{{ _('Career center') }}</a></h4>
+          {% if l10n_has_tag('about_links') %}
+          <p>{{ _('Want to work at Mozilla? Apply today!') }}</p>
+          {% else %}
+          <p>{{ _('Want to work on Firefox? Apply today!') }}</p>
+          {% endif %}
+        </li>
+        <li>
+          <h4><a href="https://blog.mozilla.org/">{{ _('Mozilla blog') }}</a></h4>
+          <p>{{ _('News, notes and ramblings from the Mozilla project') }}</p>
+        </li>
+        <li>
+          <h4><a href="{{ url('styleguide.home') }}">{{ _('Mozilla style guide') }}</a></h4>
+          <p>{{ _('Logos, copy rules, visual assets and more') }}</p>
+        </li>
+        <li>
+          <h4><a href="{{ url('mozorg.contact.spaces.spaces-landing') }}">{{ _('Locations & contacts') }}</a></h4>
+          <p>{{ _('Addresses, emails, support and feedback forms') }}</p>
+        </li>
+        {% if l10n_has_tag('about_links') %}
+        <li>
+          <h4><a href="{{ url('foundation.moco') }} ">{{ _('The Mozilla Corporation') }}</a></h4>
+          <p>{{ _('A corporation that serves the public good. Seriously.') }}</p>
+        </li>
+        {% endif %}
+      </ul>
+
+      <ul class="links">
+        {% if l10n_has_tag('about_leadership') %}
+        <li>
+          <h4><a href="{{ url('mozorg.about.leadership') }}">{{ _('Mozilla leadership') }}</a></h4>
+          <p>{{ _('Our Management Teams, Reps Council and Boards of Directors') }}</p>
+        </li>
+        {% endif %}
+        <li>
+          <h4><a href="{{ url('firefox.family.index') }}">{{ _('Our products') }}</a></h4>
+          <p>{{ _('An overview of what we make and what we’re working on') }}</p>
+        </li>
+        <li>
+          <h4><a href="{{ url('mozorg.contribute.index') }}">{{ _('Get involved') }}</a></h4>
+          <p>{{ _('Become a volunteer contributor in a number of different areas') }}</p>
+        </li>
+        <li>
+          <h4><a href="{{ press_blog_url() }}">{{ _('Press center') }}</a></h4>
+          <p>{{ _('Press info and other useful stuff') }}</p>
+        </li>
+        <li>
+          <h4><a href="{{ url('privacy') }}">{{ _('Privacy center') }}</a></h4>
+          <p>{{ _('How Mozilla handles your personal information') }}</p>
+        </li>
+        {% if l10n_has_tag('about_links') %}
+        <li>
+          <h4><a href="{{ url('foundation.index') }}">{{ _('The Mozilla Foundation') }}</a></h4>
+          <p>{{ _('The non-profit organization behind Firefox and all Mozilla products') }}</p>
+        </li>
+         {% endif %}
+      </ul>
+    </div>
+  </div>
+</main>
 {% endblock %}
 
 {% block email_form %}

--- a/bedrock/mozorg/templates/mozorg/mission.html
+++ b/bedrock/mozorg/templates/mozorg/mission.html
@@ -23,52 +23,70 @@
 {% endblock %}
 
 {% block content %}
-<article id="main-content">
-  <h1 class="title-shadow-box">{{ _('We’re building a better Internet') }}</h1>
+<main>
+  <header class="page-header">
+    <h1><span class="content">{{ _('We’re building a better Internet') }}</span></h1>
+  </header>
 
-  <div class="main">
-    {% if l10n_has_tag('bug_1251061_copy_update') %}
-    <p>{{ _('Our mission is to ensure the Internet is a global public resource, open and accessible to all. An Internet that truly puts people first, where individuals can shape their own experience and are empowered, safe and independent.') }}</p>
-    {% else %}
-    <p class="lede">{{ _('Our mission is to promote openness, innovation & opportunity on the Web.') }}</p>
-    {% endif %}
-    <p>{{ _('At Mozilla, we’re a global community of technologists, thinkers and builders working together to keep the Internet alive and accessible, so people worldwide can be informed contributors and creators of the Web.') }}
-    {{ _('We believe this act of human collaboration across an open platform is essential to individual growth and our collective future.') }}</p>
-    <p>{{ _('Read the <a href="%(url)s">Mozilla Manifesto</a> to learn even more about the values and principles that guide the pursuit of our mission.') | format(url=url('mozorg.about.manifesto')) }}</p>
+  <div class="section">
+    <div class="content content-main">
 
-  </div>
+      <div class="main">
+        {% if l10n_has_tag('bug_1251061_copy_update') %}
+        <p class="lede">{{ _('Our mission is to ensure the Internet is a global public resource, open and accessible to all. An Internet that truly puts people first, where individuals can shape their own experience and are empowered, safe and independent.') }}</p>
+        {% else %}
+        <p class="lede">{{ _('Our mission is to promote openness, innovation & opportunity on the Web.') }}</p>
+        {% endif %}
+        <p>{{ _('At Mozilla, we’re a global community of technologists, thinkers and builders working together to keep the Internet alive and accessible, so people worldwide can be informed contributors and creators of the Web.') }}
+        {{ _('We believe this act of human collaboration across an open platform is essential to individual growth and our collective future.') }}</p>
+        <p>{{ _('Read the <a href="%(url)s">Mozilla Manifesto</a> to learn even more about the values and principles that guide the pursuit of our mission.') | format(url=url('mozorg.about.manifesto')) }}</p>
+      </div>
 
-  <div class="video">
-    <div class="moz-video-container">
-      <button class="moz-video-button" type="button" aria-controls="htmlPlayer">{{ _('Play video') }}</button>
-      {{ video('Mozilla_2011_Story.webm',
-               'Mozilla_2011_Story.ogv',
-               'Mozilla_2011_Story.mp4',
-               h=259, w=460,
-               prefix='//videos.cdn.mozilla.net/brand/',
-               poster=static('img/mission/poster-mission.jpg')) }}
+      <div class="video">
+        <div class="moz-video-container">
+          <button class="moz-video-button" type="button" aria-controls="htmlPlayer">{{ _('Play video') }}</button>
+          {{ video('Mozilla_2011_Story.webm',
+                   'Mozilla_2011_Story.ogv',
+                   'Mozilla_2011_Story.mp4',
+                   h=259, w=460,
+                   prefix='//videos.cdn.mozilla.net/brand/',
+                   poster=static('img/mission/poster-mission.jpg')) }}
+        </div>
+        <p class="caption">{{ _('Watch the video above to learn more about who we are, where we came from and how we’re making the Web better for you.') }}</p>
+      </div>
+
+      <ul class="links">
+        <li>
+          <h4><a href="{{ url('mozorg.contribute.index') }}">{{ _('Get involved') }}</a></h4>
+          <p>{{ _('Volunteer opportunities in a number of different areas') }}</p>
+        </li>
+        <li>
+          <h4><a href="{{ url('mozorg.about.history') }}">{{ _('History') }}</a></h4>
+          <p>{{ _('Where we come from and how we got to where we are') }}</p>
+        </li>
+        <li>
+          <h4><a href="{{ url('mozorg.about.forums.forums') }}">{{ _('Forums') }}</a></h4>
+          <p>{{ _('Topics include support, products, and technologies') }}</p>
+        </li>
+        <li>
+          <h4><a href="{{ url('mozorg.about.governance.governance') }}">{{ _('Governance') }}</a></h4>
+          <p>{{ _('Our structure, organization, and the broader Mozilla community') }}</p>
+        </li>
+      </ul>
+
     </div>
-    <p class="caption">{{ _('Watch the video above to learn more about who we are, where we came from and how we’re making the Web better for you.') }}</p>
   </div>
+</main>
+{% endblock %}
 
-  <ul class="links">
-    <li>
-      <h4><a href="{{ url('mozorg.contribute.index') }}">{{ _('Get involved') }}</a></h4>
-      <p>{{ _('Volunteer opportunities in a number of different areas') }}</p>
-    </li>
-    <li>
-      <h4><a href="{{ url('mozorg.about.history') }}">{{ _('History') }}</a></h4>
-      <p>{{ _('Where we come from and how we got to where we are') }}</p>
-    </li>
-    <li>
-      <h4><a href="{{ url('mozorg.about.forums.forums') }}">{{ _('Forums') }}</a></h4>
-      <p>{{ _('Topics include support, products, and technologies') }}</p>
-    </li>
-    <li>
-      <h4><a href="{{ url('mozorg.about.governance.governance') }}">{{ _('Governance') }}</a></h4>
-      <p>{{ _('Our structure, organization, and the broader Mozilla community') }}</p>
-    </li>
-  </ul>
-
-</article>
+{% block email_form %}
+  <aside id="newsletter-subscribe">
+    <div class="content container">
+    {% if LANG.startswith('en-') %}
+      {{ email_newsletter_form(newsletters='mozilla-foundation', title=_('Sign up. Read up.<br> Make a difference.'), subtitle=_('Get the Mozilla newsletter and help us keep the Web free and open.'), button_class='red') }}
+    {% else %}
+      {{ email_newsletter_form(button_class='red') }}
+    {% endif %}
+    </div>
+  </aside>
 {% endblock %}

--- a/bedrock/settings/static_media.py
+++ b/bedrock/settings/static_media.py
@@ -12,7 +12,7 @@ PIPELINE_CSS = {
         'source_filenames': (
             'css/base/mozilla-video-poster.less',
             'css/newsletter/moznewsletter-subscribe.less',
-            'css/mozorg/about-base.less',
+            'css/mozorg/about.less',
         ),
         'output_filename': 'css/about-bundle.css',
     },
@@ -673,6 +673,7 @@ PIPELINE_CSS = {
     'mission': {
         'source_filenames': (
             'css/base/mozilla-video-poster.less',
+            'css/newsletter/moznewsletter-subscribe.less',
             'css/mozorg/mission.less',
         ),
         'output_filename': 'css/mission-bundle.css',

--- a/media/css/mozorg/about.less
+++ b/media/css/mozorg/about.less
@@ -1,0 +1,388 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+@import "../sandstone/lib.less";
+
+#tabzilla:before {
+    background-color: @textColorSecondary;
+}
+
+#wrapper {
+    width: 100%;
+}
+
+#masthead,
+.billboard,
+.content {
+    width: @widthDesktop - (@gridGutterWidth * 2);
+    margin-left: auto;
+    margin-right: auto;
+}
+
+.page-header {
+    background: url('/media/img/newsletter/intro-mozsummit-2000.jpg') center bottom no-repeat;
+    .background-size(cover);
+    padding-top: 300px;
+
+    @media only screen and (min-width: @breakDesktopWide) {
+        background-image: url('/media/img/newsletter/intro-mozsummit-3000.jpg');
+    }
+
+    @media only screen and (min-width: @breakTablet) and (max-width: @breakDesktop) {
+        background-image: url('/media/img/newsletter/intro-mozsummit-1000.jpg');
+    }
+
+    @media only screen and (max-width: @breakTablet) {
+        padding-top: 150px;
+        background-image: url('/media/img/newsletter/intro-mozsummit-600.jpg');
+    }
+
+    @media only screen and (min-width: @breakMobileLandscape) and (max-width: @breakTablet) {
+        background-image: url('/media/img/newsletter/intro-mozsummit-1000.jpg');
+    }
+
+    h1 {
+        background: @mozillaRed;
+        color: #fff;
+        margin-bottom: 0;
+        padding: .35em 0;
+        text-shadow: none;
+    }
+
+    .content {
+        .border-box;
+        display: block;
+        padding: 0 10px;
+    }
+}
+
+.content-main {
+    .box-shadow(0 0 0 1px #fff inset);
+    .clearfix;
+    .open-sans;
+    background: #fff;
+    border-bottom: 1px solid #ddd;
+    display: block;
+    padding: 40px @gridGutterWidth;
+    position: relative;
+
+    .main-column {
+        .span(8);
+    }
+
+    .sidebar {
+        .offset(1);
+    }
+
+    .intro {
+        .open-sans-light;
+        .font-size(28px);
+        line-height: 1.3;
+        letter-spacing: -.5px;
+        .span(6);
+        clear: left;
+        margin-top: -.25em;
+    }
+
+    .video {
+        .span(6);
+        float: right;
+        margin-bottom: @baseLine;
+
+        .moz-video-container video {
+            width: 100%;
+            height: auto;
+            margin:0 auto;
+        }
+
+        p {
+            margin: 10px 10px @baseLine;
+            .font-size(12px);
+            font-style: italic;
+        }
+
+        .placeholder-img {
+            margin-bottom: @baseLine;
+        }
+
+        .moz-video-button {
+            background-image: url('/media/img/mozorg/about/poster-i-am.jpg');
+        }
+    }
+
+    ul.links {
+        clear: right;
+        .span(6);
+
+        li {
+            list-style-type: none;
+            margin-left: 0;
+            margin-bottom: @baseLine;
+            padding-bottom: 10px;
+            background: url(/media/img/mission/thin-stripe.png) center bottom repeat-x;
+            min-height: @baseLine * 4;
+        }
+
+        li:last-child {
+            padding: 0;
+            background-image: none;
+        }
+
+        h4 {
+            margin-bottom: @baseLine / 6;
+            a:after {
+                content: " »";
+                .open-sans-light;
+            }
+        }
+
+        p {
+            .font-size(12px);
+            margin-bottom: @baseLine / 2;
+        }
+    }
+
+    li > ul {
+        margin-bottom: @baseLine;
+    }
+
+    .sidebar {
+        margin-top: 20px;
+    }
+}
+
+html[dir="rtl"] {
+    .content-main .intro {
+        float: right;
+    }
+}
+
+// Newsletter form
+#newsletter-subscribe {
+    background: transparent none;
+    color: @textColorPrimary;
+    margin-top: 0;
+
+    .form-title {
+        background: transparent none;
+        position: relative;
+        text-align: center;
+
+        h3 {
+            .font-size(28px);
+            color: @mozillaRed;
+            font-weight: bold;
+            line-height: 1.25;
+        }
+
+        h4 {
+            .font-size(18px);
+            .open-sans;
+            color: @textColorSecondary;
+            line-height: 1.25;
+        }
+
+        &:before {
+            background: @mozillaRed url('/media/img/newsletter/mozorg-newsletter.svg') center center no-repeat;
+            .background-size(100px, 100px);
+            border-radius: 100%;
+            content: '';
+            display: block;
+            height: 150px;
+            left: 0;
+            position: absolute;
+            top: 0;
+            width: 150px;
+        }
+    }
+
+    a:link,
+    a:visited {
+        color: @linkBlue;
+    }
+
+    a:hover,
+    a:focus {
+        color: @linkBlueHover;
+    }
+
+    input[type='email'] {
+        border: 1px solid @borderColor;
+    }
+
+    #newsletter-form-thankyou {
+        color: @textColorPrimary;
+
+        h3 {
+            color: @textColorPrimary;
+        }
+    }
+}
+
+
+
+/* Tablet Layout: 760px */
+@media only screen and (min-width: @breakTablet) and (max-width: @breakDesktop) {
+
+    #masthead,
+    .content,
+    .billboard {
+        width: @widthTablet - (@gridGutterWidth * 2);
+    }
+
+    .page-header {
+        background-image: url('/media/img/newsletter/intro-mozsummit-1000.jpg');
+    }
+
+    .content-main {
+        .main-column {
+            .span_narrow(8);
+        }
+
+        .sidebar {
+            .offset_narrow(1);
+        }
+
+        .video {
+            .span_narrow(6);
+            margin-bottom: @baseLine;
+        }
+
+        .intro {
+            .span_narrow(6);
+            .font-size(22px);
+        }
+
+        ul.links {
+            .span_narrow(6);
+            h4 {
+                .font-size(20px);
+            }
+        }
+
+    }
+
+    #newsletter-subscribe .form-title {
+        h3 {
+            .font-size(24px);
+        }
+
+        h4 {
+            .font-size(16px);
+        }
+
+        &:before {
+            width: 120px;
+            height: 120px;
+            .background-size(80px, 80px);
+        }
+    }
+
+    html[dir="rtl"] {
+        #main-content .title-shadow-box {
+            margin-right: 0;
+            margin-left: 250px;
+        }
+    }
+
+    .gallery .vcard {
+        .span_narrow(2);
+        margin-bottom: @baseLine;
+    }
+
+    .brass .gallery {
+        margin: 0 0 @baseLine;
+
+        .vcard {
+            width: auto;
+            float: none;
+            margin: 0 0 @baseLine;
+            .clearfix();
+        }
+    }
+
+}
+
+/* Mobile layout: 320px */
+@media only screen and (max-width: @breakTablet) {
+
+    #masthead,
+    .content,
+    .billboard {
+        width: @widthMobile - (@gridGutterWidth * 2);
+    }
+
+    .billboard {
+        padding-left: @gridGutterWidth;
+        padding-right: @gridGutterWidth;
+    }
+
+    .content-main {
+        margin-bottom: @baseLine;
+
+        .main-column,
+        .sidebar {
+            .span-all();
+        }
+
+        .video {
+            width: 100%;
+            margin: 0;
+        }
+
+        .intro {
+            width: auto;
+            .font-size(16px);
+            margin-bottom: @baseLine;
+        }
+
+        ul.links {
+            width: auto;
+            margin-bottom: 0;
+            li {
+                min-height: 0;
+            }
+        }
+
+    }
+
+    #newsletter-subscribe .form-title {
+        padding-top: 150px;
+
+        &:before {
+            left: 50%;
+            top: -20px;
+            margin-left: -75px;
+        }
+    }
+
+}
+
+/* Wide mobile layout: 480px; */
+@media only screen and (min-width: @breakMobileLandscape) and (max-width: @breakTablet) {
+
+    #masthead,
+    .content,
+    .billboard {
+        width: @widthMobileLandscape - @gridGutterWidth;
+    }
+
+    .content-main {
+        .video {
+            width: 100%;
+            margin: 0;
+        }
+
+        .intro {
+            width: auto;
+        }
+
+        ul.links {
+            width: 100%;
+            margin: 0;
+            clear: right;
+        }
+
+    }
+}

--- a/media/css/mozorg/mission.less
+++ b/media/css/mozorg/mission.less
@@ -2,44 +2,72 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-@import "../sandstone/sandstone-resp.less";
+@import "../sandstone/lib.less";
 
 #tabzilla:before {
-  background-color: @textColorSecondary;
+    background-color: @textColorSecondary;
 }
 
 #wrapper {
-  width: 100%;
+    width: 100%;
 }
 
 #masthead,
-#main-content,
-.billboard {
-  width: @widthDesktop - (@gridGutterWidth * 2);
-  margin-left: auto;
-  margin-right: auto;
+.billboard,
+.content {
+    width: @widthDesktop - (@gridGutterWidth * 2);
+    margin-left: auto;
+    margin-right: auto;
 }
 
-#main-content {
-  .callout-content;
-  position: relative;
-  margin: 100px auto @baseLine;
-  .open-sans;
+.page-header {
+    background: url('/media/img/newsletter/intro-mozsummit-2000.jpg') center bottom no-repeat;
+    .background-size(cover);
+    padding-top: 300px;
 
-  .main {
-    .span(6);
-    float: left;
-    clear: left;
-    margin-bottom: @baseLine;
-  }
+    @media only screen and (min-width: @breakDesktopWide) {
+        background-image: url('/media/img/newsletter/intro-mozsummit-3000.jpg');
+    }
 
-  .lede {
-    .open-sans-light;
-    .font-size(28px);
-    line-height: 1.3;
-    letter-spacing: -.5px;
-    margin-top: -.25em;
-  }
+    h1 {
+        background: @mozillaRed;
+        color: #fff;
+        margin-bottom: 0;
+        padding: .35em 0;
+        text-shadow: none;
+    }
+
+    .content {
+        .border-box;
+        display: block;
+        padding: 0 10px;
+    }
+}
+
+.content-main {
+    .box-shadow(0 0 0 1px #fff inset);
+    .clearfix;
+    .open-sans;
+    background: #fff;
+    border-bottom: 1px solid #ddd;
+    display: block;
+    padding: 40px @gridGutterWidth;
+    position: relative;
+
+    .main {
+        .span(6);
+        float: left;
+        clear: left;
+        margin-bottom: @baseLine;
+    }
+
+    .lede {
+        .open-sans-light;
+        .font-size(28px);
+        line-height: 1.3;
+        letter-spacing: -.01em;
+        margin-top: -.25em;
+    }
 
 }
 // Adjust main style for RTL
@@ -51,104 +79,190 @@ html[dir="rtl"] #main-content {
 }
 
 .video {
-  .span(6);
-  float: right;
-  margin-top: -50px;
-  margin-bottom: @baseLine;
-  .moz-video-container video {
-    width: 100%;
-    height: auto;
-    margin: 0 auto;
-  }
-  .moz-video-button {
-    background-image: url('/media/img/mission/poster-mission.jpg');
-  }
-  .caption {
-    margin: 10px 10px @baseLine;
-    .font-size(.857em);
-    font-style: italic;
-  }
+    .span(6);
+    float: right;
+    margin-bottom: @baseLine;
+
+    .moz-video-container video {
+        height: auto;
+        margin: 0 auto;
+        width: 100%;
+    }
+
+    .moz-video-button {
+        background-image: url('/media/img/mission/poster-mission.jpg');
+    }
+
+    .caption {
+        .font-size(.857em);
+        font-style: italic;
+        margin: 10px 10px @baseLine;
+    }
 }
 
 ul.links {
-  list-style: none;
-  clear: both;
-  margin: @baseLine 0;
-  li {
-    .span(3);
-    list-style-type: none;
-    padding-top: 25px;
-    background: url(/media/img/mission/thin-stripe.png) center top repeat-x;
-  }
+    list-style: none;
+    clear: both;
+    margin: @baseLine 0;
 
-  h4 {
-    margin-bottom: @baseLine / 6;
-    a:after {
-      content: " »";
-      .open-sans-light;
+    li {
+        .span(3);
+        list-style-type: none;
+        padding-top: 25px;
+        background: url(/media/img/mission/thin-stripe.png) center top repeat-x;
     }
-  }
 
-  p {
-    .font-size(.857em);
-    margin-bottom: @baseLine / 2;
-  }
+    h4 {
+        margin-bottom: @baseLine / 6;
+
+        a {
+            .trailing-arrow;
+        }
+    }
+
+    p {
+        .font-size(.857em);
+        margin-bottom: @baseLine / 2;
+    }
+}
+
+// Newsletter form
+#newsletter-subscribe {
+    background: transparent none;
+    color: @textColorPrimary;
+    margin-top: 0;
+
+    .form-title {
+        background: transparent none;
+        position: relative;
+        text-align: center;
+
+        h3 {
+            .font-size(28px);
+            color: @mozillaRed;
+            font-weight: bold;
+            line-height: 1.25;
+        }
+
+        h4 {
+            .font-size(18px);
+            .open-sans;
+            color: @textColorSecondary;
+            line-height: 1.25;
+        }
+
+        &:before {
+            background: @mozillaRed url('/media/img/newsletter/mozorg-newsletter.svg') center center no-repeat;
+            .background-size(100px, 100px);
+            border-radius: 100%;
+            content: '';
+            display: block;
+            height: 150px;
+            left: 0;
+            position: absolute;
+            top: 0;
+            width: 150px;
+        }
+    }
+
+    a:link,
+    a:visited {
+        color: @linkBlue;
+    }
+
+    a:hover,
+    a:focus {
+        color: @linkBlueHover;
+    }
+
+    input[type='email'] {
+        border: 1px solid @borderColor;
+    }
+
+    #newsletter-form-thankyou {
+        color: @textColorPrimary;
+
+        h3 {
+            color: @textColorPrimary;
+        }
+    }
 }
 
 /* Tablet Layout: 760px */
 @media only screen and (min-width: @breakTablet) and (max-width: @breakDesktop) {
-  #masthead,
-  #main-content,
-  .billboard {
-    width: @widthTablet - (@gridGutterWidth * 2);
-  }
+    #masthead,
+    .content,
+    .billboard {
+        width: @widthTablet - (@gridGutterWidth * 2);
+    }
 
-  #main-content .main,
-  #main-content .video {
-    .span_narrow(6);
-  }
+    .content-main .main,
+    .content-main .video {
+        .span_narrow(6);
+    }
 
-  ul.links li {
-    .span_narrow(3);
-  }
+    ul.links li {
+        .span_narrow(3);
+    }
+
+    #newsletter-subscribe .form-title {
+        h3 {
+            .font-size(24px);
+        }
+
+        h4 {
+            .font-size(16px);
+        }
+
+        &:before {
+            width: 120px;
+            height: 120px;
+            .background-size(80px, 80px);
+        }
+    }
 }
 
 /* Mobile layout: 320px */
 @media only screen and (max-width: @breakTablet) {
-  #masthead,
-  #main-content,
-  .billboard {
-    width: @widthMobile - (@gridGutterWidth * 2);
-  }
-
-  .billboard {
-    padding-left: @gridGutterWidth;
-    padding-right: @gridGutterWidth;
-  }
-
-  #main-content .video {
-    margin-top: 0;
-  }
-
-  #main-content {
-    .lede {
-      .font-size(20px);
+    #masthead,
+    .content,
+    .billboard {
+        width: @widthMobile - (@gridGutterWidth * 2);
     }
 
-    .main,
-    .video,
-    ul.links li {
-      width: auto;
-      float: none;
+    .billboard {
+        padding-left: @gridGutterWidth;
+        padding-right: @gridGutterWidth;
     }
-  }
+
+    .page-header {
+        padding-top: 150px;
+        background-image: url('/media/img/newsletter/intro-mozsummit-600.jpg');
+    }
+
+    .content-main {
+        .lede {
+            .font-size(20px);
+        }
+
+        .main,
+        .video,
+        ul.links li {
+            width: auto;
+            float: none;
+        }
+    }
 }
 
 /* Wide mobile layout: 480px; */
 @media only screen and (min-width: @breakMobileLandscape) and (max-width: @breakTablet) {
-  #masthead,
-  #main-content,
-  .billboard {
-    width: @widthMobileLandscape - @gridGutterWidth;
-  }
+    #masthead,
+    .content,
+    .billboard {
+        width: @widthMobileLandscape - @gridGutterWidth;
+    }
+
+    .page-header {
+        background-image: url('/media/img/newsletter/intro-mozsummit-1000.jpg');
+    }
 }


### PR DESCRIPTION
## Description
This is a follow-up to removing the mosaic header on these two pages. It updates the header design and also divorces these pages from about-base.less, which a lot of other pages reference and I didn't want to break that base template and have to update all those other pages as well.

* Replace the mosaic with a single image
* Update newsletter form on /mission
* Some format cleanup and minor fixes

## Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1272635

## Checklist
- [ ] Requires l10n changes.
- [ ] Related functional & integration tests passing.