### PR TITLE
[fix bug 1401728] Omit LANG from canonical URL on /credits/faq/

### DIFF
--- a/bedrock/mozorg/templates/mozorg/credits-faq.html
+++ b/bedrock/mozorg/templates/mozorg/credits-faq.html
@@ -11,6 +11,16 @@
   {% stylesheet 'credits-faq' %}
 {% endblock %}
 
+{# Bug 1401728: /credits/ is a supported non-locale, so we need to omit the LANG from the canonical URL. #}
+{% set canonical_url = settings.CANONICAL_URL + '/credits/faq/' %}
+
+{% block canonical_urls %}
+  <link rel="canonical" href="{{ canonical_url }}">
+  <link rel="alternate" hreflang="x-default" href="{{ canonical_url }}">
+{% endblock %}
+
+{% block page_og_url %}{{ canonical_url }}{% endblock %}
+
 {% block content %}
 
 <article class="container">

--- a/media/css/mozorg/credits-faq.less
+++ b/media/css/mozorg/credits-faq.less
@@ -4,6 +4,10 @@
 
 @import "../sandstone/lib.less";
 
+.moz-global-nav-drawer + #outer-wrapper {
+    padding-top: @baseLine * 2;
+}
+
 .main-column {
     .span(9);
 }


### PR DESCRIPTION
## Description
- Since `/credits/` is a supported non-locale, remove LANG from canonnical URL on `/credits/faq/`.

## Issue / Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1401728

## Testing
- Visit `/credits/faq/` and the canonical URLs should be `https://www.mozilla.org/credits/faq/` and not `https://www.mozilla.org/en-UScredits/faq/`