### PR TITLE
Firstrun fxa_link_fragment conforms to new standards

### DIFF
--- a/bedrock/firefox/templates/firefox/firstrun/firstrun-quantum.html
+++ b/bedrock/firefox/templates/firefox/firstrun/firstrun-quantum.html
@@ -65,7 +65,7 @@
       <div id="fxaccounts-wrapper">
         {{ fxa_email_form(entrypoint='mozilla.org-firstrun_page', utm_source='firstrun-page', utm_params={'campaign': 'fxa-embedded-form', 'content': 'firstrun-page', 'medium': 'referral'}, button_class='mzp-c-button mzp-t-product',) }}
 
-        <p class="fxa-signin">{{ _('Already have an account?') }} <a {{ fxa_link_fragment(entrypoint='accounts-page', utm_params={'campaign': 'fxa-embedded-form', 'content': 'firefox-firstrun', 'source': 'firstrun-page'}) }}>{{ _('Sign In') }}</a></p>
+        <p class="fxa-signin">{{ _('Already have an account?') }} <a {{ fxa_link_fragment(entrypoint='mozilla.org-firstrun_page', utm_params={'campaign': 'fxa-embedded-form', 'medium': 'referral', 'content': 'firstrun-page', 'source': 'firstrun-page'}) }}>{{ _('Sign In') }}</a></p>
       </div>
     </main>
 


### PR DESCRIPTION
## Description
This PR makes the entrypoints on this page match, using the one that was already standard.

## Testing
Local testing, the link still worked.
