### PR TITLE
Fix Bug 1359609 - Add Nightly release notes link to desktop channel page

### DIFF
--- a/bedrock/firefox/templates/firefox/channel/desktop.html
+++ b/bedrock/firefox/templates/firefox/channel/desktop.html
@@ -96,6 +96,7 @@
   <footer>
     <div class="container">
       <ul>
+        <li><a href="{{ firefox_url('desktop', 'notes', 'nightly') }}">{{_('Release Notes')}}</a></li>
         <li><a rel="external" href="https://blog.nightly.mozilla.org/">{{_('Nightly Blog')}}</a></li>
         <li><a href="{{ firefox_url('desktop', 'all', 'nightly') }}">{{_('All Languages and Builds (incl. Win 64)')}}</a></li>
       </ul>


### PR DESCRIPTION
## Description

Simply add a link to the new [Firefox Nightly Release Notes](https://www.mozilla.org/firefox/nightly/notes/) to the [desktop channel page](https://www.mozilla.org/firefox/channel/desktop/). The *Release Notes* string is already used for Beta and Developer Edition, so no l10n changes required here.

## Bugzilla link

[Bug 1359609](https://bugzilla.mozilla.org/show_bug.cgi?id=1359609)

## Testing

Visit the desktop channel page and make sure the Release Notes link is displayed under Nightly.

## Checklist
- [ ] Requires l10n changes.
- [x] Related functional & integration tests passing.
