### PR TITLE
[fix bug 1557173] Leadership page: update Amy Keating’s title

### DIFF
--- a/bedrock/mozorg/templates/mozorg/about/leadership.html
+++ b/bedrock/mozorg/templates/mozorg/about/leadership.html
@@ -676,7 +676,7 @@
         </figure>
 
         <div class="person-info">
-          <p class="title" itemprop="jobTitle">{{ _('General Counsel') }}</p>
+          <p class="title" itemprop="jobTitle">{{ _('Chief Legal Officer') }}</p>
           <p class="since">{{ _('With Mozilla since:') }} 2018</p>
 
           <ul class="utility">
@@ -688,7 +688,7 @@
         <div class="person-bio">
           <p>
           {% trans %}
-            As General Counsel, Amy is responsible for all aspects of Mozilla’s legal work including product counseling, commercial contracts, licensing, privacy issues and legal support to the Mozilla Foundation.
+            As Chief Legal Officer, Amy is responsible for all aspects of Mozilla’s legal work including product counseling, commercial contracts, licensing, privacy issues and legal support to the Mozilla Foundation.
           {% endtrans %}
           </p>
 


### PR DESCRIPTION
## Description
Update's Amy Keating's title from General Counsel to Chief Legal Officer

## Issue / Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1557173

