### PR TITLE
Remove frankfurt from master deploys

### DIFF
--- a/jenkins/branches/master.yml
+++ b/jenkins/branches/master.yml
@@ -5,7 +5,6 @@ smoke_tests: true
 regions:
   - oregon-b
   - tokyo
-  - frankfurt
   - iowa-a
 apps:
   - bedrock-dev
@@ -15,8 +14,6 @@ integration_tests:
     - headless
     - download
   tokyo:
-    - headless
-  frankfurt:
     - headless
   iowa-a:
     - download


### PR DESCRIPTION
Due to continuing issues with 504s: https://github.com/mozmeao/infra/issues/908