### PR TITLE
Fix Bug 1441818 - New advanced download page should not put Windows 32 & Linux 32 at the same level

### DIFF
--- a/bedrock/firefox/templates/firefox/includes/download-list.html
+++ b/bedrock/firefox/templates/firefox/includes/download-list.html
@@ -2,14 +2,18 @@
  # License, v. 2.0. If a copy of the MPL was not distributed with this
  # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
 
-<ul id="{{ id }}" class="download-platform-list">
-  {% for plat in builds -%}
-    <li class="os_{{ plat.os }}{% if plat.arch %} {{ plat.arch }}{% endif %}">
-      <a href="{{ plat.download_link_direct or plat.download_link }}"
-         class="download-link"
-         data-link-type="download"
-         data-download-version="{{ plat.os }}"
-         data-download-os="Desktop">{{ plat.os_arch_pretty or plat.os_pretty }}</a>
-    </li>
+<div id="{{ id }}" class="download-platform-lists">
+  {%- for cls in ['recommended', 'traditional'] %}
+    <ul class="download-platform-list {{ cls }}">
+      {% for plat in builds[cls] -%}
+        <li class="os_{{ plat.os }}{% if plat.arch %} {{ plat.arch }}{% endif %}">
+          <a href="{{ plat.download_link_direct or plat.download_link }}"
+            class="download-link"
+            data-link-type="download"
+            data-download-version="{{ plat.os }}"
+            data-download-os="Desktop">{{ plat.os_arch_pretty or plat.os_pretty }}</a>
+        </li>
+      {%- endfor %}
+    </ul>
   {%- endfor %}
-</ul>
+</div>

--- a/bedrock/firefox/tests/test_helpers.py
+++ b/bedrock/firefox/tests/test_helpers.py
@@ -330,11 +330,11 @@ class TestDownloadList(TestCase):
         # Check that links classes are ordered as expected.
         list = doc('.download-platform-list li')
         eq_(list.length, 6)
-        eq_(pq(list[0]).attr('class'), 'os_winsha1')
-        eq_(pq(list[1]).attr('class'), 'os_win64')
-        eq_(pq(list[2]).attr('class'), 'os_win')
-        eq_(pq(list[3]).attr('class'), 'os_osx')
-        eq_(pq(list[4]).attr('class'), 'os_linux64')
+        eq_(pq(list[0]).attr('class'), 'os_win64')
+        eq_(pq(list[1]).attr('class'), 'os_osx')
+        eq_(pq(list[2]).attr('class'), 'os_linux64')
+        eq_(pq(list[3]).attr('class'), 'os_win')
+        eq_(pq(list[4]).attr('class'), 'os_winsha1')
         eq_(pq(list[5]).attr('class'), 'os_linux')
 
         links = doc('.download-platform-list a')
@@ -342,15 +342,17 @@ class TestDownloadList(TestCase):
         # Check desktop links have the correct version
         self.check_desktop_links(links)
 
-        # The first link should be sha-1 bouncer.
-        first_link = pq(links[0])
+        # The fifth link should be sha-1 bouncer.
+        first_link = pq(links[4])
         first_href = first_link.attr('href')
         ok_(first_href.startswith('https://download-sha1.allizom.org'))
         self.assertListEqual(parse_qs(urlparse(first_href).query)['lang'], ['en-US'])
 
         # All other links should be to regular bouncer.
-        for link in links[1:5]:
+        for link in links:
             link = pq(link)
+            if link.attr('data-download-version') == 'winsha1':
+                continue
             href = link.attr('href')
             ok_(href.startswith('https://download.mozilla.org'))
             self.assertListEqual(parse_qs(urlparse(href).query)['lang'], ['en-US'])
@@ -370,9 +372,9 @@ class TestDownloadList(TestCase):
         list = doc('.download-platform-list li')
         eq_(list.length, 5)
         eq_(pq(list[0]).attr('class'), 'os_win64')
-        eq_(pq(list[1]).attr('class'), 'os_win')
-        eq_(pq(list[2]).attr('class'), 'os_osx')
-        eq_(pq(list[3]).attr('class'), 'os_linux64')
+        eq_(pq(list[1]).attr('class'), 'os_osx')
+        eq_(pq(list[2]).attr('class'), 'os_linux64')
+        eq_(pq(list[3]).attr('class'), 'os_win')
         eq_(pq(list[4]).attr('class'), 'os_linux')
 
         links = doc('.download-platform-list a')

--- a/media/css/firefox/new/_other-platforms.scss
+++ b/media/css/firefox/new/_other-platforms.scss
@@ -65,15 +65,29 @@ html[dir="rtl"] #other-platforms-modal-link {
         }
     }
 
+    .download-platform-lists {
+        margin: 20px 40px;
+    }
+
     .download-platform-list {
         list-style: none;
         margin: 20px auto;
         text-align: center;
 
+        &.recommended li {
+            font-weight: bold;
+        }
+
+        &.traditional {
+            border-width: 1px 0;
+            border-color: #D7D7DB;
+            border-style: solid;
+        }
+
         li {
             display: block;
             line-height: 2;
-            margin: 5px 0 0 -24px;
+            margin: 5px 0 5px -24px;
         }
 
         a:link,


### PR DESCRIPTION
## Description

Reorganize the recommended and traditional builds on [`firefox/new/`](https://www.mozilla.org/en-US/firefox/new/) like #5432.

## Issue / Bugzilla link

[Bug 1441818 - New advanced download page should not put Windows 32 & Linux 32 at the same level](https://bugzilla.mozilla.org/show_bug.cgi?id=1441818)

## Testing

Open `/firefox/new/`, click on "Advanced install options & other platforms" and see the builds reordered like [this screenshot](https://screenshots.firefox.com/05SqX3GR1KuC1BxI/www-local.allizom.org).