### PR TITLE
[fix bug 1365741] Fx54 /whatsnew: Add experiments for de, ja, & zh-CN.

### DIFF
--- a/bedrock/firefox/templates/firefox/whatsnew/fx54/whatsnew-54-ja-zhcn-base.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/fx54/whatsnew-54-ja-zhcn-base.html
@@ -1,0 +1,22 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+
+{% extends "firefox/whatsnew/fx54/whatsnew-54.html" %}
+
+{% add_lang_files "firefox/whatsnew_50" "firefox/sendto" %}
+
+{% block experiments %}
+  {% if switch('firefox-whatsnew-54-ja-zhcn', ['ja', 'zh-CN']) %}
+    {% javascript 'experiment_whatsnew_54_ja_zhcn' %}
+  {% endif %}
+{% endblock %}
+
+{% block body_content %}
+  {% if variation == 'd' %} {# QR code #}
+    <div id="qr-wrapper" class="primary-cta">
+      <img src="{{ static('img/firefox/whatsnew_54/qrcode.png') }}" width="250" height="250" alt="" />
+    </div>
+  {% endif %}
+  {# control is ?v=c, which is just the app store badges #}
+{% endblock %}

--- a/bedrock/firefox/templates/firefox/whatsnew/fx54/whatsnew-54.de.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/fx54/whatsnew-54.de.html
@@ -1,0 +1,25 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+
+{% extends "firefox/whatsnew/fx54/whatsnew-54.html" %}
+
+{% add_lang_files "firefox/whatsnew_50" "firefox/sendto" %}
+
+{% block experiments %}
+  {% if switch('firefox-whatsnew-54-de', ['de']) %}
+    {% javascript 'experiment_whatsnew_54_de' %}
+  {% endif %}
+{% endblock %}
+
+{% block body_content %}
+  {% if variation == 'b' %} {# QR code #}
+    <div id="qr-wrapper" class="primary-cta">
+      <img src="{{ static('img/firefox/whatsnew_54/qrcode.png') }}" width="250" height="250" alt="" />
+    </div>
+  {% else %} {# send to device widget / control #}
+    <div id="send-to-device-wrapper" class="primary-cta">
+      {{ send_to_device(include_title=False, message_set=send_to_device_message_set) }}
+    </div>
+  {% endif %}
+{% endblock %}

--- a/bedrock/firefox/templates/firefox/whatsnew/fx54/whatsnew-54.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/fx54/whatsnew-54.html
@@ -51,7 +51,7 @@ A modified copy of firefox/mobile-download-desktop.html
         <div class="inner-container">
           <header id="masthead">
             <div id="mozilla-logo">
-              <a href="{{ url('mozorg.home') }}" data-link-type="nav" data-link-name="mozilla">Mozilla</a>
+              <a href="{{ url('mozorg.home') }}" data-link-type="nav" data-link-name="tabzilla">Mozilla</a>
             </div>
             <h2>{{ high_res_img('firefox/template/logo-large.png', {'alt': 'Firefox', 'width': '136', 'height': '142'}) }}</h2>
           </header>
@@ -90,7 +90,7 @@ A modified copy of firefox/mobile-download-desktop.html
             {% block body_content %}
               {# Hide the widget if user is not in a supported basket locale #}
               {% if show_send_to_device %}
-                <div id="send-to-device-wrapper">
+                <div id="send-to-device-wrapper" class="primary-cta">
                   {{ send_to_device(include_title=False, message_set=send_to_device_message_set) }}
                 </div>
               {% endif %}

--- a/bedrock/firefox/templates/firefox/whatsnew/fx54/whatsnew-54.ja.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/fx54/whatsnew-54.ja.html
@@ -1,0 +1,12 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+
+{#
+Simply a specifically-named placeholder template to take advantage of
+locale-specific templates.
+#}
+
+{% extends "firefox/whatsnew/fx54/whatsnew-54-ja-zhcn-base.html" %}
+
+{% add_lang_files "firefox/whatsnew_50" "firefox/sendto" %}

--- a/bedrock/firefox/templates/firefox/whatsnew/fx54/whatsnew-54.zh-CN.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/fx54/whatsnew-54.zh-CN.html
@@ -1,0 +1,12 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+
+{#
+Simply a specifically-named placeholder template to take advantage of
+locale-specific templates.
+#}
+
+{% extends "firefox/whatsnew/fx54/whatsnew-54-ja-zhcn-base.html" %}
+
+{% add_lang_files "firefox/whatsnew_50" "firefox/sendto" %}

--- a/bedrock/firefox/templates/firefox/whatsnew/fx54/whatsnew-54.zh-TW.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/fx54/whatsnew-54.zh-TW.html
@@ -4,8 +4,6 @@
 
 {% extends "firefox/whatsnew/fx54/whatsnew-54.html" %}
 
-{% add_lang_files "firefox/sendto" "download" %}
-
 {% block header_content %}
   <h4><span>你的 Firefox 已是最新版本。</span></h4>
   <h2>想要隨時隨地都能使用 Firefox 嗎？</h2>
@@ -14,7 +12,7 @@
 {% endblock %}
 
 {% block body_content %}
-  <div id="qr-wrapper">
+  <div id="qr-wrapper" class="primary-cta">
     <img src="{{ static('img/firefox/whatsnew_54/qrcode.png') }}" width="250" height="250" alt="" />
   </div>
 {% endblock %}

--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-50.zh-TW.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-50.zh-TW.html
@@ -4,7 +4,7 @@
 
 {% extends "firefox/whatsnew/whatsnew-50.html" %}
 
-{% add_lang_files "firefox/sendto" "download" %}
+{% add_lang_files "firefox/sendto" %}
 
 {% block header_content %}
   <h4><span>你的 Firefox 已是最新版本。</span></h4>

--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -415,8 +415,9 @@ class FirstrunView(l10n_utils.LangFilesMixin, TemplateView):
 
 
 class WhatsnewView(VariationMixin, l10n_utils.LangFilesMixin, TemplateView):
-    template_context_variations = ['a', 'b']
-    variation_locales = ['zh-TW']
+    # a & b are for de, c & d are for ja/zh-CN
+    template_context_variations = ['a', 'b', 'c', 'd']
+    variation_locales = ['de', 'ja', 'zh-CN']
 
     def get_context_data(self, **kwargs):
         ctx = super(WhatsnewView, self).get_context_data(**kwargs)

--- a/bedrock/settings/static_media.py
+++ b/bedrock/settings/static_media.py
@@ -1528,6 +1528,20 @@ PIPELINE_JS = {
         ),
         'output_filename': 'js/firefox_whatsnew_50-bundle.js',
     },
+    'experiment_whatsnew_54_de': {
+        'source_filenames': (
+            'js/base/mozilla-traffic-cop.js',
+            'js/firefox/whatsnew/experiment-whatsnew-54-de.js',
+        ),
+        'output_filename': 'js/firefox_whatsnew_54_de-bundle.js',
+    },
+    'experiment_whatsnew_54_ja_zhcn': {
+        'source_filenames': (
+            'js/base/mozilla-traffic-cop.js',
+            'js/firefox/whatsnew/experiment-whatsnew-54-ja-zhcn.js',
+        ),
+        'output_filename': 'js/firefox_whatsnew_54_ja_zhcn-bundle.js',
+    },
     'firefox_firstrun_yahoo_retention': {
         'source_filenames': (
             'js/base/uitour-lib.js',

--- a/media/css/firefox/whatsnew/whatsnew-54.less
+++ b/media/css/firefox/whatsnew/whatsnew-54.less
@@ -310,6 +310,13 @@ main {
     margin: 0 auto;
 }
 
+// this is either the send to device widget or the QR code.
+// if either are present, app store badges (which sit below this primary-cta)
+// should be pushed further "below the fold".
+.primary-cta {
+    padding-bottom: 120px;
+}
+
 #mobile-download-buttons {
     margin: 40px auto 0;
     padding-top: 10px;

--- a/media/js/firefox/whatsnew/experiment-whatsnew-54-de.js
+++ b/media/js/firefox/whatsnew/experiment-whatsnew-54-de.js
@@ -1,0 +1,17 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+(function(Mozilla) {
+    'use strict';
+
+    var dozerman = new Mozilla.TrafficCop({
+        id: 'experiment-firefox-whatsnew-54-de',
+        variations: {
+            'v=a': 50, // send to device widget/control
+            'v=b': 50 // QR code
+        }
+    });
+
+    dozerman.init();
+})(window.Mozilla);

--- a/media/js/firefox/whatsnew/experiment-whatsnew-54-ja-zhcn.js
+++ b/media/js/firefox/whatsnew/experiment-whatsnew-54-ja-zhcn.js
@@ -1,0 +1,17 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+(function(Mozilla) {
+    'use strict';
+
+    var carver = new Mozilla.TrafficCop({
+        id: 'experiment-firefox-whatsnew-54-ja-zhcn',
+        variations: {
+            'v=c': 50, // control/no primary CTA
+            'v=d': 50 // QR code
+        }
+    });
+
+    carver.init();
+})(window.Mozilla);


### PR DESCRIPTION
## Description

**Experiment 1: de**
Basically running the same experiment we ran for zh-TW on Fx 53 whatsnew, but now for de. 50% should get `?v=a`, which is the control with the send to device widget. 50% get `?v=b`, which is the QR code.

**Experiment 2: ja & zh-CN**
`?v=c` is the control, and has no primary CTA (just app store badges). `?v=d` is the QR code.

Also:

- reverts `data-link-name` on the updated wordmark to `tabzilla` (at pg's request)
- moves app store badges further "below the fold" if either send to device widget or QR code are present (these are the "primary CTAs")

## Bugzilla link

https://bugzilla.mozilla.org/show_bug.cgi?id=1365741#c4
https://bugzilla.mozilla.org/show_bug.cgi?id=1365741#c6

## Testing

In a browser with DNT disabled, make sure `/de/firefox/54.0/whatsnew/` loads the variations outlined above. Also make sure `/ja/firefox/54.0/whatsnew/` and `/zh-CN/firefox/54.0/whatsnews/` load their specific variations outlined above.

Variations code in the view is a little weird, as it's a single view, but two different experiments. Breaking up by `?v=a/?v=b` and `?v=c/?v=d` seems to work just fine.

## Checklist
- [ ] Related functional & integration tests passing.
