### PR TITLE
Add 'id' to the list of active locales for /whatsnew 64 (bug 1508494)

### DIFF
--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -503,6 +503,7 @@ class WhatsnewView(l10n_utils.LangFilesMixin, TemplateView):
                 'en-US',
                 'es-ES',
                 'fr',
+                'id',
                 'pl',
                 'pt-BR',
                 'ru',


### PR DESCRIPTION
Fixes https://bugzilla.mozilla.org/show_bug.cgi?id=1508494#c22
