### PR TITLE
[fix bug 1363239] Header CSS height differences on new /firefox/features/ page

### DIFF
--- a/media/css/firefox/features/common.scss
+++ b/media/css/firefox/features/common.scss
@@ -26,7 +26,7 @@ main {
         content: '';
         display: block;
         height: 6px;
-        margin: 20px 0 25px;
+        margin: 0 0 25px;
     }
 }
 
@@ -144,6 +144,12 @@ main {
             @include span(3);
             padding: 60px 0 0;
         }
+    }
+}
+
+#firefox-features-landing {
+    .header-intro h1:first-letter {
+        letter-spacing: .025em;
     }
 }
 


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1363239