### PR TITLE
Fixes functional tests for /whatsnew:

### DIFF
--- a/tests/functional/firefox/test_whatsnew.py
+++ b/tests/functional/firefox/test_whatsnew.py
@@ -29,14 +29,6 @@ def test_send_to_device_fails_when_missing_required_fields(base_url, selenium):
 
 @pytest.mark.skip_if_not_firefox(reason='Whatsnew pages are shown to Firefox only.')
 @pytest.mark.nondestructive
-def test_qr_code_locale(base_url, selenium):
-    page = FirefoxWhatsNewPage(selenium, base_url, locale='it').open()
-    assert not page.send_to_device.is_displayed
-    assert page.is_qr_code_displayed
-
-
-@pytest.mark.skip_if_not_firefox(reason='Whatsnew pages are shown to Firefox only.')
-@pytest.mark.nondestructive
 def test_firefox_rocket_qr_code(base_url, selenium):
     page = FirefoxWhatsNewPage(selenium, base_url, locale='id').open()
     assert not page.send_to_device.is_displayed

--- a/tests/pages/firefox/whatsnew.py
+++ b/tests/pages/firefox/whatsnew.py
@@ -12,7 +12,7 @@ class FirefoxWhatsNewPage(FirefoxBasePage):
 
     URL_TEMPLATE = '/{locale}/firefox/whatsnew/'
 
-    _qr_code_locator = (By.CSS_SELECTOR, '#qr-wrapper > img')
+    _qr_code_locator = (By.CSS_SELECTOR, '.rocket-code > img')
     _zh_tw_qr_code_locator = (By.CSS_SELECTOR, 'img.qrcode')
 
     @property


### PR DESCRIPTION
## Description

The updated `/whatsnew/` pages require changes to the functional tests. The selector for the predictable QR code (which is now `id` only) changed, and there's no longer a need for the `test_qr_code_locale` test as the "standard" WNP has multiple, conditional states (the default of which shows the FxA form, which there is a test for).

## Testing

SauceLabs is having issues, so we can't get a clean run of `run-integration-tests` at the moment, but running the tests locally should work.