### PR TITLE
[fix bug 1321033] Hello EOL legal doc cleanup/archival.

### DIFF
--- a/bedrock/legal/redirects.py
+++ b/bedrock/legal/redirects.py
@@ -4,4 +4,7 @@ from bedrock.redirects.util import redirect
 redirectpatterns = (
     # bug 1243240
     redirect(r'^about/legal/report-abuse/?$', 'legal.report-infringement'),
+
+    # bug 1321033
+    redirect(r'^about/legal/terms/firefox-hello', 'privacy.archive.hello-2014-11'),
 )

--- a/bedrock/legal/templates/legal/index.html
+++ b/bedrock/legal/templates/legal/index.html
@@ -23,7 +23,6 @@
       <li class="terms-firefox"><a href="{{ url('legal.terms.services') }}"><span>{{ _('Firefox Services') }}</span></a></li>
       <li class="terms-webmaker"><a href="https://webmaker.org/#/legal"><span>{{ _('Webmaker') }}</span></a></li>
       <li class="terms-marketplace"><a href="https://marketplace.firefox.com/terms-of-use"><span>{{ _('Firefox Marketplace') }}</span></a></li>
-      <li class="terms-firefox-hello"><a href="{{ url('legal.terms.firefox-hello') }}"><span>{{ _('Firefox Hello') }}</span></a></li>
     </ul>
   </section>
 

--- a/bedrock/legal/templates/legal/terms/firefox-hello.html
+++ b/bedrock/legal/templates/legal/terms/firefox-hello.html
@@ -1,7 +1,0 @@
-{# This Source Code Form is subject to the terms of the Mozilla Public
- # License, v. 2.0. If a copy of the MPL was not distributed with this
- # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
-
-{% extends "legal/docs-base.html" %}
-
-{% block page_title %}{{ _('Firefox Hello Terms of Service') }}{% endblock %}

--- a/bedrock/legal/urls.py
+++ b/bedrock/legal/urls.py
@@ -25,9 +25,6 @@ urlpatterns = (
     url(r'^terms/firefox/$', LegalDocView.as_view(template_name='legal/terms/firefox.html', legal_doc_name='firefox_about_rights'),
         name='legal.terms.firefox'),
 
-    url(r'^terms/firefox-hello/$', LegalDocView.as_view(template_name='legal/terms/firefox-hello.html', legal_doc_name='WebRTC_ToS'),
-        name='legal.terms.firefox-hello'),
-
     url(r'^terms/thunderbird/$', LegalDocView.as_view(template_name='legal/terms/thunderbird.html', legal_doc_name='thunderbird_about_rights'),
         name='legal.terms.thunderbird'),
 

--- a/bedrock/privacy/redirects.py
+++ b/bedrock/privacy/redirects.py
@@ -7,4 +7,7 @@ redirectpatterns = (
     # special de URL should not be accessible from other locales
     no_redirect(r'^de/privacy/firefox-klar/?', locale_prefix=False),
     redirect(r'^privacy/firefox-klar/?', 'privacy.notices.firefox-focus'),
+
+    # bug 1321033 - Hello EOL
+    redirect(r'^privacy/firefox-hello/?$', 'privacy.archive.hello-2016-03'),
 )

--- a/bedrock/privacy/templates/privacy/archive/hello-2014-11.html
+++ b/bedrock/privacy/templates/privacy/archive/hello-2014-11.html
@@ -1,0 +1,215 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+
+{% extends "privacy/base-resp.html" %}
+
+{% block page_title %}Firefox Hello Terms of Service — Archived, November 25, 2014{% endblock %}
+
+{% block body_id %}hello-archived{% endblock %}
+
+{% block article %}
+<article class="section-content" itemscope itemtype="http://schema.org/Article">
+  <header>
+    <img class="logo" src="{{ static('img/privacy/logo-firefox-hello.png') }}" alt="Firefox Hello">
+    <h1 itemprop="name">Firefox Hello Terms of Service</h1>
+    <p class="meta">
+      <time datetime="2014-11-25" itemprop="dateModified">Archived, November 25, 2014</time>
+    </p>
+  </header>
+  <div itemprop="articleBody" class="article-body">
+    <section id="1-introduction">
+      <h3>1. Introduction</h3>
+      <p>
+        Firefox Hello is an end-to-end real-time communications video and
+        voice service (“Service”) by Mozilla. Please read this entire
+        document (“Terms”) carefully because it explains your rights and
+        responsibilities when you use Firefox Hello to send or receive
+        communications.
+      </p>
+    </section>
+    <section id="2-account-registration">
+      <h3>2. Account Registration</h3>
+      <p>
+        A Firefox Account may be required to use certain features of the
+        Service, such as importing your contacts from another service or
+        creating new contacts. If you sign up for a Firefox Account, you
+        agree to its <a href="{{ url('legal.terms.services') }}">Terms of
+        Service</a> and
+        <a href="{{ url('privacy.notices.firefox-cloud') }}">Privacy Notice</a>.
+      </p>
+    </section>
+    <section id="3-features">
+      <h3>3. Features</h3>
+      <p>
+        The Service is provided to you in collaboration with TokBox, Inc.
+        (TokBox is also referred to in this document as a licensor). The
+        Service is integrated into Firefox so you can easily make voice and
+        video calls between Firefox and users of any WebRTC-enabled browser
+        or device. The Service is subject to change. Please reference
+        Mozilla’s
+        <a href="https://support.mozilla.org/products/firefox">support site</a>
+        for questions on features.
+      </p>
+    </section>
+    <section id="4-privacy-policy">
+      <h3>4. Privacy Policy</h3>
+      <p>
+        The <a href="{{ url('privacy.archive.hello-2016-03') }}">Firefox
+        Hello Privacy Notice</a> explains what information is sent when you
+        use the Service and how that information is handled.
+      </p>
+    </section>
+    <section id="5-content-use">
+      <h3>5. Content &amp; Use</h3>
+      <p>
+        You understand that the Service allows users to transmit certain
+        information (such as video or images) (“Content”). You hereby grant
+        Mozilla and our licensors all rights necessary to provide the
+        Service and you agree that your use of the Service will comply with
+        Mozilla’s
+        <a href="{{ url('legal.terms.acceptable-use') }}">Conditions of
+        Use</a>. You are solely responsible for the Content you transmit and
+        the consequences.
+      </p>
+      <p>
+        For more information on how to report a claim of copyright or
+        trademark abuse, please see
+        <a href="{{ url('legal.report-infringement') }}">here</a>.
+      </p>
+    </section>
+    <section id="6-mozillas-and-tokboxs-proprietary-rights">
+      <h3>6. Mozilla's and TokBox’s Proprietary Rights</h3>
+      <p>
+        Neither Mozilla nor its licensors grant you any intellectual
+        property rights in the Service that are not specifically stated in
+        these Terms. For example, these Terms do not provide the right to
+        use any copyrights, trade names, trademarks, service marks, logos,
+        domain names, or other distinctive brand features of Mozilla or its
+        licensors.
+      </p>
+      <p>
+        The Mozilla software is distributed under and subject to the current
+        version of the Mozilla Public License, or other similarly permissive
+        licenses.
+      </p>
+    </section>
+    <section id="7-services-interruption-term-termination">
+      <h3>7. Services Interruption; Term; Termination</h3>
+      <p>
+        From time to time, we may need to perform maintenance on or upgrade
+        the Service, or temporarily suspend part or all of the Service.
+        Notice is not always possible. You will not be entitled to claim
+        expenses or damages for such suspension or limitation of the use of
+        the Service.
+      </p>
+      <p>
+        These Terms apply to your use of the Service and will continue to
+        apply until ended by either you or upon notice from Mozilla or
+        TokBox. You can choose to end them at any time for any reason by
+        discontinuing your use of the Service.
+      </p>
+      <p>
+        We may suspend or terminate your access to the Service or your
+        Firefox Account at any time for any reason, including, but not
+        limited to, if we reasonably believe: (i) you have violated these
+        Terms (ii) you create risk or possible legal exposure for Mozilla or
+        TokBox; or (iii) the provision of the Service to you is no longer
+        commercially viable. If possible, we will make reasonable efforts to
+        notify you by the email address associated with your Firefox Account
+        or the next time you attempt to access the Service.
+      </p>
+      <p>
+        In all such cases, these Terms shall terminate, including, without
+        limitation, your license to use the Service, except that the
+        following sections shall continue to apply: Indemnification,
+        Disclaimer; Limitation of Liability and Miscellaneous.
+      </p>
+    </section>
+    <section id="8-indemnification">
+      <h3>8. Indemnification</h3>
+      <p>
+        You agree to defend, indemnify and hold harmless Mozilla, TokBox and
+        their respective parent and affiliate companies, contractors,
+        contributors, licensors, partners, directors, officers, employees
+        and agents ("Indemnified Parties") from and against any and all
+        third party claims and expenses, including attorneys' fees, arising
+        out of or related to your use of the Services (including, but not
+        limited to, from any Content transmitted by you).
+      </p>
+    </section>
+    <section id="9-disclaimer-limitation-of-liability">
+      <h3>9. Disclaimer; Limitation of Liability</h3>
+      <p>
+        THE SERVICES ARE PROVIDED "AS IS" WITH ALL FAULTS. TO THE EXTENT
+        PERMITTED BY LAW, THE INDEMNIFIED PARTIES, HEREBY DISCLAIM ALL
+        WARRANTIES, WHETHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION
+        WARRANTIES THAT THE SERVICES ARE FREE OF DEFECTS, MERCHANTABLE, FIT
+        FOR A PARTICULAR PURPOSE, AND NON-INFRINGING.
+      </p>
+      <p>
+        YOU BEAR THE ENTIRE RISK AS TO SELECTING THE SERVICES FOR YOUR
+        PURPOSES AND AS TO THE QUALITY AND PERFORMANCE OF THE SERVICES,
+        INCLUDING WITHOUT LIMITATION THE RISK THAT YOUR CONTENT IS DELETED
+        OR CORRUPTED OR THAT SOMEONE ELSE ACCESSES YOUR ACCOUNT.
+      </p>
+      <p>
+        THIS LIMITATION WILL APPLY NOTWITHSTANDING THE FAILURE OF ESSENTIAL
+        PURPOSE OF ANY REMEDY. SOME JURISDICTIONS DO NOT ALLOW THE EXCLUSION
+        OR LIMITATION OF IMPLIED WARRANTIES, SO THIS DISCLAIMER MAY NOT
+        APPLY TO YOU.
+      </p>
+      <p>
+        EXCEPT AS REQUIRED BY LAW, THE INDEMNIFIED PARTIES, WILL NOT BE
+        LIABLE FOR ANY INDIRECT, SPECIAL, INCIDENTAL, CONSEQUENTIAL, OR
+        EXEMPLARY DAMAGES ARISING OUT OF OR IN ANY WAY RELATING TO THESE
+        TERMS OR THE USE OF OR INABILITY TO USE THE SERVICES, INCLUDING
+        WITHOUT LIMITATION DIRECT AND INDIRECT DAMAGES FOR LOSS OF GOODWILL,
+        WORK STOPPAGE, LOST PROFITS, LOSS OF DATA, AND COMPUTER FAILURE OR
+        MALFUNCTION, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGES AND
+        REGARDLESS OF THE THEORY (CONTRACT, TORT, OR OTHERWISE) UPON WHICH
+        SUCH CLAIM IS BASED. THE COLLECTIVE LIABILITY OF THE INDEMNIFIED
+        PARTIES, UNDER THIS AGREEMENT WILL NOT EXCEED $500 (FIVE HUNDRED
+        DOLLARS). SOME JURISDICTIONS DO NOT ALLOW THE EXCLUSION OR
+        LIMITATION OF INCIDENTAL, CONSEQUENTIAL, OR SPECIAL DAMAGES, SO THIS
+        EXCLUSION AND LIMITATION MAY NOT APPLY TO YOU.
+      </p>
+    </section>
+    <section id="10-modifications-to-these-terms">
+      <h3>10. Modifications to these Terms</h3>
+      <p>
+        These Terms may be updated from time to time to address a new
+        feature of the Service or to clarify a provision. The updated Terms
+        will be posted online. If the changes are substantive, we will
+        announce the update through Mozilla's usual channels for such
+        announcements such as blog posts and forums. Your continued use of
+        the Service after the effective date of such changes constitutes
+        your acceptance of such changes. To make your review more
+        convenient, we will post an effective date at the top of this page.
+      </p>
+    </section>
+    <section id="11-miscellaneous">
+      <h3>11. Miscellaneous</h3>
+      <p>
+        These Terms constitute the entire agreement between you, Mozilla and
+        TokBox concerning the Services and are governed by the laws of the
+        state of California, U.S.A., excluding its conflict of law
+        provisions. If any portion of these Terms is held to be invalid or
+        unenforceable, the remaining portions will remain in full force and
+        effect. In the event of a conflict between a translated version of
+        these terms and the English language version, the English language
+        version shall control.
+      </p>
+    </section>
+    <section id="12-contact-us">
+      <h3>12. Contact Us</h3>
+      <p>
+        Contact Mozilla at: Mozilla Corporation (Attn: Mozilla – Legal
+        Notices, 2 Harrison Street, San Francisco CA 94105) or via e-mail
+        to:
+        <a href="&#109;&#97;&#105;&#108;&#116;&#111;&#58;&#108;&#101;&#103;&#97;&#108;&#45;&#110;&#111;&#116;&#105;&#99;&#101;&#115;&#64;&#109;&#111;&#122;&#105;&#108;&#108;&#97;&#46;&#99;&#111;&#109;">&#108;&#101;&#103;&#97;&#108;&#45;&#110;&#111;&#116;&#105;&#99;&#101;&#115;&#64;&#109;&#111;&#122;&#105;&#108;&#108;&#97;&#46;&#99;&#111;&#109;</a>.
+      </p>
+    </section>
+  </div>
+</article>
+{% endblock %}

--- a/bedrock/privacy/templates/privacy/archive/hello-2016-03.html
+++ b/bedrock/privacy/templates/privacy/archive/hello-2016-03.html
@@ -1,0 +1,186 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+
+{% extends "privacy/base-resp.html" %}
+
+{% block page_title %}Firefox Hello Privacy Policy — Archived, March 16, 2016{% endblock %}
+
+{% block body_id %}hello-archived{% endblock %}
+
+{% block article %}
+<article class="section-content" itemscope itemtype="http://schema.org/Article">
+  <header>
+    <img class="logo" src="{{ static('img/privacy/logo-firefox-hello.png') }}" alt="Firefox Hello">
+    <h1 itemprop="name">Firefox Hello Privacy Notice</h1>
+    <p class="meta">
+      <time datetime="2016-03-16" itemprop="dateModified">Archived, March 16, 2016</time>
+    </p>
+    <p>
+      We care about your privacy. When Hello sends information to Mozilla
+      (that's us) our Mozilla Privacy Policy describes how we use that
+      information.
+    </p>
+  </header>
+  <div itemprop="articleBody">
+    <section class="highlight accordion" id="things-you-should-know">
+      <header><h2>Things you should know:</h2></header>
+      <div>
+        <p role="tab">
+          When you make calls, the data below is sent to Mozilla in order to
+          connect the call. Once connected, your communications are encrypted.
+        </p>
+
+        <ul role="tabpanel">
+          <li>
+            <p>
+              <strong>Firefox Accounts</strong>: Accounts are optional to use
+              with Firefox Hello. If you sign-in with a Firefox Account, your
+              Firefox browser sends Mozilla your account name in order to
+              direct calls to you. To learn more about how data is used by
+              Firefox Accounts, click
+              <a href="{{ url('privacy.notices.firefox-cloud') }}">here</a>.
+            </p>
+          </li>
+          <li>
+            <p>
+              <strong>Contact Information</strong>: You can import or add new
+              contacts to create an address book with email addresses, profile
+              pictures, and names of people you may call. This contact
+              information is stored locally on your device. When you use the
+              Service, your Firefox browser encrypts your contact's
+              information and sends it to us to connect calls.  If your call
+              is through a conversation URL that you generate, we delete the
+              contact information after 30 days but you can delete it sooner
+              by revoking the conversation URL. Otherwise, for direct calls,
+              we delete this information once the call is finished.
+            </p>
+          </li>
+          <li>
+            <p>
+              <strong>Feedback &amp; Support</strong>: Sending feedback to
+              Mozilla is optional. You can provide us with information if you
+              submit a crash report or a report on our support forum.
+            </p>
+          </li>
+        </ul>
+
+        <hr/>
+
+        <p role="tab">
+          We automatically receive certain metrics from use of the Service.
+        </p>
+
+        <ul role="tabpanel">
+          <li>
+            <p>
+              <strong>Performance metrics</strong>: We automatically receive
+              performance and responsiveness data about calls and attempted
+              calls in order to detect issues, diagnose them, and improve
+              Firefox Hello. For example, the data we receive includes quality
+              for audio and video streams, whether calls failed or were
+              disconnected, duration of the call, obfuscated IP addresses,
+              obfuscated network and hardware data (e.g. if you are on a wifi
+              or cellular network) and timestamps.
+            </p>
+          </li>
+          <li>
+            <p>
+              <strong>Usage metrics</strong>: We receive data on how many
+              people use the Service, types of operating systems and browsers,
+              and countries in which the Service is used.
+            </p>
+          </li>
+          <li>
+            <p>
+              <strong>Reports</strong>: We share aggregate information on
+              performance and usage metrics.
+            </p>
+          </li>
+          <li>
+            <p>
+              <strong>Analytics</strong>: If you use the web-based Hello
+              client to join a conversation by following a link to
+              https://hello.firefox.com, we may also use cookies and third
+              party services to help us understand in the aggregate how users
+              engage with Hello. We use:
+            </p>
+
+            <ul>
+              <li>
+                <p>
+                  Google Analytics, which places a cookie on your device, to
+                  obtain metrics on how users engage with Hello. This helps us
+                  to improve the Hello service.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Optimizely, which places a cookie on your device, to help us
+                  test variations of Hello. This helps us offer better
+                  experiences to Hello users.
+                </p>
+              </li>
+            </ul>
+          </li>
+          <li>
+            <p>
+              <strong>Tiles</strong>: Tiles are a feature of Hello which may
+              be displayed during a conversation or while a user is waiting
+              for a conversation to begin. In order to provide the tiles
+              feature, Hello sends to Mozilla data relating to the tiles such
+              as number of clicks, impressions, your IP address, and locale
+              information.
+            </p>
+          </li>
+        </ul>
+
+        <hr/>
+
+        <p role="tab">
+          You can control individual cookie preferences and opt-out of web
+          analytics and optimization tools.
+        </p>
+
+        <ul role="tabpanel">
+          <li>
+            <p>
+              <strong>Cookie History</strong>: You can accept or decline
+              individual cookies in the preferences in the appropriate
+              settings within your web browser. For Firefox, this can be found
+              in the Tools/Options/Privacy history section. Note that certain
+              features of Hello may not function properly without the aid of
+              cookies.
+            </p>
+          </li>
+          <li>
+            <p>
+              <strong>Analytics &amp; Optimization</strong>: If you do not
+              want data about your interaction with Hello to be collected by
+              Google Analytics, you can install the
+              <a href="https://tools.google.com/dlpage/gaoptout">Google
+              Analytics Opt-out Browser Add-on</a>. The add-on keeps your
+              visits anonymous and prohibits data transmission to Google
+              Analytics. If you do not want data about your interaction with
+              Hello to be collected by Optimizely, you can opt-out by visiting
+              <a href="https://www.optimizely.com/opt_out">Optimizely's
+              opt-out website</a> for more information.
+            </p>
+          </li>
+        </ul>
+
+        <hr/>
+
+        <p role="tab">
+          Firefox Hello is provided to you in collaboration with TokBox, Inc.
+          ("TokBox") and sends data to TokBox as a part of the function of the
+          service. This notice only describes how Mozilla handles information
+          we receive from you. For more information on TokBox’s handling of
+          data, you should read their
+          <a href="https://tokbox.com/support/privacy-policy">Privacy Policy</a>
+        </p>
+      </div>
+    </section>
+  </div>
+</article>
+{% endblock %}

--- a/bedrock/privacy/templates/privacy/archive/index.html
+++ b/bedrock/privacy/templates/privacy/archive/index.html
@@ -33,6 +33,13 @@
       </ul>
     </section>
     <section>
+      <h2>{{ _('Hello') }}</h2>
+      <ul>
+        <li><a href="{{ url('privacy.archive.hello-2014-11') }}">{{ _('November 2014') }}</a></li>
+        <li><a href="{{ url('privacy.archive.hello-2016-03') }}">{{ _('March 2016') }}</a></li>
+      </ul>
+    </section>
+    <section>
       <h2>{{ _('Thunderbird') }}</h2>
       <ul>
         <li><a href="{{ url('privacy.archive.thunderbird-2010-06') }}"><time datetime="2010-06">{{ _('June 2010') }}</time></a></li>

--- a/bedrock/privacy/urls.py
+++ b/bedrock/privacy/urls.py
@@ -13,7 +13,6 @@ urlpatterns = (
     url(r'^/firefox/$', views.firefox_notices, name='privacy.notices.firefox'),
     url(r'^/firefox-os/$', views.firefox_os_notices, name='privacy.notices.firefox-os'),
     url(r'^/firefox-cloud/$', views.firefox_cloud_notices, name='privacy.notices.firefox-cloud'),
-    url(r'^/firefox-hello/$', views.firefox_hello_notices, name='privacy.notices.firefox-hello'),
     url(r'^/firefox-focus/$', views.firefox_focus_notices, name='privacy.notices.firefox-focus'),
     # bug 1319207 - special URL for Firefox Focus in de locale
     url(r'^/firefox-klar/$', views.firefox_focus_notices, name='privacy.notices.firefox-klar'),
@@ -34,6 +33,8 @@ urlpatterns = (
     page('/archive/firefox/2012-12', 'privacy/archive/firefox-2012-12.html'),
     page('/archive/firefox/2013-05', 'privacy/archive/firefox-2013-05.html'),
     page('/archive/firefox/third-party', 'privacy/archive/firefox-third-party.html'),
+    page('/archive/hello/2014-11', 'privacy/archive/hello-2014-11.html'),
+    page('/archive/hello/2016-03', 'privacy/archive/hello-2016-03.html'),
     page('/archive/thunderbird/2010-06', 'privacy/archive/thunderbird-2010-06.html'),
     page('/archive/websites/2013-08', 'privacy/archive/websites-2013-08.html'),
 )

--- a/tests/functional/test_generated_pages.py
+++ b/tests/functional/test_generated_pages.py
@@ -29,7 +29,6 @@ def pytest_generate_tests(metafunc):
         '/privacy/firefox/',
         '/privacy/firefox-os/',
         '/privacy/firefox-cloud/',
-        '/privacy/firefox-hello/',
         '/privacy/thunderbird/',
         '/security/',
         '/security/advisories/',


### PR DESCRIPTION
## Description

Archives the current Hello [privacy policy](https://www.mozilla.org/privacy/firefox-hello/) and [terms of service](https://www.mozilla.org/about/legal/terms/firefox-hello/). Adds redirects from decommissioned URLs to the new archive pages.

## Bugzilla link

https://bugzilla.mozilla.org/show_bug.cgi?id=1321033

## Testing

Content on archive pages is copy/paste from HTML generated by existing legal docs markdown, so double check tag completion/nesting. Make sure redirects work as expected.

## Checklist
- [ ] Related functional & integration tests passing.

