### PR TITLE
[fix bug 1367183] Change anchor text of privacy policy links

### DIFF
--- a/bedrock/base/templates/includes/site-footer.html
+++ b/bedrock/base/templates/includes/site-footer.html
@@ -58,7 +58,12 @@
     <nav class="secondary">
         <div class="small-links">
           <ul>
-            <li><a rel="nofollow" href="{{ url('privacy') }}" data-link-type="footer" data-link-name="Privacy">{{ _('Privacy') }}</a></li>
+            {% if LANG.startswith('en-') %} 
+              {% set privacy_text = _('Website Privacy Notice') %}
+            {% else %}
+              {% set privacy_text = _('Privacy') %}
+            {% endif %}
+            <li><a rel="nofollow" href="{{ url('privacy.notices.websites') }}" data-link-type="footer" data-link-name="Privacy">{{ privacy_text }}</a></li>
             <li><a rel="nofollow" href="{{ url('privacy.notices.websites') }}#cookies" data-link-type="footer" data-link-name="Cookies">{{ _('Cookies') }}</a></li>
             <li><a rel="nofollow" href="{{ url('legal.index') }}" data-link-type="footer" data-link-name="Legal">{{ _('Legal') }}</a></li>
           </ul>

--- a/bedrock/firefox/templates/firefox/australis/firstrun.html
+++ b/bedrock/firefox/templates/firefox/australis/firstrun.html
@@ -59,7 +59,12 @@
     </ul>
     <ul>
       <li><a href="{{ url('legal.index') }}" data-link-type="footer" data-link-name="Legal">{{ _('Legal') }}</a></li>
-      <li><a href="{{ url('privacy') }}" data-link-type="footer" data-link-name="Privacy">{{ _('Privacy') }}</a></li>
+      {% if LANG.startswith('en-') %} 
+        {% set privacy_text = _('Website Privacy Notice') %}
+      {% else %}
+        {% set privacy_text = _('Privacy') %}
+      {% endif %}
+      <li><a href="{{ url('privacy') }}" data-link-type="footer" data-link-name="Privacy">{{ privacy_text }}</a></li>
     </ul>
   </footer>
 {% endblock %}

--- a/bedrock/firefox/templates/firefox/includes/download-button.html
+++ b/bedrock/firefox/templates/firefox/includes/download-button.html
@@ -105,6 +105,11 @@
     {% endfor %}
   </ul>
   <small class="fx-privacy-link">
-    <a href="{{ url('privacy.notices.firefox') }}">{{ _('Firefox Privacy') }}</a>
+    {% if LANG.startswith('en-') %} 
+      {% set privacy_text = _('Firefox Privacy Notice') %}
+    {% else %}
+      {% set privacy_text = _('Firefox Privacy') %}
+    {% endif %}
+    <a href="{{ url('privacy.notices.firefox') }}">{{ privacy_text }}</a>
   </small>
 </div>

--- a/bedrock/firefox/templates/firefox/products/focus.html
+++ b/bedrock/firefox/templates/firefox/products/focus.html
@@ -39,7 +39,12 @@
     {{ high_res_img('firefox/android/btn-google-play.png', {'alt': _('Get it on Google Play'), 'width': '152', 'height': '45', 'l10n': True}) }}
   </a>
   <small class="fx-privacy-link">
-    <a href="{{ url('privacy.notices.firefox-focus') }}">{{ _('Firefox Privacy') }}</a>
+    {% if LANG.startswith('en-') %} 
+      {% set privacy_text = _('Focus Privacy Notice') %}
+    {% else %}
+      {% set privacy_text = _('Firefox Privacy') %}
+    {% endif %}
+    <a href="{{ url('privacy.notices.firefox-focus') }}">{{ privacy_text }}</a>
   </small>
 {% endblock %}
 

--- a/bedrock/thunderbird/templates/thunderbird/includes/download-button.html
+++ b/bedrock/thunderbird/templates/thunderbird/includes/download-button.html
@@ -58,6 +58,11 @@
     {% if channel != 'alpha' %}{# Earlybird release notes are not available yet #}
     <a href="{{ thunderbird_url('notes', channel) }}">{{ _('What’s New') }}</a> |
     {% endif %}
-    <a href="{{ url('privacy.notices.thunderbird') }}">{{ _('Privacy') }}</a>
+    {% if LANG.startswith('en-') %} 
+      {% set privacy_text = _('Thunderbird Privacy Notice') %}
+    {% else %}
+      {% set privacy_text = _('Privacy') %}
+    {% endif %}
+    <a href="{{ url('privacy.notices.thunderbird') }}">{{ privacy_text }}</a>
   </small>
 </div>


### PR DESCRIPTION
## Description

In bug  1367183 we agreed to change the anchor text of various privacy policy notices on the site to distinguish them from *marketing content* about privacy.

## Issue / Bugzilla link

https://bugzilla.mozilla.org/show_bug.cgi?id=1367183#c11

## Testing

### Functional tests
* Opened several pages that historically had different footers (e.g. homepage, Firefox pages, styleguide pages) and verified content of anchor text in footer
* Opened /firefox/focus/, /firefox/new/, /firefox/, /thunderbird/ pages to verify content of anchor text under download buttons.

### Unit tests

=== short test summary info ===
FAIL bedrock/newsletter/tests/test_views.py::TestExistingNewsletterView::test_change_lang_country
FAIL bedrock/newsletter/tests/test_views.py::TestExistingNewsletterView::test_get_token
FAIL bedrock/newsletter/tests/test_views.py::TestExistingNewsletterView::test_get_user_not_found
FAIL bedrock/newsletter/tests/test_views.py::TestExistingNewsletterView::test_newsletter_no_order
FAIL bedrock/newsletter/tests/test_views.py::TestExistingNewsletterView::test_newsletter_ordering
FAIL bedrock/newsletter/tests/test_views.py::TestExistingNewsletterView::test_post_user_not_found
FAIL bedrock/newsletter/tests/test_views.py::TestExistingNewsletterView::test_remove_all
FAIL bedrock/newsletter/tests/test_views.py::TestExistingNewsletterView::test_show
FAIL bedrock/newsletter/tests/test_views.py::TestExistingNewsletterView::test_subscribing
FAIL bedrock/newsletter/tests/test_views.py::TestExistingNewsletterView::test_unsubscribing
FAIL bedrock/newsletter/tests/test_views.py::TestExistingNewsletterView::test_will_show_confirm_copy
SKIP [1] lib/l10n_utils/tests/test_template.py:79: <Skipped instance>
