### PR TITLE
[fix bug 1417112] Only preload metadata for first video on /firefox

### DIFF
--- a/bedrock/firefox/templates/firefox/hub/home-quantum.html
+++ b/bedrock/firefox/templates/firefox/hub/home-quantum.html
@@ -214,7 +214,7 @@
         <div class="features-scroller-content">
           <div id="video-screenshots" class="feature-content screenshots" data-ga-label="Features: Screenshots">
             <figure>
-              <video preload="metadata" muted controls playsinline poster="{{ static('img/firefox/hub/quantum/video-screenshots-poster.png') }}" data-ga-label="Features: Screenshots">
+              <video preload="none" muted controls playsinline poster="{{ static('img/firefox/hub/quantum/video-screenshots-poster.png') }}" data-ga-label="Features: Screenshots">
                 <source src="https://assets.mozilla.net/video/firefox-home/screenshots.webm" type="video/webm">
                 <source src="https://assets.mozilla.net/video/firefox-home/screenshots.ogv" type="video/ogg; codecs='theora, vorbis'">
                 <source src="https://assets.mozilla.net/video/firefox-home/screenshots.mp4" type="video/mp4">
@@ -234,7 +234,7 @@
 
           <div id="video-pocket" class="feature-content pocket" data-ga-label="Features: Pocket">
             <figure>
-              <video preload="metadata" muted controls playsinline poster="{{ static('img/firefox/hub/quantum/video-pocket-poster.png') }}" data-ga-label="Features: Pocket">
+              <video preload="none" muted controls playsinline poster="{{ static('img/firefox/hub/quantum/video-pocket-poster.png') }}" data-ga-label="Features: Pocket">
                 <source src="https://assets.mozilla.net/video/firefox-home/pocket.webm" type="video/webm">
                 <source src="https://assets.mozilla.net/video/firefox-home/pocket.ogv" type="video/ogg; codecs='theora, vorbis'">
                 <source src="https://assets.mozilla.net/video/firefox-home/pocket.mp4" type="video/mp4">
@@ -254,7 +254,7 @@
 
           <div id="video-gaming" class="feature-content gaming-vr" data-ga-label="Features: Gaming & VR">
             <figure>
-              <video preload="metadata" muted controls playsinline poster="{{ static('img/firefox/hub/quantum/video-gaming-poster.png') }}" data-ga-label="Features: Gaming & VR">
+              <video preload="none" muted controls playsinline poster="{{ static('img/firefox/hub/quantum/video-gaming-poster.png') }}" data-ga-label="Features: Gaming & VR">
                 <source src="https://assets.mozilla.net/video/firefox-home/gaming.webm" type="video/webm">
                 <source src="https://assets.mozilla.net/video/firefox-home/gaming.ogv" type="video/ogg; codecs='theora, vorbis'">
                 <source src="https://assets.mozilla.net/video/firefox-home/gaming.mp4" type="video/mp4">
@@ -275,7 +275,7 @@
 
           <div id="video-library" class="feature-content library" data-ga-label="Features: Library">
             <figure>
-              <video preload="metadata" muted controls playsinline poster="{{ static('img/firefox/hub/quantum/video-bookmarking-poster.png') }}" data-ga-label="Features: Library">
+              <video preload="none" muted controls playsinline poster="{{ static('img/firefox/hub/quantum/video-bookmarking-poster.png') }}" data-ga-label="Features: Library">
                 <source src="https://assets.mozilla.net/video/firefox-home/bookmarking.webm" type="video/webm">
                 <source src="https://assets.mozilla.net/video/firefox-home/bookmarking.ogv" type="video/ogg; codecs='theora, vorbis'">
                 <source src="https://assets.mozilla.net/video/firefox-home/bookmarking.mp4" type="video/mp4">


### PR DESCRIPTION
## Description
- Sets `preload="none"` on all videos except the top Firefox vs Chrome video.
- This gets the page down to around 2.7MB on a hard refresh. not as small as I'd like but it's a quick win for a small tweak.

## Issue / Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1417112

## Testing
https://bedrock-demo-agibson.us-west.moz.works/en-US/firefox/
