### PR TITLE
Fix Bug 1058017 - Stub installer for Nightly not working, redirect page missing Nightly

### DIFF
--- a/bedrock/firefox/templates/firefox/includes/download-button.html
+++ b/bedrock/firefox/templates/firefox/includes/download-button.html
@@ -77,6 +77,8 @@
                   {{ _('<span>Firefox Beta</span> for Android') }}
                 {% elif channel == 'alpha' %}
                   {{ _('<span>Firefox Aurora</span> for Android') }}
+                {% elif channel == 'nightly' %}
+                  {{ _('<span>Firefox Nightly</span> for Android') }}
                 {% else %}
                   {{ _('<span>Firefox</span> for Android') }}
                 {% endif %}
@@ -87,6 +89,8 @@
                   {{ _('Firefox Beta') }}
                 {% elif channel == 'alpha' %}
                   {{ _('<span>Firefox</span> Developer Edition') }}
+                {% elif channel == 'nightly' %}
+                  {{ _('Firefox Nightly') }}
                 {% else %}
                   {{ _('Download Firefox') }}
                 {% endif %}

--- a/bedrock/firefox/templates/firefox/installer-help.html
+++ b/bedrock/firefox/templates/firefox/installer-help.html
@@ -63,6 +63,10 @@
       <div class="download-box" id="aurora-desktop">
         {{ download_firefox('alpha', platform='desktop', force_direct=True, force_full_installer=True, locale=installer_lang) }}
       </div>
+
+      <div class="download-box" id="nightly-desktop">
+        {{ download_firefox('nightly', platform='desktop', force_direct=True, force_full_installer=True, locale=installer_lang) }}
+      </div>
     {% endif %}
   </div>
  </div>

--- a/tests/functional/firefox/test_installer_help.py
+++ b/tests/functional/firefox/test_installer_help.py
@@ -15,3 +15,4 @@ def test_download_buttons_displayed(base_url, selenium):
     assert page.firefox_download_button.is_displayed
     assert page.beta_download_button.is_displayed
     assert page.dev_edition_download_button.is_displayed
+    assert page.nightly_download_button.is_displayed

--- a/tests/pages/firefox/installer_help.py
+++ b/tests/pages/firefox/installer_help.py
@@ -15,6 +15,7 @@ class InstallerHelpPage(FirefoxBasePage):
     _firefox_download_button_locator = (By.ID, 'download-button-desktop-release')
     _beta_download_button_locator = (By.ID, 'download-button-desktop-beta')
     _dev_edition_download_button_locator = (By.ID, 'download-button-desktop-alpha')
+    _nightly_download_button_locator = (By.ID, 'download-button-desktop-nightly')
 
     @property
     def firefox_download_button(self):
@@ -29,4 +30,9 @@ class InstallerHelpPage(FirefoxBasePage):
     @property
     def dev_edition_download_button(self):
         el = self.find_element(*self._dev_edition_download_button_locator)
+        return DownloadButton(self, root=el)
+
+    @property
+    def nightly_download_button(self):
+        el = self.find_element(*self._nightly_download_button_locator)
         return DownloadButton(self, root=el)


### PR DESCRIPTION
## Description

Add a Firefox Nightly download button to the [installer help page](https://www.mozilla.org/en-US/firefox/installer-help/).

## Bugzilla link

[Bug 1058017](https://bugzilla.mozilla.org/show_bug.cgi?id=1058017)

## Testing

Visit `/firefox/installer-help/` and make sure there is a Nightly download button.

## Checklist
- [x] Requires l10n changes.
- [x] Related functional & integration tests passing.
