### PR TITLE
Fix Bug 1329514 - Thunderbird beta: Help | About | 'release notes' brings up *Firefox* beta page

### DIFF
--- a/bedrock/mozorg/templatetags/misc.py
+++ b/bedrock/mozorg/templatetags/misc.py
@@ -430,6 +430,8 @@ def absolute_url(url):
 @library.global_function
 def releasenotes_url(release):
     prefix = 'aurora' if release.channel == 'Aurora' else 'release'
+    if release.product == 'Thunderbird':
+        return reverse('thunderbird.notes', args=[release.version])
     if release.product == 'Firefox for Android':
         return reverse('firefox.android.releasenotes', args=(release.version, prefix))
     if release.product == 'Firefox for iOS':

--- a/bedrock/releasenotes/tests/test_base.py
+++ b/bedrock/releasenotes/tests/test_base.py
@@ -114,6 +114,21 @@ class TestRNAViews(TestCase):
         releasenotes_url.assert_called_with('mock release')
 
     @patch('bedrock.releasenotes.views.get_release_or_404')
+    @patch('bedrock.releasenotes.views.releasenotes_url')
+    def test_release_notes_thunderbird_beta_redirect(self, releasenotes_url,
+                                                     get_release_or_404):
+        """
+        Should redirect to url for Thunderbird Beta release
+        """
+        get_release_or_404.side_effect = [Http404, 'mock release']
+        releasenotes_url.return_value = '/thunderbird/51.0beta/releasenotes/'
+        response = views.release_notes(self.request, '51.0', 'Thunderbird')
+        eq_(response.status_code, 302)
+        eq_(response['location'], '/thunderbird/51.0beta/releasenotes/')
+        get_release_or_404.assert_called_with('51.0beta', 'Thunderbird')
+        releasenotes_url.assert_called_with('mock release')
+
+    @patch('bedrock.releasenotes.views.get_release_or_404')
     def test_system_requirements(self, get_release_or_404):
         """
         Should use release returned from get_release_or_404, with a


### PR DESCRIPTION
## Description

This is a redirect bug affecting Thunderbird Beta users. [/thunderbird/51.0/releasenotes/](https://www.mozilla.org/thunderbird/51.0/releasenotes/), for example, should be redirected to [/thunderbird/51.0beta/releasenotes/](https://www.mozilla.org/thunderbird/51.0beta/releasenotes/) instead of [/firefox/51.0beta/releasenotes/](https://www.mozilla.org/firefox/51.0beta/releasenotes/).

[/thunderbird/52.0/releasenotes/](https://www.mozilla.org/thunderbird/52.0/releasenotes/) -> [/thunderbird/52.0beta/releasenotes/](https://www.mozilla.org/thunderbird/52.0beta/releasenotes/) and so on.

## Bugzilla link

[Bug 1329514](https://bugzilla.mozilla.org/show_bug.cgi?id=1329514)

## Testing

Load the URL above (or any other version) to make sure you'll be taken to the Thunderbird Beta release notes. Note that past major releases like 45.0 won't be redirected.

## Checklist
- [ ] Requires l10n changes.
- [x] Related functional & integration tests passing.
