### PR TITLE
Show whatsnew pages for Beta and Dev Edition (Fixes #7044, #7043)

### DIFF
--- a/bedrock/firefox/templates/firefox/developer/whatsnew-fx68.html
+++ b/bedrock/firefox/templates/firefox/developer/whatsnew-fx68.html
@@ -1,0 +1,35 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+
+{% add_lang_files "firefox/whatsnew_66" %}
+
+{% extends "firefox/whatsnew/whatsnew-fx66.html" %}
+
+{% block fxa_form %}
+{{ fxa_email_form(
+    entrypoint='mozilla.org-whatsnew68a2',
+    button_class='mzp-c-button',
+    utm_source='whatsnew',
+    utm_params={'campaign': 'fxa-embedded-form', 'content': 'whatsnew', 'medium': 'referral'})
+}}
+{% endblock %}
+
+{% block fxa_cta %}
+<p class="show-fxa-supported-signed-out show-fxa-default">
+  <a {{ fxa_link_fragment(entrypoint='mozilla.org-whatsnew68a2', action='signup', utm_params={'campaign': 'wnp68a2', 'content': 'accounts-page-top-cta', 'medium': 'referral', 'source': 'wnp68a2'}) }} class="mzp-c-button mzp-t-product" data-button-name="Create account" data-link-type="button">
+    {{ _('Create a Firefox Account') }}
+  </a><br>
+
+  {% if l10n_has_tag('wnp66_log_in') %}
+  {% set link = fxa_link_fragment(entrypoint='mozilla.org-whatsnew68a2', action='login', utm_params={'campaign': 'wnp68a2', 'content': 'accounts-page-top-cta', 'medium': 'referral', 'source': 'wnp68a2'}) %}
+  <span class="wn64-signin">
+    {{ _('Have an account? <a %s >Log in</a>')|format(link) }}
+  </span>
+  {% else %}
+  <span class="wn64-signin">
+    <a {{ fxa_link_fragment(entrypoint='mozilla.org-whatsnew68a2', action='login', utm_params={'campaign': 'wnp68a2', 'content': 'accounts-page-top-cta', 'medium': 'referral', 'source': 'wnp68a2'}) }}>{{ _('Already have an account?') }}</a>
+  </span>
+  {% endif %}
+</p>
+{% endblock %}

--- a/bedrock/firefox/templates/firefox/whatsnew/beta/whatsnew-fx68.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/beta/whatsnew-fx68.html
@@ -1,0 +1,35 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+
+{% add_lang_files "firefox/whatsnew_66" %}
+
+{% extends "firefox/whatsnew/whatsnew-fx66.html" %}
+
+{% block fxa_form %}
+{{ fxa_email_form(
+    entrypoint='mozilla.org-whatsnew68beta',
+    button_class='mzp-c-button',
+    utm_source='whatsnew',
+    utm_params={'campaign': 'fxa-embedded-form', 'content': 'whatsnew', 'medium': 'referral'})
+}}
+{% endblock %}
+
+{% block fxa_cta %}
+<p class="show-fxa-supported-signed-out show-fxa-default">
+  <a {{ fxa_link_fragment(entrypoint='mozilla.org-whatsnew68beta', action='signup', utm_params={'campaign': 'wnp68beta', 'content': 'accounts-page-top-cta', 'medium': 'referral', 'source': 'wnp68beta'}) }} class="mzp-c-button mzp-t-product" data-button-name="Create account" data-link-type="button">
+    {{ _('Create a Firefox Account') }}
+  </a><br>
+
+  {% if l10n_has_tag('wnp66_log_in') %}
+  {% set link = fxa_link_fragment(entrypoint='mozilla.org-whatsnew68beta', action='login', utm_params={'campaign': 'wnp68beta', 'content': 'accounts-page-top-cta', 'medium': 'referral', 'source': 'wnp68beta'}) %}
+  <span class="wn64-signin">
+    {{ _('Have an account? <a %s >Log in</a>')|format(link) }}
+  </span>
+  {% else %}
+  <span class="wn64-signin">
+    <a {{ fxa_link_fragment(entrypoint='mozilla.org-whatsnew68beta', action='login', utm_params={'campaign': 'wnp68beta', 'content': 'accounts-page-top-cta', 'medium': 'referral', 'source': 'wnp68beta'}) }}>{{ _('Already have an account?') }}</a>
+  </span>
+  {% endif %}
+</p>
+{% endblock %}

--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx66.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx66.html
@@ -44,12 +44,14 @@
             <h2 class="c-sticky-signup-title">{{ _('Get a Firefox Account and all the benefits it unlocks. ') }}</h2>
             <button type="button" class="sticky-dismiss" data-parent="fxa-sticky-form">{{ _('Close') }}</button>
           </div>
+          {% block fxa_form %}
           {{ fxa_email_form(
               entrypoint='mozilla.org-whatsnew66',
               button_class='mzp-c-button',
               utm_source='whatsnew',
               utm_params={'campaign': 'fxa-embedded-form', 'content': 'whatsnew', 'medium': 'referral'})
           }}
+          {% endblock %}
         </div>
       </div>
     </section>
@@ -84,6 +86,7 @@
     include_cta=True
   ) %}
 
+  {% block fxa_cta %}
   <p class="show-fxa-supported-signed-out show-fxa-default">
     <a {{ fxa_link_fragment(entrypoint='mozilla.org-whatsnew66', action='signup', utm_params={'campaign': 'wnp66', 'content': 'accounts-page-top-cta', 'medium': 'referral', 'source': 'wnp66'}) }} class="mzp-c-button mzp-t-product" data-button-name="Create account" data-link-type="button">
       {{ _('Create a Firefox Account') }}
@@ -100,6 +103,7 @@
     </span>
     {% endif %}
   </p>
+  {% endblock %}
 
   {% endcall %}
   {% call hero(

--- a/bedrock/firefox/tests/test_base.py
+++ b/bedrock/firefox/tests/test_base.py
@@ -184,6 +184,40 @@ class TestWhatsNew(TestCase):
         self.view = fx_views.WhatsnewView.as_view()
         self.rf = RequestFactory(HTTP_USER_AGENT='Firefox')
 
+    # begin nightly whatsnew tests
+
+    @override_settings(DEV=True)
+    def test_fx_nightly_68_0_a1_whatsnew(self, render_mock):
+        """Should show nightly whatsnew template"""
+        req = self.rf.get('/en-US/firefox/whatsnew/')
+        self.view(req, version='68.0a1')
+        template = render_mock.call_args[0][1]
+        eq_(template, ['firefox/nightly_whatsnew.html'])
+
+    # end nightly whatsnew tests
+
+    # begin beta whatsnew tests
+
+    @override_settings(DEV=True)
+    def test_fx_beta_whatsnew(self, render_mock):
+        """Should show beta whatsnew template"""
+        req = self.rf.get('/en-US/firefox/whatsnew/')
+        self.view(req, version='67.0beta')
+        template = render_mock.call_args[0][1]
+        eq_(template, ['firefox/whatsnew/index.html'])
+
+    @override_settings(DEV=True)
+    def test_fx_beta_68_0_beta_whatsnew(self, render_mock):
+        """Should show beta 68 whatsnew template"""
+        req = self.rf.get('/en-US/firefox/whatsnew/')
+        self.view(req, version='68.0beta')
+        template = render_mock.call_args[0][1]
+        eq_(template, ['firefox/whatsnew/beta/whatsnew-fx68.html'])
+
+    # end beta whatsnew tests
+
+    # begin dev edition whatsnew tests
+
     @override_settings(DEV=True)
     def test_fx_dev_browser_35_0_a2_whatsnew(self, render_mock):
         """Should show dev browser whatsnew template"""
@@ -191,6 +225,34 @@ class TestWhatsNew(TestCase):
         self.view(req, version='35.0a2')
         template = render_mock.call_args[0][1]
         eq_(template, ['firefox/dev-whatsnew.html'])
+
+    @override_settings(DEV=True)
+    def test_fx_dev_browser_57_0_a2_whatsnew(self, render_mock):
+        """Should show dev browser 57 whatsnew template"""
+        req = self.rf.get('/en-US/firefox/whatsnew/')
+        self.view(req, version='57.0a2')
+        template = render_mock.call_args[0][1]
+        eq_(template, ['firefox/developer/whatsnew.html'])
+
+    @override_settings(DEV=True)
+    @patch.dict(os.environ, SWITCH_DEV_WHATSNEW_68='True')
+    def test_fx_dev_browser_68_0_a2_whatsnew_on(self, render_mock):
+        """Should show dev browser 68 whatsnew template"""
+        req = self.rf.get('/en-US/firefox/whatsnew/')
+        self.view(req, version='68.0a2')
+        template = render_mock.call_args[0][1]
+        eq_(template, ['firefox/developer/whatsnew-fx68.html'])
+
+    @override_settings(DEV=True)
+    @patch.dict(os.environ, SWITCH_DEV_WHATSNEW_68='False')
+    def test_fx_dev_browser_68_0_a2_whatsnew_off(self, render_mock):
+        """Should show regular dev browser whatsnew template"""
+        req = self.rf.get('/en-US/firefox/whatsnew/')
+        self.view(req, version='68.0a2')
+        template = render_mock.call_args[0][1]
+        eq_(template, ['firefox/developer/whatsnew.html'])
+
+    # end dev edition whatsnew tests
 
     @override_settings(DEV=True)
     def test_rv_prefix(self, render_mock):

--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -305,6 +305,8 @@ def detect_channel(version):
                 return 'nightly'
             if version.endswith('a2'):
                 return 'alpha'
+            if version.endswith('beta'):
+                return 'beta'
 
     return 'unknown'
 
@@ -459,13 +461,21 @@ class WhatsnewView(l10n_utils.LangFilesMixin, TemplateView):
             oldversion = oldversion[3:]
 
         channel = detect_channel(version)
-        if channel == 'alpha':
-            if show_57_dev_whatsnew(version):
+
+        if channel == 'nightly':
+            template = 'firefox/nightly_whatsnew.html'
+        elif channel == 'alpha':
+            if version.startswith('68.') and switch('dev_whatsnew_68'):
+                template = 'firefox/developer/whatsnew-fx68.html'
+            elif show_57_dev_whatsnew(version):
                 template = 'firefox/developer/whatsnew.html'
             else:
                 template = 'firefox/dev-whatsnew.html'
-        elif channel == 'nightly':
-            template = 'firefox/nightly_whatsnew.html'
+        elif channel == 'beta':
+            if version.startswith('68.'):
+                template = 'firefox/whatsnew/beta/whatsnew-fx68.html'
+            else:
+                template = 'firefox/whatsnew/index.html'
         elif locale == 'id':
             template = 'firefox/whatsnew/index-lite.id.html'
         elif locale == 'zh-TW' and not version.startswith('64.'):


### PR DESCRIPTION
## Description
- Repurposes `/firefox/66.0/whatsnew/` for dev edition at `/firefox/68.0a2/whatsnew/` and for beta at `/firefox/68.0beta/whatsnew/`.
- There are no string changes, so this is reusing `firefox/whatsnew_66.lang`.
- Updates Firefox Accounts tracking parameters, so that we can tell how many accounts this page creates in the beta/developer channels.
- Dev Edition page is behind a switch, falling back to regular dev edition page (as we may only want to show this once to devs).

## Issue / Bugzilla link
#7043

## Testing
- [ ] Templates should still look & function as expected at both the existing and new URLs.