### PR TITLE
[bug 1419573] Fix up to date message for non send-to-device /whatsnew locales

### DIFF
--- a/bedrock/firefox/templates/firefox/whatsnew/fx54/whatsnew-54.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/fx54/whatsnew-54.html
@@ -63,7 +63,7 @@
           {# For users not in a locale with translated basket messages... #}
           {% else %}
             {% if l10n_has_tag('fx53_whatsnew') %}
-              <div class="up-to-date-messaging hidden"></div>
+              <div class="up-to-date-messaging hidden">
                 <h4 class="up-to-date"><span>{{ _('Your Firefox is up to date.') }}</span></h4>
                 <h2>{{ _('Now get on the go.') }}</h2>
               </div>
@@ -103,7 +103,5 @@
 {% block email_form %}{% endblock %}
 
 {% block js %}
-  {% if show_send_to_device %}
-    {% javascript 'firefox_whatsnew_54' %}
-  {% endif %}
+  {% javascript 'firefox_whatsnew_54' %}
 {% endblock %}

--- a/media/js/firefox/whatsnew/whatsnew-54.js
+++ b/media/js/firefox/whatsnew/whatsnew-54.js
@@ -10,8 +10,12 @@ if (typeof window.Mozilla === 'undefined') {
 (function($, Mozilla) {
     'use strict';
 
-    var form = new Mozilla.SendToDevice();
-    form.init();
+    var sendTo = document.getElementById('send-to-device');
+
+    if (sendTo) {
+        var form = new Mozilla.SendToDevice();
+        form.init();
+    }
 
     var client = Mozilla.Client;
 


### PR DESCRIPTION
## Description
Fixes 2 errors I made in #5312 :/
- Removes stray closing `</div>`
- Ensure the JS is included for all locales (it was previously only included in the template if send-to-device was supported).

## Issue / Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1419573

## Testing
- Make sure conditional messaging works for locales such as `it`.
- Make sure no other regressions?
