### PR TITLE
Remove outdated meta page images from /channel pages

### DIFF
--- a/bedrock/firefox/templates/firefox/channel/base.html
+++ b/bedrock/firefox/templates/firefox/channel/base.html
@@ -10,7 +10,6 @@
 {% block page_title_suffix %}{% endblock %}
 {#- This will appear as <meta property="og:title"> which can be used for social share -#}
 {% block page_og_title %}{{ self.page_title() }}{% endblock %}
-{% block page_image %}{{ static('img/firefox/template/page-image-quantum.png') }}{% endblock %}
 
 {% block page_css %}
   {% stylesheet 'firefox_channel' %}

--- a/bedrock/firefox/templates/firefox/quantum.html
+++ b/bedrock/firefox/templates/firefox/quantum.html
@@ -10,7 +10,6 @@
 
 {% block page_title %}{{ _('2x faster and 30% less memory') }} | {{ _('Firefox Quantum Browser') }}{% endblock %}
 {% block page_desc %}{{ _('The new Firefox arrives November 14, 2017') }}{% endblock %}
-{% block page_image %}{{ static('img/firefox/template/page-image-quantum.png') }}{% endblock %}
 
 {% block site_header %}{% endblock %}
 


### PR DESCRIPTION
## Description
Fixes 500 on the /channel pages after removal/rename of social sharing images. Test failure: https://ci.us-west.moz.works/blue/organizations/jenkins/bedrock_multibranch_pipeline/detail/master/703/pipeline/

(appologies I missed these in the PR)

## Issue / Bugzilla link
N/A

## Testing
Successful test run: https://ci.us-west.moz.works/blue/organizations/jenkins/bedrock_multibranch_pipeline/detail/run-integration-tests/117/pipeline/