### PR TITLE
Bug 1305661 functional tests for home / technology page

### DIFF
--- a/tests/functional/newsletter/test_newsletter_embed.py
+++ b/tests/functional/newsletter/test_newsletter_embed.py
@@ -27,8 +27,7 @@ from pages.smarton.base import SmartOnBasePage
 
 @pytest.mark.nondestructive
 @pytest.mark.parametrize(('page_class', 'url_kwargs'), [
-    pytest.mark.skipif(pytest.mark.smoke((HomePage, None)),
-        reason='https://bugzilla.mozilla.org/show_bug.cgi?id=1293779'),
+    pytest.mark.smoke((HomePage, None)),
     (AboutPage, None),
     pytest.mark.smoke((ContributePage, None)),
     (TwitterTaskPage, None),
@@ -63,10 +62,7 @@ def test_newsletter_default_values(page_class, url_kwargs, base_url, selenium):
 
 
 @pytest.mark.nondestructive
-@pytest.mark.parametrize('page_class', [
-    pytest.mark.skipif(HomePage,
-    reason='https://bugzilla.mozilla.org/show_bug.cgi?id=1293779'),
-    ContributePage])
+@pytest.mark.parametrize('page_class', [HomePage, ContributePage])
 def test_newsletter_successful_sign_up(page_class, base_url, selenium):
     page = page_class(selenium, base_url).open()
     page.newsletter.expand_form()
@@ -79,10 +75,7 @@ def test_newsletter_successful_sign_up(page_class, base_url, selenium):
 
 
 @pytest.mark.nondestructive
-@pytest.mark.parametrize('page_class', [
-    pytest.mark.skipif(HomePage,
-    reason='https://bugzilla.mozilla.org/show_bug.cgi?id=1293779'),
-    ContributePage])
+@pytest.mark.parametrize('page_class', [HomePage, ContributePage])
 def test_newsletter_sign_up_fails_when_missing_required_fields(page_class, base_url, selenium):
     page = page_class(selenium, base_url).open()
     page.newsletter.expand_form()

--- a/tests/functional/test_home.py
+++ b/tests/functional/test_home.py
@@ -7,48 +7,17 @@ import pytest
 from pages.home import HomePage
 
 
-@pytest.mark.skipif(reason='https://bugzilla.mozilla.org/show_bug.cgi?id=1275626')
-@pytest.mark.smoke
-@pytest.mark.nondestructive
-def test_promo_grid_is_displayed(base_url, selenium):
-    page = HomePage(selenium, base_url).open()
-    assert page.is_promo_grid_displayed
-
-
-@pytest.mark.skipif(reason='https://bugzilla.mozilla.org/show_bug.cgi?id=1275626')
-@pytest.mark.nondestructive
-def test_promos_are_present(base_url, selenium):
-    page = HomePage(selenium, base_url).open()
-    assert page.number_of_promos_present == 16
-
-
-@pytest.mark.skipif(reason='https://bugzilla.mozilla.org/show_bug.cgi?id=1275626')
-@pytest.mark.nondestructive
-def test_tweet_is_present(base_url, selenium):
-    page = HomePage(selenium, base_url).open()
-    assert page.is_tweet_promo_present
-
-
-@pytest.mark.skipif(reason='https://bugzilla.mozilla.org/show_bug.cgi?id=1275626')
-@pytest.mark.nondestructive
-def test_tweet_is_not_present(base_url, selenium):
-    page = HomePage(selenium, base_url, 'de').open()
-    assert not page.is_tweet_promo_present
-
-
-@pytest.mark.skipif(reason='https://bugzilla.mozilla.org/show_bug.cgi?id=1275626')
+@pytest.mark.skip_if_firefox(reason='Download button is not shown to Firefox browsers.')
 @pytest.mark.sanity
-@pytest.mark.smoke
 @pytest.mark.nondestructive
 def test_download_button_is_displayed(base_url, selenium):
     page = HomePage(selenium, base_url).open()
     assert page.download_button.is_displayed
 
 
-@pytest.mark.skipif(reason='https://bugzilla.mozilla.org/show_bug.cgi?id=1275626')
+@pytest.mark.sanity
+@pytest.mark.smoke
 @pytest.mark.nondestructive
-def test_upcoming_events_are_displayed(base_url, selenium):
+def test_get_firefox_link_is_displayed(base_url, selenium):
     page = HomePage(selenium, base_url).open()
-    events = page.upcoming_events
-    assert events.is_next_event_displayed
-    assert events.is_events_list_displayed
+    assert page.is_get_firefox_link_displayed

--- a/tests/functional/test_l10n.py
+++ b/tests/functional/test_l10n.py
@@ -9,7 +9,6 @@ import pytest
 from pages.home import HomePage
 
 
-@pytest.mark.skipif(reason='https://bugzilla.mozilla.org/show_bug.cgi?id=1275626')
 @pytest.mark.nondestructive
 def test_change_language(base_url, selenium):
     page = HomePage(selenium, base_url).open()

--- a/tests/functional/test_navigation.py
+++ b/tests/functional/test_navigation.py
@@ -7,7 +7,6 @@ import pytest
 from pages.home import HomePage
 
 
-@pytest.mark.skipif(reason='https://bugzilla.mozilla.org/show_bug.cgi?id=1275626')
 @pytest.mark.nondestructive
 def test_navigation(base_url, selenium):
     page = HomePage(selenium, base_url).open()
@@ -15,15 +14,14 @@ def test_navigation(base_url, selenium):
     assert about_page.seed_url in selenium.current_url
 
     page.open()
-    participate_page = page.navigation.open_participate()
-    assert participate_page.seed_url in selenium.current_url
+    technology_page = page.navigation.open_technology()
+    assert technology_page.seed_url in selenium.current_url
 
     page.open()
     firefox_page = page.navigation.open_firefox()
     assert firefox_page.seed_url in selenium.current_url
 
 
-@pytest.mark.skipif(reason='https://bugzilla.mozilla.org/show_bug.cgi?id=1275626')
 @pytest.mark.smoke
 @pytest.mark.nondestructive
 @pytest.mark.viewport('mobile')
@@ -34,8 +32,8 @@ def test_mobile_navigation(base_url, selenium):
     assert about_page.seed_url in selenium.current_url
 
     page.open().navigation.show()
-    participate_page = page.navigation.open_participate()
-    assert participate_page.seed_url in selenium.current_url
+    technology_page = page.navigation.open_technology()
+    assert technology_page.seed_url in selenium.current_url
 
     page.open().navigation.show()
     firefox_page = page.navigation.open_firefox()

--- a/tests/functional/test_technology.py
+++ b/tests/functional/test_technology.py
@@ -1,0 +1,14 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import pytest
+
+from pages.technology import TechnologyPage
+
+
+@pytest.mark.nondestructive
+def test_blog_feed_is_displayed(base_url, selenium):
+    page = TechnologyPage(selenium, base_url).open()
+    assert page.is_blog_feed_displayed
+    assert page.number_of_blog_articles_present == 4

--- a/tests/pages/base.py
+++ b/tests/pages/base.py
@@ -40,7 +40,7 @@ class BasePage(Page):
         _toggle_locator = (By.CLASS_NAME, 'toggle')
         _menu_locator = (By.ID, 'nav-main-menu')
         _about_locator = (By.CSS_SELECTOR, 'a[data-link-name="About"]')
-        _participate_locator = (By.CSS_SELECTOR, 'a[data-link-name="Participate"]')
+        _technology_locator = (By.CSS_SELECTOR, 'a[data-link-name="Web Innovations"]')
         _firefox_locator = (By.CSS_SELECTOR, 'a[data-link-name="Firefox"]')
 
         def show(self):
@@ -60,10 +60,10 @@ class BasePage(Page):
             from about import AboutPage
             return AboutPage(self.selenium, self.page.base_url).wait_for_page_to_load()
 
-        def open_participate(self):
-            self.find_element(*self._participate_locator).click()
-            from contribute.contribute import ContributePage
-            return ContributePage(self.selenium, self.page.base_url).wait_for_page_to_load()
+        def open_technology(self):
+            self.find_element(*self._technology_locator).click()
+            from technology import TechnologyPage
+            return TechnologyPage(self.selenium, self.page.base_url).wait_for_page_to_load()
 
         def open_firefox(self):
             self.find_element(*self._firefox_locator).click()

--- a/tests/pages/home.py
+++ b/tests/pages/home.py
@@ -2,9 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from pypom import Region
 from selenium.webdriver.common.by import By
-from selenium.webdriver.support import expected_conditions as expected
 
 from pages.base import BasePage
 from pages.regions.download_button import DownloadButton
@@ -12,10 +10,8 @@ from pages.regions.download_button import DownloadButton
 
 class HomePage(BasePage):
 
-    _promo_grid_locator = (By.CSS_SELECTOR, '.promo-grid.reveal')
-    _promo_tile_locator = (By.CSS_SELECTOR, '.promo-grid > .item')
-    _promo_tweet_locator = (By.ID, 'twt-body')
-    _download_button_locator = (By.ID, 'download-button-desktop-release')
+    _download_button_locator = (By.ID, 'nav-download-firefox')
+    _get_firefox_link_locator = (By.ID, 'fx-download-link')
 
     @property
     def download_button(self):
@@ -23,33 +19,5 @@ class HomePage(BasePage):
         return DownloadButton(self, root=el)
 
     @property
-    def is_promo_grid_displayed(self):
-        self.wait.until(expected.visibility_of_element_located(self._promo_grid_locator))
-        return self.find_element(*self._promo_grid_locator).is_displayed()
-
-    @property
-    def number_of_promos_present(self):
-        return len(self.find_elements(*self._promo_tile_locator))
-
-    @property
-    def is_tweet_promo_present(self):
-        return self.is_element_present(*self._promo_tweet_locator)
-
-    @property
-    def upcoming_events(self):
-        return UpcomingEvents(self)
-
-
-class UpcomingEvents(Region):
-
-    _root_locator = (By.ID, 'upcoming-events')
-    _next_event_locator = (By.CSS_SELECTOR, '.featured-event .event-detail > a')
-    _events_list_locator = (By.CSS_SELECTOR, '.events-list')
-
-    @property
-    def is_next_event_displayed(self):
-        return self.is_element_displayed(*self._next_event_locator)
-
-    @property
-    def is_events_list_displayed(self):
-        return self.is_element_displayed(*self._events_list_locator)
+    def is_get_firefox_link_displayed(self):
+        return self.is_element_displayed(*self._get_firefox_link_locator)

--- a/tests/pages/technology.py
+++ b/tests/pages/technology.py
@@ -10,3 +10,14 @@ from pages.base import BasePage
 class TechnologyPage(BasePage):
 
     URL_TEMPLATE = '/{locale}/technology'
+
+    _blog_feed_locator = (By.ID, 'blogs')
+    _blog_feed_articles_locator = (By.CSS_SELECTOR, '#blogs article')
+
+    @property
+    def is_blog_feed_displayed(self):
+        return self.is_element_displayed(*self._blog_feed_locator)
+
+    @property
+    def number_of_blog_articles_present(self):
+        return len(self.find_elements(*self._blog_feed_articles_locator))

--- a/tests/pages/technology.py
+++ b/tests/pages/technology.py
@@ -1,0 +1,12 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from selenium.webdriver.common.by import By
+
+from pages.base import BasePage
+
+
+class TechnologyPage(BasePage):
+
+    URL_TEMPLATE = '/{locale}/technology'


### PR DESCRIPTION
Updated functional tests for the new home page. This also required creating a page object for the Technology page in order to test the main site navigation, so I added a test for the technology page blog feed as a separate commit.
