### PR TITLE
Remove checklist from pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,7 +3,3 @@
 ## Bugzilla link
 
 ## Testing
-
-## Checklist
-- [ ] Requires l10n changes.
-- [ ] Related functional & integration tests passing.


### PR DESCRIPTION
Removes the checklist from the PR template because:

1. We tend to use labels for l10n as they are more easily visible in the PR view.
2. People often confuse the integration tests checkbox with the unit test run in CI
