### PR TITLE
[fix bug 1449558] Include locale specific templates for zh-TW and id in 59.0 /whatsnew

### DIFF
--- a/bedrock/firefox/tests/test_base.py
+++ b/bedrock/firefox/tests/test_base.py
@@ -284,6 +284,24 @@ class TestWhatsNew(TestCase):
         template = render_mock.call_args[0][1]
         eq_(template, ['firefox/whatsnew/index.html'])
 
+    @override_settings(DEV=True)
+    def test_fx_59_0_id_locale_template(self, render_mock):
+        """Should use id locale specific template when updating from older major version"""
+        req = self.rf.get('/firefox/whatsnew/?oldversion=58.0')
+        req.locale = 'id'
+        self.view(req, version='59.0')
+        template = render_mock.call_args[0][1]
+        eq_(template, ['firefox/whatsnew/index.id.html'])
+
+    @override_settings(DEV=True)
+    def test_fx_59_0_zh_TW_locale_template(self, render_mock):
+        """Should use zh-TW locale specific template when updating from older major version"""
+        req = self.rf.get('/firefox/whatsnew/?oldversion=58.0')
+        req.locale = 'zh-TW'
+        self.view(req, version='59.0')
+        template = render_mock.call_args[0][1]
+        eq_(template, ['firefox/whatsnew/index.zh-TW.html'])
+
     # end 59.0 whatsnew tests
 
 

--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -421,7 +421,12 @@ class WhatsnewView(l10n_utils.LangFilesMixin, TemplateView):
         elif channel == 'nightly':
             template = 'firefox/nightly_whatsnew.html'
         elif show_59_whatsnew(version, oldversion):
-            template = 'firefox/whatsnew/whatsnew-fxa.html'
+            if locale == 'id':
+                template = 'firefox/whatsnew/index.id.html'
+            elif locale == 'zh-TW':
+                template = 'firefox/whatsnew/index.zh-TW.html'
+            else:
+                template = 'firefox/whatsnew/whatsnew-fxa.html'
         elif show_57_whatsnew(version, oldversion):
             # locale-specific templates don't seem to work for the default locale
             if locale == 'en-US':


### PR DESCRIPTION
## Description
- Show locale specific templates for `id` and `zh-TW` when updating to `/firefox/59.0/whatsnew/`

## Issue / Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1449558

## Testing
- `/id/firefox/59.0/whatsnew/` and `/zh-TW/firefox/59.0/whatsnew/` should show locale specific templates when `Dev=False`.