### PR TITLE
[fix bug 1457024] Fixes for Fx60 WNP:

### DIFF
--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx60.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx60.html
@@ -40,10 +40,12 @@
       <header class="content-header">
         <h2>{{ _('Take Firefox with You') }}</h2>
         <p class="tagline">{{ _('Get your bookmarks, history, passwords and other settings on all your devices.') }}</p>
-        <a href="{{ url('firefox.accounts-features') }}" target="_blank" rel="noopener noreferrer">{{_('Learn more about Firefox Accounts')}}</a>
+        {# firefox.accounts-features is en-US only for now, so other locales need an alternate URL #}
+        {% set learn_more_url = url('firefox.accounts-features') if LANG == 'en-US' else url('firefox.features.sync') %}
+        <a href="{{ learn_more_url }}" target="_blank" rel="noopener noreferrer">{{_('Learn more about Firefox Accounts')}}</a>
       </header>
       <div class="fxaccounts" id="fxa-iframe-config" data-host="{{ settings.FXA_IFRAME_SRC }}" data-mozillaonline-host="{{ settings.FXA_IFRAME_SRC_MOZILLAONLINE }}">
-        <iframe id="fxa" scrolling="no" data-src="{{ settings.FXA_IFRAME_SRC }}?action=email&amp;utm_campaign=fxa-embedded-form&amp;utm_medium=referral&amp;utm_source=whatsnew&amp;utm_content=fx-{{ version }}&amp;entrypoint=whatsnew&amp;service=sync&amp;context=iframe&amp;style=chromeless&amp;haltAfterSignIn=true"></iframe>
+        <iframe id="fxa" scrolling="no" data-src="{{ settings.FXA_IFRAME_SRC }}?action=email&amp;utm_campaign=fxa-embedded-form&amp;utm_medium=referral&amp;utm_source=whatsnew&amp;utm_content=fx-{{ version }}&amp;entrypoint=whatsnew&amp;service=sync&amp;context=fx_firstrun_v2&amp;style=chromeless&amp;haltAfterSignIn=true"></iframe>
       </div>
     </div>{#-- /#fxa-container --#}
 


### PR DESCRIPTION
## Description

1. Update FxA iframe param
2. Use localized link for Fx accounts 'learn more' for non en-US

## Issue / Bugzilla link

https://bugzilla.mozilla.org/show_bug.cgi?id=1457024#c43
https://github.com/mozilla/bedrock/pull/5607#discussion_r186730832

## Testing

1. Ensure iframe still loads correctly.
2. Ensure correct URL is used for `Learn more about Firefox Accounts` link for `en-US` and non `en-US` (e.g. `de`).

https://www-demo4.allizom.org/en-US/firefox/60.0/whatsnew/

Instructions for testing the iframe on demo4 can be found in #5607.
