### PR TITLE
Fix Bug 1371470 - Fix & optimize Firefox Nightly Notes feed

### DIFF
--- a/bedrock/firefox/templates/firefox/releases/nightly-feed.xml
+++ b/bedrock/firefox/templates/firefox/releases/nightly-feed.xml
@@ -3,7 +3,7 @@
  # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
 
 <?xml version="1.0" encoding="utf-8"?>
-<feed xmlns="http://www.w3.org/2005/Atom">
+<feed xmlns="http://www.w3.org/2005/Atom" xmlns:webfeeds="http://webfeeds.org/rss/1.0">
   <title>{{ _('Firefox Nightly Notes') }}</title>
   <subtitle>{{ _('Firefox Nightly gets a new version every day and as a consequence, the release notes for the Nightly channel are updated continuously to reflect features that have reached sufficient maturity to benefit from community feedback and bug reports.') }}</subtitle>
   <author>
@@ -14,9 +14,11 @@
   <link rel="alternate" type="text/html" href="{{ url('firefox.notes', channel='nightly')|absolute_url }}"/>
   <icon>{{ static('img/firefox/nightly/favicon.png')|absolute_url }}</icon>
   <updated>{{ notes[0].modified.isoformat() }}</updated>
+  <webfeeds:cover image="{{ static('img/firefox/nightly/page-image.png')|absolute_url }}" />
+  <webfeeds:icon>{{ static('img/firefox/nightly/favicon-196.png')|absolute_url }}</webfeeds:icon>
   {% for note in notes %}
   <entry>
-    <title>{{ note.note|markdown|striptags|truncate(100) }}</title>
+    <title type="html">{{ note.note|markdown|striptags|safe|truncate(100) }}</title>
     <id>{{ note.link|absolute_url }}</id>
     <link rel="alternate" type="text/html" href="{{ note.link|absolute_url }}"/>
     <updated>{{ note.modified.isoformat() }}</updated>


### PR DESCRIPTION
## Description

* Fix the current first entry not showing up on feedly, probably due to an [interoperability issue](https://validator.w3.org/feed/check.cgi?url=https://www.mozilla.org/en-US/firefox/nightly/notes/feed/).
* [Optimize the feed for feedly](https://blog.feedly.com/10-ways-to-optimize-your-feed-for-feedly/) by specifying the cover image and icon.

## Bugzilla link

[Bug 1371470](https://bugzilla.mozilla.org/show_bug.cgi?id=1371470)

## Testing

Visit `/firefox/nightly/notes/feed/` to see the first entry no longer contains `&amp;gt;` in the source. The feed should contain `<webfeeds:cover>` and `<webfeeds:icon>`, should be [validated](https://validator.w3.org/feed/).

## Checklist
- [ ] Requires l10n changes.
- [x] Related functional & integration tests passing.
