### PR TITLE
[fix bug 1324736] Remove Firefox OS participation hub link

### DIFF
--- a/bedrock/firefox/templates/firefox/os/index.html
+++ b/bedrock/firefox/templates/firefox/os/index.html
@@ -102,7 +102,6 @@
         <h2>{{_('Ready to try Firefox OS 2.5 Developer Preview on your Android device?')}}</h2>
         <div class="primary-cta">
           <a href="{{ settings.B2G_DROID_URL }}" class="cta-button button button-green" data-pixel="52162" data-id="Mozilla_B2G_Activity_Tag_2">{{_('Get the Android App')}}</a>
-          <p>{{_('Want the full Firefox OS 2.5 experience?')}} <a href="https://firefoxos.mozilla.community/devices/" class="more" rel="external">{{_('Flash your phone')}}</a></p>
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Description
- Removes a link that was missed in #4558 

## Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1324736
