### PR TITLE
Add link to /locales/ page from the main footer (Fixes #6455)

### DIFF
--- a/bedrock/base/templates/includes/lang_switcher.html
+++ b/bedrock/base/templates/includes/lang_switcher.html
@@ -4,6 +4,7 @@
 
 {% if translations|length > 1 %}
 <form id="lang_form" method="get" action="#">
+  <a class="mzp-c-cta-link" href="{{ url('mozorg.locales') }}">{{ _('Language') }}</a>
   <label for="page-language-select">{{ _('Language') }}</label>
   <select id="page-language-select" name="lang" dir="ltr">
     {% for code, label in translations|dictsort -%}

--- a/bedrock/base/templates/includes/protocol/lang-switcher.html
+++ b/bedrock/base/templates/includes/protocol/lang-switcher.html
@@ -3,15 +3,16 @@
   # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
 
  {% if translations|length > 1 %}
- <form id="lang_form" class="mzp-c-language-switcher" method="get" action="#">
-   <label for="mzp-c-language-switcher-select">{{ _('Language') }}</label>
-   <select id="mzp-c-language-switcher-select" class="mzp-js-language-switcher-select" name="lang" dir="ltr">
-     {% for code, label in translations|dictsort -%}
-       {# Don't escape the label as it may include entity references
-        # like "Português (do&nbsp;Brasil)" (Bug 861149) #}
-       <option lang="{{ code }}" value="{{ code }}"{{ code|ifeq(LANG, " selected") }}>{{ label|safe|replace('English (US)', 'English') }}</option>
-     {% endfor %}
-   </select>
-   <button type="submit">{{ _('Go') }}</button>
+ <form id="lang_form" class="mzp-c-language-switcher mzp-t-dark" method="get" action="#">
+  <a class="mzp-c-cta-link" href="{{ url('mozorg.locales') }}">{{ _('Language') }}</a>
+  <label for="mzp-c-language-switcher-select">{{ _('Language') }}</label>
+  <select id="mzp-c-language-switcher-select" class="mzp-js-language-switcher-select" name="lang" dir="ltr">
+    {% for code, label in translations|dictsort -%}
+      {# Don't escape the label as it may include entity references
+       # like "Português (do&nbsp;Brasil)" (Bug 861149) #}
+      <option lang="{{ code }}" value="{{ code }}"{{ code|ifeq(LANG, " selected") }}>{{ label|safe|replace('English (US)', 'English') }}</option>
+    {% endfor %}
+  </select>
+  <button type="submit">{{ _('Go') }}</button>
  </form>
  {% endif %}

--- a/media/css/pebbles/components/_footer.scss
+++ b/media/css/pebbles/components/_footer.scss
@@ -141,9 +141,15 @@
     .lang-switcher {
         font-weight: bold;
 
-        label {
+        label,
+        .mzp-c-cta-link {
             display: inline-block;
             margin: 0 20px 5px 0;
+        }
+
+        // hide the <label> visually should a language link be shown instead.
+        .mzp-c-cta-link + label {
+            @include visually-hidden;
         }
 
         select {
@@ -197,8 +203,11 @@
         }
     }
 
-    .lang-switcher label {
-        margin: 0 0 5px 20px;
+    .lang-switcher {
+        label,
+        .mzp-c-cta-link {
+            margin: 0 0 5px 20px;
+        }
     }
 
     .social-links li {

--- a/media/css/pebbles/components/_footer.scss
+++ b/media/css/pebbles/components/_footer.scss
@@ -139,11 +139,11 @@
     }
 
     .lang-switcher {
-        font-weight: bold;
 
         label,
         .mzp-c-cta-link {
             display: inline-block;
+            font-weight: bold;
             margin: 0 20px 5px 0;
         }
 

--- a/media/css/sandstone/sandstone-resp.less
+++ b/media/css/sandstone/sandstone-resp.less
@@ -1150,7 +1150,6 @@ nav.menu-bar {
     }
 
     .lang-switcher {
-        font-weight: bold;
         .span(4);
         margin: 2.75em 0 0;
         padding: 0 20px 0 0;
@@ -1158,6 +1157,7 @@ nav.menu-bar {
         label,
         .mzp-c-cta-link {
             display: inline-block;
+            font-weight: bold;
             margin: 0 20px 5px 0;
         }
 

--- a/media/css/sandstone/sandstone-resp.less
+++ b/media/css/sandstone/sandstone-resp.less
@@ -1155,9 +1155,15 @@ nav.menu-bar {
         margin: 2.75em 0 0;
         padding: 0 20px 0 0;
 
-        label {
+        label,
+        .mzp-c-cta-link {
             display: inline-block;
             margin: 0 20px 5px 0;
+        }
+
+        // hide the <label> visually should a language link be shown instead.
+        .mzp-c-cta-link + label {
+            .visually-hidden;
         }
 
         select {
@@ -1180,8 +1186,11 @@ nav.menu-bar {
         padding: 0 0 0 20px;
     }
 
-    .lang-switcher label {
-        margin: 0 0 5px 20px;
+    .lang-switcher {
+        label,
+        .mzp-c-cta-link {
+            margin: 0 0 5px 20px;
+        }
     }
 
     .social-links li {


### PR DESCRIPTION
## Description
- Adds a link to the new `/locales/` page from the language switcher in the main site footer.

## Issue / Bugzilla link
#6455

## Testing
- Lang switcher in footer should appear as expected on Protocol, Pebbles, and Sandstone pages.
