### PR TITLE
Fix Bug 1460968 - Button to "Get Firefox 52 ESR" points to ESR 60 (on /organizations)

### DIFF
--- a/bedrock/firefox/templates/firefox/organizations/organizations.html
+++ b/bedrock/firefox/templates/firefox/organizations/organizations.html
@@ -43,7 +43,7 @@
             <strong>{{ _('Firefox Extended Support Release (ESR 52)') }}</strong><br>
             {{ _('An older version of Firefox that supports legacy Add-Ons and runs on Windows XP/Vista.') }}
           </p>
-          <p><a href="{{ firefox_url('desktop', 'all', 'esr') }}" class="button button-light">{{ _('Get Firefox 52 ESR') }}</a></p>
+          <p><a href="{{ firefox_url('desktop', 'all', 'esr') }}#legacy" class="button button-light">{{ _('Get Firefox 52 ESR') }}</a></p>
         </div>
       </div>
     </div>

--- a/media/js/firefox/firefox-language-search.js
+++ b/media/js/firefox/firefox-language-search.js
@@ -12,6 +12,11 @@
     // Only enable the pager if we have two ESR versions.
     if ($('.esr-builds-table').length > 1) {
         buildsPager = new Mozilla.Pager($('#main-content'));
+
+        // Show the legacy builds if the URL contains `#legacy`
+        if (location.hash.replace(/^#/, '') === 'legacy') {
+            buildsPager.setStateFromPath('builds', false, false);
+        }
     }
 
     $(function (){


### PR DESCRIPTION
## Description

* Fix the Firefox 52 ESR download button on [/firefox/organizations/](https://www.mozilla.org/en-US/firefox/organizations/) leading to 60 ESR download links.
* Simply use a hash in the link and switch between tabs depending on it.
* Note that the button will be removed in this August once 52 ESR reaches EOL.

## Issue / Bugzilla link

[Bug 1460968 - Button to "Get Firefox 52 ESR" points to ESR 60 (on /organizations)](https://bugzilla.mozilla.org/show_bug.cgi?id=1460968)

## Testing

Click the Firefox 52 ESR download button and see 52 ESR downloads first.