### PR TITLE
[bug 1422042] Add optimizely block to quantum scene2

### DIFF
--- a/bedrock/firefox/templates/firefox/new/quantum/scene2.html
+++ b/bedrock/firefox/templates/firefox/new/quantum/scene2.html
@@ -10,6 +10,12 @@
   <meta name="robots" content="noindex,follow">
 {% endblock %}
 
+{% block optimizely %}
+{% if switch('firefox-new-scene2-optimizely', ['en-US']) %}
+  {% include 'includes/optimizely.html' %}
+{% endif %}
+{% endblock %}
+
 {# All stylesheets are loaded in extrahead to serve legacy IE basic styles #}
 {% block extrahead %}
   {{ super() }}


### PR DESCRIPTION
## Description

Add optimizely block to quantum scene2 page so we can track downloads in Optimizely experiments.

## Issue / Bugzilla link

https://bugzilla.mozilla.org/show_bug.cgi?id=1422042

## Testing

### Functional

- [x] Optimizely block appears when `SWITCH_FIREFOX_NEW_SCENE2_OPTIMIZELY=on` 
- [x] Optimizely block does not appear when `SWITCH_FIREFOX_NEW_SCENE2_OPTIMIZELY=off`
- [x] Optimizely block does not appear when `SWITCH_FIREFOX_NEW_SCENE2_OPTIMIZELY` is missing from env


### Unit
```
(venv) bedrock$ py.test lib bedrock/firefox
<snip>
================================================ 278 passed, 1 skipped in 12.17 seconds ===============================================
```