### PR TITLE
Update Tracking Protection tour strings for Content Blocking shield study (#6082)

### DIFF
--- a/bedrock/firefox/templates/firefox/tracking-protection-tour/index.html
+++ b/bedrock/firefox/templates/firefox/tracking-protection-tour/index.html
@@ -2,6 +2,8 @@
  # License, v. 2.0. If a copy of the MPL was not distributed with this
  # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
 
+{% add_lang_files "firefox/tracking-protection-tour" %}
+
 {% extends "firefox/base-resp.html" %}
 
 {# "noindex" pages should not have the canonical or hreflang tags: bug 1442331 #}
@@ -67,13 +69,17 @@ data-panel3-button="{{ _('Got it!') }}"
 <main role="main">
   <header>
     <div class="inner-container">
+      {% block header_title %}
       {% if l10n_has_tag('tp_tour_firefox_201601') %}
         <h1>{{ _('Tracking Protection') }}</h1>
       {% else %}
         <h1>{{ _('Private Browsing with Tracking Protection') }}</h1>
       {% endif %}
+      {% endblock %}
       <p class="prefs-link">
+      {% block header_help %}
         {{ _('Want to turn off this feature? <a href="%s">Visit Privacy Preferences</a>')|format('https://support.mozilla.org/kb/tracking-protection-pbm') }}
+      {% endblock %}
       </p>
     </div>
   </header>
@@ -97,8 +103,10 @@ data-panel3-button="{{ _('Got it!') }}"
           </div>
           <section id="info-panel" class="hidden">
             <header tabindex="-1">
+              {% block panel_2 %}
               <h2>{{ _('Differences to expect') }}</h2>
               <p>{{ _('Some page areas may be missing, because they could allow third parties to track you across different websites.') }}</p>
+              {% endblock %}
               <button class="close-btn" type="button">{{ _('Close') }}</button>
             </header>
             <footer>{{ _('2 of 3') }} <button type="button">{{ _('Next') }}</button></footer>
@@ -110,6 +118,7 @@ data-panel3-button="{{ _('Got it!') }}"
 
     <section id="end-state" class="hidden">
       <img src="{{ static('img/firefox/tracking-protection/shield-tab.svg') }}" width="145" alt="">
+      {% block thanks %}
       {% if l10n_has_tag('tp_tour_firefox_201601') %}
         <h2>{{ _('Thanks for learning about Tracking Protection.') }}</h2>
       {% else %}
@@ -117,6 +126,7 @@ data-panel3-button="{{ _('Got it!') }}"
       {% endif %}
       <p>{{ _('Learn more about how it works by visiting the <a rel="external" href="%s">FAQ page</a>.')|format('https://support.mozilla.org/kb/tracking-protection-pbm') }}</p>
       <button id="reload-btn" type="button" class="button">{{ _('Restart tour') }}</button>
+      {% endblock %}
     </section>
   </div>
 

--- a/bedrock/firefox/templates/firefox/tracking-protection-tour/variation-0.html
+++ b/bedrock/firefox/templates/firefox/tracking-protection-tour/variation-0.html
@@ -1,0 +1,20 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+
+{% add_lang_files "firefox/tracking-protection-tour" %}
+
+{% extends "firefox/tracking-protection-tour/index.html" %}
+
+{% block string_data %}
+data-panel1-title="{{ _('How Tracking Protection works') }}"
+data-panel1-text="{{ _('When you see the shield, Firefox is blocking some parts of the page that could track your browsing activity.') }}"
+data-panel1-step="{{ _('1 of 3') }}"
+data-panel1-button="{{ _('Next') }}"
+data-panel3-title="{{ _('Want to make changes?') }}"
+data-panel3-text="{{ _('It’s easy to turn off Tracking Protection for the website you’re on. Just select “Disable Blocking Temporarily.”') }}"
+data-panel3-text-new-tab="{{ _('It’s easy to turn off Tracking Protection for the website you’re on. Just select “Disable Blocking For This Site.”') }}"
+data-panel3-text-alt="{{ _('It’s easy to turn on Tracking Protection for the website you’re on by clicking “Enable Blocking For This Site.”') }}"
+data-panel3-step="{{ _('3 of 3') }}"
+data-panel3-button="{{ _('Got it!') }}"
+{% endblock %}

--- a/bedrock/firefox/templates/firefox/tracking-protection-tour/variation-1.html
+++ b/bedrock/firefox/templates/firefox/tracking-protection-tour/variation-1.html
@@ -1,0 +1,42 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+
+{% add_lang_files "firefox/tracking-protection-tour" %}
+
+{% extends "firefox/tracking-protection-tour/index.html" %}
+
+{% block page_title %}{{ _('Firefox Content Blocking') }}{% endblock %}
+
+{% block string_data %}
+data-panel1-title="{{ _('New in Firefox: Content Blocking') }}"
+data-panel1-text="{{ _('When you see the shield, Firefox is blocking parts of the page that can slow your browsing or track you online.') }}"
+data-panel1-step="{{ _('1 of 3') }}"
+data-panel1-button="{{ _('Next') }}"
+data-panel3-title="{{ _('Turn off blocking for trusted sites') }}"
+data-panel3-text="{{ _('If content blocking prevents you from using a site you trust, you can select “Disable Blocking Temporarily” in this panel.') }}"
+data-panel3-text-new-tab="{{ _('If content blocking prevents you from using a site you trust, you can select “Disable Blocking For This Site” in this panel.') }}"
+data-panel3-title-alt="{{ _('Want to make changes?') }}"
+data-panel3-text-alt="{{ _('To restore content blocking for a site, select “Enable Blocking For This Site“ in the Control Center panel.') }}"
+data-panel3-step="{{ _('3 of 3') }}"
+data-panel3-button="{{ _('Got it!') }}"
+{% endblock %}
+
+{% block header_title %}
+  <h1>{{ _('Content Blocking') }}</h1>
+{% endblock %}
+
+{% block header_help %}
+  {{ _('Want to turn off this feature? <a href="%s">Visit Privacy Preferences</a>')|format('https://support.mozilla.org/en-US/kb/content-blocking/') }}
+{% endblock %}
+
+{% block panel_2 %}
+  <h2>{{ _('Differences to expect') }}</h2>
+  <p>{{ _('Content blocking can help pages load faster, but it can also keep parts of pages or entire pages from loading.') }}</p>
+{% endblock %}
+
+{% block thanks %}
+  <h2>{{ _('Thanks for learning about Content Blocking.') }}</h2>
+  <p>{{ _('Learn more about how it works by visiting the <a rel="external" href="%s">FAQ page</a>.')|format('https://support.mozilla.org/en-US/kb/content-blocking/') }}</p>
+  <button id="reload-btn" type="button" class="button">{{ _('Restart Tour') }}</button>
+{% endblock %}

--- a/bedrock/firefox/templates/firefox/tracking-protection-tour/variation-2.html
+++ b/bedrock/firefox/templates/firefox/tracking-protection-tour/variation-2.html
@@ -1,0 +1,42 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+
+{% add_lang_files "firefox/tracking-protection-tour" %}
+
+{% extends "firefox/tracking-protection-tour/index.html" %}
+
+{% block page_title %}{{ _('Firefox Content Blocking') }}{% endblock %}
+
+{% block string_data %}
+data-panel1-title="{{ _('New in Firefox: Content Blocking') }}"
+data-panel1-text="{{ _('The privacy benefits of Tracking Protection are now just one part of content blocking. When you see the shield, content blocking is on.') }}"
+data-panel1-step="{{ _('1 of 3') }}"
+data-panel1-button="{{ _('Next') }}"
+data-panel3-title="{{ _('Turn off blocking for trusted sites') }}"
+data-panel3-text="{{ _('If content blocking prevents you from using a site you trust, you can select “Disable Blocking Temporarily“ in this panel.') }}"
+data-panel3-text-new-tab="{{ _('If content blocking prevents you from using a site you trust, you can select “Disable Blocking For This Site“ in this panel.') }}"
+data-panel3-title-alt="{{ _('Want to make changes?') }}"
+data-panel3-text-alt="{{ _('To restore content blocking for a site, select “Enable Blocking For This Site“ in the Control Center panel.') }}"
+data-panel3-step="{{ _('3 of 3') }}"
+data-panel3-button="{{ _('Got it!') }}"
+{% endblock %}
+
+{% block header_title %}
+  <h1>{{ _('Content Blocking') }}</h1>
+{% endblock %}
+
+{% block header_help %}
+  {{ _('Want to turn off this feature? <a href="%s">Visit Privacy Preferences</a>')|format('https://support.mozilla.org/en-US/kb/content-blocking/') }}
+{% endblock %}
+
+{% block panel_2 %}
+  <h2>{{ _('Differences to expect') }}</h2>
+  <p>{{ _('Content blocking can help pages load faster, but it can also  keep parts of pages or entire pages from loading.') }}</p>
+{% endblock %}
+
+{% block thanks %}
+  <h2>{{ _('Thanks for learning about Content Blocking.') }}</h2>
+  <p>{{ _('Learn more about how it works by visiting the <a rel="external" href="%s">FAQ page</a>.')|format('https://support.mozilla.org/kb/tracking-protection-pbm') }}</p>
+  <button id="reload-btn" type="button" class="button">{{ _('Restart Tour') }}</button>
+{% endblock %}

--- a/bedrock/firefox/tests/test_base.py
+++ b/bedrock/firefox/tests/test_base.py
@@ -568,3 +568,51 @@ class FxVersionRedirectsMixin(object):
         response = self.client.get(self.url, HTTP_USER_AGENT=user_agent)
         eq_(response.status_code, 200)
         eq_(response['Cache-Control'], 'max-age=0')
+
+
+@patch('bedrock.firefox.views.l10n_utils.render', return_value=HttpResponse())
+class TestTrackingProtectionTour(TestCase):
+    def setUp(self):
+        self.view = fx_views.TrackingProtectionTourView.as_view()
+        self.rf = RequestFactory()
+
+    @override_settings(DEV=True)
+    def test_fx_tracking_protection_62_0(self, render_mock):
+        """Should use default tracking protection tour template"""
+        req = self.rf.get('/en-US/firefox/tracking-protection/start/')
+        self.view(req, version='62.0')
+        template = render_mock.call_args[0][1]
+        eq_(template, ['firefox/tracking-protection-tour/index.html'])
+
+    @override_settings(DEV=True)
+    def test_fx_tracking_protection_63_0_v0(self, render_mock):
+        """Should use variation 0 template"""
+        req = self.rf.get('/en-US/firefox/tracking-protection/start/?variation=0')
+        self.view(req, version='62.0')
+        template = render_mock.call_args[0][1]
+        eq_(template, ['firefox/tracking-protection-tour/variation-0.html'])
+
+    @override_settings(DEV=True)
+    def test_fx_tracking_protection_63_0_v1(self, render_mock):
+        """Should use variation 1 template"""
+        req = self.rf.get('/en-US/firefox/tracking-protection/start/?variation=1')
+        self.view(req, version='62.0')
+        template = render_mock.call_args[0][1]
+        eq_(template, ['firefox/tracking-protection-tour/variation-1.html'])
+
+    @override_settings(DEV=True)
+    def test_fx_tracking_protection_63_0_v2(self, render_mock):
+        """Should use variation 2 template"""
+        req = self.rf.get('/en-US/firefox/tracking-protection/start/?variation=2')
+        self.view(req, version='62.0')
+        template = render_mock.call_args[0][1]
+        eq_(template, ['firefox/tracking-protection-tour/variation-2.html'])
+
+    @override_settings(DEV=True)
+    def test_fx_tracking_protection_63_0_locales(self, render_mock):
+        """Should use default tracking protection tour template for non-en locales"""
+        req = self.rf.get('/firefox/tracking-protection/start/?variation=2')
+        req.locale = 'de'
+        self.view(req, version='62.0')
+        template = render_mock.call_args[0][1]
+        eq_(template, ['firefox/tracking-protection-tour/index.html'])

--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -573,7 +573,17 @@ class FeedbackView(TemplateView):
 
 
 class TrackingProtectionTourView(l10n_utils.LangFilesMixin, TemplateView):
-    template_name = 'firefox/tracking-protection-tour.html'
+
+    def get_template_names(self):
+        variation = self.request.GET.get('variation', None)
+        locale = l10n_utils.get_locale(self.request)
+
+        if locale.startswith('en') and variation in ['0', '1', '2']:
+            template = 'firefox/tracking-protection-tour/variation-{}.html'.format(variation)
+        else:
+            template = 'firefox/tracking-protection-tour/index.html'
+
+        return [template]
 
 
 def download_thanks(request):

--- a/media/js/firefox/tracking-protection-tour.js
+++ b/media/js/firefox/tracking-protection-tour.js
@@ -100,7 +100,9 @@ if (typeof Mozilla === 'undefined') {
                     // fade out content if user has landed on step 3 after page reload.
                     _$tracker.addClass('fade-out');
                 } else if (config.targets.indexOf('controlCenter-trackingBlock') !== -1) {
-                    Mozilla.UITour.showInfo('controlCenter-trackingBlock', _step3.titleText, _step3.panelTextAlt, undefined, buttons, options);
+                    var altTitle = _step3.titleTextAlt ? _step3.titleTextAlt : _step3.titleText;
+
+                    Mozilla.UITour.showInfo('controlCenter-trackingBlock', altTitle, _step3.panelTextAlt, undefined, buttons, options);
                 }
             });
         });
@@ -231,6 +233,7 @@ if (typeof Mozilla === 'undefined') {
     TPTour.getStep3Strings = function() {
         return {
             titleText: TPTour._getText('panel3Title'),
+            titleTextAlt: TPTour._getText('panel3TitleAlt'),
             panelText: TPTour._getText('panel3Text'),
             panelTextNewTab: TPTour._getText('panel3TextNewTab'),
             panelTextAlt: TPTour._getText('panel3TextAlt'),


### PR DESCRIPTION
## Description
- Updates existing Tracking Protection tour for Content Blocking shield study, to launch during 63 Beta.
- Shield study will be en-US only for Firefox 63 Beta, but the ask is to localize these new strings ahead of rolling out to all locales post-study.
- Strings have been [tested and verified on demo](https://bugzilla.mozilla.org/show_bug.cgi?id=1484585#c10) by the Firefox team. Further QA will happen when this goes to production before the shield study is launched.

~I will update here when strings are final~ strings are final

**Needs to be in prod for Monday 10th September**

## Issue / Bugzilla link
#6082

## Testing
First, make sure to **test in Nightly** (strings have not yet been uplifted to Beta).

Next, whitelist UITour for the demo instance by creating a new preference called `browser.uitour.testingOrigins` in `about:config` and assign it a value of `https://bedrock-demo-agibson.oregon-b.moz.works/`.

Then you should be able to test for following URLs:

Private Browsing mode (make sure to test in a new PB window):
- https://bedrock-demo-agibson.oregon-b.moz.works/en-US/firefox/63.0/tracking-protection/start/?variation=0
- https://bedrock-demo-agibson.oregon-b.moz.works/en-US/firefox/63.0/tracking-protection/start/?variation=1
- https://bedrock-demo-agibson.oregon-b.moz.works/en-US/firefox/63.0/tracking-protection/start/?variation=2

Normal mode (make sure to test in a non PB window)
- https://bedrock-demo-agibson.oregon-b.moz.works/en-US/firefox/63.0/tracking-protection/start/?variation=0&newtab=true
- https://bedrock-demo-agibson.oregon-b.moz.works/en-US/firefox/63.0/tracking-protection/start/?variation=1&newtab=true
- https://bedrock-demo-agibson.oregon-b.moz.works/en-US/firefox/63.0/tracking-protection/start/?variation=2&newtab=true