### PR TITLE
[fix bug 1357173] Add noindex to scene 2 of download page

### DIFF
--- a/bedrock/firefox/templates/firefox/new/break-free/scene2.html
+++ b/bedrock/firefox/templates/firefox/new/break-free/scene2.html
@@ -4,6 +4,10 @@
 
 {% extends "firefox/new/break-free/base.html" %}
 
+{% block extra_meta %}
+  <meta name="robots" content="noindex,follow">
+{% endblock %}
+
 {% from "macros.html" import google_play_button with context %}
 
 {% block body_class %}scene-2{% endblock %}

--- a/bedrock/firefox/templates/firefox/new/onboarding/scene2.html
+++ b/bedrock/firefox/templates/firefox/new/onboarding/scene2.html
@@ -4,6 +4,10 @@
 
 {% extends "firefox/new/onboarding/base.html" %}
 
+{% block extra_meta %}
+  <meta name="robots" content="noindex,follow">
+{% endblock %}
+
 {% block extrahead %}
   {% stylesheet 'firefox_new_onboarding_common' %}
   {% stylesheet 'firefox_new_onboarding_scene2' %}

--- a/bedrock/firefox/templates/firefox/new/scene2.html
+++ b/bedrock/firefox/templates/firefox/new/scene2.html
@@ -6,6 +6,10 @@
 
 {% extends "firefox/new/base.html" %}
 
+{% block extra_meta %}
+  <meta name="robots" content="noindex,follow">
+{% endblock %}
+
 {% block optimizely %}
   {% if switch('firefox-new-scene2-optimizely', ['en-US']) %}
     {% include 'includes/optimizely.html' %}

--- a/bedrock/firefox/templates/firefox/new/way-of-the-fox/scene2.html
+++ b/bedrock/firefox/templates/firefox/new/way-of-the-fox/scene2.html
@@ -4,6 +4,10 @@
 
 {% extends "firefox/new/way-of-the-fox/base.html" %}
 
+{% block extra_meta %}
+  <meta name="robots" content="noindex,follow">
+{% endblock %}
+
 {% from "macros.html" import google_play_button with context %}
 
 {% block body_class %}scene-2{% endblock %}


### PR DESCRIPTION
## Description
Politely asks search engines not to index /firefox/new/?scene=2

## Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1357173

## Checklist
- [ ] Requires l10n changes.
- [ ] Related functional & integration tests passing.
