### PR TITLE
Move link gathering out of test discovery for download tests

### DIFF
--- a/docker/bin/run_integration_tests.sh
+++ b/docker/bin/run_integration_tests.sh
@@ -3,7 +3,7 @@
 # $1 should be the properties name for this run
 # defaults
 DRIVER=SauceLabs
-MARK_EXPRESSION="not headless"
+MARK_EXPRESSION="not headless and not download"
 
 case $1 in
   chrome)


### PR DESCRIPTION
This may mean slower tests for download links, but shouldn't be much slower. Advantages are that it's much more simple, it has no chance of collecting a different number of tests at different times, and does not call out to the site for these pages even when those tests aren't going to run.