### PR TITLE
Fix capitalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Contributing
 ------------
 
 Patches are welcome! Feel free to fork and contribute to this project on
-[github][gh-bedrock]. If you find a problem and wish to report it, please [file
+[GitHub][gh-bedrock]. If you find a problem and wish to report it, please [file
 a bug][bugzilla].
 
 Looking for a good first bug to work on? Take a look at the [wiki page][wiki] for a


### PR DESCRIPTION
## Description
I found a typo in this project's README. The right name is GitHub, not github. So I created a patch to fix that in this project's README.

## Issue / Bugzilla link
None that I know of. Just found this when going through the README for the first time.

## Testing
Check the changes I've made and see if they're grammatically correct.
