### PR TITLE
Bug 1395342: Send to device number field not US only

### DIFF
--- a/bedrock/firefox/forms.py
+++ b/bedrock/firefox/forms.py
@@ -5,47 +5,20 @@
 import re
 
 from django import forms
-from django.core.validators import EMPTY_VALUES
-from django.utils.encoding import smart_text
-
-from lib.l10n_utils.dotlang import _lazy as _
-
-
-class USPhoneNumberField(forms.CharField):
-    """A form field that validates input as a U.S. phone number.
-
-    Note: The default 'invalid' error message serves as a placeholder and is not
-    currently in use or localized.
-    """
-    default_error_messages = {
-        'invalid': _("Sorry. This number isn't valid. Please enter a U.S. phone "
-                     'number or <a href="%s">'
-                     'download directly from Google Play.</a>') % 'http://mzl.la/OgZo6k',
-    }
-
-    def __init__(self, *args, **kwargs):
-        kwargs.setdefault('max_length', 14)
-        super(USPhoneNumberField, self).__init__(*args, **kwargs)
-
-    def clean(self, value):
-        super(USPhoneNumberField, self).clean(value)
-        if value in EMPTY_VALUES:
-            return ''
-
-        value = re.sub(r'\D+', '', smart_text(value))
-        if len(value) == 10:
-            value = '1' + value
-        elif len(value) != 11 or value[0] != '1':
-            raise forms.ValidationError(self.error_messages['invalid'])
-
-        return value
 
 
 class SendToDeviceWidgetForm(forms.Form):
-    number = USPhoneNumberField(required=False)
+    number = forms.CharField(max_length=20, min_length=4, required=False)
     email = forms.EmailField(max_length=100, required=False)
     platform = forms.ChoiceField(choices=(
         ('ios', 'ios'),
         ('android', 'android'),
         ('all', 'all'),
     ), required=False)
+
+    def clean_number(self):
+        number = self.cleaned_data['number']
+        if number:
+            number = re.sub(r'\D+', '', number)
+
+        return number

--- a/bedrock/firefox/tests/test_views.py
+++ b/bedrock/firefox/tests/test_views.py
@@ -198,7 +198,7 @@ class TestSendToDeviceView(TestCase):
         })
         ok_(resp_data['success'])
         self.mock_send_sms.assert_called_with('post', 'subscribe_sms', data={
-            'mobile_number': '15558675309',
+            'mobile_number': '5558675309',
             'msg_name': views.SEND_TO_DEVICE_MESSAGE_SETS['default']['sms']['android'],
             'lang': 'en-US',
         })
@@ -206,11 +206,11 @@ class TestSendToDeviceView(TestCase):
     def test_send_android_sms_non_en_us(self):
         resp_data = self._request({
             'platform': 'android',
-            'phone-or-email': '5558675309',
+            'phone-or-email': '015558675309',
         }, locale='de')
         ok_(resp_data['success'])
         self.mock_send_sms.assert_called_with('post', 'subscribe_sms', data={
-            'mobile_number': '15558675309',
+            'mobile_number': '015558675309',
             'msg_name': views.SEND_TO_DEVICE_MESSAGE_SETS['default']['sms']['android'],
             'lang': 'de',
         })
@@ -223,7 +223,7 @@ class TestSendToDeviceView(TestCase):
         })
         ok_(resp_data['success'])
         self.mock_send_sms.assert_called_with('post', 'subscribe_sms', data={
-            'mobile_number': '15558675309',
+            'mobile_number': '5558675309',
             'msg_name': views.SEND_TO_DEVICE_MESSAGE_SETS['default']['sms']['android'],
             'lang': 'en-US',
             'country': 'de',
@@ -237,7 +237,7 @@ class TestSendToDeviceView(TestCase):
         })
         ok_(resp_data['success'])
         self.mock_send_sms.assert_called_with('post', 'subscribe_sms', data={
-            'mobile_number': '15558675309',
+            'mobile_number': '5558675309',
             'msg_name': views.SEND_TO_DEVICE_MESSAGE_SETS['default']['sms']['android'],
             'lang': 'en-US',
         })
@@ -249,7 +249,7 @@ class TestSendToDeviceView(TestCase):
         })
         ok_(resp_data['success'])
         self.mock_send_sms.assert_called_with('post', 'subscribe_sms', data={
-            'mobile_number': '15558675309',
+            'mobile_number': '5558675309',
             'msg_name': views.SEND_TO_DEVICE_MESSAGE_SETS['default']['sms']['android'],
             'lang': 'en-US',
         })
@@ -264,13 +264,13 @@ class TestSendToDeviceView(TestCase):
         ok_('system' in resp_data['errors'])
 
     def test_send_bad_sms_number(self):
+        self.mock_send_sms.side_effect = views.basket.BasketException('mobile_number is invalid')
         resp_data = self._request({
             'platform': 'android',
             'phone-or-email': '555',
         })
         ok_(not resp_data['success'])
         ok_('number' in resp_data['errors'])
-        ok_(not self.mock_send_sms.called)
 
     def test_send_android_email(self):
         resp_data = self._request({
@@ -313,7 +313,7 @@ class TestSendToDeviceView(TestCase):
         })
         ok_(resp_data['success'])
         self.mock_send_sms.assert_called_with('post', 'subscribe_sms', data={
-            'mobile_number': '15558675309',
+            'mobile_number': '5558675309',
             'msg_name': views.SEND_TO_DEVICE_MESSAGE_SETS['default']['sms']['ios'],
             'lang': 'en-US',
         })
@@ -339,7 +339,7 @@ class TestSendToDeviceView(TestCase):
         })
         ok_(resp_data['success'])
         self.mock_send_sms.assert_called_with('post', 'subscribe_sms', data={
-            'mobile_number': '15558675309',
+            'mobile_number': '5558675309',
             'msg_name': views.SEND_TO_DEVICE_MESSAGE_SETS['fx-android']['sms']['android'],
             'lang': 'en-US',
         })
@@ -363,10 +363,40 @@ class TestSendToDeviceView(TestCase):
         })
         ok_(resp_data['success'])
         self.mock_send_sms.assert_called_with('post', 'subscribe_sms', data={
-            'mobile_number': '15558675309',
+            'mobile_number': '5558675309',
             'msg_name': views.SEND_TO_DEVICE_MESSAGE_SETS['fx-mobile-download-desktop']['sms']['all'],
             'lang': 'en-US',
         })
+
+    def test_sms_number_with_punctuation(self):
+        resp_data = self._request({
+            'phone-or-email': '(555) 867-5309',
+            'message-set': 'fx-mobile-download-desktop',
+        })
+        ok_(resp_data['success'])
+        self.mock_send_sms.assert_called_with('post', 'subscribe_sms', data={
+            'mobile_number': '5558675309',
+            'msg_name': views.SEND_TO_DEVICE_MESSAGE_SETS['fx-mobile-download-desktop']['sms']['all'],
+            'lang': 'en-US',
+        })
+
+    def test_sms_number_too_long(self):
+        resp_data = self._request({
+            'phone-or-email': '5558675309555867530912',
+            'message-set': 'fx-mobile-download-desktop',
+        })
+        ok_(not resp_data['success'])
+        self.mock_send_sms.assert_not_called()
+        ok_('number' in resp_data['errors'])
+
+    def test_sms_number_too_short(self):
+        resp_data = self._request({
+            'phone-or-email': '555',
+            'message-set': 'fx-mobile-download-desktop',
+        })
+        ok_(not resp_data['success'])
+        self.mock_send_sms.assert_not_called()
+        ok_('number' in resp_data['errors'])
 
 
 @override_settings(DEV=False)

--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -220,9 +220,12 @@ def send_to_device_ajax(request):
 
                 try:
                     basket.request('post', 'subscribe_sms', data=data)
-                except basket.BasketException:
-                    return HttpResponseJSON({'success': False, 'errors': ['system']},
-                                            status=400)
+                except basket.BasketException as e:
+                    if e.desc == 'mobile_number is invalid':
+                        return HttpResponseJSON({'success': False, 'errors': ['number']})
+                    else:
+                        return HttpResponseJSON({'success': False, 'errors': ['system']},
+                                                status=400)
             else:
                 return HttpResponseJSON({'success': False, 'errors': ['platform']})
         else:  # email


### PR DESCRIPTION
This removes the form validation that I failed to remove before.  It also enables the proper message when basket says that the number is invalid.