### PR TITLE
[fix bug 1359617] Change health subpages to standard subnav

### DIFF
--- a/bedrock/mozorg/templates/mozorg/internet-health/decentralization.html
+++ b/bedrock/mozorg/templates/mozorg/internet-health/decentralization.html
@@ -29,15 +29,7 @@
 {% endblock %}
 
 {% block content %}
-<nav id="health-subnav" class="health-subnav">
-  <ul class="content">
-    <li><a href="{{ url('mozorg.internet-health.privacy-security') }}">{{ _('Privacy &amp; Security') }}</a></li>
-    <li><a href="{{ url('mozorg.internet-health.open-innovation') }}">{{ _('Open Innovation') }}</a></li>
-    <li class="current"><a href="{{ url('mozorg.internet-health.decentralization') }}">{{ _('Decentralization') }}</a></li>
-    <li><a href="{{ url('mozorg.internet-health.digital-inclusion') }}">{{ _('Digital Inclusion') }}</a></li>
-    <li><a href="{{ url('mozorg.internet-health.web-literacy') }}">{{ _('Web Literacy') }}</a></li>
-  </ul>
-</nav>
+{% include 'mozorg/internet-health/includes/sub-nav.html' %}
 
 <main role="main">
   <header class="section main-header">

--- a/bedrock/mozorg/templates/mozorg/internet-health/digital-inclusion.html
+++ b/bedrock/mozorg/templates/mozorg/internet-health/digital-inclusion.html
@@ -29,15 +29,7 @@
 {% endblock %}
 
 {% block content %}
-<nav id="health-subnav" class="health-subnav">
-  <ul class="content">
-    <li><a href="{{ url('mozorg.internet-health.privacy-security') }}">{{ _('Privacy &amp; Security') }}</a></li>
-    <li><a href="{{ url('mozorg.internet-health.open-innovation') }}">{{ _('Open Innovation') }}</a></li>
-    <li><a href="{{ url('mozorg.internet-health.decentralization') }}">{{ _('Decentralization') }}</a></li>
-    <li class="current"><a href="{{ url('mozorg.internet-health.digital-inclusion') }}">{{ _('Digital Inclusion') }}</a></li>
-    <li><a href="{{ url('mozorg.internet-health.web-literacy') }}">{{ _('Web Literacy') }}</a></li>
-  </ul>
-</nav>
+{% include 'mozorg/internet-health/includes/sub-nav.html' %}
 
 <main role="main">
   <header class="section main-header">

--- a/bedrock/mozorg/templates/mozorg/internet-health/includes/sub-nav.html
+++ b/bedrock/mozorg/templates/mozorg/internet-health/includes/sub-nav.html
@@ -9,13 +9,7 @@
 {% block sub_nav_primary_links %}
 <li><a href="{{ url('mozorg.internet-health') }}" data-link-name="About" data-link-type="nav" data-link-position="subnav">{{ _('About') }}</a></li>
 <li><a href="{{ url('mozorg.internet-health.privacy-security') }}" data-link-name="Privacy & Security" data-link-type="nav" data-link-position="subnav">{{ _('Privacy &amp; Security') }}</a></li>
-<li><a href="{{ url('mozorg.internet-health.open-innovation') }}" data-link-name="Openness" data-link-type="nav" data-link-position="subnav">
-  {% if l10n_has_tag('health-june-campaign-updates') %}
-    {{ _('Openness') }}
-  {% else %}
-    {{ _('Open Innovation') }}
-  {% endif %}
-</a></li>
+<li><a href="{{ url('mozorg.internet-health.open-innovation') }}" data-link-name="Openness" data-link-type="nav" data-link-position="subnav">{{ _('Openness') }}</a></li>
 <li><a href="{{ url('mozorg.internet-health.decentralization') }}" data-link-name="Decentralization" data-link-type="nav" data-link-position="subnav">{{ _('Decentralization') }}</a></li>
 <li><a href="{{ url('mozorg.internet-health.digital-inclusion') }}" data-link-name="Digital Inclusion" data-link-type="nav" data-link-position="subnav">{{ _('Digital Inclusion') }}</a></li>
 <li><a href="{{ url('mozorg.internet-health.web-literacy') }}" data-link-name="Web Literacy" data-link-type="nav" data-link-position="subnav">{{ _('Web Literacy') }}</a></li>

--- a/bedrock/mozorg/templates/mozorg/internet-health/open-innovation.html
+++ b/bedrock/mozorg/templates/mozorg/internet-health/open-innovation.html
@@ -29,15 +29,7 @@
 {% endblock %}
 
 {% block content %}
-<nav id="health-subnav" class="health-subnav">
-  <ul class="content">
-    <li><a href="{{ url('mozorg.internet-health.privacy-security') }}">{{ _('Privacy &amp; Security') }}</a></li>
-    <li class="current"><a href="{{ url('mozorg.internet-health.open-innovation') }}">{{ _('Open Innovation') }}</a></li>
-    <li><a href="{{ url('mozorg.internet-health.decentralization') }}">{{ _('Decentralization') }}</a></li>
-    <li><a href="{{ url('mozorg.internet-health.digital-inclusion') }}">{{ _('Digital Inclusion') }}</a></li>
-    <li><a href="{{ url('mozorg.internet-health.web-literacy') }}">{{ _('Web Literacy') }}</a></li>
-  </ul>
-</nav>
+{% include 'mozorg/internet-health/includes/sub-nav.html' %}
 
 <main role="main">
   <header class="section main-header">

--- a/bedrock/mozorg/templates/mozorg/internet-health/privacy-security.html
+++ b/bedrock/mozorg/templates/mozorg/internet-health/privacy-security.html
@@ -33,15 +33,7 @@
 {% endblock %}
 
 {% block content %}
-<nav id="health-subnav" class="health-subnav">
-  <ul class="content">
-    <li class="current"><a href="{{ url('mozorg.internet-health.privacy-security') }}">{{ _('Privacy &amp; Security') }}</a></li>
-    <li><a href="{{ url('mozorg.internet-health.open-innovation') }}">{{ _('Open Innovation') }}</a></li>
-    <li><a href="{{ url('mozorg.internet-health.decentralization') }}">{{ _('Decentralization') }}</a></li>
-    <li><a href="{{ url('mozorg.internet-health.digital-inclusion') }}">{{ _('Digital Inclusion') }}</a></li>
-    <li><a href="{{ url('mozorg.internet-health.web-literacy') }}">{{ _('Web Literacy') }}</a></li>
-  </ul>
-</nav>
+{% include 'mozorg/internet-health/includes/sub-nav.html' %}
 
 <main role="main">
   <header class="section main-header">

--- a/bedrock/mozorg/templates/mozorg/internet-health/web-literacy.html
+++ b/bedrock/mozorg/templates/mozorg/internet-health/web-literacy.html
@@ -29,15 +29,7 @@
 {% endblock %}
 
 {% block content %}
-<nav id="health-subnav" class="health-subnav">
-  <ul class="content">
-    <li><a href="{{ url('mozorg.internet-health.privacy-security') }}">{{ _('Privacy &amp; Security') }}</a></li>
-    <li><a href="{{ url('mozorg.internet-health.open-innovation') }}">{{ _('Open Innovation') }}</a></li>
-    <li><a href="{{ url('mozorg.internet-health.decentralization') }}">{{ _('Decentralization') }}</a></li>
-    <li><a href="{{ url('mozorg.internet-health.digital-inclusion') }}">{{ _('Digital Inclusion') }}</a></li>
-    <li class="current"><a href="{{ url('mozorg.internet-health.web-literacy') }}">{{ _('Web Literacy') }}</a></li>
-  </ul>
-</nav>
+{% include 'mozorg/internet-health/includes/sub-nav.html' %}
 
 <main role="main">
   <header class="section main-header">

--- a/bedrock/settings/static_media.py
+++ b/bedrock/settings/static_media.py
@@ -1670,6 +1670,9 @@ PIPELINE_JS = {
     },
     'internet-health-subpage': {
         'source_filenames': (
+            'js/libs/jquery.waypoints.min.js',
+            'js/libs/jquery.waypoints-sticky.min.js',
+            'js/hubs/sub-nav.js',
             'js/base/mozilla-smoothscroll.js',
             'js/mozorg/internet-health/health-subpage.js',
         ),

--- a/media/css/mozorg/internet-health/health-subpage.scss
+++ b/media/css/mozorg/internet-health/health-subpage.scss
@@ -4,6 +4,7 @@
 
 @import '../../pebbles/includes/lib';
 @import '../../pebbles/components/newsletter';
+@import '../../hubs/sub-nav';
 
 
 //* -------------------------------------------------------------------------- */
@@ -169,7 +170,7 @@ main .content {
         }
 
         .download-link {
-            @include font-size(14px);
+            @include font-size-small;
             border-radius: 0;
             border: none;
             padding: 15px 20px;
@@ -247,52 +248,6 @@ html[dir="rtl"] {
 
 
 //*--------------------------------------------------------------------------*/
-// Health subpages navigation
-.health-subnav {
-    @include open-sans;
-    background-color: #000;
-    text-transform: lowercase;
-
-    .content {
-        padding: 0;
-    }
-
-    a {
-        color: #fff;
-        display: block;
-        padding: .25em 20px;
-        text-decoration: none;
-
-        &:hover,
-        &:focus {
-            color: #fff;
-            text-decoration: underline;
-        }
-    }
-
-    .current a {
-        color: #000;
-        background-color: #eee;
-    }
-
-    @media #{$mq-phone-wide} {
-        .content {
-            padding: 0 20px;
-        }
-
-        li {
-            display: inline-block;
-        }
-
-        a {
-            display: block;
-            padding: 1em 20px;
-        }
-    }
-}
-
-
-//*--------------------------------------------------------------------------*/
 // Main page header
 .main-header {
     position: relative;
@@ -311,11 +266,7 @@ html[dir="rtl"] {
 }
 
 .head-intro {
-    @include font-size(18px);
-
-    @media #{$mq-tablet} {
-        @include font-size(24px);
-    }
+    @include font-size-level4;
 }
 
 .head-pagenav {
@@ -324,7 +275,7 @@ html[dir="rtl"] {
 
     .head-pagenav-title {
         @include box-decoration-break(clone);
-        @include font-size(18px);
+        @include font-size-level5;
         background-color: #fff;
         color: #000;
         display: inline-block;
@@ -436,12 +387,11 @@ html[dir="rtl"] {
 }
 
 .topic-intro-main {
-    @include font-size(18px);
+    @include font-size-level4;
     border-top: 4px solid $color-text-secondary;
     padding-top: 2em;
 
     @media #{$mq-tablet} {
-        @include font-size(20px);
         padding-left: 40px;
         padding-right: 40px;
     }
@@ -467,7 +417,7 @@ html[dir="rtl"] {
 }
 
 .topic-intro-aside {
-    @include font-size(18px);
+    @include font-size-level4;
     overflow: hidden;
     padding: 20px;
     position: relative;
@@ -480,7 +430,7 @@ html[dir="rtl"] {
     }
 
     .note-source {
-        @include font-size(14px);
+        @include font-size-small;
         @include open-sans;
         margin: 0;
 
@@ -511,18 +461,13 @@ html[dir="rtl"] {
     }
 
     @media #{$mq-tablet} {
-        @include font-size(26px);
         padding: 30px 15%;
     }
 }
 
 .topic-tagline {
-    @include font-size(20px);
+    @include font-size-level4;
     font-style: italic;
-
-    @media #{$mq-tablet} {
-        @include font-size(26px);
-    }
 }
 
 .topic-action {
@@ -564,7 +509,7 @@ html[dir="rtl"] {
 // Health report
 
 .health-report {
-    @include font-size(20px);
+    @include font-size-level4;
     background-color: $color-brand-neonblue;
 
     a:link,
@@ -591,7 +536,6 @@ html[dir="rtl"] {
 
     @media #{$mq-tablet} {
         @include at2x('/media/img/mozorg/internet-health/healthreport.png', 750px, 423px);
-        @include font-size(24px);
         background-position: right top;
         background-repeat: no-repeat;
         min-height: 150px;
@@ -631,7 +575,6 @@ html[dir="rtl"] {
         width: auto;
 
         h4 {
-            @include font-size(20px);
             line-height: 1.4;
         }
     }
@@ -690,7 +633,7 @@ html[dir="rtl"] {
 
     // Health report
     .health-report {
-        @include font-size(20px);
+        @include font-size-level4;
         background: #52fffe;
         padding: 20px 0;
 
@@ -716,10 +659,6 @@ html[dir="rtl"] {
             display: inline;
             background: #feeb33;
             padding: 0 20px;
-        }
-
-        @media #{$mq-tablet} {
-            @include font-size(24px);
         }
     }
 
@@ -756,7 +695,6 @@ html[dir="rtl"] {
             width: auto;
 
             h4 {
-                @include font-size(20px);
                 line-height: 1.4;
             }
         }


### PR DESCRIPTION
## Description
Use the common subnav include on health subpages, which gives us the "Openness" text change the bug originally requested while also paying down a little tech debt. This removes some strings from the various subpages.

The common subnav uses the tag `health-june-campaign-updates` but perhaps we have enough coverage now to remove it? https://l10n.mozilla-community.org/langchecker/?locale=all&website=0&file=mozorg/internet-health/shared.lang

## Issue / Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1359617
