### PR TITLE
Legal: remove Firefox Marketplace

### DIFF
--- a/bedrock/legal/templates/legal/index.html
+++ b/bedrock/legal/templates/legal/index.html
@@ -22,7 +22,6 @@
       <li class="terms-websites"><a href="{{ url('legal.terms.mozilla') }}"><span>{{ _('Our Websites') }}</span></a></li>
       <li class="terms-firefox"><a href="{{ url('legal.terms.services') }}"><span>{{ _('Firefox Services') }}</span></a></li>
       <li class="terms-webmaker"><a href="https://webmaker.org/#/legal"><span>{{ _('Webmaker') }}</span></a></li>
-      <li class="terms-marketplace"><a href="https://marketplace.firefox.com/terms-of-use"><span>{{ _('Firefox Marketplace') }}</span></a></li>
     </ul>
   </section>
 


### PR DESCRIPTION
## Description

Firefox Marketplace does not exist anymore, therefore it doesn't make sense to link the (non-existing) terms anymore.

## Issue / Bugzilla link

https://bugzilla.mozilla.org/show_bug.cgi?id=1496300

## Testing

(None.)
