### PR TITLE
[bug 1416710] Add functional tests for /firefox/mobile/ page

### DIFF
--- a/bedrock/firefox/tests/test_views.py
+++ b/bedrock/firefox/tests/test_views.py
@@ -1039,21 +1039,6 @@ class TestFirefoxDesktopPageRedirect(TestCase):
         ok_(resp.url.endswith('/en-US/firefox/'))
 
 
-class TestFirefoxMobilePageRedirect(TestCase):
-    @patch('bedrock.firefox.views.switch', Mock(return_value=False))
-    def test_mobile_page_pre_57(self):
-        req = RequestFactory().get('/en-US/firefox/mobile/')
-        resp = views.mobile(req)
-        eq_(resp.status_code, 302)
-        ok_(resp.url.endswith('/en-US/firefox/android/'))
-
-    @patch('bedrock.firefox.views.switch', Mock(return_value=True))
-    def test_mobile_page_post_57(self):
-        req = RequestFactory().get('/en-US/firefox/mobile/')
-        resp = views.mobile(req)
-        eq_(resp.status_code, 200)
-
-
 class TestFirefoxQuantumPageRedirect(TestCase):
     @patch('bedrock.firefox.views.switch', Mock(return_value=False))
     def test_quantum_pre_57(self):

--- a/bedrock/firefox/urls.py
+++ b/bedrock/firefox/urls.py
@@ -75,7 +75,7 @@ urlpatterns = (
         views.FirefoxProductIOSView.as_view(),
         name='firefox.ios'),
     url(r'^firefox/ios/testflight', views.ios_testflight, name='firefox.ios.testflight'),
-    url(r'^firefox/mobile/$', views.mobile, name='firefox.mobile'),
+    page('firefox/mobile', 'firefox/mobile.html'),
     page('firefox/mobile-download', 'firefox/mobile-download.html'),
     page('firefox/mobile-download/desktop', 'firefox/mobile-download-desktop.html'),
     url('^firefox/send-to-device-post/$', views.send_to_device_ajax,

--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -11,7 +11,7 @@ from time import time
 from urlparse import urlparse
 
 from django.conf import settings
-from django.http import (Http404, HttpResponseRedirect, HttpResponsePermanentRedirect)
+from django.http import (Http404, HttpResponsePermanentRedirect)
 from django.utils.cache import patch_response_headers
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_POST, require_GET
@@ -876,13 +876,6 @@ def sync_page(request):
         template = 'firefox/features/sync.html'
 
     return l10n_utils.render(request, template)
-
-
-def mobile(request):
-    if not switch('firefox-57-release'):
-        return HttpResponseRedirect(reverse('firefox.android.index'))
-    else:
-        return l10n_utils.render(request, 'firefox/mobile.html')
 
 
 def quantum(request):

--- a/tests/functional/firefox/test_mobile.py
+++ b/tests/functional/firefox/test_mobile.py
@@ -1,0 +1,71 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import pytest
+
+from selenium.common.exceptions import TimeoutException
+from pages.firefox.mobile import FirefoxMobilePage
+
+
+@pytest.mark.nondestructive
+def test_get_firefox_send_to_device_success(base_url, selenium):
+    page = FirefoxMobilePage(selenium, base_url).open()
+    modal = page.click_get_firefox_header_button()
+    assert modal.is_displayed
+    assert not page.is_firefox_qr_code_displayed
+    send_to_device = page.send_to_device
+    send_to_device.type_email('success@example.com')
+    send_to_device.click_send()
+    assert send_to_device.send_successful
+    modal.close()
+
+
+@pytest.mark.nondestructive
+def test_get_firefox_send_to_device_fails_when_missing_required_fields(base_url, selenium):
+    page = FirefoxMobilePage(selenium, base_url).open()
+    modal = page.click_get_firefox_header_button()
+    assert modal.is_displayed
+    with pytest.raises(TimeoutException):
+        page.send_to_device.click_send()
+
+
+@pytest.mark.nondestructive
+def test_get_firefox_qr_code_locale(base_url, selenium):
+    page = FirefoxMobilePage(selenium, base_url, locale='it').open()
+    modal = page.click_get_firefox_header_button()
+    assert modal.is_displayed
+    assert not page.send_to_device.is_displayed
+    assert page.is_firefox_qr_code_displayed
+    modal.close()
+
+
+@pytest.mark.smoke
+@pytest.mark.nondestructive
+def test_get_focus_header_button(base_url, selenium):
+    page = FirefoxMobilePage(selenium, base_url).open()
+    modal = page.click_get_focus_header_button()
+    assert modal.is_displayed
+    assert page.is_focus_qr_code_displayed
+    modal.close()
+
+
+@pytest.mark.smoke
+@pytest.mark.nondestructive
+def test_get_firefox_nav_button(base_url, selenium):
+    page = FirefoxMobilePage(selenium, base_url).open()
+    modal = page.click_get_firefox_nav_button()
+    assert modal.is_displayed
+    assert page.send_to_device.is_displayed
+    assert not page.is_firefox_qr_code_displayed
+    modal.close()
+
+
+@pytest.mark.smoke
+@pytest.mark.nondestructive
+def test_get_focus_nav_button(base_url, selenium):
+    page = FirefoxMobilePage(selenium, base_url).open()
+    modal = page.click_get_focus_nav_button()
+    assert modal.is_displayed
+    assert page.is_focus_qr_code_displayed
+    modal.close()

--- a/tests/pages/firefox/mobile.py
+++ b/tests/pages/firefox/mobile.py
@@ -1,0 +1,56 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from selenium.webdriver.common.by import By
+
+from pages.firefox.base import FirefoxBasePage
+from pages.regions.modal import Modal
+from pages.regions.send_to_device import SendToDevice
+
+
+class FirefoxMobilePage(FirefoxBasePage):
+
+    URL_TEMPLATE = '/{locale}/firefox/mobile/'
+
+    _get_firefox_header_button_locator = (By.CSS_SELECTOR, '#header-firefox .get-firefox')
+    _get_firefox_nav_button_locator = (By.CSS_SELECTOR, '#firefox-features .get-firefox')
+    _get_firefox_qr_code_locator = (By.CSS_SELECTOR, '#modal .desktop-download.firefox .qr-code-wrapper img')
+
+    _get_focus_header_button_locator = (By.CSS_SELECTOR, '#header-focus .get-focus')
+    _get_focus_nav_button_locator = (By.CSS_SELECTOR, '#focus-features .get-focus')
+    _get_focus_qr_code_locator = (By.CSS_SELECTOR, '#modal .desktop-download.focus .qr-code-wrapper img')
+
+    @property
+    def send_to_device(self):
+        return SendToDevice(self)
+
+    @property
+    def is_firefox_qr_code_displayed(self):
+        return self.is_element_displayed(*self._get_firefox_qr_code_locator)
+
+    @property
+    def is_focus_qr_code_displayed(self):
+        return self.is_element_displayed(*self._get_focus_qr_code_locator)
+
+    def open_modal(self, locator):
+        modal = Modal(self)
+        self.find_element(*locator).click()
+        self.wait.until(lambda s: modal.is_displayed)
+        return modal
+
+    def click_get_firefox_header_button(self):
+        self.scroll_element_into_view(*self._get_firefox_header_button_locator)
+        return self.open_modal(self._get_firefox_header_button_locator)
+
+    def click_get_focus_header_button(self):
+        self.scroll_element_into_view(*self._get_focus_header_button_locator)
+        return self.open_modal(self._get_focus_header_button_locator)
+
+    def click_get_firefox_nav_button(self):
+        self.scroll_element_into_view(*self._get_firefox_nav_button_locator)
+        return self.open_modal(self._get_firefox_nav_button_locator)
+
+    def click_get_focus_nav_button(self):
+        self.scroll_element_into_view(*self._get_focus_nav_button_locator)
+        return self.open_modal(self._get_focus_nav_button_locator)


### PR DESCRIPTION
## Description
- Adds functional tests for the main CTA states on `/firefox/mobile/`
- Removes switch/condtional view.

Note: 
- We're missing tests for android / ios platforms directly showing the mobile badges, because we don't currently have those platforms set up in our automation (future project?).
- I also started down the path of trying to test the features scroller link clicks, but this turned into a Selenium can o' worms from hell (because some browsers support `position: sticky;` and others don't). I gave in and decded just to concentrate on the main page CTA's.


## Issue / Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1416710
