### PR TITLE
Update accounts-2018.html

### DIFF
--- a/bedrock/firefox/templates/firefox/accounts-2018.html
+++ b/bedrock/firefox/templates/firefox/accounts-2018.html
@@ -62,14 +62,14 @@
     aspect_ratio='mzp-has-aspect-1-1',
     class='mzp-l-card-feature-left-half mzp-t-firefox lockbox-card',
     link_cta=_('Get the Lockbox App'),
-    link_url='https://app.adjust.com/kq8zhhz',
+    link_url='https://itunes.apple.com/us/app/firefox-lockbox/id1314000270',
     ga_title='Get the Lockbox App'
   ) %}
     <p>{{ _('No more getting locked out of apps and websites. Lockbox secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.') }}</p>
 
     <ul class="mobile-content">
       <li class="ios">
-        <a href="https://app.adjust.com/kq8zhhz" data-link-type="download" data-download-os="iOS">
+        <a href="https://itunes.apple.com/us/app/firefox-lockbox/id1314000270" data-link-type="download" data-download-os="iOS">
           <img src="{{ l10n_img('firefox/ios/btn-app-store.svg') }}" alt="{{ _('Download on the App Store') }}" width="152" height="45">
         </a>
       </li>


### PR DESCRIPTION
## Description
Currently this page has adjust.com links in it. adjust is a self-proclaimed "mobile measurement company", which is English for just another company trying to monetize user data. Mozilla is better than this. Please give the direct download links to apps instead of routing them through services such as adjust.