### PR TITLE
[fix bug 1323829] Update non-Fx header copy on /firefox/products/

### DIFF
--- a/bedrock/firefox/templates/firefox/family/index.html
+++ b/bedrock/firefox/templates/firefox/family/index.html
@@ -31,9 +31,13 @@
         {{ download_firefox(alt_copy=_('Download'), dom_id='download-button-old-fx') }}
       </div>
       <div class="message" id="dlbar-nonfx">
-        {{ _('Choose Independent.') }}
-        {{ _('Choose Firefox.') }}
-        {{ download_firefox(alt_copy=_('Download'), dom_id='download-button-non-fx') }}
+        {% if l10n_has_tag('download_browse_freely') %}
+          {{ _('Browse Freely') }}
+        {% else %}
+          {{ _('Choose Independent.') }}
+          {{ _('Choose Firefox.') }}
+        {% endif %}
+        {{ download_firefox(alt_copy=_('Download Firefox'), dom_id='download-button-non-fx') }}
       </div>
       <div class="message" id="dlbar-nonfx-android">
         <a rel="external" href="{{ settings.GOOGLE_PLAY_FIREFOX_LINK }}" data-link-type="download" data-download-os="Android">{{ _('Get Firefox for Android') }}</a>


### PR DESCRIPTION
## Description
Updates copy on /products to be consistent with the newer download page messaging.

## Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1323829

## Checklist
- [x] Requires l10n changes.
- [ ] Related functional & integration tests passing.
