### PR TITLE
Bug 1455199: Fix link on play button

### DIFF
--- a/bedrock/firefox/templates/firefox/whatsnew/index.id.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/index.id.html
@@ -39,8 +39,7 @@
 
           <div class="rocket-code">{{ high_res_img('firefox/whatsnew/rocket/code.gif', {'alt': 'Kode QR', 'width': '222', 'height': '222'}) }}</div>
           <div class="rocket-play">
-            {{ google_play_button(anchor_attributes={
-              'alt_href': 'https://app.adjust.com/xvzex7',
+            {{ google_play_button(alt_href='https://app.adjust.com/xvzex7', anchor_attributes={
               'target': '_blank'
             }, class_name='download-link') }}
           </div>


### PR DESCRIPTION
## Description
Fix link on play store button to use adjust link.

## Issue / Bugzilla link
[[Retention] update /whatsnew mobile CTA version - variation for Indonesia - Rocket](https://bugzilla.mozilla.org/show_bug.cgi?id=1455199)

## Testing
- link on play store button