### PR TITLE
Fix bug 1417972: Update ultimate authority governance role

### DIFF
--- a/bedrock/mozorg/templates/mozorg/about/governance/roles.html
+++ b/bedrock/mozorg/templates/mozorg/about/governance/roles.html
@@ -13,7 +13,7 @@
 
 <p>{{_('The Mozilla project is governed by a virtual management team made up of experts from various parts of the community. Some people with leadership roles are employed to work on Mozilla and others are not. Leadership roles are granted based on how active an individual is within the community as well as the quality and nature of his or her contributions. This meritocracy is a resilient and effective way to guide our global community. The different community leadership roles include:')}} </p>
 
-<h2>{{_('Module Owners and Peers')}}</h2>
+<h2 id="module-owners-and-peers">{{_('Module Owners and Peers')}}</h2>
 
 {% trans
 	moduleowners_url=url('mozorg.about.governance.policies.module-ownership'),
@@ -22,7 +22,7 @@
 <p><a href="{{ moduleowners_url }}">Module owners</a> are responsible for leading the development of a module of code or a community activity. This role requires a range of tasks, including approving patches to be checked into the module or resolving conflicts among community members. Lists of <a href="{{ module_url }}">code module owners</a> and <a href="{{ module_activities_url }}">non-code module owners are available.</a></p>
 
 {% endtrans %}
-<h2>{{_('Super-Reviewers')}} </h2>
+<h2 id="super-reviewers">{{_('Super-Reviewers')}} </h2>
 {% trans
 	super_reviewers_url= url('mozorg.about.governance.roles'),
 	code_review_url ="https://developer.mozilla.org/docs/Code_Review_FAQ" %}
@@ -30,46 +30,46 @@
 
 {% endtrans %}
 
-<h2>{{_('Release Drivers')}}</h2>
+<h2 id="release-drivers">{{_('Release Drivers')}}</h2>
 {% trans
 	drivers_url="https://wiki.mozilla.org/Firefox/Drivers"%}
 <p><a href="{{ drivers_url }}">Release drivers</a> provide project management for milestone releases. The drivers provide guidance to developers as to which bug fixes are important for a given release and also make a range of tree management decisions.</p>
 
 {% endtrans %}
 
-<h2>{{_('Bugzilla Component Owners')}}</h2>
+<h2 id="bugzilla-component-owners">{{_('Bugzilla Component Owners')}}</h2>
 
 {% trans
 	bugzilla_url="https://bugzilla.mozilla.org/describecomponents.cgi?product=mozilla.org" %}
 <a href="{{ bugzilla_url }}">Bugzilla component owners</a> are the default recipient of bugs filed against that component. Component owners are expected to review bug reports regularly, reassign bugs to correct owners, ensure test cases exist, track the progress toward resolving important fixes, and otherwise manage the bugs in the component. The Bugzilla component owner and the related module owner may be the same person, but in many cases they will be different.</p>
 {% endtrans %}
 
-<h2>{{_('Former Module Owners')}}</h2>
+<h2 id="former-module-owners">{{_('Former Module Owners')}}</h2>
 
 <p>{{_('When module owners and similar leaders pass on their leadership and authority to others we refer to them as Former Module Owners. This allows us to continue to acknowledge their contributions to our (collective) success -- mentoring new leadership and passing on authority to new leaders is an important part of maintaining a healthy project. "Former" status can apply to people who move to other roles within Mozilla, and to people who are no longer active in Mozilla. It is intended to be factual, not subjective or evaluative.')}} </p>
 
-<h2>{{_('Mozilla Reps')}}</h2>
+<h2 id="reps">{{_('Mozilla Reps')}}</h2>
 
 <p>{{_('Reps are deeply passionate Mozillians who represent Mozilla in their country or region and are committed to educating and empowering people to support the Mozilla mission and contribute to the project. They are the eyes, ears and voice of Mozilla on the ground.')}} </p>
 
-<h2>{{_('Mozilla Reps Mentors')}}</h2>
+<h2 id="reps-mentors">{{_('Mozilla Reps Mentors')}}</h2>
 
 <p>{{_('Mentors provide mentorship and guidance to ensure that Reps are successful in fulfilling their responsibilities. Mentors are also responsible for reviewing monthly reports, budget requests and swag requests filed by their Reps.')}} </p>
 
-<h2>{{_('Mozilla Reps Council')}}</h2>
+<h2 id="reps-council">{{_('Mozilla Reps Council')}}</h2>
 
 <p>{{_("The Council is the program's 9-member governing body and its 7 volunteer members are elected. The Council exists to ensure that the Mozilla Reps program runs smoothly, oversees the governance and finances of the program and serves as an advisory body within the Mozilla organization.")}} </p>
 
-<h2>{{_('Stewards')}}</h2>
+<h2 id="stewards">{{_('Stewards')}}</h2>
 
 {% trans  stewards_url="https://wiki.mozilla.org/Contribute#Community_Builders"%}
 <p><a href="{{ stewards_url }}">Stewards</a>  are responsible for the growth and health of the community around functional and regional areas. Although everyone in Mozilla has a responsibility to help new people join the community, Stewards maintain the contribution pathways that connect potential contributors to teams that have contribution opportunities. Stewards also run recognition, education and metrics projects that keep those pathways functioning well.</p>
 {% endtrans %}
 
-<h2>{{_('Ultimate Decision-Makers')}}</h2>
+<h2 id="ultimate-decision-makers">{{_('Ultimate Decision-Makers')}}</h2>
 
 {% trans
 	model_url="http://fringe.davesource.com/Fringe/Computers/Philosophy/Homesteading_The_Noosphere/homesteading-15.html" %}
-<p>The ultimate decision-maker(s) are trusted members of the community who have the final say in the case of disputes. This is a <a href="{{ model_url }}">model</a> followed by many successful open source projects, although most of those communities only have one person in this role, and they are sometimes called the "benevolent dictator". Mozilla has evolved to have two people in this role - Brendan Eich has the final say in any technical dispute and Mitchell Baker has the final say in any non-technical dispute. This has been the case since 1998 for Brendan and 1999 for Mitchell.</p>
+<p>The ultimate decision-maker is a trusted member of the community who has the final say in the case of disputes. This is a <a href="{{ model_url }}">model</a> followed by many successful open source projects, and they are sometimes called the "benevolent dictator". Mozilla has evolved in the past to have two people in this role, but only has one at present: Mitchell Baker. Mitchell has been in this role since 1999.</p>
 {% endtrans %}
 {% endblock %}


### PR DESCRIPTION
Remove Brendan since he is no longer an owner of the Governance module. Also add ID attributes to the headings so that the old anchors work.