### PR TITLE
[fix bug 1387034] L10n layout issue on /firstrun page

### DIFF
--- a/media/css/firefox/firstrun/onboarding.less
+++ b/media/css/firefox/firstrun/onboarding.less
@@ -84,24 +84,15 @@ img {
     height: 60%;
     float: left;
     margin: 79px 0;
-    position: relative;
-
-    img {
-        position: relative;
-        width: 250px;
-        height: auto;
-    }
 
     p {
-        margin: 0;
-        position: absolute;
+        margin: 0 0 40px;
         line-height: 150%;
         font-size: 1.1em;
     }
 
     a {
-        position: absolute;
-        bottom:0;
+        display: block;
         color: #edb200;
         font-size: .9em;
 


### PR DESCRIPTION
## Description
- Fixes an overlapping link issue on `/firstrun` that only effects longer strings on certain locales.

## Issue / Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1387034

## Testing
- Testing `de` or `fr` locales should no longer have the issue.
