### PR TITLE
Buttons and links to FxA trigger FxA-Sync event action only (#7252)

### DIFF
--- a/bedrock/base/templates/includes/protocol/navigation/index.html
+++ b/bedrock/base/templates/includes/protocol/navigation/index.html
@@ -25,7 +25,7 @@
         <div class="mzp-c-navigation-download">
           {{ download_firefox(alt_copy=_('Download Firefox'), dom_id='protocol-nav-download-firefox', button_color='mzp-t-secondary mzp-t-small', download_location='nav') }}
           <div class="c-navigation-fxa-cta-container">
-            <a class="c-navigation-fxa-cta mzp-c-button mzp-t-secondary mzp-t-small mzp-t-product" {{ fxa_link_fragment(entrypoint='mozilla.org-globalnav', action='signup', utm_params={'campaign': 'globalnav', 'content': 'get-firefox-account', 'medium': 'referral', 'source': 'www.mozilla.org'}) }} data-button-name="Get a Firefox Account" data-link-type="FxA-Sync" data-cta-position="secondary cta" data-alt-href="{{ url('firefox.accounts') }}">
+            <a class="c-navigation-fxa-cta mzp-c-button mzp-t-secondary mzp-t-small mzp-t-product" {{ fxa_link_fragment(entrypoint='mozilla.org-globalnav', action='signup', utm_params={'campaign': 'globalnav', 'content': 'get-firefox-account', 'medium': 'referral', 'source': 'www.mozilla.org'}) }} data-link-name="Get a Firefox Account" data-link-type="FxA-Sync" data-cta-position="secondary cta" data-alt-href="{{ url('firefox.accounts') }}">
               {{ _('Get a Firefox Account') }}
             </a>
             <p class="c-navigation-fxa-cta-small-link"><a data-link-type="nav" data-link-name="Check out the Benefits" href="{{ url('firefox.accounts') }}">{{ _('Check out the Benefits') }}</a></p>

--- a/bedrock/base/templates/macros.html
+++ b/bedrock/base/templates/macros.html
@@ -250,7 +250,7 @@
 {%- endmacro %}
 
 {% macro fxa_cta_link(entrypoint, campaign, content, source, button_class, button_location, button_text, account_id, action='signin', medium='referral') %}
-  <a {{ fxa_link_fragment(entrypoint=entrypoint, action="{{ action }}", utm_params={'campaign': campaign, 'content': (content or request.path_info), 'source': source, 'medium': medium }) }} class="js-fxa-cta-link {{ button_class }}" data-button-name="Create account" data-link-type="FxA-Sync" data-cta-position="{{ button_location }}" id="{{ account_id }}">
+  <a {{ fxa_link_fragment(entrypoint=entrypoint, action="{{ action }}", utm_params={'campaign': campaign, 'content': (content or request.path_info), 'source': source, 'medium': medium }) }} class="js-fxa-cta-link {{ button_class }}" data-link-name="Create account" data-link-type="FxA-Sync" data-cta-position="{{ button_location }}" id="{{ account_id }}">
     {{ button_text }}
   </a>
 {%- endmacro %}
@@ -299,7 +299,7 @@
     {{ download_firefox(dom_id=download_id, download_location=button_location) }}
   </div>
   <div class="show-fxa-supported-signed-out">
-    <a {{ fxa_link_fragment(entrypoint=entrypoint, action='signup', utm_params={'campaign': campaign, 'content': (content or request.path_info), 'source': source}) }} class="button {{ button_class }}" data-button-name="Create account" data-link-type="FxA-Sync" data-cta-position="{{ button_location }}" id="{{ account_id }}">
+    <a {{ fxa_link_fragment(entrypoint=entrypoint, action='signup', utm_params={'campaign': campaign, 'content': (content or request.path_info), 'source': source}) }} class="button {{ button_class }}" data-link-name="Create account" data-link-type="FxA-Sync" data-cta-position="{{ button_location }}" id="{{ account_id }}">
       {{ button_text }}
     </a>
   </div>
@@ -367,10 +367,11 @@
     DO NOT include utm_source in this dictionary! (It's already a required param.)
 #}
 {% macro fxa_email_form(entrypoint, utm_source, style, class_name='fxa-email-form', utm_params={}, form_title='', intro_text='', button_text='', button_class='js-fxa-cta-link button button-blue') -%}
+  {% set service  = 'sync' %}
   <form action="{{ settings.FXA_ENDPOINT }}" data-mozillaonline-action="{{ settings.FXA_ENDPOINT_MOZILLAONLINE }}" id="fxa-email-form" class="{{ class_name }}">
     <input type="hidden" name="action" value="email" />
     <input type="hidden" name="context" value="fx_desktop_v3" />
-    <input type="hidden" name="service" value="sync" />
+    <input type="hidden" name="service" value="{{ service }}" />
     <input type="hidden" name="entrypoint" value="{{ entrypoint }}" id="fxa-email-form-entrypoint" />
     <input type="hidden" name="form_type" value="email" />
     {# flow_id and flow_begin_time will be populated via JS on page load #}
@@ -411,7 +412,7 @@
         <input type="email" name="email" id="fxa-email-field" class="fxa-email-field" placeholder="user@example.com" required>
       </p>
 
-      <button type="submit" class="{{ button_class }}" id="fxa-email-form-submit" data-button-name="Continue">
+      <button type="submit" class="{{ button_class }}" id="fxa-email-form-submit" data-link-type="FxA-{{ service|title }}" data-link-name="Continue">
       {% if button_text %}
         {{ button_text }}
       {% else %}

--- a/bedrock/firefox/templates/firefox/accounts-2018.html
+++ b/bedrock/firefox/templates/firefox/accounts-2018.html
@@ -290,7 +290,7 @@
             button_text=_('Create an Account'))
           }}
 
-          <p class="fxa-signin">{{ _('Already have an account?') }} <a {{ fxa_link_fragment(entrypoint='mozzila.org-accounts_page', action='signin', utm_params={'campaign': 'fxa-embedded-form', 'content': '/firefox/accounts/', 'source': 'accounts-page'}) }}>{{ _('Sign In') }}</a></p>
+          <p class="fxa-signin">{{ _('Already have an account?') }} <a {{ fxa_link_fragment(entrypoint='mozilla.org-accounts_page', action='signin', utm_params={'campaign': 'fxa-embedded-form', 'content': '/firefox/accounts/', 'source': 'accounts-page'}) }}>{{ _('Sign In') }}</a></p>
         </div>
       </div>
 

--- a/bedrock/firefox/templates/firefox/whatsnew/beta/whatsnew-fx68.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/beta/whatsnew-fx68.html
@@ -17,7 +17,7 @@
 
 {% block fxa_cta %}
 <p class="show-fxa-supported-signed-out show-fxa-default">
-  <a {{ fxa_link_fragment(entrypoint='mozilla.org-whatsnew68beta', action='signup', utm_params={'campaign': 'wnp68beta', 'content': 'accounts-page-top-cta', 'medium': 'referral', 'source': 'wnp68beta'}) }} class="mzp-c-button mzp-t-product" data-button-name="Create account" data-link-type="FxA-Sync">
+  <a {{ fxa_link_fragment(entrypoint='mozilla.org-whatsnew68beta', action='signup', utm_params={'campaign': 'wnp68beta', 'content': 'accounts-page-top-cta', 'medium': 'referral', 'source': 'wnp68beta'}) }} class="mzp-c-button mzp-t-product" data-link-name="Create account" data-link-type="FxA-Sync">
     {{ _('Create a Firefox Account') }}
   </a><br>
 


### PR DESCRIPTION
## Description

In #7061 it was decided that when we send someone to FxA we would like to record it in GA with an Event Action that includes FxA. `FxA-ServiceName` was decided on with `FxA-Sync` being the only service currently passed to FxA from moz.org.

With the work on #7197 I realized the button in the fxa_email_form was not updated at that time.

In testing that I realized that the other links we updated in #7113 were sending two events for each click.

<img width="568" alt="Screen Shot 2019-05-29 at 5 25 49 PM" src="https://user-images.githubusercontent.com/854701/58600197-7721e400-8238-11e9-9cba-125de9e03dcc.png">

This PR:

- Updates fxa_email_form to trigger event action FxA-Sync click (via the data-link-type attribute)
- Changes data-button-name to data-link-name when link-name is FxA to improve data quality

## Issue / Bugzilla link

Fix #7252

## Testing
- [ ] data-link-type and data-button-name should not be present on the same elements
- [ ] things that send users to FxA should have `data-link-type="FxA-Sync"`