### PR TITLE
[fix bug 1425359] Correct typos in Mitchell’s bio

### DIFF
--- a/bedrock/mozorg/templates/mozorg/about/leadership.html
+++ b/bedrock/mozorg/templates/mozorg/about/leadership.html
@@ -94,7 +94,7 @@
         <div class="person-bio">
           <p>
           {% trans %}
-            Mitchell Baker co-founded the Mozilla Project to support the open, innovative web and ensure it continues offering opportunities for everyone. As Chairwoman of Mozilla, Mitchell Baker is responsible for organizing and motivating a massive, worldwide, collective of employees and volunteers around the world who are building the Internet as a global public resource, open and accessible to all. Mitchell is deeply engaged in developing product offerings that promote the mission of empowering individuals. She also guides the overall scope and direction of Mozilla’s mission.
+            Mitchell Baker co-founded the Mozilla Project to support the open, innovative web and ensure it continues offering opportunities for everyone. As Chairwoman of Mozilla, Mitchell Baker is responsible for organizing and motivating a massive, worldwide, collective of employees and volunteers around the world who are building the internet as a global public resource, open and accessible to all. Mitchell is deeply engaged in developing product offerings that promote the mission of empowering individuals. She also guides the overall scope and direction of Mozilla’s mission.
           {% endtrans %}
           </p>
 
@@ -119,7 +119,7 @@
           <p>
             <em>
             {% trans %}
-              TIME Magazine profiled Mitchell in its global list of “100 Most Influential People” under “Scientists and Thinkers”. Bloomberg listed her as one of the “25 Most Influential People on the Web”. She was honored as winner of the Anita Borg Institute’s 2009 Women of Vision Award and received the Aenne Burda Award for Creative Leadership in 2010. In 2012, Mitchell was inducted into the founding group of the <a rel="external" href="http://www.internethalloffame.org/inductees/mitchell-baker">Internet Society’s Hall of Fame</a>. In 2018 she received an honorary doctorate from the Universite Catholique de Louvain in Belgium. She has appeared on NBC “Meet the Press”, BBC “HardTalk”, “The Charlie Rose Show”, “CNN Global Office” and "NPR Morning Edition". She has spoken at high-level events like the World Economic Forum, Mobile World Congress, The Web Summit, Collision, Singularity University and Bits&Pretzels.
+              TIME Magazine profiled Mitchell in its global list of “100 Most Influential People” under “Scientists and Thinkers”. Bloomberg listed her as one of the “25 Most Influential People on the Web”. She was honored as winner of the Anita Borg Institute’s 2009 Women of Vision Award and received the Aenne Burda Award for Creative Leadership in 2010. In 2012, Mitchell was inducted into the founding group of the <a rel="external" href="http://www.internethalloffame.org/inductees/mitchell-baker">Internet Society’s Hall of Fame</a>. In 2018 she received an honorary doctorate from the Universite Catholique de Louvain in Belgium. She has appeared on NBC “Meet the Press”, BBC “HardTalk”, “The Charlie Rose Show”, “CNN Global Office” and "NPR Morning Edition". She has spoken at high-level events like the World Economic Forum, Mobile World Congress, Web Summit, Collision, Singularity University and Bits&Pretzels.
             {% endtrans %}
             </em>
           </p>
@@ -624,7 +624,7 @@
         </figure>
 
         <div class="person-info">
-          <p class="title" itemprop="jobTitle">{{ _('Firefox VP of Engineering') }}</p>
+          <p class="title" itemprop="jobTitle">{{ _('VP of Engineering, Firefox') }}</p>
           <p class="since">{{ _('With Mozilla since:') }} 2006</p>
 
           <ul class="elsewhere">
@@ -639,7 +639,7 @@
         <div class="person-bio">
           <p>
           {% trans %}
-            As Firefox VP of Engineering Dave Camp leads the global team of engineers that build, test, and ship the Firefox family of products and services. He’s responsible for making sure everything is on time and high quality.
+            As VP of Engineering, Firefox Dave Camp leads the global team of engineers that build, test, and ship the Firefox family of products and services. He’s responsible for making sure everything is on time and high quality.
           {% endtrans %}
           </p>
 


### PR DESCRIPTION
## Description
Minor corrections via email:

> Internet should be internet in the first paragraph
> 
> and The Web Summit should just be Web Summit in the last.

## Issue / Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1425359
