### PR TITLE
[bug 1320808] Remove Turvey announcement switches

### DIFF
--- a/bedrock/foundation/templates/foundation/about.html
+++ b/bedrock/foundation/templates/foundation/about.html
@@ -50,9 +50,7 @@
     <li>Cathy Davidson</li>
     <li>Bob Lisbonne</li>
     <li>Ronaldo Lemos</li>
-  {% if switch('leadership-turvey-announce') %}
     <li>Helen Turvey</li>
-  {% endif %}
   </ul>
 
   <h4>{{ _('Emeritus Board Members') }}</h4>

--- a/bedrock/mozorg/templates/mozorg/about/leadership.html
+++ b/bedrock/mozorg/templates/mozorg/about/leadership.html
@@ -1192,14 +1192,12 @@
           <figcaption><h4 class="fn" itemprop="name">Bob Lisbonne</h4></figcaption>
         </figure>
       </li>
-    {% if switch('leadership-turvey-announce') %}
       <li class="vcard" itemscope itemtype="http://schema.org/Person">
         <figure class="headshot">
           {{ high_res_img('mozorg/about/leadership/helen-turvey.jpg', {'alt': '', 'width': '160', 'height': '160', 'class': 'photo', 'itemprop': 'image'}) }}
           <figcaption><h4 class="fn" itemprop="name">Helen Turvey</h4></figcaption>
         </figure>
       </li>
-    {% endif %}
     </ul>
 
     <h3 class="group-title">{{ _('Emeritus Board Members') }}</h3>


### PR DESCRIPTION
## Description
Just cleaning up. This content no longer needs to be hidden behind a switch.

## Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1320808
