### PR TITLE
Fix bug 1315082: Reset git repos on failed db updates

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
 web: ./docker/run.sh
-clock: ./bin/cron.py db
+clock: ./docker/run-clock.sh

--- a/bedrock/mozorg/management/commands/update_product_details_files.py
+++ b/bedrock/mozorg/management/commands/update_product_details_files.py
@@ -28,10 +28,6 @@ class Command(BaseCommand):
         super(Command, self).__init__(stdout, stderr, no_color)
 
     def add_arguments(self, parser):
-        parser.add_argument('-f', '--force', action='store_true', dest='force', default=False,
-                            help=('Download product details even if they have '
-                                  'not been updated since the last fetch.'))
-
         parser.add_argument('-q', '--quiet', action='store_true', dest='quiet', default=False,
                             help='If no error occurs, swallow all output.'),
         parser.add_argument('--database', default='default',
@@ -40,7 +36,11 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         # don't really care about deleted files. almost never happens in p-d.
-        modified, _ = self.update_file_data()
+        if not self.update_file_data():
+            if not options['quiet']:
+                print('Product Details data was already up to date')
+            return
+
         try:
             self.validate_data()
         except Exception:
@@ -53,15 +53,8 @@ class Command(BaseCommand):
             # no need to continue if not using DB backend
             return
 
-        if options['force']:
-            files_to_load = self.file_storage.all_json_files()
-        else:
-            files_to_load = self.filter_filenames(modified)
-
-        if files_to_load:
-            self.load_changes(options, files_to_load)
-        elif not options['quiet']:
-            print('Product Details data was already up to date')
+        self.load_changes(options, self.file_storage.all_json_files())
+        self.repo.set_db_latest()
 
         if not options['quiet']:
             print('Product Details data update is complete')
@@ -79,7 +72,8 @@ class Command(BaseCommand):
             self.db_storage.update('regions/', '', self.file_storage.last_modified('regions/'))
 
     def update_file_data(self):
-        return self.repo.update()
+        self.repo.update()
+        return self.repo.has_changes()
 
     def count_builds(self, version_key, min_builds=20):
         version = self.file_storage.data('firefox_versions.json')[version_key]
@@ -96,17 +90,3 @@ class Command(BaseCommand):
         self.file_storage.clear_cache()
         for key in FIREFOX_VERSION_KEYS:
             self.count_builds(key)
-
-    def filter_filenames(self, filenames):
-        filtered_names = []
-        if filenames is None:
-            return filtered_names
-
-        for fn in filenames:
-            if not fn.endswith('.json'):
-                continue
-
-            filtered_names.append(str(
-                self.repo.path.joinpath(fn).relative_to(settings.PROD_DETAILS_TEST_DIR)))
-
-        return filtered_names

--- a/bedrock/security/tests/test_commands.py
+++ b/bedrock/security/tests/test_commands.py
@@ -56,15 +56,6 @@ def test_get_ids_from_files():
     eq_(update_security_advisories.get_ids_from_files(filenames), good_ids)
 
 
-def test_filter_updated_from_deleted():
-    modified_files = update_security_advisories.filter_advisory_filenames(['mfsa2016-42.yml'])
-    deleted_files = update_security_advisories.filter_advisory_filenames(['mfsa2016-42.md',
-                                                                          'mfsa2016-43.md'])
-    to_delete = update_security_advisories.filter_updated_from_deleted(modified_files,
-                                                                       deleted_files)
-    eq_(to_delete, deleted_files[1:])
-
-
 def make_mfsa(mfsa_id):
     update_security_advisories.add_or_update_advisory({
         'mfsa_id': mfsa_id,
@@ -92,22 +83,21 @@ class TestDBActions(TestCase):
         eq_(update_security_advisories.delete_orphaned_products(), 2)
         eq_(Product.objects.get().name, 'Firefox 43.0.1')
 
+    @patch.object(update_security_advisories, 'get_all_mfsa_files')
     @patch.object(update_security_advisories, 'delete_files')
     @patch.object(update_security_advisories, 'update_db_from_file')
     @patch.object(update_security_advisories, 'GitRepo')
-    def test_file_name_extension_change(self, git_mock, udbff_mock, df_mock):
+    def test_file_name_extension_change(self, git_mock, udbff_mock, df_mock, gamf_mock):
         """
         An MFSA file can now be either .md or .yml. Make sure this is an update, not a delete.
         """
         make_mfsa('2016-42')
         make_mfsa('2016-43')
-        repo = git_mock()
-        modified_files = ['mfsa2016-42.yml']
-        deleted_files = ['mfsa2016-42.md', 'mfsa2016-43.md']
-        repo.update.return_value = (modified_files, deleted_files)
-        update_security_advisories.Command().handle_noargs(quiet=True, force=False,
-                                                           no_git=False, clear_db=False)
+        all_files = ['mfsa2016-42.yml']
+        gamf_mock.return_value = all_files
+        git_mock().has_changes.return_value = False
+        update_security_advisories.Command().handle_noargs(quiet=True, no_git=False,
+                                                           clear_db=False)
         udbff_mock.assert_called_with(update_security_advisories.filter_advisory_filenames(
-            modified_files)[0])
-        df_mock.assert_called_with(update_security_advisories.filter_advisory_filenames(
-            ['mfsa2016-43.md']))
+            all_files)[0])
+        df_mock.assert_called_with(['mfsa2016-43.md'])

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -390,6 +390,7 @@ INSTALLED_APPS = (
     'bedrock.releasenotes',
     'bedrock.thunderbird',
     'bedrock.shapeoftheweb',
+    'bedrock.utils',
     # last so that redirects here will be last
     'bedrock.redirects',
 

--- a/bedrock/utils/migrations/0001_initial.py
+++ b/bedrock/utils/migrations/0001_initial.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='GitRepoState',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('repo_id', models.CharField(unique=True, max_length=100, db_index=True)),
+                ('latest_ref', models.CharField(max_length=100)),
+            ],
+        ),
+    ]

--- a/bedrock/utils/models.py
+++ b/bedrock/utils/models.py
@@ -1,0 +1,6 @@
+from django.db import models
+
+
+class GitRepoState(models.Model):
+    repo_id = models.CharField(max_length=100, db_index=True, unique=True)
+    latest_ref = models.CharField(max_length=100)

--- a/bedrock/utils/tests/test_git.py
+++ b/bedrock/utils/tests/test_git.py
@@ -30,6 +30,17 @@ def test_git_current_hash():
     git_mock.assert_called_with('rev-parse', 'HEAD')
 
 
+@pytest.mark.django_db
+def test_git_db_latest():
+    g = git.GitRepo('.', 'https://example.com/repo.git', 'testing', 'master')
+    assert g.db_latest_key == '39329169f489eca9254339aec5826b86fc49437c6a2ca85328798ead5a906cc0'
+    assert g.get_db_latest() is None
+    g.set_db_latest('deadbeef')
+    assert g.get_db_latest() == 'deadbeef'
+    g.set_db_latest('deadbeef1234')
+    assert g.get_db_latest() == 'deadbeef1234'
+
+
 def test_git_full_branch_name():
     g = git.GitRepo('.', branch_name='dude', remote_name='the')
     assert g.full_branch_name == 'the/dude'
@@ -107,8 +118,7 @@ def test_git_update(rmtree_mock):
         rmtree_mock.assert_not_called()
         git_mock['clone'].assert_not_called()
         assert git_mock['pull'].called
-        assert git_mock['diff'].called
-        assert val == git_mock['diff'].return_value
+        assert val == git_mock['pull'].return_value
 
 
 def test_git_diff():

--- a/docker/run-clock.sh
+++ b/docker/run-clock.sh
@@ -1,0 +1,4 @@
+#!/bin/bash -xe
+
+python manage.py migrate --noinput --database bedrock
+exec python bin/cron.py db

--- a/etc/supervisor_available/cron_db.conf
+++ b/etc/supervisor_available/cron_db.conf
@@ -1,5 +1,5 @@
 [program:cron_db]
-command = /app/bin/cron.py db
+command = /app/docker/run-clock.sh
 numprocs = 1
 autostart = true
 redirect_stderr = true


### PR DESCRIPTION
Reset git repos from git-based data import commands (e.g. update_security_advisories) when data import fails but the git update succeeds. In this way the next run of the command will try again and see all of the changed files.