### PR TITLE
Fix #6000: Map legal-docs locales to bedrock prod locales

### DIFF
--- a/bedrock/legal_docs/views.py
+++ b/bedrock/legal_docs/views.py
@@ -15,7 +15,7 @@ from mdx_outline import OutlineExtension
 
 from bedrock.settings import path as base_path
 from lib import l10n_utils
-from product_details import product_details
+from lib.l10n_utils.dotlang import get_translations_native_names
 
 LEGAL_DOCS_PATH = base_path('vendor-local', 'src', 'legal-docs')
 CACHE_TIMEOUT = getattr(settings, 'LEGAL_DOCS_CACHE_TIMEOUT', 60 * 60)
@@ -47,10 +47,8 @@ def load_legal_doc(doc_name, locale):
     locales = [f.replace('.md', '') for f in listdir(source_dir) if f.endswith('.md')]
     # convert legal-docs locales to bedrock equivalents
     locales = [LEGAL_DOCS_LOCALES_TO_BEDROCK.get(l, l) for l in locales]
-    # filter out non-production locales
-    locales = [l for l in locales if l in settings.PROD_LANGUAGES]
-    # all codes in PROD_LANGUAGES are in product_details.languages
-    translations = {l: product_details.languages[l]['native'] for l in locales}
+    # filter out non-production locales and convert to dict with names
+    translations = get_translations_native_names(locales)
     localized = locale != settings.LANGUAGE_CODE
 
     # it's possible the legal-docs repo changed the filename to match our locale.

--- a/lib/l10n_utils/dotlang.py
+++ b/lib/l10n_utils/dotlang.py
@@ -291,16 +291,35 @@ def get_translations_for_langfile(langfile):
     """
 
     cache_key = 'translations:%s' % langfile
-    translations = cache.get(cache_key, {})
+    translations = cache.get(cache_key, None)
 
     if translations:
         return translations
 
+    langs = []
     for lang in settings.PROD_LANGUAGES:
         if (lang in product_details.languages and
                 (lang == settings.LANGUAGE_CODE or
                  lang_file_is_active(langfile, lang))):
-            translations[lang] = product_details.languages[lang]['native']
+            langs.append(lang)
 
+    translations = get_translations_native_names(langs)
     cache.set(cache_key, translations, settings.DOTLANG_CACHE)
+    return translations
+
+
+def get_translations_native_names(locales):
+    """
+    Return a dict of locale codes and native language name strings.
+
+    Returned dict is suitable for use in view contexts and is filtered to only codes in PROD_LANGUAGES.
+
+    :param locales: list of locale codes
+    :return: dict, like {'en-US': 'English (US)', 'fr': 'Français'}
+    """
+    translations = {}
+    for locale in locales:
+        if locale in settings.PROD_LANGUAGES:
+            translations[locale] = product_details.languages[locale]['native']
+
     return translations


### PR DESCRIPTION
Also filter out legal-docs translations that are not production bedrock locales.

see also: https://github.com/mozilla/legal-docs/issues/1155