### PR TITLE
[#5946] CSS fixes for Whatsnew62

### DIFF
--- a/media/css/firefox/whatsnew/whatsnew-62.scss
+++ b/media/css/firefox/whatsnew/whatsnew-62.scss
@@ -116,20 +116,14 @@ $image-path: '/media/protocol/img';
     }
 
     @media #{$mq-md} {
-        &.show-up-to-date-message .page-header-inner {
-            align-items: center;
-            display: flex;
-            justify-content: space-between;
-        }
-
-        .logo-fx,
-        .logo-pocket {
+        .logo-fx {
             @include bidi(((float, left, right),));
         }
 
-        .logo-moz {
+        .logo-moz,
+        .logo-pocket {
             @include bidi(((float, right, left),));
-            display: inline;
+            margin: $spacing-md 0;
         }
 
         &.show-pocket {
@@ -139,6 +133,19 @@ $image-path: '/media/protocol/img';
 
             .logo-moz {
                 display: none;
+            }
+        }
+
+        &.show-up-to-date-message .page-header-inner {
+            align-items: center;
+            display: flex;
+            justify-content: space-between;
+
+            .logo-fx,
+            .logo-moz,
+            .logo-pocket {
+                float: none;
+                margin: 0;
             }
         }
     }
@@ -207,14 +214,14 @@ $image-path: '/media/protocol/img';
         &:focus {
             color: $color-link-hover;
         }
+    }
 
-        &:visited {
-            color: $color-link-visited;
+    a:visited {
+        color: $color-link-visited;
 
-            &:hover,
-            &:focus {
-                color: $color-link-visited-hover;
-            }
+        &:hover,
+        &:focus {
+            color: $color-link-visited-hover;
         }
     }
 }


### PR DESCRIPTION
## Description
- [x] Fix header logo layout when up-to-date message is hidden.
- [ ] Fix visited link color in sendto widget.

## Issue / Bugzilla link
https://github.com/mozilla/bedrock/issues/5946#issuecomment-417498724

## Testing
You'll need to view the page with an outdated Firefox so the "up to date" message is hidden; verify the header logos look acceptable (Firefox on the left, Mozilla/Pocket on the right in wide viewports). Short of using an actual old Firefox you can also fake it by removing the "show-up-to-date-messaging" class in devtools, or locally commenting out the `checkUpToDate` function in whatsnew-62.js.

To see the sendto widget you'll need to either be signed into a Firefox account or fake it by firing the `showFirefoxMobile()` event in whatsnew-62.js. There's a "learn more" link in the privacy statement below the form field. It should be blue when unvisited, purple when visited.
