### PR TITLE
Fix download sticky issues on homepage #6989

### DIFF
--- a/media/css/mozorg/home/home-2018.scss
+++ b/media/css/mozorg/home/home-2018.scss
@@ -23,6 +23,12 @@ $image-path: '/media/protocol/img';
     z-index: 3;
 }
 
+// Override footer z-index to hide download sticky behind it.
+.mzp-c-footer {
+    position: relative;
+    z-index: 2;
+}
+
 .main-page-heading {
     @include visually-hidden;
 }
@@ -292,6 +298,7 @@ $image-path: '/media/protocol/img';
 .download-firefox-sticky-cta {
     background-color: #bddefd;
 
+    .download-button,
     .download-list {
         margin-bottom: 0;
     }

--- a/media/js/mozorg/home/home.js
+++ b/media/js/mozorg/home/home.js
@@ -120,7 +120,7 @@ function onYouTubeIframeAPIReady() {
 
     // init dismiss button
     function initStickyCTA() {
-    // add and remove aria-hidden
+        // add and remove aria-hidden
         var primaryTop = new Waypoint({
             element: document.querySelectorAll('.c-primary-cta'),
             handler: function(direction) {
@@ -134,24 +134,42 @@ function onYouTubeIframeAPIReady() {
             }
         });
 
+        // hide sticky at top to prevent revealing through overscroll
+        var $stickyWrapper = $stickyCTA.find('.c-sticky-cta-wrapper');
+        $stickyWrapper.hide();
+        var mozContent = new Waypoint({
+            element: document.querySelectorAll('.mozilla-content'),
+            handler: function(direction) {
+                if(direction === 'down') {
+                    // reveal sticky
+                    $stickyWrapper.show();
+                } else {
+                    // hide sticky
+                    $stickyWrapper.hide();
+                }
+            },
+            offset: 100
+        });
+
         // add button
         var $dismissButton = $('<button type="button" class="sticky-dismiss">').text('Dismiss this prompt.');
-        var $stickyWrapper = $stickyCTA.find('.c-sticky-cta-wrapper');
         $dismissButton.appendTo($stickyWrapper);
 
         // find all the buttons
         var dismissButtons = $('.sticky-dismiss');
         // listen for the click
         dismissButtons.on('click', function() {
+            // destroy waypoints
+            primaryTop.destroy();
+            mozContent.destroy();
+
             // dismiss the sticky banner
-            dismissStickyCTA(primaryTop);
+            dismissStickyCTA();
         });
     }
 
     // handle dismiss
-    function dismissStickyCTA(stickyWayPoint) {
-        // destroy waypoint
-        stickyWayPoint.destroy();
+    function dismissStickyCTA() {
         // remove element
         $stickyCTA.remove();
         // set cookie, if cookies are supported


### PR DESCRIPTION
## Description

Fixed homepage sticky banner issues (1) in referenced issue. No changes to address (2) as unsure of desired behavior.

## Issue / Bugzilla link

#6989

## Testing

- in mobile download sticky has same padding above and below button
- in mobile sticky doesn't ever appear over footer
- in safari mobile scrolling down from top of website doesn't reveal sticky
