### PR TITLE
Truncated strings in Content Blocking tour for some locales (Fixes #6358)

### DIFF
--- a/bedrock/firefox/templates/firefox/tracking-protection-tour/index.html
+++ b/bedrock/firefox/templates/firefox/tracking-protection-tour/index.html
@@ -30,20 +30,20 @@ data-panel1-button="{{ _('Next') }}"
 data-panel3-title="{{ _('Want to make changes?') }}"
 
 {% if l10n_has_tag('tp_tour_firefox_201809') %}
-  data-panel3-text="{{ _('It’s easy to turn off Tracking Protection for the website you’re on by clicking “Disable For This Session.”') }}"
+  data-panel3-text="{{ _('It’s easy to turn off Tracking Protection for the website you’re on by clicking “Disable For This Session.”')|forceescape }}"
 {% else %}
-  data-panel3-text="{{ _('It’s easy to turn off Tracking Protection for the website you’re on by clicking “Disable protection for this session.”') }}"
+  data-panel3-text="{{ _('It’s easy to turn off Tracking Protection for the website you’re on by clicking “Disable protection for this session.”')|forceescape }}"
 {% endif %}
 
 {% if l10n_has_tag('tp_tour_firefox_201809') %}
-  data-panel3-text-new-tab="{{ _('It’s easy to turn off Tracking Protection for the website you’re on by clicking “Disable For This Site.”') }}"
+  data-panel3-text-new-tab="{{ _('It’s easy to turn off Tracking Protection for the website you’re on by clicking “Disable For This Site.”')|forceescape }}"
 {% elif l10n_has_tag('tp_tour_firefox_201602') %}
-  data-panel3-text-new-tab="{{ _('It’s easy to turn off Tracking Protection for the website you’re on by clicking “Disable protection for this site.”') }}"
+  data-panel3-text-new-tab="{{ _('It’s easy to turn off Tracking Protection for the website you’re on by clicking “Disable protection for this site.”')|forceescape }}"
 {% else %}
-  data-panel3-text-new-tab="{{ _('It’s easy to turn off Tracking Protection for the website you’re on by clicking “Disable protection for this session.”') }}"
+  data-panel3-text-new-tab="{{ _('It’s easy to turn off Tracking Protection for the website you’re on by clicking “Disable protection for this session.”')|forceescape }}"
 {% endif %}
 
-data-panel3-text-alt="{{ _('It’s easy to turn on Tracking Protection for the website you’re on by clicking “Enable protection.”') }}"
+data-panel3-text-alt="{{ _('It’s easy to turn on Tracking Protection for the website you’re on by clicking “Enable protection.”')|forceescape }}"
 data-panel3-step="{{ _('3 of 3') }}"
 data-panel3-button="{{ _('Got it!') }}"
 {% endblock %}

--- a/bedrock/firefox/templates/firefox/tracking-protection-tour/variation-0.html
+++ b/bedrock/firefox/templates/firefox/tracking-protection-tour/variation-0.html
@@ -12,9 +12,9 @@ data-panel1-text="{{ _('When you see the shield, Firefox is blocking some parts 
 data-panel1-step="{{ _('1 of 3') }}"
 data-panel1-button="{{ _('Next') }}"
 data-panel3-title="{{ _('Want to make changes?') }}"
-data-panel3-text="{{ _('It’s easy to turn off Tracking Protection for the website you’re on. Just select “Disable Blocking Temporarily.”') }}"
-data-panel3-text-new-tab="{{ _('It’s easy to turn off Tracking Protection for the website you’re on. Just select “Disable Blocking For This Site.”') }}"
-data-panel3-text-alt="{{ _('It’s easy to turn on Tracking Protection for the website you’re on by clicking “Enable Blocking For This Site.”') }}"
+data-panel3-text="{{ _('It’s easy to turn off Tracking Protection for the website you’re on. Just select “Disable Blocking Temporarily.”')|forceescape }}"
+data-panel3-text-new-tab="{{ _('It’s easy to turn off Tracking Protection for the website you’re on. Just select “Disable Blocking For This Site.”')|forceescape }}"
+data-panel3-text-alt="{{ _('It’s easy to turn on Tracking Protection for the website you’re on by clicking “Enable Blocking For This Site.”')|forceescape }}"
 data-panel3-step="{{ _('3 of 3') }}"
 data-panel3-button="{{ _('Got it!') }}"
 {% endblock %}

--- a/bedrock/firefox/templates/firefox/tracking-protection-tour/variation-1.html
+++ b/bedrock/firefox/templates/firefox/tracking-protection-tour/variation-1.html
@@ -20,10 +20,10 @@ data-panel1-text="{{ _('When you see the shield, Firefox is blocking parts of th
 data-panel1-step="{{ _('1 of 3') }}"
 data-panel1-button="{{ _('Next') }}"
 data-panel3-title="{{ _('Turn off blocking for trusted sites') }}"
-data-panel3-text="{{ _('If content blocking prevents you from using a site you trust, you can select “Disable Blocking Temporarily” in this panel.') }}"
-data-panel3-text-new-tab="{{ _('If content blocking prevents you from using a site you trust, you can select “Disable Blocking For This Site” in this panel.') }}"
+data-panel3-text="{{ _('If content blocking prevents you from using a site you trust, you can select “Disable Blocking Temporarily” in this panel.')|forceescape }}"
+data-panel3-text-new-tab="{{ _('If content blocking prevents you from using a site you trust, you can select “Disable Blocking For This Site” in this panel.')|forceescape }}"
 data-panel3-title-alt="{{ _('Want to make changes?') }}"
-data-panel3-text-alt="{{ _('To restore content blocking for a site, select “Enable Blocking For This Site“ in the Control Center panel.') }}"
+data-panel3-text-alt="{{ _('To restore content blocking for a site, select “Enable Blocking For This Site“ in the Control Center panel.')|forceescape }}"
 data-panel3-step="{{ _('3 of 3') }}"
 data-panel3-button="{{ _('Got it!') }}"
 {% endblock %}

--- a/bedrock/firefox/templates/firefox/tracking-protection-tour/variation-2.html
+++ b/bedrock/firefox/templates/firefox/tracking-protection-tour/variation-2.html
@@ -14,10 +14,10 @@ data-panel1-text="{{ _('The privacy benefits of Tracking Protection are now just
 data-panel1-step="{{ _('1 of 3') }}"
 data-panel1-button="{{ _('Next') }}"
 data-panel3-title="{{ _('Turn off blocking for trusted sites') }}"
-data-panel3-text="{{ _('If content blocking prevents you from using a site you trust, you can select “Disable Blocking Temporarily“ in this panel.') }}"
-data-panel3-text-new-tab="{{ _('If content blocking prevents you from using a site you trust, you can select “Disable Blocking For This Site“ in this panel.') }}"
+data-panel3-text="{{ _('If content blocking prevents you from using a site you trust, you can select “Disable Blocking Temporarily“ in this panel.')|forceescape }}"
+data-panel3-text-new-tab="{{ _('If content blocking prevents you from using a site you trust, you can select “Disable Blocking For This Site“ in this panel.')|forceescape }}"
 data-panel3-title-alt="{{ _('Want to make changes?') }}"
-data-panel3-text-alt="{{ _('To restore content blocking for a site, select “Enable Blocking For This Site“ in the Control Center panel.') }}"
+data-panel3-text-alt="{{ _('To restore content blocking for a site, select “Enable Blocking For This Site“ in the Control Center panel.')|forceescape }}"
 data-panel3-step="{{ _('3 of 3') }}"
 data-panel3-button="{{ _('Got it!') }}"
 {% endblock %}


### PR DESCRIPTION
Fixes #6358

@pmac this is the only filter I could find that seems to fix the issue. Curious if this is ok, or if there's a better way?

You can test this URL in a **private browsing window** to see the result (step 3 should show the string in question). You'll also need to whitelist your local dev server for [UITour](https://bedrock.readthedocs.io/en/latest/uitour.html#local-development)

`/da/firefox/63.0/tracking-protection/start/?step=1&variation=1`
