### PR TITLE
[fix bug 1396949] Remove format option from newsletter forms.

### DIFF
--- a/bedrock/newsletter/forms.py
+++ b/bedrock/newsletter/forms.py
@@ -227,9 +227,6 @@ class NewsletterFooterForm(forms.Form):
     # currently used on /contribute/friends/ (custom markup)
     first_name = forms.CharField(widget=forms.TextInput, required=False)
     last_name = forms.CharField(widget=forms.TextInput, required=False)
-    fmt = forms.ChoiceField(widget=forms.RadioSelect(renderer=SideRadios),
-                            choices=FORMATS,
-                            initial='H')
     privacy = forms.BooleanField(widget=PrivacyWidget)
     source_url = forms.URLField(required=False)
     newsletters = forms.CharField(widget=forms.HiddenInput,

--- a/bedrock/newsletter/templates/newsletter/includes/form.html
+++ b/bedrock/newsletter/templates/newsletter/includes/form.html
@@ -61,9 +61,6 @@
             {{ form.lang|safe }}
           </div>
         {% endif %}
-        <div class="field field-format">
-          {{ form.fmt|safe }}
-        </div>
         <div class="field field-privacy {% if form.privacy.errors %}form-field-error{% endif %}">
           {{ form.privacy|safe }}
         </div>

--- a/bedrock/newsletter/tests/test_forms.py
+++ b/bedrock/newsletter/tests/test_forms.py
@@ -178,13 +178,11 @@ class TestNewsletterFooterForm(TestCase):
             'first_name': 'Walter',
             'last_name': 'Sobchak',
             'privacy': True,
-            'fmt': 'H',
             'newsletters': self.newsletter_name,
         }
         form = NewsletterFooterForm(self.newsletter_name, locale='en-US', data=data.copy())
         self.assertTrue(form.is_valid(), form.errors)
         cleaned_data = form.cleaned_data
-        self.assertEqual(data['fmt'], cleaned_data['fmt'])
         self.assertEqual(data['lang'], cleaned_data['lang'])
 
     def test_country_default(self):
@@ -229,7 +227,6 @@ class TestNewsletterFooterForm(TestCase):
         data = {
             'email': 'foo@example.com',
             'privacy': True,
-            'fmt': 'H',
             'newsletters': self.newsletter_name,
         }
         form = NewsletterFooterForm(self.newsletter_name, locale='en-US', data=data.copy())
@@ -244,7 +241,6 @@ class TestNewsletterFooterForm(TestCase):
         data = {
             'email': 'foo@example.com',
             'privacy': False,
-            'fmt': 'H',
             'newsletters': self.newsletter_name,
         }
         form = NewsletterFooterForm(self.newsletter_name, locale='en-US', data=data)
@@ -261,7 +257,6 @@ class TestNewsletterFooterForm(TestCase):
             'email': 'fred@example.com',
             'lang': 'fr',
             'privacy': True,
-            'fmt': 'H',
             'newsletters': '',
         }
         form = NewsletterFooterForm('', locale='en-US', data=data.copy())
@@ -274,7 +269,6 @@ class TestNewsletterFooterForm(TestCase):
             'email': 'fred@example.com',
             'lang': 'fr',
             'privacy': True,
-            'fmt': 'H',
             'newsletters': invalid_newsletter,
         }
         form = NewsletterFooterForm(invalid_newsletter, locale='en-US', data=data.copy())

--- a/bedrock/newsletter/tests/test_views.py
+++ b/bedrock/newsletter/tests/test_views.py
@@ -554,7 +554,6 @@ class TestNewsletterSubscribe(TestCase):
         data = {
             'newsletters': 'flintstones',
             'email': 'fred@example.com',
-            'fmt': 'H',
         }
         resp = self.ajax_request(data)
         resp_data = json.loads(resp.content)
@@ -572,7 +571,6 @@ class TestNewsletterSubscribe(TestCase):
         data = {
             'newsletters': 'flintstones',
             'email': 'fred@example.com',
-            'fmt': 'H',
             'privacy': True,
             'country': '<svg/onload=alert("NEFARIOUSNESS")>',
         }
@@ -591,7 +589,6 @@ class TestNewsletterSubscribe(TestCase):
         data = {
             'newsletters': 'flintstones',
             'email': 'fred@example.com',
-            'fmt': 'H',
             'privacy': True,
         }
         source_url = 'https://example.com/bambam'
@@ -599,7 +596,7 @@ class TestNewsletterSubscribe(TestCase):
         resp_data = json.loads(resp.content)
         self.assertDictEqual(resp_data, {'success': True})
         basket_mock.subscribe.assert_called_with('fred@example.com', 'flintstones',
-                                                 format='H', source_url=source_url)
+                                                 source_url=source_url)
 
     @patch('bedrock.newsletter.views.basket')
     def test_use_source_url_with_referer(self, basket_mock):
@@ -608,7 +605,6 @@ class TestNewsletterSubscribe(TestCase):
         data = {
             'newsletters': 'flintstones',
             'email': 'fred@example.com',
-            'fmt': 'H',
             'privacy': True,
             'source_url': source_url
         }
@@ -616,7 +612,7 @@ class TestNewsletterSubscribe(TestCase):
         resp_data = json.loads(resp.content)
         self.assertDictEqual(resp_data, {'success': True})
         basket_mock.subscribe.assert_called_with('fred@example.com', 'flintstones',
-                                                 format='H', source_url=source_url)
+                                                 source_url=source_url)
 
     @patch('bedrock.newsletter.views.basket')
     def test_returns_ajax_success(self, basket_mock):
@@ -624,14 +620,12 @@ class TestNewsletterSubscribe(TestCase):
         data = {
             'newsletters': 'flintstones',
             'email': 'fred@example.com',
-            'fmt': 'H',
             'privacy': True,
         }
         resp = self.ajax_request(data)
         resp_data = json.loads(resp.content)
         self.assertDictEqual(resp_data, {'success': True})
-        basket_mock.subscribe.assert_called_with('fred@example.com', 'flintstones',
-                                                 format='H')
+        basket_mock.subscribe.assert_called_with('fred@example.com', 'flintstones')
 
     @patch.object(basket, 'subscribe')
     def test_returns_ajax_invalid_email(self, subscribe_mock):
@@ -641,7 +635,6 @@ class TestNewsletterSubscribe(TestCase):
         data = {
             'newsletters': 'flintstones',
             'email': 'fred@example.com',
-            'fmt': 'H',
             'privacy': True,
         }
         resp = self.ajax_request(data)
@@ -657,7 +650,6 @@ class TestNewsletterSubscribe(TestCase):
         data = {
             'newsletters': 'flintstones',
             'email': 'fred@example.com',
-            'fmt': 'H',
             'privacy': True,
         }
         resp = self.ajax_request(data)
@@ -678,7 +670,6 @@ class TestNewsletterSubscribe(TestCase):
         data = {
             'newsletters': 'flintstones',
             'email': 'fred@example.com',
-            'fmt': 'H',
             'privacy': True,
         }
         resp = self.request(data)
@@ -686,8 +677,7 @@ class TestNewsletterSubscribe(TestCase):
         self.assertFalse(doc('#footer_email_submit'))
         self.assertFalse(doc('input[value="mozilla-and-you"]'))
         self.assertTrue(doc('#email-form').hasClass('thank'))
-        basket_mock.subscribe.assert_called_with('fred@example.com', 'flintstones',
-                                                 format='H')
+        basket_mock.subscribe.assert_called_with('fred@example.com', 'flintstones')
 
     @patch('bedrock.newsletter.views.basket')
     def test_returns_failure(self, basket_mock):
@@ -695,7 +685,6 @@ class TestNewsletterSubscribe(TestCase):
         data = {
             'newsletters': 'flintstones',
             'email': 'fred@example.com',
-            'fmt': 'H',
         }
         resp = self.request(data)
         doc = pq(resp.content)

--- a/bedrock/newsletter/views.py
+++ b/bedrock/newsletter/views.py
@@ -589,7 +589,7 @@ def newsletter_subscribe(request):
         if form.is_valid():
             data = form.cleaned_data
 
-            kwargs = {'format': data['fmt']}
+            kwargs = {}
             # add optional data
             kwargs.update(dict((k, data[k]) for k in ['country',
                                                       'lang',
@@ -619,7 +619,7 @@ def newsletter_subscribe(request):
                 errors.append(_('Please enter a valid email address'))
             if 'privacy' in form.errors:
                 errors.append(_('You must agree to the privacy notice'))
-            for fieldname in ('fmt', 'lang', 'country'):
+            for fieldname in ('lang', 'country'):
                 if fieldname in form.errors:
                     errors.extend(form.errors[fieldname])
 

--- a/media/css/mozorg/home/home-b.scss
+++ b/media/css/mozorg/home/home-b.scss
@@ -475,7 +475,6 @@ main {
             margin: 0 0 1em;
         }
 
-        .field-format label,
         .field-privacy label {
             @include open-sans;
         }

--- a/media/css/mozorg/home/home.scss
+++ b/media/css/mozorg/home/home.scss
@@ -764,7 +764,6 @@ main {
             margin: 0 0 1em;
         }
 
-        .field-format label,
         .field-privacy label {
             @include open-sans;
         }

--- a/media/css/newsletter/fxnewsletter-subscribe.less
+++ b/media/css/newsletter/fxnewsletter-subscribe.less
@@ -88,11 +88,6 @@
         }
     }
 
-    .field-format label {
-        display: inline;
-        margin-right: 20px;
-    }
-
     input[type='email'] {
         .border-box;
         .border-radius(4px);

--- a/media/css/newsletter/moznewsletter-subscribe.less
+++ b/media/css/newsletter/moznewsletter-subscribe.less
@@ -113,11 +113,6 @@
         }
     }
 
-    .field-format label {
-        display: inline;
-        margin-right: 20px;
-    }
-
     input[type='email'] {
         .border-box;
         .border-radius(4px);

--- a/media/css/newsletter/newsletter-developer.scss
+++ b/media/css/newsletter/newsletter-developer.scss
@@ -115,11 +115,6 @@
         margin: 0 0 20px;
     }
 
-    .field-format label {
-        @include open-sans;
-        margin-right: 20px;
-    }
-
     .privacy-check-label {
         @include font-size(14px);
         @include open-sans;

--- a/media/css/newsletter/newsletter-firefox.scss
+++ b/media/css/newsletter/newsletter-firefox.scss
@@ -135,11 +135,6 @@ $color-fox-purple: #3a304b;
         margin: 0 0 20px;
     }
 
-    .field-format label {
-        @include open-sans;
-        margin-right: 20px;
-    }
-
     .privacy-check-label {
         @include font-size(14px);
         @include open-sans;

--- a/media/css/newsletter/newsletter-mozilla.scss
+++ b/media/css/newsletter/newsletter-mozilla.scss
@@ -128,11 +128,6 @@
         margin: 0 0 20px;
     }
 
-    .field-format label {
-        @include open-sans;
-        margin-right: 20px;
-    }
-
     .privacy-check-label {
         @include font-size(14px);
         @include open-sans;

--- a/media/css/pebbles/components/_newsletter.scss
+++ b/media/css/pebbles/components/_newsletter.scss
@@ -51,13 +51,6 @@
         }
     }
 
-    // html/text radio buttons
-    .field-format label {
-        @include open-sans;
-        display: inline;
-        margin-right: 20px;
-    }
-
     // privacy checkbox
     .field-privacy {
         @include font-size(12px);

--- a/tests/functional/contribute/test_friends.py
+++ b/tests/functional/contribute/test_friends.py
@@ -14,8 +14,6 @@ def test_signup_default_values(base_url, selenium):
     page = ContributeFriendsPage(selenium, base_url).open()
     assert '' == page.email
     assert 'United States' == page.country
-    assert page.html_format_selected
-    assert not page.text_format_selected
     assert not page.privacy_policy_accepted
     assert page.is_privacy_policy_link_displayed
 
@@ -34,7 +32,6 @@ def test_successful_sign_up(base_url, selenium):
     page = ContributeFriendsPage(selenium, base_url).open()
     page.type_email('success@example.com')
     page.select_country('Germany')
-    page.select_text_format()
     page.accept_privacy_policy()
     page.click_sign_me_up()
     assert page.sign_up_successful

--- a/tests/functional/firefox/test_ios_testflight.py
+++ b/tests/functional/firefox/test_ios_testflight.py
@@ -13,8 +13,6 @@ from pages.firefox.ios_testflight import iOSTestFlightPage
 def test_signup_default_values(base_url, selenium):
     page = iOSTestFlightPage(selenium, base_url).open()
     assert '' == page.email
-    assert page.html_format_selected
-    assert not page.text_format_selected
     assert not page.privacy_policy_accepted
     assert not page.terms_accepted
     assert page.is_privacy_policy_link_displayed
@@ -25,7 +23,6 @@ def test_signup_default_values(base_url, selenium):
 def test_successful_sign_up(base_url, selenium):
     page = iOSTestFlightPage(selenium, base_url).open()
     page.type_email('success@example.com')
-    page.select_text_format()
     page.accept_privacy_policy()
     page.accept_terms()
     page.click_sign_me_up()

--- a/tests/functional/newsletter/test_newsletter_embed.py
+++ b/tests/functional/newsletter/test_newsletter_embed.py
@@ -59,13 +59,13 @@ def test_newsletter_default_values(page_class, url_kwargs, base_url, selenium):
 
 
 @pytest.mark.nondestructive
-@pytest.mark.parametrize('page_class', [HomePage, ContributePage, FirefoxHomePage])
+@pytest.mark.parametrize('page_class', [ContributePage, FirefoxHomePage,
+    pytest.mark.skip_if_firefox(HomePage, reason='https://bugzilla.mozilla.org/show_bug.cgi?id=1399945')])
 def test_newsletter_successful_sign_up(page_class, base_url, selenium):
     page = page_class(selenium, base_url).open()
     page.newsletter.expand_form()
     page.newsletter.type_email('success@example.com')
     page.newsletter.select_country('United Kingdom')
-    page.newsletter.select_text_format()
     page.newsletter.accept_privacy_policy()
     page.newsletter.click_sign_me_up()
     assert page.newsletter.sign_up_successful

--- a/tests/functional/newsletter/test_newsletter_landing.py
+++ b/tests/functional/newsletter/test_newsletter_landing.py
@@ -18,8 +18,6 @@ def test_default_values(page_class, base_url, selenium):
     assert '' == page.email
     assert 'United States' == page.country
     assert 'English' == page.language
-    assert page.html_format_selected
-    assert not page.text_format_selected
     assert not page.privacy_policy_accepted
     assert page.is_privacy_policy_link_displayed
 
@@ -30,8 +28,6 @@ def test_default_values_developer_newsletter(base_url, selenium):
     page = DeveloperNewsletterPage(selenium, base_url).open()
     assert '' == page.email
     assert 'United States' == page.country
-    assert page.html_format_selected
-    assert not page.text_format_selected
     assert not page.privacy_policy_accepted
     assert page.is_privacy_policy_link_displayed
 
@@ -43,7 +39,6 @@ def test_successful_sign_up(page_class, base_url, selenium):
     page.type_email('success@example.com')
     page.select_country('United Kingdom')
     page.select_language('Deutsch')
-    page.select_text_format()
     page.accept_privacy_policy()
     page.click_sign_me_up()
     assert page.sign_up_successful
@@ -54,7 +49,6 @@ def test_successful_sign_up_developer_newsletter(base_url, selenium):
     page = DeveloperNewsletterPage(selenium, base_url).open()
     page.type_email('success@example.com')
     page.select_country('United Kingdom')
-    page.select_text_format()
     page.accept_privacy_policy()
     page.click_sign_me_up()
     assert page.sign_up_successful

--- a/tests/pages/contribute/friends.py
+++ b/tests/pages/contribute/friends.py
@@ -16,13 +16,11 @@ class ContributeFriendsPage(ContributeBasePage):
     _email_locator = (By.ID, 'id_email')
     _fx_and_you_locator = (By.ID, 'id_fx-and-you')
     _country_locator = (By.ID, 'id_country')
-    _html_format_locator = (By.ID, 'id_fmt_0')
     _newsletters_locator = (By.ID, 'id_newsletters')
     _privacy_policy_checkbox_locator = (By.ID, 'id_privacy')
     _privacy_policy_link_locator = (By.CSS_SELECTOR, 'label[for="id_privacy"] span a')
     _signup_form_locator = (By.ID, 'newsletter-form')
     _submit_button_locator = (By.ID, 'footer_email_submit')
-    _text_format_locator = (By.ID, 'id_fmt_1')
     _thank_you_locator = (By.CSS_SELECTOR, '#newsletter-form-thankyou h3')
 
     @property
@@ -33,10 +31,6 @@ class ContributeFriendsPage(ContributeBasePage):
     def country(self):
         el = self.find_element(*self._country_locator)
         return el.find_element(By.CSS_SELECTOR, 'option[selected]').text
-
-    @property
-    def html_format_selected(self):
-        return self.find_element(*self._html_format_locator).is_selected()
 
     @property
     def is_signup_form_displayed(self):
@@ -59,10 +53,6 @@ class ContributeFriendsPage(ContributeBasePage):
     def sign_up_successful(self):
         return self.is_element_displayed(*self._thank_you_locator)
 
-    @property
-    def text_format_selected(self):
-        return self.find_element(*self._text_format_locator).is_selected()
-
     def accept_fx_and_you(self):
         el = self.find_element(*self._fx_and_you_locator)
         assert not el.is_selected(), 'Firefox and you has already been accepted'
@@ -82,9 +72,6 @@ class ContributeFriendsPage(ContributeBasePage):
     def select_country(self, value):
         el = self.find_element(*self._country_locator)
         Select(el).select_by_visible_text(value)
-
-    def select_text_format(self):
-        self.find_element(*self._text_format_locator).click()
 
     def type_email(self, value):
         self.find_element(*self._email_locator).send_keys(value)

--- a/tests/pages/firefox/ios_testflight.py
+++ b/tests/pages/firefox/ios_testflight.py
@@ -13,22 +13,16 @@ class iOSTestFlightPage(FirefoxBasePage):
     URL_TEMPLATE = '/{locale}/firefox/ios/testflight'
 
     _email_locator = (By.ID, 'id_email')
-    _html_format_locator = (By.ID, 'id_fmt_0')
     _privacy_policy_checkbox_locator = (By.ID, 'id_privacy')
     _privacy_policy_link_locator = (By.CSS_SELECTOR, 'label[for="id_privacy"] span a')
     _submit_button_locator = (By.ID, 'footer_email_submit')
     _terms_checkbox_locator = (By.ID, 'id_terms')
     _terms_link_locator = (By.CSS_SELECTOR, 'label[for="id_terms"] span a')
-    _text_format_locator = (By.ID, 'id_fmt_1')
     _thank_you_locator = (By.CSS_SELECTOR, '#newsletter-form-thankyou h2')
 
     @property
     def email(self):
         return self.find_element(*self._email_locator).get_attribute('value')
-
-    @property
-    def html_format_selected(self):
-        return self.find_element(*self._html_format_locator).is_selected()
 
     @property
     def is_privacy_policy_link_displayed(self):
@@ -52,10 +46,6 @@ class iOSTestFlightPage(FirefoxBasePage):
     def sign_up_successful(self):
         return self.is_element_displayed(*self._thank_you_locator)
 
-    @property
-    def text_format_selected(self):
-        return self.find_element(*self._text_format_locator).is_selected()
-
     def accept_privacy_policy(self):
         el = self.find_element(*self._privacy_policy_checkbox_locator)
         assert not el.is_selected(), 'Privacy policy has already been accepted'
@@ -71,9 +61,6 @@ class iOSTestFlightPage(FirefoxBasePage):
     def click_sign_me_up(self):
         self.find_element(*self._submit_button_locator).click()
         self.wait.until(expected.visibility_of_element_located(self._thank_you_locator))
-
-    def select_text_format(self):
-        self.find_element(*self._text_format_locator).click()
 
     def type_email(self, value):
         self.find_element(*self._email_locator).send_keys(value)

--- a/tests/pages/newsletter/base.py
+++ b/tests/pages/newsletter/base.py
@@ -16,8 +16,6 @@ class NewsletterBasePage(BasePage):
     _email_locator = (By.ID, 'id_email')
     _country_locator = (By.ID, 'id_country')
     _language_locator = (By.ID, 'id_lang')
-    _html_format_locator = (By.ID, 'id_fmt_0')
-    _text_format_locator = (By.ID, 'id_fmt_1')
     _privacy_policy_checkbox_locator = (By.ID, 'id_privacy')
     _privacy_policy_link_locator = (By.CSS_SELECTOR, 'label[for="id_privacy"] a')
     _submit_button_locator = (By.ID, 'footer_email_submit')
@@ -47,20 +45,6 @@ class NewsletterBasePage(BasePage):
     def select_language(self, value):
         el = self.find_element(*self._language_locator)
         Select(el).select_by_visible_text(value)
-
-    @property
-    def html_format_selected(self):
-        return self.find_element(*self._html_format_locator).is_selected()
-
-    def select_html_format(self):
-        self.find_element(*self._html_format_locator).click()
-
-    @property
-    def text_format_selected(self):
-        return self.find_element(*self._text_format_locator).is_selected()
-
-    def select_text_format(self):
-        self.find_element(*self._text_format_locator).click()
 
     @property
     def privacy_policy_accepted(self):

--- a/tests/pages/regions/newsletter.py
+++ b/tests/pages/regions/newsletter.py
@@ -14,8 +14,6 @@ class NewsletterEmbedForm(Region):
     _email_locator = (By.ID, 'id_email')
     _form_details_locator = (By.ID, 'form-details')
     _country_locator = (By.ID, 'id_country')
-    _html_format_locator = (By.ID, 'id_fmt_0')
-    _text_format_locator = (By.ID, 'id_fmt_1')
     _privacy_policy_checkbox_locator = (By.ID, 'id_privacy')
     _privacy_policy_link_locator = (By.CSS_SELECTOR, 'label[for="id_privacy"] a')
     _submit_button_locator = (By.ID, 'footer_email_submit')
@@ -53,22 +51,6 @@ class NewsletterEmbedForm(Region):
     def select_country(self, value):
         el = self.find_element(*self._country_locator)
         Select(el).select_by_visible_text(value)
-
-    @property
-    def html_format_selected(self):
-        el = self.find_element(*self._html_format_locator)
-        return el.is_selected()
-
-    def select_html_format(self):
-        self.find_element(*self._html_format_locator).click()
-
-    @property
-    def text_format_selected(self):
-        el = self.find_element(*self._text_format_locator)
-        return el.is_selected()
-
-    def select_text_format(self):
-        self.find_element(*self._text_format_locator).click()
 
     @property
     def privacy_policy_accepted(self):


### PR DESCRIPTION
## Description

Removes the email format option (HTML/Text) from all newsletter forms (except from the preference center at `/newsletter/existing/`).

## Issue / Bugzilla link

https://bugzilla.mozilla.org/show_bug.cgi?id=1396949

## Testing

Ensure newsletter forms can be submitted successfully, both the standard footer forms and the form at `/newsletter/existing/`.
