### PR TITLE
Give ability to run supervisor for dev

### DIFF
--- a/.bedrock_demo_env
+++ b/.bedrock_demo_env
@@ -4,6 +4,7 @@ CSP_EXTRA_FRAME_SRC=*.mozaws.net
 DEBUG=False
 DATABASE_URL=sqlite:///bedrock.db
 DEV=True
+DB_CRON=True
 DISABLE_SSL=False
 SECRET_KEY=itsasekrit
 ALLOWED_HOSTS=*

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,3 @@
 web: ./docker/run-prod.sh
-clock: ./bin/cron.py
+clock: ./bin/cron_db.py
+dev: ./docker/run-supervisor.sh

--- a/bin/cron_db.py
+++ b/bin/cron_db.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python
+
+from __future__ import print_function, unicode_literals
+
+from apscheduler.schedulers.blocking import BlockingScheduler
+
+from bedrock.scheduler_utils import call_command, scheduled_job, ping_dms
+
+
+schedule = BlockingScheduler()
+
+
+@scheduled_job(schedule, 'interval', minutes=30)
+@ping_dms
+def update_product_details():
+    call_command('update_product_details_files --database bedrock')
+
+
+@scheduled_job(schedule, 'interval', minutes=30)
+def update_externalfiles():
+    call_command('update_externalfiles')
+
+
+@scheduled_job(schedule, 'interval', minutes=30)
+def update_security_advisories():
+    call_command('update_security_advisories')
+
+
+@scheduled_job(schedule, 'interval', minutes=5)
+def rnasync():
+    # running in a subprocess as rnasync was not designed for long-running process
+    call_command('rnasync')
+
+
+@scheduled_job(schedule, 'interval', hours=6)
+def update_tweets():
+    call_command('cron update_tweets')
+
+
+@scheduled_job(schedule, 'interval', hours=1)
+def ical_feeds():
+    call_command('cron update_ical_feeds')
+    call_command('cron cleanup_ical_events')
+
+
+@scheduled_job(schedule, 'interval', hours=1)
+def update_firefox_os_feeds():
+    call_command('runscript update_firefox_os_feeds')
+
+
+if __name__ == '__main__':
+    try:
+        schedule.start()
+    except (KeyboardInterrupt, SystemExit):
+        pass

--- a/bin/cron_l10n.py
+++ b/bin/cron_l10n.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python
+
+from __future__ import print_function, unicode_literals
+
+from apscheduler.schedulers.blocking import BlockingScheduler
+
+from bedrock.scheduler_utils import call_command, scheduled_job
+
+
+schedule = BlockingScheduler()
+
+
+@scheduled_job(schedule, 'interval', minutes=10)
+def update_locales():
+    call_command('l10n_update')
+
+
+if __name__ == '__main__':
+    try:
+        schedule.start()
+    except (KeyboardInterrupt, SystemExit):
+        pass

--- a/docker/run-supervisor.sh
+++ b/docker/run-supervisor.sh
@@ -7,8 +7,10 @@ enable_proc() {
 }
 
 DEV=$(echo "$DEV" | tr '[:upper:]' '[:lower:]')
+DB_CRON=$(echo "$DB_CRON" | tr '[:upper:]' '[:lower:]')
 
 enable_proc bedrock
-[[ "$DEV" == "true" ]] && enable_proc cron || true
+[[ "$DEV" == "true" ]] && enable_proc cron_l10n || true
+[[ "$DB_CRON" == "true" ]] && enable_proc cron_db || true
 
 exec supervisord -c etc/supervisord.conf

--- a/etc/supervisor_available/cron_db.conf
+++ b/etc/supervisor_available/cron_db.conf
@@ -1,0 +1,8 @@
+[program:cron_db]
+command = /app/bin/cron_db.py
+numprocs = 1
+autostart = true
+user = webdev
+redirect_stderr = true
+stdout_logfile = /dev/stdout
+stdout_logfile_maxbytes = 0

--- a/etc/supervisor_available/cron_l10n.conf
+++ b/etc/supervisor_available/cron_l10n.conf
@@ -1,5 +1,5 @@
-[program:cron]
-command = /app/bin/cron.py
+[program:cron_l10n]
+command = /app/bin/cron_l10n.py
 numprocs = 1
 autostart = true
 user = webdev


### PR DESCRIPTION
This will allow us to run supervisord in www-dev that will run the site and a process to keep l10n updated. It allows us to run this without also running the other cron tasks that update the DB in every container, since we use a separate clock container for that. Demo instances will also run the DB update process via supervisor.

The idea is that if you run `docker/run-supervisor.sh` and `DEV=True` in your environment, it will run the site and the `bin/cron_l10n.py` script. If you also set `DB_CRON=True` in your environment, it will add `bin/cron_db.py` to the processes. This should only really be used in demos and other single process instances. Other instances (like www-dev.allizom.org) use a real DB and have a separate docker container running just the `cron_db.py` script.