### PR TITLE
Fix Bug 1369120 - Use Google Play link for Fennec Nightly

### DIFF
--- a/bedrock/firefox/firefox_details.py
+++ b/bedrock/firefox/firefox_details.py
@@ -296,7 +296,7 @@ class FirefoxAndroid(_ProductDetails):
 
     # Human-readable channel names
     channel_labels = {
-        'alpha': _('Firefox Aurora'),
+        'nightly': _('Firefox Nightly'),
         'beta': _('Firefox Beta'),
         'release': _('Firefox'),
     }
@@ -304,14 +304,12 @@ class FirefoxAndroid(_ProductDetails):
     # Version property names in product-details
     version_map = {
         'nightly': 'nightly_version',
-        'alpha': 'alpha_version',
         'beta': 'beta_version',
         'release': 'version',
     }
 
     # Build property names in product-details
     build_map = {
-        'alpha': 'alpha_builds',
         'beta': 'beta_builds',
         'release': 'builds',
     }
@@ -330,8 +328,9 @@ class FirefoxAndroid(_ProductDetails):
 
     store_url = settings.GOOGLE_PLAY_FIREFOX_LINK
     # Product IDs defined on Google Play
+    # Nightly reuses the Aurora ID to migrate the user base
     store_product_ids = {
-        'alpha': 'org.mozilla.fennec_aurora',
+        'nightly': 'org.mozilla.fennec_aurora',
         'beta': 'org.mozilla.firefox_beta',
         'release': 'org.mozilla.firefox',
     }
@@ -340,7 +339,6 @@ class FirefoxAndroid(_ProductDetails):
                         'latest-mozilla-%s-android')
     archive_repo = {
         'nightly': 'central',
-        'alpha': 'aurora',
     }
     archive_urls = {
         'api-15': archive_url_base + '-api-15/fennec-%s.multi.android-arm.apk',
@@ -439,13 +437,9 @@ class FirefoxAndroid(_ProductDetails):
                 instead of Google Play.
         :return: string url
         """
-        # Use a direct link for Nightly until Bug 1241114 is solved
-        if channel == 'nightly':
-            force_direct = True
-
         if force_direct:
-            # Use a direct archive link for Nightly/Aurora
-            if channel in ['nightly', 'alpha']:
+            # Use a direct archive link for Nightly
+            if channel == 'nightly':
                 return self.archive_urls[arch] % (self.archive_repo[channel],
                                                   self.latest_version(channel))
 

--- a/bedrock/firefox/templates/firefox/includes/download-button.html
+++ b/bedrock/firefox/templates/firefox/includes/download-button.html
@@ -9,6 +9,8 @@
         {{ _('Firefox Beta') }}
       {% elif channel == 'alpha' %}
         {{ _('<span>Firefox</span> Developer Edition') }}
+      {% elif channel == 'nightly' %}
+        {{ _('Firefox Nightly') }}
       {% else %}
         {{ _('Download Firefox') }}
       {% endif %}  — {{ locale_name|safe }}

--- a/bedrock/firefox/templatetags/helpers.py
+++ b/bedrock/firefox/templatetags/helpers.py
@@ -1,5 +1,3 @@
-from collections import OrderedDict
-
 from django.conf import settings
 
 import jinja2
@@ -70,30 +68,11 @@ def desktop_builds(channel, builds=None, locale=None, force_direct=False,
 
 
 def android_builds(channel, builds=None):
-    channel = channel.lower()
     builds = builds or []
-    variations = OrderedDict([
-        ('api-15', 'Ice Cream Sandwich+'),
-        ('x86', 'x86'),
-    ])
-
-    if channel == 'aurora':
-        channel = 'alpha'
-
-    if channel == 'nightly':
-        for type, arch_pretty in variations.iteritems():
-            link = firefox_android.get_download_url(channel, type)
-            builds.append({'os': 'android',
-                           'os_pretty': 'Android',
-                           'os_arch_pretty': 'Android %s' % arch_pretty,
-                           'arch': 'x86' if type == 'x86' else 'armv7up %s' % type,
-                           'arch_pretty': arch_pretty,
-                           'download_link': link})
-    else:
-        link = firefox_android.get_download_url(channel)
-        builds.append({'os': 'android',
-                       'os_pretty': 'Android',
-                       'download_link': link})
+    link = firefox_android.get_download_url(channel.lower())
+    builds.append({'os': 'android',
+                   'os_pretty': 'Android',
+                   'download_link': link})
 
     return builds
 

--- a/bedrock/firefox/tests/test_firefox_details.py
+++ b/bedrock/firefox/tests/test_firefox_details.py
@@ -534,7 +534,6 @@ class TestFirefoxDesktop(TestCase):
 @patch.object(firefox_android._storage, 'data',
               Mock(return_value=dict(version='22.0.1',
                                      beta_version='23.0',
-                                     alpha_version='24.0a2',
                                      nightly_version='25.0a1')))
 class TestFirefoxAndroid(TestCase):
     archive_url_base = 'https://archive.mozilla.org/pub/mobile/nightly/'
@@ -549,22 +548,16 @@ class TestFirefoxAndroid(TestCase):
         """latest_version should return the latest beta version."""
         eq_(firefox_android.latest_version('beta'), '23.0')
 
-    def test_latest_alpha_platforms(self):
-        """latest_version should return the latest Aurora version."""
-        platforms = [key for (key, value) in firefox_android.platforms('alpha')]
-        eq_(platforms, ['android', 'android-x86'])
-
     def test_get_download_url_nightly(self):
         """
-        get_download_url should return a mozilla-central archive link depending
-        on the architecture type, even if the force_direct option is unspecified.
+        get_download_url should return the same Google Play link of the
+        'org.mozilla.fennec_aurora' product regardless of the architecture type,
+        if the force_direct option is unspecified.
         """
-        eq_(firefox_android.get_download_url('nightly', 'api-15'),
-            self.archive_url_base + 'latest-mozilla-central-android-api-15/'
-            'fennec-25.0a1.multi.android-arm.apk')
-        eq_(firefox_android.get_download_url('nightly', 'x86'),
-            self.archive_url_base + 'latest-mozilla-central-android-x86/'
-            'fennec-25.0a1.multi.android-i386.apk')
+        ok_(firefox_android.get_download_url('nightly', 'api-15')
+            .startswith(self.google_play_url_base + 'fennec_aurora'))
+        ok_(firefox_android.get_download_url('nightly', 'x86')
+            .startswith(self.google_play_url_base + 'fennec_aurora'))
 
     def test_get_download_url_nightly_direct(self):
         """
@@ -577,29 +570,6 @@ class TestFirefoxAndroid(TestCase):
         eq_(firefox_android.get_download_url('nightly', 'x86', 'multi', True),
             self.archive_url_base + 'latest-mozilla-central-android-x86/'
             'fennec-25.0a1.multi.android-i386.apk')
-
-    def test_get_download_url_aurora(self):
-        """
-        get_download_url should return the same Google Play link of the
-        'org.mozilla.fennec_aurora' product regardless of the architecture type,
-        if the force_direct option is unspecified.
-        """
-        ok_(firefox_android.get_download_url('alpha', 'api-15')
-            .startswith(self.google_play_url_base + 'fennec_aurora'))
-        ok_(firefox_android.get_download_url('alpha', 'x86')
-            .startswith(self.google_play_url_base + 'fennec_aurora'))
-
-    def test_get_download_url_aurora_direct(self):
-        """
-        get_download_url should return a mozilla-aurora archive link depending
-        on the architecture type, if the force_direct option is True.
-        """
-        eq_(firefox_android.get_download_url('alpha', 'api-15', 'multi', True),
-            self.archive_url_base + 'latest-mozilla-aurora-android-api-15/'
-            'fennec-24.0a2.multi.android-arm.apk')
-        eq_(firefox_android.get_download_url('alpha', 'x86', 'multi', True),
-            self.archive_url_base + 'latest-mozilla-aurora-android-x86/'
-            'fennec-24.0a2.multi.android-i386.apk')
 
     def test_get_download_url_beta(self):
         """

--- a/bedrock/firefox/tests/test_helpers.py
+++ b/bedrock/firefox/tests/test_helpers.py
@@ -210,27 +210,10 @@ class TestDownloadButtons(TestCase):
         eq_(pq(list[5]).attr('class'), 'os_linux64')
 
     def test_latest_nightly_android(self):
-        """The download button should have 2 direct archive links"""
-        rf = RequestFactory()
-        get_request = rf.get('/fake')
-        doc = pq(render("{{ download_firefox('nightly', platform='android') }}",
-                        {'request': get_request}))
-
-        list = doc('.download-list li')
-        eq_(list.length, 2)
-        eq_(pq(list[0]).attr('class'), 'os_android armv7up api-15')
-        eq_(pq(list[1]).attr('class'), 'os_android x86')
-
-        links = doc('.download-list li a')
-        eq_(links.length, 2)
-        ok_(pq(links[0]).attr('href').startswith('https://archive.mozilla.org'))
-        ok_(pq(links[1]).attr('href').startswith('https://archive.mozilla.org'))
-
-    def test_latest_aurora_android(self):
         """The download button should have a Google Play link"""
         rf = RequestFactory()
         get_request = rf.get('/fake')
-        doc = pq(render("{{ download_firefox('alpha', platform='android') }}",
+        doc = pq(render("{{ download_firefox('nightly', platform='android') }}",
                         {'request': get_request}))
 
         list = doc('.download-list li')

--- a/bedrock/releasenotes/tests/test_base.py
+++ b/bedrock/releasenotes/tests/test_base.py
@@ -230,7 +230,7 @@ class TestRNAViews(TestCase):
         link = views.get_download_url(release)
         ok_(link.startswith(store_url % 'org.mozilla.firefox_beta'))
 
-        release = Mock(product='Firefox for Android', channel='Aurora')
+        release = Mock(product='Firefox for Android', channel='Nightly')
         link = views.get_download_url(release)
         ok_(link.startswith(store_url % 'org.mozilla.fennec_aurora'))
 

--- a/bedrock/styleguide/templates/styleguide/websites/sandstone-all-download-buttons.html
+++ b/bedrock/styleguide/templates/styleguide/websites/sandstone-all-download-buttons.html
@@ -54,7 +54,7 @@
       </tr>
       <tr>
         <td>
-          {{ download_firefox(platform='android', channel='alpha') }}
+          {{ download_firefox(platform='android', channel='nightly') }}
         </td>
       </tr>
     </tbody>


### PR DESCRIPTION
## Description

Firefox Nightly for Android is now available on [Google Play](https://play.google.com/store/apps/details?id=org.mozilla.fennec_aurora). This PR uses the Google Play link for the Nightly download button accordingly and removes the Aurora support.

## Bugzilla link

[Bug 1369120](https://bugzilla.mozilla.org/show_bug.cgi?id=1369120)

## Testing

Visit `/firefox/channel/android/` to see the Nightly download button goes to Google Play. Meanwhile `/firefox/android/nightly/all/` still has direct links.

## Checklist
- [ ] Requires l10n changes.
- [x] Related functional & integration tests passing.
