### PR TITLE
[bug 1434764] utm_source is Facebook

### DIFF
--- a/media/js/firefox/new/experiment-firefox-new-waitface.js
+++ b/media/js/firefox/new/experiment-firefox-new-waitface.js
@@ -18,7 +18,7 @@
     var paramsMatch = function() {
         var params = {
             'utm_medium': 'display', 
-            'utm_source': 'doubleclick'
+            'utm_source': 'facebook'
         };
 
         for (var key in params) {


### PR DESCRIPTION
## Description
Addresses utm_parameter change requested in https://bugzilla.mozilla.org/show_bug.cgi?id=1434764#c9. See https://github.com/mozilla/bedrock/pull/5443 for history of this code.
