### PR TITLE
experiment to add FxA CTA to /new

### DIFF
--- a/bedrock/base/templates/macros.html
+++ b/bedrock/base/templates/macros.html
@@ -407,7 +407,7 @@
 
     DO NOT include utm_source in this dictionary! (It's already a required param.)
 #}
-{% macro fxa_email_form(entrypoint, utm_source, class_name='fxa-email-form', utm_params={}, intro_text='', button_text='', button_class='button-blue') -%}
+{% macro fxa_email_form(entrypoint, utm_source, class_name='fxa-email-form', utm_params={}, intro_text='', button_text='', button_class='button button-blue') -%}
   <form action="{{ settings.FXA_ENDPOINT }}" data-mozillaonline-action="{{ settings.FXA_ENDPOINT_MOZILLAONLINE }}" id="fxa-email-form" class="{{ class_name }}">
     <input type="hidden" name="action" value="email" />
     <input type="hidden" name="context" value="fx_desktop_v3" />
@@ -444,7 +444,7 @@
         <input type="email" name="email" id="fxa-email-field" class="fxa-email-field" placeholder="user@example.com" required>
       </p>
 
-      <button type="submit" class="button {{ button_class }}" id="fxa-email-form-submit">
+      <button type="submit" class="{{ button_class }}" id="fxa-email-form-submit">
       {% if button_text %}
         {{ button_text }}
       {% else %}

--- a/bedrock/base/templates/macros.html
+++ b/bedrock/base/templates/macros.html
@@ -407,7 +407,7 @@
 
     DO NOT include utm_source in this dictionary! (It's already a required param.)
 #}
-{% macro fxa_email_form(entrypoint, utm_source, class_name='fxa-email-form',  utm_params={}) -%}
+{% macro fxa_email_form(entrypoint, utm_source, class_name='fxa-email-form', utm_params={}, intro_text='', button_text='', button_class='button-blue') -%}
   <form action="{{ settings.FXA_ENDPOINT }}" data-mozillaonline-action="{{ settings.FXA_ENDPOINT_MOZILLAONLINE }}" id="fxa-email-form" class="{{ class_name }}">
     <input type="hidden" name="action" value="email" />
     <input type="hidden" name="context" value="fx_desktop_v3" />
@@ -423,20 +423,35 @@
     <input type="hidden" name="utm_{{ attr }}" value="{{ val }}" id="fxa-email-form-utm-{{ attr }}" />
   {% endfor %}
 
-    <p>
+    <p class="fxa-email-form-intro">
+    {% if intro_text %}
+      {{ intro_text }}
+    {% else %}
       {{ _('<strong>Enter your email</strong> to access Firefox Accounts.') }}
+    {% endif %}
     </p>
 
-    <label for="fxa-email-field">{{ _('Email address') }}</label>
-    <input type="email" name="email" id="fxa-email-field" class="fxa-email-field" placeholder="user@example.com" required />
-
-    <p class="disclaimer">
+    <p class="agreement">
     {% trans url1='https://accounts.firefox.com/legal/terms', url2='https://accounts.firefox.com/legal/privacy' %}
       By proceeding, you agree to the <a href="{{ url1 }}">Terms of Service</a> and
       <a href="{{ url2 }}">Privacy Notice</a>.
     {% endtrans %}
     </p>
 
-    <button type="submit" class="button button-blue" id="fxa-email-form-submit">{{ _('Continue') }}</button>
+    <div class="fxa-email-field-container">
+      <p class="field">
+        <label for="fxa-email-field">{{ _('Email address') }}</label>
+        <input type="email" name="email" id="fxa-email-field" class="fxa-email-field" placeholder="user@example.com" required>
+      </p>
+
+      <button type="submit" class="button {{ button_class }}" id="fxa-email-form-submit">
+      {% if button_text %}
+        {{ button_text }}
+      {% else %}
+        {{ _('Continue') }}
+      {% endif %}
+      </button>
+    </div>
+
   </form>
 {%- endmacro %}

--- a/bedrock/firefox/templates/firefox/new/fx/scene1.html
+++ b/bedrock/firefox/templates/firefox/new/fx/scene1.html
@@ -40,11 +40,13 @@
   <div class="main-cta-wrapper">
     <header>
       <h1>You’ve got Firefox.</h1>
-      <h2>Make it even better with a Firefox Account.</h2>
     </header>
-    <p>Sync bookmarks & passwords, send tabs and save to Pocket easily with one login.</p>
-    <div>
-      {{ fxa_email_form(entrypoint='accounts-page', button_class='button-black', utm_source='accounts-page', utm_params={'campaign': 'fxa-embedded-form', 'content': 'accounts-page', 'medium': 'referral'}) }}
+    <div class="show-fxa-supported-signed-out">
+      <h2>Make it even better with a Firefox Account.</h2>
+      <p>Sync bookmarks & passwords, send tabs and save to Pocket easily with one login.</p>
+      <div>
+        {{ fxa_email_form(entrypoint='accounts-page', button_class='button button-black', utm_source='accounts-page', utm_params={'campaign': 'fxa-embedded-form', 'content': 'accounts-page', 'medium': 'referral'}) }}
+      </div>
     </div>
     <div class="download-again-wrapper">
       <h2>Need to download again?</h2>

--- a/bedrock/firefox/templates/firefox/new/fx/scene1.html
+++ b/bedrock/firefox/templates/firefox/new/fx/scene1.html
@@ -1,0 +1,82 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+
+{% add_lang_files "firefox/new/quantum" %}
+
+{% from "macros.html" import fxa_email_form with context %}
+
+{% extends "firefox/new/base.html" %}
+
+{# All stylesheets are loaded in extrahead to serve legacy IE basic styles #}
+{% block extrahead %}
+  {{ super() }}
+  {{ css_bundle('firefox_new_fx_scene1') }}
+{% endblock %}
+
+{% block experiments %}
+  {% if switch('experiment_firefox_new_scene1_fx', ['en-US']) %}
+    {% if v == 'x' %}
+      {{ js_bundle('firefox_new_scene1_fx_experiment_x') }}
+    {% endif %}
+  {% endif %}
+{% endblock %}
+
+{% block body_id %}firefox-new-scene1{% endblock %}
+
+{% block messages %}
+<div class="version-message-container">
+  <div class="content">
+    <p class="version-message firefox-latest">{{_('Congrats! You’re using the latest version of Firefox.') }}</p>
+    <p class="version-message android-old">{{_('<a href="%(url)s">Update</a> your Firefox for the latest in speed and privacy.')|format(url='https://support.mozilla.org/kb/update-latest-version-firefox-android')}}</p>
+    <p class="version-message desktop-old">{{_('<a href="%(url)s">Update</a> your Firefox for the latest in speed and privacy.')|format(url='https://support.mozilla.org/kb/update-firefox-latest-version') }}</p>
+    <p class="version-message firefox-pre-release">{{_('You’re using a pre-release version of Firefox.') }}</p>
+  </div>
+</div>
+{% endblock %}
+
+{% block main_content %}
+<div class="main-download">
+  <div class="main-cta-wrapper">
+    <header>
+      <h1>You’ve got Firefox.</h1>
+      <h2>Make it even better with a Firefox Account.</h2>
+    </header>
+    <p>Sync bookmarks & passwords, send tabs and save to Pocket easily with one login.</p>
+    <div>
+      {{ fxa_email_form(entrypoint='accounts-page', button_class='button-black', utm_source='accounts-page', utm_params={'campaign': 'fxa-embedded-form', 'content': 'accounts-page', 'medium': 'referral'}) }}
+    </div>
+    <div class="download-again-wrapper">
+      <h2>Need to download again?</h2>
+
+      <div class="download-button-wrapper">
+        {# **WARNING**
+
+          The `locale_in_transition` parameter should be used very carefully. It's included
+          here because this template and scene2 share a lang file, and are therefore
+          translated into the same list of locales. Adding this to another download button
+          would significantly restrict the builds of Firefox available for download.
+
+          Bug 1290962
+        #}
+        {{ download_firefox(alt_copy=_('Download Now'), locale_in_transition=True, download_location='primary cta', button_color='button-hollow button-light') }}
+      </div>
+
+      <div id="refresh-firefox-wrapper">
+        <div class="refresh-inner-wrapper">
+          <button class="button button-hollow button-light" type="button" id="refresh-firefox" data-interaction="Refresh Firefox" data-element-action="Firefox Desktop" data-button-name="Refresh Firefox" data-cta-position="Primary">{{ _('Refresh Firefox') }}</button>
+          <small><a rel="external" href="https://support.mozilla.org/kb/refresh-firefox-reset-add-ons-and-settings?utm_source=mozilla.org&amp;utm_medium=referral&amp;utm_campaign=learn-more-link">{{ _('Learn more') }}</a></small>
+        </div>
+      </div>
+    </div>
+  </div>
+
+</div>
+{% endblock %}
+
+{% block additional_content %}
+{% endblock %}
+
+{% block js %}
+  {{ js_bundle('firefox_new_fx_scene1') }}
+{% endblock %}

--- a/bedrock/firefox/templates/firefox/new/scene1.html
+++ b/bedrock/firefox/templates/firefox/new/scene1.html
@@ -12,6 +12,16 @@
   {{ css_bundle('firefox_new_scene1') }}
 {% endblock %}
 
+{% block experiments %}
+  {% if switch('experiment_firefox_new_scene1_fx', ['en-US']) %}
+    {% if v != 'y' %}
+      {{ js_bundle('firefox_new_scene1_fx_experiment') }}
+    {% elif v == 'y' %}
+      {{ js_bundle('firefox_new_scene1_fx_experiment_y') }}
+    {% endif %}
+  {% endif %}
+{% endblock %}
+
 {% block body_id %}firefox-new-scene1{% endblock %}
 
 {% block messages %}

--- a/bedrock/firefox/tests/test_views.py
+++ b/bedrock/firefox/tests/test_views.py
@@ -972,6 +972,38 @@ class TestFirefoxNew(TestCase):
         views.download_thanks(req)
         render_mock.assert_called_once_with(req, 'firefox/new/scene2.html', ANY)
 
+    # fxa experiment for existing fx users bedrock/mozilla#5974
+
+    def test_fx_fxa_scene_1x(self, render_mock):
+        req = RequestFactory().get('/firefox/new/?v=x')
+        req.locale = 'en-US'
+        views.new(req)
+        render_mock.assert_called_once_with(req, 'firefox/new/fx/scene1.html', ANY)
+
+    def test_fx_fxa_scene_1y(self, render_mock):
+        req = RequestFactory().get('/firefox/new/?v=y')
+        req.locale = 'en-US'
+        views.new(req)
+        render_mock.assert_called_once_with(req, 'firefox/new/scene1.html', ANY)
+
+    def test_fx_fxa_scene_1_non_us(self, render_mock):
+        req = RequestFactory().get('/firefox/new/?v=x')
+        req.locale = 'de'
+        views.new(req)
+        render_mock.assert_called_once_with(req, 'firefox/new/scene1.html', ANY)
+
+    def test_fx_fxa_scene_2x(self, render_mock):
+        req = RequestFactory().get('/firefox/download/thanks/?v=x')
+        req.locale = 'en-US'
+        views.download_thanks(req)
+        render_mock.assert_called_once_with(req, 'firefox/new/scene2.html', ANY)
+
+    def test_fx_fxa_scene_2y(self, render_mock):
+        req = RequestFactory().get('/firefox/download/thanks/?v=y')
+        req.locale = 'en-US'
+        views.download_thanks(req)
+        render_mock.assert_called_once_with(req, 'firefox/new/scene2.html', ANY)
+
     # yandex - issue 5635
 
     @patch.dict(os.environ, SWITCH_FIREFOX_YANDEX='True')

--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -593,11 +593,13 @@ def download_thanks(request):
     show_newsletter = locale in ['en-US', 'en-GB', 'en-CA', 'en-ZA', 'es-ES', 'es-AR', 'es-CL', 'es-MX', 'pt-BR', 'fr', 'ru', 'id', 'de', 'pl']
 
     # ensure variant matches pre-defined value
-    if variant not in ['a']:  # place expected ?v= values in this list
+    if variant not in ['a', 'x', 'y']:  # place expected ?v= values in this list
         variant = None
 
     if variant == 'a' and locale == 'en-US':
         show_newsletter = False  # Prevent showing the newsletter for pre-download experiment Issue #5944
+    if variant == 'x' and locale == 'en-US':
+        show_newsletter = False  # Prevent showing the newsletter for FxA account experiment mozilla/bedrock#5974
 
     # `wait-face`, `reggiewatts` variations are currently localized for both en-US and de locales.
     if lang_file_is_active('firefox/new/wait-face', locale) and experience == 'waitface':
@@ -647,7 +649,7 @@ def new(request):
     locale = l10n_utils.get_locale(request)
 
     # ensure variant matches pre-defined value
-    if variant not in ['a', 'b', 'c', 'd', 'e', 'f', '1', '2']:  # place expected ?v= values in this list
+    if variant not in ['a', '1', '2', 'x', 'y']:  # place expected ?v= values in this list
         variant = None
 
     if scene == '2':
@@ -681,7 +683,9 @@ def new(request):
         elif switch('firefox-yandex') and locale == 'ru':
             template = 'firefox/new/yandex/scene1.html'
         elif locale == 'en-US':
-            if experience in ['portland', 'forgood']:
+            if variant == 'x':
+                template = 'firefox/new/fx/scene1.html'
+            elif experience in ['portland', 'forgood']:
                 template = 'firefox/new/portland/scene1.html'
             elif experience in ['portland-fast', 'fast']:
                 template = 'firefox/new/portland/scene1-fast.html'
@@ -717,7 +721,7 @@ def new(request):
 
     # no harm done by passing 'v' to template, even when no experiment is running
     # (also makes tests easier to maintain by always sending a context)
-    return l10n_utils.render(request, template, {'experience': experience})
+    return l10n_utils.render(request, template, {'experience': experience, 'v': variant})
 
 
 def ios_testflight(request):

--- a/media/css/base/mozilla-fxa-form.scss
+++ b/media/css/base/mozilla-fxa-form.scss
@@ -71,25 +71,4 @@
     .agreement {
         @include font-size-small;
     }
-
-    @media #{$mq-phone-wide} {
-        @supports (display: flex) {
-            .fxa-email-field-container {
-                display: flex;
-            }
-
-            .field {
-                width: 66%;
-                margin: 0 20px 0 0;
-
-                [dir='rtl'] & {
-                    margin: 0 0 0 20px;
-                }
-            }
-
-            .button {
-                width: 33%;
-            }
-        }
-    }
 }

--- a/media/css/base/mozilla-fxa-form.scss
+++ b/media/css/base/mozilla-fxa-form.scss
@@ -20,15 +20,15 @@
         @include font-size-level5;
         border-radius: 2px;
         box-sizing: border-box;
-        padding: 0.5em 20px;
-        margin-bottom: 1em;
+        padding: .5em 20px;
         width: 100%;
     }
 
-    button.button {
+    .button {
         background: #0060df;
-        border: none;
         border-radius: 2px;
+        border: none;
+        padding: .5em 20px;
         width: 100%;
 
         &:focus,
@@ -68,7 +68,28 @@
         margin: 0 0 1em;
     }
 
-    .disclaimer {
+    .agreement {
         @include font-size-small;
+    }
+
+    @media #{$mq-phone-wide} {
+        @supports (display: flex) {
+            .fxa-email-field-container {
+                display: flex;
+            }
+
+            .field {
+                width: 66%;
+                margin: 0 20px 0 0;
+
+                [dir='rtl'] & {
+                    margin: 0 0 0 20px;
+                }
+            }
+
+            .button {
+                width: 33%;
+            }
+        }
     }
 }

--- a/media/css/firefox/new/scene1-fx.scss
+++ b/media/css/firefox/new/scene1-fx.scss
@@ -1,0 +1,120 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+@import '../../pebbles/includes/lib';
+
+
+#firefox-new-scene1 {
+    .main-download {
+        max-width: 460px;
+    }
+
+    .main-cta-wrapper {
+        h1 {
+            font-weight: bold;
+            margin-bottom: 16px;
+        }
+
+        h2 {
+            font-weight: bold;
+            @include font-size(24px);
+            margin-bottom: 16px;
+        }
+    }
+
+    .main-content:after,
+    .header-image,
+    .features {
+        display: none;
+    }
+
+    .fxa-email-form {
+        border-top: 1px solid rgba(255,255,255,0.8);
+        color: #FFF;
+        margin-top: 35px;
+        padding-top: 24px;
+
+        .button.button-black {
+            background: #000;
+            border-radius: 2px;
+            border: 2px solid #000;
+            box-shadow: none;
+            color: #FFF;
+
+            &:hover,
+            &:focus {
+                background: #FFF;
+                box-shadow: 4px 4px 0 0 #000;
+                color: #000;
+                transition: box-shadow 100ms;
+            }
+            &:active {
+                box-shadow: 2px 2px 0 0 #000;
+                transition: box-shadow 0ms;
+            }
+        }
+
+        .fxa-email-form-intro {
+            font-weight: bold;
+            @include font-size(18px);
+
+            strong {
+                display: inline;
+                font-size: inherit;
+                font-weight: inherit;
+            }
+        }
+
+        a:link,
+        a:visited {
+            color: #fff;
+            text-decoration: underline;
+        }
+
+        a:hover,
+        a:active,
+        a:focus {
+            color: darken(#fff, 5%);
+        }
+    }
+
+    .download-again-wrapper {
+        display: flex;
+        flex-wrap: wrap;
+        justify-content: center;
+        text-align: center;
+
+        h2 {
+            @include font-size(16px);
+            margin-top: 60px;
+            width: 100%;
+        }
+
+        .button {
+            border-radius: 2px;
+        }
+    }
+
+    .refresh-inner-wrapper {
+        button {
+            margin-bottom: 10px;
+            line-height: 1.5;
+        }
+
+        small {
+            @include font-size(12px);
+            display: block;
+
+            a {
+                color: #FFF;
+                text-decoration: none;
+
+                &:hover,
+                &:focus {
+                    text-decoration: underline;
+                }
+            }
+        }
+    }
+}

--- a/media/css/firefox/new/scene1-fx.scss
+++ b/media/css/firefox/new/scene1-fx.scss
@@ -3,11 +3,22 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 @import '../../pebbles/includes/lib';
+@import '../../pebbles/components/fxa';
 
 
 #firefox-new-scene1 {
+
+    .main-content .header-content {
+        width: 100%;
+    }
+
     .main-download {
         max-width: 460px;
+        margin: 0 auto;
+
+        @media #{$mq-tablet} {
+            margin: 0;
+        }
     }
 
     .main-cta-wrapper {
@@ -93,6 +104,14 @@
 
         .button {
             border-radius: 2px;
+        }
+    }
+
+    .download-button-wrapper {
+        width: 100%;
+
+        @media #{$mq-tablet} {
+            width: auto;
         }
     }
 

--- a/media/js/base/mozilla-client.js
+++ b/media/js/base/mozilla-client.js
@@ -185,13 +185,13 @@ if (typeof Mozilla === 'undefined') {
         isESR = isESR === undefined ? false : isESR;
         userVer = userVer === undefined ? Client._getFirefoxVersion() : userVer;
 
-        var $html = $(document.documentElement);
+        var html = document.documentElement;
 
-        if (!$html.attr('data-esr-versions') || !$html.attr('data-latest-firefox')) {
+        if (!html.getAttribute('data-esr-versions') || !html.getAttribute('data-latest-firefox')) {
             return false;
         }
 
-        var versions = isESR ? $html.attr('data-esr-versions').split(' ') : [$html.attr('data-latest-firefox')];
+        var versions = isESR ? html.getAttribute('data-esr-versions').split(' ') : [html.getAttribute('data-latest-firefox')];
         var userVerArr = userVer.match(/^(\d+(?:\.\d+){1,2})/)[1].split('.');
         var isUpToDate = false;
 
@@ -221,7 +221,7 @@ if (typeof Mozilla === 'undefined') {
      */
     Client.isFirefoxOutOfDate = function(clientVer, majorVer, latestVer) {
         var clientVersion = parseInt(clientVer, 10);
-        var latestVersion = typeof latestVer === 'undefined' ? parseInt($('html').attr('data-latest-firefox'), 10) : parseInt(latestVer, 10);
+        var latestVersion = typeof latestVer === 'undefined' ? parseInt(document.documentElement.getAttribute('data-latest-firefox'), 10) : parseInt(latestVer, 10);
         var majorVersions = Math.max(parseInt(majorVer, 10), 1); // majorVersions must be at least 1.
 
         if (isNaN(latestVersion) || isNaN(clientVersion) || isNaN(majorVersions)) {
@@ -242,7 +242,7 @@ if (typeof Mozilla === 'undefined') {
         var path = typeof pathName === 'undefined' ? window.location.pathname : pathName;
         var urlVersion =  /firefox\/(\d+(?:\.\d+)?\.\da?\d?)/.exec(path);
         var version = urlVersion ? parseInt(urlVersion[1], 10) : null;
-        var latestVersion = typeof latestVer === 'undefined' ? parseInt($('html').attr('data-latest-firefox'), 10) : parseInt(latestVer, 10);
+        var latestVersion = typeof latestVer === 'undefined' ? parseInt(document.documentElement.getAttribute('data-latest-firefox'), 10) : parseInt(latestVer, 10);
         var majorVersions = Math.max(parseInt(majorVer, 10), 1); // majorVersions must be at least 1.
 
         if (version && latestVersion && (version <= latestVersion - majorVersions)) {

--- a/media/js/firefox/new/scene1-fx-experiment-x.js
+++ b/media/js/firefox/new/scene1-fx-experiment-x.js
@@ -1,0 +1,11 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+(function () {
+    'use strict';
+    var dataLayer = window.dataLayer = window.dataLayer || [];
+    dataLayer.push({
+        'data-ex-variant': 'fxa_form',
+        'data-ex-name': 'new-fx-fxa-form'
+    });
+})();

--- a/media/js/firefox/new/scene1-fx-experiment-y.js
+++ b/media/js/firefox/new/scene1-fx-experiment-y.js
@@ -1,0 +1,11 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+(function () {
+    'use strict';
+    var dataLayer = window.dataLayer = window.dataLayer || [];
+    dataLayer.push({
+        'data-ex-variant': 'no_fxa_form',
+        'data-ex-name': 'new-fx-fxa-form'
+    });
+})();

--- a/media/js/firefox/new/scene1-fx-experiment.js
+++ b/media/js/firefox/new/scene1-fx-experiment.js
@@ -5,22 +5,22 @@
 (function(Mozilla) {
     'use strict';
 
-    var client = Mozilla.Client;
-    if(client.isFirefox){
-        client.getFirefoxDetails(function(details) {
-            // only initialize experiment if current Firefox user not logged into FxA
-            if (details.firefox && !details.setup && (client.FirefoxVersion.indexOf(62) === 0)) {
-                var cop = new Mozilla.TrafficCop({
-                    id: 'scene1_fx_experiment',
-                    variations: {
-                        '&v=y': 50, // control
-                        '&v=x': 50
-                    }
-                });
+    var ua = navigator.userAgent;
+    var isFirefox = /\s(Firefox)/.test(ua) && !/Iceweasel|IceCat|SeaMonkey|Camino|like\ Firefox/i.test(ua);
+    var isDesktop = /\sFirefox/.test(ua) && !/Mobile|Tablet|Fennec|FxiOS/.test(ua);
+    var firefoxVersion = /Firefox\/(\d+(?:\.\d+){1,2})/.exec(ua);
+    var isUpToDate = firefoxVersion && firefoxVersion.hasOwnProperty(1) ? firefoxVersion[1].indexOf(62) === 0 : false;
 
-                cop.init();
+    if(isFirefox && isDesktop && isUpToDate) {
+        var cop = new Mozilla.TrafficCop({
+            id: 'scene1_fx_experiment',
+            variations: {
+                '&v=y': 50, // control
+                '&v=x': 50
             }
         });
+
+        cop.init();
     }
 
 })(window.Mozilla);

--- a/media/js/firefox/new/scene1-fx-experiment.js
+++ b/media/js/firefox/new/scene1-fx-experiment.js
@@ -1,0 +1,26 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+(function(Mozilla) {
+    'use strict';
+
+    var client = Mozilla.Client;
+    if(client.isFirefox){
+        client.getFirefoxDetails(function(details) {
+            // only initialize experiment if current Firefox user not logged into FxA
+            if (details.firefox && !details.setup && (client.FirefoxVersion.indexOf(62) === 0)) {
+                var cop = new Mozilla.TrafficCop({
+                    id: 'scene1_fx_experiment',
+                    variations: {
+                        '&v=y': 50, // control
+                        '&v=x': 50
+                    }
+                });
+
+                cop.init();
+            }
+        });
+    }
+
+})(window.Mozilla);

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -229,6 +229,14 @@
       "name": "firefox_new_scene1"
     },
     {
+      "files": [
+        "css/base/mozilla-fxa-form.scss",
+        "css/firefox/new/scene1.scss",
+        "css/firefox/new/scene1-fx.scss"
+      ],
+      "name": "firefox_new_fx_scene1"
+    },
+    {
         "files": [
           "css/firefox/new/scene1.scss",
           "css/firefox/new/yandex-scene1.scss"
@@ -986,6 +994,35 @@
         "js/firefox/new/scene1.js"
       ],
       "name": "firefox_new_scene1"
+    },
+    {
+      "files": [
+        "js/base/mozilla-traffic-cop.js",
+        "js/base/mozilla-client.js",
+        "js/firefox/new/scene1-fx-experiment.js"
+      ],
+      "name": "firefox_new_scene1_fx_experiment"
+    },
+    {
+      "files": [
+        "js/firefox/new/scene1-fx-experiment-y.js"
+      ],
+      "name": "firefox_new_scene1_fx_experiment_y"
+    },
+    {
+      "files": [
+        "js/firefox/new/scene1-fx-experiment-x.js"
+      ],
+      "name": "firefox_new_scene1_fx_experiment_x"
+    },
+    {
+      "files": [
+        "js/base/mozilla-modal.js",
+        "js/firefox/new/scene1.js",
+        "js/firefox/new/variation-scene1.js",
+        "js/base/mozilla-fxa-form.js"
+      ],
+      "name": "firefox_new_fx_scene1"
     },
     {
         "files": [

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -1018,9 +1018,11 @@
     {
       "files": [
         "js/base/mozilla-modal.js",
+        "js/base/mozilla-fxa.js",
+        "js/base/mozilla-fxa-init.js",
+        "js/base/mozilla-fxa-form.js",
         "js/firefox/new/scene1.js",
-        "js/firefox/new/variation-scene1.js",
-        "js/base/mozilla-fxa-form.js"
+        "js/firefox/new/variation-scene1.js"
       ],
       "name": "firefox_new_fx_scene1"
     },


### PR DESCRIPTION
## Description
- update client.js to not need jQuery to run (please look at this closely)
- add experiment using x and y for variations
- experiment is triggered on scene1 for en-US
  - then traffic cop checks for current Firefox Desktop usage before starting experiment
  - Firefox users are split 50% to x and 50% to the control (y)
- x variant users are sent to the scene2 page which does not ask for email address again

## Issue / Bugzilla link
mozilla/bedrock#5974

## Testing
https://www-demo4.allizom.org/en-US/firefox/new/
You will need to enable UITour for demo4 and/or localhost to do the testing.
The different states to test are here: https://github.com/mozilla/bedrock/issues/5974#issuecomment-412686553
