### PR TITLE
[fix bug 1356017] Add Optimizely snippet to ?scene=2.

### DIFF
--- a/bedrock/firefox/templates/firefox/new/scene2.html
+++ b/bedrock/firefox/templates/firefox/new/scene2.html
@@ -6,6 +6,12 @@
 
 {% extends "firefox/new/base.html" %}
 
+{% block optimizely %}
+  {% if switch('firefox-new-scene2-optimizely', ['en-US']) %}
+    {% include 'includes/optimizely.html' %}
+  {% endif %}
+{% endblock %}
+
 {% block extrahead %}
   {% stylesheet 'firefox_new_common' %}
   {% stylesheet 'firefox_new_scene2' %}


### PR DESCRIPTION
## Description

New experiment needs to target `?scene=2`. This PR just adds the Optimizely snippet to that template (for `en-US` only).

## Bugzilla link

https://bugzilla.mozilla.org/show_bug.cgi?id=1356017

## Testing

## Checklist
- [ ] Requires l10n changes.
- [ ] Related functional & integration tests passing.
