### PR TITLE
Redirect /gear to fix #6971

### DIFF
--- a/bedrock/mozorg/redirects.py
+++ b/bedrock/mozorg/redirects.py
@@ -659,4 +659,7 @@ redirectpatterns = (
 
     # issue 6756 - vanity URL
     redirect(r'^decentralization/?$', 'mozorg.internet-health.decentralization'),
+
+    # issue 6971
+    redirect(r'^gear/?$', 'https://mozillagear.corpmerchandise.com/')
 )


### PR DESCRIPTION
## Description

Redirect /gear to https://mozillagear.corpmerchandise.com/
## Issue / Bugzilla link

#6971

## Testing

Visit /gear, verify redirected to https://mozillagear.corpmerchandise.com/
