### PR TITLE
Update external data during docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -96,8 +96,17 @@ RUN pip install --no-cache-dir -r requirements/docs.txt
 COPY ./setup.cfg ./
 COPY ./tests ./tests
 
+# build args
+ARG GIT_SHA=latest
+ARG BRANCH_NAME=master
+ENV GIT_SHA=${GIT_SHA}
+ENV BRANCH_NAME=${BRANCH_NAME}
+
 # get fresh database
 RUN ./bin/run-db-download.py --force
+
+# rely on build args
+RUN bin/run-sync-all.sh
 
 # get fresh l10n files
 RUN ./manage.py l10n_update

--- a/bin/cron.py
+++ b/bin/cron.py
@@ -102,7 +102,7 @@ def schedule_database_jobs():
     @babis.decorator(ping_after=DEAD_MANS_SNITCH_URL)
     def update_upload_database():
         fn_name = 'update_upload_database'
-        command = 'bin/run-db-update.sh'
+        command = 'bin/run-db-update.sh --auth'
         time_since = get_time_since(fn_name)
         if time_since > 21600:  # 6 hours
             command += ' --all'

--- a/bin/run-db-update.sh
+++ b/bin/run-db-update.sh
@@ -1,19 +1,44 @@
 #!/bin/bash
 set -ex
 
+# run all jobs
+ALL=false
+# run jobs that require secrets
+AUTH=false
+
+# parse cli args
+while [[ $# -ge 1 ]]; do
+    key="$1"
+    case $key in
+        --all)
+            ALL=true
+            ;;
+        --auth)
+            AUTH=true
+            ;;
+    esac
+    shift # past argument or value
+done
+
 python manage.py update_product_details_files
 python manage.py update_security_advisories --quiet
 python manage.py update_wordpress --quiet
-python manage.py update_pocketfeed --quiet
 python manage.py update_release_notes --quiet
 python manage.py update_content_cards --quiet
 python manage.py update_externalfiles --quiet
 python manage.py update_newsletter_data --quiet
 python manage.py update_www_config --quiet
 
-if [[ "$1" == "--all" ]]; then
+if [[ "$AUTH" == true ]]; then
+    # jobs that require some auth. don't run these during build.
+    python manage.py update_pocketfeed --quiet
+fi
+
+if [[ "$ALL" == true ]]; then
     # less frequent. these will modify the DB every time.
     # TODO fix this
-    python manage.py cron update_tweets
+    if [[ "$AUTH" == true ]]; then
+        python manage.py cron update_tweets
+    fi
     python manage.py cron update_ical_feeds
 fi

--- a/bin/sync-all.sh
+++ b/bin/sync-all.sh
@@ -8,5 +8,6 @@ fi
 
 ./bin/run-db-download.py --force
 ./manage.py migrate --noinput
+./bin/run-db-update.sh --all
 ./manage.py l10n_update
 ./manage.py update_sitemaps


### PR DESCRIPTION
* Only pull data that doesn't require auth during build as secrets aren't available.
* Also run migrations and db updates during dev image build.