### PR TITLE
Update @mozilla-protocol/core to v2.0.1

### DIFF
--- a/bedrock/base/templates/base-protocol.html
+++ b/bedrock/base/templates/base-protocol.html
@@ -4,6 +4,10 @@
   {{ css_bundle('protocol-core') }}
 {% endblock %}
 
+{% block old_ie_styles %}
+  {{ css_bundle('protocol-oldIE') }}
+{% endblock %}
+
 {% block tabzilla_tab %}{% endblock %}
 
 {% block site_header %}
@@ -13,6 +17,10 @@
     {% set logo_src = static('img/pebbles/moz-wordmark-dark-reverse.svg') %}
     {% include 'mozorg/home/includes/nav.html' %}
   {% endif %}
+{% endblock %}
+
+{% block site_footer %}
+  {% include 'includes/protocol/site-footer.html' %}
 {% endblock %}
 
 {% block site_js %}

--- a/bedrock/base/templates/includes/protocol/lang-switcher.html
+++ b/bedrock/base/templates/includes/protocol/lang-switcher.html
@@ -1,0 +1,17 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+  # License, v. 2.0. If a copy of the MPL was not distributed with this
+  # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+
+ {% if translations|length > 1 %}
+ <form id="lang_form" class="mzp-c-language-switcher" method="get" action="#">
+   <label for="mzp-c-language-switcher-select">{{ _('Language') }}</label>
+   <select id="mzp-c-language-switcher-select" class="mzp-c-language-switcher-select" name="lang" dir="ltr">
+     {% for code, label in translations|dictsort -%}
+       {# Don't escape the label as it may include entity references
+        # like "Português (do&nbsp;Brasil)" (Bug 861149) #}
+       <option lang="{{ code }}" value="{{ code }}"{{ code|ifeq(LANG, " selected") }}>{{ label|safe|replace('English (US)', 'English') }}</option>
+     {% endfor %}
+   </select>
+   <button type="submit">{{ _('Go') }}</button>
+ </form>
+ {% endif %}

--- a/bedrock/base/templates/includes/protocol/site-footer.html
+++ b/bedrock/base/templates/includes/protocol/site-footer.html
@@ -1,0 +1,75 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+
+<footer class="mzp-c-footer mzp-has-lang-switcher">
+  <div class="mzp-l-content">
+    <nav class="mzp-c-footer-primary">
+      <div class="mzp-c-footer-primary-logo">
+        <a href="{{ url('mozorg.home') }}" data-link-type="footer" data-link-name="Mozilla">{{ _('Mozilla') }}</a>
+      </div>
+      <section class="mzp-c-footer-section">
+        <h5>
+          <a href="{{ url('mozorg.home') }}" data-link-type="footer" data-link-name="Mozilla">{{ _('Mozilla') }}</a>
+        </h5>
+        <ul>
+          <li><a href="{{ url('mozorg.about') }}" data-link-type="footer" data-link-name="About">{{ _('About') }}</a></li>
+          <li><a href="https://blog.mozilla.org/" data-link-type="footer" data-link-name="Blog">{{ _('Blog') }}</a></li>
+          <li><a href="{{ url('mozorg.contact.contact-landing') }}" data-link-type="footer" data-link-name="Contact Us">{{ _('Contact Us') }}</a></li>
+          <li><a href="{{ donate_url('footer') }}" class="donate" data-link-type="footer" data-link-name="Donate">{{ _('Donate') }}</a></li>
+          <li><a href="https://wiki.mozilla.org/Webdev/GetInvolved/mozilla.org" data-link-type="footer" rel="nofollow" data-link-name="Contribute to this site">{{ _('Contribute to this site') }}</a></li>
+          {# TODO remove the "and" clause after tranlsation #}
+          {% if template_source_url and (LANG.startswith('en') or switch('footer-source-link')) %}
+            <li><a href="{{ template_source_url }}" data-link-type="footer" rel="nofollow" data-link-name="Source code for this page">{{ _('Source code for this page') }}</a></li>
+          {% endif %}
+          <li>
+            <ul class="mzp-c-footer-links-social">
+              <li><a class="twitter" href="https://twitter.com/mozilla" data-link-type="footer" data-link-name="Twitter (@mozilla)">{{ _('Twitter') }}<span> (@mozilla)</span></a></li>
+              <li><a class="instagram" href="https://www.instagram.com/mozilla/" data-link-type="footer" data-link-name="Instagram (@mozilla)">{{ _('Instagram') }}<span> (@mozilla)</span></a></li>
+            </ul>
+          </li>
+        </ul>
+      </section>
+      <section class="mzp-c-footer-section">
+        <h5>
+          <a href="{{ url('firefox') }}" data-link-type="footer" data-link-name="Firefox">{{ _('Firefox') }}</a>
+        </h5>
+        <ul>
+          <li><a href="{{ url('firefox.new') }}" data-link-type="footer" data-link-name="Download Firefox">{{ _('Download Firefox') }}</a></li>
+          <li><a href="{{ url('firefox') }}" data-link-type="footer" data-link-name="Desktop">{{ _('Desktop') }}</a></li>
+          <li><a href="{{ url('firefox.mobile') }}" data-link-type="footer" data-link-name="Mobile">{{ _('Mobile') }}</a></li>
+          <li><a href="{{ url('firefox.features.index') }}" data-link-type="footer" data-link-name="Features">{{ _('Features') }}</a></li>
+          <li><a href="{{ url('firefox.channel.desktop') }}" data-link-type="footer" data-link-name="Beta, Nightly, Developer Edition">{{ _('Beta, Nightly, Developer Edition') }}</a></li>
+          <li>
+            <ul class="mzp-c-footer-links-social">
+              <li><a class="twitter" href="{{ firefox_twitter_url() }}" data-link-type="footer" data-link-name="Twitter (@firefox)">{{ _('Twitter') }}<span> (@firefox)</span></a></li>
+              <li><a class="youtube" href="https://www.youtube.com/firefoxchannel" data-link-type="footer" data-link-name="YouTube (firefoxchannel)">{{ _('YouTube') }}<span> (firefoxchannel)</span></a></li>
+            </ul>
+          </li>
+        </ul>
+      </section>
+    </nav>
+
+    <nav class="mzp-c-footer-secondary">
+        <div class="mzp-c-footer-legal">
+          <ul>
+            {% if LANG.startswith('en-') %}
+              {% set privacy_text = _('Website Privacy Notice') %}
+            {% else %}
+              {% set privacy_text = _('Privacy') %}
+            {% endif %}
+            <li><a rel="nofollow" href="{{ url('privacy.notices.websites') }}" data-link-type="footer" data-link-name="Privacy">{{ privacy_text }}</a></li>
+            <li><a rel="nofollow" href="{{ url('privacy.notices.websites') }}#cookies" data-link-type="footer" data-link-name="Cookies">{{ _('Cookies') }}</a></li>
+            <li><a rel="nofollow" href="{{ url('legal.index') }}" data-link-type="footer" data-link-name="Legal">{{ _('Legal') }}</a></li>
+          </ul>
+          <p class="mzp-c-footer-license">
+          {%- trans url=url('foundation.licensing.website-content') -%}
+            Portions of this content are ©1998–{{ current_year }} by individual mozilla.org
+            contributors. Content available under a <a rel="license" href="{{ url }}">Creative Commons license</a>.
+          {%- endtrans -%}
+          </p>
+        </div>
+        {% include 'includes/protocol/lang-switcher.html' %}
+    </nav>
+  </div>
+</footer>

--- a/bedrock/mozorg/templates/mozorg/home/home-en.html
+++ b/bedrock/mozorg/templates/mozorg/home/home-en.html
@@ -170,9 +170,9 @@
       </div>
 
       <div class="mzp-c-billboard mzp-l-billboard-right">
-        <a href="{{ url('mozorg.about') }}" class="mzp-c-billboard-media-link">
+        <div class="mzp-c-billboard-image-container">
           {{ high_res_img('home/2018/billboard-more-power.png', {'alt': '', 'class': 'mzp-c-billboard-image', 'width': '346', 'height': '346'}) }}
-        </a>
+        </div>
         <div class="mzp-c-billboard-content">
           <div class="mzp-c-billboard-content-inner">
             <h2 class="mzp-c-billboard-title">{{ _('More power to you.') }}</h2>
@@ -293,9 +293,9 @@
       </div>
 
       <div class="mzp-c-billboard mzp-l-billboard-left">
-        <a href="https://foundation.mozilla.org/?utm_source=www.mozilla.org&utm_medium=referral&utm_campaign=homepage&utm_content=billboard" class="mzp-c-billboard-media-link">
+        <div class="mzp-c-billboard-image-container">
           {{ high_res_img('home/2018/billboard-healthy-internet.png', {'alt': '', 'class': 'mzp-c-billboard-image', 'width': '346', 'height': '346'}) }}
-        </a>
+        </div>
         <div class="mzp-c-billboard-content">
           <div class="mzp-c-billboard-content-inner">
             <h2 class="mzp-c-billboard-title">{{ _('Support a healthy internet.') }}</h2>
@@ -374,9 +374,9 @@
       </div>
 
       <div class="mzp-c-billboard mzp-l-billboard-right">
-        <a href="{{ url('mozorg.technology') }}" class="mzp-c-billboard-media-link">
+        <div class="mzp-c-billboard-image-container">
           {{ high_res_img('home/2018/billboard-open-minds.png', {'alt': '', 'class': 'mzp-c-billboard-image', 'width': '346', 'height': '346'}) }}
-        </a>
+        </div>
         <div class="mzp-c-billboard-content">
           <div class="mzp-c-billboard-content-inner">
             <h2 class="mzp-c-billboard-title">{{ _('Open source. <br>Open minds.') }}</h2>

--- a/media/css/mozorg/home/home-2018.scss
+++ b/media/css/mozorg/home/home-2018.scss
@@ -6,11 +6,12 @@ $font-path: '/media/fonts';
 $image-path: '/media/protocol/img';
 
 @import "../../../../node_modules/@mozilla-protocol/core/protocol/css/includes/lib";
-@import "../../../../node_modules/@mozilla-protocol/core/protocol/css/components/card";
 @import "../../../../node_modules/@mozilla-protocol/core/protocol/css/components/billboard";
 @import "../../../../node_modules/@mozilla-protocol/core/protocol/css/components/button";
-@import "../../../../node_modules/@mozilla-protocol/core/protocol/css/components/newsletter-form";
+@import "../../../../node_modules/@mozilla-protocol/core/protocol/css/components/card";
+@import "../../../../node_modules/@mozilla-protocol/core/protocol/css/components/footer";
 @import "../../../../node_modules/@mozilla-protocol/core/protocol/css/components/modal";
+@import "../../../../node_modules/@mozilla-protocol/core/protocol/css/components/newsletter-form";
 @import "../../../../node_modules/@mozilla-protocol/core/protocol/css/templates/card-layout";
 
 @import '../../hubs/nav-download-button-remove';
@@ -50,7 +51,7 @@ $callout-blue: #0060df;
     font-weight: normal;
     line-height: 40px;
     margin-bottom: $margin-sm;
-    padding-top: $padding-xxl;
+    padding-top: $padding-2xl;
 }
 
 .primary-title-sub {
@@ -58,15 +59,15 @@ $callout-blue: #0060df;
     margin-bottom: $margin-sm;
 }
 
-@media #{$media-md} {
+@media #{$mq-md} {
     .primary-wrapper {
         padding-bottom: 40px;
     }
 
     .primary-title {
         background-position: top left;
-        margin-bottom: $margin-xxl;
-        padding-left: $padding-xxl;
+        margin-bottom: $margin-2xl;
+        padding-left: $padding-2xl;
         padding-top: 0;
         text-align: left;
         line-height: 40px;
@@ -89,7 +90,7 @@ $callout-blue: #0060df;
     @include light-links;
 }
 
-@media #{$media-md} {
+@media #{$mq-md} {
     #download-primary {
         margin-top: 0;
         position: absolute;
@@ -103,8 +104,7 @@ $callout-blue: #0060df;
     }
 }
 
-
-@media #{$media-lg} {
+@media #{$mq-lg} {
     .download-firefox-primary-cta {
         border-top: 100px solid #fff;
         position: relative;
@@ -169,7 +169,7 @@ $callout-blue: #0060df;
     bottom: 0;
     cursor: pointer;
     overflow: hidden;
-    padding: 0 0 0 $padding-xxl;
+    padding: 0 0 0 $padding-2xl;
     position: absolute;
     right: 0;
     top: 0;
@@ -189,7 +189,7 @@ $callout-blue: #0060df;
     }
 }
 
-@media #{$media-md} {
+@media #{$mq-md} {
     .download-firefox-sticky-cta {
         .primary-title {
             float: left;
@@ -230,7 +230,7 @@ $callout-blue: #0060df;
     }
 }
 
-@media #{$media-lg} {
+@media #{$mq-lg} {
     .download-firefox-sticky-cta {
         .primary-desc-sub {
             display: block;
@@ -286,7 +286,7 @@ $callout-blue: #0060df;
         }
     }
 
-    @media #{$media-md} {
+    @media #{$mq-md} {
         margin: $margin-xl 0 0;
         padding-top: $padding-lg;
     }
@@ -294,7 +294,6 @@ $callout-blue: #0060df;
 
 /* -------------------------------------------------------------------------- */
 // Secondary Firefox CTA section.
-
 
 .download-firefox-secondary-cta {
     background-color: $callout-blue;
@@ -326,7 +325,7 @@ $callout-blue: #0060df;
     margin-top: $margin-lg;
 }
 
-@media #{$media-md} {
+@media #{$mq-md} {
     .secondary-content {
         text-align: left;
         width: 410px;
@@ -354,24 +353,17 @@ $callout-blue: #0060df;
             top: 55px;
             left: 495px;
 
-            @media #{$media-high-res} {
+            @media #{$mq-high-res} {
                 background-image: url('/media/img/home/2018/browser-high-res.png');
             }
         }
     }
 }
 
-@media #{$media-xl} {
+@media #{$mq-xl} {
     .download-firefox-secondary-cta {
         &:before {
             left: calc(50% - 208px);
         }
     }
-}
-
-/* -------------------------------------------------------------------------- */
-// Custom modal styles
-
-.mzp-c-modal video {
-    width: 100%; // fixed in next Protocol release https://github.com/mozilla/protocol/pull/135
 }

--- a/media/css/protocol/components/_footer.scss
+++ b/media/css/protocol/components/_footer.scss
@@ -48,7 +48,7 @@
         @include border-box;
         @include clearfix;
         margin: 0 auto;
-        min-width: $width-content-xs;
+        min-width: $content-xs;
     }
 
     section {
@@ -59,16 +59,16 @@
         @include border-box;
         @include clearfix;
         margin: 0 auto;
-        max-width: $width-content-max;
-        min-width: $width-content-xs;
+        max-width: $content-max;
+        min-width: $content-xs;
         padding: $layout-xs;
         position: relative;
 
-        @media #{$media-md} {
+        @media #{$mq-md} {
             padding: $layout-xs $layout-lg;
         }
 
-        @media #{$media-lg} {
+        @media #{$mq-lg} {
             padding: $layout-xs $layout-xl;
         }
     }
@@ -172,7 +172,7 @@
         }
     }
 
-    @media #{$media-md} {
+    @media #{$mq-md} {
         .primary {
             .logo,
             section {
@@ -206,7 +206,7 @@
 }
 
 [dir='rtl'] #colophon {
-    @media #{$media-md} {
+    @media #{$mq-md} {
         .logo,
         section,
         .small-links,

--- a/media/css/protocol/components/_global-nav.scss
+++ b/media/css/protocol/components/_global-nav.scss
@@ -113,7 +113,7 @@ $color-button-green: #16da00;
             height: 25px;
         }
 
-        @media #{$media-lg} {
+        @media #{$mq-lg} {
             margin-left: 17px;
 
             a {
@@ -132,11 +132,11 @@ $color-button-green: #16da00;
         padding: 10px 0;
         position: relative;
 
-        @media #{$media-md} {
+        @media #{$mq-md} {
             padding-top: 25px;
         }
 
-        @media #{$media-lg} {
+        @media #{$mq-lg} {
             margin-left: 28px;
         }
     }
@@ -170,18 +170,18 @@ $color-button-green: #16da00;
             }
         }
 
-        @media #{$media-md} {
+        @media #{$mq-md} {
             @include border-box;
             display: block;
             margin-left: 20px;
             width: calc(100% - 370px);
         }
 
-        @media #{$media-lg} {
+        @media #{$mq-lg} {
             width: calc(100% - 480px);
         }
 
-        @media #{$media-xl} {
+        @media #{$mq-xl} {
             margin-left: 40px;
 
             &> li {
@@ -201,8 +201,8 @@ $color-button-green: #16da00;
         }
     }
 
-    @media #{$media-lg} {
-        max-width: $width-content-max;
+    @media #{$mq-lg} {
+        max-width: $content-max;
         margin: 0 auto;
     }
 }
@@ -296,7 +296,7 @@ $color-button-green: #16da00;
             transform: translate(7px, 7px) rotate(45deg);
         }
 
-        @media #{$media-lg} {
+        @media #{$mq-lg} {
 
             .rect {
                 transition: transform .12s ease-in-out;
@@ -571,7 +571,7 @@ html.moz-nav-open .moz-global-nav-page-mask {
         }
     }
 
-    @media #{$media-md} {
+    @media #{$mq-md} {
         margin-top: 5px;
         margin-right: 64px;
         width: 200px;
@@ -581,7 +581,7 @@ html.moz-nav-open .moz-global-nav-page-mask {
         }
     }
 
-    @media #{$media-lg} {
+    @media #{$mq-lg} {
         margin-right: 95px;
     }
 
@@ -672,7 +672,7 @@ html.moz-nav-open {
         visibility: hidden;
     }
 
-    @media #{$media-lg} {
+    @media #{$mq-lg} {
         html.moz-nav-open {
             height: 100%;
 

--- a/media/css/protocol/components/_masthead.scss
+++ b/media/css/protocol/components/_masthead.scss
@@ -18,16 +18,16 @@ $color-button-green: #16da00;
         @include border-box;
         @include clearfix;
         margin: 0 auto;
-        max-width: $width-content-max;
-        min-width: $width-content-xs;
+        max-width: $content-max;
+        min-width: $content-xs;
         padding: $layout-xs;
         position: relative;
 
-        @media #{$media-md} {
+        @media #{$mq-md} {
             padding: $layout-xs $layout-lg;
         }
 
-        @media #{$media-lg} {
+        @media #{$mq-lg} {
             padding: $layout-xs $layout-xl;
         }
     }
@@ -47,7 +47,7 @@ $color-button-green: #16da00;
             height: 30px;
         }
 
-        @media #{$media-md} {
+        @media #{$mq-md} {
             float: left;
             position: relative;
             width: 94px;
@@ -112,7 +112,7 @@ $color-button-green: #16da00;
 
         a {
             background: #fff;
-            color: $color-primary;
+            color: $color-black;
             display: block;
             padding: 10px 20px;
             text-decoration: none;
@@ -139,7 +139,7 @@ $color-button-green: #16da00;
     display: none;
 }
 
-@media #{$media-md} {
+@media #{$mq-md} {
 
     .masthead-nav-main {
         float: left;
@@ -194,7 +194,7 @@ $color-button-green: #16da00;
     }
 }
 
-@media #{$media-lg} {
+@media #{$mq-lg} {
     .masthead-nav-main {
         width: 60%;
 
@@ -204,7 +204,7 @@ $color-button-green: #16da00;
     }
 }
 
-@media #{$media-xl} {
+@media #{$mq-xl} {
     .masthead-nav-main {
         margin: 0 0 0 40px;
         width: 70%;
@@ -217,7 +217,7 @@ $color-button-green: #16da00;
 
 // flexbox layout for savvy browsers to push nav items to the right
 @supports (display: flex) {
-    @media #{$media-md} {
+    @media #{$mq-md} {
         .nav-main-menu,
         .js .nav-main-menu {
             @include flexbox;
@@ -240,7 +240,7 @@ $color-button-green: #16da00;
                 border-right: none;
                 border-left: 6px solid #000;
 
-                @media #{$media-md} {
+                @media #{$mq-md} {
                     border: 0;
                 }
             }
@@ -251,24 +251,24 @@ $color-button-green: #16da00;
             padding-left: 0;
             padding-right: 5px;
 
-            @media #{$media-md} {
+            @media #{$mq-md} {
                 padding-right: 10px;
             }
 
-            @media #{$media-xl} {
+            @media #{$mq-xl} {
                 padding-right: 20px;
             }
         }
     }
 
-    @media #{$media-md} {
+    @media #{$mq-md} {
         .masthead-logo,
         .masthead-nav-main {
             float: right;
         }
     }
 
-    @media #{$media-xl} {
+    @media #{$mq-xl} {
         .masthead-nav-main {
             margin: 0 40px 0 0;
 
@@ -321,7 +321,7 @@ $color-button-green: #16da00;
         }
     }
 
-    @media #{$media-lg} {
+    @media #{$mq-lg} {
         display: block;
         width: 200px;
 
@@ -341,7 +341,7 @@ html[dir="rtl"] {
     #nav-download-firefox {
         float: left;
 
-        @media #{$media-md} {
+        @media #{$mq-md} {
 
             .download-link {
                 float: left;

--- a/media/css/protocol/protocol.scss
+++ b/media/css/protocol/protocol.scss
@@ -10,5 +10,4 @@ $image-path: '/media/protocol/img';
 // TODO port these components to Protocol.
 @import "components/global-nav";
 @import "components/masthead";
-@import "components/footer";
 @import "components/download-button";

--- a/media/js/base/protocol/init-lang-switcher.js
+++ b/media/js/base/protocol/init-lang-switcher.js
@@ -1,0 +1,20 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * Initialize Protocol language switcher.
+ */
+(function() {
+    if (typeof Mozilla === 'undefined' || typeof Mozilla.LangSwitcher === 'undefined') {
+        return;
+    }
+
+    Mozilla.LangSwitcher.init(function(previousLanguage, newLanguage) {
+        window.dataLayer.push({
+            'event': 'change-language',
+            'languageSelected': newLanguage,
+            'previousLanguage': previousLanguage
+        });
+    });
+})();

--- a/media/js/mozorg/home/home.js
+++ b/media/js/mozorg/home/home.js
@@ -62,6 +62,7 @@
 
             Mozilla.Modal.createModal(this, content, {
                 title: title,
+                className: 'mzp-has-media',
                 onCreate: function() {
                     try {
                         video.load();

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -331,6 +331,12 @@
     },
     {
       "files": [
+        "css/protocol/oldIE.scss"
+      ],
+      "name": "protocol-oldIE"
+    },
+    {
+      "files": [
         "css/legal/legal.less",
         "css/newsletter/moznewsletter-subscribe.less"
       ],
@@ -1389,6 +1395,8 @@
     {
         "files": [
             "js/libs/jquery-3.2.1.min.js",
+            "protocol/js/protocol-lang-switcher.js",
+            "js/base/protocol/init-lang-switcher.js",
             "js/base/mozilla-utils.js",
             "js/base/mozilla-client.js",
             "js/base/mozilla-image-helper.js",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Making mozilla.org awesome, one pebble at a time",
   "private": true,
   "dependencies": {
-    "@mozilla-protocol/core": "1.0.1",
+    "@mozilla-protocol/core": "2.0.1",
     "ansi-colors": "^1.1.0",
     "clean-css-cli": "4.0.5",
     "del": "^3.0.0",

--- a/tests/functional/test_l10n.py
+++ b/tests/functional/test_l10n.py
@@ -6,12 +6,12 @@ import random
 
 import pytest
 
-from pages.home import HomePage
+from pages.firefox.new.download import DownloadPage
 
 
 @pytest.mark.nondestructive
 def test_change_language(base_url, selenium):
-    page = HomePage(selenium, base_url).open()
+    page = DownloadPage(selenium, base_url).open()
     initial = page.footer.language
     # avoid selecting the same language or locales that have homepage redirects
     excluded = [initial, 'ja', 'ja-JP-mac', 'zh-CN']

--- a/yarn.lock
+++ b/yarn.lock
@@ -19,9 +19,9 @@
     normalize-path "^2.0.1"
     through2 "^2.0.3"
 
-"@mozilla-protocol/core@1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@mozilla-protocol/core/-/core-1.0.1.tgz#b3c261d2bdef5bfff614d6a6caca2cb4c806310c"
+"@mozilla-protocol/core@2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@mozilla-protocol/core/-/core-2.0.1.tgz#5ccc15c6212066aba8a7ccfe68fd9e0ade11c84f"
 
 JSONStream@^0.8.4:
   version "0.8.4"


### PR DESCRIPTION
## Description
- Update bedrock to `@mozilla-protocol/core` v2.0.0.
- Update bedrock homepage to use `@mozilla-protocol/tokens` values.
- Update homepage footer & language switcher to use Protocol components.
- Use `protocol-oldIE` bundle for fallback CSS.

**Blocked by**: https://github.com/mozilla/protocol/issues/174

## Issue / Bugzilla link
N/A

## Testing
Demo: https://bedrock-demo-agibson.oregon-b.moz.works/en-US/

Successful test run: https://ci.us-west.moz.works/blue/organizations/jenkins/bedrock_multibranch_pipeline/detail/run-integration-tests/197/pipeline

Things to test for:

- [ ] No major visual regressions.
- [ ] Footer language switcher still works as expected.