### PR TITLE
Fix Bug 1236936 - Many broken links in Security Advisory pages

### DIFF
--- a/bedrock/security/tests/test_views.py
+++ b/bedrock/security/tests/test_views.py
@@ -98,3 +98,22 @@ class TestKVRedirects(TestCase):
         path = '/en-US/security/known-vulnerabilities/the-dude-abides-15.html'
         resp = self.client.get(path)
         eq_(resp.status_code, 410)
+
+
+class TestOldAdvisories(TestCase):
+    def _test_redirect(self, path, expected):
+        # old urls lack '/en-US' prefix, but that will be the first redirect.
+        resp = self.client.get('/en-US' + path)
+        eq_(resp.status_code, 301)
+        ok_(resp['Location'].endswith(expected))
+
+    def test_old_urls(self):
+        """Should redirect old URLs properly."""
+        self._test_redirect('/security/announce/mfsa2005-31.html',
+                            '/security/advisories/mfsa2005-31/')
+        self._test_redirect('/security/announce/2005/mfsa2005-40.html',
+                            '/security/advisories/mfsa2005-40/')
+        self._test_redirect('/security/advisories/2008/mfsa2008-47.html',
+                            '/security/advisories/mfsa2008-47/')
+        self._test_redirect('/security/advisories/mfsa2008-66/mfsa2008-37.html',
+                            '/security/advisories/mfsa2008-37/')

--- a/bedrock/security/urls.py
+++ b/bedrock/security/urls.py
@@ -39,6 +39,7 @@ urlpatterns = (
         ProductVersionView.as_view(), name='security.product-version-advisories'),
     url(r'^known-vulnerabilities/(?P<filename>.*)\.html$', KVRedirectsView.as_view()),
 
-    url(r'^announce/\d{4}/mfsa(?P<pk>\d{4}-\d{2,3})\.html$', OldAdvisoriesView.as_view()),
+    url(r'^(?:announce|advisories)(?:/.*)?/mfsa(?P<pk>\d{4}-\d{2,3})\.html$',
+        OldAdvisoriesView.as_view()),
     url(r'^announce/$', OldAdvisoriesListView.as_view()),
 )


### PR DESCRIPTION
## Description

Fix some older advisory URLs not redirected properly.

## Bugzilla link

[Bug 1236936](https://bugzilla.mozilla.org/show_bug.cgi?id=1236936)

## Testing

Visit `/security/announce/mfsa2005-31.html` and other URLs written in `test_views.py` to make sure you'll be directed to the correct advisories.

## Checklist
- [ ] Requires l10n changes.
- [x] Related functional & integration tests passing.
