### PR TITLE
Remove untranslated meta title and description from /campaign page (#6829)

### DIFF
--- a/bedrock/firefox/templates/firefox/campaign.html
+++ b/bedrock/firefox/templates/firefox/campaign.html
@@ -19,12 +19,6 @@
 
 {% block page_desc %}{{_('Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!')}}{% endblock %}
 
-{#- This will appear as <meta property="og:title"> which can be used for social share -#}
-{% block page_og_title %}{{_('Download the fastest Firefox ever')}}{% endblock %}
-
-{#- This will appear as <meta property="og:description"> which can be used for social share -#}
-{% block page_og_desc %}{{_('Faster page loading, less memory usage and packed with features, the new Firefox is here.')}}{% endblock %}
-
 {% block page_css %}
   {{ css_bundle('firefox_campaign') }}
 {% endblock %}


### PR DESCRIPTION
## Description
- We didn't translate the existing meta title & description when porting over the /firefox/campaign/ page. This PR removes those custom strings so the page falls back to using the standard page title / description

## Issue / Bugzilla link
#6829

## Testing
- [ ] Visit /de/firefox/campaign/ and the meta title & description should be in German instead of English.