### PR TITLE
[fix bug 1422042] Add Optimizely block to new Firefox home page.

### DIFF
--- a/bedrock/firefox/templates/firefox/hub/home-quantum.html
+++ b/bedrock/firefox/templates/firefox/hub/home-quantum.html
@@ -15,6 +15,12 @@
 
 {% block body_id %}firefox-home{% endblock %}
 
+{% block optimizely %}
+  {% if switch('firefox-home-optimizely', ['en-US']) %}
+    {% include 'includes/optimizely.html' %}
+  {% endif %}
+{% endblock %}
+
 {% block content %}
 {% include 'firefox/includes/hub/sub-nav.html' %}
 <main role="main">


### PR DESCRIPTION
## Description

Adds the Optimizely block to the new Firefox home page.

## Issue / Bugzilla link

https://bugzilla.mozilla.org/show_bug.cgi?id=1422042

## Testing

Make sure no copy pasta?