### PR TITLE
Fix Bug 1500952 - Always show Developer Information link even if there's no Developer item

### DIFF
--- a/bedrock/firefox/templates/firefox/releases/release-notes.html
+++ b/bedrock/firefox/templates/firefox/releases/release-notes.html
@@ -231,19 +231,20 @@
             {% endif %}
           {% endfor %}
 
-          {% for note in release.notes if note.tag == "Developer" %}
-            {% if loop.first %}
-            <div class="section-wrapper" id="{{ note.tag|lower() }}">
-              <h4>{{ note.tag }}</h4>
+          {# The Developer section is always visible with a MDN link #}
+          <div class="section-wrapper" id="developer">
+            <h4>{{ _('Developer') }}</h4>
+            {% for note in release.notes if note.tag == "Developer" %}
+              {% if loop.first %}
               <ul class="section-items">
               {% endif %}
               {{ note_entry(note) }}
               {% if loop.last %}
               </ul>
-              <a class="mdn-icon more" rel="external" href="https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/{{ release.major_version }}">{{ _('Developer Information') }}</a>
-            </div>
-            {% endif %}
-          {% endfor %}
+              {% endif %}
+            {% endfor %}
+            <a class="mdn-icon more" rel="external" href="https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/{{ release.major_version }}">{{ _('Developer Information') }}</a>
+          </div>
 
           {% for note in release.notes if note.tag == "HTML5" %}
             {% if loop.first %}

--- a/media/css/firefox/releasenotes-firefox.less
+++ b/media/css/firefox/releasenotes-firefox.less
@@ -13,8 +13,14 @@
 }
 
 .mdn-icon {
+    display: flex;
+    align-items: center;
     float: right;
-    margin-top: @baseLine;
+    margin-top: 10px;
+}
+
+.section-items + .mdn-icon {
+    margin-top: 20px;
 }
 
 .mdn-icon:before {


### PR DESCRIPTION
## Description

* Always show the Developer section and the **Developer Information** link on Firefox release notes, so the redundant **Changes affecting developers** item no longer has to be added manually to each note.
* Fix the alignment of elements on the section.

## Issue / Bugzilla link

[Bug 1500952 - Always show Developer Information link even if there’s no Developer item](https://bugzilla.mozilla.org/show_bug.cgi?id=1500952)

## Testing

* Visit `/en-US/firefox/64.0a1/releasenotes/` and make sure the Developer section is visible.
* Visit `/en-US/firefox/55.0a1/releasenotes/` and make sure 1 developer item and the Developer Information link are visible.

Here are the screenshots 😃 

![screenshot_2018-10-22 firefox nightly 64 0a1 see all new features updates and fixes](https://user-images.githubusercontent.com/2929505/47302440-7e707780-d5ef-11e8-9d1c-a8ed840d6e9e.png)
![screenshot_2018-10-22 firefox nightly 55 0a1 see all new features updates and fixes](https://user-images.githubusercontent.com/2929505/47302452-87614900-d5ef-11e8-93ff-1e18d5f84bca.png)