### PR TITLE
[fix bug 1391480] Update to Mitchell Baker’s bio

### DIFF
--- a/bedrock/mozorg/templates/mozorg/about/leadership.html
+++ b/bedrock/mozorg/templates/mozorg/about/leadership.html
@@ -106,7 +106,7 @@
 
           <p>
           {% trans %}
-            Mitchell is a Board Member for the OpenMRS, the world’s leading open source enterprise electronic medical record system platform, and is an MIT Media Lab Research Affiliate, Open Agriculture Initiative. She co-chairs the U.S. Department of Commerce Digital Economy Advisory Board and serves on the United Nations High Level Panel on Women’s Economic Empowerment. Mitchell was co-Chair of the World Economic Forum Annual Meeting of the New Champions in 2015 and a member of the ICANN High Level Panel on Global Internet Cooperation and Governance Mechanisms.
+            Mitchell is a Board Member for the OpenMRS, the world’s leading open source enterprise electronic medical record system platform, and is an MIT Media Lab Research Affiliate, Open Agriculture Initiative. She co-chaired the U.S. Department of Commerce Digital Economy Board of Advisors from its inception in March 2016 until August 2017 and serves on the United Nations High Level Panel on Women’s Economic Empowerment. Mitchell was co-Chair of the World Economic Forum Annual Meeting of the New Champions in 2015 and a member of the ICANN High Level Panel on Global Internet Cooperation and Governance Mechanisms.
           {% endtrans %}
           </p>
 


### PR DESCRIPTION
## Description
Small but urgent update to Mitchell's bio, changing "co-chairs the U.S. Department of Commerce Digital Economy Advisory Board" to the past tense.

## Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1391480