### PR TITLE
Skip home page tests in IE due to brand popup

### DIFF
--- a/tests/functional/newsletter/test_newsletter_embed.py
+++ b/tests/functional/newsletter/test_newsletter_embed.py
@@ -27,7 +27,8 @@ from pages.smarton.base import SmartOnBasePage
 
 @pytest.mark.nondestructive
 @pytest.mark.parametrize(('page_class', 'url_kwargs'), [
-    pytest.mark.smoke((HomePage, None)),
+    pytest.mark.skip_if_internet_explorer(pytest.mark.smoke((HomePage, None)),
+        reason='https://ci.us-west.moz.works/job/bedrock_integration_tests_runner/11169/'),
     (AboutPage, None),
     pytest.mark.smoke((ContributePage, None)),
     (TwitterTaskPage, None),
@@ -62,7 +63,10 @@ def test_newsletter_default_values(page_class, url_kwargs, base_url, selenium):
 
 
 @pytest.mark.nondestructive
-@pytest.mark.parametrize('page_class', [HomePage, ContributePage])
+@pytest.mark.parametrize('page_class', [
+    pytest.mark.skip_if_internet_explorer(HomePage,
+        reason='https://ci.us-west.moz.works/job/bedrock_integration_tests_runner/11169/'),
+    ContributePage])
 def test_newsletter_successful_sign_up(page_class, base_url, selenium):
     page = page_class(selenium, base_url).open()
     page.newsletter.expand_form()
@@ -75,7 +79,10 @@ def test_newsletter_successful_sign_up(page_class, base_url, selenium):
 
 
 @pytest.mark.nondestructive
-@pytest.mark.parametrize('page_class', [HomePage, ContributePage])
+@pytest.mark.parametrize('page_class', [
+    pytest.mark.skip_if_internet_explorer(HomePage,
+        reason='https://ci.us-west.moz.works/job/bedrock_integration_tests_runner/11169/'),
+    ContributePage])
 def test_newsletter_sign_up_fails_when_missing_required_fields(page_class, base_url, selenium):
     page = page_class(selenium, base_url).open()
     page.newsletter.expand_form()

--- a/tests/functional/test_home.py
+++ b/tests/functional/test_home.py
@@ -7,6 +7,7 @@ import pytest
 from pages.home import HomePage
 
 
+@pytest.mark.skip_if_internet_explorer(reason='https://ci.us-west.moz.works/job/bedrock_integration_tests_runner/11169/')
 @pytest.mark.skip_if_firefox(reason='Download button is not shown to Firefox browsers.')
 @pytest.mark.sanity
 @pytest.mark.nondestructive
@@ -15,6 +16,7 @@ def test_download_button_is_displayed(base_url, selenium):
     assert page.download_button.is_displayed
 
 
+@pytest.mark.skip_if_internet_explorer(reason='https://ci.us-west.moz.works/job/bedrock_integration_tests_runner/11169/')
 @pytest.mark.sanity
 @pytest.mark.smoke
 @pytest.mark.nondestructive

--- a/tests/functional/test_l10n.py
+++ b/tests/functional/test_l10n.py
@@ -9,6 +9,7 @@ import pytest
 from pages.home import HomePage
 
 
+@pytest.mark.skip_if_internet_explorer(reason='https://ci.us-west.moz.works/job/bedrock_integration_tests_runner/11169/')
 @pytest.mark.nondestructive
 def test_change_language(base_url, selenium):
     page = HomePage(selenium, base_url).open()

--- a/tests/functional/test_navigation.py
+++ b/tests/functional/test_navigation.py
@@ -7,6 +7,7 @@ import pytest
 from pages.home import HomePage
 
 
+@pytest.mark.skip_if_internet_explorer(reason='https://ci.us-west.moz.works/job/bedrock_integration_tests_runner/11169/')
 @pytest.mark.nondestructive
 def test_navigation(base_url, selenium):
     page = HomePage(selenium, base_url).open()
@@ -18,6 +19,7 @@ def test_navigation(base_url, selenium):
     assert technology_page.seed_url in selenium.current_url
 
 
+@pytest.mark.skip_if_internet_explorer(reason='https://ci.us-west.moz.works/job/bedrock_integration_tests_runner/11169/')
 @pytest.mark.smoke
 @pytest.mark.nondestructive
 @pytest.mark.viewport('mobile')


### PR DESCRIPTION
We hit some intermittent failures on the last prod push [1], [2] in IE as it seem to have trouble detecting the homepage popup that appears at the bottom of the screen. I could sink a ton of time into debugging this to try and make it more resilient, but this probably isn't worth it as it's only going to be around for a couple of weeks. This PR skips said tests in IE.

We need to remember to unskip these tests again when the popup gets removed.

[1] https://ci.us-west.moz.works/job/bedrock_integration_tests_runner/11163/
[2] https://ci.us-west.moz.works/job/bedrock_integration_tests_runner/11169/
