### PR TITLE
(Fixes #6673) Update utm params on fxa sign up button

### DIFF
--- a/bedrock/firefox/templates/firefox/accounts-2018.html
+++ b/bedrock/firefox/templates/firefox/accounts-2018.html
@@ -22,7 +22,7 @@
       <h1 class="mzp-c-hero-title">{{ _('One log-in. Power and privacy everywhere.') }}</h1>
       <div id="hero-cta" class="mzp-c-hero-cta">
         <div class="show-fxa-supported-signed-out">
-          <a href="https://accounts.firefox.com/signup?service=sync&context=fx_desktop_v3&entrypoint=mozilla.org-button-light&utm_content=%2Ffirefox%2Faccounts%2F&utm_campaign=Create an Account" class="mzp-c-button mzp-t-primary mzp-t-download" data-button-name="Create account" data-link-type="button" data-cta-position="primary cta" id="features-hero-account">
+          <a href="https://accounts.firefox.com/signup?service=sync&context=fx_desktop_v3&entrypoint=accounts-page&utm_source=accounts-page&utm_content=accounts-page-top-cta&utm_medium=referral&utm_campaign=fxa-benefits-page" class="mzp-c-button mzp-t-primary mzp-t-download" data-button-name="Create account" data-link-type="button" data-cta-position="primary cta" id="features-hero-account">
             {{ _('Create a Firefox Account') }}
           </a>
         </div>


### PR DESCRIPTION
## Description
Update link utm params on fxa sign up bottom (top of page.)

OLD: https://accounts.firefox.com/signup?service=sync&context=fx_desktop_v3&entrypoint=mozilla.org-button-light&utm_content=%2Ffirefox%2Faccounts%2F&utm_campaign=Create%20an%20Account

NEW: https://accounts.firefox.com/signup?service=sync&context=fx_desktop_v3&entrypoint=accounts-page&utm_source=accounts-page&utm_content=accounts-page-top-cta&utm_medium=referral&utm_campaign=fxa-benefits-page

## Issue / Bugzilla link
#6673 
