### PR TITLE
[bug 1316375] Set a cookie for the EOY takeover

### DIFF
--- a/bedrock/settings/static_media.py
+++ b/bedrock/settings/static_media.py
@@ -1456,13 +1456,13 @@ PIPELINE_JS = {
             'js/libs/jquery.cycle2.min.js',
             'js/libs/jquery.waypoints.min.js',
             'js/mozorg/home/home.js',
+            'js/base/mozilla-cookie-helper.js',
             'js/mozorg/home/takeover-2016.js',
         ),
         'output_filename': 'js/home-bundle.js',
     },
     'experiment-home-fundraising-2016': {
         'source_filenames': (
-            'js/base/mozilla-cookie-helper.js',
             'js/base/mozilla-traffic-cop.js',
             'js/mozorg/home/experiment-home-fundraising-2016.js',
         ),
@@ -1471,6 +1471,7 @@ PIPELINE_JS = {
     'home-voices': {
         'source_filenames': (
             'js/mozorg/home/home-voices.js',
+            'js/base/mozilla-cookie-helper.js',
             'js/mozorg/home/takeover-2016.js',
         ),
         'output_filename': 'js/home-voices-bundle.js',


### PR DESCRIPTION
## Description
We were previously using sessionStorage to disable the takeover once you'd seen it, but it meant you'd get the takeover again with any new session. It was decided that was potentially annoying to repeat visitors, so this switches to a permanent cookie with a 7 day expiration.

## Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1316375

## Testing
Verify that the cookie is being set, is set to expire in 7 days, and that the takeover isn't shown again when the cookie is present. The takeover should also not be shown if cookies are disabled (otherwise you'd see it on every refresh).

## Checklist
- [ ] Requires l10n changes.
- [ ] Related functional & integration tests passing.