### PR TITLE
[fix bug 1337451] - resize fxa iframe on new /firstrun to a width that has been tested

### DIFF
--- a/media/css/firefox/firstrun/new-firstrun.less
+++ b/media/css/firefox/firstrun/new-firstrun.less
@@ -54,12 +54,13 @@ img {
     border: none;
     position: relative;
     transition: height .3s ease-in-out;
+    width: 318px;
 }
 
 #fxa-iframe-config {
     background: #fff;
     border-radius: 5px;
-    padding: 25px 15px 20px 15px;
+    padding: 25px 6px 20px 6px;
     display: inline-block;
     margin-left: 65px;
 }


### PR DESCRIPTION
@craigcook 

## Description
The FxA iFrame has not been tested at sizes smaller than 318px.

## Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1337451

