### PR TITLE
[fix bug 1319891] Add optimizely block to newsletter templates

### DIFF
--- a/bedrock/newsletter/templates/newsletter/developer.html
+++ b/bedrock/newsletter/templates/newsletter/developer.html
@@ -11,6 +11,12 @@
 
 {% block body_class %}newsletter-developer{% endblock %}
 
+{% block optimizely %}
+  {% if switch('developer-newsletter-optimizely') %}
+    {% include 'includes/optimizely.html' %}
+  {% endif %}
+{% endblock %}
+
 {% block page_css %}
   {% stylesheet 'newsletter-developer' %}
 {% endblock %}

--- a/bedrock/newsletter/templates/newsletter/mozilla.html
+++ b/bedrock/newsletter/templates/newsletter/mozilla.html
@@ -11,6 +11,12 @@
 
 {% block body_class %}newsletter-mozilla{% endblock %}
 
+{% block optimizely %}
+  {% if switch('mozilla-newsletter-optimizely') %}
+    {% include 'includes/optimizely.html' %}
+  {% endif %}
+{% endblock %}
+
 {% block page_css %}
   {% stylesheet 'newsletter-mozilla' %}
 {% endblock %}


### PR DESCRIPTION
## Description

Add the optimizely block to two newsletter templates (mozilla and developer)

## Bugzilla link

https://bugzilla.mozilla.org/show_bug.cgi?id=1319891

## Testing

Verified that tag shows up in code. Ran tests on newsletter application, which passed.

## Checklist
- [x] Does not require l10n changes
- [ ] Related functional & integration tests passing.

