### PR TITLE
/channel/desktop page content update

### DIFF
--- a/bedrock/firefox/templates/firefox/channel/android.html
+++ b/bedrock/firefox/templates/firefox/channel/android.html
@@ -39,8 +39,16 @@
     </header>
     {{ download_firefox('beta', platform='android', alt_copy=_('Download'), dom_id="android-beta-download") }}
     <p class="notice">
-      {{_('Firefox Beta automatically sends feedback to Mozilla.')}}
-      <a href="{{ url('privacy.notices.firefox') + '#telemetry' }}">{{_('Learn more')}}</a>
+      {% if l10n_has_tag('privacy_201806') %}
+        {%- trans link=url('privacy.notices.firefox') + '#pre-release' -%}
+          Beta is an unstable testing and development platform. By default, Beta sends data to Mozilla
+          — and sometimes our partners — to help us handle problems and try ideas.
+          <a href="{{ link }}">Learn what is shared</a>.
+        {%- endtrans -%}
+      {% else %}
+        {{_('Firefox Beta automatically sends feedback to Mozilla.')}}
+        <a href="{{ url('privacy.notices.firefox') + '#pre-release' }}">{{_('Learn more')}}</a>
+      {% endif %}
     </p>
     <p class="notice">
       {% trans feedback='https://input.mozilla.com/feedback' %}
@@ -71,8 +79,16 @@
     </header>
     {{ download_firefox('nightly', platform='android', alt_copy=_('Download'), dom_id="android-nightly-download") }}
     <p class="notice">
-      {{_('Firefox Nightly automatically sends feedback to Mozilla.')}}
-      <a href="{{ url('privacy.notices.firefox') + '#telemetry' }}">{{_('Learn more')}}</a>
+        {% if l10n_has_tag('privacy_201806') %}
+        {%- trans link=url('privacy.notices.firefox') + '#pre-release' -%}
+          Nightly is an unstable testing and development platform. By default, Nightly sends data to Mozilla
+          — and sometimes our partners — to help us handle problems and try ideas.
+          <a href="{{ link }}">Learn what is shared</a>.
+        {%- endtrans -%}
+      {% else %}
+        {{_('Firefox Nightly automatically sends feedback to Mozilla.')}}
+        <a href="{{ url('privacy.notices.firefox') + '#pre-release' }}">{{_('Learn more')}}</a>
+      {% endif %}
     </p>
   </div>
   <footer>

--- a/bedrock/firefox/templates/firefox/channel/desktop.html
+++ b/bedrock/firefox/templates/firefox/channel/desktop.html
@@ -37,8 +37,14 @@
     </header>
     {{ download_firefox('beta', platform='desktop', force_direct=True, alt_copy=_('Download'), dom_id="desktop-beta-download") }}
     <p class="notice">
-      {{_('Firefox Beta automatically sends feedback to Mozilla.')}}
-      <a href="{{ url('privacy.notices.firefox') + '#telemetry' }}">{{_('Learn more')}}</a>
+      {% if l10n_has_tag('privacy_201806') %}
+        {%- trans link=url('privacy.notices.firefox') + '#pre-release' -%}
+          By default, Beta sends data to Mozilla — and in some cases to our partners — to help us find and fix problems. <a href="{{ link }}">Learn more.</a>
+        {%- endtrans -%}
+      {% else %}
+        {{_('Firefox Beta automatically sends feedback to Mozilla.')}}
+        <a href="{{ url('privacy.notices.firefox') + '#pre-release' }}">{{_('Learn more')}}</a>
+      {% endif %}
     </p>
     <p class="notice">
       {% trans feedback='https://input.mozilla.com/feedback' %}
@@ -66,8 +72,14 @@
     </header>
     {{ download_firefox('alpha', platform='desktop', force_direct=True, alt_copy=_('Download'), dom_id="desktop-developer-download") }}
     <p class="notice">
-      {{_('Firefox Developer Edition automatically sends feedback to Mozilla.')}}
-      <a href="{{ url('privacy.notices.firefox') + '#telemetry' }}">{{_('Learn more')}}</a>
+      {% if l10n_has_tag('privacy_201806') %}
+        {%- trans link=url('privacy.notices.firefox') + '#pre-release' -%}
+          Developer Edition is an unstable testing and development platform. By default, Developer Edition sends data to Mozilla — and in some cases to our partners — to help us find and fix problems. <a href="{{ link }}">Learn more.</a>
+        {%- endtrans -%}
+      {% else %}
+        {{_('Firefox Developer Edition automatically sends feedback to Mozilla.')}}
+        <a href="{{ url('privacy.notices.firefox') + '#pre-release' }}">{{_('Learn more')}}</a>
+      {% endif %}
     </p>
   </div>
   <footer>
@@ -95,8 +107,14 @@
     </header>
     {{ download_firefox('nightly', platform='desktop', force_direct=True, alt_copy=_('Download'), dom_id="desktop-nightly-download") }}
     <p class="notice">
-      {{_('Firefox Nightly automatically sends feedback to Mozilla.')}}
-      <a href="{{ url('privacy.notices.firefox') + '#telemetry' }}">{{_('Learn more')}}</a>
+      {% if l10n_has_tag('privacy_201806') %}
+        {%- trans link=url('privacy.notices.firefox') + '#pre-release' -%}
+          Nightly is an unstable testing and development platform. By default, Nightly sends data to Mozilla — and in some cases to our partners — to help us find and fix problems. <a href="{{ link }}">Learn more.</a>
+        {%- endtrans -%}
+      {% else %}
+        {{_('Firefox Nightly automatically sends feedback to Mozilla.')}}
+        <a href="{{ url('privacy.notices.firefox') + '#pre-release' }}">{{_('Learn more')}}</a>
+      {% endif %}
     </p>
   </div>
   <footer>

--- a/bedrock/firefox/templates/firefox/channel/desktop.html
+++ b/bedrock/firefox/templates/firefox/channel/desktop.html
@@ -39,7 +39,9 @@
     <p class="notice">
       {% if l10n_has_tag('privacy_201806') %}
         {%- trans link=url('privacy.notices.firefox') + '#pre-release' -%}
-          By default, Beta sends data to Mozilla — and in some cases to our partners — to help us find and fix problems. <a href="{{ link }}">Learn more.</a>
+          Beta is an unstable testing and development platform. By default, Beta sends data to Mozilla
+          — and sometimes our partners — to help us handle problems and try ideas.
+          <a href="{{ link }}">Learn what is shared</a>.
         {%- endtrans -%}
       {% else %}
         {{_('Firefox Beta automatically sends feedback to Mozilla.')}}
@@ -74,7 +76,9 @@
     <p class="notice">
       {% if l10n_has_tag('privacy_201806') %}
         {%- trans link=url('privacy.notices.firefox') + '#pre-release' -%}
-          Developer Edition is an unstable testing and development platform. By default, Developer Edition sends data to Mozilla — and in some cases to our partners — to help us find and fix problems. <a href="{{ link }}">Learn more.</a>
+        Developer Edition is an unstable testing and development platform. By default,
+        Developer Edition sends data to Mozilla  — and sometimes our partners —
+        to help us handle problems and try ideas. <a href="{{ link }}">Learn what is shared</a>.
         {%- endtrans -%}
       {% else %}
         {{_('Firefox Developer Edition automatically sends feedback to Mozilla.')}}
@@ -109,7 +113,9 @@
     <p class="notice">
       {% if l10n_has_tag('privacy_201806') %}
         {%- trans link=url('privacy.notices.firefox') + '#pre-release' -%}
-          Nightly is an unstable testing and development platform. By default, Nightly sends data to Mozilla — and in some cases to our partners — to help us find and fix problems. <a href="{{ link }}">Learn more.</a>
+          Nightly is an unstable testing and development platform. By default, Nightly sends data to Mozilla
+          — and sometimes our partners — to help us handle problems and try ideas.
+          <a href="{{ link }}">Learn what is shared</a>.
         {%- endtrans -%}
       {% else %}
         {{_('Firefox Nightly automatically sends feedback to Mozilla.')}}

--- a/media/css/firefox/channel.less
+++ b/media/css/firefox/channel.less
@@ -353,6 +353,7 @@ html[lang^="en"] {
     .notice {
         .font-size(18px);
         clear: both;
+        text-align: left;
     }
 
     footer {
@@ -429,6 +430,7 @@ html[lang^="en"] {
 
         .notice {
             .font-size(@baseFontSize);
+            text-align: center;
         }
 
         footer ul {


### PR DESCRIPTION
## Description
- Replaces https://github.com/mozilla/bedrock/pull/5843
- Updates privacy copy
- Updates copy on /channel/android/ to match desktop
- Updates legal-docs to reflect the new pre-release text linked to from /channel

**Note:** ~strings are not yet final.~ The ask is for this to go out on the 10th, as we're still waiting for an update to the Firefox privacy notice.

## Issue / Bugzilla link
https://github.com/mozilla/bedrock/issues/5746

## Testing
- Check for copy pasta?