### PR TITLE
[fix bug 1392680] Enable /new/?xv=fast for l10n to support German ad campaign

### DIFF
--- a/bedrock/firefox/templates/firefox/new/sem/base.html
+++ b/bedrock/firefox/templates/firefox/new/sem/base.html
@@ -2,6 +2,9 @@
  # License, v. 2.0. If a copy of the MPL was not distributed with this
  # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
 
+{# Bug 1392680: (limited) localization of ?xv=fast variation only #}
+{% add_lang_files "firefox/new/sem" %}
+
 {% extends "firefox/base-resp.html" %}
 
 {% block extra_meta %}
@@ -9,8 +12,8 @@
 {% endblock %}
 
 {% block page_title_prefix %}{% endblock %}
-{% block page_title %}Free Web Browser for Android, iOS, Desktop | Firefox{% endblock %}
-{% block page_desc %}Millions of people around the world trust Firefox Web browsers on Android, iOS and desktop computers. Fast. Private. Download now!{% endblock %}
+{% block page_title %}{{ _('Free Web Browser for Android, iOS, Desktop') }} | {{ _('Firefox') }}{% endblock %}
+{% block page_desc %}{{ _('Millions of people around the world trust Firefox Web browsers on Android, iOS and desktop computers. Fast. Private. Download now!') }}{% endblock %}
 
 {% block page_css %}
   {% stylesheet 'firefox_new_sem' %}
@@ -35,7 +38,7 @@
       {% endblock %}
 
       <div id="download-button-wrapper-scene1">
-        {{ download_firefox( locale_in_transition=true, dom_id="download-firefox") }}
+        {{ download_firefox(locale_in_transition=true, dom_id="download-firefox") }}
       </div>
 
       {# this button is used only for scene 2's #}
@@ -51,23 +54,33 @@
   <div class="content">
     <ul id="details">
       <li id="content-1">
-        <h3>More Browser Speed</h3>
+        <h3>{{ _('More Browser Speed') }}</h3>
         <p>
-          Bring it, Internet! We’ve spent the last year supercharging Firefox’s performance. Now start up faster, tab hop quicker, and scroll like a speed demon.
+        {% trans %}
+          Bring it, Internet! We’ve spent the last year supercharging Firefox’s performance.
+          Now start up faster, tab hop quicker, and scroll like a speed demon.
+        {% endtrans %}
         </p>
       </li>
 
       <li id="content-2">
-        <h3>More Browser Privacy</h3>
+        <h3>{{ _('More Browser Privacy') }}</h3>
         <p>
-          Firefox doesn’t sell access to your personal information like other companies. From privacy tools to tracking protection, you’re in charge of who sees what.
+        {% trans %}
+          Firefox doesn’t sell access to your personal information like other companies.
+          From privacy tools to tracking protection, you’re in charge of who sees what.
+        {% endtrans %}
         </p>
       </li>
 
       <li id="content-3">
-        <h3>More Browser Freedom</h3>
+        <h3>{{ _('More Browser Freedom') }}</h3>
         <p>
-          Following the pack isn’t our style. As part of the non-profit Mozilla, Firefox leads the fight to protect your online rights, and champion an Internet that benefits everyone—not just a few.
+        {% trans %}
+          Following the pack isn’t our style. As part of the non-profit Mozilla, Firefox
+          leads the fight to protect your online rights, and champion an Internet that
+          benefits everyone—not just a few.
+        {% endtrans %}
         </p>
       </li>
     </ul>
@@ -79,9 +92,9 @@
 <section class="content-section" id="today">
   <div class="content">
     <div id="download-contain">
-      <h3>Browse freely with Firefox today.</h3>
+      <h3>{{ _('Browse freely with Firefox today.') }}</h3>
 
-      {{ download_firefox( locale_in_transition=true, dom_id="download-firefox-today") }}
+      {{ download_firefox(locale_in_transition=true, dom_id="download-firefox-today") }}
     </div>
   </div>
 </section>

--- a/bedrock/firefox/templates/firefox/new/sem/fast/scene1.html
+++ b/bedrock/firefox/templates/firefox/new/sem/fast/scene1.html
@@ -2,16 +2,20 @@
  # License, v. 2.0. If a copy of the MPL was not distributed with this
  # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
 
+{% add_lang_files "firefox/new/sem" %}
+
 {% extends "firefox/new/sem/base.html" %}
 
 {% block head_content %}
   <h2 id="head_content_title" data-experience="fast">
-    The fastest Firefox ever
+    {{ _('The fastest Firefox ever') }}
   </h2>
 
   <p>
+  {% trans %}
     The new multi-process Firefox is faster than ever and uses less memory than
     Chrome, so you can browse smoothly and leave plenty of memory to keep your
     computer snappy.
+  {% endtrans %}
   </p>
 {% endblock %}

--- a/bedrock/firefox/templates/firefox/new/sem/fast/scene2.html
+++ b/bedrock/firefox/templates/firefox/new/sem/fast/scene2.html
@@ -2,17 +2,19 @@
  # License, v. 2.0. If a copy of the MPL was not distributed with this
  # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
 
+{% add_lang_files "firefox/new/sem" %}
+
 {% extends "firefox/new/sem/base.html" %}
 
 {% block body_class %}fx-sem-scene2{% endblock %}
 
 {% block head_content %}
-  <h2>
-    Thanks for choosing Firefox
-  </h2>
+  <h2>{{ _('Thanks for choosing Firefox') }}</h2>
 
   <p>
-    Your download should begin automatically. <br>If not, <a id="direct-download-link" href="{{ url('firefox.all') }}">click here</a>.
+  {% trans id='direct-download-link', fallback_url=url('firefox.all') %}
+    Your download should begin automatically. <br>If not, <a id="{{ id }}" href="{{ fallback_url }}">click here</a>.
+  {% endtrans %}
   </p>
 {% endblock %}
 

--- a/bedrock/firefox/tests/test_views.py
+++ b/bedrock/firefox/tests/test_views.py
@@ -459,18 +459,6 @@ class TestFirefoxNew(TestCase):
 
     # sem program campaign bug 1383063
 
-    def test_fast_scene_1(self, render_mock):
-        req = RequestFactory().get('/firefox/new/?xv=fast')
-        req.locale = 'en-US'
-        views.new(req)
-        render_mock.assert_called_once_with(req, 'firefox/new/sem/fast/scene1.html')
-
-    def test_fast_scene_2(self, render_mock):
-        req = RequestFactory().get('/firefox/new/?scene=2&xv=fast')
-        req.locale = 'en-US'
-        views.new(req)
-        render_mock.assert_called_once_with(req, 'firefox/new/sem/fast/scene2.html')
-
     def test_secure_scene_1(self, render_mock):
         req = RequestFactory().get('/firefox/new/?xv=secure')
         req.locale = 'en-US'
@@ -518,6 +506,48 @@ class TestFirefoxNew(TestCase):
         req.locale = 'en-US'
         views.new(req)
         render_mock.assert_called_once_with(req, 'firefox/new/sem/unsupported-browser/scene2.html')
+
+    # localized sem /fast page bug 1392680
+
+    def test_fast_scene_1(self, render_mock):
+        req = RequestFactory().get('/firefox/new/?xv=fast')
+        req.locale = 'en-US'
+        views.new(req)
+        render_mock.assert_called_once_with(req, 'firefox/new/sem/fast/scene1.html')
+
+    def test_fast_scene_2(self, render_mock):
+        req = RequestFactory().get('/firefox/new/?scene=2&xv=fast')
+        req.locale = 'en-US'
+        views.new(req)
+        render_mock.assert_called_once_with(req, 'firefox/new/sem/fast/scene2.html')
+
+    @patch.object(views, 'lang_file_is_active', lambda *x: True)
+    def test_fast_locale_scene_1(self, render_mock):
+        req = RequestFactory().get('/firefox/new/?xv=fast')
+        req.locale = 'de'
+        views.new(req)
+        render_mock.assert_called_once_with(req, 'firefox/new/sem/fast/scene1.html')
+
+    @patch.object(views, 'lang_file_is_active', lambda *x: True)
+    def test_fast_locale_scene_2(self, render_mock):
+        req = RequestFactory().get('/firefox/new/?scene=2&xv=fast')
+        req.locale = 'de'
+        views.new(req)
+        render_mock.assert_called_once_with(req, 'firefox/new/sem/fast/scene2.html')
+
+    @patch.object(views, 'lang_file_is_active', lambda *x: False)
+    def test_fast_not_translated_scene_1(self, render_mock):
+        req = RequestFactory().get('/firefox/new/?xv=fast')
+        req.locale = 'de'
+        views.new(req)
+        render_mock.assert_called_once_with(req, 'firefox/new/scene1.html')
+
+    @patch.object(views, 'lang_file_is_active', lambda *x: False)
+    def test_fast_not_translated_scene_2(self, render_mock):
+        req = RequestFactory().get('/firefox/new/?scene=2&xv=fast')
+        req.locale = 'de'
+        views.new(req)
+        render_mock.assert_called_once_with(req, 'firefox/new/scene2.html')
 
     # browse against the machine bug 1363802, 1364988.
 

--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -509,7 +509,12 @@ def new(request):
     locale = l10n_utils.get_locale(request)
 
     if scene == '2':
-        if locale == 'en-US':
+        # `batmprivate` and `fast` variations are currently localized for both en-US and de locales.
+        if lang_file_is_active('firefox/new/batm', locale) and experience == 'batmprivate':
+            template = 'firefox/new/batm/scene2.html'
+        elif lang_file_is_active('firefox/new/sem', locale) and experience == 'fast':
+            template = 'firefox/new/sem/fast/scene2.html'
+        elif locale == 'en-US':
             if experience == 'breakfree':
                 template = 'firefox/new/break-free/scene2.html'
             elif experience == 'wayofthefox':
@@ -528,8 +533,6 @@ def new(request):
                 template = 'firefox/new/fx-lifestyle/you-do-you/scene2.html'
             elif experience == 'itsyourweb':
                 template = 'firefox/new/fx-lifestyle/its-your-web/scene2.html'
-            elif experience == 'fast':
-                template = 'firefox/new/sem/fast/scene2.html'
             elif experience == 'secure':
                 template = 'firefox/new/sem/secure/scene2.html'
             elif experience == 'nonprofit':
@@ -538,18 +541,22 @@ def new(request):
                 template = 'firefox/new/sem/compatible/scene2.html'
             elif experience == 'unsupported-browser':
                 template = 'firefox/new/sem/unsupported-browser/scene2.html'
-            elif experience in ['batmfree', 'batmprivate', 'batmnimble', 'batmresist']:
+            elif experience in ['batmfree', 'batmnimble', 'batmresist']:
                 template = 'firefox/new/batm/scene2.html'
             else:
                 template = 'firefox/new/scene2.html'
-        # aside from en-US, this will only be seen for 'de' locale
-        elif lang_file_is_active('firefox/new/batm', locale) and experience == 'batmprivate':
-            template = 'firefox/new/batm/scene2.html'
         else:
             template = 'firefox/new/scene2.html'
     # if no/incorrect scene specified, show scene 1
     else:
-        if locale == 'en-US':
+        if lang_file_is_active('firefox/new/batm', locale) and experience == 'batmprivate':
+            if variant == 'b' and locale == 'en-US':
+                template = 'firefox/new/batm/machine.html'
+            else:
+                template = 'firefox/new/batm/private.html'
+        elif lang_file_is_active('firefox/new/sem', locale) and experience == 'fast':
+            template = 'firefox/new/sem/fast/scene1.html'
+        elif locale == 'en-US':
             if experience == 'breakfree':
                 template = 'firefox/new/break-free/scene1.html'
             elif experience == 'wayofthefox':
@@ -568,8 +575,6 @@ def new(request):
                 template = 'firefox/new/fx-lifestyle/you-do-you/scene1.html'
             elif experience == 'itsyourweb':
                 template = 'firefox/new/fx-lifestyle/its-your-web/scene1.html'
-            elif experience == 'fast':
-                template = 'firefox/new/sem/fast/scene1.html'
             elif experience == 'secure':
                 template = 'firefox/new/sem/secure/scene1.html'
             elif experience == 'nonprofit':
@@ -584,15 +589,8 @@ def new(request):
                 template = 'firefox/new/batm/nimble.html'
             elif experience == 'batmresist':
                 template = 'firefox/new/batm/resist.html'
-            elif experience == 'batmprivate':
-                if variant == 'b':
-                    template = 'firefox/new/batm/machine.html'
-                else:
-                    template = 'firefox/new/batm/private.html'
             else:
                 template = 'firefox/new/scene1.html'
-        elif lang_file_is_active('firefox/new/batm', locale) and experience == 'batmprivate':
-            template = 'firefox/new/batm/private.html'
         else:
             template = 'firefox/new/scene1.html'
 


### PR DESCRIPTION
## Description
- Enables `firefox/new/?xv=fast` for translation
- Checks for lang file `'firefox/new/sem'`

## Issue / Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1392680

## Testing
- Check that this deck of cards is still standing (thankfully we have some tests)
