### PR TITLE
Add subhead to hero section on Mozilla.org for DE homepage (Fixes #6980)

### DIFF
--- a/bedrock/mozorg/templates/mozorg/home/home-de.html
+++ b/bedrock/mozorg/templates/mozorg/home/home-de.html
@@ -38,6 +38,7 @@
   {{ fxa_banner(
     logo_title=_('Firefox'),
     title=_('Dein Leben. <br>Deine Daten.'),
+    sub_title=_('Nimm Lesezeichen und Privatsphäre-Features mit auf jedes Gerät – mit deinem Firefox-Konto.'),
     link_cta=_('Weitere Infos'),
   )}}
 


### PR DESCRIPTION
## Description
- Adds subhead to `/de/` home page for existing Firefox users.

## Issue / Bugzilla link
#6980