### PR TITLE
[bug 1417888] Disable firstrun animation for some platforms

### DIFF
--- a/bedrock/firefox/templates/firefox/firstrun/firstrun_quantum.html
+++ b/bedrock/firefox/templates/firefox/firstrun/firstrun_quantum.html
@@ -30,7 +30,7 @@
       <rect x="0" y="0" width="1440" height="800"/>
     </svg>
 
-    <svg id="wave1" class="wave1 background" xmlns="http://www.w3.org/2000/svg" viewBox="-150 -210 1750 1300" preserveAspectRatio="none">
+    <svg class="wave1 background" xmlns="http://www.w3.org/2000/svg" viewBox="-150 -210 1750 1300" preserveAspectRatio="none">
       <path d="M1370.3-182.6C1266.9-68.3 1137.6 49.5 938.2 19.7 713.4-13.8 523.4-126.7 308.9-176.4 44.3-223.7-119.5-7.6-133 165.8c0 0-92.4 416.6 212.7 598.7 254 151.6 913.4 346.3 1353.8 165.9 146.8-60.1 133.2-686.2 87.5-1015.2-18.5-133.5-119.5-132.3-150.7-97.8z"/>
     </svg>
 
@@ -63,7 +63,7 @@
     </svg>
 
     <!-- white overlay for fading out the waves -->
-    <svg class="white-overlay" viewBox="0 0 1440 800" preserveAspectRatio="none">
+    <svg id="white-overlay" class="white-overlay" viewBox="0 0 1440 800" preserveAspectRatio="none">
       <rect x="0" y="0" width="1440" height="800"/>
     </svg>
 

--- a/media/css/firefox/firstrun/firstrun_quantum.less
+++ b/media/css/firefox/firstrun/firstrun_quantum.less
@@ -128,7 +128,6 @@ body {
     background-repeat: no-repeat;
     background-size: 90px 90px;
     height: 90px;
-    opacity: 0;
     width: 90px;
 }
 
@@ -142,8 +141,6 @@ body {
     background: #fff;
     display: inline-block;
     margin-left: 20px;
-    transform: scale(.8);
-    opacity: 0;
     padding: 30px 20px;
 }
 
@@ -165,13 +162,6 @@ body {
     float: left;
     clear: both;
     width: 441px;
-
-    #title,
-    .content,
-    a {
-        opacity: 0;
-        transform: translateY(-5px);
-    }
 
     .content {
         .font-size(19px);
@@ -241,123 +231,155 @@ body {
     }
 }
 
-#scene[data-animate=true] {
-    .wave1 {
-        animation: Wave1 17.26s infinite forwards;
-    }
-
-    .wave2 {
-        animation: Wave2 11.08s infinite forwards;
-    }
-
-    .wave3 {
-        animation: Wave3 7.51s infinite forwards;
-    }
-
-    .wave4 {
-        animation: Wave4 15.14s infinite forwards;
-    }
-
-    .wave5 {
-        animation: Wave5 13.46s infinite forwards;
-    }
-
-    .wave6 {
-        animation: Wave6 20.55s infinite forwards;
-    }
-
-    .wave7 {
-        animation: Wave7 26.55s infinite forwards;
-    }
-
-    .wave8 {
-        animation: Wave8 27.43s infinite forwards;
-    }
-}
-
-#scene[data-content=true] {
-    #firefox-logo {
-        transition: opacity 1s 1.8s;
-        opacity: 1;
-    }
-
-    #fxa-iframe-config {
-        transition: opacity 1s 2s, transform 1s 2s;
-        opacity: .85;
-        transform: scale(1);
-    }
-
-    #left-divider {
-
-        #title,
-        .content,
-        a {
-            transition: transform .5s, opacity .8s;
-            transform: translateY(0);
-            opacity: 1;
-        }
-
-        #title {
-            transition-delay: 1.8s;
-        }
-
-        .content {
-            transition-delay: 2s;
-        }
-
-        a {
-            transition-delay: 2.2s;
-        }
-    }
-}
-
+// Simplified interactions for some platforms
 #scene[data-sign-in=true] {
     .fxaccounts-container {
         transition: opacity .5s;
         opacity: 0;
-        animation: HideVisibility 0s .5s 1 forwards;
+        animation: HideVisibility 0s .1s 1 forwards;
     }
 
     .color-overlay {
-        transition: opacity 1s .8s;
+        transition: opacity 1s .5s;
         opacity: 1;
     }
 
     .white-overlay {
-        transition: opacity .6s 1.1s;
+        transition: opacity .6s .8s;
         opacity: 1;
     }
+}
 
-    .wave1 {
-        animation: Wave1 17.26s 1 forwards, Expand1 1.5s var(--animation-curve) .2s forwards;
+// More complex interactions for other platforms
+html.osx,
+html.win8up {
+    #firefox-logo {
+        opacity: 0;
     }
 
-    .wave2 {
-        animation: Wave2 11.08s 1 forwards, Expand2 1.5s var(--animation-curve) .2s 1 forwards;
+    #left-divider #title,
+    #left-divider .content,
+    #left-divider a {
+        opacity: 0;
+        transform: translateY(-5px);
     }
 
-    .wave3 {
-        animation: Wave3 7.51s 1 forwards, Expand3 1.5s var(--animation-curve) .2s 1 forwards;
+    #fxa-iframe-config {
+        opacity: 0;
+        transform: scale(.8);
     }
 
-    .wave4 {
-        animation: Wave4 15.14s 1 forwards, Expand4 1.5s var(--animation-curve) .2s 1 forwards;
+    #scene[data-animate=true] {
+        .wave1 {
+            animation: Wave1 17.26s infinite forwards;
+        }
+
+        .wave2 {
+            animation: Wave2 11.08s infinite forwards;
+        }
+
+        .wave3 {
+            animation: Wave3 7.51s infinite forwards;
+        }
+
+        .wave4 {
+            animation: Wave4 15.14s infinite forwards;
+        }
+
+        .wave5 {
+            animation: Wave5 13.46s infinite forwards;
+        }
+
+        .wave6 {
+            animation: Wave6 20.55s infinite forwards;
+        }
+
+        .wave7 {
+            animation: Wave7 26.55s infinite forwards;
+        }
+
+        .wave8 {
+            animation: Wave8 27.43s infinite forwards;
+        }
     }
 
-    .wave5 {
-        animation: Wave5 13.46s 1 forwards, Expand5 1.5s var(--animation-curve) .2s 1 forwards;
+    #scene[data-content=true] {
+        #firefox-logo {
+            transition: opacity 1s 1.8s;
+            opacity: 1;
+        }
+
+        #fxa-iframe-config {
+            transition: opacity 1s 2s, transform 1s 2s;
+            opacity: .85;
+            transform: scale(1);
+        }
+
+        #left-divider {
+            #title,
+            .content,
+            a {
+                transition: transform .5s, opacity .8s;
+                transform: translateY(0);
+                opacity: 1;
+            }
+
+            #title {
+                transition-delay: 1.8s;
+            }
+
+            .content {
+                transition-delay: 2s;
+            }
+
+            a {
+                transition-delay: 2.2s;
+            }
+        }
     }
 
-    .wave6 {
-        animation: Wave6 20.55s 1 forwards, Expand6 1.5s var(--animation-curve) .2s 1 forwards;
-    }
+    #scene[data-sign-in=true] {
+        .color-overlay {
+            transition: opacity 1s .8s;
+            opacity: 1;
+        }
 
-    .wave7 {
-        animation: Wave7 26.55s 1 forwards, Expand7 1.5s var(--animation-curve) .2s 1 forwards;
-    }
+        .white-overlay {
+            transition: opacity .6s 1.1s;
+            opacity: 1;
+        }
 
-    .wave8 {
-        animation: Wave8 27.43s 1 forwards, Expand8 1.5s var(--animation-curve) .2s 1 forwards;
+        .wave1 {
+            animation: Wave1 17.26s 1 forwards, Expand1 1.5s var(--animation-curve) .2s forwards;
+        }
+
+        .wave2 {
+            animation: Wave2 11.08s 1 forwards, Expand2 1.5s var(--animation-curve) .2s 1 forwards;
+        }
+
+        .wave3 {
+            animation: Wave3 7.51s 1 forwards, Expand3 1.5s var(--animation-curve) .2s 1 forwards;
+        }
+
+        .wave4 {
+            animation: Wave4 15.14s 1 forwards, Expand4 1.5s var(--animation-curve) .2s 1 forwards;
+        }
+
+        .wave5 {
+            animation: Wave5 13.46s 1 forwards, Expand5 1.5s var(--animation-curve) .2s 1 forwards;
+        }
+
+        .wave6 {
+            animation: Wave6 20.55s 1 forwards, Expand6 1.5s var(--animation-curve) .2s 1 forwards;
+        }
+
+        .wave7 {
+            animation: Wave7 26.55s 1 forwards, Expand7 1.5s var(--animation-curve) .2s 1 forwards;
+        }
+
+        .wave8 {
+            animation: Wave8 27.43s 1 forwards, Expand8 1.5s var(--animation-curve) .2s 1 forwards;
+        }
     }
 }
 

--- a/media/js/firefox/firstrun/firstrun_quantum.js
+++ b/media/js/firefox/firstrun/firstrun_quantum.js
@@ -5,6 +5,11 @@
 (function (Mozilla) {
     'use strict';
 
+    // Add class to indicate Windows 8 and later
+    if (window.site.platform === 'windows' && window.site.platformVersion >= 6.2) {
+        document.documentElement.classList.add('win8up');
+    }
+
     var beginAnimation = function (syncConfig) {
         var redirectDest = 'about:home';
 
@@ -31,10 +36,8 @@
 
         var onVerificationComplete = function () {
             scene.dataset.signIn = 'true';
-            document.getElementById('wave1').addEventListener('animationend', function(event) {
-                if (event.animationName === 'Expand1') {
-                    window.location.href = redirectDest;
-                }
+            document.getElementById('white-overlay').addEventListener('transitionend', function() {
+                window.location.href = redirectDest;
             }, false);
         };
 


### PR DESCRIPTION
## Description
This disables the background wave animation in Linux and older Windowses (less than Win8), as well as a simplified end transition. Macs and newer Windowses (Win8 and up) should appear the same as before.

This is hopefully a temporary patch to address the most pressing concerns reported on Linux and older Windows machines that lack GPU acceleration until we can regroup and look into revising the page for better performance across all platforms and devices.

The diff looks a bit bigger than it really is because a lot of lines just changed indentation.

## Issue / Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1417888

## Testing
https://www-demo4.allizom.org/firefox/57.0/firstrun/

This uses UITour so you'll need to whitelist test domains in `browser.uitour.testingOrigins`

Test the page in Firefox 57+ on Windows 7 and verify correct FxA form functionality with no background animation. On either signing in or skipping, there should be a simple fade-to-white end transition before loading the new tab page. We should test Linux as well since I don't have access to a Linux machine.

Test the page in Firefox 57+ on Windows 8 or better (as well as Mac) and verify no regressions from what's currently in production. You should get the rolling waves background animation and the spin-and-fade end transition before loading the new tab page.
