### PR TITLE
Bug 1438302: Move /firefox/new/?scene=2 to /firefox/download/thanks/

### DIFF
--- a/bedrock/firefox/firefox_details.py
+++ b/bedrock/firefox/firefox_details.py
@@ -30,7 +30,7 @@ class _ProductDetails(ProductDetails):
 
 
 class FirefoxDesktop(_ProductDetails):
-    download_base_url_transition = '/firefox/new/?scene=2'
+    download_base_url_transition = '/firefox/download/thanks/'
 
     # Human-readable platform names
     platform_labels = OrderedDict([

--- a/bedrock/firefox/redirects.py
+++ b/bedrock/firefox/redirects.py
@@ -69,6 +69,9 @@ redirectpatterns = (
     # bug 878871
     redirect(r'^firefoxos', '/firefox/os/'),
 
+    # bug 1438302
+    no_redirect(r'^firefox/download/thanks/$'),
+
     # Bug 1006616
     redirect(r'^download/?$', 'firefox.new'),
 

--- a/bedrock/firefox/templates/firefox/new/scene2.html
+++ b/bedrock/firefox/templates/firefox/new/scene2.html
@@ -6,8 +6,12 @@
 
 {% extends "firefox/new/base.html" %}
 
-{# "noindex" pages should not have the canonical or hreflang tags: bug 1442331 #}
-{% block canonical_urls %}<meta name="robots" content="noindex,follow">{% endblock %}
+{% block canonical_urls %}
+  {# the "scene 2" page should set canonical to the /firefox/new/ page to give that
+     page the SEO weight of links directly to "scene 2".
+     see https://github.com/mozilla/bedrock/pull/5463 #}
+  <link rel="canonical" href="{{ settings.CANONICAL_URL }}/{{ LANG }}/firefox/new/">
+{% endblock %}
 
 {% block optimizely %}
   {% if switch('firefox-new-scene2-optimizely', ['en-US']) %}

--- a/bedrock/firefox/tests/test_helpers.py
+++ b/bedrock/firefox/tests/test_helpers.py
@@ -97,7 +97,7 @@ class TestDownloadButtons(TestCase):
         for link in links[1:5]:
             link = pq(link)
             href = link.attr('href')
-            eq_(href, '/fr/firefox/new/?scene=2')
+            eq_(href, '/fr/firefox/download/thanks/')
 
         doc = pq(render("{{ download_firefox(locale_in_transition=false) }}",
                         {'request': get_request}))
@@ -107,7 +107,7 @@ class TestDownloadButtons(TestCase):
         for link in links[1:5]:
             link = pq(link)
             href = link.attr('href')
-            eq_(href, '/firefox/new/?scene=2')
+            eq_(href, '/firefox/download/thanks/')
 
     @patch('bedrock.firefox.firefox_details.switch', Mock(return_value=False))
     def test_download_location_attribute(self):

--- a/bedrock/firefox/tests/test_views.py
+++ b/bedrock/firefox/tests/test_views.py
@@ -424,11 +424,18 @@ class TestFirefoxNew(TestCase):
         views.new(req)
         render_mock.assert_called_once_with(req, 'firefox/new/scene1.html', ANY)
 
-    def test_scene_2_template(self, render_mock):
-        req = RequestFactory().get('/firefox/new/?scene=2')
+    def test_scene_2_redirect(self, render_mock):
+        req = RequestFactory().get('/firefox/new/?scene=2&dude=abides')
         req.locale = 'en-US'
-        views.new(req)
-        render_mock.assert_called_once_with(req, 'firefox/new/scene2.html', ANY)
+        resp = views.new(req)
+        assert resp.status_code == 301
+        assert resp['location'].endswith('/firefox/download/thanks/?scene=2&dude=abides')
+
+    def test_scene_2_template(self, render_mock):
+        req = RequestFactory().get('/firefox/download/thanks/')
+        req.locale = 'en-US'
+        views.download_thanks(req)
+        render_mock.assert_called_once_with(req, 'firefox/new/scene2.html')
 
     # wait face campaign bug 1380044
 
@@ -439,10 +446,10 @@ class TestFirefoxNew(TestCase):
         render_mock.assert_called_once_with(req, 'firefox/new/wait-face/scene1.html', ANY)
 
     def test_wait_face_scene_2(self, render_mock):
-        req = RequestFactory().get('/firefox/new/?scene=2&xv=waitface')
+        req = RequestFactory().get('/firefox/download/thanks/?xv=waitface')
         req.locale = 'en-US'
-        views.new(req)
-        render_mock.assert_called_once_with(req, 'firefox/new/wait-face/scene2.html', ANY)
+        views.download_thanks(req)
+        render_mock.assert_called_once_with(req, 'firefox/new/wait-face/scene2.html')
 
     # wait face video experiment bug 1431795
 
@@ -455,10 +462,10 @@ class TestFirefoxNew(TestCase):
         render_mock.assert_called_once_with(req, 'firefox/new/wait-face/scene1.html', ANY)
 
     def test_wait_face_video_var_a_scene_2(self, render_mock):
-        req = RequestFactory().get('/firefox/new/?scene=2&xv=waitface&v=a')
+        req = RequestFactory().get('/firefox/download/thanks/?xv=waitface&v=a')
         req.locale = 'en-US'
-        views.new(req)
-        render_mock.assert_called_once_with(req, 'firefox/new/wait-face/scene2.html', ANY)
+        views.download_thanks(req)
+        render_mock.assert_called_once_with(req, 'firefox/new/wait-face/scene2.html')
 
     @patch.dict(os.environ, SWITCH_EXPERIMENT_FIREFOX_NEW_WAITFACE='True')
     @patch.dict(os.environ, SWITCH_EXPERIMENT_FIREFOX_NEW_WAITFACE_SWITCH='False')
@@ -469,10 +476,10 @@ class TestFirefoxNew(TestCase):
         render_mock.assert_called_once_with(req, 'firefox/new/wait-face/scene1-video.html', ANY)
 
     def test_wait_face_video_var_b_scene_2(self, render_mock):
-        req = RequestFactory().get('/firefox/new/?scene=2&xv=waitface&v=b')
+        req = RequestFactory().get('/firefox/download/thanks/?xv=waitface&v=b')
         req.locale = 'en-US'
-        views.new(req)
-        render_mock.assert_called_once_with(req, 'firefox/new/wait-face/scene2.html', ANY)
+        views.download_thanks(req)
+        render_mock.assert_called_once_with(req, 'firefox/new/wait-face/scene2.html')
 
     # wait face switch experiment bug 1443921
 
@@ -509,10 +516,10 @@ class TestFirefoxNew(TestCase):
         render_mock.assert_called_once_with(req, 'firefox/new/reggie-watts/scene1.html', ANY)
 
     def test_reggie_watts_scene_2(self, render_mock):
-        req = RequestFactory().get('/firefox/new/?scene=2&xv=reggiewatts')
+        req = RequestFactory().get('/firefox/download/thanks/?xv=reggiewatts')
         req.locale = 'en-US'
-        views.new(req)
-        render_mock.assert_called_once_with(req, 'firefox/new/reggie-watts/scene2.html', ANY)
+        views.download_thanks(req)
+        render_mock.assert_called_once_with(req, 'firefox/new/reggie-watts/scene2.html')
 
     @patch.object(views, 'lang_file_is_active', lambda *x: True)
     def test_reggie_watts_translated_scene_1(self, render_mock):
@@ -523,10 +530,10 @@ class TestFirefoxNew(TestCase):
 
     @patch.object(views, 'lang_file_is_active', lambda *x: True)
     def test_reggie_watts_translated_scene_2(self, render_mock):
-        req = RequestFactory().get('/firefox/new/?scene=2&xv=reggiewatts')
+        req = RequestFactory().get('/firefox/download/thanks/?xv=reggiewatts')
         req.locale = 'de'
-        views.new(req)
-        render_mock.assert_called_once_with(req, 'firefox/new/reggie-watts/scene2.html', ANY)
+        views.download_thanks(req)
+        render_mock.assert_called_once_with(req, 'firefox/new/reggie-watts/scene2.html')
 
     @patch.object(views, 'lang_file_is_active', lambda *x: False)
     def test_reggie_watts_untranslated_scene_1(self, render_mock):
@@ -537,10 +544,10 @@ class TestFirefoxNew(TestCase):
 
     @patch.object(views, 'lang_file_is_active', lambda *x: False)
     def test_reggie_watts_untranslated_scene_2(self, render_mock):
-        req = RequestFactory().get('/firefox/new/?scene=2&xv=reggiewatts')
+        req = RequestFactory().get('/firefox/download/thanks/?xv=reggiewatts')
         req.locale = 'de'
-        views.new(req)
-        render_mock.assert_called_once_with(req, 'firefox/new/scene2.html', ANY)
+        views.download_thanks(req)
+        render_mock.assert_called_once_with(req, 'firefox/new/scene2.html')
 
 
 class TestFirefoxNewNoIndex(TestCase):
@@ -553,15 +560,15 @@ class TestFirefoxNewNoIndex(TestCase):
         robots = doc('meta[name="robots"]')
         eq_(robots.length, 0)
 
-    def test_scene_2_noindex(self):
-        # Scene 2 of /firefox/new/ should always contain a noindex tag.
-        req = RequestFactory().get('/firefox/new/?scene=2')
+    def test_scene_2_canonical(self):
+        # Scene 2 of /firefox/new/ should contain a canonical tag to /firefox/new/.
+        req = RequestFactory().get('/firefox/download/thanks/')
         req.locale = 'en-US'
-        response = views.new(req)
+        response = views.download_thanks(req)
         doc = pq(response.content)
-        robots = doc('meta[name="robots"]')
-        eq_(robots.length, 1)
-        ok_('noindex' in robots.attr('content'))
+        canonical = doc('link[rel="canonical"]')
+        eq_(canonical.length, 1)
+        ok_('/firefox/new/' in canonical.attr('href'))
 
 
 class TestFeedbackView(TestCase):

--- a/bedrock/firefox/urls.py
+++ b/bedrock/firefox/urls.py
@@ -61,6 +61,7 @@ urlpatterns = (
         name='firefox.send-to-device-post'),
     page('firefox/unsupported-systems', 'firefox/unsupported-systems.html'),
     url(r'^firefox/new/$', views.new, name='firefox.new'),
+    url(r'^firefox/download/thanks/$', views.download_thanks, name='firefox.download.thanks'),
     page('firefox/organizations', 'firefox/organizations/organizations.html'),
     page('firefox/nightly/firstrun', 'firefox/nightly_firstrun.html'),
     url(r'^firefox/installer-help/$', views.installer_help,

--- a/docs/mozilla-notification-banner.rst
+++ b/docs/mozilla-notification-banner.rst
@@ -35,7 +35,7 @@ To configure a notification, it must be passed one or more ``config`` objects. E
         'message': 'Get the most recent version to keep browsing securely.',
         'confirm': 'Update Firefox',
         'confirmClick': _clickCallback,
-        'url': '/firefox/new/?scene=2',
+        'url': '/firefox/download/thanks/',
         'close': closeText,
         'gaConfirmAction': 'Update Firefox',
         'gaConfirmLabel': 'Firefox for Desktop',
@@ -91,7 +91,7 @@ To test multiple variations of messaging in a notification, you can also pass an
             'confirmAction': 'Update Firefox',
             'confirmLabel': 'Firefox for Desktop',
             'confirmClick': _clickCallback,
-            'url': '/firefox/new/?scene=2',
+            'url': '/firefox/download/thanks/',
             'close': 'Close',
             'closeLabel': 'Close'
         },
@@ -106,7 +106,7 @@ To test multiple variations of messaging in a notification, you can also pass an
             'confirmAction': 'Update Firefox',
             'confirmLabel': 'Firefox for Desktop',
             'confirmClick': _clickCallback,
-            'url': '/firefox/new/?scene=2',
+            'url': '/firefox/download/thanks/',
             'close': 'Close',
             'closeLabel': 'Close'
         },

--- a/media/js/base/mozilla-notification-banner-firstrun-whatsnew-init.js
+++ b/media/js/base/mozilla-notification-banner-firstrun-whatsnew-init.js
@@ -34,7 +34,7 @@ $(function() {
         'message': messageText,
         'confirm': confirmText,
         'confirmClick': _clickCallback,
-        'url': '/firefox/new/?scene=2',
+        'url': '/firefox/download/thanks/',
         'close': closeText,
         'gaConfirmAction': 'Update Firefox', // GA - English only
         'gaConfirmLabel': 'Firefox for Desktop', // GA - English only

--- a/media/js/base/mozilla-notification-banner-init.js
+++ b/media/js/base/mozilla-notification-banner-init.js
@@ -29,7 +29,7 @@ $(function() {
         'heading': headingText,
         'message': messageText,
         'confirm': confirmText,
-        'url': '/firefox/new/?scene=2',
+        'url': '/firefox/download/thanks/',
         'close': closeText,
         'gaConfirmAction': 'Update Firefox', // GA - English only
         'gaConfirmLabel': 'Firefox for Desktop', // GA - English only

--- a/media/js/base/mozilla-pixel.js
+++ b/media/js/base/mozilla-pixel.js
@@ -11,7 +11,7 @@ if (typeof Mozilla === 'undefined') {
     'use strict';
 
     /**
-     * Tracking pixels for /firefox/new/?scene=2 download page.
+     * Tracking pixels for /firefox/download/thanks/ download page.
      * For more info see websites privacy notice and bugs:
      * https://www.mozilla.org/privacy/websites/
      * Yahoo: bug 1343033.

--- a/media/js/base/stub-attribution.js
+++ b/media/js/base/stub-attribution.js
@@ -98,7 +98,7 @@ if (typeof Mozilla === 'undefined') {
         $('.download-list .download-link, .download-platform-list .download-link').each(function() {
             var version;
             // If this is a transitional download link do nothing.
-            if (this.href && this.href.indexOf('/firefox/new/?scene=2') === -1) {
+            if (this.href && this.href.indexOf('/firefox/download/thanks/') === -1) {
 
                 version = $(this).data('downloadVersion');
                 // Currently only Windows 32bit uses the stub installer, but this could
@@ -196,7 +196,7 @@ if (typeof Mozilla === 'undefined') {
      */
     StubAttribution.isFirefoxNewScene2 = function(location) {
         location = typeof location !== 'undefined' ? location : window.location.href;
-        return location.indexOf('/firefox/new/') > -1 && location.indexOf('scene=2') > -1;
+        return location.indexOf('/firefox/download/thanks/') > -1;
     };
 
     /**

--- a/media/js/firefox/new/reggie-watts-scene1.js
+++ b/media/js/firefox/new/reggie-watts-scene1.js
@@ -6,9 +6,9 @@
     'use strict';
 
     $('.download-link').each(function(i, link) {
-        if (link.href.indexOf('scene=2') > -1) {
+        if (link.href.indexOf('download/thanks/') > -1) {
             // specify template for scene 2
-            link.href = link.href.replace('scene=2', 'scene=2&xv=reggiewatts');
+            link.href = link.href + '?xv=reggiewatts';
         }
     });
 

--- a/media/js/firefox/new/wait-face-scene1.js
+++ b/media/js/firefox/new/wait-face-scene1.js
@@ -5,11 +5,9 @@
 (function($) {
     'use strict';
 
-    var extraParams = location.search.replace(/^\?/, '&');
-
     $('.download-link').each(function(i, link) {
-        if (link.href.indexOf('scene=2') > -1) {
-            link.href = link.href.replace('scene=2', 'scene=2' + extraParams);
+        if (link.href.indexOf('download/thanks/') > -1) {
+            link.href = link.href + location.search;
         }
     });
 })(window.jQuery);

--- a/tests/functional/test_download.py
+++ b/tests/functional/test_download.py
@@ -8,7 +8,7 @@ import requests
 
 
 PAGE_PATHS = (
-    '/firefox/new/?scene=2',
+    '/firefox/download/thanks/',
     '/thunderbird/',
 )
 

--- a/tests/pages/firefox/new/thank_you.py
+++ b/tests/pages/firefox/new/thank_you.py
@@ -9,7 +9,7 @@ from pages.firefox.base import FirefoxBasePage
 
 class ThankYouPage(FirefoxBasePage):
 
-    URL_TEMPLATE = '/{locale}/firefox/new/?scene=2'
+    URL_TEMPLATE = '/{locale}/firefox/download/thanks/'
 
     _direct_download_link_locator = (By.ID, 'direct-download-link')
 

--- a/tests/unit/spec/base/mozilla-notification-banner.js
+++ b/tests/unit/spec/base/mozilla-notification-banner.js
@@ -30,7 +30,7 @@ describe('mozilla-notification-banner.js', function() {
             'confirm': 'Update now',
             'gaConfirmAction': 'Update Firefox',
             'gaConfirmLabel': 'Firefox for Desktop',
-            'url': '/firefox/new/?scene=2',
+            'url': '/firefox/download/thanks/',
             'close': 'Close',
             'gaCloseLabel': 'Close'
         };
@@ -96,7 +96,7 @@ describe('mozilla-notification-banner.js', function() {
                 'confirm': 'Update now',
                 'gaConfirmAction': 'Update Firefox',
                 'gaConfirmLabel': 'Firefox for Desktop',
-                'url': '/firefox/new/?scene=2',
+                'url': '/firefox/download/thanks/',
                 'close': 'Close',
                 'gaCloseLabel': 'Close'
             };
@@ -113,7 +113,7 @@ describe('mozilla-notification-banner.js', function() {
                 'confirm': 'Update now',
                 'gaConfirmAction': 'Update Firefox',
                 'gaConfirmLabel': 'Firefox for Desktop',
-                'url': '/firefox/new/?scene=2',
+                'url': '/firefox/download/thanks/',
                 'close': 'Close',
                 'gaCloseLabel': 'Close'
             };
@@ -135,7 +135,7 @@ describe('mozilla-notification-banner.js', function() {
                 'confirm': 'Update now',
                 'gaConfirmAction': 'Update Firefox',
                 'gaConfirmLabel': 'Firefox for Desktop',
-                'url': '/firefox/new/?scene=2',
+                'url': '/firefox/download/thanks/',
                 'close': 'Close',
                 'gaCloseLabel': 'Close'
             };
@@ -166,7 +166,7 @@ describe('mozilla-notification-banner.js', function() {
                 'confirm': 'Update now',
                 'gaConfirmAction': 'Update Firefox',
                 'gaConfirmLabel': 'Firefox for Desktop',
-                'url': '/firefox/new/?scene=2',
+                'url': '/firefox/download/thanks/',
                 'close': 'Close',
                 'gaCloseLabel': 'Close'
             };
@@ -191,7 +191,7 @@ describe('mozilla-notification-banner.js', function() {
                 'confirm': 'Update now',
                 'gaConfirmAction': 'Update Firefox',
                 'gaConfirmLabel': 'Firefox for Desktop',
-                'url': '/firefox/new/?scene=2',
+                'url': '/firefox/download/thanks/',
                 'close': 'Close',
                 'gaCloseLabel': 'Close'
             };
@@ -222,7 +222,7 @@ describe('mozilla-notification-banner.js', function() {
                 'confirm': 'Update now',
                 'gaConfirmAction': 'Update Firefox',
                 'gaConfirmLabel': 'Firefox for Desktop',
-                'url': '/firefox/new/?scene=2',
+                'url': '/firefox/download/thanks/',
                 'close': 'Close',
                 'gaCloseLabel': 'Close'
             };
@@ -243,7 +243,7 @@ describe('mozilla-notification-banner.js', function() {
             var event = {
                 'metaKey': false,
                 'ctrlKey': false,
-                'target': '/firefox/new/?scene=2',
+                'target': '/firefox/download/thanks/',
                 'preventDefault': function () {}
             };
 
@@ -262,7 +262,7 @@ describe('mozilla-notification-banner.js', function() {
             var event = {
                 'metaKey': false,
                 'ctrlKey': true,
-                'target': '/firefox/new/?scene=2',
+                'target': '/firefox/download/thanks/',
                 'preventDefault': function () {}
             };
 
@@ -288,7 +288,7 @@ describe('mozilla-notification-banner.js', function() {
                 'confirm': 'Update now',
                 'gaConfirmAction': 'Update Firefox',
                 'gaConfirmLabel': 'Firefox for Desktop',
-                'url': '/firefox/new/?scene=2',
+                'url': '/firefox/download/thanks/',
                 'close': 'Close',
                 'gaCloseLabel': 'Close',
                 confirmClick: function() {}
@@ -297,7 +297,7 @@ describe('mozilla-notification-banner.js', function() {
             var event = {
                 'metaKey': false,
                 'ctrlKey': false,
-                'target': '/firefox/new/?scene=2',
+                'target': '/firefox/download/thanks/',
                 'preventDefault': function () {}
             };
 
@@ -334,7 +334,7 @@ describe('mozilla-notification-banner.js', function() {
                 'confirm': 'Update now',
                 'gaConfirmAction': 'Update Firefox',
                 'gaConfirmLabel': 'Firefox for Desktop',
-                'url': '/firefox/new/?scene=2',
+                'url': '/firefox/download/thanks/',
                 'close': 'Close',
                 'gaCloseLabel': 'Close'
             };
@@ -480,7 +480,7 @@ describe('mozilla-notification-banner.js', function() {
                 'confirm': 'Update now',
                 'gaConfirmAction': 'Update Firefox',
                 'gaConfirmLabel': 'Firefox for Desktop',
-                'url': '/firefox/new/?scene=2',
+                'url': '/firefox/download/thanks/',
                 'close': 'Close',
                 'gaCloseLabel': 'Close',
             },
@@ -494,7 +494,7 @@ describe('mozilla-notification-banner.js', function() {
                 'confirm': 'Update Firefox',
                 'gaConfirmAction': 'Update Firefox',
                 'gaConfirmLabel': 'Firefox for Desktop',
-                'url': '/firefox/new/?scene=2',
+                'url': '/firefox/download/thanks/',
                 'close': 'Close',
                 'gaCloseLabel': 'Close'
             },
@@ -508,7 +508,7 @@ describe('mozilla-notification-banner.js', function() {
                 'confirm': 'Update Firefox',
                 'gaConfirmAction': 'Update Firefox',
                 'gaConfirmLabel': 'Firefox for Desktop',
-                'url': '/firefox/new/?scene=2',
+                'url': '/firefox/download/thanks/',
                 'close': 'Close',
                 'gaCloseLabel': 'Close'
             }

--- a/tests/unit/spec/base/stub-attribution.js
+++ b/tests/unit/spec/base/stub-attribution.js
@@ -136,10 +136,10 @@ describe('stub-attribution.js', function() {
     describe('isFirefoxNewScene2', function() {
 
         it('should return true if the page is scene 2 of /firefox/new/', function() {
-            var url = 'https://www.mozilla.org/en-US/firefox/new/?scene=2';
+            var url = 'https://www.mozilla.org/en-US/firefox/download/thanks/';
             expect(Mozilla.StubAttribution.isFirefoxNewScene2(url)).toBeTruthy();
 
-            var url2 = 'https://www.mozilla.org/en-US/firefox/new/?foo=bar&scene=2';
+            var url2 = 'https://www.mozilla.org/en-US/firefox/download/thanks/?foo=bar';
             expect(Mozilla.StubAttribution.isFirefoxNewScene2(url2)).toBeTruthy();
         });
     });
@@ -239,7 +239,7 @@ describe('stub-attribution.js', function() {
         var sha1Url = 'https://download-sha1.allizom.org/?product=firefox-stub&os=win&lang=en-US';
         var winUrl = 'https://download.mozilla.org/?product=firefox-stub&os=win&lang=en-US';
         var win64Url = 'https://download.mozilla.org/?product=firefox-50.0b11-SSL&os=win64&lang=en-US';
-        var transitionalUrl = '/firefox/new/?scene=2';
+        var transitionalUrl = '/firefox/download/thanks/';
 
         beforeEach(function() {
             var downloadMarkup = '<ul class="download-list">' +


### PR DESCRIPTION
Having the page from which Firefox is actually downloaded be a "real" url and not a parameterized version of another URL will be better for a number of reasons, not least of which is that it will enable us to host a static version of the site that allows downloads.