### PR TITLE
[fix bug 1378992] Add Firefox + Cliqz privacy page

### DIFF
--- a/bedrock/privacy/templates/privacy/index.html
+++ b/bedrock/privacy/templates/privacy/index.html
@@ -81,6 +81,7 @@
         <li class="policy-websites"><a href="{{ url('privacy.notices.websites') }}">{{ _('Mozilla Websites, Communications &amp; Cookies') }}</a></li>
         <li class="policy-firefox"><a href="{{ url('privacy.notices.firefox') }}">{{ _('Firefox Browser') }}</a></li>
         <li class="policy-firefox-os"><a href="{{ url('privacy.notices.firefox-os') }}">{{ _('Firefox OS') }}</a></li>
+        <li class="policy-firefox-cliqz"><a href="{{ url('privacy.notices.firefox-cliqz') }}">{{ _('Firefox + Cliqz') }}</a></li>
         <li class="policy-firefox-cloud"><a href="{{ url('privacy.notices.firefox-cloud') }}">{{ _('Firefox Cloud Services') }}</a></li>
         <li class="policy-marketplace"><a href="https://marketplace.firefox.com/privacy-policy">{{ _('Firefox Marketplace') }}</a></li>
         <li class="policy-firefox-focus">

--- a/bedrock/privacy/templates/privacy/notices/firefox-cliqz.html
+++ b/bedrock/privacy/templates/privacy/notices/firefox-cliqz.html
@@ -1,0 +1,7 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+
+{% extends "privacy/notices/firefox.html" %}
+
+{% block body_id %}firefox-cliqz-notice{% endblock %}

--- a/bedrock/privacy/urls.py
+++ b/bedrock/privacy/urls.py
@@ -12,6 +12,7 @@ urlpatterns = (
     page('/principles', 'privacy/principles.html'),
     url(r'^/firefox/$', views.firefox_notices, name='privacy.notices.firefox'),
     url(r'^/firefox-os/$', views.firefox_os_notices, name='privacy.notices.firefox-os'),
+    url(r'^/firefox-cliqz/$', views.firefox_cliqz_notices, name='privacy.notices.firefox-cliqz'),
     url(r'^/firefox-cloud/$', views.firefox_cloud_notices, name='privacy.notices.firefox-cloud'),
     url(r'^/firefox-focus/$', views.firefox_focus_notices, name='privacy.notices.firefox-focus'),
     # bug 1319207 - special URL for Firefox Focus in de locale

--- a/bedrock/privacy/views.py
+++ b/bedrock/privacy/views.py
@@ -78,6 +78,10 @@ firefox_os_notices = PrivacyDocView.as_view(
     template_name='privacy/notices/firefox-os.html',
     legal_doc_name='firefox_os_privacy_notice')
 
+firefox_cliqz_notices = PrivacyDocView.as_view(
+    template_name='privacy/notices/firefox-cliqz.html',
+    legal_doc_name='firefox-cliqz_privacy_notice')
+
 firefox_cloud_notices = PrivacyDocView.as_view(
     template_name='privacy/notices/firefox-cloud.html',
     legal_doc_name='firefox_cloud_services_PrivacyNotice')

--- a/media/css/privacy/privacy.less
+++ b/media/css/privacy/privacy.less
@@ -191,6 +191,7 @@
 
     &.policy-firefox a:before,
     &.policy-firefox-os a:before,
+    &.policy-firefox-cliqz a:before,
     &.policy-firefox-cloud a:before {
       background-position: left -40px;
     }


### PR DESCRIPTION
## Description
- Creates the template and URL for the privacy notice added in #4946.
- Also added a link to the new notice in `/privacy/`

## Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1378992

## Testing
- Make sure you update git sub-modules to include the latest commits from legal-docs.
- Visit `/firefox-cliqz/` and make sure the page displays correctly.
