### PR TITLE
Remove local dev-server child-process from default gulp command

### DIFF
--- a/docs/firefox-accounts.rst
+++ b/docs/firefox-accounts.rst
@@ -22,7 +22,7 @@ Local Development
 
     ``FXA_IFRAME_SRC=https://stomlinson.dev.lcip.org/``
 
-#. Set your local development server to run on ``127.0.0.1:8111``, e.g. ``PORT=8111 gulp``.
+#. Set your local development server to run on ``127.0.0.1:8111``, e.g. ``./manage.py runserver 8111``.
 #. Quit Firefox.
 #. Create a new profile for testing called ``FxA Test Local`` by following the
    `instructions here`_.

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -98,7 +98,7 @@ Make it run
 To make the server run, make sure you are inside a virtualenv, and then
 run the server::
 
-    $ gulp
+    $ ./manage.py runserver
 
 If you are not inside a virtualenv, you can activate it by doing::
 
@@ -106,15 +106,17 @@ If you are not inside a virtualenv, you can activate it by doing::
 
 If you get the error "NoneType is not iterable", you didn't check out the latest product-details. See the above section for that.
 
+Next, in a new terminal tab run gulp to watch for local file changes::
+
+    $ gulp
+
+This will automatically copy over CSS, JavaScript and image files to the /static directory as and when they change, which is needed for Django Pipeline to serve the assets as pages are requested.
+
 If you have problems with gulp, or you for some reason don't want to use it you can set::
 
     PIPELINE_COLLECTOR_ENABLED=True
 
-in your ``.env`` file or otherwise set it in your environment. Then you can run::
-
-    $ ./manage.py runserver
-
-and it will collect media for you as you make changes. The reason that this is not the preferred method is that it is much slower than using gulp.
+in your ``.env`` file or otherwise set it in your environment and it will collect media for you as you make changes. The reason that this is not the preferred method is that it is much slower than using gulp.
 
 Localization
 ------------

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -2,13 +2,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-/* global __dirname, require, process */
+/* global __dirname, require */
 
 const gulp = require('gulp');
 const karma = require('karma');
 const eslint = require('gulp-eslint');
 const watch = require('gulp-watch');
-const spawn = require('child_process').spawn;
 
 const lintPaths = [
     'media/js/**/*.js',
@@ -16,15 +15,6 @@ const lintPaths = [
     'tests/unit/spec/**/*.js',
     'gulpfile.js'
 ];
-
-gulp.task('serve:backend', () => {
-    const devServerPort = process.env.PORT || 8000;
-    process.env.PYTHONUNBUFFERED = 1;
-    process.env.PYTHONDONTWRITEBITECODE = 1;
-    spawn('python', ['manage.py', 'runserver', `0.0.0.0:${devServerPort}`], {
-        stdio: 'inherit'
-    });
-});
 
 gulp.task('media:watch', () => {
     return gulp.src('./media/**/*')
@@ -49,7 +39,6 @@ gulp.task('js:lint', () => {
 });
 
 gulp.task('default', () => {
-    gulp.start('serve:backend');
     gulp.start('media:watch');
     gulp.watch(lintPaths, ['js:lint']);
 });


### PR DESCRIPTION
## Description
- Removes running the local dev server as a child-process that's part of the gulp command, as it sometimes causes the heebie jeebies after a rebase.

@craigcook r?
