### PR TITLE
Fix Bug 1391847, changes to secondary nav for /developer and /technology

### DIFF
--- a/bedrock/base/templates/includes/global-nav.html
+++ b/bedrock/base/templates/includes/global-nav.html
@@ -248,14 +248,22 @@
                   </a>
                 </li>
                 <li>
-                  <a href="{{ url('mozorg.developer') }}" data-link-type="nav" data-link-name="Mozilla Developers" data-link-group="Technology">
-                    {{ _('Mozilla Developers') }}
-                  </a>
+                    <a href="{{ url('mozorg.developer') }}" data-link-type="nav" data-link-name="Developer Hub" data-link-group="Technology">{{ _('Developer Hub') }}</a>
                 </li>
                 <li>
-                  <a href="https://developer.mozilla.org/?utm_source=www.mozilla.org&amp;utm_medium=referral&amp;utm_campaign=global-nav&amp;utm_content=MDN" data-link-type="nav" data-link-name="MDN" data-link-group="Technology">
-                    <abbr title="{{ _('Mozilla Developer Network') }}">{{ _('MDN') }}</abbr>
-                  </a>
+                  <a href="https://research.mozilla.org/?utm_source=www.mozilla.org&amp;utm_medium=referral&amp;utm_campaign=global-nav&amp;utm_content=Research" data-link-type="nav" data-link-name="Research" data-link-group="Technology">{{ _('Research') }}</a>
+                </li>
+                <li>
+                  <a href="https://vr.mozilla.org/?utm_source=www.mozilla.org&amp;utm_medium=referral&amp;utm_campaign=global-nav&amp;utm_content=VR" data-link-type="nav" data-link-name="Virtual Reality" data-link-group="Technology">{{ _('Virtual Reality') }}</a>
+                </li>
+                <li>
+                  <a href="https://games.mozilla.org/?utm_source=www.mozilla.org&amp;utm_medium=referral&amp;utm_campaign=global-nav&amp;utm_content=Games" data-link-type="nav" data-link-name="Games" data-link-group="Technology">{{ _('Games') }}</a>
+                </li>
+                <li>
+                  <a href="https://developer.mozilla.org/?utm_source=www.mozilla.org&amp;utm_medium=referral&amp;utm_campaign=global-nav&amp;utm_content=Documentation" data-link-type="nav" data-link-name="Documentation" data-link-group="Technology">{{ _('Documentation') }}</a>
+                </li>
+                <li>
+                  <a href="https://hacks.mozilla.org/?utm_source=www.mozilla.org&amp;utm_medium=referral&amp;utm_campaign=global-nav&amp;utm_content=HacksBlog" data-link-type="nav" data-link-name="Hacks Blog" data-link-group="Technology">{{ _('Hacks blog') }}</a>
                 </li>
               </ul>
 

--- a/bedrock/mozorg/templates/mozorg/developer/includes/sub-nav.html
+++ b/bedrock/mozorg/templates/mozorg/developer/includes/sub-nav.html
@@ -7,7 +7,22 @@
 {% block sub_nav_class %}technology{% endblock %}
 
 {% block sub_nav_primary_links %}
-<li><a href="{{ url('mozorg.technology') }}" data-link-name="Web Innovations" data-link-type="nav" data-link-position="subnav">{{ _('Web Innovations') }}</a></li>
-<li><a href="{{ url('mozorg.developer') }}" data-link-name="Mozilla Developers" data-link-type="nav" data-link-position="subnav">{{ _('Mozilla Developers') }}</a></li>
-<li><a href="https://developer.mozilla.org" data-link-name="MDN" data-link-type="nav" data-link-position="subnav">{{ _('MDN') }}</a></li>
+<li>
+  <a href="{{ url('mozorg.developer') }}" data-link-name="Developer Hub" data-link-type="nav" data-link-position="subnav">{{ _('Developer Hub') }}</a>
+</li>
+<li>
+  <a href="https://research.mozilla.org/?utm_source=www.mozilla.org&amp;utm_medium=referral&amp;utm_campaign=dev-tech-sub-nav&amp;utm_content=Research" data-link-name="Research" data-link-type="nav" data-link-position="subnav">{{ _('Research') }}</a>
+</li>
+<li>
+  <a href="https://vr.mozilla.org/?utm_source=www.mozilla.org&amp;utm_medium=referral&amp;utm_campaign=dev-tech-sub-nav&amp;utm_content=VR" data-link-name="Virtual Reality" data-link-type="nav" data-link-position="subnav">{{ _('Virtual Reality') }}</a>
+</li>
+<li>
+  <a href="https://games.mozilla.org/?utm_source=www.mozilla.org&amp;utm_medium=referral&amp;utm_campaign=dev-tech-sub-nav&amp;utm_content=Games" data-link-name="Games" data-link-type="nav" data-link-position="subnav">{{ _('Games') }}</a>
+</li>
+<li>
+  <a href="https://developer.mozilla.org/?utm_source=www.mozilla.org&amp;utm_medium=referral&amp;utm_campaign=dev-tech-sub-nav&amp;utm_content=Documentation" data-link-name="Documentation" data-link-type="nav" data-link-position="subnav">{{ _('Documentation') }}</a>
+</li>
+<li>
+  <a href="https://hacks.mozilla.org/?utm_source=www.mozilla.org&amp;utm_medium=referral&amp;utm_campaign=dev-tech-sub-nav&amp;utm_content=HacksBlog" data-link-name="Hacks Blog" data-link-type="nav" data-link-position="subnav">{{ _('Hacks blog') }}</a>
+</li>
 {% endblock %}

--- a/bedrock/mozorg/templates/mozorg/technology.html
+++ b/bedrock/mozorg/templates/mozorg/technology.html
@@ -29,6 +29,8 @@
 {% endblock %}
 
 {% block content %}
+{% include 'mozorg/developer/includes/sub-nav.html' %}
+
 <main role="main">
   {% block page_hero %}
   <div class="main-heading-container">

--- a/media/css/mozorg/technology.scss
+++ b/media/css/mozorg/technology.scss
@@ -4,6 +4,7 @@
 
 @import '../pebbles/includes/lib';
 @import '../pebbles/components/newsletter';
+@import '../hubs/sub-nav';
 
 body {
     border-top: none;


### PR DESCRIPTION
## Description
Adds new sub navigation items that are consistent between the /developer and /technology pages

## Issue / Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1391847

## Testing
/technology and /developer should have the same sub navigation but:

1) when on /technology, the first item in the subnav will be Developer Hub and link to /developer
2) when on /developer, the first item in the subnav will be Technology Hub and link to /technology