### PR TITLE
[fix bug 1363411] Update Firefox hub page titles

### DIFF
--- a/bedrock/firefox/templates/firefox/base-pebbles.html
+++ b/bedrock/firefox/templates/firefox/base-pebbles.html
@@ -4,7 +4,8 @@
 
 {% extends "base-pebbles.html" %}
 
-{% block page_title_prefix %}{{_('Mozilla Firefox Web Browser')}} — {% endblock %}
+{% block page_title_prefix %}{% endblock %}
+{% block page_title_suffix %} | {{ _('Firefox') }}{% endblock %}
 {% block page_image %}{{ static('img/firefox/template/page-image.png') }}{% endblock %}
 {% block page_favicon %}{{ static('img/firefox/favicon.ico') }}{% endblock %}
 {% block page_favicon_large %}{{ static('img/firefox/favicon-196.png') }}{% endblock %}

--- a/bedrock/firefox/templates/firefox/features/base.html
+++ b/bedrock/firefox/templates/firefox/features/base.html
@@ -6,8 +6,6 @@
 
 {# L10n: strings for this page are not considered final and aren't ready for localization. #}
 
-{% block page_title_prefix %}{% endblock %}
-
 {% block page_css %}
   {% stylesheet 'firefox-features-hub-common' %}
 {% endblock %}

--- a/bedrock/firefox/templates/firefox/features/fast.html
+++ b/bedrock/firefox/templates/firefox/features/fast.html
@@ -7,6 +7,7 @@
 {# L10n: strings for this page are not considered final and aren't ready for localization. #}
 
 {% block page_title %}{{ _('Firefox is faster and more powerful than ever before') }}{% endblock %}
+{% block page_title_suffix %}{% endblock %}
 {% block page_desc %}{{ _('Firefox lets you do more, faster. Our new, powerful multi-process platform easily handles all your tabs without bogging down your computer.') }}{% endblock %}
 {% block page_image %}{{ static('img/firefox/features/page-image-fast.jpg') }}{% endblock %}
 

--- a/bedrock/firefox/templates/firefox/features/independent.html
+++ b/bedrock/firefox/templates/firefox/features/independent.html
@@ -7,6 +7,7 @@
 {# L10n: strings for this page are not considered final and aren't ready for localization. #}
 
 {% block page_title %}{{ _('Firefox, a different browser for different times. Browse free.') }}{% endblock %}
+{% block page_title_suffix %}{% endblock %}
 {% block page_desc %}{{ _('Browse the Internet as it was meant to be...free, safe, and accessible to everyone. Browse independently with Firefox.') }}{% endblock %}
 {% block page_image %}{{ static('img/firefox/features/page-image-independent.jpg') }}{% endblock %}
 

--- a/bedrock/firefox/templates/firefox/features/index.html
+++ b/bedrock/firefox/templates/firefox/features/index.html
@@ -7,6 +7,7 @@
 {# L10n: strings for this page are not considered final and aren't ready for localization. #}
 
 {% block page_title %}{{ _('Firefox Features: Privacy, Speed, Independence and more') }}{% endblock %}
+{% block page_title_suffix %}{% endblock %}
 {% block page_desc %}{{ _('Firefox is the only browser built for you by an independent nonprofit, Mozilla. Check out all the features that make Firefox better than the rest.') }}{% endblock %}
 {% block page_image %}{{ static('img/firefox/features/page-image-landing.jpg') }}{% endblock %}
 

--- a/bedrock/firefox/templates/firefox/features/private-browsing.html
+++ b/bedrock/firefox/templates/firefox/features/private-browsing.html
@@ -6,7 +6,7 @@
 
 {# L10n: strings for this page are not considered final and aren't ready for localization. #}
 
-{% block page_title %}{{ _('Private Browser Protects Your Online Privacy') }} | {{ _('Firefox') }}{% endblock %}
+{% block page_title %}{{ _('Private Browser Protects Your Online Privacy') }}{% endblock %}
 {% block page_desc %}{{ _('Firefox protects your online privacy and blocks trackers that follow you around the web. Get Firefox for private browsing!') }}{% endblock %}
 
 {% block page_image %}{{ static('img/firefox/features/page-image-private.jpg') }}{% endblock %}

--- a/bedrock/firefox/templates/firefox/products/android.html
+++ b/bedrock/firefox/templates/firefox/products/android.html
@@ -8,9 +8,7 @@
 
 {# L10n: strings for this page are not considered final and aren't ready for localization. #}
 
-{% block page_title_prefix %}{% endblock %}
-{% block page_title %}{{ _('Fast, Free Android Browser for Tablets and Phones | Firefox') }}{% endblock %}
-{% block page_title_suffix %}{% endblock %}
+{% block page_title %}{{ _('Fast, Free Android Browser for Tablets and Phones') }}{% endblock %}
 {% block page_desc %}{{ _('Choose a better browser for your tablet and phone. Firefox is fast and private. Install Firefox for Android now!') }}{% endblock %}
 {% block page_image %}{{ static('img/firefox/products/android/product-android-meta.jpg') }}{% endblock %}
 

--- a/bedrock/firefox/templates/firefox/products/desktop.html
+++ b/bedrock/firefox/templates/firefox/products/desktop.html
@@ -6,9 +6,7 @@
 
 {# L10n: strings for this page are not considered final and aren't ready for localization. #}
 
-{% block page_title_prefix %}{% endblock %}
-{% block page_title %}{{ _('Fast, private, modern browser for desktop computers | Firefox') }}{% endblock %}
-{% block page_title_suffix %}{% endblock %}
+{% block page_title %}{{ _('Fast, private, modern browser for desktop computers') }}{% endblock %}
 {% block page_desc %}{{ _('Firefox is a faster, safer and more private browser than ever before — for Windows, Mac, and Linux desktop computers. Download now!') }}{% endblock %}
 {% block page_image %}{{ static('img/firefox/products/desktop/product-desktop-meta.jpg') }}{% endblock %}
 

--- a/bedrock/firefox/templates/firefox/products/ios.html
+++ b/bedrock/firefox/templates/firefox/products/ios.html
@@ -6,9 +6,7 @@
 
 {# L10n: strings for this page are not considered final and aren't ready for localization. #}
 
-{% block page_title_prefix %}{% endblock %}
-{% block page_title %}{{ _('Free Mobile Browser App for iPhone, iPad, iOS | Firefox') }}{% endblock %}
-{% block page_title_suffix %}{% endblock %}
+{% block page_title %}{{ _('Free Mobile Browser App for iPhone, iPad, iOS') }}{% endblock %}
 {% block page_desc %}{{ _('Join the millions browsing better on iPhone and iPad. Firefox is fast and private. Install Firefox for iOS now!') }}{% endblock %}
 {% block page_image %}{{ static('img/firefox/products/ios/product-ios-meta.jpg') }}{% endblock %}
 


### PR DESCRIPTION
## Description
Updates Firefox hub page titles as per the original spec.

## Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1363411

## Testing
Titles should match this doc https://docs.google.com/spreadsheets/d/1Xx5HxJhV3L304g67e3757uNWeuGqS6wu8eg-H93umdw/edit?ts=58fed2cd#gid=0

## Checklist
- [ ] Requires l10n changes.
- [ ] Related functional & integration tests passing.
