### PR TITLE
Add 'newrelic.ini' param to newrelic.agent.initialize()

### DIFF
--- a/wsgi/app.py
+++ b/wsgi/app.py
@@ -6,7 +6,7 @@ try:
 except ImportError:
     newrelic = False
 else:
-    newrelic.agent.initialize()
+    newrelic.agent.initialize('newrelic.ini')
 
 
 import os


### PR DESCRIPTION
## Description

The param was previously customizable by env var, but no existing config used a value other than 'newrelic.ini', and I made an incorrect assumption that it was the default when I removed the customization support in https://github.com/mozilla/bedrock/pull/7150  

## Testing

Dev is currently working, need to push to stage to verify fix.
