### PR TITLE
bug1320080-Newletter icon in thai page fixed

### DIFF
--- a/media/css/mozorg/home/home.scss
+++ b/media/css/mozorg/home/home.scss
@@ -756,7 +756,6 @@ main {
         @include background-size(100px, 100px);
         background-position: center top;
         margin-top: 0;
-        min-height: 0;
         padding-left: 0;
         padding-top: 120px;
         text-align: center;

--- a/media/css/newsletter/moznewsletter-subscribe.less
+++ b/media/css/newsletter/moznewsletter-subscribe.less
@@ -48,6 +48,7 @@
         padding: 10px 0 20px 180px;
         text-align: left;
         text-shadow: none;
+        height: 135px;
 
         h3 {
             .font-size(40px);

--- a/media/css/newsletter/moznewsletter-subscribe.less
+++ b/media/css/newsletter/moznewsletter-subscribe.less
@@ -48,7 +48,7 @@
         padding: 10px 0 20px 180px;
         text-align: left;
         text-shadow: none;
-        height: 135px;
+        min-height: 135px;
 
         h3 {
             .font-size(40px);


### PR DESCRIPTION
Bug 1320080

The newsletter icon in thai homepage was cut off. By adding the height in the css, it was fixed.