### PR TITLE
[fix bug 1302507] Deactivate mobile-download/desktop URL.

### DIFF
--- a/bedrock/firefox/templates/firefox/mobile-download-desktop.html
+++ b/bedrock/firefox/templates/firefox/mobile-download-desktop.html
@@ -2,6 +2,12 @@
  # License, v. 2.0. If a copy of the MPL was not distributed with this
  # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
 
+{#
+This page was originally planned for release on 9/12/16, but was pushed back due
+to reasons. Expectation is for this page to be released around the time of
+Firefox 50 (11/8/2016).
+#}
+
 {% from "macros.html" import google_play_button, send_to_device with context %}
 
 {% add_lang_files "firefox/sendto" %}

--- a/bedrock/firefox/urls.py
+++ b/bedrock/firefox/urls.py
@@ -48,7 +48,6 @@ urlpatterns = (
     page('firefox/ios', 'firefox/ios.html'),
     url(r'^firefox/ios/testflight', views.ios_testflight, name='firefox.ios.testflight'),
     page('firefox/mobile-download', 'firefox/mobile-download.html'),
-    page('firefox/mobile-download/desktop', 'firefox/mobile-download-desktop.html'),
     page('firefox/products', 'firefox/family/index.html'),
     page('firefox/private-browsing', 'firefox/private-browsing.html'),
     url('^firefox/send-to-device-post/$', views.send_to_device_ajax,


### PR DESCRIPTION
## Description

Deactivates newly created `/firefox/mobile-download/desktop/` URL due to promotion being delayed. Expectation is for page to be released around time of Fx 50 (11/8/2016).

## Bugzilla link

https://bugzilla.mozilla.org/show_bug.cgi?id=1302507

## Testing

## Checklist
- [ ] Related functional & integration tests passing.

