### PR TITLE
[fix bug 1367774] Add Optimizely to /new/?xv=batmfree variation.

### DIFF
--- a/bedrock/firefox/templates/firefox/new/batm/free.html
+++ b/bedrock/firefox/templates/firefox/new/batm/free.html
@@ -6,6 +6,12 @@
 
 {% extends "firefox/new/batm/scene1.html" %}
 
+{% block optimizely %}
+  {% if switch('firefox-new-batmfree', ['en-US']) %}
+    {% include 'includes/optimizely.html' %}
+  {% endif %}
+{% endblock %}
+
 {% block main_header_copy %}
 <p id="main-header-copy" data-experience="batmfree">
   {{_('Break free with Firefox, for people not profit.')}}


### PR DESCRIPTION
## Description

Adds Optimizely snippet to the `?xv=batmfree` variation of `/firefox/new/`. Other BATM variations will have different experiments, so keeping these switches specific to a single variation.

## Bugzilla link

https://bugzilla.mozilla.org/show_bug.cgi?id=1367774

## Testing

Look for silly mistakes?

## Checklist
- [ ] Requires l10n changes.
- [ ] Related functional & integration tests passing.
