### PR TITLE
[fix bug 1399654] Firstrun - change skip button to gray

### DIFF
--- a/media/css/firefox/firstrun/firstrun-quantum.scss
+++ b/media/css/firefox/firstrun/firstrun-quantum.scss
@@ -191,19 +191,21 @@ body {
 #skip-button {
     -moz-appearance: none;
     @include font-size(14px);
-    background-color: #0996f8;
-    border-radius: 3px;
-    border: 1px solid #0670cc;
-    color: #fff;
+    background-color: #fcfcfc;
+    border-radius: 2px;
+    border: 1px solid #0a84ff;
+    color: #0a84ff;
     cursor: pointer;
     display: block;
     margin: 10px auto 0 auto;
     min-height: 24px;
     padding: 5px 10px;
+    transition: background-color 150ms, color 150ms, border-color 150ms;
 
     &:not([disabled]):hover {
-        background-color: #0670cc;
-        border-color: #005bab;
+        background-color: #0a84ff;
+        border-color: #0060df;
+        color: #fff;
     }
 }
 

--- a/media/css/firefox/firstrun/firstrun.less
+++ b/media/css/firefox/firstrun/firstrun.less
@@ -117,20 +117,23 @@ img {
 
 #skip-button {
     -moz-appearance: none;
-    background-color: #0996f8;
-    border-radius: 3px;
-    border: 1px solid #0670cc;
+    .font-size(14px);
+    background-color: #fcfcfc;
+    border-radius: 2px;
+    border: 1px solid #0a84ff;
     box-shadow: 0 0 0 0 transparent;
-    color: #fff;
+    color: #0a84ff;
     cursor: pointer;
     display: block;
-    height: 24px;
+    min-height: 24px;
     margin: 10px auto;
-    padding: 3px 10px;
+    padding: 5px 10px;
+    transition: background-color 150ms, color 150ms, border-color 150ms;
 
     &:not([disabled]):hover {
-        background-color: #0670cc;
-        border-color: #005bab;
+        background-color: #0a84ff;
+        border-color: #0060df;
+        color: #fff;
     }
 }
 


### PR DESCRIPTION
## Description
Changes the color of the skip button so it doesn't overshadow or compete with the signup button (which recently changed from gray to blue).

I opted for blue text and border instead of dark gray so it wouldn't look disabled, but it's still secondary to the more prominent signup button. Happy to adjust colors if someone has a better suggestion.

## Issue / Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1399654

## Testing
https://bedrock-demo-craigcook.us-west.moz.works/firefox/58.0/firstrun/
Older versions, too: https://bedrock-demo-craigcook.us-west.moz.works/firefox/55.0/firstrun/