### PR TITLE
[fix bug 1356059] update the 'securely upgrade pip' command

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -25,7 +25,7 @@ You need to create a virtual environment for Python libraries. Skip the first in
     $ pip install virtualenv                       # installs virtualenv, skip if already have it
     $ virtualenv -p python2.7 venv                 # create a virtual env in the folder `venv`
     $ source venv/bin/activate                     # activate the virtual env
-    $ bin/pipstrap.py                              # securely upgrade pip
+    $ pip install -U pip                           # securely upgrade pip
     $ pip install -r requirements/test.txt         # installs dependencies
 
 If you are on OSX and some of the compiled dependencies fails to compile, try explicitly setting the arch flags and try again::


### PR DESCRIPTION
## Description

The command for securely upgrading pip in the current documentation:
 `$ bin/pipstrap.py`
 is outdated because the script it uses has been taken out.  It therefore results in  the error message:
`-bash: bin/pipstrap.py: No such file or directory`

The documentation needs to be changed to reflect that this script has been removed.

## Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1356059
## Testing

## Checklist
- [ ] Requires l10n changes.
- [ ] Related functional & integration tests passing.
