### PR TITLE
[bug 1458036] Clean up Enterprise switch

### DIFF
--- a/bedrock/firefox/templates/firefox/enterprise/index.html
+++ b/bedrock/firefox/templates/firefox/enterprise/index.html
@@ -24,15 +24,10 @@
       <div class="copy">
         {{ high_res_img('logos/firefox/logo-quantum.png', {'alt': 'Firefox', 'width': '100', 'height': '100', 'class': 'logo'}) }}
           <h1>{{ _('Firefox Quantum for Enterprise') }}</h1>
-          {% if switch('firefox_enterprise', ['en-US']) %}
-            <p>{{ _('Speed up your business by giving employees a managed version of the super-fast new Firefox. <em>Now with Windows Group Policy support.</em>') }}</p>
-            <div class="copy-cta">
-              <a href="{{ url('firefox.enterprise.signup') }}" class="button button-green qa-sign-up">{{ _('Find Out More') }}</a>
-            </div>
-          {% else %}
-            <p>{{ _('Speed up your business by deploying a managed version of the super-fast new Firefox') }}</p>
-            <a href="https://www.surveygizmo.com/s3/4201563/Firefox-for-Enterprise-Beta" class="button qa-cta" id="beta-signup">{{ _('Sign up for the beta') }}</a>
-          {% endif %}
+          <p>{{ _('Speed up your business by giving employees a managed version of the super-fast new Firefox. <em>Now with Windows Group Policy support.</em>') }}</p>
+          <div class="copy-cta">
+            <a href="{{ url('firefox.enterprise.signup') }}" class="button button-green qa-sign-up">{{ _('Find Out More') }}</a>
+          </div>
       </div>
     </div>
   </section>

--- a/bedrock/firefox/templates/firefox/organizations/organizations.html
+++ b/bedrock/firefox/templates/firefox/organizations/organizations.html
@@ -27,7 +27,6 @@
 {% block content %}
 
 {% block main_feature %}
-  {% if switch('firefox_enterprise', ['en-US']) %}
     <div class="pick">
       <h1 class="large">{{ _('Find the right Firefox for you') }}</h1>
       <div class="row">
@@ -47,48 +46,7 @@
         </div>
       </div>
     </div>
-  {% else %}
-    <hgroup id="main-feature" class="stacked">
-      <h1>{{ _('Mozilla Firefox <span class="%s">Extended Support Release</span>')|format('large') }}</h1>
-      <p class="large">{{ _('A community-led project that allows organizations to benefit from the speed, flexibility and security of Firefox while getting the support they need.') }}</p>
-    </hgroup>
-  {% endif %}
 {% endblock %}
-{% if not switch('firefox_enterprise', ['en-US']) %}
-  <div class="container">
-    <div class="main-column">
-      <p>
-      {%- trans -%}
-        Firefox Extended Support Release (ESR) is intended for system administrators who deploy and maintain the desktop
-        environment in organizations such as universities and other schools, county or city governments and businesses.
-      {%- endtrans -%}
-      </p>
-      <p>
-      {%- trans -%}
-        We encourage those who are deploying Firefox ESR to sign up for the Mozilla Enterprise mailing list available in
-        <a href="{{ list_en }}">English</a>, <a href="{{ list_fr }}">French</a> and <a href="{{ list_de }}">German</a>.
-        This list is a great place to discuss deploying Firefox with other community members. Regular communications
-        regarding product updates and support are also sent on the list by various Mozilla teams.
-      {%- endtrans -%}
-      </p>
-    </div>
-    <aside id="sidebar" class="sidebar">
-      <div id="download">
-        <p><a class="button" href="{{ firefox_url('desktop', 'all', 'esr') }}">{{ _('Download Firefox ESR') }}</a></p>
-      </div>
-      <div id="alternate-download">
-        <h4>{{ _('Not an administrator?') }}</h4>
-        <p>
-        {%- trans url=url('firefox') -%}
-          ESR is intended for system administrators in organizations. If you’re looking for Firefox for personal use
-          either at home or work, please visit our <a href="{{ url }}">Firefox product page</a> to download the latest
-          version.
-        {%- endtrans -%}
-        </p>
-      </div>
-    </aside>
-  </div>
-{% endif %}
 <div class="container">
   <section id="faq">
     <h2>{{ _('ESR FAQ') }}</h2>


### PR DESCRIPTION
## Description
https://github.com/mozilla/bedrock/pull/5695 updated the tests for the Firefox Enterprise page but the old CTA was still visible and the new one was behind a switch, which meant the test looking for the new button wasn't finding it. Since that switch is no longer needed the ideal fix for the breaking test is to just remove the switch, making the new button visible for all.

## Issue / Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1458036