### PR TITLE
Remove duplicate analytics event

### DIFF
--- a/bedrock/firefox/templates/firefox/fights-for-you.html
+++ b/bedrock/firefox/templates/firefox/fights-for-you.html
@@ -106,7 +106,7 @@
 
   {% if switch('fffy-survey', ['en-US']) %}
     <div id="fffy-survey-link" class="mzp-l-content">
-        Please help us out by taking this <a href="https://www.surveygizmo.com/s3/4693873/FFFY-Heartbeat-Survey" target="_blank" rel="noopener noreferrer" data-link-type="link" data-link-name="survey">short survey</a>.
+        Please help us out by taking this <a href="https://www.surveygizmo.com/s3/4693873/FFFY-Heartbeat-Survey" target="_blank" rel="noopener noreferrer">short survey</a>.
     </div>
   {% endif %}
 </div>


### PR DESCRIPTION
## Description

There is a JS on click event for the survey interactions and the survey link is marked up to cause an event. We only need one event for the link click so I'm removing the event on the link, leaving the event which is attached to the banner.

## Issue / Bugzilla link
https://github.com/mozilla/bedrock/issues/6387

## Testing
Link still works? You can test in Chrome with the Analytics Pros tool too if you want.