### PR TITLE
[fix #6365] Make FxA email form JS china re-pack distribution check more specific

### DIFF
--- a/media/js/base/mozilla-fxa-form.js
+++ b/media/js/base/mozilla-fxa-form.js
@@ -24,7 +24,7 @@ Mozilla.FxaForm = (function(Mozilla) {
             Mozilla.Client.getFirefoxDetails(function(data) {
                 // only switch to China re-pack URL if UITour call is successful
                 // (marked by data.accurate being true)
-                if (data.accurate && data.distribution !== 'default') {
+                if (data.accurate && data.distribution && data.distribution.toLowerCase() === 'mozillaonline') {
                     fxaForm.action = mozillaonlineAction;
                 }
 


### PR DESCRIPTION
## Description

Ensures that only users with `distribution` equal to `mozillaonline` get redirected to the Chinese re-pack FxA URL.

## Issue / Bugzilla link

#6365

## Testing

I believe the only way to truly test this is with non-default builds of Firefox. We should test with both the China re-pack and a Fedora build, but I'm not sure how to easily do this.

HOWEVER, we do have [existing code checking against this specific value](https://github.com/mozilla/bedrock/blob/bb1a65b048f130a4e1baa70a1a040eb462838c55/media/js/firefox/firstrun/firstrun_quantum.js#L67), so I think this is pretty safe.