### PR TITLE
Add timeout params to test requests for #7015

### DIFF
--- a/jenkins/branches/master.yml
+++ b/jenkins/branches/master.yml
@@ -8,5 +8,6 @@ apps:
   - bedrock-dev
 integration_tests:
   iowa-a:
+    - download
     - firefox
     - headless

--- a/jenkins/branches/prod.yml
+++ b/jenkins/branches/prod.yml
@@ -12,6 +12,7 @@ integration_tests:
     - headless
   iowa-a:
     - chrome
+    - download
     - firefox
     - headless
     - ie

--- a/jenkins/branches/stage.yml
+++ b/jenkins/branches/stage.yml
@@ -8,6 +8,7 @@ apps:
 integration_tests:
   iowa-a:
     - chrome
+    - download
     - firefox
     - headless
     - ie

--- a/tests/functional/test_download.py
+++ b/tests/functional/test_download.py
@@ -11,6 +11,8 @@ PAGE_PATHS = (
     '/firefox/download/thanks/',
 )
 
+TIMEOUT = 60
+
 
 @pytest.mark.download
 @pytest.mark.nondestructive
@@ -23,15 +25,15 @@ def test_download_links(path, base_url):
 
     full_url = base_url + '/en-US' + path
     try:
-        r = requests.get(full_url)
+        r = requests.get(full_url, timeout=TIMEOUT)
     except requests.RequestException:
         # retry
-        r = requests.get(full_url)
+        r = requests.get(full_url, timeout=TIMEOUT)
     soup = BeautifulSoup(r.content, 'html.parser')
     urls = [a['href'] for a in soup.find('ul', class_='download-list').find_all('a')]
     # Bug 1266682 remove links to Play Store to avoid rate limiting in automation.
     urls = [url for url in urls if 'play.google.com' not in url]
     assert urls
     for url in urls:
-        r = requests.head(url, allow_redirects=True)
+        r = requests.head(url, allow_redirects=True, timeout=TIMEOUT)
         assert requests.codes.ok == r.status_code

--- a/tests/functional/test_download_l10n.py
+++ b/tests/functional/test_download_l10n.py
@@ -18,6 +18,8 @@ PAGE_PATHS = (
     '/firefox/android/nightly/all/',
 )
 
+TIMEOUT = 60
+
 
 @pytest.mark.download
 @pytest.mark.nondestructive
@@ -30,14 +32,14 @@ def test_localized_download_links(path, base_url):
 
     full_url = base_url + '/en-US' + path
     try:
-        r = requests.get(full_url)
+        r = requests.get(full_url, timeout=TIMEOUT)
     except requests.RequestException:
         # retry
-        r = requests.get(full_url)
+        r = requests.get(full_url, timeout=TIMEOUT)
     soup = BeautifulSoup(r.content, 'html.parser')
     table = soup.find('table', class_='build-table')
     urls = [a['href'] for a in table.find_all('a')]
     assert urls
     for url in urls:
-        r = requests.head(url, allow_redirects=True)
+        r = requests.head(url, allow_redirects=True, timeout=TIMEOUT)
         assert requests.codes.ok == r.status_code

--- a/tests/functional/test_generated_pages.py
+++ b/tests/functional/test_generated_pages.py
@@ -6,6 +6,9 @@ import pytest
 import requests
 
 
+TIMEOUT = 60
+
+
 def pytest_generate_tests(metafunc):
     if 'not headless' in metafunc.config.option.markexpr:
         return  # test deslected by mark expression
@@ -62,5 +65,5 @@ def pytest_generate_tests(metafunc):
 @pytest.mark.headless
 @pytest.mark.nondestructive
 def test_generated_pages(url):
-    r = requests.head(url, allow_redirects=True)
+    r = requests.head(url, allow_redirects=True, timeout=TIMEOUT)
     assert requests.codes.ok == r.status_code


### PR DESCRIPTION
## Description

Add [request timeouts](http://docs.python-requests.org/en/latest/user/advanced/#timeouts).

## Issue / Bugzilla link

#7015

## Testing

- https://ci.vpn1.moz.works/blue/organizations/jenkins/bedrock_multibranch_pipeline/detail/run-integration-tests/277/pipeline
- https://ci.vpn1.moz.works/blue/organizations/jenkins/bedrock_multibranch_pipeline/detail/run-integration-tests/278/pipeline/

### Run tests locally via docker against production with 5 concurrent processes:

`docker run --rm -e BASE_URL=https://www.mozilla.org -e PYTEST_PROCESSES=5 -e MARK_EXPRESSION=download mozorg/bedrock_test:3bfb111f16fbb3e642416fd67ac3fb86646507ea bin/run-integration-tests.sh`