### PR TITLE
[bug 1434764] Add TrafficCop experiment for waitface video

### DIFF
--- a/bedrock/firefox/templates/firefox/new/wait-face/base.html
+++ b/bedrock/firefox/templates/firefox/new/wait-face/base.html
@@ -12,6 +12,12 @@
   {% endif %}
 {% endblock %}
 
+{% block experiments %}
+  {% if switch('experiment-firefox-new-waitface', ['en-US']) %}
+    {% javascript 'experiment_firefox_new_waitface' %}
+  {% endif %}
+{% endblock %}
+
 {% block extra_meta %}
   <meta name="robots" content="noindex,follow">
 {% endblock %}

--- a/bedrock/firefox/tests/test_views.py
+++ b/bedrock/firefox/tests/test_views.py
@@ -754,14 +754,26 @@ class TestFirefoxNew(TestCase):
 
     # wait face video experiment bug 1431795
 
-    def test_wait_face_video_scene_1(self, render_mock):
-        req = RequestFactory().get('/firefox/new/?xv=2xfaster')
+    def test_wait_face_video_var_a_scene_1(self, render_mock):
+        req = RequestFactory().get('/firefox/new/?xv=waitface&v=a')
+        req.locale = 'en-US'
+        views.new(req)
+        render_mock.assert_called_once_with(req, 'firefox/new/wait-face/scene1.html')
+
+    def test_wait_face_video_var_a_scene_2(self, render_mock):
+        req = RequestFactory().get('/firefox/new/?scene=2&xv=waitface&v=a')
+        req.locale = 'en-US'
+        views.new(req)
+        render_mock.assert_called_once_with(req, 'firefox/new/wait-face/scene2.html')
+
+    def test_wait_face_video_var_b_scene_1(self, render_mock):
+        req = RequestFactory().get('/firefox/new/?xv=waitface&v=b')
         req.locale = 'en-US'
         views.new(req)
         render_mock.assert_called_once_with(req, 'firefox/new/wait-face/scene1-video.html')
 
-    def test_wait_face_video_scene_2(self, render_mock):
-        req = RequestFactory().get('/firefox/new/?scene=2&xv=2xfaster')
+    def test_wait_face_video_var_b_scene_2(self, render_mock):
+        req = RequestFactory().get('/firefox/new/?scene=2&xv=waitface&v=b')
         req.locale = 'en-US'
         views.new(req)
         render_mock.assert_called_once_with(req, 'firefox/new/wait-face/scene2.html')

--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -519,8 +519,6 @@ def new(request):
                 template = 'firefox/new/sem/unsupported-browser/scene2.html'
             elif experience in ['batmfree', 'batmnimble', 'batmresist']:
                 template = 'firefox/new/batm/scene2.html'
-            elif experience == '2xfaster':
-                template = 'firefox/new/wait-face/scene2.html'
             else:
                 template = 'firefox/new/scene2.html'
         else:
@@ -535,7 +533,10 @@ def new(request):
         elif lang_file_is_active('firefox/new/sem', locale) and experience == 'fast':
             template = 'firefox/new/sem/fast/scene1.html'
         elif lang_file_is_active('firefox/new/wait-face', locale) and experience == 'waitface':
-            template = 'firefox/new/wait-face/scene1.html'
+            if variant == 'b':
+                template = 'firefox/new/wait-face/scene1-video.html'
+            else:
+                template = 'firefox/new/wait-face/scene1.html'
         elif lang_file_is_active('firefox/new/reggiewatts', locale) and experience == 'reggiewatts':
             template = 'firefox/new/reggie-watts/scene1.html'
         elif locale == 'en-US':
@@ -571,8 +572,6 @@ def new(request):
                 template = 'firefox/new/batm/nimble.html'
             elif experience == 'batmresist':
                 template = 'firefox/new/batm/resist.html'
-            elif experience == '2xfaster':
-                template = 'firefox/new/wait-face/scene1-video.html'
             else:
                 template = 'firefox/new/scene1.html'
         else:

--- a/bedrock/settings/static_media.py
+++ b/bedrock/settings/static_media.py
@@ -1327,6 +1327,13 @@ PIPELINE_JS = {
         ),
         'output_filename': 'js/firefox_new_scene1_reggie_watts-bundle.js',
     },
+    'experiment_firefox_new_waitface': {
+        'source_filenames': (
+            'js/base/mozilla-traffic-cop.js',
+            'js/firefox/new/experiment-firefox-new-waitface.js',
+        ),
+        'output_filename': 'js/experiment_firefox_new_waitface-bundle.js',
+    },
     'experiment_firefox_new_batm_anim': {
         'source_filenames': (
             'js/base/mozilla-traffic-cop.js',

--- a/media/js/firefox/new/experiment-firefox-new-waitface.js
+++ b/media/js/firefox/new/experiment-firefox-new-waitface.js
@@ -1,0 +1,43 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+
+/* Experiment: https://bugzilla.mozilla.org/show_bug.cgi?id=1434764
+ * URL: https://www.mozilla.org/en-US/firefox/new/?xv=waitface
+ * Audience: Desktop, Non-Fx, en-US with utm_medium=display&utm_source=doubleclick    
+ * Traffic: 100% audience, 50/50 split*/
+
+(function() {
+    'use strict';
+
+    var isDesktop = !/android|ios/.test(site.platform);
+
+    var notFirefox= !/\sFirefox/.test(navigator.userAgent);
+
+    var paramsMatch = function() {
+        var params = {
+            'utm_medium': 'display', 
+            'utm_source': 'doubleclick'
+        };
+
+        for (var key in params) {
+            if (!(new RegExp('[\&\?]' + key + '=' + params[key])).test(location.search)) {
+                return false;
+            }
+        }
+        return true;
+    };
+
+    if (isDesktop && notFirefox && paramsMatch()) {
+        var cop = new Mozilla.TrafficCop({
+            id: 'experiment_firefox_new_waitface',
+            variations: {
+                'v=a': 50, // 50% redirected to control
+                'v=b': 50   // 50% redirected to video content
+            }
+        });
+        cop.init();
+    }
+
+})(window.Mozilla);

--- a/media/js/firefox/new/wait-face-scene1.js
+++ b/media/js/firefox/new/wait-face-scene1.js
@@ -5,13 +5,11 @@
 (function($) {
     'use strict';
 
-    var exp;
-    var $title = $('#main-heading');
+    var extraParams = location.search.replace(/^\?/, '&');
 
     $('.download-link').each(function(i, link) {
         if (link.href.indexOf('scene=2') > -1) {
-            exp = $title.attr('data-experience');
-            link.href = link.href.replace('scene=2', 'scene=2&xv=' + exp);
+            link.href = link.href.replace('scene=2', 'scene=2' + extraParams);
         }
     });
 })(window.jQuery);


### PR DESCRIPTION
## Description
Add a trafficcop experiment to send half of visitors to an xv template to a different xv template, if they are non-Firefox desktop users in en-US with specific parameters.

## Issue / Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1434764

## Testing
Unit testing of templates passes after adjusting tests.
Sparse functional testing works as expected -- 50% of chrome visits end at the 2nd template.

## Questions for reviewers
Please consider the way this PR works with params. I believe analytics will work as we want it to work with this setup, and user flow works as expected, but would appreciate scrutiny of this approach.