### PR TITLE
Fix bug 1416825: Add iOS link to release notes

### DIFF
--- a/bedrock/firefox/templates/firefox/releases/release-notes.html
+++ b/bedrock/firefox/templates/firefox/releases/release-notes.html
@@ -38,7 +38,9 @@
     {% block site_header_logo %}
       <h2>
         <a href="{{ url('firefox') }}">
-          {% if release.major_version >= '57' %}
+          {% if release.major_version_int >= 57 %}
+            {{ high_res_img('logos/firefox/logo-quantum-wordmark-large.png', {'alt': 'Firefox', 'width': '185', 'height': '69'}) }}
+          {% elif release.product == 'Firefox for iOS' and release.major_version_int >= 10 %}
             {{ high_res_img('logos/firefox/logo-quantum-wordmark-large.png', {'alt': 'Firefox', 'width': '185', 'height': '69'}) }}
           {% else %}
             {{ high_res_img('firefox/template/header-logo.png', {'alt': 'Mozilla Firefox', 'width': '185', 'height': '70'}) }}

--- a/bedrock/firefox/templates/firefox/releases/release-notes.html
+++ b/bedrock/firefox/templates/firefox/releases/release-notes.html
@@ -92,6 +92,11 @@
           {% else %}
             <li><a href="{{ url('firefox.notes', platform='android') }}">{{ _('Android') }}</a></li>
           {% endif %}
+          {% if release.product == 'Firefox for iOS' and release.channel == 'Release' %}
+            <li class="current">{{ _('iOS') }}</li>
+          {% else %}
+            <li><a href="{{ url('firefox.notes', platform='ios') }}">{{ _('iOS') }}</a></li>
+          {% endif %}
             <li class="{% if release.channel != 'Release' %}current {% endif %}submenu-title">
               <a href="#" role="button" aria-controls="nav-submenu" aria-expanded="false">{{ _('Other Releases') }}</a>
               <ul class="submenu" id="nav-submenu">

--- a/bedrock/releasenotes/models.py
+++ b/bedrock/releasenotes/models.py
@@ -176,6 +176,10 @@ class ProductRelease(models.Model):
         return str(self.version_obj.major)
 
     @cached_property
+    def major_version_int(self):
+        return self.version_obj.major
+
+    @cached_property
     def version_obj(self):
         return Version(self.version)
 


### PR DESCRIPTION
This was removed in 900fc99d24044e66b82d9c85717c665dea2e39f6. We can now add it back since iOS release notes are now being maintained.