### PR TITLE
Remove xfail now that bug 1445077 is resolved

### DIFF
--- a/tests/functional/test_download_l10n.py
+++ b/tests/functional/test_download_l10n.py
@@ -19,8 +19,6 @@ PAGE_PATHS = (
 )
 
 
-# temporarily marking as xfail due to bug 1445077
-@pytest.mark.xfail
 @pytest.mark.download
 @pytest.mark.nondestructive
 @pytest.mark.parametrize('path', PAGE_PATHS)


### PR DESCRIPTION
## Description
Remove xfail added in #5504 

## Issue / Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1445077

## Testing
Tests are reporting XPASS in latest runs; xfail no longer necessary.