### PR TITLE
Newsletter logo is too large on low-res screens (Fixes #5761)

### DIFF
--- a/media/css/newsletter/fxnewsletter-subscribe.less
+++ b/media/css/newsletter/fxnewsletter-subscribe.less
@@ -18,6 +18,7 @@
 
     .form-title {
         .at2x('/media/img/logos/firefox/logo-quantum.png', 149px, 149px);
+        .background-size(149px, 149px);
         .span(4);
         background-position: left top;
         background-repeat: no-repeat;


### PR DESCRIPTION
## Description
- Fixes sizing issue for newsletter logo on `/firefox/channel/desktop/` (and othe pages).

## Issue / Bugzilla link
https://github.com/mozilla/bedrock/issues/5761

## Testing
- Test using a low resolution screen.