### PR TITLE
Remove EOY2015 related query strings from donate.mozilla.org links.

### DIFF
--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -451,8 +451,7 @@ class WhatsnewView(VariationMixin, l10n_utils.LangFilesMixin, TemplateView):
 class FeedbackView(TemplateView):
 
     donate_url = ('https://donate.mozilla.org/'
-       '?ref=EOYFR2015&utm_campaign=EOYFR2015'
-       '&utm_source=Heartbeat_survey&utm_medium=referral'
+       '?utm_source=Heartbeat_survey&utm_medium=referral'
        '&utm_content=Heartbeat_{0}stars')
 
     def get_score(self):

--- a/bedrock/mozorg/templatetags/misc.py
+++ b/bedrock/mozorg/templatetags/misc.py
@@ -337,15 +337,15 @@ def donate_url(ctx, source=''):
 
     For en-US this would output:
 
-        https://donate.mozilla.org/en-US/?presets=100,50,25,15&amount=50&ref=EOYFR2015&utm_campaign=EOYFR2015&utm_source=mozilla.org&utm_medium=referral&utm_content=footer&currency=usd
+        https://donate.mozilla.org/en-US/?presets=100,50,25,15&amount=50&utm_source=mozilla.org&utm_medium=referral&utm_content=footer&currency=usd
 
     For de this would output:
 
-        https://donate.mozilla.org/de/?presets=100,50,25,15&amount=50&ref=EOYFR2015&utm_campaign=EOYFR2015&utm_source=mozilla.org&utm_medium=referral&utm_content=footer&currency=eur
+        https://donate.mozilla.org/de/?presets=100,50,25,15&amount=50&utm_source=mozilla.org&utm_medium=referral&utm_content=footer&currency=eur
 
     For a locale not defined in settings.DONATE this would output:
 
-        https://donate.mozilla.org/ca/?presets=100,50,25,15&amount=50&ref=EOYFR2015&utm_campaign=EOYFR2015&utm_source=mozilla.org&utm_medium=referral&utm_content=footer&currency=usd
+        https://donate.mozilla.org/ca/?presets=100,50,25,15&amount=50&utm_source=mozilla.org&utm_medium=referral&utm_content=footer&currency=usd
 
     """
     locale = getattr(ctx['request'], 'locale', 'en-US')

--- a/bedrock/mozorg/tests/test_helper_misc.py
+++ b/bedrock/mozorg/tests/test_helper_misc.py
@@ -23,8 +23,8 @@ TEST_FILES_ROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)),
                                'test_files')
 TEST_L10N_MEDIA_PATH = os.path.join(TEST_FILES_ROOT, 'media', '%s', 'l10n')
 
-TEST_DONATE_LINK = ('https://donate.mozilla.org/{locale}/?presets={presets}'
-                    '&amount={default}&ref=EOYFR2015&utm_campaign=EOYFR2015'
+TEST_DONATE_LINK = ('https://donate.mozilla.org/{locale}/'
+                    '?presets={presets}&amount={default}'
                     '&utm_source=mozilla.org&utm_medium=referral&utm_content={source}'
                     '&currency={currency}')
 
@@ -346,32 +346,32 @@ class TestDonateUrl(TestCase):
     def test_donate_url_no_locale(self):
         """No locale, fallback to default page"""
         eq_(self._render('', 'mozillaorg_footer'),
-            'https://donate.mozilla.org//?presets=100,50,25,15'
-            '&amp;amount=50&amp;ref=EOYFR2015&amp;utm_campaign=EOYFR2015'
+            'https://donate.mozilla.org//'
+            '?presets=100,50,25,15&amp;amount=50'
             '&amp;utm_source=mozilla.org&amp;utm_medium=referral'
             '&amp;utm_content=mozillaorg_footer&amp;currency=usd')
 
     def test_donate_url_english(self):
         """en-US locale, default page"""
         eq_(self._render('en-US', 'mozillaorg_footer'),
-            'https://donate.mozilla.org/en-US/?presets=100,50,25,15'
-            '&amp;amount=50&amp;ref=EOYFR2015&amp;utm_campaign=EOYFR2015'
+            'https://donate.mozilla.org/en-US/'
+            '?presets=100,50,25,15&amp;amount=50'
             '&amp;utm_source=mozilla.org&amp;utm_medium=referral'
             '&amp;utm_content=mozillaorg_footer&amp;currency=usd')
 
     def test_donate_url_spanish(self):
         """es-MX locale, a localized page"""
         eq_(self._render('es-MX', 'mozillaorg_footer'),
-            'https://donate.mozilla.org/es-MX/?presets=100,50,25,15'
-            '&amp;amount=15&amp;ref=EOYFR2015&amp;utm_campaign=EOYFR2015'
+            'https://donate.mozilla.org/es-MX/'
+            '?presets=100,50,25,15&amp;amount=15'
             '&amp;utm_source=mozilla.org&amp;utm_medium=referral'
             '&amp;utm_content=mozillaorg_footer&amp;currency=eur')
 
     def test_donate_url_other_locale(self):
         """No page for locale, fallback to default page"""
         eq_(self._render('pt-PT', 'mozillaorg_footer'),
-            'https://donate.mozilla.org/pt-PT/?presets=100,50,25,15'
-            '&amp;amount=50&amp;ref=EOYFR2015&amp;utm_campaign=EOYFR2015'
+            'https://donate.mozilla.org/pt-PT/'
+            '?presets=100,50,25,15&amp;amount=50'
             '&amp;utm_source=mozilla.org&amp;utm_medium=referral'
             '&amp;utm_content=mozillaorg_footer&amp;currency=usd')
 

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -714,8 +714,8 @@ PRESS_BLOGS = {
     'pl': 'press-pl/',
 }
 
-DONATE_LINK = ('https://donate.mozilla.org/{locale}/?presets={presets}'
-    '&amount={default}&ref=EOYFR2015&utm_campaign=EOYFR2015'
+DONATE_LINK = ('https://donate.mozilla.org/{locale}/'
+    '?presets={presets}&amount={default}'
     '&utm_source=mozilla.org&utm_medium=referral&utm_content={source}'
     '&currency={currency}')
 


### PR DESCRIPTION
## Description
Just a quick update to remove some out of date query string params from donate.mozilla.org links.

## Bugzilla link
I didn't create one seemed too insignificant, and felt a pull request was enough. I can create one if needed though :)
