### PR TITLE
[fix bug 1370818] Inconsistent link targets on /firefox

### DIFF
--- a/bedrock/firefox/templates/firefox/features/fast.html
+++ b/bedrock/firefox/templates/firefox/features/fast.html
@@ -97,7 +97,7 @@
 
       <section id="card-independent" class="card image-card card-independent">
         <a href="{{ url('firefox.features.independent') }}" class="card-image" data-link-type="link" data-link-position="Value - Independent" data-link-name="More Freedom">
-        <img src="{{ static('img/firefox/hub/value-indie.jpg') }}" alt="">
+          <img src="{{ static('img/firefox/hub/value-indie.jpg') }}" alt="">
         </a>
         <div class="card-content">
           <a href="{{ url('firefox.features.independent') }}" data-link-type="link" data-link-position="Value - Independent" data-link-name="More Freedom">

--- a/bedrock/firefox/templates/firefox/features/index.html
+++ b/bedrock/firefox/templates/firefox/features/index.html
@@ -22,10 +22,12 @@
 {% endblock %}
 
 {% macro lazy_image(image_name) -%}
-<img src="{{ static('img/firefox/features/thumbnails/placeholder.png') }}" data-src="{{ static('img/firefox/features/thumbnails/' + image_name) }}" alt="">
-<noscript>
-  <img src="{{ static('img/firefox/features/thumbnails/' + image_name) }}" alt="">
-</noscript>
+<div class="image-container">
+  <img src="{{ static('img/firefox/features/thumbnails/placeholder.png') }}" data-src="{{ static('img/firefox/features/thumbnails/' + image_name) }}" alt="">
+  <noscript>
+    <img src="{{ static('img/firefox/features/thumbnails/' + image_name) }}" alt="">
+  </noscript>
+</div>
 {%- endmacro %}
 
 {% block features_list %}
@@ -37,8 +39,8 @@
       <li class="features-list-item">
         <a href="https://addons.mozilla.org/firefox/?utm_source=www.mozilla.org&amp;utm_medium=referral&amp;utm_campaign=fx-content-hub" data-link-type="link" data-link-name="Your favorite Add-ons and Extensions" data-link-position="modern 1">
           {{ lazy_image('addons.jpg') }}
+          <h3>{{ _('Your favorite Add-ons and Extensions') }}</h3>
         </a>
-        <h3>{{ _('Your favorite Add-ons and Extensions') }}</h3>
         <p>{{ _('Adblock, Ublock, LastPass and thousands more.') }}</p>
         <p>
           <a href="https://addons.mozilla.org/firefox/?utm_source=www.mozilla.org&amp;utm_medium=referral&amp;utm_campaign=fx-content-hub" class="cta-link" data-link-type="link" data-link-name="Your favorite Add-ons and Extensions" data-link-position="modern 1">
@@ -49,8 +51,8 @@
       <li class="features-list-item">
         <a href="https://addons.mozilla.org/firefox/themes/?utm_source=www.mozilla.org&amp;utm_medium=referral&amp;utm_campaign=fx-content-hub" data-link-type="link" data-link-name="Customize your browser" data-link-position="modern 2">
           {{ lazy_image('customize.jpg') }}
+          <h3>{{ _('Customize your browser') }}</h3>
         </a>
-        <h3>{{ _('Customize your browser') }}</h3>
         <p>{{ _('Personalize Firefox with everything from themes to privacy tools.') }}</p>
         <p>
           <a href="https://addons.mozilla.org/firefox/themes/?utm_source=www.mozilla.org&amp;utm_medium=referral&amp;utm_campaign=fx-content-hub" class="cta-link" data-link-type="link" data-link-name="Customize your browser" data-link-position="modern 2">
@@ -61,8 +63,8 @@
       <li class="features-list-item">
         <a href="{{ url('firefox.features.fast') }}" data-link-type="link" data-link-name="Browse Faster" data-link-position="modern 3">
           {{ lazy_image('fast.jpg') }}
+          <h3>{{ _('Browse Faster') }}</h3>
         </a>
-        <h3>{{ _('Browse Faster') }}</h3>
         <p>{{ _('Start faster, tab hop quicker, get more done.') }}</p>
         <p>
           <a href="{{ url('firefox.features.fast') }}" class="cta-link" data-link-type="link" data-link-name="Browse Faster" data-link-position="modern 3">
@@ -73,8 +75,8 @@
       <li class="features-list-item">
         <a href="{{ url('firefox.sync') }}" data-link-type="link" data-link-name="Sync Between Devices" data-link-position="modern 4">
           {{ lazy_image('sync.jpg') }}
+          <h3>{{ _('Sync Between Devices') }}</h3>
         </a>
-        <h3>{{ _('Sync Between Devices') }}</h3>
         <p>{{ _('Get your tabs, logins, and history on the go.') }}</p>
         <p>
           <a href="{{ url('firefox.sync') }}" class="cta-link" data-link-type="link" data-link-name="Sync Between Devices" data-link-position="modern 4">
@@ -85,8 +87,8 @@
       <li class="features-list-item">
         <a href="{{ url('firefox.android.index') }}" data-link-type="link" data-link-name="Firefox for Android" data-link-position="modern 5">
           {{ lazy_image('android.jpg') }}
+          <h3>{{ _('Firefox for Android') }}</h3>
         </a>
-        <h3>{{ _('Firefox for Android') }}</h3>
         <p>{{ _('Our most customizable Firefox for Android yet.') }}</p>
         <p>
           <a href="{{ url('firefox.android.index') }}" class="cta-link" data-link-type="link" data-link-name="Firefox for Android" data-link-position="modern 5">
@@ -97,8 +99,8 @@
       <li class="features-list-item">
         <a href="{{ url('firefox.ios') }}" data-link-type="link" data-link-name="Firefox for iOS" data-link-position="modern 6">
           {{ lazy_image('ios.jpg') }}
+          <h3>{{ _('Firefox for iOS') }}</h3>
         </a>
-        <h3>{{ _('Firefox for iOS') }}</h3>
         <p>{{ _('The speed you need. The privacy you trust.') }}</p>
         <p>
           <a href="{{ url('firefox.ios') }}" class="cta-link" data-link-type="link" data-link-name="Firefox for iOS" data-link-position="modern 6">
@@ -109,8 +111,8 @@
       <li class="features-list-item">
         <a href="https://testpilot.firefox.com/?utm_source=www.mozilla.org&amp;utm_medium=referral&amp;utm_campaign=fx-content-hub" data-link-type="link" data-link-name="Firefox Test Pilot" data-link-position="modern 7">
           {{ lazy_image('test-pilot.jpg') }}
+          <h3>{{ _('Firefox Test Pilot') }}</h3>
         </a>
-        <h3>{{ _('Firefox Test Pilot') }}</h3>
         <p>{{ _('Experimental features that can simplify your life.') }}</p>
         <p>
           <a href="https://testpilot.firefox.com/?utm_source=www.mozilla.org&amp;utm_medium=referral&amp;utm_campaign=fx-content-hub" class="cta-link" data-link-type="link" data-link-name="Firefox Test Pilot" data-link-position="modern 7">
@@ -121,8 +123,8 @@
       <li class="features-list-item">
         <a href="{{ url('firefox.features.memory') }}" data-link-type="link" data-link-name="Speed up your computer" data-link-position="modern 8">
           {{ lazy_image('memory.png') }}
+          <h3>{{ _('Balanced Memory Usage') }}</h3>
         </a>
-        <h3>{{ _('Balanced Memory Usage') }}</h3>
         <p>{{ _('Browse smoothly and leave plenty of memory for your computer programs.') }}</p>
         <p>
           <a href="{{ url('firefox.features.memory') }}" class="cta-link" data-link-type="link" data-link-name="Speed up your computer" data-link-position="modern 8">
@@ -142,8 +144,8 @@
       <li class="features-list-item">
         <a href="{{ url('firefox.features.private-browsing') }}" data-link-type="link" data-link-name="Ad Tracker Blocking" data-link-position="privacy 1">
           {{ lazy_image('tracking-protection.jpg') }}
+          <h3>{{ _('Ad Tracker Blocking') }}</h3>
         </a>
-        <h3>{{ _('Ad Tracker Blocking') }}</h3>
         <p>{{ _('Firefox Private Browsing blocks ads with trackers.') }}</p>
         <p>
           <a href="{{ url('firefox.features.private-browsing') }}" class="cta-link" data-link-type="link" data-link-name="Ad Tracker Blocking" data-link-position="privacy 1">
@@ -154,8 +156,8 @@
       <li class="features-list-item">
         <a href="{{ url('firefox.features.private-browsing') }}" data-link-type="link" data-link-name="More Powerful Private Browsing" data-link-position="privacy 2">
           {{ lazy_image('private-browsing.jpg') }}
+          <h3>{{ _('More Powerful Private Browsing') }}</h3>
         </a>
-        <h3>{{ _('More Powerful Private Browsing') }}</h3>
         <p>{{ _('More protection than Incognito mode or InPrivate.') }}</p>
         <p>
           <a href="{{ url('firefox.features.private-browsing') }}" class="cta-link" data-link-type="link" data-link-name="More Powerful Private Browsing" data-link-position="privacy 2">
@@ -166,8 +168,8 @@
       <li class="features-list-item">
         <a href="{{ url('firefox.features.private-browsing') }}" data-link-type="link" data-link-name="More Private" data-link-position="privacy 3">
           {{ lazy_image('private.jpg') }}
+          <h3>{{ _('More Private') }}</h3>
         </a>
-        <h3>{{ _('More Private') }}</h3>
         <p>{{ _('We don’t sell access to your online data. Period.') }}</p>
         <p>
           <a href="{{ url('firefox.features.private-browsing') }}" class="cta-link" data-link-type="link" data-link-name="More Private" data-link-position="privacy 3">
@@ -178,8 +180,8 @@
       <li class="features-list-item">
         <a href="{{ url('privacy') }}" data-link-type="link" data-link-name="Limited Data Collection" data-link-position="privacy 4">
           {{ lazy_image('limited-data-collection.jpg') }}
+          <h3>{{ _('Limited Data Collection') }}</h3>
         </a>
-        <h3>{{ _('Limited Data Collection') }}</h3>
         <p>{{ _('Opted-in to privacy, so you can browse freely.') }}</p>
         <p>
           <a href="{{ url('privacy') }}" class="cta-link" data-link-type="link" data-link-name="Limited Data Collection" data-link-position="privacy 4">
@@ -199,8 +201,8 @@
       <li class="features-list-item">
         <a href="{{ url('mozorg.mission') }}" data-link-type="link" data-link-name="By Non-Profit, Mozilla" data-link-position="independence 1">
           {{ lazy_image('non-profit.jpg') }}
+          <h3>{{ _('By Non-Profit, Mozilla') }}</h3>
         </a>
-        <h3>{{ _('By Non-Profit, Mozilla') }}</h3>
         <p>{{ _('Protecting the health of the internet.') }}</p>
         <p>
           <a href="{{ url('mozorg.mission') }}" class="cta-link" data-link-type="link" data-link-name="By Non-Profit, Mozilla" data-link-position="independence 1">
@@ -211,8 +213,8 @@
       <li class="features-list-item">
         <a href="{{ url('firefox.features.independent') }}" data-link-type="link" data-link-name="Open Source" data-link-position="independence 2">
           {{ lazy_image('open-source.jpg') }}
+          <h3>{{ _('Open Source') }}</h3>
         </a>
-        <h3>{{ _('Open Source') }}</h3>
         <p>{{ _('We’re always transparent.') }}</p>
         <p>
           <a href="{{ url('firefox.features.independent') }}" class="cta-link" data-link-type="link" data-link-name="Open Source" data-link-position="independence 2">
@@ -223,8 +225,8 @@
       <li class="features-list-item">
         <a href="{{ url('firefox.features.independent') }}" data-link-type="link" data-link-name="Protect Your Rights" data-link-position="independence 3">
           {{ lazy_image('independent.jpg') }}
+          <h3>{{ _('Protect Your Rights') }}</h3>
         </a>
-        <h3>{{ _('Protect Your Rights') }}</h3>
         <p>{{ _('We help keep corporate powers in check.') }}</p>
         <p>
           <a href="{{ url('firefox.features.independent') }}" class="cta-link" data-link-type="link" data-link-name="Protect Your Rights" data-link-position="independence 3">

--- a/bedrock/firefox/templates/firefox/features/private-browsing.html
+++ b/bedrock/firefox/templates/firefox/features/private-browsing.html
@@ -102,7 +102,7 @@
 
       <section id="card-independent" class="card image-card card-independent">
         <a href="{{ url('firefox.features.independent') }}" class="card-image" data-link-type="link" data-link-position="Value - Independent" data-link-name="More Freedom">
-        <img src="{{ static('img/firefox/hub/value-indie.jpg') }}" alt="">
+          <img src="{{ static('img/firefox/hub/value-indie.jpg') }}" alt="">
         </a>
         <div class="card-content">
           <a href="{{ url('firefox.features.independent') }}" data-link-type="link" data-link-position="Value - Independent" data-link-name="More Freedom">

--- a/bedrock/firefox/templates/firefox/hub/home.html
+++ b/bedrock/firefox/templates/firefox/hub/home.html
@@ -140,27 +140,33 @@
         <section id="third-party-feed">
           <div class="card card-stacked">
             <div class="card-content">
-              <blockquote class="quote">
-                Why I switched back to Firefox
-              </blockquote>
+              <a rel="external" href="http://www.computerworld.com/article/3074093/enterprise-applications/why-i-switched-back-to-firefox.html" data-link-name="Why I switched back to Firefox" data-link-type="link" data-link-position="1">
+                <blockquote class="quote">
+                  Why I switched back to Firefox
+                </blockquote>
+              </a>
 
               <a rel="external" href="http://www.computerworld.com/article/3074093/enterprise-applications/why-i-switched-back-to-firefox.html" class="cta-link" data-link-name="Why I switched back to Firefox" data-link-type="link" data-link-position="1">Computerworld</a>
             </div>
           </div>
           <div class="card card-stacked">
             <div class="card-content">
-              <blockquote class="quote">
-                Half the Web Is Now Encrypted. That Makes Everyone Safer.
-              </blockquote>
+              <a rel="external" href="https://www.wired.com/2017/01/half-web-now-encrypted-makes-everyone-safer/" data-link-name="Half the Web Is Now Encrypted. That Makes Everyone Safer." data-link-type="link" data-link-position="2">
+                <blockquote class="quote">
+                  Half the Web Is Now Encrypted. That Makes Everyone Safer.
+                </blockquote>
+              </a>
 
               <a rel="external" href="https://www.wired.com/2017/01/half-web-now-encrypted-makes-everyone-safer/" class="cta-link" data-link-name="Half the Web Is Now Encrypted. That Makes Everyone Safer." data-link-type="link" data-link-position="2">Wired</a>
             </div>
           </div>
           <div class="card card-stacked">
             <div class="card-content">
-              <blockquote class="quote">
-                Your Internet Search History Will Soon Be Up for Sale &mdash; Here’s How You Can Protect Yourself
-              </blockquote>
+              <a rel="external" href="http://www.vogue.com/article/internet-privacy-fcc-laws-eliminated-protect-yourself" data-link-name="Your Internet Search History Will Soon Be Up for Sale &mdash; Here’s How You Can Protect Yourself" data-link-type="link" data-link-position="3">
+                <blockquote class="quote">
+                  Your Internet Search History Will Soon Be Up for Sale &mdash; Here’s How You Can Protect Yourself
+                </blockquote>
+              </a>
 
               <a rel="external" href="http://www.vogue.com/article/internet-privacy-fcc-laws-eliminated-protect-yourself" class="cta-link" data-link-name="Your Internet Search History Will Soon Be Up for Sale &mdash; Here’s How You Can Protect Yourself" data-link-type="link" data-link-position="3">Vogue</a>
             </div>
@@ -178,7 +184,9 @@
         <div id="sync-card" class="card image-card">
           <div class="card-content-wrapper">
             <div class="card-content">
-              <h2 class="card-heading">{{ _('Take Firefox to go!') }}</h2>
+              <a href="{{ url('firefox.sync') }}" data-link-name="Check out Firefox Sync" data-link-type="link" data-link-position="Firefox Sync">
+                <h2 class="card-heading">{{ _('Take Firefox to go!') }}</h2>
+              </a>
 
               <p>
               {% trans url1=url('firefox.ios'), url2=url('firefox.android.index') %}

--- a/bedrock/firefox/templates/firefox/products/desktop.html
+++ b/bedrock/firefox/templates/firefox/products/desktop.html
@@ -42,8 +42,8 @@
       <li class="features-list-item">
         <a href="{{ url('firefox.features.fast') }}" data-link-type="link" data-link-position="Feature 1" data-link-name="Get more done">
           <img class="feature-image" src="{{ static('img/firefox/products/desktop/feature-desktop-speed.jpg') }}" alt="">
+          <h3 class="feature-title">{{ _('Get more done') }}</h3>
         </a>
-        <h3 class="feature-title">{{ _('Get more done') }}</h3>
         <div class="feature-desc">
           <p>
           {% trans %}
@@ -59,8 +59,8 @@
       <li class="features-list-item">
         <a href="{{ url('firefox.features.private-browsing') }}" data-link-type="link" data-link-position="Feature 2" data-link-name="Get more privacy">
           <img class="feature-image" src="{{ static('img/firefox/products/desktop/feature-desktop-privacy.jpg') }}" alt="">
+          <h3 class="feature-title">{{ _('Get more privacy') }}</h3>
         </a>
-        <h3 class="feature-title">{{ _('Get more privacy') }}</h3>
         <div class="feature-desc">
           <p>
           {% trans %}
@@ -76,8 +76,8 @@
       <li class="features-list-item">
         <a href="{{ url('firefox.features.independent') }}" data-link-type="link" data-link-position="Feature 3" data-link-name="Get more freedom">
           <img class="feature-image" src="{{ static('img/firefox/products/desktop/feature-desktop-addons.jpg') }}" alt="">
+          <h3 class="feature-title">{{ _('Get more freedom') }}</h3>
         </a>
-        <h3 class="feature-title">{{ _('Get more freedom') }}</h3>
         <div class="feature-desc">
           <p>
           {% trans %}

--- a/bedrock/mozorg/templates/mozorg/internet-health/includes/podcast.html
+++ b/bedrock/mozorg/templates/mozorg/internet-health/includes/podcast.html
@@ -9,17 +9,18 @@
 
        <div class="card-content-wrapper">
          <div class="card-content">
-           <h3 class="card-heading">{{ _('The ultimate Internet Health podcast') }}</h3>
+            <a href="https://irlpodcast.org/" data-link-name="Check out our podcasts" data-link-type="link" data-link-position="Podcast">
+              <h3 class="card-heading">{{ _('The ultimate Internet Health podcast') }}</h3>
+            </a>
+            <p>
+              {% trans %}
+              Listen up! We’re chatting all things Internet Health and how you can get involved.
+              {% endtrans %}
+            </p>
 
-           <p>
-           {% trans %}
-             Listen up! We’re chatting all things Internet Health and how you can get involved.
-           {% endtrans %}
-           </p>
-
-           <a href="https://irlpodcast.org/" class="cta-link" data-link-name="Check out our podcasts" data-link-type="link" data-link-position="Podcast">
-             {{ _('Check out our podcasts') }}
-           </a>
+            <a href="https://irlpodcast.org/" class="cta-link" data-link-name="Check out our podcasts" data-link-type="link" data-link-position="Podcast">
+              {{ _('Check out our podcasts') }}
+            </a>
          </div>
        </div> {#--/.card-content-wrapper--#}
      </div>

--- a/bedrock/mozorg/templates/mozorg/internet-health/index.html
+++ b/bedrock/mozorg/templates/mozorg/internet-health/index.html
@@ -67,9 +67,13 @@
             {% endif %}
             <h2 class="card-label"><span>{{ value|e }}</span></h2>
             <div class="card-content">
-              <h3 class="card-title">{{ title|e }}</h3>
               {% if loop.first %}
+                <a href="{{ url|e }}" data-link-type="link" data-link-position="Issue - {{ value|e }}" data-link-name="{{ title|e }}">
+                  <h3 class="card-title">{{ title|e }}</h3>
+                </a>
                 <p>{{ intro|e }}</p>
+              {% else %}
+                <h3 class="card-title">{{ title|e }}</h3>
               {% endif %}
               <p class="card-cta">
                 <a href="{{ url|e }}" class="cta-link" data-link-type="link" data-link-position="Issue - {{ value|e }}" data-link-name="{{ title|e }}">
@@ -91,7 +95,9 @@
 
         <div class="card-content-wrapper">
           <div class="card-content">
-            <h3 class="card-heading">{{ _('Net Neutrality is under threat…again.') }}</h3>
+            <a href="https://advocacy.mozilla.org/net-neutrality" data-link-name="Get involved now" data-link-type="link" data-link-position="net-neutrality">
+              <h3 class="card-heading">{{ _('Net Neutrality is under threat…again.') }}</h3>
+            </a>
 
             <p>
             {% trans %}
@@ -119,7 +125,9 @@
 
         <div class="card-content-wrapper">
           <div class="card-content">
-            <h3 class="card-heading">{{ _('All about Internet Health') }}</h3>
+            <a href="https://internethealthreport.org" data-link-name="Read the Internet Health Report" data-link-type="link" data-link-position="Internet Health Report">
+              <h3 class="card-heading">{{ _('All about Internet Health') }}</h3>
+            </a>
             <p>{{ _('The Internet got a full check-up and the results are in.') }}</p>
             <a href="https://internethealthreport.org" class="cta-link" data-link-name="Read the Internet Health Report" data-link-type="link" data-link-position="Internet Health Report">
               {{ _('Read the Internet Health Report') }}

--- a/media/css/firefox/features/common.scss
+++ b/media/css/firefox/features/common.scss
@@ -175,7 +175,7 @@ main {
         display: none;
     }
 
-    &> a {
+    .image-container {
         background-color: #eee;
         display: block;
         margin-bottom: 20px;
@@ -204,6 +204,25 @@ main {
             &.cta-link:active {
                 text-decoration: none;
             }
+        }
+    }
+
+    &> a:link,
+    &> a:visited {
+        display: block;
+        text-decoration: none;
+        h3 {
+            @include transition(color .1s ease-in-out);
+            color: $color-text-primary;
+        }
+    }
+
+    &> a:hover,
+    &> a:active,
+    &> a:focus {
+        h3 {
+            @include transition(color .1s ease-in-out);
+            color: $color-link-blue-dark;
         }
     }
 }

--- a/media/css/firefox/product-page.scss
+++ b/media/css/firefox/product-page.scss
@@ -125,6 +125,25 @@ $color-link-blue-dark: #175a77;
             padding-bottom: 0;
         }
 
+        &> a:link,
+        &> a:visited {
+            display: block;
+            text-decoration: none;
+            h3 {
+                @include transition(color .1s ease-in-out);
+                color: $color-text-primary;
+            }
+        }
+
+        &> a:hover,
+        &> a:active,
+        &> a:focus {
+            h3 {
+                @include transition(color .1s ease-in-out);
+                color: $color-link-blue-dark;
+            }
+        }
+
         img {
             display: block;
             margin: 0 auto 20px;

--- a/media/css/hubs/_card-image-large.scss
+++ b/media/css/hubs/_card-image-large.scss
@@ -6,6 +6,8 @@
 
 // A single card with a large, full width background image
 
+$color-link-blue-dark: #175a77;
+
 .card-image-large {
     padding: 0 0 40px;
 
@@ -19,6 +21,24 @@
         background: #fff;
         margin-right: 20px;
         padding: 20px;
+
+        &> a:link,
+        &> a:visited {
+            text-decoration: none;
+            h3 {
+                @include transition(color .1s ease-in-out);
+                color: $color-text-primary;
+            }
+        }
+
+        &> a:hover,
+        &> a:active,
+        &> a:focus {
+            h3 {
+                @include transition(color .1s ease-in-out);
+                color: $color-link-blue-dark;
+            }
+        }
     }
 
     @media #{$mq-tablet} {

--- a/media/css/hubs/_cards-block.scss
+++ b/media/css/hubs/_cards-block.scss
@@ -19,7 +19,8 @@
         &> a:visited {
             text-decoration: none;
 
-            h2 {
+            h2,
+            h3 {
                 @include transition(color .1s ease-in-out);
                 color: $color-text-primary;
             }
@@ -28,7 +29,8 @@
         &> a:hover,
         &> a:active,
         &> a:focus {
-            h2 {
+            h2,
+            h3 {
                 @include transition(color .1s ease-in-out);
                 color: #175a77;
             }

--- a/media/css/hubs/_cards.scss
+++ b/media/css/hubs/_cards.scss
@@ -49,6 +49,30 @@ $card-padding: 20px;
         }
     }
 
+    &> a:link,
+    &> a:visited {
+        text-decoration: none;
+
+        h2,
+        h3,
+        .quote {
+            @include transition(color .1s ease-in-out);
+            color: $color-text-primary;
+        }
+    }
+
+    &> a:hover,
+    &> a:active,
+    &> a:focus {
+
+        h2,
+        h3,
+        .quote {
+            @include transition(color .1s ease-in-out);
+            color: $color-link-blue-dark;
+        }
+    }
+
     @media #{$mq-tablet} {
         padding-left: $card-padding * 2;
     }


### PR DESCRIPTION
## Description
- Improves general consistency for link targets on Firefox hub pages (also Internet Health hub for good measure)

## Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1370818

## Testing
- Best clean `/static` dir prior to reviewing: `gulp static:clean`.

## Checklist
- [ ] Requires l10n changes.
- [ ] Related functional & integration tests passing.
