### PR TITLE
Fix broken string translation for /firefox/new/ page title (Fixes #6728)

### DIFF
--- a/bedrock/firefox/templates/firefox/new/base.html
+++ b/bedrock/firefox/templates/firefox/new/base.html
@@ -8,7 +8,9 @@
 
 {% extends "firefox/base-pebbles.html" %}
 
-{%- block page_title -%}{{_('Download Firefox - Free Web Browser')}}{%- endblock -%}
+{% block page_title_prefix %}{{_('Download Firefox')}} — {% endblock %}
+
+{%- block page_title -%}{{_('Free Web Browser')}}{%- endblock -%}
 
 {# Bug 1438302 Avoid duplicate content for en-CA and en-GB pages. #}
 {%- block page_title_suffix -%}

--- a/bedrock/firefox/templates/firefox/new/scene1_linux.html
+++ b/bedrock/firefox/templates/firefox/new/scene1_linux.html
@@ -4,8 +4,8 @@
 
 {% extends "firefox/new/scene1.html" %}
 
-{%- block page_title -%} {{_('Download Mozilla Firefox for Linux')}} {%- endblock -%}
-{%- block page_title_suffix -%} {{_(' — Free Web Browser')}} {%- endblock -%}
+{% block page_title_full %}{{_('Download Mozilla Firefox for Linux')}}{{_(' — Free Web Browser')}}{%- endblock -%}
+{% block page_title_suffix %}{% endblock %}
 
 {% block page_desc %}
   {{ _('Download Mozilla Firefox for Linux, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Linux today!') }}

--- a/bedrock/firefox/templates/firefox/new/scene1_mac.html
+++ b/bedrock/firefox/templates/firefox/new/scene1_mac.html
@@ -4,8 +4,8 @@
 
 {% extends "firefox/new/scene1.html" %}
 
-{%- block page_title -%} {{_('Download Mozilla Firefox for Mac')}} {%- endblock -%}
-{%- block page_title_suffix -%} {{_(' — Free Web Browser')}} {%- endblock -%}
+{% block page_title_full %}{{_('Download Mozilla Firefox for Mac')}}{{_(' — Free Web Browser')}}{%- endblock -%}
+{% block page_title_suffix %}{% endblock %}
 
 {% block page_desc %}
   {{ _('Download Mozilla Firefox for Mac, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Mac today!') }}

--- a/bedrock/firefox/templates/firefox/new/scene1_windows.html
+++ b/bedrock/firefox/templates/firefox/new/scene1_windows.html
@@ -4,8 +4,8 @@
 
 {% extends "firefox/new/scene1.html" %}
 
-{%- block page_title -%} {{_('Download Mozilla Firefox for Windows')}} {%- endblock -%}
-{%- block page_title_suffix -%} {{_(' — Free Web Browser')}} {%- endblock -%}
+{% block page_title_full %}{{_('Download Mozilla Firefox for Windows')}}{{_(' — Free Web Browser')}}{%- endblock -%}
+{% block page_title_suffix %}{% endblock %}
 
 {% block page_desc %}
   {{ _('Download Mozilla Firefox for Windows, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows today!') }}


### PR DESCRIPTION
Fixes #6728 

Demos: 

https://bedrock-demo-agibson.oregon-b.moz.works/firefox/new/
https://bedrock-demo-agibson.oregon-b.moz.works/firefox/windows/
https://bedrock-demo-agibson.oregon-b.moz.works/firefox/mac/
https://bedrock-demo-agibson.oregon-b.moz.works/firefox/linux/
