### PR TITLE
Adding Pocket to Mozilla's Bug Bounty program

### DIFF
--- a/bedrock/security/templates/security/bug-bounty/web-eligible-sites.html
+++ b/bedrock/security/templates/security/bug-bounty/web-eligible-sites.html
@@ -175,6 +175,12 @@
         <li>taskcluster.net</li>
         <li>tools.taskcluster.net</li>
       </ul>
+
+      <h3>Pocket</h3>
+      <ul class="prose">
+        <li>getpocket.com</li>
+        <li>api.getpocket.com</li>
+      </ul>
     </div>
   </article>
 {% endblock %}

--- a/bedrock/security/templates/security/bug-bounty/web-eligible-sites.html
+++ b/bedrock/security/templates/security/bug-bounty/web-eligible-sites.html
@@ -139,6 +139,12 @@
         <li>tls-observatory.services.mozilla.com</li>
       </ul>
 
+      <h3>Pocket</h3>
+      <ul class="prose">
+        <li>getpocket.com</li>
+        <li>api.getpocket.com</li>
+      </ul>
+
       <h3>Shield</h3>
       <ul class="prose">
         <li>qsurvey.mozilla.com</li>
@@ -174,12 +180,6 @@
         <li>statsum.taskcluster.net</li>
         <li>taskcluster.net</li>
         <li>tools.taskcluster.net</li>
-      </ul>
-
-      <h3>Pocket</h3>
-      <ul class="prose">
-        <li>getpocket.com</li>
-        <li>api.getpocket.com</li>
       </ul>
     </div>
   </article>


### PR DESCRIPTION
## Description

Pocket's bug bounty program is moving to Mozilla's program.

## Issue / Bugzilla link

https://bugzilla.mozilla.org/show_bug.cgi?id=1512252

## Testing
