### PR TITLE
Fix bug 1364452: Add ability to specify alternate canonical paths per locale

### DIFF
--- a/bedrock/base/templates/includes/canonical-url.html
+++ b/bedrock/base/templates/includes/canonical-url.html
@@ -1,10 +1,17 @@
     <link rel="canonical" hreflang="{{ LANG|replace('en-US', 'en') }}" href="{{ settings.CANONICAL_URL + '/' + LANG + canonical_path }}">
     <link rel="alternate" hreflang="x-default" href="{{ settings.CANONICAL_URL + canonical_path }}">
     {% if translations -%}
-    {% for code, label in translations|dictsort -%}
-    <link rel="alternate" hreflang="{{ code|replace('en-US', 'en') }}" href="{{ settings.CANONICAL_URL + '/' + code + canonical_path }}" title="{{ label|safe|replace('English (US)', 'English') }}">
-    {% if code == 'en-US' -%}{# Append en-CA for Bug 1097049 -#}
-    <link rel="alternate" hreflang="{{ code|replace('en-US', 'en-CA') }}" href="{{ settings.CANONICAL_URL + '/' + code + canonical_path }}" title="{{ label|safe|replace('English (US)', 'English (Canada)') }}">
-    {% endif -%}
-    {% endfor -%}
+      {% for code, label in translations|dictsort -%}
+        {% if alt_canonical_paths and code in alt_canonical_paths -%}
+          {% set loop_canonical_path = alt_canonical_paths[code] -%}
+        {% else -%}
+          {% set loop_canonical_path = canonical_path -%}
+        {% endif -%}
+        {% if code == 'en-US' -%}
+        <link rel="alternate" hreflang="en" href="{{ settings.CANONICAL_URL + '/' + code + loop_canonical_path }}" title="English">
+        <link rel="alternate" hreflang="en-CA" href="{{ settings.CANONICAL_URL + '/' + code + loop_canonical_path }}" title="English (Canada)">
+        {% else -%}
+        <link rel="alternate" hreflang="{{ code }}" href="{{ settings.CANONICAL_URL + '/' + code + loop_canonical_path }}" title="{{ label|safe }}">
+        {% endif -%}
+      {% endfor -%}
     {% endif %}

--- a/bedrock/firefox/redirects.py
+++ b/bedrock/firefox/redirects.py
@@ -517,8 +517,10 @@ redirectpatterns = (
     redirect(r'^firefox/windows-10/welcome/?$', 'https://support.mozilla.org/kb/how-change-your-default-browser-windows-10'),
 
     # Bug 1355184
-    redirect(r'^en-US/firefox/private-browsing/?', 'firefox.features.private-browsing', locale_prefix=False),
+    redirect(r'^en-US/firefox/private-browsing/?', '/en-US/firefox/features/private-browsing/',
+             locale_prefix=False),
 
     # Bug 1355189
-    redirect(r'^en-US/firefox/desktop/fast/?', 'firefox.features.fast', locale_prefix=False),
+    redirect(r'^en-US/firefox/desktop/fast/?', '/en-US/firefox/features/fast/',
+             locale_prefix=False),
 )

--- a/bedrock/firefox/urls.py
+++ b/bedrock/firefox/urls.py
@@ -37,7 +37,9 @@ urlpatterns = (
     url(r'^firefox/desktop/$',
         views.FirefoxProductDesktopView.as_view(),
         name='firefox.desktop.index'),
-    page('firefox/desktop/fast', 'firefox/desktop/fast.html'),
+    page('firefox/desktop/fast', 'firefox/desktop/fast.html', alt_canonical_paths={
+        'en-US': '/firefox/features/fast/',
+    }),
     page('firefox/desktop/customize', 'firefox/desktop/customize.html'),
     page('firefox/desktop/tips', 'firefox/desktop/tips.html'),
     page('firefox/desktop/trust', 'firefox/desktop/trust.html'),
@@ -69,7 +71,9 @@ urlpatterns = (
                                       template_name_variations=['b'],
                                       variation_locales=['en-US']),
         name='firefox.family.index'),
-    page('firefox/private-browsing', 'firefox/private-browsing.html'),
+    page('firefox/private-browsing', 'firefox/private-browsing.html', alt_canonical_paths={
+        'en-US': '/firefox/features/private-browsing/',
+    }),
     url('^firefox/send-to-device-post/$', views.send_to_device_ajax,
         name='firefox.send-to-device-post'),
     url(r'^firefox/sync/$',

--- a/tests/redirects/map_globalconf.py
+++ b/tests/redirects/map_globalconf.py
@@ -1161,8 +1161,8 @@ URLS = flatten((
     url_test('/internethealth', '/internet-health/'),
 
     # Bug 1355184
-    url_test('/en-US/firefox/private-browsing/', '/firefox/features/private-browsing/'),
+    url_test('/en-US/firefox/private-browsing/', '/en-US/firefox/features/private-browsing/'),
 
     # Bug 1355189
-    url_test('/en-US/firefox/desktop/fast/', '/firefox/features/fast/'),
+    url_test('/en-US/firefox/desktop/fast/', '/en-US/firefox/features/fast/'),
 ))


### PR DESCRIPTION
I'd like to have this be more automatic based on an alternate template and the
languages activated for it so that locales would automatically migrate to the new URL
as locales are activated, but this should fix the immediate issue.