### PR TITLE
Bug 1415544 - alternative firefox link in 57.0 whatsnew for Fx China …

### DIFF
--- a/bedrock/firefox/templates/firefox/whatsnew/fx57/whatsnew-57.zh-CN.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/fx57/whatsnew-57.zh-CN.html
@@ -27,7 +27,7 @@
 
   <p>
   {% trans firefox=url('firefox') %}
-    今天，我谨代表 Mozilla 全球社区，非常自豪地向您介绍<a href="{{ firefox }}">崭新的 Firefox</a>。快，只为更好！
+    今天，我谨代表 Mozilla 全球社区，非常自豪地向您介绍<a href="{{ firefox }}" data-mozillaonline-link="https://new.firefox.com.cn/">崭新的 Firefox</a>。快，只为更好！
   {% endtrans %}
   </p>
 


### PR DESCRIPTION
…repack.

## Description
WNP at /zh-CN/firefox/57.0/whatsnew/ will also be shown to users of Fx China repack, we'd like to avoid the potential confusion if an user visits /firefox/ and downloads a vanilla Firefox there.

## Issue / Bugzilla link
https://bugzil.la/1415544

## Testing
* Setup UITour permission for test [1]
* Set "distribution.id" with `Services.prefs.getDefaultBranch("distribution.").setCharPref("id", "MozillaOnline");` in Firefox's browser console.
* Visit /zh-CN/firefox/57.0/whatsnew/, and the "the new Firefox" link should point to http://www.firefox.com.cn/

[1]: http://bedrock.readthedocs.io/en/latest/uitour.html#local-development
