### PR TITLE
Bug 1388914: Redirect /thunderbird to thunderbird.net

### DIFF
--- a/bedrock/redirects/redirects.py
+++ b/bedrock/redirects/redirects.py
@@ -2061,7 +2061,7 @@ redirectpatterns = (
              'https://www.thunderbird.net/thunderbird/{version}/releasenotes/'),
     redirect(r'^thunderbird/(?P<version>[^/]+)/system-requirements/$',
              'https://www.thunderbird.net/thunderbird/{version}/system-requirements/'),
-    redirect(r'^thunderbird/(?P<path>.*)', 'https://www.thunderbird.net/{path}'),
+    redirect(r'^thunderbird/?(?P<path>.*)', 'https://www.thunderbird.net/{path}'),
     redirect('^tinderbox\.html$', 'http://developer.mozilla.org/en/Tinderbox'),
     redirect('^tools\.html$', 'http://developer.mozilla.org/en/Mozilla_Development_Tools'),
     redirect('^university/courses\.html$', 'http://education.mozilla.org'),

--- a/tests/redirects/map_globalconf.py
+++ b/tests/redirects/map_globalconf.py
@@ -239,7 +239,7 @@ URLS = flatten((
     url_test('/en-US/projects/calendar/random/stuff/', 'https://www.thunderbird.net/calendar/'),
 
     # bug 1388914
-    url_test('/thunderbird/', 'https://www.thunderbird.net/'),
+    url_test('/thunderbird{,/}', 'https://www.thunderbird.net/'),
     url_test('/thunderbird/channel/', 'https://www.thunderbird.net/channel/'),
     url_test('/thunderbird/features/', 'https://www.thunderbird.net/features/'),
     url_test('/thunderbird/52.6.0/releasenotes/', 'https://www.thunderbird.net/thunderbird/52.6.0/releasenotes/'),


### PR DESCRIPTION
Catch the case where there is no slash

## Description

Catch the case where there is no trailing slash.

## Issue / Bugzilla link

[Bug 1388914 - Delete thunderbird content](https://bugzilla.mozilla.org/show_bug.cgi?id=1388914)

## Testing

Does it redirect?