### PR TITLE
[fix bug 1262897] Remove deprecated FxA ping auth

### DIFF
--- a/docs/firefox-accounts.rst
+++ b/docs/firefox-accounts.rst
@@ -39,6 +39,7 @@ Local Development
         user_pref("identity.fxaccounts.settings.uri", "https://stomlinson.dev.lcip.org/settings");
         user_pref("identity.fxaccounts.remote.webchannel.uri", "https://stomlinson.dev.lcip.org/");
         user_pref("services.sync.tokenServerURI", "https://stomlinson.dev.lcip.org/syncserver/token/1.0/sync/1.5");
+        user_pref("webchannel.allowObject.urlWhitelist", "https://accounts.firefox.com https://accounts.stage.mozaws.net https://content.cdn.mozilla.net https://input.mozilla.org https://support.mozilla.org https://install.mozilla.org https://stomlinson.dev.lcip.org/");
 
         user_pref("general.warnOnAboutConfig", false);
         user_pref("devtools.chrome.enabled", true);
@@ -68,6 +69,7 @@ Demo Server Testing
         user_pref("identity.fxaccounts.settings.uri", "https://accounts.stage.mozaws.net/settings");
         user_pref("identity.fxaccounts.remote.webchannel.uri", "https://accounts.stage.mozaws.net/");
         user_pref("services.sync.tokenServerURI", "https://token.stage.mozaws.net/1.0/sync/1.5");
+        user_pref("webchannel.allowObject.urlWhitelist", "https://accounts.firefox.com https://accounts.stage.mozaws.net https://content.cdn.mozilla.net https://input.mozilla.org https://support.mozilla.org https://install.mozilla.org https://stomlinson.dev.lcip.org/");
 
         user_pref("general.warnOnAboutConfig", false);
         user_pref("devtools.chrome.enabled", true);

--- a/media/js/base/mozilla-fxa-iframe.js
+++ b/media/js/base/mozilla-fxa-iframe.js
@@ -121,10 +121,6 @@ Mozilla.FxaIframe = (function() {
         var data = JSON.parse(e.data);
 
         switch (data.command) {
-        // iframe is pinging host page
-        case 'ping':
-            _onPing(data);
-            break;
         // iframe has loaded successfully
         case 'loaded':
             _onLoaded(data);
@@ -148,22 +144,8 @@ Mozilla.FxaIframe = (function() {
         }
     };
 
-    var _onPing = function(data) {
-        // tell iframe we are expecting it
-        if (_config.testing !== true) { // allow unit test to bypass auth
-            var fxaFrameTarget = _$iframe[0].contentWindow;
-            // data must be back in string format for postMessage
-            fxaFrameTarget.postMessage(JSON.stringify(data), _host);
-        }
-
-        // remember iframe has loaded
-        _handshake = true;
-
-        _userCallback('onPing', data);
-    };
-
     var _onLoaded = function(data) {
-        // remember iframe has loaded (new auth flow doesn't fire 'ping')
+        // remember iframe has loaded
         _handshake = true;
 
         _sendGAEvent('fxa-loaded');
@@ -206,7 +188,6 @@ Mozilla.FxaIframe = (function() {
         // userConfig: optional object containing any of the following:
         //     gaEventName: string name of GA event (generally customized per
         //         page - defaults to 'fxa')
-        //     onPing: function called after iframe 'ping' postMessage
         //     onLoaded: function called after iframe 'loaded' postMessage
         //     onResize: function called after iframe 'resize' postMessage
         //     onSignupMustVerify: function called after iframe

--- a/tests/unit/spec/base/mozilla-fxa-iframe.js
+++ b/tests/unit/spec/base/mozilla-fxa-iframe.js
@@ -100,35 +100,12 @@ describe('mozilla-fxa-iframe.js', function() {
     describe('Mozilla.FxaIframe postMessage handling', function() {
         var config;
 
-        it('should execute callback for ping postMessage', function(done) {
-            var messageData = {
-                command: 'ping'
-            };
-
-            config = {
-                testing: true,
-                onPing: function(data) {
-                    var command = data.command;
-                    expect(config.onPing).toHaveBeenCalled();
-                    expect(command).toEqual('ping');
-                    done();
-                }
-            };
-
-            spyOn(config, 'onPing').and.callThrough();
-
-            Mozilla.FxaIframe.init(config);
-
-            window.postMessage(JSON.stringify(messageData), '*');
-        });
-
         it('should execute callback for loaded postMessage', function(done) {
             var messageData = {
                 command: 'loaded'
             };
 
             config = {
-                testing: true,
                 onLoaded: function(data) {
                     var command = data.command;
                     expect(config.onLoaded).toHaveBeenCalled();
@@ -153,7 +130,6 @@ describe('mozilla-fxa-iframe.js', function() {
             };
 
             config = {
-                testing: true,
                 onResize: function(data) {
                     var command = data.command;
                     expect(config.onResize).toHaveBeenCalled();
@@ -177,7 +153,6 @@ describe('mozilla-fxa-iframe.js', function() {
             };
 
             config = {
-                testing: true,
                 onSignupMustVerify: function(data) {
                     var command = data.command;
                     expect(config.onSignupMustVerify).toHaveBeenCalled();
@@ -199,7 +174,6 @@ describe('mozilla-fxa-iframe.js', function() {
             };
 
             config = {
-                testing: true,
                 onVerificationComplete: function(data) {
                     var command = data.command;
                     expect(config.onVerificationComplete).toHaveBeenCalled();


### PR DESCRIPTION
## Description

Removes now deprecated ping authorization for FxA iframe embed.

## Bugzilla link

https://bugzilla.mozilla.org/show_bug.cgi?id=1262897

## Testing

Make sure FxA iframe loads and functions properly locally and on [demo4](https://www-demo4.allizom.org/firefox/accounts/).

**You need to update your `user.js` file for local and demo testing!**

There's a new config value required to test FxA on local, demo, and the dev server. Add the following to the `user.js` file associated with your local and demo server testing profiles:

```
user_pref("webchannel.allowObject.urlWhitelist", "https://accounts.firefox.com https://accounts.stage.mozaws.net https://content.cdn.mozilla.net https://input.mozilla.org https://support.mozilla.org https://install.mozilla.org https://stomlinson.dev.lcip.org/");
```

Marking as **Do Not Merge** until hectorz has a chance to view and make sure things are lined up for the China repacks.

## Checklist
- [ ] Related functional & integration tests passing.

