### PR TITLE
Fix default setting for Newrelic INI File in wsgi/app.py

### DIFF
--- a/wsgi/app.py
+++ b/wsgi/app.py
@@ -11,7 +11,7 @@ except ImportError:
 
 
 if newrelic:
-    newrelic_ini = config('NEWRELIC_PYTHON_INI_FILE', default='False')
+    newrelic_ini = config('NEWRELIC_PYTHON_INI_FILE', default='')
     if newrelic_ini:
         newrelic.agent.initialize(newrelic_ini)
     else:


### PR DESCRIPTION
This was causing the app container to fail to start since New Relic was trying to start with a non existing config file called "False", thus causing the smoke tests to file since the app container did not stay running.