### PR TITLE
updated esr title to 'Firefox Extended Support Release'

### DIFF
--- a/bedrock/firefox/templates/firefox/organizations/organizations.html
+++ b/bedrock/firefox/templates/firefox/organizations/organizations.html
@@ -28,7 +28,7 @@
 
 {% block main_feature %}
     <div class="pick">
-      <h1 class="large">{{ _('Find the right Firefox for you') }}</h1>
+      <h1 class="large">{{ _('Firefox Extended Support Release') }}</h1>
       <div class="row">
         <div class="col">
           <p>


### PR DESCRIPTION
## Description
Updated ESR page title from "Find the right Firefox for you" to "Firefox Extended Support Release"

## Issue / Bugzilla link
https://github.com/mozilla/bedrock/issues/6145

## Testing
