### PR TITLE
[fix #6556] Keep basic store badges hidden when modal opens

### DIFF
--- a/bedrock/firefox/templates/firefox/accounts-2018.html
+++ b/bedrock/firefox/templates/firefox/accounts-2018.html
@@ -67,7 +67,7 @@
   ) %}
     <p>{{ _('No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.') }}</p>
 
-    <ul class="mobile-download-buttons mobile-lockbox">
+    <ul class="mobile-content">
       <li class="ios">
         <a href="https://app.adjust.com/kq8zhhz" data-link-type="download" data-download-os="iOS">
           <img src="{{ l10n_img('firefox/ios/btn-app-store.svg') }}" alt="{{ _('Download on the App Store') }}" width="152" height="45">
@@ -98,7 +98,7 @@
   ) %}
     <p>{{ _('Discover the web’s best content, and absorb it anytime – even offline – on any device. Pocket’s listen feature will even read any article aloud to you. All from the Firefox toolbar.') }}</p>
 
-    <ul class="mobile-download-buttons mobile-pocket">
+    <ul class="mobile-content">
       <li class="android">
         {{ google_play_button(href='https://app.adjust.com/h5iycst') }}
       </li>
@@ -122,7 +122,7 @@
   ) %}
     <p>{{ _('Your ideas and inspiration are secure and encrypted with Notes – and when you’re signed into your Account, they sync from your desktop to your Android devices.') }}</p>
 
-    <ul class="mobile-download-buttons mobile-notes">
+    <ul class="mobile-content">
       <li class="android">
         {{ google_play_button(href='https://play.google.com/store/apps/details?id=org.mozilla.testpilot.notes') }}
       </li>

--- a/media/css/firefox/accounts-2018.scss
+++ b/media/css/firefox/accounts-2018.scss
@@ -46,6 +46,10 @@ $image-path: '/media/protocol/img';
         @include text-display-md;
     }
 
+    .mobile-content {
+        display: none;
+    }
+
     .mzp-c-cta-link {
         &:link,
         &:visited {
@@ -255,6 +259,10 @@ $image-path: '/media/protocol/img';
 
 html.ios,
 html.android {
+    .mzp-c-card-feature-content .mobile-content {
+        display: block;
+    }
+
     .mobile-notes,
     .mobile-lockbox,
     .mobile-pocket {


### PR DESCRIPTION
## Description
There are app store badges in the page that are shown on iOS and Android devices in place of the CTA links that open modals. Because they shared a class with the same buttons that appear inside the modal, they were becoming visible when the modal was triggered on desktop. This just gives those mobile-only buttons a different class name so they're not caught in the same selector when the modal appears.

Side note: right now this shows both iOS and Android badges on either device. We should probably show Android badges only on Android and iOS badges only on iOS, but that was more of a refactor than I wanted to put into fixing this basic UX bug. This is good enough for now and maybe we can make additional improvements later.

## Issue / Bugzilla link
#6556 

## Testing
On desktop, click a CTA link for lockbox, pocket, or notes. Ensure the modal opens with the relevant store button(s) under the QR code, but the matching store buttton does not appear above the CTA link.

On mobile, ensure the store buttons display on the page in place of the CTA links.