### PR TITLE
Contributor asking for a name change in the Hall Of Fame

### DIFF
--- a/bedrock/security/templates/security/bug-bounty/web-hall-of-fame.html
+++ b/bedrock/security/templates/security/bug-bounty/web-hall-of-fame.html
@@ -288,7 +288,7 @@
           </li>Mario Gomes</li>
           <li>Sergey</li>
           <li>Soroush Dalili</li>
-          <li>Vaibs</li>
+          <li>Noah Wilcox</li>
         </ul>
         </div>
       </section>


### PR DESCRIPTION
## Description
Contributor "Vaibs" send us an email to our security e-mail address and asked for his listing in the hall of fame to be changed to his real name. I have confirmed that he is in fact the same person that found the bug back then.

Can we get this change in?


## Issue / Bugzilla link
N/A

## Testing
N/A