### PR TITLE
Fix Bug 1364470 - Update Country Codes in Hreflang tags

### DIFF
--- a/bedrock/base/templates/includes/canonical-url.html
+++ b/bedrock/base/templates/includes/canonical-url.html
@@ -10,7 +10,7 @@
         {% if code == 'en-US' -%}
         <link rel="alternate" hreflang="en" href="{{ settings.CANONICAL_URL + '/' + code + loop_canonical_path }}" title="English">
         <link rel="alternate" hreflang="en-CA" href="{{ settings.CANONICAL_URL + '/' + code + loop_canonical_path }}" title="English (Canada)">
-        {% else -%}
+        {% elif code|length != 3 -%}{#- Bug 1364470: Drop ISO 639-2 and -3 locales not supported by Google -#}
         <link rel="alternate" hreflang="{{ code }}" href="{{ settings.CANONICAL_URL + '/' + code + loop_canonical_path }}" title="{{ label|safe }}">
         {% endif -%}
       {% endfor -%}


### PR DESCRIPTION
## Description

Some locales on mozorg are not supported by Google and other search engines, and those `<link rel="alternate">` lines lead to errors on the SEM dashboard. This PR removes the known 7 locales from the alternate locale list.

## Bugzilla link

[Bug 1364470](https://bugzilla.mozilla.org/show_bug.cgi?id=1364470)

## Testing

Check the homepage, for example, to see the 7 locales are not included in the alternate locale list, while the language switcher at the bottom of the page still offers these locales.

## Checklist
- [ ] Requires l10n changes.
- [x] Related functional & integration tests passing.
