### PR TITLE
Update browser comparison pages for auto-play blocking in Firefox (Fixes #6536)

### DIFF
--- a/bedrock/firefox/templates/firefox/campaign/compare/scene1-edge.html
+++ b/bedrock/firefox/templates/firefox/campaign/compare/scene1-edge.html
@@ -49,7 +49,7 @@
       </tr>
       <tr class="c-compare-last">
         <th scope="row">{{ _('Autoplay blocking') }}</th>
-        <td class="c-compare-highlight"><img src="{{ static('img/firefox/new/compare/table/icon-no.svg') }}" width="17" height="20" alt="{{ _('No') }}" title="{{ _('No') }}"></td>
+        <td class="c-compare-highlight"><img src="{{ static('img/firefox/new/compare/table/icon-yes.svg') }}" width="22" height="20" alt="{{ _('Yes') }}" title="{{ _('Yes') }}"></td>
         <td><img src="{{ static('img/firefox/new/compare/table/icon-no.svg') }}" width="17" height="20" alt="{{ _('No') }}" title="{{ _('No') }}"></td>
       </tr>
     </tbody>

--- a/bedrock/firefox/templates/firefox/campaign/compare/scene1-safari.html
+++ b/bedrock/firefox/templates/firefox/campaign/compare/scene1-safari.html
@@ -46,7 +46,7 @@
       </tr>
       <tr class="c-compare-last">
         <th scope="row">{{ _('Autoplay blocking') }}</th>
-        <td class="c-compare-highlight"><img src="{{ static('img/firefox/new/compare/table/icon-no.svg') }}" width="17" height="20" alt="{{ _('No') }}" title="{{ _('No') }}"></td>
+        <td class="c-compare-highlight"><img src="{{ static('img/firefox/new/compare/table/icon-yes.svg') }}" width="22" height="20" alt="{{ _('Yes') }}" title="{{ _('Yes') }}"></td>
         <td><img src="{{ static('img/firefox/new/compare/table/icon-yes.svg') }}" width="22" height="20" alt="{{ _('Yes') }}" title="{{ _('Yes') }}"></td>
       </tr>
     </tbody>


### PR DESCRIPTION
## Description
- Updates `/en-US/firefox/campaign/?xv=safari` and `/en-US/firefox/campaign/?xv=edge`

## Issue / Bugzilla link
#6536

## Testing
- [ ] Firefox should have a green checkmark for autoplay blocking on both pages.