### PR TITLE
[bug 1429321] Switch page, reduce vertical space

### DIFF
--- a/bedrock/firefox/templates/firefox/switch.html
+++ b/bedrock/firefox/templates/firefox/switch.html
@@ -44,14 +44,14 @@
             {% set share_url = settings.CANONICAL_URL + canonical_path %}
             <ul class="share-options">
               <li>
-                <a class="facebook" data-link-type="link" data-link-name="Share to Facebook" href="https://www.facebook.com/sharer/sharer.php?s=100&p[url]={{ share_url|urlencode }}">
+                <a class="facebook" data-link-type="social share" data-link-name="Facebook" href="https://www.facebook.com/sharer/sharer.php?s=100&p[url]={{ share_url|urlencode }}">
                   {{ _('Share to Facebook') }}
                 </a>
               </li>
               <li>
                 {# L10n: the string below is for a referral Twitter message. #}
                 {% set tweet_text = _('🔥 Firefox makes switching from Chrome really fast. Try it out!') %}
-                <a class="twitter" data-link-type="link" data-link-name="Send a tweet" href="https://www.twitter.com/intent/tweet?url={{ share_url|urlencode }}&text={{ tweet_text|urlencode }}">
+                <a class="twitter" data-link-type="social share" data-link-name="Twitter" href="https://www.twitter.com/intent/tweet?url={{ share_url|urlencode }}&text={{ tweet_text|urlencode }}">
                   {{ _('Send a tweet') }}
                 </a>
               </li>
@@ -66,7 +66,7 @@
                 {% set email_end = _('Check it out and let me know what you think:')|mailtoencode %}
 
                 {% set email_body = email_intro + '%0D%0A%0D%0A' + email_start + '%0D%0A%0D%0A' + email_end + '%20' + share_url|urlencode %}
-                <a class="email" data-link-type="link" data-link-name="Send an email" href="{{ 'mailto:?subject=%s&body=%s'|format(email_subject, email_body)|e }}">
+                <a class="email" data-link-type="social share" data-link-name="Email" href="{{ 'mailto:?subject=%s&body=%s'|format(email_subject, email_body)|e }}">
                   {{ _('Send an email') }}
                 </a>
               </li>

--- a/media/css/firefox/switch.scss
+++ b/media/css/firefox/switch.scss
@@ -55,14 +55,13 @@ main {
     }
 
     header {
-        border-bottom: 1px solid #fff;
-        padding-bottom: 20px;
+        padding: 20px 0;
     }
 
     ol {
-        @include font-size-level4;
+        @include font-size-level5;
         list-style: decimal;
-        margin: 40px 0 40px 30px;
+        margin: 0 0 40px 30px;
 
         li {
             margin-bottom: 20px;
@@ -124,18 +123,20 @@ main {
                 grid-template-columns: repeat(3, 1fr);
                 grid-template-rows: auto;
                 list-style-type: none;
-                margin: 40px 0 20px 0;
+                margin: 0 0 30px;
 
                 li {
                     counter-increment: switch-steps;
                     padding-top: 2em;
 
                     &:before {
+                        @include font-size-level4;
                         content: counter(switch-steps);
+                        font-weight: bold;
                         height: 1em;
                         left: 0;
                         position: absolute;
-                        top: 0;
+                        top: -.25em;
                         width: 1em;
                     }
                 }
@@ -181,6 +182,21 @@ main {
     }
 
     @media #{$mq-desktop} {
+        @supports (display: grid) {
+
+            ol li {
+                padding-top: 0;
+                padding-left: 40px;
+
+                &:before {
+                    @include font-size(30px);
+                    float: left;
+                    margin-left: -30px;
+                    margin-top: -.15em;
+                    position: static;
+                }
+            }
+        }
 
         .outer-container:after {
             right: -650px;
@@ -191,19 +207,6 @@ main {
         background: url('/media/img/firefox/switch/oval.png') top left 38% no-repeat,
                     linear-gradient(-53deg, #07090B 40%, #0042A9 63%, #01C2FA 100%) top left no-repeat,
                     #000;
-        padding-top: 80px;
-
-        header {
-            padding-bottom: 40px;
-        }
-
-        ol {
-            margin-top: 60px;
-        }
-
-        footer {
-            margin-top: 80px;
-        }
 
         .outer-container {
             margin: 0 auto;
@@ -231,7 +234,7 @@ main {
 html[dir="rtl"] main {
 
     ol {
-        margin: 40px 30px 40px 0;
+        margin: 0 30px 40px 0;
     }
 
     .share-options li a {


### PR DESCRIPTION
## Description
This makes some layout tweaks to bring the download button higher up the page (let's pretend a fold exists for the moment). Main tweaks are:

* lose the horizontal rule between tagline and steps.
* move the step numbers inline with the steps (in windows wide enough).
* reduce step font-size (since the columns are narrower).
* generally tighten up spacing all around.

The arbitrary target size was 1280x800, anything shorter may still have to scroll but such is the nature of the web.

This also updates the GA tagging on the share links.

## Issue / Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1429321

## Testing
https://bedrock-demo-craigcook.us-west.moz.works/en-US/firefox/switch/
