### PR TITLE
[fix bug 1442327] Remove hreflang in canonical tag

### DIFF
--- a/bedrock/base/templates/includes/canonical-url.html
+++ b/bedrock/base/templates/includes/canonical-url.html
@@ -1,4 +1,4 @@
-    <link rel="canonical" hreflang="{{ LANG|replace('en-US', 'en') }}" href="{{ settings.CANONICAL_URL + '/' + LANG + canonical_path }}">
+    <link rel="canonical" href="{{ settings.CANONICAL_URL + '/' + LANG + canonical_path }}">
     <link rel="alternate" hreflang="x-default" href="{{ settings.CANONICAL_URL }}/{{ settings.LANGUAGE_CODE }}{{ canonical_path }}">
     {% if translations -%}
       {%- for code, label in translations|dictsort -%}


### PR DESCRIPTION
## Description
- Removes `hreflang` attribute from canonical link on all pages.

## Issue / Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1442327
