### PR TITLE
[fix bug 1419573] Only show 'Your Firefox is up to date' on /whatsnew if it's the latest version

### DIFF
--- a/bedrock/firefox/templates/firefox/whatsnew/fx54/whatsnew-54.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/fx54/whatsnew-54.html
@@ -47,8 +47,10 @@
           {# If user is in a locale with translated basket messages... #}
           {% if show_send_to_device %}
             {% if l10n_has_tag('fx53_whatsnew') %}
-              <h4 class="up-to-date"><span>{{ _('Your Firefox is up to date.') }}</span></h4>
-              <h2>{{ _('Now get on the go.') }}</h2>
+              <div class="up-to-date-messaging hidden">
+                <h4 class="up-to-date"><span>{{ _('Your Firefox is up to date.') }}</span></h4>
+                <h2>{{ _('Now get on the go.') }}</h2>
+              </div>
 
               {# L10n: Line break below for visual formatting only #}
               <h1>{{ _('Send Firefox to your phone<br> and unleash your Internet.') }}</h1>
@@ -61,8 +63,10 @@
           {# For users not in a locale with translated basket messages... #}
           {% else %}
             {% if l10n_has_tag('fx53_whatsnew') %}
-              <h4 class="up-to-date"><span>{{ _('Your Firefox is up to date.') }}</span></h4>
-              <h2>{{ _('Now get on the go.') }}</h2>
+              <div class="up-to-date-messaging hidden"></div>
+                <h4 class="up-to-date"><span>{{ _('Your Firefox is up to date.') }}</span></h4>
+                <h2>{{ _('Now get on the go.') }}</h2>
+              </div>
 
               <h1>{{ _('Download Firefox for your smartphone and tablet.') }}</h1>
             {% else %}

--- a/media/js/firefox/whatsnew/whatsnew-54.js
+++ b/media/js/firefox/whatsnew/whatsnew-54.js
@@ -12,4 +12,16 @@ if (typeof window.Mozilla === 'undefined') {
 
     var form = new Mozilla.SendToDevice();
     form.init();
+
+    var client = Mozilla.Client;
+
+    // bug 1419573 - only show "Your Firefox is up to date" if it's the latest version.
+    if (client.isFirefoxDesktop) {
+        client.getFirefoxDetails(function(data) {
+            if (data.isUpToDate) {
+                document.querySelector('.up-to-date-messaging').classList.remove('hidden');
+            }
+        });
+    }
+
 })(window.jQuery, window.Mozilla);


### PR DESCRIPTION
## Description
- This fixes an issue on `/whatsnew` when updating from 56.0 -> 56.0.1 -> 57.0, where the page for 56.0.1 says Firefox is up-to-date (which isn't technically true).

URL: `/firefox/56.0.1/whatsnew/?oldversion=56.0`

## Issue / Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1419573

## Testing
- Make sure the message does not display using on outdated version of Firefox.