### PR TITLE
[fix bug 1387205] Update Firefox hub third-party articles

### DIFF
--- a/bedrock/firefox/templates/firefox/hub/home.html
+++ b/bedrock/firefox/templates/firefox/hub/home.html
@@ -150,27 +150,27 @@
         <section id="third-party-feed">
           <div class="card card-stacked">
             <div class="card-content">
-              <a rel="external" href="http://www.makeuseof.com/tag/switch-chrome-firefox/" data-link-name="Bye Bye Chrome! Why We Switched to Firefox" data-link-type="link" data-link-position="1">
+              <a rel="external" href="https://www.cnet.com/special-reports/mozilla-firefox-fights-back-against-google-chrome/" data-link-name="Firefox Fights Back" data-link-type="link" data-link-position="1">
                 <blockquote class="quote">
-                  Bye Bye Chrome! Why We Switched to Firefox
+                  Firefox Fights Back
                 </blockquote>
               </a>
 
-              <a rel="external" href="http://www.makeuseof.com/tag/switch-chrome-firefox/" class="cta-link" data-link-name="Bye Bye Chrome! Why We Switched to Firefox" data-link-type="link" data-link-position="1">
-                MakeUseOf
+              <a rel="external" href="https://www.cnet.com/special-reports/mozilla-firefox-fights-back-against-google-chrome/" class="cta-link" data-link-name="Firefox Fights Back" data-link-type="link" data-link-position="1">
+                CNET
               </a>
             </div>
           </div>
           <div class="card card-stacked">
             <div class="card-content">
-              <a rel="external" href="https://www.theverge.com/2017/6/14/15802102/firefox-54-update-faster-less-memory" data-link-name="Firefox hogs less memory and gets a speed bump in its latest update" data-link-type="link" data-link-position="2">
+              <a rel="external" href="http://www.makeuseof.com/tag/switch-chrome-firefox/" data-link-name="Bye Bye Chrome! Why We Switched to Firefox" data-link-type="link" data-link-position="2">
                 <blockquote class="quote">
-                  Firefox hogs less memory and gets a speed bump in its latest update
+                  Bye Bye Chrome! Why We Switched to Firefox
                 </blockquote>
               </a>
 
-              <a rel="external" href="https://www.theverge.com/2017/6/14/15802102/firefox-54-update-faster-less-memory" class="cta-link" data-link-name="Firefox hogs less memory and gets a speed bump in its latest update" data-link-type="link" data-link-position="2">
-                The Verge
+              <a rel="external" href="http://www.makeuseof.com/tag/switch-chrome-firefox/" class="cta-link" data-link-name="Bye Bye Chrome! Why We Switched to Firefox" data-link-type="link" data-link-position="2">
+                MakeUseOf
               </a>
             </div>
           </div>


### PR DESCRIPTION
## Description
Adds CNET article in first position, moves MakeUseOf article to second position, and removes Verge article.

## Issue / Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1387205
