### PR TITLE
[fix bug 1442229] Exclude /firefox/tracking-protection/start/ from sitemap.xml

### DIFF
--- a/bedrock/firefox/templates/firefox/tracking-protection-tour.html
+++ b/bedrock/firefox/templates/firefox/tracking-protection-tour.html
@@ -4,7 +4,7 @@
 
 {% extends "firefox/base-resp.html" %}
 
-{% block extra_meta %}<meta name="robots" content="noindex">{% endblock %}
+{% block canonical_urls %}<meta name="robots" content="noindex">{% endblock %}
 
 {#- This will appear as <meta property="og:title"> which can be used for social share -#}
 {% block page_og_title %}

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -294,6 +294,7 @@ NOINDEX_URLS = [
     r'^firefox/send-to-device-post',
     r'^firefox/feedback',
     r'^firefox/stub_attribution_code/',
+    r'^.+/tracking-protection/start/$',
     r'^.+/(firstrun|whatsnew)/$',
     r'^l10n_example/',
     r'^m/',


### PR DESCRIPTION
## Description
- Removes `/firefox/tracking-protection/start/` from our XML sitemap.
- Also removes canonical/hreflang URLs from template, since this is a noindex page.

## Issue / Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1442229

## Testing
- I wasn't sure how to test the generated sitemap locally?