### PR TITLE
[fix bug 1380845] Remove Persona privacy link

### DIFF
--- a/bedrock/privacy/templates/privacy/index.html
+++ b/bedrock/privacy/templates/privacy/index.html
@@ -92,7 +92,6 @@
           <a href="{{ url('privacy.notices.firefox-focus') }}">{{ _('Firefox Focus') }}</a>
         {% endif %}
         </li>
-        <li class="policy-persona"><a href="{{ url('persona.privacy-policy') }}">{{ _('Persona') }}</a></li>
         <li class="policy-thunderbird"><a href="{{ url('privacy.notices.thunderbird') }}">{{ _('Thunderbird') }}</a></li>
       </ul>
     </nav>


### PR DESCRIPTION
## Description
- Removes link to Persona in the /privacy sidebar.
- Ask for now is to remove only the link, but keep the `/persona/privacy-policy/` URL around.

## Issue / Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1380845
