### PR TITLE
Fix Bug 1355072 - [nightly] First run page, has 2 vertical scrollbars if you change the window size.

### DIFF
--- a/media/css/firefox/nightly_firstrun.less
+++ b/media/css/firefox/nightly_firstrun.less
@@ -9,6 +9,10 @@ html {
     overflow-x: hidden;
 }
 
+body {
+    overflow-x: visible;
+}
+
 h1,
 h2,
 h3,


### PR DESCRIPTION
## Description

Remove an unnecessary scrollbar due to `overflow-x: hidden` on both `<html>` and `<body>`.

## Bugzilla link

[Bug 1355072](https://bugzilla.mozilla.org/show_bug.cgi?id=1355072)

## Testing

Open the Nightly firstrun page at `/firefox/nightly/firstrun/`, resize the window, and make sure there is only one vertical scrollbar.

## Checklist
- [ ] Requires l10n changes.
- [x] Related functional & integration tests passing.
