### PR TITLE
[fix bug 1449561] Firefox privacy page title

### DIFF
--- a/bedrock/privacy/templates/privacy/base-quantum.html
+++ b/bedrock/privacy/templates/privacy/base-quantum.html
@@ -5,7 +5,7 @@
 {% extends "base-pebbles.html" %}
 
 {% block page_title %}
-  {{ doc.body.section.h2.get_text() }}
+  {{ header.h2|join|safe }}
 {% endblock %}
 
 {% block page_css %}


### PR DESCRIPTION
## Description
- Fixes page titles for Quantum-themed Privacy policy pages.

## Issue / Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1449561

## Testing
- Page title for `/privacy/firefox/` should read "Firefox Privacy Notice - Mozilla"