### PR TITLE
Add functional tests for /firefox/switch and locale-specific /whatsnew pages

### DIFF
--- a/tests/functional/firefox/test_switch.py
+++ b/tests/functional/firefox/test_switch.py
@@ -1,0 +1,13 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import pytest
+
+from pages.firefox.switch import FirefoxSwitchPage
+
+
+@pytest.mark.nondestructive
+def test_download_button_displayed(base_url, selenium):
+    page = FirefoxSwitchPage(selenium, base_url).open()
+    assert page.download_button.is_displayed

--- a/tests/functional/firefox/test_whatsnew.py
+++ b/tests/functional/firefox/test_whatsnew.py
@@ -33,3 +33,19 @@ def test_qr_code_locale(base_url, selenium):
     page = FirefoxWhatsNewPage(selenium, base_url, locale='it').open()
     assert not page.send_to_device.is_displayed
     assert page.is_qr_code_displayed
+
+
+@pytest.mark.skip_if_not_firefox(reason='Whatsnew pages are shown to Firefox only.')
+@pytest.mark.nondestructive
+def test_firefox_rocket_qr_code(base_url, selenium):
+    page = FirefoxWhatsNewPage(selenium, base_url, locale='id').open()
+    assert not page.send_to_device.is_displayed
+    assert page.is_qr_code_displayed
+
+
+@pytest.mark.skip_if_not_firefox(reason='Whatsnew pages are shown to Firefox only.')
+@pytest.mark.nondestructive
+def test_qr_code_th_tw_locale(base_url, selenium):
+    page = FirefoxWhatsNewPage(selenium, base_url, locale='zh-TW').open()
+    assert not page.send_to_device.is_displayed
+    assert page.is_zh_tw_qr_code_displayed

--- a/tests/pages/firefox/switch.py
+++ b/tests/pages/firefox/switch.py
@@ -1,0 +1,20 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from selenium.webdriver.common.by import By
+
+from pages.firefox.base import FirefoxBasePage
+from pages.regions.download_button import DownloadButton
+
+
+class FirefoxSwitchPage(FirefoxBasePage):
+
+    URL_TEMPLATE = '/{locale}/firefox/switch/'
+
+    _download_button_locator = (By.ID, 'download-button-desktop-release')
+
+    @property
+    def download_button(self):
+        el = self.find_element(*self._download_button_locator)
+        return DownloadButton(self, root=el)

--- a/tests/pages/firefox/whatsnew.py
+++ b/tests/pages/firefox/whatsnew.py
@@ -13,6 +13,7 @@ class FirefoxWhatsNewPage(FirefoxBasePage):
     URL_TEMPLATE = '/{locale}/firefox/whatsnew/'
 
     _qr_code_locator = (By.CSS_SELECTOR, '#qr-wrapper > img')
+    _zh_tw_qr_code_locator = (By.CSS_SELECTOR, 'img.qrcode')
 
     @property
     def send_to_device(self):
@@ -21,3 +22,7 @@ class FirefoxWhatsNewPage(FirefoxBasePage):
     @property
     def is_qr_code_displayed(self):
         return self.is_element_displayed(*self._qr_code_locator)
+
+    @property
+    def is_zh_tw_qr_code_displayed(self):
+        return self.is_element_displayed(*self._zh_tw_qr_code_locator)


### PR DESCRIPTION
## Description
- Adds functional tests for:
  - `/firefox/switch/`
  - `/id/firefox/whatsnew/`
  - `/zh-TW/firefox/whatsnew/`

## Issue / Bugzilla link
N/A

## Testing
Successful test run: https://ci.us-west.moz.works/blue/organizations/jenkins/bedrock_multibranch_pipeline/detail/run-integration-tests/168/pipeline/