### PR TITLE
[no bug] Use same string as page description for Dev Edition

### DIFF
--- a/bedrock/firefox/templates/firefox/products/developer-quantum.html
+++ b/bedrock/firefox/templates/firefox/products/developer-quantum.html
@@ -7,7 +7,7 @@
 {% extends "firefox/base-pebbles.html" %}
 
 {% block page_title %}{{_('Firefox Developer Edition')}}{% endblock %}
-{% block page_desc %}{{ _('Firefox Developer Edition is the blazing fast browser that offers cutting edge developer tools and the latest features like CSS Grid support and framework debugging') }}{% endblock %}
+{% block page_desc %}{{ _('Firefox Developer Edition is the blazing fast browser that offers cutting edge developer tools and latest features like CSS Grid support and framework debugging') }}{% endblock %}
 {% block page_image %}{{ static('img/firefox/products/developer/quantum/page-image.png') }}{% endblock %}
 {% block page_favicon %}{{ static('img/firefox/products/developer/quantum/favicon.png') }}{% endblock %}
 {% block page_favicon_large %}{{ static('img/firefox/products/developer/quantum/favicon-196.png') }}{% endblock %}


### PR DESCRIPTION
In #5143 I missed that the change was not only a final period, but also an added 'the'. Can we use the same description in all 3 pages (landing, whatsnew, firstrun)? We're currently showing the description untranslated on the landing page.