### PR TITLE
Fix Bug 1349339 - Mobile menu on /nightly/all is unreadable

### DIFF
--- a/bedrock/firefox/templates/firefox/all.html
+++ b/bedrock/firefox/templates/firefox/all.html
@@ -65,7 +65,7 @@
 
 {% block body_id %}firefox-all{% endblock %}
 {% block body_class -%}
-  sky {{ platform }} {{ channel }} {% if platform == 'desktop' and channel == 'alpha' %}blueprint{% endif %}
+  sky {{ platform }} {{ channel }} {% if platform == 'desktop' and channel in ['alpha', 'nightly'] %}blueprint{% endif %}
 {% endblock %}
 
 {% block page_css %}

--- a/media/css/firefox/all.less
+++ b/media/css/firefox/all.less
@@ -24,22 +24,11 @@ body.nightly {
         color: #61CCFF;
         text-shadow: none;
     }
+    #masthead h2 img {
+        height: auto;
+    }
     #main-feature h2 {
         color: #FFF;
-    }
-    #masthead nav li {
-        a,
-        a:link,
-        a:visited {
-            color: #FFF;
-        }
-        li {
-            a,
-            a:link,
-            a:visited {
-                color: @textColorSecondary;
-            }
-        }
     }
 }
 


### PR DESCRIPTION
## Description

Fix the mobile menu on [/firefox/nightly/all/](https://www.mozilla.org/en-US/firefox/nightly/all/) unreadable due to white text on white background. This PR also fixes the height of the header Nightly logo in the mobile viewport.

## Bugzilla link

[Bug 1349339](https://bugzilla.mozilla.org/show_bug.cgi?id=1349339)

## Testing

Visit `/firefox/nightly/all/`, resize the window, and make sure the drop down menu items are readable.

## Checklist
- [ ] Requires l10n changes.
- [x] Related functional & integration tests passing.
