### PR TITLE
[fix bug 1415622] Fix utm_source param on /firstrun iframe

### DIFF
--- a/bedrock/firefox/templates/firefox/firstrun/firstrun_quantum.html
+++ b/bedrock/firefox/templates/firefox/firstrun/firstrun_quantum.html
@@ -102,6 +102,8 @@
       </div>
       <div class="fxaccounts" id="fxa-iframe-config" data-host="{{ settings.FXA_IFRAME_SRC }}" data-mozillaonline-host="{{ settings.FXA_IFRAME_SRC_MOZILLAONLINE }}">
         {% block iframe %}
+          {# Bug 1354710: firstrun pages need to pass funnelcake parameters to FxA #}
+          {% set utm_source = 'firstrun' if not funnelcake_id else 'firstrun_f' + funnelcake_id %}
           <iframe id="fxa" scrolling="no" data-src="{{ settings.FXA_IFRAME_SRC }}signin?utm_campaign=fxa-embedded-form&amp;utm_medium=referral&amp;utm_source={{ utm_source }}&amp;utm_content=fx-{{ version }}&amp;entrypoint=firstrun&amp;service=sync&amp;context=iframe&amp;style=chromeless&amp;haltAfterSignIn=true"></iframe>
         {% endblock %}
         <button id="skip-button">{{_('Skip this step')}}</button>


### PR DESCRIPTION
## Description
- Fixes missing `utm_source` param value on /firstrun FxA iframe.

## Issue / Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1415622

## Testing
- iFrame should load with `utm_source=firstrun` or `utm_source=firstrun_f111` when the page is loaded with a funnel cake parameter i.e. `/firstrun/?f=111`.
