### PR TITLE
Hide nav download button on /firefox/election/ page (Fixes #6288)

### DIFF
--- a/media/css/firefox/election.scss
+++ b/media/css/firefox/election.scss
@@ -10,6 +10,7 @@ $image-path: '/media/protocol/img';
 @import "../../protocol/css/components/call-out";
 @import "../../protocol/css/components/hero";
 @import "../../protocol/css/components/download-button";
+@import '../hubs/nav-download-button-remove';
 
 
 // paper background


### PR DESCRIPTION
Fixes #6288