### PR TITLE
bug 1345622 - change privacy notice link color to not blend in with background

### DIFF
--- a/media/css/newsletter/moznewsletter-subscribe.less
+++ b/media/css/newsletter/moznewsletter-subscribe.less
@@ -224,6 +224,10 @@
     background: #fff;
     color: @textColorPrimary;
     margin-bottom: 0;
+    a:link,
+    a:visitied {
+	color: @linkBlue;
+    }
 
     h3,
     h4 {

--- a/media/css/newsletter/moznewsletter-subscribe.less
+++ b/media/css/newsletter/moznewsletter-subscribe.less
@@ -226,7 +226,7 @@
     margin-bottom: 0;
     a:link,
     a:visited {
-	color: @linkBlue;
+	    color: @linkBlue;
     }
 
     h3,

--- a/media/css/newsletter/moznewsletter-subscribe.less
+++ b/media/css/newsletter/moznewsletter-subscribe.less
@@ -225,7 +225,7 @@
     color: @textColorPrimary;
     margin-bottom: 0;
     a:link,
-    a:visitied {
+    a:visited {
 	color: @linkBlue;
     }
 


### PR DESCRIPTION
## Description
Changing the text for the privacy notice link on https://www.mozilla.org/en-US/contribute/task/stumbler/  from white (which is not visible on the white background) to black to match the accompanying text preceding it ("I’m okay with Mozilla handling my info as explained in").

## Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1345622
## Testing

## Checklist
- [ ] Requires l10n changes.
- [ ] Related functional & integration tests passing.
