### PR TITLE
Fix Bug 1391287 - Statement and claim on firefox/features/independent

### DIFF
--- a/bedrock/firefox/templates/firefox/features/independent.html
+++ b/bedrock/firefox/templates/firefox/features/independent.html
@@ -62,12 +62,20 @@
         <img src="{{ static('img/firefox/features/thumbnails/independent/mission.jpg') }}" alt="">
         <h3>{{ _('A browser on a mission') }}</h3>
         <p>
+        {% if l10n_has_tag('independent_mission_bug_1391287') %}
+        {% trans %}
+          In addition to fighting for your online rights, we also keep corporate powers
+          in check, while working with allies all around the globe to nurture healthy
+          Internet practices. So when you choose Firefox, we’re choosing you, too.
+        {% endtrans %}
+        {% else %}
         {% trans %}
           Firefox is a browser with a conscience. As part of the technology non-profit
           Mozilla, we fight for your online rights, keep corporate powers in check
           and help educate developing countries on healthy Internet practices. So when
           you choose Firefox, we’re choosing you, too.
         {% endtrans %}
+        {% endif %}
         </p>
       </li>
     </ul>


### PR DESCRIPTION
## Description

Correct a wrong statement on [/firefox/features/independent/](https://www.mozilla.org/en-US/firefox/features/independent/), under the "A browser on a mission" section. Requires l10n.

## Issue / Bugzilla link

[Bug 1391287](https://bugzilla.mozilla.org/show_bug.cgi?id=1391287)

## Testing

Just visit the page and make sure the copy is updated properly.