### PR TITLE
[fix bug 1363955] Switch Pebbles to Zilla Slab

### DIFF
--- a/media/css/base/global-nav.less
+++ b/media/css/base/global-nav.less
@@ -324,8 +324,7 @@
     }
 
     .intro {
-        .font-size(14px);
-        font-style: italic;
+        .font-size(13px);
         margin: 0 0 20px;
     }
 
@@ -746,10 +745,9 @@ html.moz-nav-open {
         }
 
         .meta {
-            .font-size(13px);
+            .font-size(12px);
             color: #fff;
             display: block;
-            font-style: italic;
             padding: 0 0 5px 5px;
             text-align: left;
         }

--- a/media/css/firefox/features/common.scss
+++ b/media/css/firefox/features/common.scss
@@ -4,7 +4,6 @@
 
 @import '../../pebbles/includes/lib';
 @import '../../pebbles/components/newsletter';
-@import '../../pebbles/includes/fonts/zilla-slab';
 @import '../../hubs/sub-nav';
 @import '../../hubs/buttons';
 @import '../../hubs/cta-link';

--- a/media/css/firefox/hub/home.scss
+++ b/media/css/firefox/hub/home.scss
@@ -4,7 +4,6 @@
 
 @import '../../pebbles/includes/lib';
 @import '../../pebbles/components/newsletter';
-@import '../../pebbles/includes/fonts/zilla-slab';
 @import '../../hubs/sub-nav';
 @import '../../hubs/cards';
 @import '../../hubs/buttons';

--- a/media/css/firefox/product-page.scss
+++ b/media/css/firefox/product-page.scss
@@ -5,7 +5,6 @@
 @import
     '../pebbles/includes/lib',
     '../pebbles/components/newsletter',
-    '../pebbles/includes/fonts/zilla-slab',
     '../hubs/sub-nav',
     '../hubs/buttons',
     '../hubs/cta-link',

--- a/media/css/hubs/_sub-nav.scss
+++ b/media/css/hubs/_sub-nav.scss
@@ -12,6 +12,7 @@ $mq-nav-desktop:    'screen and (min-width: 1070px)';
 
 .moz-sub-nav {
     @include clearfix();
+    @include open-sans;
     background: #fff;
     display: none; // hidden for mobile
     height: 52px;

--- a/media/css/mozorg/home/home.scss
+++ b/media/css/mozorg/home/home.scss
@@ -391,6 +391,7 @@ main {
     }
 
     a {
+        @include open-sans;
         @include trailing-arrow;
         font-weight: bold;
         text-decoration: none;
@@ -531,6 +532,7 @@ main {
 
         a,
         a:hover {
+            @include open-sans;
             color: #fff;
         }
 
@@ -729,6 +731,13 @@ main {
         margin: 0 auto;
     }
 
+    input,
+    select,
+    textarea,
+    .form-details small {
+        @include open-sans;
+    }
+
     .form-title {
         @include background-size(100px, 100px);
         background-position: center top;
@@ -753,6 +762,11 @@ main {
     .form-contents {
         .field {
             margin: 0 0 1em;
+        }
+
+        .field-format label,
+        .field-privacy label {
+            @include open-sans;
         }
     }
 

--- a/media/css/mozorg/internet-health.scss
+++ b/media/css/mozorg/internet-health.scss
@@ -287,6 +287,7 @@ html[dir="rtl"] {
     }
 
     .ctas {
+        @include open-sans;
         margin-top: 20px;
     }
 
@@ -749,6 +750,7 @@ html[dir="rtl"] #pillars > section {
 
         .continue {
             @include font-size(16px);
+            @include open-sans;
             bottom: 20px;
             font-weight: bold;
             position: absolute;

--- a/media/css/mozorg/internet-health/health-subpage.scss
+++ b/media/css/mozorg/internet-health/health-subpage.scss
@@ -249,7 +249,7 @@ html[dir="rtl"] {
 //*--------------------------------------------------------------------------*/
 // Health subpages navigation
 .health-subnav {
-    @include font-size(18px);
+    @include open-sans;
     background-color: #000;
     text-transform: lowercase;
 
@@ -339,6 +339,7 @@ html[dir="rtl"] {
 
     li {
         @include border-box;
+        @include open-sans;
         margin: 0 0 1em;
         text-transform: uppercase;
     }
@@ -480,6 +481,7 @@ html[dir="rtl"] {
 
     .note-source {
         @include font-size(14px);
+        @include open-sans;
         margin: 0;
 
         cite {

--- a/media/css/mozorg/technology.scss
+++ b/media/css/mozorg/technology.scss
@@ -390,6 +390,7 @@ main {
 
             li {
                 @include font-size(16px);
+                @include open-sans;
                 display: block;
                 padding: 20px 0;
                 width: 100%;
@@ -897,6 +898,7 @@ html[dir="rtl"] #technologies > section {
 
         .continue {
             @include font-size(16px);
+            @include open-sans;
             bottom: 20px;
             color: #c33b32;
             font-weight: bold;

--- a/media/css/newsletter/newsletter-developer.scss
+++ b/media/css/newsletter/newsletter-developer.scss
@@ -116,11 +116,13 @@
     }
 
     .field-format label {
+        @include open-sans;
         margin-right: 20px;
     }
 
     .privacy-check-label {
         @include font-size(14px);
+        @include open-sans;
         display: block;
         padding-left: 30px;
         position: relative;
@@ -143,6 +145,7 @@
 
         small {
             @include font-size(12px);
+            @include open-sans;
         }
     }
 }

--- a/media/css/newsletter/newsletter-firefox.scss
+++ b/media/css/newsletter/newsletter-firefox.scss
@@ -136,11 +136,13 @@ $color-fox-purple: #3a304b;
     }
 
     .field-format label {
+        @include open-sans;
         margin-right: 20px;
     }
 
     .privacy-check-label {
         @include font-size(14px);
+        @include open-sans;
         display: block;
         padding-left: 30px;
         position: relative;
@@ -158,6 +160,7 @@ $color-fox-purple: #3a304b;
 
         small {
             @include font-size(12px);
+            @include open-sans;
         }
     }
 }

--- a/media/css/newsletter/newsletter-mozilla.scss
+++ b/media/css/newsletter/newsletter-mozilla.scss
@@ -129,11 +129,13 @@
     }
 
     .field-format label {
+        @include open-sans;
         margin-right: 20px;
     }
 
     .privacy-check-label {
         @include font-size(14px);
+        @include open-sans;
         display: block;
         padding-left: 30px;
         position: relative;
@@ -151,6 +153,7 @@
 
         small {
             @include font-size(12px);
+            @include open-sans;
         }
     }
 }

--- a/media/css/pebbles/base/elements/_forms.scss
+++ b/media/css/pebbles/base/elements/_forms.scss
@@ -9,7 +9,7 @@ button,
 input,
 select,
 textarea {
-    font-family: inherit; // must inherit or falls back to UA stylesheet/system font
+    @include open-sans;
 }
 
 textarea {

--- a/media/css/pebbles/components/_buttons-download.scss
+++ b/media/css/pebbles/components/_buttons-download.scss
@@ -8,6 +8,7 @@
 // privacy policy link that accompany most download buttons
 .fx-privacy-link {
     @include font-size(16px);
+    @include open-sans;
     display: block;
     text-align: center;
     text-shadow: none;
@@ -81,6 +82,7 @@ ul.download-list {
 
 .download-other {
     @include font-size(11px);
+    @include open-sans;
     color: $color-text-tertiary;
 
     a:link,

--- a/media/css/pebbles/components/_buttons.scss
+++ b/media/css/pebbles/components/_buttons.scss
@@ -6,6 +6,7 @@
 
 // The basis for all buttons on mozilla.org
 %base-button {
+    @include open-sans;
     @include font-size(18px);
     @include transition(background-color 100ms ease-in-out);
     background: none;

--- a/media/css/pebbles/components/_global-nav.scss
+++ b/media/css/pebbles/components/_global-nav.scss
@@ -16,6 +16,7 @@ $mq-nav-desktop:    'screen and (min-width: 1070px)';
 // Horizontal top navigation
 
 .moz-global-nav {
+    @include open-sans;
     position: relative;
     background: #fff;
     overflow: hidden;
@@ -324,8 +325,7 @@ $mq-nav-desktop:    'screen and (min-width: 1070px)';
     }
 
     .intro {
-        @include font-size(14px);
-        font-style: italic;
+        @include font-size(13px);
         margin: 0 0 20px;
     }
 
@@ -694,6 +694,7 @@ html.moz-nav-open {
 // Side drawer promo thumbnails.
 
 .moz-global-nav-drawer {
+    @include open-sans;
 
     .nav-promo {
         display: none;
@@ -730,10 +731,9 @@ html.moz-nav-open {
         }
 
         .meta {
-            @include font-size(13px);
+            @include font-size(12px);
             color: #fff;
             display: block;
-            font-style: italic;
             padding: 0 0 5px 5px;
             text-align: left;
         }

--- a/media/css/pebbles/components/_modal.scss
+++ b/media/css/pebbles/components/_modal.scss
@@ -18,6 +18,18 @@ html.noscroll {
     #modal {
         position: absolute;
     }
+
+    @media #{$mq-tablet} {
+        height: auto;
+
+        body {
+            height: auto;
+        }
+
+        #modal {
+            position: fixed;
+        }
+    }
 }
 
 

--- a/media/css/pebbles/components/_newsletter.scss
+++ b/media/css/pebbles/components/_newsletter.scss
@@ -53,6 +53,7 @@
 
     // html/text radio buttons
     .field-format label {
+        @include open-sans;
         display: inline;
         margin-right: 20px;
     }
@@ -60,6 +61,7 @@
     // privacy checkbox
     .field-privacy {
         @include font-size(12px);
+        @include open-sans;
 
         input {
             float: left;
@@ -88,13 +90,14 @@
 
     select {
         @include font-size(14px);
-        font-family: inherit;
+        @include open-sans;
         line-height: 1.5;
         max-width: 80%;
     }
 
     // copy underneath "Sign Up Now" button
     p.form-details {
+        @include open-sans;
         line-height: 1;
         margin-top: 8px;
     }

--- a/media/css/pebbles/global.scss
+++ b/media/css/pebbles/global.scss
@@ -8,6 +8,7 @@
 
 @import
     // Fonts
+    'includes/fonts/zilla-slab',
     'includes/fonts/open-sans',
 
     // Base elements - general HTML elements

--- a/media/css/pebbles/includes/_variables.scss
+++ b/media/css/pebbles/includes/_variables.scss
@@ -14,7 +14,7 @@ $font-zilla-slab: 'Zilla Slab', 'Open Sans', X-LocaleSpecific, sans-serif;
 // equally readable with a non-highlight variant.
 $font-zilla-slab-highlight: 'Zilla Slab Highlight', 'Zilla Slab', 'Open Sans', X-LocaleSpecific, sans-serif;
 
-$base-font-stack: $font-open-sans;
+$base-font-stack: $font-zilla-slab;
 $base-font-size: 100%;
 $base-line-height: 1.5;
 

--- a/media/css/pebbles/includes/fonts/_open-sans.scss
+++ b/media/css/pebbles/includes/fonts/_open-sans.scss
@@ -18,19 +18,3 @@
     src: url('/media/fonts/opensans-bold.woff2') format('woff2'),
          url('/media/fonts/opensans-bold.woff') format('woff');
 }
-
-@font-face {
-    font-family: 'Open Sans';
-    font-weight: normal;
-    font-style: italic;
-    src: url('/media/fonts/opensans-italic.woff2') format('woff2'),
-         url('/media/fonts/opensans-italic.woff') format('woff');
-}
-
-@font-face {
-    font-family: 'Open Sans';
-    font-weight: bold;
-    font-style: italic;
-    src: url('/media/fonts/opensans-bolditalic.woff2') format('woff2'),
-         url('/media/fonts/opensans-bolditalic.woff') format('woff');
-}

--- a/media/css/pebbles/includes/fonts/_zilla-slab.scss
+++ b/media/css/pebbles/includes/fonts/_zilla-slab.scss
@@ -18,3 +18,19 @@
     src: url('/media/fonts/ZillaSlab-Bold.woff2') format('woff2'),
          url('/media/fonts/ZillaSlab-Bold.woff') format('woff');
 }
+
+@font-face {
+    font-family: 'Zilla Slab';
+    font-weight: normal;
+    font-style: italic;
+    src: url('/media/fonts/ZillaSlab-RegularItalic.woff2') format('woff2'),
+         url('/media/fonts/ZillaSlab-RegularItalic.woff') format('woff');
+}
+
+@font-face {
+    font-family: 'Zilla Slab';
+    font-weight: bold;
+    font-style: italic;
+    src: url('/media/fonts/ZillaSlab-BoldItalic.woff2') format('woff2'),
+         url('/media/fonts/ZillaSlab-BoldItalic.woff') format('woff');
+}


### PR DESCRIPTION
## Description
This sets Zilla Slab as the base font for all Pebbles-based pages, with Open Sans as a secondary accent font. This started just to fix the fake italics on Firefox hub pages, but adding two more weights of Zilla on top of the four weights of Open Sans was too much. This way it's two fonts in and two fonts out. And we might as well make the leap to global Zilla sooner rather than later (just in Pebbles; no Zilla in Sandstone). 

## Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1363955

## Testing
https://bedrock-demo-craigcook.us-west.moz.works

This only impacts Pebbles-based pages, so that's the home page, all the new Firefox pages, /technology, /internet-health (and subpages), /about/leadership, /moss, /newsletter/mozilla, /newsletter/firefox, /newsletter/developer.... I think that's it.
