### PR TITLE
[fix bug 1386622] Advanced install strings on /new

### DIFF
--- a/bedrock/firefox/templates/firefox/new/onboarding/scene1.html
+++ b/bedrock/firefox/templates/firefox/new/onboarding/scene1.html
@@ -85,7 +85,23 @@
                 <li><a class="more" href="{{ url('firefox.family.index') }}">{{_('Discover all the ways to take Firefox on the go')}}</a></li>
               </ul>
             </div>
-            <button id="other-platforms-modal-link" class="hidden" type="button">{{_('Firefox for Other Platforms & Languages')}}</button>
+
+            <div class="other-downloads">
+              <p>
+                <button id="other-platforms-modal-link" class="hidden" type="button">
+                {% if l10n_has_tag('firefox_new_install_options') %}
+                  {{ _('Firefox for advanced install options or operating systems') }}
+                {% else %}
+                  {{_('Firefox for Other Platforms & Languages')}}
+                {% endif %}
+                </button>
+              </p>
+
+            {% if l10n_has_tag('firefox_new_install_options') %}
+              <p><a href="{{ url('firefox.all') }}">{{ _('Download Firefox for different languages') }}</a></p>
+            {% endif %}
+            </div>
+
             <section id="benefits">
               <ul>
                 <li>
@@ -118,7 +134,13 @@
   <div id="other-platforms">
     <div class="container">
       <section class="section-other-platforms">
-        <h4>{{_('Firefox for other platforms') }}</h4>
+        <h4>
+        {% if l10n_has_tag('firefox_new_install_options') %}
+          {{ _('Advanced install options') }}
+        {% else %}
+          {{_('Firefox for other platforms') }}
+        {% endif %}
+        </h4>
 
         {{ download_firefox_desktop_list() }}
 


### PR DESCRIPTION
## Description
Updates text on /firefox/new to mention "advanced install options." That phrase is used in a new streamlined stub installer to guide people to a full download if they need more control over their installation.

The new strings are behind the tag `firefox_new_install_options`

## Issue / Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1386622