### PR TITLE
Show trailhead /whatsnew page for Beta and Dev Edition (Fixes #7248, #7249)

### DIFF
--- a/bedrock/base/templates/macros.html
+++ b/bedrock/base/templates/macros.html
@@ -327,8 +327,8 @@
   </div>
 {%- endmacro %}
 
-{% macro monitor_button(utm_source='', utm_campaign='', button_text='', button_class='mzp-c-button mzp-t-product') -%}
-  <a data-action="{{ settings.FXA_ENDPOINT }}" href="https://monitor.firefox.com/oauth/init?utm_source={{ utm_source }}&utm_campaign={{ utm_campaign }}&form_type=email&entrypoint=mozilla.org-whatsnew6705" class="{{ button_class }}" id="fxa-monitor-submit" data-button-name="Continue">
+{% macro monitor_button(entrypoint='', utm_source='', utm_campaign='', button_text='', button_class='mzp-c-button mzp-t-product') -%}
+  <a data-action="{{ settings.FXA_ENDPOINT }}" href="https://monitor.firefox.com/oauth/init?utm_source={{ utm_source }}&utm_campaign={{ utm_campaign }}&form_type=email&entrypoint={{ entrypoint }}" class="{{ button_class }}" id="fxa-monitor-submit" data-button-name="Continue">
     {% if button_text %}
       {{ button_text }}
     {% else %}

--- a/bedrock/firefox/templates/firefox/developer/whatsnew-fx68-trailhead.html
+++ b/bedrock/firefox/templates/firefox/developer/whatsnew-fx68-trailhead.html
@@ -1,0 +1,25 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+
+{% add_lang_files "firefox/whatsnew_67.0.5" %}
+
+{% extends "firefox/whatsnew/whatsnew-fx67.0.5.html" %}
+
+{% block fxa_form %}
+  {{ fxa_email_form(
+      entrypoint='mozilla.org-whatsnew68a2',
+      button_class='mzp-c-button mzp-t-product mzp-t-small',
+      utm_source='whatsnew68a2',
+      style='trailhead',
+      utm_params={'campaign': 'fxa-embedded-form', 'content': 'whatsnew', 'medium': 'referral'})
+  }}
+{% endblock %}
+
+{% block monitor_button %}
+  {{ monitor_button(
+    entrypoint='mozilla.org-whatsnew68a2',
+    utm_source='whatsnew68a2',
+    utm_campaign='whatsnew68a2'
+  ) }}
+{% endblock %}

--- a/bedrock/firefox/templates/firefox/whatsnew/beta/whatsnew-fx68-trailhead.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/beta/whatsnew-fx68-trailhead.html
@@ -1,0 +1,25 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+
+{% add_lang_files "firefox/whatsnew_67.0.5" %}
+
+{% extends "firefox/whatsnew/whatsnew-fx67.0.5.html" %}
+
+{% block fxa_form %}
+  {{ fxa_email_form(
+      entrypoint='mozilla.org-whatsnew68beta',
+      button_class='mzp-c-button mzp-t-product mzp-t-small',
+      utm_source='whatsnew68beta',
+      style='trailhead',
+      utm_params={'campaign': 'fxa-embedded-form', 'content': 'whatsnew', 'medium': 'referral'})
+  }}
+{% endblock %}
+
+{% block monitor_button %}
+  {{ monitor_button(
+    entrypoint='mozilla.org-whatsnew68beta',
+    utm_source='whatsnew68beta',
+    utm_campaign='whatsnew68beta'
+  ) }}
+{% endblock %}

--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx67.0.5.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx67.0.5.html
@@ -52,10 +52,13 @@
         <div class="mzp-l-hero-content">
           <h2>{{ _('Including Firefox Monitor, your watchful eye for data breaches') }}</h2>
           <p>{{ _('See if your info was compromised in another company’s data breach, and get automatically signed up for future alerts.') }}</p>
-          {{ monitor_button(
-            utm_source='whatsnew6705',
-            utm_campaign='whatsnew6705'
-          ) }}
+          {% block monitor_button %}
+            {{ monitor_button(
+              entrypoint='mozilla.org-whatsnew6705',
+              utm_source='whatsnew6705',
+              utm_campaign='whatsnew6705'
+            ) }}
+          {% endblock %}
         </div>
       </div>
     </div>

--- a/bedrock/firefox/tests/test_base.py
+++ b/bedrock/firefox/tests/test_base.py
@@ -206,9 +206,29 @@ class TestWhatsNew(TestCase):
         assert template == ['firefox/whatsnew/index.html']
 
     @override_settings(DEV=True)
-    def test_fx_beta_68_0_beta_whatsnew(self, render_mock):
-        """Should show beta 68 whatsnew template"""
+    @patch.dict(os.environ, SWITCH_BETA_WHATSNEW_68_TRAILHEAD='True')
+    def test_fx_beta_68_0_trailhead_whatsnew_on(self, render_mock):
+        """Should show beta 68 trailhead template"""
         req = self.rf.get('/en-US/firefox/whatsnew/')
+        self.view(req, version='68.0beta')
+        template = render_mock.call_args[0][1]
+        assert template == ['firefox/whatsnew/beta/whatsnew-fx68-trailhead.html']
+
+    @override_settings(DEV=True)
+    @patch.dict(os.environ, SWITCH_BETA_WHATSNEW_68_TRAILHEAD='False')
+    def test_fx_beta_68_0_trailhead_whatsnew_off(self, render_mock):
+        """Should show beta 68 trailhead template"""
+        req = self.rf.get('/en-US/firefox/whatsnew/')
+        self.view(req, version='68.0beta')
+        template = render_mock.call_args[0][1]
+        assert template == ['firefox/whatsnew/beta/whatsnew-fx68.html']
+
+    @override_settings(DEV=True)
+    @patch.dict(os.environ, SWITCH_BETA_WHATSNEW_68_TRAILHEAD='True')
+    def test_fx_beta_68_0_trailhead_non_locales(self, render_mock):
+        """Should show beta 68 whatsnew template"""
+        req = self.rf.get('/firefox/whatsnew/')
+        req.locale = 'es-ES'
         self.view(req, version='68.0beta')
         template = render_mock.call_args[0][1]
         assert template == ['firefox/whatsnew/beta/whatsnew-fx68.html']
@@ -235,9 +255,31 @@ class TestWhatsNew(TestCase):
 
     @override_settings(DEV=True)
     @patch.dict(os.environ, SWITCH_DEV_WHATSNEW_68='True')
-    def test_fx_dev_browser_68_0_a2_whatsnew_on(self, render_mock):
-        """Should show dev browser 68 whatsnew template"""
+    @patch.dict(os.environ, SWITCH_DEV_WHATSNEW_68_TRAILHEAD='True')
+    def test_fx_dev_browser_68_0_a2_trailhead_on(self, render_mock):
+        """Should show dev browser 68 trailhead template"""
         req = self.rf.get('/en-US/firefox/whatsnew/')
+        self.view(req, version='68.0a2')
+        template = render_mock.call_args[0][1]
+        assert template == ['firefox/developer/whatsnew-fx68-trailhead.html']
+
+    @override_settings(DEV=True)
+    @patch.dict(os.environ, SWITCH_DEV_WHATSNEW_68='True')
+    @patch.dict(os.environ, SWITCH_DEV_WHATSNEW_68_TRAILHEAD='False')
+    def test_fx_dev_browser_68_0_a2_trailhead_off(self, render_mock):
+        """Should show dev browser 68 trailhead template"""
+        req = self.rf.get('/en-US/firefox/whatsnew/')
+        self.view(req, version='68.0a2')
+        template = render_mock.call_args[0][1]
+        assert template == ['firefox/developer/whatsnew-fx68.html']
+
+    @override_settings(DEV=True)
+    @patch.dict(os.environ, SWITCH_DEV_WHATSNEW_68='True')
+    @patch.dict(os.environ, SWITCH_DEV_WHATSNEW_68_TRAILHEAD='True')
+    def test_fx_dev_browser_68_0_a2_trailhead_non_locales(self, render_mock):
+        """Should show dev browser 68 whatsnew template"""
+        req = self.rf.get('/firefox/whatsnew/')
+        req.locale = 'es-ES'
         self.view(req, version='68.0a2')
         template = render_mock.call_args[0][1]
         assert template == ['firefox/developer/whatsnew-fx68.html']

--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -462,14 +462,20 @@ class WhatsnewView(l10n_utils.LangFilesMixin, TemplateView):
             template = 'firefox/nightly_whatsnew.html'
         elif channel == 'alpha':
             if version.startswith('68.') and switch('dev_whatsnew_68'):
-                template = 'firefox/developer/whatsnew-fx68.html'
+                if locale in trailhead_locales and switch('dev_whatsnew_68_trailhead'):
+                    template = 'firefox/developer/whatsnew-fx68-trailhead.html'
+                else:
+                    template = 'firefox/developer/whatsnew-fx68.html'
             elif show_57_dev_whatsnew(version):
                 template = 'firefox/developer/whatsnew.html'
             else:
                 template = 'firefox/dev-whatsnew.html'
         elif channel == 'beta':
             if version.startswith('68.'):
-                template = 'firefox/whatsnew/beta/whatsnew-fx68.html'
+                if locale in trailhead_locales and switch('beta_whatsnew_68_trailhead'):
+                    template = 'firefox/whatsnew/beta/whatsnew-fx68-trailhead.html'
+                else:
+                    template = 'firefox/whatsnew/beta/whatsnew-fx68.html'
             else:
                 template = 'firefox/whatsnew/index.html'
         elif locale == 'id':


### PR DESCRIPTION
## Description
- Shows the trailhead WNP for Beta and Dev Edition:
  - `/firefox/68.0beta/whatsnew/`
  - `/firefox/68.0a2/whatsnew/`
- Updates UTM params to attribute referals from each URL.

## Issue / Bugzilla link
#7248
#7249

## Testing
- [x] Pages should show as expected at each URL.