### PR TITLE
Follow up Bug 1421584 - Update ESR download page description

### DIFF
--- a/bedrock/firefox/templates/firefox/all.html
+++ b/bedrock/firefox/templates/firefox/all.html
@@ -26,6 +26,8 @@
     {{ _('Download %s in your language to experience the newest features and innovations in an unstable environment even before they go to Beta. Give us feedback that will determine what makes it to Final Release and help shape the future of Firefox.')|format(channel_label) }}
   {%- elif channel == 'nightly' -%}
     {{ _('Are you a power-user comfortable installing pre-alpha software? Install Nightly and help us improve Firefox quality, hunt crashes and regressions and test new features as they get coded!') }}
+  {%- elif channel == 'esr' and l10n_has_tag('esr_page_desc_bug1421584') -%}
+    {{ _('Firefox ESR is intended for system administrators who deploy and maintain the desktop environment in organizations such as schools, governments and businesses.') }}
   {%- elif channel == 'esr' -%}
     {{ _('Firefox ESR is intended for groups who deploy and maintain the desktop environment in large organizations. <a href="%s">Learn more.</a>')|format(url('firefox.organizations.organizations')) }}
   {%- else -%}
@@ -96,10 +98,16 @@
   {% endif -%}
 {% endblock %}
 
+{% block learn_more_url %}
+  {%- if channel == 'esr' and l10n_has_tag('esr_page_desc_bug1421584') -%}
+    {{ url('firefox.organizations.organizations') }}
+  {%- endif -%}
+{% endblock %}
+
 {% block content %}
   <header id="main-feature">
     <h1>{{ self.page_title()  }}</h1>
-    <h2>{{ self.page_desc() }}</h2>
+    <h2>{{ self.page_desc() }}{% if self.learn_more_url() %} <a href="{{ self.learn_more_url() }}">{{ _('Learn more') }}</a>{% endif %}</h2>
     {% if channel == 'nightly' %}
     <p class="warning">{{ _('<strong>Warning</strong>: Nightly is updated daily. It is most appropriate for core Mozilla contributors and early adopters, not regular users.') }}</p>
     {% endif %}


### PR DESCRIPTION
## Description

Revise the page description of the [Firefox ESR download page](https://www.mozilla.org/en-US/firefox/organizations/all/) which I forgot to update as part of my previous PR #5330. The new description excludes the "Learn more" link for easier l10n.

## Issue / Bugzilla link

[Bug 1421584 - Change ESR page content to make it clear that ESR is for sysadmins and mailing list subscription is optional](https://bugzilla.mozilla.org/show_bug.cgi?id=1421584)

## Testing

Just visit the page and make sure it has the new copy.