### PR TITLE
Fix unclosed tags in Pocket section of global nav.

### DIFF
--- a/bedrock/base/templates/includes/global-nav.html
+++ b/bedrock/base/templates/includes/global-nav.html
@@ -154,6 +154,8 @@
                   </a>
                 </li>
               </ul>
+            </div>
+          </div>
         </li>
         <li class="item-internet-health">
           <h3 class="summary" data-id="internet-health">


### PR DESCRIPTION
## Description

Just adds two missing `</div>` tags to the Pocket section of the left-drawer global nav.
