### PR TITLE
Fix Bug 1494129 - Firefox 60 ESR release notes are missing on the Releases index page

### DIFF
--- a/bedrock/releasenotes/views.py
+++ b/bedrock/releasenotes/views.py
@@ -138,8 +138,11 @@ def latest_sysreq(request, product='firefox', platform=None, channel=None):
 
 def releases_index(request, product):
     releases = {}
-    esr_major_versions = range(
-        10, int(firefox_desktop.latest_version().split('.')[0]), 7)
+    # Starting with Firefox 10, ESR had been offered every 7 major releases, but
+    # Firefox 59 wasn't ESR. Firefox 60 became the next ESR instead, and since
+    # then ESR is offered every 8 major releases.
+    esr_major_versions = (range(10, 59, 7) +
+        range(60, int(firefox_desktop.latest_version().split('.')[0]), 8))
 
     if product == 'Firefox':
         major_releases = firefox_desktop.firefox_history_major_releases


### PR DESCRIPTION
## Description

The [Firefox release notes index page](https://www.mozilla.org/en-US/firefox/releases/) is missing Firefox 60 ESR because the release cycle has been changed. See the comment in the code for why.

## Issue / Bugzilla link

[Fix Bug 1494129 - Firefox 60 ESR release notes are missing on the Releases index page](https://bugzilla.mozilla.org/show_bug.cgi?id=1494129)

## Testing

I haven’t actually tested this because the local DB remains outdated (or corrupted?) for some reason, but this should work… Visit `/firefox/releases/` and make sure 60.1.0,  60.2.0 and 60.2.1 are listed.