### PR TITLE
404 pages must not include canonical and hreflang x-default (Fixes #5895)

### DIFF
--- a/bedrock/base/templates/404.html
+++ b/bedrock/base/templates/404.html
@@ -10,6 +10,9 @@
 
 {% block page_title %}{{ _('404: Page Not Found') }}{% endblock %}
 
+{# 404 pages must not include canonical and hreflang x-default: https://github.com/mozilla/bedrock/issues/5895 #}
+{% block canonical_urls %}{% endblock %}
+
 {% block page_css %}
   {{ css_bundle('page_not_found') }}
 {% endblock %}


### PR DESCRIPTION
## Description
- Removes canonical and hreflang's from URLs that are 404.

## Issue / Bugzilla link
#5895

## Testing
- Hit `/en-US/404/` locally to test.