### PR TITLE
Add German editorial home page (Fixes #6585)

### DIFF
--- a/bedrock/mozorg/templates/mozorg/home/home-de.html
+++ b/bedrock/mozorg/templates/mozorg/home/home-de.html
@@ -1,0 +1,143 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+
+{% extends "mozorg/home/home-en.html" %}
+
+{% add_lang_files "mozorg/home/index-quantum" %}
+
+{% block page_title %}{{ _('Internet für Menschen, nicht für Profit') }}{% endblock %}
+
+{% block page_desc %}
+  {{ _('Mozilla ist die gemeinnützige Organisation hinter Firefox. Menschen sollten auch online die Kontrolle über ihr Leben haben. Dafür setzen wir uns ein.') }}
+{% endblock %}
+
+{% block main %}
+<main>
+  <header class="main-page-heading">
+    {# Main page h1 is hidden from view and exists mainly for SEO purposes #}
+    <h1>{{ self.page_title() }}</h1>
+  </header>
+
+  {% call download_banner(
+    title=_('Firefox'),
+    sub_title=_('Dein Leben. Deine Daten. Dein Browser.'),
+    desc=_('Firefox fights for you.'),
+    ) %}
+    {{ download_firefox(dom_id='download-primary', download_location='primary cta') }}
+  {% endcall %}
+
+  {% call download_banner_sticky(
+    title=_('<strong>Firefox</strong> fights for you.'),
+    sub_title=_('Dein Leben. Deine Daten. Dein Browser.'),
+    desc=_('Firefox fights for you.')
+    ) %}
+    {{ download_firefox(dom_id='download-sticky', download_location='sticky cta', button_color='mzp-t-small') }}
+  {% endcall %}
+
+  {{ fxa_banner(
+    title=_('Firefox'),
+    sub_title=_('Dein Leben. <br>Deine Daten.'),
+    link_cta=_('Weitere Infos'),
+  )}}
+
+  {{ fxa_banner_sticky(
+    title=_('Firefox'),
+    sub_title=_('Dein Leben. Deine Daten.'),
+    link_cta=_('Weitere Infos'),
+  )}}
+
+  <div class="mozilla-content">
+    <div class="mzp-l-content">
+      <div class="mzp-l-card-hero">
+        <!-- 1 -->
+        {{ content_card('card_1') }}
+        <!-- 2 -->
+        {{ content_card('card_2') }}
+        <!-- 3 -->
+        {{ content_card('card_3') }}
+        <!-- 4 -->
+        {{ content_card('card_4') }}
+        <!-- 5 -->
+        {{ content_card('card_5') }}
+      </div>
+
+      {{ billboard(
+        title=_('Für Dich & das Internet. <br>Schon seit 1998.'),
+        ga_title='Für Dich & das Internet. Schon seit 1998.',
+        desc=_('Mozilla setzt sich für ein gesundes Internet ein – und damit für die Menschen, die es nutzen. Damals. Heute. Morgen.'),
+        link_cta=_('Erfahre mehr über Mozilla'),
+        link_url=url('mozorg.about.manifesto'),
+        image_url='home/2018/billboard-more-power.png',
+        include_highres_image=True
+      )}}
+
+      <div class="mzp-l-card-half">
+        <!-- 6 -->
+        {{ content_card('card_6') }}
+        <!-- 7 -->
+        {{ content_card('card_7') }}
+      </div>
+
+      {{ billboard(
+        title=_('Technologien des offenen Webs.'),
+        ga_title='Technologien des offenen Webs.',
+        desc=_('Virtual Reality, IoT und mehr.'),
+        link_cta=_('Entdecke das Web der Zukunft'),
+        link_url=url('mozorg.technology'),
+        image_url='home/2018/billboard-open-minds.png',
+        include_highres_image=True,
+        reverse=True
+      )}}
+
+      <div class="mzp-l-card-third">
+        <!-- 8 -->
+        {{ content_card('card_8') }}
+        <!-- 9 -->
+        {{ content_card('card_9') }}
+        <!-- 10 -->
+        {{ content_card('card_10') }}
+        <!-- 11 -->
+        {{ content_card('card_11') }}
+        <!-- 12 -->
+        {{ content_card('card_12') }}
+        <!-- 13 -->
+        {{ content_card('card_13') }}
+      </div>
+
+      <aside class="mzp-c-newsletter">
+        <div class="mzp-c-newsletter-image">
+          {{ high_res_img('home/2018/newsletter-graphic.png', {'alt': ''}) }}
+        </div>
+
+        <div class="newsletter-content">
+          {{ email_newsletter_form(
+            title=_('Du liebst das Internet?'),
+            subtitle=_('Hol dir den Firefox Newsletter und sorg mit uns zusammen dafür, dass das Web frei und offen für alle bleibt.'),
+            button_class='button-dark',
+            submit_text=_('Anmelden'),
+            protocol_component=True
+          )}}
+        </div>
+      </aside>
+    </div>
+  </div>{#-- /.mozilla-content --#}
+
+  {% call download_banner_secondary(
+    title=_('Unterstütze ein gesundes Internet, das nicht nur von einigen wenigen bestimmt wird.'),
+    sub_title=_('Wenn du mit Mozillas Firefox durchs Web surfst, ist der erste Schritt schon getan.')
+  ) %}
+    {{ download_firefox(dom_id='download-secondary', download_location='secondary cta') }}
+  {% endcall %}
+
+  {% call call_out_compact(
+      title=_('Das Konto, das dich schützt, statt Profit mit dir zu machen.'),
+      desc=None,
+      class='fxaccount-secondary-cta mzp-t-product-firefox mzp-t-firefox mzp-t-dark',
+      heading_level=2
+    ) %}
+    <a href="{{ url('firefox.accounts') }}" class="mzp-c-button mzp-t-secondary mzp-t-dark" id="fxa-learn-secondary">{{ _('Learn More') }}</a>
+  {% endcall %}
+
+</main>
+{% endblock %}

--- a/bedrock/mozorg/templates/mozorg/home/home-en.html
+++ b/bedrock/mozorg/templates/mozorg/home/home-en.html
@@ -3,6 +3,7 @@
  # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
 
 {% from "macros-protocol.html" import billboard, card, call_out_compact, content_card with context %}
+{% from "mozorg/home/includes/macros.html" import download_banner, download_banner_sticky, download_banner_secondary, fxa_banner, fxa_banner_sticky %}
 
 {% extends "base-protocol.html" %}
 
@@ -45,60 +46,40 @@
 {% endblock %}
 
 {% block content %}
+{% block main %}
 <main>
   <header class="main-page-heading">
     {# Main page h1 is hidden from view and exists mainly for SEO purposes #}
     <h1>{{ self.page_title() }}</h1>
   </header>
 
-  <section id="download-firefox-primary-cta" class="c-primary-cta download-firefox-primary-cta">
-    <div class="mzp-l-content">
-      <div class="c-primary-cta-wrapper">
-        <h2 class="c-primary-cta-title">{{ _('Firefox') }}</h2>
-        <h3 class="c-primary-cta-title-sub">{{ _('Your life is your business. Not ours.') }}</h3>
-        <p class="c-primary-cta-desc-sub">{{ _('Firefox fights for you.') }}</p>
-        <div class="c-primary-cta-button">
-          {{ download_firefox(dom_id='download-primary', download_location='primary cta') }}
-        </div>
-      </div>
-    </div>
-  </section>
+  {% call download_banner(
+    title=_('Firefox'),
+    sub_title=_('Your life is your business. Not ours.'),
+    desc=_('Firefox fights for you.'),
+    ) %}
+    {{ download_firefox(dom_id='download-primary', download_location='primary cta') }}
+  {% endcall %}
 
-  <section id="download-firefox-sticky-cta" class="c-sticky-cta download-firefox-sticky-cta">
-    <div class="mzp-l-content">
-      <div class="c-sticky-cta-wrapper">
-        <h2 class="c-sticky-cta-title">{{ _('<strong>Firefox</strong> fights for you.') }}</h2>
-        <h3 class="c-sticky-cta-title-sub">{{ _('Fast. Private. Fearless.') }}</h3>
-        <p class="c-sticky-cta-desc-sub">{{ _('Firefox fights for you.') }}</p>
-        <div class="c-sticky-cta-button">
-        {{ download_firefox(dom_id='download-sticky', download_location='sticky cta', button_color='mzp-t-small') }}
-        </div>
-      </div>
-    </div>
-  </section>
+  {% call download_banner_sticky(
+    title=_('<strong>Firefox</strong> fights for you.'),
+    sub_title=_('Fast. Private. Fearless.'),
+    desc=_('Firefox fights for you.')
+    ) %}
+    {{ download_firefox(dom_id='download-sticky', download_location='sticky cta', button_color='mzp-t-small') }}
+  {% endcall %}
 
-  <section id="fxaccount-primary-cta" class="c-primary-cta fxaccount-primary-cta">
-    <div class="mzp-l-content">
-      <div class="c-primary-cta-wrapper">
-        <h2 class="c-primary-cta-title">{{ _('Firefox') }}</h2>
-        {# L10n: Line break for visual formatting. #}
-        <h3 class="c-primary-cta-title-sub">{{ _('Live your life.<br> Own your life.') }}</h3>
-        <p class="c-primary-cta-button">
-          <a href="{{ url('firefox.accounts') }}" class="mzp-c-button mzp-t-secondary" id="fxa-learn-primary">{{ _('Learn More') }}</a>
-        </p>
-      </div>
-    </div>
-  </section>
+  {{ fxa_banner(
+    title=_('Firefox'),
+    sub_title=_('Live your life.<br> Own your life.'),
+    link_cta=_('Learn More'),
+  )}}
 
-  <section id="fxaccount-sticky-cta" class="c-sticky-cta fxaccount-sticky-cta">
-    <div class="mzp-l-content">
-      <div class="c-sticky-cta-wrapper">
-        <h2 class="c-sticky-cta-title">{{ _('Firefox') }}</h2>
-        <h3 class="c-sticky-cta-title-sub">{{ _('Live your life. Own your life.') }}</h3>
-        <p class="c-sticky-cta-button"><a href="{{ url('firefox.accounts') }}" class="mzp-c-button mzp-t-small" id="fxa-learn-sticky">{{ _('Learn More') }}</a></p>
-      </div>
-    </div>
-  </section>
+  {{ fxa_banner_sticky(
+    title=_('Firefox'),
+    sub_title=_('Live your life. Own your life.'),
+    link_cta=_('Learn More'),
+  )}}
 
   <div class="mozilla-content">
     <div class="mzp-l-content">
@@ -218,28 +199,24 @@
     </div>
   </div>{#-- /.mozilla-content --#}
 
-  <div id="download-firefox-secondary-cta" class="c-secondary-cta download-firefox-secondary-cta">
-    <div class="mzp-l-content">
-      <div class="c-secondary-cta-content">
-        <h2 class="c-secondary-cta-title">{{ _('Supporting a healthy internet is easy.') }}</h2>
-        <p class="c-secondary-cta-tagline">{{ _('Get started by browsing with Firefox powered by Mozilla.') }}</p>
-        <div class="c-secondary-cta-button">
-          {{ download_firefox(dom_id='download-secondary', download_location='secondary cta') }}
-        </div>
-      </div>
-    </div>
-  </div>
+  {% call download_banner_secondary(
+    title=_('Supporting a healthy internet is easy.'),
+    sub_title=_('Get started by browsing with Firefox powered by Mozilla.')
+  ) %}
+    {{ download_firefox(dom_id='download-secondary', download_location='secondary cta') }}
+  {% endcall %}
 
   {% call call_out_compact(
-      title=_('The account that protects you rather than profits off you.'),
-      desc=None,
-      class='fxaccount-secondary-cta mzp-t-product-firefox mzp-t-firefox mzp-t-dark',
-      heading_level=2
-    ) %}
+    title=_('The account that protects you rather than profits off you.'),
+    desc=None,
+    class='fxaccount-secondary-cta mzp-t-product-firefox mzp-t-firefox mzp-t-dark',
+    heading_level=2
+  ) %}
     <a href="{{ url('firefox.accounts') }}" class="mzp-c-button mzp-t-secondary mzp-t-dark" id="fxa-learn-secondary">{{ _('Learn More') }}</a>
   {% endcall %}
 
 </main>
+{% endblock %}
 
 {# https://github.com/mozilla/bedrock/issues/5741 #}
 <script type="application/ld+json">

--- a/bedrock/mozorg/templates/mozorg/home/includes/macros.html
+++ b/bedrock/mozorg/templates/mozorg/home/includes/macros.html
@@ -1,0 +1,73 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+
+{% macro download_banner(title, sub_title, desc) -%}
+<section id="download-firefox-primary-cta" class="c-primary-cta download-firefox-primary-cta">
+  <div class="mzp-l-content">
+    <div class="c-primary-cta-wrapper">
+      <h2 class="c-primary-cta-title">{{ title }}</h2>
+      <h3 class="c-primary-cta-title-sub">{{ sub_title }}</h3>
+      <p class="c-primary-cta-desc-sub">{{ desc }}</p>
+      <div class="c-primary-cta-button">
+        {{ caller() }}
+      </div>
+    </div>
+  </div>
+</section>
+{%- endmacro %}
+
+{% macro download_banner_sticky(title, sub_title, desc) -%}
+<section id="download-firefox-sticky-cta" class="c-sticky-cta download-firefox-sticky-cta">
+  <div class="mzp-l-content">
+    <div class="c-sticky-cta-wrapper">
+      <h2 class="c-sticky-cta-title">{{ title }}</h2>
+      <h3 class="c-sticky-cta-title-sub">{{ sub_title }}</h3>
+      <p class="c-sticky-cta-desc-sub">{{ desc }}</p>
+      <div class="c-sticky-cta-button">
+        {{ caller() }}
+      </div>
+    </div>
+  </div>
+</section>
+{%- endmacro %}
+
+{% macro download_banner_secondary(title, sub_title) -%}
+<div id="download-firefox-secondary-cta" class="c-secondary-cta download-firefox-secondary-cta">
+  <div class="mzp-l-content">
+    <div class="c-secondary-cta-content">
+      <h2 class="c-secondary-cta-title">{{ title }}</h2>
+      <p class="c-secondary-cta-tagline">{{ sub_title }}</p>
+      <div class="c-secondary-cta-button">
+        {{ caller() }}
+      </div>
+    </div>
+  </div>
+</div>
+{%- endmacro %}
+
+{% macro fxa_banner(title, sub_title, link_cta) -%}
+<section id="fxaccount-primary-cta" class="c-primary-cta fxaccount-primary-cta">
+  <div class="mzp-l-content">
+    <div class="c-primary-cta-wrapper">
+      <h2 class="c-primary-cta-title">{{ title }}</h2>
+      <h3 class="c-primary-cta-title-sub">{{ sub_title }}</h3>
+      <p class="c-primary-cta-button">
+        <a href="{{ url('firefox.accounts') }}" class="mzp-c-button mzp-t-secondary" id="fxa-learn-primary">{{ link_cta }}</a>
+      </p>
+    </div>
+  </div>
+</section>
+{%- endmacro %}
+
+{% macro fxa_banner_sticky(title, sub_title, link_cta) -%}
+<section id="fxaccount-sticky-cta" class="c-sticky-cta fxaccount-sticky-cta">
+  <div class="mzp-l-content">
+    <div class="c-sticky-cta-wrapper">
+      <h2 class="c-sticky-cta-title">{{ title }}</h2>
+      <h3 class="c-sticky-cta-title-sub">{{ sub_title }}</h3>
+      <p class="c-sticky-cta-button"><a href="{{ url('firefox.accounts') }}" class="mzp-c-button mzp-t-small" id="fxa-learn-sticky">{{ link_cta }}</a></p>
+    </div>
+  </div>
+</section>
+{%- endmacro %}

--- a/bedrock/mozorg/tests/test_views.py
+++ b/bedrock/mozorg/tests/test_views.py
@@ -169,9 +169,15 @@ class TestHomePage(TestCase):
         views.home_view(req)
         render_mock.assert_called_once_with(req, 'mozorg/home/home-en.html', ANY)
 
-    def test_home_locale_template(self, render_mock):
+    def test_home_de_template(self, render_mock):
         req = RequestFactory().get('/')
         req.locale = 'de'
+        views.home_view(req)
+        render_mock.assert_called_once_with(req, 'mozorg/home/home-de.html', ANY)
+
+    def test_home_locale_template(self, render_mock):
+        req = RequestFactory().get('/')
+        req.locale = 'fr'
         views.home_view(req)
         render_mock.assert_called_once_with(req, 'mozorg/home/home.html', ANY)
 

--- a/bedrock/mozorg/views.py
+++ b/bedrock/mozorg/views.py
@@ -207,6 +207,9 @@ def home_view(request):
     if locale.startswith('en-'):
         template_name = 'mozorg/home/home-en.html'
         ctx['page_content_cards'] = get_page_content_cards('home-2019', 'en-US')
+    elif locale == 'de':
+        template_name = 'mozorg/home/home-de.html'
+        ctx['page_content_cards'] = get_page_content_cards('home-de', 'de')
     else:
         template_name = 'mozorg/home/home.html'
 

--- a/tests/functional/test_home.py
+++ b/tests/functional/test_home.py
@@ -10,16 +10,18 @@ from pages.home import HomePage
 @pytest.mark.skip_if_firefox(reason='Download button is displayed only to non-Firefox users')
 @pytest.mark.sanity
 @pytest.mark.nondestructive
-def test_download_button_is_displayed_en(base_url, selenium):
-    page = HomePage(selenium, base_url).open()
+@pytest.mark.parametrize('locale', ['en-US', 'de'])
+def test_download_button_is_displayed(locale, base_url, selenium):
+    page = HomePage(selenium, base_url, locale=locale).open()
     assert page.primary_download_button.is_displayed
     assert page.secondary_download_button.is_displayed
 
 
 @pytest.mark.skip_if_not_firefox(reason='Firefox Accounts CTA is displayed only to Firefox users')
 @pytest.mark.nondestructive
-def test_accounts_button_is_displayed_en(base_url, selenium):
-    page = HomePage(selenium, base_url).open()
+@pytest.mark.parametrize('locale', ['en-US', 'de'])
+def test_accounts_button_is_displayed(locale, base_url, selenium):
+    page = HomePage(selenium, base_url, locale=locale).open()
     assert page.is_primary_accounts_button
     assert page.is_secondary_accounts_button
 
@@ -27,5 +29,5 @@ def test_accounts_button_is_displayed_en(base_url, selenium):
 @pytest.mark.sanity
 @pytest.mark.nondestructive
 def test_download_button_is_displayed_locales(base_url, selenium):
-    page = HomePage(selenium, base_url, locale='de').open()
+    page = HomePage(selenium, base_url, locale='fr').open()
     assert page.intro_download_button.is_displayed


### PR DESCRIPTION
## Description
- Adds German editorial homepage at `/de/`.
- Converts English homepage components to reusable macros, shared by both templates.
- Adds German homepage to existing functional tests.

## Issue / Bugzilla link
#6585

## Testing

You might need to run `make fresh-data` to test this PR locally, as all the card content is stored in the admin/DB.

- [x] German homepage card content should display as expected.
- [x] Firefox download CTA's should be shown to non-Firefox users.
- [x] Firefox Accounts CTA's should be shown to Firefox users.
- [ ] The English homepage should function the same with no regressions.

Successful intergration test run: https://ci.us-west.moz.works/blue/organizations/jenkins/bedrock_multibranch_pipeline/detail/run-integration-tests/249/pipeline/