### PR TITLE
[fix #6135] Icon clipped on /firefox/features/password-manager/

### DIFF
--- a/media/css/firefox/features/detail.scss
+++ b/media/css/firefox/features/detail.scss
@@ -37,6 +37,7 @@
 
 #firefox-features-password-manager .main-header h1:before {
     background-image: url('/media/img/firefox/features/quantum/icons/password-manager-white.svg');
+    width: 124px;
 }
 
 #firefox-features-private .main-header h1:before {


### PR DESCRIPTION
## Description
The password manager icon is wider than most, needed a width adjustment in the CSS to prevent clipping the sides.

## Issue / Bugzilla link
#6135 