### PR TITLE
Fix bug 1348610: Win64 stub installer only for Nightly

### DIFF
--- a/bedrock/firefox/tests/test_firefox_details.py
+++ b/bedrock/firefox/tests/test_firefox_details.py
@@ -88,7 +88,7 @@ class TestFirefoxDesktop(TestCase):
         # Windows 64-bit
         url = firefox_desktop.get_download_url('release', '38.0', 'win64', 'en-US', True)
         self.assertListEqual(parse_qsl(urlparse(url).query),
-                             [('product', 'firefox-stub'),
+                             [('product', 'firefox-38.0-SSL'),
                               ('os', 'win64'),
                               ('lang', 'en-US')])
         # Linux 64-bit
@@ -110,7 +110,7 @@ class TestFirefoxDesktop(TestCase):
                               ('lang', 'en-US')])
         url = firefox_desktop.get_download_url('alpha', '28.0a2', 'win64', 'en-US', True)
         self.assertListEqual(parse_qsl(urlparse(url).query),
-                             [('product', 'firefox-aurora-stub'),
+                             [('product', 'firefox-aurora-latest-ssl'),
                               ('os', 'win64'),
                               ('lang', 'en-US')])
         url = firefox_desktop.get_download_url('alpha', '28.0a2', 'osx', 'en-US', True)

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -617,15 +617,21 @@ STUB_INSTALLER_ALL = '__ALL__'
 STUB_INSTALLER_LOCALES = {
     'release': {
         'win': STUB_INSTALLER_ALL,
-        'win64': STUB_INSTALLER_ALL,
+        # should come back in Fx 55
+        # bug 1348610
+        # 'win64': STUB_INSTALLER_ALL,
     },
     'beta': {
         'win': STUB_INSTALLER_ALL,
-        'win64': STUB_INSTALLER_ALL,
+        # should come back in Fx 55
+        # bug 1348610
+        # 'win64': STUB_INSTALLER_ALL,
     },
     'alpha': {
         'win': ['en-us'],
-        'win64': ['en-us'],
+        # should come back in Fx 55
+        # bug 1348610
+        # 'win64': ['en-us'],
     },
     'nightly': {
         'win': ['en-us'],


### PR DESCRIPTION
Stub installer for win64 is scheduled to ride the Fx 55 train, we should not enable it for more channels (aurora, beta, release) until we're told that smart switching has been enabled in the stub.