### PR TITLE
Missing spaces around “—” in /foundation/advocacy/

### DIFF
--- a/bedrock/foundation/templates/foundation/advocacy.html
+++ b/bedrock/foundation/templates/foundation/advocacy.html
@@ -47,7 +47,7 @@
   </p>
   <p>
     {% trans %}
-      We also push ourselves to be proactive—setting the topic and tone of the conversation, and promoting solutions—as well as reactive to current events or undesirable policies when necessary.
+      We also push ourselves to be proactive — setting the topic and tone of the conversation, and promoting solutions — as well as reactive to current events or undesirable policies when necessary.
     {% endtrans %}
   </p>
 


### PR DESCRIPTION
## Description

Just adding missing spaces around “—”, before we start translating this page.

## Bugzilla link

N/A
