### PR TITLE
[fix bug 1367793] Global nav links should behave like links

### DIFF
--- a/bedrock/base/templates/includes/global-nav.html
+++ b/bedrock/base/templates/includes/global-nav.html
@@ -22,19 +22,19 @@
           {% else %}
             {% set firefox_url = url('firefox.new') %}
           {% endif %}
-          <a href="{{ firefox_url }}" data-id="firefox" data-link-type="nav" data-link-position="top" data-link-name="expand" data-link-group="Firefox">{{ _('Firefox') }}</a>
+          <a href="{{ firefox_url }}" data-link-type="nav" data-link-position="top" data-link-name="Firefox">{{ _('Firefox') }}</a>
         </li>
         <li class="item-internet-health">
-          <a href="{{ url('mozorg.internet-health') }}" data-id="internet-health" data-link-type="nav" data-link-position="top" data-link-name="expand" data-link-group="Internet Health">{{ _('Internet Health') }}</a>
+          <a href="{{ url('mozorg.internet-health') }}" data-link-type="nav" data-link-position="top" data-link-name="Internet Health">{{ _('Internet Health') }}</a>
         </li>
         <li class="item-technology">
-          <a href="{{ url('mozorg.technology') }}" data-id="technology" data-link-type="nav" data-link-position="top" data-link-name="expand" data-link-group="Technology">{{ _('Technology') }}</a>
+          <a href="{{ url('mozorg.technology') }}" data-link-type="nav" data-link-position="top" data-link-name="Technology">{{ _('Technology') }}</a>
         </li>
         <li class="item-about-us">
-          <a href="{{ url('mozorg.about') }}" data-id="about-us" data-link-type="nav" data-link-position="top" data-link-name="expand" data-link-group="About Us">{{ _('About Us') }}</a>
+          <a href="{{ url('mozorg.about') }}" data-link-type="nav" data-link-position="top" data-link-name="About Us">{{ _('About Us') }}</a>
         </li>
         <li class="item-get-involved">
-          <a href="{{ url('mozorg.contribute.index') }}" data-id="get-involved" data-link-type="nav" data-link-position="top" data-link-name="expand" data-link-group="Get Involved">{{ _('Get Involved') }}</a>
+          <a href="{{ url('mozorg.contribute.index') }}" data-link-type="nav" data-link-position="top" data-link-name="Get Involved">{{ _('Get Involved') }}</a>
         </li>
       </ul>
 

--- a/media/js/base/mozilla-global-nav.js
+++ b/media/js/base/mozilla-global-nav.js
@@ -10,8 +10,6 @@
     var _menuButton = document.getElementById('nav-button-menu');
     var _nav = document.getElementById('moz-global-nav');
     var _page = document.getElementsByTagName('html')[0];
-    var _navLinks;
-    var _drawerTimeout;
 
     // feature detects
     var _supportsBoundingClientRect = 'getBoundingClientRect' in document.createElement('div');
@@ -69,24 +67,6 @@
                 mozGlobalNav.onDrawerOpen(accordionId);
             } else {
                 mozGlobalNav.onDrawerClose();
-            }
-
-            // Add a little delay before toggling the accordion
-            // for a smoother transition when the drawer moves.
-            clearTimeout(_drawerTimeout);
-            _drawerTimeout = setTimeout(function() {
-                mozGlobalNav.afterDrawerToggle(accordionId);
-            }, 320);
-        },
-
-        afterDrawerToggle: function(accordionId) {
-            if (_page.classList.contains('moz-nav-open')) {
-                var id = accordionId ? accordionId : document.body.getAttribute('data-global-nav-current-link');
-                if (id) {
-                    mozGlobalNav.toggleDrawerMenu(id);
-                }
-            } else {
-                mozGlobalNav.closeDrawerMenu();
             }
         },
 
@@ -258,27 +238,12 @@
             }
         },
 
-        // Handle clicks on the horozontal navigation links.
-        handleNavLinkClick: function(e) {
-            e.preventDefault();
-            var id = e.target.getAttribute('data-id');
-
-            if (id) {
-                mozGlobalNav.selectNavLink(id);
-                mozGlobalNav.toggleDrawer(id);
-            }
-        },
-
         // Bind common event handlers for the navigation menu
         bindEvents: function() {
             var menuLinks = document.querySelectorAll('.nav-menu-primary-links > li > .summary > a');
 
             for (var i = 0; i < menuLinks.length; i++) {
                 menuLinks[i].addEventListener('click', mozGlobalNav.handleDrawerLinkClick, false);
-            }
-
-            for (var j = 0; j < _navLinks.length; j++) {
-                _navLinks[j].addEventListener('click', mozGlobalNav.handleNavLinkClick, false);
             }
 
             _menuButton.addEventListener('click', mozGlobalNav.handleToggleDrawerEvent, false);
@@ -297,7 +262,6 @@
             var rolePrefix = 'moz-global-nav-item-';
 
             accordion.setAttribute('role', 'tablist');
-            document.querySelector('.nav-primary-links').setAttribute('role', 'tablist');
 
             for (var i = 0; i < accordionHeadings.length; i++) {
                 accordionHeadings[i].setAttribute('role', 'tab');
@@ -305,11 +269,6 @@
                 accordionHeadings[i].setAttribute('aria-expanded', 'false');
                 accordionHeadings[i].setAttribute('aria-controls',
                     rolePrefix + accordionHeadings[i].getAttribute('data-id'));
-
-                _navLinks[i].setAttribute('role', 'tab');
-                _navLinks[i].setAttribute('aria-selected', 'false');
-                _navLinks[i].setAttribute('aria-controls',
-                    rolePrefix + _navLinks[i].getAttribute('data-id'));
             }
 
             _drawer.setAttribute('aria-hidden', 'true');
@@ -336,10 +295,7 @@
          */
         init: function() {
             if (mozGlobalNav.cutsTheMustard()) {
-                _navLinks = document.querySelectorAll('.nav-primary-links > li > a');
-
                 _menuButton.classList.remove('nav-hidden');
-
                 mozGlobalNav.initARIARoles();
                 mozGlobalNav.createNavMask();
                 mozGlobalNav.bindEvents();


### PR DESCRIPTION
## Description
- Makes the top horizontal links on the global link behave like, duh - links.
- No longer auto expand/collapse sub menu's on drawer toggle (since only direct clicks from the user now trigger state change).

## Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1367793

## Testing
- Demo: https://www-demo5.allizom.org/en-US/
- Ensure links behave like links, naturally.
- Ensure sidebar still works as normal via the menu button.

## Checklist
- [ ] Requires l10n changes.
- [ ] Related functional & integration tests passing.
