### PR TITLE
Fix Bug 1359037 - Provide some syndication feature to Nightly release notes

### DIFF
--- a/bedrock/firefox/templates/firefox/releases/nightly-feed.xml
+++ b/bedrock/firefox/templates/firefox/releases/nightly-feed.xml
@@ -1,0 +1,32 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+
+<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>{{ _('Firefox Nightly Notes') }}</title>
+  <subtitle>{{ _('Firefox Nightly gets a new version every day and as a consequence, the release notes for the Nightly channel are updated continuously to reflect features that have reached sufficient maturity to benefit from community feedback and bug reports.') }}</subtitle>
+  <author>
+    <name>{{ _('Mozilla') }}</name>
+  </author>
+  <id>{{ url('firefox.nightly.notes.feed')|absolute_url }}</id>
+  <link rel="self" type="application/atom+xml" href="{{ url('firefox.nightly.notes.feed')|absolute_url }}"/>
+  <link rel="alternate" type="text/html" href="{{ url('firefox.notes', channel='nightly')|absolute_url }}"/>
+  <icon>{{ static('img/firefox/nightly/favicon.png')|absolute_url }}</icon>
+  <updated>{{ notes[0].modified.isoformat() }}</updated>
+  {% for note in notes %}
+  <entry>
+    <title>{{ note.note|markdown|striptags|truncate(100) }}</title>
+    <id>{{ note.link|absolute_url }}</id>
+    <link rel="alternate" type="text/html" href="{{ note.link|absolute_url }}"/>
+    <updated>{{ note.modified.isoformat() }}</updated>
+    <content type="xhtml">
+      <div xmlns="http://www.w3.org/1999/xhtml">
+        {{ note.version }} / {{ note.tag }}
+        {%- if note.bug %} / <a href="https://bugzilla.mozilla.org/show_bug.cgi?id={{ note.bug }}">{{ _('Bug %d')|format(note.bug) }}</a>{% endif %}
+        {{ note.note|markdown|safe }}
+      </div>
+    </content>
+  </entry>
+  {% endfor %}
+</feed>

--- a/bedrock/firefox/templates/firefox/releases/nightly-notes.html
+++ b/bedrock/firefox/templates/firefox/releases/nightly-notes.html
@@ -3,3 +3,7 @@
  # file, You can obtain one at http://mozilla.org/MPL/2.0/. #}
 
 {% extends "firefox/releases/release-notes.html" %}
+
+{% block extrahead %}
+<link rel="alternate" type="application/atom+xml" title="{{ _('Firefox Nightly Notes Feed') }}" href="{{ url('firefox.nightly.notes.feed') }}">
+{% endblock %}

--- a/bedrock/firefox/urls.py
+++ b/bedrock/firefox/urls.py
@@ -106,6 +106,8 @@ urlpatterns = (
     # Release notes
     url('^firefox/(?:%s/)?(?:%s/)?notes/$' % (platform_re, channel_re),
         bedrock.releasenotes.views.latest_notes, name='firefox.notes'),
+    url('^firefox/nightly/notes/feed/$',
+        bedrock.releasenotes.views.nightly_feed, name='firefox.nightly.notes.feed'),
     url('firefox/(?:latest/)?releasenotes/$', bedrock.releasenotes.views.latest_notes,
         {'product': 'firefox'}),
     url('^firefox/(?:%s/)?system-requirements/$' % channel_re,


### PR DESCRIPTION
## Description

Add an Atom feed of the [Firefox Nightly notes](https://www.mozilla.org/en-US/firefox/nightly/notes/) so people can subscribe to the latest changes in Nightly.

## Bugzilla link

[Bug 1359037](https://bugzilla.mozilla.org/show_bug.cgi?id=1359037)

## Testing

* Visit `/firefox/nightly/notes/feed/` to make sure the feed is served properly.
* Visit `/firefox/nightly/notes/` to make sure there is a link to the feed. In Firefox, **Subscribe to This Page...** in the **Bookmarks** menu will be enabled.

## Checklist
- [ ] Requires l10n changes.
- [x] Related functional & integration tests passing.
