### PR TITLE
[fix bug 1363913] Fix broken link on decentralization page

### DIFF
--- a/bedrock/mozorg/templates/mozorg/internet-health/decentralization.html
+++ b/bedrock/mozorg/templates/mozorg/internet-health/decentralization.html
@@ -115,9 +115,15 @@
 
             <p class="note-source">
               <cite>
-              {% trans accessnow='https://www.thisisnetneutrality.org/' %}
-                Source: <a href="{{ wwwf }}">Access Now</a>, 2015
-              {% endtrans %}
+              {% if l10n_has_tag('health-decentralization-link') %}
+                {% trans accessnow='https://www.thisisnetneutrality.org/' %}
+                  Source: <a href="{{ accessnow }}">Access Now</a>
+                {% endtrans %}
+              {% else %}
+                {% trans wwwf='https://www.thisisnetneutrality.org/' %}
+                  Source: <a href="{{ wwwf }}">Access Now</a>, 2015
+                {% endtrans %}
+              {% endif %}
               </cite>
             </p>
           </div>


### PR DESCRIPTION
## Description
- Fixes broken link and updates string for quotation source (uses l10n tag `health-decentralization-link`)

## Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1363913

## Testing
- Link should be fixed for both old and new strings.

## Checklist
- [x] Requires l10n changes.
- [ ] Related functional & integration tests passing.
