### PR TITLE
[no bug] Remove IRC contact info from Mozilla spaces

### DIFF
--- a/bedrock/mozorg/templates/mozorg/contact/spaces/auckland.html
+++ b/bedrock/mozorg/templates/mozorg/contact/spaces/auckland.html
@@ -22,10 +22,6 @@
         {% endtrans %}
         </p>
 
-        <ul class="extra">
-          <li><a href="irc://irc.mozilla.org" class="irc">IRC: #auckland</a></li>
-        </ul>
-
         <figure class="feature-img">
           {% set pin = static('img/contact/moz-map-pin.png')|absolute_url %}
           <img src="https://api.tiles.mapbox.com/v4/{{ settings.MAPBOX_TOKEN }}/url-{{ pin|urlencode }}(174.777106,-36.866596)/174.777106,-36.866596,16/460x250.png?access_token={{ settings.MAPBOX_ACCESS_TOKEN }}" alt="">

--- a/bedrock/mozorg/templates/mozorg/contact/spaces/london.html
+++ b/bedrock/mozorg/templates/mozorg/contact/spaces/london.html
@@ -23,7 +23,6 @@
 
         <ul class="extra">
           <li><a href="https://twitter.com/MozLDN" class="twitter">@MozLDN</a></li>
-          <li><a href="irc://irc.mozilla.org/london" class="irc">IRC: #london</a></li>
           <li><a href="https://wiki.mozilla.org/People:MozSpaces_Guidelines:London" class="book">{{ _('Space operations guide') }}</a></li>
         </ul>
 

--- a/bedrock/mozorg/templates/mozorg/contact/spaces/mountain-view.html
+++ b/bedrock/mozorg/templates/mozorg/contact/spaces/mountain-view.html
@@ -23,7 +23,6 @@
         </p>
 
         <ul class="extra">
-          <li><a href="irc://irc.mozilla.org/mv" class="irc">IRC: #mv</a></li>
           <li><a href="https://wiki.mozilla.org/People:MozSpaces_Guidelines:Mountain_View" class="book">{{ _('Space operations guide') }}</a></li>
         </ul>
 

--- a/bedrock/mozorg/templates/mozorg/contact/spaces/portland.html
+++ b/bedrock/mozorg/templates/mozorg/contact/spaces/portland.html
@@ -26,7 +26,6 @@
           <li><a href="https://twitter.com/mozpdx" class="twitter">@MozPDX</a></li>
           <li><a href="https://www.facebook.com/pages/Mozillians-PDX/506068286122532" class="facebook">Facebook</a></li>
           <li><a href="http://www.red-bean.com/mailman/listinfo/mozilla-pdx" class="email">{{ _('Mailing list') }}</a></li>
-          <li><a href="irc://irc.mozilla.org/MozPDX" class="irc">IRC: #MozPDX</a></li>
           <li><a href="https://wiki.mozilla.org/People:_MozSpaces_Guidelines:_Portland" class="book">{{ _('Space operations guide') }}</a></li>
         </ul>
 

--- a/bedrock/mozorg/templates/mozorg/contact/spaces/san-francisco.html
+++ b/bedrock/mozorg/templates/mozorg/contact/spaces/san-francisco.html
@@ -23,7 +23,6 @@
 
         <ul class="extra">
           <li><a href="https://twitter.com/MozSF" class="twitter">@MozSF</a></li>
-          <li><a href="irc://irc.mozilla.org/sf" class="irc">IRC: #sf</a></li>
           <li><a href="https://wiki.mozilla.org/People:MozSpaces_Guidelines:San_Francisco" class="book">{{ _('Space operations guide') }}</a></li>
         </ul>
 

--- a/bedrock/mozorg/templates/mozorg/contact/spaces/toronto.html
+++ b/bedrock/mozorg/templates/mozorg/contact/spaces/toronto.html
@@ -23,7 +23,6 @@
 
         <ul class="extra">
           <li><a href="http://to.mozillacanada.org" class="website">to.mozillacanada.org</a></li>
-          <li><a href="irc://irc.mozilla.org/toronto" class="irc">IRC: #toronto</a></li>
           <li><a href="https://twitter.com/MozToronto" class="twitter">@MozToronto</a></li>
           <li><a href="https://www.facebook.com/groups/224642234231741/" class="facebook">Facebook</a></li>
           <li><a href="https://wiki.mozilla.org/People:MozSpaces_Guidelines:Toronto" class="book">{{ _('Space operations guide') }}</a></li>

--- a/bedrock/mozorg/templates/mozorg/contact/spaces/vancouver.html
+++ b/bedrock/mozorg/templates/mozorg/contact/spaces/vancouver.html
@@ -23,7 +23,6 @@
 
         <ul class="extra">
           <li><a href="http://bc.mozillacanada.org/" class="website">bc.mozillacanada.org</a></li>
-          <li><a href="irc://irc.mozilla.org/vancouver" class="irc">IRC: #vancouver</a></li>
           <li><a href="https://wiki.mozilla.org/People:MozSpaces_Guidelines:Vancouver" class="book">{{ _('Space operations guide') }}</a></li>
         </ul>
 


### PR DESCRIPTION
## Description
It seems people occasionally drop into local office IRC channels seeking Firefox support. Those channels are mainly for folks in those offices, not necessarily for the general public, so this removes IRC channels from the contact pages for Mozilla spaces (leaving them for local communities).

This replaces #4538