### PR TITLE
[fix bug 1442129] Opt-out confirmation page tweaks

### DIFF
--- a/bedrock/newsletter/templates/newsletter/opt-out-confirmation.html
+++ b/bedrock/newsletter/templates/newsletter/opt-out-confirmation.html
@@ -50,9 +50,9 @@
               <div class="field-contents">
                 {{ form.email.errors }}
                 <label for="id_email">{{ _('Your email address:') }}</label>
-                {{ form.email }}
+                {{ field_with_attrs(form.email, placeholder=_('yourname@example.com'))|safe }}
               </div>
-              <button class="button button-hollow button-dark" type="submit">{{ _('Manage preferences') }}</button>
+              <button class="button button-hollow button-dark" type="submit">{{ _('Manage Preferences') }}</button>
             </div>
           </div>
 

--- a/media/css/newsletter/newsletter-opt-out-confirmation.scss
+++ b/media/css/newsletter/newsletter-opt-out-confirmation.scss
@@ -33,8 +33,13 @@ header {
     }
 
     .tagline {
-        @include font-size-level4;
         font-weight: bold;
+    }
+
+    @media #{$mq-tablet} {
+        .tagline {
+            @include font-size(24px);
+        }
     }
 }
 


### PR DESCRIPTION
## Description
- Fixes subhead font-size being smaller than body copy on small screens.
- Use title case for for button.
- Add placeholder text to email field.

## Issue / Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1442129
