### PR TITLE
Fix home page flicker when loading in Firefox (Fixes #6623)

### DIFF
--- a/media/js/base/site.js
+++ b/media/js/base/site.js
@@ -184,6 +184,13 @@
             h.className += ' x64';
         }
 
+        // Add class to reflect if user agent is Firefox. Cherry-picked from mozilla-client.js.
+        var isFirefox = /\s(Firefox|FxiOS)/.test(navigator.userAgent) && !/Iceweasel|IceCat|SeaMonkey|Camino|like\ Firefox/i.test(navigator.userAgent);
+
+        if (isFirefox) {
+            h.className += ' is-firefox';
+        }
+
         // Add class to reflect javascript availability for CSS
         h.className = h.className.replace(/\bno-js\b/, 'js');
     })();

--- a/media/js/firefox/facebook-container-video.js
+++ b/media/js/firefox/facebook-container-video.js
@@ -2,15 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-(function($) {
+(function() {
     'use strict';
 
-    var $html = $(document.documentElement);
     var videoPoster = new Mozilla.VideoPosterHelper('.fbcontainer-video');
-
-    if (window.Mozilla.Client.isFirefox) {
-        $html.addClass('is-firefox');
-    }
 
     function trackVideoInteraction(title, state) {
         window.dataLayer.push({
@@ -36,5 +31,5 @@
     videoPoster.init();
     initVideoInteractionTracking();
 
-})(window.jQuery);
+})();
 

--- a/media/js/mozorg/home/home.js
+++ b/media/js/mozorg/home/home.js
@@ -15,10 +15,6 @@ function onYouTubeIframeAPIReady() {
 (function($, Waypoint) {
     'use strict';
 
-    if (window.Mozilla.Client.isFirefox) {
-        document.documentElement.classList.add('is-firefox');
-    }
-
     var tag = document.createElement('script');
     tag.src = 'https://www.youtube.com/iframe_api';
     var firstScriptTag = document.getElementsByTagName('script')[0];


### PR DESCRIPTION
## Description
- Adds a global `is-firefox` class addition to `site.js` in the head of the base template.

## Issue / Bugzilla link
#6623

## Testing
- [x] Conditional home page banner should display correctly with no regressions.
- [x] Conditional FB container page content should display correctly with no regressions.
- [x] Content flicker should be gone.