### PR TITLE
[fix bug 1218626] Wrap Optimizely script in DNT check.

### DIFF
--- a/bedrock/base/templates/base-pebbles.html
+++ b/bedrock/base/templates/base-pebbles.html
@@ -3,7 +3,7 @@
 <!doctype html>
 {# Note the "windows" class, without javascript platform-specific
      assets default to windows #}
-<html class="windows x86 no-js" lang="{{ LANG|replace('en-US', 'en') }}" dir="{{ DIR }}" data-latest-firefox="{{ latest_firefox_version }}" data-esr-versions="{{ esr_firefox_versions|join(' ') }}" {% if settings.GTM_CONTAINER_ID %}data-gtm-container-id="{{ settings.GTM_CONTAINER_ID }}"{% endif %} {% block gtm_page_id %}{% endblock %} {% if settings.STUB_ATTRIBUTION_RATE %}data-stub-attribution-rate="{{ settings.STUB_ATTRIBUTION_RATE }}"{% endif %}>
+<html class="windows x86 no-js" lang="{{ LANG|replace('en-US', 'en') }}" dir="{{ DIR }}" data-latest-firefox="{{ latest_firefox_version }}" data-esr-versions="{{ esr_firefox_versions|join(' ') }}" {% if settings.OPTIMIZELY_PROJECT_ID %}data-optimizely-project-id="{{ settings.OPTIMIZELY_PROJECT_ID }}"{% endif %} {% if settings.GTM_CONTAINER_ID %}data-gtm-container-id="{{ settings.GTM_CONTAINER_ID }}"{% endif %} {% block gtm_page_id %}{% endblock %} {% if settings.STUB_ATTRIBUTION_RATE %}data-stub-attribution-rate="{{ settings.STUB_ATTRIBUTION_RATE }}"{% endif %}>
   <head>
     <meta charset="utf-8">{# Note: Must be within first 512 bytes of page #}
 

--- a/bedrock/base/templates/base-resp.html
+++ b/bedrock/base/templates/base-resp.html
@@ -3,7 +3,7 @@
 <!doctype html>
 {# Note the "windows" class, without javascript platform-specific
      assets default to windows #}
-<html class="windows x86 no-js" lang="{{ LANG|replace('en-US', 'en') }}" dir="{{ DIR }}" data-latest-firefox="{{ latest_firefox_version }}" data-esr-versions="{{ esr_firefox_versions|join(' ') }}" {% if settings.GTM_CONTAINER_ID %}data-gtm-container-id="{{ settings.GTM_CONTAINER_ID }}"{% endif %} {% block gtm_page_id %}{% endblock %} {% if settings.STUB_ATTRIBUTION_RATE %}data-stub-attribution-rate="{{ settings.STUB_ATTRIBUTION_RATE }}"{% endif %}>
+<html class="windows x86 no-js" lang="{{ LANG|replace('en-US', 'en') }}" dir="{{ DIR }}" data-latest-firefox="{{ latest_firefox_version }}" data-esr-versions="{{ esr_firefox_versions|join(' ') }}" {% if settings.OPTIMIZELY_PROJECT_ID %}data-optimizely-project-id="{{ settings.OPTIMIZELY_PROJECT_ID }}"{% endif %} {% if settings.GTM_CONTAINER_ID %}data-gtm-container-id="{{ settings.GTM_CONTAINER_ID }}"{% endif %} {% block gtm_page_id %}{% endblock %} {% if settings.STUB_ATTRIBUTION_RATE %}data-stub-attribution-rate="{{ settings.STUB_ATTRIBUTION_RATE }}"{% endif %}>
   <head>
     <meta charset="utf-8">{# Note: Must be within first 512 bytes of page #}
 

--- a/bedrock/base/templates/base.html
+++ b/bedrock/base/templates/base.html
@@ -3,7 +3,7 @@
 <!doctype html>
 {# Note the "windows" class, without javascript platform-specific
      assets default to windows #}
-<html class="windows x86 no-js" lang="{{ LANG|replace('en-US', 'en') }}" dir="{{ DIR }}" data-latest-firefox="{{ latest_firefox_version }}" data-esr-versions="{{ esr_firefox_versions|join(' ') }}" {% if settings.GTM_CONTAINER_ID %}data-gtm-container-id="{{ settings.GTM_CONTAINER_ID }}"{% endif %} {% block gtm_page_id %}{% endblock %} {% if settings.STUB_ATTRIBUTION_RATE %}data-stub-attribution-rate="{{ settings.STUB_ATTRIBUTION_RATE }}"{% endif %}>
+<html class="windows x86 no-js" lang="{{ LANG|replace('en-US', 'en') }}" dir="{{ DIR }}" data-latest-firefox="{{ latest_firefox_version }}" data-esr-versions="{{ esr_firefox_versions|join(' ') }}" {% if settings.OPTIMIZELY_PROJECT_ID %}data-optimizely-project-id="{{ settings.OPTIMIZELY_PROJECT_ID }}"{% endif %} {% if settings.GTM_CONTAINER_ID %}data-gtm-container-id="{{ settings.GTM_CONTAINER_ID }}"{% endif %} {% block gtm_page_id %}{% endblock %} {% if settings.STUB_ATTRIBUTION_RATE %}data-stub-attribution-rate="{{ settings.STUB_ATTRIBUTION_RATE }}"{% endif %}>
   <head>
     <meta charset="utf-8">{# Note: Must be within first 512 bytes of page #}
 

--- a/bedrock/base/templates/includes/optimizely.html
+++ b/bedrock/base/templates/includes/optimizely.html
@@ -1,3 +1,3 @@
 {% if settings.OPTIMIZELY_PROJECT_ID %}
-  <script src="//cdn.optimizely.com/js/{{ settings.OPTIMIZELY_PROJECT_ID }}.js"></script>
+  {% javascript 'optimizely-snippet' %}
 {% endif %}

--- a/bedrock/settings/static_media.py
+++ b/bedrock/settings/static_media.py
@@ -1127,6 +1127,12 @@ PIPELINE_JS = {
         ),
         'output_filename': 'js/gtm-snippet-bundle.js',
     },
+    'optimizely-snippet': {
+        'source_filenames': (
+            'js/base/optimizely-snippet.js',
+        ),
+        'output_filename': 'js/optimizely-snippet-bundle.js',
+    },
     'firefox_accounts': {
         'source_filenames': (
             'js/base/mozilla-fxa-iframe.js',

--- a/media/js/base/gtm-snippet.js
+++ b/media/js/base/gtm-snippet.js
@@ -3,6 +3,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 (function() {
+    'use strict';
+
     var GTM_CONTAINER_ID = document.getElementsByTagName('html')[0].getAttribute('data-gtm-container-id');
 
     // If doNotTrack is not enabled, it is ok to add GTM

--- a/media/js/base/optimizely-snippet.js
+++ b/media/js/base/optimizely-snippet.js
@@ -1,0 +1,20 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+(function() {
+    'use strict';
+
+    var OPTIMIZELY_PROJECT_ID = document.getElementsByTagName('html')[0].getAttribute('data-optimizely-project-id');
+
+    // If doNotTrack is not enabled, it is ok to add Optimizely
+    // @see https://bugzilla.mozilla.org/show_bug.cgi?id=1217896 for more details
+    if (typeof window._dntEnabled === 'function' && !window._dntEnabled() && OPTIMIZELY_PROJECT_ID) {
+        (function(d, optID) {
+            var newScriptTag = d.createElement('script');
+            var target = d.getElementsByTagName('script')[0];
+            newScriptTag.src = 'https://cdn.optimizely.com/js/' + optID + '.js';
+            target.parentNode.insertBefore(newScriptTag, target);
+        }(document, OPTIMIZELY_PROJECT_ID));
+    }
+})();


### PR DESCRIPTION
## Description

Wraps Optimizely script in a DNT check. Essentially mirrors method used for GTM.

## Bugzilla link

https://bugzilla.mozilla.org/show_bug.cgi?id=1218626

## Testing

Ensure Optimizely loads when DNT is disabled, and does not load with DNT enabled.
