### PR TITLE
Add /whatsnew page for Firefox 65 (Fixes #6352)

### DIFF
--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx65.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx65.html
@@ -1,0 +1,156 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+
+{% from "macros-protocol.html" import call_out, feature_card with context %}
+
+{% from "macros.html" import fxa_email_form with context %}
+
+{% add_lang_files "firefox/whatsnew_63" %}
+
+{% extends "firefox/base-protocol.html" %}
+
+{% block page_title %}{{ _('See what’s new with Firefox') }}{% endblock %}
+
+{% block page_css %}
+  {{ css_bundle('firefox_whatsnew_65') }}
+{% endblock %}
+
+{% block site_header %}{% endblock %}
+
+{% block content %}
+<main class="mzp-t-firefox">
+  <header class="c-page-header">
+    <div class="mzp-l-content c-page-header-inner">
+      {{ high_res_img('logos/firefox/logo-quantum-wordmark-large.png', {'alt': 'Firefox', 'width': '147', 'height': '55', 'class': 'c-page-header-logo-fx'}) }}
+      <h1 class="c-page-header-up-to-date">{{ _('Congrats! You’re using the latest version of Firefox.') }}</h1>
+      <img src="{{ static('img/logos/mozilla/wordmark-dark.svg') }}" alt="Mozilla" width="112" height="32" class="c-page-header-logo-moz">
+    </div>
+  </header>
+  <section class="c-sticky-signup fxa-form-cta">
+    <div class="mzp-l-content">
+      <div class="c-sticky-signup-container">
+        <div class="c-sticky-signup-content">
+          <h2 class="c-sticky-signup-title">{{ _('Get your Firefox Account') }}</h2>
+        </div>
+        {{ fxa_email_form(
+            entrypoint='whatsnew',
+            button_class='mzp-c-button',
+            utm_source='whatsnew',
+            utm_params={'campaign': 'fxa-embedded-form', 'content': 'whatsnew', 'medium': 'referral'})
+        }}
+      </div>
+    </div>
+  </section>
+
+  {% if show_newsletter %}
+  <section class="c-sticky-signup newsletter-form-cta">
+    <div class="mzp-l-content">
+      <div class="c-sticky-signup-container">
+        <div class="c-sticky-signup-content">
+          <h2 class="c-sticky-signup-title">{{ _('Get Firefox tips, tricks, news and more') }}</h2>
+        </div>
+        <div class="mzp-c-newsletter">
+          {{ email_newsletter_form(
+            protocol_component=True,
+            include_title=False,
+            spinner_color='#fff',
+            button_class='mzp-c-button')
+          }}
+        </div>
+      </div>
+    </div>
+  </section>
+  {% endif %}
+
+  <section class="mzp-c-hero mzp-has-image mzp-l-reverse intro">
+    <div class="mzp-l-content">
+      <div class="mzp-c-hero-body">
+        <h2 class="mzp-c-hero-title">{{ _('It shouldn’t be hard to own your life online.') }}</h2>
+        <div class="mzp-c-hero-desc">
+          <p>{{ _('That’s why Firefox gives more power to you with every update.') }}</p>
+        </div>
+      </div>
+    </div>
+
+    <div class="mzp-c-hero-image">
+      {{ high_res_img('firefox/whatsnew_63/wnp63-hero.png', {'alt': ''}) }}
+    </div>
+  </section>
+
+  <section>
+    {{ call_out(
+      title=_('Meet the latest version of Firefox. And sign up for a better internet all around with a free Firefox Account.'),
+      class="whats-new"
+    )}}
+
+    <div class="mzp-l-content">
+      {% call feature_card(
+        title=_('Built-In Tracking Controls'),
+        ga_title='Built-In Tracking Controls',
+        image_url='firefox/whatsnew_63/wnp63-tracking-controls.png',
+        include_highres_image=True,
+        aspect_ratio='mzp-has-aspect-3-2',
+        class='mzp-l-card-feature-left-third tracking-controls',
+        link_url='https://support.mozilla.org/kb/tracking-protection',
+        link_cta=_('Learn more')
+      ) %}
+        <p>
+          {% trans %}
+            When you see the shield in the address bar, Firefox is blocking ads and unruly
+            scripts from following you around the web. Select the icon to dial in the options.
+          {% endtrans %}
+        </p>
+      {% endcall %}
+    </div>
+
+    <section class="mzp-c-hero mzp-has-image mzp-l-reverse mzp-t-dark content-blocking">
+      <div class="mzp-l-content">
+        <div class="mzp-c-hero-body">
+          <h3 class="mzp-c-hero-title">{{ _('Better Content Blocking = Faster Internet') }}</h3>
+          <div class="mzp-c-hero-desc">
+            <p>
+              {% trans %}
+                Because ad trackers can do more than annoy you – they add data bloat that slows you down.
+              {% endtrans %}
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <div class="mzp-c-hero-image">
+        {% set content_blocking_image = 'firefox/whatsnew_63/wnp63-content-blocking.png' if DIR == 'ltr' else 'firefox/whatsnew_63/wnp63-content-blocking-rtl.png' %}
+        {{ high_res_img(content_blocking_image, {'alt': ''}) }}
+      </div>
+    </section>
+
+    <div class="mzp-l-content">
+      {% call feature_card(
+        title=_('Secure Syncing Across Devices'),
+        ga_title='Secure Syncing Across Devices',
+        image_url='firefox/whatsnew_63/wnp63-secure-sync-devices.png',
+        include_highres_image=True,
+        class='mzp-l-card-feature-left-third sync',
+        link_url=url('firefox.accounts'),
+        link_cta=_('Learn more')
+      ) %}
+        <p>
+          {% trans %}
+            With a Firefox Account, your data is secured with end-to-end encryption.
+            Even we can’t see what you save, sync and send.
+          {% endtrans %}
+        </p>
+      {% endcall %}
+    </div>
+  </section>
+
+</main>
+{% endblock %}
+
+{% block js %}
+  {% if show_newsletter %}
+    {{ js_bundle('firefox_whatsnew_65_newsletter') }}
+  {% endif %}
+  {{ js_bundle('firefox_whatsnew_65') }}
+{% endblock %}
+

--- a/bedrock/firefox/tests/test_base.py
+++ b/bedrock/firefox/tests/test_base.py
@@ -416,6 +416,32 @@ class TestWhatsNew(TestCase):
 
     # end 64.0 whatsnew tests
 
+    # begin 65.0 whatsnew tests
+
+    def test_fx_65_0(self, render_mock):
+        """Should use standard template for 65.0"""
+        req = self.rf.get('/firefox/whatsnew/')
+        req.locale = 'en-US'
+        self.view(req, version='65.0')
+        template = render_mock.call_args[0][1]
+        eq_(template, ['firefox/whatsnew/whatsnew-fx65.html'])
+        context = render_mock.call_args[0][2]
+        ok_('show_newsletter' in context)
+        eq_(True, context['show_newsletter'])
+
+    def test_fx_65_0_no_newsletter(self, render_mock):
+        """Should not include newsletter for non-translated locales"""
+        req = self.rf.get('/firefox/whatsnew/')
+        req.locale = 'el'
+        self.view(req, version='65.0')
+        template = render_mock.call_args[0][1]
+        eq_(template, ['firefox/whatsnew/whatsnew-fx65.html'])
+        context = render_mock.call_args[0][2]
+        ok_('show_newsletter' in context)
+        eq_(False, context['show_newsletter'])
+
+    # end 65.0 whatsnew tests
+
 
 @patch('bedrock.firefox.views.l10n_utils.render', return_value=HttpResponse())
 class TestFirstRun(TestCase):

--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -489,6 +489,7 @@ class FirstrunView(l10n_utils.LangFilesMixin, TemplateView):
 class WhatsnewView(l10n_utils.LangFilesMixin, TemplateView):
     def get_context_data(self, **kwargs):
         ctx = super(WhatsnewView, self).get_context_data(**kwargs)
+        locale = l10n_utils.get_locale(self.request)
 
         # add version to context for use in templates
         version = self.kwargs.get('version') or ''
@@ -508,6 +509,24 @@ class WhatsnewView(l10n_utils.LangFilesMixin, TemplateView):
                 'pt-BR',
                 'ru',
                 'zh-TW',
+            ]
+
+        if ctx['num_version'] == 65:
+            ctx['show_newsletter'] = locale in [
+                'en-US',
+                'en-GB',
+                'en-CA',
+                'en-ZA',
+                'es-ES',
+                'es-AR',
+                'es-CL',
+                'es-MX',
+                'id',
+                'pt-BR',
+                'fr',
+                'ru',
+                'de',
+                'pl'
             ]
 
         return ctx
@@ -536,6 +555,8 @@ class WhatsnewView(l10n_utils.LangFilesMixin, TemplateView):
                 template = 'firefox/whatsnew/index.id.html'
         elif locale == 'zh-TW' and not version.startswith('64.'):
             template = 'firefox/whatsnew/index.zh-TW.html'
+        elif version.startswith('65.'):
+            template = 'firefox/whatsnew/whatsnew-fx65.html'
         elif version.startswith('64.'):
             template = 'firefox/whatsnew/fx64/whatsnew-fx64.html'
         elif version.startswith('63.'):

--- a/media/css/firefox/whatsnew/whatsnew-65.scss
+++ b/media/css/firefox/whatsnew/whatsnew-65.scss
@@ -1,0 +1,356 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+$font-path: '/media/fonts';
+$image-path: '/media/protocol/img';
+
+@import '../../../protocol/css/includes/lib';
+@import '../../../protocol/css/components/call-out';
+@import '../../../protocol/css/components/hero';
+@import '../../../protocol/css/components/feature-card';
+@import '../../../protocol/css/components/newsletter-form';
+
+
+//* -------------------------------------------------------------------------- */
+// Up-to-date page header
+
+.c-page-header {
+    background-color: $color-white;
+    border-bottom: 1px solid rgba(0, 0, 0, .05);
+    box-shadow: 0 1px 3px rgba(0, 0, 0, .1);
+    position: relative;
+    text-align: center;
+
+    .c-page-header-up-to-date {
+        @include text-display-xs;
+        display: none;
+        font-weight: normal;
+        margin: 1em 0;
+        padding: 0 $spacing-md;
+        width: calc(100% - 45px);
+
+        &:before {
+            @include bidi((
+                (background-position, center left, center right),
+                (margin, 0 10px 0 0, 0 0 0 10px),
+            ));
+            background-image: url('/media/img/firefox/whatsnew/icon-green-check.svg');
+            background-repeat: no-repeat;
+            background-size: 25px 25px;
+            content: '';
+            display: inline-block;
+            height: 25px;
+            vertical-align: middle;
+            width: 25px;
+        }
+    }
+
+    .c-page-header-logo-moz {
+        display: none;
+    }
+
+    &.is-up-to-date .c-page-header-up-to-date {
+        display: block;
+    }
+
+    @media #{$mq-md} {
+        .c-page-header-logo-fx {
+            @include bidi(((float, left, right),));
+        }
+
+        .c-page-header-logo-moz {
+            @include bidi(((float, right, left),));
+            display: block;
+            margin: $spacing-md 0;
+        }
+
+        &.is-up-to-date .c-page-header-inner {
+            align-items: center;
+            display: flex;
+            justify-content: space-between;
+
+            .c-page-header-logo-fx,
+            .c-page-header-logo-moz {
+                float: none;
+                margin: 0;
+            }
+        }
+    }
+}
+
+// Sticky signup CTA component.
+.c-sticky-signup {
+    background: $color-blue-60;
+    color: $color-white;
+    display: none;
+    text-align: center;
+
+    a:link,
+    a:visited {
+        color: inherit;
+    }
+
+    .c-sticky-signup-title {
+        @include text-display-sm;
+        margin: 0 auto $spacing-md;
+    }
+
+    .c-sticky-signup-content {
+        align-items: center;
+        display: flex;
+    }
+
+    @media #{$mq-md} {
+        @include clearfix;
+        left: 0;
+        position: sticky;
+        top: 0;
+        z-index: 100;
+
+        .c-sticky-signup-container {
+            @include grid-column-gap($spacing-lg);
+            display: grid;
+            grid-template-columns: 1fr 2fr;
+        }
+
+        .c-sticky-signup-title {
+            margin: 0;
+        }
+    }
+
+    @media #{$mq-lg} {
+        .c-sticky-signup-container {
+            grid-template-columns: 1fr 1fr;
+        }
+    }
+}
+
+//* -------------------------------------------------------------------------- */
+// Firefox Accounts form sticky header
+
+.c-sticky-signup.fxa-form-cta {
+
+    // only display FxA form to users who are signed out.
+    .state-fxa-supported-signed-out & {
+        display: block;
+    }
+
+    .fxa-email-form-intro {
+        display: none;
+    }
+
+    .fxa-email-field-container {
+        .field {
+            label {
+                @include visually-hidden;
+            }
+
+            input[type="email"] {
+                border: none;
+                box-shadow: none;
+                padding: 18px 24px;
+                width: 100%;
+            }
+        }
+
+        .mzp-c-button {
+            width: 100%;
+        }
+    }
+
+    @media #{$mq-sm} {
+        .fxa-email-field-container {
+            @include grid-column-gap($spacing-md);
+            display: grid;
+            grid-template-columns: 2fr 1fr;
+
+            .field {
+                margin-bottom: 0;
+            }
+        }
+    }
+
+    @media #{$mq-md} {
+        .fxa-email-form {
+            .agreement {
+                @include text-body-sm;
+            }
+        }
+
+        .fxa-email-field-container {
+            @include bidi((
+                (background-position, center left, center right),
+                (padding-left, 37px + $spacing-md, padding-right, 0),
+            ));
+            background-image: url('/media/img/firefox/whatsnew_63/avatar.svg');
+            background-repeat: no-repeat;
+        }
+    }
+}
+
+//* -------------------------------------------------------------------------- */
+// Firefox newsletter form sticky header
+
+.c-sticky-signup.newsletter-form-cta {
+
+    // only display FxA form to users who are signed out.
+    .state-fxa-supported-signed-in & {
+        display: block;
+    }
+
+    .mzp-c-newsletter {
+        @include bidi(((text-align, left, right),));
+        display: block;
+        padding: 0;
+        margin: 0 auto;
+    }
+
+    .mzp-c-newsletter-form {
+        padding-top: 0;
+    }
+
+    .mzp-c-newsletter-content {
+        @include text-body-sm;
+    }
+
+    input[type="email"] {
+        padding: 18px 24px;
+        border: none;
+        box-shadow: none;
+    }
+
+    label[for="id_email"] {
+        @include visually-hidden;
+    }
+
+    p {
+        margin-bottom: $spacing-sm;
+    }
+
+    .mzp-c-form-submit {
+        margin-bottom: 0;
+    }
+
+    .mzp-c-fieldnote {
+        @include bidi(((text-align, left, right),));
+        color: $color-white;
+    }
+
+    .mzp-c-newsletter-thanks {
+        padding-top: 0;
+        text-align: center;
+
+        h3 {
+            @include text-display-sm;
+        }
+    }
+
+    @media #{$mq-md} {
+        .mzp-c-newsletter {
+            margin: 0;
+        }
+
+        .mzp-c-newsletter-content {
+            @include bidi(((padding-right, 40%, padding-left, 0),));
+            position: relative;
+        }
+
+        .mzp-c-button[type="submit"] {
+            @include bidi(((right, 0, left, auto),));
+            position: absolute;
+            top: 0;
+            width: calc(40% - #{$spacing-md});
+        }
+
+        .mzp-c-newsletter-thanks {
+            @include bidi(((text-align, left, right),));
+        }
+    }
+}
+
+//* -------------------------------------------------------------------------- */
+// Intro section
+
+.intro {
+    background-color: $color-gray-10;
+    min-height: 350px;
+    padding-top: $layout-sm;
+
+    @media #{$mq-md} {
+        margin-bottom: $layout-xl;
+        padding-top: $layout-xl;
+
+        .mzp-c-hero-image {
+            bottom: -$spacing-2xl;
+            height: calc(100% + #{$spacing-2xl});
+        }
+    }
+}
+
+//* -------------------------------------------------------------------------- */
+// What's new
+
+.whats-new {
+    background-color: transparent;
+
+    .mzp-c-call-out-title {
+        @include text-body-lg;
+        font-weight: normal;
+    }
+
+    @media #{$mq-lg} {
+        margin: $layout-xl 0 $layout-lg;
+    }
+}
+
+//* -------------------------------------------------------------------------- */
+// Tracking Controls section
+
+.tracking-controls {
+    .mzp-c-card-feature-title {
+        @include text-display-md;
+    }
+}
+
+//* -------------------------------------------------------------------------- */
+// Content Blocking section
+
+.content-blocking.mzp-c-hero.mzp-t-dark {
+    background-color: $color-blue-50;
+
+    .mzp-c-hero-title {
+        @include text-display-md;
+    }
+
+    @media #{$mq-md} {
+        .mzp-c-hero-image {
+            height: 100%;
+            top: -$layout-md;
+
+            img {
+                @include bidi(((margin-right, $layout-xl, margin-left, 0),));
+            }
+        }
+    }
+
+    @media #{$mq-xl} {
+        .mzp-c-hero-image {
+            height: calc(100% + #{$spacing-xl});
+            top: -$layout-xl;
+        }
+    }
+}
+
+//* -------------------------------------------------------------------------- */
+// Sync section
+
+.sync {
+    .mzp-c-card-feature-title {
+        @include text-display-md;
+    }
+
+    .mzp-c-card-feature-media img {
+        max-width: 519px;
+    }
+}

--- a/media/css/firefox/whatsnew/whatsnew-65.scss
+++ b/media/css/firefox/whatsnew/whatsnew-65.scss
@@ -31,12 +31,11 @@ $image-path: '/media/protocol/img';
         width: calc(100% - 45px);
 
         &:before {
+            background: url('/media/img/firefox/whatsnew/icon-green-check.svg') no-repeat;
             @include bidi((
                 (background-position, center left, center right),
                 (margin, 0 10px 0 0, 0 0 0 10px),
             ));
-            background-image: url('/media/img/firefox/whatsnew/icon-green-check.svg');
-            background-repeat: no-repeat;
             background-size: 25px 25px;
             content: '';
             display: inline-block;
@@ -179,12 +178,11 @@ $image-path: '/media/protocol/img';
         }
 
         .fxa-email-field-container {
+            background: url('/media/img/firefox/whatsnew_63/avatar.svg') no-repeat;
             @include bidi((
                 (background-position, center left, center right),
                 (padding-left, 37px + $spacing-md, padding-right, 0),
             ));
-            background-image: url('/media/img/firefox/whatsnew_63/avatar.svg');
-            background-repeat: no-repeat;
         }
     }
 }

--- a/media/js/firefox/whatsnew/whatsnew-65.js
+++ b/media/js/firefox/whatsnew/whatsnew-65.js
@@ -1,0 +1,34 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+(function() {
+    'use strict';
+
+    var client = Mozilla.Client;
+
+    function checkUpToDate() {
+        // bug 1419573 - only show "Your Firefox is up to date" if it's the latest version.
+        if (client.isFirefoxDesktop) {
+            client.getFirefoxDetails(function(data) {
+                if (data.isUpToDate) {
+                    document.querySelector('.c-page-header').classList.add('is-up-to-date');
+                }
+            });
+        }
+    }
+
+    function bindOpenPrefs() {
+        document.querySelector('.tracking-controls .mzp-c-cta-link').addEventListener('click', function(e) {
+            e.preventDefault();
+
+            Mozilla.UITour.openPreferences('privacy');
+        }, false);
+    }
+
+    Mozilla.UITour.ping(function() {
+        checkUpToDate();
+        bindOpenPrefs();
+    });
+
+})();

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -600,6 +600,12 @@
     },
     {
       "files": [
+        "css/firefox/whatsnew/whatsnew-65.scss"
+      ],
+      "name": "firefox_whatsnew_65"
+    },
+    {
+      "files": [
         "css/mozorg/commit-access-policy.less"
       ],
       "name": "commit-access-policy"
@@ -1053,6 +1059,23 @@
         "js/firefox/whatsnew/whatsnew-64.js"
       ],
       "name": "firefox_whatsnew_64"
+    },
+    {
+      "files": [
+        "js/base/uitour-lib.js",
+        "js/base/mozilla-fxa.js",
+        "js/base/mozilla-fxa-init.js",
+        "js/base/mozilla-fxa-form.js",
+        "js/firefox/whatsnew/whatsnew-65.js"
+      ],
+      "name": "firefox_whatsnew_65"
+    },
+    {
+      "files": [
+        "protocol/js/protocol-newsletter.js",
+        "js/newsletter/form-protocol.js"
+      ],
+      "name": "firefox_whatsnew_65_newsletter"
     },
     {
       "files": [


### PR DESCRIPTION
## Description
- Adds page at `/firefox/65.0/whatsnew/`, reusing the existing /whatsnew page and strings from 63.0. Much of this code has already been reviewed / tested, with the exception of the following:
- There is a new newsletter CTA added to the page, but this reuses strings from `main.lang`, so there should be no additional l10n requirements.
- Needs to be live in production **before Jan 22nd**.

Page logic:

- If a user is not signed into an account, show the existing Firefox Account sign-up bar at the top of the page.
- If a user is already signed into an account, and they are in a locale that supports the Firefox newsletter, show a newsletter sign-up form in place of the Firefox Account form. *
- If a user is already signed into an account, and they are not in a valid newsletter locale, do nothing special and display the regular page content. *

The * is new behavior that was not present in 63.

## Issue / Bugzilla link
#6352

## Testing
Demo: https://www-demo2.allizom.org/en-US/firefox/65.0/whatsnew/
