### PR TITLE
Fix bug 1300373: redirect helper never return protocol relative URLs

### DIFF
--- a/bedrock/redirects/redirects.py
+++ b/bedrock/redirects/redirects.py
@@ -2050,4 +2050,7 @@ redirectpatterns = (
     # bug 832348 **/index.html -> **/
     # leave this at the bottom
     redirect(r'^(.*)/index\.html$', '/{}/', locale_prefix=False),
+    # Bug 1255882
+    # multiple trailing slashes
+    redirect(r'^(.*[^/])//+$', '/{}/', locale_prefix=False),
 )

--- a/tests/redirects/map_htaccess.py
+++ b/tests/redirects/map_htaccess.py
@@ -130,7 +130,13 @@ URLS = flatten((
     url_test('/en-US/firefox/help/', 'https://support.mozilla.org/'),
 
     # Bug 1255882
+    url_test('/some/url///', '/some/url/'),
+    url_test('////', '/en-US/'),
+    url_test('/en-US///', '/en-US/'),
     url_test('/de/firefox/about/', '/de/about/'),
+
+    # bug 1300373
+    url_test('/%2fgoogle.com//', '/google.com/'),
 
     # bug 453506, 1255882
     url_test('/editor/editor-embedding.html',


### PR DESCRIPTION
Manually prevent the redirect helper function from returning protocol relative URLs (e.g. //google.com/) as this could allow unexpected redirection to other domains and we never need to redirect to an unknown protocol.

Also add shortcuts that skip Django's `reverse` function when the input is obviously a URL.