### PR TITLE
Standardizing fxa utm parameters and values (#7061)

### DIFF
--- a/bedrock/base/templates/includes/protocol/navigation/index.html
+++ b/bedrock/base/templates/includes/protocol/navigation/index.html
@@ -25,7 +25,7 @@
         <div class="mzp-c-navigation-download">
           {{ download_firefox(alt_copy=_('Download Firefox'), dom_id='protocol-nav-download-firefox', button_color='mzp-t-secondary mzp-t-small', download_location='nav') }}
           <div class="c-navigation-fxa-cta-container">
-            <a class="c-navigation-fxa-cta mzp-c-button mzp-t-secondary mzp-t-small mzp-t-product" {{ fxa_link_fragment(entrypoint='mozilla.org-globalnav', action='signup', utm_params={'campaign': 'globalnav', 'content': 'get-firefox-account', 'medium': 'referral', 'source': 'www.mozilla.org'}) }} data-button-name="Get a Firefox Account" data-link-type="button" data-cta-position="secondary cta" data-alt-href="{{ url('firefox.accounts') }}">
+            <a class="c-navigation-fxa-cta mzp-c-button mzp-t-secondary mzp-t-small mzp-t-product" {{ fxa_link_fragment(entrypoint='mozilla.org-globalnav', action='signup', utm_params={'campaign': 'globalnav', 'content': 'get-firefox-account', 'medium': 'referral', 'source': 'www.mozilla.org'}) }} data-button-name="Get a Firefox Account" data-link-type="FxA-Sync" data-cta-position="secondary cta" data-alt-href="{{ url('firefox.accounts') }}">
               {{ _('Get a Firefox Account') }}
             </a>
             <p class="c-navigation-fxa-cta-small-link"><a data-link-type="nav" data-link-name="Check out the Benefits" href="{{ url('firefox.accounts') }}">{{ _('Check out the Benefits') }}</a></p>

--- a/bedrock/base/templates/macros.html
+++ b/bedrock/base/templates/macros.html
@@ -367,7 +367,7 @@
     {{ download_firefox(dom_id=download_id, download_location=button_location) }}
   </div>
   <div class="show-fxa-supported-signed-out">
-    <a {{ fxa_link_fragment(entrypoint=entrypoint, action='signup', utm_params={'campaign': campaign, 'content': (content or request.path_info), 'source': source}) }} class="button {{ button_class }}" data-button-name="Create account" data-link-type="button" data-cta-position="{{ button_location }}" id="{{ account_id }}">
+    <a {{ fxa_link_fragment(entrypoint=entrypoint, action='signup', utm_params={'campaign': campaign, 'content': (content or request.path_info), 'source': source}) }} class="button {{ button_class }}" data-button-name="Create account" data-link-type="FxA-Sync" data-cta-position="{{ button_location }}" id="{{ account_id }}">
       {{ button_text }}
     </a>
   </div>

--- a/bedrock/firefox/templates/firefox/accounts-2018.html
+++ b/bedrock/firefox/templates/firefox/accounts-2018.html
@@ -39,7 +39,7 @@
       <div id="hero-cta" class="mzp-c-hero-cta">
         <div class="show-fxa-supported-signed-out">
           <a
-          {{ fxa_link_fragment(entrypoint='mozilla.org-accounts-page', action='signup', utm_params={'campaign': 'fxa-benefits-page', 'content': 'accounts-page-top-cta', 'medium': 'referral', 'source': 'accounts-page'}) }} class="mzp-c-button mzp-t-primary mzp-t-product" data-cta-position="primary cta" id="features-hero-account">
+          {{ fxa_link_fragment(entrypoint='mozilla.org-accounts_page', action='signup', utm_params={'campaign': 'fxa-benefits-page', 'content': 'accounts-page-top-cta', 'medium': 'referral', 'source': 'accounts-page'}) }} class="mzp-c-button mzp-t-primary mzp-t-product" data-cta-position="primary cta" id="features-hero-account">
             {{ _('Create a Firefox Account') }}
           </a>
         </div>
@@ -126,7 +126,7 @@
       {{ download_firefox(download_location='primary cta', button_color='mzp-c-button mzp-t-secondary mzp-t-product') }}
     </div>
     <div class="show-fxa-supported-signed-out">
-      <a {{ fxa_link_fragment(entrypoint='accounts-page', action='signup', utm_params={'campaign': 'fxa-benefits-page', 'content': 'accounts-page-top-cta', 'medium': 'referral', 'source': 'accounts-page'}) }} class="mzp-c-button mzp-t-secondary mzp-t-product" data-button-name="Create account" data-link-type="button">
+      <a {{ fxa_link_fragment(entrypoint='mozilla.org-accounts_page', action='signup', utm_params={'campaign': 'fxa-benefits-page', 'content': 'accounts-page-top-cta', 'medium': 'referral', 'source': 'accounts-page'}) }} class="mzp-c-button mzp-t-secondary mzp-t-product" data-button-name="Create account" data-link-type="button">
           {{ _('Create a Firefox Account') }}
       </a>
     </div>
@@ -147,7 +147,7 @@
       {{ download_firefox(dom_id='sync-download', download_location='primary cta', button_color='mzp-c-button mzp-t-secondary mzp-t-product') }}
     </div>
     <div class="show-fxa-supported-signed-out">
-      <a {{ fxa_link_fragment(entrypoint='accounts-page', action='signup', utm_params={'campaign': 'fxa-benefits-page', 'content': 'accounts-page-top-cta', 'medium': 'referral', 'source': 'accounts-page'}) }} class="mzp-c-button mzp-t-secondary mzp-t-product" data-button-name="Create account" data-link-type="button">
+      <a {{ fxa_link_fragment(entrypoint='mozilla.org-accounts_page', action='signup', utm_params={'campaign': 'fxa-benefits-page', 'content': 'accounts-page-top-cta', 'medium': 'referral', 'source': 'accounts-page'}) }} class="mzp-c-button mzp-t-secondary mzp-t-product" data-button-name="Create account" data-link-type="button">
           {{ _('Create a Firefox Account') }}
       </a>
     </div>
@@ -291,14 +291,13 @@
 
         <div class="show-fxa-supported-signed-out">
           {{ fxa_email_form(
-            entrypoint='mozilla.org-fxa_benefits',
-            utm_source='mozilla.org-fxa_benefits',
-            utm_params={'referrer': 'https://www.mozilla.org/en-US/firefox/accounts/'},
+            entrypoint='mozilla.org-accounts_page',
+            utm_source='accounts_page',
             button_class='mzp-c-button mzp-t-primary mzp-t-product',
             button_text=_('Create an Account'))
           }}
 
-          <p class="fxa-signin">{{ _('Already have an account?') }} <a {{ fxa_link_fragment(entrypoint='accounts-page', utm_params={'campaign': 'fxa-embedded-form', 'content': '/firefox/accounts/', 'source': 'accounts-page'}) }}>{{ _('Sign In') }}</a></p>
+          <p class="fxa-signin">{{ _('Already have an account?') }} <a {{ fxa_link_fragment(entrypoint='mozzila.org-accounts_page', utm_params={'campaign': 'fxa-embedded-form', 'content': '/firefox/accounts/', 'source': 'accounts-page'}) }}>{{ _('Sign In') }}</a></p>
         </div>
       </div>
 

--- a/bedrock/firefox/templates/firefox/accounts-2018.html
+++ b/bedrock/firefox/templates/firefox/accounts-2018.html
@@ -39,7 +39,7 @@
       <div id="hero-cta" class="mzp-c-hero-cta">
         <div class="show-fxa-supported-signed-out">
           <a
-          {{ fxa_link_fragment(entrypoint='mozilla.org-accounts_page', action='signup', utm_params={'campaign': 'fxa-benefits-page', 'content': 'accounts-page-top-cta', 'medium': 'referral', 'source': 'accounts-page'}) }} class="mzp-c-button mzp-t-primary mzp-t-product" data-cta-position="primary cta" id="features-hero-account">
+          {{ fxa_link_fragment(entrypoint='mozilla.org-accounts_page', action='signup', utm_params={'campaign': 'fxa-benefits-page', 'content': 'accounts-page-top-cta', 'medium': 'referral', 'source': 'accounts-page'}) }} class="mzp-c-button mzp-t-primary mzp-t-product" data-button-name="Create account" data-link-type="FxA-Sync" data-cta-position="primary cta" id="features-hero-account">
             {{ _('Create a Firefox Account') }}
           </a>
         </div>

--- a/bedrock/firefox/templates/firefox/accounts-2018.html
+++ b/bedrock/firefox/templates/firefox/accounts-2018.html
@@ -126,7 +126,7 @@
       {{ download_firefox(download_location='primary cta', button_color='mzp-c-button mzp-t-secondary mzp-t-product') }}
     </div>
     <div class="show-fxa-supported-signed-out">
-      <a {{ fxa_link_fragment(entrypoint='mozilla.org-accounts_page', action='signup', utm_params={'campaign': 'fxa-benefits-page', 'content': 'accounts-page-top-cta', 'medium': 'referral', 'source': 'accounts-page'}) }} class="mzp-c-button mzp-t-secondary mzp-t-product" data-button-name="Create account" data-link-type="button">
+      <a {{ fxa_link_fragment(entrypoint='mozilla.org-accounts_page', action='signup', utm_params={'campaign': 'fxa-benefits-page', 'content': 'accounts-page-top-cta', 'medium': 'referral', 'source': 'accounts-page'}) }} class="mzp-c-button mzp-t-secondary mzp-t-product" data-button-name="Create account" data-link-type="FxA-Sync">
           {{ _('Create a Firefox Account') }}
       </a>
     </div>
@@ -147,7 +147,7 @@
       {{ download_firefox(dom_id='sync-download', download_location='primary cta', button_color='mzp-c-button mzp-t-secondary mzp-t-product') }}
     </div>
     <div class="show-fxa-supported-signed-out">
-      <a {{ fxa_link_fragment(entrypoint='mozilla.org-accounts_page', action='signup', utm_params={'campaign': 'fxa-benefits-page', 'content': 'accounts-page-top-cta', 'medium': 'referral', 'source': 'accounts-page'}) }} class="mzp-c-button mzp-t-secondary mzp-t-product" data-button-name="Create account" data-link-type="button">
+      <a {{ fxa_link_fragment(entrypoint='mozilla.org-accounts_page', action='signup', utm_params={'campaign': 'fxa-benefits-page', 'content': 'accounts-page-top-cta', 'medium': 'referral', 'source': 'accounts-page'}) }} class="mzp-c-button mzp-t-secondary mzp-t-product" data-button-name="Create account" data-link-type="FxA-Sync">
           {{ _('Create a Firefox Account') }}
       </a>
     </div>

--- a/bedrock/firefox/templates/firefox/accounts-2018.html
+++ b/bedrock/firefox/templates/firefox/accounts-2018.html
@@ -38,7 +38,8 @@
       {% endif %}
       <div id="hero-cta" class="mzp-c-hero-cta">
         <div class="show-fxa-supported-signed-out">
-          <a {{ fxa_link_fragment(entrypoint='accounts-page', action='signup', utm_params={'campaign': 'fxa-benefits-page', 'content': 'accounts-page-top-cta', 'medium': 'referral', 'source': 'accounts-page'}) }} class="mzp-c-button mzp-t-primary mzp-t-product" data-button-name="Create account" data-link-type="button" data-cta-position="primary cta" id="features-hero-account">
+          <a
+          {{ fxa_link_fragment(entrypoint='mozilla.org-accounts-page', action='signup', utm_params={'campaign': 'fxa-benefits-page', 'content': 'accounts-page-top-cta', 'medium': 'referral', 'source': 'accounts-page'}) }} class="mzp-c-button mzp-t-primary mzp-t-product" data-cta-position="primary cta" id="features-hero-account">
             {{ _('Create a Firefox Account') }}
           </a>
         </div>
@@ -289,7 +290,13 @@
         </div>
 
         <div class="show-fxa-supported-signed-out">
-          {{ fxa_email_form(entrypoint='accounts-page', utm_source='accounts-page', utm_params={'campaign': 'fxa-embedded-form', 'content': 'accounts-page', 'medium': 'referral'}, button_class='mzp-c-button mzp-t-primary mzp-t-product', button_text=_('Create an Account')) }}
+          {{ fxa_email_form(
+            entrypoint='mozilla.org-fxa_benefits',
+            utm_source='mozilla.org-fxa_benefits',
+            utm_params={'referrer': 'https://www.mozilla.org/en-US/firefox/accounts/'},
+            button_class='mzp-c-button mzp-t-primary mzp-t-product',
+            button_text=_('Create an Account'))
+          }}
 
           <p class="fxa-signin">{{ _('Already have an account?') }} <a {{ fxa_link_fragment(entrypoint='accounts-page', utm_params={'campaign': 'fxa-embedded-form', 'content': '/firefox/accounts/', 'source': 'accounts-page'}) }}>{{ _('Sign In') }}</a></p>
         </div>

--- a/bedrock/firefox/templates/firefox/accounts.html
+++ b/bedrock/firefox/templates/firefox/accounts.html
@@ -38,7 +38,7 @@
       <div class="fxa-cta show-fxa-supported-signed-in show-fxa-supported-signed-out">
         <p class="show-fxa-supported-signed-in signed-in">{{_('You’re signed in and ready to start using Sync.')}}</p>
         <div class="show-fxa-supported-signed-out">
-          {{ fxa_email_form(entrypoint='accounts-page', utm_source='accounts-page', utm_params={'campaign': 'fxa-embedded-form', 'content': 'accounts-page', 'medium': 'referral'}) }}
+          {{ fxa_email_form(entrypoint='mozilla.org-accounts', utm_source='accounts-page', utm_params={'campaign': 'fxa-embedded-form', 'content': 'accounts-page', 'medium': 'referral'}) }}
         </div>
       </div>
       <div class="mobile-ctas">

--- a/bedrock/firefox/templates/firefox/accounts.html
+++ b/bedrock/firefox/templates/firefox/accounts.html
@@ -38,7 +38,7 @@
       <div class="fxa-cta show-fxa-supported-signed-in show-fxa-supported-signed-out">
         <p class="show-fxa-supported-signed-in signed-in">{{_('You’re signed in and ready to start using Sync.')}}</p>
         <div class="show-fxa-supported-signed-out">
-          {{ fxa_email_form(entrypoint='mozilla.org-accounts', utm_source='accounts-page', utm_params={'campaign': 'fxa-embedded-form', 'content': 'accounts-page', 'medium': 'referral'}) }}
+          {{ fxa_email_form(entrypoint='mozilla.org-accounts_page', utm_source='accounts_page', utm_params={'campaign': 'fxa-embedded-form', 'content': 'accounts-page', 'medium': 'referral'}) }}
         </div>
       </div>
       <div class="mobile-ctas">

--- a/bedrock/firefox/templates/firefox/developer/whatsnew-fx68.html
+++ b/bedrock/firefox/templates/firefox/developer/whatsnew-fx68.html
@@ -17,7 +17,7 @@
 
 {% block fxa_cta %}
 <p class="show-fxa-supported-signed-out show-fxa-default">
-  <a {{ fxa_link_fragment(entrypoint='mozilla.org-whatsnew68a2', action='signup', utm_params={'campaign': 'wnp68a2', 'content': 'accounts-page-top-cta', 'medium': 'referral', 'source': 'wnp68a2'}) }} class="mzp-c-button mzp-t-product" data-button-name="Create account" data-link-type="button">
+  <a {{ fxa_link_fragment(entrypoint='mozilla.org-whatsnew68a2', action='signup', utm_params={'campaign': 'wnp68a2', 'content': 'accounts-page-top-cta', 'medium': 'referral', 'source': 'wnp68a2'}) }} class="mzp-c-button mzp-t-product" data-button-name="Create account" data-link-type="FxA-Sync">
     {{ _('Create a Firefox Account') }}
   </a><br>
 

--- a/bedrock/firefox/templates/firefox/firstrun/firstrun-quantum.html
+++ b/bedrock/firefox/templates/firefox/firstrun/firstrun-quantum.html
@@ -63,7 +63,7 @@
       {% endblock %}
       </header>
       <div id="fxaccounts-wrapper">
-        {{ fxa_email_form(entrypoint='firstrun-page', utm_source='firstrun-page', utm_params={'campaign': 'fxa-embedded-form', 'content': 'firstrun-page', 'medium': 'referral'}, button_class='mzp-c-button mzp-t-product',) }}
+        {{ fxa_email_form(entrypoint='mozilla.org-firstrun_page', utm_source='firstrun-page', utm_params={'campaign': 'fxa-embedded-form', 'content': 'firstrun-page', 'medium': 'referral'}, button_class='mzp-c-button mzp-t-product',) }}
 
         <p class="fxa-signin">{{ _('Already have an account?') }} <a {{ fxa_link_fragment(entrypoint='accounts-page', utm_params={'campaign': 'fxa-embedded-form', 'content': 'firefox-firstrun', 'source': 'firstrun-page'}) }}>{{ _('Sign In') }}</a></p>
       </div>

--- a/bedrock/firefox/templates/firefox/new/scene1.html
+++ b/bedrock/firefox/templates/firefox/new/scene1.html
@@ -165,7 +165,7 @@
   <h4 class="fxa-title">{{ _('You’ve already got the Firefox browser. Now get everything else Firefox.') }}</h4>
   <p class="fxa-intro">{{ _('Sync bookmarks, send tabs, save to Pocket and more with a Firefox Account.') }} <a href="{{ url('firefox.accounts') }}">{{ _('Learn more') }}</a></p>
 
-  {{ fxa_email_form(entrypoint='firefox-new', button_text=_('Get a Firefox Account'), utm_source='firefox-new', utm_params={'campaign': 'firefox-new', 'content': 'firefox-new-fxa', 'term': 'existing-users', 'medium': 'referral'}) }}
+  {{ fxa_email_form(entrypoint='mozilla.org-firefox_new', button_text=_('Get a Firefox Account'), utm_source='firefox-new', utm_params={'campaign': 'firefox-new', 'content': 'firefox-new-fxa', 'term': 'existing-users', 'medium': 'referral'}) }}
 
   <p class="fxa-signin">{{ _('Already have an account?') }} <a {{ fxa_link_fragment(entrypoint='accounts-page', utm_params={'campaign': 'fxa-embedded-form', 'content': '/firefox/new/', 'source': 'download-page'}) }}>{{ _('Sign In') }}</a></p>
 

--- a/bedrock/firefox/templates/firefox/new/scene1.html
+++ b/bedrock/firefox/templates/firefox/new/scene1.html
@@ -167,7 +167,7 @@
 
   {{ fxa_email_form(entrypoint='mozilla.org-firefox_new', button_text=_('Get a Firefox Account'), utm_source='firefox-new', utm_params={'campaign': 'firefox-new', 'content': 'firefox-new-fxa', 'term': 'existing-users', 'medium': 'referral'}) }}
 
-  <p class="fxa-signin">{{ _('Already have an account?') }} <a {{ fxa_link_fragment(entrypoint='accounts-page', utm_params={'campaign': 'fxa-embedded-form', 'content': '/firefox/new/', 'source': 'download-page'}) }}>{{ _('Sign In') }}</a></p>
+  <p class="fxa-signin">{{ _('Already have an account?') }} <a {{ fxa_link_fragment(entrypoint='mozilla.org-firefox_new', utm_params={'campaign': 'fxa-embedded-form', 'content': '/firefox/new/', 'source': 'download-page'}) }}>{{ _('Sign In') }}</a></p>
 
   {{ download_firefox(dom_id='download-fxa-modal', alt_copy=_('Download Anyway'), button_color='button-hollow button-blue', locale_in_transition=True, download_location='other') }}
 </div>

--- a/bedrock/firefox/templates/firefox/whatsnew/beta/whatsnew-fx68.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/beta/whatsnew-fx68.html
@@ -17,7 +17,7 @@
 
 {% block fxa_cta %}
 <p class="show-fxa-supported-signed-out show-fxa-default">
-  <a {{ fxa_link_fragment(entrypoint='mozilla.org-whatsnew68beta', action='signup', utm_params={'campaign': 'wnp68beta', 'content': 'accounts-page-top-cta', 'medium': 'referral', 'source': 'wnp68beta'}) }} class="mzp-c-button mzp-t-product" data-button-name="Create account" data-link-type="button">
+  <a {{ fxa_link_fragment(entrypoint='mozilla.org-whatsnew68beta', action='signup', utm_params={'campaign': 'wnp68beta', 'content': 'accounts-page-top-cta', 'medium': 'referral', 'source': 'wnp68beta'}) }} class="mzp-c-button mzp-t-product" data-button-name="Create account" data-link-type="FxA-Sync">
     {{ _('Create a Firefox Account') }}
   </a><br>
 

--- a/bedrock/firefox/templates/firefox/whatsnew/fx64/whatsnew-fx64-base.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/fx64/whatsnew-fx64-base.html
@@ -68,8 +68,8 @@
    include_cta=True
   ) %}
   <p class="show-fxa-supported-signed-out show-fxa-default">
-    <a {{ fxa_link_fragment(entrypoint='mozilla.org-fx.wnp64', action='signup', utm_params=fxa_utm_params) }} class="mzp-c-button mzp-t-product">{{ button_create }}</a><br>
-    <span class="wn64-signin">{{ login_desc }} <a {{ fxa_link_fragment(entrypoint='mozilla.org-fx.wnp64', utm_params=fxa_utm_params) }}>{{ login_link }}</a></span>
+    <a {{ fxa_link_fragment(entrypoint='mozilla.org-whatsnew64', action='signup', utm_params=fxa_utm_params) }} class="mzp-c-button mzp-t-product">{{ button_create }}</a><br>
+    <span class="wn64-signin">{{ login_desc }} <a {{ fxa_link_fragment(entrypoint='mozilla.org-whatsnew64', utm_params=fxa_utm_params) }}>{{ login_link }}</a></span>
   </p>
   {% endcall %}
   {% call hero(
@@ -115,8 +115,8 @@
     class='mzp-t-firefox t-wn64 show-fxa-default show-fxa-supported-signed-out'
   ) %}
     <p>
-      <a {{ fxa_link_fragment(entrypoint='mozilla.org-fx.wnp64', action='signup', utm_params=fxa_utm_params) }} class="mzp-c-button mzp-t-product">{{ button_create }}</a><br>
-      <span class="wn64-signin">{{ login_desc }} <a {{ fxa_link_fragment(entrypoint='mozilla.org-fx.wnp64', utm_params=fxa_utm_params) }}>{{ login_link }}</a></span>
+      <a {{ fxa_link_fragment(entrypoint='mozilla.org-whatsnew64', action='signup', utm_params=fxa_utm_params) }} class="mzp-c-button mzp-t-product">{{ button_create }}</a><br>
+      <span class="wn64-signin">{{ login_desc }} <a {{ fxa_link_fragment(entrypoint='mozilla.org-whatsnew64', utm_params=fxa_utm_params) }}>{{ login_link }}</a></span>
     </p>
   {% endcall %}
 

--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx63.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx63.html
@@ -34,7 +34,7 @@
           <h2 class="c-fxa-sticky-signup-title">{{ _('Get your Firefox Account') }}</h2>
         </div>
         {{ fxa_email_form(
-            entrypoint='whatsnew',
+            entrypoint='mozilla.org-whatsnew63',
             button_class='mzp-c-button',
             utm_source='whatsnew',
             utm_params={'campaign': 'fxa-embedded-form', 'content': 'whatsnew', 'medium': 'referral'})

--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx65.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx65.html
@@ -33,11 +33,7 @@
         <div class="c-sticky-signup-content">
           <h2 class="c-sticky-signup-title">{{ _('Get your Firefox Account') }}</h2>
         </div>
-        {{ fxa_email_form(
-            entrypoint='whatsnew',
-            button_class='mzp-c-button',
-            utm_source='whatsnew',
-            utm_params={'campaign': 'fxa-embedded-form', 'content': 'whatsnew', 'medium': 'referral'})
+        {{ fxa_email_form(entrypoint='mozilla.org-whatsnew65', button_class='mzp-c-button', utm_source='whatsnew', utm_params={'campaign': 'fxa-embedded-form', 'content': 'whatsnew', 'medium': 'referral'})
         }}
       </div>
     </div>

--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx66.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx66.html
@@ -88,7 +88,7 @@
 
   {% block fxa_cta %}
   <p class="show-fxa-supported-signed-out show-fxa-default">
-    <a {{ fxa_link_fragment(entrypoint='mozilla.org-whatsnew66', action='signup', utm_params={'campaign': 'wnp66', 'content': 'accounts-page-top-cta', 'medium': 'referral', 'source': 'wnp66'}) }} class="mzp-c-button mzp-t-product" data-button-name="Create account" data-link-type="button">
+    <a {{ fxa_link_fragment(entrypoint='mozilla.org-whatsnew66', action='signup', utm_params={'campaign': 'wnp66', 'content': 'accounts-page-top-cta', 'medium': 'referral', 'source': 'wnp66'}) }} class="mzp-c-button mzp-t-product" data-button-name="Create account" data-link-type="FxA-Sync">
       {{ _('Create a Firefox Account') }}
     </a><br>
 


### PR DESCRIPTION
## Description
Standardizing FxA parameters so they are uniform across the site.

## Issue / Bugzilla link
#7061

## Testing
- Format for `entrypoint`: `domain-point_of_CTA`
