### PR TITLE
[fix bug 1370574] Add temporary redirect for send tabs page.

### DIFF
--- a/bedrock/firefox/redirects.py
+++ b/bedrock/firefox/redirects.py
@@ -542,4 +542,8 @@ redirectpatterns = (
 
     # bug 1370587
     redirect(r'^firefox/sync/?', 'firefox.features.sync'),
+
+    # bug 1370574
+    # should be removed when send tabs page goes live
+    redirect(r'^firefox/features/send-tabs/?', 'firefox.features.sync', permanent=False),
 )


### PR DESCRIPTION
## Description

While copy issues are addresses on the Send Tabs page, product needs to ship with a link to the upcoming `/firefox/features/send-tabs/` page. This is a temporary redirect just to get that URL to not 404. Will be removed when send tabs page goes live.

## Issue / Bugzilla link

https://bugzilla.mozilla.org/show_bug.cgi?id=1370574#c15

## Testing

Ensure I did the redirect correctly.