### PR TITLE
[fix bug 1388535] Fix JS error on banner init and plugincheck.

### DIFF
--- a/media/js/base/mozilla-notification-banner-init.js
+++ b/media/js/base/mozilla-notification-banner-init.js
@@ -71,7 +71,7 @@ $(function() {
     Mozilla.NotificationBanner.COOKIE_CODE_ID = 'moz-notification-fx-out-of-date';
 
     // Notification should only be shown to users on Firefox for desktop.
-    if (client._isFirefoxDesktop) {
+    if (client.isFirefoxDesktop) {
         client.getFirefoxDetails(function(details) {
             // User must be out of date and on release channel.
             if (!details.isUpToDate && details.channel === 'release') {

--- a/media/js/plugincheck/plugincheck-update.js
+++ b/media/js/plugincheck/plugincheck-update.js
@@ -8,7 +8,7 @@
     var client = window.Mozilla.Client;
     var body = $('body');
 
-    if (client._isFirefoxDesktop) {
+    if (client.isFirefoxDesktop) {
         client.getFirefoxDetails(function(details) {
             if (details.isUpToDate && details.channel === 'release') {
                 body.addClass('firefox-current');


### PR DESCRIPTION
## Description

Looks like maybe a copy pasta virus. Tricky one to catch in code review, as the bug always resulted in `true` (as the function *does* exist).

## Issue / Bugzilla link

https://bugzilla.mozilla.org/show_bug.cgi?id=1388535

## Testing

Ensure the errors are gone for non-Fx browsers, and that the code still functions as expected in Fx.
