### PR TITLE
Bug 1339870: Only offer stub for en-US aurora and nightly

### DIFF
--- a/bedrock/firefox/firefox_details.py
+++ b/bedrock/firefox/firefox_details.py
@@ -218,11 +218,9 @@ class FirefoxDesktop(_ProductDetails):
         if channel in ['alpha', 'nightly']:
             prod_name = 'firefox-nightly' if channel == 'nightly' else 'firefox-aurora'
             # Use the stub installer for 32-bit Windows
-            if _platform == 'win' and not force_full_installer:
+            if _platform == 'win' and locale == 'en-US' and not force_full_installer:
                 # Download links are different for localized versions
                 suffix = 'stub'
-                if locale != 'en-US':
-                    suffix = 'stub-l10n'
             else:
                 suffix = 'latest-ssl'
                 if locale != 'en-US':

--- a/bedrock/firefox/tests/test_firefox_details.py
+++ b/bedrock/firefox/tests/test_firefox_details.py
@@ -164,7 +164,7 @@ class TestFirefoxDesktop(TestCase):
         """Aurora non en-US should have a slightly different product name."""
         url = firefox_desktop.get_download_url('alpha', '28.0a2', 'win', 'pt-BR', True)
         self.assertListEqual(parse_qsl(urlparse(url).query),
-                             [('product', 'firefox-aurora-stub-l10n'),
+                             [('product', 'firefox-aurora-latest-l10n-ssl'),
                               ('os', 'win'),
                               ('lang', 'pt-BR')])
         url = firefox_desktop.get_download_url('alpha', '28.0a2', 'win64', 'pt-BR', True)
@@ -254,7 +254,7 @@ class TestFirefoxDesktop(TestCase):
         """Nightly non en-US should have a slightly different product name."""
         url = firefox_desktop.get_download_url('nightly', '50.0a1', 'win', 'pt-BR', True)
         self.assertListEqual(parse_qsl(urlparse(url).query),
-                             [('product', 'firefox-nightly-stub-l10n'),
+                             [('product', 'firefox-nightly-latest-l10n-ssl'),
                               ('os', 'win'),
                               ('lang', 'pt-BR')])
         url = firefox_desktop.get_download_url('nightly', '50.0a1', 'win64', 'pt-BR', True)

--- a/bedrock/firefox/tests/test_helpers.py
+++ b/bedrock/firefox/tests/test_helpers.py
@@ -129,7 +129,9 @@ class TestDownloadButtons(TestCase):
         eq_(pq(list[2]).attr('class'), 'os_osx')
         eq_(pq(list[3]).attr('class'), 'os_linux')
         eq_(pq(list[4]).attr('class'), 'os_linux64')
-        ok_('stub' in pq(pq(list[1]).find('a')[0]).attr('href'))
+        # stub disabled for now for non-en-US locales
+        # bug 1339870
+        # ok_('stub' in pq(pq(list[1]).find('a')[0]).attr('href'))
 
     def test_aurora_desktop(self):
         """The Aurora channel should have Windows 64 build"""


### PR DESCRIPTION
Bug 1339870 will fix it such that we can simply use e.g.  firefox-aurora-stub for all locales like we can for beta and release. So we'll be able to remove our special handling of nightly and aurora. Until then we have to only serve stub to en-US windows users.