### PR TITLE
Bugs 1372331, 1372328 - Change Firefox links in global nav, add link to /new

### DIFF
--- a/bedrock/base/templates/includes/global-nav.html
+++ b/bedrock/base/templates/includes/global-nav.html
@@ -17,7 +17,12 @@
       <ul class="nav-primary-links">
         {{ global_nav_active_class }}
         <li class="item-firefox">
-          <a href="{{ url('firefox.new') }}" data-id="firefox" data-link-type="nav" data-link-position="top" data-link-name="expand" data-link-group="Firefox">{{ _('Firefox') }}</a>
+          {% if LANG == 'en-US' %}
+            {% set firefox_url = url('firefox') %}
+          {% else %}
+            {% set firefox_url = url('firefox.new') %}
+          {% endif %}
+          <a href="{{ firefox_url }}" data-id="firefox" data-link-type="nav" data-link-position="top" data-link-name="expand" data-link-group="Firefox">{{ _('Firefox') }}</a>
         </li>
         <li class="item-internet-health">
           <a href="{{ url('mozorg.internet-health') }}" data-id="internet-health" data-link-type="nav" data-link-position="top" data-link-name="expand" data-link-group="Internet Health">{{ _('Internet Health') }}</a>
@@ -57,7 +62,7 @@
       <ul class="nav-menu-primary-links">
         <li class="item-firefox">
           <h3 class="summary" data-id="firefox">
-            <a href="{{ url('firefox.new') }}" data-link-type="nav" data-link-position="side" data-link-name="expand" data-link-group="Firefox">{{ _('Firefox') }}</a>
+            <a href="{{ firefox_url }}" data-link-type="nav" data-link-position="side" data-link-name="expand" data-link-group="Firefox">{{ _('Firefox') }}</a>
           </h3>
           <div class="detail">
             <div class="detail-container">
@@ -71,7 +76,7 @@
                 {% else %}
                   {% set about_url = url('firefox.family.index') %}
                 {% endif %}
-                  <a href="{{ about_url}}" data-link-type="nav" data-link-name="About Firefox" data-link-group="Firefox">
+                  <a href="{{ about_url }}" data-link-type="nav" data-link-name="About Firefox" data-link-group="Firefox">
                     {{ _('About Firefox') }}
                   </a>
                 </li>

--- a/bedrock/firefox/templates/firefox/new/scene1.html
+++ b/bedrock/firefox/templates/firefox/new/scene1.html
@@ -30,7 +30,13 @@
             <div id="tabzilla">
               <a href="{{ url('mozorg.home') }}" data-link-type="nav" data-link-name="tabzilla">Mozilla</a>
             </div>
-            <h2>{{ high_res_img('firefox/template/header-logo-inverse.png', {'alt': 'Firefox', 'width': '185', 'height': '70'}) }}</h2>
+            <h2>
+            {% if LANG == 'en-US' %}
+              <a href="{{ url('firefox') }}">{{ high_res_img('firefox/template/header-logo-inverse.png', {'alt': 'Firefox', 'width': '185', 'height': '70'}) }}</a>
+            {% else %}
+              {{ high_res_img('firefox/template/header-logo-inverse.png', {'alt': 'Firefox', 'width': '185', 'height': '70'}) }}
+            {% endif %}
+            </h2>
             <div class="version-message-container">
               <p id="version-message-android-latest" class="version-message">
                 {{_('You’re browsing freely with the latest version of Firefox.')}}

--- a/bedrock/firefox/templates/firefox/new/scene2.html
+++ b/bedrock/firefox/templates/firefox/new/scene2.html
@@ -36,7 +36,13 @@
           <div id="tabzilla">
             <a href="{{ url('mozorg.home') }}" data-link-type="nav" data-link-name="tabzilla">Mozilla</a>
           </div>
-          <h2>{{ high_res_img('firefox/template/header-logo-inverse.png', {'alt': 'Firefox', 'width': '185', 'height': '70'}) }}</h2>
+          <h2>
+          {% if LANG == 'en-US' %}
+            <a href="{{ url('firefox') }}">{{ high_res_img('firefox/template/header-logo-inverse.png', {'alt': 'Firefox', 'width': '185', 'height': '70'}) }}</a>
+          {% else %}
+            {{ high_res_img('firefox/template/header-logo-inverse.png', {'alt': 'Firefox', 'width': '185', 'height': '70'}) }}
+          {% endif %}
+          </h2>
         </header>
         <div class="main-content">
           <h1>


### PR DESCRIPTION
## Description
Seems we're squandering precious Google-juice by not linking to our own page. This update changes the main Firefox link in the global nav to point to /firefox for en-US, and we can remove that conditional once we have good locale coverage for that page. JS hijacks the link (until bug 1367793 changes that) so human users won't notice but robots will still follow the href.

This also links the logo on the /new page to /firefox, again only for en-US until /firefox is localized. Only on the standard download page (both scenes) and none of the numerous variants which shouldn't be indexed anyway.

## Bugzilla link
Nav links - https://bugzilla.mozilla.org/show_bug.cgi?id=1372331
Logo link - https://bugzilla.mozilla.org/show_bug.cgi?id=1372328

## Checklist
- [ ] Requires l10n changes.
- [ ] Related functional & integration tests passing.
