### PR TITLE
[bug 1319244] test Activist cross-site search

### DIFF
--- a/bedrock/base/templates/includes/google-search-activist.html
+++ b/bedrock/base/templates/includes/google-search-activist.html
@@ -1,0 +1,10 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+
+<aside id="moz-search" class="moz-search moz-search-activist" data-terms="{{ _('Net Neutrality, Encryption, Surveillance, Copyright Law, Cybersecurity') }}">
+  <div class="content">
+    <label class="search-label" for="gsc-i-id1"><span class="search-label-prefix">{{ _('Search Mozilla:') }}</span> <span class="search-label-term">{{ _('Cybersecurity') }}</span></label>
+    <gcse:search gname="mozsearch"></gcse:search>
+  </div>
+</aside>

--- a/bedrock/foundation/templates/foundation/base-resp.html
+++ b/bedrock/foundation/templates/foundation/base-resp.html
@@ -30,6 +30,7 @@
 {% block content %}
   <main>
     <header class="page-header">
+      {% block search %}{% endblock %}
       <h1><span class="content">{{ _('The Mozilla Foundation') }}</span></h1>
     </header>
     <section>

--- a/bedrock/foundation/templates/foundation/index.html
+++ b/bedrock/foundation/templates/foundation/index.html
@@ -8,6 +8,24 @@
 
 {% set body_id = "index" %}
 
+{% block experiments %}
+  {% if LANG.startswith('en-') and switch('experiment-search-activist') %}
+    {% javascript 'experiment-search-activist' %}
+  {% endif %}
+{% endblock %}
+
+{% block js %}
+  {% if version == 'b' and switch('mozorg-search-activist') %}
+    {% javascript 'search-activist' %}
+  {% endif %}
+{% endblock %}
+
+{% block search %}
+  {% if version == 'b' and switch('mozorg-search-activist') %}
+    {% include 'includes/google-search-activist.html' %}
+  {% endif %}
+{% endblock %}
+
 {% block article_header %}
   <p>
     {% trans url_manifesto=url('mozorg.about.manifesto') %}

--- a/bedrock/foundation/urls.py
+++ b/bedrock/foundation/urls.py
@@ -4,6 +4,8 @@
 from bedrock.base.waffle import switch
 from bedrock.mozorg.util import page
 from bedrock.redirects.util import redirect
+from django.conf.urls import url
+from bedrock.foundation import views
 
 
 SOM_2015_ENABLED = switch('som-2015')
@@ -11,7 +13,7 @@ SOM_REDIRECT = ('foundation.annualreport.2015.index' if SOM_2015_ENABLED else
                 'foundation.annualreport.2014.index')
 
 urlpatterns = (
-    page('', 'foundation/index.html'),
+    url('^$', views.foundation_index, name='foundation.index'),
     page('about', 'foundation/about.html'),
     page('issues', 'foundation/issues.html'),
     page('advocacy', 'foundation/advocacy.html'),

--- a/bedrock/foundation/views.py
+++ b/bedrock/foundation/views.py
@@ -1,0 +1,15 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from lib import l10n_utils
+
+
+def foundation_index(request):
+    locale = l10n_utils.get_locale(request)
+    version = request.GET.get('v', None)
+
+    if (locale != 'en-US' or version != 'b'):
+        version = None
+
+    return l10n_utils.render(request, 'foundation/index.html', {'version': version})

--- a/bedrock/mozorg/templates/mozorg/about.html
+++ b/bedrock/mozorg/templates/mozorg/about.html
@@ -18,13 +18,26 @@
   {% endif %}
 {% endblock %}
 
+{% block experiments %}
+  {% if LANG.startswith('en-') and switch('experiment-search-activist') %}
+    {% javascript 'experiment-search-activist' %}
+  {% endif %}
+{% endblock %}
+
 {% block js %}
   {% javascript 'about_video' %}
+
+  {% if version == 'b' and switch('mozorg-search-activist') %}
+    {% javascript 'search-activist' %}
+  {% endif %}
 {% endblock %}
 
 {% block content %}
 <main>
   <header class="page-header">
+  {% if version == 'b' and switch('mozorg-search-activist') %}
+    {% include 'includes/google-search-activist.html' %}
+  {% endif %}
     <h1><span class="content">{{ _('Get to know Mozilla') }}</span></h1>
   </header>
 

--- a/bedrock/mozorg/templates/mozorg/about/manifesto.html
+++ b/bedrock/mozorg/templates/mozorg/about/manifesto.html
@@ -17,6 +17,12 @@
 
 {% block body_id %}manifesto-landing{% endblock %}
 
+{% block experiments %}
+  {% if LANG.startswith('en-') and switch('experiment-search-activist') %}
+    {% javascript 'experiment-search-activist' %}
+  {% endif %}
+{% endblock %}
+
 {% block string_data %}
   data-principle-read-more='{{ _('See more…') }}'
   data-principle-nav-prev='{{ _('Previous principle') }}'
@@ -52,9 +58,16 @@
 <main role="main">
   <article role="article" itemscope itemtype="http://schema.org/Article">
     <header id="main-feature">
-      <h1 itemprop="name">{{ self.page_title() }}</h1>
-      <p itemprop="description">{{ self.page_desc() }}</p>
+      <div class="content">
+        <h1 itemprop="name">{{ self.page_title() }}</h1>
+        <p itemprop="description">{{ self.page_desc() }}</p>
+      </div>
     </header>
+
+  {% if version == 'b' and switch('mozorg-search-activist') %}
+    {% include 'includes/google-search-activist.html' %}
+  {% endif %}
+
     <div id="main-content">
       <div id="main-content-inner">
         <section id="sec-principles" itemprop="articleBody">
@@ -325,6 +338,10 @@
     {% javascript 'matchmedia_addlistener' %}
   <![endif]-->
   {% javascript 'manifesto' %}
+
+  {% if version == 'b' and switch('mozorg-search-activist') %}
+    {% javascript 'search-activist' %}
+  {% endif %}
 {% endblock %}
 
   {#- End the redesigned landing page -#}

--- a/bedrock/mozorg/urls.py
+++ b/bedrock/mozorg/urls.py
@@ -11,8 +11,8 @@ from bedrock.redirects.util import redirect
 
 urlpatterns = (
     url('^$', views.home, name='mozorg.home'),
-    page('about', 'mozorg/about.html'),
-    page('about/manifesto', 'mozorg/about/manifesto.html'),
+    url('^about/$', views.about, name='mozorg.about'),
+    url('^about/manifesto/$', views.about_manifesto, name='mozorg.about.manifesto'),
     page('about/manifesto/details', 'mozorg/about/manifesto-details.html'),
     page('about/leadership', 'mozorg/about/leadership.html'),
     page('about/policy/lean-data', 'mozorg/about/policy/lean-data.html'),

--- a/bedrock/mozorg/views.py
+++ b/bedrock/mozorg/views.py
@@ -360,3 +360,23 @@ def internet_health(request):
     return l10n_utils.render(request,
                              'mozorg/internet-health.html',
                              {'articles': articles})
+
+
+def about(request):
+    locale = l10n_utils.get_locale(request)
+    version = request.GET.get('v', None)
+
+    if (locale != 'en-US' or version != 'b'):
+        version = None
+
+    return l10n_utils.render(request, 'mozorg/about.html', {'version': version})
+
+
+def about_manifesto(request):
+    locale = l10n_utils.get_locale(request)
+    version = request.GET.get('v', None)
+
+    if (locale != 'en-US' or version != 'b'):
+        version = None
+
+    return l10n_utils.render(request, 'mozorg/about/manifesto.html', {'version': version})

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -1176,6 +1176,8 @@ CSP_DEFAULT_SRC = (
     '*.mozilla.net',
     '*.mozilla.org',
     '*.mozilla.com',
+    'www.google.com',
+    'cse.google.com',
 )
 CSP_IMG_SRC = CSP_DEFAULT_SRC + (
     'data:',
@@ -1185,6 +1187,9 @@ CSP_IMG_SRC = CSP_DEFAULT_SRC + (
     '*.tiles.mapbox.com',
     'api.mapbox.com',
     'creativecommons.org',
+    'www.googleapis.com',
+    'clients1.google.com',
+    '*.gstatic.com',
 )
 CSP_SCRIPT_SRC = CSP_DEFAULT_SRC + (
     # TODO fix things so that we don't need this
@@ -1196,9 +1201,12 @@ CSP_SCRIPT_SRC = CSP_DEFAULT_SRC + (
     'optimizely.s3.amazonaws.com',
     'www.googletagmanager.com',
     'www.google-analytics.com',
+    'cse.google.com',
     'tagmanager.google.com',
     'www.youtube.com',
     's.ytimg.com',
+    'clients1.google.com',
+    'www.googleapis.com',
 )
 CSP_STYLE_SRC = CSP_DEFAULT_SRC + (
     # TODO fix things so that we don't need this
@@ -1214,6 +1222,7 @@ CSP_CHILD_SRC = (
     'accounts.firefox.com',
     'accounts.firefox.com.cn',
     'www.youtube.com',
+    'cse.google.com',
 )
 CSP_CONNECT_SRC = CSP_DEFAULT_SRC + (
     '*.optimizely.com',

--- a/bedrock/settings/static_media.py
+++ b/bedrock/settings/static_media.py
@@ -12,6 +12,7 @@ PIPELINE_CSS = {
         'source_filenames': (
             'css/base/mozilla-video-poster.less',
             'css/newsletter/moznewsletter-subscribe.less',
+            'css/pebbles/components/google-search.scss',
             'css/mozorg/about.less',
         ),
         'output_filename': 'css/about-bundle.css',
@@ -94,6 +95,7 @@ PIPELINE_CSS = {
     'foundation': {
         'source_filenames': (
             'css/newsletter/moznewsletter-subscribe.less',
+            'css/pebbles/components/google-search.scss',
             'css/foundation/foundation.less',
         ),
         'output_filename': 'css/foundation-bundle.css',
@@ -655,6 +657,7 @@ PIPELINE_CSS = {
         'source_filenames': (
             'css/base/mozilla-modal.less',
             'css/base/mozilla-share-cta.less',
+            'css/pebbles/components/google-search.scss',
             'css/mozorg/manifesto.less',
         ),
         'output_filename': 'css/manifesto-bundle.css',
@@ -1555,6 +1558,20 @@ PIPELINE_JS = {
             'js/privacy/privacy.js',
         ),
         'output_filename': 'js/privacy-bundle.js',
+    },
+    'search-activist': {
+        'source_filenames': (
+            'js/base/search-activist.js',
+        ),
+        'output_filename': 'js/search-activist-bundle.js',
+    },
+    'experiment-search-activist': {
+        'source_filenames': (
+            'js/base/mozilla-cookie-helper.js',
+            'js/base/mozilla-traffic-cop.js',
+            'js/mozorg/experiment-search-activist.js',
+        ),
+        'output_filename': 'js/experiment-search-activist-bundle.js',
     },
     'smarton': {
         'source_filenames': (

--- a/media/css/foundation/foundation.less
+++ b/media/css/foundation/foundation.less
@@ -35,6 +35,7 @@
     background: url('/media/img/foundation/banner/foundation_hero-image-small.jpg') center bottom no-repeat;
     .background-size(cover);
     padding-top: 300px;
+    position: relative;
 
     @media only screen and (min-width: @breakDesktop) {
         background-image: url('/media/img/foundation/banner/foundation_hero-image-large.jpg');
@@ -65,6 +66,11 @@
         .border-box;
         display: block;
         padding: 0 10px;
+    }
+
+    .moz-search {
+        position: absolute;
+        top: 0;
     }
 }
 

--- a/media/css/mozorg/about.less
+++ b/media/css/mozorg/about.less
@@ -24,6 +24,7 @@
     background: url('/media/img/newsletter/intro-mozsummit-2000.jpg') center bottom no-repeat;
     .background-size(cover);
     padding-top: 300px;
+    position: relative;
 
     @media only screen and (min-width: @breakDesktopWide) {
         background-image: url('/media/img/newsletter/intro-mozsummit-3000.jpg');
@@ -55,6 +56,12 @@
         display: block;
         padding: 0 10px;
     }
+
+    .moz-search {
+        position: absolute;
+        top: 0;
+    }
+
 }
 
 .content-main {

--- a/media/css/mozorg/manifesto.less
+++ b/media/css/mozorg/manifesto.less
@@ -25,6 +25,29 @@
     overflow: hidden; /* Avoid overflows by the picture grids */
 }
 
+#wrapper {
+    width: 100%;
+}
+
+#masthead,
+#main-content,
+.content {
+    width: @widthDesktop;
+    margin: 0 auto;
+
+    @media only screen and (min-width: @breakTablet) and (max-width: @breakDesktop) {
+        width: @widthTablet;
+    }
+
+    @media only screen and (max-width: @breakTablet) {
+        width: @widthMobile;
+    }
+
+    @media only screen and (min-width: @breakMobileLandscape) and (max-width: @breakTablet) {
+        width: @widthMobileLandscape;
+    }
+}
+
 #main-feature {
     padding: 40px 20px;
     text-align: center;
@@ -36,14 +59,14 @@
 
     p {
         margin: 20px auto 0;
-        width: 620px;
+        max-width: 620px;
         color: #4E4F53;
         .font-size(20px);
     }
 }
 
-#main-content {
-    padding: 0;
+.moz-search {
+    margin-bottom: 20px;
 }
 
 #main-content-inner {
@@ -55,6 +78,10 @@
 
     & > section:not(:first-of-type) {
         margin-top: 40px;
+    }
+
+    @media only screen and (max-width: @breakTablet) {
+        width: auto;
     }
 }
 
@@ -470,13 +497,13 @@
 
 
 #mosaic-column-1 {
-    left: -50px;
+    left: -30px;
     background: url('/media/img/mozorg/about/manifesto/bg-faces-2.png') 0 0 no-repeat,
                 url('/media/img/mozorg/about/manifesto/bg-faces-1.png') 0 1440px no-repeat;
 }
 
 #mosaic-column-2 {
-    right: -50px;
+    right: -30px;
     background: url('/media/img/mozorg/about/manifesto/bg-faces-1.png') 0 0 no-repeat,
                 url('/media/img/mozorg/about/manifesto/bg-faces-2.png') 0 1440px no-repeat;
 }
@@ -858,11 +885,11 @@ html[dir="rtl"] {
 
 @media only screen and (min-width: @breakTablet) and (max-width: @breakDesktop) {
     #mosaic-column-1 {
-        left: -190px;
+        left: -150px;
     }
 
     #mosaic-column-2 {
-        right: -190px;
+        right: -150px;
     }
 
     html.js {
@@ -877,10 +904,6 @@ html[dir="rtl"] {
 /* Mobile */
 
 @media only screen and (max-width: @breakTablet) {
-    #main-content-inner {
-        width: auto;
-    }
-
     #main-feature p {
         width: auto;
     }

--- a/media/css/pebbles/components/google-search.scss
+++ b/media/css/pebbles/components/google-search.scss
@@ -1,0 +1,127 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+@import '../includes/lib';
+
+
+// Custom Google search
+
+.moz-search {
+    @include clearfix;
+    background: $color-mozred;
+    color: #fff;
+    display: none;
+    padding: 10px 0;
+    width: 100%;
+
+    .content {
+        @include clearfix;
+        margin: 0 auto;
+        padding: 0 10px;
+    }
+
+    .search-label {
+        @include font-size(16px);
+        display: block;
+        line-height: 1.25;
+        margin: 0 0 .5em;
+        padding: .25em 0;
+
+        @media #{$mq-tablet} {
+            float: left;
+            margin-bottom: 0;
+            width: 50%;
+        }
+    }
+
+    .search-label-term {
+        cursor: pointer;
+    }
+
+    .gsc-control-cse {
+        background: transparent !important;
+        border: 0 !important;
+        font-family: inherit !important;
+        padding: 0 !important;
+
+        table {
+            border-collapse: collapse;
+            margin: 0;
+        }
+
+        @media #{$mq-tablet} {
+            float: right;
+            width: 40%;
+        }
+    }
+
+    form.gsc-search-box {
+        margin: 0;
+        position: relative;
+    }
+
+    .gsc-search-box-tools .gsc-search-box .gsc-input,
+    .gsib_a {
+        padding: 0;
+    }
+
+    .gsc-input-box {
+        border-radius: 6px;
+        height: 2em;
+        padding: 2px 35px 2px 10px;
+
+        table {
+            height: 100%;
+        }
+    }
+
+    input.gsc-input {
+        font-family: inherit !important;
+        min-height: 20px !important;
+        padding: .25em 0 !important;
+
+        &:focus {
+            box-shadow: none;
+        }
+    }
+
+    input.gsc-search-button {
+        border-radius: 5px;
+        margin: 0;
+        min-width: 0;
+        padding: 5px;
+        position: absolute;
+        right: 8px;
+        top: 4px;
+    }
+}
+
+.js .moz-search {
+    display: block;
+}
+
+.gsc-results-wrapper-overlay {
+    @include border-box;
+    left: 5% !important;
+    width: 90% !important;
+
+    @media #{$mq-tablet} {
+        width: 70% !important;
+        left: 15% !important;
+    }
+
+    .gsc-table-result,
+    .gsc-thumbnail-inside,
+    .gsc-url-top {
+        padding: 0;
+    }
+
+    .gsc-result .gs-title {
+        height: auto !important;
+    }
+}
+
+.gsc-modal-background-image {
+    background-color: #000 !important;
+}

--- a/media/js/base/search-activist.js
+++ b/media/js/base/search-activist.js
@@ -1,0 +1,64 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+(function($) {
+    'use strict';
+
+    var $searchBar = $('#moz-search');
+    var terms = $searchBar.data('terms').split(',');
+    var displayTerm = $('.search-label-term');
+    var searchField;
+    var searchButton;
+
+    // Cycle through suggested terms
+    function changeTerm() {
+        var term = displayTerm.data('term') || 0;
+        displayTerm.data('term', term === terms.length -1 ? 0 : term + 1).text(terms[term]).fadeIn(150).delay(3500).fadeOut(150, changeTerm);
+    }
+    changeTerm();
+
+    // Click on a suggested term to fill the field
+    displayTerm.on('click', function() {
+        searchField.val(displayTerm.text());
+    });
+
+    // Activist search
+    var cx = '014783244707853607354:bbpl3emdsii';
+    var gcse = document.createElement('script');
+    gcse.type = 'text/javascript';
+    gcse.async = true;
+    gcse.src = 'https://cse.google.com/cse.js?cx=' + cx;
+    var s = document.getElementsByTagName('script')[0];
+    s.parentNode.insertBefore(gcse, s);
+
+    var setGTMSearch = function() {
+        var element = window.google.search.cse.element.getElement('mozsearch');
+        var query = element.getInputQuery();
+
+        // GTM
+        window.dataLayer.push({
+            'search-query': query,
+            'event': 'gcs-search'
+        });
+    };
+
+    // Add event handlers
+    var initMozSearch = function() {
+        searchField = $('input#gsc-i-id1');
+        searchButton = $('input.gsc-search-button');
+
+        searchButton.on('click', setGTMSearch);
+        searchField.keyup(function(e) {
+            if (e.keyCode === 13 || e.which === 13) { // Enter
+                setGTMSearch();
+            }
+        });
+    };
+
+    // Setup callback for when CSE is ready
+    window.__gcse = {
+        callback: initMozSearch
+    };
+
+})(jQuery);

--- a/media/js/mozorg/experiment-search-activist.js
+++ b/media/js/mozorg/experiment-search-activist.js
@@ -1,0 +1,17 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+(function() {
+    'use strict';
+
+    var cop = new Mozilla.TrafficCop({
+        id: 'experiment-search-activist',
+        variations: {
+            'v=a': 90,
+            'v=b': 10
+        }
+    });
+
+    cop.init();
+})(window.Mozilla);


### PR DESCRIPTION
## Description
Adds a Google custom search box to a few pages:
* /about
* /about/manifesto
* /foundation/*

This is the "Activist" search indexing sites mostly focused on advocacy, web education, internet health, etc.

The test will be English only and uses the switch `mozorg-search-activist`.

## Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1319244

## Testing
Mostly visual, since we're doing some CSS hackery to customize the look of their search box. Also verify searching works as expected and doesn't throw JavaScript errors.


