### PR TITLE
Change CSP default "on" & csp-report default "off"

### DIFF
--- a/.bedrock_demo_env
+++ b/.bedrock_demo_env
@@ -1,5 +1,5 @@
 LOGLEVEL=info
-ENABLE_CSP_MIDDLEWARE=True
+CSP_REPORT_ENABLE=True
 CSP_EXTRA_FRAME_SRC=*.mozaws.net
 DEBUG=False
 DATABASE_URL=sqlite:///bedrock.db

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -327,7 +327,7 @@ MIDDLEWARE_CLASSES = [
     'dnt.middleware.DoNotTrackMiddleware',
 ]
 
-ENABLE_CSP_MIDDLEWARE = config('ENABLE_CSP_MIDDLEWARE', default=False, cast=bool)
+ENABLE_CSP_MIDDLEWARE = config('ENABLE_CSP_MIDDLEWARE', default=True, cast=bool)
 if ENABLE_CSP_MIDDLEWARE:
     MIDDLEWARE_CLASSES.append('csp.middleware.CSPMiddleware')
 
@@ -1127,7 +1127,7 @@ CSP_CONNECT_SRC = CSP_DEFAULT_SRC + (
     'api.mapbox.com',
 )
 CSP_REPORT_ONLY = config('CSP_REPORT_ONLY', default=False, cast=bool)
-CSP_REPORT_ENABLE = config('CSP_REPORT_ENABLE', default=True, cast=bool)
+CSP_REPORT_ENABLE = config('CSP_REPORT_ENABLE', default=False, cast=bool)
 if CSP_REPORT_ENABLE:
     CSP_REPORT_URI = config('CSP_REPORT_URI', default='/csp-violation-capture')
 


### PR DESCRIPTION
If a csp-report-uri were to be enabled in prod it could be disasterous. Potentially tousands to POSTs from thousands of browsers all at once. We could DDOS ourselves. Let's only turn this on when we really mean to.

However, if we're going to use CSP in prod we should always have it on so that we catch issues as early as possible. We'll default the middleware to "On", but leave the option to turn it off should we need to.