### PR TITLE
Change symlink for calendar data

### DIFF
--- a/root_files/projects/calendar/caldata
+++ b/root_files/projects/calendar/caldata
@@ -1,1 +1,1 @@
-../../../static/caldata
+../../../media/caldata


### PR DESCRIPTION
If the symlink is to /static is will be broken and cause errors if "manage.py collectstatic" is not run first.

/cc @jpetto