### PR TITLE
[fix bug 1417105] Extra white space at the bottom of the /firefox/new/?scene=2

### DIFF
--- a/media/css/firefox/new/quantum/common.scss
+++ b/media/css/firefox/new/quantum/common.scss
@@ -12,6 +12,7 @@ $color-quantum-blue: #0a84ff;
 
 body {
     @include open-sans;
+    background: #000;
 }
 
 /* -------------------------------------------------------------------------- */
@@ -240,6 +241,7 @@ html.ios .header-content {
 
 .features {
     text-align: center;
+    background: #fff;
 
     h3 {
         @include font-size-level4;

--- a/media/css/firefox/new/quantum/scene1.scss
+++ b/media/css/firefox/new/quantum/scene1.scss
@@ -248,6 +248,10 @@ html[dir="rtl"].show-refresh {
 /* -------------------------------------------------------------------------- */
 // Newsletter
 
+.newsletter-container {
+    background: #fff;
+}
+
 #newsletter-subscribe {
     display: none;
 


### PR DESCRIPTION
## Description
Fixes a minor issue where the tracking pixel added to scene2 was causing a small bar of white space below the footer 🙄.

## Issue / Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1417105

## Testing
Make sure no other visual regressions in the page?
