### PR TITLE
[fix bug 1448875] Skip /zh-CN/ home page hreflang

### DIFF
--- a/bedrock/base/templates/includes/canonical-url.html
+++ b/bedrock/base/templates/includes/canonical-url.html
@@ -37,8 +37,11 @@
         <link rel="alternate" hreflang="sv" href="{{ settings.CANONICAL_URL + '/' + code + loop_canonical_path }}" title="Svenska">
         <link rel="alternate" hreflang="sv-SE" href="{{ settings.CANONICAL_URL + '/' + code + loop_canonical_path }}" title="{{ label|safe }}">
         {% elif code == 'zh-CN' -%}
-        <link rel="alternate" hreflang="zh" href="{{ settings.CANONICAL_URL + '/' + code + loop_canonical_path }}" title="中文">
-        <link rel="alternate" hreflang="zh-CN" href="{{ settings.CANONICAL_URL + '/' + code + loop_canonical_path }}" title="{{ label|safe }}">
+          {#- Bug 1448875: /zh-TW/ home page redirects to http://www.firefox.com.cn/ -#}
+          {% if loop_canonical_path != '/' -%}
+          <link rel="alternate" hreflang="zh" href="{{ settings.CANONICAL_URL + '/' + code + loop_canonical_path }}" title="中文">
+          <link rel="alternate" hreflang="zh-CN" href="{{ settings.CANONICAL_URL + '/' + code + loop_canonical_path }}" title="{{ label|safe }}">
+          {% endif -%}
         {% elif code|length != 3 -%}{#- Bug 1364470: Drop ISO 639-2 and -3 locales not supported by Google -#}
         <link rel="alternate" hreflang="{{ code }}" href="{{ settings.CANONICAL_URL + '/' + code + loop_canonical_path }}" title="{{ label|safe }}">
         {% endif -%}


### PR DESCRIPTION
## Description
- Skip `/zh-CN/` hreflang on the home page, as it redirects to `http://www.firefox.com.cn/`

## Issue / Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1448875

## Testing
- Visit the homepage and you should not see either `hreflang="zh-CN"` or `hreflang="zh"` listed as alternate links.
- Visit any other page, such as `/firefox/` and both `hreflang="zh-CN"` or `hreflang="zh"` should be listed.