### PR TITLE
Remove Yandex test, make 90% cohort the 100% default (Fixes #6752)

### DIFF
--- a/media/js/firefox/new/yandex/scene1.js
+++ b/media/js/firefox/new/yandex/scene1.js
@@ -8,9 +8,7 @@
     var Yandex = {
         RUSSIA_COUNTRY_CODE: 'ru',
         COOKIE_ID: 'firefox-yandex',
-        COOKIE_YANDEX_COHORT: 'firefox-yandex-cohort',
-        COOKIE_EXPIRATION_DAYS: 3,
-        YANDEX_SAMPLE_RATE: 0.9
+        COOKIE_EXPIRATION_DAYS: 3
     };
 
     var _client = Mozilla.Client;
@@ -112,8 +110,8 @@
     };
 
     Yandex.shouldShowYandex = function() {
-        // Is user in Russia and within Yandex cohort?
-        return Yandex.verifyLocation(Yandex.getCookie(Yandex.COOKIE_ID)) && Yandex.getCookie(Yandex.COOKIE_YANDEX_COHORT) === 'yes';
+        // Is user in Russia?
+        return Yandex.verifyLocation(Yandex.getCookie(Yandex.COOKIE_ID));
     };
 
     Yandex.showYandexMessaging = function() {
@@ -185,9 +183,7 @@
     };
 
     Yandex.setCookie = function(country) {
-        var cohort = Yandex.isWithinSampleRate() ? 'yes' : 'no';
         Mozilla.Cookies.setItem(Yandex.COOKIE_ID, country, Yandex.cookieExpiresDate());
-        Mozilla.Cookies.setItem(Yandex.COOKIE_YANDEX_COHORT, cohort, Yandex.cookieExpiresDate());
     };
 
     Yandex.getCookie = function(id) {
@@ -195,11 +191,7 @@
     };
 
     Yandex.hasCookie = function() {
-        return Mozilla.Cookies.hasItem(Yandex.COOKIE_ID) && Mozilla.Cookies.hasItem(Yandex.COOKIE_YANDEX_COHORT);
-    };
-
-    Yandex.isWithinSampleRate = function() {
-        return (Math.random() < Yandex.YANDEX_SAMPLE_RATE) ? true : false;
+        return Mozilla.Cookies.hasItem(Yandex.COOKIE_ID);
     };
 
     Yandex.init = function() {

--- a/tests/unit/spec/firefox/new/yandex/scene1.js
+++ b/tests/unit/spec/firefox/new/yandex/scene1.js
@@ -143,10 +143,8 @@ describe('yandex-scene1.js', function() {
 
         it('should return true if criteria is met', function() {
             spyOn(Mozilla.Yandex, 'verifyLocation').and.returnValue(true);
-            spyOn(Mozilla.Yandex, 'getCookie').and.returnValue('yes');
 
             expect(Mozilla.Yandex.shouldShowYandex()).toBeTruthy();
-            expect(Mozilla.Yandex.getCookie).toHaveBeenCalledWith(Mozilla.Yandex.COOKIE_YANDEX_COHORT);
         });
 
         it('should return false if one or more of the criteria is not met', function() {
@@ -215,14 +213,10 @@ describe('yandex-scene1.js', function() {
         it('should set session cookies as expected', function() {
             var country = 'ru';
             spyOn(Mozilla.Cookies, 'setItem');
-            spyOn(Mozilla.Yandex, 'isWithinSampleRate').and.returnValue(true);
 
             Mozilla.Yandex.setCookie(country);
 
-            expect(Mozilla.Yandex.isWithinSampleRate).toHaveBeenCalled();
-            expect(Mozilla.Cookies.setItem.calls.count()).toEqual(2);
             expect(Mozilla.Cookies.setItem).toHaveBeenCalledWith(Mozilla.Yandex.COOKIE_ID, country, jasmine.any(String));
-            expect(Mozilla.Cookies.setItem).toHaveBeenCalledWith(Mozilla.Yandex.COOKIE_YANDEX_COHORT, 'yes', jasmine.any(String));
         });
     });
 
@@ -231,41 +225,22 @@ describe('yandex-scene1.js', function() {
         it('should return an value as expected', function() {
             spyOn(Mozilla.Cookies, 'getItem');
             Mozilla.Yandex.getCookie(Mozilla.Yandex.COOKIE_ID);
-            expect(Mozilla.Cookies.getItem).toHaveBeenCalledWith(Mozilla.Yandex.COOKIE_ID);
         });
     });
 
     describe('hasCookie', function() {
 
-        it('should return true if both session cookies exists', function() {
+        it('should return true if session cookie exists', function() {
             spyOn(Mozilla.Cookies, 'hasItem').and.returnValue(true);
             var result = Mozilla.Yandex.hasCookie();
-            expect(Mozilla.Cookies.hasItem.calls.count()).toEqual(2);
             expect(Mozilla.Cookies.hasItem).toHaveBeenCalledWith(Mozilla.Yandex.COOKIE_ID);
-            expect(Mozilla.Cookies.hasItem).toHaveBeenCalledWith(Mozilla.Yandex.COOKIE_YANDEX_COHORT);
             expect(result).toBeTruthy();
         });
 
-        it('should return false if one or more session cookies do not exist', function() {
-            spyOn(Mozilla.Cookies, 'hasItem').and.callFake(function(id) {
-                return id === Mozilla.Yandex.COOKIE_ID ? true : false;
-            });
+        it('should return false if session cookie does not exist', function() {
+            spyOn(Mozilla.Cookies, 'hasItem').and.returnValue(false);
             var result = Mozilla.Yandex.hasCookie();
-            expect(Mozilla.Cookies.hasItem.calls.count()).toEqual(2);
             expect(result).toBeFalsy();
-        });
-    });
-
-    describe('isWithinSampleRate', function() {
-
-        it('should return true if within sample rate', function() {
-            spyOn(window.Math, 'random').and.returnValue(0.8);
-            expect(Mozilla.Yandex.isWithinSampleRate()).toBeTruthy();
-        });
-
-        it('should return false if exceeds sample rate', function() {
-            spyOn(window.Math, 'random').and.returnValue(1);
-            expect(Mozilla.Yandex.isWithinSampleRate()).toBeFalsy();
         });
     });
 


### PR DESCRIPTION
## Description
- Removes Yandex A/B test from `/ru/firefox/new/` and makes 100% of audience geolocated in Russia see the Yandex content.

## Issue / Bugzilla link
#6752

## Testing
- [ ] An easy way to test that all this logic still works as expected is to change [`RUSSIA_COUNTRY_CODE`](https://github.com/mozilla/bedrock/blob/master/media/js/firefox/new/yandex/scene1.js#L9) locally to `us`, and then verify that the Yandex content is shown without any regressions or errors in the console.