### PR TITLE
Scroll newsletter into view before expaning form in functional tests

### DIFF
--- a/tests/pages/regions/newsletter.py
+++ b/tests/pages/regions/newsletter.py
@@ -22,6 +22,8 @@ class NewsletterEmbedForm(Region):
     _thank_you_locator = (By.CSS_SELECTOR, '#newsletter-form-thankyou h3')
 
     def expand_form(self):
+        # scroll newsletter into view before expanding the form
+        self.scroll_element_into_view(*self._root_locator)
         assert not self.is_form_detail_displayed, 'Form detail is already displayed'
         # Click the submit button to expand the form when not visible.
         # Ideally here we would focus on the email field, but Selenium has issues


### PR DESCRIPTION
Our newsletter tests started failing as a side effect of our footer expanding in height in #4995. This was an unrelated change in behavior since Selenium automatically scrolls elements into view when clicked. The taller footer meant the newsletter submit button was now being obscured by the sticky navigation, which you can see in [this video](https://saucelabs.com/beta/tests/8d5fcdd435204e0c842b487185a93e1e/). Note you need to be logged in to view the recording. This fix scrolls the newsletter into view before interacting with it.

Failure: https://ci.us-west.moz.works/blue/organizations/jenkins/bedrock_multibranch_pipeline/detail/prod/120/pipeline

Successful test run: https://ci.us-west.moz.works/blue/organizations/jenkins/bedrock_multibranch_pipeline/detail/run-integration-tests/41/pipeline
