### PR TITLE
Fix JS unit test error (Fixes #6681)

### DIFF
--- a/tests/unit/spec/base/mozilla-highlight-target.js
+++ b/tests/unit/spec/base/mozilla-highlight-target.js
@@ -20,12 +20,10 @@ describe('mozilla-highlight-target.js', function() {
     describe('isTargetAvailable', function() {
 
         it('should throw an error if callback is not supplied', function() {
-            it('should throw an error if no callback is provided', function() {
-                spyOn(Mozilla.UITour, 'getConfiguration');
-                expect(function() {
-                    Mozilla.HighlightTarget.isTargetAvailable();
-                }).toThrowError('isTargetAvailable: second argument is not a function');
-            });
+            spyOn(Mozilla.UITour, 'getConfiguration');
+            expect(function() {
+                Mozilla.HighlightTarget.isTargetAvailable('foo');
+            }).toThrowError('isTargetAvailable: second argument is not a function');
         });
 
         it('should return true if target is available', function() {


### PR DESCRIPTION
## Description
- Looks like this nested `it` statement was tripping up Karma on latest node versions.

## Issue / Bugzilla link
#6681

## Testing
- Running `gulp js:test` locally should still pass.