### PR TITLE
[bug 1355512] remove Zilla from pebbles global

### DIFF
--- a/media/css/pebbles/global.scss
+++ b/media/css/pebbles/global.scss
@@ -9,7 +9,6 @@
 @import
     // Fonts
     'includes/fonts/open-sans',
-    'includes/fonts/zilla-slab',
 
     // Base elements - general HTML elements
     'base/elements',


### PR DESCRIPTION
## Description
Don’t load the fonts everywhere until we’re sure we need them everywhere.

## Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1355512