### PR TITLE
[fix #6899] Dry market test for privacy feature messaging

### DIFF
--- a/bedrock/firefox/templates/firefox/new/privacy-dmt/scene1-a.html
+++ b/bedrock/firefox/templates/firefox/new/privacy-dmt/scene1-a.html
@@ -1,0 +1,26 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+
+{% extends "firefox/new/scene1.html" %}
+
+{% block experiments %}{% endblock %}
+
+{% block extrahead %}
+  {{ super() }}
+  {{ css_bundle('firefox_new_scene1_privacy_dmt') }}
+{% endblock %}
+
+{% block body_class %}variant-a{% endblock %}
+
+{% block main_title %}
+<header>
+  <h1>{{ _('Now with Universal Tracking Protection') }}</h1>
+  <p class="tagline">{{ _('The new Firefox stops ads and websites from tracking your every move.') }}</p>
+</header>
+{% endblock %}
+
+{% block js %}
+  {{ super() }}
+  {{ js_bundle('firefox_new_scene1_variation') }}
+{% endblock %}

--- a/bedrock/firefox/templates/firefox/new/privacy-dmt/scene1-b.html
+++ b/bedrock/firefox/templates/firefox/new/privacy-dmt/scene1-b.html
@@ -1,0 +1,26 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+
+{% extends "firefox/new/scene1.html" %}
+
+{% block experiments %}{% endblock %}
+
+{% block extrahead %}
+  {{ super() }}
+  {{ css_bundle('firefox_new_scene1_privacy_dmt') }}
+{% endblock %}
+
+{% block body_class %}variant-b{% endblock %}
+
+{% block main_title %}
+<header>
+  <h1>{{ _('Ultimate privacy comes standard') }}</h1>
+  <p class="tagline">{{ _('The new Firefox stops ads and websites from tracking your every move.') }}</p>
+</header>
+{% endblock %}
+
+{% block js %}
+  {{ super() }}
+  {{ js_bundle('firefox_new_scene1_variation') }}
+{% endblock %}

--- a/bedrock/firefox/templates/firefox/new/privacy-dmt/scene1-c.html
+++ b/bedrock/firefox/templates/firefox/new/privacy-dmt/scene1-c.html
@@ -1,0 +1,26 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+
+{% extends "firefox/new/scene1.html" %}
+
+{% block experiments %}{% endblock %}
+
+{% block extrahead %}
+  {{ super() }}
+  {{ css_bundle('firefox_new_scene1_privacy_dmt') }}
+{% endblock %}
+
+{% block body_class %}variant-c{% endblock %}
+
+{% block main_title %}
+<header>
+  <h1>{{ _('Firefox is built for you, not advertisers') }}</h1>
+  <p class="tagline">{{ _('The new Firefox stops ads and websites from tracking your every move.') }}</p>
+</header>
+{% endblock %}
+
+{% block js %}
+  {{ super() }}
+  {{ js_bundle('firefox_new_scene1_variation') }}
+{% endblock %}

--- a/bedrock/firefox/templates/firefox/new/privacy-dmt/scene1-d.html
+++ b/bedrock/firefox/templates/firefox/new/privacy-dmt/scene1-d.html
@@ -1,0 +1,26 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+
+{% extends "firefox/new/scene1.html" %}
+
+{% block experiments %}{% endblock %}
+
+{% block extrahead %}
+  {{ super() }}
+  {{ css_bundle('firefox_new_scene1_privacy_dmt') }}
+{% endblock %}
+
+{% block body_class %}variant-d{% endblock %}
+
+{% block main_title %}
+<header>
+  <h1>{{ _('Introducing the Ultimate Privacy Edition') }}</h1>
+  <p class="tagline">{{ _('The new Firefox helps protect you from invasive ad trackers, Facebook’s spying and data breaches. Automatically.') }}</p>
+</header>
+{% endblock %}
+
+{% block js %}
+  {{ super() }}
+  {{ js_bundle('firefox_new_scene1_variation') }}
+{% endblock %}

--- a/bedrock/firefox/templates/firefox/new/privacy-dmt/scene1-e.html
+++ b/bedrock/firefox/templates/firefox/new/privacy-dmt/scene1-e.html
@@ -1,0 +1,26 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+
+{% extends "firefox/new/scene1.html" %}
+
+{% block experiments %}{% endblock %}
+
+{% block extrahead %}
+  {{ super() }}
+  {{ css_bundle('firefox_new_scene1_privacy_dmt') }}
+{% endblock %}
+
+{% block body_class %}variant-e{% endblock %}
+
+{% block main_title %}
+<header>
+  <h1>{{ _('Ultimate privacy comes standard') }}</h1>
+  <p class="tagline">{{ _('The new Firefox helps protect you from invasive ad trackers, Facebook’s spying and data breaches. Automatically.') }}</p>
+</header>
+{% endblock %}
+
+{% block js %}
+  {{ super() }}
+  {{ js_bundle('firefox_new_scene1_variation') }}
+{% endblock %}

--- a/bedrock/firefox/templates/firefox/new/privacy-dmt/scene1-f.html
+++ b/bedrock/firefox/templates/firefox/new/privacy-dmt/scene1-f.html
@@ -1,0 +1,26 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+
+{% extends "firefox/new/scene1.html" %}
+
+{% block experiments %}{% endblock %}
+
+{% block extrahead %}
+  {{ super() }}
+  {{ css_bundle('firefox_new_scene1_privacy_dmt') }}
+{% endblock %}
+
+{% block body_class %}variant-f{% endblock %}
+
+{% block main_title %}
+<header>
+  <h1>{{ _('Firefox is built for you, not advertisers') }}</h1>
+  <p class="tagline">{{ _('The new Firefox helps protect you from invasive ad trackers, Facebook’s spying and data breaches. Automatically.') }}</p>
+</header>
+{% endblock %}
+
+{% block js %}
+  {{ super() }}
+  {{ js_bundle('firefox_new_scene1_variation') }}
+{% endblock %}

--- a/bedrock/firefox/templates/firefox/new/privacy-dmt/scene2.html
+++ b/bedrock/firefox/templates/firefox/new/privacy-dmt/scene2.html
@@ -1,0 +1,98 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+
+{% extends "firefox/new/scene2.html" %}
+
+{% block experiments %}{% endblock %}
+
+{% block content %}
+<main class="main mzp-t-firefox mzp-t-dark">
+  <section class="status">
+    <div class="mzp-l-content mzp-t-firefox windows-xpvista">
+      <p>{{ _('You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.')|format(url='https://support.mozilla.org/kb/end-support-windows-xp-and-vista') }}</p>
+    </div>
+    <div class="mzp-l-content mzp-t-firefox">
+      {# fallback_url is replaced by the platform download link via JS, but if
+        something fails the user should still get a link to a working download path. #}
+
+      {% set id, fallback_url = 'direct-download-link', url('firefox.all') %}
+      <p>
+        {% if l10n_has_tag('firefox_new_try_again_link_020818') %}
+          {% trans %}
+            Your download should begin automatically. Didn’t work? <a id="{{ id }}" href="{{ fallback_url }}">Try downloading again</a>.
+          {% endtrans %}
+        {% else %}
+          {% trans %}
+            Your download should begin automatically. If it doesn’t, <a id="{{ id }}" href="{{ fallback_url }}">click here</a>.
+          {% endtrans %}
+        {% endif %}
+      </p>
+    </div>
+  </section>
+
+  <div class="mzp-l-content">
+    <div class="header-logos">
+      <h2><a class="firefox" href="{{ url('firefox') }}" title="{{ firefox_logo_title }}">{{ high_res_img('logos/firefox/logo-quantum-wordmark-white.png', {'alt': firefox_logo_title, 'width': '133', 'height': '50'}) }}</a></h2>
+      <h2><a class="mozilla" href="{{ url('mozorg.home') }}" title="{{ mozilla_logo_title }}"><img src="{{ static('img/logos/mozilla/wordmark-dark.svg')}}" alt="{{ mozilla_logo_title }}" width="101" height="34"></a></h2>
+    </div>
+
+    <div class="content-main">
+      <div class="download-button-wrapper desktop" id="download-button-wrapper-desktop">
+        {{ download_firefox(force_direct=true, dom_id='primary-download-button') }}
+      </div>
+
+
+      <h1 class="headline">
+      {% block headline %}
+        {{ _('Thank you for downloading Firefox. Updates coming soon.') }}
+      {% endblock %}
+      </h1>
+      <p class="tagline">{{ _('Our new suite of privacy features is still in development, so they’re not included by default yet. To get updates about all things Firefox, enter your email.') }}</p>
+
+      <div class="mzp-c-newsletter">
+        {{ email_newsletter_form(
+              protocol_component=True,
+              include_title=False,
+              email_label=_('Enter your email address'),
+              details='<a href="%s" class="email-privacy-link">%s</a>'|format(url('privacy.email'), _('How will Mozilla use my email?'))|safe
+        )}}
+      </div>
+
+      <p>
+        In the meantime, you’ve now got the browser that <a href="{{ url('firefox.fights-for-you') }}">fights for you</a>. And you can start using these best-of-the-web privacy features right away:
+      </p>
+
+      <ul class="mzp-u-list-styled">
+        <li>Add <a href="{{ url('firefox.facebookcontainer.index') }}">Facebook Container</a> to prevent Facebook from seeing the websites you visit</li>
+        <li>Sign up for <a href="https://monitor.firefox.com">Firefox Monitor</a> to receive alerts you if your personal info is involved in a data breach</li>
+        <li>Set <a href="https://www.youtube.com/watch?v=QtEMYSJyd-c">Enhanced Tracking Protection</a> to “Strict” to block ad trackers</li>
+      </ul>
+
+      <aside class="email-privacy mzp-u-modal-content">
+        <h3>{{ _('How will Mozilla use my email?') }}</h3>
+
+        <p>
+        {% trans
+              manifesto=url('mozorg.about.manifesto'),
+              principles=url('privacy.principles')
+        %}
+          Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="{{ manifesto }}">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="{{ principles }}">You can learn about our Data Privacy Principles here</a>.
+        {% endtrans %}
+        </p>
+
+        <p><strong>{{ _('What we want you to know:') }}</strong></p>
+
+        <ul class="prose mzp-u-list-styled">
+          <li>{{ _('You don’t need to give us your email to download and use Firefox.') }}</li>
+          <li>{{ _('We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.') }}</li>
+          <li>{{ _('You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.') }}</li>
+          <li>{{ _('You can unsubscribe anytime, for any reason.') }}</li>
+          <li>{{ _('We will not share, sell or use your email for any other purposes.') }}</li>
+        </ul>
+      </aside>
+
+    </div>
+  </div>
+</main>
+{% endblock %}

--- a/bedrock/firefox/templates/firefox/new/scene1.html
+++ b/bedrock/firefox/templates/firefox/new/scene1.html
@@ -15,8 +15,8 @@
 {% endblock %}
 
 {% block experiments %}
-  {% if switch('experiment_firefox_download_install', ['en-US']) %}
-    {{ js_bundle('experiment-firefox-download-install') }}
+  {% if switch('experiment_firefox_new_privacy_dmt', ['en-US']) %}
+    {{ js_bundle('experiment_firefox_new_privacy_dmt') }}
   {% endif %}
 {% endblock %}
 

--- a/bedrock/firefox/tests/test_views.py
+++ b/bedrock/firefox/tests/test_views.py
@@ -749,43 +749,49 @@ class TestFirefoxNew(TestCase):
         views.new(req)
         render_mock.assert_called_once_with(req, 'firefox/new/scene1.html', ANY)
 
-    # how to install experiment - issue 6704
+    # privacy dry market test - issue 6899
 
-    def test_install_scene_1_a(self, render_mock):
-        req = RequestFactory().get('/firefox/new/?v=a')
+    def test_privacy_dmt_scene_1_a(self, render_mock):
+        req = RequestFactory().get('/firefox/new/?xv=priv-dmt&v=a')
         req.locale = 'en-US'
         views.new(req)
-        render_mock.assert_called_once_with(req, 'firefox/new/install/scene1.html', ANY)
+        render_mock.assert_called_once_with(req, 'firefox/new/privacy-dmt/scene1-a.html', ANY)
 
-    def test_install_scene_1_b(self, render_mock):
-        req = RequestFactory().get('/firefox/new/?v=b')
+    def test_privacy_dmt_scene_1_b(self, render_mock):
+        req = RequestFactory().get('/firefox/new/?xv=priv-dmt&v=b')
         req.locale = 'en-US'
         views.new(req)
-        render_mock.assert_called_once_with(req, 'firefox/new/install/scene1.html', ANY)
+        render_mock.assert_called_once_with(req, 'firefox/new/privacy-dmt/scene1-b.html', ANY)
 
-    def test_install_scene_1_c(self, render_mock):
-        req = RequestFactory().get('/firefox/new/?v=c')
+    def test_privacy_dmt_scene_1_c(self, render_mock):
+        req = RequestFactory().get('/firefox/new/?xv=priv-dmt&v=c')
         req.locale = 'en-US'
         views.new(req)
-        render_mock.assert_called_once_with(req, 'firefox/new/install/scene1.html', ANY)
+        render_mock.assert_called_once_with(req, 'firefox/new/privacy-dmt/scene1-c.html', ANY)
 
-    def test_install_scene_2_a(self, render_mock):
-        req = RequestFactory().get('/firefox/download/thanks/?v=a')
+    def test_privacy_dmt_scene_1_d(self, render_mock):
+        req = RequestFactory().get('/firefox/new/?xv=priv-dmt&v=d')
+        req.locale = 'en-US'
+        views.new(req)
+        render_mock.assert_called_once_with(req, 'firefox/new/privacy-dmt/scene1-d.html', ANY)
+
+    def test_privacy_dmt_scene_1_e(self, render_mock):
+        req = RequestFactory().get('/firefox/new/?xv=priv-dmt&v=e')
+        req.locale = 'en-US'
+        views.new(req)
+        render_mock.assert_called_once_with(req, 'firefox/new/privacy-dmt/scene1-e.html', ANY)
+
+    def test_privacy_dmt_scene_1_f(self, render_mock):
+        req = RequestFactory().get('/firefox/new/?xv=priv-dmt&v=f')
+        req.locale = 'en-US'
+        views.new(req)
+        render_mock.assert_called_once_with(req, 'firefox/new/privacy-dmt/scene1-f.html', ANY)
+
+    def test_privacy_dmt_scene_2(self, render_mock):
+        req = RequestFactory().get('/firefox/download/thanks/?xv=priv-dmt')
         req.locale = 'en-US'
         views.download_thanks(req)
-        render_mock.assert_called_once_with(req, 'firefox/new/install/scene2-a.html', ANY)
-
-    def test_install_scene_2_b(self, render_mock):
-        req = RequestFactory().get('/firefox/download/thanks/?v=b')
-        req.locale = 'en-US'
-        views.download_thanks(req)
-        render_mock.assert_called_once_with(req, 'firefox/new/install/scene2-b.html', ANY)
-
-    def test_install_scene_2_c(self, render_mock):
-        req = RequestFactory().get('/firefox/download/thanks/?v=c')
-        req.locale = 'en-US'
-        views.download_thanks(req)
-        render_mock.assert_called_once_with(req, 'firefox/new/install/scene2-c.html', ANY)
+        render_mock.assert_called_once_with(req, 'firefox/new/privacy-dmt/scene2.html', ANY)
 
 
 class TestFirefoxNewNoIndex(TestCase):

--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -636,20 +636,8 @@ class ContentBlockingTourView(l10n_utils.LangFilesMixin, TemplateView):
 def download_thanks(request):
     experience = request.GET.get('xv', None)
     locale = l10n_utils.get_locale(request)
-    variant = request.GET.get('v', None)
     newsletter = request.GET.get('n', None)
     show_newsletter = locale in ['en-US', 'en-GB', 'en-CA', 'en-ZA', 'es-ES', 'es-AR', 'es-CL', 'es-MX', 'pt-BR', 'fr', 'ru', 'id', 'de', 'pl']
-
-    # ensure variant matches pre-defined value
-    if variant not in ['a', 'b', 'c']:  # place expected ?v= values in this list
-        variant = None
-
-    # check to see if a URL explicitly asks to hide the newsletter
-    if newsletter == 'f':
-        show_newsletter = False
-
-    if variant in ['b', 'c'] and locale == 'en-US':
-        show_newsletter = False
 
     # check to see if a URL explicitly asks to hide the newsletter
     if newsletter == 'f':
@@ -671,8 +659,8 @@ def download_thanks(request):
         else:
             template = 'firefox/new/scene2.html'
     elif locale == 'en-US':
-        if variant in ['a', 'b', 'c']:
-            template = 'firefox/new/install/scene2-{}.html'.format(variant)
+        if experience == 'priv-dmt':
+            template = 'firefox/new/privacy-dmt/scene2.html'
         elif experience == 'betterbrowser':
             template = 'firefox/new/better-browser/scene2.html'
         else:
@@ -698,7 +686,7 @@ def new(request):
 
     # ensure variant matches pre-defined value
 
-    if variant not in ['a', 'b', 'c']:  # place expected ?v= values in this list
+    if variant not in ['a', 'b', 'c', 'd', 'e', 'f']:  # place expected ?v= values in this list
         variant = None
 
     if scene == '2':
@@ -727,6 +715,14 @@ def new(request):
                 template = 'firefox/new/scene1.html'
         elif switch('firefox-yandex') and locale == 'ru':
             template = 'firefox/new/yandex/scene1.html'
+        elif switch('experiment_firefox_privacy_dmt') and locale == 'en-US':
+            if experience == 'priv-dmt':
+                if variant in ['a', 'b', 'c', 'd', 'e', 'f']:
+                    template = 'firefox/new/privacy-dmt/scene1-{}.html'.format(variant)
+                else:
+                    template = 'firefox/new/scene1.html'
+            else:
+                template = 'firefox/new/scene1.html'
         elif locale == 'en-US':
             if experience == 'betterbrowser':
                 template = 'firefox/new/better-browser/scene1.html'
@@ -734,8 +730,6 @@ def new(request):
                 template = 'firefox/new/compare/scene1-safari.html'
             elif experience == 'edge':
                 template = 'firefox/new/compare/scene1-edge.html'
-            elif variant in ['a', 'b', 'c']:
-                template = 'firefox/new/install/scene1.html'
             else:
                 template = 'firefox/new/scene1.html'
         else:

--- a/media/css/firefox/new/scene1-privacy-dmt.scss
+++ b/media/css/firefox/new/scene1-privacy-dmt.scss
@@ -1,0 +1,17 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+@import '../../pebbles/includes/lib';
+
+
+.main-content {
+    .tagline {
+        @include font-size(24px);
+        line-height: 1.3;
+    }
+
+    .small-links {
+        margin-top: 40px;
+    }
+}

--- a/media/css/firefox/new/scene1.scss
+++ b/media/css/firefox/new/scene1.scss
@@ -165,7 +165,6 @@ html.linux.arm {
 }
 
 .main-content {
-
     .download-button {
         margin: 0 auto 20px;
     }

--- a/media/js/firefox/new/experiment-privacy-dmt.js
+++ b/media/js/firefox/new/experiment-privacy-dmt.js
@@ -1,0 +1,43 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+(function(Mozilla) {
+    'use strict';
+
+    // Check that cookies are supported.
+    if (typeof Mozilla.Cookies === 'undefined' || !Mozilla.Cookies.enabled()) {
+        return;
+    }
+
+    // Exclude existing Firefox users.
+    if (/\s(Firefox)/.test(navigator.userAgent)) {
+        return;
+    }
+
+    // courtesy of https://davidwalsh.name/query-string-javascript
+    function getUrlParam(name) {
+        name = name.replace(/[\[]/, '\\[').replace(/[\]]/, '\\]');
+        var regex = new RegExp('[\\?&]' + name + '=([^&#]*)');
+        var results = regex.exec(location.search);
+        return results === null ? '' : decodeURIComponent(results[1].replace(/\+/g, ' '));
+    }
+
+    // if we already have a utm_content parameter, don't clobber existing stub attribution data.
+    if (!getUrlParam('utm_content')) {
+        var murphy = new Mozilla.TrafficCop({
+            id: 'priv-dmt',
+            variations: {
+                'xv=priv-dmt&v=a': 0.3,
+                'xv=priv-dmt&v=b': 0.3,
+                'xv=priv-dmt&v=c': 0.3,
+                'xv=priv-dmt&v=d': 0.3,
+                'xv=priv-dmt&v=e': 0.3,
+                'xv=priv-dmt&v=f': 0.3,
+            }
+        });
+
+        murphy.init();
+    }
+
+})(window.Mozilla);

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -241,6 +241,13 @@
         "name": "firefox_new_scene1_yandex"
     },
     {
+        "files": [
+          "css/firefox/new/scene1.scss",
+          "css/firefox/new/scene1-privacy-dmt.scss"
+        ],
+        "name": "firefox_new_scene1_privacy_dmt"
+    },
+    {
       "files": [
         "css/firefox/new/compare.scss"
       ],
@@ -1104,6 +1111,13 @@
           "js/firefox/new/yandex/scene1-init.js"
         ],
         "name": "firefox_new_scene1_yandex"
+    },
+    {
+      "files": [
+        "js/base/mozilla-traffic-cop.js",
+        "js/firefox/new/experiment-privacy-dmt.js"
+      ],
+      "name": "experiment_firefox_new_privacy_dmt"
     },
     {
       "files": [


### PR DESCRIPTION
## Description
Adds six variant download pages behind the switch `experiment_firefox_new_privacy_dmt` as well as a custom variant of /download/thanks/.

This may overlap/collide with #6908 so treating this as WIP while we work out the details of running these experiments simultaneously.

## Issue / Bugzilla link
#6899 