### PR TITLE
[fix bug 1348129] Experiment for funnelcakes 110-113.

### DIFF
--- a/bedrock/firefox/templates/firefox/new/scene1.html
+++ b/bedrock/firefox/templates/firefox/new/scene1.html
@@ -6,6 +6,12 @@
 
 {% extends "firefox/new/base.html" %}
 
+{% block experiments %}
+  {% if switch('experiment-firefox-new-funnelcakes-110-113', ['en-US']) %}
+    {% javascript 'firefox_new_scene1_experiment_funnelcakes_110_113' %}
+  {% endif %}
+{% endblock %}
+
 {% block optimizely %}
   {% if switch('firefox-new-optimizely', ['en-US']) %}
     {% include 'includes/optimizely.html' %}

--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -492,7 +492,7 @@ def new(request):
 
     if scene == '2':
         if locale == 'en-US':
-            if funnelcake_id in ['99', '100']:
+            if funnelcake_id in ['99', '100', '110', '111', '112', '113']:
                 template = 'firefox/new/onboarding/scene2.html'
             elif experience == 'breakfree':
                 template = 'firefox/new/break-free/scene2.html'
@@ -505,7 +505,7 @@ def new(request):
     # if no/incorrect scene specified, show scene 1
     else:
         if locale == 'en-US':
-            if funnelcake_id in ['99', '100']:
+            if funnelcake_id in ['99', '100', '110', '111', '112', '113']:
                 template = 'firefox/new/onboarding/scene1.html'
             elif experience == 'breakfree':
                 template = 'firefox/new/break-free/scene1.html'

--- a/bedrock/settings/static_media.py
+++ b/bedrock/settings/static_media.py
@@ -1284,6 +1284,13 @@ PIPELINE_JS = {
         ),
         'output_filename': 'js/firefox_new_scene1-bundle.js',
     },
+    'firefox_new_scene1_experiment_funnelcakes_110_113': {
+        'source_filenames': (
+            'js/base/mozilla-traffic-cop.js',
+            'js/firefox/new/experiment-funnelcakes-110-113.js',
+        ),
+        'output_filename': 'js/firefox_new_scene1_experiment_funnelcakes_110_113-bundle.js',
+    },
     'firefox_new_scene2': {
         'source_filenames': (
             'js/firefox/new/scene2.js',

--- a/media/js/firefox/new/experiment-funnelcakes-110-113.js
+++ b/media/js/firefox/new/experiment-funnelcakes-110-113.js
@@ -1,0 +1,29 @@
+(function(Mozilla) {
+    'use strict';
+
+    // en-US only (handled with switch)
+    // Windows only
+    // Non-Firefox
+    // Desktop only
+
+    // swiped from mozilla-client.js
+    var ua = navigator.userAgent;
+    var isLikeFirefox = /Iceweasel|IceCat|SeaMonkey|Camino|like\ Firefox/i.test(ua);
+    var isFirefox = /\s(Firefox|FxiOS)/.test(ua) && !isLikeFirefox(ua);
+    var isMobile = /^(android|ios|fxos)$/.test(window.site.platform);
+
+    if (window.site.platform === 'windows' && !isFirefox && !isMobile) {
+        var zed = new Mozilla.TrafficCop({
+            id: 'experiment-funnelcakes-110-113',
+            cookieExpires: 168, // 1 week
+            variations: {
+                'f=110': 7,
+                'f=111': 7,
+                'f=112': 7,
+                'f=113': 7
+            }
+        });
+
+        zed.init();
+    }
+})(window.Mozilla);


### PR DESCRIPTION
## Description

Adds experiment for funnelcakes 110 - 113 to `/firefox/new` for en-US, Windows, desktop, non-Firefox users.

Must add following funnelcake config to env:

```
FUNNELCAKE_110_PLATFORMS=win
FUNNELCAKE_110_LOCALES=en-US
FUNNELCAKE_111_PLATFORMS=win
FUNNELCAKE_111_LOCALES=en-US
FUNNELCAKE_112_PLATFORMS=win
FUNNELCAKE_112_LOCALES=en-US
FUNNELCAKE_113_PLATFORMS=win
FUNNELCAKE_113_LOCALES=en-US
```

## Bugzilla link

https://bugzilla.mozilla.org/show_bug.cgi?id=1348129

## Testing

Visit `/en-US/firefox/new/` on Windows (or with `windows` hard-coded in `window.site.getPlatform()`) in a browser with DNT disabled. Should get one of 4 variations 28% of the time.

(Funnelcakes are not yet active.)

https://bedrock-demo-jpetto-fc.us-west.moz.works/en-US/firefox/new/

## Checklist
- [ ] Requires l10n changes.
- [ ] Related functional & integration tests passing.
