### PR TITLE
Raise z-index of close button

### DIFF
--- a/media/css/mozorg/home/fundraiser2018.scss
+++ b/media/css/mozorg/home/fundraiser2018.scss
@@ -112,6 +112,7 @@ $image-path: '/media/protocol/img';
     position: absolute;
     top: $spacing-sm;
     width: 42px;
+    z-index: 1;
 
     &:hover,
     &:focus {


### PR DESCRIPTION
## Description
Close button wasn't working because it was being obscured by elements over top of it.

## Issue / Bugzilla link
https://github.com/mozilla/bedrock/issues/6525

## Testing
Can you close the banner? Does it conflict with the z-index of anything else on the page?