### PR TITLE
Remove listing of #mv IRC channel to prevent support requests.

### DIFF
--- a/bedrock/mozorg/templates/mozorg/contact/spaces/mountain-view.html
+++ b/bedrock/mozorg/templates/mozorg/contact/spaces/mountain-view.html
@@ -23,7 +23,6 @@
         </p>
 
         <ul class="extra">
-          <li><a href="irc://irc.mozilla.org/mv" class="irc">IRC: #mv</a></li>
           <li><a href="https://wiki.mozilla.org/People:MozSpaces_Guidelines:Mountain_View" class="book">{{ _('Space operations guide') }}</a></li>
         </ul>
 


### PR DESCRIPTION
Someone needs to fix the UX flow so it's obvious that the proper place for support questions is #firefox.

Until that time, we can stem the bleeding by removing this listing, since this is something that should be on Mana, not our public "contact us" for the office.

## Description

## Bugzilla link

## Testing

## Checklist
- [ ] Requires l10n changes.
- [ ] Related functional & integration tests passing.
