### PR TITLE
[bug  1366952] Add conditional to download survey link JS

### DIFF
--- a/media/js/firefox/new/survey.js
+++ b/media/js/firefox/new/survey.js
@@ -8,7 +8,7 @@
     var client = Mozilla.Client;
     var $survey = $('#firefox-new-survey-link');
 
-    if (!client.isMobile && Math.random() < 0.5) {
+    if (!client.isMobile && $survey.length && Math.random() < 0.5) {
         var link = $survey.attr('href');
         $survey.attr('href', link + window.location.search);
         $survey.css('display', 'block');


### PR DESCRIPTION
## Description
Since the link is behind a switch but the JS isn't, we'll make sure the survey link exists in the DOM before trying to show it.