### PR TITLE
[bug 1382807] Fix missing base url for Pocket link in nav drawer

### DIFF
--- a/bedrock/base/templates/includes/global-nav.html
+++ b/bedrock/base/templates/includes/global-nav.html
@@ -139,7 +139,7 @@
         </li>
         <li class="item-pocket">
           <h3 class="summary" data-id="pocket">
-            <a href="?utm_source=www.mozilla.org&amp;utm_medium=referral&amp;utm_campaign=global-nav&amp;utm_content=pocket" data-link-type="nav" data-link-position="side" data-link-name="expand" data-link-group="Pocket">{{ _('Pocket') }}</a>
+            <a href="https://getpocket.com/?utm_source=www.mozilla.org&amp;utm_medium=referral&amp;utm_campaign=global-nav&amp;utm_content=pocket" data-link-type="nav" data-link-position="side" data-link-name="expand" data-link-group="Pocket">{{ _('Pocket') }}</a>
           </h3>
           <div class="detail">
             <div class="detail-container">
@@ -149,7 +149,7 @@
 
               <ul class="nav-menu-secondary-links">
                 <li>
-                  <a href="?utm_source=www.mozilla.org&amp;utm_medium=referral&amp;utm_campaign=global-nav&amp;utm_content=pocket" data-link-type="nav" data-link-name="Get Pocket" data-link-group="Pocket">
+                  <a href="https://getpocket.com/?utm_source=www.mozilla.org&amp;utm_medium=referral&amp;utm_campaign=global-nav&amp;utm_content=pocket" data-link-type="nav" data-link-name="Get Pocket" data-link-group="Pocket">
                     {{ _('Get Pocket') }}
                   </a>
                 </li>


### PR DESCRIPTION
Fixes a bug introduced in #4990. This is what I get for trying to rush something in at the end of the day 😩 
