### PR TITLE
Update deprecated button classname (bugfix WNP66)

### DIFF
--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx66.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx66.html
@@ -85,7 +85,7 @@
   ) %}
 
   <p class="show-fxa-supported-signed-out show-fxa-default">
-    <a {{ fxa_link_fragment(entrypoint='mozilla.org-whatsnew66', action='signup', utm_params={'campaign': 'wnp66', 'content': 'accounts-page-top-cta', 'medium': 'referral', 'source': 'wnp66'}) }} class="mzp-c-button mzp-t-download" data-button-name="Create account" data-link-type="button">
+    <a {{ fxa_link_fragment(entrypoint='mozilla.org-whatsnew66', action='signup', utm_params={'campaign': 'wnp66', 'content': 'accounts-page-top-cta', 'medium': 'referral', 'source': 'wnp66'}) }} class="mzp-c-button mzp-t-product" data-button-name="Create account" data-link-type="button">
       {{ _('Create a Firefox Account') }}
     </a><br>
     <span class="wn64-signin">{{ _('Have an account?') }}


### PR DESCRIPTION
## Description
Update deprecated button classname `mzp-t-download` to new `mzp-t-product`
