### PR TITLE
[Fix #6175] Fix about page JS bundle

### DIFF
--- a/bedrock/mozorg/templates/mozorg/about-en.html
+++ b/bedrock/mozorg/templates/mozorg/about-en.html
@@ -232,11 +232,8 @@
     </div>
   </aside>
 </div>
-
-
 {% endblock %}
 
-
 {% block js %}
-  {{ js_bundle('home') }}
+  {{ js_bundle('about-en') }}
 {% endblock %}

--- a/media/js/mozorg/about-en.js
+++ b/media/js/mozorg/about-en.js
@@ -1,0 +1,11 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+(function() {
+    'use strict';
+
+    // Lazyload images
+    Mozilla.LazyLoad.init();
+
+})();

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -1083,6 +1083,15 @@
     },
     {
       "files": [
+        "protocol/js/protocol-newsletter.js",
+        "js/newsletter/form-protocol.js",
+        "js/base/mozilla-lazy-load.js",
+        "js/mozorg/about-en.js"
+      ],
+      "name": "about-en"
+    },
+    {
+      "files": [
         "js/base/mozilla-video-poster.js",
         "js/mozorg/about-video.js"
       ],


### PR DESCRIPTION
## Description
The new about page was loading the home page JS bundle (probably an artifact of save-as). This adds a new JS bundle for the about page for the lazyloading images and newsletter form, minus the video and waypoints stuff.

## Issue / Bugzilla link
#6175 

## Testing
Just make sure the page works as it should without errors. Images should load and the newsletter form should expand and submit.
