### PR TITLE
[fix #6473] Hide Fx download button in nav on Dev Edition product page

### DIFF
--- a/media/css/firefox/developer/developer.scss
+++ b/media/css/firefox/developer/developer.scss
@@ -5,6 +5,7 @@
 @import '../../pebbles/includes/lib';
 @import '../../pebbles/components/newsletter';
 @import '../../hubs/sub-nav';
+@import '../../hubs/nav-download-button-remove';
 
 @import 'includes/lib';
 
@@ -81,14 +82,6 @@
                 }
             }
         }
-    }
-
-    // Conflicting download button in nav is confusing.
-    // Hide it for now pending a better solution.
-    #global-nav-download-firefox,
-    #sub-nav-download-firefox,
-    #nav-download-firefox {
-        display: none;
     }
 
     // Adjust nav width now that we don't need room for a button.


### PR DESCRIPTION
## Description
The Dev Edition product page at https://www.mozilla.org/firefox/developer/ uses some CSS to hide the standard download button in the global nav, but the new global nav has different classes so the new button isn't hidden. We just need to add the appropriate class name to the page style sheet. 

## Issue / Bugzilla link
#6473 
