### PR TITLE
[fix bug 1366397] BATMAn - add variant param to download button

### DIFF
--- a/bedrock/firefox/templates/firefox/new/batm/machine-a.html
+++ b/bedrock/firefox/templates/firefox/new/batm/machine-a.html
@@ -44,7 +44,7 @@
   </section>
 
   <div class="download-cta">
-    <h1 id="main-header-copy" data-experience="batmprivate">{{_('Browse against the machine')}}</h1>
+    <h1 id="main-header-copy" data-experience="batmprivate" data-variant="a">{{_('Browse against the machine')}}</h1>
 
     {{ download_firefox(alt_copy=_('Download Firefox'), locale_in_transition=True, button_color='button-hollow') }}
   </div>

--- a/bedrock/firefox/templates/firefox/new/batm/machine-b.html
+++ b/bedrock/firefox/templates/firefox/new/batm/machine-b.html
@@ -15,7 +15,7 @@
 {% block content %}
 <main role="main">
   <header class="page-hero">
-    <h1 id="main-header-copy" data-experience="batmprivate"><span>{{ _('Browse against the machine') }}</span></h1>
+    <h1 id="main-header-copy" data-experience="batmprivate" data-variant="b"><span>{{ _('Browse against the machine') }}</span></h1>
   </header>
 
   <div class="download-cta">
@@ -43,5 +43,5 @@
 {% endblock %}
 
 {% block js %}
-  {% javascript 'firefox_new_scene1_batm' %}
+  {% javascript 'firefox_new_scene1_batm_anim' %}
 {% endblock %}

--- a/media/js/firefox/new/scene1-batm-anim.js
+++ b/media/js/firefox/new/scene1-batm-anim.js
@@ -5,7 +5,9 @@
 (function($) {
     'use strict';
 
-    var exp = $('#main-header-copy').data('experience');
+    var title = $('#main-header-copy');
+    var exp = title.data('experience');
+    var variant = title.data('variant');
     var mqDesktop;
     var buttonOpen = '<button type="button" class="open" title="'+ Mozilla.Utils.trans('global-open') +'">'+ Mozilla.Utils.trans('global-open') +'</button>';
     var buttonNext = '<button type="button" class="next" title="'+ Mozilla.Utils.trans('global-next') +'">'+ Mozilla.Utils.trans('global-next') +'</button>';
@@ -15,9 +17,9 @@
     var point3 = $('#point-3 .label');
 
     $('.download-link').each(function(i, link) {
-        if (exp && link.href.indexOf('scene=2') > -1) {
+        if (exp && variant && link.href.indexOf('scene=2') > -1) {
             // specify v=1 template for scene 2
-            link.href = link.href.replace('scene=2', 'scene=2&xv=' + exp);
+            link.href = link.href.replace('scene=2', 'scene=2&xv=' + exp + '&v=' + variant);
         }
     });
 


### PR DESCRIPTION
## Description
Adds the `v=` param to download buttons, and also loads the correct JS on the B version.

## Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1366397

## Testing
Ensure the buttons on both page variants are getting both the `xv=batmprivate` and `v=a/b` parameters and that it's being passed through scene 2.

## Checklist
- [ ] Requires l10n changes.
- [ ] Related functional & integration tests passing.
