### PR TITLE
[fix bug 1380841] Add Firefox update to plugincheck page

### DIFF
--- a/bedrock/mozorg/templates/mozorg/plugincheck-update.html
+++ b/bedrock/mozorg/templates/mozorg/plugincheck-update.html
@@ -1,0 +1,114 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+
+{% extends "base-pebbles.html" %}
+
+{% block page_image %}{{ static('img/plugincheck/page-image.png') }}{% endblock %}
+
+{% block page_title %}
+  {{ _('More browser features, fewer plugin updates | Firefox') }}
+{% endblock %}
+{% block page_title_suffix %}{% endblock %}
+
+{% block page_desc %}
+  {{ _('Browse with fewer interruptions. Features from NPAPI plugins are now automatically supported in Firefox. Download the latest Firefox now!') }}
+{% endblock %}
+
+{% block body_class %}{% endblock %}
+{% block body_id %}plugincheck{% endblock %}
+
+{% block page_css %}
+  {% stylesheet 'plugincheck-update' %}
+{% endblock %}
+
+
+{% block site_header_logo %}{% endblock %}
+
+{% block content %}
+<main role="main">
+  <section class="section">
+    <div class="content">
+
+      <div class="message message-firefox-current">
+        {# L10n: <br> for visual formatting #}
+        <h1>{{ _('Good news - you’re using<br> the latest version of Firefox!') }}</h1>
+        <p class="tagline">
+        {% trans npapi='https://blog.mozilla.org/futurereleases/2015/10/08/npapi-plugins-in-firefox/' %}
+          Even better news - Firefox now <a href="{{ npapi }}">supports features</a>
+          that used to require additional plugins.
+        {% endtrans %}
+        </p>
+
+        <p class="support">
+          <a href="https://support.mozilla.org" data-link-type="support" data-link-position="current" data-link-name="Mozilla Support">
+            {{ _('Need help? Visit Mozilla Support') }}
+          </a>
+        </p>
+      </div>
+
+      <div class="message message-firefox-old">
+        {# L10n: <br> for visual formatting #}
+        <h1>{{ _('Better features,<br> fewer plugin updates') }}</h1>
+        <p class="tagline">
+        {% trans npapi='https://blog.mozilla.org/futurereleases/2015/10/08/npapi-plugins-in-firefox/',
+                 blocklist='https://support.mozilla.org/kb/add-ons-cause-issues-are-on-blocklist' %}
+          Firefox has been <a href="{{ npapi }}">expanding to support features</a>
+          that used to require extra plugins. Now, they’re kept up-to-date automatically
+          and managed through <a href="{{ blocklist }}">blocklisting</a> for added security.
+          So you can stay current with just one Firefox update.
+        {% endtrans %}
+        </p>
+
+        <div class="cta">
+          <p>{{ _('Download the latest version:') }}</p>
+          {{ download_firefox(dom_id='oldfx-download', button_color='button-arrow', download_location='outdated, primary cta', alt_copy=_('Update Firefox')) }}
+        </div>
+
+        <p class="support">
+          <a href="https://support.mozilla.org" data-link-type="support" data-link-position="outdated" data-link-name="Mozilla Support">
+            {{ _('Need help? Visit Mozilla Support') }}
+          </a>
+        </p>
+      </div>
+
+      <div id="not-supported-container" class="message message-not-firefox">
+        {# L10n: <br> for visual formatting #}
+        <h1>{{ _('Tired of updating plugins?<br> Firefox has you covered.') }}</h1>
+        <p class="tagline">
+        {% trans npapi='https://blog.mozilla.org/futurereleases/2015/10/08/npapi-plugins-in-firefox/',
+                 blocklist='https://support.mozilla.org/kb/add-ons-cause-issues-are-on-blocklist' %}
+          As the web moves forward, so do we. Firefox now <a href="{{ npapi }}">supports more features</a>
+          that used to require plugins, so you can browse with fewer crashes and interruptions.
+          Plus, our <a href="{{ blocklist }}">blocklist system</a> protects you between updates.
+        {% endtrans %}
+        </p>
+
+        <div class="cta">
+          {{ download_firefox(dom_id='notfx-download', button_color='button-arrow', download_location='Not Firefox, primary cta') }}
+        </div>
+      </div>
+
+    </div>
+  </section>
+</main>
+
+<aside class="outro ga-section" data-ga-label="Hungry for more?">
+  <div class="content">
+    <section class="outro-item outro-item-newsletter">
+      <div class="outro-item-detail">
+        <h2>{{ _('Hungry for more?') }}</h2>
+        <p class="tagline">{{ _('Get the latest &amp; greatest from Firefox delivered straight to your inbox.') }}</p>
+        {{ email_newsletter_form(include_title=False, spinner_color='#000', button_class='button-hollow button-light') }}
+      </div>
+    </section>
+  </div> {#--/.content--#}
+</aside> {#--/.outro--#}
+
+{% endblock %}
+
+{% block email_form %}{% endblock %}
+
+{% block js %}
+  {% javascript 'plugincheck-update' %}
+{% endblock %}

--- a/bedrock/mozorg/urls.py
+++ b/bedrock/mozorg/urls.py
@@ -247,7 +247,7 @@ urlpatterns = (
     page('moss/foundational-technology', 'mozorg/moss/foundational-technology.html'),
     page('moss/mission-partners', 'mozorg/moss/mission-partners.html'),
     page('moss/secure-open-source', 'mozorg/moss/secure-open-source.html'),
-    page('plugincheck', 'mozorg/plugincheck.html'),
+    url(r'plugincheck/$', views.plugincheck, name='mozorg.plugincheck'),
     url(r'^robots.txt$', views.Robots.as_view(), name='robots.txt'),
     url('^technology/$', views.TechnologyView.as_view(), name='mozorg.technology'),
 

--- a/bedrock/mozorg/views.py
+++ b/bedrock/mozorg/views.py
@@ -290,3 +290,14 @@ class DeveloperView(BlogPostsView):
     blog_slugs = 'hacks'
     blog_posts_limit = 3
     blog_posts_template_variable = 'articles'
+
+
+def plugincheck(request):
+    locale = l10n_utils.get_locale(request)
+
+    if lang_file_is_active('mozorg/plugincheck-update', locale):
+        template = 'mozorg/plugincheck-update.html'
+    else:
+        template = 'mozorg/plugincheck.html'
+
+    return l10n_utils.render(request, template)

--- a/bedrock/settings/static_media.py
+++ b/bedrock/settings/static_media.py
@@ -859,6 +859,12 @@ PIPELINE_CSS = {
         ),
         'output_filename': 'css/plugincheck-bundle.css',
     },
+    'plugincheck-update': {
+        'source_filenames': (
+            'css/plugincheck/plugincheck-update.scss',
+        ),
+        'output_filename': 'css/plugincheck-update.css',
+    },
     'press': {
         'source_filenames': (
             'css/press/press.less',
@@ -1699,6 +1705,12 @@ PIPELINE_JS = {
             'js/plugincheck/check-plugins.js',
         ),
         'output_filename': 'js/plugincheck-bundle.js',
+    },
+    'plugincheck-update': {
+        'source_filenames': (
+            'js/plugincheck/plugincheck-update.js',
+        ),
+        'output_filename': 'js/plugincheck-update-bundle.js',
     },
     'press_speaker_request': {
         'source_filenames': (

--- a/media/css/plugincheck/plugincheck-update.scss
+++ b/media/css/plugincheck/plugincheck-update.scss
@@ -1,0 +1,92 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+@import
+    '../pebbles/includes/lib',
+    '../hubs/sections',
+    '../hubs/buttons',
+    '../pebbles/components/newsletter',
+    '../firefox/hub/outro';
+
+
+.message {
+    text-align: center;
+    max-width: $width-tablet;
+    margin: 40px auto;
+
+    h1 {
+        @include font-size-level2;
+    }
+
+    .tagline {
+        @include font-size-level4;
+    }
+
+    .cta {
+        padding-top: 20px;
+    }
+
+    .support {
+        margin: 20px auto;
+    }
+}
+
+.fx-privacy-link {
+    @include font-size-small;
+
+    a:link,
+    a:visited {
+        color: $color-link;
+
+        &:hover,
+        &:focus,
+        &:active {
+            color: darken($color-link, 10%);
+        }
+    }
+}
+
+// Assume not Firefox until proven otherwise.
+// This is the non-JS default.
+.message-firefox-current,
+.message-firefox-old {
+    display: none;
+}
+
+// Current Firefox
+.firefox-current {
+    .message-not-firefox,
+    .message-firefox-old {
+        display: none;
+    }
+
+    .message-firefox-current {
+        display: block;
+    }
+}
+
+// Out-of-date Firefox
+.firefox-old {
+    .message-firefox-current,
+    .message-not-firefox {
+        display: none;
+    }
+
+    .message-firefox-old {
+        display: block;
+    }
+}
+
+// Everybody else
+.not-firefox {
+    .message-firefox-current,
+    .message-firefox-old {
+        display: none;
+    }
+
+    .message-not-firefox {
+        display: block;
+    }
+}
+

--- a/media/js/plugincheck/plugincheck-update.js
+++ b/media/js/plugincheck/plugincheck-update.js
@@ -1,0 +1,23 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+* License, v. 2.0. If a copy of the MPL was not distributed with this
+* file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+(function($) {
+    'use strict';
+
+    var client = window.Mozilla.Client;
+    var body = $('body');
+
+    if (client._isFirefoxDesktop) {
+        client.getFirefoxDetails(function(details) {
+            if (details.isUpToDate && details.channel === 'release') {
+                body.addClass('firefox-current');
+            } else if (!details.isUpToDate && details.channel === 'release') {
+                body.addClass('firefox-old');
+            }
+        });
+    } else {
+        body.addClass('not-firefox');
+    }
+
+})(window.jQuery);


### PR DESCRIPTION
## Description
The plugin check functionality is deprecated but there are still old Firefoxes with in-product links to the page, which now presents misleading information. This creates a new plugincheck page encouraging users to update Firefox. This will entirely replace the old page once we have decent locale coverage, at which time we can delete the old plugincheck page and assets.

## Issue / Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1380841

## Testing
https://bedrock-demo-craigcook.us-west.moz.works/en-US/plugincheck/

There are three states with different messaging:
* Latest Firefox (or pre-release)
* Outdated Firefox
* Not Firefox

It should detect minor versions as well - e.g. Firefox 54.0 should be treated as out of date because 54.0.1 is the latest - but that could be tricky to test if you don't have a stale browser handy.