### PR TITLE
Bug 1262593 - [404] http://www.mozilla.org/unix/remote.html

### DIFF
--- a/bedrock/mozorg/redirects.py
+++ b/bedrock/mozorg/redirects.py
@@ -623,4 +623,7 @@ redirectpatterns = (
 
     redirect(r'^(careers|jobs)/?$', 'https://careers.mozilla.org/'),
     redirect(r'^join/?$', 'https://donate.mozilla.org/'),
+
+    # Bug 1262593
+    redirect(r'^unix/remote\.html$', 'http://www-archive.mozilla.org/unix/remote.html'),
 )

--- a/tests/redirects/map_globalconf.py
+++ b/tests/redirects/map_globalconf.py
@@ -1085,4 +1085,7 @@ URLS = flatten((
              'https://support.mozilla.org/kb/get-started-firefox-overview-main-features'),
     url_test('/firefox/tour',
              'https://support.mozilla.org/kb/get-started-firefox-overview-main-features'),
+
+    # Bug 1262593
+    url_test('/unix/remote.html', 'http://www-archive.mozilla.org/unix/remote.html'),
 ))


### PR DESCRIPTION
## Description
This PR will fix the Bug 1262593. Modified urls.py to redirect http://www.mozilla.org/unix/remote to the archived page http://www-archive.mozilla.org/unix/remote.html 

## Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1262593

## Testing

## Checklist
- [ ] Requires l10n changes.
- [ ] Related functional & integration tests passing.