### PR TITLE
[fix bug 1377769] Hide sha-1 bouncer links on /all for small screens

### DIFF
--- a/media/css/firefox/all.less
+++ b/media/css/firefox/all.less
@@ -362,7 +362,7 @@
 }
 
 /* The sha-1 download column is hidden by default */
-.js .build-table {
+.js #main-content .build-table {
     thead tr .winsha1,
     tbody tr .winsha1 {
         display: none;
@@ -370,7 +370,7 @@
 }
 
 /* IE on Windows XP, Server 2003, Vista need sha-1 button */
-.windows.sha-1 .build-table {
+.windows.sha-1 #main-content .build-table {
     thead tr .win,
     tbody tr .win {
         display: none;


### PR DESCRIPTION
## Description
- Hides sha-1 links on /all for small screen sizes. These should not have been visible by default.

## Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1377769

## Testing
- Resize the browser down to small viewport size. Sha-1 links should not be visible (where as they are currently visible on prod).
- Adding a class of `windows sha-1` to the `<html>` element should still make the sha-1 links visible (hiding the regular bouncer links).

## Checklist
- [ ] Requires l10n changes.
- [ ] Related functional & integration tests passing.
