### PR TITLE
Remove invalid chars from UTM params on /firefox/accounts/features/ CTAs (Fixes #5870)

### DIFF
--- a/bedrock/base/templates/macros.html
+++ b/bedrock/base/templates/macros.html
@@ -311,9 +311,9 @@
   {# Parameters for accounts.firefox.com link #}
   {% set service = 'sync' %}
   {% set context = 'fx_desktop_v3' %}
-  {% set entrypoint = 'mozilla.org:' + entrypoint %}
+  {% set entrypoint = 'mozilla.org-' + entrypoint %}
   {% if content %}
-    {% set utm_content = content %}
+    {% set utm_content = content.replace('/', '%2F') %}
   {% else %}
     {% set utm_content = request.path_info.replace('/', '%2F') %}
   {% endif %}


### PR DESCRIPTION
## Description

Long term I think we should really move this to a Python FxA helper, as this marco is doing a lot of logic (and could do with some unit tests?). But this should hopefully fix the analytics issues for short term.

## Issue / Bugzilla link
https://github.com/mozilla/bedrock/issues/5870

## Testing
- Make sure the URLs match the expected format highlighted in the issue?