### PR TITLE
Fix #6047: Add about langfile to new about-en.html template

### DIFF
--- a/bedrock/mozorg/templates/mozorg/about-en.html
+++ b/bedrock/mozorg/templates/mozorg/about-en.html
@@ -4,6 +4,8 @@
 
 {% extends "base-protocol.html" %}
 
+{% add_lang_files "mozorg/about" %}
+
 {% block page_title %}{{ _('Learn About Mozilla') }}{% endblock %}
 
 {% block page_desc %}


### PR DESCRIPTION
Bring back translations to /en-US/about/