### PR TITLE
Fix #5783 - URLs available to resolve +/- trailing slash

### DIFF
--- a/bedrock/firefox/urls.py
+++ b/bedrock/firefox/urls.py
@@ -30,7 +30,7 @@ urlpatterns = (
     url(r'^firefox/(?:%s/)?(?:%s/)?all/$' % (platform_re, channel_re),
         views.all_downloads, name='firefox.all'),
     page('firefox/accounts', 'firefox/accounts.html'),
-    url('^firefox/accounts/features',
+    url('^firefox/accounts/features/$',
         VariationTemplateView.as_view(
             template_name='firefox/accounts-features.html',
             template_context_variations=['a', 'b']),
@@ -64,7 +64,7 @@ urlpatterns = (
         name='firefox.features.private-browsing'),
     page('firefox/features/send-tabs', 'firefox/features/send-tabs.html'),
     page('firefox/features/sync', 'firefox/features/sync.html'),
-    url(r'^firefox/ios/testflight', views.ios_testflight, name='firefox.ios.testflight'),
+    url(r'^firefox/ios/testflight/$', views.ios_testflight, name='firefox.ios.testflight'),
     page('firefox/mobile', 'firefox/mobile.html'),
     url('^firefox/send-to-device-post/$', views.send_to_device_ajax,
         name='firefox.send-to-device-post'),
@@ -105,7 +105,7 @@ urlpatterns = (
         {'product': 'Firefox'}, name='firefox.releases.index'),
 
     # Bug 1108828. Different templates for different URL params.
-    url('firefox/feedback', views.FeedbackView.as_view(), name='firefox.feedback'),
+    url('firefox/feedback/$', views.FeedbackView.as_view(), name='firefox.feedback'),
 
     url('^firefox/stub_attribution_code/$', views.stub_attribution_code,
         name='firefox.stub_attribution_code'),

--- a/bedrock/newsletter/urls.py
+++ b/bedrock/newsletter/urls.py
@@ -37,7 +37,7 @@ urlpatterns = (
         name='newsletter.country'),
 
     # Request recovery message with link to manage subscriptions
-    url('^newsletter/recovery/',
+    url('^newsletter/recovery/$',
         views.recovery,
         name='newsletter.recovery'),
 
@@ -47,7 +47,7 @@ urlpatterns = (
         name='newsletter.subscribe'),
 
     # Welcome program out-out confirmation page (bug 1442129)
-    url('^newsletter/opt-out-confirmation/',
+    url('^newsletter/opt-out-confirmation/$',
         views.recovery,
         name='newsletter.opt-out-confirmation'),
 

--- a/bedrock/security/urls.py
+++ b/bedrock/security/urls.py
@@ -35,7 +35,7 @@ urlpatterns = (
         AdvisoriesView.as_view(), name='security.advisories'),
     url(r'^advisories/mfsa(?P<pk>\d{4}-\d{2,3})/$',
         AdvisoryView.as_view(), name='security.advisory'),
-    url(r'^advisories/cve-feed\.json', mitre_cve_feed, name='security.advisories.cve_feed'),
+    url(r'^advisories/cve-feed\.json$', mitre_cve_feed, name='security.advisories.cve_feed'),
 
     page('known-vulnerabilities', 'security/known-vulnerabilities.html'),
     page('known-vulnerabilities/older-vulnerabilities', 'security/older-vulnerabilities.html'),


### PR DESCRIPTION
## Description
All urls should end with a trailing slash, fix places where they're missing.

## Issue / Bugzilla link
Closes https://github.com/mozilla/bedrock/issues/5783

## Testing
Pages without trailing slash redirect 301 to the one with trailing slash.