### PR TITLE
[fix bug 1498290] Expose locale versions of Content Blocking Tour

### DIFF
--- a/bedrock/firefox/templates/firefox/tracking-protection-tour/variation-1.html
+++ b/bedrock/firefox/templates/firefox/tracking-protection-tour/variation-1.html
@@ -10,7 +10,13 @@
 
 {% block string_data %}
 data-panel1-title="{{ _('New in Firefox: Content Blocking') }}"
+
+{% if l10n_has_tag('remove_fastblock_1499589') %}
+data-panel1-text="{{ _('When you see the shield, Firefox is blocking parts of the page that can track you online.') }}"
+{% else %}
 data-panel1-text="{{ _('When you see the shield, Firefox is blocking parts of the page that can slow your browsing or track you online.') }}"
+{% endif %}
+
 data-panel1-step="{{ _('1 of 3') }}"
 data-panel1-button="{{ _('Next') }}"
 data-panel3-title="{{ _('Turn off blocking for trusted sites') }}"
@@ -32,7 +38,11 @@ data-panel3-button="{{ _('Got it!') }}"
 
 {% block panel_2 %}
   <h2>{{ _('Differences to expect') }}</h2>
+  {% if l10n_has_tag('remove_fastblock_1499589') %}
+  <p>{{ _('Content blocking can keep parts of pages or entire pages from loading.') }}</p>
+  {% else %}
   <p>{{ _('Content blocking can help pages load faster, but it can also keep parts of pages or entire pages from loading.') }}</p>
+  {% endif %}
 {% endblock %}
 
 {% block thanks %}

--- a/bedrock/firefox/templates/firefox/tracking-protection-tour/variation-2.html
+++ b/bedrock/firefox/templates/firefox/tracking-protection-tour/variation-2.html
@@ -32,7 +32,11 @@ data-panel3-button="{{ _('Got it!') }}"
 
 {% block panel_2 %}
   <h2>{{ _('Differences to expect') }}</h2>
-  <p>{{ _('Content blocking can help pages load faster, but it can also  keep parts of pages or entire pages from loading.') }}</p>
+  {% if l10n_has_tag('remove_fastblock_1499589') %}
+  <p>{{ _('Content blocking can keep parts of pages or entire pages from loading.') }}</p>
+  {% else %}
+  <p>{{ _('Content blocking can help pages load faster, but it can also keep parts of pages or entire pages from loading.') }}</p>
+  {% endif %}
 {% endblock %}
 
 {% block thanks %}

--- a/bedrock/firefox/tests/test_base.py
+++ b/bedrock/firefox/tests/test_base.py
@@ -637,12 +637,3 @@ class TestTrackingProtectionTour(TestCase):
         self.view(req, version='62.0')
         template = render_mock.call_args[0][1]
         eq_(template, ['firefox/tracking-protection-tour/variation-2.html'])
-
-    @override_settings(DEV=True)
-    def test_fx_tracking_protection_63_0_locales(self, render_mock):
-        """Should use default tracking protection tour template for non-en locales"""
-        req = self.rf.get('/firefox/tracking-protection/start/?variation=2')
-        req.locale = 'de'
-        self.view(req, version='62.0')
-        template = render_mock.call_args[0][1]
-        eq_(template, ['firefox/tracking-protection-tour/index.html'])

--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -597,9 +597,8 @@ class TrackingProtectionTourView(l10n_utils.LangFilesMixin, TemplateView):
 
     def get_template_names(self):
         variation = self.request.GET.get('variation', None)
-        locale = l10n_utils.get_locale(self.request)
 
-        if locale.startswith('en') and variation in ['0', '1', '2']:
+        if variation in ['0', '1', '2']:
             template = 'firefox/tracking-protection-tour/variation-{}.html'.format(variation)
         else:
             template = 'firefox/tracking-protection-tour/index.html'


### PR DESCRIPTION
## Description
- Exposes content blocking tour variations to all locales.
- Adds some last minute string changes due to FastBlock not shipping in FF 63.
- Needs to be in production before FF 63 launch (10/23).

## Issue / Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1498290
https://bugzilla.mozilla.org/show_bug.cgi?id=1499589
