### PR TITLE
Fix #6036: Handle no pocket article image in template

### DIFF
--- a/bedrock/mozorg/templates/mozorg/home/home-en.html
+++ b/bedrock/mozorg/templates/mozorg/home/home-en.html
@@ -225,7 +225,7 @@
             tag_label=article.domain,
             title=article.display_title,
             ga_title='Pocket Link {}'.format(loop.index),
-            image_url=article.image,
+            image_url=article.image_src or 'pocket/pocket-feed-default.png',
             aspect_ratio='mzp-has-aspect-16-9',
             link_url=article.url
           ) }}

--- a/bedrock/mozorg/views.py
+++ b/bedrock/mozorg/views.py
@@ -186,7 +186,7 @@ def home_view(request):
 
     if locale.startswith('en-'):
         template_name = 'mozorg/home/home-en.html'
-        ctx['pocket_articles'] = PocketArticle.objects.all()
+        ctx['pocket_articles'] = PocketArticle.objects.all()[:4]
     else:
         template_name = 'mozorg/home/home.html'
 

--- a/bedrock/pocketfeed/api.py
+++ b/bedrock/pocketfeed/api.py
@@ -8,7 +8,7 @@ from django.conf import settings
 from raven.contrib.django.raven_compat.models import client as sentry_client
 
 
-def get_articles_data(count=4):
+def get_articles_data(count=8):
     payload = {
         'consumer_key': settings.POCKET_CONSUMER_KEY,
         'access_token': settings.POCKET_ACCESS_TOKEN,

--- a/bedrock/pocketfeed/api.py
+++ b/bedrock/pocketfeed/api.py
@@ -5,6 +5,7 @@ import re
 import requests
 
 from django.conf import settings
+from django.utils.timezone import make_aware, utc
 from raven.contrib.django.raven_compat.models import client as sentry_client
 
 
@@ -31,7 +32,7 @@ def complete_articles_data(articles):
         article['pocket_id'] = article['id']
 
         # convert time_shared from unix timestamp to datetime
-        article['time_shared'] = datetime.datetime.fromtimestamp(int(article['time_shared']))
+        article['time_shared'] = make_aware(datetime.datetime.fromtimestamp(int(article['time_shared'])), utc)
 
         # remove data points we don't need
         del article['comment']

--- a/bedrock/pocketfeed/management/commands/update_pocketfeed.py
+++ b/bedrock/pocketfeed/management/commands/update_pocketfeed.py
@@ -13,7 +13,7 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         if settings.POCKET_CONSUMER_KEY and settings.POCKET_ACCESS_TOKEN:
-            updated, deleted = PocketArticle.objects.refresh(count=4)
+            updated, deleted = PocketArticle.objects.refresh(count=8)
 
             if updated is None:
                 raise CommandError('There was a problem updating the Pocket feed')

--- a/bedrock/pocketfeed/models.py
+++ b/bedrock/pocketfeed/models.py
@@ -52,16 +52,17 @@ class PocketArticleManager(models.Manager):
         for obj, article in articles_to_update:
             try:
                 if obj:
-                    for key, value in article.iteritems():
-                        setattr(obj, key, value)
-                    obj.save()
+                    if obj.time_shared != article['time_shared']:
+                        for key, value in article.iteritems():
+                            setattr(obj, key, value)
+                        obj.save()
+                        update_count += 1
                 else:
                     self.create(**article)
+                    update_count += 1
             except DatabaseError:
                 sentry_client.captureException()
                 raise
-
-            update_count += 1
 
         # clean up after changes
         if update_count:

--- a/bedrock/pocketfeed/models.py
+++ b/bedrock/pocketfeed/models.py
@@ -2,7 +2,6 @@
 
 from __future__ import print_function, unicode_literals
 
-from django.contrib.staticfiles.storage import staticfiles_storage
 from django.db import models
 from django.db.utils import DatabaseError
 
@@ -91,14 +90,6 @@ class PocketArticle(models.Model):
     def __unicode__(self):
         return self.title
 
-    @staticmethod
-    def fallback_image():
-        return staticfiles_storage.url('img/pocket/pocket-feed-default.png')
-
     @property
     def display_title(self):
         return Markup(self.title).unescape()
-
-    @property
-    def image(self):
-        return self.image_src or self.fallback_image()

--- a/bedrock/pocketfeed/tests/test_api.py
+++ b/bedrock/pocketfeed/tests/test_api.py
@@ -1,4 +1,5 @@
 from django.test import override_settings
+from django.utils.timezone import make_aware, utc
 
 from bedrock.pocketfeed import api
 
@@ -52,7 +53,7 @@ def test_complete_articles_data(req_mock):
     assert 'quote' not in articles[0][1]
 
     # 'time_shared' should be converted to a datetime value
-    assert articles[0][1]['time_shared'] == datetime.datetime(2018, 7, 18, 11, 14, 18)
+    assert articles[0][1]['time_shared'] == make_aware(datetime.datetime(2018, 7, 18, 11, 14, 18), utc)
 
     # should have attempted to GET request against image_src
     req_mock.get.assert_called_once_with('https://www.test.com/test.png')

--- a/bedrock/pocketfeed/tests/test_models.py
+++ b/bedrock/pocketfeed/tests/test_models.py
@@ -50,10 +50,10 @@ def test_refresh_articles():
     assert article.url == 'https://blog.mozilla.org/blog/2018/07/18/mozilla-responds-to-european-commissions-google-android-decision'
     assert article.image == article.image_src
 
-    # this article's image_src is http (not https), so should get the fallback image
+    # this article's image_src is http (not https), so should be None
     article = articles.get(pocket_id=2248108002)
-    assert article.image == PocketArticle.fallback_image()
+    assert article.image is None
 
-    # this article has an empty image_src, so should get the fallback image
+    # this article has an empty image_src, so should be None
     article = articles.get(pocket_id=2262115700)
-    assert article.image == PocketArticle.fallback_image()
+    assert article.image is None

--- a/bedrock/pocketfeed/tests/test_models.py
+++ b/bedrock/pocketfeed/tests/test_models.py
@@ -48,12 +48,12 @@ def test_refresh_articles():
     article = articles.get(pocket_id=2262198874)
     assert article.domain == 'blog.mozilla.org'
     assert article.url == 'https://blog.mozilla.org/blog/2018/07/18/mozilla-responds-to-european-commissions-google-android-decision'
-    assert article.image == article.image_src
+    assert article.image_src.startswith('https://img-getpocket.cdn.mozilla.net')
 
     # this article's image_src is http (not https), so should be None
     article = articles.get(pocket_id=2248108002)
-    assert article.image is None
+    assert article.image_src is None
 
     # this article has an empty image_src, so should be None
     article = articles.get(pocket_id=2262115700)
-    assert article.image is None
+    assert article.image_src is None


### PR DESCRIPTION
The fallback image is currently passed through `lazy_img` but could be used in other contexts, so this should be handled at the view or template layer.

Also increase the number of articles fetched to 8 and limit the display to 4. This will help if one of the fetched articles fails to store for some reason.

Only update pocket articles when timestamp changes. This will prevent the DB from appearing to change on every run of `update_pocketfeed`.

Fix warnings from storing non-aware datetime objects for pocket.