### PR TITLE
[fix bug 1324141] Remove locale from SUMO links

### DIFF
--- a/bedrock/firefox/templates/firefox/private-browsing.html
+++ b/bedrock/firefox/templates/firefox/private-browsing.html
@@ -73,9 +73,9 @@
       </div>
       <p class="footer">
         <strong>
-          <a class="android-link" href="https://support.mozilla.org/en-US/kb/private-browsing-firefox-android">{{ _('Learn how to use Private Browsing') }}</a>
+          <a class="android-link" href="https://support.mozilla.org/kb/private-browsing-firefox-android">{{ _('Learn how to use Private Browsing') }}</a>
           <a class="ios-link" href="https://support.mozilla.org/kb/private-browsing-firefox-ios">{{ _('Learn how to use Private Browsing') }}</a>
-          <a class="desktop-link" href="https://support.mozilla.org/en-US/kb/private-browsing-use-firefox-without-history">{{ _('Learn more about Private Browsing') }}</a>
+          <a class="desktop-link" href="https://support.mozilla.org/kb/private-browsing-use-firefox-without-history">{{ _('Learn more about Private Browsing') }}</a>
         </strong>
         <small id="tracking-protection-caveat"> {{ _('Tracking Protection is only available with Firefox for Android and Desktop') }}</small>
       </p>


### PR DESCRIPTION
## Description
Some links on /firefox/private-browsing included a hard-coded en-US locale. Removing the locale from the URL lets SUMO's locale detection redirect appropriately.

## Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1324141
