### PR TITLE
Double pytest reruns

### DIFF
--- a/bin/run-integration-tests.sh
+++ b/bin/run-integration-tests.sh
@@ -20,9 +20,7 @@ CMD="${CMD} -r a"
 CMD="${CMD} --verbose"
 CMD="${CMD} -n ${PYTEST_PROCESSES}"
 CMD="${CMD} --base-url ${BASE_URL}"
-# rerun a flaky test once
-# DO NOT INCREASE THIS
-CMD="${CMD} --reruns 1"
+CMD="${CMD} --reruns 2"
 CMD="${CMD} --html ${RESULTS_PATH}/index.html"
 CMD="${CMD} --junitxml ${RESULTS_PATH}/junit.xml"
 if [ -n "${DRIVER}" ]; then CMD="${CMD} --driver ${DRIVER}"; fi


### PR DESCRIPTION
Per our discussion last week, we're going to increase the number of pytest reruns to reduce the need to rerun the entire test suite on failure.
