### PR TITLE
Create redirect for /accounts to /firefox/accounts (Fixes #7287)

### DIFF
--- a/bedrock/firefox/redirects.py
+++ b/bedrock/firefox/redirects.py
@@ -606,4 +606,7 @@ redirectpatterns = (
 
     # issue 7210
     redirect(r'^firefox/account/?$', 'firefox.accounts'),
+
+    # issue 7287
+    redirect(r'^accounts/?$', 'firefox.accounts'),
 )

--- a/bedrock/firefox/urls.py
+++ b/bedrock/firefox/urls.py
@@ -2,7 +2,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 from django.conf.urls import url
-from django.views.generic import RedirectView
 
 from bedrock.mozorg.util import page
 
@@ -30,7 +29,6 @@ urlpatterns = (
     url(r'^firefox/$', views.firefox_home, name='firefox'),
     url(r'^firefox/(?:%s/)?(?:%s/)?all/$' % (platform_re, channel_re),
         views.firefox_all, name='firefox.all'),
-    url(r'^accounts/$', RedirectView.as_view(pattern_name='firefox.accounts', permanent=False)),
     url(r'^firefox/accounts/', views.firefox_accounts, name='firefox.accounts'),
     url(r'^firefox/campaign/$', views.campaign, name='firefox.campaign'),
     page('firefox/channel/desktop', 'firefox/channel/desktop.html'),

--- a/bedrock/firefox/urls.py
+++ b/bedrock/firefox/urls.py
@@ -2,6 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 from django.conf.urls import url
+from django.views.generic import RedirectView
 
 from bedrock.mozorg.util import page
 
@@ -29,6 +30,7 @@ urlpatterns = (
     url(r'^firefox/$', views.firefox_home, name='firefox'),
     url(r'^firefox/(?:%s/)?(?:%s/)?all/$' % (platform_re, channel_re),
         views.firefox_all, name='firefox.all'),
+    url(r'^accounts/$', RedirectView.as_view(pattern_name='firefox.accounts', permanent=False)),
     url(r'^firefox/accounts/', views.firefox_accounts, name='firefox.accounts'),
     url(r'^firefox/campaign/$', views.campaign, name='firefox.campaign'),
     page('firefox/channel/desktop', 'firefox/channel/desktop.html'),

--- a/tests/redirects/map_globalconf.py
+++ b/tests/redirects/map_globalconf.py
@@ -1261,4 +1261,7 @@ URLS = flatten((
     url_test('/contribute/signup/', 'https://activate.mozilla.community/'),
     url_test('/contribute/task/{,devtools-challenger/, firefox-mobile/}', 'https://activate.mozilla.community/'),
     url_test('/contribute/friends/', '/contribute/'),
+
+    # Issue 7287
+    url_test('/accounts/', '/firefox/accounts/'),
 ))


### PR DESCRIPTION
## Description
redirect for /accounts to /firefox/accounts
## Issue / Bugzilla link
#7287