### PR TITLE
[no bug] Fix minor issues on Community Participation Guidelines

### DIFF
--- a/bedrock/mozorg/templates/mozorg/about/governance/policies/participation.html
+++ b/bedrock/mozorg/templates/mozorg/about/governance/policies/participation.html
@@ -19,7 +19,7 @@
     <li>{{ _('the Anti-Harassment/Discrimination Policy <a href="#note-1">[1]</a> which sets out protections and obligations of Mozilla employees, and is crafted with specific jurisdictional legal definitions and requirements in mind.') }}</li>
     <li>{{ _('Mozilla groups for escalation and dispute resolution.') }}</li>
   </ul>
-  <p>{{ _('The Community Participation Guidelines cover our behaviour as members of the Mozilla Community in Mozilla-related forums, mailing lists, wikis, web sites, IRC channels, bugs, events, public meetings or person to person, Mozilla-related correspondence.') }}</p>
+  <p>{{ _('The Community Participation Guidelines cover our behavior as members of the Mozilla Community in Mozilla-related forums, mailing lists, wikis, web sites, IRC channels, bugs, events, public meetings or person to person, Mozilla-related correspondence.') }}</p>
   <p>{{ _('The Community Participation Guidelines have two parts -- an Inclusion and Diversity section and a general section called “Interaction Style” about how we treat each other. Each is an important part of the community we’re building.') }}</p>
 
   <section>
@@ -45,13 +45,13 @@
 
   <section>
     <h3>{{ _('Interaction Style') }}</h3>
-    <p>{{ _('This is a more general section about how we treat each other. Each aspect  is an important part of the community we’re building.') }}</p>
+    <p>{{ _('This is a more general section about how we treat each other. Each aspect is an important part of the community we’re building.') }}</p>
     <ul>
       <li>{{ _('Be respectful. We may not always agree, but disagreement is no excuse for poor manners. We will all experience some frustration now and then, but we don’t allow that frustration to turn into a personal attack. A community where people feel uncomfortable or threatened is not a productive one.') }}</li>
       <li>{{ _('Try to understand different perspectives. Our goal should not be to “win” every disagreement or argument. A more productive goal is to be open to ideas that make our own ideas better. “Winning” is when different perspectives make our work richer and stronger.') }}</li>
       <li>{{ _('Do not threaten violence.') }}</li>
       <li>{{ _('Empower others to speak.') }}</li>
-      <li>{{ _('Strive for excellence. For our  products to be great our communities must be healthy and vigorous. Being respectful does not mean papering over disagreements or accepting less than we can do.') }}</li>
+      <li>{{ _('Strive for excellence. For our products to be great our communities must be healthy and vigorous. Being respectful does not mean papering over disagreements or accepting less than we can do.') }}</li>
       <li>{{ _('Don’t expect to agree with every decision.') }}</li>
     </ul>
   </section>
@@ -65,7 +65,7 @@
   </section>
 
   <footer>
-    <p id="note-1">{{ _('[1] The anti-harassment policy is accessible to paid staff <a href="%s">here</a>.'|format('https://mana.mozilla.org/wiki/display/PR/Policy')) }}</p>
+    <p id="note-1">{{ _('[1] The anti-harassment policy is accessible to paid staff <a href="%s">here</a>.')|format('https://mana.mozilla.org/wiki/display/PR/Policy') }}</p>
   </footer>
 </section>
 


### PR DESCRIPTION
I’ve found and fixed the following issues while moving the [Japanese translation](http://www.mozilla-japan.org/about/policies/participation.html) to [mozilla.org](https://www.mozilla.org/ja/about/governance/policies/participation/):

* Replace “behaviour” with the en-US spelling
* Remove unnecessary spaces
* Fix a l10n bracket issue