### PR TITLE
[fix bug 1452765] Update betterbrowser experiment query params.

### DIFF
--- a/media/js/firefox/new/better-browser-experiment.js
+++ b/media/js/firefox/new/better-browser-experiment.js
@@ -13,7 +13,7 @@
         return results === null ? '' : decodeURIComponent(results[1].replace(/\+/g, ' '));
     }
 
-    var adcontentValues = [
+    var contentValues = [
         'A144_A203_A008845',
         'A144_A203_C002355',
         'A144_A203_C003768',
@@ -30,23 +30,23 @@
         'A144_A634_C003781'
     ];
 
-    var source = getUrlParam('source');
-    var adcontent = getUrlParam('adcontent');
+    var source = getUrlParam('utm_source');
+    var content = getUrlParam('utm_content');
 
-    var mediumOk = getUrlParam('medium') === 'cpc';
+    var mediumOk = getUrlParam('utm_medium') === 'cpc';
     var sourceOk = source === 'google' || source === 'bing';
-    var adcontentOk;
+    var contentOk;
 
     // adcontent value in querystring must match a pre-defined value
-    for (var i = adcontentValues.length - 1; i > -1; i--) {
-        if (adcontentValues[i] === adcontent) {
-            adcontentOk = true;
+    for (var i = contentValues.length - 1; i > -1; i--) {
+        if (contentValues[i] === content) {
+            contentOk = true;
             break;
         }
     }
 
     // only initialize experiment if all query params are as required
-    if (mediumOk && sourceOk && adcontentOk) {
+    if (mediumOk && sourceOk && contentOk) {
         var cop = new Mozilla.TrafficCop({
             id: 'experiment_firefox_new_betterbrowser',
             variations: {


### PR DESCRIPTION
## Description

Updates the query params being verified to match those out in the wild.

## Issue / Bugzilla link

https://bugzilla.mozilla.org/show_bug.cgi?id=1452765#c36

## Testing

Code should now match a URL like the following:

https://www.mozilla.org/en-US/firefox/new/?gclid=EAIaIQobChMIrIazwNLZ3AIVE1cNCh197wCvEAMYAiAAEgJ3WPD_BwE&gclsrc=aw.ds&utm_campaign=Firefox%7cGG%7cSearch%7cNB%7cExact%7cSP%7cUS%7cEN%7cDK%7cText%7cCompetitor&utm_content=A144_A203_A008874&utm_medium=cpc&utm_source=google&utm_term=internet%20explorer