### PR TITLE
[#6707] Add Firefox Account CTA on /new

### DIFF
--- a/bedrock/firefox/templates/firefox/new/scene1.html
+++ b/bedrock/firefox/templates/firefox/new/scene1.html
@@ -4,6 +4,8 @@
 
 {% add_lang_files "firefox/new/quantum" %}
 
+{% from "macros.html" import fxa_link_fragment, fxa_email_form with context %}
+
 {% extends "firefox/new/base.html" %}
 
 {# All stylesheets are loaded in extrahead to serve legacy IE basic styles #}
@@ -54,13 +56,6 @@
       #}
       {{ download_firefox(alt_copy=_('Download Now'), locale_in_transition=True, download_location='primary cta') }}
     </div>
-
-    <div id="refresh-firefox-wrapper">
-      <div class="refresh-inner-wrapper">
-        <button class="button button-hollow button-light" type="button" id="refresh-firefox" data-interaction="Refresh Firefox" data-element-action="Firefox Desktop" data-button-name="Refresh Firefox" data-cta-position="Primary">{{ _('Refresh Firefox') }}</button>
-        <small><a rel="external" href="https://support.mozilla.org/kb/refresh-firefox-reset-add-ons-and-settings?utm_source=mozilla.org&amp;utm_medium=referral&amp;utm_campaign=learn-more-link">{{ _('Learn more') }}</a></small>
-      </div>
-    </div>
   </div>
 
   <p class="linux-arm-download-instructions">
@@ -70,6 +65,9 @@
   <ul id="other-platforms-languages-wrapper" class="small-links desktop hidden">
     <li><button id="other-platforms-modal-link" type="button">{{_('Advanced install options & other platforms') }}</button></li>
     <li><a href="{{ url('firefox.all') }}">{{_('Download in another language') }}</a></li>
+  {% if l10n_has_tag('fxnew_account_032019') %}
+    <li><a href="https://support.mozilla.org/kb/refresh-firefox-reset-add-ons-and-settings?utm_source=mozilla.org&amp;utm_medium=referral&amp;utm_campaign=fix-problem-link">{{ _('Fix a problem') }}</a></li>
+  {% endif %}
     <li><a rel="external" href="https://support.mozilla.org/products/?utm_source=mozilla.org&amp;utm_medium=referral&amp;utm_campaign=need-help-link">{{_('Need help?')}}</a></li>
   </ul>
 
@@ -148,11 +146,29 @@
     </section>
   </div>
 </div>
+
+{% if l10n_has_tag('fxnew_account_032019') %}
+<div id="firefox-account">
+  <h4 class="fxa-title">{{ _('You’ve already got the Firefox browser. Now get everything else Firefox.') }}</h4>
+  <p class="fxa-intro">{{ _('Sync bookmarks, send tabs, save to Pocket and more with a Firefox Account.') }} <a href="{{ url('firefox.accounts') }}">{{ _('Learn more') }}</a></p>
+
+  {{ fxa_email_form(entrypoint='firefox-new', button_text=_('Get a Firefox Account'), utm_source='firefox-new', utm_params={'campaign': 'firefox-new', 'content': 'firefox-new-fxa', 'term': 'existing-users', 'medium': 'referral'}) }}
+
+  <p class="fxa-signin">{{ _('Already have an account?') }} <a {{ fxa_link_fragment(entrypoint='accounts-page', utm_params={'campaign': 'fxa-embedded-form', 'content': '/firefox/new/', 'source': 'download-page'}) }}>{{ _('Sign In') }}</a></p>
+
+  {{ download_firefox(dom_id='download-fxa-modal', alt_copy=_('Download Anyway'), button_color='button-hollow button-blue', locale_in_transition=True, download_location='other') }}
+</div>
+{% endif %}
+
 {% include 'firefox/includes/schemaorg-app.html' %}
 {% endblock %}
 
 {% block js %}
   {{ js_bundle('firefox_new_scene1') }}
+
+  {% if l10n_has_tag('fxnew_account_032019') %}
+    {{ js_bundle('firefox_new_scene1_fxa_modal') }}
+  {% endif %}
 
   {% if switch('stub-attribution-macos') %}
     {{ js_bundle('stub-attribution-macos') }}

--- a/bedrock/firefox/templates/firefox/new/scene1.html
+++ b/bedrock/firefox/templates/firefox/new/scene1.html
@@ -2,9 +2,9 @@
  # License, v. 2.0. If a copy of the MPL was not distributed with this
  # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
 
-{% add_lang_files "firefox/new/quantum" %}
-
 {% from "macros.html" import fxa_link_fragment, fxa_email_form with context %}
+
+{% add_lang_files "firefox/new/quantum" %}
 
 {% extends "firefox/new/base.html" %}
 

--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -644,6 +644,10 @@ def download_thanks(request):
     if variant not in ['a', 'b', 'c']:  # place expected ?v= values in this list
         variant = None
 
+    # check to see if a URL explicitly asks to hide the newsletter
+    if newsletter == 'f':
+        show_newsletter = False
+
     if variant in ['b', 'c'] and locale == 'en-US':
         show_newsletter = False
 

--- a/media/css/firefox/new/_firefox-account.scss
+++ b/media/css/firefox/new/_firefox-account.scss
@@ -1,0 +1,90 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+@import '../../pebbles/includes/lib';
+
+
+// Hide header visually and add top padding to compensate
+#modal.firefox-account-modal > .window > .inner {
+    background: transparent;
+    max-width: 512px;
+    padding: 70px 0 0;
+
+    .content {
+        padding: 0;
+    }
+
+    header {
+        @include visually-hidden;
+    }
+}
+
+
+.js #modal #firefox-account {
+    display: block;
+    background: #fff;
+}
+
+
+#firefox-account {
+    display: none;
+    padding: 20px;
+
+    .fxa-title {
+        color: #000;
+        font-weight: bold;
+        margin: 20px 0;
+    }
+
+    .fxa-intro {
+        @include font-size-level5;
+        margin: 0 0 40px;
+    }
+
+    .button {
+        @include border-box;
+        width: 100%;
+        padding: .9em 40px;
+    }
+
+    .mzp-c-button-download-container {
+        width: 100%;
+    }
+
+    .mzp-c-button-download-privacy-link,
+    .fxa-email-form-intro {
+        @include visually-hidden;
+    }
+
+    .fxa-email-field-container {
+        margin-bottom: 10px;
+    }
+
+    .fxa-signin {
+        @include font-size-small;
+    }
+
+    .fxa-email-form .agreement {
+        @include font-size-extra-small;
+    }
+
+    #download-fxa-modal {
+        margin: 40px 0 0;
+    }
+
+    a:link,
+    a:visited {
+        color: $color-quantum-blue;
+
+        &:hover,
+        &:active,
+        &:focus {
+            color: darken($color-quantum-blue, 15%);
+        }
+    }
+
+    @media #{$mq-tablet} {
+        padding: 60px 40px;
+    }
+}

--- a/media/css/firefox/new/_other-platforms.scss
+++ b/media/css/firefox/new/_other-platforms.scss
@@ -119,6 +119,10 @@ html[dir="rtl"] #other-platforms-modal-link {
         }
     }
 
+    .section-current-firefox {
+        display: none;
+    }
+
     .section-current-platform {
         margin-bottom: 40px;
 
@@ -149,6 +153,7 @@ html[dir="rtl"] #other-platforms-modal-link {
         }
 
         .section-current-platform {
+            @include border-box;
             float: left;
             width: 50%;
         }
@@ -201,7 +206,7 @@ html[dir="rtl"] #other-platforms {
 }
 
 // Hide header visually and add top padding to compensate
-#modal > .window > .inner {
+#modal.other-platforms-modal > .window > .inner {
     background: transparent;
     max-width: 960px;
     padding: 70px 0 0;

--- a/media/css/firefox/new/scene1.scss
+++ b/media/css/firefox/new/scene1.scss
@@ -7,6 +7,7 @@
 @import '../../hubs/sections';
 @import '../../quantum/newsletter';
 @import 'other-platforms';
+@import 'firefox-account';
 
 /* -------------------------------------------------------------------------- */
 // Conditional messaging shown to specific Firefox versions
@@ -203,6 +204,9 @@ html[dir="rtl"] .main-content {
 /* -------------------------------------------------------------------------- */
 // Refresh Firefox CTA shown for up-to-date Firefox users on release channel
 
+// NOTE: This button is being replaced by a link in the FXA modal, and should be
+// deprecated once that modal is fully localized (tag 'fxnew_account_032019').
+
 #refresh-firefox-wrapper {
     display: none;
 }
@@ -282,3 +286,4 @@ html.firefox-pre-release {
         }
     }
 }
+

--- a/media/css/firefox/new/scene1.scss
+++ b/media/css/firefox/new/scene1.scss
@@ -201,64 +201,6 @@ html[dir="rtl"] .main-content {
     }
 }
 
-/* -------------------------------------------------------------------------- */
-// Refresh Firefox CTA shown for up-to-date Firefox users on release channel
-
-// NOTE: This button is being replaced by a link in the FXA modal, and should be
-// deprecated once that modal is fully localized (tag 'fxnew_account_032019').
-
-#refresh-firefox-wrapper {
-    display: none;
-}
-
-html.show-refresh {
-
-    #refresh-firefox-wrapper {
-        display: block;
-        text-align: center;
-
-        small {
-            display: block;
-        }
-
-        a:link,
-        a:visited {
-            @include font-size-extra-small;
-            color: #fff;
-            text-decoration: none;
-        }
-
-        a:hover,
-        a:active,
-        a:focus {
-            color: #fff;
-            text-decoration: underline;
-        }
-    }
-
-    #refresh-firefox {
-        display: block;
-        margin: 0 auto 10px;
-    }
-
-    @media #{$mq-tablet} {
-        #refresh-firefox-wrapper {
-            float: left;
-        }
-
-        #refresh-firefox {
-            margin: 0 0 10px;
-        }
-    }
-}
-
-html[dir="rtl"].show-refresh {
-    @media #{$mq-tablet} {
-        #refresh-firefox-wrapper {
-            float: right;
-        }
-    }
-}
 
 /* -------------------------------------------------------------------------- */
 // Newsletter

--- a/media/css/pebbles/components/_modal.scss
+++ b/media/css/pebbles/components/_modal.scss
@@ -50,63 +50,64 @@ html.noscroll {
     .window {
         color: #333;
         padding: 20px;
+    }
 
-        .inner {
-            position: relative;
-            background: #fff;
-            padding: 20px;
-            @include clearfix;
+    .inner {
+        @include clearfix;
+        background: #fff;
+        margin: 0 auto;
+        padding: 20px;
+        position: relative;
 
-            &> header {
-                @include font-size(48px);
-                color: #fff;
-                display: block;
-                height: auto;
-                line-height: 1.3;
-                padding: 0 60px 0 20px;
-                background: $color-mozred;
-                margin: -20px -20px 20px;
+        &> header {
+            @include font-size(48px);
+            color: #fff;
+            display: block;
+            height: auto;
+            line-height: 1.3;
+            padding: 0 60px 0 20px;
+            background: $color-mozred;
+            margin: -20px -20px 20px;
+        }
+
+        #modal-close {
+            cursor: pointer;
+            position: absolute;
+            right: 9px;
+            top: 9px;
+            z-index: 99;
+
+            a {
+                // TODO: remove <a> element from mozilla-modal.js with mozID rollout
+                display: none;
             }
 
-            #modal-close {
-                cursor: pointer;
-                position: absolute;
-                right: 9px;
-                top: 9px;
-                z-index: 99;
+            .button {
+                @include image-replaced;
+                background: transparent url('/media/img/mozid/modal-close.svg') center center no-repeat;
+                @include background-size(22px, 22px);
+                border-radius: 50%;
+                border: 2px solid #fff;
+                height: 42px;
+                min-width: 0;
+                padding: 0;
+                width: 42px;
 
-                a {
-                    // TODO: remove <a> element from mozilla-modal.js with mozID rollout
-                    display: none;
-                }
-
-                .button {
-                    @include image-replaced;
-                    background: transparent url('/media/img/mozid/modal-close.svg') center center no-repeat;
-                    @include background-size(22px, 22px);
-                    border-radius: 50%;
-                    border: 2px solid #fff;
-                    height: 42px;
-                    min-width: 0;
-                    padding: 0;
-                    width: 42px;
-
-                    &:hover,
-                    &:focus {
-                        @include transform(scale(1.1));
-                        box-shadow: none;
-                    }
+                &:hover,
+                &:focus {
+                    @include transform(scale(1.1));
+                    box-shadow: none;
                 }
             }
+        }
 
-            .overlay-contents {
-                background: transparent;
-                margin: 0 auto;
-                padding-top: 20px;
+        .overlay-contents {
+            background: transparent;
+            margin: 0 auto;
+            padding-top: 20px;
 
-                img, iframe {
-                    max-width: 100%;
-                }
+            img, iframe {
+                max-width: 100%;
             }
         }
     }

--- a/media/js/base/mozilla-modal.js
+++ b/media/js/base/mozilla-modal.js
@@ -39,9 +39,10 @@ Mozilla.Modal = (function(w, $) {
 
         // Create new modal
         var title = (options && options.title) ? options.title : '';
+        var className = (options && options.className) ? options.className : '';
 
         var $modal = $(
-            '<div id="modal" role="dialog" aria-labelledby="' + origin.getAttribute('id') + '" tabindex="-1">' +
+            '<div id="modal" class="modal ' + className + '" role="dialog" aria-labelledby="' + origin.getAttribute('id') + '" tabindex="-1">' +
             '  <div class="window">' +
             '    <div class="inner">' +
             '      <header>' + title + '</header>' +

--- a/media/js/firefox/new/scene1.js
+++ b/media/js/firefox/new/scene1.js
@@ -7,53 +7,13 @@
 
     var $html = $(document.documentElement);
     var client = window.Mozilla.Client;
-    var $modalLink = $('#other-platforms-modal-link');
+    var $otherPlatformsModalLink = $('#other-platforms-modal-link');
     var $otherPlatformsLanguagesWrapper = $('#other-platforms-languages-wrapper');
-
-    var uiTourSendEvent = function(action, data) {
-        var event = new CustomEvent('mozUITour', {
-            bubbles: true,
-            detail: {
-                action: action,
-                data: data || {}
-            }
-        });
-
-        document.dispatchEvent(event);
-    };
-
-    var uiTourWaitForCallback = function(callback) {
-        var id = Math.random().toString(36).replace(/[^a-z]+/g, '');
-
-        function listener(event) {
-            if (typeof event.detail != 'object') {
-                return;
-            }
-            if (event.detail.callbackID !== id) {
-                return;
-            }
-
-            document.removeEventListener('mozUITourResponse', listener);
-            callback(event.detail.data);
-        }
-        document.addEventListener('mozUITourResponse', listener);
-
-        return id;
-    };
-
-    var showRefreshButton = function(canReset) {
-        if (canReset) {
-            $html.addClass('show-refresh');
-
-            $('#refresh-firefox').on('click', function() {
-                uiTourSendEvent('resetFirefox');
-            });
-        }
-    };
 
     var getFirefoxStatus = function() {
         var userMajorVersion = client._getFirefoxMajorVersion();
         var latestMajorVersion = parseInt($html.attr('data-latest-firefox'), 10);
+
         // Detect whether the Firefox is up-to-date in a non-strict way. The minor version and channel are not
         // considered. This can/should be strict, once the UX especially for ESR users is decided. (Bug 939470)
         if (userMajorVersion === latestMajorVersion) {
@@ -74,30 +34,17 @@
 
         var status = getFirefoxStatus();
         $html.addClass(status);
-
-        if (status === 'firefox-latest' && client.isFirefoxDesktop) {
-            // if user is on desktop release channel and has latest version, offer refresh button
-            client.getFirefoxDetails(function(data) {
-                // data.accurate will only be true if UITour API is working.
-                if (data.channel === 'release' && data.accurate) {
-                    // Bug 1274207 only show reset button if user profile supports it.
-                    uiTourSendEvent('getConfiguration', {
-                        callbackID: uiTourWaitForCallback(showRefreshButton),
-                        configuration: 'canReset'
-                    });
-                }
-            });
-        }
     };
 
     var initOtherPlatformsModal = function() {
         // show the modal cta button
         $otherPlatformsLanguagesWrapper.removeClass('hidden');
 
-        $modalLink.on('click', function(e) {
+        $otherPlatformsModalLink.on('click', function(e) {
             e.preventDefault();
             Mozilla.Modal.createModal(this, $('#other-platforms'), {
-                title: $(this).text()
+                title: $(this).text(),
+                className: 'other-platforms-modal'
             });
 
             window.dataLayer.push({
@@ -121,7 +68,7 @@
      * Enable modal to optionally download Firefox for other platforms.
      * Don't show the modal for iOS or Android.
      */
-    if ($modalLink.length && client.isDesktop) {
+    if ($otherPlatformsModalLink.length && client.isDesktop) {
         initOtherPlatformsModal();
     }
 

--- a/media/js/firefox/new/scene1_fxa_modal.js
+++ b/media/js/firefox/new/scene1_fxa_modal.js
@@ -1,0 +1,52 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// This relies on base/mozilla-modal.js, included in the firefox_new_scene1 bundle
+
+(function($) {
+    'use strict';
+
+    var client = window.Mozilla.Client;
+    var $downloadButton = $('#download-button-desktop-release .download-link[data-download-os="Desktop"]');
+    var $downloadAnyway = $('#download-fxa-modal .download-link[data-download-os="Desktop"]');
+
+    var initFxAccountModal = function() {
+        // To avoid showing users two similar forms back to back,
+        // hide the form on the /thanks page by adding a param to
+        // download links in the modal.
+        $downloadAnyway.attr('href', function(i, h) {
+            return h + (h.indexOf('?') !== -1 ? '&n=f' : '?n=f');
+        });
+
+        $downloadButton.on('click', function(e) {
+            e.preventDefault();
+
+            // Open the modal
+            Mozilla.Modal.createModal(this, $('#firefox-account'), {
+                title: $(this).text(),
+                className: 'firefox-account-modal'
+            });
+
+            // Count the click in GA
+            window.dataLayer.push({
+                'event': 'in-page-interaction',
+                'eAction': 'link click',
+                'eLabel': 'Current Firefox user downloading Firefox'
+            });
+        });
+
+        // Don't trigger the modal for signed in users
+        client.getFxaDetails(function(details) {
+            if (details.setup) {
+                $downloadButton.unbind('click');
+            }
+        });
+    };
+
+    // Only Firefox desktop 57+ (post-quantum) should get the FxA modal
+    if (client.isFirefoxDesktop && client._getFirefoxMajorVersion() >= '57') {
+        initFxAccountModal();
+    }
+
+})(window.jQuery);

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -228,6 +228,7 @@
     },
     {
       "files": [
+        "css/base/mozilla-fxa-form.scss",
         "css/firefox/new/scene1.scss"
       ],
       "name": "firefox_new_scene1"
@@ -1088,6 +1089,14 @@
         "js/firefox/new/scene1.js"
       ],
       "name": "firefox_new_scene1"
+    },
+    {
+      "files": [
+        "js/base/uitour-lib.js",
+        "js/base/mozilla-fxa-form.js",
+        "js/firefox/new/scene1_fxa_modal.js"
+      ],
+      "name": "firefox_new_scene1_fxa_modal"
     },
     {
         "files": [

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -1092,7 +1092,6 @@
     },
     {
       "files": [
-        "js/base/uitour-lib.js",
         "js/base/mozilla-fxa-form.js",
         "js/firefox/new/scene1_fxa_modal.js"
       ],

--- a/tests/functional/firefox/new/test_download.py
+++ b/tests/functional/firefox/new/test_download.py
@@ -31,3 +31,12 @@ def test_other_platforms_modal(base_url, selenium):
     modal = page.open_other_platforms_modal()
     assert modal.is_displayed
     modal.close()
+
+
+@pytest.mark.nondestructive
+@pytest.mark.skip_if_not_firefox(reason='Create Account form is only displayed to Firefox users')
+def test_firefox_account_modal(base_url, selenium):
+    page = DownloadPage(selenium, base_url, params='').open()
+    modal = page.open_firefox_account_modal()
+    assert modal.is_displayed
+    modal.close()

--- a/tests/pages/firefox/new/download.py
+++ b/tests/pages/firefox/new/download.py
@@ -14,8 +14,9 @@ class DownloadPage(FirefoxBasePage):
     URL_TEMPLATE = '/{locale}/firefox/new/{params}'
 
     _download_button_locator = (By.ID, 'download-button-desktop-release')
-    _modal_link_locator = (By.ID, 'other-platforms-modal-link')
-    _modal_content_locator = (By.ID, 'other-platforms')
+    _platforms_modal_link_locator = (By.ID, 'other-platforms-modal-link')
+    _platforms_modal_content_locator = (By.ID, 'other-platforms')
+    _account_modal_content_locator = (By.ID, 'firefox-account')
 
     @property
     def download_button(self):
@@ -29,6 +30,12 @@ class DownloadPage(FirefoxBasePage):
 
     def open_other_platforms_modal(self):
         modal = Modal(self)
-        self.find_element(*self._modal_link_locator).click()
-        self.wait.until(lambda s: modal.displays(self._modal_content_locator))
+        self.find_element(*self._platforms_modal_link_locator).click()
+        self.wait.until(lambda s: modal.displays(self._platforms_modal_content_locator))
+        return modal
+
+    def open_firefox_account_modal(self):
+        modal = Modal(self)
+        self.download_button.click()
+        self.wait.until(lambda s: modal.displays(self._account_modal_content_locator))
         return modal


### PR DESCRIPTION
## Description
Adds an FxA prompt on the main download page in a modal. Should only be shown to users on Firefox 57 and up (post-quantum) and only if they're not signed into FxA already.

New strings are behind the tag `fxnew_account_032019`.

Still a work in progress so I'm trying out the draft PR function for the first time... What I need to do and need help with:

- [x] Add a check for FxA status (no modal for signed in users)
- [x] Add tests

For the FxA check, I don't know why `client.getFxaDetails` is returning false for `setup` when I do it in `scene1.js` but returns true in `mozilla-fxa.js`, clearly I'm missing something obvious but it's on the outer edges of my JS knowledge so I'm just spinning my wheels trying to figure it out by trial and error alone.

For the tests... I have no idea what I'm doing. I took a stab at some copypasta but then found I can't get tests to run locally for some other reason so can't even try it to tell how badly it's broken.

## Issue / Bugzilla link
#6707 

## Testing
https://bedrock-demo-craigcook.oregon-b.moz.works/firefox/new/