### PR TITLE
[fix bug 1319842] Use correct JS bundle for Fx 50 whatsnew.

### DIFF
--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-50.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-50.html
@@ -44,3 +44,7 @@
 {% endif %}
 
 {% endblock %}
+
+{% block js %}
+  {% javascript 'firefox_whatsnew_50' %}
+{% endblock %}

--- a/bedrock/settings/static_media.py
+++ b/bedrock/settings/static_media.py
@@ -1409,6 +1409,13 @@ PIPELINE_JS = {
         ),
         'output_filename': 'js/firefox_whatsnew_zh_tw_49-bundle.js',
     },
+    'firefox_whatsnew_50': {
+        'source_filenames': (
+            'js/base/send-to-device.js',
+            'js/firefox/whatsnew/whatsnew-50.js',
+        ),
+        'output_filename': 'js/firefox_whatsnew_50-bundle.js',
+    },
     'geolocation': {
         'source_filenames': (
             'js/libs/mapbox-2.3.0.js',


### PR DESCRIPTION
## Description

Adds a reference to the correct JS files/bundle to the Fx 50.0 whatsnew template.

(The JS file was included in the original PR #4425, but wasn't added as a bundle/to the template. 😞 )

## Bugzilla link

https://bugzilla.mozilla.org/show_bug.cgi?id=1319842

## Testing

Double-check previously merged JS file and ensure all is well when used.

## Checklist
- [ ] Related functional & integration tests passing.

