### PR TITLE
Fix Bug 1309692 - Unique page title is missing on the refreshed Foundation pages

### DIFF
--- a/bedrock/foundation/templates/foundation/about.html
+++ b/bedrock/foundation/templates/foundation/about.html
@@ -8,10 +8,6 @@
 
 {% set body_id = "about" %}
 
-{% block article_title %}
-  {{ _('About the Mozilla Foundation') }}
-{% endblock %}
-
 {% block article %}
   <p>
     {% trans

--- a/bedrock/foundation/templates/foundation/advocacy.html
+++ b/bedrock/foundation/templates/foundation/advocacy.html
@@ -4,14 +4,9 @@
 
 {% extends "foundation/base-resp.html" %}
 
-{% block page_title %}{{ _('Mozilla Advocacy') }}{% endblock %}
+{% block page_title %}{{ _('Mozilla Advocacy — Rallying citizens to protect the open Internet') }}{% endblock %}
 
 {% set body_id = "advocacy" %}
-
-{% block article_header %}
-  <h2>{{ _('Mozilla Advocacy') }}</h2>
-  <p>{{ _('Rallying citizens to protect the open Internet') }}</p>
-{% endblock %}
 
 {% block article %}
   <p>

--- a/bedrock/foundation/templates/foundation/base-resp.html
+++ b/bedrock/foundation/templates/foundation/base-resp.html
@@ -30,7 +30,7 @@
 {% block content %}
   <main>
     <header class="page-header">
-      <h1><span class="content">{{ _('The Mozilla Foundation') }}</span></h1>
+      <h1><span class="content">{{ self.page_title() }}</span></h1>
     </header>
     <section>
       <div class="content content-main">

--- a/bedrock/foundation/templates/foundation/documents/articles-of-incorporation-amendment.html
+++ b/bedrock/foundation/templates/foundation/documents/articles-of-incorporation-amendment.html
@@ -6,10 +6,6 @@
 
 {% block page_title %}{{ _('Certificate of Second Amendment to the Bylaws of Mozilla Corporation') }}{% endblock %}
 
-{% block article_title %}
-  <h1 class="page-title">{{ self.page_title() }}</h1>
-{% endblock %}
-
 {% block article %}
 <p>{{ _('The undersigned certify that:') }}</p>
 

--- a/bedrock/foundation/templates/foundation/documents/articles-of-incorporation.html
+++ b/bedrock/foundation/templates/foundation/documents/articles-of-incorporation.html
@@ -6,10 +6,6 @@
 
 {% block page_title %}{{ _('Articles of Incorporation of M. F. Technologies') }}{% endblock %}
 
-{% block article_title %}
-  <h1 class="page-title">{{ self.page_title() }}</h1>
-{% endblock %}
-
 {% block article %}
 
 <p>{{ _('The undersigned incorporator, for the purpose of forming a corporation under the California Corporations Code, hereby certifies:') }}</p>

--- a/bedrock/foundation/templates/foundation/documents/bylaws-amendment-1.html
+++ b/bedrock/foundation/templates/foundation/documents/bylaws-amendment-1.html
@@ -6,10 +6,6 @@
 
 {% block page_title %}{{ _('Amendment No. 1 to Bylaws of Mozilla Corporation') }}{% endblock %}
 
-{% block article_title %}
-  <h1 class="page-title">{{ self.page_title() }}</h1>
-{% endblock %}
-
 {% block article %}
 <p>{{ _('Effective as of October 19, 2006') }}</p>
 

--- a/bedrock/foundation/templates/foundation/documents/bylaws-amendment-2.html
+++ b/bedrock/foundation/templates/foundation/documents/bylaws-amendment-2.html
@@ -6,10 +6,6 @@
 
 {% block page_title %}{{ _('Certificate of Second Amendment to the Bylaws of Mozilla Corporation') }}{% endblock %}
 
-{% block article_title %}
-  <h1 class="page-title">{{ self.page_title() }}</h1>
-{% endblock %}
-
 {% block article %}
 <p>{{ _('Effective November 10, 2006') }}</p>
 

--- a/bedrock/foundation/templates/foundation/documents/bylaws.html
+++ b/bedrock/foundation/templates/foundation/documents/bylaws.html
@@ -6,10 +6,6 @@
 
 {% block page_title %}{{ _('Bylaws of M.F. Technologies') }}{% endblock %}
 
-{% block article_title %}
-  <h1 class="page-title">{{ self.page_title() }}</h1>
-{% endblock %}
-
 {% block article %}
 <h2>{{ _('Article I - PURPOSE') }}</h2>
 <p>{{ _('The primary purpose of M.F. Technologies (the “<u>Corporation</u>”) is to advance the Mozilla Foundation’s objectives of promoting choice and innovation on the Internet.') }}</p> 

--- a/bedrock/foundation/templates/foundation/documents/index.html
+++ b/bedrock/foundation/templates/foundation/documents/index.html
@@ -8,10 +8,6 @@
 
 {% set body_id = "documents" %}
 
-{% block article_title %}
-  {{ self.page_title() }}
-{% endblock %}
-
 {% block article %}
   <p>{% trans %}For information relating to the Mozilla Foundation's governance and
   related matters please see the documents below.{% endtrans %}</p>

--- a/bedrock/foundation/templates/foundation/documents/mozilla-2006-financial-faq.html
+++ b/bedrock/foundation/templates/foundation/documents/mozilla-2006-financial-faq.html
@@ -6,10 +6,6 @@
 
 {% block page_title %}{{ _('Mozilla 2006 Financial FAQ') }}{% endblock %}
 
-{% block article_title %}
-  <h1 class="page-title">{{ _('Mozilla 2006 Financial FAQ') }}</h1>
-{% endblock %}
-
 {% block article %}
   <p>
    {% trans form990='http://static.mozilla.com/foundation/documents/mf-2006-irs-form-990.pdf',

--- a/bedrock/foundation/templates/foundation/documents/mozilla-2007-financial-faq.html
+++ b/bedrock/foundation/templates/foundation/documents/mozilla-2007-financial-faq.html
@@ -6,10 +6,6 @@
 
 {% block page_title %}{{ _('Mozilla 2007 Financial FAQ') }}{% endblock %}
 
-{% block article_title %}
-  <h1 class="page-title">{{ _('Mozilla 2007 Financial FAQ') }}</h1>
-{% endblock %}
-
 {% block article %}
   <p>
     {% trans

--- a/bedrock/foundation/templates/foundation/documents/mozilla-2008-financial-faq.html
+++ b/bedrock/foundation/templates/foundation/documents/mozilla-2008-financial-faq.html
@@ -6,10 +6,6 @@
 
 {% block page_title %}{{ _('Mozilla 2008 Financial FAQ') }}{% endblock %}
 
-{% block article_title %}
-  <h1 class="page-title">{{ _('Mozilla 2008 Financial FAQ') }}</h1>
-{% endblock %}
-
 {% block article %}
   <p>
     {% trans

--- a/bedrock/foundation/templates/foundation/feed-icon-guidelines/faq.html
+++ b/bedrock/foundation/templates/foundation/feed-icon-guidelines/faq.html
@@ -6,13 +6,6 @@
 
 {% block page_title %}{{ _('Feed Icon FAQ') }}{% endblock %}
 
-{% block article_title %}
-  <header class="page-title">
-    <h1>{{ _('Feed Icon Guidelines') }}</h1>
-    <h2>{{ _('Frequently Asked Questions') }}</h2>
-  </header>
-{% endblock %}
-
 {% block article %}
   <p>
     {% trans guide=url('foundation.feed-icon-guidelines.index') %}

--- a/bedrock/foundation/templates/foundation/feed-icon-guidelines/index.html
+++ b/bedrock/foundation/templates/foundation/feed-icon-guidelines/index.html
@@ -6,10 +6,6 @@
 
 {% block page_title %}{{ _('Feed Icon Guidelines') }}{% endblock %}
 
-{% block article_title %}
-  <h1 class="page-title">{{ _('Feed Icon Guidelines') }}</h1>
-{% endblock %}
-
 {% block article %}
   <p>
     {% trans

--- a/bedrock/foundation/templates/foundation/issues.html
+++ b/bedrock/foundation/templates/foundation/issues.html
@@ -4,14 +4,9 @@
 
 {% extends "foundation/base-resp.html" %}
 
-{% block page_title %}{{ _('Mozilla’s Key Internet Issues') }}{% endblock %}
+{% block page_title %}{{ _('Mozilla’s Key Internet Issues — Shaping the Agenda') }}{% endblock %}
 
 {% set body_id = "issues" %}
-
-{% block article_header %}
-  <h2>{{ _('Mozilla’s Key Internet Issues') }}</h2>
-  <p>{{ _('Shaping the Agenda') }}</p>
-{% endblock %}
 
 {% block article %}
   <p>

--- a/bedrock/foundation/templates/foundation/leadership-network.html
+++ b/bedrock/foundation/templates/foundation/leadership-network.html
@@ -4,14 +4,9 @@
 
 {% extends "foundation/base-resp.html" %}
 
-{% block page_title %}{{ _('The Mozilla Leadership Network') }}{% endblock %}
+{% block page_title %}{{ _('The Mozilla Leadership Network — Connecting Leaders') }}{% endblock %}
 
 {% set body_id = "leadership-network" %}
-
-{% block article_header %}
-  <h2>{{ _('The Mozilla Leadership Network') }}</h2>
-  <p>{{ _('Connecting Leaders') }}</p>
-{% endblock %}
 
 {% block article %}
 

--- a/bedrock/foundation/templates/foundation/licensing.html
+++ b/bedrock/foundation/templates/foundation/licensing.html
@@ -8,10 +8,6 @@
 
 {% set body_id = "licensing" %}
 
-{% block article_title %}
-  <h1 class="page-title">{{ _('Mozilla Licensing Policies') }}</h1>
-{% endblock %}
-
 {% block article %}
   <h2>{{ _('Source Code') }}</h2>
   <p>

--- a/bedrock/foundation/templates/foundation/licensing/binary-components/index.html
+++ b/bedrock/foundation/templates/foundation/licensing/binary-components/index.html
@@ -4,14 +4,7 @@
 
 {% extends "foundation/base-resp.html" %}
 
-{% block page_title %}{{ _('Mozilla Licensing Policies - Binary Components') }}{% endblock %}
-
-{% block article_title %}
-  <header class="page-title">
-    <h1>{{ _('Mozilla Licensing Policies') }}</h1>
-    <h2>{{ _('Binary Components') }}</h2>
-  </header>
-{% endblock %}
+{% block page_title %}{{ _('Mozilla Licensing Policies — Binary Components') }}{% endblock %}
 
 {% block article %}
   <p>{% trans %}Mozilla is and remains irrevocably committed to making

--- a/bedrock/foundation/templates/foundation/licensing/binary-components/rationale.html
+++ b/bedrock/foundation/templates/foundation/licensing/binary-components/rationale.html
@@ -4,14 +4,7 @@
 
 {% extends "foundation/base-resp.html" %}
 
-{% block page_title %}{{ _('Mozilla Licensing Policies - Binary Components') }}{% endblock %}
-
-{% block article_title %}
-  <header class="page-title">
-    <h1>{{ _('Mozilla Licensing Policies') }}</h1>
-    <h2>{{ _('Binary Components') }}</h2>
-  </header>
-{% endblock %}
+{% block page_title %}{{ _('Mozilla Licensing Policies — Binary Components') }}{% endblock %}
 
 {% block article %}
   <h2>Direct 3D DLL</h2>

--- a/bedrock/foundation/templates/foundation/licensing/website-content.html
+++ b/bedrock/foundation/templates/foundation/licensing/website-content.html
@@ -6,10 +6,6 @@
 
 {% block page_title %}{{ _('Mozilla.org Site Licensing Policies') }}{% endblock %}
 
-{% block article_title %}
-  <h1 class="page-title">{{ _('Mozilla.org Site Licensing Policies') }}</h1>
-{% endblock %}
-
 {% block article %}
   <p>
   {% trans %}

--- a/bedrock/foundation/templates/foundation/licensing/website-markup.html
+++ b/bedrock/foundation/templates/foundation/licensing/website-markup.html
@@ -6,10 +6,6 @@
 
 {% block page_title %}{{ _('Website Markup Usage Policy') }}{% endblock %}
 
-{% block article_title %}
-  <h1 class="page-title">{{ _('Website Markup Usage Policy') }}</h1>
-{% endblock %}
-
 {% block article %}
   <p>{% trans %}
   You may use the HTML and CSS files on www.mozilla.org or other mozilla.org 

--- a/bedrock/foundation/templates/foundation/moco.html
+++ b/bedrock/foundation/templates/foundation/moco.html
@@ -6,10 +6,6 @@
 
 {% block page_title %}{{ _('About the Mozilla Corporation') }}{% endblock %}
 
-{% block article_title %}
-  <h1 class="page-title">{{ _('About the Mozilla Corporation') }}</h1>
-{% endblock %}
-
 {% block article %}
   <p>
     {% trans

--- a/bedrock/foundation/templates/foundation/mocosc.html
+++ b/bedrock/foundation/templates/foundation/mocosc.html
@@ -6,10 +6,6 @@
 
 {% block page_title %}{{ _('About the Mozilla Corporation Steering Committee') }}{% endblock %}
 
-{% block article_title %}
-  <h1 class="page-title">{{ _('About the Mozilla Corporation Steering Committee') }}</h1>
-{% endblock %}
-
 {% block article %}
   <p>{% trans %}
     The Mozilla Corporation's senior executive team is known as the

--- a/bedrock/foundation/templates/foundation/openwebfund/more.html
+++ b/bedrock/foundation/templates/foundation/openwebfund/more.html
@@ -6,10 +6,6 @@
 
 {% block page_title %}{{ _('More About the Open Web Fund') }}{% endblock %}
 
-{% block article_title %}
-  <h1 class="page-title">{{ _('More About the Open Web Fund') }}</h1>
-{% endblock %}
-
 {% block article %}
   <p>{% trans %}The Mozilla community's greatest achievement is the creation of the open source Firefox web browser. Building on our experience with Firefox, we
   believe that even more people can – and must – get involved in the cause of keeping the internet open. Artists, lawyers, teachers, filmmakers, anyone who

--- a/bedrock/foundation/templates/foundation/openwebfund/thanks.html
+++ b/bedrock/foundation/templates/foundation/openwebfund/thanks.html
@@ -6,11 +6,7 @@
 
 {% block extra_meta %}<meta name="robots" content="noindex">{% endblock %}
 
-{% block page_title %}{{ _('Thank you') }}{% endblock %}
-
-{% block article_title %}
-  <h1 class="page-title">{{ _('Thank you for supporting the Mozilla Open Web Fund') }}</h1>
-{% endblock %}
+{% block page_title %}{{ _('Thank you for supporting the Mozilla Open Web Fund') }}{% endblock %}
 
 {% block article %}
   <p>

--- a/bedrock/foundation/templates/foundation/trademarks/community-edition-permitted-changes.html
+++ b/bedrock/foundation/templates/foundation/trademarks/community-edition-permitted-changes.html
@@ -6,10 +6,6 @@
 
 {% block page_title %}{{ _('Permitted Changes to Legacy Community Edition Builds') }}{% endblock %}
 
-{% block article_title %}
-  <h1 class="page-title">{{ _('Permitted Changes to Legacy Community Edition Builds') }}</h1>
-{% endblock %}
-
 {% block article %}
   <p>{% trans policy=url('foundation.trademarks.community-edition-policy') %}
       The following are the changes that are permitted within the

--- a/bedrock/foundation/templates/foundation/trademarks/community-edition-policy.html
+++ b/bedrock/foundation/templates/foundation/trademarks/community-edition-policy.html
@@ -6,10 +6,6 @@
 
 {% block page_title %}{{ _('Termination of the Community Edition Builds') }}{% endblock %}
 
-{% block article_title %}
-  <h1 class="page-title">{{ _('Termination of the Community Edition Builds') }}</h1>
-{% endblock %}
-
 {% block article %}
   <p><em><time datetime="2009-04-07">{{ _('April 7, 2009') }}</time></em></p>
 

--- a/bedrock/foundation/templates/foundation/trademarks/distribution-policy.html
+++ b/bedrock/foundation/templates/foundation/trademarks/distribution-policy.html
@@ -4,11 +4,7 @@
 
 {% extends "foundation/base-resp.html" %}
 
-{% block page_title %}{{ _('Distribution Trademark Policy') }}{% endblock %}
-
-{% block article_title %}
-  <h1 class="page-title">{{ _('Mozilla Trademark Policy for Distribution Partners') }}</h1>
-{% endblock %}
+{% block page_title %}{{ _('Mozilla Trademark Policy for Distribution Partners') }}{% endblock %}
 
 {% block article %}
   <p><em>{{ _('Version 0.9 (DRAFT)') }}</em></p>

--- a/bedrock/foundation/templates/foundation/trademarks/faq.html
+++ b/bedrock/foundation/templates/foundation/trademarks/faq.html
@@ -6,10 +6,6 @@
 
 {% block page_title %}{{ _('Mozilla Trademark Policy FAQ') }}{% endblock %}
 
-{% block article_title %}
-  <h1 class="page-title">{{ _('Mozilla Trademark Policy FAQ') }}</h1>
-{% endblock %}
-
 {% block article %}
   <dl class="faq">
     <dt>{% trans %}What's the purpose of this document?{% endtrans %}</dt>

--- a/bedrock/foundation/templates/foundation/trademarks/index.html
+++ b/bedrock/foundation/templates/foundation/trademarks/index.html
@@ -6,10 +6,6 @@
 
 {% block page_title %}{{ _('Mozilla Foundation Trademark Policy') }}{% endblock %}
 
-{% block article_title %}
-  <h1 class="page-title">{{ _('Mozilla Foundation Trademark Policy') }}</h1>
-{% endblock %}
-
 {% block article %}
   <p>{% trans %}We have several trademark policy documents. Please read the FAQ,
   and any documents relevant to your situation, before contacting the

--- a/bedrock/foundation/templates/foundation/trademarks/l10n-website-policy.html
+++ b/bedrock/foundation/templates/foundation/trademarks/l10n-website-policy.html
@@ -4,11 +4,7 @@
 
 {% extends "foundation/base-resp.html" %}
 
-{% block page_title %}{{ _('Localization Team Web Sites') }}{% endblock %}
-
-{% block article_title %}
-  <h1 class="page-title">{{ _('Mozilla Trademark Policy for Web Sites Created by Localization Teams') }}</h1>
-{% endblock %}
+{% block page_title %}{{ _('Mozilla Trademark Policy for Web Sites Created by Localization Teams') }}{% endblock %}
 
 {% block article %}
   <p class="warning">{% trans %}This document is a working draft, and could still be changed at any time.{% endtrans %}</p>

--- a/bedrock/foundation/templates/foundation/trademarks/list.html
+++ b/bedrock/foundation/templates/foundation/trademarks/list.html
@@ -8,10 +8,6 @@
 
 {% block body_class %}trademarks sand{% endblock %}
 
-{% block article_title %}
-  <h1 class="page-title">{{ _('List of Mozilla Trademarks') }}</h1>
-{% endblock %}
-
 {% block article %}
   <table id="logos">
     <tr>

--- a/bedrock/foundation/templates/foundation/trademarks/policy.html
+++ b/bedrock/foundation/templates/foundation/trademarks/policy.html
@@ -6,10 +6,6 @@
 
 {% block page_title %}{{ _('Mozilla Trademark Policy') }}{% endblock %}
 
-{% block article_title %}
-  <h1 class="page-title">{{ _('Mozilla Trademark Policy') }}</h1>
-{% endblock %}
-
 {% block article %}
   <p><em>{{ _('Updated: October 30, 2009') }}</em></p>
 

--- a/bedrock/foundation/templates/foundation/trademarks/poweredby/faq.html
+++ b/bedrock/foundation/templates/foundation/trademarks/poweredby/faq.html
@@ -6,10 +6,6 @@
 
 {% block page_title %}{{ _('Powered by Mozilla FAQ') }}{% endblock %}
 
-{% block article_title %}
-  <h1 class="page-title">{{ _('Powered by Mozilla FAQ') }}</h1>
-{% endblock %}
-
 {% block article %}
   <p>{% trans %}This page contains frequently asked questions about the Powered by Mozilla program.{% endtrans %}</p>
 


### PR DESCRIPTION
Simply use the page title for `<h1>` on each Foundation page.
