### PR TITLE
[fix bug 1366815] Update /firefox/sync copy for en-*.

### DIFF
--- a/bedrock/firefox/templates/firefox/sync-en.html
+++ b/bedrock/firefox/templates/firefox/sync-en.html
@@ -1,0 +1,69 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+
+{% from "macros.html" import fxfamilynav, google_play_button with context %}
+
+{% extends "/firefox/sync.html" %}
+
+{% block banner %}
+<header role="banner" class="intro container">
+  <div class="show-fx-31-signed-in">
+    <h1>Browse boldly. <br>Connect your devices.</h1>
+    <p>
+      Add Firefox on your personal devices to get your bookmarks, open tabs and passwords anywhere. Get secure access to everything you need when you sign into your Firefox Account.
+    </p>
+  </div>
+  <div class="show-fx-31-signed-out show-fx-29-30 show-fx-28-older show-fx-android">
+    <h1>Your web, how you like it, everywhere</h1>
+    <p>
+      Sign into your Firefox Account to access your protected passwords, open tabs and bookmarks. Add Firefox to your personal devices and securely connect your browsing experience everywhere. Keep everything set up how you like it, wherever you go.
+    </p>
+  </div>
+  <div class="show-not-fx show-default">
+    <h1>If you lived here <br>you'd be home by now</h1>
+    <p>
+      Download or open Firefox to start securely connecting your browsing experience on all your personal devices. Sign into your Firefox Account to access your protected passwords, open tabs and bookmarks. Keep everything set up how you like it, wherever you go.
+    </p>
+  </div>
+</header>
+{% endblock %}
+
+{% block not_fx_warning %}{% endblock %}
+
+{% block mobile_buttons_text %}
+  <p>Add Firefox to more devices now.</p>
+{% endblock %}
+
+{% block features %}
+  <header>
+    <h2>Your account. Your choice.</h2>
+    <p>
+      Control how much&mdash;or how little&mdash;of your account data you share between devices. Sync your open tabs or access all your passwords and history anywhere you log in to Firefox; your personal data is private and for your eyes only—even we can’t see it.
+    </p>
+  </header>
+  <div class="features">
+    <div class="feature-home">
+      <h3>Personal</h3>
+      <p>
+        That shopping rabbit hole you started on your laptop this morning? Pick up where you left off on your phone tonight. That dinner recipe you discovered at lunchtime? Open it on your kitchen tablet, instantly. Connect your personal devices, securely.
+      </p>
+    </div>
+    <div class="feature-work">
+      <h3>Secure</h3>
+      <p>
+        Your Firefox Account is the doorway to all your web stuff—we help you keep it safe. Your data is always in your control, unreadable by anyone else, and encrypted with your account password. We protect it and hand you the key.
+      </p>
+    </div>
+    <div class="feature-go">
+      <h3>Accessible</h3>
+      <p>
+        Catch up on your open tabs and saved reads over Saturday morning coffee. Find your bookmarks and passwords anywhere you use Firefox—your smartphone, tablet or laptop. Connect everything you need and nothing you don’t.
+      </p>
+    </div>
+  </div>
+{% endblock %}
+
+{% block everywhere_copy %}
+  Download Firefox to the devices you use and sign into your account to securely connect the passwords, tabs and bookmarks you need. Done and done.
+{% endblock %}

--- a/bedrock/firefox/templates/firefox/sync.html
+++ b/bedrock/firefox/templates/firefox/sync.html
@@ -40,21 +40,24 @@
 {% endblock %}
 
 {% block content %}
-{% include 'firefox/includes/sync-animation.html' %}
-<header role="banner" class="intro container">
-  <div class="show-fx-31-signed-in">
-    <h1>{{ _('Ready, Set, Sync') }}</h1>
-    <p>
-      {{ _('You’re signed up and ready to access <em>your</em> Firefox anywhere, anytime.') }}
-    </p>
-  </div>
-  <div class="show-fx-31-signed-out show-fx-29-30 show-fx-28-older show-fx-android show-not-fx show-default">
-    <h1>{{ _('Take your Web with you') }}</h1>
-    <p>
-      {{ _('Sync Firefox wherever you use it to access your bookmarks, passwords, tabs and more from any smartphone, tablet or computer.') }}
-    </p>
-  </div>
-</header>
+  {% include 'firefox/includes/sync-animation.html' %}
+
+  {% block banner %}
+    <header role="banner" class="intro container">
+      <div class="show-fx-31-signed-in">
+        <h1>{{ _('Ready, Set, Sync') }}</h1>
+        <p>
+          {{ _('You’re signed up and ready to access <em>your</em> Firefox anywhere, anytime.') }}
+        </p>
+      </div>
+      <div class="show-fx-31-signed-out show-fx-29-30 show-fx-28-older show-fx-android show-not-fx show-default">
+        <h1>{{ _('Take your Web with you') }}</h1>
+        <p>
+          {{ _('Sync Firefox wherever you use it to access your bookmarks, passwords, tabs and more from any smartphone, tablet or computer.') }}
+        </p>
+      </div>
+    </header>
+  {% endblock %}
 
 <section class="primary">
   <div class="inner-wrapper">
@@ -73,6 +76,7 @@
         </p>
       </div>
 
+    {% block not_fx_warning %}
       <div class="show-not-fx warning">
         <p>
           {% if l10n_has_tag('firefox_sync_non_fx') %}
@@ -82,16 +86,19 @@
           {% endif %}
         </p>
       </div>
+    {% endblock %}
 
       {# Primary Buttons #}
 
       <div class="buttons">
         <div class="show-fx-31-signed-in">
-        {% if l10n_has_tag('firefox_sync_mobile_buttons_update') %}
-          <p>
-            {{ _('Now sync Firefox with your iOS and Android devices.') }}
-          </p>
-        {% endif %}
+        {% block mobile_buttons_text %}
+          {% if l10n_has_tag('firefox_sync_mobile_buttons_update') %}
+            <p>
+              {{ _('Now sync Firefox with your iOS and Android devices.') }}
+            </p>
+          {% endif %}
+        {% endblock %}
           <ul class="primary-buttons">
             <li>
               {{ google_play_button(id='cta-android') }}
@@ -207,6 +214,7 @@
 <section class="secondary">
   <div class="inner-wrapper">
     <div class="container">
+    {% block features %}
       <header>
         <h2>{{ _('Sync a little. Sync a lot.') }}</h2>
         <p>
@@ -237,6 +245,7 @@
           </p>
         </div>
       </div>
+    {% endblock %}
     </div>
   </div>
 </section>
@@ -253,7 +262,9 @@
       </header>
       <aside>
         <p>
+        {% block everywhere_copy %}
           {{ _('To get the full Sync experience, take your Web with you everywhere you use Firefox. Connect your smartphone, tablet, computer and laptop.') }}
+        {% endblock %}
         </p>
       </aside>
     </div>

--- a/bedrock/firefox/tests/test_views.py
+++ b/bedrock/firefox/tests/test_views.py
@@ -652,3 +652,25 @@ class TestFirefoxProductIOSView(TestCase):
         view.request = RequestFactory().get('/firefox/ios/')
         view.request.locale = 'fr'
         eq_(view.get_template_names(), ['firefox/ios.html'])
+
+
+@override_settings(DEV=False)
+@patch('bedrock.firefox.views.l10n_utils.render')
+class TestSync(TestCase):
+    def test_en_us_template(self, render_mock):
+        req = RequestFactory().get('/firefox/sync/')
+        req.locale = 'en-US'
+        views.sync(req)
+        render_mock.assert_called_once_with(req, 'firefox/sync-en.html')
+
+    def test_en_gb_template(self, render_mock):
+        req = RequestFactory().get('/firefox/sync/')
+        req.locale = 'en-GB'
+        views.sync(req)
+        render_mock.assert_called_once_with(req, 'firefox/sync-en.html')
+
+    def test_locales_template(self, render_mock):
+        req = RequestFactory().get('/firefox/sync/')
+        req.locale = 'de'
+        views.sync(req)
+        render_mock.assert_called_once_with(req, 'firefox/sync.html')

--- a/bedrock/firefox/urls.py
+++ b/bedrock/firefox/urls.py
@@ -9,7 +9,6 @@ from bedrock.mozorg.util import page
 import views
 import bedrock.releasenotes.views
 from bedrock.releasenotes import version_re
-from bedrock.utils.views import VariationTemplateView
 
 
 latest_re = r'^firefox(?:/(?P<version>%s))?/%s/$'
@@ -74,11 +73,7 @@ urlpatterns = (
     }),
     url('^firefox/send-to-device-post/$', views.send_to_device_ajax,
         name='firefox.send-to-device-post'),
-    url(r'^firefox/sync/$',
-        VariationTemplateView.as_view(template_name='firefox/sync.html',
-                                      template_context_variations=['2', '3'],
-                                      variation_locales=['en-US']),
-        name='firefox.sync'),
+    url(r'^firefox/sync/$', views.sync, name='firefox.sync'),
     page('firefox/unsupported-systems', 'firefox/unsupported-systems.html'),
     url(r'^firefox/new/$', views.new, name='firefox.new'),
     page('firefox/organizations/faq', 'firefox/organizations/faq.html'),

--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -671,3 +671,14 @@ class FirefoxHubView(BlogPostsView):
             return HttpResponseRedirect(reverse('firefox.new'))
         else:
             return super(FirefoxHubView, self).get(request, *args, **kwargs)
+
+
+def sync(request):
+    locale = l10n_utils.get_locale(request)
+
+    if locale.startswith('en-'):
+        template = 'firefox/sync-en.html'
+    else:
+        template = 'firefox/sync.html'
+
+    return l10n_utils.render(request, template)


### PR DESCRIPTION
## Description

Update copy on `/firefox/sync` for `en-*` locales only.

These changes are knowingly temporary. The Sync page is scheduled to be changed significantly (functionality & copy) when brought into the Fx Hub (Q3?).

## Bugzilla link

https://bugzilla.mozilla.org/show_bug.cgi?id=1366815#c10

## Testing

Ensure minor changes to `firefox/sync.html` do not cause any new issues with non `en-*` locales.

Ensure `firefox/sync-en.html` displays the correct content for the following three states:

**Firefox, logged in to Sync**

- *Headline*: Browse boldly. Connect your devices.
- *Subhead*: Add Firefox on your personal devices to get your bookmarks, open tabs and passwords anywhere. Get secure access to everything you need when you sign into your Firefox Account.
- *Small subhead*: Add Firefox to more devices now.

**Firefox, not logged in to Sync**

- *Headline*: Your web, how you like it, everywhere
- *Subhead*: Sign into your Firefox Account to access your protected passwords, open tabs and bookmarks. Add Firefox to your personal devices and securely connect your browsing experience everywhere. Keep everything set up how you like it, wherever you go.
- *CTA*: Get started

**Not Firefox**

(Note that this is a new "state". The `firefox/sync.html` template combines this state with the Fx, not logged in state.)

- *Headline*: If you lived here you’d be home by now
- *Subhead*: Download or open Firefox to start securely connecting your browsing experience on all your personal devices. Sign into your Firefox Account to access your protected passwords, open tabs and bookmarks. Keep everything set up how you like it, wherever you go.

**All three above states share the same changes to the content area underneath the intro.**

Demo is up (reminder: [needs UITour allowance in `about:config`](http://bedrock.readthedocs.io/en/latest/uitour.html#local-development)):

https://www-demo3.allizom.org/firefox/sync/

## Checklist
- [ ] Requires l10n changes.
- [ ] Related functional & integration tests passing.
