### PR TITLE
Run only firefox tests in k8s clusters

### DIFF
--- a/jenkins/branches/frankfurt-prod.yml
+++ b/jenkins/branches/frankfurt-prod.yml
@@ -9,4 +9,4 @@ apps:
   - bedrock-prod
 integration_tests:
   frankfurt:
-    - headless
+    - firefox

--- a/jenkins/branches/frankfurt.yml
+++ b/jenkins/branches/frankfurt.yml
@@ -8,4 +8,4 @@ apps:
   - bedrock-dev
 integration_tests:
   frankfurt:
-    - headless
+    - firefox

--- a/jenkins/branches/master.yml
+++ b/jenkins/branches/master.yml
@@ -14,6 +14,6 @@ integration_tests:
     - headless
     - download
   tokyo:
-    - headless
+    - firefox
   frankfurt:
-    - headless
+    - firefox

--- a/jenkins/branches/prod.yml
+++ b/jenkins/branches/prod.yml
@@ -19,6 +19,6 @@ integration_tests:
     - ie
     - ie8
   tokyo:
-    - headless
+    - firefox
   frankfurt:
-    - headless
+    - firefox

--- a/jenkins/branches/tokyo-prod.yml
+++ b/jenkins/branches/tokyo-prod.yml
@@ -9,4 +9,4 @@ apps:
   - bedrock-prod
 integration_tests:
   tokyo:
-    - headless
+    - firefox

--- a/jenkins/branches/tokyo.yml
+++ b/jenkins/branches/tokyo.yml
@@ -8,4 +8,4 @@ apps:
   - bedrock-dev
 integration_tests:
   tokyo:
-    - headless
+    - firefox


### PR DESCRIPTION
The selenium tests seem to be more stable than headless.