### PR TITLE
Fix Bug 1425454 - The onboarding flow should end up focusing the awesomebar instead of the search box in the page

### DIFF
--- a/media/js/firefox/firstrun/firstrun_quantum.js
+++ b/media/js/firefox/firstrun/firstrun_quantum.js
@@ -11,7 +11,7 @@
     }
 
     var beginAnimation = function (syncConfig) {
-        var redirectDest = 'about:home';
+        var redirectDest = 'about:newtab';
 
         var scene = document.getElementById('scene');
         var skipbutton = document.getElementById('skip-button');
@@ -38,7 +38,12 @@
         var onVerificationComplete = function () {
             scene.dataset.signIn = 'true';
             document.getElementById('white-overlay').addEventListener('transitionend', function() {
-                window.location.href = redirectDest;
+                // Specially navigate to about:newtab and focus address bar
+                if (redirectDest === 'about:newtab') {
+                    Mozilla.UITour.showNewTab();
+                } else {
+                    window.location.href = redirectDest;
+                }
             }, false);
         };
 


### PR DESCRIPTION
## Description
Use UITour method to navigate to about:newtab (normally `Error: Access to 'about:newtab' from script denied`) that is also being updated to focus the address bar.

## Issue / Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1425454

## Testing
https://bug1425454.bmoattachments.org/attachment.cgi?id=8946540