### PR TITLE
Fix Bug 1328409 - Make Firefox pre-release redirects platform-aware

### DIFF
--- a/bedrock/firefox/redirects.py
+++ b/bedrock/firefox/redirects.py
@@ -10,6 +10,12 @@ def firefox_mobile_faq(request, *args, **kwargs):
     return 'firefox.android.faq'
 
 
+def firefox_channel(*args, **kwargs):
+    return platform_redirector('firefox.channel.desktop',
+                               'firefox.channel.android',
+                               'firefox.channel.ios')
+
+
 redirectpatterns = (
     # overrides
 
@@ -41,10 +47,10 @@ redirectpatterns = (
     # bug 657049, 1238851
     redirect(r'^firefox/accountmanager/?$', 'https://developer.mozilla.org/Persona'),
 
-    # Bug 1009247, 1101220, 1299947, 1314603
-    redirect(r'^(firefox/)?beta/?$', 'firefox.channel.desktop', anchor='beta'),
-    redirect(r'^(firefox/)?aurora/?$', 'firefox.channel.desktop', anchor='developer'),
-    redirect(r'^(firefox/)?nightly/?$', 'firefox.channel.desktop', anchor='nightly'),
+    # Bug 1009247, 1101220, 1299947, 1314603, 1328409
+    redirect(r'^(firefox/)?beta/?$', firefox_channel(), cache_timeout=0, anchor='beta'),
+    redirect(r'^(firefox/)?aurora/?$', firefox_channel(), cache_timeout=0, anchor='aurora'),
+    redirect(r'^(firefox/)?nightly/?$', firefox_channel(), cache_timeout=0, anchor='nightly'),
     redirect(r'^mobile/beta/?$', 'firefox.channel.android', anchor='beta'),
     redirect(r'^mobile/aurora/?$', 'firefox.channel.android', anchor='aurora'),
     redirect(r'^mobile/nightly/?$', 'firefox.channel.android', anchor='nightly'),
@@ -516,11 +522,7 @@ redirectpatterns = (
     redirect(r'^firefox(?:\/\d+\.\d+(?:\.\d+)?(?:a\d+)?)?/hello/start/?$', 'https://support.mozilla.org/kb/hello-status'),
 
     # bug 1299947, 1326383
-    redirect(r'^firefox/channel/?$',
-             platform_redirector('firefox.channel.desktop',
-                                 'firefox.channel.android',
-                                 'firefox.channel.ios'),
-             cache_timeout=0),
+    redirect(r'^firefox/channel/?$', firefox_channel(), cache_timeout=0),
 
     # Bug 1277196
     redirect(r'^firefox(?:\/\d+\.\d+(?:\.\d+)?(?:a\d+)?)?/firstrun/learnmore/?$', 'firefox.features'),

--- a/bedrock/firefox/templates/firefox/channel/desktop.html
+++ b/bedrock/firefox/templates/firefox/channel/desktop.html
@@ -56,6 +56,8 @@
 </section>
 
 <section id="developer" class="channel">
+  {#- Accept the channel name anchor as well, which is compatible with the Android channel page -#}
+  <span id="aurora"></span>
   <div class="container">
     <header>
       <h2>{{_('Developer Edition')}}</h2>

--- a/tests/redirects/map_globalconf.py
+++ b/tests/redirects/map_globalconf.py
@@ -8,6 +8,10 @@ import requests
 
 from .base import flatten, url_test
 
+UA_ANDROID = {'User-Agent': 'Mozilla/5.0 (Android 6.0.1; Mobile; rv:51.0) Gecko/51.0 Firefox/51.0'}
+UA_IOS = {'User-Agent': 'Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_3 like Mac OS X; de-de) '
+                        'AppleWebKit/533.17.9 (KHTML, like Gecko) Mobile/8F190'}
+
 URLS = flatten((
     # bug 832348 **/index.html -> **/
     url_test('/any/random/url/with/index.html', '/any/random/url/with/'),
@@ -174,24 +178,26 @@ URLS = flatten((
     # bug 1275483
     url_test('/firefox/nightly/whatsnew/', '/firefox/nightly/firstrun/'),
 
-    # bug 1299947, 1314603
-    url_test('/{firefox/,}beta/', '/firefox/channel/desktop/#beta'),
-    url_test('/{firefox/,}aurora/', '/firefox/channel/desktop/#developer'),
-    url_test('/{firefox/,}nightly/', '/firefox/channel/desktop/#nightly'),
-    url_test('/mobile/beta/', '/firefox/channel/android/#beta'),
-    url_test('/mobile/aurora/', '/firefox/channel/android/#aurora'),
-    url_test('/mobile/nightly/', '/firefox/channel/android/#nightly'),
+    # bug 1299947, 1314603, 1328409
+    url_test('/{beta,aurora,nightly}/', '/firefox/channel/android/#{beta,aurora,nightly}',
+             req_headers=UA_ANDROID, resp_headers={'Cache-Control': 'max-age=0'}),
+    url_test('/{beta,aurora,nightly}/', '/firefox/channel/ios/#{beta,aurora,nightly}',
+             req_headers=UA_IOS, resp_headers={'Cache-Control': 'max-age=0'}),
+    url_test('/{beta,aurora,nightly}/', '/firefox/channel/desktop/#{beta,aurora,nightly}',
+             resp_headers={'Cache-Control': 'max-age=0'}),
+    url_test('/firefox/{beta,aurora,nightly}/', '/firefox/channel/android/#{beta,aurora,nightly}',
+             req_headers=UA_ANDROID, resp_headers={'Cache-Control': 'max-age=0'}),
+    url_test('/firefox/{beta,aurora,nightly}/', '/firefox/channel/ios/#{beta,aurora,nightly}',
+             req_headers=UA_IOS, resp_headers={'Cache-Control': 'max-age=0'}),
+    url_test('/firefox/{beta,aurora,nightly}/', '/firefox/channel/desktop/#{beta,aurora,nightly}',
+             resp_headers={'Cache-Control': 'max-age=0'}),
+    url_test('/mobile/{beta,aurora,nightly}/', '/firefox/channel/android/#{beta,aurora,nightly}'),
 
     # bug 1299947, 1326383
     url_test('/firefox/channel/', '/firefox/channel/android/',
-             req_headers={'User-Agent': 'Mozilla/5.0 (Android 6.0.1; Mobile; rv:51.0) '
-                                        'Gecko/51.0 Firefox/51.0'},
-             resp_headers={'Cache-Control': 'max-age=0'}),
+             req_headers=UA_ANDROID, resp_headers={'Cache-Control': 'max-age=0'}),
     url_test('/firefox/channel/', '/firefox/channel/ios/',
-             req_headers={'User-Agent': 'Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_3 like '
-                                        'Mac OS X; de-de) AppleWebKit/533.17.9 (KHTML, '
-                                        'like Gecko) Mobile/8F190'},
-             resp_headers={'Cache-Control': 'max-age=0'}),
+             req_headers=UA_IOS, resp_headers={'Cache-Control': 'max-age=0'}),
     url_test('/firefox/channel/', '/firefox/channel/desktop/',
              resp_headers={'Cache-Control': 'max-age=0'}),
 


### PR DESCRIPTION
## Description

Like #4555, the following URLs should be redirected to an appropriate channel page depending on the UA. To simplify the code, I used the `aurora` anchor for the desktop Developer Edition as well. iOS doesn't have Nightly nor Aurora, but it's probably still better to show the iOS channel page instead of the desktop equivalent.

* https://www.mozilla.org/nightly/
* https://www.mozilla.org/aurora/
* https://www.mozilla.org/beta/
* https://www.mozilla.org/firefox/nightly/
* https://www.mozilla.org/firefox/aurora/
* https://www.mozilla.org/firefox/beta/

## Bugzilla link

[Bug 1328409](https://bugzilla.mozilla.org/show_bug.cgi?id=1328409)

## Testing

Spoof the UA string and visit those URLs, then make sure you're redirected to one of the platform-dependent locations.

## Checklist
- [ ] Requires l10n changes.
- [ ] Related functional & integration tests passing.
