### PR TITLE
[fix bug 1309847] Win64 funnelcake experiment.

### DIFF
--- a/bedrock/firefox/templates/firefox/new/scene1.html
+++ b/bedrock/firefox/templates/firefox/new/scene1.html
@@ -9,6 +9,8 @@
 {% block experiments %}
   {% if switch('firefox-new-search-retention-funnelcakes', ['en-US']) %}
     {% javascript 'experiment_firefox_new_fc_search_retention' %}
+  {% elif switch('firefox-new-win64-funnelcakes', win64_funnelcake_locales) %}
+    {% javascript 'experiment_firefox_new_fc_win64' %}
   {% endif %}
 {% endblock %}
 

--- a/bedrock/firefox/templates/firefox/new/scene2.html
+++ b/bedrock/firefox/templates/firefox/new/scene2.html
@@ -93,5 +93,8 @@
   {% if switch('tracking-pixel') %}
     {% javascript 'firefox_new_pixel' %}
   {% endif %}
+  {% if funnelcake_id == '106' and LANG in win64_funnelcake_locales %}
+    {% javascript 'experiment_firefox_new_fc_win64_scene2' %}
+  {% endif %}
   {% javascript 'firefox_new_scene2' %}
 {% endblock %}

--- a/bedrock/firefox/tests/test_views.py
+++ b/bedrock/firefox/tests/test_views.py
@@ -9,7 +9,7 @@ from django.test import override_settings
 from django.test.client import RequestFactory
 
 import querystringsafe_base64
-from mock import patch, Mock
+from mock import patch, Mock, ANY
 from nose.tools import eq_, ok_
 
 from bedrock.firefox import views
@@ -310,13 +310,13 @@ class TestFirefoxNew(TestCase):
         req = RequestFactory().get('/firefox/new/')
         req.locale = 'en-US'
         views.new(req)
-        render_mock.assert_called_once_with(req, 'firefox/new/scene1.html')
+        render_mock.assert_called_once_with(req, 'firefox/new/scene1.html', ANY)
 
     def test_scene_2_template(self, render_mock):
         req = RequestFactory().get('/firefox/new/?scene=2')
         req.locale = 'en-US'
         views.new(req)
-        render_mock.assert_called_once_with(req, 'firefox/new/scene2.html')
+        render_mock.assert_called_once_with(req, 'firefox/new/scene2.html', ANY)
 
     # ad-campaign experience tests (bug 1329661)
     def test_break_free_scene_1(self, render_mock):
@@ -335,13 +335,13 @@ class TestFirefoxNew(TestCase):
         req = RequestFactory().get('/firefox/new/?xv=breakfree')
         req.locale = 'de'
         views.new(req)
-        render_mock.assert_called_once_with(req, 'firefox/new/scene1.html')
+        render_mock.assert_called_once_with(req, 'firefox/new/scene1.html', ANY)
 
     def test_break_free_locale_scene_2(self, render_mock):
         req = RequestFactory().get('/firefox/new/?scene=2&xv=breakfree')
         req.locale = 'de'
         views.new(req)
-        render_mock.assert_called_once_with(req, 'firefox/new/scene2.html')
+        render_mock.assert_called_once_with(req, 'firefox/new/scene2.html', ANY)
 
     def test_way_of_the_fox_scene_1(self, render_mock):
         req = RequestFactory().get('/firefox/new/?xv=wayofthefox')
@@ -359,13 +359,13 @@ class TestFirefoxNew(TestCase):
         req = RequestFactory().get('/firefox/new/?xv=wayofthefox')
         req.locale = 'de'
         views.new(req)
-        render_mock.assert_called_once_with(req, 'firefox/new/scene1.html')
+        render_mock.assert_called_once_with(req, 'firefox/new/scene1.html', ANY)
 
     def test_way_of_the_fox_locale_scene_2(self, render_mock):
         req = RequestFactory().get('/firefox/new/?scene=2&xv=breakfree')
         req.locale = 'de'
         views.new(req)
-        render_mock.assert_called_once_with(req, 'firefox/new/scene2.html')
+        render_mock.assert_called_once_with(req, 'firefox/new/scene2.html', ANY)
 
     # moar ad campaign pages bug 1363543
 
@@ -535,7 +535,7 @@ class TestFirefoxNew(TestCase):
         req = RequestFactory().get('/firefox/new/?f=98')
         req.locale = 'en-US'
         views.new(req)
-        render_mock.assert_called_once_with(req, 'firefox/new/scene1.html')
+        render_mock.assert_called_once_with(req, 'firefox/new/scene1.html', ANY)
 
     def test_onboarding_f_99_scene_1_template(self, render_mock):
         req = RequestFactory().get('/firefox/new/?f=99')
@@ -553,13 +553,13 @@ class TestFirefoxNew(TestCase):
         req = RequestFactory().get('/firefox/new/?f=99')
         req.locale = 'de'
         views.new(req)
-        render_mock.assert_called_once_with(req, 'firefox/new/scene1.html')
+        render_mock.assert_called_once_with(req, 'firefox/new/scene1.html', ANY)
 
     def test_onboarding_f_98_scene_2_template(self, render_mock):
         req = RequestFactory().get('/firefox/new/?scene=2&f=98')
         req.locale = 'en-US'
         views.new(req)
-        render_mock.assert_called_once_with(req, 'firefox/new/scene2.html')
+        render_mock.assert_called_once_with(req, 'firefox/new/scene2.html', ANY)
 
     def test_onboarding_f_99_scene_2_template(self, render_mock):
         req = RequestFactory().get('/firefox/new/?scene=2&f=99')
@@ -577,7 +577,7 @@ class TestFirefoxNew(TestCase):
         req = RequestFactory().get('/firefox/new/?scene=2&f=99')
         req.locale = 'de'
         views.new(req)
-        render_mock.assert_called_once_with(req, 'firefox/new/scene2.html')
+        render_mock.assert_called_once_with(req, 'firefox/new/scene2.html', ANY)
 
 
 class TestFeedbackView(TestCase):

--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -576,7 +576,15 @@ def new(request):
         else:
             template = 'firefox/new/scene1.html'
 
-    return l10n_utils.render(request, template)
+    if (template in ['firefox/new/scene1.html', 'firefox/new/scene2.html']):
+        # Win64 funnelcake experiment (bug 1309847)
+        context = {
+            'win64_funnelcake_locales': ['de', 'es-ES', 'fr', 'pt-BR', 'ru']
+        }
+
+        return l10n_utils.render(request, template, context)
+    else:
+        return l10n_utils.render(request, template)
 
 
 def ios_testflight(request):

--- a/bedrock/settings/static_media.py
+++ b/bedrock/settings/static_media.py
@@ -1432,6 +1432,19 @@ PIPELINE_JS = {
         ),
         'output_filename': 'js/experiment_firefox_new_fc_search_retention.js',
     },
+    'experiment_firefox_new_fc_win64': {
+        'source_filenames': (
+            'js/base/mozilla-traffic-cop.js',
+            'js/firefox/new/experiment-win64-funnelcakes.js',
+        ),
+        'output_filename': 'js/experiment_firefox_new_fc_win64.js',
+    },
+    'experiment_firefox_new_fc_win64_scene2': {
+        'source_filenames': (
+            'js/firefox/new/experiment-win64-funnelcakes-scene2.js',
+        ),
+        'output_filename': 'js/experiment_firefox_new_fc_win64_scene2.js',
+    },
     'firefox_new_pixel': {
         'source_filenames': (
             'js/base/mozilla-pixel.js',

--- a/media/js/firefox/new/experiment-win64-funnelcakes-scene2.js
+++ b/media/js/firefox/new/experiment-win64-funnelcakes-scene2.js
@@ -1,0 +1,15 @@
+(function() {
+    'use strict';
+
+    // update dl link for windows to point to win64
+    // same selector from canonical scene2.js
+    var $platformLink = $('#download-button-wrapper-desktop .download-list .os_win .download-link');
+
+    if ($platformLink.length) {
+        // the bouncer URL needed for the win64 funnelcake is the same as the
+        // win32 funnelcake, but with os=win replaced with os=win64, e.g.
+        // https://download.mozilla.org/?product=firefox-stub-f106&os=win64&lang={accepted-lang}
+        var newHref = $platformLink.attr('href').replace('os=win&', 'os=win64&');
+        $platformLink.attr('href', newHref);
+    }
+})();

--- a/media/js/firefox/new/experiment-win64-funnelcakes.js
+++ b/media/js/firefox/new/experiment-win64-funnelcakes.js
@@ -1,0 +1,27 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+(function() {
+    'use strict';
+
+    // swiped from mozilla-client.js
+    var ua = navigator.userAgent;
+    var isLikeFirefox = /Iceweasel|IceCat|SeaMonkey|Camino|like\ Firefox/i.test(ua);
+    var isFirefox = /\s(Firefox|FxiOS)/.test(ua) && !isLikeFirefox;
+    var isMobile = /^(android|ios|fxos)$/.test(window.site.platform);
+
+    var isWin64 = (ua.indexOf('WOW64') > -1 || ua.indexOf('Win64') > -1);
+
+    if (window.site.platform === 'windows' && isWin64 && !isFirefox && !isMobile) {
+        var russell = new Mozilla.TrafficCop({
+            id: 'experiment_win64_funnelcake',
+            variations: {
+                'f=105': 11, // 32-bit
+                'f=106': 11 // 64-bit
+            }
+        });
+
+        russell.init();
+    }
+})(window.Mozilla);


### PR DESCRIPTION
## Description

Adds a funnelcake experiment for Win64 builds for de, es-ES, fr, pt-BR, and ru locales.

**DO NOT MERGE:** Waiting on green light from the Win64 team. Code is good for review though.

## Bugzilla link

https://bugzilla.mozilla.org/show_bug.cgi?id=1309847

## Testing

Add the following to your config:

```
FUNNELCAKE_105_PLATFORMS=win
FUNNELCAKE_105_LOCALES=pt-BR,fr,de,ru,es-ES
FUNNELCAKE_106_PLATFORMS=win
FUNNELCAKE_106_LOCALES=pt-BR,fr,de,ru,es-ES
```

On a Windows 64 VM (the MsEdge/Win10 VM works, or hack `window.site.platform` to return `windows` and hack `experiment-win64-funnelcakes-scene2.js` to skip the Win64 userAgent check), visit `/firefox/new/?f=105` and `/firefox/new/?f=106` with any of the locales listed above.

`?f=105` should download a full build of the Win32 funnelcake. `?f=106` should download a full build of the Win64 funnelcake.

This experiment should play nicely with the search retention funnelcake experiment merged in #4909.

Demo URL: https://bedrock-demo-jpetto.us-west.moz.works

## Checklist
- [ ] Requires l10n changes.
- [ ] Related functional & integration tests passing.
