### PR TITLE
Fix misattributed bug bounty

### DIFF
--- a/bedrock/security/templates/security/bug-bounty/web-hall-of-fame.html
+++ b/bedrock/security/templates/security/bug-bounty/web-hall-of-fame.html
@@ -41,10 +41,10 @@
             <li>Griffin Francis</li>
             <li>Tooru Fujisawa</li>
             <li>Matjaz Horvat</li>
+            <li>Muzammmil Abbas Kayani</li>
             <li>Wladimir Palant</li>
             <li>Aliaksei Panamarenka</li>
             <li>Arne Swinnen</li>
-            <li>John Whitlock</li>
           </ul>
           <h4>3rd Quarter 2016</h4>
           <ul>


### PR DESCRIPTION
## Description
John Whitlock was mistakenly attributed.

## Bugzilla link

## Testing

## Checklist
- [ ] Requires l10n changes.
- [ ] Related functional & integration tests passing.
