### PR TITLE
Fix Bug 1357379 - Download links for Dev Edition will need to be updated post Dawn

### DIFF
--- a/bedrock/firefox/firefox_details.py
+++ b/bedrock/firefox/firefox_details.py
@@ -222,19 +222,20 @@ class FirefoxDesktop(_ProductDetails):
             include_funnelcake_param = _platform in fc_platforms and _locale in fc_locales
 
         stub_langs = settings.STUB_INSTALLER_LOCALES.get(channel, {}).get(_platform, [])
-        # Nightly and Aurora have a special download link format
-        # see bug 1324001
+        # Nightly and Developer Edition have a special download link format
+        # see bug 1324001, 1357379
         if channel in ['alpha', 'nightly']:
-            prod_name = 'firefox-nightly' if channel == 'nightly' else 'firefox-aurora'
+            prod_name = 'firefox-nightly' if channel == 'nightly' else 'firefox-devedition'
             # Use the stub installer for approved platforms
             if (stub_langs and (stub_langs == settings.STUB_INSTALLER_ALL or _locale.lower() in stub_langs) and
                     not force_full_installer):
                 # Download links are different for localized versions
                 suffix = 'stub'
+            elif channel == 'nightly' and locale != 'en-US':
+                # Nightly uses a different product name for localized builds
+                suffix = 'latest-l10n-ssl'
             else:
                 suffix = 'latest-ssl'
-                if locale != 'en-US':
-                    suffix = 'latest-l10n-ssl'
 
             product = '%s-%s' % (prod_name, suffix)
 

--- a/bedrock/firefox/tests/test_firefox_details.py
+++ b/bedrock/firefox/tests/test_firefox_details.py
@@ -98,93 +98,96 @@ class TestFirefoxDesktop(TestCase):
                               ('os', 'linux64'),
                               ('lang', 'en-US')])
 
-    def test_get_download_url_aurora(self):
+    def test_get_download_url_devedition(self):
         """
-        The Aurora version should give us a bouncer url. For Windows, a stub url
-        should be returned.
+        The Developer Edition version should give us a bouncer url. For Windows,
+        a stub url should be returned.
         """
         url = firefox_desktop.get_download_url('alpha', '28.0a2', 'win', 'en-US', True)
         self.assertListEqual(parse_qsl(urlparse(url).query),
-                             [('product', 'firefox-aurora-stub'),
+                             [('product', 'firefox-devedition-stub'),
                               ('os', 'win'),
                               ('lang', 'en-US')])
         url = firefox_desktop.get_download_url('alpha', '28.0a2', 'win64', 'en-US', True)
         self.assertListEqual(parse_qsl(urlparse(url).query),
-                             [('product', 'firefox-aurora-latest-ssl'),
+                             [('product', 'firefox-devedition-latest-ssl'),
                               ('os', 'win64'),
                               ('lang', 'en-US')])
         url = firefox_desktop.get_download_url('alpha', '28.0a2', 'osx', 'en-US', True)
         self.assertListEqual(parse_qsl(urlparse(url).query),
-                             [('product', 'firefox-aurora-latest-ssl'),
+                             [('product', 'firefox-devedition-latest-ssl'),
                               ('os', 'osx'),
                               ('lang', 'en-US')])
         url = firefox_desktop.get_download_url('alpha', '28.0a2', 'linux', 'en-US', True)
         self.assertListEqual(parse_qsl(urlparse(url).query),
-                             [('product', 'firefox-aurora-latest-ssl'),
+                             [('product', 'firefox-devedition-latest-ssl'),
                               ('os', 'linux'),
                               ('lang', 'en-US')])
         url = firefox_desktop.get_download_url('alpha', '28.0a2', 'linux64', 'en-US', True)
         self.assertListEqual(parse_qsl(urlparse(url).query),
-                             [('product', 'firefox-aurora-latest-ssl'),
+                             [('product', 'firefox-devedition-latest-ssl'),
                               ('os', 'linux64'),
                               ('lang', 'en-US')])
 
-    def test_get_download_url_aurora_full(self):
+    def test_get_download_url_devedition_full(self):
         """
-        The Aurora version should give us a bouncer url. For Windows, a full url
-        should be returned.
+        The Developer Edition version should give us a bouncer url. For Windows,
+        a full url should be returned.
         """
         url = firefox_desktop.get_download_url('alpha', '28.0a2', 'win', 'en-US', True, True)
         self.assertListEqual(parse_qsl(urlparse(url).query),
-                             [('product', 'firefox-aurora-latest-ssl'),
+                             [('product', 'firefox-devedition-latest-ssl'),
                               ('os', 'win'),
                               ('lang', 'en-US')])
         url = firefox_desktop.get_download_url('alpha', '28.0a2', 'win64', 'en-US', True, True)
         self.assertListEqual(parse_qsl(urlparse(url).query),
-                             [('product', 'firefox-aurora-latest-ssl'),
+                             [('product', 'firefox-devedition-latest-ssl'),
                               ('os', 'win64'),
                               ('lang', 'en-US')])
         url = firefox_desktop.get_download_url('alpha', '28.0a2', 'osx', 'en-US', True, True)
         self.assertListEqual(parse_qsl(urlparse(url).query),
-                             [('product', 'firefox-aurora-latest-ssl'),
+                             [('product', 'firefox-devedition-latest-ssl'),
                               ('os', 'osx'),
                               ('lang', 'en-US')])
         url = firefox_desktop.get_download_url('alpha', '28.0a2', 'linux', 'en-US', True, True)
         self.assertListEqual(parse_qsl(urlparse(url).query),
-                             [('product', 'firefox-aurora-latest-ssl'),
+                             [('product', 'firefox-devedition-latest-ssl'),
                               ('os', 'linux'),
                               ('lang', 'en-US')])
         url = firefox_desktop.get_download_url('alpha', '28.0a2', 'linux64', 'en-US', True, True)
         self.assertListEqual(parse_qsl(urlparse(url).query),
-                             [('product', 'firefox-aurora-latest-ssl'),
+                             [('product', 'firefox-devedition-latest-ssl'),
                               ('os', 'linux64'),
                               ('lang', 'en-US')])
 
-    def test_get_download_url_aurora_l10n(self):
-        """Aurora non en-US should have a slightly different product name."""
+    def test_get_download_url_devedition_l10n(self):
+        """
+        The Developer Edition version should give us a bouncer url. For Windows,
+        a full url should be returned. The product name is the same as en-US.
+        """
         url = firefox_desktop.get_download_url('alpha', '28.0a2', 'win', 'pt-BR', True)
         self.assertListEqual(parse_qsl(urlparse(url).query),
-                             [('product', 'firefox-aurora-latest-l10n-ssl'),
+                             [('product', 'firefox-devedition-latest-ssl'),
                               ('os', 'win'),
                               ('lang', 'pt-BR')])
         url = firefox_desktop.get_download_url('alpha', '28.0a2', 'win64', 'pt-BR', True)
         self.assertListEqual(parse_qsl(urlparse(url).query),
-                             [('product', 'firefox-aurora-latest-l10n-ssl'),
+                             [('product', 'firefox-devedition-latest-ssl'),
                               ('os', 'win64'),
                               ('lang', 'pt-BR')])
         url = firefox_desktop.get_download_url('alpha', '28.0a2', 'osx', 'pt-BR', True)
         self.assertListEqual(parse_qsl(urlparse(url).query),
-                             [('product', 'firefox-aurora-latest-l10n-ssl'),
+                             [('product', 'firefox-devedition-latest-ssl'),
                               ('os', 'osx'),
                               ('lang', 'pt-BR')])
         url = firefox_desktop.get_download_url('alpha', '28.0a2', 'linux', 'pt-BR', True)
         self.assertListEqual(parse_qsl(urlparse(url).query),
-                             [('product', 'firefox-aurora-latest-l10n-ssl'),
+                             [('product', 'firefox-devedition-latest-ssl'),
                               ('os', 'linux'),
                               ('lang', 'pt-BR')])
         url = firefox_desktop.get_download_url('alpha', '28.0a2', 'linux64', 'pt-BR', True)
         self.assertListEqual(parse_qsl(urlparse(url).query),
-                             [('product', 'firefox-aurora-latest-l10n-ssl'),
+                             [('product', 'firefox-devedition-latest-ssl'),
                               ('os', 'linux64'),
                               ('lang', 'pt-BR')])
 


### PR DESCRIPTION
## Description

The bouncer prefix for Firefox Developer Edition has been changed from `firefox-aurora` to `firefox-devedition`. The download buttons on mozilla.org have to be updated accordingly.

## Bugzilla link

[Bug 1357379](https://bugzilla.mozilla.org/show_bug.cgi?id=1357379)

## Testing

Visit `/firefox/channel/desktop/`, `/firefox/developer/` and `/firefox/developer/all/` to make sure the Developer Edition download buttons are working properly.

## Checklist
- [ ] Requires l10n changes.
- [x] Related functional & integration tests passing.
