### PR TITLE
Add gulp clean task for /static when in local development

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -5,6 +5,7 @@
 /* global __dirname, require */
 
 const gulp = require('gulp');
+const del = require('del');
 const karma = require('karma');
 const eslint = require('gulp-eslint');
 const watch = require('gulp-watch');
@@ -36,6 +37,10 @@ gulp.task('js:lint', () => {
         .pipe(eslint())
         .pipe(eslint.format())
         .pipe(eslint.failAfterError());
+});
+
+gulp.task('static:clean', () => {
+    return del(['static/**', '!static', '!static/.gitignore']);
 });
 
 gulp.task('default', () => {

--- a/lockdown.json
+++ b/lockdown.json
@@ -4,10 +4,11 @@
     "1.0.9": "91b4792588a7738c25f35dd6f63752a2f8776135"
   },
   "accepts": {
-    "1.1.4": "d71c96f7d41d0feda2c38cd14e8a27c04158df4a"
+    "1.3.3": "c3ca7434938648c3e0d9c1e328dd68b622c284ca"
   },
   "acorn": {
-    "3.3.0": "45e37fb39e8da3f25baee3ff5369e2bb5f22017a"
+    "3.3.0": "45e37fb39e8da3f25baee3ff5369e2bb5f22017a",
+    "4.0.3": "1a3e850b428e73ba6b09d1cc527f5aaad4d03ef1"
   },
   "acorn-jsx": {
     "3.0.1": "afdf9488fb1ecefc8348f6fb22f464e32a58b36b"
@@ -15,11 +16,17 @@
   "after": {
     "0.8.1": "ab5d4fb883f596816d3515f8f791c0af486dd627"
   },
+  "ajv": {
+    "4.8.2": "65486936ca36fea39a1504332a78bebd5d447bdc"
+  },
+  "ajv-keywords": {
+    "1.1.1": "02550bc605a3e576041565628af972e06c549d50"
+  },
   "align-text": {
     "0.1.4": "0cd90a561093f35d0a99256c22b7069433fad117"
   },
   "amdefine": {
-    "1.0.0": "fd17474700cb5cc9c2b709f0be9d23ce3c198c33"
+    "1.0.1": "4a5282ac164729e93619bcfd3ad151f817ce91f5"
   },
   "ansi-escapes": {
     "1.4.0": "d3a8a83b319aa67793662b13e761c7911422306e"
@@ -43,7 +50,7 @@
     "1.1.2": "80e470e95a084794fe1899262c5667c6e88de1b3"
   },
   "argparse": {
-    "1.0.7": "c289506480557810f14a8bc62d7a06f63ed7f951"
+    "1.0.9": "73d83bc263f86e97f8cc4f6bae1b0e90a7d22c86"
   },
   "arr-diff": {
     "2.0.0": "8f3b827f955a8bd669697e4a4256ac3ceae356cf"
@@ -55,7 +62,7 @@
     "1.0.0": "eff52e3758249d33be402b8bb8e564bb2b5d4031"
   },
   "array-find-index": {
-    "1.0.1": "0bc25ddac941ec8a496ae258fd4ac188003ef3af"
+    "1.0.2": "df010aa1287e164bbda6f9723b0a96a1ec4187a1"
   },
   "array-index": {
     "1.0.0": "ec56a749ee103e4e08c790b9c353df16055b97f9"
@@ -80,7 +87,7 @@
   },
   "asap": {
     "2.0.3": "1fc1d1564ee11620dfca6d67029850913f9f4679",
-    "2.0.4": "b391bf7f6bfbc65706022fec8f49c4b07fecf589"
+    "2.0.5": "522765b50c3510490e52d7dcfe085ef9ba96958f"
   },
   "asn1": {
     "0.2.3": "dac8787713c9966849fc8180777ebe9c1ddf3b86"
@@ -91,8 +98,7 @@
   },
   "async": {
     "0.2.10": "b6bbe0b0674b9d719708ca38de8c237cb526c3d1",
-    "1.5.2": "ec6a61ae56480c0c3cb241c95618e20892f9672a",
-    "2.0.1": "b709cc0280a9c36f09f4536be823c838a9049e25"
+    "1.5.2": "ec6a61ae56480c0c3cb241c95618e20892f9672a"
   },
   "async-each": {
     "1.0.1": "19d386a1d9edc6e7c1c85d388aedbcc56d33602d"
@@ -100,11 +106,15 @@
   "async-foreach": {
     "0.1.3": "36121f845c0578172de419a97dbeb1d16ec34542"
   },
+  "asynckit": {
+    "0.4.0": "c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
+  },
   "aws-sign2": {
     "0.6.0": "14342dd38dbcc94d0e5b87d763cd63612c0e794f"
   },
   "aws4": {
-    "1.4.1": "fde7d5292466d230e5ee0f4e038d9dfaab08fc61"
+    "1.4.1": "fde7d5292466d230e5ee0f4e038d9dfaab08fc61",
+    "1.5.0": "0a29ffb79c31c9e712eeb087e8e7a64b4a56d755"
   },
   "backo2": {
     "1.0.2": "31ab1ac8b129363463e35b3ebb69f4dfcfba7947"
@@ -114,7 +124,7 @@
     "0.4.2": "cb3f3e3c732dc0f01ee70b403f302e61d7709838"
   },
   "base64-arraybuffer": {
-    "0.1.2": "474df4a9f2da24e05df3158c3b1db3c3cd46a154"
+    "0.1.5": "73926771923b5a19747ad666aa5cd4bf9c6e9ce8"
   },
   "base64id": {
     "0.1.0": "02ce0fdeee0cef4f40080e1e73e834f0b1bfce3f"
@@ -126,7 +136,7 @@
     "1.0.0": "3ca76b85241c7170bf7d9703e7b9aa74630040d4"
   },
   "beeper": {
-    "1.1.0": "9ee6fc1ce7f54feaace7ce73588b056037866a2c"
+    "1.1.1": "e6d5ea8c5dad001304a70b22638447f69cb2f809"
   },
   "benchmark": {
     "1.0.0": "2f1e2fa4c359f11122aa183082218e957e390c73"
@@ -135,7 +145,7 @@
     "1.0.2": "40866b9e1b9e0b55b481894311e68faffaebc522"
   },
   "binary-extensions": {
-    "1.5.0": "e6e2057f2cdfb17ad406349c86b71ef8069a25f5"
+    "1.7.0": "6c1610db163abfb34edfe42fa423343a1e01185d"
   },
   "bl": {
     "1.1.2": "fdca871a99713aa00d19e3bbba41c44787a65398"
@@ -147,8 +157,7 @@
     "0.0.9": "13ebfe778a03205cfe03751481ebb4b3300c126a"
   },
   "bluebird": {
-    "2.11.0": "534b9033c022c9579c56ba3b3e5a5caafbb650e1",
-    "3.4.5": "dfea23c733b7b8e924af97662f9c7bbefefe5ff9"
+    "2.11.0": "534b9033c022c9579c56ba3b3e5a5caafbb650e1"
   },
   "body-parser": {
     "1.15.2": "d7578cf4f1d11d5f6ea804cef35dc7a7ff6dae67"
@@ -204,7 +213,7 @@
     "1.1.3": "a8115c55e4a702fe4d150abd3872822a7e09fc98"
   },
   "chokidar": {
-    "1.6.0": "90c32ad4802901d7713de532dc284e96a63ad058"
+    "1.6.1": "2f4447ab5e96e50fb3d789fd90d4c72e0e4c70c2"
   },
   "circular-json": {
     "0.3.1": "be8b36aefccde8b3ca7aa2d6afc07a37242c0d2d"
@@ -226,8 +235,12 @@
   "clone-stats": {
     "0.0.1": "b88f94a82cf38b8791d58046ea4029ad88ca99d1"
   },
+  "co": {
+    "4.6.0": "6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
+  },
   "code-point-at": {
-    "1.0.0": "f69b192d3f7d91e382e4b71bddb77878619ab0c6"
+    "1.0.0": "f69b192d3f7d91e382e4b71bddb77878619ab0c6",
+    "1.1.0": "0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
   },
   "colors": {
     "1.1.2": "168a4701756b6a7f51a12ce0c97bfa28c084ed63"
@@ -258,7 +271,7 @@
     "1.1.9": "39ac7d4dca84faad926124c54cff25a53aa8bf6e"
   },
   "connect": {
-    "3.4.1": "a21361d3f4099ef761cda6dc4a973bb1ebb0a34d"
+    "3.5.0": "b357525a0b4c1f50599cd983e1d9efeea9677198"
   },
   "console-control-strings": {
     "1.1.0": "3d7cf4464db6446ea644bf4b39507f9851008e8e"
@@ -282,7 +295,7 @@
     "0.4.1": "988df33feab191ef799a61369dd76c17adf957ea"
   },
   "custom-event": {
-    "1.0.0": "2e4628be19dc4b214b5c02630c5971e811618062"
+    "1.0.1": "5d02a46850adf1b4a317946a3928fccb5bfd0425"
   },
   "d": {
     "0.1.1": "da184c535d18d8ee7ba2aa229b914009fae11309"
@@ -295,7 +308,8 @@
   },
   "debug": {
     "0.7.4": "06e1ea8082c2cb14e39806e22e2f6f757f92af39",
-    "2.2.0": "f87057e995b1a1f6ae6a4960664137bc56f039da"
+    "2.2.0": "f87057e995b1a1f6ae6a4960664137bc56f039da",
+    "2.3.2": "94cb466ef7d6d2c7e5245cdd6e4104f2d0d70d30"
   },
   "debuglog": {
     "1.0.1": "aa24ffb9ac3df9a2351837cfb2d279360cd78492"
@@ -304,7 +318,7 @@
     "1.2.0": "f6534d15148269b20352e7bee26f501f9a191290"
   },
   "deep-extend": {
-    "0.4.1": "efe4113d08085f4e6f9687759810f807469e2253"
+    "0.4.1": "*"
   },
   "deep-is": {
     "0.1.3": "b369d6fb5dbc13eecf524f91b070feedc357cf34"
@@ -337,7 +351,7 @@
     "0.0.1": "806649326ceaa7caa3306d75d985ea2748ba913c"
   },
   "doctrine": {
-    "1.3.0": "13e75682b55518424276f7c173783456ef913d26"
+    "1.5.0": "379dce730f6166f76cefa4e6707a159b02c5a6fa"
   },
   "dom-serialize": {
     "2.2.1": "562ae8999f44be5ea3076f5419dcd59eb43ac95b"
@@ -355,13 +369,13 @@
     "0.1.5": "8e177206c3c80837d85632e8b9359dfe8b2f6eaf"
   },
   "engine.io": {
-    "1.6.11": "2533a97a65876c40ffcf95397b7ef9b495c423fe"
+    "1.7.2": "877c14fa0486f8b664d46a8101bf74feef2e4e46"
   },
   "engine.io-client": {
-    "1.6.11": "7d250d8fa1c218119ecde51390458a57d5171376"
+    "1.7.2": "12f01d3d9d676908a86339cee067ff799a585c3d"
   },
   "engine.io-parser": {
-    "1.2.4": "e0897b0bf14e792d4cd2a5950553919c56948c42"
+    "1.3.1": "9554f1ae33107d6fbd170ca5466d2f833f6a07cf"
   },
   "ent": {
     "2.2.0": "e964219325a21d05f44466a2f686ed6ce5f5dd1d"
@@ -406,7 +420,7 @@
     "2.13.1": "e4cc8fa0f009fb829aaae23855a29360be1f6c11"
   },
   "espree": {
-    "3.1.7": "fd5deec76a97a5120a9cd3a7cb1177a0923b11d2"
+    "3.3.2": "dbf3fadeb4ecb4d4778303e50103b3d36c88b89c"
   },
   "esprima": {
     "2.7.3": "96e3b70d5779f6ad49cd032673d1c312767ba581"
@@ -457,7 +471,7 @@
     "1.2.0": "d5a51b53e9ab22ca07d558f2b67ae55fdb5fcbd8"
   },
   "fast-levenshtein": {
-    "1.1.4": "e6a754cc8f15e58987aa9cbd27af66fd6f4e5af9"
+    "2.0.5": "bd33145744519ab1c36c3ee9f31f08e9079b67f2"
   },
   "figures": {
     "1.7.0": "cbe1e3affcf1cd44b80cadfed28dc793a9701d2e"
@@ -472,7 +486,7 @@
     "2.2.3": "50b77dfd7e469bc7492470963699fe7a8485a723"
   },
   "finalhandler": {
-    "0.4.1": "85a17c6c59a94717d262d61230d4b0ebe3d4a14d"
+    "0.5.0": "e9508abece9b6dba871a6942a1d7911b91911ac7"
   },
   "find-index": {
     "0.1.1": "675d358b2ca3892d795a1ab47232f8b6e2e0dde4"
@@ -481,13 +495,14 @@
     "1.1.2": "6b2e9822b1a2ce0a60ab64d610eccad53cb24d0f"
   },
   "findup-sync": {
-    "0.4.2": "a8117d0f73124f5a4546839579fe52d7129fb5e5"
+    "0.4.3": "40043929e7bc60adf0b7f4827c4c6e75a0deca12"
   },
   "fined": {
-    "1.0.1": "c48af9ab5a8e0f400a0375e84154c37674dabfd4"
+    "1.0.2": "5b28424b760d7598960b7ef8480dff8ad3660e97"
   },
   "first-chunk-stream": {
-    "1.0.0": "59bfb50cd905f60d7c394cd3d9acaab4e6ad934e"
+    "1.0.0": "59bfb50cd905f60d7c394cd3d9acaab4e6ad934e",
+    "2.0.0": "1bdecdb8e083c0664b91945581577a43a9f31d70"
   },
   "flagged-respawn": {
     "0.3.2": "ff191eddcd7088a675b2610fffc976be9b8074b5"
@@ -496,7 +511,7 @@
     "1.2.1": "6c837d6225a7de5659323740b36d5361f71691ff"
   },
   "for-in": {
-    "0.1.5": "007374e2b6d5c67420a1479bdb75a04872b738c4"
+    "0.1.6": "c9f96e89bfad18a545af5ec3ed352a1d9e5b4dc8"
   },
   "for-own": {
     "0.1.4": "0149b41a39088c7515f51ebe1c1386d45f935072"
@@ -506,7 +521,7 @@
   },
   "form-data": {
     "1.0.0-rc4": "05ac6bc22227b43e4461f488161554699d4f8b5e",
-    "1.0.1": "ae315db9a4907fa065502304a66d7733475ee37c"
+    "2.1.2": "89c3534008b97eada4cbb157d58f6f5df025eae4"
   },
   "formatio": {
     "1.1.1": "5ed3ccd636551097383465d996199100e86161e9"
@@ -518,7 +533,7 @@
     "1.0.0": "1504ad2523158caa40db4a2787cb01411994ea4f"
   },
   "fsevents": {
-    "1.0.14": "558e8cc38643d8ef40fe45158486d0d25758eee4"
+    "1.0.15": "fa63f590f3c2ad91275e4972a6cea545fb0aae44"
   },
   "fstream": {
     "1.0.10": "604e8a92fe26ffd9f6fae30399d4984e1ab22822"
@@ -531,7 +546,7 @@
   },
   "gaze": {
     "0.5.2": "40b709537d24d1d45767db5a908689dfe69ac44f",
-    "1.1.1": "ab81d557d1b515f5752bd5f1117d6fa3c4e9db41"
+    "1.1.2": "847224677adb8870d679257ed3388fdb61e40105"
   },
   "generate-function": {
     "2.0.0": "6858fe7c0969b7d4e9093337647ac79f60dfbe74"
@@ -559,13 +574,14 @@
     "4.5.3": "c6cb73d3226c1efef04de3c56d012f03377ee15f",
     "5.0.15": "1bc936b9e02f4a603fcc222ecf7633d30b8b93b1",
     "7.0.5": "b4202a69099bbb4d292a7c1b95b6682b67ebdc95",
-    "7.0.6": "211bafaf49e525b8cd93260d14ab136152b3f57a"
+    "7.1.1": "805211df04faaf1c63a3600306cdf5ade50b2ec8"
   },
   "glob-base": {
     "0.3.0": "dbb164f6221b1c0b1ccf82aea328b497df0ea3c4"
   },
   "glob-parent": {
-    "2.0.0": "81383d72db054fcccf5336daa902f182f6edbb28"
+    "2.0.0": "81383d72db054fcccf5336daa902f182f6edbb28",
+    "3.0.1": "60021327cc963ddc3b5f085764f500479ecd82ff"
   },
   "glob-stream": {
     "3.1.18": "9170a5f12b790306fdfe598f313f8f7954fd143b"
@@ -583,14 +599,14 @@
     "0.1.4": "05158db1cde2dd491b455e290eb3ab8bfc45c6e1"
   },
   "globals": {
-    "9.9.0": "4c5ffc359fb21edc83fedb87b1c0b414dc24d552"
+    "9.13.0": "d97706b61600d8dbe94708c367d3fdcf48470b8f"
   },
   "globby": {
     "5.0.0": "ebd84667ca0dbb330b99bcfc68eac2bc54370e0d"
   },
   "globule": {
     "0.1.0": "d9c8edde1da79d125a151b79533b978676346ae5",
-    "1.0.0": "f22aebaacce02be492453e979c3ae9b6983f1c6c"
+    "1.1.0": "c49352e4dc183d85893ee825385eb994bb6df45f"
   },
   "glogg": {
     "1.0.0": "7fe0f199f57ac906cf512feead8f90ee4a284fc5"
@@ -599,9 +615,9 @@
     "1.2.3": "15a4806a57547cb2d2dbf27f42e89a8c3451b364",
     "3.0.11": "7613c778a1afea62f25c630a086d7f3acbbdd818",
     "3.0.8": "ce813e725fa82f7e6147d51c9a5ca68270551c22",
+    "4.1.10": "f2d720c22092f743228775c75e3612632501f131",
     "4.1.2": "fe2239b7574972e67e41f808823f9bfa4a991e37",
-    "4.1.4": "ef089d2880f033b011823ce5c8fae798da775dbd",
-    "4.1.6": "514c38772b31bee2e08bedc21a0aeb3abf54c19e"
+    "4.1.4": "ef089d2880f033b011823ce5c8fae798da775dbd"
   },
   "graceful-readlink": {
     "1.0.1": "4cafad76bc62f02fa039b2f94e9a3dd3a391a725"
@@ -616,13 +632,13 @@
     "3.0.7": "78925c4b8f8b49005ac01a011c557e6218941cbb"
   },
   "gulp-watch": {
-    "4.3.9": "dbf51d2a9cd38303ec5eae2720ac037c66d0a2f5"
+    "4.3.10": "776920ab54595c95f3597fb5444e61fc7bbd58a3"
   },
   "gulplog": {
     "1.0.0": "e28c4d45d05ecbbed818363ce8f9c5926229ffe5"
   },
   "handlebars": {
-    "4.0.5": "92c6ed6bb164110c50d4d8d0fbddc70806c6f8e7"
+    "4.0.6": "2ce4484850537f9c97a8026d5399b935c4ed4ed7"
   },
   "har-validator": {
     "2.0.6": "cdcbc08188265ad119b6a5a7c8ab70eecfb5d27d"
@@ -662,7 +678,7 @@
     "1.5.0": "b1cb3d8260fd8e2386cad3189045943372d48211"
   },
   "http-proxy": {
-    "1.14.0": "be32ab34dd5229e87840f4c27cb335ee195b2a83"
+    "1.15.2": "642fdcaffe52d3448d2bda3b0079e9409064da31"
   },
   "http-signature": {
     "1.1.1": "df72e267066cd0ac67fb76adf8e134a8fbcf91bf"
@@ -671,7 +687,7 @@
     "0.4.13": "1f88aba4ab0b1508e8312acc39345f36e992e2f2"
   },
   "ignore": {
-    "3.1.5": "54ba1eb92ef9fff8d49e5a1fb23961cdba77eb7a"
+    "3.2.0": "8d88f03c3002a0ac52114db25d2c673b0bf1e435"
   },
   "image-size": {
     "0.5.0": "be7aed1c37b5ac3d9ba1d66a24b4c47ff8397651"
@@ -690,11 +706,13 @@
   },
   "inflight": {
     "1.0.4": "6cbb4521ebd51ce0ec0a936bfd7657ef7e9b172a",
-    "1.0.5": "db3204cd5a9de2e6cd890b85c6e2f66bcf4f620a"
+    "1.0.5": "db3204cd5a9de2e6cd890b85c6e2f66bcf4f620a",
+    "1.0.6": "49bd6331d7d02d0c09bc910a1075ba8165b56df9"
   },
   "inherits": {
     "1.0.2": "ca4309dadee6b54cc0b8d247e8d7c7a0975bdc9b",
-    "2.0.1": "b17d08d326b4423e568eff719f91b0b1cbdf69f1"
+    "2.0.1": "b17d08d326b4423e568eff719f91b0b1cbdf69f1",
+    "2.0.3": "633c2c83e3da42a502f52466022480f4208261de"
   },
   "ini": {
     "1.3.4": "0537cb79daf59b59a1a517dff706c86ec039162e"
@@ -709,7 +727,7 @@
     "1.0.0": "104a8e4aaca6d3d8cd157a8ef8bfab2d7a3ffdb6"
   },
   "is-absolute": {
-    "0.2.5": "994142b9f468d27c14fbf0cd30fe77db934ca76d"
+    "0.2.6": "20de69f3db942ef2d87b9c2da36f172235b1b5eb"
   },
   "is-arrayish": {
     "0.2.1": "77c99840527aa8ecb1a8ba697b80645a7a926a9d"
@@ -733,19 +751,23 @@
     "0.1.1": "62b110e289a471418e3ec36a617d472e301dfc89"
   },
   "is-extglob": {
-    "1.0.0": "ac468177c4943405a092fc8f29760c6ffc6206c0"
+    "1.0.0": "ac468177c4943405a092fc8f29760c6ffc6206c0",
+    "2.1.0": "33411a482b046bf95e6b0cb27ee2711af4cf15ad"
   },
   "is-finite": {
-    "1.0.1": "6438603eaebe2793948ff4a4262ec8db3d62597b"
+    "1.0.2": "cc6677695602be550ef11e8b4aa6305342b6d0aa"
   },
   "is-fullwidth-code-point": {
-    "1.0.0": "ef9e31386f031a7f0d643af82fde50c457ef00cb"
+    "1.0.0": "ef9e31386f031a7f0d643af82fde50c457ef00cb",
+    "2.0.0": "a3b30a5c4f199183167aaab93beefae3ddfb654f"
   },
   "is-glob": {
-    "2.0.1": "d096f926a3ded5600f3fdfd91198cb0888c2d863"
+    "2.0.1": "d096f926a3ded5600f3fdfd91198cb0888c2d863",
+    "3.1.0": "7ba5ae24217804ac70707b96922567486cc3e84a"
   },
   "is-my-json-valid": {
-    "2.13.1": "d55778a82feb6b0963ff4be111d5d1684e890707"
+    "2.13.1": "d55778a82feb6b0963ff4be111d5d1684e890707",
+    "2.15.0": "936edda3ca3c211fd98f3b2d3e08da43f7b2915b"
   },
   "is-number": {
     "0.1.1": "69a7af116963d47206ec9bd9b48a14216f1e3806",
@@ -785,7 +807,6 @@
     "0.2.1": "4b0da1442104d1b336340e80797e865cf39f7d72"
   },
   "is-windows": {
-    "0.1.1": "be310715431cfabccc54ab3951210fa0b6d01abe",
     "0.2.0": "de1aa6d63ea29dd248737b69f1ff8b8002d2108c"
   },
   "isarray": {
@@ -808,7 +829,7 @@
     "0.4.5": "65c7d73d4c4da84d4f3ac310b918fb0b8033733b"
   },
   "jasmine-core": {
-    "2.5.0": "0b2e1f4d9babb66f4510681511ff0435e6b68340"
+    "2.5.2": "6f61bd79061e27f43e6f9355e44b3c6cab6ff297"
   },
   "jju": {
     "1.2.1": "edf6ec20d5d668c80c2c00cea63f8a9422a4b528"
@@ -817,7 +838,7 @@
     "1.0.2": "06d4912255093419477d425633606e0e90782967"
   },
   "js-yaml": {
-    "3.6.1": "6e5fe67d8b205ce4d22fad05b7781e8dadcc4b30"
+    "3.7.0": "5c967ddd837a9bfdca5f2de84253abe8a1c03b80"
   },
   "jsbn": {
     "0.1.0": "650987da0dd74f4ebf5a11377a2aa2d273e97dfd"
@@ -826,7 +847,8 @@
     "1.0.3": "13f14ce02eed4e981297b64eb9e3b932e2dd13dc"
   },
   "json-schema": {
-    "0.2.2": "50354f19f603917c695f70b85afa77c3b0f23506"
+    "0.2.2": "50354f19f603917c695f70b85afa77c3b0f23506",
+    "0.2.3": "b480c892e59a2f05954ce727bd3f2a4e882f9e13"
   },
   "json-stable-stringify": {
     "1.0.1": "9a759d39c5f2ff503fd5300646ed445f88c4f9af"
@@ -842,10 +864,12 @@
     "0.0.0": "2c74b6ee41d93ca51b7b5aaee8f503631d252a73"
   },
   "jsonpointer": {
-    "2.0.0": "3af1dd20fe85463910d469a385e33017d2a030d9"
+    "2.0.0": "3af1dd20fe85463910d469a385e33017d2a030d9",
+    "4.0.0": "6661e161d2fc445f19f98430231343722e1fcbd5"
   },
   "jsprim": {
-    "1.3.0": "ce2e1bef835204b4f3099928c602f8b6ae615650"
+    "1.3.0": "ce2e1bef835204b4f3099928c602f8b6ae615650",
+    "1.3.1": "2a7256f70412a29ee3670aaca625994c4dcff252"
   },
   "karma": {
     "0.13.22": "07750b1bd063d7e7e7b91bcd2e6354d8f2aa8744"
@@ -881,12 +905,13 @@
     "1.1.0": "956905708d58b4bab4c2261b04f59f31c99374c0"
   },
   "lockdown": {
-    "0.0.8-dev": "09f04e75e7abd5ccdf2019b92acb615d4b25f2f7"
+    "0.0.8-dev": "7344907fecaa3330e80f9d323b8ebe4fd4f1806f"
   },
   "lodash": {
     "1.0.2": "8f57560c83b59fc270bd3d561b690043430e2551",
     "3.10.1": "5bf45e8e49ba4189e17d482789dfd15bd140b7b6",
-    "4.9.0": "4c20d742f03ce85dc700e0dd7ab9bcab85e6fc14"
+    "4.16.6": "d22c9ac660288f3843e16ba7d2b5d06cca27d777",
+    "4.17.0": "93f4466e5ab73e5a1f1216c34eea11535f0a8df5"
   },
   "lodash._basecopy": {
     "3.0.1": "8da0e6a876cf344c0ad8a54882111dd3c5c7ca36"
@@ -931,8 +956,7 @@
     "3.1.0": "2f573d85c6a24289ff00663b491c1d338ff3458a"
   },
   "lodash.isarray": {
-    "3.0.4": "79e4eb88c36a8122af86f844aa9bcd851b5fbb55",
-    "4.0.0": "2aca496b28c4ca6d726715313590c02e6ea34403"
+    "3.0.4": "79e4eb88c36a8122af86f844aa9bcd851b5fbb55"
   },
   "lodash.isempty": {
     "4.4.0": "6f86cbedd8be4ec987be9aaf33c9684db1b31e7e"
@@ -997,12 +1021,12 @@
     "1.3.4": "115f9e3b6b3daf2959983cb38f149a2d40eb5d53"
   },
   "mime-db": {
-    "1.12.0": "3d0c63180f458eb10d325aaa37d7c58ae312e9d7",
-    "1.23.0": "a31b4070adaea27d732ea333740a64d0ec9a6659"
+    "1.23.0": "a31b4070adaea27d732ea333740a64d0ec9a6659",
+    "1.24.0": "e2d13f939f0016c6e4e9ad25a8652f126c467f0c"
   },
   "mime-types": {
-    "2.0.14": "310e159db23e077f8bb22b748dabfa4957140aa6",
-    "2.1.11": "c259c471bda808a85d6cd193b430a5fae4473b3c"
+    "2.1.11": "c259c471bda808a85d6cd193b430a5fae4473b3c",
+    "2.1.12": "152ba256777020dd4663f54c2e7bc26381e71729"
   },
   "minimatch": {
     "0.2.14": "c74e780574f63c6f9a090e90efbe6ef53a6a756a",
@@ -1012,6 +1036,7 @@
     "3.0.3": "2a4e4090b96b2db06a9d7df01055a62a77c9b774"
   },
   "minimist": {
+    "0.0.10": "de3f98543dbf96082be48ad1a0c7cda836301dcf",
     "0.0.8": "857fcabfc3397d2625b8228262e86aa7a011b05d",
     "1.2.0": "a35008b20f41383eec1fb914f4cd5df79a264284"
   },
@@ -1019,7 +1044,8 @@
     "0.5.1": "30057438eac6cf7f8c4767f38648d6697d75c903"
   },
   "ms": {
-    "0.7.1": "9cd13c03adbff25b65effde7ce864ee952017098"
+    "0.7.1": "9cd13c03adbff25b65effde7ce864ee952017098",
+    "0.7.2": "ae25cf2512b3885a1d95d7f037868d8431124765"
   },
   "multipipe": {
     "0.1.2": "2a8f2ddf70eed564dff2d57f1e1a137d9f05078b"
@@ -1034,7 +1060,7 @@
     "1.1.0": "e9ff841418a6b2ec7a495e939984f78f163e6e31"
   },
   "negotiator": {
-    "0.4.9": "92e46b6db53c7e421ed64a2bc94f08be7630df3f"
+    "0.6.1": "2b327184e8992101177b28563fb5e7102acd0ca9"
   },
   "node-gyp": {
     "3.4.0": "dda558393b3ecbbe24c9e6b8703c71194c63fa36"
@@ -1064,7 +1090,8 @@
     "3.1.2": "2d46fa874337af9498a2f12bb43d8d0be4a36873"
   },
   "number-is-nan": {
-    "1.0.0": "c020f529c5282adfdd233d91d4b181c3d686dc4b"
+    "1.0.0": "c020f529c5282adfdd233d91d4b181c3d686dc4b",
+    "1.0.1": "097b602b53422a522c1afb8790318336941a011d"
   },
   "oauth-sign": {
     "0.8.2": "46a6ab7f0aead8deae9ec0565780b7d4efeb9d43"
@@ -1077,14 +1104,15 @@
     "0.0.3": "f0c69aa50efc95b866c186f400a33769cb2f1291"
   },
   "object.omit": {
-    "2.0.0": "868597333d54e60662940bb458605dd6ae12fe94"
+    "2.0.1": "1a9c744829f39dbb858c76ca3579ae2a54ebd1fa"
   },
   "on-finished": {
     "2.3.0": "20f1336481b083cd75337992a16971aa2d906947"
   },
   "once": {
     "1.3.2": "d8feeca93b039ec1dcdee7741c92bdac5e28081b",
-    "1.3.3": "b2e261557ce4c314ec8304f3fa82663e4297ca20"
+    "1.3.3": "b2e261557ce4c314ec8304f3fa82663e4297ca20",
+    "1.4.0": "583b1aa775961d4b113ac17d9c50baef9dd76bd1"
   },
   "onetime": {
     "1.1.0": "a1f7838f8314c516f05ecefcbc4ccfe04b4ed789"
@@ -1093,25 +1121,25 @@
     "0.6.1": "da3ea74686fa21a19a111c326e90eb15a0196686"
   },
   "optionator": {
-    "0.8.1": "e31b4932cdd5fb862a8b0d10bc63d3ee1ec7d78b"
+    "0.8.2": "364c5e409d3f4d6301d6c0b4c05bba50180aeb64"
   },
   "options": {
     "0.0.6": "ec22d312806bb53e731773e7cdaefcf1c643128f"
   },
   "orchestrator": {
-    "0.3.7": "c45064e22c5a2a7b99734f409a95ffedc7d3c3df"
+    "0.3.8": "14e7e9e2764f7315fbac184e506c7aa6df94ad7e"
   },
   "ordered-read-streams": {
     "0.1.0": "fd565a9af8eb4473ba69b6ed8a34352cb552f126"
   },
   "os-homedir": {
-    "1.0.1": "0d62bdf44b916fd3bbdcf2cab191948fb094f007"
+    "1.0.2": "ffbc4988336e0e833de0c168c7ef152121aa7fb3"
   },
   "os-locale": {
     "1.4.0": "20f9f17ae29ed345e8bde583b13d2009803c14d9"
   },
   "os-tmpdir": {
-    "1.0.1": "e9b423a1edaf479882562e92ed71d7743a071b6e"
+    "1.0.2": "bbe67406c79aa85c5cfec766fe5734555dfa1274"
   },
   "osenv": {
     "0.1.0": "61668121eec584955030b9f470b1d2309504bfcb",
@@ -1141,14 +1169,18 @@
   "path-array": {
     "1.0.1": "7e2f0f35f07a2015122b868b7eac0eb2c4fec271"
   },
+  "path-dirname": {
+    "1.0.2": "cc33d24d525e099a5388c0336c6e32b9160609e0"
+  },
   "path-exists": {
     "2.1.0": "0feb6c64f0fc518d9a754dd5efb62c7022761f4b"
   },
   "path-is-absolute": {
-    "1.0.0": "263dada66ab3f2fb10bf7f9d24dd8f3e570ef912"
+    "1.0.0": "263dada66ab3f2fb10bf7f9d24dd8f3e570ef912",
+    "1.0.1": "174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
   },
   "path-is-inside": {
-    "1.0.1": "98d8f1d030bf04bd7aeee4a1ba5485d40318fd89"
+    "1.0.2": "365417dede44430d1c11af61027facf074bdfc53"
   },
   "path-root": {
     "0.1.1": "9a4a6814cac1c0cd73360a95f32083c8ea4745b7"
@@ -1178,7 +1210,7 @@
     "0.2.0": "815ed1f6ebc65926f865b310c0713bcb3315ce4b"
   },
   "pretty-hrtime": {
-    "1.0.2": "70ca96f4d0628a443b918758f79416a9a7bc9fa8"
+    "1.0.3": "b7e3ea42435a4c9b2759d99e0f201eb195802ee1"
   },
   "process-nextick-args": {
     "1.0.7": "150e20b756590ad3f91093f25a4f2ad8bff30ba3"
@@ -1198,9 +1230,12 @@
   "pseudomap": {
     "1.0.2": "f052a28da70e618917ef0a8ac34c1ae5a68286b3"
   },
+  "punycode": {
+    "1.4.1": "c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
+  },
   "qs": {
     "6.2.0": "3b7848c03c2dece69a9522b0fae8c4126d745f3b",
-    "6.2.1": "ce03c5ff0935bc1d9d69a9f14cbd18e568d67625"
+    "6.3.0": "f403b264f23bc01228c74131b407f18d5ea5d442"
   },
   "randomatic": {
     "1.1.5": "5e9ef5f2d573c67bd2b8124ae90b5156e457840b"
@@ -1209,7 +1244,7 @@
     "2.1.7": "adfeace2e4fb3098058014d08c072dcc59758774"
   },
   "rc": {
-    "1.1.6": "43651b76b6ae53b5c802f1151fa3fc3b059969c9"
+    "1.1.6": "*"
   },
   "read-installed": {
     "3.1.0": "47075ba8828147ed495084df779f29a4329ad3df"
@@ -1228,7 +1263,7 @@
     "1.1.14": "7cf4c54ef648e3813084c636dd2079e166c081d9",
     "2.0.6": "8f90341e68a53ccc928788dacfcd11b36eb9b78e",
     "2.1.4": "70b9791c6fcb8480db44bd155a0f6bb58f172468",
-    "2.1.5": "66fa8b720e1438b364681f2ad1a63c618448c9d0"
+    "2.2.1": "c459a6687ad6195f936b959870776edef27a7655"
   },
   "readdir-scoped-modules": {
     "1.0.2": "9fafa37d286be5d92cbaebdee030dc9b5f406747"
@@ -1253,7 +1288,7 @@
   },
   "repeat-string": {
     "0.2.2": "c7a8d3236068362059a7e4651fc6884e8b1fb4ae",
-    "1.5.4": "64ec0c91e0f4b475f90d5b643651e3e6e5b6c2d5"
+    "1.6.1": "8dcae470e1c88abc2d600fff4a776286da75e637"
   },
   "repeating": {
     "2.0.1": "5214c53a926d3552707527fbab415dbc08d06dda"
@@ -1263,7 +1298,7 @@
   },
   "request": {
     "2.73.0": "5f78a9fde4370abc8ff6479d7a84a71a14b878a2",
-    "2.74.0": "7693ca768bbb0ea5c8ce08c084a45efa05b892ab"
+    "2.78.0": "e1c8dec346e1c81923b24acdb337f11decabe9cc"
   },
   "require-directory": {
     "2.1.1": "8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
@@ -1272,7 +1307,7 @@
     "1.0.1": "97f717b69d48784f5f526a6c5aa8ffdda055a4d1"
   },
   "require-uncached": {
-    "1.0.2": "67dad3b733089e77030124678a459589faf6a7ec"
+    "1.0.3": "4e0d56d6c9662fd31e43011c4b95aa49955421d3"
   },
   "requires-port": {
     "1.0.0": "925d2601d39ac485e091cf0da5c6e694dc3dcaff"
@@ -1334,10 +1369,11 @@
     "1.0.1": "3ff21f198cad2175f9f3b781853fd94d0d19b590"
   },
   "signal-exit": {
-    "3.0.0": "3c0543b65d7b4fbc60b6cd94593d9bf436739be8"
+    "3.0.0": "3c0543b65d7b4fbc60b6cd94593d9bf436739be8",
+    "3.0.1": "5a4c884992b63a7acd9badb7894c3ee9cfccad81"
   },
   "sinon": {
-    "1.17.5": "1038cba830e37012e99a64837ecd3b67200c058c"
+    "1.17.6": "a43116db59577c8296356afee13fafc2332e58e1"
   },
   "slice-ansi": {
     "0.0.4": "edbf8903f66f7ce2f8eafd6ceed65e264c831b35"
@@ -1349,17 +1385,17 @@
     "1.0.9": "6541184cc90aeea6c6e7b35e2659082443c66198"
   },
   "socket.io": {
-    "1.4.8": "e576f330cd0bed64e55b3fd26df991141884867b"
+    "1.5.1": "c3ea8c4ed4164436bc56adef60e31ad366518ca9"
   },
   "socket.io-adapter": {
     "0.4.0": "fb9f82ab1aa65290bf72c3657955b930a991a24f"
   },
   "socket.io-client": {
-    "1.4.8": "481b241e73df140ea1a4fb03486a85ad097f5558"
+    "1.5.1": "0f366eae7de34bc880ebd71106e1ce8143775827"
   },
   "socket.io-parser": {
     "2.2.2": "3d7af6b64497e956b7d9fe775f999716027f9417",
-    "2.2.6": "38dfd61df50dcf8ab1d9e2091322bf902ba28b99"
+    "2.3.1": "dd532025103ce429697326befd64005fcfe5b4a0"
   },
   "source-map": {
     "0.2.0": "dab73fbcfc2ba819b4de03bd6f6eaa48164b3f9d",
@@ -1373,7 +1409,7 @@
     "1.0.2": "4b3073d933ff51f3912f03ac5519498a4150db40"
   },
   "spdx-expression-parse": {
-    "1.0.3": "ca3c3828c4fea8aa44997884b398fc5d67436442"
+    "1.0.4": "9bdf2f20e1f40ed447fbe273266191fced51626c"
   },
   "spdx-license-ids": {
     "1.2.2": "c9df7a3424594ade6bd11900d596696dc06bac57"
@@ -1382,18 +1418,19 @@
     "1.0.3": "04e6926f662895354f3dd015203633b857297e2c"
   },
   "sshpk": {
-    "1.10.0": "104d6ba2afb2ac099ab9567c0d193977f29c6dfa",
+    "1.10.1": "30e1a5d329244974a1af61511339d595af6638b0",
     "1.8.3": "890cc9d614dc5292e5cb1a543b03c9abaa5c374e"
   },
   "statuses": {
-    "1.3.0": "8e55758cb20e7682c1f4fce8dcab30bf01d1e07a"
+    "1.3.1": "faf51b9eb74aaef3b3acf4ad5f61abf24cb7b93e"
   },
   "stream-consume": {
     "0.1.0": "a41ead1a6d6081ceb79f65b061901b6d8f3d1d0f"
   },
   "string-width": {
     "1.0.1": "c92129b6f1d7f52acf9af424a26e3864a05ceb0a",
-    "1.0.2": "118bdf5b8cdc51a2a7e70d211e07e2b0b9b107d3"
+    "1.0.2": "118bdf5b8cdc51a2a7e70d211e07e2b0b9b107d3",
+    "2.0.0": "635c5436cc72a6e0c387ceca278d4e2eec52687e"
   },
   "string_decoder": {
     "0.10.31": "62e203bc41766c6c28c9fc84301dab1c5310fa94"
@@ -1409,7 +1446,7 @@
     "2.0.0": "6219a85616520491f35788bdbf1447a99c7e6b0e"
   },
   "strip-bom-stream": {
-    "1.0.0": "e7144398577d51a6bed0fa1994fa05f43fd988ee"
+    "2.0.0": "f87db5ef2613f6968aa545abfe1ec728b6a829ca"
   },
   "strip-indent": {
     "1.0.1": "0c7962a6adefa7bbd4ac366460a638552ae1a0a2"
@@ -1422,7 +1459,7 @@
     "3.1.2": "72a262894d9d408b956ca05ff37b2ed8a6e2a2d5"
   },
   "table": {
-    "3.7.8": "b424433ef596851922b2fd77224a69a1951618eb"
+    "3.8.3": "2bbc542f0fda9861a755d3947fefd8b3f513855f"
   },
   "tar": {
     "2.2.1": "8e4d2a256c0e2185c6b18ad694aec968b83cb1d1"
@@ -1451,19 +1488,16 @@
   },
   "tough-cookie": {
     "2.2.2": "c83a1830f4e5ef0b93ef2a3488e724f8de016ac7",
-    "2.3.1": "99c77dfbb7d804249e8a299d4cb0fd81fef083fd"
+    "2.3.2": "f081f76e4c85720e6c37a5faced737150d84072a"
   },
   "trim-newlines": {
     "1.0.0": "5887966bb582a4503a41eb524f7d35011815a613"
   },
   "tryit": {
-    "1.0.2": "c196b0073e6b1c595d93c9c830855b7acc32a453"
+    "1.0.3": "393be730a9446fd1ead6da59a014308f36c289cb"
   },
   "tunnel-agent": {
     "0.4.3": "6373db76909fe570e08d73583365ed828a74eeeb"
-  },
-  "tv4": {
-    "1.2.7": "bd29389afc73ade49ae5f48142b5d544bf68d120"
   },
   "tweetnacl": {
     "0.13.3": "d628b56f3bcc3d5ae74ba9d4c1a704def5ab4b56",
@@ -1480,7 +1514,7 @@
   },
   "uglify-js": {
     "1.3.5": "4b5bfff9186effbaa888e4c9e94bd9fc4c94929d",
-    "2.7.3": "39b3a7329b89f5ec507e344c6e22568698ef4868"
+    "2.7.4": "a295a0de12b6a650c031c40deb0dc40b14568bd2"
   },
   "uglify-to-browserify": {
     "1.0.2": "6e0924d6bda6b5afe349e39a6d632850a0f882b7"
@@ -1507,9 +1541,6 @@
   },
   "useragent": {
     "2.1.9": "4dba2bc4dad1875777ab15de3ff8098b475000b7"
-  },
-  "utf8": {
-    "2.1.0": "0cfec5c8052d44a23e3aaa908104e8075f95dfd5"
   },
   "util": {
     "0.10.3": "7afb1afe50805246489e3db7fe0ed379336ac0f9"
@@ -1538,7 +1569,7 @@
     "1.2.0": "5c88036cf565e5df05558bfc911f8656df218884"
   },
   "vinyl-file": {
-    "1.3.0": "aa05634d3a867ba91447bedbb34afcb26f44f6e7"
+    "2.0.0": "a7ebf5ffbefda1b7d18d140fcb07b223efb6751a"
   },
   "vinyl-fs": {
     "0.3.14": "9a6851ce1cac1c1cea5fe86c0931d620c2cfa9e6"
@@ -1547,7 +1578,7 @@
     "2.0.1": "c066afb582bb1cb4128d60ea92392e94d5e9dbec"
   },
   "which": {
-    "1.2.10": "91cd9bd0751322411b659b40f054b21de957ab2d"
+    "1.2.12": "de67b5e450269f194909ef23ece4ebe416fa1192"
   },
   "which-module": {
     "1.0.0": "bba63ca861948994ff307736089e3b96026c2a4f"
@@ -1575,14 +1606,13 @@
     "0.2.1": "5fc03828e264cea3fe91455476f7a3c566cb0757"
   },
   "ws": {
-    "1.0.1": "7d0b2a2e58cddd819039c29c9de65045e1b310e9",
-    "1.1.0": "c1d6fd1515d3ceff1f0ae2759bf5fd77030aad1d"
+    "1.1.1": "082ddb6c641e85d4bb451f03d52f06eabdb1f018"
+  },
+  "wtf-8": {
+    "1.0.0": "392d8ba2d0f1c34d1ee2d630f15d0efb68e1048a"
   },
   "xmlhttprequest-ssl": {
     "1.5.1": "3b7741fea4a86675976e908d296d4445961faa67"
-  },
-  "xregexp": {
-    "3.1.1": "8ee18d75ef5c7cb3f9967f8d29414a6ca5b1a184"
   },
   "xtend": {
     "4.0.1": "a5c6d532be656e23db820efb943a1f04998d63af"

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "url": "https://bugzilla.mozilla.org/"
   },
   "devDependencies": {
+    "del": "^2.2.2",
     "eslint": "^2.8.0",
     "gulp": "^3.9.1",
     "gulp-eslint": "^2.0.0",

--- a/static/.gitignore
+++ b/static/.gitignore
@@ -1,5 +1,4 @@
 # Ignore everything in this directory
 *
 # Except this file
-!.gitignore
 !.htaccess


### PR DESCRIPTION
Add a little `gulp static:clean` task as a handy alternative to using `git clean` for static media (which is arguably simpler, but this seems a little less dangerous for accidents occurring). I stopped short of running this automatically when just running `gulp`, but it's something we *could* also do if we thought it was beneficial enough (although it could create issues of its own). But it seems like this is mainly useful for PR's that remove code, which are obvious enough to spot.