### PR TITLE
[fix bug 1354334] Fix timing for download thank-you page functional test

### DIFF
--- a/media/js/firefox/new/scene2.js
+++ b/media/js/firefox/new/scene2.js
@@ -10,6 +10,9 @@
     var $platformLink = $('#download-button-wrapper-desktop .download-list li:visible .download-link');
     var downloadURL;
 
+    // Bug 1354334 - add a hint for test automation that page has loaded.
+    $('html').addClass('download-ready');
+
     // Only auto-start the download if a visible platform link is detected.
     if ($platformLink.length) {
         downloadURL = $platformLink.attr('href');

--- a/tests/pages/firefox/new/thank_you.py
+++ b/tests/pages/firefox/new/thank_you.py
@@ -13,6 +13,13 @@ class ThankYouPage(FirefoxBasePage):
 
     _direct_download_link_locator = (By.ID, 'direct-download-link')
 
+    # Bug 1354334 - sometimes download is triggered before window.load.
+    def wait_for_page_to_load(self):
+        self.wait.until(lambda s: self.seed_url in s.current_url)
+        el = self.find_element(By.TAG_NAME, 'html')
+        self.wait.until(lambda s: 'download-ready' in el.get_attribute('class'))
+        return self
+
     @property
     def is_direct_download_link_displayed(self):
         return self.is_element_displayed(*self._direct_download_link_locator)


### PR DESCRIPTION
## Description
- Changes functional test for download page to use a custom class when DOM is ready, rather than wait for the window load event.

## Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1354334

## Testing
- I ran this branch against the full test suite and it passed: https://ci.us-west.moz.works/blue/organizations/jenkins/bedrock_multibranch_pipeline/detail/run-integration-tests/21/pipeline

## Checklist
- [ ] Requires l10n changes.
- [x] Related functional & integration tests passing.
