### PR TITLE
Use HTTPS for links to licenses

### DIFF
--- a/bedrock/mozorg/templates/mozorg/mpl/headers/index.html
+++ b/bedrock/mozorg/templates/mozorg/mpl/headers/index.html
@@ -1,6 +1,6 @@
 {# This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+# file, You can obtain one at https://mozilla.org/MPL/2.0/. -#}
 
 {% extends "mozorg/base-resp.html" %}
 
@@ -24,22 +24,22 @@
 <pre id="mpl-c">
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 </pre>
 <pre id="mpl-python">
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
 </pre>
 <pre id="mpl-html">
 &lt;!-- This Source Code Form is subject to the terms of the Mozilla Public
    - License, v. 2.0. If a copy of the MPL was not distributed with this
-   - file, You can obtain one at http://mozilla.org/MPL/2.0/. --&gt;
+   - file, You can obtain one at https://mozilla.org/MPL/2.0/. --&gt;
 </pre>
 <pre id="mpl-text">
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
-file, You can obtain one at http://mozilla.org/MPL/2.0/.
+file, You can obtain one at https://mozilla.org/MPL/2.0/.
 </pre>
   </section>
 
@@ -48,19 +48,19 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
     <p>This license can be used for test scripts and other short code snippets, at the discretion of the author.</p>
 <pre id="pd-c">
 /* Any copyright is dedicated to the Public Domain.
- * http://creativecommons.org/publicdomain/zero/1.0/ */
+ * https://creativecommons.org/publicdomain/zero/1.0/ */
 </pre>
 <pre id="pd-python">
 # Any copyright is dedicated to the Public Domain.
-# http://creativecommons.org/publicdomain/zero/1.0/
+# https://creativecommons.org/publicdomain/zero/1.0/
 </pre>
 <pre id="pd-html">
 &lt;!-- Any copyright is dedicated to the Public Domain.
-   - http://creativecommons.org/publicdomain/zero/1.0/ --&gt;
+   - https://creativecommons.org/publicdomain/zero/1.0/ --&gt;
 </pre>
 <pre id="pd-text">
 Any copyright is dedicated to the Public Domain.
-http://creativecommons.org/publicdomain/zero/1.0/
+https://creativecommons.org/publicdomain/zero/1.0/
 </pre>
     <p>Licensing questions? Ask in <a href="{{ url('mozorg.about.forums.forums') }}#legal">mozilla.legal</a>.</p>
   </section>


### PR DESCRIPTION
The HTTP scheme was deprecated by Mozilla a while back: https://blog.mozilla.org/security/2015/04/30/deprecating-non-secure-http/