### PR TITLE
[fix bug 1401479] Add lang selector to new home page.

### DIFF
--- a/bedrock/mozorg/templates/mozorg/home/home-b.html
+++ b/bedrock/mozorg/templates/mozorg/home/home-b.html
@@ -4,6 +4,8 @@
 
 {% extends "mozorg/home/home.html" %}
 
+{% add_lang_files "mozorg/home/index-2016" %}
+
 {% block page_css %}
   {% stylesheet 'home-b' %}
 {% endblock %}


### PR DESCRIPTION
## Description

Adds lang files to the new (en-US only, for now) home page to re-enable the language selector in the footer.

## Issue / Bugzilla link

https://bugzilla.mozilla.org/show_bug.cgi?id=1401479

## Testing

Ensure using the language selector on the en-US homepage sends you to the old home page for any other locale.