### PR TITLE
Fix Bug 1338394 - Firefox/Thunderbird channel & download pages serve en-US builds on localized pages for mac users

### DIFF
--- a/bedrock/firefox/templatetags/helpers.py
+++ b/bedrock/firefox/templatetags/helpers.py
@@ -38,13 +38,9 @@ def desktop_builds(channel, builds=None, locale=None, force_direct=False,
             if plat_os == 'win64':
                 continue
 
-        # Fallback to en-US if this plat_os/version isn't available
-        # for the current locale
-        _locale = locale if plat_os_pretty in platforms else 'en-US'
-
         # And generate all the info
         download_link = firefox_desktop.get_download_url(
-            channel, version, plat_os, _locale,
+            channel, version, plat_os, locale,
             force_direct=force_direct,
             force_full_installer=force_full_installer,
             force_funnelcake=force_funnelcake,
@@ -58,7 +54,7 @@ def desktop_builds(channel, builds=None, locale=None, force_direct=False,
             download_link_direct = False
         else:
             download_link_direct = firefox_desktop.get_download_url(
-                channel, version, plat_os, _locale,
+                channel, version, plat_os, locale,
                 force_direct=True,
                 force_full_installer=force_full_installer,
                 force_funnelcake=force_funnelcake,

--- a/bedrock/firefox/tests/test_helpers.py
+++ b/bedrock/firefox/tests/test_helpers.py
@@ -1,3 +1,5 @@
+from urlparse import parse_qs, urlparse
+
 from django.conf import settings
 from django.test.client import RequestFactory
 from django.test.utils import override_settings
@@ -69,14 +71,16 @@ class TestDownloadButtons(TestCase):
 
         # The first link should be sha-1 bouncer.
         first_link = pq(links[0])
-        ok_(first_link.attr('href')
-            .startswith('https://download-sha1.allizom.org'))
+        first_href = first_link.attr('href')
+        ok_(first_href.startswith('https://download-sha1.allizom.org'))
+        self.assertListEqual(parse_qs(urlparse(first_href).query)['lang'], ['fr'])
         ok_(first_link.attr('data-direct-link') is None)
 
         for link in links[1:5]:
             link = pq(link)
-            ok_(link.attr('href')
-                .startswith('https://download.mozilla.org'))
+            href = link.attr('href')
+            ok_(href.startswith('https://download.mozilla.org'))
+            self.assertListEqual(parse_qs(urlparse(href).query)['lang'], ['fr'])
             # direct links should not have the data attr.
             ok_(link.attr('data-direct-link') is None)
 
@@ -351,14 +355,16 @@ class TestDownloadList(TestCase):
 
         # The first link should be sha-1 bouncer.
         first_link = pq(links[0])
-        ok_(first_link.attr('href')
-            .startswith('https://download-sha1.allizom.org'))
+        first_href = first_link.attr('href')
+        ok_(first_href.startswith('https://download-sha1.allizom.org'))
+        self.assertListEqual(parse_qs(urlparse(first_href).query)['lang'], ['en-US'])
 
         # All other links should be to regular bouncer.
         for link in links[1:5]:
             link = pq(link)
-            ok_(link.attr('href')
-                .startswith('https://download.mozilla.org'))
+            href = link.attr('href')
+            ok_(href.startswith('https://download.mozilla.org'))
+            self.assertListEqual(parse_qs(urlparse(href).query)['lang'], ['en-US'])
 
     @patch('bedrock.firefox.firefox_details.switch', Mock(return_value=False))
     def test_firefox_desktop_list_aurora(self):
@@ -385,14 +391,16 @@ class TestDownloadList(TestCase):
 
         # The first link should be sha-1 bouncer.
         first_link = pq(links[0])
-        ok_(first_link.attr('href')
-            .startswith('https://download-sha1.allizom.org'))
+        first_href = first_link.attr('href')
+        ok_(first_href.startswith('https://download-sha1.allizom.org'))
+        self.assertListEqual(parse_qs(urlparse(first_href).query)['lang'], ['en-US'])
 
         # All other links should be to regular bouncer.
         for link in links[1:5]:
             link = pq(link)
-            ok_(link.attr('href')
-                .startswith('https://download.mozilla.org'))
+            href = link.attr('href')
+            ok_(href.startswith('https://download.mozilla.org'))
+            self.assertListEqual(parse_qs(urlparse(href).query)['lang'], ['en-US'])
 
     @patch('bedrock.firefox.firefox_details.switch', Mock(return_value=False))
     def test_firefox_desktop_list_nightly(self):
@@ -418,14 +426,16 @@ class TestDownloadList(TestCase):
 
         # The first link should be sha-1 bouncer.
         first_link = pq(links[0])
-        ok_(first_link.attr('href')
-            .startswith('https://download-sha1.allizom.org'))
+        first_href = first_link.attr('href')
+        ok_(first_href.startswith('https://download-sha1.allizom.org'))
+        self.assertListEqual(parse_qs(urlparse(first_href).query)['lang'], ['en-US'])
 
         # All other links should be to regular bouncer.
         for link in links[1:5]:
             link = pq(link)
-            ok_(link.attr('href')
-                .startswith('https://download.mozilla.org'))
+            href = link.attr('href')
+            ok_(href.startswith('https://download.mozilla.org'))
+            self.assertListEqual(parse_qs(urlparse(href).query)['lang'], ['en-US'])
 
 
 class TestFirefoxURL(TestCase):

--- a/bedrock/thunderbird/details.py
+++ b/bedrock/thunderbird/details.py
@@ -193,18 +193,19 @@ class ThunderbirdDesktop(ProductDetails):
 
         # Check if direct download link has been requested
         # (bypassing the transition page)
-        if force_direct:
-            # build a direct download link
-            return '?'.join([self.get_bouncer_url(platform),
-                             urlencode([
-                                 ('product', 'thunderbird-%s-SSL' % _version),
-                                 ('os', _platform),
-                                 # Order matters, lang must be last for bouncer.
-                                 ('lang', _locale),
-                             ])])
-        else:
-            # build a link to the transition page
-            return self.download_base_url_transition
+        if not force_direct:
+            # Currently we don't have the transition page for Thunderbird, so
+            # return a direct link instead
+            pass
+
+        # build a direct download link
+        return '?'.join([self.get_bouncer_url(platform),
+                         urlencode([
+                             ('product', 'thunderbird-%s-SSL' % _version),
+                             ('os', _platform),
+                             # Order matters, lang must be last for bouncer.
+                             ('lang', _locale),
+                         ])])
 
 
 thunderbird_desktop = ThunderbirdDesktop()

--- a/bedrock/thunderbird/templatetags/helpers.py
+++ b/bedrock/thunderbird/templatetags/helpers.py
@@ -42,13 +42,9 @@ def download_thunderbird(ctx, channel='release', dom_id=None,
     builds = []
 
     for plat_os, plat_os_pretty in thunderbird_desktop.platform_labels.iteritems():
-        # Fallback to en-US if this plat_os/version isn't available
-        # for the current locale
-        _locale = locale if plat_os_pretty in platforms else 'en-US'
-
         # And generate all the info
         download_link = thunderbird_desktop.get_download_url(
-            channel, version, plat_os, _locale,
+            channel, version, plat_os, locale,
             force_direct=force_direct,
         )
 
@@ -59,7 +55,7 @@ def download_thunderbird(ctx, channel='release', dom_id=None,
             download_link_direct = False
         else:
             download_link_direct = thunderbird_desktop.get_download_url(
-                channel, version, plat_os, _locale,
+                channel, version, plat_os, locale,
                 force_direct=True,
             )
             if download_link_direct == download_link:


### PR DESCRIPTION
Remove the unnecessary, obsolete fallback code so download links are always localized.