### PR TITLE
Skip Yandex functional tests until switch is enabled

### DIFF
--- a/tests/functional/firefox/new/test_download_yandex.py
+++ b/tests/functional/firefox/new/test_download_yandex.py
@@ -7,6 +7,7 @@ import pytest
 from pages.firefox.new.download import DownloadPage
 
 
+@pytest.mark.skipif(reason='Test will only pass once SWITCH_FIRFOX_YANDEX=on')
 @pytest.mark.nondestructive
 def test_download_button_displayed(base_url, selenium):
     page = DownloadPage(selenium, base_url, locale='ru', params='?geo=us').open()
@@ -14,6 +15,7 @@ def test_download_button_displayed(base_url, selenium):
     assert page.download_button.is_transitional_link
 
 
+@pytest.mark.skipif(reason='Test will only pass once SWITCH_FIRFOX_YANDEX=on')
 @pytest.mark.nondestructive
 def test_yandex_download_button_displayed(base_url, selenium):
     page = DownloadPage(selenium, base_url, locale='ru', params='?geo=ru').open()
@@ -21,6 +23,7 @@ def test_yandex_download_button_displayed(base_url, selenium):
     assert page.download_button.is_yandex_link
 
 
+@pytest.mark.skipif(reason='Test will only pass once SWITCH_FIRFOX_YANDEX=on')
 @pytest.mark.nondestructive
 def test_other_platforms_modal(base_url, selenium):
     page = DownloadPage(selenium, base_url, params='?geo=us').open()


### PR DESCRIPTION
@craigcook I totally forgot that these tests will only pass once we enable Yandex on prod. Once this is merged we can push to prod before enabling on stage to test.
