### PR TITLE
Fix Bug 1275483 - Create What's New page for Firefox Nightly

### DIFF
--- a/bedrock/firefox/redirects.py
+++ b/bedrock/firefox/redirects.py
@@ -24,8 +24,11 @@ redirectpatterns = (
     }),
 
     # bug 748503
-    redirect(r'^projects/firefox/[^/]+a[0-9]+/(?:firstrun|whatsnew)(?P<p>.*)$',
+    redirect(r'^projects/firefox/[^/]+a[0-9]+/firstrun(?P<p>.*)$',
              '/firefox/nightly/firstrun{p}'),
+
+    # bug 1275483
+    redirect(r'^firefox/nightly/whatsnew/?', 'firefox.nightly_firstrun'),
 
     # bug 840814
     redirect(r'^projects/firefox'

--- a/bedrock/firefox/templates/firefox/nightly_whatsnew.html
+++ b/bedrock/firefox/templates/firefox/nightly_whatsnew.html
@@ -1,0 +1,104 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+
+{# Firefox Nightly What’s New page based on the Horizon theme for /firefox/new/ #}
+
+{% extends "/firefox/base-resp.html" %}
+{% add_lang_files "firstrun" "mobile" %}
+
+{% block extra_meta %}<meta name="robots" content="noindex">{% endblock %}
+
+{% block extrahead %}
+  {% stylesheet 'firefox_new_horizon_common' %}
+  {% stylesheet 'nightly_whatsnew' %}
+{% endblock %}
+
+{% block page_title_prefix %}{% endblock %}
+{% block page_favicon %}{{ static('img/firefox/favicon-nightly.png') }}{% endblock %}
+{% block page_title %}{{ _('You’ve just been upgraded to Firefox Nightly %(version)s!')|format(version=num_version) }}{% endblock %}
+{% block page_title_suffix %}{% endblock %}
+
+{% block body_id %}nightly-whatsnew{% endblock %}
+{% block body_class %}{% endblock %}
+
+{% block site_header %}{% endblock %}
+
+{% block content %}
+<main>
+  <div class="horizon">
+    <div class="stars">
+      <div class="inner-container">
+        <header id="masthead">
+          <div id="tabzilla">
+            <a href="{{ url('mozorg.home') }}" data-link-type="nav" data-link-name="tabzilla">Mozilla</a>
+          </div>
+          <h2>{{ high_res_img('firefox/template/header-logo-nightly.png', {'alt': _('Firefox Nightly'), 'width': '305', 'height': '70'}) }}</h2>
+        </header>
+        <div class="main-content">
+          <h1>{{ self.page_title() }}</h1>
+          <h2>
+            {% trans %}
+              Every 6 to 8 weeks, a new major version of Firefox is released and as a result, the Nightly version
+              increases as well.
+            {% endtrans %}
+          </h2>
+          <div class="body">
+            <p>
+              {% trans %}
+                This is a good time to thank you for helping us make Firefox better and to give you some pointers to
+                documentation, communication channels and news sites related to Firefox Nightly that may be of interest
+                to you.
+              {% endtrans %}
+            </p>
+            <p>
+              {% trans blog='https://blog.nightly.mozilla.org/', twitter='https://twitter.com/FirefoxNightly' %}
+                If you want to know what’s happening around Nightly and its community, reading our
+                <a href="%(blog)s">blog</a> and following us on <a href="%(twitter)s">Twitter</a> are good starting
+                points!
+              {% endtrans %}
+            </p>
+            <p>
+              {% trans mdn='https://developer.mozilla.org/en-US/Firefox/Experimental_features'
+                           '?utm_source=firefox&utm_medium=whatsnew&utm_campaign=nightly' %}
+                Want to know which platform features you could test on Nightly and can’t see yet on other Firefox
+                channels? Then have a look at the <a href="%(mdn)s">Experimental Features</a> page on
+                <abbr title="Mozilla Developer Network">MDN</abbr>.
+              {% endtrans %}
+            </p>
+            <p>
+              {% trans bugzilla='https://bugzilla.mozilla.org' %}
+                Do you experience crashes? Unexpected behavior? Web compatibility regressions? We’d love to get them
+                filed in <a href="%(bugzilla)s">Bugzilla</a> to make sure they don’t make it to the final release (extra
+                karma if you add the <em>nightly-community</em> keyword to your bug reports)!
+              {% endtrans %}
+            </p>
+            <p>
+              {% trans triagebot='https://triagebot.mozilla.org/' %}
+                Would you be willing to help us triage unconfirmed bugs in Bugzilla? Then maybe
+                <a href="%(triagebot)s">TriageBot</a> could be of interest to you.
+              {% endtrans %}
+            </p>
+            <p>
+              {% trans irc='ircs://irc.mozilla.org/nightly' %}
+                You can also interact with the Nightly community on IRC in the <a href="%(irc)s">#nightly</a> channel.
+                Feel free to ask questions and talk about features, regressions or crashes you may be experiencing.
+              {% endtrans %}
+            </p>
+            <p><strong>{{ _('Go community!') }}</strong></p>
+          </div>
+        </div>
+      </div>{#-- /.inner-container --#}
+    </div>
+  </div>
+  {% include 'firefox/new/horizon/includes/horizon.html' %}
+</main>
+{% endblock %}
+
+{% block email_form %}{% endblock %}
+
+{% block site_footer %}
+  {% include 'firefox/includes/simple_footer.html' %}
+{% endblock %}
+
+{% block js %}{% endblock %}

--- a/bedrock/settings/static_media.py
+++ b/bedrock/settings/static_media.py
@@ -320,6 +320,12 @@ PIPELINE_CSS = {
         ),
         'output_filename': 'css/nightly_firstrun-bundle.css',
     },
+    'nightly_whatsnew': {
+        'source_filenames': (
+            'css/firefox/nightly_whatsnew.less',
+        ),
+        'output_filename': 'css/nightly_whatsnew-bundle.css',
+    },
     'firefox_firstrun': {
         'source_filenames': (
             'css/sandstone/sandstone.less',

--- a/media/css/firefox/nightly_whatsnew.less
+++ b/media/css/firefox/nightly_whatsnew.less
@@ -1,0 +1,63 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+@import '../sandstone/lib.less';
+
+#masthead h2 img {
+    width: 305px;
+
+    @media (max-width: @breakMobileLandscape) {
+        width: 100%;
+        height: auto;
+    }
+}
+
+main {
+    .main-content {
+        text-align: left;
+        text-shadow: 1px 1px 0 rgba(0, 0, 0, .3);
+
+        @media (min-width: @breakDesktop) {
+            margin: 0 100px;
+        }
+
+        @media (max-width: @breakMobileLandscape) {
+            margin-top: 20px;
+        }
+
+        .body {
+            margin-top: 20px;
+
+            @media (min-width: @breakTablet) {
+                .multi-column(auto, 2, 20px);
+            }
+
+            & > * {
+                .multi-column-avoid-break;
+            }
+        }
+    }
+
+    h1 {
+        color: #FFA800;
+    }
+
+    h2 {
+        .font-size(1.5rem);
+        line-height: 1.2;
+    }
+
+    a {
+        &:link,
+        &:visited {
+            color: #F9C17E;
+        }
+
+        &:hover,
+        &:focus,
+        &:active {
+            color: lighten(#F9C17E, 10%);
+        }
+    }
+}

--- a/tests/redirects/map_globalconf.py
+++ b/tests/redirects/map_globalconf.py
@@ -172,8 +172,11 @@ URLS = flatten((
     url_test('/projects/firefox/3.6.10/whatsnew/bunny-lebowski/',
              '/firefox/3.6.10/whatsnew/bunny-lebowski/'),
     url_test('/projects/firefox/4.0/firstrun/', '/firefox/4.0/firstrun/'),
-    url_test('/projects/firefox/4.0a2/{firstrun,whatsnew}/stuff',
+    url_test('/projects/firefox/4.0a2/firstrun/stuff',
              '/firefox/nightly/firstrun/stuff'),
+
+    # bug 1275483
+    url_test('/firefox/nightly/whatsnew/', '/firefox/nightly/firstrun/'),
 
     url_test('/{{firefox,mobile}/,}beta/', '/firefox/channel/#beta'),
     url_test('/{{firefox,mobile}/,}aurora/', '/firefox/channel/#developer'),


### PR DESCRIPTION
[Demo server](https://bedrock-demo-nightly-whatsnew.us-west.moz.works/en-US/firefox/52.0a1/whatsnew/) is ready.

Note: The en-US locale is hardcoded in the MDN link, otherwise the GA query params are omitted on redirect. Until the issue is fixed at MDN side, let's keep the locale.