### PR TITLE
[bug 1311423] Re-enable flashtalking pixel on /firefox/new/

### DIFF
--- a/bedrock/firefox/templates/firefox/new/scene2.html
+++ b/bedrock/firefox/templates/firefox/new/scene2.html
@@ -51,5 +51,8 @@
 {% endblock %}
 
 {% block js %}
+  {% if switch('flashtalking') %}
+    {% javascript 'firefox_new_pixel' %}
+  {% endif %}
   {% javascript 'firefox_new_scene2' %}
 {% endblock %}

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -1169,3 +1169,6 @@ if CSP_EXTRA_FRAME_SRC:
 
 # support older browsers (mainly Safari)
 CSP_FRAME_SRC = CSP_CHILD_SRC
+
+if config('SWITCH_FLASHTALKING', default=DEV, cast=bool):
+    CSP_IMG_SRC += ('servedby.flashtalking.com',)

--- a/bedrock/settings/static_media.py
+++ b/bedrock/settings/static_media.py
@@ -1212,6 +1212,12 @@ PIPELINE_JS = {
         ),
         'output_filename': 'js/firefox_new_scene2-bundle.js',
     },
+    'firefox_new_pixel': {
+        'source_filenames': (
+            'js/firefox/new/pixel.js',
+        ),
+        'output_filename': 'js/firefox_new_pixel-bundle.js',
+    },
     'firefox_private_browsing': {
         'source_filenames': (
             'js/base/uitour-lib.js',

--- a/media/js/firefox/new/pixel.js
+++ b/media/js/firefox/new/pixel.js
@@ -1,0 +1,22 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+(function() {
+    'use strict';
+
+    // pixel status bug https://bugzilla.mozilla.org/show_bug.cgi?id=1311423
+    function addPixel() {
+        if (!window._dntEnabled()) {
+            var $pixel = $('<img />', {
+                width: '1',
+                height: '1',
+                src: 'https://servedby.flashtalking.com/spot/8/6247;40428;4669/?spotName=Mozilla_Download_Conversion'
+            });
+            $('body').append($pixel);
+        }
+    }
+
+    addPixel();
+
+})();


### PR DESCRIPTION
This is pretty much just a reversal of https://github.com/mozilla/bedrock/commit/6f30fd090b658a34a1ef706e8a21f7819be2f8c3

@jpetto r?

