### PR TITLE
[bug 1292612] Remove Hello from title and desc

### DIFF
--- a/bedrock/firefox/templates/firefox/family/index.html
+++ b/bedrock/firefox/templates/firefox/family/index.html
@@ -6,7 +6,9 @@
 
 {% block page_title_prefix %}{% endblock %}
 {% block page_title %}
-{% if l10n_has_tag('tracking_protection') %}
+{% if l10n_has_tag('fx49_remove_hello') %}
+  {{ _('Firefox – Desktop browser, Android, iOS, Sync, Private Browsing') }}
+{% elif l10n_has_tag('tracking_protection') %}
   {{ _('Firefox – Desktop browser, Android, iOS, OS, Hello, Sync, Private Browsing') }}
 {% else %}
   {{ _('Firefox — Desktop browser, Android, OS, Hello, Sync, Marketplace') }}

--- a/bedrock/firefox/templates/firefox/features.html
+++ b/bedrock/firefox/templates/firefox/features.html
@@ -8,7 +8,13 @@
 
 {% block page_title_prefix %}{{_('Firefox')}} — {% endblock %}
 {% block page_title %}{{ _('Features') }}{% endblock %}
-{% block page_desc %}{{ _('Get the most from Firefox and your time online with Hello, Sync and Private Browsing.') }}{% endblock %}
+{% block page_desc %}
+{% if l10n_has_tag('fx49_remove_hello') %}
+  {{ _('Get the most from Firefox and your time online with Sync and Private Browsing.') }}
+{% else %}
+  {{ _('Get the most from Firefox and your time online with Hello, Sync and Private Browsing.') }}
+{% endif %}
+{% endblock %}
 {% block body_id %}firefox-features{% endblock %}
 {% block body_class %}mozid{% endblock %}
 


### PR DESCRIPTION
## Description
Failed to remove a few mentions of Hello when updating these pages. These are string changes so I've tagged them with `fx49_remove_hello` (cc: @flodolo and @peiying2)

## Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1292612

## Checklist
- [x] Requires l10n changes.
- [ ] Related functional & integration tests passing.