### PR TITLE
Bug 1304281

### DIFF
--- a/media/css/firefox/new/horizon/common.less
+++ b/media/css/firefox/new/horizon/common.less
@@ -61,7 +61,8 @@
     height: 602px;
     left: -375px;
     position: absolute;
-    width: 880px;
+    width: 909px;
+    pointer-events: none;
 }
 
 .trees-right {
@@ -70,6 +71,7 @@
     position: absolute;
     right: -420px;
     width: 922px;
+    pointer-events: none
 }
 
 .fox {

--- a/media/css/firefox/new/horizon/common.less
+++ b/media/css/firefox/new/horizon/common.less
@@ -71,7 +71,7 @@
     position: absolute;
     right: -420px;
     width: 922px;
-    pointer-events: none
+    pointer-events: none;
 }
 
 .fox {

--- a/media/css/firefox/new/horizon/common.less
+++ b/media/css/firefox/new/horizon/common.less
@@ -61,7 +61,7 @@
     height: 602px;
     left: -375px;
     position: absolute;
-    width: 909px;
+    width: 880px;
 }
 
 .trees-right {


### PR DESCRIPTION
trees on the new Nightly "Whats New" page obstruct interacting with text on the page

https://bugzilla.mozilla.org/show_bug.cgi?id=1304281

## Testing

## Checklist
- [ ] Requires l10n changes.
- [ ] Related functional & integration tests passing.

Fixed. A change in the left-tree width element fixes it