### PR TITLE
Fix bug 1347663: Add etag headers to responses

### DIFF
--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -96,6 +96,8 @@ USE_L10N = True
 
 USE_TZ = True
 
+USE_ETAGS = config('USE_ETAGS', default=not DEBUG, cast=bool)
+
 # just here so Django doesn't complain
 TEST_RUNNER = 'django.test.runner.DiscoverRunner'
 


### PR DESCRIPTION
Not sure why we weren't doing this before. Bedrock lends itself perfectly to etags and our CDN provider is ready for their use:

https://support.cloudflare.com/hc/en-us/articles/218505467-Does-CloudFlare-support-ETag-headers-

Django docs for the feature enabled:

https://docs.djangoproject.com/en/1.8/ref/middleware/#module-django.middleware.common