### PR TITLE
Reconfigure frankfurt-prod branch

### DIFF
--- a/jenkins/branches/frankfurt-prod.yml
+++ b/jenkins/branches/frankfurt-prod.yml
@@ -4,8 +4,7 @@ push_public_registry: true
 regions:
   - frankfurt
 apps:
-  - bedrock-stage
   - bedrock-prod
 integration_tests:
   frankfurt:
-    - firefox
+    - headless


### PR DESCRIPTION
Only deploy bedrock-prod
Run headless test suite
This commit triggered https://ci.vpn1.moz.works/blue/organizations/jenkins/bedrock_multibranch_pipeline/detail/frankfurt-prod/24/pipeline