### PR TITLE
[fix bug 1349729] Add Optimizely snippet to /firefox/new/ variations.

### DIFF
--- a/bedrock/firefox/templates/firefox/new/base.html
+++ b/bedrock/firefox/templates/firefox/new/base.html
@@ -33,12 +33,6 @@
   {{ static('img/firefox/firefox-independent-1200.jpg') }}
 {% endblock %}
 
-{% block optimizely %}
-  {% if switch('firefox-new-optimizely') %}
-    {% include 'includes/optimizely.html' %}
-  {% endif %}
-{% endblock %}
-
 {% block body_id %}{% endblock %}
 {% block body_class %}{% endblock %}
 

--- a/bedrock/firefox/templates/firefox/new/break-free/scene1.html
+++ b/bedrock/firefox/templates/firefox/new/break-free/scene1.html
@@ -4,6 +4,12 @@
 
 {% extends "firefox/new/break-free/base.html" %}
 
+{% block optimizely %}
+  {% if switch('firefox-new-optimizely', ['en-US']) %}
+    {% include 'includes/optimizely.html' %}
+  {% endif %}
+{% endblock %}
+
 {% block content %}
 <div class="main-content content">
   {{ download_firefox(alt_copy=_('Free Download')) }}

--- a/bedrock/firefox/templates/firefox/new/scene1.html
+++ b/bedrock/firefox/templates/firefox/new/scene1.html
@@ -6,6 +6,12 @@
 
 {% extends "firefox/new/base.html" %}
 
+{% block optimizely %}
+  {% if switch('firefox-new-optimizely', ['en-US']) %}
+    {% include 'includes/optimizely.html' %}
+  {% endif %}
+{% endblock %}
+
 {# all CSS must be in extrahead block for old IE #}
 {% block extrahead %}
   {% stylesheet 'firefox_new_common' %}

--- a/bedrock/firefox/templates/firefox/new/way-of-the-fox/scene1.html
+++ b/bedrock/firefox/templates/firefox/new/way-of-the-fox/scene1.html
@@ -4,6 +4,12 @@
 
 {% extends "firefox/new/way-of-the-fox/base.html" %}
 
+{% block optimizely %}
+  {% if switch('firefox-new-optimizely', ['en-US']) %}
+    {% include 'includes/optimizely.html' %}
+  {% endif %}
+{% endblock %}
+
 {% block content_body %}
 <div class="main-content content">
   {{ download_firefox(alt_copy=_('Free Download')) }}


### PR DESCRIPTION
## Description

Experiments need to be run on two variants of `/firefox/new/`.

Also, confirmed with cmore that Optimizely only needs to be on scene 1, and only for en-US audiences (for the time being, anyway).

## Bugzilla link

https://bugzilla.mozilla.org/show_bug.cgi?id=1349729#c21

## Testing

Make sure Optimizely loads as expected, and no typos or anything.

## Checklist
- [ ] Requires l10n changes.
- [ ] Related functional & integration tests passing.
