### PR TITLE
[fix bug 1425865] Add redirects for Fire TV

### DIFF
--- a/bedrock/firefox/redirects.py
+++ b/bedrock/firefox/redirects.py
@@ -567,4 +567,9 @@ redirectpatterns = (
 
     # bug 1421584
     redirect(r'^firefox/organizations/faq/?$', 'firefox.organizations.organizations'),
+
+    # bug 1425865 - Amazon Fire TV goes to SUMO until we have a product page.
+    redirect(r'^firefox/fire-tv/?$',
+        'https://support.mozilla.org/products/firefox-fire-tv/',
+        permanent=False),
 )

--- a/bedrock/privacy/redirects.py
+++ b/bedrock/privacy/redirects.py
@@ -17,4 +17,7 @@ redirectpatterns = (
 
     # bug 1394042 - Firefox Cloud Services redirect to Fx
     redirect(r'^privacy/firefox-cloud/?$', 'privacy.notices.firefox'),
+
+    # bug 1425865 - Firefox for Amazon Fire TV uses Firefox Focus
+    redirect(r'^privacy/firefox-fire-tv/?$', 'privacy.notices.firefox-focus'),
 )

--- a/tests/redirects/map_globalconf.py
+++ b/tests/redirects/map_globalconf.py
@@ -1198,4 +1198,8 @@ URLS = flatten((
 
     # bug 1421584
     url_test('/firefox/organizations/faq/', '/firefox/organizations/'),
+
+    # bug 1425865
+    url_test('/privacy/firefox-fire-tv/', '/privacy/firefox-focus/'),
+    url_test('/firefox/fire-tv/', 'https://support.mozilla.org/products/firefox-fire-tv/', status_code=302),
 ))


### PR DESCRIPTION
## Description
Adds a 301 permanent redirect for `/privacy/firefox-fire-tv/` and 302 temporary redirect for `/firefox/fire-tv/` (actual product page forthcoming).

We need to get these redirects live by EOD Dec 18 (today).

## Issue / Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1425865
