### PR TITLE
Remove estimates table from sprint task template

### DIFF
--- a/.github/ISSUE_TEMPLATE/sprint_task.md
+++ b/.github/ISSUE_TEMPLATE/sprint_task.md
@@ -7,18 +7,6 @@ about: For project work and feature development
 
 Description, good enough that reading the card 1 month from now, you still know what it means.
 
-### Estimates
-
-| Estimates |  |
-| ------------- | ------------- |
-| TL | |
-| PM | |
-| ENG | |
-| SEO | |
-| ANA | |
-| DES | |
-| COPY | |
-
 ---
 
 #### :yellow_heart: Success Criteria :yellow_heart:


### PR DESCRIPTION
## Description
- We're using Zenhub for estimates now, so there's no need to keep this in the existing issue template.

## Issue / Bugzilla link
N/A
