### PR TITLE
[fix bug 1375967] Add Optimizely to Fx new lifestyle workingout variant

### DIFF
--- a/bedrock/firefox/templates/firefox/new/fx-lifestyle/working-out/scene1.html
+++ b/bedrock/firefox/templates/firefox/new/fx-lifestyle/working-out/scene1.html
@@ -4,6 +4,12 @@
 
 {% extends "firefox/new/fx-lifestyle/base.html" %}
 
+{% block optimizely %}
+  {% if switch('firefox-new-fxlifestyleworkingout-optimizely', ['en-US']) %}
+    {% include 'includes/optimizely.html' %}
+  {% endif %}
+{% endblock %}
+
 {% block page_css %}
   {% stylesheet 'firefox_new_working_out' %}
 {% endblock %}


### PR DESCRIPTION
## Description

Just adds the Optimizely block with a unique switch name for en-US only.

## Issue / Bugzilla link

https://bugzilla.mozilla.org/show_bug.cgi?id=1375967

## Testing

Make sure no silly mistakes.