### PR TITLE
Fix SEM download page display logic (Fixes #6974)

### DIFF
--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -720,14 +720,6 @@ def new(request):
                 template = 'firefox/new/scene1.html'
         elif switch('firefox-yandex') and locale == 'ru':
             template = 'firefox/new/yandex/scene1.html'
-        elif switch('experiment_firefox_new_privacy_dmt') and locale == 'en-US':
-            if experience == 'priv-dmt':
-                if variant in ['a', 'b', 'c', 'd', 'e', 'f']:
-                    template = 'firefox/new/privacy-dmt/scene1-{}.html'.format(variant)
-                else:
-                    template = 'firefox/new/scene1.html'
-            else:
-                template = 'firefox/new/scene1.html'
         elif locale == 'en-US':
             if experience == 'betterbrowser':
                 template = 'firefox/new/better-browser/scene1.html'
@@ -735,6 +727,11 @@ def new(request):
                 template = 'firefox/new/compare/scene1-safari.html'
             elif experience == 'edge':
                 template = 'firefox/new/compare/scene1-edge.html'
+            elif experience == 'priv-dmt' and switch('experiment_firefox_new_privacy_dmt'):
+                if variant in ['a', 'b', 'c', 'd', 'e', 'f']:
+                    template = 'firefox/new/privacy-dmt/scene1-{}.html'.format(variant)
+                else:
+                    template = 'firefox/new/scene1.html'
             else:
                 template = 'firefox/new/scene1.html'
         else:


### PR DESCRIPTION
## Description
Fixes unreachable URLs when the `experiment_firefox_new_privacy_dmt` switch is enabled.

- `/en-US/firefox/new/?xv=betterbrowser`
- `/en-US/firefox/new/?xv=safari`
- `/en-US/firefox/new/?xv=edge`

## Issue / Bugzilla link
#6974

## Testing
- [x] URLs above should load as expected
- [x] Dry-market URLs should still also be reachable.