### PR TITLE
Pre-download newsletter experiments on /new (Fixes #6950)

### DIFF
--- a/bedrock/firefox/templates/firefox/new/newsletter/scene1-a.html
+++ b/bedrock/firefox/templates/firefox/new/newsletter/scene1-a.html
@@ -1,0 +1,23 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+
+{% add_lang_files "firefox/new/quantum" %}
+
+{% extends "firefox/new/scene1.html" %}
+
+{% block experiments %}{% endblock %}
+
+{% block extrahead %}
+  {{ super() }}
+{% endblock %}
+
+{% block stub_attribution %}
+  {% if settings.STUB_ATTRIBUTION_RATE %}
+    <!--[if !lte IE 8]><!-->
+    {{ js_bundle('stub-attribution-custom') }}
+    {{ js_bundle('experiment_firefox_new_pre_download_scene1_variation') }}
+    {{ js_bundle('firefox_new_scene1_variation') }}
+    <!--<![endif]-->
+  {% endif %}
+{% endblock %}

--- a/bedrock/firefox/templates/firefox/new/newsletter/scene1-b.html
+++ b/bedrock/firefox/templates/firefox/new/newsletter/scene1-b.html
@@ -1,0 +1,24 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+
+{% add_lang_files "firefox/new/quantum" %}
+
+{% extends "firefox/new/scene1.html" %}
+
+{% block experiments %}{% endblock %}
+
+{% block extrahead %}
+  {{ super() }}
+{% endblock %}
+
+{% block stub_attribution %}
+  {% if settings.STUB_ATTRIBUTION_RATE %}
+    <!--[if !lte IE 8]><!-->
+    {{ js_bundle('stub-attribution-custom') }}
+    {{ js_bundle('experiment_firefox_new_pre_download_scene1_variation') }}
+    {{ js_bundle('firefox_new_scene1_variation') }}
+    <!--<![endif]-->
+  {% endif %}
+{% endblock %}
+

--- a/bedrock/firefox/templates/firefox/new/newsletter/scene1-c.html
+++ b/bedrock/firefox/templates/firefox/new/newsletter/scene1-c.html
@@ -1,0 +1,49 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+
+{% add_lang_files "firefox/new/quantum" %}
+
+{% extends "firefox/new/scene1.html" %}
+
+{% block experiments %}{% endblock %}
+
+{% block extrahead %}
+  {{ super() }}
+  {{ css_bundle('experiment_firefox_new_pre_download_scene1_modal') }}
+{% endblock %}
+
+{# Hide the existing newsletter for this experiment #}
+{% block newsletter_embed %}{% endblock %}
+
+{% block newsletter_modal %}
+<div class="pre-download-newsletter">
+  <div class="pre-download-newsletter-content">
+    <h2 class="pre-download-newsletter-title">Get the most from Firefox</h2>
+    <p class="pre-download-newsletter-desc">Sign up to get fresh tips and product announcements.</p>
+    {{ email_newsletter_form(
+        include_title=False,
+        spinner_color='#000',
+        email_label='Enter your email address',
+        email_placeholder='yourname@example.com',
+        submit_text='Download Firefox and Sign Up'
+    )}}
+    <p class="pre-download-privacy">
+      <a href="{{ url('privacy.email') }}" target="_blank" rel="noopener noreferer">How will Mozilla use my email?</a>
+    </p>
+    <p class="pre-download-continue">
+      <a class="button button-hollow" href="{{ url('firefox.download.thanks') }}?xv=pre-dl&v=c&n=f" data-link-name="No Thanks — Just Download Firefox" data-link-type="link">No Thanks — Just Download Firefox</a>
+    </p>
+  </div>
+</div>
+{% endblock %}
+
+{% block stub_attribution %}
+  {% if settings.STUB_ATTRIBUTION_RATE %}
+    <!--[if !lte IE 8]><!-->
+    {{ js_bundle('stub-attribution-custom') }}
+    {{ js_bundle('experiment_firefox_new_pre_download_scene1_modal') }}
+    {{ js_bundle('experiment_firefox_new_pre_download_scene1_variation') }}
+    <!--<![endif]-->
+  {% endif %}
+{% endblock %}

--- a/bedrock/firefox/templates/firefox/new/newsletter/scene1-d.html
+++ b/bedrock/firefox/templates/firefox/new/newsletter/scene1-d.html
@@ -1,0 +1,24 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+
+{% add_lang_files "firefox/new/quantum" %}
+
+{% extends "firefox/new/scene1.html" %}
+
+{% block experiments %}{% endblock %}
+
+{% block extrahead %}
+  {{ super() }}
+{% endblock %}
+
+{% block stub_attribution %}
+  {% if settings.STUB_ATTRIBUTION_RATE %}
+    <!--[if !lte IE 8]><!-->
+    {{ js_bundle('stub-attribution-custom') }}
+    {{ js_bundle('experiment_firefox_new_pre_download_scene1_variation') }}
+    {{ js_bundle('firefox_new_scene1_variation') }}
+    <!--<![endif]-->
+  {% endif %}
+{% endblock %}
+

--- a/bedrock/firefox/templates/firefox/new/newsletter/scene1-e.html
+++ b/bedrock/firefox/templates/firefox/new/newsletter/scene1-e.html
@@ -1,0 +1,66 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+
+{% add_lang_files "firefox/new/quantum" %}
+
+{% extends "firefox/new/scene1.html" %}
+
+{% block experiments %}{% endblock %}
+
+{% block extrahead %}
+  {{ super() }}
+  {{ css_bundle('experiment_firefox_new_pre_download_scene1_embed') }}
+{% endblock %}
+
+{# Hide the existing newsletter for this experiment #}
+{% block newsletter_embed %}{% endblock %}
+
+{% block main_title %}
+<header>
+  <h1>Download Firefox</h1>
+</header>
+{% endblock %}
+
+{% block main_cta %}
+<div class="pre-download-newsletter">
+  <div class="pre-download-newsletter-content">
+    <p class="pre-download-newsletter-desc">Sign up to get speed and data privacy tips, too.</p>
+    {{ email_newsletter_form(
+        include_title=False,
+        spinner_color='#fff',
+        email_label='Enter your email address',
+        email_placeholder='yourname@example.com',
+        submit_text='Download Firefox and Sign Up'
+    )}}
+  </div>
+</div>
+
+<div class="download-button-wrapper">
+  {# **WARNING**
+
+    The `locale_in_transition` parameter should be used very carefully. It's included
+    here because this template and scene2 share a lang file, and are therefore
+    translated into the same list of locales. Adding this to another download button
+    would significantly restrict the builds of Firefox available for download.
+
+    Bug 1290962
+  #}
+  {{ download_firefox(alt_copy='No Thanks — Just Download Firefox', locale_in_transition=True, download_location='primary cta') }}
+</div>
+{% endblock %}
+
+{% block small_link %}
+<li><a href="{{ url('privacy.email') }}">How will Mozilla use my email?</a></li>
+{% endblock %}
+
+{% block stub_attribution %}
+  {% if settings.STUB_ATTRIBUTION_RATE %}
+    <!--[if !lte IE 8]><!-->
+    {{ js_bundle('stub-attribution-custom') }}
+    {{ js_bundle('experiment_firefox_new_pre_download_scene1_embed') }}
+    {{ js_bundle('experiment_firefox_new_pre_download_scene1_variation') }}
+    {{ js_bundle('firefox_new_scene1_variation') }}
+    <!--<![endif]-->
+  {% endif %}
+{% endblock %}

--- a/bedrock/firefox/templates/firefox/new/newsletter/scene2-a.html
+++ b/bedrock/firefox/templates/firefox/new/newsletter/scene2-a.html
@@ -1,0 +1,10 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+
+{% add_lang_files "firefox/new/quantum" %}
+
+{% extends "firefox/new/scene2.html" %}
+
+{% block experiments %}{% endblock %}
+

--- a/bedrock/firefox/templates/firefox/new/newsletter/scene2-b.html
+++ b/bedrock/firefox/templates/firefox/new/newsletter/scene2-b.html
@@ -1,0 +1,62 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+
+{% add_lang_files "firefox/new/quantum" %}
+
+{% extends "firefox/new/scene2.html" %}
+
+{% block experiments %}{% endblock %}
+
+{% block extrahead %}
+  {{ super() }}
+  {{ css_bundle('experiment_firefox_new_pre_download_scene2_centered') }}
+{% endblock %}
+
+{% block theme %}{% endblock %}
+
+{% block headline %}Get the most from Firefox{% endblock %}
+
+{% block tagline %}
+  <p class="tagline">Get tips on speed, data privacy and more delivered to your inbox. We won’t share your email, even inside the company.</p>
+{% endblock %}
+
+{% block newsletter %}
+<div class="mzp-c-newsletter">
+  {{ email_newsletter_form(
+    protocol_component=True,
+    include_title=False,
+    email_label='Enter your email address',
+    button_class='mzp-t-product',
+    details='<a href="%s" class="email-privacy-link">%s</a>'|format(url('privacy.email'), 'How will Mozilla use my email?')|safe
+  )}}
+</div>
+{% endblock %}
+
+{% block additional_content %}
+<aside class="mobile-download hidden">
+  <h1 class="headline">Let’s do this!</h1>
+  <p class="tagline">Sync up with Firefox on mobile:</p>
+  <ul>
+    <li>
+      {{ google_play_button(extra_data_attributes={'download-location': 'other'}) }}
+    </li>
+    <li>
+      <a href="{{ firefox_ios_url('mozorg-scene_2-appstore-button') }}" data-link-type="download" data-download-os="iOS" data-download-location="other">
+        <img src="{{ l10n_img('firefox/ios/btn-app-store.svg') }}" alt="{{ _('Download on the App Store') }}" width="152" height="45">
+      </a>
+    </li>
+  </ul>
+</aside>
+{% endblock %}
+
+{% block js %}
+  {% if switch('tracking-pixel') %}
+    {{ js_bundle('firefox_new_pixel') }}
+  {% endif %}
+  {{ js_bundle('firefox_new_scene2_email') }}
+  {{ js_bundle('experiment_firefox_new_pre_download_scene2_centered') }}
+  {# Keep download JS in a separate bundle to email JS, to reduce risk of errors interrupting download. #}
+  {{ js_bundle('firefox_new_scene2') }}
+{% endblock %}
+

--- a/bedrock/firefox/templates/firefox/new/newsletter/scene2-c.html
+++ b/bedrock/firefox/templates/firefox/new/newsletter/scene2-c.html
@@ -1,0 +1,43 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+
+{% add_lang_files "firefox/new/quantum" %}
+
+{% extends "firefox/new/scene2.html" %}
+
+{% block experiments %}{% endblock %}
+
+{% block main_content %}
+  {% if signup %}
+    <h1 class="headline">Thanks!</h1>
+    <p class="tagline">
+      If you haven’t previously confirmed a subscription to a Mozilla-related
+      newsletter you may have to do so. Please check your inbox or your spam filter
+      for an email from us.
+    </p>
+  {% else %}
+    <aside class="mobile-download">
+      <h1 class="headline">Let’s do this!</h1>
+      <p class="tagline">Sync up with Firefox on mobile:</p>
+      <ul>
+        <li>
+          {{ google_play_button(extra_data_attributes={'download-location': 'other'}) }}
+        </li>
+        <li>
+          <a href="{{ firefox_ios_url('mozorg-scene_2-appstore-button') }}" data-link-type="download" data-download-os="iOS" data-download-location="other">
+            <img src="{{ l10n_img('firefox/ios/btn-app-store.svg') }}" alt="{{ _('Download on the App Store') }}" width="152" height="45">
+          </a>
+        </li>
+      </ul>
+    </aside>
+  {% endif %}
+{% endblock %}
+
+{% block js %}
+  {% if switch('tracking-pixel') %}
+    {{ js_bundle('firefox_new_pixel') }}
+  {% endif %}
+  {{ js_bundle('firefox_new_scene2') }}
+{% endblock %}
+

--- a/bedrock/firefox/templates/firefox/new/newsletter/scene2-d.html
+++ b/bedrock/firefox/templates/firefox/new/newsletter/scene2-d.html
@@ -1,0 +1,79 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+
+{% add_lang_files "firefox/new/quantum" %}
+
+{% extends "firefox/new/scene2.html" %}
+
+{% block experiments %}{% endblock %}
+
+{% block extrahead %}
+  {{ super() }}
+  {{ css_bundle('experiment_firefox_new_pre_download_scene2_centered') }}
+{% endblock %}
+
+{% block theme %}{% endblock %}
+
+{% block download_status %}{% endblock %}
+
+{% block headline %}Get the most from Firefox{% endblock %}
+
+{% block tagline %}<p class="tagline">Get fresh tips and product announcements delivered to your inbox.</p>{% endblock %}
+
+{% block newsletter %}
+<div class="mzp-c-newsletter">
+  {{ email_newsletter_form(
+    protocol_component=True,
+    include_title=False,
+    spinner_color='#000',
+    email_label='Enter your email address',
+    email_placeholder='yourname@example.com',
+    submit_text='Download Firefox and Sign Up',
+    button_class='mzp-t-product',
+    details='<a href="%s" class="email-privacy-link">%s</a>'|format(url('privacy.email'), 'How will Mozilla use my email?')|safe
+  )}}
+  <a id="continue-download-direct" class="mzp-c-button mzp-t-product mzp-t-secondary continue-download-direct" href="{{ url('firefox.all') }}" data-link-name="No Thanks — Just Download Firefox" data-link-type="link">No Thanks — Just Download Firefox</a>
+</div>
+{% endblock %}
+
+{% block additional_content %}
+<div class="thank-you-download hidden">
+  <h3>Thanks!</h3>
+  {# fallback_url is replaced by the platform download link via JS, but if
+    something fails the user should still get a link to a working download path. #}
+
+  <p>Your download should begin automatically. Didn’t work? <a id="direct-download-link" href="{{ url('firefox.all') }}">Try downloading again</a>.</p>
+
+  <aside class="newsletter-download">
+    <p>
+      If you haven’t previously confirmed a subscription to a Mozilla-related
+      newsletter you may have to do so. Please check your inbox or your spam filter
+      for an email from us.
+    </p>
+  </aside>
+
+  <aside class="mobile-download">
+    <p>Sync up with Firefox on mobile:</p>
+    <ul>
+      <li>
+        {{ google_play_button(extra_data_attributes={'download-location': 'other'}) }}
+      </li>
+      <li>
+        <a href="{{ firefox_ios_url('mozorg-scene_2-appstore-button') }}" data-link-type="download" data-download-os="iOS" data-download-location="other">
+          <img src="{{ l10n_img('firefox/ios/btn-app-store.svg') }}" alt="{{ _('Download on the App Store') }}" width="152" height="45">
+        </a>
+      </li>
+    </ul>
+  </aside>
+</div>
+{% endblock %}
+
+{% block js %}
+  {% if switch('tracking-pixel') %}
+    {{ js_bundle('firefox_new_pixel') }}
+  {% endif %}
+  {{ js_bundle('firefox_new_scene2_email') }}
+  {{ js_bundle('experiment_firefox_new_pre_download_scene2_embed') }}
+{% endblock %}
+

--- a/bedrock/firefox/templates/firefox/new/newsletter/scene2-e.html
+++ b/bedrock/firefox/templates/firefox/new/newsletter/scene2-e.html
@@ -1,0 +1,43 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+
+{% add_lang_files "firefox/new/quantum" %}
+
+{% extends "firefox/new/scene2.html" %}
+
+{% block experiments %}{% endblock %}
+
+{% block main_content %}
+  {% if signup %}
+    <h1 class="headline">Thanks!</h1>
+    <p class="tagline">
+      If you haven’t previously confirmed a subscription to a Mozilla-related
+      newsletter you may have to do so. Please check your inbox or your spam filter
+      for an email from us.
+    </p>
+  {% else %}
+    <aside class="mobile-download">
+      <h1 class="headline">Let’s do this!</h1>
+      <p class="tagline">Sync up with Firefox on mobile:</p>
+      <ul>
+        <li>
+          {{ google_play_button(extra_data_attributes={'download-location': 'other'}) }}
+        </li>
+        <li>
+          <a href="{{ firefox_ios_url('mozorg-scene_2-appstore-button') }}" data-link-type="download" data-download-os="iOS" data-download-location="other">
+            <img src="{{ l10n_img('firefox/ios/btn-app-store.svg') }}" alt="{{ _('Download on the App Store') }}" width="152" height="45">
+          </a>
+        </li>
+      </ul>
+    </aside>
+  {% endif %}
+{% endblock %}
+
+{% block js %}
+  {% if switch('tracking-pixel') %}
+    {{ js_bundle('firefox_new_pixel') }}
+  {% endif %}
+  {{ js_bundle('firefox_new_scene2') }}
+{% endblock %}
+

--- a/bedrock/firefox/templates/firefox/new/scene1.html
+++ b/bedrock/firefox/templates/firefox/new/scene1.html
@@ -15,6 +15,9 @@
 {% endblock %}
 
 {% block experiments %}
+  {% if switch('experiment_firefox_new_pre_download', ['en-US']) %}
+    {{ js_bundle('experiment_firefox_new_pre_download') }}
+  {% endif %}
   {% if switch('experiment_firefox_new_features', ['en-GB', 'de']) %}
     {{ js_bundle('experiment_firefox_new_features') }}
   {% endif %}
@@ -44,6 +47,7 @@
 {% block main_content %}
 <div class="main-download" {% if v %}data-variant="{{ v }}"{% endif %}>
   <div class="main-cta-wrapper">
+  {% block main_cta %}
     <div class="download-button-wrapper">
       {# **WARNING**
 
@@ -56,6 +60,7 @@
       #}
       {{ download_firefox(alt_copy=_('Download Now'), locale_in_transition=True, download_location='primary cta') }}
     </div>
+  {% endblock %}
   </div>
 
   <p class="linux-arm-download-instructions">
@@ -63,6 +68,7 @@
   </p>
 
   <ul id="other-platforms-languages-wrapper" class="small-links desktop hidden">
+    {% block small_link %}{% endblock %}
     <li><button id="other-platforms-modal-link" type="button">{{_('Advanced install options & other platforms') }}</button></li>
     <li><a href="{{ url('firefox.all') }}">{{_('Download in another language') }}</a></li>
   {% if l10n_has_tag('fxnew_account_032019') %}
@@ -108,18 +114,20 @@
 {% endblock %}
 
 {% block additional_content %}
-<aside class="newsletter-container">
-  <div class="content">
-    <div id="newsletter-subscribe">
-      <div class="newsletter-title">
-          <h3>{{ _('Keep up with<br> all things Firefox.') }}</h3>
-      </div>
-      <div class="newsletter-form-content">
-        {{ email_newsletter_form(include_title=False, button_class='button button-hollow', spinner_color='#fff') }}
+{% block newsletter_embed %}
+  <aside class="newsletter-container">
+    <div class="content">
+      <div id="newsletter-subscribe">
+        <div class="newsletter-title">
+            <h3>{{ _('Keep up with<br> all things Firefox.') }}</h3>
+        </div>
+        <div class="newsletter-form-content">
+          {{ email_newsletter_form(include_title=False, button_class='button button-hollow', spinner_color='#fff') }}
+        </div>
       </div>
     </div>
-  </div>
-</aside>
+  </aside>
+{% endblock %}
 
 <div id="other-platforms">
   <div class="content">
@@ -164,6 +172,8 @@
   {{ download_firefox(dom_id='download-fxa-modal', alt_copy=_('Download Anyway'), button_color='button-hollow button-blue', locale_in_transition=True, download_location='other') }}
 </div>
 {% endif %}
+
+{% block newsletter_modal %}{% endblock %}
 
 {% include 'firefox/includes/schemaorg-app.html' %}
 {% endblock %}

--- a/bedrock/firefox/templates/firefox/new/scene2.html
+++ b/bedrock/firefox/templates/firefox/new/scene2.html
@@ -52,11 +52,12 @@
 {% endif %}
 
 {% block content %}
-<main class="main mzp-t-firefox mzp-t-dark">
+<main class="main mzp-t-firefox {% block theme %}mzp-t-dark{% endblock %}">
   <section class="status">
     <div class="mzp-l-content mzp-t-firefox windows-xpvista">
       <p>{{ _('You’re using an insecure, outdated operating system <a href="%(url)s">no longer supported by Firefox</a>.')|format(url='https://support.mozilla.org/kb/end-support-windows-xp-and-vista') }}</p>
     </div>
+    {% block download_status %}
     <div class="mzp-l-content mzp-t-firefox">
       {# fallback_url is replaced by the platform download link via JS, but if
         something fails the user should still get a link to a working download path. #}
@@ -74,6 +75,7 @@
         {% endif %}
       </p>
     </div>
+    {% endblock %}
   </section>
 
   <div class="mzp-l-content">
@@ -87,70 +89,69 @@
         {{ download_firefox(force_direct=true, dom_id='primary-download-button') }}
       </div>
 
-      {% if show_newsletter and l10n_has_tag('download_thanks_newsletter_092018') %}
-
-      <h1 class="headline">
-      {% block headline %}
-        {{ _('Learn how to make Firefox even smarter, faster and more secure.') }}
-      {% endblock %}
-      </h1>
-      {% block tagline %}
-      <p class="tagline">{{ _('Get informative tips, tricks and product announcements delivered to your inbox.') }}</p>
-      {% endblock %}
-
-      <div class="mzp-c-newsletter">
-        {{ email_newsletter_form(
-              protocol_component=True,
-              include_title=False,
-              email_label=_('Enter your email address'),
-              details='<a href="%s" class="email-privacy-link">%s</a>'|format(url('privacy.email'), _('How will Mozilla use my email?'))|safe
-        )}}
-      </div>
-
-      {% block additional_content %}{% endblock %}
-
-      <aside class="email-privacy mzp-u-modal-content">
-        <h3>{{ _('How will Mozilla use my email?') }}</h3>
-
-        <p>
-        {% trans
-              manifesto=url('mozorg.about.manifesto'),
-              principles=url('privacy.principles')
-        %}
-          Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="{{ manifesto }}">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="{{ principles }}">You can learn about our Data Privacy Principles here</a>.
-        {% endtrans %}
-        </p>
-
-        <p><strong>{{ _('What we want you to know:') }}</strong></p>
-
-        <ul class="prose mzp-u-list-styled">
-          <li>{{ _('You don’t need to give us your email to download and use Firefox.') }}</li>
-          <li>{{ _('We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.') }}</li>
-          <li>{{ _('You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.') }}</li>
-          <li>{{ _('You can unsubscribe anytime, for any reason.') }}</li>
-          <li>{{ _('We will not share, sell or use your email for any other purposes.') }}</li>
-        </ul>
-      </aside>
-
-      {% else %}
       {% block main_content %}
-      <aside class="mobile-download">
-        <h1 class="headline">{{ _('Let’s do this!') }}</h1>
-        <p class="tagline">{{ _('Sync up with Firefox on mobile:') }}</p>
-        <ul>
-          <li>
-            {{ google_play_button(extra_data_attributes={'download-location': 'other'}) }}
-          </li>
-          <li>
-            <a href="{{ firefox_ios_url('mozorg-scene_2-appstore-button') }}" data-link-type="download" data-download-os="iOS" data-download-location="other">
-              <img src="{{ l10n_img('firefox/ios/btn-app-store.svg') }}" alt="{{ _('Download on the App Store') }}" width="152" height="45">
-            </a>
-          </li>
-        </ul>
-      </aside>
-      {% endblock %}
+        {% if show_newsletter and l10n_has_tag('download_thanks_newsletter_092018') %}
+          <h1 class="headline">
+          {% block headline %}
+            {{ _('Learn how to make Firefox even smarter, faster and more secure.') }}
+          {% endblock %}
+          </h1>
+          {% block tagline %}
+          <p class="tagline">{{ _('Get informative tips, tricks and product announcements delivered to your inbox.') }}</p>
+          {% endblock %}
 
-      {% endif %}
+          {% block newsletter %}
+          <div class="mzp-c-newsletter">
+            {{ email_newsletter_form(
+                  protocol_component=True,
+                  include_title=False,
+                  email_label=_('Enter your email address'),
+                  details='<a href="%s" class="email-privacy-link">%s</a>'|format(url('privacy.email'), _('How will Mozilla use my email?'))|safe
+            )}}
+          </div>
+          {% endblock %}
+
+          {% block additional_content %}{% endblock %}
+
+          <aside class="email-privacy mzp-u-modal-content">
+            <h3>{{ _('How will Mozilla use my email?') }}</h3>
+
+            <p>
+            {% trans
+                  manifesto=url('mozorg.about.manifesto'),
+                  principles=url('privacy.principles')
+            %}
+              Mozilla doesn’t just value your email privacy and security – it’s part of our <a href="{{ manifesto }}">Manifesto</a>: “Individuals’ security and privacy on the internet are fundamental and must not be treated as optional.” <a href="{{ principles }}">You can learn about our Data Privacy Principles here</a>.
+            {% endtrans %}
+            </p>
+
+            <p><strong>{{ _('What we want you to know:') }}</strong></p>
+
+            <ul class="prose mzp-u-list-styled">
+              <li>{{ _('You don’t need to give us your email to download and use Firefox.') }}</li>
+              <li>{{ _('We asked for your email because our research shows that people who receive an introductory experience do more and better with Firefox.') }}</li>
+              <li>{{ _('You can expect emails designed to help you optimize Firefox to work best for you, learn more about privacy & security and find out how to make the best of your time on the web.') }}</li>
+              <li>{{ _('You can unsubscribe anytime, for any reason.') }}</li>
+              <li>{{ _('We will not share, sell or use your email for any other purposes.') }}</li>
+            </ul>
+          </aside>
+        {% else %}
+          <aside class="mobile-download">
+            <h1 class="headline">{{ _('Let’s do this!') }}</h1>
+            <p class="tagline">{{ _('Sync up with Firefox on mobile:') }}</p>
+            <ul>
+              <li>
+                {{ google_play_button(extra_data_attributes={'download-location': 'other'}) }}
+              </li>
+              <li>
+                <a href="{{ firefox_ios_url('mozorg-scene_2-appstore-button') }}" data-link-type="download" data-download-os="iOS" data-download-location="other">
+                  <img src="{{ l10n_img('firefox/ios/btn-app-store.svg') }}" alt="{{ _('Download on the App Store') }}" width="152" height="45">
+                </a>
+              </li>
+            </ul>
+          </aside>
+        {% endif %}
+      {% endblock %}
     </div>
   </div>
 </main>

--- a/bedrock/firefox/tests/test_views.py
+++ b/bedrock/firefox/tests/test_views.py
@@ -787,6 +787,68 @@ class TestFirefoxNew(TestCase):
         views.new(req)
         render_mock.assert_called_once_with(req, 'firefox/new/features/index.de-c.html', ANY)
 
+    # pre-download test - issue 6935
+
+    def test_pre_download_scene_1_a(self, render_mock):
+        req = RequestFactory().get('/firefox/new/?xv=pre-dl&v=a')
+        req.locale = 'en-US'
+        views.new(req)
+        render_mock.assert_called_once_with(req, 'firefox/new/newsletter/scene1-a.html', ANY)
+
+    def test_pre_download_scene_1_b(self, render_mock):
+        req = RequestFactory().get('/firefox/new/?xv=pre-dl&v=b')
+        req.locale = 'en-US'
+        views.new(req)
+        render_mock.assert_called_once_with(req, 'firefox/new/newsletter/scene1-b.html', ANY)
+
+    def test_pre_download_scene_1_c(self, render_mock):
+        req = RequestFactory().get('/firefox/new/?xv=pre-dl&v=c')
+        req.locale = 'en-US'
+        views.new(req)
+        render_mock.assert_called_once_with(req, 'firefox/new/newsletter/scene1-c.html', ANY)
+
+    def test_pre_download_scene_1_d(self, render_mock):
+        req = RequestFactory().get('/firefox/new/?xv=pre-dl&v=d')
+        req.locale = 'en-US'
+        views.new(req)
+        render_mock.assert_called_once_with(req, 'firefox/new/newsletter/scene1-d.html', ANY)
+
+    def test_pre_download_scene_1_e(self, render_mock):
+        req = RequestFactory().get('/firefox/new/?xv=pre-dl&v=e')
+        req.locale = 'en-US'
+        views.new(req)
+        render_mock.assert_called_once_with(req, 'firefox/new/newsletter/scene1-e.html', ANY)
+
+    def test_pre_download_scene_2_a(self, render_mock):
+        req = RequestFactory().get('/firefox/download/thanks/?xv=pre-dl&v=a')
+        req.locale = 'en-US'
+        views.download_thanks(req)
+        render_mock.assert_called_once_with(req, 'firefox/new/newsletter/scene2-a.html', ANY)
+
+    def test_pre_download_scene_2_b(self, render_mock):
+        req = RequestFactory().get('/firefox/download/thanks/?xv=pre-dl&v=b')
+        req.locale = 'en-US'
+        views.download_thanks(req)
+        render_mock.assert_called_once_with(req, 'firefox/new/newsletter/scene2-b.html', ANY)
+
+    def test_pre_download_scene_2_c(self, render_mock):
+        req = RequestFactory().get('/firefox/download/thanks/?xv=pre-dl&v=c')
+        req.locale = 'en-US'
+        views.download_thanks(req)
+        render_mock.assert_called_once_with(req, 'firefox/new/newsletter/scene2-c.html', ANY)
+
+    def test_pre_download_scene_2_d(self, render_mock):
+        req = RequestFactory().get('/firefox/download/thanks/?xv=pre-dl&v=d')
+        req.locale = 'en-US'
+        views.download_thanks(req)
+        render_mock.assert_called_once_with(req, 'firefox/new/newsletter/scene2-d.html', ANY)
+
+    def test_pre_download_scene_2_e(self, render_mock):
+        req = RequestFactory().get('/firefox/download/thanks/?xv=pre-dl&v=e')
+        req.locale = 'en-US'
+        views.download_thanks(req)
+        render_mock.assert_called_once_with(req, 'firefox/new/newsletter/scene2-e.html', ANY)
+
 
 class TestFirefoxNewNoIndex(TestCase):
     def test_scene_1_noindex(self):

--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -543,12 +543,17 @@ def download_thanks(request):
     experience = request.GET.get('xv', None)
     locale = l10n_utils.get_locale(request)
     variant = request.GET.get('v', None)
+    signup = request.GET.get('s', None)
     newsletter = request.GET.get('n', None)
     show_newsletter = locale in ['en-US', 'en-GB', 'en-CA', 'en-ZA', 'es-ES', 'es-AR', 'es-CL', 'es-MX', 'pt-BR', 'fr', 'ru', 'id', 'de', 'pl']
 
     # ensure variant matches pre-defined value
-    if variant not in []:  # place expected ?v= values in this list
+    if variant not in ['a', 'b', 'c', 'd', 'e']:  # place expected ?v= values in this list
         variant = None
+
+    # did someone sign up for the newsletter on scene 1?
+    if signup != 't':
+        signup = None
 
     # check to see if a URL explicitly asks to hide the newsletter
     if newsletter == 'f':
@@ -572,12 +577,17 @@ def download_thanks(request):
     elif locale == 'en-US':
         if experience == 'betterbrowser':
             template = 'firefox/campaign/better-browser/scene2.html'
+        elif experience == 'pre-dl':
+            if variant in ['a', 'b', 'c', 'd', 'e']:
+                template = 'firefox/new/newsletter/scene2-{}.html'.format(variant)
+            else:
+                template = 'firefox/new/scene2.html'
         else:
             template = 'firefox/new/scene2.html'
     else:
         template = 'firefox/new/scene2.html'
 
-    return l10n_utils.render(request, template, {'show_newsletter': show_newsletter})
+    return l10n_utils.render(request, template, {'show_newsletter': show_newsletter, 'signup': signup})
 
 
 def new(request):
@@ -595,7 +605,7 @@ def new(request):
 
     # ensure variant matches pre-defined value
 
-    if variant not in ['a', 'b', 'c', 'd', 'e', 'f']:  # place expected ?v= values in this list
+    if variant not in ['a', 'b', 'c', 'd', 'e']:  # place expected ?v= values in this list
         variant = None
 
     if scene == '2':
@@ -638,6 +648,11 @@ def new(request):
                 template = 'firefox/campaign/compare/scene1-safari.html'
             elif experience == 'edge':
                 template = 'firefox/campaign/compare/scene1-edge.html'
+            elif experience == 'pre-dl':
+                if variant in ['a', 'b', 'c', 'd', 'e']:
+                    template = 'firefox/new/newsletter/scene1-{}.html'.format(variant)
+                else:
+                    template = 'firefox/new/scene1.html'
             else:
                 template = 'firefox/new/scene1.html'
         else:

--- a/media/css/firefox/new/newsletter/scene1-embed.scss
+++ b/media/css/firefox/new/newsletter/scene1-embed.scss
@@ -1,0 +1,124 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+@import '../../../pebbles/includes/lib';
+
+.main-content {
+    .header-image {
+        top: 0;
+        bottom: auto;
+    }
+
+    .pre-download-newsletter {
+        margin: 0 auto;
+        max-width: 350px;
+
+        .newsletter-form {
+            position: relative;
+        }
+
+        .field-email label {
+            font-weight: bold;
+            margin-bottom: 6px;
+            display: block;
+        }
+
+        #form-details {
+            margin-top: 20px;
+        }
+
+        input[type="email"] {
+            border-color: #fff;
+            border-radius: 2px;
+            padding: 12px 8px;
+            width: 100%;
+        }
+
+        button[type="submit"] {
+            background-color: #16da00;
+            border-color: #16da00;
+            margin-top: 50px;
+            color: #fff;
+
+            &:hover,
+            &:focus {
+                background-color: #13c100;
+                border-color: #13c100;
+                color: #fff;
+
+            }
+        }
+
+        .field {
+            margin-bottom: 10px;
+        }
+
+        select {
+            width: 100%;
+        }
+
+        .form-contents {
+            @include font-size(14px);
+
+            a:link,
+            a:visited {
+                color: #fff;
+            }
+
+            a:hover,
+            a:active,
+            a:focus {
+                text-decoration: none;
+            }
+        }
+
+        .form-details {
+            /* we're already showing the privacy link in page, so hide the default blurb that is shown via JS. */
+            display: none !important; /* stylelint-disable-line declaration-no-important */
+        }
+
+        .errorlist {
+            @include font-size(14px);
+            background: #fff;
+            color: $color-mozred;
+            padding: 0 4px;
+        }
+    }
+
+    .download-button-wrapper {
+        margin: 20px auto 0;
+        width: 100%;
+        max-width: 350px;
+
+        .download-button {
+            width: 100%;
+        }
+
+        .download-link.button.button-green {
+            background-color: transparent;
+            border-color: #fff;
+            color: #fff;
+            padding: .9em 20px;
+            width: calc(100% - 44px);
+
+            &:hover,
+            &:focus {
+                background-color: rgba(255, 255, 255, 0.1);
+                border-color: #fff;
+                color: #fff;
+            }
+        }
+    }
+
+    @media #{$mq-tablet} {
+        .pre-download-newsletter {
+            margin: 0;
+        }
+
+        .download-button-wrapper {
+            margin: 20px 0 0;
+        }
+    }
+
+}

--- a/media/css/firefox/new/newsletter/scene1-pre-download.scss
+++ b/media/css/firefox/new/newsletter/scene1-pre-download.scss
@@ -1,0 +1,10 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+@import '../../../pebbles/includes/lib';
+
+.modal .pre-download-newsletter .form-details {
+    /* we're already showing the privacy link in page, so hide the default blurb that is shown via JS. */
+    display: none !important; /* stylelint-disable-line declaration-no-important */
+}

--- a/media/css/firefox/new/newsletter/scene2-centered.scss
+++ b/media/css/firefox/new/newsletter/scene2-centered.scss
@@ -1,0 +1,123 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+$font-path: '/media/fonts';
+$image-path: '/media/protocol/img';
+
+@import '../../../../protocol/css/includes/lib';
+
+.content-main {
+    background: $color-white;
+    border-radius: 8px;
+    color: $color-black;
+    margin: 0 auto;
+    max-width: 440px;
+    padding: $spacing-xl $spacing-lg;
+
+    .headline {
+        @include text-display-md;
+    }
+
+    .tagline {
+        @include text-body-lg;
+        border-bottom: 1px solid $color-gray-40;
+    }
+}
+
+@media #{$mq-md} {
+    .header-logos  .mozilla {
+        display: none;
+    }
+
+    .content-main {
+        text-align: center;
+        width: 100%;
+    }
+}
+
+@media #{$mq-lg} {
+    .content-main {
+        margin: 0 auto;
+        padding: $spacing-2xl $spacing-lg;
+    }
+
+    .header-logos {
+        margin-bottom: 20px;
+    }
+}
+
+// Newsletter form
+.mzp-c-newsletter-form {
+    text-align: left;
+    margin-bottom: 0;
+
+    input[type="email"] {
+        border-color: $color-gray-40;
+        padding: $spacing-md $spacing-sm;
+    }
+
+    legend {
+        color: $color-black;
+    }
+
+    .mzp-c-form-submit {
+        margin-bottom: 0;
+    }
+}
+
+.mzp-c-newsletter {
+    text-align: center;
+    margin: 0;
+
+    .mzp-c-form-errors {
+        color: $color-black;
+    }
+
+    .continue-download-direct {
+        margin: $spacing-xl 0 0;
+    }
+}
+
+.status {
+    a:link,
+    a:visited {
+        color: $color-white;
+
+        &:hover,
+        &:focus,
+        &:active {
+            color: $color-white;
+            text-decoration: none;
+        }
+    }
+}
+
+.thank-you-download {
+    h3 {
+        font-weight: normal;
+    }
+
+    .newsletter-download,
+    .mobile-download {
+        border-top: 1px solid $color-gray-40;
+        display: none;
+        margin-top: $spacing-2xl;
+        padding-top: $spacing-xl;
+    }
+}
+
+.mzp-c-newsletter,
+.thank-you-download {
+    a:link,
+    a:visited {
+        color: $color-black;
+
+        &:hover,
+        &:focus,
+        &:active {
+            color: $color-black;
+            text-decoration: none;
+        }
+    }
+}

--- a/media/js/firefox/new/newsletter/experiment.js
+++ b/media/js/firefox/new/newsletter/experiment.js
@@ -1,0 +1,27 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+(function(Mozilla) {
+    'use strict';
+
+    var isFirefox = /\sFirefox/.test(navigator.userAgent);
+
+    if (window.site.platform !== 'windows' && !isFirefox) {
+        return;
+    }
+
+    var cole = new Mozilla.TrafficCop({
+        id: 'experiment-firefox-new-pre-download',
+        variations: {
+            'xv=pre-dl&v=a': 92,
+            'xv=pre-dl&v=b': 2,
+            'xv=pre-dl&v=c': 2,
+            'xv=pre-dl&v=d': 2,
+            'xv=pre-dl&v=e': 2
+        }
+    });
+
+    cole.init();
+
+})(window.Mozilla);

--- a/media/js/firefox/new/newsletter/scene1-embed.js
+++ b/media/js/firefox/new/newsletter/scene1-embed.js
@@ -1,0 +1,25 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+(function () {
+    'use strict';
+
+    var downloadButton = document.querySelector('.main-download .download-button .download-list .download-link[data-download-os="Desktop"]');
+
+    // Listen for the regular newsletter form submit response.
+    $(document).ajaxSuccess(function(evt, xhr, settings, response) {
+        // Check that it's the correct form and the response was a non-error.
+        if ((settings.url.indexOf('/newsletter/') > -1) && response.success) {
+
+            document.getElementById('newsletter-form-thankyou').style.visibility = 'hidden';
+            document.querySelector('.main-download .download-button-wrapper').style.visibility = 'hidden';
+
+            // Redirect to /download/thanks/
+            if (downloadButton) {
+                window.location.href = downloadButton.href + '&s=t';
+            }
+        }
+    });
+
+})();

--- a/media/js/firefox/new/newsletter/scene1-modal.js
+++ b/media/js/firefox/new/newsletter/scene1-modal.js
@@ -1,0 +1,43 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+(function (Mozilla) {
+    'use strict';
+
+    var client = window.Mozilla.Client;
+
+    function initNewsletterModal() {
+        // Show email newsletter modal on download button click.
+        var downloadButton = document.querySelectorAll('.download-button .download-list .download-link[data-download-os="Desktop"]');
+
+        for(var i = 0; i < downloadButton.length; i++) {
+            downloadButton[i].setAttribute('role', 'button');
+            downloadButton[i].addEventListener('click', function(e) {
+                e.preventDefault();
+
+                Mozilla.Modal.createModal(this, $('.pre-download-newsletter'));
+
+            }, false);
+        }
+
+        // Listen for the regular newsletter form submit response.
+        $(document).ajaxSuccess(function(evt, xhr, settings, response) {
+            // Check that it's the correct form and the response was a non-error.
+            if ((settings.url.indexOf('/newsletter/') > -1) && response.success) {
+
+                // Close the modal
+                Mozilla.Modal.closeModal();
+
+                // Redirect to /download/thanks/
+                window.location.href = downloadButton[0].href + '?xv=pre-dl&v=c&s=t';
+            }
+        });
+    }
+
+    // Only show newsletter modal if not Firefox desktop.
+    if (!client.isFirefoxDesktop) {
+        initNewsletterModal();
+    }
+
+})(window.Mozilla);

--- a/media/js/firefox/new/newsletter/scene2-centered.js
+++ b/media/js/firefox/new/newsletter/scene2-centered.js
@@ -1,0 +1,21 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// This relies on base/mozilla-modal.js, included in the firefox_new_scene1 bundle
+
+(function() {
+    'use strict';
+
+    // Listen for the newsletter sucess event
+    document.addEventListener('newsletterSuccess', function () {
+
+        // Hide all the things.
+        document.querySelector('.content-main .headline').classList.add('hidden');
+        document.querySelector('.content-main .tagline').classList.add('hidden');
+        document.querySelector('.mzp-c-newsletter-thanks').style = 'display: none';
+
+        // Show the mobile app store button CTA.
+        document.querySelector('.mobile-download').classList.remove('hidden');
+    }, false);
+})();

--- a/media/js/firefox/new/newsletter/scene2-embed.js
+++ b/media/js/firefox/new/newsletter/scene2-embed.js
@@ -1,0 +1,69 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+(function() {
+    'use strict';
+
+    var $platformLink = $('#download-button-wrapper-desktop .download-list li:visible .download-link');
+    var directDownloadLink = document.getElementById('direct-download-link');
+    var continueDownloadLink = document.getElementById('continue-download-direct');
+    var downloadURL;
+
+    function startDownload() {
+        if (downloadURL) {
+            window.location.href = downloadURL;
+        }
+    }
+
+    function showNewsletterThankYouMessage() {
+        document.querySelector('.thank-you-download .newsletter-download').style.display = 'block';
+    }
+
+    function showMobileButtons() {
+        document.querySelector('.thank-you-download .mobile-download').style.display = 'block';
+    }
+
+    function showThankYouMessage() {
+        // Hide all the things.
+        document.querySelector('.content-main .headline').classList.add('hidden');
+        document.querySelector('.content-main .tagline').classList.add('hidden');
+        document.querySelector('.mzp-c-newsletter').style.display = 'none';
+        document.querySelector('.mzp-c-newsletter-thanks').style.display = 'none';
+
+        // Show thank you message.
+        document.querySelector('.thank-you-download').classList.remove('hidden');
+
+        // Hide this last of all, should any unforseen error occur.
+        continueDownloadLink.style.display = 'none';
+
+        // Start the download.
+        startDownload();
+    }
+
+    // Only auto-start the download if a visible platform link is detected.
+    if ($platformLink.length) {
+        downloadURL = $platformLink.attr('href');
+
+        // Pull download link from the download button and add to the 'Continue Firefox Download' link.
+        continueDownloadLink.setAttribute('href', downloadURL);
+
+        // Pull download link from the download button and add to the 'Try downloading again link.
+        directDownloadLink.setAttribute('href', downloadURL);
+
+        // Listen for the newsletter sucess event
+        document.addEventListener('newsletterSuccess', function() {
+            showThankYouMessage();
+            showNewsletterThankYouMessage();
+        }, false);
+
+        continueDownloadLink.addEventListener('click', function(e) {
+            e.preventDefault();
+            showThankYouMessage();
+            showMobileButtons();
+        }, false);
+    }
+
+    // Bug 1354334 - add a hint for test automation that page has loaded.
+    document.getElementsByTagName('html')[0].classList.add('download-ready');
+})();

--- a/media/js/firefox/new/newsletter/variation.js
+++ b/media/js/firefox/new/newsletter/variation.js
@@ -1,0 +1,34 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+(function(Mozilla) {
+    'use strict';
+
+    var variation = document.querySelector('.main-download').getAttribute('data-variant');
+
+    function setAttribution(variation) {
+        var params = {
+            /* eslint-disable camelcase */
+            utm_source: 'www.mozilla.org',
+            utm_medium: 'experiment',
+            utm_campaign: 'firefox_new_pre_download',
+            utm_content: 'firefox_new_pre_download_v_' + variation
+            /* eslint-enable camelcase */
+        };
+
+        function trackGAEvent() {
+            window.dataLayer.push({
+                'data-ex-name': 'firefox_new_pre_download',
+                'data-ex-variant': 'v_' + variation
+            });
+        }
+
+        Mozilla.CustomStubAttribution.init(params, trackGAEvent);
+    }
+
+    if (variation) {
+        setAttribution(variation);
+    }
+
+})(window.Mozilla);

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -58,6 +58,25 @@
     },
     {
       "files": [
+        "css/firefox/new/newsletter/scene2-centered.scss"
+      ],
+      "name": "experiment_firefox_new_pre_download_scene2_centered"
+    },
+    {
+      "files": [
+        "css/firefox/new/newsletter/scene1-embed.scss"
+      ],
+      "name": "experiment_firefox_new_pre_download_scene1_embed"
+    },
+    {
+      "files": [
+        "css/firefox/home/pre-download-newsletter.scss",
+        "css/firefox/new/newsletter/scene1-pre-download.scss"
+      ],
+      "name": "experiment_firefox_new_pre_download_scene1_modal"
+    },
+    {
+      "files": [
         "css/sandstone/sandstone-resp.less",
         "css/base/notification-banner.less",
         "css/tabzilla/tabzilla-static.less",
@@ -1050,6 +1069,13 @@
     },
     {
       "files": [
+        "js/base/mozilla-traffic-cop.js",
+        "js/firefox/new/newsletter/experiment.js"
+      ],
+      "name": "experiment_firefox_new_pre_download"
+    },
+    {
+      "files": [
         "js/etc/firefox/retention/confetti.js"
       ],
       "name": "etc-firefox-retention-thank-you"
@@ -1068,6 +1094,36 @@
         "js/firefox/new/scene2-email.js"
       ],
       "name": "firefox_new_scene2_email"
+    },
+    {
+      "files": [
+        "js/firefox/new/newsletter/variation.js"
+      ],
+      "name": "experiment_firefox_new_pre_download_scene1_variation"
+    },
+    {
+      "files": [
+        "js/firefox/new/newsletter/scene1-embed.js"
+      ],
+      "name": "experiment_firefox_new_pre_download_scene1_embed"
+    },
+    {
+      "files": [
+        "js/firefox/new/newsletter/scene1-modal.js"
+      ],
+      "name": "experiment_firefox_new_pre_download_scene1_modal"
+    },
+    {
+      "files": [
+        "js/firefox/new/newsletter/scene2-centered.js"
+      ],
+      "name": "experiment_firefox_new_pre_download_scene2_centered"
+    },
+    {
+      "files": [
+        "js/firefox/new/newsletter/scene2-embed.js"
+      ],
+      "name": "experiment_firefox_new_pre_download_scene2_embed"
     },
     {
       "files": [

--- a/tests/functional/firefox/new/test_download.py
+++ b/tests/functional/firefox/new/test_download.py
@@ -17,6 +17,7 @@ def test_download_button_displayed(base_url, selenium):
 # Firefox and Internet Explorer don't cope well with file prompts whilst using Selenium.
 @pytest.mark.skip_if_firefox(reason='http://saucelabs.com/jobs/5a8a62a7620f489d92d6193fa67cf66b')
 @pytest.mark.skip_if_internet_explorer(reason='https://github.com/SeleniumHQ/selenium/issues/448')
+@pytest.mark.skip(reason='https://github.com/mozilla/bedrock/issues/6950')
 @pytest.mark.nondestructive
 def test_click_download_button(base_url, selenium):
     page = DownloadPage(selenium, base_url, params='').open()


### PR DESCRIPTION
## Description
- Adds a multi-variant newsletter treatment test to `/firefox/new/`

## Issue / Bugzilla link
#6950

## Testing

Experiment criteria: 
- Non-Firefox desktop browsers
- Windows, 
- en-US locale.
- DNT disabled.

Testing:
- [ ] Experiment should trigger at the following URL for the above criteria only: https://www-demo1.allizom.org/en-US/firefox/new/
- [ ] For each variation, signing up & downloading should work successfully.
- [ ] For each variation, downloading without signing up should work sucessfully.
- [ ] For each variation, the apropriate message should be shown on scene2, depending upon the interaction taken.
- [ ] Stub attribution and GA data is being passed correctly for each variation.

### Variations:

- https://www-demo1.allizom.org/en-US/firefox/new/?xv=pre-dl&v=a (Control).
- https://www-demo1.allizom.org/en-US/firefox/new/?xv=pre-dl&v=b (Improved post-download newsletter on /thanks).
- https://www-demo1.allizom.org/en-US/firefox/new/?xv=pre-dl&v=c (Pre-download modal on scene 1).
- https://www-demo1.allizom.org/en-US/firefox/new/?xv=pre-dl&v=d (Pre-download embedded form on /thanks).
- https://www-demo1.allizom.org/en-US/firefox/new/?xv=pre-dl&v=e (Embedded form on scene1)