### PR TITLE
[fix bug 1370326] Change button and link colors on hub pages

### DIFF
--- a/bedrock/firefox/templates/firefox/features/base.html
+++ b/bedrock/firefox/templates/firefox/features/base.html
@@ -27,7 +27,7 @@
             {% block features_header_content %}{% endblock %}
           </div>
           <div class="header-download">
-            {{ download_firefox(dom_id='features-header-download', button_color='button-hollow-arrow dark') }}
+            {{ download_firefox(dom_id='features-header-download', button_color='button-arrow') }}
           </div>
         </div>
         {% block features_header_image %}{% endblock %}

--- a/bedrock/firefox/templates/firefox/hub/home.html
+++ b/bedrock/firefox/templates/firefox/hub/home.html
@@ -45,7 +45,7 @@
           </div>
 
           <div class="header-download">
-            {{ download_firefox(dom_id='download-intro', button_color='button-hollow-arrow dark') }}
+            {{ download_firefox(dom_id='download-intro', button_color='button-arrow') }}
           </div>
         </div>
 

--- a/bedrock/firefox/templates/firefox/products/desktop.html
+++ b/bedrock/firefox/templates/firefox/products/desktop.html
@@ -24,7 +24,7 @@
 {% endblock %}
 
 {% block product_header_download %}
-  {{ download_firefox(dom_id='product-header-download', button_color='button-hollow-arrow dark') }}
+  {{ download_firefox(dom_id='product-header-download', button_color='button-arrow') }}
 {% endblock %}
 
 {% block product_header_image %}

--- a/media/css/base/global-nav.less
+++ b/media/css/base/global-nav.less
@@ -507,7 +507,7 @@ html.moz-nav-open .moz-global-nav-page-mask {
 
 #global-nav-download-firefox {
     float: right;
-    margin: -2px 85px 0 0;
+    margin: 5px 85px 0 0;
     width: 200px;
 
     .download-list {
@@ -525,12 +525,12 @@ html.moz-nav-open .moz-global-nav-page-mask {
     .download-link:link,
     .download-link:visited {
         .font-size(14px);
-        background: inherit;
+        background: #11bb69;
         border-radius: 0;
         border: none;
-        color: #646464;
+        color: #fff;
         display: inline-block;
-        padding: 14px 10px;
+        padding: 8px 20px;
         text-decoration: none;
         transition: color 0.1s ease-in-out, background-color 0.1s ease-in-out;
 
@@ -538,25 +538,24 @@ html.moz-nav-open .moz-global-nav-page-mask {
             font-weight: bold;
 
             &:before {
-                .font-size(16px);
-                color: @colorFirefoxLightOrange;
-                content: "\2193\00A0"; // downward-arrow+space
-                transition: color 0.1s ease-in-out;
-                white-space: nowrap;
+                .background-size(12px 28px);
+                background-image: url('/media/img/hubs/down-arrow-light-sprite.png');
+                background-position: left top;
+                content: '';
+                display: block;
+                float: left;
+                height: 14px;
+                margin: 4px 10px 0 0;
+                width: 12px;
             }
         }
 
         &:hover,
         &:focus,
         &:active {
-            background-color: @colorFirefoxLightOrange;
+            background-color: #039c6d;
             color: #fff;
             transition: color 0.1s ease-in-out, background-color 0.1s ease-in-out;
-
-            .download-title:before {
-                color: #fff;
-                transition: color 0.1s ease-in-out;
-            }
         }
     }
 
@@ -566,13 +565,21 @@ html.moz-nav-open .moz-global-nav-page-mask {
         .download-link {
             &:link,
             &:visited {
-                padding: 14px 10px;
+                padding: 8px 10px;
             }
         }
     }
 
     @media only screen and (max-width: @breakTablet) {
+        margin-top: 11px;
         margin-right: 20px;
+
+        .download-link {
+            &:link,
+            &:visited {
+                padding: 4px 10px;
+            }
+        }
     }
 
     .fx-privacy-link {

--- a/media/css/firefox/features/common.scss
+++ b/media/css/firefox/features/common.scss
@@ -10,14 +10,16 @@
 @import '../../hubs/buttons';
 @import '../../hubs/common';
 
-$color-burnt-orange: #9c432a;
+
+$color-link-blue: #0e9ad8;
+$color-link-blue-dark: #175a77;
 
 main {
     @include font-size(20px);
     @include zilla-slab;
 
     .content {
-        @include horizontal-rule-before($start-color: #69b9d0, $end-color: $color-burnt-orange);
+        @include horizontal-rule-before($start-color: #69b9d0, $end-color: #9c432a);
     }
 }
 
@@ -186,14 +188,22 @@ main {
     p {
         a:link,
         a:visited {
-            color: $color-burnt-orange;
+            color: $color-link-blue;
             text-decoration: none;
-        }
 
-        a:hover,
-        a:active,
-        a:focus {
-            text-decoration: underline;
+            &:hover,
+            &:focus,
+            &:active {
+                color: $color-link-blue-dark;
+                text-decoration: underline;
+            }
+
+            // Shameful specificity hack. Need to clean this up later.
+            &.cta-link:hover,
+            &.cta-link:focus,
+            &.cta-link:active {
+                text-decoration: none;
+            }
         }
     }
 }
@@ -220,24 +230,5 @@ main {
             width: auto;
             margin: 0;
         }
-    }
-}
-
-/* -------------------------------------------------------------------------- */
-// Download button overrides
-
-.fx-privacy-link {
-    a:link,
-    a:visited {
-        @include font-size(14px);
-        @include open-sans();
-        color: $color-burnt-orange;
-        text-decoration: none;
-    }
-
-    a:hover,
-    a:active,
-    a:focus {
-        text-decoration: underline;
     }
 }

--- a/media/css/firefox/hub/home.scss
+++ b/media/css/firefox/hub/home.scss
@@ -13,6 +13,9 @@
 @import '../../hubs/news-feed';
 @import './outro';
 
+$color-link-blue: #0e9ad8;
+$color-link-blue-dark: #175a77;
+
 #hub-content {
     @include font-size(20px);
     @include zilla-slab;
@@ -104,20 +107,6 @@
             padding-top: 60px;
         }
     }
-
-    .fx-privacy-link a:link,
-    .fx-privacy-link a:visited {
-        @include font-size(12px);
-        color: $color-burnt-orange;
-        font-family: $font-open-sans;
-        text-decoration: none;
-
-        &:hover,
-        &:focus {
-            color: darken($color-burnt-orange, 10%);
-        }
-    }
-
 }
 
 

--- a/media/css/firefox/product-page.scss
+++ b/media/css/firefox/product-page.scss
@@ -17,6 +17,8 @@
 $color-burnt-orange:    #9c432a;
 $color-dusty-blue:      #69b9d0;
 
+$color-link-blue: #0e9ad8;
+$color-link-blue-dark: #175a77;
 
 .page-content {
     @include font-size(20px);
@@ -81,19 +83,6 @@ $color-dusty-blue:      #69b9d0;
         .header-download {
             @include span(4);
             padding-top: 60px;
-        }
-    }
-
-    .fx-privacy-link a:link,
-    .fx-privacy-link a:visited {
-        @include font-size(12px);
-        color: $color-burnt-orange;
-        font-family: $font-open-sans;
-        text-decoration: none;
-
-        &:hover,
-        &:focus {
-            color: darken($color-burnt-orange, 10%);
         }
     }
 

--- a/media/css/hubs/_buttons.scss
+++ b/media/css/hubs/_buttons.scss
@@ -4,31 +4,31 @@
 
 @import '../pebbles/includes/lib';
 
-$color-burnt-orange: #9c432a;
+// These could eventually be the global colors for links in pebbles.
+$color-link-blue: #0e9ad8;
+$color-link-blue-dark: #175a77;
 
 .button,
 button.button,
 button.form-button,
 a.button:link,
 a.button:visited {
-    &.button-hollow,
-    &.button-hollow-arrow {
-        @include font-size(18px);
+    strong {
+        font-weight: bold;
+    }
+
+    &.button-hollow {
         @include open-sans();
         background: transparent;
         border-radius: 0;
 
-        strong {
-            font-weight: bold;
-        }
-
         &.dark {
-            border-color: $color-burnt-orange;
-            color: $color-burnt-orange;
+            border-color: $color-link-blue;
+            color: $color-link-blue-dark;
 
             &:hover,
             &:focus {
-                background: $color-burnt-orange;
+                background: $color-link-blue-dark;
                 color: #fff;
             }
         }
@@ -45,36 +45,29 @@ a.button:visited {
         }
     }
 
-    &.button-hollow-arrow {
+    &.button-arrow {
+        @include font-size(18px);
+        @include open-sans();
+        background-color: #11bb69;
+        border-radius: 0;
+        border: 0;
+        color: #fff;
 
         &:hover,
         &:focus {
-            strong:before {
-                background-position: left -14px;
-            }
+            background-color: #039c6d;
         }
 
-        strong {
-            font-weight: bold;
-
-            &:before {
-                @include background-size(12px 28px);
-                background-position: left top;
-                content: '';
-                display: block;
-                float: left;
-                height: 14px;
-                margin: 8px 10px 0 0;
-                width: 12px;
-            }
-        }
-
-        &.dark strong:before {
-            background-image: url('/media/img/hubs/down-arrow-dark-sprite.png');
-        }
-
-        &.light strong:before {
+        strong:before {
+            @include background-size(12px 28px);
             background-image: url('/media/img/hubs/down-arrow-light-sprite.png');
+            background-position: left top;
+            content: '';
+            display: block;
+            float: left;
+            height: 14px;
+            margin: 8px 10px 0 0;
+            width: 12px;
         }
     }
 }

--- a/media/css/hubs/_cards-block.scss
+++ b/media/css/hubs/_cards-block.scss
@@ -30,7 +30,7 @@
         &> a:focus {
             h2 {
                 @include transition(color .1s ease-in-out);
-                color: #9C432A;
+                color: #175a77;
             }
         }
     }

--- a/media/css/hubs/_cards.scss
+++ b/media/css/hubs/_cards.scss
@@ -4,7 +4,9 @@
 
 @import '../pebbles/includes/lib';
 
-$color-burnt-orange: #9c432a;
+$color-link-blue: #0e9ad8;
+$color-link-blue-dark: #175a77;
+
 $card-padding: 20px;
 
 .card {
@@ -23,7 +25,7 @@ $card-padding: 20px;
     &:active,
     &:hover,
     &:focus {
-        color: $color-burnt-orange;
+        color: $color-link-blue-dark;
     }
 }
 
@@ -35,13 +37,13 @@ $card-padding: 20px;
     p {
         a:link,
         a:visited {
-            color: $color-burnt-orange;
+            color: $color-link-blue;
             text-decoration: none;
 
             &:active,
             &:hover,
             &:focus {
-                color: lighten($color-burnt-orange, 10%);
+                color: $color-link-blue-dark;
                 text-decoration: underline;
             }
         }

--- a/media/css/hubs/_common.scss
+++ b/media/css/hubs/_common.scss
@@ -4,6 +4,11 @@
 
 @import '../pebbles/includes/lib';
 
+// These could eventually be the global colors for links in pebbles.
+$color-link-blue: #0e9ad8;
+$color-link-blue-dark: #175a77;
+
+
 /* -------------------------------------------------------------------------- */
 // Section titles
 
@@ -23,15 +28,10 @@
 /* -------------------------------------------------------------------------- */
 // CTA link
 
-// This probably needs a better name. It may
-// be part of the recently expanded palette so
-// it could be a global value added to pebbles.
-$color-burnt-orange: #9c432a;
-
 a.cta-link {
     @include font-size(18px);
-    border-bottom: 2px solid $color-burnt-orange;
-    color: $color-burnt-orange;
+    border-bottom: 2px solid $color-link-blue;
+    color: $color-link-blue;
     display: inline-block;
     font-family: $font-open-sans;
     font-weight: bold;
@@ -39,28 +39,49 @@ a.cta-link {
     padding: 0 10% 10px 0;
     position: relative;
     text-decoration: none;
+    transition: color 100ms ease-in-out;
     width: 80%;
 
     &:after {
-        background: url('/media/img/hubs/cta-arrow.svg') center right no-repeat;
+        background: url('/media/img/hubs/cta-arrow.svg') 0 0 no-repeat;
+        @include background-size(14px, 24px);
         content: '';
         display: block;
-        height: 14px;
-        padding: 10px 0 0 10px;
+        height: 12px;
         position: absolute;
         right: 0;
-        top: 2px;
+        bottom: .9em;
         transition: margin-right 100ms ease-in-out;
-        width: 12px;
+        width: 14px;
     }
 
     &:hover,
-    &:focus {
-        color: lighten($color-burnt-orange, 10%);
-        border-color: lighten($color-burnt-orange, 10%);
+    &:focus,
+    &:active {
+        border-color: $color-link-blue-dark;
+        color: $color-link-blue-dark;
+        text-decoration: none;
 
         &:after {
+            background-position: 0 -12px;
             margin-right: -4px;
         }
+    }
+}
+
+/* -------------------------------------------------------------------------- */
+// Download button overrides
+
+.fx-privacy-link a:link,
+.fx-privacy-link a:visited {
+    @include font-size(12px);
+    color: $color-link-blue;
+    font-family: $font-open-sans;
+    text-decoration: none;
+
+    &:hover,
+    &:focus {
+        color: $color-link-blue-dark;
+        text-decoration: underline;
     }
 }

--- a/media/css/hubs/_news-feed.scss
+++ b/media/css/hubs/_news-feed.scss
@@ -7,6 +7,8 @@
 //* -------------------------------------------------------------------------- */
 // Firefox Hub: News Feed Component
 
+$color-link-blue-dark: #175a77;
+
 .news-feed {
     margin: 0;
 
@@ -68,7 +70,7 @@
             &:focus {
                 h3 {
                     @include transition(color .1s ease-in-out);
-                    color: #9C432A;
+                    color: $color-link-blue-dark;
                 }
             }
         }

--- a/media/css/hubs/_sub-nav.scss
+++ b/media/css/hubs/_sub-nav.scss
@@ -195,12 +195,12 @@
     .download-link:link,
     .download-link:visited {
         @include font-size(14px);
-        background: inherit;
+        background: #11bb69;
         border-radius: 0;
         border: none;
-        color: #646464;
+        color: #fff;
         display: inline-block;
-        padding: 5px 10px;
+        padding: 4px 10px;
         text-decoration: none;
         transition: color 0.1s ease-in-out, background-color 0.1s ease-in-out;
 
@@ -208,25 +208,24 @@
             font-weight: bold;
 
             &:before {
-                @include font-size(16px);
-                color: $color-firefox-light-orange;
-                content: "\2193\00A0"; // downward-arrow+space
-                transition: color 0.1s ease-in-out;
-                white-space: nowrap;
+                @include background-size(12px 28px);
+                background-image: url('/media/img/hubs/down-arrow-light-sprite.png');
+                background-position: left top;
+                content: '';
+                display: block;
+                float: left;
+                height: 14px;
+                margin: 4px 10px 0 0;
+                width: 12px;
             }
         }
 
         &:hover,
         &:focus,
         &:active {
-            background-color: $color-firefox-light-orange;
+            background-color: #039c6d;
             color: #fff;
             transition: color 0.1s ease-in-out, background-color 0.1s ease-in-out;
-
-            .download-title:before {
-                color: #fff;
-                transition: color 0.1s ease-in-out;
-            }
         }
     }
 

--- a/media/css/pebbles/components/_global-nav.scss
+++ b/media/css/pebbles/components/_global-nav.scss
@@ -507,7 +507,7 @@ html.moz-nav-open .moz-global-nav-page-mask {
 
 #global-nav-download-firefox {
     float: right;
-    margin: -2px 20px 0 0;
+    margin: 11px 20px 0 0;
 
     .download-list {
         margin: 0;
@@ -520,12 +520,12 @@ html.moz-nav-open .moz-global-nav-page-mask {
     .download-link:link,
     .download-link:visited {
         @include font-size(14px);
-        background: inherit;
+        background: #11bb69;
         border-radius: 0;
         border: none;
-        color: #646464;
+        color: #fff;
         display: inline-block;
-        padding: 14px 10px;
+        padding: 4px 10px;
         text-decoration: none;
         transition: color 0.1s ease-in-out, background-color 0.1s ease-in-out;
 
@@ -533,34 +533,39 @@ html.moz-nav-open .moz-global-nav-page-mask {
             font-weight: bold;
 
             &:before {
-                @include font-size(16px);
-                color: $color-firefox-light-orange;
-                content: "\2193\00A0"; // downward-arrow+space
-                transition: color 0.1s ease-in-out;
-                white-space: nowrap;
+                @include background-size(12px 28px);
+                background-image: url('/media/img/hubs/down-arrow-light-sprite.png');
+                background-position: left top;
+                content: '';
+                display: block;
+                float: left;
+                height: 14px;
+                margin: 4px 10px 0 0;
+                width: 12px;
             }
         }
 
         &:hover,
         &:focus,
         &:active {
-            background-color: $color-firefox-light-orange;
+            background-color: #039c6d;
             color: #fff;
             transition: color 0.1s ease-in-out, background-color 0.1s ease-in-out;
-
-            .download-title:before {
-                color: #fff;
-                transition: color 0.1s ease-in-out;
-            }
         }
     }
 
     @media #{$mq-tablet} {
+        margin-top: 5px;
         margin-right: 60px;
         width: 200px;
 
         .download-link {
             float: right;
+
+            &:link,
+            &:visited {
+                padding: 8px 10px;
+            }
         }
     }
 
@@ -570,7 +575,7 @@ html.moz-nav-open .moz-global-nav-page-mask {
         .download-link {
             &:link,
             &:visited {
-                padding: 14px 20px;
+                padding: 8px 20px;
             }
         }
     }

--- a/media/img/hubs/cta-arrow.svg
+++ b/media/img/hubs/cta-arrow.svg
@@ -1,1 +1,4 @@
-<svg width="14" height="12" viewBox="0 0 14 12" xmlns="http://www.w3.org/2000/svg"><g fill="none"><g fill="#9C432A"><polygon transform="translate(-1164 -1226)translate(1171 1232.024689)rotate(-90)translate(-1171 -1232.024689)" points="1169.7 1225 1169.7 1234 1166.8 1231.2 1165 1233 1169.7 1237.7 1169.7 1237.8 1169.8 1237.8 1171 1239 1172.2 1237.8 1172.3 1237.8 1172.3 1237.7 1177 1233 1175.2 1231.2 1172.3 1234 1172.3 1225"/></g></g></svg>
+<svg id="cta-arrow" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 14 24">
+  <path fill="#0E9AD8" d="M0 7.3h9l-2.8 2.9L8 12l6-6-6-6-1.8 1.8L9 4.7H0z"/>
+  <path fill="#175A77" d="M0 19.3h9l-2.8 2.9L8 24l6-6-6-6-1.8 1.8L9 16.7H0z"/>
+</svg>


### PR DESCRIPTION
## Description
Changes the main download button to green and link colors to blue. These may become global colors in pebbles but limited to just the hub pages for now.

## Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1370326

## Testing
Make sure I didn't miss a page. There shouldn't be any more burnt orange links.

## Checklist
- [ ] Requires l10n changes.
- [ ] Related functional & integration tests passing.
