### PR TITLE
[fix bug 1381601] Link to Dev Edition page from Dev Hub

### DIFF
--- a/bedrock/mozorg/templates/mozorg/developer/index.html
+++ b/bedrock/mozorg/templates/mozorg/developer/index.html
@@ -52,7 +52,7 @@
       <div class="developer-tools card card-image-large">
         <div class="card-content-wrapper">
           <div class="card-content">
-            <a href="https://developer.mozilla.org/docs/Tools?utm_source=www.mozilla.org&amp;utm_medium=referral&amp;utm_campaign=developer-hub" data-link-name="Firefox DevTools" data-link-type="link" data-link-position="Firefox DevTools">
+            <a href="{{ url('firefox.developer') }}" data-link-name="Firefox DevTools" data-link-type="link" data-link-position="Firefox DevTools">
               <h3 class="card-title">{{ _('Firefox DevTools') }}</h3>
             </a>
 
@@ -62,7 +62,7 @@
             {% endtrans %}
             </p>
 
-            <a href="https://developer.mozilla.org/docs/Tools?utm_source=www.mozilla.org&amp;utm_medium=referral&amp;utm_campaign=developer-hub" class="cta-link" data-link-name="Explore DevTools" data-link-type="link" data-link-position="Firefox DevTools">
+            <a href="{{ url('firefox.developer') }}" class="cta-link" data-link-name="Explore DevTools" data-link-type="link" data-link-position="Firefox DevTools">
               {{ _('Explore DevTools') }}
             </a>
           </div>
@@ -94,7 +94,7 @@
         </div>
 
         <div class="card">
-          <a class="card-image" href="https://developer.mozilla.org/docs/Tools?utm_source=www.mozilla.org&amp;utm_medium=referral&amp;utm_campaign=developer-hub" data-link-type="link" data-link-position="Developer resources" data-link-name="Firefox DevTools">
+          <a class="card-image" href="{{ url('firefox.developer') }}" data-link-type="link" data-link-position="Developer resources" data-link-name="Firefox DevTools">
             {{ lazy_image('img/mozorg/developer/hub/resource-devtools.jpg', lazy_image_placeholder) }}
             <h3 class="card-title">{{ _('Firefox DevTools') }}</h3>
           </a>
@@ -104,7 +104,7 @@
           </div>
 
           <p class="card-cta">
-            <a href="https://developer.mozilla.org/docs/Tools?utm_source=www.mozilla.org&amp;utm_medium=referral&amp;utm_campaign=developer-hub" class="cta-link" data-link-type="link" data-link-position="Developer resources" data-link-name="Learn more">{{ _('Learn more') }}</a>
+            <a href="{{ url('firefox.developer') }}" class="cta-link" data-link-type="link" data-link-position="Developer resources" data-link-name="Learn more">{{ _('Learn more') }}</a>
           </p>
         </div>
 


### PR DESCRIPTION
## Description
Updates the DevTools links to point to the redesigned Firefox Developer Edition page instead of MDN. No string changes, just link URLs.

## Issue / Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1381601
