### PR TITLE
Remove app name suffix from deployment

### DIFF
--- a/bin/envcat
+++ b/bin/envcat
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+docker run --rm -v $(pwd):/envcat mozmeao/envcat:latest "$@"

--- a/docker/bin/prep_demo.sh
+++ b/docker/bin/prep_demo.sh
@@ -16,7 +16,7 @@ ENV_FILES=(
 
 # reads which ever of the above files exist in order and combines values
 # pre-installed in jenkins
-ENV_VALUES=( $(envcat "${ENV_FILES[@]}") )
+ENV_VALUES=( $(bin/envcat "${ENV_FILES[@]}") )
 
 if [[ -n "$SENTRY_DEMO_DSN" ]]; then
     ENV_VALUES+=( "SENTRY_DSN=$SENTRY_DEMO_DSN" )

--- a/docs/pipeline.rst
+++ b/docs/pipeline.rst
@@ -126,7 +126,6 @@ The available branch configuration options are as follows:
 * ``smoke_tests``: boolean. Set to ``true`` to cause the unit and smoke test suites run against the docker images.
 * ``push_public_registry``: boolean. Set to ``true`` to cause the built images to be pushed to the public docker hub.
 * ``require_tag``: boolean. Set to ``true`` to require that the commit being built have a git tag in the format YYYY-MM-DD.X.
-* ``app_name_suffix``: string. Set to a value to have the IRC notification alter the URL of the deployed app. (only useful for stage and prod)
 * ``regions``: list. A list of strings indicating the deployment regions for the set of apps. The valid values are in the ``regions`` area of
   the ``jenkins/global.yml`` file. If omitted a deployment to only ``usw`` is assumed.
 * ``apps``: list. A list of strings indicating the deis app name(s) to which to deploy. If omitted no deployments will occur.

--- a/jenkins/branches/demo/pmac-new-pipeline.yml
+++ b/jenkins/branches/demo/pmac-new-pipeline.yml
@@ -3,6 +3,6 @@
 demo: true
 regions:
   - virginia
+  - tokyo
 integration_tests:
   - headless
-  - firefox

--- a/jenkins/branches/demo/pmac-new-pipeline.yml
+++ b/jenkins/branches/demo/pmac-new-pipeline.yml
@@ -1,8 +1,0 @@
-# see the following for documentation of these options
-# http://bedrock.readthedocs.io/en/latest/pipeline.html#configuration
-demo: true
-regions:
-  - virginia
-  - tokyo
-integration_tests:
-  - headless

--- a/jenkins/branches/prod.yml
+++ b/jenkins/branches/prod.yml
@@ -3,7 +3,6 @@
 push_public_registry: true
 smoke_tests: true
 require_tag: true
-app_name_suffix: "-deis"
 regions:
   - usw
   - euw

--- a/jenkins/default.groovy
+++ b/jenkins/default.groovy
@@ -92,11 +92,10 @@ if ( config.apps ) {
             }
         }
         for (appname in config.apps) {
-            appSuffix = config.app_name_suffix ?: ''
             if ( config.demo ) {
                 appURL = utils.demoAppURL(appname, region)
             } else {
-                appURL = "https://${appname}${appSuffix}.${region.name}.moz.works"
+                appURL = "https://${appname}.${region.name}.moz.works"
             }
             stageName = "Deploy ${appname}-${region.name}"
             // ensure no deploy/test cycle happens in parallel for an app/region

--- a/jenkins/default.groovy
+++ b/jenkins/default.groovy
@@ -76,6 +76,7 @@ if ( config.push_public_registry != false ) {
  */
 if ( config.apps ) {
     milestone()
+    tested_apps = []
     // default to usw only
     def regions = config.regions ?: ['usw']
     for (regionId in regions) {
@@ -139,11 +140,14 @@ if ( config.apps ) {
                             utils.ircNotification([stage: "Integration Tests ${appname}-${region.name}", status: 'failure'])
                             throw err
                         }
+                        tested_apps << "${appname}-${region.name}".toString()
                     }
-                    // huge success \o/
-                    utils.ircNotification([message: "${appURL} passed all tests!", status: 'success'])
                 }
             }
         }
+    }
+    if ( tested_apps ) {
+        // huge success \o/
+        utils.ircNotification([message: "All tests passed: ${tested_apps.join(', ')}", status: 'success'])
     }
 }


### PR DESCRIPTION
Was only needed for the "-deis" suffix on stage and prod but those are going away.

I've added a few more fixes to this one in subsequent commits:

* switch to dockerized envcat so we don't have to worry with installing it globally on the jenkins box
* more testing success message to a single one at the end of the build to make it a bit less chatty on IRC
* Remove old demo config file