### PR TITLE
Remove spurious whitespace in links from 2015 annual report

### DIFF
--- a/bedrock/foundation/templates/foundation/annualreport/2015/index.html
+++ b/bedrock/foundation/templates/foundation/annualreport/2015/index.html
@@ -292,8 +292,8 @@
             open, global and growing internet. In 2014, Mozilla played a key role in the
             adoption of strong net neutrality rules in the United States. In 2015,
             Mozilla engaged globally in the net neutrality and zero-rating debates,
-            including in <a href="{{ peru }}">Peru</a>, <a href="{{ europe }}">Europe
-            </a> and <a href="{{ net_neutrality }}">India</a>.
+            including in <a href="{{ peru }}">Peru</a>, <a href="{{ europe }}">Europe</a>
+            and <a href="{{ net_neutrality }}">India</a>.
           {% endtrans %}
           </p>
           <p>
@@ -361,8 +361,8 @@
           %}
             To help fulfill our vision of universal web literacy, Mozilla developed,
             released and upgraded our free, open-source education tools like
-            <a href="{{ thimble }}">Thimble</a> and <a href="{{ webmaker }}">Webmaker
-            </a>. Mozilla is also developing educational programs like
+            <a href="{{ thimble }}">Thimble</a> and <a href="{{ webmaker }}">Webmaker</a>.
+            Mozilla is also developing educational programs like
             <a href="{{ hive }}">Hive Learning Networks</a>, which empowers the next
             generation to develop and use digital literacy skills that will keep the web
             open.
@@ -443,8 +443,8 @@
           %}
             The Mozilla Foundation was formed in 2003 to protect the open nature of the
             internet by developing open source software and building a global community.
-            The Mozilla Corporation was <a href="{{ established }}">established in 2005
-            </a> as a wholly owned taxable subsidiary that serves the nonprofit, public
+            The Mozilla Corporation was <a href="{{ established }}">established in 2005</a>
+            as a wholly owned taxable subsidiary that serves the nonprofit, public
             benefit goals of its parent, the Mozilla Foundation. Both Mozilla Foundation
             and Mozilla Corporation are guided by the principles of the
             <a href="{{ manifesto }}">Mozilla Manifesto</a> and each is governed by a
@@ -625,8 +625,8 @@
             Mozilla’s investment in young leaders also includes a series of fellowships
             focused on bringing open source approaches into new places. In 2015, we
             expanded this work through a partnership with Ford Foundation. In 2015, the
-            inaugural cohort of Ford-Mozilla <a href="{{ fellows }}">Open Web Fellows
-            </a> were embedded at organizations like the ACLU and Amnesty International,
+            inaugural cohort of Ford-Mozilla <a href="{{ fellows }}">Open Web Fellows</a>
+            were embedded at organizations like the ACLU and Amnesty International,
             working on issues like digital inclusion, privacy and equality online.
             Mozilla also continued to support fellows and invest in young leaders in
             partnership with allies such as Knight Foundation, MacArthur Foundation and


### PR DESCRIPTION
## Description

Remove spurious whitespace in links from 2015 annual report.

## Bugzilla link

Not reported to Bugzilla. Is this something I should do next time?

## Testing

None, seems obvious enough...