### PR TITLE
Add data-card-tag attribute to card macro (Fixes #7090)

### DIFF
--- a/bedrock/base/templates/macros-protocol.html
+++ b/bedrock/base/templates/macros-protocol.html
@@ -97,7 +97,7 @@
 {# Card: https://protocol.mozilla.org/patterns/molecules/card.html #}
 {% macro card(title, ga_title, image_url, link_url, desc=None, meta=None, cta=None, tag_label=None, media_icon=None, class=None, heading_level=2, aspect_ratio='mzp-has-aspect-3-2', include_highres_image=False, highres_image_url=None, youtube_id=None) -%}
 <section class="mzp-c-card {% if class %}{{ class }}{% endif %} {% if aspect_ratio %}{{ aspect_ratio }}{% endif %} {% if media_icon %}{{ media_icon }}{% endif %} {% if youtube_id %}has-video-embed{% endif %}">
-  <a class="mzp-c-card-block-link" href="{{ link_url }}" data-link-name="{{ ga_title }}" data-link-type="link" data-link-group="card">
+  <a class="mzp-c-card-block-link" href="{{ link_url }}" data-link-name="{{ ga_title }}" data-link-type="link" data-link-group="card" {% if tag_label %}data-card-tag="{{ tag_label }}"{% endif %}>
     <div class="mzp-c-card-media-wrapper">
       {# The highres_image_url parameter is for passing in a full URL to a highres image. #}
       {# While the include_highres_image is for allowing the lazy_img helper to figure out the name of the highres version. #}


### PR DESCRIPTION
## Description
- Adds `data-card-tag` attribute to Protocol card macro for GA.

## Issue / Bugzilla link
#7090

## Testing
- [ ] Cards with a tag label should also have a `data-card-tag` attribute with the same value.