### PR TITLE
Bug 1341547: Deny framing of /firefox/new/

### DIFF
--- a/bedrock/firefox/tests/test_views.py
+++ b/bedrock/firefox/tests/test_views.py
@@ -12,7 +12,6 @@ import querystringsafe_base64
 from mock import patch, Mock
 from nose.tools import eq_, ok_
 
-from bedrock.base.urlresolvers import reverse
 from bedrock.firefox import views
 from bedrock.mozorg.tests import TestCase
 
@@ -307,17 +306,6 @@ class TestSendToDeviceView(TestCase):
 @override_settings(DEV=False)
 @patch('bedrock.firefox.views.l10n_utils.render')
 class TestFirefoxNew(TestCase):
-    def test_frames_allow(self, render_mock):
-        """
-        Bedrock pages get the 'x-frame-options: DENY' header by default.
-        The firefox/new page needs to be framable for things like stumbleupon.
-        Bug 1004598.
-        """
-        with self.activate('en-US'):
-            resp = self.client.get(reverse('firefox.new'))
-
-        ok_('x-frame-options' not in resp)
-
     def test_scene_1_template(self, render_mock):
         req = RequestFactory().get('/firefox/new/')
         req.locale = 'en-US'

--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -20,7 +20,6 @@ from django.views.generic.base import TemplateView
 
 import basket
 import querystringsafe_base64
-from commonware.response.decorators import xframe_allow
 from product_details.version_compare import Version
 
 from lib import l10n_utils
@@ -475,7 +474,6 @@ class TrackingProtectionTourView(l10n_utils.LangFilesMixin, TemplateView):
     template_name = 'firefox/tracking-protection-tour.html'
 
 
-@xframe_allow
 def new(request):
     # Remove legacy query parameters (Bug 1236791)
     if request.GET.get('product', None) or request.GET.get('os', None):


### PR DESCRIPTION
Removes framing exemption from /firefox/new/ which was added in bug 1004598.