### PR TITLE
Correct typography mistake

### DIFF
--- a/bedrock/foundation/templates/foundation/annualreport/2015/faq.html
+++ b/bedrock/foundation/templates/foundation/annualreport/2015/faq.html
@@ -208,7 +208,7 @@
               <p>
               {% trans %}
                 In 2017, Mozilla will expand our work in protecting the health of the
-                nternet through policy, advocacy, education and products. We will launch
+                internet through policy, advocacy, education and products. We will launch
                 our first Internet Health Report, a thorough, compelling examination of
                 the state of the open internet. Through both data and narrative
                 features, our inaugural report will unpack internet health through the


### PR DESCRIPTION
The word "internet" was written without the first"i"

## Description
A typography correction

## Bugzilla link
No bugzilla link

## Testing
No test required

## Checklist
- [ ] Requires l10n changes.
- [ ] Related functional & integration tests passing.
