### PR TITLE
Fix Bug 1396560 - Release notes updates for nightly are published before the HTML page is updated

### DIFF
--- a/bedrock/releasenotes/views.py
+++ b/bedrock/releasenotes/views.py
@@ -103,7 +103,6 @@ def check_url(product, version):
         return reverse('firefox.system_requirements', args=[version])
 
 
-@cache_control_expires(1)
 def release_notes(request, version, product='Firefox'):
     if not version:
         raise Http404


### PR DESCRIPTION
## Description

I've just removed the 1-hour caching option from the release notes, so the HTML pages will always be up-to-date. Non-Nightly release notes could still be cached, but there's an idea to [provide feeds for those notes](https://bugzilla.mozilla.org/show_bug.cgi?id=1366651) as well.

Adding `@cache_control_expires(1)` to `def nightly_feed` won't solve the issue, because the caching timing of the Atom feed and HTML page won't be the same.

## Issue / Bugzilla link

[Bug 1396560](https://bugzilla.mozilla.org/show_bug.cgi?id=1396560)

## Testing

I think there's no easy way to test the change.