### PR TITLE
[bug 1396005] Remove switch for Quantum preview page

### DIFF
--- a/bedrock/firefox/urls.py
+++ b/bedrock/firefox/urls.py
@@ -5,7 +5,6 @@ from django.conf.urls import url
 
 from bedrock.redirects.util import redirect
 from bedrock.mozorg.util import page
-from bedrock.base.waffle import switch
 
 import views
 import bedrock.releasenotes.views
@@ -133,10 +132,5 @@ urlpatterns = (
 
     url('^firefox/stub_attribution_code/$', views.stub_attribution_code,
         name='firefox.stub_attribution_code'),
+    page('firefox/quantum', 'firefox/quantum.html'),
 )
-
-# Bug 1396005 Firefox 57 Quantum Preview page.
-if switch('57-quantum-preview'):
-    urlpatterns += (
-        page('firefox/quantum', 'firefox/quantum.html'),
-    )


### PR DESCRIPTION
## Description
- Quantum preview page is [now live](https://www.mozilla.org/en-US/firefox/quantum/), so this is a PR to tidy up and remove the switch that's no longer needed.

## Issue / Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1396005

## Testing
- Page should still load as expected.
