### PR TITLE
[fix bug 1364236] Pass original referrer from traffic cop to GA

### DIFF
--- a/media/js/base/dnt-helper.js
+++ b/media/js/base/dnt-helper.js
@@ -1,4 +1,11 @@
-/* exported _dntEnabled */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+* License, v. 2.0. If a copy of the MPL was not distributed with this
+* file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// create namespace
+if (typeof Mozilla === 'undefined') {
+    var Mozilla = {};
+}
 
 /**
  * Returns true or false based on whether doNotTack is enabled. It also takes into account the
@@ -9,8 +16,7 @@
  * @params {string} [ua] - An optional mock userAgent string to ease unit testing.
  * @returns {boolean} true if enabled else false
  */
-function _dntEnabled(dnt, ua) {
-
+Mozilla.dntEnabled = function(dnt, ua) {
     'use strict';
 
     // for old version of IE we need to use the msDoNotTrack property of navigator
@@ -45,4 +51,4 @@ function _dntEnabled(dnt, ua) {
     }
 
     return dntStatus === 'Enabled' ? true : false;
-}
+};

--- a/media/js/base/gtm-snippet.js
+++ b/media/js/base/gtm-snippet.js
@@ -9,7 +9,7 @@
 
     // If doNotTrack is not enabled, it is ok to add GTM
     // @see https://bugzilla.mozilla.org/show_bug.cgi?id=1217896 for more details
-    if (typeof window._dntEnabled === 'function' && !window._dntEnabled() && GTM_CONTAINER_ID) {
+    if (typeof Mozilla.dntEnabled === 'function' && !Mozilla.dntEnabled() && GTM_CONTAINER_ID) {
         (function(w,d,s,l,i,j,f,dl,k,q){
             w[l]=w[l]||[];w[l].push({'gtm.start': new Date().getTime(),event:'gtm.js'});f=d.getElementsByTagName(s)[0];
             k=i.length;q='//www.googletagmanager.com/gtm.js?id=@&l='+(l||'dataLayer');

--- a/media/js/base/mozilla-pixel.js
+++ b/media/js/base/mozilla-pixel.js
@@ -49,7 +49,7 @@ if (typeof Mozilla === 'undefined') {
 
     Pixel.init = function() {
         // Do not set pixels if visitor has DNT enabled.
-        if (!window._dntEnabled()) {
+        if (!Mozilla.dntEnabled()) {
             Pixel.setPixels();
         }
     };

--- a/media/js/base/optimizely-snippet.js
+++ b/media/js/base/optimizely-snippet.js
@@ -9,7 +9,7 @@
 
     // If doNotTrack is not enabled, it is ok to add Optimizely
     // @see https://bugzilla.mozilla.org/show_bug.cgi?id=1217896 for more details
-    if (typeof window._dntEnabled === 'function' && !window._dntEnabled() && OPTIMIZELY_PROJECT_ID) {
+    if (typeof Mozilla.dntEnabled === 'function' && !Mozilla.dntEnabled() && OPTIMIZELY_PROJECT_ID) {
         (function(d, optID) {
             var newScriptTag = d.createElement('script');
             var target = d.getElementsByTagName('script')[0];

--- a/media/js/base/stat-counter.js
+++ b/media/js/base/stat-counter.js
@@ -6,7 +6,7 @@
 
     // If doNotTrack is not enabled, it is ok to add StatCounter
     // @see https://bugzilla.mozilla.org/show_bug.cgi?id=1217896 for more details
-    if (typeof window._dntEnabled === 'function' && !window._dntEnabled() && STATCOUNTER_PROJECT_ID && STATCOUNTER_SECURITY_ID) {
+    if (typeof Mozilla.dntEnabled === 'function' && !Mozilla.dntEnabled() && STATCOUNTER_PROJECT_ID && STATCOUNTER_SECURITY_ID) {
         // Statcounter needs the following vars scoped globally as lowercase, so disable the eslint errors thrown by camelcase and no-unused-vars
         /* eslint-disable camelcase, no-unused-vars */
         var sc_project = window.sc_project = STATCOUNTER_PROJECT_ID;

--- a/media/js/base/stub-attribution.js
+++ b/media/js/base/stub-attribution.js
@@ -222,7 +222,7 @@ if (typeof Mozilla === 'undefined') {
             return false;
         }
 
-        if (window._dntEnabled()) {
+        if (Mozilla.dntEnabled()) {
             return false;
         }
 

--- a/tests/unit/spec/base/core-datalayer-page-id.js
+++ b/tests/unit/spec/base/core-datalayer-page-id.js
@@ -3,9 +3,17 @@
  * Sinon docs: http://sinonjs.org/docs/
  */
 
-/* global describe, beforeEach, afterEach, it, expect */
+/* global describe, beforeEach, afterEach, it, expect, sinon */
 
 describe('core-datalayer-page-id.js', function() {
+
+    beforeEach(function() {
+        // stub out Mozilla.Cookie lib
+        window.Mozilla.Cookies = sinon.stub();
+        window.Mozilla.Cookies.hasItem = sinon.stub();
+        window.Mozilla.Cookies.getItem = sinon.stub();
+        window.Mozilla.Cookies.removeItem = sinon.stub();
+    });
 
     describe('getPageId', function(){
         var html = document.documentElement;
@@ -26,6 +34,33 @@ describe('core-datalayer-page-id.js', function() {
 
         it('will return the full page path when no data-gtm-page-id value is present and no locale is in page path', function(){
             expect(Mozilla.Analytics.getPageId('/firefox/new/')).toBe('/firefox/new/');
+        });
+    });
+
+    describe('getTrafficCopReferrer', function(){
+        it('should return null if the referrer does not exist', function(){
+            spyOn(Mozilla.Cookies, 'hasItem').and.returnValue(false);
+            expect(Mozilla.Analytics.getTrafficCopReferrer()).toBe(undefined);
+        });
+
+        it('should return the referrer if one exists', function(){
+            spyOn(Mozilla.Cookies, 'hasItem').and.returnValue(true);
+            spyOn(Mozilla.Cookies, 'getItem').and.returnValue('direct');
+            expect(Mozilla.Analytics.getTrafficCopReferrer()).toBe('direct');
+        });
+    });
+
+    describe('buildDataObject', function(){
+        it('should contain customReferrer if found in cookie', function(){
+            spyOn(Mozilla.Analytics, 'getTrafficCopReferrer').and.returnValue('http://www.google.com');
+            var obj = Mozilla.Analytics.buildDataObject();
+            expect(obj.customReferrer).toBeDefined();
+        });
+
+        it('should not contain customReferrer if not found in cookie', function(){
+            spyOn(Mozilla.Analytics, 'getTrafficCopReferrer').and.returnValue(undefined);
+            var obj = Mozilla.Analytics.buildDataObject();
+            expect(obj.customReferrer).not.toBeDefined();
         });
     });
 });

--- a/tests/unit/spec/base/dnt-helper.js
+++ b/tests/unit/spec/base/dnt-helper.js
@@ -3,85 +3,85 @@
  * Sinon docs: http://sinonjs.org/docs/
  */
 
-/* global describe, it, expect, _dntEnabled */
+/* global describe, it, expect, Mozilla */
 
 describe('dnt-helper.js', function() {
 
     'use strict';
 
-    describe('_dntEnabled', function () {
+    describe('Mozilla.dntEnabled', function () {
 
         it('should return true for Fx41 on Mac with DNT set to true', function () {
             var dnt = 1;
             var ua = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.11; rv:41.0) Gecko/20100101 Firefox/41.0';
-            expect(_dntEnabled(dnt, ua)).toBe(true);
+            expect(Mozilla.dntEnabled(dnt, ua)).toBe(true);
         });
 
         it('should return false for Fx41 on Win7 with DNT set to false', function () {
             var dnt = 0;
             var ua = 'Mozilla/5.0 (Windows NT 6.1; rv:41.0) Gecko/20100101 Firefox/41.0';
-            expect(_dntEnabled(dnt, ua)).toBe(false);
+            expect(Mozilla.dntEnabled(dnt, ua)).toBe(false);
         });
 
         // this test is required because of bug 887703
         it('should return false for Fx28 on Mac with DNT set to true', function () {
             var dnt = 1;
             var ua = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.11; rv:28.0) Gecko/20100101 Firefox/28.0';
-            expect(_dntEnabled(dnt, ua)).toBe(false);
+            expect(Mozilla.dntEnabled(dnt, ua)).toBe(false);
         });
 
         it('should return false for Fx 41 with DNT set to false', function () {
             var dnt = 0;
             var ua = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.11; rv:41.0) Gecko/20100101 Firefox/41.0';
-            expect(_dntEnabled(dnt, ua)).toBe(false);
+            expect(Mozilla.dntEnabled(dnt, ua)).toBe(false);
         });
 
         it('should return false for IE on Win8 with DNT set to true', function () {
             var dnt = 1;
             var ua = 'Mozilla/4.0 (compatible; MSIE 9.0; Windows NT 6.2; Trident/4.0; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; Media Center PC 6.0)';
-            expect(_dntEnabled(dnt, ua)).toBe(false);
+            expect(Mozilla.dntEnabled(dnt, ua)).toBe(false);
         });
 
         it('should return true for Edge on Win10 with DNT set to true', function () {
             var dnt = 1;
             var ua = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.135 Safari/537.36 Edge/12.10240';
-            expect(_dntEnabled(dnt, ua)).toBe(true);
+            expect(Mozilla.dntEnabled(dnt, ua)).toBe(true);
         });
 
         it('should return false for Edge on Win10 with DNT set to false', function () {
             var dnt = 0;
             var ua = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.135 Safari/537.36 Edge/12.10240';
-            expect(_dntEnabled(dnt, ua)).toBe(false);
+            expect(Mozilla.dntEnabled(dnt, ua)).toBe(false);
         });
 
         it('should return false for IE11 on Win10 with DNT set to false', function () {
             var dnt = 0;
             var ua = 'Mozilla/5.0 (Windows NT 10.0; WOW64; Trident/7.0; rv:11.0) like Gecko';
-            expect(_dntEnabled(dnt, ua)).toBe(false);
+            expect(Mozilla.dntEnabled(dnt, ua)).toBe(false);
         });
 
         it('should return true for IE11 on Win10 with DNT set to true', function () {
             var dnt = 1;
             var ua = 'Mozilla/5.0 (Windows NT 10.0; WOW64; Trident/7.0; rv:11.0) like Gecko';
-            expect(_dntEnabled(dnt, ua)).toBe(true);
+            expect(Mozilla.dntEnabled(dnt, ua)).toBe(true);
         });
 
         it('should return false for IE11 on Win8.1 with DNT set to true', function () {
             var dnt = 1;
             var ua = 'Mozilla/5.0 (Windows NT 6.3; Trident/7.0; rv:11.0) like Gecko';
-            expect(_dntEnabled(dnt, ua)).toBe(false);
+            expect(Mozilla.dntEnabled(dnt, ua)).toBe(false);
         });
 
         it('should return false for IE7 on Windows Vista with DNT set to undefined', function () {
             var dnt;
             var ua = 'Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.0; SLCC1; .NET CLR 2.0.50727; .NET CLR 3.0.30729; .NET CLR 3.5.30729)';
-            expect(_dntEnabled(dnt, ua)).toBe(false);
+            expect(Mozilla.dntEnabled(dnt, ua)).toBe(false);
         });
 
         it('should return false for Chrome on Mac with DNT set to false', function () {
             var dnt = 0;
             var ua = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/46.0.2490.80 Safari/537.36';
-            expect(_dntEnabled(dnt, ua)).toBe(false);
+            expect(Mozilla.dntEnabled(dnt, ua)).toBe(false);
         });
 
     });

--- a/tests/unit/spec/base/mozilla-pixel.js
+++ b/tests/unit/spec/base/mozilla-pixel.js
@@ -16,7 +16,7 @@ describe('mozilla-pixel.js', function() {
     describe('init', function() {
 
         it('should not add pixel img if "do not track" is enabled', function() {
-            spyOn(window, '_dntEnabled').and.returnValue(true);
+            spyOn(Mozilla, 'dntEnabled').and.returnValue(true);
             spyOn(Mozilla.Pixel, 'setPixels');
             Mozilla.Pixel.init();
             expect(Mozilla.Pixel.setPixels).not.toHaveBeenCalled();
@@ -24,28 +24,28 @@ describe('mozilla-pixel.js', function() {
 
         it('should add multiple pixels to document body', function() {
             var pixels = '/img/foo.png::/img/foo.png?v=1::/img/foo.png?v=2';
-            spyOn(window, '_dntEnabled').and.returnValue(false);
+            spyOn(Mozilla, 'dntEnabled').and.returnValue(false);
             spyOn(Mozilla.Pixel, 'getPixelData').and.returnValue(pixels);
             Mozilla.Pixel.init();
             expect($('.moz-px').length).toEqual(3);
         });
 
         it('should add one pixel to document body', function() {
-            spyOn(window, '_dntEnabled').and.returnValue(false);
+            spyOn(Mozilla, 'dntEnabled').and.returnValue(false);
             spyOn(Mozilla.Pixel, 'getPixelData').and.returnValue('/img/foo.png');
             Mozilla.Pixel.init();
             expect($('.moz-px').length).toEqual(1);
         });
 
         it('should not add pixel if data is undefined', function() {
-            spyOn(window, '_dntEnabled').and.returnValue(false);
+            spyOn(Mozilla, 'dntEnabled').and.returnValue(false);
             spyOn(Mozilla.Pixel, 'getPixelData').and.returnValue(undefined);
             Mozilla.Pixel.init();
             expect($('.moz-px').length).toEqual(0);
         });
 
         it('should not add pixel if data is empty', function() {
-            spyOn(window, '_dntEnabled').and.returnValue(false);
+            spyOn(Mozilla, 'dntEnabled').and.returnValue(false);
             spyOn(Mozilla.Pixel, 'getPixelData').and.returnValue('');
             Mozilla.Pixel.init();
             expect($('.moz-px').length).toEqual(0);

--- a/tests/unit/spec/base/stub-attribution.js
+++ b/tests/unit/spec/base/stub-attribution.js
@@ -121,14 +121,14 @@ describe('stub-attribution.js', function() {
         });
 
         it('should return false if browser has DNT enabled', function() {
-            spyOn(window, '_dntEnabled').and.returnValue(true);
+            spyOn(Mozilla, 'dntEnabled').and.returnValue(true);
             expect(Mozilla.StubAttribution.meetsRequirements()).toBeFalsy();
         });
 
         it('should return true for windows users who satisfy all other requirements', function() {
             window.site.platform = 'windows';
             spyOn(window.site, 'needsSha1').and.returnValue(false);
-            spyOn(window, '_dntEnabled').and.returnValue(false);
+            spyOn(Mozilla, 'dntEnabled').and.returnValue(false);
             expect(Mozilla.StubAttribution.meetsRequirements()).toBeTruthy();
         });
     });


### PR DESCRIPTION
## Description

Adds functionality to pass original referrer ([set in a cookie by Traffic Cop](https://github.com/mozilla/trafficcop/pull/5)) to GTM after a Traffic Cop redirect has taken place.

**Note** - Version of Traffic Cop in this PR matches that pending in [`mozilla/traffic-cop #6`](https://github.com/mozilla/trafficcop/pull/6)

## Bugzilla link

https://bugzilla.mozilla.org/show_bug.cgi?id=1364236

## Testing

Biggest things to check:

1. Correct info is being passed to GTM in `core-datalayer-page-id.js`
2. Changing namespace around `dntEnabled` hasn't broken anything
3. General sanity around changes

## Checklist
- [ ] Requires l10n changes.
- [ ] Related functional & integration tests passing.
