### PR TITLE
Add fffy redirect (fixes #6979)

### DIFF
--- a/bedrock/firefox/redirects.py
+++ b/bedrock/firefox/redirects.py
@@ -598,6 +598,9 @@ redirectpatterns = (
     redirect(r'^firefox/features/sync/?', 'firefox.accounts'),
     redirect(r'^firefox/features/send-tabs/?', 'firefox.accounts'),
 
-    # issue 6512
+    # # issue 6512
     redirect(r'^firefox/firefox\.html$', 'firefox.new'),
+
+    # issue 6979
+    redirect(r'^firefoxfightsforyou/?', 'firefox.fights-for-you'),
 )

--- a/bedrock/firefox/redirects.py
+++ b/bedrock/firefox/redirects.py
@@ -598,7 +598,7 @@ redirectpatterns = (
     redirect(r'^firefox/features/sync/?', 'firefox.accounts'),
     redirect(r'^firefox/features/send-tabs/?', 'firefox.accounts'),
 
-    # # issue 6512
+    # issue 6512
     redirect(r'^firefox/firefox\.html$', 'firefox.new'),
 
     # issue 6979

--- a/tests/redirects/map_globalconf.py
+++ b/tests/redirects/map_globalconf.py
@@ -1254,4 +1254,7 @@ URLS = flatten((
     url_test('/foundation/issues/', 'https://foundation.mozilla.org/initiatives/'),
     url_test('/foundation/leadership-network/', 'https://foundation.mozilla.org/'),
     url_test('/foundation/advocacy/', 'https://foundation.mozilla.org/'),
+
+    # Issue 6979
+    url_test('/firefoxfightsforyou/', '/firefox/fights-for-you/'),
 ))


### PR DESCRIPTION
## Description
Redirect /firefoxfightsforyou to /firefox/fights-for-you/

## Issue / Bugzilla link
#6979 
