### PR TITLE
Removed odd and broken link to pdx.mozillausa.org

### DIFF
--- a/bedrock/mozorg/templates/mozorg/contact/spaces/portland.html
+++ b/bedrock/mozorg/templates/mozorg/contact/spaces/portland.html
@@ -23,7 +23,6 @@
         </p>
 
         <ul class="extra">
-          <li><a href="http://pdx.mozillausa.org/" class="website">pdx.mozillausa.org</a></li>
           <li><a href="https://twitter.com/mozpdx" class="twitter">@MozPDX</a></li>
           <li><a href="https://www.facebook.com/pages/Mozillians-PDX/506068286122532" class="facebook">Facebook</a></li>
           <li><a href="http://www.red-bean.com/mailman/listinfo/mozilla-pdx" class="email">{{ _('Mailing list') }}</a></li>


### PR DESCRIPTION
## Description
pdx.mozillausa.org was a broken link.

## Bugzilla link
None.

## Testing
None, just removed the link.

## Checklist
- [ ] Requires l10n changes.
- [x] Related functional & integration tests passing.

