### PR TITLE
Bug 1528163 - Make sure direct FxA links have replacement urls for Mo…

### DIFF
--- a/bedrock/base/templates/includes/protocol/navigation/index.html
+++ b/bedrock/base/templates/includes/protocol/navigation/index.html
@@ -2,6 +2,8 @@
  # License, v. 2.0. If a copy of the MPL was not distributed with this
  # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
 
+{% from "macros.html" import fxa_link_fragment with context %}
+
 <div class="mzp-c-navigation">
   <div class="mzp-c-navigation-l-content">
     <div class="mzp-c-navigation-container">
@@ -34,7 +36,7 @@
               {% set fxa_link_text = 'Check out the Benefits' %}
             {% endif %}
             <div class="c-navigation-fxa-cta-container">
-              <a class="c-navigation-fxa-cta mzp-c-button mzp-t-secondary mzp-t-small mzp-t-download" href="https://accounts.firefox.com/signup?service=sync&context=fx_desktop_v3&entrypoint=mozilla.org-globalnav&utm_source=www.mozilla.org&utm_content=get-firefox-account&utm_medium=referral&utm_campaign=globalnav" data-button-name="Get a Firefox Account" data-link-type="button" data-cta-position="secondary cta">
+              <a class="c-navigation-fxa-cta mzp-c-button mzp-t-secondary mzp-t-small mzp-t-download" {{ fxa_link_fragment(entrypoint='mozilla.org-globalnav', action='signup', utm_params={'campaign': 'globalnav', 'content': 'get-firefox-account', 'medium': 'referral', 'source': 'www.mozilla.org'}) }} data-button-name="Get a Firefox Account" data-link-type="button" data-cta-position="secondary cta">
                 {{ fxa_button_text }}
               </a>
               <p class="c-navigation-fxa-cta-small-link"><a data-link-type="nav" data-link-name="Check out the Benefits" href="{{ url('firefox.accounts') }}">{{ fxa_link_text }}</a></p>

--- a/bedrock/base/templates/macros.html
+++ b/bedrock/base/templates/macros.html
@@ -301,6 +301,28 @@
   </section>
 {%- endmacro %}
 
+{% macro fxa_link_fragment(entrypoint, action='signin', utm_params={}) -%}
+  {% set fxa_path = '' %}
+  {% set fxa_queries = [
+    'service=sync',
+    'context=fx_desktop_v3'
+  ] %}
+
+  {% if action == 'signup' %}
+    {% set fxa_path = 'signup' %}
+  {% else %}
+    {% do fxa_queries.insert(0, 'action=email') %}
+  {% endif %}
+  {% do fxa_queries.append('entrypoint={}'.format(entrypoint)) %}
+  {% for param, val in utm_params.items() %}
+    {% if val and param in ['campaign', 'content', 'medium', 'source'] %}
+      {% do fxa_queries.append('utm_{}={}'.format(param, val.replace('/', '%2F'))) %}
+    {% endif %}
+  {% endfor %}
+
+  href="{{ settings.FXA_ENDPOINT}}{{ fxa_path }}?{{ fxa_queries|join('&') }}" data-mozillaonline-link="{{ settings.FXA_ENDPOINT_MOZILLAONLINE }}{{ fxa_path }}?{{ fxa_queries|join('&') }}"
+{%- endmacro %}
+
 {% macro fxa_create_account_button(button_location, id_prefix, campaign, entrypoint, button_text = '', button_class = '', content = '', source = '') %}
   {# - creates the "create account" button which links to accounts.firefox.com
        and fallback states including:
@@ -322,31 +344,12 @@
        - content will default to the path to the page, minus the locale
   #}
   {# Parameters for accounts.firefox.com link #}
-  {% set service = 'sync' %}
-  {% set context = 'fx_desktop_v3' %}
   {% set entrypoint = 'mozilla.org-' + entrypoint %}
   {% if not button_text %}
     {% set button_text = _('Create account') %}
   {% endif %}
   {% if not button_class %}
     {% set button_class = 'button-hollow' %}
-  {% endif %}
-  {% if content %}
-    {% set utm_content = content.replace('/', '%2F') %}
-  {% else %}
-    {% set utm_content = request.path_info.replace('/', '%2F') %}
-  {% endif %}
-
-  {# Create accounts.firefox.com link #}
-  {% set accounts_url = ['https://accounts.firefox.com/signup?service=', service,
-                          '&context=', context,
-                          '&entrypoint=', entrypoint,
-                          '&utm_content=', utm_content,
-                          '&utm_campaign=', campaign
-                        ]|join %}
-
-  {% if source %}
-    {% set accounts_url = accounts_url + '&utm_source=' + source %}
   {% endif %}
 
   {# Create ids for buttons and links #}
@@ -364,7 +367,7 @@
     {{ download_firefox(dom_id=download_id, download_location=button_location) }}
   </div>
   <div class="show-fxa-supported-signed-out">
-    <a href="{{ accounts_url }}" class="button {{ button_class }}" data-button-name="Create account" data-link-type="button" data-cta-position="{{ button_location }}" id="{{ account_id }}">
+    <a {{ fxa_link_fragment(entrypoint=entrypoint, action='signup', utm_params={'campaign': campaign, 'content': (content or request.path_info), 'source': source}) }} class="button {{ button_class }}" data-button-name="Create account" data-link-type="button" data-cta-position="{{ button_location }}" id="{{ account_id }}">
       {{ button_text }}
     </a>
   </div>

--- a/bedrock/firefox/templates/firefox/accounts-2018.html
+++ b/bedrock/firefox/templates/firefox/accounts-2018.html
@@ -3,7 +3,7 @@
   # file, You can obtain one at http://mozilla.org/MPL/2.0/. #}
 
 {% from "macros-protocol.html" import feature_card with context %}
-{% from "macros.html" import fxa_email_form, google_play_button, fxa_create_account_button with context %}
+{% from "macros.html" import fxa_email_form, fxa_link_fragment, google_play_button with context %}
 
 {% extends "base-protocol.html" %}
 
@@ -28,7 +28,7 @@
       <h1 class="mzp-c-hero-title">{{ _('One log-in. Power and privacy everywhere.') }}</h1>
       <div id="hero-cta" class="mzp-c-hero-cta">
         <div class="show-fxa-supported-signed-out">
-          <a href="https://accounts.firefox.com/signup?service=sync&context=fx_desktop_v3&entrypoint=accounts-page&utm_source=accounts-page&utm_content=accounts-page-top-cta&utm_medium=referral&utm_campaign=fxa-benefits-page" class="mzp-c-button mzp-t-primary mzp-t-download" data-button-name="Create account" data-link-type="button" data-cta-position="primary cta" id="features-hero-account">
+          <a {{ fxa_link_fragment(entrypoint='accounts-page', action='signup', utm_params={'campaign': 'fxa-benefits-page', 'content': 'accounts-page-top-cta', 'medium': 'referral', 'source': 'accounts-page'}) }} class="mzp-c-button mzp-t-primary mzp-t-download" data-button-name="Create account" data-link-type="button" data-cta-position="primary cta" id="features-hero-account">
             {{ _('Create a Firefox Account') }}
           </a>
         </div>
@@ -230,7 +230,7 @@
         <div class="show-fxa-supported-signed-out">
           {{ fxa_email_form(entrypoint='accounts-page', utm_source='accounts-page', utm_params={'campaign': 'fxa-embedded-form', 'content': 'accounts-page', 'medium': 'referral'}, button_class='mzp-c-button mzp-t-primary mzp-t-download', button_text=_('Create an Account')) }}
 
-          <p class="fxa-signin">{{ _('Already have an account?') }} <a href="https://accounts.firefox.com/?action=email&service=sync&context=fx_desktop_v3&entrypoint=accounts-page&utm_content=%2Ffirefox%2Faccounts%2F&utm_campaign=fxa-embedded-form&utm_source=accounts-page">{{ _('Sign In') }}</a></p>
+          <p class="fxa-signin">{{ _('Already have an account?') }} <a {{ fxa_link_fragment(entrypoint='accounts-page', utm_params={'campaign': 'fxa-embedded-form', 'content': '/firefox/accounts/', 'source': 'accounts-page'}) }}>{{ _('Sign In') }}</a></p>
         </div>
       </div>
 

--- a/bedrock/firefox/templates/firefox/whatsnew/fx64/whatsnew-fx64-base.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/fx64/whatsnew-fx64-base.html
@@ -3,7 +3,7 @@
 
 {% from "macros-protocol.html" import hero, call_out_compact with context %}
 
-{% from "macros.html" import fxa_email_form, google_play_button with context %}
+{% from "macros.html" import fxa_email_form, fxa_link_fragment, google_play_button with context %}
 
 {% add_lang_files "firefox/whatsnew_64" %}
 
@@ -31,6 +31,12 @@
   {% set sync_head = _('Send tabs instantly to your devices') %}
   {% set sync_desc = _('Send an open tab on one device to all your others with a single tap. Much easier than texting or emailing yourself those links.') %}
 {% endif %}
+
+{% set fxa_utm_params = {
+  'campaign': 'wnp64',
+  'content': '/firefox/WNP/64/',
+  'source': 'wnp-64'
+} %}
 
 {% block page_title %}{{ page_title }}{% endblock %}
 {% block page_desc %}{{ page_desc }}{% endblock %}
@@ -62,8 +68,8 @@
    include_cta=True
   ) %}
   <p class="show-fxa-supported-signed-out show-fxa-default">
-    <a href="https://accounts.firefox.com/signup?service=sync&context=fx_desktop_v3&entrypoint=mozilla.org-fx.wnp64&utm_content=%2Ffirefox%2FWNP%2F64%2F&utm_campaign=wnp64&utm_source=wnp-64" class="mzp-c-button mzp-t-download">{{ button_create }}</a><br>
-    <span class="wn64-signin">{{ login_desc }} <a href="https://accounts.firefox.com/?action=email&service=sync&context=fx_desktop_v3&entrypoint=mozilla.org-fx.wnp64&utm_content=%2Ffirefox%2FWNP%2F64%2F&utm_campaign=wnp64&utm_source=wnp-64">{{ login_link }}</a></span>
+    <a {{ fxa_link_fragment(entrypoint='mozilla.org-fx.wnp64', action='signup', utm_params=fxa_utm_params) }} class="mzp-c-button mzp-t-download">{{ button_create }}</a><br>
+    <span class="wn64-signin">{{ login_desc }} <a {{ fxa_link_fragment(entrypoint='mozilla.org-fx.wnp64', utm_params=fxa_utm_params) }}>{{ login_link }}</a></span>
   </p>
   {% endcall %}
   {% call hero(
@@ -109,8 +115,8 @@
     class='mzp-t-firefox t-wn64 show-fxa-default show-fxa-supported-signed-out'
   ) %}
     <p>
-      <a href="https://accounts.firefox.com/signup?service=sync&context=fx_desktop_v3&entrypoint=mozilla.org-fx.wnp64&utm_content=%2Ffirefox%2FWNP%2F64%2F&utm_campaign=wnp64&utm_source=wnp-64" class="mzp-c-button mzp-t-download">{{ button_create }}</a><br>
-      <span class="wn64-signin">{{ login_desc }} <a href="https://accounts.firefox.com/?action=email&service=sync&context=fx_desktop_v3&entrypoint=mozilla.org-fx.wnp64&utm_content=%2Ffirefox%2FWNP%2F64%2F&utm_campaign=wnp64&utm_source=wnp-64">{{ login_link }}</a></span>
+      <a {{ fxa_link_fragment(entrypoint='mozilla.org-fx.wnp64', action='signup', utm_params=fxa_utm_params) }} class="mzp-c-button mzp-t-download">{{ button_create }}</a><br>
+      <span class="wn64-signin">{{ login_desc }} <a {{ fxa_link_fragment(entrypoint='mozilla.org-fx.wnp64', utm_params=fxa_utm_params) }}>{{ login_link }}</a></span>
     </p>
   {% endcall %}
 


### PR DESCRIPTION
…zillaOnline build

## Description
When viewing with a China repack of desktop Fx, FxA signup/signin links on /firefox/accounts/ and /firefox/64.0/whatsnew/ still points to global FxA services, while they should be replaced with urls to China FxA services.

## Issue / Bugzilla link
https://bugzilla.mozilla.org/1528163

## Testing
* Setup UITour permission for test [1](http://bedrock.readthedocs.io/en/latest/uitour.html#local-development)
* Set "distribution.id" with `Services.prefs.getDefaultBranch("distribution.").setCharPref("id", "MozillaOnline");` in Firefox's browser console.
* Visit [/firefox/accounts/](https://www.mozilla.org/firefox/accounts/), the "Create a Firefox Account" button and the "Sign In" link just above the footer  should point to https://accounts.firefox.com.cn/