### PR TITLE
Update Firefox Election Bundle card title

### DIFF
--- a/bedrock/mozorg/templates/mozorg/home/home-en-election.html
+++ b/bedrock/mozorg/templates/mozorg/home/home-en-election.html
@@ -11,9 +11,9 @@
   <div class="mzp-l-content">
     <div class="mzp-l-card-hero">
       {% if switch('firefox-election-build') %}
-          {% set bundle_title = 'Get the Firefox Election Bundle' %}
+        {% set bundle_title = 'Get the Firefox U.S. Election Bundle' %}
       {% else %}
-        {% set bundle_title = 'Get the Firefox Election Collection' %}
+        {% set bundle_title = 'Get the Firefox U.S. Election Collection' %}
       {% endif %}
       {{ card_block(
           class='mzp-c-card-large',


### PR DESCRIPTION
Update first card title from "Get the Firefox Election Bundle" to "Get the Firefox U.S. Election Bundle" per request from legal.