### PR TITLE
Make update_wordpress command efficient with DB writes

### DIFF
--- a/bedrock/wordpress/management/commands/update_wordpress.py
+++ b/bedrock/wordpress/management/commands/update_wordpress.py
@@ -10,19 +10,22 @@ class Command(BaseCommand):
     def add_arguments(self, parser):
         parser.add_argument('-q', '--quiet', action='store_true', dest='quiet', default=False,
                             help='If no error occurs, swallow all output.'),
-        parser.add_argument('--database', default='default',
-                            help=('Specifies the database to use. '
-                                  'Defaults to "default".')),
 
     def handle(self, *args, **options):
         errors = []
         for feed_id in settings.WP_BLOGS:
-            updated = BlogPost.objects.refresh(feed_id, options['database'])
-            if updated and not options['quiet']:
-                print('Refreshed %s posts from the %s blog' % (updated, feed_id))
+            updated, deleted = BlogPost.objects.refresh(feed_id)
+            if updated is None:
+                errors.append('There was a problem updating the %s blog' % feed_id)
+                continue
 
-            if not updated:
-                errors.append('Something has gone wrong with refreshing the %s blog' % feed_id)
+            if not options['quiet']:
+                if updated:
+                    print('Refreshed %s posts from the %s blog' % (updated, feed_id))
+                    if deleted:
+                        print('Deleted %s old posts from the %s blog' % (deleted, feed_id))
+                else:
+                    print('The %s blog is already up to date' % feed_id)
 
         if errors:
             raise CommandError('\n'.join(errors))

--- a/bedrock/wordpress/models.py
+++ b/bedrock/wordpress/models.py
@@ -6,20 +6,43 @@ import operator
 import random
 
 from django.conf import settings
-from django.db import models, transaction
+from django.db import models
 from django.db.models import Q
 from django.db.utils import DatabaseError
+from django.utils.dateparse import parse_datetime
+from django.utils.timezone import make_aware, utc
 
 import bleach
 from django_extensions.db.fields.json import JSONField
 from jinja2 import Markup
 from raven.contrib.django.raven_compat.models import client as sentry_client
 
-from bedrock.wordpress.api import get_posts_data
+from bedrock.wordpress.api import get_posts_data, complete_posts_data
+
+
+def make_datetime(datestr):
+    return make_aware(parse_datetime(datestr), timezone=utc)
 
 
 def strip_tags(text):
     return bleach.clean(text, tags=[], strip=True).strip()
+
+
+def post_to_dict(blog_slug, post):
+    try:
+        return dict(
+            wp_id=post['id'],
+            wp_blog_slug=blog_slug,
+            date=make_datetime(post['date_gmt']),
+            modified=make_datetime(post['modified_gmt']),
+            title=strip_tags(post['title']['rendered']),
+            excerpt=process_excerpt(post['excerpt']['rendered']),
+            link=post['link'],
+            featured_media=post['featured_media'],
+            tags=post['tags'],
+        )
+    except Exception:
+        return None
 
 
 def process_excerpt(excerpt):
@@ -58,38 +81,59 @@ class BlogPostManager(models.Manager):
     def filter_by_tags(self, *tags):
         return self.get_queryset().filter_by_tags(*tags)
 
-    def update_posts(self, data, database='default'):
-        with transaction.atomic(using=database):
-            count = 0
-            posts = data['posts']
-            self.filter_by_blogs(data['wp_blog_slug']).delete()
-            for post in posts:
-                try:
-                    self.create(
-                        wp_id=post['id'],
-                        wp_blog_slug=data['wp_blog_slug'],
-                        date=post['date_gmt'],
-                        modified=post['modified_gmt'],
-                        title=strip_tags(post['title']['rendered']),
-                        excerpt=process_excerpt(post['excerpt']['rendered']),
-                        link=post['link'],
-                        featured_media=post['featured_media'],
-                        tags=post['tags'],
-                    )
-                    count += 1
-                except (DatabaseError, KeyError):
-                    sentry_client.captureException()
-                    raise
+    def update_posts(self, blog_slug, posts):
+        update_count = 0
+        del_count = 0
+        post_ids = []
+        posts_to_update = []
+        for post in posts:
+            modified = make_datetime(post['modified_gmt'])
+            post_ids.append(post['id'])
+            try:
+                obj = self.get(wp_id=post['id'], wp_blog_slug=blog_slug)
+            except BlogPost.DoesNotExist:
+                posts_to_update.append((None, post))
+            else:
+                if obj.modified != modified:
+                    posts_to_update.append((obj, post))
 
-            return count
+        if not posts_to_update:
+            return 0, 0
 
-    def refresh(self, feed_id, database='default', num_posts=None):
-        data = get_posts_data(feed_id, num_posts)
-        if data:
-            return self.update_posts(data, database)
+        complete_posts_data(blog_slug, posts_to_update)
+        for obj, post in posts_to_update:
+            post = post_to_dict(blog_slug, post)
+            if not post:
+                continue
+
+            try:
+                if obj:
+                    for key, value in post.iteritems():
+                        setattr(obj, key, value)
+                    obj.save()
+                else:
+                    self.create(**post)
+            except DatabaseError:
+                sentry_client.captureException()
+                raise
+
+            update_count += 1
+
+        # clean up after changes
+        if update_count:
+            expired_posts = self.filter_by_blogs(blog_slug).exclude(wp_id__in=post_ids)
+            del_count = expired_posts.count()
+            expired_posts.delete()
+
+        return update_count, del_count
+
+    def refresh(self, feed_id, num_posts=None):
+        posts = get_posts_data(feed_id, num_posts)
+        if posts:
+            return self.update_posts(feed_id, posts)
 
         # no data returned. something wrong.
-        return 0
+        return None, None
 
 
 class BlogPost(models.Model):

--- a/bedrock/wordpress/tests/test_models.py
+++ b/bedrock/wordpress/tests/test_models.py
@@ -42,12 +42,15 @@ def setup_responses(blog='firefox'):
 @override_settings(WP_BLOGS=TEST_WP_BLOGS)
 def test_get_posts_data():
     setup_responses()
-    data = api.get_posts_data('firefox')
-    assert data['wp_blog_slug'] == 'firefox'
-    assert data['posts'][0]['tags'] == ['browser', 'fastest']
-    assert data['posts'][0]['featured_media'] == {}
-    assert data['posts'][1]['featured_media'] == {}
-    assert data['posts'][2]['featured_media']['id'] == 75
+    posts = api.get_posts_data('firefox')
+    tags = api.get_feed_tags('firefox')
+    for post in posts:
+        post['tags'] = [tags[t] for t in post['tags']]
+        api.update_post_media('firefox', post)
+    assert posts[0]['tags'] == ['browser', 'fastest']
+    assert posts[0]['featured_media'] == {}
+    assert posts[1]['featured_media'] == {}
+    assert posts[2]['featured_media']['id'] == 75
     assert len(responses.calls) == 4
 
 


### PR DESCRIPTION
Used to delete all entries before adding again from the server.  Now uses the server post ID and modified time to only update those that need updating and removing older posts.