### PR TITLE
Add product name to titles

### DIFF
--- a/bedrock/firefox/templates/firefox/releases/system_requirements.html
+++ b/bedrock/firefox/templates/firefox/releases/system_requirements.html
@@ -7,7 +7,7 @@
 {% block gtm_page_id %}data-gtm-page-id="/firefox/system-requirements/"{% endblock %}
 
 {% block page_title_prefix %}{% endblock %}
-{% block page_title %}{{ _('Firefox — {version} System Requirements')|f(version=version) }}{% endblock %}
+{% block page_title %}{{ _('{product} {version} System Requirements')|f(product=release.product, version=version) }}{% endblock %}
 
 {% block body_id %}notes{% endblock %}
 {% block body_class %}fxos-notes sky{% endblock %}
@@ -18,7 +18,7 @@
 
 {% block content %}
   <header id="main-feature">
-    <h1>{{ _('Firefox {version} System Requirements')|f(version=version) }}</h1>
+    <h1>{{ _('{product} {version} System Requirements')|f(product=release.product, version=version) }}</h1>
   </header>
 
   <div id="main-content">


### PR DESCRIPTION
## Description
Display product name on system requirements pages instead of "Firefox" so we can tell the system requirements for "Firefox for Android" apart.

## Issue / Bugzilla link
Closes #6053 

## Testing
Firefox system requirements are linked to from here: https://www.mozilla.org/en-US/firefox/all/
Firefox Android system requirements are linked to from here: https://www.mozilla.org/en-US/firefox/android/60.0beta/releasenotes/

As far as I can tell the page is not translated so it's okay to update the strings.