### PR TITLE
[fix bug 1432236] Add dev edition experiment to /firefox/new/.

### DIFF
--- a/bedrock/firefox/templates/firefox/new/scene1.html
+++ b/bedrock/firefox/templates/firefox/new/scene1.html
@@ -6,6 +6,12 @@
 
 {% extends "firefox/new/base.html" %}
 
+{% block experiments %}
+  {% if (switch('experiment-firefox-new-dev-edition', ['en-US'])) %}
+    {% javascript 'experiment_firefox_new_dev_edition' %}
+  {% endif %}
+{% endblock %}
+
 {% block optimizely %}
   {% if switch('firefox-new-optimizely', ['en-US']) %}
     {% include 'includes/optimizely.html' %}
@@ -78,6 +84,12 @@
   <ul class="small-links ios">
     <li><a rel="external" href="https://support.mozilla.org/products/ios/?utm_source=mozilla.org&amp;utm_medium=referral&amp;utm_campaign=need-help-link">{{_('Need help?')}}</a></li>
   </ul>
+
+  {# bug 1432236 - add dev edition A/B test #}
+  <div id="callout" class="hidden">
+    <p>Get Firefox Developer Edition to build, test and debug with the latest open-source devtools.</p>
+    <a href="{{ url('firefox.developer.index') }}">Learn more</a>
+  </div>
 </div>
 {% endblock %}
 

--- a/bedrock/firefox/templates/firefox/new/scene2.html
+++ b/bedrock/firefox/templates/firefox/new/scene2.html
@@ -14,6 +14,12 @@
 {# see https://bugzilla.mozilla.org/show_bug.cgi?id=1438302 #}
 {% block canonical_urls %}{% endblock %}
 
+{% block experiments %}
+  {% if (switch('experiment-firefox-new-dev-edition', ['en-US'])) %}
+    {% javascript 'experiment_firefox_new_dev_edition' %}
+  {% endif %}
+{% endblock %}
+
 {% block optimizely %}
   {% if switch('firefox-new-scene2-optimizely', ['en-US']) %}
     {% include 'includes/optimizely.html' %}
@@ -78,6 +84,12 @@
     {% endif %}
   </a></li>
 </ul>
+
+{# bug 1432236 - add dev edition A/B test #}
+<div id="callout" class="hidden">
+  <p>Developers - Looking for open-source devtools?</p>
+  <a href="{{ url('firefox.developer.index') }}">Check out Firefox Developer Edition</a>
+</div>
 {% endblock %}
 
 {% block js %}

--- a/bedrock/settings/static_media.py
+++ b/bedrock/settings/static_media.py
@@ -389,6 +389,7 @@ PIPELINE_CSS = {
     'firefox_new_common': {
         'source_filenames': (
             'css/firefox/new/common.scss',
+            'css/firefox/new/experiment-dev-edition.scss',
         ),
         'output_filename': 'css/firefox_new_common-bundle.css',
     },
@@ -1175,6 +1176,13 @@ PIPELINE_JS = {
             'js/firefox/new/experiment-firefox-new-waitface.js',
         ),
         'output_filename': 'js/experiment_firefox_new_waitface-bundle.js',
+    },
+    'experiment_firefox_new_dev_edition': {
+        'source_filenames': (
+            'js/base/mozilla-traffic-cop.js',
+            'js/firefox/new/experiment-firefox-new-dev-edition.js',
+        ),
+        'output_filename': 'js/experiment_firefox_new_dev_edition-bundle.js',
     },
     'firefox_new_pixel': {
         'source_filenames': (

--- a/media/css/firefox/new/experiment-dev-edition.scss
+++ b/media/css/firefox/new/experiment-dev-edition.scss
@@ -1,0 +1,49 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+@import '../../pebbles/includes/lib';
+
+.main-download {
+    position: relative;
+}
+
+.header-content .small-links {
+    margin-top: 40px;
+}
+
+#callout {
+    @include font-size-level6;
+    background-image: url('/media/img/logos/firefox/logo-developer-quantum.png'),
+                      linear-gradient(to right, rgb(19, 1, 113), rgb(1, 15, 60));
+    background-position: left 20px top 20px, left top;
+    background-repeat: no-repeat, repeat;
+    background-size: 50px, 100%;
+    border-radius: 8px;
+    box-sizing: border-box;
+    margin: 0 auto;
+    max-width: 400px;
+    min-height: 50px;
+    padding: 20px 20px 20px 100px;
+    text-align: left;
+    z-index: 1;
+
+    a,
+    a:active,
+    a:focus,
+    a:hover,
+    a:link,
+    a:visited {
+        color: #fff;
+        text-decoration: underline;
+    }
+
+    @media #{$mq-tablet} {
+        margin: 0;
+        position: absolute;
+    }
+
+    @media #{$mq-desktop} {
+        margin-top: 20px;
+    }
+}

--- a/media/js/firefox/new/experiment-firefox-new-dev-edition.js
+++ b/media/js/firefox/new/experiment-firefox-new-dev-edition.js
@@ -1,0 +1,42 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+(function(Mozilla, dataLayer) {
+    'use strict';
+
+    // do not run on mobile OS's
+    var isDesktop = !/android|ios/.test(site.platform);
+    // do not run on IE < 9
+    var isIELT9 = /MSIE\s[1-8]\./.test(navigator.userAgent);
+    // only run if referrer is present and does not contain www.mozilla.org
+    var isReferral = document.referrer !== '' && !/www\.mozilla\.org/.test(document.referrer);
+
+    if (isReferral && isDesktop && !isIELT9) {
+        var callback = function(variation) {
+            dataLayer.push({
+                'data-ex-present': 'true',
+                'data-ex-variant': variation === 'a' ? 'dev-link-present' : 'control',
+                'data-ex-experiment': 'fx-dev-ed-on-new'
+            });
+
+            if (variation === 'a') {
+                // wait for DOM load so we can find/alter the callout element
+                document.addEventListener('DOMContentLoaded', function() {
+                    var callout = document.getElementById('callout');
+                    callout.setAttribute('class', 'visible');
+                });
+            }
+        };
+
+        var ramathorn = new Mozilla.TrafficCop({
+            id: 'experiment_firefox_new_dev_edition',
+            customCallback: callback,
+            variations: {
+                'a': 5
+            }
+        });
+
+        ramathorn.init();
+    }
+})(window.Mozilla, window.dataLayer || []);


### PR DESCRIPTION
## Description

Adds experiment placing a callout for Dev Edition on scenes 1 & 2 of `/firefox/new/` for en-US only.

## Issue / Bugzilla link

https://bugzilla.mozilla.org/show_bug.cgi?id=1432236

## Testing

Make sure you have DNT/tracking protection disabled.

https://bedrock-demo-jpetto.us-west.moz.works/en-US/firefox/new/
