### PR TITLE
Fix /about/ page URL regex (Fixes #6539)

### DIFF
--- a/bedrock/mozorg/urls.py
+++ b/bedrock/mozorg/urls.py
@@ -11,7 +11,7 @@ from bedrock.redirects.util import redirect
 
 urlpatterns = (
     url(r'^$', views.home_view, name='mozorg.home'),
-    url(r'about/$', views.about_view, name='mozorg.about'),
+    url(r'^about/$', views.about_view, name='mozorg.about'),
     page('about/manifesto', 'mozorg/about/manifesto.html'),
     page('about/manifesto/details', 'mozorg/about/manifesto-details.html'),
     page('about/leadership', 'mozorg/about/leadership.html'),


### PR DESCRIPTION
## Description
- Fixes regex bug in `/about/` page URL.

## Issue / Bugzilla link
https://github.com/mozilla/bedrock/issues/6539

## Testing
- [ ] URLs like `/en-US/icanwriteherwhateveriwantanditstillgetsmea200/about/`  should now be a 404.
- [ ] `/about/` page should still load as expected.