### PR TITLE
[fix bug 1449758] Add Facebook Container video for German

### DIFF
--- a/bedrock/firefox/templates/firefox/facebookcontainer/index.html
+++ b/bedrock/firefox/templates/firefox/facebookcontainer/index.html
@@ -63,6 +63,13 @@
 
       <div class="optional-cta">
         <aside class="fbcontainer-video">
+        {% if LANG == 'de' %}
+          <div class="video-container">
+            <iframe width="640" height="360" src="https://www.youtube-nocookie.com/embed/7yLoRVwuZlc?rel=0&amp;showinfo=0" frameborder="0" allow="encrypted-media" allowfullscreen>
+              <p><a href="https://www.youtube.com/watch?v=7yLoRVwuZlc">{{ _('Watch the video') }}</a></p>
+            </iframe>
+          </div>
+        {% else %}
           <div class="moz-video-container">
             <button class="moz-video-button" type="button" aria-controls="fbcontainer-video">{{ _('Watch the video') }}</button>
             <div class="video-container">
@@ -72,7 +79,8 @@
               </video>
             </div>{#-- /.video-container --#}
           </div>{#-- /.moz-video-container --#}
-        </aside>{#-- /.faster-video --#}
+        {% endif %}
+        </aside>{#-- /.fbcontainer-video --#}
       </div>{#-- /.optional-cta --#}
 
     </div>

--- a/media/css/firefox/facebook-container.scss
+++ b/media/css/firefox/facebook-container.scss
@@ -194,6 +194,7 @@ $color-photon-blue: #0099db;
 .fbcontainer-video {
     margin: 40px auto 0;
     max-width: 645px;
+    width: 100%;
 
     .video-container {
         height: 0;


### PR DESCRIPTION
## Description
Adds a German-language video to display for the DE locale. All other locales fall back to the English video.

The original video is hosted by us but the German video is on youtube, I'm not sure why, it's what I was given.

## Issue / Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1449758#c30

## Testing
- Ensure the German video shows when LANG == 'de'.
- Ensure the English video shows for all other locales.
- Ensure the video resizes correctly at different breakpoints.
- No regressions, please.
