### PR TITLE
[fix bug 1321440] unbreak fundraising takeover buttons

### DIFF
--- a/bedrock/mozorg/templates/mozorg/home/includes/takeover-2016.html
+++ b/bedrock/mozorg/templates/mozorg/home/includes/takeover-2016.html
@@ -28,11 +28,10 @@
         <ul>
         {% for amount in donate_params.preset_list %}
           <li>
-            <label for="donate{{ amount }}" {% if amount == donate_params.default %}class="selected"{% endif %} data-amount="{{ amount }}">
-              <input type="radio" value="{{ amount }}" id="donate{{ amount }}" name="amount"
-              {% if amount == donate_params.default %}checked="checked"{% endif %}>
+            <label for="donate{{ amount }}" {% if amount == donate_params.default %}class="selected"{% endif %}>
+              <input type="radio" value="{{ amount }}" id="donate{{ amount }}" name="amount" {% if amount == donate_params.default %}checked="checked"{% endif %}>
               {# L10n: Inserts a sum with currency symbol, e.g. '$100'. Adapt the string in your translation for your locale conventions if needed, ex: %(sum)s %(symbol)s #}
-              {{ _('%(symbol)s%(sum)s')|format(symbol=donate_params.symbol, sum=amount) }}
+              <span class="label-text" data-amount="{{ amount }}">{{ _('%(symbol)s%(sum)s')|format(symbol=donate_params.symbol, sum=amount) }}</span>
             </label>
           </li>
        {% endfor %}

--- a/media/js/mozorg/home/takeover-2016.js
+++ b/media/js/mozorg/home/takeover-2016.js
@@ -19,6 +19,7 @@
     var $donateOptionsSection = $('.donate-options');
     var $donateCustom = $('#donate-custom');
     var $optionLabels = $('label[class!="own-amount"]', $donateOptionsSection);
+    var $optionLabelsText = $('label[class!="own-amount"] .label-text', $donateOptionsSection);
     var $options = $('input[type="radio"]', $donateOptionsSection);
 
     // Replaces label text with appropriately formatted numbers in supporting browsers
@@ -31,7 +32,7 @@
             minimumFractionDigits: 0
         });
 
-        $optionLabels.each(function() {
+        $optionLabelsText.each(function() {
             $(this).text(numberFormat.format($(this).data('amount')));
         });
     }


### PR DESCRIPTION
## Description
So in my enthusiasm for localizing the currency with the fancy new Intl API I foolishly broke the entire form. I was replacing the label contents with the localized text and didn't even notice that I was also replacing the hidden radio buttons.

This fixes my stupid mistake by wrapping the label text in a span and replacing THAT instead.

## Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1321440

## Testing
Verify the form works and submits the selected value to donate.mozilla.org

## Checklist
- [ ] Requires l10n changes.
- [ ] Related functional & integration tests passing.

