### PR TITLE
[fix bug 1447269] Headings should not be smaller than base font size on small screens

### DIFF
--- a/media/css/pebbles/includes/mixins/_typography.scss
+++ b/media/css/pebbles/includes/mixins/_typography.scss
@@ -96,11 +96,7 @@
 }
 
 @mixin font-size-level4 {
-    @include font-size(16px);
-
-    @media #{$mq-tablet} {
-        @include font-size(18px);
-    }
+    @include font-size(18px);
 
     @media #{$mq-desktop} {
         @include font-size(24px);
@@ -108,11 +104,7 @@
 }
 
 @mixin font-size-level5 {
-    @include font-size(14px);
-
-    @media #{$mq-tablet} {
-        @include font-size(16px);
-    }
+    @include font-size(16px);
 
     @media #{$mq-desktop} {
         @include font-size(18px);
@@ -120,11 +112,7 @@
 }
 
 @mixin font-size-level6 {
-    @include font-size(14px);
-
-    @media #{$mq-tablet} {
-        @include font-size(16px);
-    }
+    @include font-size(16px);
 }
 
 @mixin font-size-small {


### PR DESCRIPTION
## Description
- Updates our `font-size-level` mixins in Pebbles, so that headings never become smaller than our base font size for body copy (something I have to frequently fight against).
- I decided against sneaking this into the homepage redesign PR, since it touches other pages.

## Issue / Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1447269

## Testing
- This touches a lot of pages, but it only really makes a couple of pixels difference to certain bits of copy. So should hopefully be a fairly safe change.