### PR TITLE
[bug 1520400] Navigation menu titles on release notes are white on white

### DIFF
--- a/media/css/sandstone/sandstone-resp.less
+++ b/media/css/sandstone/sandstone-resp.less
@@ -84,14 +84,11 @@ a.more {
 
 // Nightly visual style
 
-.space {
+.space #outer-wrapper {
     color: #fff;
     background: #000;
-
-    #outer-wrapper {
-        background: url('/media/img/firefox/horizon/stars.svg') center 60px no-repeat,
-                    linear-gradient(to bottom, #000, #002048 1000px, #000 2000px);
-    }
+    background: url('/media/img/firefox/horizon/stars.svg') center 60px no-repeat,
+                linear-gradient(to bottom, #000, #002048 1000px, #000 2000px);
 
     a {
         color: @linkBlue;
@@ -128,16 +125,13 @@ a.more {
 }
 
 // Firefox Developer Edition visual style
-.blueprint {
+.blueprint #outer-wrapper {
     color: #fff;
-
-    #outer-wrapper {
-        background: #1e1e21;
-        #gradient > .radial(top, left, ellipse, farthest-side, #00549e 0%, rgba(0, 0, 0, 0) 100%);
-        background-size: 100% 500px;
-        background-repeat: no-repeat;
-        background-position: top center;
-    }
+    background: #1e1e21;
+    #gradient > .radial(top, left, ellipse, farthest-side, #00549e 0%, rgba(0, 0, 0, 0) 100%);
+    background-size: 100% 500px;
+    background-repeat: no-repeat;
+    background-position: top center;
 
     a {
         color: @linkBlue;


### PR DESCRIPTION
## Description
- Fixes the scope of legacy `space` and `blueprint` Sandstone themes, so the (perhaps overly broad) heading selectors only apply to content within `#outer-wrapper`, and do not interfere with the main navigation.
- There are only a couple of pages on the whole site using these themes, so I think this change should be pretty safe.

## Issue / Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1520400

## Testing
- [ ] Visit `/firefox/66.0a1/releasenotes/` and hover over the main nav to open the menu. The subheadings should be visiable, and not white on white.
- [ ] Double check that no other pages using this theme are negatively impacted.