### PR TITLE
(Fixes  #6714) Update licensing page copy

### DIFF
--- a/bedrock/foundation/templates/foundation/licensing.html
+++ b/bedrock/foundation/templates/foundation/licensing.html
@@ -53,13 +53,7 @@
   <h2>{{ _('Website Content') }}</h2>
   <p>
     {% trans %}
-      Mozilla website content (i.e. text and pictures, not look and feel) is
-      generally licensed under Creative Commons Attribution Share-Alike
-      (CC-SA) licenses. User-generated content, such as comments on our
-      blog posts, are also generally made available under CC-SA, but
-      different Mozilla websites (such as addons.mozilla.org) may allow
-      users to choose other licenses for content that they upload to
-      our sites.
+      The text of Mozilla websites is generally licensed under a Creative Commons Attribution (CC BY) or Attribution-ShareAlike (CC BY-SA) license, as indicated. Also, certain Mozilla websites (such as addons.mozilla.org) may allow users to choose Creative Commons licenses for content that they upload to our sites.
     {% endtrans %}
   </p>
 


### PR DESCRIPTION
## Description
Updates legal copy in 'Website Content' section on foundation/licensing/

## Issue / Bugzilla link
#6714 

## Testing
https://bedrock-demo-achurchwell.oregon-b.moz.works/en-US/foundation/licensing/