### PR TITLE
Fix Bug 1395075 - Remove Mozilla Japan from Mozilla Organizations page

### DIFF
--- a/bedrock/mozorg/templates/mozorg/about/governance/organizations.html
+++ b/bedrock/mozorg/templates/mozorg/about/governance/organizations.html
@@ -24,8 +24,6 @@ This page provides information about the various organizations and their relatio
 The <a href="{{ foundation_url }}">Mozilla Foundation</a> is a California non-profit corporation exempt from Federal income taxation under IRC 501(c)(3). The Foundation supports the existing Mozilla community and oversees Mozilla’s governance structure. It also actively seeks out new ways for people around the world to recognize and steward the Internet as a critical public resource.
 {% endtrans %}</p>
 
-<p>{{_('<a href="https://www.mozilla.jp/">Mozilla Japan</a> is a separate non-profit organization that promotes Mozillas products and mission in Japan and is affiliated with the Mozilla Foundation.')}}</p>
-
 <h2>{{_('Mozilla Corporation')}}</h2>
 
 <p>{% trans foundation_moco=url('foundation.moco'), firefox_url=url('firefox') %}


### PR DESCRIPTION
## Description

Updating the [Mozilla Organizations page](https://www.mozilla.org/en-US/about/governance/organizations/). From the bug:

> Not sure who manages this Organizations page, but given the organizational transition is a known fact and mozilla.jp has already been converted to a local community portal site, no one should argue against the edit.

## Issue / Bugzilla link

[Bug 1395075](https://bugzilla.mozilla.org/show_bug.cgi?id=1395075)

## Testing

Just open the page and make sure the paragraph in question is gone.