### PR TITLE
Remove Persona from the web sec bounty and add the Observatory

### DIFF
--- a/bedrock/security/templates/security/bug-bounty/faq-webapp.html
+++ b/bedrock/security/templates/security/bug-bounty/faq-webapp.html
@@ -198,21 +198,10 @@
           	<li>Static.marketplace.firefox.com</li>
           </ul>
 
-          <h4>Persona</h4>
+          <h4>Observatory</h4>
           <ul>
-          	<li>browserid.org</li>
-          	<li>firefoxos.persona.org</li>
-          	<li>persona.org</li>
-          	<li>static.login.persona.org</li>
-          	<li>verifier.login.persona.org</li>
-          	<li>www.browserid.org</li>
-          	<li>www.persona.org</li>
-          	<li>yahoo.login.persona.org</li>
-          	<li>gmail.login.persona.org</li>
-          	<li>login.anosrep.org</li>
-          	<li>login.mozilla.org</li>
-          	<li>login.persona.org</li>
-          	<li>Diresworb.org</li>
+            <li>http-observatory.security.mozilla.org</li>
+            <li>observatory.mozilla.org</li>
           </ul>
 
           <h4>Push</h4>


### PR DESCRIPTION
## Description
This adds the Observatory to the bug bounty list, and removes Persona.

@jeffbryner, can I get some r+ on the addition of the Observatory?

## Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1321479

## Testing

## Checklist
- [ ] Requires l10n changes.
- [x] Related functional & integration tests passing.

