### PR TITLE
Fix #6045: Redirect /firefox/download to /firefox/new/

### DIFF
--- a/bedrock/firefox/redirects.py
+++ b/bedrock/firefox/redirects.py
@@ -76,7 +76,7 @@ redirectpatterns = (
     redirect(r'^download/?$', 'firefox.new'),
 
     # Bug 1409554
-    redirect(r'^(firefox|mobile)/download/', 'firefox.new'),
+    redirect(r'^(firefox|mobile)/download', 'firefox.new'),
 
     # bug 837883
     redirect(r'^firefox/firefox\.exe$', 'mozorg.home', re_flags='i'),

--- a/tests/redirects/map_globalconf.py
+++ b/tests/redirects/map_globalconf.py
@@ -192,6 +192,8 @@ URLS = flatten((
     url_test('/{firefox,mobile}/download/', '/firefox/new/'),
     # also deals with anything after download/
     url_test('/firefox/download/stuff/', '/firefox/new/'),
+    # Issue #6045
+    url_test('/firefox/download', '/firefox/new/'),
 
     url_test('/firefox/firefox.exe', '/'),
     # should be case insensitive


### PR DESCRIPTION
The version with the trailing slash already redirects, this just includes the URL without the trailing slash.