### PR TITLE
Fix Bug 1326383 - When I visit nightly.mozilla.org on Android, it takes me to a page about *Desktop* Nightly (with no Android download options)

### DIFF
--- a/bedrock/firefox/redirects.py
+++ b/bedrock/firefox/redirects.py
@@ -1,4 +1,5 @@
-from bedrock.redirects.util import redirect, is_firefox_redirector, no_redirect
+from bedrock.redirects.util import (redirect, is_firefox_redirector,
+                                    platform_redirector, no_redirect)
 
 
 def firefox_mobile_faq(request, *args, **kwargs):
@@ -514,8 +515,12 @@ redirectpatterns = (
     redirect(r'^firefox/hello/?$', 'https://support.mozilla.org/kb/hello-status'),
     redirect(r'^firefox(?:\/\d+\.\d+(?:\.\d+)?(?:a\d+)?)?/hello/start/?$', 'https://support.mozilla.org/kb/hello-status'),
 
-    # bug 1299947
-    redirect('^firefox/channel/?$', 'firefox.channel.desktop'),
+    # bug 1299947, 1326383
+    redirect(r'^firefox/channel/?$',
+             platform_redirector('firefox.channel.desktop',
+                                 'firefox.channel.android',
+                                 'firefox.channel.ios'),
+             cache_timeout=0),
 
     # Bug 1277196
     redirect(r'^firefox(?:\/\d+\.\d+(?:\.\d+)?(?:a\d+)?)?/firstrun/learnmore/?$', 'firefox.features'),

--- a/bedrock/redirects/tests/test_util.py
+++ b/bedrock/redirects/tests/test_util.py
@@ -12,7 +12,7 @@ from nose.tools import eq_, ok_
 
 from bedrock.redirects.middleware import RedirectsMiddleware
 from bedrock.redirects.util import (get_resolver, header_redirector, is_firefox_redirector,
-                                    no_redirect, redirect, ua_redirector)
+                                    no_redirect, redirect, ua_redirector, platform_redirector)
 
 
 class TestHeaderRedirector(TestCase):
@@ -50,6 +50,33 @@ class TestIsFirefoxRedirector(TestCase):
         url = callback(self.rf.get('/take/comfort/',
                                    HTTP_USER_AGENT='Mozilla Firefox/17.0 Iceweasel/17.0.1'))
         self.assertEqual(url, '/flout/')
+
+
+class TestPlatformRedirector(TestCase):
+    def setUp(self):
+        self.rf = RequestFactory()
+
+    def test_desktop_redirects(self):
+        callback = platform_redirector('/red/', '/green/', '/blue/')
+        url = callback(self.rf.get('/take/comfort/',
+                                   HTTP_USER_AGENT='Mozilla/5.0 (Macintosh; Intel Mac OS X 10.12; '
+                                                   'rv:53.0) Gecko/20100101 Firefox/53.0'))
+        self.assertEqual(url, '/red/')
+
+    def test_android_redirects(self):
+        callback = platform_redirector('/red/', '/green/', '/blue/')
+        url = callback(self.rf.get('/take/comfort/',
+                                   HTTP_USER_AGENT='Mozilla/5.0 (Android 6.0.1; Mobile; rv:51.0) '
+                                                   'Gecko/51.0 Firefox/51.0'))
+        self.assertEqual(url, '/green/')
+
+    def test_ios_redirects(self):
+        callback = platform_redirector('/red/', '/green/', '/blue/')
+        url = callback(self.rf.get('/take/comfort/',
+                                   HTTP_USER_AGENT='Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_3 like '
+                                                   'Mac OS X; de-de) AppleWebKit/533.17.9 (KHTML, '
+                                                   'like Gecko) Mobile/8F190'))
+        self.assertEqual(url, '/blue/')
 
 
 class TestNoRedirectUrlPattern(TestCase):

--- a/bedrock/redirects/util.py
+++ b/bedrock/redirects/util.py
@@ -66,6 +66,22 @@ def is_firefox_redirector(fx_dest, nonfx_dext):
     return decider
 
 
+def platform_redirector(desktop_dest, android_dest, ios_dest):
+    android_re = re.compile(r'\bAndroid\b', flags=re.I)
+    ios_re = re.compile(r'\b(iPhone|iPad|iPod)\b', flags=re.I)
+
+    def decider(request, *args, **kwargs):
+        value = request.META.get('HTTP_USER_AGENT', '')
+        if android_re.search(value):
+            return android_dest
+        elif ios_re.search(value):
+            return ios_dest
+        else:
+            return desktop_dest
+
+    return decider
+
+
 def no_redirect(pattern, locale_prefix=True, re_flags=None):
     """
     Return a url matcher that will stop the redirect middleware and force

--- a/tests/redirects/map_globalconf.py
+++ b/tests/redirects/map_globalconf.py
@@ -182,6 +182,19 @@ URLS = flatten((
     url_test('/mobile/aurora/', '/firefox/channel/android/#aurora'),
     url_test('/mobile/nightly/', '/firefox/channel/android/#nightly'),
 
+    # bug 1299947, 1326383
+    url_test('/firefox/channel/', '/firefox/channel/android/',
+             req_headers={'User-Agent': 'Mozilla/5.0 (Android 6.0.1; Mobile; rv:51.0) '
+                                        'Gecko/51.0 Firefox/51.0'},
+             resp_headers={'Cache-Control': 'max-age=0'}),
+    url_test('/firefox/channel/', '/firefox/channel/ios/',
+             req_headers={'User-Agent': 'Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_3 like '
+                                        'Mac OS X; de-de) AppleWebKit/533.17.9 (KHTML, '
+                                        'like Gecko) Mobile/8F190'},
+             resp_headers={'Cache-Control': 'max-age=0'}),
+    url_test('/firefox/channel/', '/firefox/channel/desktop/',
+             resp_headers={'Cache-Control': 'max-age=0'}),
+
     url_test('/firefox/unsupported-systems.html', '/firefox/unsupported-systems/'),
     url_test('/download/', '/firefox/new/'),
 


### PR DESCRIPTION
## Description

Currently [/firefox/channel/](https://www.mozilla.org/en-US/firefox/channel/) is redirected to [/firefox/channel/desktop/](https://www.mozilla.org/en-US/firefox/channel/desktop/) unconditionally. It should be redirected to [/firefox/channel/android/](https://www.mozilla.org/en-US/firefox/channel/android/) on Android and [/firefox/channel/ios/](https://www.mozilla.org/en-US/firefox/channel/ios/) on iOS.

## Bugzilla link

[Bug 1326383](https://bugzilla.mozilla.org/show_bug.cgi?id=1326383)

## Testing

Spoof the UA string and visit /firefox/channel/, then make sure the URL is redirected to one of the platform-dependent locations.

## Checklist
- [ ] Requires l10n changes.
- [x] Related functional & integration tests passing.
