### PR TITLE
Feature pages - left align right side text

### DIFF
--- a/media/css/quantum/_key-features.scss
+++ b/media/css/quantum/_key-features.scss
@@ -80,16 +80,6 @@
 
                 .key-feature-content {
                     float: right;
-                    text-align: right;
-
-                    h2:before {
-                        left: auto;
-                        right: 0;
-                    }
-
-                    p {
-                        float: right;
-                    }
                 }
             }
         }
@@ -126,16 +116,7 @@ html[dir="rtl"] .key-features-section .key-feature {
 
             .key-feature-content {
                 float: left;
-                text-align: left;
 
-                h2:before {
-                    left: 0;
-                    right: auto;
-                }
-
-                p {
-                    float: left;
-                }
             }
         }
     }


### PR DESCRIPTION
## Description
Left align the text in the right-side boxes.

## Issue / Bugzilla link
Close #6136

## Testing
The pages using this code are linked to from here: mozilla.org/en-US/firefox/features/
Test RTL as well.
