### PR TITLE
Update tests for new accounts page

### DIFF
--- a/tests/functional/firefox/test_accounts.py
+++ b/tests/functional/firefox/test_accounts.py
@@ -7,17 +7,17 @@ import pytest
 from pages.firefox.accounts import FirefoxAccountsPage
 
 
-@pytest.mark.skip_if_firefox(reason='Download button is displayed only to non-Firefox users')
+@pytest.mark.skip_if_firefox(reason='Download button is only displayed to non-Firefox users')
 @pytest.mark.nondestructive
 def test_download_button_displayed(base_url, selenium):
     page = FirefoxAccountsPage(selenium, base_url).open()
-    assert not page.is_accounts_form_displayed
+    assert not page.is_create_account_form_displayed
     assert page.download_button.is_displayed
 
 
-@pytest.mark.skip_if_not_firefox(reason='Accounts iFrame is only displayed to Firefox users')
+@pytest.mark.skip_if_not_firefox(reason='Create Account form is only displayed to Firefox users')
 @pytest.mark.nondestructive
-def test_accounts_form_displayed(base_url, selenium):
+def test_create_account_form_displayed(base_url, selenium):
     page = FirefoxAccountsPage(selenium, base_url).open()
     assert not page.download_button.is_displayed
-    assert page.is_accounts_form_displayed
+    assert page.is_create_account_form_displayed

--- a/tests/pages/firefox/accounts.py
+++ b/tests/pages/firefox/accounts.py
@@ -13,7 +13,7 @@ class FirefoxAccountsPage(FirefoxBasePage):
     URL_TEMPLATE = '/{locale}/firefox/accounts/'
 
     _download_button_locator = (By.ID, 'features-hero-download')
-    _create_account_button_locator = (By.ID, 'features-hero-account')
+    _create_account_form_locator = (By.ID, 'fxa-email-form')
 
     @property
     def download_button(self):
@@ -22,4 +22,4 @@ class FirefoxAccountsPage(FirefoxBasePage):
 
     @property
     def create_account_button(self):
-        return self.is_element_displayed(*self._create_account_button_locator)
+        return self.is_element_displayed(*self._create_account_form_locator)

--- a/tests/pages/firefox/accounts.py
+++ b/tests/pages/firefox/accounts.py
@@ -21,5 +21,5 @@ class FirefoxAccountsPage(FirefoxBasePage):
         return DownloadButton(self, root=el)
 
     @property
-    def create_account_button(self):
+    def is_create_account_form_displayed(self):
         return self.is_element_displayed(*self._create_account_form_locator)


### PR DESCRIPTION
## Description
I think I had a version of this working at some point previous to the new page merging but it's possible I never committed it, or never pushed it, or pushed it and it got overwritten in a rebase, or something who knows... the week is a bit of a blur. Anyway, I think this updates the tests for the new accounts page and it's passing locally so maybe I did something right. At the time I'm submitting this PR (late on Friday night, I might add) I've pushed it to the `run-integration-tests` branch but Jenkins is unresponsive and probably needs a kick, but I'm going to submit the PR anyway. If I'm completely off base feel free to just close it but if I'm on the right track I'm happy to tweak until we get there. And I'm babbling and should probably go to bed.