### PR TITLE
[fix bug 1301721] isFirefoxUpToDate should only use the major version until FF 49 is released

### DIFF
--- a/media/js/base/mozilla-client.js
+++ b/media/js/base/mozilla-client.js
@@ -125,6 +125,52 @@ if (typeof Mozilla === 'undefined') {
     };
 
     /**
+     * Determine if user version is up to date with latest version from product details.
+     *
+     * @private
+     * @param  {Boolean} strict - if false compare the major version number only.
+     * @param  {Array} userVerArr - the user version number.
+     * @param  {Array} latestVerArr - the latest version number from product details.
+     * @return {Boolean} true if user version number is equal to or greater than product details version.
+     */
+    Client._compareVersion = function (strict, userVerArr, latestVerArr) {
+        var currentUserNumber = 0;
+        var currentLatestNumber = 0;
+        var isUpToDate = false;
+
+        // Make sure both latest and user array lengths match.
+        while (latestVerArr.length < userVerArr.length) {
+            latestVerArr.push('0');
+        }
+        while (userVerArr.length < latestVerArr.length) {
+            userVerArr.push('0');
+        }
+
+        // Only check the major version in non-strict comparison mode.
+        if (!strict) {
+            latestVerArr.length = 1;
+        }
+
+        // Step through the array from product details and compare to the user array.
+        for (var j = 0; j < latestVerArr.length; j++) {
+            currentUserNumber = Number(userVerArr[j]);
+            currentLatestNumber = Number(latestVerArr[j]);
+
+            if (currentUserNumber < currentLatestNumber) {
+                isUpToDate = false;
+                break;
+            } else if (currentUserNumber > currentLatestNumber) {
+                isUpToDate = true;
+                break;
+            } else {
+                isUpToDate = true;
+            }
+        }
+
+        return isUpToDate;
+    };
+
+    /**
      * Detect whether the user's Firefox is up to date or outdated. This data is mainly used for security notifications.
      *
      * @private
@@ -148,30 +194,14 @@ if (typeof Mozilla === 'undefined') {
         var userVerArr = userVer.match(/^(\d+(?:\.\d+){1,2})/)[1].split('.');
         var isUpToDate = false;
 
-        // Compare the newer version first
+        // Sort product details version so we compare the newer version first
         versions.sort(function(a, b) { return parseFloat(a) < parseFloat(b); });
 
-        // Only check the major version in non-strict comparison mode
-        if (!strict) {
-            userVerArr.length = 1;
-        }
-
+        // Compare each latest version in product details to the user version.
         for (var i = 0; i < versions.length; i++) {
             var latestVerArr = versions[i].split('.');
 
-            // Only check the major version in non-strict comparison mode
-            if (!strict) {
-                latestVerArr.length = 1;
-            }
-
-            for (var j = 0; j < userVerArr.length; j++) {
-                if (Number(userVerArr[j]) < Number(latestVerArr[j] || 0)) {
-                    isUpToDate = false;
-                    break;
-                } else {
-                    isUpToDate = true;
-                }
-            }
+            isUpToDate = Client._compareVersion(strict, userVerArr, latestVerArr);
 
             if (isUpToDate) {
                 break;

--- a/media/js/firefox/desktop/common.js
+++ b/media/js/firefox/desktop/common.js
@@ -20,14 +20,13 @@
     }
 
     // only show download buttons for users on desktop platforms, using either a non-Firefox browser
-    // or an out of date version of Firefox
+    // or an out of date version of Firefox.
+    // bug 1301721 only use major Firefox version until 49.0 is released
     if (client.isDesktop) {
         if (client.isFirefox) {
-            client.getFirefoxDetails(function(data) {
-                if (!data.isUpToDate) {
-                    showDownloadButtons();
-                }
-            });
+            if (!client._isFirefoxUpToDate(false)) {
+                showDownloadButtons();
+            }
         } else {
             showDownloadButtons();
         }

--- a/media/js/firefox/desktop/index.js
+++ b/media/js/firefox/desktop/index.js
@@ -42,11 +42,8 @@
         });
     }
 
-    if (client.isFirefoxDesktop || client.isFirefoxAndroid) {
-        client.getFirefoxDetails(function(data) {
-            if (data.isUpToDate) {
-                $('#overview-intro-up-to-date').addClass('active');
-            }
-        });
+    // bug 1301721 only use major Firefox version until 49.0 is released
+    if ((client.isFirefoxDesktop || client.isFirefoxAndroid) && client._isFirefoxUpToDate(false)) {
+        $('#overview-intro-up-to-date').addClass('active');
     }
 })(window.jQuery);

--- a/media/js/firefox/desktop/tips.js
+++ b/media/js/firefox/desktop/tips.js
@@ -14,13 +14,12 @@
     var $tipsNavDots = $('#tips-nav-dots');
 
     // only show download button for users on desktop platforms, using either a non-Firefox browser
-    // or an out of date version of Firefox
+    // or an out of date version of Firefox.
+    // bug 1301721 only use major Firefox version until 49.0 is released
     if (client.isFirefoxDesktop) {
-        client.getFirefoxDetails(function(data) {
-            if (data.isUpToDate) {
-                $('#footer').addClass('hide-download');
-            }
-        });
+        if (client._isFirefoxUpToDate(false)) {
+            $('#footer').addClass('hide-download');
+        }
     } else if (client.isMobile) {
         $('#footer').addClass('hide-download');
     }

--- a/media/js/firefox/family-index.js
+++ b/media/js/firefox/family-index.js
@@ -22,10 +22,9 @@
     });
 
     // Check Firefox version
+    // bug 1301721 only use major Firefox version until 49.0 is released
     if (client.isFirefoxDesktop || client.isFirefoxAndroid) {
-        client.getFirefoxDetails(function(data) {
-            $html.addClass(data.isUpToDate ? 'firefox-latest' : 'firefox-old');
-        });
+        $html.addClass(client._isFirefoxUpToDate(false) ? 'firefox-latest' : 'firefox-old');
     } else {
         $html.addClass('nonfx');
     }

--- a/media/js/firefox/new/scene1.js
+++ b/media/js/firefox/new/scene1.js
@@ -60,7 +60,7 @@
             if (client.isFirefoxDesktop) {
                 client.getFirefoxDetails(function(data) {
                     // data.accurate will only be true if UITour API is working.
-                    if (data.channel === 'release' && data.isUpToDate && data.accurate) {
+                    if (data.channel === 'release' && data.accurate) {
                         // Bug 1274207 only show reset button if user profile supports it.
                         uiTourSendEvent('getConfiguration', {
                             callbackID: uiTourWaitForCallback(showRefreshButton),

--- a/media/js/firefox/releasenotes.js
+++ b/media/js/firefox/releasenotes.js
@@ -66,10 +66,9 @@
             $html.addClass('firefox-up-to-date');
 
         // Android or desktop
+        // bug 1301721 only use major Firefox version until 49.0 is released
         } else {
-            client.getFirefoxDetails(function(data) {
-                $html.addClass(data.isUpToDate ? 'firefox-up-to-date' : 'firefox-old');
-            });
+            $html.addClass(client._isFirefoxUpToDate(false) ? 'firefox-up-to-date' : 'firefox-old');
         }
     } else {
         $html.addClass('non-firefox');

--- a/media/js/plugincheck/check-plugins-redesign.js
+++ b/media/js/plugincheck/check-plugins-redesign.js
@@ -284,9 +284,10 @@ $(function() {
     }
 
     // show for outdated Fx versions
+    // bug 1301721 only use major Firefox version until 49.0 is released
     if (client.isFirefoxDesktop || client.isFirefoxAndroid) {
         client.getFirefoxDetails(function(data) {
-            if (!data.isUpToDate && !data.isESR) {
+            if (!client._isFirefoxUpToDate(false) && !data.isESR) {
                 wrapper.addClass('firefox-out-of-date');
                 $outOfDateContainer.removeClass('hidden');
             }

--- a/media/js/plugincheck/check-plugins.js
+++ b/media/js/plugincheck/check-plugins.js
@@ -217,9 +217,10 @@ $(function() {
     }
 
     // show for outdated Fx versions
+    // bug 1301721 only use major Firefox version until 49.0 is released
     if (client.isFirefoxDesktop || client.isFirefoxAndroid) {
         client.getFirefoxDetails(function(data) {
-            if (!data.isUpToDate && !data.isESR) {
+            if (!client._isFirefoxUpToDate(false) && !data.isESR) {
                 outdatedFx.show();
             }
         });

--- a/tests/unit/spec/base/mozilla-client.js
+++ b/tests/unit/spec/base/mozilla-client.js
@@ -458,7 +458,7 @@ describe('mozilla-client.js', function() {
 
         it('should consider outdated if user version is slightly less than latest version and strict option is true', function() {
             test(true, false, '46.0.1').toBeFalsy();
-            test(true, false, '45.0').toBeFalsy();
+            test(true, false, '46.0').toBeFalsy();
             test(true, false, '38.7.0').toBeFalsy();
             test(true, false, '45.0').toBeFalsy();
         });


### PR DESCRIPTION
## Description
- Switches checks for `_isFirefoxUpToDate()` to only use the major version number until Firefox 49 is released (see bug for context).

## Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1301721

## Testing
- Check in both current & older Firefox (or change UA) to ensure no regressions.