### PR TITLE
Fix Bug 1431348 - Unpublished Release notes should not be 404 but should get a default template with a "coming soon" message instead

### DIFF
--- a/bedrock/firefox/templates/firefox/releases/nightly-notes.html
+++ b/bedrock/firefox/templates/firefox/releases/nightly-notes.html
@@ -5,10 +5,12 @@
 {% extends "firefox/releases/release-notes.html" %}
 
 {% set channel_name = 'Nightly' %}
+{% set notes_feed = url('firefox.nightly.notes.feed') %}
+{% set blog_feed = 'https://blog.nightly.mozilla.org/feed/' %}
 
 {% block extrahead %}
-<link rel="alternate" type="application/atom+xml" title="{{ _('Firefox Nightly Notes Feed') }}" href="{{ url('firefox.nightly.notes.feed') }}">
-<link rel="alternate" type="application/atom+xml" title="{{ _('Firefox Nightly News Feed') }}" href="https://blog.nightly.mozilla.org/feed/">
+<link rel="alternate" type="application/atom+xml" title="{{ _('Firefox Nightly Notes Feed') }}" href="{{ notes_feed }}">
+<link rel="alternate" type="application/atom+xml" title="{{ _('Firefox Nightly News Feed') }}" href="{{ blog_feed }}">
 {% endblock %}
 
 {% block page_favicon %}{{ static('img/firefox/nightly/favicon.png') }}{% endblock %}
@@ -27,4 +29,14 @@
 
 {% block extra_resources %}
   <a rel="external" href="https://blog.nightly.mozilla.org/">{{ _('Firefox Nightly News') }}</a>
+{% endblock %}
+
+{% block extra_draft_description %}
+  <p>
+    {%- trans twitter='https://twitter.com/FirefoxNightly' -%}
+      ProTip: Be the first to know the latest changes by subscribing to the Nightly <a href="{{ notes_feed }}">Notes
+      Feed</a> and <a href="{{ blog_feed }}">News Feed</a>. Also, don’t forget to follow us on
+      <a href="{{ twitter }}">Twitter</a>!
+    {%- endtrans -%}
+  </p>
 {% endblock %}

--- a/bedrock/firefox/templates/firefox/releases/release-notes.html
+++ b/bedrock/firefox/templates/firefox/releases/release-notes.html
@@ -129,11 +129,18 @@
           <div class="version">
             <h2>{{ _('{version}')|f(version=release.version) }}</h2>
             <h3>{{ release.product }} {{ release.channel }}</h3>
-            <p>{{ _('{date}')|f(date=release.release_date|l10n_format_date) }}</p>
+            {% if release.is_public %}
+              <p>{{ _('{date}')|f(date=release.release_date|l10n_format_date) }}</p>
+            {% endif %}
           </div>
           <div class="description">
+            {% if release.is_public %}
               <h2>{{ _('Version {version}, first offered to {channel} channel users on {date}')|f(channel=release.channel, date=release.release_date|l10n_format_date, version=release.version) }}</h2>
               <p>{{ release.text|safe }}</p>
+            {% else %}
+              <h2>{{ _('The notes for this release are not yet publicly available, but are coming soon! Please check this page again later.') }}</h2>
+              {% block extra_draft_description %}{% endblock %}
+            {% endif %}
           </div>
           {% endblock %}
         </div>
@@ -145,7 +152,7 @@
     <section class="notes-section">
       <div class="features" id="new-features">
         <div class="container">
-        {% if release.notes %}
+        {% if release.is_public and release.notes %}
           {% for note in release.notes if note.tag == "New" %}
             {% if loop.first %}
             <div class="section-wrapper" id="{{ note.tag|lower() }}">

--- a/bedrock/releasenotes/tests/releases/firefox-58.0a1-nightly.json
+++ b/bedrock/releasenotes/tests/releases/firefox-58.0a1-nightly.json
@@ -1,0 +1,9 @@
+{
+  "product": "Firefox",
+  "channel": "Nightly",
+  "version": "58.0a1",
+  "release_date": "2017-09-21",
+  "created": "2017-03-21T13:19:13.668000+00:00",
+  "modified": "2017-03-21T13:19:13.668000+00:00",
+  "is_public": false
+}

--- a/bedrock/releasenotes/tests/test_models.py
+++ b/bedrock/releasenotes/tests/test_models.py
@@ -121,19 +121,20 @@ class TestGetRelease(TestCase):
     def test_get_release(self, manager_mock):
         manager_mock.product().get.return_value = 'dude is released'
         assert models.get_release('Firefox', '57.0') == 'dude is released'
-        manager_mock.product.assert_called_with('Firefox', models.ProductRelease.CHANNELS[0], '57.0')
+        manager_mock.product.assert_called_with('Firefox', models.ProductRelease.CHANNELS[0], '57.0', False)
 
     def test_get_release_esr(self, manager_mock):
         manager_mock.product().get.return_value = 'dude is released'
         assert models.get_release('Firefox Extended Support Release', '51.0') == 'dude is released'
-        manager_mock.product.assert_called_with('Firefox Extended Support Release', 'esr', '51.0')
+        manager_mock.product.assert_called_with('Firefox Extended Support Release', 'esr', '51.0', False)
 
     def test_get_release_none_match(self, manager_mock):
         """Make sure the proper exception is raised if no file matches the query"""
         manager_mock.product().get.side_effect = models.ProductRelease.DoesNotExist
         assert models.get_release('Firefox', '57.0') is None
 
-        expected_calls = chain.from_iterable((call('Firefox', ch, '57.0'), call().get()) for ch in models.ProductRelease.CHANNELS)
+        expected_calls = chain.from_iterable(
+            (call('Firefox', ch, '57.0', False), call().get()) for ch in models.ProductRelease.CHANNELS)
         manager_mock.product.assert_has_calls(expected_calls)
 
 

--- a/bedrock/releasenotes/views.py
+++ b/bedrock/releasenotes/views.py
@@ -88,10 +88,13 @@ def release_notes(request, version, product='Firefox'):
     if not version:
         raise Http404
 
+    # Show a "coming soon" page for any unpublished Firefox releases
+    include_drafts = product == 'Firefox'
+
     try:
-        release = get_release_or_404(version, product)
+        release = get_release_or_404(version, product, include_drafts)
     except Http404:
-        release = get_release_or_404(version + 'beta', product)
+        release = get_release_or_404(version + 'beta', product, include_drafts)
         return HttpResponseRedirect(release.get_absolute_url())
 
     return l10n_utils.render(


### PR DESCRIPTION
## Description

Show a "coming soon" page for unpublished releases on production, where people get a 404 page at this time. The draft notes can still be previewed on stage.

**Do not merge yet** until the copy gets reviewed by @pascalchevrel.

## Issue / Bugzilla link

[Bug 1431348 - Unpublished Release notes should not be 404 but should get a default template with a "coming soon" message instead](https://bugzilla.mozilla.org/show_bug.cgi?id=1431348)

## Testing

This is actually difficult to test with actual release data depending on the timing. Currently [59.0beta](https://www.mozilla.org/en-US/firefox/59.0beta/releasenotes/) is unpublished so this page will be "coming soon" once this PR is merged, like [this screnshot](https://screenshots.firefox.com/MjqzpkbJdVq3rCpA/127.0.0.1).