### PR TITLE
Fix Bug 1436437 - Change one instance of LongBrandName to ShortBrandName on Nightly You've been upgraded page

### DIFF
--- a/bedrock/firefox/templates/firefox/nightly_whatsnew.html
+++ b/bedrock/firefox/templates/firefox/nightly_whatsnew.html
@@ -49,8 +49,7 @@
             <p>
               {% trans %}
                 This is a good time to thank you for helping us make Firefox better and to give you some pointers to
-                documentation, communication channels and news sites related to Firefox Nightly that may be of interest
-                to you.
+                documentation, communication channels and news sites related to Nightly that may be of interest to you.
               {% endtrans %}
             </p>
             <p>


### PR DESCRIPTION
## Description

* Change Firefox Nightly to Nightly on the [whatsnew page](https://www.mozilla.org/en-US/firefox/59.0a1/whatsnew/) for copy consistency.
* The localized strings will be updated by @peiying2 or @flodolo so no l10n tag is added here.

## Issue / Bugzilla link

[Bug 1436437 - Change one instance of LongBrandName to ShortBrandName on Nightly You've been upgraded page](https://bugzilla.mozilla.org/show_bug.cgi?id=1436437)

## Testing

Just open the page to see the new copy.