### PR TITLE
Fix JS error on /firefox/new/ whern using Firefox (Fixes #7026)

### DIFF
--- a/media/js/firefox/new/scene1_fxa_modal.js
+++ b/media/js/firefox/new/scene1_fxa_modal.js
@@ -50,11 +50,11 @@
         client.getFxaDetails(function(details) {
             if (details.setup) {
                 for(var i = 0; i < downloadLinkPrimary.length; i++) {
-                    downloadLinkPrimary.removeEventListener('click', showFxAModal, false);
+                    downloadLinkPrimary[i].removeEventListener('click', showFxAModal, false);
                 }
 
                 for(var j = 0; j < downloadLinkSecondary.length; j++) {
-                    downloadLinkSecondary.removeEventListener('click', showFxAModal, false);
+                    downloadLinkSecondary[j].removeEventListener('click', showFxAModal, false);
                 }
             }
         });


### PR DESCRIPTION
## Description
- Fixes JS error on /firefox/new/

## Issue / Bugzilla link
#7026

## Testing
- [ ] Error no longer occurs if you're using Firefox and already signed into Sync.