### PR TITLE
[fix bug 1409993] 'Learn more' link on Quantum home page promo does a 301 redirect

### DIFF
--- a/bedrock/mozorg/templates/mozorg/home/includes/fx-quantum-promo.html
+++ b/bedrock/mozorg/templates/mozorg/home/includes/fx-quantum-promo.html
@@ -1,4 +1,4 @@
 <section class="section quantum-promo">
   <p>{{ _('The <strong>New Firefox</strong> arrives November 14, 2017') }}</p>
-  <a href="firefox/quantum" class="button button-hollow button-light">{{ _('Learn More') }}</a>
+  <a href="{{ url('firefox.quantum') }}" class="button button-hollow button-light">{{ _('Learn More') }}</a>
 </section>


### PR DESCRIPTION
## Description
- Uses URL helper instead of hard coded relative path.

## Issue / Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1409993
