### PR TITLE
[#6054, #5655] Profile-per-install messaging

### DIFF
--- a/bedrock/base/templates/macros.html
+++ b/bedrock/base/templates/macros.html
@@ -407,7 +407,7 @@
 
     DO NOT include utm_source in this dictionary! (It's already a required param.)
 #}
-{% macro fxa_email_form(entrypoint, utm_source, class_name='fxa-email-form', utm_params={}, intro_text='', button_text='', button_class='button-blue') -%}
+{% macro fxa_email_form(entrypoint, utm_source, class_name='fxa-email-form',  utm_params={}) -%}
   <form action="{{ settings.FXA_ENDPOINT }}" data-mozillaonline-action="{{ settings.FXA_ENDPOINT_MOZILLAONLINE }}" id="fxa-email-form" class="{{ class_name }}">
     <input type="hidden" name="action" value="email" />
     <input type="hidden" name="context" value="fx_desktop_v3" />
@@ -423,35 +423,20 @@
     <input type="hidden" name="utm_{{ attr }}" value="{{ val }}" id="fxa-email-form-utm-{{ attr }}" />
   {% endfor %}
 
-    <p class="fxa-email-form-intro">
-    {% if intro_text %}
-      {{ intro_text }}
-    {% else %}
+    <p>
       {{ _('<strong>Enter your email</strong> to access Firefox Accounts.') }}
-    {% endif %}
     </p>
 
-    <p class="agreement">
+    <label for="fxa-email-field">{{ _('Email address') }}</label>
+    <input type="email" name="email" id="fxa-email-field" class="fxa-email-field" placeholder="user@example.com" required />
+
+    <p class="disclaimer">
     {% trans url1='https://accounts.firefox.com/legal/terms', url2='https://accounts.firefox.com/legal/privacy' %}
       By proceeding, you agree to the <a href="{{ url1 }}">Terms of Service</a> and
       <a href="{{ url2 }}">Privacy Notice</a>.
     {% endtrans %}
     </p>
 
-    <div class="fxa-email-field-container">
-      <p class="field">
-        <label for="fxa-email-field">{{ _('Email address') }}</label>
-        <input type="email" name="email" id="fxa-email-field" class="fxa-email-field" placeholder="user@example.com" required>
-      </p>
-
-      <button type="submit" class="button {{ button_class }}" id="fxa-email-form-submit">
-      {% if button_text %}
-        {{ button_text }}
-      {% else %}
-        {{ _('Continue') }}
-      {% endif %}
-      </button>
-    </div>
-
+    <button type="submit" class="button button-blue" id="fxa-email-form-submit">{{ _('Continue') }}</button>
   </form>
 {%- endmacro %}

--- a/bedrock/base/templates/macros.html
+++ b/bedrock/base/templates/macros.html
@@ -407,7 +407,7 @@
 
     DO NOT include utm_source in this dictionary! (It's already a required param.)
 #}
-{% macro fxa_email_form(entrypoint, utm_source, class_name='fxa-email-form',  utm_params={}) -%}
+{% macro fxa_email_form(entrypoint, utm_source, class_name='fxa-email-form', utm_params={}, intro_text='', button_text='', button_class='button-blue') -%}
   <form action="{{ settings.FXA_ENDPOINT }}" data-mozillaonline-action="{{ settings.FXA_ENDPOINT_MOZILLAONLINE }}" id="fxa-email-form" class="{{ class_name }}">
     <input type="hidden" name="action" value="email" />
     <input type="hidden" name="context" value="fx_desktop_v3" />
@@ -423,20 +423,35 @@
     <input type="hidden" name="utm_{{ attr }}" value="{{ val }}" id="fxa-email-form-utm-{{ attr }}" />
   {% endfor %}
 
-    <p>
+    <p class="fxa-email-form-intro">
+    {% if intro_text %}
+      {{ intro_text }}
+    {% else %}
       {{ _('<strong>Enter your email</strong> to access Firefox Accounts.') }}
+    {% endif %}
     </p>
 
-    <label for="fxa-email-field">{{ _('Email address') }}</label>
-    <input type="email" name="email" id="fxa-email-field" class="fxa-email-field" placeholder="user@example.com" required />
-
-    <p class="disclaimer">
+    <p class="agreement">
     {% trans url1='https://accounts.firefox.com/legal/terms', url2='https://accounts.firefox.com/legal/privacy' %}
       By proceeding, you agree to the <a href="{{ url1 }}">Terms of Service</a> and
       <a href="{{ url2 }}">Privacy Notice</a>.
     {% endtrans %}
     </p>
 
-    <button type="submit" class="button button-blue" id="fxa-email-form-submit">{{ _('Continue') }}</button>
+    <div class="fxa-email-field-container">
+      <p class="field">
+        <label for="fxa-email-field">{{ _('Email address') }}</label>
+        <input type="email" name="email" id="fxa-email-field" class="fxa-email-field" placeholder="user@example.com" required>
+      </p>
+
+      <button type="submit" class="button {{ button_class }}" id="fxa-email-form-submit">
+      {% if button_text %}
+        {{ button_text }}
+      {% else %}
+        {{ _('Continue') }}
+      {% endif %}
+      </button>
+    </div>
+
   </form>
 {%- endmacro %}

--- a/bedrock/firefox/templates/firefox/profile/profile-base.html
+++ b/bedrock/firefox/templates/firefox/profile/profile-base.html
@@ -68,7 +68,7 @@
     <div class="fxa-cta show-fxa-supported-signed-in show-fxa-supported-signed-out">
       <p class="show-fxa-supported-signed-in signed-in">{{ _('You’re signed in and ready to start using Sync.') }}</p>
       <div class="show-fxa-supported-signed-out signed-out">
-        {{ fxa_email_form(entrypoint='accounts-page', utm_source='accounts-page', utm_params={'campaign': 'fxa-embedded-form', 'content': 'accounts-page', 'medium': 'referral'}, intro_text=_('Get Your Firefox Account'), button_text=_('Sign Up Now'), button_class='mzp-c-button') }}
+        {{ fxa_email_form(entrypoint='accounts-page', utm_source='accounts-page', utm_params={'campaign': 'fxa-embedded-form', 'content': 'accounts-page', 'medium': 'referral'},) }}
       </div>
     </div>
   </aside>

--- a/bedrock/firefox/templates/firefox/profile/profile-base.html
+++ b/bedrock/firefox/templates/firefox/profile/profile-base.html
@@ -1,0 +1,82 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. #}
+
+{% from "macros.html" import fxa_email_form with context %}
+
+{% add_lang_files "firefox/profile-per-install" %}
+
+{% extends "firefox/base-protocol.html" %}
+
+{% block page_title %}{{ _('An Important Change in Firefox: Dedicated Profiles') }}{% endblock %}
+
+{% block page_css %}
+  {{ css_bundle('profile_per_install') }}
+{% endblock %}
+
+{% block body_class %}state-fxa-default{% endblock %}
+
+{% block site_header %}
+<header id="page-header" class="page-header">
+  <div class="mzp-l-content">
+    <a href="{{ url('firefox') }}">
+      {{ high_res_img('logos/firefox/logo-quantum-wordmark-large.png', {'alt': 'Firefox', 'width': '147', 'height': '55', 'class': 'logo-fx'}) }}
+    </a>
+
+    <a href="{{ url('mozorg.home') }}">
+      <img src="{{ static('img/logos/mozilla/wordmark-dark.svg') }}" alt="Mozilla" width="112" height="32" class="logo-moz" id="logo-moz">
+    </a>
+  </div>
+</header>
+{% endblock %}
+
+{% block content %}
+<article class="mzp-c-article mzp-t-firefox mzp-l-content">
+  <h1 class="mzp-c-article-title">{{ self.page_title() }}</h1>
+
+  {% block profile_state %}{% endblock %}
+
+  <h2>{{ _('What’s Changed') }}</h2>
+
+  <p>{{ _('Before, all Firefox installations were sharing a single profile by default. Now, Firefox provides dedicated profiles for each Firefox installation (this includes installations of Firefox Nightly, Firefox Beta, or Firefox ESR). This will make Firefox more stable when switching between Firefox installations on the same computer.') }}</p>
+
+  <h2>{{ _('How Dedicated Profiles Work') }}</h2>
+
+  <p>{{ _('Firefox saves information such as bookmarks, passwords and user preferences in a set of files called your profile. This profile is stored in a separate location from the Firefox program files.') }}</p>
+
+  <ul class="mzp-u-list-styled">
+    <li><p>{{ _('The installation you choose as your primary Firefox installation will keep your previously shared profile data like bookmarks, history and passwords.') }}</p></li>
+    <li><p>{{ _('You have not lost any personal data or customizations. Any previous profile data is safe and attached to the first Firefox installation that was opened after this change.') }}</p></li>
+    <li><p>{{ _('All of your Firefox installations will now have separate profiles.') }}</p></li>
+  </ul>
+
+  <h2>{{ _('What You Need to Do') }}</h2>
+
+  <ul class="mzp-u-list-styled">
+    <li><p>{{ _('If you do nothing, each installation will have a separate profile. This means your profile data will be different on each installation of Firefox.') }}</p></li>
+    <li><p>
+    {% trans support='https://support.mozilla.org/kb/profile-manager-create-and-remove-firefox-profiles' %}
+      You can change which installation uses which profile using the profile manager. Directions on how to use the profile manager are available on <a href="{{ support }}">this support page</a>.
+    {% endtrans %}
+    </p></li>
+    <li><p>{{ _('While profiles are now connected to each installation of Firefox, you can use your Firefox Account to keep them in sync. If you would like all of your profile data to be the same on all installations of Firefox, we recommend you sync all of your profiles with a Firefox Account.') }}</p></li>
+  </ul>
+
+  <aside>
+    <p>{{ _('A Firefox Account is the easiest way to make your profiles consistent on all of your versions of Firefox. You also get additional benefits like sending tabs and secure password storage.') }}</p>
+
+    <div class="fxa-cta show-fxa-supported-signed-in show-fxa-supported-signed-out">
+      <p class="show-fxa-supported-signed-in signed-in">{{ _('You’re signed in and ready to start using Sync.') }}</p>
+      <div class="show-fxa-supported-signed-out signed-out">
+        {{ fxa_email_form(entrypoint='accounts-page', utm_source='accounts-page', utm_params={'campaign': 'fxa-embedded-form', 'content': 'accounts-page', 'medium': 'referral'}, intro_text=_('Get Your Firefox Account'), button_text=_('Sign Up Now'), button_class='mzp-c-button') }}
+      </div>
+    </div>
+  </aside>
+
+</article>
+{% endblock %}
+
+{% block js %}
+  {{ js_bundle('profile_per_install') }}
+{% endblock %}
+

--- a/bedrock/firefox/templates/firefox/profile/profile-downgrade.html
+++ b/bedrock/firefox/templates/firefox/profile/profile-downgrade.html
@@ -1,0 +1,11 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. #}
+
+{% add_lang_files "firefox/profile-per-install" %}
+
+{% extends "firefox/profile/profile-base.html" %}
+
+{% block profile_state %}
+  <p class="mzp-c-article-intro">{{ _('We detected that you have installed and opened an older version of Firefox on your computer. You may need to take action.') }}</p>
+{% endblock %}

--- a/bedrock/firefox/templates/firefox/profile/profile-migrate.html
+++ b/bedrock/firefox/templates/firefox/profile/profile-migrate.html
@@ -1,0 +1,11 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. #}
+
+{% add_lang_files "firefox/profile-per-install" %}
+
+{% extends "firefox/profile/profile-base.html" %}
+
+{% block profile_state %}
+  <p class="mzp-c-article-intro">{{ _('We detected more than one version of Firefox on your computer. You may need to take action.') }}</p>
+{% endblock %}

--- a/bedrock/firefox/urls.py
+++ b/bedrock/firefox/urls.py
@@ -112,4 +112,8 @@ urlpatterns = (
 
     page('firefox/switch', 'firefox/switch.html'),
     page('firefox/pocket', 'firefox/pocket.html'),
+
+    # Bug 1474285
+    page('firefox/profile-migrate', 'firefox/profile/profile-migrate.html'),
+    page('firefox/profile-downgrade', 'firefox/profile/profile-downgrade.html'),
 )

--- a/media/css/base/mozilla-fxa-form.scss
+++ b/media/css/base/mozilla-fxa-form.scss
@@ -11,6 +11,7 @@
     color: #000;
     margin: 0 auto;
     position: relative;
+    width: 250px;
 
     label {
         @include visually-hidden;
@@ -20,15 +21,15 @@
         @include font-size-level5;
         border-radius: 2px;
         box-sizing: border-box;
-        padding: .5em 20px;
+        padding: 0.5em 20px;
+        margin-bottom: 1em;
         width: 100%;
     }
 
-    .button {
+    button.button {
         background: #0060df;
-        border-radius: 2px;
         border: none;
-        padding: .5em 20px;
+        border-radius: 2px;
         width: 100%;
 
         &:focus,
@@ -68,28 +69,7 @@
         margin: 0 0 1em;
     }
 
-    .agreement {
+    .disclaimer {
         @include font-size-small;
-    }
-
-    @media #{$mq-phone-wide} {
-        @supports (display: flex) {
-            .fxa-email-field-container {
-                display: flex;
-            }
-
-            .field {
-                width: 66%;
-                margin: 0 20px 0 0;
-
-                [dir='rtl'] & {
-                    margin: 0 0 0 20px;
-                }
-            }
-
-            .button {
-                width: 33%;
-            }
-        }
     }
 }

--- a/media/css/base/mozilla-fxa-form.scss
+++ b/media/css/base/mozilla-fxa-form.scss
@@ -20,15 +20,15 @@
         @include font-size-level5;
         border-radius: 2px;
         box-sizing: border-box;
-        padding: 0.5em 20px;
-        margin-bottom: 1em;
+        padding: .5em 20px;
         width: 100%;
     }
 
-    button.button {
+    .button {
         background: #0060df;
-        border: none;
         border-radius: 2px;
+        border: none;
+        padding: .5em 20px;
         width: 100%;
 
         &:focus,
@@ -68,7 +68,28 @@
         margin: 0 0 1em;
     }
 
-    .disclaimer {
+    .agreement {
         @include font-size-small;
+    }
+
+    @media #{$mq-phone-wide} {
+        @supports (display: flex) {
+            .fxa-email-field-container {
+                display: flex;
+            }
+
+            .field {
+                width: 66%;
+                margin: 0 20px 0 0;
+
+                [dir='rtl'] & {
+                    margin: 0 0 0 20px;
+                }
+            }
+
+            .button {
+                width: 33%;
+            }
+        }
     }
 }

--- a/media/css/firefox/profile-per-install.scss
+++ b/media/css/firefox/profile-per-install.scss
@@ -1,0 +1,107 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+$font-path: '/media/fonts';
+$image-path: '/media/protocol/img';
+
+@import "../../../node_modules/@mozilla-protocol/core/protocol/css/includes/lib";
+@import "../../../node_modules/@mozilla-protocol/core/protocol/css/components/article";
+@import "../../../node_modules/@mozilla-protocol/core/protocol/css/components/button";
+@import "../protocol/components/fxa";
+
+.mzp-c-article {
+    margin-bottom: $layout-lg;
+
+    &.mzp-l-content {
+        padding-left: $spacing-lg;
+        padding-right: $spacing-lg;
+    }
+
+    h2 {
+        @include text-display-sm;
+        margin-top: $layout-md;
+    }
+}
+
+.mzp-c-article-title {
+    @include text-display-sm;
+    color: $color-red-60;
+}
+
+.mzp-c-article-intro {
+    @include text-display-md;
+    font-weight: bold;
+    margin: $layout-md 0;
+}
+
+.page-header {
+    text-align: center;
+
+    .logo-fx,
+    .logo-moz {
+        display: block;
+        margin: 0 auto $spacing-md;
+    }
+
+    @media #{$mq-md} {
+        .logo-fx {
+            @include bidi(((float, left, right),));
+        }
+
+        .logo-moz {
+            @include bidi(((float, right, left),));
+            margin: $spacing-md 0;
+        }
+    }
+}
+
+//* -------------------------------------------------------------------------- */
+// Firefox Accounts
+
+.fxa-cta {
+   .signed-in {
+        @include at2x('/media/img/firefox/accounts/green-check.png', 30px, 30px);
+        background-position: left top;
+        background-repeat: no-repeat;
+        min-height: 30px;
+        padding-left: $spacing-2xl;
+    }
+
+    .fxa-email-form {
+        margin: 0;
+        width: auto;
+
+        .fxa-email-form-intro {
+            font-weight: bold;
+        }
+
+        .fxa-email-field {
+            padding: $spacing-sm $spacing-lg;
+            margin: 0;
+        }
+
+        .mzp-c-button {
+            background: $color-black;
+            border-radius: 2px;
+            border: 2px solid $color-black;
+            box-shadow: none;
+            color: $color-white;
+            padding: ($spacing-sm - 2px) ($spacing-lg - 2px); // minus 2px to compensate for border width
+
+            &:hover,
+            &:focus {
+                background: $color-white;
+                box-shadow: 4px 4px 0 0 $color-black;
+                color: $color-black;
+                transition: box-shadow 100ms;
+            }
+
+            &:active {
+                box-shadow: 2px 2px 0 0 $color-black;
+                transition: box-shadow 0ms;
+            }
+        }
+    }
+}
+

--- a/media/css/firefox/profile-per-install.scss
+++ b/media/css/firefox/profile-per-install.scss
@@ -7,7 +7,6 @@ $image-path: '/media/protocol/img';
 
 @import "../../../node_modules/@mozilla-protocol/core/protocol/css/includes/lib";
 @import "../../../node_modules/@mozilla-protocol/core/protocol/css/components/article";
-@import "../../../node_modules/@mozilla-protocol/core/protocol/css/components/button";
 @import "../protocol/components/fxa";
 
 .mzp-c-article {
@@ -72,35 +71,9 @@ $image-path: '/media/protocol/img';
         margin: 0;
         width: auto;
 
-        .fxa-email-form-intro {
-            font-weight: bold;
-        }
-
-        .fxa-email-field {
-            padding: $spacing-sm $spacing-lg;
-            margin: 0;
-        }
-
-        .mzp-c-button {
-            background: $color-black;
-            border-radius: 2px;
-            border: 2px solid $color-black;
-            box-shadow: none;
-            color: $color-white;
-            padding: ($spacing-sm - 2px) ($spacing-lg - 2px); // minus 2px to compensate for border width
-
-            &:hover,
-            &:focus {
-                background: $color-white;
-                box-shadow: 4px 4px 0 0 $color-black;
-                color: $color-black;
-                transition: box-shadow 100ms;
-            }
-
-            &:active {
-                box-shadow: 2px 2px 0 0 $color-black;
-                transition: box-shadow 0ms;
-            }
+        strong {
+            font-size: inherit;
+            display: inline;
         }
     }
 }

--- a/media/css/firefox/profile-per-install.scss
+++ b/media/css/firefox/profile-per-install.scss
@@ -5,8 +5,8 @@
 $font-path: '/media/fonts';
 $image-path: '/media/protocol/img';
 
-@import "../../../node_modules/@mozilla-protocol/core/protocol/css/includes/lib";
-@import "../../../node_modules/@mozilla-protocol/core/protocol/css/components/article";
+@import "../../protocol/css/includes/lib";
+@import "../../protocol/css/components/article";
 @import "../protocol/components/fxa";
 
 .mzp-c-article {
@@ -61,10 +61,13 @@ $image-path: '/media/protocol/img';
 .fxa-cta {
    .signed-in {
         @include at2x('/media/img/firefox/accounts/green-check.png', 30px, 30px);
-        background-position: left top;
+        @include bidi((
+            (background-position, left top, right top),
+            (padding-left, $spacing-2xl, 0),
+            (padding-right, 0, $spacing-2xl),
+        ));
         background-repeat: no-repeat;
         min-height: 30px;
-        padding-left: $spacing-2xl;
     }
 
     .fxa-email-form {

--- a/media/css/protocol/components/_fxa.scss
+++ b/media/css/protocol/components/_fxa.scss
@@ -1,0 +1,27 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+@import "../../../node_modules/@mozilla-protocol/core/protocol/css/includes/lib";
+
+// Hide elements marked for specific variations by default
+.show-fxa-default,
+.show-fxa-not-fx,
+.show-fxa-supported-signed-out,
+.show-fxa-supported-signed-in,
+.show-fxa-unsupported,
+.show-fxa-android,
+.show-fxa-ios {
+    display: none;
+}
+
+// Show elements for current variation
+.state-fxa-supported-signed-in  .show-fxa-supported-signed-in,
+.state-fxa-supported-signed-out .show-fxa-supported-signed-out,
+.state-fxa-unsupported          .show-fxa-unsupported,
+.state-fxa-android              .show-fxa-android,
+.state-fxa-ios                  .show-fxa-ios,
+.state-fxa-not-fx               .show-fxa-not-fx,
+.state-fxa-default              .show-fxa-default {
+    display: block;
+}

--- a/media/js/base/mozilla-fxa-form.js
+++ b/media/js/base/mozilla-fxa-form.js
@@ -15,7 +15,6 @@ Mozilla.FxaForm = (function(Mozilla) {
 
     // swap form action for Fx China re-pack
     function init() {
-
         // disable form while we check distribution
         fxaSubmitButton.disabled = true;
 
@@ -66,9 +65,6 @@ Mozilla.FxaForm = (function(Mozilla) {
     }
 
     if (fxaForm) {
-        // form is Firefox only right now
-        if (Mozilla.Client.isFirefox) {
-            init();
-        }
+        init();
     }
 })(window.Mozilla);

--- a/media/js/base/mozilla-fxa-form.js
+++ b/media/js/base/mozilla-fxa-form.js
@@ -65,6 +65,9 @@ Mozilla.FxaForm = (function(Mozilla) {
     }
 
     if (fxaForm) {
-        init();
+        // form is Firefox only right now
+        if (Mozilla.Client.isFirefox) {
+            init();
+        }
     }
 })(window.Mozilla);

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -871,6 +871,13 @@
         "css/firefox/pocket.scss"
       ],
       "name": "product_pocket"
+    },
+    {
+      "files": [
+        "css/base/mozilla-fxa-form.scss",
+        "css/firefox/profile-per-install.scss"
+      ],
+      "name": "profile_per_install"
     }
   ],
   "js": [
@@ -1537,6 +1544,14 @@
         "js/firefox/pocket.js"
       ],
       "name": "product_pocket"
+    },
+    {
+      "files": [
+        "js/base/mozilla-fxa.js",
+        "js/base/mozilla-fxa-form.js",
+        "js/base/mozilla-fxa-init.js"
+      ],
+      "name": "profile_per_install"
     }
   ]
 }


### PR DESCRIPTION
## Description
Adds two variant pages explaining the new changes in profile management to users with multiple installs. This change is targeted for Firefox 64 but is due to land in Nightly in a few days so we need to a) secure the URLs since they'll be in-product and b) allow plenty of time for l10n before the release of Fx64.

Note this also includes some changes in the iframeless FxA macro that can have impact on other current FxA work such as #5974 

## Bug/Issue
#6054 
#5655 
https://bugzilla.mozilla.org/show_bug.cgi?id=1474285

## Testing
https://bedrock-demo-craigcook.oregon-b.moz.works/firefox/profile-migrate/
https://bedrock-demo-craigcook.oregon-b.moz.works/firefox/profile-downgrade/