### PR TITLE
[fix Bug 1313032] - highlight the target element on the forums page

### DIFF
--- a/media/css/mozorg/about-forums.less
+++ b/media/css/mozorg/about-forums.less
@@ -18,10 +18,15 @@
     & > li {
         list-style-type: none;
         border-top: 1px dotted @borderColor;
-        padding: 10px 0;
-        margin: 0;
+        padding: 10px 20px;
+        margin: 0 -20px;
         .clearfix();
     }
+
+    & > li:target{
+        background: #fff9c4;
+    }
+    
     .summary {
         .span(5);
         margin-left: 0;


### PR DESCRIPTION
## Description
Add highlighting for :target to forums page. Added background colour to the target element & added some padding to the .forums > li element.
## Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1313032
## Testing

## Checklist
- [ ] Requires l10n changes.
- [ ] Related functional & integration tests passing.

