### PR TITLE
Bug 1444561: Features page is en only, link to sync for others

### DIFF
--- a/bedrock/firefox/templates/firefox/firstrun/firstrun-quantum.html
+++ b/bedrock/firefox/templates/firefox/firstrun/firstrun-quantum.html
@@ -45,7 +45,9 @@
         {% endif %}
         </p>
       {% endblock %}
-        <a href="{{ url('firefox.accounts-features') }}" rel="noopener noreferrer" target="_blank">{{_('Learn more about Firefox Accounts')}}</a>
+        {# firefox.accounts-features is en-US only for now, so other locales need an alternate URL #}
+        {% set learn_more_url = url('firefox.accounts-features') if LANG == 'en-US' else url('firefox.features.sync') %}
+        <a href="{{ learn_more_url }}" target="_blank" rel="noopener noreferrer">{{_('Learn more about Firefox Accounts')}}</a>
       </header>
       <div id="fxaccounts-wrapper">
         <div class="fxaccounts" id="fxa-iframe-config" data-host="{{ settings.FXA_IFRAME_SRC }}" data-mozillaonline-host="{{ settings.FXA_IFRAME_SRC_MOZILLAONLINE }}">

--- a/bedrock/firefox/templates/firefox/firstrun/index.html
+++ b/bedrock/firefox/templates/firefox/firstrun/index.html
@@ -30,7 +30,9 @@
       <div id="left-divider">
         <h1 id="title">{{_('Already using Firefox?')}}</h1>
         <p>{{_('Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.')}}</p>
-        <a href="{{ url('firefox.accounts-features') }}">{{_('Learn more about Firefox Accounts')}}</a>
+        {# firefox.accounts-features is en-US only for now, so other locales need an alternate URL #}
+        {% set learn_more_url = url('firefox.accounts-features') if LANG == 'en-US' else url('firefox.features.sync') %}
+        <a href="{{ learn_more_url }}" target="_blank" rel="noopener noreferrer">{{_('Learn more about Firefox Accounts')}}</a>
       </div>
       <div id="firefox-logo"></div>
       {# Bug 1354710: firstrun pages need to pass funnelcake parameters to FxA #}

--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fxa.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fxa.html
@@ -27,7 +27,9 @@
       <header class="content-header">
         <h2>{{ _('Take Firefox with You') }}</h2>
         <p class="tagline">{{ _('Get your bookmarks, history, passwords and other settings on all your devices.') }}</p>
-        <a href="{{ url('firefox.accounts-features') }}" target="_blank" rel="noopener noreferrer">{{_('Learn more about Firefox Accounts')}}</a>
+        {# firefox.accounts-features is en-US only for now, so other locales need an alternate URL #}
+        {% set learn_more_url = url('firefox.accounts-features') if LANG == 'en-US' else url('firefox.features.sync') %}
+        <a href="{{ learn_more_url }}" target="_blank" rel="noopener noreferrer">{{_('Learn more about Firefox Accounts')}}</a>
       </header>
       <div class="fxaccounts" id="fxa-iframe-config" data-host="{{ settings.FXA_IFRAME_SRC }}" data-mozillaonline-host="{{ settings.FXA_IFRAME_SRC_MOZILLAONLINE }}">
         <iframe id="fxa" scrolling="no" data-src="{{ settings.FXA_IFRAME_SRC }}?action=email&amp;utm_campaign=fxa-embedded-form&amp;utm_medium=referral&amp;utm_source=whatsnew&amp;utm_content=fx-{{ version }}&amp;entrypoint=whatsnew&amp;service=sync&amp;context=iframe&amp;style=chromeless&amp;haltAfterSignIn=true"></iframe>


### PR DESCRIPTION
## Description

Features page is en only, link to sync for others

## Issue / Bugzilla link

As spotted in: https://github.com/mozilla/bedrock/pull/5666/files#diff-6da246948f44628799c88b281633818bR43

## Testing
