### PR TITLE
Include stub-attribution bundle for non-experiment locales on /firefox/new/ (#6851)

### DIFF
--- a/bedrock/firefox/templates/firefox/new/scene1.html
+++ b/bedrock/firefox/templates/firefox/new/scene1.html
@@ -164,15 +164,21 @@
 {% endblock %}
 
 {% block stub_attribution %}
-  <!--[if !lte IE 8]><!-->
-  {{ js_bundle('stub-attribution-custom') }}
-  {% if switch('experiment_firefox_new_headlne_en', ['en-US', 'en-CA', 'en-GB']) %}
-    {{ js_bundle('experiment-firefox-new-headline-en') }}
+  {% if settings.STUB_ATTRIBUTION_RATE %}
+    {% if LANG in ['en-US', 'en-CA', 'en-GB', 'de'] %}
+      <!--[if !lte IE 8]><!-->
+      {{ js_bundle('stub-attribution-custom') }}
+      {% if switch('experiment_firefox_new_headlne_en', ['en-US', 'en-CA', 'en-GB']) %}
+        {{ js_bundle('experiment-firefox-new-headline-en') }}
+      {% endif %}
+      {% if switch('experiment_firefox_new_headlne_de', ['de']) %}
+        {{ js_bundle('experiment-firefox-new-headline-de') }}
+      {% endif %}
+      <!--<![endif]-->
+    {% else %}
+      {{ js_bundle('stub-attribution') }}
+    {% endif %}
   {% endif %}
-  {% if switch('experiment_firefox_new_headlne_de', ['de']) %}
-    {{ js_bundle('experiment-firefox-new-headline-de') }}
-  {% endif %}
-  <!--<![endif]-->
 {% endblock %}
 
 {% block js %}

--- a/docs/stub-attribution.rst
+++ b/docs/stub-attribution.rst
@@ -72,10 +72,12 @@ the page template where an experiment exists:
 .. code-block:: html
 
     {% block stub_attribution %}
-      <!--[if !lte IE 8]><!-->
-      {{ js_bundle('stub-attribution-custom') }}
-      {{ js_bundle('my-page-experiment-script') }}
-      <!--<![endif]-->
+      {% if settings.STUB_ATTRIBUTION_RATE %}
+        <!--[if !lte IE 8]><!-->
+        {{ js_bundle('stub-attribution-custom') }}
+        {{ js_bundle('my-page-experiment-script') }}
+        <!--<![endif]-->
+      {% endif %}
     {% endblock %}
 
 The `stub-attribution-custom` bundle contains the code that enables passing custom data


### PR DESCRIPTION
## Description
It occured to me that in the headline experiment on `/firefox/new/` we're overriding the regular stub attribution block in the `scene1.html` template, but we only really need to do this for the locales the experiment applies to.

This PR adds back the regular `stub-attribution` bundle for all other locales. It also adds an extra check for `STUB_ATTRIBUTION_RATE` (which is already 100% in production, but if we ever had to suddenly turn it off for any reason then the experiment would comply).

## Issue / Bugzilla link
#6851

## Testing
- [ ] `stub-attribution-custom` bundle should be included for experiment locales.
- [ ] The regular `stub-attribution` bundle should be included for any other locales.