### PR TITLE
Fix Bug 1458389: Added additional portland variants.

### DIFF
--- a/bedrock/firefox/templates/firefox/new/portland/scene1-fast.html
+++ b/bedrock/firefox/templates/firefox/new/portland/scene1-fast.html
@@ -4,7 +4,7 @@
 
 {% extends "firefox/new/portland/base.html" %}
 
-{% block body_class %}portland-fast{% endblock %}
+{% block body_class %}portland-fast {{experience}}{% endblock %}
 
 {% block primary_download_button %}
   {{ download_firefox(alt_copy=_('Download Now'), locale_in_transition=true, dom_id="download-firefox", download_location='primary cta') }}

--- a/bedrock/firefox/templates/firefox/new/portland/scene1-safe.html
+++ b/bedrock/firefox/templates/firefox/new/portland/scene1-safe.html
@@ -4,7 +4,7 @@
 
 {% extends "firefox/new/portland/base.html" %}
 
-{% block body_class %}portland-safe{% endblock %}
+{% block body_class %}portland-safe {{experience}}{% endblock %}
 
 {% block primary_download_button %}
   {{ download_firefox(alt_copy=_('Download Now'), locale_in_transition=true, dom_id="download-firefox", download_location='primary cta') }}

--- a/bedrock/firefox/templates/firefox/new/portland/scene1.html
+++ b/bedrock/firefox/templates/firefox/new/portland/scene1.html
@@ -4,7 +4,7 @@
 
 {% extends "firefox/new/portland/base.html" %}
 
-{% block body_class %}portland{% endblock %}
+{% block body_class %}portland {{experience}}{% endblock %}
 
 {% block primary_download_button %}
   {{ download_firefox(alt_copy=_('Download Now'), locale_in_transition=true, dom_id="download-firefox", download_location='primary cta') }}

--- a/bedrock/firefox/tests/test_views.py
+++ b/bedrock/firefox/tests/test_views.py
@@ -552,6 +552,24 @@ class TestFirefoxNew(TestCase):
         views.new(req)
         render_mock.assert_called_once_with(req, 'firefox/new/portland/scene1-safe.html', ANY)
 
+    def test_portland_scene_1_1(self, render_mock):
+        req = RequestFactory().get('/firefox/new/?xv=forgood')
+        req.locale = 'en-US'
+        views.new(req)
+        render_mock.assert_called_once_with(req, 'firefox/new/portland/scene1.html', ANY)
+
+    def test_portland_scene_1_fast_1(self, render_mock):
+        req = RequestFactory().get('/firefox/new/?xv=fast')
+        req.locale = 'en-US'
+        views.new(req)
+        render_mock.assert_called_once_with(req, 'firefox/new/portland/scene1-fast.html', ANY)
+
+    def test_portland_scene_1_safe_1(self, render_mock):
+        req = RequestFactory().get('/firefox/new/?xv=safe')
+        req.locale = 'en-US'
+        views.new(req)
+        render_mock.assert_called_once_with(req, 'firefox/new/portland/scene1-safe.html', ANY)
+
     def test_portland_scene_2(self, render_mock):
         req = RequestFactory().get('/firefox/download/thanks/?xv=portland')
         req.locale = 'en-US'
@@ -566,6 +584,24 @@ class TestFirefoxNew(TestCase):
 
     def test_portland_scene_2_safe(self, render_mock):
         req = RequestFactory().get('/firefox/download/thanks/?xv=portland-safe')
+        req.locale = 'en-US'
+        views.download_thanks(req)
+        render_mock.assert_called_once_with(req, 'firefox/new/portland/scene2-safe.html')
+
+    def test_portland_scene_2_1(self, render_mock):
+        req = RequestFactory().get('/firefox/download/thanks/?xv=forgood')
+        req.locale = 'en-US'
+        views.download_thanks(req)
+        render_mock.assert_called_once_with(req, 'firefox/new/portland/scene2.html')
+
+    def test_portland_scene_2_fast_1(self, render_mock):
+        req = RequestFactory().get('/firefox/download/thanks/?xv=fast')
+        req.locale = 'en-US'
+        views.download_thanks(req)
+        render_mock.assert_called_once_with(req, 'firefox/new/portland/scene2-fast.html')
+
+    def test_portland_scene_2_safe_1(self, render_mock):
+        req = RequestFactory().get('/firefox/download/thanks/?xv=safe')
         req.locale = 'en-US'
         views.download_thanks(req)
         render_mock.assert_called_once_with(req, 'firefox/new/portland/scene2-safe.html')

--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -505,11 +505,11 @@ def download_thanks(request):
     elif locale == 'de' and experience == 'berlin':
         template = 'firefox/new/berlin/scene2.html'
     elif locale == 'en-US':
-        if experience == 'portland':
+        if experience in ['portland', 'forgood']:
             template = 'firefox/new/portland/scene2.html'
-        elif experience == 'portland-fast':
+        elif experience in ['portland-fast', 'fast']:
             template = 'firefox/new/portland/scene2-fast.html'
-        elif experience == 'portland-safe':
+        elif experience in ['portland-safe', 'safe']:
             template = 'firefox/new/portland/scene2-safe.html'
         else:
             template = 'firefox/new/scene2.html'
@@ -549,11 +549,11 @@ def new(request):
         elif locale == 'de' and experience == 'berlin':
             template = 'firefox/new/berlin/scene1.html'
         elif locale == 'en-US':
-            if experience == 'portland':
+            if experience in ['portland', 'forgood']:
                 template = 'firefox/new/portland/scene1.html'
-            elif experience == 'portland-fast':
+            elif experience in ['portland-fast', 'fast']:
                 template = 'firefox/new/portland/scene1-fast.html'
-            elif experience == 'portland-safe':
+            elif experience in ['portland-safe', 'safe']:
                 template = 'firefox/new/portland/scene1-safe.html'
             else:
                 template = 'firefox/new/scene1.html'
@@ -562,7 +562,7 @@ def new(request):
 
     # no harm done by passing 'v' to template, even when no experiment is running
     # (also makes tests easier to maintain by always sending a context)
-    return l10n_utils.render(request, template, {'v': variant})
+    return l10n_utils.render(request, template, {'experience': experience})
 
 
 def ios_testflight(request):

--- a/media/js/firefox/new/portland-scene1.js
+++ b/media/js/firefox/new/portland-scene1.js
@@ -10,4 +10,8 @@
     $('.portland').find('.os_android .download-link, .os_ios .download-link').attr('href', 'https://app.adjust.com/4mnnhn?campaign=city_portland_2018&adgroup=website_xv_portland&creative=non-profit');
     $('.portland-fast').find('.os_android .download-link, .os_ios .download-link').attr('href', 'https://app.adjust.com/4mnnhn?campaign=city_portland_2018&adgroup=website_xv_portland&creative=fast');
     $('.portland-safe').find('.os_android .download-link, .os_ios .download-link').attr('href', 'https://app.adjust.com/4mnnhn?campaign=city_portland_2018&adgroup=website_xv_portland&creative=private');
+
+    $('.portland.forgood').find('.os_android .download-link, .os_ios .download-link').attr('href', 'https://app.adjust.com/4mnnhn?campaign=national&adgroup=landingpage&creative=xv_forgood');
+    $('.portland-fast.fast').find('.os_android .download-link, .os_ios .download-link').attr('href', 'https://app.adjust.com/4mnnhn?campaign=national&adgroup=landingpage&creative=xv_fast');
+    $('.portland-safe.safe').find('.os_android .download-link, .os_ios .download-link').attr('href', 'https://app.adjust.com/4mnnhn?campaign=national&adgroup=landingpage&creative=xv_safe');
 })(window.jQuery);


### PR DESCRIPTION
## Description
This PR enables the following new URLs to render the 3 portland variations:

https://www.mozilla.org/en-US/firefox/new/?xv=forgood
https://www.mozilla.org/en-US/firefox/new/?xv=safe
https://www.mozilla.org/en-US/firefox/new/?xv=fast

New adjust links were also added for each.

## Issue / Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1458389

## Testing
The 3 urls should all render the same content as their existing _siblings_:
portland=forgood
portland-safe=safe
portland-fast=fast

A few things in this PR to pay attention to.

1. I rarely code these days so ...
2. Because the urls provided by fabio were not great (example "fast") I did my best with the classnames for handling adjust and avoiding any possible conflict. 
3. I am setting a var in context to accomplish the above.. im not 100% sure about the previous usage of context here so take a close look.
4. If we are doing more variations like this we should think about a better implementation. 

