### PR TITLE
Bug 1451431: Homepage takover

### DIFF
--- a/bedrock/mozorg/templates/mozorg/home/home.html
+++ b/bedrock/mozorg/templates/mozorg/home/home.html
@@ -24,10 +24,8 @@
   {{ _('Did you know? Mozilla — the maker of Firefox — fights to keep the Internet a global public resource, open and accessible to all.') }}
 {% endblock %}
 
-{% set cop = request.GET.get('v', None) %}
-
 {% block body_id %}home{% endblock %}
-{% block body_class %}lang-{{ LANG }} var-{{cop}}{% endblock %}
+{% block body_class %}lang-{{ LANG }}{% endblock %}
 
 {% block extra_meta %}
 <!-- validates bing webmaster tools -->

--- a/bedrock/mozorg/templates/mozorg/home/home.html
+++ b/bedrock/mozorg/templates/mozorg/home/home.html
@@ -24,8 +24,10 @@
   {{ _('Did you know? Mozilla — the maker of Firefox — fights to keep the Internet a global public resource, open and accessible to all.') }}
 {% endblock %}
 
+{% set cop = request.GET.get('v', None) %}
+
 {% block body_id %}home{% endblock %}
-{% block body_class %}lang-{{ LANG }}{% endblock %}
+{% block body_class %}lang-{{ LANG }} var-{{cop}}{% endblock %}
 
 {% block extra_meta %}
 <!-- validates bing webmaster tools -->
@@ -40,6 +42,11 @@
 
 {% block site_header %}
   {% include 'mozorg/home/includes/home-icons-sprite.svg' %}
+
+  {% if switch('statement-04-2018', ['en-US', 'en-GB', 'de', 'fr']) %}
+      {% include 'mozorg/home/includes/statement.html' %}
+  {% endif %}
+
   {% if LANG.startswith('en-') %}
     {% include 'includes/global-nav.html' %}
   {% else %}
@@ -251,4 +258,17 @@
   </aside>
 
 </main>
+{% endblock %}
+
+{% block js %}
+  {% if switch('statement-04-2018', ['en-US', 'en-GB', 'de', 'fr']) %}
+    {% javascript 'home-statement' %}
+  {% endif %}
+{% endblock %}
+
+{% block update_notification %}
+  {# do not show the update banner if the takeover banner is active #}
+  {% if not switch('statement-04-2018', ['en-US', 'en-GB', 'de', 'fr']) %}
+    {{ super() }}
+  {% endif %}
 {% endblock %}

--- a/bedrock/mozorg/templates/mozorg/home/includes/statement.html
+++ b/bedrock/mozorg/templates/mozorg/home/includes/statement.html
@@ -1,0 +1,22 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+
+{% if LANG == 'de' %}
+  {% set head = 'Dafür stehen wir: Für Menschen statt Profit.' %}
+  {% set cta = 'Mehr dazu hier: <a href="http://blog.mozilla.org/press-de/2018/04/09/dafuer-stehen-wir-fuer-menschen-statt-profit" rel="external">Mozilla’s Data Q&amp;A.</a>' %}
+{% elif LANG == 'fr' %}
+  {% set head = 'French TODO' %}
+  {% set cta = 'TODO' %}
+{% else %}
+  {% set head = 'We stand for people over profit.' %}
+  {% set cta = 'Find out more: <a href="https://blog.mozilla.org/blog/2018/04/11/we-stand-for-people-over-profit/?utm_source=www.mozilla.org&utm_medium=referral&utm_campaign=homepage&utm_content=people-over-profit-overlay" rel="external">Mozilla’s Data Q&A</a>.' %}
+{% endif %}
+
+<aside class="promo promo-statement" id="promo-statement">
+  <button type="button" id="promo-close"><span>{{ _('Close') }}</span></button>
+  <div class="content-wrapper">
+      <h1 class="type type-head"><span data-content="{{ head }}">{{ head }}</span></h1>
+      <p class="type type-p">{{ cta|safe }}</p>
+  </div>{#--/.content--#}
+</aside>

--- a/bedrock/mozorg/templates/mozorg/home/includes/statement.html
+++ b/bedrock/mozorg/templates/mozorg/home/includes/statement.html
@@ -10,7 +10,7 @@
   {% set cta = 'TODO' %}
 {% else %}
   {% set head = 'We stand for people over profit.' %}
-  {% set cta = 'Find out more: <a href="https://blog.mozilla.org/blog/2018/04/11/we-stand-for-people-over-profit/?utm_source=www.mozilla.org&utm_medium=referral&utm_campaign=homepage&utm_content=people-over-profit-overlay" rel="external">Mozilla’s Data Q&A</a>.' %}
+  {% set cta = 'Read: <a href="https://blog.mozilla.org/blog/2018/04/11/we-stand-for-people-over-profit/?utm_source=www.mozilla.org&utm_medium=referral&utm_campaign=homepage&utm_content=people-over-profit-overlay" rel="external">Mozilla’s approach to your data</a>.' %}
 {% endif %}
 
 <aside class="promo promo-statement" id="promo-statement">

--- a/bedrock/settings/static_media.py
+++ b/bedrock/settings/static_media.py
@@ -531,6 +531,7 @@ PIPELINE_CSS = {
         'source_filenames': (
             'css/newsletter/moznewsletter-subscribe.less',
             'css/mozorg/home/home.scss',
+            'css/mozorg/home/statement.scss',
         ),
         'output_filename': 'css/home-bundle.css',
     },
@@ -1218,6 +1219,12 @@ PIPELINE_JS = {
             'js/mozorg/home/home.js',
         ),
         'output_filename': 'js/home-bundle.js',
+    },
+    'home-statement': {
+        'source_filenames': (
+            'js/mozorg/home/statement.js',
+        ),
+        'output_filename': 'js/statement-bundle.js',
     },
     'history-slides': {
         'source_filenames': (

--- a/media/css/mozorg/home/statement.scss
+++ b/media/css/mozorg/home/statement.scss
@@ -85,7 +85,7 @@
 }
 
 #promo-close {
-    background: rgba(0, 0, 0, .2) url('/media/img/notification/close.svg') center center no-repeat;
+    background: transparent url('/media/img/notification/close-dark.svg') center center no-repeat;
     background-size: 20px 20px;
     border-radius: 50%;
     border: none;
@@ -100,7 +100,7 @@
 
     &:focus,
     &:hover {
-        background-color: rgba(0, 0, 0, .3);
+        background-color: rgba(0, 0, 0, .2);
         cursor: pointer;
     }
 
@@ -150,7 +150,7 @@ $delay: 0.2s;
     max-width: $paragraph-length + ch;
 
     &:before {
-        animation: highlight-#{$paragraph-length} 0.2s linear #{$delay * 2 + $duration} 1 both;
+        animation: highlight-#{$paragraph-length} 0.2s linear #{$delay * 2 + 1s} 1 both;
     }
 
     &:after {
@@ -207,7 +207,7 @@ $delay: 0.2s;
         }
 
         .type-p {
-            animation: pop 0.5s ease-out #{0.5s + $delay} 1 both;
+            animation: pop 0.2s ease-out #{$delay * 2 + 1s} 1 both;
         }
     }
 }

--- a/media/css/mozorg/home/statement.scss
+++ b/media/css/mozorg/home/statement.scss
@@ -42,7 +42,6 @@
     position: relative;
 }
 
-
 .type-head {
     @include font-size-level3;
     margin: 0 auto 1.25em auto;
@@ -150,7 +149,7 @@ $delay: 0.2s;
     max-width: $paragraph-length + ch;
 
     &:before {
-        animation: highlight-#{$paragraph-length} 0.2s linear #{$delay * 2 + 1s} 1 both;
+        animation: highlight-#{$paragraph-length} 0.2s linear #{$delay * 2 + 1s} 1 both; /* stylelint-disable-line no-unknown-animations */
     }
 
     &:after {
@@ -207,7 +206,7 @@ $delay: 0.2s;
         }
 
         .type-p {
-            animation: pop 0.2s ease-out #{$delay * 2 + 1s} 1 both;
+            animation: pop 0.2s ease-out #{$delay * 2 + 1s} 1 both; /* stylelint-disable-line no-unknown-animations */
         }
     }
 }

--- a/media/css/mozorg/home/statement.scss
+++ b/media/css/mozorg/home/statement.scss
@@ -1,0 +1,221 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+@import '../../pebbles/includes/lib';
+
+#promo-statement {
+    @include border-box;
+    background: #fff;
+    color: #000;
+    padding: 150px 20px;
+    position: relative;
+
+    .content-wrapper {
+        text-align: center;
+    }
+
+    // hide by default if JS is available to avoid flicker
+    // (if visitor previously dismissed)
+    .js & {
+        display: none;
+    }
+
+    &:before {
+        @include background-size(100px, 32px);
+        background: url('/media/img/pebbles/moz-wordmark-dark-reverse.svg') no-repeat;
+        content: '';
+        display: inline-block;
+        height: 32px;
+        left: 20px;
+        position: absolute;
+        top: 20px;
+        width: 100px;
+    }
+}
+
+.type {
+    font-family: Monaco, monospace;
+    font-weight: normal;
+    line-height: 1.2;
+    margin-bottom: 1.25em;
+    position: relative;
+}
+
+
+.type-head {
+    @include font-size-level3;
+    margin: 0 auto 1.25em auto;
+    text-align: center;
+
+    span {
+        @include box-decoration-break(clone);
+        display: inline;
+        padding-left: 4px;
+    }
+}
+
+.type-p {
+    @include font-size-level5;
+    @include border-box;
+    padding: 0 20px;
+    width: 100%;
+}
+
+@supports (width: 1vh) {
+    #promo-statement {
+        min-height: 100vh;
+    }
+
+    .type-head {
+        position: absolute;
+        top: calc(50% - 2em);
+        left: 0;
+        width: 100%;
+    }
+
+    .type-p {
+        position: absolute;
+        bottom: 20px;
+        left: 0;
+        width: 100%;
+    }
+}
+
+#promo-close {
+    background: rgba(0, 0, 0, .2) url('/media/img/notification/close.svg') center center no-repeat;
+    background-size: 20px 20px;
+    border-radius: 50%;
+    border: none;
+    display: none;
+    height: 35px;
+    padding: 6px;
+    position: absolute;
+    right: 15px;
+    top: 15px;
+    transition: background-color 0.2s ease;
+    width: 35px;
+
+    &:focus,
+    &:hover {
+        background-color: rgba(0, 0, 0, .3);
+        cursor: pointer;
+    }
+
+    // hide the 'Close' text
+    span {
+        @include visually-hidden;
+    }
+
+    // only display when JS is available
+    .js & {
+        display: block;
+    }
+}
+
+
+/*
+Animation
+============================================================================= */
+$delay: 0.2s;
+
+@mixin type-effect($paragraph-length) {
+    /* with graditiude to http://lea.verou.me/2012/02/simpler-css-typing-animation-with-the-ch-unit/*/
+    $cursor-speed: $paragraph-length; // characters per second
+    $duration: $paragraph-length / $cursor-speed * 1s;
+    $characters: $paragraph-length;
+
+    @keyframes letters-#{$paragraph-length} {
+        // animation, go from left to right
+        from {
+            left: 0;
+        }
+        to {
+            left: $paragraph-length + ch;
+        }
+    }
+
+    @keyframes highlight-#{$paragraph-length} {
+        // animation, go from left to right
+        from {
+            width: 0;
+        }
+        to {
+            width: $paragraph-length + ch;
+        }
+    }
+
+    max-width: $paragraph-length + ch;
+
+    &:before {
+        animation: highlight-#{$paragraph-length} 0.2s linear #{$delay + $duration} 1 both;
+    }
+
+    &:after {
+        animation: letters-#{$paragraph-length} $duration steps($paragraph-length, end) $delay 1 both;
+    }
+}
+
+@media #{$mq-desktop} {
+    @supports (width: 1ch) {
+        #promo-statement {
+            overflow: hidden;
+        }
+
+        .type-head span {
+            overflow: hidden;
+            padding-left: 0;
+            position: relative;
+            text-align: left;
+            word-break: break-all;
+
+            &:before {
+                background-color: #000;
+                bottom: 0;
+                color: #fff;
+                content: attr(data-content);
+                left: 0;
+                position: absolute;
+                top: 0;
+                width: 0;
+                overflow: hidden;
+                white-space: nowrap;
+            }
+
+            &:after {
+                background-color: #fff;
+                bottom: 0;
+                box-sizing: border-box;
+                content: '';
+                display: block;
+                position: absolute;
+                top: 0;
+                width: 100%;
+                z-index: 1;
+            }
+
+            .lang-en-US &,
+            .lang-en-GB & {
+                @include type-effect(32);
+            }
+
+            .lang-de & {
+                @include type-effect(44);
+            }
+        }
+
+        .type-p {
+            animation: pop 0.5s ease-out #{0.5s + $delay} 1 both;
+        }
+    }
+}
+
+
+@keyframes pop {
+    from {
+        bottom: -5em;
+    }
+    to {
+        bottom: 20px;
+    }
+}

--- a/media/css/mozorg/home/statement.scss
+++ b/media/css/mozorg/home/statement.scss
@@ -50,6 +50,8 @@
 
     span {
         @include box-decoration-break(clone);
+        background-color: #000;
+        color: #fff;
         display: inline;
         padding-left: 4px;
     }
@@ -138,17 +140,17 @@ $delay: 0.2s;
     @keyframes highlight-#{$paragraph-length} {
         // animation, go from left to right
         from {
-            width: 0;
+            width: $paragraph-length + ch;
         }
         to {
-            width: $paragraph-length + ch;
+            width: 0;
         }
     }
 
     max-width: $paragraph-length + ch;
 
     &:before {
-        animation: highlight-#{$paragraph-length} 0.2s linear #{$delay + $duration} 1 both;
+        animation: highlight-#{$paragraph-length} 0.2s linear #{$delay * 2 + $duration} 1 both;
     }
 
     &:after {
@@ -170,9 +172,9 @@ $delay: 0.2s;
             word-break: break-all;
 
             &:before {
-                background-color: #000;
+                background-color: #fff;
                 bottom: 0;
-                color: #fff;
+                color: #000;
                 content: attr(data-content);
                 left: 0;
                 position: absolute;

--- a/media/js/mozorg/home/statement.js
+++ b/media/js/mozorg/home/statement.js
@@ -1,0 +1,53 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+(function($, Mozilla) {
+    'use strict';
+
+    var $promo = $('#promo-statement');
+    var cookieDurationDays = 2;
+    var cookiesOK = typeof Mozilla.Cookies !== 'undefined' && Mozilla.Cookies.enabled();
+    var storageKey = 'statement-04-2018';
+    var wasClosed = false;
+    var evtNamespace = 'promo-statement';
+    var $doc = $(window.document);
+
+    // see if visitor previously dismissed the banner
+    if (cookiesOK) {
+        wasClosed = Mozilla.Cookies.getItem(storageKey);
+    }
+
+    if (!wasClosed) {
+        // show the banner
+        $promo.css('display', 'block');
+
+        // close with escape key
+        $doc.on('keyup.' + evtNamespace, function(e) {
+            if (e.keyCode === 27) {
+                promoClose();
+            }
+        });
+
+        // close with close button
+        $('#promo-close').one('click', function() {
+            promoClose();
+        });
+    }
+
+    function promoClose() {
+        var d;
+
+        // unbind document listeners
+        $doc.off('.' + evtNamespace);
+
+        $promo.remove();
+
+        if (cookiesOK) {
+            d = new Date();
+            d.setTime(d.getTime() + (cookieDurationDays * 24 * 60 * 60 * 1000)); // 2 day expiration
+            Mozilla.Cookies.setItem(storageKey, true, d.toUTCString(), '/');
+        }
+    }
+
+})(window.jQuery, window.Mozilla);


### PR DESCRIPTION
## Waiting for
- [ ] Updated German strings
- [ ] French strings
- [ ] Updated English blog URL
- [ ] Design review

## Description
Similar to our Net Neutrality banner in the fall we're going to take over the homepage to push our privacy message at the same time as Facebook is testifying before congress on use and protection of user data.

## Issue / Bugzilla link
[Bug 1451431 - Add Facebook statement to homepage on Tuesday April 10th](https://bugzilla.mozilla.org/show_bug.cgi?id=1451431)

## Testing
There's several combinations here:
Desktop / not 
en-US, en-GB / de, fr / other 
v=a/control
ch support / not
animation support / not

## l10n
After a discussion with @peiying2 on Slack we decided it was best to handle l10n with some switches in the templates.