### PR TITLE
[fix bug 1376816] Fix title on /firefox/features/fast/

### DIFF
--- a/bedrock/firefox/templates/firefox/features/fast.html
+++ b/bedrock/firefox/templates/firefox/features/fast.html
@@ -6,7 +6,7 @@
 
 {% extends "firefox/features/base.html" %}
 
-{% block page_title %}{{ _('Get more done. Browse faster and lighter with multiple tabs') }} | {{ _('Firefox') }} }}{% endblock %}
+{% block page_title %}{{ _('Get more done. Browse faster and lighter with multiple tabs') }} | {{ _('Firefox') }}{% endblock %}
 {% block page_desc %}{{ _('Our new, powerful multi-process platform handles all your tabs without slowing down your computer.') }}{% endblock %}
 {% block page_image %}{{ static('img/firefox/features/page-image-fast.jpg') }}{% endblock %}
 


### PR DESCRIPTION
## Description
- Removes some erroneous copy/pasta braces introduced in #4908.
- Does not effect existing strings or l10n.

## Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1376816

## Testing

## Checklist
- [ ] Requires l10n changes.
- [ ] Related functional & integration tests passing.
