### PR TITLE
Bug 1335569 - Revert unwanted string change in IH privacy-security

### DIFF
--- a/bedrock/mozorg/templates/mozorg/internet-health/privacy-security.html
+++ b/bedrock/mozorg/templates/mozorg/internet-health/privacy-security.html
@@ -453,7 +453,7 @@
       <p class="report-cta">
         <span>
         {% trans healthreport='https://internethealthreport.org' %}
-          Read on about Digital Inclusion in our <a href="{{ healthreport }}">Internet Health Report</a>.
+          Keep reading about Privacy and Security in our <a href="{{ healthreport }}">Internet Health Report</a>.
         {% endtrans %}
         </span>
       </p>


### PR DESCRIPTION
Currently there's an English string exposed in production, since the page was localized.