### PR TITLE
Fix bug 1337123: Update newsletter sign-up language to avoid confusion

### DIFF
--- a/bedrock/newsletter/templates/newsletter/index.html
+++ b/bedrock/newsletter/templates/newsletter/index.html
@@ -12,7 +12,11 @@
     {# Remove the span tags from the headline next time it changes: #}
     <h1 class="large">{{ _('Read all about it in our <span>newsletter</span>') }}</h1>
     <p>
-      {% trans %}Subscribe to monthly updates and keep current with Mozilla news, including the latest tips and tricks for getting the most out of your Firefox browser. It’s the perfect way for us to keep in touch!{% endtrans %}
+      {% if l10n_has_tag('mozilla_newsletter_2017') %}
+        {{ _('Subscribe to updates and keep current with Mozilla news. It’s the perfect way for us to keep in touch!') }}
+      {% else %}
+        {{ _('Subscribe to monthly updates and keep current with Mozilla news, including the latest tips and tricks for getting the most out of your Firefox browser. It’s the perfect way for us to keep in touch!') }}
+      {% endif %}
     </p>
   </div>
 {% endblock %}


### PR DESCRIPTION
## Description
Currently, the sign-up invitation text misleadingly refers to Firefox tips and tricks, when the newsletter is only delivering Mozilla news.

## Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1337123

## Checklist
- [x] Requires l10n changes.
