### PR TITLE
Update Web Bounty HOF with Q3 Bounty winners

### DIFF
--- a/bedrock/security/templates/security/bug-bounty/web-hall-of-fame.html
+++ b/bedrock/security/templates/security/bug-bounty/web-hall-of-fame.html
@@ -35,9 +35,18 @@
       <section id="year-2016">
         <h3 data-accordion-role="tab">{{ _('2016') }}</h3>
         <div data-accordion-role="tabpanel">
+          <h4>3rd Quarter 2016</h4>
+          <ul>
+            <li>Fredrik Nordberg</li>
+            <li>Griffin Francis </li>
+            <li>Amir Saad</li>
+            <li>Lucio Corsa</li>
+            <li>Arne Swinnen</li>
+            <li>Wladimir Palant</li>
+          </ul>
           <h4>2nd Quarter 2016</h4>
           <ul>
-            <li>Adrian Gaudebert</li>
+            <li>Sergey Bobrov</li>
             <li>Griffin Francis</li>
             <li>Takashi Suzuki</li>
             <li>Mario Gomes</li>
@@ -64,6 +73,9 @@
             <li>Sergey Bobrov</li>
             <li>Tom Prince</li>
             <li>Wladimir Palant</li>
+            <li>Daniel Tomescu</li>
+            <li>Shahar Albeck</li>
+            <li>Andrew</li>
           </ul>
         </div>
       </section>


### PR DESCRIPTION
## Description
Update Web Bounty HOF with Q3 Bounty winners
## Bugzilla link
Not a code change
## Testing

## Checklist
- [ ] Requires l10n changes.
- [ ] Related functional & integration tests passing.

Add Q3 winners, 3 missing names from Q1, 1 from q2