### PR TITLE
Trailhead WNP: add up to date banner JS, design tweaks. (Fixes #7256, #7244)

### DIFF
--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx67.0.5.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx67.0.5.html
@@ -22,8 +22,8 @@
 {% block content %}
 
 <main class="mzp-t-firefox">
-  <header class="mzp-l-content c-page-header">
-    <div class="c-page-header-inner">
+  <header class="c-page-header">
+    <div class="mzp-l-content c-page-header-inner">
       {{ high_res_img('firefox/whatsnew_67/logo.png', {'alt': 'Firefox', 'width': '147', 'height': '55', 'class': 'c-page-header-logo-fx'}) }}
       <h1 class="c-page-header-up-to-date"><span>{{ _('Congrats! You’re using the latest version of Firefox.') }}</span></h1>
     </div>
@@ -44,11 +44,7 @@
             }}
           {% endblock %}
         </div>
-        {% if LANG.startswith('en-') %}
-          <a href="{{ url('firefox.accounts') }}">{{ _('Learn more about joining Firefox') }}</a>
-        {% else %}
-          <a href="{{ url('firefox.accounts') }}">{{ _('Learn More about joining Firefox') }}</a>
-        {% endif %}
+        <a href="{{ url('firefox.accounts') }}">{{ _('Learn more about joining Firefox') }}</a>
       </div>
       <div class="show-fxa-supported-signed-in">
         <h1>{{ _('Your account connects you to all of our products. ') }}</h1>

--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx67.0.5.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx67.0.5.html
@@ -85,9 +85,7 @@
         <img class="glyphs" src="{{ static('img/firefox/whatsnew_67/heart_glyph.svg') }}" alt="">
         <div class="benefit-content">
           <h3>{{ _('Fierce defense of your privacy') }}</h3>
-          <p>{{ _('Everything we make and do honors our Personal Data Promise:') }}
-            <strong>{{ _('Take less. Keep it safe. No secrets.') }}</strong>
-          </p>
+          <p>{{ _('Everything we make and do honors our Personal Data Promise: <strong>Take less. Keep it safe. No secrets.</strong>') }}</p>
         </div>
       </div>
       <div class="show-fxa-supported-signed-in">

--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx67.0.5.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx67.0.5.html
@@ -44,7 +44,11 @@
             }}
           {% endblock %}
         </div>
-        <a href="{{ url('firefox.accounts') }}">{{ _('Learn more about joining Firefox') }}</a>
+        {% if LANG.startswith('en-') %}
+          <a href="{{ url('firefox.accounts') }}">{{ _('Learn more about joining Firefox') }}</a>
+        {% else %}
+          <a href="{{ url('firefox.accounts') }}">{{ _('Learn More about joining Firefox') }}</a>
+        {% endif %}
       </div>
       <div class="show-fxa-supported-signed-in">
         <h1>{{ _('Your account connects you to all of our products. ') }}</h1>
@@ -70,7 +74,7 @@
         <div class="benefit-content">
           <h3>{{ _('Products that respect') }}</h3>
           <p>
-            {% trans send='https://send.firefox.com/', lockwise='https://lockbox.firefox.com/', monitor='https://monitor.firefox.com/' %}
+            {% trans send='https://send.firefox.com/', lockwise='https://lockwise.firefox.com/', monitor='https://monitor.firefox.com/' %}
             Firefox products like <a href="{{ send }}">Send</a>, <a href="{{ lockwise }}">Lockwise</a> and <a href="{{ monitor }}">Monitor</a> help you get things done without invading your privacy.
             {% endtrans %}
           </p>
@@ -85,7 +89,9 @@
         <img class="glyphs" src="{{ static('img/firefox/whatsnew_67/heart_glyph.svg') }}" alt="">
         <div class="benefit-content">
           <h3>{{ _('Fierce defense of your privacy') }}</h3>
-          <p>{{ _('Everything we make and do honors our Personal Data Promise: <strong>Take less. Keep it safe. No secrets.</strong>') }}</p>
+          <p>{{ _('Everything we make and do honors our Personal Data Promise:') }}
+            <strong>{{ _('Take less. Keep it safe. No secrets.') }}</strong>
+          </p>
         </div>
       </div>
       <div class="show-fxa-supported-signed-in">

--- a/media/css/firefox/whatsnew/whatsnew-67.0.5.scss
+++ b/media/css/firefox/whatsnew/whatsnew-67.0.5.scss
@@ -26,7 +26,6 @@ main {
 .c-page-header {
     background: #fff;
     margin-bottom: $spacing-2xl;
-    margin-left: 0;
 }
 
 .c-page-header-up-to-date {

--- a/media/css/firefox/whatsnew/whatsnew-67.0.5.scss
+++ b/media/css/firefox/whatsnew/whatsnew-67.0.5.scss
@@ -69,7 +69,7 @@ main {
     box-shadow: 1px 1px 10px 1px rgba(0, 0, 0, 0.21);
     padding: $spacing-xl $spacing-2xl;
     margin: 0 auto;
-    max-width: 600px;
+    max-width: 500px;
 
     h1 {
         font-size: 2.25rem;

--- a/media/js/firefox/whatsnew/up-to-date.js
+++ b/media/js/firefox/whatsnew/up-to-date.js
@@ -1,0 +1,25 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+(function() {
+    'use strict';
+
+    var client = Mozilla.Client;
+
+    function checkUpToDate() {
+        // bug 1419573 - only show "Your Firefox is up to date" if it's the latest version.
+        if (client.isFirefoxDesktop) {
+            client.getFirefoxDetails(function(data) {
+                if (data.isUpToDate) {
+                    document.querySelector('.c-page-header').classList.add('is-up-to-date');
+                }
+            });
+        }
+    }
+
+    Mozilla.UITour.ping(function() {
+        checkUpToDate();
+    });
+
+})();

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -1037,7 +1037,7 @@
         "js/base/mozilla-fxa-init.js",
         "js/base/mozilla-fxa-form.js",
         "js/base/mozilla-monitor-button.js",
-        "protocol/js/protocol-modal.js"
+        "js/firefox/whatsnew/up-to-date.js"
       ],
       "name": "firefox_whatsnew_67.0.5"
     },


### PR DESCRIPTION
## Description
- Tweak design slightly (omitting new fonts and button blue color because that will arrive in a protocol update)
- Add JS to display "Congrats! You’re using the latest version of Firefox." banner.

## Issue / Bugzilla link
#7256
#7244 

## Testing
https://bedrock-demo-achurchwell.oregon-b.moz.works/en-US/firefox/67.0.1/whatsnew/