### PR TITLE
[fix bug 1429891] Highlight current link/page in sub navigation menus

### DIFF
--- a/bedrock/firefox/templates/firefox/home.html
+++ b/bedrock/firefox/templates/firefox/home.html
@@ -22,7 +22,9 @@
 {% endblock %}
 
 {% block content %}
-{% include 'firefox/includes/hub/sub-nav.html' %}
+{% with current='desktop' %}
+  {% include 'firefox/includes/hub/sub-nav.html' %}
+{% endwith %}
 <main role="main">
   <header class="page-section main-header-section">
     <div class="content">

--- a/bedrock/firefox/templates/firefox/includes/hub/sub-nav.html
+++ b/bedrock/firefox/templates/firefox/includes/hub/sub-nav.html
@@ -17,8 +17,8 @@
 
 {% block sub_nav_primary_links %}
   {% set blog_url = 'https://blog.mozilla.org/firefox-de/' if LANG == 'de' else 'https://blog.mozilla.org/firefox/' %}
-  <li><a href="{{ url('firefox') }}" data-link-name="Desktop" data-link-type="nav" data-link-position="subnav">{{ _('Desktop') }}</a></li>
-  <li><a href="{{ url('firefox.mobile') }}" data-link-name="Mobile" data-link-type="nav" data-link-position="subnav">{{ _('Mobile') }}</a></li>
+  <li><a {% if current == 'desktop' %}class="current"{% endif %} href="{{ url('firefox') }}" data-link-name="Desktop" data-link-type="nav" data-link-position="subnav">{{ _('Desktop') }}</a></li>
+  <li><a {% if current == 'mobile' %}class="current"{% endif %} href="{{ url('firefox.mobile') }}" data-link-name="Mobile" data-link-type="nav" data-link-position="subnav">{{ _('Mobile') }}</a></li>
   <li><a href="https://addons.mozilla.org/firefox/?utm_source=www.mozilla.org&amp;utm_medium=referral&amp;utm_campaign=fx-sub-nav" data-link-name="Extensions" data-link-type="nav" data-link-position="subnav">{{ _('Extensions') }}</a></li>
   <li><a href="https://support.mozilla.org/?utm_source=www.mozilla.org&amp;utm_medium=referral&amp;utm_campaign=fx-sub-nav" data-link-name="Support" data-link-type="nav" data-link-position="subnav">{{ _('Support') }}</a></li>
   <li><a href="{{ blog_url }}?utm_source=www.mozilla.org&amp;utm_medium=referral&amp;utm_campaign=fx-sub-nav" data-link-name="Blog" data-link-type="nav" data-link-position="subnav">{{ _('Blog') }}</a></li>

--- a/bedrock/firefox/templates/firefox/mobile.html
+++ b/bedrock/firefox/templates/firefox/mobile.html
@@ -18,7 +18,9 @@
 {% set show_send_to_device = LANG in settings.SEND_TO_DEVICE_LOCALES %}
 
 {% block content %}
-  {% include 'firefox/includes/hub/sub-nav.html' %}
+  {% with current='mobile' %}
+    {% include 'firefox/includes/hub/sub-nav.html' %}
+  {% endwith %}
 
   <main role="main">
     <header class="main-header">

--- a/bedrock/mozorg/templates/mozorg/developer/includes/sub-nav.html
+++ b/bedrock/mozorg/templates/mozorg/developer/includes/sub-nav.html
@@ -7,22 +7,10 @@
 {% block sub_nav_class %}technology{% endblock %}
 
 {% block sub_nav_primary_links %}
-<li>
-  <a href="{{ url('mozorg.developer') }}" data-link-name="Developer Hub" data-link-type="nav" data-link-position="subnav">{{ _('Developer Hub') }}</a>
-</li>
-<li>
-  <a href="https://research.mozilla.org/?utm_source=www.mozilla.org&amp;utm_medium=referral&amp;utm_campaign=dev-tech-sub-nav&amp;utm_content=Research" data-link-name="Research" data-link-type="nav" data-link-position="subnav">{{ _('Research') }}</a>
-</li>
-<li>
-  <a href="https://vr.mozilla.org/?utm_source=www.mozilla.org&amp;utm_medium=referral&amp;utm_campaign=dev-tech-sub-nav&amp;utm_content=VR" data-link-name="Virtual Reality" data-link-type="nav" data-link-position="subnav">{{ _('Virtual Reality') }}</a>
-</li>
-<li>
-  <a href="https://games.mozilla.org/?utm_source=www.mozilla.org&amp;utm_medium=referral&amp;utm_campaign=dev-tech-sub-nav&amp;utm_content=Games" data-link-name="Games" data-link-type="nav" data-link-position="subnav">{{ _('Games') }}</a>
-</li>
-<li>
-  <a href="https://developer.mozilla.org/?utm_source=www.mozilla.org&amp;utm_medium=referral&amp;utm_campaign=dev-tech-sub-nav&amp;utm_content=Documentation" data-link-name="Documentation" data-link-type="nav" data-link-position="subnav">{{ _('Documentation') }}</a>
-</li>
-<li>
-  <a href="https://hacks.mozilla.org/?utm_source=www.mozilla.org&amp;utm_medium=referral&amp;utm_campaign=dev-tech-sub-nav&amp;utm_content=HacksBlog" data-link-name="Hacks Blog" data-link-type="nav" data-link-position="subnav">{{ _('Hacks blog') }}</a>
-</li>
+<li><a {% if current == 'developer' %}class="current"{% endif %} href="{{ url('mozorg.developer') }}" data-link-name="Developer Hub" data-link-type="nav" data-link-position="subnav">{{ _('Developer Hub') }}</a></li>
+<li><a href="https://research.mozilla.org/?utm_source=www.mozilla.org&amp;utm_medium=referral&amp;utm_campaign=dev-tech-sub-nav&amp;utm_content=Research" data-link-name="Research" data-link-type="nav" data-link-position="subnav">{{ _('Research') }}</a></li>
+<li><a href="https://vr.mozilla.org/?utm_source=www.mozilla.org&amp;utm_medium=referral&amp;utm_campaign=dev-tech-sub-nav&amp;utm_content=VR" data-link-name="Virtual Reality" data-link-type="nav" data-link-position="subnav">{{ _('Virtual Reality') }}</a></li>
+<li><a href="https://games.mozilla.org/?utm_source=www.mozilla.org&amp;utm_medium=referral&amp;utm_campaign=dev-tech-sub-nav&amp;utm_content=Games" data-link-name="Games" data-link-type="nav" data-link-position="subnav">{{ _('Games') }}</a></li>
+<li><a href="https://developer.mozilla.org/?utm_source=www.mozilla.org&amp;utm_medium=referral&amp;utm_campaign=dev-tech-sub-nav&amp;utm_content=Documentation" data-link-name="Documentation" data-link-type="nav" data-link-position="subnav">{{ _('Documentation') }}</a></li>
+<li><a href="https://hacks.mozilla.org/?utm_source=www.mozilla.org&amp;utm_medium=referral&amp;utm_campaign=dev-tech-sub-nav&amp;utm_content=HacksBlog" data-link-name="Hacks Blog" data-link-type="nav" data-link-position="subnav">{{ _('Hacks blog') }}</a></li>
 {% endblock %}

--- a/bedrock/mozorg/templates/mozorg/developer/index.html
+++ b/bedrock/mozorg/templates/mozorg/developer/index.html
@@ -31,7 +31,9 @@
 {% endblock %}
 
 {% block content %}
-{% include 'mozorg/developer/includes/sub-nav.html' %}
+{% with current='developer' %}
+  {% include 'mozorg/developer/includes/sub-nav.html' %}
+{% endwith %}
 {% include 'mozorg/developer/includes/icon-sprite.svg' %}
 
 {% set lazy_image_placeholder = 'img/mozorg/developer/hub/placeholder.png' %}

--- a/bedrock/mozorg/templates/mozorg/internet-health/decentralization.html
+++ b/bedrock/mozorg/templates/mozorg/internet-health/decentralization.html
@@ -29,7 +29,9 @@
 {% endblock %}
 
 {% block content %}
-{% include 'mozorg/internet-health/includes/sub-nav.html' %}
+{% with current='decentralization' %}
+  {% include 'mozorg/internet-health/includes/sub-nav.html' %}
+{% endwith %}
 
 <main role="main">
   <header class="section main-header">

--- a/bedrock/mozorg/templates/mozorg/internet-health/digital-inclusion.html
+++ b/bedrock/mozorg/templates/mozorg/internet-health/digital-inclusion.html
@@ -29,7 +29,9 @@
 {% endblock %}
 
 {% block content %}
-{% include 'mozorg/internet-health/includes/sub-nav.html' %}
+{% with current='inclusion' %}
+  {% include 'mozorg/internet-health/includes/sub-nav.html' %}
+{% endwith %}
 
 <main role="main">
   <header class="section main-header">

--- a/bedrock/mozorg/templates/mozorg/internet-health/includes/sub-nav.html
+++ b/bedrock/mozorg/templates/mozorg/internet-health/includes/sub-nav.html
@@ -7,10 +7,10 @@
 {% block sub_nav_class %}internet-health{% endblock %}
 
 {% block sub_nav_primary_links %}
-<li><a href="{{ url('mozorg.internet-health') }}" data-link-name="About" data-link-type="nav" data-link-position="subnav">{{ _('About') }}</a></li>
-<li><a href="{{ url('mozorg.internet-health.privacy-security') }}" data-link-name="Privacy & Security" data-link-type="nav" data-link-position="subnav">{{ _('Privacy &amp; Security') }}</a></li>
-<li><a href="{{ url('mozorg.internet-health.open-innovation') }}" data-link-name="Openness" data-link-type="nav" data-link-position="subnav">{{ _('Openness') }}</a></li>
-<li><a href="{{ url('mozorg.internet-health.decentralization') }}" data-link-name="Decentralization" data-link-type="nav" data-link-position="subnav">{{ _('Decentralization') }}</a></li>
-<li><a href="{{ url('mozorg.internet-health.digital-inclusion') }}" data-link-name="Digital Inclusion" data-link-type="nav" data-link-position="subnav">{{ _('Digital Inclusion') }}</a></li>
-<li><a href="{{ url('mozorg.internet-health.web-literacy') }}" data-link-name="Web Literacy" data-link-type="nav" data-link-position="subnav">{{ _('Web Literacy') }}</a></li>
+<li><a {% if current == 'about' %}class="current"{% endif %} href="{{ url('mozorg.internet-health') }}" data-link-name="About" data-link-type="nav" data-link-position="subnav">{{ _('About') }}</a></li>
+<li><a {% if current == 'privacy' %}class="current"{% endif %} href="{{ url('mozorg.internet-health.privacy-security') }}" data-link-name="Privacy & Security" data-link-type="nav" data-link-position="subnav">{{ _('Privacy &amp; Security') }}</a></li>
+<li><a {% if current == 'openness' %}class="current"{% endif %} href="{{ url('mozorg.internet-health.open-innovation') }}" data-link-name="Openness" data-link-type="nav" data-link-position="subnav">{{ _('Openness') }}</a></li>
+<li><a {% if current == 'decentralization' %}class="current"{% endif %} href="{{ url('mozorg.internet-health.decentralization') }}" data-link-name="Decentralization" data-link-type="nav" data-link-position="subnav">{{ _('Decentralization') }}</a></li>
+<li><a {% if current == 'inclusion' %}class="current"{% endif %} href="{{ url('mozorg.internet-health.digital-inclusion') }}" data-link-name="Digital Inclusion" data-link-type="nav" data-link-position="subnav">{{ _('Digital Inclusion') }}</a></li>
+<li><a {% if current == 'literacy' %}class="current"{% endif %} href="{{ url('mozorg.internet-health.web-literacy') }}" data-link-name="Web Literacy" data-link-type="nav" data-link-position="subnav">{{ _('Web Literacy') }}</a></li>
 {% endblock %}

--- a/bedrock/mozorg/templates/mozorg/internet-health/index.html
+++ b/bedrock/mozorg/templates/mozorg/internet-health/index.html
@@ -33,7 +33,9 @@
 {% endblock %}
 
 {% block content %}
-{% include 'mozorg/internet-health/includes/sub-nav.html' %}
+{% with current='about' %}
+  {% include 'mozorg/internet-health/includes/sub-nav.html' %}
+{% endwith %}
 
 <main role="main">
   <header class="header-intro">

--- a/bedrock/mozorg/templates/mozorg/internet-health/open-innovation.html
+++ b/bedrock/mozorg/templates/mozorg/internet-health/open-innovation.html
@@ -29,7 +29,9 @@
 {% endblock %}
 
 {% block content %}
-{% include 'mozorg/internet-health/includes/sub-nav.html' %}
+{% with current='openness' %}
+  {% include 'mozorg/internet-health/includes/sub-nav.html' %}
+{% endwith %}
 
 <main role="main">
   <header class="section main-header">

--- a/bedrock/mozorg/templates/mozorg/internet-health/privacy-security.html
+++ b/bedrock/mozorg/templates/mozorg/internet-health/privacy-security.html
@@ -33,7 +33,9 @@
 {% endblock %}
 
 {% block content %}
-{% include 'mozorg/internet-health/includes/sub-nav.html' %}
+{% with current='privacy' %}
+  {% include 'mozorg/internet-health/includes/sub-nav.html' %}
+{% endwith %}
 
 <main role="main">
   <header class="section main-header">

--- a/bedrock/mozorg/templates/mozorg/internet-health/web-literacy.html
+++ b/bedrock/mozorg/templates/mozorg/internet-health/web-literacy.html
@@ -29,7 +29,9 @@
 {% endblock %}
 
 {% block content %}
-{% include 'mozorg/internet-health/includes/sub-nav.html' %}
+{% with current='literacy' %}
+  {% include 'mozorg/internet-health/includes/sub-nav.html' %}
+{% endwith %}
 
 <main role="main">
   <header class="section main-header">

--- a/media/css/hubs/_sub-nav.scss
+++ b/media/css/hubs/_sub-nav.scss
@@ -156,6 +156,14 @@
             a:focus {
                 color: $theme-color;
             }
+
+            a.current {
+                color: $theme-color;
+
+                &:hover {
+                    cursor: default;
+                }
+            }
         }
 
         .sub-nav-logo-link {


### PR DESCRIPTION
## Description
- Highlights the current page/link in the sub nav manus under Firefox, Internet Health, and Technology.

## Issue / Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1429891

## Testing
- Make sure all pages show the correct current hightlight color when navigating through the menus.