### PR TITLE
Fix #5928: Run full release Docker build in PR tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,8 @@ RUN yarn global add gulp-cli@2.0.1
 COPY .eslintrc.js .stylelintrc gulpfile.js ./
 COPY ./media ./media
 
+RUN gulp build --production
+
 
 ########
 # Python dependencies builder
@@ -106,18 +108,11 @@ USER webdev
 
 
 ########
-# build production assets
-#
-FROM assets AS assets-release
-RUN gulp build --production
-
-
-########
 # final image for deployment
 #
 FROM app-base AS release
 
-COPY --from=assets-release /app/static_final /app/static_final
+COPY --from=assets /app/static_final /app/static_final
 RUN honcho run --env docker/envfiles/prod.env docker/bin/build_staticfiles.sh
 
 # build args

--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ docs: .docker-build-pull
 .docker-build-ci:
 	${MAKE} build-ci
 
-build-ci: .env .docker-build-pull submodules
+build-ci: .docker-build-pull
 	${DC_CI} build release
 #	tag intermediate images using cache
 	${DC_CI} build app assets builder app-base


### PR DESCRIPTION
CircleCI was only running a partial build of our images for pull-requests, but we need it to run the full release build so that we can make sure all assets build correctly before merge.