### PR TITLE
[no bug] Show footer MoFo link for more languages

### DIFF
--- a/bedrock/base/templates/includes/protocol/site-footer.html
+++ b/bedrock/base/templates/includes/protocol/site-footer.html
@@ -46,7 +46,7 @@
       </ul>
       <div class="mzp-c-footer-legal">
         <p class="mzp-c-footer-license">
-        {% if LANG.startswith('en-') %}
+        {% if LANG.startswith('en-') or LANG.startswith('es-') or LANG in ['de', 'fr', 'pl', 'pt-BR', 'it', 'zh-CN', 'zh-TW', 'ja', 'ko', 'ru'] %}
           {% trans url='https://foundation.mozilla.org', link_type='footer', link_name='Mozilla Foundation' %}
             Visit Mozilla Corporation’s not-for-profit parent, the <a href="{{ url }}" data-link-type="{{ link_type }}" data-link-name="{{ link_name }}">Mozilla Foundation</a>.
           {% endtrans %}


### PR DESCRIPTION
## Description
Recently, at the request of the legal team, we added a sentence to the footer reading "Visit Mozilla Corporation’s not-for-profit parent, the Mozilla Foundation." and linking to foundation.mozilla.org. Since that was a new string in the global footer we wrapped it in an English conditional until other locales could get up to date.

At the time of this PR it's been translated in 61 locales but we have 99 locales active, so I'm hesitant to remove the condition entirely. But at the very least we can expand the subset for now (Janis requested this for German but I took the liberty of including several more).

## Testing
- [x] The sentence appears in en-US, en-CA, en-GB, es-ES, es-MX, es-CL, es-AR, de, fr, pl, pt-BR, it, zh-CN, zh-TW, ja, ko, and ru.
- [x] It does not appear in other locales.