### PR TITLE
[fix bug 1349760] Add link to /firefox/android/all to homepage

### DIFF
--- a/bedrock/mozorg/templates/mozorg/home/home.html
+++ b/bedrock/mozorg/templates/mozorg/home/home.html
@@ -176,6 +176,7 @@
                 </a>
               </li>
             </ul>
+            <p><a class="android-systems-link hidden" href="{{ firefox_url('android', 'all', 'release') }}">{{_('Systems &amp; Languages')}}</a></p>
           </div> {# --/#fxmobile-download-buttons --#}
         </div> {# --/.content --#}
       </div> {# --/.stars --#}

--- a/media/css/mozorg/home/home.scss
+++ b/media/css/mozorg/home/home.scss
@@ -649,6 +649,10 @@ main {
         &.visible {
             display: block;
         }
+
+        .android-systems-link {
+            @include font-size(16px);
+        }
     }
 }
 

--- a/media/js/mozorg/home/home.js
+++ b/media/js/mozorg/home/home.js
@@ -48,6 +48,10 @@
     if (mozClient.isMobile && !mozClient.isFirefox) {
         $('#fxmobile-download-buttons').addClass('visible');
         $('#fx-download-link').addClass('hidden');
+
+        if (window.site.platform === 'android') {
+            $('.android-systems-link').removeClass('hidden');
+        }
     }
 
     $(function() {


### PR DESCRIPTION
## Description
- Adds link to /firefox/android/all/ to homepage Firefox CTA

## Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1349760
