### PR TITLE
[fix bug 1371832] Use correct utm_campaign params in hub news feeds

### DIFF
--- a/bedrock/base/templates/includes/news-feed.html
+++ b/bedrock/base/templates/includes/news-feed.html
@@ -11,7 +11,7 @@
       {% for article in articles %}
         <li>
           <article class="entry">
-            <a class="entry-block" rel="bookmark" href="{{ article.link }}?utm_source=www.mozilla.org&amp;utm_medium=referral&amp;utm_campaign=fx-content-hub" data-link-name="{{ article.blog_title }}" data-link-type="link" data-link-position="Fresh from the blog">
+            <a class="entry-block" rel="bookmark" href="{{ article.link }}?utm_source=www.mozilla.org&amp;utm_medium=referral{% if campaign %}&amp;utm_campaign={{ campaign|urlencode }}{% endif %}" data-link-name="{{ article.blog_title }}" data-link-type="link" data-link-position="Fresh from the blog">
               {% set thumbnail = article.get_featured_image_url(size='large') %}
               {% if thumbnail %}
                 <img src="{{ thumbnail }}" alt="">
@@ -24,7 +24,7 @@
               <p>{{ article.htmlify() }}</p>
             </div>
             <p class="entry-cta">
-              <a href="{{ article.link }}?utm_source=www.mozilla.org&amp;utm_medium=referral&amp;utm_campaign=fx-content-hub" class="cta-link" rel="nofollow" data-link-name="{{ article.blog_title }}" data-link-type="link" data-link-position="Fresh from the blog">{{ _('Read more') }}</a>
+              <a href="{{ article.link }}?utm_source=www.mozilla.org&amp;utm_medium=referral{% if campaign %}&amp;utm_campaign={{ campaign|urlencode }}{% endif %}" class="cta-link" rel="nofollow" data-link-name="{{ article.blog_title }}" data-link-type="link" data-link-position="Fresh from the blog">{{ _('Read more') }}</a>
             </p>
           </article>
         </li>

--- a/bedrock/firefox/templates/firefox/features/base.html
+++ b/bedrock/firefox/templates/firefox/features/base.html
@@ -38,7 +38,9 @@
   {% block features_list %}{% endblock %}
 
   {% block news %}
-    {% include 'includes/news-feed.html' %}
+    {% with campaign='fx-content-hub' %}
+      {% include 'includes/news-feed.html' %}
+    {% endwith %}
   {% endblock %}
 
   {% block values %}{% endblock %}

--- a/bedrock/firefox/templates/firefox/hub/home.html
+++ b/bedrock/firefox/templates/firefox/hub/home.html
@@ -129,7 +129,9 @@
     </section>
     {% endif %}
 
-    {% include 'includes/news-feed.html' %}
+    {% with campaign='fx-content-hub' %}
+      {% include 'includes/news-feed.html' %}
+    {% endwith %}
 
     {% if LANG.startswith('en-') %}
     <section id="feeds" class="section">

--- a/bedrock/firefox/templates/firefox/products/product-base.html
+++ b/bedrock/firefox/templates/firefox/products/product-base.html
@@ -31,7 +31,9 @@
   {% block features_list %}{% endblock %}
 
   {% block news %}
-    {% include 'includes/news-feed.html' %}
+    {% with campaign='fx-content-hub' %}
+      {% include 'includes/news-feed.html' %}
+    {% endwith %}
   {% endblock %}
 
   {% block values %}{% endblock %}

--- a/bedrock/mozorg/templates/mozorg/internet-health/index.html
+++ b/bedrock/mozorg/templates/mozorg/internet-health/index.html
@@ -108,7 +108,9 @@
     </div> {#--/.content--#}
   </section> {#--/.net-neutrality--#}
 
-  {% include 'includes/news-feed.html' %}
+  {% with campaign='ih-content-hub' %}
+    {% include 'includes/news-feed.html' %}
+  {% endwith %}
 
   <section class="report">
     <div class="content">


### PR DESCRIPTION
## Description
- Updated news feed links on hub pages to use the correct utm_campaign values.

## Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1371832

## Testing
- Blog links on Firefox hub pages should use `utm_campaign=fx-content-hub`
- Blog links on Internet Health hub page should use `utm_campaign=ih-content-hub`
- Make sure I didn't miss any pages?

## Checklist
- [ ] Requires l10n changes.
- [ ] Related functional & integration tests passing.
