### PR TITLE
[no bug] Consistent labeling for ESR buttons

### DIFF
--- a/bedrock/firefox/templates/firefox/organizations/organizations.html
+++ b/bedrock/firefox/templates/firefox/organizations/organizations.html
@@ -35,7 +35,7 @@
             <strong>{{ _('Firefox Extended Support Release (ESR 60)') }}</strong><br>
             {{ _('The new super-fast Firefox, with features for IT professionals to configure and deploy Firefox in their organization.') }}
           </p>
-          <p><a href="{{ firefox_url('desktop', 'all', 'esr') }}" class="button">{{ _('Get Firefox ESR 60') }}</a></p>
+          <p><a href="{{ firefox_url('desktop', 'all', 'esr') }}" class="button">{{ _('Get Firefox 60 ESR') }}</a></p>
         </div>
         <div class="col">
           <p>


### PR DESCRIPTION
## Description
One button read "Get Firefox ESR 60" and the other read "Get Firefox 52 ESR". This updates them to consistently use the "Get Firefox [version] ESR" format for both.

This page doesn't appear to be localized but if it is I can add a tag for this string change.

## Issue / Bugzilla link
https://twitter.com/pratab_a/status/1012637039119011840
