### PR TITLE
Fix Bug 1384370 - Redirect https://www.mozilla.org/en-US/developers - redirect to /developer

### DIFF
--- a/bedrock/mozorg/redirects.py
+++ b/bedrock/mozorg/redirects.py
@@ -671,4 +671,7 @@ redirectpatterns = (
 
     # Bug 1361194
     redirect(r'^internethealth/?$', 'mozorg.internet-health'),
+
+    # Bug 1384370
+    redirect(r'^developers/?$', 'mozorg.developer'),
 )

--- a/tests/redirects/map_globalconf.py
+++ b/tests/redirects/map_globalconf.py
@@ -1167,6 +1167,9 @@ URLS = flatten((
     # Bug 1361194
     url_test('/internethealth', '/internet-health/'),
 
+    # Bug 1384370
+    url_test('/developers', '/developer/'),
+
     # Bug 1355184
     url_test('/en-US/firefox/private-browsing/', '/en-US/firefox/features/private-browsing/'),
 


### PR DESCRIPTION
## Description

Redirect `/developers/` to [`/developer/`](https://www.mozilla.org/developer/) so it won't lead to 404 Not Found.

## Issue / Bugzilla link

[Bug 1384370](https://bugzilla.mozilla.org/show_bug.cgi?id=1384370)

## Testing

Just visit `/developers/` to make sure you'll be taken to `/developer/`.