### PR TITLE
Fix #6209: Redirect /pocket to /firefox/pocket

### DIFF
--- a/bedrock/firefox/redirects.py
+++ b/bedrock/firefox/redirects.py
@@ -586,4 +586,7 @@ redirectpatterns = (
 
     # bug 1428783
     redirect(r'^firefox/dnt/?$', 'https://support.mozilla.org/kb/how-do-i-turn-do-not-track-feature'),
+
+    # issue 6209
+    redirect(r'^pocket/?', '/firefox/pocket/'),
 )

--- a/tests/redirects/map_globalconf.py
+++ b/tests/redirects/map_globalconf.py
@@ -1237,4 +1237,7 @@ URLS = flatten((
     # Bug 1436740
     url_test('/teach/{,smarton/}', '/internet-health/'),
     url_test('/teach/smarton/{tracking,security,surveillance}/', '/internet-health/privacy-security/'),
+
+    # Issue 6209
+    url_test('/pocket/', '/firefox/pocket/'),
 ))


### PR DESCRIPTION
## Description
Add redirect and test.

## Issue / Bugzilla link
#6209