### PR TITLE
Bug 1445070: Addendum to the Manifesto

### DIFF
--- a/bedrock/mozorg/templates/mozorg/about/manifesto.html
+++ b/bedrock/mozorg/templates/mozorg/about/manifesto.html
@@ -14,7 +14,13 @@
 
 {% block page_title %}{{ _('The Mozilla Manifesto') }}{% endblock %}
 {% block page_title_suffix %}{% endblock %}
-{% block page_desc %}{{ _('These are the principles that guide our mission to promote openness, innovation & opportunity on the Web.') }}{% endblock %}
+
+{% if l10n_has_tag('addendum_032018') %}
+  {% set page_description = _('These are the principles that guide our mission to promote openness, innovation & opportunity on the web.') %}
+{% else %}
+  {% set page_description = _('These are the principles that guide our mission to promote openness, innovation & opportunity on the Web.') %}
+{% endif %}
+{% block page_desc %}{{ page_description }}{% endblock %}
 
 {% block body_id %}manifesto-landing{% endblock %}
 {% block body_attrs %}{{ super() }} data-global-nav-current-link="about-us"{% endblock %}
@@ -40,227 +46,333 @@
   {% endif %}
 {% endblock %}
 
-{% set twitter_share_shorten_url = {
-  '01': '1o4BGY1',
-  '02': '1o4Cmwi',
-  '03': '1pHvACg',
-  '04': '1olpxj7',
-  '05': 'V8O1SM',
-  '06': 'TArZa0',
-  '07': '1mRltrl',
-  '08': 'TMI1Ox',
-  '09': '1xcEisc',
-  '10': '1z5HIPk',
-  'custom': '1iRxjCi',
-} %}
-
-{% macro twitter_link(content_id, text, hashtag = '#mozmanifesto') -%}
-  {{ twitter_share_url('http://mzl.la/' + twitter_share_shorten_url[content_id], text|truncate(102, False, '…') + ' ' + hashtag) }}
+{% macro twitter_link(content_id, text) -%}
+  {{ twitter_share_url('https://mzl.la/manifesto', text|truncate(102, False, '…')) }}
 {%- endmacro %}
 
+{% if l10n_has_tag('addendum_032018') %}
+  {% set principle_text_01 = _('The internet is an integral part of modern life—a key component in education, communication, collaboration, business, entertainment and society as a whole.') %}
+  {% set principle_text_02 = _('The internet is a global public resource that must remain open and accessible.') %}
+  {% set principle_text_03 = _('The internet must enrich the lives of individual human beings.') %}
+  {% set principle_text_04 = _('Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.') %}
+  {% set principle_text_05 = _('Individuals must have the ability to shape the internet and their own experiences on it.') %}
+  {% set principle_text_06 = _('The effectiveness of the internet as a public resource depends upon interoperability (protocols, data formats, content), innovation and decentralized participation worldwide.') %}
+  {% set principle_text_07 = _('Free and open source software promotes the development of the internet as a public resource.') %}
+  {% set principle_text_08 = _('Transparent community-based processes promote participation, accountability and trust.') %}
+  {% set principle_text_09 = _('Commercial involvement in the development of the internet brings many benefits; a balance between commercial profit and public benefit is critical.') %}
+  {% set principle_text_10 = _('Magnifying the public benefit aspects of the internet is an important goal, worthy of time, attention and commitment.') %}
+{% else %}
+  {% set principle_text_01 = _('The Internet is an integral part of modern life—a key component in education, communication, collaboration, business, entertainment and society as a whole.') %}
+  {% set principle_text_02 = _('The Internet is a global public resource that must remain open and accessible.') %}
+  {% set principle_text_03 = _('The Internet must enrich the lives of individual human beings.') %}
+  {% set principle_text_04 = _('Individuals’ security and privacy on the Internet are fundamental and must not be treated as optional.') %}
+  {% set principle_text_05 = _('Individuals must have the ability to shape the Internet and their own experiences on it.') %}
+  {% set principle_text_06 = _('The effectiveness of the Internet as a public resource depends upon interoperability (protocols, data formats, content), innovation and decentralized participation worldwide.') %}
+  {% set principle_text_07 = _('Free and open source software promotes the development of the Internet as a public resource.') %}
+  {% set principle_text_08 = _('Transparent community-based processes promote participation, accountability and trust.') %}
+  {% set principle_text_09 = _('Commercial involvement in the development of the Internet brings many benefits; a balance between commercial profit and public benefit is critical.') %}
+  {% set principle_text_10 = _('Magnifying the public benefit aspects of the Internet is an important goal, worthy of time, attention and commitment.') %}
+{% endif %}
+
+{% if l10n_has_tag('addendum_032018') %}
+  {% set principle_number_01 = _('Principle 1') %}
+  {% set principle_number_02 = _('Principle 2') %}
+  {% set principle_number_03 = _('Principle 3') %}
+  {% set principle_number_04 = _('Principle 4') %}
+  {% set principle_number_05 = _('Principle 5') %}
+  {% set principle_number_06 = _('Principle 6') %}
+  {% set principle_number_07 = _('Principle 7') %}
+  {% set principle_number_08 = _('Principle 8') %}
+  {% set principle_number_09 = _('Principle 9') %}
+  {% set principle_number_10 = _('Principle 10') %}
+{% else %}
+  {% set principle_number_01 = _('01') %}
+  {% set principle_number_02 = _('02') %}
+  {% set principle_number_03 = _('03') %}
+  {% set principle_number_04 = _('04') %}
+  {% set principle_number_05 = _('05') %}
+  {% set principle_number_06 = _('06') %}
+  {% set principle_number_07 = _('07') %}
+  {% set principle_number_08 = _('08') %}
+  {% set principle_number_09 = _('09') %}
+  {% set principle_number_10 = _('10') %}
+{% endif %}
+
 {% block content %}
-
-<main role="main">
-  <article role="article" itemscope itemtype="http://schema.org/Article">
-    <header id="main-feature">
-      <div class="content">
-        <h1 itemprop="name"><span class="highlight">{{ self.page_title() }}</span></h1>
-      </div>
+<main role="main" itemscope itemtype="http://schema.org/Article">
+  <article role="article" itemprop="articleBody">
+  {% if switch('manifesto-addendum') and l10n_has_tag('addendum_032018') %}
+    <header>
+      <h1 itemprop="name" class="manifesto-title manifesto-title-addendum">{{ self.page_title() }}</h1>
     </header>
-
-    <div id="main-content">
-      <div id="main-content-inner">
-        <section id="sec-principles" itemprop="articleBody">
-          <header class="content">
-            <h2>{{ _('<strong>Our 10</strong> Principles') }}</h2>
-            <p itemprop="description">{{ self.page_desc() }}</p>
-            <!--
-            <aside class="share-wrapper">
-              {% set share_urls = { 'twitter': 'http://mzl.la/1b858Kd', 'googleplus': 'http://mzl.la/1b858Kd', 'facebook': 'http://mzl.la/1b858Kd' } -%}
-              {% set share_text = _('The Mozilla Manifesto') %}
-              {{ share_cta(_('Share'), share_urls, share_text, 'share-mozilla-manifesto', 'sky mini') }}
-            </aside>
-          -->
-          </header>
-          <div id="principles">
-            <section class="principle" id="principle-01" data-ga-quote-number="1" data-ga-quote="modern life">
-              <header class="principle-head">
-                <h3><a href="#principle-01" class="principle-number">{{ _('01') }}</a> {{ _('The Internet is an integral part of modern life—a key component in education, communication, collaboration, business, entertainment and society as a whole.') }}</h3>
-              </header>
-              <section class="principle-more">
-                <h4>{{ _('Learn more') }}</h4>
-                <ul class="resources">
-                  <li><a href="http://openbadges.org/">{{ _('Use Open Badges to share your skills and interests') }}</a></li>
-                  <li><a href="http://mozillascience.org/">{{ _('Explore how the Web impacts science') }}</a></li>
-                  <li><a href="https://opennews.org/getinvolved/">{{ _('Learn about open source code in journalism') }}</a></li>
-                </ul>
-              </section>
-              <footer class="principle-foot">
-                <p class="share"><a class="tweet" href="{{ twitter_link('01', _('The Internet is an integral part of modern life—a key component in education, communication, collaboration, business, entertainment and society as a whole.')) }}">{{ _('Tweet this') }}</a></p>
-              </footer>
-            </section>
-            <section class="principle" id="principle-02" data-ga-quote-number="2" data-ga-quote="public resource">
-              <header class="principle-head">
-                <h3><a href="#principle-02" class="principle-number">{{ _('02') }}</a> {{ _('The Internet is a global public resource that must remain open and accessible.') }}</h3>
-              </header>
-              <section class="principle-more">
-                <h4>{{ _('Learn more') }}</h4>
-                <ul class="resources">
-                  <li><a href="https://blog.mozilla.org/netpolicy/">{{ _('Read about open Internet policy initiatives and developments') }}</a></li>
-                  <li><a href="https://teach.mozilla.org/web-literacy/participate/open-practice/">{{ _('Explore how to help keep the Web open') }}</a></li>
-                </ul>
-              </section>
-              <footer class="principle-foot">
-                <p class="share"><a class="tweet" href="{{ twitter_link('02', _('The Internet is a global public resource that must remain open and accessible.')) }}">{{ _('Tweet this') }}</a></p>
-              </footer>
-            </section>
-            <section class="principle" id="principle-03" data-ga-quote-number="3" data-ga-quote="enrich lives">
-              <header class="principle-head">
-                <h3><a href="#principle-03" class="principle-number">{{ _('03') }}</a> {{ _('The Internet must enrich the lives of individual human beings.') }}</h3>
-              </header>
-              <section class="principle-more">
-                <h4>{{ _('Learn more') }}</h4>
-                <ul class="resources">
-                  <li><a href="https://blog.mozilla.org/blog/2014/04/09/firefox-os-and-medic-mobile-use-the-web-to-connect-the-world-to-healthcare/">{{ _('See how the Web can connect the world to healthcare') }}</a></li>
-                  <li><a href="https://teach.mozilla.org/web-literacy/read/navigate/">{{ _('Explore how the Web works') }}</a></li>
-                </ul>
-              </section>
-              <footer class="principle-foot">
-                <p class="share"><a class="tweet" href="{{ twitter_link('03', _('The Internet must enrich the lives of individual human beings.')) }}">{{ _('Tweet this') }}</a></p>
-              </footer>
-            </section>
-            <section class="principle" id="principle-04" data-ga-quote-number="4" data-ga-quote="individual security">
-              <header class="principle-head">
-                <h3><a href="#principle-04" class="principle-number">{{ _('04') }}</a> {{ _('Individuals’ security and privacy on the Internet are fundamental and must not be treated as optional.') }}</h3>
-              </header>
-              <section class="principle-more">
-                <h4>{{ _('Learn more') }}</h4>
-                <ul class="resources">
-                  <li><a href="{{ url('teach.smarton.index') }}">{{ _('See how Mozilla works to put your privacy first') }}</a></li>
-                  <li><a href="https://blog.mozilla.org/netpolicy/">{{ _('Read about developments in privacy and data safety') }}</a></li>
-                  <li><a href="https://teach.mozilla.org/web-literacy/participate/protect/">{{ _('Learn more about how to protect yourself online') }}</a></li>
-                </ul>
-              </section>
-              <footer class="principle-foot">
-                <p class="share"><a class="tweet" href="{{ twitter_link('04', _('Individuals’ security and privacy on the Internet are fundamental and must not be treated as optional.')) }}">{{ _('Tweet this') }}</a></p>
-              </footer>
-            </section>
-            <section class="principle" id="principle-05" data-ga-quote-number="5" data-ga-quote="shape internet">
-              <header class="principle-head">
-                <h3><a href="#principle-05" class="principle-number">{{ _('05') }}</a> {{ _('Individuals must have the ability to shape the Internet and their own experiences on it.') }}</h3>
-              </header>
-              <section class="principle-more">
-                <h4>{{ _('Learn more') }}</h4>
-                <ul class="resources">
-                  <li><a href="https://teach.mozilla.org/tools/">{{ _('Use these free tools to teach the Web') }}</a></li>
-                  <li><a href="https://teach.mozilla.org/web-literacy/write/compose/">{{ _('Learn about creating and curating content for the Web') }}</a></li>
-                </ul>
-              </section>
-              <footer class="principle-foot">
-                <p class="share"><a class="tweet" href="{{ twitter_link('05', _('Individuals must have the ability to shape the Internet and their own experiences on it.')) }}">{{ _('Tweet this') }}</a></p>
-              </footer>
-            </section>
-            <section class="principle" id="principle-06" data-ga-quote-number="6" data-ga-quote="internet effectiveness">
-              <header class="principle-head">
-                <h3><a href="#principle-06" class="principle-number">{{ _('06') }}</a> {{ _('The effectiveness of the Internet as a public resource depends upon interoperability (protocols, data formats, content), innovation and decentralized participation worldwide.') }}</h3>
-              </header>
-              <section class="principle-more">
-                <h4>{{ _('Learn more') }}</h4>
-                <ul class="resources">
-                  <li><a href="http://ascendproject.org/">{{ _('Add new voices to open source technology') }}</a></li>
-                  <li><a href="https://support.mozilla.org/kb/how-do-i-turn-do-not-track-feature">{{ _('Set your Do Not Track preference') }}</a></li>
-                  <li><a href="https://teach.mozilla.org/web-literacy/read/navigate/">{{ _('Understand the Web ecosystem') }}</a></li>
-                </ul>
-              </section>
-              <footer class="principle-foot">
-                <p class="share"><a class="tweet" href="{{ twitter_link('06', _('The effectiveness of the Internet as a public resource depends upon interoperability (protocols, data formats, content), innovation and decentralized participation worldwide.')) }}">{{ _('Tweet this') }}</a></p>
-              </footer>
-            </section>
-            <section class="principle" id="principle-07" data-ga-quote-number="7" data-ga-quote="open source">
-              <header class="principle-head">
-                <h3><a href="#principle-07" class="principle-number">{{ _('07') }}</a> {{ _('Free and open source software promotes the development of the Internet as a public resource.') }}</h3>
-              </header>
-              <section class="principle-more">
-                <h4>{{ _('Learn more') }}</h4>
-                <ul class="resources">
-                  <li><a href="https://teach.mozilla.org/web-literacy/participate/open-practice/">{{ _('Explore how open practices keep the Web accessible') }}</a></li>
-                  <li><a href="https://teach.mozilla.org/web-literacy/write/remix/">{{ _('Learn how to remix content to create something new') }}</a></li>
-                  <li><a href="https://teach.mozilla.org/web-literacy/write/code/">{{ _('Learn how to maximize the interactive potential of the Web') }}</a></li>
-                </ul>
-              </section>
-              <footer class="principle-foot">
-                <p class="share"><a class="tweet" href="{{ twitter_link('07', _('Free and open source software promotes the development of the Internet as a public resource.')) }}">{{ _('Tweet this') }}</a></p>
-              </footer>
-            </section>
-            <section class="principle" id="principle-08" data-ga-quote-number="8" data-ga-quote="transparent process">
-              <header class="principle-head">
-                <h3><a href="#principle-08" class="principle-number">{{ _('08') }}</a> {{ _('Transparent community-based processes promote participation, accountability and trust.') }}</h3>
-              </header>
-              <section class="principle-more">
-                <h4>{{ _('Learn more') }}</h4>
-                <ul class="resources">
-                  <li><a href="https://groups.google.com/forum/#!forum/mozilla.governance">{{ _('Participate in our governance forum') }}</a></li>
-
-                  {% if l10n_has_tag('join-us') %}
-                    <li><a href="{{ url('mozorg.contribute.index') }}">{{ _('Join us as a volunteer') }}</a></li>
-                    <li><a href="{{ url('mozorg.contribute.studentambassadors.landing') }}">{{ _('Join us as a student ambassador') }}</a></li>
-                  {% else %}
-                    <li>{{ _('Join us as a <a href="%(volunteer)s">volunteer</a> or <a href="%(ambassador)s">student ambassador</a>')|format(volunteer=url('mozorg.contribute.index'), ambassador=url('mozorg.contribute.studentambassadors.landing')) }}</li>
-                  {% endif %}
-
-                  <li><a href="https://teach.mozilla.org/web-literacy/skills/">{{ _('Learn how to collaborate online') }}</a></li>
-                </ul>
-              </section>
-              <footer class="principle-foot">
-                <p class="share"><a class="tweet" href="{{ twitter_link('08', _('Transparent community-based processes promote participation, accountability and trust.')) }}">{{ _('Tweet this') }}</a></p>
-              </footer>
-            </section>
-            <section class="principle" id="principle-09" data-ga-quote-number="9" data-ga-quote="commercial involvement">
-              <header class="principle-head">
-                <h3><a href="#principle-09" class="principle-number">{{ _('09') }}</a> {{ _('Commercial involvement in the development of the Internet brings many benefits; a balance between commercial profit and public benefit is critical.') }}</h3>
-              </header>
-              <section class="principle-more">
-                <h4>{{ _('Learn more') }}</h4>
-                <ul class="resources">
-                  <li><a href="https://addons.mozilla.org/firefox/addon/lightbeam/">{{ _('Visualize who you interact with on the Web with Lightbeam') }}</a></li>
-                  <li><a href="https://teach.mozilla.org/web-literacy/participate/share/">{{ _('Learn about creating Web resources with others') }}</a></li>
-                </ul>
-              </section>
-              <footer class="principle-foot">
-                <p class="share"><a class="tweet" href="{{ twitter_link('09', _('Commercial involvement in the development of the Internet brings many benefits; a balance between commercial profit and public benefit is critical.')) }}">{{ _('Tweet this') }}</a></p>
-              </footer>
-            </section>
-            <section class="principle" id="principle-10" data-ga-quote-number="10" data-ga-quote="magnify benefit">
-              <header class="principle-head">
-                <h3><a href="#principle-10" class="principle-number">{{ _('10') }}</a> {{ _('Magnifying the public benefit aspects of the Internet is an important goal, worthy of time, attention and commitment.') }}</h3>
-              </header>
-              <section class="principle-more">
-                <h4>{{ _('Learn more') }}</h4>
-                <ul class="resources">
-                  <li><a href="https://teach.mozilla.org/events/">{{ _('Host or join a Maker Party') }}</a></li>
-                  <li><a href="https://teach.mozilla.org/web-literacy/skills/">{{ _('Learn how to build online collaboration skills') }}</a></li>
-                </ul>
-              </section>
-              <footer class="principle-footco">
-                <p class="share"><a class="tweet" href="{{ twitter_link('10', _('Magnifying the public benefit aspects of the Internet is an important goal, worthy of time, attention and commitment.')) }}">{{ _('Tweet this') }}</a></p>
-              </footer>
-            </section>
-          </div>
-          <footer class="content">
-            <p><a class="manifesto-details" href="{{ url('mozorg.about.manifesto-details') }}">{{ _('Read the entire manifesto') }}</a></p>
-          </footer>
-        </section>
-        <aside class="section section-newsletter" id="newsletter-subscribe">
-          <div class="content">
-            {% if LANG.startswith('en-') %}
-                {{ email_newsletter_form(newsletters='mozilla-foundation', title=_('Love the Web?'), subtitle=_('Get the Mozilla newsletter and help us keep it open and free.'), button_class='button-hollow button-light', spinner_color='#fff') }}
-              {% else %}
-                {{ email_newsletter_form(button_class='button-hollow button-light', spinner_color='#fff') }}
-              {% endif %}
-          </div>
-        </aside>
+    <section>
+      <h2 class="addendum-subtitle">{{ _('Pledge for a Healthy Internet') }}</h2>
+      <p class="addendum-paragraph">{{ _('The open, global internet is the most powerful communication and collaboration resource we have ever seen. It embodies some of our deepest hopes for human progress. It enables new opportunities for learning, building a sense of shared humanity, and solving the pressing problems facing people everywhere.') }}</p>
+      <p class="addendum-paragraph">{{ _('Over the last decade we have seen this promise fulfilled in many ways. We have also seen the power of the internet used to magnify divisiveness, incite violence, promote hatred, and intentionally manipulate fact and reality. We have learned that we should more explicitly set out our aspirations for the human experience of the internet. We do so now.') }}</p>
+      <ol class="addendum-list">
+        <li>{{ _('We are committed to an internet that includes all the peoples of the earth — where a person’s demographic characteristics do not determine their online access, opportunities, or quality of experience.') }}</li>
+        <li>{{ _('We are committed to an internet that promotes civil discourse, human dignity, and individual expression.') }}</li>
+        <li>{{ _('We are committed to an internet that elevates critical thinking, reasoned argument, shared knowledge, and verifiable facts. ') }}</li>
+        <li>{{ _('We are committed to an internet that catalyzes collaboration among diverse communities working together for the common good. ') }}</li>
+      </ol>
+      <div class="share-addendum">
+        <h2 class="share-head">{{ _('Show Your Support') }}</h2>
+        <p class="share-paragraph">{{ _('An internet with these qualities will not come to life on its own. Individuals and organizations must embed these aspirations into internet technology and into the human experience with the internet. The Mozilla Manifesto and Addendum represent Mozilla’s commitment to advancing these aspirations. We aim to work together with people and organizations everywhere who share these goals to make the internet an even better place for everyone.') }}</p>
+        <p class="share-button-outter"><a class="button button-manifesto js-manifesto-share" href="{{ twitter_link('custom', _('I support the vision of a better, healthier internet from @mozilla, will you join me?')) }}">{{  _('Share on Twitter') }}</a></p>
       </div>
-    </div>
+    </section>
+  {% endif %}
+    <section id="sec-principles">
+      <header class="content principles-header">
+        {% if not switch('manifesto-addendum') or not l10n_has_tag('addendum_032018') %}
+          <h1 itemprop="name" class="manifesto-title">{{ self.page_title() }}</h1>
+        {% endif %}
+        <h2 class="principles-head">{{ _('<strong>Our 10</strong> Principles') }}</h2>
+      </header>
+      <div id="principles">
+        <section class="principle" id="principle-01" data-ga-quote-number="1" data-ga-quote="modern life">
+          <header class="principle-header">
+            <h3><span class="principle-number">{{ principle_number_01 }}</span> {{principle_text_01 }}</h3>
+          </header>
+          <section class="principle-more">
+            <h4>{{ _('Learn more') }}</h4>
+            <ul class="resources">
+              <li><a href="http://openbadges.org/">{{ _('Use Open Badges to share your skills and interests') }}</a></li>
+              <li>
+                <a href="http://mozillascience.org/">
+                  {% if l10n_has_tag('addendum_032018') %}
+                    {{ _('Explore how the web impacts science') }}
+                  {% else %}
+                    {{ _('Explore how the Web impacts science') }}
+                  {% endif %}
+                </a>
+              </li>
+              <li><a href="https://opennews.org/getinvolved/">{{ _('Learn about open source code in journalism') }}</a></li>
+            </ul>
+          </section>
+        </section>
+        <section class="principle" id="principle-02" data-ga-quote-number="2" data-ga-quote="public resource">
+          <header class="principle-header">
+            <h3><span class="principle-number">{{ principle_number_02 }}</span> {{ principle_text_02 }}</h3>
+          </header>
+          <section class="principle-more">
+            <h4>{{ _('Learn more') }}</h4>
+            <ul class="resources">
+              <li>
+                <a href="https://blog.mozilla.org/netpolicy/">
+                  {% if l10n_has_tag('addendum_032018') %}
+                    {{ _('Read about open internet policy initiatives and developments') }}
+                  {% else %}
+                    {{ _('Read about open Internet policy initiatives and developments') }}
+                  {% endif %}
+                </a>
+              </li>
+              <li>
+                <a href="https://teach.mozilla.org/web-literacy/participate/open-practice/">
+                  {% if l10n_has_tag('addendum_032018') %}
+                    {{ _('Explore how to help keep the web open') }}
+                  {% else %}
+                    {{ _('Explore how to help keep the Web open') }}
+                  {% endif %}
+                </a>
+              </li>
+            </ul>
+          </section>
+        </section>
+        <section class="principle" id="principle-03" data-ga-quote-number="3" data-ga-quote="enrich lives">
+          <header class="principle-header">
+            <h3><span class="principle-number">{{ principle_number_03 }}</span> {{ principle_text_03 }}</h3>
+          </header>
+          <section class="principle-more">
+            <h4>{{ _('Learn more') }}</h4>
+            <ul class="resources">
+              <li>
+                <a href="https://blog.mozilla.org/blog/2014/04/09/firefox-os-and-medic-mobile-use-the-web-to-connect-the-world-to-healthcare/">
+                  {% if l10n_has_tag('addendum_032018') %}
+                    {{ _('See how the web can connect the world to healthcare') }}
+                  {% else %}
+                    {{ _('See how the Web can connect the world to healthcare') }}
+                  {% endif %}
+                </a>
+              </li>
+              <li>
+                <a href="https://teach.mozilla.org/web-literacy/read/navigate/">
+                  {% if l10n_has_tag('addendum_032018') %}
+                    {{ _('Explore how the web works') }}
+                  {% else %}
+                    {{ _('Explore how the Web works') }}
+                  {% endif %}
+                </a>
+              </li>
+            </ul>
+          </section>
+        </section>
+        <section class="principle" id="principle-04" data-ga-quote-number="4" data-ga-quote="individual security">
+          <header class="principle-header">
+            <h3><span class="principle-number">{{ principle_number_04 }}</span> {{ principle_text_04 }}</h3>
+          </header>
+          <section class="principle-more">
+            <h4>{{ _('Learn more') }}</h4>
+            <ul class="resources">
+              <li><a href="{{ url('teach.smarton.index') }}">{{ _('See how Mozilla works to put your privacy first') }}</a></li>
+              <li><a href="https://blog.mozilla.org/netpolicy/">{{ _('Read about developments in privacy and data safety') }}</a></li>
+              <li><a href="https://teach.mozilla.org/web-literacy/participate/protect/">{{ _('Learn more about how to protect yourself online') }}</a></li>
+            </ul>
+          </section>
+        </section>
+        <section class="principle" id="principle-05" data-ga-quote-number="5" data-ga-quote="shape internet">
+          <header class="principle-header">
+            <h3><span class="principle-number">{{ principle_number_05 }}</span> {{ principle_text_05 }}</h3>
+          </header>
+          <section class="principle-more">
+            <h4>{{ _('Learn more') }}</h4>
+            <ul class="resources">
+              <li>
+                <a href="https://teach.mozilla.org/tools/">
+                  {% if l10n_has_tag('addendum_032018') %}
+                    {{ _('Use these free tools to teach the web') }}
+                  {% else %}
+                    {{ _('Use these free tools to teach the Web') }}
+                  {% endif %}
+                </a>
+              </li>
+              <li>
+                <a href="https://teach.mozilla.org/web-literacy/write/compose/">
+                  {% if l10n_has_tag('addendum_032018') %}
+                    {{ _('Learn about creating and curating content for the web') }}
+                  {% else %}
+                    {{ _('Learn about creating and curating content for the Web') }}
+                  {% endif %}
+                </a>
+              </li>
+            </ul>
+          </section>
+        </section>
+        <section class="principle" id="principle-06" data-ga-quote-number="6" data-ga-quote="internet effectiveness">
+          <header class="principle-header">
+            <h3><span class="principle-number">{{ principle_number_06 }}</span> {{ principle_text_06 }}</h3>
+          </header>
+          <section class="principle-more">
+            <h4>{{ _('Learn more') }}</h4>
+            <ul class="resources">
+              <li><a href="http://ascendproject.org/">{{ _('Add new voices to open source technology') }}</a></li>
+              <li><a href="https://support.mozilla.org/kb/how-do-i-turn-do-not-track-feature">{{ _('Set your Do Not Track preference') }}</a></li>
+              <li>
+                <a href="https://teach.mozilla.org/web-literacy/read/navigate/">
+                  {% if l10n_has_tag('addendum_032018') %}
+                    {{ _('Understand the web ecosystem') }}
+                  {% else %}
+                    {{ _('Understand the Web ecosystem') }}
+                  {% endif %}
+                </a>
+              </li>
+            </ul>
+          </section>
+        </section>
+        <section class="principle" id="principle-07" data-ga-quote-number="7" data-ga-quote="open source">
+          <header class="principle-header">
+            <h3><span class="principle-number">{{ principle_number_07 }}</span> {{ principle_text_07 }}</h3>
+          </header>
+          <section class="principle-more">
+            <h4>{{ _('Learn more') }}</h4>
+            <ul class="resources">
+              <li>
+                <a href="https://teach.mozilla.org/web-literacy/participate/open-practice/">
+                  {% if l10n_has_tag('addendum_032018') %}
+                    {{ _('Explore how open practices keep the web accessible') }}
+                  {% else %}
+                    {{ _('Explore how open practices keep the Web accessible') }}
+                  {% endif %}
+                </a>
+              </li>
+              <li><a href="https://teach.mozilla.org/web-literacy/write/remix/">{{ _('Learn how to remix content to create something new') }}</a></li>
+              <li>
+                <a href="https://teach.mozilla.org/web-literacy/write/code/">
+                  {% if l10n_has_tag('addendum_032018') %}
+                    {{ _('Learn how to maximize the interactive potential of the web') }}
+                  {% else %}
+                    {{ _('Learn how to maximize the interactive potential of the Web') }}
+                  {% endif %}
+                </a>
+              </li>
+            </ul>
+          </section>
+        </section>
+        <section class="principle" id="principle-08" data-ga-quote-number="8" data-ga-quote="transparent process">
+          <header class="principle-header">
+            <h3><span class="principle-number">{{ principle_number_08 }}</span> {{ principle_text_08 }}</h3>
+          </header>
+          <section class="principle-more">
+            <h4>{{ _('Learn more') }}</h4>
+            <ul class="resources">
+              <li><a href="https://groups.google.com/forum/#!forum/mozilla.governance">{{ _('Participate in our governance forum') }}</a></li>
+              {% if l10n_has_tag('join-us') %}
+                <li><a href="{{ url('mozorg.contribute.index') }}">{{ _('Join us as a volunteer') }}</a></li>
+                <li><a href="{{ url('mozorg.contribute.studentambassadors.landing') }}">{{ _('Join us as a student ambassador') }}</a></li>
+              {% else %}
+                <li>{{ _('Join us as a <a href="%(volunteer)s">volunteer</a> or <a href="%(ambassador)s">student ambassador</a>')|format(volunteer=url('mozorg.contribute.index'), ambassador=url('mozorg.contribute.studentambassadors.landing')) }}</li>
+              {% endif %}
+              <li><a href="https://teach.mozilla.org/web-literacy/skills/">{{ _('Learn how to collaborate online') }}</a></li>
+            </ul>
+          </section>
+        </section>
+        <section class="principle" id="principle-09" data-ga-quote-number="9" data-ga-quote="commercial involvement">
+          <header class="principle-header">
+            <h3><span class="principle-number">{{ principle_number_09 }}</span> {{ principle_text_09 }}</h3>
+          </header>
+          <section class="principle-more">
+            <h4>{{ _('Learn more') }}</h4>
+            <ul class="resources">
+              <li>
+                <a href="https://addons.mozilla.org/firefox/addon/lightbeam/">
+                  {% if l10n_has_tag('addendum_032018') %}
+                    {{ _('Visualize who you interact with on the web with Lightbeam') }}
+                  {% else %}
+                    {{ _('Visualize who you interact with on the Web with Lightbeam') }}
+                  {% endif %}
+                </a>
+              </li>
+              <li>
+                <a href="https://teach.mozilla.org/web-literacy/participate/share/">
+                  {% if l10n_has_tag('addendum_032018') %}
+                    {{ _('Learn about creating web resources with others') }}
+                  {% else %}
+                    {{ _('Learn about creating Web resources with others') }}
+                  {% endif %}
+                </a>
+              </li>
+            </ul>
+          </section>
+        </section>
+        <section class="principle" id="principle-10" data-ga-quote-number="10" data-ga-quote="magnify benefit">
+          <header class="principle-header">
+            <h3><span class="principle-number">{{ principle_number_10 }}</span> {{ principle_text_10 }}</h3>
+          </header>
+          <section class="principle-more">
+            <h4>{{ _('Learn more') }}</h4>
+            <ul class="resources">
+              <li><a href="https://teach.mozilla.org/events/">{{ _('Host or join a Maker Party') }}</a></li>
+              <li><a href="https://teach.mozilla.org/web-literacy/skills/">{{ _('Learn how to build online collaboration skills') }}</a></li>
+            </ul>
+          </section>
+        </section>
+      </div>
+      <footer class="content principles-foot">
+        {% if l10n_has_tag('addendum_032018') %}
+          <p><a class="button button-manifesto js-manifesto-share" href="{{ twitter_link('custom', _('I support the vision of a better, healthier internet from @mozilla, will you join me?')) }}">{{  _('Share on Twitter') }}</a></p>
+        {% endif %}
+        <p><a class="manifesto-details" href="{{ url('mozorg.about.manifesto-details') }}">{{ _('Read the entire manifesto') }}</a></p>
+      </footer>
+    </section>
+    <aside class="section section-newsletter" id="newsletter-subscribe">
+      <div class="content">
+        {% if LANG.startswith('en-') %}
+            {{ email_newsletter_form(newsletters='mozilla-foundation', title=_('Love the web?'), subtitle=_('Get the Mozilla newsletter and help us keep it open and free.'), button_class='button-hollow button-light', spinner_color='#fff') }}
+          {% else %}
+            {{ email_newsletter_form(button_class='button-hollow button-light', spinner_color='#fff') }}
+          {% endif %}
+      </div>
+    </aside>
   </article>
 </main>
 

--- a/media/css/mozorg/manifesto.scss
+++ b/media/css/mozorg/manifesto.scss
@@ -3,48 +3,294 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 @import '../pebbles/includes/lib';
-@import '../pebbles/components/highlight';
 @import '../pebbles/components/newsletter';
 @import '../hubs/sections';
-@import '../hubs/buttons';
 @import '../hubs/masthead';
 
-#main-feature {
+$addendum-blue: #16AABF;
+
+/* needs to be at the top so other classes can over-ride the mixin defaults */
+.manifesto-title-addendum,
+.addendum-subtitle,
+.addendum-paragraph,
+.share-head,
+.share-paragraph {
+    padding: 0 $mobile-content-padding;
+    max-width: 700px;
+
     @media #{$mq-tablet} {
-        padding-top: $tablet-content-padding - $gutter-width;
+        padding: 0 $tablet-content-padding;
+    }
+
+    @media #{$mq-desktop} {
+        @include span(8);
+        float: none; // needs to over-ride span()
+        margin: 0 auto; // needs to over-ride span()
+        padding: 0;
     }
 
     @media #{$mq-desktop-wide} {
-        padding-top: $desktop-content-padding - $gutter-width;
+        @include span(6);
+        float: none; // needs to over-ride span()
+        margin: 0 auto; // needs to over-ride span()
     }
+}
+
+
+/*
+Manifesto
+====================================================================== */
+
+.manifesto-title {
+    @include open-sans;
+    @include font-size-level4;
+    margin-bottom: 15px;
+}
+
+.manifesto-details {
+    @include font-size-level5;
+    @include open-sans;
+    color: $color-text-primary;
+    display: inline-block;
+    font-weight: bold;
+    text-decoration: none;
+
+    &:after {
+        @include background-size(cover);
+        background-image: url('/media/img/mozorg/about/manifesto/cta-arrow.svg');
+        background-position: 0 0;
+        content: '';
+        display: inline-block;
+        height: 12px;
+        margin-left: 10px;
+        position: relative;
+        right: 0;
+        transition: right 100ms ease-in-out;
+        width: 14px;
+
+        html[dir="rtl"] & {
+            margin-left: 0;
+            margin-right: 10px;
+            transform: rotate(180deg);
+        }
+    }
+
+    &:link,
+    &:visited {
+        color: $color-text-primary;
+
+        &:hover,
+        &:focus,
+        &:active {
+            color: $color-text-primary;
+            text-decoration: underline;
+
+            &:after {
+                right: -4px;
+
+                html[dir="rtl"] & {
+                    right: 4px;
+                }
+            }
+        }
+    }
+
+    @media #{$mq-tablet} {
+        margin-bottom: $tablet-content-padding;
+    }
+
+    @media #{$mq-desktop-wide} {
+        margin-bottom: $desktop-content-padding;
+    }
+}
+
+/*
+Addendum
+====================================================================== */
+
+.manifesto-title-addendum {
+    padding-top: $mobile-content-padding;
+
+    @media #{$mq-tablet} {
+        padding-top: $tablet-content-padding;
+    }
+
+    @media #{$mq-desktop-wide} {
+        padding-top: $desktop-content-padding;
+    }
+}
+
+.addendum-subtitle {
+    @include font-size-huge;
+    line-height: 1;
+    margin-bottom: 0.6em;
+}
+
+.addendum-list {
+    @include clearfix;
+    @include font-size-level3;
+    margin: 2em ($mobile-content-padding * 2) 0;
+
+    @media #{$mq-tablet} {
+        margin-bottom: 2em;
+        margin-left: ($tablet-content-padding * 2);
+        margin-right: ($tablet-content-padding * 2);
+    }
+
+    @media #{$mq-desktop-wide} {
+        margin-left: auto;
+        margin-right: auto;
+        max-width: $width-max-content;
+    }
+
+    li {
+        padding-bottom: 60px;
+        padding-top: 40px;
+        position: relative;
+
+        @media #{$mq-desktop-wide} {
+            @include border-box;
+            float: left;
+            line-height: 1.25;
+            margin-left: $desktop-content-padding;
+            margin-right: $desktop-content-padding;
+            width: calc(50% - #{$desktop-content-padding * 1.5});
+
+            html[dir="rtl"] {
+                float: right;
+            }
+        }
+
+        &:nth-child(odd) {
+            clear: left;
+            margin-right: 0;
+        }
+
+        &:before {
+            background-color: $color-text-primary;
+            content: '';
+            display: block;
+            height: 7px;
+            left: 0;
+            position: absolute;
+            top: 0;
+            width: 80px;
+
+            html[dir="rtl"] & {
+                left: auto;
+                right: 0;
+            }
+        }
+    }
+}
+
+.addendum-paragraph {
+    @include font-size-level5;
+    @include open-sans;
+    margin-bottom: 1.25em;
+}
+
+
+/*
+Share section
+====================================================================== */
+
+.share-addendum {
+    @include open-sans;
+    background-color: #b9e5ec;
+    margin-bottom: $mobile-content-padding * 2;
+    padding: ($mobile-content-padding * 2) 0;
+
+    @media #{$mq-tablet} {
+        margin-bottom: 20px;
+        padding: $tablet-content-padding 0;
+    }
+
+    @media #{$mq-desktop} {
+        margin-bottom: 55px;
+        padding: $desktop-content-padding 0;
+    }
+}
+
+.share-button-outter {
+    margin: $mobile-content-padding 0 0 0;
+    text-align: center;
+
+    @media #{$mq-tablet} {
+        margin-top: 60px;
+    }
+}
+
+.share-head {
+    @include font-size-level4;
+    margin-bottom: 15px;
+}
+
+a.button.button-manifesto {
+    background-color: $addendum-blue;
+    border-color: $addendum-blue;
+    padding-left: 25px + 25px + 15px; // left padding + icon width + right padding
+    position: relative;
+
+    html[dir="rtl"] & {
+        padding-left: 40px;
+        padding-right: 25px + 25px + 15px; // left padding + icon width + right padding
+    }
+
+    &:hover,
+    &:focus,
+    &:active {
+        background-color: darken(#149bae, 2%);
+        border-color: darken(#149bae, 2%);
+    }
+
+    &:before {
+        background-image: url('/media/img/logos/social/social-icon-sprite.svg');
+        background-position: 0 0;
+        background-size: cover;
+        content: '';
+        display: inline-block;
+        height: 20px;
+        left: 25px;
+        position: absolute;
+        top: 1.1em;
+        width: 25px;
+
+        html[dir="rtl"] & {
+            left: auto;
+            right: 25px;
+        }
+    }
+}
+
+
+/*
+Principles
+====================================================================== */
+
+.principles-header {
+    padding-top: $mobile-content-padding;
+
+    @media #{$mq-tablet} {
+        margin-bottom: 1.5em;
+        padding-top: $tablet-content-padding;
+    }
+
+    @media #{$mq-desktop-wide} {
+        padding-top: $desktop-content-padding;
+    }
+}
+
+.principles-foot {
+    text-align: center;
 }
 
 .principle {
     @include border-box;
+    @include clearfix;
     margin: 0 auto;
     max-width: $width-max-content;
     padding: $mobile-content-padding;
-}
-
-.principle-number {
-    color: #999;
-    display: block;
-    text-decoration: none;
-
-    &:visited {
-        color: #999;
-    }
-}
-
-.principle-head h3 {
-    @include font-size-level2;
-    font-weight: normal;
-}
-
-.principle-more {
-    @include open-sans;
-    @include font-size-small;
-    margin-top: $mobile-content-padding;
 }
 
 @media #{$mq-tablet} {
@@ -59,40 +305,63 @@
     }
 }
 
-@supports (display: grid) {
-    @media #{$mq-tablet} {
-        .principle {
-            display: grid;
-            grid-column-gap: 60px;
-            grid-template:
-                "text more"
-                "link more"
-                "link more";
-            grid-template-columns: 2fr 1fr;
-        }
+.principle-number {
+    @include font-size(20px);
+    @include open-sans;
+    display: block;
+    font-weight: bold;
+    margin-bottom: 0.8em;
+    text-decoration: none;
+}
 
-        .principle-head {
-            grid-area: text;
-        }
+.principle-header {
+    h3 {
+        @include font-size-level2;
+        font-weight: normal;
 
-        .principle-more {
-            grid-area: more;
-            margin-top: 4.1em;
-        }
-
-        .principle-foot {
-            grid-area: link;
+        @media #{$mq-desktop} {
+            @include font-size(44px);
         }
     }
 
-    @media #{mq-desktop} {
-        .principle {
-            grid-column-gap: 85px;
+    @media #{$mq-tablet} {
+        @include span(7);
+        padding: 0;
+
+        html[dir="rtl"] & {
+            float: right;
         }
     }
 }
 
 .principle-more {
+    @include open-sans;
+    @include font-size-level6;
+    margin-top: $mobile-content-padding;
+
+    @media #{$mq-tablet} {
+        @include span(5);
+        margin-top: 0;
+        padding: 0;
+        padding-left: $tablet-content-padding;
+
+        html[dir="rtl"] & {
+            float: right;
+            padding-left: 0;
+            padding-right: $tablet-content-padding;
+        }
+    }
+
+    @media #{$mq-desktop} {
+        padding-left: $desktop-content-padding;
+    }
+
+    h4 {
+        font-size: inherit;
+        line-height: 1.6;
+        margin-bottom: 1em;
+    }
+
     ul {
         margin-bottom: 0;
     }
@@ -100,34 +369,4 @@
     li {
         margin-bottom: 0.5em;
     }
-
-    img {
-        display: block;
-    }
-
-    blockquote {
-        p {
-            margin-bottom: 0.25em;
-        }
-
-        &:before {
-            @include font-size-level4;
-            content: "“";
-            display: block;
-            float: left;
-            font-family: Candara, "Trebuchet MS", sans-serif;
-            font-weight: bold;
-            line-height: 1;
-            margin: 0 0 0 -0.8em;
-        }
-    }
-}
-
-.share {
-    margin-bottom: 0;
-}
-
-.manifesto-details {
-    @include font-size-level3;
-    @include trailing-double-caret;
 }

--- a/media/css/pebbles/base/elements/_links.scss
+++ b/media/css/pebbles/base/elements/_links.scss
@@ -15,7 +15,7 @@ a {
     &:visited:hover,
     &:visited:focus,
     &:visited:active {
-        color: darken($color-link, 10%);
+        color: $color-link-hover;
         text-decoration: underline;
     }
 

--- a/media/css/pebbles/includes/_variables.scss
+++ b/media/css/pebbles/includes/_variables.scss
@@ -48,6 +48,7 @@ $color-quantum-blue: #0a84ff;
 // Link colors
 $color-link-blue:       #00a7e0;
 $color-link:            $color-link-blue; // standard links (blue)
+$color-link-hover:      darken($color-link, 10%);
 $color-link-yellow:     #ffbb38;
 
 // Button colors

--- a/media/img/mozorg/about/manifesto/cta-arrow.svg
+++ b/media/img/mozorg/about/manifesto/cta-arrow.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg id="cta-arrow" width="14px" height="12px" viewBox="0 0 14 12" xmlns="http://www.w3.org/2000/svg">
+  <path d="M0 7.3h9l-2.8 2.9L8 12l6-6-6-6-1.8 1.8L9 4.7H0z"/>
+</svg>

--- a/media/js/mozorg/manifesto.js
+++ b/media/js/mozorg/manifesto.js
@@ -6,13 +6,7 @@ $(function() {
     'use strict';
 
     // Open Twitter in a sub window
-    var openTwitterSubwin = function (section, url) {
-
-        window.dataLayer.push({
-            'event': 'manifesto-quote-share',
-            'quote': $('#modal section').data('ga-quote')
-        });
-
+    var openTwitterSubwin = function (url) {
         var width = 550;
         var height = 420;
         var options = {
@@ -27,36 +21,18 @@ $(function() {
         };
 
         window.open(url, 'twitter_share', $.param(options).replace(/&/g, ',')).focus();
+
+        window.dataLayer.push({
+            'event': 'manifesto-share'
+        });
     };
 
-    // Set up link handler
-    $(document).on('click', '.principle a', function (event) {
-        var $this = $(this);
-        var section = $this.parents('.principle').attr('id').match(/\d+/)[0];
-        var href = $this.attr('href');
-        var action;
+    // Set up twitter link handler
+    $(document).on('click', '.js-manifesto-share', function (event) {
+        var href = $(this).attr('href');
 
-        if ($this.hasClass('tweet')) {
-            // Open Twitter in a sub window
-            event.preventDefault();
-            openTwitterSubwin(section, href);
-        } else if ($this.hasClass('principle-number')) {
-            // nothing
-        } else {
-            // Open the link in a new tab
-            $this.attr({
-                'target': '_blank',
-                'rel': 'noopener noreferrer'
-            });
-
-            action = href.match(/youtube/) ? 'video link click'
-                                           : 'link click';
-
-            window.dataLayer.push({
-                'event': 'manifesto-interaction',
-                'browserAction': action,
-                'section': $this.parents('.principle').data('ga-quote')
-            });
-        }
+        // Open Twitter in a sub window
+        event.preventDefault();
+        openTwitterSubwin(href);
     });
 });


### PR DESCRIPTION
## Description

- Added addendum text behind a switch.
- Added supporting CSS.
- Updated tweet button styling and content.

## Issue / Bugzilla link

[Bug 1445070 - Addendum to manifesto](https://bugzilla.mozilla.org/show_bug.cgi?id=1445070)

## Testing

- Addendum is hidden until the switch is activated
  - The page title "The Mozilla Manifesto" is properly positioned with the switch enabled or disabled 
- RTL


