### PR TITLE
Fix Bug 1359091 - Release notes top menu should have a link to the pre-release channel page

### DIFF
--- a/bedrock/firefox/templates/firefox/includes/release-menu.html
+++ b/bedrock/firefox/templates/firefox/includes/release-menu.html
@@ -1,11 +1,14 @@
 <nav id="nav-main" role="navigation">
   <span id="nav-main-toggle" class="toggle" role="button" aria-controls="nav-main-menu" aria-expanded="false" tabindex="0">{{_('Menu')}}</span>
   <ul id="nav-main-menu">
-    <li class="first"><a class="more" rel="external" href="https://developer.mozilla.org">{{_('MDN')}}</a>
-    </li>
-    <li><a href="{{ url('firefox') }}">{{_('Firefox')}}</a>
-    </li>
-    <li><a href="{{ url('firefox.developer') }}">{{_('Firefox Developer Edition')}}</a>
-    </li>
+    <li class="first"><a class="more" rel="external" href="https://developer.mozilla.org">{{_('MDN')}}</a></li>
+    <li><a href="{{ url('firefox') }}">{{_('Firefox')}}</a></li>
+    {% if release.product == 'Firefox for Android' %}
+    <li><a href="{{ url('firefox.channel.android') }}">{{_('Pre-release downloads')}}</a></li>
+    {% elif release.product == 'Firefox for iOS' %}
+    <li><a href="{{ url('firefox.channel.ios') }}">{{_('Pre-release downloads')}}</a></li>
+    {% else %}
+    <li><a href="{{ url('firefox.channel.desktop') }}">{{_('Pre-release downloads')}}</a></li>
+    {% endif %}
   </ul>
 </nav>


### PR DESCRIPTION
## Description

* Add a channel page link to the top menu on release notes.
* Remove Developer Edition link from Android/iOS notes.

Release notes are not localized, so no l10n changes required.

## Bugzilla link

[Bug 1359091](https://bugzilla.mozilla.org/show_bug.cgi?id=1359091)

## Testing

Visit release notes and make sure there is a channel link based on the platform. The label says **Firefox Beta** on the iOS notes, **Firefox Nightly & Beta** otherwise.

## Checklist
- [ ] Requires l10n changes.
- [x] Related functional & integration tests passing.
