### PR TITLE
Add `git clean -f` to `make clean`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,6 +75,8 @@ clean:
 	-rm -rf static_build/
 #	state files
 	-rm -f .docker-build*
+# clean untracked files
+	git clean -f
 
 lint: .docker-build-pull
 	${DC} run test flake8 bedrock lib tests


### PR DESCRIPTION
## Description

Remove files left over from previous builds in other branches

## Issue / Bugzilla link

https://github.com/mozilla/bedrock/issues/7028#issuecomment-480883105

## Testing

Create a new file without adding to git, run `make clean`, verify file is deleted.
