### PR TITLE
Remove OpenHatch

### DIFF
--- a/bedrock/mozorg/templates/mozorg/internet-health/open-innovation.html
+++ b/bedrock/mozorg/templates/mozorg/internet-health/open-innovation.html
@@ -126,10 +126,15 @@
             <li>
               <h4>{{ _('Contribute to a project') }}</h4>
               <p>
-              {% trans contribute=url('mozorg.contribute.index'),
-              %}
-                Contribute to an existing open source project. Become a <a href="{{ contribute }}">Mozillian!</a>
-              {% endtrans %}
+              {% if l10n_has_tag('open-innovation-update-20171130') %}
+                  {% trans contribute=url('mozorg.contribute.index') %}
+                     Contribute to an existing open source project. Become a <a href="{{ contribute }}">Mozillian!</a>
+                  {% endtrans %}
+              {% else %}
+                  {% trans contribute=url('mozorg.contribute.index'),
+                           open_hatch='https://openhatch.org/' %}
+                     Contribute to an existing open source project. Become a <a href="{{ contribute }}">Mozillian!</a> Or use <a href="{{ open_hatch }}">OpenHatch</a> to match your skillset to a project.
+              {% endif %}
               </p>
             </li>
             <li>

--- a/bedrock/mozorg/templates/mozorg/internet-health/open-innovation.html
+++ b/bedrock/mozorg/templates/mozorg/internet-health/open-innovation.html
@@ -134,6 +134,7 @@
                   {% trans contribute=url('mozorg.contribute.index'),
                            open_hatch='https://openhatch.org/' %}
                      Contribute to an existing open source project. Become a <a href="{{ contribute }}">Mozillian!</a> Or use <a href="{{ open_hatch }}">OpenHatch</a> to match your skillset to a project.
+                  {% endtrans %}
               {% endif %}
               </p>
             </li>

--- a/bedrock/mozorg/templates/mozorg/internet-health/open-innovation.html
+++ b/bedrock/mozorg/templates/mozorg/internet-health/open-innovation.html
@@ -127,10 +127,8 @@
               <h4>{{ _('Contribute to a project') }}</h4>
               <p>
               {% trans contribute=url('mozorg.contribute.index'),
-                       open_hatch='https://openhatch.org/'
               %}
                 Contribute to an existing open source project. Become a <a href="{{ contribute }}">Mozillian!</a>
-                Or use <a href="{{ open_hatch }}">OpenHatch</a> to match your skillset to a project.
               {% endtrans %}
               </p>
             </li>


### PR DESCRIPTION
## Description
OpenHatch has [closed its doors](https://blog.openhatch.org/2017/celebrating-our-successes-and-winding-down-as-an-organization/) and is no longer providing assistance to new contributors. Removing it from the page lest we lead new contribs down a blind alley.

## Issue / Bugzilla link
None. Just something I spotted while reading the Open Innovation page.

## Testing
