### PR TITLE
[bug 1370326] Update button color for fallback navigation

### DIFF
--- a/media/css/base/global-nav.less
+++ b/media/css/base/global-nav.less
@@ -530,7 +530,7 @@ html.moz-nav-open .moz-global-nav-page-mask {
         border: none;
         color: #fff;
         display: inline-block;
-        padding: 8px 20px;
+        padding: 8px 10px;
         text-decoration: none;
         transition: color 0.1s ease-in-out, background-color 0.1s ease-in-out;
 
@@ -561,13 +561,6 @@ html.moz-nav-open .moz-global-nav-page-mask {
 
     @media only screen and (max-width: @breakDesktop) {
         margin-right: 60px;
-
-        .download-link {
-            &:link,
-            &:visited {
-                padding: 8px 10px;
-            }
-        }
     }
 
     @media only screen and (max-width: @breakTablet) {

--- a/media/css/hubs/_masthead.scss
+++ b/media/css/hubs/_masthead.scss
@@ -86,6 +86,7 @@
 
 #nav-download-firefox {
     float: right;
+    margin: 11px 0 0;
 
     .download-list {
         margin: 0;
@@ -98,12 +99,12 @@
     .download-link:link,
     .download-link:visited {
         @include font-size(14px);
-        background: inherit;
+        background: #11bb69;
         border-radius: 0;
         border: none;
-        color: #646464;
+        color: #fff;
         display: inline-block;
-        padding: 14px 10px;
+        padding: 4px 10px;
         text-decoration: none;
         transition: color 0.1s ease-in-out, background-color 0.1s ease-in-out;
 
@@ -111,33 +112,37 @@
             font-weight: bold;
 
             &:before {
-                @include font-size(16px);
-                color: $color-firefox-light-orange;
-                content: "\2193\00A0"; // downward-arrow+space
-                transition: color 0.1s ease-in-out;
-                white-space: nowrap;
+                @include background-size(12px 28px);
+                background-image: url('/media/img/hubs/down-arrow-light-sprite.png');
+                background-position: left top;
+                content: '';
+                display: block;
+                float: left;
+                height: 14px;
+                margin: 4px 10px 0 0;
+                width: 12px;
             }
         }
 
         &:hover,
         &:focus,
         &:active {
-            background-color: $color-firefox-light-orange;
+            background-color: #039c6d;
             color: #fff;
             transition: color 0.1s ease-in-out, background-color 0.1s ease-in-out;
-
-            .download-title:before {
-                color: #fff;
-                transition: color 0.1s ease-in-out;
-            }
         }
     }
 
-    @media #{$mq-desktop} {
+    @media #{$mq-tablet} {
+        margin-top: 5px;
+        width: 200px;
+
         .download-link {
+            float: right;
+
             &:link,
             &:visited {
-                padding: 14px 20px;
+                padding: 8px 10px;
             }
         }
     }

--- a/media/css/hubs/_sub-nav.scss
+++ b/media/css/hubs/_sub-nav.scss
@@ -179,7 +179,7 @@
 // Near-total copy pasta from global-nav.html. TODO: DRY this up
 
 #sub-nav-download-firefox {
-    margin: 8px 0 0 0;
+    margin: 7px 0 0;
     opacity: 0;
     transform: translateY(-100px);
     transition: opacity 0.3s ease 0.1s, transform 0.4s ease-in-out;
@@ -201,7 +201,7 @@
         border: none;
         color: #fff;
         display: inline-block;
-        padding: 4px 10px;
+        padding: 8px 10px;
         text-decoration: none;
         transition: color 0.1s ease-in-out, background-color 0.1s ease-in-out;
 
@@ -228,10 +228,6 @@
             color: #fff;
             transition: color 0.1s ease-in-out, background-color 0.1s ease-in-out;
         }
-    }
-
-    @media #{$mq-desktop} {
-        margin-right: 10px;
     }
 
     .fx-privacy-link {

--- a/media/css/pebbles/components/_global-nav.scss
+++ b/media/css/pebbles/components/_global-nav.scss
@@ -571,13 +571,6 @@ html.moz-nav-open .moz-global-nav-page-mask {
 
     @media #{$mq-desktop} {
         margin-right: 85px;
-
-        .download-link {
-            &:link,
-            &:visited {
-                padding: 8px 20px;
-            }
-        }
     }
 
     .fx-privacy-link {


### PR DESCRIPTION
## Description
- Updates download button color in the fallback navigation which gets shown for locales that don't yet get the global navigation e.g. https://www-dev.allizom.org/de/internet-health/
- This PR also tweaks the default button padding in both the global and sub navigation, so "Firefox herunterladen" still fits on one line.

## Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1370326

## Testing
- Test `/de/internet-health/` and make sure both nav and sub-nav buttons look ok.
- Test `/en-US/` homepage (pebbles), test `/en-US/about/` (sandstone) for any regressions.

## Checklist
- [ ] Requires l10n changes.
- [ ] Related functional & integration tests passing.
