### PR TITLE
[fix #6610] Add query params to FxA sign in links.

### DIFF
--- a/bedrock/firefox/templates/firefox/accounts-2018.html
+++ b/bedrock/firefox/templates/firefox/accounts-2018.html
@@ -212,7 +212,7 @@
         <div class="show-fxa-supported-signed-out">
           {{ fxa_email_form(entrypoint='accounts-page', utm_source='accounts-page', utm_params={'campaign': 'fxa-embedded-form', 'content': 'accounts-page', 'medium': 'referral'}, button_class='mzp-c-button mzp-t-primary mzp-t-download', button_text=_('Create an Account')) }}
 
-          <p class="fxa-signin">{{ _('Already have an account?') }} <a href="https://accounts.firefox.com/signin">{{ _('Sign In') }}</a></p>
+          <p class="fxa-signin">{{ _('Already have an account?') }} <a href="https://accounts.firefox.com/?action=email&service=sync&context=fx_desktop_v3&entrypoint=accounts-page&utm_content=%2Ffirefox%2Faccounts%2F&utm_campaign=fxa-embedded-form&utm_source=accounts-page">{{ _('Sign In') }}</a></p>
         </div>
       </div>
 

--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx64-base.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx64-base.html
@@ -63,7 +63,7 @@
   ) %}
   <p class="show-fxa-supported-signed-out">
     <a href="https://accounts.firefox.com/signup?service=sync&context=fx_desktop_v3&entrypoint=mozilla.org-fx.wnp64&utm_content=%2Ffirefox%2FWNP%2F64%2F&utm_campaign=wnp64&utm_source=wnp-64" class="mzp-c-button mzp-t-download">{{ button_create }}</a><br>
-    <span class="wn64-signin">{{ login_desc }} <a href="https://accounts.firefox.com/signin">{{ login_link }}</a></span>
+    <span class="wn64-signin">{{ login_desc }} <a href="https://accounts.firefox.com/?action=email&service=sync&context=fx_desktop_v3&entrypoint=mozilla.org-fx.wnp64&utm_content=%2Ffirefox%2FWNP%2F64%2F&utm_campaign=wnp64&utm_source=wnp-64">{{ login_link }}</a></span>
   </p>
   {% endcall %}
   {% call hero(
@@ -110,7 +110,7 @@
   ) %}
     <p>
       <a href="https://accounts.firefox.com/signup?service=sync&context=fx_desktop_v3&entrypoint=mozilla.org-fx.wnp64&utm_content=%2Ffirefox%2FWNP%2F64%2F&utm_campaign=wnp64&utm_source=wnp-64" class="mzp-c-button mzp-t-download">{{ button_create }}</a><br>
-      <span class="wn64-signin">{{ login_desc }} <a href="https://accounts.firefox.com/signin">{{ login_link }}</a></span>
+      <span class="wn64-signin">{{ login_desc }} <a href="https://accounts.firefox.com/?action=email&?service=sync&context=fx_desktop_v3&entrypoint=mozilla.org-fx.wnp64&utm_content=%2Ffirefox%2FWNP%2F64%2F&utm_campaign=wnp64&utm_source=wnp-64">{{ login_link }}</a></span>
     </p>
   {% endcall %}
 


### PR DESCRIPTION
## Description

Add query params to FxA sign in links, specifically `service=sync` so the user is actually signed in to Sync.

## Issue / Bugzilla link

https://github.com/mozilla/bedrock/issues/6610

## Testing

Ensure querystring for `accounts-2018.html` is accurate/good enough for now.

Ensure adding this querystring won't negatively impact any user flow (e.g. user's not using Firefox).
