### PR TITLE
[fix bug 1427724] Link to /firefox/all/ on scene2 of /firefox/new/ should mention other platforms

### DIFF
--- a/bedrock/firefox/templates/firefox/new/scene2.html
+++ b/bedrock/firefox/templates/firefox/new/scene2.html
@@ -58,7 +58,13 @@
 </aside>
 
 <ul class="small-links">
-  <li><a href="{{ url('firefox.all') }}">{{_('Download in another language') }}</a></li>
+  <li><a href="{{ url('firefox.all') }}">
+    {% if l10n_has_tag('firefox_new_platform_link_text') %}
+      {{_('Download for other platforms & languages') }}
+    {% else %}
+      {{_('Download in another language') }}
+    {% endif %}
+  </a></li>
 </ul>
 {% endblock %}
 


### PR DESCRIPTION
## Description
- Updates link to `/firefox/all` on `/firefox/new/?scene=2` to mention platforms as well as languages. For context, see https://github.com/mozilla/bedrock/issues/5300.

## Issue / Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1427724

## Testing
- Page should display the new copy as expected when l10n tag is active.