### PR TITLE
Remove interstitial link to Pocket in the main navigation (Fixes #6450)

### DIFF
--- a/bedrock/base/templates/includes/protocol/navigation/menu/firefox.html
+++ b/bedrock/base/templates/includes/protocol/navigation/menu/firefox.html
@@ -46,7 +46,7 @@
         <ul>
           <li>
             <section class="mzp-c-menu-item mzp-has-icon">
-              <a class="mzp-c-menu-item-link" href="{{ url('firefox.pocket') }}" data-link-name="Pocket by Firefox" data-link-type="nav" data-link-position="topnav" data-link-group="firefox">
+              <a class="mzp-c-menu-item-link" href="https://getpocket.com/firefox_learnmore/?utm_source=www.mozilla.org&amp;utm_medium=referral&amp;utm_campaign=nav&amp;utm_content=firefox" data-link-name="Pocket by Firefox" data-link-type="nav" data-link-position="topnav" data-link-group="firefox">
                 <svg class="mzp-c-menu-item-icon" width="24" height="22" xmlns="http://www.w3.org/2000/svg"><path d="M12 21.5c-6.627 0-12-5.373-12-12v-6a3 3 0 0 1 3-3h18a3 3 0 0 1 3 3v6c0 6.627-5.373 12-12 12zm5.977-15.048a1.485 1.485 0 0 0-1.087.479l-4.923 4.924-4.835-4.851A1.476 1.476 0 0 0 6 6.452a1.5 1.5 0 0 0-1.071 2.55l-.024.016 4.94 4.96 1.06 1.06a1.5 1.5 0 0 0 2.121 0l1.06-1.06 4.964-4.96a1.5 1.5 0 0 0-1.073-2.566z" fill="#FF4056" fill-rule="nonzero"/></svg>
                 <h4 class="mzp-c-menu-item-title">{{ _('Pocket by Firefox') }}</h4>
                 <p class="mzp-c-menu-item-desc">{{ _('Save content. Absorb knowledge.') }}</p>


### PR DESCRIPTION
## Description
- Updates Pocket link in navigation to point directly to `https://getpocket.com/firefox_learnmore/`.

Note: the `/firefox/pocket/` page is staying around, at least for now, as it might have some SEO value still.

## Issue / Bugzilla link
#6450
