### PR TITLE
[bug 1392855] Add firstrun lang file to Cliqz funnelcake experiment pages

### DIFF
--- a/bedrock/firefox/templates/firefox/firstrun/cliqz-funnelcake-119-122.html
+++ b/bedrock/firefox/templates/firefox/firstrun/cliqz-funnelcake-119-122.html
@@ -2,6 +2,8 @@
  # License, v. 2.0. If a copy of the MPL was not distributed with this
  # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
 
+{% add_lang_files "firefox/new/onboarding" %}
+
 {% extends "firefox/firstrun/index.html" %}
 
 {% block site_css %}


### PR DESCRIPTION
## Description
- German funnelcake pages are not shown correctly on staging: https://www.allizom.org/de/firefox/56.0/firstrun/?f=120. You can replicate this locally with `Dev=False`

## Testing
- Set `Dev=False` and the pages should display as expected.
