### PR TITLE
Fix Bug 1339226 - Update download buttons for Windows XP/Vista users once Firefox 52 ESR reaches EOL

### DIFF
--- a/bedrock/firefox/templates/firefox/all.html
+++ b/bedrock/firefox/templates/firefox/all.html
@@ -104,7 +104,9 @@
     <h1>{{ self.page_title()  }}</h1>
     <h2>{{ self.page_desc() }}{% if self.learn_more_url() %} <a href="{{ self.learn_more_url() }}">{{ _('Learn more') }}</a>{% endif %}</h2>
     {% if channel == 'nightly' %}
-    <p class="warning">{{ _('<strong>Warning</strong>: Nightly is updated daily. It is most appropriate for core Mozilla contributors and early adopters, not regular users.') }}</p>
+    <p class="warning nightly">{{ _('<strong>Warning</strong>: Nightly is updated daily. It is most appropriate for core Mozilla contributors and early adopters, not regular users.') }}</p>
+    {% elif channel == 'release' %}
+    <p class="warning xpvista">{{ _('<a href="%(url)s">Mozilla no longer provides security updates for Firefox on Windows XP or Vista</a>, but you can still download the final Windows 32-bit version.')|format(url='https://support.mozilla.org/kb/end-support-windows-xp-and-vista') }}</p>
     {% endif %}
     <ul>
       {% if channel != 'nightly' %}

--- a/bedrock/firefox/templates/firefox/new/scene1.html
+++ b/bedrock/firefox/templates/firefox/new/scene1.html
@@ -31,6 +31,7 @@
     <p class="version-message android-old">{{_('<a href="%(url)s">Update</a> your Firefox for the latest in speed and privacy.')|format(url='https://support.mozilla.org/kb/update-latest-version-firefox-android')}}</p>
     <p class="version-message desktop-old">{{_('<a href="%(url)s">Update</a> your Firefox for the latest in speed and privacy.')|format(url='https://support.mozilla.org/kb/update-firefox-latest-version') }}</p>
     <p class="version-message firefox-pre-release">{{_('You’re using a pre-release version of Firefox.') }}</p>
+    <p class="version-message windows-xpvista">{{_('You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.')|format(url='https://support.mozilla.org/kb/end-support-windows-xp-and-vista') }}</p>
   </div>
 </div>
 {% endblock %}

--- a/bedrock/firefox/templates/firefox/new/scene2.html
+++ b/bedrock/firefox/templates/firefox/new/scene2.html
@@ -58,6 +58,9 @@
 {% block content %}
 <main class="main mzp-t-firefox mzp-t-dark">
   <section class="status">
+    <div class="mzp-l-content mzp-t-firefox windows-xpvista">
+      <p>{{ _('You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.')|format(url='https://support.mozilla.org/kb/end-support-windows-xp-and-vista') }}</p>
+    </div>
     <div class="mzp-l-content mzp-t-firefox">
       {# fallback_url is replaced by the platform download link via JS, but if
         something fails the user should still get a link to a working download path. #}

--- a/media/css/firefox/all.less
+++ b/media/css/firefox/all.less
@@ -25,14 +25,41 @@
         .span-all();
         margin-top: @baseLine;
     }
-    p.warning {
-        font-size: @largeFontSize;
-    }
     li {
         margin: 0;
         list-style-type: none;
         a:after {
             content: "\00A0\00BB";
+        }
+    }
+
+    .warning {
+        position: relative;
+        .border-box();
+        border: 2px solid #FFA500;
+        padding: 10px 15px;
+        color: @textColorSecondary;
+        background-color: #FAFAD2;
+        font-size: @largeFontSize;
+        text-align: left;
+
+        &.xpvista {
+            display: none;
+
+            .windows.xpvista & {
+                display: block;
+            }
+        }
+
+        a:link,
+        a:visited,
+        a:hover,
+        a:focus,
+        a:active {
+            color: @textColorSecondary;
+            text-decoration: underline;
+            .open-sans-light();
+            font-weight: bold;
         }
     }
 }

--- a/media/css/firefox/new/scene1.scss
+++ b/media/css/firefox/new/scene1.scss
@@ -109,6 +109,20 @@ html.android.firefox-old {
     }
 }
 
+html.windows.xpvista {
+    .version-message-container {
+        display: block;
+    }
+
+    .version-message.windows-xpvista {
+        display: inline-block;
+
+        &:before {
+            background-image: url('/media/img/firefox/new/icon-alert.svg');
+        }
+    }
+}
+
 .linux-arm-download-instructions {
     display: none;
     margin-top: 40px;

--- a/media/css/firefox/new/scene2.scss
+++ b/media/css/firefox/new/scene2.scss
@@ -41,6 +41,25 @@ $image-path: '/media/protocol/img';
     p {
         margin: 0;
     }
+
+    .windows-xpvista {
+        display: none;
+        max-width: none;
+        color: $color-black;
+        background-color: $brand-lemon-yellow;
+
+        .windows.xpvista & {
+            display: block;
+        }
+
+        a:link,
+        a:visited,
+        a:hover,
+        a:focus,
+        a:active {
+            color: $color-black;
+        }
+    }
 }
 
 .main {

--- a/media/js/base/site.js
+++ b/media/js/base/site.js
@@ -146,10 +146,17 @@
         // to avoid lots of flickering
         var platform = window.site.platform = window.site.getPlatform();
         var version = window.site.platformVersion = window.site.getPlatformVersion();
+        var _version = version ? parseFloat(version) : 0;
 
         if (platform === 'windows') {
+            // Add class to allow Windows XP/Vista users to download Firefox 52 ESR, though these
+            // legacy platforms are now officially unsupported
+            if (_version >= 5.1 && _version <= 6) {
+                h.className += ' xpvista';
+            }
+
             // Add class to support downloading Firefox for Windows 64-bit on Windows 7 and later
-            if (version && parseFloat(version) >= 6.1) {
+            if (_version >= 6.1) {
                 h.className += ' win7up';
             }
         } else {

--- a/media/js/firefox/new/scene1.js
+++ b/media/js/firefox/new/scene1.js
@@ -67,6 +67,11 @@
     };
 
     var setFirefoxStatus = function() {
+        // Windows XP/Vista warning overrides the Firefox status message
+        if ($html.hasClass('xpvista')) {
+            return;
+        }
+
         var status = getFirefoxStatus();
         $html.addClass(status);
 


### PR DESCRIPTION
## Description

* Firefox 52 ESR reaches the EOL on September 5. The Firefox download buttons have to be updated to show a warning to Windows XP/Vista users while allowing downloads
* See [my bug comment](https://bugzilla.mozilla.org/show_bug.cgi?id=1339226#c17) for details and screenshots
* I don’t know how Protocol works so didn’t add any warning styling to `media/css/protocol/components/_download-button.scss`

## Localization

There are 2 new short strings. The latter is TBD

```html
<a href="%(url)s">Mozilla no longer provides security updates for Firefox on Windows XP or Vista</a>, but you can still download the final Windows 32-bit version below.
```
```html
You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.
```

## Issue / Bugzilla link

[Bug 1339226](https://bugzilla.mozilla.org/show_bug.cgi?id=1339226#c17)

## Testing

Testing with a physical/virtual XP/Vista machine would be great, but you can still see the warnings by changing the class name on `<html>` to `windows xpvista x86 js loaded`