### PR TITLE
[fix bug 1295181] Update audience size/segmentation for fx /new all test

### DIFF
--- a/media/js/firefox/new/experiment-all-links.js
+++ b/media/js/firefox/new/experiment-all-links.js
@@ -4,8 +4,9 @@
     var cop = new Mozilla.TrafficCop({
         id: 'exp_fx_new_scene1_all_links',
         variations: {
-            'v=1': 25,
-            'v=2': 25
+            'v=1': 3, // link under dl button to /firefox/all/
+            'v=2': 3, // link under dl button opens modal w/direct dl links
+            'v=3': 3 // double control group/no variation
         }
     });
 


### PR DESCRIPTION
## Description

Shrinking audience significantly to reduce risk. According to pg, should give us enough data in 2 days at this new rate.

## Bugzilla link

https://bugzilla.mozilla.org/show_bug.cgi?id=1295181#c29

## Testing

Make sure double control variation works as expected. (Easiest way is probably to boost the `v=3` variation percentage.)

## Checklist
- [ ] Related functional & integration tests passing.