### PR TITLE
Remove the word "Truly" from "Truly Private Browsing" (Fixes #6299)

### DIFF
--- a/bedrock/firefox/templates/firefox/campaign.html
+++ b/bedrock/firefox/templates/firefox/campaign.html
@@ -56,7 +56,11 @@
         {{ picto_card(title=_('Lightweight'), desc=_('Uses 30% less memory than Chrome')) }}
       </li>
       <li class="private">
-        {{ picto_card(title=_('Powerfully private'), desc=_('Truly Private Browsing with Tracking Protection')) }}
+        {% if l10n_has_tag('truly_removal_2019') %}
+          {{ picto_card(title=_('Powerfully private'), desc=_('Private Browsing with Tracking Protection')) }}
+        {% else %}
+          {{ picto_card(title=_('Powerfully private'), desc=_('Truly Private Browsing with Tracking Protection')) }}
+        {% endif %}
       </li>
     </ul>
   </section>

--- a/bedrock/firefox/templates/firefox/new/scene1.html
+++ b/bedrock/firefox/templates/firefox/new/scene1.html
@@ -96,7 +96,11 @@
       </li>
       <li class="private">
         <h3>{{_('Powerfully private') }}</h3>
-        <p>{{_('Truly Private Browsing with Tracking Protection') }}</p>
+        {% if l10n_has_tag('truly_removal_2019') %}
+          <p>{{_('Private Browsing with Tracking Protection') }}</p>
+        {% else %}
+          <p>{{_('Truly Private Browsing with Tracking Protection') }}</p>
+        {% endif %}
       </li>
     </ul>
   </div>

--- a/bedrock/firefox/templates/firefox/new/yandex/base.html
+++ b/bedrock/firefox/templates/firefox/new/yandex/base.html
@@ -87,7 +87,13 @@
         </li>
         <li class="private">
           <h3 data-yandex-alt="Визуальные закладки">{{_('Powerfully private') }}</h3>
-          <p data-yandex-alt="Браузерное расширение, которое преобразует сохраненные закладки в графическое панно на стартовой странице браузера.">{{_('Truly Private Browsing with Tracking Protection') }}</p>
+          <p data-yandex-alt="Браузерное расширение, которое преобразует сохраненные закладки в графическое панно на стартовой странице браузера.">
+            {% if l10n_has_tag('truly_removal_2019') %}
+              {{_('Private Browsing with Tracking Protection') }}
+            {% else %}
+              {{_('Truly Private Browsing with Tracking Protection') }}
+            {% endif %}
+          </p>
         </li>
       </ul>
     </div>

--- a/bedrock/firefox/templates/firefox/recommended.html
+++ b/bedrock/firefox/templates/firefox/recommended.html
@@ -48,11 +48,7 @@
         {{ picto_card(title=_('Lightweight'), desc=_('Rebuilt to use less memory')) }}
       </li>
       <li class="private">
-        {% if l10n_has_tag('truly_removal_2019') %}
-          {{ picto_card(title=_('Powerfully private'), desc=_('Private Browsing with Tracking Protection')) }}
-        {% else %}
-          {{ picto_card(title=_('Powerfully private'), desc=_('Truly Private Browsing with Tracking Protection')) }}
-        {% endif %}
+        {{ picto_card(title=_('Powerfully private'), desc=_('Private Browsing with Tracking Protection')) }}
       </li>
     </ul>
   </div>

--- a/bedrock/firefox/templates/firefox/recommended.html
+++ b/bedrock/firefox/templates/firefox/recommended.html
@@ -48,7 +48,11 @@
         {{ picto_card(title=_('Lightweight'), desc=_('Rebuilt to use less memory')) }}
       </li>
       <li class="private">
-        {{ picto_card(title=_('Powerfully private'), desc=_('Truly Private Browsing with Tracking Protection')) }}
+        {% if l10n_has_tag('truly_removal_2019') %}
+          {{ picto_card(title=_('Powerfully private'), desc=_('Private Browsing with Tracking Protection')) }}
+        {% else %}
+          {{ picto_card(title=_('Powerfully private'), desc=_('Truly Private Browsing with Tracking Protection')) }}
+        {% endif %}
       </li>
     </ul>
   </div>


### PR DESCRIPTION
## Description
Remove the word "Truly" from instances of "Truly Private Browsing with Tracking Protection" 

## Issue / Bugzilla link
#6299 

## Testing
New strings are behind l10n tags on:
- firefox/campaign
- firefox/new
- /ru/firefox/new/
- firefox/this-browser-comes-highly-recommended/

