### PR TITLE
Localized /firefox/67.0.1/whatsnew/ URLs redirect to /en-US/ (Fixes #7246)

### DIFF
--- a/bedrock/firefox/tests/test_base.py
+++ b/bedrock/firefox/tests/test_base.py
@@ -402,12 +402,20 @@ class TestWhatsNew(TestCase):
     # begin 67.0.5 whatsnew tests
 
     def test_fx_67_0_5(self, render_mock):
-        """Should use standard template for 67.0"""
+        """Should use trailhead template for 67.0.5"""
         req = self.rf.get('/firefox/whatsnew/')
         req.locale = 'en-US'
         self.view(req, version='67.0.5')
         template = render_mock.call_args[0][1]
         assert template == ['firefox/whatsnew/whatsnew-fx67.0.5.html']
+
+    def test_fx_67_0_5_locales(self, render_mock):
+        """Should use standard template for 67.0.5 for other locales"""
+        req = self.rf.get('/firefox/whatsnew/')
+        req.locale = 'es-ES'
+        self.view(req, version='67.0.5')
+        template = render_mock.call_args[0][1]
+        assert template == ['firefox/whatsnew/whatsnew-fx67.html']
 
     # end 67.0.5 whatsnew tests
 

--- a/bedrock/firefox/tests/test_base.py
+++ b/bedrock/firefox/tests/test_base.py
@@ -401,19 +401,19 @@ class TestWhatsNew(TestCase):
 
     # begin 67.0.5 whatsnew tests
 
-    def test_fx_67_0_5(self, render_mock):
-        """Should use trailhead template for 67.0.5"""
+    def test_fx_67_0_1(self, render_mock):
+        """Should use trailhead template for 67.0.1"""
         req = self.rf.get('/firefox/whatsnew/')
         req.locale = 'en-US'
-        self.view(req, version='67.0.5')
+        self.view(req, version='67.0.1')
         template = render_mock.call_args[0][1]
         assert template == ['firefox/whatsnew/whatsnew-fx67.0.5.html']
 
-    def test_fx_67_0_5_locales(self, render_mock):
-        """Should use standard template for 67.0.5 for other locales"""
+    def test_fx_67_0_1_locales(self, render_mock):
+        """Should use standard template for 67.0.1 for other locales"""
         req = self.rf.get('/firefox/whatsnew/')
         req.locale = 'es-ES'
-        self.view(req, version='67.0.5')
+        self.view(req, version='67.0.1')
         template = render_mock.call_args[0][1]
         assert template == ['firefox/whatsnew/whatsnew-fx67.html']
 

--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -448,6 +448,7 @@ class WhatsnewView(l10n_utils.LangFilesMixin, TemplateView):
 
     def get_template_names(self):
         locale = l10n_utils.get_locale(self.request)
+        trailhead_locales = ['en-US', 'en-CA', 'en-GB', 'de', 'fr']
 
         version = self.kwargs.get('version') or ''
         oldversion = self.request.GET.get('oldversion', '')
@@ -475,7 +476,7 @@ class WhatsnewView(l10n_utils.LangFilesMixin, TemplateView):
             template = 'firefox/whatsnew/index-lite.id.html'
         elif locale == 'zh-TW' and not version.startswith('64.'):
             template = 'firefox/whatsnew/index.zh-TW.html'
-        elif version == '67.0.5' and locale in ['en-US', 'en-CA', 'en-GB', 'de', 'fr']:
+        elif version.startswith('67.0.') and locale in trailhead_locales:
             template = 'firefox/whatsnew/whatsnew-fx67.0.5.html'
         elif version.startswith('67.'):
             template = 'firefox/whatsnew/whatsnew-fx67.html'

--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -475,7 +475,7 @@ class WhatsnewView(l10n_utils.LangFilesMixin, TemplateView):
             template = 'firefox/whatsnew/index-lite.id.html'
         elif locale == 'zh-TW' and not version.startswith('64.'):
             template = 'firefox/whatsnew/index.zh-TW.html'
-        elif version.startswith('67.0.5'):
+        elif version == '67.0.5' and locale in ['en-US', 'en-CA', 'en-GB', 'de', 'fr']:
             template = 'firefox/whatsnew/whatsnew-fx67.0.5.html'
         elif version.startswith('67.'):
             template = 'firefox/whatsnew/whatsnew-fx67.html'


### PR DESCRIPTION
Fixes https://github.com/mozilla/bedrock/issues/7246