### PR TITLE
Fix bug 1389178: Dev Edition notes redirect to beta

### DIFF
--- a/bedrock/releasenotes/tests/test_base.py
+++ b/bedrock/releasenotes/tests/test_base.py
@@ -358,10 +358,10 @@ class TestNotesRedirects(TestCase):
                    '/firefox/23.0beta/releasenotes/')
 
     @patch('bedrock.releasenotes.views.firefox_desktop.latest_version',
-           Mock(return_value='24.0a2'))
+           Mock(return_value='23.0b1'))
     def test_desktop_developer_version(self):
         self._test('/firefox/developer/notes/',
-                   '/firefox/24.0a2/auroranotes/')
+                   '/firefox/23.0beta/releasenotes/')
 
     @patch('bedrock.releasenotes.views.firefox_desktop.latest_version',
            Mock(return_value='24.2.0esr'))
@@ -429,10 +429,10 @@ class TestSysreqRedirect(TestCase):
                    '/firefox/23.0beta/system-requirements/')
 
     @patch('bedrock.releasenotes.views.firefox_desktop.latest_version',
-           Mock(return_value='24.0a2'))
+           Mock(return_value='23.0b1'))
     def test_desktop_developer_version(self):
         self._test('/firefox/developer/system-requirements/',
-                   '/firefox/24.0a2/system-requirements/')
+                   '/firefox/23.0beta/system-requirements/')
 
     @patch('bedrock.releasenotes.views.firefox_desktop.latest_version',
            Mock(return_value='24.2.0esr'))

--- a/bedrock/releasenotes/views.py
+++ b/bedrock/releasenotes/views.py
@@ -146,7 +146,9 @@ def latest_notes(request, product='firefox', platform=None, channel=None):
 
     if not channel:
         channel = 'release'
-    if channel in ['aurora', 'developer']:
+    if channel == 'developer':
+        channel = 'beta'
+    if channel == 'aurora':
         channel = 'alpha'
     if channel == 'organizations':
         channel = 'esr'
@@ -165,8 +167,8 @@ def latest_notes(request, product='firefox', platform=None, channel=None):
     if channel == 'esr':
         version = re.sub(r'esr$', '', version)
 
-    dir = 'auroranotes' if channel == 'alpha' else 'releasenotes'
-    path = [product, version, dir]
+    notes_dir = 'auroranotes' if channel == 'alpha' else 'releasenotes'
+    path = [product, version, notes_dir]
     locale = getattr(request, 'locale', None)
     if product == 'firefox' and platform != 'desktop':
         path.insert(1, platform)
@@ -177,7 +179,7 @@ def latest_notes(request, product='firefox', platform=None, channel=None):
 
 def latest_sysreq(request, channel, product):
     if product == 'firefox' and channel == 'developer':
-        channel = 'alpha'
+        channel = 'beta'
     if channel == 'organizations':
         channel = 'esr'
 


### PR DESCRIPTION
They were still redirecting to aurora notes, which is now stuck at an old version as well. Sys Requirments redirect had the same problem.