### PR TITLE
Firefox retention thank you pages fix canvas after tab change.

### DIFF
--- a/media/js/etc/firefox/retention/confetti.js
+++ b/media/js/etc/firefox/retention/confetti.js
@@ -45,6 +45,7 @@
             defaultOpacity = 1;
         } else {
             window.addEventListener('resize', resizeWindow, false);
+            window.addEventListener('focus', resizeWindow, false);
         }
 
         var confettiSize = 6;


### PR DESCRIPTION
## Description
On FF nightly, if you open one of the Retention pages, tab away, and tab back after a few seconds, the canvas stops drawing.

This resets it. I'm trying to get a better understanding as to why, as it's something that's new in nightly and not on stable. Might even be a reproducible bug. I'll keep digging, but for now I don't see why not have people looking at this patch in it's current state.