### PR TITLE
[fix bug 1466235] Update tracking protection tour strings

### DIFF
--- a/bedrock/firefox/templates/firefox/tracking-protection-tour.html
+++ b/bedrock/firefox/templates/firefox/tracking-protection-tour.html
@@ -26,9 +26,16 @@ data-panel1-text="{{ _('When you see the shield, Firefox is blocking some parts 
 data-panel1-step="{{ _('1 of 3') }}"
 data-panel1-button="{{ _('Next') }}"
 data-panel3-title="{{ _('Want to make changes?') }}"
-data-panel3-text="{{ _('It’s easy to turn off Tracking Protection for the website you’re on by clicking “Disable protection for this session.”') }}"
 
-{% if l10n_has_tag('tp_tour_firefox_201602') %}
+{% if l10n_has_tag('tp_tour_firefox_201809') %}
+  data-panel3-text="{{ _('It’s easy to turn off Tracking Protection for the website you’re on by clicking “Disable For This Session.”') }}"
+{% else %}
+  data-panel3-text="{{ _('It’s easy to turn off Tracking Protection for the website you’re on by clicking “Disable protection for this session.”') }}"
+{% endif %}
+
+{% if l10n_has_tag('tp_tour_firefox_201809') %}
+  data-panel3-text-new-tab="{{ _('It’s easy to turn off Tracking Protection for the website you’re on by clicking “Disable For This Site.”') }}"
+{% elif l10n_has_tag('tp_tour_firefox_201602') %}
   data-panel3-text-new-tab="{{ _('It’s easy to turn off Tracking Protection for the website you’re on by clicking “Disable protection for this site.”') }}"
 {% else %}
   data-panel3-text-new-tab="{{ _('It’s easy to turn off Tracking Protection for the website you’re on by clicking “Disable protection for this session.”') }}"


### PR DESCRIPTION
## Description
Updates two strings in the Tracking Protection tour using the l10n tag `tp_tour_firefox_201809`

## Issue / Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1466235
Issue #6056 

## Testing
https://www-demo4.allizom.org/firefox/62.0a1/tracking-protection/start/?step=3
https://www-demo4.allizom.org/en-US/firefox/62.0a1/tracking-protection/start/?step=3&newtab=true

You'll need to whitelist `https://www-demo4.allizom.org` in about:config > browser.uitour.testingOrigins
