### PR TITLE
Fix Bug 1355173 - Get rid of title prefix/suffix on certain Firefox pages (SEO)

### DIFF
--- a/bedrock/firefox/templates/firefox/android/index.html
+++ b/bedrock/firefox/templates/firefox/android/index.html
@@ -9,6 +9,7 @@
 {% add_lang_files "firefox/sendto" %}
 
 {% block page_title_prefix %}{% endblock %}
+{% block page_title_suffix %}{% endblock %}
 {% block page_title %}
 {% if l10n_has_tag('firefox_title_meta_bug1345338') %}
   {{ _('Fast, Free Android Browser for Tablets and Phones | Firefox') }}

--- a/bedrock/firefox/templates/firefox/channel/android.html
+++ b/bedrock/firefox/templates/firefox/channel/android.html
@@ -6,6 +6,7 @@
 
 {% add_lang_files "firefox/channel/index" %}
 
+{% block page_title_suffix %}{% endblock %}
 {% block page_title %}
 {% if l10n_has_tag('firefox_title_meta_bug1345338') %}
   {{ _('Try New Features in a Pre-Release Android Browser | Firefox') }}

--- a/bedrock/firefox/templates/firefox/channel/base.html
+++ b/bedrock/firefox/templates/firefox/channel/base.html
@@ -7,7 +7,7 @@
 {% add_lang_files "firefox/channel/index" %}
 
 {% block page_title_prefix %}{% endblock %}
-
+{% block page_title_suffix %}{% endblock %}
 {#- This will appear as <meta property="og:title"> which can be used for social share -#}
 {% block page_og_title %}{{ self.page_title() }}{% endblock %}
 

--- a/bedrock/firefox/templates/firefox/channel/desktop.html
+++ b/bedrock/firefox/templates/firefox/channel/desktop.html
@@ -6,6 +6,7 @@
 
 {% add_lang_files "firefox/channel/index" %}
 
+{% block page_title_suffix %}{% endblock %}
 {% block page_title %}
 {% if l10n_has_tag('firefox_title_meta_bug1345338') %}
   {{ _('Try New Browser Features in Pre-Release Versions | Firefox') }}

--- a/bedrock/firefox/templates/firefox/channel/ios.html
+++ b/bedrock/firefox/templates/firefox/channel/ios.html
@@ -6,6 +6,7 @@
 
 {% add_lang_files "firefox/channel/index" %}
 
+{% block page_title_suffix %}{% endblock %}
 {% block page_title %}
 {% if l10n_has_tag('firefox_title_meta_bug1345338') %}
   {{ _('Try New Features in a Pre-Release iOS Browser | Firefox') }}

--- a/bedrock/firefox/templates/firefox/desktop/index.html
+++ b/bedrock/firefox/templates/firefox/desktop/index.html
@@ -7,6 +7,7 @@
 {% extends "firefox/desktop/desktop-base.html" %}
 
 {% block page_title_prefix %}{% endblock %}
+{% block page_title_suffix %}{% endblock %}
 {% block page_title %}
   {% if l10n_has_tag('firefox_title_meta_bug1345338') %}
     {{ _('Free Web Browser for Mac, Windows, Linux | Firefox') }}

--- a/bedrock/firefox/templates/firefox/family/index.html
+++ b/bedrock/firefox/templates/firefox/family/index.html
@@ -11,6 +11,7 @@
 {% endblock %}
 
 {% block page_title_prefix %}{% endblock %}
+{% block page_title_suffix %}{% endblock %}
 {% block page_title %}
 {% if l10n_has_tag('firefox_title_meta_bug1345338') %}
   {{ _('Free Web Browser for Android, iOS, Desktop | Firefox') }}

--- a/bedrock/firefox/templates/firefox/ios.html
+++ b/bedrock/firefox/templates/firefox/ios.html
@@ -8,7 +8,8 @@
 
 {% add_lang_files "firefox/sendto" %}
 
-{% block page_title_prefix %}{{ _('Firefox for iOS') }} — {% endblock %}
+{% block page_title_prefix %}{% endblock %}
+{% block page_title_suffix %}{% endblock %}
 {% block page_title %}
 {% if l10n_has_tag('firefox_title_meta_bug1345338') %}
   {{ _('Free Mobile Browser App for iPhone, iPad, iOS | Firefox') }}

--- a/bedrock/firefox/templates/firefox/private-browsing.html
+++ b/bedrock/firefox/templates/firefox/private-browsing.html
@@ -7,6 +7,8 @@
 {% extends "firefox/base-resp.html" %}
 
 {% block page_image %}{{ static('img/firefox/private-browsing/private-browsing-meta.png') }}{% endblock %}
+{% block page_title_prefix %}{% endblock %}
+{% block page_title_suffix %}{% endblock %}
 {% block page_title %}
 {% if l10n_has_tag('firefox_title_meta_bug1345338') %}
   {{ _('Private Browser Protects Your Online Privacy | Firefox') }}

--- a/bedrock/firefox/templates/firefox/sync.html
+++ b/bedrock/firefox/templates/firefox/sync.html
@@ -6,6 +6,8 @@
 
 {% extends "/firefox/base-resp.html" %}
 
+{% block page_title_prefix %}{% endblock %}
+{% block page_title_suffix %}{% endblock %}
 {% block page_title %}
 {% if l10n_has_tag('firefox_title_meta_bug1345338') %}
   {{ _('Use Bookmarks, Tabs and Passwords Across Devices | Firefox') }}


### PR DESCRIPTION
## Description
A follow up to bug 1345338 where we were to set new meta titles and descriptions. Turns out there were left over prefix and suffixes still existing on many of these page titles. This bug removes those.

[Previous Bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1345338)
[Previous PR](https://github.com/mozilla/bedrock/pull/4736)
[Titles and pages](https://docs.google.com/spreadsheets/d/1kFpqkkssd-keOyVS13azQS_iJ8ESNtvqjZ5TLy5hBq0/edit#gid=0)


## Bugzilla link
[Current Bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1355173)

@jpetto r?