### PR TITLE
Change how ID is set on forms, patents, and transparency

### DIFF
--- a/bedrock/mozorg/templates/mozorg/about/forums/cancellation.html
+++ b/bedrock/mozorg/templates/mozorg/about/forums/cancellation.html
@@ -5,7 +5,7 @@
 {% extends "mozorg/about-base.html" %}
 
 {% block page_title %}{{ _('Newsgroups Message Cancellation Policy') }}{% endblock %}
-{% block body_id %}about-forum-cancellation{% endblock %}
+{% set body_id = "about-forum-cancellation" %}
 
 {% block page_css %}
   {{ css_bundle('about-forums') }}

--- a/bedrock/mozorg/templates/mozorg/about/forums/etiquette.html
+++ b/bedrock/mozorg/templates/mozorg/about/forums/etiquette.html
@@ -5,7 +5,7 @@
 {% extends "mozorg/about-base.html" %}
 
 {% block page_title %}{{ _('Mozilla Forum Etiquette') }}{% endblock %}
-{% block body_id %}about-forum-etiquette{% endblock %}
+{% set body_id = "about-forum-etiquette" %}
 
 {% block page_css %}
   {{ css_bundle('about-forums') }}

--- a/bedrock/mozorg/templates/mozorg/about/forums/forums.html
+++ b/bedrock/mozorg/templates/mozorg/about/forums/forums.html
@@ -8,7 +8,7 @@
 {% set mdn_forums = ['mozilla.mdn', 'mozilla.dev.mdc', 'mozilla.dev.mdn'] %}
 
 {% block page_title %}{{ _('Forums') }}{% endblock %}
-{% block body_id %}about-forums{% endblock %}
+{% set body_id = "about-forums" %}
 
 {% block page_css %}
   {{ css_bundle('about-forums') }}

--- a/bedrock/mozorg/templates/mozorg/about/policy/patents/guide.html
+++ b/bedrock/mozorg/templates/mozorg/about/policy/patents/guide.html
@@ -5,7 +5,7 @@
 {% extends "mozorg/about-base.html" %}
 
 {% block page_title %}{{ _('Mozilla Patents') }}{% endblock %}
-{% block body_id %}about-patents{% endblock %}
+{% set body_id = "about-patents" %}
 {% block body_class %}about-patents{% endblock %}
 
 

--- a/bedrock/mozorg/templates/mozorg/about/policy/patents/guide.html
+++ b/bedrock/mozorg/templates/mozorg/about/policy/patents/guide.html
@@ -5,7 +5,7 @@
 {% extends "mozorg/about-base.html" %}
 
 {% block page_title %}{{ _('Mozilla Patents') }}{% endblock %}
-{% set body_id = "about-patents" %}
+{% set body_id = "about-patents-guide" %}
 {% block body_class %}about-patents{% endblock %}
 
 

--- a/bedrock/mozorg/templates/mozorg/about/policy/patents/index.html
+++ b/bedrock/mozorg/templates/mozorg/about/policy/patents/index.html
@@ -5,7 +5,7 @@
 {% extends "mozorg/about-base.html" %}
 
 {% block page_title %}{{ _('Mozilla Patents') }}{% endblock %}
-{% block body_id %}about-patents{% endblock %}
+{% set body_id = "about-patents" %}
 {% block body_class %}about-patents{% endblock %}
 
 

--- a/bedrock/mozorg/templates/mozorg/about/policy/patents/license-1.0.html
+++ b/bedrock/mozorg/templates/mozorg/about/policy/patents/license-1.0.html
@@ -5,7 +5,7 @@
 {% extends "mozorg/about-base.html" %}
 
 {% block page_title %}{{ _('Mozilla Open Software Patent License Agreement v1.0') }}{% endblock %}
-{% block body_id %}about-patents{% endblock %}
+{% set body_id = "about-patents-guide" %}
 {% block body_class %}about-patents{% endblock %}
 
 

--- a/bedrock/mozorg/templates/mozorg/about/policy/patents/license-1.0.html
+++ b/bedrock/mozorg/templates/mozorg/about/policy/patents/license-1.0.html
@@ -5,7 +5,7 @@
 {% extends "mozorg/about-base.html" %}
 
 {% block page_title %}{{ _('Mozilla Open Software Patent License Agreement v1.0') }}{% endblock %}
-{% set body_id = "about-patents-guide" %}
+{% set body_id = "about-patents-license-1-0" %}
 {% block body_class %}about-patents{% endblock %}
 
 

--- a/bedrock/mozorg/templates/mozorg/about/policy/patents/license.html
+++ b/bedrock/mozorg/templates/mozorg/about/policy/patents/license.html
@@ -5,7 +5,7 @@
 {% extends "mozorg/about-base.html" %}
 
 {% block page_title %}{{ _('Mozilla Open Software Patent License Agreement v1.1') }}{% endblock %}
-{% block body_id %}about-patents{% endblock %}
+{% set body_id = "about-patents-license" %}
 {% block body_class %}about-patents{% endblock %}
 
 

--- a/bedrock/mozorg/templates/mozorg/about/policy/transparency/includes/past-reports.html
+++ b/bedrock/mozorg/templates/mozorg/about/policy/transparency/includes/past-reports.html
@@ -5,15 +5,15 @@
 
 {# Add links to previous reports as new reports are published. #}
 <div class="nav-previous">
-<div class="content">
-<nav>
-  <h3>{{ _('Previous Reports') }}</h3>
-  <ul>
-    <li><a href="{{ url('mozorg.about.policy.transparency.jan-jun-2017') }}">{{ _('January-June 2017') }}</a></li>
-    <li><a href="{{ url('mozorg.about.policy.transparency.jul-dec-2016') }}">{{ _('July-December 2016') }}</a></li>
-    <li><a href="{{ url('mozorg.about.policy.transparency.jan-jun-2016') }}">{{ _('January-June 2016') }}</a></li>
-    <li><a href="{{ url('mozorg.about.policy.transparency.jan-dec-2015') }}">{{ _('January-December 2015') }}</a></li>
-  </ul>
-</nav>
-</div>
+  <div class="content">
+    <nav>
+      <h3>{{ _('Previous Reports') }}</h3>
+      <ul>
+        <li><a href="{{ url('mozorg.about.policy.transparency.jan-jun-2017') }}">{{ _('January-June 2017') }}</a></li>
+        <li><a href="{{ url('mozorg.about.policy.transparency.jul-dec-2016') }}">{{ _('July-December 2016') }}</a></li>
+        <li><a href="{{ url('mozorg.about.policy.transparency.jan-jun-2016') }}">{{ _('January-June 2016') }}</a></li>
+        <li><a href="{{ url('mozorg.about.policy.transparency.jan-dec-2015') }}">{{ _('January-December 2015') }}</a></li>
+      </ul>
+    </nav>
+  </div>
 </div>

--- a/bedrock/mozorg/templates/mozorg/about/policy/transparency/includes/past-reports.html
+++ b/bedrock/mozorg/templates/mozorg/about/policy/transparency/includes/past-reports.html
@@ -4,7 +4,9 @@
 
 
 {# Add links to previous reports as new reports are published. #}
-<nav class="content nav-previous">
+<div class="nav-previous">
+<div class="content">
+<nav>
   <h3>{{ _('Previous Reports') }}</h3>
   <ul>
     <li><a href="{{ url('mozorg.about.policy.transparency.jan-jun-2017') }}">{{ _('January-June 2017') }}</a></li>
@@ -13,3 +15,5 @@
     <li><a href="{{ url('mozorg.about.policy.transparency.jan-dec-2015') }}">{{ _('January-December 2015') }}</a></li>
   </ul>
 </nav>
+</div>
+</div>

--- a/bedrock/mozorg/templates/mozorg/about/policy/transparency/index.html
+++ b/bedrock/mozorg/templates/mozorg/about/policy/transparency/index.html
@@ -5,7 +5,8 @@
 {% extends "mozorg/about-base.html" %}
 
 {% block page_title %}{{ _('Transparency') }}{% endblock %}
-{% block body_class %}sand about-transparency{% endblock %}
+{% set body_id = "about-transparency" %}
+{% block body_class %}about-transparency{% endblock %}
 
 {% block page_css %}
   {{ css_bundle('about-transparency') }}
@@ -225,25 +226,25 @@
           </dd>
 
           <dt id="dfn-natl-security-request">{{ _('National Security Request') }}</dt>
-          <dd>{{ _('A National Security Letter issued under 18 U.S.C.§2709, a Court Order issued under the Foreign Intelligence Surveillance Act or any other classified request for user information issued in the U.S.') }}</dd>
+          <dd><p>{{ _('A National Security Letter issued under 18 U.S.C.§2709, a Court Order issued under the Foreign Intelligence Surveillance Act or any other classified request for user information issued in the U.S.') }}</p></dd>
 
           <dt id="dfn-pen-register-order">{{ _('Pen Register Order') }}</dt>
-          <dd>{{ _('A Pen Register and Trap and Trace Order is a type of U.S. <a href="%s">Court Order</a> compelling a company to disclose data about a user’s real­time communications (excluding the content of the communications themselves) to law enforcement on an ongoing basis, usually for a period of 60 days.')|format('#dfn-court-order') }}</dd>
+          <dd><p>{{ _('A Pen Register and Trap and Trace Order is a type of U.S. <a href="%s">Court Order</a> compelling a company to disclose data about a user’s real­time communications (excluding the content of the communications themselves) to law enforcement on an ongoing basis, usually for a period of 60 days.')|format('#dfn-court-order') }}</p></dd>
 
           <dt id="dfn-search-warrant">{{ _('Search Warrant') }}</dt>
-          <dd>{{ _('A document authorizing law enforcement to obtain user data issued by a neutral and detached magistrate on the basis of finding that “probable cause” exists to believe that the items being sought will be found in the place to be searched.') }}</dd>
+          <dd><p>{{ _('A document authorizing law enforcement to obtain user data issued by a neutral and detached magistrate on the basis of finding that “probable cause” exists to believe that the items being sought will be found in the place to be searched.') }}</p></dd>
 
           <dt id="dfn-specific-user">{{ _('Specific User') }}</dt>
-          <dd>{{ _('An identifiable user of Mozilla’s products and services.') }}</dd>
+          <dd><p>{{ _('An identifiable user of Mozilla’s products and services.') }}</p></dd>
 
           <dt id="dfn-subpoena">{{ _('Subpoena') }}</dt>
-          <dd>{{ _('A formal request for the production of evidence or testimony that can be issued by a government agency or court. Judicial review is not necessarily required.') }}</dd>
+          <dd><p>{{ _('A formal request for the production of evidence or testimony that can be issued by a government agency or court. Judicial review is not necessarily required.') }}</p></dd>
 
           <dt id="dfn-takedown-notice">{{ _('Takedown Notice') }}</dt>
-          <dd>{{ _('Documentation that meets the requirements set forth in our <a href="%s">reporting copyright or trademark infringement page</a>.')|format(url('legal.report-infringement')) }}</dd>
+          <dd><p>{{ _('Documentation that meets the requirements set forth in our <a href="%s">reporting copyright or trademark infringement page</a>.')|format(url('legal.report-infringement')) }}</p></dd>
 
           <dt id="dfn-wiretap-order">{{ _('Wiretap Order') }}</dt>
-          <dd>{{ _('A type of U.S. Court Order compelling a company to disclose the metadata and content of a user’s real­time communications to law enforcement on an ongoing basis, usually for a period of 30 days.') }}</dd>
+          <dd><p>{{ _('A type of U.S. Court Order compelling a company to disclose the metadata and content of a user’s real­time communications to law enforcement on an ongoing basis, usually for a period of 30 days.') }}</p></dd>
         </dl>
       </div>
     </section>


### PR DESCRIPTION
## Description
- Follow up on conversion off Sandstone
- The nav menu macro needs the body to be set this way instead of with the block
- Also a small formatting fix for the transparency index page.