### PR TITLE
[fix bug 1555626] Add signin action to fxa_link_fragment macro

### DIFF
--- a/bedrock/base/templates/macros.html
+++ b/bedrock/base/templates/macros.html
@@ -233,6 +233,8 @@
 
   {% if action == 'signup' %}
     {% set fxa_path = 'signup' %}
+  {% elif action == 'signin' %}
+    {% set fxa_path = 'signin' %}
   {% else %}
     {% do fxa_queries.insert(0, 'action=email') %}
   {% endif %}

--- a/bedrock/firefox/templates/firefox/accounts-2018.html
+++ b/bedrock/firefox/templates/firefox/accounts-2018.html
@@ -290,7 +290,7 @@
             button_text=_('Create an Account'))
           }}
 
-          <p class="fxa-signin">{{ _('Already have an account?') }} <a {{ fxa_link_fragment(entrypoint='mozzila.org-accounts_page', utm_params={'campaign': 'fxa-embedded-form', 'content': '/firefox/accounts/', 'source': 'accounts-page'}) }}>{{ _('Sign In') }}</a></p>
+          <p class="fxa-signin">{{ _('Already have an account?') }} <a {{ fxa_link_fragment(entrypoint='mozzila.org-accounts_page', action='signin', utm_params={'campaign': 'fxa-embedded-form', 'content': '/firefox/accounts/', 'source': 'accounts-page'}) }}>{{ _('Sign In') }}</a></p>
         </div>
       </div>
 

--- a/bedrock/firefox/templates/firefox/accounts-2019.html
+++ b/bedrock/firefox/templates/firefox/accounts-2019.html
@@ -52,7 +52,7 @@
         utm_params={'campaign': 'accounts-trailhead', 'content': 'form-upper', 'medium': 'referral'})
       }}
 
-      <p class="fxa-signin">{{ _('Already have an account?') }} <a {{ fxa_link_fragment(entrypoint='mozilla.org-accounts_page', utm_params={'campaign': 'accounts-trailhead', 'content': 'form-upper', 'source': 'accounts_page'}) }}>{{ _('Sign In') }}</a></p>
+      <p class="fxa-signin">{{ _('Already have an account?') }} <a {{ fxa_link_fragment(entrypoint='mozilla.org-accounts_page', action='signin', utm_params={'campaign': 'accounts-trailhead', 'content': 'form-upper', 'source': 'accounts_page'}) }}>{{ _('Sign In') }}</a></p>
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Description
In a recent change the default "signin" action was overwritten, effectively making "email" the new default and "signin" no longer an option. This adds back signin as an explicit option.

## Issue / Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1555626
