### PR TITLE
[fix bug 1313371] Update app-dev newsletter title & description.

### DIFF
--- a/bedrock/newsletter/views.py
+++ b/bedrock/newsletter/views.py
@@ -71,9 +71,9 @@ NEWSLETTER_STRINGS = {
         'description': _lazy(u'A monthly newsletter on how to get involved with Mozilla on your campus. '),
         'title': _lazy(u'Firefox Student Ambassadors')},
     u'app-dev': {
-        'description': _lazy(u'News for developers about Firefox OS, Firefox Marketplace and the '
-                             u'Open Web apps ecosystem.'),
-        'title': _lazy(u'Firefox Apps & Hacks')},
+        'description': _lazy(u'A developer\u2019s guide to highlights of Web platform '
+                             u'innovations, best practices, new documentation and more.'),
+        'title': _lazy(u'Mozilla Developer Newsletter')},
     u'aurora': {
         'description': _lazy(u'Aurora'),
         'title': _lazy(u'Aurora')},


### PR DESCRIPTION
## Description

Update title and description of the `app-dev` newsletter.

## Bugzilla link

https://bugzilla.mozilla.org/show_bug.cgi?id=1313371

## Testing

As this newsletter is now English only, and since the Firefox Friends newsletter is also English only and [currently untranslated](https://www.mozilla.org/fr/newsletter/existing/80a58e10-88ee-4369-aabe-881da32a1aba/), I don't think we need to block on/code around L10n.

## Checklist
- [ ] Related functional & integration tests passing.

