### PR TITLE
Update the stub-attribution-code view to use a 5 min cache header

### DIFF
--- a/bedrock/firefox/tests/test_views.py
+++ b/bedrock/firefox/tests/test_views.py
@@ -39,7 +39,7 @@ class TestStubAttributionCode(TestCase):
         req = self._get_request({'dude': 'abides'})
         resp = views.stub_attribution_code(req)
         self.assertEqual(resp.status_code, 400)
-        assert resp['cache-control'] == 'max-age=31536000'
+        assert resp['cache-control'] == 'max-age=300'
         data = json.loads(resp.content)
         self.assertEqual(data['error'], 'no params')
 
@@ -48,7 +48,7 @@ class TestStubAttributionCode(TestCase):
         req = self._get_request(params)
         resp = views.stub_attribution_code(req)
         self.assertEqual(resp.status_code, 400)
-        assert resp['cache-control'] == 'max-age=31536000'
+        assert resp['cache-control'] == 'max-age=300'
         data = json.loads(resp.content)
         self.assertEqual(data['error'], 'no params')
 
@@ -64,7 +64,7 @@ class TestStubAttributionCode(TestCase):
         req = self._get_request(params)
         resp = views.stub_attribution_code(req)
         self.assertEqual(resp.status_code, 200)
-        assert resp['cache-control'] == 'max-age=31536000'
+        assert resp['cache-control'] == 'max-age=300'
         data = json.loads(resp.content)
         # will it blend?
         attrs = parse_qs(querystringsafe_base64.decode(data['attribution_code']))
@@ -86,7 +86,7 @@ class TestStubAttributionCode(TestCase):
         req = self._get_request(params)
         resp = views.stub_attribution_code(req)
         self.assertEqual(resp.status_code, 200)
-        assert resp['cache-control'] == 'max-age=31536000'
+        assert resp['cache-control'] == 'max-age=300'
         data = json.loads(resp.content)
         # will it blend?
         attrs = parse_qs(querystringsafe_base64.decode(data['attribution_code']))
@@ -108,7 +108,7 @@ class TestStubAttributionCode(TestCase):
         req = self._get_request(params)
         resp = views.stub_attribution_code(req)
         self.assertEqual(resp.status_code, 200)
-        assert resp['cache-control'] == 'max-age=31536000'
+        assert resp['cache-control'] == 'max-age=300'
         data = json.loads(resp.content)
         # will it blend?
         attrs = parse_qs(querystringsafe_base64.decode(data['attribution_code']))
@@ -130,7 +130,7 @@ class TestStubAttributionCode(TestCase):
         req = self._get_request(params)
         resp = views.stub_attribution_code(req)
         self.assertEqual(resp.status_code, 200)
-        assert resp['cache-control'] == 'max-age=31536000'
+        assert resp['cache-control'] == 'max-age=300'
         data = json.loads(resp.content)
         # will it blend?
         attrs = parse_qs(querystringsafe_base64.decode(data['attribution_code']))
@@ -146,7 +146,7 @@ class TestStubAttributionCode(TestCase):
         req = self._get_request(params)
         resp = views.stub_attribution_code(req)
         self.assertEqual(resp.status_code, 200)
-        assert resp['cache-control'] == 'max-age=31536000'
+        assert resp['cache-control'] == 'max-age=300'
 
     @override_settings(STUB_ATTRIBUTION_RATE=0)
     def test_rate_limit_disabled(self):
@@ -154,7 +154,7 @@ class TestStubAttributionCode(TestCase):
         req = self._get_request(params)
         resp = views.stub_attribution_code(req)
         self.assertEqual(resp.status_code, 429)
-        assert resp['cache-control'] == 'max-age=600'
+        assert resp['cache-control'] == 'max-age=300'
 
     @override_settings(STUB_ATTRIBUTION_HMAC_KEY='')
     def test_no_hmac_key_set(self):
@@ -162,7 +162,7 @@ class TestStubAttributionCode(TestCase):
         req = self._get_request(params)
         resp = views.stub_attribution_code(req)
         self.assertEqual(resp.status_code, 403)
-        assert resp['cache-control'] == 'max-age=600'
+        assert resp['cache-control'] == 'max-age=300'
 
 
 class TestSendToDeviceView(TestCase):

--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -125,7 +125,7 @@ def stub_attribution_code(request):
         response = HttpResponseJSON({'error': 'service not configured'}, status=403)
 
     if response:
-        patch_response_headers(response, 600)  # 10 min
+        patch_response_headers(response, 300)  # 5 min
         return response
 
     data = request.GET
@@ -162,7 +162,7 @@ def stub_attribution_code(request):
     else:
         response = HttpResponseJSON({'error': 'no params'}, status=400)
 
-    patch_response_headers(response, 31536000)  # 1 year
+    patch_response_headers(response, 300)  # 5 min
     return response
 
 


### PR DESCRIPTION
The data includes a timestamp, so we can't cache for long.