### PR TITLE
[fix bug 1317171] Stop home Fx copy from being covered by image.

### DIFF
--- a/media/css/mozorg/home/home.scss
+++ b/media/css/mozorg/home/home.scss
@@ -564,6 +564,13 @@ main {
         @media #{$mq-tablet} {
             @include font-size(24px);
         }
+
+        @media #{$mq-desktop} {
+            p {
+                max-width: 780px; // keep text from going behind the trees
+                margin: 0 auto 40px;
+            }
+        }
     }
 
     .forest-container {


### PR DESCRIPTION
## Description

Fixes copy display issue in Fx copy section on home page introduced by #4458.

## Bugzilla link

https://bugzilla.mozilla.org/show_bug.cgi?id=1317171

## Testing

Make sure text is no longer covered by tree images for various locales.

## Checklist
- [ ] Related functional & integration tests passing.

