### PR TITLE
Fix error in thunderbird release notes template

### DIFF
--- a/bedrock/mozorg/templatetags/misc.py
+++ b/bedrock/mozorg/templatetags/misc.py
@@ -26,7 +26,6 @@ import bleach
 import jinja2
 from django_jinja import library
 
-from bedrock.base.urlresolvers import reverse
 from bedrock.base.templatetags.helpers import static
 from bedrock.firefox.firefox_details import firefox_ios
 
@@ -425,19 +424,6 @@ def absolute_url(url):
         prefix = ''
 
     return prefix + url
-
-
-@library.global_function
-def releasenotes_url(release):
-    prefix = 'aurora' if release.channel == 'Aurora' else 'release'
-    if release.product == 'Thunderbird':
-        return reverse('thunderbird.notes', args=[release.version])
-    if release.product == 'Firefox for Android':
-        return reverse('firefox.android.releasenotes', args=(release.version, prefix))
-    if release.product == 'Firefox for iOS':
-        return reverse('firefox.ios.releasenotes', args=(release.version, prefix))
-    else:
-        return reverse('firefox.desktop.releasenotes', args=(release.version, prefix))
 
 
 @library.global_function

--- a/bedrock/mozorg/tests/test_helper_misc.py
+++ b/bedrock/mozorg/tests/test_helper_misc.py
@@ -16,7 +16,6 @@ from pyquery import PyQuery as pq
 from bedrock.base.templatetags.helpers import static
 from bedrock.mozorg.templatetags import misc
 from bedrock.mozorg.tests import TestCase
-from bedrock.releasenotes.models import Release
 
 
 TEST_FILES_ROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)),
@@ -497,29 +496,6 @@ class TestAbsoluteURLFilter(TestCase):
         eq_(misc.absolute_url('/en-US/firefox/new/'), expected)
         eq_(misc.absolute_url('//www.mozilla.org/en-US/firefox/new/'), expected)
         eq_(misc.absolute_url('https://www.mozilla.org/en-US/firefox/new/'), expected)
-
-
-class TestReleaseNotesURL(TestCase):
-    @patch('bedrock.mozorg.templatetags.misc.reverse')
-    def test_aurora_android_releasenotes_url(self, mock_reverse):
-        """
-        Should return the results of reverse with the correct args
-        """
-        release = Release(dict(
-            channel='Aurora', version='42.0a2', product='Firefox for Android'))
-        eq_(misc.releasenotes_url(release), mock_reverse.return_value)
-        mock_reverse.assert_called_with(
-            'firefox.android.releasenotes', args=('42.0a2', 'aurora'))
-
-    @patch('bedrock.mozorg.templatetags.misc.reverse')
-    def test_desktop_releasenotes_url(self, mock_reverse):
-        """
-        Should return the results of reverse with the correct args
-        """
-        release = Release(dict(version='42.0', product='Firefox'))
-        eq_(misc.releasenotes_url(release), mock_reverse.return_value)
-        mock_reverse.assert_called_with(
-            'firefox.desktop.releasenotes', args=('42.0', 'release'))
 
 
 class TestFirefoxIOSURL(TestCase):

--- a/bedrock/releasenotes/tests/test_base.py
+++ b/bedrock/releasenotes/tests/test_base.py
@@ -96,34 +96,30 @@ class TestReleaseViews(TestCase):
             mock_release.channel, 'Firefox', 34)
 
     @patch('bedrock.releasenotes.views.get_release_or_404')
-    @patch('bedrock.releasenotes.views.releasenotes_url')
-    def test_release_notes_beta_redirect(self, releasenotes_url,
-                                         get_release_or_404):
+    def test_release_notes_beta_redirect(self, get_release_or_404):
         """
         Should redirect to url for beta release
         """
-        get_release_or_404.side_effect = [Http404, 'mock release']
-        releasenotes_url.return_value = '/firefox/27.0beta/releasenotes/'
+        release = Mock()
+        release.get_absolute_url.return_value = '/firefox/27.0beta/releasenotes/'
+        get_release_or_404.side_effect = [Http404, release]
         response = views.release_notes(self.request, '27.0')
         eq_(response.status_code, 302)
         eq_(response['location'], '/firefox/27.0beta/releasenotes/')
         get_release_or_404.assert_called_with('27.0beta', 'Firefox')
-        releasenotes_url.assert_called_with('mock release')
 
     @patch('bedrock.releasenotes.views.get_release_or_404')
-    @patch('bedrock.releasenotes.views.releasenotes_url')
-    def test_release_notes_thunderbird_beta_redirect(self, releasenotes_url,
-                                                     get_release_or_404):
+    def test_release_notes_thunderbird_beta_redirect(self, get_release_or_404):
         """
         Should redirect to url for Thunderbird Beta release
         """
-        get_release_or_404.side_effect = [Http404, 'mock release']
-        releasenotes_url.return_value = '/thunderbird/51.0beta/releasenotes/'
+        release = Mock()
+        release.get_absolute_url.return_value = '/thunderbird/51.0beta/releasenotes/'
+        get_release_or_404.side_effect = [Http404, release]
         response = views.release_notes(self.request, '51.0', 'Thunderbird')
         eq_(response.status_code, 302)
         eq_(response['location'], '/thunderbird/51.0beta/releasenotes/')
         get_release_or_404.assert_called_with('51.0beta', 'Thunderbird')
-        releasenotes_url.assert_called_with('mock release')
 
     @patch('bedrock.releasenotes.views.get_release_or_404')
     def test_system_requirements(self, get_release_or_404):
@@ -175,39 +171,31 @@ class TestReleaseViews(TestCase):
         with self.assertRaises(Http404):
             views.get_release_or_404('42', 'Firefox')
 
-    @patch('bedrock.releasenotes.views.releasenotes_url')
-    def test_no_equivalent_release_url(self, mock_releasenotes_url):
+    def test_no_equivalent_release_url(self):
         """
-        Should return None without calling releasenotes_url
+        Should return None
         """
         release = Mock()
         release.equivalent_android_release.return_value = None
         release.equivalent_desktop_release.return_value = None
         eq_(views.equivalent_release_url(release), None)
-        eq_(mock_releasenotes_url.called, 0)
 
-    @patch('bedrock.releasenotes.views.releasenotes_url')
-    def test_android_equivalent_release_url(self, mock_releasenotes_url):
+    def test_android_equivalent_release_url(self):
         """
         Should return the url for the equivalent android release
         """
         release = Mock()
         eq_(views.equivalent_release_url(release),
-            mock_releasenotes_url.return_value)
-        mock_releasenotes_url.assert_called_with(
-            release.equivalent_android_release.return_value)
+            release.equivalent_android_release.return_value.get_absolute_url.return_value)
 
-    @patch('bedrock.releasenotes.views.releasenotes_url')
-    def test_desktop_equivalent_release_url(self, mock_releasenotes_url):
+    def test_desktop_equivalent_release_url(self):
         """
         Should return the url for the equivalent desktop release
         """
         release = Mock()
         release.equivalent_android_release.return_value = None
         eq_(views.equivalent_release_url(release),
-            mock_releasenotes_url.return_value)
-        mock_releasenotes_url.assert_called_with(
-            release.equivalent_desktop_release.return_value)
+            release.equivalent_desktop_release.return_value.get_absolute_url.return_value)
 
     def test_get_download_url_android(self):
         """

--- a/bedrock/releasenotes/tests/test_models.py
+++ b/bedrock/releasenotes/tests/test_models.py
@@ -19,6 +19,26 @@ RELEASES_PATH = str(Path(__file__).parent)
 release_cache = caches['release-notes']
 
 
+@patch('bedrock.releasenotes.models.reverse')
+class TestReleaseNotesURL(TestCase):
+    def test_aurora_android_releasenotes_url(self, mock_reverse):
+        """
+        Should return the results of reverse with the correct args
+        """
+        release = models.Release(dict(
+            channel='Aurora', version='42.0a2', product='Firefox for Android'))
+        assert release.get_absolute_url() == mock_reverse.return_value
+        mock_reverse.assert_called_with('firefox.android.releasenotes', args=('42.0a2', 'aurora'))
+
+    def test_desktop_releasenotes_url(self, mock_reverse):
+        """
+        Should return the results of reverse with the correct args
+        """
+        release = models.Release(dict(version='42.0', product='Firefox'))
+        assert release.get_absolute_url() == mock_reverse.return_value
+        mock_reverse.assert_called_with('firefox.desktop.releasenotes', args=('42.0', 'release'))
+
+
 @override_settings(RELEASE_NOTES_PATH=RELEASES_PATH)
 class TestReleaseModel(TestCase):
     def setUp(self):
@@ -47,6 +67,11 @@ class TestReleaseModel(TestCase):
         rel = models.get_release('firefox', '45.0esr', 'esr')
         android = rel.equivalent_release_for_product('Firefox for Android')
         assert android is None
+
+    def test_note_fixed_in_release(self):
+        rel = models.get_release('firefox', '55.0a1')
+        note = rel.notes[11]
+        assert note.fixed_in_release.get_absolute_url() == '/en-US/firefox/55.0a1/releasenotes/'
 
     def test_field_processors(self):
         rel = models.get_release('firefox', '57.0a1')

--- a/bedrock/releasenotes/views.py
+++ b/bedrock/releasenotes/views.py
@@ -13,7 +13,6 @@ from bedrock.base.urlresolvers import reverse
 from bedrock.firefox.firefox_details import firefox_desktop, firefox_android, firefox_ios
 from bedrock.firefox.templatetags.helpers import android_builds, ios_builds
 from bedrock.thunderbird.details import thunderbird_desktop
-from bedrock.mozorg.templatetags.misc import releasenotes_url
 from bedrock.releasenotes.models import get_release_or_404, get_releases_or_404
 
 SUPPORT_URLS = {
@@ -41,7 +40,7 @@ def equivalent_release_url(release):
     equivalent_release = (release.equivalent_android_release() or
                           release.equivalent_desktop_release())
     if equivalent_release:
-        return releasenotes_url(equivalent_release)
+        return equivalent_release.get_absolute_url()
 
 
 def get_download_url(release):
@@ -93,7 +92,7 @@ def release_notes(request, version, product='Firefox'):
         release = get_release_or_404(version, product)
     except Http404:
         release = get_release_or_404(version + 'beta', product)
-        return HttpResponseRedirect(releasenotes_url(release))
+        return HttpResponseRedirect(release.get_absolute_url())
 
     return l10n_utils.render(
         request, release_notes_template(release.channel, product,

--- a/bedrock/thunderbird/templates/thunderbird/releases/release-notes.html
+++ b/bedrock/thunderbird/templates/thunderbird/releases/release-notes.html
@@ -79,7 +79,7 @@
               {{ note.note|safe }}
             {% if note.fixed_in_release %}
               <p class="note">
-                <a href="{{ releasenotes_url(note.fixed_in_release) }}">
+                <a href="{{ note.fixed_in_release.get_absolute_url() }}">
                   {{ _('Resolved in v{version_number}')|f(version_number=note.fixed_in_release.version) }}
                 </a>
               </p>


### PR DESCRIPTION
* Add ability to get release notes URL to Release model.
* Add Release instance to Note for fixed_in_release property.