### PR TITLE
Fix bug 1299817: Add img tag to set HSTS header for mozilla.org

### DIFF
--- a/bedrock/base/templates/base-pebbles.html
+++ b/bedrock/base/templates/base-pebbles.html
@@ -187,5 +187,9 @@
       <script src="https://pontoon.mozilla.org/pontoon.js"></script>
     {% endif %}
     <!--<![endif]-->
+
+    {# Bug 1299817 #}
+    {# Sets the HSTS header for the root domain #}
+    <img src="https://mozilla.org/set_hsts.gif" class="hidden">
   </body>
 </html>

--- a/bedrock/base/templates/base-resp.html
+++ b/bedrock/base/templates/base-resp.html
@@ -210,5 +210,9 @@
       <script src="https://pontoon.mozilla.org/pontoon.js"></script>
     {% endif %}
     <!--<![endif]-->
+
+    {# Bug 1299817 #}
+    {# Sets the HSTS header for the root domain #}
+    <img src="https://mozilla.org/set_hsts.gif" class="hidden">
   </body>
 </html>

--- a/bedrock/base/templates/base.html
+++ b/bedrock/base/templates/base.html
@@ -183,5 +183,9 @@
       <script src="https://pontoon.mozilla.org/pontoon.js"></script>
     {% endif %}
     <!--<![endif]-->
+
+    {# Bug 1299817 #}
+    {# Sets the HSTS header for the root domain #}
+    <img src="https://mozilla.org/set_hsts.gif" class="hidden">
   </body>
 </html>

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -1332,6 +1332,7 @@ CSP_DEFAULT_SRC = (
 )
 CSP_IMG_SRC = CSP_DEFAULT_SRC + (
     'data:',
+    'mozilla.org',
     '*.optimizely.com',
     'www.googletagmanager.com',
     'www.google-analytics.com',


### PR DESCRIPTION
Bedrock sets HSTS for www.mozilla.org, but only a request from the root domain itself can set it for the root domain. This will set HSTS for all visitors to the site.