### PR TITLE
Fix exception when equavalent releases exist but none are public

### DIFF
--- a/bedrock/releasenotes/models.py
+++ b/bedrock/releasenotes/models.py
@@ -156,7 +156,8 @@ class Release(RNModel):
         if releases:
             releases = [get_release_from_file(fn) for fn in releases]
             releases = [r for r in releases if r.is_public]
-            return sorted(releases, reverse=True, key=attrgetter('version_obj'))[0]
+            if releases:
+                return sorted(releases, reverse=True, key=attrgetter('version_obj'))[0]
 
         return None
 

--- a/bedrock/releasenotes/tests/test_models.py
+++ b/bedrock/releasenotes/tests/test_models.py
@@ -68,10 +68,18 @@ class TestReleaseModel(TestCase):
         android = rel.equivalent_release_for_product('Firefox for Android')
         assert android is None
 
+    @patch.object(models, 'get_release_from_file')
+    def test_equivalent_release_for_product_no_public_match(self, grff_mock):
+        rel = models.Release(dict(product='Firefox', version='56.0', is_public=True, channel='Release'))
+        grff_mock.return_value = models.Release(dict(product='Firefox for Android', is_public=False, version='56.0.2', channel='Release'))
+        android = rel.equivalent_release_for_product('Firefox for Android')
+        assert android is None
+
     def test_note_fixed_in_release(self):
         rel = models.get_release('firefox', '55.0a1')
         note = rel.notes[11]
-        assert note.fixed_in_release.get_absolute_url() == '/en-US/firefox/55.0a1/releasenotes/'
+        with self.activate('en-US'):
+            assert note.fixed_in_release.get_absolute_url() == '/en-US/firefox/55.0a1/releasenotes/'
 
     def test_field_processors(self):
         rel = models.get_release('firefox', '57.0a1')


### PR DESCRIPTION
Was getting IndexError trying to get the first item in an empty list because we were not checking for an empty list after filtering out non-public releases in the equivalent_release_for_product method.