### PR TITLE
[fix bug 1393549, bug 1393548] Update Sync and Send Tabs feature pages

### DIFF
--- a/bedrock/firefox/templates/firefox/features/base.html
+++ b/bedrock/firefox/templates/firefox/features/base.html
@@ -27,7 +27,9 @@
             {% block features_header_content %}{% endblock %}
           </div>
           <div class="header-download">
-            {{ download_firefox(dom_id='features-header-download', button_color='button-arrow', download_location='primary cta') }}
+            {% block features_header_download %}
+              {{ download_firefox(dom_id='features-header-download', button_color='button-arrow', download_location='primary cta') }}
+            {% endblock %}
           </div>
         </div>
         {% block features_header_image %}{% endblock %}

--- a/bedrock/firefox/templates/firefox/features/send-tabs.html
+++ b/bedrock/firefox/templates/firefox/features/send-tabs.html
@@ -35,10 +35,56 @@
 
 {% block features_header_content %}
   <h1><span>{{ _('Take your tabs to go') }}</span></h1>
-  <p class="tagline">{{ _('Share your open tabs seamlessly across mobile, desktop or tablet with Firefox.') }}</p>
+  {% if l10n_has_tag('send-tabs-update-08-2017') %}
+    <p class="tagline show-not-fx show-fx-31-signed-out show-fx-30-older show-default">{{ _('Share your open tabs seamlessly across mobile, desktop or tablet with Firefox.') }}</p>
+    <p class="tagline show-fx-31-signed-in">{{ _('View your open tabs across mobile and tablet devices by signing in to your Firefox Account.') }}</p>
+    <p class="tagline show-fx-android show-fx-ios">{{ _('View your open tabs across desktop and tablet too. Just sign in or create a Firefox account.') }}</p>
+  {% else %}
+    <p class="tagline">{{ _('Share your open tabs seamlessly across mobile, desktop or tablet with Firefox.') }}</p>
+  {% endif %}
+{% endblock %}
+
+{% block features_header_download %}
+{% if l10n_has_tag('send-tabs-update-08-2017') %}
+  <div class="show-not-fx show-default">
+    {{ download_firefox(dom_id='features-header-download', button_color='button-arrow', download_location='primary cta') }}
+  </div>
+  <div class="show-fx-31-signed-out">
+    <button class="button button-hollow" data-button-name="Create account" data-cta-position="Primary" id="cta-sync">
+      {{ _('Create account') }}
+    </button>
+  </div>
+  <div class="show-fx-31-signed-in">
+    <p>{{ _('Get the app') }}</p>
+    <ul class="primary-buttons">
+      <li>
+        {{ google_play_button(id='cta-android', anchor_attributes={'data-download-location': 'primary cta'}) }}
+      </li>
+      <li>
+        <a href="{{ firefox_ios_url('mozorg-sync_page-appstore-button') }}" data-link-type="download" data-download-os="iOS" data-download-location="primary cta" id="cta-ios">
+          <img src="{{ l10n_img('firefox/ios/btn-app-store.svg') }}" alt="{{ _('Download on the App Store') }}" width="152" height="45">
+        </a>
+      </li>
+    </ul>
+  </div>
+  <div class="show-fx-30-older">
+    <a href="https://support.mozilla.org/kb/update-firefox-latest-version/?utm_source=www.mozilla.org&amp;utm_medium=referral&amp;utm_campaign=fx-send-tabs-page" class="button button-hollow" data-link-type="link" data-link-name="Update your Firefox" id="cta-update">
+      {{ _('Update your Firefox') }}
+    </a>
+  </div>
+  <div class="show-fx-android">
+    <a href="https://support.mozilla.org/kb/sync-bookmarks-tabs-history-and-passwords-android/?utm_source=www.mozilla.org&amp;utm_medium=referral&amp;utm_campaign=fx-send-tabs-page" class="button button-hollow" data-link-type="link" data-link-name="Learn more">{{ _('Learn more') }}</a>
+  </div>
+  <div class="show-fx-ios">
+      <a href="https://support.mozilla.org/kb/sync-firefox-bookmarks-and-browsing-history-iOS/?utm_source=www.mozilla.org&amp;utm_medium=referral&amp;utm_campaign=fx-send-tabs-page" class="button button-hollow" data-link-type="link" data-link-name="Learn more">{{ _('Learn more') }}</a>
+  </div>
+{% else %}
+  {{ download_firefox(dom_id='features-header-download', button_color='button-arrow', download_location='primary cta') }}
+{% endif %}
 {% endblock %}
 
 {% block features_list %}
+{% if not l10n_has_tag('send-tabs-update-08-2017') %}
 <section>
   <div class="content">
     <h2 class="section-title"><span>{{ _('Send tabs') }}</span></h2>
@@ -110,6 +156,7 @@
     </div>{#--/#sync-intro-copy-cta-wrapper--#}
   </div>{#--/.content--#}
 </section>
+{% endif %}
 
 <section class="features-list-section">
   <div class="content">

--- a/bedrock/firefox/templates/firefox/features/sync-old.html
+++ b/bedrock/firefox/templates/firefox/features/sync-old.html
@@ -1,0 +1,197 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+
+{% from "macros.html" import google_play_button with context %}
+
+{% add_lang_files "firefox/shared" "firefox/sync" %}
+
+{% extends "firefox/features/base.html" %}
+
+{% block page_title %}
+  {{ _('Use Bookmarks, Tabs and Passwords Across Devices | Firefox') }}
+{% endblock %}
+
+{% block page_desc %}
+  {{ _('Bring your Firefox bookmarks, tabs, or passwords wherever you go with Firefox Sync. Share between computers and mobile devices. Get Firefox now!') }}
+{% endblock %}
+
+{% block page_css %}
+  {{ super() }}
+  {% stylesheet 'firefox-features-hub-detail' %}
+  {% stylesheet 'firefox-features-sync' %}
+{% endblock %}
+
+{% block body_id %}firefox-features-sync{% endblock %}
+
+{% block body_class %}
+  {{ super() }}
+  state-default
+{% endblock %}
+
+{% block features_header_image %}
+  {{ high_res_img('firefox/features/sync-hero.png', {'class': 'hero-image', 'alt': '', 'width': '700', 'height': '390'}) }}
+{% endblock %}
+
+{% block features_header_content %}
+  <h1><span>{{ _('Firefox Sync') }}</span></h1>
+{% endblock %}
+
+{% block features_list %}
+<section>
+  <div class="content">
+    <h2 class="section-title"><span>{{ _('Sync') }}</span></h2>
+
+    <div id="sync-intro-copy-cta-wrapper">
+      <div id="sync-intro-copy">
+        {# Warning Text #}
+        <div class="show-fx-30-older warning">
+          <p>
+            <span>{{ _('It looks like you’re running an older version of Firefox.') }}</span>
+          </p>
+        </div>
+
+        <div class="show-not-fx warning">
+          <p>
+            <span>
+              {{ _('Sync is just one of the great features you’ll only get with Firefox.') }}
+            </span>
+          </p>
+        </div>
+
+        <div class="show-fx-31-signed-in">
+        {% if l10n_has_tag('sync-update-q3-2017') %}
+          <strong>{{ _('Browse boldly. Connect your devices.') }}</strong>
+          <p>
+            {{ _('Add Firefox on your personal devices to get your bookmarks, open tabs and passwords anywhere. Get secure access to everything you need when you sign into your Firefox Account.') }}
+          </p>
+        {% else %}
+          <strong>{{ _('Ready, Set, Sync') }}</strong>
+          <p>
+            {{ _('You’re signed up and ready to access <em>your</em> Firefox anywhere, anytime.') }}
+          </p>
+        {% endif %}
+        </div>
+
+      {% if l10n_has_tag('sync-update-q3-2017') %}
+        <div class="show-fx-31-signed-out show-fx-android show-fx-ios">
+          <strong>{{ _('Your web, how you like it, everywhere') }}</strong>
+          <p>
+            {{ _('Sign into your Firefox Account to access your protected passwords, open tabs and bookmarks. Add Firefox to your personal devices and securely connect your browsing experience everywhere. Keep everything set up how you like it, wherever you go.') }}
+          </p>
+        </div>
+        <div class="show-not-fx show-default">
+          <strong>{{ _('If you lived here you’d be home by now') }}</strong>
+          <p>
+            {{ _('Download or open Firefox to start securely connecting your browsing experience on all your personal devices. Sign into your Firefox Account to access your protected passwords, open tabs and bookmarks. Keep everything set up how you like it, wherever you go.') }}
+          </p>
+        </div>
+      {% else %}
+        <div class="show-fx-31-signed-out show-fx-android show-fx-ios show-not-fx show-default">
+          <strong>{{ _('Take your Web with you') }}</strong>
+          <p>
+            {{ _('Sync Firefox wherever you use it to access your bookmarks, passwords, tabs and more from any smartphone, tablet or computer.') }}
+          </p>
+        </div>
+      {% endif %}
+      </div>{#--/#sync-intro-copy--#}
+
+      <div id="sync-intro-cta">
+        <div class="show-fx-31-signed-in">
+          <ul class="primary-buttons">
+            <li>
+              {{ google_play_button(id='cta-android', anchor_attributes={'data-download-location': 'other'}) }}
+            </li>
+            <li>
+              <a href="{{ firefox_ios_url('mozorg-sync_page-appstore-button') }}" data-link-type="download" data-download-os="iOS" data-download-location="other" id="cta-ios">
+                <img src="{{ l10n_img('firefox/ios/btn-app-store.svg') }}" alt="{{ _('Download on the App Store') }}" width="152" height="45">
+              </a>
+            </li>
+          </ul>
+
+          <p class="button-footer">
+            <a href="https://support.mozilla.org/kb/how-do-i-set-up-firefox-sync" class="ga-link" data-interaction="outbound link click">
+              {{ _('Need help?') }}
+            </a>
+          </p>
+        </div>
+
+        <div class="show-fx-31-signed-out">
+          <button class="button button-hollow" data-button-name="Get started with Sync" data-cta-position="Primary" id="cta-sync">
+            {{ _('Get started with Sync') }}
+          </button>
+        </div>
+
+        <div class="show-fx-30-older">
+          <a href="https://support.mozilla.org/kb/update-firefox-latest-version" class="button button-hollow" data-interaction="button click" data-element-action="Sync CTA" id="cta-update">
+            {{ _('Update your Firefox') }}
+          </a>
+        </div>
+
+        <div class="show-not-fx">
+          {{ download_firefox(button_color='button-arrow', download_location='other') }}
+        </div>
+      </div>{#--/#sync-intro-cta--#}
+    </div>{#--/#sync-intro-copy-cta-wrapper--#}
+  </div>{#--/.content--#}
+</section>
+
+<section class="features-list-section">
+  <div class="content">
+    <h2 class="section-title"><span>{{ _('Features') }}</span></h2>
+
+    <ul class="features-list">
+      <li class="features-list-item">
+        <img src="{{ static('img/firefox/features/thumbnails/sync/personal.jpg') }}" alt="">
+      {% if l10n_has_tag('sync-update-q3-2017') %}
+        <h3>{{ _('Personal') }}</h3>
+        <p>
+          {{ _('That shopping rabbit hole you started on your laptop this morning? Pick up where you left off on your phone tonight. That dinner recipe you discovered at lunchtime? Open it on your kitchen tablet, instantly. Connect your personal devices, securely.') }}
+        </p>
+      {% else %}
+        <h3>{{ _('At home') }}</h3>
+        <p>
+          {{ _('Move from your desk to the couch without skipping a beat. Access your open tabs on your smartphone, or keeping browsing your bookmarks right on your tablet.') }}
+        </p>
+      {% endif %}
+      </li>
+
+      <li class="features-list-item">
+        <img src="{{ static('img/firefox/features/thumbnails/sync/secure.jpg') }}" alt="">
+      {% if l10n_has_tag('sync-update-q3-2017') %}
+        <h3>{{ _('Secure') }}</h3>
+        <p>
+          {{ _('Your Firefox Account is the doorway to all your web stuff—we help you keep it safe. Your data is always in your control, unreadable by anyone else, and encrypted with your account password. We protect it and hand you the key.') }}
+        </p>
+      {% else %}
+        <h3>{{ _('At work') }}</h3>
+        <p>
+          {{ _('Stay connected to all of your important information. Sync the passwords and bookmarks that you might need to access at any time. Just like Firefox, it’s safe as can be.') }}
+        </p>
+      {% endif %}
+      </li>
+
+      <li class="features-list-item">
+        <img src="{{ static('img/firefox/features/thumbnails/sync/accessible.jpg') }}" alt="">
+      {% if l10n_has_tag('sync-update-q3-2017') %}
+        <h3>{{ _('Accessible') }}</h3>
+        <p>
+          {{ _('Catch up on your open tabs and saved reads over Saturday morning coffee. Find your bookmarks and passwords anywhere you use Firefox—your smartphone, tablet or laptop. Connect everything you need and nothing you don’t.') }}
+        </p>
+      {% else %}
+        <h3>{{ _('On the go') }}</h3>
+        <p>
+          {{ _('Keep up with your favorite sites, or finish that story you started at home — wherever you go. With Sync, it’s never been easier.') }}
+        </p>
+      {% endif %}
+      </li>
+    </ul>
+
+  </div> {#--/.content--#}
+</section>
+{% endblock %}
+
+{% block js %}
+  {{ super() }}
+  {% javascript 'firefox-features-sync' %}
+{% endblock %}

--- a/bedrock/firefox/templates/firefox/features/sync.html
+++ b/bedrock/firefox/templates/firefox/features/sync.html
@@ -4,7 +4,7 @@
 
 {% from "macros.html" import google_play_button with context %}
 
-{% add_lang_files "firefox/shared" "firefox/sync" %}
+{% add_lang_files "firefox/shared" %}
 
 {% extends "firefox/features/base.html" %}
 
@@ -34,108 +34,51 @@
 {% endblock %}
 
 {% block features_header_content %}
-  <h1><span>{{ _('Firefox Sync') }}</span></h1>
+<h1>
+  <span class="show-not-fx show-fx-android show-fx-ios show-fx-31-signed-out show-fx-30-older show-default">{{ _('Browse uninterrupted with Firefox Sync') }}</span>
+  <span class="show-fx-31-signed-in">{{ _('Sync across devices') }}</span>
+</h1>
+<p class="tagline show-not-fx show-fx-31-signed-out show-fx-30-older show-default">{{ _('With Firefox on all your devices, you can access bookmarks, tabs and passwords with one easy sign-in.') }}</p>
+<p class="tagline show-fx-31-signed-in">{{ _('Sign in to your Firefox Account on mobile or tablet to get your open tabs, bookmarks and passwords anywhere.') }}</p>
+<p class="tagline show-fx-android show-fx-ios">{{ _('Sign in or create an account through your Firefox app for seamless browsing of passwords, bookmarks and open tabs.') }}</p>
+{% endblock %}
+
+{% block features_header_download %}
+<div class="show-not-fx show-default">
+  {{ download_firefox(dom_id='features-header-download', button_color='button-arrow', download_location='primary cta') }}
+</div>
+<div class="show-fx-31-signed-out">
+  <button class="button button-hollow" data-button-name="Create Account" data-cta-position="Primary" id="cta-sync">
+    {{ _('Create account') }}
+  </button>
+</div>
+<div class="show-fx-31-signed-in">
+  <p>{{ _('Get the app') }}</p>
+  <ul class="primary-buttons">
+    <li>
+      {{ google_play_button(id='cta-android', anchor_attributes={'data-download-location': 'primary cta'}) }}
+    </li>
+    <li>
+      <a href="{{ firefox_ios_url('mozorg-sync_page-appstore-button') }}" data-link-type="download" data-download-os="iOS" data-download-location="primary cta" id="cta-ios">
+        <img src="{{ l10n_img('firefox/ios/btn-app-store.svg') }}" alt="{{ _('Download on the App Store') }}" width="152" height="45">
+      </a>
+    </li>
+  </ul>
+</div>
+<div class="show-fx-30-older">
+  <a href="https://support.mozilla.org/kb/update-firefox-latest-version/?utm_source=www.mozilla.org&amp;utm_medium=referral&amp;utm_campaign=fx-sync-page" class="button button-hollow" data-link-type="link" data-link-name="Update your Firefox" id="cta-update">
+    {{ _('Update your Firefox') }}
+  </a>
+</div>
+<div class="show-fx-android">
+  <a href="https://support.mozilla.org/kb/sync-bookmarks-tabs-history-and-passwords-android/?utm_source=www.mozilla.org&amp;utm_medium=referral&amp;utm_campaign=fx-sync-page" class="button button-hollow" data-link-type="link" data-link-name="Learn more">{{ _('Learn more') }}</a>
+</div>
+<div class="show-fx-ios">
+    <a href="https://support.mozilla.org/kb/sync-firefox-bookmarks-and-browsing-history-iOS/?utm_source=www.mozilla.org&amp;utm_medium=referral&amp;utm_campaign=fx-sync-page" class="button button-hollow" data-link-type="link" data-link-name="Learn more">{{ _('Learn more') }}</a>
+</div>
 {% endblock %}
 
 {% block features_list %}
-<section>
-  <div class="content">
-    <h2 class="section-title"><span>{{ _('Sync') }}</span></h2>
-
-    <div id="sync-intro-copy-cta-wrapper">
-      <div id="sync-intro-copy">
-        {# Warning Text #}
-        <div class="show-fx-30-older warning">
-          <p>
-            <span>{{ _('It looks like you’re running an older version of Firefox.') }}</span>
-          </p>
-        </div>
-
-        <div class="show-not-fx warning">
-          <p>
-            <span>
-              {{ _('Sync is just one of the great features you’ll only get with Firefox.') }}
-            </span>
-          </p>
-        </div>
-
-        <div class="show-fx-31-signed-in">
-        {% if l10n_has_tag('sync-update-q3-2017') %}
-          <strong>{{ _('Browse boldly. Connect your devices.') }}</strong>
-          <p>
-            {{ _('Add Firefox on your personal devices to get your bookmarks, open tabs and passwords anywhere. Get secure access to everything you need when you sign into your Firefox Account.') }}
-          </p>
-        {% else %}
-          <strong>{{ _('Ready, Set, Sync') }}</strong>
-          <p>
-            {{ _('You’re signed up and ready to access <em>your</em> Firefox anywhere, anytime.') }}
-          </p>
-        {% endif %}
-        </div>
-
-      {% if l10n_has_tag('sync-update-q3-2017') %}
-        <div class="show-fx-31-signed-out show-fx-android show-fx-ios">
-          <strong>{{ _('Your web, how you like it, everywhere') }}</strong>
-          <p>
-            {{ _('Sign into your Firefox Account to access your protected passwords, open tabs and bookmarks. Add Firefox to your personal devices and securely connect your browsing experience everywhere. Keep everything set up how you like it, wherever you go.') }}
-          </p>
-        </div>
-        <div class="show-not-fx show-default">
-          <strong>{{ _('If you lived here you’d be home by now') }}</strong>
-          <p>
-            {{ _('Download or open Firefox to start securely connecting your browsing experience on all your personal devices. Sign into your Firefox Account to access your protected passwords, open tabs and bookmarks. Keep everything set up how you like it, wherever you go.') }}
-          </p>
-        </div>
-      {% else %}
-        <div class="show-fx-31-signed-out show-fx-android show-fx-ios show-not-fx show-default">
-          <strong>{{ _('Take your Web with you') }}</strong>
-          <p>
-            {{ _('Sync Firefox wherever you use it to access your bookmarks, passwords, tabs and more from any smartphone, tablet or computer.') }}
-          </p>
-        </div>
-      {% endif %}
-      </div>{#--/#sync-intro-copy--#}
-
-      <div id="sync-intro-cta">
-        <div class="show-fx-31-signed-in">
-          <ul class="primary-buttons">
-            <li>
-              {{ google_play_button(id='cta-android', anchor_attributes={'data-download-location': 'other'}) }}
-            </li>
-            <li>
-              <a href="{{ firefox_ios_url('mozorg-sync_page-appstore-button') }}" data-link-type="download" data-download-os="iOS" data-download-location="other" id="cta-ios">
-                <img src="{{ l10n_img('firefox/ios/btn-app-store.svg') }}" alt="{{ _('Download on the App Store') }}" width="152" height="45">
-              </a>
-            </li>
-          </ul>
-
-          <p class="button-footer">
-            <a href="https://support.mozilla.org/kb/how-do-i-set-up-firefox-sync" class="ga-link" data-interaction="outbound link click">
-              {{ _('Need help?') }}
-            </a>
-          </p>
-        </div>
-
-        <div class="show-fx-31-signed-out">
-          <button class="button button-hollow" data-button-name="Get started with Sync" data-cta-position="Primary" id="cta-sync">
-            {{ _('Get started with Sync') }}
-          </button>
-        </div>
-
-        <div class="show-fx-30-older">
-          <a href="https://support.mozilla.org/kb/update-firefox-latest-version" class="button button-hollow" data-interaction="button click" data-element-action="Sync CTA" id="cta-update">
-            {{ _('Update your Firefox') }}
-          </a>
-        </div>
-
-        <div class="show-not-fx">
-          {{ download_firefox(button_color='button-arrow', download_location='other') }}
-        </div>
-      </div>{#--/#sync-intro-cta--#}
-    </div>{#--/#sync-intro-copy-cta-wrapper--#}
-  </div>{#--/.content--#}
-</section>
-
 <section class="features-list-section">
   <div class="content">
     <h2 class="section-title"><span>{{ _('Features') }}</span></h2>
@@ -143,47 +86,26 @@
     <ul class="features-list">
       <li class="features-list-item">
         <img src="{{ static('img/firefox/features/thumbnails/sync/personal.jpg') }}" alt="">
-      {% if l10n_has_tag('sync-update-q3-2017') %}
         <h3>{{ _('Personal') }}</h3>
         <p>
           {{ _('That shopping rabbit hole you started on your laptop this morning? Pick up where you left off on your phone tonight. That dinner recipe you discovered at lunchtime? Open it on your kitchen tablet, instantly. Connect your personal devices, securely.') }}
         </p>
-      {% else %}
-        <h3>{{ _('At home') }}</h3>
-        <p>
-          {{ _('Move from your desk to the couch without skipping a beat. Access your open tabs on your smartphone, or keeping browsing your bookmarks right on your tablet.') }}
-        </p>
-      {% endif %}
       </li>
 
       <li class="features-list-item">
         <img src="{{ static('img/firefox/features/thumbnails/sync/secure.jpg') }}" alt="">
-      {% if l10n_has_tag('sync-update-q3-2017') %}
         <h3>{{ _('Secure') }}</h3>
         <p>
           {{ _('Your Firefox Account is the doorway to all your web stuff—we help you keep it safe. Your data is always in your control, unreadable by anyone else, and encrypted with your account password. We protect it and hand you the key.') }}
         </p>
-      {% else %}
-        <h3>{{ _('At work') }}</h3>
-        <p>
-          {{ _('Stay connected to all of your important information. Sync the passwords and bookmarks that you might need to access at any time. Just like Firefox, it’s safe as can be.') }}
-        </p>
-      {% endif %}
       </li>
 
       <li class="features-list-item">
         <img src="{{ static('img/firefox/features/thumbnails/sync/accessible.jpg') }}" alt="">
-      {% if l10n_has_tag('sync-update-q3-2017') %}
         <h3>{{ _('Accessible') }}</h3>
         <p>
           {{ _('Catch up on your open tabs and saved reads over Saturday morning coffee. Find your bookmarks and passwords anywhere you use Firefox—your smartphone, tablet or laptop. Connect everything you need and nothing you don’t.') }}
         </p>
-      {% else %}
-        <h3>{{ _('On the go') }}</h3>
-        <p>
-          {{ _('Keep up with your favorite sites, or finish that story you started at home — wherever you go. With Sync, it’s never been easier.') }}
-        </p>
-      {% endif %}
       </li>
     </ul>
 

--- a/bedrock/firefox/tests/test_views.py
+++ b/bedrock/firefox/tests/test_views.py
@@ -687,3 +687,20 @@ class TestFeedbackView(TestCase):
 
         ctx = view.get_context_data()
         self.assertFalse('donate_stars_url' in ctx)
+
+
+@override_settings(DEV=False)
+@patch('bedrock.firefox.views.l10n_utils.render')
+class TestSyncPage(TestCase):
+    def test_sync_page_template(self, render_mock):
+        req = RequestFactory().get('/firefox/features/sync/')
+        req.locale = 'en-US'
+        views.sync_page(req)
+        render_mock.assert_called_once_with(req, 'firefox/features/sync.html')
+
+    @patch.object(views, 'lang_file_is_active', lambda *x: False)
+    def test_old_sync_page_template(self, render_mock):
+        req = RequestFactory().get('/firefox/features/sync/')
+        req.locale = 'de'
+        views.sync_page(req)
+        render_mock.assert_called_once_with(req, 'firefox/features/sync-old.html')

--- a/bedrock/firefox/urls.py
+++ b/bedrock/firefox/urls.py
@@ -57,7 +57,7 @@ urlpatterns = (
         views.FeaturesPasswordManagerView.as_view(),
         name='firefox.features.password-manager'),
     page('firefox/features/send-tabs', 'firefox/features/send-tabs.html'),
-    page('firefox/features/sync', 'firefox/features/sync.html'),
+    url('^firefox/features/sync/$', views.sync_page, name='firefox.features.sync'),
     url(r'^firefox/focus/$',
         views.FirefoxFocusView.as_view(),
         name='firefox.focus'),

--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -675,3 +675,14 @@ class FirefoxHubView(BlogPostsView):
     blog_slugs = 'firefox'
     blog_tags = ['home']
     template_name = 'firefox/hub/home.html'
+
+
+def sync_page(request):
+    locale = l10n_utils.get_locale(request)
+
+    if lang_file_is_active('firefox/features/sync', locale):
+        template = 'firefox/features/sync.html'
+    else:
+        template = 'firefox/features/sync-old.html'
+
+    return l10n_utils.render(request, template)

--- a/media/css/firefox/features/sync.scss
+++ b/media/css/firefox/features/sync.scss
@@ -100,3 +100,14 @@ Thank you for your hard work.
 .state-default          .show-default {
     display: block;
 }
+
+// Heading variations need to be inline level elements
+.state-fx-31-signed-in  h1 > span.show-fx-31-signed-in,
+.state-fx-31-signed-out h1 > span.show-fx-31-signed-out,
+.state-fx-30-older      h1 > span.show-fx-30-older,
+.state-fx-android       h1 > span.show-fx-android,
+.state-fx-ios           h1 > span.show-fx-ios,
+.state-not-fx           h1 > span.show-not-fx,
+.state-default          h1 > span.show-default {
+    display: inline;
+}

--- a/tests/functional/firefox/features/test_features.py
+++ b/tests/functional/firefox/features/test_features.py
@@ -14,8 +14,7 @@ from pages.firefox.features.feature import FeaturePage
     ('fast'),
     ('memory'),
     ('bookmarks'),
-    ('password-manager'),
-    ('sync')])
+    ('password-manager')])
 def test_download_button_is_displayed(slug, base_url, selenium):
     page = FeaturePage(selenium, base_url, slug=slug).open()
     assert page.download_button.is_displayed


### PR DESCRIPTION
## Description
- Updates `features/sync` and `features/send-tabs` pages with more prominent CTA's.
- **Do not merge** until we confirm GA is all working as expected.

## Issue / Bugzilla link
- https://bugzilla.mozilla.org/show_bug.cgi?id=1393549
- https://bugzilla.mozilla.org/show_bug.cgi?id=1393548

## Testing
Demo:
- https://bedrock-demo-agibson.us-west.moz.works/en-US/firefox/features/sync/
- https://bedrock-demo-agibson.us-west.moz.works/en-US/firefox/features/send-tabs/

CTA states to test:
- Firefox signed into Sync (shows mobile buttons, custom header)
- Firefox signed out of Sync (shows create account button)
- Non-Firefox (shows download button)
- Firefox for iOS (shows SUMO link, custom header)
- Firefox for Android (shows SUMO link, custom header)
- Old Firefox (v < 31) (shows update firefox link)

Also test to make sure there are no regressions when the new l10n tags are not enabled?
