### PR TITLE
[fix bug 1451051] /firstrun copy experiment.

### DIFF
--- a/bedrock/firefox/templates/firefox/firstrun/firstrun-quantum-a.html
+++ b/bedrock/firefox/templates/firefox/firstrun/firstrun-quantum-a.html
@@ -1,0 +1,7 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+
+{% add_lang_files "firefox/new/quantum" %}
+
+{% extends "firefox/firstrun/firstrun-quantum.html" %}

--- a/bedrock/firefox/templates/firefox/firstrun/firstrun-quantum-b.html
+++ b/bedrock/firefox/templates/firefox/firstrun/firstrun-quantum-b.html
@@ -1,0 +1,17 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+
+{% add_lang_files "firefox/new/quantum" %}
+
+{% extends "firefox/firstrun/firstrun-quantum.html" %}
+
+{% block main_copy %}
+  <h1>Firefox Account: One login.</h1>
+
+  <ul class="content">
+    <li>Send content instantly between your devices</li>
+    <li>Sync bookmarks, history and more</li>
+    <li>View pages offline and ad-free with Pocket</li>
+  </ul>
+{% endblock %}

--- a/bedrock/firefox/templates/firefox/firstrun/firstrun-quantum-c.html
+++ b/bedrock/firefox/templates/firefox/firstrun/firstrun-quantum-c.html
@@ -1,0 +1,17 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+
+{% add_lang_files "firefox/new/quantum" %}
+
+{% extends "firefox/firstrun/firstrun-quantum.html" %}
+
+{% block main_copy %}
+  <h1>Firefox Account: One login. Epic perks.</h1>
+
+  <ul class="content">
+    <li>Send content instantly between your devices</li>
+    <li>Sync bookmarks, history and more</li>
+    <li>View pages offline and ad-free</li>
+  </ul>
+{% endblock %}

--- a/bedrock/firefox/templates/firefox/firstrun/firstrun-quantum-d.html
+++ b/bedrock/firefox/templates/firefox/firstrun/firstrun-quantum-d.html
@@ -1,0 +1,16 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+
+{% add_lang_files "firefox/new/quantum" %}
+
+{% extends "firefox/firstrun/firstrun-quantum.html" %}
+
+{% block main_copy %}
+  <h1>Firefox Account: One login.</h1>
+
+  <p class="content">
+    Send content instantly between your devices. Sync bookmarks, history and
+    more. View pages offline and ad-free with Pocket.
+  </p>
+{% endblock %}

--- a/bedrock/firefox/templates/firefox/firstrun/firstrun-quantum.html
+++ b/bedrock/firefox/templates/firefox/firstrun/firstrun-quantum.html
@@ -6,6 +6,12 @@
 
 {% extends "firefox/firstrun/base-pebbles.html" %}
 
+{% block experiments %}
+  {% if switch('firstrun-copy-experiment', ['en-US']) %}
+    {% javascript 'experiment_firstrun_copy' %}
+  {% endif %}
+{% endblock %}
+
 {% block body_id %}firstrun-quantum-onboarding{% endblock %}
 
 {% block page_title %}
@@ -23,6 +29,7 @@
   <div id="scene">
     <main class="fxaccounts-container">
       <header id="main-header">
+      {% block main_copy %}
         <h1>
         {% if l10n_has_tag('firstrun_email_only_form') %}
           {{ _('Take Firefox with You') }}
@@ -37,6 +44,7 @@
           {{_('Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.')}}
         {% endif %}
         </p>
+      {% endblock %}
         <a href="{{ url('firefox.features.sync') }}" rel="noopener noreferrer" target="_blank">{{_('Learn more about Firefox Accounts')}}</a>
       </header>
       <div id="fxaccounts-wrapper">

--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -377,6 +377,10 @@ class FirstrunView(l10n_utils.LangFilesMixin, TemplateView):
         experience = self.request.GET.get('xv', None)
         locale = l10n_utils.get_locale(self.request)
 
+        # for copy test
+        # https://bugzilla.mozilla.org/show_bug.cgi?id=1451051
+        variation = self.request.GET.get('v', None)
+
         if detect_channel(version) == 'alpha':
             if show_57_dev_firstrun(version):
                 template = 'firefox/developer/firstrun.html'
@@ -386,7 +390,10 @@ class FirstrunView(l10n_utils.LangFilesMixin, TemplateView):
             if (switch('firefox-facebook-container-funnelcake') and locale == 'en-US' and experience == 'facebook-container'):
                 template = 'firefox/firstrun/facebook-container.html'
             else:
-                template = 'firefox/firstrun/firstrun-quantum.html'
+                if locale == 'en-US' and variation in ['a', 'b', 'c', 'd']:
+                    template = 'firefox/firstrun/firstrun-quantum-{}.html'.format(variation)
+                else:
+                    template = 'firefox/firstrun/firstrun-quantum.html'
         elif show_40_firstrun(version):
             template = 'firefox/firstrun/index.html'
         elif show_38_0_5_firstrun(version):

--- a/bedrock/settings/static_media.py
+++ b/bedrock/settings/static_media.py
@@ -1044,6 +1044,13 @@ PIPELINE_JS = {
         ),
         'output_filename': 'js/firefox_firstrun_quantum-bundle.js',
     },
+    'experiment_firstrun_copy': {
+        'source_filenames': (
+            'js/base/mozilla-traffic-cop.js',
+            'js/firefox/firstrun/experiment-firstrun-copy.js',
+        ),
+        'output_filename': 'js/experiment_firstrun_copy-bundle.js',
+    },
     'firefox_developer': {
         'source_filenames': (
             'js/libs/jquery.waypoints.min.js',

--- a/media/css/firefox/firstrun/firstrun-quantum.scss
+++ b/media/css/firefox/firstrun/firstrun-quantum.scss
@@ -7,7 +7,7 @@
 /* -------------------------------------------------------------------------- */
 // Common elements & variables
 
-$mq-medium: 'screen and (min-width: 790px) and (min-height: 550px)';
+$mq-medium: 'screen and (min-width: 790px)';
 
 @font-face {
     font-display: swap;
@@ -27,33 +27,31 @@ $mq-medium: 'screen and (min-width: 790px) and (min-height: 550px)';
          url('/media/fonts/FiraSans-SemiBold.woff') format('woff');
 }
 
-:root {
-    --animation-curve: linear;
-}
-
 html {
-    height: 100%;
+    min-height: 100vh;
 }
 
 body {
-    background: #003eaa;
-    background: #003eaa url("/media/img/firefox/firstrun/fox-tail-header.png") top -200px center no-repeat;
-    height: 100%;
+    background: url("/media/img/firefox/firstrun/fox-tail-header.png") top -200px center no-repeat,
+                linear-gradient(to bottom, #003eaa 40%, #004ec2 60%, #0060df 80%, #0080ff 90%, #00c7ff 100%) top center no-repeat,
+                #003eaa;
     margin: 0;
-    overflow-y: auto;
-
-    @media #{$mq-medium} {
-        overflow: hidden;
-        background: url("/media/img/firefox/firstrun/fox-tail-header.png") top -200px center no-repeat,
-                    linear-gradient(to bottom, #003eaa 40%, #004ec2 60%, #0060df 80%, #0080ff 90%, #00c7ff 100%) top center no-repeat,
-                    #003eaa;
-    }
+    min-height: 100vh;
 }
 
 * {
     font-family: 'Fira Sans Light', sans-serif;
 }
 
+#outer-wrapper {
+    min-height: 100vh;
+}
+
+#scene {
+    align-items: center;
+    display: flex;
+    min-height: 100vh;
+}
 
 /* -------------------------------------------------------------------------- */
 // Main page content container
@@ -65,6 +63,7 @@ body {
     text-align: center;
 
     @media #{$mq-medium} {
+        align-items: center;
         display: grid;
         grid-column-gap: 20px;
         grid-template-columns: 390px 1fr;
@@ -75,12 +74,6 @@ body {
         @media screen and (min-width: 900px) {
             max-width: (390px * 2) + 60px;
             grid-column-gap: 80px;
-            margin-top: calc((100vh - 540px) / 2);
-        }
-
-        // keep the text near-ish to the top
-        @media screen and (min-height: 900px) {
-            margin-top: 200px;
         }
     }
 }
@@ -148,14 +141,6 @@ body {
     text-align: center;
     padding: 20px;
 
-    @media #{$mq-medium} {
-        text-align: left;
-
-        html[dir="rtl"] & {
-            text-align: right;
-        }
-    }
-
     h1 {
         @include at2x('/media/img/logos/firefox/logo-quantum.png', 90px, 90px);
         @include font-size(38px);
@@ -174,16 +159,17 @@ body {
         }
     }
 
-    p {
-        background: url('/media/img/firefox/firstrun/sync/sync-devices-icons-anim.svg') bottom center no-repeat;
-        padding-bottom: 210px;
+    ul {
+        padding-left: 20px;
     }
 
     .content {
         @include font-size(19px);
+        background: url('/media/img/firefox/firstrun/sync/sync-devices-icons-anim.svg') bottom center no-repeat;
         line-height: 1.5;
         margin: 0 auto 40px;
         max-width: 350px;
+        padding-bottom: 210px;
     }
 
     a {
@@ -191,6 +177,19 @@ body {
         color: #fff;
         display: block;
         font-weight: 400;
+    }
+
+    @media #{$mq-medium} {
+        text-align: left;
+
+        html[dir="rtl"] & {
+            text-align: right;
+
+            ul {
+                padding-left: 0;
+                padding-right: 20px;
+            }
+        }
     }
 }
 

--- a/media/js/firefox/firstrun/experiment-firstrun-copy.js
+++ b/media/js/firefox/firstrun/experiment-firstrun-copy.js
@@ -1,0 +1,19 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+(function(Mozilla) {
+    'use strict';
+
+    var moreland = new Mozilla.TrafficCop({
+        id: 'experiment-fxfirstrun-copy-042018',
+        variations: {
+            'v=a': 2, // control
+            'v=b': 2,
+            'v=c': 2,
+            'v=d': 2
+        }
+    });
+
+    moreland.init();
+})(window.Mozilla);


### PR DESCRIPTION
## Description

Adds a copy experiment for `/firstrun/`. Also updates the CSS a bit in an attempt to keep content vertically centered.

## Issue / Bugzilla link

https://bugzilla.mozilla.org/show_bug.cgi?id=1451051

## Testing

Ensure no layout regressions on the control/default page.

https://www-demo4.allizom.org/en-US/firefox/59.0.2/firstrun/

(Note percentages are bumped to 25% per variation on the demo server for easier testing.)
