### PR TITLE
Use branch name in test container names; avoid conflicts

### DIFF
--- a/docker/bin/cleanup_after_functional_tests.sh
+++ b/docker/bin/cleanup_after_functional_tests.sh
@@ -3,14 +3,14 @@
 BIN_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 source $BIN_DIR/set_git_env_vars.sh
 
-docker stop bedrock-code-${GIT_COMMIT_SHORT}
+docker stop bedrock-code-${BRANCH_NAME_SAFE}-${GIT_COMMIT_SHORT}
 
 for NODE_NUMBER in `seq ${NUMBER_OF_NODES:-5}`;
 do
-    docker stop bedrock-selenium-node-${NODE_NUMBER}-${GIT_COMMIT_SHORT}
+    docker stop bedrock-selenium-node-${NODE_NUMBER}-${BRANCH_NAME_SAFE}-${GIT_COMMIT_SHORT}
 done;
 
-docker stop bedrock-selenium-hub-${GIT_COMMIT_SHORT}
+docker stop bedrock-selenium-hub-${BRANCH_NAME_SAFE}-${GIT_COMMIT_SHORT}
 
 # always report success
 exit 0

--- a/docker/bin/run_integration_tests.sh
+++ b/docker/bin/run_integration_tests.sh
@@ -52,7 +52,7 @@ source $BIN_DIR/set_git_env_vars.sh
 if [ -z "${BASE_URL}" ]; then
   # start bedrock
   docker run -d --rm \
-    --name bedrock-code-${GIT_COMMIT_SHORT} \
+    --name bedrock-code-${BRANCH_NAME_SAFE}-${GIT_COMMIT_SHORT} \
     -e ALLOWED_HOSTS="*" \
     -e SECRET_KEY=foo \
     -e DEBUG=False \
@@ -76,7 +76,7 @@ if [ "${DRIVER}" = "Remote" ]; then
 
   # start selenium grid hub
   docker run -d --rm \
-    --name bedrock-selenium-hub-${GIT_COMMIT_SHORT} \
+    --name bedrock-selenium-hub-${BRANCH_NAME_SAFE}-${GIT_COMMIT_SHORT} \
     selenium/hub:${SELENIUM_VERSION}
   DOCKER_LINKS=(${DOCKER_LINKS[@]} --link bedrock-selenium-hub-${GIT_COMMIT_SHORT}:hub)
   SELENIUM_HOST="hub"
@@ -84,7 +84,7 @@ if [ "${DRIVER}" = "Remote" ]; then
   # start selenium grid nodes
   for NODE_NUMBER in `seq ${NUMBER_OF_NODES:-5}`; do
     docker run -d --rm \
-      --name bedrock-selenium-node-${NODE_NUMBER}-${GIT_COMMIT_SHORT} \
+      --name bedrock-selenium-node-${NODE_NUMBER}-${BRANCH_NAME_SAFE}-${GIT_COMMIT_SHORT} \
       ${DOCKER_LINKS[@]} \
       selenium/node-firefox:${SELENIUM_VERSION}
     while ! ${SELENIUM_READY}; do

--- a/docker/bin/set_git_env_vars.sh
+++ b/docker/bin/set_git_env_vars.sh
@@ -14,4 +14,6 @@ fi
 if [[ -z "$GIT_BRANCH" ]]; then
     export GIT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
     export BRANCH_NAME="$GIT_BRANCH"
+    # BRANCH_NAME with "/" replaced with "-"
+    export BRANCH_NAME_SAFE="${BRANCH_NAME/\//-}"
 fi


### PR DESCRIPTION
If you try a deployment of two branches with the same commit (e.g. master and prod) it will often fail due to conflicting container names when they were just using commit hash. Adding the branch name should eliminate these failures.