### PR TITLE
Separate fr and de locales in pre-download experiment (Fixes #6634)

### DIFF
--- a/bedrock/firefox/templates/firefox/home.html
+++ b/bedrock/firefox/templates/firefox/home.html
@@ -21,7 +21,10 @@
   {% if switch('experiment-firefox-home-pre-download', ['en-US', 'en-GB', 'en-CA', 'en-ZA']) %}
     {{ js_bundle('experiment-firefox-home-pre-download') }}
   {% endif %}
-  {% if switch('experiment-firefox-home-pre-download-locales', ['de', 'fr']) %}
+  {% if switch('experiment-firefox-home-pre-download-fr', ['fr']) %}
+    {{ js_bundle('experiment-firefox-home-pre-download-locales') }}
+  {% endif %}
+  {% if switch('experiment-firefox-home-pre-download-de', ['de']) %}
     {{ js_bundle('experiment-firefox-home-pre-download-locales') }}
   {% endif %}
 {% endblock %}


### PR DESCRIPTION
## Description
- Places `fr` and `de` pre-download experiment locales behind separate switches so that we can shut each off independently.

**Note:** this PR should not be merged before https://github.com/mozmeao/www-config/pull/175 is order for the experiment to continue running without interruption.

## Issue / Bugzilla link
#6634
