### PR TITLE
Fix race condition in Mozilla.Client.getFxaDetails() (Fixes #6904)

### DIFF
--- a/media/js/base/core-datalayer-init.js
+++ b/media/js/base/core-datalayer-init.js
@@ -3,7 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 // init core dataLayer object and push into dataLayer
-// This needs to happen on DOM ready for UITour (see https://github.com/mozilla/bedrock/issues/6624).
 $(function() {
     var analytics = Mozilla.Analytics;
     var client = Mozilla.Client;

--- a/media/js/base/mozilla-client.js
+++ b/media/js/base/mozilla-client.js
@@ -357,7 +357,7 @@ if (typeof Mozilla === 'undefined') {
             return;
         }
         // set up the object with default values of false
-        var details = Client.FxaDetails = {
+        var details = {
             'firefox': false,
             'legacy': false,
             'mobile': false,
@@ -423,6 +423,7 @@ if (typeof Mozilla === 'undefined') {
 
         function returnFxaDetails() {
             window.clearTimeout(timer);
+            Client.FxaDetails = details;
             callback(details);
         }
 


### PR DESCRIPTION
## Description

- Fixes a bug where calling `getFxADetails()` twice in quick succession sometimes resulted in the second call returning too early with incorrect data.

## Issue / Bugzilla link
#6904

## Testing

This is a tiny code change but could do with some careful testing:

- [x] When any bedrock page loads we already query FxA for GA [here](https://github.com/mozilla/bedrock/blob/master/media/js/base/core-datalayer-init.js#L34-L38). This should still return the correct data as it does currently.
- [x] Adding an additional call to`getFxADetails()` in a page's JS bundle should now always result in the exact same data being returned. A page should not need to wait until DOMReady to make a second call (this has been a red herring).
- [x] Existing pages like `/firefox/accounts/` should still show the correct state.