### PR TITLE
[fix bug 1335248] Remove Hoffman from MoCo board

### DIFF
--- a/bedrock/foundation/templates/foundation/moco.html
+++ b/bedrock/foundation/templates/foundation/moco.html
@@ -42,11 +42,10 @@
   <h3>{{ _('Board of Directors') }}</h3>
   <ul>
     {# L10n: This "Chair" is the chairperson of the board of directors, not something to sit on #}
-    <li><a href="https://blog.mozilla.org/press/bios/mitchell-baker/">Mitchell Baker</a>, {{ _('Chair') }}</li>
-    <li><a href="https://blog.mozilla.org/press/bios/chris-beard/">Chris Beard</a></li>
-    <li><a href="https://mozillians.org/u/juliehanna/">Julie Hanna</a></li>
-    <li><a href="https://www.linkedin.com/in/reidhoffman">Reid Hoffman</a></li>
-    <li><a href="http://www.hbs.edu/klakhani">Karim Lakhani</a></li>
+    <li><a href="{{ url('mozorg.about.leadership') }}#mitchell-baker">Mitchell Baker</a>, {{ _('Chair') }}</li>
+    <li><a href="{{ url('mozorg.about.leadership') }}#chris-beard">Chris Beard</a></li>
+    <li><a href="https://mozillians.org/u/juliehanna/" rel="external">Julie Hanna</a></li>
+    <li><a href="http://www.hbs.edu/klakhani" rel="external">Karim Lakhani</a></li>
   </ul>
 
   <p>


### PR DESCRIPTION
## Description
Missed a spot. 
Also updating bio links for Mitchell and Chris.

## Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1335248

## Checklist
- [ ] Requires l10n changes.
- [ ] Related functional & integration tests passing.
