### PR TITLE
[#5946] Fix Mozilla logo display on whatsnew62

### DIFF
--- a/media/css/firefox/whatsnew/whatsnew-62.scss
+++ b/media/css/firefox/whatsnew/whatsnew-62.scss
@@ -126,9 +126,13 @@ $image-path: '/media/protocol/img';
             margin: $spacing-md 0;
         }
 
+        .logo-moz {
+            display: block;
+        }
+
         &.show-pocket {
             .logo-pocket {
-                display: inline;
+                display: block;
             }
 
             .logo-moz {


### PR DESCRIPTION
## Description
Fixing the new bug my previous bug fix introduced.

## Testing
The Mozilla logo should appear on the right in large viewports for all page states besides the Pocket promo. It should be hidden in small viewports.