### PR TITLE
[fix bug 1345416] Hide sha-1 download links by default on /organizations/all/

### DIFF
--- a/media/css/firefox/all.less
+++ b/media/css/firefox/all.less
@@ -408,7 +408,7 @@ body.nightly {
 }
 
 /* The sha-1 download column is hidden by default */
-.js #builds .build-table {
+.js .build-table {
     thead tr .winsha1,
     tbody tr .winsha1 {
         display: none;
@@ -416,7 +416,7 @@ body.nightly {
 }
 
 /* IE on Windows XP, Server 2003, Vista need sha-1 button */
-.windows.sha-1 #builds .build-table {
+.windows.sha-1 .build-table {
     thead tr .win,
     tbody tr .win {
         display: none;


### PR DESCRIPTION
## Description
- We're currently showing `Windows (XP/Vista)` sha-1 download links on `/firefox/organizations/all` by default, along side regular bouncer links. This has happened because there are now two ESR releases.
- This PR updates the CSS to hide the sha-1 links by default, showing them only to users who need it.

## Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1345416

## Testing
- By default only regular bouncer links should be shown.
- Setting a class of `windows sha-1` on the HTML element should toggle showing the sha-1 bouncer links.

## Checklist
- [ ] Requires l10n changes.
- [ ] Related functional & integration tests passing.
