### PR TITLE
[fix bug 1316044] Remove redirects from mozilla.org/zh-TW to http://mozilla.com.tw/

### DIFF
--- a/bedrock/firefox/redirects.py
+++ b/bedrock/firefox/redirects.py
@@ -11,8 +11,6 @@ def firefox_mobile_faq(request, *args, **kwargs):
 
 redirectpatterns = (
     # overrides
-    redirect('^zh-TW/mobile/?', 'http://mozilla.com.tw/firefox/mobile/', locale_prefix=False),
-    redirect('^zh-TW/download/?', 'http://mozilla.com.tw/firefox/download/', locale_prefix=False),
 
     redirect(r'^firefox/aurora/all/?$', 'firefox.all', to_kwargs={'channel': 'developer'}),
 

--- a/bedrock/mozorg/redirects.py
+++ b/bedrock/mozorg/redirects.py
@@ -16,9 +16,6 @@ redirectpatterns = (
         'utm_source': 'mozilla.org'
     }),
 
-    # bug 764261, 841393, 996608, 1008162, 1067691, 1113136, 1119022, 1131680, 1115626
-    redirect(r'^zh-TW/?$', 'http://mozilla.com.tw/', locale_prefix=False),
-
     # bug 1013082
     redirect(r'^ja/?$', 'https://www.mozilla.jp/', locale_prefix=False),
 

--- a/tests/functional/test_l10n.py
+++ b/tests/functional/test_l10n.py
@@ -14,7 +14,7 @@ def test_change_language(base_url, selenium):
     page = HomePage(selenium, base_url).open()
     initial = page.footer.language
     # avoid selecting the same language or locales that have homepage redirects
-    excluded = [initial, 'ja', 'ja-JP-mac', 'zh-TW', 'zh-CN']
+    excluded = [initial, 'ja', 'ja-JP-mac', 'zh-CN']
     available = [l for l in page.footer.languages if l not in excluded]
     new = random.choice(available)
     page.footer.select_language(new)

--- a/tests/redirects/map_globalconf.py
+++ b/tests/redirects/map_globalconf.py
@@ -39,11 +39,6 @@ URLS = flatten((
         'utm_source': 'mozilla.org'
     }),
 
-    # bug 764261, 841393, 996608, 1008162, 1067691, 1113136, 1119022, 1131680, 1115626
-    url_test('/zh-TW/', 'http://mozilla.com.tw/'),
-    url_test('/zh-TW/mobile/', 'http://mozilla.com.tw/firefox/mobile/'),
-    url_test('/zh-TW/download/', 'http://mozilla.com.tw/firefox/download/'),
-
     # bug 874913
     url_test('/en-US/{,products/}download.html{,?stuff=whatnot}', '/en-US/firefox/new/'),
     url_test('/{,products/}download.html{,?stuff=whatnot}', '/firefox/new/'),


### PR DESCRIPTION
## Description
- Do not merge while translations to existing pages are checked on demo.

## Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1316044

## Testing
https://www-demo1.allizom.org/zh-TW/

## Checklist
- [ ] Requires l10n changes.
- [ ] Related functional & integration tests passing.