### PR TITLE
Make notification banner content container visible to fix #6246

### DIFF
--- a/media/css/base/notification-banner.less
+++ b/media/css/base/notification-banner.less
@@ -38,7 +38,7 @@
         font-style: italic;
     }
 
-    .content-container {
+    .notification-content-container {
         float: left;
         position: relative;
         width: 65%;
@@ -120,7 +120,7 @@
             width: @widthTablet;
         }
 
-        .content-container:after {
+        .notification-content-container:after {
             .background-size(192px 190px);
             height: 190px;
             right: -200px;
@@ -138,7 +138,7 @@
             width: auto;
         }
 
-        .content-container:after {
+        .notification-content-container:after {
             content: none;
         }
 
@@ -148,7 +148,7 @@
     }
 
     @media only screen and (max-width: @breakMobileLandscape) {
-        .content-container {
+        .notification-content-container {
             width: 80%;
         }
     }
@@ -179,4 +179,3 @@
         margin-bottom: 100px;
     }
 }
-

--- a/media/css/pebbles/components/_notification-banner.scss
+++ b/media/css/pebbles/components/_notification-banner.scss
@@ -19,7 +19,7 @@
         font-style: italic;
     }
 
-    .content-container {
+    .notification-content-container {
         float: left;
         position: relative;
         width: 80%;
@@ -68,13 +68,13 @@
     }
 
     @media #{$mq-phone-wide} {
-        .content-container {
+        .notification-content-container {
             width: 65%;
         }
     }
 
     @media #{$mq-tablet} {
-        .content-container:after {
+        .notification-content-container:after {
             @include at2x('/media/img/notification/alarm-bell.png', 192px, 190px);
             background-repeat: no-repeat;
             content: '';
@@ -97,7 +97,7 @@
             padding-top: 40px;
         }
 
-        .content-container:after {
+        .notification-content-container:after {
             @include background-size(383px 380px);
             height: 380px;
             right: -320px;

--- a/media/js/base/mozilla-notification-banner.js
+++ b/media/js/base/mozilla-notification-banner.js
@@ -149,7 +149,7 @@ if (typeof Mozilla === 'undefined') {
 
         _container.className = 'notification-banner';
         _content.className = 'content';
-        _contentContainer.className = 'content-container';
+        _contentContainer.className = 'notification-content-container';
         _heading.innerHTML = options.heading;
         _message.innerHTML = options.message;
 


### PR DESCRIPTION
## Description

Make notification banner content container visible 

## Issue / Bugzilla link

#6246 

## Testing

Load https://www.mozilla.org/en-US/firefox/60.0.2/whatsnew/?oldversion=59.0.2 in an out of date version of firefox.