### PR TITLE
[fix bug 1449758] Use high res logo on FB containers page.

### DIFF
--- a/bedrock/firefox/templates/firefox/facebookcontainer/index.html
+++ b/bedrock/firefox/templates/firefox/facebookcontainer/index.html
@@ -23,7 +23,7 @@
     <div class="content">
 
       <div class="copy">
-        <img class="firefox-logo" src="{{ static('img/logos/firefox/logo-quantum-wordmark-white.png') }}" alt="">
+        {{ high_res_img('logos/firefox/logo-quantum-wordmark-white.png', {'alt': '', 'width': '200', 'height': '75', 'class': 'firefox-logo'}) }}
         <header>
           <h1 class="title" id="main-heading">
             {{ _('Facebook. Well contained. Keep the rest of your life to yourself.') }}


### PR DESCRIPTION
## Description

Just updates the logo to be high res (when applicable).
