### PR TITLE
Add spin.min.js to whatsnew_61, fix JS error in sendto widget

### DIFF
--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -951,6 +951,7 @@
     {
       "files": [
         "js/base/mozilla-fxa-iframe.js",
+        "js/libs/spin.min.js",
         "js/base/send-yourself.js",
         "js/firefox/whatsnew/whatsnew-61.js",
         "js/firefox/whatsnew/whatsnew-61-init.js"


### PR DESCRIPTION
## Description
While testing #6090 @stephaniehobson noted this error thrown by the sendto widget:
`ReferenceError: Spinner is not defined`

This seems also make the widget submission fail (at least when using 'success@example.com' to test), which seems pretty serious.

The sendto widget was forked from the original send-to-device widget and renders a little spinner while the Ajax is working. However, the library that renders that spinner is included in the common.js bundle but is *not* included in the common-protocol.js bundle, so Protocol-based pages using the new widget are broken.

We're making an effort not to rely on third-party libraries with Protocol so I'd rather not just add the spinner to the common bundle and forget about it, so instead the quicker fix is to add spin.min.js only on the pages that need it (only whatsnew61 right now, as well as whatsnew62 but that's in the other PR). The real long-term fix for this issue is to refactor the sendto widget not to rely on that spinner, and that can be part of deprecating the old widget as well (see #5844). This is just a quick hack to hastily fix a bug in production.

## Testing
Load firefox/61.0/whatsnew while signed into sync (so you get the Fx mobile promo with widget), verify no JS errors and that the widget successfully submits (using 'success@example.com' should be sufficient).