### PR TITLE
[fix bug 1416068] Add Dev Playground Links to DevEdition Onboarding Pages

### DIFF
--- a/bedrock/firefox/templates/firefox/developer-quantum-firstrun.html
+++ b/bedrock/firefox/templates/firefox/developer-quantum-firstrun.html
@@ -66,7 +66,7 @@
         <h2 class="section-title"><span>{{ _('New Tools') }}</span></h2>
 
         <div class="section-body">
-          <a href="http://firefox-dev.tools/" rel="external">
+          <a href="https://mozilladevelopers.github.io/playground/debugger/" rel="external">
             <h3 id="devtools" class="body-title">{{ _('Firefox DevTools') }}</h3>
 
             <img class="hero-image" src="{{ static('img/firefox/products/developer/quantum/hero-debugger-ani.gif') }}" alt="{% if l10n_has_tag('quantum-firstrun-whatsnew') %}{{ _('Learn more about Firefox developer tools') }}{% endif %}">
@@ -86,6 +86,7 @@
             {% endtrans %}
           {% endif %}
           </p>
+          <a class="more" rel="external" href="https://mozilladevelopers.github.io/playground/debugger/">{{ _('Learn more') }}</a>
         </div>
       </div>
 
@@ -93,7 +94,7 @@
         <h2 class="section-title"><span>{{ _('Innovative Features') }}</span></h2>
 
         <div class="section-body">
-          <a href="https://mozilladevelopers.github.io/playground/" rel="external">
+          <a href="https://mozilladevelopers.github.io/playground/css-grid/" rel="external">
             <h3 id="cssgrid" class="body-title">{{ _('Master CSS Grid') }}</h3>
 
             <img class="hero-image" src="{{ static('img/firefox/products/developer/quantum/hero-cssgrid-ani.gif') }}" alt="{% if l10n_has_tag('quantum-firstrun-whatsnew') %}{{ _('Learn more about CSS Grid') }}{% endif %}">
@@ -105,6 +106,8 @@
             visualize the grid, display associated area names, preview
             transformations on the grid and much more.
           {% endtrans %}
+          </p>
+          <a class="more" rel="external" href="https://mozilladevelopers.github.io/playground/css-grid/">{{ _('Learn more') }}</a>
         </div>
       </div>
     </div>

--- a/bedrock/firefox/templates/firefox/developer-quantum-whatsnew.html
+++ b/bedrock/firefox/templates/firefox/developer-quantum-whatsnew.html
@@ -66,7 +66,7 @@
         <h2 class="section-title"><span>{{ _('New Tools') }}</span></h2>
 
         <div class="section-body">
-          <a href="http://firefox-dev.tools/" rel="external">
+          <a href="https://mozilladevelopers.github.io/playground/debugger/" rel="external">
             <h3 id="devtools" class="body-title">{{ _('Firefox DevTools') }}</h3>
 
             <img class="hero-image" src="{{ static('img/firefox/products/developer/quantum/hero-debugger-ani.gif') }}" alt="{% if l10n_has_tag('quantum-firstrun-whatsnew') %}{{ _('Learn more about Firefox developer tools') }}{% endif %}">
@@ -86,6 +86,7 @@
             {% endtrans %}
           {% endif %}
           </p>
+          <a class="more" rel="external" href="https://mozilladevelopers.github.io/playground/debugger/">{{ _('Learn more') }}</a>
         </div>
       </div>
 
@@ -93,7 +94,7 @@
         <h2 class="section-title"><span>{{ _('Innovative Features') }}</span></h2>
 
         <div class="section-body">
-          <a href="https://mozilladevelopers.github.io/playground/" rel="external">
+          <a href="https://mozilladevelopers.github.io/playground/css-grid/" rel="external">
             <h3 id="cssgrid" class="body-title">{{ _('Master CSS Grid') }}</h3>
 
             <img class="hero-image" src="{{ static('img/firefox/products/developer/quantum/hero-cssgrid-ani.gif') }}" alt="{% if l10n_has_tag('quantum-firstrun-whatsnew') %}{{ _('Learn more about CSS Grid') }}{% endif %}">
@@ -105,6 +106,8 @@
             visualize the grid, display associated area names, preview
             transformations on the grid and much more.
           {% endtrans %}
+          </p>
+          <a class="more" rel="external" href="https://mozilladevelopers.github.io/playground/css-grid/">{{ _('Learn more') }}</a>
         </div>
       </div>
     </div>

--- a/media/css/firefox/developer-quantum.scss
+++ b/media/css/firefox/developer-quantum.scss
@@ -269,8 +269,18 @@ $color-dev-mediumblue: #306efe;
         margin-bottom: 40px;
     }
 
+    .more {
+        @include trailing-arrow;
+
+        &:hover,
+        &:active,
+        &:focus {
+            text-decoration: underline;
+        }
+    }
+
     @media #{$mq-tablet} {
-        padding-bottom: 100px;
+        padding-bottom: 140px;
 
         &:before {
             @include background-size(3000px 140px);


### PR DESCRIPTION
## Description
Adds Dev Edition playground links to `/firefox/58.0a2/firstrun/` and `/firefox/58.0a2/whatsnew/`.

## Issue / Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1416068

## Testing
Check for copy/pasta errors?