### PR TITLE
[fix bug 1387573] Add user intent survey to /new

### DIFF
--- a/bedrock/firefox/templates/firefox/new/scene1.html
+++ b/bedrock/firefox/templates/firefox/new/scene1.html
@@ -48,6 +48,9 @@
                 {{_('You’re using a pre-release version of Firefox.') }}
               </p>
             </div>{#-- /.version-message-container --#}
+            {% if switch('firefox-new-survey', ['en-US']) %}
+              {% include 'firefox/new/survey.html' %}
+            {% endif %}
           </header>
           <div class="main-content">
             <h1>{{ _('Chart your own course') }}</h1>

--- a/bedrock/firefox/templates/firefox/new/scene2.html
+++ b/bedrock/firefox/templates/firefox/new/scene2.html
@@ -38,6 +38,9 @@
             <a href="{{ url('mozorg.home') }}" data-link-type="nav" data-link-name="tabzilla">Mozilla</a>
           </div>
           <h2><a href="{{ url('firefox') }}">{{ high_res_img('firefox/template/header-logo-inverse.png', {'alt': 'Firefox', 'width': '185', 'height': '70'}) }}</a></h2>
+          {% if switch('firefox-new-survey', ['en-US']) %}
+            {% include 'firefox/new/survey.html' %}
+          {% endif %}
         </header>
         <div class="main-content">
           <h1>{{ _('Behold! The open web awaits.') }}</h1>

--- a/bedrock/firefox/templates/firefox/new/survey.html
+++ b/bedrock/firefox/templates/firefox/new/survey.html
@@ -1,0 +1,7 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+  # License, v. 2.0. If a copy of the MPL was not distributed with this
+  # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+
+ <a id="firefox-new-survey-link" href="https://qsurvey.mozilla.com/s3/Firefox-2017-dwnbase/" target="_blank" rel="noopener noreferrer">
+   {{_('Let us know why you’re choosing Firefox.')}}
+ </a>

--- a/bedrock/settings/static_media.py
+++ b/bedrock/settings/static_media.py
@@ -1198,12 +1198,14 @@ PIPELINE_JS = {
     'firefox_new_scene1': {
         'source_filenames': (
             'js/base/mozilla-modal.js',
+            'js/firefox/new/survey.js',
             'js/firefox/new/scene1.js',
         ),
         'output_filename': 'js/firefox_new_scene1-bundle.js',
     },
     'firefox_new_scene2': {
         'source_filenames': (
+            'js/firefox/new/survey.js',
             'js/firefox/new/scene2.js',
         ),
         'output_filename': 'js/firefox_new_scene2-bundle.js',

--- a/media/css/firefox/new/common.less
+++ b/media/css/firefox/new/common.less
@@ -53,6 +53,20 @@
     top: 0;
 }
 
+#firefox-new-survey-link {
+    clear: left;
+    color: #ffbb38;
+    display: none;
+    width: 280px;
+
+    @media only screen and (max-width: @breakTablet) {
+        padding-top: 20px;
+        text-align: center;
+        width: 100%;
+        float: left;
+    }
+}
+
 .inner-container,
 #newsletter-subscribe > .container {
     margin: 0 auto;

--- a/media/js/firefox/new/survey.js
+++ b/media/js/firefox/new/survey.js
@@ -1,0 +1,17 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+(function($) {
+    'use strict';
+
+    var client = Mozilla.Client;
+    var $survey = $('#firefox-new-survey-link');
+
+    if (!client.isMobile && $survey.length && Math.random() < 0.25) {
+        var link = $survey.attr('href');
+        $survey.attr('href', link + window.location.search);
+        $survey.css('display', 'block');
+    }
+
+})(window.jQuery);


### PR DESCRIPTION
## Description
- Adds a survey link to `/firefox/new/` for 100% of en-US audience (as specified in the bug).
- ~**do-not-merge** until I find out if this should be on scene2 also.~

## Issue / Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1387573

## Testing
- Make sure survey link displays correctly
