### PR TITLE
[#6887] Global FxA, increase specificity of button hiding rule

### DIFF
--- a/media/css/protocol/components/_navigation.scss
+++ b/media/css/protocol/components/_navigation.scss
@@ -57,7 +57,7 @@
     }
 }
 
-html.is-firefox {
+html.is-firefox .mzp-c-navigation {
     .mzp-c-button-download-container {
         display: none;
     }


### PR DESCRIPTION
## Description
Only hide the button in the navbar, leave others alone.

## Testing
- [x] Download button is hidden in Firefox in navbar, but others on other pages are still visible (e.g. /new)