### PR TITLE
Fix Bug 1455460: Removed two links to facebook from footer per request from Janis G.

### DIFF
--- a/bedrock/base/templates/includes/site-footer.html
+++ b/bedrock/base/templates/includes/site-footer.html
@@ -25,7 +25,6 @@
           <li>
             <ul class="social-links">
               <li><a class="twitter" href="https://twitter.com/mozilla" data-link-type="footer" data-link-name="Twitter (@mozilla)">{{ _('Twitter') }}<span> (@mozilla)</span></a></li>
-              <li><a class="facebook" href="https://www.facebook.com/mozilla" data-link-type="footer" data-link-name="Facebook (Mozilla)">{{ _('Facebook') }}<span> (Mozilla)</span></a></li>
               <li><a class="instagram" href="https://www.instagram.com/mozilla/" data-link-type="footer" data-link-name="Instagram (@mozilla)">{{ _('Instagram') }}<span> (@mozilla)</span></a></li>
             </ul>
           </li>
@@ -44,7 +43,6 @@
           <li>
             <ul class="social-links">
               <li><a class="twitter" href="{{ firefox_twitter_url() }}" data-link-type="footer" data-link-name="Twitter (@firefox)">{{ _('Twitter') }}<span> (@firefox)</span></a></li>
-              <li><a class="facebook" href="https://www.facebook.com/Firefox" data-link-type="footer" data-link-name="Facebook (Firefox)">{{ _('Facebook') }}<span> (Firefox)</span></a></li>
               <li><a class="youtube" href="https://www.youtube.com/firefoxchannel" data-link-type="footer" data-link-name="YouTube (firefoxchannel)">{{ _('YouTube') }}<span> (firefoxchannel)</span></a></li>
             </ul>
           </li>


### PR DESCRIPTION
## Description
![zuck](https://user-images.githubusercontent.com/198507/39063234-3197ea80-447f-11e8-871a-817b1bf51b8f.jpg)

## Issue / Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1455460

## Testing
The two links to facebook in the footer should be gone with no ill effects to layout.
