### PR TITLE
[bug 1397381] Update /firefox/new/ headline

### DIFF
--- a/bedrock/firefox/templates/firefox/new/quantum/scene1.html
+++ b/bedrock/firefox/templates/firefox/new/quantum/scene1.html
@@ -27,8 +27,13 @@
 
 {% block main_content %}
 <header>
+{% if l10n_has_tag('firefox_quantum_new_headline') %}
+  <h1>{{ _('The new <strong>Firefox</strong>') }}</h1>
+  <h2>{{ _('Fast for good.') }}</h2>
+{% else %}
   <h1>{{_('Meet Firefox Quantum') }}</h1>
   <h2>{{_('New. Fast. For good.') }}</h2>
+{% endif %}
 </header>
 
 <div class="main-download">


### PR DESCRIPTION
## Description
- Updates the headline on `/firefox/new/` to match the headline on `/firefox/`.
- Uses l10n tag `firefox_quantum_new_headline`.

## Issue / Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1397381#c51

## Testing
Check for copy pasta?