### PR TITLE
[fix AMO issue #3920] Fix broken link to AMO privacy add-ons.

### DIFF
--- a/bedrock/teach/templates/teach/smarton/tracking.html
+++ b/bedrock/teach/templates/teach/smarton/tracking.html
@@ -332,7 +332,7 @@
 
           <section class="feature feature-addons">
             <h5>{{ _('Privacy Add-ons') }}</h5>
-            <p>{{ _('The Mozilla privacy team has put together <a href="{url}">a collection of Firefox add-ons</a> to help you manage your privacy online.').format(url='https://addons.mozilla.org/firefox/collections/mozilla/privacy/')|safe }}</p>
+            <p>{{ _('The Mozilla privacy team has put together <a href="{url}">a collection of Firefox add-ons</a> to help you manage your privacy online.').format(url='https://addons.mozilla.org/firefox/collections/mozilla/privacy-matters/')|safe }}</p>
           </section>
         </aside>
 


### PR DESCRIPTION
## Description

After some changes on AMO, the link to the privacy add-ons on `/smarton/tracking/` is now a 404. This PR just updates the URL as requested by the AMO team.

## Issue / Bugzilla link

mozilla/addons-frontend#3920

## Testing

Make sure new link works?