### PR TITLE
Push virginia dev

### DIFF
--- a/jenkins/branches/virginia.yml
+++ b/jenkins/branches/virginia.yml
@@ -1,0 +1,11 @@
+# see the following for documentation of these options
+# http://bedrock.readthedocs.io/en/latest/pipeline.html#configuration
+push_public_registry: true
+smoke_tests: false
+regions:
+  - virginia
+apps:
+  - bedrock-dev
+integration_tests:
+  virginia:
+    - headless


### PR DESCRIPTION
I pushed this to the virginia branch to trigger a deployment to work around some issues pulling the bedrock image from the docker hub. Pasting partial IRC transcript:

```
12:45 PM H<hms-flintstone-325> 🚨 FAILURE: Deploy bedrock-dev-virginia: Branch master build #325: https://ci.us-west.moz.works/blue/organizations/jenkins/bedrock_multibranch_pipeline/detail/master/325/pipeline
12:46 PM C<•craigcook> not sure what's up with Virginia...
1:02 PM J<jpetto> we waiting on virginia before pushing, eh?
1:02 PM J<jpetto> looks like a 502 - likely not code related. jgmize?
1:08 PM J<•jgmize> jpetto: working on it now
1:08 PM J<jpetto> thx
1:18 PM M<mr_slate> [bedrock] jgmize created virginia (+1 new commit): https://github.com/mozilla/bedrock/commit/be0a62d993ef
1:18 PM M<mr_slate> bedrock/virginia be0a62d Josh Mize: Push virginia dev
1:19 PM H<hms-flintstone-1> ✨ STARTING: Test & Deploy: Branch virginia build #1: https://ci.us-west.moz.works/blue/organizations/jenkins/bedrock_multibranch_pipeline/detail/virginia/1/pipeline
1:21 PM J<•jgmize> yeah, it keeps timing out pulling the docker image from the docker hub. not seeing any other issues, but the repeat failures are very annoying. might try switching from the docker hub to quay.io if this continues.
1:22 PM J<•jgmize> or possibly amazon's
1:22 PM J<•jgmize> https://aws.amazon.com/ecr/
1:23 PM J<•jgmize> or we can run our own backed by s3 like we do in the older clusters. I was hoping that wouldn't be necessary though
1:29 PM H<hms-flintstone-1> 🚢 SHIPPED: https://bedrock-dev.virginia.moz.works
```