### PR TITLE
[fix bug 1311643] Remove legacy 'virtual-pageview' GA event from scene2 of /firefox/new/

### DIFF
--- a/media/js/firefox/new/scene2.js
+++ b/media/js/firefox/new/scene2.js
@@ -2,55 +2,29 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-(function($, dataLayer) {
+(function($) {
     'use strict';
 
     var isIELT9 = window.Mozilla.Client.platform === 'windows' && /MSIE\s[1-8]\./.test(navigator.userAgent);
     var $directDownloadLink = $('#direct-download-link');
     var $platformLink = $('#download-button-wrapper-desktop .download-list li:visible .download-link');
-    var $stage = $('#stage');
-
-    // build virtualUrl for GA
-    var pathParts = window.location.pathname.split('/');
-    var queryStr = window.location.search ? window.location.search + '&' : '?';
-    var referrer = pathParts[pathParts.length - 2];
-    var locale = pathParts[1];
-    var virtualUrl = ('/' + locale + '/products/download.html' +
-                       queryStr + 'referrer=' + referrer);
-
+    var downloadURL;
 
     if ($platformLink.length) {
-        // Pull download link from the download button and add to the
-        // 'click here' link.
+        downloadURL = $platformLink.attr('href');
+
+        // Pull download link from the download button and add to the 'click here' link.
         // TODO: Remove and generate link in bedrock.
-        $directDownloadLink.attr('href', $platformLink.attr('href'));
+        $directDownloadLink.attr('href', downloadURL);
+
+        // if user is not on an IE that blocks JS triggered downloads, start the
+        // platform-detected download after window (read: images) have loaded.
+        // only auto-start the download if a visible platform link is detected.
+        if (!isIELT9) {
+            $(window).on('load', function() {
+                window.location.href = downloadURL;
+            });
+        }
     }
 
-    // #direct-download-link = "click here" text on page
-    // .download-link = any links in download button (which are effectively
-    // hidden, but could be clicked by screen reader?)
-    $stage.on('click', '#direct-download-link, .download-link', function(e) {
-        e.preventDefault();
-
-        var url = $(e.currentTarget).attr('href');
-
-        // An iframe cannot be used here to trigger the download because
-        // it will be blocked by Chrome if the download link redirects
-        // to a HTTP URI and we are on HTTPS.
-        dataLayer.push({
-            'event': 'virtual-pageview',
-            'virtualUrl': virtualUrl
-        });
-
-        window.location.href = url;
-    });
-
-    // if user is not on an IE that blocks JS triggered downloads, start the
-    // platform-detected download after window (read: images) have loaded.
-    // only auto-start the download if a visible platform link is detected.
-    if (!isIELT9 && $platformLink.length) {
-        $(window).on('load', function() {
-            $directDownloadLink.trigger('click');
-        });
-    }
-})(window.jQuery, window.dataLayer = window.dataLayer || []);
+})(window.jQuery);


### PR DESCRIPTION
## Description
- Removes legacy GA download event, simplifying the JS for scene2 of the download page considerably.

## Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1311643

## Testing
https://bedrock-demo-agibson.us-west.moz.works/en-US/firefox/new/

## Checklist
- [ ] Requires l10n changes.
- [ ] Related functional & integration tests passing.
