### PR TITLE
Deindex /download/thanks/ (Fixes #7024)

### DIFF
--- a/bedrock/firefox/templates/firefox/new/scene2.html
+++ b/bedrock/firefox/templates/firefox/new/scene2.html
@@ -8,12 +8,8 @@
 
 {% extends "firefox/base-protocol.html" %}
 
-{% block canonical_urls %}
-  {# the "scene 2" page should set canonical to the /firefox/new/ page to give that
-     page the SEO weight of links directly to "scene 2".
-     see https://github.com/mozilla/bedrock/pull/5463 #}
-  <link rel="canonical" href="{{ settings.CANONICAL_URL }}/{{ LANG }}/firefox/new/">
-{% endblock %}
+{# "scene2" page should not be indexed to avoid it appearing in search results: issue 7024 #}
+{% block canonical_urls %}<meta name="robots" content="noindex,follow">{% endblock %}
 
 {% block page_og_url %}{{ settings.CANONICAL_URL }}/{{ LANG }}/firefox/new/{% endblock %}
 

--- a/bedrock/firefox/tests/test_views.py
+++ b/bedrock/firefox/tests/test_views.py
@@ -799,14 +799,14 @@ class TestFirefoxNewNoIndex(TestCase):
         eq_(robots.length, 0)
 
     def test_scene_2_canonical(self):
-        # Scene 2 of /firefox/new/ should contain a canonical tag to /firefox/new/.
+        # Scene 2 /firefox/download/thanks/ should always contain a noindex tag.
         req = RequestFactory().get('/firefox/download/thanks/')
         req.locale = 'en-US'
         response = views.download_thanks(req)
         doc = pq(response.content)
-        canonical = doc('link[rel="canonical"]')
-        eq_(canonical.length, 1)
-        ok_('/firefox/new/' in canonical.attr('href'))
+        robots = doc('meta[name="robots"]')
+        eq_(robots.length, 1)
+        ok_('noindex' in robots.attr('content'))
 
 
 @override_settings(DEV=False)


### PR DESCRIPTION
## Description
- De-index `/firefox/download/thanks/ page to stop it showing in search results.

## Issue / Bugzilla link
#7024

## Testing
- [ ] page should contain `<meta name="robots" content="noindex,follow">` in the head.
