### PR TITLE
New heading for old release notes (#6823)

### DIFF
--- a/bedrock/firefox/templates/firefox/releases/aurora-notes.html
+++ b/bedrock/firefox/templates/firefox/releases/aurora-notes.html
@@ -17,3 +17,12 @@
 {% endblock %}
 
 {% set channel_name = 'Aurora' %}
+
+{% block notes_heading_primary %}
+  {# must over ride or last Aurora will be treated as "latest"  #}
+  {% if release.product == 'Firefox for Android' %}
+    <h1>{{ _('Firefox for Android Aurora<br> Release Notes') }}</h1>
+  {% else %}
+    <h1>{{ _('Firefox Aurora Release Notes') }}</h1>
+  {% endif %}
+{% endblock %}

--- a/bedrock/firefox/templates/firefox/releases/dev-browser-notes.html
+++ b/bedrock/firefox/templates/firefox/releases/dev-browser-notes.html
@@ -10,6 +10,11 @@
   <h2>{{ high_res_img('firefox/developer/title-inverse.png', {'alt': _('Firefox Developer Edition'), 'width': '220', 'height': '84'}) }}</h2>
 {% endblock %}
 
+{% block notes_heading_primary %}
+  {# must over ride or last Dev Edition will be treated as "latest"  #}
+  <h1>{{ _('Firefox Developer Edition<br> Release Notes') }}</h1>
+{% endblock %}
+
 {% block notes_heading_secondary %}
   <div class="version">
     <h2>{{ _('{version}')|f(version=release.version) }}</h2>

--- a/bedrock/firefox/templates/firefox/releases/nightly-notes.html
+++ b/bedrock/firefox/templates/firefox/releases/nightly-notes.html
@@ -24,7 +24,11 @@
 {% endblock %}
 
 {% block notes_heading_primary %}
-  <h1>{{ _('See what landed recently in <span>Firefox Nightly</span>!') }}</h1>
+  {% if release.is_latest %}
+    <h1>{{ _('See what landed recently in <span>Firefox Nightly</span>!') }}</h1>
+  {% else %}
+    <h1>{{ _('Firefox Nightly Release Notes') }}</h1>
+  {% endif %}
 {% endblock %}
 
 {% block extra_resources %}

--- a/bedrock/firefox/templates/firefox/releases/notes.html
+++ b/bedrock/firefox/templates/firefox/releases/notes.html
@@ -92,7 +92,12 @@
       <div class="intro">
         <div class="container">
           {% block notes_heading_primary %}
-            <h1>{{ _('See what’s new in Firefox!') }}</h1>
+            {% set product_name = release.product + ' ' + channel_name if channel_name else release.product %}
+            {% if release.is_latest %}
+              <h1>{{ _('See what’s new in %s!')|format(product_name) }}</h1>
+            {% else %}
+              <h1>{{ _('%s<br> Release Notes')|format(product_name) }}</h1>
+            {% endif %}
           {% endblock %}
           <p>
             {% trans

--- a/bedrock/releasenotes/models.py
+++ b/bedrock/releasenotes/models.py
@@ -186,6 +186,10 @@ class ProductRelease(models.Model):
     def version_obj(self):
         return Version(self.version)
 
+    @property
+    def is_latest(self):
+        return self == get_latest_release(self.product, self.channel)
+
     def get_absolute_url(self):
         if self.product == 'Firefox for Android':
             urlname = 'firefox.android.releasenotes'


### PR DESCRIPTION
## Description

Remove the "What's new!" heading from release notes pages for older versions of all products.

## Issue / Bugzilla link
Part of the work for #6823.

## Testing
Here are examples of each type of note:
- Release
  - http://localhost:8000/en-US/firefox/65.0/releasenotes/ 
  - http://localhost:8000/en-US/firefox/35.0/releasenotes/
- ESR
  - http://localhost:8000/en-US/firefox/52.7.1/releasenotes/
- Beta
  - http://localhost:8000/en-US/firefox/66.0beta/releasenotes/
  - http://localhost:8000/en-US/firefox/55.0beta/releasenotes/
- DevEd Fx? 2014 - Fx54 April 2017
  - http://localhost:8000/en-US/firefox/54.0a2/auroranotes/
- Aurora (Fx5 2011)
  - http://localhost:8000/en-US/firefox/32.0a2/auroranotes/
- Nightly
  - http://localhost:8000/en-US/firefox/67.0a1/releasenotes/
  - http://localhost:8000/en-US/firefox/55.0a1/releasenotes/ (bug-id)
- Android
  - http://localhost:8000/en-US/firefox/android/60.0.2/releasenotes/
  - http://localhost:8000/en-US/firefox/android/55.0.2/releasenotes/
- Android Beta
  - http://localhost:8000/en-US/firefox/android/66.0beta/releasenotes/
  - http://localhost:8000/en-US/firefox/android/55.0beta/releasenotes/
- Android Aurora
  - http://localhost:8000/en-US/firefox/android/54.0a2/auroranotes/
- iOS
  - http://localhost:8000/en-US/firefox/ios/10.0/releasenotes/
  - http://localhost:8000/en-US/firefox/ios/3.0/releasenotes/