### PR TITLE
[fix #6844] Don’t use Zilla Slab in Vietnamese

### DIFF
--- a/media/css/l10n/vi/intl.css
+++ b/media/css/l10n/vi/intl.css
@@ -1,0 +1,44 @@
+/*
+@font-face {
+    font-family: 'Zilla Slab';
+    font-weight: normal;
+    font-style: normal;
+    font-display: swap;
+    src: url('/media/fonts/opensans-regular.woff2') format('woff2'),
+         url('/media/fonts/opensans-regular.woff') format('woff');
+}
+
+@font-face {
+    font-family: 'Zilla Slab';
+    font-weight: bold;
+    font-style: normal;
+    font-display: swap;
+    src: url('/media/fonts/opensans-bold.woff2') format('woff2'),
+         url('/media/fonts/opensans-bold.woff') format('woff');
+}
+
+@font-face {
+    font-family: 'Zilla Slab';
+    font-weight: normal;
+    font-style: italic;
+    font-display: swap;
+    src: url('/media/fonts/opensans-italic.woff2') format('woff2'),
+         url('/media/fonts/opensans-italic.woff') format('woff');
+}
+
+@font-face {
+    font-family: 'Zilla Slab';
+    font-weight: bold;
+    font-style: italic;
+    font-display: swap;
+    src: url('/media/fonts/opensans-bolditalic.woff2') format('woff2'),
+         url('/media/fonts/opensans-bolditalic.woff') format('woff');
+}
+*/
+
+/* !important required for locale specific override */
+/* stylelint-disable declaration-no-important  */
+html[lang='vi'] body,
+html[lang='vi'] body * {
+    font-family: 'Open Sans', X-LocaleSpecific, sans-serif !important;
+}


### PR DESCRIPTION
## Description
Zilla Slab doesn’t support the full Vietnamese character set resulting in an ugly mix of characters. This adds an intl.css file that reassigns Open Sans in place of Zilla Slab when the language is Vietnamese.

## Issue / Bugzilla link
#6844 

## Testing
https://bedrock-demo-craigcook.oregon-b.moz.works/vi/

Browse the site in Vietnamese, ensure that instances of Zilla Slab are displaying in Open Sans instead.