### PR TITLE
Fix Bug 1407349, expand max-content to prevent choose button from overlapping text

### DIFF
--- a/media/css/privacy/firefox-privacy.scss
+++ b/media/css/privacy/firefox-privacy.scss
@@ -130,7 +130,7 @@ main {
     width: 94%;
 
     @media #{$mq-desktop} {
-        max-width: 600px;
+        max-width: 700px;
     }
 
     h2 {
@@ -255,6 +255,7 @@ main.interactive-widget {
         p {
             display: inline-block;
             margin: 0;
+            max-width: 80%;
         }
 
         button {
@@ -290,12 +291,12 @@ main.interactive-widget {
     width: 94%;
 
     @media #{$mq-desktop} {
-        max-width: 600px;
+        max-width: 700px;
     }
 }
 
 /* RTL LANGUAGES */
-html[dir="rtl"]{
+html[dir='rtl']{
     .privacy-head {
         text-align: right;
 


### PR DESCRIPTION
## Description
In some locales, notably French, the constricted `max-width` of the content is causing the Choose button to overlap the text. I always felt that `600px` was going to be to narrow, so here I extended it to `700px` and tested `en`, `fr`, `de`, `it` and there is now enough breathing room.

## Issue / Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1407349

## Testing
Ensure that the Choose button does not overlap the text in various locales, most notably Franch. 
