### PR TITLE
Fix multiple objects returned error for release notes

### DIFF
--- a/bedrock/releasenotes/models.py
+++ b/bedrock/releasenotes/models.py
@@ -124,7 +124,7 @@ class ProductReleaseManager(models.Manager):
         release_objs = []
         rn_path = os.path.join(settings.RELEASE_NOTES_PATH, 'releases')
         with transaction.atomic(using=self.db):
-            self.all().delete()
+            self.get_queryset(include_drafts=True).delete()
             releases = glob(os.path.join(rn_path, '*.json'))
             for release_file in releases:
                 with codecs.open(release_file, 'r', encoding='utf-8') as rel_fh:

--- a/bedrock/releasenotes/tests/test_models.py
+++ b/bedrock/releasenotes/tests/test_models.py
@@ -147,3 +147,11 @@ class TestGetLatestRelease(TestCase):
     def test_latest_release(self):
         correct_release = models.get_release('firefox for android', '56.0.2')
         assert models.get_latest_release('firefox for android', 'release') == correct_release
+
+    def test_non_public_release_not_duped(self):
+        # refresh again
+        models.ProductRelease.objects.refresh()
+        release_cache.clear()
+        # non public release
+        # should NOT raise multiple objects error
+        assert models.get_release('firefox for android', '56.0.3', include_drafts=True)


### PR DESCRIPTION
Drafts were not being deleted on refresh of data when DEV = False (as it is in production. This fixes that.