### PR TITLE
Fix bug 1300373: Remove redirect handler for trailing slashes

### DIFF
--- a/bedrock/redirects/redirects.py
+++ b/bedrock/redirects/redirects.py
@@ -2050,7 +2050,4 @@ redirectpatterns = (
     # bug 832348 **/index.html -> **/
     # leave this at the bottom
     redirect(r'^(.*)/index\.html$', '/{}/', locale_prefix=False),
-    # Bug 1255882
-    # multiple trailing slashes
-    redirect(r'^(.*[^/])//+$', '/{}/', locale_prefix=False),
 )

--- a/tests/redirects/map_htaccess.py
+++ b/tests/redirects/map_htaccess.py
@@ -130,7 +130,6 @@ URLS = flatten((
     url_test('/en-US/firefox/help/', 'https://support.mozilla.org/'),
 
     # Bug 1255882
-    url_test('/some/url///', '/some/url/'),
     url_test('/de/firefox/about/', '/de/about/'),
 
     # bug 453506, 1255882


### PR DESCRIPTION
Django handles this properly now. We no longer need this.

See bug 1300373 for more details.