### PR TITLE
Relaunch and redo the web bug bounty program

### DIFF
--- a/bedrock/mozorg/templates/mozorg/about/governance/policies/security/bugs.html
+++ b/bedrock/mozorg/templates/mozorg/about/governance/policies/security/bugs.html
@@ -12,10 +12,10 @@
 
   <p>{{ _(' Version 1.1') }}</p>
 
-  <p><strong>{% trans mail='mailto:security@mozilla.org?subject=Mozilla%20security%20bug%20report' %}
-    IMPORTANT: Anyone who believes they have found a Mozilla-related security vulnerability can and should report
-it by sending email to the address <a href="{{ mail }}">security@mozilla.org</a>.
-  {% endtrans %}</strong></p>
+  <p><strong>
+    IMPORTANT: Anyone who believes they have found a Mozilla-related security vulnerability should visit
+    our <a href="{{ url('security.bug-bounty') }}">bug bounty program</a> for information on how to submit them.
+  </strong></p>
 
   <h2 id="intro">{{ _('Introduction') }}</h2>
 

--- a/bedrock/security/templates/security/base.html
+++ b/bedrock/security/templates/security/base.html
@@ -8,15 +8,28 @@
   {% stylesheet 'security' %}
 {% endblock %}
 
-{% set navigation_bar = [
+{% set navigation_bar_security = [
     (url('security.index'), 'security-index', 'Mozilla Security'),
-    (url('security.advisories'), 'advisories', 'Security Advisories'),
+    (url('security.advisories'), 'advisories', 'Advisories'),
     (url('security.known-vulnerabilities'), 'known-vulnerabilities', 'Known Vulnerabilities'),
-    (url('security.bug-bounty'), 'bug-bounty', 'Bug Bounty'),
-    (url('security.bug-bounty.hall-of-fame'), 'hall-of-fame', 'Firefox Hall Of Fame'),
-    (url('security.bug-bounty.web-hall-of-fame'), 'web-hall-of-fame', 'Mozilla Web and Services Hall Of Fame'),
-    ('https://blog.mozilla.com/security/', 'blog', 'Security Blog'),
+    ('https://blog.mozilla.com/security/', 'blog', 'Blog'),
 ] %}
+
+{% set navigation_bar_client_bounty = [
+    (url('security.client-bug-bounty'), None, 'Client Bug Bounty'),
+    (url('security.client-bug-bounty'), 'client-bug-bounty', 'Guidelines'),
+    (url('security.bug-bounty.faq'), 'faq', 'Frequently Asked Questions'),
+    (url('security.bug-bounty.hall-of-fame'), 'hall-of-fame', 'Hall of Fame'),
+] %}
+
+{% set navigation_bar_web_bounty = [
+    (url('security.web-bug-bounty'), 'wbb', 'Web Bug Bounty'),
+    (url('security.web-bug-bounty'), 'web-bug-bounty', 'Guidelines'),
+    (url('security.bug-bounty.web-eligible-sites'), 'web-eligible-sites', 'Eligible Websites'),
+    (url('security.bug-bounty.faq-webapp'), 'faq-webapp', 'Frequently Asked Questions'),
+    (url('security.bug-bounty.web-hall-of-fame'), 'web-hall-of-fame', 'Hall of Fame'),
+] %}
+
 
 {% block body_class %}sand{% endblock %}
 
@@ -39,7 +52,7 @@
         {% block side_nav %}
           <nav>
             <ul>
-            {% for href, id, caption in navigation_bar %}
+            {% for href, id, caption in navigation_bar_security %}
               <li>
               {% if id == body_id %}
                 <b>{{ caption|e }}</b>
@@ -50,6 +63,35 @@
             {% endfor %}
             </ul>
           </nav>
+
+          <nav>
+            <ul>
+            {% for href, id, caption in navigation_bar_client_bounty %}
+              <li>
+              {% if id == body_id %}
+                <b>{{ caption|e }}</b>
+              {% else %}
+                <a href="{{ href|e }}">{{ caption|e }}</a>
+              {% endif %}
+              </li>
+            {% endfor %}
+            </ul>
+          </nav>
+
+          <nav>
+            <ul>
+            {% for href, id, caption in navigation_bar_web_bounty %}
+              <li>
+              {% if id == body_id %}
+                <b>{{ caption|e }}</b>
+              {% else %}
+                <a href="{{ href|e }}">{{ caption|e }}</a>
+              {% endif %}
+              </li>
+            {% endfor %}
+            </ul>
+          </nav>
+
         {% endblock %}
         {% block side_extra %}
         {% endblock %}

--- a/bedrock/security/templates/security/bug-bounty.html
+++ b/bedrock/security/templates/security/bug-bounty.html
@@ -21,11 +21,11 @@
 
       <p>Mozilla has paid out over 1.6 million dollars in bounties to our various researchers!</p>
 
-      <p>Mozilla manages two different bug bounty programs.  One program focuses on Firefox and other client applications and one bounty program focuses on our web properties and services.</p>
+      <p>Mozilla manages two different bug bounty programs.  One focuses on Firefox and other Mozilla applications and the other covers our websites and services.</p>
 
       <ul>
-        <li>Information on the Client Bug Bounty Program can be found <a href="{{ url('security.client-bug-bounty') }}">here</a>
-        <li>Information on the Web and Services Bug Bounty Program can be found <a href="{{ url('security.web-bug-bounty') }}">here</a>
+        <li><a href="{{ url('security.client-bug-bounty') }}">Client Bug Bounty Guidelines</a></li>
+        <li><a href="{{ url('security.web-bug-bounty') }}">Web Bug Bounty Guidelines</a></li>
       </ul>
      </div>
   </article>

--- a/bedrock/security/templates/security/bug-bounty/faq-webapp.html
+++ b/bedrock/security/templates/security/bug-bounty/faq-webapp.html
@@ -1,6 +1,8 @@
 {% extends "security/base.html" %}
 
 {% block page_title %}Mozilla Web Application Security Bug Bounty FAQ{% endblock %}
+{% set body_id = "faq-webapp" %}
+
 
 {% block breadcrumbs %}
   <nav class="breadcrumbs">
@@ -13,342 +15,173 @@
 {% block article %}
   <article class="section-content" itemscope itemtype="http://schema.org/Article">
     <header>
-      <h1 itemprop="name" class="title-shadow-box">Web Application Security Bug Bounty FAQ</h1>
+      <h1 itemprop="name" class="title-shadow-box">Web Bug Bounty FAQ</h1>
     </header>
 
     <div itemprop="articleBody">
-      <p>This FAQ covers websites and services. If you are reporting on a client software issue
-        (e.g. a security issue in the Firefox browser), please see the
-        <a href="{{ url('security.bug-bounty.faq') }}">Client Security Bug Bounty Program FAQ.</a>
-        For more about the background of the bug bounty program see the
-        <a href="{{ url('security.bug-bounty') }}">official guidelines</a>
-        governing the program.</p>
-
       <h3>General questions</h3>
+
       <ul>
         <li><a href="#why">Why do we include web applications as part
-          of our security Bug Bounty Program?</a></li>
+          of our bug bounty program?</a></li>
         <li><a href="#howto">How can I find potential vulnerabilities
-          and are there things I shouldn't do in trying to find them?</a></li>
-        <li><a href="#bounty-amount">Is the amount of the bounty
-          different for web applications vulnerabilities?</a></li>
-        <li><a href="#severity-ratings">Is there a list of severity ratings
-          with examples?</a></li>
+          and are there things I shouldn't do in trying to discover them?</a></li>
+        <li><a href="{{ url('security.web-bug-bounty') }}#payouts-section">What are the bounty payouts?</a></li>
       </ul>
 
       <h3>Eligible bugs</h3>
+
       <ul>
         <li><a href="#eligible-bugs">Which domains and web applications will be
           considered to be part of the bug bounty?</a></li>
-        <li><a href="#issues">What types of issues will be considered as
-          part of the bounty program?</a></li>
-        <li><a href="#dos-bugs">Why won't you provide a reward for denial of service
+        <li><a href="{{ url('security.web-bug-bounty') }}#payouts-section">
+          What types of issues will be considered as part of the bounty program?</a></li>
+        <li><a href="#dos-bugs">Why don't you provide a reward for denial of service
           bugs?</a></li>
-        <li><a href="#sites-not-listed">What about sites which are not listed?</a></li>
       </ul>
 
       <h3>Bug reporting</h3>
+
       <ul>
         <li><a href="#what-next">Once I have found a vulnerability,
           what next?</a></li>
         <li><a href="#nondisclosure">If I report the bug directly to you,
-          do I have to keep the bug confidential and not publish information
-          about it in order to receive a reward?</a></li>
-        <li><a href="#cooperation">I don’t have the time or desire to work
-          with you further in investigating and fixing the bug; can I still get a
-          bug bounty reward?</a></li>
+          do I have to keep the bug confidential in order to receive a bouncy?</a></li>
+        <li><a href="#cooperation">If I don’t have the time to assist you further, can I still receive a
+          bug bounty?</a></li>
+        <li><a href="#attack-scenario">What does a valid attack scenario look like?</a></li>
+        <li><a href="#step-by-step-exploit">What does a valid step-by-step exploit process look like?</a></li>
+        <li><a href="#xss-reporting">How should I report an XSS vulnerability?</a></li>
       </ul>
 
       <h2>General questions</h2>
-      <dl class="faq">
-        <dt class="question" id="why">Why do we include web applications
-          as part of our security Bug Bounty Program?</dt>
-        <dd class="answer">
-          <p>Mozilla client software relies on web services, and Mozilla’s community uses
-          websites and services to communicate and coordinate activity.
-          Our goal is to make our products and services more secure.
-          Mozilla community members submitted bugs before we had an official bounty program
-          to reward researchers. The bounty program is designed to incentivize bug reporting towards the websites,
-          services, and types of bugs we’d like community members to focus on.</p>
-        </dd>
 
-        <dt class="question" id="howto">How can I find potential vulnerabilities
-          and are there things I shouldn’t do in trying to find them?</dt>
-        <dd class="answer">
-          <p>We have received many questions around how to find web application
-            security issues. The most common concern is the use of automatic tools.
-            We ask that people don’t use automatic tools against our web services
-            as it is important to maintain our services and availability. We do
-            encourage people to examine typical areas for vulnerabilities such as
-            authentication and session management. Since our code is open source, you are
-            encourage to run on the software on your own server instance or just look
-            at the source code for potential issues.</p>
-            <p>On Mozilla’s Wiki, you can find information about some of our
-              <a href="https://wiki.mozilla.org/Security/TestingToolchains/">security testing toolchains.</a></p>
-            <p>See the list below for the domains and applications which are in scope.</p>
-        </dd>
+      <h4 id="why">Why do we include web applications
+          as part of our bug bounty program?</h4>
+          <p>Mozilla client software relies heavily on web services, and Mozilla’s
+          community uses our websites and services to communicate and coordinate activity.
+          Our goal is to make these products and services as safe and secure as possible.
+          </p>
 
-        <dt class="question" id="bounty-amount">Is the amount of the bounty
-          different for web applications vulnerabilities?</dt>
-        <dd class="answer">
-          <p>Payments vary according to the severity of the issue, with the range
-            starting at $500 (US) for moderate severity and up to $3000 (US) for
-            High or Critical vulnerabilities.</p>
-        </dd>
-
-        <dt class="question" id="severity-ratings">Is there a list of severity
-          ratings with examples?</dt>
-        <dd class="answer">
-          <p>Yes, here it is:
-            <a href="https://wiki.mozilla.org/WebAppSec/Web_App_Severity_Ratings">
-              Web Application Severity Ratings</a></p>
-              The bounty committee’s reward is based on the security and privacy
-              impact of the bug and ultimately the importance of the website or service.
-        </dd>
-      </dl>
+      <h4 id="howto">How can I find potential vulnerabilities
+        and are there things I shouldn’t do in trying to discover them?</h4>
+        <p>We have received many questions around how to discover web application
+          security issues, largely revolving around use of automated attack tools
+          such as ZAP and Burp.</p>
+        <p>
+          We request that people refrain from using automated tools against our production web
+          services, as it is important to maintain our services' availability and minimize
+          unintentional vandalism. Since our code is open source, you are encouraged to run
+          it on your own server instance or examine the it directly for potential issues.
+        </p>
 
       <h2>Eligible bugs</h2>
-      <dl class="faq">
-        <dt class="question" id="eligible-bugs">Which domains and web applications
-          will be considered to be part of the bug bounty?</dt>
-        <dd class="answer">
-          <p>Below is the list of domains eligible for Mozilla’s website and services
-            security bug bounty. Please check it regularly, as it changes over time.</p>
 
-          <h4>www.mozilla.com/org</h4>
-          <ul>
-          	<li>www.mozilla.com</li>
-          	<li>www.mozilla.org</li>
-          	<li>www.firefox.com</li>
-          	<li>www.getfirefox.com</li>
-          </ul>
+      <h4 id="eligible-bugs">Which domains and web applications will be considered to be part of the bug bounty?</h4>
+      <p>Although all of our non-community websites are considered in scope for acknowledgment on our
+      <a href="{{ url('security.bug-bounty.web-hall-of-fame') }}">hall of fame</a>, only
+      a limited subset are eligible for monetary payouts. Please see our
+      <a href="{{ url('security.bug-bounty.web-eligible-sites') }}">list of eligible sites</a>
+      for additional information.</p>
 
-          <h4>ABSearch</h4>
-          <ul>
-          	<li>Search.services.mozilla.com</li>
-          </ul>
-
-          <h4>Addons.mozilla.org</h4>
-          <ul>
-          	<li>addon.mozilla.org</li>
-          	<li>addons.mozilla.org</li>
-          	<li>blocklist.addons.mozilla.org</li>
-          	<li>builder.addons.mozilla.org</li>
-          	<li>services.addons.mozilla.org</li>
-          	<li>static.addons.mozilla.net</li>
-          	<li>versioncheck-bg.addons.mozilla.org</li>
-          	<li>Versioncheck.addons.mozilla.org</li>
-          </ul>
-
-          <h4>bugzilla.mozilla.org</h4>
-          <p>
-            <strong>Please don’t use automated scanners and create bugs for testing on the production instance.</strong>
-            Install your own local copy for testing from
-            <a href="https://github.com/mozilla/webtools-bmo-bugzilla">https://github.com/mozilla/webtools-bmo-bugzilla</a>.
-          </p>
-          <ul>
-          	<li>bugzilla.mozilla.org</li>
-          </ul>
-
-          <h4>Product Delivery</h4>
-          <ul>
-          	<li>download-installer.cdn.mozilla.net</li>
-          	<li>Download.mozilla.org</li>
-          </ul>
-
-          <h4>AUS/Balrog</h4>
-          <ul>
-          	<li>aus3.mozilla.org</li>
-          	<li>aus4.mozilla.org</li>
-          	<li>aus5.mozilla.org</li>
-          	<li>Aus.mozilla.org</li>
-          </ul>
-
-          <h4>Firefox Accounts</h4>
-          <ul>
-          	<li>accounts.firefox.com</li>
-          	<li>api.accounts.firefox.com</li>
-          	<li>oauth.accounts.firefox.com</li>
-          	<li>profile.accounts.firefox.com</li>
-          	<li>Verifier.accounts.firefox.com</li>
-          </ul>
-
-          <h4>Firefox Sync</h4>
-          <ul>
-          	<li>*.$region.sync.services.mozilla.com</li>
-          	<li>Token.services.mozilla.com</li>
-          </ul>
-
-          <h4>Firefox Hello</h4>
-          <ul>
-          	<li>hello.firefox.com</li>
-          	<li>Loop.services.mozilla.com</li>
-          </ul>
-
-          <h4>Location (MLS)</h4>
-          <ul>
-          	<li>location.services.mozilla.com</li>
-          	<li>Location-leaderboard.services.mozilla.com</li>
-          </ul>
-
-          <h4>Marketplace.firefox.com</h4>
-          <ul>
-          	<li>marketplace.firefox.com</li>
-          	<li>receiptcheck.marketplace.firefox.com</li>
-          	<li>Static.marketplace.firefox.com</li>
-          </ul>
-
-          <h4>Observatory</h4>
-          <ul>
-            <li>http-observatory.security.mozilla.org</li>
-            <li>observatory.mozilla.org</li>
-          </ul>
-
-          <h4>Push</h4>
-          <ul>
-          	<li>push.services.mozilla.com</li>
-          	<li>Updates.push.services.mozilla.com</li>
-          </ul>
-
-          <h4>Telemetry</h4>
-          <ul>
-          	<li>incoming.telemetry.mozilla.org</li>
-          	<li>telemetry-experiment.cdn.mozilla.net</li>
-          	<li>analysis.telemetry.mozilla.org</li>
-          	<li>sql.telemetry.mozilla.org</li>
-          	<li>Metrics.services.mozilla.com</li>
-          </ul>
-
-          <h4>Test Pilot</h4>
-          <ul>
-          	<li>testpilot.firefox.com</li>
-          </ul>
-
-          <h4>Tiles</h4>
-          <ul>
-          	<li>tiles.cdn.mozilla.net</li>
-          	<li>tiles.services.mozilla.com</li>
-          </ul>
-
-          <h4>Tracking Protection</h4>
-          <ul>
-          	<li>shavar.services.mozilla.com</li>
-          	<li>tracking.services.mozilla.com</li>
-          </ul>
-
-          <p>The Mozilla Developer Network (developer.mozilla.org) and wiki.mozilla.org have been removed from this
-            list due to site vandalism by researchers looking for security issues. They will be
-            added back at a later date when a test server is deployed to avoid negative impacts
-            on our primary reference site.</p>
-
-          <p>Only Mozilla websites and services are in scope. Issue categories explicitly excluded
-            from eligibility include denial of service attacks, email phishing attacks
-            against employees, our offices, etc. Additionally, flaws relying on out-of-date
-            browsers, plugins, or add-ons, which require extremely unlikely/unusual user
-            interaction, and banner and version information are generally not eligible.</p>
-        </dd>
-
-        <dt class="question" id="sites-not-listed">What about sites which are not
-          listed?</dt>
-        <dd class="answer">
-          <p>If you find an issue with a site which is not “officially” part under the
-            website and services bug bounty program, we would still like to know. If the bug is
-            extraordinary, we might still consider the bug to be nominated for a bounty. In
-            the past we have paid for interesting bugs which are outside of normal
-            policy, but it’s the rare exception and not the rule. It's hard to define “extraordinary”,
-            since by definition there are no common examples.
-            If you are searching security issues for the joy of it or to help the Mozilla project,
-            we would appreciate reports on non-eligible sites.
-            If you are looking for bug bounties, focus on the sites listed as eligible, don’t hunt for
-            “extraordinary” bugs on sites not listed in thie FAQ.
-            .</p>
-        </dd>
-
-        <dt class="question" id="issues">What types of issues will be considered
-          as part of the bounty program?</dt>
-        <dd class="answer">
-          <p>While there are many types of web vulnerabilities, the list below directly
-            affects our users and our infrastructure. These are just a few examples.</p>
-          <ul>
-            <li>Cross-site request forgery</li>
-            <li>Mixed-content scripts</li>
-            <li>Authentication or authorization flaws</li>
-            <li>Server-side code execution bugs</li>
-            <li>Cross-site scripting bugs (XSS) other than self-XSS</li>
-            <li>Remote File Include (RFI)</li>
-            <li>Local File Include (LFI)</li>
-            <li>Injection issues and logic bugs with a demonstrated Medium to higher security impact. Example: A bug that leaks user email addresses intended to remain private qualifies. Being able to change an inconsequential piece of data associated with a user where there is no other demonstrated security issue and/or zero to low impact does not.</li>
-          </ul>
-          <p>We generally consider HTML and text injection to be low-risk and thus not bounty-eligible.</p>
-          <p>Redirect issues are generally ineligible unless they can be used as part of a more significant attack such as CRLF injection or XSS.</p>
-          <p>The <a href="https://wiki.mozilla.org/WebAppSec/Web_App_Severity_Ratings">
-              Web Application Severity Ratings</a> explains how Mozilla measures website and
-              service security risk. Medium, High, and Critical issues reported are eligible
-              for bounties when confirmed.</p>
-        </dd>
-
-        <dt class="question" id="dos-bugs">Why won’t you provide a reward
-          for denial of service bugs?</dt>
-        <dd class="answer">
-          <p>Because DoS bugs are generally less serious than other web application
-            security bugs and in many cases a DoS doesn’t need to involve a technical
-            vulnerability within a web application. We have decided to concentrate our
-            resources on rewarding people who find what we consider to be more
-            serious security problems.</p>
-        </dd>
-      </dl>
+      <h4 id="dos-bugs">Why don’t you provide a reward for denial-of-service bugs?</h4>
+      <p>Denial-of-services bugs are generally less serious than other web application
+        security bugs and in many cases don't require a technical vulnerability
+        within the web application.</p>
 
       <h2>Bug reporting</h2>
-      <dl class="faq">
-        <dt class="question" id="what-next">Once I have found a
-          vulnerability, what next?</dt>
-        <dd class="answer">
-          <p>
-            <strong>Follow the <a href="{{ url('security.web-bug-bounty') }}">guide on submitting a web or service security bug</a> and then
-            <a href="https://bugzilla.mozilla.org/form.web.bounty">file a bug</a>.</strong>
-            When filing, please verify that you have followed the guidance on how to
-            write your report in order to assure it is evaluated as quickly as possible.
-            Repeat the attack using only your own description in order to prevent
-            errors and omissions, then update your documentation to be submitted.
-            <strong>Please do not ever submit website vulnerabilities via email.</strong>
-            <i>Bounty award amount is dependent on following the bug submission instructions. 
-            To summarize: Write step-by-step instructions, follow them again yourself with zero-knowledge
-            to verify completeness, and describe the impact of the attack. Please do not send links to videos.</i>
-          </p>
-        </dd>
 
-        <dt class="question" id="nondisclosure">If I report the bug
-          directly to you, do I have to keep the bug confidential and not publish
-          information about it in order to receive a reward?</dt>
-        <dd class="answer">
-          <p>No. We’re rewarding you for finding a bug, not trying to buy
-            your silence. However if you report the bug through the standard
-            Mozilla process and haven’t already published information about it then
-            we do ask that you follow the guidelines set forth in the official
-            policy on
-            <a href="{{ url('mozorg.about.governance.policies.security.bugs') }}">handling Mozilla security bugs</a>.
-            Under this policy security-sensitive bug reports in our Bugzilla system
-            may be kept private for a limited period of time to give us a chance to
-            fix the bug before the bug is made public, with an option for the bug reporter
-            (or others) to open the bug to public view earlier whenever circumstances
-            warrant it (e.g., if you feel your bug report is being completely ignored).
-            However, in the interest of protecting our users, we would appreciate a
-            reasonable amount of time to address the issue before the information is
-            publicly disclosed.</p>
-        </dd>
+      <h4 id="nondisclosure">If I report the bug
+        directly to you, do I have to keep the bug confidential to receive a bounty?</h4>
+      <p>
+        We’re rewarding you for finding a bug, not trying to buy
+        your silence. However, if you report the bug through the standard
+        Mozilla process and haven’t already published information about it then
+        we do ask that you keep the bug private for a limited period of time to
+        give us a chance to fix the bug before the bug is made public.
+      </p>
 
-        <dt class="question" id="cooperation">I don’t have the time or
-          desire to work with you further in investigating and fixing the bug;
-          can I still get a bug bounty reward?</dt>
-        <dd class="answer">
-          <p>Yes. Again, we’re rewarding you for finding a bug, not trying to
-            buy your cooperation. However we do invite you to work together with
-            us, and we hope that you’ll accept that offer in the spirit in which it
-            was intended. In return you’ll get the opportunity to work as a full
-            member of the team fixing your bug and see “from the inside” exactly
-            how Mozilla security bugs get resolved.</p>
-        </dd>
-      </dl>
+      <p>
+        Bug reporters may open the bug to public view earlier whenever circumstances
+        warrant it (e.g., if you feel your bug report is being completely ignored).
+        However, in the interests of protecting our users, we would appreciate a
+        reasonable amount of time to address the issue before the information is
+        publicly disclosed.
+      </p>
+
+      <h4 id="cooperation">If I don’t have the time to assist you further, can I still receive a
+          bug bounty?</h4>
+      <p>We’re rewarding you for finding a bug, not trying to buy your cooperation.</p>
+      <p>
+        However, we do invite you to work together with
+        us, and we hope that you’ll accept that offer in the spirit in which it
+        was intended. In return, you’ll get the opportunity to work as a full
+        member of the team and see exactly how Mozilla security
+        bugs are resolved.
+      </p>
+
+      <h4 id="attack-scenario">What does a valid attack scenario look like?</h4>
+      <p>
+        Please describe how an attacker would use the bug you
+        are submitting, any necessary conditions for it to work, and what the attacker
+        would gain through a successful attack.
+      </p>
+
+      <p>Please answer the following questions to the best of your ability:</p>
+
+      <ol>
+        <li>What is the necessary position of the attacker?
+          <ul>
+            <li>Do you need to be logged in or unauthenticated?</li>
+            <li>Do certain cookies need to be set?</li>
+            <li>Do you need to connect from a specific system?</li>
+          </ul>
+        </li>
+
+        <li>Are there any other assumptions that must be made about the victim?
+          <ul>
+            <li>Do they need to be running a specific web browser?</li>
+            <li>Does the victim need to be tricked into clicking on a specific link?</li>
+            <li>Does the user need to be a member of a specific group?</li>
+          </ul>
+        </li>
+
+        <li>How might a malicious actor use this attack?
+          <ul>
+            <li>Stealing a victim's session information</li>
+            <li>Redirect users to malicious websites</li>
+            <li>Read files on server outside the web root</li>
+            <li>Executing remote OS commands</li>
+            <li>XSSing users</li>
+          </ul>
+        </li>
+      </ol>
+
+      <h4 id="step-by-step-exploit">What does a valid step-by-step exploit process look like?</h4>
+      <p>Please describe the process required, step-by-step, in the proper order.
+         If there are multiple parties involved, please describe them all clearly. For example:</p>
+
+      <ol>
+        <li>Visit <code>https://shop.firefox.com/order?name=value&amp;name2=value2</code></li>
+        <li>Click the "Log in" link and login</li>
+        <li>Click the "Order" button</li>
+        <li>Place order for "Firefox Plush"
+        <li>Continue navigation to the Shipping Address page</li>
+        <li>Add the following payload <code>"&gt;&lt;img src=x onerror=alert(document.domain);// &gt;</code> into the "City" field, then click Submit</li>
+        <li>The XSS payload ends up in the <code>POST</code> parameter named <code>city_order</code></li>
+        <li>Visitors to the page <code>/past_orders_by_city</code> are affected by stored XSS</li>
+      </ol>
+
+      <p>Include the HTTP request(s), any necessary header values and/or <code>POST</code> parameters along with your bug submission.</p>
+      <p>Once you have <em>written</em> your step-by-step instructions, repeat the attack by following
+        them exactly. This helps prevent errors and omissions in your submission.</p>
+
+      <h4 id="xss-reporting">How should I report an XSS vulnerability?</h4>
+      <p>For a reflected XSS vulnerabilities, the affected URL along with a working payload is usually sufficient.
+      For stored XSS attacks, please describe the step-by-step exploit process, as above.</p>
+      <p>Please use <code>alert(document.domain)</code> and not <code>alert(1)</code> in your proof-of-concept.</p>
+      <p>Self-XSSes &mdash; where the attacker tricks users into copying and pasting malicious script content &mdash; are not eligible for bounties.</p>
+
     </div>
   </article>
 {% endblock %}

--- a/bedrock/security/templates/security/bug-bounty/faq.html
+++ b/bedrock/security/templates/security/bug-bounty/faq.html
@@ -1,6 +1,8 @@
 {% extends "security/base.html" %}
 
 {% block page_title %}Mozilla Security Bug Bounty Program{% endblock %}
+{% set body_id = "faq" %}
+
 
 {% block breadcrumbs %}
   <nav class="breadcrumbs">

--- a/bedrock/security/templates/security/bug-bounty/hall-of-fame.html
+++ b/bedrock/security/templates/security/bug-bounty/hall-of-fame.html
@@ -1,6 +1,7 @@
 {% extends "security/base.html" %}
 
 {% block page_title %}Mozilla Security Bug Bounty Program Hall of Fame{% endblock %}
+{% set body_id = "hall-of-fame" %}
 
 {% block breadcrumbs %}
   <nav class="breadcrumbs">

--- a/bedrock/security/templates/security/bug-bounty/web-eligible-sites.html
+++ b/bedrock/security/templates/security/bug-bounty/web-eligible-sites.html
@@ -1,0 +1,190 @@
+{% extends "security/base.html" %}
+
+{% block page_title %}Mozilla Web Application Security Bug Bounty FAQ{% endblock %}
+{% set body_id = "web-eligible-sites" %}
+
+
+{% block breadcrumbs %}
+  <nav class="breadcrumbs">
+    <a href="{{ url('mozorg.home') }}">{{ _('Home') }}</a> &gt;
+    <a href="{{ url('security.index') }}">{{ _('Mozilla Security') }}</a> &gt;
+    <a href="{{ url('security.bug-bounty') }}">{{ _(' Bug Bounty ') }}</a> &gt;
+  </nav>
+{% endblock %}
+
+{% block article %}
+  <article class="section-content" itemscope itemtype="http://schema.org/Article">
+    <header>
+      <h1 itemprop="name" class="title-shadow-box">Eligible Websites &amp; Services</h1>
+    </header>
+
+    <div itemprop="articleBody">
+      <h2>
+        <strong id="critical-sites">Critical</strong>
+      </h2>
+
+      <p>These websites and services are considered critical to Mozilla operations and pay out at the highest bounty rate.</p>
+      <h4>ABSearch</h4>
+      <ul>
+        <li>search.services.mozilla.com</li>
+      </ul>
+
+      <h4>Add-ons</h4>
+      <ul>
+        <li>addons.cdn.mozilla.net</li>
+        <li>addons.mozilla.org</li>
+        <li>blocklist.addons.mozilla.org</li>
+        <li>builder.addons.mozilla.org</li>
+        <li>compatibility-lookup.services.mozilla.com</li>
+        <li>discovery.addons.mozilla.org</li>
+        <li>services.addons.mozilla.org</li>
+        <li>static.addons.mozilla.net</li>
+        <li>versioncheck-bg.addons.mozilla.org</li>
+        <li>versioncheck.addons.mozilla.org</li>
+      </ul>
+
+      <h4>Bedrock (www)</h4>
+      <ul>
+        <li>www.firefox.com</li>
+        <li>www.getfirefox.com</li>
+      	<li>www.mozilla.com</li>
+      	<li>www.mozilla.org</li>
+      </ul>
+
+      <h4>Bugzilla</h4>
+      <ul>
+        <li>bugzilla.mozilla.org</li>
+        <li>*.bmoattachments.org (excludes XSS and open redirects)</li>
+      </ul>
+      <p>
+        <strong>Please do not use automated scanners, create, or modify bugs when testing Bugzilla.</strong>
+        <br>Instead, install your own local copy for testing from <a href="https://github.com/mozilla/webtools-bmo-bugzilla">webtools-bmo-bugzilla</a>.
+      </p>
+
+      <h4>Crash Reports</h4>
+      <ul>
+        <li>crash-reports.mozilla.com</li>
+        <li>crash-reports-xpsp2.mozilla.com</li>
+        <li>crash-stats.mozilla.com</li>
+      </ul>
+
+      <h4>Downloads (Product Delivery)</h4>
+      <ul>
+        <li>archive.mozilla.org</li>
+        <li>download.mozilla.org</li>
+      </ul>
+
+      <h4>Firefox Accounts</h4>
+      <ul>
+        <li>accounts.firefox.com</li>
+        <li>api.accounts.firefox.com</li>
+        <li>oauth.accounts.firefox.com</li>
+        <li>profile.accounts.firefox.com</li>
+        <li>verifier.accounts.firefox.com</li>
+      </ul>
+
+      <h4>Firefox Settings (Kinto)</h4>
+      <ul>
+        <li>firefox.settings.services.mozilla.com</li>
+        <li>webextensions.settings.services.mozilla.com</li>
+      </ul>
+
+      <h4>Firefox Sync</h4>
+      <ul>
+        <li>*.sync.services.mozilla.com</li>
+        <li>token.services.mozilla.com</li>
+      </ul>
+
+      <h4>Firefox Updates (AUS/Balrug)</h4>
+      <ul>
+        <li>aus3.mozilla.org</li>
+        <li>aus4.mozilla.org</li>
+        <li>aus5.mozilla.org</li>
+      </ul>
+
+      <h4>Push</h4>
+      <ul>
+        <li>push.services.mozilla.com</li>
+        <li>updates.push.services.mozilla.com</li>
+      </ul>
+
+      <h4>Shield</h4>
+      <ul>
+        <li>self-repair.mozilla.org</li>
+      </ul>
+
+      <h4>Source Control</h4>
+      <ul>
+        <li>hg.mozilla.org (excludes website)</li>
+      </ul>
+
+      <h4>Test Pilot</h4>
+      <ul>
+        <li>testpilot.firefox.com</li>
+      </ul>
+
+      <h4>Tracking Protection</h4>
+      <ul>
+        <li>shavar.services.mozilla.com</li>
+        <li>tracking.services.mozilla.com</li>
+      </ul>
+
+      <h2>
+        <strong id="core-sites">Core</strong>
+      </h2>
+      <p>Core websites pay out bounties, but at a reduced rate.</p>
+
+      <h4>Internal</h4>
+      <ul>
+        <li>login.mozilla.com</li>
+        <li>mana.mozilla.org</li>
+        <li>phonebook.mozilla.org</li>
+      </ul>
+
+      <h4>Observatory</h4>
+      <ul>
+        <li>http-observatory.security.mozilla.org</li>
+        <li>observatory.mozilla.org</li>
+        <li>tls-observatory.services.mozilla.com</li>
+      </ul>
+
+      <h4>Shield</h4>
+      <ul>
+        <li>qsurvey.mozilla.com</li>
+      </ul>
+
+      <h4>Source Control</h4>
+      <ul>
+        <li>hg.mozilla.org (website)</li>
+      </ul>
+
+      <h4>Taskcluster</h4>
+      <ul>
+        <li>auth.taskcluster.net</li>
+        <li>aws-provisioner.taskcluster.net</li>
+        <li>cloud-mirror.taskcluster.net</li>
+        <li>cors-proxy.taskcluster.net</li>
+        <li>docs.taskcluster.net</li>
+        <li>events.taskcluster.net</li>
+        <li>github.taskcluster.net</li>
+        <li>grafana.taskcluster.net</li>
+        <li>hooks.taskcluster.net</li>
+        <li>index.taskcluster.net</li>
+        <li>login.taskcluster.net</li>
+        <li>loop.telemetry.mozilla.org</li>
+        <li>notify.taskcluster.net</li>
+        <li>public-artifacts.taskcluster.net</li>
+        <li>pulse.taskcluster.net</li>
+        <li>purge-cache.taskcluster.net</li>
+        <li>queue.taskcluster.net</li>
+        <li>references.taskcluster.net</li>
+        <li>scheduler.taskcluster.net</li>
+        <li>schemas.taskcluster.net</li>
+        <li>secrets.taskcluster.net</li>
+        <li>statsum.taskcluster.net</li>
+        <li>taskcluster.net</li>
+        <li>tools.taskcluster.net</li>
+      </ul>
+    </div>
+  </article>
+{% endblock %}

--- a/bedrock/security/templates/security/bug-bounty/web-eligible-sites.html
+++ b/bedrock/security/templates/security/bug-bounty/web-eligible-sites.html
@@ -58,7 +58,7 @@
       </ul>
       <p>
         <strong>Please do not use automated scanners, create, or modify bugs when testing Bugzilla.</strong>
-        <br>Instead, install your own local copy for testing from <a href="https://github.com/mozilla/webtools-bmo-bugzilla">webtools-bmo-bugzilla</a>.
+        <br><br>Instead, install your own local copy for testing from <a href="https://github.com/mozilla/webtools-bmo-bugzilla">webtools-bmo-bugzilla</a> or use our <a href="https://bugzilla-dev.allizom.org/">development instance</a>.
       </p>
 
       <h4>Crash Reports</h4>

--- a/bedrock/security/templates/security/bug-bounty/web-hall-of-fame.html
+++ b/bedrock/security/templates/security/bug-bounty/web-hall-of-fame.html
@@ -1,6 +1,7 @@
 {% extends "security/base.html" %}
 
 {% block page_title %}Mozilla Security Web and Services Bug Bounty Program Hall of Fame{% endblock %}
+{% set body_id = "web-hall-of-fame" %}
 
 {% block breadcrumbs %}
   <nav class="breadcrumbs">
@@ -28,7 +29,7 @@
 
       <p>On behalf of the Mozilla and the millions of people who visit our sites, use Firefox and our other products we would like to thank them for their hard work in helping to make us more secure.</p>
 
-      <p>As of this date, we have paid out almost <b>$1,000,000</b> across all of our bounties. Congratulations to everybody who has participated!</p>
+      <p>As of this date, we have paid out over <b>$1,600,000</b> across all of our bounties. Congratulations to everybody who has participated!</p>
 
       <div class="accordion accordion-auto-init zebra">
 

--- a/bedrock/security/templates/security/client-bug-bounty.html
+++ b/bedrock/security/templates/security/client-bug-bounty.html
@@ -1,7 +1,7 @@
 {% extends "security/base.html" %}
 
 {% block page_title %}Mozilla Security Bug Bounty Program{% endblock %}
-{% set body_id = "bug-bounty" %}
+{% set body_id = "client-bug-bounty" %}
 
 {% block article %}
   <article class="section-content" itemscope itemtype="http://schema.org/Article">
@@ -91,7 +91,7 @@
           <li>When creating the bug, be sure to check the box near the bottom of the entry form that marks this bug report as confidential.</li>
           <li>Attach a "proof of concept" testcase, or point to explicit code that identifies the vulnerability or exploit.  While not required, such a testcase will help us judge submissions more quickly and accurately.</li>
           <li>If you have debug output or output from a tool demonstrating the issue, please include it in the bug. (If it is very long, please attach it to the bug as an attached file.)</li>
-          <li>Notify the Mozilla Security Group by email to security@mozilla.org and include the number of the bug you filed and a brief summary of the issue.</li>
+          <li>Notify the Mozilla Security Group by email to security@mozilla.org and include the number of the bug you filed and a brief summary of the issue. <strong>Do not send the actual vulnerability via email.</strong></li>
     </ul>
 
     <p>We ask that you be available to follow along and provide further information on the bug as needed, and invite you to work together with Mozilla engineers in reproducing, diagnosing, and fixing the bug. As part of this process we will provide you full access to participate in our internal discussions about the bug; for more information read our policy for handling security bugs.</p>

--- a/bedrock/security/templates/security/web-bug-bounty.html
+++ b/bedrock/security/templates/security/web-bug-bounty.html
@@ -1,7 +1,7 @@
 {% extends "security/base.html" %}
 
 {% block page_title %}Mozilla Security Bug Bounty Program{% endblock %}
-{% set body_id = "bug-bounty" %}
+{% set body_id = "web-bug-bounty" %}
 
 {% block article %}
   <article class="section-content" itemscope itemtype="http://schema.org/Article">
@@ -12,99 +12,140 @@
     <div itemprop="articleBody">
       <h2>Introduction</h2>
 
-      <p>The Mozilla Web Application Security Bug Bounty Program is designed to encourage security research in Mozilla websites and services  and to reward those who help us protect Mozilla users data.</p>
+      <p>The Mozilla Bug Bounty Program is designed to encourage security research into Mozilla's websites and services and to reward those who help protect our users and infrastructure.</p>
 
-      <h2>General Bounty Guidelines</h2>
+      <h2>Eligibility</h2>
 
-      <p>Mozilla will pay a bounty for certain website and service security bugs, as detailed below. All security bugs must follow the following general criteria to be eligible:</p>
+      <p>All security bugs must follow the following general criteria to be eligible:</p>
 
       <ul>
         <li>Security bug must be original and previously unreported.</li>
-        <li>Security bug must be a remote exploit, compromise user data, allow access to Mozilla infrastructure or resources, or easily manipulate a user.</li>
-        <li>Submitter must not be the author of the buggy code nor otherwise involved in its contribution to the Mozilla project (such as by providing check-in reviews).</li>
+        <li>Submitter must not be the author of the buggy code nor otherwise involved in its contribution to the Mozilla project.</li>
         <li>Employees of the Mozilla Foundation and its subsidiaries are ineligible.</li>
-        <li>Community volunteer members involved with bug handling/who have security bug access are not eligible during their period of involvement.</li>
+        <li>Community volunteer members involved with bug handling or who have security bug access are not eligible during their period of involvement.</li>
       </ul>
 
-      <p>If two or more people report the bug together, or working independently at approximately the same time, the reward will be divided between them.</p>
+      <p>If a bug is reported by a team or by multiple researchers simultaneously, the bounty will be split evenly amongst them.</p>
 
-      <h2>How To Submit Bugs</h2>
+      <h2 id="payouts-section">Payouts</h2>
 
-      <p>The sooner we can reproduce and fix the bug, the sooner we can validate it, fix it, and send your reward.</p>
+      <table id="payouts">
+        <thead>
+          <tr>
+            <th>Bug Classification</th>
+            <th><a href="{{ url('security.bug-bounty.web-eligible-sites') }}#critical-sites">Critical sites</a></th>
+            <th><a href="{{ url('security.bug-bounty.web-eligible-sites') }}#core-sites">Core sites</a></th>
+            <th>Other Mozilla sites<sup>1</sup></th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Remote Code Execution</td>
+            <td>$5000</td>
+            <td>$2500</td>
+            <td>$500</td>
+          </tr>
+          <tr>
+            <td>Authentication Bypass</td>
+            <td>$3000</td>
+            <td>$1500</td>
+            <td>&nbsp;&nbsp;ACK<sup>2</sup></td>
+          </tr>
+          <tr>
+            <td>SQL Injection</td>
+            <td>$3000</td>
+            <td>$1500</td>
+            <td>ACK</td>
+          </tr>
+          <tr>
+            <td>CSRF<sup>3</sup></td>
+            <td>$2500</td>
+            <td>$1000</td>
+            <td>--</td>
+          </tr>
+          <tr>
+            <td>XSS<sup>4</sup></td>
+            <td>$2500</td>
+            <td>$1000</td>
+            <td>ACK</td>
+          </tr>
+          <tr>
+            <td>XXE</td>
+            <td>$2500</td>
+            <td>$1000</td>
+            <td>ACK</td>
+          </tr>
+          <tr>
+            <td>XSS<sup>4</sup> (blocked by CSP)</td>
+            <td>$500</td>
+            <td>ACK</td>
+            <td>--</td>
+          </tr>
+          <tr>
+            <td>Clickjacking<sup>5</sup></td>
+            <td>$500</td>
+            <td>$250</td>
+            <td>--</td>
+          </tr>
+          <tr>
+            <td>Open Redirects</td>
+            <td>ACK</td>
+            <td>ACK</td>
+            <td>ACK</td>
+          </tr>
+        </tbody>
+      </table>
 
-      <p>We prefer to receive bug reports in English. If English is not your native language and you are not fluent, Mozilla has employees and volunteers from all over the world who can help. If necessary, please write bug reports in your native language rather than using automated translation software. Automated translation software tends to mangle technical descriptions in indecipherable way.</p>
+      <ol>
+        <li>Excludes community websites</li>
+        <li>Acknowledgement on our 
+          <a href="{{ url('security.bug-bounty.web-hall-of-fame') }}">hall of fame</a>
+        </li>
+        <li>Significant actions only, such as changing email/passwords, deleting accounts, etc.</li>
+        <li>Excludes self-XSS</li>
+        <li>Lack of clickjacking protection (XFO, CSP) is insufficient to claim a bounty</li>
+      </ol>
+
+
+      <h2>Exclusions</h2>
+      <p>Although we still appreciate being notified about them, the following issues fall outside the scope of our bug bounty program:
+
+      <ul>
+        <li>Self-XSS</li>
+        <li>Executing scripts on sandboxed domains (such as bmoattachments or mozillademos)</li>
+        <li>CSRF for non-significant actions (logout, etc.)</li>
+        <li>Clickjacking attacks without a documented series of clicks that produce a vulnerability</li>
+        <li>Spam (including issues related to SPF/DKIM/DMARC)</li>
+        <li>Denial-of-service attacks or issues related to rate limiting</li>
+        <li>Attacks that require social engineering (phishing)</li>
+        <li>Content injection, such as reflected text or HTML tags</li>
+        <li>Missing HTTP headers, except as where their absence fails to mitigate an existing attack</li>
+        <li>Authentication bypasses that require access to software/hardware tokens</li>
+        <li>Vulnerabilities that only affect users with outdated browsers</li>
+        <li>Vulnerabilities that require access to passwords, tokens, or the local system (e.g. session fixation)</li>
+        <li>Assumed vulnerabilities based upon version numbers only</li>
+        <li>Source code disclosures, as most of our code is open source</li>
+        <li>Vulnerabilities discovered shortly after their public release</li>
+        <li>Outdated TLS configurations which remain to support downloads from Windows XP systems</li>
+      </ul>
+
+
+      <h2 id="how-to-submit-bugs">How To Submit Bugs</h2>
+
+      <p>The sooner we can reproduce and fix the bug, the sooner we can fix it and send you your bounty. Please submit all bugs through the <a href="https://bugzilla.mozilla.org/form.web.bounty">Bugzilla web bounty form</a>. <strong>Do not send vulnerabilities
+      via email and please avoid using video.</strong></p>
 
       <p>There are three main things you can provide which will help us to evaluate your submission quickly and pay a bounty sooner:</p>
 
       <ol>
-        <li>What is the attack scenario?</li>
-        <li>What is the step-by-step exploit process?</li>
+        <li><a href="{{ url('security.bug-bounty.faq-webapp') }}#attack-scenario">What is the attack scenario?</a></li>
+        <li><a href="{{ url('security.bug-bounty.faq-webapp') }}#step-by-step-exploit">What is the step-by-step exploit process?</a></li>
         <li>What is the security impact?</li>
       </ol>
       
-      <p>Please submit all bugs through the <a href="https://bugzilla.mozilla.org/form.web.bounty">Bugzilla web bounty form.</a> Do not submit bugs by email.</p>
+      <p>Once you have <em>written</em> your step-by-step instructions, repeat the attack by following them exactly. This helps prevent errors and omissions in your submission.</p>
 
-      <h3>What is the attack scenario?</h3>
-
-      <p>For the attack scenario, please describe how an attacker would use the bug you are submitting, any necessary conditions for it to work, and what the attacker would gain through successful attack. Please answer the following questions to the best of your ability:</p>
-
-      <ol>
-        <li>What is the necessary position of the attacker? (Example: Logged in to x website, unauthenticated, etc.)</li>
-        <li>Are there any other assumptions that must be made about the victim? (Example: only affects specific web browser versions, requires that the user can be tricked into clicking on a link, etc. </li>
-        <li>How might a malicious actor use this attack? (Example: Steal victim’s cookies, redirect to malicious website, read files on server outside web root, remote OS command injection, XSS users, etc.)</li>
-      </ol>
-
-      <h3>What is the step-by-step exploit process?</h3>
-
-      <p>Please describe the multi-step process required, step by step, in the right order. If there are multiple parties involved, please describe them all clearly. For example:</p>
-
-      <blockquote>
-        <ol>
-          <li>Visit the url https://xyz.firefox.com/somepage/form?name=value&amp;name2=value2</li>
-          <li>Log in</li>
-          <li>Click the “Frobozz” button</li>
-          <li>Place order for “Anti-Grue Cream” to shipping location “small mailbox,” continue navigation to the Shipping Address page.</li>
-          <li>Add the following payload <code>"&gt;&lt;img src=x onerror=alert(document.domain);// &gt;</code> into the “City” field, then click Submit.</li>
-          <li>The XSS payload ends up in the POST parameter name d oddly_angled_room</li>
-          <li>Visitors to the page /puzzles are affected by stored XSS</li>
-        </ol>
-      </blockquote>
-
-      <p>Include the HTTP request(s) including any necessary header values and POST parameters with your bug submission.</p>
-
-      <p>Please avoid videos. They take time to create and much more time for us to interpret.</p>
-
-      <p>Repeat the attack using only your own description in order to prevent errors and omissions, update documentation.</p>
-
-      <h3>XSS reporting tips</h3>
-
-      <ul>
-        <li>For a reflected XSS vulnerability, the affected URL with a working payload is usually sufficient. Please use <code>alert(document.domain)</code> and not <code>alert(1)</code> in your POC.</li>
-        <li>For any XSS vulnerability, please make sure to write down the attack scenario, which is different than the step-by-step exploit process. Where would the attacker have to be positioned in order to get the victim to trigger the exploit? What action would the victim need to follow? What would be the impact?</li>
-        <li>Self-XSS, where the attacker tricks users into copying and pasting malicious script content or other content into their browser, is not eligible for the Bug Bounty program.</li>
-      </ul>
-
-      <h2>Reward Guidelines</h2>
-
-      <p>Mozilla will pay a bounty for website and service security bugs as detailed below. All security bugs must follow the following general criteria to be eligible:</p>
-
-      <ul>
-        <li>Eligible security bugs may be present in any of eligible sites or services as outlined in the <a href="{{ url('security.bug-bounty.faq-webapp') }}">Web Application Security Bounty FAQ</a>.</li>
-        <li>The security rating given by the Bounty Committee for a bug must be “sec-critical”, “sec-high” or “sec-moderate” in order for it to be eligible for a bounty. (See <a href="https://wiki.mozilla.org/WebAppSec/Web_App_Severity_Ratings">Web App Ratings</a> for details of the rating qualifications.)</li>
-        <li>All bounties paid will be at the discretion of the Mozilla Bounty Committee, which will evaluate the severity of reported issues with the help of engineers who work on the affected code. Security researchers are invited to participate in the assignment of ratings, but final decisions on the rating are at the discretion of the Bounty Committee.</li>
-      </ul>
-
-      <h2>Rewards Amounts</h2>
-
-      <p>Vulnerabilities found in Mozilla Web applications and services are eligible for bounties between $500 (USD) and $3000 (USD), for extraordinary or critical vulnerabilities in valid web applications or Mozilla services. Rewards for some critical sites can be even higher (e.g. FxAccounts, FindMyDevice, Update Services, Bugzilla)</p>
-
-      <p>Bounties will be awarded for sec-critical, sec-high, or sec-moderate rated security bugs that meet the following criteria:</p>
-
-      <ul>
-        <li>Security bug is on the list of sites which part of the bounty. See the eligible bugs section of the <a href="{{ url('security.bug-bounty.faq-webapp') }}">Web Application Security Bounty FAQ</a> for the list of sites which are included under the bounty.</li>
-        <li>More information about this program can be found in the <a href="{{ url('security.bug-bounty.faq-webapp') }}">Web Application Security Bounty FAQ</a>.</li>
-        <li>The risk determination and bounty reward are based on the sole determination of the bounty committee after analysis of the bug, its impact, the difficulty of successful exploitation, and the resource impacted.</li>
-      </ul>
+      <p>We prefer to receive bug reports in English. If English is not your native language and you are not fluent, please submit bugs in your native language. Please note that this may delay our response time.</p>
     </div>
   </article>
 {% endblock %}

--- a/bedrock/security/templates/security/web-bug-bounty.html
+++ b/bedrock/security/templates/security/web-bug-bounty.html
@@ -107,7 +107,7 @@
       </ol>
 
 
-      <h2>Exclusions</h2>
+      <h2 id="exclusions">Exclusions</h2>
       <p>Although we still appreciate being notified about them, the following issues fall outside the scope of our bug bounty program:
 
       <ul>

--- a/bedrock/security/templates/security/web-bug-bounty.html
+++ b/bedrock/security/templates/security/web-bug-bounty.html
@@ -12,20 +12,7 @@
     <div itemprop="articleBody">
       <h2>Introduction</h2>
 
-      <p>The Mozilla Bug Bounty Program is designed to encourage security research into Mozilla's websites and services and to reward those who help protect our users and infrastructure.</p>
-
-      <h2>Eligibility</h2>
-
-      <p>All security bugs must follow the following general criteria to be eligible:</p>
-
-      <ul>
-        <li>Security bug must be original and previously unreported.</li>
-        <li>Submitter must not be the author of the buggy code nor otherwise involved in its contribution to the Mozilla project.</li>
-        <li>Employees of the Mozilla Foundation and its subsidiaries are ineligible.</li>
-        <li>Community volunteer members involved with bug handling or who have security bug access are not eligible during their period of involvement.</li>
-      </ul>
-
-      <p>If a bug is reported by a team or by multiple researchers simultaneously, the bounty will be split evenly amongst them.</p>
+      <p>The Mozilla Bug Bounty Program is designed to encourage security research into Mozilla's websites and services and to reward those who find unique and original bugs in our web infrastructure.</p>
 
       <h2 id="payouts-section">Payouts</h2>
 
@@ -46,16 +33,16 @@
             <td>$500</td>
           </tr>
           <tr>
-            <td>Authentication Bypass</td>
+            <td>Authentication Bypass<sup>2</sup></td>
             <td>$3000</td>
             <td>$1500</td>
-            <td>&nbsp;&nbsp;ACK<sup>2</sup></td>
+            <td><a href="{{ url('security.bug-bounty.web-hall-of-fame') }}">HoF</a></td>
           </tr>
           <tr>
             <td>SQL Injection</td>
             <td>$3000</td>
             <td>$1500</td>
-            <td>ACK</td>
+            <td><a href="{{ url('security.bug-bounty.web-hall-of-fame') }}">HoF</a></td>
           </tr>
           <tr>
             <td>CSRF<sup>3</sup></td>
@@ -67,44 +54,57 @@
             <td>XSS<sup>4</sup></td>
             <td>$2500</td>
             <td>$1000</td>
-            <td>ACK</td>
+            <td><a href="{{ url('security.bug-bounty.web-hall-of-fame') }}">HoF</a></td>
           </tr>
           <tr>
             <td>XXE</td>
             <td>$2500</td>
             <td>$1000</td>
-            <td>ACK</td>
+            <td><a href="{{ url('security.bug-bounty.web-hall-of-fame') }}">HoF</a></td>
           </tr>
           <tr>
-            <td>XSS<sup>4</sup> (blocked by CSP)</td>
+            <td>Domain Takeovers</td>
+            <td>$2500</td>
+            <td>$1000</td>
+            <td>$250/$100<sup>5</sup></td>
+          </tr>
+          <tr>
+            <td>XSS (minor)</td>
+            <td>$1000</td>
             <td>$500</td>
-            <td>ACK</td>
+            <td><a href="{{ url('security.bug-bounty.web-hall-of-fame') }}">HoF</a></td>
+          </tr>
+          <tr>
+            <td>XSS (blocked by CSP)</td>
+            <td>$500</td>
+            <td><a href="{{ url('security.bug-bounty.web-hall-of-fame') }}">HoF</a></td>
             <td>--</td>
           </tr>
           <tr>
-            <td>Clickjacking<sup>5</sup></td>
+            <td>Clickjacking<sup>6</sup></td>
             <td>$500</td>
             <td>$250</td>
             <td>--</td>
           </tr>
           <tr>
             <td>Open Redirects</td>
-            <td>ACK</td>
-            <td>ACK</td>
-            <td>ACK</td>
+            <td><a href="{{ url('security.bug-bounty.web-hall-of-fame') }}">HoF</a></td>
+            <td><a href="{{ url('security.bug-bounty.web-hall-of-fame') }}">HoF</a></td>
+            <td><a href="{{ url('security.bug-bounty.web-hall-of-fame') }}">HoF</a>/--<sup>5</sup></td>
           </tr>
         </tbody>
       </table>
 
       <ol>
         <li>Excludes community websites</li>
-        <li>Acknowledgement on our 
-          <a href="{{ url('security.bug-bounty.web-hall-of-fame') }}">hall of fame</a>
-        </li>
+        <li>Includes IDORs that bypass authentication or authorization for significant actions</li>
         <li>Significant actions only, such as changing email/passwords, deleting accounts, etc.</li>
-        <li>Excludes self-XSS</li>
+        <li>Must be able to conduct significant action (i.e., not defacement, phishing, cookie injection, etc.)</li>
+        <li>For domains falling outside mozilla.org, mozilla.com, mozilla.net, or firefox.com</li>
         <li>Lack of clickjacking protection (XFO, CSP) is insufficient to claim a bounty</li>
       </ol>
+
+      <p>Any bounty that receives a payout also obtains inclusion on our <a href="{{ url('security.bug-bounty.web-hall-of-fame') }}">Hall of Fame</a>.</p>
 
 
       <h2 id="exclusions">Exclusions</h2>
@@ -146,6 +146,18 @@
       <p>Once you have <em>written</em> your step-by-step instructions, repeat the attack by following them exactly. This helps prevent errors and omissions in your submission.</p>
 
       <p>We prefer to receive bug reports in English. If English is not your native language and you are not fluent, please submit bugs in your native language. Please note that this may delay our response time.</p>
+
+      <h2>Eligibility</h2>
+
+      <p>All security bugs must follow the following general criteria to be eligible:</p>
+
+      <ul>
+        <li>Security bug must be original and previously unreported.</li>
+        <li>Submitter must not be the author of the buggy code nor otherwise involved in its contribution to the Mozilla project.</li>
+        <li>Employees of the Mozilla Foundation and its subsidiaries are ineligible.</li>
+      </ul>
+
+      <p>If a bug is reported by a team or by multiple researchers simultaneously, the bounty will be split evenly amongst them.</p>
     </div>
   </article>
 {% endblock %}

--- a/bedrock/security/templates/security/web-bug-bounty.html
+++ b/bedrock/security/templates/security/web-bug-bounty.html
@@ -100,7 +100,7 @@
         <li>Includes IDORs that bypass authentication or authorization for significant actions</li>
         <li>Significant actions only, such as changing email/passwords, deleting accounts, etc.</li>
         <li>Must be able to conduct significant action (i.e., not defacement, phishing, cookie injection, etc.)</li>
-        <li>For domains falling outside mozilla.org, mozilla.com, mozilla.net, or firefox.com</li>
+        <li>For domains falling outside *.mozilla.org, *.mozilla.com, *.mozilla.net, and *.firefox.com</li>
         <li>Lack of clickjacking protection (XFO, CSP) is insufficient to claim a bounty</li>
       </ol>
 

--- a/bedrock/security/urls.py
+++ b/bedrock/security/urls.py
@@ -24,6 +24,7 @@ urlpatterns = (
     page('bug-bounty/faq', 'security/bug-bounty/faq.html'),
     page('bug-bounty/faq-webapp', 'security/bug-bounty/faq-webapp.html'),
     page('bug-bounty/hall-of-fame', 'security/bug-bounty/hall-of-fame.html'),
+    page('bug-bounty/web-eligible-sites', 'security/bug-bounty/web-eligible-sites.html'),
     page('bug-bounty/web-hall-of-fame', 'security/bug-bounty/web-hall-of-fame.html'),
     url(r'^advisories/$',
         AdvisoriesView.as_view(), name='security.advisories'),

--- a/media/css/security/security.less
+++ b/media/css/security/security.less
@@ -380,3 +380,23 @@ p.note {
         width: @breakMobileLandscape - (@gridGutterWidth * 3);
     }
 }
+
+/* Bug bounty payouts */
+#payouts {
+    margin-bottom: 15px;
+}
+
+#payouts th {
+    .font-size(@largeFontSize);
+    padding: 10px 12px;
+}
+
+#payouts tr {
+    padding-left: 10px;
+    text-align: center;
+}
+
+#payouts tr td:first-child, #payouts tr th:first-child {
+    padding-left: 0;
+    text-align: left;
+}


### PR DESCRIPTION
## Description
This completely relaunches the Mozilla web bug bounty program.

It includes:

- Updated site lists
- Revamped navigation
- Completely rewritten documentation
- Specific payouts

And a lot more.

Could the following users please r+?
@dveditz, @jeffbryner, @jvehent, @claudijd, @rforbes, @albill

Thanks! 

## Bugzilla link

## Testing
I am having trouble running the tests locally, but I have been running it off a local bedrock instance for days without issue.

## Checklist
- [ ] Requires l10n changes.
- [ ] Related functional & integration tests passing.
