### PR TITLE
Add Android APK link to mobile download modal

### DIFF
--- a/bedrock/firefox/templates/firefox/mobile.html
+++ b/bedrock/firefox/templates/firefox/mobile.html
@@ -331,6 +331,11 @@
         <li class="android">
           {{ google_play_button(alt_href=settings.GOOGLE_PLAY_FIREFOX_FOCUS_LINK, anchor_attributes={'data-link-type': 'download', 'data-download-os': 'Android', 'id': 'playStoreLink'}) }}
         </li>
+        {% if l10n_has_tag('focus_apk_link_012018') %}
+        <li class="android-apk">
+            <a href="https://archive.mozilla.org/pub/android/focus/latest/" data-link-type="download" data-download-os="Android">{{ _('Download the APK') }}</a>
+        </li>
+        {% endif %}
         <li class="ios">
           <a id="appStoreLink" href="{{ settings.APPLE_APPSTORE_FIREFOX_FOCUS_LINK }}" data-link-type="download" data-download-os="iOS">
             <img src="{{ l10n_img('firefox/ios/btn-app-store.svg') }}" alt="{{ _('Download on the App Store') }}" width="152" height="45">

--- a/media/css/firefox/mobile.scss
+++ b/media/css/firefox/mobile.scss
@@ -875,6 +875,7 @@ html[dir="rtl"] {
 
     @media #{$mq-phone-wide} {
         @supports (display: flex) {
+            align-items: center;
             display: flex;
             justify-content: space-between;
             margin: 1em auto;
@@ -883,7 +884,17 @@ html[dir="rtl"] {
             &.hidden {
                 display: none;
             }
+
+            li {
+                margin: 0 auto; // so that a single item is centred
+            }
         }
+    }
+
+    .android-apk a {
+        display: inline-block;
+        margin: 10px 0;
+        @include font-size-level5;
     }
 }
 
@@ -951,6 +962,17 @@ body[data-modal-product='focus'] #modal .window .inner {
     background: #ce2473;
     background: url('/media/img/firefox/mobile/tail-focus.svg') center center no-repeat,
     linear-gradient(to bottom, #ce2473 10%, #701979 100%);
+
+    a {
+        color: #ffffff;
+    }
+
+    a:hover,
+    a:focus,
+    a:active {
+        color: #ffffff;
+        text-decoration: none;
+    }
 }
 
 #send-to-device {
@@ -1057,6 +1079,16 @@ body[data-modal-product='focus'] #modal .window .inner {
     #send-to-device {
         display: none;
     }
+}
+
+// hide download links for one platform from the other
+.android .mobile-download-buttons .ios {
+    display: none;
+}
+
+.ios .mobile-download-buttons .android,
+.ios .mobile-download-buttons .android-apk {
+    display: none;
 }
 
 // hide page-level app store badge wrapper if JS is available


### PR DESCRIPTION
## Description
Add Android APK link to mobile download modal on /firefox/mobile/

## Issue / Bugzilla link
[Bug 1434019](https://bugzilla.mozilla.org/show_bug.cgi?id=1434019)

## Testing
- [ ] link appears to Android users
- [ ] link does not appear to iOS or desktop users
- [ ] link goes to download directory
- [ ] sufficient test coverage