### PR TITLE
[bug 1453144] Facebook Container - fix typo

### DIFF
--- a/bedrock/firefox/templates/firefox/facebookcontainer/index.html
+++ b/bedrock/firefox/templates/firefox/facebookcontainer/index.html
@@ -86,7 +86,7 @@
           <h3>{{ _('Opt out on your terms') }}</h3>
           <p>
           {% trans fbcontainer='https://addons.mozilla.org/firefox/addon/facebook-container/' %}
-            Facebook can track almost all your web activity and tie it to your facebook identity. If that’s too much for you, the <a href="{{ fbcontainer }}">Facebook Container extension</a> isolates your identity into a separate container tab, making it harder for Facebook to track you on the web outside of Facebook.
+            Facebook can track almost all your web activity and tie it to your Facebook identity. If that’s too much for you, the <a href="{{ fbcontainer }}">Facebook Container extension</a> isolates your identity into a separate container tab, making it harder for Facebook to track you on the web outside of Facebook.
           {% endtrans %}
           </p>
         </li>


### PR DESCRIPTION
## Description
“Facebook” is a proper noun and should always be capitalized in English. We need to get this string updated so l10n can begin.

## Issue / Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1453144
