### PR TITLE
Set active locales for FFY campaign page (#6387)

### DIFF
--- a/bedrock/firefox/urls.py
+++ b/bedrock/firefox/urls.py
@@ -53,7 +53,7 @@ urlpatterns = (
     page('firefox/enterprise/signup', 'firefox/enterprise/signup.html'),
     page('firefox/enterprise/signup/thanks', 'firefox/enterprise/signup-thanks.html'),
     page('firefox/facebookcontainer', 'firefox/facebookcontainer/index.html'),
-    page('firefox/fights-for-you', 'firefox/fights-for-you.html'),
+    page('firefox/fights-for-you', 'firefox/fights-for-you.html', active_locales=['en-US', 'de']),
     url(r'^firefox/features/$',
         VariationTemplateView.as_view(template_name='firefox/features/index.html',
             template_context_variations=['a', 'b']),


### PR DESCRIPTION
## Description
- Sets active locales for `/firefox/fights-for-you/` campaign page ([docs link](https://bedrock.readthedocs.io/en/latest/l10n.html#specifying-active-locales-in-views)).

## Issue / Bugzilla link
#6387

## Testing
- With `Dev=False` in your `.env` file, both English and German should be available in the language switcher in the page footer.