### PR TITLE
[fix bug 1359878] Add noindex to /new variation templates

### DIFF
--- a/bedrock/firefox/templates/firefox/new/break-free/base.html
+++ b/bedrock/firefox/templates/firefox/new/break-free/base.html
@@ -4,6 +4,10 @@
 
 {% extends "base-pebbles.html" %}
 
+{% block extra_meta %}
+  <meta name="robots" content="noindex,follow">
+{% endblock %}
+
 {% block page_title_prefix %}{{_('Download Firefox')}} — {% endblock %}
 {% block page_title %}{{_('Free Web Browser')}}{% endblock %}
 {% block page_desc %}{{_('Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, Mac OS X, Linux, Android and iOS today!')}}{% endblock %}

--- a/bedrock/firefox/templates/firefox/new/break-free/scene2.html
+++ b/bedrock/firefox/templates/firefox/new/break-free/scene2.html
@@ -4,10 +4,6 @@
 
 {% extends "firefox/new/break-free/base.html" %}
 
-{% block extra_meta %}
-  <meta name="robots" content="noindex,follow">
-{% endblock %}
-
 {% from "macros.html" import google_play_button with context %}
 
 {% block body_class %}scene-2{% endblock %}

--- a/bedrock/firefox/templates/firefox/new/fx-lifestyle/base.html
+++ b/bedrock/firefox/templates/firefox/new/fx-lifestyle/base.html
@@ -4,6 +4,10 @@
 
 {% extends "firefox/base-resp.html" %}
 
+{% block extra_meta %}
+  <meta name="robots" content="noindex,follow">
+{% endblock %}
+
 {% block page_title_prefix %}{% endblock %}
 {% block page_title %}{{_('Free Web Browser for Android, iOS, Desktop | Firefox')}}{% endblock %}
 {% block page_desc %}{{_('Millions of people around the world trust Firefox Web browsers on Android, iOS and desktop computers. Fast. Private. Download now!')}}{% endblock %}

--- a/bedrock/firefox/templates/firefox/new/fx-lifestyle/browse-up-to-you/scene2.html
+++ b/bedrock/firefox/templates/firefox/new/fx-lifestyle/browse-up-to-you/scene2.html
@@ -4,10 +4,6 @@
 
 {% extends "firefox/new/fx-lifestyle/base.html" %}
 
-{% block extra_meta %}
-  <meta name="robots" content="noindex,follow">
-{% endblock %}
-
 {% block body_class %}fx-lifestyle-scene2{% endblock %}
 
 {% block page_css %}

--- a/bedrock/firefox/templates/firefox/new/fx-lifestyle/conformity-not-default/scene2.html
+++ b/bedrock/firefox/templates/firefox/new/fx-lifestyle/conformity-not-default/scene2.html
@@ -4,10 +4,6 @@
 
 {% extends "firefox/new/fx-lifestyle/base.html" %}
 
-{% block extra_meta %}
-  <meta name="robots" content="noindex,follow">
-{% endblock %}
-
 {% block body_class %}fx-lifestyle-scene2{% endblock %}
 
 {% block page_css %}

--- a/bedrock/firefox/templates/firefox/new/fx-lifestyle/private-not-option/scene2.html
+++ b/bedrock/firefox/templates/firefox/new/fx-lifestyle/private-not-option/scene2.html
@@ -4,10 +4,6 @@
 
 {% extends "firefox/new/fx-lifestyle/base.html" %}
 
-{% block extra_meta %}
-  <meta name="robots" content="noindex,follow">
-{% endblock %}
-
 {% block body_class %}fx-lifestyle-scene2{% endblock %}
 
 {% block page_css %}

--- a/bedrock/firefox/templates/firefox/new/onboarding/base.html
+++ b/bedrock/firefox/templates/firefox/new/onboarding/base.html
@@ -6,6 +6,10 @@
 
 {% extends "firefox/base-resp.html" %}
 
+{% block extra_meta %}
+  <meta name="robots" content="noindex,follow">
+{% endblock %}
+
 {% block page_title_prefix %}{{_('Download Firefox')}} — {% endblock %}
 {% block page_title %}{{_('Free Web Browser')}}{% endblock %}
 {% block page_desc %}{{_('Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, Mac OS X, Linux, Android and iOS today!')}}{% endblock %}

--- a/bedrock/firefox/templates/firefox/new/onboarding/scene2.html
+++ b/bedrock/firefox/templates/firefox/new/onboarding/scene2.html
@@ -4,10 +4,6 @@
 
 {% extends "firefox/new/onboarding/base.html" %}
 
-{% block extra_meta %}
-  <meta name="robots" content="noindex,follow">
-{% endblock %}
-
 {% block extrahead %}
   {% stylesheet 'firefox_new_onboarding_common' %}
   {% stylesheet 'firefox_new_onboarding_scene2' %}

--- a/bedrock/firefox/templates/firefox/new/way-of-the-fox/base.html
+++ b/bedrock/firefox/templates/firefox/new/way-of-the-fox/base.html
@@ -4,6 +4,10 @@
 
 {% extends "base-pebbles.html" %}
 
+{% block extra_meta %}
+  <meta name="robots" content="noindex,follow">
+{% endblock %}
+
 {% block page_title_prefix %}{{_('Download Firefox')}} — {% endblock %}
 {% block page_title %}{{_('Free Web Browser')}}{% endblock %}
 {% block page_desc %}{{_('Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, Mac OS X, Linux, Android and iOS today!')}}{% endblock %}

--- a/bedrock/firefox/templates/firefox/new/way-of-the-fox/scene2.html
+++ b/bedrock/firefox/templates/firefox/new/way-of-the-fox/scene2.html
@@ -4,10 +4,6 @@
 
 {% extends "firefox/new/way-of-the-fox/base.html" %}
 
-{% block extra_meta %}
-  <meta name="robots" content="noindex,follow">
-{% endblock %}
-
 {% from "macros.html" import google_play_button with context %}
 
 {% block body_class %}scene-2{% endblock %}


### PR DESCRIPTION
## Description

Adds `<meta name="robots" content="noindex,follow">` to all `/new` variations, both scene's 1 & 2.

## Bugzilla link

https://bugzilla.mozilla.org/show_bug.cgi?id=1359878

## Testing

Make sure my haste isn't making waste.

## Checklist
- [ ] Requires l10n changes.
- [ ] Related functional & integration tests passing.
