### PR TITLE
Add one retry to integration test runs

### DIFF
--- a/jenkins/utils.groovy
+++ b/jenkins/utils.groovy
@@ -64,13 +64,15 @@ def integrationTestJob(propFileName, appURL='') {
                               usernameVariable: 'SAUCELABS_USERNAME',
                               passwordVariable: 'SAUCELABS_API_KEY']]) {
                 withEnv(["BASE_URL=${appURL}"]) {
-                    try {
-                        sh testScript
-                    }
-                    finally {
-                        junit 'results/*.xml'
-                        if ( propFileName == 'smoke' ) {
-                            sh 'docker/bin/cleanup_after_functional_tests.sh'
+                    retry(1) {
+                        try {
+                            sh testScript
+                        }
+                        finally {
+                            junit 'results/*.xml'
+                            if ( propFileName == 'smoke' ) {
+                                sh 'docker/bin/cleanup_after_functional_tests.sh'
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
We're seeing random failures, and this would help prevent having to run the full deployment again.