### PR TITLE
[fix bug 1316576] Email field placeholder text on homepage difficult …

### DIFF
--- a/media/css/newsletter/moznewsletter-subscribe.less
+++ b/media/css/newsletter/moznewsletter-subscribe.less
@@ -198,17 +198,17 @@
         }
 
         ::-webkit-input-placeholder {
-           color: #ccc;
+           color: #333;
            font-weight: normal;
         }
 
         ::-moz-placeholder {
-           color: #ccc;
+           color: #333;
            font-weight: normal;
         }
 
         :-ms-input-placeholder {
-           color: #ccc;
+           color: #333;
            font-weight: normal;
         }
     }


### PR DESCRIPTION
## Description
Simple colour change from #ccc to # 333. Makes the placeholder text as readable as the [legal](https://www.mozilla.org/en-US/about/legal/) page.

## Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1316576

## Checklist
- [x] Related functional & integration tests passing.