### PR TITLE
[bug 1389676] Update client logic for isFirefoxOutOfDate()

### DIFF
--- a/media/js/base/mozilla-client.js
+++ b/media/js/base/mozilla-client.js
@@ -212,7 +212,7 @@ if (typeof Mozilla === 'undefined') {
     };
 
     /**
-     * Determine if a version number is more than a specific number of major releases old.
+     * Determine if a client version number is at least a specific number of major releases old.
      * @param {String} clientVer - Client version number "58.0a1", "56.0".
      * @param {Number} majorVer - Number of major versions old a client considered 'out of date' should be.
      * @param {String} latestVer - Current latest release version number.
@@ -221,13 +221,13 @@ if (typeof Mozilla === 'undefined') {
     Client.isFirefoxOutOfDate = function(clientVer, majorVer, latestVer) {
         var clientVersion = parseInt(clientVer, 10);
         var latestVersion = typeof latestVer === 'undefined' ? parseInt($('html').attr('data-latest-firefox'), 10) : parseInt(latestVer, 10);
-        var majorVersions = parseInt(majorVer, 10) - 1;
+        var majorVersions = Math.max(parseInt(majorVer, 10), 1); // majorVersions must be at least 1.
 
         if (isNaN(latestVersion) || isNaN(clientVersion) || isNaN(majorVersions)) {
             return false;
         }
 
-        return clientVersion < latestVersion - majorVersions;
+        return clientVersion <= latestVersion - majorVersions;
     };
 
     /**

--- a/media/js/base/mozilla-notification-banner-init.js
+++ b/media/js/base/mozilla-notification-banner-init.js
@@ -43,7 +43,7 @@ $(function() {
     if (client.isFirefoxDesktop) {
         client.getFirefoxDetails(function(details) {
             // Don't rely on UA strings as they can be altered by extensions, so use UITour instead (Bug 1406299).
-            // User must be more than 2 major versions out of date and on release channel.
+            // User must be at least 2 major versions out of date and on release channel.
             if (client.isFirefoxOutOfDate(details.version, 2) && details.channel === 'release') {
 
                 // Check that cookies are enabled before seeing if one already exists.

--- a/media/js/base/mozilla-notification-banner-modal-init.js
+++ b/media/js/base/mozilla-notification-banner-modal-init.js
@@ -51,7 +51,7 @@ $(function() {
     if (client.isFirefoxDesktop) {
         client.getFirefoxDetails(function(details) {
             // Don't rely on UA strings as they can be altered by extensions, so use UITour instead (Bug 1406299).
-            // User must be more than 2 major versions out of date and on release channel.
+            // User must be at least 2 major versions out of date and on release channel.
             if (client.isFirefoxOutOfDate(details.version, 2) && details.channel === 'release') {
                 // Check that cookies are enabled.
                 if (typeof Mozilla.Cookies !== 'undefined' && Mozilla.Cookies.enabled()) {

--- a/tests/unit/spec/base/mozilla-client.js
+++ b/tests/unit/spec/base/mozilla-client.js
@@ -517,7 +517,7 @@ describe('mozilla-client.js', function() {
 
     describe('isFirefoxOutOfDate', function () {
 
-        it('should return true if version number is less than the number of major versions specified out of date', function () {
+        it('should return true if client version is equal to or less than the major version considered out of date', function () {
             var result = Mozilla.Client.isFirefoxOutOfDate('50.0', 2, '56.0.1');
             expect(result).toBeTruthy();
 
@@ -527,11 +527,11 @@ describe('mozilla-client.js', function() {
             var result3 = Mozilla.Client.isFirefoxOutOfDate('54.0a1', 2, '56.0.1a1');
             expect(result3).toBeTruthy();
 
-            var result4 = Mozilla.Client.isFirefoxOutOfDate('54.0.1', 1, '56.0');
+            var result4 = Mozilla.Client.isFirefoxOutOfDate('55.0.1', 1, '56.0');
             expect(result4).toBeTruthy();
         });
 
-        it('should return false if version number is equal to or greater than number of major versions specified out of date', function () {
+        it('should return false if client version is greater than the major version considered out of date', function () {
             var result = Mozilla.Client.isFirefoxOutOfDate('56.0', 2, '56.0.1');
             expect(result).toBeFalsy();
 


### PR DESCRIPTION
@jpetto sorry - I read through my commit after it merged and thought I could have made my comments / logic a little clearer. Sorry to bug you again on this, but hopefully this reads a bit nicer than it did originally.
