### PR TITLE
Bug 1345338 follow-up: update fallback title in firefox/channel iOS page

### DIFF
--- a/bedrock/firefox/templates/firefox/channel/ios.html
+++ b/bedrock/firefox/templates/firefox/channel/ios.html
@@ -10,7 +10,7 @@
 {% if l10n_has_tag('firefox_title_meta_bug1345338') %}
   {{ _('Try New Features in a Pre-Release iOS Browser | Firefox') }}
 {% else %}
-  {{_('Test beta versions of Firefox for iOS via Apple’s TestFlight program and help make our mobile browser for iPhone, iPad and iPod touch even better.')}}
+  {{ _('Download and test future releases of Firefox for desktop, Android and iOS.') }}
 {% endif %}
 {% endblock %}
 


### PR DESCRIPTION
Currently falling back to a description, which doesn't make sense.