### PR TITLE
Bug 1438302: Add canonical link tag tests to headless integration tests

### DIFF
--- a/tests/functional/test_link_hreflang_tags.py
+++ b/tests/functional/test_link_hreflang_tags.py
@@ -1,0 +1,26 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import pytest
+import requests
+
+
+LINK_TEMPLATE = '<link rel="canonical" hreflang="{lang}" href="{url}">'
+
+
+@pytest.mark.smoke
+@pytest.mark.headless
+@pytest.mark.nondestructive
+@pytest.mark.parametrize('url,locales', [
+    ('/firefox/new/', ('en-US', 'de', 'id')),
+    ('/firefox/', ('en-US', 'de', 'id')),
+    ('/', ('en-US', 'de', 'id')),
+])
+def test_link_hreflang_tags(url, locales, base_url):
+    for locale in locales:
+        lang = locale if locale != 'en-US' else 'en'
+        full_url = '{}/{}{}'.format(base_url, locale, url)
+        link_url = '{}/{}{}'.format('https://www.mozilla.org', locale, url)
+        resp = requests.get(full_url, timeout=5)
+        assert LINK_TEMPLATE.format(lang=lang, url=link_url) in resp.content


### PR DESCRIPTION
Hopefully this will tell us if we're actually seeing any incorrect metadata from these pages.