### PR TITLE
Fix tag

### DIFF
--- a/bedrock/security/templates/security/bug-bounty/faq.html
+++ b/bedrock/security/templates/security/bug-bounty/faq.html
@@ -177,7 +177,7 @@
             a list of supported operating systems and hardware configurations see
             the system requirements for <a href="{{ url('firefox.sysreq') }}">Firefox</a> or
             <a href="{{ firefox_url('android', 'sysreq') }}">
-            Firefox for Android</a>/p>
+            Firefox for Android</a></p>
         </dd>
       </dl>
 


### PR DESCRIPTION
There is an errant </p> tag missing the < in the security FAQ page.