### PR TITLE
[bug 1493595] increase sample rate for win10 taskbar experiment

### DIFF
--- a/media/js/firefox/new/experiment-win10-taskbar-funnelcake.js
+++ b/media/js/firefox/new/experiment-win10-taskbar-funnelcake.js
@@ -15,8 +15,8 @@
         var mclane = new Mozilla.TrafficCop({
             id: 'experiment_win10_taskbar_funnelcake',
             variations: {
-                'f=138': 9, // control build
-                'f=139': 9  // taskbar build
+                'f=138': 18, // control build
+                'f=139': 18  // taskbar build
             }
         });
 


### PR DESCRIPTION
## Description
Downloads have been a bit slower than projected, so we're increasing the sample size in order to reach the target total so we can turn off the experiment before Firefox 65 ships (thus avoiding the need for funnelcake builds of Fx65).

## Issue / Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1493595#c56
