### PR TITLE
update hall of fame to q2 2017 and remove thunderbird from faq

### DIFF
--- a/bedrock/security/templates/security/bug-bounty/faq.html
+++ b/bedrock/security/templates/security/bug-bounty/faq.html
@@ -44,18 +44,16 @@
           Bugzilla, Tinderbox, Bonsai, and other software created and distributed
           as part of the Mozilla project?</a></li>
         <li><a href="#most-recent">What do you mean by the "most recent
-          version" of Firefox, Firefox for Android, and/or Thunderbird?</a></li>
+          version" of Firefox, and/or Firefox for Android?</a></li>
         <li><a href="#older-releases">Can I get the bug bounty reward if I
-          discover a bug in an older release of Firefox, Firefox for Android,
-          and/or Thunderbird?</a></li>
+          discover a bug in an older release of Firefox, and/or Firefox for Android?
+          </a></li>
         <li><a href="#development-releases">Can I get the bug bounty reward if I
-          discover a bug in a pre-release version of Firefox, Firefox for Android, or
-          Thunderbird?</a></li>
+          discover a bug in a pre-release version of Firefox, and/or Firefox for Android?</a></li>
         <li><a href="#third-party-releases">Can I get the bug bounty reward
-          if I discover a bug that occurs in a third-party release of Firefox,
-          Firefox for Android, and/or Thunderbird (e.g., a localized build, optimized
-          build, or third-party Firefox, Firefox for Android, or Thunderbird
-          distribution)?</a></li>
+          if I discover a bug that occurs in a third-party release of Firefox, and/or 
+          Firefox for Android,(e.g., a localized build, optimized
+          build, or third-party Firefox, or Firefox for Android distribution)?</a></li>
         <li><a href="#platform-specific">Can I get the bug bounty reward if I
           discover a bug that occurs only on a particular operating system?</a></li>
       </ul>

--- a/bedrock/security/templates/security/bug-bounty/faq.html
+++ b/bedrock/security/templates/security/bug-bounty/faq.html
@@ -109,7 +109,7 @@
           Galeon, K-Meleon, Netscape 7, Mozilla Suite, SeaMonkey, or other products based on Mozilla code?</dt>
         <dd>
           <p>Only if we can reproduce the problem in the most recent version
-            of Firefox, Firefox for Android, and/or Thunderbird.</p>
+            of Firefox and/or Firefox for Android.</p>
         </dd>
 
         <dt id="bugzilla-etc">Does the bug bounty cover
@@ -122,8 +122,7 @@
         </dd>
 
         <dt id="most-recent">What do you mean by the
-          "most recent version" of Firefox, Firefox for Android, and/or
-          Thunderbird?</dt>
+          "most recent version" of Firefox, and/or Firefox for Android?</dt>
         <dd>
           <p>In general we mean the releases available for download on the <a
             href="{{ url('firefox.family.index') }}">mozilla.org download pages</a> at the time the
@@ -132,8 +131,8 @@
         </dd>
 
         <dt id="older-releases">Can I get the bug
-          bounty reward if I discover a bug in an older release of Firefox,
-          Firefox for Android, and/or Thunderbird?</dt>
+          bounty reward if I discover a bug in an older release of Firefox and/or 
+          Firefox for Android?</dt>
         <dd>
           <p>In general bugs found in earlier releases are eligible for a
             reward only if we can reproduce the problem using the most recent
@@ -150,21 +149,20 @@
         </dd>
 
         <dt id="development-releases">Can I get the bug bounty
-          reward if I discover a bug in a pre-release version of Firefox, Firefox for
-          Android, or Thunderbird?</dt>
+          reward if I discover a bug in a pre-release version of Firefox and/or 
+          Firefox for Android?</dt>
         <dd>
           <p>Yes, as long as the bug otherwise meets the published bug bounty
-            program guidelines. Bugs found in Developer Edition and Beta releases of Firefox and
-            Firefox for Android, EarlyBird and Beta releases of Thunderbird are eligible as
+            program guidelines. Bugs found in Nightly and Beta releases of Firefox and
+            Firefox for Android are eligible as
             long the bug is reproducible in the latest nightly mozilla-central build and has
             not been previously reported.</p>
         </dd>
 
         <dt id="third-party-releases">Can I get the bug
           bounty reward if I discover a bug that occurs in a third-party release
-          of Firefox, Firefox for Android, and/or Thunderbird (e.g., a localized
-          build, optimized build, or third-party Firefox, Firefox for Android, or
-          Thunderbird distribution)?</dt>
+          of Firefox, Firefox and/or Firefox for Android (e.g., a localized
+          build, optimized build, or third-party Firefox or Firefox for Android)?</dt>
         <dd>
           <p>Yes, if the bug can be reproduced in an official Mozilla
             Foundation release and otherwise meets the published guidelines.</p>
@@ -177,10 +175,9 @@
           <p>Yes, if the operating system is officially supported by the most
             recent version of the product for which you're reporting the bug. (For
             a list of supported operating systems and hardware configurations see
-            the system requirements for <a href="{{ url('firefox.sysreq') }}">Firefox</a>,
+            the system requirements for <a href="{{ url('firefox.sysreq') }}">Firefox</a> or
             <a href="{{ firefox_url('android', 'sysreq') }}">
-            Firefox for Android</a>, and <a href="{{ url('thunderbird.sysreq') }}">
-            Thunderbird</a>.)</p>
+            Firefox for Android</a>/p>
         </dd>
       </dl>
 

--- a/bedrock/security/templates/security/bug-bounty/hall-of-fame.html
+++ b/bedrock/security/templates/security/bug-bounty/hall-of-fame.html
@@ -36,6 +36,39 @@
       <section id="year-2017">
         <h3 data-accordion-role="tab">{{ _('2017') }}</h3>
         <div data-accordion-role="tabpanel">
+          <h4>2nd Quarter 2017</h4>
+          <ul>
+            <li>Abhishek Arya</li>
+            <li>ak1t4</li>
+            <li>Antonio Sanso</li>
+            <li>Arthur Edelstein [:arthuredelstein]</li>
+            <li>Attacker911india</li>
+            <li>Atte Kettunen</li>
+            <li>Brian Carpenter [:geeknik]</li>
+            <li>Chamal De Silva</li>
+            <li>Falko Strenzke</li>
+            <li>Francisco A.</li>
+            <li>gharris</li>
+            <li>Holger Fuhrmannek</li>
+            <li>Jun</li>
+            <li>Looben Yang</li>
+            <li>Michał Bentkowski</li>
+            <li>Muneaki Nishimura</li>
+            <li>Nils</li>
+            <li>ntrippan</li>
+            <li>Oliver Wagner</li>
+            <li>Rafael Gieschke</li>
+            <li>Ron Crane</li>
+            <li>Sam Erb</li>
+            <li>Samuel Groß</li>
+            <li>Seb Patane</li>
+            <li>Sergey</li>
+            <li>SkyLined</li>
+            <li>Takeshi Terada</li>
+            <li>Tobias Klein</li>
+            <li>Tyler Hawkins</li>
+            <li>Yuji Tounai</li>
+          </ul>
           <h4>1st Quarter 2017</h4>
           <ul>
             <li>ak1t4</li>


### PR DESCRIPTION
## Description

## Issue / Bugzilla link

## Testing
