### PR TITLE
Mark hreflang tests as not smoke

### DIFF
--- a/tests/functional/test_link_hreflang_tags.py
+++ b/tests/functional/test_link_hreflang_tags.py
@@ -9,7 +9,6 @@ import requests
 LINK_TEMPLATE = '<link rel="canonical" hreflang="{lang}" href="{url}">'
 
 
-@pytest.mark.smoke
 @pytest.mark.headless
 @pytest.mark.nondestructive
 @pytest.mark.parametrize('url,locales', [


### PR DESCRIPTION
Smoke tests run against the code image which doesn't have locales.  These tests require the localization files.