### PR TITLE
Fix bug 1401708: The Beast awakens

### DIFF
--- a/bedrock/mozorg/templates/mozorg/book.html
+++ b/bedrock/mozorg/templates/mozorg/book.html
@@ -96,6 +96,24 @@ And the beasts brought <em class="f">fire</em> and light to the darkness.
 </p>
 
 
+{% if switch('firefox-57-release') %}
+<!-- 14th November 2017: Firefox 57 is officially released -->
+<!-- The major release of projects Quantum, Flow, and Photon, bringing Rust-based software,
+     major architectural changes, and a new look to the masses. -->
+
+<p class="moztext">
+The Beast adopted <em>new raiment</em> and studied the ways of <em>Time</em> and
+<em>Space</em> and <em>Light</em> and the <em>Flow</em> of energy through the Universe.
+From its studies, the Beast fashioned new structures from <em>oxidised metal</em> and proclaimed
+their glories. And the Beast’s followers rejoiced, finding renewed purpose in these <em>teachings</em>.
+</p>
+
+<p class="from">
+ from <strong>The Book of Mozilla,</strong> 11:14
+</p>
+{% endif %}
+
+
 {% endblock %}
 </body>
 </html>


### PR DESCRIPTION
Update the Book of Mozilla to include the new verse heralding the release of Firefox 57 (bug 1370613).