### PR TITLE
Fix Bug 1304448 - Figure out a way from mozilla.org to be able to install Firefox aurora on Google play

### DIFF
--- a/bedrock/firefox/firefox_details.py
+++ b/bedrock/firefox/firefox_details.py
@@ -339,6 +339,13 @@ class FirefoxAndroid(_ProductDetails):
     }
 
     store_url = settings.GOOGLE_PLAY_FIREFOX_LINK
+    # Product IDs defined on Google Play
+    store_product_ids = {
+        'alpha': 'org.mozilla.fennec_aurora',
+        'beta': 'org.mozilla.firefox_beta',
+        'release': 'org.mozilla.firefox',
+    }
+
     archive_url_base = ('https://archive.mozilla.org/pub/mobile/nightly/'
                         'latest-mozilla-%s-android')
     archive_repo = {
@@ -444,7 +451,7 @@ class FirefoxAndroid(_ProductDetails):
         # We don't have pre-release builds yet
         return []
 
-    def get_download_url(self, channel, arch='api-15', locale='multi',
+    def get_download_url(self, channel='release', arch='api-15', locale='multi',
                          force_direct=False):
         """
         Get direct download url for the product.
@@ -455,8 +462,8 @@ class FirefoxAndroid(_ProductDetails):
                 instead of Google Play.
         :return: string url
         """
-        # Use a direct link for Nightly/Aurora until Bug 1241114 is solved
-        if channel in ['nightly', 'alpha']:
+        # Use a direct link for Nightly until Bug 1241114 is solved
+        if channel == 'nightly':
             force_direct = True
 
         if force_direct:
@@ -473,9 +480,9 @@ class FirefoxAndroid(_ProductDetails):
                 ('lang', locale),
             ])])
 
-        if channel == 'beta':
-            return self.store_url.replace('org.mozilla.firefox',
-                                          'org.mozilla.firefox_beta')
+        if channel != 'release':
+            return self.store_url.replace(self.store_product_ids['release'],
+                                          self.store_product_ids[channel])
 
         return self.store_url
 

--- a/bedrock/firefox/templates/firefox/channel/android.html
+++ b/bedrock/firefox/templates/firefox/channel/android.html
@@ -20,7 +20,7 @@
       <h2>{{_('Beta')}}</h2>
       <p>{{_('Try the latest Android features, before they get released to the rest of the world.')}}</p>
     </header>
-    {{ download_firefox('beta', platform='android', force_direct=True, alt_copy=_('Download'), dom_id="android-beta-download") }}
+    {{ download_firefox('beta', platform='android', alt_copy=_('Download'), dom_id="android-beta-download") }}
     <p class="notice">
       {{_('Firefox Beta automatically sends feedback to Mozilla.')}}
       <a href="{{ url('privacy.notices.firefox') + '#telemetry' }}">{{_('Learn more')}}</a>
@@ -47,7 +47,7 @@
       <h2>{{_('Aurora')}}</h2>
       <p>{{_('Help determine what features will go into the next Firefox for Android.')}}</p>
     </header>
-    {{ download_firefox('alpha', platform='android', force_direct=True, alt_copy=_('Download'), dom_id="android-aurora-download") }}
+    {{ download_firefox('alpha', platform='android', alt_copy=_('Download'), dom_id="android-aurora-download") }}
     <p class="notice">
       {{_('Firefox Aurora automatically sends feedback to Mozilla.')}}
       <a href="{{ url('privacy.notices.firefox') + '#telemetry' }}">{{_('Learn more')}}</a>
@@ -57,6 +57,7 @@
     <div class="container">
       <ul>
         <li><a href="{{ firefox_url('android', 'notes', 'aurora') }}">{{_('Release Notes')}}</a></li>
+        <li><a href="https://support.mozilla.org/kb/participate-firefox-android-testing-program">{{_('Learn more')}}</a></li>
         <li><a href="{{ firefox_url('android', 'all', 'aurora') }}">{{_('All Languages and Builds')}}</a></li>
       </ul>
     </div>
@@ -74,7 +75,7 @@
         <p>{{_('Test brand new features daily (or… nightly). Enjoy at your own risk.')}}</p>
       {% endif %}
     </header>
-    {{ download_firefox('nightly', platform='android', force_direct=True, alt_copy=_('Download'), dom_id="android-nightly-download") }}
+    {{ download_firefox('nightly', platform='android', alt_copy=_('Download'), dom_id="android-nightly-download") }}
     <p class="notice">
       {{_('Firefox Nightly automatically sends feedback to Mozilla.')}}
       <a href="{{ url('privacy.notices.firefox') + '#telemetry' }}">{{_('Learn more')}}</a>

--- a/bedrock/firefox/templatetags/helpers.py
+++ b/bedrock/firefox/templatetags/helpers.py
@@ -22,7 +22,7 @@ def android_builds(channel, builds=None):
         ('x86', 'x86'),
     ])
 
-    if channel in ['alpha', 'nightly']:
+    if channel == 'nightly':
         version = int(firefox_android.latest_version(channel).split('.', 1)[0])
 
         for type, arch_pretty in variations.iteritems():
@@ -65,6 +65,8 @@ def firefox_footer_links(ctx, channel='release', platform='all'):
     :param platform: Target platform: 'desktop', 'android', or 'ios'.
     :return: The footer links html.
     """
+    # channel could be Undefined, so double check the value
+    channel = 'release' if not isinstance(channel, str) else channel
 
     show_desktop = platform in ['all', 'desktop']
     show_android = platform in ['all', 'android']

--- a/bedrock/firefox/tests/test_firefox_details.py
+++ b/bedrock/firefox/tests/test_firefox_details.py
@@ -441,15 +441,14 @@ class TestFirefoxAndroid(TestCase):
 
     def test_get_download_url_aurora(self):
         """
-        get_download_url should return a mozilla-aurora archive link depending
-        on the architecture type, even if the force_direct option is unspecified.
+        get_download_url should return the same Google Play link of the
+        'org.mozilla.fennec_aurora' product regardless of the architecture type,
+        if the force_direct option is unspecified.
         """
-        eq_(firefox_android.get_download_url('alpha', 'api-15'),
-            self.archive_url_base + 'latest-mozilla-aurora-android-api-15/'
-            'fennec-24.0a2.multi.android-arm.apk')
-        eq_(firefox_android.get_download_url('alpha', 'x86'),
-            self.archive_url_base + 'latest-mozilla-aurora-android-x86/'
-            'fennec-24.0a2.multi.android-i386.apk')
+        ok_(firefox_android.get_download_url('alpha', 'api-15')
+            .startswith(self.google_play_url_base + 'fennec_aurora'))
+        ok_(firefox_android.get_download_url('alpha', 'x86')
+            .startswith(self.google_play_url_base + 'fennec_aurora'))
 
     def test_get_download_url_aurora_direct(self):
         """

--- a/bedrock/firefox/tests/test_helpers.py
+++ b/bedrock/firefox/tests/test_helpers.py
@@ -266,14 +266,15 @@ class TestDownloadButtons(TestCase):
                         {'request': get_request}))
 
         list = doc('.download-list li')
-        eq_(list.length, 2)
-        eq_(pq(list[0]).attr('class'), 'os_android armv7up api-15')
-        eq_(pq(list[1]).attr('class'), 'os_android x86')
+        eq_(list.length, 1)
+        eq_(pq(list[0]).attr('class'), 'os_android')
 
         links = doc('.download-list li a')
-        eq_(links.length, 2)
-        ok_(pq(links[0]).attr('href').startswith('https://archive.mozilla.org'))
-        ok_(pq(links[1]).attr('href').startswith('https://archive.mozilla.org'))
+        eq_(links.length, 1)
+        ok_(pq(links[0]).attr('href').startswith('https://play.google.com'))
+
+        list = doc('.download-other .arch')
+        eq_(list.length, 0)
 
     @patch.object(firefox_android._storage, 'data',
                   Mock(return_value=dict(alpha_version='47.0a2')))
@@ -285,16 +286,15 @@ class TestDownloadButtons(TestCase):
                         {'request': get_request}))
 
         list = doc('.download-list li')
-        eq_(list.length, 3)
-        eq_(pq(list[0]).attr('class'), 'os_android armv7up api-9')
-        eq_(pq(list[1]).attr('class'), 'os_android armv7up api-15')
-        eq_(pq(list[2]).attr('class'), 'os_android x86')
+        eq_(list.length, 1)
+        eq_(pq(list[0]).attr('class'), 'os_android')
 
         links = doc('.download-list li a')
-        eq_(links.length, 3)
-        ok_(pq(links[0]).attr('href').startswith('https://archive.mozilla.org'))
-        ok_(pq(links[1]).attr('href').startswith('https://archive.mozilla.org'))
-        ok_(pq(links[2]).attr('href').startswith('https://archive.mozilla.org'))
+        eq_(links.length, 1)
+        ok_(pq(links[0]).attr('href').startswith('https://play.google.com'))
+
+        list = doc('.download-other .arch')
+        eq_(list.length, 0)
 
     def test_beta_mobile(self):
         rf = RequestFactory()


### PR DESCRIPTION
## Description

* Use the Google Play store link for Firefox Aurora on the [Android channel page](https://www.mozilla.org/en-US/firefox/channel/android/), instead of direct archive links for ARMv7 and x86.
* Add a [Learn More](https://support.mozilla.org/kb/participate-firefox-android-testing-program) link to the Aurora section, which was created in [Bug 1304445](https://bugzilla.mozilla.org/show_bug.cgi?id=1304445). The string has been localized for the desktop channel page, so no l10n required here.

## Bugzilla link

[Bug 1304448](https://bugzilla.mozilla.org/show_bug.cgi?id=1304448)

## Testing

* The channel page shows the Google Play link and Learn More link for Aurora.
* No other changes.

## Checklist
- [ ] Requires l10n changes.
- [ ] Related functional & integration tests passing.
