### PR TITLE
Fix Bug 1374261 - Nightly and dev edition stub installers not offered for download on https://www.mozilla.org/firefox/channel/desktop/ for non en-us locales

### DIFF
--- a/bedrock/firefox/tests/test_firefox_details.py
+++ b/bedrock/firefox/tests/test_firefox_details.py
@@ -162,12 +162,13 @@ class TestFirefoxDesktop(TestCase):
 
     def test_get_download_url_devedition_l10n(self):
         """
-        The Developer Edition version should give us a bouncer url. For Windows,
-        a full url should be returned. The product name is the same as en-US.
+        The Developer Edition version should give us a bouncer url. A stub url
+        should be returned for win32, while other platforms get a full url.
+        The product name is the same as en-US.
         """
         url = firefox_desktop.get_download_url('alpha', '28.0a2', 'win', 'pt-BR', True)
         self.assertListEqual(parse_qsl(urlparse(url).query),
-                             [('product', 'firefox-devedition-latest-ssl'),
+                             [('product', 'firefox-devedition-stub'),
                               ('os', 'win'),
                               ('lang', 'pt-BR')])
         url = firefox_desktop.get_download_url('alpha', '28.0a2', 'win64', 'pt-BR', True)
@@ -254,10 +255,14 @@ class TestFirefoxDesktop(TestCase):
                               ('lang', 'en-US')])
 
     def test_get_download_url_nightly_l10n(self):
-        """Nightly non en-US should have a slightly different product name."""
+        """
+        The Nightly version should give us a bouncer url. A stub url should be
+        returned for win32, while other platforms get a full url. The product
+        name is slightly different from en-US.
+        """
         url = firefox_desktop.get_download_url('nightly', '50.0a1', 'win', 'pt-BR', True)
         self.assertListEqual(parse_qsl(urlparse(url).query),
-                             [('product', 'firefox-nightly-latest-l10n-ssl'),
+                             [('product', 'firefox-nightly-stub'),
                               ('os', 'win'),
                               ('lang', 'pt-BR')])
         url = firefox_desktop.get_download_url('nightly', '50.0a1', 'win64', 'pt-BR', True)

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -638,13 +638,13 @@ STUB_INSTALLER_LOCALES = {
         # 'win64': STUB_INSTALLER_ALL,
     },
     'alpha': {
-        'win': ['en-us'],
+        'win': STUB_INSTALLER_ALL,
         # should come back in Fx 55
         # bug 1348610
         # 'win64': ['en-us'],
     },
     'nightly': {
-        'win': ['en-us'],
+        'win': STUB_INSTALLER_ALL,
         'win64': ['en-us'],
     },
 }


### PR DESCRIPTION
## Description

Offer stub installer for both 32 and 64-bit Windows in all locales and channels.

## Bugzilla link

[Bug 1374261](https://bugzilla.mozilla.org/show_bug.cgi?id=1374261)

## Testing

Visit `/fr/firefox/channel/desktop/` or other localized channel page and make sure Windows download links are all stub.

## Checklist
- [ ] Requires l10n changes.
- [x] Related functional & integration tests passing.
