### PR TITLE
Update Firefox base template for new hub pages

### DIFF
--- a/bedrock/firefox/templates/firefox/base-pebbles.html
+++ b/bedrock/firefox/templates/firefox/base-pebbles.html
@@ -2,8 +2,6 @@
  # License, v. 2.0. If a copy of the MPL was not distributed with this
  # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
 
-{% add_lang_files "firefox/new" %}
-
 {% extends "base-pebbles.html" %}
 
 {% block page_title_prefix %}{{_('Mozilla Firefox Web Browser')}} — {% endblock %}
@@ -11,5 +9,10 @@
 {% block page_favicon %}{{ static('img/firefox/favicon.ico') }}{% endblock %}
 {% block page_favicon_large %}{{ static('img/firefox/favicon-196.png') }}{% endblock %}
 {% block page_ios_icon %}{{ static('img/firefox/ios-icon-180.png') }}{% endblock %}
+
+{% block facebook_id %}14696440021{# facebook.com/Firefox #}{% endblock %}
+{% block twitter_id %}firefox{% endblock %}
+
+{% block body_attrs %}{{ super() }} data-global-nav-current-link="firefox"{% endblock %}
 
 {% block tabzilla_tab %}{% endblock %}


### PR DESCRIPTION
- Add global nav default highlight attribute
- Use correct Twitter / Facebook accounts in meta data
- Remove superfluous /firefox/new lang file
