### PR TITLE
Link to code of conduct from readme and contributing docs

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -12,9 +12,8 @@ code-review experience.
 Code of Conduct
 ---------------
 
-This repository is governed by Mozilla's code of conduct and etiquette guidelines.
-For more details please see the [Mozilla Community Participation Guidelines][participation]
+This repository is governed by Mozilla's [Community Participation Guidelines][participation]
 and [Developer Etiquette Guidelines][etiquette].
 
-[participation]: https://www.mozilla.org/about/governance/policies/participation/
+[participation]: https://github.com/mozilla/bedrock/blob/master/CODE_OF_CONDUCT.md
 [etiquette]: https://bugzilla.mozilla.org/page.cgi?id=etiquette.html

--- a/README.md
+++ b/README.md
@@ -36,11 +36,10 @@ list of mentored bugs.
 Code of Conduct
 ---------------
 
-This repository is governed by Mozilla's code of conduct and etiquette guidelines.
-For more details, please see the [Mozilla Community Participation Guidelines][participation]
+This repository is governed by Mozilla's [Community Participation Guidelines][participation]
 and [Developer Etiquette Guidelines][etiquette].
 
-[participation]: https://www.mozilla.org/about/governance/policies/participation/
+[participation]: https://github.com/mozilla/bedrock/blob/master/CODE_OF_CONDUCT.md
 [etiquette]: https://bugzilla.mozilla.org/page.cgi?id=etiquette.html
 
 License


### PR DESCRIPTION
GitHub suggests that we should be linking to the new `CODE_Of_CONDUCT.md` file from our readme and contributing markdown docs:

![image](https://user-images.githubusercontent.com/400117/56023362-948d0400-5d05-11e9-96e1-e6d52e698791.png)

