### PR TITLE
[fix #7296] Add home page fundraising banner for June 2019

### DIFF
--- a/bedrock/mozorg/templates/mozorg/home/home-en.html
+++ b/bedrock/mozorg/templates/mozorg/home/home-en.html
@@ -42,6 +42,10 @@
 {% endblock %}
 
 {% block site_header %}
+  {% if LANG.startswith('en') and switch('home-fundraising-jun2019') %}
+    {% include 'mozorg/home/includes/fundraiser.html' %}
+  {% endif %}
+
   {% include 'includes/protocol/navigation/index.html' %}
 {% endblock %}
 
@@ -61,6 +65,7 @@
     {{ download_firefox(dom_id='download-primary', download_location='primary cta') }}
   {% endcall %}
 
+{% if not switch('home-fundraising-jun2019') %}
   {% call download_banner_sticky(
     title=_('<strong>Firefox</strong> fights for you.'),
     sub_title=_('Fast. Private. Fearless.'),
@@ -68,6 +73,7 @@
     ) %}
     {{ download_firefox(dom_id='download-sticky', download_location='sticky cta', button_color='mzp-t-small') }}
   {% endcall %}
+{% endif %}
 
   {{ fxa_banner(
     logo_title=_('Firefox'),
@@ -76,11 +82,13 @@
     link_cta=_('Learn More'),
   )}}
 
+{% if not switch('home-fundraising-jun2019') %}
   {{ fxa_banner_sticky(
     title=_('Firefox'),
     sub_title=_('Live your life. Own your life.'),
     link_cta=_('Learn More'),
   )}}
+{% endif %}
 
   <div class="mozilla-content">
     <div class="mzp-l-content mzp-t-mozilla">
@@ -230,4 +238,7 @@
 
 {% block js %}
   {{ js_bundle('home') }}
+  {% if switch('home-fundraising-jun2019') %}
+    {{ js_bundle('home-fundraiser') }}
+  {% endif %}
 {% endblock %}

--- a/bedrock/mozorg/templates/mozorg/home/includes/fundraiser.html
+++ b/bedrock/mozorg/templates/mozorg/home/includes/fundraiser.html
@@ -1,0 +1,58 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+
+<aside class="c-fundraiser" id="fundraiser">
+  <button type="button" class="c-fundraiser-close" id="fundraiser-close"><span>{{ _('Close') }}</span></button>
+  <div class="content mzp-l-content">
+    <h2 class="c-fundraiser-title">
+      {{ _('We all love the web. Join Mozilla in defending it.') }}
+    </h2>
+
+    <div class="c-fundraiser-content">
+      <p>
+      {% trans %}
+        Big corporations try to restrict how we access the web. Misinformation
+        makes it harder for us to find the truth. Web-connected devices go to
+        market without basic security standards. The non-profit Mozilla Foundation
+        fights for a healthier internet. <strong>Will you donate today?</strong>
+      {% endtrans %}
+      </p>
+
+      <form id="fundraiser-form" class="c-fundraiser-form" method="get" action="https://donate.mozilla.org/{{ LANG }}/">
+        <fieldset class="c-fundraiser-recurring">
+          <label for="monthly">
+            <input type="radio" value="monthly" id="monthly" name="frequency"> {{ _('Monthly') }}
+          </label>
+
+          <label for="onetime">
+            <input type="radio" value="single" id="onetime" name="frequency" checked> {{ _('One-time') }}
+          </label>
+        </fieldset>
+
+        <fieldset class="c-fundraiser-options">
+        {% for amount in donate_params.preset_list %}
+          <label for="donate{{ amount }}"{% if amount == donate_params.default %} class="selected"{% endif %}>
+            <input class="c-fundraiser-amount-input" type="radio" value="{{ amount }}" id="donate{{ amount }}" name="amount"{% if amount == donate_params.default %} checked="checked"{% endif %}>
+            {# L10n: Inserts a sum in US dollars, e.g. '$100'. Adapt the string in your translation for your locale conventions if needed, ex: %(sum)s US$ #}
+            <span class="mzp-c-button mzp-t-secondary mzp-t-dark">{{ _('$%(sum)s')|format(sum=amount) }}</span>
+          </label>
+        {% endfor %}
+        </fieldset>
+
+        <button type="submit" class="mzp-c-button mzp-t-dark">{{ _('Donate') }}</button>
+
+        <input type="hidden" name="currency" value="{{ donate_params.currency }}">
+        <input type="hidden" name="presets" value="{{ donate_params.presets }}">
+
+        {# GA params #}
+        <input type="hidden" name="ref" value="apr2019banner">
+        <input type="hidden" name="utm_campaign" value="apr2019banner">
+        <input type="hidden" name="utm_source" value="mozilla.org">
+        <input type="hidden" name="utm_medium" value="referral">
+        <input type="hidden" name="utm_content" value="banner">
+
+      </form>
+    </div>{#--/#fundraiser-content--#}
+  </div>{#--/.content--#}
+</aside>

--- a/media/css/mozorg/home/fundraiser.scss
+++ b/media/css/mozorg/home/fundraiser.scss
@@ -1,0 +1,133 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+$font-path: '/media/fonts';
+$image-path: '/media/protocol/img';
+
+@import '../../../protocol/css/includes/lib';
+
+.c-fundraiser {
+    @include clearfix;
+    background: $color-black;
+    background-size: cover;
+    color: $color-white;
+    padding: $spacing-md 0 0;
+
+    // hide by default if JS is available to avoid flicker
+    // (if visitor previously dismissed)
+    .js & {
+        display: none;
+    }
+
+    .mzp-c-button.mzp-t-secondary {
+        background-color: transparent;
+
+        &:focus,
+        &:hover {
+            background-color: rgba(255, 255, 255, .15);
+        }
+    }
+}
+
+.c-fundraiser-title {
+    @include text-display-lg;
+    font-weight: normal;
+    margin-bottom: $spacing-lg;
+}
+
+.c-fundraiser-amount-input {
+    left: 0;
+    opacity: 0;
+    position: absolute;
+    top: 0;
+
+    &:checked + .mzp-c-button.mzp-t-secondary {
+        background-color: rgba(255, 255, 255, .25);
+        font-weight: bold;
+    }
+}
+
+.c-fundraiser-recurring {
+    margin-bottom: $spacing-lg;
+
+    label {
+        display: inline-block;
+
+        &:first-child {
+            @include bidi(((margin-right, $spacing-lg, 0),(margin-left, 0, $spacing-lg)));
+        }
+    }
+}
+
+.c-fundraiser-options {
+    label {
+        @include bidi(((margin, 0 $spacing-sm $spacing-md 0, 0 0 $spacing-md $spacing-sm),));
+        @include open-sans;
+        display: inline-block;
+        position: relative;
+
+        &:first-child {
+            @include bidi(((margin-left, 0, $spacing-sm),(margin-right, $spacing-sm, 0)));
+        }
+    }
+
+    @media #{$mq-md} {
+        @include bidi(((margin-right, $spacing-md, 0),(margin-left, 0, $spacing-md)));
+        display: inline-block;
+    }
+}
+
+// Close button
+.c-fundraiser-close {
+    @include image-replaced;
+    @include bidi(((right, $spacing-sm, auto), (left, auto, $spacing-sm)));
+    background: transparent url('#{$image-path}/icons/ui/close-white.svg') center center no-repeat;
+    @include background-size(16px 16px);
+    border: none;
+    display: none;
+    height: 42px;
+    min-width: 0;
+    padding: 0;
+    position: absolute;
+    top: $spacing-sm;
+    width: 42px;
+    z-index: 1;
+
+    &:hover,
+    &:focus {
+        @include transition(transform .1s ease-in-out);
+        @include transform(scale(1.1));
+    }
+
+    &:focus {
+        outline: 1px dotted $color-white;
+    }
+
+    // hide the 'Close' text
+    span {
+        @include visually-hidden;
+    }
+
+    // only display when JS is available
+    .js & {
+        display: block;
+    }
+}
+
+@media #{$mq-lg} {
+    .c-fundraiser {
+        padding-bottom: $spacing-md;
+    }
+
+    .c-fundraiser-title {
+        @include bidi(((float, left, right),(padding-right, $spacing-xl, 0), (padding-left, 0, $spacing-xl)));
+        @include grid-half;
+        margin-bottom: 0;
+    }
+
+    .c-fundraiser-content {
+        @include bidi(((float, right, left),));
+        @include grid-half;
+    }
+}

--- a/media/js/mozorg/home/fundraiser.js
+++ b/media/js/mozorg/home/fundraiser.js
@@ -1,0 +1,38 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+(function(Mozilla) {
+    'use strict';
+
+    var fundraiser = document.getElementById('fundraiser');
+    var fundraiserClose = document.getElementById('fundraiser-close');
+    var cookieDurationDays = 1;
+    var cookiesOK = typeof Mozilla.Cookies !== 'undefined' && Mozilla.Cookies.enabled();
+    var storageKey = 'fundraiser-jun2019';
+    var wasClosed = false;
+
+    // see if visitor previously dismissed the banner
+    if (cookiesOK) {
+        wasClosed = Mozilla.Cookies.getItem(storageKey);
+    }
+
+    if (!wasClosed) {
+        // show the banner
+        fundraiser.style.display = 'block';
+
+        // wire up close button
+        fundraiserClose.addEventListener('click', function() {
+            var d;
+
+            fundraiser.parentNode.removeChild(fundraiser);
+
+            if (cookiesOK) {
+                d = new Date();
+                d.setTime(d.getTime() + (cookieDurationDays * 24 * 60 * 60 * 1000)); // 1 day expiration
+                Mozilla.Cookies.setItem(storageKey, true, d.toUTCString(), '/');
+            }
+        }, false);
+    }
+
+})(window.Mozilla);

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -336,7 +336,8 @@
     },
     {
       "files": [
-        "css/mozorg/home/home-2018.scss"
+        "css/mozorg/home/home-2018.scss",
+        "css/mozorg/home/fundraiser.scss"
       ],
       "name": "home-2018"
     },
@@ -1154,6 +1155,12 @@
         "js/mozorg/home/home.js"
       ],
       "name": "home"
+    },
+    {
+      "files": [
+        "js/mozorg/home/fundraiser.js"
+      ],
+      "name": "home-fundraiser"
     },
     {
       "files": [


### PR DESCRIPTION
## Description
Resurrecting the banner again, aiming to go live on 13 June and run for at least a week. Uses the switch `home-fundraising-jun2019`

## Issue / Bugzilla link
#7296 
