### PR TITLE
[fix bug 1440404] Remove custom URL scheme for app store links to Firefox on iOS

### DIFF
--- a/media/js/base/mozilla-utils.js
+++ b/media/js/base/mozilla-utils.js
@@ -12,20 +12,12 @@ if (typeof Mozilla === 'undefined') {
 
     var Utils = {};
 
-    // Replace Google Play and Apple App Store links on Android and iOS devices to
-    // let them open the native marketplace app
+    // Replace Google Play links on Android devices to let them open the marketplace app
     Utils.initMobileDownloadLinks = function() {
         if (site.platform === 'android') {
             $('a[href^="https://play.google.com/store/apps/"]').each(function() {
                 $(this).attr('href', $(this).attr('href')
                     .replace('https://play.google.com/store/apps/', 'market://'));
-            });
-        }
-
-        if (site.platform === 'ios') {
-            $('a[href^="https://itunes.apple.com/"]').each(function() {
-                $(this).attr('href', $(this).attr('href')
-                    .replace('https://', 'itms-apps://'));
             });
         }
     };

--- a/tests/unit/spec/base/mozilla-utils.js
+++ b/tests/unit/spec/base/mozilla-utils.js
@@ -24,14 +24,6 @@ describe('mozilla-utils.js', function() {
             Mozilla.Utils.initMobileDownloadLinks();
             expect($link.attr('href')).toEqual('market://details?id=org.mozilla.firefox');
         });
-
-        it('should set a URL with the itms-apps scheme on iOS', function () {
-            window.site.platform = 'ios';
-            $link = $('<a class="download-link" href="https://itunes.apple.com/us/app/apple-store/id989804926?mt=8">foo</a>').appendTo('body');
-            Mozilla.Utils.initMobileDownloadLinks();
-            expect($link.attr('href')).toEqual('itms-apps://itunes.apple.com/us/app/apple-store/id989804926?mt=8');
-        });
-
     });
 
     describe('maybeSwitchToDistDownloadLinks', function() {


### PR DESCRIPTION
## Description
- Removes dynamic `itms-apps://` links for Firefox on iOS, as the protocal does not work for some newer webviews by default.

## Issue / Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1440404

## Testing
- Visit `/firefox/new/` on an iOS device, and the download button should use `https://` and not `itms-apps://`.
- Clicking the download button should still redirect to the native app store as expected.
