### PR TITLE
[fix bug 1395269] Broken Firefox link in global nav

### DIFF
--- a/bedrock/base/templates/includes/global-nav.html
+++ b/bedrock/base/templates/includes/global-nav.html
@@ -60,7 +60,7 @@
       <ul class="nav-menu-primary-links">
         <li class="item-firefox">
           <h3 class="summary" data-id="firefox">
-            <a href="{{ firefox_url }}" data-link-type="nav" data-link-position="side" data-link-name="expand" data-link-group="Firefox">{{ _('Firefox') }}</a>
+            <a href="{{ url('firefox') }}" data-link-type="nav" data-link-position="side" data-link-name="expand" data-link-group="Firefox">{{ _('Firefox') }}</a>
           </h3>
           <div class="detail">
             <div class="detail-container">


### PR DESCRIPTION
## Description
Fixes a minor regression from https://github.com/mozilla/bedrock/commit/15acbe8cb0e25da3719e89587af70d6f4fd21069 wherein the definition for `firefox_url` was removed but we missed the second reference to it further down.

## Issue / Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1395269

## Testing
The "Firefox" heading in the subnav flyout should link to /firefox/ (JS overrides that link behavior).
