### PR TITLE
[fix bug 1332677] Fix CSS linting errors for styleguide

### DIFF
--- a/media/css/styleguide/identity-firefox.less
+++ b/media/css/styleguide/identity-firefox.less
@@ -239,8 +239,8 @@
             position: absolute;
             top: 0;
             right: 75px;
-            background: url(/media/img/styleguide/download-arrow.png) center right no-repeat;
-            padding-right: 40px
+            background: url("/media/img/styleguide/download-arrow.png") center right no-repeat;
+            padding-right: 40px;
         }
     }
     .clear {

--- a/media/css/styleguide/identity-firefoxos.less
+++ b/media/css/styleguide/identity-firefoxos.less
@@ -564,8 +564,8 @@
               position: absolute;
               top: 0;
               right: 75px;
-              background: url(/media/img/styleguide/download-arrow.png) center right no-repeat;
-              padding-right: 40px
+              background: url("/media/img/styleguide/download-arrow.png") center right no-repeat;
+              padding-right: 40px;
           }
       }
       .clear {

--- a/media/css/styleguide/identity-marketplace.less
+++ b/media/css/styleguide/identity-marketplace.less
@@ -138,8 +138,8 @@
             position: absolute;
             top: 0;
             right: 75px;
-            background: url(/media/img/styleguide/download-arrow.png) center right no-repeat;
-            padding-right: 40px
+            background: url("/media/img/styleguide/download-arrow.png") center right no-repeat;
+            padding-right: 40px;
         }
     }
     .clear {

--- a/media/css/styleguide/identity-mozilla.less
+++ b/media/css/styleguide/identity-mozilla.less
@@ -96,8 +96,8 @@
             position: absolute;
             top: 0;
             right: 75px;
-            background: url(/media/img/styleguide/download-arrow.png) center right no-repeat;
-            padding-right: 40px
+            background: url("/media/img/styleguide/download-arrow.png") center right no-repeat;
+            padding-right: 40px;
         }
     }
     .clear {

--- a/media/css/styleguide/identity-persona.less
+++ b/media/css/styleguide/identity-persona.less
@@ -129,8 +129,8 @@
             position: absolute;
             top: 0;
             right: 75px;
-            background: url(/media/img/styleguide/download-arrow.png) center right no-repeat;
-            padding-right: 40px
+            background: url("/media/img/styleguide/download-arrow.png") center right no-repeat;
+            padding-right: 40px;
         }
     }
     .clear {

--- a/media/css/styleguide/identity-webmaker.less
+++ b/media/css/styleguide/identity-webmaker.less
@@ -110,8 +110,8 @@
             position: absolute;
             top: 0;
             right: 75px;
-            background: url(/media/img/styleguide/download-arrow.png) center right no-repeat;
-            padding-right: 40px
+            background: url("/media/img/styleguide/download-arrow.png") center right no-repeat;
+            padding-right: 40px;
         }
     }
     .clear {

--- a/media/css/styleguide/products-firefox-os.less
+++ b/media/css/styleguide/products-firefox-os.less
@@ -22,7 +22,7 @@
             width: 40px;
             top: 0;
             left: 0;
-            background: transparent url(/media/img/styleguide/products/firefoxos/ol-list.png) no-repeat 0 0;
+            background: transparent url("/media/img/styleguide/products/firefoxos/ol-list.png") no-repeat 0 0;
         }
         li:nth-child(2):before {
             background-position: 0 -47px;
@@ -179,12 +179,12 @@
                         .span_guide(2);
                         margin-right: 0;
                         padding-top: 15px;
-                        li {
-                            list-style-type: none;
-                            margin-left: 0;
-                            .font-size(@smallFontSize);
-                            color: @darkThemeText;
-                        }
+                    }
+                    div li {
+                        list-style-type: none;
+                        margin-left: 0;
+                        .font-size(@smallFontSize);
+                        color: @darkThemeText;
                     }
                 }
             }
@@ -491,24 +491,51 @@
         #swatch_000000 .swatch span { background-color: #000000; }
         #swatch_333333 .swatch span { background-color: #333333; }
         #swatch_2c393b .swatch span { background-color: #2c393b; }
-        #swatch_f4f4f4 .swatch span { background-color: #f4f4f4; color: #000; }
-        #swatch_eaeae7 .swatch span { background-color: #eaeae7; color: #000; }
+        #swatch_f4f4f4 .swatch span {
+            background-color: #f4f4f4;
+            color: #000;
+        }
+        #swatch_eaeae7 .swatch span {
+            background-color: #eaeae7;
+            color: #000;
+        }
         #swatch_000000 .swatch span { background-color: #000000; }
         #swatch_333333 .swatch span { background-color: #333333; }
         #swatch_4d4d4d .swatch span { background-color: #4d4d4d; }
         #swatch_5f5f5f .swatch span { background-color: #5f5f5f; }
         #swatch_858585 .swatch span { background-color: #858585; }
         #swatch_a6a6a6 .swatch span { background-color: #a6a6a6; }
-        #swatch_c7c7c7 .swatch span { background-color: #c7c7c7; color: #000; }
-        #swatch_e7e7e7 .swatch span { background-color: #e7e7e7; color: #000; }
-        #swatch_eeeeee .swatch span { background-color: #eeeeee; color: #000; }
-        #swatch_f4f4f4 .swatch span { background-color: #f4f4f4; color: #000; }
-        #swatch_ffffff .swatch span { background-color: #ffffff; color: #000; }
-        #swatch_eaeae7 .swatch span { background-color: #eaeae7; color: #000; }
+        #swatch_c7c7c7 .swatch span {
+            background-color: #c7c7c7;
+            color: #000;
+        }
+        #swatch_e7e7e7 .swatch span {
+            background-color: #e7e7e7;
+            color: #000;
+        }
+        #swatch_eeeeee .swatch span {
+            background-color: #eeeeee;
+            color: #000;
+        }
+        #swatch_f4f4f4 .swatch span {
+            background-color: #f4f4f4;
+            color: #000;
+        }
+        #swatch_ffffff .swatch span {
+            background-color: #ffffff;
+            color: #000;
+        }
+        #swatch_eaeae7 .swatch span {
+            background-color: #eaeae7;
+            color: #000;
+        }
         #swatch_008eab .swatch span { background-color: #008eab; }
         #swatch_00aacc .swatch span { background-color: #00aacc; }
         #swatch_00caf2 .swatch span { background-color: #00caf2; }
-        #swatch_b2f2ff .swatch span { background-color: #b2f2ff; color: #000; }
+        #swatch_b2f2ff .swatch span {
+            background-color: #b2f2ff;
+            color: #000;
+        }
         #swatch_820000 .swatch span { background-color: #820000; }
         #swatch_b90000 .swatch span { background-color: #b90000; }
         #swatch_ff4e00 .swatch span { background-color: #ff4e00; }

--- a/media/css/styleguide/styleguide-lib.less
+++ b/media/css/styleguide/styleguide-lib.less
@@ -9,12 +9,12 @@
 .divider() {
     padding-bottom: @baseLine * 3;
     margin-bottom: @baseLine * 2;
-    background: url(/media/img/styleguide/divider.png) 50% 100% no-repeat;
+    background: url("/media/img/styleguide/divider.png") 50% 100% no-repeat;
 }
 
 .divider-dark() {
     .divider();
-    background-image: url(/media/img/styleguide/divider-dark.png);
+    background-image: url("/media/img/styleguide/divider-dark.png");
 }
 
 /* {{{ Grid setup */

--- a/media/css/styleguide/styleguide.less
+++ b/media/css/styleguide/styleguide.less
@@ -118,7 +118,7 @@
                     }
                 }
                 &.active > a:only-child {
-                    background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAgAAAAPCAQAAABzA0a4AAAAgklEQVQI12NgQAGe2ijcQK1CFSRulEaZUq0SnJukVqXUoNigCOVmqdYqNSqCIJhbqNyg2AyFQG6lUotiqwIMMuSqNCm2KSAgUEWuSotCBxyCzUhTbVbsVIBAqC1x6k2K3fIgCHdHqGa9Yq98rzySSwO0q5VQBBgY/HVKlFE9yxCsDwAkyidSkh/I2gAAAABJRU5ErkJggg==);
+                    background-image: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAgAAAAPCAQAAABzA0a4AAAAgklEQVQI12NgQAGe2ijcQK1CFSRulEaZUq0SnJukVqXUoNigCOVmqdYqNSqCIJhbqNyg2AyFQG6lUotiqwIMMuSqNCm2KSAgUEWuSotCBxyCzUhTbVbsVIBAqC1x6k2K3fIgCHdHqGa9Yq98rzySSwO0q5VQBBgY/HVKlFE9yxCsDwAkyidSkh/I2gAAAABJRU5ErkJggg==");
                 }
                 &.path > a {
                     .open-sans;
@@ -133,7 +133,7 @@
                 &.has-children > a:focus,
                 &.has-children > a:active,
                 &.active.has-children > a {
-                    background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABkAAAALCAYAAACK9ybzAAABIElEQVR42mNgoAcQEBBgAmJWMjAT0ZYYGxtziIqKWisqKlqpqKhYEMIgdUD1ViB9RFvy//9/li1btmhaW1sbhoeHayQkJKjhwiB5kLrNmzdrgPSRFGRADRyLFi3S9vHx0S4vL1dqbGxURMdlZWXK3t7eOkuWLNEGqScrboAaeYCG6QcHB2vW1NQotbS0KMAwiB8YGKjZ29urB1JHUSIAGiCUm5trEBcXp97c3KzQ0dGh0NTUpBgdHa1eUFBgAJQXoEpq+/jxo0RUVJRBZmamKtAXimlpaWrx8fEGP3/+FKNakga6lvHZs2dywGDTj4yM1ABGtsGbN29kQOJUzTtAA5nOnj2r7ObmZnrv3j1FEJ8mmRRoMOvv37/lgTQzpWYBAOKQkXaJladPAAAAAElFTkSuQmCC);
+                    background-image: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABkAAAALCAYAAACK9ybzAAABIElEQVR42mNgoAcQEBBgAmJWMjAT0ZYYGxtziIqKWisqKlqpqKhYEMIgdUD1ViB9RFvy//9/li1btmhaW1sbhoeHayQkJKjhwiB5kLrNmzdrgPSRFGRADRyLFi3S9vHx0S4vL1dqbGxURMdlZWXK3t7eOkuWLNEGqScrboAaeYCG6QcHB2vW1NQotbS0KMAwiB8YGKjZ29urB1JHUSIAGiCUm5trEBcXp97c3KzQ0dGh0NTUpBgdHa1eUFBgAJQXoEpq+/jxo0RUVJRBZmamKtAXimlpaWrx8fEGP3/+FKNakga6lvHZs2dywGDTj4yM1ABGtsGbN29kQOJUzTtAA5nOnj2r7ObmZnrv3j1FEJ8mmRRoMOvv37/lgTQzpWYBAOKQkXaJladPAAAAAElFTkSuQmCC");
                 }
             }
         }
@@ -207,12 +207,12 @@ h1 {
             padding: 4px 10px 4px 18px;
             background-repeat: no-repeat;
             background-position: 0 50%;
-            background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAgAAAAOCAQAAAC4X5UdAAAAqUlEQVQI12NggAM5BeUfcrIIrrTFJ+93mt+gXHkJy08xr/zfnp0A4YpYfIx9EfLq2OT/QkCugpDlh/in4S8OTP0vBuLymXxIfZz2eNeM/5Jg5SVijq8q76Q9zPKGGvef42Fn5OO8u64vlQxgQtyPOiMeZdxzeKmkDRe61RP1IPO2wwtFVZgQ3/WemHuJd/Tewl36X+Biv8MzqMOgQkJ/G/4LMyCD/4wMDAA0i0VIl3QqKwAAAABJRU5ErkJggg==);
+            background-image: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAgAAAAOCAQAAAC4X5UdAAAAqUlEQVQI12NggAM5BeUfcrIIrrTFJ+93mt+gXHkJy08xr/zfnp0A4YpYfIx9EfLq2OT/QkCugpDlh/in4S8OTP0vBuLymXxIfZz2eNeM/5Jg5SVijq8q76Q9zPKGGvef42Fn5OO8u64vlQxgQtyPOiMeZdxzeKmkDRe61RP1IPO2wwtFVZgQ3/WemHuJd/Tewl36X+Biv8MzqMOgQkJ/G/4LMyCD/4wMDAA0i0VIl3QqKwAAAABJRU5ErkJggg==");
         }
         a.next {
             padding: 4px 18px 4px 10px;
             background-position: 100% 50%;
-            background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAkAAAAOCAQAAABXnf4jAAAAs0lEQVQY02NgYJDTUPwoJ82AAHL8Wt+835m9lpOAC/3n2Dct4E30K7NXciIIQYk900NeRb8weyEvhBCU3jI7/HnsM/MX8nwIQbn1c9MfJz82eq7ACxdMD0t/UHbX+UUBzEQlS7cXufeiHr5s+s8OETBxepl+L+rBw9b/HBABA6fnmbej791v/c8NFlDkM3yTdCfm7o2O/zxwp+6f6vzkaud/PiQv/Zf8W/tfgAEV/GdE5gEAoDlHYRy+CTkAAAAASUVORK5CYII=);
+            background-image: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAkAAAAOCAQAAABXnf4jAAAAs0lEQVQY02NgYJDTUPwoJ82AAHL8Wt+835m9lpOAC/3n2Dct4E30K7NXciIIQYk900NeRb8weyEvhBCU3jI7/HnsM/MX8nwIQbn1c9MfJz82eq7ACxdMD0t/UHbX+UUBzEQlS7cXufeiHr5s+s8OETBxepl+L+rBw9b/HBABA6fnmbej791v/c8NFlDkM3yTdCfm7o2O/zxwp+6f6vzkaud/PiQv/Zf8W/tfgAEV/GdE5gEAoDlHYRy+CTkAAAAASUVORK5CYII=");
         }
     }
     #breadcrumbs {
@@ -221,7 +221,7 @@ h1 {
             margin-right: 10px;
             background-position: 100% 50%;
             background-repeat: no-repeat;
-            background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA0AAAAUCAYAAABWMrcvAAAAkElEQVR42rXTOwrCQBRG4bzMOM4gBAJaSppUFsYVZAEhWYBpDe5/AeNJEbCcP+DAKb/m3rlJCCGl4tINR0qT2AfK6ASqKVdgQRWooYMCS7qCHmQUaOgG6skq0FILmsgp0NEdNJNXoKcOtNBZhU/Q5/9QRnvBOoh3LNhG/ooa+c9yx6jlyt9I/rDyachHuOfcvyUWl/SX1/69AAAAAElFTkSuQmCC);
+            background-image: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA0AAAAUCAYAAABWMrcvAAAAkElEQVR42rXTOwrCQBRG4bzMOM4gBAJaSppUFsYVZAEhWYBpDe5/AeNJEbCcP+DAKb/m3rlJCCGl4tINR0qT2AfK6ASqKVdgQRWooYMCS7qCHmQUaOgG6skq0FILmsgp0NEdNJNXoKcOtNBZhU/Q5/9QRnvBOoh3LNhG/ooa+c9yx6jlyt9I/rDyachHuOfcvyUWl/SX1/69AAAAAElFTkSuQmCC");
 
         }
         a:last-child,b:last-child {
@@ -263,20 +263,18 @@ body.dark {
             a,b {
                 color: @darkThemeText;
             }
-            ul {
-                li {
-                    &.active > a:only-child {
-                        background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAgAAAAPCAYAAADZCo4zAAAAqklEQVR42n2QSQ7CMAxFexguwSA60IEwSblEegBOTxYJz5a8SGmp9BXX79uJXf379nXvNmE7PfyxHeMqrIebP/cuovwDSfpmvEeUMZaGQzNIW61EpYEKbXvqpowE6qmwuz49iYgMqOiWK4IdwUcAL8900vb2b6+eUQJq0s5iChJqkrYiYjUu55+ZJAlki/niXqt7CFQmm2TJbR+Ba9S0xm0vgXelLW77eX8BLJlorrHHwwoAAAAASUVORK5CYII=);
-                    }
-                    &.active {
+            ul li {
+                &.active > a:only-child {
+                    background-image: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAgAAAAPCAYAAADZCo4zAAAAqklEQVR42n2QSQ7CMAxFexguwSA60IEwSblEegBOTxYJz5a8SGmp9BXX79uJXf379nXvNmE7PfyxHeMqrIebP/cuovwDSfpmvEeUMZaGQzNIW61EpYEKbXvqpowE6qmwuz49iYgMqOiWK4IdwUcAL8900vb2b6+eUQJq0s5iChJqkrYiYjUu55+ZJAlki/niXqt7CFQmm2TJbR+Ba9S0xm0vgXelLW77eX8BLJlorrHHwwoAAAAASUVORK5CYII=");
+                }
+                &.active {
+                    background: rgba(0,0,0,0.2);
+                    .active {
                         background: rgba(0,0,0,0.2);
-                        .active {
-                            background: rgba(0,0,0,0.2);
-                        }
                     }
-                    &.path a {
-                        color: @darkThemeText;
-                    }
+                }
+                &.path a {
+                    color: @darkThemeText;
                 }
             }
         }
@@ -287,10 +285,10 @@ body.dark {
     #subnav {
         #nextprev {
             a {
-                background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAgAAAAOCAMAAAAliK2kAAAABGdBTUEAALGPC/xhBQAAACBjSFJNAAB6JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAAQlBMVEUAAAAAx+8Ax+8Ax+8Ax+8Ax+8Ax+8Ax+8Ax+8Ax+8Ax+8Ax+8Ax+8Ax+8Ax+8Ax+8Ax+8Ax+8Ax+8Ax+8Ax+8AAAC5xB8hAAAAFHRSTlMAIR4cGSQVKxMxDzc4MhYtJx8mAbj4DgQAAAABYktHRACIBR1IAAAACXBIWXMAAAsSAAALEgHS3X78AAAARUlEQVQI1z3MSxaAIAxD0aCgCH4x+1+raeXQyX2DtoBN4OTOJM0ok1zkKrPcZJEVPXY/sZXD61Rd483t9fSHQGL7Ay/GfOFEA1fWXxq+AAAAAElFTkSuQmCC);
+                background-image: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAgAAAAOCAMAAAAliK2kAAAABGdBTUEAALGPC/xhBQAAACBjSFJNAAB6JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAAQlBMVEUAAAAAx+8Ax+8Ax+8Ax+8Ax+8Ax+8Ax+8Ax+8Ax+8Ax+8Ax+8Ax+8Ax+8Ax+8Ax+8Ax+8Ax+8Ax+8Ax+8Ax+8AAAC5xB8hAAAAFHRSTlMAIR4cGSQVKxMxDzc4MhYtJx8mAbj4DgQAAAABYktHRACIBR1IAAAACXBIWXMAAAsSAAALEgHS3X78AAAARUlEQVQI1z3MSxaAIAxD0aCgCH4x+1+raeXQyX2DtoBN4OTOJM0ok1zkKrPcZJEVPXY/sZXD61Rd483t9fSHQGL7Ay/GfOFEA1fWXxq+AAAAAElFTkSuQmCC");
             }
             a.next {
-                background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAgAAAAOCAMAAAAliK2kAAAABGdBTUEAALGPC/xhBQAAACBjSFJNAAB6JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAAQlBMVEUAAAAAx+8Ax+8Ax+8Ax+8Ax+8Ax+8Ax+8Ax+8Ax+8Ax+8Ax+8Ax+8Ax+8Ax+8Ax+8Ax+8Ax+8Ax+8Ax+8Ax+8AAAC5xB8hAAAAFHRSTlMAHiEcJBkrFTETNw84Mi0WJx8mAWJpHNYAAAABYktHRACIBR1IAAAACXBIWXMAAAsSAAALEgHS3X78AAAARElEQVQI11XNRwKAIBADwFVRBAst/38rMeLBXDKHLTZhNgXAIjhqlTbKSzsVpEgdD86Bawzd7MTO3yF20UqFe19Ys3865gQDWAXNNv4AAAAASUVORK5CYII=);
+                background-image: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAgAAAAOCAMAAAAliK2kAAAABGdBTUEAALGPC/xhBQAAACBjSFJNAAB6JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAAQlBMVEUAAAAAx+8Ax+8Ax+8Ax+8Ax+8Ax+8Ax+8Ax+8Ax+8Ax+8Ax+8Ax+8Ax+8Ax+8Ax+8Ax+8Ax+8Ax+8Ax+8Ax+8AAAC5xB8hAAAAFHRSTlMAHiEcJBkrFTETNw84Mi0WJx8mAWJpHNYAAAABYktHRACIBR1IAAAACXBIWXMAAAsSAAALEgHS3X78AAAARElEQVQI11XNRwKAIBADwFVRBAst/38rMeLBXDKHLTZhNgXAIjhqlTbKSzsVpEgdD86Bawzd7MTO3yF20UqFe19Ys3865gQDWAXNNv4AAAAASUVORK5CYII=");
             }
         }
     }
@@ -380,7 +378,7 @@ body.dark {
         clear: left;
     }
     #wrapper:before {
-        background: url(/media/img/styleguide/home.png) 50% 90px no-repeat;
+        background: url("/media/img/styleguide/home.png") 50% 90px no-repeat;
         content:"";
         height: 800px;
         width: 100%;


### PR DESCRIPTION
## Description
Fix CSS linting errors for the styleguide, as laid out in the bug report.

## Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1332677

## Testing
There are now no error messages when the following command is run:
```bash
./node_modules/gulp-stylelint/node_modules/.bin/stylelint "media/css/styleguide/**/*.less"
```

## Checklist
- [ ] Requires l10n changes.
- [x] Related functional & integration tests passing.
