### PR TITLE
Remove unused ability to use custom newrelic.ini

### DIFF
--- a/wsgi/app.py
+++ b/wsgi/app.py
@@ -5,14 +5,9 @@ try:
     import newrelic.agent
 except ImportError:
     newrelic = False
+else:
+    newrelic.agent.initialize()
 
-
-if newrelic:
-    newrelic_ini = config('NEWRELIC_PYTHON_INI_FILE', default='')
-    if newrelic_ini:
-        newrelic.agent.initialize(newrelic_ini)
-    else:
-        newrelic = False
 
 import os
 


### PR DESCRIPTION
## Description

After https://github.com/mozilla/bedrock/pull/7149 was merged the deployment in https://ci.vpn1.moz.works/blue/organizations/jenkins/bedrock_multibranch_pipeline/detail/master/1643/pipeline failed, with the following traceback:

```
[2019-05-02 19:31:07 +0000] [1693] [ERROR] Exception in worker process
Traceback (most recent call last):
  File "/venv/lib/python2.7/site-packages/gunicorn/arbiter.py", line 578, in spawn_worker
    worker.init_process()
  File "/venv/lib/python2.7/site-packages/gunicorn/workers/base.py", line 126, in init_process
    self.load_wsgi()
  File "/venv/lib/python2.7/site-packages/gunicorn/workers/base.py", line 135, in load_wsgi
    self.wsgi = self.app.wsgi()
  File "/venv/lib/python2.7/site-packages/gunicorn/app/base.py", line 67, in wsgi
    self.callable = self.load()
  File "/venv/lib/python2.7/site-packages/gunicorn/app/wsgiapp.py", line 65, in load
    return self.load_wsgiapp()
  File "/venv/lib/python2.7/site-packages/gunicorn/app/wsgiapp.py", line 52, in load_wsgiapp
    return util.import_app(self.app_uri)
  File "/venv/lib/python2.7/site-packages/gunicorn/util.py", line 352, in import_app
    __import__(module)
  File "/app/wsgi/app.py", line 11, in <module>
    newrelic_ini = config('NEWRELIC_PYTHON_INI_FILE', default='')
NameError: name 'config' is not defined
```

We can't use `config` or `os` without importing them first, but newrelic needs to be imported first. Fortunately, we do not appear to actually use a custom `newrelic.ini` anywhere that I have been able to find, so we can simply remove it.