### PR TITLE
Remove switch for election firstrun page

### DIFF
--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -470,7 +470,7 @@ class FirstrunView(l10n_utils.LangFilesMixin, TemplateView):
             else:
                 template = 'firefox/dev-firstrun.html'
         elif show_62_firstrun(version):
-            if (switch('firefox-election-funnelcake') and locale == 'en-US' and experience == 'firefox-election'):
+            if locale == 'en-US' and experience == 'firefox-election':
                 template = 'firefox/firstrun/firstrun-election.html'
             else:
                 template = 'firefox/firstrun/firstrun-quantum.html'


### PR DESCRIPTION
## Description
I need to put the bundle download buttons behind a switch and I want
to re-use the name of this one instead of coming up with a 3rd name.

## Issue / Bugzilla link
mozilla/bedrock#6186
