### PR TITLE
[fix bug 1337448] FxA redirect after login.

### DIFF
--- a/media/js/base/global.js
+++ b/media/js/base/global.js
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 /* exported triggerIEDownload, initDownloadLinks, initMobileDownloadLinks,
-   maybeSwitchToDistDownloadLinks, initLangSwitcher */
+   maybeSwitchToDistDownloadLinks, initLangSwitcher, doRedirect */
 
 // download buttons
 
@@ -79,6 +79,13 @@ function initLangSwitcher() {
         $('#lang_form').attr('action', window.location.hash || '#');
         $('#lang_form').submit();
     });
+}
+
+// client-side redirects (handy for testing)
+function doRedirect(destination) {
+    if (destination) {
+        window.location.href = destination;
+    }
 }
 
 // Create text translation function using #strings element.

--- a/media/js/base/mozilla-fxa-iframe.js
+++ b/media/js/base/mozilla-fxa-iframe.js
@@ -139,7 +139,7 @@ Mozilla.FxaIframe = (function() {
             break;
         // user has logged in (instead of signing up)
         case 'login':
-            _onLogin();
+            _onLogin(data);
             break;
         }
     };
@@ -175,7 +175,26 @@ Mozilla.FxaIframe = (function() {
 
     var _onLogin = function(data) {
         _sendGAEvent('fxa-signin');
-        _userCallback('onLogin', data);
+
+        // ****************************************************************** //
+        // ****************************************************************** //
+        // If an 'onLogin' handler is supplied, it *must* redirect the user away
+        // from the current page! (see below)
+        // ****************************************************************** //
+        // ****************************************************************** //
+
+        // After a successful login, the FxA iframe, due to the
+        // 'haltAfterSignIn=True' parameter, will appear to spin, displaying a
+        // "Working..." error message that never goes away (even though the
+        // login is successful). Because of this, a redirect *must* happen
+        // after the 'login' postMessage.
+        if (typeof _config['onLogin'] === 'function') {
+            // We are trusting that the 'onLogin' handler does *something* to
+            // hide the FxA iframe.
+            _userCallback('onLogin', data);
+        } else {
+            window.doRedirect(_host + '/settings');
+        }
     };
 
     // public properties/methods

--- a/tests/unit/spec/base/mozilla-fxa-iframe.js
+++ b/tests/unit/spec/base/mozilla-fxa-iframe.js
@@ -188,5 +188,41 @@ describe('mozilla-fxa-iframe.js', function() {
 
             window.postMessage(JSON.stringify(messageData), '*');
         });
+
+        it('should redirect the user to FxA host /settings URL if no custom handler defined', function(done) {
+            var messageData = {
+                command: 'login'
+            };
+
+            spyOn(window, 'doRedirect').and.callFake(function(destination) {
+                expect(destination).toEqual(fxaHost + '/settings');
+                done();
+            });
+
+            Mozilla.FxaIframe.init();
+
+            window.postMessage(JSON.stringify(messageData), '*');
+        });
+
+        it('should execute callback for login postMessage', function(done) {
+            var messageData = {
+                command: 'login'
+            };
+
+            config = {
+                onLogin: function(data) {
+                    var command = data.command;
+                    expect(config.onLogin).toHaveBeenCalled();
+                    expect(command).toEqual('login');
+                    done();
+                }
+            };
+
+            spyOn(config, 'onLogin').and.callThrough();
+
+            Mozilla.FxaIframe.init(config);
+
+            window.postMessage(JSON.stringify(messageData), '*');
+        });
     });
 });


### PR DESCRIPTION
## Description

#4579 [introduced a regression](https://github.com/mozilla/bedrock/pull/4579/files#diff-dc9018ca2e4502c42779505aa8eeaea4L181) whereby users logging in to the FxA iframe stopped being redirected to the FxA settings page. This resulted in a significant uptick in errors on the FxA side (which is how the bug was discovered), as well as poor UX (the user saw a "Working..." error message in the iframe that never went away).

This PR fixes that regression, and adds tests.

## Bugzilla link

https://bugzilla.mozilla.org/show_bug.cgi?id=1337448

## Testing

On demo3, using a profile configured to work with the FxA staging server, log in to Sync on the current firstrun page [1]. You should be redirected to the FxA accounts settings URL.

Also on demo3, using the same profile as above, log in to Sync on the soon to be released funnelcake firstrun page [2]. You should be redirected to the new tab view.

(Working with FxA on a demo is detailed in [the docs](http://bedrock.readthedocs.io/en/latest/firefox-accounts.html).)

[1] https://www-demo3.allizom.org/en-US/firefox/51.0/firstrun/
[2] https://www-demo3.allizom.org/en-US/firefox/51.0/firstrun/?f=99

## Checklist
- [x] Related functional & integration tests passing.
