### PR TITLE
correct minor grammar nit ("when if")

### DIFF
--- a/bedrock/mozorg/templates/mozorg/about/governance/policies/participation.html
+++ b/bedrock/mozorg/templates/mozorg/about/governance/policies/participation.html
@@ -31,7 +31,7 @@
         <ul>
           <li>{{ _('(a) support for exclusionary practices must not be carried into Mozilla activities.') }}</li>
           <li>{{ _('(b) support for exclusionary practices in non-Mozilla activities should not be expressed in Mozilla spaces (which extends to Mozilla-hosted events, even if not in our spaces).') }}</li>
-          <li>{{ _('(c) when if (a) and (b) are met, other Mozillians should treat this as a private matter, not a Mozilla issue.') }}</li>
+          <li>{{ _('(c) if (a) and (b) are met, other Mozillians should treat this as a private matter, not a Mozilla issue.') }}</li>
         </ul>
       </li>
     </ul>


### PR DESCRIPTION
## Description

Under the Diversity and Inclusion section, in the sublist for "Some Mozillians may identify with activities or organizations that do not support the same inclusion and diversity standards as Mozilla. When this is the case:", there's an occurrence of "when if" in the sentence "when if (a) and (b) are met, other Mozillians should treat this as a private matter, not a Mozilla issue."

I suspect this was meant to be either "when" or "if" but not both, since either makes sense on its own, while both are ungrammatical.

## Bugzilla link

I haven't filed a bug but would be happy to do so if such a change rises to that level.

## Testing

I haven't tested, as I used GitHub's built-in support for editing files to fix this grammar nit.

## Checklist
- [ ] Requires l10n changes.
- [x] Related functional & integration tests passing.
