### PR TITLE
Bug 1542992 - Get distribution link with the correct attribute name

### DIFF
--- a/media/js/base/mozilla-utils.js
+++ b/media/js/base/mozilla-utils.js
@@ -35,11 +35,11 @@ if (typeof Mozilla === 'undefined') {
         var links = document.querySelectorAll('a[data-' + distribution + '-link]');
         var images = document.querySelectorAll('img[data-' + distribution + '-link]');
         for (var i = 0; i < links.length; i++) {
-            var distributionLink = links[i].getAttribute('data-' + distribution + '-' + 'Link');
+            var distributionLink = links[i].getAttribute('data-' + distribution + '-link');
             links[i].setAttribute('href', distributionLink);
         }
         for (var j = 0; j < images.length; j++) {
-            var distributionSrc = images[j].getAttribute('data-' + distribution + 'Link');
+            var distributionSrc = images[j].getAttribute('data-' + distribution + '-link');
             images[j].setAttribute('src', distributionSrc);
         }
     };


### PR DESCRIPTION
## Description
Alternative QR Code for Fx China repack was introduced in #5260, and it's currently broken.

## Issue / Bugzilla link
https://bugzilla.mozilla.org/1542992

## Testing
* Setup UITour permission for test [1]
* Set "distribution.id" with Services.prefs.getDefaultBranch("distribution.").setCharPref("id", "MozillaOnline"); in Firefox's browser console.
* Visit /firefox/mobile/, the QR code shown should link to https://www.firefox.com.cn/mobile/qrcode-redirect/

[1]: https://bedrock.readthedocs.io/en/latest/uitour.html#local-development