### PR TITLE
[fix bug 1344240] Move /all link from page footer to inside modal on /firefox/new/

### DIFF
--- a/bedrock/firefox/templates/firefox/includes/download-list.html
+++ b/bedrock/firefox/templates/firefox/includes/download-list.html
@@ -13,3 +13,5 @@
     </li>
   {%- endfor %}
 </ul>
+
+<p><a href="{{ firefox_url('desktop', 'all', 'release') }}">{{_('Available Languages') }}</a></p>

--- a/bedrock/firefox/templates/firefox/new/base.html
+++ b/bedrock/firefox/templates/firefox/new/base.html
@@ -52,9 +52,7 @@
 {% block email_form %}{% endblock %}
 
 {% block site_footer %}
-  {% with fx_footer_links=True %}
-    {% include 'firefox/includes/simple_footer.html' %}
-  {% endwith %}
+  {% include 'firefox/includes/simple_footer.html' %}
 {% endblock %}
 
 {% block js %}{% endblock %}

--- a/bedrock/firefox/templates/firefox/new/onboarding/base.html
+++ b/bedrock/firefox/templates/firefox/new/onboarding/base.html
@@ -44,9 +44,7 @@
 {% block email_form %}{% endblock %}
 
 {% block site_footer %}
-  {% with fx_footer_links=True %}
-    {% include 'firefox/includes/simple_footer.html' %}
-  {% endwith %}
+  {% include 'firefox/includes/simple_footer.html' %}
 {% endblock %}
 
 {% block js %}{% endblock %}

--- a/bedrock/firefox/templates/firefox/new/onboarding/scene1.html
+++ b/bedrock/firefox/templates/firefox/new/onboarding/scene1.html
@@ -81,7 +81,7 @@
                 <li><a class="more" href="{{ url('firefox.family.index') }}">{{_('Discover all the ways to take Firefox on the go')}}</a></li>
               </ul>
             </div>
-            <button id="other-platforms-modal-link" class="hidden" type="button">{{_('Download Firefox for another platform')}}</button>
+            <button id="other-platforms-modal-link" class="hidden" type="button">{{_('Firefox for Other Platforms & Languages')}}</button>
             <section id="benefits">
               <ul>
                 <li>

--- a/bedrock/firefox/templates/firefox/new/scene1.html
+++ b/bedrock/firefox/templates/firefox/new/scene1.html
@@ -85,7 +85,7 @@
               </ul>
             </div>
             {% if l10n_has_tag('firefox_new_other_platforms') %}
-              <button id="other-platforms-modal-link" class="hidden" type="button">{{_('Download Firefox for another platform')}}</button>
+              <button id="other-platforms-modal-link" class="hidden" type="button">{{_('Firefox for Other Platforms & Languages')}}</button>
             {% endif %}
           </div>{#-- /.main-content --#}
         </div>{#-- /.inner-container --#}


### PR DESCRIPTION
## Description
- Moves the link to `/all` from the footer to inside modal on `/firefox/new/` (footer links are due to be removed in [Bug 1342235](https://bugzilla.mozilla.org/show_bug.cgi?id=1342235))
- This doesn't fix the discover-ability problem for other pages once the footer links are removed, but it should fix things for this most critical page. Arguably the links in the footer we're way too hard to find anyway.
- This PR uses existing strings in `main.lang` and `download_button.lang`, so it shouldn't require any l10n conditional tags.

## Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1344240

## Testing

## Checklist
- [ ] Requires l10n changes.
- [ ] Related functional & integration tests passing.
