### PR TITLE
Remove jQuery from core-datalayer JS files (#6504)

### DIFF
--- a/media/js/base/core-datalayer-init.js
+++ b/media/js/base/core-datalayer-init.js
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 // init core dataLayer object and push into dataLayer
-$(function() {
+(function() {
     var analytics = Mozilla.Analytics;
     var client = Mozilla.Client;
     var dataLayer = window.dataLayer = window.dataLayer || [];
@@ -48,4 +48,4 @@ $(function() {
     }
 
     analytics.updateDataLayerPush();
-});
+})();

--- a/media/js/base/core-datalayer.js
+++ b/media/js/base/core-datalayer.js
@@ -12,13 +12,17 @@ if (typeof Mozilla.Analytics == 'undefined') {
 
 (function() {
     var analytics = Mozilla.Analytics;
+    var isModernBrowser = 'querySelector' in document && 'querySelectorAll' in document;
 
     /** Returns whether page has download button.
     * @param {String} path - URL path name fallback if page ID does not exist.
     * @return {String} string.
     */
     analytics.pageHasDownload = function() {
-        return $('[data-download-os]').length ? 'true' : 'false';
+        if (!isModernBrowser) {
+            return 'false';
+        }
+        return document.querySelector('[data-download-os]') !== null ? 'true' : 'false';
     };
 
     /** Returns whether page has video.
@@ -26,7 +30,10 @@ if (typeof Mozilla.Analytics == 'undefined') {
     * @return {String} string.
     */
     analytics.pageHasVideo = function() {
-        return ($('video').length || $('iframe[src^="https://www.youtube"]').length) ? 'true' : 'false';
+        if (!isModernBrowser) {
+            return 'false';
+        }
+        return (document.querySelector('video') !== null || document.querySelector('iframe[src^="https://www.youtube"]') !== null) ? 'true' : 'false';
     };
 
     /** Returns page version.
@@ -44,7 +51,7 @@ if (typeof Mozilla.Analytics == 'undefined') {
     * @return {String} latest Fx version.
     */
     analytics.getLatestFxVersion = function() {
-        return $('html').data('latest-firefox');
+        return document.getElementsByTagName('html')[0].getAttribute('data-latest-firefox');
     };
 
     /** Returns an object containing GA-formatted FxA details
@@ -64,7 +71,7 @@ if (typeof Mozilla.Analytics == 'undefined') {
 
         if (FxaDetails.firefox === true) {
             // only add FxA account details if this is Fx, otherwise their segment is just 'Not Firefox'
-            if(FxaDetails.mobile) {
+            if (FxaDetails.mobile) {
                 // Firefox Mobile
                 formatted.FxASegment = 'Firefox Mobile';
             } else {
@@ -75,7 +82,7 @@ if (typeof Mozilla.Analytics == 'undefined') {
                     // set FxASegment with default value, to be refined
                     formatted.FxASegment = 'Logged in';
                     // Change FxASegment to Legacy if this is an old browser
-                    if(FxaDetails.legacy === true) {
+                    if (FxaDetails.legacy === true) {
                         formatted.FxASegment = 'Legacy Firefox';
                     }
 
@@ -118,7 +125,7 @@ if (typeof Mozilla.Analytics == 'undefined') {
 
                 } else {
                     // Not logged into FxA
-                    if(FxaDetails.legacy === true) {
+                    if (FxaDetails.legacy === true) {
                         // too old to support UITour or FxA, or pre FxASegment and logged out
                         formatted.FxASegment = 'Legacy Firefox';
                         formatted.FxALogin = 'unknown';

--- a/tests/unit/spec/base/core-datalayer.js
+++ b/tests/unit/spec/base/core-datalayer.js
@@ -70,17 +70,17 @@ describe('core-datalayer.js', function() {
     describe('getLatestFxVersion', function() {
 
         afterEach(function() {
-            $('html').removeData('latest-firefox');
+            document.getElementsByTagName('html')[0].removeAttribute('data-latest-firefox');
         });
 
         it('will return the Firefox version from the data-latest-firefox attribute from the html element if present', function() {
-            $('html').data('latest-firefox', '48.0');
+            document.getElementsByTagName('html')[0].setAttribute('data-latest-firefox', '48.0');
 
             expect(Mozilla.Analytics.getLatestFxVersion()).toBe('48.0');
         });
 
-        it('will return undefined if no data-latest-firefox attribute is present on the html element', function() {
-            expect(Mozilla.Analytics.getLatestFxVersion()).toBeUndefined();
+        it('will return null if no data-latest-firefox attribute is present on the html element', function() {
+            expect(Mozilla.Analytics.getLatestFxVersion()).toBe(null);
         });
     });
 


### PR DESCRIPTION
## Description
- Removes jQuery code from `core-datalayer.js` and `core-datalayer-init.js` files.

## Issue / Bugzilla link
#6504

## Testing
- [x] Make sure I didn't miss any stray jQuery selectors?
- [ ] Check backward compatibility for old IE?