### PR TITLE
Revert to jQuery DOM ready handler in core-datalayer-init.js (Fixes #6624)

### DIFF
--- a/media/js/base/core-datalayer-init.js
+++ b/media/js/base/core-datalayer-init.js
@@ -3,7 +3,8 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 // init core dataLayer object and push into dataLayer
-(function() {
+// This needs to happen on DOM ready for UITour (see https://github.com/mozilla/bedrock/issues/6624).
+$(function() {
     var analytics = Mozilla.Analytics;
     var client = Mozilla.Client;
     var dataLayer = window.dataLayer = window.dataLayer || [];
@@ -48,4 +49,4 @@
     }
 
     analytics.updateDataLayerPush();
-})();
+});


### PR DESCRIPTION
## Description
- Reverts removal of jQuery ready handler from `core-data-layer-init.js`. It seems like running this code prior to DOM ready was causing some weird race condition when querying UITour 😕. 

We'll have to be a bit more careful when testing removing jQuery from this file in the future. For now, this just reverts the change.

## Issue / Bugzilla link
#6624

## Testing
- [ ] When signed into FxA, visiting pages like `/firefox/accounts/` and `/firefox/64.0/whatsnew/` should consistently show the correct state.