### PR TITLE
[fix #6610] Fix typo in FxA querystring.

### DIFF
--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx64-base.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx64-base.html
@@ -110,7 +110,7 @@
   ) %}
     <p>
       <a href="https://accounts.firefox.com/signup?service=sync&context=fx_desktop_v3&entrypoint=mozilla.org-fx.wnp64&utm_content=%2Ffirefox%2FWNP%2F64%2F&utm_campaign=wnp64&utm_source=wnp-64" class="mzp-c-button mzp-t-download">{{ button_create }}</a><br>
-      <span class="wn64-signin">{{ login_desc }} <a href="https://accounts.firefox.com/?action=email&?service=sync&context=fx_desktop_v3&entrypoint=mozilla.org-fx.wnp64&utm_content=%2Ffirefox%2FWNP%2F64%2F&utm_campaign=wnp64&utm_source=wnp-64">{{ login_link }}</a></span>
+      <span class="wn64-signin">{{ login_desc }} <a href="https://accounts.firefox.com/?action=email&service=sync&context=fx_desktop_v3&entrypoint=mozilla.org-fx.wnp64&utm_content=%2Ffirefox%2FWNP%2F64%2F&utm_campaign=wnp64&utm_source=wnp-64">{{ login_link }}</a></span>
     </p>
   {% endcall %}
 


### PR DESCRIPTION
## Description

## Issue / Bugzilla link

## Testing
