### PR TITLE
Fix Bug 1466834 - Rename or merge HTML5 section on Firefox release notes

### DIFF
--- a/bedrock/firefox/templates/firefox/releases/nightly-feed.xml
+++ b/bedrock/firefox/templates/firefox/releases/nightly-feed.xml
@@ -24,7 +24,7 @@
     <updated>{{ note.modified.isoformat() }}</updated>
     <content type="xhtml">
       <div xmlns="http://www.w3.org/1999/xhtml">
-        {{ note.version }} / {{ note.tag }}
+        {{ note.version }} / {{ note.tag|replace('HTML5', _('Web Platform')) }}
         {%- if note.bug %} / <a href="https://bugzilla.mozilla.org/show_bug.cgi?id={{ note.bug }}">{{ _('Bug %d')|format(note.bug) }}</a>{% endif %}
         {{ note.note|markdown|safe }}
       </div>

--- a/bedrock/firefox/templates/firefox/releases/release-notes.html
+++ b/bedrock/firefox/templates/firefox/releases/release-notes.html
@@ -246,8 +246,8 @@
 
           {% for note in release.notes if note.tag == "HTML5" %}
             {% if loop.first %}
-            <div class="section-wrapper" id="{{ note.tag|lower() }}">
-              <h4>{{ note.tag }}</h4>
+            <div class="section-wrapper" id="web-platform">
+              <h4>{{ _('Web Platform') }}</h4>
               <ul class="section-items">
               {% endif %}
               {{ note_entry(note) }}

--- a/media/css/firefox/releasenotes-firefox.less
+++ b/media/css/firefox/releasenotes-firefox.less
@@ -340,7 +340,7 @@ ul.section-items {
     font-family: 'Font Awesome';
     margin-right: .2em;
 }
-#html5 h4:before {
+#web-platform h4:before {
     content: '\00A0\f121\00A0';
     font-family: 'Font Awesome';
     margin-right: .2em;


### PR DESCRIPTION
## Description

Rename the **HTML5** section on the [Firefox release notes](https://www.mozilla.org/en-US/firefox/62.0a1/releasenotes/) to **Web Platform** to reflect the reality. This just changes the label in HTML and Atom feed so the backward compatibility in Nucleus will be maintained.

## Issue / Bugzilla link

[Bug 1466834 - Rename or merge HTML5 section on Firefox release notes](https://bugzilla.mozilla.org/show_bug.cgi?id=1466834)

## Testing

Open the 62.0a1 notes to see the new label like this:

![screen shot 2018-06-05 at 10 02 51](https://user-images.githubusercontent.com/2929505/40981234-76355b58-68a8-11e8-9cf2-d5c57173da69.png)