### PR TITLE
Fix Bug 1375100 - Update the Nightly copy to be slightly less frightening.

### DIFF
--- a/bedrock/firefox/templates/firefox/channel/desktop.html
+++ b/bedrock/firefox/templates/firefox/channel/desktop.html
@@ -85,7 +85,13 @@
   <div class="container">
     <header>
       <h2>{{_('Nightly')}}</h2>
-      <p>{{_('Test brand new features daily (or… nightly). Enjoy at your own risk.')}}</p>
+      <p>
+        {%- if l10n_has_tag('nightly_description_bug1375100') -%}
+          {{_('Get a sneak peek at our next generation web browser, and help us make it the best browser it can be: try Firefox Nightly.')}}
+        {%- else -%}
+          {{_('Test brand new features daily (or… nightly). Enjoy at your own risk.')}}
+        {%- endif -%}
+      </p>
     </header>
     {{ download_firefox('nightly', platform='desktop', force_direct=True, alt_copy=_('Download'), dom_id="desktop-nightly-download") }}
     <p class="notice">


### PR DESCRIPTION
## Description

Update the "frightening" Nightly description on [/firefox/channel/desktop/](https://www.mozilla.org/en-US/firefox/channel/desktop/). Cc @flodolo @peiying2

## Bugzilla link

[Bug 1375100](https://bugzilla.mozilla.org/show_bug.cgi?id=1375100)

## Testing

Open the channel page to make sure the new copy is displayed.

## Checklist
- [x] Requires l10n changes.
- [x] Related functional & integration tests passing.
