### PR TITLE
[bug 1353587] Make global nav accommodate text wrapping

### DIFF
--- a/media/css/base/global-nav.less
+++ b/media/css/base/global-nav.less
@@ -100,7 +100,7 @@
             height: 25px;
         }
 
-        @media only screen and (max-width: @breakNavDesktop) {
+        @media only screen and (max-width: @breakDesktop) {
             margin-left: 5px;
 
             a {
@@ -115,15 +115,15 @@
     .nav-horizontal-menu {
         .clearfix;
         margin-left: 17px;
+        overflow: hidden;
         padding: 25px 0 10px;
         position: relative;
-        overflow: hidden;
 
-        @media only screen and (max-width: @breakNavTablet) {
+        @media only screen and (max-width: @breakTablet) {
             padding-top: 10px;
         }
 
-        @media only screen and (max-width: @breakNavDesktop) {
+        @media only screen and (max-width: @breakDesktop) {
             margin-left: 5px;
         }
     }
@@ -134,13 +134,19 @@
         display: block;
         float: left;
         list-style-type: none;
-        margin: 0 0 0 21px;
-        padding: 13px 0;
+        margin: 0 0 0 17px;
+        padding: 13px 0 0;
+        width: calc(~'100% - 480px');
 
         &> li {
             display: inline-block;
-            padding: 0 21px;
+            line-height: 1.2;
+            padding: 0 20px 10px 0;
             margin: 0;
+
+            &:last-child {
+                padding-right: 0;
+            }
 
             a:hover,
             a:active,
@@ -153,15 +159,32 @@
             }
         }
 
-        @media only screen and (max-width: @breakNavDesktop) {
-            margin-left: 10px;
+        @media only screen and (min-width: @breakDesktopWide) {
+            margin-left: 40px;
 
             &> li {
-                padding: 0 6px;
+                padding-right: 40px;
+
+                &:last-child {
+                    padding-right: 0;
+                }
             }
         }
 
-        @media only screen and (max-width: @breakNavTablet) {
+        @media only screen and (max-width: @breakDesktop) {
+            margin-left: 20px;
+            width: calc(~'100% - 370px');
+
+            &> li {
+                padding-right: 20px;
+
+                &:last-child {
+                    padding-right: 0;
+                }
+            }
+        }
+
+        @media only screen and (max-width: @breakTablet) {
             display: none;
         }
     }
@@ -266,7 +289,7 @@
             }
         }
 
-        @media only screen and (max-width: @breakNavDesktop) {
+        @media only screen and (max-width: @breakDesktop) {
 
             .rect {
                 transition: none;
@@ -485,6 +508,7 @@ html.moz-nav-open .moz-global-nav-page-mask {
 #global-nav-download-firefox {
     float: right;
     margin: -2px 85px 0 0;
+    width: 200px;
 
     .download-list {
         margin: 0;
@@ -492,6 +516,10 @@ html.moz-nav-open .moz-global-nav-page-mask {
         &> li {
             margin: 0;
         }
+    }
+
+    .download-link {
+        float: right;
     }
 
     .download-link:link,
@@ -532,7 +560,7 @@ html.moz-nav-open .moz-global-nav-page-mask {
         }
     }
 
-    @media only screen and (max-width: @breakNavDesktop) {
+    @media only screen and (max-width: @breakDesktop) {
         margin-right: 60px;
 
         .download-link {
@@ -543,7 +571,7 @@ html.moz-nav-open .moz-global-nav-page-mask {
         }
     }
 
-    @media only screen and (max-width: @breakNavTablet) {
+    @media only screen and (max-width: @breakTablet) {
         margin-right: 20px;
     }
 
@@ -672,7 +700,7 @@ html.moz-nav-open {
         }
     }
 
-    @media only screen and (max-width: @breakNavDesktop) {
+    @media only screen and (max-width: @breakDesktop) {
         html.moz-nav-open {
             height: auto;
 
@@ -752,7 +780,7 @@ html.moz-nav-open {
     }
 
     // only show promos on taller desktop viewports
-    @media only screen and (max-width: @breakNavTablet) {
+    @media only screen and (max-width: @breakTablet) {
         .nav-promo {
             display: none;
         }

--- a/media/css/hubs/_sections.scss
+++ b/media/css/hubs/_sections.scss
@@ -4,10 +4,6 @@
 
 @import '../pebbles/includes/lib';
 
-// override .content breakpoints to match navigation.
-$mq-desktop: $mq-nav-desktop;
-$mq-tablet: $mq-nav-tablet;
-
 // override .content widths and padding for fluid pages.
 .content {
     width: auto;

--- a/media/css/hubs/_sub-nav.scss
+++ b/media/css/hubs/_sub-nav.scss
@@ -33,7 +33,7 @@
         margin: 0 60px;
         position: relative;
 
-        @media #{$mq-nav-desktop} {
+        @media #{$mq-desktop} {
             margin: 0 85px;
         }
     }
@@ -45,7 +45,7 @@
 
     .sub-nav-primary-links-container {
         float: left;
-        width: 100%;
+        width: calc(100% - 200px);
     }
 
     .sub-nav-primary-links {
@@ -56,7 +56,7 @@
 
         &> li {
             display: inline-block;
-            padding: 0 12px 13px 0;
+            padding: 0 20px 10px 0;
 
             a:hover,
             a:active,
@@ -74,12 +74,12 @@
         }
     }
 
-    @media #{$mq-nav-tablet} {
+    @media #{$mq-tablet} {
         display: block;
         margin-bottom: 20px;
 
         .sub-nav-logo-link + .sub-nav-primary-links  {
-            margin-left: 43px;
+            margin-left: 45px;
         }
 
         &.stuck {
@@ -90,34 +90,17 @@
             width: 100%;
             z-index: 200;
 
-            .sub-nav-primary-links-container {
-                width: 78%;
-            }
-
             .sub-nav-download-wrapper {
                 height: auto;
-                width: 22%;
-            }
-
-            .sub-nav-primary-links li {
-                padding-right: 6px;
-
-                &:last-child {
-                    padding-right: 0;
-                }
-            }
-
-            .sub-nav-logo-link + .sub-nav-primary-links  {
-                margin-left: 37px;
+                width: 200px;
             }
         }
     }
 
-    @media #{$mq-nav-desktop} {
-
+    @media #{$mq-desktop} {
         .sub-nav-primary-links {
             li {
-                padding: 0 42px 13px 0;
+                padding: 0 20px 10px 0;
 
                 &:last-child {
                     padding-right: 0;
@@ -126,25 +109,17 @@
         }
 
         .sub-nav-logo-link + .sub-nav-primary-links  {
-            margin-left: 120px;
+            margin-left: 98px;
+        }
+    }
+
+    @media #{$mq-desktop-wide} {
+        .sub-nav-primary-links li {
+            padding-right: 40px;
         }
 
-        &.stuck {
-            .sub-nav-primary-links-container {
-                width: 80%;
-            }
-
-            .sub-nav-download-wrapper {
-                width: 20%;
-            }
-
-            .sub-nav-primary-links li {
-                padding-right: 24px;
-            }
-
-            .sub-nav-logo-link + .sub-nav-primary-links  {
-                margin-left: 120px;
-            }
+        .sub-nav-logo-link + .sub-nav-primary-links  {
+            margin-left: 120px;
         }
     }
 
@@ -255,7 +230,7 @@
         }
     }
 
-    @media #{$mq-nav-desktop} {
+    @media #{$mq-desktop} {
         margin-right: 10px;
     }
 
@@ -264,7 +239,7 @@
     }
 }
 
-@media #{$mq-nav-tablet} {
+@media #{$mq-tablet} {
     .moz-sub-nav.stuck #sub-nav-download-firefox {
         opacity: 1;
         transform: translateY(0);

--- a/media/css/pebbles/components/_global-nav.scss
+++ b/media/css/pebbles/components/_global-nav.scss
@@ -9,9 +9,9 @@
 
 .moz-global-nav {
     @include open-sans;
-    position: relative;
     background: #fff;
     overflow: hidden;
+    position: relative;
 
     a:link,
     a:visited {
@@ -100,7 +100,7 @@
             height: 25px;
         }
 
-        @media #{$mq-nav-desktop} {
+        @media #{$mq-desktop} {
             margin-left: 17px;
 
             a {
@@ -114,16 +114,16 @@
     // Horizontal link menu container
     .nav-horizontal-menu {
         @include clearfix;
-        padding: 10px 0 10px;
-        position: relative;
-        overflow: hidden;
         margin-left: 5px;
+        overflow: hidden;
+        padding: 10px 0;
+        position: relative;
 
-        @media #{$mq-nav-tablet} {
+        @media #{$mq-tablet} {
             padding-top: 25px;
         }
 
-        @media #{$mq-nav-desktop} {
+        @media #{$mq-desktop} {
             margin-left: 17px;
         }
     }
@@ -135,11 +135,16 @@
         float: left;
         list-style-type: none;
         margin: 0 0 0 10px;
-        padding: 13px 0;
+        padding: 13px 0 0;
 
         &> li {
             display: inline-block;
-            padding: 0 6px;
+            line-height: 1.2;
+            padding: 0 20px 10px 0;
+
+            &:last-child {
+                padding-right: 0;
+            }
 
             a:hover,
             a:active,
@@ -152,15 +157,26 @@
             }
         }
 
-        @media #{$mq-nav-tablet} {
+        @media #{$mq-tablet} {
+            @include border-box;
             display: block;
+            margin-left: 20px;
+            width: calc(100% - 370px);
         }
 
-        @media #{$mq-nav-desktop} {
-            margin-left: 21px;
+        @media #{$mq-desktop} {
+            width: calc(100% - 480px);
+        }
+
+        @media #{$mq-desktop-wide} {
+            margin-left: 40px;
 
             &> li {
-                padding: 0 21px;
+                padding-right: 40px;
+
+                &:last-child {
+                    padding-right: 0;
+                }
             }
         }
     }
@@ -172,7 +188,7 @@
         }
     }
 
-    @media #{$mq-nav-desktop} {
+    @media #{$mq-desktop} {
         max-width: $width-max-content;
         margin: 0 auto;
     }
@@ -266,7 +282,7 @@
             transform: translate(7px, 7px) rotate(45deg);
         }
 
-        @media #{$mq-nav-desktop} {
+        @media #{$mq-desktop} {
 
             .rect {
                 transition: transform .12s ease-in-out;
@@ -539,11 +555,16 @@ html.moz-nav-open .moz-global-nav-page-mask {
         }
     }
 
-    @media #{$mq-nav-tablet} {
+    @media #{$mq-tablet} {
         margin-right: 60px;
+        width: 200px;
+
+        .download-link {
+            float: right;
+        }
     }
 
-    @media #{$mq-nav-desktop} {
+    @media #{$mq-desktop} {
         margin-right: 85px;
 
         .download-link {
@@ -641,7 +662,7 @@ html.moz-nav-open {
         visibility: hidden;
     }
 
-    @media #{$mq-nav-desktop} {
+    @media #{$mq-desktop} {
         html.moz-nav-open {
             height: 100%;
 
@@ -741,7 +762,7 @@ html.moz-nav-open {
     }
 
     // only show promos on taller desktop viewports
-    @media #{$mq-nav-tablet} {
+    @media #{$mq-tablet} {
         .nav-promo {
             display: block;
         }

--- a/media/css/pebbles/includes/_variables.scss
+++ b/media/css/pebbles/includes/_variables.scss
@@ -79,10 +79,6 @@ $mq-high-res:       'only screen and (-webkit-min-device-pixel-ratio: 1.5), only
 $mq-short:          '(max-height: 600px)';
 $mq-tall:           '(min-height: 600px)';
 
-// Media queries for global nav and subnav
-$mq-nav-tablet:     'screen and (min-width: 860px)';
-$mq-nav-desktop:    'screen and (min-width: 1140px)';
-
 
 // Grid columns
 $column-width:  8.333%; // 100% / 12 columns

--- a/media/css/sandstone/lib.less
+++ b/media/css/sandstone/lib.less
@@ -140,9 +140,6 @@
 @breakMobileLandscape:    480px;
 @breakMobile:             320px;
 
-// Breakpoints for global navigation
-@breakNavTablet:  860px;
-@breakNavDesktop: 1140px;
 
 // Page widths for common breakpoints
 

--- a/media/js/hubs/sub-nav.js
+++ b/media/js/hubs/sub-nav.js
@@ -26,7 +26,7 @@ js/libs/jquery.waypoints-sticky.min.js
 
     // It's your world, IE
     if (typeof matchMedia !== 'undefined') {
-        mqShowNav = matchMedia('(min-width: 840px)'); // magic number :(
+        mqShowNav = matchMedia('(min-width: 760px)');
 
         mqShowNav.addListener(function(mq) {
             if (mq.matches) {


### PR DESCRIPTION
## Description
The first iteration of the global nav had some hard-coded widths designed around the specific English links and didn't really handle links wrapping when they get lonk, which is almost guaranteed to happen once we start localizing those labels. This makes a few tweaks to the nav so when links wrap to a second line it doesn't look too horrible.

## Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1353587

## Testing
Since the navbar is only English right now you'll have to change some content locally to really test the wrapping. Try adding longer text in existing links as well as additional links, both in the main nav and subnav.

## Checklist
- [ ] Requires l10n changes.
- [ ] Related functional & integration tests passing.
