### PR TITLE
Fix utm_content value for global FxA CTA in navigation (Fixes #6809)

### DIFF
--- a/bedrock/base/templates/includes/protocol/navigation/index.html
+++ b/bedrock/base/templates/includes/protocol/navigation/index.html
@@ -24,7 +24,7 @@
           {{ download_firefox(alt_copy=_('Download Firefox'), dom_id='protocol-nav-download-firefox', button_color='mzp-t-secondary mzp-t-small', download_location='nav') }}
           {% if LANG == 'en-US' %}
           <div class="c-navigation-fxa-cta-container">
-            <a class="c-navigation-fxa-cta mzp-c-button mzp-t-secondary mzp-t-small mzp-t-download" href="https://accounts.firefox.com/signup?service=sync&context=fx_desktop_v3&entrypoint=mozilla.org-globalnav&utm_source=www.mozilla.org&utm_content=Get%20a%20Firefox%20Account&utm_medium=referral&utm_campaign=globalnav" data-button-name="Create a Firefox Account" data-link-type="button" data-cta-position="secondary cta">
+            <a class="c-navigation-fxa-cta mzp-c-button mzp-t-secondary mzp-t-small mzp-t-download" href="https://accounts.firefox.com/signup?service=sync&context=fx_desktop_v3&entrypoint=mozilla.org-globalnav&utm_source=www.mozilla.org&utm_content=get-firefox-account&utm_medium=referral&utm_campaign=globalnav" data-button-name="Get a Firefox Account" data-link-type="button" data-cta-position="secondary cta">
               Get a Firefox Account
             </a>
             <p class="c-navigation-fxa-cta-small-link"><a data-link-type="nav" data-link-name="Check out the Benefits" href="{{ url('firefox.accounts') }}">Check out the Benefits</a></p>


### PR DESCRIPTION
## Description
- Changes `utm_content=Get%20a%20Firefox%20Account` to `utm_content=get-firefox-account`.
- Also changes `data-button-name="Create a Firefox Account"` to `data-button-name="Get a Firefox Account"` so that it better matches the button text.

## Issue / Bugzilla link
#6809