### PR TITLE
[fix bug 1409094] Link alignment issue on /de/firefox/new/

### DIFF
--- a/media/css/firefox/new/quantum/_other-platforms.scss
+++ b/media/css/firefox/new/quantum/_other-platforms.scss
@@ -24,6 +24,16 @@ $color-quantum-blue: #0a84ff;
     &:hover {
         text-decoration: underline;
     }
+
+    @media #{$mq-tablet} {
+        text-align: left;
+    }
+}
+
+html[dir="rtl"] #other-platforms-modal-link {
+    @media #{$mq-tablet} {
+        text-align: right;
+    }
 }
 
 /* -------------------------------------------------------------------------- */

--- a/media/css/firefox/new/quantum/common.scss
+++ b/media/css/firefox/new/quantum/common.scss
@@ -116,7 +116,7 @@ body {
             }
 
             .mozilla {
-                display: inline;
+                display: block;
                 float: right;
             }
         }


### PR DESCRIPTION
## Description
- Fixes a link alignment issue on /de/firefox/new/

## Issue / Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1409094

## Testing
- Load /de/firefox/new/ (make sure to pull latest .lang files)
- Resize the browser to around 790px wide and make sure link is aligned correctly.
