### PR TITLE
Add enterprise category to release notes pages

### DIFF
--- a/bedrock/firefox/templates/firefox/releases/release-notes.html
+++ b/bedrock/firefox/templates/firefox/releases/release-notes.html
@@ -239,6 +239,19 @@
             {% endif %}
           {% endfor %}
 
+          {% for note in release.notes if note.tag == "Enterprise" %}
+            {% if loop.first %}
+            <div class="section-wrapper" id="{{ note.tag|lower() }}">
+              <h4>{{ note.tag }}</h4>
+              <ul class="section-items">
+              {% endif %}
+              {{ note_entry(note) }}
+              {% if loop.last %}
+              </ul>
+            </div>
+            {% endif %}
+          {% endfor %}
+
           {# The Developer section is always visible with a MDN link #}
           <div class="section-wrapper" id="developer">
             <h4>{{ _('Developer') }}</h4>

--- a/media/css/firefox/releasenotes-firefox.less
+++ b/media/css/firefox/releasenotes-firefox.less
@@ -346,6 +346,11 @@ ul.section-items {
     font-family: 'Font Awesome';
     margin-right: .2em;
 }
+#enterprise h4:before {
+    content: '\00A0\f1ad\00A0';
+    font-family: 'Font Awesome';
+    margin-right: .2em;
+}
 #web-platform h4:before {
     content: '\00A0\f121\00A0';
     font-family: 'Font Awesome';


### PR DESCRIPTION
This will support a change in Nucleus to add the "enterprise" tag.

See https://github.com/mozilla/nucleus/issues/63

Fix #6591