### PR TITLE
[fix bug 1386434] /new variation for 'unsupported browser' referrals

### DIFF
--- a/bedrock/firefox/templates/firefox/new/sem/unsupported-browser/scene1.html
+++ b/bedrock/firefox/templates/firefox/new/sem/unsupported-browser/scene1.html
@@ -4,8 +4,15 @@
 
 {% extends "firefox/new/sem/base.html" %}
 
+{% block optimizely %}
+  {% if switch('firefox-new-unsupported-browser-optimizely', ['en-US']) %}
+    {% include 'includes/optimizely.html' %}
+  {% endif %}
+{% endblock %}
+
+
 {% block head_content %}
-  <h2 id="head_content_title" data-experience="compatible">
+  <h2 id="head_content_title" data-experience="unsupported-browser">
     Smooth and Reliable
   </h2>
 

--- a/bedrock/firefox/templates/firefox/new/sem/unsupported-browser/scene2.html
+++ b/bedrock/firefox/templates/firefox/new/sem/unsupported-browser/scene2.html
@@ -1,0 +1,33 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+
+{% extends "firefox/new/sem/base.html" %}
+
+{% block optimizely %}
+  {% if switch('firefox-new-unsupported-browser-optimizely', ['en-US']) %}
+    {% include 'includes/optimizely.html' %}
+  {% endif %}
+{% endblock %}
+
+{% block body_class %}fx-sem-scene2{% endblock %}
+
+{% block head_content %}
+  <h2>
+    Thanks for choosing Firefox
+  </h2>
+
+  <p>
+    Your download should begin automatically. <br>If not, <a id="direct-download-link" href="{{ url('firefox.all') }}">click here</a>.
+  </p>
+{% endblock %}
+
+{% block details_contain %}{% endblock %}
+{% block today %}{% endblock %}
+
+{% block js %}
+  {% if switch('tracking-pixel') %}
+    {% javascript 'firefox_new_pixel' %}
+  {% endif %}
+  {% javascript 'firefox_new_scene2' %}
+{% endblock %}

--- a/bedrock/firefox/tests/test_views.py
+++ b/bedrock/firefox/tests/test_views.py
@@ -521,6 +521,18 @@ class TestFirefoxNew(TestCase):
         views.new(req)
         render_mock.assert_called_once_with(req, 'firefox/new/sem/compatible/scene2.html')
 
+    def test_unsupported_browser_scene_1(self, render_mock):
+        req = RequestFactory().get('/firefox/new/?xv=unsupported-browser')
+        req.locale = 'en-US'
+        views.new(req)
+        render_mock.assert_called_once_with(req, 'firefox/new/sem/unsupported-browser/scene1.html')
+
+    def test_unsupported_browser_scene_2(self, render_mock):
+        req = RequestFactory().get('/firefox/new/?scene=2&xv=unsupported-browser')
+        req.locale = 'en-US'
+        views.new(req)
+        render_mock.assert_called_once_with(req, 'firefox/new/sem/unsupported-browser/scene2.html')
+
     # browse against the machine bug 1363802, 1364988.
 
     def test_batmfree_scene_1(self, render_mock):

--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -520,6 +520,8 @@ def new(request):
                 template = 'firefox/new/sem/nonprofit/scene2.html'
             elif experience == 'compatible':
                 template = 'firefox/new/sem/compatible/scene2.html'
+            elif experience == 'unsupported-browser':
+                template = 'firefox/new/sem/unsupported-browser/scene2.html'
             elif experience in ['batmfree', 'batmprivate', 'batmnimble', 'batmresist']:
                 template = 'firefox/new/batm/scene2.html'
             else:
@@ -557,6 +559,8 @@ def new(request):
                 template = 'firefox/new/sem/nonprofit/scene1.html'
             elif experience == 'compatible':
                 template = 'firefox/new/sem/compatible/scene1.html'
+            elif experience == 'unsupported-browser':
+                template = 'firefox/new/sem/unsupported-browser/scene1.html'
             elif experience == 'batmfree':
                 template = 'firefox/new/batm/free.html'
             elif experience == 'batmprivate':

--- a/media/css/firefox/new/sem.less
+++ b/media/css/firefox/new/sem.less
@@ -4,21 +4,6 @@
 
 @import '../../sandstone/lib.less';
 
-@font-face {
-    font-family: antoniobold;
-    src: url('/media/fonts/fx-lifestyle/antonio-bold-webfont.woff2') format('woff2'),
-         url('/media/fonts/fx-lifestyle/antonio-bold-webfont.woff') format('woff');
-    font-weight: normal;
-    font-style: normal;
-}
-
-h2,
-h3 {
-    font-family: antoniobold, 'Open Sans', sans-serif;
-    line-height: 1;
-    text-transform: uppercase;
-}
-
 #outer-wrapper {
     background: #efefef;
 }


### PR DESCRIPTION
## Description
- Adds a new sem page variation at `/firefox/new/?xv=unsupported-browser`
- Removes Antoniobold font from headings on all /sem page variations, [as requested here](https://bugzilla.mozilla.org/show_bug.cgi?id=1383063#c15).

Marking as do-not-merge for now, as I have a feeling supporting > IE8 for first-class CSS may not be enough for this one 😩 

## Issue / Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1386434

## Testing
TODO
