### PR TITLE
Fix #6002: Remove Mozilla Board member from Foundation/About page

### DIFF
--- a/bedrock/foundation/templates/foundation/about.html
+++ b/bedrock/foundation/templates/foundation/about.html
@@ -48,7 +48,6 @@
     <li>Mitchell Baker, {{ _('Chair') }}</li>
     <li>Bob Lisbonne</li>
     <li>Brian Behlendorf</li>
-    <li>Cathy Davidson</li>
     <li>Helen Turvey</li>
     <li>Mohamed Nanabhay</li>
     <li>Nicole Wong</li>


### PR DESCRIPTION
## Description
Update about page (https://www.mozilla.org/en-US/foundation/about/ ) to remove Cathy Davidson.

## Issue / Bugzilla link
#6002

## Testing