### PR TITLE
Change Thimble to Glitch

### DIFF
--- a/bedrock/mozorg/templates/mozorg/internet-health/decentralization.html
+++ b/bedrock/mozorg/templates/mozorg/internet-health/decentralization.html
@@ -419,10 +419,17 @@
             <li>
               <h4>{{ _('Start making') }}</h4>
               <p>
-              {% trans glitch='https://glitch.com/' %}
-                Try your hand at creating Web content you care about, in your language.
-                <a href="{{ glitch }}">Glitch</a> is a great way to start.
-              {% endtrans %}
+              {% if l10n_has_tag('glitch_feb2019') %}
+                {% trans glitch='https://glitch.com/' %}
+                  Try your hand at creating Web content you care about, in your language.
+                  <a href="{{ glitch }}">Glitch</a> is a great way to start.
+                {% endtrans %}
+              {% else %}
+                {% trans thimble='https://thimble.mozilla.org/' %}
+                  Try your hand at creating Web content you care about, in your language.
+                  <a href="{{ thimble }}">Thimble</a> is a great way to start.
+                {% endtrans %}
+              {% endif %}
               </p>
             </li>
           </ul>

--- a/bedrock/mozorg/templates/mozorg/internet-health/decentralization.html
+++ b/bedrock/mozorg/templates/mozorg/internet-health/decentralization.html
@@ -419,9 +419,9 @@
             <li>
               <h4>{{ _('Start making') }}</h4>
               <p>
-              {% trans thimble='https://thimble.mozilla.org/' %}
+              {% trans glitch='https://glitch.com/' %}
                 Try your hand at creating Web content you care about, in your language.
-                <a href="{{ thimble }}">Thimble</a> is a great way to start.
+                <a href="{{ glitch }}">Glitch</a> is a great way to start.
               {% endtrans %}
               </p>
             </li>


### PR DESCRIPTION
## Description
Mozilla is recommending Thimble users move to Glitch, since they're going to 'sunset' Thimble.

I haven't used `trans` tags in Django before, so apologies in advance if I've done it wrong.

## Issue / Bugzilla link
N/A

## Testing
I'm afraid I haven't done any.