### PR TITLE
Downgrade Requests to fix LinkChecker

### DIFF
--- a/docker/bin/run_linkchecker.sh
+++ b/docker/bin/run_linkchecker.sh
@@ -1,5 +1,4 @@
 #!/bin/bash -xe
 GIT_COMMIT=${GIT_COMMIT:-$(git rev-parse HEAD)}
-cp docker/dockerfiles/bedrock_linkchecker Dockerfile
-docker build -t bedrock_linkchecker:${GIT_COMMIT} --pull=true .
+docker build -t bedrock_linkchecker:${GIT_COMMIT} --pull=true -f docker/dockerfiles/bedrock_linkchecker .
 docker run --rm -v `pwd`/results:/results -e URLS="${URLS}" -e THREADS=${THREADS} -e RECURSION_LEVEL=${RECURSION_LEVEL} -e CHECK_EXTERNAL=${CHECK_EXTERNAL} -e VERBOSE=${VERBOSE} bedrock_linkchecker:${GIT_COMMIT}

--- a/requirements/linkchecker.txt
+++ b/requirements/linkchecker.txt
@@ -1,5 +1,5 @@
 linkchecker==9.3 \
     --hash=sha256:ee0aa60de440fdcf8587ddebf1f691bc777a32d8d4f119beed63f405dc56176d
-requests==2.13.0 \
-    --hash=sha256:1a720e8862a41aa22e339373b526f508ef0c8988baf48b84d3fc891a8e237efb \
-    --hash=sha256:5722cd09762faa01276230270ff16af7acf7c5c45d623868d9ba116f15791ce8
+requests==2.9.2 \
+    --hash=sha256:22a8c72dfc7fc18db1aca6784e97a638e9d09abe2cd387be473f88bd6dcba22f \
+    --hash=sha256:d8be941a08cf36e4f424ac76073eb911e5e646a33fcb3402e1642c426bf34682


### PR DESCRIPTION
Turns out LinkChecker checks for a good version of python-requests in a dumb way, so it sees version "2.13.0" as being lower than "2.2.0". Also the project seems to have been abandoned, so there isn't a newer release, though it seems this issue has been fixed in the master branch.

Easiest fix is to just downgrade requests to the latest version that is < 2.10.0, which is what I've done.