### PR TITLE
Use Whitenoise as wsgi middleware, not Django

### DIFF
--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -410,8 +410,6 @@ BASIC_AUTH_CREDS = config('BASIC_AUTH_CREDS', default=None)
 
 MIDDLEWARE_CLASSES = [
     'django.middleware.security.SecurityMiddleware',
-    # must be after SecurityMiddleware
-    'whitenoise.middleware.WhiteNoiseMiddleware',
     'bedrock.mozorg.middleware.MozorgRequestTimingMiddleware',
     'django_statsd.middleware.GraphiteMiddleware',
     'corsheaders.middleware.CorsMiddleware',
@@ -435,8 +433,6 @@ if ENABLE_CSP_MIDDLEWARE:
 
 INSTALLED_APPS = (
     'cronjobs',  # for ./manage.py cron * cmd line tasks
-    # needs to be above django.contrib.staticfiles
-    'whitenoise.runserver_nostatic',
 
     # Django contrib apps
     'django.contrib.auth',

--- a/wsgi/app.py
+++ b/wsgi/app.py
@@ -23,6 +23,8 @@ os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'bedrock.settings')
 # must be imported after env var is set above.
 from django.core.handlers.wsgi import WSGIRequest
 from django.core.wsgi import get_wsgi_application
+
+from whitenoise.django import DjangoWhiteNoise
 from raven.contrib.django.raven_compat.middleware.wsgi import Sentry
 
 
@@ -35,6 +37,7 @@ class WSGIHTTPSRequest(WSGIRequest):
 
 application = get_wsgi_application()
 application.request_class = WSGIHTTPSRequest
+application = DjangoWhiteNoise(application)
 application = Sentry(application)
 
 if newrelic:


### PR DESCRIPTION
When used as a Django middleware all asset responses include all headers intended for page responses (e.g. CSP and XSS protection).  Switch to WSGI middleware to avoid sending extra data as well as to avoid confusing Safari.