### PR TITLE
Add firefox.html redirect (#6512)

### DIFF
--- a/bedrock/firefox/redirects.py
+++ b/bedrock/firefox/redirects.py
@@ -597,4 +597,7 @@ redirectpatterns = (
     redirect(r'^firefox/accounts/features/?', 'firefox.accounts'),
     redirect(r'^firefox/features/sync/?', 'firefox.accounts'),
     redirect(r'^firefox/features/send-tabs/?', 'firefox.accounts'),
+
+    # issue 6512
+    redirect(r'^firefox/firefox\.html$', 'firefox.new'),
 )


### PR DESCRIPTION
## Description
/firefox/firefox.html redirects to /firefox/new

## Issue / Bugzilla link
#6512
