### PR TITLE
[fix bug 1403474] Add back link to quantum privacy pages.

### DIFF
--- a/bedrock/privacy/templates/privacy/base-quantum.html
+++ b/bedrock/privacy/templates/privacy/base-quantum.html
@@ -2,6 +2,7 @@
  # License, v. 2.0. If a copy of the MPL was not distributed with this
  # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
 
+{% add_lang_files "privacy/index" %}
 {% extends "base-pebbles.html" %}
 
 {% block page_title %}
@@ -59,13 +60,17 @@
   </div>
 </main>
 
-{% if footnote %}
 <section class="privacy-footnote">
   <div class="content-girdle">
+  {% if footnote %}
     {{ footnote.div|join|safe }}
+  {% endif %}
+
+    <p>
+      <a href="{{ url('privacy') }}">{{ _('Back to Mozilla Privacy Policy') }}</a>
+    </p>
   </div>
 </section>
-{% endif %}
 </article>
 {% endblock %}
 


### PR DESCRIPTION
## Description

Adds a link back to `/privacy/` on all Quantum-themed privacy pages.

## Issue / Bugzilla link

https://bugzilla.mozilla.org/show_bug.cgi?id=1403474

## Testing

Ensure I did the L10n correctly?
