### PR TITLE
[bug 1323841] Remove boyd-announce switch from leadership page

### DIFF
--- a/bedrock/mozorg/templates/mozorg/about/leadership.html
+++ b/bedrock/mozorg/templates/mozorg/about/leadership.html
@@ -986,7 +986,6 @@
         </div>
       </article>
 
-    {% if switch('leadership-boyd-announce') %}
       <article id="ashley-boyd" data-id="ashley-boyd" class="vcard has-bio" itemscope itemtype="http://schema.org/Person">
         <figure class="headshot">
           <img class="photo" itemprop="image" alt="" src="{{ static('img/mozorg/about/leadership/ashley-boyd.jpg') }}">
@@ -1039,7 +1038,6 @@
           </p>
         </div>
       </article>
-    {% endif %}
 
       <article id="chris-lawrence" data-id="chris-lawrence" class="vcard has-bio" itemscope itemtype="http://schema.org/Person">
         <figure class="headshot">


### PR DESCRIPTION
## Description
Just cleans up the switch now that we no longer need it.

## Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1323841