### PR TITLE
Fix channel redirect for legacy URLs

### DIFF
--- a/bedrock/firefox/redirects.py
+++ b/bedrock/firefox/redirects.py
@@ -47,8 +47,8 @@ redirectpatterns = (
              permanent=False),
 
     # Bug 1009247, 1101220, 1299947
-    redirect(r'^(firefox)?/beta/?$', 'firefox.channel.desktop', anchor='beta'),
-    redirect(r'^(firefox)?/aurora/?$', 'firefox.channel.desktop', anchor='developer'),
+    redirect(r'^(firefox/)?beta/?$', 'firefox.channel.desktop', anchor='beta'),
+    redirect(r'^(firefox/)?aurora/?$', 'firefox.channel.desktop', anchor='developer'),
     redirect(r'^mobile/beta/?$', 'firefox.channel.android', anchor='beta'),
     redirect(r'^mobile/aurora/?$', 'firefox.channel.android', anchor='aurora'),
 

--- a/tests/redirects/map_globalconf.py
+++ b/tests/redirects/map_globalconf.py
@@ -179,8 +179,8 @@ URLS = flatten((
     url_test('/firefox/nightly/whatsnew/', '/firefox/nightly/firstrun/'),
 
     # bug 1299947
-    url_test('/{firefox,}/beta/', '/firefox/channel/desktop/#beta'),
-    url_test('/{firefox,}/aurora/', '/firefox/channel/desktop/#developer'),
+    url_test('/{firefox/,}beta/', '/firefox/channel/desktop/#beta'),
+    url_test('/{firefox/,}aurora/', '/firefox/channel/desktop/#developer'),
     url_test('/mobile/beta/', '/firefox/channel/android/#beta'),
     url_test('/mobile/aurora/', '/firefox/channel/android/#aurora'),
 


### PR DESCRIPTION
https://ci.us-west.moz.works/job/bedrock_integration_tests/1286/

@pmac r?