### PR TITLE
Fetch FxA metrics for non-FF browsers on /accounts (Fixes #7269)

### DIFF
--- a/media/js/base/mozilla-fxa-form.js
+++ b/media/js/base/mozilla-fxa-form.js
@@ -14,12 +14,7 @@ Mozilla.FxaForm = (function(Mozilla) {
     var fxaSubmitButton = document.getElementById('fxa-email-form-submit');
     var fxaFormContextField = fxaForm.querySelector('[name="context"]');
     var fxaFormServiceField = fxaForm.querySelector('[name="service"]');
-
     var supportsFetch = 'fetch' in window;
-
-    if (!supportsFetch) {
-        return;
-    }
 
     // swap form action for Fx China re-pack
     function init() {
@@ -45,6 +40,10 @@ Mozilla.FxaForm = (function(Mozilla) {
 
     // get tokens from FxA for analytics purposes
     function fetchTokens() {
+        if (!supportsFetch) {
+            return;
+        }
+
         fxaSubmitButton.disabled = false;
 
         var destURL = fxaForm.getAttribute('action') + 'metrics-flow';
@@ -81,6 +80,7 @@ Mozilla.FxaForm = (function(Mozilla) {
             // This allows non-Firefoxes to create accounts.
             fxaFormContextField.remove();
             fxaFormServiceField.remove();
+            fetchTokens();
         }
     }
 })(window.Mozilla);

--- a/media/js/base/mozilla-fxa-form.js
+++ b/media/js/base/mozilla-fxa-form.js
@@ -78,8 +78,8 @@ Mozilla.FxaForm = (function(Mozilla) {
         } else {
             // Omit the fields required for sync.
             // This allows non-Firefoxes to create accounts.
-            fxaFormContextField.remove();
-            fxaFormServiceField.remove();
+            fxaForm.removeChild(fxaFormContextField);
+            fxaForm.removeChild(fxaFormServiceField);
             fetchTokens();
         }
     }


### PR DESCRIPTION
## Description
- Fetch `flow_id` and `flow_begin_time` for non-Firefox browsers when signing up from /accounts.

## Issue / Bugzilla link
#7269

## Testing
- [ ] Fetch request should occur for non-Firefox browsers.
- [ ] Fetch request should still occur for Firefox browsers.