### PR TITLE
[fix bug 1297399] Hide unsubscribe fields from newsletter confirm users.

### DIFF
--- a/bedrock/newsletter/templates/newsletter/existing.html
+++ b/bedrock/newsletter/templates/newsletter/existing.html
@@ -139,7 +139,7 @@
         </div>
       </div><!-- close #default-newsletters -->
 
-      <div class="field" id="other-newsletters">
+      <div class="field{% if did_confirm %} hidden{% endif %}" id="other-newsletters">
         <h3>{{ _('Getting too much email from us?') }}</h3>
         <p>
           {{ _('Not interested in our newsletters, but like those special announcements? No problem.') }}
@@ -179,7 +179,7 @@
         </div>
       </div><!-- close #other-newsletters -->
 
-      <div class="field" id="remove-all-section">
+      <div class="field{% if did_confirm %} hidden{% endif %}" id="remove-all-section">
         {{ form['remove_all'] }}
         {{ form.remove_all.label_tag(_('Remove me from all Mozilla emails')) }}
       </div>


### PR DESCRIPTION
## Description

Hide form fields associated with unsubscribing from users that just confirmed their subscription.

## Bugzilla link

https://bugzilla.mozilla.org/show_bug.cgi?id=1297399#c20

## Testing

Make sure updating preferences after confirming still works.

## Checklist
- [ ] Related functional & integration tests passing.

