### PR TITLE
Bug 1311037 - The language switcher doesn't take the anchor into account

### DIFF
--- a/media/js/base/global.js
+++ b/media/js/base/global.js
@@ -76,6 +76,7 @@ function initLangSwitcher() {
             'languageSelected': $language.val(),
             'previousLanguage': previousLanguage
         });
+        $('#lang_form').attr('action', window.location.hash || '#');
         $('#lang_form').submit();
     });
 }


### PR DESCRIPTION
## Description
Bug 1311037 - The language switcher doesn't take the anchor into account
## Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1311037

## Testing
Manual testing

## Checklist
- [ ] Requires l10n changes.
- [ ] Related functional & integration tests passing.

