### PR TITLE
[fix bug 1320666] Embed Rust video in modal overlay on /technology landing page

### DIFF
--- a/bedrock/mozorg/templates/mozorg/technology.html
+++ b/bedrock/mozorg/templates/mozorg/technology.html
@@ -104,7 +104,7 @@
         <div class="inner-container">
           <h2>{{ _('Inventing a safer programming language') }}</h2>
           <p>{{ _('Supported by Mozilla, Rust allows browsers, systems and more to run much faster and more safely.') }}</p>
-          <a rel="external" href="https://developer.mozilla.org/docs/Mozilla/Rust" class="button">{{ _('Learn more') }}</a>
+          <a rel="external" href="https://www.youtube.com/watch?list=PLo3w8EB99pqJ74XIGe72c9hBZWz9Y16cY&v=8EPsnf_ZYU0" class="button" data-video-title="Rust and the Future of Systems Programming">{{ _('Watch the video') }}</a>
         </div>
       </div>
       <footer>
@@ -148,9 +148,15 @@
   </section>
   {% endif %}
 
+  <div id="video-container">
+    <div class="video"></div>
+  </div>
+
 </main>
 {% endblock %}
 
 {% block email_form %}{% endblock %}
 
-{% block js %}{% endblock %}
+{% block js %}
+  {% javascript 'technology' %}
+{% endblock %}

--- a/bedrock/settings/static_media.py
+++ b/bedrock/settings/static_media.py
@@ -851,6 +851,7 @@ PIPELINE_CSS = {
     },
     'technology': {
         'source_filenames': (
+            'css/base/mozilla-modal.less',
             'css/mozorg/technology.scss',
         ),
         'output_filename': 'css/technology-bundle.css',
@@ -1582,6 +1583,13 @@ PIPELINE_JS = {
             'js/styleguide/docs/send-to-device.js',
         ),
         'output_filename': 'js/styleguide-docs-send-to-device-bundle.js',
+    },
+    'technology': {
+        'source_filenames': (
+            'js/base/mozilla-modal.js',
+            'js/mozorg/technology.js',
+        ),
+        'output_filename': 'js/technology-bundle.js',
     },
     'tracking-protection-tour': {
         'source_filenames': (

--- a/media/css/mozorg/technology.scss
+++ b/media/css/mozorg/technology.scss
@@ -671,6 +671,32 @@ html[dir="rtl"] #technologies > section {
     }
 }
 
+// Rust modal video overlay
+#video-container {
+    display: none;
+}
+
+#modal .window .inner #video-container.overlay-contents {
+    background: #000;
+    display: block;
+    height: 0;
+    padding-bottom: 56.25%;
+    position: relative;
+    top: 20px;
+
+    @media #{$mq-tablet} {
+        top: 40px;
+    }
+
+    iframe {
+        height: 100%;
+        left: 0;
+        position: absolute;
+        top: 0;
+        width: 100%;
+    }
+}
+
 /*--------------------------------------------------------------------------*/
 // Newsletter
 

--- a/media/js/mozorg/technology.js
+++ b/media/js/mozorg/technology.js
@@ -1,0 +1,80 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/* global YT */
+/* eslint no-unused-vars: [2, { "varsIgnorePattern": "onYouTubeIframeAPIReady" }] */
+
+// YouTube API hook has to be in global scope
+function onYouTubeIframeAPIReady() {
+    'use strict';
+
+    Mozilla.technologyOnYouTubeIframeAPIReady();
+}
+
+(function($) {
+
+    var tag = document.createElement('script');
+    tag.src = 'https://www.youtube.com/iframe_api';
+
+    var firstScriptTag = document.getElementsByTagName('script')[0];
+    firstScriptTag.parentNode.insertBefore(tag, firstScriptTag);
+
+    function onYouTubeIframeAPIReady() {
+        // show video modal when user clicks "watch now" button
+        $('#rust a.button').attr('role', 'button').click(function(e) {
+            e.preventDefault();
+
+            var $videoContainer = $('#video-container');
+            var video = $videoContainer.find('.video')[0];
+            var videoTitle = $(this).data('videoTitle');
+
+            var player = new YT.Player(video, {
+                height: '390',
+                width: '640',
+                videoId: '8EPsnf_ZYU0',
+                events: {
+                    'onReady': onPlayerReady,
+                    'onStateChange': onPlayerStateChange
+                }
+            });
+
+            function onPlayerReady(event) {
+                event.target.playVideo();
+            }
+
+            function onPlayerStateChange(event) {
+                var state;
+
+                switch(event.data) {
+                case YT.PlayerState.PLAYING:
+                    state = 'video play';
+                    break;
+                case YT.PlayerState.PAUSED:
+                    state = 'video paused';
+                    break;
+                case YT.PlayerState.ENDED:
+                    state = 'video complete';
+                    break;
+                }
+
+                if (state) {
+                    window.dataLayer.push({
+                        'event': 'video-interaction',
+                        'videoTitle': videoTitle,
+                        'interaction': state
+                    });
+                }
+            }
+
+            Mozilla.Modal.createModal(this, $videoContainer, {
+                onDestroy: function() {
+                    player.destroy();
+                }
+            });
+        });
+    }
+
+    Mozilla.technologyOnYouTubeIframeAPIReady = onYouTubeIframeAPIReady;
+
+})(window.jQuery);


### PR DESCRIPTION
## Description
- Adds Rust video modal to `/technology` landing page using YouTube JS API.
- The ask is to show the video in English for all locales until we can add subtitles (sorry in advance).

## Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1320666

## Testing
- Still need to verify GA events on demo.

## Checklist
- [ ] Requires l10n changes.
- [ ] Related functional & integration tests passing.