### PR TITLE
Fix dry-market experiment switch name

### DIFF
--- a/bedrock/firefox/tests/test_views.py
+++ b/bedrock/firefox/tests/test_views.py
@@ -751,49 +751,49 @@ class TestFirefoxNew(TestCase):
 
     # privacy dry market test - issue 6899
 
-    @patch.dict(os.environ, SWITCH_EXPERIMENT_FIREFOX_PRIVACY_DMT='True')
+    @patch.dict(os.environ, SWITCH_EXPERIMENT_FIREFOX_NEW_PRIVACY_DMT='True')
     def test_privacy_dmt_scene_1_a(self, render_mock):
         req = RequestFactory().get('/firefox/new/?xv=priv-dmt&v=a')
         req.locale = 'en-US'
         views.new(req)
         render_mock.assert_called_once_with(req, 'firefox/new/privacy-dmt/scene1-a.html', ANY)
 
-    @patch.dict(os.environ, SWITCH_EXPERIMENT_FIREFOX_PRIVACY_DMT='True')
+    @patch.dict(os.environ, SWITCH_EXPERIMENT_FIREFOX_NEW_PRIVACY_DMT='True')
     def test_privacy_dmt_scene_1_b(self, render_mock):
         req = RequestFactory().get('/firefox/new/?xv=priv-dmt&v=b')
         req.locale = 'en-US'
         views.new(req)
         render_mock.assert_called_once_with(req, 'firefox/new/privacy-dmt/scene1-b.html', ANY)
 
-    @patch.dict(os.environ, SWITCH_EXPERIMENT_FIREFOX_PRIVACY_DMT='True')
+    @patch.dict(os.environ, SWITCH_EXPERIMENT_FIREFOX_NEW_PRIVACY_DMT='True')
     def test_privacy_dmt_scene_1_c(self, render_mock):
         req = RequestFactory().get('/firefox/new/?xv=priv-dmt&v=c')
         req.locale = 'en-US'
         views.new(req)
         render_mock.assert_called_once_with(req, 'firefox/new/privacy-dmt/scene1-c.html', ANY)
 
-    @patch.dict(os.environ, SWITCH_EXPERIMENT_FIREFOX_PRIVACY_DMT='True')
+    @patch.dict(os.environ, SWITCH_EXPERIMENT_FIREFOX_NEW_PRIVACY_DMT='True')
     def test_privacy_dmt_scene_1_d(self, render_mock):
         req = RequestFactory().get('/firefox/new/?xv=priv-dmt&v=d')
         req.locale = 'en-US'
         views.new(req)
         render_mock.assert_called_once_with(req, 'firefox/new/privacy-dmt/scene1-d.html', ANY)
 
-    @patch.dict(os.environ, SWITCH_EXPERIMENT_FIREFOX_PRIVACY_DMT='True')
+    @patch.dict(os.environ, SWITCH_EXPERIMENT_FIREFOX_NEW_PRIVACY_DMT='True')
     def test_privacy_dmt_scene_1_e(self, render_mock):
         req = RequestFactory().get('/firefox/new/?xv=priv-dmt&v=e')
         req.locale = 'en-US'
         views.new(req)
         render_mock.assert_called_once_with(req, 'firefox/new/privacy-dmt/scene1-e.html', ANY)
 
-    @patch.dict(os.environ, SWITCH_EXPERIMENT_FIREFOX_PRIVACY_DMT='True')
+    @patch.dict(os.environ, SWITCH_EXPERIMENT_FIREFOX_NEW_PRIVACY_DMT='True')
     def test_privacy_dmt_scene_1_f(self, render_mock):
         req = RequestFactory().get('/firefox/new/?xv=priv-dmt&v=f')
         req.locale = 'en-US'
         views.new(req)
         render_mock.assert_called_once_with(req, 'firefox/new/privacy-dmt/scene1-f.html', ANY)
 
-    @patch.dict(os.environ, SWITCH_EXPERIMENT_FIREFOX_PRIVACY_DMT='True')
+    @patch.dict(os.environ, SWITCH_EXPERIMENT_FIREFOX_NEW_PRIVACY_DMT='True')
     def test_privacy_dmt_scene_2(self, render_mock):
         req = RequestFactory().get('/firefox/download/thanks/?xv=priv-dmt')
         req.locale = 'en-US'

--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -720,7 +720,7 @@ def new(request):
                 template = 'firefox/new/scene1.html'
         elif switch('firefox-yandex') and locale == 'ru':
             template = 'firefox/new/yandex/scene1.html'
-        elif switch('experiment_firefox_privacy_dmt') and locale == 'en-US':
+        elif switch('experiment_firefox_new_privacy_dmt') and locale == 'en-US':
             if experience == 'priv-dmt':
                 if variant in ['a', 'b', 'c', 'd', 'e', 'f']:
                     template = 'firefox/new/privacy-dmt/scene1-{}.html'.format(variant)


### PR DESCRIPTION
Switch name in the view doesn't match the [template](https://github.com/mozilla/bedrock/blob/master/bedrock/firefox/templates/firefox/new/scene1.html#L18), this should fix things
