### PR TITLE
Add more data to git repo state in the database

### DIFF
--- a/bedrock/base/management/commands/update_www_config.py
+++ b/bedrock/base/management/commands/update_www_config.py
@@ -49,7 +49,7 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         self.quiet = options['quiet']
         repo = GitRepo(settings.WWW_CONFIG_PATH, settings.WWW_CONFIG_REPO,
-                       branch_name=settings.WWW_CONFIG_BRANCH)
+                       branch_name=settings.WWW_CONFIG_BRANCH, name='WWW Config')
         self.output('Updating git repo')
         repo.update()
         if not (options['force'] or repo.has_changes()):

--- a/bedrock/base/templates/cron-health-check.html
+++ b/bedrock/base/templates/cron-health-check.html
@@ -17,8 +17,9 @@
     tr:nth-child(even) > td, th {
       background-color: #eee;
     }
-    #other-data tr > td:first-child {
+    .data-table tr > td:first-child {
       font-weight: bold;
+      padding-right: 10px;
     }
     .error > td {
       color: #c00;
@@ -56,8 +57,8 @@
     </tbody>
   </table>
 
-  <h1>Other Site Data</h1>
-  <table id="other-data">
+  <h1 id="other-data">Other Site Data</h1>
+  <table class="data-table">
     <tbody>
       <tr>
         <td>Hostname</td>
@@ -84,7 +85,7 @@
       {% if server_info.db_last_update %}
       <tr>
         <td>DB Last Updated</td>
-        <td>{{ server_info.db_last_update }} min ago</td>
+        <td>{{ server_info.db_last_update }}</td>
       </tr>
       {% endif %}
       {% if server_info.db_file_name %}
@@ -93,6 +94,31 @@
         <td><a href="{{ server_info.db_file_url }}">{{ server_info.db_file_name }}</a></td>
       </tr>
       {% endif %}
+    </tbody>
+  </table>
+
+  <h1 id="git-repos">External Git Repos</h1>
+  <table>
+    <thead>
+      <tr>
+        <th>Repo Name</th>
+        <th>Latest Commit</th>
+        <th>Last Updated</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><a href="{{ l10n_repo.repo_url }}">L10n Files</a></td>
+        <td><a href="{{ l10n_repo.repo_url }}/commit/{{ l10n_repo.latest_ref }}">{{ l10n_repo.latest_ref[:10] }}</a></td>
+        <td>{{ l10n_repo.last_updated }}</td>
+      </tr>
+      {% for repo in git_repos %}
+      <tr>
+        <td><a href="{{ repo.repo_url }}">{{ repo.repo_name }}</a></td>
+        <td><a href="{{ repo.commit_url }}">{{ repo.latest_ref[:10] }}</a></td>
+        <td>{{ repo.last_updated }}</td>
+      </tr>
+      {% endfor %}
     </tbody>
   </table>
 </body>

--- a/bedrock/externalfiles/management/commands/update_externalfiles.py
+++ b/bedrock/externalfiles/management/commands/update_externalfiles.py
@@ -21,7 +21,8 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         self.quiet = options['quiet']
         repo = GitRepo(settings.EXTERNAL_FILES_PATH, settings.EXTERNAL_FILES_REPO,
-                       branch_name=settings.EXTERNAL_FILES_BRANCH)
+                       branch_name=settings.EXTERNAL_FILES_BRANCH,
+                       name='Community Data')
         self.output('Updating git repo')
         repo.update()
         if not (options['force'] or repo.has_changes()):

--- a/bedrock/mozorg/management/commands/update_product_details_files.py
+++ b/bedrock/mozorg/management/commands/update_product_details_files.py
@@ -24,7 +24,8 @@ class Command(BaseCommand):
         self.file_storage = PDFileStorage(json_dir=settings.PROD_DETAILS_TEST_DIR)
         self.db_storage = PDDatabaseStorage()
         self.repo = GitRepo(settings.PROD_DETAILS_JSON_REPO_PATH,
-                            settings.PROD_DETAILS_JSON_REPO_URI)
+                            settings.PROD_DETAILS_JSON_REPO_URI,
+                            name='Product Details')
         super(Command, self).__init__(stdout, stderr, no_color)
 
     def add_arguments(self, parser):

--- a/bedrock/releasenotes/management/commands/update_release_notes.py
+++ b/bedrock/releasenotes/management/commands/update_release_notes.py
@@ -21,7 +21,7 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         self.quiet = options['quiet']
         repo = GitRepo(settings.RELEASE_NOTES_PATH, settings.RELEASE_NOTES_REPO,
-                       branch_name=settings.RELEASE_NOTES_BRANCH)
+                       branch_name=settings.RELEASE_NOTES_BRANCH, name='Release Notes')
         self.output('Updating git repo')
         repo.update()
         if not (options['force'] or repo.has_changes()):

--- a/bedrock/releasenotes/utils.py
+++ b/bedrock/releasenotes/utils.py
@@ -12,8 +12,8 @@ def get_data_version():
     This will ensure that the cache is invalidated when the repo is updated.
     """
     repo = GitRepo(settings.RELEASE_NOTES_PATH,
-                    settings.RELEASE_NOTES_REPO,
-                    branch_name=settings.RELEASE_NOTES_BRANCH)
+                   settings.RELEASE_NOTES_REPO,
+                   branch_name=settings.RELEASE_NOTES_BRANCH)
     git_ref = repo.get_db_latest()
     if git_ref is None:
         git_ref = 'default'

--- a/bedrock/security/management/commands/update_security_advisories.py
+++ b/bedrock/security/management/commands/update_security_advisories.py
@@ -258,7 +258,8 @@ class Command(NoArgsCommand):
         no_git = options['no_git']
         clear_db = options['clear_db']
         force = no_git or clear_db
-        repo = GitRepo(ADVISORIES_PATH, ADVISORIES_REPO, branch_name=ADVISORIES_BRANCH)
+        repo = GitRepo(ADVISORIES_PATH, ADVISORIES_REPO, branch_name=ADVISORIES_BRANCH,
+                       name='Security Advisories')
 
         def printout(msg, ending=None):
             if not quiet:

--- a/bedrock/utils/migrations/0002_auto_20180522_1249.py
+++ b/bedrock/utils/migrations/0002_auto_20180522_1249.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('utils', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='gitrepostate',
+            name='latest_ref_timestamp',
+            field=models.IntegerField(default=0),
+        ),
+        migrations.AddField(
+            model_name='gitrepostate',
+            name='repo_name',
+            field=models.CharField(max_length=200, blank=True),
+        ),
+        migrations.AddField(
+            model_name='gitrepostate',
+            name='repo_url',
+            field=models.CharField(max_length=200, blank=True),
+        ),
+    ]

--- a/bedrock/utils/models.py
+++ b/bedrock/utils/models.py
@@ -1,6 +1,31 @@
+from datetime import datetime
+
 from django.db import models
+
+import timeago
 
 
 class GitRepoState(models.Model):
+    repo_name = models.CharField(max_length=200, blank=True)
+    repo_url = models.CharField(max_length=200, blank=True)
     repo_id = models.CharField(max_length=100, db_index=True, unique=True)
     latest_ref = models.CharField(max_length=100)
+    latest_ref_timestamp = models.IntegerField(default=0)
+
+    def __unicode__(self):
+        return '%s: %s' % (self.repo_name, self.latest_ref)
+
+    @property
+    def commit_url(self):
+        if self.repo_url:
+            return '%s/commit/%s' % (self.repo_url, self.latest_ref)
+
+        return ''
+
+    @property
+    def last_updated(self):
+        if self.latest_ref_timestamp:
+            latest_datetime = datetime.fromtimestamp(self.latest_ref_timestamp)
+            return timeago.format(latest_datetime)
+
+        return 'unknown'

--- a/bedrock/utils/tests/test_git.py
+++ b/bedrock/utils/tests/test_git.py
@@ -41,6 +41,27 @@ def test_git_db_latest():
     assert g.get_db_latest() == 'deadbeef1234'
 
 
+@pytest.mark.django_db
+def test_git_db_latest_methods():
+    g = git.GitRepo('.', 'https://example.com/repo.git', 'master', 'dude')
+    g.set_db_latest('deadbeef')
+    assert g.get_db_latest() == 'deadbeef'
+    gobj = git.GitRepoState.objects.get(repo_id=g.db_latest_key)
+    assert gobj.repo_name == 'dude'
+    assert gobj.commit_url == 'https://example.com/repo/commit/deadbeef'
+
+
+@pytest.mark.django_db
+def test_git_db_latest_auto_name():
+    # name should be the last bit of the path, and the repo URL can deal with a trailing slash
+    g = git.GitRepo('hollywood-star-lanes/the-dude', 'https://example.com/repo/', 'master')
+    g.set_db_latest('deadbeef')
+    assert g.get_db_latest() == 'deadbeef'
+    gobj = git.GitRepoState.objects.get(repo_id=g.db_latest_key)
+    assert gobj.repo_name == 'the-dude'
+    assert gobj.commit_url == 'https://example.com/repo/commit/deadbeef'
+
+
 @override_settings(DEV=True)
 def test_git_clone():
     g = git.GitRepo('.')

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -191,3 +191,5 @@ everett==0.9 \
 envcat==0.1.1 \
     --hash=sha256:3659c6bad8f47cd3c2691d754a5659c1953480c066718c8a1d87367b03f11bc8 \
     --hash=sha256:6831806d205b7b1c8456bba5d9cd7ced90f52cf2fc8cfbe234d48d3fdb91111d
+timeago==1.0.8 \
+    --hash=sha256:f2acf144a9aabbc1e46a7f84387e6dd17bf41ff5fd87822c878621d06ef6b77c


### PR DESCRIPTION
This is so that we can display the current commit synced to the db for each external repo on the /healthz-cron/ page. We also link to the repo, the commit, and display how long ago the repo was last updated.

Fix #5726