### PR TITLE
Tag all images as "latest" during prod push

### DIFF
--- a/docker/bin/docker_build.sh
+++ b/docker/bin/docker_build.sh
@@ -44,3 +44,8 @@ cat "docker/dockerfiles/bedrock_$DOCKERFILE" | envsubst '$GIT_COMMIT' > "$FINAL_
 
 # build the docker image
 docker build -t "$DOCKER_IMAGE_TAG" --pull="$DOCKER_PULL" --no-cache="$DOCKER_NO_CACHE" -f "$FINAL_DOCKERFILE" "$DOCKER_CTX"
+
+if [[ "$GIT_TAG_DATE_BASED" == true ]]; then
+    docker tag "$DOCKER_IMAGE_TAG" "${DOCKER_REPO}/bedrock_${DOCKERFILE}:${GIT_TAG}"
+    docker tag "$DOCKER_IMAGE_TAG" "${DOCKER_REPO}/bedrock_${DOCKERFILE}:latest"
+fi


### PR DESCRIPTION
This will allow other jobs (configurator e.g.) to use
the ":latest" images for testing and other things.