### PR TITLE
Update security sidebar and main index to link to top level bug bounty page

### DIFF
--- a/bedrock/security/templates/security/base.html
+++ b/bedrock/security/templates/security/base.html
@@ -12,7 +12,8 @@
     (url('security.index'), 'security-index', 'Mozilla Security'),
     (url('security.advisories'), 'advisories', 'Advisories'),
     (url('security.known-vulnerabilities'), 'known-vulnerabilities', 'Known Vulnerabilities'),
-    ('https://blog.mozilla.com/security/', 'blog', 'Blog'),
+    ('https://blog.mozilla.com/security/', 'blog', 'Mozilla Security Blog'),
+    (url('security.bug-bounty'), 'bug-bounty', 'Security Bug Bounty'),
 ] %}
 
 {% set navigation_bar_client_bounty = [

--- a/bedrock/security/templates/security/bug-bounty.html
+++ b/bedrock/security/templates/security/bug-bounty.html
@@ -6,7 +6,7 @@
 {% block article %}
   <article itemscope itemtype="http://schema.org/Article">
     <header>
-      <h1 itemprop="name"><span class="highlight">Bug Bounty Program</span></h1>
+      <h1 itemprop="name"><span class="highlight">Security Bug Bounty Program</span></h1>
     </header>
     <div itemprop="articleBody">
       <h2>Introduction</h2>
@@ -16,7 +16,7 @@
       <h2>General Eligibility</h2>
 
       <p>To be eligible for a reward under this program: </p>
-      
+
       <ul class="prose">
         <li>The security bug must be original and previously unreported.</li>
         <li>The security bug must be a part of Mozilla’s code, not the code of a third party.  We will pay bounties for vulnerabilities in third-party libraries incorporated into shipped client code or third-party websites utilized by Mozilla.</li>
@@ -41,7 +41,7 @@
       <p>As a result, we will not threaten or bring any legal action against anyone who makes a good faith effort to comply with this Bug Bounty Program, or for any accidental or good faith violation of this policy. This includes any claim under the DMCA for circumventing technological measures to protect the services and applications eligible under this policy.</p>
 
       <p>As long as you comply with this policy:</p>
-      
+
       <ul class="prose">
         <li>We consider your security research to be "authorized" under the Computer Fraud and Abuse Act,</li>
         <li>We waive any restrictions in our applicable Terms of Service and <a href="{{ url('legal.terms.acceptable-use') }}">Acceptable Use Policy</a> that would prohibit your participation in this policy, for the limited purpose of your security research under this policy.</li>

--- a/bedrock/security/templates/security/client-bug-bounty.html
+++ b/bedrock/security/templates/security/client-bug-bounty.html
@@ -12,8 +12,8 @@
       <h2>Introduction</h2>
 
       <p>The Mozilla Client Security Bug Bounty Program is designed to encourage security research in Mozilla software and to reward those who help us create the safest Internet software in existence.</p>
-      
-      <p><strong>Guidelines:</strong> In addition to our <a href="{{ url('security.bug-bounty') }}">general eligibility requirements</a>, a security bug must be a remote exploit, the cause of a privilege escalation, or an information leak.</p> 
+
+      <p><strong>Guidelines:</strong> In addition to our <a href="{{ url('security.bug-bounty') }}">general eligibility requirements</a>, a security bug must be a remote exploit, the cause of a privilege escalation, or an information leak.</p>
 
       <h2>Reward Guidelines</h2>
 

--- a/bedrock/security/templates/security/index.html
+++ b/bedrock/security/templates/security/index.html
@@ -16,18 +16,12 @@
       <h1 itemprop="name"><span class="highlight">Mozilla Security</span></h1>
     </header>
     <div itemprop="articleBody">
-      <p class="intro">Whether you’re using the Web or checking your email, you care about
-        your security and privacy. In the Mozilla project
-        <a href="{{ url('security.advisories') }}">we understand the importance of security</a>.
-        Here you will find alerts and announcements on security and privacy
-        issues, general tips for surfing the Web and using email more securely,
-        more information about how we maintain and enhance the security of our
-        products, and useful links for Web developers.</p>
+      <p class="intro">Whether you’re using the Web or checking your email, you care about your security and privacy. At Mozilla we understand the importance of security. Here you will find alerts and announcements on security and privacy issues, general tips for surfing the Web and using email more securely, more information about how we maintain and enhance the security of our products, and useful links for developers.</p>
 
       <ul class="links">
         <li>
           <h4><a href="{{ url('security.advisories') }}">
-            Mozilla Foundation Security Advisories
+            Mozilla Security Advisories
           </a></h4>
           for all products
         </li>
@@ -36,6 +30,12 @@
             Known vulnerabilities
           </a></h4>
           listed by product
+        </li>
+        <li>
+          <h4><a href="{{ url('security.bug-bounty') }}">
+            Security Bug Bounty Program
+          </a></h4>
+          Mozilla's Security Bug Bounty Program for security issues
         </li>
         <li>
           <h4>
@@ -117,7 +117,7 @@
       <ul class="prose">
         <li><strong>If you believe that you've found a Mozilla-related
           security vulnerability, please report it by sending email to the
-          address security@mozilla.org.</strong> Note that your report may be
+          address <a href="mailto:security@mozilla.org">security@mozilla.org</a>.</strong> Note that your report may be
           eligible for a reward; see below.
         </li>
         <li>For more information on how to report security vulnerabilities
@@ -125,12 +125,7 @@
           <a href="{{ url('mozorg.about.governance.policies.security.bugs') }}">policy
             for handling security bugs</a>.
         </li>
-        <li>We want to make Firefox, Thunderbird, the Mozilla Suite, and
-          other Mozilla products as secure as possible, and want to encourage
-          research, study, timely disclosure, and rapid fixing of any serious
-          security vulnerabilities. We've established a
-          <a href="{{ url('security.bug-bounty') }}">Security Bug
-            Bounty Program</a> to reward people who help us reach that objective.
+        <li>We want to make Mozilla products and sites as secure as possible, and wish to encourage research, study, timely disclosure, and rapid fixing of any serious security vulnerabilities. We've established a <a href="{{ url('security.bug-bounty') }}">Security Bug Bounty Program</a> to reward people who help us reach that objective.
         </li>
         <li>Mozilla-based products include a default list of CA certificates
           used when connecting to SSL-enabled servers and in other contexts. If you
@@ -138,19 +133,12 @@
           in Mozilla, please see the <a href="{{ url('mozorg.about.governance.policies.security.certs.policy') }}">
             Mozilla CA certificate policy</a>.
         </li>
-        <li>We encourage you to learn more about our
-          <a href="/projects/security/">Mozilla security
-            projects</a> and participate in the development of security features
-          and capabilities in our products.
-        </li>
       </ul>
     </section>
 
       <p>Press Contact: send mail to <em>press</em> at <em>mozilla dot com</em>.</p>
 
-      <p id="pgpkey">The PGP key for security@mozilla.org below can be used to send encrypted mail
-        or to verify responses received from that address. We transitioned keys in October 2017.
-        Please see our signed <a href="/security/transition.txt">transition statement</a> for confirmation.</p>
+      <p id="pgpkey">The PGP key for <a href="mailto:security@mozilla.org">security@mozilla.org</a> below can be used to send encrypted mail or to verify responses received from that address. We transitioned keys in October 2017. Please see our signed <a href="/security/transition.txt">transition statement</a> for confirmation.</p>
 
 <pre class="pgp-key">
 -----BEGIN PGP PUBLIC KEY BLOCK-----


### PR DESCRIPTION
Updating sidebar and main index to link to top level bug bounty page because there was only a hidden link to the overall progrm. Fixed mailto: links and updated language for the first time in eight years for clarity.