### PR TITLE
[fix bug 1416499] Remove autoplay from videos on /firefox

### DIFF
--- a/media/js/firefox/quantum/features-scroller.js
+++ b/media/js/firefox/quantum/features-scroller.js
@@ -58,25 +58,6 @@
         }
     }
 
-    function playVideo(el) {
-        var video = el.querySelector('video');
-
-        // Only try and auto play video on desktop.
-        if (!client.isDesktop) {
-            return;
-        }
-
-        try {
-            if (video && video.readyState && video.readyState > 0 && video.paused) {
-                // Set each video to the start before auto-playing.
-                video.currentTime = 0.1;
-                video.play();
-            }
-        } catch(e) {
-            // Fail silently.
-        }
-    }
-
     function pauseVideo(el) {
         var video = el.querySelector('video');
 
@@ -155,7 +136,6 @@
                 handler: function(direction) {
                     if (direction === 'down') {
                         setActiveFeature(this.element.id);
-                        playVideo(this.element);
                         trackGAScroll(this.element);
                     } else {
                         pauseVideo(this.element);
@@ -169,7 +149,6 @@
                 handler: function(direction) {
                     if (direction === 'up') {
                         setActiveFeature(this.element.id);
-                        playVideo(this.element);
                     } else {
                         pauseVideo(this.element);
                     }


### PR DESCRIPTION
## Description
- Removes auto play from videos on /firefox because it's wasteful of users bandwidth.
- Note: I've left the auto-pause functionality, as I think leaving video playing that is no longer in the viewport is still a useful feature.

## Issue / Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1416499

## Testing
Make sure no regressions from code removal?
