### PR TITLE
Send entrypoint and form_type when calling /metrics-flow (Fixes #6839)

### DIFF
--- a/media/js/firefox/concerts.js
+++ b/media/js/firefox/concerts.js
@@ -231,7 +231,7 @@ function onYouTubeIframeAPIReady() {
         // copied from base/mozilla-fxa-form.js
         function fetchTokens(destURL) {
             // add required params to the token fetch request
-            destURL += '?utm_campaign=firefox-concert-series-q4-2018&utm_source=mozilla.org';
+            destURL += '?entrypoint=concerts&form_type=email&utm_campaign=firefox-concert-series-q4-2018&utm_source=mozilla.org';
 
             fetch(destURL).then(function(resp) {
                 return resp.json();


### PR DESCRIPTION
## Description
- Adds additional params to the oAuth metric-flow on the `/firefox/concerts/` page.

## Issue / Bugzilla link
https://github.com/mozilla/bedrock/issues/6839

## Testing
- [ ] After loading the page, look at the `params` tab in the network console for the `accounts.firefox.com` GET request. It should now include values for both `entrypoint` and `form_value` params, which are not present in production.