### PR TITLE
[fix bug 1348129] Increase experiment audience size.

### DIFF
--- a/media/js/firefox/new/experiment-funnelcakes-110-113.js
+++ b/media/js/firefox/new/experiment-funnelcakes-110-113.js
@@ -17,10 +17,10 @@
             id: 'experiment-funnelcakes-110-113',
             cookieExpires: 168, // 1 week
             variations: {
-                'f=110': 1,
-                'f=111': 1,
-                'f=112': 1,
-                'f=113': 1
+                'f=110': 7,
+                'f=111': 7,
+                'f=112': 7,
+                'f=113': 7
             }
         });
 


### PR DESCRIPTION
## Description

Funnelcakes look good at 1% per variation - increasing to 7% per.

## Bugzilla link

https://bugzilla.mozilla.org/show_bug.cgi?id=1348129#c47

## Testing

## Checklist
- [ ] Requires l10n changes.
- [ ] Related functional & integration tests passing.
