### PR TITLE
[fix bug 1323707] Remove conditional logic that hides download buttons from Firefox users

### DIFF
--- a/bedrock/firefox/templates/firefox/releases/release-notes.html
+++ b/bedrock/firefox/templates/firefox/releases/release-notes.html
@@ -267,24 +267,16 @@
           <a rel="external" href="{{ firefox_url('desktop', 'all', channel=channel_name|lower()) }}">{{ _('All Firefox downloads') }}</a>
         </div>
         <div class="download-buttons">
-          <div class="firefox-latest-cta">
-            <p class="version-message">Congrats! You’re using the latest version of Firefox.</p>
-          </div>
-          <div class="non-firefox-cta">
-            <div class="desktop-download-button">
-              {{ download_firefox() }}
-            </div>
-            <div class="android-download-button">
-              {{ google_play_button() }}
-            </div>
-            <div class="ios-download-button">
-              <a rel="external" href="{{ firefox_ios_url('mozorg-releasenotes_page-appstore-button') }}" data-link-type="download" data-download-os="iOS">
-                <img src="{{ l10n_img('firefox/ios/btn-app-store.svg') }}" alt="{{ _('Download on the App Store') }}">
-              </a>
-            </div>
-          </div>
-          <div class="firefox-old-cta">
+          <div class="desktop-download-button">
             {{ download_firefox() }}
+          </div>
+          <div class="android-download-button">
+            {{ google_play_button() }}
+          </div>
+          <div class="ios-download-button">
+            <a rel="external" href="{{ firefox_ios_url('mozorg-releasenotes_page-appstore-button') }}" data-link-type="download" data-download-os="iOS">
+              <img src="{{ l10n_img('firefox/ios/btn-app-store.svg') }}" alt="{{ _('Download on the App Store') }}">
+            </a>
           </div>
         </div>
       </div>

--- a/media/css/firefox/desktop/index.less
+++ b/media/css/firefox/desktop/index.less
@@ -50,20 +50,11 @@
     }
 }
 
-// let JS decide if we should show the intro download button
-.js #overview-intro-download-wrapper {
-    display: none;
-}
-
-#sticky-download-desktop {
-    display: none;
-}
-
 // up to date message
 
 #overview-intro-up-to-date {
     display: none;
-    padding: 10px 0 20px;
+    padding: 20px 0;
     font-style: italic;
 
     &.active {
@@ -1003,12 +994,6 @@ html[lang^="en"] #sticky-download-desktop .download-link .download-content {
         h1 {
             .font-size(32px);
         }
-    }
-
-    #overview-intro-download-wrapper {
-        // js displays the button for non fx browsers, so this needs to be
-        // important to override the generated inline style
-        display: none !important;
     }
 
     #customize {

--- a/media/css/firefox/desktop/tips.less
+++ b/media/css/firefox/desktop/tips.less
@@ -295,23 +295,18 @@ html[lang^='en'] #tips-nav-direct li a span:after {
 #footer {
     .clearfix();
     padding-top: @baseLine * 2;
-
-    &.hide-download {
-        #footer-download {
-            display: none;
-        }
-
-        #footer-share {
-            float: none;
-            width: auto;
-            margin-right: 0;
-        }
-    }
 }
 
 #footer-download {
     float: left;
     width: 470px;
+
+    .fx-privacy-link {
+        a:link,
+        a:visited {
+            color: @linkBlue;
+        }
+    }
 }
 
 #footer-share {

--- a/media/css/firefox/releasenotes-firefox.less
+++ b/media/css/firefox/releasenotes-firefox.less
@@ -535,59 +535,63 @@ ul.section-items {
 
 // Download Buttons hide/show
 
-.download-buttons > div {
+.download-link {
+    margin-bottom: 10px;
+}
+
+.fx-privacy-link {
+    a:link,
+    a:visited {
+        color: @linkBlue;
+    }
+}
+
+.all-download .message {
     display: none;
 }
+
+.desktop-download-button {
+    display: block;
+}
+.android-download-button {
+    display: none;
+}
+.ios-download-button {
+    display: none;
+}
+
 .android {
-    &.non-firefox .download-buttons .non-firefox-cta {
-        .desktop-download-button {
-            display: none;
-        }
-        .android-download-button {
-            display: block;
-        }
+    .desktop-download-button {
+        display: none;
     }
-}
-.ios {
-    &.non-firefox .download-buttons .non-firefox-cta {
-        & .desktop-download-button {
-            display: none;
-        }
-        .ios-download-button {
-            display: block;
-        }
-    }
-}
-.firefox-up-to-date {
-    .download-buttons .firefox-latest-cta {
+    .android-download-button {
         display: block;
     }
-    .all-download p.message {
+    .ios-download-button {
         display: none;
     }
 }
-.firefox-old {
-    .download-buttons .firefox-old-cta {
-       display: block;
+.ios {
+    .desktop-download-button {
+        display: none;
     }
-}
-
-.non-firefox {
-    .download-buttons .non-firefox-cta {
+    .android-download-button {
+        display: none;
+    }
+    .ios-download-button {
         display: block;
-
-        > div {
-            display: none;
-        }
-        & .desktop-download-button {
-           display: block;
-        }
     }
 }
 
 .ios,
 .android {
     .all-download {
-        display: none;
+        a {
+            display: none;
+        }
+
+        .message {
+            display: block;
+        }
     }
 }

--- a/media/js/firefox/desktop/common.js
+++ b/media/js/firefox/desktop/common.js
@@ -11,12 +11,6 @@
         // hide the footer download button and extend email form to full width
         $('#download-wrapper').show();
         $('#subscribe-wrapper').addClass('columned');
-
-        // show the download button on the overview page intro section
-        $('#overview-intro-download-wrapper').fadeIn('fast');
-
-        // show download button in sticky nav on overview page
-        $('#sticky-download-desktop').fadeIn('fast');
     }
 
     // only show download buttons for users on desktop platforms, using either a non-Firefox browser

--- a/media/js/firefox/desktop/tips.js
+++ b/media/js/firefox/desktop/tips.js
@@ -5,24 +5,12 @@
 (function($, Hammer) {
     'use strict';
 
-    var client = window.Mozilla.Client;
     var $window = $(window);
     var $tipPrev = $('#tip-prev');
     var $tipNext = $('#tip-next');
     var $tipsNavDirect = $('#tips-nav-direct');
     var $tipsTabLinks = $tipsNavDirect.find('a');
     var $tipsNavDots = $('#tips-nav-dots');
-
-    // only show download button for users on desktop platforms, using either a non-Firefox browser
-    // or an out of date version of Firefox.
-    // bug 1301721 only use major Firefox version until 49.0 is released
-    if (client.isFirefoxDesktop) {
-        if (client._isFirefoxUpToDate(false)) {
-            $('#footer').addClass('hide-download');
-        }
-    } else if (client.isMobile) {
-        $('#footer').addClass('hide-download');
-    }
 
     // mozilla pager stuff must be in doc ready wrapper
     $(function() {

--- a/tests/functional/firefox/desktop/test_desktop.py
+++ b/tests/functional/firefox/desktop/test_desktop.py
@@ -7,7 +7,6 @@ import pytest
 from pages.firefox.desktop.desktop import DesktopPage
 
 
-@pytest.mark.skip_if_firefox(reason='Download button is not shown for up-to-date Firefox browsers.')
 @pytest.mark.smoke
 @pytest.mark.nondestructive
 def test_primary_download_button_displayed(base_url, selenium):


### PR DESCRIPTION
## Description
- Simplifies download button logic on a few remaining pages (we already covered the home page and main download page in different bugs):
  - `/firefox/desktop/`
  - `/firefox/desktop/tips/`
  - `/firefox/releasenotes/`

I decided to leave `/products/` as is, since the download bar is more of a conditional UI, and the additional changes to `/desktop` already make it easier for Firefox pre-release users to download.

## Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1323707

## Testing
- Test to make sure no visual regressions, download buttons show correctly etc.

## Checklist
- [ ] Requires l10n changes.
- [x] Related functional & integration tests passing.