### PR TITLE
Set h1 as <title> for grants pages

### DIFF
--- a/bedrock/grants/templates/grants/info.html
+++ b/bedrock/grants/templates/grants/info.html
@@ -4,7 +4,7 @@
 
 {% extends "grants/base.html" %}
 
-{% block page_title %}Grants{% endblock %}
+{% block page_title %}{{ grant.title }}{% endblock %}
 {% block body_id %}grants{% endblock %}
 
 {% block article %}


### PR DESCRIPTION
## Description
Set h1 as <title> for grants pages
## Issue / Bugzilla link
https://github.com/mozilla/bedrock/issues/6078

## Testing
