### PR TITLE
Update community data via git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ bedrock/externalfiles/files_cache
 mofo_security_advisories
 release_notes
 product_details_json
+community_data
 supervisord.log
 .idea
 .env

--- a/bedrock/externalfiles/management/commands/update_externalfiles.py
+++ b/bedrock/externalfiles/management/commands/update_externalfiles.py
@@ -1,58 +1,45 @@
-from optparse import make_option
+from __future__ import print_function
 
 from django.conf import settings
 from django.core.management.base import BaseCommand, CommandError
-from django.utils.module_loading import import_by_path
+from django.utils.module_loading import import_string
 
-
-DEFAULT_CLASS = 'bedrock.externalfiles.ExternalFile'
+from bedrock.utils.git import GitRepo
 
 
 class Command(BaseCommand):
-    args = '[<file_id ...>]'
-    help = 'Update data files from the web. Specify file IDs or none to update all.'
-    option_list = BaseCommand.option_list + (
-        make_option('--force',
-                    action='store_true',
-                    dest='force',
-                    default=False,
-                    help='Force updating files even if up-to-date.'),
-        make_option('--quiet',
-                    action='store_true',
-                    dest='quiet',
-                    default=False,
-                    help='Do not print output to stdout.'),
-        make_option('--status',
-                    action='store_true',
-                    dest='status',
-                    default=False,
-                    help='Print only a final status to stdout. Mostly for scripts.')
-    )
+    def add_arguments(self, parser):
+        parser.add_argument('-q', '--quiet', action='store_true', dest='quiet', default=False,
+                            help='If no error occurs, swallow all output.'),
+        parser.add_argument('-f', '--force', action='store_true', dest='force', default=False,
+                            help='Load the data even if nothing new from git.'),
+
+    def output(self, msg):
+        if not self.quiet:
+            print(msg)
 
     def handle(self, *args, **options):
-        file_ids = args or settings.EXTERNAL_FILES.keys()
-        updated = False
+        self.quiet = options['quiet']
+        repo = GitRepo(settings.EXTERNAL_FILES_PATH, settings.EXTERNAL_FILES_REPO,
+                       branch_name=settings.EXTERNAL_FILES_BRANCH)
+        self.output('Updating git repo')
+        repo.update()
+        if not (options['force'] or repo.has_changes()):
+            self.output('No community data updates')
+            return
 
-        def printout(msg, ending=None):
-            if not (options['quiet'] or options['status']):
-                self.stdout.write(msg, ending=ending)
+        self.output('Loading community data into database')
 
-        for fid in file_ids:
+        for fid, finfo in settings.EXTERNAL_FILES.items():
+            klass = import_string(finfo['type'])
             try:
-                finfo = settings.EXTERNAL_FILES[fid]
-            except KeyError:
-                raise CommandError('No external file configuration for ' + fid)
-            klass = import_by_path(finfo.get('type', DEFAULT_CLASS))
-            printout('updating {0}... '.format(fid), ending='')
-            result = klass(fid).update(options['force'])
-            if result is None:
-                printout('already up-to-date')
-            else:
-                updated = True
-                printout('done')
+                klass(fid).update()
+            except ValueError as e:
+                raise CommandError(str(e))
 
-        if options['status']:
-            if updated:
-                self.stdout.write('updated')
-            else:
-                self.stdout.write('up-to-date')
+        self.output('Community data successfully loaded')
+
+        repo.set_db_latest()
+
+        self.output('Saved latest git repo state to database')
+        self.output('Done!')

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -685,17 +685,17 @@ EMAIL_HOST_PASSWORD = config('EMAIL_HOST_PASSWORD', default='')
 # Google Analytics
 GA_ACCOUNT_CODE = ''
 
-# Files from The Web[tm]
+EXTERNAL_FILES_PATH = config('EXTERNAL_FILES_PATH', default=path('community_data'))
+EXTERNAL_FILES_BRANCH = config('EXTERNAL_FILES_BRANCH', default='master')
+EXTERNAL_FILES_REPO = config('EXTERNAL_FILES_REPO', default='https://github.com/mozilla/community-data.git')
 EXTERNAL_FILES = {
     'credits': {
-        'url': 'https://raw.githubusercontent.com/mozilla/community-data/master/credits/names.csv',
         'type': 'bedrock.mozorg.credits.CreditsFile',
-        'name': 'credits.csv',
+        'name': 'credits/names.csv',
     },
     'forums': {
-        'url': 'https://raw.githubusercontent.com/mozilla/community-data/master/forums/raw-ng-list.txt',
         'type': 'bedrock.mozorg.forums.ForumsFile',
-        'name': 'forums.txt',
+        'name': 'forums/raw-ng-list.txt',
     },
 }
 


### PR DESCRIPTION
Converts community data (external files) updates to use git just like we do for release notes and security advisories. These files are already in a git repo together.

The way it's currently done is inefficient and tends to change the database more often than is necessary.