### PR TITLE
(Fixes #6643) Replace modal with app store buttons for mobile.

### DIFF
--- a/bedrock/firefox/templates/firefox/mobile.html
+++ b/bedrock/firefox/templates/firefox/mobile.html
@@ -75,7 +75,7 @@
               </div>
 
               <div class="header-product-ctas">
-                <a href="#mobile-download-buttons-firefox" class="button button-green get-firefox" data-product="firefox" data-button-name="Send to SMS Modal - Firefox Mobile">{{ _('Get Firefox') }}</a>
+                <button type="button" class="button button-green get-firefox" data-product="firefox" data-button-name="Send to SMS Modal - Firefox Mobile">{{ _('Get Firefox') }}</button>
                 <br>
                 <a href="#firefox" class="see-more">{{ _('See more') }}</a>
               </div>
@@ -114,7 +114,7 @@
               </div>
 
               <div class="header-product-ctas">
-                <a href="#mobile-download-buttons-focus" class="button button-green get-focus" data-product="focus" data-button-name="Send to SMS Modal - Firefox Focus">{{ _('Get Firefox Focus') }}</a>
+                <button type="button" class="button button-green get-focus" data-product="focus" data-button-name="Send to SMS Modal - Firefox Focus">{{ _('Get Firefox Focus') }}</button>
                 <br>
                 <a href="#focus" class="see-more">{{ _('See more') }}</a>
               </div>

--- a/bedrock/firefox/templates/firefox/mobile.html
+++ b/bedrock/firefox/templates/firefox/mobile.html
@@ -61,6 +61,19 @@
                 {{ _('Full-featured. Customizable. Lightning fast. Browse without compromise.') }}
               </p>
 
+              <div class="mobile-download-buttons-wrapper">
+                <ul class="mobile-download-buttons firefox" id="mobile-download-buttons-firefox">
+                  <li class="android">
+                    {{ google_play_button(href='https://app.adjust.com/2uo1qc?campaign=desktop_xp&amp;adgroup=Google_Play_Store&amp;creative=badge_en', id='playStoreLink') }}
+                  </li>
+                  <li class="ios">
+                    <a id="appStoreLink" href="https://app.adjust.com/2uo1qc?campaign=desktop_xp&amp;adgroup=iOS_App_Store&amp;creative=badge_en&amp;fallback=https%3A%2F%2Fitunes.apple.com%2Fapp%2Fapple-store%2Fid989804926%3Fpt%3D373246%26ct%3Dadjust_tracker%26mt%3D8" data-link-type="download" data-download-os="iOS">
+                      <img src="{{ l10n_img('firefox/ios/btn-app-store.svg') }}" alt="{{ _('Download on the App Store') }}" width="152" height="45">
+                    </a>
+                  </li>
+                </ul>
+              </div>
+
               <div class="header-product-ctas">
                 <a href="#mobile-download-buttons-firefox" class="button button-green get-firefox" data-product="firefox" data-button-name="Send to SMS Modal - Firefox Mobile">{{ _('Get Firefox') }}</a>
                 <br>
@@ -81,6 +94,24 @@
               <p>
                 {{ _('Automatic ad blocking and tracking protection on an easy-to-use private browser.') }}
               </p>
+
+              <div class="mobile-download-buttons-wrapper">
+                <ul class="mobile-download-buttons focus" id="mobile-download-buttons-focus">
+                  <li class="android">
+                    {{ google_play_button(href=settings.GOOGLE_PLAY_FIREFOX_FOCUS_LINK, id='playStoreLink', product='Focus') }}
+                  </li>
+                  {% if l10n_has_tag('focus_apk_link_012018') %}
+                  <li class="android-apk">
+                      <a href="https://archive.mozilla.org/pub/android/focus/latest/" data-link-type="download" data-download-os="Android">{{ _('Download the APK') }}</a>
+                  </li>
+                  {% endif %}
+                  <li class="ios">
+                    <a id="appStoreLink" href="{{ settings.APPLE_APPSTORE_FIREFOX_FOCUS_LINK }}" data-link-type="download" data-download-os="iOS">
+                      <img src="{{ l10n_img('firefox/ios/btn-app-store.svg') }}" alt="{{ _('Download on the App Store') }}" width="152" height="45">
+                    </a>
+                  </li>
+                </ul>
+              </div>
 
               <div class="header-product-ctas">
                 <a href="#mobile-download-buttons-focus" class="button button-green get-focus" data-product="focus" data-button-name="Send to SMS Modal - Firefox Focus">{{ _('Get Firefox Focus') }}</a>
@@ -342,37 +373,6 @@
       </div>{#--/#focus-features--#}
     </article>
 
-    <aside id="mobile-download-buttons-wrapper">
-      <strong>{{ _('Firefox') }}</strong>
-      <ul class="mobile-download-buttons firefox" id="mobile-download-buttons-firefox">
-        <li class="android">
-          {{ google_play_button(href='https://app.adjust.com/2uo1qc?campaign=desktop_xp&amp;adgroup=Google_Play_Store&amp;creative=badge_en', id='playStoreLink') }}
-        </li>
-        <li class="ios">
-          <a id="appStoreLink" href="https://app.adjust.com/2uo1qc?campaign=desktop_xp&amp;adgroup=iOS_App_Store&amp;creative=badge_en&amp;fallback=https%3A%2F%2Fitunes.apple.com%2Fapp%2Fapple-store%2Fid989804926%3Fpt%3D373246%26ct%3Dadjust_tracker%26mt%3D8" data-link-type="download" data-download-os="iOS">
-            <img src="{{ l10n_img('firefox/ios/btn-app-store.svg') }}" alt="{{ _('Download on the App Store') }}" width="152" height="45">
-          </a>
-        </li>
-      </ul>
-
-      <strong>{{ _('Firefox Focus') }}</strong>
-      <ul class="mobile-download-buttons focus" id="mobile-download-buttons-focus">
-        <li class="android">
-          {{ google_play_button(href=settings.GOOGLE_PLAY_FIREFOX_FOCUS_LINK, id='playStoreLink', product='Focus') }}
-        </li>
-        {% if l10n_has_tag('focus_apk_link_012018') %}
-        <li class="android-apk">
-            <a href="https://archive.mozilla.org/pub/android/focus/latest/" data-link-type="download" data-download-os="Android">{{ _('Download the APK') }}</a>
-        </li>
-        {% endif %}
-        <li class="ios">
-          <a id="appStoreLink" href="{{ settings.APPLE_APPSTORE_FIREFOX_FOCUS_LINK }}" data-link-type="download" data-download-os="iOS">
-            <img src="{{ l10n_img('firefox/ios/btn-app-store.svg') }}" alt="{{ _('Download on the App Store') }}" width="152" height="45">
-          </a>
-        </li>
-      </ul>
-    </aside>
-
     {#
       L10n: The content below is intended to be shown in a modal window when clicking any of the
       'Download' buttons above. Depending on the button clicked, the content below will either
@@ -415,7 +415,6 @@
           </div>
         </div>
 
-        <div id="modal-mobile-download-buttons-wrapper"></div>
       </div>{#--/#modal-wrapper--#}
     </div>{#--/#modal-outer-wrapper--#}
   </main>

--- a/media/css/firefox/mobile.scss
+++ b/media/css/firefox/mobile.scss
@@ -871,38 +871,42 @@ html[dir="rtl"] {
 }
 
 // very basic styling for no-JS visitors
-.mobile-download-buttons-wrapper {
-    background: #111;
-    color: #fff;
-    padding: 20px 0;
-    text-align: center;
-}
-
-.mobile-download-buttons {
-    margin: 1em 0;
-
-    @media #{$mq-phone-wide} {
-        @supports (display: flex) {
-            align-items: center;
-            display: flex;
-            justify-content: space-between;
-            margin: 1em auto;
-            width: 340px;
-
-            &.hidden {
-                display: none;
-            }
-
-            li {
-                margin: 0 auto; // so that a single item is centred
-            }
-        }
+.no-js {
+    .header-product-ctas {
+        display: none;
     }
 
-    .android-apk a {
-        display: inline-block;
-        margin: 10px 0;
-        @include font-size-level5;
+    .mobile-download-buttons-wrapper {
+        display: block;
+        text-align: center;
+    }
+
+    .mobile-download-buttons {
+        margin: 1em 0;
+
+        @media #{$mq-phone-wide} {
+            @supports (display: flex) {
+                align-items: center;
+                display: flex;
+                flex-direction: column;
+                margin: 1em auto;
+                width: 340px;
+
+                &.hidden {
+                    display: none;
+                }
+
+                li {
+                    margin: 0 auto; // so that a single item is centred
+                }
+            }
+        }
+
+        .android-apk a {
+            display: inline-block;
+            margin: 10px 0;
+            @include font-size-level5;
+        }
     }
 }
 
@@ -1098,5 +1102,4 @@ body[data-modal-product='focus'] #modal .window .inner {
 .ios .mobile-download-buttons .android-apk {
     display: none;
 }
-
 

--- a/media/css/firefox/mobile.scss
+++ b/media/css/firefox/mobile.scss
@@ -871,7 +871,7 @@ html[dir="rtl"] {
 }
 
 // very basic styling for no-JS visitors
-#mobile-download-buttons-wrapper {
+.mobile-download-buttons-wrapper {
     background: #111;
     color: #fff;
     padding: 20px 0;
@@ -1065,26 +1065,26 @@ body[data-modal-product='focus'] #modal .window .inner {
     }
 }
 
-// hide app store badges in modal by default
-#modal-mobile-download-buttons-wrapper {
+// hide app store badges by default
+.mobile-download-buttons-wrapper {
     display: none;
     margin-top: 60px;
-
-    @media #{$mq-desktop} {
-        margin-top: 100px;
-    }
 }
 
 // for android/iOS, hide widget/QR code in favor of app store badges
 .android,
 .ios {
-    #modal-mobile-download-buttons-wrapper {
+    .mobile-download-buttons-wrapper {
         display: block;
     }
 
     .qr-code-wrapper,
     #modal-wrapper .desktop-download,
     #send-to-device {
+        display: none;
+    }
+
+    .header-product-ctas {
         display: none;
     }
 }
@@ -1099,10 +1099,4 @@ body[data-modal-product='focus'] #modal .window .inner {
     display: none;
 }
 
-// hide page-level app store badge wrapper if JS is available
-// (badges get moved into modal)
-.js {
-    #mobile-download-buttons-wrapper {
-        display: none;
-    }
-}
+

--- a/media/js/firefox/mobile/mobile.js
+++ b/media/js/firefox/mobile/mobile.js
@@ -6,7 +6,6 @@
     'use strict';
 
     var $body = $('body');
-    var $mobileDownloadButtons = $('.mobile-download-buttons').remove();
     var $modalContents = $('#modal-wrapper');
 
     function openModal(e) {
@@ -25,9 +24,6 @@
 
         Mozilla.Modal.createModal(this, $modalContents);
     }
-
-    // move app store badges inside modal
-    $('#modal-mobile-download-buttons-wrapper').append($mobileDownloadButtons);
 
     // clicking any download-looking button opens the modal
     $('.get-firefox, .get-focus').attr('role', 'button').on('click', openModal);


### PR DESCRIPTION
## Description
Refactors firefox/mobile mobile view to see app store buttons instead of modal.

## Issue / Bugzilla link
#6643 