### PR TITLE
Mark test_localized_download_links as xfail due to bug 1445077

### DIFF
--- a/tests/functional/test_download_l10n.py
+++ b/tests/functional/test_download_l10n.py
@@ -18,7 +18,8 @@ PAGE_PATHS = (
     '/firefox/android/nightly/all/',
 )
 
-
+#temporarily marking as xfail due to bug 1445077
+@pytest.mark.xfail
 @pytest.mark.download
 @pytest.mark.nondestructive
 @pytest.mark.parametrize('path', PAGE_PATHS)


### PR DESCRIPTION
## Description
test_localized_download_links is currently failing due to a legitimate 404 for a localized nightly build

## Issue / Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1445077

## Testing
This should mark the failing test as an expected failure.