### PR TITLE
Don't run db-update commands during docker build

### DIFF
--- a/bin/sync-all.sh
+++ b/bin/sync-all.sh
@@ -10,4 +10,3 @@ fi
 ./manage.py migrate --noinput
 ./manage.py l10n_update
 ./manage.py update_sitemaps
-./bin/run-db-update.sh --all


### PR DESCRIPTION
Only download the current database and run migrations.