### PR TITLE
Add 'style' utm param to fxa form (#7238)

### DIFF
--- a/bedrock/base/templates/macros.html
+++ b/bedrock/base/templates/macros.html
@@ -362,7 +362,7 @@
 
     DO NOT include utm_source in this dictionary! (It's already a required param.)
 #}
-{% macro fxa_email_form(entrypoint, utm_source, class_name='fxa-email-form', utm_params={}, intro_text='', button_text='', button_class='js-fxa-cta-link button button-blue') -%}
+{% macro fxa_email_form(entrypoint, utm_source, style, class_name='fxa-email-form', utm_params={}, intro_text='', button_text='', button_class='js-fxa-cta-link button button-blue') -%}
   <form action="{{ settings.FXA_ENDPOINT }}" data-mozillaonline-action="{{ settings.FXA_ENDPOINT_MOZILLAONLINE }}" id="fxa-email-form" class="{{ class_name }}">
     <input type="hidden" name="action" value="email" />
     <input type="hidden" name="context" value="fx_desktop_v3" />
@@ -378,6 +378,9 @@
   {% for attr, val in utm_params.items() %}
     <input type="hidden" name="utm_{{ attr }}" value="{{ val }}" id="fxa-email-form-utm-{{ attr }}" />
   {% endfor %}
+  {% if style %}
+    <input type="hidden" name="style" value="{{ style }}" />
+  {% endif %}
 
     <p class="fxa-email-form-intro">
     {% if intro_text %}

--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx67.0.5.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx67.0.5.html
@@ -39,6 +39,7 @@
                 entrypoint='mozilla.org-whatsnew6705',
                 button_class='mzp-c-button mzp-t-product mzp-t-small',
                 utm_source='whatsnew6705',
+                style='trailhead',
                 utm_params={'campaign': 'fxa-embedded-form', 'content': 'whatsnew', 'medium': 'referral'})
             }}
           {% endblock %}


### PR DESCRIPTION
## Description
Add optional `style` utm parameter to FxA form.
The form on WNP67.0.5 needs to pass `style=trailhead`

## Issue / Bugzilla link
#7238

## Testing
Breaks other fxa forms?