### PR TITLE
Localize Firefox platform-specific download pages (#7056, #7057, #7058)

### DIFF
--- a/bedrock/firefox/templates/firefox/new/scene1_linux.html
+++ b/bedrock/firefox/templates/firefox/new/scene1_linux.html
@@ -2,47 +2,106 @@
  # License, v. 2.0. If a copy of the MPL was not distributed with this
  # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
 
+{% add_lang_files "firefox/new/quantum" %}
+
 {% extends "firefox/new/scene1.html" %}
 
-{% block page_title_full %}{{_('Download Mozilla Firefox for Linux')}}{{_(' — Free Web Browser')}}{%- endblock -%}
+{% block page_title_full %}
+  {% if l10n_has_tag('platform_strings_04232019') %}
+    {# L10n: /firefox/linux/ HTML page title #}
+    {{_('Download Mozilla Firefox for Linux')}} - {{_('Free Web Browser')}}
+  {% else %}
+    {{_('Download Firefox')}} - {{_('Free Web Browser')}}
+  {% endif %}
+{%- endblock -%}
 {% block page_title_suffix %}{% endblock %}
 
 {% block page_desc %}
-  {{ _('Download Mozilla Firefox for Linux, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Linux today!') }}
+  {% if l10n_has_tag('platform_strings_04232019') %}
+    {# L10n: /firefox/linux/ HTML page description #}
+    {{ _('Download Mozilla Firefox for Linux, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Linux today!') }}
+  {% else %}
+    {{_('Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!')}}
+  {% endif %}
 {% endblock %}
 
 {#- This will appear as <meta property="og:title"> which can be used for social share -#}
-{% block page_og_title %}{{_('Download the fastest Firefox for Linux ever')}}{% endblock %}
+{% block page_og_title %}
+  {% if l10n_has_tag('platform_strings_04232019') %}
+    {# L10n: /firefox/linux/ social sharing title #}
+    {{_('Download the fastest Firefox for Linux ever')}}
+  {% else %}
+    {{_('Download the fastest Firefox ever')}}
+  {% endif %}
+{% endblock %}
 
 {#- This will appear as <meta property="og:description"> which can be used for social share -#}
-{% block page_og_desc %}{{_('Faster page loading, less memory usage and packed with features, the new Firefox for Linux is here.')}}{% endblock %}
+{% block page_og_desc %}
+  {% if l10n_has_tag('platform_strings_04232019') %}
+    {# L10n: /firefox/linux/ social sharing description #}
+    {{_('Faster page loading, less memory usage and packed with features, the new Firefox for Linux is here.')}}
+  {% else %}
+    {{_('Faster page loading, less memory usage and packed with features, the new Firefox is here.')}}
+  {% endif %}
+{% endblock %}
 
 {% block experiments %}{% endblock %}
 
 {% block main_title %}
 <header>
+{% if l10n_has_tag('platform_strings_04232019') %}
+  {# L10n: /firefox/linux/ main page title. #}
   <h1>{{ _('Firefox for Linux') }}</h1>
   <h2>{{ _('Own your online life.') }}</h2>
+{% else %}
+  <h1>{{ _('The new <strong>Firefox</strong>') }}</h1>
+  <h2>{{ _('Fast for good.') }}</h2>
+{% endif %}
 </header>
 {% endblock %}
 
 {% block features_content %}
-<div class="features">
-  <div class="content">
-    <ul>
-      <li class="private">
-        <h3>{{_('Privacy - more than a policy') }}</h3>
-        <p>{{_('Your life, your business. Firefox blocks third-party tracking cookies on Linux.') }}</p>
-      </li>
-      <li class="faster">
-        <h3>{{_('2X Faster') }}</h3>
-        <p>{{_('Speed, meet security. Firefox is two times faster with 30% less memory than Chrome.') }}</p>
-      </li>
-      <li class="open-source">
-        <h3>{{_('Open source') }}</h3>
-        <p>{{_('Look under the hood. Like Linux, Firefox features are open source.') }}</p>
-      </li>
-    </ul>
+{% if l10n_has_tag('platform_strings_04232019') %}
+  <div class="features">
+    <div class="content">
+      <ul>
+        <li class="private">
+          <h3>{{_('Privacy - more than a policy') }}</h3>
+          <p>{{_('Your life, your business. Firefox blocks third-party tracking cookies on Linux.') }}</p>
+        </li>
+        <li class="faster">
+          <h3>{{_('2x Faster') }}</h3>
+          <p>{{_('Speed, meet security. Firefox is two times faster with 30% less memory than Chrome.') }}</p>
+        </li>
+        <li class="open-source">
+          <h3>{{_('Open source') }}</h3>
+          <p>{{_('Look under the hood. Like Linux, Firefox features are open source.') }}</p>
+        </li>
+      </ul>
+    </div>
   </div>
-</div>
+{% else %}
+  <div class="features">
+    <div class="content">
+      <ul>
+        <li class="faster">
+          <h3>{{_('2x Faster') }}</h3>
+          <p>{{_('The best Firefox ever') }}</p>
+        </li>
+        <li class="lighter">
+          <h3>{{_('Lightweight') }}</h3>
+          <p>{{_('Uses 30% less memory than Chrome') }}</p>
+        </li>
+        <li class="private">
+          <h3>{{_('Powerfully private') }}</h3>
+          {% if l10n_has_tag('truly_removal_2019') %}
+            <p>{{_('Private Browsing with Tracking Protection') }}</p>
+          {% else %}
+            <p>{{_('Truly Private Browsing with Tracking Protection') }}</p>
+          {% endif %}
+        </li>
+      </ul>
+    </div>
+  </div>
+{% endif %}
 {% endblock %}

--- a/bedrock/firefox/templates/firefox/new/scene1_mac.html
+++ b/bedrock/firefox/templates/firefox/new/scene1_mac.html
@@ -2,47 +2,105 @@
  # License, v. 2.0. If a copy of the MPL was not distributed with this
  # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
 
+{% add_lang_files "firefox/new/quantum" %}
+
 {% extends "firefox/new/scene1.html" %}
 
-{% block page_title_full %}{{_('Download Mozilla Firefox for Mac')}}{{_(' — Free Web Browser')}}{%- endblock -%}
+{% block page_title_full %}
+  {% if l10n_has_tag('platform_strings_04232019') %}
+    {# L10n: /firefox/mac/ HTML page title #}
+    {{_('Download Mozilla Firefox for Mac')}} - {{_('Free Web Browser')}}
+  {% else %}
+    {{_('Download Firefox')}} - {{_('Free Web Browser')}}
+  {% endif %}
+{%- endblock -%}
 {% block page_title_suffix %}{% endblock %}
 
 {% block page_desc %}
-  {{ _('Download Mozilla Firefox for Mac, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Mac today!') }}
+  {% if l10n_has_tag('platform_strings_04232019') %}
+    {# L10n: /firefox/mac/ HTML page description #}
+    {{ _('Download Mozilla Firefox for Mac, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Mac today!') }}
+  {% else %}
+    {{_('Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!')}}
+  {% endif %}
 {% endblock %}
 
 {#- This will appear as <meta property="og:title"> which can be used for social share -#}
-{% block page_og_title %}{{_('Download the fastest Firefox for Mac ever')}}{% endblock %}
+{% block page_og_title %}
+  {% if l10n_has_tag('platform_strings_04232019') %}
+    {# L10n: /firefox/mac/ social sharing title #}
+    {{_('Download the fastest Firefox for Mac ever')}}
+  {% else %}
+    {{_('Download the fastest Firefox ever')}}
+  {% endif %}
+{% endblock %}
 
 {#- This will appear as <meta property="og:description"> which can be used for social share -#}
-{% block page_og_desc %}{{_('Faster page loading, less memory usage and packed with features, the new Firefox for Mac is here.')}}{% endblock %}
+{% block page_og_desc %}
+  {% if l10n_has_tag('platform_strings_04232019') %}
+    {# L10n: /firefox/mac/ social sharing description #}
+    {{_('Faster page loading, less memory usage and packed with features, the new Firefox for Mac is here.')}}
+  {% else %}
+    {{_('Faster page loading, less memory usage and packed with features, the new Firefox is here.')}}
+  {% endif %}
+{% endblock %}
 
 {% block experiments %}{% endblock %}
 
 {% block main_title %}
 <header>
-  {# L10n: Span is for visually formatting. #}
+{% if l10n_has_tag('platform_strings_04232019') %}
+  {# L10n: /firefox/mac/ main page title. Span is for visually formatting. #}
   <h1>{{ _('Firefox respects <span>your privacy on Mac.</span>') }}</h1>
+{% else %}
+  <h1>{{ _('The new <strong>Firefox</strong>') }}</h1>
+  <h2>{{ _('Fast for good.') }}</h2>
+{% endif %}
 </header>
 {% endblock %}
 
 {% block features_content %}
-<div class="features">
-  <div class="content">
-    <ul>
-      <li class="private">
-        <h3>{{_('Privacy comes first') }}</h3>
-        <p>{{_('Firefox doesn’t spy on searches. We stop third-party tracking cookies and give you full control.') }}</p>
-      </li>
-      <li class="faster">
-        <h3>{{_('2X Faster') }}</h3>
-        <p>{{_('Get speed and security. Firefox is fast on Mac because we don’t track your moves.') }}</p>
-      </li>
-      <li class="blocker">
-        <h3>{{_('Block trackers') }}</h3>
-        <p>{{_('Be the master of your domain with strict content blocking. Cut off all cookies and trackers.') }}</p>
-      </li>
-    </ul>
+{% if l10n_has_tag('platform_strings_04232019') %}
+  <div class="features">
+    <div class="content">
+      <ul>
+        <li class="private">
+          <h3>{{_('Privacy comes first') }}</h3>
+          <p>{{_('Firefox doesn’t spy on searches. We stop third-party tracking cookies and give you full control.') }}</p>
+        </li>
+        <li class="faster">
+          <h3>{{_('2x Faster') }}</h3>
+          <p>{{_('Get speed and security. Firefox is fast on Mac because we don’t track your moves.') }}</p>
+        </li>
+        <li class="blocker">
+          <h3>{{_('Block trackers') }}</h3>
+          <p>{{_('Be the master of your domain with strict content blocking. Cut off all cookies and trackers.') }}</p>
+        </li>
+      </ul>
+    </div>
   </div>
-</div>
+{% else %}
+  <div class="features">
+    <div class="content">
+      <ul>
+        <li class="faster">
+          <h3>{{_('2x Faster') }}</h3>
+          <p>{{_('The best Firefox ever') }}</p>
+        </li>
+        <li class="lighter">
+          <h3>{{_('Lightweight') }}</h3>
+          <p>{{_('Uses 30% less memory than Chrome') }}</p>
+        </li>
+        <li class="private">
+          <h3>{{_('Powerfully private') }}</h3>
+          {% if l10n_has_tag('truly_removal_2019') %}
+            <p>{{_('Private Browsing with Tracking Protection') }}</p>
+          {% else %}
+            <p>{{_('Truly Private Browsing with Tracking Protection') }}</p>
+          {% endif %}
+        </li>
+      </ul>
+    </div>
+  </div>
+{% endif %}
 {% endblock %}

--- a/bedrock/firefox/templates/firefox/new/scene1_windows.html
+++ b/bedrock/firefox/templates/firefox/new/scene1_windows.html
@@ -2,47 +2,105 @@
  # License, v. 2.0. If a copy of the MPL was not distributed with this
  # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
 
+{% add_lang_files "firefox/new/quantum" %}
+
 {% extends "firefox/new/scene1.html" %}
 
-{% block page_title_full %}{{_('Download Mozilla Firefox for Windows')}}{{_(' — Free Web Browser')}}{%- endblock -%}
+{% block page_title_full %}
+  {% if l10n_has_tag('platform_strings_04232019') %}
+    {# L10n: /firefox/windows/ HTML page title #}
+    {{_('Download Mozilla Firefox for Windows')}} - {{_('Free Web Browser')}}
+  {% else %}
+    {{_('Download Firefox')}} - {{_('Free Web Browser')}}
+  {% endif %}
+{%- endblock -%}
 {% block page_title_suffix %}{% endblock %}
 
 {% block page_desc %}
-  {{ _('Download Mozilla Firefox for Windows, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows today!') }}
+  {% if l10n_has_tag('platform_strings_04232019') %}
+    {# L10n: /firefox/windows/ HTML page description #}
+    {{ _('Download Mozilla Firefox for Windows, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows today!') }}
+  {% else %}
+    {{_('Download Mozilla Firefox, a free Web browser. Firefox is created by a global non-profit dedicated to putting individuals in control online. Get Firefox for Windows, macOS, Linux, Android and iOS today!')}}
+  {% endif %}
 {% endblock %}
 
 {#- This will appear as <meta property="og:title"> which can be used for social share -#}
-{% block page_og_title %}{{_('Download the fastest Firefox for Windows ever')}}{% endblock %}
+{% block page_og_title %}
+  {% if l10n_has_tag('platform_strings_04232019') %}
+    {# L10n: /firefox/windows/ social sharing title #}
+    {{_('Download the fastest Firefox for Windows ever')}}
+  {% else %}
+    {{_('Download the fastest Firefox ever')}}
+  {% endif %}
+{% endblock %}
 
 {#- This will appear as <meta property="og:description"> which can be used for social share -#}
-{% block page_og_desc %}{{_('Faster page loading, less memory usage and packed with features, the new Firefox for Windows is here.')}}{% endblock %}
+{% block page_og_desc %}
+  {% if l10n_has_tag('platform_strings_04232019') %}
+    {# L10n: /firefox/windows/ social sharing description #}
+    {{_('Faster page loading, less memory usage and packed with features, the new Firefox for Windows is here.')}}
+  {% else %}
+    {{_('Faster page loading, less memory usage and packed with features, the new Firefox is here.')}}
+  {% endif %}
+{% endblock %}
 
 {% block experiments %}{% endblock %}
 
 {% block main_title %}
 <header>
-  {# L10n: Span is for visually formatting. #}
+{% if l10n_has_tag('platform_strings_04232019') %}
+  {# L10n: /firefox/windows/ main page title. Span is for visually formatting. #}
   <h1>{{ _('Firefox fights for you <span>on Windows.</span>') }}</h1>
+{% else %}
+  <h1>{{ _('The new <strong>Firefox</strong>') }}</h1>
+  <h2>{{ _('Fast for good.') }}</h2>
+{% endif %}
 </header>
 {% endblock %}
 
 {% block features_content %}
-<div class="features">
-  <div class="content">
-    <ul>
-      <li class="faster">
-        <h3>{{_('2X Faster') }}</h3>
-        <p>{{_('Firefox moves fast and treats your data with care - no ad tracking and no slowdown.') }}</p>
-      </li>
-      <li class="private">
-        <h3>{{_('Common sense privacy') }}</h3>
-        <p>{{_('Live your life, Firefox isn’t watching. Choose what to share and when to share it.') }}</p>
-      </li>
-      <li class="seamless">
-        <h3>{{_('Seamless setup') }}</h3>
-        <p>{{_('Easy migration of preferences and bookmarks when you download Firefox for Windows.') }}</p>
-      </li>
-    </ul>
+{% if l10n_has_tag('platform_strings_04232019') %}
+  <div class="features">
+    <div class="content">
+      <ul>
+        <li class="faster">
+          <h3>{{_('2x Faster') }}</h3>
+          <p>{{_('Firefox moves fast and treats your data with care - no ad tracking and no slowdown.') }}</p>
+        </li>
+        <li class="private">
+          <h3>{{_('Common sense privacy') }}</h3>
+          <p>{{_('Live your life, Firefox isn’t watching. Choose what to share and when to share it.') }}</p>
+        </li>
+        <li class="seamless">
+          <h3>{{_('Seamless setup') }}</h3>
+          <p>{{_('Easy migration of preferences and bookmarks when you download Firefox for Windows.') }}</p>
+        </li>
+      </ul>
+    </div>
   </div>
-</div>
+{% else %}
+  <div class="features">
+    <div class="content">
+      <ul>
+        <li class="faster">
+          <h3>{{_('2x Faster') }}</h3>
+          <p>{{_('The best Firefox ever') }}</p>
+        </li>
+        <li class="lighter">
+          <h3>{{_('Lightweight') }}</h3>
+          <p>{{_('Uses 30% less memory than Chrome') }}</p>
+        </li>
+        <li class="private">
+          <h3>{{_('Powerfully private') }}</h3>
+          {% if l10n_has_tag('truly_removal_2019') %}
+            <p>{{_('Private Browsing with Tracking Protection') }}</p>
+          {% else %}
+            <p>{{_('Truly Private Browsing with Tracking Protection') }}</p>
+          {% endif %}
+        </li>
+      </ul>
+    </div>
+  </div>
+{% endif %}
 {% endblock %}


### PR DESCRIPTION
## Description
- Exposes the strings in `/firefox/windows/`, `/firefox/mac/` and `/firefox/linux/` for localization (behind an l10n tag).
- includes `firefox/new/quantum.lang` in each template so these pages share the same strings as `/firefox/new/`.

## Issue / Bugzilla link
#7056, 
#7057, 
#7058

## Testing
- [ ] Each page should still show the new strings when `Dev=True`.
- [ ] Each page should fall back to the old strings if not translated and `Dev=False`.