### PR TITLE
[bug 1438302] Avoid duplicate content on key 'en-GB' pages

### DIFF
--- a/bedrock/base/templates/includes/global-nav.html
+++ b/bedrock/base/templates/includes/global-nav.html
@@ -11,7 +11,14 @@
       </button>
 
       <h2 class="nav-logo">
-        <a href="{{ url('mozorg.home') }}">{{_('Mozilla')}}</a>
+        <a href="{{ url('mozorg.home') }}">
+          {# Bug 1438302 Avoid duplicate content for en-GB pages. #}
+          {% if LANG == 'en-GB' %}
+            Mozilla (UK)
+          {% else %}
+            {{_('Mozilla')}}
+          {% endif %}
+        </a>
       </h2>
 
       <ul class="nav-primary-links">

--- a/bedrock/firefox/templates/firefox/home.html
+++ b/bedrock/firefox/templates/firefox/home.html
@@ -6,7 +6,9 @@
 
 {% extends "firefox/base-pebbles.html" %}
 
-{% block page_title %}{{ _('The new, fast browser for Mac, PC and Linux') }} | {{ _('Firefox') }}{% endblock %}
+{# Bug 1438302 Avoid duplicate content for en-GB pages. #}
+{% set title_suffix = 'Firefox (UK)' if LANG == 'en-GB' else _('Firefox') %}
+{% block page_title %}{{ _('The new, fast browser for Mac, PC and Linux') }} | {{ title_suffix }}{% endblock %}
 {% block page_desc %}{{ _('Responsive engine, less memory usage and packed with features. Download for desktop now.') }}{% endblock %}
 
 {% block page_css %}

--- a/bedrock/firefox/templates/firefox/new/base.html
+++ b/bedrock/firefox/templates/firefox/new/base.html
@@ -9,7 +9,16 @@
 {% extends "firefox/base-pebbles.html" %}
 
 {% block page_title_prefix %}{{_('Download Firefox')}} — {% endblock %}
-{% block page_title %}{{_('Free Web Browser')}}{% endblock %}
+
+{# Bug 1438302 Avoid duplicate content for en-GB pages. #}
+{%- block page_title -%}
+  {% if LANG == 'en-GB' %}
+    Free Web Browser (UK)
+  {% else %}
+    {{_('Free Web Browser')}}
+  {% endif %}
+{%- endblock -%}
+
 {% block page_desc %}{{_('Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!')}}{% endblock %}
 
 {#- This will appear as <meta property="og:title"> which can be used for social share -#}
@@ -39,8 +48,11 @@
     {% block messages %}{% endblock %}
     <div class="content">
       <div class="header-logos">
-        <h2><a class="firefox" href="{{ url('firefox') }}">{{ high_res_img('logos/firefox/logo-quantum-wordmark-white.png', {'alt': 'Firefox', 'width': '133', 'height': '50'}) }}</a></h2>
-        <h2><a class="mozilla" href="{{ url('mozorg.home') }}"><img src="{{ static('img/logos/mozilla/wordmark-dark.svg')}}" alt="Mozilla" width="101" height="34"></a></h2>
+        {# Bug 1438302 Avoid duplicate content for en-GB pages. #}
+        {% set firefox_logo_title = 'Firefox (UK)' if LANG == 'en-GB' else 'Firefox' %}
+        {% set mozilla_logo_title = 'Mozilla (UK)' if LANG == 'en-GB' else 'Mozilla' %}
+        <h2><a class="firefox" href="{{ url('firefox') }}" title="{{ firefox_logo_title }}">{{ high_res_img('logos/firefox/logo-quantum-wordmark-white.png', {'alt': firefox_logo_title, 'width': '133', 'height': '50'}) }}</a></h2>
+        <h2><a class="mozilla" href="{{ url('mozorg.home') }}" title="{{ mozilla_logo_title }}"><img src="{{ static('img/logos/mozilla/wordmark-dark.svg')}}" alt="{{ mozilla_logo_title }}" width="101" height="34"></a></h2>
       </div>
       <div class="header-container">
         <div class="header-content">

--- a/bedrock/mozorg/templates/mozorg/home/home.html
+++ b/bedrock/mozorg/templates/mozorg/home/home.html
@@ -12,6 +12,14 @@
   {{ _('Internet for people, not profit') }}
 {% endblock %}
 
+{%- block page_title_suffix -%}
+  {% if LANG == 'en-GB' %}
+    — Mozilla (UK)
+  {% else %}
+    — Mozilla
+  {% endif %}
+{%- endblock -%}
+
 {% block page_desc %}
   {{ _('Did you know? Mozilla — the maker of Firefox — fights to keep the Internet a global public resource, open and accessible to all.') }}
 {% endblock %}


### PR DESCRIPTION
## Description
- Adds `(UK)` to page titles and logo attributes on key `/en-GB/` pages, to try and avoid duplicate content penalties in Google search.

## Issue / Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1438302

## Testing
- `/en-GB/`, `/en-GB/firefox/` and `/en-GB/firefox/new/` should all display `(UK)` as expected in the respective places. Other locales should show as normal.
