### PR TITLE
Update Protocol to version 5.0.0

### DIFF
--- a/bedrock/base/templates/includes/protocol/navigation/index.html
+++ b/bedrock/base/templates/includes/protocol/navigation/index.html
@@ -45,7 +45,7 @@
         </div>
         {% endif %}
         <div class="mzp-c-navigation-menu">
-          <nav class="mzp-c-menu">
+          <nav class="mzp-c-menu mzp-is-basic">
             <ul class="mzp-c-menu-category-list">
               {% include 'includes/protocol/navigation/menu/firefox.html' %}
               {% include 'includes/protocol/navigation/menu/projects.html' %}

--- a/bedrock/base/templates/includes/protocol/navigation/index.html
+++ b/bedrock/base/templates/includes/protocol/navigation/index.html
@@ -36,7 +36,7 @@
               {% set fxa_link_text = 'Check out the Benefits' %}
             {% endif %}
             <div class="c-navigation-fxa-cta-container">
-              <a class="c-navigation-fxa-cta mzp-c-button mzp-t-secondary mzp-t-small mzp-t-download" {{ fxa_link_fragment(entrypoint='mozilla.org-globalnav', action='signup', utm_params={'campaign': 'globalnav', 'content': 'get-firefox-account', 'medium': 'referral', 'source': 'www.mozilla.org'}) }} data-button-name="Get a Firefox Account" data-link-type="button" data-cta-position="secondary cta">
+              <a class="c-navigation-fxa-cta mzp-c-button mzp-t-secondary mzp-t-small mzp-t-product" {{ fxa_link_fragment(entrypoint='mozilla.org-globalnav', action='signup', utm_params={'campaign': 'globalnav', 'content': 'get-firefox-account', 'medium': 'referral', 'source': 'www.mozilla.org'}) }} data-button-name="Get a Firefox Account" data-link-type="button" data-cta-position="secondary cta">
                 {{ fxa_button_text }}
               </a>
               <p class="c-navigation-fxa-cta-small-link"><a data-link-type="nav" data-link-name="Check out the Benefits" href="{{ url('firefox.accounts') }}">{{ fxa_link_text }}</a></p>

--- a/bedrock/firefox/templates/firefox/accounts-2018.html
+++ b/bedrock/firefox/templates/firefox/accounts-2018.html
@@ -28,15 +28,15 @@
       <h1 class="mzp-c-hero-title">{{ _('One log-in. Power and privacy everywhere.') }}</h1>
       <div id="hero-cta" class="mzp-c-hero-cta">
         <div class="show-fxa-supported-signed-out">
-          <a {{ fxa_link_fragment(entrypoint='accounts-page', action='signup', utm_params={'campaign': 'fxa-benefits-page', 'content': 'accounts-page-top-cta', 'medium': 'referral', 'source': 'accounts-page'}) }} class="mzp-c-button mzp-t-primary mzp-t-download" data-button-name="Create account" data-link-type="button" data-cta-position="primary cta" id="features-hero-account">
+          <a {{ fxa_link_fragment(entrypoint='accounts-page', action='signup', utm_params={'campaign': 'fxa-benefits-page', 'content': 'accounts-page-top-cta', 'medium': 'referral', 'source': 'accounts-page'}) }} class="mzp-c-button mzp-t-primary mzp-t-product" data-button-name="Create account" data-link-type="button" data-cta-position="primary cta" id="features-hero-account">
             {{ _('Create a Firefox Account') }}
           </a>
         </div>
         <div class="show-fxa-supported-signed-in">
-          <button class="mzp-c-button mzp-t-download" type="button" id="fx-modal" data-button-name="download the firefox app" data-cta-position="primary cta">{{ _('Download the Firefox App') }}</button>
+          <button class="mzp-c-button mzp-t-product" type="button" id="fx-modal" data-button-name="download the firefox app" data-cta-position="primary cta">{{ _('Download the Firefox App') }}</button>
         </div>
         <div class="show-fxa-not-fx">
-          {{ download_firefox(dom_id='features-hero-download', download_location='primary cta', button_color='mzp-c-button mzp-t-primary mzp-t-download') }}
+          {{ download_firefox(dom_id='features-hero-download', download_location='primary cta', button_color='mzp-c-button mzp-t-primary mzp-t-product') }}
         </div>
       </div>
     </div>
@@ -228,7 +228,7 @@
         </div>
 
         <div class="show-fxa-supported-signed-out">
-          {{ fxa_email_form(entrypoint='accounts-page', utm_source='accounts-page', utm_params={'campaign': 'fxa-embedded-form', 'content': 'accounts-page', 'medium': 'referral'}, button_class='mzp-c-button mzp-t-primary mzp-t-download', button_text=_('Create an Account')) }}
+          {{ fxa_email_form(entrypoint='accounts-page', utm_source='accounts-page', utm_params={'campaign': 'fxa-embedded-form', 'content': 'accounts-page', 'medium': 'referral'}, button_class='mzp-c-button mzp-t-primary mzp-t-product', button_text=_('Create an Account')) }}
 
           <p class="fxa-signin">{{ _('Already have an account?') }} <a {{ fxa_link_fragment(entrypoint='accounts-page', utm_params={'campaign': 'fxa-embedded-form', 'content': '/firefox/accounts/', 'source': 'accounts-page'}) }}>{{ _('Sign In') }}</a></p>
         </div>
@@ -247,7 +247,7 @@
 
       <div class="show-fxa-not-fx show-fxa-unsupported show-fxa-default">
         <div class="download-firefox">
-          {{ download_firefox(dom_id='accounts-bottom', download_location='secondary cta', button_color='mzp-c-button mzp-t-primary mzp-t-download') }}
+          {{ download_firefox(dom_id='accounts-bottom', download_location='secondary cta', button_color='mzp-c-button mzp-t-primary mzp-t-product') }}
         </div>
       </div>
     </div>

--- a/bedrock/firefox/templates/firefox/concerts.html
+++ b/bedrock/firefox/templates/firefox/concerts.html
@@ -106,7 +106,7 @@
                     <input type="email" name="email" required placeholder="yourname@example.com">
                   </p>
                   <p>
-                    <button type="submit" class="mzp-c-button mzp-t-download" id="fxa-email-form-submit" data-button-name="Create an Account">Create an Account</button>
+                    <button type="submit" class="mzp-c-button mzp-t-product" id="fxa-email-form-submit" data-button-name="Create an Account">Create an Account</button>
                   </p>
                 </form>
 

--- a/bedrock/firefox/templates/firefox/election/index.html
+++ b/bedrock/firefox/templates/firefox/election/index.html
@@ -91,7 +91,7 @@
                 <div id="case-funnel" class="hidden">
                   <p id="case-funnel-windows" class="hidden">
                     <a
-                      class="download-link button mzp-c-button mzp-t-download"
+                      class="download-link button mzp-c-button mzp-t-product"
                       href="https://download.mozilla.org/?product=firefox-election-edition&os=win&lang=en-US"
                       data-link-type="download"
                       data-download-os="Desktop"
@@ -102,7 +102,7 @@
                   </p>
                   <p id="case-funnel-mac" class="hidden">
                     <a
-                      class="download-link button mzp-c-button mzp-t-download"
+                      class="download-link button mzp-c-button mzp-t-product"
                       href="https://download.mozilla.org/?product=firefox-election-edition&os=osx&lang=en-US"
                       data-link-type="download"
                       data-download-os="Desktop"

--- a/bedrock/firefox/templates/firefox/includes/download-button.html
+++ b/bedrock/firefox/templates/firefox/includes/download-button.html
@@ -18,7 +18,7 @@
     <ul>
       {% for plat in builds -%}
         <li><a href="{{ plat.download_link_direct or plat.download_link }}"
-               class="download-link button button-green mzp-c-button mzp-t-download"
+               class="download-link button button-green mzp-c-button mzp-t-product"
                data-link-type="download"
                data-download-version="{{ plat.os }}"
                {% if plat.os == 'android' %}data-download-os="Android"
@@ -61,7 +61,7 @@
   <ul class="download-list">
     {% for plat in builds %}
       <li class="os_{{ plat.os }}{% if plat.arch %} {{ plat.arch }}{% endif %}">
-        <a class="download-link button {{ button_color }} mzp-c-button mzp-t-download"
+        <a class="download-link button {{ button_color }} mzp-c-button mzp-t-product"
            href="{{ plat.download_link }}"{% if plat.download_link_direct %}
            data-direct-link="{{ plat.download_link_direct }}"{% endif %}
            data-link-type="download"

--- a/bedrock/firefox/templates/firefox/whatsnew/fx64/whatsnew-fx64-base.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/fx64/whatsnew-fx64-base.html
@@ -68,7 +68,7 @@
    include_cta=True
   ) %}
   <p class="show-fxa-supported-signed-out show-fxa-default">
-    <a {{ fxa_link_fragment(entrypoint='mozilla.org-fx.wnp64', action='signup', utm_params=fxa_utm_params) }} class="mzp-c-button mzp-t-download">{{ button_create }}</a><br>
+    <a {{ fxa_link_fragment(entrypoint='mozilla.org-fx.wnp64', action='signup', utm_params=fxa_utm_params) }} class="mzp-c-button mzp-t-product">{{ button_create }}</a><br>
     <span class="wn64-signin">{{ login_desc }} <a {{ fxa_link_fragment(entrypoint='mozilla.org-fx.wnp64', utm_params=fxa_utm_params) }}>{{ login_link }}</a></span>
   </p>
   {% endcall %}
@@ -115,7 +115,7 @@
     class='mzp-t-firefox t-wn64 show-fxa-default show-fxa-supported-signed-out'
   ) %}
     <p>
-      <a {{ fxa_link_fragment(entrypoint='mozilla.org-fx.wnp64', action='signup', utm_params=fxa_utm_params) }} class="mzp-c-button mzp-t-download">{{ button_create }}</a><br>
+      <a {{ fxa_link_fragment(entrypoint='mozilla.org-fx.wnp64', action='signup', utm_params=fxa_utm_params) }} class="mzp-c-button mzp-t-product">{{ button_create }}</a><br>
       <span class="wn64-signin">{{ login_desc }} <a {{ fxa_link_fragment(entrypoint='mozilla.org-fx.wnp64', utm_params=fxa_utm_params) }}>{{ login_link }}</a></span>
     </p>
   {% endcall %}

--- a/bedrock/firefox/templates/firefox/whatsnew/index-lite.id.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/index-lite.id.html
@@ -45,7 +45,7 @@
           field_title: "Enter your e-mail address and send Firefox Lite to your mobile."
           field_note: "Email recipients must agree in advance." #}
         <div class="send-yourself-wrapper">
-          {{ send_yourself(include_title=False, product='download-firefox-rocket', id='download-firefox-rocket', message_set='download-firefox-rocket', spinner_color='#000', field_title='Masukkan alamat surel dan kirimkan Firefox Lite ke ponselmu.', field_note='Penerima email harus menyetujui sebelumnya.', button_theme='mzp-t-download', dark_background=True) }}
+          {{ send_yourself(include_title=False, product='download-firefox-rocket', id='download-firefox-rocket', message_set='download-firefox-rocket', spinner_color='#000', field_title='Masukkan alamat surel dan kirimkan Firefox Lite ke ponselmu.', field_note='Penerima email harus menyetujui sebelumnya.', button_theme='mzp-t-product', dark_background=True) }}
         </div>
       </div>
     </div>

--- a/media/css/firefox/accounts-2018.scss
+++ b/media/css/firefox/accounts-2018.scss
@@ -49,21 +49,6 @@ $image-path: '/media/protocol/img';
     .mobile-content {
         display: none;
     }
-
-    .mzp-c-cta-link {
-        &:link,
-        &:visited {
-            color: $color-link;
-            border-bottom-color: $color-link;
-        }
-
-        &:hover,
-        &:focus,
-        &:active {
-            color: $color-link-hover;
-            border-bottom-color: $color-link-hover;
-        }
-    }
 }
 
 
@@ -280,4 +265,3 @@ html.android {
         display: block;
     }
 }
-

--- a/media/css/firefox/fights-for-you.scss
+++ b/media/css/firefox/fights-for-you.scss
@@ -159,21 +159,6 @@ $fffy-pink: #FF2889;
     .fffy-t-privacy .mzp-c-card-feature-title:before {
         content: url('/media/img/firefox/fights-for-you/icon-privacy.svg');
     }
-
-    .mzp-c-cta-link {
-        &:link,
-        &:visited {
-            color: $color-link;
-            border-bottom-color: $color-link;
-        }
-
-        &:hover,
-        &:focus,
-        &:active {
-            color: $color-link-hover;
-            border-bottom-color: $color-link-hover;
-        }
-    }
 }
 
 .fffy-t-focus .u-mobile-content {
@@ -328,4 +313,3 @@ $fffy-pink: #FF2889;
         }
     }
 }
-

--- a/media/css/mozorg/about-en.scss
+++ b/media/css/mozorg/about-en.scss
@@ -148,16 +148,17 @@ $city-image-size: 106px;
     &:active {
         color: $color-black;
         text-decoration: none;
+
+        .c-city-title {
+            color: $color-link;
+        }
     }
 }
 
 .c-city-title {
     @include open-sans;
     @include text-body-sm;
-    border-bottom: 2px solid $color-gray-30;
-    border-image: linear-gradient(to top, $color-gray-30 1px, $color-white 1px);
-    border-image-width: 100%;
-    border-image-slice: 9;
+    border-bottom: 2px solid $color-link;
     padding-bottom: $spacing-sm;
     margin: 0 auto $spacing-sm;
     max-width: 200px;
@@ -165,8 +166,8 @@ $city-image-size: 106px;
     .c-city:hover &,
     .c-city:focus &,
     .c-city:active {
-        border-color: $color-black;
-        border-image: none;
+        @include transition(border-bottom-color 100ms ease-in-out);
+        border-color: transparent;
     }
 }
 

--- a/media/css/protocol/protocol.scss
+++ b/media/css/protocol/protocol.scss
@@ -11,9 +11,3 @@ $image-path: '/media/protocol/img';
 // Bedrock specific component tweaks.
 @import 'components/navigation';
 @import 'components/download-button';
-
-
-// bug fix, remove after backported to Protocol
-.mzp-c-footer-links-social li a {
-    background-repeat: no-repeat;
-}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Making mozilla.org awesome, one pebble at a time",
   "private": true,
   "dependencies": {
-    "@mozilla-protocol/core": "4.0.0",
+    "@mozilla-protocol/core": "5.0.0",
     "ansi-colors": "3.2.3",
     "clean-css-cli": "4.0.5",
     "del": "^3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -21,10 +21,10 @@
     normalize-path "^2.0.1"
     through2 "^2.0.3"
 
-"@mozilla-protocol/core@4.0.0":
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/@mozilla-protocol/core/-/core-4.0.0.tgz#17d339c99ab13f18b92bb3b6df46a3d49414f0d1"
-  integrity sha512-3F4PvLtCFawSXjRWCC1rq9o3mv1em6RPWuSU6WbnjaDTksXskqUrMZUzkRiGp5CIQWTq7Vir4oZRxYWbw/KOiQ==
+"@mozilla-protocol/core@5.0.0":
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/@mozilla-protocol/core/-/core-5.0.0.tgz#28e1877345b81c5782871218a2e091bacc5a4e8c"
+  integrity sha512-TqG854ztxFn89Ak6Vcw1FGJelH+X36i+8sinhecrlZstKtuLstlF+RY3R49r4ya7nBHXkkQCDk00EzhQ7jJ39Q==
 
 JSONStream@^0.8.4:
   version "0.8.4"


### PR DESCRIPTION
## Description

Update Protocol to version 5.0.0

## Testing
Remember to `make build` to get the right version of Protocol.

Breaking changes and the pages I tested them on:
- css: Add basic styles for hr elements (mozilla/protocol#296)
  - does this break any HRs already on protocol pages?
  - http://localhost:8000/en-US/firefox/windows-64-bit/
  - http://localhost:8000/en-US/privacy/firefox/
- css: (breaking) Rename download button theme to product button theme (mozilla/protocol#273)
  - http://localhost:8000/en-US/ (look at nav menu and download banner for nonFX users, sticky banner, and bottom of the page)
  - http://localhost:8000/en-US/firefox/accounts/
  - http://localhost:8000/en-US/firefox/concerts/
  - http://localhost:8000/en-US/firefox/election/ (non Firefox user download button)
  - http://localhost:8000/en-US/firefox/64.0/whatsnew/
  - http://localhost:8000/id/firefox/64.0/whatsnew/
  - http://localhost:8000/en-US/firefox/features/adblocker/
  - I could not find any pages with download button customizations
- css: Convert CTA links to blue (mozilla/protocol#280)
  - http://localhost:8000/en-US/firefox/accounts/ (removed custom cta link styles)
  - http://localhost:8000/en-US/firefox/fights-for-you/ (removed custom cta link styles)
  - http://localhost:8000/en-US/about/ (updated custom link styles on city names) (also the only place we use CTAs inside cards I think)
- js: (breaking) Make the Menu molecule more resilient to JS errors (mozilla/protocol#320)
  - remember to test this one with JS disabled
