### PR TITLE
Quantify daily unique users of Win10 S mode attempting to download Firefox (Fixes #6984)

### DIFF
--- a/media/js/base/core-datalayer-init.js
+++ b/media/js/base/core-datalayer-init.js
@@ -18,7 +18,8 @@ $(function() {
             'pageVersion': analytics.getPageVersion(),
             // white listed for www.mozill.org, will always return false on other domains
             'testPilotUser': 'testpilotAddon' in navigator ? 'true' : 'false',
-            'releaseWindowVersion': analytics.getLatestFxVersion()
+            'releaseWindowVersion': analytics.getLatestFxVersion(),
+            'win10SUser': analytics.isWin10S()
         };
 
         dataLayer.push(dataLayerCore);

--- a/media/js/base/core-datalayer.js
+++ b/media/js/base/core-datalayer.js
@@ -54,6 +54,21 @@ if (typeof Mozilla.Analytics == 'undefined') {
         return document.getElementsByTagName('html')[0].getAttribute('data-latest-firefox');
     };
 
+    /** Returns true if user is running Windows 10 in S mode.
+    * @return {Boolean}.
+    */
+    analytics.isWin10S = function() {
+        try {
+            var mode = JSON.parse(window.external.getHostEnvironmentValue('os-mode'));
+            if (mode && mode['os-mode'] === '2') {
+                return true;
+            }
+            return false;
+        } catch(e) {
+            return false;
+        }
+    };
+
     /** Returns an object containing GA-formatted FxA details
     * The specs for this are a combination of:
     * - https://bugzilla.mozilla.org/show_bug.cgi?id=1457024#c33

--- a/media/js/base/core-datalayer.js
+++ b/media/js/base/core-datalayer.js
@@ -55,9 +55,18 @@ if (typeof Mozilla.Analytics == 'undefined') {
     };
 
     /** Returns true if user is running Windows 10 in S mode.
+    * @param {String} ua - User Agent string.
     * @return {Boolean}.
     */
-    analytics.isWin10S = function() {
+    analytics.isWin10S = function(ua) {
+        ua = ua || navigator.userAgent;
+
+        var isEdge = ua.indexOf('Edge') > -1;
+
+        if (!isEdge) {
+            return false;
+        }
+
         try {
             var mode = JSON.parse(window.external.getHostEnvironmentValue('os-mode'));
             if (mode && mode['os-mode'] === '2') {

--- a/tests/unit/spec/base/core-datalayer.js
+++ b/tests/unit/spec/base/core-datalayer.js
@@ -3,7 +3,7 @@
  * Sinon docs: http://sinonjs.org/docs/
  */
 
-/* global describe, beforeEach, afterEach, it, expect */
+/* global describe, beforeEach, afterEach, it, expect, sinon */
 
 describe('core-datalayer.js', function() {
 
@@ -81,6 +81,33 @@ describe('core-datalayer.js', function() {
 
         it('will return null if no data-latest-firefox attribute is present on the html element', function() {
             expect(Mozilla.Analytics.getLatestFxVersion()).toBe(null);
+        });
+    });
+
+    describe('isWin10S', function() {
+
+        beforeEach(function () {
+            window.external = sinon.stub();
+            window.external.getHostEnvironmentValue = sinon.stub();
+        });
+
+        it('should return true if Windows 10 has S mode enabled', function() {
+            spyOn(window.external, 'getHostEnvironmentValue').and.returnValue('{"os-mode": "2"}');
+            var result = Mozilla.Analytics.isWin10S();
+            expect(window.external.getHostEnvironmentValue).toHaveBeenCalledWith('os-mode');
+            expect(result).toBeTruthy();
+        });
+
+        it('should return false if Windows 10 is unlocked', function() {
+            spyOn(window.external, 'getHostEnvironmentValue').and.returnValue('{"os-mode": "0"}');
+            var result = Mozilla.Analytics.isWin10S();
+            expect(result).toBeFalsy();
+        });
+
+        it('should return false for everyone else', function() {
+            spyOn(window.external, 'getHostEnvironmentValue').and.returnValue(new TypeError('window.external.getHostEnvironmentValue is not a function'));
+            var result = Mozilla.Analytics.isWin10S();
+            expect(result).toBeFalsy();
         });
     });
 

--- a/tests/unit/spec/base/core-datalayer.js
+++ b/tests/unit/spec/base/core-datalayer.js
@@ -86,6 +86,9 @@ describe('core-datalayer.js', function() {
 
     describe('isWin10S', function() {
 
+        var edgeUA = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML like Gecko) Chrome/51.0.2704.79 Safari/537.36 Edge/14.14931';
+        var chromeUA = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.77 Safari/537.36';
+
         beforeEach(function () {
             window.external = sinon.stub();
             window.external.getHostEnvironmentValue = sinon.stub();
@@ -93,20 +96,25 @@ describe('core-datalayer.js', function() {
 
         it('should return true if Windows 10 has S mode enabled', function() {
             spyOn(window.external, 'getHostEnvironmentValue').and.returnValue('{"os-mode": "2"}');
-            var result = Mozilla.Analytics.isWin10S();
+            var result = Mozilla.Analytics.isWin10S(edgeUA);
             expect(window.external.getHostEnvironmentValue).toHaveBeenCalledWith('os-mode');
             expect(result).toBeTruthy();
         });
 
         it('should return false if Windows 10 is unlocked', function() {
             spyOn(window.external, 'getHostEnvironmentValue').and.returnValue('{"os-mode": "0"}');
-            var result = Mozilla.Analytics.isWin10S();
+            var result = Mozilla.Analytics.isWin10S(edgeUA);
             expect(result).toBeFalsy();
         });
 
-        it('should return false for everyone else', function() {
+        it('should return false if API is not supported in Edge', function() {
             spyOn(window.external, 'getHostEnvironmentValue').and.returnValue(new TypeError('window.external.getHostEnvironmentValue is not a function'));
-            var result = Mozilla.Analytics.isWin10S();
+            var result = Mozilla.Analytics.isWin10S(edgeUA);
+            expect(result).toBeFalsy();
+        });
+
+        it('should return false for other browsers', function() {
+            var result = Mozilla.Analytics.isWin10S(chromeUA);
             expect(result).toBeFalsy();
         });
     });


### PR DESCRIPTION
## Description
- Adds a new `win10SUser` property to the core `dataLayer` page event object in GA.

## Issue / Bugzilla link
#6984

## Testing
Demo: https://www-demo2.allizom.org/en-US/