### PR TITLE
Add base template for Protocol design system (Fixes #5752)

### DIFF
--- a/bedrock/base/templates/base-protocol.html
+++ b/bedrock/base/templates/base-protocol.html
@@ -1,0 +1,18 @@
+{% extends 'base-pebbles.html' %}
+
+{% block site_css %}
+  {% stylesheet 'protocol-core' %}
+{% endblock %}
+
+{% block tabzilla_tab %}{% endblock %}
+
+{% block site_header %}
+  {% if LANG.startswith('en-') %}
+    {% include 'includes/global-nav.html' %}
+  {% else %}
+    {% set logo_src = static('img/pebbles/moz-wordmark-dark-reverse.svg') %}
+    {% include 'mozorg/home/includes/nav.html' %}
+  {% endif %}
+{% endblock %}
+
+{% block update_notification %}{% endblock %}

--- a/media/css/protocol/components/_download-button.scss
+++ b/media/css/protocol/components/_download-button.scss
@@ -1,0 +1,234 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+@import "../../../../node_modules/@mozilla-protocol/core/protocol/css/includes/lib";
+
+// Download button color
+$color-button-green: #16da00;
+
+// The basis for all buttons on mozilla.org
+%base-button {
+    @include text-body-md;
+    @include open-sans;
+    background: none;
+    border-radius: 100px;
+    border-style: solid;
+    border-width: 2px;
+    cursor: pointer;
+    display: inline-block;
+    font-weight: bold;
+    padding: .9em 40px;
+    position: relative;
+    text-align: center;
+    text-decoration: none;
+    text-shadow: none;
+    transition: background-color .1s ease-in-out, border-color .1s ease-in-out;
+
+    &:active {
+        position: relative;
+        top: 1px;
+    }
+
+    &:hover,
+    &:focus {
+        text-decoration: none;
+    }
+}
+
+// Standard solid buttons, especially those not in a form context such as CTA and download buttons
+.button,
+button.button,
+a.button:link,
+a.button:visited {
+    @extend %base-button;
+
+    &.button-green {
+        background-color: $color-button-green;
+        border-color: $color-button-green;
+        color: #fff;
+
+        &:hover,
+        &:focus {
+            background-color: saturate(darken($color-button-green, 5%), 10%);
+            border-color: saturate(darken($color-button-green, 5%), 10%);
+        }
+    }
+}
+
+// privacy policy link that accompany most download buttons
+.fx-privacy-link {
+    @include text-body-xs;
+    @include open-sans;
+    display: block;
+    text-align: center;
+    margin-bottom: 20px;
+
+    a:link,
+    a:visited {
+        color: inherit;
+        text-decoration: none;
+    }
+
+    a:hover,
+    a:active,
+    a:focus {
+        text-decoration: underline;
+    }
+}
+
+// download button and related containers
+ul.download-list {
+    list-style-type: none;
+    margin-bottom: 10px;
+
+    li {
+        margin-left: 0;
+    }
+
+    strong {
+        font-weight: bold;
+    }
+}
+
+.download-dumb {
+    ul {
+        list-style: none;
+
+        li {
+            display: inline-block;
+            margin: 20px 0 0;
+
+            .button {
+                @include text-body-sm;
+                margin-left: 3px;
+                padding: 6px 10px;
+            }
+        }
+    }
+}
+
+.download-button {
+    display: inline-block;
+    vertical-align: top;
+}
+
+.download-other {
+    @include text-body-xs;
+    @include open-sans;
+    color: #666;
+
+    a:link,
+    a:visited {
+        color: #999;
+    }
+
+    a:hover,
+    a:focus,
+    a:active {
+        color: #999;
+        text-decoration: underline;
+    }
+}
+
+/* !important used for strict download link enforcement */
+/* stylelint-disable declaration-no-important  */
+
+// Product download buttons
+.download-button {
+    .ios-download,
+    .linux-arm-download,
+    .unrecognized-download,
+    .unsupported-download,
+    .unsupported-download-osx,
+    .nojs-download {
+        display: none;
+    }
+}
+
+// OS detection
+.download-button .os_win64,
+.download-button .os_linux,
+.download-button .os_linux64,
+// Uncomment this to enable the win64 download buttons:
+// .win7up.x86.x64 .download-button .os_win,
+.android .download-button-desktop,
+.windows.arm .download-button .os_win,
+.linux.arm .download-button .os_linux,
+.linux.x86.x64 .download-list .os_linux,
+.download-button .os_win,
+.download-button .os_osx,
+.download-button .os_android,
+.download-button .os_ios,
+.no-js .download-list,
+.other .download-list {
+    display: none !important;
+}
+
+// Uncomment this to enable the win64 download buttons:
+// .win7up.x86.x64 .download-button .os_win64,
+.linux .download-button .os_linux,
+.linux.x86.x64 .download-button .os_linux64,
+.windows .download-button .os_win,
+.osx .download-button .os_osx,
+.android .download-button .os_android,
+.download-button-android .os_android,
+.android .download-button-desktop .download-list,
+.android .download-button-desktop small.os_win,
+.download-button-ios .os_ios,
+.ios .download-button .os_ios,
+.ios .download-button .ios-download,
+.ios .download-button-desktop .download-list,
+.other .download-button-android .download-list,
+.other .download-button small.os_win {
+    display: block !important;
+}
+
+.windows.arm .download-button .unsupported-download,
+.linux.arm .download-button .linux-arm-download,
+.oldwin .download-button .unsupported-download,
+.oldmac .download-button .unsupported-download {
+    display: block;
+    max-width: 250px;
+}
+
+// Hide the privacy link if platform is unsupported.
+.windows.arm .download-button .fx-privacy-link,
+.linux.arm .download-button .fx-privacy-link,
+.oldwin .download-button .fx-privacy-link,
+.oldmac .download-button .fx-privacy-link {
+    display: none;
+}
+
+.android .download-button-desktop,
+.ios .download-button-desktop,
+.no-js .download-button {
+    .nojs-download {
+        display: block;
+    }
+}
+
+.other .download-button {
+    .unrecognized-download {
+        display: block;
+    }
+}
+
+// Android architecture detection
+.download-button .download-list .os_android.x86,
+.download-button .download-other.os_android .arm,
+.android.x86 .download-button .download-list .os_android.armv7up,
+.android.x86 .download-button .download-other.os_android .x86 {
+    display: none !important;
+}
+
+.android.x86 .download-button .download-list .os_android.x86 {
+    display: block !important;
+}
+
+.android.x86 .download-button .download-other.os_android .armv7up {
+    display: inline !important;
+}
+
+/* stylelint-enable */
+

--- a/media/css/protocol/components/_footer.scss
+++ b/media/css/protocol/components/_footer.scss
@@ -1,0 +1,230 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+@import "../../../../node_modules/@mozilla-protocol/core/protocol/css/includes/lib";
+
+#colophon {
+    @include open-sans;
+    background: #000;
+    clear: both;
+    color: #fff;
+    line-height: 1.3;
+    margin: 0;
+    padding: 40px 0;
+    width: 100%;
+
+    a:link,
+    a:visited {
+        color: #fff;
+        font-weight: normal;
+        text-decoration: none;
+    }
+
+    a:hover,
+    a:focus,
+    a:active {
+        color: #fff;
+        text-decoration: underline;
+    }
+
+    h5 {
+        @include text-display-xs;
+        color: #fff;
+        margin-bottom: .9em;
+
+        a:link,
+        a:visited {
+            font-weight: bold;
+        }
+    }
+
+    li {
+        list-style-type: none;
+        margin: 0 0 .8em;
+    }
+
+    nav {
+        @include border-box;
+        @include clearfix;
+        margin: 0 auto;
+        min-width: $width-content-xs;
+    }
+
+    section {
+        margin-bottom: 40px;
+    }
+
+    .content {
+        @include border-box;
+        @include clearfix;
+        margin: 0 auto;
+        max-width: $width-content-max;
+        min-width: $width-content-xs;
+        padding: $layout-xs;
+        position: relative;
+
+        @media #{$media-md} {
+            padding: $layout-xs $layout-lg;
+        }
+
+        @media #{$media-lg} {
+            padding: $layout-xs $layout-xl;
+        }
+    }
+
+    .logo {
+        margin-bottom: 40px;
+
+        a {
+            background: url('/media/img/pebbles/moz-wordmark-light-reverse.svg') no-repeat;
+            @include background-size(100px, 32px);
+            @include image-replaced;
+            display: inline-block;
+            height: 32px;
+            width: 100px;
+        }
+    }
+
+    .social-links {
+        margin: 2em 0 0;
+
+        li {
+            display: inline-block;
+            margin-right: 20px;
+
+            a {
+                display: block;
+                @include image-replaced;
+                background-image: url('/media/img/logos/social/social-icon-sprite.svg');
+
+                &.twitter {
+                    background-position: 0 0;
+                    width: 18px;
+                    height: 15px;
+                }
+
+                &.instagram {
+                    background-position: 0 -25px;
+                    width: 19px;
+                    height: 19px;
+                }
+
+                &.youtube {
+                    background-position: 0 -54px;
+                    width: 19px;
+                    height: 13px;
+                }
+
+                &.facebook {
+                    background-position: 0 -77px;
+                    width: 10px;
+                    height: 19px;
+                }
+            }
+        }
+    }
+
+    .primary {
+        @include font-size(16px);
+    }
+
+    .secondary {
+        @include text-body-xs;
+    }
+
+    .small-links {
+        li {
+            display: inline;
+            padding-right: 20px;
+
+            &:last-child {
+                padding-right: 0;
+            }
+        }
+    }
+
+    .license {
+        margin-bottom: 40px;
+
+        a:link,
+        a:visited {
+            color: #9b9b9b;
+        }
+    }
+
+    .lang-switcher {
+        font-weight: bold;
+
+        label {
+            display: inline-block;
+            margin: 0 20px 5px 0;
+        }
+
+        select {
+            @include text-body-xs;
+            border: none;
+            background: #ededed;
+        }
+
+        .js & button {
+            display: none;
+        }
+    }
+
+    @media #{$media-md} {
+        .primary {
+            .logo,
+            section {
+                @include colspan(4);
+                float: left;
+                padding: 0 20px 0 0;
+            }
+        }
+
+        .secondary {
+            padding-top: 20px;
+        }
+
+        .license {
+            margin-bottom: 0;
+        }
+
+        .small-links {
+            @include colspan(8);
+            float: left;
+            padding: 0 20px 0 0;
+        }
+
+        .lang-switcher {
+            @include colspan(4);
+            float: left;
+            margin-top: 2.25em;
+            padding: 0 20px 0 0;
+        }
+    }
+}
+
+[dir='rtl'] #colophon {
+    @media #{$media-md} {
+        .logo,
+        section,
+        .small-links,
+        .lang-switcher {
+            float: right;
+            padding: 0 0 0 20px;
+        }
+    }
+
+    .lang-switcher label {
+        margin: 0 0 5px 20px;
+    }
+
+    .social-links li {
+        margin: 0 0 0 20px;
+    }
+
+    .small-links li {
+        padding: 0 0 0 20px;
+    }
+}

--- a/media/css/protocol/components/_global-nav.scss
+++ b/media/css/protocol/components/_global-nav.scss
@@ -1,0 +1,740 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+@import "../../../../node_modules/@mozilla-protocol/core/protocol/css/includes/lib";
+
+// Product colors
+$color-firefox-light-orange: #ff9500;
+$color-pocket-red: #ef4056;
+
+// Brand colors
+$color-brand-cyan:      #4eb5e6;
+$color-brand-coral:     #ff8385;
+$color-brand-lilac:     #b0b2e9;
+$color-brand-lime:      #b6d806;
+
+// Download button color
+$color-button-green: #16da00;
+
+/* -------------------------------------------------------------------------- */
+// Horizontal top navigation
+
+.moz-global-nav {
+    @include open-sans;
+    background: #fff;
+    overflow: hidden;
+    position: relative;
+
+    a:link,
+    a:visited {
+        color: #000;
+        font-weight: bold;
+        text-decoration: none;
+    }
+
+    a:hover,
+    a:focus,
+    a:active {
+        color: #000;
+        text-decoration: underline;
+        transition: color 0.1s ease-in-out;
+    }
+
+    // Three-dotted nenu button
+    .nav-button-menu {
+        -moz-appearance: none;
+        -webkit-appearance: none;
+        appearance: none;
+        background: transparent;
+        border: none;
+        cursor: pointer;
+        float: left;
+        font-size: 0;
+        height: 25px;
+        margin: 13px 0;
+        padding: 0;
+        width: 50px;
+
+        .p1,
+        .p2,
+        .p3 {
+            transition: transform .2s ease-in-out;
+        }
+
+        &:hover,
+        &:active {
+            .p1 {
+                transform: translateX(4px);
+            }
+
+            .p2 {
+                transform: translateX(-3px);
+            }
+
+            .p3 {
+                transform: translateX(4px);
+            }
+        }
+
+        &:focus {
+            outline: none;
+
+            .p1,
+            .p2,
+            .p3 {
+                fill: #646464;
+            }
+        }
+
+        &::-moz-focus-inner {
+            border: none;
+        }
+
+        &.nav-hidden {
+            display: none;
+        }
+    }
+
+    // Mozilla wordmark logo
+    .nav-logo {
+        @include font-size(15px);
+        float: left;
+        height: 25px;
+        margin: 0 0 0 5px;
+        padding: 13px 0;
+
+        a {
+            @include image-replaced;
+            background: url('/media/img/favicon/favicon-196x196.png') top left no-repeat;
+            @include background-size(25px 25px);
+            display: block;
+            width: 25px;
+            height: 25px;
+        }
+
+        @media #{$media-lg} {
+            margin-left: 17px;
+
+            a {
+                @include background-size(auto, auto);
+                background-image: url('/media/img/pebbles/moz-wordmark-dark-reverse.svg');
+                width: 78px;
+            }
+        }
+    }
+
+    // Horizontal link menu container
+    .nav-horizontal-menu {
+        @include clearfix;
+        margin-left: 10px;
+        overflow: hidden;
+        padding: 10px 0;
+        position: relative;
+
+        @media #{$media-md} {
+            padding-top: 25px;
+        }
+
+        @media #{$media-lg} {
+            margin-left: 28px;
+        }
+    }
+
+    // Primary horizontal links
+    .nav-primary-links {
+        @include font-size(16px);
+        display: none;
+        float: left;
+        list-style-type: none;
+        margin: 0 0 0 10px;
+        padding: 13px 0 0;
+
+        &> li {
+            display: inline-block;
+            line-height: 1.2;
+            padding: 0 20px 10px 0;
+
+            &:last-child {
+                padding-right: 0;
+            }
+
+            a:hover,
+            a:active,
+            a:focus {
+                text-decoration: none;
+            }
+
+            a:focus {
+                outline: none;
+            }
+        }
+
+        @media #{$media-md} {
+            @include border-box;
+            display: block;
+            margin-left: 20px;
+            width: calc(100% - 370px);
+        }
+
+        @media #{$media-lg} {
+            width: calc(100% - 480px);
+        }
+
+        @media #{$media-xl} {
+            margin-left: 40px;
+
+            &> li {
+                padding-right: 40px;
+
+                &:last-child {
+                    padding-right: 0;
+                }
+            }
+        }
+    }
+
+    // Class for legacy browser support
+    &.simple {
+        .nav-primary-links {
+            display: block;
+        }
+    }
+
+    @media #{$media-lg} {
+        max-width: $width-content-max;
+        margin: 0 auto;
+    }
+}
+
+// Menu button animation open state
+.moz-nav-open .moz-global-nav .nav-button-menu {
+    .p1 {
+        transform: translateX(4px);
+    }
+
+    .p2 {
+        transform: translateX(-3px);
+    }
+
+    .p3 {
+        transform: translateX(4px);
+    }
+}
+
+/* -------------------------------------------------------------------------- */
+// Vertical side navigation drawer
+
+.moz-global-nav-drawer {
+    @include open-sans;
+    background: #000;
+    bottom: 0;
+    color: #fff;
+    left: -320px;
+    padding: 20px;
+    position: absolute;
+    top: 0;
+    width: 280px;
+    z-index: 1000;
+
+    a:link,
+    a:visited {
+        transition: color 0.1s ease-in-out;
+        color: #fff;
+        text-decoration: none;
+    }
+
+    a:hover,
+    a:active,
+    a:focus {
+        transition: color 0.1s ease-in-out;
+    }
+
+    a:focus {
+        outline: none;
+    }
+
+    abbr[title] {
+        border-bottom: none;
+        cursor: inherit;
+        text-decoration: none;
+    }
+
+    .nav-drawer-close-button {
+        -moz-appearance: none;
+        -webkit-appearance: none;
+        @include font-size(13px);
+        background-color: #000;
+        border: none;
+        cursor: pointer;
+        height: 22px;
+        margin: 30px 0 0 22px;
+        padding: 0;
+        text-transform: uppercase;
+
+        .rect {
+            transform-origin: center center;
+        }
+
+        .center {
+            transform: rotate(45deg);
+        }
+
+        .top-left {
+            transform: translate(-7px, -7px) rotate(45deg);
+        }
+
+        .top-right {
+            transform: translate(7px, -7px) rotate(45deg);
+        }
+
+        .bottom-left {
+            transform: translate(-7px, 7px) rotate(45deg);
+        }
+
+        .bottom-right {
+            transform: translate(7px, 7px) rotate(45deg);
+        }
+
+        @media #{$media-lg} {
+
+            .rect {
+                transition: transform .12s ease-in-out;
+                transform: translate(0, 0) rotate(45deg);
+            }
+
+            &:hover,
+            &:active,
+            &:focus {
+                .top-left {
+                    transform: translate(-7px, -7px) rotate(45deg);
+                }
+
+                .top-right {
+                    transform: translate(7px, -7px) rotate(45deg);
+                }
+
+                .bottom-left {
+                    transform: translate(-7px, 7px) rotate(45deg);
+                }
+
+                .bottom-right {
+                    transform: translate(7px, 7px) rotate(45deg);
+                }
+            }
+        }
+
+        &:focus {
+            outline: none;
+        }
+
+        &::-moz-focus-inner {
+            border: none;
+        }
+    }
+
+    .nav-menu-inner-container {
+        margin-top: 42px;
+        position: relative;
+    }
+
+    .nav-menu-scroll-pane {
+        padding: 0 22px;
+        width: 234px;
+    }
+
+    .nav-menu-primary-links {
+        padding-bottom: 40px;
+
+        h3 {
+            @include open-sans;
+        }
+
+        &> li {
+            margin: 20px 0;
+        }
+    }
+
+    .intro {
+        @include font-size(13px);
+        margin: 0 0 20px;
+    }
+
+    .summary {
+        @include font-size(16px);
+        padding-bottom: 20px;
+
+        a:link,
+        a:visited {
+            position: relative;
+            display: block;
+
+            &:after {
+                background-image: url('/media/img/nav/subnav-expand.svg');
+                content: '';
+                height: 12px;
+                position: absolute;
+                right: 0;
+                top: 0;
+                transition: transform .2s ease-in-out;
+                width: 12px;
+            }
+        }
+
+        &.selected {
+            a:link:after,
+            a:visited:after {
+                transform: rotate(45deg);
+            }
+        }
+    }
+
+    .detail-container {
+        border-top: 1px solid #fff;
+        border-bottom: 1px solid #fff;
+        padding-top: 20px;
+    }
+
+    .nav-menu-secondary-links > li {
+        @include font-size(16px);
+        margin: 20px 0;
+
+        a:link,
+        a:visited {
+            display: block;
+        }
+    }
+}
+
+/* -------------------------------------------------------------------------- */
+// Common color styles for both primary and side navigation links & headings
+
+.moz-global-nav,
+.moz-global-nav-drawer {
+
+    .item-firefox {
+        a:hover,
+        a:active,
+        a:focus,
+        a.selected,
+        a.currrent {
+            color: $color-firefox-light-orange;
+        }
+    }
+
+    .item-pocket {
+        a:hover,
+        a:active,
+        a:focus,
+        a.selected,
+        a.currrent {
+            color: $color-pocket-red;
+        }
+    }
+
+    .item-internet-health {
+        a:hover,
+        a:active,
+        a:focus,
+        a.selected,
+        a.currrent {
+            color: $color-brand-cyan;
+        }
+    }
+
+    .item-technology {
+        a:hover,
+        a:active,
+        a:focus,
+        a.selected,
+        a.currrent {
+            color: $color-brand-lilac;
+        }
+    }
+
+    .item-about-us {
+        a:hover,
+        a:active,
+        a:focus,
+        a.selected,
+        a.currrent {
+            color: $color-brand-lime;
+        }
+    }
+
+    .item-get-involved {
+        a:hover,
+        a:active,
+        a:focus,
+        a.selected,
+        a.currrent {
+            color: $color-brand-coral;
+        }
+    }
+}
+
+body[data-global-nav-current-link="firefox"] .nav-primary-links .item-firefox {
+    &> a:link,
+    &> a:visited {
+        color: $color-firefox-light-orange;
+    }
+}
+
+body[data-global-nav-current-link="internet-health"] .item-internet-health {
+    &> a:link,
+    &> a:visited {
+        color: $color-brand-cyan;
+    }
+}
+
+body[data-global-nav-current-link="technology"] .item-technology {
+    &> a:link,
+    &> a:visited {
+        color: $color-brand-lilac;
+    }
+}
+
+body[data-global-nav-current-link="about-us"] .item-about-us {
+    &> a:link,
+    &> a:visited {
+        color: $color-brand-lime;
+    }
+}
+
+body[data-global-nav-current-link="get-involved"] .item-get-involved {
+    &> a:link,
+    &> a:visited {
+        color: $color-brand-coral;
+    }
+}
+
+/* -------------------------------------------------------------------------- */
+// Semi-opaque mask shown when side drawer is open.
+
+.moz-global-nav-page-mask {
+    background: #000;
+    bottom: auto;
+    left: 0;
+    opacity: 0;
+    position: absolute;
+    right: auto;
+    top: 0;
+    transition: opacity 0.2s ease-in-out;
+    z-index: 10000;
+}
+
+html.moz-nav-open .moz-global-nav-page-mask {
+    bottom: 0;
+    opacity: 0.3;
+    right: 0;
+    transition: opacity 0.2s ease-in-out;
+}
+
+/* -------------------------------------------------------------------------- */
+// Customized Firefox download button for primary navigation.
+
+#global-nav-download-firefox {
+    float: right;
+    margin: 11px 20px 0 0;
+
+    .download-list {
+        margin: 0;
+
+        &> li {
+            margin: 0;
+        }
+    }
+
+    .download-link:link,
+    .download-link:visited {
+        @include text-display-xxs;
+        background-color: #fff;
+        border-radius: 100px;
+        border: 2px solid $color-button-green;
+        color: $color-button-green;
+        display: inline-block;
+        font-weight: bold;
+        padding: .5em 20px;
+        text-decoration: none;
+        transition: color .1s ease-in-out, background-color .1s ease-in-out;
+
+        .download-title {
+            font-weight: bold;
+        }
+
+        &:hover,
+        &:focus,
+        &:active {
+            background-color: $color-button-green;
+            color: #fff;
+            transition: color .1s ease-in-out, background-color .1s ease-in-out;
+        }
+    }
+
+    @media #{$media-md} {
+        margin-top: 5px;
+        margin-right: 64px;
+        width: 200px;
+
+        .download-link {
+            float: right;
+        }
+    }
+
+    @media #{$media-lg} {
+        margin-right: 95px;
+    }
+
+    .fx-privacy-link {
+        display: none;
+    }
+}
+
+.other #global-nav-download-firefox,
+.oldwin #global-nav-download-firefox,
+.oldmac #global-nav-download-firefox {
+    display: none;
+}
+
+/* -------------------------------------------------------------------------- */
+// Side drawer state rules.
+
+// Default (non-animated) accordion for old browsers.
+.moz-global-nav-drawer {
+
+    .detail {
+        display: none;
+    }
+
+    .summary.selected + .detail {
+        display: block;
+    }
+}
+
+// Animated accordion for newer browsers.
+@supports (transition: max-height .6s ease-in-out, visibility 0s 0s) {
+
+    .moz-global-nav-drawer {
+
+        .detail {
+            display: block;
+            max-height: 0;
+            overflow: hidden;
+            visibility: hidden;
+            transition: max-height .3s ease-in-out, visibility 0s .8s;
+        }
+
+        .summary.selected + .detail {
+            max-height: 1000px;
+            visibility: visible;
+            transition: max-height .6s ease-in-out, visibility 0s 0s;
+        }
+    }
+}
+
+// Default (non-animated) drawer for old browsers.
+body {
+    overflow-x: hidden;
+}
+
+html.moz-nav-open {
+    body {
+        left: 320px;
+        position: relative;
+    }
+}
+
+// Animated drawer for newer browsers.
+@supports (transform: translateX(320px)) {
+    body {
+        position: static;
+        transition: transform .25s ease-in-out;
+    }
+
+    html.moz-nav-open {
+
+        body {
+            left: 0;
+            transition: transform .25s ease-in-out;
+            transform: translateX(320px);
+        }
+
+        .moz-global-nav-drawer {
+            transition: visibility 0s 0s;
+            visibility: visible;
+        }
+    }
+
+    .moz-global-nav-drawer {
+        left: 0;
+        transform: translateX(-320px);
+        transition: visibility 0s .4s;
+        visibility: hidden;
+    }
+
+    @media #{$media-lg} {
+        html.moz-nav-open {
+            height: 100%;
+
+            body {
+                height: 100%;
+                overflow: hidden;
+            }
+        }
+
+        .moz-global-nav-drawer {
+            bottom: auto;
+            height: 100%;
+
+            .nav-menu-inner-container {
+                height: 100%;
+                margin-top: 22px;
+            }
+
+            .nav-menu-scroll-pane {
+                bottom: 100px;
+                overflow-y: scroll;
+                position: absolute;
+                top: 0;
+                width: 254px;
+
+                &::-webkit-scrollbar {
+                    width: 8px;
+                    height: 100%;
+                }
+
+                &::-webkit-scrollbar-track {
+                    background: #000;
+                }
+
+                &::-webkit-scrollbar-thumb {
+                    width: 8px;
+                    height: 8px;
+                    background: #999;
+                    border-radius: 8px;
+                }
+            }
+
+            .nav-menu-primary-links {
+                padding-right: 20px;
+            }
+        }
+    }
+}
+
+/* -------------------------------------------------------------------------- */
+// Styles for JavaScript disabled.
+
+.no-js {
+    #global-nav-download-firefox {
+        display: none;
+    }
+
+    .nav-primary-links {
+        display: block;
+    }
+
+    .moz-global-nav-drawer {
+        display: none;
+    }
+}

--- a/media/css/protocol/components/_masthead.scss
+++ b/media/css/protocol/components/_masthead.scss
@@ -1,0 +1,353 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+@import "../../../../node_modules/@mozilla-protocol/core/protocol/css/includes/lib";
+
+// Download button color
+$color-button-green: #16da00;
+
+
+#masthead {
+    color: #000;
+    min-height: 50px;
+    padding: 0;
+    width: 100%;
+
+    .content {
+        @include border-box;
+        @include clearfix;
+        margin: 0 auto;
+        max-width: $width-content-max;
+        min-width: $width-content-xs;
+        padding: $layout-xs;
+        position: relative;
+
+        @media #{$media-md} {
+            padding: $layout-xs $layout-lg;
+        }
+
+        @media #{$media-lg} {
+            padding: $layout-xs $layout-xl;
+        }
+    }
+
+    .masthead-logo {
+        @include font-size(16px);
+        height: 30px;
+        left: 0;
+        margin: 0;
+        padding: 10px 0;
+        position: absolute;
+        text-align: center;
+        top: 0;
+        width: 100%;
+
+        img {
+            height: 30px;
+        }
+
+        @media #{$media-md} {
+            float: left;
+            position: relative;
+            width: 94px;
+        }
+    }
+
+    .fx-privacy-link {
+        display: none;
+    }
+}
+
+.masthead-nav-main {
+    @include font-size(16px);
+    @include open-sans;
+    font-weight: bold;
+    left: 0;
+    margin: 0 0 0 20px;
+    position: absolute;
+    top: 0;
+    z-index: 99;
+
+    a {
+        text-decoration: none;
+
+        &:hover,
+        &:focus,
+        &:active {
+            text-decoration: underline;
+        }
+    }
+
+    .toggle {
+        @include image-replaced;
+        background: transparent url('/media/img/pebbles/icon-menu-dark.svg') center center no-repeat;
+        @include background-size(22px auto);
+        cursor: pointer;
+        display: block;
+        height: 50px;
+        overflow: hidden;
+        position: relative;
+        width: 50px;
+    }
+
+    .nav-main-menu {
+        background: #fff;
+        box-shadow: 2px 2px 0 rgba(0, 0, 0, .2);
+        left: -300px;
+        margin: 0;
+        overflow: visible;
+        position: absolute;
+        top: 50px;
+        width: 200px;
+        z-index: 99;
+
+        li {
+            border-bottom: 1px solid #ccc;
+
+            &:last-child {
+                border: 0;
+            }
+        }
+
+        a {
+            background: #fff;
+            color: $color-primary;
+            display: block;
+            padding: 10px 20px;
+            text-decoration: none;
+            @include transition(background-color 150ms ease, border-width 150ms ease, color 150ms ease, padding 150ms ease);
+
+            &:hover,
+            &:focus {
+                background-color: #f5f5f5;
+                border-right: 6px solid #000;
+                color: #000;
+                text-decoration: underline;
+            }
+        }
+    }
+}
+
+.masthead-nav-main:hover .nav-main-menu,
+.nav-main-menu:target {
+    left: auto;
+}
+
+.js .masthead-nav-main .nav-main-menu {
+    left: auto;
+    display: none;
+}
+
+@media #{$media-md} {
+
+    .masthead-nav-main {
+        float: left;
+        margin: 0 0 0 20px;
+        position: relative;
+        width: 80%;
+
+        .nav-main-menu {
+            width: auto;
+            position: static;
+            background: transparent;
+            box-shadow: none;
+            padding: 15px 0;
+
+            li {
+                display: inline-block;
+                border: 0;
+                padding: 0 20px 10px 0;
+
+                &:first-child {
+                    border-left: none;
+                }
+            }
+
+            a {
+                background: transparent;
+                display: inline-block;
+                padding: 0;
+
+                &:link,
+                &:visited {
+                    color: #000;
+                }
+
+
+                &:hover,
+                &:focus {
+                    background: transparent;
+                    border: 0;
+                }
+            }
+        }
+
+        .toggle {
+            @include hidden;
+        }
+
+    }
+
+    .js .masthead-nav-main .nav-main-menu {
+        display: block;
+    }
+}
+
+@media #{$media-lg} {
+    .masthead-nav-main {
+        width: 60%;
+
+        .nav-main-menu li {
+            padding: 0 10px;
+        }
+    }
+}
+
+@media #{$media-xl} {
+    .masthead-nav-main {
+        margin: 0 0 0 40px;
+        width: 70%;
+
+        .nav-main-menu li {
+            padding: 0 40px 10px 0;
+        }
+    }
+}
+
+// flexbox layout for savvy browsers to push nav items to the right
+@supports (display: flex) {
+    @media #{$media-md} {
+        .nav-main-menu,
+        .js .nav-main-menu {
+            @include flexbox;
+            @include justify-content(flex-end);
+        }
+    }
+}
+
+[dir="rtl"] #masthead {
+
+    .masthead-nav-main {
+        left: auto;
+        right: 0;
+        margin: 0 20px 0 0;
+
+        .nav-main-menu {
+            a:active,
+            a:focus,
+            a:hover {
+                border-right: none;
+                border-left: 6px solid #000;
+
+                @media #{$media-md} {
+                    border: 0;
+                }
+            }
+        }
+
+        #nav-main-menu li:last-child {
+            border-left: 0;
+            padding-left: 0;
+            padding-right: 5px;
+
+            @media #{$media-md} {
+                padding-right: 10px;
+            }
+
+            @media #{$media-xl} {
+                padding-right: 20px;
+            }
+        }
+    }
+
+    @media #{$media-md} {
+        .masthead-logo,
+        .masthead-nav-main {
+            float: right;
+        }
+    }
+
+    @media #{$media-xl} {
+        .masthead-nav-main {
+            margin: 0 40px 0 0;
+
+            .nav-main-menu li {
+                padding: 0 0 0 40px;
+            }
+        }
+    }
+}
+
+/*--------------------------------------------------------------------------*/
+// Custom Firefox download button for main navigation.
+
+#nav-download-firefox {
+    display: none;
+    float: right;
+    margin: 11px 0 0;
+
+    .download-list {
+        margin: 0;
+
+        &> li {
+            margin: 0;
+        }
+    }
+
+    .download-link:link,
+    .download-link:visited {
+        @include text-body-sm;
+        background-color: #fff;
+        border-radius: 100px;
+        border: 2px solid $color-button-green;
+        color: $color-button-green;
+        display: inline-block;
+        font-weight: bold;
+        padding: .5em 20px;
+        text-decoration: none;
+        transition: color .1s ease-in-out, background-color .1s ease-in-out;
+
+        .download-title {
+            font-weight: bold;
+        }
+
+        &:hover,
+        &:focus,
+        &:active {
+            background-color: $color-button-green;
+            color: #fff;
+            transition: color .1s ease-in-out, background-color .1s ease-in-out;
+        }
+    }
+
+    @media #{$media-lg} {
+        display: block;
+        width: 200px;
+
+        .download-link {
+            float: right;
+        }
+    }
+}
+
+.other #nav-download-firefox,
+.oldwin #nav-download-firefox,
+.oldmac #nav-download-firefox {
+    display: none;
+}
+
+html[dir="rtl"] {
+    #nav-download-firefox {
+        float: left;
+
+        @media #{$media-md} {
+
+            .download-link {
+                float: left;
+            }
+        }
+    }
+}
+
+

--- a/media/css/protocol/oldIE.scss
+++ b/media/css/protocol/oldIE.scss
@@ -1,0 +1,59 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// This style sheet is served exclusively to Internet Explorer 8 and older.
+// Old versions get this minimal style while IE9 and up recieve more advanced styling.
+
+@import "../../../node_modules/@mozilla-protocol/core/protocol/css/includes/lib";
+@import "../../../node_modules/@mozilla-protocol/core/protocol/css/base/elements";
+
+@import "components/download-button";
+
+// An arbitrary container for translatable strings to use in scripts
+#strings {
+    display: none;
+}
+
+body {
+    margin: 20px 30px;
+}
+
+.center {
+    text-align: center;
+}
+
+img {
+    -ms-interpolation-mode: bicubic;
+}
+
+label {
+    display: block;
+}
+
+.masthead .toggle {
+    display: none; /* oldIE never gets a mobile menu. */
+}
+
+/* oldIE never gets slide out drawer */
+.moz-global-nav {
+    .nav-button-menu {
+        display: none;
+    }
+}
+
+.moz-global-nav-drawer {
+    display: none;
+}
+
+#colophon .logo {
+    font-size: 100%;
+}
+
+.visually-hidden {
+    @include visually-hidden;
+}
+
+.hidden {
+    @include hidden;
+}

--- a/media/css/protocol/protocol.scss
+++ b/media/css/protocol/protocol.scss
@@ -6,3 +6,9 @@ $font-path: '/media/fonts';
 $image-path: '/media/protocol/img';
 
 @import "../../../node_modules/@mozilla-protocol/core/protocol/css/protocol.scss";
+
+// TODO port these components to Protocol.
+@import "components/global-nav";
+@import "components/masthead";
+@import "components/footer";
+@import "components/download-button";


### PR DESCRIPTION
## Description
- Adds a new base template for Protocol.
- Ports the following components which do not yet exist in Protocol:
  - Global nav
  - Legacy masthead
  - Download button
  - Footer
- Adds a universal Protocol stylesheet for legacy IE browsers.
- Adds temporary test page for demo purposes.

## Issue / Bugzilla link
https://github.com/mozilla/bedrock/issues/5752

## Testing
Demo page: https://bedrock-demo-agibson.oregon-b.moz.works/en-US/protocol-test/