### PR TITLE
Fix #5581: Switch lang switcher to client-side

### DIFF
--- a/bedrock/base/tests/test_middleware.py
+++ b/bedrock/base/tests/test_middleware.py
@@ -10,8 +10,7 @@ class TestLocaleURLMiddleware(TestCase):
         self.rf = RequestFactory()
         self.middleware = LocaleURLMiddleware()
 
-    @override_settings(DEV_LANGUAGES=('de', 'fr'),
-                       FF_EXEMPT_LANG_PARAM_URLS=())
+    @override_settings(DEV_LANGUAGES=('de', 'fr'))
     def test_redirects_to_correct_language(self):
         """Should redirect to lang prefixed url."""
         path = '/the/dude/'
@@ -20,8 +19,7 @@ class TestLocaleURLMiddleware(TestCase):
         self.assertEqual(resp['Location'], '/de' + path)
 
     @override_settings(DEV_LANGUAGES=('es', 'fr'),
-                       LANGUAGE_CODE='en-US',
-                       FF_EXEMPT_LANG_PARAM_URLS=())
+                       LANGUAGE_CODE='en-US')
     def test_redirects_to_default_language(self):
         """Should redirect to default lang if not in settings."""
         path = '/the/dude/'
@@ -29,26 +27,7 @@ class TestLocaleURLMiddleware(TestCase):
         resp = LocaleURLMiddleware().process_request(req)
         self.assertEqual(resp['Location'], '/en-US' + path)
 
-    @override_settings(DEV_LANGUAGES=('de', 'fr'),
-                       FF_EXEMPT_LANG_PARAM_URLS=('/other/',))
-    def test_redirects_lang_param(self):
-        """Middleware should remove the lang param on redirect."""
-        path = '/fr/the/dude/'
-        req = self.rf.get(path, {'lang': 'de'})
-        resp = LocaleURLMiddleware().process_request(req)
-        self.assertEqual(resp['Location'], '/de/the/dude/')
-
-    @override_settings(DEV_LANGUAGES=('de', 'fr'),
-                       FF_EXEMPT_LANG_PARAM_URLS=('/dude/',))
-    def test_no_redirect_lang_param(self):
-        """Middleware should not redirect when exempt."""
-        path = '/fr/the/dude/'
-        req = self.rf.get(path, {'lang': 'de'})
-        resp = LocaleURLMiddleware().process_request(req)
-        self.assertIs(resp, None)  # no redirect
-
-    @override_settings(DEV_LANGUAGES=('de', 'fr'),
-                       FF_EXEMPT_LANG_PARAM_URLS=())
+    @override_settings(DEV_LANGUAGES=('de', 'fr'))
     def test_redirects_to_correct_language_despite_unicode_errors(self):
         """Should redirect to lang prefixed url, stripping invalid chars."""
         path = '/the/dude/'

--- a/bedrock/base/tests/test_urlresolvers.py
+++ b/bedrock/base/tests/test_urlresolvers.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from django.conf import settings
 from django.conf.urls import patterns, url
 from django.test import TestCase
 from django.test.client import RequestFactory
@@ -7,7 +6,7 @@ from django.test.utils import override_settings
 
 from bedrock.base.urlresolvers import find_supported, reverse, split_path, Prefixer
 from mock import patch, Mock
-from nose.tools import eq_, ok_
+from nose.tools import eq_
 
 
 # split_path tests use a test generator, which cannot be used inside of a
@@ -72,30 +71,6 @@ class TestPrefixer(TestCase):
         request = self.factory.get('/')
         self.assertFalse('lang' in request.GET)
         self.assertFalse(request.META.get('HTTP_ACCEPT_LANGUAGE'))
-        prefixer = Prefixer(request)
-        eq_(prefixer.get_language(), 'en-US')
-
-    @override_settings(LANGUAGE_URL_MAP={'en-us': 'en-US', 'de': 'de'})
-    def test_get_language_valid_lang_param(self):
-        """
-        Should return lang param value if it is in settings.LANGUAGE_URL_MAP
-        """
-        request = self.factory.get('/?lang=de')
-        eq_(request.GET.get('lang'), 'de')
-        ok_('de' in settings.LANGUAGE_URL_MAP)
-        prefixer = Prefixer(request)
-        eq_(prefixer.get_language(), 'de')
-
-    @override_settings(LANGUAGE_CODE='en-US',
-                       LANGUAGE_URL_MAP={'en-us': 'en-US'})
-    def test_get_language_invalid_lang_param(self):
-        """
-        Should return default set by settings.LANGUAGE_CODE if lang
-        param value is not in settings.LANGUAGE_URL_MAP
-        """
-        request = self.factory.get('/?lang=de')
-        ok_('lang' in request.GET)
-        self.assertFalse('de' in settings.LANGUAGE_URL_MAP)
         prefixer = Prefixer(request)
         eq_(prefixer.get_language(), 'en-US')
 

--- a/bedrock/base/urlresolvers.py
+++ b/bedrock/base/urlresolvers.py
@@ -98,16 +98,12 @@ class Prefixer(object):
         user's Accept-Language header to determine which is best. This
         mostly follows the RFCs but read bug 439568 for details.
         """
-        if 'lang' in self.request.GET:
-            lang = self.request.GET['lang'].lower()
-            if lang in FULL_LANGUAGE_MAP:
-                return FULL_LANGUAGE_MAP[lang]
-
-        if self.request.META.get('HTTP_ACCEPT_LANGUAGE'):
-            best = self.get_best_language(
-                self.request.META['HTTP_ACCEPT_LANGUAGE'])
+        accept_lang = self.request.META.get('HTTP_ACCEPT_LANGUAGE')
+        if accept_lang:
+            best = self.get_best_language(accept_lang)
             if best:
                 return best
+
         return settings.LANGUAGE_CODE
 
     def get_best_language(self, accept_lang):

--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -522,8 +522,8 @@ def new(request):
         thanks_url = reverse('firefox.download.thanks')
         query_string = request.META.get('QUERY_STRING', '')
         if query_string:
-            done_url = '?'.join([thanks_url, force_text(query_string, errors='ignore')])
-        return HttpResponsePermanentRedirect(done_url)
+            thanks_url = '?'.join([thanks_url, force_text(query_string, errors='ignore')])
+        return HttpResponsePermanentRedirect(thanks_url)
     # if no/incorrect scene specified, show scene 1
     else:
         if lang_file_is_active('firefox/new/wait-face', locale) and experience == 'waitface':

--- a/media/js/base/mozilla-utils.js
+++ b/media/js/base/mozilla-utils.js
@@ -37,17 +37,24 @@ if (typeof Mozilla === 'undefined') {
         });
     };
 
+    Utils.switchPathLanguage = function(location, newLang) {
+        // get path without locale
+        var urlpath = location.pathname.slice(1).split('/').slice(1).join('/');
+        return '/' + newLang + '/' + urlpath + location.search;
+    };
+
     // language switcher
     Utils.initLangSwitcher = function() {
         var $language = $('#page-language-select');
         var previousLanguage = $language.val();
         $language.on('change', function() {
+            var newLanguage = $language.val();
             window.dataLayer.push({
                 'event': 'change-language',
-                'languageSelected': $language.val(),
+                'languageSelected': newLanguage,
                 'previousLanguage': previousLanguage
             });
-            $('#lang_form').attr('action', window.location.hash || '#').submit();
+            Utils.doRedirect(Utils.switchPathLanguage(window.location, newLanguage));
         });
     };
 

--- a/tests/unit/spec/base/mozilla-utils.js
+++ b/tests/unit/spec/base/mozilla-utils.js
@@ -9,6 +9,34 @@ describe('mozilla-utils.js', function() {
 
     'use strict';
 
+    describe('switchPathLanguage', function () {
+        var location = {};
+
+        it('should return the same URL with a different language prefix', function () {
+            location.pathname = '/en-US/firefox/new/';
+            location.search = '';
+            expect(Mozilla.Utils.switchPathLanguage(location, 'de')).toEqual('/de/firefox/new/');
+
+            location.pathname = '/fr/firefox/';
+            expect(Mozilla.Utils.switchPathLanguage(location, 'zh-TW')).toEqual('/zh-TW/firefox/');
+
+            location.pathname = '/de/';
+            expect(Mozilla.Utils.switchPathLanguage(location, 'fr')).toEqual('/fr/');
+        });
+
+        it('should return the same URL with a different language prefix and include the query string', function () {
+            location.pathname = '/en-US/firefox/new/';
+            location.search = '?dude=abide';
+            expect(Mozilla.Utils.switchPathLanguage(location, 'de')).toEqual('/de/firefox/new/?dude=abide');
+
+            location.pathname = '/fr/firefox/';
+            expect(Mozilla.Utils.switchPathLanguage(location, 'zh-TW')).toEqual('/zh-TW/firefox/?dude=abide');
+
+            location.pathname = '/de/';
+            expect(Mozilla.Utils.switchPathLanguage(location, 'fr')).toEqual('/fr/?dude=abide');
+        });
+    });
+
     describe('initMobileDownloadLinks', function () {
 
         var $link;


### PR DESCRIPTION
This is not yet in a mergable state IMHO, but I would like for people to let me know what they think of the proposal and technique. There must be a better way to parse the current URL, but this does work. Needs tests, but there don't seem to currently be tests for the lang switcher function.