### PR TITLE
[fix bug 1401308] Add 'Learn more' link for /firefox/quantum/ to whatsnew 56

### DIFF
--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-56.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-56.html
@@ -74,6 +74,11 @@
         <p>{{ _('The all-new New Tab gives you quick access to your top sites and recommendations from around the web.') }}</p>
       </li>
     </ul>
+
+    {# Bug 1401308: Only link to /firefox/quantum/ for locales that have the page translated. #}
+    {% if LANG.startswith('en') or LANG == 'de' %}
+    <a class="button photon-flat" href="{{ url('firefox.quantum') }}">{{ _('Learn more') }}</a>
+    {% endif %}
   </div>
 </section>
 {% endblock %}

--- a/media/css/firefox/whatsnew/whatsnew-56.scss
+++ b/media/css/firefox/whatsnew/whatsnew-56.scss
@@ -330,7 +330,7 @@ html[dir="rtl"] .features-list {
     }
 
     ul li {
-        margin: 40px auto;
+        margin: 40px auto 60px;
         max-width: 24em;
 
         h3 {
@@ -357,6 +357,20 @@ html[dir="rtl"] .features-list {
 
         p {
             margin: 0;
+        }
+    }
+
+    .button.photon-flat {
+        @include background-size(18px);
+        background: #00e8ff;
+        border-radius: 100px;
+        border: none;
+        color: #000;
+        margin-bottom: 60px;
+
+        &:hover,
+        &:active {
+            background: lighten(#00e8ff, 10%);
         }
     }
 


### PR DESCRIPTION
## Description
- Adds a link to `/firefox/quantum/` on the `/whatsnew` 56 page for both English and German locales only.
- Reuses "Learn more" string that is already translated.
- **Do not merge** until the quantum page is live.

## Issue / Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1401308

## Testing
- Ensure no visual regressions.
- Ensure link shows for only English and German locales.
