### PR TITLE
[fix bug 1386622] force full win installers in modal on /new page.

### DIFF
--- a/bedrock/firefox/templates/firefox/new/scene1.html
+++ b/bedrock/firefox/templates/firefox/new/scene1.html
@@ -100,7 +100,7 @@
     <section class="section-other-platforms">
       <h4>{{ _('Advanced Install Options & Other Platforms') }}</h4>
 
-      {{ download_firefox_desktop_list() }}
+      {{ download_firefox_desktop_list(force_full_installer=True) }}
 
       <ul class="other-platforms-mobile">
         <li class="android">


### PR DESCRIPTION
## Description

Windows installer links in the "Advanced install options & other platforms" should point to the full installers. (Currently pointing to stub installer for both 32 and 64-bit links.)

## Issue / Bugzilla link

https://bugzilla.mozilla.org/show_bug.cgi?id=1386622#c38

## Testing

Ensure no regressions.
