### PR TITLE
Switch to using a Jenkins Multibranch Pipeline for deploy

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,17 @@
+def branch = env.BRANCH_NAME
+
+if ( branch == 'master') {
+    echo "Building master"
+    build 'bedrock_base_image'
+}
+else if ( branch == 'prod') {
+    echo "Building prod"
+    build 'bedrock_base_image'
+}
+else if ( branch ==~ /^demo__[a-z_-]+$/ ) {
+    echo "Building a demo: ${branch} (just for testing. does not work yet.)"
+    echo "TODO: make this work"
+}
+else {
+    echo "Doing nothing for ${branch}"
+}

--- a/bin/circleci-trigger-jenkins.sh
+++ b/bin/circleci-trigger-jenkins.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-set -e
-
-curl -d "delay=0" -d "token=$JENKINS_WEBHOOK_TOKEN" \
-  https://ci.us-west.moz.works/job/bedrock_base_image/buildWithParameters

--- a/bin/tag-release.sh
+++ b/bin/tag-release.sh
@@ -14,4 +14,5 @@ done
 echo "tagged $tag_value"
 if [[ "$1" == "--push" ]]; then
   git push "$moz_git_remote" "$tag_value"
+  git push "$moz_git_remote" master:prod
 fi

--- a/circle.yml
+++ b/circle.yml
@@ -43,13 +43,3 @@ deployment:
     owner: mozilla
     commands:
       - bin/circleci-demo-deploy.sh
-  jenkins:
-    branch: master
-    owner: mozilla
-    commands:
-      - bin/circleci-trigger-jenkins.sh
-  release:
-    tag: /\d{4}-\d{2}-\d{2}(\.\d)?/
-    owner: mozilla
-    commands:
-      - bin/circleci-trigger-jenkins.sh

--- a/docker/jenkins/check_if_tag.sh
+++ b/docker/jenkins/check_if_tag.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
 # Used to trigger downstream Jenkins jobs
-TRIGGER_FILE=.commit_is_tag
+TRIGGER_FILE=".commit_is_tag"
 rm -rf $TRIGGER_FILE
 
-if git describe --tags --exact-match $GIT_COMMIT 2> /dev/null;
-then
+TAG=$(git describe --tags --exact-match $GIT_COMMIT 2> /dev/null)
+if [[ -n "$TAG" ]] && [[ "$TAG" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}(\.[0-9])?$ ]]; then
     touch $TRIGGER_FILE
 fi;


### PR DESCRIPTION
The new Jenkins Multibranch Pipeline will now start the bedrock build jobs instead of having CircleCI do it. This wil mean having to push to a "prod" branch to trigger a prod deployment, but it should be much better and faster than waiting for Circle.