### PR TITLE
Fix Bug 1430027 - On the download page, for Linux, highlight the 64-bit version (to limit the number of 32 downloads)

### DIFF
--- a/bedrock/base/templates/product-all-macros.html
+++ b/bedrock/base/templates/product-all-macros.html
@@ -50,10 +50,19 @@
             {% endif %}
         </caption>
         <thead>
+          {% if platform_cls %}
+            <tr>
+              <th scope="col" rowspan="2" class="language">{{ _('Language') }}</th>
+              <th scope="col" colspan="{{ platform_cls.recommended|length }}" class="cls recommended">{{ _('Recommended') }}</th>
+              <th scope="col" colspan="{{ platform_cls.traditional|length }}" class="cls traditional">&nbsp;</th>
+            </tr>
+          {% endif %}
           <tr>
-            <th scope="col">{{ _('Language') }}</th>
+            {% if not platform_cls %}
+              <th scope="col" class="language">{{ _('Language') }}</th>
+            {% endif %}
             {% for p_name, p_label in platforms %}
-              <th scope="col" class="{{ p_name }}">{{ p_label|replace('\n', '<br>'|safe) }}</th>
+              <th scope="col" class="{{ p_name }}{% if platform_cls %} {{ 'recommended' if p_name in platform_cls.recommended else 'traditional' }}{% endif %}">{{ p_label|replace('\n', '<br>'|safe) }}</th>
             {% endfor %}
           </tr>
         </thead>
@@ -87,7 +96,7 @@
 #}
 {% macro build_link(build, platform, tooltip) %}
   {% if build.platforms[platform] %}
-    <td class="download {{ platform }}">
+    <td class="download {{ platform }}{% if platform_cls %} {{ 'recommended' if platform in platform_cls.recommended else 'traditional' }}{% endif %}">
         <a href="{{ build.platforms[platform].download_url }}" title="{{ tooltip }}"
            data-download-version="{{ platform }}" data-download-language="{{ build.name_en|lower}}" data-link-type="download"
            {% if platform == 'android' %} data-download-os="Android"

--- a/bedrock/firefox/firefox_details.py
+++ b/bedrock/firefox/firefox_details.py
@@ -42,6 +42,12 @@ class FirefoxDesktop(_ProductDetails):
         ('linux', 'Linux 32-bit'),
     ])
 
+    # Recommended/modern vs traditional/legacy platforms
+    platform_classification = OrderedDict([
+        ('recommended', ('win64', 'osx', 'linux64')),
+        ('traditional', ('win', 'winsha1', 'linux')),
+    ])
+
     # Human-readable channel names
     channel_labels = {
         'nightly': _('Firefox Nightly'),
@@ -69,8 +75,20 @@ class FirefoxDesktop(_ProductDetails):
     def get_bouncer_url(self, platform):
         return self.sha1_bouncer_url if not switch('disable-sha1-downloads') and platform == 'winsha1' else self.bouncer_url
 
-    def platforms(self, channel='release'):
-        platforms = self.platform_labels.copy()
+    def platforms(self, channel='release', classified=False):
+        """
+        Get the desktop platform dictionary containing slugs and corresponding
+        labels. If the classified option is True, it will be ordered by the
+        classification where recommended platforms go first, otherwise a simple
+        copy of platform_labels will be returned.
+        """
+        if classified:
+            platforms = OrderedDict()
+            for k, v in self.platform_classification.iteritems():
+                for platform in v:
+                    platforms[platform] = self.platform_labels[platform]
+        else:
+            platforms = self.platform_labels.copy()
 
         return platforms.items()
 
@@ -290,6 +308,10 @@ class FirefoxAndroid(_ProductDetails):
         ('x86', _('Intel devices\n(Android %s+ x86 CPU)')),
     ])
 
+    # Recommended/modern vs traditional/legacy platforms
+    # Unused but required to match FirefoxDesktop
+    platform_classification = None
+
     # Human-readable channel names
     channel_labels = {
         'nightly': _('Firefox Nightly'),
@@ -341,7 +363,12 @@ class FirefoxAndroid(_ProductDetails):
         'x86': archive_url_base + '-%s/fennec-%s.multi.android-i386.apk',
     }
 
-    def platforms(self, channel='release'):
+    def platforms(self, channel='release', classified=False):
+        """
+        Get the Android platform dictionary containing slugs and corresponding
+        labels. The classified option is unused but required to match the
+        FirefoxDesktop implementation.
+        """
         # Use an OrderedDict to always put the ARM build in front
         platforms = OrderedDict()
 

--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -253,7 +253,8 @@ def all_downloads(request, platform, channel):
 
     context = {
         'platform': platform,
-        'platforms': product.platforms(channel),
+        'platforms': product.platforms(channel, True),
+        'platform_cls': product.platform_classification,
         'full_builds_version': version.split('.', 1)[0],
         'full_builds': product.get_filtered_full_builds(channel, version, query),
         'test_builds': product.get_filtered_test_builds(channel, version, query),

--- a/media/css/firefox/all.less
+++ b/media/css/firefox/all.less
@@ -85,10 +85,17 @@
         width: 100%;
         thead {
             th {
+                vertical-align: bottom;
                 white-space: nowrap;
+                &.cls {
+                    padding-bottom: 0;
+                    text-align: center;
+                    font-weight: bold;
+                }
             }
-            th, td {
-                padding: 10px 0;
+            tr:last-child:not(:first-child) th {
+                padding-top: 0;
+                text-align: center;
             }
         }
         tbody {
@@ -103,15 +110,21 @@
             tr:target th {
                 padding-left: 10px;
             }
-            th, td {
-                padding: 10px 10px 10px 0;
-            }
             th {
                 font-weight: normal;
                 strong, span {
                     display: block;
                 }
             }
+        }
+        th, td {
+            padding: 10px;
+        }
+        .recommended {
+            background-color: rgba(255, 255, 255, .5);
+        }
+        tr:target .recommended {
+            background-color: rgba(255, 255, 255, .1);
         }
         .unavailable {
             padding: 10px;
@@ -120,10 +133,9 @@
             text-shadow: 0 -1px #fff;
         }
         .download {
-            padding: 10px 0;
             a {
                 display: block;
-                padding: 10px 10px 10px 45px;
+                padding: 10px 0 10px 45px;
                 background: transparent url('/media/img/firefox/all/download-icons-desktop.png') left top no-repeat;
             }
 
@@ -149,7 +161,18 @@
             &.android-x86 a {
                 background-position: 0 -80px;
             }
+            &.traditional a {
+                opacity: .7;
+            }
         }
+    }
+}
+
+/* Nightly and DevEdition */
+body.blueprint,
+body.space {
+    #main-content table .recommended {
+        background-color: rgba(255, 255, 255, .1);
     }
 }
 


### PR DESCRIPTION
## Description

* Highlight recommended builds on the [Firefox download page](https://www.mozilla.org/en-US/firefox/all/)
* l10n: there is 1 new string: _Recommended_

## Issue / Bugzilla link

[Bug 1430027 - On the download page, for Linux, highlight the 64-bit version (to limit the number of 32 downloads)](https://bugzilla.mozilla.org/show_bug.cgi?id=1430027)

## Testing

* [Demo server](https://bedrock-demo-firefox-all.us-west.moz.works/en-US/firefox/all/) is available
* The change should not affect download pages other than Firefox for desktop.
