### PR TITLE
Fix IE SEM comparison page cohort sizes (#6466)

### DIFF
--- a/bedrock/firefox/templates/firefox/new/compare/scene1-ie-2.html
+++ b/bedrock/firefox/templates/firefox/new/compare/scene1-ie-2.html
@@ -6,12 +6,6 @@
 
 {% extends "firefox/new/compare/base-1.html" %}
 
-{% block experiments %}
-  {% if switch('firefox_new_compare_ie_experiment', ['en-US']) %}
-    {{ js_bundle('firefox_new_compare_ie_experiment') }}
-  {% endif %}
-{% endblock %}
-
 {% block body_class %}{{ super() }} variant-ie-1{% endblock %}
 
 {% block page_title %}{{ _('Firefox vs. Internet Explorer') }}{% endblock %}

--- a/media/js/firefox/new/compare-ie-experiment.js
+++ b/media/js/firefox/new/compare-ie-experiment.js
@@ -60,7 +60,7 @@
         var cop = new Mozilla.TrafficCop({
             id: 'experiment_firefox_new_ie',
             variations: {
-                'v=a': 30, // control
+                'v=a': 20, // control
                 'v=1': 20,
                 'v=2': 20,
                 'v=3': 20,


### PR DESCRIPTION
@stephaniehobson the experiment seems to trigger ok for me with the correct UTM values, but I did notice I had included an incorrect cohort size for the control variation. This should fix it.

I also removed the experiment bundle from the variation 2 template, since it only needs to be triggered by the default template.