### PR TITLE
[fix bug 1365741] Fx54 /whatsnew: Add experiment for de.

### DIFF
--- a/bedrock/firefox/templates/firefox/whatsnew/fx54/whatsnew-54.de.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/fx54/whatsnew-54.de.html
@@ -1,0 +1,25 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+
+{% extends "firefox/whatsnew/fx54/whatsnew-54.html" %}
+
+{% add_lang_files "firefox/sendto" "download" %}
+
+{% block experiments %}
+  {% if switch('firefox-whatsnew-54-de', ['de']) %}
+    {% javascript 'experiment_whatsnew_54_de' %}
+  {% endif %}
+{% endblock %}
+
+{% block body_content %}
+  {% if variation == 'b' %} {# QR code #}
+    <div id="qr-wrapper" class="primary-cta">
+      <img src="{{ static('img/firefox/whatsnew_54/qrcode.png') }}" width="250" height="250" alt="" />
+    </div>
+  {% else %} {# send to device widget / control #}
+    <div id="send-to-device-wrapper" class="primary-cta">
+      {{ send_to_device(include_title=False, message_set=send_to_device_message_set) }}
+    </div>
+  {% endif %}
+{% endblock %}

--- a/bedrock/firefox/templates/firefox/whatsnew/fx54/whatsnew-54.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/fx54/whatsnew-54.html
@@ -51,7 +51,7 @@ A modified copy of firefox/mobile-download-desktop.html
         <div class="inner-container">
           <header id="masthead">
             <div id="mozilla-logo">
-              <a href="{{ url('mozorg.home') }}" data-link-type="nav" data-link-name="mozilla">Mozilla</a>
+              <a href="{{ url('mozorg.home') }}" data-link-type="nav" data-link-name="tabzilla">Mozilla</a>
             </div>
             <h2>{{ high_res_img('firefox/template/logo-large.png', {'alt': 'Firefox', 'width': '136', 'height': '142'}) }}</h2>
           </header>
@@ -90,7 +90,7 @@ A modified copy of firefox/mobile-download-desktop.html
             {% block body_content %}
               {# Hide the widget if user is not in a supported basket locale #}
               {% if show_send_to_device %}
-                <div id="send-to-device-wrapper">
+                <div id="send-to-device-wrapper" class="primary-cta">
                   {{ send_to_device(include_title=False, message_set=send_to_device_message_set) }}
                 </div>
               {% endif %}

--- a/bedrock/firefox/templates/firefox/whatsnew/fx54/whatsnew-54.zh-TW.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/fx54/whatsnew-54.zh-TW.html
@@ -14,7 +14,7 @@
 {% endblock %}
 
 {% block body_content %}
-  <div id="qr-wrapper">
+  <div id="qr-wrapper" class="primary-cta">
     <img src="{{ static('img/firefox/whatsnew_54/qrcode.png') }}" width="250" height="250" alt="" />
   </div>
 {% endblock %}

--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -416,7 +416,7 @@ class FirstrunView(l10n_utils.LangFilesMixin, TemplateView):
 
 class WhatsnewView(VariationMixin, l10n_utils.LangFilesMixin, TemplateView):
     template_context_variations = ['a', 'b']
-    variation_locales = ['zh-TW']
+    variation_locales = ['de']
 
     def get_context_data(self, **kwargs):
         ctx = super(WhatsnewView, self).get_context_data(**kwargs)

--- a/bedrock/settings/static_media.py
+++ b/bedrock/settings/static_media.py
@@ -1528,6 +1528,13 @@ PIPELINE_JS = {
         ),
         'output_filename': 'js/firefox_whatsnew_50-bundle.js',
     },
+    'experiment_whatsnew_54_de': {
+        'source_filenames': (
+            'js/base/mozilla-traffic-cop.js',
+            'js/firefox/whatsnew/experiment-whatsnew-54-de.js',
+        ),
+        'output_filename': 'js/firefox_whatsnew_54_de-bundle.js',
+    },
     'firefox_firstrun_yahoo_retention': {
         'source_filenames': (
             'js/base/uitour-lib.js',

--- a/media/css/firefox/whatsnew/whatsnew-54.less
+++ b/media/css/firefox/whatsnew/whatsnew-54.less
@@ -310,6 +310,13 @@ main {
     margin: 0 auto;
 }
 
+// this is either the send to device widget or the QR code.
+// if either are present, app store badges (which sit below this primary-cta)
+// should be pushed further "below the fold".
+.primary-cta {
+    padding-bottom: 80px;
+}
+
 #mobile-download-buttons {
     margin: 40px auto 0;
     padding-top: 10px;

--- a/media/js/firefox/whatsnew/experiment-whatsnew-54-de.js
+++ b/media/js/firefox/whatsnew/experiment-whatsnew-54-de.js
@@ -1,0 +1,17 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+(function(Mozilla) {
+    'use strict';
+
+    var dozerman = new Mozilla.TrafficCop({
+        id: 'experiment-firefox-whatsnew-54-de',
+        variations: {
+            'v=a': 50, // send to device widget/control
+            'v=b': 50 // QR code
+        }
+    });
+
+    dozerman.init();
+})(window.Mozilla);


### PR DESCRIPTION
## Description

Basically running the same experiment we ran for zh-TW on Fx 53 whatsnew, but now for de. 50% should get `?v=a`, which is the control with the send to device widget. 50% get `?v=b`, which is the QR code.

Also:

- reverts `data-link-name` on the update wordmark to `tabzilla` (at pg's request)
- moves app store badges further "below the fold" if either send to device widget or QR code are present

## Bugzilla link

https://bugzilla.mozilla.org/show_bug.cgi?id=1365741#c4

## Testing

In a browser with DNT disabled, make sure `/de/firefox/54.0/whatsnew/` loads the variations outlined above.

## Checklist
- [ ] Requires l10n changes.
- [ ] Related functional & integration tests passing.
