### PR TITLE
Global FxA CTA experiment for Firefox users (Fixes #6629)

### DIFF
--- a/bedrock/base/templates/base-pebbles.html
+++ b/bedrock/base/templates/base-pebbles.html
@@ -174,6 +174,13 @@
     <!--[if !lte IE 8]><!-->
     {% block js %}{% endblock %}
 
+    {# Issue issue #6629 #}
+    {% block global_fxa_cta_experiment %}
+    {% if switch('global-fxa-cta-experiment', ['en-US']) %}
+      {{ js_bundle('global-fxa-cta-experiment') }}
+    {% endif %}
+    {% endblock %}
+
     {# Bug 1381776 #}
     {% block update_notification %}
       {% if switch('firefox-update-notification', ['en-US']) %}

--- a/bedrock/base/templates/base-resp.html
+++ b/bedrock/base/templates/base-resp.html
@@ -197,6 +197,13 @@
     <!--[if !lte IE 8]><!-->
     {% block js %}{% endblock %}
 
+    {# Issue issue #6629 #}
+    {% block global_fxa_cta_experiment %}
+    {% if switch('global-fxa-cta-experiment', ['en-US']) %}
+      {{ js_bundle('global-fxa-cta-experiment') }}
+    {% endif %}
+    {% endblock %}
+
     {# Bug 1381776 #}
     {% block update_notification %}
       {% if switch('firefox-update-notification', ['en-US']) %}

--- a/bedrock/base/templates/includes/protocol/navigation/index.html
+++ b/bedrock/base/templates/includes/protocol/navigation/index.html
@@ -21,6 +21,14 @@
       <div class="mzp-c-navigation-items" id="mzp-c-navigation-items">
         <div class="mzp-c-navigation-download">
           {{ download_firefox(alt_copy=_('Download Firefox'), dom_id='protocol-nav-download-firefox', button_color='mzp-t-secondary mzp-t-small', download_location='nav') }}
+          {% if LANG == 'en-US' %}
+          <div class="c-navigation-fxa-cta-container">
+            <a class="c-navigation-fxa-cta mzp-c-button mzp-t-secondary mzp-t-small mzp-t-download" href="https://accounts.firefox.com/signup?service=sync&context=fx_desktop_v3&entrypoint=mozilla.org-globalnav&utm_source=www.mozilla.org&utm_content=Get%20a%20Firefox%20Account&utm_medium=referral&utm_campaign=globalnav" data-button-name="Create a Firefox Account" data-link-type="button" data-cta-position="secondary cta">
+              Get a Firefox Account
+            </a>
+            <p class="c-navigation-fxa-cta-small-link"><a data-link-type="nav" data-link-name="Check out the Benefits" href="{{ url('firefox.accounts') }}">Check out the Benefits</a></p>
+          </div>
+          {% endif %}
         </div>
         <div class="mzp-c-navigation-menu">
           <nav class="mzp-c-menu">

--- a/bedrock/firefox/templates/firefox/content-blocking-tour/index.html
+++ b/bedrock/firefox/templates/firefox/content-blocking-tour/index.html
@@ -147,3 +147,6 @@ data-panel3-button="{{ _('Got it!') }}"
 
 {# Bug 1381776 #}
 {% block update_notification %}{% endblock %}
+
+{# Issue issue #6629 #}
+{% block global_fxa_cta_experiment %}{% endblock %}

--- a/bedrock/firefox/templates/firefox/new/base.html
+++ b/bedrock/firefox/templates/firefox/new/base.html
@@ -88,3 +88,6 @@
 
 {# Bug 1381776 #}
 {% block update_notification %}{% endblock %}
+
+{# Issue issue #6629 #}
+{% block global_fxa_cta_experiment %}{% endblock %}

--- a/bedrock/firefox/templates/firefox/new/scene2.html
+++ b/bedrock/firefox/templates/firefox/new/scene2.html
@@ -164,3 +164,6 @@
   {# Keep download JS in a separate bundle to email JS, to reduce risk of errors interrupting download. #}
   {{ js_bundle('firefox_new_scene2') }}
 {% endblock %}
+
+{# Issue issue #6629 #}
+{% block global_fxa_cta_experiment %}{% endblock %}

--- a/bedrock/firefox/templates/firefox/tracking-protection-tour/index.html
+++ b/bedrock/firefox/templates/firefox/tracking-protection-tour/index.html
@@ -143,3 +143,6 @@ data-panel3-button="{{ _('Got it!') }}"
 
 {# Bug 1381776 #}
 {% block update_notification %}{% endblock %}
+
+{# Issue issue #6629 #}
+{% block global_fxa_cta_experiment %}{% endblock %}

--- a/media/css/firefox/accounts-2018.scss
+++ b/media/css/firefox/accounts-2018.scss
@@ -9,6 +9,7 @@ $image-path: '/media/protocol/img';
 @import '../../protocol/css/components/feature-card';
 @import '../../protocol/css/components/hero';
 @import '../../protocol/css/components/modal';
+@import '../protocol/includes/navigation-hide-download-button'; // Global FxA CTA experiment: issue #6629
 
 .show {
     display: block;

--- a/media/css/hubs/_nav-download-button-remove.scss
+++ b/media/css/hubs/_nav-download-button-remove.scss
@@ -15,6 +15,11 @@
     display: none;
 }
 
+// Global FxA CTA experiment: issue #6629
+.c-navigation-fxa-cta-container {
+    display: none !important; /* stylelint-disable-line declaration-no-important */
+}
+
 .moz-global-nav .nav-primary-links {
     @media #{$mq-tablet} {
         width: calc(100% - 160px);

--- a/media/css/pebbles/components/_protocol-nav.scss
+++ b/media/css/pebbles/components/_protocol-nav.scss
@@ -80,3 +80,44 @@ $image-path: '/media/protocol/img';
         @include font-size(12px);
     }
 }
+
+// Global FxA CTA experiment: issue #6629
+.mzp-c-navigation {
+    .c-navigation-fxa-cta {
+        @include font-size(14px);
+        background-color: transparent;
+        background-image: none;
+        border-radius: 2px;
+        border: 2px solid $color-green-60;
+        box-shadow: none;
+        color: $color-green-60;
+        display: inline-block;
+        font-weight: bold;
+        line-height: 1.125;
+        padding: $padding-sm $padding-md;
+        text-decoration: none;
+
+        &:hover,
+        &:focus {
+            background-color: $color-green-60;
+            border-color: $color-green-60;
+            color: $color-white;
+        }
+    }
+
+    .c-navigation-fxa-cta-small-link {
+        a:link,
+        a:visited {
+            @include font-size(10px);
+            color: #000;
+            text-decoration: none;
+        }
+
+        a:hover,
+        a:active,
+        a:focus {
+            color: inherit;
+            text-decoration: underline;
+        }
+    }
+}

--- a/media/css/protocol/components/_navigation.scss
+++ b/media/css/protocol/components/_navigation.scss
@@ -21,3 +21,49 @@
     }
 }
 
+// Global FxA CTA experiment: issue #6629
+.mzp-c-navigation {
+    .c-navigation-fxa-cta-container {
+        display: none;
+    }
+
+    .c-navigation-fxa-cta-small-link {
+        margin-bottom: 0;
+        text-align: center;
+
+        a:link,
+        a:visited {
+            @include text-body-xs;
+            color: $color-black;
+            text-decoration: none;
+        }
+
+        a:hover,
+        a:active,
+        a:focus {
+            color: inherit;
+            text-decoration: underline;
+        }
+    }
+
+    @media #{$mq-md} {
+        .c-navigation-fxa-cta-small-link {
+            text-align: right;
+        }
+    }
+}
+
+.mzp-c-navigation.show-fxa-button {
+    .mzp-c-button-download-container {
+        display: none;
+    }
+
+    .mzp-c-navigation-download {
+        margin-bottom: $spacing-sm;
+    }
+
+    .c-navigation-fxa-cta-container {
+        display: block;
+    }
+}
+

--- a/media/css/protocol/includes/_navigation-hide-download-button.scss
+++ b/media/css/protocol/includes/_navigation-hide-download-button.scss
@@ -14,6 +14,11 @@
     display: none;
 }
 
+// Global FxA CTA experiment: issue #6629
+.c-navigation-fxa-cta-container {
+    display: none !important; /* stylelint-disable-line declaration-no-important */
+}
+
 .moz-global-nav .nav-primary-links {
     @media #{$mq-md} {
         width: calc(100% - 160px);

--- a/media/css/sandstone/protocol-nav.scss
+++ b/media/css/sandstone/protocol-nav.scss
@@ -61,3 +61,45 @@ $image-path: '/media/protocol/img';
     text-shadow: none;
     letter-spacing: normal;
 }
+
+// Global FxA CTA experiment: issue #6629
+.mzp-c-navigation {
+    .c-navigation-fxa-cta {
+        @include font-size(16px);
+        background-color: transparent;
+        background-image: none;
+        border-radius: 2px;
+        border: 2px solid $color-green-60;
+        box-shadow: none;
+        color: $color-green-60;
+        display: inline-block;
+        font-weight: bold;
+        line-height: 1.125;
+        padding: $padding-sm $padding-md;
+        text-decoration: none;
+
+        &:hover,
+        &:focus {
+            background-color: $color-green-60;
+            border-color: $color-green-60;
+            color: $color-white;
+        }
+    }
+
+    .c-navigation-fxa-cta-small-link {
+        a:link,
+        a:visited {
+            @include font-size(12px);
+            color: #000;
+            text-decoration: none;
+        }
+
+        a:hover,
+        a:active,
+        a:focus {
+            color: inherit;
+            text-decoration: underline;
+        }
+
+    }
+}

--- a/media/js/base/global-fxa-cta-experiment.js
+++ b/media/js/base/global-fxa-cta-experiment.js
@@ -1,0 +1,110 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * Global FxA CTA experiment: issue #6629
+ */
+(function() {
+    'use strict';
+
+    var SAMPLE_RATE = 0.1; // FxA button is shown at 10% sample rate.
+    var COOKIE_EXPIRATION_DAYS = 2;
+    var COOKIE_ID = 'global-fxa-cta-exp';
+    var nav = document.querySelector('.mzp-c-navigation');
+
+    function isWithinSampleRate() {
+        return (Math.random() < SAMPLE_RATE) ? true : false;
+    }
+
+    function cookieExpiresDate(date) {
+        var d = date || new Date();
+        d.setTime(d.getTime() + (COOKIE_EXPIRATION_DAYS * 24 * 60 * 60 * 1000));
+        return d.toUTCString();
+    }
+
+    function setCookie(cohort) {
+        Mozilla.Cookies.setItem(COOKIE_ID, cohort, cookieExpiresDate(), '/');
+    }
+
+    function getCookie() {
+        return Mozilla.Cookies.getItem(COOKIE_ID);
+    }
+
+    function hasCookie() {
+        return Mozilla.Cookies.hasItem(COOKIE_ID);
+    }
+
+    function shouldShowFxAButton() {
+        var cohort;
+
+        // If a cookie already exists then use that value to determine what to show.
+        if (hasCookie()) {
+            cohort = getCookie();
+        }
+        // Else roll the dice!
+        else {
+            cohort = isWithinSampleRate() ? 'fxa' : 'download';
+            setCookie(cohort);
+        }
+
+        return cohort === 'fxa' ? true : false;
+    }
+
+    function showFxAButton() {
+        nav.classList.add('show-fxa-button');
+
+        window.dataLayer.push({
+            'data-ex-variant': 'accounts-button',
+            'data-ex-name': 'global-fxa-button'
+        });
+    }
+
+    function showDownloadButton() {
+        // Since the download button is already visible by default,
+        // there's nothing to do here except tag the variant in GA.
+        window.dataLayer.push({
+            'data-ex-variant': 'download-button',
+            'data-ex-name': 'global-fxa-button'
+        });
+    }
+
+    function meetsRequirements() {
+        if (typeof Mozilla.Client === 'undefined' || typeof Mozilla.Cookies === 'undefined') {
+            return false;
+        }
+
+        // Respect privacy!
+        if (!Mozilla.Cookies.enabled() || Mozilla.dntEnabled()) {
+            return false;
+        }
+
+        // User should be on Firefox desktop and nav should be present on page.
+        if (!Mozilla.Client.isFirefoxDesktop || !nav) {
+            return false;
+        }
+
+        var userMajorVersion = Mozilla.Client._getFirefoxMajorVersion();
+        var latestMajorVersion = parseInt(document.documentElement.getAttribute('data-latest-firefox'), 10);
+
+        if (!userMajorVersion || !latestMajorVersion) {
+            return false;
+        }
+
+        // Detect whether the Firefox is up-to-date in a non-strict way.
+        // The minor version is not considered.
+        return userMajorVersion === latestMajorVersion;
+    }
+
+    function init() {
+        if (meetsRequirements()) {
+            if (shouldShowFxAButton()) {
+                showFxAButton();
+            } else {
+                showDownloadButton();
+            }
+        }
+    }
+
+    init();
+})();

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -934,6 +934,12 @@
   "js": [
     {
       "files": [
+        "js/base/global-fxa-cta-experiment.js"
+      ],
+      "name": "global-fxa-cta-experiment"
+    },
+    {
+      "files": [
         "js/mozorg/contribute/contribute-nav.js"
       ],
       "name": "contribute-base"

--- a/tests/functional/test_internet_health.py
+++ b/tests/functional/test_internet_health.py
@@ -7,6 +7,7 @@ import pytest
 from pages.internet_health import InternetHealthPage
 
 
+@pytest.mark.skip_if_firefox(reason='https://github.com/mozilla/bedrock/issues/6629')
 @pytest.mark.nondestructive
 def test_download_button_is_displayed(base_url, selenium):
     page = InternetHealthPage(selenium, base_url).open()


### PR DESCRIPTION
## Description
- Adds a global Firefox Accounts signup button to the main navigation, shown only to Firefox users, replacing the existing download button.

Experiment cohorts:

- Firefox (up-to-date, release channel) users on en-US locale.
  - 90% see download button (control)
  - 10% see FxA button.

## Issue / Bugzilla link
#6629

## Testing
- Test using the **current release version** of Firefox, with **DNT disabled**.
- Depending on which variant you get, a cookie is stored. You may need to clear this cookie before refreshing to see the other variant.

Demo: https://bedrock-demo-agibson.oregon-b.moz.works/en-US/

- [ ] 10% en-US Firefox desktop users should see the FxA button.
- [ ] 90% en-US Firefox desktop users should see the download button.
- [ ] Non-Firefox users should always see the regular download button.
- [ ] Experiment code should not be excecuted when switch is disabled.
- [ ] Experiment code should not be excecuted for non en-US locales.
