### PR TITLE
Add redirects for careers and donate

### DIFF
--- a/bedrock/mozorg/redirects.py
+++ b/bedrock/mozorg/redirects.py
@@ -620,4 +620,7 @@ redirectpatterns = (
 
     # bug 1288647
     redirect(r'^hacking/?$', 'https://developer.mozilla.org/docs/Mozilla/Developer_guide/Introduction'),
+
+    redirect(r'^careers/?$', 'https://careers.mozilla.org/'),
+    redirect(r'^join/?$', 'https://donate.mozilla.org/'),
 )

--- a/tests/redirects/map_globalconf.py
+++ b/tests/redirects/map_globalconf.py
@@ -1076,4 +1076,7 @@ URLS = flatten((
 
     # bug 1288647
     url_test('/hacking', 'https://developer.mozilla.org/docs/Mozilla/Developer_guide/Introduction'),
+
+    url_test('/careers', 'https://careers.mozilla.org/'),
+    url_test('/join', 'https://donate.mozilla.org/'),
 ))


### PR DESCRIPTION
I found these URLs on the back of a sticker. They should work.