### PR TITLE
Add Mozilla Labs newsletter form to /technology (Fixes #6400)

### DIFF
--- a/bedrock/mozorg/templates/mozorg/technology.html
+++ b/bedrock/mozorg/templates/mozorg/technology.html
@@ -149,10 +149,22 @@
 
   <aside id="newsletter-subscribe">
     <div class="content">
-      {{ email_newsletter_form(newsletters='mozilla-foundation',
-         title=_('What’s next?'),
-         subtitle=_('Get the Mozilla newsletter for our latest tech news and more.'), button_class='button-light')
-      }}
+      {% if LANG.startswith('en-') %}
+        {{ email_newsletter_form(
+          newsletters='mozilla-technology',
+          title=_('What’s next?'),
+          subtitle=_('Get the Mozilla Labs newsletter for updates on our latest tech and product innovations.'),
+          button_class='button-light',
+          include_language=False)
+        }}
+      {% else %}
+        {{ email_newsletter_form(
+          newsletters='mozilla-foundation',
+          title=_('What’s next?'),
+          subtitle=_('Get the Mozilla newsletter for our latest tech news and more.'),
+          button_class='button-light')
+        }}
+      {% endif %}
     </div>
   </aside>
 


### PR DESCRIPTION
## Description
- Updates newsletter form on `/technology` to subscribe to Mozilla Labs newsletter (English locales only).

## Issue / Bugzilla link
#6400
https://bugzilla.mozilla.org/show_bug.cgi?id=1503021

## Testing
- [ ] Subscription should work as expected
- [ ] Non-en locales stil get regular newsletter form as expected.
