### PR TITLE
[fix bug 1391046] Remove 'browser' from global/firefox top nav

### DIFF
--- a/bedrock/base/templates/includes/global-nav.html
+++ b/bedrock/base/templates/includes/global-nav.html
@@ -76,8 +76,16 @@
                 <li>
                 {% if LANG == 'en-US' %}
                   {% set about_url = url('firefox') %}
+                  {% set desktop_text = 'Desktop' %}
+                  {% set android_text = 'Android' %}
+                  {% set ios_text = 'iOS' %}
+                  {% set focus_text = 'Focus' %}
                 {% else %}
                   {% set about_url = url('firefox.family.index') %}
+                  {% set desktop_text = _('Desktop Browser') %}
+                  {% set android_text = _('Android Browser') %}
+                  {% set ios_text = _('iOS Browser') %}
+                  {% set focus_text = _('Focus Browser') %}
                 {% endif %}
                   <a href="{{ about_url }}" data-link-type="nav" data-link-name="About Firefox" data-link-group="Firefox">
                     {{ _('About Firefox') }}
@@ -85,22 +93,22 @@
                 </li>
                 <li>
                   <a href="{{ url('firefox.desktop.index')}}" data-link-type="nav" data-link-name="Desktop Browser" data-link-group="Firefox">
-                    {{ _('Desktop Browser') }}
+                    {{ desktop_text }}
                   </a>
                 </li>
                 <li>
                   <a href="{{ url('firefox.ios')}}" data-link-type="nav" data-link-name="iOS Browser" data-link-group="Firefox">
-                    {{ _('iOS Browser') }}
+                    {{ ios_text }}
                   </a>
                 </li>
                 <li>
                   <a href="{{ url('firefox.android.index')}}" data-link-type="nav" data-link-name="Android Browser" data-link-group="Firefox">
-                    {{ _('Android Browser') }}
+                    {{ android_text }}
                   </a>
                 </li>
                 <li>
                   <a href="{{ url('firefox.focus')}}" data-link-type="nav" data-link-name="Focus Browser" data-link-group="Firefox">
-                    {{ _('Focus Browser') }}
+                    {{ focus_text }}
                   </a>
                 </li>
                 <li>
@@ -115,25 +123,28 @@
                 </li>
               </ul>
 
-              <aside class="nav-promo">
-                <span class="meta">{{ _('Faster Browser') }}</span>
-                <a class="thumbnail" href="https://blog.mozilla.org/firefox/fast-responsive-reliable-browser-multi-tab-age/?utm_source=www.mozilla.org&amp;utm_medium=referral&amp;utm_campaign=global-nav&amp;utm_content=promo" data-link-type="nav" data-link-name="Nav Aritcle: Fast, Responsive, Reliable: A Browser for the Multi-Tab Age" data-link-group="Nav Article">
-                  <figure>
-                    {{ high_res_img('nav/promos/better-browser.png', {'alt': '', 'width': '204', 'height': '140'}) }}
-                    <figcaption>{{ _('Fast, Responsive, Reliable: A Browser for the Multi-Tab Age') }}</figcaption>
-                  </figure>
-                </a>
-              </aside>
+              {% if LANG != 'en-US' %}
+                <aside class="nav-promo">
+                  <span class="meta">{{ _('Faster Browser') }}</span>
+                  <a class="thumbnail" href="https://blog.mozilla.org/firefox/fast-responsive-reliable-browser-multi-tab-age/?utm_source=www.mozilla.org&amp;utm_medium=referral&amp;utm_campaign=global-nav&amp;utm_content=promo" data-link-type="nav" data-link-name="Nav Aritcle: Fast, Responsive, Reliable: A Browser for the Multi-Tab Age" data-link-group="Nav Article">
+                    <figure>
+                      {{ high_res_img('nav/promos/better-browser.png', {'alt': '', 'width': '204', 'height': '140'}) }}
+                      <figcaption>{{ _('Fast, Responsive, Reliable: A Browser for the Multi-Tab Age') }}</figcaption>
+                    </figure>
+                  </a>
+                </aside>
 
-              <aside class="nav-promo">
-                <span class="meta">{{ _('Better Browsing') }}</span>
-                <a class="thumbnail" href="https://blog.mozilla.org/firefox/smooth-scrolling-web-browser-removes-jank/?utm_source=www.mozilla.org&amp;utm_medium=referral&amp;utm_campaign=global-nav&amp;utm_content=promo" data-link-type="nav" data-link-name="Nav Aritcle: Smooth Scrolling: How a Web Browser Removes Jank" data-link-group="Nav Article">
-                  <figure>
-                    {{ high_res_img('nav/promos/smooth-scrolling.png', {'alt': '', 'width': '204', 'height': '140'}) }}
-                    <figcaption>{{ _('Smooth Scrolling: How a Web Browser Removes Jank') }}</figcaption>
-                  </figure>
-                </a>
-              </aside>
+                <aside class="nav-promo">
+                  <span class="meta">{{ _('Better Browsing') }}</span>
+                  <a class="thumbnail" href="https://blog.mozilla.org/firefox/smooth-scrolling-web-browser-removes-jank/?utm_source=www.mozilla.org&amp;utm_medium=referral&amp;utm_campaign=global-nav&amp;utm_content=promo" data-link-type="nav" data-link-name="Nav Aritcle: Smooth Scrolling: How a Web Browser Removes Jank" data-link-group="Nav Article">
+                    <figure>
+                      {{ high_res_img('nav/promos/smooth-scrolling.png', {'alt': '', 'width': '204', 'height': '140'}) }}
+                      <figcaption>{{ _('Smooth Scrolling: How a Web Browser Removes Jank') }}</figcaption>
+                    </figure>
+                  </a>
+                </aside>
+              {% endif %}
+
             </div>
           </div>
         </li>

--- a/bedrock/firefox/templates/firefox/includes/hub/sub-nav.html
+++ b/bedrock/firefox/templates/firefox/includes/hub/sub-nav.html
@@ -15,11 +15,23 @@
 </a>
 {% endblock %}
 
+{% if LANG == 'en-US' %}
+  {% set desktop_text = 'Desktop' %}
+  {% set android_text = 'Android' %}
+  {% set ios_text = 'iOS' %}
+  {% set focus_text = 'Focus' %}
+{% else %}
+  {% set desktop_text = _('Desktop Browser') %}
+  {% set android_text = _('Android Browser') %}
+  {% set ios_text = _('iOS Browser') %}
+  {% set focus_text = _('Focus Browser') %}
+{% endif %}
+
 {% block sub_nav_primary_links %}
-<li><a href="{{ url('firefox.desktop.index') }}" data-link-name="Desktop Browser" data-link-type="nav" data-link-position="subnav">{{ _('Desktop Browser') }}</a></li>
-<li><a href="{{ url('firefox.android.index') }}" data-link-name="Android Browser" data-link-type="nav" data-link-position="subnav">{{ _('Android Browser') }}</a></li>
-<li><a href="{{ url('firefox.ios') }}" data-link-name="iOS Browser" data-link-type="nav" data-link-position="subnav">{{ _('iOS Browser') }}</a></li>
-<li><a href="{{ url('firefox.focus') }}" data-link-name="Focus Browser" data-link-type="nav" data-link-position="subnav">{{ _('Focus Browser') }}</a></li>
+<li><a href="{{ url('firefox.desktop.index') }}" data-link-name="Desktop Browser" data-link-type="nav" data-link-position="subnav">{{ desktop_text }}</a></li>
+<li><a href="{{ url('firefox.android.index') }}" data-link-name="Android Browser" data-link-type="nav" data-link-position="subnav">{{ android_text }}</a></li>
+<li><a href="{{ url('firefox.ios') }}" data-link-name="iOS Browser" data-link-type="nav" data-link-position="subnav">{{ ios_text }}</a></li>
+<li><a href="{{ url('firefox.focus') }}" data-link-name="Focus Browser" data-link-type="nav" data-link-position="subnav">{{ focus_text }}</a></li>
 <li><a href="{{ url('firefox.features') }}" data-link-name="Features" data-link-type="nav" data-link-position="subnav">{{ _('Features') }}</a></li>
 <li><a href="https://support.mozilla.org/?utm_source=www.mozilla.org&amp;utm_medium=referral&amp;utm_campaign=fx-sub-nav" data-link-name="Support" data-link-type="nav" data-link-position="subnav">{{ _('Support') }}</a></li>
 {% endblock %}


### PR DESCRIPTION
## Description

Remove instances of "browser" from global nav and firefox subnav.

## Issue / Bugzilla link

https://bugzilla.mozilla.org/show_bug.cgi?id=1391046

## Testing

### Functional browser tests (Firefox Nightly)
- [x] en-US side nav has intended content
- [x] en-US top nav has intended content
- [x] es-ES top nav has no changes

### Unit test output 
==== short test summary info ====
FAIL bedrock/newsletter/tests/test_views.py::TestExistingNewsletterView::test_change_lang_country
FAIL bedrock/newsletter/tests/test_views.py::TestExistingNewsletterView::test_get_token
FAIL bedrock/newsletter/tests/test_views.py::TestExistingNewsletterView::test_get_user_not_found
FAIL bedrock/newsletter/tests/test_views.py::TestExistingNewsletterView::test_newsletter_no_order
FAIL bedrock/newsletter/tests/test_views.py::TestExistingNewsletterView::test_newsletter_ordering
FAIL bedrock/newsletter/tests/test_views.py::TestExistingNewsletterView::test_post_user_not_found
FAIL bedrock/newsletter/tests/test_views.py::TestExistingNewsletterView::test_remove_all
FAIL bedrock/newsletter/tests/test_views.py::TestExistingNewsletterView::test_show
FAIL bedrock/newsletter/tests/test_views.py::TestExistingNewsletterView::test_subscribing
FAIL bedrock/newsletter/tests/test_views.py::TestExistingNewsletterView::test_unsubscribing
FAIL bedrock/newsletter/tests/test_views.py::TestExistingNewsletterView::test_will_show_confirm_copy
SKIP [1] lib/l10n_utils/tests/test_template.py:79: <Skipped instance>
