### PR TITLE
[fix bug 1330435] Add link to internet health report to health landing

### DIFF
--- a/bedrock/mozorg/templates/mozorg/internet-health.html
+++ b/bedrock/mozorg/templates/mozorg/internet-health.html
@@ -194,6 +194,18 @@
     </section>
   </div>
 
+{% if l10n_has_tag('mozorg-health-report') and switch('internet-health-report-live') %}
+  <section id="health-report" class="section">
+    <div class="content">
+      <a href="https://internethealthreport.org" rel="external">
+        {# L10n: Line break for visual layout #}
+        <h2><span>{{ _('Check out Mozilla’s <br>Internet Health Report') }}</span></h2>
+        <p class="cta">{{ _('Read up on what’s helping (and what’s hurting) our world’s largest shared resource.') }}</p>
+      </a>
+    </div>
+  </section>
+{% endif %}
+
   <aside id="newsletter-subscribe">
     <div class="content">
       {{ email_newsletter_form(newsletters='mozilla-foundation',

--- a/media/css/mozorg/internet-health.scss
+++ b/media/css/mozorg/internet-health.scss
@@ -590,6 +590,82 @@ html[dir="rtl"] #pillars > section {
     }
 }
 
+
+//*--------------------------------------------------------------------------*/
+// Health report
+
+#health-report {
+    @include font-size(18px);
+    background: #00e6ff;
+    padding: 20px 0;
+    text-align: center;
+
+    h2 {
+        @include font-size(22px);
+        color: #000;
+        font-weight: bold;
+        line-height: 1.4;
+
+        span {
+            background: $colorHeading;
+        }
+    }
+
+    .cta {
+        margin: 0;
+    }
+
+    a:link,
+    a:visited {
+        color: $color-text-primary;
+        display: block;
+        text-decoration: none;
+    }
+
+    a:hover,
+    a:focus,
+    a:active {
+        color: $color-text-tertiary;
+
+        .cta {
+            text-decoration: underline;
+        }
+    }
+
+    @media #{$mq-phone-wide} {
+        h2 {
+            @include font-size(26px);
+        }
+    }
+
+    @media #{$mq-tablet} {
+        @include font-size(20px);
+        text-align: left;
+
+        h2 {
+            @include font-size(32px);
+
+            br {
+                display: none;
+            }
+        }
+    }
+
+    @media #{$mq-desktop} {
+        @include font-size(24px);
+
+        h2 {
+            @include font-size(36px);
+        }
+    }
+
+    @media #{$mq-desktop-wide} {
+        .content {
+            width: $width-desktop;
+        }
+    }
+}
+
 /*--------------------------------------------------------------------------*/
 // Newsletter
 


### PR DESCRIPTION
## Description
Adds a block to the internet health landing page that links to internethealthreport.org. The block is behind the switch `internet-health-report-live` which we should flip once the website is confirmed live (planned for 19 January around 9am PST).

Uses the l10n tag `mozorg-health-report` for two new strings. 

## Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1330435

## Checklist
- [x] Requires l10n changes.
- [ ] Related functional & integration tests passing.
