### PR TITLE
Test global FxA CTA in German and French locales (Fixes #6792)

### DIFF
--- a/bedrock/base/templates/base-pebbles.html
+++ b/bedrock/base/templates/base-pebbles.html
@@ -132,6 +132,14 @@
     {% if switch('global-fxa-cta-experiment', ['en-US']) %}
       {{ js_bundle('global-fxa-cta-experiment') }}
     {% endif %}
+
+    {% if switch('global-fxa-cta-experiment-de', ['de']) %}
+      {{ js_bundle('global-fxa-cta-experiment') }}
+    {% endif %}
+
+    {% if switch('global-fxa-cta-experiment-fr', ['fr']) %}
+      {{ js_bundle('global-fxa-cta-experiment') }}
+    {% endif %}
     {% endblock %}
 
     {# Bug 1381776 #}

--- a/bedrock/base/templates/base-resp.html
+++ b/bedrock/base/templates/base-resp.html
@@ -156,6 +156,14 @@
     {% if switch('global-fxa-cta-experiment', ['en-US']) %}
       {{ js_bundle('global-fxa-cta-experiment') }}
     {% endif %}
+
+    {% if switch('global-fxa-cta-experiment-de', ['de']) %}
+      {{ js_bundle('global-fxa-cta-experiment') }}
+    {% endif %}
+
+    {% if switch('global-fxa-cta-experiment-fr', ['fr']) %}
+      {{ js_bundle('global-fxa-cta-experiment') }}
+    {% endif %}
     {% endblock %}
 
     {# Bug 1381776 #}

--- a/bedrock/base/templates/includes/protocol/navigation/index.html
+++ b/bedrock/base/templates/includes/protocol/navigation/index.html
@@ -22,13 +22,23 @@
         {% if not hide_nav_download_button %}
         <div class="mzp-c-navigation-download">
           {{ download_firefox(alt_copy=_('Download Firefox'), dom_id='protocol-nav-download-firefox', button_color='mzp-t-secondary mzp-t-small', download_location='nav') }}
-          {% if LANG == 'en-US' %}
-          <div class="c-navigation-fxa-cta-container">
-            <a class="c-navigation-fxa-cta mzp-c-button mzp-t-secondary mzp-t-small mzp-t-download" href="https://accounts.firefox.com/signup?service=sync&context=fx_desktop_v3&entrypoint=mozilla.org-globalnav&utm_source=www.mozilla.org&utm_content=get-firefox-account&utm_medium=referral&utm_campaign=globalnav" data-button-name="Get a Firefox Account" data-link-type="button" data-cta-position="secondary cta">
-              Get a Firefox Account
-            </a>
-            <p class="c-navigation-fxa-cta-small-link"><a data-link-type="nav" data-link-name="Check out the Benefits" href="{{ url('firefox.accounts') }}">Check out the Benefits</a></p>
-          </div>
+          {% if LANG in ['en-US', 'de', 'fr'] %}
+            {% if LANG == 'de' %}
+              {% set fxa_button_text = 'Firefox-Konto erstellen' %}
+              {% set fxa_link_text = 'Das sind deine Vorteile' %}
+            {% elif LANG == 'fr' %}
+              {% set fxa_button_text = 'Créez un compte Firefox' %}
+              {% set fxa_link_text = 'Découvrez les avantages' %}
+            {% else %}
+              {% set fxa_button_text = 'Get a Firefox Account' %}
+              {% set fxa_link_text = 'Check out the Benefits' %}
+            {% endif %}
+            <div class="c-navigation-fxa-cta-container">
+              <a class="c-navigation-fxa-cta mzp-c-button mzp-t-secondary mzp-t-small mzp-t-download" href="https://accounts.firefox.com/signup?service=sync&context=fx_desktop_v3&entrypoint=mozilla.org-globalnav&utm_source=www.mozilla.org&utm_content=get-firefox-account&utm_medium=referral&utm_campaign=globalnav" data-button-name="Get a Firefox Account" data-link-type="button" data-cta-position="secondary cta">
+                {{ fxa_button_text }}
+              </a>
+              <p class="c-navigation-fxa-cta-small-link"><a data-link-type="nav" data-link-name="Check out the Benefits" href="{{ url('firefox.accounts') }}">{{ fxa_link_text }}</a></p>
+            </div>
           {% endif %}
         </div>
         {% endif %}

--- a/media/js/base/global-fxa-cta-experiment.js
+++ b/media/js/base/global-fxa-cta-experiment.js
@@ -91,9 +91,8 @@
             return false;
         }
 
-        // Detect whether the Firefox is up-to-date in a non-strict way.
-        // The minor version is not considered.
-        return userMajorVersion === latestMajorVersion;
+        // User should be on Firefox Quantum or greater.
+        return userMajorVersion >= 57;
     }
 
     function init() {


### PR DESCRIPTION
## Description
- Enables global FxA experiment for `de` and `fr` locales.
- Updates FF version requirements from latest release to >= 57 (Quantum).
- Adds each locale via a separate switch, so that we can start/stop independently.

## Issue / Bugzilla link
#6792

## Testing
- [ ] Experiment should trigger for the above locales, as well as `en-US`.
- [ ] Localized strings should be shown correctly.