### PR TITLE
[bug 1449758] Add a vanity redirect for /facebookcontainer

### DIFF
--- a/bedrock/mozorg/redirects.py
+++ b/bedrock/mozorg/redirects.py
@@ -649,4 +649,7 @@ redirectpatterns = (
     redirect(r'^about/partnerships/?$', 'mozorg.contact.contact-landing'),
     redirect(r'^about/partnerships/contentservices(/.*)?$', 'mozorg.contact.contact-landing'),
     redirect(r'^about/partnerships\.html', 'mozorg.contact.contact-landing'),
+
+    # Vanity url for Facebook Container page, bug 1449758
+    redirect(r'^facebookcontainer/?$', 'firefox.facebookcontainer.index'),
 )


### PR DESCRIPTION
## Description
Marketing has requested a (slightly) shorter vanity URL for the Facebook Container page.

## Issue / Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1449758

## Testing
`/facebookcontainer` should redirect to `/firefox/facebookcontainer`
