### PR TITLE
[fix bug 1380317] Update site footer Firefox links

### DIFF
--- a/bedrock/base/templates/includes/site-footer.html
+++ b/bedrock/base/templates/includes/site-footer.html
@@ -9,7 +9,9 @@
         <a href="{{ url('mozorg.home') }}" data-link-type="footer" data-link-name="Mozilla">{{ _('Mozilla') }}</a>
       </div>
       <section class="mozilla">
-        <h5>{{ _('Mozilla') }}</h5>
+        <h5>
+          <a href="{{ url('mozorg.home') }}" data-link-type="footer" data-link-name="Mozilla">{{ _('Mozilla') }}</a>
+        </h5>
         <ul class="mozilla-links">
           <li><a href="{{ url('mozorg.about') }}" data-link-type="footer" data-link-name="About">{{ _('About') }}</a></li>
           <li><a href="{{ url('mozorg.contact.contact-landing') }}" data-link-type="footer" data-link-name="Contact Us">{{ _('Contact Us') }}</a></li>
@@ -25,12 +27,23 @@
         </ul>
       </section>
       <section class="firefox">
-        <h5>{{ _('Firefox') }}</h5>
+        <h5>
+          <a href="{{ url('firefox') }}" data-link-type="footer" data-link-name="Firefox">{{ _('Firefox') }}</a>
+        </h5>
         <ul class="firefox-links">
-          <li><a href="{{ url('firefox') }}" data-link-type="footer" data-link-name="Download Firefox now">{{ _('Download Firefox Web Browser') }}</a></li>
+        {% if LANG.startswith('en') %}
+          <li><a href="{{ url('firefox.new') }}" data-link-type="footer" data-link-name="Download Firefox">{{ _('Download Firefox') }}</a></li>
+          <li><a href="{{ url('firefox.android.index') }}" data-link-type="footer" data-link-name="Android Browser">{{ _('Android Browser') }}</a></li>
+          <li><a href="{{ url('firefox.ios') }}" data-link-type="footer" data-link-name="iOS Browser">{{ _('iOS Browser') }}</a></li>
+          <li><a href="{{ url('firefox.focus') }}" data-link-type="footer" data-link-name="Focus Browser">{{ _('Focus Browser') }}</a></li>
+          <li><a href="{{ url('firefox.desktop.index') }}" data-link-type="footer" data-link-name="Desktop Browser">{{ _('Desktop Browser') }}</a></li>
+          <li><a href="{{ url('firefox.channel.desktop') }}" data-link-type="footer" data-link-name="Beta, Nightly, Developer Edition">{{ _('Beta, Nightly, Developer Edition') }}</a></li>
+        {% else %}
+          <li><a href="{{ url('firefox.new') }}" data-link-type="footer" data-link-name="Download Firefox now">{{ _('Download Firefox Web Browser') }}</a></li>
           <li><a href="{{ url('firefox.desktop.index') }}" data-link-type="footer" data-link-name="Desktop Browser for Mac, Windows, Linux">{{ _('Desktop Browser for Mac, Windows, Linux') }}</a></li>
           <li><a href="{{ url('firefox.android.index') }}" data-link-type="footer" data-link-name="Mobile Browser for Android">{{ _('Mobile Browser for Android') }}</a></li>
           <li><a href="{{ url('firefox.ios') }}" data-link-type="footer" data-link-name="Mobile Browser for iOS">{{ _('Mobile Browser for iOS') }}</a></li>
+        {% endif %}
           <li>
             <ul class="social-links">
               <li><a class="twitter" href="{{ firefox_twitter_url() }}" data-link-type="footer" data-link-name="Twitter (@firefox)">{{ _('Twitter') }}<span> (@firefox)</span></a></li>

--- a/media/css/pebbles/components/_footer.scss
+++ b/media/css/pebbles/components/_footer.scss
@@ -29,11 +29,15 @@
 
     h5 {
         color: #fff;
-        font-weight: bold;
         margin-bottom: .9em;
 
         @media #{$mq-desktop} {
             @include font-size-level5;
+        }
+
+        a:link,
+        a:visited {
+            font-weight: bold;
         }
     }
 

--- a/media/css/sandstone/sandstone-resp.less
+++ b/media/css/sandstone/sandstone-resp.less
@@ -1023,9 +1023,13 @@ nav.menu-bar {
     h5 {
         .font-size(18px);
         color: #fff;
-        font-weight: bold;
         margin-bottom: .9em;
         text-shadow: none;
+
+        a:link,
+        a:visited {
+            font-weight: bold;
+        }
     }
 
     li {

--- a/media/css/sandstone/sandstone.less
+++ b/media/css/sandstone/sandstone.less
@@ -760,19 +760,24 @@ nav.menu-bar {
         text-decoration: none;
     }
 
-    a:link,
-    a:visited {
+    a:hover,
+    a:active,
+    a:focus {
         color: #fff;
         font-weight: normal;
-        text-decoration: none;
+        text-decoration: underline;
     }
 
     h5 {
         .font-size(18px);
         color: #fff;
-        font-weight: bold;
         margin-bottom: .9em;
         text-shadow: none;
+
+        a:link,
+        a:visited {
+            font-weight: bold;
+        }
     }
 
     li {


### PR DESCRIPTION
## Description
- Updates site footer to add links to `/firefox/focus/` and `/firefox/channel/` pages.
- Also updates some of the keywords in existing links (at @hoosteeno's request).
- `Mozilla` and `Firefox` headings become links.
- Also fixes an existing CSS bug in the non-responsive version of the footer styles, where `:hover` & `:focus` link styles weren't being applied (you can test this on the `/styleguide` pages).

The intent here is to push this out for `en` locales now and begin translating the new strings. Once enough locales have updated, we can remove the conditional.

## Issue / Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1380317

## Testing
- Check for any typos? (see [final spec](https://bugzilla.mozilla.org/show_bug.cgi?id=1380317#c14) in the bug for reference).
