### PR TITLE
[fix bug 1313717] Homepage Fx copy tests.

### DIFF
--- a/bedrock/mozorg/templates/mozorg/home/home-a.html
+++ b/bedrock/mozorg/templates/mozorg/home/home-a.html
@@ -1,0 +1,15 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+
+{% extends "mozorg/home/home.html" %}
+
+{% add_lang_files "mozorg/home/index-2016" %}
+
+{% block fx_copy %}
+  <h2>Adventure awaits</h2>
+
+  <p>
+    Find your favorite corners of the wide, weird, wonderful Web.
+  </p>
+{% endblock %}

--- a/bedrock/mozorg/templates/mozorg/home/home-b.html
+++ b/bedrock/mozorg/templates/mozorg/home/home-b.html
@@ -1,0 +1,15 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+
+{% extends "mozorg/home/home.html" %}
+
+{% add_lang_files "mozorg/home/index-2016" %}
+
+{% block fx_copy %}
+  <h2>The Web is yours</h2>
+
+  <p>
+    Explore it your way with the speed and security of Firefox.
+  </p>
+{% endblock %}

--- a/bedrock/mozorg/templates/mozorg/home/home-c.html
+++ b/bedrock/mozorg/templates/mozorg/home/home-c.html
@@ -1,0 +1,15 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+
+{% extends "mozorg/home/home.html" %}
+
+{% add_lang_files "mozorg/home/index-2016" %}
+
+{% block fx_copy %}
+  <h2>Unleash your Internet</h2>
+
+  <p>
+    Set the Web free and your mind will follow.
+  </p>
+{% endblock %}

--- a/bedrock/mozorg/templates/mozorg/home/home.html
+++ b/bedrock/mozorg/templates/mozorg/home/home.html
@@ -33,6 +33,12 @@
   {% stylesheet 'home' %}
 {% endblock %}
 
+{% block experiments %}
+  {% if LANG.startswith('en-') and switch('experiment-home-fx-copy') %}
+    {% javascript 'experiment-home-fx-copy' %}
+  {% endif %}
+{% endblock %}
+
 {% block optimizely %}
   {% if switch('mozorg-home-optimizely') %}
     {% include 'includes/optimizely.html' %}
@@ -171,33 +177,33 @@
     <div class="horizon">
       <div class="stars">
         <div class="content">
+        {% block fx_copy %}
           <h2>{{ _('Browse freely.') }}</h2>
-        </div>
+
+          <p>
+            {{ _('Discover unlimited potential, endless possibility and a wide open Web.') }}
+          </p>
+        {% endblock %}
+          <a id="fx-download-link" href="{{ url('firefox.new') }}">{{ _('Get Firefox today') }}</a>
+
+          <div id="fxmobile-download-buttons">
+            <ul>
+              <li class="android">
+                {{ google_play_button() }}
+              </li>
+              <li class="ios">
+                <a href="{{ firefox_ios_url('mozorg-homepage_prototype_b-button') }}" data-link-type="download" data-download-os="iOS">
+                  <img src="{{ l10n_img('firefox/ios/btn-app-store.svg') }}" alt="{{ _('Download on the App Store') }}" width="152" height="45">
+                </a>
+              </li>
+            </ul>
+          </div> {# --/#fxmobile-download-buttons --#}
+        </div> {# --/.content --#}
       </div> {# --/.stars --#}
     </div> {# --/.horizon --#}
 
     <div class="foreground">
       {% include 'firefox/includes/horizon.html' %}
-      <div class="content">
-        <p>
-          {{ _('Discover unlimited potential, endless possibility and a wide open Web.') }}
-        </p>
-
-        <a id="fx-download-link" href="{{ url('firefox.new') }}">{{ _('Get Firefox today') }}</a>
-
-        <div id="fxmobile-download-buttons">
-          <ul>
-            <li class="android">
-              {{ google_play_button() }}
-            </li>
-            <li class="ios">
-              <a href="{{ firefox_ios_url('mozorg-homepage_prototype_b-button') }}" data-link-type="download" data-download-os="iOS">
-                <img src="{{ l10n_img('firefox/ios/btn-app-store.svg') }}" alt="{{ _('Download on the App Store') }}" width="152" height="45">
-              </a>
-            </li>
-          </ul>
-        </div>
-      </div>
     </div> {# --/.foreground --#}
   </section>
 

--- a/bedrock/mozorg/tests/test_views.py
+++ b/bedrock/mozorg/tests/test_views.py
@@ -50,7 +50,7 @@ class TestHome(TestCase):
 
     # testing home page
     def test_en_us(self, render_mock):
-        req = RequestFactory().get('/')
+        req = self.rf.get('/')
         req.locale = 'en-US'
         views.home(req)
         render_mock.assert_called_once_with(req,
@@ -58,11 +58,34 @@ class TestHome(TestCase):
 
     @patch.object(views, 'lang_file_is_active', lambda *x: False)
     def test_old_home_template(self, render_mock):
-        req = RequestFactory().get('/')
+        req = self.rf.get('/')
         req.locale = 'es-ES'
         views.home(req)
         render_mock.assert_called_once_with(req,
             'mozorg/home/home-voices.html', ANY)
+
+    # home Fx copy tests - bug 1313717
+    def test_valid_variant(self, render_mock):
+        req = self.rf.get('/?v=b')
+        req.locale = 'en-US'
+        views.home(req)
+        render_mock.assert_called_once_with(req,
+            'mozorg/home/home-b.html', ANY)
+
+    def test_invalid_variant(self, render_mock):
+        req = self.rf.get('/?v=3')
+        req.locale = 'en-US'
+        views.home(req)
+        render_mock.assert_called_once_with(req,
+            'mozorg/home/home.html', ANY)
+
+    @patch.object(views, 'lang_file_is_active', lambda *x: True)
+    def test_valid_variant_invalid_locale(self, render_mock):
+        req = self.rf.get('/?v=a')
+        req.locale = 'fr'
+        views.home(req)
+        render_mock.assert_called_once_with(req,
+            'mozorg/home/home.html', ANY)
 
 
 class TestViews(TestCase):

--- a/bedrock/mozorg/views.py
+++ b/bedrock/mozorg/views.py
@@ -255,8 +255,14 @@ def home_tweets(locale):
 def home(request, template='mozorg/home/home.html'):
     locale = l10n_utils.get_locale(request)
 
-    if lang_file_is_active('mozorg/home/index-2016', l10n_utils.get_locale(request)):
-        template = 'mozorg/home/home.html'
+    if lang_file_is_active('mozorg/home/index-2016', locale):
+        # check for variant - fx copy experiment
+        v = request.GET.get('v', None)
+
+        if (locale.startswith('en-') and v in ['a', 'b', 'c']):
+            template = 'mozorg/home/home-{0}.html'.format(v)
+        else:
+            template = 'mozorg/home/home.html'
     else:
         template = 'mozorg/home/home-voices.html'
 

--- a/bedrock/settings/static_media.py
+++ b/bedrock/settings/static_media.py
@@ -1451,6 +1451,14 @@ PIPELINE_JS = {
         ),
         'output_filename': 'js/home-bundle.js',
     },
+    'experiment-home-fx-copy': {
+        'source_filenames': (
+            'js/base/mozilla-cookie-helper.js',
+            'js/base/mozilla-traffic-cop.js',
+            'js/mozorg/home/experiment-home-fx-copy.js',
+        ),
+        'output_filename': 'js/experiment-home-fx-copy-bundle.js',
+    },
     'home-voices': {
         'source_filenames': (
             'js/mozorg/home/home-voices.js',

--- a/media/css/mozorg/home/home.scss
+++ b/media/css/mozorg/home/home.scss
@@ -551,9 +551,7 @@ main {
         background: url('/media/img/firefox/horizon/stars.svg') center 60px no-repeat;
     }
 
-    .foreground .content {
-        padding-bottom: 60px;
-
+    .content {
         p {
             margin-bottom: 40px;
         }
@@ -569,7 +567,7 @@ main {
     }
 
     .forest-container {
-        height: 483px;
+        height: 416px;
         margin-top: -254px;
         position: relative;
     }

--- a/media/js/mozorg/home/experiment-home-fx-copy.js
+++ b/media/js/mozorg/home/experiment-home-fx-copy.js
@@ -1,0 +1,19 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+(function() {
+    'use strict';
+
+    var cop = new Mozilla.TrafficCop({
+        id: 'experiment-home-fx-copy',
+        variations: {
+            'v=a': 25,
+            'v=b': 25,
+            'v=c': 25,
+            'v=d': 25 // double control group
+        }
+    });
+
+    cop.init();
+})(window.Mozilla);


### PR DESCRIPTION
## Description

Prepare experiment to test 3 different copy blocks in the Firefox section of the home page.

Also removes gap in Firefox copy for all variants & control, and shortens Firefox section a bit.

## Bugzilla link

https://bugzilla.mozilla.org/show_bug.cgi?id=1313717

## Testing

Ensure variants load as expected for en-* locales.

## Checklist
- [ ] Related functional & integration tests passing.

