### PR TITLE
[fix bug 1447445] Add lang files to Berlin fxnew variation.

### DIFF
--- a/bedrock/firefox/templates/firefox/new/berlin/base.html
+++ b/bedrock/firefox/templates/firefox/new/berlin/base.html
@@ -2,6 +2,8 @@
  # License, v. 2.0. If a copy of the MPL was not distributed with this
  # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
 
+{% add_lang_files "firefox/new/quantum" %}
+
 {% extends "firefox/base-pebbles.html" %}
 
 {# "noindex" pages should not have the canonical or hreflang tags: bug 1442331 #}

--- a/bedrock/firefox/templates/firefox/new/berlin/scene1.html
+++ b/bedrock/firefox/templates/firefox/new/berlin/scene1.html
@@ -2,6 +2,8 @@
  # License, v. 2.0. If a copy of the MPL was not distributed with this
  # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
 
+{% add_lang_files "firefox/new/quantum" %}
+
 {% extends "firefox/new/berlin/base.html" %}v
 
 {% block primary_download_button %}

--- a/bedrock/firefox/templates/firefox/new/berlin/scene2.html
+++ b/bedrock/firefox/templates/firefox/new/berlin/scene2.html
@@ -2,6 +2,8 @@
  # License, v. 2.0. If a copy of the MPL was not distributed with this
  # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
 
+{% add_lang_files "firefox/new/quantum" %}
+
 {% extends "firefox/new/berlin/base.html" %}
 
 {% block body_class %}berlin-scene2{% endblock %}


### PR DESCRIPTION
## Description

Adds lang files so the template will render for `/de/`.

## Testing

I think this can only be tested on stage/prod.