### PR TITLE
Update tracking on social share links

### DIFF
--- a/bedrock/mozorg/templates/mozorg/about/manifesto.html
+++ b/bedrock/mozorg/templates/mozorg/about/manifesto.html
@@ -118,7 +118,7 @@
       <div class="share-addendum">
         <h2 class="share-head">{{ _('Show Your Support') }}</h2>
         <p class="share-paragraph">{{ _('An internet with these qualities will not come to life on its own. Individuals and organizations must embed these aspirations into internet technology and into the human experience with the internet. The Mozilla Manifesto and Addendum represent Mozilla’s commitment to advancing these aspirations. We aim to work together with people and organizations everywhere who share these goals to make the internet an even better place for everyone.') }}</p>
-        <p class="share-button-outter"><a class="button button-manifesto js-manifesto-share" target="_blank" rel="noopener noreferrer" href="{{ twitter_link('custom', _('I support the vision of a better, healthier internet from @mozilla, will you join me?')) }}">{{  _('Share on Twitter') }}</a></p>
+        <p class="share-button-outter"><a class="button button-manifesto js-manifesto-share" target="_blank" rel="noopener noreferrer" href="{{ twitter_link('custom', _('I support the vision of a better, healthier internet from @mozilla, will you join me?')) }}" data-link-type="social share" data-link-name="Twitter">{{  _('Share on Twitter') }}</a></p>
       </div>
     </section>
   {% endif %}
@@ -359,7 +359,7 @@
       </div>
       <footer class="content principles-foot">
         {% if l10n_has_tag('addendum_032018') %}
-          <p><a class="button button-manifesto js-manifesto-share" target="_blank" rel="noopener noreferrer" href="{{ twitter_link('custom', _('I support the vision of a better, healthier internet from @mozilla, will you join me?')) }}">{{  _('Share on Twitter') }}</a></p>
+          <p><a class="button button-manifesto js-manifesto-share" target="_blank" rel="noopener noreferrer" href="{{ twitter_link('custom', _('I support the vision of a better, healthier internet from @mozilla, will you join me?')) }}" data-link-type="social share" data-link-name="Twitter">{{  _('Share on Twitter') }}</a></p>
         {% endif %}
         <p><a class="manifesto-details" href="{{ url('mozorg.about.manifesto-details') }}">{{ _('Read the entire manifesto') }}</a></p>
       </footer>

--- a/media/js/mozorg/manifesto.js
+++ b/media/js/mozorg/manifesto.js
@@ -21,10 +21,6 @@ $(function() {
         };
 
         window.open(url, 'twitter_share', $.param(options).replace(/&/g, ',')).focus();
-
-        window.dataLayer.push({
-            'event': 'manifesto-share'
-        });
     };
 
     // Set up twitter link handler


### PR DESCRIPTION
## Description
Updating how the social sharing links are tracked to rely on the global configuration and not custom config for this page.

## Issue / Bugzilla link
[Bug 1445070 - Addendum to manifesto](https://bugzilla.mozilla.org/show_bug.cgi?id=1445070#c10)

## Testing
Open in a browser without DNT or TP, open network panel, click link, watch for call to Google. (Might only work on [a demo](https://bedrock-demo-shobson.us-west.moz.works/en-US/about/manifesto/)?)    
 