### PR TITLE
[fix bug 1340599] Remove hard-coded mozilla-labs forum links

### DIFF
--- a/bedrock/mozorg/templates/mozorg/about/forums/forums.html
+++ b/bedrock/mozorg/templates/mozorg/about/forums/forums.html
@@ -51,7 +51,6 @@
       {% for title in forums.ordered.keys() %}
         <li><a href="#{{ title|slugify }}">{{ title }}</a></li>
       {% endfor %}
-      <li><a href="#mozilla-labs">{{ _('Mozilla Labs') }}</a></li>
       <li><a href="#chat">{{ _('Realtime Chat') }}</a></li>
     </ul>
   </nav>
@@ -92,90 +91,6 @@
 {% endfor %}
 
 <!--END_LIST-->
-
-<section id="mozilla-labs" class="forum-group">
-  <a href="#" class="top">{{ _('Back to top') }}</a>
-  <h2>{{ _('Mozilla Labs') }}</h2>
-
-  <p>
-  {{ _('These forums are only available as Google Groups.') }}
-  {{ _('Please read the <a href="%s">Mozilla forum etiquette</a> document for posting rules and conventions.')|format(url('mozorg.about.forums.etiquette')) }}
-  </p>
-
-  <ul class="forums">
-    <li id="labs">
-      <div class="summary">
-        <h4>mozilla.labs<a href="#labs">#</a></h4>
-        <p class="description">{{ _('General labs discussion') }}</p>
-      </div>
-      <ul class="subscribe">
-        <li>{{ _('Web:') }} <a href="http://groups.google.com/group/mozilla-labs">Google Groups</a></li>
-      </ul>
-    </li>
-
-    <li id="labs-skywriter">
-      <div class="summary">
-        <h4>mozilla.labs.skywriter<a href="#labs-skywriter">#</a></h4>
-        <p class="description">{{ _('Skywriter online code editor') }}</p>
-      </div>
-      <ul class="subscribe">
-        <li>{{ _('Web:') }} <a href="http://groups.google.com/group/skywriter">Google Groups</a></li>
-      </ul>
-    </li>
-
-    <li id="labs-concept-series">
-      <div class="summary">
-        <h4>mozilla.labs.concept-series<a href="#labs-concept-series">#</a></h4>
-        <p class="description">{{ _('Concept Series') }}</p>
-      </div>
-      <ul class="subscribe">
-        <li>{{ _('Web:') }} <a href="http://groups.google.com/group/mozilla-labs-concept-series">Google Groups</a></li>
-      </ul>
-    </li>
-
-    <li id="labs-jetpack">
-      <div class="summary">
-        <h4>mozilla.labs.jetpack<a href="#labs-jetpack">#</a></h4>
-        <p class="description">{{ _('Jetpack extension API') }}</p>
-      </div>
-      <ul class="subscribe">
-        <li>{{ _('Web:') }} <a href="http://groups.google.com/group/mozilla-labs-jetpack">Google Groups</a></li>
-      </ul>
-    </li>
-
-    <li id="labs-personas">
-      <div class="summary">
-        <h4>mozilla.labs.personas<a href="#labs-personas">#</a></h4>
-        <p class="description">{{ _('Personas lightweight browser customization framework') }}</p>
-      </div>
-      <ul class="subscribe">
-        <li>{{ _('Web:') }} <a href="https://forums.mozilla.org/addons/viewforum.php?f=30">Mozilla Add-ons Forum</a></li>
-      </ul>
-    </li>
-
-    <li id="labs-testpilot">
-      <div class="summary">
-        <h4>mozilla.labs.testpilot<a href="#labs-testpilot">#</a></h4>
-        <p class="description">{{ _('TestPilot user interaction testing framework') }}</p>
-      </div>
-      <ul class="subscribe">
-        <li>{{ _('Web:') }} <a href="http://groups.google.com/group/mozilla-labs-testpilot">Google Groups</a></li>
-      </ul>
-    </li>
-
-    <li id="labs-weave">
-      <div class="summary">
-        <h4>mozilla.labs.weave<a href="#labs-weave">#</a></h4>
-        <p class="description">{{ _('Weave browser sync') }}</p>
-      </div>
-      <ul class="subscribe">
-        <li>{{ _('Web:') }} <a href="http://groups.google.com/group/mozilla-labs-weave">Google Groups</a></li>
-      </ul>
-    </li>
-
-  </ul>
-</section>
-
 
 <h2 id="chat">{{ _('Realtime Chat') }}</h2>
 


### PR DESCRIPTION
## Description
- Removes out of date mozilla-labs forum links to dead projects.

## Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1340599
