### PR TITLE
[fix bug 1324161] Add optimizely block to firefox newsletter template

### DIFF
--- a/bedrock/newsletter/templates/newsletter/firefox.html
+++ b/bedrock/newsletter/templates/newsletter/firefox.html
@@ -11,6 +11,12 @@
 
 {% block body_class %}newsletter-mozilla{% endblock %}
 
+{% block optimizely %}
+  {% if switch('firefox-newsletter-optimizely') %}
+    {% include 'includes/optimizely.html' %}
+  {% endif %}
+{% endblock %}
+
 {% block page_css %}
   {% stylesheet 'newsletter-firefox' %}
 {% endblock %}


### PR DESCRIPTION
## Description
Adds an optimizely code block behind a waffle switch to the firefox newsletter template.

## Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1324161

## Testing
- [x] functional test to verify that the page loads in dev environment and switch behaves as expected

## Checklist
- [ ] Requires l10n changes.
- [ ] Related functional & integration tests passing.
