### PR TITLE
Fix broken trademark-permissions email link

### DIFF
--- a/bedrock/foundation/templates/foundation/trademarks/distribution-policy.html
+++ b/bedrock/foundation/templates/foundation/trademarks/distribution-policy.html
@@ -95,7 +95,7 @@
 
   <p>
     {% trans permissions="mailto:trademark-permissions@mozilla.com" %}
-    If you wish to distribute a modified version of Firefox with Mozilla trademarks please contact us with your request at <a href="{{ trademarks }}">trademark-permissions@mozilla.com</a>.
+    If you wish to distribute a modified version of Firefox with Mozilla trademarks please contact us with your request at <a href="{{ permissions }}">trademark-permissions@mozilla.com</a>.
     {% endtrans %}
   </p>
 


### PR DESCRIPTION
It looks like PR #6059 had a mistake in it. The [line with the trademark-permissions email address](https://github.com/mozilla/bedrock/blob/b13e0f962ee4e131daf94e8ce4a43ff27e538fc5/bedrock/foundation/templates/foundation/trademarks/distribution-policy.html#L98) defines the `permissions` variable which contains the email address, but then uses the `trademarks` variable instead.