### PR TITLE
Add Protocol navigation to release notes pages (Fixes #6403)

### DIFF
--- a/bedrock/firefox/templates/firefox/releases/index.html
+++ b/bedrock/firefox/templates/firefox/releases/index.html
@@ -8,6 +8,20 @@
   {{ css_bundle('firefox_releases_index') }}
 {% endblock %}
 
+{% block global_nav %}
+  {% if LANG.startswith('en-') %}
+    {% include 'includes/navigation-switch.html' %}
+  {% endif %}
+{% endblock %}
+
+{% block tabzilla_tab %}{% endblock %}
+
+{% block site_header_nav %}
+  {% if not LANG.startswith('en-') %}
+    {% include 'firefox/includes/top-menu.html' %}
+  {% endif %}
+{% endblock %}
+
 {% block breadcrumbs %}
   <nav class="breadcrumbs">
     <a href="{{ url('mozorg.home') }}">{{ _('Home') }}</a> >

--- a/bedrock/firefox/templates/firefox/releases/release-notes.html
+++ b/bedrock/firefox/templates/firefox/releases/release-notes.html
@@ -27,6 +27,12 @@
   {{ css_bundle('firefox_releasenotes_firefox') }}
 {% endblock %}
 
+{% block global_nav %}
+  {% if LANG.startswith('en-') %}
+    {% include 'includes/navigation-switch.html' %}
+  {% endif %}
+{% endblock %}
+
 {# channel_name is for display purposes where needed.  #}
 {% set channel_name = channel_name|default('') %}
 
@@ -34,7 +40,9 @@
 <header id="masthead" class="relasenotes-header">
   <div class="container">
     {% block site_header_nav %}
-      {% include 'firefox/includes/release-menu.html' %}
+      {% if not LANG.startswith('en-') %}
+        {% include 'firefox/includes/release-menu.html' %}
+      {% endif %}
     {% endblock %}
     {% block site_header_logo %}
       <h2>


### PR DESCRIPTION
## Description
- Adds Protocol navigation menu to `/firefox/releases/` and `/firefox/releasenotes/` pages.

## Issue / Bugzilla link
#6403

## Testing
- [x] Navigation should appear as expected for English locales.
- [x] Existing navigation links should display for non-English locales.