### PR TITLE
[#5913] Update /firefox/new “herz” variant headline

### DIFF
--- a/bedrock/firefox/templates/firefox/new/berlin/base-herz.html
+++ b/bedrock/firefox/templates/firefox/new/berlin/base-herz.html
@@ -29,7 +29,7 @@
       <div class="copy">
         <img class="logo" src="{{ static('img/firefox/new/berlin/firefox-logo-wordmark.png') }}" width="408" height="103" alt="Besser digital leben — mit Firefox" />
         {% block head_content %}
-          <h1 id="main-heading">Dein Browser <br/>mit Herz.</h1>
+          <h1 id="main-heading">Zeit für den Browser <br>mit Herz.</h1>
         {% endblock %}
         <div class="secondary-content">
           {% block secondary_content %}{% endblock %}


### PR DESCRIPTION
Fixes issue #5913 

Strings are hard-coded in German, no l10n impact.