### PR TITLE
[fix bug 1354304] Hide download button on /privacy/firefox page for funnelcake experiment

### DIFF
--- a/media/js/privacy/privacy.js
+++ b/media/js/privacy/privacy.js
@@ -6,6 +6,7 @@ $(function() {
     'use strict';
 
     var utils = Mozilla.Utils;
+    var client = Mozilla.Client;
 
     /**
      * Detects whether do not track is enabled and takes one of two possible actions:
@@ -106,4 +107,9 @@ $(function() {
             }
         }
     });
+
+    // Bug 1354304: temporarily hide download button on privacy page for funnelcake experiment.
+    if (client.isFirefox) {
+        $('#global-nav-download-firefox').hide();
+    }
 });


### PR DESCRIPTION
## Description
- Temporarily hides the download button in global nav on the /privacy pages to help facilitate a funnelcake experiment.

## Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1354304

## Testing
- Button should not be visible in Firefox, but still visible to other browsers.

## Checklist
- [ ] Requires l10n changes.
- [ ] Related functional & integration tests passing.
