### PR TITLE
Shifted anchor link to project repo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ general technical documentation. In addition, there are project-specific
 Contributing
 ------------
 
-Patches are welcome! Feel free to fork and contribute to this project on
-[GitHub][gh-bedrock]. If you find a problem and wish to report it, please [file
+Patches are welcome! Feel free to fork and contribute to [this project][gh-bedrock] on
+GitHub. If you find a problem and wish to report it, please [file
 a bug][bugzilla].
 
 Looking for a good first bug to work on? Take a look at the [wiki page][wiki] for a


### PR DESCRIPTION
## Description

Shifted the anchor link to the main project from `GitHub` to `this project` for more understandability and to prevent ambiguity.
Hopefully the changes are valid and good to be merged.
(my first contribution here.)

## Issue / Bugzilla link
No issue filed for the same as changes are small and only to README
## Testing
Same reason as above.