### PR TITLE
[fix bug 1361873] Add Optimizely to Fx Hub pages.

### DIFF
--- a/bedrock/firefox/templates/firefox/features/base.html
+++ b/bedrock/firefox/templates/firefox/features/base.html
@@ -6,6 +6,12 @@
 
 {# L10n: strings for this page are not considered final and aren't ready for localization. #}
 
+{% block optimizely %}
+  {% if switch('firefox-features-optimizely', ['en-US']) %}
+    {% include 'includes/optimizely.html' %}
+  {% endif %}
+{% endblock %}
+
 {% block page_css %}
   {% stylesheet 'firefox-features-hub-common' %}
 {% endblock %}

--- a/bedrock/firefox/templates/firefox/features/index.html
+++ b/bedrock/firefox/templates/firefox/features/index.html
@@ -13,12 +13,6 @@
 
 {% block body_id %}firefox-features-landing{% endblock %}
 
-{% block optimizely %}
-  {% if switch('firefox-features-optimizely', ['en-US']) %}
-    {% include 'includes/optimizely.html' %}
-  {% endif %}
-{% endblock %}
-
 {% block features_header_content %}
   <h1><span>{{ _('Firefox features') }}</span></h1>
 {% endblock %}

--- a/bedrock/firefox/templates/firefox/hub/home.html
+++ b/bedrock/firefox/templates/firefox/hub/home.html
@@ -22,6 +22,12 @@
 {% block body_id %}{% endblock %}
 {% block body_class %}{% endblock %}
 
+{% block optimizely %}
+  {% if switch('firefox-home-optimizely', ['en-US']) %}
+    {% include 'includes/optimizely.html' %}
+  {% endif %}
+{% endblock %}
+
 {% block page_css %}
   {% stylesheet 'firefox-hub-home' %}
 {% endblock %}

--- a/bedrock/firefox/templates/firefox/products/desktop.html
+++ b/bedrock/firefox/templates/firefox/products/desktop.html
@@ -12,6 +12,11 @@
 
 {% block body_id %}firefox-product-desktop{% endblock %}
 
+{% block optimizely %}
+  {% if switch('firefox-products-desktop-optimizely', ['en-US']) %}
+    {% include 'includes/optimizely.html' %}
+  {% endif %}
+{% endblock %}
 
 {% block product_header_content %}
   <h1 class="page-title"><span>{{ _('Firefox for Desktop') }}</span></h1>


### PR DESCRIPTION
## Description

Add Optimizely block to the new Fx Hub pages.

## Bugzilla link

https://bugzilla.mozilla.org/show_bug.cgi?id=1361873

## Testing

Make sure no copy pasta mistakes.

## Checklist
- [ ] Requires l10n changes.
- [ ] Related functional & integration tests passing.
