### PR TITLE
[fix bug 1426735] Disable native autocomplete on locale searches.

### DIFF
--- a/bedrock/base/templates/product-all-macros.html
+++ b/bedrock/base/templates/product-all-macros.html
@@ -10,6 +10,7 @@
              name="q"
              id="language-search-q"
              list="languages"
+             autocomplete="off"
              {% if query %}value="{{ query }}"{% endif %}>
       <datalist id="languages">
         {% for build in full_builds -%}


### PR DESCRIPTION
## Description

Stops locale search boxes from autocompleting terms from other sites/searches.

## Issue / Bugzilla link

https://bugzilla.mozilla.org/show_bug.cgi?id=1426735

## Testing

Make sure no regressions?