### PR TITLE
[fix bug 1316892] Expose nav links to /technology and /internet-health for all locales

### DIFF
--- a/bedrock/base/templates/base-pebbles.html
+++ b/bedrock/base/templates/base-pebbles.html
@@ -99,22 +99,12 @@
         <nav class="masthead-nav-main" id="nav-main">
           <span class="toggle" role="button" aria-controls="nav-main-menu" aria-expanded="false" tabindex="0">{{_('Menu')}}</span>
           <ul class="nav-main-menu" id="nav-main-menu">
-          {% if LANG.startswith('en-') %}
             <li class="first internet-health-item">
               <a href="{{ url('mozorg.internet-health') }}" data-link-type="nav" data-link-name="Internet Health">{{ _('Internet Health') }}</a>
             </li>
             <li class="technology-item">
-              {# L10n: these strings are both potential navigation labels #}
-              <a href="{{ url('mozorg.technology') }}" data-link-type="nav" data-link-name="Web Innovations" data-alt-text="{{ _('Innovations') }}">{{ _('Web Innovations') }}</a>
+              <a href="{{ url('mozorg.technology') }}" data-link-type="nav" data-link-name="Web Innovations">{{ _('Web Innovations') }}</a>
             </li>
-          {% else %}
-            <li class="first about-item">
-              <a href="{{ url('mozorg.about') }}" data-link-type="nav" data-link-name="About">{{ _('About') }}</a>
-            </li>
-            <li class="contribute-item">
-              <a href="{{ url('mozorg.contribute.index') }}" data-link-type="nav" data-link-name="Participate">{{ _('Participate') }}</a>
-            </li>
-          {% endif %}
             <li class="last donate-item">
               <a href="{{ donate_url('header') }}" data-link-type="nav" data-link-name="Donate">{{_('Donate')}}</a>
             </li>

--- a/bedrock/base/templates/base-resp.html
+++ b/bedrock/base/templates/base-resp.html
@@ -104,22 +104,12 @@
           <nav id="nav-main" role="navigation">
             <span class="toggle" role="button" aria-controls="nav-main-menu" aria-expanded="false" tabindex="0">{{_('Menu')}}</span>
             <ul id="nav-main-menu">
-            {% if LANG.startswith('en-') %}
               <li class="first internet-health-item">
                 <a href="{{ url('mozorg.internet-health') }}" data-link-type="nav" data-link-name="Internet Health">{{ _('Internet Health') }}</a>
               </li>
               <li class="technology-item">
-                {# L10n: these strings are both potential navigation labels #}
-                <a href="{{ url('mozorg.technology') }}" data-link-type="nav" data-link-name="Web Innovations" data-alt-text="{{ _('Innovations') }}">{{ _('Web Innovations') }}</a>
+                <a href="{{ url('mozorg.technology') }}" data-link-type="nav" data-link-name="Web Innovations">{{ _('Web Innovations') }}</a>
               </li>
-            {% else %}
-              <li class="first about-item">
-                <a href="{{ url('mozorg.about') }}" data-link-type="nav" data-link-name="About">{{ _('About') }}</a>
-              </li>
-              <li class="contribute-item">
-                <a href="{{ url('mozorg.contribute.index') }}" data-link-type="nav" data-link-name="Participate">{{ _('Participate') }}</a>
-              </li>
-            {% endif %}
               <li class="last donate-item">
                 <a href="{{ donate_url('header') }}" data-link-type="nav" data-link-name="Donate">{{_('Donate')}}</a>
               </li>

--- a/bedrock/base/templates/base.html
+++ b/bedrock/base/templates/base.html
@@ -99,22 +99,12 @@
         {% block site_header_nav %}
         <nav id="nav-main" role="navigation">
           <ul>
-          {% if LANG.startswith('en-') %}
             <li class="first internet-health-item">
               <a href="{{ url('mozorg.internet-health') }}" data-link-type="nav" data-link-name="Internet Health">{{ _('Internet Health') }}</a>
             </li>
             <li class="technology-item">
-              {# L10n: these strings are both potential navigation labels #}
-              <a href="{{ url('mozorg.technology') }}" data-link-type="nav" data-link-name="Web Innovations" data-alt-text="{{ _('Innovations') }}">{{ _('Web Innovations') }}</a>
+              <a href="{{ url('mozorg.technology') }}" data-link-type="nav" data-link-name="Web Innovations">{{ _('Web Innovations') }}</a>
             </li>
-          {% else %}
-            <li class="first about-item">
-              <a href="{{ url('mozorg.about') }}" data-link-type="nav" data-link-name="About">{{ _('About') }}</a>
-            </li>
-            <li class="contribute-item">
-              <a href="{{ url('mozorg.contribute.index') }}" data-link-type="nav" data-link-name="Participate">{{ _('Participate') }}</a>
-            </li>
-          {% endif %}
             <li class="last donate-item">
               <a href="{{ donate_url('header') }}" data-link-type="nav" data-link-name="Donate">{{_('Donate')}}</a>
             </li>

--- a/bedrock/mozorg/templates/mozorg/home/includes/nav.html
+++ b/bedrock/mozorg/templates/mozorg/home/includes/nav.html
@@ -17,22 +17,12 @@
     <nav class="masthead-nav-main" id="nav-main">
       <span class="toggle" role="button" aria-controls="nav-main-menu" aria-expanded="false" tabindex="0">{{ _('Menu') }}</span>
       <ul class="nav-main-menu" id="nav-main-menu">
-      {% if LANG.startswith('en-') %}
         <li class="first internet-health-item">
           <a href="{{ url('mozorg.internet-health') }}" data-link-type="nav" data-link-name="Internet Health">{{ _('Internet Health') }}</a>
         </li>
         <li class="technology-item">
-          {# L10n: these strings are both potential navigation labels #}
-          <a href="{{ url('mozorg.technology') }}" data-link-type="nav" data-link-name="Web Innovations" data-alt-text="{{ _('Innovations') }}">{{ _('Web Innovations') }}</a>
+          <a href="{{ url('mozorg.technology') }}" data-link-type="nav" data-link-name="Web Innovations">{{ _('Web Innovations') }}</a>
         </li>
-      {% else %}
-        <li class="first about-item">
-          <a href="{{ url('mozorg.about') }}" data-link-type="nav" data-link-name="About">{{ _('About') }}</a>
-        </li>
-        <li class="contribute-item">
-          <a href="{{ url('mozorg.contribute.index') }}" data-link-type="nav" data-link-name="Participate">{{ _('Participate') }}</a>
-        </li>
-      {% endif %}
         <li class="donate-item">
           <a href="{{ donate_url('header') }}" data-link-type="nav" data-link-name="Donate">{{ _('Donate') }}</a>
         </li>

--- a/bedrock/mozorg/templates/mozorg/moss/base.html
+++ b/bedrock/mozorg/templates/mozorg/moss/base.html
@@ -30,22 +30,12 @@
     <nav class="masthead-nav-main" id="nav-main">
       <span class="toggle" role="button" aria-controls="nav-main-menu" aria-expanded="false" tabindex="0">{{ _('Menu') }}</span>
       <ul class="nav-main-menu" id="nav-main-menu">
-      {% if LANG.startswith('en-') %}
         <li class="first internet-health-item">
           <a href="{{ url('mozorg.internet-health') }}" data-link-type="nav" data-link-name="Internet Health">{{ _('Internet Health') }}</a>
         </li>
         <li class="technology-item">
-          {# L10n: these strings are both potential navigation labels #}
-          <a href="{{ url('mozorg.technology') }}" data-link-type="nav" data-link-name="Web Innovations" data-alt-text="{{ _('Innovations') }}">{{ _('Web Innovations') }}</a>
+          <a href="{{ url('mozorg.technology') }}" data-link-type="nav" data-link-name="Web Innovations">{{ _('Web Innovations') }}</a>
         </li>
-      {% else %}
-        <li class="first about-item">
-          <a href="{{ url('mozorg.about') }}" data-link-type="nav" data-link-name="About">{{ _('About') }}</a>
-        </li>
-        <li class="contribute-item">
-          <a href="{{ url('mozorg.contribute.index') }}" data-link-type="nav" data-link-name="Participate">{{ _('Participate') }}</a>
-        </li>
-      {% endif %}
         <li class="donate-item">
           <a href="{{ donate_url('header') }}" data-link-type="nav" data-link-name="Donate">{{ _('Donate') }}</a>
         </li>

--- a/media/css/mozorg/home/home.scss
+++ b/media/css/mozorg/home/home.scss
@@ -97,6 +97,15 @@ body {
             color: #fff;
         }
     }
+}
+
+@media #{$mq-desktop} {
+    #nav-main-menu,
+    .js #nav-main-menu {
+        li {
+            padding: 0 20px;
+        }
+    }
 
     #nav-download-firefox {
         display: inline-block;
@@ -116,15 +125,6 @@ body {
 
         .fx-privacy-link {
             display: none;
-        }
-    }
-}
-
-@media #{$mq-desktop} {
-    #nav-main-menu,
-    .js #nav-main-menu {
-        li {
-            padding: 0 20px;
         }
     }
 }
@@ -849,4 +849,3 @@ main {
         @include at2x('/media/img/sandstone/footer-mozilla-white.png', 93px, 24px);
     }
 }
-

--- a/media/css/mozorg/internet-health.scss
+++ b/media/css/mozorg/internet-health.scss
@@ -122,20 +122,17 @@ main {
             position: relative;
             width: auto;
         }
+    }
+
+    @media #{$mq-desktop} {
 
         .download-button {
             display: block;
             float: right;
 
             .download-link {
-                padding: 15px 12px;
+                padding: 15px 20px;
             }
-        }
-    }
-
-    @media #{$mq-desktop} {
-        .download-button .download-link {
-            padding: 15px 20px;
         }
     }
 }

--- a/media/css/mozorg/technology.scss
+++ b/media/css/mozorg/technology.scss
@@ -103,20 +103,17 @@ main {
             position: relative;
             width: auto;
         }
+    }
+
+    @media #{$mq-desktop} {
 
         .download-button {
             display: block;
             float: right;
 
             .download-link {
-                padding: 15px 12px;
+                padding: 15px 20px;
             }
-        }
-    }
-
-    @media #{$mq-desktop} {
-        .download-button .download-link {
-            padding: 15px 20px;
         }
     }
 }


### PR DESCRIPTION
## Description
- Exposes links for new landing pages in main nav for all locales (enough locales now have the translated strings).
- Hides the nav download button at tablet breakpoints to accommodate the new longer strings. I would have liked a way around this, but testing different locales it just becomes too squished to fit everything on 😢. The other option would be to hide the wordmark, but I settled on it being more important for the header (particularly for the home page, which also features a separate Firefox download CTA). 

## Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1316892

## Testing
- We have a few variations on the masthead for different pages, so double check to make sure I didn't miss any more?

## Checklist
- [x] Requires l10n changes.
- [x] Related functional & integration tests passing.
