### PR TITLE
Add signed-in state on /firefox/accounts/ (Fixes #6907)

### DIFF
--- a/bedrock/firefox/templates/firefox/accounts-2019.html
+++ b/bedrock/firefox/templates/firefox/accounts-2019.html
@@ -3,7 +3,7 @@
   # file, You can obtain one at http://mozilla.org/MPL/2.0/. #}
 
 {% from "macros-protocol.html" import feature_card with context %}
-{% from "macros.html" import fxa_email_form, fxa_link_fragment with context %}
+{% from "macros.html" import fxa_email_form, fxa_link_fragment, monitor_button with context %}
 
 {% extends "firefox/base-protocol.html" %}
 
@@ -29,17 +29,32 @@
 {% endblock %}
 
 {% block content %}
-
+{% set has_signed_in_copy = l10n_has_tag('accounts-signed-in-06132019') %}
 
 <section class="c-accounts-hero">
   <div class="mzp-l-content">
-    <div class="c-accounts-hero-body">
+    <div class="c-accounts-hero-body {% if has_signed_in_copy %}c-accounts-hero-body-default{% endif %}">
       {# L10n: the span here is for visual formatting to display the phrase "Join Firefox" in a different color. #}
       <h1 class="c-accounts-hero-title">{{ _('There is a way to protect your privacy. <span>Join Firefox.</span>') }}</h1>
 
       {# L10n: This refers to the way some tech companies treat personal information as a commodity, as if their users are the product they're selling to their advertisers. #}
       <p class="c-accounts-hero-desc">{{ _('Take your stand against an industry that’s making you the product.') }}</p>
     </div>
+
+    {% if has_signed_in_copy %}
+    <div class="c-accounts-hero-body c-accounts-hero-body-signed-in">
+      {# L10n: the span here is to display the phrase "Now try Firefox Monitor." in a different color. Line breaks are for visual formatting. #}
+      <h2 class="c-accounts-hero-title">{{ _('You’re signed <br>in to Firefox. <br><span>Now try Firefox Monitor.</span>') }}</h2>
+
+      <p class="c-accounts-hero-desc">{{ _('See if you’ve been involved in an online data breach.') }}</p>
+
+      {{ monitor_button(
+        entrypoint='mozilla.org-accounts_page',
+        utm_source='accounts_page',
+        utm_campaign='accounts-trailhead'
+      ) }}
+    </div>
+    {% endif %}
 
     <div class="c-accounts-form">
       {{ fxa_email_form(
@@ -59,7 +74,13 @@
 
 <section class="c-accounts-products">
   <div class="mzp-l-content">
-    <h2 class="c-section-title">{{ _('Get technology that fights for you.') }}</h2>
+    <h2 class="c-section-title">
+      {% if has_signed_in_copy %}
+        {{ _('Firefox is technology that fights for you.') }}
+      {% else %}
+        {{ _('Get technology that fights for you.') }}
+      {% endif %}
+    </h2>
 
     <ul class="c-product-list">
       <li class="c-product-list-item t-product-firefox">
@@ -89,7 +110,13 @@
       </li>
     </ul>
 
-    <p class="c-accounts-products-tagline">{{ _('And get it all on every device, without feeling trapped in a single operating system.') }}</p>
+    <p class="c-accounts-products-tagline">
+      {% if has_signed_in_copy %}
+        {{ _('Get it all on every device, without feeling trapped in a single operating system.') }}
+      {% else %}
+        {{ _('And get it all on every device, without feeling trapped in a single operating system.') }}}
+      {% endif %}
+    </p>
   </div>
 </section>
 

--- a/media/css/firefox/accounts-2019.scss
+++ b/media/css/firefox/accounts-2019.scss
@@ -20,6 +20,10 @@
     padding: $spacing-lg 0;
     text-align: center;
 
+    .c-accounts-hero-body-signed-in {
+        display: none;
+    }
+
     .c-accounts-hero-title {
         @include text-display-lg;
         background: transparent url('/media/img/logos/firefox/logo-master-wordmark-dark.svg') center top no-repeat;
@@ -34,6 +38,16 @@
 
     .c-accounts-hero-desc {
         @include text-body-lg;
+    }
+
+    .state-fxa-supported-signed-in & {
+        .c-accounts-hero-body-default {
+            display: none;
+        }
+
+        .c-accounts-hero-body-signed-in {
+            display: block;
+        }
     }
 
     @media #{$mq-md} {
@@ -66,6 +80,7 @@
 
         .c-accounts-hero-title {
             @include bidi(((background-position, left top, right top),));
+            max-width: 12em;
         }
 
         @supports (display: grid) {

--- a/media/js/base/mozilla-monitor-button.js
+++ b/media/js/base/mozilla-monitor-button.js
@@ -11,15 +11,15 @@ Mozilla.MonitorButton = (function() {
     'use strict';
 
     var monitorButton = document.getElementById('fxa-monitor-submit');
-    var buttonURL = monitorButton.getAttribute('href');
 
     // fetch request
     var supportsFetch = 'fetch' in window;
 
-    if (!supportsFetch) {
+    if (!supportsFetch || !monitorButton) {
         return;
     }
 
+    var buttonURL = monitorButton.getAttribute('href');
     var destURL = monitorButton.getAttribute('data-action') + 'metrics-flow';
 
     fetch(destURL).then(function(resp) {

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -1495,6 +1495,7 @@
         "js/base/mozilla-fxa.js",
         "js/base/mozilla-fxa-init.js",
         "js/base/mozilla-fxa-form.js",
+        "js/base/mozilla-monitor-button.js",
         "js/firefox/accounts-2019.js"
       ],
       "name": "firefox_accounts_2019"


### PR DESCRIPTION
## Description
- Adds signed-in state for Firefox users on `/firefox/accounts`.
- New string added behind the tag `accounts-signed-in-06132019`.

**Do not merge** until we have copy approval.

## Issue / Bugzilla link
#6907

## Testing
Demo: https://www-demo5.allizom.org/en-US/firefox/accounts/

- [ ] Signed-in users should see a Firefox Monitor CTA.
- [ ] All other states should still see the Join Firefox CTA.
- [ ] Locales that don't have the new strings translated should still get the current experience.