### PR TITLE
[fix bug 1319207] Add custom privacy URL for Firefox Focus in de locale.

### DIFF
--- a/bedrock/privacy/redirects.py
+++ b/bedrock/privacy/redirects.py
@@ -1,0 +1,10 @@
+from bedrock.redirects.util import no_redirect, redirect
+
+redirectpatterns = (
+    # bug 1319207
+    # 'Firefox Focus' cannot be used in de locale due to legal constraints
+    redirect(r'^de/privacy/firefox-focus/?', '/de/privacy/firefox-klar/', locale_prefix=False),
+    # special de URL should not be accessible from other locales
+    no_redirect(r'^de/privacy/firefox-klar/?', locale_prefix=False),
+    redirect(r'^privacy/firefox-klar/?', 'privacy.notices.firefox-focus'),
+)

--- a/bedrock/privacy/templates/privacy/index.html
+++ b/bedrock/privacy/templates/privacy/index.html
@@ -83,7 +83,14 @@
         <li class="policy-firefox-os"><a href="{{ url('privacy.notices.firefox-os') }}">{{ _('Firefox OS') }}</a></li>
         <li class="policy-firefox-cloud"><a href="{{ url('privacy.notices.firefox-cloud') }}">{{ _('Firefox Cloud Services') }}</a></li>
         <li class="policy-marketplace"><a href="https://marketplace.firefox.com/privacy-policy">{{ _('Firefox Marketplace') }}</a></li>
-        <li class="policy-firefox-focus"><a href="{{ url('privacy.notices.firefox-focus') }}">{{ _('Firefox Focus') }}</a></li>
+        <li class="policy-firefox-focus">
+        {% if LANG == 'de' %}
+          {# bug 1319207 - As product names are not exposed to L10n, best to specify unique name for de #}
+          <a href="{{ url('privacy.notices.firefox-klar') }}">Firefox Klar</a>
+        {% else %}
+          <a href="{{ url('privacy.notices.firefox-focus') }}">{{ _('Firefox Focus') }}</a>
+        {% endif %}
+        </li>
         <li class="policy-persona"><a href="{{ url('persona.privacy-policy') }}">{{ _('Persona') }}</a></li>
         <li class="policy-thunderbird"><a href="{{ url('privacy.notices.thunderbird') }}">{{ _('Thunderbird') }}</a></li>
       </ul>

--- a/bedrock/privacy/urls.py
+++ b/bedrock/privacy/urls.py
@@ -15,6 +15,8 @@ urlpatterns = (
     url(r'^/firefox-cloud/$', views.firefox_cloud_notices, name='privacy.notices.firefox-cloud'),
     url(r'^/firefox-hello/$', views.firefox_hello_notices, name='privacy.notices.firefox-hello'),
     url(r'^/firefox-focus/$', views.firefox_focus_notices, name='privacy.notices.firefox-focus'),
+    # bug 1319207 - special URL for Firefox Focus in de locale
+    url(r'^/firefox-klar/$', views.firefox_focus_notices, name='privacy.notices.firefox-klar'),
     url(r'^/thunderbird/$', views.thunderbird_notices, name='privacy.notices.thunderbird'),
     url(r'^/websites/$', views.websites_notices, name='privacy.notices.websites'),
     url(r'^/facebook/$', views.facebook_notices, name='privacy.notices.facebook'),

--- a/tests/redirects/map_globalconf.py
+++ b/tests/redirects/map_globalconf.py
@@ -1099,4 +1099,9 @@ URLS = flatten((
     url_test('/firefox/firstrun/learnmore', '/firefox/features/'),
     url_test('/firefox/{49.0,49.0.1,50.0a1,51.0a2}/firstrun/learnmore', '/firefox/features/'),
     url_test('/firefox/windows-10/welcome', 'https://support.mozilla.org/kb/how-change-your-default-browser-windows-10'),
+
+    # bug 1319207
+    url_test('/de/privacy/firefox-focus/', '/de/privacy/firefox-klar/'),
+    url_test('/fr/privacy/firefox-klar/', '/fr/privacy/firefox-focus/'),
+    url_test('/es-ES/privacy/firefox-klar/', '/es-ES/privacy/firefox-focus/'),
 ))


### PR DESCRIPTION
## Description

Creates a custom privacy URL for Firefox Focus visitors hitting the `de` locale.

## Bugzilla link

https://bugzilla.mozilla.org/show_bug.cgi?id=1319207

## Testing

Ensure that visiting `/de/privacy/firefox-focus/` redirects to `/de/privacy/firefox-klar/`. Also ensure any non-de locale hitting `/privacy/firefox-klar/` is redirected to `/{locale}/privacy/firefox-focus/`.

## Checklist
- [ ] Related functional & integration tests passing.

