### PR TITLE
Change card layout on DE homepage (#7308)

### DIFF
--- a/bedrock/base/templates/macros-protocol.html
+++ b/bedrock/base/templates/macros-protocol.html
@@ -132,7 +132,7 @@
         </div>
       </div>
       <figcaption>
-        <p>{% if desc %}{{ desc }}{% endif %} <a href="{{ link_url }}">{{ _('Read more') }}</a></p>
+        <p>{% if desc %}{{ desc }}{% endif %} <a href="{{ link_url }}">{{ _('Learn more') }}</a></p>
       </figcaption>
     </figure>
   </div>

--- a/bedrock/mozorg/templates/mozorg/home/home-de.html
+++ b/bedrock/mozorg/templates/mozorg/home/home-de.html
@@ -37,7 +37,7 @@
   {{ fxa_banner(
     logo_title=_('Firefox'),
     title=_('Tech mit R.E.S.P.E.K.T.'),
-    sub_title=_('Firefox kann mehr als nur einen richtig guten Browser'),
+    sub_title=_('Firefox kann mehr als nur einen richtig guten Browser.'),
     link_cta=_('Weitere Infos'),
   )}}
 

--- a/bedrock/mozorg/templates/mozorg/home/home-de.html
+++ b/bedrock/mozorg/templates/mozorg/home/home-de.html
@@ -21,30 +21,29 @@
 
   {% call download_banner(
     logo_title=_('Firefox'),
-    title=_('Dein Leben. Deine Daten. Dein Browser.'),
-    desc=_('Firefox fights for you.'),
+    title=_('Dein Leben.<br> Deine Daten.')|safe,
+    desc=_('Hol dir echte Privatsphäre auf jedes deiner Geräte.'),
     ) %}
     {{ download_firefox(dom_id='download-primary', download_location='primary cta') }}
   {% endcall %}
 
   {% call download_banner_sticky(
     title=_('<strong>Firefox</strong> fights for you.'),
-    sub_title=_('Dein Leben. Deine Daten. Dein Browser.'),
-    desc=_('Firefox fights for you.')
+    sub_title=_('Dein Leben. Deine Daten.')
     ) %}
     {{ download_firefox(dom_id='download-sticky', download_location='sticky cta', button_color='mzp-t-small') }}
   {% endcall %}
 
   {{ fxa_banner(
     logo_title=_('Firefox'),
-    title=_('Dein Leben. <br>Deine Daten.'),
-    sub_title=_('Nimm Lesezeichen und Privatsphäre-Features mit auf jedes Gerät – mit deinem Firefox-Konto.'),
+    title=_('Tech mit R.E.S.P.E.K.T.'),
+    sub_title=_('Firefox kann mehr als nur einen richtig guten Browser'),
     link_cta=_('Weitere Infos'),
   )}}
 
   {{ fxa_banner_sticky(
     title=_('Firefox'),
-    sub_title=_('Dein Leben. Deine Daten.'),
+    sub_title=_('Tech mit R.E.S.P.E.K.T.'),
     link_cta=_('Weitere Infos'),
   )}}
 
@@ -84,13 +83,15 @@
         reverse=True
       )}}
 
-      <div class="mzp-l-card-third">
+      <div class="mzp-l-card-half">
         {{ content_card('card_8') }}
         {{ content_card('card_9') }}
+      </div>
+
+      <div class="mzp-l-card-third">
         {{ content_card('card_10') }}
         {{ content_card('card_11') }}
         {{ content_card('card_12') }}
-        {{ content_card('card_13') }}
       </div>
 
       <aside class="mzp-c-newsletter">

--- a/tests/functional/test_home.py
+++ b/tests/functional/test_home.py
@@ -10,7 +10,7 @@ from pages.home import HomePage
 @pytest.mark.skip_if_firefox(reason='Download button is displayed only to non-Firefox users')
 @pytest.mark.sanity
 @pytest.mark.nondestructive
-@pytest.mark.parametrize('locale', ['en-US', 'de'])
+@pytest.mark.parametrize('locale', ['en-US', 'de', 'fr'])
 def test_download_button_is_displayed(locale, base_url, selenium):
     page = HomePage(selenium, base_url, locale=locale).open()
     assert page.primary_download_button.is_displayed
@@ -19,7 +19,7 @@ def test_download_button_is_displayed(locale, base_url, selenium):
 
 @pytest.mark.skip_if_not_firefox(reason='Firefox Accounts CTA is displayed only to Firefox users')
 @pytest.mark.nondestructive
-@pytest.mark.parametrize('locale', ['en-US', 'de'])
+@pytest.mark.parametrize('locale', ['en-US', 'de', 'fr'])
 def test_accounts_button_is_displayed(locale, base_url, selenium):
     page = HomePage(selenium, base_url, locale=locale).open()
     assert page.is_primary_accounts_button
@@ -29,5 +29,5 @@ def test_accounts_button_is_displayed(locale, base_url, selenium):
 @pytest.mark.sanity
 @pytest.mark.nondestructive
 def test_download_button_is_displayed_locales(base_url, selenium):
-    page = HomePage(selenium, base_url, locale='fr').open()
+    page = HomePage(selenium, base_url, locale='es').open()
     assert page.intro_download_button.is_displayed

--- a/tests/functional/test_home.py
+++ b/tests/functional/test_home.py
@@ -10,7 +10,7 @@ from pages.home import HomePage
 @pytest.mark.skip_if_firefox(reason='Download button is displayed only to non-Firefox users')
 @pytest.mark.sanity
 @pytest.mark.nondestructive
-@pytest.mark.parametrize('locale', ['en-US', 'de', 'fr'])
+@pytest.mark.parametrize('locale', ['en-US', 'de'])
 def test_download_button_is_displayed(locale, base_url, selenium):
     page = HomePage(selenium, base_url, locale=locale).open()
     assert page.primary_download_button.is_displayed
@@ -19,7 +19,7 @@ def test_download_button_is_displayed(locale, base_url, selenium):
 
 @pytest.mark.skip_if_not_firefox(reason='Firefox Accounts CTA is displayed only to Firefox users')
 @pytest.mark.nondestructive
-@pytest.mark.parametrize('locale', ['en-US', 'de', 'fr'])
+@pytest.mark.parametrize('locale', ['en-US', 'de'])
 def test_accounts_button_is_displayed(locale, base_url, selenium):
     page = HomePage(selenium, base_url, locale=locale).open()
     assert page.is_primary_accounts_button
@@ -29,5 +29,5 @@ def test_accounts_button_is_displayed(locale, base_url, selenium):
 @pytest.mark.sanity
 @pytest.mark.nondestructive
 def test_download_button_is_displayed_locales(base_url, selenium):
-    page = HomePage(selenium, base_url, locale='es').open()
+    page = HomePage(selenium, base_url, locale='fr').open()
     assert page.intro_download_button.is_displayed


### PR DESCRIPTION
## Description

- update card layout to 12 card layout
- change video CTA to "Learn more" which is in the main.lang file 

## Issue / Bugzilla link

See #7308, Fix #7319 

## Testing

Needs to be tested with the content cards on dev. Localhost and demos will both use those.
See it here: https://bedrock-demo-shobson.oregon-b.moz.works/de/
