### PR TITLE
Fix Bug 1461220: Add prose class to lists

### DIFF
--- a/bedrock/mozorg/templates/mozorg/about/governance/policies/security/certs/policy.html
+++ b/bedrock/mozorg/templates/mozorg/about/governance/policies/security/certs/policy.html
@@ -21,7 +21,8 @@
    # 3. Process the markdown and copy the results: grip policy.md --export --no-inline
    # 4. Paste the document contents in `policy.html` (minus header and footer) below.
    # 5. Add the `<span class="highlight"></span>` element around the `<h1>`.
-   # 6. Clean up Github specific anchor markup.
+   # 6. Add `class=prose` to any `<ol>` or `<ul>` elements
+   # 7. Clean up Github specific anchor markup.
    #}
   <h1><span class="highlight">Mozilla Root Store Policy</span></h1>
   <p><em>Version 2.5</em></p>
@@ -47,7 +48,7 @@
   <h3 id="scope">1.1 Scope</h3>
   <p>This policy applies, as appropriate, to certificates matching any of the
     following (and the CAs which control or issue them):</p>
-  <ol>
+  <ol class="prose">
     <li>
       <p>CA certificates included in, or under consideration for inclusion in, the
         Mozilla root program.</p>
@@ -57,7 +58,7 @@
         to such a CA certificate and which are not technically constrained to
         prevent issuance of working server or email certificates. Such technical
         constraints could consist of either:</p>
-      <ul>
+      <ul class="prose">
         <li>an Extended Key Usage (EKU) extension which does not contain any of
           these KeyPurposeIds: anyExtendedKeyUsage, id-kp-serverAuth,
           id-kp-emailProtection; or:</li>
@@ -69,7 +70,7 @@
       <p>End-entity certificates which have at least one valid, unrevoked chain up
         to such a CA certificate through intermediate certificates which are all in
         scope, such end-entity certificates having either:</p>
-      <ul>
+      <ul class="prose">
         <li>an Extended Key Usage (EKU) extension which contains one or more of these
           KeyPurposeIds: anyExtendedKeyUsage, id-kp-serverAuth,
           id-kp-emailProtection; or:</li>
@@ -96,7 +97,7 @@
   <h2 id="certificate-authorities">2. Certificate Authorities</h2>
   <h3 id="ca-operations">2.1 CA Operations</h3>
   <p>CAs whose certificates are included in Mozilla's root program MUST:</p>
-  <ol>
+  <ol class="prose">
     <li>provide some service relevant to typical users of our software
       products;</li>
     <li>follow industry best practice for securing their networks, for example
@@ -123,7 +124,7 @@
   <h3 id="validation-practices">2.2 Validation Practices</h3>
   <p>We consider verification of certificate signing requests to be acceptable if it
     meets or exceeds the following requirements:</p>
-  <ol>
+  <ol class="prose">
     <li>All information that is supplied by the certificate subscriber
       MUST be verified by using an independent source of information
       or an alternative communication channel before it is included in
@@ -158,7 +159,7 @@
     places where this policy takes precedence over the Baseline Requirements. If
     you find an inconsistency that is not listed here, notify Mozilla so the item
     can be considered for addition or clarification.</p>
-  <ul>
+  <ul class="prose">
     <li>
       <p>Insofar as the Baseline Requirements attempt to define their own scope, the
         scope of this policy (section 1.1) overrides that. Mozilla thus requires CA
@@ -180,7 +181,7 @@
   <h4 id="audit-criteria">3.1.1 Audit Criteria</h4>
   <p>We consider the criteria for CA operations published in the
     following documents to be acceptable:</p>
-  <ul>
+  <ul class="prose">
     <li>WebTrust "<a href="http://www.webtrust.org/homepage-documents/item54279.pdf">Principles and Criteria for Certification Authorities - Version
       2.0</a>" or later in <a href="http://www.webtrust.org/homepage-documents/item27839.aspx">WebTrust Program for Certification
       Authorities</a>;</li>
@@ -216,11 +217,11 @@
   <h5 id="webtrust">3.1.2.1 WebTrust</h5>
   <p>If being audited to the WebTrust criteria, the following audit requirements
     apply (see section 3.1.1 for specific version numbers):</p>
-  <ul>
+  <ul class="prose">
     <li>
       <p>For the SSL trust bit, a CA and all subordinate CAs technically capable
         of issuing server certificates must have all of the following audits:</p>
-      <ul>
+      <ul class="prose">
         <li><a href="http://www.webtrust.org/homepage-documents/item54279.pdf">WebTrust for CAs</a></li>
         <li><a href="http://www.webtrust.org/principles-and-criteria/docs/item83987.pdf">WebTrust for CAs - SSL Baseline with Network Security</a></li>
         <li>
@@ -230,7 +231,7 @@
     <li>
       <p>For the email trust bit, a CA and all subordinate CAs technically capable
         of issuing email certificates must have all of the following audits:</p>
-      <ul>
+      <ul class="prose">
         <li><a href="http://www.webtrust.org/homepage-documents/item54279.pdf">WebTrust for CAs</a></li>
       </ul>
     </li>
@@ -238,13 +239,13 @@
   <h5 id="etsi">3.1.2.2 ETSI</h5>
   <p>If being audited to the ETSI criteria, the following audit requirements apply
     (see section 3.1.1 for version numbers):</p>
-  <ul>
+  <ul class="prose">
     <li>
       <p>For the SSL trust bit, a CA and all subordinate CAs technically
         capable of issuing server certificates must have one of the
         following audits, with at least one of the noted policies or sets of
         policies:</p>
-      <ul>
+      <ul class="prose">
         <li>
           <a href="http://www.etsi.org/deliver/etsi_ts/102000_102099/102042/02.03.01_60/ts_102042v020301p.pdf">ETSI TS 102 042</a> (DVCP, OVCP, or PTC-BR)</li>
         <li>
@@ -260,7 +261,7 @@
       <p>For the email trust bit, a CA and all subordinate CAs technically
         capable of issuing email certificates must have one of the
         following audits, with at least one of the noted policies:</p>
-      <ul>
+      <ul class="prose">
         <li><a href="http://www.etsi.org/deliver/etsi_ts/101400_101499/101456/01.04.03_60/ts_101456v010403p.pdf">ETSI TS 101 456</a></li>
         <li>
           <a href="http://www.etsi.org/deliver/etsi_ts/102000_102099/102042/02.03.01_60/ts_102042v020301p.pdf">ETSI TS 102 042</a> (LCP, NCP, or NCP+)</li>
@@ -288,7 +289,7 @@
   <h4 id="public-audit-information">3.1.4 Public Audit Information</h4>
   <p>The publicly-available documentation relating to each audit MUST contain at
     least the following clearly-labelled information:</p>
-  <ol>
+  <ol class="prose">
     <li>name of the company being audited;</li>
     <li>name and address of the organization performing the audit;</li>
     <li>Distinguished Name and SHA256 fingerprint of each root and intermediate
@@ -319,7 +320,7 @@
   <p>We rely on publicly disclosed documentation (e.g., in a Certificate Policy and
     Certification Practice Statement) to ascertain that our requirements are met.
     Therefore, the following MUST be true:</p>
-  <ol>
+  <ol class="prose">
     <li>
       <p>the publicly disclosed documentation provides sufficient
         information for Mozilla to determine whether and how the CA
@@ -332,7 +333,7 @@
     <li>
       <p>CPs and CPSes are made available to Mozilla under one
         of the following Creative Commons licenses (or later versions):</p>
-      <ul>
+      <ul class="prose">
         <li>Attribution (<a href="https://creativecommons.org/licenses/by/4.0/">CC-BY</a>) 4.0</li>
         <li>Attribution-ShareAlike (<a href="https://creativecommons.org/licenses/by-sa/4.0/">CC-BY-SA</a>) 4.0</li>
         <li>Attribution-NoDerivs (<a href="https://creativecommons.org/licenses/by-nd/4.0/">CC-BY-ND</a>) 4.0</li>
@@ -359,7 +360,7 @@
   <p>Mozilla has requirements for the use of the CCADB above and beyond those in the
     CCADB Policy, as follows:</p>
   <h3 id="additional-requirements">4.1 Additional Requirements</h3>
-  <ul>
+  <ul class="prose">
     <li>If the revocation of an intermediate certificate chaining up to a root in
       Mozilla’s root program is due to a security concern, as well as performing the
       actions defined in the CCADB Policy, a <a href="https://bugzilla.mozilla.org/enter_bug.cgi?product=NSS&amp;component=CA%20Certificate%20Mis-Issuance&amp;groups=crypto-core-security">security bug must be filed in
@@ -374,12 +375,12 @@
   <p>Root certificates in our root program, and any certificate which
     chains up to them, MUST use only algorithms and key sizes from the following
     set:</p>
-  <ul>
+  <ul class="prose">
     <li>RSA keys whose modulus size in bits is divisible by 8, and is at
       least 2048.</li>
     <li>Digest algorithms: SHA-1 (see below), SHA-256, SHA-384, or SHA-512.</li>
     <li>ECDSA keys using one of the following curve-hash pairs:
-      <ul>
+      <ul class="prose">
         <li>P‐256 with SHA-256</li>
         <li>P‐384 with SHA-384</li>
       </ul>
@@ -388,10 +389,10 @@
   <h4 id="sha-1">5.1.1 SHA-1</h4>
   <p>CAs MAY sign SHA-1 hashes over end-entity certificates which chain
     up to roots in Mozilla's program only if all the following are true:</p>
-  <ol>
+  <ol class="prose">
     <li>
       <p>The end-entity certificate:</p>
-      <ul>
+      <ul class="prose">
         <li>is not within the scope of the Baseline Requirements;</li>
         <li>contains an EKU extension which does not contain either of the
           id-kp-serverAuth or anyExtendedKeyUsage key purposes;</li>
@@ -400,7 +401,7 @@
     </li>
     <li>
       <p>The issuing certificate:</p>
-      <ul>
+      <ul class="prose">
         <li>contains an EKU extension which does not contain either of the
           id-kp-serverAuth or anyExtendedKeyUsage key purposes;</li>
         <li>has a pathlen:0 constraint.</li>
@@ -413,7 +414,7 @@
     chain up to roots in Mozilla's program only if the certificate to be signed
     is a duplicate of an existing SHA-1 intermediate certificate with the
     only changes being all of:</p>
-  <ul>
+  <ul class="prose">
     <li>a new key (of the same size);</li>
     <li>a new serial number (of the same length);</li>
     <li>the addition of an EKU and/or a pathlen constraint to meet the
@@ -438,7 +439,7 @@
     MUST have a serial number greater than zero, containing at least 64 bits of
     output from a CSPRNG.</p>
   <p>CAs MUST NOT issue certificates that have:</p>
-  <ul>
+  <ul class="prose">
     <li>ASN.1 DER encoding errors;</li>
     <li>invalid public keys (e.g., RSA certificates with public exponent
       equal to 1);</li>
@@ -518,7 +519,7 @@
     more than ten days beyond the value of the thisUpdate field.</p>
   <p>For end-entity certificates, if the CA provides revocation information
     via an Online Certificate Status Protocol (OCSP) service:</p>
-  <ul>
+  <ul class="prose">
     <li>it MUST update that service at least every four days; and</li>
     <li>responses MUST have a defined value in the nextUpdate field, and it
       MUST be no more than ten days after the thisUpdate field; and</li>
@@ -554,14 +555,14 @@
     further details about how to submit a formal request. The request
     MUST be made by an authorized representative of the subject CA, and
     MUST include the following:</p>
-  <ol>
+  <ol class="prose">
     <li>the certificate data (or links to the data) for the CA
       certificate(s) requested for inclusion;</li>
     <li>for each CA certificate requested for inclusion, whether or not
       the CA issues certificates for each of the following purposes
       within the certificate hierarchy associated with the CA
       certificate:
-      <ul>
+      <ul class="prose">
         <li>SSL-enabled servers</li>
         <li>digitally-signed and/or encrypted email;</li>
       </ul>
@@ -585,7 +586,7 @@
   <h3 id="updates">7.2 Updates</h3>
   <p>Changes MAY be made to root certificates that are included in
     Mozilla's root program as follows:</p>
-  <ol>
+  <ol class="prose">
     <li>enabling a trust bit in a root certificate that is currently
       included, may only be done after careful consideration of the
       CA’s current policies, practices, and audits,
@@ -644,7 +645,7 @@
   <h2 id="ca-operational-changes">8. CA Operational Changes</h2>
   <p>CAs SHOULD NOT assume that trust is transferable. All CAs whose certificates
     are included in Mozilla's root program MUST <a href="mailto:certificates@mozilla.org">notify Mozilla</a> if:</p>
-  <ul>
+  <ul class="prose">
     <li>ownership or control of the CA’s certificate(s) changes, or</li>
     <li>ownership or control of the CA’s operations changes; or</li>
     <li>there is a <a href="http://legal-dictionary.thefreedictionary.com/Material+Changes">material change</a> in the CA's operations.</li>
@@ -693,7 +694,7 @@
     times. The auditor MUST confirm that there are appropriate procedures in place
     to ensure that the requirements are met and that those procedures are followed.</p>
   <p>The following steps MUST be taken by the organization(s) concerned:</p>
-  <ul>
+  <ul class="prose">
     <li>Make sure the annual audit statements are current.</li>
     <li>Notify Mozilla of the pending change.</li>
     <li>Create a transfer plan (and legal agreement if more than one organization is


### PR DESCRIPTION
## Description
Adds `class=prose` to all lists so they get the correct CSS styling.

## Issue / Bugzilla link
[Bug 1461220 - List formatting broken on /about/governance/policies/security-group/certs/policy/](https://bugzilla.mozilla.org/show_bug.cgi?id=1461220)

## Testing
Do the lists have bullets and numbers?