### PR TITLE
Fix Bug 1341005 - "Private Browsing" link in Firefox navigation should point to /firefox/private-browsing/

### DIFF
--- a/bedrock/base/templates/macros.html
+++ b/bedrock/base/templates/macros.html
@@ -208,7 +208,7 @@
         <li><a href="{{ url('firefox.channel.desktop') }}" data-link-type="nav" data-link-name="Side Menu: Pre-release downloads">{{ _('Pre-release downloads') }}</a>
         <li><a href="{{ url('firefox.dnt') }}" data-link-type="nav" data-link-name="Side Menu: Do Not Track">{{ _('Do Not Track') }}</a></li>
         <li><a href="{{ url('firefox.interest-dashboard') }}" data-link-type="nav" data-link-name="Side Menu: Interest Dashboard">{{ _('Interest Dashboard') }}</a></li>
-        <li><a rel="external" href="https://support.mozilla.org/kb/private-browsing-browse-web-without-saving-info" data-link-type="nav" data-link-name="Side Menu: Private Browsing">{{ _('Private Browsing') }}</a></li>
+        <li><a href="{{ url('firefox.private-browsing') }}" data-link-type="nav" data-link-name="Side Menu: Private Browsing">{{ _('Private Browsing') }}</a></li>
         <li><a rel="external" href="https://addons.mozilla.org" data-link-type="nav" data-link-name="Side Menu: Add-ons">{{ _('Add-ons') }}</a></li>
         <li><a rel="external" href="https://support.mozilla.org/products/firefox" data-link-type="nav" data-link-name="Side Menu: Need help?">{{ _('Need help?') }}</a></li>
       </ul>


### PR DESCRIPTION
## Description
 made the "Private Browsing"  link in Firefox navigation to point to /firefox/private-browsing/
## Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1341005