### PR TITLE
[fix bug 1309692] Unique page title is missing on the refreshed Foundation pages

### DIFF
--- a/bedrock/foundation/templates/foundation/base-resp.html
+++ b/bedrock/foundation/templates/foundation/base-resp.html
@@ -37,7 +37,9 @@
       <div class="content content-main">
       <div class="main-column">
         <header class="section-header">
-        {% block article_header %}{% endblock %}
+        {% block article_header %}
+          <h2>{{ self.page_title() }}</h2>
+        {% endblock %}
         </header>
         {% block article %}{% endblock %}
       </div>

--- a/media/css/foundation/foundation.less
+++ b/media/css/foundation/foundation.less
@@ -111,6 +111,7 @@
     .open-sans-light;
     h2 {
         .font-size(40px);
+        margin-bottom: @baseLine;
     }
     p{
         .font-size(26px);


### PR DESCRIPTION
## Description
- Adds an `<h2>` to foundation base template using existing page titles.

## Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1309692

## Testing
- Double check to make sure this makes sense for all foundation pages? I did a spot check, but some verification would be good.

## Checklist
- [ ] Requires l10n changes.
- [ ] Related functional & integration tests passing.
