### PR TITLE
Update the web bug bounty Hall of Fame to have q1 2017

### DIFF
--- a/bedrock/security/templates/security/bug-bounty/web-hall-of-fame.html
+++ b/bedrock/security/templates/security/bug-bounty/web-hall-of-fame.html
@@ -32,6 +32,22 @@
       <p>As of this date, we have paid out over <b>$1,600,000</b> across all of our bounties. Congratulations to everybody who has participated!</p>
 
       <div class="accordion accordion-auto-init zebra">
+      <section id="year-2017">
+        <h3 data-accordion-role="tab">{{ _('2017') }}</h3>
+        <div data-accordion-role="tabpanel">
+          <h4>1st Quarter 2017</h4>
+          <ul>
+            <li><a href="https://detectify.com/">Fredrik Nordberg Almroth</a></li>
+            <li>Mario Gomes</li>
+            <li>Tyler Hawkins</li>
+            <li><a href="https://twitter.com/knowledge_2014">Akita (Lucas Moreira)</a></li>
+            <li>Muhammad Hassham Nagori</li>
+            <li>Wladimir Palant</li>
+            <li><a href="https://twitter.com/Paresh_parmar1">Paresh Parmar</a></li>
+            <li><a href="https://twitter.com/SecurityYasin">Yasin Soliman</a></li>
+          </ul>
+        </div>
+      </section>
 
       <section id="year-2016">
         <h3 data-accordion-role="tab">{{ _('2016') }}</h3>
@@ -50,7 +66,7 @@
           <h4>3rd Quarter 2016</h4>
           <ul>
             <li>Fredrik Nordberg</li>
-            <li>Griffin Francis </li>
+            <li>Griffin Francis</li>
             <li>Amir Saad</li>
             <li>Lucio Corsa</li>
             <li>Arne Swinnen</li>


### PR DESCRIPTION
## Description
Just updated the list for Q1 2017.

## Bugzilla link

## Testing
Everything seems good on local bedrock instance.

## Checklist
- [ ] Requires l10n changes.
- [ ] Related functional & integration tests passing.
