### PR TITLE
Add missing name to q2 2016

### DIFF
--- a/bedrock/security/templates/security/bug-bounty/web-hall-of-fame.html
+++ b/bedrock/security/templates/security/bug-bounty/web-hall-of-fame.html
@@ -46,6 +46,7 @@
             <li>Karim Valiev</li>
             <li>Adel Afsharipour</li>
             <li>Yassine Aboukir</li>
+            <li>Jose Carlos Exposito Bueno</li>
           </ul>
           <h4>1st Quarter 2016</h4>
           <ul>


### PR DESCRIPTION
## Description
Missing name from web bounty q2 16

## Bugzilla link
n/a
## Testing

## Checklist
- [ ] Requires l10n changes.
- [ ] Related functional & integration tests passing.

