### PR TITLE
[fix bug 1449743] Firstrun iframe is off center

### DIFF
--- a/media/css/firefox/firstrun/firstrun-quantum.scss
+++ b/media/css/firefox/firstrun/firstrun-quantum.scss
@@ -103,10 +103,13 @@ body {
     padding: 30px 0;
     width: 320px;
 
+    @media #{$mq-medium} {
+        padding: 30px 20px;
+    }
+
     @supports (display: grid) {
         @media #{$mq-medium} {
             margin: 20px 0;
-            width: 360px;
         }
     }
 }


### PR DESCRIPTION
## Description
- Fixes iframe alignment on `/firstrun/`

![screenshot-2018-3-29 chart your own course](https://user-images.githubusercontent.com/400117/38081967-418c8bc4-333d-11e8-9101-330af195a163.png)

## Issue / Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1449743

## Testing
Demo: https://www-demo3.allizom.org/en-US/firefox/59.0/firstrun/