### PR TITLE
[fix #6580] Updating fundraising banner copy

### DIFF
--- a/bedrock/mozorg/templates/mozorg/home/includes/fundraiser-eoy2018.html
+++ b/bedrock/mozorg/templates/mozorg/home/includes/fundraiser-eoy2018.html
@@ -6,15 +6,20 @@
   <button type="button" class="c-fundraiser-close" id="fundraiser-close"><span>{{ _('Close') }}</span></button>
   <div class="content mzp-l-content">
     <h2 class="c-fundraiser-title">
+    {% if LANG.startswith('en') %}
+      Help Mozilla defend the web.
+    {% else %}
       {{ _('We all love the web. Join Mozilla in defending it.') }}
+    {% endif %}
     </h2>
 
     <div class="c-fundraiser-content">
       <p>
       {% if LANG.startswith('en') %}
-        Let’s protect the world’s largest public resource for future
-        generations. A few times a year, Mozilla asks for donations. Chip in to
-        help us keep the web healthy, wonderful and welcoming to all.
+        The future of the internet is at stake, with new threats to our
+        online privacy and security virtually every day. Chip in today to
+        help the not-for-profit Mozilla Foundation continue its mission to
+        make the internet safe, open and accessible to all.
       {% else %}
       {#
         L10n: The "cup of coffee" item below is meant to represent an

--- a/media/css/mozorg/home/fundraiser2018.scss
+++ b/media/css/mozorg/home/fundraiser2018.scss
@@ -54,6 +54,10 @@ $image-path: '/media/protocol/img';
     @include text-display-lg;
     font-weight: normal;
     margin-bottom: $spacing-lg;
+
+    html[lang^='en'] & {
+        @include text-display-xl;
+    }
 }
 
 .c-fundraiser-amount-input {


### PR DESCRIPTION
## Description
Updates headline and body copy for the home page fundraising banner. Only for English; other locales still get the old strings.

## Issue / Bugzilla link
#6580