### PR TITLE
[fix bug 1295181] Test /all links on /firefox/new/.

### DIFF
--- a/bedrock/firefox/templates/firefox/includes/download-button.html
+++ b/bedrock/firefox/templates/firefox/includes/download-button.html
@@ -18,6 +18,7 @@
         <li><a href="{{ plat.download_link_direct or plat.download_link }}"
                class="download-link button green"
                data-link-type="download"
+               data-download-version="{{ plat.os }}"
                {% if plat.os == 'android' %}data-download-os="Android"
                {% elif plat.os == 'ios' %}data-download-os="iOS"
                {% else %}data-download-os="Desktop"{% endif %}>{{ plat.os_arch_pretty or plat.os_pretty }}</a>
@@ -63,6 +64,8 @@
            href="{{ plat.download_link }}"{% if plat.download_link_direct %}
            data-direct-link="{{ plat.download_link_direct }}"{% endif %}
            data-link-type="download"
+           data-display-name="{{ plat.os_arch_pretty or plat.os_pretty }}"
+           data-download-version="{{ plat.os }}"
            {% if plat.os == 'android' %}data-download-os="Android"
            {% elif plat.os == 'ios' %}data-download-os="iOS"
            {% else %}data-download-os="Desktop"{% endif %}>

--- a/bedrock/firefox/templates/firefox/includes/firefox-footer-links.html
+++ b/bedrock/firefox/templates/firefox/includes/firefox-footer-links.html
@@ -27,7 +27,7 @@
 
 {% if show_desktop %}
   <ul class="fx-footer-links os_desktop os_other">
-    <li><a href="{{ firefox_url('desktop', 'all', channel) }}">{{ _('Firefox for Other Platforms & Languages') }}</a></li>
+    <li><a id="fx-footer-links-desktop-all" href="{{ firefox_url('desktop', 'all', channel) }}">{{ _('Firefox for Other Platforms & Languages') }}</a></li>
     <li><a href="{{ firefox_url('desktop', 'notes', channel) }}">{{ _('Release Notes') }}</a></li>
   </ul>
 {% endif %}

--- a/bedrock/firefox/templates/firefox/new/scene1.html
+++ b/bedrock/firefox/templates/firefox/new/scene1.html
@@ -2,14 +2,25 @@
  # License, v. 2.0. If a copy of the MPL was not distributed with this
  # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
 
+{% from "macros.html" import google_play_button with context %}
+
 {% add_lang_files "firefox/new/horizon" %}
 
 {% extends "firefox/new/base.html" %}
+
+{% block experiments %}
+  {% if switch('experiment-firefox-new-all-links') and LANG == 'en-US' %}
+    {% javascript 'experiment-firefox-new-scene1-all-links' %}
+  {% endif %}
+{% endblock %}
 
 {# all CSS must be in extrahead block for old IE #}
 {% block extrahead %}
   {% stylesheet 'firefox_new_common' %}
   {% stylesheet 'firefox_new_scene1' %}
+  {% if version in ['1', '2'] %}
+    {% stylesheet 'firefox_new_scene1_variations' %}
+  {% endif %}
 {% endblock %}
 
 {% block body_id %}firefox-new-scene1{% endblock %}
@@ -20,7 +31,7 @@
     <div class="horizon">
       <div class="stars">
         <div class="inner-container">
-          <header id="masthead">
+          <header id="masthead" data-version="{{ version }}">
             <div id="tabzilla">
               <a href="{{ url('mozorg.home') }}" data-link-type="nav" data-link-name="tabzilla">Mozilla</a>
             </div>
@@ -114,9 +125,42 @@
   </div>
 </main>
 
+{% if version == '2' %}
+  <div id="fx-modal-wrapper">
+    <div id="fx-modal">
+      <div id="fx-modal-content">
+        <section id="fx-modal-primary-ctas" class="fx-modal-section">
+          <h4>Firefox for other platforms</h4>
+
+          <ul id="fx-modal-direct-downloads"></ul>
+
+          <ul id="fx-modal-mobile-downloads">
+            <li class="android">
+              {{ google_play_button() }}
+            </li>
+            <li class="ios">
+              <a href="{{ firefox_ios_url('mozorg-fxnew_page_scene1_modal-appstore-button') }}" data-link-type="download" data-download-os="iOS">
+                <img src="{{ l10n_img('firefox/ios/btn-app-store.svg') }}" alt="{{ _('Download on the App Store') }}" width="152" height="45">
+              </a>
+            </li>
+          </ul>
+        </section>{#-- /#fx-modal-primary-ctas --#}
+
+        <section id="fx-modal-secondary-cta" class="fx-modal-section">
+          <h3>Download Firefox <span id="fx-modal-user-platform"></span></h3>
+          {{ download_firefox(alt_copy=_('Free Download'), dom_id="fx-modal-download") }}
+        </section>{#-- /#fx-modal-secondary-cta --#}
+      </div>{#-- /#fx-modal-content --#}
+    </div>{#-- /#fx-modal --#}
+  </div>{#-- /#fx-modal-wrapper -_#}
+{% endif %}
+
 {% include 'firefox/includes/schemaorg-app.html' %}
 {% endblock %}
 
 {% block js %}
   {% javascript 'firefox_new_scene1' %}
+  {% if version in ['1', '2'] %}
+    {% javascript 'firefox_new_scene1_variations' %}
+  {% endif %}
 {% endblock %}

--- a/bedrock/firefox/tests/test_views.py
+++ b/bedrock/firefox/tests/test_views.py
@@ -8,7 +8,7 @@ from django.test import override_settings
 from django.test.client import RequestFactory
 
 from bedrock.base.urlresolvers import reverse
-from mock import patch
+from mock import ANY, patch
 from nose.tools import eq_, ok_
 
 from bedrock.firefox import views
@@ -172,13 +172,32 @@ class TestFirefoxNew(TestCase):
         req = RequestFactory().get('/firefox/new/')
         req.locale = 'en-US'
         views.new(req)
-        render_mock.assert_called_once_with(req, 'firefox/new/scene1.html')
+        render_mock.assert_called_once_with(req, 'firefox/new/scene1.html', ANY)
 
     def test_scene_2_template(self, render_mock):
         req = RequestFactory().get('/firefox/new/?scene=2')
         req.locale = 'en-US'
         views.new(req)
-        render_mock.assert_called_once_with(req, 'firefox/new/scene2.html')
+        render_mock.assert_called_once_with(req, 'firefox/new/scene2.html', ANY)
+
+    # /all tests (bug 1295181)
+    def test_all_variation_1(self, render_mock):
+        req = RequestFactory().get('/firefox/new/?v=1')
+        req.locale = 'en-US'
+        views.new(req)
+        render_mock.assert_called_once_with(req, 'firefox/new/scene1.html', {'version': '1'})
+
+    def test_all_variation_2(self, render_mock):
+        req = RequestFactory().get('/firefox/new/?v=2')
+        req.locale = 'en-US'
+        views.new(req)
+        render_mock.assert_called_once_with(req, 'firefox/new/scene1.html', {'version': '2'})
+
+    def test_all_variation_invalid(self, render_mock):
+        req = RequestFactory().get('/firefox/new/?v=3')
+        req.locale = 'en-US'
+        views.new(req)
+        render_mock.assert_called_once_with(req, 'firefox/new/scene1.html', {'version': None})
 
 
 class TestWin10WelcomeView(TestCase):

--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -475,6 +475,7 @@ def new(request):
         return HttpResponsePermanentRedirect(reverse('firefox.new'))
 
     scene = request.GET.get('scene', None)
+    version = None
 
     if scene == '2':
         template = 'firefox/new/scene2.html'
@@ -482,7 +483,18 @@ def new(request):
     else:
         template = 'firefox/new/scene1.html'
 
-    return l10n_utils.render(request, template)
+        # en-US tests
+        locale = l10n_utils.get_locale(request)
+        if locale == 'en-US':
+            version = request.GET.get('v', None)
+
+            # each variation puts a link under the primary dl button
+            # 1. links to /firefox/all
+            # 2. opens modal offering alternate direct & app store downloads
+            if version not in ['1', '2']:
+                version = None
+
+    return l10n_utils.render(request, template, {'version': version})
 
 
 def sync(request):

--- a/bedrock/settings/static_media.py
+++ b/bedrock/settings/static_media.py
@@ -444,6 +444,13 @@ PIPELINE_CSS = {
         ),
         'output_filename': 'css/firefox_new_scene2-bundle.css',
     },
+    'firefox_new_scene1_variations': {
+        'source_filenames': (
+            'css/base/mozilla-modal.less',
+            'css/firefox/new/all-test-variations.less',
+        ),
+        'output_filename': 'css/firefox_new_scene1_variations-bundle.css',
+    },
     'firefox_organizations': {
         'source_filenames': (
             'css/firefox/organizations.less',
@@ -1183,6 +1190,21 @@ PIPELINE_JS = {
             'js/firefox/new/scene1.js',
         ),
         'output_filename': 'js/firefox_new_scene1-bundle.js',
+    },
+    'experiment-firefox-new-scene1-all-links': {
+        'source_filenames': (
+            'js/base/mozilla-cookie-helper.js',
+            'js/base/mozilla-traffic-cop.js',
+            'js/firefox/new/experiment-all-links.js',
+        ),
+        'output_filename': 'js/experiment_firefox_new_scene1_all_links-bundle.js',
+    },
+    'firefox_new_scene1_variations': {
+        'source_filenames': (
+            'js/base/mozilla-modal.js',
+            'js/firefox/new/all-test-variations.js',
+        ),
+        'output_filename': 'js/firefox_new_scene1_variations-bundle.js',
     },
     'firefox_new_scene2': {
         'source_filenames': (

--- a/media/css/base/mozilla-modal.less
+++ b/media/css/base/mozilla-modal.less
@@ -70,6 +70,7 @@ html.noscroll body {
                     .image-replaced();
                     border-radius: 50%;
                     border: 2px solid #fff;
+                    .transition(transform 0.15s ease);
 
                     &:hover,
                     &:focus {

--- a/media/css/firefox/new/all-test-variations.less
+++ b/media/css/firefox/new/all-test-variations.less
@@ -1,0 +1,190 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+@import "../../sandstone/lib.less";
+
+#fx-modal-wrapper {
+    display: none;
+}
+
+#fx-modal {
+    margin-top: 40px;
+}
+
+#fx-modal-content {
+    .clearfix();
+    background: #fff;
+    border-radius: 6px;
+    color: @textColorPrimary;
+    margin-top: 20px;
+    padding: 40px 20px;
+    text-align: center;
+
+    ul {
+        list-style: none;
+    }
+
+    li {
+        display: inline-block;
+        margin: 0;
+    }
+
+    h3,
+    h4 {
+        color: @textColorPrimary;
+    }
+
+    h3 span {
+        .font-size(18px);
+        display: block;
+        margin-top: 5px;
+        text-align: center;
+    }
+
+    .fx-privacy-link {
+        a:link,
+        a:visited {
+            color: @linkBlue;
+        }
+    }
+}
+
+.fx-modal-section {
+    .border-box();
+    padding: 20px 0;
+    width: 50%;
+}
+
+#fx-modal-secondary-cta {
+    float: left;
+    padding-right: 40px;
+}
+
+#fx-modal-primary-ctas {
+    border-left: 1px solid @textColorLight;
+    float: right;
+    padding-left: 40px;
+}
+
+#fx-modal-mobile-downloads {
+    text-align: center;
+
+    li:first-child {
+        margin-right: 10px;
+    }
+}
+
+#fx-modal-direct-downloads {
+    padding: 10px 30px 0;
+    text-align: left;
+
+    li {
+        .border-box();
+        margin-bottom: 10px;
+        width: 50%;
+
+        a {
+            .font-size(@largeFontSize);
+            background: url('/media/img/firefox/new/down-arrow.svg') left center no-repeat;
+            background-size: 20px 16px;
+            padding-left: 24px;
+        }
+    }
+}
+
+@media only screen and (max-width: @breakDesktop) {
+    #fx-modal-primary-ctas {
+        padding-left: 20px;
+        width: 60%;
+    }
+
+    #fx-modal-secondary-cta {
+        padding-right: 20px;
+        width: 40%;
+    }
+}
+
+@media only screen and (max-width: @breakTablet) {
+    #fx-modal-primary-ctas,
+    #fx-modal-secondary-cta {
+        float: none;
+        margin-bottom: 40px;
+        padding: 0;
+        width: auto;
+    }
+
+    #fx-modal-primary-ctas {
+        border-bottom: 1px solid @textColorLight;
+        border-left: 0;
+        padding-bottom: 20px;
+
+        h4 {
+            .font-size(24px);
+        }
+    }
+
+    #fx-modal-direct-downloads {
+        margin-left: auto;
+        margin-right: auto;
+        width: @widthMobile - @baseLine;
+    }
+}
+
+@media only screen and (max-width: @breakMobileLandscape) {
+    #fx-modal-direct-downloads {
+        width: auto;
+
+        li {
+            display: list-item;
+            text-align: center;
+            width: auto;
+        }
+    }
+
+    #fx-modal-mobile-downloads li {
+        display: list-item;
+
+        &:first-child {
+            margin-right: 0;
+        }
+    }
+}
+
+@supports (display: flex) {
+    #fx-modal-content {
+        align-items: center;
+        display: flex;
+        flex-wrap: no-wrap;
+    }
+
+    .fx-modal-section {
+        flex: 0 0 50%;
+    }
+
+    #fx-modal-primary-ctas {
+        float: none;
+        order: 1;
+    }
+
+    #fx-modal-secondary-cta {
+        float: none;
+        order: 0;
+    }
+
+    @media only screen and (max-width: @breakDesktop) {
+        #fx-modal-primary-ctas {
+            flex-basis: 60%;
+        }
+
+        #fx-modal-secondary-cta {
+            flex-basis: 40%;
+        }
+    }
+
+    @media only screen and (max-width: @breakTablet) {
+        #fx-modal-content {
+            display: block;
+        }
+    }
+}

--- a/media/img/firefox/new/down-arrow.svg
+++ b/media/img/firefox/new/down-arrow.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><path d="M50 16v72M20 60l30 28m30-28L50 88" stroke="#0096dd" stroke-linecap="round" stroke-width="8"/></svg>

--- a/media/js/firefox/new/all-test-variations.js
+++ b/media/js/firefox/new/all-test-variations.js
@@ -1,0 +1,133 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+(function($, dataLayer) {
+    'use strict';
+
+    // check page version for tests
+    var version = Number($('#masthead').data('version'));
+
+    // adds sort value & (optional) new text to direct download li
+    var prepLi = function(li) {
+        var $li = $(li);
+        var $liA = $li.find('a');
+        var newOsName;
+
+        switch ($liA.text()) {
+        case 'Windows':
+            newOsName = 'Windows 32-bit';
+            $li.attr('data-sort', 1);
+            break;
+        case 'Linux':
+            newOsName = 'Linux 32-bit';
+            $li.attr('data-sort', 2);
+            break;
+        case 'Windows 64-bit':
+            $li.attr('data-sort', 3);
+            break;
+        case 'Linux 64-bit':
+            $li.attr('data-sort', 4);
+            break;
+        case 'OS X':
+            $li.attr('data-sort', 5);
+            break;
+        }
+
+        if (newOsName) {
+            $liA.text(newOsName);
+        }
+
+        return li;
+    };
+
+    var setupTest = function(version) {
+        var $dlButton = $('#download-button-desktop-release');
+        var $html = $('html');
+        var $newLink;
+
+        // make sure desktop download button exists, user is not on Android or iOS, and user is on a recognized platform
+        if (!$html.hasClass('ios') && !$html.hasClass('android') && $dlButton.length && $dlButton.find('.unrecognized-download:visible').length === 0) {
+            if (version === 1) {
+                // snag the link from the footer and clone it
+                $newLink = $('#fx-footer-links-desktop-all').clone();
+            } else if (version === 2) {
+                // pull the nojs links out of the modal's download button
+                var $directLis = $('#fx-modal-download .nojs-download li').remove();
+                // container to hold direct download links in the modal
+                var $modalDirectDownloadList = $('#fx-modal-direct-downloads');
+                // os's to filter out of modal (as we have the app store specific buttons displayed already)
+                var mobileOs = ['android', 'ios'];
+                // array to hold re-sorted download li's
+                var sortedLis = [];
+
+                // remove button-y CSS
+                $directLis.find('a').removeClass('button green');
+
+                // massage the download links
+                $directLis.each(function(i, li) {
+                    // do not include mobileOs's
+                    if ($.inArray($(li).find('a').data('download-os').toLowerCase(), mobileOs) === -1) {
+                        sortedLis.push(prepLi(li));
+                    }
+                });
+
+                // sort the download links
+                sortedLis.sort(function(a, b) {
+                    if (Number($(a).attr('data-sort')) < Number($(b).attr('data-sort'))) {
+                        return 1;
+                    } else {
+                        return -1;
+                    }
+                });
+
+                // add the download links to the DOM
+                for (var i = sortedLis.length; i >= 0; i--) {
+                    $modalDirectDownloadList.append(sortedLis[i]);
+                }
+
+                // get current user platform display name
+                var platformDisplayName = $dlButton.find('.download-list li:visible a').data('display-name');
+
+                if (platformDisplayName) {
+                    // put "for {user's os}" text underneath modal primary dl button
+                    $('#fx-modal-user-platform').text('for ' + platformDisplayName);
+                } else {
+                    $('#fx-modal-user-platform').remove();
+                }
+
+                // conjure up a new link that will trigger the modal
+                $newLink = $('<a href="#" id="fx-modal-link">Download Firefox for another platform</a>');
+
+                $newLink.on('click', function(e) {
+                    e.preventDefault();
+
+                    // open up said modal
+                    Mozilla.Modal.createModal(this, $('#fx-modal'));
+
+                    dataLayer.push({
+                        'event': 'alternate-version',
+                        'link-name': 'Systems & Languages'
+                    });
+                });
+            }
+
+            // double check that we have a new link to add
+            if ($newLink.length) {
+                // apply common styles
+                $newLink.css({
+                    'display': 'inline-block',
+                    'paddingTop': '10px'
+                });
+
+                // place the new link underneath the main download button
+                $dlButton.append($newLink);
+            }
+        }
+    };
+
+    // initiate test if valid version supplied
+    if (version === 1 || version === 2) {
+        setupTest(version);
+    }
+})(window.jQuery, window.dataLayer = window.dataLayer || []);

--- a/media/js/firefox/new/experiment-all-links.js
+++ b/media/js/firefox/new/experiment-all-links.js
@@ -1,0 +1,13 @@
+(function() {
+    'use strict';
+
+    var cop = new Mozilla.TrafficCop({
+        id: 'exp_fx_new_scene1_all_links',
+        variations: {
+            'v=1': 25,
+            'v=2': 25
+        }
+    });
+
+    cop.init();
+})(window.Mozilla);


### PR DESCRIPTION
## Description

Adds two variations to scene 1 of `/firefox/new`. Each variation adds a link underneath the primary download button that:

1. sends the user to `/firefox/all`
2. opens  a modal containing direct download links for all platforms, app store badges, and another primary download button

Understood that the JS is very much a hack right now for the modal variation. If that variation ends up winning, we'll need to figure out a more robust implementation.

Code to serve variations w/out Optimizely will come in a follow-up PR.

## Bugzilla link

https://bugzilla.mozilla.org/show_bug.cgi?id=1295181

## Testing

The usual. Ensure new links only display when download button is present (i.e. not when using up-to-date Firefox) and only for en-US. Double check old IE.

https://bedrock-demo-jpetto-fxnew.us-west.moz.works/en-US/firefox/new/?v=1
https://bedrock-demo-jpetto-fxnew.us-west.moz.works/en-US/firefox/new/?v=2

## Checklist
- [ ] Related functional & integration tests passing.

