### PR TITLE
[fix bug 1319158] Change link on /internet-health/ page

### DIFF
--- a/bedrock/mozorg/templates/mozorg/internet-health.html
+++ b/bedrock/mozorg/templates/mozorg/internet-health.html
@@ -29,8 +29,7 @@
         {% trans %}
           At Mozilla, we see the Internet as our largest shared global resource.
           The healthier it is, the more it benefits everyone. We can all be a
-          part of keeping the Internet open, safe and accessible. Here’s how we
-          can all be a part of keeping the Internet open, safe and accessible.
+          part of keeping the Internet open, safe and accessible.
         {% endtrans %}
         </p>
       </header>
@@ -114,7 +113,7 @@
 
           <ul class="ctas">
             <li>
-              <a rel="external" href="http://tech.newstatesman.com/guest-opinion/digital-empires">{{ _('Read more from Mozilla Foundation’s Mark Surman') }}</a>
+              <a rel="external" href="https://blog.mozilla.org/internetcitizen/2016/11/15/rise-digital-empires/">{{ _('Read more from Mozilla Foundation’s Mark Surman') }}</a>
             </li>
           </ul>
         </div>

--- a/tests/functional/test_internet_health.py
+++ b/tests/functional/test_internet_health.py
@@ -7,7 +7,6 @@ import pytest
 from pages.internet_health import InternetHealthPage
 
 
-@pytest.mark.skipif(reason='Skip test until cron job has run in production')
 @pytest.mark.nondestructive
 def test_blog_feed_is_displayed(base_url, selenium):
     page = InternetHealthPage(selenium, base_url).open()


### PR DESCRIPTION
## Description
- Updates a link.
- Removes a line of copy from a string. @flodolo says we haven't started translating this page yet, so I don't believe we need an l10n tag.

## Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1319158

## Checklist
- [ ] Requires l10n changes.
- [ ] Related functional & integration tests passing.

