### PR TITLE
Data attribute additions

### DIFF
--- a/bedrock/base/templates/product-all-macros.html
+++ b/bedrock/base/templates/product-all-macros.html
@@ -84,10 +84,14 @@
 #}
 {% macro build_link(build, platform, tooltip) %}
   {% if build.platforms[platform] %}
-    <td class="download {{ platform }}"><a href="{{ build.platforms[platform].download_url }}" title="{{ tooltip }}"
-    {% if platform == 'android' %}data-link-type="download" data-download-os="Android"
-    {% elif platform == 'ios' %}data-link-type="download" data-download-os="iOS"
-    {% else %}data-link-type="download" data-download-os="Desktop"{% endif %}>{{ _('Download') }}</a></td>
+    <td class="download {{ platform }}">
+        <a href="{{ build.platforms[platform].download_url }}" title="{{ tooltip }}"
+           data-download-version="{{ platform }}" data-download-language="{{ build.name_en|lower}}" data-link-type="download"
+           {% if platform == 'android' %} data-download-os="Android"
+           {% elif platform == 'ios' %} data-download-os="iOS"
+           {% else %} data-download-os="Desktop"{% endif %}>{{ _('Download') }}
+        </a>
+    </td>
   {% else %}
     <td class="unavailable">{{ _('Not Yet Available') }}</td>
   {% endif %}

--- a/bedrock/firefox/templates/firefox/android/index.html
+++ b/bedrock/firefox/templates/firefox/android/index.html
@@ -35,7 +35,7 @@
   {% call fxfamilynav('android') %}
     <div class="{% if has_widget %}show-widget{% endif %}">
       {{ google_play_button(class_name='dl-button') }}
-      <button id="send-to-button-header" class="send-to button dark" type="button" data-button-name="Get Firefox for Android">{{ _('Get Firefox for Android') }}</button>
+      <button id="send-to-button-header" class="send-to button dark" type="button" data-button-name="Get Firefox for Android" data-cta-position="Nav">{{ _('Get Firefox for Android') }}</button>
     </div>
   {% endcall %}
 {% endblock %}
@@ -384,7 +384,7 @@
           <h3>{{ _('Choose Firefox') }}</h3>
           <div id="send-to-device-footer">
             {{ google_play_button(anchor_attributes={'data-alt': _('Get Firefox for Android')}, class_name='dl-button') }}
-            <button id="send-to-button-footer" class="send-to button dark" type="button" data-button-name="Get Firefox for Android">{{ _('Get Firefox for Android') }}</button>
+            <button id="send-to-button-footer" class="send-to button dark" type="button" data-button-name="Get Firefox for Android" data-cta-position="Secondary">{{ _('Get Firefox for Android') }}</button>
           </div>
         </div>{#-- /#download-content --#}
       </div>{#-- /#download-wrapper --#}

--- a/bedrock/firefox/templates/firefox/desktop/customize.html
+++ b/bedrock/firefox/templates/firefox/desktop/customize.html
@@ -246,7 +246,7 @@
 
       {% include 'firefox/includes/sync-animation.html' %}
 
-      <a class="button" id="sync-button" href="http://www.mozilla.org/mobile/sync/" data-link-type="button" data-link-name="Learn more about Sync"><span></span>{{ _('Learn more about Sync') }}</a>
+      <a class="button" id="sync-button" href="http://www.mozilla.org/mobile/sync/" data-link-type="button" data-link-name="Learn more about Sync" data-cta-position="Secondary"><span></span>{{ _('Learn more about Sync') }}</a>
       <br>
       <a class="more" rel="external" data-interaction="outbound link" href="https://support.mozilla.org/kb/how-do-i-set-up-firefox-sync">{{ _('Get help with Sync') }}</a>
     </div>

--- a/bedrock/firefox/templates/firefox/ios.html
+++ b/bedrock/firefox/templates/firefox/ios.html
@@ -28,7 +28,7 @@
       <a class="dl-button" rel="external" href="{{ firefox_ios_url('mozorg-ios_page-appstore-button') }}" data-link-type="download" data-download-os="iOS">
         <img src="{{ l10n_img('firefox/ios/btn-app-store.svg') }}" alt="{{ _('Download on the App Store') }}">
       </a>
-      <button class="send-to button green" type="button" data-button-name="Get Firefox for iOS">{{ _('Get Firefox for iOS') }}</button>
+      <button class="send-to button green" type="button" data-button-name="Get Firefox for iOS" data-cta-position="Nav">{{ _('Get Firefox for iOS') }}</button>
     </div>
   {% endcall %}
 {% endblock %}
@@ -81,22 +81,22 @@
     <div class="sync-cta">
 
       <div class="default">
-        <p><a href="{{ url('firefox.sync') }}" class="button" data-link-type="button" data-link-name="Learn more about Sync">{{ _('Learn more about Sync') }}</a></p>
+        <p><a href="{{ url('firefox.sync') }}" class="button" data-link-type="button" data-link-name="Learn more about Sync" data-cta-position="Secondary">{{ _('Learn more about Sync') }}</a></p>
       </div>
 
       <div class="fx-signed-out">
-        <p><button type="button" class="button sync-button" data-button-name="Get started with Sync">{{ _('Get started with Sync') }}</button></p>
+        <p><button type="button" class="button sync-button" data-button-name="Get started with Sync" data-cta-position="Secondary">{{ _('Get started with Sync') }}</button></p>
         <p>{{ _('Already have an account?') }} <a href="https://support.mozilla.org/kb/how-do-i-set-up-firefox-sync" class="go">{{ _('Sign in') }}</a></p>
       </div>
 
       <div class="fx-signed-in">
         <h3>{{ _('You’re already signed in!') }}</h3>
-        <p><a href="{{ url('firefox.sync') }}" class="go" data-link-type="button" data-link-name="Learn more about Sync">{{ _('Learn more about Sync') }}</a></p>
+        <p><a href="{{ url('firefox.sync') }}" class="go" data-link-type="button" data-link-name="Learn more about Sync" data-cta-position="Secondary">{{ _('Learn more about Sync') }}</a></p>
       </div>
 
       <div class="fx-ios">
         <h3>{{ _('Sync your Firefox browsing history on iOS') }}</h3>
-        <p><button type="button" class="button sync-start-ios" data-button-name="Get started with Sync">{{ _('Get started with Sync') }}</button></p>
+        <p><button type="button" class="button sync-start-ios" data-button-name="Get started with Sync" data-cta-position="Secondary">{{ _('Get started with Sync') }}</button></p>
         <p><a href="{{ firefox_ios_url() }}" class="go">{{ _('Learn more in the App Store') }}</a></p>
       </div>
 

--- a/bedrock/firefox/templates/firefox/new/horizon/scene1.html
+++ b/bedrock/firefox/templates/firefox/new/horizon/scene1.html
@@ -44,7 +44,7 @@
             <h1 class="hide-for-refresh">{{ _('Browse Freely') }}</h1>
             <div id="refresh-firefox-wrapper">
               <h2>{{ _('Give Firefox a tune up') }}</h2>
-              <button type="button" id="refresh-firefox" data-interaction="Refresh Firefox" data-element-action="Firefox Desktop" class="button">{{ _('Refresh Firefox') }}</button>
+              <button type="button" id="refresh-firefox" data-interaction="Refresh Firefox" data-element-action="Firefox Desktop" data-button-name="Refresh Firefox" data-cta-position="Primary" class="button">{{ _('Refresh Firefox') }}</button>
               <a href="https://support.mozilla.org/kb/refresh-firefox-reset-add-ons-and-settings?utm_source=mozilla.org&amp;utm_medium=referral&amp;utm_campaign=learn-more-link" rel="external">{{ _('Learn more') }}</a>
             </div>
             <div class="desktop-latest-links-wrapper latest-links-wrapper">

--- a/bedrock/firefox/templates/firefox/new/scene1.html
+++ b/bedrock/firefox/templates/firefox/new/scene1.html
@@ -61,7 +61,7 @@
     {% if l10n_has_tag('firefox_new_refresh_button') %}
       <div id="refresh-firefox-wrapper">
         <p>{{ _('Give Firefox a tune up') }}</p>
-        <button type="button" id="refresh-firefox" data-button-name="Refresh Firefox" class="button">{{ _('Refresh Firefox') }}</button>
+        <button type="button" id="refresh-firefox" data-button-name="Refresh Firefox" data-cta-position="Primary" class="button">{{ _('Refresh Firefox') }}</button>
         <a href="https://support.mozilla.org/kb/refresh-firefox-reset-add-ons-and-settings?utm_source=mozilla.org&amp;utm_medium=referral&amp;utm_campaign=learn-more-link" rel="external">{{ _('Learn more') }}</a>
       </div>
     {% endif %}

--- a/bedrock/firefox/templates/firefox/private-browsing.html
+++ b/bedrock/firefox/templates/firefox/private-browsing.html
@@ -31,7 +31,7 @@
         <h1>{{ _('More protection. <br>The most privacy. <br>Only from Firefox.') }}</h1>
         <div class="download-buttons">
           <div class="firefox-latest-cta">
-            <a class="try-pb-button button dark" data-highlight="privateWindow" href="https://support.mozilla.org/kb/private-browsing-use-firefox-without-history/">{{ _('Try Private Browsing') }}</a>
+            <a class="try-pb-button button dark" data-highlight="privateWindow" data-link-type="button" data-link-name="Try Private Browsing" data-cta-position="Primary" href="https://support.mozilla.org/kb/private-browsing-use-firefox-without-history/">{{ _('Try Private Browsing') }}</a>
           </div>
           <div class="non-firefox-cta">
             <p>{{ _('To give the new Private Browsing a try, download Firefox.') }}</p>
@@ -136,7 +136,7 @@
       <div class="download-buttons">
         <div class="firefox-latest-cta">
           <h2>{{ _('Try it now to stay in control') }}</h2>
-          <a class="try-pb-button button dark" data-highlight="privateWindow" href="https://support.mozilla.org/kb/private-browsing-use-firefox-without-history/">{{ _('Try Private Browsing') }}</a>
+          <a class="try-pb-button button dark" data-highlight="privateWindow" data-link-type="button" data-link-name="Try Private Browsing" data-cta-position="Secondary" href="https://support.mozilla.org/kb/private-browsing-use-firefox-without-history/">{{ _('Try Private Browsing') }}</a>
         </div>
         <div class="non-firefox-cta">
           <h2>{{ _('To give the new Private Browsing a try, download Firefox.') }}</h2>

--- a/bedrock/firefox/templates/firefox/sync.html
+++ b/bedrock/firefox/templates/firefox/sync.html
@@ -102,7 +102,7 @@
 
         <div class="show-fx-31-signed-out">
         {% if not version %}
-          <button class="button" data-interaction="button click" data-element-action="Sync CTA"  id="cta-sync">
+          <button class="button" data-button-name="Get started with Sync" data-cta-position="Primary" id="cta-sync">
             {{ _('Get started with Sync') }}
           </button>
         {% else %}
@@ -116,7 +116,7 @@
             {% endif %}
             </label>
             <input type="email" id="fxa-email" class="fxa-email" placeholder="{{ _('YOUR EMAIL HERE') }}">
-            <button type="submit" class="button" data-interaction="button click" data-element-action="Sync CTA" id="cta-sync-variation">
+            <button type="submit" class="button" data-button-name="Get started with Sync" data-cta-position="Primary" id="cta-sync-variation">
             {% if version == '2' %}
               {{ _('Get started with Sync') }}
             {% elif version == '3' %}

--- a/bedrock/firefox/templates/firefox/whatsnew_42/whatsnew.html
+++ b/bedrock/firefox/templates/firefox/whatsnew_42/whatsnew.html
@@ -13,7 +13,7 @@
 {% block body_class %}firefox-up-to-date{% endblock %}
 
 {% block main_subhead %}
-  <a class="button dark" href="{{ url('firefox.private-browsing') }}" data-highlight="privateWindow" role="button" data-link-type="button" data-link-name="Try the new Private Browsing">{{ _('Try the new Private Browsing') }}</a>
+  <a class="button dark" href="{{ url('firefox.private-browsing') }}" data-highlight="privateWindow" role="button" data-link-type="button" data-link-name="Try the new Private Browsing" data-cta-position="Primary">{{ _('Try the new Private Browsing') }}</a>
 {% endblock %}
 
 {% block private_browsing_cta %}

--- a/bedrock/firefox/templates/firefox/win10-welcome.html
+++ b/bedrock/firefox/templates/firefox/win10-welcome.html
@@ -49,7 +49,7 @@
   </header>
   <section class="firefox-default-cta hidden">
     {% if l10n_has_tag('win10_button_update') %}
-      <button id="set-default" type="button" class="button dark" data-button-name="Let's do it">{{ _('Let’s do it') }}</button>
+      <button id="set-default" type="button" class="button dark" data-button-name="Let's do it" data-cta-position="Primary">{{ _('Let’s do it') }}</button>
     {% endif %}
     <h2>{{ _('Make Firefox your default in 3 easy steps:') }}</h2>
     <ol>

--- a/bedrock/mozorg/templates/mozorg/contribute/contribute-base.html
+++ b/bedrock/mozorg/templates/mozorg/contribute/contribute-base.html
@@ -43,7 +43,7 @@
               {{ _('Meet<br> Mozillians') }}
             </a></li>
             {% block contrib_nav_cta %}
-            <li class="nav-cta"><a href="{{ url('mozorg.contribute.signup') }}" data-link-type="nav" data-link-name="Get involved">{{ _('Get involved') }}</a></li>
+            <li class="nav-cta"><a href="{{ url('mozorg.contribute.signup') }}" data-link-type="nav" data-link-name="Get involved" data-cta-position="Nav">{{ _('Get involved') }}</a></li>
             {% endblock contrib_nav_cta %}
           </ul>
         </nav>

--- a/bedrock/mozorg/templates/mozorg/contribute/index.html
+++ b/bedrock/mozorg/templates/mozorg/contribute/index.html
@@ -37,7 +37,7 @@
         </div>
       </div>
 
-      <p class="cta"><a href="{{ url('mozorg.contribute.signup') }}" class="button" data-link-type="button" data-link-name="Get Involved">{{ _('Get Involved') }}</a></p>
+      <p class="cta"><a href="{{ url('mozorg.contribute.signup') }}" class="button" data-link-type="button" data-link-name="Get Involved" data-cta-position="Primary">{{ _('Get Involved') }}</a></p>
 
       <div class="cycle-pager"></div>
     </div>
@@ -110,10 +110,10 @@
         <li class="step2">{{ _('Stand by for an email that will connect you to the Mozilla community') }}</li>
         <li class="step3">{{ _('Create your Mozillians account and share your contributions with the world') }}</li>
       </ol>
-      <p class="cta"><a href="{{ url('mozorg.contribute.signup') }}" class="button" data-link-type="button" data-link-name="Get started">{{ _('Get started') }}</a></p>
+      <p class="cta"><a href="{{ url('mozorg.contribute.signup') }}" class="button" data-link-type="button" data-link-name="Get started" data-cta-position="Secondary">{{ _('Get started') }}</a></p>
       #}
       <h2 class="section-title">{{ _('Join a global community of game-changers.') }}</h2>
-      <p class="cta"><a href="{{ url('mozorg.contribute.signup') }}" class="button" data-link-type="button" data-link-name="Get Involved">{{ _('Get Involved') }}</a></p>
+      <p class="cta"><a href="{{ url('mozorg.contribute.signup') }}" class="button" data-link-type="button" data-link-name="Get Involved" data-cta-position="Secondary">{{ _('Get Involved') }}</a></p>
     </div>
   </section>
 

--- a/media/js/base/core-datalayer-init.js
+++ b/media/js/base/core-datalayer-init.js
@@ -15,7 +15,8 @@ $(function() {
             'pageHasVideo': analytics.pageHasVideo(),
             'pageVersion': analytics.getPageVersion(),
             // white listed for www.mozill.org, will always return false on other domains
-            'testPilotUser': 'testpilotAddon' in navigator ? 'true' : 'false'
+            'testPilotUser': 'testpilotAddon' in navigator ? 'true' : 'false',
+            'releaseWindowVersion': analytics.getLatestFxVersion()
         };
 
         dataLayer.push(dataLayerCore);

--- a/media/js/base/core-datalayer.js
+++ b/media/js/base/core-datalayer.js
@@ -40,6 +40,13 @@ if (typeof Mozilla.Analytics == 'undefined') {
         return versionResults ? versionResults[1] : null;
     };
 
+    /** Returns latest Fx version.
+    * @return {String} latest Fx version.
+    */
+    analytics.getLatestFxVersion = function() {
+        return $('html').data('latest-firefox');
+    };
+
     /** Monkey patch for dataLayer.push
     *   Adds href stripped of locale to link click objects when pushed to the dataLayer,
     *   also removes protocol and host if same as parent page from href.

--- a/tests/unit/spec/base/core-datalayer.js
+++ b/tests/unit/spec/base/core-datalayer.js
@@ -67,6 +67,23 @@ describe('core-datalayer.js', function() {
         });
     });
 
+    describe('getLatestFxVersion', function() {
+
+        afterEach(function() {
+            $('html').removeData('latest-firefox');
+        });
+
+        it('will return the Firefox version from the data-latest-firefox attribute from the html element if present', function() {
+            $('html').data('latest-firefox', '48.0');
+
+            expect(Mozilla.Analytics.getLatestFxVersion()).toBe('48.0');
+        });
+
+        it('will return undefined if no data-latest-firefox attribute is present on the html element', function() {
+            expect(Mozilla.Analytics.getLatestFxVersion()).toBeUndefined();
+        });
+    });
+
     describe('updateDataLayerPush', function() {
         var linkElement;
 


### PR DESCRIPTION
## Description
-Added data attributes for download version and language on downloads on /firefox/all page. 
-Added data attributes for cta positions on cta buttons.
-Added Release Window Version to core datalayer object which pulls from the data-latest-firefox attribute on the `<html>` element on the page.

## Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1286903
https://bugzilla.mozilla.org/show_bug.cgi?id=1286933

