### PR TITLE
fix bug 1345338 Update titles+metadata on mozilla.org/firefox/*

### DIFF
--- a/bedrock/firefox/templates/firefox/android/index.html
+++ b/bedrock/firefox/templates/firefox/android/index.html
@@ -9,8 +9,22 @@
 {% add_lang_files "firefox/sendto" %}
 
 {% block page_title_prefix %}{% endblock %}
-{% block page_title %}{{ _('Firefox for Android — Mobile Web browser — More ways to customize and protect your privacy') }}{% endblock %}
-{% block page_desc %}{{ _('Only Firefox for Android offers so many ways to make your mobile browsing experience truly your own') }}{% endblock %}
+{% block page_title %}
+{% if l10n_has_tag('firefox_title_meta_bug1345338') %}
+  {{ _('Fast, Free Android Browser for Tablets and Phones | Firefox') }}
+{% else %}
+  {{ _('Firefox for Android — Mobile Web browser — More ways to customize and protect your privacy') }}
+{% endif %}
+{% endblock %}
+
+{% block page_desc %}
+{% if l10n_has_tag('firefox_title_meta_bug1345338') %}
+  {{ _('Join the millions browsing better on tablets and phones. Firefox is fast and private. Install Firefox for Android now!') }}
+{% else %}
+  {{ _('Only Firefox for Android offers so many ways to make your mobile browsing experience truly your own') }}
+{% endif %}
+{% endblock %}
+
 {% block body_id %}firefox-android{% endblock %}
 {% block body_class %}firefox-android{% endblock %}
 

--- a/bedrock/firefox/templates/firefox/channel/android.html
+++ b/bedrock/firefox/templates/firefox/channel/android.html
@@ -6,10 +6,24 @@
 
 {% add_lang_files "firefox/channel/index" %}
 
-{% block page_desc %}{{_('Download and test the latest Firefox for Android features with Aurora, Beta and Nightly builds.')}}{% endblock %}
+{% block page_title %}
+{% if l10n_has_tag('firefox_title_meta_bug1345338') %}
+  {{ _('Try New Features in a Pre-Release Android Browser | Firefox') }}
+{% else %}
+  {{ _('Download and test future releases of Firefox for desktop, Android and iOS.') }}
+{% endif %}
+{% endblock %}
+
+{% block page_desc %}
+{% if l10n_has_tag('firefox_title_meta_bug1345338') %}
+  {{_('Experience cutting-edge features in a pre-release browser for Android: Firefox Beta, Firefox Aurora and Firefox Nightly. Install now!')}}
+{% else %}
+  {{_('Download and test the latest Firefox for Android features with Aurora, Beta and Nightly builds.')}}
+{% endif %}
+{% endblock %}
 
 {#- This will appear as <meta property="og:description"> which can be used for social share -#}
-{% block page_og_desc %}{{ self.page_desc() }}{% endblock %}
+{% block page_og_desc %}{ self.page_desc() }}{% endblock %}
 
 {% block body_id %}platform-android{% endblock %}
 

--- a/bedrock/firefox/templates/firefox/channel/android.html
+++ b/bedrock/firefox/templates/firefox/channel/android.html
@@ -23,7 +23,7 @@
 {% endblock %}
 
 {#- This will appear as <meta property="og:description"> which can be used for social share -#}
-{% block page_og_desc %}{ self.page_desc() }}{% endblock %}
+{% block page_og_desc %}{{ self.page_desc() }}{% endblock %}
 
 {% block body_id %}platform-android{% endblock %}
 

--- a/bedrock/firefox/templates/firefox/channel/base.html
+++ b/bedrock/firefox/templates/firefox/channel/base.html
@@ -7,7 +7,6 @@
 {% add_lang_files "firefox/channel/index" %}
 
 {% block page_title_prefix %}{% endblock %}
-{% block page_title %}{{ _('Download and test future releases of Firefox for desktop, Android and iOS.') }}{% endblock %}
 
 {#- This will appear as <meta property="og:title"> which can be used for social share -#}
 {% block page_og_title %}{{ self.page_title() }}{% endblock %}

--- a/bedrock/firefox/templates/firefox/channel/desktop.html
+++ b/bedrock/firefox/templates/firefox/channel/desktop.html
@@ -6,7 +6,21 @@
 
 {% add_lang_files "firefox/channel/index" %}
 
-{% block page_desc %}{{_('Download and test the latest Firefox for desktop features with Developer Edition, Beta and Nightly builds.')}}{% endblock %}
+{% block page_title %}
+{% if l10n_has_tag('firefox_title_meta_bug1345338') %}
+  {{ _('Try New Browser Features in Pre-Release Versions | Firefox') }}
+{% else %}
+  {{ _('Download and test future releases of Firefox for desktop, Android and iOS.') }}
+{% endif %}
+{% endblock %}
+
+{% block page_desc %}
+{% if l10n_has_tag('firefox_title_meta_bug1345338') %}
+  {{_('Experience cutting-edge browser features in pre-release versions: Firefox Developer Edition, Firefox Beta and Firefox Nightly. Download now!')}}
+{% else %}
+  {{_('Download and test the latest Firefox for desktop features with Developer Edition, Beta and Nightly builds.')}}
+{% endif %}
+{% endblock %}
 
 {#- This will appear as <meta property="og:description"> which can be used for social share -#}
 {% block page_og_desc %}{{ self.page_desc() }}{% endblock %}

--- a/bedrock/firefox/templates/firefox/channel/ios.html
+++ b/bedrock/firefox/templates/firefox/channel/ios.html
@@ -18,7 +18,7 @@
 {% if l10n_has_tag('firefox_title_meta_bug1345338') %}
   {{_('Experience cutting-edge features in a pre-release browser for iOS via Apple’s TestFlight program. Install now!')}}
 {% else %}
-  {{_('Test beta versions of Firefox for iOS via Apple’s TestFlight program and help make our mobile browser for iPhone, iPad and iPod touch even better..')}}
+  {{_('Test beta versions of Firefox for iOS via Apple’s TestFlight program and help make our mobile browser for iPhone, iPad and iPod touch even better.')}}
 {% endif %}
 {% endblock %}
 

--- a/bedrock/firefox/templates/firefox/channel/ios.html
+++ b/bedrock/firefox/templates/firefox/channel/ios.html
@@ -6,7 +6,21 @@
 
 {% add_lang_files "firefox/channel/index" %}
 
-{% block page_desc %}{{_('Test beta versions of Firefox for iOS via Apple’s TestFlight program and help make our mobile browser for iPhone, iPad and iPod touch even better.')}}{% endblock %}
+{% block page_title %}
+{% if l10n_has_tag('firefox_title_meta_bug1345338') %}
+  {{ _('Try New Features in a Pre-Release iOS Browser | Firefox') }}
+{% else %}
+  {{_('Test beta versions of Firefox for iOS via Apple’s TestFlight program and help make our mobile browser for iPhone, iPad and iPod touch even better.')}}
+{% endif %}
+{% endblock %}
+
+{% block page_desc %}
+{% if l10n_has_tag('firefox_title_meta_bug1345338') %}
+  {{_('Experience cutting-edge features in a pre-release browser for iOS via Apple’s TestFlight program. Install now!')}}
+{% else %}
+  {{_('Test beta versions of Firefox for iOS via Apple’s TestFlight program and help make our mobile browser for iPhone, iPad and iPod touch even better..')}}
+{% endif %}
+{% endblock %}
 
 {#- This will appear as <meta property="og:description"> which can be used for social share -#}
 {% block page_og_desc %}{{ self.page_desc() }}{% endblock %}

--- a/bedrock/firefox/templates/firefox/desktop/index.html
+++ b/bedrock/firefox/templates/firefox/desktop/index.html
@@ -8,11 +8,19 @@
 
 {% block page_title_prefix %}{% endblock %}
 {% block page_title %}
-  {% if l10n_has_tag('home_title_update') %}
-    {{ _("Firefox Web browser — Trusted, Flexible, Fast — Committed to you, your privacy and an open Web") }}
+  {% if l10n_has_tag('firefox_title_meta_bug1345338') %}
+    {{ _('Free Web Browser for Mac, Windows, Linux | Firefox') }}
+  {% elif l10n_has_tag('home_title_update') %}
+    {{ _('Firefox Web browser — Trusted, Flexible, Fast — Committed to you, your privacy and an open Web') }}
   {% else %}
     {{ _("Firefox Web browser — Trusted, Flexible, Fast — There's never been a better time") }}
   {% endif %}
+{% endblock %}
+
+{% block page_desc %}
+{% if l10n_has_tag('firefox_title_meta_bug1345338') %}
+  {{ _('Millions of people around the world trust Firefox Web browsers on Mac, Windows and Linux computers. Fast. Private. Download now!') }}
+{% endif %}
 {% endblock %}
 
 {% block page_css %}

--- a/bedrock/firefox/templates/firefox/family/index.html
+++ b/bedrock/firefox/templates/firefox/family/index.html
@@ -8,12 +8,8 @@
 {% block page_title %}
 {% if l10n_has_tag('firefox_title_meta_bug1345338') %}
   {{ _('Free Web Browser for Android, iOS, Desktop | Firefox') }}
-{% elif l10n_has_tag('fx49_remove_hello') %}
-  {{ _('Firefox – Desktop browser, Android, iOS, Sync, Private Browsing') }}
-{% elif l10n_has_tag('tracking_protection') %}
-  {{ _('Firefox – Desktop browser, Android, iOS, OS, Hello, Sync, Private Browsing') }}
 {% else %}
-  {{ _('Firefox — Desktop browser, Android, OS, Hello, Sync, Marketplace') }}
+  {{ _('Firefox – Desktop browser, Android, iOS, Sync, Private Browsing') }}
 {% endif %}
 {% endblock %}
 

--- a/bedrock/firefox/templates/firefox/family/index.html
+++ b/bedrock/firefox/templates/firefox/family/index.html
@@ -6,7 +6,9 @@
 
 {% block page_title_prefix %}{% endblock %}
 {% block page_title %}
-{% if l10n_has_tag('fx49_remove_hello') %}
+{% if l10n_has_tag('firefox_title_meta_bug1345338') %}
+  {{ _('Free Web Browser for Android, iOS, Desktop | Firefox') }}
+{% elif l10n_has_tag('fx49_remove_hello') %}
   {{ _('Firefox – Desktop browser, Android, iOS, Sync, Private Browsing') }}
 {% elif l10n_has_tag('tracking_protection') %}
   {{ _('Firefox – Desktop browser, Android, iOS, OS, Hello, Sync, Private Browsing') }}
@@ -14,7 +16,14 @@
   {{ _('Firefox — Desktop browser, Android, OS, Hello, Sync, Marketplace') }}
 {% endif %}
 {% endblock %}
-{% block page_desc %}{{ _('Learn more about our complete lineup of products for desktop and mobile browsing (and more) that help keep you in control online. Free yourself with Firefox.') }}{% endblock %}
+
+{% block page_desc %}
+{% if l10n_has_tag('firefox_title_meta_bug1345338') %}
+  {{ _('Millions of people around the world trust Firefox Web browsers on Android, iOS and desktop computers. Fast. Private. Download now!') }}
+{% else %}
+  {{ _('Learn more about our complete lineup of products for desktop and mobile browsing (and more) that help keep you in control online. Free yourself with Firefox.') }}
+{% endif %}
+{% endblock %}
 
 {% block page_css %}
   {% stylesheet 'firefox_family' %}

--- a/bedrock/firefox/templates/firefox/ios.html
+++ b/bedrock/firefox/templates/firefox/ios.html
@@ -9,8 +9,21 @@
 {% add_lang_files "firefox/sendto" %}
 
 {% block page_title_prefix %}{{ _('Firefox for iOS') }} — {% endblock %}
-{% block page_title %}{{ _('Mobile Web browser for your iPhone, iPad and iPod touch') }}{% endblock %}
-{% block page_desc %}{{ _('Add Firefox to your iPhone, iPad and iPod touch.') }}{% endblock %}
+{% block page_title %}
+{% if l10n_has_tag('firefox_title_meta_bug1345338') %}
+  {{ _('Free Mobile Browser App for iPhone, iPad, iOS | Firefox') }}
+{% else %}
+  {{ _('Mobile Web browser for your iPhone, iPad and iPod touch') }}
+{% endif %}
+{% endblock %}
+
+{% block page_desc %}
+{% if l10n_has_tag('firefox_title_meta_bug1345338') %}
+  {{ _('Join the millions browsing better on iPhone and iPad. Firefox is fast and private. Install Firefox for iOS now!') }}
+{% else %}
+  {{ _('Add Firefox to your iPhone, iPad and iPod touch.') }}
+{% endif %}
+{% endblock %}
 
 {% block body_id %}firefox-ios{% endblock %}
 {% block body_class %}

--- a/bedrock/firefox/templates/firefox/private-browsing.html
+++ b/bedrock/firefox/templates/firefox/private-browsing.html
@@ -7,8 +7,22 @@
 {% extends "firefox/base-resp.html" %}
 
 {% block page_image %}{{ static('img/firefox/private-browsing/private-browsing-meta.png') }}{% endblock %}
-{% block page_title %}{{ _('Firefox Web browser — Private Browsing with Tracking Protection — Mozilla') }}{% endblock %}
-{% block page_desc %}{{ _('Get more protection and the most privacy, only from Firefox. No other browser gives you so much control over your digital footprint.')}}{% endblock %}
+{% block page_title %}
+{% if l10n_has_tag('firefox_title_meta_bug1345338') %}
+  {{ _('Private Browser Protects Your Online Privacy | Firefox') }}
+{% else %}
+  {{ _('Firefox Web browser — Private Browsing with Tracking Protection — Mozilla') }}
+{% endif %}
+{% endblock %}
+
+{% block page_desc %}
+{% if l10n_has_tag('firefox_title_meta_bug1345338') %}
+  {{ _('Firefox protects your online privacy and blocks trackers that follow you around the web. Get Firefox for private browsing!') }}
+{% else %}
+  {{ _('Get more protection and the most privacy, only from Firefox. No other browser gives you so much control over your digital footprint.') }}
+{% endif %}
+{% endblock %}
+
 {% block body_id %}firefox-private-browsing{% endblock %}
 {% block body_class %}mozid{% endblock %}
 

--- a/bedrock/firefox/templates/firefox/sync.html
+++ b/bedrock/firefox/templates/firefox/sync.html
@@ -6,7 +6,20 @@
 
 {% extends "/firefox/base-resp.html" %}
 
-{% block page_title %}{{ _('Keep your Firefox in sync') }}{% endblock %}
+{% block page_title %}
+{% if l10n_has_tag('firefox_title_meta_bug1345338') %}
+  {{ _('Use Bookmarks, Tabs and Passwords Across Devices | Firefox') }}
+{% else %}
+  {{ _('Keep your Firefox in sync') }}
+{% endif %}
+{% endblock %}
+
+{% block page_desc %}
+{% if l10n_has_tag('firefox_title_meta_bug1345338') %}
+  {{ _('Bring your Firefox bookmarks, tabs, or passwords wherever you go with Firefox Sync. Share between computers and mobile devices. Get Firefox now!') }}
+{% endif %}
+{% endblock %}
+
 {% block body_id %}firefox-sync{% endblock %}
 {% block body_class %}
   {{ super() }}


### PR DESCRIPTION
## Description
Updating the following pages with [these](https://docs.google.com/spreadsheets/d/1kFpqkkssd-keOyVS13azQS_iJ8ESNtvqjZ5TLy5hBq0/edit#gid=0) meta-decriptions and titles:

- https://www.mozilla.org/en-US/firefox/products/
- https://www.mozilla.org/en-US/firefox/desktop/
- https://www.mozilla.org/en-US/firefox/ios/
- https://www.mozilla.org/en-US/firefox/private-browsing/
- https://www.mozilla.org/en-US/firefox/sync/
- https://www.mozilla.org/en-US/firefox/releases/
- https://www.mozilla.org/en-US/firefox/android/

## Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1345338#c12

## Testing
Ensure various meta titles and descriptions are updated as denoted [here](https://docs.google.com/spreadsheets/d/1kFpqkkssd-keOyVS13azQS_iJ8ESNtvqjZ5TLy5hBq0/edit#gid=0).

## Checklist
- [x] Requires l10n changes.
