### PR TITLE
Replace Firefox Quantum w. Firefox Desktop Browser in global nav (#7303)

### DIFF
--- a/bedrock/base/templates/includes/protocol/navigation/menu/firefox.html
+++ b/bedrock/base/templates/includes/protocol/navigation/menu/firefox.html
@@ -13,7 +13,7 @@
             <section class="mzp-c-menu-item mzp-has-icon">
               <a class="mzp-c-menu-item-link" href="{{ url('firefox') }}" data-link-name="Firefox Quantum Desktop Browser" data-link-type="nav" data-link-position="topnav" data-link-group="firefox">
                 <img src="{{ static('protocol/img/logos/firefox/firefox.png') }}" class="mzp-c-menu-item-icon" width="24" height="24" alt="">
-                {% if l10n_has_tag('firefox_quantum_removal2019') %}
+                {% if LANG.startswith('en-') %}
                   <h4 class="mzp-c-menu-item-title">{{ _('Firefox Desktop Browser') }}</h4>
                 {% else %}
                   <h4 class="mzp-c-menu-item-title">{{ _('Firefox Quantum Desktop Browser') }}</h4>

--- a/bedrock/base/templates/includes/protocol/navigation/menu/firefox.html
+++ b/bedrock/base/templates/includes/protocol/navigation/menu/firefox.html
@@ -13,7 +13,11 @@
             <section class="mzp-c-menu-item mzp-has-icon">
               <a class="mzp-c-menu-item-link" href="{{ url('firefox') }}" data-link-name="Firefox Quantum Desktop Browser" data-link-type="nav" data-link-position="topnav" data-link-group="firefox">
                 <img src="{{ static('protocol/img/logos/firefox/firefox.png') }}" class="mzp-c-menu-item-icon" width="24" height="24" alt="">
-                <h4 class="mzp-c-menu-item-title">{{ _('Firefox Quantum Desktop Browser') }}</h4>
+                {% if l10n_has_tag('firefox_quantum_removal2019') %}
+                  <h4 class="mzp-c-menu-item-title">{{ _('Firefox Desktop Browser') }}</h4>
+                {% else %}
+                  <h4 class="mzp-c-menu-item-title">{{ _('Firefox Quantum Desktop Browser') }}</h4>
+                {% endif %}
                 <p class="mzp-c-menu-item-desc">{{ _('Get the browser that gives more power to you on Windows, macOS or Linux.') }}</p>
               </a>
               <ul class="mzp-c-menu-item-list">


### PR DESCRIPTION
## Description
Replace "Firefox Quantum Desktop Browser" with "Firefox Desktop Browser" in global nav.

## Issue / Bugzilla link
#7303 
