### PR TITLE
Add /firefox/nightly/all/ to download link tests

### DIFF
--- a/tests/functional/test_download_l10n.py
+++ b/tests/functional/test_download_l10n.py
@@ -19,6 +19,7 @@ def pytest_generate_tests(metafunc):
         '/firefox/all/',
         '/firefox/beta/all/',
         '/firefox/developer/all/',
+        '/firefox/nightly/all/',
         '/firefox/organizations/all/',
         '/firefox/android/all/',
         '/firefox/android/beta/all/')


### PR DESCRIPTION
Adds `/firefox/nightly/all/` to the existing download link tests.

@jgmize r?



