### PR TITLE
[fix bug 1313508] Update /firefox/developer/ newsletter.

### DIFF
--- a/bedrock/firefox/templates/firefox/developer.html
+++ b/bedrock/firefox/templates/firefox/developer.html
@@ -221,11 +221,9 @@
       <h3>{{ _('Choose Firefox') }}</h3>
       {{ download_firefox('alpha', platform='desktop') }}
     </div>
-    {# See Bug 1095176 #}
+    {# See Bug 1313508 #}
     {% if LANG.startswith('en-') %}
-      {{ email_newsletter_form('app-dev', 'Firefox Apps & Hacks', button_class='light') }}
-    {% elif LANG.startswith('es-') %}
-      {{ email_newsletter_form('app-dev', 'Firefox Apps y Hacks', button_class='light') }}
+      {{ email_newsletter_form('app-dev', 'Mozilla Developer Newsletter', button_class='light', include_language=False) }}
     {% else %}
       {{ super() }}
     {% endif %}

--- a/docs/newsletters.rst
+++ b/docs/newsletters.rst
@@ -102,10 +102,6 @@ Bedrock came along and so are unlikely to be changed.
 
 /newsletter/ - subscribe to 'mozilla-and-you' newsletter (public name: "Firefox & You")
 
-/newsletter/hacks.mozilla.org/ - subscribe to 'app-dev' newsletter ('Firefox Apps & Hacks').
-This one is displayed as a frame inside some other page(s), so it works differently than
-the other signup pages.
-
 /newsletter/existing/USERTOKEN/ - user management of their preferences and subscriptions
 
 


### PR DESCRIPTION
## Description

Updates the en-* newsletter title and hides the language selector. Non en-* locales get the fallback `mozilla-and-you` newsletter.

Also removes section in docs referring to the [recently removed embeddable URL](https://github.com/mozilla/bedrock/pull/4406) for the developer newsletter.

## Bugzilla link

https://bugzilla.mozilla.org/show_bug.cgi?id=1313508

## Testing

Make sure no typos?

## Checklist
- [ ] Related functional & integration tests passing.

