### PR TITLE
Add data attributes to Yandex download button

### DIFF
--- a/media/js/firefox/new/yandex/scene1.js
+++ b/media/js/firefox/new/yandex/scene1.js
@@ -131,6 +131,9 @@
             button[i].href = Mozilla.Utils.trans('buttonLink');
             button[i].removeAttribute('data-direct-link');
             button[i].querySelector('.download-title').innerHTML = Mozilla.Utils.trans('buttonText');
+            button[i].setAttribute('data-link-name', 'Yandex redirect');
+            button[i].setAttribute('data-link-type', 'Download Firefox (RU)');
+            button[i].setAttribute('data-link-position', 'primary cta');
         }
 
         // Update privacy policy text for Yandex.


### PR DESCRIPTION
## Description
Add data attributes to Yandex download button.

**data-link-name="Yandex redirect"
data-link-type="Download Firefox (RU)"**

_optional_
_data-link-position="primary cta"
data-link-group="" //any extra info
data-cta-position="" //any extra info_

## Issue / Bugzilla link
#6276