### PR TITLE
[fix #6686] Correct copy in FFFY home page card

### DIFF
--- a/bedrock/mozorg/templates/mozorg/home/home-en.html
+++ b/bedrock/mozorg/templates/mozorg/home/home-en.html
@@ -117,7 +117,7 @@
           media_icon='mzp-has-video',
           title=_('We keep your data safe, never sold.'),
           ga_title='We keep your data safe, never sold.',
-          desc=_('You have the right to your own life — and your own data. Everything we make and do fights for you.'),
+          desc=_('You have the right to own your life — and your data. Everything we make and do fights for you.'),
           image_url='home/2018/cards/dec/ffyr.png',
           include_highres_image=True,
           aspect_ratio='mzp-has-aspect-16-9',


### PR DESCRIPTION
## Description
Changes the blurb in the FFFY card from "You have the right to your own life — and your own data." to "You have the right to own your life — and your data."

## Issue / Bugzilla link
#6686 
