### PR TITLE
Release notes nav no longer sticky (#6880)

### DIFF
--- a/media/css/firefox/releasenotes-firefox.less
+++ b/media/css/firefox/releasenotes-firefox.less
@@ -104,18 +104,6 @@ ul.menu {
             cursor: auto;
         }
     }
-
-    &.fixedNav {
-        background-color: #e4e5e5;
-        background-image: none;
-        box-shadow: 0 1px 3px rgba(50, 50, 50, 0.4);
-        position: fixed;
-        margin: 0;
-        top: 0;
-        left: 0;
-        width: 100%;
-        z-index: 200;
-    }
 }
 
 ul.submenu {

--- a/media/js/firefox/releasenotes.js
+++ b/media/js/firefox/releasenotes.js
@@ -4,23 +4,11 @@
 
 /* eslint no-unused-vars: [2, { "varsIgnorePattern": "stickyNav" }] */
 
-(function($, Mozilla, Waypoint) {
+(function($, Mozilla) {
     'use strict';
 
     var client = Mozilla.Client;
     var $html = $('html');
-    var $nav = $('#nav');
-
-    var stickyNav = new Waypoint.Sticky({
-        element: $nav,
-        handler: function(direction) {
-            if (direction === 'down'){
-                $nav.addClass('fixedNav');
-            } else{
-                $nav.removeClass('fixedNav');
-            }
-        }
-    });
 
     // navigation drop-down menu
     function initSubMenu() {
@@ -76,4 +64,4 @@
 
     initSubMenu();
 
-})(window.jQuery, window.Mozilla, window.Waypoint);
+})(window.jQuery, window.Mozilla);

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -1270,8 +1270,6 @@
     },
     {
       "files": [
-        "js/libs/jquery.waypoints.min.js",
-        "js/libs/jquery.waypoints-sticky.min.js",
         "js/firefox/releasenotes.js"
       ],
       "name": "releasenotes"


### PR DESCRIPTION
## Description

Removing sticky menu in preparation for port to Protocol.

## Issue / Bugzilla link

As part of #6880 

## Testing
- Did I remove all files and functions?
- Any JS errors?
http://localhost:8000/en-US/firefox/60.0.2/releasenotes/