### PR TITLE
Web bug bounty related updates

### DIFF
--- a/bedrock/security/templates/security/bug-bounty/web-eligible-sites.html
+++ b/bedrock/security/templates/security/bug-bounty/web-eligible-sites.html
@@ -138,6 +138,7 @@
         <li>login.mozilla.com</li>
         <li>mana.mozilla.org</li>
         <li>phonebook.mozilla.org</li>
+        <li>pto.mozilla.org</li>
       </ul>
 
       <h3>Observatory</h3>

--- a/bedrock/security/templates/security/bug-bounty/web-hall-of-fame.html
+++ b/bedrock/security/templates/security/bug-bounty/web-hall-of-fame.html
@@ -35,8 +35,19 @@
       <section id="year-2017">
         <h3 data-accordion-role="tab">{{ _('2017') }}</h3>
         <div data-accordion-role="tabpanel">
+          <h4>3rd Quarter 2017</h4>
+          <ul>
+            <li>Ed</li>
+            <li><a href="https://twitter.com/securityshell">Avram Marius Gabriel</a></li>
+            <li><a href="https://www.linkedin.com/in/tyler-hawkins-149ba2b2/">Tyler Hawkins</a></li>
+            <li><a href="https://twitter.com/yendrzei">Jędrzej Krysztofiak</a></li>
+            <li>michon2</li>
+            <li><a href="http://www.pareshparmar.com/">Paresh Parmar</a></li>
+            <li><a href="https://www.facebook.com/shukla304">Vishal Shukla</a></li>
+          </ul>
           <h4>2nd Quarter 2017</h4>
           <ul>
+            <li>Dodi Ara</li>
             <li><a href="https://twitter.com/Black2Fan">Sergey Bobrov</a></li>
             <li>Aam Chandra</li>
             <li><a href="https://twitter.com/cecleandro">Leandro Chaves</a></li>
@@ -52,11 +63,10 @@
           <ul>
             <li><a href="https://detectify.com/">Fredrik Nordberg Almroth</a></li>
             <li>Mario Gomes</li>
-            <li><a href="https://www.linkedin.com/in/tyler-hawkins-149ba2b2/">Tyler Hawkins</a></li>
             <li><a href="https://twitter.com/knowledge_2014">Akita (Lucas Moreira)</a></li>
             <li>Muhammad Hassham Nagori</li>
             <li>Wladimir Palant</li>
-            <li><a href="https://twitter.com/Paresh_parmar1">Paresh Parmar</a></li>
+            <li><a href="http://www.pareshparmar.com/">Paresh Parmar</a></li>
             <li><a href="https://twitter.com/SecurityYasin">Yasin Soliman</a></li>
           </ul>
         </div>


### PR DESCRIPTION
## Description
- Update the list of web bug bounty sites to add pto.mozilla.org
- Update the hall of fame for Q3 2017, update some URLs for previous hall-of-famers

## Testing
None, small HTML update.