### PR TITLE
[bug 1350170] Update values copy on /firefox/focus/ for l10n

### DIFF
--- a/bedrock/firefox/templates/firefox/products/focus.html
+++ b/bedrock/firefox/templates/firefox/products/focus.html
@@ -107,9 +107,9 @@
           </a>
           <p>
           {% trans %}
-            Firefox doesn’t sell access to your personal information like other
-            browsers. From privacy tools to tracking protection, you’re in charge
-            of who sees what.
+            Firefox doesn’t sell access to your personal information like
+            other companies. From privacy tools to tracking protection,
+            you’re in charge of who sees what.
           {% endtrans %}
           </p>
           <p class="card-cta">
@@ -128,7 +128,7 @@
           <p>
           {% trans %}
             Following the pack isn’t our style. As part of the non-profit Mozilla,
-            Firefox leads the fight to protect your online rights, and champion an
+            Firefox leads the fight to protect your online rights and champion an
             Internet that benefits everyone — not just a few.
           {% endtrans %}
           </p>


### PR DESCRIPTION
## Description
- Updates values copy on /firefox/focus/ page to match other hub page strings for l10n
