### PR TITLE
Fix Bug 1360034 - Show bug ID field in Nightly release notes

### DIFF
--- a/bedrock/firefox/templates/firefox/releases/release-notes.html
+++ b/bedrock/firefox/templates/firefox/releases/release-notes.html
@@ -132,9 +132,7 @@
               <h4>{{ note.tag }}</h4>
               <ul class="section-items">
               {% endif %}
-                <li id="note-{{ note.id }}">
-                  {{ note.note|markdown|safe }}
-                </li>
+              {{ note_entry(note) }}
               {% if loop.last %}
               </ul>
             </div>
@@ -147,9 +145,7 @@
               <h4>{{ note.tag }}</h4>
               <ul class="section-items">
               {% endif %}
-                <li id="note-{{ note.id }}">
-                  {{ note.note|markdown|safe }}
-                </li>
+              {{ note_entry(note) }}
               {% if loop.last %}
               </ul>
             </div>
@@ -162,9 +158,7 @@
               <h4>{{ note.tag }}</h4>
               <ul class="section-items">
               {% endif %}
-                <li id="note-{{ note.id }}">
-                  {{ note.note|markdown|safe }}
-                </li>
+              {{ note_entry(note) }}
               {% if loop.last %}
               </ul>
             </div>
@@ -177,9 +171,7 @@
               <h4>{{ note.tag }}</h4>
               <ul class="section-items">
               {% endif %}
-                <li id="note-{{ note.id }}">
-                  {{ note.note|markdown|safe }}
-                </li>
+              {{ note_entry(note) }}
               {% if loop.last %}
               </ul>
               <a class="mdn-icon more" rel="external" href="https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/{{ release.major_version() }}">{{ _('Developer Information') }}</a>
@@ -193,9 +185,7 @@
               <h4>{{ note.tag }}</h4>
               <ul class="section-items">
               {% endif %}
-                <li id="note-{{ note.id }}">
-                  {{ note.note|markdown|safe }}
-                </li>
+              {{ note_entry(note) }}
               {% if loop.last %}
               </ul>
             </div>
@@ -208,9 +198,7 @@
               <h4>{{ note.tag }}</h4>
               <ul class="section-items">
               {% endif %}
-                <li id="note-{{ note.id }}">
-                  {{ note.note|markdown|safe }}
-                </li>
+              {{ note_entry(note) }}
               {% if loop.last %}
               </ul>
             </div>
@@ -223,9 +211,7 @@
               <h4>{{ note.tag }}</h4>
               <ul class="section-items untagged">
               {% endif %}
-                <li id="note-{{ note.id }}">
-                  {{ note.note|markdown|safe }}
-                </li>
+              {{ note_entry(note) }}
               {% if loop.last %}
               </ul>
             </div>
@@ -240,9 +226,7 @@
               <h4>{{ _('unresolved') }}</h4>
               <ul class="section-items">
               {% endif %}
-                <li id="note-{{ note.id }}">
-                  {{ note.note|markdown|safe }}
-                </li>
+              {{ note_entry(note) }}
               {% if loop.last %}
               </ul>
             </div>
@@ -327,3 +311,12 @@
     {% include 'includes/stat_counter.html' %}
   {% endif %}
 {% endblock %}
+
+{% macro note_entry(note) %}
+  <li id="note-{{ note.id }}">
+    {{ note.note|markdown|safe }}
+    {% if release.channel == 'Nightly' and note.bug -%}
+    <span class="bug-id"><a href="https://bugzilla.mozilla.org/show_bug.cgi?id={{ note.bug }}">{{ _('Bug %d')|format(note.bug) }}</a></span>
+    {%- endif %}
+  </li>
+{% endmacro %}

--- a/media/css/firefox/releasenotes-firefox.less
+++ b/media/css/firefox/releasenotes-firefox.less
@@ -246,6 +246,13 @@ ul.section-items {
             margin: 0;
             padding: 0;
         }
+
+        .bug-id {
+            display: block;
+            margin-top: 5px;
+            .font-size(12px);
+            text-align: right;
+        }
     }
     li:nth-child(odd) {
         background-color: rgba(223, 236, 250, 0.41);


### PR DESCRIPTION
## Description

Show the relevant bug ID on each note entry to make Nightly release notes more informative. Currently bug IDs are displayed only when manually added to the description, but there's actually the bug ID field for each note, so let's use it.

## Bugzilla link

[Bug 1360034](https://bugzilla.mozilla.org/show_bug.cgi?id=1360034)

## Testing

* Open the Nightly release notes at `/firefox/nightly/notes/` to see a bug ID reference on each note, like [this screenshot](https://bug1360034.bmoattachments.org/attachment.cgi?id=8862500).
* Open non-Nightly release notes e.g. `/firefox/notes/` or `/firefox/beta/notes/` to make sure bug IDs are not displayed.

## Checklist
- [ ] Requires l10n changes.
- [x] Related functional & integration tests passing.
