### PR TITLE
Skip broken Fennec link for 'be' until bug 1321262 is resolved

### DIFF
--- a/tests/functional/test_download_l10n.py
+++ b/tests/functional/test_download_l10n.py
@@ -29,6 +29,8 @@ def pytest_generate_tests(metafunc):
         soup = BeautifulSoup(r.content, 'html.parser')
         table = soup.find('table', class_='build-table')
         urls = [a['href'] for a in table.find_all('a')]
+        # Bug 1321262 skip broken feccec link for 'be' until bug is resolved
+        urls = [url for url in urls if 'product=fennec-latest&os=android&lang=be' not in url]
         assert len(urls) > 0
         argvalues.extend(urls)
     metafunc.parametrize('url', argvalues)


### PR DESCRIPTION
@pmac r?

No rush to look at this, I know you're traveling! (It's 4.30am and I'm awake, so thought I might as well try and do something productive).

P.S - I ran this locally and it passes.