### PR TITLE
[fix bug 1367270] Reword blog CTA in news feed

### DIFF
--- a/bedrock/base/templates/includes/news-feed.html
+++ b/bedrock/base/templates/includes/news-feed.html
@@ -24,7 +24,7 @@
               <p>{{ article.htmlify() }}</p>
             </div>
             <p class="entry-cta">
-              <a href="{{ article.link }}?utm_source=www.mozilla.org&amp;utm_medium=referral&amp;utm_campaign=fx-content-hub" class="cta-link" data-link-name="{{ article.blog_title }}" data-link-type="link" data-link-position="Fresh from the blog">{{ article.blog_name }}</a>
+              <a href="{{ article.link }}?utm_source=www.mozilla.org&amp;utm_medium=referral&amp;utm_campaign=fx-content-hub" class="cta-link" rel="nofollow" data-link-name="{{ article.blog_title }}" data-link-type="link" data-link-position="Fresh from the blog">{{ _('Read more') }}</a>
             </p>
           </article>
         </li>


### PR DESCRIPTION
## Description
Rewords the blog CTA in the news feed from "The Firefox Frontier" to "Read More".

## Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1367270

## Testing
Passing: 
```(venv) bedrock$ py.test lib bedrock/firefox```

## Checklist
- [ ] Requires l10n changes.
- [ ] Related functional & integration tests passing.
