### PR TITLE
[fix #6592] Fix home sticky banner dismiss button

### DIFF
--- a/media/js/mozorg/home/home.js
+++ b/media/js/mozorg/home/home.js
@@ -139,12 +139,15 @@ function onYouTubeIframeAPIReady() {
         });
 
         // add button
-        var $dismissButton = $('<button>').addClass('sticky-dismiss').text('Dismiss this prompt.');
+        var $dismissButton = $('<button type="button" class="sticky-dismiss">').text('Dismiss this prompt.');
         var $stickyWrapper = $stickyCTA.find('.c-sticky-cta-wrapper');
         $dismissButton.appendTo($stickyWrapper);
-        // listen for click
-        $dismissButton.on('click', function() {
-        // dismiss
+
+        // find all the buttons
+        var dismissButtons = $('.sticky-dismiss');
+        // listen for the click
+        dismissButtons.on('click', function() {
+            // dismiss the sticky banner
             dismissStickyCTA(primaryTop);
         });
     }


### PR DESCRIPTION
## Description
The script was only attaching the click event to the latest matching button (the last one appended to the DOM) so the first button had no event. This uses a jQuery selector to attach the click to all matching buttons. 

## Issue / Bugzilla link
#6592 

## Testing
The sticky banners are currently hidden because of the fundraising banner. To bring them back locally you'll need to remove the `{% if not switch('fundraising-eoy2018') %}` conditions around each sticky banner in `home-en.html`

Firefox shows the accounts CTA and all other browsers show the download CTA so you'll need to test in different browsers. Both sticky banners should be dismissed when you click the X. It sets a cookie named `sticky-home-cta-dismissed` so you'll need to delete that cookie to get the banner back.
