### PR TITLE
[fix bug 1383843] Remove LastPass from password manager feature page

### DIFF
--- a/bedrock/firefox/templates/firefox/features/password-manager.html
+++ b/bedrock/firefox/templates/firefox/features/password-manager.html
@@ -54,15 +54,22 @@
         <img src="{{ static('img/firefox/features/thumbnails/password-manager/addons.png') }}" alt="">
         <h3>{{ _('Password master') }}</h3>
         <p>
+      {% if l10n_has_tag('fxfeature-remove-lastpass') %}
+        {% trans addons='https://addons.mozilla.org/firefox/collections/mozilla/password-managers/' %}
+          Earn your second security black belt with Firefox’s vast array of password manager
+          <a href="{{ addons }}">add-ons</a>. Choose an existing favorite or find a next-level
+          one through expert community ratings and reviews.
+        {% endtrans %}
+      {% else %}
         {% trans addons='https://addons.mozilla.org/firefox/collections/mozilla/password-managers/',
-                 lastpass='https://addons.mozilla.org/firefox/addon/lastpass-password-manager/',
-                 manager='https://addons.mozilla.org/firefox/search/?q=password+manager'
+                 lastpass='https://addons.mozilla.org/firefox/addon/lastpass-password-manager/'
         %}
           Earn your second security black belt with Firefox’s vast array of password manager
           <a href="{{ addons }}">add-ons</a>. Go with a favorite like
           <a href="{{ lastpass }}">LastPass</a>, or reach password manager mastery with
           ratings and community reviews.
         {% endtrans %}
+      {% endif %}
         </p>
       </li>
     </ul>


### PR DESCRIPTION
## Description
Updates a string on the Password Manager page to avoid recommending a specific add-on since we can't guarantee its status with the move to WebExtensions. Uses the l10n tag `fxfeature-remove-lastpass`

## Issue / Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1383843
