### PR TITLE
[fix bug 1415599] Redirect /firefox/quantum/ to /firefox/

### DIFF
--- a/bedrock/firefox/tests/test_views.py
+++ b/bedrock/firefox/tests/test_views.py
@@ -1023,3 +1023,18 @@ class TestFirefoxDesktopPageRedirect(TestCase):
         resp = view(req)
         eq_(resp.status_code, 301)
         ok_(resp.url.endswith('/en-US/firefox/'))
+
+
+class TestFirefoxQuantumPageRedirect(TestCase):
+    @patch('bedrock.firefox.views.switch', Mock(return_value=False))
+    def test_quantum_pre_57(self):
+        req = RequestFactory().get('/en-US/firefox/quantum/')
+        resp = views.quantum(req)
+        eq_(resp.status_code, 200)
+
+    @patch('bedrock.firefox.views.switch', Mock(return_value=True))
+    def test_quantum_post_57(self):
+        req = RequestFactory().get('/en-US/firefox/quantum/')
+        resp = views.quantum(req)
+        eq_(resp.status_code, 301)
+        ok_(resp.url.endswith('/en-US/firefox/'))

--- a/bedrock/firefox/urls.py
+++ b/bedrock/firefox/urls.py
@@ -134,5 +134,5 @@ urlpatterns = (
 
     url('^firefox/stub_attribution_code/$', views.stub_attribution_code,
         name='firefox.stub_attribution_code'),
-    page('firefox/quantum', 'firefox/quantum.html'),
+    url(r'^firefox/quantum/$', views.quantum, name='firefox.quantum'),
 )

--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -813,3 +813,13 @@ def sync_page(request):
         template = 'firefox/features/sync.html'
 
     return l10n_utils.render(request, template)
+
+
+def quantum(request):
+    template = 'firefox/quantum.html'
+
+    # bug 1415599
+    if switch('firefox-57-release'):
+        return HttpResponsePermanentRedirect(reverse('firefox'))
+    else:
+        return l10n_utils.render(request, template)

--- a/tests/functional/firefox/test_quantum.py
+++ b/tests/functional/firefox/test_quantum.py
@@ -7,6 +7,7 @@ import pytest
 from pages.firefox.quantum import FirefoxQuantumPage
 
 
+@pytest.mark.skipif(reason='https://bugzilla.mozilla.org/show_bug.cgi?id=1415599')
 @pytest.mark.nondestructive
 def test_modal_successful_sign_up(base_url, selenium):
     page = FirefoxQuantumPage(selenium, base_url).open()
@@ -22,6 +23,7 @@ def test_modal_successful_sign_up(base_url, selenium):
     modal.close()
 
 
+@pytest.mark.skipif(reason='https://bugzilla.mozilla.org/show_bug.cgi?id=1415599')
 @pytest.mark.nondestructive
 def test_video_carousel(base_url, selenium):
     page = FirefoxQuantumPage(selenium, base_url).open()


### PR DESCRIPTION
## Description
- Redirects `/firefox/quantum/` to `/firefox/` behind the switch `firefox-57-release`

## Issue / Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1415599

## Testing
I added a unit test for the redirect, but some manual verification would be good too?
