### PR TITLE
Fixes bug 1343648; removes chofmann from l10n-voucher section.

### DIFF
--- a/bedrock/mozorg/templates/mozorg/about/governance/policies/commit/access-policy.html
+++ b/bedrock/mozorg/templates/mozorg/about/governance/policies/commit/access-policy.html
@@ -124,7 +124,7 @@ This is the lowest level of access. It allows someone to check in to the <a href
 
 <h4 id="L10n">{{ _('L10n') }}</h4>
 
-<p>{{ _('In addition, l10n is a separate category so l10n-only access can be more freely given than might be the case if it were included in level 2. This exception is worth making because of the size and diversity of the l10n community and the looser relationship people in it sometimes have to the rest of the project. l10n access implies level 1 access but not level 2 access. The named vouchers are Axel Hecht, Jeff Beatty and Chris Hofmann.') }}</p>
+<p>{{ _('In addition, l10n is a separate category so l10n-only access can be more freely given than might be the case if it were included in level 2. This exception is worth making because of the size and diversity of the l10n community and the looser relationship people in it sometimes have to the rest of the project. l10n access implies level 1 access but not level 2 access. The named vouchers are Axel Hecht and Jeff Beatty.') }}</p>
 
 <h2 id="Level2">{{ _('Level 2 - General Access') }}</h2>
 


### PR DESCRIPTION
## Description
Removes Chris Hofmann from l10n-voucher list on access-policy page
## Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1343648
## Testing
None, admittedly (sorry!)
## Checklist
- [ ] Requires l10n changes.
- [ ] Related functional & integration tests passing.
