### PR TITLE
[bug 1313717] Update home page Firefox copy

### DIFF
--- a/bedrock/mozorg/templates/mozorg/home/home.html
+++ b/bedrock/mozorg/templates/mozorg/home/home.html
@@ -148,13 +148,15 @@
     <div class="horizon">
       <div class="stars">
         <div class="content">
-        {% block fx_copy %}
-          <h2>{{ _('Browse freely.') }}</h2>
 
-          <p>
-            {{ _('Discover unlimited potential, endless possibility and a wide open Web.') }}
-          </p>
-        {% endblock %}
+        {% if l10n_has_tag('mozorg-home-fxcopy-unleash') %}
+          <h2>{{ _('Unleash your Internet') }}</h2>
+          <p>{{ _('Set the Web free and your mind will follow.') }}</p>
+        {% else %}
+          <h2>{{ _('Browse freely.') }}</h2>
+          <p>{{ _('Discover unlimited potential, endless possibility and a wide open Web.') }}</p>
+        {% endif %}
+
           <a id="fx-download-link" href="{{ url('firefox.new') }}">{{ _('Get Firefox today') }}</a>
 
           <div id="fxmobile-download-buttons">


### PR DESCRIPTION
## Description
Updates the copy in the Firefox section of the home page, behind the l10n tag `mozorg-home-fxcopy-unleash`

## Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1313717

## Checklist
- [ ] Requires l10n changes.
- [ ] Related functional & integration tests passing.

