### PR TITLE
[fix bug 1406139] Add unbranded search funnelcake experiment.

### DIFF
--- a/bedrock/firefox/templates/firefox/new/scene1.html
+++ b/bedrock/firefox/templates/firefox/new/scene1.html
@@ -10,6 +10,10 @@
   {% if switch('firefox-new-cliqz-funnelcakes', ['de']) %}
     {% javascript 'experiment_firefox_new_cliqz_funnelcakes' %}
   {% endif %}
+
+  {% if switch('firefox-new-unbranded-search-funnelcakes', ['en-US']) %}
+    {% javascript 'experiment_firefox_new_unbranded_search_funnelcakes' %}
+  {% endif %}
 {% endblock %}
 
 {% block optimizely %}

--- a/bedrock/settings/static_media.py
+++ b/bedrock/settings/static_media.py
@@ -1337,6 +1337,14 @@ PIPELINE_JS = {
         ),
         'output_filename': 'js/firefox_new_cliqz_funnelcakes-bundle.js',
     },
+    'experiment_firefox_new_unbranded_search_funnelcakes': {
+        'source_filenames': (
+            'js/base/mozilla-traffic-cop.js',
+            'js/base/mozilla-traffic-cop-funnelcake-geo.js',
+            'js/firefox/new/experiment-unbranded-search-funnelcakes.js',
+        ),
+        'output_filename': 'js/experiment_firefox_new_unbranded_search_funnelcakes-bundle.js',
+    },
     'firefox_new_pixel': {
         'source_filenames': (
             'js/base/mozilla-pixel.js',

--- a/media/js/firefox/new/experiment-unbranded-search-funnelcakes.js
+++ b/media/js/firefox/new/experiment-unbranded-search-funnelcakes.js
@@ -1,0 +1,20 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+(function(Mozilla) {
+    'use strict';
+
+    // initialize experiment - performs env check and does geo-lookup
+    Mozilla.TCFCGeoExp.init({
+        countryCode: 'us',
+        experimentConfig: {
+            id: 'experiment_unbranded_search_funnelcake',
+            variations: {
+                'f=130': 10,
+                'f=131': 10,
+                'f=132': 10
+            }
+        }
+    });
+})(window.Mozilla);


### PR DESCRIPTION
## Description

Adds funnelcakes for unbranded search experiment. en-US locale/US geo only, so should not conflict with de only Cliqz funnelcakes.

## Issue / Bugzilla link

https://bugzilla.mozilla.org/show_bug.cgi?id=1406139

## Testing

Ensure experiment works as expected - 30% chance of a funnelcake when using Windows/non-Fx with DNT disabled.