### PR TITLE
[fix bug 1367774] Add Optimizely to /new/?xv=batmprivate variation.

### DIFF
--- a/bedrock/firefox/templates/firefox/new/batm/free.html
+++ b/bedrock/firefox/templates/firefox/new/batm/free.html
@@ -7,7 +7,7 @@
 {% extends "firefox/new/batm/scene1.html" %}
 
 {% block optimizely %}
-  {% if switch('firefox-new-batmfree', ['en-US']) %}
+  {% if switch('firefox-new-batmfree-optimizely', ['en-US']) %}
     {% include 'includes/optimizely.html' %}
   {% endif %}
 {% endblock %}

--- a/bedrock/firefox/templates/firefox/new/batm/private.html
+++ b/bedrock/firefox/templates/firefox/new/batm/private.html
@@ -6,6 +6,12 @@
 
 {% extends "firefox/new/batm/scene1.html" %}
 
+{% block optimizely %}
+  {% if switch('firefox-new-batmprivate-optimizely', ['en-US']) %}
+    {% include 'includes/optimizely.html' %}
+  {% endif %}
+{% endblock %}
+
 {% block main_header_copy %}
 <p id="main-header-copy" data-experience="batmprivate">
   {{_('Get Firefox, the only browser built for people, not profit.')}}


### PR DESCRIPTION


## Description

Adds Optimizely snippet to the `?xv=batmprivate` variation of `/firefox/new/`.

Also changes switch name for `?xv=batmfree` variation to be more explicit (adds `-optimizely` suffix).

**This will require renaming the currently enabled switch `SWITCH_FIREFOX_NEW_BATMFREE` to `SWITCH_FIREFOX_NEW_BATMFREE_OPTIMIZELY`.**

## Bugzilla link

https://bugzilla.mozilla.org/show_bug.cgi?id=1367774#c19

## Testing

Look for copy pasta errors.

## Checklist
- [ ] Requires l10n changes.
- [ ] Related functional & integration tests passing.
