### PR TITLE
Use :latest docker tags for builds from "master"

### DIFF
--- a/docker/bin/push2dockerhub.sh
+++ b/docker/bin/push2dockerhub.sh
@@ -19,9 +19,14 @@ fi
 # Push to docker hub
 docker push $FROM_DOCKER_REPOSITORY:${DOCKER_TAG}
 
+if [[ "$BRANCH_NAME" == "master" ]]; then
+    docker tag $FROM_DOCKER_REPOSITORY:${DOCKER_TAG} $FROM_DOCKER_REPOSITORY:latest
+    docker push $FROM_DOCKER_REPOSITORY:latest
+fi
+
 if [[ "$GIT_TAG_DATE_BASED" == true ]]; then
     docker tag $FROM_DOCKER_REPOSITORY:${DOCKER_TAG} $FROM_DOCKER_REPOSITORY:$GIT_TAG
-    docker tag $FROM_DOCKER_REPOSITORY:${DOCKER_TAG} $FROM_DOCKER_REPOSITORY:latest
+    docker tag $FROM_DOCKER_REPOSITORY:${DOCKER_TAG} $FROM_DOCKER_REPOSITORY:prod-latest
     docker push $FROM_DOCKER_REPOSITORY:$GIT_TAG
-    docker push $FROM_DOCKER_REPOSITORY:latest
+    docker push $FROM_DOCKER_REPOSITORY:prod-latest
 fi


### PR DESCRIPTION
Add :prod-latest tags for production images. This means that local devs would get updated images with updated dependencies much more quickly just via a `make pull` instead of having to build fresh images themselves.