### PR TITLE
[fix bug 1392860] Update skip link on /firstrun membership experiment

### DIFF
--- a/bedrock/firefox/templates/firefox/firstrun/membership-b.html
+++ b/bedrock/firefox/templates/firefox/firstrun/membership-b.html
@@ -50,7 +50,7 @@
         <li><button type="button" data-index="1" data-id="membership-comm" data-label="Privacy">{{ _('Privacy') }}</button></li>
         <li><button type="button" data-index="2" data-id="membership-tech" data-label="Technology">{{ _('Technology') }}</button></li>
       </ul>
-      <a href="{{ url('newsletter.mozilla') }}" class="later">{{ _('Remind me later') }}</a>
+      <a href="about:home" class="later">{{ _('Skip this step') }}</a>
     </section>
   </div>
   <div class="step-2 hidden">

--- a/media/js/firefox/firstrun/membership.js
+++ b/media/js/firefox/firstrun/membership.js
@@ -123,7 +123,7 @@
         window.dataLayer.push({
             'event': 'in-page-interaction',
             'eAction': 'Link Click',
-            'eLabel': 'Remind Me Later'
+            'eLabel': 'Skip this step'
         });
     }
 


### PR DESCRIPTION
## Description
- Updated skip link on /firstrun membership experiment.

## Issue / Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1392860#c70

## Testing
- Link should now load `about:home` instead of the newsletter page.
