### PR TITLE
Fix bug 1324579: Use new nightly and aurora "latest" bouncer products

### DIFF
--- a/bedrock/firefox/tests/test_firefox_details.py
+++ b/bedrock/firefox/tests/test_firefox_details.py
@@ -164,98 +164,119 @@ class TestFirefoxDesktop(TestCase):
         """Aurora non en-US should have a slightly different product name."""
         url = firefox_desktop.get_download_url('alpha', '28.0a2', 'win', 'pt-BR', True)
         self.assertListEqual(parse_qsl(urlparse(url).query),
-                             [('product', 'firefox-aurora-latest-l10n'),
+                             [('product', 'firefox-aurora-stub-l10n'),
                               ('os', 'win'),
                               ('lang', 'pt-BR')])
         url = firefox_desktop.get_download_url('alpha', '28.0a2', 'win64', 'pt-BR', True)
         self.assertListEqual(parse_qsl(urlparse(url).query),
-                             [('product', 'firefox-aurora-latest-l10n'),
+                             [('product', 'firefox-aurora-latest-l10n-ssl'),
                               ('os', 'win64'),
                               ('lang', 'pt-BR')])
         url = firefox_desktop.get_download_url('alpha', '28.0a2', 'osx', 'pt-BR', True)
         self.assertListEqual(parse_qsl(urlparse(url).query),
-                             [('product', 'firefox-aurora-latest-l10n'),
+                             [('product', 'firefox-aurora-latest-l10n-ssl'),
                               ('os', 'osx'),
                               ('lang', 'pt-BR')])
         url = firefox_desktop.get_download_url('alpha', '28.0a2', 'linux', 'pt-BR', True)
         self.assertListEqual(parse_qsl(urlparse(url).query),
-                             [('product', 'firefox-aurora-latest-l10n'),
+                             [('product', 'firefox-aurora-latest-l10n-ssl'),
                               ('os', 'linux'),
                               ('lang', 'pt-BR')])
         url = firefox_desktop.get_download_url('alpha', '28.0a2', 'linux64', 'pt-BR', True)
         self.assertListEqual(parse_qsl(urlparse(url).query),
-                             [('product', 'firefox-aurora-latest-l10n'),
+                             [('product', 'firefox-aurora-latest-l10n-ssl'),
                               ('os', 'linux64'),
                               ('lang', 'pt-BR')])
 
-    def test_get_download_url_nightly_stub(self):
+    def test_get_download_url_nightly(self):
         """
-        The Nightly version should give us a direct url. For Windows platforms,
-        a universal stub installer is served by default.
+        The Nightly version should give us a bouncer url. For Windows, a stub url
+        should be returned.
         """
-        url_base = 'https://archive.mozilla.org/pub/firefox/nightly/latest-mozilla-central/'
-        eq_(firefox_desktop.get_download_url('nightly', '50.0a1', 'win', 'en-US', True),
-            url_base + 'firefox-50.0a1.en-US.win32.installer-stub.exe')
-        eq_(firefox_desktop.get_download_url('nightly', '50.0a1', 'win64', 'en-US', True),
-            url_base + 'firefox-50.0a1.en-US.win32.installer-stub.exe')
-        eq_(firefox_desktop.get_download_url('nightly', '50.0a1', 'osx', 'en-US', True),
-            url_base + 'firefox-50.0a1.en-US.mac.dmg')
-        eq_(firefox_desktop.get_download_url('nightly', '50.0a1', 'linux', 'en-US', True),
-            url_base + 'firefox-50.0a1.en-US.linux-i686.tar.bz2')
-        eq_(firefox_desktop.get_download_url('nightly', '50.0a1', 'linux64', 'en-US', True),
-            url_base + 'firefox-50.0a1.en-US.linux-x86_64.tar.bz2')
+        url = firefox_desktop.get_download_url('nightly', '50.0a1', 'win', 'en-US', True)
+        self.assertListEqual(parse_qsl(urlparse(url).query),
+                             [('product', 'firefox-nightly-stub'),
+                              ('os', 'win'),
+                              ('lang', 'en-US')])
+        url = firefox_desktop.get_download_url('nightly', '50.0a1', 'win64', 'en-US', True)
+        self.assertListEqual(parse_qsl(urlparse(url).query),
+                             [('product', 'firefox-nightly-latest-ssl'),
+                              ('os', 'win64'),
+                              ('lang', 'en-US')])
+        url = firefox_desktop.get_download_url('nightly', '50.0a1', 'osx', 'en-US', True)
+        self.assertListEqual(parse_qsl(urlparse(url).query),
+                             [('product', 'firefox-nightly-latest-ssl'),
+                              ('os', 'osx'),
+                              ('lang', 'en-US')])
+        url = firefox_desktop.get_download_url('nightly', '50.0a1', 'linux', 'en-US', True)
+        self.assertListEqual(parse_qsl(urlparse(url).query),
+                             [('product', 'firefox-nightly-latest-ssl'),
+                              ('os', 'linux'),
+                              ('lang', 'en-US')])
+        url = firefox_desktop.get_download_url('nightly', '50.0a1', 'linux64', 'en-US', True)
+        self.assertListEqual(parse_qsl(urlparse(url).query),
+                             [('product', 'firefox-nightly-latest-ssl'),
+                              ('os', 'linux64'),
+                              ('lang', 'en-US')])
 
     def test_get_download_url_nightly_full(self):
         """
-        The Nightly version should give us a direct url. For Windows platforms,
-        a full installer is served if the force_full_installer option is enabled.
+        The Aurora version should give us a bouncer url. For Windows, a full url
+        should be returned.
         """
-        url_base = 'https://archive.mozilla.org/pub/firefox/nightly/latest-mozilla-central/'
-        eq_(firefox_desktop.get_download_url('nightly', '50.0a1', 'win', 'en-US', True, True),
-            url_base + 'firefox-50.0a1.en-US.win32.installer.exe')
-        eq_(firefox_desktop.get_download_url('nightly', '50.0a1', 'win64', 'en-US', True, True),
-            url_base + 'firefox-50.0a1.en-US.win64.installer.exe')
-        eq_(firefox_desktop.get_download_url('nightly', '50.0a1', 'osx', 'en-US', True, True),
-            url_base + 'firefox-50.0a1.en-US.mac.dmg')
-        eq_(firefox_desktop.get_download_url('nightly', '50.0a1', 'linux', 'en-US', True, True),
-            url_base + 'firefox-50.0a1.en-US.linux-i686.tar.bz2')
-        eq_(firefox_desktop.get_download_url('nightly', '50.0a1', 'linux64', 'en-US', True, True),
-            url_base + 'firefox-50.0a1.en-US.linux-x86_64.tar.bz2')
+        url = firefox_desktop.get_download_url('nightly', '50.0a1', 'win', 'en-US', True, True)
+        self.assertListEqual(parse_qsl(urlparse(url).query),
+                             [('product', 'firefox-nightly-latest-ssl'),
+                              ('os', 'win'),
+                              ('lang', 'en-US')])
+        url = firefox_desktop.get_download_url('nightly', '50.0a1', 'win64', 'en-US', True, True)
+        self.assertListEqual(parse_qsl(urlparse(url).query),
+                             [('product', 'firefox-nightly-latest-ssl'),
+                              ('os', 'win64'),
+                              ('lang', 'en-US')])
+        url = firefox_desktop.get_download_url('nightly', '50.0a1', 'osx', 'en-US', True, True)
+        self.assertListEqual(parse_qsl(urlparse(url).query),
+                             [('product', 'firefox-nightly-latest-ssl'),
+                              ('os', 'osx'),
+                              ('lang', 'en-US')])
+        url = firefox_desktop.get_download_url('nightly', '50.0a1', 'linux', 'en-US', True, True)
+        self.assertListEqual(parse_qsl(urlparse(url).query),
+                             [('product', 'firefox-nightly-latest-ssl'),
+                              ('os', 'linux'),
+                              ('lang', 'en-US')])
+        url = firefox_desktop.get_download_url('nightly', '50.0a1', 'linux64', 'en-US', True, True)
+        self.assertListEqual(parse_qsl(urlparse(url).query),
+                             [('product', 'firefox-nightly-latest-ssl'),
+                              ('os', 'linux64'),
+                              ('lang', 'en-US')])
 
-    def test_get_download_url_nightly_l10n_stub(self):
-        """
-        Nightly non en-US should have a slightly different directory name. For
-        Windows platforms, a universal stub installer is served by default.
-        """
-        url_base = 'https://archive.mozilla.org/pub/firefox/nightly/latest-mozilla-central-l10n/'
-        eq_(firefox_desktop.get_download_url('nightly', '50.0a1', 'win', 'pt-BR', True),
-            url_base + 'firefox-50.0a1.pt-BR.win32.installer-stub.exe')
-        eq_(firefox_desktop.get_download_url('nightly', '50.0a1', 'win64', 'pt-BR', True),
-            url_base + 'firefox-50.0a1.pt-BR.win32.installer-stub.exe')
-        eq_(firefox_desktop.get_download_url('nightly', '50.0a1', 'osx', 'pt-BR', True),
-            url_base + 'firefox-50.0a1.pt-BR.mac.dmg')
-        eq_(firefox_desktop.get_download_url('nightly', '50.0a1', 'linux', 'pt-BR', True),
-            url_base + 'firefox-50.0a1.pt-BR.linux-i686.tar.bz2')
-        eq_(firefox_desktop.get_download_url('nightly', '50.0a1', 'linux64', 'pt-BR', True),
-            url_base + 'firefox-50.0a1.pt-BR.linux-x86_64.tar.bz2')
-
-    def test_get_download_url_nightly_l10n_full(self):
-        """
-        Nightly non en-US should have a slightly different directory name. For
-        Windows platforms, a full installer is served if the force_full_installer
-        option is enabled.
-        """
-        url_base = 'https://archive.mozilla.org/pub/firefox/nightly/latest-mozilla-central-l10n/'
-        eq_(firefox_desktop.get_download_url('nightly', '50.0a1', 'win', 'pt-BR', True, True),
-            url_base + 'firefox-50.0a1.pt-BR.win32.installer.exe')
-        eq_(firefox_desktop.get_download_url('nightly', '50.0a1', 'win64', 'pt-BR', True, True),
-            url_base + 'firefox-50.0a1.pt-BR.win64.installer.exe')
-        eq_(firefox_desktop.get_download_url('nightly', '50.0a1', 'osx', 'pt-BR', True, True),
-            url_base + 'firefox-50.0a1.pt-BR.mac.dmg')
-        eq_(firefox_desktop.get_download_url('nightly', '50.0a1', 'linux', 'pt-BR', True, True),
-            url_base + 'firefox-50.0a1.pt-BR.linux-i686.tar.bz2')
-        eq_(firefox_desktop.get_download_url('nightly', '50.0a1', 'linux64', 'pt-BR', True, True),
-            url_base + 'firefox-50.0a1.pt-BR.linux-x86_64.tar.bz2')
+    def test_get_download_url_nightly_l10n(self):
+        """Nightly non en-US should have a slightly different product name."""
+        url = firefox_desktop.get_download_url('nightly', '50.0a1', 'win', 'pt-BR', True)
+        self.assertListEqual(parse_qsl(urlparse(url).query),
+                             [('product', 'firefox-nightly-stub-l10n'),
+                              ('os', 'win'),
+                              ('lang', 'pt-BR')])
+        url = firefox_desktop.get_download_url('nightly', '50.0a1', 'win64', 'pt-BR', True)
+        self.assertListEqual(parse_qsl(urlparse(url).query),
+                             [('product', 'firefox-nightly-latest-l10n-ssl'),
+                              ('os', 'win64'),
+                              ('lang', 'pt-BR')])
+        url = firefox_desktop.get_download_url('nightly', '50.0a1', 'osx', 'pt-BR', True)
+        self.assertListEqual(parse_qsl(urlparse(url).query),
+                             [('product', 'firefox-nightly-latest-l10n-ssl'),
+                              ('os', 'osx'),
+                              ('lang', 'pt-BR')])
+        url = firefox_desktop.get_download_url('nightly', '50.0a1', 'linux', 'pt-BR', True)
+        self.assertListEqual(parse_qsl(urlparse(url).query),
+                             [('product', 'firefox-nightly-latest-l10n-ssl'),
+                              ('os', 'linux'),
+                              ('lang', 'pt-BR')])
+        url = firefox_desktop.get_download_url('nightly', '50.0a1', 'linux64', 'pt-BR', True)
+        self.assertListEqual(parse_qsl(urlparse(url).query),
+                             [('product', 'firefox-nightly-latest-l10n-ssl'),
+                              ('os', 'linux64'),
+                              ('lang', 'pt-BR')])
 
     def test_get_download_url_scene2_funnelcake(self):
         scene2 = firefox_desktop.download_base_url_transition

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -605,8 +605,6 @@ EMAIL_SUBJECT_PREFIX = config('EMAIL_SUBJECT_PREFIX', default='[bedrock] ')
 EMAIL_HOST_USER = config('EMAIL_HOST_USER', default='')
 EMAIL_HOST_PASSWORD = config('EMAIL_HOST_PASSWORD', default='')
 
-AURORA_STUB_INSTALLER = False
-
 # special value that means all locales are enabled.
 STUB_INSTALLER_ALL = '__ALL__'
 # values should be a list of lower case locales per platform for which a


### PR DESCRIPTION
* Fix bug 1331667: Use the "aurora-latest-l10n-ssl" product
* Fix bug 937865: Use bouncer "latest" products for all buttons