### PR TITLE
Run firefox pre-download experiment for de and fr locales (Fixes #6456)

### DIFF
--- a/bedrock/firefox/templates/firefox/home-b.de.html
+++ b/bedrock/firefox/templates/firefox/home-b.de.html
@@ -1,0 +1,49 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. #}
+
+{% add_lang_files "firefox/hub/home-quantum" "firefox/shared" %}
+
+{% extends "firefox/home.html" %}
+
+{% block experiments %}{% endblock %}
+
+{% block page_css %}
+  {{ super() }}
+  {{ css_bundle('firefox-home-pre-download') }}
+{% endblock %}
+
+{% block button_primary %}
+  <div class="pre-download-button-container" {% block variant_name %}data-variant-name="v-2-headline-a"{% endblock %}>
+    <button class="button button-green" id="pre-download-button" type="button" data-button-name="Download Firefox CTA">{{ _('Download Firefox') }}</button>
+    <small class="fx-privacy-link">
+      <a href="{{ url('privacy.notices.firefox') }}">Firefox Privacy Notice</a>
+    </small>
+  </div>
+{% endblock %}
+
+{% block additional_content %}
+  <div class="pre-download-newsletter">
+    <div class="pre-download-newsletter-content">
+      <h2 class="pre-download-newsletter-title">{% block newsletter_title %}{{ _('So machst Du Firefox noch schneller, sicherer und smarter.') }}{% endblock %}</h2>
+      <p class="pre-download-newsletter-desc">{{ _('Lass Dir Tipps, Tricks und Produktankündigungen direkt in Dein Postfach schicken.') }}</p>
+      {{ email_newsletter_form(
+          include_title=False,
+          spinner_color='#000',
+          button_class='button-hollow',
+          email_label=_('Gib Deine E-Mail-Adresse ein'),
+          email_placeholder=_('Sie@example.com'),
+          details='<a href="%s" class="email-privacy-link">%s</a>'|format(url('privacy.email'), _('Was genau macht Mozilla mit meiner E-Mail-Adresse?'))|safe,
+          submit_text=_('Firefox downloaden & Account erstellen'))
+      }}
+      <p class="pre-download-continue">
+        <a href="{{ url('firefox.download.thanks') }}?v=a" data-link-name="Continue FireFox Download" data-link-type="link">{{ _('Firefox Download fortsetzen') }}</a>
+      </p>
+    </div>
+  </div>
+{% endblock %}
+
+{% block js %}
+  {{ super() }}
+  {{ js_bundle('firefox-home-pre-download-newsletter') }}
+{% endblock %}

--- a/bedrock/firefox/templates/firefox/home-b.fr.html
+++ b/bedrock/firefox/templates/firefox/home-b.fr.html
@@ -1,0 +1,49 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. #}
+
+{% add_lang_files "firefox/hub/home-quantum" "firefox/shared" %}
+
+{% extends "firefox/home.html" %}
+
+{% block experiments %}{% endblock %}
+
+{% block page_css %}
+  {{ super() }}
+  {{ css_bundle('firefox-home-pre-download') }}
+{% endblock %}
+
+{% block button_primary %}
+  <div class="pre-download-button-container" {% block variant_name %}data-variant-name="v-2-headline-a"{% endblock %}>
+    <button class="button button-green" id="pre-download-button" type="button" data-button-name="Download Firefox CTA">{{ _('Download Firefox') }}</button>
+    <small class="fx-privacy-link">
+      <a href="{{ url('privacy.notices.firefox') }}">Firefox Privacy Notice</a>
+    </small>
+  </div>
+{% endblock %}
+
+{% block additional_content %}
+  <div class="pre-download-newsletter">
+    <div class="pre-download-newsletter-content">
+      <h2 class="pre-download-newsletter-title">{% block newsletter_title %}{{ _('Découvrez comment rendre Firefox plus intelligent, plus rapide et plus sûr.') }}{% endblock %}</h2>
+      <p class="pre-download-newsletter-desc">{{ _('Recevez des informations, des astuces et des nouvelles sur les produits directement dans votre boîte de réception.') }}</p>
+      {{ email_newsletter_form(
+          include_title=False,
+          spinner_color='#000',
+          button_class='button-hollow',
+          email_label=_('Saisissez votre adresse de courrier électronique'),
+          email_placeholder=_('votrenom@example.com'),
+          details='<a href="%s" class="email-privacy-link">%s</a>'|format(url('privacy.email'), _('Comment mon adresse sera-t-elle utilisée par Mozilla ?'))|safe,
+          submit_text=_('Je télécharge Firefox et je crée un compte'))
+      }}
+      <p class="pre-download-continue">
+        <a href="{{ url('firefox.download.thanks') }}?v=a" data-link-name="Continue FireFox Download" data-link-type="link">{{ _('Continuer le téléchargement de Firefox') }}</a>
+      </p>
+    </div>
+  </div>
+{% endblock %}
+
+{% block js %}
+  {{ super() }}
+  {{ js_bundle('firefox-home-pre-download-newsletter') }}
+{% endblock %}

--- a/bedrock/firefox/templates/firefox/home-c.de.html
+++ b/bedrock/firefox/templates/firefox/home-c.de.html
@@ -1,0 +1,13 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. #}
+
+{% add_lang_files "firefox/hub/home-quantum" "firefox/shared" %}
+
+{% extends "firefox/home-b.de.html" %}
+
+{% block experiments %}{% endblock %}
+
+{% block variant_name %}data-variant-name="v-2-headline-b"{% endblock %}>
+
+{% block newsletter_title %}{{ _('So holst Du das beste aus Firefox – dem Browser, der für Menschen entwickelt wurde, nicht für Profit.') }}{% endblock %}

--- a/bedrock/firefox/templates/firefox/home-c.fr.html
+++ b/bedrock/firefox/templates/firefox/home-c.fr.html
@@ -1,0 +1,13 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. #}
+
+{% add_lang_files "firefox/hub/home-quantum" "firefox/shared" %}
+
+{% extends "firefox/home-b.fr.html" %}
+
+{% block experiments %}{% endblock %}
+
+{% block variant_name %}data-variant-name="v-2-headline-b"{% endblock %}>
+
+{% block newsletter_title %}{{ _('Découvrez comment tirer le meilleur parti du navigateur conçu pour tout le monde, non pour faire du profit.') }}{% endblock %}

--- a/bedrock/firefox/templates/firefox/home.html
+++ b/bedrock/firefox/templates/firefox/home.html
@@ -18,8 +18,11 @@
 {% block page_desc %}{{ _('Responsive engine, less memory usage and packed with features. Download for desktop now.') }}{% endblock %}
 
 {% block experiments %}
-  {% if switch('experiment-firefox-home-pre-download', ['en']) %}
+  {% if switch('experiment-firefox-home-pre-download', ['en-US', 'en-GB', 'en-CA', 'en-ZA']) %}
     {{ js_bundle('experiment-firefox-home-pre-download') }}
+  {% endif %}
+  {% if switch('experiment-firefox-home-pre-download-locales', ['de', 'fr']) %}
+    {{ js_bundle('experiment-firefox-home-pre-download-locales') }}
   {% endif %}
 {% endblock %}
 

--- a/bedrock/firefox/urls.py
+++ b/bedrock/firefox/urls.py
@@ -33,7 +33,7 @@ urlpatterns = (
         VariationTemplateView.as_view(template_name='firefox/home.html',
                                       template_context_variations=['a', 'b', 'c'],
                                       template_name_variations=['a', 'b', 'c'],
-                                      variation_locales=['en']),
+                                      variation_locales=['en-US', 'en-GB', 'en-CA', 'en-ZA', 'de', 'fr']),
         name='firefox'),
     url(r'^firefox/(?:%s/)?(?:%s/)?all/$' % (platform_re, channel_re),
         views.all_downloads, name='firefox.all'),

--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -593,12 +593,13 @@ def download_thanks(request):
     locale = l10n_utils.get_locale(request)
     variant = request.GET.get('v', None)
     show_newsletter = locale in ['en-US', 'en-GB', 'en-CA', 'en-ZA', 'es-ES', 'es-AR', 'es-CL', 'es-MX', 'pt-BR', 'fr', 'ru', 'id', 'de', 'pl']
+    pre_download_locales = ['en-US', 'en-GB', 'en-CA', 'en-ZA', 'de', 'fr']
 
     # ensure variant matches pre-defined value
     if variant not in ['a', 'x', 'y']:  # place expected ?v= values in this list
         variant = None
 
-    if variant == 'a' and locale.startswith('en'):
+    if variant == 'a' and locale in pre_download_locales:
         show_newsletter = False  # Prevent showing the newsletter for pre-download experiment Issue #6456
     if variant == 'x' and locale == 'en-US':
         show_newsletter = False  # Prevent showing the newsletter for FxA account experiment mozilla/bedrock#5974

--- a/bedrock/privacy/templates/privacy/email.de.html
+++ b/bedrock/privacy/templates/privacy/email.de.html
@@ -1,0 +1,37 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. #}
+
+{% extends "base-protocol.html" %}
+
+{% block page_title %}Wie verwendet Mozilla meine E-Mail-Adresse?{% endblock %}
+
+{% block page_css %}
+  {{ css_bundle('privacy_email') }}
+{% endblock %}
+
+{% block page_class %}privacy-email{% endblock %}
+
+{% block content %}
+<div class="mzp-l-content article-wrapper">
+  <main class="mzp-c-article">
+    <h1 class="mzp-c-article-title">{{ self.page_title() }}</h1>
+
+    <p class="mzp-c-article-intro">
+      Mozilla ist der Schutz Ihrer E-Mail-Privatsphäre und -Sicherheit nicht nur wichtig – sie sind Teil unseres <a href="{{ url('mozorg.about.manifesto') }}">Manifests</a>:„ Individuelle Sicherheit und Datenschutz im Internet sind von grundlegender Bedeutung und dürfen nicht als optional betrachtet werden.“ <a href="{{ url('privacy.principles') }}">Hier können Sie mehr über unsere Prinzipien zur Datensicherheit erfahren</a>.
+    </p>
+
+    <p><strong>Was Sie wissen sollten:</strong></p>
+
+    <ul class="prose mzp-u-list-styled">
+      <li>Sie müssen Ihre E-Mail-Adresse nicht angeben, um Firefox herunterzuladen und zu verwenden.</li>
+      <li>Wir fragen nach Ihrer E-Mail-Adresse, weil unsere Forschung zeigt, dass Menschen, die eine Einführung erhalten, mehr und besser mit Firefox arbeiten.</li>
+      <li>Sie können E-Mails erwarten, mit deren Hilfe Sie besser mit Firefox arbeiten können, mehr über Datenschutz und Sicherheit erfahren und herausfinden, wie Sie Ihre Zeit im Internet am besten nutzen können.</li>
+      <li>Sie können den Newsletter jederzeit aus beliebigen Gründen abbestellen.</li>
+      <li>Wir werden Ihre E-Mail-Adresse nicht weitergeben, verkaufen oder zu anderen Zwecken nutzen.</li>
+    </ul>
+  </main>
+
+</div>
+{% endblock %}
+

--- a/bedrock/privacy/templates/privacy/email.fr.html
+++ b/bedrock/privacy/templates/privacy/email.fr.html
@@ -1,0 +1,35 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. #}
+
+{% extends "base-protocol.html" %}
+
+{% block page_title %}Comment mon adresse sera-t-elle utilisée par Mozilla ?{% endblock %}
+
+{% block page_css %}
+  {{ css_bundle('privacy_email') }}
+{% endblock %}
+
+{% block page_class %}privacy-email{% endblock %}
+
+{% block content %}
+<div class="mzp-l-content article-wrapper">
+  <main class="mzp-c-article">
+    <h1 class="mzp-c-article-title">{{ self.page_title() }}</h1>
+
+    <p class="mzp-c-article-intro">
+      Mozilla n’accorde pas seulement de l’importance à la confidentialité et à la sécurité de votre adresse électronique — cela fait partie de notre <a href="{{ url('mozorg.about.manifesto') }}"></a>Manifeste</a> : « La sécurité et la vie privée de chacun sur Internet sont fondamentales et ne doivent pas être facultatives. » <a href="{{ url('privacy.principles') }}"></a>Apprenez-en davantage sur nos principes de confidentialité des données</a>. 
+    </p>
+
+    <p><strong>Ce que vous devez savoir :</strong></p>
+
+    <ul class="prose mzp-u-list-styled">
+      <li>Il n’est pas nécessaire de nous donner votre adresse pour télécharger et utiliser Firefox.</li>
+      <li>Nous vous avons demandé votre adresse parce que nos recherches montrent que les personnes auxquelles nous présentons une introduction arrivent à faire plus de choses avec Firefox.</li>
+      <li>Vous recevrez des courriels destinés à vous aider à optimiser le fonctionnement de Firefox pour votre utilisation personnelle, des informations sur la vie privée et la sécurité et sur la manière de profiter à fond de votre temps passé sur le Web.</li>
+      <li>Vous pouvez vous désinscrire à tout moment, quelle qu’en soit la raison.</li>
+      <li>Nous ne partagerons, ne vendrons ni n’utiliserons votre adresse pour aucun autre usage.</li>
+    </ul>
+  </main>
+</div>
+{% endblock %}

--- a/bedrock/privacy/urls.py
+++ b/bedrock/privacy/urls.py
@@ -12,7 +12,7 @@ urlpatterns = (
     url(r'^/$', views.privacy, name='privacy'),
     page('/principles', 'privacy/principles.html'),
     page('/faq', 'privacy/faq.html'),
-    page('/email', 'privacy/email.html'),
+    page('/email', 'privacy/email.html', active_locales=['en-US', 'de', 'fr']),
     url(r'^/firefox/$', views.firefox_notices, name='privacy.notices.firefox'),
     url(r'^/firefox-os/$', views.firefox_os_notices, name='privacy.notices.firefox-os'),
     url(r'^/firefox-fire-tv/$', views.firefox_fire_tv_notices, name='privacy.notices.firefox-fire-tv'),

--- a/media/js/firefox/home/experiment-pre-download-locales.js
+++ b/media/js/firefox/home/experiment-pre-download-locales.js
@@ -1,0 +1,74 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+(function(Mozilla) {
+    'use strict';
+
+    function removeParams() {
+        window.history.replaceState({}, document.title, window.location.href.split('?')[0]);
+    }
+
+    function getUrlParam(name) {
+        name = name.replace(/[\[]/, '\\[').replace(/[\]]/, '\\]');
+        var regex = new RegExp('[\\?&]' + name + '=([^&#]*)');
+        var results = regex.exec(location.search);
+        return results === null ? '' : decodeURIComponent(results[1].replace(/\+/g, ' '));
+    }
+
+    // Check that cookies are supported.
+    if (typeof Mozilla.Cookies === 'undefined' || !Mozilla.Cookies.enabled()) {
+        return;
+    }
+
+    // Test criteria is Windows on desktop only.
+    if (window.site.platform !== 'windows') {
+        return;
+    }
+
+    // Exclude existing Firefox users.
+    if (/\s(Firefox)/.test(navigator.userAgent)) {
+        return;
+    }
+
+    // Check that history API is supported.
+    if (!window.history && !window.history.replaceState) {
+        return;
+    }
+
+    var source = getUrlParam('utm_source');
+    var medium = getUrlParam('utm_medium');
+    var campaign = getUrlParam('utm_campaign');
+
+    var params = {
+        utmSource: source ? source : 'www.mozilla.org',
+        utmMedium: medium ? medium : 'download_button',
+        utmCampaign: campaign ? campaign : 'firefox_page',
+        utmContent: 'downloader_email_form_experiment_'
+    };
+
+    var stringA = 'v=a&utm_source=' + params.utmSource + '&utm_medium=' + params.utmMedium + '&utm_campaign=' + params.utmCampaign + '&utm_content=' + params.utmContent + 'va';
+    var stringB = 'v=b&utm_source=' + params.utmSource + '&utm_medium=' + params.utmMedium + '&utm_campaign=' + params.utmCampaign + '&utm_content=' + params.utmContent + 'vb';
+    var stringC = 'v=c&utm_source=' + params.utmSource + '&utm_medium=' + params.utmMedium + '&utm_campaign=' + params.utmCampaign + '&utm_content=' + params.utmContent + 'vc';
+
+    var queries = {};
+
+    queries[stringA] = 8;
+    queries[stringB] = 8;
+    queries[stringC] = 8;
+
+    // remove existing params as we're amending our own and passing to Traffic Cop.
+    removeParams();
+
+    // Remove existing stub attribution data before Traffic Cop redirect.
+    Mozilla.Cookies.removeItem('moz-stub-attribution-code', '/');
+    Mozilla.Cookies.removeItem('moz-stub-attribution-sig', '/');
+
+    var cop = new Mozilla.TrafficCop({
+        id: 'exp-firefox-home-pre-download-rerun-locales',
+        variations: queries
+    });
+
+    cop.init();
+
+})(window.Mozilla);

--- a/media/js/firefox/home/experiment-pre-download-locales.js
+++ b/media/js/firefox/home/experiment-pre-download-locales.js
@@ -40,6 +40,8 @@
     var medium = getUrlParam('utm_medium');
     var campaign = getUrlParam('utm_campaign');
 
+    var locale = document.getElementsByTagName('html')[0].getAttribute('lang') || '';
+
     var params = {
         utmSource: source ? source : 'www.mozilla.org',
         utmMedium: medium ? medium : 'download_button',
@@ -47,9 +49,9 @@
         utmContent: 'downloader_email_form_experiment_'
     };
 
-    var stringA = 'v=a&utm_source=' + params.utmSource + '&utm_medium=' + params.utmMedium + '&utm_campaign=' + params.utmCampaign + '&utm_content=' + params.utmContent + 'va';
-    var stringB = 'v=b&utm_source=' + params.utmSource + '&utm_medium=' + params.utmMedium + '&utm_campaign=' + params.utmCampaign + '&utm_content=' + params.utmContent + 'vb';
-    var stringC = 'v=c&utm_source=' + params.utmSource + '&utm_medium=' + params.utmMedium + '&utm_campaign=' + params.utmCampaign + '&utm_content=' + params.utmContent + 'vc';
+    var stringA = 'v=a&utm_source=' + params.utmSource + '&utm_medium=' + params.utmMedium + '&utm_campaign=' + params.utmCampaign + '&utm_content=' + params.utmContent + 'va_' + locale;
+    var stringB = 'v=b&utm_source=' + params.utmSource + '&utm_medium=' + params.utmMedium + '&utm_campaign=' + params.utmCampaign + '&utm_content=' + params.utmContent + 'vb_' + locale;
+    var stringC = 'v=c&utm_source=' + params.utmSource + '&utm_medium=' + params.utmMedium + '&utm_campaign=' + params.utmCampaign + '&utm_content=' + params.utmContent + 'vc_' + locale;
 
     var queries = {};
 

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -1361,6 +1361,13 @@
     },
     {
       "files": [
+        "js/base/mozilla-traffic-cop.js",
+        "js/firefox/home/experiment-pre-download-locales.js"
+      ],
+      "name": "experiment-firefox-home-pre-download-locales"
+    },
+    {
+      "files": [
         "js/libs/jquery.hoverIntent.min.js",
         "js/libs/jquery.waypoints.min.js",
         "js/libs/jquery.jcarousel.min.js",


### PR DESCRIPTION
## Description
- Enables pre-download experiment on `/firefox/` for `de` and `fr` locales at 25% of traffic.

**Do not merge** until https://www.mozilla.org/en-US/privacy/email/ is localized in French and German.

## Issue / Bugzilla link
#6456

## Testing
Demo URLs:

https://bedrock-demo-agibson.oregon-b.moz.works/fr/firefox/
https://bedrock-demo-agibson.oregon-b.moz.works/de/firefox/

Note: test in a non-Firefox browser on Windows with DNT disabled.