### PR TITLE
Some small changes to FF retention pages in css and a link.

### DIFF
--- a/bedrock/etc/templates/etc/firefox/retention/thank-you-a.html
+++ b/bedrock/etc/templates/etc/firefox/retention/thank-you-a.html
@@ -47,7 +47,7 @@
     <article>
       <h1>{{ _('Get Firefox on your phone') }}</h1>
       <div class="time">{{ _('2 min install') }}</div>
-      <a href="https://support.mozilla.org/kb/install-firefox-android-device-using-google-play">{{ _('Download Firefox') }}</a>
+      <a href="https://www.mozilla.org/firefox/mobile-download/desktop/">{{ _('Download Firefox') }}</a>
     </article>
     <article>
       <h1>{{ _('Tell your friends about Firefox') }}</h1>

--- a/bedrock/etc/templates/etc/firefox/retention/thank-you-a.html
+++ b/bedrock/etc/templates/etc/firefox/retention/thank-you-a.html
@@ -47,7 +47,7 @@
     <article>
       <h1>{{ _('Get Firefox on your phone') }}</h1>
       <div class="time">{{ _('2 min install') }}</div>
-      <a href="https://www.mozilla.org/firefox/mobile-download/desktop/">{{ _('Download Firefox') }}</a>
+      <a href="{{ url('firefox.mobile-download-desktop') }}">{{ _('Download Firefox') }}</a>
     </article>
     <article>
       <h1>{{ _('Tell your friends about Firefox') }}</h1>
@@ -57,7 +57,7 @@
     <article>
       <h1>{{ _('Make the Internet a safer place') }}</h1>
       <div class="time">{{ _('4 min read') }}</div>
-      <a href="https://www.mozilla.org/internet-health/privacy-security/">{{ _('Learn more') }}</a>
+      <a href="{{ url('mozorg.internet-health.privacy-security') }}">{{ _('Learn more') }}</a>
     </article>
   </section>
 </main>

--- a/bedrock/etc/templates/etc/firefox/retention/thank-you-b.html
+++ b/bedrock/etc/templates/etc/firefox/retention/thank-you-b.html
@@ -49,7 +49,6 @@
       <span class="time">{{ _('1 min') }}</span>
       <h1>
         {{ _('Make Firefox your default browser') }}
-        <br/>
         <a href="https://support.mozilla.org/kb/make-firefox-your-default-browser">{{ _('Set as your default') }}</a>
       </h1>
     </article>
@@ -57,7 +56,6 @@
       <span class="time">{{ _('1 min') }}</span>
       <h1>
         {{ _('Tell your friends about Firefox') }}
-        <br/>
         <a href="{{ 'https://www.twitter.com/intent/tweet?url=%s&text=%s%s'|format('https://mozilla.org/firefox/new'|urlencode, '%F0%9F%94%A5%2B%F0%9F%A6%8A=%F0%9F%99%8C%F0%9F%8F%BE%20', _('Join me in the fight for an open web by choosing Firefox!')|urlencode)|e }}">{{ _('Send a tweet') }}</a>
       </h1>
     </article>
@@ -65,7 +63,6 @@
       <span class="time">{{ _('2 min') }}</span>
       <h1>
         {{ _('Get Firefox on your phone') }}
-        <br/>
         <a href="{{ url('firefox.mobile-download-desktop') }}">{{ _('Download Firefox') }}</a>
       </h1>
     </article>
@@ -73,7 +70,6 @@
       <span class="time">{{ _('4 min') }}</span>
       <h1>
         {{ _('Make the Internet a safer place') }}
-        <br/>
         <a href="{{ url('mozorg.internet-health.privacy-security') }}">{{ _('Learn more') }}</a>
       </h1>
     </article>

--- a/bedrock/etc/templates/etc/firefox/retention/thank-you-b.html
+++ b/bedrock/etc/templates/etc/firefox/retention/thank-you-b.html
@@ -61,7 +61,7 @@
       <h1>
         <span class="time">{{ _('2 min') }}</span>{{ _('Get Firefox on your phone') }}
       </h1>
-      <a href="https://support.mozilla.org/kb/install-firefox-android-device-using-google-play">{{ _('Download Firefox') }}</a>
+      <a href="https://www.mozilla.org/firefox/mobile-download/desktop/">{{ _('Download Firefox') }}</a>
     </article>
     <article>
       <h1>

--- a/bedrock/etc/templates/etc/firefox/retention/thank-you-b.html
+++ b/bedrock/etc/templates/etc/firefox/retention/thank-you-b.html
@@ -46,28 +46,36 @@
       {{ _('Here’s more super-easy things you can do to keep supporting our mission:') }}
     </h1>
     <article>
+      <span class="time">{{ _('1 min') }}</span>
       <h1>
-        <span class="time">{{ _('1 min') }}</span>{{ _('Make Firefox your default browser') }}
+        {{ _('Make Firefox your default browser') }}
+        <br/>
+        <a href="https://support.mozilla.org/kb/make-firefox-your-default-browser">{{ _('Set as your default') }}</a>
       </h1>
-      <a href="https://support.mozilla.org/kb/make-firefox-your-default-browser">{{ _('Set as your default') }}</a>
     </article>
     <article>
+      <span class="time">{{ _('1 min') }}</span>
       <h1>
-        <span class="time">{{ _('1 min') }}</span>{{ _('Tell your friends about Firefox') }}
+        {{ _('Tell your friends about Firefox') }}
+        <br/>
+        <a href="{{ 'https://www.twitter.com/intent/tweet?url=%s&text=%s%s'|format('https://mozilla.org/firefox/new'|urlencode, '%F0%9F%94%A5%2B%F0%9F%A6%8A=%F0%9F%99%8C%F0%9F%8F%BE%20', _('Join me in the fight for an open web by choosing Firefox!')|urlencode)|e }}">{{ _('Send a tweet') }}</a>
       </h1>
-      <a href="{{ 'https://www.twitter.com/intent/tweet?url=%s&text=%s%s'|format('https://mozilla.org/firefox/new'|urlencode, '%F0%9F%94%A5%2B%F0%9F%A6%8A=%F0%9F%99%8C%F0%9F%8F%BE%20', _('Join me in the fight for an open web by choosing Firefox!')|urlencode)|e }}">{{ _('Send a tweet') }}</a>
     </article>
     <article>
+      <span class="time">{{ _('2 min') }}</span>
       <h1>
-        <span class="time">{{ _('2 min') }}</span>{{ _('Get Firefox on your phone') }}
+        {{ _('Get Firefox on your phone') }}
+        <br/>
+        <a href="{{ url('firefox.mobile-download-desktop') }}">{{ _('Download Firefox') }}</a>
       </h1>
-      <a href="https://www.mozilla.org/firefox/mobile-download/desktop/">{{ _('Download Firefox') }}</a>
     </article>
     <article>
+      <span class="time">{{ _('4 min') }}</span>
       <h1>
-        <span class="time">{{ _('4 min') }}</span>{{ _('Make the Internet a safer place') }}
+        {{ _('Make the Internet a safer place') }}
+        <br/>
+        <a href="{{ url('mozorg.internet-health.privacy-security') }}">{{ _('Learn more') }}</a>
       </h1>
-      <a href="https://www.mozilla.org/internet-health/privacy-security/">{{ _('Learn more') }}</a>
     </article>
   </section>
 </main>

--- a/media/css/etc/firefox/retention/thank-you-b.scss
+++ b/media/css/etc/firefox/retention/thank-you-b.scss
@@ -32,7 +32,8 @@ main {
             header {
                 box-sizing: border-box;
                 text-align: center;
-                max-width: 490px;
+                max-width: 793px;
+                width: 100%;
                 margin-left: auto;
                 margin-right: auto;
 
@@ -41,10 +42,17 @@ main {
                     line-height: 8.125rem;
                 }
 
-                @media #{$mq-desktop} {
+                h1, p {
+                    width: 100%;
+                    max-width: 490px;
                     margin-left: auto;
-                    width: 793px;
+                    margin-right: auto;
+                }
+
+                @media #{$mq-desktop} {
                     height: 737px;
+                    margin-left: auto;
+                    margin-right: 0;
                 }
             }
         }

--- a/media/css/etc/firefox/retention/thank-you-b.scss
+++ b/media/css/etc/firefox/retention/thank-you-b.scss
@@ -51,7 +51,6 @@ main {
 
                 @media #{$mq-desktop} {
                     height: 737px;
-                    margin-left: auto;
                     margin-right: 0;
                 }
             }
@@ -67,12 +66,11 @@ main {
               margin-right: auto;
             }
             h1 {
-                padding-left: 72px;
                 color: #4D4D4D;
                 font-size: 2.25rem;
                 line-height: 3.25rem;
-                width: 100%;
                 max-width: 484px;
+                box-sizing: border-box;
             }
             article {
                 background: #FFFFFF;
@@ -83,16 +81,18 @@ main {
                     font-size: 1.75rem;
                     line-height: 2.625rem;
                     max-width: none;
+                    display: inline-block;
                 }
                 a {
                     margin-top: 0.03rem;
-                    padding-left: 72px;
                 }
                 .time {
                     vertical-align: top;
                     line-height: 2.25rem;
                     min-width: 72px;
                     display: inline-block;
+                    padding-right: 0.5rem;
+                    box-sizing: border-box;
                 }
             }
         }

--- a/media/css/etc/firefox/retention/thank-you-b.scss
+++ b/media/css/etc/firefox/retention/thank-you-b.scss
@@ -5,6 +5,7 @@
 @import '../../../pebbles/includes/lib';
 
 main {
+    position: relative;
     section {
         &.left-panel {
             overflow: hidden;
@@ -50,7 +51,6 @@ main {
                 }
 
                 @media #{$mq-desktop} {
-                    height: 737px;
                     margin-right: 0;
                 }
             }
@@ -70,38 +70,49 @@ main {
                 font-size: 2.25rem;
                 line-height: 3.25rem;
                 max-width: 484px;
-                box-sizing: border-box;
+                padding: 0 8px 0 72px;
             }
             article {
                 background: #FFFFFF;
                 padding: 22px 0;
                 margin: 9px 0;
                 h1 {
-                    padding-left: 0;
                     font-size: 1.75rem;
                     line-height: 2.625rem;
-                    max-width: none;
-                    display: inline-block;
+                    overflow: hidden;
+                    padding: 0 8px;
                 }
                 a {
                     margin-top: 0.03rem;
+                    text-transform: initial;
+                    line-height: 1.5;
+                    display: block;
                 }
                 .time {
                     vertical-align: top;
                     line-height: 2.25rem;
-                    min-width: 72px;
-                    display: inline-block;
-                    padding-right: 0.5rem;
-                    box-sizing: border-box;
+                    min-width: 64px;
+                    display: block;
+                    float: left;
                 }
             }
         }
 
-        &.left-panel,
-        &.right-panel {
-            @media #{$mq-desktop} {
-                float: left;
+        @media #{$mq-desktop} {
+            &.left-panel,
+            &.right-panel {
                 width: 50%;
+            }
+
+            &.left-panel {
+                position: absolute;
+                top: 0;
+                bottom: 0;
+            }
+
+            &.right-panel {
+                float: right;
+                min-height: 845px;
             }
         }
     }

--- a/media/css/etc/firefox/retention/thank-you.scss
+++ b/media/css/etc/firefox/retention/thank-you.scss
@@ -65,6 +65,7 @@ html {
       max-width: 530px;
       width: 100%;
       background-image: none;
+      padding-top: 0;
       color: #000000;
       h3 {
           font-family: "Open Sans", sans-serif;


### PR DESCRIPTION
## Description
Two small changes.
1. Updating a link that was requested. Should be straight forward enough.
2. If the page width is wide enough for thank-you-b https://www.mozilla.org/en-US/etc/firefox/retention/thank-you-b/ the "it's all thanks to you" blerb is no longer centered inside the confetti. The css changes should address this.
