### PR TITLE
Fix DOM nesting

### DIFF
--- a/bedrock/firefox/templates/firefox/accounts-features.html
+++ b/bedrock/firefox/templates/firefox/accounts-features.html
@@ -41,9 +41,9 @@
       <div class="content">
         <h1 class="fab-head-title">{{_('Firefox Account')}}</h1>
         <p class="fab-head-subtitle">{{_('One easy login.<br> Epic perks.')}}</p>
-        <p class="fab-head-cta">
+        <div class="fab-head-cta">
           {{ fxa_create_account_button('primary cta', 'features-header', 'may2018', 'fxa.features', utm_content, 'account-features') }}
-        </p>
+        </div>
       </div>
     </header>
 


### PR DESCRIPTION
## Description
The button macro contains block level elements that can't be nested in a `<p>`. Change the `<p>` to a `<div>`.

## Issue / Bugzilla link
https://github.com/mozilla/bedrock/pull/5749#issuecomment-395673226

## Testing
