### PR TITLE
Switch sanity tests to run against IE9

### DIFF
--- a/docker/bin/run_integration_tests.sh
+++ b/docker/bin/run_integration_tests.sh
@@ -19,9 +19,9 @@ case $1 in
     BROWSER_NAME="internet explorer"
     PLATFORM="Windows 10"
     ;;
-  ie8)
+  ie9)
     BROWSER_NAME="internet explorer"
-    BROWSER_VERSION="8.0"
+    BROWSER_VERSION="9.0"
     PLATFORM="Windows 7"
     MARK_EXPRESSION=sanity
     ;;

--- a/jenkins/branches/prod.yml
+++ b/jenkins/branches/prod.yml
@@ -17,7 +17,7 @@ integration_tests:
     - firefox
     - headless
     - ie
-    - ie8
+    - ie9
   frankfurt:
     - headless
   iowa-a:

--- a/jenkins/branches/run-integration-tests.yml
+++ b/jenkins/branches/run-integration-tests.yml
@@ -12,4 +12,4 @@ integration_tests:
     - firefox
     - chrome
     - ie
-    - ie8
+    - ie9


### PR DESCRIPTION
## Description
- Bumps our sanity tests to run against IE9 in SauceLabs, due to IE8 now being [unsupported](https://wiki.saucelabs.com/display/DOCS/2018/10/16/Announcing+End+of+Life+for+Internet+Explorer+8+on+Windows+7).

## Issue / Bugzilla link
Fixes: https://ci.us-west.moz.works/blue/organizations/jenkins/bedrock_multibranch_pipeline/detail/prod/367/pipeline/

## Testing
Successful test run: https://ci.us-west.moz.works/blue/organizations/jenkins/bedrock_multibranch_pipeline/detail/run-integration-tests/235/pipeline/175/