### PR TITLE
[fix bug 1375967] Add Optimizely to scene 2 on /new variations:

### DIFF
--- a/bedrock/firefox/templates/firefox/new/batm/scene2.html
+++ b/bedrock/firefox/templates/firefox/new/batm/scene2.html
@@ -4,6 +4,12 @@
 
 {% extends "firefox/new/batm/base.html" %}
 
+{% block optimizely %}
+  {% if switch('firefox-new-batm-scene2-optimizely', ['en-US']) %}
+    {% include 'includes/optimizely.html' %}
+  {% endif %}
+{% endblock %}
+
 {% block body_class %}scene-2{% endblock %}
 
 {% block string_data %}

--- a/bedrock/firefox/templates/firefox/new/fx-lifestyle/working-out/scene2.html
+++ b/bedrock/firefox/templates/firefox/new/fx-lifestyle/working-out/scene2.html
@@ -4,6 +4,12 @@
 
 {% extends "firefox/new/fx-lifestyle/base.html" %}
 
+{% block optimizely %}
+  {% if switch('firefox-new-fxlifestyleworkingout-optimizely', ['en-US']) %}
+    {% include 'includes/optimizely.html' %}
+  {% endif %}
+{% endblock %}
+
 {% block body_class %}fx-lifestyle-scene2{% endblock %}
 
 {% block page_css %}


### PR DESCRIPTION
- batm*
- workingout

## Description

Adds Optimizely block for scene 2's targeted by experiment.

Accompanying config change is at mozmeao/www-config#26.

## Issue / Bugzilla link

https://bugzilla.mozilla.org/show_bug.cgi?id=1375967

## Testing

Make sure no typos or regressions.

Optimizely should end up added to these URLs:

- `firefox/new/?xv=batmprivate&scene=2`
- `firefox/new/?xv=workingout&scene=2`