### PR TITLE
[fix bug 1429849] Hide button in top nav on /firefox/mobile/

### DIFF
--- a/media/css/firefox/mobile.scss
+++ b/media/css/firefox/mobile.scss
@@ -8,6 +8,7 @@
 @import '../hubs/masthead';
 @import '../hubs/sections';
 @import '../hubs/sub-nav';
+@import '../hubs/nav-download-button-remove';
 @import '../quantum/common';
 @import '../quantum/features-scroller';
 

--- a/media/css/hubs/_nav-download-button-remove.scss
+++ b/media/css/hubs/_nav-download-button-remove.scss
@@ -1,0 +1,51 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+@import '../pebbles/includes/lib';
+
+// Bug 1429849 - Overrides to hide the download button in global navigation and sub navigation
+
+/* -------------------------------------------------------------------------- */
+// global navigation and sub navigation
+
+#global-nav-download-firefox,
+#sub-nav-download-firefox {
+    display: none;
+}
+
+.moz-global-nav .nav-primary-links {
+    @media #{$mq-tablet} {
+        width: calc(100% - 160px);
+    }
+
+    @media #{$mq-desktop} {
+        width: calc(100% - 270px);
+    }
+
+}
+
+.moz-sub-nav .sub-nav-primary-links-container {
+    width: 100%;
+}
+
+/* -------------------------------------------------------------------------- */
+// Legacy navigation overrides for non en-US localized pages
+
+#nav-download-firefox {
+    display: none;
+}
+
+#masthead {
+    @media #{$mq-tablet} {
+        .masthead-nav-main {
+            width: calc(100% - 120px);
+        }
+    }
+
+    @media #{$mq-desktop-wide} {
+        .masthead-nav-main {
+            width: calc(100% - 140px);
+        }
+    }
+}


### PR DESCRIPTION
## Description
- Hides button in the top nav (& sticky sub nav) on `/firefox/mobile/` which both download the desktop product.

## Issue / Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1429849

## Testing
- Both global nav and sub nav buttons should be hidden.
