### PR TITLE
Change campaign parameters on fx-fxa experiment form

### DIFF
--- a/bedrock/base/templates/macros.html
+++ b/bedrock/base/templates/macros.html
@@ -404,6 +404,7 @@
     }
 
     all values must validate against /^[\w\/.%-]+/
+    More info on how to pick names: https://mozilla.github.io/application-services/docs/accounts/metrics.html
 
     DO NOT include utm_source in this dictionary! (It's already a required param.)
 #}
@@ -413,6 +414,7 @@
     <input type="hidden" name="context" value="fx_desktop_v3" />
     <input type="hidden" name="service" value="sync" />
     <input type="hidden" name="entrypoint" value="{{ entrypoint }}" id="fxa-email-form-entrypoint" />
+    <input type="hidden" name="form_type" value="email" />
     {# flow_id and flow_begin_time will be populated via JS on page load #}
     <input type="hidden" name="flow_id" value="" />
     <input type="hidden" name="flow_begin_time" value="" />

--- a/bedrock/firefox/templates/firefox/new/fx/scene1.html
+++ b/bedrock/firefox/templates/firefox/new/fx/scene1.html
@@ -45,7 +45,7 @@
       <h2>Make it even better with a Firefox Account.</h2>
       <p>Sync bookmarks & passwords, send tabs and save to Pocket easily with one login.</p>
       <div>
-        {{ fxa_email_form(entrypoint='accounts-page', button_class='button button-black', utm_source='accounts-page', utm_params={'campaign': 'fxa-embedded-form', 'content': 'accounts-page', 'medium': 'referral'}) }}
+        {{ fxa_email_form(entrypoint='firefox-new', button_class='button button-black', utm_source='firefox-new', utm_params={'campaign': 'firefox-new', 'content': 'firefox-new-fxa-v1', 'term': 'existing-users', 'medium': 'referral'}) }}
       </div>
     </div>
     <div class="download-again-wrapper">


### PR DESCRIPTION
## Description
- Change campaign parameters on fx-fxa experiment form.
- Add URL to explanations about how to pick campaign values

## Issue / Bugzilla link
https://github.com/mozilla/bedrock/issues/5974

## Testing
Make sure I got these right:
utm_source = firefox-new
utm_content = firefox-new-fxa-v1 
utm_campaign = firefox-new
utm_term = existing-users
entrypoint = firefox-new
form_type = email

You need to be in Firefox to test, you might also need to enable UI Tour (I can't remember, tryfirst before going to that trouble?)

Up on demo here: https://bedrock-demo-shobson.oregon-b.moz.works/en-US/firefox/new/?v=x