### PR TITLE
Remove en conditional on FxA button in global navigation (Fixes #7080)

### DIFF
--- a/bedrock/base/templates/includes/protocol/navigation/index.html
+++ b/bedrock/base/templates/includes/protocol/navigation/index.html
@@ -24,14 +24,12 @@
         {% if not hide_nav_download_button %}
         <div class="mzp-c-navigation-download">
           {{ download_firefox(alt_copy=_('Download Firefox'), dom_id='protocol-nav-download-firefox', button_color='mzp-t-secondary mzp-t-small', download_location='nav') }}
-          {% if LANG.startswith('en-') %}
-            <div class="c-navigation-fxa-cta-container">
-              <a class="c-navigation-fxa-cta mzp-c-button mzp-t-secondary mzp-t-small mzp-t-product" {{ fxa_link_fragment(entrypoint='mozilla.org-globalnav', action='signup', utm_params={'campaign': 'globalnav', 'content': 'get-firefox-account', 'medium': 'referral', 'source': 'www.mozilla.org'}) }} data-button-name="Get a Firefox Account" data-link-type="button" data-cta-position="secondary cta" data-alt-href="{{ url('firefox.accounts') }}">
-                {{ _('Get a Firefox Account') }}
-              </a>
-              <p class="c-navigation-fxa-cta-small-link"><a data-link-type="nav" data-link-name="Check out the Benefits" href="{{ url('firefox.accounts') }}">{{ _('Check out the Benefits') }}</a></p>
-            </div>
-          {% endif %}
+          <div class="c-navigation-fxa-cta-container">
+            <a class="c-navigation-fxa-cta mzp-c-button mzp-t-secondary mzp-t-small mzp-t-product" {{ fxa_link_fragment(entrypoint='mozilla.org-globalnav', action='signup', utm_params={'campaign': 'globalnav', 'content': 'get-firefox-account', 'medium': 'referral', 'source': 'www.mozilla.org'}) }} data-button-name="Get a Firefox Account" data-link-type="button" data-cta-position="secondary cta" data-alt-href="{{ url('firefox.accounts') }}">
+              {{ _('Get a Firefox Account') }}
+            </a>
+            <p class="c-navigation-fxa-cta-small-link"><a data-link-type="nav" data-link-name="Check out the Benefits" href="{{ url('firefox.accounts') }}">{{ _('Check out the Benefits') }}</a></p>
+          </div>
         </div>
         {% endif %}
         <div class="mzp-c-navigation-menu">


### PR DESCRIPTION
## Description
- Removes `en` conditional on showing the FxA CTA in the global navigation, shown to existing Firefox users.

## Issue / Bugzilla link
#7080

## Testing
- [ ] Button should be visible for all locales.