### PR TITLE
Implement font-display: swap; to remove FOIT

### DIFF
--- a/docs/l10n.rst
+++ b/docs/l10n.rst
@@ -350,30 +350,35 @@ Here's an example of ``intl.css``:
     @font-face {
       font-family: X-LocaleSpecific-Light;
       font-weight: normal;
+      font-display: swap;
       src: local(mplus-2p-light), local(Meiryo);
     }
 
     @font-face {
       font-family: X-LocaleSpecific-Light;
       font-weight: bold;
+      font-display: swap;
       src: local(mplus-2p-medium), local(Meiryo-Bold);
     }
 
     @font-face {
       font-family: X-LocaleSpecific;
       font-weight: normal;
+      font-display: swap;
       src: local(mplus-2p-regular), local(Meiryo);
     }
 
     @font-face {
       font-family: X-LocaleSpecific;
       font-weight: bold;
+      font-display: swap;
       src: local(mplus-2p-bold), local(Meiryo-Bold);
     }
 
     @font-face {
       font-family: X-LocaleSpecific-Extrabold;
       font-weight: 800;
+      font-display: swap;
       src: local(mplus-2p-black), local(Meiryo-Bold);
     }
 

--- a/media/css/etc/firefox/retention/thank-you.scss
+++ b/media/css/etc/firefox/retention/thank-you.scss
@@ -15,24 +15,28 @@ html {
 
 @font-face {
     font-family: Antonio;
-    src: url('/media/fonts/fx-lifestyle/antonio-regular-webfont.woff2') format('woff2'),
-         url('/media/fonts/fx-lifestyle/antonio-regular-webfont.woff') format('woff');
     font-weight: normal;
     font-style: normal;
+    font-display: swap;
+    src: url('/media/fonts/fx-lifestyle/antonio-regular-webfont.woff2') format('woff2'),
+         url('/media/fonts/fx-lifestyle/antonio-regular-webfont.woff') format('woff');
 }
 
 @font-face {
     font-family: Antonio;
-    src: url('/media/fonts/fx-lifestyle/antonio-bold-webfont.woff2') format('woff2'),
-         url('/media/fonts/fx-lifestyle/antonio-bold-webfont.woff') format('woff');
     font-weight: 700;
     font-style: normal;
+    font-display: swap;
+    src: url('/media/fonts/fx-lifestyle/antonio-bold-webfont.woff2') format('woff2'),
+         url('/media/fonts/fx-lifestyle/antonio-bold-webfont.woff') format('woff');
+
 }
 
 @font-face {
     font-family: 'Open Sans';
     font-weight: 600;
     font-style: normal;
+    font-display: swap;
     src: url('/media/fonts/opensans-semibold.woff2') format('woff2'),
          url('/media/fonts/opensans-semibold.woff') format('woff');
 }

--- a/media/css/firefox/firstrun/firstrun.less
+++ b/media/css/firefox/firstrun/firstrun.less
@@ -2,18 +2,20 @@
 
 @font-face {
     font-family: 'Fira Sans Light';
-    src: url('/media/fonts/FiraSans-Light.woff2') format('woff2'),
-         url('/media/fonts/FiraSans-Light.woff') format('woff');
     font-weight: normal;
     font-style: normal;
+    font-display: swap;
+    src: url('/media/fonts/FiraSans-Light.woff2') format('woff2'),
+         url('/media/fonts/FiraSans-Light.woff') format('woff');
 }
 
 @font-face {
     font-family: 'Fira Sans Light';
-    src: url('/media/fonts/FiraSans-SemiBold.woff2') format('woff2'),
-         url('/media/fonts/FiraSans-SemiBold.woff') format('woff');
     font-weight: bold;
     font-style: normal;
+    font-display: swap;
+    src: url('/media/fonts/FiraSans-SemiBold.woff2') format('woff2'),
+         url('/media/fonts/FiraSans-SemiBold.woff') format('woff');
 }
 
 body {

--- a/media/css/firefox/firstrun/firstrun_quantum.less
+++ b/media/css/firefox/firstrun/firstrun_quantum.less
@@ -2,18 +2,20 @@
 
 @font-face {
     font-family: 'Fira Sans Light';
-    src: url('/media/fonts/FiraSans-Light.woff2') format('woff2'),
-         url('/media/fonts/FiraSans-Light.woff') format('woff');
     font-weight: normal;
     font-style: normal;
+    font-display: swap;
+    src: url('/media/fonts/FiraSans-Light.woff2') format('woff2'),
+         url('/media/fonts/FiraSans-Light.woff') format('woff');
 }
 
 @font-face {
     font-family: 'Fira Sans Light';
-    src: url('/media/fonts/FiraSans-SemiBold.woff2') format('woff2'),
-         url('/media/fonts/FiraSans-SemiBold.woff') format('woff');
     font-weight: bold;
     font-style: normal;
+    font-display: swap;
+    src: url('/media/fonts/FiraSans-SemiBold.woff2') format('woff2'),
+         url('/media/fonts/FiraSans-SemiBold.woff') format('woff');
 }
 
 :root {

--- a/media/css/firefox/new/batm.scss
+++ b/media/css/firefox/new/batm.scss
@@ -8,6 +8,7 @@
     font-family: 'Open Sans Light';
     font-weight: normal;
     font-style: normal;
+    font-display: swap;
     src: url('/media/fonts/opensans-light.woff2') format('woff2'),
          url('/media/fonts/opensans-light.woff') format('woff');
 }

--- a/media/css/firefox/new/fx-lifestyle/its-your-web.less
+++ b/media/css/firefox/new/fx-lifestyle/its-your-web.less
@@ -8,18 +8,20 @@
 
 @font-face {
     font-family: antonioregular;
-    src: url('/media/fonts/fx-lifestyle/antonio-regular-webfont.woff2') format('woff2'),
-         url('/media/fonts/fx-lifestyle/antonio-regular-webfont.woff') format('woff');
     font-weight: normal;
     font-style: normal;
+    font-display: swap;
+    src: url('/media/fonts/fx-lifestyle/antonio-regular-webfont.woff2') format('woff2'),
+         url('/media/fonts/fx-lifestyle/antonio-regular-webfont.woff') format('woff');
 }
 
 @font-face {
     font-family: antoniobold;
-    src: url('/media/fonts/fx-lifestyle/antonio-bold-webfont.woff2') format('woff2'),
-         url('/media/fonts/fx-lifestyle/antonio-bold-webfont.woff') format('woff');
     font-weight: normal;
     font-style: normal;
+    font-display: swap;
+    src: url('/media/fonts/fx-lifestyle/antonio-bold-webfont.woff2') format('woff2'),
+         url('/media/fonts/fx-lifestyle/antonio-bold-webfont.woff') format('woff');
 }
 
 #wrapper {

--- a/media/css/firefox/whatsnew/send-to-device.scss
+++ b/media/css/firefox/whatsnew/send-to-device.scss
@@ -8,6 +8,7 @@
     font-family: 'Open Sans Light';
     font-weight: normal;
     font-style: normal;
+    font-display: swap;
     src: url('/media/fonts/opensans-light.woff2') format('woff2'),
          url('/media/fonts/opensans-light.woff') format('woff');
 }

--- a/media/css/l10n/ar/intl.css
+++ b/media/css/l10n/ar/intl.css
@@ -3,12 +3,14 @@
 @font-face {
   font-family: X-LocaleSpecific;
   font-weight: normal;
+  font-display: swap;
   src: url('/media/fonts/l10n/DroidNaskh-Regular.woff') format('woff');
 }
 
 @font-face {
   font-family: X-LocaleSpecific;
   font-weight: bold;
+  font-display: swap;
   src: url('/media/fonts/l10n/DroidNaskh-Bold.woff') format('woff');
 }
 

--- a/media/css/l10n/az/intl.css
+++ b/media/css/l10n/az/intl.css
@@ -3,30 +3,35 @@
 @font-face {
     font-family: X-LocaleSpecific-Light;
     font-weight: normal;
+    font-display: swap;
     src: url('/media/fonts/l10n/az/mplus-2c-light-az-subset.woff') format('woff');
 }
 
 @font-face {
     font-family: X-LocaleSpecific-Light;
     font-weight: bold;
+    font-display: swap;
     src: url('/media/fonts/l10n/az/mplus-2c-medium-az-subset.woff') format('woff');
 }
 
 @font-face {
     font-family: X-LocaleSpecific;
     font-weight: normal;
+    font-display: swap;
     src: url('/media/fonts/l10n/az/mplus-2c-regular-az-subset.woff') format('woff');
 }
 
 @font-face {
     font-family: X-LocaleSpecific;
     font-weight: bold;
+    font-display: swap;
     src: url('/media/fonts/l10n/az/mplus-2c-bold-az-subset.woff') format('woff');
 }
 
 @font-face {
     font-family: X-LocaleSpecific-Extrabold;
     font-weight: 800;
+    font-display: swap;
     src: url('/media/fonts/l10n/az/mplus-2c-black-az-subset.woff') format('woff');
 }
 

--- a/media/css/l10n/fa/intl.css
+++ b/media/css/l10n/fa/intl.css
@@ -3,12 +3,14 @@
 @font-face {
     font-family: X-LocaleSpecific;
     font-weight: normal;
+    font-display: swap;
     src: url('/media/fonts/l10n/DroidNaskh-Regular.woff') format('woff');
 }
 
 @font-face {
     font-family: X-LocaleSpecific;
     font-weight: bold;
+    font-display: swap;
     src: url('/media/fonts/l10n/DroidNaskh-Bold.woff') format('woff');
 }
 

--- a/media/css/l10n/ff/intl.css
+++ b/media/css/l10n/ff/intl.css
@@ -4,6 +4,7 @@
     font-family: X-LocaleSpecific-Light;
     font-weight: normal;
     font-style: normal;
+    font-display: swap;
     src: url('/media/fonts/l10n/ff/mplus-2c-light-ff-sub.woff2') format('woff2'),
          url('/media/fonts/l10n/ff/mplus-2c-light-ff-sub.woff') format('woff');
 }
@@ -12,6 +13,7 @@
     font-family: X-LocaleSpecific-Light;
     font-weight: bold;
     font-style: normal;
+    font-display: swap;
     src: url('/media/fonts/l10n/ff/mplus-2c-medium-ff-sub.woff2') format('woff2'),
          url('/media/fonts/l10n/ff/mplus-2c-medium-ff-sub.woff') format('woff');
 }
@@ -20,6 +22,7 @@
     font-family: X-LocaleSpecific;
     font-weight: normal;
     font-style: normal;
+    font-display: swap;
     src: url('/media/fonts/l10n/ff/mplus-2c-regular-ff-sub.woff2') format('woff2'),
          url('/media/fonts/l10n/ff/mplus-2c-regular-ff-sub.woff') format('woff');
 }
@@ -28,6 +31,7 @@
     font-family: X-LocaleSpecific;
     font-weight: normal;
     font-style: italic;
+    font-display: swap;
     src: url('/media/fonts/l10n/ff/notosans-italic-ff-sub.woff2') format('woff2'),
          url('/media/fonts/l10n/ff/notosans-italic-ff-sub.woff') format('woff');
 }
@@ -36,6 +40,7 @@
     font-family: X-LocaleSpecific;
     font-weight: bold;
     font-style: normal;
+    font-display: swap;
     src: url('/media/fonts/l10n/ff/notosans-bold-ff-sub.woff2') format('woff2'),
          url('/media/fonts/l10n/ff/notosans-bold-ff-sub.woff') format('woff');
 }
@@ -44,6 +49,7 @@
     font-family: X-LocaleSpecific;
     font-weight: bold;
     font-style: italic;
+    font-display: swap;
     src: url('/media/fonts/l10n/ff/notosans-bolditalic-ff-sub.woff2') format('woff2'),
          url('/media/fonts/l10n/ff/notosans-bolditalic-ff-sub.woff') format('woff');
 }

--- a/media/css/l10n/ja/intl.css
+++ b/media/css/l10n/ja/intl.css
@@ -3,6 +3,7 @@
 @font-face {
     font-family: X-LocaleSpecific-Light;
     font-weight: normal;
+    font-display: swap;
     src: /* All */
        local(mplus-2p-light),
        local(KozGoPro-Light),
@@ -21,6 +22,7 @@
 @font-face {
     font-family: X-LocaleSpecific-Light;
     font-weight: bold;
+    font-display: swap;
     src: /* All */
        local(mplus-2p-medium),
        local(KozGoPro-Medium),
@@ -39,6 +41,7 @@
 @font-face {
     font-family: X-LocaleSpecific;
     font-weight: normal;
+    font-display: swap;
     src: /* All */
        local(mplus-2p-regular),
        local(KozGoPro-Regular),
@@ -57,6 +60,7 @@
 @font-face {
     font-family: X-LocaleSpecific;
     font-weight: bold;
+    font-display: swap;
     src: /* All */
        local(mplus-2p-bold),
        local(KozGoPro-Bold),
@@ -75,6 +79,7 @@
 @font-face {
     font-family: X-LocaleSpecific-Extrabold;
     font-weight: 800;
+    font-display: swap;
     src: /* All */
        local(mplus-2p-black),
        local(KozGoPro-Heavy),

--- a/media/css/l10n/ko/intl.css
+++ b/media/css/l10n/ko/intl.css
@@ -3,6 +3,7 @@
 @font-face {
     font-family: X-LocaleSpecific-Light;
     font-weight: normal;
+    font-display: swap;
     src: /* OS X */
        local(AppleSDGothicNeo-UltraLight),
        /* Windows */
@@ -12,6 +13,7 @@
 @font-face {
     font-family: X-LocaleSpecific-Light;
     font-weight: bold;
+    font-display: swap;
     src: /* OS X */
        local(AppleSDGothicNeo-SemiBold),
        /* Windows */
@@ -21,6 +23,7 @@
 @font-face {
     font-family: X-LocaleSpecific;
     font-weight: normal;
+    font-display: swap;
     src: /* OS X */
        local(AppleSDGothicNeo-Regular),
        /* Windows */
@@ -30,6 +33,7 @@
 @font-face {
     font-family: X-LocaleSpecific;
     font-weight: bold;
+    font-display: swap;
     src: /* OS X */
        local(AppleSDGothicNeo-Bold),
        /* Windows */
@@ -39,6 +43,7 @@
 @font-face {
     font-family: X-LocaleSpecific-Extrabold;
     font-weight: 800;
+    font-display: swap;
     src: /* OS X */
        local(AppleSDGothicNeo-Heavy),
        /* Windows */

--- a/media/css/l10n/ro/intl.css
+++ b/media/css/l10n/ro/intl.css
@@ -4,6 +4,7 @@
     font-family: X-LocaleSpecific-Light;
     font-weight: normal;
     font-style: normal;
+    font-display: swap;
     src: url('/media/fonts/l10n/ro/opensans-light-ro-subset.woff2') format('woff2'),
          url('/media/fonts/l10n/ro/opensans-light-ro-subset.woff') format('woff');
 }
@@ -12,6 +13,7 @@
     font-family: X-LocaleSpecific-Light;
     font-weight: bold;
     font-style: normal;
+    font-display: swap;
     src: url('/media/fonts/l10n/ro/opensans-semibold-ro-subset.woff2') format('woff2'),
          url('/media/fonts/l10n/ro/opensans-semibold-ro-subset.woff') format('woff');
 }
@@ -20,6 +22,7 @@
     font-family: X-LocaleSpecific-Light;
     font-weight: normal;
     font-style: italic;
+    font-display: swap;
     src: url('/media/fonts/l10n/ro/opensans-lightitalic-ro-subset.woff2') format('woff2'),
          url('/media/fonts/l10n/ro/opensans-lightitalic-ro-subset.woff') format('woff');
 }
@@ -28,6 +31,7 @@
     font-family: X-LocaleSpecific;
     font-weight: normal;
     font-style: normal;
+    font-display: swap;
     src: url('/media/fonts/l10n/ro/opensans-regular-ro-subset.woff2') format('woff2'),
          url('/media/fonts/l10n/ro/opensans-regular-ro-subset.woff') format('woff');
 }
@@ -36,6 +40,7 @@
     font-family: X-LocaleSpecific;
     font-weight: bold;
     font-style: normal;
+    font-display: swap;
     src: url('/media/fonts/l10n/ro/opensans-bold-ro-subset.woff2') format('woff2'),
          url('/media/fonts/l10n/ro/opensans-bold-ro-subset.woff') format('woff');
 }
@@ -44,6 +49,7 @@
     font-family: X-LocaleSpecific;
     font-weight: normal;
     font-style: italic;
+    font-display: swap;
     src: url('/media/fonts/l10n/ro/opensans-italic-ro-subset.woff2') format('woff2'),
          url('/media/fonts/l10n/ro/opensans-italic-ro-subset.woff') format('woff');
 }
@@ -52,6 +58,7 @@
     font-family: X-LocaleSpecific;
     font-weight: bold;
     font-style: italic;
+    font-display: swap;
     src: url('/media/fonts/l10n/ro/opensans-bolditalic-ro-subset.woff2') format('woff2'),
          url('/media/fonts/l10n/ro/opensans-bolditalic-ro-subset.woff') format('woff');
 }
@@ -60,6 +67,7 @@
     font-family: X-LocaleSpecific-Extrabold;
     font-weight: 800;
     font-style: normal;
+    font-display: swap;
     src: url('/media/fonts/l10n/ro/opensans-extrabold-ro-subset.woff2') format('woff2'),
          url('/media/fonts/l10n/ro/opensans-extrabold-ro-subset.woff') format('woff');
 }
@@ -68,6 +76,7 @@
     font-family: X-LocaleSpecific-Extrabold;
     font-weight: 800;
     font-style: italic;
+    font-display: swap;
     src: url('/media/fonts/l10n/ro/opensans-extrabolditalic-ro-subset.woff2') format('woff2'),
          url('/media/fonts/l10n/ro/opensans-extrabolditalic-ro-subset.woff') format('woff');
 }

--- a/media/css/l10n/zh-CN/intl.css
+++ b/media/css/l10n/zh-CN/intl.css
@@ -3,6 +3,7 @@
 @font-face {
     font-family: X-LocaleSpecific;
     font-weight: normal;
+    font-display: swap;
     src: /* OS X */
        local(FZLTXHK--GBK1-0), /* = Lantinghei SC Extralight */
        local(HiraginoSansGB-W3),
@@ -15,6 +16,7 @@
 @font-face {
     font-family: X-LocaleSpecific;
     font-weight: bold;
+    font-display: swap;
     src: /* OS X */
        local(FZLTZHK--GBK1-0), /* = Lantinghei SC Demibold */
        local(HiraginoSansGB-W6),
@@ -27,6 +29,7 @@
 @font-face {
     font-family: X-LocaleSpecific-Extrabold;
     font-weight: 800;
+    font-display: swap;
     src: /* OS X */
        local(FZLTTHK--GBK1-0), /* = Lantinghei SC Heavy */
        local(HiraginoSansGB-W6),

--- a/media/css/l10n/zh-TW/intl.css
+++ b/media/css/l10n/zh-TW/intl.css
@@ -3,6 +3,7 @@
 @font-face {
     font-family: X-LocaleSpecific;
     font-weight: normal;
+    font-display: swap;
     src: /* OS X */
        local(FZLTXHB--B51-0), /* = Lantinghei TC Extralight */
        /* Windows */
@@ -14,6 +15,7 @@
 @font-face {
     font-family: X-LocaleSpecific;
     font-weight: bold;
+    font-display: swap;
     src: /* OS X */
        local(FZLTZHB--B51-0), /* = Lantinghei TC Demibold */
        /* Windows */
@@ -25,6 +27,7 @@
 @font-face {
     font-family: X-LocaleSpecific-Extrabold;
     font-weight: 800;
+    font-display: swap;
     src: /* OS X */
        local(FZLTTHB--B51-0), /* = Lantinghei TC Heavy */
        /* Windows */

--- a/media/css/mozorg/developer/css-grid-demo.scss
+++ b/media/css/mozorg/developer/css-grid-demo.scss
@@ -14,6 +14,7 @@ $color-light-green: lighten(desaturate($color-green, 25%), 30%);
     font-family: 'Theano Didot';
     font-weight: normal;
     font-style: normal;
+    font-display: swap;
     src: url('/media/fonts/TheanoDidot-regular.woff2') format('woff2'),
          url('/media/fonts/TheanoDidot-regular.woff') format('woff');
 }

--- a/media/css/mozorg/manifesto.less
+++ b/media/css/mozorg/manifesto.less
@@ -10,6 +10,7 @@
     font-family: 'Open Sans Extrabold';
     font-weight: 800;
     font-style: normal;
+    font-display: swap;
     src: url('/media/fonts/opensans-extrabold.woff2') format('woff2'),
          url('/media/fonts/opensans-extrabold.woff') format('woff');
 }

--- a/media/css/pebbles/includes/fonts/_open-sans.scss
+++ b/media/css/pebbles/includes/fonts/_open-sans.scss
@@ -7,6 +7,7 @@
     font-family: 'Open Sans';
     font-weight: normal;
     font-style: normal;
+    font-display: swap;
     src: url('/media/fonts/opensans-regular.woff2') format('woff2'),
          url('/media/fonts/opensans-regular.woff') format('woff');
 }
@@ -15,6 +16,7 @@
     font-family: 'Open Sans';
     font-weight: bold;
     font-style: normal;
+    font-display: swap;
     src: url('/media/fonts/opensans-bold.woff2') format('woff2'),
          url('/media/fonts/opensans-bold.woff') format('woff');
 }

--- a/media/css/pebbles/includes/fonts/_zilla-slab-highlight.scss
+++ b/media/css/pebbles/includes/fonts/_zilla-slab-highlight.scss
@@ -10,6 +10,7 @@
     font-family: 'Zilla Slab Highlight';
     font-weight: normal;
     font-style: normal;
+    font-display: swap;
     src: url('/media/fonts/ZillaSlabHighlight-Regular.woff2') format('woff2'),
          url('/media/fonts/ZillaSlabHighlight-Regular.woff') format('woff');
 }
@@ -18,6 +19,7 @@
     font-family: 'Zilla Slab Highlight';
     font-weight: bold;
     font-style: normal;
+    font-display: swap;
     src: url('/media/fonts/ZillaSlabHighlight-Bold.woff2') format('woff2'),
          url('/media/fonts/ZillaSlabHighlight-Bold.woff') format('woff');
 }

--- a/media/css/pebbles/includes/fonts/_zilla-slab.scss
+++ b/media/css/pebbles/includes/fonts/_zilla-slab.scss
@@ -7,6 +7,7 @@
     font-family: 'Zilla Slab';
     font-weight: normal;
     font-style: normal;
+    font-display: swap;
     src: url('/media/fonts/ZillaSlab-Regular.woff2') format('woff2'),
          url('/media/fonts/ZillaSlab-Regular.woff') format('woff');
 }
@@ -15,6 +16,7 @@
     font-family: 'Zilla Slab';
     font-weight: bold;
     font-style: normal;
+    font-display: swap;
     src: url('/media/fonts/ZillaSlab-Bold.woff2') format('woff2'),
          url('/media/fonts/ZillaSlab-Bold.woff') format('woff');
 }
@@ -23,6 +25,7 @@
     font-family: 'Zilla Slab';
     font-weight: normal;
     font-style: italic;
+    font-display: swap;
     src: url('/media/fonts/ZillaSlab-RegularItalic.woff2') format('woff2'),
          url('/media/fonts/ZillaSlab-RegularItalic.woff') format('woff');
 }
@@ -31,6 +34,7 @@
     font-family: 'Zilla Slab';
     font-weight: bold;
     font-style: italic;
+    font-display: swap;
     src: url('/media/fonts/ZillaSlab-BoldItalic.woff2') format('woff2'),
          url('/media/fonts/ZillaSlab-BoldItalic.woff') format('woff');
 }

--- a/media/css/sandstone/fira-fonts.less
+++ b/media/css/sandstone/fira-fonts.less
@@ -6,42 +6,47 @@
 
 @font-face {
     font-family: 'Fira Sans';
-    src: url('/media/fonts/FiraSans-Regular.woff2') format('woff2'),
-         url('/media/fonts/FiraSans-Regular.woff') format('woff');
     font-weight: normal;
     font-style: normal;
+    font-display: swap;
+    src: url('/media/fonts/FiraSans-Regular.woff2') format('woff2'),
+         url('/media/fonts/FiraSans-Regular.woff') format('woff');
 }
 
 @font-face {
     font-family: 'Fira Sans';
+    font-weight: bold;
+    font-style: normal;
+    font-display: swap;
     src: url('/media/fonts/FiraSans-Bold.woff2') format('woff2'),
          url('/media/fonts/FiraSans-Bold.woff') format('woff');
-    font-weight: bold;
-    font-style: normal;
 }
 
 @font-face {
     font-family: 'Fira Sans Light';
-    src: url('/media/fonts/FiraSans-Light.woff2') format('woff2'),
-         url('/media/fonts/FiraSans-Light.woff') format('woff');
     font-weight: normal;
     font-style: normal;
+    font-display: swap;
+    src: url('/media/fonts/FiraSans-Light.woff2') format('woff2'),
+         url('/media/fonts/FiraSans-Light.woff') format('woff');
 }
 
 @font-face {
     font-family: 'Fira Sans Light';
-    src: url('/media/fonts/FiraSans-SemiBold.woff2') format('woff2'),
-         url('/media/fonts/FiraSans-SemiBold.woff') format('woff');
     font-weight: bold;
     font-style: normal;
+    font-display: swap;
+    src: url('/media/fonts/FiraSans-SemiBold.woff2') format('woff2'),
+         url('/media/fonts/FiraSans-SemiBold.woff') format('woff');
 }
 
 @font-face {
     font-family: 'Fira Sans Light';
-    src: url('/media/fonts/FiraSans-LightItalic.woff2') format('woff2'),
-         url('/media/fonts/FiraSans-LightItalic.woff') format('woff');
     font-weight: bold;
     font-style: italic;
+    font-display: swap;
+    src: url('/media/fonts/FiraSans-LightItalic.woff2') format('woff2'),
+         url('/media/fonts/FiraSans-LightItalic.woff') format('woff');
 }
 
 @baseFiraFontFamily: 'Fira Sans', X-LocaleSpecific, sans-serif;

--- a/media/css/sandstone/fonts.less
+++ b/media/css/sandstone/fonts.less
@@ -8,6 +8,7 @@
     font-family: 'Open Sans Light';
     font-weight: normal;
     font-style: normal;
+    font-display: swap;
     src: url('/media/fonts/opensans-light.woff2') format('woff2'),
          url('/media/fonts/opensans-light.woff') format('woff');
 }
@@ -16,6 +17,7 @@
     font-family: 'Open Sans Light';
     font-weight: bold;
     font-style: normal;
+    font-display: swap;
     src: url('/media/fonts/opensans-semibold.woff2') format('woff2'),
          url('/media/fonts/opensans-semibold.woff') format('woff');
 }
@@ -24,6 +26,7 @@
     font-family: 'Open Sans Light';
     font-weight: normal;
     font-style: italic;
+    font-display: swap;
     src: url('/media/fonts/opensans-lightitalic.woff2') format('woff2'),
          url('/media/fonts/opensans-lightitalic.woff') format('woff');
 }
@@ -32,6 +35,7 @@
     font-family: 'Open Sans';
     font-weight: normal;
     font-style: normal;
+    font-display: swap;
     src: url('/media/fonts/opensans-regular.woff2') format('woff2'),
          url('/media/fonts/opensans-regular.woff') format('woff');
 }
@@ -40,6 +44,7 @@
     font-family: 'Open Sans';
     font-weight: bold;
     font-style: normal;
+    font-display: swap;
     src: url('/media/fonts/opensans-bold.woff2') format('woff2'),
          url('/media/fonts/opensans-bold.woff') format('woff');
 }
@@ -48,6 +53,7 @@
     font-family: 'Open Sans';
     font-weight: normal;
     font-style: italic;
+    font-display: swap;
     src: url('/media/fonts/opensans-italic.woff2') format('woff2'),
          url('/media/fonts/opensans-italic.woff') format('woff');
 }
@@ -61,6 +67,7 @@
     font-family: 'Open Sans';
     font-weight: bold;
     font-style: italic;
+    font-display: swap;
     src: url('/media/fonts/opensans-bolditalic.woff2') format('woff2'),
          url('/media/fonts/opensans-bolditalic.woff') format('woff');
 }
@@ -69,6 +76,7 @@
     font-family: 'Open Sans Extrabold';
     font-weight: 800;
     font-style: italic;
+    font-display: swap;
     src: url('/media/fonts/opensans-extrabolditalic.woff2') format('woff2'),
          url('/media/fonts/opensans-extrabolditalic.woff') format('woff');
 }

--- a/media/css/styleguide/styleguide.less
+++ b/media/css/styleguide/styleguide.less
@@ -10,6 +10,7 @@
     font-family: 'Open Sans';
     font-weight: bold;
     font-style: italic;
+    font-display: swap;
     src: url('/media/fonts/opensans-bolditalic.woff2') format('woff2'),
          url('/media/fonts/opensans-bolditalic.woff') format('woff');
 }
@@ -18,6 +19,7 @@
     font-family: 'Open Sans Extrabold';
     font-weight: 800;
     font-style: italic;
+    font-display: swap;
     src: url('/media/fonts/opensans-extrabolditalic.woff2') format('woff2'),
          url('/media/fonts/opensans-extrabolditalic.woff') format('woff');
 }


### PR DESCRIPTION
## Description
- Adds `font-display: swap;` descriptor to our generic `@font-face` stack, eliminating FOIT in browsers that support it (Currently in Chrome & FF 58+. It's also in Safari Tech Preview). This makes text content readable much earlier in the page loading process, especially for those on slower connections.

## Issue / Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1427719

## Testing
- Demo: https://www-demo1.allizom.org/en-US/
- Hard-refreshing pages in both Chrome and Firefox (58+) is the easiest way to view the change in behavior on individual pages. I also did some basic tests on mobile using web page test, which you can see in the bug.
- Make sure I didn't miss any `@font-face` rules?

  