### PR TITLE
Make 'measuring installs' a repeatable, modular piece of code (Fixes #6871)

### DIFF
--- a/bedrock/firefox/templates/firefox/new/install/scene1.html
+++ b/bedrock/firefox/templates/firefox/new/install/scene1.html
@@ -9,6 +9,7 @@
 {% block experiments %}{% endblock %}
 
 {% block stub_attribution %}
+  {{ js_bundle('stub-attribution-custom') }}
   {{ js_bundle('experiment-firefox-download-install-variant') }}
 {% endblock %}
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -39,4 +39,5 @@ Contents
    funnelcake
    abtest
    analytics
+   stub-attribution
    architectural-decisions

--- a/docs/stub-attribution.rst
+++ b/docs/stub-attribution.rst
@@ -1,0 +1,96 @@
+.. This Source Code Form is subject to the terms of the Mozilla Public
+.. License, v. 2.0. If a copy of the MPL was not distributed with this
+.. file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+.. _stub_attribution:
+
+================
+Stub Attribution
+================
+
+Stub Attribution is a process that enables the construction and transmission
+of marketing attribution code on www.mozilla.org. When a user visits a mozilla.org
+download page, the website constructs an attribution code, which is then passed to
+download.mozilla.org via a URL parameter. This attribution code is then passed to
+the Windows stub installer, where it finally gets passed to Firefox for use in
+Telemetry. This attribution funnel enables Mozilla to better understand how
+different marketing campaigns effect overall retention in Firefox.
+
+How does it work in bedrock?
+----------------------------
+
+The base template in bedrock contains a stub attribution script that runs on every
+page of the website. The script only runs on Windows (since the stub installer is a
+Windows feature) and if cookies are enabled. The script also respects Do Not Track,
+so it will not run if the user agent has this flag set.
+
+The stub attribution script looks for `utm_*` params on the page URL as well as the
+referrer, and then creates a hash of that data by passing it to an authentication
+service in bedrock. This hash is then accompanied by a signed, encrypted signature
+to prove that the data came from a trusted source. Both pieces of authenticated
+data are then stored in a cookie.
+
+Once the user reaches the download page, bedrock then checks if the cookie exists,
+and if so appends the authenticated data to the download URL. The rest of the process
+is handled by the download service and stub installer.
+
+Measuring campaigns and experiments
+-----------------------------------
+
+Stub Attribution was originally designed for measuring the effectiveness of marketing
+campaigns where the top of the funnel was outside the remit of www.mozilla.org. For
+these types of campaigns, stub attribution requires zero configuration. It just works
+in the background and passes along any attribution data that exists.
+
+For campaigns or experiments that originate on www.mozilla.org, Stub Attribution
+requires some extra configuration. We want to avoid using first-party utm parameters
+on mozilla.org pages, since those create new sessions in Google Analytics and can
+confound data. To work around this, there is a custom stub attribution script that can
+be used to pass custom data to the authentication service, avoiding the need for any
+first-party utm parameters.
+
+To use the custom attribution script, override the regular stub attribution block in
+the page template where an experiment exists:
+
+.. code-block:: html
+
+    {% block stub_attribution %}
+      {{ js_bundle('stub-attribution-custom') }}
+      {{ js_bundle('my-page-experiment-script') }}
+    {% endblock %}
+
+The `stub-attribution-custom` bundle contains the code that enables passing custom data
+to the authentication service. You can then use that code in `my-page-experiment-script`,
+or whatever you decide to call the experiment bundle:
+
+.. code-block:: javascript
+
+    var params = {
+        utm_source: 'www.mozilla.org',
+        utm_medium: 'download_button',
+        utm_campaign: 'download_thanks_page',
+        utm_content: 'download_thanks_install_experiment-v1'
+    };
+
+    // an optional callback for tracking when the experiment is seen in GA.
+    function callback() {
+        window.dataLayer.push({
+            'data-ex-name': 'download_thanks_install_experiment',
+            'data-ex-variant': 'v1'
+        });
+    }
+
+    Mozilla.CustomStubAttribution.init(params, callback);
+
+Authenticating custom data this way will override any existing stub attribution cookie
+a visitor may have.
+
+.. Note::
+
+    There are some exceptions in the way that the custom attribution script behaves.
+    Existing utm data will not be overwritten if there is already a `utm_content` parameter
+    in the page URL. The custom attribution script will do nothing in this scenario. If
+    any other utm parameters exist on the page URL, those will be passed through to the
+    custom attribution script in favor of any custom values. This is to try and preserve
+    as much existing information as possible, whilst still retaining the `utm_content`
+    value that is essential to attributing an experiment.

--- a/docs/stub-attribution.rst
+++ b/docs/stub-attribution.rst
@@ -34,13 +34,30 @@ Once the user reaches the download page, bedrock then checks if the cookie exist
 and if so appends the authenticated data to the download URL. The rest of the process
 is handled by the download service and stub installer.
 
+Local testing
+-------------
+
+For stub attribution to work locally or on a demo instance, a value for the HMAC key
+that is used to sign the attribution code must be set via an environment variable e.g.
+
+.. code-block:: html
+
+    STUB_ATTRIBUTION_HMAC_KEY='thedude'
+
+.. Note::
+
+    This value can be anything if all you need to do is test the bedrock functionality.
+    It only needs to match the value used to verify data passed to the stub installer
+    for full end-to-end testing via Telemetry.
+
 Measuring campaigns and experiments
 -----------------------------------
 
 Stub Attribution was originally designed for measuring the effectiveness of marketing
 campaigns where the top of the funnel was outside the remit of www.mozilla.org. For
 these types of campaigns, stub attribution requires zero configuration. It just works
-in the background and passes along any attribution data that exists.
+(as configured in  `/media/js/base/stub-attribution.js`) in the background and passes
+along any attribution data that exists.
 
 For campaigns or experiments that originate on www.mozilla.org, Stub Attribution
 requires some extra configuration. We want to avoid using first-party utm parameters

--- a/media/js/base/stub-attribution-custom.js
+++ b/media/js/base/stub-attribution-custom.js
@@ -1,0 +1,69 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+(function(Mozilla) {
+    'use strict';
+
+    /**
+     * A custom stub attribution script that circumvents the normal stub
+     * attribution logic, and instead authenticates custom data that can
+     * be used to attribute first-party experiments on www.mozilla.org.
+     */
+    var CustomStubAttribution = {};
+
+    CustomStubAttribution.setAttributionValues = function(params) {
+        // preserve any existing utm params.
+        var current = new window._SearchParams().utmParams();
+
+        // if there's already a utm_content param then don't modify anything.
+        if (current.utm_content) {
+            return false;
+        }
+
+        // if custom attribution data is not fully formed then return false.
+        if (!params.hasOwnProperty('utm_source') ||
+            !params.hasOwnProperty('utm_medium') ||
+            !params.hasOwnProperty('utm_campaign') ||
+            !params.hasOwnProperty('utm_content')) {
+            return false;
+        }
+
+        return {
+            /* eslint-disable camelcase */
+            utm_source: current.utm_source || params.utm_source,
+            utm_medium: current.utm_medium || params.utm_medium,
+            utm_campaign: current.utm_campaign || params.utm_campaign,
+            utm_content: params.utm_content,
+            referrer: document.referrer
+            /* eslint-enable camelcase */
+        };
+    };
+
+    CustomStubAttribution.init = function(params, callback) {
+        if (typeof Mozilla.StubAttribution === 'undefined' || typeof window._SearchParams === 'undefined') {
+            return;
+        }
+
+        // if we don't meet the usual requirements for stub attribution return false.
+        if (!Mozilla.StubAttribution.meetsRequirements()) {
+            return false;
+        }
+
+        // create our custom utm attribution data.
+        var data = CustomStubAttribution.setAttributionValues(params);
+
+        if (data) {
+            // authenticate the custom data in the usual manner and let stub attribution do the rest.
+            Mozilla.StubAttribution.requestAuthentication(data);
+
+            // fire a callback if supplied (e.g. to fire a GA event).
+            if (typeof callback === 'function') {
+                callback();
+            }
+        }
+    };
+
+    window.Mozilla.CustomStubAttribution = CustomStubAttribution;
+
+})(window.Mozilla);

--- a/media/js/firefox/new/install/variant.js
+++ b/media/js/firefox/new/install/variant.js
@@ -5,39 +5,26 @@
 (function(Mozilla) {
     'use strict';
 
-    function setAttributionValues(variant) {
-        // preserve any existing utm params except for utm_content.
-        var params = new window._SearchParams().utmParams();
+    var variant = document.querySelector('.main-download').getAttribute('data-variant');
 
+    var params = {
         /* eslint-disable camelcase */
-        return {
-            utm_source: params.utm_source || 'www.mozilla.org',
-            utm_medium: params.utm_medium || 'download_button',
-            utm_campaign: params.utm_campaign || 'download_thanks_page',
-            utm_content: 'download_thanks_install_experiment-v-' + variant,
-            referrer: document.referrer
-        };
+        utm_source: 'www.mozilla.org',
+        utm_medium: 'download_button',
+        utm_campaign: 'download_thanks_page',
+        utm_content: 'download_thanks_install_experiment-v-' + variant
         /* eslint-enable camelcase */
+    };
+
+    function trackGAEvent() {
+        window.dataLayer.push({
+            'data-ex-name': 'download_thanks_install_experiment',
+            'data-ex-variant': 'v-' + variant
+        });
     }
 
-    function init() {
-        if (!Mozilla.StubAttribution.meetsRequirements()) {
-            return;
-        }
-
-        var variant = document.querySelector('.main-download').getAttribute('data-variant');
-
-        if (variant) {
-            var data = setAttributionValues(variant);
-            Mozilla.StubAttribution.requestAuthentication(data);
-
-            window.dataLayer.push({
-                'data-ex-name': 'download_thanks_install_experiment',
-                'data-ex-variant': 'v-' + variant
-            });
-        }
+    if (variant) {
+        Mozilla.CustomStubAttribution.init(params, trackGAEvent);
     }
-
-    init();
 
 })(window.Mozilla);

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -1110,6 +1110,13 @@
     },
     {
       "files": [
+        "js/base/stub-attribution.js",
+        "js/base/stub-attribution-custom.js"
+      ],
+      "name": "stub-attribution-custom"
+    },
+    {
+      "files": [
         "js/base/stub-attribution-macos.js",
         "js/base/stub-attribution-macos-init.js"
       ],
@@ -1293,7 +1300,6 @@
     },
     {
       "files": [
-        "js/base/stub-attribution.js",
         "js/firefox/new/install/variant.js"
       ],
       "name": "experiment-firefox-download-install-variant"

--- a/tests/unit/karma.conf.js
+++ b/tests/unit/karma.conf.js
@@ -35,6 +35,7 @@ module.exports = function(config) {
             'media/js/base/svg-animation-check.js',
             'media/js/base/mozilla-svg-image-fallback.js',
             'media/js/base/stub-attribution.js',
+            'media/js/base/stub-attribution-custom.js',
             'media/js/base/stub-attribution-macos.js',
             'media/js/firefox/new/yandex/scene1.js',
             'media/js/firefox/new-ios-redirect-helper.js',
@@ -71,6 +72,7 @@ module.exports = function(config) {
             'tests/unit/spec/base/send-to-device.js',
             'tests/unit/spec/base/core-datalayer.js',
             'tests/unit/spec/base/stub-attribution.js',
+            'tests/unit/spec/base/stub-attribution-custom.js',
             'tests/unit/spec/base/stub-attribution-macos.js',
             {
                 pattern: 'node_modules/sinon/pkg/sinon.js',

--- a/tests/unit/spec/base/stub-attribution-custom.js
+++ b/tests/unit/spec/base/stub-attribution-custom.js
@@ -1,0 +1,106 @@
+/* For reference read the Jasmine and Sinon docs
+ * Jasmine docs: https://jasmine.github.io/2.0/introduction.html
+ * Sinon docs: http://sinonjs.org/docs/
+ */
+
+/* global describe, beforeEach, afterEach, it, expect */
+
+describe('stub-attribution-custom.js', function () {
+
+    'use strict';
+
+    var params = {
+        /* eslint-disable camelcase */
+        utm_source: 'www.mozilla.org',
+        utm_medium: 'download_button',
+        utm_campaign: 'download_thanks_page',
+        utm_content: 'download_thanks_experiment'
+        /* eslint-enable camelcase */
+    };
+
+    describe('setAttributionValues', function () {
+
+        it('should return custom attribution parameters as expected', function () {
+            spyOn(window._SearchParams.prototype, 'utmParams').and.returnValue({});
+
+            var result = Mozilla.CustomStubAttribution.setAttributionValues(params);
+            expect(result.utm_source).toEqual('www.mozilla.org');
+            expect(result.utm_medium).toEqual('download_button');
+            expect(result.utm_campaign).toEqual('download_thanks_page');
+            expect(result.utm_content).toEqual('download_thanks_experiment');
+        });
+
+        it('should return false if custom attribution data is not fully formed', function() {
+            spyOn(window._SearchParams.prototype, 'utmParams').and.returnValue({});
+
+            var params = {
+                /* eslint-disable camelcase */
+                utm_source: 'www.mozilla.org',
+                utm_medium: 'download_button',
+                utm_content: 'download_thanks_experiment'
+                /* eslint-enable camelcase */
+            };
+
+            var result = Mozilla.CustomStubAttribution.setAttributionValues(params);
+            expect(result).toBeFalsy();
+        });
+
+        it('should return false if there is already utm_content', function() {
+            spyOn(window._SearchParams.prototype, 'utmParams').and.returnValue({
+                /* eslint-disable camelcase */
+                utm_content: 'some-other-content'
+                /* eslint-enable camelcase */
+            });
+
+            var result = Mozilla.CustomStubAttribution.setAttributionValues(params);
+            expect(result).toBeFalsy();
+        });
+
+        it('should not override any other existing utm params', function() {
+            spyOn(window._SearchParams.prototype, 'utmParams').and.returnValue({
+                /* eslint-disable camelcase */
+                utm_source: 'support.mozilla.org',
+                /* eslint-enable camelcase */
+            });
+
+            var result = Mozilla.CustomStubAttribution.setAttributionValues(params);
+            expect(result.utm_source).toEqual('support.mozilla.org');
+            expect(result.utm_medium).toEqual('download_button');
+            expect(result.utm_campaign).toEqual('download_thanks_page');
+            expect(result.utm_content).toEqual('download_thanks_experiment');
+        });
+    });
+
+    describe('init', function () {
+
+        it('should return false if stub attribution requirements are not satisfied', function() {
+            spyOn(Mozilla.StubAttribution, 'meetsRequirements').and.returnValue(false);
+
+            var result = Mozilla.CustomStubAttribution.init(params);
+            expect(result).toBeFalsy();
+        });
+
+        it('should authenticate stub attribution data as expected', function() {
+            spyOn(Mozilla.StubAttribution, 'meetsRequirements').and.returnValue(true);
+            spyOn(Mozilla.StubAttribution, 'requestAuthentication');
+            spyOn(Mozilla.CustomStubAttribution, 'setAttributionValues').and.returnValue(params);
+
+            Mozilla.CustomStubAttribution.init(params);
+            expect(Mozilla.CustomStubAttribution.setAttributionValues).toHaveBeenCalledWith(params);
+            expect(Mozilla.StubAttribution.requestAuthentication).toHaveBeenCalledWith(params);
+        });
+
+        it('should fire a callback once authenticated', function() {
+            var options = {
+                callback: function() {}
+            };
+            spyOn(options, 'callback');
+            spyOn(Mozilla.StubAttribution, 'meetsRequirements').and.returnValue(true);
+            spyOn(Mozilla.StubAttribution, 'requestAuthentication');
+
+            Mozilla.CustomStubAttribution.init(params, options.callback);
+            expect(options.callback).toHaveBeenCalled();
+        });
+
+    });
+});


### PR DESCRIPTION
## Description
- Adds a script that enables passing custom data to the Stub Attribution service for first-party experiments.
- Adds documentation on how Stub Attribution works.
- Converts the "how to install" experiment code to use the new script (this experiment is finished in prod, but I figured this would be a good way to test locally that this all works).

## Issue / Bugzilla link
#6871

## Testing
- [x] "How to install" experiment still functions as expected using the new code.
  - Open `/firefox/new/` using Chrome on Windows.
  - Once redirected to a variation, inspect cookies in dev tools and copy the value for `moz-stub-attribution-code`.
  - [Decode](https://www.base64decode.org/) that base64 value, and it should match the params configured in the experiment (e.g. `source=www.mozilla.org&medium=download_button&campaign=download_thanks_page&content=download_thanks_install_experiment-v-a`).