### PR TITLE
[bug 1389676] Trigger notification  if 2 major versions out of date

### DIFF
--- a/media/js/base/mozilla-client.js
+++ b/media/js/base/mozilla-client.js
@@ -212,6 +212,25 @@ if (typeof Mozilla === 'undefined') {
     };
 
     /**
+     * Determine if a version number is more than a specific number of major releases old.
+     * @param {String} clientVer - Client version number "58.0a1", "56.0".
+     * @param {Number} majorVer - Number of major versions old a client considered 'out of date' should be.
+     * @param {String} latestVer - Current latest release version number.
+     * @return {Boolean}
+     */
+    Client.isFirefoxOutOfDate = function(clientVer, majorVer, latestVer) {
+        var clientVersion = parseInt(clientVer, 10);
+        var latestVersion = typeof latestVer === 'undefined' ? parseInt($('html').attr('data-latest-firefox'), 10) : parseInt(latestVer, 10);
+        var majorVersions = parseInt(majorVer, 10) - 1;
+
+        if (isNaN(latestVersion) || isNaN(clientVersion) || isNaN(majorVersions)) {
+            return false;
+        }
+
+        return clientVersion < latestVersion - majorVersions;
+    };
+
+    /**
      * Use the async mozUITour API of Firefox to retrieve the user's browser info, including the update channel and
      * accurate, patch-level version number. This API is available on Firefox 35 and later. See
      * http://bedrock.readthedocs.org/en/latest/uitour.html for details.

--- a/media/js/base/mozilla-notification-banner-init.js
+++ b/media/js/base/mozilla-notification-banner-init.js
@@ -14,15 +14,14 @@ $(function() {
     var confirmText;
     var closeText;
 
-    // try to get localized copy
-    // if any of the below fail, the banner will detect missing strings and
-    // will not initialize
-    if (typeof utils !== 'undefined') {
-        headingText = utils.trans('global-fx-out-of-date-banner-heading');
-        messageText = utils.trans('global-fx-out-of-date-banner-message');
-        confirmText = utils.trans('global-fx-out-of-date-banner-confirm');
-        closeText = utils.trans('global-close');
+    if (typeof utils === 'undefined' || typeof client === 'undefined') {
+        return;
     }
+
+    headingText = utils.trans('global-fx-out-of-date-banner-heading');
+    messageText = utils.trans('global-fx-out-of-date-banner-message');
+    confirmText = utils.trans('global-fx-out-of-date-banner-confirm');
+    closeText = utils.trans('global-close');
 
     var config = {
         'id': 'fx-out-of-date-banner',
@@ -43,8 +42,9 @@ $(function() {
     // Notification should only be shown to users on Firefox for desktop.
     if (client.isFirefoxDesktop) {
         client.getFirefoxDetails(function(details) {
-            // User must be out of date and on release channel.
-            if (!details.isUpToDate && details.channel === 'release') {
+            // Don't rely on UA strings as they can be altered by extensions, so use UITour instead (Bug 1406299).
+            // User must be more than 2 major versions out of date and on release channel.
+            if (client.isFirefoxOutOfDate(details.version, 2) && details.channel === 'release') {
 
                 // Check that cookies are enabled before seeing if one already exists.
                 if (typeof Mozilla.Cookies !== 'undefined' && Mozilla.Cookies.enabled()) {

--- a/media/js/base/mozilla-notification-banner-modal-init.js
+++ b/media/js/base/mozilla-notification-banner-modal-init.js
@@ -14,19 +14,18 @@ $(function() {
     var confirmText;
     var closeText;
 
+    if (typeof utils === 'undefined' || typeof client === 'undefined') {
+        return;
+    }
+
     var _clickCallback = function() {
         Mozilla.Modal.createModal(this, $('.notification-modal-content'));
     };
 
-    // try to get localized copy
-    // if any of the below fail, the banner will detect missing strings and
-    // will not initialize
-    if (typeof utils !== 'undefined') {
-        headingText = utils.trans('global-fx-out-of-date-banner-heading');
-        messageText = utils.trans('global-fx-out-of-date-banner-message');
-        confirmText = utils.trans('global-fx-out-of-date-banner-confirm');
-        closeText = utils.trans('global-close');
-    }
+    headingText = utils.trans('global-fx-out-of-date-banner-heading');
+    messageText = utils.trans('global-fx-out-of-date-banner-message');
+    confirmText = utils.trans('global-fx-out-of-date-banner-confirm');
+    closeText = utils.trans('global-close');
 
     var config = {
         'id': 'fx-out-of-date-banner',
@@ -42,22 +41,6 @@ $(function() {
         'gaCloseLabel': 'Close' // GA - English only
     };
 
-    /**
-     * Determine if Firefox client is out of date.
-     * @param {String} - Client version provided by UITour e.g. "58.0a1", "56.0".
-     * @return {Boolean} - Returns true if client is at least 2 major versions out of date.
-     */
-    var _isClientOutOfDate = function(version) {
-        var clientVersion = parseInt(version, 10);
-        var latestVersion = parseInt($('html').attr('data-latest-firefox'), 10);
-
-        if (!latestVersion || !clientVersion) {
-            return false;
-        }
-
-        return clientVersion < latestVersion - 1;
-    };
-
     // Set a unique cookie ID for fx-out-of-date notification.
     Mozilla.NotificationBanner.COOKIE_CODE_ID = 'moz-notification-fx-out-of-date';
 
@@ -68,7 +51,8 @@ $(function() {
     if (client.isFirefoxDesktop) {
         client.getFirefoxDetails(function(details) {
             // Don't rely on UA strings as they can be altered by extensions, so use UITour instead (Bug 1406299).
-            if (_isClientOutOfDate(details.version) && details.channel === 'release') {
+            // User must be more than 2 major versions out of date and on release channel.
+            if (client.isFirefoxOutOfDate(details.version, 2) && details.channel === 'release') {
                 // Check that cookies are enabled.
                 if (typeof Mozilla.Cookies !== 'undefined' && Mozilla.Cookies.enabled()) {
                     Mozilla.NotificationBanner.init(config);

--- a/tests/unit/spec/base/mozilla-client.js
+++ b/tests/unit/spec/base/mozilla-client.js
@@ -515,4 +515,36 @@ describe('mozilla-client.js', function() {
 
     });
 
+    describe('isFirefoxOutOfDate', function () {
+
+        it('should return true if version number is less than the number of major versions specified out of date', function () {
+            var result = Mozilla.Client.isFirefoxOutOfDate('50.0', 2, '56.0.1');
+            expect(result).toBeTruthy();
+
+            var result2 = Mozilla.Client.isFirefoxOutOfDate('54.0', 2, '56.0');
+            expect(result2).toBeTruthy();
+
+            var result3 = Mozilla.Client.isFirefoxOutOfDate('54.0a1', 2, '56.0.1a1');
+            expect(result3).toBeTruthy();
+
+            var result4 = Mozilla.Client.isFirefoxOutOfDate('54.0.1', 1, '56.0');
+            expect(result4).toBeTruthy();
+        });
+
+        it('should return false if version number is equal to or greater than number of major versions specified out of date', function () {
+            var result = Mozilla.Client.isFirefoxOutOfDate('56.0', 2, '56.0.1');
+            expect(result).toBeFalsy();
+
+            var result2 = Mozilla.Client.isFirefoxOutOfDate('58.0a2', 2, '56.0.1');
+            expect(result2).toBeFalsy();
+
+            var result3 = Mozilla.Client.isFirefoxOutOfDate('55.0', 2, '56.0.1');
+            expect(result3).toBeFalsy();
+
+            var result4 = Mozilla.Client.isFirefoxOutOfDate('56.0', 1, '56.0.1');
+            expect(result4).toBeFalsy();
+        });
+
+    });
+
 });


### PR DESCRIPTION
## Description
- Sets site wide notification to only trigger if at least 2 major versions out of date.
- Also moves logic to a shared function and adds unit tests.

## Issue / Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1389676

## Testing
- Notification should only show for Firefoxes 2 major releases old or less.
