### PR TITLE
Fixing typo in js+ld

### DIFF
--- a/bedrock/mozorg/templates/mozorg/home/home-en.html
+++ b/bedrock/mozorg/templates/mozorg/home/home-en.html
@@ -433,7 +433,7 @@
       "https://www.facebook.com/mozilla",
       "https://github.com/mozilla",
       "https://www.instagram.com/mozilla/",
-      "https://www.youtube.com/user/Mozilla";
+      "https://www.youtube.com/user/Mozilla",
       "https://wikipedia.org/wiki/Mozilla",
       "https://www.linkedin.com/company/mozilla-corporation"
 		]

--- a/bedrock/security/templates/security/bug-bounty.html
+++ b/bedrock/security/templates/security/bug-bounty.html
@@ -1,6 +1,6 @@
 {% extends "security/base.html" %}
 
-{% block page_title %}Mozilla Security Bug Bounty Program{% endblock %}
+{% block page_title %}Security Bug Bounty Program{% endblock %}
 {% set body_id = "bug-bounty" %}
 
 {% block article %}

--- a/bedrock/security/templates/security/bug-bounty/faq.html
+++ b/bedrock/security/templates/security/bug-bounty/faq.html
@@ -1,6 +1,6 @@
 {% extends "security/base.html" %}
 
-{% block page_title %}Mozilla Security Bug Bounty Program{% endblock %}
+{% block page_title %}Bug Bounty Program FAQ{% endblock %}
 {% set body_id = "faq" %}
 
 {% block article %}

--- a/bedrock/security/templates/security/client-bug-bounty.html
+++ b/bedrock/security/templates/security/client-bug-bounty.html
@@ -1,6 +1,6 @@
 {% extends "security/base.html" %}
 
-{% block page_title %}Mozilla Security Bug Bounty Program{% endblock %}
+{% block page_title %}Client Bug Bounty Program{% endblock %}
 {% set body_id = "client-bug-bounty" %}
 
 {% block article %}

--- a/bedrock/security/templates/security/web-bug-bounty.html
+++ b/bedrock/security/templates/security/web-bug-bounty.html
@@ -1,6 +1,6 @@
 {% extends "security/base.html" %}
 
-{% block page_title %}Mozilla Security Bug Bounty Program{% endblock %}
+{% block page_title %}Web and Services Bug Bounty Program{% endblock %}
 {% set body_id = "web-bug-bounty" %}
 
 {% block article %}


### PR DESCRIPTION
I found a typo in the new js+ld code on our english homepage. Every line but the last must end with a , not a ;
<img width="1784" alt="screen shot 2018-08-22 at 13 10 19" src="https://user-images.githubusercontent.com/36700618/44460292-caf9ff80-a60c-11e8-921d-e335549533a9.png">

## https://github.com/mozilla/bedrock/issues/5741

