### PR TITLE
Remove Fx home blog feed functional test

### DIFF
--- a/tests/functional/firefox/test_home.py
+++ b/tests/functional/firefox/test_home.py
@@ -13,9 +13,3 @@ from pages.firefox.home import FirefoxHubHomePage
 def test_download_buttons_displayed(base_url, selenium):
     page = FirefoxHubHomePage(selenium, base_url).open()
     assert page.download_button.is_displayed
-
-
-@pytest.mark.nondestructive
-def test_news_feed_is_displayed(base_url, selenium):
-    page = FirefoxHubHomePage(selenium, base_url).open()
-    assert len(page.news_feed.articles) == 1

--- a/tests/pages/firefox/home.py
+++ b/tests/pages/firefox/home.py
@@ -6,7 +6,6 @@ from selenium.webdriver.common.by import By
 
 from pages.firefox.base import FirefoxBasePage
 from pages.regions.download_button import DownloadButton
-from pages.regions.news_feed import NewsFeed
 
 
 class FirefoxHubHomePage(FirefoxBasePage):
@@ -19,7 +18,3 @@ class FirefoxHubHomePage(FirefoxBasePage):
     def download_button(self):
         el = self.find_element(*self._download_button_locator)
         return DownloadButton(self, root=el)
-
-    @property
-    def news_feed(self):
-        return NewsFeed(self)


### PR DESCRIPTION
## Description

As the home page blog feed presence is potentially very fickle, best to remove the test for now so as not to block test runs should a blog post not be available.

Kept the [property/region on the page class](https://github.com/mozilla/bedrock/blob/master/tests/pages/firefox/home.py#L24) in the event we want to reinstate a version of this test later on.

## Bugzilla link

Nope.

## Testing

Ensure tests still pass and no other code should be removed.

## Checklist
- [ ] Requires l10n changes.
- [ ] Related functional & integration tests passing.
