### PR TITLE
Show newsletter on FF 68 /whats page for beta and dev edition (#7043)

### DIFF
--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -432,7 +432,7 @@ class WhatsnewView(l10n_utils.LangFilesMixin, TemplateView):
                 'zh-TW',
             ]
 
-        if ctx['num_version'] in [65, 66]:
+        if ctx['num_version'] in [65, 66, 68]:
             ctx['show_newsletter'] = locale in [
                 'en-US',
                 'en-GB',


### PR DESCRIPTION
## Description
I noticed on the two following URLs, the newsletter form wasn't being displayed if already signed-in to a Firefox account.

- http://127.0.0.1:8000/en-US/firefox/68.0beta/whatsnew/
- http://127.0.0.1:8000/en-US/firefox/68.0a2/whatsnew/

## Issue / Bugzilla link
#7043

## Testing
- [ ] Sticky newsletter prompt should be displayed at the two above URLs if already signed-in to FxA.