### PR TITLE
[#6141] Add disclaimer to Chrome comparison page

### DIFF
--- a/bedrock/firefox/templates/firefox/new/compare/scene1-chrome-2.html
+++ b/bedrock/firefox/templates/firefox/new/compare/scene1-chrome-2.html
@@ -194,6 +194,8 @@
       </tr>
     </tbody>
   </table>
+
+  <p class="footnote">{{ _('Based on Firefox 62 and Google Chrome 68.') }}</p>
 </section>
 
 {% endblock %}

--- a/media/css/firefox/new/compare.scss
+++ b/media/css/firefox/new/compare.scss
@@ -113,6 +113,11 @@ $image-path: '/media/protocol/img';
     .secondary-cta {
         background: $color-gray-20;
     }
+
+    .footnote {
+        color: $color-gray-50;
+        text-align: center;
+    }
 }
 
 


### PR DESCRIPTION
## Description
Adds a footnote to the Chrome comparison (V2) page indicating which versions were compared.

## Issue / Bugzilla link
https://github.com/mozilla/bedrock/pull/6143#issuecomment-419564801
