### PR TITLE
Bug 1549219: don't link to android relnotes under "Desktop" heading a…

### DIFF
--- a/bedrock/firefox/templates/firefox/releases/notes.html
+++ b/bedrock/firefox/templates/firefox/releases/notes.html
@@ -90,13 +90,13 @@
               <div class="mzp-c-navigation-menu">
                 <nav class="mzp-c-menu mzp-is-basic">
                   <ul class="mzp-c-menu-category-list">
-                    {% if release.channel == 'Release' and equivalent_release_url %}
+                    {% if release.channel == 'Release' and release.product == 'Firefox for Android' and equivalent_release_url %}
                       <li class="mzp-c-menu-category"><a class="mzp-c-menu-title" href="{{ equivalent_release_url }}">{{ _('Desktop') }}</a></li>
                     {% else %}
                       <li class="mzp-c-menu-category"><a class="mzp-c-menu-title" href="{{ url('firefox.notes') }}">{{ _('Desktop') }}</a></li>
                     {% endif %}
 
-                    {% if release.channel == 'Release' and equivalent_release_url %}
+                    {% if release.channel == 'Release' and release.product == 'Firefox' and equivalent_release_url %}
                       <li class="mzp-c-menu-category"><a class="mzp-c-menu-title" href="{{ equivalent_release_url }}">{{ _('Android') }}</a></li>
                     {% else %}
                       <li class="mzp-c-menu-category"><a class="mzp-c-menu-title" href="{{ url('firefox.notes', platform='android') }}">{{ _('Android') }}</a></li>


### PR DESCRIPTION
…nd vice-versa

## Description

## Issue / Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1549219
https://github.com/mozilla/bedrock/issues/7156

## Testing
