### PR TITLE
fix bug 1405533: Misaligned text on Channel Desktop Landing

### DIFF
--- a/media/css/firefox/channel.less
+++ b/media/css/firefox/channel.less
@@ -579,6 +579,7 @@ html[lang^="en"] {
         .open-sans;
         line-height: 1.3;
         margin-bottom: @baseLine;
+        text-align: center;
     }
 
     ul {
@@ -611,10 +612,6 @@ html[lang^="en"] {
         &.bugzilla,
         &.test-pilot {
             float: none;
-        }
-
-        h3 {
-            text-align: center;
         }
     }
 


### PR DESCRIPTION
## Description
Fixes text alignment on desktop (/en-US/firefox/channel/desktop/)

## Issue / Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1405533
