### PR TITLE
remove scroll bar from windows re: Bug 1402131

### DIFF
--- a/media/css/firefox/firstrun/firstrun.less
+++ b/media/css/firefox/firstrun/firstrun.less
@@ -113,6 +113,37 @@ img {
     margin: 20px 0;
 }
 
+#skip-button {
+    -moz-appearance: none;
+    background-color: #0996f8;
+    border-radius: 3px;
+    border: 1px solid #0670cc;
+    box-shadow: 0 0 0 0 transparent;
+    color: #fff;
+    cursor: pointer;
+    display: block;
+    height: 24px;
+    margin: 10px auto;
+    padding: 3px 10px;
+
+    &:not([disabled]):hover {
+        background-color: #0670cc;
+        border-color: #005bab;
+    }
+}
+
+#skip-button[disabled] {
+    background-color: #ebebeb;
+    border-color: #b1b1b1;
+    color: #6a6a6a;
+    cursor: default;
+    opacity: .5;
+}
+
+.skipbutton-hidden {
+    display: none;
+}
+
 #scene[data-sunrise=true] {
 
     #firefox-logo {
@@ -125,37 +156,6 @@ img {
       right: 125px;
       top: -55px;
       width: 80px;
-    }
-
-    button {
-        -moz-appearance: none;
-        background-color: #0996f8;
-        border-radius: 3px;
-        border: 1px solid #0670cc;
-        box-shadow: 0 0 0 0 transparent;
-        color: #fff;
-        cursor: pointer;
-        display: block;
-        height: 24px;
-        margin: 10px auto;
-        padding: 3px 10px;
-
-        &:not([disabled]):hover {
-            background-color: #0670cc;
-            border-color: #005bab;
-        }
-    }
-
-    button[disabled] {
-        background-color: #ebebeb;
-        border-color: #b1b1b1;
-        color: #6a6a6a;
-        cursor: default;
-        opacity: .5;
-    }
-
-    .skipbutton-hidden {
-        display: none;
     }
 
     #sunrise {


### PR DESCRIPTION
@pmac

## Description
On windows, when arriving on the page there is a scroll bar on the right, that bar disappears once the animation starts. This was because the button on the page was not positioned until the animation starts.

So, I moved the styles to position the button outside of the styles for the animation.

## Issue / Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1402131

note: 
Once the fxa container is visible, if the screen is small, the scroll bar will come back - this is necessary to allow the user to scroll along the fxa form. I noticed that `notification-banner.css` adds a `margin-bottom` of 100px on the `#fxa-iframe-config` element. this makes the scroll bar appear a little earlier than necessary, but I figured this is being used for something I am unaware of - so I did not touch it.

