### PR TITLE
[fix bug 1429255] Update links to /firefox/de/ blog

### DIFF
--- a/bedrock/firefox/templates/firefox/home.html
+++ b/bedrock/firefox/templates/firefox/home.html
@@ -75,7 +75,7 @@
           {% if l10n_has_tag('update_faster_copy') %}
             <h2 class="section-title">{{ _('Now 2x faster') }}</h2>
             <p>
-            {% trans url='https://blog.mozilla.org/firefox-de/firefox-quantum-superschnell-und-schont-den-speicher/' if LANG == 'de' else 'https://blog.mozilla.org/firefox/quantum-performance-test/' %}
+            {% trans url='https://blog.mozilla.org/firefox/de/firefox-quantum-superschnell-und-schont-den-speicher/' if LANG == 'de' else 'https://blog.mozilla.org/firefox/quantum-performance-test/' %}
               Crazy <a href="{{ url }}">powerful browser engine</a>? Check. Less time waiting around for pages to load?
               Also, check. Firefox Quantum is twice as fast as Firefox was before.
             {% endtrans %}
@@ -83,7 +83,7 @@
           {% else %}
             <h2 class="section-title">{{ _('2x Faster') }}</h2>
             <p>
-            {% trans url='https://blog.mozilla.org/firefox-de/firefox-quantum-superschnell-und-schont-den-speicher/' if LANG == 'de' else 'https://blog.mozilla.org/firefox/quantum-performance-test/' %}
+            {% trans url='https://blog.mozilla.org/firefox/de/firefox-quantum-superschnell-und-schont-den-speicher/' if LANG == 'de' else 'https://blog.mozilla.org/firefox/quantum-performance-test/' %}
               Crazy <a href="{{ url }}">powerful browser engine</a>? Check. Less time waiting around for pages to load?
               Also, check. Get the best Firefox yet.
             {% endtrans %}
@@ -115,7 +115,7 @@
           <div class="key-feature-content">
             <h2 class="section-title">{{ _('30% lighter than Chrome') }}</h2>
             <p>
-            {% trans url='https://blog.mozilla.org/firefox-de/firefox-quantum-superschnell-und-schont-den-speicher/' if LANG == 'de' else 'https://blog.mozilla.org/firefox/quantum-performance-test/' %}
+            {% trans url='https://blog.mozilla.org/firefox/de/firefox-quantum-superschnell-und-schont-den-speicher/' if LANG == 'de' else 'https://blog.mozilla.org/firefox/quantum-performance-test/' %}
               <a href="{{ url }}">Less memory usage</a> means more space for your computer to keep running smoothly.
               Your other programs will thank you.
             {% endtrans %}
@@ -197,7 +197,7 @@
         <li class="faster-loading">
           <h3>{{ _('Faster Page Loading') }}</h3>
           <p>
-          {% trans url='https://blog.mozilla.org/firefox-de/die-studie-zum-schutz-vor-aktivitatsverfolgung/' if LANG == 'de' else 'https://blog.mozilla.org/firefox/tracking-protection-study/' %}
+          {% trans url='https://blog.mozilla.org/firefox/de/die-studie-zum-schutz-vor-aktivitatsverfolgung/' if LANG == 'de' else 'https://blog.mozilla.org/firefox/tracking-protection-study/' %}
             By blocking some ads and scripts that bog down browsing,
             <a href="{{ url }}">pages load up to 44% faster</a>. Now that’s a win-win.
           {% endtrans %}

--- a/bedrock/firefox/templates/firefox/includes/hub/sub-nav.html
+++ b/bedrock/firefox/templates/firefox/includes/hub/sub-nav.html
@@ -16,7 +16,7 @@
 {% endblock %}
 
 {% block sub_nav_primary_links %}
-  {% set blog_url = 'https://blog.mozilla.org/firefox-de/' if LANG == 'de' else 'https://blog.mozilla.org/firefox/' %}
+  {% set blog_url = 'https://blog.mozilla.org/firefox/de/' if LANG == 'de' else 'https://blog.mozilla.org/firefox/' %}
   <li><a {% if current == 'desktop' %}class="current"{% endif %} href="{{ url('firefox') }}" data-link-name="Desktop" data-link-type="nav" data-link-position="subnav">{{ _('Desktop') }}</a></li>
   <li><a {% if current == 'mobile' %}class="current"{% endif %} href="{{ url('firefox.mobile') }}" data-link-name="Mobile" data-link-type="nav" data-link-position="subnav">{{ _('Mobile') }}</a></li>
   <li><a href="https://addons.mozilla.org/firefox/?utm_source=www.mozilla.org&amp;utm_medium=referral&amp;utm_campaign=fx-sub-nav" data-link-name="Extensions" data-link-type="nav" data-link-position="subnav">{{ _('Extensions') }}</a></li>

--- a/bedrock/firefox/templates/firefox/new/reggie-watts/base.html
+++ b/bedrock/firefox/templates/firefox/new/reggie-watts/base.html
@@ -43,7 +43,7 @@
         <li>
           <h3>{{ _('Runs 2x faster') }}</h3>
           <p>
-          {% trans url='https://blog.mozilla.org/firefox-de/firefox-quantum-superschnell-und-schont-den-speicher/' if LANG == 'de' else 'https://blog.mozilla.org/firefox/quantum-performance-test/' %}
+          {% trans url='https://blog.mozilla.org/firefox/de/firefox-quantum-superschnell-und-schont-den-speicher/' if LANG == 'de' else 'https://blog.mozilla.org/firefox/quantum-performance-test/' %}
             The New Firefox has a new engine. <a href="{{ url }}">Twice as fast</a>? Yes. Crazy-powerful engine?
             Yes. Less time waiting for browser pages to load? Double yes, yes. Get the best Firefox yet.
           {% endtrans %}
@@ -52,7 +52,7 @@
         <li>
           <h3>{{ _('Uses 30% less memory') }}</h3>
           <p>
-          {% trans url='https://blog.mozilla.org/firefox-de/firefox-quantum-superschnell-und-schont-den-speicher/' if LANG == 'de' else 'https://blog.mozilla.org/firefox/quantum-performance-test/' %}
+          {% trans url='https://blog.mozilla.org/firefox/de/firefox-quantum-superschnell-und-schont-den-speicher/' if LANG == 'de' else 'https://blog.mozilla.org/firefox/quantum-performance-test/' %}
             <a href="{{ url }}">Lighter than Chrome</a> means more of your computer resources are freed up and run smoother.
             You can thank the New Firefox multiprocess architecture for that. Your computer will thank you back.
           {% endtrans %}

--- a/bedrock/firefox/templates/firefox/new/wait-face/base.html
+++ b/bedrock/firefox/templates/firefox/new/wait-face/base.html
@@ -56,7 +56,7 @@
         {% block content_1 %}
           <h3>{{ _('Runs 2x faster') }}</h3>
           <p>
-          {% trans url='https://blog.mozilla.org/firefox-de/firefox-quantum-superschnell-und-schont-den-speicher/?utm_source=mozilla.org&utm_medium=referral&utm_campaign=new-2xfaster&utm_content=twice-as-fast' if LANG == 'de' else 'https://blog.mozilla.org/firefox/quantum-performance-test/?utm_source=mozilla.org&utm_medium=referral&utm_campaign=new-2xfaster&utm_content=twice-as-fast' %}
+          {% trans url='https://blog.mozilla.org/firefox/de/firefox-quantum-superschnell-und-schont-den-speicher/?utm_source=mozilla.org&utm_medium=referral&utm_campaign=new-2xfaster&utm_content=twice-as-fast' if LANG == 'de' else 'https://blog.mozilla.org/firefox/quantum-performance-test/?utm_source=mozilla.org&utm_medium=referral&utm_campaign=new-2xfaster&utm_content=twice-as-fast' %}
             The New Firefox has a new engine. <a href="{{ url }}">Twice as fast</a>? Yes. Crazy-powerful engine?
             Yes. Less time waiting for browser pages to load? Double yes, yes. Get the best Firefox yet.
           {% endtrans %}
@@ -67,7 +67,7 @@
         {% block content_2 %}
           <h3>{{ _('Uses 30% less memory') }}</h3>
           <p>
-          {% trans url='https://blog.mozilla.org/firefox-de/firefox-quantum-superschnell-und-schont-den-speicher/?utm_source=mozilla.org&utm_medium=referral&utm_campaign=new-2xfaster&utm_content=lighter-than-chrome' if LANG == 'de' else 'https://blog.mozilla.org/firefox/quantum-performance-test/?utm_source=mozilla.org&utm_medium=referral&utm_campaign=new-2xfaster&utm_content=lighter-than-chrome' %}
+          {% trans url='https://blog.mozilla.org/firefox/de/firefox-quantum-superschnell-und-schont-den-speicher/?utm_source=mozilla.org&utm_medium=referral&utm_campaign=new-2xfaster&utm_content=lighter-than-chrome' if LANG == 'de' else 'https://blog.mozilla.org/firefox/quantum-performance-test/?utm_source=mozilla.org&utm_medium=referral&utm_campaign=new-2xfaster&utm_content=lighter-than-chrome' %}
             <a href="{{ url }}">Lighter than Chrome</a> means more of your computer resources are freed up and run smoother.
             You can thank the New Firefox multiprocess architecture for that. Your computer will thank you back.
           {% endtrans %}


### PR DESCRIPTION
## Description
- Updates links for `https://blog.mozilla.org/firefox-de/` to `https://blog.mozilla.org/firefox/de/` now that the German Firefox blog content has been moved.

## Issue / Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1429255

## Testing
- Make sure URLs still show the expected content?
