### PR TITLE
Fix Bug 1301650 - Implement mozilla.org/firefox/android/nightly/all to list all localized Fennec Nightly builds

### DIFF
--- a/bedrock/firefox/templates/firefox/all.html
+++ b/bedrock/firefox/templates/firefox/all.html
@@ -23,7 +23,7 @@
   {%- if channel == 'beta' -%}
     {{ _('Download Firefox Beta in your language and experience cutting edge features before they make it to final release. Provide feedback to help us refine and polish the next version of Firefox.') }}
   {%- elif channel == 'alpha' -%}
-    {{ _('Download Firefox Developer Edition in your language to experience the newest features and innovations in an unstable environment even before they go to Beta. Give us feedback that will determine what makes it to Final Release and help shape the future of Firefox.') }}
+    {{ _('Download %s in your language to experience the newest features and innovations in an unstable environment even before they go to Beta. Give us feedback that will determine what makes it to Final Release and help shape the future of Firefox.')|format(channel_label) }}
   {%- elif channel == 'nightly' -%}
     {{ _('Are you a power-user comfortable installing pre-alpha software? Install Nightly and help us improve Firefox quality, hunt crashes and regressions and test new features as they get coded!') }}
   {%- elif channel == 'esr' -%}
@@ -34,7 +34,7 @@
 {% endblock %}
 
 {% block page_favicon %}
-  {%- if channel == 'alpha' -%}
+  {%- if platform == 'desktop' and channel == 'alpha' -%}
     {{ static('img/firefox/developer/favicon.png') }}
   {%- elif channel == 'nightly' -%}
     {{ static('img/firefox/nightly/favicon.png') }}
@@ -44,7 +44,7 @@
 {% endblock %}
 
 {% block page_favicon_large %}
-  {%- if channel == 'alpha' -%}
+  {%- if platform == 'desktop' and channel == 'alpha' -%}
     {{ static('img/firefox/developer/favicon-196.png') }}
   {%- elif channel == 'nightly' -%}
     {{ static('img/firefox/nightly/favicon-196.png') }}
@@ -54,7 +54,7 @@
 {% endblock %}
 
 {% block page_image %}
-  {%- if channel == 'alpha' -%}
+  {%- if platform == 'desktop' and channel == 'alpha' -%}
     {{ static('img/firefox/developer/page-image.png') }}
   {%- elif channel == 'nightly' -%}
     {{ static('img/firefox/nightly/page-image.png') }}
@@ -65,7 +65,7 @@
 
 {% block body_id %}firefox-all{% endblock %}
 {% block body_class -%}
-  sky {{ platform }} {{ channel }} {% if channel == 'alpha' %}blueprint{% endif %}
+  sky {{ platform }} {{ channel }} {% if platform == 'desktop' and channel == 'alpha' %}blueprint{% endif %}
 {% endblock %}
 
 {% block page_css %}
@@ -79,7 +79,7 @@
 {% endblock %}
 
 {% block site_header_logo %}
-  {% if channel == 'alpha' %}
+  {% if platform == 'desktop' and channel == 'alpha' %}
     <h2><a href="{{ url('firefox.developer') }}">{{ high_res_img('firefox/developer/title.png', {'alt': _('Firefox Developer Edition'), 'width': '220', 'height': '84'}) }}</a></h2>
   {% elif channel == 'nightly' %}
     <h2>{{ high_res_img('firefox/template/header-logo-nightly.png', {'alt': _('Firefox Nightly'), 'width': '305', 'height': '70'}) }}</h2>
@@ -112,7 +112,10 @@
     </ul>
   </header>
 
-  {{ build_search_box(query, full_builds, test_builds) }}
+
+  {% if platform == 'desktop' %}
+    {{ build_search_box(query, full_builds, test_builds) }}
+  {% endif %}
 
   <main id="main-content" role="main" class="pager pager-with-tabs pager-no-history">
   {% if full_builds_next %}
@@ -178,7 +181,7 @@
 
 {% block js %}
   {# searching with js only makes sense if we're displaying all #}
-  {% if not query %}
+  {% if platform == 'desktop' and not query %}
     {% javascript 'firefox_all' %}
   {% endif %}
 {% endblock %}

--- a/bedrock/firefox/templates/firefox/channel/android.html
+++ b/bedrock/firefox/templates/firefox/channel/android.html
@@ -57,6 +57,7 @@
     <div class="container">
       <ul>
         <li><a href="{{ firefox_url('android', 'notes', 'aurora') }}">{{_('Release Notes')}}</a></li>
+        <li><a href="{{ firefox_url('android', 'all', 'aurora') }}">{{_('All Languages and Builds')}}</a></li>
       </ul>
     </div>
   </footer>
@@ -83,6 +84,7 @@
     <div class="container">
       <ul>
         <li><a rel="external" href="https://blog.nightly.mozilla.org/">{{_('Nightly Blog')}}</a></li>
+        <li><a href="{{ firefox_url('android', 'all', 'nightly') }}">{{_('All Languages and Builds')}}</a></li>
       </ul>
     </div>
   </footer>

--- a/bedrock/firefox/tests/test_base.py
+++ b/bedrock/firefox/tests/test_base.py
@@ -150,26 +150,22 @@ class TestFirefoxAll(TestCase):
 
     def test_android(self):
         """
-        Android x64 builds are only available in multi and en-US locales.
+        The Firefox for Android download table should only show the multi-locale
+        builds for api-15 and x86.
         """
         resp = self.client.get(self._get_url('android'))
         doc = pq(resp.content)
-        eq_(len(doc('tr#multi a')), 2)
-        eq_(len(doc('tr#multi .android-x86')), 1)
-        eq_(len(doc('tr#en-US a')), 2)
-        eq_(len(doc('tr#en-US .android-x86')), 1)
-        eq_(len(doc('tr#fr a')), 1)
-        eq_(len(doc('tr#fr .android-x86')), 0)
+        eq_(len(doc('tbody tr')), 1)
+        eq_(len(doc('tbody tr#multi a')), 2)
+        eq_(len(doc('tbody tr#multi .android')), 1)
+        eq_(len(doc('tbody tr#multi .android-x86')), 1)
 
     def test_404(self):
         """
-        Firefox for iOS and Firefox Aurora for Android don't have the /all/ page.
-        Also, Firefox for Android doesn't have the ESR channel.
+        Firefox for iOS doesn't have the /all/ page. Also, Firefox for Android
+        doesn't have the ESR channel.
         """
         resp = self.client.get(self._get_url('ios'))
-        self.assertEqual(resp.status_code, 404)
-
-        resp = self.client.get(self._get_url('android', 'aurora'))
         self.assertEqual(resp.status_code, 404)
 
         resp = self.client.get(self._get_url('android', 'organizations'))

--- a/bedrock/firefox/tests/test_firefox_details.py
+++ b/bedrock/firefox/tests/test_firefox_details.py
@@ -377,7 +377,7 @@ class TestFirefoxAndroid(TestCase):
     def test_get_download_url_nightly(self):
         """
         get_download_url should return a mozilla-central archive link depending
-        on the architecture type.
+        on the architecture type, even if the force_direct option is unspecified.
         """
         eq_(firefox_android.get_download_url('nightly', 'api-15'),
             self.archive_url_base + 'latest-mozilla-central-android-api-15/'
@@ -386,10 +386,22 @@ class TestFirefoxAndroid(TestCase):
             self.archive_url_base + 'latest-mozilla-central-android-x86/'
             'fennec-25.0a1.multi.android-i386.apk')
 
+    def test_get_download_url_nightly_direct(self):
+        """
+        get_download_url should return a mozilla-central archive link depending
+        on the architecture type, if the force_direct option is True.
+        """
+        eq_(firefox_android.get_download_url('nightly', 'api-15', 'multi', True),
+            self.archive_url_base + 'latest-mozilla-central-android-api-15/'
+            'fennec-25.0a1.multi.android-arm.apk')
+        eq_(firefox_android.get_download_url('nightly', 'x86', 'multi', True),
+            self.archive_url_base + 'latest-mozilla-central-android-x86/'
+            'fennec-25.0a1.multi.android-i386.apk')
+
     def test_get_download_url_aurora(self):
         """
         get_download_url should return a mozilla-aurora archive link depending
-        on the architecture type.
+        on the architecture type, even if the force_direct option is unspecified.
         """
         eq_(firefox_android.get_download_url('alpha', 'api-15'),
             self.archive_url_base + 'latest-mozilla-aurora-android-api-15/'
@@ -398,25 +410,67 @@ class TestFirefoxAndroid(TestCase):
             self.archive_url_base + 'latest-mozilla-aurora-android-x86/'
             'fennec-24.0a2.multi.android-i386.apk')
 
+    def test_get_download_url_aurora_direct(self):
+        """
+        get_download_url should return a mozilla-aurora archive link depending
+        on the architecture type, if the force_direct option is True.
+        """
+        eq_(firefox_android.get_download_url('alpha', 'api-15', 'multi', True),
+            self.archive_url_base + 'latest-mozilla-aurora-android-api-15/'
+            'fennec-24.0a2.multi.android-arm.apk')
+        eq_(firefox_android.get_download_url('alpha', 'x86', 'multi', True),
+            self.archive_url_base + 'latest-mozilla-aurora-android-x86/'
+            'fennec-24.0a2.multi.android-i386.apk')
+
     def test_get_download_url_beta(self):
         """
         get_download_url should return the same Google Play link of the
-        'org.mozilla.firefox_beta' product regardless of the architecture type.
+        'org.mozilla.firefox_beta' product regardless of the architecture type,
+        if the force_direct option is unspecified.
         """
         ok_(firefox_android.get_download_url('beta', 'api-15')
             .startswith(self.google_play_url_base + 'firefox_beta'))
         ok_(firefox_android.get_download_url('beta', 'x86')
             .startswith(self.google_play_url_base + 'firefox_beta'))
 
+    def test_get_download_url_beta_direct(self):
+        """
+        get_download_url should return a bouncer link depending on the
+        architecture type, if the force_direct option is True.
+        """
+        url = firefox_android.get_download_url('beta', 'api-15', 'multi', True)
+        self.assertListEqual(parse_qsl(urlparse(url).query),
+                             [('product', 'fennec-beta-latest'),
+                              ('os', 'android'), ('lang', 'multi')])
+        url = firefox_android.get_download_url('beta', 'x86', 'multi', True)
+        self.assertListEqual(parse_qsl(urlparse(url).query),
+                             [('product', 'fennec-beta-latest'),
+                              ('os', 'android-x86'), ('lang', 'multi')])
+
     def test_get_download_url_release(self):
         """
         get_download_url should return the same Google Play link of the
-        'org.mozilla.firefox' product regardless of the architecture type.
+        'org.mozilla.firefox' product regardless of the architecture type,
+        if the force_direct option is unspecified.
         """
         ok_(firefox_android.get_download_url('release', 'api-15')
             .startswith(self.google_play_url_base + 'firefox'))
         ok_(firefox_android.get_download_url('release', 'x86')
             .startswith(self.google_play_url_base + 'firefox'))
+
+    def test_get_download_url_release_direct(self):
+        """
+        get_download_url should return a bouncer link depending on the
+        architecture type, if the force_direct option is True.
+        """
+        url = firefox_android.get_download_url('release', 'api-15', 'multi', True)
+        self.assertListEqual(parse_qsl(urlparse(url).query),
+                             [('product', 'fennec-latest'),
+                              ('os', 'android'), ('lang', 'multi')])
+        url = firefox_android.get_download_url('release', 'x86', 'multi', True)
+        self.assertListEqual(parse_qsl(urlparse(url).query),
+                             [('product', 'fennec-latest'),
+                              ('os', 'android-x86'), ('lang', 'multi')])
 
 
 @patch.object(firefox_ios._storage, 'data',

--- a/bedrock/firefox/tests/test_helpers.py
+++ b/bedrock/firefox/tests/test_helpers.py
@@ -210,6 +210,11 @@ class TestDownloadButtons(TestCase):
         eq_(pq(list[0]).attr('class'), 'os_android armv7up api-15')
         eq_(pq(list[1]).attr('class'), 'os_android x86')
 
+        links = doc('.download-list li a')
+        eq_(links.length, 2)
+        ok_(pq(links[0]).attr('href').startswith('https://archive.mozilla.org'))
+        ok_(pq(links[1]).attr('href').startswith('https://archive.mozilla.org'))
+
     @patch.object(firefox_android._storage, 'data',
                   Mock(return_value=dict(nightly_version='47.0a2')))
     def test_legacy_nightly_android(self):
@@ -225,6 +230,12 @@ class TestDownloadButtons(TestCase):
         eq_(pq(list[1]).attr('class'), 'os_android armv7up api-15')
         eq_(pq(list[2]).attr('class'), 'os_android x86')
 
+        links = doc('.download-list li a')
+        eq_(links.length, 3)
+        ok_(pq(links[0]).attr('href').startswith('https://archive.mozilla.org'))
+        ok_(pq(links[1]).attr('href').startswith('https://archive.mozilla.org'))
+        ok_(pq(links[2]).attr('href').startswith('https://archive.mozilla.org'))
+
     @patch.object(firefox_android._storage, 'data',
                   Mock(return_value=dict(alpha_version='48.0a2')))
     def test_latest_aurora_android(self):
@@ -238,6 +249,11 @@ class TestDownloadButtons(TestCase):
         eq_(list.length, 2)
         eq_(pq(list[0]).attr('class'), 'os_android armv7up api-15')
         eq_(pq(list[1]).attr('class'), 'os_android x86')
+
+        links = doc('.download-list li a')
+        eq_(links.length, 2)
+        ok_(pq(links[0]).attr('href').startswith('https://archive.mozilla.org'))
+        ok_(pq(links[1]).attr('href').startswith('https://archive.mozilla.org'))
 
     @patch.object(firefox_android._storage, 'data',
                   Mock(return_value=dict(alpha_version='47.0a2')))
@@ -254,6 +270,12 @@ class TestDownloadButtons(TestCase):
         eq_(pq(list[1]).attr('class'), 'os_android armv7up api-15')
         eq_(pq(list[2]).attr('class'), 'os_android x86')
 
+        links = doc('.download-list li a')
+        eq_(links.length, 3)
+        ok_(pq(links[0]).attr('href').startswith('https://archive.mozilla.org'))
+        ok_(pq(links[1]).attr('href').startswith('https://archive.mozilla.org'))
+        ok_(pq(links[2]).attr('href').startswith('https://archive.mozilla.org'))
+
     def test_beta_mobile(self):
         rf = RequestFactory()
         get_request = rf.get('/fake')
@@ -263,6 +285,10 @@ class TestDownloadButtons(TestCase):
         list = doc('.download-list li')
         eq_(list.length, 1)
         eq_(pq(list[0]).attr('class'), 'os_android')
+
+        links = doc('.download-list li a')
+        eq_(links.length, 1)
+        ok_(pq(links[0]).attr('href').startswith('https://play.google.com'))
 
         list = doc('.download-other .arch')
         eq_(list.length, 0)
@@ -276,6 +302,10 @@ class TestDownloadButtons(TestCase):
         list = doc('.download-list li')
         eq_(list.length, 1)
         eq_(pq(list[0]).attr('class'), 'os_android')
+
+        links = doc('.download-list li a')
+        eq_(links.length, 1)
+        ok_(pq(links[0]).attr('href').startswith('https://play.google.com'))
 
         list = doc('.download-other .arch')
         eq_(list.length, 0)

--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -279,7 +279,7 @@ def all_downloads(request, platform, channel):
     # nonexistent pages here as 404 Not Found
     if platform == 'ios':
         raise Http404
-    if platform == 'android' and channel in ['alpha', 'nightly', 'esr']:
+    if platform == 'android' and channel == 'esr':
         raise Http404
 
     version = product.latest_version(channel)

--- a/tests/functional/test_download_l10n.py
+++ b/tests/functional/test_download_l10n.py
@@ -22,7 +22,10 @@ def pytest_generate_tests(metafunc):
         '/firefox/nightly/all/',
         '/firefox/organizations/all/',
         '/firefox/android/all/',
-        '/firefox/android/beta/all/')
+        '/firefox/android/beta/all/',
+        '/firefox/android/aurora/all/',
+        '/firefox/android/nightly/all/',
+    )
     argvalues = []
     for path in paths:
         r = requests.get(base_url + path)


### PR DESCRIPTION
## Description

* A cleaned-up version of #4382
* Create [/firefox/android/aurora/all/](https://bedrock-demo-android-all.us-west.moz.works/en-US/firefox/android/aurora/all/) and [/firefox/android/nightly/all/](https://bedrock-demo-android-all.us-west.moz.works/en-US/firefox/android/nightly/all/) to complete /all/ download pages
* List only the multi-locale builds on all the Android /all/ pages, as discussed in the bug

## Bugzilla link

[Bug 1301650](https://bugzilla.mozilla.org/show_bug.cgi?id=1301650)

## Testing

* Those new /all/ pages for Nightly and Aurora can be found on [/firefox/channel/android/](https://bedrock-demo-android-all.us-west.moz.works/en-US/firefox/channel/android/)
* The single-locale builds should not be listed any more.

## Checklist
- [ ] Requires l10n changes.
- [x] Related functional & integration tests passing.

## Notes on upcoming PRs

* The api-9 code will be deleted ([Bug 1293711](https://bugzilla.mozilla.org/show_bug.cgi?id=1293711))
* The Aurora download link will be replaced with Google Play ([Bug 1304448](https://bugzilla.mozilla.org/show_bug.cgi?id=1304448))