### PR TITLE
Fix Bug 1445648 - Unpublished Android release notes get a 404 message on production instead of the coming soon message

### DIFF
--- a/bedrock/releasenotes/tests/releases/firefox-for-android-58.0a1-nightly.json
+++ b/bedrock/releasenotes/tests/releases/firefox-for-android-58.0a1-nightly.json
@@ -1,0 +1,9 @@
+{
+  "product": "Firefox for Android",
+  "channel": "Nightly",
+  "version": "58.0a1",
+  "release_date": "2017-09-21",
+  "created": "2017-03-21T13:19:13.668000+00:00",
+  "modified": "2017-03-21T13:19:13.668000+00:00",
+  "is_public": false
+}

--- a/bedrock/releasenotes/tests/test_base.py
+++ b/bedrock/releasenotes/tests/test_base.py
@@ -29,6 +29,10 @@ RELEASES_PATH = str(TESTS_PATH)
 
 @override_settings(RELEASE_NOTES_PATH=RELEASES_PATH)
 class TestReleaseViews(TestCase):
+    # Set DEV=False, otherwise all the releases will be erroneously made public
+    # through the following refresh function, leading to wrong results in
+    # get_release_or_404
+    @override_settings(DEV=False)
     def setUp(self):
         ProductRelease.objects.refresh()
         caches['release-notes'].clear()
@@ -170,6 +174,9 @@ class TestReleaseViews(TestCase):
         with self.assertRaises(Http404):
             views.get_release_or_404('58.0a1', 'Firefox')
         eq_(views.get_release_or_404('58.0a1', 'Firefox', True).is_public, False)
+        with self.assertRaises(Http404):
+            views.get_release_or_404('58.0a1', 'Firefox for Android')
+        eq_(views.get_release_or_404('58.0a1', 'Firefox for Android', True).is_public, False)
 
     def test_no_equivalent_release_url(self):
         """

--- a/bedrock/releasenotes/views.py
+++ b/bedrock/releasenotes/views.py
@@ -89,7 +89,7 @@ def release_notes(request, version, product='Firefox'):
         raise Http404
 
     # Show a "coming soon" page for any unpublished Firefox releases
-    include_drafts = product == 'Firefox'
+    include_drafts = product in ['Firefox', 'Firefox for Android']
 
     try:
         release = get_release_or_404(version, product, include_drafts)


### PR DESCRIPTION
## Description

* Show a "coming soon" message for draft/unpublished Firefox for Android notes, just like desktop notes.
* Fix a bug in the test added in #5408: `DEV=False` was missing.

## Issue / Bugzilla link

[Bug 1445648 - Unpublished Android release notes get a 404 message on production instead of the coming soon message](https://bugzilla.mozilla.org/show_bug.cgi?id=1445648)

## Testing

Already tested in #5408, so I think no additional tests are required.