### PR TITLE
[Fix for Bug 1306002] - Release notes page should link to /firefox/releases/

### DIFF
--- a/bedrock/firefox/templates/firefox/releases/release-notes.html
+++ b/bedrock/firefox/templates/firefox/releases/release-notes.html
@@ -314,6 +314,7 @@
       <a rel="external" href="https://blog.mozilla.org/press/kits/">{{ _('Press Kit') }}</a>
       <a rel="external" href="https://blog.mozilla.org/press/">{{ _('Mozilla and Firefox News') }}</a>
       <a href="{{ url('firefox.organizations.organizations') }}">{{ _('Firefox Extended Support Release') }}</a>
+      <a href="{{ url('firefox.releases.index') }}">{{ _('All Firefox for Desktop Releases') }}</a>
     </div>
   </div>
 </footer>


### PR DESCRIPTION
## Description
Updated the release notes page template. The "/firefox/releases/" page is now linked to the release notes page. The link can be found in the 'Other Resources" section.
## Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1306002
## Testing

## Checklist
- [ ] Requires l10n changes.
- [ ] Related functional & integration tests passing.