### PR TITLE
[bug 1396029] Skip functional test until we can remove the switch

### DIFF
--- a/tests/functional/firefox/test_developer.py
+++ b/tests/functional/firefox/test_developer.py
@@ -7,6 +7,7 @@ import pytest
 from pages.firefox.developer import DeveloperPage
 
 
+@pytest.mark.skipif(reason='https://bugzilla.mozilla.org/show_bug.cgi?id=1396029')  # Quantum page behind switch, unskip when the switch is removed
 @pytest.mark.sanity
 @pytest.mark.smoke
 @pytest.mark.nondestructive


### PR DESCRIPTION
## Description
The new page is behind a switch and makes testing problematic until it's in production. We'll just skip the test temporarily and update after Tuesday.