### PR TITLE
[fix bug 1340087] Update funnelcake logic to include IDs for windows only

### DIFF
--- a/bedrock/firefox/firefox_details.py
+++ b/bedrock/firefox/firefox_details.py
@@ -209,6 +209,10 @@ class FirefoxDesktop(_ProductDetails):
         _locale = 'ja-JP-mac' if platform == 'osx' and locale == 'ja' else locale
         _platform = 'win' if platform == 'winsha1' else platform
 
+        # Bug 1340087 - Only include funnelcake params for Windows 32bit en-US builds by default.
+        include_funnelcake_param = (funnelcake_id and _platform in settings.FUNNELCAKE_PLATFORMS and
+                                    _locale in settings.FUNNELCAKE_LOCALES)
+
         # Nightly and Aurora have a special download link format
         # see bug 1324001
         if channel in ['alpha', 'nightly']:
@@ -246,13 +250,13 @@ class FirefoxDesktop(_ProductDetails):
                 suffix = 'latest'
 
             _version = ('beta-' if channel == 'beta' else '') + suffix
-        elif not funnelcake_id:
+        elif not include_funnelcake_param:
             # Force download via SSL. Stub installers are always downloaded via SSL.
             # Funnelcakes may not be ready for SSL download
             _version += '-SSL'
 
         # append funnelcake id to version if we have one
-        if funnelcake_id:
+        if include_funnelcake_param:
             _version = '{vers}-f{fc}'.format(vers=_version, fc=funnelcake_id)
 
         # Check if direct download link has been requested

--- a/bedrock/firefox/tests/test_firefox_details.py
+++ b/bedrock/firefox/tests/test_firefox_details.py
@@ -399,6 +399,58 @@ class TestFirefoxDesktop(TestCase):
         """latest_major_version should return 0 when no int."""
         eq_(firefox_desktop.latest_major_version('release'), 0)
 
+    @override_settings(FUNNELCAKE_LOCALES=('en-US',), FUNNELCAKE_PLATFORMS=('win',))
+    def test_funnelcake_direct_links_en_us_win_only(self):
+        """
+        Ensure funnelcake params are included for Windows en-US builds only.
+        """
+        url = firefox_desktop.get_download_url('release', '45.0', 'win', 'en-US', force_direct=True, funnelcake_id='64')
+        ok_('product=firefox-stub-f64' in url)
+
+        url = firefox_desktop.get_download_url('release', '45.0', 'win', 'en-US', force_direct=True, force_full_installer=True, funnelcake_id='64')
+        ok_('product=firefox-45.0-f64' in url)
+
+        url = firefox_desktop.get_download_url('release', '45.0', 'win', 'en-US', force_direct=True, force_funnelcake=True, funnelcake_id='64')
+        ok_('product=firefox-latest-f64' in url)
+
+        url = firefox_desktop.get_download_url('release', '45.0', 'win', 'de', force_direct=True, funnelcake_id='64')
+        ok_('product=firefox-45.0-f64' not in url)
+
+        url = firefox_desktop.get_download_url('release', '45.0', 'osx', 'en-US', force_direct=True, funnelcake_id='64')
+        ok_('product=firefox-45.0-f64' not in url)
+
+    @override_settings(FUNNELCAKE_LOCALES=('en-US', 'de'), FUNNELCAKE_PLATFORMS=('linux', 'osx'))
+    def test_funnelcake_direct_links_locales_linux_osx_(self):
+        """
+        Ensure funnelcake params are included for Linux and OSX en-US builds only.
+        """
+        url = firefox_desktop.get_download_url('release', '45.0', 'win', 'en-US', force_direct=True, funnelcake_id='64')
+        ok_('product=firefox-stub-f64' not in url)
+
+        url = firefox_desktop.get_download_url('release', '45.0', 'win', 'en-US', force_direct=True, force_full_installer=True, funnelcake_id='64')
+        ok_('product=firefox-45.0-f64' not in url)
+
+        url = firefox_desktop.get_download_url('release', '45.0', 'win', 'en-US', force_direct=True, force_funnelcake=True, funnelcake_id='64')
+        ok_('product=firefox-latest-f64' not in url)
+
+        url = firefox_desktop.get_download_url('release', '45.0', 'osx', 'de', force_direct=True, funnelcake_id='64')
+        ok_('product=firefox-45.0-f64' in url)
+
+        url = firefox_desktop.get_download_url('release', '45.0', 'osx', 'en-US', force_direct=True, funnelcake_id='64')
+        ok_('product=firefox-45.0-f64' in url)
+
+        url = firefox_desktop.get_download_url('release', '45.0', 'osx', 'fr', force_direct=True, funnelcake_id='64')
+        ok_('product=firefox-45.0-f64' not in url)
+
+        url = firefox_desktop.get_download_url('release', '45.0', 'linux', 'de', force_direct=True, funnelcake_id='64')
+        ok_('product=firefox-45.0-f64' in url)
+
+        url = firefox_desktop.get_download_url('release', '45.0', 'linux', 'en-US', force_direct=True, funnelcake_id='64')
+        ok_('product=firefox-45.0-f64' in url)
+
+        url = firefox_desktop.get_download_url('release', '45.0', 'linux', 'fr', force_direct=True, funnelcake_id='64')
+        ok_('product=firefox-45.0-f64' not in url)
+
     @override_settings(STUB_INSTALLER_LOCALES={'win': ['en-us']})
     def test_force_funnelcake_en_us_win_only(self):
         """

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -1304,3 +1304,7 @@ if config('SWITCH_TRACKING_PIXEL', default=DEV, cast=bool):
     CSP_IMG_SRC += (
         'ad.doubleclick.net',
     )
+
+# Bug 1340087 - Funnelcake experiments default to Windows 32bit and en-US builds only.
+FUNNELCAKE_PLATFORMS = config('FUNNELCAKE_PLATFORMS', default='win', cast=Csv())
+FUNNELCAKE_LOCALES = config('FUNNELCAKE_LOCALES', default='en-US', cast=Csv())


### PR DESCRIPTION
## Description
- Updates bedrock's logic for including funnelcake query params in download links, so it now only happens for Windows and en-US. This avoids scenarios where the download could 404 for other platforms, should anyone come across a link like below:

https://www.mozilla.org/en-US/firefox/new/?f=99

## Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1340087

## Testing
- I added some unit tests, but this could still use some careful review.
- Demo URL: https://bedrock-demo-agibson.us-west.moz.works/en-US/firefox/new/?f=99

## Checklist
- [ ] Requires l10n changes.
- [ ] Related functional & integration tests passing.
