### PR TITLE
Bug 1401245 send tabs video experiment

### DIFF
--- a/bedrock/firefox/templates/firefox/features/send-tabs-a.html
+++ b/bedrock/firefox/templates/firefox/features/send-tabs-a.html
@@ -6,3 +6,8 @@
 
 {# Don't display notification for test variation #}
 {% block update_notification %}{% endblock %}
+
+{% block js %}
+  {{ super() }}
+  {% javascript 'experiment-send-tabs-video' %}
+{% endblock %}

--- a/bedrock/firefox/templates/firefox/features/send-tabs-a.html
+++ b/bedrock/firefox/templates/firefox/features/send-tabs-a.html
@@ -1,0 +1,8 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+
+{% extends "firefox/features/send-tabs.html" %}
+
+{# Don't display notification for test variation #}
+{% block update_notification %}{% endblock %}

--- a/bedrock/firefox/templates/firefox/features/send-tabs-b.html
+++ b/bedrock/firefox/templates/firefox/features/send-tabs-b.html
@@ -10,11 +10,9 @@
 {% endblock %}
 
 {% block features_header_image %}
- <figure class="video send-tabs">
-  <div class="video-wrap">
-    <iframe width="700" height="390" src="https://www.youtube.com/embed/CM40b14i41M?rel=0" frameborder="0" allowfullscreen>
-    <p><a href="https://www.youtube.com/watch?v=CM40b14i41M">{{ _('Watch this video') }}</a></p>
-     </iframe>
+<figure class="send-tabs-video">
+  <div id="video-wrap">
+    <div class="video"></div>
   </div>
   <figcaption>
     <p>{{ _('Stop emailing links to yourself! Sierra walks us through the Firefox feature Send Tabs.') }}</p>
@@ -24,3 +22,8 @@
 
 {# Don't display notification for test variation #}
 {% block update_notification %}{% endblock %}
+
+{% block js %}
+  {{ super() }}
+  {% javascript 'experiment-send-tabs-video' %}
+{% endblock %}

--- a/bedrock/firefox/templates/firefox/features/send-tabs-b.html
+++ b/bedrock/firefox/templates/firefox/features/send-tabs-b.html
@@ -1,0 +1,26 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+
+{% extends "firefox/features/send-tabs.html" %}
+
+{% block page_css %}
+  {{ super() }}
+  {% stylesheet 'experiment-send-tabs' %}
+{% endblock %}
+
+{% block features_header_image %}
+ <figure class="video send-tabs">
+  <div class="video-wrap">
+    <iframe width="700" height="390" src="https://www.youtube.com/embed/CM40b14i41M?rel=0" frameborder="0" allowfullscreen>
+    <p><a href="https://www.youtube.com/watch?v=CM40b14i41M">{{ _('Watch this video') }}</a></p>
+     </iframe>
+  </div>
+  <figcaption>
+    <p>{{ _('Stop emailing links to yourself! Sierra walks us through the Firefox feature Send Tabs.') }}</p>
+  </figcaption>
+</figure>
+{% endblock %}
+
+{# Don't display notification for test variation #}
+{% block update_notification %}{% endblock %}

--- a/bedrock/firefox/templates/firefox/features/send-tabs.html
+++ b/bedrock/firefox/templates/firefox/features/send-tabs.html
@@ -23,7 +23,9 @@
 {% endblock %}
 
 {% block experiments %}
-  {% javascript 'experiment-send-tabs' %}
+  {% if switch('firefox-features-send-tabs-video-experiment', ['en-US']) %}
+    {% javascript 'experiment-send-tabs' %}
+  {% endif %}
 {% endblock %}
 
 {% block body_id %}firefox-features-send-tabs{% endblock %}

--- a/bedrock/firefox/templates/firefox/features/send-tabs.html
+++ b/bedrock/firefox/templates/firefox/features/send-tabs.html
@@ -22,6 +22,10 @@
   {% stylesheet 'firefox-features-sync' %}
 {% endblock %}
 
+{% block experiments %}
+  {% javascript 'experiment-send-tabs' %}
+{% endblock %}
+
 {% block body_id %}firefox-features-send-tabs{% endblock %}
 
 {% block body_class %}

--- a/bedrock/firefox/tests/test_views.py
+++ b/bedrock/firefox/tests/test_views.py
@@ -951,7 +951,7 @@ class TestFeatureSendTabs(TestCase):
     def test_send_tabs_experiment_a(self, render_mock):
         """Should use send-tabs-a template for control experiment"""
         req = RequestFactory().get('/firefox/features/send-tabs/?v=a')
-        views.feauture_send_tabs(req)
+        views.send_tabs(req)
         render_mock.assert_called_once_with(
             req,
             'firefox/features/send-tabs-a.html'
@@ -960,7 +960,7 @@ class TestFeatureSendTabs(TestCase):
     def test_send_tabs_experiment_b(self, render_mock):
         """Should use send-tabs-b template for video experiment"""
         req = RequestFactory().get('/firefox/features/send-tabs/?v=b')
-        views.feauture_send_tabs(req)
+        views.send_tabs(req)
         render_mock.assert_called_once_with(
             req,
             'firefox/features/send-tabs-b.html'
@@ -970,7 +970,7 @@ class TestFeatureSendTabs(TestCase):
         """Should use send-tabs template for non en locales"""
         req = RequestFactory().get('/firefox/features/send-tabs/?v=b')
         req.locale = 'de'
-        views.feauture_send_tabs(req)
+        views.send_tabs(req)
         render_mock.assert_called_once_with(
             req,
             'firefox/features/send-tabs.html'

--- a/bedrock/firefox/tests/test_views.py
+++ b/bedrock/firefox/tests/test_views.py
@@ -943,3 +943,35 @@ class TestFeaturesPages(TestCase):
         req.locale = 'en-US'
         views.sync_page(req)
         render_mock.assert_called_once_with(req, 'firefox/features/quantum/sync.html')
+
+
+@override_settings(DEV=False)
+@patch('bedrock.firefox.views.l10n_utils.render')
+class TestFeatureSendTabs(TestCase):
+    def test_send_tabs_experiment_a(self, render_mock):
+        """Should use send-tabs-a template for control experiment"""
+        req = RequestFactory().get('/firefox/features/send-tabs/?v=a')
+        views.feauture_send_tabs(req)
+        render_mock.assert_called_once_with(
+            req,
+            'firefox/features/send-tabs-a.html'
+        )
+
+    def test_send_tabs_experiment_b(self, render_mock):
+        """Should use send-tabs-b template for video experiment"""
+        req = RequestFactory().get('/firefox/features/send-tabs/?v=b')
+        views.feauture_send_tabs(req)
+        render_mock.assert_called_once_with(
+            req,
+            'firefox/features/send-tabs-b.html'
+        )
+
+    def test_send_tabs_experiment_other_locales(self, render_mock):
+        """Should use send-tabs template for non en locales"""
+        req = RequestFactory().get('/firefox/features/send-tabs/?v=b')
+        req.locale = 'de'
+        views.feauture_send_tabs(req)
+        render_mock.assert_called_once_with(
+            req,
+            'firefox/features/send-tabs.html'
+        )

--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -731,7 +731,13 @@ def send_tabs(request):
     if switch('firefox-57-release'):
         template = 'firefox/features/quantum/send-tabs.html'
     else:
-        template = 'firefox/features/send-tabs.html'
+        locale = l10n_utils.get_locale(request)
+        exp = request.GET.get('v')
+
+        if locale.startswith('en') and exp in ['a', 'b']:
+            template = 'firefox/features/send-tabs-{0}.html'.format(exp)
+        else:
+            template = 'firefox/features/send-tabs.html'
 
     return l10n_utils.render(request, template)
 
@@ -783,18 +789,6 @@ def FirefoxProductDeveloperView(request):
         template = 'firefox/products/developer-quantum.html'
     else:
         template = 'firefox/products/developer.html'
-
-    return l10n_utils.render(request, template)
-
-
-def feauture_send_tabs(request):
-    locale = l10n_utils.get_locale(request)
-    exp = request.GET.get('v')
-
-    if locale.startswith('en') and exp in ['a', 'b']:
-        template = 'firefox/features/send-tabs-{0}.html'.format(exp)
-    else:
-        template = 'firefox/features/send-tabs.html'
 
     return l10n_utils.render(request, template)
 

--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -787,6 +787,18 @@ def FirefoxProductDeveloperView(request):
     return l10n_utils.render(request, template)
 
 
+def feauture_send_tabs(request):
+    locale = l10n_utils.get_locale(request)
+    exp = request.GET.get('v')
+
+    if locale.startswith('en') and exp in ['a', 'b']:
+        template = 'firefox/features/send-tabs-{0}.html'.format(exp)
+    else:
+        template = 'firefox/features/send-tabs.html'
+
+    return l10n_utils.render(request, template)
+
+
 def sync_page(request):
     if switch('firefox-57-release'):
         template = 'firefox/features/quantum/sync.html'

--- a/bedrock/settings/static_media.py
+++ b/bedrock/settings/static_media.py
@@ -1288,6 +1288,12 @@ PIPELINE_JS = {
         ),
         'output_filename': 'js/experiment_send_tabs-bundle.js',
     },
+    'experiment-send-tabs-video': {
+        'source_filenames': (
+            'js/firefox/features/experiment-send-tabs-video.js',
+        ),
+        'output_filename': 'js/experiment_send_tabs_video-bundle.js',
+    },
     'firefox_fx38_0_5_firstrun': {
         'source_filenames': (
             'js/base/uitour-lib.js',

--- a/bedrock/settings/static_media.py
+++ b/bedrock/settings/static_media.py
@@ -336,6 +336,12 @@ PIPELINE_CSS = {
         'output_filename': 'css/firefox-features-sync-quantum-bundle.css',
     },
     # end FEATURES QUANTUM UPDATE
+    'experiment-send-tabs': {
+        'source_filenames': (
+            'css/firefox/features/experiment-send-tabs.scss',
+        ),
+        'output_filename': 'css/experiment_send_tabs-bundle.css',
+    },
     'firefox-interest-dashboard': {
         'source_filenames': (
             'css/firefox/family-nav.less',
@@ -1274,6 +1280,13 @@ PIPELINE_JS = {
             'js/firefox/features/sync-init.js',
         ),
         'output_filename': 'js/firefox-features-sync-bundle.js',
+    },
+    'experiment-send-tabs': {
+        'source_filenames': (
+            'js/base/mozilla-traffic-cop.js',
+            'js/firefox/features/experiment-send-tabs.js',
+        ),
+        'output_filename': 'js/experiment_send_tabs-bundle.js',
     },
     'firefox_fx38_0_5_firstrun': {
         'source_filenames': (

--- a/media/css/firefox/features/experiment-send-tabs.scss
+++ b/media/css/firefox/features/experiment-send-tabs.scss
@@ -4,10 +4,26 @@
 
 @import '../../pebbles/includes/lib';
 
-.video.send-tabs {
+.send-tabs-video {
     margin: 60px auto 0;
-    width: 700px;
-    height: 390px;
+    max-width: 700px;
+
+    #video-wrap {
+        display: block;
+        height: 0;
+        margin: 0 auto;
+        padding-bottom: 56.25%;
+        position: relative;
+    }
+
+    .video {
+        height: 100%;
+        left: 0;
+        max-width: 100%;
+        position: absolute;
+        top: 0;
+        width: 100%;
+    }
 
     figcaption {
         @include visually-hidden();

--- a/media/css/firefox/features/experiment-send-tabs.scss
+++ b/media/css/firefox/features/experiment-send-tabs.scss
@@ -1,0 +1,15 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+@import '../../pebbles/includes/lib';
+
+.video.send-tabs {
+    margin: 60px auto 0;
+    width: 700px;
+    height: 390px;
+
+    figcaption {
+        @include visually-hidden();
+    }
+}

--- a/media/js/firefox/features/experiment-send-tabs-video.js
+++ b/media/js/firefox/features/experiment-send-tabs-video.js
@@ -1,0 +1,73 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/* global YT */
+/* eslint no-unused-vars: [2, { "varsIgnorePattern": "onYouTubeIframeAPIReady" }] */
+
+// YouTube API hook has to be in global scope
+function onYouTubeIframeAPIReady() {
+    'use strict';
+
+    Mozilla.firefoxFeaturesSendTabsOnYouTubeIframeAPIReady();
+}
+
+(function($) {
+    var variation = (window.location.search.indexOf('v=a') > -1) ? 'a' : 'b';
+    var $videoContainer = $('#video-wrap');
+
+    // add experiment details to dataLayer at page load
+    window.dataLayer.push({
+        'data-ex-experiment': 'firefox-sync-videoPresent',
+        'data-ex-variant': variation,
+        'data-ex-present': 'true'
+    });
+
+    function onYouTubeIframeAPIReady() {
+        var video = $videoContainer.find('.video')[0];
+
+        new YT.Player(video, {
+            height: '390',
+            width: '640',
+            videoId: 'CM40b14i41M',
+            events: {
+                'onStateChange': onPlayerStateChange
+            }
+        });
+
+        function onPlayerStateChange(event) {
+            var state;
+
+            switch(event.data) {
+            case YT.PlayerState.PLAYING:
+                state = 'video play';
+                break;
+            case YT.PlayerState.PAUSED:
+                state = 'video paused';
+                break;
+            case YT.PlayerState.ENDED:
+                state = 'video complete';
+                break;
+            }
+
+            if (state) {
+                window.dataLayer.push({
+                    'event': 'video-interaction',
+                    'videoTitle': 'send tabs video',
+                    'interaction': state
+                });
+            }
+        }
+    }
+
+    if ($videoContainer.length) {
+        var tag = document.createElement('script');
+        tag.src = 'https://www.youtube.com/iframe_api';
+
+        var firstScriptTag = document.getElementsByTagName('script')[0];
+        firstScriptTag.parentNode.insertBefore(tag, firstScriptTag);
+
+        Mozilla.firefoxFeaturesSendTabsOnYouTubeIframeAPIReady = onYouTubeIframeAPIReady;
+    }
+
+})(window.jQuery);

--- a/media/js/firefox/features/experiment-send-tabs.js
+++ b/media/js/firefox/features/experiment-send-tabs.js
@@ -1,0 +1,17 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+(function() {
+    'use strict';
+
+    var cop = new Mozilla.TrafficCop({
+        id: 'experiment_send_tabs',
+        variations: {
+            'v=a': 50,  // double-control
+            'v=b': 50   // video experiment
+        }
+    });
+
+    cop.init();
+})(window.Mozilla);


### PR DESCRIPTION
## Description

Adds an A/B test to `/firefox/features/send-tabs/`. 

## Issue / Bugzilla link

https://bugzilla.mozilla.org/show_bug.cgi?id=1401245

## Testing

https://bedrock-demo-jpetto-sendtabs.us-west.moz.works/en-US/firefox/features/send-tabs/?v=a (control)
https://bedrock-demo-jpetto-sendtabs.us-west.moz.works/en-US/firefox/features/send-tabs/?v=b (video variation)
