### PR TITLE
[fix bug 1419125] Ensure string values in utmParamsFxA.

### DIFF
--- a/media/js/base/search-params.js
+++ b/media/js/base/search-params.js
@@ -81,5 +81,11 @@ _SearchParams.prototype.utmParamsFxA = function(pathname) {
 
     /* eslint-enable camelcase */
 
+    // ensure all values are strings, as no numeric values are allowed
+    // into UITour.showFirefoxAccounts
+    Object.keys(utms).forEach(function(key) {
+        utms[key] = utms[key].toString();
+    });
+
     return utms;
 };

--- a/tests/unit/spec/base/search-params.js
+++ b/tests/unit/spec/base/search-params.js
@@ -59,6 +59,15 @@ describe('search-params.js', function() {
             expect(utms.utm_content).toEqual('/firefox/sync/');
         });
 
+        it('should return an object of string utm_ values for FxA', function () {
+            var sp = new _SearchParams('utm_dude=lebowski&utm_strikes=10&source=getfirefox');
+            var utms = sp.utmParamsFxA('/es-ES/firefox/sync/');
+            expect(utms.utm_dude).toEqual('lebowski');
+            expect(utms.utm_strikes).not.toEqual(10);
+            expect(utms.utm_strikes).toEqual('10');
+            expect(utms.utm_content).toEqual('/firefox/sync/');
+        });
+
         it('should not override utm_campaign when set in URL', function () {
             var sp = new _SearchParams('utm_dude=lebowski&utm_campaign=bowling&source=getfirefox');
             var utms = sp.utmParamsFxA();


### PR DESCRIPTION
## Description

Forces all values in the object returned by `utmParamsFxA` to be strings, as `UITour.showFirefoxAccounts` fails if any values are numeric.

## Issue / Bugzilla link

https://bugzilla.mozilla.org/show_bug.cgi?id=1419125

## Testing

Ensure no regressions?
