### PR TITLE
Revert removal of accordion from /privacy/firefox/ pages (Fixes #6713)

### DIFF
--- a/bedrock/privacy/templates/privacy/base-protocol.html
+++ b/bedrock/privacy/templates/privacy/base-protocol.html
@@ -73,4 +73,6 @@
 </article>
 {% endblock %}
 
-{% block js %}{% endblock %}
+{% block js %}
+  {{ js_bundle('privacy_protocol') }}
+{% endblock %}

--- a/bedrock/privacy/templates/privacy/notices/firefox-quantum.html
+++ b/bedrock/privacy/templates/privacy/notices/firefox-quantum.html
@@ -7,5 +7,6 @@
 {% block body_class %}{{ super() }} product-firefox{% endblock %}
 
 {% block js %}
+  {{ super() }}
   {{ js_bundle('privacy_firefox') }}
 {% endblock %}

--- a/media/css/privacy/privacy-protocol.scss
+++ b/media/css/privacy/privacy-protocol.scss
@@ -197,3 +197,65 @@
 .back {
     margin-bottom: 0;
 }
+
+/* Accordion styles */
+.privacy-body.interactive-widget {
+
+    & .l-narrow > section > header {
+        position: relative;
+
+        h2 {
+            @include bidi(((padding-right, 110px, padding-left, 0),));
+        }
+    }
+
+    h3 {
+        @include bidi(((padding-right, 40px, padding-left, 0),));
+        cursor: pointer;
+        font-weight: normal;
+        margin: 0;
+        position: relative;
+
+        &:after {
+            @include bidi(((right, 0, left, auto),));
+            background: transparent url('/media/img/privacy/arrowhead-up-16.svg') 0 0 no-repeat;
+            content: '';
+            display: block;
+            height: 16px;
+            position: absolute;
+            top: .25em;
+            width: 16px;
+            transition: transform .1s ease-in-out;
+        }
+    }
+
+    h3.collapsed:after {
+        transform: rotate(180deg);
+    }
+
+    .toggle {
+        @include bidi(((right, 0, left, auto),));
+        background: none;
+        border: 0;
+        border-bottom: 3px solid $color-black;
+        cursor: pointer;
+        display: inline-block;
+        line-height: 1.2;
+        max-width: 90px;
+        padding-bottom: 3px;
+        position: absolute;
+        top: 0;
+
+        &:hover,
+        &:active,
+        &:focus {
+            border-bottom-color: transparent;
+        }
+    }
+
+    @media #{$mq-md} {
+        section > section {
+            padding-bottom: $layout-md;
+        }
+    }
+}

--- a/media/css/privacy/privacy-protocol.scss
+++ b/media/css/privacy/privacy-protocol.scss
@@ -2,6 +2,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+$image-path: '/media/protocol/img';
+
 @import '../../protocol/css/includes/lib';
 @import "../../protocol/css/components/article";
 
@@ -218,7 +220,7 @@
 
         &:after {
             @include bidi(((right, 0, left, auto),));
-            background: transparent url('/media/img/privacy/arrowhead-up-16.svg') 0 0 no-repeat;
+            background: transparent url('#{$image-path}/icons/ui/expand-black.svg') 0 0 no-repeat;
             content: '';
             display: block;
             height: 16px;
@@ -229,8 +231,8 @@
         }
     }
 
-    h3.collapsed:after {
-        transform: rotate(180deg);
+    h3[aria-expanded="true"]:after {
+        transform: rotate(45deg);
     }
 
     .toggle {

--- a/media/js/privacy/privacy-protocol.js
+++ b/media/js/privacy/privacy-protocol.js
@@ -1,0 +1,267 @@
+(function() {
+    'use strict';
+
+    var strings;
+    var mainContent;
+    var topicHeaders;
+    var topics = [];
+    var tabpanelCloseText;
+    var tabpanelOpenText;
+
+    /**
+     * Check for feature support
+     */
+    function supportsBaselineJS() {
+        return 'querySelectorAll' in document &&
+               'addEventListener' in window;
+    }
+
+    /**
+     * For each main section, this innjects a button to either,
+     * show all topics under the section, or collapse all.
+     */
+    function addMasterToggles() {
+        var toggle = document.createElement('button');
+
+        toggle.classList.add('toggle');
+        toggle.setAttribute('type', 'button');
+        toggle.textContent = tabpanelOpenText;
+
+        dataAttributeHandler({
+            elem: toggle,
+            property: 'data-is-expanded',
+            value: false
+        });
+
+        for (var i = 0, l = topicHeaders.length; i < l; i++) {
+            var currentHeading = topicHeaders[i].querySelector('h2').parentNode;
+
+            dataAttributeHandler({
+                elem: toggle,
+                property: 'data-parent-container',
+                value: topicHeaders[i].id
+            });
+
+            if (currentHeading.nodeName.toLowerCase() === 'header') {
+                currentHeading.insertAdjacentHTML('beforeend', toggle.outerHTML);
+            }
+        }
+    }
+
+    /**
+     * Collects all of the individual topics(sections) into an Array
+     * for use in various other functions.
+     */
+    function collectAllTopics() {
+        for (var i = 0, l = topicHeaders.length; i < l; i++) {
+            var nestedTopics = topicHeaders[i].querySelectorAll('section');
+            /* nestedTopics is a NodeList which is Array like but,
+            not a real array. We therefore need to coherce it into one. */
+            topics.push([].slice.call(nestedTopics));
+        }
+
+        /* At this point `topics` is a two dimensional array.
+        The final step then is to flatten it. */
+        topics = topics.reduce(function(a, b) {
+            return a.concat(b);
+        });
+    }
+
+    /**
+     * Simple pollyfil for setting and getting data attributes
+     * across browsers.
+     * @param {Object} data - An object containing the data needed
+     * to get or set the data attribute. For example:
+     *
+     * {
+     *     elem: document.getElementById('strings'),
+     *     property: 'isExpanded',
+     *     value: 'value'
+     * }
+     *
+     * @returns For get operations, it returns the value of the data attribute
+     */
+    function dataAttributeHandler(data) {
+        // if a value is passed, this is a set operation
+        if (data.value) {
+            if (strings.dataset === undefined) {
+                data.elem.setAttribute(data.property, data.value);
+            } else {
+                data.elem.dataset[formatAsDatasetProperty(data.property)] = data.value;
+            }
+        } else {
+            if (strings.dataset === undefined) {
+                /* When using dataset, boolean values are returned as strings.
+                When getting the value using `getAttribute` it is returned as a boolean.
+                This causes inconsistencies with conditional statements so, explicitly
+                convert all return values to a string */
+                var propertyValue = data.elem.getAttribute(data.property);
+                return propertyValue ? propertyValue.toString() : propertyValue;
+            } else {
+                return data.elem.dataset[formatAsDatasetProperty(data.property)];
+            }
+        }
+    }
+
+    /**
+     * Takes a string in the format `data-tabpanel-open-text` and
+     * returns a string formatted such that it can be used as a
+     * property accessor on a `dataset`
+     * Example:
+     * input: data-tabpanel-open-text
+     * returns tabpanelOpenText
+     *
+     * @param {String} property - The property to convert as a string
+     * @returns the formatted string
+     */
+    function formatAsDatasetProperty(property) {
+        var formattedProperty = '';
+        // first strip of the `data-`
+        var stripped = property.substr(property.indexOf('-') + 1);
+        // split the result into an array
+        var split = stripped.split('-');
+
+        /* start by adding the first item in the array
+        to the `formattedProperty` which will be returned */
+        formattedProperty = split[0];
+
+        // if the resulting array has more than one item
+        if (split.length > 1) {
+            // loop over the array, starting at the second item
+            for (var i = 1, l = split.length; i < l; i++) {
+                var currentString = split[i];
+                formattedProperty += currentString.replace(
+                    currentString.substr(0,1),
+                    currentString.substr(0,1).toUpperCase()
+                );
+            }
+        }
+        return formattedProperty;
+    }
+
+    /**
+     * Hides *all* topics across sections
+     */
+    function hideAllTopicContent() {
+        for (var i = 0, l = topics.length; i < l; i++) {
+            var divElem = topics[i].querySelector('div');
+            var topicHeading = topics[i].querySelector('h3');
+
+            divElem.classList.add('hidden');
+            divElem.setAttribute('aria-hidden', true);
+
+            topicHeading.classList.add('collapsed');
+        }
+    }
+
+    /**
+     * Runs a set of functions on page load.
+     */
+    function initPage() {
+        collectAllTopics();
+        hideAllTopicContent();
+        addMasterToggles();
+        showInitialTopic();
+    }
+
+    /**
+     * On load, expands the first topic of the first main section. This
+     * also calls `addDataChoicesWidget` if on Fx desktop.
+     */
+    function showInitialTopic() {
+        var initialTopic = topicHeaders[0].querySelector('section');
+        var initialTopicContent = initialTopic.querySelector('div');
+        var initialTopicHeading = initialTopic.querySelector('h3');
+
+        initialTopicContent.classList.remove('hidden');
+        initialTopicContent.setAttribute('aria-hidden', false);
+
+        initialTopicHeading.classList.remove('collapsed');
+    }
+
+    /**
+     * Hide or show all topics for the main section.
+     * @param {Object} targetElem - The element that triggered the event
+     */
+    function toggleMainSectionTopics(targetElem) {
+        var targetSectionId = dataAttributeHandler({
+            elem: targetElem,
+            property: 'data-parent-container'
+        });
+        var isExpanded = dataAttributeHandler({
+            elem: targetElem,
+            property: 'data-is-expanded'
+        });
+
+        var targetAction = isExpanded === 'true' ? 'add' : 'remove';
+        var targetSection = document.getElementById(targetSectionId);
+        var subSections = targetSection.querySelectorAll('section');
+
+        for (var i = 0, l = subSections.length; i < l; i++) {
+            var divElem = subSections[i].querySelector('div');
+            var heading = subSections[i].querySelector('h3');
+
+            divElem.classList[targetAction]('hidden');
+            divElem.setAttribute('aria-hidden', isExpanded || 'false');
+            heading.classList[targetAction]('collapsed');
+        }
+
+        if (isExpanded === 'true') {
+            dataAttributeHandler({
+                elem: targetElem,
+                property: 'data-is-expanded',
+                value: 'false'
+            });
+
+            targetElem.textContent = tabpanelOpenText;
+        } else {
+            dataAttributeHandler({
+                elem: targetElem,
+                property: 'data-is-expanded',
+                value: 'true'
+            });
+
+            targetElem.textContent = tabpanelCloseText;
+        }
+    }
+
+    // Don't execute if features aren't supported
+    if (supportsBaselineJS()) {
+        strings = document.getElementById('strings');
+        mainContent = document.querySelector('.privacy-body');
+        topicHeaders = document.querySelectorAll('.privacy-body .l-narrow > section');
+        tabpanelCloseText = dataAttributeHandler({ elem: strings, property: 'data-tabpanel-close-text' });
+        tabpanelOpenText = dataAttributeHandler({ elem: strings, property: 'data-tabpanel-open-text' });
+
+        /* add a class to indicate that js is enabled. This will trigger
+        the appropriate styling to be applied */
+        mainContent.classList.add('interactive-widget');
+        initPage();
+
+        /**
+         * Listens for click events on items inside the main content area.
+         * It then calls the appropriate function based on the event target.
+         * This avoids adding multiple event handlers on individual elements.
+         */
+        mainContent.addEventListener('click', function(event) {
+            // hanle clicks on an individual topic
+            if (event.target.tagName === 'H3') {
+                var tabContent = event.target.parentElement.nextElementSibling;
+                if (tabContent.classList.contains('hidden')) {
+                    tabContent.classList.remove('hidden');
+                    tabContent.setAttribute('aria-hidden', false);
+                    event.target.classList.remove('collapsed');
+                } else {
+                    tabContent.classList.add('hidden');
+                    tabContent.setAttribute('aria-hidden', true);
+                    event.target.classList.add('collapsed');
+                }
+            }
+
+            // handle clicks on the master toggle buttons
+            if (event.target.classList.contains('toggle')) {
+                toggleMainSectionTopics(event.target);
+            }
+        });
+    }
+})();

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -1198,9 +1198,9 @@
     },
     {
       "files": [
-        "js/privacy/privacy-quantum.js"
+        "js/privacy/privacy-protocol.js"
       ],
-      "name": "privacy_quantum"
+      "name": "privacy_protocol"
     },
     {
       "files": [


### PR DESCRIPTION
## Description
- Reverts removal of accordion functionality from `privacy/firefox` pages, that was removed in https://github.com/mozilla/bedrock/pull/6278.

Note: whilst restoring this code I realised it was never very accessible. The ARIA support isn't great, and the individual sections are not expandable via keyboard 😩. There seems to be some urgency in restoring this that I don't fully understand (from a legal point of view), but if we are to support this accordion as a feature long term, then we should at least file bugs and make sure our privacy content is accessible to everyone.

## Issue / Bugzilla link
#6713

## Testing
- [ ] Accordion should function as it was previously on all related privacy pages.
- [ ] Accordion should be keyboard accessible.
