### PR TITLE
Bug 1415544 - open alternative start page in firstrun for Fx China re…

### DIFF
--- a/media/js/firefox/firstrun/firstrun.js
+++ b/media/js/firefox/firstrun/firstrun.js
@@ -6,6 +6,9 @@
     'use strict';
 
     var animateSunrise = function () {
+        // Bug 1381051 sign in should redirect to about:home instead of about:newtab.
+        var redirectDest = 'about:home';
+
         var scene = document.getElementById('scene');
         var skipbutton = document.getElementById('skip-button');
 
@@ -32,8 +35,7 @@
             document.getElementById('sunrise').addEventListener('transitionend', function(event) {
                 if (event.propertyName === 'transform') {
                     window.setTimeout(function () {
-                        // Bug 1381051 sign in should redirect to about:home instead of about:newtab.
-                        window.location.href = 'about:home';
+                        window.location.href = redirectDest;
                     }, 200);
                 }
             }, false);
@@ -50,6 +52,10 @@
                 onFormEnabled: disableSkipButton,
                 onNavigated:  hideOrShowSkipButton
             });
+
+            if (data.distribution && data.distribution.toLowerCase() === 'mozillaonline') {
+                redirectDest = 'https://start.firefoxchina.cn/';
+            }
         });
 
         scene.dataset.sunrise = 'true';

--- a/media/js/firefox/firstrun/firstrun_quantum.js
+++ b/media/js/firefox/firstrun/firstrun_quantum.js
@@ -6,6 +6,8 @@
     'use strict';
 
     var beginAnimation = function (syncConfig) {
+        var redirectDest = 'about:home';
+
         var scene = document.getElementById('scene');
         var skipbutton = document.getElementById('skip-button');
         scene.dataset.animate = 'true';
@@ -31,7 +33,7 @@
             scene.dataset.signIn = 'true';
             document.getElementById('wave1').addEventListener('animationend', function(event) {
                 if (event.animationName === 'Expand1') {
-                    window.location.href = 'about:home';
+                    window.location.href = redirectDest;
                 }
             }, false);
         };
@@ -55,6 +57,10 @@
                 onFormEnabled: disableSkipButton,
                 onNavigated: hideOrShowSkipButton
             });
+
+            if (data.distribution && data.distribution.toLowerCase() === 'mozillaonline') {
+                redirectDest = 'https://start.firefoxchina.cn/';
+            }
         });
     };
 


### PR DESCRIPTION
…pack.

## Description
Firstrun page at /zh-CN/firefox/{version}/firstrun/ will be shown to users of Fx China repack, we'd like to avoid the potential confusion if an user sees the start page of the vanilla Firefox, especially after the introduction of the richer Activity Stream experience in Fx 57.

PR already updated after the merge of #5223.

## Issue / Bugzilla link
https://bugzil.la/1415544

## Testing
* Setup UITour permission for test 1
* Set "distribution.id" with `Services.prefs.getDefaultBranch("distribution.").setCharPref("id", "MozillaOnline");` in Firefox's browser console.
* Visit /zh-CN/firefox/{version}/firstrun/, and click the "Skip this step" button should open http://start.firefoxchina.cn/
