### PR TITLE
Fix newsletter layout on /thanks/ for IE (Fixes #6031)

### DIFF
--- a/media/css/firefox/new/scene2.scss
+++ b/media/css/firefox/new/scene2.scss
@@ -151,16 +151,18 @@ $image-path: '/media/protocol/img';
     display: block;
     padding: 0;
 
-    .mzp-c-newsletter-form {
-        padding: 0;
+    legend {
+        color: $color-white;
     }
 
+    .mzp-c-newsletter-form,
     .mzp-c-newsletter-thanks {
         padding: 0;
+        width: 100%;
+    }
 
-        h3 {
-            font-weight: normal;
-        }
+    .mzp-c-newsletter-thanks h3 {
+        font-weight: normal;
     }
 }
 


### PR DESCRIPTION
## Description
- Fixes newsletter layout on /thanks/ in Internet Explorer.
- Also fixes text contrast issue on field legend.

<img width="473" alt="screen shot 2018-08-16 at 10 26 20" src="https://user-images.githubusercontent.com/400117/44200661-0b560b00-a13f-11e8-970c-57a893ea1ca2.png">

## Issue / Bugzilla link
#6031

## Testing
- [ ] Newsletter should now occupy the full width of it's parent container.