### PR TITLE
Don't load Pontoon on dev for older browsers

### DIFF
--- a/bedrock/base/templates/base-pebbles.html
+++ b/bedrock/base/templates/base-pebbles.html
@@ -149,7 +149,9 @@
     {% endblock %}
     {% block js %}{% endblock %}
     {% if settings.DEV %}
-      <script src="https://pontoon.mozilla.org/pontoon.js"></script>
+      <!--[if !lte IE 8]><!-->
+        <script src="https://pontoon.mozilla.org/pontoon.js"></script>
+      <!--<![endif]-->
     {% endif %}
   </body>
 </html>

--- a/bedrock/base/templates/base-resp.html
+++ b/bedrock/base/templates/base-resp.html
@@ -169,7 +169,9 @@
     {% endblock %}
     {% block js %}{% endblock %}
     {% if settings.DEV %}
-      <script src="https://pontoon.mozilla.org/pontoon.js"></script>
+      <!--[if !lte IE 8]><!-->
+        <script src="https://pontoon.mozilla.org/pontoon.js"></script>
+      <!--<![endif]-->
     {% endif %}
   </body>
 </html>

--- a/bedrock/base/templates/base.html
+++ b/bedrock/base/templates/base.html
@@ -151,7 +151,9 @@
     {% endblock %}
     {% block js %}{% endblock %}
     {% if settings.DEV %}
-      <script src="https://pontoon.mozilla.org/pontoon.js"></script>
+      <!--[if !lte IE 8]><!-->
+        <script src="https://pontoon.mozilla.org/pontoon.js"></script>
+      <!--<![endif]-->
     {% endif %}
   </body>
 </html>


### PR DESCRIPTION
While Pontoon is only loaded on dev environments, it still throws JS errors in older browsers such as IE.

![pontoon-error](https://cloud.githubusercontent.com/assets/400117/19594019/28b69f40-977b-11e6-9132-d1c361e24a28.png)

This can be a bit annoying when trying to debug real issues, so let's not load it for older browsers.