### PR TITLE
[fix bug 1380825] Firstrun page should add  param upon opening FxA's settings page

### DIFF
--- a/media/js/base/mozilla-fxa-iframe.js
+++ b/media/js/base/mozilla-fxa-iframe.js
@@ -217,7 +217,9 @@ Mozilla.FxaIframe = (function() {
             // hide the FxA iframe.
             _userCallback('onLogin', data);
         } else {
-            Mozilla.Utils.doRedirect(_host + '/settings');
+            // `?service=sync` is a temporary workaround to avoid an
+            // unwanted redirect back to /signin. See bug 1380825.
+            Mozilla.Utils.doRedirect(_host + '/settings?service=sync');
         }
     };
 

--- a/tests/unit/spec/base/mozilla-fxa-iframe.js
+++ b/tests/unit/spec/base/mozilla-fxa-iframe.js
@@ -258,7 +258,7 @@ describe('mozilla-fxa-iframe.js', function() {
             };
 
             spyOn(Mozilla.Utils, 'doRedirect').and.callFake(function(destination) {
-                expect(destination).toEqual(fxaHost + '/settings');
+                expect(destination).toEqual(fxaHost + '/settings?service=sync');
                 done();
             });
 


### PR DESCRIPTION
## Description
- Adds `?service=sync` as a temporary workaround to avoid an unwanted redirect back to /signin.

## Issue / Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1380825

## Testing
Demo: https://www-demo3.allizom.org/en-US/firefox/54.0/firstrun/

1. Launch a new profile using [settings required](http://bedrock.readthedocs.io/en/latest/firefox-accounts.html#demo-server-testing) for testing against a demo instance of bedrock / fxa server.
2. Sign in with an existing Fx Account.
3. Verify that upon successful signin you are redirected to https://accounts.firefox.com/settings?service=sync
