### PR TITLE
Fix Bug 1401039 - /home Servo link change

### DIFF
--- a/bedrock/mozorg/templates/mozorg/home/home-new.html
+++ b/bedrock/mozorg/templates/mozorg/home/home-new.html
@@ -160,7 +160,7 @@
             <a rel="external" href="https://vr.mozilla.org/"><svg class="icon"><use xlink:href="#icon-vr"></use></svg>{{ _('Virtual Reality Platform') }}</a>
           </li>
           <li id="servo">
-            <a rel="external" href="https://servo.org/"><svg class="icon"><use xlink:href="#icon-servo"></use></svg>{{ _('Servo') }}</a>
+            <a rel="external" href="https://research.mozilla.org/servo-engines/"><svg class="icon"><use xlink:href="#icon-servo"></use></svg>{{ _('Servo') }}</a>
           </li>
           <li id="rust">
             <a rel="external" href="https://research.mozilla.org/rust/"><svg class="icon"><use xlink:href="#icon-rust"></use></svg>{{ _('Rust') }}</a>

--- a/bedrock/mozorg/templates/mozorg/home/home.html
+++ b/bedrock/mozorg/templates/mozorg/home/home.html
@@ -130,7 +130,7 @@
             <a rel="external" href="https://vr.mozilla.org/"><svg class="icon"><use xlink:href="#icon-vr"></use></svg>{{ _('Virtual Reality Platform') }}</a>
           </li>
           <li id="servo">
-            <a rel="external" href="https://servo.org/"><svg class="icon"><use xlink:href="#icon-servo"></use></svg>{{ _('Servo') }}</a>
+            <a rel="external" href="https://research.mozilla.org/servo-engines/"><svg class="icon"><use xlink:href="#icon-servo"></use></svg>{{ _('Servo') }}</a>
           </li>
           <li id="rust">
             <a rel="external" href="https://research.mozilla.org/rust/"><svg class="icon"><use xlink:href="#icon-rust"></use></svg>{{ _('Rust') }}</a>


### PR DESCRIPTION
## Description

Change the Servo link on the [home page](https://www.mozilla.org/), located under Our innovations.

## Issue / Bugzilla link

[Bug 1401039](https://bugzilla.mozilla.org/show_bug.cgi?id=1401039)

## Testing

Visit the home page and make sure the Servo link goes to the new landing page on Mozilla Research.