### PR TITLE
[fix bug 1449758] Add Focus CTA for mobile browsers

### DIFF
--- a/bedrock/firefox/templates/firefox/facebookcontainer/index.html
+++ b/bedrock/firefox/templates/firefox/facebookcontainer/index.html
@@ -2,6 +2,8 @@
  # License, v. 2.0. If a copy of the MPL was not distributed with this
  # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
 
+{% from "macros.html" import google_play_button with context %}
+
 {% extends "firefox/base-pebbles.html" %}
 
 {% block page_title_prefix %}{% endblock %}
@@ -38,6 +40,23 @@
 
           <div class="extension-cta">
             <a href="https://addons.mozilla.org/firefox/addon/facebook-container/">{{ _('Get the Facebook Container Extension') }}</a>
+          </div>
+
+          <div class="mobile-cta">
+            <p>{{ _('The Facebook Container Extension is not available on mobile devices.') }}</p>
+            {# L10n: For German, all instances of the string 'Firefox Focus' must be 'Firefox Klar' (as done on https://www.mozilla.org/de/firefox/focus/) #}
+            <p>{{ _('Try <strong>Firefox Focus</strong>, the privacy browser for Android and iOS.') }}</p>
+
+            <ul class="mobile-download-buttons">
+              <li class="android">
+                {{ google_play_button(alt_href=settings.GOOGLE_PLAY_FIREFOX_FOCUS_LINK, anchor_attributes={'data-link-type': 'download', 'data-download-os': 'Android', 'id': 'playStoreLink'}) }}
+              </li>
+              <li class="ios">
+                <a id="appStoreLink" href="{{ settings.APPLE_APPSTORE_FIREFOX_FOCUS_LINK }}" data-link-type="download" data-download-os="iOS">
+                  <img src="{{ l10n_img('firefox/ios/btn-app-store.svg') }}" alt="{{ _('Download on the App Store') }}" width="152" height="45">
+                </a>
+              </li>
+            </ul>
           </div>
         </div>
       </div>

--- a/media/css/firefox/facebook-container.scss
+++ b/media/css/firefox/facebook-container.scss
@@ -39,11 +39,11 @@ $color-photon-blue: #0099db;
 // Top hero section
 
 .intro {
+    @include open-sans;
     background: #3b5998;
 
     .title {
         @include font-size-level3;
-        @include open-sans;
         line-height: 1.35;
         font-weight: bold;
         color: #fff;
@@ -52,7 +52,6 @@ $color-photon-blue: #0099db;
 
     .tagline {
         @include font-size-level4;
-        @include open-sans;
         color: #fff;
         margin-bottom: 1em;
     }
@@ -77,7 +76,6 @@ $color-photon-blue: #0099db;
         margin-top: 40px;
 
         a {
-            @include open-sans;
             color: #fff;
             font-weight: bold;
         }
@@ -94,6 +92,19 @@ $color-photon-blue: #0099db;
         &:active {
             background-color: darken(#fb5d1c, 5%);
             border-color: darken(#fb5d1c, 7%);
+        }
+    }
+
+    .mobile-cta {
+        background: #fff;
+        border-radius: 6px;
+        border: 2px solid darken(#3b5998, 5%);
+        color: #000;
+        margin-top: 1em;
+        padding: 1em 20px;
+
+        p {
+            @include font-size-level4;
         }
     }
 
@@ -116,7 +127,9 @@ $color-photon-blue: #0099db;
 }
 
 // Hide extension CTA for non-Firefox
-.extension-cta {
+// Hide mobile CTA for non-mobile
+.extension-cta,
+.mobile-cta {
     display: none;
 }
 
@@ -134,6 +147,32 @@ $color-photon-blue: #0099db;
     }
 }
 
+.ios,
+.android {
+    .firefox-cta,
+    .extension-cta,
+    .secondary-download,
+    .tagline-download,
+    .tagline-extension {
+        display: none;
+    }
+
+    .mobile-cta {
+        display: block;
+    }
+}
+
+.mobile-download-buttons {
+    margin: 0;
+
+    .ios & .android {
+        display: none;
+    }
+
+    .android & .ios {
+        display: none;
+    }
+}
 
 .optional-cta {
     margin-top: 40px;


### PR DESCRIPTION
## Description
The extension is only available for desktop Firefox. This adds an alternative CTA for mobile browsers promoting Firefox Focus.

## Issue / Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1449758#c26

## Testing
The mobile tagline and CTA should only be shown when Android or iOS are detected, and the platform-appropriate store badge should appear.
https://bedrock-demo-craigcook.oregon-b.moz.works/firefox/facebookcontainer/
