### PR TITLE
[bug 1332650][CSS linting] MPL and namespace pages

### DIFF
--- a/media/css/mozorg/mpl-1-1-annotated.scss
+++ b/media/css/mozorg/mpl-1-1-annotated.scss
@@ -25,7 +25,7 @@ h1 {
 }
 
 #moveacross p:first-child {
-    margin-top: 0px;
+    margin-top: 0;
 }
 
 .subsection {
@@ -53,8 +53,8 @@ a.mouseover {
     color: black;
     display: block;
     font-weight: normal;
-    left: 0px;
-    margin: 0px 5px 5px 5px;
+    left: 0;
+    margin: 0 5px 5px 5px;
     padding: 5px;
     position: absolute;
     text-decoration: none;

--- a/media/css/mozorg/mpl-differences.scss
+++ b/media/css/mozorg/mpl-differences.scss
@@ -39,7 +39,7 @@ h1 {
 }
 
 #moveacross p:first-child {
-    margin-top: 0px;
+    margin-top: 0;
 }
 
 .subsection {
@@ -79,8 +79,8 @@ strong {
     font-size: 100%;
     font-variant: normal;
     font-weight: normal;
-    left: 0px;
-    margin: 0px 5px 5px 5px;
+    left: 0;
+    margin: 0 5px 5px 5px;
     padding: 5px;
     position: absolute;
     text-decoration: none;


### PR DESCRIPTION
- Fixed

## Description
Fix the CSS linting errors for the MPL and namespace pages.

## Bugzilla link
[#1332650](https://bugzilla.mozilla.org/show_bug.cgi?id=1332650)

## Testing
./node_modules/gulp-stylelint/node_modules/.bin/stylelint "media/css/mozorg/mpl-1-1-annotated.scss"
./node_modules/gulp-stylelint/node_modules/.bin/stylelint "media/css/mozorg/mpl-differences.scss"
./node_modules/gulp-stylelint/node_modules/.bin/stylelint "media/css/mozorg/namespaces.scss"

## Checklist
- [ ] Requires l10n changes.
- [ ] Related functional & integration tests passing.
