### PR TITLE
[fix bug 1348129] Adjust funnelcake experiment audience size

### DIFF
--- a/media/js/firefox/new/experiment-funnelcakes-110-113.js
+++ b/media/js/firefox/new/experiment-funnelcakes-110-113.js
@@ -17,10 +17,10 @@
             id: 'experiment-funnelcakes-110-113',
             cookieExpires: 168, // 1 week
             variations: {
-                'f=110': 7,
-                'f=111': 7,
-                'f=112': 7,
-                'f=113': 7
+                'f=110': 1,
+                'f=111': 1,
+                'f=112': 1,
+                'f=113': 1
             }
         });
 


### PR DESCRIPTION
## Description

Reduces audience size initially to be careful testing funnelcakes. Will increase audience size as soon as funnelcakes are considered safe.

## Bugzilla link

https://bugzilla.mozilla.org/show_bug.cgi?id=1348129#c44

## Testing

## Checklist
- [ ] Requires l10n changes.
- [ ] Related functional & integration tests passing.
