### PR TITLE
[fix bug 1309149] oldIE.scss is missing download button component

### DIFF
--- a/media/css/pebbles/base/oldIE.scss
+++ b/media/css/pebbles/base/oldIE.scss
@@ -8,7 +8,8 @@
 @import
     '../includes/lib',
     'elements',
-    '../components/buttons';
+    '../components/buttons',
+    '../components/buttons-download';
 
 
 // @Fonts


### PR DESCRIPTION
## Description
- This should fix the test failures that blocked yesterday's push.

## Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1309149

