### PR TITLE
Use sync gunicorn worker class for smoke tests

### DIFF
--- a/bin/run-prod.sh
+++ b/bin/run-prod.sh
@@ -1,2 +1,7 @@
 #!/bin/bash -xe
-gunicorn wsgi.app:application -b 0.0.0.0:${PORT:-8000} -w ${WEB_CONCURRENCY:-2} --error-logfile - --access-logfile - --log-level ${LOGLEVEL:-info} --worker-class ${GUNICORN_WORKER_CLASS:-meinheld.gmeinheld.MeinheldWorker}
+gunicorn wsgi.app:application -b 0.0.0.0:${PORT:-8000} \
+                              -w ${WEB_CONCURRENCY:-2} \
+                              --error-logfile - \
+                              --access-logfile - \
+                              --log-level ${LOGLEVEL:-info} \
+                              --worker-class ${GUNICORN_WORKER_CLASS:-meinheld.gmeinheld.MeinheldWorker}

--- a/docker/bin/run_integration_tests.sh
+++ b/docker/bin/run_integration_tests.sh
@@ -59,6 +59,7 @@ if [ -z "${BASE_URL}" ]; then
     -e SECRET_KEY=foo \
     -e DEBUG=False \
     -e DATABASE_URL=sqlite:////tmp/temp.db \
+    -e GUNICORN_WORKER_CLASS=sync \
     mozorg/bedrock_code:${GIT_COMMIT}
 
   DOCKER_LINKS=(--link bedrock-code-${GIT_COMMIT_SHORT}:bedrock)


### PR DESCRIPTION
Meinheld (the default) is causing problems at tests startup, but works better when deployed.