### PR TITLE
Fix Bug 1311121 - Links to past Firefox for Android release notes all point to current version

### DIFF
--- a/bedrock/firefox/templates/firefox/releases/release-notes.html
+++ b/bedrock/firefox/templates/firefox/releases/release-notes.html
@@ -75,11 +75,15 @@
           <ul class="menu">
           {% if release.product == 'Firefox' and release.channel == 'Release' %}
             <li class="current">{{ _('Desktop') }}</li>
+          {% elif release.channel == 'Release' and equivalent_release_url %}
+            <li><a href="{{ equivalent_release_url }}">{{ _('Desktop') }}</a></li>
           {% else %}
             <li><a href="{{ url('firefox.notes') }}">{{ _('Desktop') }}</a></li>
           {% endif %}
           {% if release.product == 'Firefox for Android' and release.channel == 'Release' %}
             <li class="current">{{ _('Android') }}</li>
+          {% elif release.channel == 'Release' and equivalent_release_url %}
+            <li><a href="{{ equivalent_release_url }}">{{ _('Android') }}</a></li>
           {% else %}
             <li><a href="{{ url('firefox.notes', platform='android') }}">{{ _('Android') }}</a></li>
           {% endif %}


### PR DESCRIPTION
## Description

The Desktop/Android navigation switches on older release notes, like [52.0](https://www.mozilla.org/en-US/firefox/52.0/releasenotes/), should link to the equivalent notes rather than the latest notes. There is the `equivalent_release_url` variable available in the template so let's use it.

## Bugzilla link

[Bug 1311121](https://bugzilla.mozilla.org/show_bug.cgi?id=1311121)

## Testing

Visit any older Desktop/Android release notes and click the navigation link to see if it works as expected.

## Checklist
- [ ] Requires l10n changes.
- [x] Related functional & integration tests passing.
