### PR TITLE
[fix bug 1319684] Fix internet health section heights for L10n.

### DIFF
--- a/media/css/mozorg/internet-health.scss
+++ b/media/css/mozorg/internet-health.scss
@@ -360,6 +360,7 @@ html[dir="rtl"] {
         }
 
         .inner-container {
+            min-height: 360px;
             width: 320px;
         }
 
@@ -418,10 +419,10 @@ html[dir="rtl"] {
         .content {
             @include background-size(350px 350px);
             background-position: top 30px left 60px;
-            min-height: 450px;
         }
 
         .inner-container {
+            min-height: 420px;
             width: 440px;
         }
 


### PR DESCRIPTION
## Description

If localized copy is shorter than en-US, section footer overlaps section icon. Adds a `min-height` to the copy area to force footer below icon.

## Bugzilla link

https://bugzilla.mozilla.org/show_bug.cgi?id=1319684

## Testing

Delete/shorten text in any one of the sections and make sure section footer doesn't overlap icon.

## Checklist
- [ ] Related functional & integration tests passing.

