### PR TITLE
Desktop Aurora no longer has Android Aurora gtm_page_id

### DIFF
--- a/bedrock/firefox/templates/firefox/releases/aurora-notes.html
+++ b/bedrock/firefox/templates/firefox/releases/aurora-notes.html
@@ -4,7 +4,13 @@
 
 {% extends "firefox/releases/release-notes.html" %}
 
-{% block gtm_page_id %}data-gtm-page-id="/firefox/android/auroranotes/"{% endblock %}
+{% block gtm_page_id %}
+    {% if release.product == 'Firefox for Android' %}
+        data-gtm-page-id="/firefox/android/auroranotes/"
+    {% else %}
+        data-gtm-page-id="/firefox/auroranotes/"
+    {% endif %}
+{% endblock %}
 
 {% block page_css %}
   {{ css_bundle('firefox_releasenotes_firefox') }}

--- a/bedrock/firefox/templates/firefox/releases/aurora-notes.html
+++ b/bedrock/firefox/templates/firefox/releases/aurora-notes.html
@@ -5,11 +5,11 @@
 {% extends "firefox/releases/release-notes.html" %}
 
 {% block gtm_page_id %}
-    {% if release.product == 'Firefox for Android' %}
-        data-gtm-page-id="/firefox/android/auroranotes/"
-    {% else %}
-        data-gtm-page-id="/firefox/auroranotes/"
-    {% endif %}
+  {% if release.product == 'Firefox for Android' %}
+    data-gtm-page-id="/firefox/android/auroranotes/"
+  {% else %}
+    data-gtm-page-id="/firefox/auroranotes/"
+  {% endif %}
 {% endblock %}
 
 {% block page_css %}


### PR DESCRIPTION
## Description
Aurora notes template handles both desktop and android browsers.

## Issue / Bugzilla link
Fix #6930

## Testing
Desktop Aurora: https://www.mozilla.org/en-US/firefox/32.0a2/auroranotes/
Android Aurora: https://www.mozilla.org/en-US/firefox/android/54.0a2/auroranotes/