### PR TITLE
Add support for win-msi and win64-msi in download URL helpers

### DIFF
--- a/bedrock/firefox/firefox_details.py
+++ b/bedrock/firefox/firefox_details.py
@@ -228,13 +228,21 @@ class FirefoxDesktop(_ProductDetails):
         :param locale_in_transition: Include the locale in the transition URL
         :return: string url
         """
-        _version = version
+        # no longer used, but still passed in. leaving here for now
+        # as it will likely be used in future.
+        # _version = version
         _locale = 'ja-JP-mac' if platform == 'osx' and locale == 'ja' else locale
         channel = 'devedition' if channel == 'alpha' else channel
         force_direct = True if channel != 'release' else force_direct
         stub_platforms = ['win', 'win64']
         esr_channels = ['esr', 'esr_next']
         include_funnelcake_param = False
+
+        # support optional MSI installer downloads
+        # bug 1493205
+        is_msi = platform.endswith('-msi')
+        if is_msi:
+            platform = platform[:-4]
 
         # Bug 1345467 - Only allow specifically configured funnelcake builds
         if funnelcake_id:
@@ -259,15 +267,15 @@ class FirefoxDesktop(_ProductDetails):
         # otherwise build a full download URL
         prod_name = 'firefox' if channel == 'release' else 'firefox-%s' % channel
         suffix = 'latest-ssl'
+        if is_msi:
+            suffix = 'msi-' + suffix
+
         if channel in esr_channels:
             # nothing special about ESR other than there is no stub.
             # included in this contitional to avoid the following elif.
             if channel == 'esr_next':
-                # no firefox-esr-next-latest-ssl alias just yet
-                # could come in future in bug 1408868
-                prod_name = 'firefox'
-                suffix = '%s-SSL' % _version
-        elif platform in stub_platforms and not force_full_installer:
+                prod_name = 'firefox-esr-next'
+        elif platform in stub_platforms and not is_msi and not force_full_installer:
             # Use the stub installer for approved platforms
             # append funnelcake id to version if we have one
             if include_funnelcake_param:
@@ -278,6 +286,8 @@ class FirefoxDesktop(_ProductDetails):
             # Nightly uses a different product name for localized builds,
             # and is the only one ಠ_ಠ
             suffix = 'latest-l10n-ssl'
+            if is_msi:
+                suffix = 'msi-' + suffix
 
         product = '%s-%s' % (prod_name, suffix)
 

--- a/bedrock/firefox/tests/test_firefox_details.py
+++ b/bedrock/firefox/tests/test_firefox_details.py
@@ -122,6 +122,12 @@ class TestFirefoxDesktop(TestCase):
                              [('product', 'firefox-stub'),
                               ('os', 'win64'),
                               ('lang', 'en-US')])
+        # Windows 64-bit MSI installer
+        url = firefox_desktop.get_download_url('release', '38.0', 'win64-msi', 'en-US', True)
+        self.assertListEqual(parse_qsl(urlparse(url).query),
+                             [('product', 'firefox-msi-latest-ssl'),
+                              ('os', 'win64'),
+                              ('lang', 'en-US')])
         # Linux 64-bit
         url = firefox_desktop.get_download_url('release', '17.0.1', 'linux64', 'en-US', True)
         self.assertListEqual(parse_qsl(urlparse(url).query),
@@ -136,6 +142,12 @@ class TestFirefoxDesktop(TestCase):
         url = firefox_desktop.get_download_url('esr', '28.0a2', 'win', 'en-US', True)
         self.assertListEqual(parse_qsl(urlparse(url).query),
                              [('product', 'firefox-esr-latest-ssl'),
+                              ('os', 'win'),
+                              ('lang', 'en-US')])
+        # MSI installer
+        url = firefox_desktop.get_download_url('esr', '28.0a2', 'win-msi', 'en-US', True)
+        self.assertListEqual(parse_qsl(urlparse(url).query),
+                             [('product', 'firefox-esr-msi-latest-ssl'),
                               ('os', 'win'),
                               ('lang', 'en-US')])
         url = firefox_desktop.get_download_url('esr', '28.0a2', 'win64', 'en-US', True)
@@ -161,31 +173,36 @@ class TestFirefoxDesktop(TestCase):
 
     def test_get_download_url_esr_next(self):
         """
-        The ESR_NEXT version should give us a bouncer url with a full version. There is no stub for ESR.
+        The ESR_NEXT version should give us a bouncer url with 'esr-next'. There is no stub for ESR.
         """
         url = firefox_desktop.get_download_url('esr_next', '52.4.1esr', 'win', 'en-US', True)
         self.assertListEqual(parse_qsl(urlparse(url).query),
-                             [('product', 'firefox-52.4.1esr-SSL'),
+                             [('product', 'firefox-esr-next-latest-ssl'),
                               ('os', 'win'),
                               ('lang', 'en-US')])
         url = firefox_desktop.get_download_url('esr_next', '52.4.1esr', 'win64', 'en-US', True)
         self.assertListEqual(parse_qsl(urlparse(url).query),
-                             [('product', 'firefox-52.4.1esr-SSL'),
+                             [('product', 'firefox-esr-next-latest-ssl'),
+                              ('os', 'win64'),
+                              ('lang', 'en-US')])
+        url = firefox_desktop.get_download_url('esr_next', '52.4.1esr', 'win64-msi', 'en-US', True)
+        self.assertListEqual(parse_qsl(urlparse(url).query),
+                             [('product', 'firefox-esr-next-msi-latest-ssl'),
                               ('os', 'win64'),
                               ('lang', 'en-US')])
         url = firefox_desktop.get_download_url('esr_next', '52.4.1esr', 'osx', 'en-US', True)
         self.assertListEqual(parse_qsl(urlparse(url).query),
-                             [('product', 'firefox-52.4.1esr-SSL'),
+                             [('product', 'firefox-esr-next-latest-ssl'),
                               ('os', 'osx'),
                               ('lang', 'en-US')])
         url = firefox_desktop.get_download_url('esr_next', '52.4.1esr', 'linux', 'en-US', True)
         self.assertListEqual(parse_qsl(urlparse(url).query),
-                             [('product', 'firefox-52.4.1esr-SSL'),
+                             [('product', 'firefox-esr-next-latest-ssl'),
                               ('os', 'linux'),
                               ('lang', 'en-US')])
         url = firefox_desktop.get_download_url('esr_next', '52.4.1esr', 'linux64', 'en-US', True)
         self.assertListEqual(parse_qsl(urlparse(url).query),
-                             [('product', 'firefox-52.4.1esr-SSL'),
+                             [('product', 'firefox-esr-next-latest-ssl'),
                               ('os', 'linux64'),
                               ('lang', 'en-US')])
 
@@ -202,6 +219,12 @@ class TestFirefoxDesktop(TestCase):
         url = firefox_desktop.get_download_url('alpha', '28.0a2', 'win64', 'en-US', True)
         self.assertListEqual(parse_qsl(urlparse(url).query),
                              [('product', 'firefox-devedition-stub'),
+                              ('os', 'win64'),
+                              ('lang', 'en-US')])
+        # MSI installer
+        url = firefox_desktop.get_download_url('alpha', '28.0a2', 'win64-msi', 'en-US', True)
+        self.assertListEqual(parse_qsl(urlparse(url).query),
+                             [('product', 'firefox-devedition-msi-latest-ssl'),
                               ('os', 'win64'),
                               ('lang', 'en-US')])
         url = firefox_desktop.get_download_url('alpha', '28.0a2', 'osx', 'en-US', True)
@@ -262,6 +285,12 @@ class TestFirefoxDesktop(TestCase):
                              [('product', 'firefox-devedition-stub'),
                               ('os', 'win'),
                               ('lang', 'pt-BR')])
+        # MSI installer
+        url = firefox_desktop.get_download_url('alpha', '28.0a2', 'win-msi', 'pt-BR', True)
+        self.assertListEqual(parse_qsl(urlparse(url).query),
+                             [('product', 'firefox-devedition-msi-latest-ssl'),
+                              ('os', 'win'),
+                              ('lang', 'pt-BR')])
         url = firefox_desktop.get_download_url('alpha', '28.0a2', 'win64', 'pt-BR', True)
         self.assertListEqual(parse_qsl(urlparse(url).query),
                              [('product', 'firefox-devedition-stub'),
@@ -292,6 +321,12 @@ class TestFirefoxDesktop(TestCase):
         self.assertListEqual(parse_qsl(urlparse(url).query),
                              [('product', 'firefox-nightly-stub'),
                               ('os', 'win'),
+                              ('lang', 'en-US')])
+        # MSI installer
+        url = firefox_desktop.get_download_url('nightly', '50.0a1', 'win64-msi', 'en-US', True)
+        self.assertListEqual(parse_qsl(urlparse(url).query),
+                             [('product', 'firefox-nightly-msi-latest-ssl'),
+                              ('os', 'win64'),
                               ('lang', 'en-US')])
         url = firefox_desktop.get_download_url('nightly', '50.0a1', 'win64', 'en-US', True)
         self.assertListEqual(parse_qsl(urlparse(url).query),
@@ -359,6 +394,12 @@ class TestFirefoxDesktop(TestCase):
         url = firefox_desktop.get_download_url('nightly', '50.0a1', 'win64', 'pt-BR', True)
         self.assertListEqual(parse_qsl(urlparse(url).query),
                              [('product', 'firefox-nightly-stub'),
+                              ('os', 'win64'),
+                              ('lang', 'pt-BR')])
+        # MSI installer
+        url = firefox_desktop.get_download_url('nightly', '50.0a1', 'win64-msi', 'pt-BR', True)
+        self.assertListEqual(parse_qsl(urlparse(url).query),
+                             [('product', 'firefox-nightly-msi-latest-l10n-ssl'),
                               ('os', 'win64'),
                               ('lang', 'pt-BR')])
         url = firefox_desktop.get_download_url('nightly', '50.0a1', 'osx', 'pt-BR', True)


### PR DESCRIPTION
Also move `firefox-esr-next` to use bouncer aliases setup for that product. Re [bug 1408868](https://bugzilla.mozilla.org/show_bug.cgi?id=1408868).

Followup work to actually add the buttons to pages is still needed.  To use this you simply use `win-msi` or `win64-msi` as the `platform` argument to the download helpers.

Re [bug 1493205](https://bugzilla.mozilla.org/show_bug.cgi?id=1493205)
Re #7265