### PR TITLE
feat(fxa): Add the email-first experiment to the firstrun page

### DIFF
--- a/bedrock/firefox/templates/firefox/firstrun/email-first-experiment/index-a.html
+++ b/bedrock/firefox/templates/firefox/firstrun/email-first-experiment/index-a.html
@@ -1,0 +1,5 @@
+{% extends "firefox/firstrun/firstrun_quantum.html" %}
+
+{% block iframe %}
+  <iframe id="fxa" scrolling="no" data-src="{{ settings.FXA_IFRAME_SRC }}signin?utm_campaign=fxa-embedded-form&amp;utm_medium=referral&amp;utm_source=firstrun-login&amp;utm_content=fx-{{ version }}&amp;entrypoint=firstrun&amp;service=sync&amp;context=iframe&amp;style=chromeless&amp;haltAfterSignIn=true"></iframe>
+{% endblock %}

--- a/bedrock/firefox/templates/firefox/firstrun/email-first-experiment/index-b.html
+++ b/bedrock/firefox/templates/firefox/firstrun/email-first-experiment/index-b.html
@@ -1,0 +1,13 @@
+{% extends "firefox/firstrun/firstrun_quantum.html" %}
+
+{% block fxa_title %}
+  {{ _('Take Firefox with You') }}
+{% endblock %}
+
+{% block fxa_content %}
+  {{ _('Get your bookmarks, history, passwords and other settings on all your devices.') }}
+{% endblock %}
+
+{% block iframe %}
+  <iframe class="treatment" id="fxa" scrolling="no" data-src="{{ settings.FXA_IFRAME_SRC }}?action=email&amp;utm_campaign=fxa-embedded-form&amp;utm_medium=referral&amp;utm_source=firstrun-emailfirst&amp;utm_content=fx-{{ version }}&amp;entrypoint=firstrun&amp;service=sync&amp;context=iframe&amp;style=chromeless&amp;haltAfterSignIn=true"></iframe>
+{% endblock %}

--- a/bedrock/firefox/templates/firefox/firstrun/firstrun_quantum.html
+++ b/bedrock/firefox/templates/firefox/firstrun/firstrun_quantum.html
@@ -20,6 +20,12 @@
   {% javascript 'firefox_firstrun_quantum' %}
 {% endblock %}
 
+{% block experiments %}
+  {% if switch('experiment_firstrun_email_first', ['en-US']) %}
+    {% javascript 'experiment_firstrun_email_first' %}
+  {% endif %}
+{% endblock %}
+
 {% block global_nav %}{% endblock %}
 {% block site_header %}{% endblock %}
 
@@ -90,12 +96,14 @@
     <div class="fxaccounts-container">
       <div id="left-divider">
         <div id="firefox-logo"></div>
-        <h1 id="title">{{_('Already using Firefox?')}}</h1>
-        <p class="content">{{_('Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.')}}</p>
+        <h1 id="title">{% block fxa_title %}{{_('Already using Firefox?')}}{% endblock %}</h1>
+        <p class="content">{% block fxa_content %}{{_('Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.')}}{% endblock %}</p>
         <a href="{{ url('firefox.features.sync') }}" target="_blank">{{_('Learn more about Firefox Accounts')}}</a>
       </div>
       <div class="fxaccounts" id="fxa-iframe-config" data-host="{{ settings.FXA_IFRAME_SRC }}" data-mozillaonline-host="{{ settings.FXA_IFRAME_SRC_MOZILLAONLINE }}">
-        <iframe id="fxa" scrolling="no" data-src="{{ settings.FXA_IFRAME_SRC }}signin?utm_campaign=fxa-embedded-form&amp;utm_medium=referral&amp;utm_source={{ utm_source }}&amp;utm_content=fx-{{ version }}&amp;entrypoint=firstrun&amp;service=sync&amp;context=iframe&amp;style=chromeless&amp;haltAfterSignIn=true"></iframe>
+        {% block iframe %}
+          <iframe id="fxa" scrolling="no" data-src="{{ settings.FXA_IFRAME_SRC }}signin?utm_campaign=fxa-embedded-form&amp;utm_medium=referral&amp;utm_source={{ utm_source }}&amp;utm_content=fx-{{ version }}&amp;entrypoint=firstrun&amp;service=sync&amp;context=iframe&amp;style=chromeless&amp;haltAfterSignIn=true"></iframe>
+        {% endblock %}
         <button id="skip-button">{{_('Skip this step')}}</button>
       </div>
     </div>

--- a/bedrock/firefox/tests/test_base.py
+++ b/bedrock/firefox/tests/test_base.py
@@ -329,6 +329,22 @@ class TestFirstRun(TestCase):
         template = render_mock.call_args[0][1]
         eq_(template, ['firefox/firstrun/firstrun_quantum.html'])
 
+    @override_settings(DEV=True)
+    def test_fx_firstrun_57_0_email_first_control(self, render_mock):
+        """Should use 57 quantum firstrun email-first control group template"""
+        req = self.rf.get('/en-US/firefox/firstrun/?v=a')
+        self.view(req, version='57.0')
+        template = render_mock.call_args[0][1]
+        eq_(template, ['firefox/firstrun/email-first-experiment/index-a.html'])
+
+    @override_settings(DEV=True)
+    def test_fx_firstrun_57_0_email_first_treatment(self, render_mock):
+        """Should use 57 quantum firstrun email-first treatment group template"""
+        req = self.rf.get('/en-US/firefox/firstrun/?v=b')
+        self.view(req, version='57.0')
+        template = render_mock.call_args[0][1]
+        eq_(template, ['firefox/firstrun/email-first-experiment/index-b.html'])
+
     # start cliqz funnelcake tests (bug 1392855)
 
     @override_settings(DEV=True)

--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -398,7 +398,11 @@ class FirstrunView(l10n_utils.LangFilesMixin, TemplateView):
         elif show_56_cliqz_firstrun(locale, version, f):
             template = 'firefox/firstrun/cliqz-funnelcake-119-122.html'
         elif show_57_firstrun(version):
-            template = 'firefox/firstrun/firstrun_quantum.html'
+            variant = self.request.GET.get('v', None)
+            if locale == 'en-US' and variant in ['a', 'b']:
+                template = 'firefox/firstrun/email-first-experiment/index-{0}.html'.format(variant)
+            else:
+                template = 'firefox/firstrun/firstrun_quantum.html'
         elif show_40_firstrun(version):
             template = 'firefox/firstrun/index.html'
         elif show_38_0_5_firstrun(version):

--- a/bedrock/settings/static_media.py
+++ b/bedrock/settings/static_media.py
@@ -1267,6 +1267,13 @@ PIPELINE_JS = {
         ),
         'output_filename': 'js/firefox_firstrun_quantum-bundle.js',
     },
+    'experiment_firstrun_email_first': {
+        'source_filenames': (
+            'js/base/mozilla-traffic-cop.js',
+            'js/firefox/firstrun/experiment-firstrun-email-first.js',
+        ),
+        'output_filename': 'js/firefox_firstrun_quantum-email_first_experiment-bundle.js',
+    },
     'firefox_firstrun_cliqz_funnelcake': {
         'source_filenames': (
             'js/firefox/firstrun/firstrun-cliqz-funnelcake.js',

--- a/media/css/firefox/firstrun/firstrun_quantum.less
+++ b/media/css/firefox/firstrun/firstrun_quantum.less
@@ -135,6 +135,13 @@ body {
     border: none;
     position: relative;
     width: 318px;
+
+    // Bug 1405822: Ensures the iframe + skip button
+    // is never smaller than the text on the left hand side.
+    min-height: 321px;
+    &.treatment {
+        min-height: 220px;
+    }
 }
 
 #fxa-iframe-config {

--- a/media/js/firefox/firstrun/experiment-firstrun-email-first.js
+++ b/media/js/firefox/firstrun/experiment-firstrun-email-first.js
@@ -1,0 +1,25 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+(function() {
+    'use strict';
+
+    /**
+     * An experiment to show FxA's "email-first" flow where
+     * the user first enters their email and then /signin
+     * or /signup is displayed depending on whether the
+     * account exists.
+     *
+     * 5% go to each bucket, 10% total.
+     */
+    var cop = new Mozilla.TrafficCop({
+        id: 'experiment_firstrun_email_first',
+        variations: {
+            'v=a': 5,  // control
+            'v=b': 5   // treatment - email first
+        }
+    });
+
+    cop.init();
+})(window.Mozilla);

--- a/media/js/firefox/firstrun/firstrun_quantum.js
+++ b/media/js/firefox/firstrun/firstrun_quantum.js
@@ -18,6 +18,7 @@
         scene.dataset.animate = 'true';
         var hideOrShowSkipButton = function (data) {
             switch(data.data.url) {
+            case '':
             case 'signin':
             case 'signup':
             case 'reset_password':


### PR DESCRIPTION
@alexgibson - here's the WIP I mentioned in bugzilla.

## Description

Add the FxA email-first experiment to the quantum firstrun page.

## Issue / Bugzilla link

https://bugzilla.mozilla.org/show_bug.cgi?id=1405822
https://docs.google.com/document/d/1seUQEXOR-JGD6ff77iAP8lzDjW-BPengXugUzo-p2UQ

## Testing

I have yet to add tests, and have lots of questions.

* Are `a` and `b` typical names for a variation? I see a combination of `a`, `b`, and `1`, `2`, `3`, etc.
* When an A/B test changes copy, do you use a single template for both variants or create separate templates? I went with a single template and if statements to control which copy is displayed.
* The [way I set the template context](https://github.com/mozilla/bedrock/compare/master...shane-tomlinson:fxa-email-first-experiment?expand=1#diff-784e0d4de42af29595e70315a6be5337R422) seems like it should be extracted, but I'm not sure how you usually handle that.
* Since the A/B test is limited to en-US, do I need to surround the treatment group text with  `_('')`
* If the new strings should be translated now, is there a big string table or are they extracted from the templates?
* I have a content-server fix that reduces the large gap between the FxA submit button and the "submit" button. This shrinks the iframe quite a bit and makes the box appear to be too high. Would it be alright to use flexbox to vertically center the iframe?

fixes mozilla/fxa-bugzilla-mirror#381