### PR TITLE
Bug 1330000 - Rename 'OS X' to 'macOS' on download pages / buttons

### DIFF
--- a/bedrock/firefox/firefox_details.py
+++ b/bedrock/firefox/firefox_details.py
@@ -34,7 +34,7 @@ class FirefoxDesktop(_ProductDetails):
         ('winsha1', 'Windows (XP/Vista)'),
         ('win', 'Windows'),
         ('win64', 'Windows 64-bit'),
-        ('osx', 'OS X'),
+        ('osx', 'macOS'),
         ('linux', 'Linux'),
         ('linux64', 'Linux 64-bit'),
     ])

--- a/bedrock/firefox/templates/firefox/dnt.html
+++ b/bedrock/firefox/templates/firefox/dnt.html
@@ -151,9 +151,11 @@
     </p>
     <noscript>
     <p>
-    {% trans %}
-      On Mac OS X, go to Firefox &gt; Preferences… &gt; Privacy. On Linux, go to Edit &gt; Preferences &gt; Privacy.
-    {% endtrans %}
+    {% if l10n_has_tag('macos_branding') %}
+      {{ _('On macOS, go to Firefox &gt; Preferences… &gt; Privacy. On Linux, go to Edit &gt; Preferences &gt; Privacy.') }}
+    {% else %}
+      {{ _('On OS X, go to Firefox &gt; Preferences… &gt; Privacy. On Linux, go to Edit &gt; Preferences &gt; Privacy.') }}
+    {% endif %}
     </p>
     </noscript>
     <p>

--- a/bedrock/firefox/templates/firefox/new/base.html
+++ b/bedrock/firefox/templates/firefox/new/base.html
@@ -10,7 +10,13 @@
 
 {% block page_title_prefix %}{{_('Download Firefox')}} — {% endblock %}
 {% block page_title %}{{_('Free Web Browser')}}{% endblock %}
-{% block page_desc %}{{_('Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, Mac OS X, Linux, Android and iOS today!')}}{% endblock %}
+{% block page_desc %}
+{% if l10n_has_tag('macos_branding') %}
+  {{ _('Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!') }}
+{% else %}
+  {{ _('Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, OS X, Linux, Android and iOS today!') }}
+{% endif %}
+{% endblock %}
 
 {#- This will appear as <meta property="og:title"> which can be used for social share -#}
 {% block page_og_title %}

--- a/bedrock/firefox/templates/firefox/new/onboarding/scene1.html
+++ b/bedrock/firefox/templates/firefox/new/onboarding/scene1.html
@@ -134,7 +134,7 @@
       <section class="section-current-platform">
         {# L10n: span's below are for visual formatting and line break. #}
         <h4 class="heading-windows">{{_('Download Firefox <span>for Windows</span>') }}</h4>
-        <h4 class="heading-osx">{{_('Download Firefox <span>for OSX</span>') }}</h4>
+        <h4 class="heading-osx">{{_('Download Firefox <span>for macOS</span>') }}</h4>
         <h4 class="heading-linux">{{_('Download Firefox <span>for Linux</span>') }}</h4>
 
         {{ download_firefox(dom_id='download-other-platforms-modal', alt_copy=_('Free Download')) }}

--- a/bedrock/firefox/templates/firefox/new/scene1.html
+++ b/bedrock/firefox/templates/firefox/new/scene1.html
@@ -141,7 +141,7 @@
       <section class="section-current-platform">
         {# L10n: span's below are for visual formatting and line break. #}
         <h4 class="heading-windows">{{_('Download Firefox <span>for Windows</span>') }}</h4>
-        <h4 class="heading-osx">{{_('Download Firefox <span>for OS X</span>') }}</h4>
+        <h4 class="heading-osx">{{_('Download Firefox <span>for macOS</span>') }}</h4>
         <h4 class="heading-linux">{{_('Download Firefox <span>for Linux</span>') }}</h4>
 
         {{ download_firefox(dom_id='download-other-platforms-modal', alt_copy=_('Free Download')) }}

--- a/bedrock/thunderbird/details.py
+++ b/bedrock/thunderbird/details.py
@@ -28,7 +28,7 @@ class ThunderbirdDesktop(ProductDetails):
     platform_labels = OrderedDict([
         ('winsha1', 'Windows (XP/Vista)'),
         ('win', 'Windows'),
-        ('osx', 'OS X'),
+        ('osx', 'macOS'),
         ('linux', 'Linux'),
         ('linux64', 'Linux 64-bit'),
     ])

--- a/bedrock/thunderbird/templates/thunderbird/features.html
+++ b/bedrock/thunderbird/templates/thunderbird/features.html
@@ -223,7 +223,13 @@
         <div class="col">
           <section>
             <h3>{{ _('Automated Update') }}</h3>
-            <p>{{ _('Thunderbird’s update system checks to see if you’re running the latest version, and notifies you when a security update is available. These security updates are small (usually 200KB - 700KB), giving you only what you need and making the security update quick to download and install. The automated update system provides updates for Thunderbird on Windows, Mac OS X, and Linux in over 40 different languages.') }}</p>
+            <p>
+            {% if l10n_has_tag('macos_branding') %}
+              {{ _('Thunderbird’s update system checks to see if you’re running the latest version, and notifies you when a security update is available. These security updates are small (usually 200KB - 700KB), giving you only what you need and making the security update quick to download and install. The automated update system provides updates for Thunderbird on Windows, macOS, and Linux in over 40 different languages.') }}
+            {% else %}
+              {{ _('Thunderbird’s update system checks to see if you’re running the latest version, and notifies you when a security update is available. These security updates are small (usually 200KB - 700KB), giving you only what you need and making the security update quick to download and install. The automated update system provides updates for Thunderbird on Windows, OS X, and Linux in over 40 different languages.') }}
+            {% endif %}
+            </p>
             <img src="{{ static('img/thunderbird/features/automated-update.png') }}" alt="">
           </section>
         </div>


### PR DESCRIPTION
Rename 'OS X' to 'macOS' on various appropriate user facing components, like on download page.

Bugzilla link: https://bugzilla.mozilla.org/show_bug.cgi?id=1330000
