### PR TITLE
Add main navigation to /firefox/channel/, /firefox/accounts/ and /firefox/enterprise/ (Fixes #6381)

### DIFF
--- a/bedrock/firefox/templates/firefox/accounts.html
+++ b/bedrock/firefox/templates/firefox/accounts.html
@@ -15,7 +15,6 @@
 {% endblock %}
 
 {% block body_class %}firefox-accounts state-fxa-default {% endblock %}
-{% block site_header %}{% endblock %}
 
 {% block content %}
 <main role="main">

--- a/bedrock/firefox/templates/firefox/channel/base.html
+++ b/bedrock/firefox/templates/firefox/channel/base.html
@@ -17,7 +17,14 @@
 
 {% block body_class %}{% endblock %}
 
+{% block global_nav %}
+  {% if LANG.startswith('en-') %}
+    {% include 'includes/navigation-switch.html' %}
+  {% endif %}
+{% endblock %}
+
 {% block site_header %}
+{% if not LANG.startswith('en-') %}
 <header id="masthead">
   <div class="container">
     <div class="logo">
@@ -39,6 +46,7 @@
     </nav>
   </div>
 </header>
+{% endif %}
 {% endblock %}
 
 {% block content %}

--- a/bedrock/firefox/templates/firefox/enterprise/index.html
+++ b/bedrock/firefox/templates/firefox/enterprise/index.html
@@ -15,8 +15,6 @@
 {% block body_id %}firefox{% endblock %}
 {% block body_class %}{% endblock %}
 
-{% block site_header %}{% endblock %}
-
 {% block content %}
 <main role="main">
   <section class="intro content-section">

--- a/media/css/firefox/accounts.scss
+++ b/media/css/firefox/accounts.scss
@@ -5,6 +5,7 @@
 @import '../pebbles/includes/lib';
 @import '../hubs/sections';
 @import '../quantum/common';
+@import '../hubs/masthead';
 
 /* -------------------------------------------------------------------------- */
 // Common elements

--- a/media/css/firefox/enterprise.scss
+++ b/media/css/firefox/enterprise.scss
@@ -4,6 +4,7 @@
 
 @import '../pebbles/includes/lib';
 @import '../hubs/sections';
+@import '../hubs/masthead';
 
 $enterprise-grid-spacing: 60px;
 


### PR DESCRIPTION
## Description
- Adds Protocol navigation component to `/firefox/channel/`, `/firefox/accounts/` and `/firefox/enterprise/` pages.

## Issue / Bugzilla link
#6381

## Testing
- [x] Protocol navigation should appear as expected on `en` pages.
- [x] Existing / legacy navigation should appear as expected on non-English locales.