### PR TITLE
Add Jul-Dec 2017 Transparency Report

### DIFF
--- a/bedrock/mozorg/templates/mozorg/about/policy/transparency/includes/past-reports.html
+++ b/bedrock/mozorg/templates/mozorg/about/policy/transparency/includes/past-reports.html
@@ -7,6 +7,7 @@
 <nav class="content nav-previous">
   <h3>{{ _('Previous Reports') }}</h3>
   <ul>
+    <li><a href="{{ url('mozorg.about.policy.transparency.jan-jun-2017') }}">{{ _('January-June 2017') }}</a></li>
     <li><a href="{{ url('mozorg.about.policy.transparency.jul-dec-2016') }}">{{ _('July-December 2016') }}</a></li>
     <li><a href="{{ url('mozorg.about.policy.transparency.jan-jun-2016') }}">{{ _('January-June 2016') }}</a></li>
     <li><a href="{{ url('mozorg.about.policy.transparency.jan-dec-2015') }}">{{ _('January-December 2015') }}</a></li>

--- a/bedrock/mozorg/templates/mozorg/about/policy/transparency/includes/reports-nav.html
+++ b/bedrock/mozorg/templates/mozorg/about/policy/transparency/includes/reports-nav.html
@@ -3,6 +3,7 @@
           <li><a href="{{ url('mozorg.about.policy.transparency.index') + '#faq' }}">{{ _('FAQ') }}</a></li>
           <li><a href="{{ url('mozorg.about.policy.transparency.index') + '#definitions' }}">{{ _('Definitions') }}</a></li>
           {# This link should point to the latest report. Past reports are added to 'includes/past-reports.html' #}
-          <li><a href="{{ url('mozorg.about.policy.transparency.jan-jun-2017') }}">{{ _('January-June 2017 Report') }}</a></li>
+          {# There are also links in the faq that need to be updated to point to the latest report. #}
+          <li><a href="{{ url('mozorg.about.policy.transparency.jul-dec-2017') }}">{{ _('July-December 2017 Report') }}</a></li>
         </ul>
       </nav>

--- a/bedrock/mozorg/templates/mozorg/about/policy/transparency/index.html
+++ b/bedrock/mozorg/templates/mozorg/about/policy/transparency/index.html
@@ -59,10 +59,10 @@
               <p>
                 {# NOTE: Remember to update these links when publishing a new report. #}
                 {% trans
-                  link_userdata=url('mozorg.about.policy.transparency.jan-jun-2017') + '#government-user-data',
-                  link_removal=url('mozorg.about.policy.transparency.jan-jun-2017') + '#government-content-removal',
-                  link_copytrade=url('mozorg.about.policy.transparency.jan-jun-2017') + '#copyright-trademark',
-                  link_supplement=url('mozorg.about.policy.transparency.jan-jun-2017') + '#supplement'
+                  link_userdata=url('mozorg.about.policy.transparency.jul-dec-2017') + '#government-user-data',
+                  link_removal=url('mozorg.about.policy.transparency.jul-dec-2017') + '#government-content-removal',
+                  link_copytrade=url('mozorg.about.policy.transparency.jul-dec-2017') + '#copyright-trademark',
+                  link_supplement=url('mozorg.about.policy.transparency.jul-dec-2017') + '#supplement'
                 %}
                   We report on <a href="{{ link_userdata }}">Government Demands for User Data</a>, <a href="{{ link_removal }}">Government Requests for Content Removal</a>, and <a href="{{ link_copytrade }}">Copyright and Trademark Requests</a>. We also include a <a href="{{ link_supplement }}">Supplement</a>, which provides additional information.
                 {% endtrans %}
@@ -87,6 +87,29 @@
                 {{ _('Recipients of <a href="%s">National Security Requests</a> can only publish reporting bands instead of specific figures.')|format(url('mozorg.about.policy.transparency.index') + '#dfn-natl-security-request') }}
                 {{ _('If we receive such a request, we may challenge these reporting bands, in addition to opposing any unlawful or overbroad requests.') }}
               </p>
+            </div>
+          </section>
+
+          <section>
+            <h3 data-accordion-role="tab">{{ ('How does Mozilla handle Gag Orders?') }}</h3>
+            <div data-accordion-role="tabpanel">
+              <p>
+                {{ _('We don’t believe it is appropriate for the government to indefinitely delay a company from providing user notice.  We will take steps to enforce this belief for gag orders that meet any of the following criteria:') }}
+              </p>
+
+              <p>
+                {{ _('<strong>Unreasonable Duration</strong> - Any gag order with an unspecified duration or with a duration longer than one year.  This time period may be changed if specific facts in the case lead us to believe that a longer time period is reasonable.  We support policy proposals to codify into a federal statute shorter durations of one year or less, consistent with Section 9-13.700 of the DOJ U.S. Attorneys’ Manual.') }}
+              </p>
+              <p>
+                {{ _('<strong>Unreasonable Scope</strong> - Any gag order that would prevent us from disclosing the existence of legal process in our transparency report.') }}
+              </p>
+              <p>
+                {{ _('<strong>Unreasonable Number of Impacted Users</strong> - Any gag order that appears to affect more than 50 users, or where specific facts suggest that the order affects users we can reasonably determine are unrelated to the activity under investigation, such as users of a shared computer or IP address.') }}
+              </p>
+              <p>
+                {{ _('<strong>Unreasonable Impact on Free Expression</strong> - Specific facts of the case raise free expression issues (such as cases involving journalists or the press). ') }}
+              </p>
+
             </div>
           </section>
 

--- a/bedrock/mozorg/templates/mozorg/about/policy/transparency/jul-dec-2017.html
+++ b/bedrock/mozorg/templates/mozorg/about/policy/transparency/jul-dec-2017.html
@@ -1,0 +1,255 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+
+{% extends "mozorg/about/policy/transparency/report-base.html" %}
+
+{% block page_title %}{{ _('Transparency Report - July-December, 2017') }}{% endblock %}
+
+{% block report_title %}
+  <h1>{{ _('Transparency Report') }} <span>{{ _('Reporting Period: July 1, 2017 to December 31, 2017') }}</span></h1>
+{% endblock %}
+
+{% block report_body %}
+  <section class="section" id="government-user-data">
+    <h2 class="section-title" data-accordion-role="tab">{{ _('Government Demands for User Data') }}</h2>
+
+    <div class="content" data-accordion-role="tabpanel">
+      <p>
+        {{ _('In the Reporting Period, Mozilla received 1 Court Order for user data.') }}
+      </p>
+
+      <table class="table">
+        <thead>
+          <tr>
+            <th scope="col">{{ _('Legal Processes') }}</th>
+            <th scope="col">{{ _('Received') }}</th>
+            <th scope="col">{{ _('Data Produced') }}</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <th scope="row">
+              <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-search-warrant' }}">{{ _('Search Warrants') }}</a>
+            </th>
+            <td>0</td>
+            <td>{{ _('N/A') }}</td>
+          </tr>
+          <tr>
+            <th scope="row">
+              <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-subpoena' }}">{{ _('Subpoenas') }}</a>
+            </th>
+            <td>0</td>
+            <td>{{ _('N/A') }}</td>
+          </tr>
+          <tr>
+            <th scope="row">
+              <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-court-order' }}">{{ _('Court Orders') }}</a>
+            </th>
+            <td>1</td>
+            <td>{{ _('Yes') }}</td>
+          </tr>
+          <tr>
+            <th scope="row">
+              <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-wiretap-order' }}">{{ _('Wiretap Orders') }}</a>
+            </th>
+            <td>0</td>
+            <td>{{ _('N/A') }}</td>
+          </tr>
+          <tr>
+            <th scope="row">
+              <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-pen-register-order' }}">{{ _('Pen Register Orders') }}</a>
+            </th>
+            <td>0</td>
+            <td>{{ _('N/A') }}</td>
+          </tr>
+          <tr>
+            <th scope="row">
+              <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-emergency-request' }}">{{ _('Emergency Requests') }}</a>
+            </th>
+            <td>0</td>
+            <td>{{ _('N/A') }}</td>
+          </tr>
+          <tr>
+            <th scope="row">
+              <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-natl-security-request' }}">{{ _('National Security Requests') }}</a> <sup><a href="#footnote-1">1</a></sup>
+            </th>
+            <td>0</td>
+            <td>{{ _('N/A') }}</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <aside class="footnotes">
+        <section id="footnote-1">
+          <p>{{ _('1. Mozilla has never received a National Security Request.') }}</p>
+        </section>
+      </aside>
+    </div>
+  </section>
+
+  <section class="section" id="government-content-removal">
+    <h2 class="section-title" data-accordion-role="tab">{{ _('Government Demands for Content Removal') }}</h2>
+
+    <div class="content" data-accordion-role="tabpanel">
+      <p>{{ _('In the Reporting Period, Mozilla did not receive any government requests for content removal from our services.') }}</p>
+
+      <table class="table">
+        <thead>
+          <tr>
+            <th scope="col">{{ _('Requesting Country') }}</th>
+            <th scope="col">{{ _('Requests Received') }}</th>
+            <th scope="col">{{ _('Data Produced') }}</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <th scope="row">{{ _('N/A') }}</th>
+            <td>0</td>
+            <td>{{ _('N/A') }}</td>
+          </tr>
+        </tbody>
+      </table>
+
+    </div>
+  </section>
+
+  <section class="section" id="copyright-trademark">
+    <h2 class="section-title" data-accordion-role="tab">{{ _('Copyright and Trademark Requests') }}</h2>
+
+    <div class="content" data-accordion-role="tabpanel">
+      <h3>{{ _('Copyright') }}</h3>
+      <p>{{ _('In the Reporting Period, we received 7 Copyright Takedown Notices and 0 Counter Notices.') }}</p>
+
+      <table class="table">
+        <thead>
+          <tr>
+            <th scope="col">{{ _('Mozilla Service') }}</th>
+            <th scope="col">
+              <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-takedown-notice' }}">{{ _('Takedown Notices') }}</a>
+            </th>
+            <th scope="col">
+              <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-counter-notice' }}">{{ _('Counter Notices') }}</a>
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <th scope="row">{{ _('Firefox Add-ons') }}</th>
+            <td>7</td>
+            <td>0</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <h3>{{ _('Trademark') }}</h3>
+      <p>{{ _('In the Reporting Period, we received 7 Trademark Takedown Notices and 0 Counter Notices.') }}</p>
+
+      <table class="table">
+        <thead>
+          <tr>
+            <th scope="col">{{ _('Mozilla Service') }}</th>
+            <th scope="col">
+              <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-takedown-notice' }}">{{ _('Takedown Notices') }}</a>
+            </th>
+            <th scope="col">
+              <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-counter-notice' }}">{{ _('Counter Notices') }}</a>
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <th scope="row">{{ _('Firefox Add-ons') }}</th>
+            <td>7</td>
+            <td>0</td>
+          </tr>
+        </tbody>
+      </table>
+
+    </div>
+  </section>
+
+  <section class="section" id="supplement">
+    <h2 class="section-title" data-accordion-role="tab">{{ _('Supplement') }}</h2>
+
+    <div class="content" data-accordion-role="tabpanel">
+      <h3>{{ _('Legislative Reform') }}</h3>
+
+      <p>
+        {% trans charter='https://blog.mozilla.org/netpolicy/2017/11/15/white-house-releases-new-vep-charter/',
+                 advocated='https://blog.mozilla.org/netpolicy/2017/10/03/vulnerability-disclosure-should-be-in-new-eu-cybersecurity-strategy/' %}
+          In the Reporting Period, Mozilla continued to push for reforms to the
+          U.S. Government’s process for handling security vulnerabilities,
+          culminating in the release by the White House of a
+          <a href="{{ charter }}">new charter</a> for the Vulnerabilities
+          Equities Process. We also <a href="{{ advocated }}">advocated</a> for
+          European governments to develop government vulnerability disclosure
+          review processes to be included in the forthcoming EU Cybersecurity
+          Act, including as members of the Centre for European Policy Studies
+          Task Force on Software Vulnerability Disclosure.
+        {% endtrans %}
+      </p>
+      <p>
+        {% trans vocal='https://blog.mozilla.org/netpolicy/2017/11/16/need-aadhaar-to-investigate-lost-package/',
+                 regulation='https://blog.mozilla.org/netpolicy/2017/10/12/mozilla-releases-recommendations-draft-eu-eprivacy-regulation/',
+                 crossborder='https://blog.mozilla.org/netpolicy/files/2017/10/Mozilla-e-evidence-submission.pdf',
+                 copyright='http://copybuzz.com/copyright/interview-raegan-macdonald/' %}
+          We’ve been <a href="{{ vocal }}">vocal</a> in the debate around
+          India’s first data protection law, and we continued to engage with
+          Europe’s <a href="{{ regulation }}">e-Privacy Regulation</a>. We've
+          also contributed to the development of the EU's approach to
+          <a href="{{ crossborder }}">cross-border access to data</a>, and
+          worked to influence the EU Commission’s ongoing
+          <a href="{{ copyright }}">copyright reform</a> efforts.
+        {% endtrans %}
+      </p>
+      <p>
+        {% trans urging='https://blog.mozilla.org/wp-content/uploads/2017/08/No.-16-402-ac-Technology-Companies1.pdf' %}
+          In July 2017, Mozilla joined with other technology companies in an amicus brief urging the Supreme Court of the United States to reexamine how the 4th Amendment and search warrant requirements should apply in our digital era.
+        {% endtrans %}
+      </p>
+
+      <h3>{{ _('Threat Indicators &amp; Data Disclosures') }}</h3>
+      <table class="table">
+        <thead>
+          <tr>
+            <th scope="col">{{ _('Type of Disclosure') }}</th>
+            <th scope="col">{{ _('Number of Disclosures') }}</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <th scope="row"><a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-threat-indicator' }}">{{ _('Cybersecurity Threat Indicator') }}</a></th>
+            <td>0</td>
+          </tr>
+          <tr>
+            <th scope="row">{{ _('Other <a href="%s">Specific User</a> Data Disclosure')|format(url('mozorg.about.policy.transparency.index') + '#dfn-specific-user') }}</th>
+            <td>1<sup>*</sup></td>
+          </tr>
+        </tbody>
+      </table>
+
+      <footer class="footnotes">
+        <p class="footnote" id="footnote1">
+        {% trans link_cybertipline='http://www.missingkids.org/cybertipline' %}
+          * Information about possible child sexual exploitation can be voluntarily reported by anyone to the National Center for Missing & Exploited Children’s (NCMEC) <a href="{{ link_cybertipline }}">CyberTipline</a>. We take this issue seriously. In the Reporting Period, Mozilla disclosed Specific User data to the NCMEC in connection with content that was uploaded to a Mozilla service and implicated child sexual exploitation.
+        {% endtrans %}
+        </p>
+      </footer>
+
+    </div>
+  </section>
+{% endblock %}
+
+{% block report_nav %}
+  <aside class="section nav-block">
+    <nav class="content nav-report two-up">
+      <ul>
+        <li><a href="{{ url('mozorg.about.policy.transparency.index') + '#faq' }}">{{ _('FAQ') }}</a></li>
+        <li><a href="{{ url('mozorg.about.policy.transparency.index') + '#definitions' }}">{{ _('Definitions') }}</a></li>
+      </ul>
+    </nav>
+
+    {% include 'mozorg/about/policy/transparency/includes/past-reports.html' %}
+  </aside>
+{% endblock %}

--- a/bedrock/mozorg/urls.py
+++ b/bedrock/mozorg/urls.py
@@ -79,6 +79,8 @@ urlpatterns = (
          'mozorg/about/policy/transparency/jul-dec-2016.html'),
     page('about/policy/transparency/jan-jun-2017',
          'mozorg/about/policy/transparency/jan-jun-2017.html'),
+    page('about/policy/transparency/jul-dec-2017',
+         'mozorg/about/policy/transparency/jul-dec-2017.html'),
 
     page('contact', 'mozorg/contact/contact-landing.html'),
     page('contact/spaces', 'mozorg/contact/spaces/spaces-landing.html'),


### PR DESCRIPTION
## Description
- Add Jul-Dec 2017 report
- Update links on landing page to link to newest report
- Add previous report to list of previous reports
- Add new question to FAQ

## Localization
-  The transparency report has not been localized in the past.

## Issue / Bugzilla link
Closes mozilla/bedrock#5747

## Testing
- check I found all the links to the old report