### PR TITLE
[fix bug 1506463] Fix typo in Firefox subtitle in navigation

### DIFF
--- a/bedrock/base/templates/includes/protocol/navigation/menu/firefox.html
+++ b/bedrock/base/templates/includes/protocol/navigation/menu/firefox.html
@@ -14,7 +14,7 @@
               <a class="mzp-c-menu-item-link" href="{{ url('firefox') }}" data-link-name="Firefox Quantum Desktop Browser" data-link-type="nav" data-link-position="topnav" data-link-group="firefox">
                 <img src="{{ static('protocol/img/logos/firefox/firefox.png') }}" class="mzp-c-menu-item-icon" width="24" height="24" alt="">
                 <h4 class="mzp-c-menu-item-title">{{ _('Firefox Quantum Desktop Browser') }}</h4>
-                <p class="mzp-c-menu-item-desc">{{ _('Get the browser gives more power to you on Windows, Mac OS or Linux.') }}</p>
+                <p class="mzp-c-menu-item-desc">{{ _('Get the browser that gives more power to you on Windows, Mac OS or Linux.') }}</p>
               </a>
               <ul class="mzp-c-menu-item-list">
                 <li><a href="{{ url('firefox.new') }}" data-link-name="Download" data-link-type="nav" data-link-position="subnav" data-link-group="firefox">{{ _('Download') }}</a></li>


### PR DESCRIPTION
## Issue / Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1506463
