### PR TITLE
[fix bug 1316631] Newsletter landing pages are missing meta descriptions

### DIFF
--- a/bedrock/newsletter/templates/newsletter/developer.html
+++ b/bedrock/newsletter/templates/newsletter/developer.html
@@ -7,6 +7,7 @@
 {% set_lang_files "mozorg/newsletters" %}
 
 {% block page_title %}{{ _('Love the web? So do we!') }}{% endblock page_title %}
+{% block page_desc %}{{ _('Join thousands of developers like you who are learning the best of web development.') }}{% endblock %}
 
 {% block body_class %}newsletter-developer{% endblock %}
 
@@ -34,7 +35,7 @@
     <div class="content">
       <header class="header-main" role="banner">
         <h1 class="page-title">{{ self.page_title() }}</h1>
-        <h2 class="section-title">{{ _('Join thousands of developers like you who are learning the best of web development.') }} {{ _('If you don’t like the Mozilla developer newsletter, you can easily unsubscribe (but we think you’ll like it).') }}</h2>
+        <h2 class="section-title">{{ self.page_desc() }} {{ _('If you don’t like the Mozilla developer newsletter, you can easily unsubscribe (but we think you’ll like it).') }}</h2>
       </header>
       {{ email_newsletter_form(newsletters='app-dev', include_language=False, include_title=False, spinner_color='#0c99d5', button_class='hollow') }}
     </div>

--- a/bedrock/newsletter/templates/newsletter/firefox.html
+++ b/bedrock/newsletter/templates/newsletter/firefox.html
@@ -7,6 +7,7 @@
 {% set_lang_files "mozorg/newsletters" %}
 
 {% block page_title %}{{ _('Put more fox in your inbox.') }}{% endblock page_title %}
+{% block page_desc %}{{ _('See where the Web can take you with monthly Firefox tips, tricks and Internet intel.') }}{% endblock %}
 
 {% block body_class %}newsletter-mozilla{% endblock %}
 
@@ -33,8 +34,8 @@
   <section class="section-subscribe">
     <div class="content">
       <header class="header-main" role="banner">
-        <h1 class="page-title">{{ _('Put more fox in your inbox.') }}</h1>
-        <h2 class="section-title">{{ _('See where the Web can take you with monthly Firefox tips, tricks and Internet intel.') }}</h2>
+        <h1 class="page-title">{{ self.page_title() }}</h1>
+        <h2 class="section-title">{{ self.page_desc() }}</h2>
       </header>
       {{ email_newsletter_form(include_title=False, spinner_color='#3a304b', button_class='hollow') }}
     </div>

--- a/bedrock/newsletter/templates/newsletter/mozilla.html
+++ b/bedrock/newsletter/templates/newsletter/mozilla.html
@@ -7,6 +7,7 @@
 {% set_lang_files "mozorg/newsletters" %}
 
 {% block page_title %}{{ _('Sign up. Read up. Make a difference.') }}{% endblock page_title %}
+{% block page_desc %}{{ _('Get the Mozilla newsletter to stay informed about issues challenging the health of the Internet and to discover how you can get involved.') }}{% endblock %}
 
 {% block body_class %}newsletter-mozilla{% endblock %}
 
@@ -34,7 +35,7 @@
 
   <section class="section section-subscribe" id="subscribe">
     <div class="content">
-      <h2 class="section-title">{{ _('Get the Mozilla newsletter to stay informed about issues challenging the health of the Internet and to discover how you can get involved.') }}</h2>
+      <h2 class="section-title">{{ self.page_desc() }}</h2>
 
       {{ email_newsletter_form(newsletters='mozilla-foundation', include_title=False, spinner_color='#c13832', button_class='red') }}
 


### PR DESCRIPTION
## Description
- Adds meta descriptions for newsletter landing pages (re-using page subtitles)

## Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1316631

