### PR TITLE
[fix bug 1361175] Remove custom entrypoint param from firstrun template

### DIFF
--- a/bedrock/firefox/templates/firefox/firstrun/new-firstrun.html
+++ b/bedrock/firefox/templates/firefox/firstrun/new-firstrun.html
@@ -30,7 +30,7 @@
       {# Bug 1354710: firstrun pages need to pass funnelcake parameters to FxA #}
       {% set utm_source = 'firstrun' if not funnelcake_id else 'firstrun_f' + funnelcake_id %}
       <div class="fxaccounts" id="fxa-iframe-config" data-host="{{ settings.FXA_IFRAME_SRC }}" data-mozillaonline-host="{{ settings.FXA_IFRAME_SRC_MOZILLAONLINE }}">
-        <iframe id="fxa" scrolling="no" data-src="{{ settings.FXA_IFRAME_SRC }}signin?utm_campaign=fxa-embedded-form&amp;utm_medium=referral&amp;utm_source={{ utm_source }}&amp;utm_content=fx-{{ version }}&amp;entrypoint=firstrunwow{{ funnelcake_id }}&amp;service=sync&amp;context=iframe&amp;style=chromeless&amp;haltAfterSignIn=true"></iframe>
+        <iframe id="fxa" scrolling="no" data-src="{{ settings.FXA_IFRAME_SRC }}signin?utm_campaign=fxa-embedded-form&amp;utm_medium=referral&amp;utm_source={{ utm_source }}&amp;utm_content=fx-{{ version }}&amp;entrypoint=firstrun&amp;service=sync&amp;context=iframe&amp;style=chromeless&amp;haltAfterSignIn=true"></iframe>
         <button id="skip-button">{{_('Skip this step')}}</button>
       </div>
     </div>


### PR DESCRIPTION
## Description

Removes custom `entrypoint` param behavior on FxA iframe.

## Bugzilla link

https://bugzilla.mozilla.org/show_bug.cgi?id=1361175

## Testing

Make sure `entrypoint` params matches FxA implementations on other pages.

## Checklist
- [ ] Requires l10n changes.
- [ ] Related functional & integration tests passing.
