### PR TITLE
Add Oregon-B cluster to deployment

### DIFF
--- a/jenkins/branches/master.yml
+++ b/jenkins/branches/master.yml
@@ -6,6 +6,7 @@ regions:
   - usw
   - tokyo
   - frankfurt
+  - oregon-b
 apps:
   - bedrock-dev
 integration_tests:
@@ -16,4 +17,6 @@ integration_tests:
   tokyo:
     - firefox
   frankfurt:
+    - firefox
+  oregon-b:
     - firefox

--- a/jenkins/branches/prod.yml
+++ b/jenkins/branches/prod.yml
@@ -7,6 +7,7 @@ regions:
   - usw
   - tokyo
   - frankfurt
+  - oregon-b
 apps:
   - bedrock-stage
   - bedrock-prod
@@ -21,4 +22,6 @@ integration_tests:
   tokyo:
     - firefox
   frankfurt:
+    - firefox
+  oregon-b:
     - firefox

--- a/jenkins/global.yml
+++ b/jenkins/global.yml
@@ -16,3 +16,7 @@ regions:
     deis_profile: frankfurt
     name: frankfurt
     deis_bin: deis2
+  oregon-b:
+    deis_profile: oregon-b
+    name: oregon-b
+    deis_bin: deis2


### PR DESCRIPTION
For now this adds it as the last cluster for dev, stage, and prod deployments. It will be shuffeled to the primary cluster when us-west is decommissioned.