### PR TITLE
[fix bug 1354304] Unhide download button on privacy page

### DIFF
--- a/media/js/privacy/privacy.js
+++ b/media/js/privacy/privacy.js
@@ -6,7 +6,6 @@ $(function() {
     'use strict';
 
     var utils = Mozilla.Utils;
-    var client = Mozilla.Client;
 
     /**
      * Detects whether do not track is enabled and takes one of two possible actions:
@@ -107,9 +106,4 @@ $(function() {
             }
         }
     });
-
-    // Bug 1354304: temporarily hide download button on privacy page for funnelcake experiment.
-    if (client.isFirefox) {
-        $('#global-nav-download-firefox').hide();
-    }
 });


### PR DESCRIPTION
## Description
- Button was temporarily hidden for an experiment.

## Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1354304

## Testing
- Button should no longer be hidden in Firefox browsers.

## Checklist
- [ ] Requires l10n changes.
- [ ] Related functional & integration tests passing.
