### PR TITLE
[fix bug 1495671] Content Blocking Tour breaks on step 3 with only cookie restrictions enabled.

### DIFF
--- a/bedrock/firefox/templates/firefox/tracking-protection-tour/index.html
+++ b/bedrock/firefox/templates/firefox/tracking-protection-tour/index.html
@@ -99,7 +99,7 @@ data-panel3-button="{{ _('Got it!') }}"
         <aside role="presentation"></aside>
         <div class="dubious-container">
           <div class="dubious">
-            <iframe src="https://trackertest.org/" height="100%" width="100%" frameborder="0"></iframe>
+            <iframe src="https://trackertest.org/set_cookie.html" height="100%" width="100%" frameborder="0"></iframe>
           </div>
           <section id="info-panel" class="hidden">
             <header tabindex="-1">


### PR DESCRIPTION
## Description
Adds a tracker that loads a cookie to the Content Blocking tour, in order to fix a bug when only cookie restrictions are enabled.

## Issue / Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1495671

## Testing
1. Test using **Firefox Beta**
2. Set `browser.contentblocking.ui.enabled` to `true`
3. [Enable UITour](https://bedrock.readthedocs.io/en/latest/uitour.html#local-development) for demo and/or local dev.
4. Open `about:preferences#privacy`
5. Set Content Blocking prefs like so:
  - Third party cookies - block trackers OR block all third parties
  - All Detected Trackers - OFF or Only in private mode
  - Slow Loading Trackers - OFF

Expected results: step 3 of the tour should display correctly (with info panel pointed at control center).

Test URL: `/firefox/63.0/tracking-protection/start/?newtab=true`