### PR TITLE
[fix bug 1416496] Redirect mobile product pages to new mobile page.

### DIFF
--- a/bedrock/firefox/tests/test_views.py
+++ b/bedrock/firefox/tests/test_views.py
@@ -1053,3 +1053,50 @@ class TestFirefoxQuantumPageRedirect(TestCase):
         resp = views.quantum(req)
         eq_(resp.status_code, 301)
         ok_(resp.url.endswith('/en-US/firefox/'))
+
+
+class TestFirefoxMobileProductPagesRedirects(TestCase):
+    @patch('bedrock.firefox.views.switch', Mock(return_value=False))
+    def test_android_pre_57(self):
+        view = views.FirefoxProductAndroidView.as_view()
+        req = RequestFactory().get('/en-US/firefox/android/')
+        resp = view(req)
+        eq_(resp.status_code, 200)
+
+    @patch('bedrock.firefox.views.switch', Mock(return_value=True))
+    def test_android_post_57(self):
+        view = views.FirefoxProductAndroidView.as_view()
+        req = RequestFactory().get('/en-US/firefox/android/')
+        resp = view(req)
+        eq_(resp.status_code, 301)
+        ok_(resp.url.endswith('/en-US/firefox/mobile/'))
+
+    @patch('bedrock.firefox.views.switch', Mock(return_value=False))
+    def test_focus_pre_57(self):
+        view = views.FirefoxFocusView.as_view()
+        req = RequestFactory().get('/en-US/firefox/focus/')
+        resp = view(req)
+        eq_(resp.status_code, 200)
+
+    @patch('bedrock.firefox.views.switch', Mock(return_value=True))
+    def test_focus_post_57(self):
+        view = views.FirefoxFocusView.as_view()
+        req = RequestFactory().get('/en-US/firefox/focus/')
+        resp = view(req)
+        eq_(resp.status_code, 301)
+        ok_(resp.url.endswith('/en-US/firefox/mobile/'))
+
+    @patch('bedrock.firefox.views.switch', Mock(return_value=False))
+    def test_ios_pre_57(self):
+        view = views.FirefoxProductIOSView.as_view()
+        req = RequestFactory().get('/en-US/firefox/ios/')
+        resp = view(req)
+        eq_(resp.status_code, 200)
+
+    @patch('bedrock.firefox.views.switch', Mock(return_value=True))
+    def test_ios_post_57(self):
+        view = views.FirefoxProductIOSView.as_view()
+        req = RequestFactory().get('/en-US/firefox/ios/')
+        resp = view(req)
+        eq_(resp.status_code, 301)
+        ok_(resp.url.endswith('/en-US/firefox/mobile/'))

--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -790,6 +790,15 @@ class FirefoxProductAndroidView(BlogPostsView):
     blog_tags = ['mobile', 'featured']
     template_name = 'firefox/products/android.html'
 
+    def render_to_response(self, context, **response_kwargs):
+        if switch('firefox-57-release'):
+            return HttpResponsePermanentRedirect(reverse('firefox.mobile'))
+        else:
+            return l10n_utils.render(self.request,
+                                     self.get_template_names(),
+                                     context,
+                                     **response_kwargs)
+
 
 class FirefoxProductIOSView(BlogPostsView):
     blog_posts_limit = 3
@@ -798,6 +807,15 @@ class FirefoxProductIOSView(BlogPostsView):
     blog_tags = ['mobile', 'featured']
     template_name = 'firefox/products/ios.html'
 
+    def render_to_response(self, context, **response_kwargs):
+        if switch('firefox-57-release'):
+            return HttpResponsePermanentRedirect(reverse('firefox.mobile'))
+        else:
+            return l10n_utils.render(self.request,
+                                     self.get_template_names(),
+                                     context,
+                                     **response_kwargs)
+
 
 class FirefoxFocusView(BlogPostsView):
     blog_posts_limit = 3
@@ -805,6 +823,15 @@ class FirefoxFocusView(BlogPostsView):
     blog_slugs = 'firefox'
     blog_tags = ['privacy', 'mobile', 'featured']
     template_name = 'firefox/products/focus.html'
+
+    def render_to_response(self, context, **response_kwargs):
+        if switch('firefox-57-release'):
+            return HttpResponsePermanentRedirect(reverse('firefox.mobile'))
+        else:
+            return l10n_utils.render(self.request,
+                                     self.get_template_names(),
+                                     context,
+                                     **response_kwargs)
 
 
 class FirefoxHubView(BlogPostsView):

--- a/tests/functional/firefox/test_android.py
+++ b/tests/functional/firefox/test_android.py
@@ -7,6 +7,7 @@ import pytest
 from pages.firefox.android import FirefoxAndroidPage
 
 
+@pytest.mark.skipif(reason='https://bugzilla.mozilla.org/show_bug.cgi?id=1416496')
 @pytest.mark.smoke
 @pytest.mark.nondestructive
 def test_play_store_button_is_displayed(base_url, selenium):

--- a/tests/functional/firefox/test_focus.py
+++ b/tests/functional/firefox/test_focus.py
@@ -7,6 +7,7 @@ import pytest
 from pages.firefox.focus import FirefoxFocusPage
 
 
+@pytest.mark.skipif(reason='https://bugzilla.mozilla.org/show_bug.cgi?id=1416496')
 @pytest.mark.smoke
 @pytest.mark.nondestructive
 def test_app_store_button_is_displayed(base_url, selenium):

--- a/tests/functional/firefox/test_ios.py
+++ b/tests/functional/firefox/test_ios.py
@@ -7,6 +7,7 @@ import pytest
 from pages.firefox.ios import FirefoxIOSPage
 
 
+@pytest.mark.skipif(reason='https://bugzilla.mozilla.org/show_bug.cgi?id=1416496')
 @pytest.mark.smoke
 @pytest.mark.nondestructive
 def test_app_store_button_is_displayed(base_url, selenium):


### PR DESCRIPTION
## Description

Redirects `/firefox/android/`, `/firefox/focus/`, and `/firefox/ios/` to `/firefox/mobile/` for 57 launch.

## Issue / Bugzilla link

https://bugzilla.mozilla.org/show_bug.cgi?id=1416496

## Testing

Ensure correct pages load with switch on and off.
