### PR TITLE
Fix Bug 1359102 - Release notes for Nightly need to display the Firefox Nightly logo + wording fixes

### DIFF
--- a/bedrock/firefox/templates/firefox/all.html
+++ b/bedrock/firefox/templates/firefox/all.html
@@ -65,7 +65,7 @@
 
 {% block body_id %}firefox-all{% endblock %}
 {% block body_class -%}
-  sky {{ platform }} {{ channel }} {% if platform == 'desktop' and channel in ['alpha', 'nightly'] %}blueprint{% endif %}
+  sky {{ platform }} {{ channel }} {% if channel == 'alpha' %}blueprint{% endif %} {% if channel == 'nightly' %}space{% endif %}
 {% endblock %}
 
 {% block page_css %}

--- a/bedrock/firefox/templates/firefox/releases/nightly-notes.html
+++ b/bedrock/firefox/templates/firefox/releases/nightly-notes.html
@@ -7,3 +7,21 @@
 {% block extrahead %}
 <link rel="alternate" type="application/atom+xml" title="{{ _('Firefox Nightly Notes Feed') }}" href="{{ url('firefox.nightly.notes.feed') }}">
 {% endblock %}
+
+{% block body_class %}fx-notes space{% endblock %}
+
+{% block site_header_logo %}
+  <h2>{{ high_res_img('firefox/template/header-logo-nightly.png', {'alt': _('Firefox Nightly'), 'width': '305', 'height': '70'}) }}</h2>
+{% endblock %}
+
+{% block notes_heading_primary %}
+  <h1>{{ _('See what landed recently in <span>Firefox Nightly</span>!') }}</h1>
+{% endblock %}
+
+{% block site_footer %}
+  {% if LANG.startswith('en-') %}
+    {% include 'includes/site-footer-new.html' %}
+  {% else %}
+    {% include 'includes/site-footer.html' %}
+  {% endif %}
+{% endblock %}

--- a/media/css/firefox/all.less
+++ b/media/css/firefox/all.less
@@ -4,34 +4,6 @@
 
 @import "../sandstone/lib.less";
 
-body.nightly {
-    color: #FFF;
-    background: #000;
-    #outer-wrapper {
-        background: #000;
-        background: url('/media/img/firefox/horizon/stars.svg') center 60px no-repeat,
-                    linear-gradient(to bottom, #000, #002048 1000px, #000 2000px);
-    }
-    a {
-        color: #EB9500;
-        &:hover,
-        &:focus,
-        &:active {
-            color: lighten(#EB9500, 10%);
-        }
-    }
-    h1, h2, h3 {
-        color: #61CCFF;
-        text-shadow: none;
-    }
-    #masthead h2 img {
-        height: auto;
-    }
-    #main-feature h2 {
-        color: #FFF;
-    }
-}
-
 .build-table-container {
     .hide {
         display: none;
@@ -63,6 +35,10 @@ body.nightly {
             content: "\00A0\00BB";
         }
     }
+}
+
+.space #main-feature h2 {
+    color: #FFF;
 }
 
 #language-search {
@@ -207,13 +183,6 @@ body.nightly {
                 text-decoration: none;
             }
         }
-    }
-}
-
-/* Aurora Download Page */
-.space #main-content table tbody {
-    tr, th, td {
-        border-color: rgba(255,255,255,0.2);
     }
 }
 

--- a/media/css/firefox/releasenotes-firefox.less
+++ b/media/css/firefox/releasenotes-firefox.less
@@ -256,9 +256,6 @@ ul.section-items {
     li:nth-child(odd) {
         background-color: rgba(223, 236, 250, 0.41);
     }
-    li:nth-child(even) {
-        background-color: #FFF;
-    }
     ul {
         list-style-type: disc;
         margin-top: 10px;
@@ -267,8 +264,7 @@ ul.section-items {
             padding: 0;
             list-style-type: circle;
         }
-        li:nth-child(odd),
-        li:nth-child(even) {
+        li:nth-child(odd) {
             background-color: transparent;
         }
     }
@@ -571,6 +567,54 @@ ul.section-items {
 
         .message {
             display: block;
+        }
+    }
+}
+
+// Nightly notes
+
+.space {
+    .notes-head h1 span {
+        white-space: nowrap;
+    }
+
+    .navigator,
+    .notes-footer {
+        background-color: #09273D;
+    }
+
+    .navigator li.current {
+        border-color: @linkBlue;
+    }
+
+    .notes-head .latest-release,
+    .notes-section .features,
+    .release-footer {
+        background-color: transparent;
+    }
+
+    .notes-section .section-wrapper {
+        border-color: #093A5C;
+    }
+
+    ul.section-items {
+        li:nth-child(odd) {
+            background-color: rgba(223, 236, 250, .06);
+        }
+
+        ul li:nth-child(odd) {
+            background-color: transparent;
+        }
+    }
+
+    @media only screen and (max-width: @breakTablet) {
+        .navigator ul.menu > li {
+            border-color: #000;
+            background-color: #09273D;
+        }
+
+        .navigator ul.menu li.current {
+            background-color: @linkBlue;
         }
     }
 }

--- a/media/css/sandstone/buttons.less
+++ b/media/css/sandstone/buttons.less
@@ -215,14 +215,14 @@ a.button:visited {
 .space .fx-privacy-link {
     a:link,
     a:visited {
-        color: @linkSpacePurple;
+        color: @linkBlue;
     }
 }
 
 .blueprint .fx-privacy-link {
     a:link,
     a:visited {
-        color: @linkSpaceBlue;
+        color: @linkBlue;
     }
 }
 

--- a/media/css/sandstone/lib.less
+++ b/media/css/sandstone/lib.less
@@ -51,8 +51,6 @@
 @linkBlue:           rgb(0,150,221);
 @linkBlueHover:      rgb(0,83,159);
 @linkSkyBlue:        rgb(103,167,208);
-@linkSpaceBlue:      rgb(47,138,202);
-@linkSpacePurple:    rgb(147,111,188);
 
 @mozillaRed: #c13832;
 

--- a/media/css/sandstone/oldIE.less
+++ b/media/css/sandstone/oldIE.less
@@ -324,6 +324,7 @@ img {
     /* ensure link text is white for buttons in IE6 */
     .button,
     button.button,
+    .space .button,
     .blueprint .button,
     a.button:link,
     a.button:visited {
@@ -344,19 +345,19 @@ img {
 
     a:link,
     a:visited {
-        color: @linkSpaceBlue;
+        color: @linkBlue;
     }
 
     a:hover,
     a:focus,
     a:active {
-        color: lighten(@linkSpaceBlue, 10%);
+        color: lighten(@linkBlue, 10%);
     }
 
     #masthead nav li {
         a:link,
         a:visited {
-            color: @linkSpacePurple;
+            color: @linkBlue;
         }
 
         li {
@@ -370,6 +371,7 @@ img {
     /* ensure link text is white for buttons in IE6 */
     .button,
     button.button,
+    .space .button,
     .blueprint .button,
     a.button:link,
     a.button:visited {

--- a/media/css/sandstone/sandstone-resp.less
+++ b/media/css/sandstone/sandstone-resp.less
@@ -82,21 +82,23 @@ a.more {
     }
 }
 
-// Aurora visual style
+// Nightly visual style
 
 .space {
     color: #fff;
+    background: #000;
 
     #outer-wrapper {
-        background: #04020b url("/media/img/sandstone/bg-space.png") repeat-x;
+        background: url('/media/img/firefox/horizon/stars.svg') center 60px no-repeat,
+                    linear-gradient(to bottom, #000, #002048 1000px, #000 2000px);
     }
 
     a {
-        color: @linkSpaceBlue;
+        color: @linkBlue;
         &:hover,
         &:focus,
         &:active {
-            color: lighten(@linkSpaceBlue, 10%);
+            color: lighten(@linkBlue, 10%);
         }
     }
 
@@ -109,7 +111,7 @@ a.more {
         a,
         a:link,
         a:visited {
-            color: @linkSpacePurple;
+            color: @linkBlue;
         }
         li {
             a,
@@ -120,6 +122,9 @@ a.more {
         }
     }
 
+    #masthead h2 img {
+        height: auto;
+    }
 }
 
 // Firefox Developer Edition visual style
@@ -135,11 +140,11 @@ a.more {
     }
 
     a {
-        color: @linkSpaceBlue;
+        color: @linkBlue;
         &:hover,
         &:focus,
         &:active {
-            color: lighten(@linkSpaceBlue, 10%);
+            color: lighten(@linkBlue, 10%);
         }
     }
 
@@ -1477,6 +1482,7 @@ nav.menu-bar {
         }
     }
 
+    .space #masthead nav li,
     .blueprint #masthead nav li {
         a,
         a:link,

--- a/media/css/sandstone/sandstone.less
+++ b/media/css/sandstone/sandstone.less
@@ -76,20 +76,22 @@ a.more {
     }
 }
 
-// Aurora visual style
+// Nightly visual style
 .space {
     color: #fff;
+    background: #000;
 
     #outer-wrapper {
-        background: #04020b url("/media/img/sandstone/bg-space.png") repeat-x;
+        background: url('/media/img/firefox/horizon/stars.svg') center 60px no-repeat,
+                    linear-gradient(to bottom, #000, #002048 1000px, #000 2000px);
     }
 
     a {
-        color: @linkSpaceBlue;
+        color: @linkBlue;
         &:hover,
         &:focus,
         &:active {
-            color: lighten(@linkSpaceBlue, 10%);
+            color: lighten(@linkBlue, 10%);
         }
     }
 
@@ -102,7 +104,7 @@ a.more {
         a,
         a:link,
         a:visited {
-            color: @linkSpacePurple;
+            color: @linkBlue;
         }
         li {
             a,
@@ -128,11 +130,11 @@ a.more {
     }
 
     a {
-        color: @linkSpaceBlue;
+        color: @linkBlue;
         &:hover,
         &:focus,
         &:active {
-            color: lighten(@linkSpaceBlue, 10%);
+            color: lighten(@linkBlue, 10%);
         }
     }
 


### PR DESCRIPTION
## Description

* Change the logo and headline on the [Firefox Nightly notes](https://www.mozilla.org/en-US/firefox/nightly/notes/).
* Redesign the page by adopting the current [download page](https://www.mozilla.org/en-US/firefox/nightly/all/)'s theme.
* Repurpose Aurora's `space` visual style which is no longer used.

## Bugzilla link

[Bug 1359102](https://bugzilla.mozilla.org/show_bug.cgi?id=1359102)

## Testing

Check out the [demo server](https://bedrock-demo-nightly-notes.us-west.moz.works/en-US/firefox/nightly/notes/) to see everything looks right.

## Checklist
- [ ] Requires l10n changes.
- [x] Related functional & integration tests passing.
