### PR TITLE
[fix bug 1395575] Disallow index of /etc app.

### DIFF
--- a/bedrock/mozorg/templates/mozorg/robots.txt
+++ b/bedrock/mozorg/templates/mozorg/robots.txt
@@ -5,9 +5,9 @@ user-agent: *
 {% if disallow_all -%}
 disallow: /
 {% else -%}
-disallow: /*/download/
 disallow: /*/firstrun/
 disallow: /*/newsletter/existing/
 disallow: /*/whatsnew/
+disallow: /*/etc/
 {% endif -%}
 Sitemap: {{ request.scheme }}://{{ request.get_host() }}/sitemap.xml

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -259,7 +259,9 @@ SUPPORTED_NONLOCALES = [
     'country-code.json',
 ]
 
-# Pages that we don't want be indexed by search engines.
+# Pages that we don't want to be indexed by search engines.
+# Only impacts sitemap generator. If you need to disallow indexing of
+# specific URLs, add them to mozorg/templates/mozorg/robots.txt.
 NOINDEX_URLS = [
     r'^(404|500)/',
     r'^about/partnerships/contact-bizdev/',


### PR DESCRIPTION
## Description

Disallows indexing of all pages in `/etc` app.

## Issue / Bugzilla link

https://bugzilla.mozilla.org/show_bug.cgi?id=1395575