### PR TITLE
Fix bug 1357380: Remove Aurora mention from Bug Bounty FAQ page

### DIFF
--- a/bedrock/security/templates/security/bug-bounty/faq.html
+++ b/bedrock/security/templates/security/bug-bounty/faq.html
@@ -162,7 +162,7 @@
 
         <dd class="answer">
           <p>Yes, as long as the bug otherwise meets the published bug bounty
-            program guidelines. Bugs found in Aurora and Beta releases of Firefox and
+            program guidelines. Bugs found in Developer Edition and Beta releases of Firefox and
             Firefox for Android, EarlyBird and Beta releases of Thunderbird are eligible as
             long the bug is reproducible in the latest nightly mozilla-central build and has
             not been previously reported.</p>


### PR DESCRIPTION
## Description
The Aurora release channel has been murdered as part of “Project Dawn”. Therefore, it’s no longer appropriate to mention it in the FAQ of the Bug Bounty program. Aurora’s users are going to be migrated to both Beta and Nightly, and Developer Edition is going to be based off Beta, so I replaced “Aurora” with “Developer Edition”. Alternatively, one could just mention Beta and be done with it.

## Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1357380

## Testing
N/A.

## Checklist
- [ ] Requires l10n changes. _(This page isn’t localized, AFAICT)_
- [ ] Related functional & integration tests passing.
