### PR TITLE
Transparency Report: jan-june 2018 update ( #6479)

### DIFF
--- a/bedrock/mozorg/templates/mozorg/about/policy/transparency/includes/past-reports.html
+++ b/bedrock/mozorg/templates/mozorg/about/policy/transparency/includes/past-reports.html
@@ -9,7 +9,7 @@
     <nav>
       <h3>{{ _('Previous Reports') }}</h3>
       <ul>
-        {% if switch('transparency_report') %}
+        {% if switch('transparency-report') %}
         <li><a href="{{ url('mozorg.about.policy.transparency.jul-dec-2017') }}">{{ _('July-December 2017') }}</a></li>
         {% endif %}
         <li><a href="{{ url('mozorg.about.policy.transparency.jan-jun-2017') }}">{{ _('January-June 2017') }}</a></li>

--- a/bedrock/mozorg/templates/mozorg/about/policy/transparency/includes/past-reports.html
+++ b/bedrock/mozorg/templates/mozorg/about/policy/transparency/includes/past-reports.html
@@ -9,7 +9,7 @@
     <nav>
       <h3>{{ _('Previous Reports') }}</h3>
       <ul>
-        {% if switch('transparency-report') %}
+        {% if switch('transparency_report_dec_2018') %}
         <li><a href="{{ url('mozorg.about.policy.transparency.jul-dec-2017') }}">{{ _('July-December 2017') }}</a></li>
         {% endif %}
         <li><a href="{{ url('mozorg.about.policy.transparency.jan-jun-2017') }}">{{ _('January-June 2017') }}</a></li>

--- a/bedrock/mozorg/templates/mozorg/about/policy/transparency/includes/past-reports.html
+++ b/bedrock/mozorg/templates/mozorg/about/policy/transparency/includes/past-reports.html
@@ -9,7 +9,9 @@
     <nav>
       <h3>{{ _('Previous Reports') }}</h3>
       <ul>
+        {% if switch('transparency_report') %}
         <li><a href="{{ url('mozorg.about.policy.transparency.jul-dec-2017') }}">{{ _('July-December 2017') }}</a></li>
+        {% endif %}
         <li><a href="{{ url('mozorg.about.policy.transparency.jan-jun-2017') }}">{{ _('January-June 2017') }}</a></li>
         <li><a href="{{ url('mozorg.about.policy.transparency.jul-dec-2016') }}">{{ _('July-December 2016') }}</a></li>
         <li><a href="{{ url('mozorg.about.policy.transparency.jan-jun-2016') }}">{{ _('January-June 2016') }}</a></li>

--- a/bedrock/mozorg/templates/mozorg/about/policy/transparency/includes/past-reports.html
+++ b/bedrock/mozorg/templates/mozorg/about/policy/transparency/includes/past-reports.html
@@ -9,6 +9,7 @@
     <nav>
       <h3>{{ _('Previous Reports') }}</h3>
       <ul>
+        <li><a href="{{ url('mozorg.about.policy.transparency.jul-dec-2017') }}">{{ _('July-December 2017') }}</a></li>
         <li><a href="{{ url('mozorg.about.policy.transparency.jan-jun-2017') }}">{{ _('January-June 2017') }}</a></li>
         <li><a href="{{ url('mozorg.about.policy.transparency.jul-dec-2016') }}">{{ _('July-December 2016') }}</a></li>
         <li><a href="{{ url('mozorg.about.policy.transparency.jan-jun-2016') }}">{{ _('January-June 2016') }}</a></li>

--- a/bedrock/mozorg/templates/mozorg/about/policy/transparency/includes/reports-nav.html
+++ b/bedrock/mozorg/templates/mozorg/about/policy/transparency/includes/reports-nav.html
@@ -4,6 +4,6 @@
           <li><a class="button" href="{{ url('mozorg.about.policy.transparency.index') + '#definitions' }}">{{ _('Definitions') }}</a></li>
           {# This link should point to the latest report. Past reports are added to 'includes/past-reports.html' #}
           {# There are also links in the faq that need to be updated to point to the latest report. #}
-          <li><a class="button" href="{{ url('mozorg.about.policy.transparency.jul-dec-2017') }}">{{ _('July-December 2017 Report') }}</a></li>
+          <li><a class="button" href="{{ url('mozorg.about.policy.transparency.jan-jun-2018') }}">{{ _('January-June 2018 Report') }}</a></li>
         </ul>
       </nav>

--- a/bedrock/mozorg/templates/mozorg/about/policy/transparency/includes/reports-nav.html
+++ b/bedrock/mozorg/templates/mozorg/about/policy/transparency/includes/reports-nav.html
@@ -4,6 +4,10 @@
           <li><a class="button" href="{{ url('mozorg.about.policy.transparency.index') + '#definitions' }}">{{ _('Definitions') }}</a></li>
           {# This link should point to the latest report. Past reports are added to 'includes/past-reports.html' #}
           {# There are also links in the faq that need to be updated to point to the latest report. #}
+          {% if switch('transparency_report') %}
           <li><a class="button" href="{{ url('mozorg.about.policy.transparency.jan-jun-2018') }}">{{ _('January-June 2018 Report') }}</a></li>
+          {% else %}
+          <li><a class="button" href="{{ url('mozorg.about.policy.transparency.jul-dec-2017') }}">{{ _('July-December 2017 Report') }}</a></li>
+          {% endif %}
         </ul>
       </nav>

--- a/bedrock/mozorg/templates/mozorg/about/policy/transparency/includes/reports-nav.html
+++ b/bedrock/mozorg/templates/mozorg/about/policy/transparency/includes/reports-nav.html
@@ -4,7 +4,7 @@
           <li><a class="button" href="{{ url('mozorg.about.policy.transparency.index') + '#definitions' }}">{{ _('Definitions') }}</a></li>
           {# This link should point to the latest report. Past reports are added to 'includes/past-reports.html' #}
           {# There are also links in the faq that need to be updated to point to the latest report. #}
-          {% if switch('transparency_report') %}
+          {% if switch('transparency-report') %}
           <li><a class="button" href="{{ url('mozorg.about.policy.transparency.jan-jun-2018') }}">{{ _('January-June 2018 Report') }}</a></li>
           {% else %}
           <li><a class="button" href="{{ url('mozorg.about.policy.transparency.jul-dec-2017') }}">{{ _('July-December 2017 Report') }}</a></li>

--- a/bedrock/mozorg/templates/mozorg/about/policy/transparency/includes/reports-nav.html
+++ b/bedrock/mozorg/templates/mozorg/about/policy/transparency/includes/reports-nav.html
@@ -4,7 +4,7 @@
           <li><a class="button" href="{{ url('mozorg.about.policy.transparency.index') + '#definitions' }}">{{ _('Definitions') }}</a></li>
           {# This link should point to the latest report. Past reports are added to 'includes/past-reports.html' #}
           {# There are also links in the faq that need to be updated to point to the latest report. #}
-          {% if switch('transparency-report') %}
+          {% if switch('transparency_report_dec_2018') %}
           <li><a class="button" href="{{ url('mozorg.about.policy.transparency.jan-jun-2018') }}">{{ _('January-June 2018 Report') }}</a></li>
           {% else %}
           <li><a class="button" href="{{ url('mozorg.about.policy.transparency.jul-dec-2017') }}">{{ _('July-December 2017 Report') }}</a></li>

--- a/bedrock/mozorg/templates/mozorg/about/policy/transparency/index.html
+++ b/bedrock/mozorg/templates/mozorg/about/policy/transparency/index.html
@@ -58,7 +58,7 @@
                   {% set link_copytrade=url('mozorg.about.policy.transparency.jan-jun-2018') + '#copyright-trademark' %}
                   {% set link_supplement=url('mozorg.about.policy.transparency.jan-jun-2018') + '#supplement' %}
 
-                {% if switch('transparency_report') %}
+                {% if switch('transparency-report') %}
                 {% trans %}
                   This report covers the Mozilla Foundation, Mozilla Corporation, and Pocket (from 2018). We report on <a href="{{ link_userdata }}">Government Demands for User Data</a>, <a href="{{ link_removal }}">Government Requests for Content Removal</a>, and <a href="{{ link_copytrade }}">Copyright and Trademark Requests</a>. We also include a <a href="{{ link_supplement }}">Supplement</a>, which provides additional information.
                 {% endtrans %}

--- a/bedrock/mozorg/templates/mozorg/about/policy/transparency/index.html
+++ b/bedrock/mozorg/templates/mozorg/about/policy/transparency/index.html
@@ -53,13 +53,21 @@
             <div data-accordion-role="tabpanel">
               <p>
                 {# NOTE: Remember to update these links when publishing a new report. #}
-                  {% set link_userdata=url('mozorg.about.policy.transparency.jul-dec-2017') + '#government-user-data' %}
-                  {% set link_removal=url('mozorg.about.policy.transparency.jul-dec-2017') + '#government-content-removal' %}
-                  {% set link_copytrade=url('mozorg.about.policy.transparency.jul-dec-2017') + '#copyright-trademark' %}
-                  {% set link_supplement=url('mozorg.about.policy.transparency.jul-dec-2017') + '#supplement' %}
+                  {% set link_userdata=url('mozorg.about.policy.transparency.jan-jun-2018') + '#government-user-data' %}
+                  {% set link_removal=url('mozorg.about.policy.transparency.jan-jun-2018') + '#government-content-removal' %}
+                  {% set link_copytrade=url('mozorg.about.policy.transparency.jan-jun-2018') + '#copyright-trademark' %}
+                  {% set link_supplement=url('mozorg.about.policy.transparency.jan-jun-2018') + '#supplement' %}
+
+                {% if l10n_has_tag('transparency_h1_2018') %}
+                {% trans %}
+                  This report covers the Mozilla Foundation, Mozilla Corporation, and Pocket (from 2018). We report on <a href="{{ link_userdata }}">Government Demands for User Data</a>, <a href="{{ link_removal }}">Government Requests for Content Removal</a>, and <a href="{{ link_copytrade }}">Copyright and Trademark Requests</a>. We also include a <a href="{{ link_supplement }}">Supplement</a>, which provides additional information.
+                {% endtrans %}
+                {% else %}
                 {% trans %}
                   We report on <a href="{{ link_userdata }}">Government Demands for User Data</a>, <a href="{{ link_removal }}">Government Requests for Content Removal</a>, and <a href="{{ link_copytrade }}">Copyright and Trademark Requests</a>. We also include a <a href="{{ link_supplement }}">Supplement</a>, which provides additional information.
                 {% endtrans %}
+                {% endif %}
+
                 {{ _('With each additional report that we publish, we’ll continue to re­evaluate how we can be more transparent.') }}
               </p>
             </div>

--- a/bedrock/mozorg/templates/mozorg/about/policy/transparency/index.html
+++ b/bedrock/mozorg/templates/mozorg/about/policy/transparency/index.html
@@ -58,7 +58,7 @@
                   {% set link_copytrade=url('mozorg.about.policy.transparency.jan-jun-2018') + '#copyright-trademark' %}
                   {% set link_supplement=url('mozorg.about.policy.transparency.jan-jun-2018') + '#supplement' %}
 
-                {% if l10n_has_tag('transparency_h1_2018') %}
+                {% if switch('transparency_report') %}
                 {% trans %}
                   This report covers the Mozilla Foundation, Mozilla Corporation, and Pocket (from 2018). We report on <a href="{{ link_userdata }}">Government Demands for User Data</a>, <a href="{{ link_removal }}">Government Requests for Content Removal</a>, and <a href="{{ link_copytrade }}">Copyright and Trademark Requests</a>. We also include a <a href="{{ link_supplement }}">Supplement</a>, which provides additional information.
                 {% endtrans %}

--- a/bedrock/mozorg/templates/mozorg/about/policy/transparency/index.html
+++ b/bedrock/mozorg/templates/mozorg/about/policy/transparency/index.html
@@ -53,10 +53,17 @@
             <div data-accordion-role="tabpanel">
               <p>
                 {# NOTE: Remember to update these links when publishing a new report. #}
+                {% if switch('transparency_report_dec_2018') %}
                   {% set link_userdata=url('mozorg.about.policy.transparency.jan-jun-2018') + '#government-user-data' %}
                   {% set link_removal=url('mozorg.about.policy.transparency.jan-jun-2018') + '#government-content-removal' %}
                   {% set link_copytrade=url('mozorg.about.policy.transparency.jan-jun-2018') + '#copyright-trademark' %}
                   {% set link_supplement=url('mozorg.about.policy.transparency.jan-jun-2018') + '#supplement' %}
+                {% else %}
+                  {% set link_userdata=url('mozorg.about.policy.transparency.jul-dec-2017') + '#government-user-data' %}
+                  {% set link_removal=url('mozorg.about.policy.transparency.jul-dec-2017') + '#government-content-removal' %}
+                  {% set link_copytrade=url('mozorg.about.policy.transparency.jul-dec-2017') + '#copyright-trademark' %}
+                  {% set link_supplement=url('mozorg.about.policy.transparency.jul-dec-2017') + '#supplement' %}
+                {% endif %}
 
                 {% if switch('transparency_report_dec_2018') %}
                 {% trans %}

--- a/bedrock/mozorg/templates/mozorg/about/policy/transparency/index.html
+++ b/bedrock/mozorg/templates/mozorg/about/policy/transparency/index.html
@@ -58,7 +58,7 @@
                   {% set link_copytrade=url('mozorg.about.policy.transparency.jan-jun-2018') + '#copyright-trademark' %}
                   {% set link_supplement=url('mozorg.about.policy.transparency.jan-jun-2018') + '#supplement' %}
 
-                {% if switch('transparency-report') %}
+                {% if switch('transparency_report_dec_2018') %}
                 {% trans %}
                   This report covers the Mozilla Foundation, Mozilla Corporation, and Pocket (from 2018). We report on <a href="{{ link_userdata }}">Government Demands for User Data</a>, <a href="{{ link_removal }}">Government Requests for Content Removal</a>, and <a href="{{ link_copytrade }}">Copyright and Trademark Requests</a>. We also include a <a href="{{ link_supplement }}">Supplement</a>, which provides additional information.
                 {% endtrans %}

--- a/bedrock/mozorg/templates/mozorg/about/policy/transparency/jan-jun-2018.html
+++ b/bedrock/mozorg/templates/mozorg/about/policy/transparency/jan-jun-2018.html
@@ -140,6 +140,16 @@
               <td>5</td>
               <td>0</td>
             </tr>
+            <tr>
+              <th scope="row">{{ _('Pocket') }}</th>
+              <td>0</td>
+              <td>0</td>
+            </tr>
+            <tr>
+              <th scope="row">{{ _('Other Services') }}</th>
+              <td>0</td>
+              <td>0</td>
+            </tr>
           </tbody>
         </table>
 
@@ -164,6 +174,15 @@
               <td>6</td>
               <td>0</td>
             </tr>
+            <tr>
+              <th scope="row">{{ _('Pocket') }}</th>
+              <td>0</td>
+              <td>0</td>
+            </tr>
+            <tr>
+              <th scope="row">{{ _('Other Services') }}</th>
+              <td>0</td>
+              <td>0</td>
           </tbody>
         </table>
 
@@ -211,7 +230,6 @@
             </tr>
             <tr>
               <th scope="row">{{ _('Other <a href="%s">Specific User</a> Data Disclosure')|format(url('mozorg.about.policy.transparency.index') + '#dfn-specific-user') }}</th>
-              <td>0</td>
             </tr>
           </tbody>
         </table>

--- a/bedrock/mozorg/templates/mozorg/about/policy/transparency/jan-jun-2018.html
+++ b/bedrock/mozorg/templates/mozorg/about/policy/transparency/jan-jun-2018.html
@@ -39,15 +39,15 @@
               <th scope="row">
                 <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-subpoena' }}">{{ _('Subpoenas') }}</a>
               </th>
-              <td>1[2]</td>
-              <td>{{ _('N/A') }}</td>
+              <td>1<sub>[2]</sub></td>
+              <td>{{ _('No') }}</td>
             </tr>
             <tr>
               <th scope="row">
                 <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-court-order' }}">{{ _('Court Orders') }}</a>
               </th>
-              <td>1</td>
-              <td>{{ _('N/A') }}</td>
+              <td>1<sub>[3]</sub></td>
+              <td>{{ _('No') }}</td>
             </tr>
             <tr>
               <th scope="row">
@@ -82,8 +82,9 @@
 
         <aside class="footnotes">
           <section id="footnote-1">
-            <p>{{ _('1. Mozilla has never received a National Security Request.') }}</p>
+            <p>{{ _('1. None of the Mozilla Foundation, Mozilla Corporation or Pocket have ever received a National Security Request.') }}</p>
             <p>{{ _('2. Issued to Mozilla Corporation in connection with Pocket.') }}</p>
+            <p>{{ _('3. Issued to Mozilla Corporation.') }}</p>
           </section>
         </aside>
       </div>
@@ -230,6 +231,7 @@
             </tr>
             <tr>
               <th scope="row">{{ _('Other <a href="%s">Specific User</a> Data Disclosure')|format(url('mozorg.about.policy.transparency.index') + '#dfn-specific-user') }}</th>
+              <td>0</td>
             </tr>
           </tbody>
         </table>

--- a/bedrock/mozorg/templates/mozorg/about/policy/transparency/jan-jun-2018.html
+++ b/bedrock/mozorg/templates/mozorg/about/policy/transparency/jan-jun-2018.html
@@ -1,0 +1,233 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+  # License, v. 2.0. If a copy of the MPL was not distributed with this
+  # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+
+  {% extends "mozorg/about/policy/transparency/report-base.html" %}
+
+  {% block page_title %}{{ _('Transparency Report - January-June, 2018') }}{% endblock %}
+
+  {% block report_title %}
+    <h1>{{ _('Transparency Report') }} <span>{{ _('Reporting Period: January 1, 2018 to June 30, 2018') }}</span></h1>
+  {% endblock %}
+
+  {% block report_body %}
+    <section class="section" id="government-user-data">
+      <h2 class="section-title" data-accordion-role="tab">{{ _('Government Demands for User Data') }}</h2>
+
+      <div class="content" data-accordion-role="tabpanel">
+        <p>
+          {{ _('In the Reporting Period, Mozilla received 1 Court Order and 1 Subpoena for user data.') }}
+        </p>
+
+        <table class="data-table">
+          <thead>
+            <tr>
+              <th scope="col">{{ _('Legal Processes') }}</th>
+              <th scope="col">{{ _('Received') }}</th>
+              <th scope="col">{{ _('Data Produced') }}</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <th scope="row">
+                <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-search-warrant' }}">{{ _('Search Warrants') }}</a>
+              </th>
+              <td>0</td>
+              <td>{{ _('N/A') }}</td>
+            </tr>
+            <tr>
+              <th scope="row">
+                <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-subpoena' }}">{{ _('Subpoenas') }}</a>
+              </th>
+              <td>1[2]</td>
+              <td>{{ _('N/A') }}</td>
+            </tr>
+            <tr>
+              <th scope="row">
+                <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-court-order' }}">{{ _('Court Orders') }}</a>
+              </th>
+              <td>1</td>
+              <td>{{ _('N/A') }}</td>
+            </tr>
+            <tr>
+              <th scope="row">
+                <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-wiretap-order' }}">{{ _('Wiretap Orders') }}</a>
+              </th>
+              <td>0</td>
+              <td>{{ _('N/A') }}</td>
+            </tr>
+            <tr>
+              <th scope="row">
+                <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-pen-register-order' }}">{{ _('Pen Register Orders') }}</a>
+              </th>
+              <td>0</td>
+              <td>{{ _('N/A') }}</td>
+            </tr>
+            <tr>
+              <th scope="row">
+                <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-emergency-request' }}">{{ _('Emergency Requests') }}</a>
+              </th>
+              <td>0</td>
+              <td>{{ _('N/A') }}</td>
+            </tr>
+            <tr>
+              <th scope="row">
+                <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-natl-security-request' }}">{{ _('National Security Requests') }}</a> <sup><a href="#footnote-1">1</a></sup>
+              </th>
+              <td>0</td>
+              <td>{{ _('N/A') }}</td>
+            </tr>
+          </tbody>
+        </table>
+
+        <aside class="footnotes">
+          <section id="footnote-1">
+            <p>{{ _('1. Mozilla has never received a National Security Request.') }}</p>
+            <p>{{ _('2. Issued to Mozilla Corporation in connection with Pocket.') }}</p>
+          </section>
+        </aside>
+      </div>
+    </section>
+
+    <section class="section" id="government-content-removal">
+      <h2 class="section-title" data-accordion-role="tab">{{ _('Government Demands for Content Removal') }}</h2>
+
+      <div class="content" data-accordion-role="tabpanel">
+        <p>{{ _('In the Reporting Period, Mozilla did not receive any government requests for content removal from our services.') }}</p>
+
+        <table class="data-table">
+          <thead>
+            <tr>
+              <th scope="col">{{ _('Requesting Country') }}</th>
+              <th scope="col">{{ _('Requests Received') }}</th>
+              <th scope="col">{{ _('Data Produced') }}</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <th scope="row">{{ _('N/A') }}</th>
+              <td>0</td>
+              <td>{{ _('N/A') }}</td>
+            </tr>
+          </tbody>
+        </table>
+
+      </div>
+    </section>
+
+    <section class="section" id="copyright-trademark">
+      <h2 class="section-title" data-accordion-role="tab">{{ _('Copyright and Trademark Requests') }}</h2>
+
+      <div class="content" data-accordion-role="tabpanel">
+        <h3>{{ _('Copyright') }}</h3>
+        <p>{{ _('In the Reporting Period, we received 5 Copyright Takedown Notices and 0 Counter Notices.') }}</p>
+
+        <table class="data-table">
+          <thead>
+            <tr>
+              <th scope="col">{{ _('Mozilla Service') }}</th>
+              <th scope="col">
+                <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-takedown-notice' }}">{{ _('Takedown Notices') }}</a>
+              </th>
+              <th scope="col">
+                <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-counter-notice' }}">{{ _('Counter Notices') }}</a>
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <th scope="row">{{ _('Firefox Add-ons') }}</th>
+              <td>5</td>
+              <td>0</td>
+            </tr>
+          </tbody>
+        </table>
+
+        <h3>{{ _('Trademark') }}</h3>
+        <p>{{ _('In the Reporting Period, we received 6 Trademark Takedown Notices and 0 Counter Notices.') }}</p>
+
+        <table class="data-table">
+          <thead>
+            <tr>
+              <th scope="col">{{ _('Mozilla Service') }}</th>
+              <th scope="col">
+                <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-takedown-notice' }}">{{ _('Takedown Notices') }}</a>
+              </th>
+              <th scope="col">
+                <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-counter-notice' }}">{{ _('Counter Notices') }}</a>
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <th scope="row">{{ _('Firefox Add-ons') }}</th>
+              <td>6</td>
+              <td>0</td>
+            </tr>
+          </tbody>
+        </table>
+
+      </div>
+    </section>
+
+    <section class="section" id="supplement">
+      <h2 class="section-title" data-accordion-role="tab">{{ _('Supplement') }}</h2>
+
+      <div class="content" data-accordion-role="tabpanel">
+        <h3>{{ _('Legislative Reform') }}</h3>
+
+        <p>
+          {% trans india='https://blog.mozilla.org/netpolicy/2018/03/30/effective-rights-protective-procedures-tackling-illegal-content-mozilla-files-comment-european-commission/',
+                   california='https://blog.mozilla.org/netpolicy/2018/06/26/privacy-progress-and-protections-for-california/',
+                   carpenter='https://blog.mozilla.org/netpolicy/2018/06/22/the-supreme-court-scores-a-win-for-privacy/' %}
+            In this Reporting Period, Mozilla continued to push for strong privacy protections around the world including work on the e-Privacy Regulation in Europe, <a href="{{india}}">India’s first data protection law</a>, <a href="{{ california }}">California’s Privacy Act</a>, as well as engagement on discussions about a privacy law at the US federal level. Additionally, in Carpenter, a case where <a href="{{ carpenter }}">we filed an amicus brief</a>, the US Supreme Court found that the government must get a warrant to obtain records of where someone’s cell phone has been.
+          {% endtrans %}
+        </p>
+        <p>
+          {% trans europe='https://blog.mozilla.org/netpolicy/2018/04/24/mozilla-publishes-recommendations-on-government-vulnerability-disclosure-in-europe/',
+                   recommendations='https://www.ceps.eu/publications/software-vulnerability-disclosure-europe-technology-policies-and-legal-challenges' %}
+          We also continued our engagement with European stakeholders around <a href="{{ europe }}">government vulnerability disclosure in Europe</a>, including through our participation in the Centre for European Policy Studies Task Force on Software Vulnerability Disclosure which published its <a href="{{ recommendations }}">recommendations</a> in June.
+          {% endtrans %}
+        </p>
+        <p>
+          {% trans reform='https://blog.mozilla.org/netpolicy/2018/06/22/jurivote/',
+                   illegal='https://blog.mozilla.org/netpolicy/2018/03/30/effective-rights-protective-procedures-tackling-illegal-content-mozilla-files-comment-european-commission/' %}
+          We were also deeply engaged on other fronts in Europe, including <a href="{{ reform }}">pushing for better copyright reform</a>, filing on the <a href="{{ illegal }}">European Commission’s consultation on illegal content</a>, fighting for additional protections as part of the EU’s E-Evidence proposal around cross-border data access, and engaging on discussions about the EU’s terrorist content regulation.
+          {% endtrans %}
+        </p>
+
+        <h3>{{ _('Threat Indicators &amp; Data Disclosures') }}</h3>
+        <table class="data-table">
+          <thead>
+            <tr>
+              <th scope="col">{{ _('Type of Disclosure') }}</th>
+              <th scope="col">{{ _('Number of Disclosures') }}</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <th scope="row"><a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-threat-indicator' }}">{{ _('Cybersecurity Threat Indicator') }}</a></th>
+              <td>0</td>
+            </tr>
+            <tr>
+              <th scope="row">{{ _('Other <a href="%s">Specific User</a> Data Disclosure')|format(url('mozorg.about.policy.transparency.index') + '#dfn-specific-user') }}</th>
+              <td>0</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+  {% endblock %}
+
+  {% block report_nav %}
+    <aside class="section nav-block">
+      <nav class="content nav-report two-up">
+        <ul>
+          <li><a class="button" href="{{ url('mozorg.about.policy.transparency.index') + '#faq' }}">{{ _('FAQ') }}</a></li>
+          <li><a class="button" href="{{ url('mozorg.about.policy.transparency.index') + '#definitions' }}">{{ _('Definitions') }}</a></li>
+        </ul>
+      </nav>
+
+      {% include 'mozorg/about/policy/transparency/includes/past-reports.html' %}
+    </aside>
+  {% endblock %}

--- a/bedrock/mozorg/templates/mozorg/about/policy/transparency/jan-jun-2018.html
+++ b/bedrock/mozorg/templates/mozorg/about/policy/transparency/jan-jun-2018.html
@@ -39,14 +39,14 @@
               <th scope="row">
                 <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-subpoena' }}">{{ _('Subpoenas') }}</a>
               </th>
-              <td>1<sup><a href="#footnote-1">2</a></sup></td>
+              <td>1<sup><a href="#footnote-1">1</a></sup></td>
               <td>{{ _('No') }}</td>
             </tr>
             <tr>
               <th scope="row">
                 <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-court-order' }}">{{ _('Court Orders') }}</a>
               </th>
-              <td>1<sup><a href="#footnote-1">3</a></sup></td>
+              <td>1<sup><a href="#footnote-2">2</a></sup></td>
               <td>{{ _('No') }}</td>
             </tr>
             <tr>
@@ -72,7 +72,7 @@
             </tr>
             <tr>
               <th scope="row">
-                <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-natl-security-request' }}">{{ _('National Security Requests') }}</a> <sup><a href="#footnote-1">1</a></sup>
+                <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-natl-security-request' }}">{{ _('National Security Requests') }}</a> <sup><a href="#footnote-3">3</a></sup>
               </th>
               <td>0</td>
               <td>{{ _('N/A') }}</td>
@@ -82,13 +82,13 @@
 
         <aside class="footnotes">
           <section id="footnote-1">
-            <p>{{ _('1. None of the Mozilla Foundation, Mozilla Corporation or Pocket have ever received a National Security Request.') }}</p>
+            <p>{{ _('1. Issued to Mozilla Corporation in connection with Pocket.') }}</p>
           </section>
           <section id="footnote-2">
-            <p>{{ _('2. Issued to Mozilla Corporation in connection with Pocket.') }}</p>
+            <p>{{ _('2. Issued to Mozilla Corporation.') }}</p>
           </section>
           <section id="footnote-3">
-            <p>{{ _('3. Issued to Mozilla Corporation.') }}</p>
+            <p>{{ _('3. None of the Mozilla Foundation, Mozilla Corporation or Pocket have ever received a National Security Request.') }}</p>
           </section>
         </aside>
       </div>

--- a/bedrock/mozorg/templates/mozorg/about/policy/transparency/jan-jun-2018.html
+++ b/bedrock/mozorg/templates/mozorg/about/policy/transparency/jan-jun-2018.html
@@ -83,7 +83,11 @@
         <aside class="footnotes">
           <section id="footnote-1">
             <p>{{ _('1. None of the Mozilla Foundation, Mozilla Corporation or Pocket have ever received a National Security Request.') }}</p>
+          </section>
+          <section id="footnote-2">
             <p>{{ _('2. Issued to Mozilla Corporation in connection with Pocket.') }}</p>
+          </section>
+          <section id="footnote-3">
             <p>{{ _('3. Issued to Mozilla Corporation.') }}</p>
           </section>
         </aside>

--- a/bedrock/mozorg/templates/mozorg/about/policy/transparency/jan-jun-2018.html
+++ b/bedrock/mozorg/templates/mozorg/about/policy/transparency/jan-jun-2018.html
@@ -39,14 +39,14 @@
               <th scope="row">
                 <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-subpoena' }}">{{ _('Subpoenas') }}</a>
               </th>
-              <td>1<sub>[2]</sub></td>
+              <td>1<sup><a href="#footnote-1">2</a></sup></td>
               <td>{{ _('No') }}</td>
             </tr>
             <tr>
               <th scope="row">
                 <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-court-order' }}">{{ _('Court Orders') }}</a>
               </th>
-              <td>1<sub>[3]</sub></td>
+              <td>1<sup><a href="#footnote-1">3</a></sup></td>
               <td>{{ _('No') }}</td>
             </tr>
             <tr>

--- a/bedrock/mozorg/urls.py
+++ b/bedrock/mozorg/urls.py
@@ -81,6 +81,8 @@ urlpatterns = (
          'mozorg/about/policy/transparency/jan-jun-2017.html'),
     page('about/policy/transparency/jul-dec-2017',
          'mozorg/about/policy/transparency/jul-dec-2017.html'),
+    page('about/policy/transparency/jan-jun-2018',
+         'mozorg/about/policy/transparency/jan-jun-2018.html'),
 
     page('contact', 'mozorg/contact/contact-landing.html'),
     page('contact/spaces', 'mozorg/contact/spaces/spaces-landing.html'),


### PR DESCRIPTION
## Description
Updated transparency report with [current information.](https://docs.google.com/document/d/1inLs0TpZHt2kfmaU3ODlhRWCybLl4_HhrARel5xv5W4/edit#heading=h.vvyxsb7n8bru)

**Switch config:** https://github.com/mozmeao/www-config/pull/176

## Issue / Bugzilla link
 #6479 

## Testing
https://bedrock-demo-achurchwell.oregon-b.moz.works/en-US/about/policy/transparency/