### PR TITLE
Include test image in push to dockerhub

### DIFF
--- a/docker/bin/docker_build.sh
+++ b/docker/bin/docker_build.sh
@@ -44,8 +44,3 @@ cat "docker/dockerfiles/bedrock_$DOCKERFILE" | envsubst '$GIT_COMMIT' > "$FINAL_
 
 # build the docker image
 docker build -t "$DOCKER_IMAGE_TAG" --pull="$DOCKER_PULL" --no-cache="$DOCKER_NO_CACHE" -f "$FINAL_DOCKERFILE" "$DOCKER_CTX"
-
-if [[ "$GIT_TAG_DATE_BASED" == true ]]; then
-    docker tag "$DOCKER_IMAGE_TAG" "${DOCKER_REPO}/bedrock_${DOCKERFILE}:${GIT_TAG}"
-    docker tag "$DOCKER_IMAGE_TAG" "${DOCKER_REPO}/bedrock_${DOCKERFILE}:latest"
-fi

--- a/jenkins/default.groovy
+++ b/jenkins/default.groovy
@@ -56,6 +56,7 @@ if ( config.push_public_registry != false ) {
             else {
                 utils.pushDockerhub('mozorg/bedrock_base')
                 utils.pushDockerhub('mozorg/bedrock_build')
+                utils.pushDockerhub('mozorg/bedrock_test')
                 utils.pushDockerhub('mozorg/bedrock_code')
                 utils.pushDockerhub('mozorg/bedrock_l10n', 'mozorg/bedrock')
             }


### PR DESCRIPTION
This will ensure that the test image is available to the other jobs that need to tests bedrock instances.