### PR TITLE
[fix bug 1307998] Remove superfluous copy from MOSS home page.

### DIFF
--- a/bedrock/mozorg/templates/mozorg/moss/index.html
+++ b/bedrock/mozorg/templates/mozorg/moss/index.html
@@ -109,10 +109,6 @@
         source software projects, and remedial work to rectify the problems
         found.
       {% endtrans %}
-
-      {% trans %}
-        Suggest a recipient.
-      {% endtrans %}
       </p>
 
       <div class="moss-ctas">


### PR DESCRIPTION
## Description

Copy update/fix requested by Gerv.

## Bugzilla link

https://bugzilla.mozilla.org/show_bug.cgi?id=1307998#c21

