### PR TITLE
[fix bug 1392973] /firefox/ CSS header alignment issues on smaller screens

### DIFF
--- a/media/css/firefox/hub/home.scss
+++ b/media/css/firefox/hub/home.scss
@@ -57,6 +57,7 @@ $color-link-blue-dark: #175a77;
 
     .tagline {
         text-align: center;
+        max-width: none;
 
         span {
             @include box-decoration-break(repeat);
@@ -67,15 +68,21 @@ $color-link-blue-dark: #175a77;
 
     @media #{$mq-tablet} {
         h1 {
-            @include at2x('/media/img/logos/firefox/logo-wordmark-large-noshadow.png', 375px, 141px);
-            height: 141px;
             margin-left: 0;
             margin-right: 0;
-            width: 375px;
         }
 
         .tagline {
+            max-width: 25em;
             text-align: left;
+        }
+    }
+
+    @media #{$mq-desktop} {
+        h1 {
+            @include at2x('/media/img/logos/firefox/logo-wordmark-large-noshadow.png', 375px, 141px);
+            height: 141px;
+            width: 375px;
         }
     }
 }


### PR DESCRIPTION
## Description
Fixes a CSS regression for the main header on /firefox/ at small screen sizes.

## Issue / Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1392973

## Testing
- Check responsiveness.
- Check non-en locales with longer strings.
- Check RTL.
