### PR TITLE
Avoid overwriting AMO referral data in custom stub attribution script (Fixes #7003)

### DIFF
--- a/docs/stub-attribution.rst
+++ b/docs/stub-attribution.rst
@@ -16,6 +16,11 @@ the Windows stub installer, where it finally gets passed to Firefox for use in
 Telemetry. This attribution funnel enables Mozilla to better understand how
 different marketing campaigns effect overall retention in Firefox.
 
+.. Note::
+
+    The `AMO`_ team also relies on Stub Attribution on the /new page to inform
+    their `Return to AMO`_ feature.
+
 How does it work in bedrock?
 ----------------------------
 
@@ -109,9 +114,14 @@ a visitor may have.
 .. Note::
 
     There are some exceptions in the way that the custom attribution script behaves.
-    Existing utm data will not be overwritten if there is already a `utm_content` parameter
-    in the page URL. The custom attribution script will do nothing in this scenario. If
-    any other utm parameters exist on the page URL, those will be passed through to the
-    custom attribution script in favor of any custom values. This is to try and preserve
-    as much existing information as possible, whilst still retaining the `utm_content`
-    value that is essential to attributing an experiment.
+    Existing utm data will not be overwritten if there is already a `utm_content`
+    parameter in the page URL, or if the `utm_source` is from `addons.mozilla.org`.
+    The custom script will follow the regular attribution flow in this scenario and
+    will not modify anything. If any other utm parameters already exist on the page URL,
+    those will be passed through to the custom attribution script and will take
+    precedence over any custom values. This is to try and preserve as much existing
+    information as possible, whilst still retaining the `utm_content` value that is
+    essential to attributing an experiment.
+
+.. _AMO: https://addons.mozilla.org/firefox/
+.. _Return to AMO: https://wiki.mozilla.org/Add-ons/QA/Testplan/Return_to_AMO

--- a/media/js/base/stub-attribution-custom.js
+++ b/media/js/base/stub-attribution-custom.js
@@ -16,8 +16,8 @@
         // preserve any existing utm params.
         var current = new window._SearchParams().utmParams();
 
-        // if there's already a utm_content param then don't modify anything.
-        if (current.utm_content) {
+        // if utm_content exists or utm_source is from AMO then don't modify anything.
+        if (current.utm_content || current.utm_source === 'addons.mozilla.org') {
             return false;
         }
 
@@ -61,6 +61,8 @@
             if (typeof callback === 'function') {
                 callback();
             }
+        } else {
+            Mozilla.StubAttribution.init();
         }
     };
 

--- a/tests/unit/spec/base/stub-attribution-custom.js
+++ b/tests/unit/spec/base/stub-attribution-custom.js
@@ -30,6 +30,30 @@ describe('stub-attribution-custom.js', function () {
             expect(result.utm_content).toEqual('download_thanks_experiment');
         });
 
+        it('should call return false if there is already utm_content', function() {
+            spyOn(window._SearchParams.prototype, 'utmParams').and.returnValue({
+                /* eslint-disable camelcase */
+                utm_content: 'some-other-content'
+                /* eslint-enable camelcase */
+            });
+
+            var result = Mozilla.CustomStubAttribution.setAttributionValues(params);
+            expect(result).toBeFalsy();
+        });
+
+        it('should call return false if utm_source is addons.mozilla.org', function() {
+            spyOn(window._SearchParams.prototype, 'utmParams').and.returnValue({
+                /* eslint-disable camelcase */
+                utm_campaign: 'non-fx-button',
+                utm_medium: 'referral',
+                utm_source: 'addons.mozilla.org'
+                /* eslint-enable camelcase */
+            });
+
+            var result = Mozilla.CustomStubAttribution.setAttributionValues(params);
+            expect(result).toBeFalsy();
+        });
+
         it('should return false if custom attribution data is not fully formed', function() {
             spyOn(window._SearchParams.prototype, 'utmParams').and.returnValue({});
 
@@ -40,17 +64,6 @@ describe('stub-attribution-custom.js', function () {
                 utm_content: 'download_thanks_experiment'
                 /* eslint-enable camelcase */
             };
-
-            var result = Mozilla.CustomStubAttribution.setAttributionValues(params);
-            expect(result).toBeFalsy();
-        });
-
-        it('should return false if there is already utm_content', function() {
-            spyOn(window._SearchParams.prototype, 'utmParams').and.returnValue({
-                /* eslint-disable camelcase */
-                utm_content: 'some-other-content'
-                /* eslint-enable camelcase */
-            });
 
             var result = Mozilla.CustomStubAttribution.setAttributionValues(params);
             expect(result).toBeFalsy();
@@ -100,6 +113,14 @@ describe('stub-attribution-custom.js', function () {
 
             Mozilla.CustomStubAttribution.init(params, options.callback);
             expect(options.callback).toHaveBeenCalled();
+        });
+
+        it('should call regular stub attribution flow if custom data is not satisfied', function() {
+            spyOn(Mozilla.StubAttribution, 'meetsRequirements').and.returnValue(true);
+            spyOn(Mozilla.CustomStubAttribution, 'setAttributionValues').and.returnValue(false);
+            spyOn(Mozilla.StubAttribution, 'init');
+            Mozilla.CustomStubAttribution.init(params);
+            expect(Mozilla.StubAttribution.init).toHaveBeenCalled();
         });
 
     });


### PR DESCRIPTION
## Description
- Avoids overwriting stub attribution data if the referal is from AMO.

## Issue / Bugzilla link
#7003

## Testing
- I've verified this is working as expected locally, and also added tests for the new conditional.