### PR TITLE
[fix bug 1385052] Update mailing address on privacy page

### DIFF
--- a/bedrock/privacy/templates/privacy/index.html
+++ b/bedrock/privacy/templates/privacy/index.html
@@ -45,10 +45,10 @@
         <span itemprop="name">Mozilla Corporation</span><br>
         <span itemprop="address" itemscope itemtype="http://schema.org/PostalAddress">
           {{ _('Attn:') }} <span itemprop="name">Legal Notices - Privacy</span><br>
-          <span itemprop="streetAddress">2 Harrison St</span>,<br>
-          <span itemprop="addressLocality">San Francisco</span>,
+          <span itemprop="streetAddress">331 E. Evelyn Ave</span>,<br>
+          <span itemprop="addressLocality">Mountain View</span>,
           <span itemprop="addressRegion">CA</span>
-          <span itemprop="postalCode">94105</span>
+          <span itemprop="postalCode">94041</span>
         </span>
       </p>
     </header>


### PR DESCRIPTION
## Description
Changing to the Mountain View office instead of San Francisco.

## Issue / Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1385052