### PR TITLE
Add pebbles base template for /firefox app

### DIFF
--- a/bedrock/base/templates/base-pebbles.html
+++ b/bedrock/base/templates/base-pebbles.html
@@ -118,7 +118,7 @@
       {% endblock %}
 
       {% block site_header_logo %}
-        <h2 class="masthead-logo"><a href="{{ url('mozorg.home') }}">{{ high_res_img('sandstone/header-mozilla-stone.png', {'alt': 'Mozilla', 'width': '170', 'height': '45'}) }}</a></h2>
+        <h2 class="masthead-logo"><a href="{{ url('mozorg.home') }}"><img src="{{ static('img/pebbles/moz-wordmark-dark-reverse.svg')}}" alt="Mozilla" width="94" height="30"></a></h2>
       {% endblock %}
 
       </div>

--- a/bedrock/firefox/templates/firefox/base-pebbles.html
+++ b/bedrock/firefox/templates/firefox/base-pebbles.html
@@ -1,0 +1,15 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+
+{% add_lang_files "firefox/new" %}
+
+{% extends "base-pebbles.html" %}
+
+{% block page_title_prefix %}{{_('Mozilla Firefox Web Browser')}} — {% endblock %}
+{% block page_image %}{{ static('img/firefox/template/page-image.png') }}{% endblock %}
+{% block page_favicon %}{{ static('img/firefox/favicon.ico') }}{% endblock %}
+{% block page_favicon_large %}{{ static('img/firefox/favicon-196.png') }}{% endblock %}
+{% block page_ios_icon %}{{ static('img/firefox/ios-icon-180.png') }}{% endblock %}
+
+{% block tabzilla_tab %}{% endblock %}

--- a/bedrock/firefox/urls.py
+++ b/bedrock/firefox/urls.py
@@ -118,4 +118,6 @@ urlpatterns = (
 
     url('^firefox/stub_attribution_code/$', views.stub_attribution_code,
         name='firefox.stub_attribution_code'),
+
+    page('firefox/foo', 'firefox/base-pebbles.html'),
 )

--- a/media/css/mozorg/home/home.scss
+++ b/media/css/mozorg/home/home.scss
@@ -34,24 +34,11 @@ body {
 
     .masthead-logo {
         background: #ff8c8e;
-        height: 30px;
-        left: 0;
-        margin: 0;
-        padding: 10px 0;
-        position: absolute;
-        text-align: center;
-        top: 0;
-        width: 100%;
-
-        img {
-            height: 30px;
-        }
     }
 }
 
 .masthead-nav-main .toggle {
     background-color: #ff8c8e;
-    background-image: url('/media/img/pebbles/icon-menu-dark.svg');
 }
 
 #nav-download-firefox {
@@ -65,12 +52,6 @@ body {
 
         .content {
             padding-top: 0;
-        }
-
-        .masthead-logo {
-            float: left;
-            position: relative;
-            width: 115px;
         }
     }
 

--- a/media/css/mozorg/internet-health.scss
+++ b/media/css/mozorg/internet-health.scss
@@ -46,22 +46,6 @@ main {
         position: relative;
     }
 
-    .masthead-logo {
-        font-size: 100%;
-        height: 30px;
-        left: 0;
-        margin: 0;
-        padding: 10px 0 0;
-        position: absolute;
-        text-align: center;
-        top: 0;
-        width: 100%;
-
-        img {
-            height: 30px;
-        }
-    }
-
     .download-button {
         display: none;
 
@@ -85,6 +69,7 @@ main {
     .masthead-nav-main {
         .toggle {
             background-color: darken(#4a4a4a, 10%);
+            background-image: url('/media/img/pebbles/icon-menu-light.svg');
         }
 
         .nav-main-menu a:hover {
@@ -113,13 +98,6 @@ main {
                     }
                 }
             }
-        }
-
-        .masthead-logo {
-            float: left;
-            padding: 10px 0;
-            position: relative;
-            width: auto;
         }
     }
 

--- a/media/css/mozorg/internet-health/health-subpage.scss
+++ b/media/css/mozorg/internet-health/health-subpage.scss
@@ -107,22 +107,6 @@ main .content {
     padding: 0;
     width: 100%;
 
-    .masthead-logo {
-        font-size: 100%;
-        height: 30px;
-        left: 0;
-        margin: 0;
-        padding: 10px 0 0;
-        position: absolute;
-        text-align: center;
-        top: 0;
-        width: 100%;
-
-        img {
-            height: 30px;
-        }
-    }
-
     .download-button {
         display: none;
 
@@ -146,6 +130,7 @@ main .content {
     .masthead-nav-main {
         .toggle {
             background-color: #000;
+            background-image: url('/media/img/pebbles/icon-menu-light.svg');
         }
 
         .nav-main-menu a:hover {
@@ -174,13 +159,6 @@ main .content {
                     }
                 }
             }
-        }
-
-        .masthead-logo {
-            float: left;
-            padding: 10px 0;
-            position: relative;
-            width: auto;
         }
 
         .download-button {

--- a/media/css/mozorg/technology.scss
+++ b/media/css/mozorg/technology.scss
@@ -38,22 +38,6 @@ main {
         position: relative;
     }
 
-    .masthead-logo {
-        font-size: 100%;
-        height: 30px;
-        left: 0;
-        margin: 0;
-        padding: 10px 0 0;
-        position: absolute;
-        text-align: center;
-        top: 0;
-        width: 100%;
-
-        img {
-            height: 30px;
-        }
-    }
-
     .download-button {
         display: none;
 
@@ -72,6 +56,10 @@ main {
 
     .fx-privacy-link {
         display: none;
+    }
+
+    .masthead-nav-main .toggle {
+        background-image: url('/media/img/pebbles/icon-menu-light.svg');
     }
 
     @media #{$mq-tablet} {
@@ -94,13 +82,6 @@ main {
                     }
                 }
             }
-        }
-
-        .masthead-logo {
-            float: left;
-            padding: 10px 0;
-            position: relative;
-            width: auto;
         }
     }
 

--- a/media/css/pebbles/components/_masthead.scss
+++ b/media/css/pebbles/components/_masthead.scss
@@ -10,14 +10,29 @@
         padding-top: 0;
         padding-bottom: 0;
     }
-}
 
-.masthead-logo {
-    @include font-size(16px);
-    margin: 0;
-    padding: 30px 0 20px;
-}
+    .masthead-logo {
+        @include font-size(16px);
+        height: 30px;
+        left: 0;
+        margin: 0;
+        padding: 10px 0;
+        position: absolute;
+        text-align: center;
+        top: 0;
+        width: 100%;
 
+        img {
+            height: 30px;
+        }
+
+        @media #{$mq-tablet} {
+            float: left;
+            position: relative;
+            width: 94px;
+        }
+    }
+}
 
 .masthead-nav-main {
     @include font-size(14px);
@@ -39,7 +54,7 @@
 
     .toggle {
         @include image-replaced;
-        background: $color-mozred url('/media/img/pebbles/icon-menu-light.svg') center center no-repeat;
+        background: transparent url('/media/img/pebbles/icon-menu-dark.svg') center center no-repeat;
         @include background-size(22px auto);
         cursor: pointer;
         display: block;
@@ -108,7 +123,7 @@
             position: static;
             background: transparent;
             box-shadow: none;
-            padding: 20px 0;
+            padding: 10px 0;
 
             li {
                 display: inline;


### PR DESCRIPTION
@jpetto @craigcook - it occurred to me that we don't yet have a base template in the Firefox app that uses pebbles. I think it might be a good idea to create a common base template which all the new hub pages can inherit from. This gives us the following things:

- All pages have the correct Favicon / social meta data.
- For non-en locales, we'll likely have to fix up some sort of minimal header since they don't get the new global nav. For now I've just updated the default header in `./base-pebbles.html` to use the new logo. This did mean some slight refactoring of the existing header CSS on other pages, as there are so many versions of the same `#masthead` CSS :/

Thoughts?

Testing:
--------
- New base template for en-US should get the global nav, other locales the old nav (but with new logo).
- Test other pebbles page headers (non en) to make sure there are no regressions.