### PR TITLE
Only change the DB if the Newsletter data has changed

### DIFF
--- a/bedrock/newsletter/management/commands/update_newsletter_data.py
+++ b/bedrock/newsletter/management/commands/update_newsletter_data.py
@@ -17,14 +17,9 @@ class Command(BaseCommand):
         if not newsletters:
             raise CommandError('No data from basket')
 
-        Newsletter.objects.all().delete()
-        count = 0
-        for slug, data in newsletters.iteritems():
-            Newsletter.objects.create(
-                slug=slug,
-                data=data,
-            )
-            count += 1
-
+        count = Newsletter.objects.refresh(newsletters)
         if not options['quiet']:
-            print('Updated %d newsletters' % count)
+            if count:
+                print('Updated %d newsletters' % count)
+            else:
+                print('Nothing to update')

--- a/bedrock/newsletter/models.py
+++ b/bedrock/newsletter/models.py
@@ -3,9 +3,42 @@ from django.db import models
 from django_extensions.db.fields.json import JSONField
 
 
+class NewsletterManager(models.Manager):
+    def serialize(self):
+        data = {}
+        for nl in self.all():
+            data[nl.slug] = nl.data
+        return data
+
+    def refresh(self, new_data):
+        """Update all data in the table from a dict of Newsletter data
+
+        Return None if nothing changed, or number of records otherwise.
+        """
+        curr_data = self.serialize()
+        if new_data == curr_data:
+            return None
+
+        self.all().delete()
+        count = 0
+        for slug, data in new_data.iteritems():
+            self.create(
+                slug=slug,
+                data=data,
+            )
+            count += 1
+
+        return count
+
+
 class Newsletter(models.Model):
     slug = models.SlugField(
         unique=True,
         help_text="The ID for the newsletter that will be used by clients",
     )
     data = JSONField()
+
+    objects = NewsletterManager()
+
+    def __unicode__(self):
+        return self.slug

--- a/bedrock/newsletter/utils.py
+++ b/bedrock/newsletter/utils.py
@@ -8,10 +8,7 @@ def get_newsletters():
     Keys are the internal keys we use to designate newsletters to basket.
     Values are dictionaries with the remaining newsletter information.
     """
-    data = {}
-    for nl in Newsletter.objects.all():
-        data[nl.slug] = nl.data
-    return data
+    return Newsletter.objects.serialize()
 
 
 def get_languages_for_newsletters(newsletters=None):


### PR DESCRIPTION
Checks for a difference before refreshing the data. This prevents the database checksum from changing needlessly every sync.