### PR TITLE
[fix bug 1333294] Remove links to iOS release notes

### DIFF
--- a/bedrock/firefox/templates/firefox/releases/aurora-notes.html
+++ b/bedrock/firefox/templates/firefox/releases/aurora-notes.html
@@ -18,7 +18,6 @@
       <ul class="menu">
         <li><a href="{{ url('firefox.notes') }}">{{ _('Desktop') }}</a></li>
         <li><a href="{{ url('firefox.notes', platform='android') }}">{{ _('Android') }}</a></li>
-        <li><a href="{{ url('firefox.notes', platform='ios') }}">{{ _('iOS') }}</a></li>
         <li class="current submenu-title">
           <a>{{ _('Other Releases') }}</a>
           <ul class="submenu">

--- a/bedrock/firefox/templates/firefox/releases/beta-notes.html
+++ b/bedrock/firefox/templates/firefox/releases/beta-notes.html
@@ -20,7 +20,6 @@
       <ul class="menu">
         <li><a href="{{ url('firefox.notes') }}">{{ _('Desktop') }}</a></li>
         <li><a href="{{ url('firefox.notes', platform='android') }}">{{ _('Android') }}</a></li>
-        <li><a href="{{ url('firefox.notes', platform='ios') }}">{{ _('iOS') }}</a></li>
         <li class="current submenu-title">
           <a>{{ _('Other Releases') }}</a>
           <ul class="submenu">

--- a/bedrock/firefox/templates/firefox/releases/release-notes.html
+++ b/bedrock/firefox/templates/firefox/releases/release-notes.html
@@ -76,15 +76,9 @@
           {% if release.product == 'Firefox for Android' %}
             <li><a href="{{ url('firefox.notes') }}">{{ _('Desktop') }}</a></li>
             <li class="current">{{ _('Android') }}</li>
-            <li><a href="{{ url('firefox.notes', platform='ios') }}">{{ _('iOS') }}</a></li>
-          {% elif release.product == 'Firefox for iOS' %}
-            <li><a href="{{ url('firefox.notes') }}">{{ _('Desktop') }}</a></li>
-            <li><a href="{{ url('firefox.notes', platform='android') }}">{{ _('Android') }}</a></li>
-            <li class="current">{{ _('iOS') }}</li>
           {% else %}
             <li class="current">{{ _('Desktop') }}</li>
             <li><a href="{{ url('firefox.notes', platform='android') }}">{{ _('Android') }}</a></li>
-            <li><a href="{{ url('firefox.notes', platform='ios') }}">{{ _('iOS') }}</a></li>
           {% endif %}
             <li class="submenu-title">
               <a href="#" role="button" aria-controls="nav-submenu" aria-expanded="false">{{ _('Other Releases') }}</a>


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1333294