### PR TITLE
Pin SauceLabs to Chrome 60 due to outdated chromedriver

### DIFF
--- a/docker/bin/run_integration_tests.sh
+++ b/docker/bin/run_integration_tests.sh
@@ -8,6 +8,7 @@ MARK_EXPRESSION="not headless"
 case $1 in
   chrome)
     BROWSER_NAME=chrome
+    BROWSER_VERSION="60.0"
     PLATFORM="Windows 10"
     ;;
   firefox)


### PR DESCRIPTION
Fixes: https://ci.us-west.moz.works/blue/organizations/jenkins/bedrock_multibranch_pipeline/detail/run-integration-tests/71/pipeline

See: #5113 for more context