### PR TITLE
Fix Bug 1500250 - Broken layout on https://www.mozilla.org/fr/firefox/developer/

### DIFF
--- a/bedrock/firefox/templates/firefox/developer/includes/highlights.html
+++ b/bedrock/firefox/templates/firefox/developer/includes/highlights.html
@@ -1,6 +1,6 @@
 <section class="section section-highlights">
   <div class="content">
-    <div class="highlight-tools">
+    <div class="highlight-item">
       <h2 class="section-title"><span>{{ _('New Tools') }}</span></h2>
 
       <div class="section-body">
@@ -28,7 +28,7 @@
       </div>
     </div>
 
-    <div class="highlight-features">
+    <div class="highlight-item">
       <h2 class="section-title"><span>{{ _('Innovative Features') }}</span></h2>
 
       <div class="section-body">
@@ -50,7 +50,7 @@
     </div>
 
     {% if l10n_has_tag('new_features_20180830') %}
-    <div class="highlight-features">
+    <div class="highlight-item">
       <h2 class="section-title"><span>{{ _('Convenient Features') }}</span></h2>
 
       <div class="section-body">
@@ -79,7 +79,7 @@
       </div>
     </div>
 
-    <div class="highlight-features">
+    <div class="highlight-item">
       <h2 class="section-title"><span>{{ _('Faster Information') }}</span></h2>
 
       <div class="section-body">

--- a/media/css/firefox/developer/developer.scss
+++ b/media/css/firefox/developer/developer.scss
@@ -23,6 +23,7 @@
         span {
             padding-bottom: 2px;
             border-bottom: 3px solid;
+            line-height: 2;
         }
     }
 

--- a/media/css/firefox/developer/includes/highlights.scss
+++ b/media/css/firefox/developer/includes/highlights.scss
@@ -6,6 +6,11 @@
     background: $color-dev-mediumblue;
     color: #fff;
 
+    .content {
+        @include flexbox;
+        @include flex-wrap;
+    }
+
     .hero-image {
         box-shadow: 0 15px 20px rgba(0, 0, 0, .15), 0 3px 6px rgba(0, 0, 0, .15);
     }
@@ -39,9 +44,9 @@
         .highlight-tools,
         .highlight-features {
             @include border-box;
-            @include span(6);
             margin-bottom: 0;
             padding: 20px 40px;
+            width: 50%;
         }
 
         .section-title,

--- a/media/css/firefox/developer/includes/highlights.scss
+++ b/media/css/firefox/developer/includes/highlights.scss
@@ -10,7 +10,7 @@
         box-shadow: 0 15px 20px rgba(0, 0, 0, .15), 0 3px 6px rgba(0, 0, 0, .15);
     }
 
-    .highlight-tools {
+    .highlight-item {
         padding-bottom: 20px;
         margin-bottom: 40px;
     }
@@ -41,8 +41,7 @@
             @include flex-wrap;
         }
 
-        .highlight-tools,
-        .highlight-features {
+        .highlight-item {
             @include border-box;
             margin-bottom: 0;
             padding: 20px 40px;

--- a/media/css/firefox/developer/includes/highlights.scss
+++ b/media/css/firefox/developer/includes/highlights.scss
@@ -6,11 +6,6 @@
     background: $color-dev-mediumblue;
     color: #fff;
 
-    .content {
-        @include flexbox;
-        @include flex-wrap;
-    }
-
     .hero-image {
         box-shadow: 0 15px 20px rgba(0, 0, 0, .15), 0 3px 6px rgba(0, 0, 0, .15);
     }
@@ -39,6 +34,11 @@
             background-image: url('/media/img/firefox/developer/curve-highlights-top.svg');
             height: 140px;
             top: -139px;
+        }
+
+        .content {
+            @include flexbox;
+            @include flex-wrap;
         }
 
         .highlight-tools,


### PR DESCRIPTION
## Description

Use flexbox instead of float to fix the broken layout. The reported page is French but this could happen in any locale.

## Issue / Bugzilla link

[Bug 1500250 - Broken layout on https://www.mozilla.org/fr/firefox/developer/](https://bugzilla.mozilla.org/show_bug.cgi?id=1500250)

## Testing

Visit /fr/firefox/developer/ and make sure the layout is fixed.