### PR TITLE
Fix BUG 681572. redirect /download.html to /firefox/products/

### DIFF
--- a/bedrock/mozorg/redirects.py
+++ b/bedrock/mozorg/redirects.py
@@ -629,4 +629,7 @@ redirectpatterns = (
 
     # Bug 1313023
     redirect(r'^story/?$', 'https://donate.mozilla.org/?source=story_redirect'),
+
+    # Bug 681572
+    redirect(r'^download.html$', 'firefox.family.index'),
 )

--- a/tests/redirects/map_globalconf.py
+++ b/tests/redirects/map_globalconf.py
@@ -1093,4 +1093,7 @@ URLS = flatten((
 
     # Bug 1313023
     url_test('/story', 'https://donate.mozilla.org/?source=story_redirect'),
+
+    # Bug 681572
+    url_test('/download.html', '/firefox/products/'),
 ))


### PR DESCRIPTION
## Description
Redirect /download.html to /firefox/products/
## Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=681572
## Testing

## Checklist
- [ ] Requires l10n changes.
- [ ] Related functional & integration tests passing.

