### PR TITLE
Fix Bug 1408501 - Newsletter signup on mission page has overlapping image at phone size

### DIFF
--- a/media/css/mozorg/mission.less
+++ b/media/css/mozorg/mission.less
@@ -252,6 +252,16 @@ ul.links {
             float: none;
         }
     }
+
+    #newsletter-subscribe .form-title {
+        padding-top: 150px;
+
+        &:before {
+            left: 50%;
+            top: -20px;
+            margin-left: -75px;
+        }
+    }
 }
 
 /* Wide mobile layout: 480px; */


### PR DESCRIPTION
## Description

The newsletter form on the [mission](https://www.mozilla.org/en-US/mission/) page doesn't look good on mobile. Copy a portion of CSS from `about.less` to solve the issue. Other pages using this style have no problem.

## Issue / Bugzilla link

[Bug 1408501](https://bugzilla.mozilla.org/show_bug.cgi?id=1408501)

## Testing

Visit `/mission/`, switch to the responsive mode, and make sure the icon is not overlapping with the copy.