### PR TITLE
[fix bug 1290313] Remove reference to deleted mosaic.less

### DIFF
--- a/bedrock/settings/static_media.py
+++ b/bedrock/settings/static_media.py
@@ -665,7 +665,6 @@ PIPELINE_CSS = {
         'source_filenames': (
             'css/base/mozilla-modal.less',
             'css/base/mozilla-share-cta.less',
-            'css/mozorg/mosaic.less',
             'css/mozorg/manifesto.less',
         ),
         'output_filename': 'css/manifesto-bundle.css',


### PR DESCRIPTION
## Description

Removes lingering reference to the recently deleted (see #4259) `mosaic.less`. 

## Bugzilla link

https://bugzilla.mozilla.org/show_bug.cgi?id=1290313

## Testing

Ensure `/about/manifesto` still renders properly.

## Checklist
- [ ] Related functional & integration tests passing.

