### PR TITLE
[#5862] FxA button - append button_class to fallback buttons

### DIFF
--- a/bedrock/base/templates/macros.html
+++ b/bedrock/base/templates/macros.html
@@ -371,14 +371,14 @@
     </ul>
   </div>
   <div class="show-fxa-unsupported">
-    <a href="https://support.mozilla.org/kb/update-firefox-latest-version/?utm_source=www.mozilla.org&amp;utm_medium=referral&amp;utm_campaign={{ campaign }}" class="button button-hollow button-light" data-link-type="link" data-link-name="Update your Firefox" id="{{ update_id }}">
+    <a href="https://support.mozilla.org/kb/update-firefox-latest-version/?utm_source=www.mozilla.org&amp;utm_medium=referral&amp;utm_campaign={{ campaign }}" class="button {{ button_class }}" data-link-type="link" data-link-name="Update your Firefox" id="{{ update_id }}">
       {{ _('Update your Firefox') }}
     </a>
   </div>
   <div class="show-fxa-android">
-    <a href="https://support.mozilla.org/kb/sync-bookmarks-tabs-history-and-passwords-android/?utm_source=www.mozilla.org&amp;utm_medium=referral&amp;utm_campaign={{ campaign }}" class="button button-hollow button-light" data-link-type="link" data-link-name="Learn more" id="{{ link_id }}">{{ _('Learn more') }}</a>
+    <a href="https://support.mozilla.org/kb/sync-bookmarks-tabs-history-and-passwords-android/?utm_source=www.mozilla.org&amp;utm_medium=referral&amp;utm_campaign={{ campaign }}" class="button {{ button_class }}" data-link-type="link" data-link-name="Learn more" id="{{ link_id }}">{{ _('Learn more') }}</a>
   </div>
   <div class="show-fxa-ios">
-    <a href="https://support.mozilla.org/kb/sync-firefox-bookmarks-and-browsing-history-iOS/?utm_source=www.mozilla.org&amp;utm_medium=referral&amp;utm_campaign={{ campaign }}" class="button button-hollow button-light" data-link-type="link" data-link-name="Learn more" id="{{ link_id }}">{{ _('Learn more') }}</a>
+    <a href="https://support.mozilla.org/kb/sync-firefox-bookmarks-and-browsing-history-iOS/?utm_source=www.mozilla.org&amp;utm_medium=referral&amp;utm_campaign={{ campaign }}" class="button {{ button_class }}" data-link-type="link" data-link-name="Learn more" id="{{ link_id }}">{{ _('Learn more') }}</a>
   </div>
 {%- endmacro %}


### PR DESCRIPTION
## Description
When I added the new button_class param I neglected to append it to the other buttons shown for other cases (mobile, outdated Firefox, etc).

## Testing
Test in Firefox on a mobile device or use dev tools to hide/unhide the various bits.