### PR TITLE
FxA validation of utm parameters (#6854)

### DIFF
--- a/bedrock/base/templates/macros.html
+++ b/bedrock/base/templates/macros.html
@@ -247,12 +247,10 @@
 
 {%- endmacro %}
 
-{% macro fxa_cta_link(button_location, id_prefix, campaign, entrypoint, button_text = '', button_class = '', content = '', source = '', action='signup', utm_params={}) %}
-<div class="show-fxa-supported-signed-out">
-  <a {{ fxa_link_fragment(entrypoint="{{ entrypoint }}", action="{{ action }}", utm_params={'campaign': campaign, 'content': (content or request.path_info), 'source': source}) }} class="js-fxa-cta-link {{ button_class }}" data-button-name="Create account" data-link-type="FxA-Sync" data-cta-position="{{ button_location }}" id="{{ account_id }}">
+{% macro fxa_cta_link(entrypoint, campaign, content, source, button_class, button_location, button_text, account_id, action='signin', utm_params={}) %}
+  <a {{ fxa_link_fragment(entrypoint=entrypoint, action="{{ action }}", utm_params={'campaign': campaign, 'content': (content or request.path_info), 'source': source}) }} class="js-fxa-cta-link {{ button_class }}" data-button-name="Create account" data-link-type="FxA-Sync" data-cta-position="{{ button_location }}" id="{{ account_id }}">
     {{ button_text }}
   </a>
-</div>
 {%- endmacro %}
 
 {% macro fxa_create_account_button(button_location, id_prefix, campaign, entrypoint, button_text = '', button_class = '', content = '', source = '') %}

--- a/bedrock/base/templates/macros.html
+++ b/bedrock/base/templates/macros.html
@@ -243,7 +243,7 @@
     {% endif %}
   {% endfor %}
 
-  href="{{ settings.FXA_ENDPOINT }}{{ fxa_path }}?service={{ service_type }}&{{ fxa_queries|join('&') }}" data-mozillaonline-link="{{ settings.FXA_ENDPOINT_MOZILLAONLINE }}{{ fxa_path }}?{{ fxa_queries|join('&') }}"
+  href="{{ settings.FXA_ENDPOINT }}{{ fxa_path }}?service={{ service_type }}&{{ fxa_queries|join('&') }}" data-mozillaonline-link="{{ settings.FXA_ENDPOINT_MOZILLAONLINE }}{{ fxa_path }}?service={{ service_type }}&{{ fxa_queries|join('&') }}"
 
 {%- endmacro %}
 

--- a/bedrock/base/templates/macros.html
+++ b/bedrock/base/templates/macros.html
@@ -225,10 +225,9 @@
   </section>
 {%- endmacro %}
 
-{% macro fxa_link_fragment(entrypoint, action='signin', utm_params={}) -%}
+{% macro fxa_link_fragment(entrypoint, service_type='sync', action='signin', utm_params={}) -%}
   {% set fxa_path = '' %}
   {% set fxa_queries = [
-    'service=sync',
     'context=fx_desktop_v3'
   ] %}
 
@@ -244,7 +243,16 @@
     {% endif %}
   {% endfor %}
 
-  href="{{ settings.FXA_ENDPOINT}}{{ fxa_path }}?{{ fxa_queries|join('&') }}" data-mozillaonline-link="{{ settings.FXA_ENDPOINT_MOZILLAONLINE }}{{ fxa_path }}?{{ fxa_queries|join('&') }}"
+  href="{{ settings.FXA_ENDPOINT }}{{ fxa_path }}?service={{ service_type }}&{{ fxa_queries|join('&') }}" data-mozillaonline-link="{{ settings.FXA_ENDPOINT_MOZILLAONLINE }}{{ fxa_path }}?{{ fxa_queries|join('&') }}"
+
+{%- endmacro %}
+
+{% macro fxa_cta_link(button_location, id_prefix, campaign, entrypoint, button_text = '', button_class = '', content = '', source = '', action='signup', utm_params={}) %}
+<div class="show-fxa-supported-signed-out">
+  <a {{ fxa_link_fragment(entrypoint="{{ entrypoint }}", action="{{ action }}", utm_params={'campaign': campaign, 'content': (content or request.path_info), 'source': source}) }} class="js-fxa-cta-link {{ button_class }}" data-button-name="Create account" data-link-type="FxA-Sync" data-cta-position="{{ button_location }}" id="{{ account_id }}">
+    {{ button_text }}
+  </a>
+</div>
 {%- endmacro %}
 
 {% macro fxa_create_account_button(button_location, id_prefix, campaign, entrypoint, button_text = '', button_class = '', content = '', source = '') %}
@@ -346,7 +354,7 @@
 
     DO NOT include utm_source in this dictionary! (It's already a required param.)
 #}
-{% macro fxa_email_form(entrypoint, utm_source, class_name='fxa-email-form', utm_params={}, intro_text='', button_text='', button_class='button button-blue') -%}
+{% macro fxa_email_form(entrypoint, utm_source, class_name='fxa-email-form', utm_params={}, intro_text='', button_text='', button_class='js-fxa-cta-link button button-blue') -%}
   <form action="{{ settings.FXA_ENDPOINT }}" data-mozillaonline-action="{{ settings.FXA_ENDPOINT_MOZILLAONLINE }}" id="fxa-email-form" class="{{ class_name }}">
     <input type="hidden" name="action" value="email" />
     <input type="hidden" name="context" value="fx_desktop_v3" />

--- a/bedrock/base/templates/macros.html
+++ b/bedrock/base/templates/macros.html
@@ -247,8 +247,8 @@
 
 {%- endmacro %}
 
-{% macro fxa_cta_link(entrypoint, campaign, content, source, button_class, button_location, button_text, account_id, action='signin', utm_params={}) %}
-  <a {{ fxa_link_fragment(entrypoint=entrypoint, action="{{ action }}", utm_params={'campaign': campaign, 'content': (content or request.path_info), 'source': source}) }} class="js-fxa-cta-link {{ button_class }}" data-button-name="Create account" data-link-type="FxA-Sync" data-cta-position="{{ button_location }}" id="{{ account_id }}">
+{% macro fxa_cta_link(entrypoint, campaign, content, source, button_class, button_location, button_text, account_id, action='signin', medium='referral') %}
+  <a {{ fxa_link_fragment(entrypoint=entrypoint, action="{{ action }}", utm_params={'campaign': campaign, 'content': (content or request.path_info), 'source': source, 'medium': medium }) }} class="js-fxa-cta-link {{ button_class }}" data-button-name="Create account" data-link-type="FxA-Sync" data-cta-position="{{ button_location }}" id="{{ account_id }}">
     {{ button_text }}
   </a>
 {%- endmacro %}

--- a/bedrock/firefox/templates/firefox/accounts-2018.html
+++ b/bedrock/firefox/templates/firefox/accounts-2018.html
@@ -3,7 +3,7 @@
   # file, You can obtain one at http://mozilla.org/MPL/2.0/. #}
 
 {% from "macros-protocol.html" import feature_card with context %}
-{% from "macros.html" import fxa_email_form, fxa_link_fragment, google_play_button with context %}
+{% from "macros.html" import fxa_email_form, fxa_link_fragment, fxa_cta_link, google_play_button with context %}
 
 {% extends "base-protocol.html" %}
 

--- a/bedrock/firefox/templates/firefox/accounts-2018.html
+++ b/bedrock/firefox/templates/firefox/accounts-2018.html
@@ -38,10 +38,7 @@
       {% endif %}
       <div id="hero-cta" class="mzp-c-hero-cta">
         <div class="show-fxa-supported-signed-out">
-          <a
-          {{ fxa_link_fragment(entrypoint='mozilla.org-accounts_page', action='signup', utm_params={'campaign': 'fxa-benefits-page', 'content': 'accounts-page-top-cta', 'medium': 'referral', 'source': 'accounts-page'}) }} class="mzp-c-button mzp-t-primary mzp-t-product" data-button-name="Create account" data-link-type="FxA-Sync" data-cta-position="primary cta" id="features-hero-account">
-            {{ _('Create a Firefox Account') }}
-          </a>
+          {{ fxa_cta_link(entrypoint='mozilla.org-accounts_page', account_id='features-hero-account', action='signup', button_text=_('Create a Firefox Account'), button_class='mzp-c-button mzp-t-primary mzp-t-product', campaign='fxa-benefits-page', content='accounts-page-top-cta', medium='referral', source='accounts-page') }}
         </div>
         <div class="show-fxa-supported-signed-in">
           <button class="mzp-c-button mzp-t-product" type="button" id="fx-modal" data-button-name="download the firefox app" data-cta-position="primary cta">{{ _('Download the Firefox App') }}</button>
@@ -126,9 +123,7 @@
       {{ download_firefox(download_location='primary cta', button_color='mzp-c-button mzp-t-secondary mzp-t-product') }}
     </div>
     <div class="show-fxa-supported-signed-out">
-      <a {{ fxa_link_fragment(entrypoint='mozilla.org-accounts_page', action='signup', utm_params={'campaign': 'fxa-benefits-page', 'content': 'accounts-page-top-cta', 'medium': 'referral', 'source': 'accounts-page'}) }} class="mzp-c-button mzp-t-secondary mzp-t-product" data-button-name="Create account" data-link-type="FxA-Sync">
-          {{ _('Create a Firefox Account') }}
-      </a>
+      {{ fxa_cta_link(entrypoint='mozilla.org-accounts_page', action='signup', button_text=_('Create a Firefox Account'), button_class='mzp-c-button mzp-t-secondary mzp-t-product', campaign='fxa-benefits-page', content='accounts-page-top-cta', medium='referral', source='accounts-page') }}
     </div>
   {% endcall %}
 
@@ -147,9 +142,7 @@
       {{ download_firefox(dom_id='sync-download', download_location='primary cta', button_color='mzp-c-button mzp-t-secondary mzp-t-product') }}
     </div>
     <div class="show-fxa-supported-signed-out">
-      <a {{ fxa_link_fragment(entrypoint='mozilla.org-accounts_page', action='signup', utm_params={'campaign': 'fxa-benefits-page', 'content': 'accounts-page-top-cta', 'medium': 'referral', 'source': 'accounts-page'}) }} class="mzp-c-button mzp-t-secondary mzp-t-product" data-button-name="Create account" data-link-type="FxA-Sync">
-          {{ _('Create a Firefox Account') }}
-      </a>
+      {{ fxa_cta_link(entrypoint='mozilla.org-accounts_page', action='signup', button_text=_('Create a Firefox Account'), button_class='mzp-c-button mzp-t-secondary mzp-t-product', campaign='fxa-benefits-page', content='accounts-page-top-cta', medium='referral', source='accounts-page') }}
     </div>
   {% endcall %}
 

--- a/bedrock/firefox/templates/firefox/developer/whatsnew-fx68.html
+++ b/bedrock/firefox/templates/firefox/developer/whatsnew-fx68.html
@@ -17,9 +17,7 @@
 
 {% block fxa_cta %}
 <p class="show-fxa-supported-signed-out show-fxa-default">
-  <a {{ fxa_link_fragment(entrypoint='mozilla.org-whatsnew68a2', action='signup', utm_params={'campaign': 'wnp68a2', 'content': 'accounts-page-top-cta', 'medium': 'referral', 'source': 'wnp68a2'}) }} class="mzp-c-button mzp-t-product" data-button-name="Create account" data-link-type="FxA-Sync">
-    {{ _('Create a Firefox Account') }}
-  </a><br>
+  {{ fxa_cta_link(entrypoint='mozilla.org-whatsnew68a2', action='signup', button_text=_('Create a Firefox Account'), button_class='mzp-c-button mzp-t-product', campaign='wnp68a2', content='accounts-page-top-cta', medium='referral', source='wnp68a2') }}<br>
 
   {% if l10n_has_tag('wnp66_log_in') %}
   {% set link = fxa_link_fragment(entrypoint='mozilla.org-whatsnew68a2', action='login', utm_params={'campaign': 'wnp68a2', 'content': 'accounts-page-top-cta', 'medium': 'referral', 'source': 'wnp68a2'}) %}

--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx66.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx66.html
@@ -3,7 +3,7 @@
 
 {% from "macros-protocol.html" import hero, call_out_compact with context %}
 
-{% from "macros.html" import fxa_email_form, fxa_link_fragment, google_play_button with context %}
+{% from "macros.html" import fxa_email_form, fxa_link_fragment, fxa_cta_link, google_play_button with context %}
 
 {% add_lang_files "firefox/whatsnew_66" %}
 
@@ -88,9 +88,7 @@
 
   {% block fxa_cta %}
   <p class="show-fxa-supported-signed-out show-fxa-default">
-    <a {{ fxa_link_fragment(entrypoint='mozilla.org-whatsnew66', action='signup', utm_params={'campaign': 'wnp66', 'content': 'accounts-page-top-cta', 'medium': 'referral', 'source': 'wnp66'}) }} class="mzp-c-button mzp-t-product" data-button-name="Create account" data-link-type="FxA-Sync">
-      {{ _('Create a Firefox Account') }}
-    </a><br>
+    {{ fxa_cta_link(entrypoint='mozilla.org-whatsnew66', action='signup', button_text=_('Create a Firefox Account'), button_class='mzp-c-button mzp-t-product', campaign='wnp66', content='accounts-page-top-cta', medium='referral', source='wnp66') }}<br>
 
     {% if l10n_has_tag('wnp66_log_in') %}
     {% set link = fxa_link_fragment(entrypoint='mozilla.org-whatsnew66', action='login', utm_params={'campaign': 'wnp66', 'content': 'accounts-page-top-cta', 'medium': 'referral', 'source': 'wnp66'}) %}

--- a/media/js/base/fxa-utm-referral.js
+++ b/media/js/base/fxa-utm-referral.js
@@ -6,57 +6,95 @@
 
     var UtmUrl = {};
 
+    /**
+     * Fetch and validate utm params from the page URL for FxA referral.
+     * https://mozilla.github.io/application-services/docs/accounts/metrics.html#descriptions-of-metrics-related-query-parameters
+     * @returns {Object} if one or more valit utms exist, else {null}.
+     */
     UtmUrl.getAttributionData = function () {
         var params = new window._SearchParams().utmParams();
+        var allowedChars = /^[\w/.%-]+$/;
         var finalParams = {};
 
-        // utm_source
-        if (params.hasOwnProperty('utm_source') && (/^[\w/.%-]+$/).test(params['utm_source'])) {
-            // this value is already URI encoded, so we need to decode here as
-            // it will get re-encoded in _SearchParams.objectToQueryString
+        if (params.hasOwnProperty('utm_source') && (allowedChars).test(params['utm_source'])) {
             finalParams['utm_source'] = decodeURIComponent(params['utm_source']);
         }
-        return Object.getOwnPropertyNames(finalParams).length === 1 ? finalParams : null;
+
+        if (params.hasOwnProperty('utm_campaign') && (allowedChars).test(params['utm_campaign'])) {
+            finalParams['utm_campaign'] = decodeURIComponent(params['utm_campaign']);
+        }
+
+        if (params.hasOwnProperty('utm_content') && (allowedChars).test(params['utm_content'])) {
+            finalParams['utm_content'] = decodeURIComponent(params['utm_content']);
+        }
+
+        if (params.hasOwnProperty('utm_term') && (allowedChars).test(params['utm_term'])) {
+            finalParams['utm_term'] = decodeURIComponent(params['utm_term']);
+        }
+
+        if (params.hasOwnProperty('utm_medium') && (allowedChars).test(params['utm_medium'])) {
+            finalParams['utm_medium'] = decodeURIComponent(params['utm_medium']);
+        }
+        return Object.getOwnPropertyNames(finalParams).length >= 1 ? finalParams : null;
     };
 
+    /**
+     * Append an object of URL parameters to a given URL.
+     * @param {String} URL to append parameters to.
+     * @param {Object} data object consisting of one or more parameters.
+     * @returns {String} URL containing updated parameters.
+     */
     UtmUrl.appendToDownloadURL = function (url, data) {
-        var finalParams = data;
+        var finalParams;
         var linkParams;
 
         if (url.indexOf('?') > 0) {
             linkParams = window._SearchParams.queryStringToObject(url.split('?')[1]);
-            finalParams = Object.getOwnPropertyNames(finalParams, linkParams);
-            console.log(finalParams);
+            finalParams = Object.assign(linkParams, data);
+        } else {
+            finalParams = data;
         }
+
         return url.split('?')[0] + '?' + window._SearchParams.objectToQueryString(finalParams);
     };
 
+    /**
+     * If there are valid utm params on the page URL, query the
+     * DOM and update Firefox Account links with the new utm data
+     */
     UtmUrl.getAttributionData.init = function (){
         var params = UtmUrl.getAttributionData();
         var ctaLinks = document.getElementsByClassName('js-fxa-cta-link');
-        var link;
+
+        // If there are no utm params on the page, do nothing.
+        if (!params) {
+            return;
+        }
+
+        // feature detect support for object modification.
+        if (typeof Object.assign !== 'function' || typeof Object.getOwnPropertyNames !== 'function') {
+            return;
+        }
 
         for (var i = 0; i < ctaLinks.length; i++) {
-            if (params) {
-                var url = UtmUrl.appendToDownloadURL(params);
-                ctaLinks[i].href = url;
-                console.log(ctaLinks[i].getAttribute('data-mozillaonline-link'));
+            // get the current FxA links.
+            var oldAccountsLink = ctaLinks[i].href;
+            var oldMozillaOnlineLink = ctaLinks[i].getAttribute('data-mozillaonline-link');
+
+            // append our new UTM param data to create new FxA links.
+            var newAccountsLink = UtmUrl.appendToDownloadURL(oldAccountsLink, params);
+
+            // set the FxA button to use the new link.
+            ctaLinks[i].href = newAccountsLink;
+
+            // also handle mozilla-online links for FxA China Repack.
+            if (oldMozillaOnlineLink) {
+                var newMozillaOnlineLink = UtmUrl.appendToDownloadURL(oldMozillaOnlineLink, params);
+                ctaLinks[i].setAttribute('data-mozillaonline-link', newMozillaOnlineLink);
             }
         }
     };
 
     UtmUrl.getAttributionData.init();
 
-})(window.Mozilla);
-
-
-// _SearchParams.objectToQueryString
-// fxa_link_fragment
-// /^[\w/.%-]+$/
-// decodeURIComponent
-// validate with regex
-// before adding to fxa_link_fragment function looks for common classname on fxa_link_fragment
-// query for that selector in DOM
-// does the function does the thing -- test UtmUrl.getAttributionData.init, updates link in page. assert
-// spec/base/stub-attribution-macos.js
-// update button to fxa_link_cta
+})();

--- a/media/js/base/fxa-utm-referral.js
+++ b/media/js/base/fxa-utm-referral.js
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 (function () {
+    'use strict';
 
     var UtmUrl = {};
 

--- a/media/js/base/fxa-utm-referral.js
+++ b/media/js/base/fxa-utm-referral.js
@@ -14,10 +14,9 @@
         if (params.hasOwnProperty('utm_source') && (/^[\w/.%-]+$/).test(params['utm_source'])) {
             // this value is already URI encoded, so we need to decode here as
             // it will get re-encoded in _SearchParams.objectToQueryString
-            finalParams['source'] = decodeURIComponent(params['utm_source']);
-            console.log(finalParams);
+            finalParams['utm_source'] = decodeURIComponent(params['utm_source']);
         }
-        return Object.getOwnPropertyNames(finalParams);
+        return Object.getOwnPropertyNames(finalParams).length === 1 ? finalParams : null;
     };
 
     UtmUrl.appendToDownloadURL = function (url, data) {
@@ -26,20 +25,23 @@
 
         if (url.indexOf('?') > 0) {
             linkParams = window._SearchParams.queryStringToObject(url.split('?')[1]);
-            finalParams = Object.assign(finalParams, linkParams);
+            finalParams = Object.getOwnPropertyNames(finalParams, linkParams);
+            console.log(finalParams);
         }
-
         return url.split('?')[0] + '?' + window._SearchParams.objectToQueryString(finalParams);
     };
 
     UtmUrl.getAttributionData.init = function (){
-        UtmUrl.getAttributionData();
-
+        var params = UtmUrl.getAttributionData();
         var ctaLinks = document.getElementsByClassName('js-fxa-cta-link');
-        var url;
+        var link;
 
         for (var i = 0; i < ctaLinks.length; i++) {
-            console.log(ctaLinks[i].href);
+            if (params) {
+                var url = UtmUrl.appendToDownloadURL(params);
+                ctaLinks[i].href = url;
+                console.log(ctaLinks[i].getAttribute('data-mozillaonline-link'));
+            }
         }
     };
 
@@ -55,3 +57,6 @@
 // validate with regex
 // before adding to fxa_link_fragment function looks for common classname on fxa_link_fragment
 // query for that selector in DOM
+// does the function does the thing -- test UtmUrl.getAttributionData.init, updates link in page. assert
+// spec/base/stub-attribution-macos.js
+// update button to fxa_link_cta

--- a/media/js/base/fxa-utm-referral.js
+++ b/media/js/base/fxa-utm-referral.js
@@ -1,0 +1,43 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+(function () {
+
+    var UtmUrl = {};
+
+    UtmUrl.getAttributionData = function () {
+        var params = new window._SearchParams().utmParams();
+        var finalParams = {};
+
+        // utm_source
+        if (params.hasOwnProperty('utm_source') && (/^[\w/.%-]+$/).test(params['utm_source'])) {
+            // this value is already URI encoded, so we need to decode here as
+            // it will get re-encoded in _SearchParams.objectToQueryString
+            finalParams['source'] = decodeURIComponent(params['utm_source']);
+        }
+        return Object.getOwnPropertyNames(finalParams);
+    };
+
+    UtmUrl.getAttributionData.init = function (){
+        // var data;
+        // data = UtmUrl.getAttributionData();
+
+        // var linkFragment = document.querySelectorAll('.fxa_link_fragment');
+        // console.log(linkFragment);
+
+    };
+
+    // window.Mozilla.UtmUrl = UtmUrl;
+    UtmUrl.getAttributionData.init();
+
+})(window.Mozilla);
+
+
+// _SearchParams.objectToQueryString
+// fxa_link_fragment
+// /^[\w/.%-]+$/
+// decodeURIComponent
+// validate with regex
+// before adding to fxa_link_fragment function looks for common classname on fxa_link_fragment
+// query for that selector in DOM

--- a/media/js/base/fxa-utm-referral.js
+++ b/media/js/base/fxa-utm-referral.js
@@ -23,8 +23,8 @@
         // var data;
         // data = UtmUrl.getAttributionData();
 
-        // var linkFragment = document.querySelectorAll('.fxa_link_fragment');
-        // console.log(linkFragment);
+        var linkFragment = document.querySelectorAll('.js-fxa-cta-link');
+        console.log(linkFragment);
 
     };
 

--- a/media/js/base/fxa-utm-referral.js
+++ b/media/js/base/fxa-utm-referral.js
@@ -15,20 +15,34 @@
             // this value is already URI encoded, so we need to decode here as
             // it will get re-encoded in _SearchParams.objectToQueryString
             finalParams['source'] = decodeURIComponent(params['utm_source']);
+            console.log(finalParams);
         }
         return Object.getOwnPropertyNames(finalParams);
     };
 
-    UtmUrl.getAttributionData.init = function (){
-        // var data;
-        // data = UtmUrl.getAttributionData();
+    UtmUrl.appendToDownloadURL = function (url, data) {
+        var finalParams = data;
+        var linkParams;
 
-        var linkFragment = document.querySelectorAll('.js-fxa-cta-link');
-        console.log(linkFragment);
+        if (url.indexOf('?') > 0) {
+            linkParams = window._SearchParams.queryStringToObject(url.split('?')[1]);
+            finalParams = Object.assign(finalParams, linkParams);
+        }
 
+        return url.split('?')[0] + '?' + window._SearchParams.objectToQueryString(finalParams);
     };
 
-    // window.Mozilla.UtmUrl = UtmUrl;
+    UtmUrl.getAttributionData.init = function (){
+        UtmUrl.getAttributionData();
+
+        var ctaLinks = document.getElementsByClassName('js-fxa-cta-link');
+        var url;
+
+        for (var i = 0; i < ctaLinks.length; i++) {
+            console.log(ctaLinks[i].href);
+        }
+    };
+
     UtmUrl.getAttributionData.init();
 
 })(window.Mozilla);

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -1505,7 +1505,8 @@
         "js/base/base-page-init.js",
         "js/base/core-datalayer.js",
         "js/base/core-datalayer-init.js",
-        "js/base/search-params.js"
+        "js/base/search-params.js",
+        "js/base/fxa-utm-referral.js"
       ],
       "name": "common"
     },
@@ -1527,7 +1528,8 @@
         "js/base/base-page-init.js",
         "js/base/core-datalayer.js",
         "js/base/core-datalayer-init.js",
-        "js/base/search-params.js"
+        "js/base/search-params.js",
+        "js/base/fxa-utm-referral.js"
       ],
       "name": "common-protocol"
     },


### PR DESCRIPTION
## Description
Per conversation in #6854
https://github.com/mozilla/bedrock/issues/6854#issuecomment-482443889
This is a rough draft of validating utm_source params.

## Issue
#6854

## Testing

Search url for preexisting source params.
1. if utm_source is present, [validate with regex](https://mozilla.github.io/application-services/docs/accounts/metrics.html#descriptions-of-metrics-related-query-parameters)
2. if utm_source is not present, use value passed to `fxa_link_fragment` macro.