### PR TITLE
Enable German locale for election page (Fixes #7099)

### DIFF
--- a/bedrock/firefox/urls.py
+++ b/bedrock/firefox/urls.py
@@ -37,7 +37,7 @@ urlpatterns = (
     page('firefox/channel/ios', 'firefox/channel/ios.html'),
     url(r'^firefox/concerts/', views.firefox_concerts, name='firefox.concerts'),
     page('firefox/developer', 'firefox/developer/index.html'),
-    url('firefox/election', views.election_with_cards, name="firefox.election"),
+    url('firefox/election', views.election_with_cards, name='firefox.election'),
     page('firefox/enterprise', 'firefox/enterprise/index.html'),
     page('firefox/enterprise/signup', 'firefox/enterprise/signup.html'),
     page('firefox/enterprise/signup/thanks', 'firefox/enterprise/signup-thanks.html'),

--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -809,7 +809,10 @@ def firefox_accounts(request):
 
 def election_with_cards(request):
     locale = l10n_utils.get_locale(request)
-    ctx = {'page_content_cards': get_page_content_cards('election-en', locale)}
+    ctx = {
+        'page_content_cards': get_page_content_cards('election-en', locale),
+        'active_locales': ['de', 'en-US']
+    }
 
     if locale == 'de':
         template_name = 'firefox/election/index-de.html'


### PR DESCRIPTION
## Description
- Sets both `de` and `en-US` as active locales for the new election page.

## Issue / Bugzilla link
Fixes #7099

## Testing
- [ ] Both locales should be viewable when `Dev=False`.