### PR TITLE
[fix bug 1414326] Add Disconnect link to /firefox/mobile/ page

### DIFF
--- a/bedrock/firefox/templates/firefox/mobile.html
+++ b/bedrock/firefox/templates/firefox/mobile.html
@@ -157,6 +157,14 @@
                     </li>
                   </ol>
                 </div>{#--/.features-image-wrapper--#}
+
+                {% if l10n_has_tag('disconnect_link') %}
+                  <p class="disclaimer">
+                  {% trans url='https://disconnect.me/' %}
+                    Built-in tracking protection and block lists provided by <a href="{{ url }}">Disconnect</a>.
+                  {% endtrans %}
+                  </p>
+                {% endif %}
               </section>
 
               <section class="page-article-section feature-content" id="firefox-extensions" data-section="firefox" data-ga-label="firefox mobile - extensions">
@@ -247,6 +255,14 @@
                     </li>
                   </ol>
                 </div>{#--/.features-image-wrapper--#}
+
+                {% if l10n_has_tag('disconnect_link') %}
+                  <p class="disclaimer">
+                  {% trans url='https://disconnect.me/' %}
+                    Built-in tracking protection and block lists provided by <a href="{{ url }}">Disconnect</a>.
+                  {% endtrans %}
+                  </p>
+                {% endif %}
               </section>
 
               <section class="page-article-section feature-content" id="focus-speed" data-section="focus" data-ga-label="firefox focus - speed">

--- a/media/css/firefox/mobile.scss
+++ b/media/css/firefox/mobile.scss
@@ -464,6 +464,23 @@ html[dir="rtl"] {
             padding-top: 20px;
         }
 
+        .disclaimer {
+            @include font-size-small;
+
+            a:link,
+            a:visited {
+                color: $color-quantum-blue;
+                text-decoration: none;
+            }
+
+            a:hover,
+            a:active,
+            a:focus {
+                text-decoration: underline;
+            }
+
+        }
+
         &:last-child {
             padding-bottom: 20px;
         }


### PR DESCRIPTION
## Description
- Adds disclaimer & link to Disconnect on the privacy sections of `/firefox/mobile/`

## Issue / Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1414326

## Testing
- Check for copy/pasta errors?
