### PR TITLE
Protocol 6.0.1

### DIFF
--- a/bedrock/base/templates/base-protocol-mozilla.html
+++ b/bedrock/base/templates/base-protocol-mozilla.html
@@ -1,0 +1,4 @@
+{% extends 'base-protocol.html' %}
+
+{% block body_class %}mzp-t-mozilla{% endblock %}
+

--- a/bedrock/firefox/templates/firefox/campaign/index.html
+++ b/bedrock/firefox/templates/firefox/campaign/index.html
@@ -37,7 +37,7 @@
     {% call hero(
       title=_('The new <strong>Firefox</strong>'),
       desc=_('Fast for good.'),
-      class='mzp-has-image mzp-u-no-shape mzp-t-firefox mzp-t-dark',
+      class='mzp-has-image mzp-t-firefox mzp-t-dark',
       include_cta=True,
       image_url='firefox/new/browser.png',
       include_highres_image=True,

--- a/bedrock/firefox/templates/firefox/fights-for-you.html
+++ b/bedrock/firefox/templates/firefox/fights-for-you.html
@@ -118,12 +118,6 @@
       {{ download_firefox(download_location='secondary cta', dom_id='fffy-download-secondary') }}
     </div>
   {% endcall %}
-
-  {% if switch('fffy-survey', ['en-US']) %}
-    <div id="fffy-survey-link" class="mzp-l-content">
-        Please help us out by taking this <a href="https://www.surveygizmo.com/s3/4693873/FFFY-Heartbeat-Survey" target="_blank" rel="noopener noreferrer">short survey</a>.
-    </div>
-  {% endif %}
 </div>
 
 <div id="fffy-video-modal" class="mzp-u-modal-content">

--- a/bedrock/firefox/templates/firefox/recommended.html
+++ b/bedrock/firefox/templates/firefox/recommended.html
@@ -20,7 +20,7 @@
 
 {% block content %}
 <main role="main">
-  <section class="mzp-c-hero mzp-t-firefox mzp-t-product-firefox mzp-u-no-shape">
+  <section class="mzp-c-hero mzp-t-firefox mzp-t-product-firefox">
     <div class="mzp-l-content">
       <div class="mzp-c-hero-body">
         <h1 class="mzp-c-hero-title">{{ _('Fast. Private. Fearless. <br>Firefox fights for you.') }}</h1>

--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx66.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx66.html
@@ -78,7 +78,7 @@
   {% set content_blocking_image='firefox/whatsnew_64/hero.png' if DIR == 'ltr' else 'firefox/whatsnew_64/hero-rtl.png' %}
   {% call hero(
     title=_('One log-in. Power and security everywhere.'),
-    class='mzp-has-image mzp-l-reverse t-wn64 show-fxa-default show-fxa-supported-signed-out',
+    class='mzp-has-image mzp-l-reverse show-fxa-default show-fxa-supported-signed-out',
     image_url=content_blocking_image,
     include_highres_image=true,
     include_cta=True

--- a/bedrock/firefox/templates/firefox/windows-64-bit.html
+++ b/bedrock/firefox/templates/firefox/windows-64-bit.html
@@ -66,7 +66,7 @@
 
  {% call call_out_compact(
   title=_('Take control of your browser.'),
-  class='mzp-t-product-firefox mzp-t-firefox'
+  class='mzp-t-product-firefox mzp-t-firefox mzp-t-dark'
 ) %}
   <div class="download-firefox">
     {{ download_firefox(dom_id='win64-bottom-download', download_location='secondary cta') }}

--- a/bedrock/foundation/templates/foundation/annualreport/2017/index.html
+++ b/bedrock/foundation/templates/foundation/annualreport/2017/index.html
@@ -2,7 +2,7 @@
  # License, v. 2.0. If a copy of the MPL was not distributed with this
  # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
 
-{% extends "base-protocol.html" %}
+{% extends "base-protocol-mozilla.html" %}
 
 {% block page_title %}{{ _('The State of Mozilla: 2017 Annual Report') }}{% endblock %}
 {% block body_id %}annual-2017{% endblock %}

--- a/bedrock/mozorg/templates/mozorg/about-2019.html
+++ b/bedrock/mozorg/templates/mozorg/about-2019.html
@@ -4,7 +4,7 @@
 
 {% from "macros-protocol.html" import billboard, card, feature_card with context %}
 
-{% extends "base-protocol.html" %}
+{% extends "base-protocol-mozilla.html" %}
 
 {% add_lang_files "mozorg/about-2019" %}
 

--- a/bedrock/mozorg/templates/mozorg/about/policy/lean-data/build-security.html
+++ b/bedrock/mozorg/templates/mozorg/about/policy/lean-data/build-security.html
@@ -2,7 +2,7 @@
  # License, v. 2.0. If a copy of the MPL was not distributed with this
  # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
 
-{% extends "base-protocol.html" %}
+ {% extends "base-protocol-mozilla.html" %}
 
 {% block page_title_prefix %}{{ _('Build Security') }} — {% endblock %}
 {% block page_title %}{{ _('Lean Data Practices') }}{% endblock %}

--- a/bedrock/mozorg/templates/mozorg/about/policy/lean-data/engage-users.html
+++ b/bedrock/mozorg/templates/mozorg/about/policy/lean-data/engage-users.html
@@ -2,7 +2,7 @@
  # License, v. 2.0. If a copy of the MPL was not distributed with this
  # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
 
-{% extends "base-protocol.html" %}
+ {% extends "base-protocol-mozilla.html" %}
 
 {% block page_title_prefix %}{{ _('Engage Users') }} — {% endblock %}
 {% block page_title %}{{ _('Lean Data Practices') }}{% endblock %}

--- a/bedrock/mozorg/templates/mozorg/about/policy/lean-data/index.html
+++ b/bedrock/mozorg/templates/mozorg/about/policy/lean-data/index.html
@@ -2,7 +2,7 @@
  # License, v. 2.0. If a copy of the MPL was not distributed with this
  # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
 
-{% extends "base-protocol.html" %}
+ {% extends "base-protocol-mozilla.html" %}
 
 {% block page_title %}{{ _('Lean Data Practices') }}{% endblock %}
 

--- a/bedrock/mozorg/templates/mozorg/about/policy/lean-data/stay-lean.html
+++ b/bedrock/mozorg/templates/mozorg/about/policy/lean-data/stay-lean.html
@@ -2,7 +2,7 @@
  # License, v. 2.0. If a copy of the MPL was not distributed with this
  # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
 
-{% extends "base-protocol.html" %}
+ {% extends "base-protocol-mozilla.html" %}
 
 {% block page_title_prefix %}{{ _('Stay Lean') }} — {% endblock %}
 {% block page_title %}{{ _('Lean Data Practices') }}{% endblock %}

--- a/bedrock/mozorg/templates/mozorg/home/home-de.html
+++ b/bedrock/mozorg/templates/mozorg/home/home-de.html
@@ -49,7 +49,7 @@
   )}}
 
   <div class="mozilla-content">
-    <div class="mzp-l-content">
+    <div class="mzp-l-content mzp-t-mozilla">
       <div class="mzp-l-card-hero">
         {{ content_card('card_1') }}
         {{ content_card('card_2') }}

--- a/bedrock/mozorg/templates/mozorg/home/home-en.html
+++ b/bedrock/mozorg/templates/mozorg/home/home-en.html
@@ -83,7 +83,7 @@
   )}}
 
   <div class="mozilla-content">
-    <div class="mzp-l-content">
+    <div class="mzp-l-content mzp-t-mozilla">
       <div class="mzp-l-card-hero">
         {{ content_card('card_1') }}
         {{ content_card('card_2') }}
@@ -130,7 +130,7 @@
     </aside>
     {% endif %}
 
-    <div class="mzp-l-content">
+    <div class="mzp-l-content mzp-t-mozilla">
       <div class="mzp-l-card-half">
         {{ content_card('card_8') }}
         {{ content_card('card_9') }}

--- a/bedrock/mozorg/templates/mozorg/locales.html
+++ b/bedrock/mozorg/templates/mozorg/locales.html
@@ -2,7 +2,7 @@
  # License, v. 2.0. If a copy of the MPL was not distributed with this
  # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
 
-{% extends "base-protocol.html" %}
+ {% extends "base-protocol-mozilla.html" %}
 
 {% block page_title %}Choose your language or locale to browse Mozilla.org{% endblock %}
 

--- a/bedrock/privacy/templates/privacy/email.de.html
+++ b/bedrock/privacy/templates/privacy/email.de.html
@@ -2,7 +2,7 @@
  # License, v. 2.0. If a copy of the MPL was not distributed with this
  # file, You can obtain one at http://mozilla.org/MPL/2.0/. #}
 
-{% extends "base-protocol.html" %}
+ {% extends "base-protocol-mozilla.html" %}
 
 {% block page_title %}Wie verwendet Mozilla meine E-Mail-Adresse?{% endblock %}
 
@@ -10,7 +10,7 @@
   {{ css_bundle('privacy_email') }}
 {% endblock %}
 
-{% block page_class %}privacy-email{% endblock %}
+{% block body_class %}{{ super() }} privacy-email{% endblock %}
 
 {% block content %}
 <div class="mzp-l-content article-wrapper">
@@ -34,4 +34,3 @@
 
 </div>
 {% endblock %}
-

--- a/bedrock/privacy/templates/privacy/email.fr.html
+++ b/bedrock/privacy/templates/privacy/email.fr.html
@@ -2,7 +2,7 @@
  # License, v. 2.0. If a copy of the MPL was not distributed with this
  # file, You can obtain one at http://mozilla.org/MPL/2.0/. #}
 
-{% extends "base-protocol.html" %}
+ {% extends "base-protocol-mozilla.html" %}
 
 {% block page_title %}Comment mon adresse sera-t-elle utilisée par Mozilla ?{% endblock %}
 
@@ -10,7 +10,7 @@
   {{ css_bundle('privacy_email') }}
 {% endblock %}
 
-{% block page_class %}privacy-email{% endblock %}
+{% block body_class %}{{ super() }} privacy-email{% endblock %}
 
 {% block content %}
 <div class="mzp-l-content article-wrapper">
@@ -18,7 +18,7 @@
     <h1 class="mzp-c-article-title">{{ self.page_title() }}</h1>
 
     <p class="mzp-c-article-intro">
-      Mozilla n’accorde pas seulement de l’importance à la confidentialité et à la sécurité de votre adresse électronique — cela fait partie de notre <a href="{{ url('mozorg.about.manifesto') }}"></a>Manifeste</a> : « La sécurité et la vie privée de chacun sur Internet sont fondamentales et ne doivent pas être facultatives. » <a href="{{ url('privacy.principles') }}"></a>Apprenez-en davantage sur nos principes de confidentialité des données</a>. 
+      Mozilla n’accorde pas seulement de l’importance à la confidentialité et à la sécurité de votre adresse électronique — cela fait partie de notre <a href="{{ url('mozorg.about.manifesto') }}"></a>Manifeste</a> : « La sécurité et la vie privée de chacun sur Internet sont fondamentales et ne doivent pas être facultatives. » <a href="{{ url('privacy.principles') }}"></a>Apprenez-en davantage sur nos principes de confidentialité des données</a>.
     </p>
 
     <p><strong>Ce que vous devez savoir :</strong></p>

--- a/bedrock/privacy/templates/privacy/email.html
+++ b/bedrock/privacy/templates/privacy/email.html
@@ -2,7 +2,7 @@
  # License, v. 2.0. If a copy of the MPL was not distributed with this
  # file, You can obtain one at http://mozilla.org/MPL/2.0/. #}
 
-{% extends "base-protocol.html" %}
+ {% extends "base-protocol-mozilla.html" %}
 
 {% block page_title %}{{ _('How Will Mozilla Use My Email?') }}{% endblock %}
 
@@ -10,7 +10,7 @@
   {{ css_bundle('privacy_email') }}
 {% endblock %}
 
-{% block page_class %}privacy-email{% endblock %}
+{% block body_class %}{{ super() }} privacy-email{% endblock %}
 
 {% block content %}
 <div class="mzp-l-content article-wrapper">
@@ -39,4 +39,3 @@
 </div>
 
 {% endblock %}
-

--- a/media/css/firefox/accounts-2018.scss
+++ b/media/css/firefox/accounts-2018.scss
@@ -74,11 +74,6 @@ $image-path: '/media/protocol/img';
 /* -------------------------------------------------------------------------- */
 // Modal, custom styles
 
-#fx-modal-button {
-    background: $color-blue-60;
-    border: $color-blue-60;
-}
-
 .mobile-notes,
 .mobile-lockbox,
 .mobile-pocket {
@@ -183,7 +178,7 @@ $image-path: '/media/protocol/img';
             @include border-box;
             @include text-body-md;
             border-radius: 2px;
-            padding: ($padding-md - 2px) ($padding-xl - 2px); //2px extra padding removed to compensate for 2px border.
+            padding: ($spacing-md - 2px) ($spacing-xl - 2px); //2px extra padding removed to compensate for 2px border.
             width: 100%;
         }
 

--- a/media/css/firefox/accounts-2018.scss
+++ b/media/css/firefox/accounts-2018.scss
@@ -30,11 +30,6 @@ $image-path: '/media/protocol/img';
     margin-bottom: $spacing-2xl;
 }
 
-.mzp-c-hero.mzp-t-firefox:after {
-    display: none;
-    mask: none;
-}
-
 .mzp-c-call-out {
     background: transparent;
 }

--- a/media/css/firefox/accounts-2018.scss
+++ b/media/css/firefox/accounts-2018.scss
@@ -139,6 +139,7 @@ $image-path: '/media/protocol/img';
 // Bottom Banner
 
 #bottom-banner {
+    @include light-links;
     background: #2a0140 url('/media/img/firefox/accounts/blob-img.png') center -120px no-repeat;
     @include background-size(cover);
     color: $color-white;
@@ -155,7 +156,6 @@ $image-path: '/media/protocol/img';
     }
 
     .fxa-email-form {
-        @include light-links;
         color: $color-white;
         max-width: $content-sm;
 
@@ -193,7 +193,6 @@ $image-path: '/media/protocol/img';
 
     .fxa-signin {
         @include text-body-sm;
-        @include light-links;
         text-align: center;
     }
 }

--- a/media/css/firefox/concerts.scss
+++ b/media/css/firefox/concerts.scss
@@ -42,10 +42,6 @@ $image-path: '/media/protocol/img';
         margin-bottom: 0;
     }
 
-    .mzp-c-hero.mzp-t-firefox:after {
-        display: none;
-    }
-
     .tagline {
         @include text-body-lg;
     }

--- a/media/css/firefox/concerts.scss
+++ b/media/css/firefox/concerts.scss
@@ -5,8 +5,6 @@
 $font-path: '/media/fonts';
 $image-path: '/media/protocol/img';
 
-$concert-coral: #ff4f5d;
-
 @import "../../protocol/css/includes/lib";
 @import "../../protocol/css/components/feature-card";
 @import "../../protocol/css/components/hero";
@@ -33,7 +31,7 @@ $concert-coral: #ff4f5d;
     }
 
     .mzp-c-hero-title {
-        color: $concert-coral;
+        color: $color-red-50;
     }
 
     .mzp-c-hero {
@@ -200,7 +198,7 @@ $concert-coral: #ff4f5d;
         @include border-box;
         @include text-body-md;
         border-radius: 2px;
-        padding: ($padding-md - 2px) ($padding-xl - 2px); //2px extra padding removed to compensate for 2px border.
+        padding: ($spacing-md - 2px) ($spacing-xl - 2px); //2px extra padding removed to compensate for 2px border.
         width: 100%;
     }
 
@@ -264,7 +262,7 @@ $concert-coral: #ff4f5d;
         @include border-box;
         @include text-body-md;
         border-radius: 2px;
-        padding: ($padding-md - 2px) ($padding-xl - 2px); //2px extra padding removed to compensate for 2px border.
+        padding: ($spacing-md - 2px) ($spacing-xl - 2px); //2px extra padding removed to compensate for 2px border.
         width: 100%;
     }
 }

--- a/media/css/firefox/features/adblocker.scss
+++ b/media/css/firefox/features/adblocker.scss
@@ -16,7 +16,7 @@ $image-path: '/media/protocol/img';
 /* -------------------------------------------------------------------------- */
 // Custom layout
 
-h1, h2, h3, blockquote {
+h1, h2, h3 {
     @include open-sans;
 }
 
@@ -26,9 +26,8 @@ ul li span {
 
 blockquote {
     @include text-display-sm;
-    margin: 30px 0;
+    margin: $layout-sm 0;
     text-align: left;
-
 }
 
 .mzp-c-call-out-compact.mzp-t-product-firefox.mzp-t-firefox {

--- a/media/css/firefox/fights-for-you.scss
+++ b/media/css/firefox/fights-for-you.scss
@@ -30,9 +30,7 @@ $image-path: '/media/protocol/img';
     font-weight: normal;
 }
 
-$fffy-purple: #2A0140;
-$fffy-coral: #FF4F5D;
-$fffy-pink: #FF2889;
+$fffy-purple: #2A0140; // do not update to match new colour tokens without updating background image assets
 
 .fffy-c-hero {
     background-color: $fffy-purple;
@@ -71,7 +69,7 @@ $fffy-pink: #FF2889;
     }
 
     .mzp-c-hero-title {
-        color: $fffy-coral;
+        color: $color-red-50;
         @include text-display-lg;
     }
 
@@ -102,7 +100,7 @@ $fffy-pink: #FF2889;
     }
 
     .mzp-c-call-out-title {
-        color: $fffy-pink;
+        color: $color-pink-50;
         @include text-display-lg;
     }
 }
@@ -196,13 +194,13 @@ $fffy-pink: #FF2889;
     background-repeat: no-repeat;
 
     .mzp-c-call-out-title {
-        color: $fffy-pink;
+        color: $color-pink-50;
 
         span {
             display: inline-block;
 
             &:last-child {
-                color: $fffy-coral;
+                color: $color-red-50;
             }
         }
     }
@@ -230,31 +228,6 @@ $fffy-pink: #FF2889;
 
     @media #{$mq-xl} {
         background-position: top 20px center, bottom -14px center, center left calc(50% - 650px);
-    }
-}
-
-#fffy-survey-link {
-    background-color: $color-gray-20;
-    bottom: 0;
-    display: none;
-    margin-bottom: 0;
-    max-width: 100%;
-    padding: $spacing-md;
-    position: sticky;
-    text-align: center;
-
-    a {
-        &:link,
-        &:visited {
-            color: $color-black;
-            font-weight: bold;
-        }
-
-        &:hover,
-        &:focus,
-        &:active {
-            text-decoration: none;
-        }
     }
 }
 

--- a/media/css/firefox/fights-for-you.scss
+++ b/media/css/firefox/fights-for-you.scss
@@ -64,10 +64,6 @@ $fffy-purple: #2A0140; // do not update to match new colour tokens without updat
         }
     }
 
-    .mzp-c-hero.mzp-t-firefox::after {
-        display: none;
-    }
-
     .mzp-c-hero-title {
         color: $color-red-50;
         @include text-display-lg;

--- a/media/css/firefox/home/pre-download-newsletter-protocol.scss
+++ b/media/css/firefox/home/pre-download-newsletter-protocol.scss
@@ -43,7 +43,7 @@ $image-path: '/media/protocol/img';
         @include border-box;
         @include text-body-md;
         border-radius: 2px;
-        padding: ($padding-md - 2px) ($padding-xl - 2px); //2px extra padding removed to compensate for 2px border.
+        padding: ($spacing-md - 2px) ($spacing-xl - 2px); //2px extra padding removed to compensate for 2px border.
         width: 100%;
     }
 

--- a/media/css/firefox/home/protocol.scss
+++ b/media/css/firefox/home/protocol.scss
@@ -17,12 +17,6 @@ $image-path: '/media/protocol/img';
 //* -------------------------------------------------------------------------- */
 // Page specific variables and over-rides
 
-$fx-body: #42425A;
-$fx-coral: #FF4F5D;
-$fx-orange: #FF7139;
-$fx-pink: #FF2889;
-$fx-purple: #20123A;
-
 .mzp-t-firefox {
     &,
     h1,
@@ -46,7 +40,7 @@ main .mzp-l-content {
 
 .mzp-c-hero {
     text-align: center;
-    color: $fx-purple;
+    color: $color-purple-90;
 
     &.mzp-t-firefox::after {
         display: none;
@@ -79,7 +73,7 @@ main .mzp-l-content {
     @include text-display-xl;
     font-weight: bold;
     margin-bottom: $spacing-md;
-    color: $fx-purple;
+    color: $color-purple-90;
 
     p {
         margin-bottom: $spacing-lg;
@@ -135,11 +129,11 @@ main .mzp-l-content {
     }
 
     .mzp-c-card-feature-title {
-        color: $fx-purple;
+        color: $color-purple-90;
     }
 
     .mzp-c-card-feature-desc {
-        color: $fx-body;
+        color: $color-gray-80;
     }
 
     @media #{$mq-lg} {
@@ -154,18 +148,18 @@ main .mzp-l-content {
 // Trio
 
 .c-trio {
-    color: $fx-body;
+    color: $color-gray-80;
 
     h2 {
         @include text-display-lg;
-        color: $fx-purple;
+        color: $color-purple-90;
         margin-top: $layout-lg;
         text-align: center;
     }
 
     h3 {
         @include text-display-sm;
-        color: $fx-purple;
+        color: $color-purple-90;
     }
 
     ul {
@@ -210,12 +204,12 @@ main .mzp-l-content {
 }
 
 .t-privacy {
-    background-color: $fx-purple;
+    background-color: $color-purple-90;
     color: #fff;
     margin-bottom: $layout-xl;
 
     h2 {
-        color: $fx-pink;
+        color: $color-pink-50;
         max-width: 600px;
         margin-left: auto;
         margin-right: auto;
@@ -262,7 +256,7 @@ main .mzp-l-content {
 // Comparison feature cards
 
 .t-compare {
-    background-color: $color-gray-10;
+    background-color: $color-gray-20;
     padding-top: $layout-md;
 
     video {
@@ -297,7 +291,7 @@ main .mzp-l-content {
 //
 
 .mzp-c-call-out-compact.t-you {
-    background-color: $fx-purple;
+    background-color: $color-purple-90;
 
     .mzp-c-call-out-container {
         &:before {
@@ -313,18 +307,19 @@ main .mzp-l-content {
 
     .mzp-c-call-out-title {
         @include text-display-xl;
-        color: $fx-orange;
+        color: $color-orange-50;
     }
 
     .mzp-c-call-out-desc {
         @include text-display-sm;
-        color: $fx-pink;
+        color: $color-pink-50;
         font-weight: bold;
         padding-bottom: $layout-sm;
     }
 
     @media #{$mq-lg} {
-        background: $fx-purple top left calc(50% + 500px) no-repeat url('/media/img/firefox/home/bright.png');
+        // do not update background colour without updating background image
+        background: #20123a top left calc(50% + 500px) no-repeat url('/media/img/firefox/home/bright.png');
         padding-top: $layout-sm;
 
         .mzp-l-content {

--- a/media/css/firefox/home/protocol.scss
+++ b/media/css/firefox/home/protocol.scss
@@ -41,10 +41,6 @@ main .mzp-l-content {
 .mzp-c-hero {
     text-align: center;
     color: $color-purple-90;
-
-    &.mzp-t-firefox::after {
-        display: none;
-    }
 }
 
 .mzp-c-hero-title {

--- a/media/css/firefox/home/protocol.scss
+++ b/media/css/firefox/home/protocol.scss
@@ -204,18 +204,6 @@ main .mzp-l-content {
     h3 {
         color: #fff;
     }
-
-    // protocol/issues#335
-    a:visited {
-        color: #ffffff;
-        opacity: 0.8;
-    }
-
-    a:hover,
-    a:focus,
-    a:active {
-        opacity: 1;
-    }
 }
 
 .t-custom {

--- a/media/css/firefox/home/protocol.scss
+++ b/media/css/firefox/home/protocol.scss
@@ -86,17 +86,13 @@ main .mzp-l-content {
 
 @media #{$mq-md} {
     .mzp-c-hero.mzp-has-image {
+        @include at2x('/media/img/firefox/home/hero-small.jpg', contain);
         align-items: center;
-        background: top left 50vw no-repeat url('/media/img/firefox/home/hero-small.jpg');
-        background-size: contain;
+        background-position: top left 50vw;
+        background-repeat: no-repeat;
         display: flex;
         min-height: 560px;
         text-align: left;
-
-        @media all #{$mq-high-res} {
-            background: top left 50vw no-repeat url('/media/img/firefox/home/hero-small-high-res.jpg');
-            background-size: contain;
-        }
     }
 
     .mzp-l-content {
@@ -106,15 +102,9 @@ main .mzp-l-content {
 
 @media #{$mq-lg} and #{$mq-tall} {
     .mzp-c-hero.mzp-has-image {
-        background: top left 50vw no-repeat url('/media/img/firefox/home/hero.jpg');
-        background-size: contain;
+        @include at2x('/media/img/firefox/home/hero.jpg', contain);
         height: 60vh;
         max-height: 672px;
-
-        @media all #{$mq-high-res} {
-            background: top left 50vw no-repeat url('/media/img/firefox/home/hero-high-res.jpg');
-            background-size: contain;
-        }
     }
 }
 

--- a/media/css/firefox/new/compare.scss
+++ b/media/css/firefox/new/compare.scss
@@ -68,10 +68,6 @@ $image-path: '/media/protocol/img';
         text-align: center;
     }
 
-    .secondary-cta {
-        background: $color-gray-20;
-    }
-
     .footnote {
         color: $color-gray-50;
         text-align: center;

--- a/media/css/firefox/new/scene2.scss
+++ b/media/css/firefox/new/scene2.scss
@@ -177,17 +177,6 @@ $image-path: '/media/protocol/img';
 }
 
 .mzp-t-dark {
-    :link,
-    :visited {
-        color: $color-white;
-
-        &:hover,
-        &:focus,
-        &:active {
-            color: $color-gray-20;
-        }
-    }
-
     .mzp-c-form-errors {
         color: $color-black;
     }

--- a/media/css/firefox/new/scene2.scss
+++ b/media/css/firefox/new/scene2.scss
@@ -44,7 +44,7 @@ $image-path: '/media/protocol/img';
         display: none;
         max-width: none;
         color: $color-black;
-        background-color: $brand-lemon-yellow;
+        background-color: $color-yellow-30;
 
         .windows.xpvista & {
             display: block;

--- a/media/css/firefox/pocket.scss
+++ b/media/css/firefox/pocket.scss
@@ -13,19 +13,6 @@ $image-path: '/media/protocol/img';
 @import '../../protocol/css/templates/card-layout';
 
 
-.mzp-t-dark .note {
-    :link,
-    :visited {
-        color: $color-white;
-
-        &:hover,
-        &:focus,
-        &:active {
-            color: $color-gray-20;
-        }
-    }
-}
-
 .mzp-c-hero-title img {
     display: block;
     margin: 0 auto $spacing-lg;

--- a/media/css/firefox/recommended.scss
+++ b/media/css/firefox/recommended.scss
@@ -67,6 +67,6 @@ $image-path: '/media/protocol/img';
     a:hover,
     a:active,
     a:focus {
-        color: $color-gray-60;
+        color: $color-gray-80;
     }
 }

--- a/media/css/firefox/releasenotes.scss
+++ b/media/css/firefox/releasenotes.scss
@@ -18,19 +18,6 @@ $image-path: '/media/protocol/img';
 @import '../../protocol/css/components/article';
 @import '../../protocol/css/components/call-out';
 
-.mzp-t-dark{
-    // protocol/issues#335
-    a:visited {
-        color: #ffffff;
-        opacity: 0.8;
-    }
-
-    a:hover,
-    a:focus,
-    a:active {
-        opacity: 1;
-    }
-}
 
 /* -------------------------------------------------------------------------- */
 // Call out / page header

--- a/media/css/firefox/releases-index.scss
+++ b/media/css/firefox/releases-index.scss
@@ -33,17 +33,12 @@ $image-path: '/media/protocol/img';
     }
 
     &:before {
-        @include background-size(40px 40px);
-        background-image: url('/media/img/logos/firefox/logo-quantum.png');
+        @include at2x('/media/img/logos/firefox/logo-quantum.png', 40px 40px);
         background-repeat: no-repeat;
         content: '';
         display: block;
         height: 40px;
         width: 40px;
-
-        @media #{$mq-high-res} {
-            background-image: url('/media/img/logos/firefox/logo-quantum-high-res.png');
-        }
 
         @media #{$mq-sm} {
             @include bidi((

--- a/media/css/firefox/releases-index.scss
+++ b/media/css/firefox/releases-index.scss
@@ -74,7 +74,7 @@ $image-path: '/media/protocol/img';
     li {
         @include clearfix;
         border: 0 solid $color-gray-20;
-        border-top-width: 4px;
+        border-top-width: 2px;
         padding: $spacing-md 0;
 
         &:first-child {

--- a/media/css/firefox/whatsnew/whatsnew-66.scss
+++ b/media/css/firefox/whatsnew/whatsnew-66.scss
@@ -322,25 +322,6 @@ $image-path: '/media/protocol/img';
 }
 
 //* -------------------------------------------------------------------------- */
-// Intro section
-
-.intro {
-    background-color: $color-gray-10;
-    min-height: 350px;
-    padding-top: $layout-sm;
-
-    @media #{$mq-md} {
-        margin-bottom: $layout-xl;
-        padding-top: $layout-xl;
-
-        .mzp-c-hero-image {
-            bottom: -$spacing-2xl;
-            height: calc(100% + #{$spacing-2xl});
-        }
-    }
-}
-
-//* -------------------------------------------------------------------------- */
 // Benefits section
 
 .wn66-benefit {
@@ -381,22 +362,6 @@ $image-path: '/media/protocol/img';
 
         @media #{$mq-md} {
             max-width: 100%;
-        }
-    }
-}
-
-//* -------------------------------------------------------------------------- */
-// callout container
-
-.t-wn64 {
-
-    &.mzp-c-call-out-compact {
-        background: $color-gray-10;
-    }
-
-    .mzp-c-call-out-cta-container {
-        @media #{$mq-md} {
-            text-align: center;
         }
     }
 }
@@ -454,4 +419,3 @@ $image-path: '/media/protocol/img';
         text-align: center;
     }
 }
-

--- a/media/css/firefox/windows-64-bit.scss
+++ b/media/css/firefox/windows-64-bit.scss
@@ -10,7 +10,7 @@ $image-path: '/media/protocol/img';
 @import '../../protocol/css/components/call-out';
 
 .mzp-c-hero {
-    background: #33124e;
+    background: $color-purple-90;
     color: #fff;
     text-align: center;
     min-height: 500px;
@@ -28,7 +28,7 @@ $image-path: '/media/protocol/img';
         }
 
         p {
-            color: #f07274;
+            color: $color-orange-50;
             font-weight: bold;
         }
 
@@ -53,7 +53,7 @@ $image-path: '/media/protocol/img';
     hr {
         margin: $layout-lg auto $layout-lg;
         width: 100px;
-        border: 2px solid #33124e;
+        border: 2px solid $color-purple-90;
     }
 }
 
@@ -61,9 +61,13 @@ $image-path: '/media/protocol/img';
 /* -------------------------------------------------------------------------- */
 // Call out
 
-.mzp-c-call-out-compact {
-    background: #33124e;
-    color: #f07274;
+.mzp-c-call-out-compact.mzp-t-dark {
+    background: $color-purple-90;
+
+    .mzp-c-call-out-title {
+        color: $color-orange-50;
+    }
+
     @media #{$mq-lg} {
         @include background-size(contain);
         background-image: url('/media/img/firefox/shapes.png');
@@ -72,4 +76,3 @@ $image-path: '/media/protocol/img';
     }
 
 }
-

--- a/media/css/foundation/annual2017.scss
+++ b/media/css/foundation/annual2017.scss
@@ -142,7 +142,7 @@
 
         a {
             @include transition(background-color .1s ease-in-out);
-            background-color: $color-teal-70;
+            background-color: $color-link;
             color: $color-white;
             display: block;
             font-weight: bold;
@@ -162,7 +162,7 @@
             &:hover,
             &:active,
             &:focus {
-                background-color: $color-teal-80;
+                background-color: $color-link-hover;
                 color: $color-white;
                 text-decoration: none;
             }

--- a/media/css/mozorg/about-en.scss
+++ b/media/css/mozorg/about-en.scss
@@ -57,8 +57,8 @@ $image-path: '/media/protocol/img';
 // Intro section
 
 .t-shade {
-    background: $color-gray-10;
-    background: $color-gray-10 linear-gradient($color-gray-10, #fff 350px);
+    background: $color-gray-20;
+    background: $color-gray-20 linear-gradient($color-gray-20, #fff 350px);
 
     @media #{$mq-lg}{
         margin-bottom: $layout-xl;

--- a/media/css/mozorg/what-is-a-browser.scss
+++ b/media/css/mozorg/what-is-a-browser.scss
@@ -29,7 +29,6 @@ $image-path: '/media/protocol/img';
     }
 
     blockquote {
-        @include open-sans;
         @include text-display-sm;
         margin: $layout-md auto;
     }
@@ -45,5 +44,3 @@ $image-path: '/media/protocol/img';
         margin: $spacing-lg 0;
     }
 }
-
-

--- a/media/css/pebbles/components/_protocol-nav.scss
+++ b/media/css/pebbles/components/_protocol-nav.scss
@@ -24,16 +24,16 @@ $image-path: '/media/protocol/img';
             background-color: transparent;
             background-image: none;
             border-radius: 2px;
-            color: $color-green-60;
-            border: 2px solid $color-green-60;
+            color: #12bc00;
+            border: 2px solid #12bc00;
             box-shadow: none;
             line-height: 1.125;
-            padding: $padding-sm $padding-md;
+            padding: $spacing-sm $spacing-md;
 
             &:hover,
             &:focus {
-                background-color: $color-green-60;
-                border-color: $color-green-60;
+                background-color: #12bc00;
+                border-color: #12bc00;
                 color: $color-white;
             }
         }
@@ -88,19 +88,19 @@ $image-path: '/media/protocol/img';
         background-color: transparent;
         background-image: none;
         border-radius: 2px;
-        border: 2px solid $color-green-60;
+        border: 2px solid #12bc00;
         box-shadow: none;
-        color: $color-green-60;
+        color: #12bc00;
         display: inline-block;
         font-weight: bold;
         line-height: 1.125;
-        padding: $padding-sm $padding-md;
+        padding: $spacing-sm $spacing-md;
         text-decoration: none;
 
         &:hover,
         &:focus {
-            background-color: $color-green-60;
-            border-color: $color-green-60;
+            background-color: #12bc00;
+            border-color: #12bc00;
             color: $color-white;
         }
     }

--- a/media/css/privacy/privacy-protocol.scss
+++ b/media/css/privacy/privacy-protocol.scss
@@ -7,7 +7,8 @@ $image-path: '/media/protocol/img';
 @import '../libs/system-font';
 
 @import '../../protocol/css/includes/lib';
-@import "../../protocol/css/components/article";
+@import '../../protocol/css/includes/mixins/details';
+@import '../../protocol/css/components/article';
 
 $heading-purple: #20123A;
 $body-purple: #42425A;
@@ -220,44 +221,13 @@ $border: 2px solid $color-gray-20;
 // Summary and details widget
 
 .privacy-body {
-    .is-summary {
-        button {
-            @include bidi(((padding, 0 $spacing-xl 0 0, 0 0 0 $spacing-xl),));
-            background: transparent;
-            border: 0;
-            color: inherit;
-            cursor: pointer;
-            font-family: inherit;
-            font-size: inherit;
-            font-weight: inherit;
-            position: relative;
-            text-align: inherit;
-            width: 100%;
-        }
-    }
-
-    .is-closed[aria-hidden="true"] {
-        display: none;
-    }
+    @include details;
 }
 
 .privacy-body .is-summary button {
-    position: relative;
-
-    &:before {
-        @include background-size(16px, 16px);
-        @include bidi(((right, 8px, left, auto),));
-        @include transition(transform 100ms ease-in-out);
-        background: $url-image-expand-black top left no-repeat;
-        content: '';
-        height: 16px;
-        margin-top: -8px;
-        position: absolute;
-        top: 50%;
-        width: 16px;
-    }
+    @include summary;
 }
 
 .privacy-body .is-summary button[aria-expanded=true]:before {
-    @include transform(rotate(45deg));
+    @include summary-open;
 }

--- a/media/css/privacy/privacy-protocol.scss
+++ b/media/css/privacy/privacy-protocol.scss
@@ -168,7 +168,7 @@ $border: 2px solid $color-gray-20;
 
 .data-choices {
     @include clearfix;
-    background-color: $color-gray-10;
+    background-color: $color-gray-20;
     border-radius: 8px;
     margin-top: $spacing-xl;
     padding: $spacing-sm;

--- a/media/css/protocol/components/_fxa-form.scss
+++ b/media/css/protocol/components/_fxa-form.scss
@@ -21,7 +21,7 @@ $image-path: '/media/protocol/img';
         @include border-box;
         @include text-body-md;
         border-radius: 2px;
-        padding: ($padding-md - 2px) ($padding-xl - 2px); //2px extra padding removed to compensate for 2px border.
+        padding: ($spacing-md - 2px) ($spacing-xl - 2px); //2px extra padding removed to compensate for 2px border.
         width: 100%;
     }
 

--- a/media/css/sandstone/protocol-nav.scss
+++ b/media/css/sandstone/protocol-nav.scss
@@ -24,16 +24,16 @@ $image-path: '/media/protocol/img';
             background-color: transparent;
             background-image: none;
             border-radius: 2px;
-            color: $color-green-60;
-            border: 2px solid $color-green-60;
+            color: #12bc00;
+            border: 2px solid #12bc00;
             box-shadow: none;
             line-height: 1.125;
-            padding: $padding-sm $padding-md;
+            padding: $spacing-sm $spacing-md;
 
             &:hover,
             &:focus {
-                background-color: $color-green-60;
-                border-color: $color-green-60;
+                background-color: #12bc00;
+                border-color: #12bc00;
                 color: $color-white;
             }
         }
@@ -69,19 +69,19 @@ $image-path: '/media/protocol/img';
         background-color: transparent;
         background-image: none;
         border-radius: 2px;
-        border: 2px solid $color-green-60;
+        border: 2px solid #12bc00;
         box-shadow: none;
-        color: $color-green-60;
+        color: #12bc00;
         display: inline-block;
         font-weight: bold;
         line-height: 1.125;
-        padding: $padding-sm $padding-md;
+        padding: $spacing-sm $spacing-md;
         text-decoration: none;
 
         &:hover,
         &:focus {
-            background-color: $color-green-60;
-            border-color: $color-green-60;
+            background-color: #12bc00;
+            border-color: #12bc00;
             color: $color-white;
         }
     }

--- a/media/js/firefox/fights-for-you.js
+++ b/media/js/firefox/fights-for-you.js
@@ -5,33 +5,6 @@
 (function() {
     'use strict';
 
-    var client = Mozilla.Client;
-    var survey = document.getElementById('fffy-survey-link');
-    if (survey && !client.isMobile && Math.random() < 0.5) {
-        var link = survey.querySelector('a');
-        var linkHref = link.getAttribute('href');
-
-        // show survey
-        survey.style.display = 'block';
-        window.dataLayer.push({
-            'eLabel': 'Banner Impression',
-            'data-banner-name': 'FFFY Survey Link',
-            'data-banner-impression': '1',
-            'event': 'non-interaction'
-        });
-
-        // survey tracking
-        link.setAttribute('href', linkHref + window.location.search);
-        link.addEventListener('click', function() {
-            window.dataLayer.push({
-                'eLabel': 'Banner Clickthrough',
-                'data-banner-name': 'FFFY Survey Link',
-                'data-banner-click': '1',
-                'event': 'in-page-interaction'
-            });
-        }, false);
-    }
-
     // Set up modal for the Focus link
     var focusContent = document.getElementById('fffy-focus-modal');
     var focusTrigger = document.querySelector('.fffy-t-focus .mzp-c-cta-link');

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Making mozilla.org awesome, one pebble at a time",
   "private": true,
   "dependencies": {
-    "@mozilla-protocol/core": "6.0.0",
+    "@mozilla-protocol/core": "6.0.1",
     "ansi-colors": "3.2.3",
     "clean-css-cli": "4.0.5",
     "del": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Making mozilla.org awesome, one pebble at a time",
   "private": true,
   "dependencies": {
-    "@mozilla-protocol/core": "5.0.0",
+    "@mozilla-protocol/core": "6.0.0",
     "ansi-colors": "3.2.3",
     "clean-css-cli": "4.0.5",
     "del": "^3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -21,10 +21,10 @@
     normalize-path "^2.0.1"
     through2 "^2.0.3"
 
-"@mozilla-protocol/core@5.0.0":
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/@mozilla-protocol/core/-/core-5.0.0.tgz#28e1877345b81c5782871218a2e091bacc5a4e8c"
-  integrity sha512-TqG854ztxFn89Ak6Vcw1FGJelH+X36i+8sinhecrlZstKtuLstlF+RY3R49r4ya7nBHXkkQCDk00EzhQ7jJ39Q==
+"@mozilla-protocol/core@6.0.0":
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/@mozilla-protocol/core/-/core-6.0.0.tgz#c9b68d58975815d414aa0b757fdb17da8414777e"
+  integrity sha512-wLFUZ22WuL9hZVsvLx3yiBI/8Y05c1ciZsKDB0jCu1pIIFDw+FqE8ZBN1yNydQ694KRSA8ltkH8T3O54NdksXw==
 
 JSONStream@^0.8.4:
   version "0.8.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -21,10 +21,10 @@
     normalize-path "^2.0.1"
     through2 "^2.0.3"
 
-"@mozilla-protocol/core@6.0.0":
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/@mozilla-protocol/core/-/core-6.0.0.tgz#c9b68d58975815d414aa0b757fdb17da8414777e"
-  integrity sha512-wLFUZ22WuL9hZVsvLx3yiBI/8Y05c1ciZsKDB0jCu1pIIFDw+FqE8ZBN1yNydQ694KRSA8ltkH8T3O54NdksXw==
+"@mozilla-protocol/core@6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/@mozilla-protocol/core/-/core-6.0.1.tgz#88107f83590182a44c322f799041acb1f1f1bd1f"
+  integrity sha512-edVsiYkThKKQvAD5TvrU9v5BI+1z6UuyZd61VI6NZRbMxLVxPbPlJGfKMMl+KiZsuYNL1NdFEWRLwvKNbGJqGg==
 
 JSONStream@^0.8.4:
   version "0.8.4"


### PR DESCRIPTION
## Description

Update bedrock to use Protocol 6.0.1

## Issue / Bugzilla link

Fix #7040

## Testing
Remember to use `make build` to pull in the new stuff locally.

Here is the list of changes from the Protocol change log and the effected pages that I found:
* **css:** (breaking) Move Zilla Slab from default theme to custom theme (mozilla/protocol#342)
	- http://localhost:8000/en-US/foundation/annualreport/2017/
	- http://localhost:8000/en-US/about/
		- error with background image see https://github.com/mozilla/protocol/issues/368
	- http://localhost:8000/locales/
	- http://localhost:8000/en-US/about/policy/lean-data/
	- http://localhost:8000/en-US/about/policy/lean-data/stay-lean/
	- http://localhost:8000/en-US/about/policy/lean-data/build-security/
	- http://localhost:8000/en-US/about/policy/lean-data/engage-users/
	- http://localhost:8000/en-US/
	- http://localhost:8000/de/
	- http://localhost:8000/en-US/privacy/email/
	- http://localhost:8000/de/privacy/email/
	- http://localhost:8000/fr/privacy/email/
* **css:** (breaking) Update protocol/tokens v3.0.0
	- http://localhost:8000/en-US/firefox/download/thanks/ (yellow on the XP warning)
	- http://localhost:8000/en-US/foundation/annualreport/2017/ 
	- http://localhost:8000/en-US/firefox/65.0/whatsnew/
	- http://localhost:8000/en-US/firefox/63.0/whatsnew/
* **css:** Update at2x to allow background-size: contain (mozilla/protocol#336)
	- http://localhost:8000/en-US/firefox/?v=b
	- http://localhost:8000/en-US/firefox/releases/
	- error with background image see mozilla/protocol#368
* **css:** (breaking) Remove curve under hero component mozilla/protocol(#311)
	- I could not find any pages using this. I tried to remove all the over-rides removing it.
* **css:** Call Out component is missing display: flex vendor prefixes (mozilla/protocol#218)
	- bug fix, should not be any visible change
* **css:** Decrease size of article h3 and h4s mozilla/protocol mozilla/protocol#293
	- I don't think we are using this anywhere yet
* **css:** blockquote needs mzp-t-firefox theme mozilla/protocol#303
	- No code changes since the default display no-longer uses Zilla
* **css:** Summary button text over laps icon mozilla/protocol#331
	- http://localhost:8000/en-US/privacy/firefox/
* **css:** Make summary and details widget styles into mixins mozilla/protocol#332
	- http://localhost:8000/en-US/privacy/firefox/
* **css:** Visited link colour in t-dark themes too dark mozilla/protocol#335
	- http://localhost:8000/en-US/firefox/68.0a1/releasenotes/
	- http://localhost:8000/en-US/firefox/pocket/
	- http://localhost:8000/en-US/firefox/download/thanks/
	- http://localhost:8000/en-US/firefox/accounts/

I would be good to have a look to see if I missed any pages.