### PR TITLE
Add a mailtoencode template filter

### DIFF
--- a/bedrock/base/templatetags/helpers.py
+++ b/bedrock/base/templatetags/helpers.py
@@ -93,8 +93,16 @@ def _urlencode(items):
 
 
 @library.filter
+def mailtoencode(txt):
+    """Url encode a string using %20 for spaces."""
+    if isinstance(txt, unicode):
+        txt = txt.encode('utf-8')
+    return urllib.quote(txt)
+
+
+@library.filter
 def urlencode(txt):
-    """Url encode a path."""
+    """Url encode a string using + for spaces."""
     if isinstance(txt, unicode):
         txt = txt.encode('utf-8')
     return urllib.quote_plus(txt)

--- a/bedrock/base/tests/test_helpers.py
+++ b/bedrock/base/tests/test_helpers.py
@@ -42,6 +42,14 @@ class HelpersTests(TestCase):
         context = {'key': u'\xe4'}
         eq_(render(template, context), '<a href="?var=%C3%A4">')
 
+    def test_mailtoencode_with_unicode(self):
+        template = '<a href="?var={{ key|mailtoencode }}">'
+        context = {'key': '?& /()'}
+        eq_(render(template, context), '<a href="?var=%3F%26%20/%28%29">')
+        # non-ascii
+        context = {'key': u'\xe4'}
+        eq_(render(template, context), '<a href="?var=%C3%A4">')
+
 
 @override_settings(SEND_TO_DEVICE_MESSAGE_SETS=SEND_TO_DEVICE_MESSAGE_SETS)
 def test_send_to_device_sms_countries():


### PR DESCRIPTION
Main difference from urlencode is that it converts spaces to "%20" instead of "+".