### PR TITLE
[fix bug 1382107] Developer Edition string updates

### DIFF
--- a/bedrock/firefox/templates/firefox/products/developer.html
+++ b/bedrock/firefox/templates/firefox/products/developer.html
@@ -34,7 +34,7 @@
     <div class="content">
 
       <h1 class="fx-logo">{{ high_res_img('firefox/developer/title.png', {'alt': _('Firefox Developer Edition'), 'width': '220', 'height': '84'}) }}</h1>
-      <h2 class="section-title">{{ _('Modern Tools for the Open Web') }}</h2>
+      <h2 class="section-title">{{ _('Modern tools for the Open Web') }}</h2>
       <p class="tagline">{{ _('Create and debug web experiences with powerful, open source tools.') }}</p>
 
       {{ download_firefox('alpha', platform='desktop', dom_id='intro-download', button_color='button-arrow', download_location='primary cta') }}
@@ -88,15 +88,15 @@
     <div class="content">
 
       <section class="speak-up">
-        <h3>{{ _('Speak Up') }}</h3>
+        <h3>{{ _('Speak up') }}</h3>
         <p>{{ _('Feedback makes us better. Tell us how we can improve the browser and Developer tools.') }}</p>
-        <p class="cta"><a href="https://discourse.mozilla-community.org/c/devtools" class="button button-hollow">{{ _('Join the Conversation') }}</a></p>
+        <p class="cta"><a href="https://discourse.mozilla-community.org/c/devtools" class="button button-hollow">{{ _('Join the conversation') }}</a></p>
       </section>
 
       <section class="get-involved">
-        <h3>{{ _('Get Involved') }}</h3>
+        <h3>{{ _('Get involved') }}</h3>
         <p>{{ _('Help build the last independent browser. Write code, fix bugs, make add-ons, and more.') }}</p>
-        <p class="cta"><a href="https://devtools-html.github.io/" class="button button-hollow">{{ _('Get Involved') }}</a></p>
+        <p class="cta"><a href="https://devtools-html.github.io/" class="button button-hollow">{{ _('Start now') }}</a></p>
       </section>
 
     </div>
@@ -155,11 +155,11 @@
         <li class="gallery-item feature">
           <a href="https://developer.mozilla.org/docs/Tools/Storage_Inspector">
             <img class="icon" src="{{ static('img/firefox/products/developer/feature-storage.svg') }}" alt="">
-            <h3 class="name">{{ _('Storage Panel') }}</h3>
+            <h3 class="name">{{ _('Storage panel') }}</h3>
           </a>
           <p class="desc">{{ _('Add, modify and remove cache, cookies, databases and session data.') }}</p>
           <p class="cta">
-            <a href="https://developer.mozilla.org/docs/Tools/Storage_Inspector">{{ _('Learn more about the Storage Panel') }}</a>
+            <a href="https://developer.mozilla.org/docs/Tools/Storage_Inspector">{{ _('Learn more about the Storage panel') }}</a>
           </p>
         </li>
 


### PR DESCRIPTION
## Description
Changes a CTA to avoid a duplicate string. Also changes some headlines and CTAs to sentence case. A few headings appear to be title case but only because the feature name is treated as a proper noun (e.g. "Responsive Design Mode").

The page hasn't yet been exposed to l10n so I don't think we need tags for these changes.

## Issue / Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1382107
