### PR TITLE
Fix color contrast on links within Firefox homepage banner (Fixes #5820)

### DIFF
--- a/media/css/mozorg/home/home-2018.scss
+++ b/media/css/mozorg/home/home-2018.scss
@@ -85,6 +85,10 @@ $callout-blue: #0060df;
     margin-top: $margin-lg;
 }
 
+.download-button {
+    @include light-links;
+}
+
 @media #{$media-md} {
     #download-primary {
         margin-top: 0;


### PR DESCRIPTION
## Description
Fixes system requirements link color contrast on home page

## Issue / Bugzilla link
#5820

## Testing
- A quck way to test this PR is to set a class on `oldmac` on the `<html>` element when viewing the home page (replacing your regular OS e.g. `osx`).