### PR TITLE
Remove games.mozilla.org from nav and home. (Fixes #7193)

### DIFF
--- a/bedrock/base/templates/includes/protocol/navigation/menu/developers.html
+++ b/bedrock/base/templates/includes/protocol/navigation/menu/developers.html
@@ -48,7 +48,6 @@
                 <ul class="mzp-c-menu-item-list">
                   <li><a href="https://research.mozilla.org/webassembly/?utm_source=www.mozilla.org&amp;utm_medium=referral&amp;utm_campaign=nav&amp;utm_content=developers" data-link-name="Web Assembly" data-link-type="nav" data-link-position="subnav" data-link-group="developers">{{ _('Web Assembly') }}</a></li>
                   <li><a href="https://research.mozilla.org/rust/?utm_source=www.mozilla.org&amp;utm_medium=referral&amp;utm_campaign=nav&amp;utm_content=developers" data-link-name="Rust" data-link-type="nav" data-link-position="subnav" data-link-group="developers">{{ _('Rust') }}</a></li>
-                  <li><a href="https://games.mozilla.org/?utm_source=www.mozilla.org&amp;utm_medium=referral&amp;utm_campaign=nav&amp;utm_content=developers" data-link-name="Gaming" data-link-type="nav" data-link-position="subnav" data-link-group="developers">{{ _('Gaming') }}</a></li>
                   <li><a href="https://mixedreality.mozilla.org/?utm_source=www.mozilla.org&amp;utm_medium=referral&amp;utm_campaign=nav&amp;utm_content=developers" data-link-name="Mixed Reality" data-link-type="nav" data-link-position="subnav" data-link-group="developers">{{ _('Mixed Reality') }}</a></li>
                 </ul>
               </section>

--- a/bedrock/mozorg/templates/mozorg/developer/includes/sub-nav.html
+++ b/bedrock/mozorg/templates/mozorg/developer/includes/sub-nav.html
@@ -10,7 +10,6 @@
 <li><a {% if current == 'developer' %}class="current"{% endif %} href="{{ url('mozorg.developer') }}" data-link-name="Developer Hub" data-link-type="nav" data-link-position="subnav">{{ _('Developer Hub') }}</a></li>
 <li><a href="https://research.mozilla.org/?utm_source=www.mozilla.org&amp;utm_medium=referral&amp;utm_campaign=dev-tech-sub-nav&amp;utm_content=Research" data-link-name="Research" data-link-type="nav" data-link-position="subnav">{{ _('Research') }}</a></li>
 <li><a href="https://vr.mozilla.org/?utm_source=www.mozilla.org&amp;utm_medium=referral&amp;utm_campaign=dev-tech-sub-nav&amp;utm_content=VR" data-link-name="Virtual Reality" data-link-type="nav" data-link-position="subnav">{{ _('Virtual Reality') }}</a></li>
-<li><a href="https://games.mozilla.org/?utm_source=www.mozilla.org&amp;utm_medium=referral&amp;utm_campaign=dev-tech-sub-nav&amp;utm_content=Games" data-link-name="Games" data-link-type="nav" data-link-position="subnav">{{ _('Games') }}</a></li>
 <li><a href="https://developer.mozilla.org/?utm_source=www.mozilla.org&amp;utm_medium=referral&amp;utm_campaign=dev-tech-sub-nav&amp;utm_content=Documentation" data-link-name="Documentation" data-link-type="nav" data-link-position="subnav">{{ _('Documentation') }}</a></li>
 <li><a href="https://hacks.mozilla.org/?utm_source=www.mozilla.org&amp;utm_medium=referral&amp;utm_campaign=dev-tech-sub-nav&amp;utm_content=HacksBlog" data-link-name="Hacks Blog" data-link-type="nav" data-link-position="subnav">{{ _('Hacks blog') }}</a></li>
 {% endblock %}

--- a/bedrock/mozorg/templates/mozorg/home/home.html
+++ b/bedrock/mozorg/templates/mozorg/home/home.html
@@ -197,10 +197,6 @@
           <li id="common-voice">
             <a rel="external" href="https://voice.mozilla.org/"><svg class="icon"><use xlink:href="#icon-common-voice"></use></svg>{{ _('Common Voice') }}</a>
           </li>
-        {% else %}
-          <li id="gaming">
-            <a rel="external" href="https://games.mozilla.org/"><svg class="icon"><use xlink:href="#icon-gaming"></use></svg>{{ _('Gaming on the Web') }}</a>
-          </li>
         {% endif %}
           <li id="vr">
             <a rel="external" href="https://vr.mozilla.org/"><svg class="icon"><use xlink:href="#icon-vr"></use></svg>{{ _('Virtual Reality Platform') }}</a>


### PR DESCRIPTION
## Description
Websites team was asked to remove the gaming link under 'developers' in nav.
R.I.P games.mozilla.org. :ghost:

## Issue / Bugzilla link
#1793

## Testing
games.mozilla.org is removed from navigation.