### PR TITLE
[fix bug 1360462] Update funnelcake download & firstrun views for 110-113

### DIFF
--- a/bedrock/firefox/templates/firefox/firstrun/new-firstrun.html
+++ b/bedrock/firefox/templates/firefox/firstrun/new-firstrun.html
@@ -27,8 +27,10 @@
         <a href="{{ url('firefox.sync') }}">{{_('Learn more about Firefox Accounts')}}</a>
       </div>
       <div id="firefox-logo"></div>
+      {# Bug 1354710: firstrun pages need to pass funnelcake parameters to FxA #}
+      {% set utm_source = 'firstrun' if not funnelcake_id else 'firstrun_f' + funnelcake_id %}
       <div class="fxaccounts" id="fxa-iframe-config" data-host="{{ settings.FXA_IFRAME_SRC }}" data-mozillaonline-host="{{ settings.FXA_IFRAME_SRC_MOZILLAONLINE }}">
-        <iframe id="fxa" scrolling="no" data-src="{{ settings.FXA_IFRAME_SRC }}signin?utm_campaign=fxa-embedded-form&amp;utm_medium=referral&amp;utm_source=firstrun&amp;utm_content=fx-{{ version }}&amp;entrypoint=firstrunwow{{ funnelcake_id }}&amp;service=sync&amp;context=iframe&amp;style=chromeless&amp;haltAfterSignIn=true"></iframe>
+        <iframe id="fxa" scrolling="no" data-src="{{ settings.FXA_IFRAME_SRC }}signin?utm_campaign=fxa-embedded-form&amp;utm_medium=referral&amp;utm_source={{ utm_source }}&amp;utm_content=fx-{{ version }}&amp;entrypoint=firstrunwow{{ funnelcake_id }}&amp;service=sync&amp;context=iframe&amp;style=chromeless&amp;haltAfterSignIn=true"></iframe>
         <button id="skip-button">{{_('Skip this step')}}</button>
       </div>
     </div>

--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -383,7 +383,7 @@ class FirstrunView(l10n_utils.LangFilesMixin, TemplateView):
             template = 'firefox/dev-firstrun.html'
         elif show_40_firstrun(version):
             # New onboarding animation funnecake
-            if locale == 'en-US' and funnelcake in ['99', '100']:
+            if locale == 'en-US' and funnelcake in ['99', '100', '111', '112', '113']:
                 template = 'firefox/firstrun/new-firstrun.html'
             # Yahoo search retention funnelcake test
             elif locale == 'en-US' and funnelcake == '92':
@@ -492,7 +492,7 @@ def new(request):
 
     if scene == '2':
         if locale == 'en-US':
-            if funnelcake_id in ['99', '100', '110', '111', '112', '113']:
+            if funnelcake_id in ['99', '100', '111', '112', '113']:
                 template = 'firefox/new/onboarding/scene2.html'
             elif experience == 'breakfree':
                 template = 'firefox/new/break-free/scene2.html'
@@ -505,7 +505,7 @@ def new(request):
     # if no/incorrect scene specified, show scene 1
     else:
         if locale == 'en-US':
-            if funnelcake_id in ['99', '100', '110', '111', '112', '113']:
+            if funnelcake_id in ['99', '100', '111', '112', '113']:
                 template = 'firefox/new/onboarding/scene1.html'
             elif experience == 'breakfree':
                 template = 'firefox/new/break-free/scene1.html'


### PR DESCRIPTION
## Description

Follow-up to #4778. More requirements came in to:

1. Show standard/canonical `/firefox/new/` scenes 1 & 2 for funnelcake 110
2. Use `new-firstrun.html` for funnelcakes 111, 112, & 113
3. Add updated `utm_source` logic to `new-firstrun.html` template

## Bugzilla link

https://bugzilla.mozilla.org/show_bug.cgi?id=1360462
https://bugzilla.mozilla.org/show_bug.cgi?id=1360397

## Testing

- Ensure `/firefox/new/?f=110` shows the standard/canonical template.
- Ensure `/firefox/new/?f=[111-113]` shows the `onboarding/scene[1-2].html` template.
- Ensure `/firefox/53.0/firstrun/?f=110` shows the standard/canonical template
- Ensure `/firefox/53.0/firstrun/?f=[111-113]` shows the `new-firstrun.html` template.

https://bedrock-demo-jpetto-fc.us-west.moz.works/en-US/firefox/new/?f=110
https://bedrock-demo-jpetto-fc.us-west.moz.works/en-US/firefox/new/?f=111
https://bedrock-demo-jpetto-fc.us-west.moz.works/en-US/firefox/new/?f=112
https://bedrock-demo-jpetto-fc.us-west.moz.works/en-US/firefox/new/?f=113

https://bedrock-demo-jpetto-fc.us-west.moz.works/en-US/firefox/53.0/firstrun/?f=110
https://bedrock-demo-jpetto-fc.us-west.moz.works/en-US/firefox/53.0/firstrun/?f=111
https://bedrock-demo-jpetto-fc.us-west.moz.works/en-US/firefox/53.0/firstrun/?f=112
https://bedrock-demo-jpetto-fc.us-west.moz.works/en-US/firefox/53.0/firstrun/?f=113

Marking as **DO NOT MERGE** while mverdi et al verify all is as they need it, but should be good for review.

## Checklist
- [ ] Requires l10n changes.
- [ ] Related functional & integration tests passing.
