### PR TITLE
Switch back to using port 8000 for local dev

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,13 +12,13 @@ services:
     image: mozorg/bedrock_assets:${GIT_COMMIT:-latest}
     command: gulp watch
     ports:
-      - "3000:3000"
-      - "3001:3001"
+      - "8000:8000"
+      - "8001:8001"
     volumes:
       - ./media/:/app/media:delegated
       - ./bedrock/:/app/bedrock:delegated
     environment:
-      BS_PROXY_URL: "app:8000"
+      BS_PROXY_URL: "app:8080"
       BS_OPEN_BROWSER: "false"
 
   # the django app
@@ -27,10 +27,10 @@ services:
       context: .
       target: devapp
     image: mozorg/bedrock_test:${GIT_COMMIT:-latest}
-    command: python manage.py runserver 0.0.0.0:8000
+    command: python manage.py runserver 0.0.0.0:8080
     env_file: .env
     ports:
-      - "8000:8000"
+      - "8080:8080"
     volumes:
       - ./bedrock/:/app/bedrock:delegated
       - ./bin/:/app/bin:delegated

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -41,7 +41,7 @@ Linux subsystem) you can run a script that will pull our production docker image
         $ make run
 
 You should see a number of things happening, but when it's done it will output something saying that the server is running
-at `localhost:3000 <http://localhost:3000/>`_. Go to that URL in a browser and you should see the mozilla.org home page.
+at `localhost:8000 <http://localhost:8000/>`_. Go to that URL in a browser and you should see the mozilla.org home page.
 In this mode the site will refresh itself when you make changes to any template or media file. Simply open your editor of
 choice and modify things and you should see those changes reflected in your browser.
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -330,15 +330,19 @@ gulp.task('all:watch', ['js:compile', 'css:compile'], () => {
  * Start the browser-sync daemon for local development.
  */
 gulp.task('browser-sync', ['all:watch'], () => {
-    const proxyURL = process.env.BS_PROXY_URL || 'localhost:8000';
+    const proxyURL = process.env.BS_PROXY_URL || 'localhost:8080';
     const openBrowser = !(process.env.BS_OPEN_BROWSER === 'false');
     return browserSync.init({
+        port: 8000,
         proxy: proxyURL,
         open: openBrowser,
         notify: true,
         reloadDelay: 300,
         reloadDebounce: 500,
         injectChanges: false,
+        ui: {
+            port: 8001
+        },
         serveStatic: [{
             route: '/media',
             dir: finalDir

--- a/package.json
+++ b/package.json
@@ -47,6 +47,6 @@
     "browser-sync": "/.bin/browser-sync"
   },
   "scripts": {
-    "start": "concurrently --kill-others \"python manage.py runserver\" \"gulp\""
+    "start": "concurrently --kill-others \"python manage.py runserver 0.0.0.0:8080\" \"gulp\""
   }
 }


### PR DESCRIPTION
Many docs and some external services are configured for port 8000, so let's keep it.