### PR TITLE
[fix bug 1304538] Add sha-1 download buttons for IE 6-8

### DIFF
--- a/bedrock/base/templates/product-all-macros.html
+++ b/bedrock/base/templates/product-all-macros.html
@@ -52,7 +52,7 @@
           <tr>
             <th colspan="2" scope="col">{{ _('Language') }}</th>
             {% for p_name, p_label in platforms %}
-              <th scope="col">{{ p_label|replace('\n', '<br>'|safe) }}</th>
+              <th scope="col" class="{{ p_name }}">{{ p_label|replace('\n', '<br>'|safe) }}</th>
             {% endfor %}
           </tr>
         </thead>

--- a/bedrock/firefox/firefox_details.py
+++ b/bedrock/firefox/firefox_details.py
@@ -4,6 +4,7 @@ from operator import itemgetter
 from urllib import urlencode
 
 from django.conf import settings
+from bedrock.base.waffle import switch
 from product_details import ProductDetails
 from lib.l10n_utils.dotlang import _lazy as _
 
@@ -11,6 +12,11 @@ from lib.l10n_utils.dotlang import _lazy as _
 # TODO: port this to django-mozilla-product-details
 class _ProductDetails(ProductDetails):
     bouncer_url = 'https://download.mozilla.org/'
+
+    # Note allizom.org is the production endpoint for SHA-1.
+    # It uses this because that's the only SHA-1 certificate
+    # we have that's usable. (SHA-1 certs can no longer be issued).
+    sha1_bouncer_url = 'https://download-sha1.allizom.org/'
 
     def _matches_query(self, info, query):
         words = re.split(r',|,?\s+', query.strip().lower())
@@ -25,6 +31,7 @@ class FirefoxDesktop(_ProductDetails):
 
     # Human-readable platform names
     platform_labels = OrderedDict([
+        ('winsha1', 'Windows (XP/Vista)'),
         ('win', 'Windows'),
         ('win64', 'Windows 64-bit'),
         ('osx', 'OS X'),
@@ -62,6 +69,9 @@ class FirefoxDesktop(_ProductDetails):
 
     def __init__(self, **kwargs):
         super(FirefoxDesktop, self).__init__(**kwargs)
+
+    def get_bouncer_url(self, platform):
+        return self.sha1_bouncer_url if not switch('disable-sha1-downloads') and platform == 'winsha1' else self.bouncer_url
 
     def platforms(self, channel='release'):
         platforms = self.platform_labels.copy()
@@ -121,9 +131,10 @@ class FirefoxDesktop(_ProductDetails):
         for builds in all_builds:
             if locale in builds and version in builds[locale]:
                 _builds = builds[locale][version]
-                # Append 64-bit builds
+                # Append 64-bit builds and Sha-1
                 if 'Windows' in _builds:
                     _builds['Windows 64-bit'] = _builds['Windows']
+                    _builds['Windows (XP/Vista)'] = _builds['Windows']
                 if 'Linux' in _builds:
                     _builds['Linux 64-bit'] = _builds['Linux']
                 return version, _builds
@@ -207,23 +218,24 @@ class FirefoxDesktop(_ProductDetails):
         """
         _version = version
         _locale = 'ja-JP-mac' if platform == 'osx' and locale == 'ja' else locale
+        _platform = 'win' if platform == 'winsha1' else platform
 
         # Aurora has a special download link format
         if channel == 'alpha':
             # Download links are different for localized versions
             if locale == 'en-US':
                 # Use the stub installer for 32-bit Windows
-                if platform == 'win':
+                if _platform == 'win':
                     product = 'firefox-aurora-stub'
                 else:
                     product = 'firefox-aurora-latest-ssl'
             else:
                 product = 'firefox-aurora-latest-l10n'
 
-            return '?'.join([self.bouncer_url,
+            return '?'.join([self.get_bouncer_url(platform),
                              urlencode([
                                  ('product', product),
-                                 ('os', platform),
+                                 ('os', _platform),
                                  # Order matters, lang must be last for bouncer.
                                  ('lang', _locale),
                              ])])
@@ -231,14 +243,14 @@ class FirefoxDesktop(_ProductDetails):
         # Use direct archive links for Nightly
         if channel == 'nightly':
             _dir = self.nightly_url_base + ('' if locale == 'en-US' else '-l10n')
-            _suffix = self.platform_file_suffixes.get(platform)
+            _suffix = self.platform_file_suffixes.get(_platform)
 
             return '{dir}/firefox-{version}.{locale}.{suffix}'.format(
                 dir=_dir, version=_version, locale=_locale, suffix=_suffix)
 
         # stub installer exceptions
         # TODO: NUKE FROM ORBIT!
-        stub_langs = settings.STUB_INSTALLER_LOCALES.get(platform, [])
+        stub_langs = settings.STUB_INSTALLER_LOCALES.get(_platform, [])
         if (stub_langs and (stub_langs == settings.STUB_INSTALLER_ALL or
                             _locale.lower() in stub_langs) and
                            not force_full_installer and
@@ -261,10 +273,10 @@ class FirefoxDesktop(_ProductDetails):
         # (bypassing the transition page)
         if force_direct:
             # build a direct download link
-            return '?'.join([self.bouncer_url,
+            return '?'.join([self.get_bouncer_url(platform),
                              urlencode([
                                  ('product', 'firefox-%s' % _version),
-                                 ('os', platform),
+                                 ('os', _platform),
                                  # Order matters, lang must be last for bouncer.
                                  ('lang', _locale),
                              ])])

--- a/bedrock/firefox/templates/firefox/all.html
+++ b/bedrock/firefox/templates/firefox/all.html
@@ -72,6 +72,12 @@
   {% stylesheet 'firefox_all' %}
 {% endblock %}
 
+{% block extrahead %}
+<!--[if lte IE 8]>
+  {% stylesheet 'firefox_all_old_ie' %}
+<![endif]-->
+{% endblock %}
+
 {% block site_header_logo %}
   {% if channel == 'alpha' %}
     <h2><a href="{{ url('firefox.developer') }}">{{ high_res_img('firefox/developer/title.png', {'alt': _('Firefox Developer Edition'), 'width': '220', 'height': '84'}) }}</a></h2>

--- a/bedrock/firefox/tests/test_base.py
+++ b/bedrock/firefox/tests/test_base.py
@@ -135,7 +135,7 @@ class TestFirefoxAll(TestCase):
         num_builds = len(firefox_desktop.get_filtered_full_builds('release'))
         num_builds += len(firefox_desktop.get_filtered_test_builds('release'))
         eq_(len(doc('tr[data-search]')), num_builds)
-        eq_(len(doc('tr#en-US a')), 5)
+        eq_(len(doc('tr#en-US a')), 6)
 
     def test_no_locale_details(self):
         """

--- a/bedrock/firefox/tests/test_helpers.py
+++ b/bedrock/firefox/tests/test_helpers.py
@@ -52,6 +52,7 @@ class TestDownloadButtons(TestCase):
         eq_(pq(links[5]).attr('href'), settings.APPLE_APPSTORE_FIREFOX_LINK
                                             .replace('/{country}/', '/'))
 
+    @patch('bedrock.firefox.firefox_details.switch', Mock(return_value=False))
     def test_button_force_direct(self):
         """
         If the force_direct parameter is True, all download links must be
@@ -63,15 +64,23 @@ class TestDownloadButtons(TestCase):
         doc = pq(render("{{ download_firefox(force_direct=true) }}",
                         {'request': get_request}))
 
-        # Check that the first 4 links are direct.
+        # Check that the first 6 links are direct.
         links = doc('.download-list a')
-        for link in links[:4]:
+
+        # The first link should be sha-1 bouncer.
+        first_link = pq(links[0])
+        ok_(first_link.attr('href')
+            .startswith('https://download-sha1.allizom.org'))
+        ok_(first_link.attr('data-direct-link') is None)
+
+        for link in links[1:5]:
             link = pq(link)
             ok_(link.attr('href')
                 .startswith('https://download.mozilla.org'))
             # direct links should not have the data attr.
             ok_(link.attr('data-direct-link') is None)
 
+    @patch('bedrock.firefox.firefox_details.switch', Mock(return_value=False))
     def test_button_has_data_attr_if_not_direct(self):
         """
         If the button points to the thank you page, it should have a
@@ -83,13 +92,20 @@ class TestDownloadButtons(TestCase):
         doc = pq(render("{{ download_firefox() }}",
                         {'request': get_request}))
 
-        # The first 5 links should be for desktop.
+        # The first 6 links should be for desktop.
         links = doc('.download-list a')
-        for link in links[:5]:
+
+        # The first link should be sha-1 bouncer.
+        first_link = pq(links[0])
+        ok_(first_link.attr('data-direct-link')
+            .startswith('https://download-sha1.allizom.org'))
+
+        for link in links[1:5]:
             ok_(pq(link).attr('data-direct-link')
                 .startswith('https://download.mozilla.org'))
-        # The fifth link is mobile and should not have the attr
-        ok_(pq(links[5]).attr('data-direct-link') is None)
+
+        # The seventh link is mobile and should not have the attr
+        ok_(pq(links[6]).attr('data-direct-link') is None)
 
     @override_settings(AURORA_STUB_INSTALLER=True)
     def test_stub_aurora_installer_enabled_locales(self):
@@ -138,12 +154,13 @@ class TestDownloadButtons(TestCase):
                         {'request': get_request}))
 
         list = doc('.download-list li')
-        eq_(list.length, 5)
-        eq_(pq(list[0]).attr('class'), 'os_win')
-        eq_(pq(list[1]).attr('class'), 'os_win64')
-        eq_(pq(list[2]).attr('class'), 'os_osx')
-        eq_(pq(list[3]).attr('class'), 'os_linux')
-        eq_(pq(list[4]).attr('class'), 'os_linux64')
+        eq_(list.length, 6)
+        eq_(pq(list[0]).attr('class'), 'os_winsha1')
+        eq_(pq(list[1]).attr('class'), 'os_win')
+        eq_(pq(list[2]).attr('class'), 'os_win64')
+        eq_(pq(list[3]).attr('class'), 'os_osx')
+        eq_(pq(list[4]).attr('class'), 'os_linux')
+        eq_(pq(list[5]).attr('class'), 'os_linux64')
 
     def test_beta_desktop(self):
         """The Beta channel should not have Windows 64 build yet"""
@@ -154,12 +171,13 @@ class TestDownloadButtons(TestCase):
                         {'request': get_request}))
 
         list = doc('.download-list li')
-        eq_(list.length, 5)
-        eq_(pq(list[0]).attr('class'), 'os_win')
-        eq_(pq(list[1]).attr('class'), 'os_win64')
-        eq_(pq(list[2]).attr('class'), 'os_osx')
-        eq_(pq(list[3]).attr('class'), 'os_linux')
-        eq_(pq(list[4]).attr('class'), 'os_linux64')
+        eq_(list.length, 6)
+        eq_(pq(list[0]).attr('class'), 'os_winsha1')
+        eq_(pq(list[1]).attr('class'), 'os_win')
+        eq_(pq(list[2]).attr('class'), 'os_win64')
+        eq_(pq(list[3]).attr('class'), 'os_osx')
+        eq_(pq(list[4]).attr('class'), 'os_linux')
+        eq_(pq(list[5]).attr('class'), 'os_linux64')
 
     def test_firefox_desktop(self):
         """The Release channel should not have Windows 64 build yet"""
@@ -170,12 +188,13 @@ class TestDownloadButtons(TestCase):
                         {'request': get_request}))
 
         list = doc('.download-list li')
-        eq_(list.length, 5)
-        eq_(pq(list[0]).attr('class'), 'os_win')
-        eq_(pq(list[1]).attr('class'), 'os_win64')
-        eq_(pq(list[2]).attr('class'), 'os_osx')
-        eq_(pq(list[3]).attr('class'), 'os_linux')
-        eq_(pq(list[4]).attr('class'), 'os_linux64')
+        eq_(list.length, 6)
+        eq_(pq(list[0]).attr('class'), 'os_winsha1')
+        eq_(pq(list[1]).attr('class'), 'os_win')
+        eq_(pq(list[2]).attr('class'), 'os_win64')
+        eq_(pq(list[3]).attr('class'), 'os_osx')
+        eq_(pq(list[4]).attr('class'), 'os_linux')
+        eq_(pq(list[5]).attr('class'), 'os_linux64')
 
     @patch.object(firefox_android._storage, 'data',
                   Mock(return_value=dict(alpha_version='48.0a2')))

--- a/bedrock/settings/static_media.py
+++ b/bedrock/settings/static_media.py
@@ -206,6 +206,12 @@ PIPELINE_CSS = {
         ),
         'output_filename': 'css/firefox_all-bundle.css',
     },
+    'firefox_all_old_ie': {
+        'source_filenames': (
+            'css/firefox/all-oldIE.less',
+        ),
+        'output_filename': 'css/firefox_all_old_ie-bundle.css',
+    },
     'firefox_android': {
         'source_filenames': (
             'css/firefox/family-nav.less',

--- a/bedrock/thunderbird/templates/thunderbird/includes/download-button.html
+++ b/bedrock/thunderbird/templates/thunderbird/includes/download-button.html
@@ -53,7 +53,7 @@
       </li>
     {% endfor %}
   </ul>
-  <small class="download-other download-other-desktop os_linux os_linux64 os_osx os_win">
+  <small class="download-other download-other-desktop os_linux os_linux64 os_osx os_win os_winsha1">
     <a href="{{ thunderbird_url('all', channel) }}">{{ _('Systems &amp; Languages') }}</a> |
     {% if channel != 'alpha' %}{# Earlybird release notes are not available yet #}
     <a href="{{ thunderbird_url('notes', channel) }}">{{ _('What’s New') }}</a> |

--- a/bedrock/thunderbird/tests/test_base.py
+++ b/bedrock/thunderbird/tests/test_base.py
@@ -55,4 +55,4 @@ class TestThunderbirdAll(TestCase):
 
         num_builds = len(thunderbird_desktop.get_filtered_full_builds('release'))
         eq_(len(doc('tr[data-search]')), num_builds)
-        eq_(len(doc('tr#en-US a')), 4)
+        eq_(len(doc('tr#en-US a')), 5)

--- a/bedrock/thunderbird/tests/test_helpers.py
+++ b/bedrock/thunderbird/tests/test_helpers.py
@@ -18,7 +18,7 @@ def render(s, context=None):
 class TestDownloadButtons(TestCase):
 
     def test_thunderbird(self):
-        """Should have 4 links on the Thunderbird download button"""
+        """Should have 5 links on the Thunderbird download button"""
         with self.activate('en-US'):
             rf = RequestFactory()
             get_request = rf.get('/fake')
@@ -27,14 +27,15 @@ class TestDownloadButtons(TestCase):
                             {'request': get_request}))
 
         list = doc('.download-list li')
-        eq_(list.length, 4)
-        eq_(pq(list[0]).attr('class'), 'os_win')
-        eq_(pq(list[1]).attr('class'), 'os_osx')
-        eq_(pq(list[2]).attr('class'), 'os_linux')
-        eq_(pq(list[3]).attr('class'), 'os_linux64')
+        eq_(list.length, 5)
+        eq_(pq(list[0]).attr('class'), 'os_winsha1')
+        eq_(pq(list[1]).attr('class'), 'os_win')
+        eq_(pq(list[2]).attr('class'), 'os_osx')
+        eq_(pq(list[3]).attr('class'), 'os_linux')
+        eq_(pq(list[4]).attr('class'), 'os_linux64')
 
     def test_beta(self):
-        """Should have 4 links on the Thunderbird Beta download button"""
+        """Should have 5 links on the Thunderbird Beta download button"""
         with self.activate('en-US'):
             rf = RequestFactory()
             get_request = rf.get('/fake')
@@ -43,14 +44,15 @@ class TestDownloadButtons(TestCase):
                             {'request': get_request}))
 
         list = doc('.download-list li')
-        eq_(list.length, 4)
-        eq_(pq(list[0]).attr('class'), 'os_win')
-        eq_(pq(list[1]).attr('class'), 'os_osx')
-        eq_(pq(list[2]).attr('class'), 'os_linux')
-        eq_(pq(list[3]).attr('class'), 'os_linux64')
+        eq_(list.length, 5)
+        eq_(pq(list[0]).attr('class'), 'os_winsha1')
+        eq_(pq(list[1]).attr('class'), 'os_win')
+        eq_(pq(list[2]).attr('class'), 'os_osx')
+        eq_(pq(list[3]).attr('class'), 'os_linux')
+        eq_(pq(list[4]).attr('class'), 'os_linux64')
 
     def test_earlybird(self):
-        """Should have 4 links on the Earlybird download button"""
+        """Should have 5 links on the Earlybird download button"""
         with self.activate('en-US'):
             rf = RequestFactory()
             get_request = rf.get('/fake')
@@ -59,11 +61,12 @@ class TestDownloadButtons(TestCase):
                             {'request': get_request}))
 
         list = doc('.download-list li')
-        eq_(list.length, 4)
-        eq_(pq(list[0]).attr('class'), 'os_win')
-        eq_(pq(list[1]).attr('class'), 'os_osx')
-        eq_(pq(list[2]).attr('class'), 'os_linux')
-        eq_(pq(list[3]).attr('class'), 'os_linux64')
+        eq_(list.length, 5)
+        eq_(pq(list[0]).attr('class'), 'os_winsha1')
+        eq_(pq(list[1]).attr('class'), 'os_win')
+        eq_(pq(list[2]).attr('class'), 'os_osx')
+        eq_(pq(list[3]).attr('class'), 'os_linux')
+        eq_(pq(list[4]).attr('class'), 'os_linux64')
 
 
 class TestThunderbirdURL(TestCase):

--- a/media/css/firefox/all-oldIE.less
+++ b/media/css/firefox/all-oldIE.less
@@ -1,0 +1,26 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+@import "../sandstone/lib.less";
+
+/* The sha-1 download column is hidden by default */
+.js #builds .build-table {
+    thead tr .winsha1,
+    tbody tr .winsha1 {
+        display: none;
+    }
+}
+
+/* IE on Windows XP, Server 2003, Vista need sha-1 button */
+.windows.sha-1 #builds .build-table {
+    thead tr .win,
+    tbody tr .win {
+        display: none;
+    }
+
+    thead tr .winsha1,
+    tbody tr .winsha1 {
+        display: block;
+    }
+}

--- a/media/css/firefox/all.less
+++ b/media/css/firefox/all.less
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 @import "../sandstone/lib.less";
 
 body.nightly {
@@ -405,5 +409,26 @@ body.nightly {
         top: auto;
         right: auto;
         margin: 0 10px;
+    }
+}
+
+/* The sha-1 download column is hidden by default */
+.js #builds .build-table {
+    thead tr .winsha1,
+    tbody tr .winsha1 {
+        display: none;
+    }
+}
+
+/* IE on Windows XP, Server 2003, Vista need sha-1 button */
+.windows.sha-1 #builds .build-table {
+    thead tr .win,
+    tbody tr .win {
+        display: none;
+    }
+
+    thead tr .winsha1,
+    tbody tr .winsha1 {
+        display: block;
     }
 }

--- a/media/css/firefox/new/all-test-variations.less
+++ b/media/css/firefox/new/all-test-variations.less
@@ -90,6 +90,21 @@
             background-size: 20px 16px;
             padding-left: 24px;
         }
+
+        &.winsha1 {
+            display: none;
+        }
+    }
+}
+
+.windows.sha-1 {
+    #fx-modal-direct-downloads {
+        .win32 {
+            display: none;
+        }
+        .winsha1 {
+            display: inline-block;
+        }
     }
 }
 

--- a/media/css/pebbles/components/_buttons-download.scss
+++ b/media/css/pebbles/components/_buttons-download.scss
@@ -106,6 +106,7 @@ ul.download-list {
 }
 
 /* OS detection */
+.download-button .os_winsha1,
 .download-button .os_win64,
 .download-button .os_linux,
 .download-button .os_linux64,
@@ -201,6 +202,15 @@ ul.download-list {
 .android.gingerbread .download-button .download-other.os_android .api-15,
 .android.x86 .download-button .download-other.os_android .armv7up {
     display: inline !important;
+}
+
+/* IE on Windows XP, Server 2003, Vista need sha-1 button */
+.windows.sha-1 .download-button .os_win {
+    display: none !important;
+}
+
+.windows.sha-1 .download-button .os_winsha1 {
+    display: block !important;
 }
 
 /* l10n download button tweaks */

--- a/media/css/sandstone/buttons.less
+++ b/media/css/sandstone/buttons.less
@@ -308,6 +308,7 @@ ul.download-list {
 }
 
 /* OS detection */
+.download-button .os_winsha1,
 .download-button .os_win64,
 .download-button .os_linux,
 .download-button .os_linux64,
@@ -403,6 +404,15 @@ ul.download-list {
 .android.gingerbread .download-button .download-other.os_android .api-15,
 .android.x86 .download-button .download-other.os_android .armv7up {
     display: inline !important;
+}
+
+/* IE on Windows XP, Server 2003, Vista need sha-1 button */
+.windows.sha-1 .download-button .os_win {
+    display: none !important;
+}
+
+.windows.sha-1 .download-button .os_winsha1 {
+    display: block !important;
 }
 
 /* l10n download button tweaks */

--- a/media/js/base/site.js
+++ b/media/js/base/site.js
@@ -134,6 +134,18 @@
             return 32;
         },
 
+        needsSha1: function(ua) {
+            ua = ua || navigator.userAgent;
+            // Check for Windows XP, Server 2003, Vista.
+            // Matches sha-1 regex in Bouncer
+            // https://github.com/mozilla-services/go-bouncer/
+            var os = /Windows (?:NT 5.1|XP|NT 5.2|NT 6.0)/;
+            // Firefox uses its own trust store, so can continue to use sha-256.
+            var ff = /\sFirefox/;
+
+            return os.test(ua) && !ff.test(ua);
+        },
+
         platform: 'other',
         platformVersion: undefined,
         archType: 'x64',
@@ -151,6 +163,9 @@
             // Add class to support downloading Firefox for Windows 64-bit on Windows 7 and later
             if (version && parseFloat(version) >= 6.1) {
                 h.className += ' win7up';
+            } else if (window.site.needsSha1()) {
+                // Add class to support sha-1 downloads for IE on Windows XP, Server 2003, Vista.
+                h.className += ' sha-1';
             }
         } else {
             h.className = h.className.replace('windows', platform);

--- a/media/js/firefox/new/all-test-variations.js
+++ b/media/js/firefox/new/all-test-variations.js
@@ -18,19 +18,25 @@
         case 'Windows':
             newOsName = 'Windows 32-bit';
             $li.attr('data-sort', 1);
+            $li.addClass('win32');
+            break;
+        case 'Windows (XP/Vista)':
+            newOsName = 'Windows 32-bit';
+            $li.attr('data-sort', 2);
+            $li.addClass('winsha1');
             break;
         case 'Linux':
             newOsName = 'Linux 32-bit';
-            $li.attr('data-sort', 2);
-            break;
-        case 'Windows 64-bit':
             $li.attr('data-sort', 3);
             break;
-        case 'Linux 64-bit':
+        case 'Windows 64-bit':
             $li.attr('data-sort', 4);
             break;
-        case 'OS X':
+        case 'Linux 64-bit':
             $li.attr('data-sort', 5);
+            break;
+        case 'OS X':
+            $li.attr('data-sort', 6);
             break;
         }
 

--- a/tests/unit/spec/base/site.js
+++ b/tests/unit/spec/base/site.js
@@ -134,4 +134,47 @@ describe('site.js', function () {
             expect(window.site.getArchSize('Mozilla/5.0 (X11; Ubuntu; Linux armv7l; rv:32.0) Gecko/20100101 Firefox/32.0', 'Linux armv7l')).toBe(32);
         });
     });
+
+    describe('needsSha1', function () {
+
+        it('should return true for IE6 on Windows XP', function() {
+            expect(window.site.needsSha1('Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1)')).toBeTruthy();
+        });
+
+        it('should return true for IE7 on Windows XP, Server 2003, Vista', function () {
+            expect(window.site.needsSha1('Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 5.1)')).toBeTruthy();
+            expect(window.site.needsSha1('Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 5.2)')).toBeTruthy();
+            expect(window.site.needsSha1('Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.0)')).toBeTruthy();
+        });
+
+        it('should return true for IE8 on Windows XP, Server 2003, Vista', function () {
+            expect(window.site.needsSha1('Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 5.1)')).toBeTruthy();
+            expect(window.site.needsSha1('Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 5.2)')).toBeTruthy();
+            expect(window.site.needsSha1('Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 6.0)')).toBeTruthy();
+        });
+
+        it('should return false for IE8 on Windows 7', function() {
+            expect(window.site.needsSha1('Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 6.1)')).toBeFalsy();
+        });
+
+        it('should return true for IE9 on Windows Vista', function() {
+            expect(window.site.needsSha1('Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.0)')).toBeTruthy();
+        });
+
+        it('should return false for IE9 on Windows 7', function() {
+            expect(window.site.needsSha1('Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1)')).toBeFalsy();
+        });
+
+        it('should return true for Chrome on Windows XP, Server 2003, Vista', function() {
+            expect(window.site.needsSha1('Mozilla/5.0 (Windows NT 5.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2224.3 Safari/537.36')).toBeTruthy();
+            expect(window.site.needsSha1('Mozilla/5.0 (Windows NT 5.2) AppleWebKit/535.1 (KHTML, like Gecko) Chrome/14.0.794.0 Safari/535.1')).toBeTruthy();
+            expect(window.site.needsSha1('Mozilla/5.0 (Windows NT 6.0) AppleWebKit/534.30 (KHTML, like Gecko) Chrome/12.0.742.100 Safari/534.30')).toBeTruthy();
+        });
+
+        it('should return false for Firefox on Windows XP, Server 2003, Vista', function() {
+            expect(window.site.needsSha1('Mozilla/5.0 (Windows NT 5.1; rv:31.0) Gecko/20100101 Firefox/31.0')).toBeFalsy();
+            expect(window.site.needsSha1('Mozilla/5.0 (Windows NT 5.2; WOW64; rv:31.0) Gecko/20100101 Firefox/31.0')).toBeFalsy();
+            expect(window.site.needsSha1('Mozilla/5.0 (Windows NT 6.0; WOW64; rv:24.0) Gecko/20100101 Firefox/24.0')).toBeFalsy();
+        });
+    });
 });


### PR DESCRIPTION
## Description
- Still WIP but opening this early to make sure I'm on the right path in terms of implementation.

## Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1304538

## Testing
Demo:
- https://www-demo1.allizom.org/en-US/firefox/new/
- https://www-demo1.allizom.org/en-US/firefox/all/
- https://www-demo1.allizom.org/en-US/firefox/channel/desktop/

## Checklist
- [ ] Requires l10n changes.
- [ ] Related functional & integration tests passing.