### PR TITLE
[fix bug 1331069] Replace Flashtalking Tracking Pixel With DoubleClick

### DIFF
--- a/bedrock/firefox/templates/firefox/new/break-free/scene2.html
+++ b/bedrock/firefox/templates/firefox/new/break-free/scene2.html
@@ -8,6 +8,10 @@
 
 {% block body_class %}scene-2{% endblock %}
 
+{% block string_data %}
+  data-tracking-pixel={{ settings.TRACKING_PIXEL_URL }}
+{% endblock %}
+
 {% block content %}
 <div class="main-content content">
   <div id="download-button-wrapper-desktop">
@@ -37,7 +41,7 @@
 {% endblock %}
 
 {% block js %}
-  {% if switch('flashtalking') %}
+  {% if switch('tracking-pixel') %}
     {% javascript 'firefox_new_pixel' %}
   {% endif %}
   {% javascript 'firefox_new_scene2' %}

--- a/bedrock/firefox/templates/firefox/new/scene2.html
+++ b/bedrock/firefox/templates/firefox/new/scene2.html
@@ -15,6 +15,10 @@
 
 {% block body_id %}firefox-new-scene2{% endblock %}
 
+{% block string_data %}
+  data-tracking-pixel={{ settings.TRACKING_PIXEL_URL }}
+{% endblock %}
+
 {% block content %}
 <main role="main" id="stage">
   <div class="horizon">
@@ -72,7 +76,7 @@
 {% endblock %}
 
 {% block js %}
-  {% if switch('flashtalking') %}
+  {% if switch('tracking-pixel') %}
     {% javascript 'firefox_new_pixel' %}
   {% endif %}
   {% javascript 'firefox_new_scene2' %}

--- a/bedrock/firefox/templates/firefox/new/way-of-the-fox/scene2.html
+++ b/bedrock/firefox/templates/firefox/new/way-of-the-fox/scene2.html
@@ -8,6 +8,10 @@
 
 {% block body_class %}scene-2{% endblock %}
 
+{% block string_data %}
+  data-tracking-pixel={{ settings.TRACKING_PIXEL_URL }}
+{% endblock %}
+
 {% block content_body %}
 <div class="main-content content">
   <div id="download-button-wrapper-desktop">
@@ -37,7 +41,7 @@
 {% endblock %}
 
 {% block js %}
-  {% if switch('flashtalking') %}
+  {% if switch('tracking-pixel') %}
     {% javascript 'firefox_new_pixel' %}
   {% endif %}
   {% javascript 'firefox_new_scene2' %}

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -1302,5 +1302,14 @@ GOOG_CUSTOM_SEARCH_TYPES = {
     'activist': '014783244707853607354:bbpl3emdsii',
 }
 
-if config('SWITCH_FLASHTALKING', default=DEV, cast=bool):
-    CSP_IMG_SRC += ('servedby.flashtalking.com',)
+# Bug 1331069 - Replace Flashtalking Tracking Pixel With DoubleClick
+FLASH_TALKING_URL = 'https://servedby.flashtalking.com/spot/8/6247;40428;4669/?spotName=Mozilla_Download_Conversion'
+DOUBLE_CLICK_URL = ('https://ad.doubleclick.net/ddm/activity/src=6417015;type=deskt0;cat=mozil0;dc_lat=;dc_rdid=;'
+                    'tag_for_child_directed_treatment=;ord=1;num=1?&_dc_ck=try')
+
+TRACKING_PIXEL_URL = DOUBLE_CLICK_URL if config('SWITCH_DOUBLE_CLICK', default=DEV, cast=bool) else FLASH_TALKING_URL
+
+if config('SWITCH_TRACKING_PIXEL', default=DEV, cast=bool):
+    CSP_IMG_SRC += (
+        'ad.doubleclick.net' if config('SWITCH_DOUBLE_CLICK', default=DEV, cast=bool) else 'servedby.flashtalking.com',
+    )

--- a/media/js/firefox/new/pixel.js
+++ b/media/js/firefox/new/pixel.js
@@ -8,12 +8,16 @@
     // pixel status bug https://bugzilla.mozilla.org/show_bug.cgi?id=1311423
     function addPixel() {
         if (!window._dntEnabled()) {
-            var $pixel = $('<img />', {
-                width: '1',
-                height: '1',
-                src: 'https://servedby.flashtalking.com/spot/8/6247;40428;4669/?spotName=Mozilla_Download_Conversion'
-            });
-            $('body').append($pixel);
+            var href = $('#strings').data('trackingPixel');
+
+            if (href) {
+                var $pixel = $('<img />', {
+                    width: '1',
+                    height: '1',
+                    src: href
+                });
+                $('body').append($pixel);
+            }
         }
     }
 


### PR DESCRIPTION
## Description
- Replaces Flashtalking Tracking Pixel With DoubleClick
- Updates switch name for the pixel to be more generic. We'll have to remember to turn this on again in staging / prod, and remove the old switch.
- We'll need to make sure the flip `SWITCH_TRACKING_PIXEL` is turned on on stage / prod prior to pushing this. The double click switch (`SWITCH_DOUBLE_CLICK`) should be turned on Feb 1st (this will toggle off Flash Talking).

## Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1331069

## Testing
- Demo: https://www-demo1.allizom.org/en-US/firefox/new/?scene=2
- Test that the correct pixel is triggered depending on the switch?
