### PR TITLE
[fix bug 1386622] Update /new strings for advanced installs.

### DIFF
--- a/bedrock/firefox/templates/firefox/includes/download-list.html
+++ b/bedrock/firefox/templates/firefox/includes/download-list.html
@@ -13,5 +13,3 @@
     </li>
   {%- endfor %}
 </ul>
-
-<p><a href="{{ firefox_url('desktop', 'all', 'release') }}">{{_('Available Languages') }}</a></p>

--- a/bedrock/firefox/templates/firefox/new/onboarding/scene1.html
+++ b/bedrock/firefox/templates/firefox/new/onboarding/scene1.html
@@ -85,7 +85,27 @@
                 <li><a class="more" href="{{ url('firefox.family.index') }}">{{_('Discover all the ways to take Firefox on the go')}}</a></li>
               </ul>
             </div>
-            <button id="other-platforms-modal-link" class="hidden" type="button">{{_('Firefox for Other Platforms & Languages')}}</button>
+
+            <div id="other-platforms-languages-wrapper" class="hidden">
+              <button id="other-platforms-modal-link" type="button">
+              {% if l10n_has_tag('firefox_new_install_options') %}
+                {{ _('Advanced install options & other platforms') }}
+              {% else %}
+                {{ _('Firefox for other platforms') }}
+              {% endif %}
+              </button>
+
+              <p>
+                <a href="{{ url('firefox.all') }}">
+                {% if l10n_has_tag('firefox_new_install_options') %}
+                  {{ _('Other languages') }}
+                {% else %}
+                  {{ _('Available Languages') }}
+                {% endif %}
+                </a>
+              </p>
+            </div>
+
             <section id="benefits">
               <ul>
                 <li>
@@ -118,7 +138,13 @@
   <div id="other-platforms">
     <div class="container">
       <section class="section-other-platforms">
-        <h4>{{_('Firefox for other platforms') }}</h4>
+        <h4>
+        {% if l10n_has_tag('firefox_new_install_options') %}
+          {{ _('Advanced Install Options & Other Platforms') }}
+        {% else %}
+          {{_('Firefox for other platforms') }}
+        {% endif %}
+        </h4>
 
         {{ download_firefox_desktop_list() }}
 

--- a/bedrock/firefox/templates/firefox/new/scene1.html
+++ b/bedrock/firefox/templates/firefox/new/scene1.html
@@ -105,9 +105,11 @@
                 <li><a class="more" href="{{ url('firefox.family.index') }}">{{_('Discover all the ways to take Firefox on the go')}}</a></li>
               </ul>
             </div>
-            {% if l10n_has_tag('firefox_new_other_platforms') %}
-              <button id="other-platforms-modal-link" class="hidden" type="button">{{_('Firefox for Other Platforms & Languages')}}</button>
-            {% endif %}
+
+            <div id="other-platforms-languages-wrapper" class="hidden">
+              <button id="other-platforms-modal-link" type="button">{{_('Firefox for Other Platforms & Languages')}}</button>
+            </div>
+
           </div>{#-- /.main-content --#}
         </div>{#-- /.inner-container --#}
       </div>
@@ -138,7 +140,6 @@
     </aside>
   </div>
 
-  {% if l10n_has_tag('firefox_new_other_platforms') %}
   <div id="other-platforms">
     <div class="container">
       <section class="section-other-platforms">
@@ -168,7 +169,6 @@
       </section>
     </div>
   </div>
-  {% endif %}
 
 </main>
 

--- a/media/css/firefox/new/other-platforms.less
+++ b/media/css/firefox/new/other-platforms.less
@@ -196,23 +196,28 @@ html[dir="rtl"] #other-platforms {
     }
 }
 
-#other-platforms-modal-link {
+#other-platforms-languages-wrapper {
     .font-size(16px);
-    background: none;
-    border: none;
-    color: #fff;
-    cursor: pointer;
-    display: inline-block;
-    margin-top: 20px;
+    margin-top: 60px;
 
     &.hidden {
         display: none;
     }
 
-    &:active,
-    &:focus,
-    &:hover {
-        text-decoration: underline;
+    #other-platforms-modal-link {
+        .font-size(16px);
+        background: none;
+        border: none;
+        color: #fff;
+        cursor: pointer;
+        display: inline-block;
+        margin-bottom: 6px;
+
+        &:active,
+        &:focus,
+        &:hover {
+            text-decoration: underline;
+        }
     }
 }
 

--- a/media/js/firefox/new/scene1.js
+++ b/media/js/firefox/new/scene1.js
@@ -8,6 +8,7 @@
     var $html = $(document.documentElement);
     var client = window.Mozilla.Client;
     var $modalLink = $('#other-platforms-modal-link');
+    var $otherPlatformsLanguagesWrapper = $('#other-platforms-languages-wrapper');
 
     var uiTourSendEvent = function(action, data) {
         var event = new CustomEvent('mozUITour', {
@@ -86,7 +87,7 @@
 
     var initOtherPlatformsModal = function() {
         // show the modal cta button
-        $modalLink.removeClass('hidden');
+        $otherPlatformsLanguagesWrapper.removeClass('hidden');
 
         $modalLink.on('click', function(e) {
             e.preventDefault();


### PR DESCRIPTION
## Description

Updates link messaging for advanced install options and other languages.

## Issue / Bugzilla link

https://bugzilla.mozilla.org/show_bug.cgi?id=1386622#c27

## Testing

Make sure new UX is sane, and old UX (for un-translated locales) isn't broken.

https://www-demo5.allizom.org/firefox/new/