### PR TITLE
[fix bug 1387573] Adjust sample rate limit for firefox/new/ survey

### DIFF
--- a/media/js/firefox/new/survey.js
+++ b/media/js/firefox/new/survey.js
@@ -8,7 +8,7 @@
     var client = Mozilla.Client;
     var $survey = $('#firefox-new-survey-link');
 
-    if (!client.isMobile && $survey.length && Math.random() < 0.25) {
+    if (!client.isMobile && $survey.length && Math.random() < 0.05) {
         var link = $survey.attr('href');
         $survey.attr('href', link + window.location.search);
         $survey.css('display', 'block');


### PR DESCRIPTION
## Description
- Adjust sample rate limit of existing Firefox survey on /new from 25% to 5% (survey is getting more responses than needed currently).

## Issue / Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1387573#c26
