### PR TITLE
[fix #5829] xfail releasenotes timed cache test.

### DIFF
--- a/bedrock/releasenotes/tests/test__utils.py
+++ b/bedrock/releasenotes/tests/test__utils.py
@@ -1,3 +1,4 @@
+import pytest
 import time
 
 from mock import Mock, patch
@@ -39,6 +40,9 @@ class TestReleaseMemoizer(TestCase):
         memoizer._memoize_version(mem_func)
         assert gdv_cache.call_count == 2
 
+    # This test passes in Jenkins but fails in Circle (likely race condition).
+    # xfail for now, but should either improve/change test or remove.
+    @pytest.mark.xfail
     def test_calls_function_when_version_changes(self, gdv_cache):
         """Memoized function should be called after timeout or version change.
 


### PR DESCRIPTION
## Description

Marks failing* `/releasenotes` util test with `xfail`.

* Only seems to fail in Circle, but not in Jenkins or locally.
