### PR TITLE
Remove local.py-dist

### DIFF
--- a/bedrock/settings/local.py-dist
+++ b/bedrock/settings/local.py-dist
@@ -1,9 +1,0 @@
-# This is an example settings/local.py file.
-# Copy it and add your local settings here.
-
-ADMINS = ('foo@bar.com',)
-MANAGERS = ADMINS
-
-DEBUG = TEMPLATE_DEBUG = DEV = True
-SESSION_COOKIE_SECURE = False
-


### PR DESCRIPTION
## Description

As we have moved from `bedrock/settings/local.py` to `/.env`, removing `bedrock/settings/local.py-dist` to avoid confusion/clean up codebase.

## Bugzilla link

Nope.

## Testing

Double check that no references or dependencies remain to `local.py`.

## Checklist
- [ ] Related functional & integration tests passing.

