### PR TITLE
[fix #6787] Link to local press center blogs in global nav

### DIFF
--- a/bedrock/base/templates/includes/protocol/navigation/menu/about.html
+++ b/bedrock/base/templates/includes/protocol/navigation/menu/about.html
@@ -21,7 +21,7 @@
                 <li><a href="{{ url('mozorg.about.leadership') }}" data-link-name="Leadership" data-link-type="nav" data-link-position="subnav" data-link-group="about">{{ _('Leadership') }}</a></li>
                 <li><a href="https://foundation.mozilla.org/?utm_source=www.mozilla.org&amp;utm_medium=referral&amp;utm_campaign=nav&amp;utm_content=about" data-link-name="Mozilla Foundation" data-link-type="nav" data-link-position="subnav" data-link-group="about">{{ _('Mozilla Foundation') }}</a></li>
                 <li><a href="{{ url('mozorg.mission') }}" data-link-name="Mission" data-link-type="nav" data-link-position="subnav" data-link-group="about">{{ _('Mission') }}</a></li>
-                <li><a href="https://blog.mozilla.org/press/?utm_source=www.mozilla.org&amp;utm_medium=referral&amp;utm_campaign=nav&amp;utm_content=about" data-link-name="Press Center" data-link-type="nav" data-link-position="subnav" data-link-group="about">{{ _('Press Center') }}</a></li>
+                <li><a href="{{ press_blog_url() }}?utm_source=www.mozilla.org&amp;utm_medium=referral&amp;utm_campaign=nav&amp;utm_content=about" data-link-name="Press Center" data-link-type="nav" data-link-position="subnav" data-link-group="about">{{ _('Press Center') }}</a></li>
                 <li><a href="{{ url('mozorg.contact.contact-landing') }}" data-link-name="Contact" data-link-type="nav" data-link-position="subnav" data-link-group="about">{{ _('Contact') }}</a></li>
               </ul>
             </section>

--- a/bedrock/mozorg/templatetags/misc.py
+++ b/bedrock/mozorg/templatetags/misc.py
@@ -334,7 +334,7 @@ def press_blog_url(ctx):
     """Output a link to the press blog taking locales into account.
 
     Uses the locale from the current request. Checks to see if we have
-    a press blog that match this locale, returns the localized press blog
+    a press blog that matches this locale, returns the localized press blog
     url or falls back to the US press blog url if not.
 
     Examples
@@ -349,13 +349,13 @@ def press_blog_url(ctx):
 
         https://blog.mozilla.org/press/
 
-    For es-ES this would output:
+    For en-GB this would output:
 
-        https://blog.mozilla.org/press-es/
+        https://blog.mozilla.org/press-uk/
 
-    For es-MX this would output:
+    For de this would output:
 
-        https://blog.mozilla.org/press-latam/
+        https://blog.mozilla.org/press-de/
 
     """
     locale = getattr(ctx['request'], 'locale', 'en-US')

--- a/bedrock/mozorg/tests/test_helper_misc.py
+++ b/bedrock/mozorg/tests/test_helper_misc.py
@@ -321,10 +321,14 @@ class TestPressBlogUrl(TestCase):
         eq_(self._render('en-GB'), 'https://blog.mozilla.org/press-uk/')
 
     def test_press_blog_url_latam(self):
-        """South American Spanishes have a specific blog"""
-        eq_(self._render('es-AR'), 'https://blog.mozilla.org/press-latam/')
-        eq_(self._render('es-CL'), 'https://blog.mozilla.org/press-latam/')
-        eq_(self._render('es-MX'), 'https://blog.mozilla.org/press-latam/')
+        """South American Spanishes use the es-ES blog"""
+        eq_(self._render('es-AR'), 'https://blog.mozilla.org/press-es/')
+        eq_(self._render('es-CL'), 'https://blog.mozilla.org/press-es/')
+        eq_(self._render('es-MX'), 'https://blog.mozilla.org/press-es/')
+
+    def test_press_blog_url_brazil(self):
+        """Brazilian Portuguese has its own br blog"""
+        eq_(self._render('pt-BR'), 'https://blog.mozilla.org/press-br/')
 
     def test_press_blog_url_other_locale(self):
         """No blog for locale, fallback to default press blog"""

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -708,13 +708,14 @@ PRESS_BLOGS = {
     'de': 'press-de/',
     'en-GB': 'press-uk/',
     'en-US': 'press/',
-    'es-AR': 'press-latam/',
-    'es-CL': 'press-latam/',
+    'es-AR': 'press-es/',
+    'es-CL': 'press-es/',
     'es-ES': 'press-es/',
-    'es-MX': 'press-latam/',
+    'es-MX': 'press-es/',
     'fr': 'press-fr/',
     'it': 'press-it/',
     'pl': 'press-pl/',
+    'pt-BR': 'press-br/',
 }
 
 DONATE_LINK = ('https://donate.mozilla.org/{locale}/'


### PR DESCRIPTION
## Description
Use the `press_blog_url()` template tag for localized links in the new global nav.

The tag is defined in [`mozorg/templatetags/misc.py`](https://github.com/mozilla/bedrock/blob/master/bedrock/mozorg/templatetags/misc.py#L333) and the list of press blogs is defined in [`settings/base.py`](https://github.com/mozilla/bedrock/blob/master/bedrock/settings/base.py#L707).

This also updates the list of local press blogs, adding `/press-br/` (which was launched some time after the initial batch of local press blogs but apparently just never got added here) and changing all Spanish locales to use the general `/press-es/` blog (we used to have a separate blog at `/press-latam/` but it was recently decommissioned and redirected).

Also updates related tests.

## Issue / Bugzilla link
#6787 

## Testing
We have local press blogs for de, en-GB, es-AR, es-CL, es-ES, es-MX, fr, it, pl, and pt-BR. Other locales default to the en-US press blog.

Since this also updates the list of local press blogs and related tests, we should ensure it doesn't cause any regressions or break any other tests.
