### PR TITLE
Reinstate pre-download newsletter modal on /firefox/ (Fixes #6886)

### DIFF
--- a/bedrock/firefox/templates/firefox/home/index.de.html
+++ b/bedrock/firefox/templates/firefox/home/index.de.html
@@ -1,0 +1,30 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. #}
+
+{% add_lang_files "firefox/hub/home-quantum" "firefox/shared" %}
+
+{% extends "firefox/home/index.html" %}
+
+{% block newsletter %}
+  <div class="pre-download-newsletter">
+    <div class="pre-download-newsletter-content">
+      <h2 class="pre-download-newsletter-title">So machst Du Firefox noch schneller, sicherer und smarter.</h2>
+      <p class="pre-download-newsletter-desc">Lass Dir Tipps, Tricks und Produktankündigungen direkt in Dein Postfach schicken.</p>
+      {{ email_newsletter_form(
+          include_title=False,
+          spinner_color='#000',
+          button_class='button-hollow',
+          email_label='Gib Deine E-Mail-Adresse ein',
+          email_placeholder='Sie@example.com',
+          submit_text='Firefox downloaden & Account erstellen'
+      )}}
+      <p class="pre-download-privacy">
+        <a href="url('privacy.email')">Was genau macht Mozilla mit meiner E-Mail-Adresse?</a>
+      </p>
+      <p class="pre-download-continue">
+        <a class="button button-hollow" href="{{ url('firefox.download.thanks') }}?xv=pre-download" data-link-name="Continue FireFox Download" data-link-type="link">Firefox Download fortsetzen</a>
+      </p>
+    </div>
+  </div>
+{% endblock %}

--- a/bedrock/firefox/templates/firefox/home/index.de.html
+++ b/bedrock/firefox/templates/firefox/home/index.de.html
@@ -23,7 +23,7 @@
         <a href="url('privacy.email')">Was genau macht Mozilla mit meiner E-Mail-Adresse?</a>
       </p>
       <p class="pre-download-continue">
-        <a class="button button-hollow" href="{{ url('firefox.download.thanks') }}?xv=pre-download" data-link-name="Continue FireFox Download" data-link-type="link">Firefox Download fortsetzen</a>
+        <a class="button button-hollow" href="{{ url('firefox.download.thanks') }}?n=f" data-link-name="Continue FireFox Download" data-link-type="link">Firefox Download fortsetzen</a>
       </p>
     </div>
   </div>

--- a/bedrock/firefox/templates/firefox/home/index.fr.html
+++ b/bedrock/firefox/templates/firefox/home/index.fr.html
@@ -1,0 +1,30 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. #}
+
+{% add_lang_files "firefox/hub/home-quantum" "firefox/shared" %}
+
+{% extends "firefox/home/index.html" %}
+
+{% block newsletter %}
+<div class="pre-download-newsletter">
+  <div class="pre-download-newsletter-content">
+    <h2 class="pre-download-newsletter-title">Découvrez comment rendre Firefox plus intelligent, plus rapide et plus sûr.</h2>
+    <p class="pre-download-newsletter-desc">Recevez des informations, des astuces et des nouvelles sur les produits directement dans votre boîte de réception.</p>
+    {{ email_newsletter_form(
+        include_title=False,
+        spinner_color='#000',
+        button_class='button-hollow',
+        email_label='Saisissez votre adresse de courrier électronique',
+        email_placeholder='votrenom@example.com',
+        submit_text='Je télécharge Firefox et je crée un compte'
+    )}}
+    <p class="pre-download-privacy">
+      <a href="url('privacy.email')">Comment mon adresse sera-t-elle utilisée par Mozilla ?</a>
+    </p>
+    <p class="pre-download-continue">
+      <a class="button button-hollow" href="{{ url('firefox.download.thanks') }}?xv=pre-download" data-link-name="Continue FireFox Download" data-link-type="link">{{ _('Continuer le téléchargement de Firefox') }}</a>
+    </p>
+  </div>
+</div>
+{% endblock %}

--- a/bedrock/firefox/templates/firefox/home/index.fr.html
+++ b/bedrock/firefox/templates/firefox/home/index.fr.html
@@ -23,7 +23,7 @@
       <a href="url('privacy.email')">Comment mon adresse sera-t-elle utilisée par Mozilla ?</a>
     </p>
     <p class="pre-download-continue">
-      <a class="button button-hollow" href="{{ url('firefox.download.thanks') }}?xv=pre-download" data-link-name="Continue FireFox Download" data-link-type="link">{{ _('Continuer le téléchargement de Firefox') }}</a>
+      <a class="button button-hollow" href="{{ url('firefox.download.thanks') }}?n=f" data-link-name="Continue FireFox Download" data-link-type="link">{{ _('Continuer le téléchargement de Firefox') }}</a>
     </p>
   </div>
 </div>

--- a/bedrock/firefox/templates/firefox/home/index.html
+++ b/bedrock/firefox/templates/firefox/home/index.html
@@ -265,7 +265,7 @@
           <a href="url('privacy.email')">How will Mozilla use my email?</a>
         </p>
         <p class="pre-download-continue">
-          <a class="button button-hollow" href="{{ url('firefox.download.thanks') }}?xv=pre-download" data-link-name="Continue FireFox Download" data-link-type="link">Continue Firefox Download</a>
+          <a class="button button-hollow" href="{{ url('firefox.download.thanks') }}?n=f" data-link-name="Continue FireFox Download" data-link-type="link">Continue Firefox Download</a>
         </p>
       </div>
     </div>

--- a/bedrock/firefox/templates/firefox/home/index.html
+++ b/bedrock/firefox/templates/firefox/home/index.html
@@ -248,10 +248,37 @@
     </div>
   </section>
 
+  {% if show_newsletter %}
+    {% block newsletter %}
+    <div class="pre-download-newsletter">
+      <div class="pre-download-newsletter-content">
+        <h2 class="pre-download-newsletter-title">Learn how to make your Firefox even smarter, faster and more secure.</h2>
+        <p class="pre-download-newsletter-desc">Get informative tips, tricks and product announcements delivered to your inbox.</p>
+        {{ email_newsletter_form(
+            include_title=False,
+            spinner_color='#000',
+            email_label='Enter your email address',
+            email_placeholder='yourname@example.com',
+            submit_text='Download Firefox & Sign Up'
+        )}}
+        <p class="pre-download-privacy">
+          <a href="url('privacy.email')">How will Mozilla use my email?</a>
+        </p>
+        <p class="pre-download-continue">
+          <a class="button button-hollow" href="{{ url('firefox.download.thanks') }}?xv=pre-download" data-link-name="Continue FireFox Download" data-link-type="link">Continue Firefox Download</a>
+        </p>
+      </div>
+    </div>
+    {% endblock %}
+  {% endif %}
+
   {% include 'firefox/includes/schemaorg-app.html' %}
 </main>
 {% endblock %}
 
 {% block js %}
   {{ js_bundle('firefox-home') }}
+  {% if show_newsletter %}
+    {{ js_bundle('pre-download-newsletter') }}
+  {% endif %}
 {% endblock %}

--- a/bedrock/firefox/tests/test_views.py
+++ b/bedrock/firefox/tests/test_views.py
@@ -863,3 +863,44 @@ class TestFirefoxConcerts(TestCase):
         req = RequestFactory().get('/firefox/concerts')
         views.firefox_concerts(req)
         render_mock.assert_called_once_with(req, 'firefox/concerts.html')
+
+
+class TestFirefoxHome(TestCase):
+    @override_settings(DEV=False)
+    @override_settings(SWITCH_FIREFOX_PRE_DOWNLOAD_NEWSLETTER=False)
+    @patch('bedrock.firefox.views.l10n_utils.render')
+    def test_switch_off(self, render_mock):
+        req = RequestFactory().get('/firefox/')
+        views.firefox_home(req)
+        render_mock.assert_called_once_with(req, 'firefox/home/index.html', {'show_newsletter': False})
+
+    @override_settings(DEV=True)
+    @patch('bedrock.firefox.views.l10n_utils.render')
+    def test_switch_on(self, render_mock):
+        req = RequestFactory().get('/firefox/')
+        views.firefox_home(req)
+        render_mock.assert_called_once_with(req, 'firefox/home/index.html', {'show_newsletter': True})
+
+    @override_settings(DEV=True)
+    @patch('bedrock.firefox.views.l10n_utils.render')
+    def test_locale_de(self, render_mock):
+        req = RequestFactory().get('/firefox/')
+        req.locale = 'de'
+        views.firefox_home(req)
+        render_mock.assert_called_once_with(req, 'firefox/home/index.html', {'show_newsletter': True})
+
+    @override_settings(DEV=True)
+    @patch('bedrock.firefox.views.l10n_utils.render')
+    def test_locale_fr(self, render_mock):
+        req = RequestFactory().get('/firefox/')
+        req.locale = 'fr'
+        views.firefox_home(req)
+        render_mock.assert_called_once_with(req, 'firefox/home/index.html', {'show_newsletter': True})
+
+    @override_settings(DEV=True)
+    @patch('bedrock.firefox.views.l10n_utils.render')
+    def test_locale_no_newsletter(self, render_mock):
+        req = RequestFactory().get('/firefox/')
+        req.locale = 'it'
+        views.firefox_home(req)
+        render_mock.assert_called_once_with(req, 'firefox/home/index.html', {'show_newsletter': False})

--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -644,6 +644,10 @@ def download_thanks(request):
     if variant in ['b', 'c'] and locale == 'en-US':
         show_newsletter = False
 
+    # if someone has already seen the newsletter pre-download, don't show it again.
+    if experience == 'pre-download':
+        show_newsletter = False
+
     if locale == 'de':
         if experience == 'berlin':
             template = 'firefox/new/berlin/scene2.html'
@@ -797,7 +801,13 @@ class FeaturesPrivateBrowsingView(BlogPostsView):
 
 
 def firefox_home(request):
-    return l10n_utils.render(request, 'firefox/home.html')
+    locale = l10n_utils.get_locale(request)
+    newsletter_locales = ['en-US', 'en-GB', 'en-CA', 'en-ZA', 'fr', 'de']
+    show_newsletter = switch('firefox_pre_download_newsletter') and locale in newsletter_locales
+
+    return l10n_utils.render(request,
+                             'firefox/home/index.html',
+                             {'show_newsletter': show_newsletter})
 
 
 def firefox_concerts(request):

--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -635,6 +635,7 @@ def download_thanks(request):
     experience = request.GET.get('xv', None)
     locale = l10n_utils.get_locale(request)
     variant = request.GET.get('v', None)
+    newsletter = request.GET.get('n', None)
     show_newsletter = locale in ['en-US', 'en-GB', 'en-CA', 'en-ZA', 'es-ES', 'es-AR', 'es-CL', 'es-MX', 'pt-BR', 'fr', 'ru', 'id', 'de', 'pl']
 
     # ensure variant matches pre-defined value
@@ -644,8 +645,8 @@ def download_thanks(request):
     if variant in ['b', 'c'] and locale == 'en-US':
         show_newsletter = False
 
-    # if someone has already seen the newsletter pre-download, don't show it again.
-    if experience == 'pre-download':
+    # check to see if a URL explicitly asks to hide the newsletter
+    if newsletter == 'f':
         show_newsletter = False
 
     if locale == 'de':

--- a/media/css/firefox/home/home.scss
+++ b/media/css/firefox/home/home.scss
@@ -2,11 +2,11 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-@import '../pebbles/includes/lib';
-@import '../pebbles/components/video-poster';
-@import '../hubs/sections';
-@import '../hubs/sub-nav';
-@import '../quantum/common';
+@import '../../pebbles/includes/lib';
+@import '../../pebbles/components/video-poster';
+@import '../../hubs/sections';
+@import '../../hubs/sub-nav';
+@import '../../quantum/common';
 
 /* -------------------------------------------------------------------------- */
 // Common elements & variables

--- a/media/css/firefox/home/pre-download-newsletter.scss
+++ b/media/css/firefox/home/pre-download-newsletter.scss
@@ -1,0 +1,150 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+@import '../../pebbles/includes/lib';
+@import '../../pebbles/components/modal';
+
+
+.pre-download-newsletter {
+    display: none;
+}
+
+#modal .pre-download-newsletter {
+    display: block;
+}
+
+.pre-download-newsletter-content {
+    @include font-size(16px);
+    background: #fff;
+    padding: 40px 20px;
+
+    @media #{$mq-tablet} {
+        padding: 40px;
+    }
+
+    h2 {
+        @include font-size(28px);
+        font-weight: bold;
+        margin-bottom: 20px;
+    }
+
+    .field-email label {
+        display: block;
+        font-weight: bold;
+        margin-bottom: 10px;
+    }
+
+    .field {
+        margin-bottom: 20px;
+    }
+
+    input[type="email"] {
+        padding: 12px 8px;
+        width: 100%;
+    }
+
+    select {
+        width: 100%;
+    }
+
+    button[type="submit"] {
+        background-color: #0060df;
+        border-radius: 2px;
+        border: 2px solid #0060df;
+        color: #fff;
+        transition: background-color 100ms, color 100ms;
+
+        &:hover,
+        &:focus {
+            background-color: #003eaa;
+            border-color: transparent;
+        }
+    }
+
+    .form-details small {
+        @include font-size(16px);
+        display: block;
+        margin-top: 10px;
+        text-align: center;
+    }
+
+    .errorlist {
+        color: $color-mozred;
+    }
+}
+
+.pre-download-newsletter-content,
+.pre-download-privacy {
+    a:link,
+    a:visited {
+        color: #0060df;
+        text-decoration: underline;
+    }
+
+    a:hover,
+    a:active,
+    a:focus {
+        text-decoration: none;
+    }
+}
+
+.pre-download-privacy {
+    text-align: center;
+    margin: 10px 0 0;
+}
+
+.pre-download-continue {
+    text-align: center;
+    margin: 50px 0 0;
+
+    a.button.button-hollow {
+        &:link,
+        &:visited {
+            @include border-box;
+            background-color: transparent;
+            border-radius: 2px;
+            border: 2px solid #0060df;
+            color: #0060df;
+            transition: background-color 100ms, color 100ms;
+            width: 100%;
+        }
+
+        &:hover,
+        &:active,
+        &:focus {
+            background-color: #003eaa;
+            border-color: transparent;
+            color: #fff;
+        }
+    }
+}
+
+// Hide modal header visually and add top padding to compensate
+#modal > .window > .inner {
+    background: transparent;
+    margin: 0 auto;
+    max-width: 512px;
+    padding: 70px 0 0;
+
+    header {
+        @include visually-hidden;
+    }
+}
+
+.js {
+    // hide details for JS users
+    // (displayed when email field is focused)
+    #form-details,
+    .form-details {
+        display: none;
+    }
+
+    #newsletter-spinner {
+        bottom: 0;
+        left: 0;
+        position: absolute;
+        right: 0;
+        top: 0;
+    }
+}

--- a/media/js/firefox/home/pre-download-newsletter.js
+++ b/media/js/firefox/home/pre-download-newsletter.js
@@ -1,0 +1,34 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+(function (Mozilla) {
+    'use strict';
+
+    // Show email newsletter modal on download button click.
+    var downloadButton = document.querySelectorAll('.download-link[data-download-os="Desktop"]');
+
+    for(var i = 0; i < downloadButton.length; i++) {
+        downloadButton[i].setAttribute('role', 'button');
+        downloadButton[i].addEventListener('click', function(e) {
+            e.preventDefault();
+
+            Mozilla.Modal.createModal(this, $('.pre-download-newsletter'));
+        }, false);
+    }
+
+    // Listen for the regular newsletter form submit response.
+    $(document).ajaxSuccess(function(evt, xhr, settings, response) {
+        // Check that it's the correct form and the response was a non-error.
+        if ((settings.url.indexOf('/newsletter/') > -1) && response.success) {
+
+            // Close the modal
+            Mozilla.Modal.closeModal();
+
+            // Redirect to /download/thanks/
+            window.location.href = document.querySelector('.pre-download-continue a').href;
+        }
+    });
+
+})(window.Mozilla);
+

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -734,7 +734,8 @@
     },
     {
       "files": [
-        "css/firefox/home.scss",
+        "css/firefox/home/home.scss",
+        "css/firefox/home/pre-download-newsletter.scss",
         "css/base/mozilla-lazy-image.scss"
       ],
       "name": "firefox-home"
@@ -1296,6 +1297,13 @@
         "js/firefox/home/main.js"
       ],
       "name": "firefox-home"
+    },
+    {
+      "files": [
+        "js/base/mozilla-modal.js",
+        "js/firefox/home/pre-download-newsletter.js"
+      ],
+      "name": "pre-download-newsletter"
     },
     {
       "files": [


### PR DESCRIPTION
## Description
- Reinstated the pre-download newsletter modal on /firefox/
- Incorporated design/copy tweaks to signup form.
- 100% audience for English, German and French locales.
- Modal is behind the switch `firefox_pre_download_newsletter`

~**Still need to write tests, so not yet ready for review**~

It occured to me that I can't write functional tests for this just yet, becuase the feature is behind a switch 😕. I'll file a separate issue to write tests once we're confident that things are OK data-wise.

## Issue / Bugzilla link
#6886

## Testing
Demo: https://bedrock-demo-agibson.oregon-b.moz.works/en-US/firefox/

- [x] Modal newsletter signup works as expected for above locales.
- [x] Modal should only trigger for desktop download links.
- [x] Downloading without signing up works as expected.
- [x] Locales that don't get the newsletter don't see the modal, and can download as normal.
- [x] Modal does not show when the switch is disabled and downloads work as normal.