### PR TITLE
Fix bug 1082122: Allow 5 char locales for newsletters

### DIFF
--- a/bedrock/newsletter/tests/test_forms.py
+++ b/bedrock/newsletter/tests/test_forms.py
@@ -74,11 +74,13 @@ class TestRenderers(TestCase):
 
 
 class TestManageSubscriptionsForm(TestCase):
-    def test_locale(self):
+    @mock.patch('bedrock.newsletter.forms.get_lang_choices')
+    def test_locale(self, langs_mock):
         """Get initial lang, country from the right places"""
         # Get initial lang and country from 'initial' if provided there,
         # else from the locale passed in
         # First, not passed in
+        langs_mock.return_value = [['en', 'English'], ['pt', 'Portuguese']]
         locale = "en-US"
         form = ManageSubscriptionsForm(locale=locale, initial={})
         self.assertEqual('en', form.initial['lang'])

--- a/bedrock/newsletter/utils.py
+++ b/bedrock/newsletter/utils.py
@@ -42,10 +42,6 @@ def get_languages_for_newsletters(newsletters=None):
 
     If no newsletters are provided, it will return language codes
     supported by all newsletters.
-
-    These are 2-letter language codes and `do not` include the country part,
-    even if the newsletter languages list does.  E.g. this returns 'pt',
-    not 'pt-Br'
     """
     all_newsletters = get_newsletters()
     if newsletters is None:
@@ -57,7 +53,7 @@ def get_languages_for_newsletters(newsletters=None):
 
     langs = set()
     for newsletter in newsletters:
-        langs.update(lang[:2].lower() for lang in newsletter.get('languages', []))
+        langs.update(newsletter.get('languages', []))
 
     return langs
 


### PR DESCRIPTION
We need to allow 5 char locales (e.g. zh-TW) to post to basket.