### PR TITLE
[fix bug 1261810] Bring back the system requirements link to release notes

### DIFF
--- a/bedrock/firefox/templates/firefox/releases/release-notes.html
+++ b/bedrock/firefox/templates/firefox/releases/release-notes.html
@@ -67,10 +67,9 @@
             feedback='https://input.mozilla.org/feedback/android/' + release.version + '?utm_source=releasenotes'
             if release.product == 'Firefox for Android'
             else 'https://input.mozilla.org/feedback/firefox/' + release.version + '?utm_source=releasenotes',
-            bugzilla='https://bugzilla.mozilla.org/',
-            bug_search_url=release.get_bug_search_url()
+            bugzilla='https://bugzilla.mozilla.org/'
             %}
-              Release Notes tell you what’s new in Firefox. As always, we welcome your <a href="{{ feedback }}">feedback</a>. You can also <a href="{{ bugzilla }}"> file a bug in Bugzilla </a> or see the <a href="{{ bug_search_url }}">complete list of changes</a> in this release.
+              Release Notes tell you what’s new in Firefox. As always, we welcome your <a href="{{ feedback }}">feedback</a>. You can also <a href="{{ bugzilla }}">file a bug in Bugzilla</a> or see the <a href="{{ check_url }}">system requirements</a> of this release.
             {% endtrans %}
           </p>
         </div>

--- a/bedrock/firefox/urls.py
+++ b/bedrock/firefox/urls.py
@@ -22,6 +22,7 @@ releasenotes_re = latest_re % (version_re, r'(aurora|release)notes')
 android_releasenotes_re = releasenotes_re.replace('firefox', 'firefox/android')
 ios_releasenotes_re = releasenotes_re.replace('firefox', 'firefox/ios')
 sysreq_re = latest_re % (version_re, 'system-requirements')
+android_sysreq_re = sysreq_re.replace('firefox', 'firefox/android')
 ios_sysreq_re = sysreq_re.replace('firefox', 'firefox/ios')
 
 
@@ -107,6 +108,8 @@ urlpatterns = (
         {'product': 'Firefox for iOS'}, name='firefox.ios.releasenotes'),
     url(sysreq_re, bedrock.releasenotes.views.system_requirements,
         name='firefox.system_requirements'),
+    url(android_sysreq_re, bedrock.releasenotes.views.system_requirements,
+        {'product': 'Firefox for Android'}, name='firefox.android.system_requirements'),
     url(ios_sysreq_re, bedrock.releasenotes.views.system_requirements,
         {'product': 'Firefox for iOS'}, name='firefox.ios.system_requirements'),
     url('^firefox/releases/$', bedrock.releasenotes.views.releases_index,

--- a/bedrock/releasenotes/tests/test_base.py
+++ b/bedrock/releasenotes/tests/test_base.py
@@ -220,8 +220,10 @@ class TestRNAViews(TestCase):
         eq_(link, '/en-US/thunderbird/channel/')
 
     def test_check_url(self):
-        eq_(views.check_url('Firefox for Android', '42.0'),
+        eq_(views.check_url('Firefox for Android', '45.0'),
             'https://support.mozilla.org/kb/will-firefox-work-my-mobile-device')
+        eq_(views.check_url('Firefox for Android', '46.0'),
+            '/en-US/firefox/android/46.0/system-requirements/')
         eq_(views.check_url('Firefox for iOS', '1.4'),
             '/en-US/firefox/ios/1.4/system-requirements/')
         eq_(views.check_url('Firefox', '42.0'),

--- a/bedrock/releasenotes/views.py
+++ b/bedrock/releasenotes/views.py
@@ -81,9 +81,22 @@ def get_download_url(release):
             return reverse('firefox')
 
 
+def show_android_sys_req(version):
+    match = re.match(r'\d{1,2}', version)
+    if match:
+        num_version = int(match.group(0))
+        return num_version >= 46
+
+    return False
+
+
 def check_url(product, version):
     if product == 'Firefox for Android':
-        return settings.FIREFOX_MOBILE_SYSREQ_URL
+        # System requirement pages for Android releases exist from 46.0 and upward.
+        if show_android_sys_req(version):
+            return reverse('firefox.android.system_requirements', args=[version])
+        else:
+            return settings.FIREFOX_MOBILE_SYSREQ_URL
     elif product == 'Firefox for iOS':
         return reverse('firefox.ios.system_requirements', args=[version])
     else:


### PR DESCRIPTION
## Description
- Brings back the System Requirements link to release notes pages, replacing the bugzilla list of bugs).
- Also enables System Requirements pages for Android releases (seem to exist for 46.0 and onward for all channels), so older versions still get the old SUMO link.

## Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1261810