### PR TITLE
Serve 64bit funnelcake to Win10 taskbar experiment visitors (Issue #6586)

### DIFF
--- a/bedrock/firefox/templates/firefox/new/scene2.html
+++ b/bedrock/firefox/templates/firefox/new/scene2.html
@@ -161,6 +161,9 @@
   {% if show_newsletter %}
     {{ js_bundle('firefox_new_scene2_email') }}
   {% endif %}
+  {% if switch('experiment_firefox_new_win10_taskbar_funnelcake', ['en-US']) and funnelcake_id in ['138', '139'] %}
+    {{ js_bundle('experiment_firefox_new_win10_taskbar_funnelcake_scene2') }}
+  {% endif %}
   {# Keep download JS in a separate bundle to email JS, to reduce risk of errors interrupting download. #}
   {{ js_bundle('firefox_new_scene2') }}
 {% endblock %}

--- a/media/js/firefox/new/experiment-win10-taskbar-funnelcake-scene2.js
+++ b/media/js/firefox/new/experiment-win10-taskbar-funnelcake-scene2.js
@@ -1,0 +1,15 @@
+(function() {
+    'use strict';
+
+    // update dl link for windows to point to win64
+    // same selector from canonical scene2.js
+    var $platformLink = $('#download-button-wrapper-desktop .download-list .os_win .download-link');
+
+    if ($platformLink.length) {
+        // the bouncer URL needed for the win64 funnelcake is the same as the
+        // win32 URL, but with os=win replaced with os=win64, e.g.
+        // https://download.mozilla.org/?product=firefox-stub-f138&os=win64&lang={accepted-lang}
+        var newHref = $platformLink.attr('href').replace('os=win&', 'os=win64&');
+        $platformLink.attr('href', newHref);
+    }
+})();

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -1101,6 +1101,12 @@
     },
     {
       "files": [
+        "js/firefox/new/experiment-win10-taskbar-funnelcake-scene2.js"
+      ],
+      "name": "experiment_firefox_new_win10_taskbar_funnelcake_scene2"
+    },
+    {
+      "files": [
         "js/base/mozilla-modal.js",
         "js/base/mozilla-fxa.js",
         "js/base/mozilla-fxa-init.js",


### PR DESCRIPTION
## Description
- Serves 64bit funnelcake build for Windows to visitors who hit the following URLs:
  - `/firefox/download/thanks/?f=138`
  - `/firefox/download/thanks/?f=139`

Disclaimer: code here is based on what we did for #4922

## Issue / Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1493595
https://bugzilla.mozilla.org/show_bug.cgi?id=1517138
https://github.com/mozilla/bedrock/issues/6586

## Testing
- [ ] Visiting the above URLs on Windows should result in a 64bit file download.