### PR TITLE
Bug 1416798 - Update the /zh-CN/ to firefox.com.cn redirect to use ht…

### DIFF
--- a/bedrock/base/templates/includes/canonical-url.html
+++ b/bedrock/base/templates/includes/canonical-url.html
@@ -37,7 +37,7 @@
         <link rel="alternate" hreflang="sv" href="{{ settings.CANONICAL_URL + '/' + code + loop_canonical_path }}" title="Svenska">
         <link rel="alternate" hreflang="sv-SE" href="{{ settings.CANONICAL_URL + '/' + code + loop_canonical_path }}" title="{{ label|safe }}">
         {% elif code == 'zh-CN' -%}
-          {#- Bug 1448875: /zh-TW/ home page redirects to http://www.firefox.com.cn/ -#}
+          {#- Bug 1448875: /zh-CN/ home page redirects to https://www.firefox.com.cn/ -#}
           {% if loop_canonical_path != '/' -%}
           <link rel="alternate" hreflang="zh" href="{{ settings.CANONICAL_URL + '/' + code + loop_canonical_path }}" title="中文">
           <link rel="alternate" hreflang="zh-CN" href="{{ settings.CANONICAL_URL + '/' + code + loop_canonical_path }}" title="{{ label|safe }}">

--- a/bedrock/firefox/templates/firefox/whatsnew/fx57/whatsnew-57.zh-CN.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/fx57/whatsnew-57.zh-CN.html
@@ -27,7 +27,7 @@
 
   <p>
   {% trans firefox=url('firefox') %}
-    今天，我谨代表 Mozilla 全球社区，非常自豪地向您介绍<a href="{{ firefox }}" data-mozillaonline-link="https://new.firefox.com.cn/">崭新的 Firefox</a>。快，只为更好！
+    今天，我谨代表 Mozilla 全球社区，非常自豪地向您介绍<a href="{{ firefox }}" data-mozillaonline-link="https://www.firefox.com.cn/">崭新的 Firefox</a>。快，只为更好！
   {% endtrans %}
   </p>
 

--- a/bedrock/mozorg/redirects.py
+++ b/bedrock/mozorg/redirects.py
@@ -10,8 +10,8 @@ def to_uppercase(url):
 
 
 redirectpatterns = (
-    # bug 755826, 1222348
-    redirect(r'^zh-CN/?$', 'http://www.firefox.com.cn/', locale_prefix=False, query={
+    # bug 755826, 1222348, 1416798
+    redirect(r'^zh-CN/?$', 'https://www.firefox.com.cn/', locale_prefix=False, query={
         'utm_medium': 'referral',
         'utm_source': 'mozilla.org'
     }),

--- a/bedrock/mozorg/templates/mozorg/about/governance/organizations.html
+++ b/bedrock/mozorg/templates/mozorg/about/governance/organizations.html
@@ -30,7 +30,7 @@ The <a href="{{ foundation_url }}">Mozilla Foundation</a> is a California non-pr
 The <a href="{{ foundation_moco }}">Mozilla Corporation</a>, a wholly owned subsidiary of the Mozilla Foundation, works with the community to develop software that advances Mozilla’s principles. This includes the <a href="{{ firefox_url }}">Firefox</a> browser, which is well recognized as a market leader in security, privacy and language localization. These features make the Internet safer and more accessible.
 {% endtrans %}</p>
 
-<p>{{_('<a href="//firefox.com.cn/">Mozilla Online</a> is a separate organization that operates in China and is a wholly owned subsidiary of the Mozilla Corporation.')}}</p>
+<p>{{_('<a href="https://www.firefox.com.cn/">Mozilla Online</a> is a separate organization that operates in China and is a wholly owned subsidiary of the Mozilla Corporation.')}}</p>
 
 <h2>{{_('Community Member Organizations')}}</h2>
 

--- a/tests/redirects/map_globalconf.py
+++ b/tests/redirects/map_globalconf.py
@@ -37,8 +37,8 @@ URLS = flatten((
     url_test('/en-US/firefox//all/', '/en-US/firefox/all/'),
     url_test('/pt-BR/////thunderbird/', '/pt-BR/thunderbird/'),
 
-    # bug 755826, 1222348
-    url_test('/zh-CN/', 'http://www.firefox.com.cn/', query={
+    # bug 755826, 1222348, 1416798
+    url_test('/zh-CN/', 'https://www.firefox.com.cn/', query={
         'utm_medium': 'referral',
         'utm_source': 'mozilla.org'
     }),


### PR DESCRIPTION
…tps.

## Description
With SHA-1 fallback disabled, the https://www.mozilla.org/zh-CN/ => www.firefox.com.cn redirect can be updated to use https.

## Issue / Bugzilla link
https://bugzil.la/1416798