### PR TITLE
Changes to bug bounty pages for safe harbor

### DIFF
--- a/bedrock/security/templates/security/bug-bounty.html
+++ b/bedrock/security/templates/security/bug-bounty.html
@@ -11,17 +11,49 @@
     <div itemprop="articleBody">
       <h2>Introduction</h2>
 
-      <p>The Mozilla Security Bug Bounty Program is designed to encourage
-        security research in Mozilla software and to reward those who help us create
-        the safest Internet clients in existence.</p>
+      <p>The Mozilla Security Bug Bounty Program is designed to encourage security research in Mozilla software and to reward those who help us make the internet a safer place.</p>
 
-      <p>Many thanks to <a href="http://en.wikipedia.org/wiki/Linspire">Linspire</a>
-        and <a href="http://www.markshuttleworth.com/">Mark Shuttleworth</a>, who
-        provided start-up funding for this endeavor.</p>
+      <h2>General Eligibility</h2>
 
-      <p>Mozilla has paid out around 3 million dollars in bounties to our various researchers!</p>
+      <p>To be eligible for a reward under this program: </p>
+      
+      <ul class="prose">
+        <li>The security bug must be original and previously unreported.</li>
+        <li>The security bug must be a part of Mozilla’s code, not the code of a third party.  We will pay bounties for vulnerabilities in third-party libraries incorporated into shipped client code or third-party websites utilized by Mozilla.</li>
+        <li>You must not have written the buggy code or otherwise been involved in contributing the buggy code to the Mozilla project.</li>
+        <li>You must be old enough to be eligible participate in and receive payment from this program in your jurisdiction, or otherwise qualify to receive payment, whether through consent from your parent or guardian or some other way.</li>
+        <li>You must not be an employee, contractor, or otherwise have a business relationship with the Mozilla Foundation or any of its subsidiaries.</li>
+        <li>You should use your best effort not to access, modify, delete, or store user data or Mozilla’s data. Instead, use your own accounts or test accounts for security research purposes.</li>
+        <li>If you inadvertently access, modify, delete, or store user data, we ask that you notify Mozilla immediately at <a href="security@mozilla.org">security@mozilla.org</a> and delete any stored data after notifying us.</li>
+        <li>You must not be on a US sanctions list or in a country (e.g. Cuba, Iran, North Korea, Sudan and Syria) on the US sanctions list.</li>
+        <li>You must not exploit the security vulnerability for your own gain.</li>
+        <li>You must give us a reasonable amount of time to address the security issue you raise before making any part of it public.</li>
+      </ul>
 
-      <p>Mozilla manages two different bug bounty programs.  One focuses on Firefox and other Mozilla applications and the other covers our websites and services.</p>
+      <p>If a bug is reported by a team or by multiple researchers simultaneously, the bounty will be split evenly amongst them.</p>
+
+      <p>Do not threaten or attempt to extort Mozilla. We will not award a bounty if you threaten to withhold the security issue from us or if you threaten to release the vulnerability or any exposed data to the public.</p>
+
+      <h2>Safe Harbor</h2>
+
+      <p>Mozilla strongly supports security research into our products and wants to encourage that research.</p>
+
+      <p>As a result, we will not threaten or bring any legal action against anyone who makes a good faith effort to comply with this Bug Bounty Program, or for any accidental or good faith violation of this policy. This includes any claim under the DMCA for circumventing technological measures to protect the services and applications eligible under this policy.</p>
+
+      <p>As long as you comply with this policy:</p>
+      
+      <ul class="prose">
+        <li>We consider your security research to be "authorized" under the Computer Fraud and Abuse Act,</li>
+        <li>We waive any restrictions in our applicable Terms of Service and <a href="{{ url('legal.terms.acceptable-use') }}">Acceptable Use Policy</a> that would prohibit your participation in this policy, for the limited purpose of your security research under this policy.</li>
+      </ul>
+
+      <p>We understand that many Mozilla systems and services are interconnected with third-party systems and services. While we can authorize your research on Mozilla’s systems and services, and promise that Mozilla will not bring or threaten litigation against you for your efforts under this policy, we cannot authorize efforts on third-party products or guarantee they won’t pursue legal action against you. However, if a third party threatens or brings any legal action against you for your efforts under this policy, we are willing to make clear&mdash;to the Court, the public, or otherwise--that we authorized your efforts to test and research the security of Mozilla’s eligible systems and services.</p>
+
+      <p><strong>If you’re not sure whether your conduct complies with this policy, please contact us first at <a href="security@mozilla.org">security@mozilla.org</a> and we will do our best to clarify.</strong></p>
+
+      <h2>Web and Client</h2>
+
+      <p>Mozilla manages two different bug bounty programs. One focuses on Firefox and other Mozilla applications and the other covers our websites and services.</p>
 
       <ul class="prose">
         <li><a href="{{ url('security.client-bug-bounty') }}">Client Bug Bounty Guidelines</a></li>

--- a/bedrock/security/templates/security/bug-bounty.html
+++ b/bedrock/security/templates/security/bug-bounty.html
@@ -24,7 +24,7 @@
         <li>You must be old enough to be eligible participate in and receive payment from this program in your jurisdiction, or otherwise qualify to receive payment, whether through consent from your parent or guardian or some other way.</li>
         <li>You must not be an employee, contractor, or otherwise have a business relationship with the Mozilla Foundation or any of its subsidiaries.</li>
         <li>You should use your best effort not to access, modify, delete, or store user data or Mozilla’s data. Instead, use your own accounts or test accounts for security research purposes.</li>
-        <li>If you inadvertently access, modify, delete, or store user data, we ask that you notify Mozilla immediately at <a href="security@mozilla.org">security@mozilla.org</a> and delete any stored data after notifying us.</li>
+        <li>If you inadvertently access, modify, delete, or store user data, we ask that you notify Mozilla immediately at <a href="mailto:security@mozilla.org">security@mozilla.org</a> and delete any stored data after notifying us.</li>
         <li>You must not be on a US sanctions list or in a country (e.g. Cuba, Iran, North Korea, Sudan and Syria) on the US sanctions list.</li>
         <li>You must not exploit the security vulnerability for your own gain.</li>
         <li>You must give us a reasonable amount of time to address the security issue you raise before making any part of it public.</li>
@@ -49,7 +49,7 @@
 
       <p>We understand that many Mozilla systems and services are interconnected with third-party systems and services. While we can authorize your research on Mozilla’s systems and services, and promise that Mozilla will not bring or threaten litigation against you for your efforts under this policy, we cannot authorize efforts on third-party products or guarantee they won’t pursue legal action against you. However, if a third party threatens or brings any legal action against you for your efforts under this policy, we are willing to make clear&mdash;to the Court, the public, or otherwise--that we authorized your efforts to test and research the security of Mozilla’s eligible systems and services.</p>
 
-      <p><strong>If you’re not sure whether your conduct complies with this policy, please contact us first at <a href="security@mozilla.org">security@mozilla.org</a> and we will do our best to clarify.</strong></p>
+      <p><strong>If you’re not sure whether your conduct complies with this policy, please contact us first at <a href="mailto:security@mozilla.org">security@mozilla.org</a> and we will do our best to clarify.</strong></p>
 
       <h2>Web and Client</h2>
 

--- a/bedrock/security/templates/security/client-bug-bounty.html
+++ b/bedrock/security/templates/security/client-bug-bounty.html
@@ -12,36 +12,18 @@
       <h2>Introduction</h2>
 
       <p>The Mozilla Client Security Bug Bounty Program is designed to encourage security research in Mozilla software and to reward those who help us create the safest Internet software in existence.</p>
-
-      <h2>General Client Bounty Guidelines</h2>
-
-      <p>Mozilla will pay a bounty for certain client security bugs,  as detailed below.  All security bugs must follow the following general criteria to be eligible:
-      </p>
-
-      <ul class="prose">
-        <li>Security bug must be original and previously unreported.</li>
-        <li>Security bug must be a remote exploit, the cause of a privilege escalation, or an information leak.</li>
-        <li>Submitter must not be the author of the buggy code nor otherwise involved
-          in its
-          contribution to the Mozilla project (such as by providing check-in
-          reviews).
-        </li>
-        <li>Employees of the Mozilla Foundation and its subsidiaries are
-          ineligible.
-        </li>
-      </ul>
-      <p>If two or more people report the bug together the
-        reward will be divided among them. </p>
+      
+      <p><strong>Guidelines:</strong> In addition to our <a href="{{ url('security.bug-bounty') }}">general eligibility requirements</a>, a security bug must be a remote exploit, the cause of a privilege escalation, or an information leak. 
 
       <h2>Reward Guidelines</h2>
 
       <p>Mozilla will pay a bounty for client and security bugs as detailed below. All security bugs must follow the following general criteria to be eligible:</p>
 
-       <p> Eligible security bugs may be present in any of the current main development or released versions of Firefox or Firefox for Android as released by Mozilla Corporation (e.g. Nightly mozilla-central or Beta test versions, as well as the final release product versions)</p>
-
-        <p>The security rating given by the Bounty Committee for a bug must be rated a "sec-critical" or a "sec-high" in order for it to be eligible for a bounty. Some "sec-moderate" bugs may be eligible for the bounty as well. (See <a href="https://wiki.mozilla.org/Security_Severity_Ratings">Security Ratings</a> for details of the rating qualifications.)</p>
-
-        <p>All bounties paid will be at the discretion of the Mozilla Bounty Committee.  The committee will evaluate the severity of reported issues with the help of engineers who work on the affected code. Security researchers are invited to participate in the assignment of ratings, but final decisions on the rating are at the discretion of the Bounty Committee.</p>
+      <ul class="prose">
+        <li>Eligible security bugs may be present in any of the current main development or released versions of Firefox or Firefox for Android as released by Mozilla Corporation (e.g. Nightly mozilla-central or Beta test versions, as well as the final release product versions).</li>
+        <li>The security rating given by the Bounty Committee for a bug must be rated a "sec-critical" or a "sec-high" in order for it to be eligible for a bounty. Some "sec-moderate" bugs may be eligible for the bounty as well. (See <a href="https://wiki.mozilla.org/Security_Severity_Ratings">Security Ratings</a> for details of the rating qualifications.)</li>
+        <li>All bounties paid will be at the discretion of the Mozilla Bounty Committee. The committee will evaluate the severity of reported issues with the help of engineers who work on the affected code. Security researchers are invited to participate in the assignment of ratings, but final decisions on the rating are at the discretion of the Bounty Committee.</li>
+      </ul>
 
       <h2>Rewards Amount</h2>
 
@@ -50,8 +32,8 @@
       <p>Here are some examples how to receive a higher reward</p>
       <ul class="prose">
         <li>The researcher can demonstrate new classes of attacks, or techniques for bypassing security features </li>
-
-        <li>  Or, if an existing vulnerability can be demonstrated to be exploitable though additional research by the reporter, additional compensation can be earned for the same bug. Research might also uncover extremely severe, complex, or interesting problem areas that were previously unreported or unknown issues. Examples of severe or complex bugs would be: Use After Free bugs that also allow for ASLR bypass; bypassing the Firefox security wrappers to allow content to manipulate browser components, or a vulnerability that allows you to break out of a sandboxed process.</li>
+        <li>Or, if an existing vulnerability can be demonstrated to be exploitable though additional research by the reporter, additional compensation can be earned for the same bug. Research might also uncover extremely severe, complex, or interesting problem areas that were previously unreported or unknown issues. Examples of severe or complex bugs would be: Use After Free bugs that also allow for ASLR bypass; bypassing the Firefox security wrappers to allow content to manipulate browser components, or a vulnerability that allows you to break out of a sandboxed process.</li>
+        <li>You are responsible for any tax implications depending on your country of residency and citizenship. There may be additional restrictions on your ability to enter depending upon your local law.</li>
       </ul>
 
       <p>We reserve the right not to pay bounties for security bugs in or caused by additional third party software (e.g. binary plugins, extensions) not bundled by Mozilla in a release.</p>
@@ -86,13 +68,13 @@
 
       <p>To claim a bounty:</p>
       <ul class="prose">
-        <li>Make sure you have a Bugzilla account</li>
-          <li>File a bug at <a href="https://bugzilla.mozilla.org">bugzilla.mozilla.org</a> describing the security issue.</li>
-          <li>When creating the bug, be sure to check the box near the bottom of the entry form that marks this bug report as confidential.</li>
-          <li>Attach a "proof of concept" testcase, or point to explicit code that identifies the vulnerability or exploit.  While not required, such a testcase will help us judge submissions more quickly and accurately.</li>
-          <li>If you have debug output or output from a tool demonstrating the issue, please include it in the bug. (If it is very long, please attach it to the bug as an attached file.)</li>
-          <li>Notify the Mozilla Security Group by email to security@mozilla.org and include the number of the bug you filed and a brief summary of the issue. <strong>Do not send the actual vulnerability via email.</strong></li>
-    </ul>
+        <li>Make sure you have a Bugzilla account.</li>
+        <li>Use the <a href="https://bugzilla.mozilla.org/form.client.bounty">bugzilla client bug bounty form</a> to file the issue and automatically mark it for bug bounty consideration.</li>
+        <li>In the "Description" field, please clearly describe the security issue.</li>
+        <li>If one is available, attach a "proof of concept" testcase with the "Attachment" option, or point to explicit code that identifies the vulnerability or exploit. While not required, such a testcase will help us judge submissions more quickly and accurately.</li>
+        <li>If you have debug output or output from a tool demonstrating the issue, please include it in the bug. If it is very long, please attach it to the bug as an attached file and do not add it to the description.</li>
+        <li>If you have filed the bug directly in Bugzilla without using the <a href="https://bugzilla.mozilla.org/form.client.bounty">Bugzilla client bug bounty form</a>, notify the Mozilla Security Group by email to <a href="security@mozilla.org">security@mozilla.org</a> and include the number of the bug you filed and a mention that you are submitting it for bounty consideration. <strong>Do not send the actual vulnerability via email.</strong></li>
+      </ul>
 
     <p>We ask that you be available to follow along and provide further information on the bug as needed, and invite you to work together with Mozilla engineers in reproducing, diagnosing, and fixing the bug. As part of this process we will provide you full access to participate in our internal discussions about the bug; for more information read our policy for handling security bugs.</p>
 

--- a/bedrock/security/templates/security/client-bug-bounty.html
+++ b/bedrock/security/templates/security/client-bug-bounty.html
@@ -13,7 +13,7 @@
 
       <p>The Mozilla Client Security Bug Bounty Program is designed to encourage security research in Mozilla software and to reward those who help us create the safest Internet software in existence.</p>
       
-      <p><strong>Guidelines:</strong> In addition to our <a href="{{ url('security.bug-bounty') }}">general eligibility requirements</a>, a security bug must be a remote exploit, the cause of a privilege escalation, or an information leak. 
+      <p><strong>Guidelines:</strong> In addition to our <a href="{{ url('security.bug-bounty') }}">general eligibility requirements</a>, a security bug must be a remote exploit, the cause of a privilege escalation, or an information leak.</p> 
 
       <h2>Reward Guidelines</h2>
 
@@ -73,7 +73,7 @@
         <li>In the "Description" field, please clearly describe the security issue.</li>
         <li>If one is available, attach a "proof of concept" testcase with the "Attachment" option, or point to explicit code that identifies the vulnerability or exploit. While not required, such a testcase will help us judge submissions more quickly and accurately.</li>
         <li>If you have debug output or output from a tool demonstrating the issue, please include it in the bug. If it is very long, please attach it to the bug as an attached file and do not add it to the description.</li>
-        <li>If you have filed the bug directly in Bugzilla without using the <a href="https://bugzilla.mozilla.org/form.client.bounty">Bugzilla client bug bounty form</a>, notify the Mozilla Security Group by email to <a href="security@mozilla.org">security@mozilla.org</a> and include the number of the bug you filed and a mention that you are submitting it for bounty consideration. <strong>Do not send the actual vulnerability via email.</strong></li>
+        <li>If you have filed the bug directly in Bugzilla without using the <a href="https://bugzilla.mozilla.org/form.client.bounty">Bugzilla client bug bounty form</a>, notify the Mozilla Security Group by email to <a href="mailto:security@mozilla.org">security@mozilla.org</a> and include the number of the bug you filed and a mention that you are submitting it for bounty consideration. <strong>Do not send the actual vulnerability via email.</strong></li>
       </ul>
 
     <p>We ask that you be available to follow along and provide further information on the bug as needed, and invite you to work together with Mozilla engineers in reproducing, diagnosing, and fixing the bug. As part of this process we will provide you full access to participate in our internal discussions about the bug; for more information read our policy for handling security bugs.</p>

--- a/bedrock/security/templates/security/web-bug-bounty.html
+++ b/bedrock/security/templates/security/web-bug-bounty.html
@@ -131,20 +131,6 @@
         <li>Outdated TLS configurations which remain to support downloads from Windows XP systems</li>
       </ul>
 
-      <h2 id="eligibility">Eligibility</h2>
-
-      <p>All security bugs must follow the following general criteria
-        to be eligible:</p>
-
-      <ul class="prose">
-        <li>Security bug must be original and previously unreported.</li>
-        <li>Submitter must not be the author of the buggy code nor otherwise involved in its contribution to the Mozilla project.</li>
-        <li>Employees of the Mozilla Foundation and its subsidiaries are ineligible.</li>
-      </ul>
-
-      <p>If a bug is reported by a team or by multiple researchers
-        simultaneously, the bounty will be split evenly amongst them.</p>
-
       <h2 id="how-to-submit-bugs">How To Submit Bugs</h2>
 
       <p>Please submit all bug reports via our <a href="{{ url('security.bug-bounty.faq-webapp') }}#bug-reporting">secure bug reporting process</a>.</p>


### PR DESCRIPTION
We've added Safe Harbor language to our bug bounty pages and have updated client and web bounty pages accordingly. Also added a link to the client bounty submission form.

## Description
These are changes to the bug bounty mozilla.org pages from Marshall Erwin and others on the legal team. These are text only changes to conform to new language.

## Issue / Bugzilla link

There is no open issue or bug for this.

