### PR TITLE
Tighten up spacing on release notes

### DIFF
--- a/bedrock/firefox/templates/firefox/releases/notes.html
+++ b/bedrock/firefox/templates/firefox/releases/notes.html
@@ -170,7 +170,7 @@
     </header>
   {% endblock %}
 
-    <section>
+    <section class="c-release-notes">
     {% if release.is_public and release.notes %}
       {% for note in release.notes if note.tag == "New" %}
         {% if loop.first %}

--- a/media/css/firefox/releasenotes.scss
+++ b/media/css/firefox/releasenotes.scss
@@ -143,12 +143,6 @@ $image-path: '/media/protocol/img';
     @include text-body-md;
 }
 
-.c-release-first-text{
-    border-bottom: 2px solid $color-gray-40;
-    margin-bottom: $layout-md;
-    padding-bottom: $layout-md;
-}
-
 .mzp-l-content {
     .c-release-product {
         @include text-display-xs;
@@ -173,18 +167,53 @@ $image-path: '/media/protocol/img';
 
     h3 {
         @include text-display-sm;
+        margin-bottom: $layout-sm;
     }
 }
 
+.c-release-notes > .mzp-l-content {
+    padding-top: $layout-lg;
+
+    &:before {
+        content: '';
+        display: block;
+        width: calc(100% - #{ $layout-xs * 2});
+        height: 2px;
+        background-color: $color-gray-20;
+        position: absolute;
+        top: 0;
+        left: $layout-xs;
+
+        @media #{$mq-md} {
+            left: $layout-lg;
+            width: calc(100% - #{ $layout-lg * 2});
+        }
+
+        @media #{$mq-lg} {
+            left: $layout-xl;
+            width: calc(100% - #{ $layout-xl * 2});
+        }
+    }
+}
 
 .mzp-l-article {
     > ul > li {
         border-bottom: 2px solid $color-gray-20;
-        margin-bottom: $layout-md;
-        padding-bottom: $layout-md;
+        margin-bottom: $layout-sm;
+        padding-bottom: $layout-sm;
 
         &:last-child {
-            border-bottom-color: $color-gray-40;
+            border-bottom: none;
+            margin-bottom: 0;
+            padding-bottom: 0;
+        }
+
+        > ul,
+        > ol,
+        > p {
+            &:last-child {
+                margin-bottom: 0;
+            }
         }
 
         p + ul,
@@ -281,7 +310,7 @@ $image-path: '/media/protocol/img';
 .bug-id {
     @include bidi(((text-align, right, left),));
     display: block;
-    margin-bottom: 1.25em;
+    margin-bottom: 0;
 
     p + &,
     ul + & {
@@ -295,7 +324,9 @@ $image-path: '/media/protocol/img';
     padding-bottom: $layout-md;
 
     &:last-child {
-        border-bottom-color: $color-gray-40;
+        border-bottom: none;
+        margin-bottom: 0;
+        padding-bottom: 0;
     }
 }
 
@@ -338,6 +369,10 @@ $image-path: '/media/protocol/img';
 
 /* -------------------------------------------------------------------------- */
 // Compact call out
+
+.mzp-c-call-out-compact {
+    margin-top: $layout-md;
+}
 
 /* nightly footer gradient */
 .mzp-c-call-out-compact.mzp-t-product-nightly {


### PR DESCRIPTION
## Description

Tighten up spacing on the release notes pages.

## Issue / Bugzilla link

Fix #7070

## Testing
Sample pages for testing
- http://localhost:8000/en-US/firefox/66.0/releasenotes/
- http://localhost:8000/en-US/firefox/65.0/releasenotes/
- http://localhost:8000/en-US/firefox/55.0/releasenotes/
- http://localhost:8000/en-US/firefox/35.0/releasenotes/
- http://localhost:8000/en-US/firefox/52.7.1/releasenotes/
- http://localhost:8000/en-US/firefox/67.0a1/releasenotes/
- http://localhost:8000/en-US/firefox/android/60.0.2/releasenotes/