### PR TITLE
Fix Bug 1406766 - Firefox for Android notes are missing

### DIFF
--- a/bedrock/firefox/redirects.py
+++ b/bedrock/firefox/redirects.py
@@ -548,6 +548,6 @@ redirectpatterns = (
     redirect(r'^firefox/new/.+', '/firefox/new/'),
     redirect(r'^firefox/38.0.3/releasenotes/$', '/firefox/38.0.5/releasenotes/'),
     redirect(r'^firefox/default\.htm', '/firefox/'),
-    redirect(r'^firefox/android/\d', '/firefox/android/'),
+    redirect(r'^firefox/android/(?P<version>\d+\.\d+(?:\.\d+)?)$', '/firefox/android/{version}/releasenotes/'),
     redirect(r'^firefox/stats/', '/firefox/'),
 )

--- a/tests/redirects/map_globalconf.py
+++ b/tests/redirects/map_globalconf.py
@@ -1177,6 +1177,6 @@ URLS = flatten((
     url_test('/firefox/{new,developer}/)', '/firefox/{new,developer}/'),
     url_test('/firefox/default.htm', '/firefox/'),
     url_test('/firefox/fx/dude', '/firefox/'),
-    url_test('/firefox/android/45.0', '/firefox/android/'),
+    url_test('/firefox/android/45.0', '/firefox/android/45.0/releasenotes/'),
     url_test('/firefox/stats/', '/firefox/'),
 ))


### PR DESCRIPTION
## Description

Fix Android notes missing due to a catch-all redirect recently added in [Bug 1405436](https://bugzilla.mozilla.org/show_bug.cgi?id=1405436) / #5176. Redirect those URLs to the relevant release notes instead of the product home page.

## Issue / Bugzilla link

[Bug 1406766](https://bugzilla.mozilla.org/show_bug.cgi?id=1406766)

## Testing

Make sure all of these URLs work properly.

* `/firefox/android/55.0` ->  `/firefox/android/55.0/releasenotes/`
* `/firefox/android/56.0/releasenotes/`
* `/firefox/android/57.0beta/releasenotes/`