### PR TITLE
[fix bug 1354710] Firstrun pages need to pass funnelcake parameters to FxA

### DIFF
--- a/bedrock/firefox/templates/firefox/firstrun/firstrun-horizon.html
+++ b/bedrock/firefox/templates/firefox/firstrun/firstrun-horizon.html
@@ -55,8 +55,10 @@
           {% endif %}
         </header>
         <div class="fxaccounts-container">
+          {# Bug 1354710: firstrun pages need to pass funnelcake parameters to FxA #}
+          {% set utm_source = 'firstrun' if not funnelcake_id else 'firstrun_f' + funnelcake_id %}
           <div class="fxaccounts" id="fxa-iframe-config" data-host="{{ settings.FXA_IFRAME_SRC }}" data-mozillaonline-host="{{ settings.FXA_IFRAME_SRC_MOZILLAONLINE }}">
-            <iframe id="fxa" scrolling="no" data-src="{{ settings.FXA_IFRAME_SRC }}?utm_campaign=fxa-embedded-form&amp;utm_medium=referral&amp;utm_source=firstrun&amp;utm_content=fx-{{ version }}&amp;entrypoint=firstrun&amp;service=sync&amp;context=iframe&amp;style=chromeless&amp;haltAfterSignIn=true"></iframe>
+            <iframe id="fxa" scrolling="no" data-src="{{ settings.FXA_IFRAME_SRC }}?utm_campaign=fxa-embedded-form&amp;utm_medium=referral&amp;utm_source={{ utm_source }}&amp;utm_content=fx-{{ version }}&amp;entrypoint=firstrun&amp;service=sync&amp;context=iframe&amp;style=chromeless&amp;haltAfterSignIn=true"></iframe>
           </div>
           <p>{{ _('With your Firefox Account you can sync your bookmarks, passwords, open tabs and more, and access them everywhere you use Firefox.') }}</p>
         </div>

--- a/bedrock/firefox/templates/firefox/firstrun/new-firstrun.html
+++ b/bedrock/firefox/templates/firefox/firstrun/new-firstrun.html
@@ -12,6 +12,8 @@
   {% javascript 'firefox_new_firstrun' %}
 {% endblock %}
 
+{% block global_nav %}{% endblock %}
+
 {% block content %}
   <div id="scene">
     <div class="fxaccounts-container">


### PR DESCRIPTION
## Description
- Pass along funnelcake ID's along in the utm_source to the /firstrun FxA iframe.

## Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1354710

## Testing
- If page contains funnelcake query param e.g. `?f=110`, then `utm_source` should equal `firstrun_f110`.
- If pages does not have funnelcake query param, `utm_source` should just be `firstrun`.

## Checklist
- [ ] Requires l10n changes.
- [ ] Related functional & integration tests passing.
