### PR TITLE
Update @mozilla-protocol/core to v2.4.2

### DIFF
--- a/media/css/firefox/new/compare.scss
+++ b/media/css/firefox/new/compare.scss
@@ -5,12 +5,11 @@
 $font-path: '/media/fonts';
 $image-path: '/media/protocol/img';
 
-@import "../../../../node_modules/@mozilla-protocol/core/protocol/css/includes/lib";
-@import "../../../../node_modules/@mozilla-protocol/core/protocol/css/components/button";
-@import "../../../../node_modules/@mozilla-protocol/core/protocol/css/components/download-button";
-@import "../../../../node_modules/@mozilla-protocol/core/protocol/css/components/call-out";
-@import "../../../../node_modules/@mozilla-protocol/core/protocol/css/components/hero";
-@import "../../../../node_modules/@mozilla-protocol/core/protocol/css/components/feature-card";
+@import '../../../protocol/css/includes/lib';
+@import '../../../protocol/css/components/button';
+@import '../../../protocol/css/components/call-out';
+@import '../../../protocol/css/components/hero';
+@import '../../../protocol/css/components/feature-card';
 
 .section-title {
     @include text-display-sm;

--- a/media/css/firefox/new/scene2.scss
+++ b/media/css/firefox/new/scene2.scss
@@ -5,11 +5,10 @@
 $font-path: '/media/fonts';
 $image-path: '/media/protocol/img';
 
-@import "../../../../node_modules/@mozilla-protocol/core/protocol/css/includes/lib";
-@import "../../../../node_modules/@mozilla-protocol/core/protocol/css/components/button";
-@import "../../../../node_modules/@mozilla-protocol/core/protocol/css/components/modal";
-@import "../../../../node_modules/@mozilla-protocol/core/protocol/css/components/newsletter-form";
-
+@import '../../../protocol/css/includes/lib';
+@import '../../../protocol/css/components/button';
+@import '../../../protocol/css/components/modal';
+@import '../../../protocol/css/components/newsletter-form';
 
 
 // keep the button technically visible to grab correct download link for

--- a/media/css/firefox/pocket.scss
+++ b/media/css/firefox/pocket.scss
@@ -5,14 +5,13 @@
 $font-path: '/media/fonts';
 $image-path: '/media/protocol/img';
 
-@import "../../../node_modules/@mozilla-protocol/core/protocol/css/includes/lib";
-@import "../../../node_modules/@mozilla-protocol/core/protocol/css/components/button";
-@import "../../../node_modules/@mozilla-protocol/core/protocol/css/components/billboard";
-@import "../../../node_modules/@mozilla-protocol/core/protocol/css/components/call-out";
-@import "../../../node_modules/@mozilla-protocol/core/protocol/css/components/card";
-@import "../../../node_modules/@mozilla-protocol/core/protocol/css/components/feature-card";
-@import "../../../node_modules/@mozilla-protocol/core/protocol/css/components/hero";
-@import "../../../node_modules/@mozilla-protocol/core/protocol/css/templates/card-layout";
+@import '../../protocol/css/includes/lib';
+@import '../../protocol/css/components/button';
+@import '../../protocol/css/components/billboard';
+@import '../../protocol/css/components/call-out';
+@import '../../protocol/css/components/feature-card';
+@import '../../protocol/css/components/hero';
+@import '../../protocol/css/templates/card-layout';
 
 
 .mzp-t-dark {

--- a/media/css/firefox/whatsnew/whatsnew-62.scss
+++ b/media/css/firefox/whatsnew/whatsnew-62.scss
@@ -5,10 +5,10 @@
 $font-path: '/media/fonts';
 $image-path: '/media/protocol/img';
 
-@import "../../../../node_modules/@mozilla-protocol/core/protocol/css/includes/lib";
-@import "../../../../node_modules/@mozilla-protocol/core/protocol/css/components/button";
-@import "../../../../node_modules/@mozilla-protocol/core/protocol/css/components/hero";
-@import "../../../../node_modules/@mozilla-protocol/core/protocol/css/components/call-out";
+@import '../../../protocol/css/includes/lib';
+@import '../../../protocol/css/components/button';
+@import '../../../protocol/css/components/hero';
+@import '../../../protocol/css/components/call-out';
 @import 'send-yourself';
 
 

--- a/media/css/mozorg/about-en.scss
+++ b/media/css/mozorg/about-en.scss
@@ -5,15 +5,13 @@
 $font-path: '/media/fonts';
 $image-path: '/media/protocol/img';
 
-@import "../../../node_modules/@mozilla-protocol/core/protocol/css/includes/lib";
-@import "../../../node_modules/@mozilla-protocol/core/protocol/css/components/billboard";
-@import "../../../node_modules/@mozilla-protocol/core/protocol/css/components/button";
-@import "../../../node_modules/@mozilla-protocol/core/protocol/css/components/card";
-@import "../../../node_modules/@mozilla-protocol/core/protocol/css/components/feature-card";
-@import "../../../node_modules/@mozilla-protocol/core/protocol/css/components/hero";
-@import "../../../node_modules/@mozilla-protocol/core/protocol/css/components/newsletter-form";
-@import "../../../node_modules/@mozilla-protocol/core/protocol/css/templates/card-layout";
-
+@import '../../protocol/css/includes/lib';
+@import '../../protocol/css/components/billboard';
+@import '../../protocol/css/components/button';
+@import '../../protocol/css/components/feature-card';
+@import '../../protocol/css/components/hero';
+@import '../../protocol/css/components/newsletter-form';
+@import '../../protocol/css/templates/card-layout';
 
 
 /* -------------------------------------------------------------------------- */

--- a/media/css/mozorg/home/home-2018.scss
+++ b/media/css/mozorg/home/home-2018.scss
@@ -5,15 +5,13 @@
 $font-path: '/media/fonts';
 $image-path: '/media/protocol/img';
 
-@import "../../../protocol/css/includes/lib";
-@import "../../../protocol/css/components/billboard";
-@import "../../../protocol/css/components/button";
-@import "../../../protocol/css/components/download-button";
-@import "../../../protocol/css/components/card";
-@import "../../../protocol/css/components/footer";
-@import "../../../protocol/css/components/modal";
-@import "../../../protocol/css/components/newsletter-form";
-@import "../../../protocol/css/templates/card-layout";
+@import '../../../protocol/css/includes/lib';
+@import '../../../protocol/css/components/billboard';
+@import '../../../protocol/css/components/button';
+@import '../../../protocol/css/components/footer';
+@import '../../../protocol/css/components/modal';
+@import '../../../protocol/css/components/newsletter-form';
+@import '../../../protocol/css/templates/card-layout';
 
 @import '../../hubs/nav-download-button-remove';
 

--- a/media/css/mozorg/lean-data.scss
+++ b/media/css/mozorg/lean-data.scss
@@ -5,12 +5,11 @@
 $font-path: '/media/fonts';
 $image-path: '/media/protocol/img';
 
-@import "../../protocol/css/includes/lib";
-@import "../../protocol/css/components/button";
-@import "../../protocol/css/components/call-out";
-@import "../../protocol/css/components/card";
-@import "../../protocol/css/components/hero";
-@import "../../protocol/css/templates/card-layout";
+@import '../../protocol/css/includes/lib';
+@import '../../protocol/css/components/button';
+@import '../../protocol/css/components/call-out';
+@import '../../protocol/css/components/hero';
+@import '../../protocol/css/templates/card-layout';
 
 .mzp-l-content.l-content-narrow {
     max-width: $content-lg;

--- a/media/css/privacy/privacy-email.scss
+++ b/media/css/privacy/privacy-email.scss
@@ -5,8 +5,8 @@
 $font-path: '/media/fonts';
 $image-path: '/media/protocol/img';
 
-@import "../../../node_modules/@mozilla-protocol/core/protocol/css/includes/lib";
-@import "../../../node_modules/@mozilla-protocol/core/protocol/css/components/article";
+@import '../../protocol/css/includes/lib';
+@import '../../protocol/css/components/article';
 
 .mzp-c-article-title {
     @include text-display-md;

--- a/media/css/protocol/components/_download-button.scss
+++ b/media/css/protocol/components/_download-button.scss
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-@import "../../../../node_modules/@mozilla-protocol/core/protocol/css/includes/lib";
+@import '../../../protocol/css/includes/lib';
 
 // Download button color
 $color-button-green: #16da00;

--- a/media/css/protocol/components/_footer.scss
+++ b/media/css/protocol/components/_footer.scss
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-@import "../../../../node_modules/@mozilla-protocol/core/protocol/css/includes/lib";
+@import '../../../protocol/css/includes/lib';
 
 #colophon {
     @include open-sans;

--- a/media/css/protocol/components/_global-nav.scss
+++ b/media/css/protocol/components/_global-nav.scss
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-@import "../../../../node_modules/@mozilla-protocol/core/protocol/css/includes/lib";
+@import '../../../protocol/css/includes/lib';
 
 // Product colors
 $color-firefox-light-orange: #ff9500;

--- a/media/css/protocol/components/_masthead.scss
+++ b/media/css/protocol/components/_masthead.scss
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-@import "../../../../node_modules/@mozilla-protocol/core/protocol/css/includes/lib";
+@import '../../../protocol/css/includes/lib';
 
 // Download button color
 $color-button-green: #16da00;

--- a/media/css/protocol/oldIE.scss
+++ b/media/css/protocol/oldIE.scss
@@ -5,10 +5,10 @@
 // This style sheet is served exclusively to Internet Explorer 8 and older.
 // Old versions get this minimal style while IE9 and up recieve more advanced styling.
 
-@import "../../../node_modules/@mozilla-protocol/core/protocol/css/includes/lib";
-@import "../../../node_modules/@mozilla-protocol/core/protocol/css/base/elements";
+@import '../../protocol/css/includes/lib';
+@import '../../protocol/css/base/elements';
 
-@import "components/download-button";
+@import 'components/download-button';
 
 // An arbitrary container for translatable strings to use in scripts
 #strings {

--- a/media/css/protocol/protocol.scss
+++ b/media/css/protocol/protocol.scss
@@ -5,9 +5,9 @@
 $font-path: '/media/fonts';
 $image-path: '/media/protocol/img';
 
-@import "../../protocol/css/protocol.scss";
+@import '../../protocol/css/protocol.scss';
 
 // TODO port these components to Protocol.
-@import "components/global-nav";
-@import "components/masthead";
-@import "components/download-button";
+@import 'components/global-nav';
+@import 'components/masthead';
+@import 'components/download-button';

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Making mozilla.org awesome, one pebble at a time",
   "private": true,
   "dependencies": {
-    "@mozilla-protocol/core": "2.2.0",
+    "@mozilla-protocol/core": "2.4.2",
     "ansi-colors": "^1.1.0",
     "clean-css-cli": "4.0.5",
     "del": "^3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -19,9 +19,9 @@
     normalize-path "^2.0.1"
     through2 "^2.0.3"
 
-"@mozilla-protocol/core@2.2.0":
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/@mozilla-protocol/core/-/core-2.2.0.tgz#8fa67f646c9c32f044fb959bc7e87bdac58f29db"
+"@mozilla-protocol/core@2.4.2":
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/@mozilla-protocol/core/-/core-2.4.2.tgz#74dd781051955db61b98a42cd9b846f685b8fee6"
 
 JSONStream@^0.8.4:
   version "0.8.4"


### PR DESCRIPTION
## Description
- I'm updating Protocol in a separate PR here to make the navigation easier to review, plus there are more changes here not directly related to the nav, so it probably makes sense to do this separately.

## Issue / Bugzilla link
N/A

## Testing
- You'll need to run `make build` after pulling this PR down locally to pick up the new npm package inside docker.

- Things to check:
  - [ ] [Layout bug](https://github.com/mozilla/protocol/issues/227) on the homepage is now fixed.
  - [ ] Card component is now in the base bundle, so there should be no page specific imports.
  - [ ] [Font optimization](https://github.com/mozilla/protocol/pull/223) on Protocol pages for macOS.
  - [ ] Tidied up component sass imports for better readability.
