### PR TITLE
[fix bug 1311052] Traffic Cop will ignore URL hash.

### DIFF
--- a/media/js/base/mozilla-traffic-cop.js
+++ b/media/js/base/mozilla-traffic-cop.js
@@ -146,7 +146,21 @@ Mozilla.TrafficCop.prototype.generateRedirectUrl = function(url, querystring) {
     // conjure a random number between 1 and 100 (inclusive)
     var rando = Math.floor(Math.random() * 100) + 1;
 
-    url = url || window.location;
+    // make sure to disregard hash in original URL
+    if (!url) {
+        // build URL root, e.g. https://www.mozilla.org
+        url = window.location.protocol + '//' + window.location.hostname;
+
+        // handy for local testing
+        if (window.location.port !== '') {
+            // adds port, e.g. (https://www.mozilla.org):443
+            url += ':' + window.location.port;
+        }
+
+        // add suffix, e.g. (https://www.mozilla.org)/en-US/about/
+        url += window.location.pathname;
+    }
+
     querystring = querystring || window.location.search;
 
     // check to see if user has a cookie from a previously visited variation

--- a/media/js/base/mozilla-traffic-cop.js
+++ b/media/js/base/mozilla-traffic-cop.js
@@ -139,29 +139,23 @@ Mozilla.TrafficCop.prototype.isVariation = function(queryString) {
  * Generates a random percentage (between 1 and 100, inclusive) and determines
  * which (if any) variation should be matched.
  */
-Mozilla.TrafficCop.prototype.generateRedirectUrl = function(url, querystring) {
+Mozilla.TrafficCop.prototype.generateRedirectUrl = function(url) {
+    var hash;
     var redirect;
     var runningTotal;
+    var urlParts;
 
     // conjure a random number between 1 and 100 (inclusive)
     var rando = Math.floor(Math.random() * 100) + 1;
 
-    // make sure to disregard hash in original URL
-    if (!url) {
-        // build URL root, e.g. https://www.mozilla.org
-        url = window.location.protocol + '//' + window.location.hostname;
+    url = url || window.location.href;
 
-        // handy for local testing
-        if (window.location.port !== '') {
-            // adds port, e.g. (https://www.mozilla.org):443
-            url += ':' + window.location.port;
-        }
-
-        // add suffix, e.g. (https://www.mozilla.org)/en-US/about/
-        url += window.location.pathname;
+    // strip hash from URL (if present)
+    if (url.indexOf('#') > -1) {
+        urlParts = url.split('#');
+        url = urlParts[0];
+        hash = urlParts[1];
     }
-
-    querystring = querystring || window.location.search;
 
     // check to see if user has a cookie from a previously visited variation
     // also make sure variation in cookie is still valid (you never know)
@@ -195,10 +189,11 @@ Mozilla.TrafficCop.prototype.generateRedirectUrl = function(url, querystring) {
 
     // if a variation was chosen, construct a new URL
     if (this.redirectVariation) {
-        if (querystring) {
-            redirect = url + querystring + '&' + this.redirectVariation;
-        } else {
-            redirect = url + '?' + this.redirectVariation;
+        redirect = url + (url.indexOf('?') > -1 ? '&' : '?') + this.redirectVariation;
+
+        // re-insert hash (if originally present)
+        if (hash) {
+            redirect += '#' + hash;
         }
     }
 

--- a/tests/unit/spec/base/mozilla-traffic-cop.js
+++ b/tests/unit/spec/base/mozilla-traffic-cop.js
@@ -190,7 +190,17 @@ describe('mozilla-traffic-cop.js', function () {
 
         it('should generate a redirect retaining the original querystring when present', function() {
             spyOn(window.Math, 'random').and.returnValue(0.74);
-            expect(cop.generateRedirectUrl('https://www.mozilla.org', '?foo=bar')).toEqual('https://www.mozilla.org?foo=bar&v=2');
+            expect(cop.generateRedirectUrl('https://www.mozilla.org?foo=bar')).toEqual('https://www.mozilla.org?foo=bar&v=2');
+        });
+
+        it('should generate a redirect retaining the original hash when present', function() {
+            spyOn(window.Math, 'random').and.returnValue(0.74);
+            expect(cop.generateRedirectUrl('https://www.mozilla.org#hash')).toEqual('https://www.mozilla.org?v=2#hash');
+        });
+
+        it('should generate a redirect retaining the original querystring and hash when present', function() {
+            spyOn(window.Math, 'random').and.returnValue(0.74);
+            expect(cop.generateRedirectUrl('https://www.mozilla.org?foo=bar#hash')).toEqual('https://www.mozilla.org?foo=bar&v=2#hash');
         });
 
         it('should use a valid variation stored in a cookie', function() {


### PR DESCRIPTION
## Description

Ensure URL hash is handled appropriately in redirect URL when present in the original URL.

As the variant experience could be completely different from the control - hash element may not exist, we may want a "fresh" (no page scrolling) UX - I decided to drop the hash instead of adding it back to the variation URL.

However, I'm not completely sold on this approach. I suppose it could be a config option with the default being no hash, but that smells like over-engineering. My gut is saying leave it off until a specific case arises where we need it.

It would be relatively simple to add the hash on to the variation URL, so, thoughts?

## Bugzilla link

https://bugzilla.mozilla.org/show_bug.cgi?id=1311052

## Testing

Change a local test to have 100% variation coverage and open some private windows.

## Checklist
- [ ] Related functional & integration tests passing.

