### PR TITLE
[fix #6756] Add vanity redirect for decentralization

### DIFF
--- a/bedrock/mozorg/redirects.py
+++ b/bedrock/mozorg/redirects.py
@@ -656,4 +656,7 @@ redirectpatterns = (
 
     # issue 6266
     redirect(r'^about/policy/leandata/?$', 'mozorg.about.policy.lean-data.index'),
+
+    # issue 6756 - vanity URL
+    redirect(r'^decentralization/?$', 'mozorg.internet-health.decentralization'),
 )


### PR DESCRIPTION
## Description
Adds a redirect from `/decentralization` to `/internet-health/decentralization/`

## Issue / Bugzilla link
#6756 