### PR TITLE
Remove test pilot content

### DIFF
--- a/bedrock/firefox/templates/firefox/channel/base.html
+++ b/bedrock/firefox/templates/firefox/channel/base.html
@@ -82,14 +82,6 @@
           <li><a rel="external" class="more" href="https://developer.mozilla.org/docs/Mozilla/QA/Bug_writing_guidelines">{{ _('Tips for filing a bug') }}</a>
         </ul>
       </section>
-      {% block test_pilot %}
-      <section class="test-pilot">
-        <h3>{{ _('Take our latest experimental features for a spin and shape the future of Firefox.') }}</h3>
-        <ul>
-          <li><a rel="external" class="more" href="https://testpilot.firefox.com/">{{ _('Learn more about Test Pilot') }}</a></li>
-        </ul>
-      </section>
-      {% endblock %}
     </div>
   </div>
   <aside id="newsletter-subscribe">

--- a/bedrock/firefox/templates/firefox/features/index.html
+++ b/bedrock/firefox/templates/firefox/features/index.html
@@ -65,11 +65,6 @@
           <h3>{{ _('Sync between devices') }}</h3>
         </a>
       </li>
-      <li class="features-list-item test-pilot">
-        <a href="https://testpilot.firefox.com/?utm_source=www.mozilla.org&amp;utm_medium=referral&amp;utm_campaign=fx-content-hub" data-link-type="link" data-link-name="Firefox Test Pilot">
-          <h3>{{ _('Firefox Test Pilot') }}</h3>
-        </a>
-      </li>
     {% if l10n_has_tag('firefox-features-send-tabs') %}
       <li class="features-list-item send-tabs">
         <a href="{{ url('firefox.accounts') }}" data-link-type="link" data-link-name="Tabs that travel">

--- a/media/css/firefox/channel.less
+++ b/media/css/firefox/channel.less
@@ -564,16 +564,11 @@ html[lang^="en"] {
         .at2x('/media/img/firefox/channel/alert-icon.png', 130px, 114px);
         background-position: top 20px center;
         background-repeat: no-repeat;
-        float: left;
         padding-top: 162px;
-    }
-
-    &.test-pilot {
-        .at2x('/media/img/firefox/channel/test-pilot.png', 200px, 162px);
-        background-position: top center;
-        background-repeat: no-repeat;
-        float: right;
-        padding-top: 162px;
+        float: none;
+        margin: (@baseLine * 2) auto (@baseLine * 3);
+        text-align: center;
+        width: auto;
     }
 
     h3 {
@@ -610,11 +605,6 @@ html[lang^="en"] {
 
     @media only screen and (max-width: @breakTablet) {
         width: auto;
-
-        &.bugzilla,
-        &.test-pilot {
-            float: none;
-        }
     }
 
     @media only screen and (max-width: @breakMobileLandscape) {
@@ -625,36 +615,6 @@ html[lang^="en"] {
 
         ul li {
             .font-size(@baseFontSize);
-        }
-    }
-}
-
-#platform-android #help-out section,
-#platform-ios #help-out section {
-
-    &.bugzilla {
-        float: none;
-        margin: (@baseLine * 2) auto (@baseLine * 3);
-        text-align: center;
-        width: auto;
-    }
-}
-
-.html-rtl #help-out section {
-
-    &.bugzilla {
-        float: right;
-    }
-
-    &.test-pilot {
-        float: left;
-    }
-
-    @media only screen and (max-width: @breakTablet) {
-
-        &.bugzilla,
-        &.test-pilot {
-            float: none;
         }
     }
 }


### PR DESCRIPTION
## Description

Removes Test Pilot content from 2 pages, and some CSS that made the content work. Fixes #6776 .

## Issue / Bugzilla link

#6776 

## Testing

Browser tested in Firefox 65 wide/narrow screen, LTR/RTL locales.
