### PR TITLE
[fix bug 1322704] Remove secure_url helper.

### DIFF
--- a/bedrock/base/templates/macros.html
+++ b/bedrock/base/templates/macros.html
@@ -406,7 +406,7 @@
         </h2>
       {% endif %}
       <h2 class="thank-you hidden">{{ _('Your download link was sent.') }}</h2>
-      <form id="send-to-device-form" action="{{ secure_url('firefox.send-to-device-post') }}" method="post"{% if platform == 'select' %} class="dropdown"{% endif %}>
+      <form id="send-to-device-form" action="{{ url('firefox.send-to-device-post') }}" method="post"{% if platform == 'select' %} class="dropdown"{% endif %}>
         <ul class="error-list hidden">
           <li class="sms">{{ _('Sorry. This number isn’t valid. Please enter a U.S. phone number.') }}</li>
           <li class="email">{{ _('Please enter an email address.') }}</li>
@@ -428,7 +428,7 @@
             {% else %}
               <input type="hidden" id="id-platform" name="platform" value="{{ platform }}">
             {% endif %}
-            <input type="hidden" name="source-url" value="{{ secure_url() }}">
+            <input type="hidden" name="source-url" value="{{ request.build_absolute_uri(request.path) }}">
             <input type="hidden" name="message-set" value="{{ message_set }}">
           </div>
           <div class="inline-field">

--- a/bedrock/legal/templates/legal/fraud-report.html
+++ b/bedrock/legal/templates/legal/fraud-report.html
@@ -124,7 +124,7 @@
           </div>
         {% endif %}
 
-        <form action="{{ secure_url('legal.fraud-report') }}" method="post" name="reportForm" id="reportForm" enctype="multipart/form-data">
+        <form action="{{ url('legal.fraud-report') }}" method="post" name="reportForm" id="reportForm" enctype="multipart/form-data">
           <input type="hidden" name="csrfmiddlewaretoken" value="{{ csrf_token }}">
 
           <div class="field required" id="url">

--- a/bedrock/mozorg/templates/mozorg/contribute/studentambassadors/join.html
+++ b/bedrock/mozorg/templates/mozorg/contribute/studentambassadors/join.html
@@ -29,7 +29,7 @@
 
 {% block billboardcontent %}
   <form method="POST" class="billboard {% if form.non_field_errors() or form.errors %}has-errors{% endif %}"
-        id="ambassadors-form" action="{{ secure_url() }}#ambassadors-form">
+        id="ambassadors-form" action="{{ url('mozorg.contribute.studentambassadors.join') }}#ambassadors-form">
     {{ csrf() }}
     <input type="hidden" name="source_url" value="{{ request.build_absolute_uri() }}">
       <div class="form-column">

--- a/bedrock/mozorg/templates/mozorg/credits.html
+++ b/bedrock/mozorg/templates/mozorg/credits.html
@@ -35,7 +35,7 @@
   This is a list of people who have "made a significant investment of time, with useful results,
   into <a href="/">Mozilla project</a>-governed activities". Any such
   contributors who wish to be added to the list should <a href="https://docs.google.com/forms/d/1rwLVzr1Fql9ZtAKkG_z5jcRczn2uy84zqwBX9gX52OY/viewform">fill in this form</a>.
-  There is a <a href="{{ secure_url('mozorg.credits-faq') }}">FAQ</a> about this process. The list was last updated {{ credits.last_modified|datetime }}.
+  There is a <a href="{{ url('mozorg.credits-faq') }}">FAQ</a> about this process. The list was last updated {{ credits.last_modified|datetime }}.
 </p>
 </body>
 </html>

--- a/bedrock/mozorg/templates/mozorg/partnerships.html
+++ b/bedrock/mozorg/templates/mozorg/partnerships.html
@@ -98,7 +98,7 @@
     <h3>{{ _('Get started') }}</h3>
     <p>{{ _('Please complete the form below. Our partnership team will review your request and get back to you as soon as possible.') }}</p>
 
-    <form action="{{ secure_url('mozorg.partnerships') }}" method="POST" id="sf-form">
+    <form action="{{ url('mozorg.partnerships') }}" method="POST" id="sf-form">
 
     <input type="hidden" name="csrfmiddlewaretoken" value="{{ csrf_token }}">
 

--- a/bedrock/mozorg/templatetags/misc.py
+++ b/bedrock/mozorg/templatetags/misc.py
@@ -27,7 +27,7 @@ import jinja2
 from django_jinja import library
 
 from bedrock.base.urlresolvers import reverse
-from bedrock.base.templatetags.helpers import static, url
+from bedrock.base.templatetags.helpers import static
 from bedrock.firefox.firefox_details import firefox_ios
 
 
@@ -48,20 +48,6 @@ def add_string_to_image_url(url, addition):
 def convert_to_high_res(url):
     """Convert a file name to the high-resolution version."""
     return add_string_to_image_url(url, 'high-res')
-
-
-@library.global_function
-@jinja2.contextfunction
-def secure_url(ctx, viewname=None):
-    """Retrieve a full secure URL especially for form submissions"""
-    _path = url(viewname) if viewname else None
-    _url = ctx['request'].build_absolute_uri(_path)
-
-    # only force https if current page was requested via SSL
-    # otherwise, CSRF/AJAX errors will occur (submitting to https from http)
-    if ctx['request'].is_secure():
-        return _url.replace('http://', 'https://')
-    return _url
 
 
 def l10n_img_file_name(ctx, url):

--- a/bedrock/mozorg/tests/test_helper_misc.py
+++ b/bedrock/mozorg/tests/test_helper_misc.py
@@ -15,7 +15,6 @@ from pyquery import PyQuery as pq
 from rna.models import Release
 
 from bedrock.base.templatetags.helpers import static
-from bedrock.base.urlresolvers import reverse
 from bedrock.mozorg.templatetags import misc
 from bedrock.mozorg.tests import TestCase
 
@@ -60,37 +59,6 @@ def test_convert_to_high_res():
     eq_(misc.convert_to_high_res('/media/img/the.dude.png'), '/media/img/the.dude-high-res.png')
     eq_(misc.convert_to_high_res('/media/thats-a-bummer-man.jpg'),
         '/media/thats-a-bummer-man-high-res.jpg')
-
-
-@patch('django.conf.settings.LANGUAGE_CODE', 'en-US')
-class TestSecureURL(TestCase):
-    host = 'www.mozilla.org'
-    test_path = '/firefox/partners/'
-    test_view_name = 'mozorg.partnerships'
-    req = RequestFactory(HTTP_HOST=host).get(test_path)
-    secure_req = RequestFactory(HTTP_HOST=host).get(test_path, {}, **{'wsgi.url_scheme': 'https'})
-
-    def _test(self, view_name, expected_url, ssl):
-        eq_(render("{{ secure_url('%s') }}" % view_name, {'request': (self.secure_req if ssl else self.req)}),
-            expected_url)
-
-    def test_no_ssl_with_view_name(self):
-        # Should output a reversed path without https
-        self._test(self.test_view_name,
-                   'http://' + self.host + reverse(self.test_view_name), False)
-
-    def test_no_ssl_without_view_name(self):
-        # Should output the current, full URL without https
-        self._test('', 'http://' + self.host + self.test_path, False)
-
-    def test_ssl_with_view_name(self):
-        # Should output a reversed, full secure URL
-        self._test(self.test_view_name,
-                   'https://' + self.host + reverse(self.test_view_name), True)
-
-    def test_ssl_without_view_name(self):
-        # Should output the current, full secure URL
-        self._test('', 'https://' + self.host + self.test_path, True)
 
 
 @patch('bedrock.mozorg.templatetags.misc._l10n_media_exists')

--- a/bedrock/newsletter/templates/newsletter/existing.html
+++ b/bedrock/newsletter/templates/newsletter/existing.html
@@ -52,7 +52,8 @@
   {% endblock %}
 
   {% if formset and not switch('newsletter-maintenance-mode') %}
-    <form method="post" action="{{ secure_url() }}" id="existing-newsletter-form" class="container billboard"
+    {# using uri builder instead of named URL to easily maintain user newsletter token #}
+    <form method="post" action="{{ request.build_absolute_uri(request.path) }}" id="existing-newsletter-form" class="container billboard"
         data-initial-newsletters='{{ newsletters_subscribed }}'>
       {{ formset.management_form }}
 

--- a/bedrock/newsletter/templates/newsletter/recovery.html
+++ b/bedrock/newsletter/templates/newsletter/recovery.html
@@ -16,7 +16,7 @@
   {% endblock %}
 
   {% if form %}
-    <form method="post" action="{{ secure_url() }}" id="newsletter-recovery-form" class="container billboard">
+    <form method="post" action="{{ url('newsletter.recovery') }}" id="newsletter-recovery-form" class="container billboard">
       {% if form.non_field_errors() %}
         <div class="errorlist">
           {{ form.non_field_errors() }}

--- a/bedrock/newsletter/templates/newsletter/updated.html
+++ b/bedrock/newsletter/templates/newsletter/updated.html
@@ -17,7 +17,7 @@
     <div id="content" class="unsub billboard">
       <h4>{{_('Would you mind telling us why you’re leaving?') }}</h4>
 
-      <form action="{{ secure_url('newsletter.updated') }}" method="post">
+      <form action="{{ url('newsletter.updated') }}" method="post">
         <input type="hidden" name="unsub" value="2" />
         <input type="hidden" name="token" value="{{ token }}" />
         <table class="table">

--- a/bedrock/press/templates/press/speaker-request.html
+++ b/bedrock/press/templates/press/speaker-request.html
@@ -35,7 +35,7 @@
         </div>
       {% endif %}
 
-      <form action="{{ secure_url('press.speaker-request') }}" method="post" name="speaker-request-form" id="speaker-request-form" enctype="multipart/form-data">
+      <form action="{{ url('press.speaker-request') }}" method="post" name="speaker-request-form" id="speaker-request-form" enctype="multipart/form-data">
         {{ csrf() }}
 
         <fieldset>


### PR DESCRIPTION
## Description

Since `mozilla.org` is now all `https` 🔒, we don't really need a `secure_url` helper. 

## Bugzilla link

https://bugzilla.mozilla.org/show_bug.cgi?id=1322704

## Testing

Ensure no regressions on links or forms. It's on [a demo](https://bedrock-demo-jpetto-secureurl.us-west.moz.works/en-US/) as well.

## Checklist
- [ ] Related functional & integration tests passing.
