### PR TITLE
[fix bug 1313714] Update newsletter id on /newsletter.

### DIFF
--- a/bedrock/newsletter/templates/newsletter/index.html
+++ b/bedrock/newsletter/templates/newsletter/index.html
@@ -3,7 +3,7 @@
 {% set_lang_files "mozorg/newsletters" %}
 
 {% set newsletter_title = _('Mozilla Newsletter') %}
-{% set newsletter_id = 'mozilla-and-you' %}
+{% set newsletter_id = 'mozilla-foundation' %}
 
 {% block page_title %}{{ _('Mozilla Newsletter') }}{% endblock %}
 
@@ -16,8 +16,3 @@
     </p>
   </div>
 {% endblock %}
-
-{% block success_confirm %}
-  <h3>{{ _('Thanks!') }}</h3>
-  {{ super() }}
-{% endblock success_confirm %}

--- a/bedrock/newsletter/tests/test_views.py
+++ b/bedrock/newsletter/tests/test_views.py
@@ -670,7 +670,7 @@ class TestNewsletterSubscribe(TestCase):
         resp = self.request()
         doc = pq(resp.content)
         self.assertTrue(doc('#newsletter-form'))
-        self.assertTrue(doc('input[value="mozilla-and-you"]'))
+        self.assertTrue(doc('input[value="mozilla-foundation"]'))
 
     @patch('bedrock.newsletter.views.basket')
     def test_returns_success(self, basket_mock):

--- a/bedrock/newsletter/views.py
+++ b/bedrock/newsletter/views.py
@@ -634,6 +634,6 @@ def newsletter_subscribe(request):
             if not errors:
                 ctx['success'] = True
 
-            return l10n_utils.render(request, 'newsletter/mozilla-and-you.html', ctx)
+            return l10n_utils.render(request, 'newsletter/index.html', ctx)
 
-    return l10n_utils.render(request, 'newsletter/mozilla-and-you.html')
+    return l10n_utils.render(request, 'newsletter/index.html')


### PR DESCRIPTION
## Description

Updates the newsletter id used on [mozilla.org/newsletter/](https://www.mozilla.org/en-US/newsletter/).

## Bugzilla link

https://bugzilla.mozilla.org/show_bug.cgi?id=1313714

## Testing

Make sure I didn't miss updating any dependencies.

## Checklist
- [ ] Related functional & integration tests passing.

