### PR TITLE
Fix Bug 1384360 - Mozilla.org Home - Our Innovations - VR Link Update for Fx55

### DIFF
--- a/bedrock/mozorg/templates/mozorg/home/home.html
+++ b/bedrock/mozorg/templates/mozorg/home/home.html
@@ -135,7 +135,7 @@
             <a rel="external" href="https://games.mozilla.org/"><svg class="icon"><use xlink:href="#icon-gaming"></use></svg>{{ _('Gaming on the Web') }}</a>
           </li>
           <li id="vr">
-            <a rel="external" href="https://research.mozilla.org/mixed-reality/"><svg class="icon"><use xlink:href="#icon-vr"></use></svg>{{ _('Virtual Reality Platform') }}</a>
+            <a rel="external" href="https://vr.mozilla.org/"><svg class="icon"><use xlink:href="#icon-vr"></use></svg>{{ _('Virtual Reality Platform') }}</a>
           </li>
           <li id="servo">
             <a rel="external" href="https://servo.org/"><svg class="icon"><use xlink:href="#icon-servo"></use></svg>{{ _('Servo') }}</a>


### PR DESCRIPTION
## Description

Change the Mozilla VR link to the new canonical URL: vr.mozilla.org

## Issue / Bugzilla link

[Bug 1384360](https://bugzilla.mozilla.org/show_bug.cgi?id=1384360)

## Testing

Visit the homepage and make sure the ﻿﻿﻿﻿Virtual Reality Platform goes to vr.mozilla.org, though it's still redirected to mozvr.com.