### PR TITLE
Update release notes page titles

### DIFF
--- a/bedrock/firefox/templates/firefox/releases/release-notes.html
+++ b/bedrock/firefox/templates/firefox/releases/release-notes.html
@@ -17,7 +17,8 @@
 {% endblock %}
 
 {% block page_title_prefix %}{% endblock %}
-{% block page_title %}{{ _('{product} — {channel} Notes ({version})')|f(product=release.product, channel=channel_name, version=release.version) }}{% endblock %}
+{% block page_title %}{{ _('{product} {channel} {version}, See All New Features, Updates and Fixes')|f(product=release.product, channel=channel_name, version=release.version) }}{% endblock %}
+{% block page_title_suffix %}{% endblock %}
 
 {% block body_id %}notes{% endblock %}
 {% block body_class %}fx-notes{% endblock %}


### PR DESCRIPTION
## Description
- More user friendly page titles
- Remove title suffix

## Issue / Bugzilla link
Closes #5751 

## Testing
- Do all the different release versions still have a well formatted title?