### PR TITLE
Bug 1430147: Restore page-image-quantum.png

### DIFF
--- a/media/img/firefox/template/page-image-quantum.png
+++ b/media/img/firefox/template/page-image-quantum.png
@@ -1,0 +1,1 @@
+page-image.png


### PR DESCRIPTION
Add a symlink to page-image.png, and since it's the same file as page-image-quantum.png, the hashed name will be the same as it was originally, thus continuing to serve the image at the old URL.