### PR TITLE
[fix #6205] Add Firefox Monitor privacy notice

### DIFF
--- a/bedrock/privacy/templates/privacy/notices/firefox-monitor.html
+++ b/bedrock/privacy/templates/privacy/notices/firefox-monitor.html
@@ -1,0 +1,8 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+
+{% extends "privacy/notices/firefox.html" %}
+
+{% block body_class %}{{ super() }} product-firefox-monitor{% endblock %}
+{% block article_header_logo %}{{ static('img/logos/firefox/logo-quantum.png') }}{% endblock %}

--- a/bedrock/privacy/urls.py
+++ b/bedrock/privacy/urls.py
@@ -23,6 +23,7 @@ urlpatterns = (
     url(r'^/thunderbird/$', views.thunderbird_notices, name='privacy.notices.thunderbird'),
     url(r'^/websites/$', views.websites_notices, name='privacy.notices.websites'),
     url(r'^/facebook/$', views.facebook_notices, name='privacy.notices.facebook'),
+    url(r'^/firefox-monitor/$', views.firefox_monitor_notices, name='privacy.notices.firefox-monitor'),
 
     page('/archive', 'privacy/archive/index.html'),
     page('/archive/firefox/2006-10', 'privacy/archive/firefox-2006-10.html'),

--- a/bedrock/privacy/views.py
+++ b/bedrock/privacy/views.py
@@ -124,6 +124,10 @@ facebook_notices = PrivacyDocView.as_view(
     legal_doc_name='facebook_privacy_info')
 facebook_notices = xframe_allow(facebook_notices)
 
+firefox_monitor_notices = PrivacyDocView.as_view(
+    template_name='privacy/notices/firefox-monitor.html',
+    legal_doc_name='firefox_monitor_terms_privacy')
+
 
 @cache_page(60 * 60)  # cache for 1 hour
 def privacy(request):


### PR DESCRIPTION
## Description
Adds a new page for the Firefox Monitor terms and privacy notice. The URL will be https://www.mozilla.org/privacy/firefox-monitor/ This page is currently *NOT* linked from the main privacy page.

Also updates the legal-docs submodule.

This needs to be in production on 20 September if possible.

## Issue / Bugzilla link
#6205 
https://bugzilla.mozilla.org/show_bug.cgi?id=1491440
