### PR TITLE
bug 1397532 change rtl treatment of wave and add white background

### DIFF
--- a/bedrock/firefox/templates/firefox/firstrun/firstrun_quantum.html
+++ b/bedrock/firefox/templates/firefox/firstrun/firstrun_quantum.html
@@ -25,6 +25,10 @@
 
 {% block content %}
   <div id="scene">
+    <!-- white background for mix-blend-mode -->
+    <svg class="white-background" viewBox="0 0 1440 800" preserveAspectRatio="none">
+      <rect x="0" y="0" width="1440" height="800"/>
+    </svg>
 
     <svg id="wave1" class="wave1 background" xmlns="http://www.w3.org/2000/svg" viewBox="-150 -210 1750 1300" preserveAspectRatio="none">
       <path d="M1370.3-182.6C1266.9-68.3 1137.6 49.5 938.2 19.7 713.4-13.8 523.4-126.7 308.9-176.4 44.3-223.7-119.5-7.6-133 165.8c0 0-92.4 416.6 212.7 598.7 254 151.6 913.4 346.3 1353.8 165.9 146.8-60.1 133.2-686.2 87.5-1015.2-18.5-133.5-119.5-132.3-150.7-97.8z"/>
@@ -58,6 +62,7 @@
       <path d="M1327.5-88.5c-1315-237.8-1451 225.9-1443 438S620.5 9.7 983.9 131.8c316.6 106.4 497 380 684.8 337s973.8-319.4-341.2-557.3z"/>
     </svg>
 
+    <!-- white overlay for fading out the waves -->
     <svg class="white-overlay" viewBox="0 0 1440 800" preserveAspectRatio="none">
       <rect x="0" y="0" width="1440" height="800"/>
     </svg>

--- a/media/css/firefox/firstrun/firstrun_quantum.less
+++ b/media/css/firefox/firstrun/firstrun_quantum.less
@@ -23,7 +23,10 @@
 body {
     margin: 0;
     overflow: hidden;
-    font-family: 'Fira Sans Light', sans-serif;
+}
+
+* {
+  font-family: 'Fira Sans Light', sans-serif;
 }
 
 #scene {
@@ -39,11 +42,15 @@ body {
     margin: auto;
 }
 
-.white-overlay {
+.white-overlay,
+.white-background {
     fill: #FFFFFF;
     height: 100vh;
     width: 100vw;
     position: absolute;
+}
+
+.white-overlay {
     opacity: 0;
     will-change: opacity;
 }
@@ -94,7 +101,7 @@ body {
 .wave7 {
     opacity: 0.3;
     fill: url('#light-gradient');
-    margin: 0;
+    margin-left: 0;
     height: 59vh;
     width: 60vw;
 }
@@ -128,28 +135,28 @@ body {
 #fxa {
     border: none;
     position: relative;
-    width: 420px;
+    width: 318px;
 }
 
 #fxa-iframe-config {
     background: #fff;
     display: inline-block;
-    margin-left: 77px;
+    margin-left: 20px;
     transform: scale(.8);
     opacity: 0;
-    padding-bottom: 20px;
+    padding: 30px 20px;
 }
 
 .fxaccounts-container {
     bottom: 0;
     color: #fff;
-    height: 489px;
+    height: 424px;
     left: 0;
     margin: auto;
     position: absolute;
     right: 0;
     top: 0;
-    width: 980px;
+    width: 819px;
     z-index: 10;
 }
 
@@ -157,7 +164,7 @@ body {
     position: relative;
     float: left;
     clear: both;
-    width: 483px;
+    width: 441px;
 
     #title,
     .content,
@@ -169,7 +176,7 @@ body {
     .content {
         .font-size(19px);
         line-height: 1.5;
-        margin-bottom: 60px;
+        margin-bottom: 48px;
         max-width: 352px;
     }
 
@@ -181,9 +188,9 @@ body {
     }
 
     #title {
-        .font-size(42px);
+        .font-size(38px);
         font-weight: normal;
-        margin: 50px 0 10px;
+        margin: 40px 0 10px;
     }
 }
 
@@ -196,7 +203,7 @@ body {
     color: #fff;
     cursor: pointer;
     display: block;
-    margin: 0 auto;
+    margin: 10px auto 0 auto;
     min-height: 24px;
     padding: 5px 10px;
 
@@ -214,48 +221,17 @@ body {
     opacity: .5;
 }
 
-.skipbutton-hidden {
+#skip-button.skipbutton-hidden {
     display: none;
-}
-
-[dir="rtl"] .wave7 {
-    width: 100vw;
-}
-
-@media (max-width: 1200px) {
-  .fxaccounts-container {
-      width: 837px;
-  }
-
-  #left-divider {
-    width: 410px;
-
-    #title {
-        clear: both;
-        .font-size(38px);
-    }
-  }
-
-  #fxa-iframe-config {
-    margin-left: 23px;
-  }
-
-  #fxa {
-    width: 404px;
-  }
 }
 
 @media (max-width: 855px) {
   .fxaccounts-container {
-      width: 710px;
+      width: 749px;
   }
 
   #left-divider {
-    width: 324px;
-  }
-
-  #fxa {
-    width: 363px;
+      max-width: 371px;
   }
 }
 
@@ -307,7 +283,7 @@ body {
 
     #fxa-iframe-config {
         transition: opacity 1s 2s, transform 1s 2s;
-        opacity: .9;
+        opacity: .85;
         transform: scale(1);
     }
 

--- a/media/js/base/mozilla-fxa-iframe.js
+++ b/media/js/base/mozilla-fxa-iframe.js
@@ -129,9 +129,9 @@ Mozilla.FxaIframe = (function() {
         case 'resize':
             _onResize(data);
             break;
-        // user has entered email address and password
-        case 'form_enabled':
-            _onFormEnabled(data);
+        // user has entered email address or password
+        case 'form_engaged':
+            _onFormEngaged(data);
             break;
         // user has deleted email address or password
         case 'form_disabled':
@@ -170,8 +170,8 @@ Mozilla.FxaIframe = (function() {
         _userCallback('onResize', data);
     };
 
-    var _onFormEnabled = function(data) {
-        _userCallback('onFormEnabled', data);
+    var _onFormEngaged = function(data) {
+        _userCallback('onFormEngaged', data);
     };
 
     var _onFormDisabled = function(data) {
@@ -232,7 +232,7 @@ Mozilla.FxaIframe = (function() {
         //         page - defaults to 'fxa')
         //     onLoaded: function called after iframe 'loaded' postMessage
         //     onResize: function called after iframe 'resize' postMessage
-        //     onFormEnabled: function called after user has entered information in the form
+        //     onFormEngaged: function called after user has entered information in the form
         //     onFormDisabled: function called after user has removed information from the form
         //     onNavigated: function called after user has submitted a form
         //     onSignupMustVerify: function called after iframe

--- a/media/js/firefox/firstrun/firstrun.js
+++ b/media/js/firefox/firstrun/firstrun.js
@@ -47,7 +47,7 @@
                 gaEventName: 'firstrun-fxa',
                 onVerificationComplete: onVerificationComplete,
                 onLogin: onVerificationComplete,
-                onFormEnabled: disableSkipButton,
+                onFormEngaged: disableSkipButton,
                 onNavigated:  hideOrShowSkipButton
             });
         });

--- a/media/js/firefox/firstrun/firstrun_quantum.js
+++ b/media/js/firefox/firstrun/firstrun_quantum.js
@@ -52,7 +52,7 @@
                 gaEventName: 'firstrun-fxa',
                 onVerificationComplete: onVerificationComplete,
                 onLogin: onVerificationComplete,
-                onFormEnabled: disableSkipButton,
+                onFormEngaged: disableSkipButton,
                 onNavigated: hideOrShowSkipButton
             });
         });

--- a/tests/unit/spec/base/mozilla-fxa-iframe.js
+++ b/tests/unit/spec/base/mozilla-fxa-iframe.js
@@ -146,21 +146,21 @@ describe('mozilla-fxa-iframe.js', function() {
             window.postMessage(JSON.stringify(messageData), '*');
         });
 
-        it('should execute callback for form_enabled postMessage', function(done) {
+        it('should execute callback for form_engaged postMessage', function(done) {
             var messageData = {
-                command: 'form_enabled'
+                command: 'form_engaged'
             };
 
             config = {
-                onFormEnabled: function(data) {
+                onFormEngaged: function(data) {
                     var command = data.command;
-                    expect(config.onFormEnabled).toHaveBeenCalled();
-                    expect(command).toEqual('form_enabled');
+                    expect(config.onFormEngaged).toHaveBeenCalled();
+                    expect(command).toEqual('form_engaged');
                     done();
                 }
             };
 
-            spyOn(config, 'onFormEnabled').and.callThrough();
+            spyOn(config, 'onFormEngaged').and.callThrough();
 
             Mozilla.FxaIframe.init(config);
 


### PR DESCRIPTION
@craigcook 

## Description
Small visual tweaks for the firstrun page. 
Wave 7 stays to the left for rtl and ltr locales.
Add white background to show through for mix-blend-mode. so we never see colour off of the waves.
connect messaging for fxa-iframe hiding and showing the skip button when appropriate
shrink iframe to tested size to enable multi-column layout