### PR TITLE
Fix Bug 1405076, firefox landing page layout and content updates

### DIFF
--- a/bedrock/firefox/templates/firefox/firefox-quantum.html
+++ b/bedrock/firefox/templates/firefox/firefox-quantum.html
@@ -1,0 +1,170 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+
+{% extends "firefox/base-pebbles.html" %}
+
+{% block page_css %}
+  {% stylesheet 'firefox-quantum-landing' %}
+{% endblock %}
+
+{% block page_title %}{{ _('2x faster and 30% less memory') }} | {{ _('Firefox Browser') }}{% endblock %}
+{% block page_desc %}{{ _('Download now to start browsing the fastest Firefox ever.') }}{% endblock %}
+{% block page_image %}{{ static('img/firefox/template/page-image-quantum.png') }}{% endblock %}
+
+{% block content %}
+{% include 'firefox/includes/hub/sub-nav.html' %}
+<main role="main">
+  <header class="main-header" data-scroll-tracking="Main Header">
+    <div class="header-image">
+      {{ high_res_img('firefox/quantum/new-tab.png', {'alt': '', 'width': '922', 'height': '662'}) }}
+    </div>
+    <div class="content">
+      <div class="header-content">
+        <h1>{{ _('<strong>Firefox</strong> Quantum') }}</h1>
+        <h2>{{ _('New. Fast. For good.') }}</h2>
+        <div class="cta-wrapper">
+          {{ download_firefox(alt_copy=_('Download Now'), dom_id='firefox-desktop-page-primary', download_location='primary cta', button_color='quantum-download') }}
+        </div>
+      </div>
+    </div>
+  </header>
+  <div class="key-features-section main" data-scroll-tracking="First Key Features">
+    <div class="content">
+      <section class="key-feature fast">
+        <div class="key-feature-content">
+          <h2>{{ _('2x faster') }}</h2>
+          <p>
+          {% trans url='https://blog.mozilla.org/firefox-de/firefox-quantum-superschnell-und-schont-den-speicher/' if LANG == 'de' else 'https://blog.mozilla.org/firefox/quantum-performance-test/' %}
+            Powered by a new, cutting-edge engine, Firefox has <a href="{{ url }}">doubled its speed</a>
+            from last year. Because the Internet waits for no one.
+          {% endtrans %}
+          </p>
+        </div>
+      </section>
+      <section class="key-feature performance">
+        <div class="key-feature-content">
+          <h2>{{ _('Lean, mean speed machine') }}</h2>
+          <p>
+          {% trans url='https://blog.mozilla.org/firefox-de/firefox-quantum-superschnell-und-schont-den-speicher/' if LANG == 'de' else 'https://blog.mozilla.org/firefox/quantum-performance-test/' %}
+            Firefox Quantum’s new engine uses <a href="{{ url }}">30% less memory</a> than Chrome,
+            so other programs won’t slow down during browsing. Now that’s a win-win.
+          {% endtrans %}
+          </p>
+        </div>
+      </section>
+      <section class="key-feature design">
+        <h2>{{ _('Beautiful, intelligent design') }}</h2>
+        <div class="feature-carousel-container">
+          <ul class="feature-carousel">
+            <li class="video-bookmarking">
+              <figure>
+                <video preload="metadata" muted controls poster="{{ static('img/firefox/quantum/carousel/placeholder-bookmarks.png') }}">
+                  <source src="https://assets.mozilla.net/video/quantum/bookmarking.webm" type="video/webm">
+                  <source src="https://assets.mozilla.net/video/quantum/bookmarking.ogv" type="video/ogg; codecs='theora, vorbis'">
+                  <source src="https://assets.mozilla.net/video/quantum/bookmarking.mp4" type="video/mp4">
+                  <img src="{{ static('img/firefox/quantum/carousel/placeholder-bookmarks.png') }}" alt="">
+                </video>
+                <figcaption>{{ _('Bookmarks + Pocket') }}</figcaption>
+              </figure>
+            </li>
+            <li class="video-new-tab">
+              <figure>
+                <video preload="metadata" muted controls poster="{{ static('img/firefox/quantum/carousel/placeholder-new-tab.png') }}">
+                  <source src="https://assets.mozilla.net/video/quantum/new-tab.webm" type="video/webm">
+                  <source src="https://assets.mozilla.net/video/quantum/new-tab.ogv" type="video/ogg; codecs='theora, vorbis'">
+                  <source src="https://assets.mozilla.net/video/quantum/new-tab.mp4" type="video/mp4">
+                  <img src="{{ static('img/firefox/quantum/carousel/placeholder-new-tab.png') }}" alt="">
+                </video>
+                <figcaption>{{ _('New Tab') }}</figcaption>
+              </figure>
+            </li>
+            <li class="video-screenshots">
+              <figure>
+                <video preload="metadata" muted controls poster="{{ static('img/firefox/quantum/carousel/placeholder-screenshots.png') }}">
+                  <source src="https://assets.mozilla.net/video/quantum/screenshots.webm" type="video/webm">
+                  <source src="https://assets.mozilla.net/video/quantum/screenshots.ogv" type="video/ogg; codecs='theora, vorbis'">
+                  <source src="https://assets.mozilla.net/video/quantum/screenshots.mp4" type="video/mp4">
+                  <img src="{{ static('img/firefox/quantum/carousel/placeholder-screenshots.png') }}" alt="">
+                </video>
+                <figcaption>{{ _('Screenshots') }}</figcaption>
+              </figure>
+            </li>
+          </ul>
+          <button class="feature-carousel-previous" type="button">{{ _('Previous') }}</button>
+          <button class="feature-carousel-next" type="button">{{ _('Next') }}</button>
+          <p>
+          {% trans %}
+            Hello, gorgeous! Firefox’s sleek, new look comes loaded with intuitive features
+            like in-browser screenshots and more.
+          {% endtrans %}
+          </p>
+        </div>
+      </section>
+    </div>
+  </div>
+  <section class="other-features" data-scroll-tracking="Other Features">
+    <div class="content">
+      <h2>{{ _('Get the job done… faster') }}</h2>
+      <ul>
+        <li>
+          <h3 class="new-tab">{{ _('New Tab') }}</h3>
+          <p>{{ _('Search across multiple sites, view your top pages and discover new content.') }}</p>
+        </li>
+        <li>
+          <h3 class="library">{{ _('Library') }}</h3>
+          <p>{{ _('Enjoy everything you’ve saved to Firefox while browsing in one, easy place.') }}</p>
+        </li>
+        <li>
+          <h3 class="extensions">{{ _('Extensions') }}</h3>
+          <p>{{ _('Personalize Firefox with your favorite extras that help you do you.') }}</p>
+        </li>
+        <li>
+          <h3 class="mobile-browsing">{{ _('Mobile Browsing') }}</h3>
+          <p>{{ _('Access your bookmarks, open tabs and passwords across all your devices.') }}</p>
+        </li>
+      </ul>
+    </div>
+  </section>
+  <div class="key-features-section" data-scroll-tracking="Second Key Features">
+    <div class="content">
+      <section class="key-feature privacy">
+        <div class="key-feature-content">
+          <h2>{{ _('Powerful privacy') }}</h2>
+          <p>
+          {% trans url='https://blog.mozilla.org/firefox-de/die-studie-zum-schutz-vor-aktivitatsverfolgung/' if LANG == 'de' else 'https://blog.mozilla.org/firefox/tracking-protection-study/' %}
+            You’re in control of your online information. Use Firefox Private Browsing to block ads
+            with trackers for extra peace of mind… and pages that load <a href="{{ url }}">up to 44% faster</a>.
+          {% endtrans %}
+          </p>
+        </div>
+      </section>
+      <section class="key-feature mozilla">
+        <div class="key-feature-content">
+          <h2>{{ _('Browse for good') }}</h2>
+          <p>
+          {% trans %}
+            Firefox is backed by the non-profit Mozilla, who keeps the Internet healthier through programs
+            that support tech education for girls, create trust around factual news, bring civility to the
+            comments section and more.
+          {% endtrans %}
+          </p>
+        </div>
+      </section>
+    </div>
+  </div>
+  <section class="secondary-download-cta" data-scroll-tracking="Secondary Download CTA">
+    <div class="content">
+      <div class="secondary-download-cta-content">
+        <h2>{{ _('Start browsing with <strong>Firefox</strong> Quantum') }}</h2>
+        {{ download_firefox(alt_copy=_('Download Now'), dom_id='firefox-desktop-page-secondary', download_location='other', button_color='quantum-download') }}
+      </div>
+    </div>
+  </section>
+
+</main>
+{% endblock %}
+
+{% block js %}
+  {% javascript 'firefox-quantum-landing' %}
+{% endblock %}

--- a/bedrock/firefox/tests/test_views.py
+++ b/bedrock/firefox/tests/test_views.py
@@ -810,6 +810,34 @@ class TestFeedbackView(TestCase):
 
 @override_settings(DEV=False)
 @patch('bedrock.firefox.views.l10n_utils.render')
+class TestFirefoxFeatures(TestCase):
+    @patch.object(views, 'lang_file_is_active', lambda *x: True)
+    @patch('bedrock.firefox.views.switch', Mock(return_value=True))
+    def test_new_firefox_page_loads_with_active_switch(self, render_mock):
+        view = views.FirefoxHubView()
+        view.request = RequestFactory().get('/firefox/')
+        view.request.locale = 'en-US'
+        eq_(view.get_template_names(), ['firefox/firefox-quantum.html'])
+
+    @patch.object(views, 'lang_file_is_active', lambda *x: True)
+    @patch('bedrock.firefox.views.switch', Mock(return_value=False))
+    def test_firefox_hub_page_loads_with_inactive_switch(self, render_mock):
+        view = views.FirefoxHubView()
+        view.request = RequestFactory().get('/firefox/')
+        view.request.locale = 'en-US'
+        eq_(view.get_template_names(), ['firefox/hub/home.html'])
+
+    @patch.object(views, 'lang_file_is_active', lambda *x: False)
+    @patch('bedrock.firefox.views.switch', Mock(return_value=True))
+    def test_firefox_hub_page_loads_with_inactive_locale(self, render_mock):
+        view = views.FirefoxHubView()
+        view.request = RequestFactory().get('/firefox/')
+        view.request.locale = 'fr'
+        eq_(view.get_template_names(), ['firefox/hub/home.html'])
+
+
+@override_settings(DEV=False)
+@patch('bedrock.firefox.views.l10n_utils.render')
 class TestSyncPage(TestCase):
     def test_sync_page_template(self, render_mock):
         req = RequestFactory().get('/firefox/features/sync/')

--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -753,7 +753,17 @@ class FirefoxHubView(BlogPostsView):
     blog_posts_template_variable = 'articles'
     blog_slugs = 'firefox'
     blog_tags = ['home']
-    template_name = 'firefox/hub/home.html'
+
+    def get_template_names(self):
+        locale = l10n_utils.get_locale(self.request)
+
+        if switch('firefox-57-release') and lang_file_is_active(
+                'firefox/firefox-quantum', locale):
+            template_name = 'firefox/firefox-quantum.html'
+        else:
+            template_name = 'firefox/hub/home.html'
+
+        return [template_name]
 
 
 def FirefoxProductDeveloperView(request):

--- a/bedrock/settings/static_media.py
+++ b/bedrock/settings/static_media.py
@@ -576,6 +576,12 @@ PIPELINE_CSS = {
         ),
         'output_filename': 'css/firefox-quantum-bundle.css',
     },
+    'firefox-quantum-landing': {
+        'source_filenames': (
+            'css/firefox/quantum-landing.scss',
+        ),
+        'output_filename': 'css/firefox_quantum_landing-bundle.css',
+    },
     'firefox_releases_index': {
         'source_filenames': (
             'css/base/menu-resp.less',
@@ -1387,6 +1393,16 @@ PIPELINE_JS = {
             'js/firefox/quantum.js',
         ),
         'output_filename': 'js/firefox-quantum-bundle.js',
+    },
+    'firefox-quantum-landing': {
+        'source_filenames': (
+            'js/libs/jquery.cycle2.min.js',
+            'js/libs/jquery.waypoints.min.js',
+            'js/libs/jquery.waypoints-sticky.min.js',
+            'js/hubs/sub-nav.js',
+            'js/firefox/quantum-landing.js',
+        ),
+        'output_filename': 'js/firefox_quantum_landing-bundle.js',
     },
     'firefox_interest_dashboard': {
         'source_filenames': (

--- a/media/css/firefox/components/_buttons.scss
+++ b/media/css/firefox/components/_buttons.scss
@@ -1,0 +1,44 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+@import '../../pebbles/includes/lib';
+
+.download-button {
+    .button,
+    a.button:link,
+    a.button:visited {
+        &.quantum-download {
+            background-color: #4ee331;
+            padding: .3em 40px .5em;
+            border-color: #4ee331;
+            border-radius: 100px;
+
+            .download-title {
+                color: #0040ab;
+                @include font-size-small;
+                font-weight: bold;
+            }
+
+            &:hover,
+            &:focus {
+                background-color: #65e74c;
+            }
+        }
+    }
+
+    .fx-privacy-link a {
+        @include font-size-extra-small;
+
+        &:link,
+        &:visited {
+            text-decoration: none;
+        }
+
+        &:active,
+        &:focus,
+        &:hover {
+            text-decoration: underline;
+        }
+    }
+}

--- a/media/css/firefox/quantum-landing.scss
+++ b/media/css/firefox/quantum-landing.scss
@@ -1,0 +1,772 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+@import
+    '../pebbles/includes/lib',
+    '../hubs/sections',
+    '../hubs/sub-nav',
+    'components/_buttons.scss';
+
+$color-quantum-blue: #0a84ff;
+
+/* -------------------------------------------------------------------------- */
+// Common elements
+
+body {
+    @include open-sans;
+}
+
+#outer-wrapper {
+    overflow-x: hidden;
+}
+
+h1, h2, h3, h4, h5, h6 {
+    font-weight: normal;
+}
+
+/* -------------------------------------------------------------------------- */
+// Top header
+
+.main-header {
+    background: #0060df;
+    background: url('/media/img/firefox/quantum/fox-tail-header.png') top -60px center no-repeat,
+                linear-gradient(148deg, #0060df 7%, #0479f4 20%, #0681fc 27%, #02bdf1 60%, #01d3f0 67%, #05f0e6 100%);
+    color: #fff;
+    padding: 60px 0 50px;
+    position: relative;
+    z-index: 1;
+
+    h1 {
+        @include at2x('/media/img/logos/firefox/logo-quantum.png', 189px, 189px);
+        @include font-size-level2;
+        background-position: top center;
+        background-repeat: no-repeat;
+        padding-top: 210px;
+    }
+
+    h2 {
+        @include font-size-level3;
+    }
+
+    p {
+        margin: 40px auto;
+        max-width: 24em;
+    }
+
+    .cta-wrapper {
+        display: inline-block;
+        text-align: center;
+
+        .download-button {
+            margin-top: 20px;
+        }
+    }
+
+    .header-content {
+        @include background-size(300px 222px);
+        background-image: url('/media/img/firefox/quantum/new-tab.png');
+        background-position: bottom -40px center;
+        background-repeat: no-repeat;
+        padding-bottom: 240px;
+        text-align: center;
+    }
+
+    .header-image {
+        z-index: 1;
+
+        img {
+            display: none;
+        }
+    }
+
+    &:after {
+        background: transparent url('/media/img/firefox/quantum/wave-top.svg') top center no-repeat;
+        @include background-size(3844px 335px);
+        bottom: -40px;
+        content: '';
+        display: block;
+        height: 355px;
+        left: 0;
+        position: absolute;
+        width: 100%;
+    }
+
+    @media #{$mq-phone-wide} {
+        padding: 60px 0 40px;
+
+        .header-content {
+            @include background-size(400px 296px);
+            padding-bottom: 320px;
+        }
+    }
+
+    @media #{$mq-tablet} {
+        padding: 60px 0 30px;
+
+        .header-content {
+            @include background-size(500px 370px);
+            padding-bottom: 390px;
+        }
+    }
+
+    @media #{$mq-desktop} {
+        padding: 60px 0;
+
+        h1 {
+            background-position: top left;
+        }
+
+        p {
+            margin: 40px 0;
+        }
+
+        .content {
+            z-index: 2;
+        }
+
+        .header-content {
+            background: none;
+            float: left;
+            padding-bottom: 0;
+            text-align: left;
+            width: 45%;
+        }
+
+        .header-image {
+            float: right;
+            margin-top: 40px;
+            width: 50%;
+
+            img {
+                display: block;
+                height: 662px;
+                max-width: none;
+                width: 922px;
+            }
+        }
+    }
+
+    @media #{$mq-desktop-wide} {
+        padding: 60px 0 30px;
+    }
+}
+
+html[dir="rtl"] .main-header {
+
+    @media #{$mq-desktop} {
+
+        h1 {
+            background-position: top right;
+        }
+
+        .header-content {
+            float: right;
+            text-align: right;
+        }
+
+        .header-image {
+            float: left;
+        }
+    }
+}
+
+/* -------------------------------------------------------------------------- */
+// Key features sections
+
+.key-features-section {
+    background: #fff;
+
+    h2 {
+        @include font-size-level3;
+        color: $color-quantum-blue;
+        margin-bottom: 20px;
+        padding-top: 40px;
+        position: relative;
+
+        &:before {
+            background: $color-quantum-blue;
+            border-radius: 5px;
+            content: '';
+            height: 5px;
+            left: 0;
+            position: absolute;
+            top: 0;
+            width: 130px;
+        }
+    }
+
+    .key-feature {
+        background-position: top center;
+        background-repeat: no-repeat;
+        margin-top: 40px;
+        text-align: center;
+
+        h2:before {
+            left: 50%;
+            margin-left: -65px;
+        }
+
+        a:link,
+        a:visited {
+            color: $color-quantum-blue;
+            text-decoration: none;
+        }
+
+        a:hover,
+        a:active,
+        a:focus {
+            color: $color-quantum-blue;
+            text-decoration: underline;
+        }
+
+        &.fast {
+            @include at2x('/media/img/firefox/quantum/faster.png', 130px, 141px);
+            padding-top: 160px;
+        }
+
+        &.performance {
+            @include at2x('/media/img/firefox/quantum/performance.png', 160px, 150px);
+            padding-top: 170px;
+        }
+
+        &.privacy {
+            @include at2x('/media/img/firefox/quantum/privacy.png', 300px, 242px);
+            padding-top: 260px;
+        }
+
+        &.mozilla {
+            @include at2x('/media/img/firefox/quantum/mozilla.png', 300px, 261px);
+            padding-top: 280px;
+        }
+    }
+
+    @media #{$mq-tablet} {
+        .key-feature {
+            @include clearfix;
+            background-position: top right;
+            margin: 40px 0 120px;
+            text-align: left;
+
+            &:last-child {
+                margin-bottom: 0;
+            }
+
+            &.fast,
+            &.performance,
+            &.privacy,
+            &.mozilla {
+                h2:before {
+                    left: 0;
+                    margin-left: 0;
+                }
+            }
+
+            &.design {
+                text-align: center;
+            }
+
+            .key-feature-content {
+                width: 45%;
+
+                p {
+                    max-width: 24em;
+                }
+            }
+
+            &.fast {
+                @include background-size(195px 212px);
+                min-height: 250px;
+                padding-top: 0;
+            }
+
+            &.performance {
+                @include background-size(239px 225px);
+                min-height: 250px;
+                padding-top: 0;
+            }
+
+            &.privacy {
+                @include background-size(370px 298px);
+                min-height: 320px;
+                padding-top: 0;
+            }
+
+            &.mozilla {
+                @include background-size(350px 305px);
+                min-height: 320px;
+                padding-top: 0;
+            }
+
+            &:nth-child(even) {
+                background-position: top left;
+
+                .key-feature-content {
+                    float: right;
+                    text-align: right;
+
+                    h2:before {
+                        left: auto;
+                        right: 0;
+                    }
+
+                    p {
+                        float: right;
+                    }
+                }
+            }
+        }
+    }
+
+    @media #{$mq-desktop} {
+        padding: 60px 0 0;
+
+        .key-feature {
+
+            &.fast {
+                @include background-size(260px 282px);
+                min-height: 300px;
+            }
+
+            &.performance {
+                @include background-size(319px 300px);
+                min-height: 320px;
+            }
+
+            &.privacy {
+                @include background-size(470px 378px);
+                min-height: 420px;
+            }
+
+            &.mozilla {
+                @include background-size(450px 392px);
+                min-height: 420px;
+            }
+        }
+    }
+
+    @media #{$mq-desktop-wide} {
+        .key-feature {
+            background-position: top right 160px;
+
+            &:nth-child(even) {
+                background-position: top left 160px;
+            }
+
+            &.privacy {
+                @include background-size(585px 471px);
+                background-position: top right 60px;
+                min-height: 490px;
+            }
+
+            &.mozilla {
+                @include background-size(541px 471px);
+                background-position: top left 60px;
+                min-height: 490px;
+            }
+        }
+    }
+}
+
+html[dir="rtl"] .key-features-section .key-feature {
+
+    h2:before {
+        left: 50%;
+        margin-left: -65px;
+    }
+
+    @media #{$mq-tablet} {
+        background-position: top left;
+        text-align: right;
+
+        &.fast,
+        &.performance,
+        &.privacy,
+        &.mozilla {
+            h2:before {
+                left: auto;
+                margin-left: 0;
+                right: 0;
+            }
+        }
+
+        &.design {
+            text-align: center;
+        }
+
+        &:nth-child(even) {
+            background-position: top right;
+
+            .key-feature-content {
+                float: left;
+                text-align: left;
+
+                h2:before {
+                    left: 0;
+                    right: auto;
+                }
+
+                p {
+                    float: left;
+                }
+            }
+        }
+    }
+
+    @media #{$mq-desktop-wide} {
+        background-position: top left 160px;
+
+        &:nth-child(even) {
+            background-position: top right 160px;
+        }
+
+        &.privacy {
+            background-position: top left 60px;
+        }
+
+        &.mozilla {
+            background-position: top right 60px;
+        }
+    }
+}
+
+/* -------------------------------------------------------------------------- */
+// Features carousel
+
+.feature-carousel-container {
+    margin: 0 auto;
+    max-width: 700px;
+    position: relative;
+
+    p {
+        margin: 20px auto 40px;
+        max-width: 34em;
+    }
+
+    .feature-carousel-previous,
+    .feature-carousel-next {
+        display: none;
+    }
+
+    @media #{$mq-desktop-wide} {
+        max-width: 850px;
+    }
+}
+
+.supports-videos .feature-carousel-container {
+
+    .feature-carousel-previous,
+    .feature-carousel-next {
+        @include image-replaced();
+        @include transition(background-color .1s ease-in-out);
+        background-color: transparent;
+        background-repeat: no-repeat;
+        border-radius: 100%;
+        border: none;
+        display: none;
+        height: 74px;
+        position: absolute;
+        top: 30%;
+        width: 74px;
+
+        &:hover,
+        &:focus {
+            background-color: #f7f7f7;
+        }
+    }
+
+    .feature-carousel-previous {
+        @include at2x('/media/img/firefox/quantum/carousel/arrow-left.png', 74px, 74px);
+        left: -110px;
+    }
+
+    .feature-carousel-next {
+        @include at2x('/media/img/firefox/quantum/carousel/arrow-right.png', 74px, 74px);
+        right: -110px;
+    }
+
+    @media #{$mq-desktop} {
+        .feature-carousel-previous,
+        .feature-carousel-next {
+            display: block;
+        }
+    }
+}
+
+.feature-carousel {
+    margin: 0 auto;
+    overflow: hidden;
+
+    li {
+        width: 100%;
+    }
+
+    figure {
+        display: block;
+        margin: 0 auto 20px;
+        max-width: 850px;
+        text-align: center;
+        width: 100%;
+    }
+
+    figcaption {
+        color: #b1b1b3;
+        margin-top: 20px;
+    }
+
+    video {
+        box-shadow: 0 0 10px 0 rgba(0, 0, 0, .2);
+        height: auto;
+        width: 100%;
+    }
+}
+
+.supports-videos .feature-carousel li {
+    @media #{$mq-desktop} {
+        display: none;
+    }
+}
+
+#colophon {
+    padding-bottom: 100px;
+}
+
+/* -------------------------------------------------------------------------- */
+// Other features list
+
+.other-features {
+    background: #0a84ff url('/media/img/firefox/quantum/fox-tail-features.png') top -160px center no-repeat;
+    color: #fff;
+    padding-bottom: 250px;
+    position: relative;
+    text-align: center;
+
+    &:after {
+        background: transparent url('/media/img/firefox/quantum/wave-middle.svg') top center no-repeat;
+        @include background-size(3821px 304px);
+        bottom: -10px;
+        content: '';
+        display: block;
+        height: 304px;
+        left: 0;
+        position: absolute;
+        width: 100%;
+    }
+
+    .content {
+        padding-top: 60px;
+    }
+
+    h2 {
+        @include font-size-level3;
+        margin-bottom: 60px;
+        padding-top: 40px;
+        position: relative;
+
+        &:before {
+            background: #fff;
+            border-radius: 5px;
+            content: '';
+            height: 5px;
+            left: 50%;
+            margin-left: -65px;
+            position: absolute;
+            top: 0;
+            width: 130px;
+        }
+    }
+
+    ul {
+        margin: 0;
+        padding: 0;
+
+        li {
+            margin: 0;
+            padding: 0;
+        }
+    }
+
+    h3 {
+        @include font-size(18px);
+        background-position: top center;
+        background-repeat: no-repeat;
+        font-weight: bold;
+        margin-bottom: 20px;
+        padding-top: 180px;
+
+        &.new-tab {
+            background-image: url('/media/img/firefox/quantum/features/new-tab.svg');
+        }
+
+        &.library {
+            background-image: url('/media/img/firefox/quantum/features/library.svg');
+        }
+
+        &.extensions {
+            background-image: url('/media/img/firefox/quantum/features/extensions.svg');
+        }
+
+        &.mobile-browsing {
+            background-image: url('/media/img/firefox/quantum/features/mobile-browsing.svg');
+        }
+    }
+
+    @media #{$mq-phone-wide} {
+        ul {
+            display: flex;
+            flex-wrap: wrap;
+
+            li {
+                margin: 0 auto;
+                width: 50%;
+
+                p {
+                    padding: 0 20px 20px;
+                }
+            }
+        }
+    }
+
+    @media #{$mq-desktop} {
+        padding: 60px 0 250px;
+
+        ul li {
+            width: 25%;
+        }
+    }
+
+    @media #{$mq-desktop-wide} {
+        padding: 60px 0 280px;
+    }
+}
+
+@supports(display: grid) {
+
+    .other-features ul {
+        @media #{$mq-phone-wide} {
+            display: grid;
+            grid-gap: 40px;
+            grid-template-columns: repeat(2, 1fr);
+
+            li {
+                width: auto;
+
+                p {
+                    padding: 0 0 20px;
+                }
+            }
+        }
+
+        @media #{$mq-desktop} {
+            grid-template-columns: repeat(4, 1fr);
+
+            li {
+                width: auto;
+            }
+        }
+    }
+}
+
+/* -------------------------------------------------------------------------- */
+// Bottom download cta
+
+.secondary-download-cta {
+    background: #0060df;
+    background: url('/media/img/firefox/quantum/fox-tail-sign-up.png') top -100px center no-repeat,
+                linear-gradient(-80deg, #0060df 11%, #0080ff 45%, #00feff 82%, #06fde1 100%);
+    color: #fff;
+    padding-top: 390px;
+    position: relative;
+
+    &:before {
+        background: transparent url('/media/img/firefox/quantum/wave-bottom.svg') top center no-repeat;
+        @include background-size(4615px 385px);
+        content: '';
+        display: block;
+        height: 390px;
+        left: 0;
+        position: absolute;
+        top: -20px;
+        width: 100%;
+    }
+
+    h2 {
+        @include font-size-level2;
+        line-height: 1.3;
+        margin: 20px auto;
+        max-width: 10em;
+    }
+
+    .secondary-download-cta-content {
+        margin: -140px 0 40px;
+        padding-top: 165px;
+        position: relative;
+        text-align: center;
+
+        &:before {
+            @include at2x('/media/img/firefox/quantum/laptop.png', 280px, 165px);
+            background-position: top left;
+            background-repeat: no-repeat;
+            content: '';
+            height: 165px;
+            left: 50%;
+            margin-left: -140px;
+            position: absolute;
+            top: 0;
+            width: 280px;
+        }
+    }
+
+    @media #{$mq-tablet} {
+        .secondary-download-cta-content {
+            margin-bottom: 0;
+            min-height: 180px;
+            padding: 0 0 0 320px;
+            text-align: left;
+
+            h2 {
+                margin: 20px 0;
+            }
+
+            &:before {
+                left: 0;
+                margin-left: 0;
+            }
+        }
+    }
+
+    @media #{$mq-desktop} {
+        .secondary-download-cta-content {
+            min-height: 300px;
+            padding-left: 460px;
+
+            &:before {
+                @include background-size(422px 248px);
+                height: 248px;
+                width: 422px;
+            }
+        }
+    }
+}
+
+html[dir="rtl"] .secondary-download-cta {
+
+    @media #{$mq-tablet} {
+        .secondary-download-cta-content {
+            padding: 0 320px 0 0;
+            text-align: right;
+
+
+            &:before {
+                left: auto;
+                right: 0;
+            }
+        }
+    }
+
+    @media #{$mq-desktop} {
+        .secondary-download-cta-content {
+            padding-right: 460px;
+        }
+    }
+}

--- a/media/js/firefox/quantum-landing.js
+++ b/media/js/firefox/quantum-landing.js
@@ -1,0 +1,213 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+(function (Mozilla, Waypoint) {
+    'use strict';
+
+    var client = Mozilla.Client;
+    var $slideShow = $('.feature-carousel');
+    var videoCarouselWaypoint;
+    var otherFeaturesWaypoint;
+
+    function cutsTheMustard() {
+        return 'querySelector' in document &&
+               'querySelectorAll' in document &&
+               'addEventListener' in window &&
+               typeof window.matchMedia !== 'undefined' &&
+               typeof HTMLMediaElement !== 'undefined';
+    }
+
+    // Init feature video carousel.
+    function initVideoCarousel() {
+
+        $slideShow.cycle({
+            fx: 'scrollHorz',
+            log: false,
+            slides: '> li',
+            speed: 620,
+            prev: '.feature-carousel-previous',
+            next: '.feature-carousel-next',
+        });
+
+        $slideShow.cycle('pause');
+
+        /**
+         * We only auto-play videos inline in the carousel for desktop users, since many mobile platforms
+         * restrict auto play without direct user interaction, and also disallow inline video.
+         */
+        if (client.isDesktop) {
+
+            var videos = document.querySelectorAll('.feature-carousel video');
+
+            // remove standard controls and set each video to loop.
+            for (var i = 0; i < videos.length; i++) {
+                videos[i].removeAttribute('controls');
+                videos[i].setAttribute('loop', '');
+            }
+
+            // triggered just prior to a transition to a new slide.
+            $slideShow.on('cycle-before', function(event, optionHash, outgoingSlideEl, incomingSlideEl, forwardFlag) {
+                var outgoingVideo = $(outgoingSlideEl).find('video')[0];
+                var incomingVideo = $(incomingSlideEl).find('video')[0];
+                var direction = forwardFlag ? 'Right' : 'Left';
+
+                // pause the outgoing video.
+                if (outgoingVideo && !outgoingVideo.paused) {
+                    outgoingVideo.pause();
+                }
+
+                // reset the incoming video to the first frame.
+                if (incomingVideo && incomingVideo.paused) {
+                    // if a video is slow to load metadata may not yet be available, so fail gracefully.
+                    try {
+                        incomingVideo.currentTime = 0;
+                    } catch(e) {
+                        // empty
+                    }
+                }
+
+                window.dataLayer.push({
+                    'event': 'in-page-interaction',
+                    'eAction': 'Button Click',
+                    'eLabel': 'Carousel ' + direction
+                });
+            });
+
+            // triggered after the slideshow has completed transitioning to the next slide.
+            $slideShow.on('cycle-after', function(event, optionHash, outgoingSlideEl, incomingSlideEl) {
+                var video = $(incomingSlideEl).find('video')[0];
+
+                // play the incoming video.
+                if (video && video.paused) {
+                    playVideo(video);
+                }
+            });
+        }
+    }
+
+    // Destroy feature video carousel.
+    function destroyVideoCarousel() {
+        var videos;
+        var activeVideo = document.querySelector('.cycle-slide-active video');
+
+        if (activeVideo && client.isDesktop) {
+            activeVideo.pause();
+
+            videos = document.querySelectorAll('.feature-carousel video');
+
+            // reinstate videos to use standard controls.
+            for (var i = 0; i < videos.length; i++) {
+                videos[i].setAttribute('controls', '');
+                videos[i].removeAttribute('loop');
+            }
+        }
+
+        $slideShow.cycle('destroy');
+    }
+
+    // Scroll waypoints to automatically start / pause the video carousel as user scrolls in / out of section.
+    function initVideoWaypoints() {
+
+        videoCarouselWaypoint = new Waypoint({
+            element: document.querySelector('.feature-carousel-container'),
+            offset: '50%',
+            handler: function(direction) {
+                var video = document.querySelector('.cycle-slide-active video');
+
+                if (video && client.isDesktop) {
+                    if (direction === 'down') {
+                        playVideo(video);
+                    } else {
+                        video.pause();
+                    }
+                }
+            }
+        });
+
+        otherFeaturesWaypoint = new Waypoint({
+            element: document.querySelector('.other-features'),
+            offset: 0,
+            handler: function(direction) {
+                var video = document.querySelector('.cycle-slide-active video');
+
+                if (video && client.isDesktop) {
+                    if (direction === 'down') {
+                        playVideo(video);
+                    } else {
+                        video.play();
+                    }
+                }
+            }
+        });
+    }
+
+    function playVideo(video) {
+        if (video.readyState && video.readyState > 0) {
+            video.play();
+        }
+    }
+
+    // Scroll waypoints for GA tracking.
+    function initScrollTracking() {
+        var sections = document.querySelectorAll('[data-scroll-tracking]');
+
+        for (var i = 0; i < sections.length; i++) {
+            new Waypoint({
+                element: sections[i],
+                handler: function(direction) {
+                    if (direction === 'down') {
+                        window.dataLayer.push({
+                            event: 'scroll-section',
+                            interaction: 'scroll',
+                            section: this.element.getAttribute('data-scroll-tracking')
+                        });
+                    }
+                },
+                offset: '100%'
+            });
+        }
+    }
+
+    // Only init video carousel for wide viewports on desktop browsers.
+    function initMediaQueries() {
+        var desktopWidth;
+
+        desktopWidth = matchMedia('(min-width: 1000px)');
+
+        if (desktopWidth.matches) {
+            initVideoCarousel();
+            initVideoWaypoints();
+        }
+
+        desktopWidth.addListener(function(mq) {
+            if (mq.matches) {
+                initVideoCarousel();
+                initVideoWaypoints();
+            } else {
+                destroyVideoCarousel();
+                destroyWaypoints();
+            }
+        });
+    }
+
+    // Destroy all waypoints used for UI interactions.
+    function destroyWaypoints() {
+
+        if (videoCarouselWaypoint) {
+            videoCarouselWaypoint.destroy();
+        }
+
+        if (otherFeaturesWaypoint) {
+            otherFeaturesWaypoint.destroy();
+        }
+    }
+
+    // Basic feature detect for 1st class JS features.
+    if (cutsTheMustard()) {
+        document.querySelector('main').className = 'supports-videos';
+        initMediaQueries();
+        initScrollTracking();
+    }
+
+})(window.Mozilla, window.Waypoint);

--- a/tests/functional/firefox/test_home.py
+++ b/tests/functional/firefox/test_home.py
@@ -7,6 +7,8 @@ import pytest
 from pages.firefox.home import FirefoxHomePage
 
 
+@pytest.mark.skipif(
+    reason='https://bugzilla.mozilla.org/show_bug.cgi?id=1405076')
 @pytest.mark.smoke
 @pytest.mark.sanity
 @pytest.mark.nondestructive

--- a/tests/functional/newsletter/test_newsletter_embed.py
+++ b/tests/functional/newsletter/test_newsletter_embed.py
@@ -24,6 +24,8 @@ from pages.smarton.landing import SmartOnLandingPage
 from pages.smarton.base import SmartOnBasePage
 
 
+@pytest.mark.skipif((FirefoxHomePage, None),
+    reason='https://bugzilla.mozilla.org/show_bug.cgi?id=1405076')
 @pytest.mark.nondestructive
 @pytest.mark.parametrize(('page_class', 'url_kwargs'), [
     pytest.mark.smoke((HomePage, None)),
@@ -59,7 +61,11 @@ def test_newsletter_default_values(page_class, url_kwargs, base_url, selenium):
 
 
 @pytest.mark.nondestructive
-@pytest.mark.parametrize('page_class', [HomePage, ContributePage, FirefoxHomePage])
+@pytest.mark.parametrize('page_class', [
+    HomePage,
+    ContributePage,
+    pytest.mark.skipif((FirefoxHomePage, None),
+        reason='https://bugzilla.mozilla.org/show_bug.cgi?id=1405076')])
 def test_newsletter_successful_sign_up(page_class, base_url, selenium):
     page = page_class(selenium, base_url).open()
     page.newsletter.expand_form()
@@ -72,7 +78,11 @@ def test_newsletter_successful_sign_up(page_class, base_url, selenium):
 
 
 @pytest.mark.nondestructive
-@pytest.mark.parametrize('page_class', [HomePage, ContributePage, FirefoxHomePage])
+@pytest.mark.parametrize('page_class', [
+    HomePage,
+    ContributePage,
+    pytest.mark.skipif((FirefoxHomePage, None),
+        reason='https://bugzilla.mozilla.org/show_bug.cgi?id=1405076')])
 def test_newsletter_sign_up_fails_when_missing_required_fields(page_class, base_url, selenium):
     page = page_class(selenium, base_url).open()
     page.newsletter.expand_form()


### PR DESCRIPTION
## Description
Updates the /firefox page to mirror the current /firefox/quantum with additional copy updates.

## Issue / Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1405076

## Testing
Ensure that is switch is not enabled the current content hub version of the page is shown.