### PR TITLE
Fix Bug 1395013 - Update Firefox ESR mailing list links

### DIFF
--- a/bedrock/firefox/templates/firefox/organizations/faq.html
+++ b/bedrock/firefox/templates/firefox/organizations/faq.html
@@ -151,15 +151,17 @@
 
 <h4>{{ _('Is Mozilla Firefox ESR available in my language?') }}</h4>
 <p>
-{% trans url1='..', url2='https://mail.mozilla.org/listinfo/enterprise-de',
-		url3='https://www.mozilla.jp/business/', url4='mailto:stormy@mozilla.com' %}
+{% trans list_en='https://mail.mozilla.org/listinfo/enterprise',
+         list_fr='https://mail.mozilla.org/listinfo/enterprise-fr',
+         list_de='https://mail.mozilla.org/listinfo/enterprise-de',
+         contact='mailto:sledru@mozilla.com' %}
 	Firefox ESR is available in every locale currently available for Firefox.
 	Because of the precise needs of Firefox ESR, it’s important that anyone
-	deploying the build be registered and participate in an EWG
-	<a href="{{ url1 }}">mailing list</a>. The mailing list is only available
-	in <a href="{{ url2 }}">German</a>, <a href="{{ url3 }}">Japanese</a> and
-	English, but if you would like to volunteer to lead a Firefox ESR mailing
-	list in your language, please get <a href="{{ url4 }}">in touch</a>.
+	deploying the build be registered and participate in an EWG mailing list.
+	The mailing list is only available in <a href="{{ list_en }}">English</a>,
+	<a href="{{ list_fr }}">French</a> and <a href="{{ list_de }}">German</a>,
+	but if you would like to volunteer to lead a Firefox ESR mailing list in
+	your language, please <a href="{{ contact }}">get in touch</a>.
 {% endtrans %}
 </p>
 


### PR DESCRIPTION
## Description

Update the second last section on the [ESR FAQ page](https://www.mozilla.org/en-US/firefox/organizations/faq/). Add the French mailing list, remove the Japanese list, and replace the contact person. I've also used a direct link for the English list to avoid confusion.

## Issue / Bugzilla link

[Bug 1395013](https://bugzilla.mozilla.org/show_bug.cgi?id=1395013)

## Testing

Just visit the FAQ page, and make sure the lists are updated as explained.