### PR TITLE
Add download button to Windows 64-bit hero. (Fixes #6892)

### DIFF
--- a/bedrock/firefox/templates/firefox/windows-64-bit.html
+++ b/bedrock/firefox/templates/firefox/windows-64-bit.html
@@ -19,9 +19,12 @@
  {% block content %}
    <div class="mzp-c-hero">
      <div class="hero-content">
+       <img src="{{ static('protocol/img/logos/firefox/firefox.png') }}" width="50" height="50" alt="">
        <p>{{ _('64-bit') }}</p>
        <h1>{{ _('A more secure Firefox.') }}</h1>
-       <img src="{{ static('protocol/img/logos/firefox/firefox.png') }}" width="50" height="50" alt="">
+       <div class="download-firefox">
+         {{ download_firefox(download_location='primary cta') }}
+       </div>
      </div>
    </div>
    <div class="mzp-l-content">

--- a/bedrock/firefox/templates/firefox/windows-64-bit.html
+++ b/bedrock/firefox/templates/firefox/windows-64-bit.html
@@ -23,7 +23,7 @@
        <p>{{ _('64-bit') }}</p>
        <h1>{{ _('A more secure Firefox.') }}</h1>
        <div class="download-firefox">
-         {{ download_firefox(download_location='primary cta') }}
+         {{ download_firefox(dom_id='win64-hero-download', download_location='primary cta') }}
        </div>
      </div>
    </div>
@@ -69,7 +69,7 @@
   class='mzp-t-product-firefox mzp-t-firefox'
 ) %}
   <div class="download-firefox">
-    {{ download_firefox(download_location='secondary cta') }}
+    {{ download_firefox(dom_id='win64-bottom-download', download_location='secondary cta') }}
   </div>
 {% endcall %}
 

--- a/media/css/firefox/windows-64-bit.scss
+++ b/media/css/firefox/windows-64-bit.scss
@@ -13,7 +13,7 @@ $image-path: '/media/protocol/img';
     background: #33124e;
     color: #fff;
     text-align: center;
-    height: 500px;
+    min-height: 500px;
     margin-bottom: $spacing-xl;
 
     .hero-content {

--- a/media/css/firefox/windows-64-bit.scss
+++ b/media/css/firefox/windows-64-bit.scss
@@ -13,7 +13,7 @@ $image-path: '/media/protocol/img';
     background: #33124e;
     color: #fff;
     text-align: center;
-    height: 400px;
+    height: 500px;
     margin-bottom: $spacing-xl;
 
     .hero-content {
@@ -21,12 +21,19 @@ $image-path: '/media/protocol/img';
         h1 {
             @include open-sans;
             @include text-display-lg;
-            margin-bottom: $spacing-xl;
+            margin: 0 auto $spacing-2xl;
+            @media #{$mq-lg} {
+                width: 400px;
+            }
         }
 
         p {
             color: #f07274;
             font-weight: bold;
+        }
+
+        img {
+            margin-bottom: $spacing-md;
         }
     }
 }


### PR DESCRIPTION
## Description
Add download button to hero on firefox/windows-64-bit/

## Issue / Bugzilla link
#6892

## Testing
Download button in hero has unique GA data.
No potential l10n issues? (Page is not currently localized, but perhaps in future.)
