### PR TITLE
[fix bug 1349284] Show correct CSS for grid example

### DIFF
--- a/bedrock/mozorg/templates/mozorg/developer/css-grid-demo.html
+++ b/bedrock/mozorg/templates/mozorg/developer/css-grid-demo.html
@@ -276,22 +276,22 @@
 
 .item-1 {
     grid-area: a;
-    align-self: end;
+    align-self: start;
 }
 
 .item-2 {
     grid-area: b;
-    align-self: start;
+    align-self: end;
 }
 
 .item-3 {
     grid-area: c;
-    align-self: end;
+    align-self: start;
 }
 
 .item-4 {
     grid-area: d;
-    align-self: start;
+    align-self: end;
 }</pre>
           </div>
 

--- a/media/css/mozorg/developer/css-grid-demo.scss
+++ b/media/css/mozorg/developer/css-grid-demo.scss
@@ -728,7 +728,7 @@ a:visited {
         .grid-container {
             display: grid;
             grid-template-columns: repeat(4, 1fr);
-            grid-auto-rows: 100px;
+            grid-auto-rows: minmax(100px, 1fr);
             grid-gap: 20px;
             grid-template-areas:
                 'a a b b'


### PR DESCRIPTION
## Description
The code example shown wasn't accurate to the actual code that rendered the demo. This fixes that mismatch.

## Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1349284

## Testing
Assure the code example for display matches the actual CSS. We can double-check all the examples but I think this was the only one.