### PR TITLE
Release notes: move logic into channel templates

### DIFF
--- a/bedrock/firefox/templates/firefox/releases/aurora-notes.html
+++ b/bedrock/firefox/templates/firefox/releases/aurora-notes.html
@@ -4,16 +4,17 @@
 
 {% extends "firefox/releases/notes.html" %}
 
-{% block gtm_page_id %}
-  {% if release.product == 'Firefox for Android' %}
-    data-gtm-page-id="/firefox/android/auroranotes/"
-  {% else %}
-    data-gtm-page-id="/firefox/auroranotes/"
-  {% endif %}
-{% endblock %}
-
-{% block page_css %}
-  {{ css_bundle('firefox_releasenotes_firefox') }}
-{% endblock %}
-
-{% set channel_name = 'Aurora' %}
+{% if release.product == 'Firefox for Android' %}
+  {% set page_id = 'data-gtm-page-id="/firefox/android/auroranotes/"' %}
+  {% set download_button %}
+    {{ download_firefox('nightly', platform='android', alt_copy=_('Download Firefox for Android Nightly')) }}
+  {% endset %}
+  {% set download_all_link = firefox_url('android', 'all', channel='nightly') %}
+{% elif release.product == 'Firefox' %}
+  {% set page_id = 'data-gtm-page-id="/firefox/auroranotes/"' %}
+  {% set download_title = _('Build, test, scale and more with the only browser built just for developers.') %}
+  {% set download_button %}
+    {{ download_firefox('alpha', platform='desktop', force_direct=True, alt_copy=_('Download Firefox Developer Edition')) }}
+  {% endset %}
+  {% set download_all_link = firefox_url('desktop', 'all', channel='alpha') %}
+{% endif %}

--- a/bedrock/firefox/templates/firefox/releases/beta-notes.html
+++ b/bedrock/firefox/templates/firefox/releases/beta-notes.html
@@ -4,12 +4,16 @@
 
 {% extends "firefox/releases/notes.html" %}
 
-{% block gtm_page_id %}
-    {% if release.product == 'Firefox for Android' %}
-        data-gtm-page-id="/firefox/android/beta/releasenotes/"
-    {% else %}
-        data-gtm-page-id="/firefox/beta/releasenotes/"
-    {% endif %}
-{% endblock %}
-
-{% set channel_name = 'Beta' %}
+{% if release.product == 'Firefox for Android' %}
+  {% set page_id = 'data-gtm-page-id="/firefox/android/beta/releasenotes"' %}
+  {% set download_button %}
+    {{ download_firefox('beta', platform='android', alt_copy=_('Download Firefox for Android Beta')) }}
+  {% endset %}
+  {% set download_all_link = firefox_url('android', 'all', channel='beta') %}
+{% elif release.product == 'Firefox' %}
+  {% set page_id = 'data-gtm-page-id="/firefox/beta/releasenotes/"' %}
+  {% set download_button %}
+    {{ download_firefox('beta', platform='desktop', force_direct=True, alt_copy=_('Download Firefox Beta')) }}
+  {% endset %}
+  {% set download_all_link = firefox_url('desktop', 'all', channel='beta') %}
+{% endif %}

--- a/bedrock/firefox/templates/firefox/releases/dev-browser-notes.html
+++ b/bedrock/firefox/templates/firefox/releases/dev-browser-notes.html
@@ -18,9 +18,9 @@
 
 {% block notes_heading_secondary %}
  <div class="version">
-   <h2>{{ _('{version}')|f(version=release.version) }}</h2>
+   <h2>{{ release.version }}</h2>
    <h3>{{ _('Firefox Developer Edition') }}</h3>
-   <p>{{ _('{date}')|f(date=release.release_date|l10n_format_date) }}</p>
+   <p>{{ release.release_date|l10n_format_date }}</p>
  </div>
  <div class="description">
      <h2>{{ _('Version {version}, first offered to Firefox Developer Edition channel users on {date}')|f(channel=release.channel, date=release.release_date|l10n_format_date, version=release.version) }}</h2>

--- a/bedrock/firefox/templates/firefox/releases/dev-browser-notes.html
+++ b/bedrock/firefox/templates/firefox/releases/dev-browser-notes.html
@@ -4,20 +4,26 @@
 
 {% extends "firefox/releases/notes.html" %}
 
-{% block gtm_page_id %}data-gtm-page-id="/firefox/auroranotes/"{% endblock %}
+{% set page_id = 'data-gtm-page-id="/firefox/auroranotes/"' %}
+{% set product_name = 'Firefox Developer Edition' %}
+{% set download_button %}
+ {{ download_firefox('alpha', platform='desktop', force_direct=True, alt_copy=_('Download Firefox Developer Edition')) }}
+{% endset %}
+
+{% set download_all_link = firefox_url('desktop', 'all', channel='alpha') %}
 
 {% block site_header_logo %}
-  <h2>{{ high_res_img('firefox/developer/title-inverse.png', {'alt': _('Firefox Developer Edition'), 'width': '220', 'height': '84'}) }}</h2>
+ <h2>{{ high_res_img('firefox/developer/title-inverse.png', {'alt': _('Firefox Developer Edition'), 'width': '220', 'height': '84'}) }}</h2>
 {% endblock %}
 
 {% block notes_heading_secondary %}
-  <div class="version">
-    <h2>{{ _('{version}')|f(version=release.version) }}</h2>
-    <h3>{{ _('Firefox Developer Edition') }}</h3>
-    <p>{{ _('{date}')|f(date=release.release_date|l10n_format_date) }}</p>
-  </div>
-  <div class="description">
-      <h2>{{ _('Version {version}, first offered to Firefox Developer Edition channel users on {date}')|f(channel=release.channel, date=release.release_date|l10n_format_date, version=release.version) }}</h2>
-      <p>{{ release.text|safe }}</p>
-  </div>
+ <div class="version">
+   <h2>{{ _('{version}')|f(version=release.version) }}</h2>
+   <h3>{{ _('Firefox Developer Edition') }}</h3>
+   <p>{{ _('{date}')|f(date=release.release_date|l10n_format_date) }}</p>
+ </div>
+ <div class="description">
+     <h2>{{ _('Version {version}, first offered to Firefox Developer Edition channel users on {date}')|f(channel=release.channel, date=release.release_date|l10n_format_date, version=release.version) }}</h2>
+     <p>{{ release.text|safe }}</p>
+ </div>
 {% endblock %}

--- a/bedrock/firefox/templates/firefox/releases/esr-notes.html
+++ b/bedrock/firefox/templates/firefox/releases/esr-notes.html
@@ -4,4 +4,10 @@
 
 {% extends "firefox/releases/notes.html" %}
 
-{% block gtm_page_id %}data-gtm-page-id="/firefox/esr/releasenotes/"{% endblock %}
+{% set page_id ='data-gtm-page-id="/firefox/esr/releasenotes/"' %}
+
+{% set download_button %}
+  {{ download_firefox('esr', platform='desktop', force_direct=True, alt_copy=_('Download Firefox ESR')) }}
+{% endset %}
+
+{% set download_all_link = firefox_url('desktop', 'all', channel='organizations') %}

--- a/bedrock/firefox/templates/firefox/releases/nightly-notes.html
+++ b/bedrock/firefox/templates/firefox/releases/nightly-notes.html
@@ -4,7 +4,6 @@
 
 {% extends "firefox/releases/notes.html" %}
 
-{% set channel_name = 'Nightly' %}
 {% set notes_feed = url('firefox.nightly.notes.feed') %}
 {% set blog_feed = 'https://blog.nightly.mozilla.org/feed/' %}
 
@@ -18,14 +17,21 @@
 {% block page_image %}{{ static('img/firefox/nightly/page-image.png') }}{% endblock %}
 
 {% block body_class %}fx-notes space{% endblock %}
+{% set page_id = 'data-gtm-page-id="/firefox/nightly/releasenotes"' %}
+
+{% if release.is_latest %}
+  {% set primary_heading = _('See what landed recently in <span>Firefox Nightly</span>!') %}
+{% endif %}
 
 {% block site_header_logo %}
   <h2>{{ high_res_img('firefox/template/header-logo-nightly.png', {'alt': _('Firefox Nightly'), 'width': '305', 'height': '70'}) }}</h2>
 {% endblock %}
 
-{% block notes_heading_primary %}
-  <h1>{{ _('See what landed recently in <span>Firefox Nightly</span>!') }}</h1>
-{% endblock %}
+{% set download_button %}
+  {{ download_firefox('nightly', platform='desktop', force_direct=True, alt_copy=_('Download Firefox Nightly')) }}
+{% endset %}
+
+{% set download_all_link = firefox_url('desktop', 'all', channel='nightly') %}
 
 {% block extra_resources %}
   <a rel="external" href="https://blog.nightly.mozilla.org/">{{ _('Firefox Nightly News') }}</a>

--- a/bedrock/firefox/templates/firefox/releases/notes.html
+++ b/bedrock/firefox/templates/firefox/releases/notes.html
@@ -140,10 +140,10 @@
         <div class="container">
           {% block notes_heading_secondary %}
           <div class="version">
-            <h2>{{ _('{version}')|f(version=release.version) }}</h2>
+            <h2>{{ release.version }}</h2>
             <h3>{{ release.product }} {{ release.channel }}</h3>
             {% if release.is_public %}
-              <p>{{ _('{date}')|f(date=release.release_date|l10n_format_date) }}</p>
+              <p>{{ release.release_date }}</p>
             {% endif %}
           </div>
           <div class="description">

--- a/bedrock/firefox/templates/firefox/releases/notes.html
+++ b/bedrock/firefox/templates/firefox/releases/notes.html
@@ -2,19 +2,15 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/. #}
 
-{% from "macros.html" import google_play_button with context %}
-
 {% extends "firefox/base-resp.html" %}
 
-{% block gtm_page_id %}
-    {% if release.product == 'Firefox for Android' %}
-        data-gtm-page-id="/firefox/android/releasenotes/"
-    {% elif release.product == 'Firefox for iOS' %}
-        data-gtm-page-id="/firefox/ios/releasenotes/"
-    {% else %}
-        data-gtm-page-id="/firefox/releasenotes/"
-    {% endif %}
-{% endblock %}
+{# page ID for gtm #}
+{# page_id may be over-ridden with more appropriate content #}
+{% set page_id = page_id|default('data-gtm-page-id="/firefox/releasenotes/"') %}
+
+{# product_name is the product and channel together. Example: Firefox for Android Beta. #}
+{# product_name may be over-ridden with more appropriate content to avoid bad names like: Firefox Release Release #}
+{% set product_name = product_name|default(release.product + ' ' + release.channel) %}
 
 {% block page_title_prefix %}{% endblock %}
 {% block page_title %}{{ _('{product} {channel} {version}, See All New Features, Updates and Fixes')|f(product=release.product, channel=channel_name, version=release.version) }}{% endblock %}
@@ -31,8 +27,9 @@
   {% include 'includes/protocol/navigation/index.html' %}
 {% endblock %}
 
-{# channel_name is for display purposes where needed.  #}
-{% set channel_name = channel_name|default('') %}
+{% set channel_name = '' if release.channel == 'Release' else release.channel %}
+
+{% set download_title = download_title|default(_('Get the most recent version')) %}
 
 {% block site_header %}
 <header id="masthead" class="relasenotes-header">
@@ -55,34 +52,6 @@
 </header>
 {% endblock %}
 
-{% set download_button %}
-  <div class="download-buttons">
-    {% if release.product == 'Firefox for iOS' %}
-      <a rel="external" href="{{ firefox_ios_url('mozorg-releasenotes_page-appstore-button') }}" data-link-type="download" data-download-os="iOS">
-        <img src="{{ l10n_img('firefox/ios/btn-app-store.svg') }}" alt="{{ _('Download on the App Store') }}">
-      </a>
-    {% elif release.product == 'Firefox for Android' %}
-      {% if release.channel in ['Nightly', 'Aurora'] %}
-        {{ download_firefox('nightly', platform='android', alt_copy=_('Download Firefox for Android Nightly')) }}
-      {% elif release.channel == 'Beta' %}
-        {{ download_firefox('beta', platform='android', alt_copy=_('Download Firefox for Android Beta')) }}
-      {% else %}
-        {{ google_play_button() }}
-      {% endif %}
-    {% elif release.product == 'Firefox' %}
-      {% if release.channel == 'Nightly' %}
-        {{ download_firefox('nightly', platform='desktop', force_direct=True, alt_copy=_('Download Firefox Nightly')) }}
-      {% elif release.channel == 'Aurora' %}
-        {{ download_firefox('alpha', platform='desktop', force_direct=True, alt_copy=_('Download Firefox Developer Edition')) }}
-      {% elif release.channel == 'Beta' %}
-        {{ download_firefox('beta', platform='desktop', force_direct=True, alt_copy=_('Download Firefox Beta')) }}
-      {% else %}
-        {{ download_firefox() }}
-      {% endif %}
-    {% endif %}
-  </div>
-{% endset %}
-
 {% block content %}
 <main role="main" class="release-notes">
   <article id="main-content">
@@ -91,31 +60,34 @@
     <header class="notes-head">
       <div class="intro">
         <div class="container">
-          {% block notes_heading_primary %}
-            <h1>{{ _('See what’s new in Firefox!') }}</h1>
-          {% endblock %}
+          {% if not primary_heading %}
+            {# L10n: The replacement text will be filled in with a product name. Example:  "Firefox for Android Release Notes" #}
+            {% set primary_heading = _('%s <br> Release Notes')|format(product_name) %}
+          {% endif %}
+          {% if release.product == 'Firefox for Android' %}
+            {% set feedback_url='https://input.mozilla.org/feedback/android/' + release.version + '?utm_source=releasenotes' %}
+          {% else %}
+            {% set feedback_url='https://input.mozilla.org/feedback/firefox/' + release.version + '?utm_source=releasenotes' %}
+          {% endif %}
+          {% set bugzilla_url='https://bugzilla.mozilla.org/' %}
+          <h1>{{ primary_heading }}</h1>
           <p>
-            {% trans
-            feedback='https://input.mozilla.org/feedback/android/' + release.version + '?utm_source=releasenotes'
-            if release.product == 'Firefox for Android'
-            else 'https://input.mozilla.org/feedback/firefox/' + release.version + '?utm_source=releasenotes',
-            bugzilla='https://bugzilla.mozilla.org/'
-            %}
-              Release Notes tell you what’s new in Firefox. As always, we welcome your <a href="{{ feedback }}">feedback</a>. You can also <a href="{{ bugzilla }}">file a bug in Bugzilla</a> or see the <a href="{{ check_url }}">system requirements</a> of this release.
-            {% endtrans %}
+            {{ _('Release Notes tell you what’s new in Firefox. As always, we welcome your <a href="%(feedback)s">feedback</a>. You can also <a href="%(bugzilla)s">file a bug in Bugzilla</a> or see the <a href="%(check)s">system requirements</a> of this release.')|format(feedback=feedback_url, bugzilla=bugzilla_url, check=check_url) }}
           </p>
         </div>
       </div>
 
-    {% block top_download_buttons %}
-      <div class="top-download-buttons">
-        <div class="container">
-          <div class="header-download">
-            {{ download_button }}
+    {% if download_button %}
+      {% block top_download_buttons %}
+        <div class="top-download-buttons">
+          <div class="container">
+            <div class="header-download">
+              {{ download_button }}
+            </div>
           </div>
         </div>
-      </div>
-    {% endblock %}
+      {% endblock %}
+    {% endif %}
 
     {% block platform_switch %}
       <nav id="nav" class="navigator">
@@ -321,25 +293,17 @@
     <section class="notes-footer">
       <div class="container">
         <div class="all-download">
-          <p class="message">{{ _('Download the latest version of Firefox') }}</p>
-          {% if release.product == 'Firefox for Android' %}
-            {% if release.channel in ['Nightly', 'Aurora'] %}
-              <a href="{{ firefox_url('android', 'all', channel='nightly') }}">{{ _('All Firefox Nightly for Android downloads') }}</a>
-            {% else %}
-              <a href="{{ firefox_url('android', 'all', channel=channel_name|lower()) }}">{{ _('All Firefox %s for Android downloads')|format(channel_name) }}</a>
-            {% endif %}
-          {% elif release.product == 'Firefox Extended Support Release' %}
-            <a href="{{ firefox_url('desktop', 'all', channel='organizations') }}">{{ _('All Firefox ESR downloads') }}</a>
-          {% elif release.product == 'Firefox' %}
-            {% if release.channel == 'Aurora' %}
-              <a href="{{ firefox_url('desktop', 'all', channel='alpha') }}">{{ _('All Firefox Developer Edition downloads') }}</a>
-            {% else %}
-              <a href="{{ firefox_url('desktop', 'all', channel=channel_name|lower()) }}">{{ _('All Firefox %s downloads')|format(channel_name) }}</a>
-            {% endif %}
+          <p class="message">{{ download_title }}</p>
+          {% if download_all_link %}
+            <a href="{{ download_all_link }}">{{ _('All %s downloads')|format(product_name) }}</a>
           {% endif %}
         </div>
 
-        {{ download_button }}
+        {% if download_button %}
+          <div class="download-buttons">
+            {{ download_button }}
+          </div>
+        {% endif %}
 
       </div>
     </section>

--- a/bedrock/firefox/templates/firefox/releases/release-notes.html
+++ b/bedrock/firefox/templates/firefox/releases/release-notes.html
@@ -3,3 +3,28 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/. #}
 
 {% extends "firefox/releases/notes.html" %}
+{% from "macros.html" import google_play_button with context %}
+
+{% if release.product == 'Firefox for iOS' %}
+  {% set page_id = 'data-gtm-page-id="/firefox/ios/releasenotes/"' %}
+  {% set product_name = release.product %}
+  {% set download_button %}
+    <a rel="external" href="{{ firefox_ios_url('mozorg-releasenotes_page-appstore-button') }}" data-link-type="download" data-download-os="iOS">
+      <img src="{{ l10n_img('firefox/ios/btn-app-store.svg') }}" alt="{{ _('Download on the App Store') }}">
+    </a>
+  {% endset %}
+{% elif release.product == 'Firefox for Android' %}
+  {% set page_id = 'data-gtm-page-id="/firefox/android/releasenotes/"' %}
+  {% set product_name = 'Firefox for Android' %}
+  {% set download_button %}
+    {{ google_play_button() }}
+  {% endset %}
+  {% set download_all_link = firefox_url('android', 'all', channel=channel_name|lower()) %}
+{% elif release.product == 'Firefox' %}
+  {% set product_name = 'Firefox' %}
+  {% set primary_heading =  _('See what’s new in Firefox!') if release.is_latest else _('Firefox Release Notes') %}
+  {% set download_button %}
+    {{ download_firefox() }}
+  {% endset %}
+  {% set download_all_link = firefox_url('desktop', 'all', channel='release') %}
+{% endif %}

--- a/bedrock/releasenotes/models.py
+++ b/bedrock/releasenotes/models.py
@@ -186,6 +186,10 @@ class ProductRelease(models.Model):
     def version_obj(self):
         return Version(self.version)
 
+    @property
+    def is_latest(self):
+        return self == get_latest_release(self.product, self.channel)
+
     def get_absolute_url(self):
         if self.product == 'Firefox for Android':
             urlname = 'firefox.android.releasenotes'


### PR DESCRIPTION
## Description

- Move product logic into channel templates
  - Set defaults in notes.html based on product details
     - Tried to avoid hard coding values we can get from product details
  - Affected attributes:
    - gtm-page-id
    - Channel name
    - Product name
    - Primary Heading
    - Download title (does not appear to be displayed, but will be in Protocol)
    - Download button
    - Download all link
- Remove `notes_heading_primary` block in favour of `primary_heading` variable
  - to accommodate grouping if/else logic by product
  - default value is now `_('%s <br> Release Notes')|format(product_name)`
    - release and nightly have custom values for the latest version
- Set gtm_page_id using `page_id` variable
  - to accommodate grouping if/else logic by product

## Issue / Bugzilla link

Clean-up work in preparation for #6823

## Testing

Here are examples of each type of note:

- Release
  - http://localhost:8000/en-US/firefox/65.0/releasenotes/ 
  - http://localhost:8000/en-US/firefox/35.0/releasenotes/
- ESR
  - http://localhost:8000/en-US/firefox/52.7.1/releasenotes/
- Beta
  - http://localhost:8000/en-US/firefox/66.0beta/releasenotes/
  - http://localhost:8000/en-US/firefox/55.0beta/releasenotes/
- DevEd Fx? 2014 - Fx54 April 2017
  - http://localhost:8000/en-US/firefox/54.0a2/auroranotes/
- Aurora (Fx5 2011)
  - http://localhost:8000/en-US/firefox/32.0a2/auroranotes/
- Nightly
  - http://localhost:8000/en-US/firefox/67.0a1/releasenotes/
  - http://localhost:8000/en-US/firefox/55.0a1/releasenotes/ (bug-id)
- Android
  - http://localhost:8000/en-US/firefox/android/60.0.2/releasenotes/
  - http://localhost:8000/en-US/firefox/android/55.0.2/releasenotes/
- Android Beta
  - http://localhost:8000/en-US/firefox/android/66.0beta/releasenotes/
  - http://localhost:8000/en-US/firefox/android/55.0beta/releasenotes/
- Android Aurora
  - http://localhost:8000/en-US/firefox/android/54.0a2/auroranotes/
- iOS
  - http://localhost:8000/en-US/firefox/ios/10.0/releasenotes/
  - http://localhost:8000/en-US/firefox/ios/3.0/releasenotes/