### PR TITLE
[bug 1413353] Update Firefox wordmark in base templates

### DIFF
--- a/bedrock/firefox/templates/firefox/base-resp.html
+++ b/bedrock/firefox/templates/firefox/base-resp.html
@@ -63,7 +63,7 @@
   {% endblock %}
 
   {% block site_header_logo %}
-    <h2><a href="{{ url('firefox') }}">{{ high_res_img('firefox/template/header-logo.png', {'alt': 'Mozilla Firefox', 'width': '185', 'height': '70'}) }}</a></h2>
+    <h2><a href="{{ url('firefox') }}">{{ high_res_img('logos/firefox/logo-quantum-wordmark-large.png', {'alt': 'Firefox', 'width': '185', 'height': '69'}) }}</a></h2>
   {% endblock %}
 
   {% block alt_header %}{% endblock %}

--- a/bedrock/firefox/templates/firefox/base.html
+++ b/bedrock/firefox/templates/firefox/base.html
@@ -52,5 +52,5 @@
 {% endblock %}
 
 {% block site_header_logo %}
-  <h2><a href="{{ url('firefox') }}">{{ high_res_img('firefox/template/header-logo.png', {'alt': 'Mozilla Firefox', 'width': '185', 'height': '70'}) }}</a></h2>
+  <h2><a href="{{ url('firefox') }}">{{ high_res_img('logos/firefox/logo-quantum-wordmark-large.png', {'alt': 'Firefox', 'width': '185', 'height': '69'}) }}</a></h2>
 {% endblock %}


### PR DESCRIPTION
## Description
Updates Firefox wordmark in base templates (e.g. header on `/firefox/all/`)

## Issue / Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1413353

## Testing
Check I didn't miss any other occurences?