### PR TITLE
[fix bug 1419110] Add blog link to global footer

### DIFF
--- a/bedrock/base/templates/includes/site-footer.html
+++ b/bedrock/base/templates/includes/site-footer.html
@@ -14,6 +14,7 @@
         </h5>
         <ul class="mozilla-links">
           <li><a href="{{ url('mozorg.about') }}" data-link-type="footer" data-link-name="About">{{ _('About') }}</a></li>
+          <li><a href="https://blog.mozilla.org/" data-link-type="footer" data-link-name="Blog">{{ _('Blog') }}</a></li>
           <li><a href="{{ url('mozorg.contact.contact-landing') }}" data-link-type="footer" data-link-name="Contact Us">{{ _('Contact Us') }}</a></li>
           <li><a href="{{ donate_url('footer') }}" class="donate" data-link-type="footer" data-link-name="Donate">{{ _('Donate') }}</a></li>
           <li><a href="https://wiki.mozilla.org/Webdev/GetInvolved/mozilla.org" data-link-type="footer" rel="nofollow" data-link-name="Contribute to this site">{{ _('Contribute to this site') }}</a></li>


### PR DESCRIPTION
## Description
Adds a link to the main blog in the global footer. 

@peiying2 The string "Blog" already seems to be in main.lang, I suspect because it appears in the global nav so I'm not sure how many locales have translated it so far. But if it's an older string we might already be really well covered and could merge this right away. If not, we can wrap it in a conditional.

## Issue / Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1419110
