### PR TITLE
Add Stylelint to gulp and CI

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -1,0 +1,43 @@
+{
+  "rules": {
+    "color-no-invalid-hex": true,
+    "font-family-no-duplicate-names": true,
+    "font-family-name-quotes": ["always-where-recommended", { "severity": "warning" }],
+    "function-name-case": "lower",
+    "function-url-no-scheme-relative": true,
+    "function-url-quotes": ["always", { "severity": "warning" }],
+    "number-no-trailing-zeros": [true, { "severity": "warning" }],
+    "length-zero-no-unit": [true, { "severity": "warning" }],
+    "unit-case": "lower",
+    "unit-no-unknown": true,
+    "property-case": "lower",
+    "property-no-unknown": true,
+    "keyframe-declaration-no-important": true,
+    "declaration-no-important": true,
+    "declaration-block-no-ignored-properties": true,
+    "declaration-block-no-shorthand-property-overrides": true,
+    "declaration-block-single-line-max-declarations": [1, { "severity": "warning" }],
+    "declaration-block-trailing-semicolon": ["always", { "severity": "warning" }],
+    "block-no-empty": true,
+    "selector-no-empty": true,
+    "selector-pseudo-class-no-unknown": true,
+    "selector-pseudo-element-no-unknown": true,
+    "selector-pseudo-element-case": "lower",
+    "selector-type-case": "lower",
+    "selector-type-no-unknown": true,
+    "selector-max-empty-lines": 0,
+    "media-feature-name-case": "lower",
+    "media-feature-name-no-unknown": [true, {
+      ignoreMediaFeatureNames: ["min--moz-device-pixel-ratio"]
+    }],
+    "media-feature-no-missing-punctuation": true,
+    "stylelint-disable-reason": "always-before",
+    "comment-no-empty": true,
+    "max-nesting-depth": [5, { "severity": "warning" }],
+    "no-invalid-double-slash-comments": true,
+    "no-unknown-animations": true,
+    "no-extra-semicolons": true,
+    "no-missing-end-of-source-newline": [true, { "severity": "warning" }],
+    "no-eol-whitespace": [true, { "severity": "warning" }]
+  }
+}

--- a/bedrock/firefox/templates/firefox/desktop/desktop-base.html
+++ b/bedrock/firefox/templates/firefox/desktop/desktop-base.html
@@ -29,7 +29,7 @@
     <div class="container">
       <div id="subscribe-wrapper">
         {# L10n: Line break for visual formatting. #}
-        {{ email_newsletter_form(title=_('Keep up with<br> all things Firefox.'), button_class='button-light') }}
+        {{ email_newsletter_form(title=_('Keep up with<br> all things Firefox.'), button_class='button-light', spinner_color='#fff') }}
       </div>
       <div id="download-wrapper">
         {{ download_firefox() }}

--- a/bedrock/firefox/templates/firefox/new/scene1.html
+++ b/bedrock/firefox/templates/firefox/new/scene1.html
@@ -126,7 +126,7 @@
     </section>
     <aside id="newsletter-subscribe">
       <div class="container">
-        {{ email_newsletter_form(title=_('Keep up with<br> all things Firefox.'), button_class='button-light') }}
+        {{ email_newsletter_form(title=_('Keep up with<br> all things Firefox.'), button_class='button-light', spinner_color='#fff') }}
       </div>
     </aside>
   </div>

--- a/circle.yml
+++ b/circle.yml
@@ -33,6 +33,7 @@ test:
   pre:
     - mkdir -p "$CIRCLE_TEST_REPORTS/django"
   override:
+    - gulp css:lint
     - gulp js:lint
     - gulp js:test
     - make test-image

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -9,12 +9,20 @@ const del = require('del');
 const karma = require('karma');
 const eslint = require('gulp-eslint');
 const watch = require('gulp-watch');
+const gulpStylelint = require('gulp-stylelint');
 
-const lintPaths = [
+const lintPathsJS = [
     'media/js/**/*.js',
     '!media/js/libs/*.js',
     'tests/unit/spec/**/*.js',
     'gulpfile.js'
+];
+
+const lintPathsCSS = [
+    'media/css/**/*.scss',
+    'media/css/**/*.less',
+    'media/css/**/*.css',
+    '!media/css/libs/*'
 ];
 
 gulp.task('media:watch', () => {
@@ -33,10 +41,21 @@ gulp.task('js:test', done => {
 });
 
 gulp.task('js:lint', () => {
-    return gulp.src(lintPaths)
+    return gulp.src(lintPathsJS)
         .pipe(eslint())
         .pipe(eslint.format())
         .pipe(eslint.failAfterError());
+});
+
+
+gulp.task('css:lint', () => {
+    return gulp.src(lintPathsCSS)
+        .pipe(gulpStylelint({
+            reporters: [{
+                formatter: 'string',
+                console: true
+            }]
+        }));
 });
 
 gulp.task('static:clean', () => {
@@ -45,5 +64,21 @@ gulp.task('static:clean', () => {
 
 gulp.task('default', () => {
     gulp.start('media:watch');
-    gulp.watch(lintPaths, ['js:lint']);
+
+    gulp.watch(lintPathsJS).on('change', file => {
+        return gulp.src(file.path)
+            .pipe(eslint())
+            .pipe(eslint.format());
+    });
+
+    gulp.watch(lintPathsCSS).on('change', file => {
+        return gulp.src(file.path)
+            .pipe(gulpStylelint({
+                failAfterError: false,
+                reporters: [{
+                    formatter: 'string',
+                    console: true
+                }]
+            }));
+    });
 });

--- a/lockdown.json
+++ b/lockdown.json
@@ -1,4 +1,7 @@
 {
+  "JSONStream": {
+    "0.8.4": "91657dfe6ff857483066132b4618b62e8f4887bd"
+  },
   "abbrev": {
     "1.0.7": "5b6035b2ee9d4fb5cf859f08a9be81b208491843",
     "1.0.9": "91b4792588a7738c25f35dd6f63752a2f8776135"
@@ -17,10 +20,12 @@
     "0.8.1": "ab5d4fb883f596816d3515f8f791c0af486dd627"
   },
   "ajv": {
+    "4.10.3": "3e4fea9675b157de7888b80dd0ed735b83f28e11",
     "4.9.0": "5a358085747b134eb567d6d15e015f1d7802f45c"
   },
   "ajv-keywords": {
-    "1.1.1": "02550bc605a3e576041565628af972e06c549d50"
+    "1.1.1": "02550bc605a3e576041565628af972e06c549d50",
+    "1.5.0": "c11e6859eafff83e0dafc416929472eca946aa2c"
   },
   "align-text": {
     "0.1.4": "0cd90a561093f35d0a99256c22b7069433fad117"
@@ -109,6 +114,9 @@
   "asynckit": {
     "0.4.0": "c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
   },
+  "autoprefixer": {
+    "6.6.1": "11a4077abb4b313253ec2f6e1adb91ad84253519"
+  },
   "aws-sign2": {
     "0.6.0": "14342dd38dbcc94d0e5b87d763cd63612c0e794f"
   },
@@ -177,6 +185,9 @@
     "0.1.5": "c085711085291d8b75fdd74eab0f8597280711e6",
     "1.8.5": "ba77962e12dff969d6b76711e914b737857bf6a7"
   },
+  "browserslist": {
+    "1.5.1": "67c3f2a1a6ad174cd01d25d2362e6e6083b26986"
+  },
   "buffer-shims": {
     "1.0.0": "9978ce317388c649ad8793028c3477ef044a8b51"
   },
@@ -205,6 +216,9 @@
   },
   "camelcase-keys": {
     "2.1.0": "308beeaffdf28119051efa1d932213c91b8f92e7"
+  },
+  "caniuse-db": {
+    "1.0.30000604": "bc139270a777564d19c0aadcd832b491d093bda5"
   },
   "caseless": {
     "0.11.0": "715b96ea9841593cc33067923f5ec60ebda4f7d7"
@@ -235,6 +249,9 @@
     "0.2.0": "c6126a90ad4f72dbf5acdb243cc37724fe93fc1f",
     "1.0.2": "260b7a99ebb1edfe247538175f783243cb19d149"
   },
+  "clone-regexp": {
+    "1.0.0": "eae0a2413f55c0942f818c229fefce845d7f3b1c"
+  },
   "clone-stats": {
     "0.0.1": "b88f94a82cf38b8791d58046ea4029ad88ca99d1"
   },
@@ -244,6 +261,12 @@
   "code-point-at": {
     "1.0.0": "f69b192d3f7d91e382e4b71bddb77878619ab0c6",
     "1.1.0": "0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
+  },
+  "color-diff": {
+    "0.1.7": "6db78cd9482a8e459d40821eaf4b503283dcb8e2"
+  },
+  "colorguard": {
+    "1.2.0": "f3facaf5caaeba4ef54653d9fb25bb73177c0d84"
   },
   "colors": {
     "1.1.2": "168a4701756b6a7f51a12ce0c97bfa28c084ed63"
@@ -288,11 +311,23 @@
   "core-util-is": {
     "1.0.2": "b5fd54220aa2bc5ab57aab7140c940754503c1a7"
   },
+  "cosmiconfig": {
+    "2.1.1": "817f2c2039347a1e9bf7d090c0923e53f749ca82"
+  },
   "cross-spawn": {
     "3.0.1": "1256037ecb9f0c5f79e3d6ef135e30770184b982"
   },
   "cryptiles": {
     "2.0.5": "3bdfecdc608147c1c67202fa291e7dca59eaa3b8"
+  },
+  "css-color-names": {
+    "0.0.3": "de0cef16f4d8aa8222a320d5b6d7e9bbada7b9f6"
+  },
+  "css-rule-stream": {
+    "1.1.0": "3786e7198983d965a26e31957e09078cbb7705a2"
+  },
+  "css-tokenize": {
+    "1.0.1": "4625cb1eda21c143858b7f81d6803c1d26fc14be"
   },
   "currently-unhandled": {
     "0.4.1": "988df33feab191ef799a61369dd76c17adf957ea"
@@ -307,7 +342,8 @@
     "1.14.0": "29e486c5418bf0f356034a993d51686a33e84141"
   },
   "dateformat": {
-    "1.0.12": "9f124b67594c937ff706932e4a642cca8dbbfee9"
+    "1.0.12": "9f124b67594c937ff706932e4a642cca8dbbfee9",
+    "2.0.0": "2743e3abb5c3fc2462e527dca445e04e9f4dee17"
   },
   "debug": {
     "0.7.4": "06e1ea8082c2cb14e39806e22e2f6f757f92af39",
@@ -321,7 +357,7 @@
     "1.2.0": "f6534d15148269b20352e7bee26f501f9a191290"
   },
   "deep-extend": {
-    "0.4.1": "*"
+    "0.4.1": "efe4113d08085f4e6f9687759810f807469e2253"
   },
   "deep-is": {
     "0.1.3": "b369d6fb5dbc13eecf524f91b070feedc357cf34"
@@ -356,8 +392,14 @@
   "doctrine": {
     "1.5.0": "379dce730f6166f76cefa4e6707a159b02c5a6fa"
   },
+  "doiuse": {
+    "2.5.0": "c7f156965d054bf4d699a4067af1cadbc7350b7c"
+  },
   "dom-serialize": {
     "2.2.1": "562ae8999f44be5ea3076f5419dcd59eb43ac95b"
+  },
+  "duplexer": {
+    "0.1.1": "ace6ff808c1ce66b57d1ebf97977acb02334cfc1"
   },
   "duplexer2": {
     "0.0.2": "c614dcf67e2fb14995a91711e5a617e8a60a31db"
@@ -445,6 +487,9 @@
   "eventemitter3": {
     "1.2.0": "1c86991d816ad1e504750e73874224ecf3bec508"
   },
+  "execall": {
+    "1.0.0": "73d0904e395b3cab0658b08d09ec25307f29bb73"
+  },
   "exit-hook": {
     "1.1.1": "f05ca233b48c05d54fff07765df8507e95c02ff8"
   },
@@ -471,7 +516,8 @@
     "1.0.2": "e1080e0658e300b06294990cc70e1502235fd550"
   },
   "fancy-log": {
-    "1.2.0": "d5a51b53e9ab22ca07d558f2b67ae55fdb5fcbd8"
+    "1.2.0": "d5a51b53e9ab22ca07d558f2b67ae55fdb5fcbd8",
+    "1.3.0": "45be17d02bb9917d60ccffd4995c999e6c8c9948"
   },
   "fast-levenshtein": {
     "2.0.5": "bd33145744519ab1c36c3ee9f31f08e9079b67f2"
@@ -513,6 +559,9 @@
   "flat-cache": {
     "1.2.1": "6c837d6225a7de5659323740b36d5361f71691ff"
   },
+  "flatten": {
+    "1.0.2": "dae46a9d78fbe25292258cc1e780a41d95c03782"
+  },
   "for-in": {
     "0.1.6": "c9f96e89bfad18a545af5ec3ed352a1d9e5b4dc8"
   },
@@ -544,6 +593,9 @@
   "fstream-ignore": {
     "1.0.5": "*"
   },
+  "gather-stream": {
+    "1.0.0": "b33994af457a8115700d410f317733cbe7a0904b"
+  },
   "gauge": {
     "2.6.0": "d35301ad18e96902b4751dcbbe40f4218b942a46"
   },
@@ -561,7 +613,8 @@
     "1.0.2": "f702e63127e7e231c160a80c1554acb70d5047e5"
   },
   "get-stdin": {
-    "4.0.1": "b968c6b0a04384324902e8bf1a5df32579a450fe"
+    "4.0.1": "b968c6b0a04384324902e8bf1a5df32579a450fe",
+    "5.0.1": "122e161591e21ff4c52530305693f20e6393a398"
   },
   "getpass": {
     "0.1.6": "283ffd9fc1256840875311c1b60e8c40187110e6"
@@ -605,7 +658,11 @@
     "9.13.0": "d97706b61600d8dbe94708c367d3fdcf48470b8f"
   },
   "globby": {
-    "5.0.0": "ebd84667ca0dbb330b99bcfc68eac2bc54370e0d"
+    "5.0.0": "ebd84667ca0dbb330b99bcfc68eac2bc54370e0d",
+    "6.1.0": "f5a6d70e8395e21c858fb0489d64df02424d506c"
+  },
+  "globjoin": {
+    "0.1.4": "2f4494ac8919e3767c5cbb691e9f463324285d43"
   },
   "globule": {
     "0.1.0": "d9c8edde1da79d125a151b79533b978676346ae5",
@@ -631,8 +688,12 @@
   "gulp-eslint": {
     "3.0.1": "04e57e3e18c6974267c12cf6855dc717d4a313bd"
   },
+  "gulp-stylelint": {
+    "3.7.0": "199bd968fbe6447088a584dc7d665543f9fa97b4"
+  },
   "gulp-util": {
-    "3.0.7": "78925c4b8f8b49005ac01a011c557e6218941cbb"
+    "3.0.7": "78925c4b8f8b49005ac01a011c557e6218941cbb",
+    "3.0.8": "0054e1e744502e27c04c187c3ecc505dd54bbb4f"
   },
   "gulp-watch": {
     "4.3.10": "776920ab54595c95f3597fb5444e61fc7bbd58a3"
@@ -677,6 +738,9 @@
   "hosted-git-info": {
     "2.1.5": "0ba81d90da2e25ab34a332e6ec77936e1598118b"
   },
+  "html-tags": {
+    "1.1.1": "869f43859f12d9bdc3892419e494a628aa1b204e"
+  },
   "http-errors": {
     "1.5.1": "788c0d2c1de2c81b9e6e8c01843b6b97eb920750"
   },
@@ -704,6 +768,9 @@
   "indent-string": {
     "2.1.0": "8e2d48348742121b4a8218b7a137e9a52049dc80"
   },
+  "indexes-of": {
+    "1.0.1": "f30f716c8e2bd346c7b67d3df3915566a7c05607"
+  },
   "indexof": {
     "0.0.1": "82dc336d232b9062179d05ab3293a66059fd435d"
   },
@@ -728,6 +795,9 @@
   },
   "invert-kv": {
     "1.0.0": "104a8e4aaca6d3d8cd157a8ef8bfab2d7a3ffdb6"
+  },
+  "irregular-plurals": {
+    "1.2.0": "38f299834ba8c00c30be9c554e137269752ff3ac"
   },
   "is-absolute": {
     "0.2.6": "20de69f3db942ef2d87b9c2da36f172235b1b5eb"
@@ -794,11 +864,17 @@
   "is-property": {
     "1.0.2": "57fe1c4e48474edd65b09911f26b1cd4095dda84"
   },
+  "is-regexp": {
+    "1.0.0": "fd2d883545c46bac5a633e7b9a09e87fa2cb5069"
+  },
   "is-relative": {
     "0.2.1": "d27f4c7d516d175fb610db84bbeef23c3bc97aa5"
   },
   "is-resolvable": {
     "1.0.0": "8df57c61ea2e3c501408d100fb013cf8d6e0cc62"
+  },
+  "is-supported-regexp-flag": {
+    "1.0.0": "8b520c85fae7a253382d4b02652e045576e13bb8"
   },
   "is-typedarray": {
     "1.0.0": "e479c80858df0c1b11ddda6940f96011fcda4a9a"
@@ -840,6 +916,9 @@
   "jodid25519": {
     "1.0.2": "06d4912255093419477d425633606e0e90782967"
   },
+  "js-base64": {
+    "2.1.9": "f0e80ae039a4bd654b5f281fc93f04a914a7fcce"
+  },
   "js-tokens": {
     "2.0.0": "79903f5563ee778cc1162e6dcf1a0027c97f9cb5"
   },
@@ -866,8 +945,14 @@
     "3.2.6": "f6efc93c06a04de9aec53053df2559bb19e2038b",
     "3.3.2": "3c0434743df93e2f5c42aee7b19bcb483575f4e1"
   },
+  "jsonfilter": {
+    "1.1.2": "21ef7cedc75193813c75932e96a98be205ba5a11"
+  },
   "jsonify": {
     "0.0.0": "2c74b6ee41d93ca51b7b5aaee8f503631d252a73"
+  },
+  "jsonparse": {
+    "0.0.5": "330542ad3f0a654665b778f3eb2d9a9fa507ac64"
   },
   "jsonpointer": {
     "2.0.0": "3af1dd20fe85463910d469a385e33017d2a030d9",
@@ -892,11 +977,17 @@
   "kind-of": {
     "3.0.4": "7b8ecf18a4e17f8269d73b501c9f232c96887a74"
   },
+  "known-css-properties": {
+    "0.0.6": "71a0b8fde1b6e3431c471efbc3d9733faebbcfbf"
+  },
   "lazy-cache": {
     "1.0.4": "a1d78fc3a50474cb80845d3b3b6e1da49a446e8e"
   },
   "lcid": {
     "1.0.0": "308accafa0bc483a3867b4b6f2b9506251d1b835"
+  },
+  "ldjson-stream": {
+    "1.2.1": "91beceda5ac4ed2b17e649fb777e7abfa0189c2b"
   },
   "less": {
     "2.7.1": "6cbfea22b3b830304e9a5fb371d54fa480c9d7cf"
@@ -917,7 +1008,8 @@
     "1.0.2": "8f57560c83b59fc270bd3d561b690043430e2551",
     "3.10.1": "5bf45e8e49ba4189e17d482789dfd15bd140b7b6",
     "4.16.6": "d22c9ac660288f3843e16ba7d2b5d06cca27d777",
-    "4.17.2": "34a3055babe04ce42467b607d700072c7ff6bf42"
+    "4.17.2": "34a3055babe04ce42467b607d700072c7ff6bf42",
+    "4.17.4": "78203a4d1c328ae1d86dca6460e369b57f4055ae"
   },
   "lodash._basecopy": {
     "3.0.1": "8da0e6a876cf344c0ad8a54882111dd3c5c7ca36"
@@ -991,6 +1083,9 @@
   "lodash.templatesettings": {
     "3.1.1": "fb307844753b66b9f1afa54e262c745307dba8e5"
   },
+  "log-symbols": {
+    "1.0.2": "376ff7b58ea3086a0f09facc74617eca501e1a18"
+  },
   "log4js": {
     "0.6.38": "2c494116695d6fb25480943d3fc872e662a522fd"
   },
@@ -1053,6 +1148,9 @@
     "0.7.1": "9cd13c03adbff25b65effde7ce864ee952017098",
     "0.7.2": "ae25cf2512b3885a1d95d7f037868d8431124765"
   },
+  "multimatch": {
+    "2.1.0": "9c7906a22fb4c02919e2f5f75161b4cdbd4b2a2b"
+  },
   "multipipe": {
     "0.1.2": "2a8f2ddf70eed564dff2d57f1e1a137d9f05078b"
   },
@@ -1092,11 +1190,20 @@
   "normalize-path": {
     "2.0.1": "47886ac1662760d4261b7d979d241709d3ce3f7a"
   },
+  "normalize-range": {
+    "0.1.2": "2d10c06bdfd312ea9777695a4d28439456b75942"
+  },
+  "normalize-selector": {
+    "0.2.0": "d0b145eb691189c63a78d201dc4fdb1293ef0c03"
+  },
   "npmconf": {
     "1.1.5": "07777bea48d78eed75a4258962a09f3dc7b6b916"
   },
   "npmlog": {
     "3.1.2": "2d46fa874337af9498a2f12bb43d8d0be4a36873"
+  },
+  "num2fraction": {
+    "1.2.2": "6f682b6a027a4e9ddfa4564cd2589d1d4e669ede"
   },
   "number-is-nan": {
     "1.0.0": "c020f529c5282adfdd233d91d4b181c3d686dc4b",
@@ -1122,6 +1229,9 @@
     "1.3.2": "d8feeca93b039ec1dcdee7741c92bdac5e28081b",
     "1.3.3": "b2e261557ce4c314ec8304f3fa82663e4297ca20",
     "1.4.0": "583b1aa775961d4b113ac17d9c50baef9dd76bd1"
+  },
+  "onecolor": {
+    "3.0.4": "75a46f80da6c7aaa5b4daae17a47198bd9652494"
   },
   "onetime": {
     "1.1.0": "a1f7838f8314c516f05ecefcbc4ccfe04b4ed789"
@@ -1209,8 +1319,39 @@
   "pinkie-promise": {
     "2.0.1": "2135d6dfa7a358c069ac9b178776288228450ffa"
   },
+  "pipetteur": {
+    "2.0.3": "1955760959e8d1a11cb2a50ec83eec470633e49f"
+  },
+  "plur": {
+    "2.1.2": "7482452c1a0f508e3e344eaec312c91c29dc655a"
+  },
   "pluralize": {
     "1.2.1": "d1a21483fd22bb41e58a12fa3421823140897c45"
+  },
+  "postcss": {
+    "5.2.8": "05720c49df23c79bda51fd01daeb1e9222e94390"
+  },
+  "postcss-less": {
+    "0.14.0": "c631b089c6cce422b9a10f3a958d2bedd3819324"
+  },
+  "postcss-media-query-parser": {
+    "0.2.3": "27b39c6f4d94f81b1a73b8f76351c609e5cef244"
+  },
+  "postcss-reporter": {
+    "1.4.1": "c136f0a5b161915f379dd3765c61075f7e7b9af2",
+    "3.0.0": "09ea0f37a444c5693878606e09b018ebeff7cf8f"
+  },
+  "postcss-resolve-nested-selector": {
+    "0.1.1": "29ccbc7c37dedfac304e9fff0bf1596b3f6a0e4e"
+  },
+  "postcss-scss": {
+    "0.4.0": "087c052c529b9270d9580bd1248a0f93d3b40d57"
+  },
+  "postcss-selector-parser": {
+    "2.2.2": "3d70f5adda130da51c7c0c2fc023f56b1374fe08"
+  },
+  "postcss-value-parser": {
+    "3.3.0": "87f38f9f18f774a4ab4c8a232f5c5ce8872a9d15"
   },
   "prelude-ls": {
     "1.1.2": "21932a549f5e52ffd9a827f570e04be62a97da54"
@@ -1254,6 +1395,9 @@
   },
   "rc": {
     "1.1.6": "*"
+  },
+  "read-file-stdin": {
+    "0.2.1": "25eccff3a153b6809afacb23ee15387db9e0ee61"
   },
   "read-installed": {
     "3.1.0": "47075ba8828147ed495084df779f29a4329ad3df"
@@ -1312,6 +1456,9 @@
   "require-directory": {
     "2.1.1": "8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
   },
+  "require-from-string": {
+    "1.2.1": "529c9ccef27380adfec9a2f965b649bbee636418"
+  },
   "require-main-filename": {
     "1.0.1": "97f717b69d48784f5f526a6c5aa8ffdda055a4d1"
   },
@@ -1328,7 +1475,8 @@
     "0.1.1": "b219259a5602fac5c5c496ad894a6e8cc430261e"
   },
   "resolve-from": {
-    "1.0.1": "26cbfe935d1aeeeabb29bc3fe5aeb01e93d44226"
+    "1.0.1": "26cbfe935d1aeeeabb29bc3fe5aeb01e93d44226",
+    "2.0.0": "9480ab20e94ffa1d9e80a804c7ea147611966b57"
   },
   "restore-cursor": {
     "1.0.1": "34661f46886327fed2991479152252df92daa541"
@@ -1423,6 +1571,12 @@
   "spdx-license-ids": {
     "1.2.2": "c9df7a3424594ade6bd11900d596696dc06bac57"
   },
+  "specificity": {
+    "0.3.0": "332472d4e5eb5af20821171933998a6bc3b1ce6f"
+  },
+  "split2": {
+    "0.2.1": "02ddac9adc03ec0bb78c1282ec079ca6e85ae900"
+  },
   "sprintf-js": {
     "1.0.3": "04e6926f662895354f3dd015203633b857297e2c"
   },
@@ -1432,6 +1586,9 @@
   },
   "statuses": {
     "1.3.1": "faf51b9eb74aaef3b3acf4ad5f61abf24cb7b93e"
+  },
+  "stream-combiner": {
+    "0.2.2": "aec8cbac177b56b6f4fa479ced8c1912cee52858"
   },
   "stream-consume": {
     "0.1.0": "a41ead1a6d6081ceb79f65b061901b6d8f3d1d0f"
@@ -1464,12 +1621,31 @@
   "strip-json-comments": {
     "1.0.4": "1e15fbcac97d3ee99bf2d73b4c656b082bbafb91"
   },
+  "style-search": {
+    "0.1.0": "7958c793e47e32e07d2b5cafe5c0bf8e12e77902"
+  },
+  "stylehacks": {
+    "2.3.1": "de49e8baa2e12b29c35b416b337094839bc97b35"
+  },
+  "stylelint": {
+    "7.7.1": "af30b6677e307d38b0ad64b70e719c1752973c67"
+  },
+  "sugarss": {
+    "0.2.0": "ac34237563327c6ff897b64742bf6aec190ad39e"
+  },
   "supports-color": {
     "2.0.0": "535d045ce6b6363fa40117084629995e9df324c7",
     "3.1.2": "72a262894d9d408b956ca05ff37b2ed8a6e2a2d5"
   },
+  "svg-tags": {
+    "1.0.0": "58f71cee3bd519b59d4b2a843b6c7de64ac04764"
+  },
+  "synesthesia": {
+    "1.0.1": "5ef95ea548c0d5c6e6f9bb4b0d0731dff864a777"
+  },
   "table": {
-    "3.8.3": "2bbc542f0fda9861a755d3947fefd8b3f513855f"
+    "3.8.3": "2bbc542f0fda9861a755d3947fefd8b3f513855f",
+    "4.0.1": "a8116c133fac2c61f4a420ab6cdf5c4d61f0e435"
   },
   "tar": {
     "2.2.1": "8e4d2a256c0e2185c6b18ad694aec968b83cb1d1"
@@ -1485,7 +1661,8 @@
   },
   "through2": {
     "0.6.5": "41ab9c67b29d57209071410e1d7a7a968cd3ad48",
-    "2.0.1": "384e75314d49f32de12eebb8136b8eb6b5d59da9"
+    "2.0.1": "384e75314d49f32de12eebb8136b8eb6b5d59da9",
+    "2.0.3": "0004569b37c7c74ba39c43f3ced78d1ad94140be"
   },
   "tildify": {
     "1.2.0": "dcec03f55dca9b7aa3e5b04f21817eb56e63588a"
@@ -1538,6 +1715,9 @@
   },
   "unc-path-regex": {
     "0.1.2": "e73dd3d7b0d7c5ed86fbac6b0ae7d8c6a69d50fa"
+  },
+  "uniq": {
+    "1.0.1": "b31c5ae8254844a3a8281541ce2b04b865a734ff"
   },
   "unique-stream": {
     "1.0.0": "d59a4a75427447d9aa6c91e70263f8d26a4b104b"
@@ -1598,6 +1778,7 @@
   },
   "window-size": {
     "0.1.0": "5438cd2ea93b202efa3a19fe8887aee7c94f9c9d",
+    "0.1.4": "f8e1aa1ee5a53ec5bf151ffa09742a6ad7697876",
     "0.2.0": "b4315bb4214a3d7058ebeee892e13fa24d98b075"
   },
   "wordwrap": {
@@ -1614,6 +1795,9 @@
   },
   "write": {
     "0.2.1": "5fc03828e264cea3fe91455476f7a3c566cb0757"
+  },
+  "write-file-stdout": {
+    "0.0.2": "c252d7c7c5b1b402897630e3453c7bfe690d9ca1"
   },
   "ws": {
     "1.1.1": "082ddb6c641e85d4bb451f03d52f06eabdb1f018"
@@ -1634,7 +1818,9 @@
     "2.0.0": "306c543835f09ee1a4cb23b7bce9ab341c91cdd4"
   },
   "yargs": {
+    "1.3.3": "054de8b61f22eefdb7207059eaef9d6b83fb931a",
     "3.10.0": "f7ee7bd857dd7c1d2d38c0e74efbd681d1431fd1",
+    "3.32.0": "03088e9ebf9e756b69751611d2a5ef591482c995",
     "4.8.1": "c0c42924ca4aaa6b0e6da1739dfb216439f9ddc0"
   },
   "yargs-parser": {

--- a/media/css/base/menu-resp.less
+++ b/media/css/base/menu-resp.less
@@ -88,7 +88,6 @@
         a:hover,
         a:focus,
         a:active {
-            background-image: none;
             background: rgb(227,235,244);
             background: rgba(152,178,201,0.2);
             -moz-transition: background 0.1s ease-out;
@@ -184,11 +183,6 @@ html[dir="rtl"] #nav-main .submenu {
         .box-shadow(0 2px 3px rgba(0,0,0,.35));
         opacity: 1;
         padding: 0;
-    }
-
-    .js #nav-main li .submenu {
-        xleft: 80px;
-        xtop: auto;
     }
 
     #nav-main-menu .submenu a,

--- a/media/css/base/menu.less
+++ b/media/css/base/menu.less
@@ -105,7 +105,6 @@ body.html-rtl #nav-main li ul {
         a:hover,
         a:focus,
         a:active {
-            background-image: none;
             background: rgb(227,235,244);
             background: rgba(152,178,201,0.2);
             -moz-transition: background 0.1s ease-out;

--- a/media/css/base/mozilla-modal.less
+++ b/media/css/base/mozilla-modal.less
@@ -61,8 +61,6 @@ html.noscroll body {
                     background-position: center center;
                     background-repeat: no-repeat;
                     background-size: 22px 22px;
-                    filter: progid:DXImageTransform.Microsoft.gradient(enabled = false);
-                    -ms-filter: progid:DXImageTransform.Microsoft.gradient(enabled = false);
                     padding: 0;
                     min-width: 0;
                     width: 42px;

--- a/media/css/firefox/accounts.less
+++ b/media/css/firefox/accounts.less
@@ -107,7 +107,7 @@ aside {
 .non-firefox,
 .old-firefox,
 .button.button-dark.firefox-ios,
-.button.button-dark.firefox-android, {
+.button.button-dark.firefox-android {
     display: none;
 }
 

--- a/media/css/firefox/all.less
+++ b/media/css/firefox/all.less
@@ -143,8 +143,7 @@ body.nightly {
             }
         }
         .unavailable {
-            padding-right: @baseLine * 2;
-            padding: 10px 10px 10px 10px;
+            padding: 10px;
             background-repeat: no-repeat;
             color: @textColorTertiary;
             text-shadow: 0 -1px #fff;

--- a/media/css/firefox/android.less
+++ b/media/css/firefox/android.less
@@ -107,28 +107,6 @@
     }
 }
 
-// Only displayed if the user is on iOS
-.ios-link {
-    display: none;
-    max-width: 15em;
-    margin: @baseLine auto;
-    color: #fff;
-    .font-size(@largeFontSize);
-
-    a {
-        color: #fff;
-        text-decoration: underline;
-    }
-
-    & a:after {
-        content: '' !important;
-    }
-}
-
-.ios .ios-link {
-    display: block;
-}
-
 #intro-phone-tablet {
     z-index: 1;
 }

--- a/media/css/firefox/australis/fx38_0_5/firstrun.less
+++ b/media/css/firefox/australis/fx38_0_5/firstrun.less
@@ -107,7 +107,8 @@ h2 {
 
         li {
             display: inline;
-            margin: 0 10px;
+            margin-left: 10px;
+            margin-right: 10px;
 
             &:after {
                 content: '•';

--- a/media/css/firefox/desktop/common.less
+++ b/media/css/firefox/desktop/common.less
@@ -87,11 +87,6 @@ html[dir="rtl"] {
     }
 }
 
-//override JS inline color style for spin.js
-#newsletter-spinner .spinner > div > div {
-    background-color: #fff !important;
-}
-
 // force dl button links to be white in blue bg footer
 #subscribe-download-wrapper .download-button small.download-other {
     color: #fff;
@@ -876,9 +871,9 @@ html[dir="rtl"] {
     }
 
     #download-wrapper {
-        // js displays the buttons for non fx browsers, so this needs to be
-        // important to override the generated inline style
-        display: none !important;
+        /* js displays the buttons for non fx browsers, so this needs to be
+         * important to override the generated inline style */
+        display: none !important; /* stylelint-disable-line declaration-no-important */
     }
 
     #main-content .container {

--- a/media/css/firefox/desktop/customize.less
+++ b/media/css/firefox/desktop/customize.less
@@ -528,7 +528,7 @@ html[dir="rtl"] {
             30% { opacity: 1; }
             50% {
                 opacity: 1;
-                webkit-transform: scale3d(1.2, 1.2, 0);
+                -webkit-transform: scale3d(1.2, 1.2, 0);
                 transform: scale3d(1.2, 1.2, 0);
             }
             100% {

--- a/media/css/firefox/firstrun/firstrun-horizon.less
+++ b/media/css/firefox/firstrun/firstrun-horizon.less
@@ -235,7 +235,8 @@ footer {
 
         li {
             display: inline;
-            margin: 0 10px;
+            margin-left: 10px;
+            margin-right: 10px;
 
             &:after {
                 color: #fff;

--- a/media/css/firefox/firstrun/firstrun.less
+++ b/media/css/firefox/firstrun/firstrun.less
@@ -150,7 +150,8 @@ footer {
 
         li {
             display: inline;
-            margin: 0 10px;
+            margin-left: 10px;
+            margin-right: 10px;
 
             &:after {
                 content: '•';

--- a/media/css/firefox/new/common.less
+++ b/media/css/firefox/new/common.less
@@ -36,7 +36,6 @@
 }
 
 #tabzilla {
-    float: none;
     position: absolute;
     right: 10px;
     top: 0;

--- a/media/css/firefox/new/scene1.less
+++ b/media/css/firefox/new/scene1.less
@@ -502,9 +502,4 @@ html.show-refresh {
             .font-size(@largeFontSize);
         }
     }
-
-    // override JS applied styles so the spinner is visible on dark background.
-    #newsletter-spinner > .spinner > div > div {
-        background: #fff !important;
-    }
 }

--- a/media/css/firefox/unsupported.less
+++ b/media/css/firefox/unsupported.less
@@ -82,7 +82,7 @@ html[lang='si'], html[lang='bn-IN'], html[lang='ka'], html[lang='kn']  {
 }
 
 html[lang="th"] #details-header p {
-    font-size:80% !important;
+    font-size:80%;
 }
 
 html[lang='th'] li{

--- a/media/css/foundation/annual2011.less
+++ b/media/css/foundation/annual2011.less
@@ -65,7 +65,7 @@ a.vid-youtube:focus {
   width: auto;
   padding: 0px 20px 20px;
   position: relative;
-  margin-top: -10px; 
+  margin-top: -10px;
 
   h1 {
     font-style: normal;
@@ -634,7 +634,7 @@ body.noscroll {
 #story-slider {
   overflow: hidden;
   top: 0;
-  
+
   .vcard {
     background: rgba(255,100,0,.1);
     width: 175px;
@@ -642,7 +642,7 @@ body.noscroll {
     margin: 0 5px;
     position: relative;
     list-style: none;
-    
+
     .photo {
       position: absolute;
       top: 0;
@@ -958,7 +958,8 @@ body.noscroll {
     position: static;
     padding: 0;
     margin: 20px 0 0;
-    background: transparent none !important;
+    /* important! required for overriding many section specific selectors */
+    background: transparent none !important; /* stylelint-disable-line declaration-no-important */
     color: inherit;
     a:link,
     a:visited {

--- a/media/css/foundation/annual2011print.css
+++ b/media/css/foundation/annual2011print.css
@@ -123,7 +123,8 @@ h1, h2, h3, h4, h5, h6 {
 #masthead {
   padding-bottom: 20px;
   border-bottom: 1px solid;
-  margin: 0 !important;
+  /* !important required for print stylesheet overrides */
+  margin: 0 !important; /* stylelint-disable-line declaration-no-important */
 }
 
 #masthead h1 {
@@ -178,6 +179,8 @@ h1, h2, h3, h4, h5, h6 {
   margin: 0 0 20px 20px;
 }
 
+/* !important required for print stylesheet overrides */
+/* stylelint-disable declaration-no-important  */
 .jcarousel-list {
   margin-top: 1em;
   width: 100% !important;
@@ -191,6 +194,7 @@ h1, h2, h3, h4, h5, h6 {
   display: block;
   margin: 0 20px 20px;
 }
+/* stylelint-enable */
 
 #story-slider .vcard:nth-child(odd),
 #story-slider-clone .vcard:nth-child(odd) {

--- a/media/css/foundation/annual2012.less
+++ b/media/css/foundation/annual2012.less
@@ -93,6 +93,12 @@ body {
 	}
 }
 
+/* Larger font size in English */
+html[lang|="en"] .banner blockquote {
+  .font-size(48px);
+  line-height: 1.1;
+}
+
 .content-section {
 	padding-top: @baseLine * 3;
 	padding-bottom: @baseLine;
@@ -228,7 +234,10 @@ body {
 }
 
 .site-footer {
-	padding: 0 !important;
+
+	&.content {
+		padding: 0;
+	}
 
 	ul {
 		margin: 0 auto;
@@ -384,13 +393,17 @@ html[dir="rtl"] {
 			margin-bottom: 40px;
 		}
 		blockquote {
-			.font-size(30px) !important;
+			.font-size(30px);
 			padding-left: 50px;
 			&:before {
 				width: 40px;
 				height: 40px;
 			}
 		}
+	}
+
+	html[lang|="en"] .banner blockquote {
+		.font-size(30px);
 	}
 
 	.content {
@@ -497,15 +510,15 @@ html[dir="rtl"] {
 	}
 
 	.box-links {
-		margin: 20px auto !important;
+		margin: 20px auto;
 		li {
-			float: none !important;
-			margin: 20px auto !important;
+			float: none;
+			margin: 20px auto;
 		}
 	}
 
 	.videos {
-		float: none !important;
+		float: none;
 		width: 380px;
 		margin: @baseLine auto;
 		li {
@@ -538,10 +551,10 @@ html[dir="rtl"] {
 		.banner h1 {
 			margin: 40px 0 20px;
 		}
-		blockquote {
+		.banner blockquote {
 			margin-right: -20px;
 			margin-left: 0;
-			padding: @baseLine !important;
+			padding: @baseLine;
 		}
 		.videos li a {
 			background-position: 20px 138px;
@@ -572,8 +585,12 @@ html[dir="rtl"] {
 			margin-left: -20px;
 			width: @breakMobile - (@baseLine * 2);
 			padding: @baseLine;
-			.font-size(26px) !important;
+			.font-size(26px);
 		}
+	}
+
+	html[lang|="en"] .banner blockquote {
+		.font-size(26px);
 	}
 
 	.content-section header h1 {
@@ -616,12 +633,6 @@ html[lang="ar"] {
 	.box-links li a {
 		line-height: 1.5;
 	}
-}
-
-/* Larger font size in English */
-html[lang|="en"] .banner blockquote {
-  .font-size(48px);
-  line-height: 1.1;
 }
 
 /* No Italic in Chinese */

--- a/media/css/l10n/ar/intl.css
+++ b/media/css/l10n/ar/intl.css
@@ -14,6 +14,8 @@
 
 /* Bug 944269 */
 
+/* !important required for locale specific override */
+/* stylelint-disable declaration-no-important  */
 * {
   letter-spacing: normal !important;
 }
@@ -29,3 +31,4 @@ h6,
 legend {
   line-height: 1.5 !important;
 }
+/* stylelint-enable */

--- a/media/css/l10n/az/intl.css
+++ b/media/css/l10n/az/intl.css
@@ -1,37 +1,38 @@
 /* Bug 991516 */
 
 @font-face {
-  font-family: X-LocaleSpecific-Light;
-  font-weight: normal;
-  src: url('/media/fonts/l10n/az/mplus-2c-light-az-subset.woff') format('woff');
+    font-family: X-LocaleSpecific-Light;
+    font-weight: normal;
+    src: url('/media/fonts/l10n/az/mplus-2c-light-az-subset.woff') format('woff');
 }
 
 @font-face {
-  font-family: X-LocaleSpecific-Light;
-  font-weight: bold;
-  src: url('/media/fonts/l10n/az/mplus-2c-medium-az-subset.woff') format('woff');
+    font-family: X-LocaleSpecific-Light;
+    font-weight: bold;
+    src: url('/media/fonts/l10n/az/mplus-2c-medium-az-subset.woff') format('woff');
 }
 
 @font-face {
-  font-family: X-LocaleSpecific;
-  font-weight: normal;
-  src: url('/media/fonts/l10n/az/mplus-2c-regular-az-subset.woff') format('woff');
+    font-family: X-LocaleSpecific;
+    font-weight: normal;
+    src: url('/media/fonts/l10n/az/mplus-2c-regular-az-subset.woff') format('woff');
 }
 
 @font-face {
-  font-family: X-LocaleSpecific;
-  font-weight: bold;
-  src: url('/media/fonts/l10n/az/mplus-2c-bold-az-subset.woff') format('woff');
+    font-family: X-LocaleSpecific;
+    font-weight: bold;
+    src: url('/media/fonts/l10n/az/mplus-2c-bold-az-subset.woff') format('woff');
 }
 
 @font-face {
-  font-family: X-LocaleSpecific-Extrabold;
-  font-weight: 800;
-  src: url('/media/fonts/l10n/az/mplus-2c-black-az-subset.woff') format('woff');
+    font-family: X-LocaleSpecific-Extrabold;
+    font-weight: 800;
+    src: url('/media/fonts/l10n/az/mplus-2c-black-az-subset.woff') format('woff');
 }
 
 /* Bug 1174423 */
 
 * {
-  font-variant: normal !important;
+    /* !important required for locale specific override */
+    font-variant: normal !important; /* stylelint-disable-line declaration-no-important */
 }

--- a/media/css/l10n/bn-IN/intl.css
+++ b/media/css/l10n/bn-IN/intl.css
@@ -1,5 +1,6 @@
 /* Bug 944269 */
 
 * {
-  letter-spacing: normal !important;
+    /* !important required for locale specific override */
+    letter-spacing: normal !important; /* stylelint-disable-line declaration-no-important */
 }

--- a/media/css/l10n/el/intl.css
+++ b/media/css/l10n/el/intl.css
@@ -1,5 +1,6 @@
 /* Bug 1174423 */
 
 * {
-  font-variant: normal !important;
+    /* !important required for locale specific override */
+    font-variant: normal !important; /* stylelint-disable-line declaration-no-important */
 }

--- a/media/css/l10n/fa/intl.css
+++ b/media/css/l10n/fa/intl.css
@@ -1,19 +1,20 @@
 /* Bug 958321 */
 
 @font-face {
-  font-family: X-LocaleSpecific;
-  font-weight: normal;
-  src: url('/media/fonts/l10n/DroidNaskh-Regular.woff') format('woff');
+    font-family: X-LocaleSpecific;
+    font-weight: normal;
+    src: url('/media/fonts/l10n/DroidNaskh-Regular.woff') format('woff');
 }
 
 @font-face {
-  font-family: X-LocaleSpecific;
-  font-weight: bold;
-  src: url('/media/fonts/l10n/DroidNaskh-Bold.woff') format('woff');
+    font-family: X-LocaleSpecific;
+    font-weight: bold;
+    src: url('/media/fonts/l10n/DroidNaskh-Bold.woff') format('woff');
 }
 
 /* Bug 944269 */
 
 * {
-  letter-spacing: normal !important;
+    /* !important required for locale specific override */
+    letter-spacing: normal !important; /* stylelint-disable-line declaration-no-important */
 }

--- a/media/css/l10n/ff/intl.css
+++ b/media/css/l10n/ff/intl.css
@@ -1,13 +1,13 @@
 /* Bug 776967 */
 
 @font-face {
-  font-family: X-LocaleSpecific-Light;
-  font-weight: normal;
-  src: url('/media/fonts/l10n/mplus-2c-light-fulah-subset.woff') format('woff');
+    font-family: X-LocaleSpecific-Light;
+    font-weight: normal;
+    src: url('/media/fonts/l10n/mplus-2c-light-fulah-subset.woff') format('woff');
 }
 
 @font-face {
-  font-family: X-LocaleSpecific;
-  font-weight: normal;
-  src: url('/media/fonts/l10n/mplus-2c-regular-fulah-subset.woff') format('woff');
+    font-family: X-LocaleSpecific;
+    font-weight: normal;
+    src: url('/media/fonts/l10n/mplus-2c-regular-fulah-subset.woff') format('woff');
 }

--- a/media/css/l10n/ga-IE/intl.css
+++ b/media/css/l10n/ga-IE/intl.css
@@ -1,6 +1,9 @@
 /* Bug 854756, 1174423 */
 
+/* !important required for locale specific override */
+/* stylelint-disable declaration-no-important  */
 * {
   text-transform: none !important;
   font-variant: normal !important;
 }
+/* stylelint-enable */

--- a/media/css/l10n/gd/intl.css
+++ b/media/css/l10n/gd/intl.css
@@ -1,5 +1,6 @@
 /* Bug 1174423 */
 
 * {
-  font-variant: normal !important;
+    /* !important required for locale specific override */
+    font-variant: normal !important; /* stylelint-disable-line declaration-no-important */
 }

--- a/media/css/l10n/hi-IN/intl.css
+++ b/media/css/l10n/hi-IN/intl.css
@@ -1,5 +1,6 @@
 /* Bug 944269 */
 
 * {
-  letter-spacing: normal !important;
+    /* !important required for locale specific override */
+    letter-spacing: normal !important; /* stylelint-disable-line declaration-no-important */
 }

--- a/media/css/l10n/ja/intl.css
+++ b/media/css/l10n/ja/intl.css
@@ -1,9 +1,9 @@
 /* Bug 993702 */
 
 @font-face {
-  font-family: X-LocaleSpecific-Light;
-  font-weight: normal;
-  src: /* All */
+    font-family: X-LocaleSpecific-Light;
+    font-weight: normal;
+    src: /* All */
        local(mplus-2p-light),
        local(KozGoPro-Light),
        /* OS X */
@@ -19,9 +19,9 @@
 }
 
 @font-face {
-  font-family: X-LocaleSpecific-Light;
-  font-weight: bold;
-  src: /* All */
+    font-family: X-LocaleSpecific-Light;
+    font-weight: bold;
+    src: /* All */
        local(mplus-2p-medium),
        local(KozGoPro-Medium),
        /* OS X */
@@ -37,9 +37,9 @@
 }
 
 @font-face {
-  font-family: X-LocaleSpecific;
-  font-weight: normal;
-  src: /* All */
+    font-family: X-LocaleSpecific;
+    font-weight: normal;
+    src: /* All */
        local(mplus-2p-regular),
        local(KozGoPro-Regular),
        /* OS X */
@@ -55,9 +55,9 @@
 }
 
 @font-face {
-  font-family: X-LocaleSpecific;
-  font-weight: bold;
-  src: /* All */
+    font-family: X-LocaleSpecific;
+    font-weight: bold;
+    src: /* All */
        local(mplus-2p-bold),
        local(KozGoPro-Bold),
        /* OS X */
@@ -73,9 +73,9 @@
 }
 
 @font-face {
-  font-family: X-LocaleSpecific-Extrabold;
-  font-weight: 800;
-  src: /* All */
+    font-family: X-LocaleSpecific-Extrabold;
+    font-weight: 800;
+    src: /* All */
        local(mplus-2p-black),
        local(KozGoPro-Heavy),
        /* OS X */
@@ -93,5 +93,6 @@
 /* Bug 973171 */
 
 * {
-  font-style: normal !important;
+    /* !important required for locale specific override */
+    font-style: normal !important;  /* stylelint-disable-line declaration-no-important */
 }

--- a/media/css/l10n/ko/intl.css
+++ b/media/css/l10n/ko/intl.css
@@ -1,45 +1,45 @@
 /* Bug 993704 */
 
 @font-face {
-  font-family: X-LocaleSpecific-Light;
-  font-weight: normal;
-  src: /* OS X */
+    font-family: X-LocaleSpecific-Light;
+    font-weight: normal;
+    src: /* OS X */
        local(AppleSDGothicNeo-UltraLight),
        /* Windows */
        local('Malgun Gothic');
 }
 
 @font-face {
-  font-family: X-LocaleSpecific-Light;
-  font-weight: bold;
-  src: /* OS X */
+    font-family: X-LocaleSpecific-Light;
+    font-weight: bold;
+    src: /* OS X */
        local(AppleSDGothicNeo-SemiBold),
        /* Windows */
        local('Malgun Gothic Bold');
 }
 
 @font-face {
-  font-family: X-LocaleSpecific;
-  font-weight: normal;
-  src: /* OS X */
+    font-family: X-LocaleSpecific;
+    font-weight: normal;
+    src: /* OS X */
        local(AppleSDGothicNeo-Regular),
        /* Windows */
        local('Malgun Gothic');
 }
 
 @font-face {
-  font-family: X-LocaleSpecific;
-  font-weight: bold;
-  src: /* OS X */
+    font-family: X-LocaleSpecific;
+    font-weight: bold;
+    src: /* OS X */
        local(AppleSDGothicNeo-Bold),
        /* Windows */
        local('Malgun Gothic Bold');
 }
 
 @font-face {
-  font-family: X-LocaleSpecific-Extrabold;
-  font-weight: 800;
-  src: /* OS X */
+    font-family: X-LocaleSpecific-Extrabold;
+    font-weight: 800;
+    src: /* OS X */
        local(AppleSDGothicNeo-Heavy),
        /* Windows */
        local('Malgun Gothic Bold');
@@ -48,5 +48,6 @@
 /* Bug 973171 */
 
 * {
-  font-style: normal !important;
+    /* !important required for locale specific override */
+    font-style: normal !important; /* stylelint-disable-line declaration-no-important */
 }

--- a/media/css/l10n/tr/intl.css
+++ b/media/css/l10n/tr/intl.css
@@ -1,5 +1,6 @@
 /* Bug 1174423 */
 
 * {
-  font-variant: normal !important;
+    /* !important required for locale specific override */
+    font-variant: normal !important; /* stylelint-disable-line declaration-no-important */
 }

--- a/media/css/l10n/zh-CN/intl.css
+++ b/media/css/l10n/zh-CN/intl.css
@@ -1,9 +1,9 @@
 /* Bug 993709 */
 
 @font-face {
-  font-family: X-LocaleSpecific;
-  font-weight: normal;
-  src: /* OS X */
+    font-family: X-LocaleSpecific;
+    font-weight: normal;
+    src: /* OS X */
        local(FZLTXHK--GBK1-0), /* = Lantinghei SC Extralight */
        local(HiraginoSansGB-W3),
        /* Windows */
@@ -13,9 +13,9 @@
 }
 
 @font-face {
-  font-family: X-LocaleSpecific;
-  font-weight: bold;
-  src: /* OS X */
+    font-family: X-LocaleSpecific;
+    font-weight: bold;
+    src: /* OS X */
        local(FZLTZHK--GBK1-0), /* = Lantinghei SC Demibold */
        local(HiraginoSansGB-W6),
        /* Windows */
@@ -25,9 +25,9 @@
 }
 
 @font-face {
-  font-family: X-LocaleSpecific-Extrabold;
-  font-weight: 800;
-  src: /* OS X */
+    font-family: X-LocaleSpecific-Extrabold;
+    font-weight: 800;
+    src: /* OS X */
        local(FZLTTHK--GBK1-0), /* = Lantinghei SC Heavy */
        local(HiraginoSansGB-W6),
        /* Windows */
@@ -39,5 +39,6 @@
 /* Bug 973171 */
 
 * {
-  font-style: normal !important;
+    /* !important required for locale specific override */
+    font-style: normal !important; /* stylelint-disable-line declaration-no-important */
 }

--- a/media/css/l10n/zh-TW/intl.css
+++ b/media/css/l10n/zh-TW/intl.css
@@ -1,9 +1,9 @@
 /* Bug 795396 */
 
 @font-face {
-  font-family: X-LocaleSpecific;
-  font-weight: normal;
-  src: /* OS X */
+    font-family: X-LocaleSpecific;
+    font-weight: normal;
+    src: /* OS X */
        local(FZLTXHB--B51-0), /* = Lantinghei TC Extralight */
        /* Windows */
        local('Microsoft JhengHei Light'),
@@ -12,9 +12,9 @@
 }
 
 @font-face {
-  font-family: X-LocaleSpecific;
-  font-weight: bold;
-  src: /* OS X */
+    font-family: X-LocaleSpecific;
+    font-weight: bold;
+    src: /* OS X */
        local(FZLTZHB--B51-0), /* = Lantinghei TC Demibold */
        /* Windows */
        local('Microsoft JhengHei Bold'),
@@ -23,9 +23,9 @@
 }
 
 @font-face {
-  font-family: X-LocaleSpecific-Extrabold;
-  font-weight: 800;
-  src: /* OS X */
+    font-family: X-LocaleSpecific-Extrabold;
+    font-weight: 800;
+    src: /* OS X */
        local(FZLTTHB--B51-0), /* = Lantinghei TC Heavy */
        /* Windows */
        local('Microsoft JhengHei Bold'),
@@ -36,5 +36,6 @@
 /* Bug 973171 */
 
 * {
-  font-style: normal !important;
+    /* !important required for locale specific override */
+    font-style: normal !important; /* stylelint-disable-line declaration-no-important */
 }

--- a/media/css/mozorg/history-slides.less
+++ b/media/css/mozorg/history-slides.less
@@ -800,7 +800,7 @@
     .message,
     .block1,
     .block2,
-    .block3, {
+    .block3 {
         background: url(/media/img/mozorg/history/fact05-pads.png) no-repeat;
     }
 

--- a/media/css/mozorg/home/home-voices-promo.less
+++ b/media/css/mozorg/home/home-voices-promo.less
@@ -551,27 +551,6 @@ html[lang|="en"] {
             }
         }
 
-        .download-other {
-            margin-top: 11px;
-            .font-size(14px);
-            text-align: center;
-
-            a:link,
-            a:visited {
-                color: #fff;
-            }
-
-            &.download-other-desktop {
-                display: block !important;
-
-                /* unless we're in iOS or Android */
-                .ios &,
-                .android & {
-                    display: none !important;
-                }
-            }
-        }
-
         .ios-download,
         .linux-arm-download,
         .unsupported-download {
@@ -713,10 +692,6 @@ html[lang|="en"] {
     .promo-small-landscape.firefox-download {
         .fxos-link {
             display: inline-block;
-        }
-
-        .download-other.download-other-desktop {
-            display: none !important;
         }
     }
 }

--- a/media/css/mozorg/home/home-voices.less
+++ b/media/css/mozorg/home/home-voices.less
@@ -687,7 +687,7 @@ h1, h2, h3, h4, h5, h6 {
 @media only screen and (min-width: (@widthSquareGrid_8)) {
 
     .module .container,
-    .main-header .container, {
+    .main-header .container {
         width: @widthSquareGrid_8 - (@gridGutterWidth * 2);
     }
 
@@ -751,7 +751,7 @@ h1, h2, h3, h4, h5, h6 {
 @media only screen and (min-width: @widthSquareGrid_7) and (max-width: (@widthSquareGrid_8 - 1)) {
 
     .module .container,
-    .main-header .container, {
+    .main-header .container {
         width: @widthSquareGrid_7 - (@gridGutterWidth * 2);
     }
 

--- a/media/css/mozorg/manifesto.less
+++ b/media/css/mozorg/manifesto.less
@@ -157,35 +157,35 @@
 #principle-06,
 #principle-01-overlay,
 #principle-06-overlay {
-    background: #00A0DB !important;
+    background: #00A0DB;
 }
 
 #principle-02,
 #principle-07,
 #principle-02-overlay,
 #principle-07-overlay {
-    background: #DD5A00 !important;
+    background: #DD5A00;
 }
 
 #principle-03,
 #principle-08,
 #principle-03-overlay,
 #principle-08-overlay {
-    background: #689F2A !important;
+    background: #689F2A;
 }
 
 #principle-04,
 #principle-09,
 #principle-04-overlay,
 #principle-09-overlay {
-    background: #4B5C66 !important;
+    background: #4B5C66;
 }
 
 #principle-05,
 #principle-10,
 #principle-05-overlay,
 #principle-10-overlay {
-    background: #A52D2D !important;
+    background: #A52D2D;
 }
 
 .principle {

--- a/media/css/pebbles/components/_buttons-download.scss
+++ b/media/css/pebbles/components/_buttons-download.scss
@@ -96,6 +96,9 @@ ul.download-list {
     }
 }
 
+/* !important used for strict download link enforcement */
+/* stylelint-disable declaration-no-important  */
+
 // Product download buttons
 .download-button {
     .ios-download,
@@ -215,6 +218,8 @@ ul.download-list {
 .windows.sha-1 .download-button .os_winsha1 {
     display: block !important;
 }
+
+/* stylelint-enable */
 
 // l10n download button tweaks
 html[lang="ml"] {

--- a/media/css/pebbles/components/google-search.scss
+++ b/media/css/pebbles/components/google-search.scss
@@ -4,8 +4,8 @@
 
 @import '../includes/lib';
 
-
-// Custom Google search
+/* !important required Custom Google search JS overrides */
+/* stylelint-disable declaration-no-important  */
 
 .moz-search {
     @include clearfix;
@@ -125,3 +125,5 @@
 .gsc-modal-background-image {
     background-color: #000 !important;
 }
+
+/* stylelint-enable */

--- a/media/css/pebbles/includes/_mixins.scss
+++ b/media/css/pebbles/includes/_mixins.scss
@@ -125,7 +125,8 @@
     margin: -1px;
     overflow: hidden;
     padding: 0;
-    position: absolute !important;
+    /* !important required to ensure element is hidden when mixin is applied */
+    position: absolute !important; /* stylelint-disable-line declaration-no-important */
     width: 1px;
 }
 
@@ -209,5 +210,5 @@
     -webkit-column-break-inside: avoid;
        -moz-column-break-inside: avoid;
          -o-column-break-inside: avoid;
-            column-break-inside: avoid;
+                   break-inside: avoid;
 }

--- a/media/css/sandstone/buttons.less
+++ b/media/css/sandstone/buttons.less
@@ -297,6 +297,9 @@ ul.download-list {
     }
 }
 
+/* !important used for strict download link enforcement */
+/* stylelint-disable declaration-no-important  */
+
 // Product download buttons
 .download-button {
     .ios-download,
@@ -416,6 +419,8 @@ ul.download-list {
 .windows.sha-1 .download-button .os_winsha1 {
     display: block !important;
 }
+
+/* stylelint-enable */
 
 // l10n download button tweaks
 html[lang="ml"] {

--- a/media/css/sandstone/lib.less
+++ b/media/css/sandstone/lib.less
@@ -404,7 +404,8 @@
 
 // Hide visually, but not to screen readers
 .visually-hidden() {
-    position: absolute!important;
+    /* !important required to ensure element is hidden when mixin is applied */
+    position: absolute !important; /* stylelint-disable-line declaration-no-important */
     height: 1px;
     width: 1px;
     margin: -1px;
@@ -494,7 +495,7 @@
   -webkit-column-break-inside: avoid;
      -moz-column-break-inside: avoid;
        -o-column-break-inside: avoid;
-          column-break-inside: avoid;
+                 break-inside: avoid;
 }
 
 // A helper mixin for applying high-resolution background images (http://www.retinajs.com)

--- a/media/css/styleguide/docs/mozilla-pager.less
+++ b/media/css/styleguide/docs/mozilla-pager.less
@@ -35,7 +35,8 @@
 
 .pager-nav-links-wrapper {
     display: inline;
-    margin: 0 (@baseLine / 2);
+    margin-left: @baseLine / 2;
+    margin-right: @baseLine / 2;
 }
 
 .pager-nav-divider {

--- a/media/css/styleguide/styleguide.less
+++ b/media/css/styleguide/styleguide.less
@@ -22,8 +22,6 @@
          url('/media/fonts/opensans-extrabolditalic.woff') format('woff');
 }
 
-a[href="#TODO"] { color: #f00 !important; }
-
 .copyright-note {
   clear: both;
   padding-top: 20px;

--- a/media/css/teach/smarton.less
+++ b/media/css/teach/smarton.less
@@ -1246,11 +1246,6 @@ body.not-firefox .footer-cta {
     }
 }
 
-#smarton-foot-download .download-other {
-    display: none !important;
-}
-
-
 // Multi-column blocks
 .columns {
     .flexbox;

--- a/media/css/thunderbird/landing.less
+++ b/media/css/thunderbird/landing.less
@@ -81,11 +81,6 @@ html.ios {
     }
 }
 
-.download-button.download-button-simple small.download-other {
-    display: block !important;
-    margin-top: 16px;
-}
-
 #thunderbird-screenshot {
     margin: 40px 20px 0;
     text-align: center;

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "del": "^2.2.2",
     "gulp": "^3.9.1",
     "gulp-eslint": "^3.0.1",
+    "gulp-stylelint": "^3.7.0",
     "gulp-watch": "^4.3.6",
     "jasmine-core": "^2.4.1",
     "karma": "^0.13.22",


### PR DESCRIPTION
Taking a look at adding Stylelint to our gulp/CI. The full list of rules that can be applied is here: http://stylelint.io/user-guide/rules/

Right now this is just linting our Sass files, but I'll take a look to see if it can do the Less files too. I'm trying to avoid purely stylistic things, but if there are things that we would normally pick out in code review anyway we should probably add them.

Like ESLint, you can make allowances for certain rules on a case by case basis using CSS comments: http://stylelint.io/user-guide/configuration/#turning-rules-off-from-within-your-css

We can also make certain rules only report as warnings, so not to break a build: http://stylelint.io/user-guide/configuration/#severities-error--warning