### PR TITLE
[fix bug 1442331] Noindex pages must not have canonical and hreflang

### DIFF
--- a/bedrock/etc/templates/etc/firefox/retention/thank-you-a.html
+++ b/bedrock/etc/templates/etc/firefox/retention/thank-you-a.html
@@ -16,6 +16,9 @@
   {{ _('Thank you page.') }}
 {% endblock %}
 
+{# "noindex" pages should not have the canonical or hreflang tags: bug 1442331 #}
+{% block canonical_urls %}<meta name="robots" content="noindex,follow">{% endblock %}
+
 {% block page_css %}
   {% stylesheet 'etc-firefox-retention-thank-you-a' %}
 {% endblock %}

--- a/bedrock/etc/templates/etc/firefox/retention/thank-you-b.html
+++ b/bedrock/etc/templates/etc/firefox/retention/thank-you-b.html
@@ -16,6 +16,9 @@
   {{ _('Thank you page.') }}
 {% endblock %}
 
+{# "noindex" pages should not have the canonical or hreflang tags: bug 1442331 #}
+{% block canonical_urls %}<meta name="robots" content="noindex,follow">{% endblock %}
+
 {% block page_css %}
   {% stylesheet 'etc-firefox-retention-thank-you-b' %}
 {% endblock %}

--- a/bedrock/etc/templates/etc/firefox/retention/thank-you-referral.html
+++ b/bedrock/etc/templates/etc/firefox/retention/thank-you-referral.html
@@ -10,6 +10,9 @@
 {% block page_title_suffix %}{% endblock %}
 {% block page_desc %}{{ _('Tell your friends to try the new Firefox') }}{% endblock %}
 
+{# "noindex" pages should not have the canonical or hreflang tags: bug 1442331 #}
+{% block canonical_urls %}<meta name="robots" content="noindex,follow">{% endblock %}
+
 {% block page_css %}
   {% stylesheet 'etc-firefox-retention-thank-you-referral' %}
 {% endblock %}

--- a/bedrock/firefox/templates/firefox/all.html
+++ b/bedrock/firefox/templates/firefox/all.html
@@ -1,7 +1,8 @@
 {% from "product-all-macros.html" import build_search_box, build_table, build_row, build_link with context %}
 {% extends "firefox/base-resp.html" %}
 
-{% block extra_meta %}<meta name="robots" content="noindex">{% endblock %}
+{# "noindex" pages should not have the canonical or hreflang tags: bug 1442331 #}
+{% block canonical_urls %}<meta name="robots" content="noindex,follow">{% endblock %}
 
 {% block page_title %}
   {%- if platform == 'android' -%}

--- a/bedrock/firefox/templates/firefox/australis/base.html
+++ b/bedrock/firefox/templates/firefox/australis/base.html
@@ -6,7 +6,8 @@
 
 {% set_lang_files "firefox/australis/firefox_tour" %}
 
-{% block extra_meta %}<meta name="robots" content="noindex">{% endblock %}
+{# "noindex" pages should not have the canonical or hreflang tags: bug 1442331 #}
+{% block canonical_urls %}<meta name="robots" content="noindex,follow">{% endblock %}
 
 {% block extrahead %}
   {% if switch('firefox-update-notification-modal', ['en-US']) %}

--- a/bedrock/firefox/templates/firefox/australis/fx38_0_5/firstrun.html
+++ b/bedrock/firefox/templates/firefox/australis/fx38_0_5/firstrun.html
@@ -8,7 +8,8 @@
 
 {% block gtm_page_id %}data-gtm-page-id="/firefox/firstrun/"{% endblock %}
 
-{% block extra_meta %}<meta name="robots" content="noindex">{% endblock %}
+{# "noindex" pages should not have the canonical or hreflang tags: bug 1442331 #}
+{% block canonical_urls %}<meta name="robots" content="noindex,follow">{% endblock %}
 
 {#- This will appear as <meta property="og:title"> which can be used for social share -#}
 {% block page_og_title %}

--- a/bedrock/firefox/templates/firefox/dev-firstrun.html
+++ b/bedrock/firefox/templates/firefox/dev-firstrun.html
@@ -8,7 +8,8 @@
 
 {% block gtm_page_id %}data-gtm-page-id="/firefox/dev-firstrun/"{% endblock %}
 
-{% block extra_meta %}<meta name="robots" content="noindex">{% endblock %}
+{# "noindex" pages should not have the canonical or hreflang tags: bug 1442331 #}
+{% block canonical_urls %}<meta name="robots" content="noindex,follow">{% endblock %}
 
 {% block page_css %}
   {% stylesheet 'firefox_developer_firstrun' %}

--- a/bedrock/firefox/templates/firefox/dev-whatsnew.html
+++ b/bedrock/firefox/templates/firefox/dev-whatsnew.html
@@ -8,7 +8,8 @@
 
 {% block gtm_page_id %}data-gtm-page-id="/firefox/dev-whatsnew/"{% endblock %}
 
-{% block extra_meta %}<meta name="robots" content="noindex">{% endblock %}
+{# "noindex" pages should not have the canonical or hreflang tags: bug 1442331 #}
+{% block canonical_urls %}<meta name="robots" content="noindex,follow">{% endblock %}
 
 {% block page_css %}
   {% stylesheet 'firefox_developer_firstrun' %}

--- a/bedrock/firefox/templates/firefox/firstrun/base-pebbles.html
+++ b/bedrock/firefox/templates/firefox/firstrun/base-pebbles.html
@@ -6,7 +6,8 @@
 
 {% extends "firefox/base-pebbles.html" %}
 
-{% block extra_meta %}<meta name="robots" content="noindex">{% endblock %}
+{# "noindex" pages should not have the canonical or hreflang tags: bug 1442331 #}
+{% block canonical_urls %}<meta name="robots" content="noindex,follow">{% endblock %}
 
 {% block page_title_prefix %}{% endblock %}
 {% block page_title %}{{ _('Welcome to Firefox') }}{% endblock %}

--- a/bedrock/firefox/templates/firefox/firstrun/base.html
+++ b/bedrock/firefox/templates/firefox/firstrun/base.html
@@ -6,7 +6,8 @@
 
 {% extends "firefox/base.html" %}
 
-{% block extra_meta %}<meta name="robots" content="noindex">{% endblock %}
+{# "noindex" pages should not have the canonical or hreflang tags: bug 1442331 #}
+{% block canonical_urls %}<meta name="robots" content="noindex,follow">{% endblock %}
 
 {% block page_title_prefix %}{% endblock %}
 {% block page_title %}{{ _('Welcome to Firefox') }}{% endblock %}

--- a/bedrock/firefox/templates/firefox/installer-help.html
+++ b/bedrock/firefox/templates/firefox/installer-help.html
@@ -4,7 +4,8 @@
 
 {% extends "/firefox/base-resp.html" %}
 
-{% block extra_meta %}<meta name="robots" content="noindex">{% endblock %}
+{# "noindex" pages should not have the canonical or hreflang tags: bug 1442331 #}
+{% block canonical_urls %}<meta name="robots" content="noindex,follow">{% endblock %}
 
 {% block page_title %}{{ _('Your download was interrupted') }}{% endblock %}
 {% block body_id %}installer-help{% endblock %}

--- a/bedrock/firefox/templates/firefox/new/reggie-watts/base.html
+++ b/bedrock/firefox/templates/firefox/new/reggie-watts/base.html
@@ -6,13 +6,8 @@
 
 {% extends "firefox/base-pebbles.html" %}
 
-{# "noindex" pages should not have the canonical or hreflang tags #}
-{# see https://bugzilla.mozilla.org/show_bug.cgi?id=1438302 #}
-{% block canonical_urls %}{% endblock %}
-
-{% block extra_meta %}
-  <meta name="robots" content="noindex,follow">
-{% endblock %}
+{# "noindex" pages should not have the canonical or hreflang tags: bug 1442331 #}
+{% block canonical_urls %}<meta name="robots" content="noindex,follow">{% endblock %}
 
 {% block page_title_prefix %}{% endblock %}
 {% block page_title %}{{_('Free Web Browser for Android, iOS, Desktop | Firefox')}}{% endblock %}

--- a/bedrock/firefox/templates/firefox/new/scene2.html
+++ b/bedrock/firefox/templates/firefox/new/scene2.html
@@ -6,13 +6,8 @@
 
 {% extends "firefox/new/base.html" %}
 
-{% block extra_meta %}
-  <meta name="robots" content="noindex,follow">
-{% endblock %}
-
-{# "noindex" pages should not have the canonical or hreflang tags #}
-{# see https://bugzilla.mozilla.org/show_bug.cgi?id=1438302 #}
-{% block canonical_urls %}{% endblock %}
+{# "noindex" pages should not have the canonical or hreflang tags: bug 1442331 #}
+{% block canonical_urls %}<meta name="robots" content="noindex,follow">{% endblock %}
 
 {% block experiments %}
   {% if (switch('experiment-firefox-new-dev-edition', ['en-US'])) %}

--- a/bedrock/firefox/templates/firefox/new/wait-face/base.html
+++ b/bedrock/firefox/templates/firefox/new/wait-face/base.html
@@ -18,13 +18,8 @@
   {% endif %}
 {% endblock %}
 
-{# "noindex" pages should not have the canonical or hreflang tags #}
-{# see https://bugzilla.mozilla.org/show_bug.cgi?id=1438302 #}
-{% block canonical_urls %}{% endblock %}
-
-{% block extra_meta %}
-  <meta name="robots" content="noindex,follow">
-{% endblock %}
+{# "noindex" pages should not have the canonical or hreflang tags: bug 1442331 #}
+{% block canonical_urls %}<meta name="robots" content="noindex,follow">{% endblock %}
 
 {% block page_title_prefix %}{% endblock %}
 {% block page_title %}{{_('Free Web Browser for Android, iOS, Desktop | Firefox')}}{% endblock %}

--- a/bedrock/firefox/templates/firefox/nightly_firstrun.html
+++ b/bedrock/firefox/templates/firefox/nightly_firstrun.html
@@ -6,7 +6,8 @@
 
 {% extends "/firefox/base-resp.html" %}
 
-{% block extra_meta %}<meta name="robots" content="noindex">{% endblock %}
+{# "noindex" pages should not have the canonical or hreflang tags: bug 1442331 #}
+{% block canonical_urls %}<meta name="robots" content="noindex,follow">{% endblock %}
 
 {% block page_css %}
   {% stylesheet 'nightly_firstrun' %}

--- a/bedrock/firefox/templates/firefox/nightly_whatsnew.html
+++ b/bedrock/firefox/templates/firefox/nightly_whatsnew.html
@@ -5,7 +5,8 @@
 {% extends "/firefox/base-pebbles.html" %}
 {% add_lang_files "firstrun" "mobile" %}
 
-{% block extra_meta %}<meta name="robots" content="noindex">{% endblock %}
+{# "noindex" pages should not have the canonical or hreflang tags: bug 1442331 #}
+{% block canonical_urls %}<meta name="robots" content="noindex,follow">{% endblock %}
 
 {% block extrahead %}
   {% stylesheet 'nightly_whatsnew' %}

--- a/bedrock/firefox/templates/firefox/tracking-protection-tour.html
+++ b/bedrock/firefox/templates/firefox/tracking-protection-tour.html
@@ -4,7 +4,8 @@
 
 {% extends "firefox/base-resp.html" %}
 
-{% block canonical_urls %}<meta name="robots" content="noindex">{% endblock %}
+{# "noindex" pages should not have the canonical or hreflang tags: bug 1442331 #}
+{% block canonical_urls %}<meta name="robots" content="noindex,follow">{% endblock %}
 
 {#- This will appear as <meta property="og:title"> which can be used for social share -#}
 {% block page_og_title %}

--- a/bedrock/firefox/templates/firefox/whatsnew/base-pebbles.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/base-pebbles.html
@@ -4,7 +4,8 @@
 
 {% extends "firefox/base-pebbles.html" %}
 
-{% block extra_meta %}<meta name="robots" content="noindex">{% endblock %}
+{# "noindex" pages should not have the canonical or hreflang tags: bug 1442331 #}
+{% block canonical_urls %}<meta name="robots" content="noindex,follow">{% endblock %}
 
 {% block gtm_page_id %}data-gtm-page-id="/firefox/whatsnew/"{% endblock %}
 

--- a/bedrock/firefox/templates/firefox/whatsnew/base.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/base.html
@@ -4,7 +4,8 @@
 
 {% extends "firefox/base-resp.html" %}
 
-{% block extra_meta %}<meta name="robots" content="noindex">{% endblock %}
+{# "noindex" pages should not have the canonical or hreflang tags: bug 1442331 #}
+{% block canonical_urls %}<meta name="robots" content="noindex,follow">{% endblock %}
 
 {% block gtm_page_id %}data-gtm-page-id="/firefox/whatsnew/"{% endblock %}
 

--- a/bedrock/foundation/templates/foundation/openwebfund/thanks.html
+++ b/bedrock/foundation/templates/foundation/openwebfund/thanks.html
@@ -4,7 +4,8 @@
 
 {% extends "foundation/base-resp.html" %}
 
-{% block extra_meta %}<meta name="robots" content="noindex">{% endblock %}
+{# "noindex" pages should not have the canonical or hreflang tags: bug 1442331 #}
+{% block canonical_urls %}<meta name="robots" content="noindex,follow">{% endblock %}
 
 {% block page_title %}{{ _('Thank you') }}{% endblock %}
 

--- a/bedrock/newsletter/templates/newsletter/confirm.html
+++ b/bedrock/newsletter/templates/newsletter/confirm.html
@@ -4,7 +4,8 @@
 
 {% block gtm_page_id %}data-gtm-page-id="/newsletter/confirm/"{% endblock %}
 
-{% block extra_meta %}<meta name="robots" content="noindex">{% endblock %}
+{# "noindex" pages should not have the canonical or hreflang tags: bug 1442331 #}
+{% block canonical_urls %}<meta name="robots" content="noindex,follow">{% endblock %}
 
 {% block body_id %}newsletter-confirm{% endblock body_id %}
 

--- a/bedrock/newsletter/templates/newsletter/country.html
+++ b/bedrock/newsletter/templates/newsletter/country.html
@@ -2,7 +2,8 @@
 
 {% block gtm_page_id %}data-gtm-page-id="/newsletter/country/"{% endblock %}
 
-{% block extra_meta %}<meta name="robots" content="noindex">{% endblock %}
+{# "noindex" pages should not have the canonical or hreflang tags: bug 1442331 #}
+{% block canonical_urls %}<meta name="robots" content="noindex,follow">{% endblock %}
 
 {% block body_id %}newsletter-country{% endblock body_id %}
 

--- a/bedrock/newsletter/templates/newsletter/country_success.html
+++ b/bedrock/newsletter/templates/newsletter/country_success.html
@@ -1,6 +1,7 @@
 {% extends 'newsletter/base.html' %}
 
-{% block extra_meta %}<meta name="robots" content="noindex">{% endblock %}
+{# "noindex" pages should not have the canonical or hreflang tags: bug 1442331 #}
+{% block canonical_urls %}<meta name="robots" content="noindex,follow">{% endblock %}
 
 {% block body_id %}newsletter-country-success{% endblock body_id %}
 

--- a/bedrock/newsletter/templates/newsletter/existing.html
+++ b/bedrock/newsletter/templates/newsletter/existing.html
@@ -6,7 +6,8 @@
 
 {% block gtm_page_id %}data-gtm-page-id="/newsletter/existing/"{% endblock %}
 
-{% block extra_meta %}<meta name="robots" content="noindex">{% endblock %}
+{# "noindex" pages should not have the canonical or hreflang tags: bug 1442331 #}
+{% block canonical_urls %}<meta name="robots" content="noindex,follow">{% endblock %}
 
 {% block body_id %}newsletter-existing{% endblock body_id %}
 

--- a/bedrock/newsletter/templates/newsletter/recovery.html
+++ b/bedrock/newsletter/templates/newsletter/recovery.html
@@ -2,7 +2,8 @@
 
 {% set_lang_files "mozorg/newsletters" %}
 
-{% block extra_meta %}<meta name="robots" content="noindex">{% endblock %}
+{# "noindex" pages should not have the canonical or hreflang tags: bug 1442331 #}
+{% block canonical_urls %}<meta name="robots" content="noindex,follow">{% endblock %}
 
 {% block body_id %}newsletter-recovery{% endblock body_id %}
 

--- a/bedrock/newsletter/templates/newsletter/updated.html
+++ b/bedrock/newsletter/templates/newsletter/updated.html
@@ -2,7 +2,8 @@
 
 {% set_lang_files "mozorg/newsletters" %}
 
-{% block extra_meta %}<meta name="robots" content="noindex">{% endblock %}
+{# "noindex" pages should not have the canonical or hreflang tags: bug 1442331 #}
+{% block canonical_urls %}<meta name="robots" content="noindex,follow">{% endblock %}
 
 {% block body_id %}newsletter-updated{% endblock body_id %}
 

--- a/bedrock/thunderbird/templates/thunderbird/all.html
+++ b/bedrock/thunderbird/templates/thunderbird/all.html
@@ -5,7 +5,8 @@
 {% from "product-all-macros.html" import build_search_box, build_table, build_row, build_link with context %}
 {% extends "thunderbird/base-resp.html" %}
 
-{% block extra_meta %}<meta name="robots" content="noindex">{% endblock %}
+{# "noindex" pages should not have the canonical or hreflang tags: bug 1442331 #}
+{% block canonical_urls %}<meta name="robots" content="noindex,follow">{% endblock %}
 
 {% block page_title %}{{ _('Download %s in your language')|format(channel_name) }}{% endblock %}
 {% block body_id %}thunderbird-all{% endblock %}


### PR DESCRIPTION
## Description
- Removes `canonincal` and `hreflang` links from all pages that are `noindex`

## Issue / Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1442331

## Testing
- [ ] `<head>` should appear as above for all pages touched in the PR.
- [ ] Check I didn't miss any stragglers?