### PR TITLE
Add primary CTA for iOS and Android visitors to /accounts page (Fixes #6694)

### DIFF
--- a/bedrock/firefox/templates/firefox/accounts-2018.html
+++ b/bedrock/firefox/templates/firefox/accounts-2018.html
@@ -38,6 +38,13 @@
         <div class="show-fxa-not-fx">
           {{ download_firefox(dom_id='features-hero-download', download_location='primary cta', button_color='mzp-c-button mzp-t-primary mzp-t-product') }}
         </div>
+        <div class="show-fxa-ios">
+          <a class="mzp-c-button mzp-t-secondary" rel="external" href="https://support.mozilla.org/kb/sync-firefox-bookmarks-and-browsing-history-iOS">{{ _('Set up Sync for iOS') }}</a>
+        </div>
+        {# L10n: Line break below for visual formatting only. #}
+        <div class="show-fxa-android">
+          <a class="mzp-c-button mzp-t-secondary" rel="external" href="https://support.mozilla.org/kb/sync-bookmarks-tabs-history-and-passwords-android">{{ _('Set up Sync on your <br>Android device') }}</a>
+        </div>
       </div>
     </div>
   </div>

--- a/media/css/firefox/accounts-2018.scss
+++ b/media/css/firefox/accounts-2018.scss
@@ -265,3 +265,7 @@ html.android {
         display: block;
     }
 }
+
+.show-fxa-android > .mzp-c-button {
+    text-align: center;
+}


### PR DESCRIPTION
## Description
- Adds a primary CTA to the `/firefox/accounts/` page for both Firefox Android and Firefox iOS users:

![accounts-mobile](https://user-images.githubusercontent.com/400117/54814559-ebb03380-4c87-11e9-8ee6-3ca72f3475ed.png)


## Issue / Bugzilla link
#6694

## Testing
- [x] Button should be visible on Firefox for Android and Firefox for iOS.
- [x] Button should not be visible for any other conditions.