### PR TITLE
[fix bug 1363499] Experiment for funnelcakes 114-118.

### DIFF
--- a/bedrock/firefox/templates/firefox/new/scene1.html
+++ b/bedrock/firefox/templates/firefox/new/scene1.html
@@ -6,6 +6,12 @@
 
 {% extends "firefox/new/base.html" %}
 
+{% block experiments %}
+  {% if switch('firefox-new-search-retention-funnelcakes', ['en-US']) %}
+    {% javascript 'experiment_firefox_new_fc_search_retention' %}
+  {% endif %}
+{% endblock %}
+
 {% block optimizely %}
   {% if switch('firefox-new-optimizely', ['en-US']) %}
     {% include 'includes/optimizely.html' %}

--- a/bedrock/settings/static_media.py
+++ b/bedrock/settings/static_media.py
@@ -1425,6 +1425,13 @@ PIPELINE_JS = {
         ),
         'output_filename': 'js/experiment_firefox_new_batm_anim-bundle.js',
     },
+    'experiment_firefox_new_fc_search_retention': {
+        'source_filenames': (
+            'js/base/mozilla-traffic-cop.js',
+            'js/firefox/new/experiment-search-retention-funnelcakes.js',
+        ),
+        'output_filename': 'js/experiment_firefox_new_fc_search_retention.js',
+    },
     'firefox_new_pixel': {
         'source_filenames': (
             'js/base/mozilla-pixel.js',

--- a/media/js/firefox/new/experiment-search-retention-funnelcakes.js
+++ b/media/js/firefox/new/experiment-search-retention-funnelcakes.js
@@ -1,0 +1,99 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+(function() {
+    'use strict';
+
+    var experimentId = 'experiment_search_retention_funnelcake';
+    var geoNonmatchCookie = experimentId + '_nonUS';
+
+    // IE 9 can't handle the truth
+    var isIELT10 = /MSIE\s[1-9]\./.test(navigator.userAgent);
+
+    // swiped from mozilla-client.js
+    var ua = navigator.userAgent;
+    var isLikeFirefox = /Iceweasel|IceCat|SeaMonkey|Camino|like\ Firefox/i.test(ua);
+    var isFirefox = /\s(Firefox|FxiOS)/.test(ua) && !isLikeFirefox;
+    var isMobile = /^(android|ios|fxos)$/.test(window.site.platform);
+
+    // check if cookies are enabled
+    var hasCookies = (typeof Mozilla.Cookies !== 'undefined' || Mozilla.Cookies.enabled());
+    // check if user already was served a variation
+    var hasVariationCookie = hasCookies && Mozilla.Cookies.hasItem(experimentId);
+    // check if user already failed geolookup
+    var hasGeoNonmatchCookie = hasCookies && Mozilla.Cookies.hasItem(geoNonmatchCookie);
+    // check if user is on windows
+    var isWindows = window.site.platform === 'windows';
+    // check if current URL has a funnelcake param (in the unlikely event of navigating directly)
+    var isFunnelcake = /^.*\?.*f=\d{3}.*/.test(document.location.search);
+    // check if DNT is detectable and off
+    var dntOk = (typeof Mozilla.dntEnabled === 'function' && !Mozilla.dntEnabled());
+
+    // 0. if visitor previously failed the geolookup, skip everything
+    if (hasGeoNonmatchCookie) {
+        return;
+    }
+
+    // 1. if visitor already has a cookie for this experiment, skip the expensive
+    // checks below and run experiment (uses variation in the cookie)
+    if (hasVariationCookie) {
+        runExperiment();
+    }
+    // 2. experiment criteria prior to expensive geolookup check:
+    //      a. is not currently on a funnelcake URL (sanity infinite loop check)
+    //      b. is on Windows
+    //      c. on IE 10 or greater
+    //      d. is not on Firefox
+    //      e. is not on a mobile browser
+    //      f. DNT is detectable and off
+    else if (!isFunnelcake && isWindows && !isIELT10 && !isFirefox && !isMobile && dntOk) {
+        // 2. check geolocation for US
+        var xhr = new XMLHttpRequest();
+
+        xhr.onload = function(r) {
+            // make sure status is in the acceptable range
+            if (r.target.status >= 200 && r.target.status < 300) {
+                var country;
+
+                try {
+                    country = JSON.parse(r.target.response).country_code.toLowerCase();
+                } catch (e) {
+                    country = 'none';
+                }
+
+                if (country === 'us') {
+                    runExperiment();
+                } else {
+                    if (hasCookies) {
+                        // store cookie for two days to avoid repeated lookups
+                        // that we know will fail
+                        var d = new Date();
+                        d.setHours(d.getHours() + 48);
+                        Mozilla.Cookies.setItem(geoNonmatchCookie, country, d);
+                    }
+                }
+            }
+        };
+
+        xhr.open('GET', '/country-code.json');
+        // must come after open call above for IE 10 & 11
+        xhr.timeout = 2000;
+        xhr.send();
+    }
+
+    function runExperiment() {
+        var landsman = new Mozilla.TrafficCop({
+            id: experimentId,
+            variations: {
+                'f=114': 9,
+                'f=115': 9,
+                'f=116': 34,
+                'f=117': 9,
+                'f=118': 34
+            }
+        });
+
+        landsman.init();
+    }
+})(window.Mozilla);


### PR DESCRIPTION
## Description

Adds experiment for funnelcakes 114 - 118 to `/firefox/new` for en-US, Windows, desktop, non-Firefox users geolocated in the US.

(I checked with Hanno regarding the increased hits to `location.services.mozilla.com` and he said it wont be a problem.)

Must add following funnelcake config to env:

```
FUNNELCAKE_114_PLATFORMS=win
FUNNELCAKE_114_LOCALES=en-US
FUNNELCAKE_115_PLATFORMS=win
FUNNELCAKE_115_LOCALES=en-US
FUNNELCAKE_116_PLATFORMS=win
FUNNELCAKE_116_LOCALES=en-US
FUNNELCAKE_117_PLATFORMS=win
FUNNELCAKE_117_LOCALES=en-US
FUNNELCAKE_118_PLATFORMS=win
FUNNELCAKE_118_LOCALES=en-US
```

## Bugzilla link

https://bugzilla.mozilla.org/show_bug.cgi?id=1363499

## Testing

Visit `/en-US/firefox/new/` on Windows (or with `windows` hard-coded in `window.site.getPlatform()`) in a browser with DNT disabled. Should get one of 5 variations 95% of the time.

**DO NOT MERGE** - Funnelcakes are not yet active.

https://bedrock-demo-jpetto.us-west.moz.works/en-US/firefox/new/

## Checklist
- [ ] Requires l10n changes.
- [ ] Related functional & integration tests passing.
