### PR TITLE
[fix bug 1355458] Remove Optimizely from all pages except /new and /firstrun

### DIFF
--- a/bedrock/firefox/templates/firefox/accounts.html
+++ b/bedrock/firefox/templates/firefox/accounts.html
@@ -14,12 +14,6 @@
   {% stylesheet 'firefox_accounts' %}
 {% endblock %}
 
-{% block optimizely %}
-  {% if switch('firefox-accounts') %}
-     {% include 'includes/optimizely.html' %}
-  {% endif %}
-{% endblock %}
-
 {% block body_class %}{% endblock %}
 {% block site_header_nav %}{% endblock %}
 

--- a/bedrock/firefox/templates/firefox/android/index.html
+++ b/bedrock/firefox/templates/firefox/android/index.html
@@ -28,12 +28,6 @@
 {% block body_id %}firefox-android{% endblock %}
 {% block body_class %}firefox-android{% endblock %}
 
-{% block optimizely %}
-  {% if switch('firefox-android-optimizely') %}
-    {% include 'includes/optimizely.html' %}
-  {% endif %}
-{% endblock %}
-
 {% block page_css %}
   {% stylesheet 'firefox_android' %}
   <!--[if gt IE 9]><!-->

--- a/bedrock/firefox/templates/firefox/australis/fx38_0_5/firstrun.html
+++ b/bedrock/firefox/templates/firefox/australis/fx38_0_5/firstrun.html
@@ -29,12 +29,6 @@
   {% stylesheet 'firefox_fx38_0_5_firstrun' %}
 {% endblock %}
 
-{% block optimizely %}
-  {% if switch('firefox-firstrun-optimizely') %}
-    {% include 'includes/optimizely.html' %}
-  {% endif %}
-{% endblock %}
-
 {% block site_header %}
   <header id="masthead">
     {% block tabzilla_tab %}

--- a/bedrock/firefox/templates/firefox/desktop/desktop-base.html
+++ b/bedrock/firefox/templates/firefox/desktop/desktop-base.html
@@ -14,12 +14,6 @@
   <script src="{{ static('js/libs/modernizr.custom.cssanimations.js') }}"></script>
 {% endblock %}
 
-{% block optimizely %}
-  {% if switch('firefox-desktop-optimizely') %}
-    {% include 'includes/optimizely.html' %}
-  {% endif %}
-{% endblock %}
-
 {% block site_header %}{% endblock %}
 
 {% block content %}{% endblock %}

--- a/bedrock/firefox/templates/firefox/desktop/index.html
+++ b/bedrock/firefox/templates/firefox/desktop/index.html
@@ -27,12 +27,6 @@
   {% stylesheet 'firefox_desktop' %}
 {% endblock %}
 
-{% block optimizely %}
-  {% if switch('firefox-desktop-optimizely') %}
-    {% include 'includes/optimizely.html' %}
-  {% endif %}
-{% endblock %}
-
 {% block site_header_unwrapped %}
   {% call fxfamilynav('desktop', 'dark') %}
     {{ download_firefox(dom_id="sticky-download-desktop", alt_copy=_('Download')) }}

--- a/bedrock/firefox/templates/firefox/installer-help.html
+++ b/bedrock/firefox/templates/firefox/installer-help.html
@@ -9,12 +9,6 @@
 {% block page_title %}{{ _('Your download was interrupted') }}{% endblock %}
 {% block body_id %}installer-help{% endblock %}
 
-{% block optimizely %}
-  {% if switch('firefox-installer-help-optimizely') %}
-     {% include 'includes/optimizely.html' %}
-  {% endif %}
-{% endblock %}
-
 {% block page_css %}
   {% stylesheet 'installer_help' %}
 {% endblock %}

--- a/bedrock/firefox/templates/firefox/mobile-download-desktop.html
+++ b/bedrock/firefox/templates/firefox/mobile-download-desktop.html
@@ -25,12 +25,6 @@
 {% block body_id %}firefox-mobile-download{% endblock %}
 {% block body_class %}{% endblock %}
 
-{% block optimizely %}
-  {% if switch('firefox-mobile-download-desktop-optimizely') %}
-    {% include 'includes/optimizely.html' %}
-  {% endif %}
-{% endblock %}
-
 {% block site_header %}{% endblock %}
 
 {% block page_css %}

--- a/bedrock/firefox/templates/firefox/releases/release-notes.html
+++ b/bedrock/firefox/templates/firefox/releases/release-notes.html
@@ -26,12 +26,6 @@
   {% stylesheet 'firefox_releasenotes_firefox' %}
 {% endblock %}
 
-{% block optimizely %}
-  {% if switch('firefox-releasenotes-optimizely') %}
-    {% include 'includes/optimizely.html' %}
-  {% endif %}
-{% endblock %}
-
 {# channel_name is for display purposes where needed.  #}
 {% set channel_name = channel_name|default('') %}
 

--- a/bedrock/firefox/templates/firefox/sync.html
+++ b/bedrock/firefox/templates/firefox/sync.html
@@ -37,12 +37,6 @@
   {{ fxfamilynav('features', 'dark') }}
 {% endblock %}
 
-{% block optimizely %}
-  {% if switch('firefox-sync') %}
-    {% include 'includes/optimizely.html' %}
-  {% endif %}
-{% endblock %}
-
 {% block content %}
 {% include 'firefox/includes/sync-animation.html' %}
 <header role="banner" class="intro container">

--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-50.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-50.html
@@ -14,8 +14,6 @@
 
 {% block extra_meta %}<meta name="robots" content="noindex">{% endblock %}
 
-{% block optimizely %}{% endblock %}
-
 {% block page_css %}
   {% stylesheet 'firefox_whatsnew_50' %}
 {% endblock %}

--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-base-42.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-base-42.html
@@ -23,12 +23,6 @@
 {#- Override <meta property="og:url"> for social share -#}
 {% block page_og_url %}{{ url('firefox') }}{% endblock %}
 
-{% block optimizely %}
-  {% if switch('firefox-whatsnew-optimizely') %}
-    {% include 'includes/optimizely.html' %}
-  {% endif %}
-{% endblock %}
-
 {% block page_css %}{% endblock %}
 
 {% block page_title_prefix %}{% endblock %}

--- a/bedrock/mozorg/templates/mozorg/about.html
+++ b/bedrock/mozorg/templates/mozorg/about.html
@@ -12,12 +12,6 @@
   {% stylesheet 'about' %}
 {% endblock %}
 
-{% block optimizely %}
-  {% if switch('mozorg-about-optimizely') %}
-     {% include 'includes/optimizely.html' %}
-  {% endif %}
-{% endblock %}
-
 {% block js %}
   {% javascript 'about_video' %}
 {% endblock %}

--- a/bedrock/mozorg/templates/mozorg/contribute/signup.html
+++ b/bedrock/mozorg/templates/mozorg/contribute/signup.html
@@ -13,12 +13,6 @@
   {% stylesheet 'contribute-signup' %}
 {% endblock %}
 
-{% block optimizely %}
-  {% if switch('contribute-signup-optimizely') %}
-    {% include 'includes/optimizely.html' %}
-  {% endif %}
-{% endblock %}
-
 {% block contrib_nav_cta %}{% endblock %}
 {% block contrib_country_form %}{% endblock %}
 

--- a/bedrock/mozorg/templates/mozorg/home/home.html
+++ b/bedrock/mozorg/templates/mozorg/home/home.html
@@ -31,12 +31,6 @@
   {% stylesheet 'home' %}
 {% endblock %}
 
-{% block optimizely %}
-  {% if switch('mozorg-home-optimizely') %}
-    {% include 'includes/optimizely.html' %}
-  {% endif %}
-{% endblock %}
-
 {% block site_header %}
 {% include 'mozorg/home/includes/home-icons-sprite.svg' %}
   {% if LANG.startswith('en-') %}

--- a/bedrock/mozorg/templates/mozorg/mission.html
+++ b/bedrock/mozorg/templates/mozorg/mission.html
@@ -16,12 +16,6 @@
   {% javascript 'about_video' %}
 {% endblock %}
 
-{% block optimizely %}
-  {% if switch('mozorg-mission-optimizely') %}
-     {% include 'includes/optimizely.html' %}
-  {% endif %}
-{% endblock %}
-
 {% block content %}
 <main>
   <header class="page-header">

--- a/bedrock/mozorg/templates/mozorg/plugincheck.html
+++ b/bedrock/mozorg/templates/mozorg/plugincheck.html
@@ -23,12 +23,6 @@
   {% stylesheet 'plugincheck' %}
 {% endblock %}
 
-{% block optimizely %}
-  {% if switch('plugincheck-optimizely') %}
-     {% include 'includes/optimizely.html' %}
-  {% endif %}
-{% endblock %}
-
 {% block string_data %}
   {# L10n: This is a button telling the user to update their plugin #}
   data-button-update-now="{{ _('Update Now') }}"

--- a/bedrock/newsletter/templates/newsletter/developer.html
+++ b/bedrock/newsletter/templates/newsletter/developer.html
@@ -11,12 +11,6 @@
 
 {% block body_class %}newsletter-developer{% endblock %}
 
-{% block optimizely %}
-  {% if switch('developer-newsletter-optimizely') %}
-    {% include 'includes/optimizely.html' %}
-  {% endif %}
-{% endblock %}
-
 {% block page_css %}
   {% stylesheet 'newsletter-developer' %}
 {% endblock %}

--- a/bedrock/newsletter/templates/newsletter/firefox.html
+++ b/bedrock/newsletter/templates/newsletter/firefox.html
@@ -11,12 +11,6 @@
 
 {% block body_class %}newsletter-mozilla{% endblock %}
 
-{% block optimizely %}
-  {% if switch('firefox-newsletter-optimizely') %}
-    {% include 'includes/optimizely.html' %}
-  {% endif %}
-{% endblock %}
-
 {% block page_css %}
   {% stylesheet 'newsletter-firefox' %}
 {% endblock %}

--- a/bedrock/newsletter/templates/newsletter/mozilla.html
+++ b/bedrock/newsletter/templates/newsletter/mozilla.html
@@ -25,12 +25,6 @@
 
 {% block body_class %}newsletter-mozilla{% endblock %}
 
-{% block optimizely %}
-  {% if switch('mozilla-newsletter-optimizely') %}
-    {% include 'includes/optimizely.html' %}
-  {% endif %}
-{% endblock %}
-
 {% block page_css %}
   {% stylesheet 'newsletter-mozilla' %}
 {% endblock %}

--- a/bedrock/teach/templates/teach/smarton/tracking.html
+++ b/bedrock/teach/templates/teach/smarton/tracking.html
@@ -8,12 +8,6 @@
 {% block page_desc %}{{ _('What you do online is your business, and you can keep it that way. Get smart on tracking.') }}{% endblock %}
 {% block page_image %}{{ static('img/teach/smarton/tracking/tracking-hero-white.jpg') }}{% endblock %}
 
-{% block optimizely %}
-  {% if switch('smarton-tracking-optimizely') %}
-     {% include 'includes/optimizely.html' %}
-  {% endif %}
-{% endblock %}
-
 {% block body_id %}smarton-tracking{% endblock %}
 {% block body_class %}smarton theme-tracking state-default{% endblock %}
 


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1355458

(We should clean up these switches afterward too)