### PR TITLE
Fix Bug 1369732 - Redirect http://mozilla.org/Firefox to https://www.mozilla.org/firefox/

### DIFF
--- a/bedrock/firefox/redirects.py
+++ b/bedrock/firefox/redirects.py
@@ -536,4 +536,7 @@ redirectpatterns = (
 
     # Bug 1361181
     redirect(r'^en-US/firefox/products/?', '/en-US/firefox/', locale_prefix=False),
+
+    # bug 1369732
+    redirect(r'^Firefox/?$', 'firefox'),
 )

--- a/tests/redirects/map_globalconf.py
+++ b/tests/redirects/map_globalconf.py
@@ -1171,4 +1171,7 @@ URLS = flatten((
 
     # Bug 1361181
     url_test('/en-US/firefox/products/', '/en-US/firefox/'),
+
+    # Bug 1369732
+    url_test('{/en-US,}/Firefox', '{/en-US,}/firefox/'),
 ))


### PR DESCRIPTION
## Description

Canonicalize the capitalized `Firefox` URL so it won't end up with a 404 page.

## Bugzilla link

[Bug 1369732](https://bugzilla.mozilla.org/show_bug.cgi?id=1369732)

## Testing

Visit `/Firefox` and `/en-US/Firefox` to see those URLs are redirected to `/firefox/`.

## Checklist
- [ ] Requires l10n changes.
- [x] Related functional & integration tests passing.
