### PR TITLE
Update Web Bounty HOF with Q2 Bounty winners

### DIFF
--- a/bedrock/security/templates/security/bug-bounty/web-hall-of-fame.html
+++ b/bedrock/security/templates/security/bug-bounty/web-hall-of-fame.html
@@ -35,6 +35,18 @@
       <section id="year-2016">
         <h3 data-accordion-role="tab">{{ _('2016') }}</h3>
         <div data-accordion-role="tabpanel">
+          <h4>2nd Quarter 2016</h4>
+          <ul>
+            <li>Adrian Gaudebert</li>
+            <li>Griffin Francis</li>
+            <li>Takashi Suzuki</li>
+            <li>Mario Gomes</li>
+            <li>Aleh Boitsau</li>
+            <li>Sergey Bobrov</li>
+            <li>Karim Valiev</li>
+            <li>Adel Afsharipour</li>
+            <li>Yassine Aboukir</li>
+          </ul>
           <h4>1st Quarter 2016</h4>
           <ul>
             <li>Ashar Javed</li>


### PR DESCRIPTION
## Description
Update web bounty HOF with Q2 2016 winners
## Bugzilla link
n/a
## Testing

## Checklist
- [ ] Requires l10n changes.
- [ ] Related functional & integration tests passing.

