### PR TITLE
Add "declaration-block-semicolon-newline-after" rule to Stylelint

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -18,6 +18,7 @@
     "declaration-block-no-shorthand-property-overrides": true,
     "declaration-block-single-line-max-declarations": [1, { "severity": "warning" }],
     "declaration-block-trailing-semicolon": ["always", { "severity": "warning" }],
+    "declaration-block-semicolon-newline-after": ["always-multi-line", { "severity": "warning"  }],
     "block-no-empty": true,
     "selector-no-empty": true,
     "selector-pseudo-class-no-unknown": true,


### PR DESCRIPTION
## Description
As mentioned in #4610 (and #4607), Stylelint could use a rule to ensure newlines between CSS declarations. This change adds the rule "declaration-block-semicolon-newline-after" ([view on Stylelint](https://stylelint.io/user-guide/rules/declaration-block-semicolon-newline-after/)) with value "always -multi-line".
Ie, with this new rule, now this:
```less
#swatch_f4f4f4 .swatch span {
    background-color: #f4f4f4; color: #000;
}
 ```
will trigger a warning; and this:
```less
#swatch_f4f4f4 .swatch span {
    background-color: #f4f4f4;
    color: #000;
}
```
will not.

## Bugzilla link

## Testing

## Checklist
- [ ] Requires l10n changes.
- [ ] Related functional & integration tests passing.
