### PR TITLE
Fix Bug 1358198 - Remove Aurora/DevEdition links from Release Notes navigation, add Desktop Nightly link instead

### DIFF
--- a/bedrock/firefox/templates/firefox/releases/aurora-notes.html
+++ b/bedrock/firefox/templates/firefox/releases/aurora-notes.html
@@ -11,25 +11,3 @@
 {% endblock %}
 
 {% set channel_name = 'Aurora' %}
-
-{% block platform_switch %}
-  <nav id="nav" class="navigator">
-    <div class="container">
-      <ul class="menu">
-        <li><a href="{{ url('firefox.notes') }}">{{ _('Desktop') }}</a></li>
-        <li><a href="{{ url('firefox.notes', platform='android') }}">{{ _('Android') }}</a></li>
-        <li class="current submenu-title">
-          <a>{{ _('Other Releases') }}</a>
-          <ul class="submenu">
-            <li class="title">{{ _('Recent Desktop Releases') }}</li>
-            <li><a href="{{ url('firefox.notes', channel='beta') }}">{{ _('Latest Beta') }}</a></li>
-            <li><a href="{{ url('firefox.notes', channel='developer') }}">{{ _('Latest Developer Edition') }}</a></li>
-            <li class="title">{{ _('Recent Android Releases') }}</a></li>
-            <li><a href="{{ url('firefox.notes', platform='android', channel='beta') }}">{{ _('Latest Beta') }}</a></li>
-            <li><a href="{{ url('firefox.notes', platform='android', channel='aurora') }}">{{ _('Latest Aurora') }}</a></li>
-          </ul>
-        </li>
-      </ul>
-    </div>
-  </nav>
-{% endblock %}

--- a/bedrock/firefox/templates/firefox/releases/beta-notes.html
+++ b/bedrock/firefox/templates/firefox/releases/beta-notes.html
@@ -13,25 +13,3 @@
 {% endblock %}
 
 {% set channel_name = 'Beta' %}
-
-{% block platform_switch %}
-  <nav id="nav" class="navigator">
-    <div class="container">
-      <ul class="menu">
-        <li><a href="{{ url('firefox.notes') }}">{{ _('Desktop') }}</a></li>
-        <li><a href="{{ url('firefox.notes', platform='android') }}">{{ _('Android') }}</a></li>
-        <li class="current submenu-title">
-          <a>{{ _('Other Releases') }}</a>
-          <ul class="submenu">
-            <li class="title">{{ _('Recent Desktop Releases') }}</li>
-            <li><a href="{{ url('firefox.notes', channel='beta') }}">{{ _('Latest Beta') }}</a></li>
-            <li><a href="{{ url('firefox.notes', channel='developer') }}">{{ _('Latest Developer Edition') }}</a></li>
-            <li class="title">{{ _('Recent Android Releases') }}</a></li>
-            <li><a href="{{ url('firefox.notes', platform='android', channel='beta') }}">{{ _('Latest Beta') }}</a></li>
-            <li><a href="{{ url('firefox.notes', platform='android', channel='aurora') }}">{{ _('Latest Aurora') }}</a></li>
-          </ul>
-        </li>
-      </ul>
-    </div>
-  </nav>
-{% endblock %}

--- a/bedrock/firefox/templates/firefox/releases/release-notes.html
+++ b/bedrock/firefox/templates/firefox/releases/release-notes.html
@@ -73,22 +73,32 @@
       <nav id="nav" class="navigator">
         <div class="container">
           <ul class="menu">
-          {% if release.product == 'Firefox for Android' %}
+          {% if release.product == 'Firefox' and release.channel == 'Release' %}
+            <li class="current">{{ _('Desktop') }}</li>
+          {% else %}
             <li><a href="{{ url('firefox.notes') }}">{{ _('Desktop') }}</a></li>
+          {% endif %}
+          {% if release.product == 'Firefox for Android' and release.channel == 'Release' %}
             <li class="current">{{ _('Android') }}</li>
           {% else %}
-            <li class="current">{{ _('Desktop') }}</li>
             <li><a href="{{ url('firefox.notes', platform='android') }}">{{ _('Android') }}</a></li>
           {% endif %}
-            <li class="submenu-title">
+            <li class="{% if release.channel != 'Release' %}current {% endif %}submenu-title">
               <a href="#" role="button" aria-controls="nav-submenu" aria-expanded="false">{{ _('Other Releases') }}</a>
               <ul class="submenu" id="nav-submenu">
-                <li class="title">{{ _('Recent Desktop Releases') }}</li>
-                <li><a href="{{ url('firefox.notes', channel='beta') }}">{{ _('Latest Beta') }}</a></li>
-                <li><a href="{{ url('firefox.notes', channel='developer') }}">{{ _('Latest Developer Edition') }}</a></li>
-                <li class="title">{{ _('Recent Android Releases') }}</li>
-                <li><a href="{{ url('firefox.notes', platform='android', channel='beta') }}">{{ _('Latest Beta') }}</a></li>
-                <li><a href="{{ url('firefox.notes', platform='android', channel='aurora') }}">{{ _('Latest Aurora') }}</a></li>
+                <li>
+                  <span class="title">{{ _('Recent Desktop Releases') }}</span>
+                  <ul>
+                    <li><a href="{{ url('firefox.notes', channel='beta') }}">{{ _('Latest Beta &amp; Developer Edition') }}</a></li>
+                    <li><a href="{{ url('firefox.notes', channel='nightly') }}">{{ _('Latest Nightly') }}</a></li>
+                  </ul>
+                </li>
+                <li>
+                  <span class="title">{{ _('Recent Android Releases') }}</span>
+                  <ul>
+                    <li><a href="{{ url('firefox.notes', platform='android', channel='beta') }}">{{ _('Latest Beta') }}</a></li>
+                  </ul>
+                </li>
               </ul>
             </li>
           </ul>

--- a/media/css/firefox/releasenotes-firefox.less
+++ b/media/css/firefox/releasenotes-firefox.less
@@ -117,28 +117,27 @@ ul.submenu {
     box-shadow: 0 1px 1px 0 rgba(50, 50, 50, 0.4);
     display: none;
     margin-top: 0;
-    padding: 5px 10px 15px 10px;
+    padding: 5px 15px 15px 15px;
     position: absolute;
     text-align: left;
-    width: 300px;
     z-index: 1;
+    white-space: nowrap;
 
     li {
-        display: inline;
+        display: block;
         .font-size(14px);
         text-align: left;
         text-transform: none;
         margin-left: 0;
-        padding: 5px;
         background-color: transparent;
-    }
 
-    li.title {
-        .font-size(10px);
-        color: #333;
-        display: block;
-        text-transform: uppercase;
-        padding: 15px 5px 0 5px;
+        .title {
+            display: block;
+            .font-size(10px);
+            color: #333;
+            text-transform: uppercase;
+            padding: 15px 0 0;
+        }
     }
 }
 
@@ -387,7 +386,6 @@ ul.section-items {
     ul.submenu  {
         background-color: #fff;
         left: 0;
-        width: 190px;
 
         li {
             border: none;
@@ -465,7 +463,6 @@ ul.section-items {
         ul.submenu {
             background-color: #fff;
             left: 25%;
-            width: 50%;
 
             li {
                 border: none;


### PR DESCRIPTION
## Description

Under the Other Releases drop down menu:

* Replace Desktop **Latest Beta** link with **Latest Beta & Developer Edition**
* Add Desktop **Latest Nightly** link
* Remove Android **Latest Aurora** link

Plus redundant code clean-up.

## Bugzilla link

[Bug 1358198](https://bugzilla.mozilla.org/show_bug.cgi?id=1358198)

## Testing

Open any release notes page, and make sure the Other Releases drop down menu contains **Latest Beta & Developer Edition** and **Latest Nightly** under Desktop as well as **Latest Beta** under Android. Note that **Latest Nightly** for Android will be added later, so it shouldn't be there for now.

## Checklist
- [ ] Requires l10n changes.
- [x] Related functional & integration tests passing.
