### PR TITLE
[fix bug 1451403] Fix funnelcake id propagation.

### DIFF
--- a/bedrock/firefox/firefox_details.py
+++ b/bedrock/firefox/firefox_details.py
@@ -260,7 +260,7 @@ class FirefoxDesktop(_ProductDetails):
             transition_url = self.download_base_url_transition
             if funnelcake_id:
                 # include funnelcake in scene 2 URL
-                transition_url += '&f=%s' % funnelcake_id
+                transition_url += '?f=%s' % funnelcake_id
 
             if locale_in_transition:
                 transition_url = '/%s%s' % (locale, transition_url)

--- a/bedrock/firefox/tests/test_firefox_details.py
+++ b/bedrock/firefox/tests/test_firefox_details.py
@@ -391,7 +391,7 @@ class TestFirefoxDesktop(TestCase):
         url = firefox_desktop.get_download_url('release', '45.0', 'win', 'en-US')
         self.assertEqual(url, scene2)
         url = firefox_desktop.get_download_url('release', '45.0', 'win', 'en-US', funnelcake_id='64')
-        self.assertEqual(url, scene2 + '&f=64')
+        self.assertEqual(url, scene2 + '?f=64')
 
     def test_get_download_url_scene2_with_locale(self):
         scene2 = firefox_desktop.download_base_url_transition
@@ -402,7 +402,7 @@ class TestFirefoxDesktop(TestCase):
         url = firefox_desktop.get_download_url('release', '45.0', 'win', 'fr',
                                                locale_in_transition=True,
                                                funnelcake_id='64')
-        self.assertEqual(url, '/fr' + scene2 + '&f=64')
+        self.assertEqual(url, '/fr' + scene2 + '?f=64')
 
     def get_download_url_ssl(self):
         """


### PR DESCRIPTION
## Description

Fixes funnelcake id propagation/funnelcakes in general.

## Issue / Bugzilla link

https://bugzilla.mozilla.org/show_bug.cgi?id=1451403

## Testing

Prior to checking out this branch, visit `/firefox/new/?f=136`. Notice the download button points to `/firefox/download/thanks/&f=136`. Clicking the button redirects you back to `/firefox/new/` (with no query params).

After checking out this branch, the download button should point to `/firefox/download/thanks/?f=136`. Clicking the button should take you to that same URL.