### PR TITLE
[fix bug 1363802] /new variation to support ad campaign - BATM

### DIFF
--- a/bedrock/firefox/templates/firefox/new/base.html
+++ b/bedrock/firefox/templates/firefox/new/base.html
@@ -2,7 +2,7 @@
  # License, v. 2.0. If a copy of the MPL was not distributed with this
  # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
 
- {% from "macros.html" import google_play_button with context %}
+{% from "macros.html" import google_play_button with context %}
 
 {% add_lang_files "firefox/new/horizon" %}
 

--- a/bedrock/firefox/templates/firefox/new/batm/base.html
+++ b/bedrock/firefox/templates/firefox/new/batm/base.html
@@ -1,0 +1,30 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+
+{% extends "firefox/base-pebbles.html" %}
+
+{% block extra_meta %}
+  <meta name="robots" content="noindex,follow">
+{% endblock %}
+
+{% block page_title_prefix %}{{_('Download Firefox')}} — {% endblock %}
+{% block page_title %}{{_('Free Web Browser')}}{% endblock %}
+{% block page_desc %}{{_('Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, Mac OS X, Linux, Android and iOS today!')}}{% endblock %}
+
+{% block page_css %}
+  {% stylesheet 'firefox_new_batm' %}
+{% endblock %}
+
+{% block site_header %}{% endblock %}
+
+{% block body_id %}batm{% endblock %}
+{% block body_class %}{% endblock %}
+
+{% block content %}{% endblock %}
+
+{% block email_form %}{% endblock %}
+
+{% block site_footer %}{% endblock %}
+
+{% block js %}{% endblock %}

--- a/bedrock/firefox/templates/firefox/new/batm/free.html
+++ b/bedrock/firefox/templates/firefox/new/batm/free.html
@@ -1,0 +1,13 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+
+{% from "macros.html" import google_play_button with context %}
+
+{% extends "firefox/new/batm/scene1.html" %}
+
+{% block main_header_copy %}
+<p id="main-header-copy" data-experience="batmfree">
+  {{_('Break free with Firefox, for people not profit.')}}
+</p>
+{% endblock %}

--- a/bedrock/firefox/templates/firefox/new/batm/nimble.html
+++ b/bedrock/firefox/templates/firefox/new/batm/nimble.html
@@ -1,0 +1,13 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+
+{% from "macros.html" import google_play_button with context %}
+
+{% extends "firefox/new/batm/scene1.html" %}
+
+{% block main_header_copy %}
+<p id="main-header-copy" data-experience="batmnimble">
+  {{_('Get Firefox, faster to put you first.')}}
+</p>
+{% endblock %}

--- a/bedrock/firefox/templates/firefox/new/batm/private.html
+++ b/bedrock/firefox/templates/firefox/new/batm/private.html
@@ -1,0 +1,13 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+
+{% from "macros.html" import google_play_button with context %}
+
+{% extends "firefox/new/batm/scene1.html" %}
+
+{% block main_header_copy %}
+<p id="main-header-copy" data-experience="batmprivate">
+  {{_('Get Firefox, the only browser built for people, not profit.')}}
+</p>
+{% endblock %}

--- a/bedrock/firefox/templates/firefox/new/batm/resist.html
+++ b/bedrock/firefox/templates/firefox/new/batm/resist.html
@@ -1,0 +1,13 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+
+{% from "macros.html" import google_play_button with context %}
+
+{% extends "firefox/new/batm/scene1.html" %}
+
+{% block main_header_copy %}
+<p id="main-header-copy" data-experience="batmresist">
+  {{_('Get nonprofit Firefox and resist Internet empires.')}}
+</p>
+{% endblock %}

--- a/bedrock/firefox/templates/firefox/new/batm/scene1.html
+++ b/bedrock/firefox/templates/firefox/new/batm/scene1.html
@@ -1,0 +1,45 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+
+{% from "macros.html" import google_play_button with context %}
+
+{% extends "firefox/new/batm/base.html" %}
+
+{% block optimizely %}
+  {% if switch('firefox-new-optimizely', ['en-US']) %}
+    {% include 'includes/optimizely.html' %}
+  {% endif %}
+{% endblock %}
+
+{% block body_class %}scene-1{% endblock %}
+
+{% block content %}
+<main role="main">
+  <header>
+    <h1>{{_('Browse against the machine')}}</h1>
+    <p>{{_('Get Firefox, the only browser built for people, not profit.')}}</p>
+  </header>
+  <div class="download-cta">
+    {{ download_firefox(alt_copy=_('Download Firefox'), locale_in_transition=True, button_color='button-hollow') }}
+  </div>
+  <ul class="copy">
+    <li>
+      <h2>{{_('Click it to the man')}}</h2>
+      <p>{{_('Because Firefox is independent, and built by a non-profit, we fight for your online rights, keep corporate powers in check, and make the internet accessible to everyone, everywhere.')}}</p>
+    </li>
+    <li>
+      <h2>{{_('Get out of dodgy')}}</h2>
+      <p>{{_('Firefox doesn’t sell access to your personal information. From privacy tools to tracking protection, you control who sees what.')}}</p>
+    </li>
+    <li>
+      <h2>{{_('Take a load off')}}</h2>
+      <p>{{_('We’ve spent the last year supercharging Firefox’s performance. Now you can start up faster, switch tabs quicker, and scroll like there’s no tomorrow.')}}</p>
+    </li>
+  </ul>
+</main>
+{% endblock %}
+
+{% block js %}
+  {% javascript 'firefox_new_scene1_batm' %}
+{% endblock %}

--- a/bedrock/firefox/templates/firefox/new/batm/scene1.html
+++ b/bedrock/firefox/templates/firefox/new/batm/scene1.html
@@ -6,19 +6,13 @@
 
 {% extends "firefox/new/batm/base.html" %}
 
-{% block optimizely %}
-  {% if switch('firefox-new-optimizely', ['en-US']) %}
-    {% include 'includes/optimizely.html' %}
-  {% endif %}
-{% endblock %}
-
 {% block body_class %}scene-1{% endblock %}
 
 {% block content %}
 <main role="main">
   <header>
     <h1>{{_('Browse against the machine')}}</h1>
-    <p>{{_('Get Firefox, the only browser built for people, not profit.')}}</p>
+    {% block main_header_copy %}{% endblock %}
   </header>
   <div class="download-cta">
     {{ download_firefox(alt_copy=_('Download Firefox'), locale_in_transition=True, button_color='button-hollow') }}

--- a/bedrock/firefox/templates/firefox/new/batm/scene2.html
+++ b/bedrock/firefox/templates/firefox/new/batm/scene2.html
@@ -1,0 +1,34 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+
+{% extends "firefox/new/batm/base.html" %}
+
+{% block body_class %}scene-2{% endblock %}
+
+{% block string_data %}
+  data-pixels="{% for pixel in settings.TRACKING_PIXELS %}{{ pixel }}{% if not loop.last %}::{% endif %}{% endfor %}"
+{% endblock %}
+
+{% block content %}
+<main role="main">
+  <header>
+    <h1>{{_('Thank you. And welcome to freedom.')}}</h1>
+    <p>
+    {% trans id='direct-download-link', fallback_url=url('firefox.all') %}
+      Your download should begin with a quickness. If not, <a id="{{ id }}" href="{{ fallback_url }}">click here</a>.
+    {% endtrans %}
+    </p>
+  </header>
+  <div id="download-button-wrapper-desktop">
+    {{ download_firefox(force_direct=true, dom_id='primary-download-button') }}
+  </div>
+</main>
+{% endblock %}
+
+{% block js %}
+  {% if switch('tracking-pixel') %}
+    {% javascript 'firefox_new_pixel' %}
+  {% endif %}
+  {% javascript 'firefox_new_scene2' %}
+{% endblock %}

--- a/bedrock/firefox/templates/firefox/new/fx-lifestyle/base.html
+++ b/bedrock/firefox/templates/firefox/new/fx-lifestyle/base.html
@@ -17,6 +17,10 @@
 {% block body_id %}firefox{% endblock %}
 {% block body_class %}{% endblock %}
 
+{% block string_data %}
+  data-pixels="{% for pixel in settings.TRACKING_PIXELS %}{{ pixel }}{% if not loop.last %}::{% endif %}{% endfor %}"
+{% endblock %}
+
 {% block site_header %}{% endblock %}
 
 {% block content %}

--- a/bedrock/firefox/templates/firefox/new/onboarding/scene1.html
+++ b/bedrock/firefox/templates/firefox/new/onboarding/scene1.html
@@ -136,7 +136,7 @@
         <h4 class="heading-osx">{{_('Download Firefox <span>for macOS</span>') }}</h4>
         <h4 class="heading-linux">{{_('Download Firefox <span>for Linux</span>') }}</h4>
 
-        {{ download_firefox(dom_id='download-other-platforms-modal', alt_copy=_('Free Download')) }}
+        {{ download_firefox(dom_id='download-other-platforms-modal', alt_copy=_('Free Download'), locale_in_transition=True) }}
       </section>
     </div>
   </div>

--- a/bedrock/firefox/templates/firefox/new/scene1.html
+++ b/bedrock/firefox/templates/firefox/new/scene1.html
@@ -164,7 +164,7 @@
         <h4 class="heading-osx">{{_('Download Firefox <span>for macOS</span>') }}</h4>
         <h4 class="heading-linux">{{_('Download Firefox <span>for Linux</span>') }}</h4>
 
-        {{ download_firefox(dom_id='download-other-platforms-modal', alt_copy=_('Free Download')) }}
+        {{ download_firefox(dom_id='download-other-platforms-modal', alt_copy=_('Free Download'), locale_in_transition=True) }}
       </section>
     </div>
   </div>

--- a/bedrock/firefox/tests/test_views.py
+++ b/bedrock/firefox/tests/test_views.py
@@ -453,13 +453,27 @@ class TestFirefoxNew(TestCase):
         views.new(req)
         render_mock.assert_called_once_with(req, 'firefox/new/fx-lifestyle/its-your-web/scene2.html')
 
+    # browse against the machine bug 1363802
+
+    def test_batm_scene_1(self, render_mock):
+        req = RequestFactory().get('/firefox/new/?xv=batmfree')
+        req.locale = 'en-US'
+        views.new(req)
+        render_mock.assert_called_once_with(req, 'firefox/new/batm/scene1.html')
+
+    def test_batm_scene_2(self, render_mock):
+        req = RequestFactory().get('/firefox/new/?scene=2&xv=batmfree')
+        req.locale = 'en-US'
+        views.new(req)
+        render_mock.assert_called_once_with(req, 'firefox/new/batm/scene2.html')
+
+    # onboarding experiment bug 1333435
+
     def test_onboarding_f_98_scene_1_template(self, render_mock):
         req = RequestFactory().get('/firefox/new/?f=98')
         req.locale = 'en-US'
         views.new(req)
         render_mock.assert_called_once_with(req, 'firefox/new/scene1.html')
-
-    # onboarding experiment bug 1333435
 
     def test_onboarding_f_99_scene_1_template(self, render_mock):
         req = RequestFactory().get('/firefox/new/?f=99')

--- a/bedrock/firefox/tests/test_views.py
+++ b/bedrock/firefox/tests/test_views.py
@@ -453,16 +453,52 @@ class TestFirefoxNew(TestCase):
         views.new(req)
         render_mock.assert_called_once_with(req, 'firefox/new/fx-lifestyle/its-your-web/scene2.html')
 
-    # browse against the machine bug 1363802
+    # browse against the machine bug 1363802, 1364988.
 
-    def test_batm_scene_1(self, render_mock):
+    def test_batmfree_scene_1(self, render_mock):
         req = RequestFactory().get('/firefox/new/?xv=batmfree')
         req.locale = 'en-US'
         views.new(req)
-        render_mock.assert_called_once_with(req, 'firefox/new/batm/scene1.html')
+        render_mock.assert_called_once_with(req, 'firefox/new/batm/free.html')
 
-    def test_batm_scene_2(self, render_mock):
+    def test_batmfree_scene_2(self, render_mock):
         req = RequestFactory().get('/firefox/new/?scene=2&xv=batmfree')
+        req.locale = 'en-US'
+        views.new(req)
+        render_mock.assert_called_once_with(req, 'firefox/new/batm/scene2.html')
+
+    def test_batmprivate_scene_1(self, render_mock):
+        req = RequestFactory().get('/firefox/new/?xv=batmprivate')
+        req.locale = 'en-US'
+        views.new(req)
+        render_mock.assert_called_once_with(req, 'firefox/new/batm/private.html')
+
+    def test_batmprivate_scene_2(self, render_mock):
+        req = RequestFactory().get('/firefox/new/?scene=2&xv=batmprivate')
+        req.locale = 'en-US'
+        views.new(req)
+        render_mock.assert_called_once_with(req, 'firefox/new/batm/scene2.html')
+
+    def test_batmnimble_scene_1(self, render_mock):
+        req = RequestFactory().get('/firefox/new/?xv=batmnimble')
+        req.locale = 'en-US'
+        views.new(req)
+        render_mock.assert_called_once_with(req, 'firefox/new/batm/nimble.html')
+
+    def test_batmnimble_scene_2(self, render_mock):
+        req = RequestFactory().get('/firefox/new/?scene=2&xv=batmnimble')
+        req.locale = 'en-US'
+        views.new(req)
+        render_mock.assert_called_once_with(req, 'firefox/new/batm/scene2.html')
+
+    def test_batmresist_scene_1(self, render_mock):
+        req = RequestFactory().get('/firefox/new/?xv=batmresist')
+        req.locale = 'en-US'
+        views.new(req)
+        render_mock.assert_called_once_with(req, 'firefox/new/batm/resist.html')
+
+    def test_batmresist_scene_2(self, render_mock):
+        req = RequestFactory().get('/firefox/new/?scene=2&xv=batmresist')
         req.locale = 'en-US'
         views.new(req)
         render_mock.assert_called_once_with(req, 'firefox/new/batm/scene2.html')

--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -515,6 +515,8 @@ def new(request):
                 template = 'firefox/new/fx-lifestyle/you-do-you/scene2.html'
             elif experience == 'itsyourweb':
                 template = 'firefox/new/fx-lifestyle/its-your-web/scene2.html'
+            elif experience == 'batmfree':
+                template = 'firefox/new/batm/scene2.html'
             else:
                 template = 'firefox/new/scene2.html'
         else:
@@ -542,6 +544,8 @@ def new(request):
                 template = 'firefox/new/fx-lifestyle/you-do-you/scene1.html'
             elif experience == 'itsyourweb':
                 template = 'firefox/new/fx-lifestyle/its-your-web/scene1.html'
+            elif experience == 'batmfree':
+                template = 'firefox/new/batm/scene1.html'
             else:
                 template = 'firefox/new/scene1.html'
         else:

--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -515,7 +515,7 @@ def new(request):
                 template = 'firefox/new/fx-lifestyle/you-do-you/scene2.html'
             elif experience == 'itsyourweb':
                 template = 'firefox/new/fx-lifestyle/its-your-web/scene2.html'
-            elif experience == 'batmfree':
+            elif experience in ['batmfree', 'batmprivate', 'batmnimble', 'batmresist']:
                 template = 'firefox/new/batm/scene2.html'
             else:
                 template = 'firefox/new/scene2.html'
@@ -545,7 +545,13 @@ def new(request):
             elif experience == 'itsyourweb':
                 template = 'firefox/new/fx-lifestyle/its-your-web/scene1.html'
             elif experience == 'batmfree':
-                template = 'firefox/new/batm/scene1.html'
+                template = 'firefox/new/batm/free.html'
+            elif experience == 'batmprivate':
+                template = 'firefox/new/batm/private.html'
+            elif experience == 'batmnimble':
+                template = 'firefox/new/batm/nimble.html'
+            elif experience == 'batmresist':
+                template = 'firefox/new/batm/resist.html'
             else:
                 template = 'firefox/new/scene1.html'
         else:

--- a/bedrock/settings/static_media.py
+++ b/bedrock/settings/static_media.py
@@ -1391,7 +1391,6 @@ PIPELINE_JS = {
     },
     'firefox_new_scene1_batm': {
         'source_filenames': (
-            'js/base/mozilla-modal.js',
             'js/firefox/new/scene1-batm.js',
         ),
         'output_filename': 'js/firefox_new_scene1_batm-bundle.js',

--- a/bedrock/settings/static_media.py
+++ b/bedrock/settings/static_media.py
@@ -586,6 +586,12 @@ PIPELINE_CSS = {
         ),
         'output_filename': 'css/firefox_new_its_your_web_bundle.css',
     },
+    'firefox_new_batm': {
+        'source_filenames': (
+            'css/firefox/new/batm.scss',
+        ),
+        'output_filename': 'css/firefox_new_batm-bundle.css',
+    },
     'firefox_new_onboarding_common': {
         'source_filenames': (
             'css/sandstone/sandstone-resp.less',
@@ -1382,6 +1388,13 @@ PIPELINE_JS = {
             'js/firefox/new/fx-lifestyle.js',
         ),
         'output_filename': 'js/firefox_new_scene1_fx_lifestyle-bundle.js',
+    },
+    'firefox_new_scene1_batm': {
+        'source_filenames': (
+            'js/base/mozilla-modal.js',
+            'js/firefox/new/scene1-batm.js',
+        ),
+        'output_filename': 'js/firefox_new_scene1_batm-bundle.js',
     },
     'firefox_new_pixel': {
         'source_filenames': (

--- a/media/css/firefox/new/batm.scss
+++ b/media/css/firefox/new/batm.scss
@@ -1,0 +1,213 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+@import '../../pebbles/includes/lib';
+
+@font-face {
+    font-family: 'Open Sans Light';
+    font-weight: normal;
+    font-style: normal;
+    src: url('/media/fonts/opensans-light.woff2') format('woff2'),
+         url('/media/fonts/opensans-light.woff') format('woff');
+}
+
+$font-open-sans-light: 'Open Sans Light', X-LocaleSpecific, sans-serif;
+
+
+@keyframes fade-in {
+    0% {
+        opacity: 0;
+        transform: translateY(50px);
+    }
+    100% {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+html,
+body {
+    background: #ec8c32;
+    background: linear-gradient(135deg, #ec8c32 0%,#e5472c 100%);
+    min-height: 100%;
+}
+
+main {
+    background: #fff;
+    border-radius: 10px;
+    margin: 20px;
+    padding: 20px;
+
+    @media #{$mq-desktop} {
+        margin: 40px;
+        padding: 60px;
+    }
+
+    header {
+        @include at2x('/media/img/firefox/template/logo-large.png', 122px, 128px);
+        background-repeat: no-repeat;
+        background-position: top center;
+        text-align: center;
+        min-height: 128px;
+
+        h1 {
+            @include font-size(24px);
+            padding-top: 150px;
+        }
+
+        p {
+            font-family: $font-open-sans-light;
+        }
+
+        @media #{$mq-desktop} {
+            background-position: top left;
+
+            h1 {
+                @include font-size(36px);
+                padding-top: 130px;
+            }
+
+            p {
+                @include font-size(25px);
+            }
+        }
+    }
+
+    .copy {
+        @include clearfix;
+        margin: 40px 0;
+        padding: 0;
+        position: relative;
+        text-align: center;
+
+        li {
+            margin-bottom: 20px;
+        }
+
+        h2 {
+            @include font-size(20px);
+            margin-bottom: 20px;
+        }
+
+        p {
+            @include font-size(16px);
+            font-family: $font-open-sans-light;
+            margin: 0 auto;
+            max-width: 420px;
+        }
+
+        @media #{$mq-desktop} {
+            margin: 100px 0 40px;
+
+
+            li {
+                float: left;
+                width: 33%;
+            }
+
+            h2 {
+                @include font-size(25px);
+                padding: 0 20px;
+            }
+
+            p {
+                padding: 0 40px;
+            }
+        }
+    }
+
+    .download-cta {
+        margin-top: 60px;
+        text-align: center;
+    }
+}
+
+.scene-2 main header {
+    margin-bottom: 160px;
+}
+
+a.button:link.button-hollow,
+a.button:visited.button-hollow {
+    background: #ea7530;
+    border-color: #ea7530;
+    border-radius: 0;
+    color: #fff;
+    -webkit-transition: background-color 100ms ease-in-out, color 100ms ease-in-out;
+    transition: background-color 100ms ease-in-out, color 100ms ease-in-out;
+
+    strong {
+        font-weight: bold;
+    }
+
+    &:hover,
+    &:focus {
+        background: #fff;
+        border-color: #ea7530;
+        color: #000;
+    }
+
+    @media #{$mq-desktop} {
+        @include font-size(22px);
+    }
+}
+
+.fx-privacy-link {
+
+    a:link,
+    a:visited {
+        color: #000;
+        text-decoration: none;
+    }
+
+    a:hover,
+    a:active,
+    a:focus {
+        text-decoration: underline;
+    }
+
+    @media #{$mq-desktop} {
+        @include font-size(18px);
+    }
+}
+
+// always hide special scene 2 button (as it forces direct download)
+#download-button-wrapper-desktop {
+    height: 0;
+    visibility: hidden;
+    width: 0;
+}
+
+@supports(animation: fade-in .5s ease-in-out 0s 1 normal both) {
+    .js .scene-1 main {
+        opacity: 0;
+    }
+
+    .js.ready {
+        main {
+            animation: fade-in .3s ease-in-out 0s 1 normal both;
+
+            header p {
+                animation: fade-in .5s ease-in-out .3s 1 normal both;
+            }
+
+            .copy li {
+                &:nth-child(1) {
+                    animation: fade-in .5s ease-in-out .4s 1 normal both;
+                }
+
+                &:nth-child(2) {
+                    animation: fade-in .5s ease-in-out .55s 1 normal both;
+                }
+
+                &:nth-child(3) {
+                    animation: fade-in .5s ease-in-out .7s 1 normal both;
+                }
+            }
+
+            .download-cta {
+                animation: fade-in .5s ease-in-out .55s 1 normal both;
+            }
+        }
+    }
+}

--- a/media/css/firefox/new/break-free.scss
+++ b/media/css/firefox/new/break-free.scss
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 @import '../../pebbles/includes/lib';
-@import '../../pebbles/components/buttons-download';
 @import '../../pebbles/components/platform-footer-links';
 
 #outer-wrapper {

--- a/media/css/firefox/new/way-of-the-fox.scss
+++ b/media/css/firefox/new/way-of-the-fox.scss
@@ -3,7 +3,6 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 @import '../../pebbles/includes/lib';
-@import '../../pebbles/components/buttons-download';
 @import '../../pebbles/components/platform-footer-links';
 
 #outer-wrapper {

--- a/media/js/firefox/new/scene1-batm.js
+++ b/media/js/firefox/new/scene1-batm.js
@@ -1,0 +1,20 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+(function($) {
+    'use strict';
+
+    $('.download-link').each(function(i, link) {
+        if (link.href.indexOf('scene=2') > -1) {
+            // specify v=1 template for scene 2
+            link.href = link.href.replace('scene=2', 'scene=2&xv=batmfree');
+        }
+    });
+
+    // trigger fade-in CSS animation
+    $(function() {
+        $('html').addClass('ready');
+    });
+
+})(window.jQuery);

--- a/media/js/firefox/new/scene1-batm.js
+++ b/media/js/firefox/new/scene1-batm.js
@@ -5,10 +5,12 @@
 (function($) {
     'use strict';
 
+    var exp = $('#main-header-copy').data('experience');
+
     $('.download-link').each(function(i, link) {
-        if (link.href.indexOf('scene=2') > -1) {
+        if (exp && link.href.indexOf('scene=2') > -1) {
             // specify v=1 template for scene 2
-            link.href = link.href.replace('scene=2', 'scene=2&xv=batmfree');
+            link.href = link.href.replace('scene=2', 'scene=2&xv=' + exp);
         }
     });
 


### PR DESCRIPTION
## Description
- Adds another new ad campaign download page variation

## Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1363802
https://bugzilla.mozilla.org/show_bug.cgi?id=1364988

## Testing
- It's a new page, so some basic cross browser testing should cover things?
- Check for copy / pasta?

Demo:
https://bedrock-demo-agibson.us-west.moz.works/en-US/firefox/new/?xv=batmfree
https://bedrock-demo-agibson.us-west.moz.works/en-US/firefox/new/?xv=batmprivate
https://bedrock-demo-agibson.us-west.moz.works/en-US/firefox/new/?xv=batmnimble
https://bedrock-demo-agibson.us-west.moz.works/en-US/firefox/new/?xv=batmresist

## Checklist
- [ ] Requires l10n changes.
- [ ] Related functional & integration tests passing.
