### PR TITLE
Fix Bug 1405834 - Update copy in https://www.mozilla.org/en-US/about/leadership/

### DIFF
--- a/bedrock/mozorg/templates/mozorg/about/leadership.html
+++ b/bedrock/mozorg/templates/mozorg/about/leadership.html
@@ -990,7 +990,7 @@
         </figure>
 
         <div class="person-info">
-          <p class="title" itemprop="jobTitle">{{ _('EVP') }}</p>
+          <p class="title" itemprop="jobTitle">{{ _('Executive Vice President') }}</p>
           <p class="since">{{ _('With Mozilla since:') }} 2012</p>
 
           <ul class="elsewhere">


### PR DESCRIPTION
## Description

Fix the title of Angela Plohman. EVP ➡️ Executive Vice President. That's it!

## Issue / Bugzilla link

[Bug 1405834](https://bugzilla.mozilla.org/show_bug.cgi?id=1405834)

## Testing

Visit `/about/leadership/` and make sure her title is correct.