### PR TITLE
Skip accounts page test

### DIFF
--- a/tests/functional/firefox/test_accounts.py
+++ b/tests/functional/firefox/test_accounts.py
@@ -7,6 +7,7 @@ import pytest
 from pages.firefox.accounts import FirefoxAccountsPage
 
 
+@pytest.mark.skipif(reason='Page is temporarily behind the switch "firefox_accounts_trailhead"')
 @pytest.mark.nondestructive
 def test_account_form(base_url, selenium):
     page = FirefoxAccountsPage(selenium, base_url).open()

--- a/tests/functional/firefox/test_accounts.py
+++ b/tests/functional/firefox/test_accounts.py
@@ -7,7 +7,7 @@ import pytest
 from pages.firefox.accounts import FirefoxAccountsPage
 
 
-@pytest.mark.skipif(reason='Page is temporarily behind the switch "firefox_accounts_trailhead"')
+@pytest.mark.skip(reason='Page is temporarily behind the switch "firefox_accounts_trailhead"')
 @pytest.mark.nondestructive
 def test_account_form(base_url, selenium):
     page = FirefoxAccountsPage(selenium, base_url).open()


### PR DESCRIPTION
## Description
Test fails because the page is behind a switch, so we'll just skip it for now. We can unskip once the switch is cleaned up post-launch.