### PR TITLE
Localize the new /about page (Fixes #6828)

### DIFF
--- a/bedrock/mozorg/templates/mozorg/about-2019.html
+++ b/bedrock/mozorg/templates/mozorg/about-2019.html
@@ -6,7 +6,7 @@
 
 {% extends "base-protocol.html" %}
 
-{% add_lang_files "mozorg/about" %}
+{% add_lang_files "mozorg/about-2019" %}
 
 {% block page_title %}{{ _('Learn About Mozilla') }}{% endblock %}
 

--- a/bedrock/mozorg/tests/test_views.py
+++ b/bedrock/mozorg/tests/test_views.py
@@ -187,13 +187,15 @@ class TestAboutPage(TestCase):
     def setUp(self):
         self.rf = RequestFactory()
 
-    def test_about_en_template(self, render_mock):
+    @patch.object(views, 'lang_file_is_active', lambda *x: True)
+    def test_about_2019_template(self, render_mock):
         req = RequestFactory().get('/')
         req.locale = 'en-US'
         views.about_view(req)
-        render_mock.assert_called_once_with(req, 'mozorg/about-en.html')
+        render_mock.assert_called_once_with(req, 'mozorg/about-2019.html')
 
-    def test_about_locale_template(self, render_mock):
+    @patch.object(views, 'lang_file_is_active', lambda *x: False)
+    def test_about_old_template(self, render_mock):
         req = RequestFactory().get('/')
         req.locale = 'de'
         views.about_view(req)

--- a/bedrock/mozorg/views.py
+++ b/bedrock/mozorg/views.py
@@ -219,8 +219,8 @@ def home_view(request):
 def about_view(request):
     locale = l10n_utils.get_locale(request)
 
-    if locale.startswith('en-'):
-        template_name = 'mozorg/about-en.html'
+    if lang_file_is_active('mozorg/about-2019', locale):
+        template_name = 'mozorg/about-2019.html'
     else:
         template_name = 'mozorg/about.html'
 


### PR DESCRIPTION
## Description
- Exposes the new `/about/` page for localization.

## Issue / Bugzilla link
#6828