### PR TITLE
[fix bug 1438373] Correct pullquote on Decentralization page

### DIFF
--- a/bedrock/mozorg/templates/mozorg/internet-health/decentralization.html
+++ b/bedrock/mozorg/templates/mozorg/internet-health/decentralization.html
@@ -205,24 +205,26 @@
           </p>
         </div>
 
+      {% if l10n_has_tag('iot_interoperable_quote') %}
         <aside class="topic-intro-aside">
           <div class="note">
             <p>
             {% trans %}
-              73% of Internet users have seen someone harassed online and 40% have personally experienced it.
+              Nearly half the economic potential of the Internet of Things relies on its systems being interoperable.
             {% endtrans %}
             </p>
             <p class="note-source">
               <cite>
-              {% trans pew='http://www.pewinternet.org/2014/10/22/online-harassment/' %}
-                Source: <a href="{{ pew }}">Pew Research</a>, 2014
+              {% trans mckinsey='http://www.mckinsey.com/business-functions/digital-mckinsey/our-insights/the-internet-of-things-the-value-of-digitizing-the-physical-world' %}
+                Source: <a href="{{ mckinsey }}">McKinsey</a>, 2015
               {% endtrans %}
               </cite>
             </p>
           </div>
           {# L10n: this is used as a decorative element in a callout box. #}
-          <span class="aside-accent" aria-hidden="true" role="presentation">{{ _('73%') }}</span>
+          <span class="aside-accent" aria-hidden="true" role="presentation">{{ _('50%') }}</span>
         </aside>
+      {% endif %}
       </div>
     </section>
 


### PR DESCRIPTION
## Description
Through some sloppy duplication on my part the wrong quote has been on this page for months. 😳 This corrects that error.

I've wrapped the entire block in the l10n tag `iot_interoperable_quote` and removed the old quote as I think it's probably better to show nothing at all than to show the wrong content.

## Issue / Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1438373
