### PR TITLE
Ensure failed blog featured_media does not break pages

### DIFF
--- a/bedrock/wordpress/api.py
+++ b/bedrock/wordpress/api.py
@@ -54,11 +54,14 @@ def get_posts_data(feed_id, num_posts=None):
     for post in posts:
         post['tags'] = [tags[t] for t in post['tags']]
         # some blogs set featured_media to 0 when none is set
-        if 'featured_media' in post and post['featured_media']:
-            media = get_wp_data(feed_id, 'media', post['featured_media'])
-            if media:
-                post['featured_media'] = media
-        else:
+        if 'featured_media' in post:
+            if post['featured_media']:
+                media = get_wp_data(feed_id, 'media', post['featured_media'])
+                if media:
+                    post['featured_media'] = media
+                    continue
+
+            # blank featured_media value if anything went wrong
             post['featured_media'] = {}
 
     return {

--- a/bedrock/wordpress/models.py
+++ b/bedrock/wordpress/models.py
@@ -144,5 +144,5 @@ class BlogPost(models.Model):
     def get_featured_image_url(self, size='large'):
         try:
             return self.featured_media['media_details']['sizes'][size]['source_url']
-        except KeyError:
+        except (KeyError, TypeError):
             return None

--- a/bedrock/wordpress/tests/test_data/posts.json
+++ b/bedrock/wordpress/tests/test_data/posts.json
@@ -24,7 +24,7 @@
             "protected": false
         },
         "author": 144,
-        "featured_media": 0,
+        "featured_media": 42,
         "comment_status": "closed",
         "ping_status": "closed",
         "sticky": false,


### PR DESCRIPTION
* Reset featured_media to empty dict for any problem
* Add tests for failed media fetching
* Catch TypeError in model method to ensure it won't break for users