### PR TITLE
Update 'Get involved' link for devtools

### DIFF
--- a/bedrock/firefox/templates/firefox/developer/includes/engage.html
+++ b/bedrock/firefox/templates/firefox/developer/includes/engage.html
@@ -10,7 +10,7 @@
     <section class="get-involved">
       <h3>{{ _('Get involved') }}</h3>
       <p>{{ _('Help build the last independent browser. Write code, fix bugs, make add-ons, and more.') }}</p>
-      <p class="cta"><a href="https://devtools-html.github.io/" class="button button-hollow">{{ _('Start now') }}</a></p>
+      <p class="cta"><a href="https://firefox-dev.tools/" class="button button-hollow">{{ _('Start now') }}</a></p>
     </section>
 
   </div>


### PR DESCRIPTION
## Description

This PR updates the 'Get involved' URL for engaging with Firefox DevTools. The Github organisation has recently be renamed and the old link doesn't work anymore.

## Issue / Bugzilla link

none

## Testing

Tested locally.