### PR TITLE
Fix bug 836587: Add "Source code for this page" link to footer

### DIFF
--- a/bedrock/base/templates/includes/site-footer.html
+++ b/bedrock/base/templates/includes/site-footer.html
@@ -16,7 +16,11 @@
           <li><a href="{{ url('mozorg.about') }}" data-link-type="footer" data-link-name="About">{{ _('About') }}</a></li>
           <li><a href="{{ url('mozorg.contact.contact-landing') }}" data-link-type="footer" data-link-name="Contact Us">{{ _('Contact Us') }}</a></li>
           <li><a href="{{ donate_url('footer') }}" class="donate" data-link-type="footer" data-link-name="Donate">{{ _('Donate') }}</a></li>
-          <li><a href="https://wiki.mozilla.org/Webdev/GetInvolved/mozilla.org" data-link-type="footer" data-link-name="Contribute to this site">{{ _('Contribute to this site') }}</a></li>
+          <li><a href="https://wiki.mozilla.org/Webdev/GetInvolved/mozilla.org" data-link-type="footer" rel="nofollow" data-link-name="Contribute to this site">{{ _('Contribute to this site') }}</a></li>
+          {# TODO remove the "and" clause after tranlsation #}
+          {% if template_source_url and (LANG.startswith('en') or switch('footer-source-link')) %}
+            <li><a href="{{ template_source_url }}" data-link-type="footer" rel="nofollow" data-link-name="Source code for this page">{{ _('Source code for this page') }}</a></li>
+          {% endif %}
           <li>
             <ul class="social-links">
               <li><a class="twitter" href="https://twitter.com/mozilla" data-link-type="footer" data-link-name="Twitter (@mozilla)">{{ _('Twitter') }}<span> (@mozilla)</span></a></li>
@@ -58,7 +62,7 @@
     <nav class="secondary">
         <div class="small-links">
           <ul>
-            {% if LANG.startswith('en-') %} 
+            {% if LANG.startswith('en-') %}
               {% set privacy_text = _('Website Privacy Notice') %}
             {% else %}
               {% set privacy_text = _('Privacy') %}

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -146,6 +146,28 @@ LOCALES_PATH = ROOT_PATH / 'locale'
 default_locales_repo = 'www.mozilla.org' if DEV else 'bedrock-l10n'
 default_locales_repo = 'https://github.com/mozilla-l10n/{}'.format(default_locales_repo)
 LOCALES_REPO = config('LOCALES_REPO', default=default_locales_repo)
+GITHUB_REPO = 'https://github.com/mozilla/bedrock'
+
+# templates to exclude from having an "edit this page" link in the footer
+# these are typically ones for which most of the content is in the DB
+EXCLUDE_EDIT_TEMPLATES = [
+    'firefox/releases/nightly-notes.html',
+    'firefox/releases/dev-browser-notes.html',
+    'firefox/releases/esr-notes.html',
+    'firefox/releases/beta-notes.html',
+    'firefox/releases/aurora-notes.html',
+    'firefox/releases/release-notes.html',
+    'firefox/releases/system_requirements.html',
+    'mozorg/credits.html',
+    'mozorg/about/forums.html',
+    'security/advisory.html',
+    'security/advisories.html',
+    'security/product-advisories.html',
+    'security/known-vulnerabilities.html',
+    'thunderbird/releases/beta-notes.html',
+    'thunderbird/releases/release-notes.html',
+    'thunderbird/releases/system_requirements.html',
+]
 
 
 def get_dev_languages():


### PR DESCRIPTION
It will be a link to the current template source on github.

Original inspiration for this commit from:

https://github.com/l-hedgehog/bedrock/commit/36f011c0