### PR TITLE
Add translations back to english Tecnology page

### DIFF
--- a/bedrock/mozorg/templates/mozorg/technology-en.html
+++ b/bedrock/mozorg/templates/mozorg/technology-en.html
@@ -4,6 +4,8 @@
 
 {% extends "mozorg/technology.html" %}
 
+{% add_lang_files "mozorg/technology" %}
+
 {% block page_hero %}
   <div class="hero-rust-video section">
     <a rel="external" class="video-play" title="{{ _('Watch the video') }}" href="https://www.youtube.com/watch?list=PLo3w8EB99pqJ74XIGe72c9hBZWz9Y16cY&v=8EPsnf_ZYU0" data-video-title="Rust and the Future of Systems Programming">


### PR DESCRIPTION
Since en-* locales have a separate template it wasn't picking up the list of translations, and so it appeared from the English page that it wasn't translated. This also meant that the en-GB version was redirecting to the en-US since that locale isn't active for the "mozorg/technology-en" langfile.