### PR TITLE
[fix bug 1441597] Add FxA copy experiment to /firstrun.

### DIFF
--- a/bedrock/firefox/templates/firefox/firstrun/firstrun-quantum.html
+++ b/bedrock/firefox/templates/firefox/firstrun/firstrun-quantum.html
@@ -8,6 +8,12 @@
 
 {% block body_id %}firstrun-quantum-onboarding{% endblock %}
 
+{% block experiments %}
+  {% if (switch('experiment-firefox-firstrun-fxa', ['en-US'])) %}
+    {% javascript 'experiment_firefox_firstrun_fxa' %}
+  {% endif %}
+{% endblock %}
+
 {% block page_title %}
   {{ _('Welcome to Firefox') }}
 {% endblock %}
@@ -85,6 +91,49 @@
 
     <main class="fxaccounts-container">
       <header id="main-header">
+      {% if v == 'b' %}
+        <h1>The web is a big place.<br>Take shortcuts.<br>Get a Firefox Account.</h1>
+
+        <p class="content">
+          Instantly share tabs, sync bookmarks and save pages for offline viewing.
+        </p>
+
+        <a href="{{ url('firefox.features.sync') }}" rel="noopener noreferrer" target="_blank">Learn more</a>
+      {% elif v == 'c' %}
+        <h1>Firefox Account: One login. Epic perks.</h1>
+
+        <ul class="content">
+          <li>Send content instantly between your devices</li>
+          <li>Sync bookmarks, history and more</li>
+          <li>View pages offline and ad-free</li>
+        </ul>
+
+        <a href="{{ url('firefox.features.sync') }}" rel="noopener noreferrer" target="_blank">Learn more</a>
+      {% elif v == 'd' %}
+        <h1>Any device, anytime with a Firefox Account</h1>
+
+        <p class="content">
+          Share pages instantly, because you have better things to do than email links to yourself.
+        </p>
+
+        <a href="{{ url('firefox.features.send-tabs') }}" rel="noopener noreferrer" target="_blank">Learn more</a>
+      {% elif v == 'e' %}
+        <h1>Your internet, wherever you go. Sign up for a Firefox Account.</h1>
+
+        <p class="content">
+          Get instant link sharing, offline reading and more.
+        </p>
+
+        <a href="{{ url('firefox.features.send-tabs') }}" rel="noopener noreferrer" target="_blank">Learn more</a>
+      {% elif v == 'f' %}
+        <h1>Control your privacy</h1>
+
+        <p class="content">
+          A Firefox Account safeguards your stuff and data with end-to-end encryption. Even we can’t see it.
+        </p>
+
+        <a href="{{ url('firefox.features.sync') }}" rel="noopener noreferrer" target="_blank">Learn more</a>
+      {% else %}
         <h1>
         {% if l10n_has_tag('firstrun_email_only_form') %}
           {{ _('Take Firefox with You') }}
@@ -99,12 +148,16 @@
           {{_('Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.')}}
         {% endif %}
         </p>
-        <a href="{{ url('firefox.features.sync') }}" target="_blank">{{_('Learn more about Firefox Accounts')}}</a>
+        <a href="{{ url('firefox.features.sync') }}" rel="noopener noreferrer" target="_blank">{{_('Learn more about Firefox Accounts')}}</a>
+      {% endif %}
       </header>
       <div class="fxaccounts" id="fxa-iframe-config" data-host="{{ settings.FXA_IFRAME_SRC }}" data-mozillaonline-host="{{ settings.FXA_IFRAME_SRC_MOZILLAONLINE }}">
         {# Bug 1354710: firstrun pages need to pass funnelcake parameters to FxA #}
         {% set utm_source = 'firstrun' if not funnelcake_id else 'firstrun_f' + funnelcake_id %}
-        <iframe id="fxa" scrolling="no" data-src="{{ settings.FXA_IFRAME_SRC }}?action=email&amp;utm_campaign=fxa-embedded-form&amp;utm_medium=referral&amp;utm_source={{ utm_source }}&amp;utm_content=fx-{{ version }}&amp;entrypoint=firstrun&amp;service=sync&amp;context=iframe&amp;style=chromeless&amp;haltAfterSignIn=true"></iframe>
+        {# FxA copy experiment: https://bugzilla.mozilla.org/show_bug.cgi?id=1441597 #}
+        {% set utm_term = '&utm_term=%s'|format(v) if v else '' %}
+        {% set utm_campaign = 'firstrun-copy-ex1' if v else 'fxa-embedded-form' %}
+        <iframe id="fxa" scrolling="no" data-src="{{ settings.FXA_IFRAME_SRC }}?action=email&amp;utm_campaign={{ utm_campaign }}&amp;utm_medium=referral&amp;utm_source={{ utm_source }}&amp;utm_content=fx-{{ version }}{{ utm_term }}&amp;entrypoint=firstrun&amp;service=sync&amp;context=iframe&amp;style=chromeless&amp;haltAfterSignIn=true"></iframe>
         <button id="skip-button">{{_('Skip this step')}}</button>
       </div>
     </main>

--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -367,6 +367,23 @@ class FirstrunView(l10n_utils.LangFilesMixin, TemplateView):
         # add version to context for use in templates
         ctx['version'] = self.kwargs.get('version') or ''
 
+        # add variation for FxA copy experiment
+        # https://bugzilla.mozilla.org/show_bug.cgi?id=1441597
+        locale = l10n_utils.get_locale(self.request)
+
+        # experiment is en-US only
+        if locale == 'en-US':
+            variation = self.request.GET.get('v', None)
+
+            # ensure variation value is of a pre-defined set
+            if (variation not in ['a', 'b', 'c', 'd', 'e', 'f']):
+                variation = None
+        else:
+            variation = None
+
+        # send variation value (or None) to template
+        ctx['v'] = variation
+
         return ctx
 
     def get_template_names(self):

--- a/bedrock/settings/static_media.py
+++ b/bedrock/settings/static_media.py
@@ -1076,6 +1076,13 @@ PIPELINE_JS = {
         ),
         'output_filename': 'js/firefox_firstrun_quantum-bundle.js',
     },
+    'experiment_firefox_firstrun_fxa': {
+        'source_filenames': (
+            'js/base/mozilla-traffic-cop.js',
+            'js/firefox/firstrun/experiment-firefox-firstrun-fxa.js',
+        ),
+        'output_filename': 'js/experiment_firefox_firstrun_fxa-bundle.js',
+    },
     'firefox_developer': {
         'source_filenames': (
             'js/libs/jquery.waypoints.min.js',

--- a/media/css/firefox/firstrun/firstrun-quantum.scss
+++ b/media/css/firefox/firstrun/firstrun-quantum.scss
@@ -628,3 +628,7 @@ html.win8up {
     }
 }
 
+// FxA experiment: https://bugzilla.mozilla.org/show_bug.cgi?id=1441597
+ul.content {
+    padding-left: 20px;
+}

--- a/media/js/firefox/firstrun/experiment-firefox-firstrun-fxa.js
+++ b/media/js/firefox/firstrun/experiment-firefox-firstrun-fxa.js
@@ -1,0 +1,21 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+(function(Mozilla) {
+    'use strict';
+
+    var rabbit = new Mozilla.TrafficCop({
+        id: 'experiment_firefox_firstrun_fxa',
+        variations: {
+            'v=a': 2, // control
+            'v=b': 2,
+            'v=c': 2,
+            'v=d': 2,
+            'v=e': 2,
+            'v=f': 2
+        }
+    });
+
+    rabbit.init();
+})(window.Mozilla);


### PR DESCRIPTION
## Description

Adds copy experiment for `/firefox/firstrun/`.

## Issue / Bugzilla link

https://bugzilla.mozilla.org/show_bug.cgi?id=1441597

## Testing

Has a 12% chance of being entered into an experiment:
https://www-demo4.allizom.org/en-US/firefox/58.0/firstrun/

Or, hit each variation directly:

- https://www-demo4.allizom.org/en-US/firefox/58.0/firstrun/?v=a (control)
- https://www-demo4.allizom.org/en-US/firefox/58.0/firstrun/?v=b
- https://www-demo4.allizom.org/en-US/firefox/58.0/firstrun/?v=c
- https://www-demo4.allizom.org/en-US/firefox/58.0/firstrun/?v=d
- https://www-demo4.allizom.org/en-US/firefox/58.0/firstrun/?v=e
- https://www-demo4.allizom.org/en-US/firefox/58.0/firstrun/?v=f
