### PR TITLE
[bug 1323315] Add separate switch for dev search traffic cop

### DIFF
--- a/bedrock/firefox/templates/firefox/channel/desktop.html
+++ b/bedrock/firefox/templates/firefox/channel/desktop.html
@@ -9,7 +9,7 @@
 {% add_lang_files "firefox/channel/index" %}
 
 {% block experiments %}
-  {% if LANG.startswith('en-') and switch('mozorg-search-developer') %}
+  {% if LANG.startswith('en-') and switch('experiment-search-developer') %}
     {% javascript 'experiment-search-developer' %}
   {% endif %}
 {% endblock %}

--- a/bedrock/firefox/templates/firefox/developer.html
+++ b/bedrock/firefox/templates/firefox/developer.html
@@ -29,7 +29,7 @@
 {% endblock %}
 
 {% block experiments %}
-  {% if LANG.startswith('en-') and switch('mozorg-search-developer') %}
+  {% if LANG.startswith('en-') and switch('experiment-search-developer') %}
     {% javascript 'experiment-search-developer' %}
   {% endif %}
 {% endblock %}


### PR DESCRIPTION
## Description
We need a distinct switch so we can turn off the traffic cop redirect without disabling search entirely. The new switch is `experiment-search-developer`

## Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1323315