### PR TITLE
Add FxA sign in link to global nav (Fixes #6333)

### DIFF
--- a/bedrock/base/templates/includes/protocol/navigation/menu/firefox.html
+++ b/bedrock/base/templates/includes/protocol/navigation/menu/firefox.html
@@ -58,8 +58,12 @@
               <a class="mzp-c-menu-item-link" href="{{ url('firefox.accounts') }}" data-link-name="Your Firefox Account" data-link-type="nav" data-link-position="topnav" data-link-group="firefox">
                 <svg class="mzp-c-menu-item-icon" width="24" height="24" xmlns="http://www.w3.org/2000/svg"><path d="M21 21a1 1 0 0 1-2 0v-2a3 3 0 0 0-3-3H8a3 3 0 0 0-3 3v2a1 1 0 0 1-2 0v-2a5 5 0 0 1 5-5h8a5 5 0 0 1 5 5v2zm-9-9a5 5 0 1 1 0-10 5 5 0 0 1 0 10zm0-2a3 3 0 1 0 0-6 3 3 0 0 0 0 6z" fill="#000" fill-rule="nonzero"/></svg>
                 <h4 class="mzp-c-menu-item-title">{{ _('Your Firefox Account') }}</h4>
-                <p class="mzp-c-menu-item-desc">{{ _('Make the most of your Firefox experience, across every device.') }}</p>
+                <p class="mzp-c-menu-item-desc">{{ _('Make the most of your Firefox experience, across every device.') }}
+                </p>
               </a>
+              <ul class="mzp-c-menu-item-list">
+                <li><a href="https://accounts.firefox.com/signin?utm_source=www.mozilla.org&amp;utm_medium=referral&amp;utm_campaign=nav&amp;utm_content=firefox" data-link-name="Download" data-link-type="nav" data-link-position="subnav" data-link-group="firefox">{{ _('Sign In') }}</a></li>
+              </ul>
             </section>
           </li>
           <li>


### PR DESCRIPTION
## Description
In Global nav under "Firefox" > "Your Firefox Account" there is a 'Sign In' sublink that links to https://accounts.firefox.com/signin

## Issue / Bugzilla link
#6333

## Testing
- [ ] Updates the global protocol nav
