### PR TITLE
[bug 1331048] Hide navbar styling behind switch

### DIFF
--- a/bedrock/mozorg/templates/mozorg/home/home.html
+++ b/bedrock/mozorg/templates/mozorg/home/home.html
@@ -42,7 +42,9 @@
 {% block site_header %}
   {% include 'mozorg/home/includes/home-icons-sprite.svg' %}
   {% with is_home = True %}
-    {% set logo_src = static('img/pebbles/moz-wordmark-dark-reverse.svg') %}
+    {% if switch('mozorg-home-brand-announce') %}
+      {% set logo_src = static('img/pebbles/moz-wordmark-dark-reverse.svg') %}
+    {% endif %}
     {% include 'mozorg/home/includes/nav.html' %}
   {% endwith %}
 {% endblock %}

--- a/bedrock/mozorg/templates/mozorg/home/includes/nav.html
+++ b/bedrock/mozorg/templates/mozorg/home/includes/nav.html
@@ -1,8 +1,12 @@
 {% if not logo_src %}
-  {% set logo_src = static('img/pebbles/moz-wordmark-light-reverse.svg') %}
+  {% if switch('mozorg-home-brand-announce') %}
+    {% set logo_src = static('img/pebbles/moz-wordmark-light-reverse.svg') %}
+  {% else %}
+    {% set logo_src = static('img/home/2016/mozilla-wordmark.svg') %}
+  {% endif %}
 {% endif %}
 
-<header class="section masthead" id="masthead">
+<header class="section masthead {% if switch('mozorg-home-brand-announce') %}rebrand{% endif %}" id="masthead">
   <div class="content">
   {% if is_home %}
     <h1 class="masthead-logo">

--- a/media/css/mozorg/home/home.scss
+++ b/media/css/mozorg/home/home.scss
@@ -34,15 +34,15 @@ body {
 
 // Header
 #masthead {
-    background: #ff8c8e;
-    color: #000;
+    background: $color-mozred-bright;
+    color: #fff;
 
     .content {
         padding: 51px 20px 0;
     }
 
     .masthead-logo {
-        background: #ff8c8e;
+        background: $color-mozred-bright;
         height: 30px;
         left: 0;
         margin: 0;
@@ -58,13 +58,22 @@ body {
     }
 }
 
+#masthead.rebrand {
+    background: #ff8c8e;
+    color: #000;
+
+    .masthead-logo {
+        background: #ff8c8e;
+    }
+}
+
 #nav-download-firefox {
     display: none;
 }
 
 @media #{$mq-tablet} {
     #masthead {
-        background: #ff8c8e;
+        background: $color-mozred-bright;
         padding: 0;
 
         .content {
@@ -83,12 +92,27 @@ body {
         padding: 15px 0;
 
         li {
-            border-right: 1px solid #000;
+            border-right: 1px solid #fff;
 
             &:last-child {
                 border-right: 0;
                 padding-right: 0;
             }
+        }
+
+        a,
+        a:hover,
+        a:focus {
+            color: #fff;
+        }
+    }
+
+    #masthead.rebrand {
+        background: #ff8c8e;
+
+        #nav-main-menu li,
+        .js #nav-main-menu li {
+            border-right-color: #000;
         }
 
         a,


### PR DESCRIPTION
## Description
While the takeover was behind a switch, the navbar changes weren't. This puts those style changes behind the same switch as the takeover (using a class for the color; kinda kludgey but it only needs to last a day).

## Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1331048

## Testing
Ensure the navbar shows the old wordmark and coloring when the switch is off.

## Checklist
- [ ] Requires l10n changes.
- [ ] Related functional & integration tests passing.
