### PR TITLE
Use HTML char for ampersand

### DIFF
--- a/bedrock/firefox/templates/firefox/new/scene1.html
+++ b/bedrock/firefox/templates/firefox/new/scene1.html
@@ -98,7 +98,7 @@
 <div id="other-platforms">
   <div class="content">
     <section class="section-other-platforms">
-      <h4>{{ _('Advanced Install Options & Other Platforms') }}</h4>
+      <h4>{{ _('Advanced Install Options &amp; Other Platforms') }}</h4>
 
       {{ download_firefox_desktop_list(force_full_installer=True) }}
 


### PR DESCRIPTION
for better cross-browser compatibility.

## Description

## Issue / Bugzilla link

## Testing
