### PR TITLE
Handle empty footnote in quantum privacy notice

### DIFF
--- a/bedrock/privacy/templates/privacy/notices/firefox-quantum.html
+++ b/bedrock/privacy/templates/privacy/notices/firefox-quantum.html
@@ -26,7 +26,10 @@
 
 {% set header = doc.body.section.extract() %}
 {% set lead_in = doc.body.section.extract() %}
-{% set footnote = doc.body.select('#footnote')[0].extract() %}
+{% set footnote = doc.body.select('#footnote') %}
+{% if footnote %}
+    {% set footnote = footnote[0].extract()
+{% endif %}
 
 <header class="privacy-head">
   <div class="privacy-head-wrapper">
@@ -54,11 +57,13 @@
   {% endfor %}
 </main>
 
+{% if footnote %}
 <section class="privacy-footnote">
   <div class="content-girdle">
     {{ footnote.div|join|safe }}
   </div>
 </section>
+{% endif %}
 </article>
 {% endblock %}
 


### PR DESCRIPTION
https://github.com/mozilla/bedrock/pull/5131/files#diff-1df9cc4f76b0aaabd6c07634c259aec0R29 introduced an error in production when the footnote did not exist. This PR handles that situation.