### PR TITLE
[no bug] Use shared lang files in all Internet Health pages

### DIFF
--- a/bedrock/mozorg/templates/mozorg/internet-health/decentralization.html
+++ b/bedrock/mozorg/templates/mozorg/internet-health/decentralization.html
@@ -4,6 +4,8 @@
 
 {% extends "base-pebbles.html" %}
 
+{% add_lang_files "mozorg/internet-health/shared" %}
+
 {% block page_title %}{{ _('Decentralization: Vital to Internet Health') }}{% endblock %}
 
 {% block page_desc %}{{ _('A decentralized internet, owned by all of us, is where net neutrality, interoperability, competition, and local contribution thrive.') }}{% endblock %}

--- a/bedrock/mozorg/templates/mozorg/internet-health/digital-inclusion.html
+++ b/bedrock/mozorg/templates/mozorg/internet-health/digital-inclusion.html
@@ -4,6 +4,8 @@
 
 {% extends "base-pebbles.html" %}
 
+{% add_lang_files "mozorg/internet-health/shared" %}
+
 {% block page_title %}{{ _('Digital Inclusion: Vital to Internet Health') }}{% endblock %}
 
 {% block page_desc %}{{ _('Digital inclusion means promoting diversity, practicing respect, and supporting universal access online.') }}{% endblock %}
@@ -31,13 +33,9 @@
   <ul class="content">
     <li><a href="{{ url('mozorg.internet-health.privacy-security') }}">{{ _('Privacy &amp; Security') }}</a></li>
     <li><a href="{{ url('mozorg.internet-health.open-innovation') }}">{{ _('Open Innovation') }}</a></li>
-  {% if l10n_has_tag('health-decentralization-and-literacy') %}
     <li><a href="{{ url('mozorg.internet-health.decentralization') }}">{{ _('Decentralization') }}</a></li>
-  {% endif %}
     <li class="current"><a href="{{ url('mozorg.internet-health.digital-inclusion') }}">{{ _('Digital Inclusion') }}</a></li>
-  {% if l10n_has_tag('health-decentralization-and-literacy') %}
     <li><a href="{{ url('mozorg.internet-health.web-literacy') }}">{{ _('Web Literacy') }}</a></li>
-  {% endif %}
   </ul>
 </nav>
 

--- a/bedrock/mozorg/templates/mozorg/internet-health/index.html
+++ b/bedrock/mozorg/templates/mozorg/internet-health/index.html
@@ -4,7 +4,7 @@
 
 {% extends "base-pebbles.html" %}
 
-{% add_lang_files "mozorg/internet-health/index" %}
+{% add_lang_files "mozorg/internet-health/shared" %}
 
 {% block page_title %}{{ _('Protect Internet Health and Privacy with Mozilla') }}{% endblock %}
 {% block page_title_suffix %}{% endblock %}

--- a/bedrock/mozorg/templates/mozorg/internet-health/open-innovation.html
+++ b/bedrock/mozorg/templates/mozorg/internet-health/open-innovation.html
@@ -4,6 +4,8 @@
 
 {% extends "base-pebbles.html" %}
 
+{% add_lang_files "mozorg/internet-health/shared" %}
+
 {% block page_title %}{{ _('Open Innovation: Vital to Internet Health') }}{% endblock %}
 
 {% block page_desc %}{{ _('Open Innovation means innovating collectively through shared ideas and open source code.') }}{% endblock %}
@@ -31,13 +33,9 @@
   <ul class="content">
     <li><a href="{{ url('mozorg.internet-health.privacy-security') }}">{{ _('Privacy &amp; Security') }}</a></li>
     <li class="current"><a href="{{ url('mozorg.internet-health.open-innovation') }}">{{ _('Open Innovation') }}</a></li>
-  {% if l10n_has_tag('health-decentralization-and-literacy') %}
     <li><a href="{{ url('mozorg.internet-health.decentralization') }}">{{ _('Decentralization') }}</a></li>
-  {% endif %}
     <li><a href="{{ url('mozorg.internet-health.digital-inclusion') }}">{{ _('Digital Inclusion') }}</a></li>
-  {% if l10n_has_tag('health-decentralization-and-literacy') %}
     <li><a href="{{ url('mozorg.internet-health.web-literacy') }}">{{ _('Web Literacy') }}</a></li>
-  {% endif %}
   </ul>
 </nav>
 

--- a/bedrock/mozorg/templates/mozorg/internet-health/privacy-security.html
+++ b/bedrock/mozorg/templates/mozorg/internet-health/privacy-security.html
@@ -4,6 +4,8 @@
 
 {% extends "base-pebbles.html" %}
 
+{% add_lang_files "mozorg/internet-health/shared" %}
+
 {% block page_title %}{{ _('A Healthy Internet is Secure and Private') }}{% endblock %}
 
 {% block page_desc %}{{ _('The Internet only stays healthy if we trust it as a safe place – to explore, transact, connect, and create.') }}{% endblock %}
@@ -31,21 +33,15 @@
 {% endblock %}
 
 {% block content %}
-{% if l10n_has_tag('internet_health_digital_inclusion') %}
 <nav id="health-subnav" class="health-subnav">
   <ul class="content">
     <li class="current"><a href="{{ url('mozorg.internet-health.privacy-security') }}">{{ _('Privacy &amp; Security') }}</a></li>
     <li><a href="{{ url('mozorg.internet-health.open-innovation') }}">{{ _('Open Innovation') }}</a></li>
-  {% if l10n_has_tag('health-decentralization-and-literacy') %}
     <li><a href="{{ url('mozorg.internet-health.decentralization') }}">{{ _('Decentralization') }}</a></li>
-  {% endif %}
     <li><a href="{{ url('mozorg.internet-health.digital-inclusion') }}">{{ _('Digital Inclusion') }}</a></li>
-  {% if l10n_has_tag('health-decentralization-and-literacy') %}
     <li><a href="{{ url('mozorg.internet-health.web-literacy') }}">{{ _('Web Literacy') }}</a></li>
-  {% endif %}
   </ul>
 </nav>
-{% endif %}
 
 <main role="main">
   <header class="section main-header">

--- a/bedrock/mozorg/templates/mozorg/internet-health/web-literacy.html
+++ b/bedrock/mozorg/templates/mozorg/internet-health/web-literacy.html
@@ -4,6 +4,8 @@
 
 {% extends "base-pebbles.html" %}
 
+{% add_lang_files "mozorg/internet-health/shared" %}
+
 {% block page_title %}{{ _('Web Literacy: Vital to Internet Health') }}{% endblock %}
 
 {% block page_desc %}{{ _('Web literacy means having the skills to read, write, and participate online. A healthy internet is yours to master.') }}{% endblock %}


### PR DESCRIPTION
My gut reaction is: let's never do this again. 

We ended up duplicating strings all over the place by adding a new page to a connected system every couple of weeks. 

This tries to fix the mess, and it would be blocking us from exposing new strings for the hub (we need it merged and pushed to prod), since it moved shared strings (nav menu, newsletter) to a shared file.

CC @peiying2 