### PR TITLE
[#5745] Add principles link to privacy sidebar

### DIFF
--- a/bedrock/privacy/templates/privacy/index.html
+++ b/bedrock/privacy/templates/privacy/index.html
@@ -61,7 +61,14 @@
   <section id="side-principles">
     <h2>{{ _('Data Privacy Principles') }}</h2>
     <p>
-      {% if l10n_has_tag('updates-052018') %}
+      {% if l10n_has_tag('updates-072018') %}
+      {%- trans principles=url('privacy.principles'), faq=url('privacy.faq') -%}
+        Mozilla's <a href="{{ principles }}">Data Privacy Principles</a> inspire our
+        practices that respect and protect people who use the Internet. Learn how
+        these principles shape Firefox and all of our products in this
+        <a href="{{ faq }}">FAQ</a>.
+      {%- endtrans -%}
+      {% elif l10n_has_tag('updates-052018') %}
       {%- trans faq=url('privacy.faq') -%}
         Mozilla's Data Privacy Principles inspire our practices that respect and
         protect people who use the Internet. Learn how these principles shape

--- a/media/css/privacy/privacy.less
+++ b/media/css/privacy/privacy.less
@@ -147,10 +147,6 @@
   }
 }
 
-#side-principles a:after {
-  content: "\00A0\00BB"; /* nbsp raquo */
-}
-
 #side-notices nav {
   padding: 0;
 


### PR DESCRIPTION
## Description
A link was omitted in PR #5850 but strings had already been extracted so this separate PR adds the link behind new tag, `updates-072018`

## Issue / Bugzilla link
#5745 
