### PR TITLE
Set better no-cache headers for l10n redirect responses

### DIFF
--- a/bedrock/mozorg/middleware.py
+++ b/bedrock/mozorg/middleware.py
@@ -8,6 +8,7 @@ import time
 
 from django.conf import settings
 from django.core.exceptions import MiddlewareNotUsed
+from django.utils.cache import add_never_cache_headers
 
 from django_statsd.middleware import GraphiteRequestTimingMiddleware
 
@@ -75,6 +76,6 @@ class VaryNoCacheMiddleware(object):
                                        settings.VARY_NOCACHE_EXEMPT_URL_PREFIXES):
                 del response['vary']
                 del response['expires']
-                response['Cache-Control'] = 'max-age=0'
+                add_never_cache_headers(response)
 
         return response


### PR DESCRIPTION
This is not likely to help much, but it can't hurt. It's possible that some cache is not respecting just the 'max-age=0' header and needs the extra bits that the Django never_cache util provieds.