### PR TITLE
[fix bug 1404301] Remove Tabzilla from new Firefox Privacy Policy

### DIFF
--- a/bedrock/privacy/templates/privacy/base.html
+++ b/bedrock/privacy/templates/privacy/base.html
@@ -21,6 +21,8 @@
   data-choices-button="{{ _('Choose…') }}"
 {% endblock %}
 
+{% block tabzilla_tab %}{% endblock %}
+
 {% set header = doc.body.section.extract() %}
 {% set lead_in = doc.body.section.extract() %}
 {% set footnote = doc.body.select('#footnote') %}


### PR DESCRIPTION
## Description
Removes tabzilla from localized versions of the new privacy pages.

## Issue / Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1404301

## Testing
Load `/de/privacy/firefox/` and resize the window down to mobile sized viewport. The Tabzilla wordmark should no longer obscure the Mozilla logo.