### PR TITLE
Bug 1395342: Configure send-to-device SMS countries per message-set

### DIFF
--- a/bedrock/base/templates/macros.html
+++ b/bedrock/base/templates/macros.html
@@ -276,7 +276,7 @@
     {% set ios_link = firefox_ios_url('mozorg') %}
   {% endif %}
   {% set android_link = settings.GOOGLE_PLAY_FIREFOX_LINK %}
-  <section id="send-to-device" class="{% if include_logo %}logo {% endif %}{% if include_title %}title{% else %}no-title{% endif %}" data-countries="{{ send_to_device_countries() }}"{% if spinner_color %} data-spinner-color="{{ spinner_color }}"{% endif %}>
+  <section id="send-to-device" class="{% if include_logo %}logo {% endif %}{% if include_title %}title{% else %}no-title{% endif %}" data-countries="{{ send_to_device_sms_countries(message_set) }}"{% if spinner_color %} data-spinner-color="{{ spinner_color }}"{% endif %}>
     <div class="form-container">
       {% if include_title %}
         <h2 class="form-heading">

--- a/bedrock/base/templatetags/helpers.py
+++ b/bedrock/base/templatetags/helpers.py
@@ -15,8 +15,12 @@ from bedrock.utils import expand_locale_groups
 
 
 @library.global_function
-def send_to_device_countries():
-    return '|%s|' % '|'.join(cc.lower() for cc in settings.SEND_TO_DEVICE_COUNTRIES)
+def send_to_device_sms_countries(message_set):
+    try:
+        countries = settings.SEND_TO_DEVICE_MESSAGE_SETS[message_set]['sms_countries']
+    except KeyError:
+        countries = ['US']
+    return '|%s|' % '|'.join(cc.lower() for cc in countries)
 
 
 @library.global_function

--- a/bedrock/base/tests/test_helpers.py
+++ b/bedrock/base/tests/test_helpers.py
@@ -9,6 +9,23 @@ from bedrock.base.templatetags import helpers
 
 
 jinja_env = Jinja2.get_default()
+SEND_TO_DEVICE_MESSAGE_SETS = {
+    'default': {
+        'sms_countries': ['US', 'DE'],
+        'sms': {
+            'ios': 'ff-ios-download',
+            'android': 'SMS_Android',
+        },
+        'email': {
+            'android': 'download-firefox-android',
+            'ios': 'download-firefox-ios',
+            'all': 'download-firefox-mobile',
+        }
+    },
+    'other': {
+        'sms_countries': ['US', 'FR'],
+    }
+}
 
 
 def render(s, context={}):
@@ -17,7 +34,6 @@ def render(s, context={}):
 
 
 class HelpersTests(TestCase):
-
     def test_urlencode_with_unicode(self):
         template = '<a href="?var={{ key|urlencode }}">'
         context = {'key': '?& /()'}
@@ -25,6 +41,13 @@ class HelpersTests(TestCase):
         # non-ascii
         context = {'key': u'\xe4'}
         eq_(render(template, context), '<a href="?var=%C3%A4">')
+
+
+@override_settings(SEND_TO_DEVICE_MESSAGE_SETS=SEND_TO_DEVICE_MESSAGE_SETS)
+def test_send_to_device_sms_countries():
+    assert helpers.send_to_device_sms_countries('default') == '|us|de|'
+    assert helpers.send_to_device_sms_countries('other') == '|us|fr|'
+    assert helpers.send_to_device_sms_countries('none') == '|us|'
 
 
 @override_settings(LANG_GROUPS={'en': ['en-US', 'en-GB']})

--- a/bedrock/firefox/tests/test_views.py
+++ b/bedrock/firefox/tests/test_views.py
@@ -280,9 +280,9 @@ class TestSendToDeviceView(TestCase):
         })
         ok_(resp_data['success'])
         self.mock_subscribe.assert_called_with('dude@example.com',
-                                                views.SEND_TO_DEVICE_MESSAGE_SETS['default']['email']['android'],
-                                                source_url='https://nihilism.info',
-                                                lang='en-US')
+                                               views.SEND_TO_DEVICE_MESSAGE_SETS['default']['email']['android'],
+                                               source_url='https://nihilism.info',
+                                               lang='en-US')
 
     def test_send_android_email_basket_error(self):
         self.mock_subscribe.side_effect = views.basket.BasketException

--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -41,47 +41,7 @@ INSTALLER_CHANNElS = [
     'alpha',
     # 'nightly',  # soon
 ]
-
-SEND_TO_DEVICE_MESSAGE_SETS = {
-    'default': {
-        'sms': {
-            'ios': 'ff-ios-download',
-            'android': 'SMS_Android',
-        },
-        'email': {
-            'android': 'download-firefox-android',
-            'ios': 'download-firefox-ios',
-            'all': 'download-firefox-mobile',
-        }
-    },
-    'fx-android': {
-        'sms': {
-            'ios': 'ff-ios-download',
-            'android': 'android-download-embed',
-        },
-        'email': {
-            'android': 'get-android-embed',
-            'ios': 'download-firefox-ios',
-            'all': 'download-firefox-mobile',
-        }
-    },
-    'fx-mobile-download-desktop': {
-        'sms': {
-            'all': 'mobile-heartbeat',
-        },
-        'email': {
-            'all': 'download-firefox-mobile-reco',
-        }
-    },
-    'fx-50-whatsnew': {
-        'sms': {
-            'all': 'whatsnewfifty',
-        },
-        'email': {
-            'all': 'download-firefox-mobile-whatsnew',
-        }
-    }
-}
+SEND_TO_DEVICE_MESSAGE_SETS = settings.SEND_TO_DEVICE_MESSAGE_SETS
 
 STUB_VALUE_NAMES = [
     # name, default value

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -1231,7 +1231,50 @@ SEND_TO_DEVICE_LOCALES = ['de', 'en-GB', 'en-US', 'en-ZA',
 
 # country code for /country-code.json to return in dev mode
 DEV_GEO_COUNTRY_CODE = config('DEV_GEO_COUNTRY_CODE', default='US')
-SEND_TO_DEVICE_COUNTRIES = config('SEND_TO_DEVICE_COUNTRIES', default='US', cast=Csv())
+SEND_TO_DEVICE_MESSAGE_SETS = {
+    'default': {
+        'sms_countries': config('STD_SMS_COUNTRIES_DEFAULT', default='US', cast=Csv()),
+        'sms': {
+            'ios': 'ff-ios-download',
+            'android': 'SMS_Android',
+        },
+        'email': {
+            'android': 'download-firefox-android',
+            'ios': 'download-firefox-ios',
+            'all': 'download-firefox-mobile',
+        }
+    },
+    'fx-android': {
+        'sms_countries': config('STD_SMS_COUNTRIES_ANDROID', default='US', cast=Csv()),
+        'sms': {
+            'ios': 'ff-ios-download',
+            'android': 'android-download-embed',
+        },
+        'email': {
+            'android': 'get-android-embed',
+            'ios': 'download-firefox-ios',
+            'all': 'download-firefox-mobile',
+        }
+    },
+    'fx-mobile-download-desktop': {
+        'sms_countries': config('STD_SMS_COUNTRIES_DESKTOP', default='US', cast=Csv()),
+        'sms': {
+            'all': 'mobile-heartbeat',
+        },
+        'email': {
+            'all': 'download-firefox-mobile-reco',
+        }
+    },
+    'fx-50-whatsnew': {
+        'sms_countries': config('STD_SMS_COUNTRIES_WHATSNEW50', default='US', cast=Csv()),
+        'sms': {
+            'all': 'whatsnewfifty',
+        },
+        'email': {
+            'all': 'download-firefox-mobile-whatsnew',
+        }
+    }
+}
 
 RELEASE_NOTES_PATH = config('RELEASE_NOTES_PATH', default=path('release_notes'))
 RELEASE_NOTES_REPO = config('RELEASE_NOTES_REPO', default='https://github.com/mozilla/release-notes.git')

--- a/docs/send-to-device.rst
+++ b/docs/send-to-device.rst
@@ -8,11 +8,11 @@
 Send to Device widget
 =====================
 
-The *Send to Device* widget is a single macro form which facilitates the sending of a download link for either Firefox for iOS, Firefox for Android, or both. The form allows sending via SMS or Email, although the SMS copy & messaging is shown only to those in the US. Geo-location is handled in JavaScript using `GeoDude <https://github.com/mozilla/geodude>`_. For users without JavaScript, the widget falls back to a standard Email form.
+The *Send to Device* widget is a single macro form which facilitates the sending of a download link for either Firefox for iOS, Firefox for Android, or both. The form allows sending via SMS or Email, although the SMS copy & messaging is shown only to those in the configured countries. Geo-location is handled in JavaScript using a `bedrock view <https://github.com/mozilla/bedrock/blob/7ae0f693ab0347057b56397462351f7085205e3c/bedrock/base/views.py#L31>`_ that gets the request country from `CloudFlare CDN headers <https://support.cloudflare.com/hc/en-us/articles/200168236-What-does-CloudFlare-IP-Geolocation-do->`_. For users without JavaScript, the widget falls back to a standard Email form.
 
 .. important:: This widget should only be shown to a limited set of locales who are set up to receive the emails. For those locales not in the list, direct links to the respective app stores should be shown instead. If a user is on iOS or Android, CTA buttons should also link directly to respective app stores instead of showing the widget. This logic should be handled on a page-by-page basis to cover individual needs.
 
-.. note:: A full list of supported locales can be found in ``settings/base.py`` under ``SEND_TO_DEVICE_LOCALES``, which can be used in the template logic for each page to show the form.
+.. note:: A full list of supported locales can be found in ``settings/base.py`` under ``SEND_TO_DEVICE_LOCALES``, which can be used in the template logic for each page to show the form. The countries enabled for SMS for each message are defined in the `running configuration <https://mozmeao.github.io/www-config/configs/>`_ per the environment names in ``SEND_TO_DEVICE_MESSAGE_SETS`` in the settings file.
 
 Usage
 -----


### PR DESCRIPTION
Not all messages will be available in the same list of countries.  This ensures we're able to provide the best experience by showing the SMS version only to people in the countries for which we have an SMS message that works for them.