### PR TITLE
[bug 1367774] Update BATM download page copy

### DIFF
--- a/bedrock/firefox/templates/firefox/new/batm/scene1.html
+++ b/bedrock/firefox/templates/firefox/new/batm/scene1.html
@@ -20,15 +20,15 @@
   <ul class="copy">
     <li>
       <h2>{{_('Click it to the man')}}</h2>
-      <p>{{_('Because Firefox is independent, and backed by a non-profit, we fight for your online rights, keep corporate powers in check, and make the internet accessible to everyone, everywhere.')}}</p>
+      <p>{{ _('Because Firefox is independent, and built by a non-profit, we can do things that others can’t, like build new products and features without a hidden agenda. We fight for your online rights, keep corporate powers in check, and make the internet accessible to everyone, everywhere.') }}</p>
     </li>
     <li>
       <h2>{{_('Get out of dodgy')}}</h2>
-      <p>{{_('Firefox doesn’t sell access to your personal information. From privacy tools to tracking protection, you control who sees what.')}}</p>
+      <p>{{_('Firefox doesn’t sell access to your personal information. In fact, we’re obsessed with protecting your privacy. That’s why we’ve made Firefox Private Browsing more powerful than the others. From privacy tools to tracking protection, you control who sees what.')}}</p>
     </li>
     <li>
       <h2>{{_('Take a load off')}}</h2>
-      <p>{{_('We’ve spent the last year supercharging Firefox’s performance. Now you can start up faster, switch tabs quicker, and scroll like there’s no tomorrow.')}}</p>
+      <p>{{_('We’ve spent the last year supercharging Firefox’s performance. Now you can start up faster, switch tabs quicker, and scroll like there’s no tomorrow. We also use less memory than Chrome, so it’s easier for your computer to keep running other programs without being weighed down.')}}</p>
     </li>
   </ul>
 </main>


### PR DESCRIPTION
## Description
After testing different copy treatments on the BATM download page, this makes the winning version permanent.

## Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1367774#c30

## Testing

## Checklist
- [ ] Requires l10n changes.
- [ ] Related functional & integration tests passing.
