### PR TITLE
Remove display: none from .content-container to fix #6246

### DIFF
--- a/media/css/firefox/whatsnew/whatsnew-60.scss
+++ b/media/css/firefox/whatsnew/whatsnew-60.scss
@@ -90,7 +90,6 @@ h1, h2, h3, h4, h5, h6 {
 
 .content-container {
     color: #fff;
-    display: none;
     padding: 0 10px;
     z-index: 10;
 

--- a/media/css/firefox/whatsnew/whatsnew-61.scss
+++ b/media/css/firefox/whatsnew/whatsnew-61.scss
@@ -88,7 +88,6 @@ h1, h2, h3, h4, h5, h6 {
 
 .content-container {
     color: #fff;
-    display: none;
     padding: 0 10px;
     z-index: 10;
 

--- a/media/css/firefox/whatsnew/whatsnew-62.scss
+++ b/media/css/firefox/whatsnew/whatsnew-62.scss
@@ -252,11 +252,6 @@ $image-path: '/media/protocol/img';
 //* -------------------------------------------------------------------------- */
 // Conditional content
 
-// First we hide all the things
-.content-container {
-    display: none;
-}
-
 // Show no-js fallback by default
 .no-js #nojs-fx-mobile {
     display: block;

--- a/media/css/firefox/whatsnew/whatsnew-fxa.scss
+++ b/media/css/firefox/whatsnew/whatsnew-fxa.scss
@@ -41,7 +41,6 @@ h1, h2, h3, h4, h5, h6 {
 
 .content-container {
     color: #fff;
-    display: none;
     z-index: 10;
 
     @media #{$mq-tablet} {


### PR DESCRIPTION
## Description

Remove display: none from .content-container stylesheet to prevent empty notifications on whatsnew

## Issue / Bugzilla link

#6246

## Testing

Load whatsnew pages such as https://www.mozilla.org/en-US/firefox/60.0.2/whatsnew/?oldversion=59.0.2 with an out of date browser and verify content appears.
