### PR TITLE
[fix bug 1399173] Add link to /firefox/ in the old site navigation

### DIFF
--- a/bedrock/base/templates/base-pebbles.html
+++ b/bedrock/base/templates/base-pebbles.html
@@ -107,7 +107,10 @@
           <nav class="masthead-nav-main" id="nav-main">
             <span class="toggle" role="button" aria-controls="nav-main-menu" aria-expanded="false" tabindex="0">{{_('Menu')}}</span>
             <ul class="nav-main-menu" id="nav-main-menu">
-              <li class="first internet-health-item">
+              <li class="first firefox-item">
+                <a href="{{ url('firefox') }}" data-link-type="nav" data-link-name="Firefox">{{ _('Firefox') }}</a>
+              </li>
+              <li class="internet-health-item">
                 <a href="{{ url('mozorg.internet-health') }}" data-link-type="nav" data-link-name="Internet Health">{{ _('Internet Health') }}</a>
               </li>
               <li class="technology-item">

--- a/bedrock/base/templates/base-resp.html
+++ b/bedrock/base/templates/base-resp.html
@@ -115,7 +115,10 @@
           <nav id="nav-main" role="navigation">
             <span class="toggle" role="button" aria-controls="nav-main-menu" aria-expanded="false" tabindex="0">{{_('Menu')}}</span>
             <ul id="nav-main-menu">
-              <li class="first internet-health-item">
+              <li class="first firefox-item">
+                <a href="{{ url('firefox') }}" data-link-type="nav" data-link-name="Firefox">{{ _('Firefox') }}</a>
+              </li>
+              <li class="internet-health-item">
                 <a href="{{ url('mozorg.internet-health') }}" data-link-type="nav" data-link-name="Internet Health">{{ _('Internet Health') }}</a>
               </li>
               <li class="technology-item">

--- a/bedrock/base/templates/base.html
+++ b/bedrock/base/templates/base.html
@@ -102,7 +102,10 @@
         {% block site_header_nav %}
         <nav id="nav-main" role="navigation">
           <ul>
-            <li class="first internet-health-item">
+            <li class="first firefox-item">
+              <a href="{{ url('firefox') }}" data-link-type="nav" data-link-name="Firefox">{{ _('Firefox') }}</a>
+            </li>
+            <li class="internet-health-item">
               <a href="{{ url('mozorg.internet-health') }}" data-link-type="nav" data-link-name="Internet Health">{{ _('Internet Health') }}</a>
             </li>
             <li class="technology-item">

--- a/bedrock/mozorg/templates/mozorg/home/includes/nav.html
+++ b/bedrock/mozorg/templates/mozorg/home/includes/nav.html
@@ -19,7 +19,10 @@
     <nav class="masthead-nav-main" id="nav-main">
       <span class="toggle" role="button" aria-controls="nav-main-menu" aria-expanded="false" tabindex="0">{{ _('Menu') }}</span>
       <ul class="nav-main-menu" id="nav-main-menu">
-        <li class="first internet-health-item">
+        <li class="first firefox-item">
+          <a href="{{ url('firefox') }}" data-link-type="nav" data-link-name="Firefox">{{ _('Firefox') }}</a>
+        </li>
+        <li class="internet-health-item">
           <a href="{{ url('mozorg.internet-health') }}" data-link-type="nav" data-link-name="Internet Health">{{ _('Internet Health') }}</a>
         </li>
         <li class="technology-item">

--- a/media/css/hubs/_masthead.scss
+++ b/media/css/hubs/_masthead.scss
@@ -47,6 +47,7 @@
     @media #{$mq-tablet} {
         .masthead-nav-main {
             margin-right: 0;
+            width: 80%;
 
             .nav-main-menu {
                 padding: 15px 0;
@@ -56,19 +57,32 @@
                     color: #000;
                 }
 
-                li:first-child {
-                    border-left: none;
+                li {
+                    display: inline-block;
+                    padding: 0 20px 10px 0;
+
+                    &:first-child {
+                        border-left: none;
+                    }
                 }
+
             }
+        }
+    }
+
+    @media #{$mq-desktop} {
+        .masthead-nav-main {
+            width: 60%;
         }
     }
 
     @media #{$mq-desktop-wide} {
         .masthead-nav-main {
             margin: 0 0 0 40px;
+            width: 70%;
 
             .nav-main-menu li {
-                padding: 0 40px 0 0;
+                padding: 0 40px 10px 0;
             }
         }
     }
@@ -126,7 +140,6 @@
 
     @media #{$mq-desktop} {
         display: block;
-        margin-top: 5px;
         width: 200px;
 
         .download-link {

--- a/media/css/mozorg/home/home.scss
+++ b/media/css/mozorg/home/home.scss
@@ -80,7 +80,7 @@ body {
     #nav-main-menu,
     .js #nav-main-menu {
         li {
-            padding: 0 20px;
+            padding: 0 10px;
         }
     }
 
@@ -102,6 +102,15 @@ body {
 
         .fx-privacy-link {
             display: none;
+        }
+    }
+}
+
+@media #{$mq-desktop-wide} {
+    #nav-main-menu,
+    .js #nav-main-menu {
+        li {
+            padding: 0 20px;
         }
     }
 }

--- a/media/css/pebbles/components/_masthead.scss
+++ b/media/css/pebbles/components/_masthead.scss
@@ -128,7 +128,7 @@
             li {
                 display: inline;
                 border: 0;
-                padding: 0 10px;
+                padding: 0 5px;
             }
 
             a {
@@ -157,7 +157,13 @@
 
 @media #{$mq-desktop} {
     .masthead-nav-main .nav-main-menu li {
-            padding: 0 20px;
+        padding: 0 10px;
+    }
+}
+
+@media #{$mq-desktop-wide} {
+    .masthead-nav-main .nav-main-menu li {
+        padding: 0 20px;
     }
 }
 

--- a/media/css/sandstone/sandstone-resp.less
+++ b/media/css/sandstone/sandstone-resp.less
@@ -1233,6 +1233,10 @@ nav.menu-bar {
         .font-size(13px);
     }
 
+    #masthead nav ul li a {
+        padding: 12px 5px;
+    }
+
     .sidebar {
         .span_narrow(3);
         .offset_narrow(1);

--- a/tests/functional/test_navigation.py
+++ b/tests/functional/test_navigation.py
@@ -11,6 +11,10 @@ from pages.home import HomePage
 def test_navigation(base_url, selenium):
     locale = 'de'
     page = HomePage(selenium, base_url, locale).open()
+    firefox_page = page.navigation.open_firefox(locale)
+    assert firefox_page.seed_url in selenium.current_url
+
+    page.open()
     internet_health_page = page.navigation.open_internet_health(locale)
     assert internet_health_page.seed_url in selenium.current_url
 
@@ -25,6 +29,10 @@ def test_mobile_navigation(base_url, selenium):
     locale = 'de'
     page = HomePage(selenium, base_url, locale).open()
     page.navigation.show()
+    firefox_page = page.navigation.open_firefox(locale)
+    assert firefox_page.seed_url in selenium.current_url
+
+    page.open().navigation.show()
     internet_health_page = page.navigation.open_internet_health(locale)
     assert internet_health_page.seed_url in selenium.current_url
 

--- a/tests/pages/base.py
+++ b/tests/pages/base.py
@@ -39,6 +39,7 @@ class BasePage(Page):
         _root_locator = (By.ID, 'nav-main')
         _toggle_locator = (By.CLASS_NAME, 'toggle')
         _menu_locator = (By.ID, 'nav-main-menu')
+        _firefox_locator = (By.CSS_SELECTOR, 'a[data-link-name="Firefox"]')
         _internet_health_locator = (By.CSS_SELECTOR, 'a[data-link-name="Internet Health"]')
         _technology_locator = (By.CSS_SELECTOR, 'a[data-link-name="Web Innovations"]')
 
@@ -53,6 +54,11 @@ class BasePage(Page):
             toggle = self.find_element(*self._toggle_locator)
             return (self.find_element(*self._menu_locator).is_displayed() and
                 toggle.get_attribute('aria-expanded') == 'true')
+
+        def open_firefox(self, locale='en-US'):
+            self.find_element(*self._firefox_locator).click()
+            from firefox.home import FirefoxHomePage
+            return FirefoxHomePage(self.selenium, self.page.base_url, locale).wait_for_page_to_load()
 
         def open_internet_health(self, locale='en-US'):
             self.find_element(*self._internet_health_locator).click()


### PR DESCRIPTION
## Description
- Adds a link to `/firefox/` in the old nav, now that the Firefox hub is fully localized.
- This adds the string `"Firefox"`, but should be ok with l10n?

## Issue / Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1399173

## Testing
- Make sure i didn't miss any other occurences of the old nav template?
