### PR TITLE
Use staticfiles.json map to set proper cache headers in s3

### DIFF
--- a/bin/move_hashed_staticfiles.py
+++ b/bin/move_hashed_staticfiles.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python
+
+from __future__ import print_function, unicode_literals
+
+import json
+import os
+import sys
+from textwrap import dedent
+
+
+def get_hashed_filenames(static_path):
+    json_file = '{}/staticfiles.json'.format(static_path)
+    with open(json_file) as jsonf:
+        staticfiles = json.load(jsonf)
+
+    return staticfiles['paths'].values()
+
+
+def move_hashed_files(static_path, hashed_path):
+    filenames = get_hashed_filenames(static_path)
+    moved_count = 0
+    for filename in filenames:
+        # some filenames in the file are in the form
+        # fontawesome/fonts/fontawesome-webfont.f7c2b4b747b1.eot?v=4.3.0
+        # we can skip these as they're duplicated
+        if '?' in filename:
+            continue
+
+        src_fn = os.path.join(static_path, filename)
+        dst_fn = os.path.join(hashed_path, filename)
+        if not os.path.exists(os.path.dirname(dst_fn)):
+            os.makedirs(os.path.dirname(dst_fn))
+
+        os.rename(src_fn, dst_fn)
+        moved_count += 1
+
+    return moved_count
+
+
+def main(static_path, hashed_path):
+    moved = move_hashed_files(static_path, hashed_path)
+    print('Successfully moved {} files'.format(moved))
+
+
+if __name__ == '__main__':
+    try:
+        main(sys.argv[1], sys.argv[2])
+    except IndexError:
+        sys.exit(dedent("""\
+            ERROR: source and destination directory arguments required.
+
+            Usage: move_hashed_staticfiles.py <source_dir> <dest_dir>
+
+            Moves hashed static files from source_dir to dest_dir based on the
+            map of staticfiles in `source_dir/staticfiles.json`.
+        """))

--- a/bin/upload-staticfiles.sh
+++ b/bin/upload-staticfiles.sh
@@ -9,32 +9,37 @@ if [[ "$BRANCH_NAME" != "prod" ]]; then
     exit 0
 fi
 
+TMP_DIR="s3-static"
+TMP_DIR_HASHED="s3-static-hashed"
 CONTAINER_NAME="bedrock-${BRANCH_AND_COMMIT}"
 
-rm -rf static
+rm -rf "${TMP_DIR}"
+rm -rf "${TMP_DIR_HASHED}"
+
 # have to rerun staticfiles without symlinks or we just copy broken symlinks
 docker-compose run --name "$CONTAINER_NAME" release docker/bin/build_staticfiles.sh --nolink
-docker cp "${CONTAINER_NAME}:/app/static" ./static
+docker cp "${CONTAINER_NAME}:/app/static" "${TMP_DIR}"
 docker rm -f "$CONTAINER_NAME"
+
+# separate the hashed files into another directory
+bin/move_hashed_staticfiles.py "${TMP_DIR}" "${TMP_DIR_HASHED}"
 
 for BUCKET in stage prod; do
     # hashed filenames
     aws s3 sync \
-        --exclude "*" \
-        --include "*.????????????.*" \
         --acl public-read \
         --cache-control "max-age=315360000, public, immutable" \
         --profile bedrock-media \
-        ./static "s3://bedrock-${BUCKET}-media/media/"
+        "./${TMP_DIR_HASHED}" "s3://bedrock-${BUCKET}-media/media/"
     # non-hashed filenames
     # may not need to include non-hashed files
     # TODO look into this if this is slow or makes the bucket too large
     aws s3 sync \
-        --exclude "*.????????????.*" \
         --acl public-read \
         --cache-control "max-age=21600, public" \
         --profile bedrock-media \
-        ./static "s3://bedrock-${BUCKET}-media/media/"
+        "./${TMP_DIR}" "s3://bedrock-${BUCKET}-media/media/"
 done
 
-rm -rf static
+rm -rf "${TMP_DIR}"
+rm -rf "${TMP_DIR_HASHED}"


### PR DESCRIPTION
Instead of trying to match filenames it is more accurate to use the JSON map Django gives us to move the hashed files to a new directory and do the `aws s3 sync` separately for each type of file.