### PR TITLE
[fix #6609] Enclose string for l10n on CPG reporting page

### DIFF
--- a/bedrock/mozorg/templates/mozorg/about/governance/policies/reporting.html
+++ b/bedrock/mozorg/templates/mozorg/about/governance/policies/reporting.html
@@ -149,7 +149,7 @@
 
   <h2>{{ _('What happens after the Report is filed') }}</h2>
 
-  <h3>Investigation</h3>
+  <h3>{{ _('Investigation') }}</h3>
   <p>
   {% trans %}
     Reports are handled discretely and privately, and will only be shared with the people who can investigate, respond, and advise. As part of this investigation, it may be necessary for some information to be disclosed to others, for example to key stakeholders administering communities or events, witnesses, and the wrongdoer.


### PR DESCRIPTION
## Description
Missed a string: "Investigation" on line 152.

## Issue / Bugzilla link
#6609 