### PR TITLE
Bug 1386184 - Firstrun page should skip the FxA form if the user is signed in

### DIFF
--- a/bedrock/settings/static_media.py
+++ b/bedrock/settings/static_media.py
@@ -1223,6 +1223,7 @@ PIPELINE_JS = {
     'firefox_firstrun': {
         'source_filenames': (
             'js/base/mozilla-fxa-iframe.js',
+            'js/base/uitour-lib.js',
             'js/firefox/firstrun/firstrun.js',
         ),
         'output_filename': 'js/firefox_firstrun-bundle.js',

--- a/media/js/firefox/firstrun/firstrun.js
+++ b/media/js/firefox/firstrun/firstrun.js
@@ -41,24 +41,33 @@
 
         skipbutton.onclick = onVerificationComplete;
 
-        Mozilla.Client.getFirefoxDetails(function(data) {
-            Mozilla.FxaIframe.init({
-                distribution: data.distribution,
-                gaEventName: 'firstrun-fxa',
-                onVerificationComplete: onVerificationComplete,
-                onLogin: onVerificationComplete,
-                onFormEnabled: disableSkipButton,
-                onNavigated:  hideOrShowSkipButton
-            });
+        Mozilla.UITour.getConfiguration('sync', function(config) {
+            if (config.setup) {
+                // skip showing the sign in form if the user is signed in
+                document.getElementById('sky').addEventListener('transitionend', function() {
+                    onVerificationComplete();
+                });
+            } else {
+                document.getElementById('sky').addEventListener('transitionend', function(event) {
+                    if (event.propertyName === 'opacity') {
+                        scene.dataset.modal = 'true';
+                    }
+                }, false);
+
+                Mozilla.Client.getFirefoxDetails(function(data) {
+                    Mozilla.FxaIframe.init({
+                        distribution: data.distribution,
+                        gaEventName: 'firstrun-fxa',
+                        onVerificationComplete: onVerificationComplete,
+                        onLogin: onVerificationComplete,
+                        onFormEnabled: disableSkipButton,
+                        onNavigated:  hideOrShowSkipButton
+                    });
+                });
+            }
         });
 
         scene.dataset.sunrise = 'true';
-
-        document.getElementById('sky').addEventListener('transitionend', function(event) {
-            if (event.propertyName === 'opacity') {
-                scene.dataset.modal = 'true';
-            }
-        }, false);
     };
 
     document.onreadystatechange = function () {


### PR DESCRIPTION
## Description

Use Mozilla.UITour.getConfiguration("sync") API to get FxA signin status and skip the FxA form if the user is signed in
http://searchfox.org/mozilla-central/source/browser/components/uitour/UITour.jsm#1605

## Issue / Bugzilla link

https://bugzilla.mozilla.org/show_bug.cgi?id=1386184

