### PR TITLE
Dry market test for privacy feature messaging

### DIFF
--- a/bedrock/firefox/templates/firefox/new/privacy-dmt/scene1-a.html
+++ b/bedrock/firefox/templates/firefox/new/privacy-dmt/scene1-a.html
@@ -1,0 +1,28 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+
+{% add_lang_files "firefox/new/quantum" %}
+
+{% extends "firefox/new/scene1.html" %}
+
+{% block experiments %}{% endblock %}
+
+{% block extrahead %}
+  {{ super() }}
+  {{ css_bundle('firefox_new_scene1_privacy_dmt') }}
+{% endblock %}
+
+{% block body_class %}variant-a{% endblock %}
+
+{% block main_title %}
+<header>
+  <h1>{{ _('Now with Universal Tracking Protection') }}</h1>
+  <p class="tagline">{{ _('The new Firefox stops ads and websites from tracking your every move.') }}</p>
+</header>
+{% endblock %}
+
+{% block js %}
+  {{ super() }}
+  {{ js_bundle('firefox_new_scene1_variation') }}
+{% endblock %}

--- a/bedrock/firefox/templates/firefox/new/privacy-dmt/scene1-b.html
+++ b/bedrock/firefox/templates/firefox/new/privacy-dmt/scene1-b.html
@@ -1,0 +1,28 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+
+{% add_lang_files "firefox/new/quantum" %}
+
+{% extends "firefox/new/scene1.html" %}
+
+{% block experiments %}{% endblock %}
+
+{% block extrahead %}
+  {{ super() }}
+  {{ css_bundle('firefox_new_scene1_privacy_dmt') }}
+{% endblock %}
+
+{% block body_class %}variant-b{% endblock %}
+
+{% block main_title %}
+<header>
+  <h1>{{ _('Ultimate privacy comes standard') }}</h1>
+  <p class="tagline">{{ _('The new Firefox stops ads and websites from tracking your every move.') }}</p>
+</header>
+{% endblock %}
+
+{% block js %}
+  {{ super() }}
+  {{ js_bundle('firefox_new_scene1_variation') }}
+{% endblock %}

--- a/bedrock/firefox/templates/firefox/new/privacy-dmt/scene1-c.html
+++ b/bedrock/firefox/templates/firefox/new/privacy-dmt/scene1-c.html
@@ -1,0 +1,28 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+
+{% add_lang_files "firefox/new/quantum" %}
+
+{% extends "firefox/new/scene1.html" %}
+
+{% block experiments %}{% endblock %}
+
+{% block extrahead %}
+  {{ super() }}
+  {{ css_bundle('firefox_new_scene1_privacy_dmt') }}
+{% endblock %}
+
+{% block body_class %}variant-c{% endblock %}
+
+{% block main_title %}
+<header>
+  <h1>{{ _('Firefox is built for you, not advertisers') }}</h1>
+  <p class="tagline">{{ _('The new Firefox stops ads and websites from tracking your every move.') }}</p>
+</header>
+{% endblock %}
+
+{% block js %}
+  {{ super() }}
+  {{ js_bundle('firefox_new_scene1_variation') }}
+{% endblock %}

--- a/bedrock/firefox/templates/firefox/new/privacy-dmt/scene1-d.html
+++ b/bedrock/firefox/templates/firefox/new/privacy-dmt/scene1-d.html
@@ -1,0 +1,28 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+
+{% add_lang_files "firefox/new/quantum" %}
+
+{% extends "firefox/new/scene1.html" %}
+
+{% block experiments %}{% endblock %}
+
+{% block extrahead %}
+  {{ super() }}
+  {{ css_bundle('firefox_new_scene1_privacy_dmt') }}
+{% endblock %}
+
+{% block body_class %}variant-d{% endblock %}
+
+{% block main_title %}
+<header>
+  <h1>{{ _('Introducing the Ultimate Privacy Edition') }}</h1>
+  <p class="tagline">{{ _('The new Firefox helps protect you from invasive ad trackers, Facebook’s spying and data breaches. Automatically.') }}</p>
+</header>
+{% endblock %}
+
+{% block js %}
+  {{ super() }}
+  {{ js_bundle('firefox_new_scene1_variation') }}
+{% endblock %}

--- a/bedrock/firefox/templates/firefox/new/privacy-dmt/scene1-e.html
+++ b/bedrock/firefox/templates/firefox/new/privacy-dmt/scene1-e.html
@@ -1,0 +1,28 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+
+{% add_lang_files "firefox/new/quantum" %}
+
+{% extends "firefox/new/scene1.html" %}
+
+{% block experiments %}{% endblock %}
+
+{% block extrahead %}
+  {{ super() }}
+  {{ css_bundle('firefox_new_scene1_privacy_dmt') }}
+{% endblock %}
+
+{% block body_class %}variant-e{% endblock %}
+
+{% block main_title %}
+<header>
+  <h1>{{ _('Ultimate privacy comes standard') }}</h1>
+  <p class="tagline">{{ _('The new Firefox helps protect you from invasive ad trackers, Facebook’s spying and data breaches. Automatically.') }}</p>
+</header>
+{% endblock %}
+
+{% block js %}
+  {{ super() }}
+  {{ js_bundle('firefox_new_scene1_variation') }}
+{% endblock %}

--- a/bedrock/firefox/templates/firefox/new/privacy-dmt/scene1-f.html
+++ b/bedrock/firefox/templates/firefox/new/privacy-dmt/scene1-f.html
@@ -1,0 +1,28 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+
+{% add_lang_files "firefox/new/quantum" %}
+
+{% extends "firefox/new/scene1.html" %}
+
+{% block experiments %}{% endblock %}
+
+{% block extrahead %}
+  {{ super() }}
+  {{ css_bundle('firefox_new_scene1_privacy_dmt') }}
+{% endblock %}
+
+{% block body_class %}variant-f{% endblock %}
+
+{% block main_title %}
+<header>
+  <h1>{{ _('Firefox is built for you, not advertisers') }}</h1>
+  <p class="tagline">{{ _('The new Firefox helps protect you from invasive ad trackers, Facebook’s spying and data breaches. Automatically.') }}</p>
+</header>
+{% endblock %}
+
+{% block js %}
+  {{ super() }}
+  {{ js_bundle('firefox_new_scene1_variation') }}
+{% endblock %}

--- a/bedrock/firefox/templates/firefox/new/privacy-dmt/scene2.html
+++ b/bedrock/firefox/templates/firefox/new/privacy-dmt/scene2.html
@@ -1,0 +1,29 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+
+{% add_lang_files "firefox/new/quantum" %}
+
+{% extends "firefox/new/scene2.html" %}
+
+{% block experiments %}{% endblock %}
+
+{% block headline %}
+  {{ _('Thank you for downloading Firefox. Updates coming soon.') }}
+{% endblock %}
+
+{% block tagline %}
+<p class="tagline">{{ _('Our new suite of privacy features is still in development, so they’re not included by default yet. To get updates about all things Firefox, enter your email.') }}</p>
+{% endblock %}
+
+{% block additional_content %}
+<p>
+  In the meantime, you’ve now got the browser that <a href="{{ url('firefox.fights-for-you') }}">fights for you</a>. And you can start using these best-of-the-web privacy features right away:
+</p>
+
+<ul class="mzp-u-list-styled">
+  <li>Add <a href="{{ url('firefox.facebookcontainer.index') }}">Facebook Container</a> to prevent Facebook from seeing the websites you visit</li>
+  <li>Sign up for <a href="https://monitor.firefox.com">Firefox Monitor</a> to receive alerts you if your personal info is involved in a data breach</li>
+  <li>Set <a href="https://www.youtube.com/watch?v=QtEMYSJyd-c">Enhanced Tracking Protection</a> to “Strict” to block ad trackers</li>
+</ul>
+{% endblock %}

--- a/bedrock/firefox/templates/firefox/new/scene1.html
+++ b/bedrock/firefox/templates/firefox/new/scene1.html
@@ -14,7 +14,11 @@
   {{ css_bundle('firefox_new_scene1') }}
 {% endblock %}
 
-{% block experiments %}{% endblock %}
+{% block experiments %}
+  {% if switch('experiment_firefox_new_privacy_dmt', ['en-US']) %}
+    {{ js_bundle('experiment_firefox_new_privacy_dmt') }}
+  {% endif %}
+{% endblock %}
 
 {% block body_id %}firefox-new-scene1{% endblock %}
 

--- a/bedrock/firefox/templates/firefox/new/scene2.html
+++ b/bedrock/firefox/templates/firefox/new/scene2.html
@@ -98,7 +98,9 @@
         {{ _('Learn how to make Firefox even smarter, faster and more secure.') }}
       {% endblock %}
       </h1>
+      {% block tagline %}
       <p class="tagline">{{ _('Get informative tips, tricks and product announcements delivered to your inbox.') }}</p>
+      {% endblock %}
 
       <div class="mzp-c-newsletter">
         {{ email_newsletter_form(
@@ -108,6 +110,8 @@
               details='<a href="%s" class="email-privacy-link">%s</a>'|format(url('privacy.email'), _('How will Mozilla use my email?'))|safe
         )}}
       </div>
+
+      {% block additional_content %}{% endblock %}
 
       <aside class="email-privacy mzp-u-modal-content">
         <h3>{{ _('How will Mozilla use my email?') }}</h3>

--- a/bedrock/firefox/tests/test_views.py
+++ b/bedrock/firefox/tests/test_views.py
@@ -749,6 +749,57 @@ class TestFirefoxNew(TestCase):
         views.new(req)
         render_mock.assert_called_once_with(req, 'firefox/new/scene1.html', ANY)
 
+    # privacy dry market test - issue 6899
+
+    @patch.dict(os.environ, SWITCH_EXPERIMENT_FIREFOX_PRIVACY_DMT='True')
+    def test_privacy_dmt_scene_1_a(self, render_mock):
+        req = RequestFactory().get('/firefox/new/?xv=priv-dmt&v=a')
+        req.locale = 'en-US'
+        views.new(req)
+        render_mock.assert_called_once_with(req, 'firefox/new/privacy-dmt/scene1-a.html', ANY)
+
+    @patch.dict(os.environ, SWITCH_EXPERIMENT_FIREFOX_PRIVACY_DMT='True')
+    def test_privacy_dmt_scene_1_b(self, render_mock):
+        req = RequestFactory().get('/firefox/new/?xv=priv-dmt&v=b')
+        req.locale = 'en-US'
+        views.new(req)
+        render_mock.assert_called_once_with(req, 'firefox/new/privacy-dmt/scene1-b.html', ANY)
+
+    @patch.dict(os.environ, SWITCH_EXPERIMENT_FIREFOX_PRIVACY_DMT='True')
+    def test_privacy_dmt_scene_1_c(self, render_mock):
+        req = RequestFactory().get('/firefox/new/?xv=priv-dmt&v=c')
+        req.locale = 'en-US'
+        views.new(req)
+        render_mock.assert_called_once_with(req, 'firefox/new/privacy-dmt/scene1-c.html', ANY)
+
+    @patch.dict(os.environ, SWITCH_EXPERIMENT_FIREFOX_PRIVACY_DMT='True')
+    def test_privacy_dmt_scene_1_d(self, render_mock):
+        req = RequestFactory().get('/firefox/new/?xv=priv-dmt&v=d')
+        req.locale = 'en-US'
+        views.new(req)
+        render_mock.assert_called_once_with(req, 'firefox/new/privacy-dmt/scene1-d.html', ANY)
+
+    @patch.dict(os.environ, SWITCH_EXPERIMENT_FIREFOX_PRIVACY_DMT='True')
+    def test_privacy_dmt_scene_1_e(self, render_mock):
+        req = RequestFactory().get('/firefox/new/?xv=priv-dmt&v=e')
+        req.locale = 'en-US'
+        views.new(req)
+        render_mock.assert_called_once_with(req, 'firefox/new/privacy-dmt/scene1-e.html', ANY)
+
+    @patch.dict(os.environ, SWITCH_EXPERIMENT_FIREFOX_PRIVACY_DMT='True')
+    def test_privacy_dmt_scene_1_f(self, render_mock):
+        req = RequestFactory().get('/firefox/new/?xv=priv-dmt&v=f')
+        req.locale = 'en-US'
+        views.new(req)
+        render_mock.assert_called_once_with(req, 'firefox/new/privacy-dmt/scene1-f.html', ANY)
+
+    @patch.dict(os.environ, SWITCH_EXPERIMENT_FIREFOX_PRIVACY_DMT='True')
+    def test_privacy_dmt_scene_2(self, render_mock):
+        req = RequestFactory().get('/firefox/download/thanks/?xv=priv-dmt')
+        req.locale = 'en-US'
+        views.download_thanks(req)
+        render_mock.assert_called_once_with(req, 'firefox/new/privacy-dmt/scene2.html', ANY)
+
 
 class TestFirefoxNewNoIndex(TestCase):
     def test_scene_1_noindex(self):

--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -664,7 +664,9 @@ def download_thanks(request):
         else:
             template = 'firefox/new/scene2.html'
     elif locale == 'en-US':
-        if experience == 'betterbrowser':
+        if experience == 'priv-dmt':
+            template = 'firefox/new/privacy-dmt/scene2.html'
+        elif experience == 'betterbrowser':
             template = 'firefox/new/better-browser/scene2.html'
         else:
             template = 'firefox/new/scene2.html'
@@ -689,7 +691,7 @@ def new(request):
 
     # ensure variant matches pre-defined value
 
-    if variant not in []:  # place expected ?v= values in this list
+    if variant not in ['a', 'b', 'c', 'd', 'e', 'f']:  # place expected ?v= values in this list
         variant = None
 
     if scene == '2':
@@ -718,6 +720,14 @@ def new(request):
                 template = 'firefox/new/scene1.html'
         elif switch('firefox-yandex') and locale == 'ru':
             template = 'firefox/new/yandex/scene1.html'
+        elif switch('experiment_firefox_privacy_dmt') and locale == 'en-US':
+            if experience == 'priv-dmt':
+                if variant in ['a', 'b', 'c', 'd', 'e', 'f']:
+                    template = 'firefox/new/privacy-dmt/scene1-{}.html'.format(variant)
+                else:
+                    template = 'firefox/new/scene1.html'
+            else:
+                template = 'firefox/new/scene1.html'
         elif locale == 'en-US':
             if experience == 'betterbrowser':
                 template = 'firefox/new/better-browser/scene1.html'

--- a/media/css/firefox/new/scene1-privacy-dmt.scss
+++ b/media/css/firefox/new/scene1-privacy-dmt.scss
@@ -1,0 +1,17 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+@import '../../pebbles/includes/lib';
+
+
+.main-content {
+    .tagline {
+        @include font-size(24px);
+        line-height: 1.3;
+    }
+
+    .small-links {
+        margin-top: 40px;
+    }
+}

--- a/media/css/firefox/new/scene1.scss
+++ b/media/css/firefox/new/scene1.scss
@@ -165,7 +165,6 @@ html.linux.arm {
 }
 
 .main-content {
-
     .download-button {
         margin: 0 auto 20px;
     }

--- a/media/js/firefox/new/experiment-privacy-dmt.js
+++ b/media/js/firefox/new/experiment-privacy-dmt.js
@@ -1,0 +1,56 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+(function(Mozilla) {
+    'use strict';
+
+    var isWithinSampleRate = Math.random() <= 0.5;
+
+    // Check that cookies are supported.
+    if (typeof Mozilla.Cookies === 'undefined' || !Mozilla.Cookies.enabled()) {
+        return;
+    }
+
+    // Exclude users who are in alternate headline experiment (Issue #6851)
+    if (Mozilla.Cookies.hasItem('experiment-firefox-new-headline-us')) {
+        return;
+    }
+
+    // Exclude existing Firefox users.
+    if (/\s(Firefox)/.test(navigator.userAgent)) {
+        return;
+    }
+
+    // Allow 50% of users to drop through to alternate headline experiment (Issue #6851)
+    if (!isWithinSampleRate && !Mozilla.Cookies.hasItem('priv-dmt')) {
+        return;
+    }
+
+    // courtesy of https://davidwalsh.name/query-string-javascript
+    function getUrlParam(name) {
+        name = name.replace(/[\[]/, '\\[').replace(/[\]]/, '\\]');
+        var regex = new RegExp('[\\?&]' + name + '=([^&#]*)');
+        var results = regex.exec(location.search);
+        return results === null ? '' : decodeURIComponent(results[1].replace(/\+/g, ' '));
+    }
+
+    // if we already have an `xv` parameter on the page, don't enter into the experiment.
+    if (!getUrlParam('xv')) {
+        var murphy = new Mozilla.TrafficCop({
+            id: 'priv-dmt',
+            variations: {
+                'xv=priv-dmt&v=1': 98.2, // control
+                'xv=priv-dmt&v=a': 0.3,
+                'xv=priv-dmt&v=b': 0.3,
+                'xv=priv-dmt&v=c': 0.3,
+                'xv=priv-dmt&v=d': 0.3,
+                'xv=priv-dmt&v=e': 0.3,
+                'xv=priv-dmt&v=f': 0.3,
+            }
+        });
+
+        murphy.init();
+    }
+
+})(window.Mozilla);

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -235,6 +235,13 @@
         "name": "firefox_new_scene1_yandex"
     },
     {
+        "files": [
+          "css/firefox/new/scene1.scss",
+          "css/firefox/new/scene1-privacy-dmt.scss"
+        ],
+        "name": "firefox_new_scene1_privacy_dmt"
+    },
+    {
       "files": [
         "css/firefox/new/compare.scss"
       ],
@@ -1098,6 +1105,13 @@
           "js/firefox/new/yandex/scene1-init.js"
         ],
         "name": "firefox_new_scene1_yandex"
+    },
+    {
+      "files": [
+        "js/base/mozilla-traffic-cop.js",
+        "js/firefox/new/experiment-privacy-dmt.js"
+      ],
+      "name": "experiment_firefox_new_privacy_dmt"
     },
     {
       "files": [


### PR DESCRIPTION
## Description

Adds six variant download pages behind the switch experiment_firefox_new_privacy_dmt as well as a custom variant of /download/thanks/.

- Replaces https://github.com/mozilla/bedrock/pull/6925 since Craig is out on PTO.
- Adds some review fixes

## Issue / Bugzilla link
https://github.com/mozilla/bedrock/issues/6899
https://github.com/mozilla/bedrock/issues/6920

## Testing
Demo URL: https://bedrock-demo-agibson.oregon-b.moz.works/en-US/firefox/new/

Variations:

https://bedrock-demo-agibson.oregon-b.moz.works/en-US/firefox/new/?xv=priv-dmt&v=1
https://bedrock-demo-agibson.oregon-b.moz.works/en-US/firefox/new/?xv=priv-dmt&v=a
https://bedrock-demo-agibson.oregon-b.moz.works/en-US/firefox/new/?xv=priv-dmt&v=b
https://bedrock-demo-agibson.oregon-b.moz.works/en-US/firefox/new/?xv=priv-dmt&v=c
https://bedrock-demo-agibson.oregon-b.moz.works/en-US/firefox/new/?xv=priv-dmt&v=d
https://bedrock-demo-agibson.oregon-b.moz.works/en-US/firefox/new/?xv=priv-dmt&v=e
https://bedrock-demo-agibson.oregon-b.moz.works/en-US/firefox/new/?xv=priv-dmt&v=f

To best test this PR, I'd suggest using a non-Firefox browser on Windows. Non-Firefox is a criteria for this experiment, and Windows is a criteria for the headline experiment.

Things to check:

- [ ] Custom /thanks/ is shown for all experiment variations (except control).
- [ ] Experiment will trigger 50% of the time for qualifying visitors (allowing other 50% to enter the headline experiment from https://github.com/mozilla/bedrock/pull/6908).
- [ ] Experiment will not trigger if user already has a cookie from headline experiment.
- [ ] Headline experiment will not trigger if user already has a cookie from this experiment.