### PR TITLE
[fix bug 1405409] Add microdata to /firefox/ page

### DIFF
--- a/bedrock/firefox/templates/firefox/home.html
+++ b/bedrock/firefox/templates/firefox/home.html
@@ -398,6 +398,8 @@
       {{ download_firefox(dom_id='footer-download', alt_copy=_('Download now'), locale_in_transition=True, download_location='other') }}
     </div>
   </section>
+
+  {% include 'firefox/includes/schemaorg-app.html' %}
 </main>
 {% endblock %}
 


### PR DESCRIPTION
## Description
- Adds shared Schema.org microdata include to `/firefox/`.

## Issue / Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1405409

## Testing
- Microdata should be present when inspecting the markup for `/firefox/` (but nothing visually noticable to the page).
  