### PR TITLE
Fix bug 1300090: Exempt css files from softlinkstatic.py

### DIFF
--- a/docker/bin/softlinkstatic.py
+++ b/docker/bin/softlinkstatic.py
@@ -10,6 +10,12 @@ with open(STATIC) as static_fp:
 for orig, hashed in static_files['paths'].items():
     if '?' in orig:
         continue
+
+    if orig.endswith('.css'):
+        # contents of hashed css files have been modified to referenced
+        # other hashed files (images and whatnot). We want to keep that.
+        continue
+
     hashed_path = os.path.join('./static', hashed)
     orig_filename = os.path.split(orig)[1]
 


### PR DESCRIPTION
The content of the hashed CSS files is different from the non-hashed versions. In the former the references to other files (e.g. images) have been changed to their hashed versions.  We want to keep these versions since they are served with far-future cache headers and thus reduce our server loads.