### PR TITLE
[fix #6587] Firefox Concerts between-show content updates

### DIFF
--- a/bedrock/firefox/templates/firefox/concerts.html
+++ b/bedrock/firefox/templates/firefox/concerts.html
@@ -10,7 +10,7 @@
 {% block page_title %}Watch free live concerts in Firefox{% endblock %}
 
 {%- block page_desc -%}
-  {%- if switch('firefox-concert-one-over') -%}
+  {%- if switch('firefox_concert_one_over') -%}
     Here’s to you. Here’s to live music. Here’s to watching free, from all kinds of artists, right from Firefox. Thanks for being part of our community. Firefox fights for you.
   {%- else -%}
     Live on 12/11 get a front row seat for one of the last shows on Phosphorescent’s C’est La Vie tour.
@@ -18,7 +18,7 @@
 {%- endblock -%}
 
 {%- block page_image -%}
-  {%- if switch('firefox-concert-one-over') -%}
+  {%- if switch('firefox_concert_one_over') -%}
     {{ static('img/firefox/concerts/page-image.jpg') }}
   {%- else -%}
     {{ static('img/firefox/concerts/page-image-phosphorescent.jpg') }}
@@ -50,11 +50,11 @@
       <section class="artist-card mzp-c-card-feature mzp-has-aspect-16-9 mzp-t-firefox mzp-t-dark">
         <div class="mzp-c-card-feature-media-wrapper">
           <div class="mzp-c-card-feature-media">
-          {% if switch('firefox-concert-one-live') %}
+          {% if switch('firefox_concert_one_live') %}
             <a class="video-play" href="http://firefoxconcerts.livenation.com" rel="external" title="Watch the livestream">
               <img src="{{ static('img/firefox/concerts/video-poster-phosphorescent.jpg') }}" alt="Phosphorescent (Matthew Houck) and his six-piece band perform on stage before a crowd. The lighting is tinted purple and the band is backed by a large, illuminated sign reading ‘C’est La Vie’, the title of their recent album.">
             </a>
-          {% elif switch('firefox-concert-one-over') %}
+          {% elif switch('firefox_concert_one_over') %}
             <img src="{{ static('img/firefox/concerts/video-poster-phosphorescent.jpg') }}" alt="Phosphorescent (Matthew Houck) and his six-piece band perform on stage before a crowd. The lighting is tinted purple and the band is backed by a large, illuminated sign reading ‘C’est La Vie’, the title of their recent album.">
           {% else %}
             <a class="video-play js-video-play" href="https://youtu.be/PcNpDCdkhLc" data-id="PcNpDCdkhLc" title="Play the video">
@@ -65,15 +65,15 @@
         </div>
         <div class="mzp-c-card-feature-content">
           <div class="mzp-c-card-feature-content-container">
-          {% if switch('firefox-concert-one-live') %}
+          {% if switch('firefox_concert_one_live') %}
             <p class="mzp-c-card-tag live">Live</p>
-          {% elif switch('firefox-concert-one-over') %}
+          {% elif switch('firefox_concert_one_over') %}
             <p class="mzp-c-card-tag ended">Coming soon</p>
           {% else %}
             <p class="mzp-c-card-tag countdown" id="countdown-one">Starts in <span class="time days"></span> days, <span class="time hours"></span> hours</p>
           {% endif %}
 
-          {% if switch('firefox-concert-one-over') %}
+          {% if switch('firefox_concert_one_over') %}
             <h2 class="mzp-c-card-feature-title">Next concert: To be announced</h2>
             <p class="mzp-c-card-feature-desc">The first concert is over, but we have more music in the queue. Check back here to find out who’s playing next in the Firefox Concert Series! Sign up below to be the first to know when the next show is announced.</p>
           {% else %}
@@ -81,7 +81,7 @@
             <p class="mzp-c-card-feature-desc">Livestreamed from DC’s 9:30 Club, get a front row seat for one of the last shows on Phosphorescent’s <cite lang="fr">C’est La Vie</cite> tour. Special guest Liz Cooper and The Stampede kick off the show 8:00pm EST.</p>
           {% endif %}
 
-          {% if switch('firefox-concert-one-live') %}
+          {% if switch('firefox_concert_one_live') %}
             <p class="stream-link"><a href="http://firefoxconcerts.livenation.com" rel="external" class="mzp-c-button mzp-t-dark">Watch Now</a></p>
           {% endif %}
           </div>

--- a/bedrock/firefox/templates/firefox/concerts.html
+++ b/bedrock/firefox/templates/firefox/concerts.html
@@ -54,6 +54,8 @@
             <a class="video-play" href="http://firefoxconcerts.livenation.com" rel="external" title="Watch the livestream">
               <img src="{{ static('img/firefox/concerts/video-poster-phosphorescent.jpg') }}" alt="Phosphorescent (Matthew Houck) and his six-piece band perform on stage before a crowd. The lighting is tinted purple and the band is backed by a large, illuminated sign reading ‘C’est La Vie’, the title of their recent album.">
             </a>
+          {% elif switch('firefox-concert-one-over') %}
+            <img src="{{ static('img/firefox/concerts/video-poster-phosphorescent.jpg') }}" alt="Phosphorescent (Matthew Houck) and his six-piece band perform on stage before a crowd. The lighting is tinted purple and the band is backed by a large, illuminated sign reading ‘C’est La Vie’, the title of their recent album.">
           {% else %}
             <a class="video-play js-video-play" href="https://youtu.be/PcNpDCdkhLc" data-id="PcNpDCdkhLc" title="Play the video">
               <img src="{{ static('img/firefox/concerts/video-poster-phosphorescent.jpg') }}" alt="Phosphorescent (Matthew Houck) and his six-piece band perform on stage before a crowd. The lighting is tinted purple and the band is backed by a large, illuminated sign reading ‘C’est La Vie’, the title of their recent album.">
@@ -66,12 +68,18 @@
           {% if switch('firefox-concert-one-live') %}
             <p class="mzp-c-card-tag live">Live</p>
           {% elif switch('firefox-concert-one-over') %}
-            <p class="mzp-c-card-tag ended">Ended</p>
+            <p class="mzp-c-card-tag ended">Coming soon</p>
           {% else %}
             <p class="mzp-c-card-tag countdown" id="countdown-one">Starts in <span class="time days"></span> days, <span class="time hours"></span> hours</p>
           {% endif %}
+
+          {% if switch('firefox-concert-one-over') %}
+            <h2 class="mzp-c-card-feature-title">Next concert: To be announced</h2>
+            <p class="mzp-c-card-feature-desc">The first concert is over, but we have more music in the queue. Check back here to find out who’s playing next in the Firefox Concert Series! Sign up below to be the first to know when the next show is announced.</p>
+          {% else %}
             <h2 class="mzp-c-card-feature-title"><time datetime="2018-12-11T20:00:00-0500">Tuesday, Dec. 11</time>: Phosphorescent</h2>
             <p class="mzp-c-card-feature-desc">Livestreamed from DC’s 9:30 Club, get a front row seat for one of the last shows on Phosphorescent’s <cite lang="fr">C’est La Vie</cite> tour. Special guest Liz Cooper and The Stampede kick off the show 8:00pm EST.</p>
+          {% endif %}
 
           {% if switch('firefox-concert-one-live') %}
             <p class="stream-link"><a href="http://firefoxconcerts.livenation.com" rel="external" class="mzp-c-button mzp-t-dark">Watch Now</a></p>
@@ -80,25 +88,6 @@
         </div>
       </section>
     </div>
-
-{# No TBA section for now
-    <div class="artist-next mzp-l-content l-content-narrow">
-      <section class="artist-card mzp-c-card-feature mzp-has-aspect-16-9 mzp-l-card-feature-right-half mzp-t-firefox mzp-t-dark">
-        <div class="mzp-c-card-feature-media-wrapper">
-          <div class="mzp-c-card-feature-media">
-            <img src="{{ static('img/firefox/concerts/concert.jpg') }}" alt="">
-          </div>
-        </div>
-        <div class="mzp-c-card-feature-content">
-          <div class="mzp-c-card-feature-content-container">
-            <p class="date"><time datetime="2019-01">January 2019</time></p>
-            <h2 class="mzp-c-card-feature-title">To be announced</h2>
-            <p class="mzp-c-card-feature-desc">Check back here to find out who’s playing next!</p>
-          </div>
-        </div>
-      </section>
-    </div>
-#}
 
     <div class="fxa-cta mzp-l-content">
       <section class="mzp-c-card-feature mzp-has-aspect-16-9 mzp-l-card-feature-right-half mzp-t-firefox mzp-t-dark">

--- a/bedrock/mozorg/templates/mozorg/home/home-en.html
+++ b/bedrock/mozorg/templates/mozorg/home/home-en.html
@@ -134,22 +134,22 @@
           youtube_id='rZAQ6vgt8nE'
         )}}
         <!-- 2 -->
-      {% if switch('firefox_concert_series') %}
-        {{ card(
-          tag_label=_('Firefox Concert Series | Phosphorescent'),
-          title=_('Here’s to you. Here’s to live music.'),
-          ga_title='Here’s to you. Here’s to live music.',
-          desc=_('Here’s to watching it free, from all kinds of artists, right from Firefox. Rock out with Phosphorescent, LIVE on Dec. 11.'),
-          image_url='home/2018/cards/nov/concerts.jpg',
-          aspect_ratio='mzp-has-aspect-1-1',
-          link_url=url('firefox.concerts')
-        )}}
-      {% elif switch('firefox_concert_series') and switch('firefox-concert-one-over') %}
+      {% if switch('firefox_concert_series') and switch('firefox_concert_one_over') %}
         {{ card(
           tag_label=_('Firefox Concert Series'),
           title=_('Here’s to you. Here’s to live music.'),
           ga_title='Here’s to you. Here’s to live music.',
           desc=_('Here’s to watching it free, from all kinds of artists, right from Firefox. Join us and rock out with the Firefox Concert Series.'),
+          image_url='home/2018/cards/nov/concerts.jpg',
+          aspect_ratio='mzp-has-aspect-1-1',
+          link_url=url('firefox.concerts')
+        )}}
+      {% elif switch('firefox_concert_series') %}
+        {{ card(
+          tag_label=_('Firefox Concert Series | Phosphorescent'),
+          title=_('Here’s to you. Here’s to live music.'),
+          ga_title='Here’s to you. Here’s to live music.',
+          desc=_('Here’s to watching it free, from all kinds of artists, right from Firefox. Rock out with Phosphorescent, LIVE on Dec. 11.'),
           image_url='home/2018/cards/nov/concerts.jpg',
           aspect_ratio='mzp-has-aspect-1-1',
           link_url=url('firefox.concerts')

--- a/bedrock/mozorg/templates/mozorg/home/home-en.html
+++ b/bedrock/mozorg/templates/mozorg/home/home-en.html
@@ -137,9 +137,19 @@
       {% if switch('firefox_concert_series') %}
         {{ card(
           tag_label=_('Firefox Concert Series | Phosphorescent'),
-          title=_('Here’s to you. Here’s to the internet.'),
-          ga_title='Here’s to you. Here’s to the internet.',
+          title=_('Here’s to you. Here’s to live music.'),
+          ga_title='Here’s to you. Here’s to live music.',
           desc=_('Here’s to watching it free, from all kinds of artists, right from Firefox. Rock out with Phosphorescent, LIVE on Dec. 11.'),
+          image_url='home/2018/cards/nov/concerts.jpg',
+          aspect_ratio='mzp-has-aspect-1-1',
+          link_url=url('firefox.concerts')
+        )}}
+      {% elif switch('firefox_concert_series') and switch('firefox-concert-one-over') %}
+        {{ card(
+          tag_label=_('Firefox Concert Series'),
+          title=_('Here’s to you. Here’s to live music.'),
+          ga_title='Here’s to you. Here’s to live music.',
+          desc=_('Here’s to watching it free, from all kinds of artists, right from Firefox. Join us and rock out with the Firefox Concert Series.'),
           image_url='home/2018/cards/nov/concerts.jpg',
           aspect_ratio='mzp-has-aspect-1-1',
           link_url=url('firefox.concerts')


### PR DESCRIPTION
## Description
Updates content for the period after the Phosphorescent show but before we announce the next one, using the switch `firefox-concert-one-over` (boring switch names are because so much was unknown when this was all first built, we expected to have two concerts announced at the same time, etc etc...).

## Issue / Bugzilla link
#6587 

## Testing
You can fake the between-show state in local dev mode by changing all the `{% if switch('firefox-concert-one-live') %}` switches to `{% if not switch('firefox-concert-one-live') %}`
