### PR TITLE
[fix bug 1402029] Standardize ‘privacy’ tag for blog feeds

### DIFF
--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -626,14 +626,14 @@ class FeaturesBookmarksView(BlogPostsView):
     blog_posts_limit = 3
     blog_posts_template_variable = 'articles'
     blog_slugs = 'firefox'
-    blog_tags = ['modern', 'private', 'featured']
+    blog_tags = ['modern', 'privacy', 'featured']
 
 
 class FeaturesPasswordManagerView(BlogPostsView):
     blog_posts_limit = 3
     blog_posts_template_variable = 'articles'
     blog_slugs = 'firefox'
-    blog_tags = ['modern', 'private', 'featured']
+    blog_tags = ['modern', 'privacy', 'featured']
     template_name = 'firefox/features/password-manager.html'
 
 


### PR DESCRIPTION
## Description
Somewhere along the way we got redundant tags for both "private" and "privacy." This sets "privacy" as the One True Tag and we'll re-tag any previous blog posts.

## Issue / Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1402029
