### PR TITLE
Fix bug 1344381: Disable last-modified headers from security pages

### DIFF
--- a/bedrock/security/tests/test_views.py
+++ b/bedrock/security/tests/test_views.py
@@ -1,18 +1,15 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
-from django.test import RequestFactory
 
-from mock import patch, Mock
+from mock import patch
 from nose.tools import eq_, ok_
 from product_details import product_details
 from product_details.version_compare import Version
 
 from bedrock.mozorg.tests import TestCase
-from bedrock.security.management.commands.update_security_advisories import add_or_update_advisory
 from bedrock.security.models import Product
-from bedrock.security.views import (ProductView, ProductVersionView, latest_queryset,
-                                    product_is_obsolete)
+from bedrock.security.views import ProductView, ProductVersionView, product_is_obsolete
 
 
 @patch.object(product_details, 'firefox_versions', {'LATEST_FIREFOX_VERSION': '33.0',
@@ -69,79 +66,6 @@ class TestViews(TestCase):
         pview = ProductVersionView()
         pview.kwargs = {'product': 'firefox', 'version': '4.2'}
         self.assertListEqual(pview.get_queryset(), [self.pvs[4], self.pvs[3]])
-
-
-class TestLastModified(TestCase):
-    def setUp(self):
-        self.next_id = 1
-        self.rf = RequestFactory()
-
-    def new_advisory(self, mfsa_id=None, title='WILMAAAA!', impact='Critical',
-                     announced='August 18, 2014', fixed_in=None,
-                     html='Wilma finally leaves Fred for a brontosaurus.'):
-        if mfsa_id is None:
-            mfsa_id = '2014-{0:0>2}'.format(self.next_id)
-            self.next_id += 1
-
-        if fixed_in is None:
-            fixed_in = ['Firefox 29', 'Thunderbird 29']
-
-        return add_or_update_advisory({
-            'mfsa_id': mfsa_id,
-            'title': title,
-            'impact': impact,
-            'announced': announced,
-            'fixed_in': fixed_in,
-        }, html)
-
-    def test_latest_queryset_all(self):
-        """Should return all advisories for the all page."""
-        advisories = [self.new_advisory() for i in range(10)]
-        req = self.rf.get('/')
-        req.resolver_match = Mock()
-        req.resolver_match.url_name = 'security.advisories'
-        qs = latest_queryset(req, {})
-        self.assertListEqual(advisories, list(qs.order_by('year', 'order')))
-
-    def test_latest_queryset_single(self):
-        """Should return a single advisory based on PK."""
-        advisories = [self.new_advisory() for i in range(10)]
-        req = self.rf.get('/')
-        req.resolver_match = Mock()
-        req.resolver_match.url_name = 'security.advisory'
-        qs = latest_queryset(req, {'pk': '2014-05'})
-        self.assertEqual(advisories[4], qs.get())
-
-    def test_latest_queryset_product(self):
-        """Should advisories for a single product."""
-        advisories_fx = [self.new_advisory(fixed_in='Firefox 30.0') for i in range(5)]
-        for i in range(5):
-            self.new_advisory(fixed_in='Thunderbird 30.0')
-        req = self.rf.get('/')
-        req.resolver_match = Mock()
-        req.resolver_match.url_name = 'security.product-advisories'
-        qs = latest_queryset(req, {'slug': 'firefox'})
-        self.assertListEqual(advisories_fx, list(qs.order_by('year', 'order')))
-
-    def test_latest_queryset_product_version(self):
-        """Should advisories for a single product version."""
-        advisories_30 = [self.new_advisory(fixed_in='Firefox 30.{0}'.format(i))
-                         for i in range(5)]
-        advisories_29 = [self.new_advisory(fixed_in='Firefox 29.0.{0}'.format(i))
-                         for i in range(1, 5)]
-        # make sure the one with no point version is included
-        advisories_29.append(self.new_advisory(fixed_in=['Firefox 29.0']))
-        # make sure the one outside of 29.0 isn't included
-        self.new_advisory(fixed_in=['Firefox 29.1'])
-        req = self.rf.get('/')
-        req.resolver_match = Mock()
-        req.resolver_match.url_name = 'security.product-version-advisories'
-        qs = latest_queryset(req, {'product': 'firefox', 'version': '30'})
-        self.assertListEqual(advisories_30, list(qs.order_by('year', 'order')))
-        qs = latest_queryset(req, {'product': 'firefox', 'version': '30.1'})
-        self.assertEqual(advisories_30[1], qs.get())
-        qs = latest_queryset(req, {'product': 'firefox', 'version': '29.0'})
-        self.assertListEqual(advisories_29, list(qs.order_by('year', 'order')))
 
 
 class TestKVRedirects(TestCase):


### PR DESCRIPTION
They were causing a miss-match in HTML and static file cache.  I will be investigating ways in which we can more efficiently use our CDN caches.