### PR TITLE
[fix bug 1305179] Add tagmanager.google.com to CSP script src

### DIFF
--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -1102,6 +1102,7 @@ CSP_SCRIPT_SRC = CSP_DEFAULT_SRC + (
     'optimizely.s3.amazonaws.com',
     'www.googletagmanager.com',
     'www.google-analytics.com',
+    'tagmanager.google.com',
     'www.youtube.com',
     's.ytimg.com',
 )


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1305179

@pmac r?

