### PR TITLE
Capitalize 'Restart Tour' in variation 0 of Tracking Protection tour (#6082)

### DIFF
--- a/bedrock/firefox/templates/firefox/tracking-protection-tour/variation-0.html
+++ b/bedrock/firefox/templates/firefox/tracking-protection-tour/variation-0.html
@@ -18,3 +18,9 @@ data-panel3-text-alt="{{ _('It’s easy to turn on Tracking Protection for the w
 data-panel3-step="{{ _('3 of 3') }}"
 data-panel3-button="{{ _('Got it!') }}"
 {% endblock %}
+
+{% block thanks %}
+  <h2>{{ _('Thanks for learning about Tracking Protection.') }}</h2>
+  <p>{{ _('Learn more about how it works by visiting the <a rel="external" href="%s">FAQ page</a>.')|format('https://support.mozilla.org/kb/tracking-protection-pbm') }}</p>
+  <button id="reload-btn" type="button" class="button">{{ _('Restart Tour') }}</button>
+{% endblock %}


### PR DESCRIPTION
## Description
- A minor string change: "Restart tour" to "Restart Tour".
- Both strings are already in the template, so no l10n required.

## Issue / Bugzilla link
#6082

## Testing
- Test in Nightly.
- Page should be opened in a private browsing window with Content Blocking enabled.
- URL: `/firefox/63.0/tracking-protection/start/?variation=0`