### PR TITLE
[fix bug 1388871] Promote update banner winning copy.

### DIFF
--- a/bedrock/base/templates/base-pebbles.html
+++ b/bedrock/base/templates/base-pebbles.html
@@ -85,6 +85,9 @@
       data-global-next="{{ _('Next') }}"
       data-global-previous="{{ _('Previous') }}"
       data-global-update-firefox="{{ _('Update your Firefox') }}"
+      data-global-fx-out-of-date-banner-heading="{{ _('Your Firefox is out-of-date.') }}"
+      data-global-fx-out-of-date-banner-message="{{ _('Get the most recent version to keep browsing securely.') }}"
+      data-global-fx-out-of-date-banner-confirm="{{ _('Update Firefox') }}"
       {% block string_data %}{% endblock %}></div>
 
   {% block site_header %}

--- a/bedrock/base/templates/base-resp.html
+++ b/bedrock/base/templates/base-resp.html
@@ -83,6 +83,9 @@
       data-global-next="{{ _('Next') }}"
       data-global-previous="{{ _('Previous') }}"
       data-global-update-firefox="{{ _('Update your Firefox') }}"
+      data-global-fx-out-of-date-banner-heading="{{ _('Your Firefox is out-of-date.') }}"
+      data-global-fx-out-of-date-banner-message="{{ _('Get the most recent version to keep browsing securely.') }}"
+      data-global-fx-out-of-date-banner-confirm="{{ _('Update Firefox') }}"
       {% block string_data %}{% endblock %}></div>
 
     {% block global_nav %}

--- a/bedrock/base/templates/base.html
+++ b/bedrock/base/templates/base.html
@@ -83,6 +83,9 @@
       data-global-next="{{ _('Next') }}"
       data-global-previous="{{ _('Previous') }}"
       data-global-update-firefox="{{ _('Update your Firefox') }}"
+      data-global-fx-out-of-date-banner-heading="{{ _('Your Firefox is out-of-date.') }}"
+      data-global-fx-out-of-date-banner-message="{{ _('Get the most recent version to keep browsing securely.') }}"
+      data-global-fx-out-of-date-banner-confirm="{{ _('Update Firefox') }}"
       {% block string_data %}{% endblock %}></div>
     <div id="outer-wrapper">
     <div id="wrapper">

--- a/media/js/base/mozilla-notification-banner-init.js
+++ b/media/js/base/mozilla-notification-banner-init.js
@@ -7,65 +7,35 @@ $(function() {
     'use strict';
 
     var client = window.Mozilla.Client;
+    var utils = window.Mozilla.Utils;
 
-    var options = [
-        {
-            'id': 'fx-out-of-date-banner-copy1-direct-1',
-            'name': 'fx-out-of-date',
-            'experimentName': 'fx-out-of-date-banner-copy1',
-            'experimentVariant': 'direct-1',
-            'heading': 'Your browser security is at risk.',
-            'message': 'Update Firefox now to protect yourself from the latest malware.',
-            'confirm': 'Update now',
-            'confirmAction': 'Update Firefox',
-            'confirmLabel': 'Firefox for Desktop',
-            'url': '/firefox/new/?scene=2',
-            'close': 'Close',
-            'closeLabel': 'Close'
-        },
-        {
-            'id': 'fx-out-of-date-banner-copy1-direct-2',
-            'name': 'fx-out-of-date',
-            'experimentName': 'fx-out-of-date-banner-copy1',
-            'experimentVariant': 'direct-2',
-            'heading': 'Your Firefox is out-of-date.',
-            'message': 'Get the most recent version to keep browsing securely.',
-            'confirm': 'Update Firefox',
-            'confirmAction': 'Update Firefox',
-            'confirmLabel': 'Firefox for Desktop',
-            'url': '/firefox/new/?scene=2',
-            'close': 'Close',
-            'closeLabel': 'Close'
-        },
-        {
-            'id': 'fx-out-of-date-banner-copy1-foxy-1',
-            'name': 'fx-out-of-date',
-            'experimentName': 'fx-out-of-date-banner-copy1',
-            'experimentVariant': 'foxy-1',
-            'heading': 'Psst… it’s time for a tune up',
-            'message': 'Stay safe and fast with a quick update.',
-            'confirm': 'Update Firefox',
-            'confirmAction': 'Update Firefox',
-            'confirmLabel': 'Firefox for Desktop',
-            'url': '/firefox/new/?scene=2',
-            'close': 'Close',
-            'closeLabel': 'Close'
-        },
-        {
-            'id': 'fx-out-of-date-banner-copy1-foxy-2',
-            'name': 'fx-out-of-date',
-            'experimentName': 'fx-out-of-date-banner-copy1',
-            'experimentVariant': 'foxy-2',
-            'heading': 'Time to browse better!',
-            'message': 'Get the latest version of Firefox for extra speed and safety.',
-            'confirm': 'Update now',
-            'confirmAction': 'Update Firefox',
-            'confirmLabel': 'Firefox for Desktop',
-            'url': '/firefox/new/?scene=2',
-            'close': 'Close',
-            'closeLabel': 'Close'
-        }
-    ];
+    var headingText;
+    var messageText;
+    var confirmText;
+    var closeText;
+
+    // try to get localized copy
+    // if any of the below fail, the banner will detect missing strings and
+    // will not initialize
+    if (typeof utils !== 'undefined') {
+        headingText = utils.trans('global-fx-out-of-date-banner-heading');
+        messageText = utils.trans('global-fx-out-of-date-banner-message');
+        confirmText = utils.trans('global-fx-out-of-date-banner-confirm');
+        closeText = utils.trans('global-close');
+    }
+
+    var config = {
+        'id': 'fx-out-of-date-banner',
+        'name': 'fx-out-of-date',
+        'heading': headingText,
+        'message': messageText,
+        'confirm': confirmText,
+        'url': '/firefox/new/?scene=2',
+        'close': closeText,
+        'gaConfirmAction': 'Update Firefox', // GA - English only
+        'gaConfirmLabel': 'Firefox for Desktop', // GA - English only
+        'gaCloseLabel': 'Close' // GA - English only
+    };
 
     // Set a unique cookie ID for fx-out-of-date notification.
     Mozilla.NotificationBanner.COOKIE_CODE_ID = 'moz-notification-fx-out-of-date';
@@ -78,11 +48,7 @@ $(function() {
 
                 // Check that cookies are enabled before seeing if one already exists.
                 if (typeof Mozilla.Cookies !== 'undefined' && Mozilla.Cookies.enabled()) {
-                    var choice = Mozilla.NotificationBanner.getOptions(options);
-
-                    if (choice) {
-                        Mozilla.NotificationBanner.init(choice);
-                    }
+                    Mozilla.NotificationBanner.init(config);
                 }
             }
         });

--- a/media/js/base/mozilla-notification-banner-modal-init.js
+++ b/media/js/base/mozilla-notification-banner-modal-init.js
@@ -7,76 +7,43 @@ $(function() {
     'use strict';
 
     var client = window.Mozilla.Client;
+    var utils = window.Mozilla.Utils;
+
+    var headingText;
+    var messageText;
+    var confirmText;
+    var closeText;
 
     var _clickCallback = function() {
         Mozilla.Modal.createModal(this, $('.notification-modal-content'));
     };
 
-    var options = [
-        {
-            'id': 'fx-out-of-date-banner-copy1-direct-1',
-            'name': 'fx-out-of-date',
-            'experimentName': 'fx-out-of-date-banner-copy1',
-            'experimentVariant': 'direct-1',
-            'heading': 'Your browser security is at risk.',
-            'message': 'Update Firefox now to protect yourself from the latest malware.',
-            'confirm': 'Update now',
-            'confirmAction': 'Update Firefox',
-            'confirmLabel': 'Firefox for Desktop',
-            'confirmClick': _clickCallback,
-            'url': '/firefox/new/?scene=2',
-            'close': 'Close',
-            'closeLabel': 'Close'
-        },
-        {
-            'id': 'fx-out-of-date-banner-copy1-direct-2',
-            'name': 'fx-out-of-date',
-            'experimentName': 'fx-out-of-date-banner-copy1',
-            'experimentVariant': 'direct-2',
-            'heading': 'Your Firefox is out-of-date.',
-            'message': 'Get the most recent version to keep browsing securely.',
-            'confirm': 'Update Firefox',
-            'confirmAction': 'Update Firefox',
-            'confirmLabel': 'Firefox for Desktop',
-            'confirmClick': _clickCallback,
-            'url': '/firefox/new/?scene=2',
-            'close': 'Close',
-            'closeLabel': 'Close'
-        },
-        {
-            'id': 'fx-out-of-date-banner-copy1-foxy-1',
-            'name': 'fx-out-of-date',
-            'experimentName': 'fx-out-of-date-banner-copy1',
-            'experimentVariant': 'foxy-1',
-            'heading': 'Psst… it’s time for a tune up',
-            'message': 'Stay safe and fast with a quick update.',
-            'confirm': 'Update Firefox',
-            'confirmAction': 'Update Firefox',
-            'confirmLabel': 'Firefox for Desktop',
-            'confirmClick': _clickCallback,
-            'url': '/firefox/new/?scene=2',
-            'close': 'Close',
-            'closeLabel': 'Close'
-        },
-        {
-            'id': 'fx-out-of-date-banner-copy1-foxy-2',
-            'name': 'fx-out-of-date',
-            'experimentName': 'fx-out-of-date-banner-copy1',
-            'experimentVariant': 'foxy-2',
-            'heading': 'Time to browse better!',
-            'message': 'Get the latest version of Firefox for extra speed and safety.',
-            'confirm': 'Update now',
-            'confirmAction': 'Update Firefox',
-            'confirmLabel': 'Firefox for Desktop',
-            'confirmClick': _clickCallback,
-            'url': '/firefox/new/?scene=2',
-            'close': 'Close',
-            'closeLabel': 'Close'
-        }
-    ];
+    // try to get localized copy
+    // if any of the below fail, the banner will detect missing strings and
+    // will not initialize
+    if (typeof utils !== 'undefined') {
+        headingText = utils.trans('global-fx-out-of-date-banner-heading');
+        messageText = utils.trans('global-fx-out-of-date-banner-message');
+        confirmText = utils.trans('global-fx-out-of-date-banner-confirm');
+        closeText = utils.trans('global-close');
+    }
+
+    var config = {
+        'id': 'fx-out-of-date-banner',
+        'name': 'fx-out-of-date',
+        'heading': headingText,
+        'message': messageText,
+        'confirm': confirmText,
+        'confirmClick': _clickCallback,
+        'url': '/firefox/new/?scene=2',
+        'close': closeText,
+        'gaConfirmAction': 'Update Firefox', // GA - English only
+        'gaConfirmLabel': 'Firefox for Desktop', // GA - English only
+        'gaCloseLabel': 'Close' // GA - English only
+    };
 
     /**
-     * Determine if Firefox cliient is out of date.
+     * Determine if Firefox client is out of date.
      * @return {Boolean} - Returns true if client is at least 2 major versions out of date.
      */
     var _isClientOutOfDate = function() {
@@ -102,12 +69,7 @@ $(function() {
 
             // User must be on release channel and have cookies enabled.
             if (details.channel === 'release' && typeof Mozilla.Cookies !== 'undefined' && Mozilla.Cookies.enabled()) {
-
-                var choice = Mozilla.NotificationBanner.getOptions(options);
-
-                if (choice) {
-                    Mozilla.NotificationBanner.init(choice);
-                }
+                Mozilla.NotificationBanner.init(config);
             }
         });
     }

--- a/media/js/base/mozilla-notification-banner.js
+++ b/media/js/base/mozilla-notification-banner.js
@@ -59,7 +59,7 @@ if (typeof Mozilla === 'undefined') {
             'data-banner-name': _options.name,
             'data-banner-dismissal': '1',
             'eAction' : 'banner dismissal',
-            'eLabel': _options.closeLabel,
+            'eLabel': _options.gaCloseLabel,
             'event': 'in-page-interaction'
         });
     };
@@ -89,8 +89,8 @@ if (typeof Mozilla === 'undefined') {
         window.dataLayer.push({
             'data-banner-name': _options.name,
             'data-banner-click': '1',
-            'eAction' : _options.confirmAction,
-            'eLabel': _options.confirmLabel,
+            'eAction' : _options.gaConfirmAction,
+            'eLabel': _options.gaConfirmLabel,
             'event': 'in-page-interaction'
         });
     };
@@ -218,11 +218,11 @@ if (typeof Mozilla === 'undefined') {
             typeof options.heading !== 'string' ||
             typeof options.message !== 'string' ||
             typeof options.confirm !== 'string' ||
-            typeof options.confirmAction !== 'string' ||
-            typeof options.confirmLabel !== 'string' ||
+            typeof options.gaConfirmAction !== 'string' ||
+            typeof options.gaConfirmLabel !== 'string' ||
             typeof options.url !== 'string' ||
             typeof options.close !== 'string' ||
-            typeof options.closeLabel !== 'string') {
+            typeof options.gaCloseLabel !== 'string') {
             return false;
         }
 
@@ -313,11 +313,11 @@ if (typeof Mozilla === 'undefined') {
      * {String} heading (required) - Copy string for notification heading.
      * {String} message (required) - Copy string for notification message / subheading.
      * {String} confirm (required) - Copy string for main CTA button.
-     * {String} confirmAction (required) - String for action of CTA button in GA (this should always be English).
-     * {String} confirmLabel (required) - String for labelling CTA button in GA (this should always be English).
      * {String} url (required) - URL for main CTA link.
      * {String} close (required) - Copy string for close button.
-     * {String} closeLabel (required) - String for labelling close button in GA (this should always be English).
+     * {String} gaConfirmAction (required) - String for action of CTA button in GA (this should always be English).
+     * {String} gaConfirmLabel (required) - String for labeling CTA button in GA (this should always be English).
+     * {String} gaCloseLabel (required) - String for labeling close button in GA (this should always be English).
      * {Function} confirmClick (optional) - Callback to be executed on confirm CTA click.
      */
     NotificationBanner.init = function(options) {

--- a/tests/unit/spec/base/mozilla-notification-banner.js
+++ b/tests/unit/spec/base/mozilla-notification-banner.js
@@ -28,11 +28,11 @@ describe('mozilla-notification-banner.js', function() {
             'heading': 'Your browser security is at risk.',
             'message': 'Update Firefox now to protect yourself from the latest malware.',
             'confirm': 'Update now',
-            'confirmAction': 'Update Firefox',
-            'confirmLabel': 'Firefox for Desktop',
+            'gaConfirmAction': 'Update Firefox',
+            'gaConfirmLabel': 'Firefox for Desktop',
             'url': '/firefox/new/?scene=2',
             'close': 'Close',
-            'closeLabel': 'Close'
+            'gaCloseLabel': 'Close'
         };
 
         it('should call show() if cookie does not exist', function() {
@@ -43,7 +43,7 @@ describe('mozilla-notification-banner.js', function() {
             expect(Mozilla.NotificationBanner.show).toHaveBeenCalled();
         });
 
-        it('should call show() if cookie value does not equal "interacted', function() {
+        it('should call show() if cookie value does not equal "interacted"', function() {
             spyOn(Mozilla.NotificationBanner, 'cutsTheMustard').and.returnValue(true);
             spyOn(Mozilla.NotificationBanner, 'getCookie').and.returnValue('foo');
             spyOn(Mozilla.NotificationBanner, 'show');
@@ -94,11 +94,11 @@ describe('mozilla-notification-banner.js', function() {
                 'heading': 'Your browser security is at risk.',
                 'message': 'Update Firefox now to protect yourself from the latest malware.',
                 'confirm': 'Update now',
-                'confirmAction': 'Update Firefox',
-                'confirmLabel': 'Firefox for Desktop',
+                'gaConfirmAction': 'Update Firefox',
+                'gaConfirmLabel': 'Firefox for Desktop',
                 'url': '/firefox/new/?scene=2',
                 'close': 'Close',
-                'closeLabel': 'Close'
+                'gaCloseLabel': 'Close'
             };
 
             expect(Mozilla.NotificationBanner.validateOptions(options)).toBeTruthy();
@@ -111,11 +111,11 @@ describe('mozilla-notification-banner.js', function() {
                 'heading': 'Your browser security is at risk.',
                 'message': 'Update Firefox now to protect yourself from the latest malware.',
                 'confirm': 'Update now',
-                'confirmAction': 'Update Firefox',
-                'confirmLabel': 'Firefox for Desktop',
+                'gaConfirmAction': 'Update Firefox',
+                'gaConfirmLabel': 'Firefox for Desktop',
                 'url': '/firefox/new/?scene=2',
                 'close': 'Close',
-                'closeLabel': 'Close'
+                'gaCloseLabel': 'Close'
             };
 
             expect(Mozilla.NotificationBanner.validateOptions(options)).toBeFalsy();
@@ -133,11 +133,11 @@ describe('mozilla-notification-banner.js', function() {
                 'heading': 'Your browser security is at risk.',
                 'message': 'Update Firefox now to protect yourself from the latest malware.',
                 'confirm': 'Update now',
-                'confirmAction': 'Update Firefox',
-                'confirmLabel': 'Firefox for Desktop',
+                'gaConfirmAction': 'Update Firefox',
+                'gaConfirmLabel': 'Firefox for Desktop',
                 'url': '/firefox/new/?scene=2',
                 'close': 'Close',
-                'closeLabel': 'Close'
+                'gaCloseLabel': 'Close'
             };
 
             spyOn(Mozilla.NotificationBanner, 'bind');
@@ -164,11 +164,11 @@ describe('mozilla-notification-banner.js', function() {
                 'heading': 'Your browser security is at risk.',
                 'message': 'Update Firefox now to protect yourself from the latest malware.',
                 'confirm': 'Update now',
-                'confirmAction': 'Update Firefox',
-                'confirmLabel': 'Firefox for Desktop',
+                'gaConfirmAction': 'Update Firefox',
+                'gaConfirmLabel': 'Firefox for Desktop',
                 'url': '/firefox/new/?scene=2',
                 'close': 'Close',
-                'closeLabel': 'Close'
+                'gaCloseLabel': 'Close'
             };
 
             spyOn(window.dataLayer, 'push');
@@ -189,11 +189,11 @@ describe('mozilla-notification-banner.js', function() {
                 'heading': 'Your browser security is at risk.',
                 'message': 'Update Firefox now to protect yourself from the latest malware.',
                 'confirm': 'Update now',
-                'confirmAction': 'Update Firefox',
-                'confirmLabel': 'Firefox for Desktop',
+                'gaConfirmAction': 'Update Firefox',
+                'gaConfirmLabel': 'Firefox for Desktop',
                 'url': '/firefox/new/?scene=2',
                 'close': 'Close',
-                'closeLabel': 'Close'
+                'gaCloseLabel': 'Close'
             };
 
             spyOn(window.dataLayer, 'push');
@@ -220,11 +220,11 @@ describe('mozilla-notification-banner.js', function() {
                 'heading': 'Your browser security is at risk.',
                 'message': 'Update Firefox now to protect yourself from the latest malware.',
                 'confirm': 'Update now',
-                'confirmAction': 'Update Firefox',
-                'confirmLabel': 'Firefox for Desktop',
+                'gaConfirmAction': 'Update Firefox',
+                'gaConfirmLabel': 'Firefox for Desktop',
                 'url': '/firefox/new/?scene=2',
                 'close': 'Close',
-                'closeLabel': 'Close'
+                'gaCloseLabel': 'Close'
             };
 
             var notification = Mozilla.NotificationBanner.create(options);
@@ -286,11 +286,11 @@ describe('mozilla-notification-banner.js', function() {
                 'heading': 'Your browser security is at risk.',
                 'message': 'Update Firefox now to protect yourself from the latest malware.',
                 'confirm': 'Update now',
-                'confirmAction': 'Update Firefox',
-                'confirmLabel': 'Firefox for Desktop',
+                'gaConfirmAction': 'Update Firefox',
+                'gaConfirmLabel': 'Firefox for Desktop',
                 'url': '/firefox/new/?scene=2',
                 'close': 'Close',
-                'closeLabel': 'Close',
+                'gaCloseLabel': 'Close',
                 confirmClick: function() {}
             };
 
@@ -332,11 +332,11 @@ describe('mozilla-notification-banner.js', function() {
                 'heading': 'Your browser security is at risk.',
                 'message': 'Update Firefox now to protect yourself from the latest malware.',
                 'confirm': 'Update now',
-                'confirmAction': 'Update Firefox',
-                'confirmLabel': 'Firefox for Desktop',
+                'gaConfirmAction': 'Update Firefox',
+                'gaConfirmLabel': 'Firefox for Desktop',
                 'url': '/firefox/new/?scene=2',
                 'close': 'Close',
-                'closeLabel': 'Close'
+                'gaCloseLabel': 'Close'
             };
 
             spyOn(Mozilla.NotificationBanner, 'bind');
@@ -478,11 +478,11 @@ describe('mozilla-notification-banner.js', function() {
                 'heading': 'Your browser security is at risk.',
                 'message': 'Update Firefox now to protect yourself from the latest malware.',
                 'confirm': 'Update now',
-                'confirmAction': 'Update Firefox',
-                'confirmLabel': 'Firefox for Desktop',
+                'gaConfirmAction': 'Update Firefox',
+                'gaConfirmLabel': 'Firefox for Desktop',
                 'url': '/firefox/new/?scene=2',
                 'close': 'Close',
-                'closeLabel': 'Close',
+                'gaCloseLabel': 'Close',
             },
             {
                 'id': 'fx-out-of-date-banner-copy1-direct-2',
@@ -492,11 +492,11 @@ describe('mozilla-notification-banner.js', function() {
                 'heading': 'Your Firefox is out-of-date.',
                 'message': 'Get the most recent version to keep browsing securely.',
                 'confirm': 'Update Firefox',
-                'confirmAction': 'Update Firefox',
-                'confirmLabel': 'Firefox for Desktop',
+                'gaConfirmAction': 'Update Firefox',
+                'gaConfirmLabel': 'Firefox for Desktop',
                 'url': '/firefox/new/?scene=2',
                 'close': 'Close',
-                'closeLabel': 'Close'
+                'gaCloseLabel': 'Close'
             },
             {
                 'id': 'fx-out-of-date-banner-copy1-foxy-1',
@@ -506,11 +506,11 @@ describe('mozilla-notification-banner.js', function() {
                 'heading': 'Psst… it’s time for a tune up',
                 'message': 'Stay safe and fast with a quick update.',
                 'confirm': 'Update Firefox',
-                'confirmAction': 'Update Firefox',
-                'confirmLabel': 'Firefox for Desktop',
+                'gaConfirmAction': 'Update Firefox',
+                'gaConfirmLabel': 'Firefox for Desktop',
                 'url': '/firefox/new/?scene=2',
                 'close': 'Close',
-                'closeLabel': 'Close'
+                'gaCloseLabel': 'Close'
             }
         ];
 


### PR DESCRIPTION
## Description

Promotes winning copy to the default for site-wide banner and alternate firstrun/whatsnew banner.

## Issue / Bugzilla link

https://bugzilla.mozilla.org/show_bug.cgi?id=1388871

## Testing

Essentially ensure no regressions introduced in terms of banner functionality. Also make sure strings are showing up properly in banners.

**Note that banners will be en-US only while new strings are localized.**

https://www-demo5.allizom.org/en-US/

*banner only has 5% display frequency for `/firstrun` and `/whatsnew`*
https://www-demo5.allizom.org/en-US/firefox/54.0/firstrun
https://www-demo5.allizom.org/en-US/firefox/54.0/whatsnew

1. Download an old version of Fx. 53.0.2 is available [here](https://ftp.mozilla.org/pub/firefox/releases/53.0.2/)
2. Once you have installed / opened the browser, open a new tab and type 'about:config'. Accept the warning that is displayed.
3. On the about:config page, search for `uitour`.
4. Verify that `browser.uitour.enabled` is already set to `true`.
5. Next create a new preference (Right click -> New -> String) called `browser.uitour.testingOrigins`.
6. Give that preference a value of `https://www-demo5.allizom.org`
7. Open a new tab and visit `https://www-demo5.allizom.org`