### PR TITLE
Improve functional tests for /firefox/accounts/ page

### DIFF
--- a/media/js/base/mozilla-fxa.js
+++ b/media/js/base/mozilla-fxa.js
@@ -27,17 +27,18 @@ if (typeof window.Mozilla === 'undefined') {
     FxaState.convertFxaDetailsToStateAndDo = function(details, callback) {
         var stateClass = '';
 
-        if(details.firefox) {
-            if(details.legacy) {
+        if (details.firefox) {
+            if (details.legacy) {
                 stateClass = 'state-fxa-unsupported';
-            } else if(details.mobile) {
-                if(details.mobile === 'ios') {
+            } else if (details.mobile) {
+                if (details.mobile === 'ios') {
                     stateClass = 'state-fxa-ios';
                 } else {
                     stateClass = 'state-fxa-android';
                 }
             } else {
-                if(details.setup) {
+                // Query param `signed-in=true` is used for integration testing and demo review only.
+                if (details.setup || window.location.search.indexOf('signed-in=true') !== -1) {
                     stateClass = 'state-fxa-supported-signed-in';
                 } else {
                     stateClass = 'state-fxa-supported-signed-out';

--- a/tests/functional/firefox/test_accounts.py
+++ b/tests/functional/firefox/test_accounts.py
@@ -3,11 +3,23 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import pytest
+import urllib
 
 from pages.firefox.accounts import FirefoxAccountsPage
 
 
 @pytest.mark.nondestructive
 def test_account_form(base_url, selenium):
-    page = FirefoxAccountsPage(selenium, base_url).open()
-    assert page.is_create_account_form_displayed, "Create account form is displayed for signed out users"
+    page = FirefoxAccountsPage(selenium, base_url, params='').open()
+    page.join_firefox_form.type_email('success@example.com')
+    page.join_firefox_form.click_continue()
+    url = urllib.unquote(selenium.current_url)
+    assert 'email=success@example.com' in url, 'Email address is not in URL'
+
+
+@pytest.mark.nondestructive
+@pytest.mark.skip_if_not_firefox(reason='Signed-in state is shown only to Firefox users.')
+def test_signed_in_call_to_action(base_url, selenium):
+    page = FirefoxAccountsPage(selenium, base_url, params='?signed-in=true').open()
+    assert not page.join_firefox_form.is_displayed
+    assert page.is_firefox_monitor_button_displayed

--- a/tests/pages/firefox/accounts.py
+++ b/tests/pages/firefox/accounts.py
@@ -2,25 +2,28 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from selenium.common.exceptions import TimeoutException
 from selenium.webdriver.common.by import By
-from selenium.webdriver.support import expected_conditions as expected
-from selenium.webdriver.support.ui import WebDriverWait as Wait
 
 from pages.firefox.base import FirefoxBasePage
+from pages.regions.join_firefox_form import JoinFirefoxForm
 
 
 class FirefoxAccountsPage(FirefoxBasePage):
 
-    URL_TEMPLATE = '/{locale}/firefox/accounts/'
+    URL_TEMPLATE = '/{locale}/firefox/accounts/{params}'
 
-    _create_account_form_locator = (By.ID, 'fxa-email-form')
+    _firefox_monitor_button_locator = (By.ID, 'fxa-monitor-submit')
+
+    def wait_for_page_to_load(self):
+        self.wait.until(lambda s: self.seed_url in s.current_url)
+        el = self.find_element(By.TAG_NAME, 'body')
+        self.wait.until(lambda s: 'state-fxa-default' not in el.get_attribute('class'))
+        return self
 
     @property
-    def is_create_account_form_displayed(self):
-        wait = Wait(self, timeout=3)
-        try:
-            result = wait.until(expected.visibility_of_element_located((self._create_account_form_locator)))
-            return result
-        except TimeoutException:
-            return False
+    def join_firefox_form(self):
+        return JoinFirefoxForm(self)
+
+    @property
+    def is_firefox_monitor_button_displayed(self):
+        return self.is_element_displayed(*self._firefox_monitor_button_locator)

--- a/tests/pages/regions/join_firefox_form.py
+++ b/tests/pages/regions/join_firefox_form.py
@@ -1,0 +1,29 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from pypom import Region
+from selenium.webdriver.common.by import By
+
+
+class JoinFirefoxForm(Region):
+
+    _root_locator = (By.ID, 'fxa-email-form')
+    _email_locator = (By.ID, 'fxa-email-field')
+    _continue_button_locator = (By.ID, 'fxa-email-form-submit')
+
+    @property
+    def is_displayed(self):
+        return self.page.is_element_displayed(*self._root_locator)
+
+    @property
+    def email(self):
+        el = self.find_element(*self._email_locator)
+        return el.get_attribute('value')
+
+    def type_email(self, value):
+        self.find_element(*self._email_locator).send_keys(value)
+
+    def click_continue(self):
+        self.find_element(*self._continue_button_locator).click()
+        self.wait.until(lambda s: '/signup?action=email' in s.current_url)


### PR DESCRIPTION
## Description
- Updates existing test to cover functionality of the "Join Firefox" form.
- Adds a new test for signed-in state.
- Adds a `signed-in=true` query param override to `mozilla-fxa.js` for easier state testing.

## Issue / Bugzilla link
#7327

## Testing
Successful integration test run: https://ci.vpn1.moz.works/blue/organizations/jenkins/bedrock_multibranch_pipeline/detail/run-integration-tests/325/pipeline