### PR TITLE
Fix css linting for sandstone + pebbles

### DIFF
--- a/media/css/pebbles/includes/_animations.scss
+++ b/media/css/pebbles/includes/_animations.scss
@@ -5,8 +5,8 @@
 
 @-webkit-keyframes pebbles-bounce-down {
     0%, 60%, 75%, 90%, 100% {
-        -webkit-transition-timing-function: cubic-bezier(0.215, 0.610, 0.355, 1.000);
-                transition-timing-function: cubic-bezier(0.215, 0.610, 0.355, 1.000);
+        -webkit-transition-timing-function: cubic-bezier(0.215, 0.61, 0.355, 1);
+                transition-timing-function: cubic-bezier(0.215, 0.61, 0.355, 1);
     }
     0% {
         opacity: 0;
@@ -29,7 +29,7 @@
 
 @keyframes pebbles-bounce-down {
     0%, 60%, 75%, 90%, 100% {
-        transition-timing-function: cubic-bezier(0.215, 0.610, 0.355, 1.000);
+        transition-timing-function: cubic-bezier(0.215, 0.61, 0.355, 1);
     }
     0% {
         opacity: 0;

--- a/media/css/sandstone/animations.less
+++ b/media/css/sandstone/animations.less
@@ -4,8 +4,8 @@
 
 @-webkit-keyframes sand-bounce-down {
     0%, 60%, 75%, 90%, 100% {
-        -webkit-transition-timing-function: cubic-bezier(0.215, 0.610, 0.355, 1.000);
-        transition-timing-function: cubic-bezier(0.215, 0.610, 0.355, 1.000);
+        -webkit-transition-timing-function: cubic-bezier(0.215, 0.61, 0.355, 1);
+        transition-timing-function: cubic-bezier(0.215, 0.61, 0.355, 1);
     }
     0% {
         opacity: 0;
@@ -33,7 +33,7 @@
 
 @keyframes sand-bounce-down {
     0%, 60%, 75%, 90%, 100% {
-        transition-timing-function: cubic-bezier(0.215, 0.610, 0.355, 1.000);
+        transition-timing-function: cubic-bezier(0.215, 0.61, 0.355, 1);
     }
     0% {
         opacity: 0;

--- a/media/css/sandstone/lib.less
+++ b/media/css/sandstone/lib.less
@@ -87,18 +87,18 @@
 
 // Button shadows
 
-@shadowPartBottom:      0px 1px 0px 0px rgba(0, 0, 0, 0.2);
-@shadowPartBottomInset: inset 0px -1px 0px 0px rgba(0, 0, 0, 0.3);
-@shadowPartHover:       inset 0px 12px 24px 2px saturate(@buttonBlue, 10%);
+@shadowPartBottom:      0 1px 0 0 rgba(0, 0, 0, 0.2);
+@shadowPartBottomInset: inset 0 -1px 0 0 rgba(0, 0, 0, 0.3);
+@shadowPartHover:       inset 0 12px 24px 2px saturate(@buttonBlue, 10%);
 @shadowPartFocusRing:   0 0 0 2px rgba(73,173,227,0.4);
 
 @buttonShadow:          @shadowPartBottom, @shadowPartBottomInset;
 @buttonShadowHover:     @shadowPartBottom, @shadowPartBottomInset, @shadowPartHover;
 @buttonShadowFocus:     @shadowPartBottom, @shadowPartBottomInset, @shadowPartHover, @shadowPartFocusRing;
 
-@buttonShadowActive:     inset 0px 2px 0px 0px rgba(0, 0, 0, 0.2),
-                         inset 0px 12px 24px 6px rgba(0,0,0,0.2),
-                         inset 0px 0px 2px 2px rgba(0,0,0,0.2);
+@buttonShadowActive:     inset 0 2px 0 0 rgba(0, 0, 0, 0.2),
+                         inset 0 12px 24px 6px rgba(0,0,0,0.2),
+                         inset 0 0 2px 2px rgba(0,0,0,0.2);
 
 @borderColor: #d6d6d6;
 
@@ -373,7 +373,7 @@
 .button-hover-box-shadow(@color: #ffffff) {
     @shadow:  @shadowPartBottom,
               @shadowPartBottomInset,
-              inset 0px 12px 24px 2px saturate(@color, 10%);
+              inset 0 12px 24px 2px saturate(@color, 10%);
     .box-shadow(@shadow);
 }
 
@@ -522,32 +522,32 @@
 .aurora-bars(@pageBgColor: @mozIDBlue, @auroraStartColor: #00a7e0) {
     background-color: @pageBgColor;
     background-image: none;
-    background-image: linear-gradient(to bottom, fade(@pageBgColor, 0%) 0px, fade(@pageBgColor, 0%) 100px, @pageBgColor 450px, @pageBgColor),
+    background-image: linear-gradient(to bottom, fade(@pageBgColor, 0%) 0, fade(@pageBgColor, 0%) 100px, @pageBgColor 450px, @pageBgColor),
         repeating-linear-gradient(118deg,
-            fade(@pageBgColor, 0%) 0px, @auroraStartColor 550px,
+            fade(@pageBgColor, 0%) 0, @auroraStartColor 550px,
             fade(@pageBgColor, 0%) 550px, @auroraStartColor 800px,
             fade(@pageBgColor, 0%) 800px, @auroraStartColor 950px);
 
     @media (max-width: @breakDesktop) {
-        background-image: linear-gradient(to bottom, fade(@pageBgColor, 0%) 0px, fade(@pageBgColor, 0%) 100px, @pageBgColor 350px, @pageBgColor),
+        background-image: linear-gradient(to bottom, fade(@pageBgColor, 0%) 0, fade(@pageBgColor, 0%) 100px, @pageBgColor 350px, @pageBgColor),
             repeating-linear-gradient(118deg,
-                fade(@pageBgColor, 0%) 0px, @auroraStartColor 410px,
+                fade(@pageBgColor, 0%) 0, @auroraStartColor 410px,
                 fade(@pageBgColor, 0%) 410px, @auroraStartColor 600px,
                 fade(@pageBgColor, 0%) 600px, @auroraStartColor 720px);
     }
 
     @media (max-width: @breakTablet) {
-        background-image: linear-gradient(to bottom, fade(@pageBgColor, 0%) 0px, fade(@pageBgColor, 0%) 100px, @pageBgColor 300px, @pageBgColor),
+        background-image: linear-gradient(to bottom, fade(@pageBgColor, 0%) 0, fade(@pageBgColor, 0%) 100px, @pageBgColor 300px, @pageBgColor),
             repeating-linear-gradient(118deg,
-                fade(@pageBgColor, 0%) 0px, @auroraStartColor 320px,
+                fade(@pageBgColor, 0%) 0, @auroraStartColor 320px,
                 fade(@pageBgColor, 0%) 320px, @auroraStartColor 480px,
                 fade(@pageBgColor, 0%) 480px, @auroraStartColor 570px);
     }
 
     @media (max-width: @breakMobileLandscape) {
-        background-image: linear-gradient(to bottom, fade(@pageBgColor, 0%) 0px, fade(@pageBgColor, 0%) 100px, @pageBgColor 250px, @pageBgColor),
+        background-image: linear-gradient(to bottom, fade(@pageBgColor, 0%) 0, fade(@pageBgColor, 0%) 100px, @pageBgColor 250px, @pageBgColor),
             repeating-linear-gradient(118deg,
-                fade(@pageBgColor, 0%) 0px, @auroraStartColor 200px,
+                fade(@pageBgColor, 0%) 0, @auroraStartColor 200px,
                 fade(@pageBgColor, 0%) 200px, @auroraStartColor 320px,
                 fade(@pageBgColor, 0%) 320px, @auroraStartColor 380px);
     }

--- a/media/css/sandstone/oldIE.less
+++ b/media/css/sandstone/oldIE.less
@@ -281,12 +281,12 @@ img {
 
 // Color schemes
 .sand #outer-wrapper {
-    background: #f5f1e8 url(/media/img/sandstone/bg-gradient-sand.png) repeat-x;
+    background: #f5f1e8 url("/media/img/sandstone/bg-gradient-sand.png") repeat-x;
 }
 
 .sky {
     #outer-wrapper {
-        background: #eee url(/media/img/sandstone/bg-gradient-sky.png) repeat-x;
+        background: #eee url("/media/img/sandstone/bg-gradient-sky.png") repeat-x;
     }
 
     a:link,
@@ -324,7 +324,7 @@ img {
     color: #fff;
 
     #outer-wrapper {
-        background: #04020b url(/media/img/sandstone/bg-space.png) repeat-x;
+        background: #04020b url("/media/img/sandstone/bg-space.png") repeat-x;
     }
 
     h1, h2, h3, h4, h5, h6 {
@@ -395,7 +395,7 @@ img {
             .current {
                 background-position: 50% 0;
                 background-repeat: no-repeat;
-                background-image: url(/media/img/sandstone/menu-current.png);
+                background-image: url("/media/img/sandstone/menu-current.png");
             }
             a:link,
             a:visited {

--- a/media/css/sandstone/sandstone-resp.less
+++ b/media/css/sandstone/sandstone-resp.less
@@ -22,7 +22,7 @@ body {
 #outer-wrapper {
     position: relative;
     border-top: 2px solid #fff;
-    background: #f9f9f9 url(/media/img/sandstone/bg-stone.png) 0 0 repeat-x;
+    background: #f9f9f9 url("/media/img/sandstone/bg-stone.png) 0 0 repeat-x;
 }
 
 #wrapper {
@@ -58,17 +58,17 @@ a.more {
 }
 
 .sand #outer-wrapper {
-    background: #f5f1e8 url(/media/img/sandstone/bg-gradient-sand.png) repeat-x;
-    background: url(/media/img/sandstone/bg-gradient-sand.png) repeat-x,
-                url(/media/img/sandstone/bg-sand.png) repeat,
+    background: #f5f1e8 url("/media/img/sandstone/bg-gradient-sand.png) repeat-x;
+    background: url("/media/img/sandstone/bg-gradient-sand.png) repeat-x,
+                url("/media/img/sandstone/bg-sand.png) repeat,
                 #f5f1e8;
 }
 
 .sky {
     #outer-wrapper {
-        background: #eee url(/media/img/sandstone/bg-gradient-sky.png) repeat-x;
-        background: url(/media/img/sandstone/bg-gradient-sky.png) repeat-x,
-                    url(/media/img/sandstone/grain.png) repeat,
+        background: #eee url("/media/img/sandstone/bg-gradient-sky.png) repeat-x;
+        background: url("/media/img/sandstone/bg-gradient-sky.png) repeat-x,
+                    url("/media/img/sandstone/grain.png) repeat,
                     #eee;
     }
 
@@ -88,7 +88,7 @@ a.more {
     color: #fff;
 
     #outer-wrapper {
-        background: #04020b url(/media/img/sandstone/bg-space.png) repeat-x;
+        background: #04020b url("/media/img/sandstone/bg-space.png) repeat-x;
     }
 
     a {
@@ -646,7 +646,7 @@ label.error {
             .current {
                 background-position: 50% 0;
                 background-repeat: no-repeat;
-                background-image: url(/media/img/sandstone/menu-current.png);
+                background-image: url("/media/img/sandstone/menu-current.png");
             }
 
 
@@ -724,7 +724,7 @@ label.error {
     position: absolute;
     bottom: -40px;
     left: 0;
-    background: url(/media/img/mission/title-banner-shadow.png) no-repeat;
+    background: url("/media/img/mission/title-banner-shadow.png") no-repeat;
 }
 
 html[dir="rtl"] {
@@ -1245,7 +1245,7 @@ nav.menu-bar {
             width: 32px;
             height: 32px;
             /*margin: -3px 0 0 -3px;*/
-            background: no-repeat center top url(/media/img/sandstone/icn-menu.png);
+            background: no-repeat center top url("/media/img/sandstone/icn-menu.png");
             text-indent: -999em;
             overflow: hidden;
             cursor: pointer;
@@ -1434,7 +1434,7 @@ nav.menu-bar {
         }
 
         #nav-main-menu a.submenu-item {
-            background: 94% 50% no-repeat url(/media/img/sandstone/arrow-go.png);
+            background: 94% 50% no-repeat url("/media/img/sandstone/arrow-go.png");
         }
 
         #nav-main-menu a:hover,
@@ -1453,8 +1453,8 @@ nav.menu-bar {
         #nav-main-menu a.submenu-item:hover,
         #nav-main-menu a.submenu-item:focus,
         #nav-main-menu a.submenu-item:active {
-            background-image: url(/media/img/sandstone/arrow-go.png), -webkit-linear-gradient(top, #43a6e2, #247ac1);
-            background-image: url(/media/img/sandstone/arrow-go.png), linear-gradient(to bottom, #43a6e2, #247ac1);
+            background-image: url("/media/img/sandstone/arrow-go.png"), -webkit-linear-gradient(top, #43a6e2, #247ac1);
+            background-image: url("/media/img/sandstone/arrow-go.png"), linear-gradient(to bottom, #43a6e2, #247ac1);
         }
 
         #nav-main-menu li.first > a {
@@ -1494,7 +1494,7 @@ nav.menu-bar {
         display: block;
         width: 28px;
         height: 10px;
-        background: no-repeat url(/media/img/sandstone/menu-point.png);
+        background: no-repeat url("/media/img/sandstone/menu-point.png");
         position: absolute;
         left: 22px;
         top: -10px;

--- a/media/css/sandstone/sandstone.less
+++ b/media/css/sandstone/sandstone.less
@@ -23,7 +23,7 @@ body {
     position: relative;
     border-top: 2px solid #fff;
     min-width: 992px;
-    background: #f9f9f9 url(/media/img/sandstone/bg-stone.png) 0 0 repeat-x;
+    background: #f9f9f9 url("/media/img/sandstone/bg-stone.png") 0 0 repeat-x;
 }
 
 #wrapper {
@@ -52,17 +52,17 @@ a.more {
 }
 
 .sand #outer-wrapper {
-    background: #f5f1e8 url(/media/img/sandstone/bg-gradient-sand.png) repeat-x;
-    background: url(/media/img/sandstone/bg-gradient-sand.png) repeat-x,
-                url(/media/img/sandstone/bg-sand.png) repeat,
+    background: #f5f1e8 url("/media/img/sandstone/bg-gradient-sand.png") repeat-x;
+    background: url("/media/img/sandstone/bg-gradient-sand.png") repeat-x,
+                url("/media/img/sandstone/bg-sand.png") repeat,
                 #f5f1e8;
 }
 
 .sky {
     #outer-wrapper {
-        background: #eee url(/media/img/sandstone/bg-gradient-sky.png) repeat-x;
-        background: url(/media/img/sandstone/bg-gradient-sky.png) repeat-x,
-                    url(/media/img/sandstone/grain.png) repeat,
+        background: #eee url("/media/img/sandstone/bg-gradient-sky.png") repeat-x;
+        background: url("/media/img/sandstone/bg-gradient-sky.png") repeat-x,
+                    url("/media/img/sandstone/grain.png) repeat,
                     #eee;
     }
 
@@ -81,7 +81,7 @@ a.more {
     color: #fff;
 
     #outer-wrapper {
-        background: #04020b url(/media/img/sandstone/bg-space.png) repeat-x;
+        background: #04020b url("/media/img/sandstone/bg-space.png) repeat-x;
     }
 
     a {
@@ -474,7 +474,7 @@ px      68    160    252    344    436    528    620    712    804    896    */
             .current {
                 background-position: 50% 0;
                 background-repeat: no-repeat;
-                background-image: url(/media/img/sandstone/menu-current.png);
+                background-image: url("/media/img/sandstone/menu-current.png");
             }
 
 


### PR DESCRIPTION
## Description
Fix CSS linting errors for Sandstone and Pebble libraries, as laid out in the bug report.

## Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1332675

## Testing
There are now no error messages when the following commands are run:
```bash
./node_modules/gulp-stylelint/node_modules/.bin/stylelint "media/css/pebbles/**/*.scss"

./node_modules/gulp-stylelint/node_modules/.bin/stylelint "media/css/sandstone/**/*.less"
```

## Checklist
- [ ] Requires l10n changes.
- [x] Related functional & integration tests passing.
