### PR TITLE
Fix broken download test

### DIFF
--- a/tests/functional/test_download_l10n.py
+++ b/tests/functional/test_download_l10n.py
@@ -37,8 +37,6 @@ def test_localized_download_links(path, base_url):
     soup = BeautifulSoup(r.content, 'html.parser')
     table = soup.find('table', class_='build-table')
     urls = [a['href'] for a in table.find_all('a')]
-    # Bug 1513622 skip broken fennec link until bug is resolved
-    urls = [url for url in urls if 'product=fennec-beta-latest' not in url]
     assert urls
     for url in urls:
         r = requests.head(url, allow_redirects=True)


### PR DESCRIPTION
## Description
Test is failing on [master](https://ci.us-west.moz.works/blue/organizations/jenkins/bedrock_multibranch_pipeline/detail/master/1398/pipeline/) because `urls` is returning an empty array since it removes all links for `/firefox/android/beta/all/`.

## Issue / Bugzilla link
https://github.com/mozilla/bedrock/pull/6597

## Testing
- Bug 1513622 seems fixed, so I think we can just remove this line entirely now.