### PR TITLE
Fix bottom download CTA on dev edition pages

### DIFF
--- a/media/css/firefox/developer/developer.scss
+++ b/media/css/firefox/developer/developer.scss
@@ -112,6 +112,7 @@
 @import 'includes/highlights';
 @import 'includes/features-gallery';
 @import 'includes/performance';
+@import 'includes/download';
 @import 'includes/newsletter';
 
 //*------------------------------------------------------------------*/

--- a/media/css/firefox/developer/firstrun.scss
+++ b/media/css/firefox/developer/firstrun.scss
@@ -6,18 +6,6 @@
 
 @import 'includes/lib';
 
-@mixin section-curve {
-    position: absolute;
-    display: block;
-    left: 0;
-    content: '';
-    background-position: center bottom;
-    background-repeat: no-repeat;
-    width: 100%;
-    visibility: visible;
-    z-index: 10;
-}
-
 body {
     scroll-behavior: smooth;
 }


### PR DESCRIPTION
## Description
The styling for the bottom download CTA on the dev edition pages was moved to a separate include file in https://github.com/mozilla/bedrock/pull/6132 but we forgot to `@import` it back into the main style sheet.

Also removed a redundant mixin.

Before (unstyled):
![image](https://user-images.githubusercontent.com/205591/45721762-3f698500-bb5e-11e8-8204-f71dd04bfd3a.png)

After (styled):
![image](https://user-images.githubusercontent.com/205591/45721900-c74f8f00-bb5e-11e8-973f-ff48b6801afa.png)

The dev edition whatsnew and firstrun pages also have the same section, but promoting Nightly:
![image](https://user-images.githubusercontent.com/205591/45721864-a38c4900-bb5e-11e8-9909-7776babec5d0.png)

## Testing
Verify the page section is styled on all three pages, and that the whatsnew and firstrun pages for dev edition show the Nightly logo. And the usual testing for responsiveness etc.