### PR TITLE
Remove git commit from build lock

### DIFF
--- a/jenkins/default.groovy
+++ b/jenkins/default.groovy
@@ -10,7 +10,7 @@ stage ('Build Images') {
         }
     }
     utils.ircNotification([stage: 'Test & Deploy', status: 'starting'])
-    lock ("bedrock-docker-${env.GIT_COMMIT}") {
+    lock ("bedrock-docker-build") {
         try {
             sh "make clean build-ci"
         } catch(err) {


### PR DESCRIPTION
## Description

Address issues like https://ci.us-west.moz.works/blue/organizations/jenkins/bedrock_multibranch_pipeline/detail/master/1083/pipeline/ due to concurrent builds possible with separate commits.