### PR TITLE
Run sanity functional tests in IE8

### DIFF
--- a/docker/bin/run_integration_tests.sh
+++ b/docker/bin/run_integration_tests.sh
@@ -20,16 +20,10 @@ case $1 in
     BROWSER_NAME="internet explorer"
     PLATFORM="Windows 10"
     ;;
-  ie6)
+  ie8)
     BROWSER_NAME="internet explorer"
-    BROWSER_VERSION="6.0"
-    PLATFORM="Windows XP"
-    MARK_EXPRESSION="sanity and not headless"
-    ;;
-  ie7)
-    BROWSER_NAME="internet explorer"
-    BROWSER_VERSION="7.0"
-    PLATFORM="Windows XP"
+    BROWSER_VERSION="8.0"
+    PLATFORM="Windows 7"
     MARK_EXPRESSION="sanity and not headless"
     ;;
   headless)

--- a/jenkins/branches/prod.yml
+++ b/jenkins/branches/prod.yml
@@ -16,8 +16,7 @@ integration_tests:
     - firefox
     - chrome
     - ie
-    - ie6
-    - ie7
+    - ie8
   tokyo:
     - headless
   frankfurt:

--- a/jenkins/branches/run-integration-tests.yml
+++ b/jenkins/branches/run-integration-tests.yml
@@ -11,5 +11,4 @@ integration_tests:
     - firefox
     - chrome
     - ie
-    - ie6
-    - ie7
+    - ie8


### PR DESCRIPTION
Fixes #5156

SauceLabs ended support for Windows XP (IE6 & IE7) last night: https://wiki.saucelabs.com/pages/viewpage.action?pageId=70068108

IE8 on Windows 7 is now the oldest IE they support, so this PR moves sanity tests to run with this specific configuration.

Successful test run: https://ci.us-west.moz.works/blue/organizations/jenkins/bedrock_multibranch_pipeline/detail/run-integration-tests/80/pipeline/