### PR TITLE
Fix foundation homepage on webkit small screen

### DIFF
--- a/media/css/foundation/foundation.less
+++ b/media/css/foundation/foundation.less
@@ -126,9 +126,7 @@
 .program-column {
     .border-box;
     padding: 0.5em;
-    flex-basis: 33%;
-    flex-grow: 1;
-    min-width: 14em;
+    flex: 1 0 14em;
     li + li{
         margin-top: 0;
     }


### PR DESCRIPTION
## Description
mozilla.org/foundation has a horizontal scroll on small webkit viewports due to a flexbox bug. This solves that.

## Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1309321

## Testing
Visual

## Checklist
- [ ] Requires l10n changes.
- [ ] Related functional & integration tests passing.

Programs now stay within the appropriate column.