### PR TITLE
[fix bug 1393035] Plugin check doesn't recognize nightly as FF

### DIFF
--- a/media/js/plugincheck/plugincheck.js
+++ b/media/js/plugincheck/plugincheck.js
@@ -10,9 +10,11 @@
 
     if (client.isFirefoxDesktop) {
         client.getFirefoxDetails(function(details) {
-            if (details.isUpToDate && details.channel === 'release') {
+            // set `strict` to `false`, so we only test against the major version number.
+            var isUpToDate = client._isFirefoxUpToDate(false, details.isESR, details.version);
+            if (isUpToDate) {
                 body.addClass('firefox-current');
-            } else if (!details.isUpToDate && details.channel === 'release') {
+            } else {
                 body.addClass('firefox-old');
             }
         });


### PR DESCRIPTION
## Description
- Fixes plugincheck to treat pre-release versions of Firefox as up-to-date.
- Also adjusts the logic to only check against the major version number.

## Issue / Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1393035#c4

## Testing
- Test pre-release versions of Firefox are considered as up-to-date.
- Test old versions are considered out of date.
- Test latest ESR is considered as up-to-date.
