### PR TITLE
[fix bug 1359982] Add location tag to download button

### DIFF
--- a/bedrock/base/templates/includes/global-nav.html
+++ b/bedrock/base/templates/includes/global-nav.html
@@ -38,7 +38,7 @@
         </li>
       </ul>
 
-      {{ download_firefox(alt_copy=_('Download Firefox'), dom_id='global-nav-download-firefox') }}
+      {{ download_firefox(alt_copy=_('Download Firefox'), dom_id='global-nav-download-firefox', download_location='nav') }}
   </div>
 </nav>
 

--- a/bedrock/base/templates/includes/sub-nav.html
+++ b/bedrock/base/templates/includes/sub-nav.html
@@ -13,7 +13,7 @@
         </ul>
       </div>
       <div class="sub-nav-download-wrapper">
-        {{ download_firefox(alt_copy=_('Download Firefox'), dom_id='sub-nav-download-firefox') }}
+        {{ download_firefox(alt_copy=_('Download Firefox'), dom_id='sub-nav-download-firefox', download_location='sub nav') }}
       </div>
     </div>
   </div>

--- a/bedrock/firefox/templates/firefox/features/base.html
+++ b/bedrock/firefox/templates/firefox/features/base.html
@@ -27,7 +27,7 @@
             {% block features_header_content %}{% endblock %}
           </div>
           <div class="header-download">
-            {{ download_firefox(dom_id='features-header-download', button_color='button-arrow') }}
+            {{ download_firefox(dom_id='features-header-download', button_color='button-arrow', download_location='primary cta') }}
           </div>
         </div>
         {% block features_header_image %}{% endblock %}

--- a/bedrock/firefox/templates/firefox/hub/home.html
+++ b/bedrock/firefox/templates/firefox/hub/home.html
@@ -45,7 +45,7 @@
           </div>
 
           <div class="header-download">
-            {{ download_firefox(dom_id='download-intro', button_color='button-arrow') }}
+            {{ download_firefox(dom_id='download-intro', button_color='button-arrow', download_location='primary cta') }}
           </div>
         </div>
 

--- a/bedrock/firefox/templates/firefox/includes/download-button.html
+++ b/bedrock/firefox/templates/firefox/includes/download-button.html
@@ -61,7 +61,7 @@
   <ul class="download-list">
     {% for plat in builds %}
       <li class="os_{{ plat.os }}{% if plat.arch %} {{ plat.arch }}{% endif %}">
-        <a class="download-link button {{button_color}}"
+        <a class="download-link button {{ button_color }}"
            href="{{ plat.download_link }}"{% if plat.download_link_direct %}
            data-direct-link="{{ plat.download_link_direct }}"{% endif %}
            data-link-type="download"
@@ -69,7 +69,8 @@
            data-download-version="{{ plat.os }}"
            {% if plat.os == 'android' %}data-download-os="Android"
            {% elif plat.os == 'ios' %}data-download-os="iOS"
-           {% else %}data-download-os="Desktop"{% endif %}>
+           {% else %}data-download-os="Desktop"{% endif %}
+           {% if download_location %}data-download-location="{{ download_location }}"{% endif %}>
           <strong class="download-title">
             {% if alt_copy %}
               {{ alt_copy }}

--- a/bedrock/firefox/templates/firefox/new/onboarding/scene1.html
+++ b/bedrock/firefox/templates/firefox/new/onboarding/scene1.html
@@ -50,11 +50,11 @@
             <section id="download-buttons">
               {# handles desktop users (windows, os x, linux) #}
               <div class="download-button-wrapper desktop" id="download-button-wrapper-desktop">
-                {{ download_firefox(alt_copy=_('Free Download'), locale_in_transition=True) }}
+                {{ download_firefox(alt_copy=_('Free Download'), locale_in_transition=True, download_location='primary cta') }}
               </div>
               {# handles Android and iOS users #}
               <div class="mobile download-button-wrapper" id="download-button-wrapper-mobile" data-upgrade-subtitle="{{_('Get it free on Google Play')}}">
-                {{ download_firefox(dom_id='download-button-mobile') }}
+                {{ download_firefox(dom_id='download-button-mobile', download_location='primary cta') }}
               </div>
             </section>{#-- /#download-buttons --#}
             <p id="version-message-linux-arm" class="version-message">
@@ -120,10 +120,10 @@
 
         <ul class="other-platforms-mobile">
           <li class="android">
-            {{ google_play_button() }}
+            {{ google_play_button(anchor_attributes={'data-download-location': 'other'}) }}
           </li>
           <li class="ios">
-            <a href="{{ firefox_ios_url('mozorg-fxnew_page_scene1_modal-appstore-button') }}" data-link-type="download" data-download-os="iOS">
+            <a href="{{ firefox_ios_url('mozorg-fxnew_page_scene1_modal-appstore-button') }}" data-link-type="download" data-download-os="iOS" data-download-location="other">
               <img src="{{ l10n_img('firefox/ios/btn-app-store.svg') }}" alt="{{ _('Download on the App Store') }}" width="152" height="45">
             </a>
           </li>
@@ -136,7 +136,7 @@
         <h4 class="heading-osx">{{_('Download Firefox <span>for macOS</span>') }}</h4>
         <h4 class="heading-linux">{{_('Download Firefox <span>for Linux</span>') }}</h4>
 
-        {{ download_firefox(dom_id='download-other-platforms-modal', alt_copy=_('Free Download'), locale_in_transition=True) }}
+        {{ download_firefox(dom_id='download-other-platforms-modal', alt_copy=_('Free Download'), locale_in_transition=True, download_location='other') }}
       </section>
     </div>
   </div>

--- a/bedrock/firefox/templates/firefox/new/onboarding/scene2.html
+++ b/bedrock/firefox/templates/firefox/new/onboarding/scene2.html
@@ -46,10 +46,10 @@
             <h2>{{ _('Get Firefox for Android and iOS.') }}</h2>
             <ul>
               <li class="android">
-                {{ google_play_button() }}
+                {{ google_play_button(anchor_attributes={'data-download-location': 'other'}) }}
               </li>
               <li class="ios">
-                <a href="{{ firefox_ios_url('mozorg-scene_2-appstore-button') }}" data-link-type="download" data-download-os="iOS">
+                <a href="{{ firefox_ios_url('mozorg-scene_2-appstore-button') }}" data-link-type="download" data-download-os="iOS" data-download-location="other">
                   <img src="{{ l10n_img('firefox/ios/btn-app-store.svg') }}" alt="{{ _('Download on the App Store') }}" width="152" height="45">
                 </a>
               </li>

--- a/bedrock/firefox/templates/firefox/new/scene1.html
+++ b/bedrock/firefox/templates/firefox/new/scene1.html
@@ -73,12 +73,12 @@
 
                   Bug 1290962
                 #}
-                {{ download_firefox(alt_copy=_('Free Download'), locale_in_transition=True) }}
+                {{ download_firefox(alt_copy=_('Free Download'), locale_in_transition=True, download_location='primary cta') }}
               </div>
 
               {# handles Android and iOS users #}
               <div class="mobile download-button-wrapper" id="download-button-wrapper-mobile" data-upgrade-subtitle="{{_('Get it free on Google Play')}}">
-                {{ download_firefox(dom_id='download-button-mobile') }}
+                {{ download_firefox(dom_id='download-button-mobile', download_location='primary cta') }}
               </div>
             </section>{#-- /#download-buttons --#}
             <p id="version-message-linux-arm" class="version-message">
@@ -148,10 +148,10 @@
 
         <ul class="other-platforms-mobile">
           <li class="android">
-            {{ google_play_button() }}
+            {{ google_play_button(anchor_attributes={'data-download-location': 'other'}) }}
           </li>
           <li class="ios">
-            <a href="{{ firefox_ios_url('mozorg-fxnew_page_scene1_modal-appstore-button') }}" data-link-type="download" data-download-os="iOS">
+            <a href="{{ firefox_ios_url('mozorg-fxnew_page_scene1_modal-appstore-button') }}" data-link-type="download" data-download-os="iOS" data-download-location="other">
               <img src="{{ l10n_img('firefox/ios/btn-app-store.svg') }}" alt="{{ _('Download on the App Store') }}" width="152" height="45">
             </a>
           </li>
@@ -164,7 +164,7 @@
         <h4 class="heading-osx">{{_('Download Firefox <span>for macOS</span>') }}</h4>
         <h4 class="heading-linux">{{_('Download Firefox <span>for Linux</span>') }}</h4>
 
-        {{ download_firefox(dom_id='download-other-platforms-modal', alt_copy=_('Free Download'), locale_in_transition=True) }}
+        {{ download_firefox(dom_id='download-other-platforms-modal', alt_copy=_('Free Download'), locale_in_transition=True, download_location='other') }}
       </section>
     </div>
   </div>

--- a/bedrock/firefox/templates/firefox/new/scene2.html
+++ b/bedrock/firefox/templates/firefox/new/scene2.html
@@ -69,10 +69,10 @@
             <h2>{{ _('Get Firefox for Android and iOS.') }}</h2>
             <ul>
               <li class="android">
-                {{ google_play_button() }}
+                {{ google_play_button(anchor_attributes={'data-download-location': 'other'}) }}
               </li>
               <li class="ios">
-                <a href="{{ firefox_ios_url('mozorg-scene_2-appstore-button') }}" data-link-type="download" data-download-os="iOS">
+                <a href="{{ firefox_ios_url('mozorg-scene_2-appstore-button') }}" data-link-type="download" data-download-os="iOS" data-download-location="other">
                   <img src="{{ l10n_img('firefox/ios/btn-app-store.svg') }}" alt="{{ _('Download on the App Store') }}" width="152" height="45">
                 </a>
               </li>

--- a/bedrock/firefox/templates/firefox/products/android.html
+++ b/bedrock/firefox/templates/firefox/products/android.html
@@ -21,11 +21,11 @@
 
 {% block product_header_download %}
   {% if LANG.startswith('en-') %}
-  <a class="dl-button google-play" rel="external noreferrer" href="{{ alt_href|default(settings.GOOGLE_PLAY_FIREFOX_LINK, True) }}" data-link-type="download" data-download-os="Android" data-mozillaonline-link="{{ settings.GOOGLE_PLAY_FIREFOX_LINK_MOZILLAONLINE }}">
+  <a class="dl-button google-play" rel="external noreferrer" href="{{ alt_href|default(settings.GOOGLE_PLAY_FIREFOX_LINK, True) }}" data-link-type="download" data-download-os="Android" data-mozillaonline-link="{{ settings.GOOGLE_PLAY_FIREFOX_LINK_MOZILLAONLINE }}" data-download-location="primary cta">
     {{ high_res_img('firefox/products/android/btn-google-play.png', {'alt': _('Get it on Google Play'), 'width': '190', 'height': '57'}) }}
   </a>
   {% else %}
-    {{ google_play_button(class_name='dl-button') }}
+    {{ google_play_button(class_name='dl-button', anchor_attributes={'data-download-location': 'primary cta'}) }}
   {% endif %}
 {% endblock %}
 

--- a/bedrock/firefox/templates/firefox/products/desktop.html
+++ b/bedrock/firefox/templates/firefox/products/desktop.html
@@ -24,7 +24,7 @@
 {% endblock %}
 
 {% block product_header_download %}
-  {{ download_firefox(dom_id='product-header-download', button_color='button-arrow') }}
+  {{ download_firefox(dom_id='product-header-download', button_color='button-arrow', download_location='primary cta') }}
 {% endblock %}
 
 {% block product_header_image %}

--- a/bedrock/firefox/templates/firefox/products/focus.html
+++ b/bedrock/firefox/templates/firefox/products/focus.html
@@ -24,10 +24,10 @@
 {% endblock %}
 
 {% block product_header_download %}
-  <a class="dl-button app-store" href="{{ settings.APPLE_APPSTORE_FIREFOX_FOCUS_LINK }}" data-link-type="download" data-download-os="iOS">
+  <a class="dl-button app-store" href="{{ settings.APPLE_APPSTORE_FIREFOX_FOCUS_LINK }}" data-link-type="download" data-download-os="iOS" data-download-location="primary cta">
     <img src="{{ l10n_img('firefox/ios/btn-app-store.svg') }}" alt="{{ _('Download on the App Store') }}">
   </a>
-  <a class="dl-button google-play" href="{{ settings.GOOGLE_PLAY_FIREFOX_FOCUS_LINK }}" data-link-type="download" data-download-os="Android">
+  <a class="dl-button google-play" href="{{ settings.GOOGLE_PLAY_FIREFOX_FOCUS_LINK }}" data-link-type="download" data-download-os="Android" data-download-location="primary cta">
     {{ high_res_img('firefox/android/btn-google-play.png', {'alt': _('Get it on Google Play'), 'width': '152', 'height': '45', 'l10n': True}) }}
   </a>
   <small class="fx-privacy-link">

--- a/bedrock/firefox/templates/firefox/products/ios.html
+++ b/bedrock/firefox/templates/firefox/products/ios.html
@@ -18,7 +18,7 @@
 {% endblock %}
 
 {% block product_header_download %}
-  <a class="dl-button app-store" href="{{ firefox_ios_url('mozorg-ios_page-appstore-button') }}" data-link-type="download" data-download-os="iOS">
+  <a class="dl-button app-store" href="{{ firefox_ios_url('mozorg-ios_page-appstore-button') }}" data-link-type="download" data-download-os="iOS" data-download-location="primary cta">
     <img src="{{ l10n_img('firefox/ios/btn-app-store.svg') }}" alt="{{ _('Download on the App Store') }}">
   </a>
 {% endblock %}

--- a/bedrock/firefox/templatetags/helpers.py
+++ b/bedrock/firefox/templatetags/helpers.py
@@ -99,7 +99,7 @@ def download_firefox(ctx, channel='release', platform='all',
                      dom_id=None, locale=None, force_direct=False,
                      force_full_installer=False, force_funnelcake=False,
                      alt_copy=None, button_color='button-green',
-                     locale_in_transition=False):
+                     locale_in_transition=False, download_location=None):
     """ Output a "download firefox" button.
 
     :param ctx: context from calling template.
@@ -113,7 +113,10 @@ def download_firefox(ctx, channel='release', platform='all',
     :param force_funnelcake: Force the download version for en-US Windows to be
             'latest', which bouncer will translate to the funnelcake build.
     :param alt_copy: Specifies alternate copy to use for download buttons.
-    :param button_color: color of download button. Default to 'button-green'.
+    :param button_color: Color of download button. Default to 'button-green'.
+    :param locale_in_transition: Include the page locale in transitional download link.
+    :param download_location: Specify the location of download button for
+            GA reporting: 'primary cta', 'nav', 'sub nav', or 'other'.
     """
     show_desktop = platform in ['all', 'desktop']
     show_android = platform in ['all', 'android']
@@ -159,6 +162,7 @@ def download_firefox(ctx, channel='release', platform='all',
         'show_ios': show_ios,
         'alt_copy': alt_copy,
         'button_color': button_color,
+        'download_location': download_location
     }
 
     html = render_to_string('firefox/includes/download-button.html', data,

--- a/bedrock/firefox/tests/test_helpers.py
+++ b/bedrock/firefox/tests/test_helpers.py
@@ -110,6 +110,31 @@ class TestDownloadButtons(TestCase):
             eq_(href, '/firefox/new/?scene=2')
 
     @patch('bedrock.firefox.firefox_details.switch', Mock(return_value=False))
+    def test_download_location_attribute(self):
+        """
+        If the download_location parameter is set, it should be included as a data attribute.
+        """
+        rf = RequestFactory()
+        get_request = rf.get('/fake')
+        get_request.locale = 'fr'
+        doc = pq(render("{{ download_firefox(download_location='primary cta') }}",
+                        {'request': get_request}))
+
+        links = doc('.download-list a')
+
+        for link in links:
+            link = pq(link)
+            eq_(link.attr('data-download-location'), 'primary cta')
+
+        doc = pq(render("{{ download_firefox() }}", {'request': get_request}))
+
+        links = doc('.download-list a')
+
+        for link in links[1:5]:
+            link = pq(link)
+            ok_(link.attr('data-download-location') is None)
+
+    @patch('bedrock.firefox.firefox_details.switch', Mock(return_value=False))
     def test_button_has_data_attr_if_not_direct(self):
         """
         If the button points to the thank you page, it should have a

--- a/bedrock/mozorg/templates/mozorg/home/includes/nav.html
+++ b/bedrock/mozorg/templates/mozorg/home/includes/nav.html
@@ -15,7 +15,7 @@
       </a>
     </h2>
   {% endif %}
-    {{ download_firefox(alt_copy=_('Download Firefox'), dom_id='nav-download-firefox') }}
+    {{ download_firefox(alt_copy=_('Download Firefox'), dom_id='nav-download-firefox', download_location='nav') }}
     <nav class="masthead-nav-main" id="nav-main">
       <span class="toggle" role="button" aria-controls="nav-main-menu" aria-expanded="false" tabindex="0">{{ _('Menu') }}</span>
       <ul class="nav-main-menu" id="nav-main-menu">


### PR DESCRIPTION
## Description
- Add an optional `download_location` parameter to the button helper, which can be used to specify the location of a button on any given page, passed to GA via a data attribute.
- Adds data attributes to all buttons on new style hub pages, plus the global and sub nav components (We're is not concerned with older legacy pages right now).
- Also adds data attributes to `/firefox/new/`
~- Still need to confirm this is what Peter expects to see, so do not merge for now.~

## Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1359982

## Testing
https://www-demo3.allizom.org/en-US/firefox/

## Checklist
- [ ] Requires l10n changes.
- [ ] Related functional & integration tests passing.
