### PR TITLE
fix Bug 1341242 - Video on /contribute does not stop playing when closing modal

### DIFF
--- a/media/js/mozorg/contribute/contribute-landing.js
+++ b/media/js/mozorg/contribute/contribute-landing.js
@@ -16,6 +16,9 @@
             title: '',
             onCreate: function() {
                 playVideo();
+            },
+            onDestroy: function() {
+                pauseVideo();
             }
         });
 
@@ -42,6 +45,11 @@
                 });
             });
         }
+    };
+
+    // Pause the video when the modal is closed (Bug 1341242)
+    var pauseVideo = function() {
+        document.getElementById('htmlPlayer').pause();
     };
 
     // Track user scrolling through each section on the landing page


### PR DESCRIPTION
## Description
Pause video playback when a user closes the modal on the /contribute page.
## Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1341242
## Testing

## Checklist
- [ ] Related functional & integration tests passing.
