### PR TITLE
[fix bug 1355333] Update lang files for /whatsnew 50.

### DIFF
--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-50.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-50.html
@@ -8,7 +8,7 @@ A modified copy of firefox/mobile-download-desktop.html
 
 {% from "macros.html" import google_play_button, send_to_device with context %}
 
-{% add_lang_files "firefox/sendto" "download" %}
+{% add_lang_files "firefox/whatsnew_50" "firefox/sendto" %}
 
 {% extends "firefox/base-resp.html" %}
 


### PR DESCRIPTION
## Description

Updates lang files for `whatsnew-50.html` (as per @flodolo's request).
