### PR TITLE
Fix bug 1290962: Include locale in Fx download scene2 URL

### DIFF
--- a/bedrock/firefox/firefox_details.py
+++ b/bedrock/firefox/firefox_details.py
@@ -193,7 +193,8 @@ class FirefoxDesktop(_ProductDetails):
 
     def get_download_url(self, channel, version, platform, locale,
                          force_direct=False, force_full_installer=False,
-                         force_funnelcake=False, funnelcake_id=None):
+                         force_funnelcake=False, funnelcake_id=None,
+                         locale_in_transition=False):
         """
         Get direct download url for the product.
         :param channel: one of self.version_map.keys().
@@ -206,6 +207,7 @@ class FirefoxDesktop(_ProductDetails):
         :param force_funnelcake: Force the download version for en-US Windows to be
                 'latest', which bouncer will translate to the funnelcake build.
         :param funnelcake_id: ID for the the funnelcake build.
+        :param locale_in_transition: Include the locale in the transition URL
         :return: string url
         """
         _version = version
@@ -274,13 +276,15 @@ class FirefoxDesktop(_ProductDetails):
                              ])])
         else:
             # build a link to the transition page
-
+            transition_url = self.download_base_url_transition
             if funnelcake_id:
                 # include funnelcake in scene 2 URL
-                return '&f='.join([self.download_base_url_transition,
-                                   funnelcake_id])
-            else:
-                return self.download_base_url_transition
+                transition_url += '&f=%s' % funnelcake_id
+
+            if locale_in_transition:
+                transition_url = '/%s%s' % (locale, transition_url)
+
+            return transition_url
 
 
 class FirefoxAndroid(_ProductDetails):

--- a/bedrock/firefox/templates/firefox/new/break-free/scene1.html
+++ b/bedrock/firefox/templates/firefox/new/break-free/scene1.html
@@ -12,7 +12,7 @@
 
 {% block content %}
 <div class="main-content content">
-  {{ download_firefox(alt_copy=_('Free Download')) }}
+  {{ download_firefox(alt_copy=_('Free Download'), locale_in_transition=True) }}
 
   <p class="tagline">{{ _('Faster than a freight train. More privacy than a secret decoder ring. Whenever you call for a better browser,
   Firefox is there!') }}</p>

--- a/bedrock/firefox/templates/firefox/new/onboarding/scene1.html
+++ b/bedrock/firefox/templates/firefox/new/onboarding/scene1.html
@@ -50,7 +50,7 @@
             <section id="download-buttons">
               {# handles desktop users (windows, os x, linux) #}
               <div class="download-button-wrapper desktop" id="download-button-wrapper-desktop">
-                {{ download_firefox(alt_copy=_('Free Download')) }}
+                {{ download_firefox(alt_copy=_('Free Download'), locale_in_transition=True) }}
               </div>
               {# handles Android and iOS users #}
               <div class="mobile download-button-wrapper" id="download-button-wrapper-mobile" data-upgrade-subtitle="{{_('Get it free on Google Play')}}">

--- a/bedrock/firefox/templates/firefox/new/scene1.html
+++ b/bedrock/firefox/templates/firefox/new/scene1.html
@@ -58,7 +58,16 @@
             <section id="download-buttons">
               {# handles desktop users (windows, os x, linux) #}
               <div class="download-button-wrapper desktop" id="download-button-wrapper-desktop">
-                {{ download_firefox(alt_copy=_('Free Download')) }}
+                {# **WARNING**
+
+                  The `locale_in_transition` parameter should be used very carefully. It's included
+                  here because this template and scene2 share a lang file, and are therefore
+                  translated into the same list of locales. Adding this to another download button
+                  would significantly restrict the builds of Firefox available for download.
+
+                  Bug 1290962
+                #}
+                {{ download_firefox(alt_copy=_('Free Download'), locale_in_transition=True) }}
               </div>
 
               {# handles Android and iOS users #}

--- a/bedrock/firefox/templates/firefox/new/way-of-the-fox/scene1.html
+++ b/bedrock/firefox/templates/firefox/new/way-of-the-fox/scene1.html
@@ -12,7 +12,7 @@
 
 {% block content_body %}
 <div class="main-content content">
-  {{ download_firefox(alt_copy=_('Free Download')) }}
+  {{ download_firefox(alt_copy=_('Free Download'), locale_in_transition=True) }}
   <p class="tagline">
     {# L10n: span tags below for visual formatting only. #}
     {{ _('<span>Quicken</span> your browsing. <span>Reclaim</span> your privacy. Enjoy your <span>freedom</span>.') }}

--- a/bedrock/firefox/templatetags/helpers.py
+++ b/bedrock/firefox/templatetags/helpers.py
@@ -13,7 +13,7 @@ from lib.l10n_utils import get_locale
 
 def desktop_builds(channel, builds=None, locale=None, force_direct=False,
                    force_full_installer=False, force_funnelcake=False,
-                   funnelcake_id=False):
+                   funnelcake_id=False, locale_in_transition=False):
     builds = builds or []
 
     l_version = firefox_desktop.latest_builds(locale, channel)
@@ -42,6 +42,7 @@ def desktop_builds(channel, builds=None, locale=None, force_direct=False,
             force_full_installer=force_full_installer,
             force_funnelcake=force_funnelcake,
             funnelcake_id=funnelcake_id,
+            locale_in_transition=locale_in_transition,
         )
 
         # If download_link_direct is False the data-direct-link attr
@@ -112,7 +113,8 @@ def ios_builds(channel, builds=None):
 def download_firefox(ctx, channel='release', platform='all',
                      dom_id=None, locale=None, force_direct=False,
                      force_full_installer=False, force_funnelcake=False,
-                     alt_copy=None, button_color='button-green'):
+                     alt_copy=None, button_color='button-green',
+                     locale_in_transition=False):
     """ Output a "download firefox" button.
 
     :param ctx: context from calling template.
@@ -144,7 +146,7 @@ def download_firefox(ctx, channel='release', platform='all',
         version = firefox_desktop.latest_version(channel)
         builds = desktop_builds(channel, builds, locale, force_direct,
                                 force_full_installer, force_funnelcake,
-                                funnelcake_id)
+                                funnelcake_id, locale_in_transition)
 
     if show_android:
         version = firefox_android.latest_version(channel)

--- a/bedrock/firefox/tests/test_firefox_details.py
+++ b/bedrock/firefox/tests/test_firefox_details.py
@@ -285,6 +285,17 @@ class TestFirefoxDesktop(TestCase):
         url = firefox_desktop.get_download_url('release', '45.0', 'win', 'en-US', funnelcake_id='64')
         self.assertEqual(url, scene2 + '&f=64')
 
+    def test_get_download_url_scene2_with_locale(self):
+        scene2 = firefox_desktop.download_base_url_transition
+        url = firefox_desktop.get_download_url('release', '45.0', 'win', 'de',
+                                               locale_in_transition=True)
+        self.assertEqual(url, '/de' + scene2)
+
+        url = firefox_desktop.get_download_url('release', '45.0', 'win', 'fr',
+                                               locale_in_transition=True,
+                                               funnelcake_id='64')
+        self.assertEqual(url, '/fr' + scene2 + '&f=64')
+
     @override_settings(STUB_INSTALLER_LOCALES={'release': {'win': settings.STUB_INSTALLER_ALL}})
     def get_download_url_ssl(self):
         """


### PR DESCRIPTION
Add option to download_firefox helper to include the locale in the URL for the scene2 page.