### PR TITLE
[bug 1378137] Fix lazy-image placeholder color on /firefox/features/

### DIFF
--- a/media/css/firefox/features/common.scss
+++ b/media/css/firefox/features/common.scss
@@ -176,7 +176,7 @@ main {
         display: none;
     }
 
-    .image-container {
+    .lazy-image-container {
         background-color: #eee;
         display: block;
         margin-bottom: 20px;

--- a/media/css/mozorg/developer/index.scss
+++ b/media/css/mozorg/developer/index.scss
@@ -134,7 +134,7 @@ html[dir="rtl"] {
         display: none;
     }
 
-    .image-container {
+    .lazy-image-container {
         background-color: #eee;
         display: block;
         margin-bottom: 20px;


### PR DESCRIPTION
Minor visual regression from #4960