### PR TITLE
Add French version of EU Elections page

### DIFF
--- a/bedrock/firefox/templates/firefox/election/index-fr.html
+++ b/bedrock/firefox/templates/firefox/election/index-fr.html
@@ -1,0 +1,59 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. #}
+
+{% from "macros-protocol.html" import hero, content_card with context %}
+
+{% extends "base-protocol.html" %}
+
+{% block page_title %}Votre Europe. Votre vote. Vos outils.{% endblock %}
+{% block page_desc %}Internet a changé la façon dont les gens votent. Préparez-vous aux élections européennes avec des outils qui vous aident à comprendre tous leurs enjeux.{% endblock %}
+
+{% block page_css %}
+  {{ css_bundle('firefox_election') }}
+{% endblock %}
+
+{% block body_id %}election{% endblock %}
+
+{% block body_class %}election{% endblock %}
+
+{% block site_header %}
+  {% include 'includes/protocol/navigation/index.html' %}
+{% endblock %}
+
+{% block content %}
+<main class="mzp-t-firefox">
+
+  {% call hero(
+    title=_('Votre Europe.<br> Votre vote.<br> Vos outils.')|safe,
+    class='mzp-has-image mzp-u-no-shape mzp-t-firefox',
+    heading_level=1,
+    desc="Internet a changé la façon dont les gens votent. Préparez-vous aux élections européennes avec des outils qui vous aident à comprendre tous leurs enjeux."
+  ) %}
+  {% endcall %}
+
+  <div class="mzp-l-content">
+    <div class="mzp-l-card-hero">
+      {{ content_card('card_1') }}
+      {{ content_card('card_2') }}
+      {{ content_card('card_3') }}
+      {{ content_card('card_4') }}
+      {{ content_card('card_5') }}
+    </div>
+
+    <div class="mzp-l-card-half">
+      {{ content_card('card_6') }}
+      {{ content_card('card_7') }}
+    </div>
+    <div class="mzp-l-card-half">
+      {{ content_card('card_8') }}
+      {{ content_card('card_9') }}
+    </div>
+  </div>
+
+</main>
+{% endblock %}
+
+{% block js %}
+  {{ js_bundle('firefox_election') }}
+{% endblock %}

--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -821,12 +821,15 @@ def election_with_cards(request):
     locale = l10n_utils.get_locale(request)
     ctx = {
         'page_content_cards': get_page_content_cards('election-en', locale),
-        'active_locales': ['de', 'en-US']
+        'active_locales': ['de', 'fr', 'en-US']
     }
 
     if locale == 'de':
         template_name = 'firefox/election/index-de.html'
         ctx['page_content_cards'] = get_page_content_cards('election-de', 'de')
+    elif locale == 'fr':
+        template_name = 'firefox/election/index-fr.html'
+        ctx['page_content_cards'] = get_page_content_cards('election-fr', 'fr')
     else:
         template_name = 'firefox/election/index.html'
         ctx['page_content_cards'] = get_page_content_cards('election-en', 'en-US')


### PR DESCRIPTION
## Description

Add French version of EU Elections page.

This needs to be reviewed and approved but can't be merged and pushed until the card 1 content is updated.

## Issue / Bugzilla link

https://github.com/mozilla/bedrock/issues/6849

## Testing
- Card 1 is expected to be in English.
https://bedrock-demo-election.oregon-b.moz.works/fr/firefox/election