### PR TITLE
Update wording for Firefox Student Ambassadors transitioning

### DIFF
--- a/bedrock/mozorg/templates/mozorg/contribute/studentambassadors/landing.html
+++ b/bedrock/mozorg/templates/mozorg/contribute/studentambassadors/landing.html
@@ -4,8 +4,8 @@
 {% block facebook_id %}107747252595375{# facebook.com/Firefox.Student.Ambassadors #}{% endblock %}
 {% block twitter_id %}mozstudents{% endblock %}
 
-{% block page_title %}{{ _('Firefox Student Ambassadors') }}{% endblock %}
-{% block page_desc %}{{ _('Individuals who are passionate about Mozilla and raise awareness about the many benefits of Firefox &amp; other Mozilla products - especially <a href="%s">Firefox&nbsp;OS</a>!') }}{% endblock %}
+{% block page_title %}{{ _('Firefox Student Ambassadors is transitioning') }}{% endblock %}
+{% block page_desc %}{{ _('A new program is coming to campuses this September to supercharge College and University students around the world. Let\'s Teach, Build and Protect the Open Web together! ') }}{% endblock %}
 {% block page_image %}{{ static('img/contribute/studentambassadors/hero.jpg') }}{% endblock %}
 {% block page_css %}
   {% stylesheet 'contribute-studentambassadors-landing' %}
@@ -24,15 +24,12 @@
     <div class="row">
       <header>
         <h1>{{ self.page_title() }}</h1>
-        <p>{{ self.page_desc()|format(url('firefox.os.index')) }}</p>
       </header>
       <div class="callout">
-        <p>{{ _('At this time, new participants are being accepted into the program. To serve as a Firefox Student Ambassador you must be:') }}</p>
-        <ul>
-          <li>{{ _('At least <strong>18 years</strong> of age') }}</li>
-          <li>{{ _('Currently a student, professor, or administrator with a college or university') }}</li>
-        </ul>
-        <p><a href="{{ url('mozorg.contribute.studentambassadors.join') }}" class="button">{{ _('Become a Student Ambassador') }}</a></p>
+        <p>{{ self.page_desc() }}</p>
+        <br>
+        <p><a href="https://campus.mozilla.community" class="button">{{ _('Join the new program') }}</a></p>
+        <br>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Description
The FSA program is transitioning to Mozilla Campus Clubs. For the time being we will just update the wording to the website and forward students to the [new program](http://campus.mozilla.community).

Changes have already tested locally and l10n is not required.

## Bugzilla link

## Testing

## Checklist
- [ ] Related functional & integration tests passing.

