### PR TITLE
Push HEAD to prod when tagging release.

### DIFF
--- a/bin/tag-release.sh
+++ b/bin/tag-release.sh
@@ -31,5 +31,5 @@ done
 echo "tagged $tag_value"
 if [[ "$do_push" == true ]]; then
   git push "$moz_git_remote" "$tag_value"
-  git push "$moz_git_remote" master:prod
+  git push "$moz_git_remote" HEAD:prod
 fi


### PR DESCRIPTION
This pushes the commit you just tagged to the prod branch, not just master. I needed to push master~1 to prod first, since the HEAD of master contains a migration. This will allow me to do this kind of thing with the normal `tag-release.sh` script.