### PR TITLE
Import newrelic.agent first in wsgi app

### DIFF
--- a/wsgi/app.py
+++ b/wsgi/app.py
@@ -1,9 +1,6 @@
 # flake8: noqa
-import os
-
-from bedrock.base.config_manager import config
-
-
+# newrelic import & initialization must come first
+# https://docs.newrelic.com/docs/agents/python-agent/installation/python-agent-advanced-integration#manual-integration
 try:
     import newrelic.agent
 except ImportError:
@@ -16,6 +13,11 @@ if newrelic:
         newrelic.agent.initialize(newrelic_ini)
     else:
         newrelic = False
+
+import os
+
+from bedrock.base.config_manager import config
+
 
 IS_HTTPS = os.environ.get('HTTPS', '').strip() == 'on'
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'bedrock.settings')


### PR DESCRIPTION
## Description

We are getting the following message in NR: 
> Some modules were uninstrumented during the current time window: meinheld.server, gunicorn.app.base. Make sure newrelic.agent.initialize() is called before any of these modules are imported. Visit the documentation for more information.

This PR re-orders the imports in the wsgi app as per the message above and [the docs](https://docs.newrelic.com/docs/agents/python-agent/installation/python-agent-advanced-integration#manual-integration).