### PR TITLE
[#7132] Trailhead accounts page: clean up switch

### DIFF
--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -788,7 +788,7 @@ def firefox_accounts(request):
         'promise_url': promise_url + promise_query,
     }
 
-    if lang_file_is_active('firefox/accounts-2019', locale) and switch('firefox_accounts_trailhead'):
+    if lang_file_is_active('firefox/accounts-2019', locale):
         template_name = 'firefox/accounts-2019.html'
     elif lang_file_is_active('firefox/accounts-2018', locale):
         template_name = 'firefox/accounts-2018.html'

--- a/tests/functional/firefox/test_accounts.py
+++ b/tests/functional/firefox/test_accounts.py
@@ -7,7 +7,6 @@ import pytest
 from pages.firefox.accounts import FirefoxAccountsPage
 
 
-@pytest.mark.skip(reason='Page is temporarily behind the switch "firefox_accounts_trailhead"')
 @pytest.mark.nondestructive
 def test_account_form(base_url, selenium):
     page = FirefoxAccountsPage(selenium, base_url).open()


### PR DESCRIPTION
## Description
Cleans up the `firefox_accounts_trailhead` switch and unskips the test. We can remove the switch from www-config once this is in production.