### PR TITLE
[fix bug 1506402] Update Participation Guidelines, add reporting

### DIFF
--- a/bedrock/mozorg/templates/mozorg/about/governance/policies/participation.html
+++ b/bedrock/mozorg/templates/mozorg/about/governance/policies/participation.html
@@ -121,7 +121,7 @@
     <a href="{{ mailto_inclusion }}">inclusion@mozilla.com</a>. While these
     guidelines / code of conduct are specifically aimed at Mozilla’s work and
     community, we recognize that it is possible for actions taken outside of
-    Mozilla’s online or inperson spaces  to have a deep impact on community
+    Mozilla’s online or inperson spaces to have a deep impact on community
     health. (For example, in the past, we publicly identified an anonymous
     posting aimed at a Mozilla employee in a non-Mozilla forum as clear grounds
     for removal from the Mozilla community.) This is an active topic in the

--- a/bedrock/mozorg/templates/mozorg/about/governance/policies/participation.html
+++ b/bedrock/mozorg/templates/mozorg/about/governance/policies/participation.html
@@ -10,7 +10,11 @@
 
 {% block article %}
 <h1><span class="highlight">{{ _('Mozilla Community Participation Guidelines') }}</span></h1>
-<h4>{{ _('Version 2.3 – Updated May 16, 2017') }}</h4>
+{% if l10n_has_tag('participation_nov2018') %}
+  <h4>{{ _('Version 3.0 – Updated November 28, 2018') }}</h4>
+{% else %}
+  <h4>{{ _('Version 2.3 – Updated May 16, 2017') }}</h4>
+{% endif %}
 
 <section id="introduction">
   <p>
@@ -95,6 +99,20 @@
   {% endtrans %}
   </p>
 
+{% if l10n_has_tag('participation_nov2018') %}
+  <p>
+  {% trans %}
+    While these guidelines / code of conduct are specifically aimed at Mozilla’s
+    work and community, we recognize that it is possible for actions taken outside
+    of Mozilla’s online or inperson spaces  to have a deep impact on community
+    health. (For example, in the past, we publicly identified an anonymous
+    posting aimed at a Mozilla employee in a non-Mozilla forum as clear grounds
+    for removal from the Mozilla community.) This is an active topic in the
+    diversity and inclusion realm. We anticipate wide-ranging discussions
+    among our communities about appropriate boundaries.
+  {% endtrans %}
+  </p>
+{% else %}
   <p>
   {% trans mailto_inclusion='mailto:inclusion@mozilla.com' %}
     If you experience behavior outside of Mozilla communities, in person
@@ -111,6 +129,7 @@
     among our communities about appropriate boundaries.
   {% endtrans %}
   </p>
+{% endif %}
 </section>
 
 <section id="expected-behavior">
@@ -399,6 +418,34 @@
 
 <section id="reporting">
   <h2>{{ _('Reporting') }}</h2>
+
+{% if l10n_has_tag('participation_nov2018') %}
+  <p>
+  {% trans hotline='https://communityparticipationhotline.splashthat.com/' %}
+    If you believe you’re experiencing unacceptable behavior that will
+    not be tolerated as outlined above, <a href="{{ hotline }}">please use our hotline to report</a>.
+    Reports go directly to Mozilla’s Employment Counsel and HR People
+    Partners and are triaged by the Community Participation Guidelines
+    Response Lead.
+  {% endtrans %}
+  </p>
+
+  <p>
+  {% trans %}
+    After receiving a concise description of your situation, they will
+    review and determine next steps. In addition to conducting any
+    investigation, they can provide a range of resources, from a private
+    consultation to other community resources. They will involve other
+    colleagues or outside specialists (such as legal counsel), as needed
+    to appropriately address each situation.
+  {% endtrans %}
+  </p>
+
+  <ul class="prose">
+    <li>{{ _('Additional Resources: <a href="%s">How to Report</a>')|format(url('mozorg.about.governance.policies.reporting')) }}</li>
+    <li>{{ _('Questions: <a href="%s">inclusion@mozilla.com</a>')|format('mailto:inclusion@mozilla.com') }}</li>
+  </ul>
+{% else %}
   <p>
   {% trans mailto_inclusion='mailto:inclusion@mozilla.com',
       di_leader='Larissa Shapiro',
@@ -417,6 +464,7 @@
     appropriately address each situation.
   {% endtrans %}
   </p>
+{% endif %}
 
   <p>
   {% trans %}
@@ -430,13 +478,6 @@
   {% trans %}
     If you feel you have been unfairly accused of violating these guidelines,
     please follow the same reporting process.
-  {% endtrans %}
-  </p>
-
-  <h3>{{ _('Who to Contact') }}</h3>
-  <p>
-  {% trans mailto_inclusion='mailto:inclusion@mozilla.com' %}
-    <a href="{{ mailto_inclusion }}">inclusion@mozilla.com</a>
   {% endtrans %}
   </p>
 

--- a/bedrock/mozorg/templates/mozorg/about/governance/policies/reporting.html
+++ b/bedrock/mozorg/templates/mozorg/about/governance/policies/reporting.html
@@ -74,44 +74,46 @@
   {% endtrans %}
   </p>
 
-  <table class="data-table reporting-matrix">
-    <thead>
-      <tr>
-        <td colspan="2"></td>
-        <th scope="col" colspan="2" class="group-header">{{ _('By') }}</th>
-      </tr>
-      <tr>
-        <td colspan="2"></td>
-        <th scope="col">{{ _('Employee') }}</th>
-        <th scope="col">{{ _('Contributor') }}</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <th rowspan="5" class="group-header">{{ _('About') }}</th>
-      </tr>
-      <tr>
-        <th scope="row">{{ _('Employee') }}</th>
-        <td><a href="https://app.convercent.com/en-us/LandingPage/4a6ee0c0-5bc1-e611-80d5-000d3ab1117e">{{ _('Employee Hotline') }}</a></td>
-        <td><a href="https://app.convercent.com/en-us/LandingPage/4a6ee0c0-5bc1-e611-80d5-000d3ab1117e">{{ _('Employee Hotline') }}</a></td>
-      </tr>
-      <tr>
-        <th scope="row">{{ _('Contributor') }}</th>
-        <td><a href="https://app.convercent.com/en-us/LandingPage/4a6ee0c0-5bc1-e611-80d5-000d3ab1117e">{{ _('Employee Hotline') }}</a></td>
-        <td><a href="https://events.mozilla.org/communityparticipationhotline">{{ _('Community Hotline') }}</a></td>
-      </tr>
-      <tr>
-        <th scope="row">{{ _('Contractor') }}</th>
-        <td><a href="https://app.convercent.com/en-us/LandingPage/4a6ee0c0-5bc1-e611-80d5-000d3ab1117e">{{ _('Employee Hotline') }}</a></td>
-        <td><a href="https://events.mozilla.org/communityparticipationhotline">{{ _('Community Hotline') }}</a></td>
-      </tr>
-      <tr>
-        <th scope="row">{{ _('Vendor') }}</th>
-        <td><a href="https://app.convercent.com/en-us/LandingPage/4a6ee0c0-5bc1-e611-80d5-000d3ab1117e">{{ _('Employee Hotline') }}</a></td>
-        <td><a href="https://events.mozilla.org/communityparticipationhotline">{{ _('Community Hotline') }}</a></td>
-      </tr>
-    </tbody>
-  </table>
+  <div class="reporting-matrix-container">
+    <table class="data-table reporting-matrix">
+      <thead>
+        <tr>
+          <td colspan="2"></td>
+          <th scope="col" colspan="2" class="group-header">{{ _('By') }}</th>
+        </tr>
+        <tr>
+          <td colspan="2"></td>
+          <th scope="col">{{ _('Employee') }}</th>
+          <th scope="col">{{ _('Contributor') }}</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <th rowspan="5" class="group-header">{{ _('About') }}</th>
+        </tr>
+        <tr>
+          <th scope="row">{{ _('Employee') }}</th>
+          <td><a href="https://app.convercent.com/en-us/LandingPage/4a6ee0c0-5bc1-e611-80d5-000d3ab1117e">{{ _('Employee Hotline') }}</a></td>
+          <td><a href="https://app.convercent.com/en-us/LandingPage/4a6ee0c0-5bc1-e611-80d5-000d3ab1117e">{{ _('Employee Hotline') }}</a></td>
+        </tr>
+        <tr>
+          <th scope="row">{{ _('Contributor') }}</th>
+          <td><a href="https://app.convercent.com/en-us/LandingPage/4a6ee0c0-5bc1-e611-80d5-000d3ab1117e">{{ _('Employee Hotline') }}</a></td>
+          <td><a href="https://events.mozilla.org/communityparticipationhotline">{{ _('Community Hotline') }}</a></td>
+        </tr>
+        <tr>
+          <th scope="row">{{ _('Contractor') }}</th>
+          <td><a href="https://app.convercent.com/en-us/LandingPage/4a6ee0c0-5bc1-e611-80d5-000d3ab1117e">{{ _('Employee Hotline') }}</a></td>
+          <td><a href="https://events.mozilla.org/communityparticipationhotline">{{ _('Community Hotline') }}</a></td>
+        </tr>
+        <tr>
+          <th scope="row">{{ _('Vendor') }}</th>
+          <td><a href="https://app.convercent.com/en-us/LandingPage/4a6ee0c0-5bc1-e611-80d5-000d3ab1117e">{{ _('Employee Hotline') }}</a></td>
+          <td><a href="https://events.mozilla.org/communityparticipationhotline">{{ _('Community Hotline') }}</a></td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
 
   <h3>{{ _('If someone reports to you…') }}</h3>
 

--- a/bedrock/mozorg/templates/mozorg/about/governance/policies/reporting.html
+++ b/bedrock/mozorg/templates/mozorg/about/governance/policies/reporting.html
@@ -1,0 +1,194 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+
+{% extends "mozorg/about-base.html" %}
+
+{% block page_title %}{{ _('Community Participation Guidelines - How to Report') }}{% endblock %}
+{% set body_id = "participation-reporting" %}
+
+{% block page_css %}
+  {{ css_bundle('participation-reporting') }}
+{% endblock %}
+
+{% block article %}
+  <h1><span class="highlight">{{ _('How to Report Violations of the Community Participation Guidelines') }}</span></h1>
+
+  <p>
+  {% trans %}
+    This document provides high-level information, for understanding and reporting violations of Mozilla's Community Participation Guidelines.
+  {% endtrans %}
+  </p>
+
+  <p>
+  {% trans cpg=url('mozorg.about.governance.policies.participation') %}
+    From the <a href="{{ cpg }}">Community Participation Guidelines</a>:
+  {% endtrans %}
+  </p>
+
+  <blockquote cite="{{ url('mozorg.about.governance.policies.participation') }}">
+    <p>
+    {% trans %}
+      The heart of Mozilla is people. We put people first and do our best to recognize, appreciate and respect the diversity of our global contributors. The Mozilla Project welcomes contributions from everyone who shares our goals and wants to contribute in a healthy and constructive manner within our community. As such, we have adopted this code of conduct and require all those who participate to agree and adhere to these Community Participation Guidelines in order to help us create a safe and positive community experience for all.
+    {% endtrans %}
+    </p>
+  </blockquote>
+
+  <p>
+  {% trans %}
+    This document is intended as an interface to existing documents, processes and people responsible for ensuring Mozilla’s communities are healthy, and inclusive for all.
+  {% endtrans %}
+  </p>
+
+  <h2>{{ _('When To Report') }}</h2>
+
+  <p>
+  {% trans cpg=url('mozorg.about.governance.policies.participation') %}
+    Please report all incidents where someone has engaged in behavior that is potentially illegal or makes you or someone else feel unsafe, unwelcome or uncomfortable <a href="{{ cpg }}">as further explained in the CPG</a>.
+  {% endtrans %}
+  </p>
+
+  <h2>{{ _('How to Give a Report') }}</h2>
+
+  <p>
+  {% trans %}
+    If you believe someone is in physical danger call your local emergency number.
+  {% endtrans %}
+  </p>
+
+  <p>
+  {% trans community_hotline='https://events.mozilla.org/communityparticipationhotline' %}
+    If you have a report <strong>by <em>and</em> about</strong> a contributor (for example, the report is made <strong>by</strong> one contributor <strong>about</strong> another contributor), then you should make your report at the <a href="{{ community_hotline }}">Community Participation Guidelines hotline</a>.
+  {% endtrans %}
+  </p>
+
+  <p>
+  {% trans employee_hotline='https://app.convercent.com/en-us/LandingPage/4a6ee0c0-5bc1-e611-80d5-000d3ab1117e' %}
+    If you have a report <strong>involving an employee, contractor, or vendor</strong> (for example, the report is made <strong>by</strong> an employee or is <strong>about</strong> an employee) then you should report at the <a href="{{ employee_hotline }}">Mozilla Employee hotline</a>.
+  {% endtrans %}
+  </p>
+
+  <p>
+  {% trans %}
+    Put another way…
+  {% endtrans %}
+  </p>
+
+  <table class="data-table reporting-matrix">
+    <thead>
+      <tr>
+        <td colspan="2"></td>
+        <th scope="col" colspan="2" class="group-header">{{ _('By') }}</th>
+      </tr>
+      <tr>
+        <td colspan="2"></td>
+        <th scope="col">{{ _('Employee') }}</th>
+        <th scope="col">{{ _('Contributor') }}</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <th rowspan="5" class="group-header">{{ _('About') }}</th>
+      </tr>
+      <tr>
+        <th scope="row">{{ _('Employee') }}</th>
+        <td><a href="https://app.convercent.com/en-us/LandingPage/4a6ee0c0-5bc1-e611-80d5-000d3ab1117e">{{ _('Employee Hotline') }}</a></td>
+        <td><a href="https://app.convercent.com/en-us/LandingPage/4a6ee0c0-5bc1-e611-80d5-000d3ab1117e">{{ _('Employee Hotline') }}</a></td>
+      </tr>
+      <tr>
+        <th scope="row">{{ _('Contributor') }}</th>
+        <td><a href="https://app.convercent.com/en-us/LandingPage/4a6ee0c0-5bc1-e611-80d5-000d3ab1117e">{{ _('Employee Hotline') }}</a></td>
+        <td><a href="https://events.mozilla.org/communityparticipationhotline">{{ _('Community Hotline') }}</a></td>
+      </tr>
+      <tr>
+        <th scope="row">{{ _('Contractor') }}</th>
+        <td><a href="https://app.convercent.com/en-us/LandingPage/4a6ee0c0-5bc1-e611-80d5-000d3ab1117e">{{ _('Employee Hotline') }}</a></td>
+        <td><a href="https://events.mozilla.org/communityparticipationhotline">{{ _('Community Hotline') }}</a></td>
+      </tr>
+      <tr>
+        <th scope="row">{{ _('Vendor') }}</th>
+        <td><a href="https://app.convercent.com/en-us/LandingPage/4a6ee0c0-5bc1-e611-80d5-000d3ab1117e">{{ _('Employee Hotline') }}</a></td>
+        <td><a href="https://events.mozilla.org/communityparticipationhotline">{{ _('Community Hotline') }}</a></td>
+      </tr>
+    </tbody>
+  </table>
+
+  <h3>{{ _('If someone reports to you…') }}</h3>
+
+  <ul class="prose">
+    <li>{{ _('Do not question, or judge their experience.') }}</li>
+    <li>{{ _('Do not invite them to withdraw the incident report.') }}</li>
+    <li>{{ _('Do not promise any particular response.') }}</li>
+    <li>{{ _('<strong>Do</strong> let them know that for Mozilla’s policy to be impactful, reports should go through the hotline. If they do not feel comfortable filing the report themselves, you may do so.') }}</li>
+  </ul>
+
+  <p>
+  {% trans %}
+    No matter who files the report, the information below is important to capture.
+  {% endtrans %}
+  </p>
+
+  <ul class="prose">
+    <li>{{ _('Names of the people involved (or if names are unknown, use descriptions and any identifiable info such as appearance, role, handle, project/community affiliation).') }}</li>
+    <li>{{ _('Description of incident, including memorable dates (or event) and locations.') }}</li>
+    <li>{{ _('If the reporter wants to make an anonymous report, please inform them that this contact information we may not be able to update the initial reporter if appropriate. Some laws prohibit anonymous reporting and that you may be required to provide their name if you are a Mozilla Manager or Community Leader.') }}</li>
+    <li>{{ _('Relationship of reporter/victim.') }}</li>
+  </ul>
+
+  <h3>{{ _('Mozilla Managers and Community leaders') }}</h3>
+
+  <p>
+  {% trans cpg=url('mozorg.about.governance.policies.participation') %}
+    If a Mozilla Manager or Community leaders is informed about potential <a href="{{ cpg }}">CPG</a> violations they are expected to immediately report the incident through the applicable hotline, even if the initial reporter will also file a report. Mozilla Managers and Community leaders are not permitted to investigate complaints on their own.
+  {% endtrans %}
+  </p>
+
+  <p><strong>{{ _('Do not impose your own judgement on how the reporter should react. Focus on listening.') }}</strong></p>
+
+  <h2>{{ _('What happens after the Report is filed') }}</h2>
+
+  <h3>Investigation</h3>
+  <p>
+  {% trans %}
+    Reports are handled discretely and privately, and will only be shared with the people who can investigate, respond, and advise. As part of this investigation, it may be necessary for some information to be disclosed to others, for example to key stakeholders administering communities or events, witnesses, and the wrongdoer.
+  {% endtrans %}
+  </p>
+
+  <h3>{{ _('Correspondence') }}</h3>
+  <p>
+  {% trans %}
+    All reports are reviewed and responded to based on the nature of the report and we try to provide reasonably timed updates as part of open investigations.
+  {% endtrans %}
+  </p>
+
+
+  <h3>{{ _('Redress') }}</h3>
+  <p>
+  {% trans %}
+    When an investigation is complete, to the extent the wrongdoer is subject to Mozilla’s control, appropriate measures will be taken to address the situation.
+  {% endtrans %}
+  </p>
+
+  <h3>{{ _('No Retaliation') }}</h3>
+  <p>
+  {% trans %}
+    Mozilla does not tolerate retaliation against Mozillians who report concerns under the CPG in good faith. Acts of retaliation should be reported in the same process as described above.
+  {% endtrans %}
+  </p>
+
+
+  <h2>{{ _('License') }}</h2>
+
+  <p>
+  {% trans pycon='https://us.pycon.org/2018/about/code-of-conduct/' %}
+    This document includes content forked from the <a href="{{ pycon }}">PyCon Code of Conduct Revision 2f4d980</a> which is licensed under a Creative Commons Attribution 3.0 Unported License.
+  {% endtrans %}
+  </p>
+
+  <p>
+  {% trans license='https://creativecommons.org/licenses/by/3.0/' %}
+    This document is licensed under a <a href="{{ license }}">Creative Commons Attribution 3.0 Unported License</a>.
+  {% endtrans %}
+  </p>
+
+{% endblock %}

--- a/bedrock/mozorg/urls.py
+++ b/bedrock/mozorg/urls.py
@@ -62,6 +62,8 @@ urlpatterns = (
     page('about/governance/organizations', 'mozorg/about/governance/organizations.html'),
     page('about/governance/policies/participation',
          'mozorg/about/governance/policies/participation.html'),
+    page('about/governance/policies/participation/reporting',
+         'mozorg/about/governance/policies/reporting.html'),
     page('about/governance/policies/module-ownership',
          'mozorg/about/governance/policies/module-ownership.html'),
     page('about/governance/policies/regressions',

--- a/media/css/mozorg/participation-reporting.scss
+++ b/media/css/mozorg/participation-reporting.scss
@@ -1,0 +1,33 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+@import '../pebbles/includes/lib';
+
+.reporting-matrix {
+    width: 100%;
+
+    .group-header {
+        background-color: #f3f3f3;
+        padding-top: .5em;
+        text-align: center;
+        vertical-align: middle;
+    }
+
+    thead tr + tr th,
+    thead tr + tr td {
+        padding-top: .5em;
+    }
+}
+
+blockquote {
+    @include font-size-level4;
+    border-left: 3px solid #eee;
+    font-style: italic;
+    margin: 1em auto;
+    padding: 1em 30px;
+
+    & > :last-child {
+        margin-bottom: 0;
+    }
+}

--- a/media/css/mozorg/participation-reporting.scss
+++ b/media/css/mozorg/participation-reporting.scss
@@ -4,6 +4,11 @@
 
 @import '../pebbles/includes/lib';
 
+.reporting-matrix-container {
+    max-width: 100%;
+    overflow: auto;
+}
+
 .reporting-matrix {
     width: 100%;
 

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -148,6 +148,12 @@
     },
     {
       "files": [
+        "css/mozorg/participation-reporting.scss"
+      ],
+      "name": "participation-reporting"
+    },
+    {
+      "files": [
         "css/base/social-widgets.less",
         "css/mozorg/contribute/studentambassadors/landing.less"
       ],


### PR DESCRIPTION
## Description
Updates Participation Guidelines and adds a new reporting page. String changes are behind the l10n tag `participation_nov2018`

## Issue / Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1506402

## Testing
https://bedrock-demo-craigcook.oregon-b.moz.works/en-US/about/governance/policies/participation/
https://bedrock-demo-craigcook.oregon-b.moz.works/en-US/about/governance/policies/participation/reporting/