### PR TITLE
Avoid testing all download URLs more than once per deployment

### DIFF
--- a/docker/bin/run_integration_tests.sh
+++ b/docker/bin/run_integration_tests.sh
@@ -25,6 +25,10 @@ case $1 in
     PLATFORM="Windows 7"
     MARK_EXPRESSION="sanity and not headless"
     ;;
+  download)
+    DRIVER=
+    MARK_EXPRESSION=download
+    ;;
   headless)
     DRIVER=
     MARK_EXPRESSION=headless

--- a/jenkins/branches/master.yml
+++ b/jenkins/branches/master.yml
@@ -12,6 +12,7 @@ integration_tests:
   usw:
     - firefox
     - headless
+    - download
   tokyo:
     - headless
   frankfurt:

--- a/jenkins/branches/prod.yml
+++ b/jenkins/branches/prod.yml
@@ -13,6 +13,7 @@ apps:
 integration_tests:
   usw:
     - headless
+    - download
     - firefox
     - chrome
     - ie

--- a/jenkins/branches/run-integration-tests.yml
+++ b/jenkins/branches/run-integration-tests.yml
@@ -8,6 +8,7 @@ apps:
 integration_tests:
   usw:
     - headless
+    - download
     - firefox
     - chrome
     - ie

--- a/jenkins/utils.groovy
+++ b/jenkins/utils.groovy
@@ -63,7 +63,7 @@ def integrationTestJob(propFileName, appURL='') {
                               usernameVariable: 'SAUCELABS_USERNAME',
                               passwordVariable: 'SAUCELABS_API_KEY']]) {
                 withEnv(["BASE_URL=${appURL}"]) {
-                    retry(3) {
+                    retry(2) {
                         try {
                             sh testScript
                         }

--- a/tests/functional/test_download.py
+++ b/tests/functional/test_download.py
@@ -8,7 +8,7 @@ import requests
 
 
 def pytest_generate_tests(metafunc):
-    if 'not headless' in metafunc.config.option.markexpr:
+    if 'not download' in metafunc.config.option.markexpr:
         return  # test deslected by mark expression
     base_url = metafunc.config.option.base_url
     if not base_url:
@@ -35,7 +35,7 @@ def pytest_generate_tests(metafunc):
     metafunc.parametrize('url', argvalues)
 
 
-@pytest.mark.headless
+@pytest.mark.download
 @pytest.mark.nondestructive
 def test_download_links(url):
     r = requests.head(url, allow_redirects=True)

--- a/tests/functional/test_download_l10n.py
+++ b/tests/functional/test_download_l10n.py
@@ -8,7 +8,7 @@ import requests
 
 
 def pytest_generate_tests(metafunc):
-    if 'not headless' in metafunc.config.option.markexpr:
+    if 'not download' in metafunc.config.option.markexpr:
         return  # test deslected by mark expression
     base_url = metafunc.config.option.base_url
     if not base_url:
@@ -41,7 +41,7 @@ def pytest_generate_tests(metafunc):
     metafunc.parametrize('url', argvalues)
 
 
-@pytest.mark.headless
+@pytest.mark.download
 @pytest.mark.nondestructive
 def test_localized_download_links(url):
     r = requests.head(url, allow_redirects=True)


### PR DESCRIPTION
I'm not sure if this will help with our deployment woes or not, but it does seem inefficient at best to test every download URL on the site 6* per deployment. I'll explain:

The download tests find all download links on the various `*/all/` pages. That comes out to around 3,000 unique URLs, almost all of which point to bouncer (download.mozilla.org). That means that we're sending 3,000 requests to bouncer for each deployment, per app, per region. Since we deploy stage and prod to 3 regions during a prod deployment that comes out to 6 deployments and 18,000 requests. These are just `HEAD` requests, so the CDN isn't sending the download bytes, but it does seem wasteful to check those for every app in every region, especially since the checks are all coming from the Jenkins box. 