### PR TITLE
Bug 1332248: Site footer needs updating to the new wordmark (for pages /technology, /internet-health, /internet-health/privacy-security)

### DIFF
--- a/media/css/mozorg/internet-health.scss
+++ b/media/css/mozorg/internet-health.scss
@@ -881,7 +881,30 @@ html[dir="rtl"] #blogs {
 }
 
 #colophon {
-    background: #56565a;
-    color: #d1d2d3;
-    margin-top: 0;
+    background: #666;
+    color: #fff;
+    margin: 0;
+
+    a,
+    a:link {
+        color: #23c7db;
+        text-decoration: none;
+    }
+
+    a:visited {
+        color: darken(#23c7db, 10%);
+    }
+
+    a:hover,
+    a:focus {
+        color: #23c7db;
+        text-decoration: underline;
+    }
+
+    .logo a {
+        background: url('/media/img/pebbles/moz-wordmark-light-reverse.svg') no-repeat;
+        @include background-size(100px 32px);
+        height: 32px;
+        width: 100px;
+    }
 }

--- a/media/css/mozorg/internet-health/privacy-security.scss
+++ b/media/css/mozorg/internet-health/privacy-security.scss
@@ -609,7 +609,30 @@ html[dir="rtl"] {
 // Footer
 
 #colophon {
-    background: #56565a;
-    color: #d1d2d3;
-    margin-top: 0;
+    background: #666;
+    color: #fff;
+    margin: 0;
+
+    a,
+    a:link {
+        color: #23c7db;
+        text-decoration: none;
+    }
+
+    a:visited {
+        color: darken(#23c7db, 10%);
+    }
+
+    a:hover,
+    a:focus {
+        color: #23c7db;
+        text-decoration: underline;
+    }
+
+    .logo a {
+        background: url('/media/img/pebbles/moz-wordmark-light-reverse.svg') no-repeat;
+        @include background-size(100px 32px);
+        height: 32px;
+        width: 100px;
+    }
 }

--- a/media/css/mozorg/technology.scss
+++ b/media/css/mozorg/technology.scss
@@ -900,3 +900,32 @@ html[dir="rtl"] #blogs {
         }
     }
 }
+
+#colophon {
+    background: #fff;
+    color: #666;
+    margin: 0;
+
+    a,
+    a:link {
+        color: #23c7db;
+        text-decoration: none;
+    }
+
+    a:visited {
+        color: darken(#23c7db, 10%);
+    }
+
+    a:hover,
+    a:focus {
+        color: #23c7db;
+        text-decoration: underline;
+    }
+
+    .logo a {
+        background: url('/media/img/pebbles/moz-wordmark-dark-reverse.svg') no-repeat;
+        @include background-size(100px 32px);
+        height: 32px;
+        width: 100px;
+    }
+}


### PR DESCRIPTION
Updated site footer for pages /technology, /internet-health, /internet-health/privacy-security

Bugzilla link: https://bugzilla.mozilla.org/show_bug.cgi?id=1332248
