### PR TITLE
[fix bug 1313323] Fix home 2016 lang file name.

### DIFF
--- a/bedrock/mozorg/views.py
+++ b/bedrock/mozorg/views.py
@@ -255,7 +255,7 @@ def home_tweets(locale):
 def home(request, template='mozorg/home/home.html'):
     locale = l10n_utils.get_locale(request)
 
-    if lang_file_is_active('mozorg/home/home-2016', l10n_utils.get_locale(request)):
+    if lang_file_is_active('mozorg/home/index-2016', l10n_utils.get_locale(request)):
         template = 'mozorg/home/home.html'
     else:
         template = 'mozorg/home/home-voices.html'


### PR DESCRIPTION
## Description

Check correct lang file (as used in [the new homepage template](https://github.com/mozilla/bedrock/blob/master/bedrock/mozorg/templates/mozorg/home/home.html#L8)) in the view when deciding which template to serve.

## Bugzilla link

https://bugzilla.mozilla.org/show_bug.cgi?id=1313323

(Bug doesn't actually reference this issue - @flodolo mentioned it in IRC, but the 2 may well be related.)

## Testing

## Checklist
- [ ] Related functional & integration tests passing.

