### PR TITLE
[fix bug 1336573] Jul-Dec 2016 transparency report

### DIFF
--- a/bedrock/mozorg/templates/mozorg/about/policy/transparency/includes/past-reports.html
+++ b/bedrock/mozorg/templates/mozorg/about/policy/transparency/includes/past-reports.html
@@ -7,6 +7,7 @@
 <nav class="content nav-previous">
   <h3>{{ _('Previous Reports') }}</h3>
   <ul>
+    <li><a href="{{ url('mozorg.about.policy.transparency.jan-jun-2016') }}">January-June 2016</a></li>
     <li><a href="{{ url('mozorg.about.policy.transparency.jan-dec-2015') }}">January-December 2015</a></li>
   </ul>
 </nav>

--- a/bedrock/mozorg/templates/mozorg/about/policy/transparency/includes/reports-nav.html
+++ b/bedrock/mozorg/templates/mozorg/about/policy/transparency/includes/reports-nav.html
@@ -3,6 +3,6 @@
           <li><a href="{{ url('mozorg.about.policy.transparency.index') + '#faq' }}">{{ _('FAQ') }}</a></li>
           <li><a href="{{ url('mozorg.about.policy.transparency.index') + '#definitions' }}">{{ _('Definitions') }}</a></li>
           {# This link should point to the latest report. Past reports are added to 'includes/past-reports.html' #}
-          <li><a href="{{ url('mozorg.about.policy.transparency.jan-jun-2016') }}">{{ _('January–June 2016 Report') }}</a></li>
+          <li><a href="{{ url('mozorg.about.policy.transparency.jul-dec-2016') }}">{{ _('July-December 2016 Report') }}</a></li>
         </ul>
       </nav>

--- a/bedrock/mozorg/templates/mozorg/about/policy/transparency/index.html
+++ b/bedrock/mozorg/templates/mozorg/about/policy/transparency/index.html
@@ -44,15 +44,7 @@
     </section>
 
     <aside class="section nav-block">
-      <nav class="content nav-report three-up">
-        <ul>
-          <li><a href="#faq">{{ _('FAQ') }}</a></li>
-          <li><a href="#definitions">{{ _('Definitions') }}</a></li>
-          {# This link should point to the latest report. Past reports are added to 'includes/past-reports.html' #}
-          <li><a href="{{ url('mozorg.about.policy.transparency.jan-jun-2016') }}">{{ _('January–June 2016 Report') }}</a></li>
-        </ul>
-      </nav>
-
+      {% include 'mozorg/about/policy/transparency/includes/reports-nav.html' %}
       {% include 'mozorg/about/policy/transparency/includes/past-reports.html' %}
     </aside>
 
@@ -67,10 +59,10 @@
               <p>
                 {# NOTE: Remember to update these links when publishing a new report. #}
                 {% trans
-                  link_userdata=url('mozorg.about.policy.transparency.jan-dec-2015') + '#government-user-data',
-                  link_removal=url('mozorg.about.policy.transparency.jan-dec-2015') + '#government-content-removal',
-                  link_copytrade=url('mozorg.about.policy.transparency.jan-dec-2015') + '#copyright-trademark',
-                  link_supplement=url('mozorg.about.policy.transparency.jan-dec-2015') + '#supplement'
+                  link_userdata=url('mozorg.about.policy.transparency.jul-dec-2016') + '#government-user-data',
+                  link_removal=url('mozorg.about.policy.transparency.jul-dec-2016') + '#government-content-removal',
+                  link_copytrade=url('mozorg.about.policy.transparency.jul-dec-2016') + '#copyright-trademark',
+                  link_supplement=url('mozorg.about.policy.transparency.jul-dec-2016') + '#supplement'
                 %}
                   We report on <a href="{{ link_userdata }}">Government Demands for User Data</a>, <a href="{{ link_removal }}">Government Requests for Content Removal</a>, and <a href="{{ link_copytrade }}">Copyright and Trademark Requests</a>. We also include a <a href="{{ link_supplement }}">Supplement</a>, which provides additional information.
                 {% endtrans %}

--- a/bedrock/mozorg/templates/mozorg/about/policy/transparency/jul-dec-2016.html
+++ b/bedrock/mozorg/templates/mozorg/about/policy/transparency/jul-dec-2016.html
@@ -4,10 +4,10 @@
 
 {% extends "mozorg/about/policy/transparency/report-base.html" %}
 
-{% block page_title %}{{ _('Transparency Report - January–June, 2016') }}{% endblock %}
+{% block page_title %}{{ _('Transparency Report - July–December, 2016') }}{% endblock %}
 
 {% block report_title %}
-  <h1>{{ _('Transparency Report') }} <span>{{ _('Reporting Period: January 1, 2016 to June 30, 2016') }}</span></h1>
+  <h1>{{ _('Transparency Report') }} <span>{{ _('Reporting Period: July 1, 2016 to December 31, 2016') }}</span></h1>
 {% endblock %}
 
 {% block report_body %}
@@ -148,7 +148,7 @@
       </table>
 
       <h3>{{ _('Trademark') }}</h3>
-      <p>{{ _('In the Reporting Period, we received 4 Trademark Takedown Notices and 0 Counter Notices') }}</p>
+      <p>{{ _('In the Reporting Period, we received 65 Trademark Takedown Notices and 1 Counter Notice') }}</p>
 
       <table class="table">
         <thead>
@@ -165,12 +165,12 @@
         <tbody>
           <tr>
             <th scope="row">{{ _('Firefox Add-ons') }}</th>
-            <td>3</td>
-            <td>0</td>
+            <td>65</td>
+            <td>1</td>
           </tr>
           <tr>
             <th scope="row">{{ _('Firefox Marketplace (Apps)') }}</th>
-            <td>1</td>
+            <td>0</td>
             <td>0</td>
           </tr>
         </tbody>
@@ -184,35 +184,37 @@
 
     <div class="content" data-accordion-role="tabpanel">
       <h3>{{ _('Legislative Reform') }}</h3>
-      <p>
-      {% trans %}
-        In the Reporting Period, we advocated for stronger encryption, privacy, and security practices.
-      {% endtrans %}
 
+      <p>
       {% trans
-          link_encryption='https://mzl.la/encrypt',
-          link_principles='https://surveillance.mozilla.org',
-          link_disclosure='https://blog.mozilla.org/blog/2016/05/11/advanced-disclosure-needed-to-keep-users-secure/',
-          link_brief='https://blog.mozilla.org/blog/2016/03/03/standing-up-with-apple-to-fight-for-everyones-security/',
-          link_letter='http://www.digital4th.org/wp-content/uploads/2016/05/ECPA-Provider-Emergency-Letter.pdf' %}
-        We ran a large scale <a href="{{ link_encryption }}">education campaign on encryption</a>, proposed <a href="{{ link_principles }}">Surveillance Principles</a> for government adoption, spoke out on the importance of <a href="{{ link_disclosure }}">disclosing security vulnerabilities</a> to affected companies in judicial proceedings, and joined with other tech companies to <a href="{{ link_brief }}">file a brief</a> arguing against backdoors in the Apple and FBI dispute and a <a href="{{ link_letter }}">letter to the U.S. Senate Judiciary Committee</a> opposing legislation that would compel companies to disclose the content of user communications without judicial oversight.
+          shared_responsibility='https://blog.mozilla.org/blog/2016/09/13/cybersecurity-is-a-shared-responsibility/',
+          security_vuln='https://blog.mozilla.org/netpolicy/2016/09/19/improving-government-disclosure-of-security-vulnerabilities/',
+          speaker_gov='http://cyberlaw.stanford.edu/events/government-hacking-vulnerabilities-equities-process',
+          speaker_hack='http://cyberlaw.stanford.edu/events/government-hacking-rule-41',
+          gag_orders='https://blog.mozilla.org/mozilla-brief-of-joint-amicus-in-msft-v-doj/',
+          eu_privacy='https://blog.mozilla.org/netpolicy/files/2017/01/Mozilla-Filing_E-Privacy-Survey.pdf',
+          india_cloud='https://blog.mozilla.org/netpolicy/files/2016/07/Mozilla-Submissions-TRAI-Consultation-on-Cloud-Computing.pdf'
+      %}
+        In the Reporting Period, we highlighted the need to see
+        <a href="{{ shared_responsibility }}">cybersecurity as a shared responsibility</a>,
+        called for <a href="{{ security_vuln }}">reform of how the U.S. Government handles security vulnerabilities</a>
+        and sponsored a speaker series on <a href="{{ speaker_gov }}">government</a>
+        <a href="{{ speaker_hack }}">hacking</a>. Together with other
+        tech companies, we <a href="{{ gag_orders }}">advocated against the U.S. Government’s use of unlimited indefinite gag orders</a>.
+        We also filed comments on the <a href="{{ eu_privacy }}">EU’s proposed e-Privacy Regulation</a> as well as
+        <a href="{{ india_cloud }}">India’s proposed Cloud Computing regulations</a>.
       {% endtrans %}
       </p>
 
       <p>
-      {% trans link_us1='https://blog.mozilla.org/netpolicy/2016/03/07/challenges-to-openness-under-u-s-copyright-law/',
-          link_us2='https://blog.mozilla.org/netpolicy/2016/04/05/reining-in-abuses-of-the-dmca-notice-system/',
-          link_eu1='https://blog.mozilla.org/netpolicy/files/2016/05/Mozilla-IPRED-filing-April-2016.pdf',
-          link_eu2='https://blog.mozilla.org/netpolicy/2016/05/02/this-is-what-a-rightsholder-looks-like-in-2016/',
-          link_fcc='https://blog.mozilla.org/netpolicy/files/2016/05/Comments-on-NPRM-for-Broadband-Privacy.pdf'
-           %}
-        In the realm of copyright, we filed comment on two U.S. Copyright Office consultations (<a href="{{ link_us1 }}">here</a> and <a href="{{ link_us2 }}">here</a>) and spoke out about the European Commission’s proposed overhaul of the EU’s copyright laws (<a href="{{ link_eu1 }}">here</a> and <a href="{{ link_eu2 }}">here</a>). We also commented on the U.S. Federal Communications Commission <a href="{{ link_fcc }}">recently proposed framework for broadband privacy</a>.
-      {% endtrans %}
-
       {% trans
-          link_fund='https://blog.mozilla.org/blog/2016/06/09/help-make-open-source-secure/',
-          link_leandata=url('mozorg.about.policy.lean-data') %}
-         In addition, we launched the <a href="{{ link_fund }}">Secure Open Source Fund</a> to promote security auditing and patching of widely used open source technologies and our <a href="{{ link_leandata }}">Lean Data Initiative</a> to encourage companies to be responsible in their use and stewardship of data.
+          eu_copyright='https://www.changecopyright.org/',
+          dmca_1201='https://blog.mozilla.org/netpolicy/files/2017/01/AdditionalCommentsonSection1201Study.pdf',
+          berec_neutrality='https://blog.mozilla.org/netpolicy/files/2016/07/Mozilla-comments-on-draft-BEREC-guidelines-of-EU-net-neutrality-rules.pdf'
+      %}
+        We also <a href="{{ eu_copyright }}">campaigned to reform Europe’s copyright laws</a>,
+        filed comments with the U.S. Copyright Office on their <a href="{{ dmca_1201 }}">review of Section 1201 of the Digital Millennium Copyright Act</a>,
+        and filed <a href="{{ berec_neutrality }}">comments with the Body of European Regulators of Electronic Communications on their net neutrality implementation guidelines</a>.
       {% endtrans %}
       </p>
 
@@ -240,3 +242,15 @@
   </section>
 {% endblock %}
 
+{% block report_nav %}
+  <aside class="section nav-block">
+    <nav class="content nav-report two-up">
+      <ul>
+        <li><a href="{{ url('mozorg.about.policy.transparency.index') + '#faq' }}">{{ _('FAQ') }}</a></li>
+        <li><a href="{{ url('mozorg.about.policy.transparency.index') + '#definitions' }}">{{ _('Definitions') }}</a></li>
+      </ul>
+    </nav>
+
+    {% include 'mozorg/about/policy/transparency/includes/past-reports.html' %}
+  </aside>
+{% endblock %}

--- a/bedrock/mozorg/urls.py
+++ b/bedrock/mozorg/urls.py
@@ -67,6 +67,8 @@ urlpatterns = (
          'mozorg/about/policy/transparency/jan-dec-2015.html'),
     page('about/policy/transparency/jan-jun-2016',
          'mozorg/about/policy/transparency/jan-jun-2016.html'),
+    page('about/policy/transparency/jul-dec-2016',
+         'mozorg/about/policy/transparency/jul-dec-2016.html'),
 
     page('contact', 'mozorg/contact/contact-landing.html'),
     page('contact/spaces', 'mozorg/contact/spaces/spaces-landing.html'),

--- a/media/css/mozorg/about-transparency.less
+++ b/media/css/mozorg/about-transparency.less
@@ -213,9 +213,10 @@ main {
 .nav-previous {
     .border-box;
     background: #f3f3f3;
-    border: 1px solid rgba(0, 0, 0, .05);
+    border: solid rgba(0, 0, 0, .05);
+    border-width: 1px 0;
     padding: 20px;
-    margin-top: @baseLine;
+    margin: @baseLine 0 -40px;
 
     ul {
         list-style: none;
@@ -258,4 +259,8 @@ main {
             }
         }
     }
+}
+
+#colophon {
+    margin-top: 40px;
 }


### PR DESCRIPTION
## Description
Adds a transparency report for July-December 2016 and moves the previous one to "past reports." No l10n required.

## Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1336573

## Testing
https://bedrock-demo-craigcook.us-west.moz.works/en-US/about/policy/transparency/jul-dec-2016/