### PR TITLE
[#6586] Add win10 taskbar pinning funnelcake experiment

### DIFF
--- a/bedrock/firefox/templates/firefox/new/scene1.html
+++ b/bedrock/firefox/templates/firefox/new/scene1.html
@@ -20,6 +20,10 @@
       {{ js_bundle('firefox_new_scene1_fx_experiment_y') }}
     {% endif %}
   {% endif %}
+
+  {% if switch('experiment_firefox_new_win10_taskbar_funnelcake', ['en-US']) %}
+    {{ js_bundle('experiment_firefox_new_win10_taskbar_funnelcake') }}
+  {% endif %}
 {% endblock %}
 
 {% block body_id %}firefox-new-scene1{% endblock %}

--- a/media/js/firefox/new/experiment-win10-taskbar-funnelcake.js
+++ b/media/js/firefox/new/experiment-win10-taskbar-funnelcake.js
@@ -1,0 +1,27 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+(function(Mozilla) {
+    'use strict';
+
+    var ua = navigator.userAgent;
+    var isLikeFirefox = /Iceweasel|IceCat|SeaMonkey|Camino|like\ Firefox/i.test(ua);
+    var isFirefox = /\s(Firefox|FxiOS)/.test(ua) && !isLikeFirefox;
+
+    var isWin10 = (ua.indexOf('Windows NT 10') > -1);
+    var isWin64 = (ua.indexOf('WOW64') > -1 || ua.indexOf('Win64') > -1);
+
+    if (window.site.platform === 'windows' && isWin10 && isWin64 && !isFirefox) {
+        var mclane = new Mozilla.TrafficCop({
+            id: 'experiment_win10_taskbar_funnelcake',
+            variations: {
+                'f=138': 9, // control build
+                'f=139': 9  // taskbar build
+            }
+        });
+
+        mclane.init();
+    }
+
+})(window.Mozilla);

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -1093,6 +1093,14 @@
     },
     {
       "files": [
+        "js/base/mozilla-traffic-cop.js",
+        "js/base/mozilla-client.js",
+        "js/firefox/new/experiment-win10-taskbar-funnelcake.js"
+      ],
+      "name": "experiment_firefox_new_win10_taskbar_funnelcake"
+    },
+    {
+      "files": [
         "js/base/mozilla-modal.js",
         "js/base/mozilla-fxa.js",
         "js/base/mozilla-fxa-init.js",


### PR DESCRIPTION
## Description
Adds a funnelcake experiment to /new targeting Windows 10 and en-US, with a 50/50 split between funnelcake builds 138 (control) and 139 (the experiment).

## Issue / Bugzilla link
#6586
https://bugzilla.mozilla.org/show_bug.cgi?id=1493595

## Testing
