### PR TITLE
/firefox/download/thanks redirects to /firefox/new/ (Fixes #6210)

### DIFF
--- a/bedrock/firefox/redirects.py
+++ b/bedrock/firefox/redirects.py
@@ -70,7 +70,7 @@ redirectpatterns = (
     redirect(r'^firefoxos', '/firefox/os/'),
 
     # bug 1438302
-    no_redirect(r'^firefox/download/thanks/$'),
+    no_redirect(r'^firefox/download/thanks/?$'),
 
     # Bug 1006616
     redirect(r'^download/?$', 'firefox.new'),


### PR DESCRIPTION
Fixes #6210
