### PR TITLE
Fix privacy page toggle (Fixes #6817)

### DIFF
--- a/media/js/privacy/privacy-protocol.js
+++ b/media/js/privacy/privacy-protocol.js
@@ -283,7 +283,7 @@
 
             // handle clicks on the master toggle buttons
             if (e.target.classList.contains('toggle')) {
-                toggleMainSectionTopics(event.target);
+                toggleMainSectionTopics(e.target);
             }
         });
 


### PR DESCRIPTION
## Description
- Fixes "Show all" button on `/privacy/firefox/`.

## Issue / Bugzilla link
#6817

## Testing
- [ ] Button should work in Firefox 65, and continue to work in other browsers.