### PR TITLE
Fix Bug 1384823 - Remove all redirects to mozilla.jp

### DIFF
--- a/bedrock/firefox/redirects.py
+++ b/bedrock/firefox/redirects.py
@@ -246,11 +246,6 @@ redirectpatterns = (
     # bug 960543
     redirect(r'^firefox/(?P<vers>[23])\.0/eula', '/legal/eula/firefox-{vers}/'),
 
-    # bug 1224060
-    redirect(
-        r'^ja/firefox/ios/(?P<vers>[0-9]+(\.[0-9]+)*)/(?P<file>releasenotes|system-requirements)',
-        'https://www.mozilla.jp/firefox/ios/{vers}/{file}/', locale_prefix=False),
-
     # bug 1150713
     redirect(r'^firefox/sms(?:/.*)?$', 'firefox.family.index'),
 

--- a/bedrock/mozorg/redirects.py
+++ b/bedrock/mozorg/redirects.py
@@ -16,13 +16,6 @@ redirectpatterns = (
         'utm_source': 'mozilla.org'
     }),
 
-    # bug 1013082
-    redirect(r'^ja/?$', 'https://www.mozilla.jp/', locale_prefix=False),
-
-    # bug 1051686
-    redirect(r'^ja/firefox/organizations/?$', 'https://www.mozilla.jp/business/',
-             locale_prefix=False),
-
     # bug 874913, 681572
     redirect(r'^(products/)?download\.html', 'firefox.new', query=''),
 
@@ -253,12 +246,6 @@ redirectpatterns = (
     # bug 927442
     redirect(r'^(firefox/)?community/?', 'mozorg.contribute.index'),
 
-    # bug 1138280, bug 1200464
-    redirect(r'^ja/(firefox|thunderbird)/(beta/)?notes/?', 'https://www.mozilla.jp/{0}/{1}notes/',
-             locale_prefix=False),
-    redirect(r'^ja/(firefox|thunderbird)/((?:android/)?[0-9.]+(?:beta)?)/releasenotes/?',
-             'https://www.mozilla.jp/{0}/{1}/releasenotes/', locale_prefix=False),
-
     # bug 925551
     redirect(r'^plugincheck/more_info\.html$', 'mozorg.plugincheck'),
 
@@ -270,14 +257,6 @@ redirectpatterns = (
 
     # bug 957664
     redirect(r'^press/awards(?:/|\.html)?$', 'https://blog.mozilla.org/press/awards/'),
-
-    # bug 987059, 1050149, 1072170, 1208358
-    redirect(r'^ja/about/?$', 'https://www.mozilla.jp/about/mozilla/'),
-    redirect(r'^ja/about/japan/?$', 'https://www.mozilla.jp/about/japan/'),
-
-    # bug 1091977
-    redirect(r'^ja/contribute(?:/.*)?$', 'https://www.mozilla.jp/community/',
-             locale_prefix=False),
 
     # bug 885799, 952429
     redirect(r'^projects/calendar/holidays\.html$', 'mozorg.projects.holiday_calendars'),

--- a/tests/redirects/map_globalconf.py
+++ b/tests/redirects/map_globalconf.py
@@ -129,12 +129,6 @@ URLS = flatten((
     url_test('/ports/os2/', 'https://wiki.mozilla.org/Ports/os2'),
     url_test('/ports/other-things/', 'http://www-archive.mozilla.org/ports/other-things/'),
 
-    # bug 1013082
-    url_test('/ja/', 'https://www.mozilla.jp/'),
-
-    # bug 1051686
-    url_test('/ja/firefox/organizations/', 'https://www.mozilla.jp/business/'),
-
     # bug 1205632
     url_test('/js/language/',
              'https://developer.mozilla.org/docs/Web/JavaScript/Language_Resources'),
@@ -142,16 +136,6 @@ URLS = flatten((
     url_test('/js/language/es4/', 'http://www.ecmascript-lang.org'),
     url_test('/js/language/E262-3-errata.html',
              'http://www-archive.mozilla.org/js/language/E262-3-errata.html'),
-
-    # bug 1138280
-    url_test('/ja/firefox/beta/notes/', 'https://www.mozilla.jp/firefox/beta/notes/'),
-    url_test('/ja/thunderbird/notes/', 'https://www.mozilla.jp/thunderbird/notes/'),
-    url_test('/ja/thunderbird/android/2.2beta/releasenotes/',
-             'https://www.mozilla.jp/thunderbird/android/2.2beta/releasenotes/'),
-
-    # bug 987059, 1050149, 1072170, 1208358
-    url_test('/ja/about/', 'https://www.mozilla.jp/about/mozilla/'),
-    url_test('/ja/about/japan/', 'https://www.mozilla.jp/about/japan/'),
 
     # bug 927442
     url_test('{/firefox,}/community/', '/contribute/'),
@@ -226,9 +210,6 @@ URLS = flatten((
 
     # bug 882845
     url_test('/firefox/toolkit/download-to-your-devices/because-i-say-so/', '/firefox/new/'),
-
-    # bug 1091977
-    url_test('/ja/contribute/random/stuff/', 'https://www.mozilla.jp/community/'),
 
     # bug 1014823
     url_test('/pt-BR/{products/,}firefox/releases/whatsnew/', '/pt-BR/firefox/whatsnew/'),
@@ -951,10 +932,6 @@ URLS = flatten((
     url_test('/firefox/hello/feedbacksurvey/',
              'https://www.surveygizmo.com/s3/2319863/d2b7dc4b5687',
              status_code=requests.codes.found),
-
-    # bug 1224060
-    url_test('/ja/firefox/ios/1.0/{releasenotes,system-requirements}/',
-             'https://www.mozilla.jp/firefox/ios/1.0/{releasenotes,system-requirements}/'),
 
     # bug 1236791
     url_test('/en-US/firefox/new/?product=firefox-{3.6.8,13.0.1}{&os={osx〈=en-US,win},}',


### PR DESCRIPTION
## Description

Split from #4937. Simply remove all the redirects to mozilla.jp which have been added over the course of years as per requested by the Mozilla Japan team (including me). We have discussed today and decided to proceed with the change. The removal shouldn't require any confirmation or approval from MoCo management.

## Issue / Bugzilla link

[Bug 1384823](https://bugzilla.mozilla.org/show_bug.cgi?id=1384823)

## Testing

Visit `/ja/` or `/ja/about/` to make sure those URLs will no longer be redirected. Those pages have already been localized so you'll just get Japanese content there.