### PR TITLE
[bug 1364268] Participation guidelines, enclose string for l10n

### DIFF
--- a/bedrock/mozorg/templates/mozorg/about/governance/policies/participation.html
+++ b/bedrock/mozorg/templates/mozorg/about/governance/policies/participation.html
@@ -470,7 +470,7 @@
 </section>
 
 <section id="questions">
-  <h2>Ask questions</h2>
+  <h2>{{ _('Ask questions') }}</h2>
   <p>
   {% trans mailto_inclusion='mailto:inclusion@mozilla.com' %}
     Everyone is encouraged to ask questions about these guidelines.


### PR DESCRIPTION
## Description
Oops, missed a string.

## Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1364268#c13

## Checklist
- [ ] Requires l10n changes.
- [ ] Related functional & integration tests passing.
