### PR TITLE
Add product name to download button (#6880)

### DIFF
--- a/bedrock/firefox/templates/firefox/releases/release-notes.html
+++ b/bedrock/firefox/templates/firefox/releases/release-notes.html
@@ -63,9 +63,9 @@
       </a>
     {% elif release.product == 'Firefox for Android' %}
       {% if release.channel in ['Nightly', 'Aurora'] %}
-        {{ download_firefox('nightly', platform='android', alt_copy=_('Download')) }}
+        {{ download_firefox('nightly', platform='android', alt_copy=_('Download Firefox for Android Nightly')) }}
       {% elif release.channel == 'Beta' %}
-        {{ download_firefox('beta', platform='android', alt_copy=_('Download')) }}
+        {{ download_firefox('beta', platform='android', alt_copy=_('Download Firefox for Android Beta')) }}
       {% else %}
         {{ google_play_button() }}
       {% endif %}


### PR DESCRIPTION
## Description

Make it  clear to the user what they are downloading when they click download on the release notes pages.

## Issue / Bugzilla link
Part of the work for #6880.

## Testing
Here are examples of each type of note:
- Android
  - http://localhost:8000/en-US/firefox/android/60.0.2/releasenotes/
- Android Beta
  - http://localhost:8000/en-US/firefox/android/66.0beta/releasenotes/
- Android Aurora
  - http://localhost:8000/en-US/firefox/android/54.0a2/auroranotes/
