### PR TITLE
Fix Bug 1336524 - The sign up button should be aligned properly with the mail input box - governance page

### DIFF
--- a/media/css/sandstone/sandstone-resp.less
+++ b/media/css/sandstone/sandstone-resp.less
@@ -901,7 +901,7 @@ nav.menu-bar {
     input[type=email] {
         .border-box();
         width: 100%;
-        padding: 15px 10px;
+        padding: 19px 10px;
     }
 
     .field-privacy {


### PR DESCRIPTION
## Description
Adjusted the height of the mail input box of the /about/governance/ page to align properly with the sign up button.
## Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1336524