### PR TITLE
Fix Bug 1403443 - Firefox Quantum page is promoting only en-US and de builds

### DIFF
--- a/bedrock/firefox/templates/firefox/quantum.html
+++ b/bedrock/firefox/templates/firefox/quantum.html
@@ -27,7 +27,8 @@
         <p>{{ _('Launches November 14, 2017. Sign up to stay in the know and get launch updates.') }}</p>
         <div class="cta-wrapper">
           <a class="button photon sign-up" href="{{ url('newsletter.firefox') }}" data-link-type="link" data-link-name="Notify me">{{ _('Notify me') }}</a>
-          <a class="beta-link" href="{{ url('firefox.channel.desktop')}}#beta" data-link-type="link" data-link-name="Or try beta">{{ _('Or try beta') }}</a>
+          {#- Use a language neutral link here to make sure people can download Quantum in their own language #}
+          <a class="beta-link" href="/firefox/channel/desktop/#beta" data-link-type="link" data-link-name="Or try beta">{{ _('Or try beta') }}</a>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Description

The [Quantum landing page](https://www.mozilla.org/firefox/quantum/) is only offered in English and German, so people get there from the blog post, other media articles, etc. cannot download the Beta build in their language. This PR instead uses a language neutral link to workaround the issue for the time being.

## Issue / Bugzilla link

[Bug 1403443](https://bugzilla.mozilla.org/show_bug.cgi?id=1403443)

## Testing

Just make sure the "Or try beta" link has no locale.