### PR TITLE
Add clarifying legal copy to /foundation

### DIFF
--- a/bedrock/foundation/templates/foundation/index.html
+++ b/bedrock/foundation/templates/foundation/index.html
@@ -29,6 +29,13 @@
   {% endtrans %}
   </p>
 
+
+  {% if l10n_has_tag('foundation_legal_201810') %}
+  <p>
+  {{ _('The Corporation also owns and is responsible for maintenance of mozilla.org and blog.mozilla.org') }}
+  </p>
+  {% endif %}
+
   <p>
     <a href="https://mzl.la/foundation-strategy" class="read-strategy">{{ _('Read the Mozilla Foundation’s 2016-2018 Strategy') }}</a>
   </p>


### PR DESCRIPTION
## Description
Add to the description of the corporation that it owns and is responsible for mozilla.org websites other than foundation.mozilla.org per legal request.

## Issue / Bugzilla link
[1500937](https://bugzilla.mozilla.org/show_bug.cgi?id=1500937)
