### PR TITLE
Use standardized adjust links across the site (Fixes #7214)

### DIFF
--- a/bedrock/base/templates/macros.html
+++ b/bedrock/base/templates/macros.html
@@ -54,7 +54,7 @@
 </aside>
 {%- endmacro %}
 
-{% macro google_play_button(class_name='', extra_data_attributes={}, extra_img_attributes={}, href=settings.GOOGLE_PLAY_FIREFOX_LINK, id='', product='Firefox', target='') -%}
+{% macro google_play_button(class_name='', extra_data_attributes={}, extra_img_attributes={}, href=settings.GOOGLE_PLAY_FIREFOX_LINK_UTMS, id='', product='Firefox', target='') -%}
 {% set optional_img_attributes = {'alt': _('Get it on Google Play'), 'width': '152', 'height': '45', 'l10n': True} %}
 {% do optional_img_attributes.update(extra_img_attributes) %}
 <a{% if class_name %} class="{{ class_name }}"{% endif %}{% if id %} id="{{ id }}"{% endif %}{% if target %} target="{{ target }}" rel="external noopener noreferrer"{% else %} rel="external"{% endif %} href="{{ href }}"{% if product in ['Firefox', 'Focus'] %} data-link-type="download" data-download-os="Android"{% endif %}{% if product == 'Firefox' %} data-mozillaonline-link="{{ settings.GOOGLE_PLAY_FIREFOX_LINK_MOZILLAONLINE }}"{% endif %}{% for attr, val in extra_data_attributes.items() %} data-{{ attr }}="{{ val }}"{% endfor %}>
@@ -70,7 +70,7 @@
   {% if ios_link == '' %}
     {% set ios_link = firefox_ios_url('mozorg') %}
   {% endif %}
-  {% set android_link = settings.GOOGLE_PLAY_FIREFOX_LINK %}
+  {% set android_link = settings.GOOGLE_PLAY_FIREFOX_LINK_UTMS %}
   <section id="send-to-device" class="{% if include_logo %}logo {% endif %}{% if include_title %}title{% else %}no-title{% endif %}" data-countries="{{ send_to_device_sms_countries(message_set) }}"{% if spinner_color %} data-spinner-color="{{ spinner_color }}"{% endif %}>
     <div class="form-container">
       {% if include_title %}

--- a/bedrock/firefox/firefox_details.py
+++ b/bedrock/firefox/firefox_details.py
@@ -344,7 +344,7 @@ class FirefoxAndroid(_ProductDetails):
         'release': 'fennec-latest',
     }
 
-    store_url = settings.GOOGLE_PLAY_FIREFOX_LINK
+    store_url = settings.GOOGLE_PLAY_FIREFOX_LINK_UTMS
     # Product IDs defined on Google Play
     # Nightly reuses the Aurora ID to migrate the user base
     store_product_ids = {

--- a/bedrock/firefox/templates/firefox/accounts-2018.html
+++ b/bedrock/firefox/templates/firefox/accounts-2018.html
@@ -93,15 +93,15 @@
     {% endif %}
 
     <div>
-      <a class="mzp-c-button mzp-t-secondary mzp-t-product" href="https://app.adjust.com/kq8zhhz" data-link-name="Get the Lockbox App" data-link-type="button">{{ _('Get the Lockbox App') }}</a>
+      <a class="mzp-c-button mzp-t-secondary mzp-t-product" href="https://lockwise.firefox.com/" data-link-name="Get the Lockbox App" data-link-type="button">{{ _('Get the Lockbox App') }}</a>
     </div>
 
     <ul class="mobile-content">
       <li class="android">
-          {{ google_play_button(href='https://app.adjust.com/kq8zhhz') }}
+          {{ google_play_button(href=lockwise_adjust_url('android', 'accounts-page')) }}
       </li>
       <li class="ios">
-        <a href="https://app.adjust.com/kq8zhhz" data-link-type="download" data-download-os="iOS">
+        <a href="{{ lockwise_adjust_url('ios', 'accounts-page') }}" data-link-type="download" data-download-os="iOS">
           <img src="{{ l10n_img('firefox/ios/btn-app-store.svg') }}" alt="{{ _('Download on the App Store') }}" width="152" height="45">
         </a>
       </li>
@@ -162,10 +162,10 @@
 
     <ul class="mobile-content">
       <li class="android">
-        {{ google_play_button(href='https://app.adjust.com/h5iycst') }}
+        {{ google_play_button(href=pocket_adjust_url('android', 'accounts-page')) }}
       </li>
       <li class="ios">
-        <a href="https://app.adjust.com/h5iycst" data-link-type="download" data-download-os="iOS">
+        <a href="{{ pocket_adjust_url('ios', 'accounts-page') }}" data-link-type="download" data-download-os="iOS">
           <img src="{{ l10n_img('firefox/ios/btn-app-store.svg') }}" alt="{{ _('Download on the App Store') }}" width="152" height="45">
         </a>
       </li>
@@ -228,10 +228,10 @@
   <section>
     <ul class="mobile-download-buttons mobile-pocket">
       <li class="android">
-        {{ google_play_button(href='https://app.adjust.com/h5iycst') }}
+        {{ google_play_button(href=pocket_adjust_url('android', 'accounts-page')) }}
       </li>
       <li class="ios">
-        <a href="https://app.adjust.com/h5iycst" data-link-type="download" data-download-os="iOS">
+        <a href="{{ pocket_adjust_url('ios', 'accounts-page') }}" data-link-type="download" data-download-os="iOS">
           <img src="{{ l10n_img('firefox/ios/btn-app-store.svg') }}" alt="{{ _('Download on the App Store') }}" width="152" height="45">
         </a>
       </li>
@@ -241,10 +241,10 @@
   <section>
     <ul class="mobile-download-buttons mobile-lockbox">
       <li class="android">
-          {{ google_play_button(href='https://app.adjust.com/kq8zhhz') }}
+          {{ google_play_button(href=lockwise_adjust_url('android','accounts-page')) }}
       </li>
       <li class="ios">
-        <a href="https://app.adjust.com/kq8zhhz" data-link-type="download" data-download-os="iOS">
+        <a href="{{ lockwise_adjust_url('ios', 'accounts-page') }}" data-link-type="download" data-download-os="iOS">
           <img src="{{ l10n_img('firefox/ios/btn-app-store.svg') }}" alt="{{ _('Download on the App Store') }}" width="152" height="45">
         </a>
       </li>

--- a/bedrock/firefox/templates/firefox/facebookcontainer/index.html
+++ b/bedrock/firefox/templates/firefox/facebookcontainer/index.html
@@ -49,10 +49,10 @@
 
             <ul class="mobile-download-buttons">
               <li class="android">
-                {{ google_play_button(href=settings.GOOGLE_PLAY_FIREFOX_FOCUS_LINK, id='playStoreLink', product='Focus') }}
+                {{ google_play_button(href=focus_adjust_url('android', 'fb-container-page'), id='playStoreLink', product='Focus') }}
               </li>
               <li class="ios">
-                <a id="appStoreLink" href="{{ settings.APPLE_APPSTORE_FIREFOX_FOCUS_LINK }}" data-link-type="download" data-download-os="iOS">
+                <a id="appStoreLink" href="{{ focus_adjust_url('ios', 'fb-container-page') }}" data-link-type="download" data-download-os="iOS">
                   <img src="{{ l10n_img('firefox/ios/btn-app-store.svg') }}" alt="{{ _('Download on the App Store') }}" width="152" height="45">
                 </a>
               </li>

--- a/bedrock/firefox/templates/firefox/fights-for-you.de.html
+++ b/bedrock/firefox/templates/firefox/fights-for-you.de.html
@@ -77,7 +77,7 @@
       image_url='firefox/fights-for-you/pic-focus.jpg',
       aspect_ratio='mzp-has-aspect-16-9',
       class='mzp-l-card-feature-right-third mzp-t-firefox fffy-t-focus',
-      link_url='https://app.adjust.com/rtnpf1x',
+      link_url=url('firefox.mobile'),
       link_cta='Hol Dir Firefox Klar',
       ga_title='Download Firefox Focus'
     ) %}
@@ -85,10 +85,10 @@
 
       <ul class="app-store-badges u-mobile-content">
         <li class="badge-android">
-          {{ google_play_button(href='https://mzl.la/2tabw1i', id='playStoreLink', product='Klar', extra_data_attributes={'download-product': 'Klar', 'download-version': 'android', 'download-location': 'primary cta'}) }}
+          {{ google_play_button(href=focus_adjust_url('android', 'fights-for-you-page'), id='playStoreLink', product='Klar', extra_data_attributes={'download-product': 'Klar', 'download-version': 'android', 'download-location': 'primary cta'}) }}
         </li>
         <li class="badge-ios">
-          <a id="appStoreLink" href="https://mzl.la/2JSz6da" data-link-type="download" data-download-os="iOS" data-download-product="Klar" data-download-version="ios" data-download-location="primary cta">
+          <a id="appStoreLink" href="{{ focus_adjust_url('ios', 'fights-for-you-page') }}" data-link-type="download" data-download-os="iOS" data-download-product="Klar" data-download-version="ios" data-download-location="primary cta">
             <img src="{{ l10n_img('firefox/ios/btn-app-store.svg') }}" alt="{{ _('Download on the App Store') }}" width="152" height="45">
           </a>
         </li>

--- a/bedrock/firefox/templates/firefox/fights-for-you.fr.html
+++ b/bedrock/firefox/templates/firefox/fights-for-you.fr.html
@@ -77,7 +77,7 @@
       image_url='firefox/fights-for-you/pic-focus.jpg',
       aspect_ratio='mzp-has-aspect-16-9',
       class='mzp-l-card-feature-right-third mzp-t-firefox fffy-t-focus',
-      link_url='https://app.adjust.com/oh460vy',
+      link_url=url('firefox.mobile'),
       link_cta='Télécharger Firefox Focus',
       ga_title='Download Firefox Focus'
     ) %}
@@ -85,10 +85,10 @@
 
       <ul class="app-store-badges u-mobile-content">
         <li class="badge-android">
-          {{ google_play_button(href='https://mzl.la/2tabw1i', id='playStoreLink', product='Klar', extra_data_attributes={'download-product': 'Klar', 'download-version': 'android', 'download-location': 'primary cta'}) }}
+          {{ google_play_button(href=focus_adjust_url('android', 'fights-for-you-page'), id='playStoreLink', product='Focus', extra_data_attributes={'download-product': 'Focus', 'download-version': 'android', 'download-location': 'primary cta'}) }}
         </li>
         <li class="badge-ios">
-          <a id="appStoreLink" href="https://mzl.la/2JSz6da" data-link-type="download" data-download-os="iOS" data-download-product="Klar" data-download-version="ios" data-download-location="primary cta">
+          <a id="appStoreLink" href="{{ focus_adjust_url('ios', 'fights-for-you-page') }}" data-link-type="download" data-download-os="iOS" data-download-product="Focus" data-download-version="ios" data-download-location="primary cta">
             <img src="{{ l10n_img('firefox/ios/btn-app-store.svg') }}" alt="{{ _('Download on the App Store') }}" width="152" height="45">
           </a>
         </li>

--- a/bedrock/firefox/templates/firefox/mobile.html
+++ b/bedrock/firefox/templates/firefox/mobile.html
@@ -64,10 +64,10 @@
               <div class="mobile-download-buttons-wrapper">
                 <ul class="mobile-download-buttons firefox" id="mobile-download-buttons-firefox">
                   <li class="android">
-                    {{ google_play_button(href='https://app.adjust.com/2uo1qc?campaign=desktop_xp&amp;adgroup=Google_Play_Store&amp;creative=badge_en', id='playStoreLink') }}
+                    {{ google_play_button(href=firefox_adjust_url('android', 'mobile-page'), id='playStoreLink') }}
                   </li>
                   <li class="ios">
-                    <a id="appStoreLink" href="https://app.adjust.com/2uo1qc?campaign=desktop_xp&amp;adgroup=iOS_App_Store&amp;creative=badge_en&amp;fallback=https%3A%2F%2Fitunes.apple.com%2Fapp%2Fapple-store%2Fid989804926%3Fpt%3D373246%26ct%3Dadjust_tracker%26mt%3D8" data-link-type="download" data-download-os="iOS">
+                    <a id="appStoreLink" href="{{ firefox_adjust_url('ios', 'mobile-page') }}" data-link-type="download" data-download-os="iOS">
                       <img src="{{ l10n_img('firefox/ios/btn-app-store.svg') }}" alt="{{ _('Download on the App Store') }}" width="152" height="45">
                     </a>
                   </li>
@@ -98,7 +98,7 @@
               <div class="mobile-download-buttons-wrapper">
                 <ul class="mobile-download-buttons focus" id="mobile-download-buttons-focus">
                   <li class="android">
-                    {{ google_play_button(href=settings.GOOGLE_PLAY_FIREFOX_FOCUS_LINK, id='playStoreLink', product='Focus') }}
+                    {{ google_play_button(href=focus_adjust_url('android', 'mobile-page'), id='playStoreLink', product='Focus') }}
                   </li>
                   {% if l10n_has_tag('focus_apk_link_012018') %}
                   <li class="android-apk">
@@ -106,7 +106,7 @@
                   </li>
                   {% endif %}
                   <li class="ios">
-                    <a id="appStoreLink" href="{{ settings.APPLE_APPSTORE_FIREFOX_FOCUS_LINK }}" data-link-type="download" data-download-os="iOS">
+                    <a id="appStoreLink" href="{{ focus_adjust_url('ios', 'mobile-page') }}" data-link-type="download" data-download-os="iOS">
                       <img src="{{ l10n_img('firefox/ios/btn-app-store.svg') }}" alt="{{ _('Download on the App Store') }}" width="152" height="45">
                     </a>
                   </li>

--- a/bedrock/firefox/templates/firefox/whatsnew/fx64/whatsnew-fx64-base.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/fx64/whatsnew-fx64-base.html
@@ -92,7 +92,7 @@
       {{ high_res_img('firefox/whatsnew_64/fxa-lockbox.png', {'alt': '', 'width': '590', 'height': '590'}) }}
       <h3>{{ lockbox_head }}</h3>
       <p>{{ lockbox_desc }}</p>
-      <p><a class="mzp-c-button wn64-benefit-link" data-app="lockbox" href="https://app.adjust.com/orzhlh0">{{ lockbox_link }}</a></p>
+      <p><a class="mzp-c-button wn64-benefit-link" data-app="lockbox" href="https://lockwise.firefox.com/">{{ lockbox_link }}</a></p>
     </div>
 
     <div class="wn64-benefit wn64-pocket">
@@ -135,7 +135,7 @@
       <img class="mobile-qr" src="{{ static('img/firefox/whatsnew_64/lockbox-qr.png') }}" height="300" width="300">
         <ul class="mobile-download-buttons mobile-lockbox">
         <li class="ios">
-          <a href="https://app.adjust.com/kq8zhhz" data-link-type="download" data-download-os="iOS">
+          <a href="{{ lockwise_adjust_url('ios', 'whatsnew-64-page') }}" data-link-type="download" data-download-os="iOS">
             <img src="{{ l10n_img('firefox/ios/btn-app-store.svg') }}" alt="" width="152" height="45">
           </a>
         </li>
@@ -145,10 +145,10 @@
         <img class="mobile-qr" src="{{ static('img/firefox/whatsnew_64/pocket-qr.png') }}" height="300" width="300">
         <ul class="mobile-download-buttons mobile-pocket">
           <li class="android">
-            {{ google_play_button(href='https://app.adjust.com/h5iycst') }}
+            {{ google_play_button(href=pocket_adjust_url('android', 'whatsnew-64-page')) }}
           </li>
           <li class="ios">
-            <a href="https://app.adjust.com/h5iycst" data-link-type="download" data-download-os="iOS">
+            <a href="{{ pocket_adjust_url('ios', 'whatsnew-64-page') }}" data-link-type="download" data-download-os="iOS">
               <img src="{{ l10n_img('firefox/ios/btn-app-store.svg') }}" alt="" width="152" height="45">
             </a>
           </li>

--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx66.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx66.html
@@ -166,7 +166,7 @@
       <img class="mobile-qr" src="{{ static('img/firefox/whatsnew_64/lockbox-qr.png') }}" height="300" width="300">
         <ul class="mobile-download-buttons mobile-lockbox">
         <li class="ios">
-          <a href="https://app.adjust.com/kq8zhhz" data-link-type="download" data-download-os="iOS">
+          <a href="{{ lockwise_adjust_url('ios', 'whatsnew-64-page') }}" data-link-type="download" data-download-os="iOS">
             <img src="{{ l10n_img('firefox/ios/btn-app-store.svg') }}" alt="" width="152" height="45">
           </a>
         </li>
@@ -177,10 +177,10 @@
         <img class="mobile-qr" src="{{ static('img/firefox/whatsnew_64/pocket-qr.png') }}" height="300" width="300">
         <ul class="mobile-download-buttons mobile-pocket">
           <li class="android">
-            {{ google_play_button(href='https://app.adjust.com/h5iycst') }}
+            {{ google_play_button(href=pocket_adjust_url('android', 'whatsnew-64-page')) }}
           </li>
           <li class="ios">
-            <a href="https://app.adjust.com/h5iycst" data-link-type="download" data-download-os="iOS">
+            <a href="{{ pocket_adjust_url('ios', 'whatsnew-64-page') }}" data-link-type="download" data-download-os="iOS">
               <img src="{{ l10n_img('firefox/ios/btn-app-store.svg') }}" alt="" width="152" height="45">
             </a>
           </li>

--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx67.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx67.html
@@ -143,10 +143,10 @@
       <img class="mobile-qr" src="{{ static('img/firefox/whatsnew_64/lockbox-qr.png') }}" height="300" width="300">
       <ul class="mobile-download-buttons mobile-lockbox">
         <li class="android">
-          {{ google_play_button(href='https://app.adjust.com/kq8zhhz') }}
+          {{ google_play_button(href=lockwise_adjust_url('android', 'whatsnew-67-page')) }}
         </li>
         <li class="ios">
-          <a href="https://app.adjust.com/kq8zhhz" data-link-type="download" data-download-os="iOS">
+          <a href="{{ lockwise_adjust_url('ios', 'whatsnew-67-page') }}" data-link-type="download" data-download-os="iOS">
             <img src="{{ l10n_img('firefox/ios/btn-app-store.svg') }}" alt="" width="152" height="45">
           </a>
         </li>
@@ -157,10 +157,10 @@
         <img class="mobile-qr" src="{{ static('img/firefox/whatsnew_64/pocket-qr.png') }}" height="300" width="300">
         <ul class="mobile-download-buttons mobile-pocket">
           <li class="android">
-            {{ google_play_button(href='https://app.adjust.com/h5iycst') }}
+            {{ google_play_button(href=pocket_adjust_url('android', 'whatsnew-67-page')) }}
           </li>
           <li class="ios">
-            <a href="https://app.adjust.com/h5iycst" data-link-type="download" data-download-os="iOS">
+            <a href="{{ pocket_adjust_url('ios', 'whatsnew-67-page') }}" data-link-type="download" data-download-os="iOS">
               <img src="{{ l10n_img('firefox/ios/btn-app-store.svg') }}" alt="" width="152" height="45">
             </a>
           </li>

--- a/bedrock/firefox/tests/test_helpers.py
+++ b/bedrock/firefox/tests/test_helpers.py
@@ -45,7 +45,7 @@ class TestDownloadButtons(TestCase):
         self.check_desktop_links(links[:4])
 
         # Check that the rest of the links are Android and iOS
-        assert pq(links[4]).attr('href') == settings.GOOGLE_PLAY_FIREFOX_LINK
+        assert pq(links[4]).attr('href') == settings.GOOGLE_PLAY_FIREFOX_LINK_UTMS
         assert (pq(links[5]).attr('href') ==
             settings.APPLE_APPSTORE_FIREFOX_LINK.replace('/{country}/', '/'))
 

--- a/bedrock/mozorg/tests/test_helper_misc.py
+++ b/bedrock/mozorg/tests/test_helper_misc.py
@@ -586,43 +586,43 @@ class TestFirefoxIOSURL(TestCase):
         """No locale, fallback to default URL"""
         assert (
             self._render('') == 'https://itunes.apple.com'
-            '/app/apple-store/id989804926?pt=373246&amp;mt=8')
+            '/app/firefox-private-safe-browser/id989804926')
 
     def test_firefox_ios_url_default(self):
         """should fallback to default URL"""
         assert (
             self._render('ar') == 'https://itunes.apple.com'
-            '/app/apple-store/id989804926?pt=373246&amp;mt=8')
+            '/app/firefox-private-safe-browser/id989804926')
         assert (
             self._render('zu') == 'https://itunes.apple.com'
-            '/app/apple-store/id989804926?pt=373246&amp;mt=8')
+            '/app/firefox-private-safe-browser/id989804926')
 
     def test_firefox_ios_url_localized(self):
         """should return localized URL"""
         assert (
             self._render('en-US') == 'https://itunes.apple.com/us'
-            '/app/apple-store/id989804926?pt=373246&amp;mt=8')
+            '/app/firefox-private-safe-browser/id989804926')
         assert (
             self._render('es-ES') == 'https://itunes.apple.com/es'
-            '/app/apple-store/id989804926?pt=373246&amp;mt=8')
+            '/app/firefox-private-safe-browser/id989804926')
         assert (
             self._render('ja') == 'https://itunes.apple.com/jp'
-            '/app/apple-store/id989804926?pt=373246&amp;mt=8')
+            '/app/firefox-private-safe-browser/id989804926')
 
     def test_firefox_ios_url_param(self):
         """should return default or localized URL with ct param"""
         assert (
             self._render('', 'mozorg') ==
             'https://itunes.apple.com'
-            '/app/apple-store/id989804926?pt=373246&amp;mt=8&amp;ct=mozorg')
+            '/app/firefox-private-safe-browser/id989804926?ct=mozorg')
         assert (
             self._render('en-US', 'mozorg') ==
             'https://itunes.apple.com/us'
-            '/app/apple-store/id989804926?pt=373246&amp;mt=8&amp;ct=mozorg')
+            '/app/firefox-private-safe-browser/id989804926?ct=mozorg')
         assert (
             self._render('es-ES', 'mozorg') ==
             'https://itunes.apple.com/es'
-            '/app/apple-store/id989804926?pt=373246&amp;mt=8&amp;ct=mozorg')
+            '/app/firefox-private-safe-browser/id989804926?ct=mozorg')
 
 
 # from jingo
@@ -689,3 +689,185 @@ def test_csrf():
     s = render('{{ csrf() }}', {'csrf_token': 'fffuuu'})
     csrf = "<input type='hidden' name='csrfmiddlewaretoken' value='fffuuu' />"
     assert csrf in s
+
+
+class TestFirefoxAdjustUrl(TestCase):
+    rf = RequestFactory()
+
+    def _render(self, locale, redirect, adgroup, creative=None):
+        req = self.rf.get('/')
+        req.locale = locale
+
+        if creative:
+            return render("{{{{ firefox_adjust_url('{0}', '{1}', '{2}') }}}}".format(
+                          redirect, adgroup, creative), {'request': req})
+
+        return render("{{{{ firefox_adjust_url('{0}', '{1}') }}}}".format(
+                      redirect, adgroup), {'request': req})
+
+    def test_firefox_ios_adjust_url(self):
+        """Firefox for mobile with an App Store URL redirect"""
+        assert (
+            self._render('en-US', 'ios', 'test-page') == 'https://app.adjust.com/2uo1qc?redirect='
+            'https%3A%2F%2Fitunes.apple.com%2Fus%2Fapp%2Ffirefox-private-safe-browser%2Fid989804926'
+            '&amp;campaign=www.mozilla.org&amp;adgroup=test-page')
+
+    def test_firefox_ios_adjust_url_creative(self):
+        """Firefox for mobile with an App Store URL redirect and creative param"""
+        assert (
+            self._render('de', 'ios', 'test-page', 'experiment-name') == 'https://app.adjust.com/2uo1qc?redirect='
+            'https%3A%2F%2Fitunes.apple.com%2Fde%2Fapp%2Ffirefox-private-safe-browser%2Fid989804926'
+            '&amp;campaign=www.mozilla.org&amp;adgroup=test-page&amp;creative=experiment-name')
+
+    def test_firefox_android_adjust_url(self):
+        """Firefox for mobile with a Play Store redirect"""
+        assert (
+            self._render('en-US', 'android', 'test-page') == 'https://app.adjust.com/2uo1qc?redirect='
+            'https%3A%2F%2Fplay.google.com%2Fstore%2Fapps%2Fdetails%3Fid%3Dorg.mozilla.firefox'
+            '&amp;campaign=www.mozilla.org&amp;adgroup=test-page')
+
+    def test_firefox_no_redirect_adjust_url(self):
+        """Firefox for mobile with no redirect"""
+        assert (
+            self._render('en-US', None, 'test-page') == 'https://app.adjust.com/2uo1qc?'
+            'campaign=www.mozilla.org&amp;adgroup=test-page')
+
+
+class TestFocusAdjustUrl(TestCase):
+    rf = RequestFactory()
+
+    def _render(self, locale, redirect, adgroup, creative=None):
+        req = self.rf.get('/')
+        req.locale = locale
+
+        if creative:
+            return render("{{{{ focus_adjust_url('{0}', '{1}', '{2}') }}}}".format(
+                          redirect, adgroup, creative), {'request': req})
+
+        return render("{{{{ focus_adjust_url('{0}', '{1}') }}}}".format(
+                      redirect, adgroup), {'request': req})
+
+    def test_focus_ios_adjust_url(self):
+        """Firefox Focus with an App Store URL redirect"""
+        assert (
+            self._render('en-US', 'ios', 'test-page') == 'https://app.adjust.com/b8s7qo?redirect='
+            'https%3A%2F%2Fitunes.apple.com%2Fus%2Fapp%2Ffirefox-focus-privacy-browser%2Fid1055677337'
+            '&amp;campaign=www.mozilla.org&amp;adgroup=test-page')
+
+    def test_focus_ios_adjust_url_creative(self):
+        """Firefox Focus with an App Store URL redirect and creative param"""
+        assert (
+            self._render('fr', 'ios', 'test-page', 'experiment-name') == 'https://app.adjust.com/b8s7qo?'
+            'redirect=https%3A%2F%2Fitunes.apple.com%2Ffr%2Fapp%2Ffirefox-focus-privacy-browser%2Fid1055677337'
+            '&amp;campaign=www.mozilla.org&amp;adgroup=test-page&amp;creative=experiment-name')
+
+    def test_focus_android_adjust_url(self):
+        """Firefox Focus for mobile with a Play Store redirect"""
+        assert (
+            self._render('en-US', 'android', 'test-page') == 'https://app.adjust.com/b8s7qo?redirect='
+            'https%3A%2F%2Fplay.google.com%2Fstore%2Fapps%2Fdetails%3Fid%3Dorg.mozilla.focus'
+            '&amp;campaign=www.mozilla.org&amp;adgroup=test-page')
+
+    def test_focus_no_redirect_adjust_url(self):
+        """Firefox Focus for mobile with no redirect"""
+        assert (
+            self._render('en-US', None, 'test-page') == 'https://app.adjust.com/b8s7qo?'
+            'campaign=www.mozilla.org&amp;adgroup=test-page')
+
+    def test_klar_ios_adjust_url(self):
+        """Firefox Klar with an App Store URL redirect"""
+        assert (
+            self._render('de', 'ios', 'test-page') == 'https://app.adjust.com/jfcx5x?redirect='
+            'https%3A%2F%2Fitunes.apple.com%2Fde%2Fapp%2Fklar-by-firefox%2Fid1073435754'
+            '&amp;campaign=www.mozilla.org&amp;adgroup=test-page')
+
+    def test_klar_android_adjust_url(self):
+        """Firefox Klar for mobile with a Play Store redirect"""
+        assert (
+            self._render('de', 'android', 'test-page') == 'https://app.adjust.com/jfcx5x?redirect='
+            'https%3A%2F%2Fplay.google.com%2Fstore%2Fapps%2Fdetails%3Fid%3Dorg.mozilla.klar'
+            '&amp;campaign=www.mozilla.org&amp;adgroup=test-page')
+
+
+class TestLockwiseAdjustUrl(TestCase):
+    rf = RequestFactory()
+
+    def _render(self, locale, redirect, adgroup, creative=None):
+        req = self.rf.get('/')
+        req.locale = locale
+
+        if creative:
+            return render("{{{{ lockwise_adjust_url('{0}', '{1}', '{2}') }}}}".format(
+                          redirect, adgroup, creative), {'request': req})
+
+        return render("{{{{ lockwise_adjust_url('{0}', '{1}') }}}}".format(
+                      redirect, adgroup), {'request': req})
+
+    def test_lockwise_ios_adjust_url(self):
+        """Firefox Lockwise for mobile with an App Store URL redirect"""
+        assert (
+            self._render('en-US', 'ios', 'test-page') == 'https://app.adjust.com/6tteyjo?redirect='
+            'https%3A%2F%2Fitunes.apple.com%2Fus%2Fapp%2Fid1314000270%3Fmt%3D8'
+            '&amp;campaign=www.mozilla.org&amp;adgroup=test-page')
+
+    def test_lockwise_ios_adjust_url_creative(self):
+        """Firefox Lockwise for mobile with an App Store URL redirect and creative param"""
+        assert (
+            self._render('de', 'ios', 'test-page', 'experiment-name') == 'https://app.adjust.com/6tteyjo'
+            '?redirect=https%3A%2F%2Fitunes.apple.com%2Fde%2Fapp%2Fid1314000270%3Fmt%3D8'
+            '&amp;campaign=www.mozilla.org&amp;adgroup=test-page&amp;creative=experiment-name')
+
+    def test_lockwise_android_adjust_url(self):
+        """Firefox Lockwise for mobile with a Play Store redirect"""
+        assert (
+            self._render('en-US', 'android', 'test-page') == 'https://app.adjust.com/6tteyjo?redirect='
+            'https%3A%2F%2Fplay.google.com%2Fstore%2Fapps%2Fdetails%3Fid%3Dmozilla.lockbox'
+            '&amp;campaign=www.mozilla.org&amp;adgroup=test-page')
+
+    def test_lockwise_no_redirect_adjust_url(self):
+        """Firefox Lockwise for mobile with no redirect"""
+        assert (
+            self._render('en-US', None, 'test-page') == 'https://app.adjust.com/6tteyjo'
+            '?campaign=www.mozilla.org&amp;adgroup=test-page')
+
+
+class TestPocketAdjustUrl(TestCase):
+    rf = RequestFactory()
+
+    def _render(self, locale, redirect, adgroup, creative=None):
+        req = self.rf.get('/')
+        req.locale = locale
+
+        if creative:
+            return render("{{{{ pocket_adjust_url('{0}', '{1}', '{2}') }}}}".format(
+                          redirect, adgroup, creative), {'request': req})
+
+        return render("{{{{ pocket_adjust_url('{0}', '{1}') }}}}".format(
+                      redirect, adgroup), {'request': req})
+
+    def test_pocket_ios_adjust_url(self):
+        """Pocket for mobile with an App Store URL redirect"""
+        assert (
+            self._render('en-US', 'ios', 'test-page') == 'https://app.adjust.com/m54twk?redirect='
+            'https%3A%2F%2Fitunes.apple.com%2Fus%2Fapp%2Fpocket-save-read-grow%2Fid309601447'
+            '&amp;campaign=www.mozilla.org&amp;adgroup=test-page')
+
+    def test_pocket_ios_adjust_url_creative(self):
+        """Pocket for mobile with an App Store URL redirect and creative param"""
+        assert (
+            self._render('de', 'ios', 'test-page', 'experiment-name') == 'https://app.adjust.com/m54twk?redirect='
+            'https%3A%2F%2Fitunes.apple.com%2Fde%2Fapp%2Fpocket-save-read-grow%2Fid309601447'
+            '&amp;campaign=www.mozilla.org&amp;adgroup=test-page&amp;creative=experiment-name')
+
+    def test_pocket_android_adjust_url(self):
+        """Pocket for mobile with a Play Store redirect"""
+        assert (
+            self._render('en-US', 'android', 'test-page') == 'https://app.adjust.com/m54twk?redirect='
+            'https%3A%2F%2Fplay.google.com%2Fstore%2Fapps%2Fdetails%3Fid%3Dcom.ideashower.readitlater.pro'
+            '&amp;campaign=www.mozilla.org&amp;adgroup=test-page')
+
+    def test_pocket_no_redirect_adjust_url(self):
+        """Pocket for mobile with no redirect"""
+        assert (
+            self._render('en-US', None, 'test-page') == 'https://app.adjust.com/m54twk?'
+            'campaign=www.mozilla.org&amp;adgroup=test-page')

--- a/bedrock/settings/appstores.py
+++ b/bedrock/settings/appstores.py
@@ -5,25 +5,24 @@
 from django.utils.http import urlquote
 
 
+# Base link to Firefox for Android on the Google Play store.
+GOOGLE_PLAY_FIREFOX_LINK = 'https://play.google.com/store/apps/details?id=org.mozilla.firefox'
+
 # Link to Firefox for Android on the Google Play store with Google Analytics
 # campaign parameters.
 # To clarify below, 'referrer' key value must be a URL encoded string of utm_*
 # key/values (https://bugzilla.mozilla.org/show_bug.cgi?id=1099429#c0).
-GOOGLE_PLAY_FIREFOX_LINK = ('https://play.google.com/store/apps/details?' +
-                            'id=org.mozilla.firefox&referrer=' +
-                            urlquote('utm_source=mozilla&utm_medium=Referral&'
-                                     'utm_campaign=mozilla-org'))
+GOOGLE_PLAY_FIREFOX_LINK_UTMS = (GOOGLE_PLAY_FIREFOX_LINK + '&referrer=' +
+                                 urlquote('utm_source=mozilla&utm_medium=Referral&'
+                                          'utm_campaign=mozilla-org'))
 
 # Bug 1264843: link to China build of Fx4A, for display within Fx China repack
-GOOGLE_PLAY_FIREFOX_LINK_MOZILLAONLINE = GOOGLE_PLAY_FIREFOX_LINK.replace(
+GOOGLE_PLAY_FIREFOX_LINK_MOZILLAONLINE = GOOGLE_PLAY_FIREFOX_LINK_UTMS.replace(
     'org.mozilla.firefox', 'cn.mozilla.firefox')
 
 # Link to Firefox for iOS on the Apple App Store with Google Analytics campaign
 # patameters. Each implementation should add a "ct" parameter for analytics.
-# Note: this URL is likely to change for Fx42. See bug comment:
-# https://bugzilla.mozilla.org/show_bug.cgi?id=1196310#c18
-APPLE_APPSTORE_FIREFOX_LINK = ('https://itunes.apple.com/{country}/app/' +
-                               'apple-store/id989804926?pt=373246&mt=8')
+APPLE_APPSTORE_FIREFOX_LINK = 'https://itunes.apple.com/{country}/app/firefox-private-safe-browser/id989804926'
 
 # Map Mozilla's locale codes to Apple's country codes so we can link to a
 # localized App Store page when possible. Here's the official territory list:
@@ -85,14 +84,33 @@ APPLE_APPSTORE_COUNTRY_MAP = {
     'vi': 'vt',     # Vietnam
 }
 
-# Link to Firefox Focus for iOS on the Apple App Store via app.adjust.
-# Fallback parameter sends users who are on the wrong platform to the iTunes website.
-# https://bugzilla.mozilla.org/show_bug.cgi?id=1350170
-APPLE_APPSTORE_FIREFOX_FOCUS_LINK = ('https://app.adjust.com/b8s7qo?campaign=moz.org&adgroup=Focus&creative=iOS&' +
-                                     'fallback=https%3A%2F%2Fitunes.apple.com%2Fapp%2Fid1055677337%3Fmt%3D8')
+# Link to Firefox Focus on the Apple App Store.
+APPLE_APPSTORE_FOCUS_LINK = 'https://itunes.apple.com/{country}/app/firefox-focus-privacy-browser/id1055677337'
 
-# Link to Firefox Focus for Android on the Google Play Store via app.adjust.
-# Fallback parameter sends users who are on the wrong platform to the Play Store website.
-# https://bugzilla.mozilla.org/show_bug.cgi?id=1350170
-GOOGLE_PLAY_FIREFOX_FOCUS_LINK = ('https://app.adjust.com/b8s7qo?campaign=moz.org&adgroup=Focus&creative=android' +
-                                  '&fallback=https%3A%2F%2Fplay.google.com%2Fstore%2Fapps%2Fdetails%3Fid%3Dorg.mozilla.focus')
+# Link to Firefox Focus on the Google Play store.
+GOOGLE_PLAY_FOCUS_LINK = 'https://play.google.com/store/apps/details?id=org.mozilla.focus'
+
+# Link to Firefox Focus on the Apple App Store.
+APPLE_APPSTORE_KLAR_LINK = 'https://itunes.apple.com/{country}/app/klar-by-firefox/id1073435754'
+
+# Link to Firefox Klar on the Google Play store.
+GOOGLE_PLAY_KLAR_LINK = 'https://play.google.com/store/apps/details?id=org.mozilla.klar'
+
+# Link to Pocket on the Apple App Store.
+APPLE_APPSTORE_POCKET_LINK = 'https://itunes.apple.com/{country}/app/pocket-save-read-grow/id309601447'
+
+# Link to Pocket on the Google Play store.
+GOOGLE_PLAY_POCKET_LINK = 'https://play.google.com/store/apps/details?id=com.ideashower.readitlater.pro'
+
+# Link to Lockwise on the Apple App Store.
+APPLE_APPSTORE_LOCKWISE_LINK = 'https://itunes.apple.com/{country}/app/id1314000270?mt=8'
+
+# Link to Lockwise on the Google Play store.
+GOOGLE_PLAY_LOCKWISE_LINK = 'https://play.google.com/store/apps/details?id=mozilla.lockbox'
+
+# app.adjust.com links for all of the above products (Issue 7214)
+ADJUST_FIREFOX_URL = 'https://app.adjust.com/2uo1qc'
+ADJUST_FOCUS_URL = 'https://app.adjust.com/b8s7qo'
+ADJUST_KLAR_URL = 'https://app.adjust.com/jfcx5x'
+ADJUST_POCKET_URL = 'https://app.adjust.com/m54twk'
+ADJUST_LOCKWISE_URL = 'https://app.adjust.com/6tteyjo'

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -1205,10 +1205,16 @@ FXA_OAUTH_CLIENT_SECRET = config('FXA_OAUTH_CLIENT_SECRET', default='')
 FXA_OAUTH_SERVER_ENV = config('FXA_OAUTH_SERVER_ENV', default='production')
 
 # Google Play and Apple App Store settings
-from .appstores import (GOOGLE_PLAY_FIREFOX_LINK,  # noqa
+from .appstores import (GOOGLE_PLAY_FIREFOX_LINK, GOOGLE_PLAY_FIREFOX_LINK_UTMS,  # noqa
                         GOOGLE_PLAY_FIREFOX_LINK_MOZILLAONLINE,  # noqa
                         APPLE_APPSTORE_FIREFOX_LINK, APPLE_APPSTORE_COUNTRY_MAP,
-                        APPLE_APPSTORE_FIREFOX_FOCUS_LINK, GOOGLE_PLAY_FIREFOX_FOCUS_LINK)
+                        APPLE_APPSTORE_FOCUS_LINK, GOOGLE_PLAY_FOCUS_LINK,
+                        APPLE_APPSTORE_KLAR_LINK, GOOGLE_PLAY_KLAR_LINK,
+                        APPLE_APPSTORE_POCKET_LINK, GOOGLE_PLAY_POCKET_LINK,
+                        APPLE_APPSTORE_LOCKWISE_LINK, GOOGLE_PLAY_LOCKWISE_LINK,
+                        ADJUST_FIREFOX_URL, ADJUST_FOCUS_URL,
+                        ADJUST_KLAR_URL, ADJUST_POCKET_URL,
+                        ADJUST_LOCKWISE_URL)
 
 # Locales that should display the 'Send to Device' widget
 SEND_TO_DEVICE_LOCALES = ['de', 'en-GB', 'en-US',


### PR DESCRIPTION
## Description
- Creates standardized adjust links for mobile products that all redirect to the correct app stores if clicked on desktop.

## Issue / Bugzilla link
#7214

## Testing
Demo page: https://www-demo1.allizom.org/en-US/adjust-test/

- [ ] Links should take mobile users to the correct destinations.
- [ ] Links should take desktop users to the correct destinations.