### PR TITLE
Fix Bug 1396550 - Firefox for Android Nightly is pointing at obsolete api-15 folder

### DIFF
--- a/bedrock/firefox/tests/test_base.py
+++ b/bedrock/firefox/tests/test_base.py
@@ -151,7 +151,7 @@ class TestFirefoxAll(TestCase):
     def test_android(self):
         """
         The Firefox for Android download table should only show the multi-locale
-        builds for api-15 and x86.
+        builds for ARM and x86.
         """
         resp = self.client.get(self._get_url('android'))
         doc = pq(resp.content)

--- a/media/css/pebbles/components/_buttons-download.scss
+++ b/media/css/pebbles/components/_buttons-download.scss
@@ -184,7 +184,7 @@ ul.download-list {
 
 // Android architecture detection
 .download-button .download-list .os_android.x86,
-.download-button .download-other.os_android .api-15,
+.download-button .download-other.os_android .arm,
 .android.x86 .download-button .download-list .os_android.armv7up,
 .android.x86 .download-button .download-other.os_android .x86 {
     display: none !important;

--- a/media/css/sandstone/buttons.less
+++ b/media/css/sandstone/buttons.less
@@ -383,7 +383,7 @@ ul.download-list {
 
 // Android architecture detection
 .download-button .download-list .os_android.x86,
-.download-button .download-other.os_android .api-15,
+.download-button .download-other.os_android .arm,
 .android.x86 .download-button .download-list .os_android.armv7up,
 .android.x86 .download-button .download-other.os_android .x86 {
     display: none !important;


### PR DESCRIPTION
## Description

The download link of Firefox Nightly for Android is broken due the an Android API update. Firefox 56+ requires Android 4.1 (API 16) instead of Android 4.0.3 (API 15). This PR will fix the issue. This kind of complexity will be solved once Android Nightly gets bouncer URLs :sweat_smile:

Updated the relevant CSS files as well, but I think it's no longer used since all the Android download buttons are currently pointing Google Play.

## Issue / Bugzilla link

[Bug 1396550](https://bugzilla.mozilla.org/show_bug.cgi?id=1396550)

## Testing

* Visit `/firefox/android/nightly/all/` and make sure the ARM download link works properly. The label should say "ARM devices (Android 4.1+)".
* Visit `/firefox/android/beta/all/`. The label should say "ARM devices (Android 4.1+)".
* Visit `/firefox/android/all/`. The label should still say "ARM devices (Android 4.0.3+)".