### PR TITLE
(Fixes #6651) Bug fix, incorrect trademark-permissions email link

### DIFF
--- a/bedrock/foundation/templates/foundation/licensing.html
+++ b/bedrock/foundation/templates/foundation/licensing.html
@@ -45,8 +45,8 @@
     {% endtrans %}
   </p>
   <p>
-    {% trans trademarks=url('foundation.trademarks.policy'), email="mailto:trademark-permissions@mozilla.org"%}
-    For more detail on our trademark licensing, see our <a href="{{ trademarks }}">Mozilla Trademark Guidelines</a>. If you still have questions after reading the policy, please contact <a href="{{ email }}">trademark-permissions@mozilla.org</a>.
+    {% trans trademarks=url('foundation.trademarks.policy'), email="mailto:trademark-permissions@mozilla.com"%}
+    For more detail on our trademark licensing, see our <a href="{{ trademarks }}">Mozilla Trademark Guidelines</a>. If you still have questions after reading the policy, please contact <a href="{{ email }}">trademark-permissions@mozilla.com</a>.
     {% endtrans %}
   </p>
 


### PR DESCRIPTION
## Description
`trademark-permissions@mozilla.org` is the incorrect address.
`trademark-permissions@mozilla.com` is correct.

## Issue / Bugzilla link
#6651
