### PR TITLE
Fix Bug 1371495 - Specify Nightly page image and icon for Nightly release notes

### DIFF
--- a/bedrock/firefox/templates/firefox/releases/nightly-notes.html
+++ b/bedrock/firefox/templates/firefox/releases/nightly-notes.html
@@ -8,7 +8,12 @@
 
 {% block extrahead %}
 <link rel="alternate" type="application/atom+xml" title="{{ _('Firefox Nightly Notes Feed') }}" href="{{ url('firefox.nightly.notes.feed') }}">
+<link rel="alternate" type="application/atom+xml" title="{{ _('Firefox Nightly News Feed') }}" href="https://blog.nightly.mozilla.org/feed/">
 {% endblock %}
+
+{% block page_favicon %}{{ static('img/firefox/nightly/favicon.png') }}{% endblock %}
+{% block page_favicon_large %}{{ static('img/firefox/nightly/favicon-196.png') }}{% endblock %}
+{% block page_image %}{{ static('img/firefox/nightly/page-image.png') }}{% endblock %}
 
 {% block body_class %}fx-notes space{% endblock %}
 
@@ -18,6 +23,10 @@
 
 {% block notes_heading_primary %}
   <h1>{{ _('See what landed recently in <span>Firefox Nightly</span>!') }}</h1>
+{% endblock %}
+
+{% block extra_resources %}
+  <a rel="external" href="https://blog.nightly.mozilla.org/">{{ _('Firefox Nightly News') }}</a>
 {% endblock %}
 
 {% block site_footer %}

--- a/bedrock/firefox/templates/firefox/releases/release-notes.html
+++ b/bedrock/firefox/templates/firefox/releases/release-notes.html
@@ -313,6 +313,7 @@
     </div>
     <div class="col">
       <h2>{{ _('Other Resources') }}</h2>
+      {% block extra_resources %}{% endblock %}
       <a rel="external" href="https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/{{ release.major_version() }}">{{ _('Developer Information') }}</a>
       <a rel="external"  href="{{ release.get_bug_search_url() }}">{{ _('Complete list of changes for this release') }}</a>
       <a rel="external" href="https://blog.mozilla.org/press/kits/">{{ _('Press Kit') }}</a>


### PR DESCRIPTION
## Description

* Specify the Nightly `og:image` and favicon
* Add links to the Nightly blog

## Bugzilla link

[Bug 1371495](https://bugzilla.mozilla.org/show_bug.cgi?id=1371495)

## Testing

Visit `/firefox/nightly/notes/` to see the favicon and page image are the Nightly branding. In Firefox the Nightly News feed should be discoverable via the Bookmarks menu. There is also a link to the blog in the Other Resources section at the bottom of the page.

## Checklist
- [ ] Requires l10n changes.
- [ ] Related functional & integration tests passing.
