### PR TITLE
[fix bug 1317727] Set SOM 2015 as default.

### DIFF
--- a/bedrock/foundation/urls.py
+++ b/bedrock/foundation/urls.py
@@ -2,14 +2,9 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from bedrock.base.waffle import switch
 from bedrock.mozorg.util import page
 from bedrock.redirects.util import redirect
 
-
-SOM_2015_ENABLED = switch('som-2015')
-SOM_REDIRECT = ('foundation.annualreport.2015.index' if SOM_2015_ENABLED else
-                'foundation.annualreport.2014.index')
 
 urlpatterns = (
     page('', 'foundation/index.html'),
@@ -19,7 +14,7 @@ urlpatterns = (
     page('leadership-network', 'foundation/leadership-network.html'),
 
     # Bug 1317727  /foundation/annualreport/2015/
-    redirect(r'^annualreport/$', SOM_REDIRECT,
+    redirect(r'^annualreport/$', 'foundation.annualreport.2015.index',
              name='foundation.annualreport', locale_prefix=False),
 
     # Older annual report financial faqs - these are linked from blog posts
@@ -66,6 +61,9 @@ urlpatterns = (
     page('annualreport/2014', 'foundation/annualreport/2014/index.html'),
     page('annualreport/2014/faq', 'foundation/annualreport/2014/faq.html'),
 
+    page('annualreport/2015', 'foundation/annualreport/2015/index.html'),
+    page('annualreport/2015/faq', 'foundation/annualreport/2015/faq.html'),
+
     page('feed-icon-guidelines', 'foundation/feed-icon-guidelines/index.html'),
     page('feed-icon-guidelines/faq', 'foundation/feed-icon-guidelines/faq.html'),
 
@@ -93,9 +91,3 @@ urlpatterns = (
     # documents
     page('documents', 'foundation/documents/index.html'),
 )
-
-if SOM_2015_ENABLED:
-    urlpatterns += (
-        page('annualreport/2015', 'foundation/annualreport/2015/index.html'),
-        page('annualreport/2015/faq', 'foundation/annualreport/2015/faq.html'),
-    )


### PR DESCRIPTION
## Description

Sets SOM 2015 as the default. After this makes it to prod, we can remove the SWITCH_SOM_2015 switch.

## Bugzilla link

https://bugzilla.mozilla.org/show_bug.cgi?id=1317727

## Testing

Ensure no regressions.

## Checklist
- [ ] Related functional & integration tests passing.
