### PR TITLE
Fix deployment for clusters with no clock-deploy.yaml

### DIFF
--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -9,8 +9,12 @@ git clone --depth=1 -b ${CONFIG_BRANCH:=master} ${CONFIG_REPO} config_checkout
 cd config_checkout
 
 set -u
-sed -i -e "s|image: .*|image: ${DEPLOYMENT_DOCKER_IMAGE}|" ${CLUSTER_NAME}/${NAMESPACE}/{clock-,}${DEPLOYMENT_YAML:=deploy.yaml}
-git add ${CLUSTER_NAME}/${NAMESPACE}/{clock-,}${DEPLOYMENT_YAML}
+sed -i -e "s|image: .*|image: ${DEPLOYMENT_DOCKER_IMAGE}|" ${CLUSTER_NAME}/${NAMESPACE}/${DEPLOYMENT_YAML:=deploy.yaml}
+git add ${CLUSTER_NAME}/${NAMESPACE}/${DEPLOYMENT_YAML}
+if [[ -f "${CLUSTER_NAME}/${NAMESPACE}/clock-${DEPLOYMENT_YAML}" ]]; then
+    sed -i -e "s|image: .*|image: ${DEPLOYMENT_DOCKER_IMAGE}|" ${CLUSTER_NAME}/${NAMESPACE}/clock-${DEPLOYMENT_YAML}
+    git add ${CLUSTER_NAME}/${NAMESPACE}/clock-${DEPLOYMENT_YAML}
+fi
 git commit -m "set image to ${DEPLOYMENT_DOCKER_IMAGE} in ${CLUSTER_NAME}" || echo "nothing new to commit"
 git push
 DEPLOYMENT_VERSION=$(git rev-parse --short HEAD)


### PR DESCRIPTION
Check to see if the file exists before updating it. Deployment failed when deploy.sh tried to update the non-existant file.

https://ci.us-west.moz.works/blue/organizations/jenkins/bedrock_multibranch_pipeline/detail/prod/374/pipeline/