### PR TITLE
Deploy stage on push to master instead of prod

### DIFF
--- a/jenkins/branches/master.yml
+++ b/jenkins/branches/master.yml
@@ -4,15 +4,11 @@ push_public_registry: true
 smoke_tests: true
 regions:
   - oregon-b
-  - iowa-a
 apps:
   - bedrock-dev
+  - bedrock-stage
 integration_tests:
   oregon-b:
     - firefox
     - headless
     - download
-  iowa-a:
-    - download
-    - firefox
-    - headless

--- a/jenkins/branches/prod.yml
+++ b/jenkins/branches/prod.yml
@@ -1,14 +1,11 @@
 # see the following for documentation of these options
 # http://bedrock.readthedocs.io/en/latest/pipeline.html#configuration
-push_public_registry: true
-smoke_tests: true
 require_tag: true
 regions:
   - oregon-b
   - frankfurt
   - iowa-a
 apps:
-  - bedrock-stage
   - bedrock-prod
 integration_tests:
   oregon-b:
@@ -21,7 +18,4 @@ integration_tests:
   frankfurt:
     - headless
   iowa-a:
-    - chrome
-    - download
-    - firefox
     - headless


### PR DESCRIPTION
## Description

Alternative to https://github.com/mozilla/bedrock/pull/6675 based on https://github.com/mozilla/bedrock/pull/6675#issuecomment-451485847

## Issue / Bugzilla link

mozmeao/infra#981

## Testing

On merge to master, look for messages in #www-notify on mozilla.slack.com for dev and stage jenkins jobs. Note that the jobs will run sequentially, not in parallel.
