### PR TITLE
[fix bug 1458036] Copy updates to /firefox/enterprise/ page

### DIFF
--- a/bedrock/firefox/templates/firefox/enterprise/index.html
+++ b/bedrock/firefox/templates/firefox/enterprise/index.html
@@ -27,8 +27,7 @@
           {% if switch('firefox_enterprise', ['en-US']) %}
             <p>{{ _('Speed up your business by giving employees a managed version of the super-fast new Firefox. <em>Now with Windows Group Policy support.</em>') }}</p>
             <div class="copy-cta">
-              <a href="{{ url('firefox.enterprise.signup') }}" class="button button-green qa-cta">{{ _('Request More Information') }}</a>
-              <div class="copy-cta-2"><a href="https://support.mozilla.org/products/firefox-enterprise">{{ _('Or, read the docs.') }}</a></div>
+              <a href="{{ url('firefox.enterprise.signup') }}" class="button button-green qa-sign-up">{{ _('Find Out More') }}</a>
             </div>
           {% else %}
             <p>{{ _('Speed up your business by deploying a managed version of the super-fast new Firefox') }}</p>
@@ -66,23 +65,34 @@
           </p>
         </li>
       </ul>
-    </div>
-  </section>
 
-  <section class="secondary-download content-section">
-    <div class="content">
-      <div class="download-contain">
-        <h2>
-          {{ _('Speed up your business.') }}
-        </h2>
-        <div class="download-button-wrapper">
-          {% if switch('firefox_enterprise', ['en-US']) %}
-            <a href="{{ url('firefox.enterprise.signup') }}" class="button button-green">{{ _('Request More Information') }}</a>
-          {% else %}
-            <a href="https://www.surveygizmo.com/s3/4201563/Firefox-for-Enterprise-Beta" class="button">{{ _('Sign up for the beta') }}</a>
-          {% endif %}
-        </div>
-      </div>
+      <table class="download-table">
+        <caption><h3>{{ _('Firefox Enterprise Downloads') }}</h3></caption>
+        <tbody>
+          <tr>
+            <th>{{ _('Firefox Rapid Release') }}</th>
+            <td><a class="qa-download-release" href="{{ url('firefox.new') }}">{{ _('Download Firefox') }}</a></td>
+          </tr>
+          <tr>
+            <th>{{ _('Firefox Extended Support Release (ESR)') }}</th>
+            <td><a class="qa-download-esr" href="{{ url('firefox.organizations.organizations') }}">{{ _('Download ESR') }}</a></td>
+          </tr>
+        </tbody>
+      </table>
+
+      <table class="download-table">
+        <caption><h3>{{ _('Resources') }}</h3></caption>
+        <tbody>
+          <tr>
+            <th>{{ _('Support & Documentation') }}</th>
+            <td><a href="https://support.mozilla.org/products/firefox-enterprise/">{{ _('Learn More') }}</a></td>
+          </tr>
+          <tr>
+            <th>{{ _('Windows Group Policy ADMX Templates') }}</th>
+            <td><a href="https://github.com/mozilla/policy-templates/releases/">{{ _('Get Templates') }}</a></td>
+          </tr>
+        </tbody>
+      </table>
     </div>
   </section>
 </main>

--- a/media/css/firefox/enterprise.scss
+++ b/media/css/firefox/enterprise.scss
@@ -16,6 +16,10 @@ $color-photon-blue: #0099db;
     background: #fff;
 }
 
+body {
+    @include open-sans;
+}
+
 .content-section {
     color: #000;
     padding: 40px 0;
@@ -34,16 +38,13 @@ $color-photon-blue: #0099db;
     background: #0f257e url('/media/img/firefox/enterprise/wave.png') bottom left no-repeat;
     color: #fff;
 
-    h1,
-    h2 {
-        @include font-size-level1;
+    h1 {
+        @include font-size-level2;
         @include open-sans;
-        font-weight: normal;
         margin-bottom: 0;
     }
 
     .copy {
-        @include open-sans;
         padding: 0;
         width: auto;
 
@@ -220,52 +221,78 @@ $color-photon-blue: #0099db;
 }
 
 /* -------------------------------------------------------------------------- */
-// Bottom download CTA.
+// Download table
 
-.secondary-download.content-section {
-    padding: 20px 0;
+.download-table {
+    @include font-size-level6;
+    border-collapse: separate;
+    border-spacing: 0 4px;
+    margin-top: 40px;
+    width: 100%;
 
-    .download-contain {
-        position: relative;
-        padding: 40px 0;
+    caption {
+        text-align: left;
 
-        &:before {
-            background-color: #65e1ff;
-            background-image: linear-gradient(to left, #65e1ff 0%, #95b5ff 78%, #a2a9ff 100%);
-            content: '';
-            height: 6px;
-            left: 0;
-            position: absolute;
-            top: 0;
-            width: 100%;
+        h3 {
+            @include font-size-level5;
+            margin-bottom: 20px;
         }
     }
 
-    h2 {
+    tr {
+        background-color: #ededf0;
+        margin-bottom: 4px;
+    }
+
+    th {
         font-weight: normal;
-        margin-bottom: 40px;
+    }
+
+    tr,
+    th,
+    td {
+        padding: 10px;
+    }
+
+    th,
+    td {
+        display: block;
+        text-align: left;
+    }
+
+    a:link,
+    a:visited {
+        color: #0060df;
+        font-weight: bold;
+        text-decoration: none;
+    }
+
+    a:hover,
+    a:active,
+    a:focus {
+        text-decoration: underline;
     }
 
     @media #{$mq-desktop} {
-        .download-contain {
-            @include clearfix;
-            padding: 100px 0 $enterprise-grid-spacing;
+        margin-top: 60px;
+
+        th {
+            text-align: left;
         }
 
-        h2 {
-            float: left;
-            text-align: left;
-            width: 66%;
-
-            @supports(display: grid) {
-                // to left align button with the 3rd grid box above (66% is not accurate enough)
-                width: calc((100% - #{$enterprise-grid-spacing * 2}) / 3 * 2 + #{$enterprise-grid-spacing * 2});
-            }
+        td {
+            text-align: right;
         }
 
-        .download-button-wrapper {
-            float: left;
-            text-align: left;
+        tr,
+        th,
+        td {
+            padding: 20px;
+        }
+
+        th,
+        td {
+            display: table-cell;
         }
     }
 }

--- a/tests/functional/firefox/test_enterprise.py
+++ b/tests/functional/firefox/test_enterprise.py
@@ -7,9 +7,16 @@ import pytest
 from pages.firefox.enterprise import EnterprisePage
 
 
-@pytest.mark.sanity
 @pytest.mark.smoke
 @pytest.mark.nondestructive
-def test_cta_is_displayed(base_url, selenium):
+def test_signup_button_is_displayed(base_url, selenium):
     page = EnterprisePage(selenium, base_url).open()
-    assert page.primary_cta.is_displayed
+    assert page.signup_button.is_displayed
+
+
+@pytest.mark.smoke
+@pytest.mark.nondestructive
+def test_download_links_are_displayed(base_url, selenium):
+    page = EnterprisePage(selenium, base_url).open()
+    assert page.download_release_link.is_displayed
+    assert page.download_esr_link.is_displayed

--- a/tests/pages/firefox/enterprise.py
+++ b/tests/pages/firefox/enterprise.py
@@ -11,8 +11,18 @@ class EnterprisePage(FirefoxBasePage):
 
     URL_TEMPLATE = '/{locale}/firefox/enterprise/'
 
-    _primary_cta_locator = (By.CSS_SELECTOR, '.qa-cta')
+    _signup_button_locator = (By.CSS_SELECTOR, '.qa-sign-up')
+    _download_release_locator = (By.CSS_SELECTOR, '.qa-download-release')
+    _download_esr_locator = (By.CSS_SELECTOR, '.qa-download-esr')
 
     @property
-    def primary_cta(self):
-        return self.find_element(*self._primary_cta_locator)
+    def signup_button(self):
+        return self.find_element(*self._signup_button_locator)
+
+    @property
+    def download_release_link(self):
+        return self.find_element(*self._download_release_locator)
+
+    @property
+    def download_esr_link(self):
+        return self.find_element(*self._download_esr_locator)


### PR DESCRIPTION
## Description
- Updates `/firefox/enterprise/` page with links to both general release and ESR downloads.
- Page is not yet localized, so copy changes should be fine as-is.

## Issue / Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1458036

## Testing
- [ ] Check for copy pasta errors
- [ ] Test responsiveness
- [ ] No regressions to existing content

Demo:
-------

https://bedrock-demo-agibson.oregon-b.moz.works/en-US/firefox/enterprise/