### PR TITLE
Re-enable /firefox/new/ download test (#6950)

### DIFF
--- a/tests/functional/firefox/new/test_download.py
+++ b/tests/functional/firefox/new/test_download.py
@@ -17,7 +17,6 @@ def test_download_button_displayed(base_url, selenium):
 # Firefox and Internet Explorer don't cope well with file prompts whilst using Selenium.
 @pytest.mark.skip_if_firefox(reason='http://saucelabs.com/jobs/5a8a62a7620f489d92d6193fa67cf66b')
 @pytest.mark.skip_if_internet_explorer(reason='https://github.com/SeleniumHQ/selenium/issues/448')
-@pytest.mark.skip(reason='https://github.com/mozilla/bedrock/issues/6950')
 @pytest.mark.nondestructive
 def test_click_download_button(base_url, selenium):
     page = DownloadPage(selenium, base_url, params='').open()


### PR DESCRIPTION
## Description
- Re-enables a test now that https://github.com/mozilla/bedrock/issues/6950 is finished.

## Issue / Bugzilla link
#6950