### PR TITLE
Fix inconsistencies in Developer Edition pages

### DIFF
--- a/bedrock/firefox/templates/firefox/developer/firstrun.html
+++ b/bedrock/firefox/templates/firefox/developer/firstrun.html
@@ -116,8 +116,11 @@
         <h2 class="section-title"><span>{{ _('Convenient Features') }}</span></h2>
 
         <div class="section-body">
-          <h3 class="body-title">{{ _('Shapes Editor') }}</h3>
-          <img class="hero-image" src="{{ static('img/firefox/developer/hero-clip-ani.gif') }}" alt="">
+          <a href="https://developer.mozilla.org/en-US/docs/Tools/Page_Inspector/How_to/Edit_CSS_shapes" rel="external" >
+            <h3 class="body-title">{{ _('Shapes Editor') }}</h3>
+
+            <img class="hero-image" src="{{ static('img/firefox/developer/hero-clip-ani.gif') }}" alt="">
+          </a>
           <p>
           {% trans %}
             Firefox DevTools has a brand new shape path editor that takes
@@ -134,9 +137,11 @@
         <h2 class="section-title"><span>{{ _('Faster Information') }}</span></h2>
 
         <div class="section-body">
-          <h3 class="body-title">{{ _('Fonts Panel') }}</h3>
+          <a rel="external" href="https://developer.mozilla.org/en-US/docs/Tools/Page_Inspector/How_to/Edit_fonts" rel="external">
+            <h3 class="body-title">{{ _('Fonts Panel') }}</h3>
 
-          <img class="hero-image" src="{{ static('img/firefox/developer/hero-fonts.gif') }}" alt="">
+            <img class="hero-image" src="{{ static('img/firefox/developer/hero-fonts.gif') }}" alt="">
+          </a>
           <p>
           {% trans %}
             The new fonts panel in Firefox DevTools gives developers quick

--- a/bedrock/firefox/templates/firefox/developer/index.html
+++ b/bedrock/firefox/templates/firefox/developer/index.html
@@ -70,9 +70,11 @@
         <h2 class="section-title"><span>{{ _('New Tools') }}</span></h2>
 
         <div class="section-body">
-          <h3 class="body-title">{{ _('Firefox DevTools') }}</h3>
+          <a href="https://mozilladevelopers.github.io/playground/debugger/" rel="external">
+            <h3 class="body-title">{{ _('Firefox DevTools') }}</h3>
 
-          <img class="hero-image" src="{{ static('img/firefox/developer/hero-debugger-ani.gif') }}" alt="">
+            <img class="hero-image" src="{{ static('img/firefox/developer/hero-debugger-ani.gif') }}" alt="">
+          </a>
           <p>
           {% if l10n_has_tag('ember_reference_fix') %}
             {% trans %}
@@ -86,15 +88,18 @@
             {% endtrans %}
           {% endif %}
           </p>
+          <a class="more" rel="external" href="https://mozilladevelopers.github.io/playground/debugger/">{{ _('Learn more') }}</a>
         </div>
       </div>
 
       <div class="highlight-features">
         <h2 class="section-title"><span>{{ _('Innovative Features') }}</span></h2>
         <div class="section-body">
-          <h3 class="body-title">{{ _('Master CSS Grid') }}</h3>
+          <a href="https://mozilladevelopers.github.io/playground/css-grid/" rel="external">
+            <h3 class="body-title">{{ _('Master CSS Grid') }}</h3>
 
-          <img class="hero-image" src="{{ static('img/firefox/developer/hero-cssgrid-ani.gif') }}" alt="">
+            <img class="hero-image" src="{{ static('img/firefox/developer/hero-cssgrid-ani.gif') }}" alt="">
+          </a>
           <p>
           {% trans %}
             Firefox is the only browser with tools built specifically for
@@ -103,6 +108,7 @@
             transformations on the grid and much more.
           {% endtrans %}
           </p>
+          <a class="more" rel="external" href="https://mozilladevelopers.github.io/playground/css-grid/">{{ _('Learn more') }}</a>
         </div>
       </div>
       {% if l10n_has_tag('new_features_20180830') %}
@@ -110,8 +116,11 @@
         <h2 class="section-title"><span>{{ _('Convenient Features') }}</span></h2>
 
         <div class="section-body">
-          <h3 class="body-title">{{ _('Shapes Editor') }}</h3>
-          <img class="hero-image" src="{{ static('img/firefox/developer/hero-clip-ani.gif') }}" alt="">
+          <a href="https://developer.mozilla.org/en-US/docs/Tools/Page_Inspector/How_to/Edit_CSS_shapes" rel="external" >
+            <h3 class="body-title">{{ _('Shapes Editor') }}</h3>
+
+            <img class="hero-image" src="{{ static('img/firefox/developer/hero-clip-ani.gif') }}" alt="">
+          </a>
           <p>
           {% trans %}
             Firefox DevTools has a brand new shape path editor that takes
@@ -120,6 +129,7 @@
             with a visual editor.
           {% endtrans %}
           </p>
+          <a class="more" rel="external" href="https://developer.mozilla.org/en-US/docs/Tools/Page_Inspector/How_to/Edit_CSS_shapes">{{ _('Learn more') }}</a>
         </div>
       </div>
 
@@ -127,9 +137,11 @@
         <h2 class="section-title"><span>{{ _('Faster Information') }}</span></h2>
 
         <div class="section-body">
-          <h3 class="body-title">{{ _('Fonts Panel') }}</h3>
+          <a rel="external" href="https://developer.mozilla.org/en-US/docs/Tools/Page_Inspector/How_to/Edit_fonts" rel="external">
+            <h3 class="body-title">{{ _('Fonts Panel') }}</h3>
 
-          <img class="hero-image" src="{{ static('img/firefox/developer/hero-fonts.gif') }}" alt="">
+            <img class="hero-image" src="{{ static('img/firefox/developer/hero-fonts.gif') }}" alt="">
+          </a>
           <p>
           {% trans %}
             The new fonts panel in Firefox DevTools gives developers quick
@@ -138,6 +150,7 @@
             as the font source, weight, style and more.
           {% endtrans %}
           </p>
+          <a class="more" rel="external" href="https://developer.mozilla.org/en-US/docs/Tools/Page_Inspector/How_to/Edit_fonts">{{ _('Learn more') }}</a>
         </div>
       </div>
       {% endif %}

--- a/bedrock/firefox/templates/firefox/developer/whatsnew.html
+++ b/bedrock/firefox/templates/firefox/developer/whatsnew.html
@@ -116,8 +116,11 @@
         <h2 class="section-title"><span>{{ _('Convenient Features') }}</span></h2>
 
         <div class="section-body">
-          <h3 class="body-title">{{ _('Shapes Editor') }}</h3>
-          <img class="hero-image" src="{{ static('img/firefox/developer/hero-clip-ani.gif') }}" alt="">
+          <a href="https://developer.mozilla.org/en-US/docs/Tools/Page_Inspector/How_to/Edit_CSS_shapes" rel="external" >
+            <h3 class="body-title">{{ _('Shapes Editor') }}</h3>
+
+            <img class="hero-image" src="{{ static('img/firefox/developer/hero-clip-ani.gif') }}" alt="">
+          </a>
           <p>
           {% trans %}
             Firefox DevTools has a brand new shape path editor that takes
@@ -134,9 +137,11 @@
         <h2 class="section-title"><span>{{ _('Faster Information') }}</span></h2>
 
         <div class="section-body">
-          <h3 class="body-title">{{ _('Fonts Panel') }}</h3>
+          <a rel="external" href="https://developer.mozilla.org/en-US/docs/Tools/Page_Inspector/How_to/Edit_fonts" rel="external">
+            <h3 class="body-title">{{ _('Fonts Panel') }}</h3>
 
-          <img class="hero-image" src="{{ static('img/firefox/developer/hero-fonts.gif') }}" alt="">
+            <img class="hero-image" src="{{ static('img/firefox/developer/hero-fonts.gif') }}" alt="">
+          </a>
           <p>
           {% trans %}
             The new fonts panel in Firefox DevTools gives developers quick

--- a/media/css/firefox/developer/developer.scss
+++ b/media/css/firefox/developer/developer.scss
@@ -259,6 +259,12 @@ $color-dev-mediumblue: #306efe;
     background: $color-dev-mediumblue;
     color: #fff;
 
+    a:link,
+    a:visited {
+        color: #fff;
+        text-decoration: none;
+    }
+
     .hero-image {
         box-shadow: 0 15px 20px rgba(0, 0, 0, .15), 0 3px 6px rgba(0, 0, 0, .15);
     }

--- a/media/css/firefox/developer/firstrun.scss
+++ b/media/css/firefox/developer/firstrun.scss
@@ -105,14 +105,6 @@ body {
     }
 }
 
-.section-highlights {
-    a:link,
-    a:visited {
-        color: #fff;
-        text-decoration: none;
-    }
-}
-
 .section-features {
     .features-learn-more {
         display: block;

--- a/media/css/firefox/developer/whatsnew.scss
+++ b/media/css/firefox/developer/whatsnew.scss
@@ -104,14 +104,6 @@ body {
     }
 }
 
-.section-highlights {
-    a:link,
-    a:visited {
-        color: #fff;
-        text-decoration: none;
-    }
-}
-
 .section-features {
     .features-learn-more {
         display: block;


### PR DESCRIPTION
## Description
* Add "Learn more" links to the highlights section on firefox/developer/
* Link images in the highlights section on
  * firefox/developer/
  * firefox/62.0a2/firstrun/
  * firefox/61.0a2/whatsnew/

## Issue / Bugzilla link
Follow up to #6122

## Testing
Changes were tested locally. Sorry for not providing test links.