### PR TITLE
Fix Bug 1387466 - Adjust download page strings to remove "(incl. Win 64)" now that Win64 builds are default on all channels

### DIFF
--- a/bedrock/firefox/templates/firefox/channel/android.html
+++ b/bedrock/firefox/templates/firefox/channel/android.html
@@ -52,7 +52,7 @@
     <div class="container">
       <ul>
         <li><a href="{{ firefox_url('android', 'notes', 'beta') }}">{{_('Release Notes')}}</a></li>
-        <li><a href="{{ firefox_url('android', 'all', 'beta') }}">{{_('All Languages and Builds')}}</a></li>
+        <li><a href="{{ firefox_url('android', 'all', 'beta') }}">{% if l10n_has_tag('firefox_channel_bug1387466') %}{{_('All Languages and Platforms')}}{% else %}{{_('All Languages and Builds')}}{% endif %}</a></li>
       </ul>
     </div>
   </footer>

--- a/bedrock/firefox/templates/firefox/channel/desktop.html
+++ b/bedrock/firefox/templates/firefox/channel/desktop.html
@@ -50,7 +50,7 @@
     <div class="container">
       <ul>
         <li><a href="{{ firefox_url('desktop', 'notes', 'beta') }}">{{_('Release Notes')}}</a></li>
-        <li><a href="{{ firefox_url('desktop', 'all', 'beta') }}">{{_('All Languages and Builds (incl. Win 64)')}}</a></li>
+        <li><a href="{{ firefox_url('desktop', 'all', 'beta') }}">{% if l10n_has_tag('firefox_channel_bug1387466') %}{{_('All Languages and Platforms')}}{% else %}{{_('All Languages and Builds')}}{% endif %}</a></li>
       </ul>
     </div>
   </footer>
@@ -75,7 +75,7 @@
       <ul>
         <li><a href="{{ firefox_url('desktop', 'notes', 'developer') }}">{{_('Release Notes')}}</a></li>
         <li><a href="{{ url('firefox.developer') }}">{{_('Learn more')}}</a></li>
-        <li><a href="{{ firefox_url('desktop', 'all', 'developer') }}">{{_('All Languages and Builds (incl. Win 64)')}}</a></li>
+        <li><a href="{{ firefox_url('desktop', 'all', 'developer') }}">{% if l10n_has_tag('firefox_channel_bug1387466') %}{{_('All Languages and Platforms')}}{% else %}{{_('All Languages and Builds')}}{% endif %}</a></li>
       </ul>
     </div>
   </footer>
@@ -104,7 +104,7 @@
       <ul>
         <li><a href="{{ firefox_url('desktop', 'notes', 'nightly') }}">{{_('Release Notes')}}</a></li>
         <li><a rel="external" href="https://blog.nightly.mozilla.org/">{{_('Nightly Blog')}}</a></li>
-        <li><a href="{{ firefox_url('desktop', 'all', 'nightly') }}">{{_('All Languages and Builds (incl. Win 64)')}}</a></li>
+        <li><a href="{{ firefox_url('desktop', 'all', 'nightly') }}">{% if l10n_has_tag('firefox_channel_bug1387466') %}{{_('All Languages and Platforms')}}{% else %}{{_('All Languages and Builds')}}{% endif %}</a></li>
       </ul>
     </div>
   </footer>


### PR DESCRIPTION
## Description

Update the links from the [channel](https://www.mozilla.org/en-US/firefox/channel/desktop/) page to /all/ pages since the 64-bit version is now default. Also use the term "platforms" instead of "builds" to be consistent with the [/new/](https://www.mozilla.org/en-US/firefox/new/) page. So this basically replaces "**All Languages and Builds (incl. Win 64)**" with "**All Languages and Platforms**" (which I think was the original copy.)

This Requires a l10n update, but we can use "All Languages and Builds" as the fallback string, which has already been used on the Android channel page.

## Issue / Bugzilla link

[Bug 1387466](https://bugzilla.mozilla.org/show_bug.cgi?id=1387466)

## Testing

Just visit the channel page and make sure the new link copy is displayed.