### PR TITLE
Add en and de videos to FFFY campaign page

### DIFF
--- a/bedrock/firefox/templates/firefox/fights-for-you.de.html
+++ b/bedrock/firefox/templates/firefox/fights-for-you.de.html
@@ -36,7 +36,9 @@
     title='Firefox Fights For You',
     desc='Privatsphäre sollte einfach sein. Daten sicher. Einstellungen eindeutig. Wir kämpfen für ein besseres Internet – mit Produkten, die Dir auch online die Kontrolle über Dein Leben geben.',
     class='mzp-has-image mzp-t-firefox mzp-t-product-firefox mzp-t-dark',
+    include_cta=True
   ) %}
+  <a id="fffy-video-button" href="https://www.youtube.com/watch?v=3NG6dZl9kpA" data-id="3NG6dZl9kpA" class="mzp-c-button mzp-t-secondary mzp-t-dark mzp-t-small" data-link-type="button" data-link-name="Watch video">Video anschauen</a>
   {% endcall %}
 
   <div class="fffy-c-product mzp-l-content">
@@ -104,6 +106,13 @@
       {{ download_firefox(download_location='secondary cta', dom_id='fffy-download-secondary') }}
     </div>
   {% endcall %}
+</div>
+
+<div id="fffy-video-modal" class="mzp-c-card-video-wrapper">
+  <figure class="mzp-c-card-video-content">
+    <div id="fffy-video-container" class="ytcontainer-video">
+    </div>
+  </figure>
 </div>
 
 {% endblock %}

--- a/bedrock/firefox/templates/firefox/fights-for-you.de.html
+++ b/bedrock/firefox/templates/firefox/fights-for-you.de.html
@@ -38,7 +38,7 @@
     class='mzp-has-image mzp-t-firefox mzp-t-product-firefox mzp-t-dark',
     include_cta=True
   ) %}
-  <a id="fffy-video-button" href="https://www.youtube.com/watch?v=3NG6dZl9kpA" data-id="3NG6dZl9kpA" class="mzp-c-button mzp-t-secondary mzp-t-dark mzp-t-small" data-link-type="button" data-link-name="Watch video">Video anschauen</a>
+  <p><a id="fffy-video-button" href="https://www.youtube.com/watch?v=3NG6dZl9kpA" data-id="3NG6dZl9kpA" class="mzp-c-button mzp-t-secondary mzp-t-dark mzp-t-small" data-link-type="button" data-link-name="Watch video">Video anschauen</a></p>
   {% endcall %}
 
   <div class="fffy-c-product mzp-l-content">
@@ -108,11 +108,12 @@
   {% endcall %}
 </div>
 
-<div id="fffy-video-modal" class="mzp-c-card-video-wrapper">
-  <figure class="mzp-c-card-video-content">
-    <div id="fffy-video-container" class="ytcontainer-video">
+<div id="fffy-video-modal" class="mzp-u-modal-content">
+    <div class="ytcontainer-video">
+      <div class="video-container">
+        <div id="fffy-video-player"></div>
+      </div>
     </div>
-  </figure>
 </div>
 
 {% endblock %}

--- a/bedrock/firefox/templates/firefox/fights-for-you.html
+++ b/bedrock/firefox/templates/firefox/fights-for-you.html
@@ -38,7 +38,7 @@
     class='mzp-has-image mzp-t-firefox mzp-t-product-firefox mzp-t-dark',
     include_cta=True
   ) %}
-  <a id="fffy-video-button" href="https://www.youtube.com/watch?v=rZAQ6vgt8nE" data-id="rZAQ6vgt8nE" class="mzp-c-button mzp-t-secondary mzp-t-dark mzp-t-small" data-link-type="button" data-link-name="Watch video">Watch video</a>
+  <p><a id="fffy-video-button" href="https://www.youtube.com/watch?v=rZAQ6vgt8nE" data-id="rZAQ6vgt8nE" class="mzp-c-button mzp-t-secondary mzp-t-dark mzp-t-small" data-link-type="button" data-link-name="Watch video">Watch video</a></p>
   {% endcall %}
 
   <div class="fffy-c-product mzp-l-content">
@@ -113,11 +113,12 @@
   {% endif %}
 </div>
 
-<div id="fffy-video-modal" class="mzp-c-card-video-wrapper">
-  <figure class="mzp-c-card-video-content">
-    <div id="fffy-video-container" class="ytcontainer-video">
+<div id="fffy-video-modal" class="mzp-u-modal-content">
+    <div class="ytcontainer-video">
+      <div class="video-container">
+        <div id="fffy-video-player"></div>
+      </div>
     </div>
-  </figure>
 </div>
 
 {% endblock %}

--- a/bedrock/firefox/templates/firefox/fights-for-you.html
+++ b/bedrock/firefox/templates/firefox/fights-for-you.html
@@ -36,7 +36,9 @@
     title='Firefox Fights For You',
     desc='You have the right to own your life – and your data. Everything we make and do fights for you.',
     class='mzp-has-image mzp-t-firefox mzp-t-product-firefox mzp-t-dark',
+    include_cta=True
   ) %}
+  <a id="fffy-video-button" href="https://www.youtube.com/watch?v=rZAQ6vgt8nE" data-id="rZAQ6vgt8nE" class="mzp-c-button mzp-t-secondary mzp-t-dark mzp-t-small" data-link-type="button" data-link-name="Watch video">Watch video</a>
   {% endcall %}
 
   <div class="fffy-c-product mzp-l-content">
@@ -109,6 +111,13 @@
         Please help us out by taking this <a href="https://www.surveygizmo.com/s3/4693873/FFFY-Heartbeat-Survey" target="_blank" rel="noopener noreferrer" data-link-type="link" data-link-name="survey">short survey</a>.
     </div>
   {% endif %}
+</div>
+
+<div id="fffy-video-modal" class="mzp-c-card-video-wrapper">
+  <figure class="mzp-c-card-video-content">
+    <div id="fffy-video-container" class="ytcontainer-video">
+    </div>
+  </figure>
 </div>
 
 {% endblock %}

--- a/media/css/firefox/fights-for-you.scss
+++ b/media/css/firefox/fights-for-you.scss
@@ -10,6 +10,7 @@ $image-path: '/media/protocol/img';
 @import '../protocol/base/fonts/sharpsans';
 
 @import '../../protocol/css/includes/lib';
+@import '../../protocol/css/components/modal';
 @import '../../protocol/css/components/call-out';
 @import '../../protocol/css/components/feature-card';
 @import '../../protocol/css/components/hero';
@@ -242,5 +243,38 @@ $fffy-pink: #FF2889;
         &:active {
             text-decoration: none;
         }
+    }
+}
+
+
+/* -------------------------------------------------------------------------- */
+// YouTube iframe responsive in modal.
+
+.mzp-c-card-video-wrapper {
+    display: none;
+
+    &.mzp-c-modal-overlay-contents {
+        display: block;
+    }
+}
+
+.ytcontainer-video {
+    max-width: 100%;
+
+    .video-container {
+        height: 0;
+        margin-bottom: $spacing-lg;
+        overflow: hidden;
+        padding-bottom: 56.25%;
+        position: relative;
+        width: 100%;
+    }
+
+    iframe {
+        height: 100%;
+        left: 0;
+        position: absolute;
+        top:0;
+        width: 100%;
     }
 }

--- a/media/css/firefox/fights-for-you.scss
+++ b/media/css/firefox/fights-for-you.scss
@@ -250,12 +250,8 @@ $fffy-pink: #FF2889;
 /* -------------------------------------------------------------------------- */
 // YouTube iframe responsive in modal.
 
-.mzp-c-card-video-wrapper {
+.mzp-u-modal-content {
     display: none;
-
-    &.mzp-c-modal-overlay-contents {
-        display: block;
-    }
 }
 
 .ytcontainer-video {

--- a/media/js/firefox/fights-for-you.js
+++ b/media/js/firefox/fights-for-you.js
@@ -31,4 +31,92 @@
             });
         }, false);
     }
+
 })();
+
+(function() {
+    'use strict';
+
+    /* global YT */
+    /* eslint no-unused-vars: [2, { "varsIgnorePattern": "onYouTubeIframeAPIReady" }] */
+
+    var content = document.getElementById('fffy-video-modal');
+    var button = document.getElementById('fffy-video-button');
+    var container = document.getElementById('fffy-video-container');
+    var tag = document.createElement('script');
+    tag.src = 'https://www.youtube.com/iframe_api';
+    var firstScriptTag = document.getElementsByTagName('script')[0];
+    firstScriptTag.parentNode.insertBefore(tag, firstScriptTag);
+
+    function onYouTubeIframeAPIReady() {
+        // lazy load video when visitor clicks the button
+        var videoId = button.getAttribute('data-id');
+
+        button.setAttribute('role', 'button');
+
+        button.addEventListener('click', function(e) {
+            e.preventDefault();
+
+            var player = new YT.Player(container, {
+                height: '703',
+                width: '1250',
+                videoId: videoId,
+                playerVars: {
+                    modestbranding: 1, // hide YouTube logo.
+                    rel: 0, // do not show related videos on end.
+                },
+                events: {
+                    'onReady': onPlayerReady,
+                    'onStateChange': onPlayerStateChange
+                }
+            });
+
+            Mzp.Modal.createModal(e.target, content, {
+                title: 'Firefox Fights For You',
+                className: 'mzp-has-media',
+                closeText: 'Close modal',
+                onDestroy: function() {
+                    player.destroy();
+                }
+            });
+
+            function onPlayerReady(event) {
+                event.target.playVideo();
+            }
+
+            function onPlayerStateChange(event) {
+                var state;
+
+                switch(event.data) {
+                case YT.PlayerState.PLAYING:
+                    state = 'video play';
+                    break;
+                case YT.PlayerState.PAUSED:
+                    state = 'video paused';
+                    break;
+                case YT.PlayerState.ENDED:
+                    state = 'video complete';
+                    Mzp.Modal.closeModal();
+                    break;
+                }
+
+                if (state) {
+                    window.dataLayer.push({
+                        'event': 'video-interaction',
+                        'videoTitle': 'Firefox Fights For You',
+                        'interaction': state
+                    });
+                }
+            }
+        });
+    }
+
+    Mozilla.firstRunOnYouTubeIframeAPIReady = onYouTubeIframeAPIReady;
+})();
+
+// YouTube API hook has to be in global scope
+function onYouTubeIframeAPIReady() {
+    'use strict';
+
+    Mozilla.firstRunOnYouTubeIframeAPIReady();
+}

--- a/media/js/firefox/fights-for-you.js
+++ b/media/js/firefox/fights-for-you.js
@@ -42,7 +42,7 @@
 
     var content = document.getElementById('fffy-video-modal');
     var button = document.getElementById('fffy-video-button');
-    var container = document.getElementById('fffy-video-container');
+    var player = document.getElementById('fffy-video-player');
     var tag = document.createElement('script');
     tag.src = 'https://www.youtube.com/iframe_api';
     var firstScriptTag = document.getElementsByTagName('script')[0];
@@ -57,7 +57,7 @@
         button.addEventListener('click', function(e) {
             e.preventDefault();
 
-            var player = new YT.Player(container, {
+            var ytPlayer = new YT.Player(player, {
                 height: '703',
                 width: '1250',
                 videoId: videoId,
@@ -76,7 +76,7 @@
                 className: 'mzp-has-media',
                 closeText: 'Close modal',
                 onDestroy: function() {
-                    player.destroy();
+                    ytPlayer.destroy();
                 }
             });
 
@@ -111,12 +111,12 @@
         });
     }
 
-    Mozilla.firstRunOnYouTubeIframeAPIReady = onYouTubeIframeAPIReady;
+    Mozilla.fffyOnYouTubeIframeAPIReady = onYouTubeIframeAPIReady;
 })();
 
 // YouTube API hook has to be in global scope
 function onYouTubeIframeAPIReady() {
     'use strict';
 
-    Mozilla.firstRunOnYouTubeIframeAPIReady();
+    Mozilla.fffyOnYouTubeIframeAPIReady();
 }

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -973,6 +973,7 @@
     },
     {
       "files": [
+        "protocol/js/protocol-modal.js",
         "js/firefox/fights-for-you.js"
       ],
       "name": "fights-for-you"


### PR DESCRIPTION
## Description
Add en and de videos to FFFY campaign page

## Issue / Bugzilla link
Closes mozilla/bedrock#6387

## Testing
I'm not very confident with this one, please give it a good look.
- Videos open and play when button is pressed
- Videos do not play if button not pressed or if closed button pressed
- Video and associated container does not display on the page until the button is pressed
- https://bedrock-demo-shobson.oregon-b.moz.works/en-US/firefox/fights-for-you/
- https://bedrock-demo-shobson.oregon-b.moz.works/de/firefox/fights-for-you/