### PR TITLE
[#5747] Clean up transparency report switch

### DIFF
--- a/bedrock/mozorg/templates/mozorg/about/policy/transparency/includes/past-reports.html
+++ b/bedrock/mozorg/templates/mozorg/about/policy/transparency/includes/past-reports.html
@@ -7,9 +7,7 @@
 <nav class="content nav-previous">
   <h3>{{ _('Previous Reports') }}</h3>
   <ul>
-    {% if switch('transparency-report-030618') %}
     <li><a href="{{ url('mozorg.about.policy.transparency.jan-jun-2017') }}">{{ _('January-June 2017') }}</a></li>
-    {% endif %}
     <li><a href="{{ url('mozorg.about.policy.transparency.jul-dec-2016') }}">{{ _('July-December 2016') }}</a></li>
     <li><a href="{{ url('mozorg.about.policy.transparency.jan-jun-2016') }}">{{ _('January-June 2016') }}</a></li>
     <li><a href="{{ url('mozorg.about.policy.transparency.jan-dec-2015') }}">{{ _('January-December 2015') }}</a></li>

--- a/bedrock/mozorg/templates/mozorg/about/policy/transparency/includes/reports-nav.html
+++ b/bedrock/mozorg/templates/mozorg/about/policy/transparency/includes/reports-nav.html
@@ -4,10 +4,6 @@
           <li><a href="{{ url('mozorg.about.policy.transparency.index') + '#definitions' }}">{{ _('Definitions') }}</a></li>
           {# This link should point to the latest report. Past reports are added to 'includes/past-reports.html' #}
           {# There are also links in the faq that need to be updated to point to the latest report. #}
-          {% if switch('transparency-report-030618') %}
           <li><a href="{{ url('mozorg.about.policy.transparency.jul-dec-2017') }}">{{ _('July-December 2017 Report') }}</a></li>
-          {% else %}
-          <li><a href="{{ url('mozorg.about.policy.transparency.jan-jun-2017') }}">{{ _('January-June 2017 Report') }}</a></li>
-          {% endif %}
         </ul>
       </nav>

--- a/bedrock/mozorg/templates/mozorg/about/policy/transparency/index.html
+++ b/bedrock/mozorg/templates/mozorg/about/policy/transparency/index.html
@@ -58,17 +58,10 @@
             <div data-accordion-role="tabpanel">
               <p>
                 {# NOTE: Remember to update these links when publishing a new report. #}
-                {% if switch('transparency-report-030618') %}
                   {% set link_userdata=url('mozorg.about.policy.transparency.jul-dec-2017') + '#government-user-data' %}
                   {% set link_removal=url('mozorg.about.policy.transparency.jul-dec-2017') + '#government-content-removal' %}
                   {% set link_copytrade=url('mozorg.about.policy.transparency.jul-dec-2017') + '#copyright-trademark' %}
                   {% set link_supplement=url('mozorg.about.policy.transparency.jul-dec-2017') + '#supplement' %}
-                {% else %}
-                  {% set link_userdata=url('mozorg.about.policy.transparency.jan-jun-2017') + '#government-user-data' %}
-                  {% set link_removal=url('mozorg.about.policy.transparency.jan-jun-2017') + '#government-content-removal' %}
-                  {% set link_copytrade=url('mozorg.about.policy.transparency.jan-jun-2017') + '#copyright-trademark' %}
-                  {% set link_supplement=url('mozorg.about.policy.transparency.jan-jun-2017') + '#supplement' %}
-                {% endif %}
                 {% trans %}
                   We report on <a href="{{ link_userdata }}">Government Demands for User Data</a>, <a href="{{ link_removal }}">Government Requests for Content Removal</a>, and <a href="{{ link_copytrade }}">Copyright and Trademark Requests</a>. We also include a <a href="{{ link_supplement }}">Supplement</a>, which provides additional information.
                 {% endtrans %}

--- a/bedrock/mozorg/urls.py
+++ b/bedrock/mozorg/urls.py
@@ -6,7 +6,6 @@ from django.conf.urls import url
 
 from .util import page
 from . import views
-from bedrock.base.waffle import switch
 from bedrock.redirects.util import redirect
 
 
@@ -76,6 +75,9 @@ urlpatterns = (
          'mozorg/about/policy/transparency/jul-dec-2016.html'),
     page('about/policy/transparency/jan-jun-2017',
          'mozorg/about/policy/transparency/jan-jun-2017.html'),
+    page('about/policy/transparency/jul-dec-2017',
+         'mozorg/about/policy/transparency/jul-dec-2017.html'),
+
 
     page('contact', 'mozorg/contact/contact-landing.html'),
     page('contact/spaces', 'mozorg/contact/spaces/spaces-landing.html'),
@@ -313,8 +315,3 @@ urlpatterns = (
     url(r'^projects/xforms/2005/type$', views.namespaces, {'namespace': 'xforms-type'}),
     url(r'^xbl$', views.namespaces, {'namespace': 'xbl'}),
 )
-
-if switch('transparency-report-030618'):
-    urlpatterns += (
-        page('about/policy/transparency/jul-dec-2017', 'mozorg/about/policy/transparency/jul-dec-2017.html'),
-    )


### PR DESCRIPTION
## Description
Removes the switch added in #5848 now that the page is live. This should also address intermittent errors occurring in production (see https://github.com/mozilla/bedrock/issues/5747#issuecomment-402277888)
