### PR TITLE
[fix bug 1391829] Add Dev Edition to Firefox secondary nav

### DIFF
--- a/bedrock/base/templates/includes/global-nav.html
+++ b/bedrock/base/templates/includes/global-nav.html
@@ -105,6 +105,11 @@
                   </a>
                 </li>
                 <li>
+                  <a href="{{ url('firefox.products.developer') }}" data-link-type="nav" data-link-name="Developer Edition" data-link-group="Firefox">
+                    {{ _('Developer Edition') }}
+                  </a>
+                </li>
+                <li>
                   <a href="{{ url('firefox.features.index')}}" data-link-type="nav" data-link-name="Features" data-link-group="Firefox">
                     {{ _('Features') }}
                   </a>

--- a/bedrock/firefox/templates/firefox/includes/hub/sub-nav.html
+++ b/bedrock/firefox/templates/firefox/includes/hub/sub-nav.html
@@ -32,6 +32,7 @@
 <li><a href="{{ url('firefox.android.index') }}" data-link-name="Android Browser" data-link-type="nav" data-link-position="subnav">{{ android_text }}</a></li>
 <li><a href="{{ url('firefox.ios') }}" data-link-name="iOS Browser" data-link-type="nav" data-link-position="subnav">{{ ios_text }}</a></li>
 <li><a href="{{ url('firefox.focus') }}" data-link-name="Focus Browser" data-link-type="nav" data-link-position="subnav">{{ focus_text }}</a></li>
+<li><a href="{{ url('firefox.products.developer') }}" data-link-name="Developer Edition" data-link-type="nav" data-link-position="subnav">{{ _('Developer Edition') }}</a></li>
 <li><a href="{{ url('firefox.features.index') }}" data-link-name="Features" data-link-type="nav" data-link-position="subnav">{{ _('Features') }}</a></li>
 <li><a href="https://support.mozilla.org/?utm_source=www.mozilla.org&amp;utm_medium=referral&amp;utm_campaign=fx-sub-nav" data-link-name="Support" data-link-type="nav" data-link-position="subnav">{{ _('Support') }}</a></li>
 {% endblock %}


### PR DESCRIPTION
## Description
- Adds "Developer Edition" to secondary nav on Firefox
- ~en-US only for now, until we have enough locales translated with the new string.~

## Issue / Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1391829
