### PR TITLE
[fix bug 1298402] Mapbox static images on /contact pages are 400

### DIFF
--- a/bedrock/mozorg/templates/mozorg/contact/spaces/auckland.html
+++ b/bedrock/mozorg/templates/mozorg/contact/spaces/auckland.html
@@ -27,7 +27,8 @@
         </ul>
 
         <figure class="feature-img">
-          <img src="//api.tiles.mapbox.com/v4/mozilla-webprod.e91ef8b3/url-{{ 'mozorg.cdn.mozilla.net/media/img/contact/moz-map-pin.png'|urlencode }}(174.777106,-36.866596)/174.777106,-36.866596,16/460x250.png?access_token={{ settings.MAPBOX_ACCESS_TOKEN }}" alt="">
+          {% set pin = static('img/contact/moz-map-pin.png')|absolute_url %}
+          <img src="https://api.tiles.mapbox.com/v4/{{ settings.MAPBOX_TOKEN }}/url-{{ pin|urlencode }}(174.777106,-36.866596)/174.777106,-36.866596,16/460x250.png?access_token={{ settings.MAPBOX_ACCESS_TOKEN }}" alt="">
         </figure>
       </div>
 

--- a/bedrock/mozorg/templates/mozorg/contact/spaces/beijing.html
+++ b/bedrock/mozorg/templates/mozorg/contact/spaces/beijing.html
@@ -23,7 +23,8 @@
         </p>
 
         <figure class="feature-img">
-          <img src="//api.tiles.mapbox.com/v4/{{ settings.MAPBOX_TOKEN }}/url-{{ 'mozorg.cdn.mozilla.net/media/img/contact/moz-map-pin.png'|urlencode }}(116.4280,39.9115)/116.4280,39.9115,16/460x250.png?access_token={{ settings.MAPBOX_ACCESS_TOKEN }}" alt="">
+          {% set pin = static('img/contact/moz-map-pin.png')|absolute_url %}
+          <img src="https://api.tiles.mapbox.com/v4/{{ settings.MAPBOX_TOKEN }}/url-{{ pin|urlencode }}(116.4280,39.9115)/116.4280,39.9115,16/460x250.png?access_token={{ settings.MAPBOX_ACCESS_TOKEN }}" alt="">
         </figure>
       </div>
 

--- a/bedrock/mozorg/templates/mozorg/contact/spaces/berlin.html
+++ b/bedrock/mozorg/templates/mozorg/contact/spaces/berlin.html
@@ -28,7 +28,8 @@
         </ul>
 
         <figure class="feature-img">
-          <img src="//api.tiles.mapbox.com/v4/{{ settings.MAPBOX_TOKEN }}/url-{{ 'mozorg.cdn.mozilla.net/media/img/contact/moz-map-pin.png'|urlencode }}(13.38935,52.54175)/13.38935,52.54175,16/460x250.png?access_token={{ settings.MAPBOX_ACCESS_TOKEN }}" alt="">
+          {% set pin = static('img/contact/moz-map-pin.png')|absolute_url %}
+          <img src="https://api.tiles.mapbox.com/v4/{{ settings.MAPBOX_TOKEN }}/url-{{ pin|urlencode }}(13.38935,52.54175)/13.38935,52.54175,16/460x250.png?access_token={{ settings.MAPBOX_ACCESS_TOKEN }}" alt="">
         </figure>
       </div>
 

--- a/bedrock/mozorg/templates/mozorg/contact/spaces/london.html
+++ b/bedrock/mozorg/templates/mozorg/contact/spaces/london.html
@@ -28,7 +28,8 @@
         </ul>
 
         <figure class="feature-img">
-          <img src="//api.tiles.mapbox.com/v4/{{ settings.MAPBOX_TOKEN }}/url-{{ 'mozorg.cdn.mozilla.net/media/img/contact/moz-map-pin.png'|urlencode }}(-0.0971,51.5047)/-0.0971,51.5047,16/460x250.png?access_token={{ settings.MAPBOX_ACCESS_TOKEN }}" alt="">
+          {% set pin = static('img/contact/moz-map-pin.png')|absolute_url %}
+          <img src="https://api.tiles.mapbox.com/v4/{{ settings.MAPBOX_TOKEN }}/url-{{ pin|urlencode }}(-0.0971,51.5047)/-0.0971,51.5047,16/460x250.png?access_token={{ settings.MAPBOX_ACCESS_TOKEN }}" alt="">
         </figure>
       </div>
 

--- a/bedrock/mozorg/templates/mozorg/contact/spaces/mountain-view.html
+++ b/bedrock/mozorg/templates/mozorg/contact/spaces/mountain-view.html
@@ -28,7 +28,8 @@
         </ul>
 
         <figure class="feature-img">
-          <img src="//api.tiles.mapbox.com/v4/{{ settings.MAPBOX_TOKEN }}/url-{{ 'mozorg.cdn.mozilla.net/media/img/contact/moz-map-pin.png'|urlencode }}(-122.060197,37.387447)/-122.060197,37.387447,16/460x250.png?access_token={{ settings.MAPBOX_ACCESS_TOKEN }}" alt="">
+          {% set pin = static('img/contact/moz-map-pin.png')|absolute_url %}
+          <img src="https://api.tiles.mapbox.com/v4/{{ settings.MAPBOX_TOKEN }}/url-{{ pin|urlencode }}(-122.060197,37.387447)/-122.060197,37.387447,16/460x250.png?access_token={{ settings.MAPBOX_ACCESS_TOKEN }}" alt="">
         </figure>
       </div>
 

--- a/bedrock/mozorg/templates/mozorg/contact/spaces/paris.html
+++ b/bedrock/mozorg/templates/mozorg/contact/spaces/paris.html
@@ -27,7 +27,8 @@
         </ul>
 
         <figure class="feature-img">
-          <img src="//api.tiles.mapbox.com/v4/{{ settings.MAPBOX_TOKEN }}/url-{{ 'mozorg.cdn.mozilla.net/media/img/contact/moz-map-pin.png'|urlencode }}(2.341210,48.871951)/2.341210,48.871951,16/460x250.png?access_token={{ settings.MAPBOX_ACCESS_TOKEN }}" alt="">
+          {% set pin = static('img/contact/moz-map-pin.png')|absolute_url %}
+          <img src="https://api.tiles.mapbox.com/v4/{{ settings.MAPBOX_TOKEN }}/url-{{ pin|urlencode }}(2.341210,48.871951)/2.341210,48.871951,16/460x250.png?access_token={{ settings.MAPBOX_ACCESS_TOKEN }}" alt="">
         </figure>
       </div>
 

--- a/bedrock/mozorg/templates/mozorg/contact/spaces/portland.html
+++ b/bedrock/mozorg/templates/mozorg/contact/spaces/portland.html
@@ -32,7 +32,8 @@
         </ul>
 
         <figure class="feature-img">
-          <img src="//api.tiles.mapbox.com/v4/{{ settings.MAPBOX_TOKEN }}/url-{{ 'mozorg.cdn.mozilla.net/media/img/contact/moz-map-pin.png'|urlencode }}(-122.6827999,45.5236536)/-122.6827999,45.5236536,16/460x250.png?access_token={{ settings.MAPBOX_ACCESS_TOKEN }}" alt="">
+          {% set pin = static('img/contact/moz-map-pin.png')|absolute_url %}
+          <img src="//api.tiles.mapbox.com/v4/{{ settings.MAPBOX_TOKEN }}/url-{{ pin|urlencode }}(-122.6827999,45.5236536)/-122.6827999,45.5236536,16/460x250.png?access_token={{ settings.MAPBOX_ACCESS_TOKEN }}" alt="">
         </figure>
       </div>
 

--- a/bedrock/mozorg/templates/mozorg/contact/spaces/san-francisco.html
+++ b/bedrock/mozorg/templates/mozorg/contact/spaces/san-francisco.html
@@ -28,7 +28,8 @@
         </ul>
 
         <figure class="feature-img">
-          <img src="//api.tiles.mapbox.com/v4/{{ settings.MAPBOX_TOKEN }}/url-{{ 'mozorg.cdn.mozilla.net/media/img/contact/moz-map-pin.png'|urlencode }}(-122.38889,37.78955)/-122.38889,37.78955,16/460x250.png?access_token={{ settings.MAPBOX_ACCESS_TOKEN }}" alt="">
+          {% set pin = static('img/contact/moz-map-pin.png')|absolute_url %}
+          <img src="https://api.tiles.mapbox.com/v4/{{ settings.MAPBOX_TOKEN }}/url-{{ pin|urlencode }}(-122.38889,37.78955)/-122.38889,37.78955,16/460x250.png?access_token={{ settings.MAPBOX_ACCESS_TOKEN }}" alt="">
         </figure>
       </div>
 

--- a/bedrock/mozorg/templates/mozorg/contact/spaces/taipei.html
+++ b/bedrock/mozorg/templates/mozorg/contact/spaces/taipei.html
@@ -22,7 +22,8 @@
         </p>
 
         <figure class="feature-img">
-          <img src="//api.tiles.mapbox.com/v4/{{ settings.MAPBOX_TOKEN }}/url-{{ 'mozorg.cdn.mozilla.net/media/img/contact/moz-map-pin.png'|urlencode }}(121.56705,25.03265)/121.56705,25.03265,16/460x250.png?access_token={{ settings.MAPBOX_ACCESS_TOKEN }}" alt="">
+          {% set pin = static('img/contact/moz-map-pin.png')|absolute_url %}
+          <img src="https://api.tiles.mapbox.com/v4/{{ settings.MAPBOX_TOKEN }}/url-{{ pin|urlencode }}(121.56705,25.03265)/121.56705,25.03265,16/460x250.png?access_token={{ settings.MAPBOX_ACCESS_TOKEN }}" alt="">
         </figure>
       </div>
 

--- a/bedrock/mozorg/templates/mozorg/contact/spaces/tokyo.html
+++ b/bedrock/mozorg/templates/mozorg/contact/spaces/tokyo.html
@@ -22,7 +22,8 @@
         </p>
 
         <figure class="feature-img">
-          <img src="//api.tiles.mapbox.com/v4/{{ settings.MAPBOX_TOKEN }}/url-{{ 'mozorg.cdn.mozilla.net/media/img/contact/moz-map-pin.png'|urlencode }}(139.727765,35.665208)/139.727765,35.665208,16/460x250.png?access_token={{ settings.MAPBOX_ACCESS_TOKEN }}" alt="">
+          {% set pin = static('img/contact/moz-map-pin.png')|absolute_url %}
+          <img src="https://api.tiles.mapbox.com/v4/{{ settings.MAPBOX_TOKEN }}/url-{{ pin|urlencode }}(139.727765,35.665208)/139.727765,35.665208,16/460x250.png?access_token={{ settings.MAPBOX_ACCESS_TOKEN }}" alt="">
         </figure>
       </div>
 

--- a/bedrock/mozorg/templates/mozorg/contact/spaces/toronto.html
+++ b/bedrock/mozorg/templates/mozorg/contact/spaces/toronto.html
@@ -30,7 +30,8 @@
         </ul>
 
         <figure class="feature-img">
-          <img src="//api.tiles.mapbox.com/v4/{{ settings.MAPBOX_TOKEN }}/url-{{ 'mozorg.cdn.mozilla.net/media/img/contact/moz-map-pin.png'|urlencode }}(-79.39430,43.64715)/-79.39430,43.64715,16/460x250.png?access_token={{ settings.MAPBOX_ACCESS_TOKEN }}" alt="">
+          {% set pin = static('img/contact/moz-map-pin.png')|absolute_url %}
+          <img src="https://api.tiles.mapbox.com/v4/{{ settings.MAPBOX_TOKEN }}/url-{{ pin|urlencode }}(-79.39430,43.64715)/-79.39430,43.64715,16/460x250.png?access_token={{ settings.MAPBOX_ACCESS_TOKEN }}" alt="">
         </figure>
       </div>
 

--- a/bedrock/mozorg/templates/mozorg/contact/spaces/vancouver.html
+++ b/bedrock/mozorg/templates/mozorg/contact/spaces/vancouver.html
@@ -28,7 +28,8 @@
         </ul>
 
         <figure class="feature-img">
-          <img src="//api.tiles.mapbox.com/v4/{{ settings.MAPBOX_TOKEN }}/url-{{ 'mozorg.cdn.mozilla.net/media/img/contact/moz-map-pin.png'|urlencode }}(-123.1091763,49.2824945)/-123.1091763,49.2824945,16/460x250.png?access_token={{ settings.MAPBOX_ACCESS_TOKEN }}" alt="">
+          {% set pin = static('img/contact/moz-map-pin.png')|absolute_url %}
+          <img src="https://api.tiles.mapbox.com/v4/{{ settings.MAPBOX_TOKEN }}/url-{{ pin|urlencode }}(-123.1091763,49.2824945)/-123.1091763,49.2824945,16/460x250.png?access_token={{ settings.MAPBOX_ACCESS_TOKEN }}" alt="">
         </figure>
       </div>
 


### PR DESCRIPTION
## Description
- Fixes mapbox static images on /spaces pages. For some reason the mozorg.cdn.mozilla.net image file no longer seems to work in the request. I'm not 100% clear why it stopped working but this fixes it.

## Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1298402

## Testing
Load each spaces page and make sure the static image is displayed as expected.

## Checklist
- [ ] Requires l10n changes.
- [ ] Related functional & integration tests passing.

