### PR TITLE
establish the use of Architectural Decision Records for bedrock

### DIFF
--- a/.adr-dir
+++ b/.adr-dir
@@ -1,0 +1,1 @@
+docs/architecture/decisions

--- a/docs/architecture/decisions/0001-record-architecture-decisions.md
+++ b/docs/architecture/decisions/0001-record-architecture-decisions.md
@@ -1,0 +1,19 @@
+# 1. Record architecture decisions
+
+Date: 2019-01-07
+
+## Status
+
+Accepted
+
+## Context
+
+We need to record the architectural decisions made on this project.
+
+## Decision
+
+We will use Architecture Decision Records, as [described by Michael Nygard](http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions).
+
+## Consequences
+
+See Michael Nygard's article, linked above. For a lightweight ADR toolset, see Nat Pryce's [adr-tools](https://github.com/npryce/adr-tools).


### PR DESCRIPTION
ADRs help us capture context around architectural decisions. 

Here's some quotes from the [blog post](http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions) (included in the first ADR as part of this PR) of why I'm interested in using them:

```
One ADR describes one significant decision for a specific project. It should be something 
that has an effect on how the rest of the project will run.
...
Developers and project stakeholders can see the ADRs, even as the team composition 
changes over time.
...
The motivation behind previous decisions is visible for everyone, present and future. 
Nobody is left scratching their heads to understand, "What were they thinking?" and 
the time to change old decisions will be clear from changes in the project's context.
```

Note that the blog post mentions `One ADR describes one ***significant*** decision for a specific project`. These aren't intended for day-to-day tweaks to bedrock. I see them being used for: infrastructure/hosting changes, changes to the bedrock CI/CD pipeline, CDN changes, etc.

Please see the blog post included in the md as well as install the `adr` cli tool.

What do you think @mozilla/meao?