### PR TITLE
Fix Bug 1350305 - Replace One and Done, remove badge link on Nightly firstrun page

### DIFF
--- a/bedrock/firefox/templates/firefox/nightly_firstrun.html
+++ b/bedrock/firefox/templates/firefox/nightly_firstrun.html
@@ -43,7 +43,7 @@
         <p class="description">
           {{ _('Find and file bugs and generally make sure things work as they should.') }}
         </p>
-        <a rel="external" data-element-type="button" href="{{ _('https://oneanddone.mozilla.org') }}" class="button">{{ _('Start testing') }}</a>
+        <a rel="external" data-element-type="button" href="{{ _('https://quality.mozilla.org/get-involved/') }}" class="button">{{ _('Start testing') }}</a>
       </div>
     </section>
     <section class="blue-box code">
@@ -68,12 +68,6 @@
         <a rel="external" data-element-type="button" href="{{ _('https://wiki.mozilla.org/L10n:Contribute') }}" class="button">{{ _('Start localizing') }}</a>
       </div>
     </section>
-  </div>
-  <div class="blue-box badge">
-    <h3>{{ _('Show everyone that you’re helping to build the Web the world needs.') }}</h3>
-    <p class="description">
-      <a rel="external" data-element-type="link" href="https://badges.mozilla.org/badges/claim/vpvacp">{{ _('Get your Nightly User badge') }}</a>
-    </p>
   </div>
 
   {% if not request.locale.startswith('en') %}


### PR DESCRIPTION
## Description

On the [Nightly firstrun page](https://www.mozilla.org/en-US/firefox/nightly/firstrun/):

* Replace One and Done, which is no longer available, with Get Involved with QA
* Remove Nightly user badge, which is also no longer available

The One and Done link has been exposed as a localizable string, but no locale has customized the URL so far. Given that, l10n shouldn't be a blocker here. Cc @flodolo for the string updates.

## Bugzilla link

[Bug 1350305](https://bugzilla.mozilla.org/show_bug.cgi?id=1350305)

## Testing

Just visit the firstrun page to see the links are updated/removed.

## Checklist
- [x] Requires l10n changes.
- [x] Related functional & integration tests passing.
