### PR TITLE
Fix typo in /firefox/new/ trailhead page

### DIFF
--- a/bedrock/firefox/templates/firefox/new/trailhead/download-b.html
+++ b/bedrock/firefox/templates/firefox/new/trailhead/download-b.html
@@ -44,7 +44,7 @@
   <section class="features">
     <ul class="mzp-l-card-third mzp-l-content">
       {{ picto_card(title=_('Join Firefox'), desc=_('Connect to a whole family of respectful products, plus all the knowledge you need to protect yourself online.'), class='join') }}
-      {{ picto_card(title=_('Passwords made portable'), desc=_('<strong>Firefox Lockwis</strong>e makes the passwords you save in Firefox available on all your devices.'), class='lockwise') }}
+      {{ picto_card(title=_('Passwords made portable'), desc=_('<strong>Firefox Lockwise</strong> makes the passwords you save in Firefox available on all your devices.'), class='lockwise') }}
       {{ picto_card(title=_('Protect your privacy'), desc=_('<strong>Private Browsing</strong> clears your history to keep it secret from anyone who uses your computer.'), class='private') }}
     </ul>
   </section>

--- a/bedrock/firefox/templates/firefox/new/trailhead/thanks.html
+++ b/bedrock/firefox/templates/firefox/new/trailhead/thanks.html
@@ -8,6 +8,9 @@
 
 {% extends "firefox/new/trailhead/base.html" %}
 
+{# "scene2" page should not be indexed to avoid it appearing in search results: issue 7024 #}
+{% block canonical_urls %}<meta name="robots" content="noindex,follow">{% endblock %}
+
 {% block extrahead %}
   {{ super() }}
   {{ css_bundle('firefox_new_thanks') }}


### PR DESCRIPTION
## Description

- Spotted this typo when extracting strings for l10n.
- Also added another commit to include noindex tag in /thanks/`

## Issue / Bugzilla link
#7177