### PR TITLE
[fix bug 1330090] Update leadership photo download links

### DIFF
--- a/bedrock/mozorg/templates/mozorg/about/leadership.html
+++ b/bedrock/mozorg/templates/mozorg/about/leadership.html
@@ -85,7 +85,7 @@
           </ul>
 
           <ul class="utility">
-            <li><a class="file" rel="external" href="https://mozilla.netx.net/app/#share/request/f1bf2ea5-f897-4867-830f-be0d7ab56d96">{{ _('Download high resolution photo') }}</a></li>
+            <li><a class="file" rel="external" href="https://assets.mozilla.org/portal/assets/#asset/6089">{{ _('Download high resolution photo') }}</a></li>
             <li><a class="link" href="{{ url('mozorg.about.leadership') }}#mitchell-baker">{{ _('Link to this bio') }}</a></li>
           </ul>
         </div>
@@ -142,7 +142,7 @@
           </ul>
 
           <ul class="utility">
-            <li><a class="file" rel="external" href="https://mozilla.netx.net/app/#share/request/f8649af6-d7cc-4401-bb43-ffe2bd7284f9">{{ _('Download high resolution photo') }}</a></li>
+            <li><a class="file" rel="external" href="https://assets.mozilla.org/portal/assets/#asset/6096">{{ _('Download high resolution photo') }}</a></li>
             <li><a class="link" href="{{ url('mozorg.about.leadership') }}#chris-beard">{{ _('Link to this bio') }}</a></li>
           </ul>
         </div>
@@ -203,7 +203,7 @@
           </ul>
 
           <ul class="utility">
-            <li><a class="file" rel="external" href="https://mozilla.netx.net/app/#share/request/84d41bcb-7e37-4767-a60e-f6e7a3b71870">{{ _('Download high resolution photo') }}</a></li>
+            <li><a class="file" rel="external" href="https://assets.mozilla.org/portal/assets/#asset/6085">{{ _('Download high resolution photo') }}</a></li>
             <li><a class="link" href="{{ url('mozorg.about.leadership') }}#katharina-borchert">{{ _('Link to this bio') }}</a></li>
           </ul>
         </div>
@@ -246,7 +246,7 @@
           </ul>
 
           <ul class="utility">
-            <li><a class="file" rel="external" href="https://mozilla.netx.net/app/#share/request/335192cb-4b16-466c-9a2e-1c4706539fc7">{{ _('Download high resolution photo') }}</a></li>
+            <li><a class="file" rel="external" href="https://assets.mozilla.org/portal/assets/#asset/6084">{{ _('Download high resolution photo') }}</a></li>
             <li><a class="link" href="{{ url('mozorg.about.leadership') }}#jim-cook">{{ _('Link to this bio') }}</a></li>
           </ul>
         </div>
@@ -294,7 +294,7 @@
           </ul>
 
           <ul class="utility">
-            <li><a class="file" rel="external" href="https://mozilla.netx.net/app/#share/request/1a10b383-f34a-4131-a184-5fe98abd472b">{{ _('Download high resolution photo') }}</a></li>
+            <li><a class="file" rel="external" href="https://assets.mozilla.org/portal/assets/#asset/6081">{{ _('Download high resolution photo') }}</a></li>
             <li><a class="link" href="{{ url('mozorg.about.leadership') }}#denelle-dixon-thayer">{{ _('Link to this bio') }}</a></li>
           </ul>
         </div>
@@ -365,7 +365,7 @@
           </ul>
 
           <ul class="utility">
-            <li><a class="file" rel="external" href="https://mozilla.netx.net/app/#share/request/ffe3dd50-f74a-4704-88be-bd7f99e1d39e">{{ _('Download high resolution photo') }}</a></li>
+            <li><a class="file" rel="external" href="https://assets.mozilla.org/portal/assets/#asset/6077">{{ _('Download high resolution photo') }}</a></li>
             <li><a class="link" href="{{ url('mozorg.about.leadership') }}#ari-jaaksi">{{ _('Link to this bio') }}</a></li>
           </ul>
         </div>
@@ -408,7 +408,7 @@
           </ul>
 
           <ul class="utility">
-            <li><a class="file" rel="external" href="https://mozilla.netx.net/app/#share/request/9ef3eea7-0e69-4184-b83f-9545129f2b7c">{{ _('Download high resolution photo') }}</a></li>
+            <li><a class="file" rel="external" href="https://assets.mozilla.org/portal/assets/#asset/6083">{{ _('Download high resolution photo') }}</a></li>
             <li><a class="link" href="{{ url('mozorg.about.leadership') }}#jascha-kaykas-wolff">{{ _('Link to this bio') }}</a></li>
           </ul>
         </div>
@@ -463,7 +463,7 @@
           </ul>
 
           <ul class="utility">
-            <li><a class="file" rel="external" href="https://mozilla.netx.net/app/#share/request/e6bab82c-2b7c-4212-ab80-81203257163e">{{ _('Download high resolution photo') }}</a></li>
+            <li><a class="file" rel="external" href="https://assets.mozilla.org/portal/assets/#asset/6086">{{ _('Download high resolution photo') }}</a></li>
             <li><a class="link" href="{{ url('mozorg.about.leadership') }}#mark-mayo">{{ _('Link to this bio') }}</a></li>
           </ul>
         </div>
@@ -500,7 +500,7 @@
           </ul>
 
           <ul class="utility">
-            <li><a class="file" rel="external" href="https://mozilla.netx.net/app/#share/request/91a155d7-f5c4-4ffe-9dc0-7b144700552b">{{ _('Download high resolution photo') }}</a></li>
+            <li><a class="file" rel="external" href="https://assets.mozilla.org/portal/assets/#asset/6080">{{ _('Download high resolution photo') }}</a></li>
             <li><a class="link" href="{{ url('mozorg.about.leadership') }}#david-slater">{{ _('Link to this bio') }}</a></li>
           </ul>
         </div>
@@ -543,7 +543,7 @@
           </ul>
 
           <ul class="utility">
-            <li><a class="file" rel="external" href="https://mozilla.netx.net/app/#share/request/975a1470-b529-4dec-829e-dcb6f3ffe9d5">{{ _('Download high resolution photo') }}</a></li>
+            <li><a class="file" rel="external" href="https://assets.mozilla.org/portal/assets/#asset/6091">{{ _('Download high resolution photo') }}</a></li>
             <li><a class="link" href="{{ url('mozorg.about.leadership') }}#sean-white">{{ _('Link to this bio') }}</a></li>
           </ul>
         </div>
@@ -591,7 +591,7 @@
           </ul>
 
           <ul class="utility">
-            <li><a class="file" rel="external" href="https://mozilla.netx.net/app/#share/request/b3106f91-897c-4e33-b00a-c516df87512a">{{ _('Download high resolution photo') }}</a></li>
+            <li><a class="file" rel="external" href="https://assets.mozilla.org/portal/assets/#asset/6075">{{ _('Download high resolution photo') }}</a></li>
             <li><a class="link" href="{{ url('mozorg.about.leadership') }}#allison-banks">{{ _('Link to this bio') }}</a></li>
           </ul>
         </div>
@@ -633,7 +633,7 @@
           </ul>
 
           <ul class="utility">
-            <li><a class="file" rel="external" href="https://mozilla.netx.net/app/#share/request/b14ea218-47f4-41e0-bfb5-a2db87721965">{{ _('Download high resolution photo') }}</a></li>
+            <li><a class="file" rel="external" href="https://assets.mozilla.org/portal/assets/#asset/6079">{{ _('Download high resolution photo') }}</a></li>
             <li><a class="link" href="{{ url('mozorg.about.leadership') }}#david-bryant">{{ _('Link to this bio') }}</a></li>
           </ul>
         </div>
@@ -680,7 +680,7 @@
           </ul>
 
           <ul class="utility">
-            <li><a class="file" rel="external" href="https://mozilla.netx.net/app/#share/request/a7d2cd8e-c247-45a3-9375-8b7372bd17e1">{{ _('Download high resolution photo') }}</a></li>
+            <li><a class="file" rel="external" href="https://assets.mozilla.org/portal/assets/#asset/6092">{{ _('Download high resolution photo') }}</a></li>
             <li><a class="link" href="{{ url('mozorg.about.leadership') }}#susan-chen">{{ _('Link to this bio') }}</a></li>
           </ul>
         </div>
@@ -727,7 +727,7 @@
           </ul>
 
           <ul class="utility">
-            <li><a class="file" rel="external" href="https://mozilla.netx.net/app/#share/request/55a5a3e8-6700-4dce-a271-8757143253fe">{{ _('Download high resolution photo') }}</a></li>
+            <li><a class="file" rel="external" href="https://assets.mozilla.org/portal/assets/#asset/6088">{{ _('Download high resolution photo') }}</a></li>
             <li><a class="link" href="{{ url('mozorg.about.leadership') }}#mary-ellen-muckerman">{{ _('Link to this bio') }}</a></li>
           </ul>
         </div>
@@ -770,7 +770,7 @@
           </ul>
 
           <ul class="utility">
-            <li><a class="file" rel="external" href="https://mozilla.netx.net/app/#share/request/f65ed517-be7c-4f43-9093-022625d3936e">{{ _('Download high resolution photo') }}</a></li>
+            <li><a class="file" rel="external" href="https://assets.mozilla.org/portal/assets/#asset/6090">{{ _('Download high resolution photo') }}</a></li>
             <li><a class="link" href="{{ url('mozorg.about.leadership') }}#nick-nguyen">{{ _('Link to this bio') }}</a></li>
           </ul>
         </div>
@@ -805,7 +805,7 @@
           </ul>
 
           <ul class="utility">
-            <li><a class="file" rel="external" href="https://mozilla.netx.net/app/#share/request/be8f9608-949d-4aea-8596-abdc2cb25523">{{ _('Download high resolution photo') }}</a></li>
+            <li><a class="file" rel="external" href="https://assets.mozilla.org/portal/assets/#asset/6082">{{ _('Download high resolution photo') }}</a></li>
             <li><a class="link" href="{{ url('mozorg.about.leadership') }}#eric-rescorla">{{ _('Link to this bio') }}</a></li>
           </ul>
         </div>
@@ -853,7 +853,7 @@
           </ul>
 
           <ul class="utility">
-            <li><a class="file" rel="external" href="https://mozilla.netx.net/app/#share/request/cba5be7a-467e-43c2-a86f-3c06b36ab696">{{ _('Download high resolution photo') }}</a></li>
+            <li><a class="file" rel="external" href="https://assets.mozilla.org/portal/assets/#asset/6074">{{ _('Download high resolution photo') }}</a></li>
             <li><a class="link" href="{{ url('mozorg.about.leadership') }}#alex-salkever">{{ _('Link to this bio') }}</a></li>
           </ul>
         </div>
@@ -900,7 +900,7 @@
           </ul>
 
           <ul class="utility">
-            <li><a class="file" rel="external" href="https://mozilla.netx.net/app/#share/request/6b97028b-d409-4277-8a38-345ba9624399">{{ _('Download high resolution photo') }}</a></li>
+            <li><a class="file" rel="external" href="https://assets.mozilla.org/portal/assets/#asset/6093">{{ _('Download high resolution photo') }}</a></li>
             <li><a class="link" href="{{ url('mozorg.about.leadership') }}#sylvie-veilleux">{{ _('Link to this bio') }}</a></li>
           </ul>
         </div>
@@ -942,7 +942,7 @@
           </ul>
 
           <ul class="utility">
-            <li><a class="file" rel="external" href="https://mozilla.netx.net/app/#share/request/9805271a-a471-41b4-95b8-41348570f4bd">{{ _('Download high resolution photo') }}</a></li>
+            <li><a class="file" rel="external" href="https://assets.mozilla.org/portal/assets/#asset/6087">{{ _('Download high resolution photo') }}</a></li>
             <li><a class="link" href="{{ url('mozorg.about.leadership') }}#mark-surman">{{ _('Link to this bio') }}</a></li>
           </ul>
         </div>
@@ -1102,7 +1102,7 @@
           </ul>
 
           <ul class="utility">
-            <li><a class="file" rel="external" href="https://mozilla.netx.net/app/#share/request/fe5740a7-2563-4895-997d-d6003ee6276d">{{ _('Download high resolution photo') }}</a></li>
+            <li><a class="file" rel="external" href="https://assets.mozilla.org/portal/assets/#asset/6076">{{ _('Download high resolution photo') }}</a></li>
             <li><a class="link" href="{{ url('mozorg.about.leadership') }}#angela-plohman">{{ _('Link to this bio') }}</a></li>
           </ul>
         </div>


### PR DESCRIPTION
## Description
Updates the download links to point to assets.mozilla.org.

## Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1330090

## Checklist
- [ ] Requires l10n changes.
- [ ] Related functional & integration tests passing.
