### PR TITLE
Implement redirects to foundation.mozilla.org

### DIFF
--- a/bedrock/foundation/redirects.py
+++ b/bedrock/foundation/redirects.py
@@ -2,12 +2,12 @@ from bedrock.redirects.util import redirect
 
 redirectpatterns = (
 
-    redirect(r'^foundation/$', 'https://foundation.mozilla.org/en/'),
-    redirect(r'^foundation/about/$', 'https://foundation.mozilla.org/en/about/'),
-    redirect(r'^foundation/documents/$', 'https://foundation.mozilla.org/en/about/public-records/'),
-    redirect(r'^foundation/issues/$', 'https://foundation.mozilla.org/en/initiatives/'),
-    redirect(r'^foundation/leadership-network/$', 'https://foundation.mozilla.org/en/'),
-    redirect(r'^foundation/advocacy/$', 'https://foundation.mozilla.org/en/'),
+    redirect(r'^foundation/$', 'https://foundation.mozilla.org/'),
+    redirect(r'^foundation/about/$', 'https://foundation.mozilla.org/about/'),
+    redirect(r'^foundation/documents/$', 'https://foundation.mozilla.org/about/public-records/'),
+    redirect(r'^foundation/issues/$', 'https://foundation.mozilla.org/initiatives/'),
+    redirect(r'^foundation/leadership-network/$', 'https://foundation.mozilla.org/'),
+    redirect(r'^foundation/advocacy/$', 'https://foundation.mozilla.org/'),
     redirect(r'^foundation/trademarks/?$', '/foundation/trademarks/policy/'),
     redirect(r'^foundation/trademarks/faq/$', '/foundation/trademarks/policy/'),
     redirect(r'^foundation/documents/domain-name-license.pdf$', '/foundation/trademarks/policy/'),

--- a/bedrock/foundation/redirects.py
+++ b/bedrock/foundation/redirects.py
@@ -2,6 +2,12 @@ from bedrock.redirects.util import redirect
 
 redirectpatterns = (
 
+    redirect(r'^foundation/$', 'https://foundation.mozilla.org/en/'),
+    redirect(r'^foundation/about/$', 'https://foundation.mozilla.org/en/about/'),
+    redirect(r'^foundation/documents/$', 'https://foundation.mozilla.org/en/about/public-records/'),
+    redirect(r'^foundation/issues/$', 'https://foundation.mozilla.org/en/initiatives/'),
+    redirect(r'^foundation/leadership-network/$', 'https://foundation.mozilla.org/en/'),
+    redirect(r'^foundation/advocacy/$', 'https://foundation.mozilla.org/en/'),
     redirect(r'^foundation/trademarks/?$', '/foundation/trademarks/policy/'),
     redirect(r'^foundation/trademarks/faq/$', '/foundation/trademarks/policy/'),
     redirect(r'^foundation/documents/domain-name-license.pdf$', '/foundation/trademarks/policy/'),

--- a/tests/redirects/map_globalconf.py
+++ b/tests/redirects/map_globalconf.py
@@ -1246,4 +1246,12 @@ URLS = flatten((
 
     # Issue 6209
     url_test('/pocket/', '/firefox/pocket/'),
+
+    # Issue 6476
+    url_test('/foundation/', 'https://foundation.mozilla.org/'),
+    url_test('/foundation/about/', 'https://foundation.mozilla.org/about/'),
+    url_test('/foundation/documents/', 'https://foundation.mozilla.org/about/public-records/'),
+    url_test('/foundation/issues/', 'https://foundation.mozilla.org/initiatives/'),
+    url_test('/foundation/leadership-network/', 'https://foundation.mozilla.org/'),
+    url_test('/foundation/advocacy/', 'https://foundation.mozilla.org/'),
 ))


### PR DESCRIPTION
## Description
Add in redirects for various `/foundation/` paths on Bedrock, leading to the new foundation homepage on foundation.mozilla.org.

## Issue / Bugzilla link
Closes #6467

