### PR TITLE
[fix bug 1324722] Relocate Mozilla.Cookies helper to site.js bundle

### DIFF
--- a/bedrock/settings/static_media.py
+++ b/bedrock/settings/static_media.py
@@ -1005,6 +1005,7 @@ PIPELINE_JS = {
         'source_filenames': (
             'js/base/site.js',  # this is automatically included on every page
             'js/base/dnt-helper.js',
+            'js/base/mozilla-cookie-helper.js',
             'js/base/core-datalayer-page-id.js',
         ),
         'output_filename': 'js/site-bundle.js',
@@ -1283,14 +1284,6 @@ PIPELINE_JS = {
         ),
         'output_filename': 'js/firefox_new_pixel-bundle.js',
     },
-    'experiment-firefox-new-up-to-date-users': {
-        'source_filenames': (
-            'js/base/mozilla-cookie-helper.js',
-            'js/base/mozilla-traffic-cop.js',
-            'js/firefox/new/experiment-up-to-date-users.js',
-        ),
-        'output_filename': 'js/experiment-firefox-new-up-to-date-users-bundle.js',
-    },
     'firefox_private_browsing': {
         'source_filenames': (
             'js/base/uitour-lib.js',
@@ -1461,7 +1454,6 @@ PIPELINE_JS = {
             'js/libs/jquery.cycle2.min.js',
             'js/libs/jquery.waypoints.min.js',
             'js/mozorg/home/home.js',
-            'js/base/mozilla-cookie-helper.js',
             'js/mozorg/home/takeover-2016.js',
         ),
         'output_filename': 'js/home-bundle.js',
@@ -1476,7 +1468,6 @@ PIPELINE_JS = {
     'home-voices': {
         'source_filenames': (
             'js/mozorg/home/home-voices.js',
-            'js/base/mozilla-cookie-helper.js',
             'js/mozorg/home/takeover-2016.js',
         ),
         'output_filename': 'js/home-voices-bundle.js',
@@ -1578,7 +1569,6 @@ PIPELINE_JS = {
     },
     'experiment-search-developer': {
         'source_filenames': (
-            'js/base/mozilla-cookie-helper.js',
             'js/base/mozilla-traffic-cop.js',
             'js/base/experiment-search-developer.js',
         ),

--- a/docs/mozilla-traffic-cop.rst
+++ b/docs/mozilla-traffic-cop.rst
@@ -11,7 +11,8 @@ Mozilla Traffic Cop
 `mozilla-traffic-cop.js` handles redirecting users to different A/B/x variations
 through a query parameter.
 
-**`mozilla-traffic-cop.js` requires `mozilla-cookie-helper.js`.**
+**`mozilla-traffic-cop.js` requires `mozilla-cookie-helper.js`, which is included as
+default in the `site.js` bundle for most pages.**
 
 How It Works
 ------------
@@ -33,7 +34,7 @@ could be considered the "control".)
 If a variation is chosen, a cookie is set (for the session only) that will
 send the user back to the same variation if/when the page is again visited.
 
-Any querystring parameters present when a user initially lands on a page will be
+Any query string parameters present when a user initially lands on a page will be
 propagated to the variation redirect.
 
 Configuration
@@ -43,7 +44,7 @@ Each instance of the Traffic Cop requires two pieces of configuration:
 
 - A string ID that is unique to other currently running tests (to avoid
 confusion when reading cookies)
-- A variations object that lists all variations by querystring along with the
+- A variations object that lists all variations by query string along with the
 associated visitor percentage
 
 An implementation might look like::
@@ -95,7 +96,6 @@ Implementation
 To add a Traffic Cop to a page, create a new JS bundle for the experiment that
 includes:
 
-- `mozilla-cookie-helper.js`
 - `mozilla-traffic-cop.js`
 - A new JS file that configures and initializes the experiment
 

--- a/media/js/base/mozilla-cookie-helper.js
+++ b/media/js/base/mozilla-cookie-helper.js
@@ -68,5 +68,32 @@ Mozilla.Cookies = {
         var aKeys = document.cookie.replace(/((?:^|\s*;)[^\=]+)(?=;|$)|^\s*|\s*(?:\=[^;]*)?(?:\1|$)/g, '').split(/\s*(?:\=[^;]*)?;\s*/);
         for (var nLen = aKeys.length, nIdx = 0; nIdx < nLen; nIdx++) { aKeys[nIdx] = decodeURIComponent(aKeys[nIdx]); }
         return aKeys;
+    },
+    enabled: function() {
+        /**
+         * Cookies feature detect lifted from Modernizr
+         * https://github.com/Modernizr/Modernizr/blob/master/feature-detects/cookies.js
+         *
+         * navigator.cookieEnabled cannot detect custom or nuanced cookie blocking
+         * configurations. For example, when blocking cookies via the Advanced
+         * Privacy Settings in IE9, it always returns true. And there have been
+         * issues in the past with site-specific exceptions.
+         * Don't rely on it.
+
+         * try..catch because in some situations `document.cookie` is exposed but throws a
+         * SecurityError if you try to access it; e.g. documents created from data URIs
+         * or in sandboxed iframes (depending on flags/context)
+         */
+        try {
+            // Create cookie
+            document.cookie = 'cookietest=1';
+            var ret = document.cookie.indexOf('cookietest=') !== -1;
+            // Delete cookie
+            document.cookie = 'cookietest=1; expires=Thu, 01-Jan-1970 00:00:01 GMT';
+            return ret;
+        }
+        catch (e) {
+            return false;
+        }
     }
 };

--- a/media/js/base/mozilla-traffic-cop.js
+++ b/media/js/base/mozilla-traffic-cop.js
@@ -77,6 +77,11 @@ Mozilla.TrafficCop.prototype.init = function() {
         return;
     }
 
+    // If cookie helper is not defined or cookies are not enabled, do nothing.
+    if (typeof Mozilla.Cookies === 'undefined' || !Mozilla.Cookies.enabled()) {
+        return;
+    }
+
     // make sure config is valid (id & variations present)
     if (this.verifyConfig()) {
         // make sure current page doesn't match a variation
@@ -199,4 +204,3 @@ Mozilla.TrafficCop.prototype.generateRedirectUrl = function(url) {
 
     return redirect;
 };
-

--- a/media/js/mozorg/home/takeover-2016.js
+++ b/media/js/mozorg/home/takeover-2016.js
@@ -37,21 +37,6 @@
         });
     }
 
-    // Check for cookie support (stolen from Modernizr)
-    function testCookies() {
-        try {
-            // Create cookie
-            document.cookie = 'cookietest=1';
-            var ret = document.cookie.indexOf('cookietest=') !== -1;
-            // Delete cookie
-            document.cookie = 'cookietest=1; expires=Thu, 01-Jan-1970 00:00:01 GMT';
-            return ret;
-        }
-        catch (e) {
-            return false;
-        }
-    }
-
     // Sets a cookie so you won't see the takeover again for seven days
     function seenTakover() {
         var date = new Date();
@@ -146,10 +131,10 @@
     // Do not bother showing the modal for users of IE8 and below
     // the donate.m.o site does not work for it.
     // Modal is waffled so first ensure it exists.
-    if (arrayIndexOfSupported && $takeoverModal.length > 0) {
+    if (arrayIndexOfSupported && $takeoverModal.length > 0 && typeof Mozilla.Cookies !== 'undefined') {
         // only show the takeover modal if the user has not
         // already seen it (has no cookie).
-        if (testCookies() && !Mozilla.Cookies.hasItem('eoy-takeover')) {
+        if (Mozilla.Cookies.enabled() && !Mozilla.Cookies.hasItem('eoy-takeover')) {
             initTakeOver();
         }
     }

--- a/tests/unit/spec/base/mozilla-traffic-cop.js
+++ b/tests/unit/spec/base/mozilla-traffic-cop.js
@@ -11,6 +11,7 @@ describe('mozilla-traffic-cop.js', function () {
     beforeEach(function() {
         // stub out Mozilla.Cookie lib
         window.Mozilla.Cookies = sinon.stub();
+        window.Mozilla.Cookies.enabled = sinon.stub().returns(true);
         window.Mozilla.Cookies.setItem = sinon.stub().returns(true);
         window.Mozilla.Cookies.getItem = sinon.stub().returns(false);
         window.Mozilla.Cookies.hasItem = sinon.stub().returns(false);
@@ -47,6 +48,12 @@ describe('mozilla-traffic-cop.js', function () {
             cop.init();
             expect(cop.verifyConfig).toHaveBeenCalled();
             window._dntEnabled = dntBak;
+        });
+
+        it('should not initialize is cookies are disabled', function() {
+            spyOn(window.Mozilla.Cookies, 'enabled').and.returnValue(false);
+            cop.init();
+            expect(cop.verifyConfig).not.toHaveBeenCalled();
         });
     });
 


### PR DESCRIPTION
## Description
- Also adds enabled() cookie feature detect function to helper

## Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1324722

## Testing
- Test to make sure no I didn't introduce any regressions, or miss any other pages/experiments?

## Checklist
- [ ] Requires l10n changes.
- [ ] Related functional & integration tests passing.
