### PR TITLE
[bug 1352821] Fix StatCounter CSP script error

### DIFF
--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -1317,7 +1317,7 @@ if config('SWITCH_TRACKING_PIXEL', default=DEV, cast=bool):
 # See https://bugzilla.mozilla.org/show_bug.cgi?id=1352821
 if config('SWITCH_STATCOUNTER_EXPERIMENT', default=DEV, cast=bool):
     CSP_IMG_SRC += ('*.statcounter.com',)
-    CSP_SCRIPT_SRC += ('www.statcounter.com',)
+    CSP_SCRIPT_SRC += ('secure.statcounter.com',)
 
 # Bug 1345467: Funnelcakes are now explicitly configured in the environment.
 # Set experiment specific variables like the following:

--- a/media/js/base/stat-counter.js
+++ b/media/js/base/stat-counter.js
@@ -15,8 +15,7 @@
         /* eslint-enable camelcase, no-unused-vars */
         var newScriptTag = document.createElement('script');
         var target = document.getElementsByTagName('script')[0];
-        var scJsHost = (('https:' === document.location.protocol) ? 'https://secure.' : 'http://www.');
-        newScriptTag.src = scJsHost + 'statcounter.com/counter/counter.js';
+        newScriptTag.src = 'https://secure.statcounter.com/counter/counter.js';
         target.parentNode.insertBefore(newScriptTag, target);
     }
 })();


### PR DESCRIPTION
- Fixes CSP error for when script is loaded securely: https://www.mozilla.org/en-US/firefox/52.0/firstrun/