### PR TITLE
Update homepage locale test_download_button_is_displayed_locales

### DIFF
--- a/tests/functional/test_home.py
+++ b/tests/functional/test_home.py
@@ -29,5 +29,5 @@ def test_accounts_button_is_displayed(locale, base_url, selenium):
 @pytest.mark.sanity
 @pytest.mark.nondestructive
 def test_download_button_is_displayed_locales(base_url, selenium):
-    page = HomePage(selenium, base_url, locale='es').open()
+    page = HomePage(selenium, base_url, locale='es-ES').open()
     assert page.intro_download_button.is_displayed


### PR DESCRIPTION
## Description

Update homepage locale test_download_button_is_displayed_locales from `es` to `es-ES` to avoid redirect.

## Issue / Bugzilla link

#7311 

## Testing
