### PR TITLE
[fix bug 1429429] Update headline on /firefox/mobile/

### DIFF
--- a/bedrock/firefox/templates/firefox/mobile.html
+++ b/bedrock/firefox/templates/firefox/mobile.html
@@ -24,9 +24,16 @@
     <header class="main-header">
       <div class="content">
         <div class="header-content">
-          <h1>{{ _('Firefox for mobile') }}</h1>
-          <h3>{{ _('The speed you need with the privacy you want on all your devices.') }}</h3>
-          <p>{{ _('Choose one or download them all for iOS and Android.') }}</p>
+          {% if l10n_has_tag('update_mobile_headline') %}
+            <h1>{{ _('Firefox mobile apps') }}</h1>
+            <h2>{{ _('Fast for good.') }}</h2>
+            <p>{{ _('The speed you need with the privacy you want on all your devices.') }}</p>
+            <p>{{ _('Download for iOS and Android.') }}</p>
+          {% else %}
+            <h1>{{ _('Firefox for mobile') }}</h1>
+            <p>{{ _('The speed you need with the privacy you want on all your devices.') }}</p>
+            <p>{{ _('Choose one or download them all for iOS and Android.') }}</p>
+          {% endif %}
         </div>
       </div>
 

--- a/media/css/firefox/mobile.scss
+++ b/media/css/firefox/mobile.scss
@@ -88,16 +88,25 @@ a.button.button-focus {
     text-align: center;
     z-index: 1;
 
-    h1 {
+    h1,
+    h2 {
         @include font-size-level2;
         font-weight: bold;
-        margin-bottom: 0.75em;
+        margin-bottom: 0;
     }
 
-    h3,
+    h2 {
+        margin-top: 0.25em;
+    }
+
     p {
         @include font-size-level4;
         margin-bottom: 0.75em;
+    }
+
+    h1 + p,
+    h2 + p {
+        margin-top: 1.5em;
     }
 
     @media #{$mq-desktop} {


### PR DESCRIPTION
## Description
- Updates headline on `/firefox/mobile/` to include "Fast for good." subhead.

**Do not merge** until I get the strings and styling approved.

## Issue / Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1429429

## Testing
- Test for visual regressions between old headline and new?