### PR TITLE
[fix bug 1369144] Adjust Fx Hub headers & sub-headers

### DIFF
--- a/bedrock/base/templates/includes/news-feed.html
+++ b/bedrock/base/templates/includes/news-feed.html
@@ -6,7 +6,7 @@
 {% if LANG.startswith('en') and articles %}
 <section class="news">
   <div class="content">
-    <h2 class="section-title"><span>{{ _('Fresh from our Blog') }}</span></h2>
+    <h2 class="section-title"><span>{{ _('Fresh from our blog') }}</span></h2>
     <ul class="news-feed">
       {% for article in articles %}
         <li>

--- a/bedrock/firefox/templates/firefox/hub/home.html
+++ b/bedrock/firefox/templates/firefox/hub/home.html
@@ -32,7 +32,7 @@
 {% block content %}
   {% include 'firefox/includes/hub/sub-nav.html' %}
 
-  <div id="hub-content">
+  <main id="hub-content">
     <section id="intro-features" class="section header-intro">
       <div class="content">
         <div class="header-container">
@@ -223,7 +223,7 @@
     </section> {#--/#sync--#}
 
     {% include 'firefox/includes/hub/outro.html' %}
-  </div> {#--/.hub-content--#}
+  </main> {#--/.hub-content--#}
 {% endblock %}
 
 {% block js %}

--- a/bedrock/firefox/templates/firefox/products/android.html
+++ b/bedrock/firefox/templates/firefox/products/android.html
@@ -15,7 +15,15 @@
 {% block body_id %}firefox-product-android{% endblock %}
 
 {% block product_header_content %}
-  <h1 class="page-title"><span>{{ _('Firefox for Android') }}</span></h1>
+  <h1 class="page-title">
+    <span>
+    {% if l10n_has_tag('firefox_hub_titles_062017') %}
+      {{ _('Firefox browser for Android') }}
+    {% else %}
+      {{ _('Firefox for Android') }}
+    {% endif %}
+    </span>
+  </h1>
   <p class="tagline">{{ _('Our most customizable Firefox for Android yet.') }}</p>
 {% endblock %}
 

--- a/bedrock/firefox/templates/firefox/products/desktop.html
+++ b/bedrock/firefox/templates/firefox/products/desktop.html
@@ -19,7 +19,15 @@
 {% endblock %}
 
 {% block product_header_content %}
-  <h1 class="page-title"><span>{{ _('Firefox for Desktop') }}</span></h1>
+  <h1 class="page-title">
+    <span>
+    {% if l10n_has_tag('firefox_hub_titles_062017') %}
+      {{ _('Firefox browser for desktop') }}
+    {% else %}
+      {{ _('Firefox for Desktop') }}
+    {% endif %}
+    </span>
+  </h1>
   <p class="tagline">{{ _('Get more done, even faster.') }}</p>
 {% endblock %}
 

--- a/bedrock/firefox/templates/firefox/products/focus.html
+++ b/bedrock/firefox/templates/firefox/products/focus.html
@@ -19,7 +19,15 @@
 {% block sub_nav_download_button %}{% endblock %}
 
 {% block product_header_content %}
-  <h1 class="page-title"><span>{{ _('Firefox Focus Browser') }}</span></h1>
+  <h1 class="page-title">
+    <span>
+    {% if l10n_has_tag('firefox_hub_titles_062017') %}
+      {{ _('Firefox Focus browser') }}
+    {% else %}
+      {{ _('Firefox Focus Browser') }}
+    {% endif %}
+    </span>
+  </h1>
   <p class="tagline">{{ _('Keep it private with automatic ad blocking and tracking protection on iOS and Android.') }}</p>
 {% endblock %}
 

--- a/bedrock/firefox/templates/firefox/products/ios.html
+++ b/bedrock/firefox/templates/firefox/products/ios.html
@@ -13,7 +13,15 @@
 {% block body_id %}firefox-product-ios{% endblock %}
 
 {% block product_header_content %}
-  <h1 class="page-title"><span>{{ _('Firefox for iOS') }}</span></h1>
+  <h1 class="page-title">
+    <span>
+    {% if l10n_has_tag('firefox_hub_titles_062017') %}
+      {{ _('Firefox browser for iOS') }}
+    {% else %}
+      {{ _('Firefox for iOS') }}
+    {% endif %}
+    </span>
+  </h1>
   <p class="tagline">{{ _('The speed you need. The privacy you trust.') }}</p>
 {% endblock %}
 

--- a/bedrock/mozorg/templates/mozorg/developer/index.html
+++ b/bedrock/mozorg/templates/mozorg/developer/index.html
@@ -40,10 +40,8 @@
   <header class="header-intro">
     <div class="content">
       <div class="header-container">
-        <div class="header-content">
-          <h1><span>{{ _('Mozilla Developers') }}</span></h1>
-          <p class="tagline">{{ _('Developer tools, resources, videos and more') }}</p>
-        </div>
+        <h1><span>{{ _('Mozilla Developers') }}</span></h1>
+        <p class="tagline">{{ _('Developer tools, resources, videos and more') }}</p>
       </div>
     </div>
   </header>
@@ -76,7 +74,7 @@
 
   <section class="resources">
     <div class="content">
-      <h2 class="section-title"><span>{{ _('Developer Resources') }}</span></h2>
+      <h2 class="section-title"><span>{{ _('Developer resources') }}</span></h2>
 
       <div class="card-group">
         <div class="card card-image-large resource-mdn">
@@ -147,7 +145,7 @@
 
   <section class="events">
     <div class="content">
-      <h2 class="section-title"><span>{{ _('Events to Check Out') }}</span></h2>
+      <h2 class="section-title"><span>{{ _('Events to check out') }}</span></h2>
 
       <ul class="news-feed">
         <li>
@@ -177,7 +175,7 @@
 
   <section class="projects">
     <div class="content">
-      <h2 class="section-title"><span>{{ _('Projects We Love') }}</span></h2>
+      <h2 class="section-title"><span>{{ _('Projects we love') }}</span></h2>
 
       <div class="card-group">
         <div class="card card-double">
@@ -282,7 +280,7 @@
 
   <section class="videos">
     <div class="content">
-      <h2 class="section-title"><span>{{ _('Videos to Watch') }}</span></h2>
+      <h2 class="section-title"><span>{{ _('Videos to watch') }}</span></h2>
 
       <div class="card-group">
         <div class="card card-double">
@@ -357,7 +355,7 @@
 
   <section class="social">
     <div class="content">
-      <h2 class="section-title"><span>{{ _('Stay Connected') }}</span></h2>
+      <h2 class="section-title"><span>{{ _('Stay connected') }}</span></h2>
 
       <ul class="social-groups">
         <li>

--- a/bedrock/mozorg/templates/mozorg/internet-health/index.html
+++ b/bedrock/mozorg/templates/mozorg/internet-health/index.html
@@ -39,10 +39,8 @@
   <header class="header-intro">
     <div class="content">
       <div class="header-container">
-        <div class="header-content">
-          <h1><span>{{ _('Internet Health') }}</span></h1>
-          <p class="tagline">{{ _('Mozilla is on a mission to keep the Internet growing and healthy. Join us!') }}</p>
-        </div>
+        <h1><span>{{ _('Internet Health') }}</span></h1>
+        <p class="tagline">{{ _('Mozilla is on a mission to keep the Internet growing and healthy. Join us!') }}</p>
       </div>
     </div>
   </header>

--- a/media/css/firefox/features/common.scss
+++ b/media/css/firefox/features/common.scss
@@ -6,6 +6,7 @@
 @import '../../hubs/mixins';
 @import '../../hubs/sections';
 @import '../../hubs/masthead';
+@import '../../hubs/header';
 @import '../../pebbles/components/newsletter';
 @import '../../hubs/sub-nav';
 @import '../../hubs/buttons';
@@ -15,113 +16,8 @@
 $color-link-blue: #0e9ad8;
 $color-link-blue-dark: #175a77;
 
-main {
-    @include font-size(20px);
-    @include zilla-slab;
-
-    .content {
-        @include horizontal-rule-before($start-color: #69b9d0, $end-color: #9c432a);
-    }
-}
-
-/* -------------------------------------------------------------------------- */
-// Page header
-
-.header-intro {
-    h1 {
-        color: #fff;
-        line-height: 1.3;
-
-        span {
-            @include box-decoration-break(clone);
-            background-color: #000;
-        }
-    }
-
-    .tagline {
-        @include font-size-level3;
-        color: $color-text-secondary;
-        font-weight: bold;
-        line-height: 1.2;
-        margin-bottom: 0;
-    }
-
-    .hero-image {
-        display: block;
-        margin: 20px auto 0;
-    }
-
-    .header-download {
-        text-align: center;
-        padding-top: 40px;
-    }
-
-    .content:before {
-        height: 10px;
-    }
-
-    @media #{$mq-tablet} {
-
-        .hero-image {
-            height: 400px;
-            margin-top: 60px;
-            width: 720px;
-        }
-
-        .header-container {
-            @include clearfix;
-        }
-
-        .header-content {
-            @include span(6);
-            padding-left: 0;
-        }
-
-        .header-download {
-            @include span(6);
-            padding: 60px 0 0;
-        }
-    }
-
-    @media #{$mq-desktop} {
-        h1 {
-            @include font-size(72px);
-        }
-
-        .tagline {
-            @include font-size(32px);
-        }
-
-        .header-content {
-            @include span(8);
-            padding-left: 0;
-        }
-
-        .header-download {
-            @include span(4);
-            padding: 60px 0 0;
-        }
-    }
-
-    @media #{$mq-desktop-wide} {
-        h1 {
-            @include font-size(95px);
-        }
-
-        .tagline {
-            @include font-size(48px);
-        }
-
-        .header-content {
-            @include span(9);
-            padding-left: 0;
-        }
-
-        .header-download {
-            @include span(3);
-            padding: 60px 0 0;
-        }
-    }
+main .content {
+    @include horizontal-rule-before($start-color: #69b9d0, $end-color: #9c432a);
 }
 
 #firefox-features-landing {

--- a/media/css/firefox/features/detail.scss
+++ b/media/css/firefox/features/detail.scss
@@ -6,39 +6,3 @@
 @import '../../hubs/news-feed';
 @import '../../hubs/cards-block';
 @import '../hub/outro';
-
-/* -------------------------------------------------------------------------- */
-// Page header
-
-.header-intro {
-
-    @media #{$mq-tablet} {
-        h1 {
-            @include font-size(42px);
-        }
-
-        .tagline {
-            @include font-size(22px);
-        }
-    }
-
-    @media #{$mq-desktop} {
-        h1 {
-            @include font-size(58px);
-        }
-
-        .tagline {
-            @include font-size(24px);
-        }
-    }
-
-    @media #{$mq-desktop-wide} {
-        h1 {
-            @include font-size(82px);
-        }
-
-        .tagline {
-            @include font-size(34px);
-        }
-    }
-}

--- a/media/css/firefox/focus.scss
+++ b/media/css/firefox/focus.scss
@@ -19,38 +19,3 @@
 #masthead #nav-download-firefox {
     display: none;
 }
-
-/* -------------------------------------------------------------------------- */
-// Page header
-
-.header-intro {
-
-    .page-title {
-        @include font-size(42px);
-    }
-
-    .tagline {
-        @include font-size(22px);
-        max-width: 35ch;
-    }
-
-    @media #{$mq-tablet} {
-        .page-title {
-            @include font-size(64px);
-        }
-
-        .tagline {
-            @include font-size(28px);
-        }
-    }
-
-    @media #{$mq-desktop-wide} {
-        .page-title {
-            @include font-size(78px);
-        }
-
-        .tagline {
-            @include font-size(34px);
-        }
-    }
-}

--- a/media/css/firefox/hub/_outro.scss
+++ b/media/css/firefox/hub/_outro.scss
@@ -19,11 +19,11 @@
     color: #fff;
 
     h2 {
-        @include font-size-level2;
+        @include font-size-level3;
     }
 
     .tagline {
-        @include font-size-level3;
+        @include font-size-level4;
     }
 
     @media #{$mq-desktop} {
@@ -37,7 +37,7 @@
 
 .outro-item-detail {
     @media #{$mq-tablet} {
-        width: 45%;
+        width: 40%;
     }
 }
 
@@ -112,6 +112,7 @@ html[dir="rtl"] {
 }
 
 #newsletter-form {
+    @include open-sans;
     width: 100%;
 
     @media screen and (min-width: 640px) {
@@ -119,7 +120,7 @@ html[dir="rtl"] {
     }
 
     input[type="email"] {
-        @include open-sans();
+        @include open-sans;
         border-color: #fff;
         border-radius: 0;
         padding: .5em 10px;
@@ -127,7 +128,7 @@ html[dir="rtl"] {
     }
 
     #form-details {
-        @include font-size(16px);
+        @include font-size-small;
         padding-top: 20px;
     }
 
@@ -136,7 +137,11 @@ html[dir="rtl"] {
     }
 
     label {
-        @include font-size(16px);
+        @include font-size-small;
+    }
+
+    small {
+        @include font-size-extra-small;
     }
 
     select {

--- a/media/css/firefox/hub/home.scss
+++ b/media/css/firefox/hub/home.scss
@@ -6,6 +6,7 @@
 @import '../../hubs/mixins';
 @import '../../hubs/sections';
 @import '../../hubs/masthead';
+@import '../../hubs/header';
 @import '../../pebbles/components/newsletter';
 @import '../../hubs/sub-nav';
 @import '../../hubs/cards';
@@ -18,8 +19,6 @@ $color-link-blue: #0e9ad8;
 $color-link-blue-dark: #175a77;
 
 #hub-content {
-    @include font-size(20px);
-    @include zilla-slab;
 
     .form-button,
     .form-contents,
@@ -37,14 +36,6 @@ $color-link-blue-dark: #175a77;
 //* -------------------------------------------------------------------------- */
 // Page head
 .header-intro {
-    .content:before {
-        height: 10px;
-    }
-
-    .header-container {
-        @include clearfix;
-        padding: 20px 0;
-    }
 
     h1 {
         @include at2x('/media/img/logos/firefox/logo-wordmark-small-noshadow.png', 280px, 105px);
@@ -57,17 +48,14 @@ $color-link-blue-dark: #175a77;
 
         span {
             @include image-replaced();
-            display: inline-block;
+            background: transparent;
             color: #000;
+            display: inline-block;
             padding: 0 3px;
         }
     }
 
     .tagline {
-        @include font-size-level2;
-        font-weight: bold;
-        line-height: 1.3;
-        margin-bottom: 0;
         text-align: center;
 
         span {
@@ -75,12 +63,6 @@ $color-link-blue-dark: #175a77;
             background-color: #000;
             color: #fff;
         }
-    }
-
-    .header-content,
-    .header-download {
-        text-align: center;
-        padding-bottom: 40px;
     }
 
     @media #{$mq-tablet} {
@@ -96,16 +78,12 @@ $color-link-blue-dark: #175a77;
             text-align: left;
         }
     }
+}
 
-    @media #{$mq-desktop} {
-        .header-content {
-            @include span(8);
-            padding-left: 0;
-        }
-
-        .header-download {
-            @include span(4);
-            padding-top: 60px;
+html[dir="rtl"] {
+    @media #{$mq-tablet} {
+        .tagline {
+            text-align: right;
         }
     }
 }
@@ -139,6 +117,11 @@ $color-link-blue-dark: #175a77;
 // Blogosphere 🌎
 #feeds .content:before {
     display: none;
+}
+
+#third-party-feed .card:first-child {
+    border-top: none;
+    padding-top: 0;
 }
 
 

--- a/media/css/firefox/product-page.scss
+++ b/media/css/firefox/product-page.scss
@@ -7,6 +7,7 @@
     '../hubs/mixins',
     '../hubs/sections',
     '../hubs/masthead',
+    '../hubs/header',
     '../pebbles/components/newsletter',
     '../hubs/sub-nav',
     '../hubs/buttons',
@@ -22,85 +23,9 @@ $color-link-blue: #0e9ad8;
 $color-link-blue-dark: #175a77;
 
 .page-content {
-    @include font-size(20px);
-    @include zilla-slab;
-
     .section > .content,
     .news > .content {
         @include horizontal-rule-before($start-color: $color-dusty-blue, $end-color: $color-burnt-orange);
-    }
-}
-
-//* -------------------------------------------------------------------------- */
-// Page head
-.header-intro {
-    .content:before {
-        height: 10px;
-    }
-
-    .page-title {
-        @include font-size(55px);
-        color: #fff;
-        line-height: 1.3;
-
-        span {
-            @include box-decoration-break(clone);
-            background-color: #000;
-        }
-
-        @media #{$mq-desktop} {
-            @include font-size(95px);
-        }
-    }
-
-    .tagline {
-        @include font-size(28px);
-        color: $color-text-secondary;
-        font-weight: bold;
-        line-height: 1.3;
-        max-width: 25ch;
-
-        @media #{$mq-desktop} {
-            @include font-size(48px);
-        }
-    }
-
-    .header-download {
-        text-align: center;
-        padding-bottom: 40px;
-    }
-
-    .dl-button {
-        display: inline-block;
-
-        img {
-            width: 190px;
-        }
-    }
-
-    @media #{$mq-desktop} {
-        .header-content {
-            @include span(8);
-            padding-left: 0;
-        }
-
-        .header-download {
-            @include span(4);
-            padding-top: 60px;
-        }
-    }
-
-    .hero-image {
-        display: block;
-        margin: 0 auto;
-
-        @media #{$mq-tablet} {
-            width: 550px;
-        }
-
-        @media #{$mq-desktop} {
-            width: 700px;
-        }
     }
 }
 
@@ -184,7 +109,6 @@ $color-link-blue-dark: #175a77;
     }
 
     .feature-title {
-        @include font-size(28px);
         margin: 20px 0;
 
         @media #{$mq-desktop} {

--- a/media/css/hubs/_cards-block.scss
+++ b/media/css/hubs/_cards-block.scss
@@ -52,7 +52,7 @@
     }
 
     .card-title {
-        @include font-size-level2;
+        @include font-size-level3;
     }
 
     // Some cards have an image. Used with .card

--- a/media/css/hubs/_cards.scss
+++ b/media/css/hubs/_cards.scss
@@ -17,6 +17,10 @@ $card-padding: 20px;
     }
 }
 
+.card-heading {
+    @include font-size-level3;
+}
+
 .card-heading a:link,
 .card-heading a:visited {
     color: #000;
@@ -80,7 +84,7 @@ $card-padding: 20px;
 
 // the little highlighted bit of text at the top of a card
 .card-label {
-    @include font-size(24px);
+    @include font-size-level4;
     background: #000;
     color: #fff;
     display: inline-block;
@@ -281,7 +285,7 @@ $card-padding: 20px;
 }
 
 .quote {
-    @include font-size-level2;
+    @include font-size-level3;
     margin-bottom: 20px;
 }
 

--- a/media/css/hubs/_common.scss
+++ b/media/css/hubs/_common.scss
@@ -13,7 +13,7 @@ $color-link-blue-dark: #175a77;
 // Section titles
 
 .section-title {
-    @include font-size(24px);
+    @include font-size-level4;
     margin: 0 0 20px;
 
     span {
@@ -21,7 +21,7 @@ $color-link-blue-dark: #175a77;
         background-color: #000;
         color: #fff;
         line-height: 1.3;
-        padding: 0 5px 0 60px;
+        padding: 0 5px 0 40px;
     }
 }
 
@@ -29,7 +29,7 @@ $color-link-blue-dark: #175a77;
 // CTA link
 
 a.cta-link {
-    @include font-size(18px);
+    @include font-size-level6;
     border-bottom: 2px solid $color-link-blue;
     color: $color-link-blue;
     display: inline-block;

--- a/media/css/hubs/_header.scss
+++ b/media/css/hubs/_header.scss
@@ -1,0 +1,97 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+@import '../pebbles/includes/lib';
+
+/* -------------------------------------------------------------------------- */
+// Page header
+
+.header-intro {
+    h1 {
+        @include font-size-huge;
+        color: #fff;
+        line-height: 1.3;
+
+        span {
+            @include box-decoration-break(clone);
+            background-color: #000;
+        }
+    }
+
+    .tagline {
+        @include font-size-level3;
+        font-weight: bold;
+        line-height: 1.2;
+        margin-bottom: 0;
+        max-width: 25em;
+    }
+
+    .hero-image {
+        display: block;
+        margin: 20px auto 0;
+    }
+
+    .header-download {
+        text-align: center;
+        padding-top: 40px;
+    }
+
+    .dl-button {
+        display: inline-block;
+
+        img {
+            width: 190px;
+        }
+    }
+
+    .content:before {
+        height: 10px;
+    }
+
+    @media #{$mq-tablet} {
+
+        .hero-image {
+            height: 400px;
+            margin-top: 60px;
+            width: 720px;
+        }
+
+        .header-container {
+            @include clearfix;
+        }
+
+        .header-content {
+            @include span(6);
+            padding-left: 0;
+        }
+
+        .header-download {
+            @include span(6);
+            padding: 60px 0 0;
+        }
+    }
+
+    @media #{$mq-desktop} {
+
+        .header-content {
+            @include span(8);
+            padding-left: 0;
+        }
+
+        .header-download {
+            @include span(4);
+            padding: 60px 0 0;
+        }
+    }
+}
+
+html[dir="rtl"] .header-intro {
+    @media #{$mq-tablet} {
+        .header-content {
+            float: right;
+            padding-left: 10px;
+            padding-right: 0;
+        }
+    }
+}

--- a/media/css/hubs/_masthead.scss
+++ b/media/css/hubs/_masthead.scss
@@ -20,35 +20,27 @@
         float: left;
     }
 
-    .download-button {
-        display: none;
-
-        .download-list {
-            margin-bottom: 0;
-        }
-
-        .download-link {
-            @include font-size(14px);
-            border-radius: 0;
-            border: none;
-            font-weight: bold;
-            padding: 15px 20px;
-        }
-    }
-
     .fx-privacy-link {
         display: none;
     }
 
     .masthead-nav-main {
-        text-transform: none;
-        font-weight: bold;
-        @include open-sans;
         @include font-size(16px);
+        @include open-sans;
+        font-weight: bold;
+        margin: 0 0 0 20px;
+        text-transform: none;
 
-        .nav-main-menu a:hover {
-            border-color: #000;
-            color: #000;
+        .nav-main-menu {
+
+            li {
+                padding: 0 20px 0 0;
+            }
+
+            a:hover {
+                border-color: #000;
+                color: #000;
+            }
         }
     }
 
@@ -71,20 +63,19 @@
         }
     }
 
-    @media #{$mq-desktop} {
+    @media #{$mq-desktop-wide} {
+        .masthead-nav-main {
+            margin: 0 0 0 40px;
 
-        .download-button {
-            display: block;
-            float: right;
-
-            .download-link {
-                padding: 15px 20px;
+            .nav-main-menu li {
+                padding: 0 40px 0 0;
             }
         }
     }
 }
 
 #nav-download-firefox {
+    display: none;
     float: right;
     margin: 11px 0 0;
 
@@ -133,7 +124,8 @@
         }
     }
 
-    @media #{$mq-tablet} {
+    @media #{$mq-desktop} {
+        display: block;
         margin-top: 5px;
         width: 200px;
 
@@ -146,14 +138,51 @@
             }
         }
     }
-
-    .fx-privacy-link {
-        display: none;
-    }
 }
 
 .other #nav-download-firefox,
 .oldwin #nav-download-firefox,
 .oldmac #nav-download-firefox {
     display: none;
+}
+
+html[dir="rtl"] {
+    #masthead {
+
+        .masthead-nav-main {
+            float: right;
+            margin: 0 20px 0 0;
+
+            .nav-main-menu li {
+                padding: 0 0 0 20px;
+            }
+        }
+
+        @media #{$mq-tablet} {
+            .masthead-logo {
+                float: right;
+            }
+        }
+
+        @media #{$mq-desktop-wide} {
+            .masthead-nav-main {
+                margin: 0 40px 0 0;
+
+                .nav-main-menu li {
+                    padding: 0 0 0 40px;
+                }
+            }
+        }
+    }
+
+    #nav-download-firefox {
+        float: left;
+
+        @media #{$mq-tablet} {
+
+            .download-link {
+                float: left;
+            }
+        }
+    }
 }

--- a/media/css/hubs/_news-feed.scss
+++ b/media/css/hubs/_news-feed.scss
@@ -80,6 +80,6 @@ $color-link-blue-dark: #175a77;
     }
 
     .entry-title {
-        @include font-size-level2;
+        @include font-size-level3;
     }
 }

--- a/media/css/hubs/_sub-nav.scss
+++ b/media/css/hubs/_sub-nav.scss
@@ -248,3 +248,54 @@
         display: none;
     }
 }
+
+html[dir="rtl"] {
+    .sub-nav-primary-links-container {
+        float: right;
+    }
+
+    .sub-nav-primary-links > li {
+        padding: 0 0 10px 20px;
+
+        &:last-child {
+            padding-left: 0;
+        }
+    }
+
+    @media #{$mq-tablet} {
+        .sub-nav-logo-link + .sub-nav-primary-links  {
+            margin-left: 0;
+            margin-right: 45px;
+        }
+    }
+
+    @media #{$mq-desktop} {
+        .sub-nav-logo-link + .sub-nav-primary-links  {
+            margin-left: 0;
+            margin-right: 98px;
+        }
+    }
+
+    @media #{$mq-desktop-wide} {
+        .sub-nav-primary-links li {
+            padding-left: 40px;
+            padding-right: 0;
+        }
+
+        .sub-nav-logo-link + .sub-nav-primary-links  {
+            margin-left: 0;
+            margin-right: 120px;
+        }
+    }
+
+    // black outline firefox logo
+    .sub-nav-logo-link {
+        left: auto;
+        right: 0;
+    }
+
+    .sub-nav-download-wrapper {
+        float: left;
+        text-align: left;
+    }
+}

--- a/media/css/mozorg/developer/hub/_newsletter.scss
+++ b/media/css/mozorg/developer/hub/_newsletter.scss
@@ -32,11 +32,11 @@
     }
 
     h2 {
-        @include font-size-level2;
+        @include font-size-level3;
     }
 
     .tagline {
-        @include font-size-level3;
+        @include font-size-level4;
     }
 
     @media #{$mq-desktop} {
@@ -81,7 +81,7 @@ html[dir="rtl"] {
     }
 
     #form-details {
-        @include font-size(16px);
+        @include font-size-small;
         padding-top: 20px;
     }
 
@@ -109,11 +109,15 @@ html[dir="rtl"] {
     }
 
     label {
-        @include font-size(16px);
+        @include font-size-small;
+    }
+
+    small {
+        @include font-size-extra-small;
     }
 
     select {
-        @include open-sans();
+        @include open-sans;
         max-width: 100%;
     }
 

--- a/media/css/mozorg/developer/index.scss
+++ b/media/css/mozorg/developer/index.scss
@@ -6,6 +6,7 @@
 @import '../../pebbles/components/newsletter';
 @import '../../hubs/mixins';
 @import '../../hubs/masthead';
+@import '../../hubs/header';
 @import '../../hubs/sections';
 @import '../../hubs/sub-nav';
 @import '../../hubs/buttons';
@@ -15,96 +16,14 @@
 @import '../../hubs/news-feed';
 @import 'hub/newsletter';
 
-main {
-    @include font-size(20px);
-    @include zilla-slab;
-
-    .content {
-        @include horizontal-rule-before($start-color: #8edc34, $end-color: #82d1f5); // light green to light blue
-    }
+main .content {
+    @include horizontal-rule-before($start-color: #8edc34, $end-color: #82d1f5); // light green to light blue
 }
 
 // Hero promo doesn't get a gradient rule
 .devtools .content:before {
     content: none;
 }
-
-/* -------------------------------------------------------------------------- */
-// Page header
-
-.header-intro {
-    h1 {
-        color: #fff;
-        line-height: 1.3;
-
-        span {
-            @include box-decoration-break(clone);
-            background: #000;
-        }
-    }
-
-    .tagline {
-        @include font-size-level3;
-        color: $color-text-secondary;
-        font-weight: bold;
-        line-height: 1.2;
-        margin-bottom: 0;
-    }
-
-    .content:before {
-        height: 10px;
-    }
-
-    @media #{$mq-tablet} {
-
-        .header-container {
-            @include clearfix;
-        }
-
-        .header-content {
-            @include span(6);
-            padding-left: 0;
-        }
-    }
-
-    @media #{$mq-desktop} {
-        h1 {
-            @include font-size(72px);
-        }
-
-        .tagline {
-            @include font-size(32px);
-        }
-
-        .header-content {
-            @include span(8);
-            padding-left: 0;
-        }
-    }
-
-    @media #{$mq-desktop-wide} {
-        h1 {
-            @include font-size(95px);
-        }
-
-        .tagline {
-            @include font-size(48px);
-        }
-
-        .header-content {
-            @include span(9);
-            padding-left: 0;
-        }
-    }
-}
-
-html[dir="rtl"] {
-    .header-intro .header-content {
-        float: right;
-        padding: 0 0 0 10px;
-    }
-}
-
 
 //* -------------------------------------------------------------------------- */
 // Cards

--- a/media/css/mozorg/internet-health/hub/_campaign.scss
+++ b/media/css/mozorg/internet-health/hub/_campaign.scss
@@ -85,6 +85,7 @@ html[lang^="en"] {
     }
 
     h2 {
+        @include font-size-level3;
         margin-bottom: 20px;
     }
 

--- a/media/css/mozorg/internet-health/hub/_newsletter.scss
+++ b/media/css/mozorg/internet-health/hub/_newsletter.scss
@@ -31,11 +31,11 @@
     }
 
     h2 {
-        @include font-size-level2;
+        @include font-size-level3;
     }
 
     .tagline {
-        @include font-size-level3;
+        @include font-size-level4;
     }
 
     @media #{$mq-desktop} {
@@ -63,6 +63,7 @@ html[dir="rtl"] {
 }
 
 #newsletter-form {
+    @include open-sans;
     width: 100%;
 
     @media screen and (min-width: 640px) {
@@ -70,7 +71,7 @@ html[dir="rtl"] {
     }
 
     input[type="email"] {
-        @include open-sans();
+        @include open-sans;
         border-color: #fff;
         border-radius: 0;
         padding: .5em 10px;
@@ -78,7 +79,7 @@ html[dir="rtl"] {
     }
 
     #form-details {
-        @include font-size(16px);
+        @include font-size-small;
         padding-top: 20px;
     }
 
@@ -87,11 +88,15 @@ html[dir="rtl"] {
     }
 
     label {
-        @include font-size(16px);
+        @include font-size-small;
+    }
+
+    small {
+        @include font-size-extra-small;
     }
 
     select {
-        @include open-sans();
+        @include open-sans;
         max-width: 100%;
     }
 

--- a/media/css/mozorg/internet-health/index.scss
+++ b/media/css/mozorg/internet-health/index.scss
@@ -6,6 +6,7 @@
 @import '../../pebbles/components/newsletter';
 @import '../../hubs/mixins';
 @import '../../hubs/masthead';
+@import '../../hubs/header';
 @import '../../hubs/sections';
 @import '../../hubs/sub-nav';
 @import '../../hubs/buttons';
@@ -16,92 +17,9 @@
 @import 'hub/campaign';
 @import 'hub/newsletter';
 
-main {
-    @include font-size(20px);
-    @include zilla-slab;
-
-    .content {
-        @include horizontal-rule-before($start-color: #b1f5f5, $end-color: #00a6d6);
-    }
+main .content {
+    @include horizontal-rule-before($start-color: #b1f5f5, $end-color: #00a6d6);
 }
-
-/* -------------------------------------------------------------------------- */
-// Page header
-
-.header-intro {
-
-    h1 {
-        color: #fff;
-        line-height: 1.3;
-
-        span {
-            @include box-decoration-break(clone);
-            background: #000;
-        }
-    }
-
-    .tagline {
-        @include font-size-level3;
-        color: $color-text-secondary;
-        font-weight: bold;
-        line-height: 1.2;
-        margin-bottom: 0;
-    }
-
-    .content:before {
-        height: 10px;
-    }
-
-    @media #{$mq-tablet} {
-
-        .header-container {
-            @include clearfix;
-        }
-
-        .header-content {
-            @include span(6);
-            padding-left: 0;
-        }
-    }
-
-    @media #{$mq-desktop} {
-        h1 {
-            @include font-size(72px);
-        }
-
-        .tagline {
-            @include font-size(32px);
-        }
-
-        .header-content {
-            @include span(8);
-            padding-left: 0;
-        }
-    }
-
-    @media #{$mq-desktop-wide} {
-        h1 {
-            @include font-size(95px);
-        }
-
-        .tagline {
-            @include font-size(48px);
-        }
-
-        .header-content {
-            @include span(9);
-            padding-left: 0;
-        }
-    }
-}
-
-html[dir="rtl"] {
-    .header-intro .header-content {
-        float: right;
-        padding: 0 0 0 10px;
-    }
-}
-
 
 // Issues block does not been a divider right after the header.
 .issues .content:before {

--- a/media/css/pebbles/base/elements/_document.scss
+++ b/media/css/pebbles/base/elements/_document.scss
@@ -6,12 +6,12 @@
 
 
 html {
-    font-size: 100%;
+    font-size: 112.5%;
     background: #fff;
 }
 
 body {
-    font-size: 100%;
+    @include font-size(18px);
     background: #fff;
     color: $color-text-primary;
     font-family: $base-font-stack;

--- a/media/css/pebbles/components/_footer.scss
+++ b/media/css/pebbles/components/_footer.scss
@@ -6,7 +6,6 @@
 
 #colophon {
     @include open-sans;
-    @include font-size(14px);
     background: #000;
     color: #fff;
     line-height: 1.3;
@@ -34,7 +33,7 @@
         margin-bottom: .9em;
 
         @media #{$mq-desktop} {
-            @include font-size(18px);
+            @include font-size-level5;
         }
     }
 
@@ -55,7 +54,6 @@
     }
 
     .logo {
-        @include font-size(16px);
         margin-bottom: 40px;
 
         a {
@@ -107,8 +105,12 @@
         }
     }
 
+    .primary {
+        @include font-size(16px);
+    }
+
     .secondary {
-        @include font-size(12px);
+        @include font-size-extra-small;
     }
 
     .small-links {
@@ -171,12 +173,6 @@
             @include span(4);
             margin-top: 2.25em;
             padding: 0 20px 0 0;
-        }
-    }
-
-    @media #{$mq-desktop} {
-        .primary {
-            @include font-size(16px);
         }
     }
 }

--- a/media/css/pebbles/includes/_functions.scss
+++ b/media/css/pebbles/includes/_functions.scss
@@ -3,10 +3,10 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 
-// Convert pixel units to rems, assuming a 16px base size
+// Convert pixel units to rems, assuming a 18px base size
 // Usage: remify(24px)
 @function remify($pixels) {
-    $rems: $pixels / 16px;
+    $rems: $pixels / 18px;
     @return #{$rems}rem;
 }
 

--- a/media/css/pebbles/includes/mixins/_typography.scss
+++ b/media/css/pebbles/includes/mixins/_typography.scss
@@ -40,42 +40,58 @@
 }
 
 
-// Consistent font sizes for headings and titles.
-// Don't misuse these mixins; they're for headings! Use the regular font-size mixin for other elements.
-// Type scale based on a 1.333 ratio (Perfect Fourth) with 16px base, rounded to whole pixels for simplicity.
-// See: http://www.modularscale.com/?16&px&1.333&web&text
+// Consistent font sizes. Avoid sizing text arbitrarily and use this
+// set of predefined sizes. Sizes adapt at common breakpoints, and
+// there's some redundancy at smaller sizes because we don't want things
+// getting too tiny.
 // Usage:
 //  .foo { @include font-size-level1; }
 
 @mixin font-size-huge { // For especially huge titles
-    @include font-size(50px);
+    @include font-size(48px);
 
     @media #{$mq-tablet} {
-        @include font-size(90px);
+        @include font-size(60px);
+    }
+
+    @media #{$mq-desktop} {
+        @include font-size(72px);
     }
 }
 
 @mixin font-size-level1 {
-    @include font-size(38px);
+    @include font-size(36px);
 
     @media #{$mq-tablet} {
-        @include font-size(50px);
+        @include font-size(48px);
+    }
+
+    @media #{$mq-desktop} {
+        @include font-size(60px);
     }
 }
 
 @mixin font-size-level2 {
-    @include font-size(28px);
+    @include font-size(24px);
 
     @media #{$mq-tablet} {
-        @include font-size(38px);
+        @include font-size(36px);
+    }
+
+    @media #{$mq-desktop} {
+        @include font-size(48px);
     }
 }
 
 @mixin font-size-level3 {
-    @include font-size(21px);
+    @include font-size(18px);
 
     @media #{$mq-tablet} {
-        @include font-size(28px);
+        @include font-size(24px);
+    }
+
+    @media #{$mq-desktop} {
+        @include font-size(36px);
     }
 }
 
@@ -83,6 +99,42 @@
     @include font-size(16px);
 
     @media #{$mq-tablet} {
-        @include font-size(21px);
+        @include font-size(18px);
     }
+
+    @media #{$mq-desktop} {
+        @include font-size(24px);
+    }
+}
+
+@mixin font-size-level5 {
+    @include font-size(14px);
+
+    @media #{$mq-tablet} {
+        @include font-size(16px);
+    }
+
+    @media #{$mq-desktop} {
+        @include font-size(18px);
+    }
+}
+
+@mixin font-size-level6 {
+    @include font-size(14px);
+
+    @media #{$mq-tablet} {
+        @include font-size(16px);
+    }
+}
+
+@mixin font-size-small {
+    @include font-size(12px);
+
+    @media #{$mq-tablet} {
+        @include font-size(14px);
+    }
+}
+
+@mixin font-size-extra-small {
+    @include font-size(12px);
 }


### PR DESCRIPTION
## Description
- Updates headings in Pebbles to fit the [new typographic scale](http://craigcook.github.io/etc/typescale/).
- Changes all labels to sentance case
- Updates product headings to incorporate the word "Browser".
- Moves header CSS to a shared component.
- Updates nav and subnav CSS to accommodate RTL.

Note: I've lowered the base size of Zilla from 20px to 18px for the body copy on all hub pages. If we stuck exactly to the scale linked above, the base size should be 16px. For the regular Zilla weight however, 18px *looks* the same size as 16px in Open Sans. Zilla at 16px looks around 14px, and feels just too small. The two just aren't well balanced enough imho :/

## Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1369144
https://bugzilla.mozilla.org/show_bug.cgi?id=1375636

## Testing
https://bedrock-demo-agibson.us-west.moz.works/en-US/firefox/

This change effects hub pages mainly, although the heading size changes do effect all Pebbles pages, so a cursory check of all existing pages is worthwhile. Impact should be minimal as it's only font size changes.