### PR TITLE
Bug 1542118 - Unify Bengali as 'bn', remove obsolete locales

### DIFF
--- a/bedrock/base/templatetags/helpers.py
+++ b/bedrock/base/templatetags/helpers.py
@@ -45,7 +45,7 @@ def switch(cxt, name, locales=None):
 
     If the `locales` argument is a list of locales then it will only check the switch in those
     locales, and return False otherwise. The `locales` argument could also contain a "locale group",
-    which is a list of locales for a prefix (e.g. "en" expands to "en-US, en-GB, en-ZA").
+    which is a list of locales for a prefix (e.g. "en" expands to "en-US, en-GB").
     """
     if locales:
         if cxt['LANG'] not in expand_locale_groups(locales):

--- a/bedrock/base/tests/test_settings.py
+++ b/bedrock/base/tests/test_settings.py
@@ -5,10 +5,10 @@ from django.test import override_settings
 
 
 @override_settings(DEV=False, PROD_LANGUAGES=('de', 'fr', 'nb-NO', 'ja', 'ja-JP-mac',
-                                              'en-US', 'en-ZA'))
+                                              'en-US', 'en-GB'))
 def test_lang_groups():
     # should not contain 'nb' and 'ja' group should contain 'ja'
     assert dict(settings.LANG_GROUPS) == {
         'ja': ['ja-JP-mac', 'ja'],
-        'en': ['en-US', 'en-ZA'],
+        'en': ['en-US', 'en-GB'],
     }

--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -434,7 +434,6 @@ class WhatsnewView(l10n_utils.LangFilesMixin, TemplateView):
                 'en-US',
                 'en-GB',
                 'en-CA',
-                'en-ZA',
                 'es-ES',
                 'es-AR',
                 'es-CL',
@@ -545,7 +544,7 @@ def download_thanks(request):
     variant = request.GET.get('v', None)
     signup = request.GET.get('s', None)
     newsletter = request.GET.get('n', None)
-    show_newsletter = locale in ['en-US', 'en-GB', 'en-CA', 'en-ZA', 'es-ES', 'es-AR', 'es-CL', 'es-MX', 'pt-BR', 'fr', 'ru', 'id', 'de', 'pl']
+    show_newsletter = locale in ['en-US', 'en-GB', 'en-CA', 'es-ES', 'es-AR', 'es-CL', 'es-MX', 'pt-BR', 'fr', 'ru', 'id', 'de', 'pl']
 
     # ensure variant matches pre-defined value
     if variant not in ['a', 'b', 'c', 'd', 'e']:  # place expected ?v= values in this list

--- a/bedrock/settings/appstores.py
+++ b/bedrock/settings/appstores.py
@@ -83,7 +83,6 @@ APPLE_APPSTORE_COUNTRY_MAP = {
     'en-US': 'us',  # United States
     'uz': 'uz',     # Uzbekistan
     'vi': 'vt',     # Vietnam
-    'en-ZA': 'za',  # South Africa
 }
 
 # Link to Firefox Focus for iOS on the Apple App Store via app.adjust.

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -113,16 +113,16 @@ if Path(PROD_DETAILS_TEST_DIR).is_dir():
     PROD_DETAILS_DIR = PROD_DETAILS_TEST_DIR
 
 # Accepted locales
-PROD_LANGUAGES = ('ach', 'af', 'an', 'ar', 'as', 'ast', 'az', 'azz', 'be', 'bg',
-                  'bn-BD', 'bn-IN', 'br', 'bs', 'ca', 'cak', 'cs',
+PROD_LANGUAGES = ('ach', 'af', 'an', 'ar', 'ast', 'az', 'azz', 'be', 'bg',
+                  'bn', 'br', 'bs', 'ca', 'cak', 'cs',
                   'cy', 'da', 'de', 'dsb', 'el', 'en-CA', 'en-GB', 'en-US',
-                  'en-ZA', 'eo', 'es-AR', 'es-CL', 'es-ES', 'es-MX', 'et',
+                  'eo', 'es-AR', 'es-CL', 'es-ES', 'es-MX', 'et',
                   'eu', 'fa', 'ff', 'fi', 'fr', 'fy-NL', 'ga-IE', 'gd',
                   'gl', 'gn', 'gu-IN', 'he', 'hi-IN', 'hr', 'hsb',
                   'hu', 'hy-AM', 'ia', 'id', 'is', 'it', 'ja', 'ja-JP-mac',
                   'ka', 'kab', 'kk', 'km', 'kn', 'ko', 'lij', 'lt', 'ltg', 'lv',
-                  'mai', 'mk', 'ml', 'mr', 'ms', 'my', 'nb-NO', 'ne-NP', 'nl',
-                  'nn-NO', 'oc', 'or', 'pa-IN', 'pl', 'pt-BR', 'pt-PT',
+                  'mk', 'ml', 'mr', 'ms', 'my', 'nb-NO', 'ne-NP', 'nl',
+                  'nn-NO', 'oc', 'pa-IN', 'pl', 'pt-BR', 'pt-PT',
                   'rm', 'ro', 'ru', 'si', 'sk', 'sl', 'son', 'sq',
                   'sr', 'sv-SE', 'ta', 'te', 'th', 'tl', 'tr', 'trs', 'uk', 'ur',
                   'uz', 'vi', 'xh', 'zh-CN', 'zh-TW', 'zu')
@@ -755,6 +755,12 @@ DONATE_PARAMS = {
         'presets': '34,17,8,5',
         'default': '17'
     },
+    'bn': {
+        'currency': 'bdt',
+        'symbol': u'৳',
+        'presets': '1700,840,420,250',
+        'default': '840'
+    },
     'bn-BD': {
         'currency': 'bdt',
         'symbol': u'৳',
@@ -1208,7 +1214,7 @@ from .appstores import (GOOGLE_PLAY_FIREFOX_LINK,  # noqa
                         APPLE_APPSTORE_FIREFOX_FOCUS_LINK, GOOGLE_PLAY_FIREFOX_FOCUS_LINK)
 
 # Locales that should display the 'Send to Device' widget
-SEND_TO_DEVICE_LOCALES = ['de', 'en-GB', 'en-US', 'en-ZA',
+SEND_TO_DEVICE_LOCALES = ['de', 'en-GB', 'en-US',
                           'es-AR', 'es-CL', 'es-ES', 'es-MX',
                           'fr', 'id', 'pl', 'pt-BR', 'ru', 'zh-TW']
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -240,7 +240,7 @@ environment variable ``SWITCH_THE_DUDE``. If the value of that variable is any o
 You can also supply a list of locale codes that will be the only ones for which the switch is active.
 If the page is viewed in any other locale the switch will always return ``False``, even in ``DEV``
 mode. This list can also include a "Locale Group", which is all locales with a common prefix
-(e.g. "en-US, en-GB, en-ZA" or "zh-CN, zh-TW"). You specify these with just the prefix. So if you
+(e.g. "en-US, en-GB" or "zh-CN, zh-TW"). You specify these with just the prefix. So if you
 used ``switch('the-dude', ['en', 'de'])`` in a template, the switch would be active for German and
 any English locale the site supports.
 

--- a/tests/redirects/map_locales.py
+++ b/tests/redirects/map_locales.py
@@ -6,7 +6,7 @@ from .base import flatten, url_test
 
 # supported locales
 LOCALES = [
-    'ar', 'ast', 'bg', 'bn-IN', 'ca', 'cs', 'de', 'dsb', 'el', 'en-GB',
+    'ar', 'ast', 'bg', 'ca', 'cs', 'de', 'dsb', 'el', 'en-GB',
     'en-US', 'es-CL', 'es-ES', 'fr', 'fy-NL', 'gd', 'it', 'ja', 'ko', 'nl',
     'pt-BR', 'pt-PT', 'ru', 'son', 'sv-SE', 'ta', 'tr', 'uk', 'zh-CN', 'zh-TW']
 


### PR DESCRIPTION
Locales removed:
* bn-BD, bn-IN (now 'bn')
* as, en-ZA, mai, or

Also removed references to en-ZA from code.