### PR TITLE
Remove Dec 2018 Transparency Report switch

### DIFF
--- a/bedrock/mozorg/templates/mozorg/about/policy/transparency/includes/past-reports.html
+++ b/bedrock/mozorg/templates/mozorg/about/policy/transparency/includes/past-reports.html
@@ -9,9 +9,7 @@
     <nav>
       <h3>{{ _('Previous Reports') }}</h3>
       <ul>
-        {% if switch('transparency_report_dec_2018') %}
         <li><a href="{{ url('mozorg.about.policy.transparency.jul-dec-2017') }}">{{ _('July-December 2017') }}</a></li>
-        {% endif %}
         <li><a href="{{ url('mozorg.about.policy.transparency.jan-jun-2017') }}">{{ _('January-June 2017') }}</a></li>
         <li><a href="{{ url('mozorg.about.policy.transparency.jul-dec-2016') }}">{{ _('July-December 2016') }}</a></li>
         <li><a href="{{ url('mozorg.about.policy.transparency.jan-jun-2016') }}">{{ _('January-June 2016') }}</a></li>

--- a/bedrock/mozorg/templates/mozorg/about/policy/transparency/includes/reports-nav.html
+++ b/bedrock/mozorg/templates/mozorg/about/policy/transparency/includes/reports-nav.html
@@ -4,10 +4,6 @@
           <li><a class="button" href="{{ url('mozorg.about.policy.transparency.index') + '#definitions' }}">{{ _('Definitions') }}</a></li>
           {# This link should point to the latest report. Past reports are added to 'includes/past-reports.html' #}
           {# There are also links in the faq that need to be updated to point to the latest report. #}
-          {% if switch('transparency_report_dec_2018') %}
           <li><a class="button" href="{{ url('mozorg.about.policy.transparency.jan-jun-2018') }}">{{ _('January-June 2018 Report') }}</a></li>
-          {% else %}
-          <li><a class="button" href="{{ url('mozorg.about.policy.transparency.jul-dec-2017') }}">{{ _('July-December 2017 Report') }}</a></li>
-          {% endif %}
         </ul>
       </nav>

--- a/bedrock/mozorg/templates/mozorg/about/policy/transparency/index.html
+++ b/bedrock/mozorg/templates/mozorg/about/policy/transparency/index.html
@@ -53,27 +53,14 @@
             <div data-accordion-role="tabpanel">
               <p>
                 {# NOTE: Remember to update these links when publishing a new report. #}
-                {% if switch('transparency_report_dec_2018') %}
-                  {% set link_userdata=url('mozorg.about.policy.transparency.jan-jun-2018') + '#government-user-data' %}
-                  {% set link_removal=url('mozorg.about.policy.transparency.jan-jun-2018') + '#government-content-removal' %}
-                  {% set link_copytrade=url('mozorg.about.policy.transparency.jan-jun-2018') + '#copyright-trademark' %}
-                  {% set link_supplement=url('mozorg.about.policy.transparency.jan-jun-2018') + '#supplement' %}
-                {% else %}
-                  {% set link_userdata=url('mozorg.about.policy.transparency.jul-dec-2017') + '#government-user-data' %}
-                  {% set link_removal=url('mozorg.about.policy.transparency.jul-dec-2017') + '#government-content-removal' %}
-                  {% set link_copytrade=url('mozorg.about.policy.transparency.jul-dec-2017') + '#copyright-trademark' %}
-                  {% set link_supplement=url('mozorg.about.policy.transparency.jul-dec-2017') + '#supplement' %}
-                {% endif %}
+                {% set link_userdata=url('mozorg.about.policy.transparency.jan-jun-2018') + '#government-user-data' %}
+                {% set link_removal=url('mozorg.about.policy.transparency.jan-jun-2018') + '#government-content-removal' %}
+                {% set link_copytrade=url('mozorg.about.policy.transparency.jan-jun-2018') + '#copyright-trademark' %}
+                {% set link_supplement=url('mozorg.about.policy.transparency.jan-jun-2018') + '#supplement' %}
 
-                {% if switch('transparency_report_dec_2018') %}
                 {% trans %}
                   This report covers the Mozilla Foundation, Mozilla Corporation, and Pocket (from 2018). We report on <a href="{{ link_userdata }}">Government Demands for User Data</a>, <a href="{{ link_removal }}">Government Requests for Content Removal</a>, and <a href="{{ link_copytrade }}">Copyright and Trademark Requests</a>. We also include a <a href="{{ link_supplement }}">Supplement</a>, which provides additional information.
                 {% endtrans %}
-                {% else %}
-                {% trans %}
-                  We report on <a href="{{ link_userdata }}">Government Demands for User Data</a>, <a href="{{ link_removal }}">Government Requests for Content Removal</a>, and <a href="{{ link_copytrade }}">Copyright and Trademark Requests</a>. We also include a <a href="{{ link_supplement }}">Supplement</a>, which provides additional information.
-                {% endtrans %}
-                {% endif %}
 
                 {{ _('With each additional report that we publish, we’ll continue to re­evaluate how we can be more transparent.') }}
               </p>


### PR DESCRIPTION
## Description
Removes transparency report switch.
www-config: https://github.com/mozmeao/www-config/pull/180

## Issue / Bugzilla link
#6665 
