### PR TITLE
Test stage on pushes to master for #5561

### DIFF
--- a/jenkins/branches/master.yml
+++ b/jenkins/branches/master.yml
@@ -7,8 +7,8 @@ regions:
   - tokyo
   - frankfurt
 apps:
-  - bedrock-dev
   - bedrock-stage
+  - bedrock-dev
 integration_tests:
   oregon-b:
     - firefox

--- a/jenkins/branches/master.yml
+++ b/jenkins/branches/master.yml
@@ -8,6 +8,7 @@ regions:
   - frankfurt
 apps:
   - bedrock-dev
+  - bedrock-stage
 integration_tests:
   oregon-b:
     - firefox


### PR DESCRIPTION
## Description
I'd like to test the hypothesis that the browser test timeouts could be caused by something specific to when settings.DEV=True by testing the stage environment, where DEV=False, on every push to master instead of only on push to the prod branch. 

## Issue / Bugzilla link

#5561

## Testing

Stage will be tested on push to master
