### PR TITLE
[fix bug 1364928] Add UTM params to /firstrun/learnmore/ and /windows-10/welcome/ redirects

### DIFF
--- a/bedrock/firefox/redirects.py
+++ b/bedrock/firefox/redirects.py
@@ -513,8 +513,18 @@ redirectpatterns = (
     redirect(r'^firefox/channel/?$', firefox_channel(), cache_timeout=0),
 
     # Bug 1277196
-    redirect(r'^firefox(?:\/\d+\.\d+(?:\.\d+)?(?:a\d+)?)?/firstrun/learnmore/?$', 'firefox.features'),
-    redirect(r'^firefox/windows-10/welcome/?$', 'https://support.mozilla.org/kb/how-change-your-default-browser-windows-10'),
+    redirect(r'^firefox(?:\/\d+\.\d+(?:\.\d+)?(?:a\d+)?)?/firstrun/learnmore/?$', 'firefox.features', query={
+        'utm_source': 'firefox-browser',
+        'utm_medium': 'firefox-browser',
+        'utm_campaign': 'redirect',
+        'utm_content': 'learnmore-tab',
+    }),
+    redirect(r'^firefox/windows-10/welcome/?$', 'https://support.mozilla.org/kb/how-change-your-default-browser-windows-10', query={
+        'utm_source': 'firefox-browser',
+        'utm_medium': 'firefox-browser',
+        'utm_campaign': 'redirect',
+        'utm_content': 'windows10-welcome-tab',
+    }),
 
     # Bug 1355184
     redirect(r'^en-US/firefox/private-browsing/?', '/en-US/firefox/features/private-browsing/',

--- a/tests/redirects/map_globalconf.py
+++ b/tests/redirects/map_globalconf.py
@@ -1096,9 +1096,12 @@ URLS = flatten((
     url_test('/story', 'https://donate.mozilla.org/?source=story_redirect'),
 
     # Bug 1277196
-    url_test('/firefox/firstrun/learnmore', '/firefox/features/'),
-    url_test('/firefox/{49.0,49.0.1,50.0a1,51.0a2}/firstrun/learnmore', '/firefox/features/'),
-    url_test('/firefox/windows-10/welcome', 'https://support.mozilla.org/kb/how-change-your-default-browser-windows-10'),
+    url_test('/firefox/firstrun/learnmore',
+             '/firefox/features/?utm_campaign=redirect&utm_medium=firefox-browser&utm_source=firefox-browser&utm_content=learnmore-tab'),
+    url_test('/firefox/{49.0,49.0.1,50.0a1,51.0a2}/firstrun/learnmore',
+             '/firefox/features/?utm_campaign=redirect&utm_medium=firefox-browser&utm_source=firefox-browser&utm_content=learnmore-tab'),
+    url_test('/firefox/windows-10/welcome',
+             'https://support.mozilla.org/kb/how-change-your-default-browser-windows-10?utm_campaign=redirect&utm_medium=firefox-browser&utm_source=firefox-browser&utm_content=windows10-welcome-tab'),
 
     # bug 1319207
     url_test('/de/privacy/firefox-focus/', '/de/privacy/firefox-klar/'),


### PR DESCRIPTION
## Description
- Adds UTM params to two existing redirects.

## Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1364928

## Testing
- Updated redirect tests to make sure params are being passed along correctly.

## Checklist
- [ ] Requires l10n changes.
- [ ] Related functional & integration tests passing.
