### PR TITLE
Update UITour lib and docs for showNewTab()

### DIFF
--- a/docs/uitour.rst
+++ b/docs/uitour.rst
@@ -615,6 +615,19 @@ Closes the current tab.
     only one tab. You may need to provide a work around for this edge case in your code.
     This function is also only available in Firefox 46 onward.
 
+showNewTab();
+^^^^^^^^^^^^^
+
+Opens about:newtab in the same tab.
+
+.. code-block:: javascript
+
+    Mozilla.UITour.showNewTab();
+
+.. Important::
+
+    This function is only available in Firefox 51 onward.
+
 .. _Mozilla Central: http://dxr.mozilla.org/mozilla-central/source/browser/components/uitour/UITour-lib.js
 .. _Telemetry: https://wiki.mozilla.org/Telemetry
 .. _FHR: https://support.mozilla.org/en-US/kb/firefox-health-report-understand-your-browser-perf

--- a/media/js/base/uitour-lib.js
+++ b/media/js/base/uitour-lib.js
@@ -168,6 +168,10 @@ if (typeof Mozilla == 'undefined') {
         });
     };
 
+    Mozilla.UITour.showNewTab = function() {
+        _sendEvent('showNewTab');
+    };
+
     Mozilla.UITour.getConfiguration = function(configName, callback) {
         _sendEvent('getConfiguration', {
             callbackID: _waitForCallback(callback),


### PR DESCRIPTION
## Description
- Adds a new UITour function to open about:newtab and updates bedrock docs.
- ~~Marking as do-not-merge for now until uplifted to Firefox 51, but it is testable in the latest Nightly as of now.~~

## Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1322726

## Testing
Make sure it works as expected.

## Checklist
- [ ] Requires l10n changes.
- [ ] Related functional & integration tests passing.
