### PR TITLE
Fix bug 1400369: Send-to-device widget support multiple countries

### DIFF
--- a/bedrock/base/templates/macros.html
+++ b/bedrock/base/templates/macros.html
@@ -276,7 +276,7 @@
     {% set ios_link = firefox_ios_url('mozorg') %}
   {% endif %}
   {% set android_link = settings.GOOGLE_PLAY_FIREFOX_LINK %}
-  <section id="send-to-device" class="{% if include_logo %}logo {% endif %}{% if include_title %}title{% else %}no-title{% endif %}" data-key="{{ settings.MOZILLA_LOCATION_SERVICES_KEY }}" {% if spinner_color %}data-spinner-color="{{ spinner_color }}{% endif %}">
+  <section id="send-to-device" class="{% if include_logo %}logo {% endif %}{% if include_title %}title{% else %}no-title{% endif %}" data-countries="{{ send_to_device_countries() }}"{% if spinner_color %} data-spinner-color="{{ spinner_color }}"{% endif %}>
     <div class="form-container">
       {% if include_title %}
         <h2 class="form-heading">

--- a/bedrock/base/templatetags/helpers.py
+++ b/bedrock/base/templatetags/helpers.py
@@ -15,6 +15,11 @@ from bedrock.utils import expand_locale_groups
 
 
 @library.global_function
+def send_to_device_countries():
+    return '|%s|' % '|'.join(cc.lower() for cc in settings.SEND_TO_DEVICE_COUNTRIES)
+
+
+@library.global_function
 @jinja2.contextfunction
 def switch(cxt, name, locales=None):
     """A template helper that replaces waffle

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -1181,6 +1181,7 @@ SEND_TO_DEVICE_LOCALES = ['de', 'en-GB', 'en-US', 'en-ZA',
 
 # country code for /country-code.json to return in dev mode
 DEV_GEO_COUNTRY_CODE = config('DEV_GEO_COUNTRY_CODE', default='US')
+SEND_TO_DEVICE_COUNTRIES = config('SEND_TO_DEVICE_COUNTRIES', default='US', cast=Csv())
 
 RNA_SYNC_URL = config('RNA_SYNC_URL',
                       default='https://nucleus.mozilla.org/rna/sync/')

--- a/media/css/base/send-to-device-micro.less
+++ b/media/css/base/send-to-device-micro.less
@@ -181,7 +181,7 @@
         display: none;
     }
 
-    &.us {
+    &.sms-country {
         .email {
             display: none;
         }

--- a/media/css/base/send-to-device.less
+++ b/media/css/base/send-to-device.less
@@ -251,7 +251,7 @@
         display: none;
     }
 
-    &.us {
+    &.sms-country {
         .email {
             display: none;
         }


### PR DESCRIPTION
This adds a setting for specifying supported countries as they'll be added as support is added in Salesforce.