### PR TITLE
[fix issue 5730] MOSS content updates for June 1

### DIFF
--- a/bedrock/mozorg/templates/mozorg/moss/foundational-technology.html
+++ b/bedrock/mozorg/templates/mozorg/moss/foundational-technology.html
@@ -45,7 +45,7 @@
   <div class="moss-ctas">
     <p class="moss-copy">{{ _('Ready to go?') }}</p>
 
-    <a href="https://docs.google.com/a/mozilla.com/forms/d/1Pa5IsuhT6vMUfg0HUXxr7SzrSwq5fpiZfZIJVPxN1Mc/viewform" rel="external" class="button">{{ _('Apply Now') }}</a>
+    <a href="https://mozilla.fluxx.io/apply/MOSS" rel="external" class="button">{{ _('Apply Now') }}</a>
   </div>
 </section>
 

--- a/bedrock/mozorg/templates/mozorg/moss/index.html
+++ b/bedrock/mozorg/templates/mozorg/moss/index.html
@@ -49,6 +49,12 @@
     in India.
   {% endtrans %}
   </p>
+
+ {% if l10n_has_tag('mozilla_moss_disclosure') %}
+  <p class="moss-copy">{{ _('MOSS is an awards program of the Mozilla Corporation, which is ultimately responsible for selecting and
+    funding final award recipients. MOSS is administered in part by the Mozilla Foundation, the nonprofit owner of the Mozilla Corporation.') }}
+  </p>
+  {% endif %}
 </section>
 
 <section class="moss-section">
@@ -72,7 +78,7 @@
         </p>
 
         <p>
-          <a href="https://docs.google.com/a/mozilla.com/forms/d/e/1FAIpQLSdSSJ2jCuNCSY2SlIReOPwuF-ILnkt7IpNk4YkLKPn1spJoMA/viewform" rel="external" class="button">{{ _('Apply Now') }}</a>
+          <a href="https://mozilla.fluxx.io/apply/MOSS" rel="external" class="button">{{ _('Apply Now') }}</a>
         </p>
       </div>
     </li>
@@ -94,7 +100,7 @@
         </p>
 
         <p>
-          <a href="https://docs.google.com/a/mozilla.com/forms/d/e/1FAIpQLSe9a9h4afnJnDp3rRRHB4i1Xnb3otzfaQrb9uXVeoeXlB3NSg/viewform" rel="external" class="button">{{ _('Apply Now') }}</a>
+          <a href="https://mozilla.fluxx.io/apply/MOSS" rel="external" class="button">{{ _('Apply Now') }}</a>
         </p>
       </div>
     </li>
@@ -127,7 +133,7 @@
 
   <p class="moss-copy">
   {% trans %}
-    MOSS applications are considered in batches every three months.
+    MOSS applications are considered in batches every month.
   {% endtrans %}
 
   {% trans %}

--- a/bedrock/mozorg/templates/mozorg/moss/mission-partners.html
+++ b/bedrock/mozorg/templates/mozorg/moss/mission-partners.html
@@ -31,7 +31,7 @@
   <div class="moss-ctas">
     <p class="moss-copy">{{ _('Ready to go?') }}</p>
 
-    <a href="https://docs.google.com/forms/d/1rwYQTT-9-eldS-kElY646bMwMzJpxfL8lDskX86xgCQ/viewform" rel="external" class="button">{{ _('Apply Now') }}</a>
+    <a href="https://mozilla.fluxx.io/apply/MOSS" rel="external" class="button">{{ _('Apply Now') }}</a>
   </div>
 </section>
 


### PR DESCRIPTION
Submitting a squashed #5743 with a different branch name to see if the tests pass.

## Description

It includes updates to the links to apply (Apply now buttons), disclosure copy and and change to the copy on frequency of evaluations.

The Do Not Merge tag has been applied due to the fact that the content should go live on June 1st (anytime) and not before

## Issue / Bugzilla link
Issue #5730.

## Testing
