### PR TITLE
Fix Bug 1394042, redirect cloud services pn to Fx pn

### DIFF
--- a/bedrock/privacy/redirects.py
+++ b/bedrock/privacy/redirects.py
@@ -14,4 +14,7 @@ redirectpatterns = (
 
     # bug 1321033 - Hello EOL
     redirect(r'^privacy/firefox-hello/?$', 'privacy.archive.hello-2016-03'),
+
+    # bug 1394042 - Firefox Cloud Services redirect to Fx
+    redirect(r'^privacy/firefox-cloud/?$', 'privacy.notices.firefox'),
 )

--- a/bedrock/privacy/templates/privacy/archive/hello-2014-11.html
+++ b/bedrock/privacy/templates/privacy/archive/hello-2014-11.html
@@ -36,7 +36,7 @@
         creating new contacts. If you sign up for a Firefox Account, you
         agree to its <a href="{{ url('legal.terms.services') }}">Terms of
         Service</a> and
-        <a href="{{ url('privacy.notices.firefox-cloud') }}">Privacy Notice</a>.
+        <a href="{{ url('privacy.notices.firefox') }}">Privacy Notice</a>.
       </p>
     </section>
     <section id="3-features">

--- a/bedrock/privacy/templates/privacy/archive/hello-2016-03.html
+++ b/bedrock/privacy/templates/privacy/archive/hello-2016-03.html
@@ -39,7 +39,7 @@
               Firefox browser sends Mozilla your account name in order to
               direct calls to you. To learn more about how data is used by
               Firefox Accounts, click
-              <a href="{{ url('privacy.notices.firefox-cloud') }}">here</a>.
+              <a href="{{ url('privacy.notices.firefox') }}">here</a>.
             </p>
           </li>
           <li>

--- a/bedrock/privacy/templates/privacy/index.html
+++ b/bedrock/privacy/templates/privacy/index.html
@@ -82,7 +82,7 @@
         <li class="policy-firefox"><a href="{{ url('privacy.notices.firefox') }}">{{ _('Firefox Browser') }}</a></li>
         <li class="policy-firefox-os"><a href="{{ url('privacy.notices.firefox-os') }}">{{ _('Firefox OS') }}</a></li>
         <li class="policy-firefox-cliqz"><a href="{{ url('privacy.notices.firefox-cliqz') }}">{{ _('Firefox + Cliqz') }}</a></li>
-        <li class="policy-firefox-cloud"><a href="{{ url('privacy.notices.firefox-cloud') }}">{{ _('Firefox Cloud Services') }}</a></li>
+        <li class="policy-firefox-cloud"><a href="{{ url('privacy.notices.firefox') }}">{{ _('Firefox Cloud Services') }}</a></li>
         <li class="policy-marketplace"><a href="https://marketplace.firefox.com/privacy-policy">{{ _('Firefox Marketplace') }}</a></li>
         <li class="policy-firefox-focus">
         {% if LANG == 'de' %}

--- a/bedrock/privacy/templates/privacy/notices/firefox-cloud.html
+++ b/bedrock/privacy/templates/privacy/notices/firefox-cloud.html
@@ -1,7 +1,0 @@
-{# This Source Code Form is subject to the terms of the Mozilla Public
- # License, v. 2.0. If a copy of the MPL was not distributed with this
- # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
-
-{% extends "privacy/notices/firefox.html" %}
-
-{% block body_id %}firefox-cloud-notice{% endblock %}

--- a/bedrock/privacy/urls.py
+++ b/bedrock/privacy/urls.py
@@ -13,7 +13,6 @@ urlpatterns = (
     url(r'^/firefox/$', views.firefox_notices, name='privacy.notices.firefox'),
     url(r'^/firefox-os/$', views.firefox_os_notices, name='privacy.notices.firefox-os'),
     url(r'^/firefox-cliqz/$', views.firefox_cliqz_notices, name='privacy.notices.firefox-cliqz'),
-    url(r'^/firefox-cloud/$', views.firefox_cloud_notices, name='privacy.notices.firefox-cloud'),
     url(r'^/firefox-focus/$', views.firefox_focus_notices, name='privacy.notices.firefox-focus'),
     # bug 1319207 - special URL for Firefox Focus in de locale
     url(r'^/firefox-klar/$', views.firefox_focus_notices, name='privacy.notices.firefox-klar'),

--- a/bedrock/releasenotes/tests/test_models.py
+++ b/bedrock/releasenotes/tests/test_models.py
@@ -39,7 +39,7 @@ class TestReleaseNotesURL(TestCase):
         mock_reverse.assert_called_with('firefox.desktop.releasenotes', args=('42.0', 'release'))
 
 
-@override_settings(RELEASE_NOTES_PATH=RELEASES_PATH)
+@override_settings(RELEASE_NOTES_PATH=RELEASES_PATH, DEV=False)
 class TestReleaseModel(TestCase):
     def setUp(self):
         release_cache.clear()
@@ -57,7 +57,7 @@ class TestReleaseModel(TestCase):
         assert 'custom url' == rel.get_bug_search_url()
 
     def test_equivalent_release_for_product(self):
-        """Based on the test files the equivalent release for 56 should be 56.0.2."""
+        """Based on the test files the equivalent release for 56 should be 56.0.2"""
         rel = models.get_release('firefox', '56.0', 'release')
         android = rel.equivalent_release_for_product('Firefox for Android')
         assert android.version == '56.0.2'


### PR DESCRIPTION
## Description
As requested in the bug, all traffic to '/privacy/firefox-cloud/' should be redirected to '/privacy/firefox/'

## Issue / Bugzilla link

https://bugzilla.mozilla.org/show_bug.cgi?id=1394042

## Testing

Requests for '/privacy/firefox-cloud/' should redirect to '/privacy/firefox/'