### PR TITLE
Add data-version attribute to security advisory links

### DIFF
--- a/bedrock/security/templates/security/product-advisories.html
+++ b/bedrock/security/templates/security/product-advisories.html
@@ -48,7 +48,7 @@
         </a></h3>
         <ul>
         {% for advisory in version.advisories.all() %}
-          <li class="level-item"><a href="{{ advisory.get_absolute_url() }}">
+          <li class="level-item"><a href="{{ advisory.get_absolute_url() }}" data=version="{{ version.html_id }}">
             <span class="level {{ advisory.impact_class }}">{{ advisory.id }}</span> {{ advisory.title|safe }}
           </a></li>
         {% endfor %}


### PR DESCRIPTION
## Description

PollBot is a collection of bots that poll for the state of things during the release process. One of these polls checks mozilla.org for a release's security advisories. This change adds a `data-version` attribute to the advisory links so it is easier for a scraper to locate and verify them. 

## Issue / Bugzilla link

https://github.com/mozilla/PollBot/issues/6

## Testing

(Please advise on how Bedrock tests HTML templates)