### PR TITLE
Bug 1400369: Send-to-device sends country and language when available

### DIFF
--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -210,8 +210,17 @@ def send_to_device_ajax(request):
 
         if data_type == 'number':
             if platform in MESSAGES['sms']:
+                data = {
+                    'mobile_number': phone_or_email,
+                    'msg_name': MESSAGES['sms'][platform],
+                    'lang': locale,
+                }
+                country = request.POST.get('country')
+                if country and re.match(r'^[a-z]{2}$', country, flags=re.I):
+                    data['country'] = country
+
                 try:
-                    basket.send_sms(phone_or_email, MESSAGES['sms'][platform])
+                    basket.request('post', 'subscribe_sms', data=data)
                 except basket.BasketException:
                     return HttpResponseJSON({'success': False, 'errors': ['system']},
                                             status=400)

--- a/media/js/base/send-to-device.js
+++ b/media/js/base/send-to-device.js
@@ -216,6 +216,10 @@ if (typeof Mozilla === 'undefined') {
             return;
         }
 
+        if (SendToDevice.COUNTRY_CODE) {
+            formData += '&country=' + SendToDevice.COUNTRY_CODE;
+        }
+
         // else POST and let the server work out whether the input is a
         // valid email address or US phone number.
         $.post(action, formData)


### PR DESCRIPTION
This is so the SMS infra can pick the proper message that is deliverable in said country and language.