### PR TITLE
[fix bug 1406299] Only show notification if /whatsnew page URL is out of date

### DIFF
--- a/bedrock/firefox/templates/firefox/australis/base.html
+++ b/bedrock/firefox/templates/firefox/australis/base.html
@@ -10,7 +10,7 @@
 
 {% block extrahead %}
   {% if switch('firefox-update-notification-modal', ['en-US']) %}
-    {% stylesheet 'firefox-update-notification-modal' %}
+    {% stylesheet 'firefox-update-notification-firstrun-whatsnew' %}
   {% endif %}
 {% endblock %}
 
@@ -64,6 +64,6 @@
 {% block update_notification %}
   {% if switch('firefox-update-notification-modal', ['en-US']) %}
     {% include 'includes/firefox-update-instructions.html' %}
-    {% javascript 'firefox-update-notification-modal' %}
+    {% javascript 'firefox-update-notification-firstrun-whatsnew' %}
   {% endif %}
 {% endblock %}

--- a/bedrock/firefox/templates/firefox/firstrun/base.html
+++ b/bedrock/firefox/templates/firefox/firstrun/base.html
@@ -38,7 +38,7 @@
 
 {% block extrahead %}
   {% if switch('firefox-update-notification-modal', ['en-US']) %}
-    {% stylesheet 'firefox-update-notification-modal' %}
+    {% stylesheet 'firefox-update-notification-firstrun-whatsnew' %}
   {% endif %}
 {% endblock %}
 
@@ -46,6 +46,6 @@
 {% block update_notification %}
   {% if switch('firefox-update-notification-modal', ['en-US']) %}
     {% include 'includes/firefox-update-instructions.html' %}
-    {% javascript 'firefox-update-notification-modal' %}
+    {% javascript 'firefox-update-notification-firstrun-whatsnew' %}
   {% endif %}
 {% endblock %}

--- a/bedrock/firefox/templates/firefox/whatsnew/base-pebbles.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/base-pebbles.html
@@ -19,7 +19,7 @@
 
 {% block extrahead %}
   {% if switch('firefox-update-notification-modal', ['en-US']) %}
-    {% stylesheet 'firefox-update-notification-modal' %}
+    {% stylesheet 'firefox-update-notification-firstrun-whatsnew' %}
   {% endif %}
 {% endblock %}
 
@@ -27,6 +27,6 @@
 {% block update_notification %}
   {% if switch('firefox-update-notification-modal', ['en-US']) %}
     {% include 'includes/firefox-update-instructions.html' %}
-    {% javascript 'firefox-update-notification-modal' %}
+    {% javascript 'firefox-update-notification-firstrun-whatsnew' %}
   {% endif %}
 {% endblock %}

--- a/bedrock/firefox/templates/firefox/whatsnew/base.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/base.html
@@ -10,7 +10,7 @@
 
 {% block extrahead %}
   {% if switch('firefox-update-notification-modal', ['en-US']) %}
-    {% stylesheet 'firefox-update-notification-modal' %}
+    {% stylesheet 'firefox-update-notification-firstrun-whatsnew' %}
   {% endif %}
 {% endblock %}
 
@@ -18,6 +18,6 @@
 {% block update_notification %}
   {% if switch('firefox-update-notification-modal', ['en-US']) %}
     {% include 'includes/firefox-update-instructions.html' %}
-    {% javascript 'firefox-update-notification-modal' %}
+    {% javascript 'firefox-update-notification-firstrun-whatsnew' %}
   {% endif %}
 {% endblock %}

--- a/bedrock/settings/static_media.py
+++ b/bedrock/settings/static_media.py
@@ -620,12 +620,12 @@ PIPELINE_CSS = {
         ),
         'output_filename': 'css/firefox_tour_none-bundle.css',
     },
-    'firefox-update-notification-modal': {
+    'firefox-update-notification-firstrun-whatsnew': {
         'source_filenames': (
             'css/base/mozilla-modal.less',
             'css/base/notification-modal.less',
         ),
-        'output_filename': 'css/firefox-update-notification-modal-bundle.css',
+        'output_filename': 'css/firefox-update-notification-firstrun-whatsnew-bundle.css',
     },
     'firefox_whatsnew_42': {
         'source_filenames': (
@@ -1487,13 +1487,13 @@ PIPELINE_JS = {
         ),
         'output_filename': 'js/firefox-update-notification-bundle.js',
     },
-    'firefox-update-notification-modal': {
+    'firefox-update-notification-firstrun-whatsnew': {
         'source_filenames': (
             'js/base/mozilla-modal.js',
             'js/base/mozilla-notification-banner.js',
-            'js/base/mozilla-notification-banner-modal-init.js',
+            'js/base/mozilla-notification-banner-firstrun-whatsnew-init.js',
         ),
-        'output_filename': 'js/firefox-update-notification-modal-bundle.js',
+        'output_filename': 'js/firefox-update-notification-firstrun-whatsnew-bundle.js',
     },
     'geolocation': {
         'source_filenames': (

--- a/media/js/base/mozilla-client.js
+++ b/media/js/base/mozilla-client.js
@@ -231,6 +231,27 @@ if (typeof Mozilla === 'undefined') {
     };
 
     /**
+     * Determine if a /whatsnew or /firstrun page is at least a specific number of major releases old.
+     * @param {Number} majorVer - Number of major versions old a client considered 'out of date' should be.
+     * @param {String} pathName - Version number URL pathname e.g. '/firefox/56.0.1/'.
+     * @param {String} latestVer - Current latest release version number.
+     * @return {Boolean}
+     */
+    Client.isFirefoxURLOutOfDate = function(majorVer, pathName, latestVer) {
+        var path = typeof pathName === 'undefined' ? window.location.pathname : pathName;
+        var urlVersion =  /firefox\/(\d+(?:\.\d+)?\.\da?\d?)/.exec(path);
+        var version = urlVersion ? parseInt(urlVersion[1], 10) : null;
+        var latestVersion = typeof latestVer === 'undefined' ? parseInt($('html').attr('data-latest-firefox'), 10) : parseInt(latestVer, 10);
+        var majorVersions = Math.max(parseInt(majorVer, 10), 1); // majorVersions must be at least 1.
+
+        if (version && latestVersion && (version <= latestVersion - majorVersions)) {
+            return true;
+        }
+
+        return false;
+    };
+
+    /**
      * Use the async mozUITour API of Firefox to retrieve the user's browser info, including the update channel and
      * accurate, patch-level version number. This API is available on Firefox 35 and later. See
      * http://bedrock.readthedocs.org/en/latest/uitour.html for details.

--- a/media/js/base/mozilla-notification-banner-firstrun-whatsnew-init.js
+++ b/media/js/base/mozilla-notification-banner-firstrun-whatsnew-init.js
@@ -50,12 +50,16 @@ $(function() {
     // Notification should only be shown to Firefox desktop users more than 2 major versions out of date.
     if (client.isFirefoxDesktop) {
         client.getFirefoxDetails(function(details) {
-            // Don't rely on UA strings as they can be altered by extensions, so use UITour instead (Bug 1406299).
-            // User must be at least 2 major versions out of date and on release channel.
-            if (client.isFirefoxOutOfDate(details.version, 2) && details.channel === 'release') {
-                // Check that cookies are enabled.
-                if (typeof Mozilla.Cookies !== 'undefined' && Mozilla.Cookies.enabled()) {
-                    Mozilla.NotificationBanner.init(config);
+            // Only run the query if the /whatsnew or /firstrun page being viewed is
+            // at least 2 major versions out of date. (Bug 1406299).
+            if (client.isFirefoxURLOutOfDate(2)) {
+                // Don't rely on UA strings as they can be altered by extensions, so use UITour instead.
+                // User must be at least 2 major versions out of date and on release channel.
+                if (client.isFirefoxOutOfDate(details.version, 2) && details.channel === 'release') {
+                    // Check that cookies are enabled.
+                    if (typeof Mozilla.Cookies !== 'undefined' && Mozilla.Cookies.enabled()) {
+                        Mozilla.NotificationBanner.init(config);
+                    }
                 }
             }
         });

--- a/tests/unit/spec/base/mozilla-client.js
+++ b/tests/unit/spec/base/mozilla-client.js
@@ -547,4 +547,50 @@ describe('mozilla-client.js', function() {
 
     });
 
+    describe('isFirefoxURLOutOfDate', function () {
+
+        it('should return true if URL version is equal to or less than the major version considered out of date', function () {
+            var result = Mozilla.Client.isFirefoxURLOutOfDate(2, '/firefox/54.0/', '56.0');
+            expect(result).toBeTruthy();
+
+            var result2 = Mozilla.Client.isFirefoxURLOutOfDate(2, '/firefox/54.0a1/', '56.0');
+            expect(result2).toBeTruthy();
+
+            var result3 = Mozilla.Client.isFirefoxURLOutOfDate(2, '/firefox/54.0a2/', '56.0');
+            expect(result3).toBeTruthy();
+
+            var result4 = Mozilla.Client.isFirefoxURLOutOfDate(1, '/firefox/55.0.1/', '56.0');
+            expect(result4).toBeTruthy();
+
+            var result5 = Mozilla.Client.isFirefoxURLOutOfDate(2, '/firefox/53.0/', '56.0');
+            expect(result5).toBeTruthy();
+        });
+
+        it('should return false if URL version is greater than the major version considered out of date', function () {
+            var result = Mozilla.Client.isFirefoxURLOutOfDate(2, '/firefox/55.0/', '56.0');
+            expect(result).toBeFalsy();
+
+            var result2 = Mozilla.Client.isFirefoxURLOutOfDate(2, '/firefox/55.0a1/', '56.0');
+            expect(result2).toBeFalsy();
+
+            var result3 = Mozilla.Client.isFirefoxURLOutOfDate(2, '/firefox/55.0a2/', '56.0');
+            expect(result3).toBeFalsy();
+
+            var result4 = Mozilla.Client.isFirefoxURLOutOfDate(1, '/firefox/56.0/', '56.0.1');
+            expect(result4).toBeFalsy();
+
+            var result5 = Mozilla.Client.isFirefoxURLOutOfDate(2, '/firefox/58.0/', '56.0');
+            expect(result5).toBeFalsy();
+        });
+
+        it('should return false if the URL version is invalid', function() {
+            var result = Mozilla.Client.isFirefoxURLOutOfDate(2, '/firefox/foo/', '56.0');
+            expect(result).toBeFalsy();
+
+            var result2 = Mozilla.Client.isFirefoxURLOutOfDate(2, '/firefox/10/', '56.0');
+            expect(result2).toBeFalsy();
+        });
+
+    });
+
 });


### PR DESCRIPTION
## Description
Adds a check to make sure a ` /firstrun` or `/whatsnew` page is at least 2 major releases out of date before trying to show a notification.

## Issue / Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1406299

## Testing
Out of date notification should only be shown if using an old firefox AND the /firstrun or /whatsnew page is also old (2 major versions out of date).
