### PR TITLE
Reindex /firefox/all/ (Fixes #6531)

### DIFF
--- a/bedrock/firefox/templates/firefox/all.html
+++ b/bedrock/firefox/templates/firefox/all.html
@@ -1,9 +1,6 @@
 {% from "product-all-macros.html" import build_search_box, build_table, build_row, build_link with context %}
 {% extends "firefox/base-resp.html" %}
 
-{# "noindex" pages should not have the canonical or hreflang tags: bug 1442331 #}
-{% block canonical_urls %}<meta name="robots" content="noindex,follow">{% endblock %}
-
 {% block page_title %}
   {%- if platform == 'android' -%}
     {{ _('Download %s for Android in your language')|format(channel_label) }}


### PR DESCRIPTION
## Description
- Remove noindex from `/firefox/all/` pages.

## Issue / Bugzilla link
#6531

## Testing
