### PR TITLE
[fix bug 1366952] Add survey to /firefox/new/

### DIFF
--- a/bedrock/firefox/templates/firefox/new/scene1.html
+++ b/bedrock/firefox/templates/firefox/new/scene1.html
@@ -58,6 +58,9 @@
                 {% endif %}
               </p>
             </div>{#-- /.version-message-container --#}
+            {% if switch('firefox-new-survey', ['en-US']) %}
+              {% include 'firefox/new/survey.html' %}
+            {% endif %}
           </header>
           <div class="main-content">
             <h1>{{ _('Browse Freely') }}</h1>

--- a/bedrock/firefox/templates/firefox/new/scene2.html
+++ b/bedrock/firefox/templates/firefox/new/scene2.html
@@ -43,6 +43,9 @@
             {{ high_res_img('firefox/template/header-logo-inverse.png', {'alt': 'Firefox', 'width': '185', 'height': '70'}) }}
           {% endif %}
           </h2>
+          {% if switch('firefox-new-survey', ['en-US']) %}
+            {% include 'firefox/new/survey.html' %}
+          {% endif %}
         </header>
         <div class="main-content">
           <h1>

--- a/bedrock/firefox/templates/firefox/new/survey.html
+++ b/bedrock/firefox/templates/firefox/new/survey.html
@@ -1,0 +1,7 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+
+<a id="firefox-new-survey-link" href="https://qsurvey.mozilla.com/s3/Firefox-Downloader-Survey-2017-BATM/" target="_blank" rel="noopener noreferrer">
+  {{_('Tell us what you think about Firefox.')}}
+</a>

--- a/bedrock/settings/static_media.py
+++ b/bedrock/settings/static_media.py
@@ -1378,12 +1378,14 @@ PIPELINE_JS = {
     'firefox_new_scene1': {
         'source_filenames': (
             'js/base/mozilla-modal.js',
+            'js/firefox/new/survey.js',
             'js/firefox/new/scene1.js',
         ),
         'output_filename': 'js/firefox_new_scene1-bundle.js',
     },
     'firefox_new_scene2': {
         'source_filenames': (
+            'js/firefox/new/survey.js',
             'js/firefox/new/scene2.js',
         ),
         'output_filename': 'js/firefox_new_scene2-bundle.js',

--- a/media/css/firefox/new/common.less
+++ b/media/css/firefox/new/common.less
@@ -41,6 +41,20 @@
     top: 0;
 }
 
+#firefox-new-survey-link {
+    clear: left;
+    color: #ffbb38;
+    display: none;
+    width: 250px;
+
+    @media only screen and (max-width: @breakTablet) {
+        padding-top: 20px;
+        text-align: center;
+        width: 100%;
+        float: left;
+    }
+}
+
 .inner-container,
 #benefits ul,
 #newsletter-subscribe > .container {

--- a/media/js/firefox/new/survey.js
+++ b/media/js/firefox/new/survey.js
@@ -1,0 +1,17 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+(function($) {
+    'use strict';
+
+    var client = Mozilla.Client;
+    var $survey = $('#firefox-new-survey-link');
+
+    if (!client.isMobile && Math.random() < 0.5) {
+        var link = $survey.attr('href');
+        $survey.attr('href', link + window.location.search);
+        $survey.css('display', 'block');
+    }
+
+})(window.jQuery);


### PR DESCRIPTION
## Description
- Adds a simple survey link to both scene1 and scene2 of /firefox/new/
- Survey shows for en-US Desktop only, at 50% sample rate.
- Query params are passed along to the survey.

## Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1366952

## Testing
- Both scene1 and scene2 for en-US. Survey should show up 50% of the time as expected.

## Checklist
- [ ] Requires l10n changes.
- [ ] Related functional & integration tests passing.
