### PR TITLE
Fetch tokens for FxA metrics flow on /66.0/whatsnew/ (Fixes #6945)

### DIFF
--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -1079,6 +1079,7 @@
         "js/base/uitour-lib.js",
         "js/base/mozilla-fxa.js",
         "js/base/mozilla-fxa-init.js",
+        "js/base/mozilla-fxa-form.js",
         "protocol/js/protocol-modal.js",
         "js/firefox/whatsnew/whatsnew-66.js"
       ],


### PR DESCRIPTION
## Description
- Fixes FxA signup analytics on `/firefox/66.0/whatsnew/`

## Issue / Bugzilla link
https://github.com/mozilla/bedrock/issues/6945

## Testing
- [ ] Page should now make a fetch request for `https://accounts.firefox.com/metrics-flow?form_type=email&entrypoint=mozilla.org-whatsnew66&utm_source=whatsnew&utm_campaign=fxa-embedded-form`