### PR TITLE
[fix issue 5629] Improve adjust iOS flow.

### DIFF
--- a/media/js/firefox/new/scene1.js
+++ b/media/js/firefox/new/scene1.js
@@ -120,4 +120,19 @@
         initOtherPlatformsModal();
     }
 
+    /**
+     * If user is on iOS and has followed an adjust.com link, redirect to
+     * the App Store.
+     * https://github.com/mozilla/bedrock/issues/5629
+     */
+    // TODO: is this a solid enough check?
+    if (window.site.platform === 'ios' && /open\-app\-store=true/.test(window.location.search)) {
+        var appStoreURL = $('.os_ios a').attr('href');
+
+        if (appStoreURL) {
+            // TODO: do we need a dataLayer call here?
+            window.location.href = appStoreURL;
+        }
+    }
+
 })(window.jQuery);

--- a/media/js/firefox/new/scene1.js
+++ b/media/js/firefox/new/scene1.js
@@ -125,12 +125,10 @@
      * the App Store.
      * https://github.com/mozilla/bedrock/issues/5629
      */
-    // TODO: is this a solid enough check?
     if (window.site.platform === 'ios' && /open\-app\-store=true/.test(window.location.search)) {
-        var appStoreURL = $('.os_ios a').attr('href');
+        var appStoreURL = $('.download-button .os_ios > a.download-link').attr('href');
 
         if (appStoreURL) {
-            // TODO: do we need a dataLayer call here?
             window.location.href = appStoreURL;
         }
     }


### PR DESCRIPTION
## Description

Improve UX for iOS users following adjust.com links to download Firefox mobile. 

## Issue / Bugzilla link

#5629
https://bugzilla.mozilla.org/show_bug.cgi?id=1460039

## Testing

https://app.adjust.com/2uo1qc?campaign=whats_new&adgroup=send_to_device&creative=sms&fallback_lp=https%3A%2F%2Fwww-demo2.allizom.org%2Ffirefox%2Fnew%2F%3Fopen-app-store%3Dtrue

Both email and SMS the above link to yourself. Open the link on iOS, both in your mail client and messaging client.

You *should* see our `/firefox/new/` page displayed and immediately be given an iOS (not website) prompt to open the App Store. Accepting the dialog should take you to the App Store, while cancelling should leave you on `/firefox/new/.

(Note that there is a known [issue going from the Gmail iOS app to the Chrome iOS browser](https://bugzilla.mozilla.org/show_bug.cgi?id=1460039#c5). Someone from Adjust is looking at this, but I don't think we need to block on it.)