### PR TITLE
[fix bug 1392473] Copy test on /firstrun page

### DIFF
--- a/bedrock/firefox/templates/firefox/firstrun/onboarding-a.html
+++ b/bedrock/firefox/templates/firefox/firstrun/onboarding-a.html
@@ -1,0 +1,8 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+  # License, v. 2.0. If a copy of the MPL was not distributed with this
+  # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+
+{% extends "firefox/firstrun/onboarding.html" %}
+
+{# Don't display notification for test variation #}
+{% block update_notification %}{% endblock %}

--- a/bedrock/firefox/templates/firefox/firstrun/onboarding-b.html
+++ b/bedrock/firefox/templates/firefox/firstrun/onboarding-b.html
@@ -1,0 +1,19 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+  # License, v. 2.0. If a copy of the MPL was not distributed with this
+  # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+
+{% extends "firefox/firstrun/onboarding.html" %}
+
+{% block main_copy %}
+<h1 id="title">Save time! <br>Get Firefox to go.</h1>
+<p>Pick up exactly where you left off on your devices with one login.</p>
+<p>Instantly view your:</p>
+<ul>
+  <li>Open tabs</li>
+  <li>Saved passwords</li>
+  <li>Bookmarks</li>
+</ul>
+{% endblock %}
+
+{# Don't display notification for test variation #}
+{% block update_notification %}{% endblock %}

--- a/bedrock/firefox/templates/firefox/firstrun/onboarding.html
+++ b/bedrock/firefox/templates/firefox/firstrun/onboarding.html
@@ -16,6 +16,12 @@
   {% stylesheet 'firefox_firstrun_onboarding' %}
 {% endblock %}
 
+{% block experiments %}
+  {% if switch('experiment-firstrun-copy', ['en-US']) %}
+    {% javascript 'experiment-firstrun-copy' %}
+  {% endif %}
+{% endblock %}
+
 {% block js %}
   {% javascript 'firefox_firstrun_onboarding' %}
 {% endblock %}
@@ -27,9 +33,11 @@
   <div id="scene">
     <div class="fxaccounts-container">
       <div id="left-divider">
+        {% block main_copy %}
         <h1 id="title">{{_('Already using Firefox?')}}</h1>
         <p>{{_('Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.')}}</p>
         <a href="{{ url('firefox.features.sync') }}">{{_('Learn more about Firefox Accounts')}}</a>
+        {% endblock %}
       </div>
       <div id="firefox-logo"></div>
       {# Bug 1354710: firstrun pages need to pass funnelcake parameters to FxA #}

--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -388,11 +388,14 @@ class FirstrunView(l10n_utils.LangFilesMixin, TemplateView):
     def get_template_names(self):
         locale = l10n_utils.get_locale(self.request)
         version = self.kwargs.get('version') or ''
+        exp = self.request.GET.get('v')
 
         if detect_channel(version) == 'alpha':
             template = 'firefox/dev-firstrun.html'
         elif show_40_firstrun(version):
-            if lang_file_is_active('firefox/new/onboarding', locale):
+            if locale == 'en-US' and exp in ['a', 'b']:
+                template = 'firefox/firstrun/onboarding-{0}.html'.format(exp)
+            elif lang_file_is_active('firefox/new/onboarding', locale):
                 template = 'firefox/firstrun/onboarding.html'
             else:
                 template = 'firefox/firstrun/firstrun-horizon.html'

--- a/bedrock/settings/static_media.py
+++ b/bedrock/settings/static_media.py
@@ -1186,6 +1186,13 @@ PIPELINE_JS = {
         ),
         'output_filename': 'js/firefox_dnt-bundle.js',
     },
+    'experiment-firstrun-copy': {
+        'source_filenames': (
+            'js/base/mozilla-traffic-cop.js',
+            'js/firefox/firstrun/experiment-firstrun-copy.js',
+        ),
+        'output_filename': 'js/experiment-firstrun-copy.js',
+    },
     'gtm-snippet': {
         'source_filenames': (
             'js/base/gtm-snippet.js',

--- a/media/css/firefox/firstrun/onboarding.less
+++ b/media/css/firefox/firstrun/onboarding.less
@@ -25,17 +25,17 @@ body {
 }
 
 img {
-    width: 100%;
-    height: auto;
-    min-width: 100%;
-    min-height: 100%;
-    margin: auto;
-    position: fixed;
-    top: 0;
-    left: 0;
     bottom: 0;
-    right: 0;
+    height: auto;
+    left: 0;
+    margin: auto;
+    min-height: 100%;
+    min-width: 100%;
     object-fit: cover;
+    position: fixed;
+    right: 0;
+    top: 0;
+    width: 100%;
 }
 
 #night-foreground-fox, #foreground-fox {
@@ -64,41 +64,42 @@ img {
 #fxa-iframe-config {
     background: #fff;
     border-radius: 5px;
-    padding: 25px 6px 20px 6px;
     display: inline-block;
     margin-left: 65px;
+    padding: 25px 6px 20px 6px;
 }
 
 .fxaccounts-container {
-    margin: auto;
-    position: absolute;
-    top: 0;
-    left: 0;
     bottom: 0;
-    right: 0;
-    width: 695px;
-    height: 395px;
-    z-index: 10;
-    opacity: 0;
     color: #fff;
+    height: 395px;
+    left: 0;
+    margin: auto;
+    opacity: 0;
+    position: absolute;
+    right: 0;
+    top: 0;
+    width: 695px;
+    z-index: 10;
 }
 
 #left-divider {
-    width: 300px;
-    height: 60%;
     float: left;
+    height: 60%;
     margin: 79px 0;
+    width: 300px;
 
     p {
-        margin: 0 0 40px;
-        line-height: 150%;
         font-size: 1.1em;
+        line-height: 150%;
+        margin: 0 0 20px;
     }
 
     a {
-        display: block;
         color: #edb200;
+        display: block;
         font-size: .9em;
+        margin-top: 40px;
 
         &:hover {
             color: #d99100;
@@ -107,8 +108,8 @@ img {
 }
 
 #title {
-    font-weight: bold;
     font-size: 1.8em;
+    font-weight: bold;
     margin: 20px 0;
 }
 
@@ -116,27 +117,27 @@ img {
 
     #firefox-logo {
       background-image: url('/media/img/firefox/template/release-logo-high-res.png');
-      height: 80px;
-      width: 80px;
       background-position: center;
       background-repeat: no-repeat;
       background-size: contain;
+      height: 80px;
       position: absolute;
-      top: -55px;
       right: 125px;
+      top: -55px;
+      width: 80px;
     }
 
     button {
-        margin: 10px auto;
-        display: block;
-        cursor: pointer;
-        background-color: #0996f8;
         -moz-appearance: none;
-        color: #fff;
-        border: 1px solid #0670cc;
+        background-color: #0996f8;
         border-radius: 3px;
+        border: 1px solid #0670cc;
         box-shadow: 0 0 0 0 transparent;
+        color: #fff;
+        cursor: pointer;
+        display: block;
         height: 24px;
+        margin: 10px auto;
         padding: 3px 10px;
 
         &:not([disabled]):hover {
@@ -146,25 +147,25 @@ img {
     }
 
     button[disabled] {
-      background-color: #ebebeb;
-      border-color: #b1b1b1;
-      color: #6a6a6a;
-      opacity: .5;
-      cursor: default;
+        background-color: #ebebeb;
+        border-color: #b1b1b1;
+        color: #6a6a6a;
+        cursor: default;
+        opacity: .5;
     }
 
     .skipbutton-hidden {
-      display: none;
+        display: none;
     }
 
     #sunrise {
-        transition: transform 1.7s cubic-bezier(.41,.61,.54,.96) .5s;
         transform: none;
+        transition: transform 1.7s cubic-bezier(.41,.61,.54,.96) .5s;
     }
 
     #mountains, #trees, #foreground-fox, #sky {
-        transition: opacity 2.3s ease-in-out .9s;
         opacity: 1;
+        transition: opacity 2.3s ease-in-out .9s;
     }
 }
 
@@ -175,13 +176,13 @@ img {
     }
 
     #scene-blur {
-        transition: opacity .7s;
         opacity: 1;
+        transition: opacity .7s;
     }
 
    .fxaccounts-container {
-        transition: opacity .3s;
         opacity: 1;
+        transition: opacity .3s;
     }
 }
 

--- a/media/js/firefox/firstrun/experiment-firstrun-copy.js
+++ b/media/js/firefox/firstrun/experiment-firstrun-copy.js
@@ -1,0 +1,17 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+(function() {
+    'use strict';
+
+    var cop = new Mozilla.TrafficCop({
+        id: 'experiment_firstrun_copy',
+        variations: {
+            'v=a': 5,  // double-control
+            'v=b': 5   // copy test
+        }
+    });
+
+    cop.init();
+})(window.Mozilla);


### PR DESCRIPTION
## Description
- Adds an A/B copy test on /firstrun (en-US only).
- Fixes formatting in `onboarding.less`

## Issue / Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1392473

## Testing
- Ensure traffic cop experiment works as expected with DNT disabled (each version is set to 5% sample rate)
- Ensure correct variations load for both `?v=a` and `?v=b`.
- Ensure no visual regressions.

Demo:
https://bedrock-demo-agibson.us-west.moz.works/en-US/firefox/55.0/firstrun/
https://bedrock-demo-agibson.us-west.moz.works/en-US/firefox/55.0/firstrun/?v=a
https://bedrock-demo-agibson.us-west.moz.works/en-US/firefox/55.0/firstrun/?v=b
