### PR TITLE
[fix bug 1469981] Firefox for Fire TV Privacy Notice

### DIFF
--- a/bedrock/privacy/redirects.py
+++ b/bedrock/privacy/redirects.py
@@ -17,7 +17,4 @@ redirectpatterns = (
 
     # bug 1394042 - Firefox Cloud Services redirect to Fx
     redirect(r'^privacy/firefox-cloud/?$', 'privacy.notices.firefox'),
-
-    # bug 1425865 - Firefox for Amazon Fire TV uses Firefox Focus
-    redirect(r'^privacy/firefox-fire-tv/?$', 'privacy.notices.firefox-focus'),
 )

--- a/bedrock/privacy/templates/privacy/index.html
+++ b/bedrock/privacy/templates/privacy/index.html
@@ -83,6 +83,7 @@
         <li class="policy-firefox-os"><a href="{{ url('privacy.notices.firefox-os') }}">{{ _('Firefox OS') }}</a></li>
         <li class="policy-firefox-cliqz"><a href="{{ url('privacy.notices.firefox-cliqz') }}">{{ _('Firefox + Cliqz') }}</a></li>
         <li class="policy-firefox-cloud"><a href="{{ url('privacy.notices.firefox') }}">{{ _('Firefox Cloud Services') }}</a></li>
+        <li class="policy-firefox-fire-tv"><a href="{{ url('privacy.notices.firefox-fire-tv') }}">{{ _('Firefox for Fire TV') }}</a></li>
         <li class="policy-firefox-rocket"><a href="{{ url('privacy.notices.firefox-rocket') }}">{{ _('Firefox Rocket') }}</a></li>
         <li class="policy-marketplace"><a href="https://marketplace.firefox.com/privacy-policy">{{ _('Firefox Marketplace') }}</a></li>
         <li class="policy-firefox-focus">

--- a/bedrock/privacy/templates/privacy/notices/firefox-fire-tv.html
+++ b/bedrock/privacy/templates/privacy/notices/firefox-fire-tv.html
@@ -1,0 +1,8 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+
+{% extends "privacy/notices/firefox.html" %}
+
+{% block body_class %}{{ super() }} product-firefox-fire-tv{% endblock %}
+{% block article_header_logo %}{{ static('img/logos/firefox/logo-quantum.png') }}{% endblock %}

--- a/bedrock/privacy/urls.py
+++ b/bedrock/privacy/urls.py
@@ -13,6 +13,7 @@ urlpatterns = (
     url(r'^/firefox/$', views.firefox_notices, name='privacy.notices.firefox'),
     url(r'^/firefox-os/$', views.firefox_os_notices, name='privacy.notices.firefox-os'),
     url(r'^/firefox-cliqz/$', views.firefox_cliqz_notices, name='privacy.notices.firefox-cliqz'),
+    url(r'^/firefox-fire-tv/$', views.firefox_fire_tv_notices, name='privacy.notices.firefox-fire-tv'),
     url(r'^/firefox-focus/$', views.firefox_focus_notices, name='privacy.notices.firefox-focus'),
     url(r'^/firefox-rocket/$', views.firefox_rocket_notices, name='privacy.notices.firefox-rocket'),
     # bug 1319207 - special URL for Firefox Focus in de locale

--- a/bedrock/privacy/views.py
+++ b/bedrock/privacy/views.py
@@ -100,6 +100,10 @@ firefox_os_notices = PrivacyDocView.as_view(
 firefox_cliqz_notices = FirefoxCliqzPrivacyDocView.as_view(
     legal_doc_name='firefox-cliqz_privacy_notice')
 
+firefox_fire_tv_notices = PrivacyDocView.as_view(
+    template_name='privacy/notices/firefox-fire-tv.html',
+    legal_doc_name='Firefox_FireTV_Privacy_Notice')
+
 firefox_cloud_notices = PrivacyDocView.as_view(
     template_name='privacy/notices/firefox-cloud.html',
     legal_doc_name='firefox_cloud_services_PrivacyNotice')

--- a/media/css/privacy/privacy.less
+++ b/media/css/privacy/privacy.less
@@ -42,6 +42,7 @@
         float: right;
         margin: -80px -20px 0 0;
         vertical-align: top;
+        width: 160px;
       }
 
       p {
@@ -193,7 +194,8 @@
     &.policy-firefox a:before,
     &.policy-firefox-os a:before,
     &.policy-firefox-cliqz a:before,
-    &.policy-firefox-cloud a:before {
+    &.policy-firefox-cloud a:before,
+    &.policy-firefox-fire-tv a:before {
       background-position: center -40px;
     }
 

--- a/tests/redirects/map_globalconf.py
+++ b/tests/redirects/map_globalconf.py
@@ -1200,7 +1200,6 @@ URLS = flatten((
     url_test('/firefox/organizations/faq/', '/firefox/organizations/'),
 
     # bug 1425865
-    url_test('/privacy/firefox-fire-tv/', '/privacy/firefox-focus/'),
     url_test('/firefox/fire-tv/', 'https://support.mozilla.org/products/firefox-fire-tv/', status_code=302),
 
     # bug 1421584


### PR DESCRIPTION
## Description
- Adds a new privacy notice for Firefo for Fire TV at `/privacy/firefox-fire-tv/`.

## Issue / Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1469981

## Testing
Demo: https://bedrock-demo-agibson.oregon-b.moz.works/en-US/privacy/firefox-fire-tv/