### PR TITLE
Resolves #5718 - 2 URL Changes to /enterprise

### DIFF
--- a/bedrock/firefox/templates/firefox/enterprise/index.html
+++ b/bedrock/firefox/templates/firefox/enterprise/index.html
@@ -66,11 +66,11 @@
         <tbody>
           <tr>
             <th>{{ _('Firefox Rapid Release') }}</th>
-            <td><a class="qa-download-release" href="{{ url('firefox.new') }}">{{ _('Download Firefox') }}</a></td>
+            <td><a class="qa-download-release" href="{{ firefox_url('desktop', 'all') }}">{{ _('Download Firefox') }}</a></td>
           </tr>
           <tr>
             <th>{{ _('Firefox Extended Support Release (ESR)') }}</th>
-            <td><a class="qa-download-esr" href="{{ url('firefox.organizations.organizations') }}">{{ _('Download ESR') }}</a></td>
+            <td><a class="qa-download-esr" href="{{ firefox_url('desktop', 'all', 'esr') }}">{{ _('Download ESR') }}</a></td>
           </tr>
         </tbody>
       </table>


### PR DESCRIPTION
## Description
1. Change Firefox Rapid Release URL to https://www.mozilla.org/en-US/firefox/all/
1. Change Firefox ESR URL to https://www.mozilla.org/en-US/firefox/organizations/all/

## Issue / Bugzilla link
Resolves #5718 

## Testing
Click links.