### PR TITLE
[fix bug 1297399] Show pref form on email confirmation.

### DIFF
--- a/bedrock/newsletter/templates/newsletter/existing.html
+++ b/bedrock/newsletter/templates/newsletter/existing.html
@@ -15,20 +15,39 @@
 
   {% block main_feature %}
     <div id="main-feature">
+    {% if did_confirm == '1' %}
+      <h1>{{ _('Thanks for Subscribing!') }}</h1>
+
+      {% if l10n_has_tag('newsletter_confirm_2016') %}
+        <p>
+          {{ _('You’re awesome!') }}
+          {{ _('And we’re not just saying that because you trusted us with your email address.') }}
+          {{ _('Please be sure to add mozilla@e.mozilla.org to your address book to ensure we always reach your inbox.') }}
+        </p>
+
+        <p>
+          {{ _('Mozilla touches on a variety of important issues.') }}
+          {{ _('Open your inbox (and your heart) even more — take a look at other topics we cover.') }}
+        </p>
+      {% else %}
+        <p>{{ _('Your newsletter subscription has been confirmed.') }}</p>
+        <p>{{ _('Please be sure to add our sending address: mozilla@e.mozilla.org to your address book to ensure we always reach your inbox.') }}</p>
+      {% endif %}
+    {% else %}
       <h1>{{ _('Manage your Email Preferences') }}</h1>
 
-    {% if switch('newsletter-maintenance-mode') %}
-      <p class="billboard">
-        {{ _('This page is in maintenance mode and is temporarily unavailable.') }}<br>
-        {{ _('To update your email preferences, please check back in a little while. Thanks!') }}
-      </p>
-    {% else %}
-      <p>
-        {{ _('We love sharing updates about all the awesome things happening at Mozilla.') }}<br>
-        {{ _('Set your preferences below to make sure you always receive the news you want.') }}
-      </p>
+      {% if switch('newsletter-maintenance-mode') %}
+        <p class="billboard">
+          {{ _('This page is in maintenance mode and is temporarily unavailable.') }}<br>
+          {{ _('To update your email preferences, please check back in a little while. Thanks!') }}
+        </p>
+      {% else %}
+        <p>
+          {{ _('We love sharing updates about all the awesome things happening at Mozilla.') }}<br>
+          {{ _('Set your preferences below to make sure you always receive the news you want.') }}
+        </p>
+      {% endif %}
     {% endif %}
-
     </div>
   {% endblock %}
 

--- a/bedrock/newsletter/templates/newsletter/existing.html
+++ b/bedrock/newsletter/templates/newsletter/existing.html
@@ -15,7 +15,7 @@
 
   {% block main_feature %}
     <div id="main-feature">
-    {% if did_confirm == '1' %}
+    {% if did_confirm %}
       <h1>{{ _('Thanks for Subscribing!') }}</h1>
 
       {% if l10n_has_tag('newsletter_confirm_2016') %}

--- a/bedrock/newsletter/tests/test_views.py
+++ b/bedrock/newsletter/tests/test_views.py
@@ -132,7 +132,7 @@ class TestExistingNewsletterView(TestCase):
                 render.return_value = HttpResponse('')
                 self.client.get(url)
         request, template_name, context = render.call_args[0]
-        self.assertEqual(context['did_confirm'], '1')
+        self.assertEqual(context['did_confirm'], True)
 
     @patch('bedrock.newsletter.utils.get_newsletters')
     def test_get_token(self, get_newsletters, mock_basket_request):

--- a/bedrock/newsletter/views.py
+++ b/bedrock/newsletter/views.py
@@ -225,8 +225,7 @@ def confirm(request, token):
     # Assume rate limit error means user already confirmed and clicked confirm
     # link twice in quick succession
     if success or rate_limit_error:
-        print '*** success or rate limit! ***'
-        return HttpResponseRedirect("%s?confirm=1" % (reverse('newsletter.existing.token', kwargs={'token': token})))
+        return HttpResponseRedirect("%s?confirm=1" % reverse('newsletter.existing.token', kwargs={'token': token}))
     else:
         return l10n_utils.render(
             request,
@@ -440,7 +439,7 @@ def existing(request, token=None):
     already_subscribed = mark_safe(json.dumps(user['newsletters']))
 
     context = {
-        'did_confirm': request.GET.get('confirm', None),
+        'did_confirm': request.GET.get('confirm', None) == '1',
         'form': form,
         'formset': formset,
         'newsletter_languages': newsletter_languages,

--- a/bedrock/newsletter/views.py
+++ b/bedrock/newsletter/views.py
@@ -10,6 +10,7 @@ from operator import itemgetter
 
 from django.contrib import messages
 from django.forms.formsets import formset_factory
+from django.http import HttpResponseRedirect
 from django.shortcuts import redirect
 from django.utils.safestring import mark_safe
 from django.views.decorators.cache import never_cache
@@ -200,7 +201,7 @@ def confirm(request, token):
     """
     Confirm subscriptions.
     """
-    success = generic_error = token_error = False
+    success = generic_error = token_error = rate_limit_error = False
 
     try:
         result = basket.confirm(token)
@@ -208,6 +209,8 @@ def confirm(request, token):
         log.exception("Exception confirming token %s" % token)
         if e.code == basket.errors.BASKET_UNKNOWN_TOKEN:
             token_error = True
+        elif e.code == basket.errors.BASKET_USAGE_ERROR:
+            rate_limit_error = True
         else:
             # Any other exception
             generic_error = True
@@ -219,12 +222,18 @@ def confirm(request, token):
             # but just in case:
             generic_error = True
 
-    return l10n_utils.render(
-        request,
-        'newsletter/confirm.html',
-        {'success': success,
-         'generic_error': generic_error,
-         'token_error': token_error})
+    # Assume rate limit error means user already confirmed and clicked confirm
+    # link twice in quick succession
+    if success or rate_limit_error:
+        print '*** success or rate limit! ***'
+        return HttpResponseRedirect("%s?confirm=1" % (reverse('newsletter.existing.token', kwargs={'token': token})))
+    else:
+        return l10n_utils.render(
+            request,
+            'newsletter/confirm.html',
+            {'success': success,
+             'generic_error': generic_error,
+             'token_error': token_error})
 
 
 @never_cache
@@ -427,17 +436,18 @@ def existing(request, token=None):
             newsletter_languages[lang].append(newsletter)
     newsletter_languages = mark_safe(json.dumps(newsletter_languages))
 
-    # We also want a list of the newsletters the user is already subscribed
-    # to
+    # We also want a list of the newsletters the user is already subscribed to
     already_subscribed = mark_safe(json.dumps(user['newsletters']))
 
     context = {
+        'did_confirm': request.GET.get('confirm', None),
         'form': form,
         'formset': formset,
         'newsletter_languages': newsletter_languages,
         'newsletters_subscribed': already_subscribed,
         'email': user['email'],
     }
+
     return l10n_utils.render(request,
                              'newsletter/existing.html',
                              context)


### PR DESCRIPTION
## Description

Add subscription confirmation handling to `/newsletter/existing/`.

## Bugzilla link

https://bugzilla.mozilla.org/show_bug.cgi?id=1297399

## Testing

Make sure newsletter preferences can be updated when confirming and not confirming subscription.

## Checklist
- [ ] Requires l10n changes.
- [ ] Related functional & integration tests passing.

