### PR TITLE
[fix bug 1375728] Update 3rd party quotes on /firefox/

### DIFF
--- a/bedrock/firefox/templates/firefox/hub/home.html
+++ b/bedrock/firefox/templates/firefox/hub/home.html
@@ -140,24 +140,28 @@
         <section id="third-party-feed">
           <div class="card card-stacked">
             <div class="card-content">
-              <a rel="external" href="http://www.computerworld.com/article/3074093/enterprise-applications/why-i-switched-back-to-firefox.html" data-link-name="Why I switched back to Firefox" data-link-type="link" data-link-position="1">
+              <a rel="external" href="http://www.makeuseof.com/tag/switch-chrome-firefox/" data-link-name="Bye Bye Chrome! Why We Switched to Firefox" data-link-type="link" data-link-position="1">
                 <blockquote class="quote">
-                  Why I switched back to Firefox
+                  Bye Bye Chrome! Why We Switched to Firefox
                 </blockquote>
               </a>
 
-              <a rel="external" href="http://www.computerworld.com/article/3074093/enterprise-applications/why-i-switched-back-to-firefox.html" class="cta-link" data-link-name="Why I switched back to Firefox" data-link-type="link" data-link-position="1">Computerworld</a>
+              <a rel="external" href="http://www.makeuseof.com/tag/switch-chrome-firefox/" class="cta-link" data-link-name="Bye Bye Chrome! Why We Switched to Firefox" data-link-type="link" data-link-position="1">
+                MakeUseOf
+              </a>
             </div>
           </div>
           <div class="card card-stacked">
             <div class="card-content">
-              <a rel="external" href="https://www.wired.com/2017/01/half-web-now-encrypted-makes-everyone-safer/" data-link-name="Half the Web Is Now Encrypted. That Makes Everyone Safer." data-link-type="link" data-link-position="2">
+              <a rel="external" href="https://www.theverge.com/2017/6/14/15802102/firefox-54-update-faster-less-memory" data-link-name="Firefox hogs less memory and gets a speed bump in its latest update" data-link-type="link" data-link-position="2">
                 <blockquote class="quote">
-                  Half the Web Is Now Encrypted. That Makes Everyone Safer.
+                  Firefox hogs less memory and gets a speed bump in its latest update
                 </blockquote>
               </a>
 
-              <a rel="external" href="https://www.wired.com/2017/01/half-web-now-encrypted-makes-everyone-safer/" class="cta-link" data-link-name="Half the Web Is Now Encrypted. That Makes Everyone Safer." data-link-type="link" data-link-position="2">Wired</a>
+              <a rel="external" href="https://www.theverge.com/2017/6/14/15802102/firefox-54-update-faster-less-memory" class="cta-link" data-link-name="Firefox hogs less memory and gets a speed bump in its latest update" data-link-type="link" data-link-position="2">
+                The Verge
+              </a>
             </div>
           </div>
           <div class="card card-stacked">
@@ -168,7 +172,9 @@
                 </blockquote>
               </a>
 
-              <a rel="external" href="http://www.vogue.com/article/internet-privacy-fcc-laws-eliminated-protect-yourself" class="cta-link" data-link-name="Your Internet Search History Will Soon Be Up for Sale &mdash; Here’s How You Can Protect Yourself" data-link-type="link" data-link-position="3">Vogue</a>
+              <a rel="external" href="http://www.vogue.com/article/internet-privacy-fcc-laws-eliminated-protect-yourself" class="cta-link" data-link-name="Your Internet Search History Will Soon Be Up for Sale &mdash; Here’s How You Can Protect Yourself" data-link-type="link" data-link-position="3">
+                Vogue
+              </a>
             </div>
           </div>
         </section> {#--/#third-party-feed.content--#}


### PR DESCRIPTION
## Description
- Updates 2 quotes on /firefox/
- Both use hard-coded, English only strings (no l10n impact)

## Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1375728

## Testing
- Check for copy pasta errors?

## Checklist
- [ ] Requires l10n changes.
- [ ] Related functional & integration tests passing.
