### PR TITLE
Convert System Requirements to Protocol (#7335)

### DIFF
--- a/bedrock/firefox/templates/firefox/releases/system_requirements.html
+++ b/bedrock/firefox/templates/firefox/releases/system_requirements.html
@@ -2,7 +2,7 @@
  # License, v. 2.0. If a copy of the MPL was not distributed with this
  # file, You can obtain one at http://mozilla.org/MPL/2.0/. #}
 
-{% extends "firefox/base-resp.html" %}
+{% extends "firefox/base-protocol.html" %}
 
 {% block gtm_page_id %}data-gtm-page-id="/firefox/system-requirements/"{% endblock %}
 
@@ -12,17 +12,26 @@
 {% block page_title %}{{ _('{product} {channel} {version} System Requirements')|f(product=release.product, channel=channel_name, version=version) }}{% endblock %}
 
 {% block body_id %}notes{% endblock %}
-{% block body_class %}sky{% endblock %}
+{% block body_class %}mzp-t-firefox mzp-t-{{ channel_name|lower }}{% endblock %}
+
+{% block page_css %}
+  {{ css_bundle('firefox_system_requirements') }}
+{% endblock %}
 
 {% block content %}
-  <header id="main-feature">
-    <h1>{{ _('{product} {channel} {version} System Requirements')|f(product=release.product, channel=channel_name, version=version) }}</h1>
-  </header>
+  <div class="mzp-l-content">
+    <header class="l-narrow">
+      <div class="c-page-section">
+        <h1>Firefox System Requirements</h1>
+      </div>
+      <h2>{{ _('{product} {channel} {version}')|f(product=release.product, channel=channel_name, version=version) }}</h2>
+    </header>
 
-  <div id="main-content">
-    <article class="main-column">
-        {{ release.system_requirements|safe }}
-    </article>
+    <main class="l-narrow">
+      <div class="mzp-c-article">
+          {{ release.system_requirements|safe }}
+      </div>
+    </main>
   </div>
   {% block sidebar %}{% endblock %}
 {% endblock %}

--- a/media/css/firefox/system-requirements.scss
+++ b/media/css/firefox/system-requirements.scss
@@ -1,0 +1,173 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+$font-path: '/media/fonts';
+$image-path: '/media/protocol/img';
+@import '../../protocol/css/includes/lib';
+
+.l-narrow {
+    margin: 0 auto;
+    max-width: 640px;
+
+    @media #{$mq-md} {
+        padding: 0 $spacing-lg;
+    }
+}
+
+/* -------------------------------------------------------------------------- */
+// Header
+
+.c-page-section {
+    @include font-firefox;
+    margin-bottom: $spacing-lg;
+    min-height: 40px;
+
+    @media #{$mq-sm} {
+        margin-top: $layout-sm;
+        margin-bottom: $layout-sm;
+        @include flexbox;
+        @include align-items(center);
+    }
+
+    @media #{$mq-md} {
+        margin-top: $layout-sm;
+        margin-bottom: $layout-lg;
+        min-height: 48px;
+    }
+
+    &:before {
+        @include background-size(40px 40px);
+        background-repeat: no-repeat;
+        content: '';
+        display: block;
+        height: 40px;
+        margin-bottom: $spacing-sm;
+        width: 40px;
+
+        @media #{$mq-sm} {
+            @include bidi((
+                (float, left, right),
+                (margin-right, $spacing-sm, margin-left, 0),
+            ));
+        }
+
+        @media #{$mq-md} {
+            @include background-size(48px 48px);
+            @include bidi((
+                (margin-right, $spacing-md, (-48px - $spacing-md)),
+                (margin-left, (-48px - $spacing-md), $spacing-md),
+            ));
+            height: 48px;
+            width: 48px;
+        }
+
+        @media #{$mq-lg} {
+            @include bidi((
+                (left, $layout-xl, right, auto),
+                (margin-left, 0, 0),
+            ));
+            position: absolute;
+        }
+    }
+
+    h1 {
+        @include text-display-xs;
+        font-weight: bold;
+    }
+
+    a {
+        color: inherit;
+        text-decoration: none;
+    }
+}
+
+.c-page-section:before {
+    background-image: url('/media/img/logos/firefox/logo-quantum.png');
+
+    @media #{$mq-high-res} {
+        background-image: url('/media/img/logos/firefox/logo-quantum-high-res.png');
+    }
+}
+
+.mzp-t-beta .c-page-section:before {
+    background-image: url('/media/img/logos/firefox/beta-logo.png');
+
+    @media #{$mq-high-res} {
+        background-image: url('/media/img/logos/firefox/beta-logo-high-res.png');
+    }
+}
+
+.mzp-t-aurora .c-page-section:before {
+    background-image: url('/media/img/firefox/releasenotes/aurora.png');
+
+    @media #{$mq-high-res} {
+        background-image: url('/media/img/firefox/releasenotes/aurora-high-res.png');
+    }
+}
+
+.mzp-t-nightly .c-page-section:before {
+    background-image: url('/media/img/logos/firefox/nightly-logo.png');
+
+    @media #{$mq-high-res} {
+        background-image: url('/media/img/logos/firefox/nightly-logo-high-res.png');
+    }
+}
+
+.mzp-c-article {
+    h1 {
+        @include text-display-lg;
+        margin-bottom: $layout-md;
+    }
+
+    h2 {
+        @include text-display-md;
+    }
+
+    h3 {
+        @include text-display-xs;
+    }
+
+    // copied straight out of Protocol because we can't add the utility class to the lists
+    ul {
+        @include bidi(((margin-left, $layout-sm, margin-right, 0),));
+        list-style: disc;
+
+        li {
+            margin-bottom: .25em;
+        }
+
+        ul {
+            @include bidi(((margin-left, $layout-xs, margin-right, 0),));
+            list-style: circle;
+            margin-bottom: 0;
+        }
+
+        ol {
+            @include bidi(((margin-left, $layout-xs, margin-right, 0),));
+            list-style: decimal;
+            margin-bottom: 0;
+        }
+    }
+
+    ol {
+        @include bidi(((margin-left, $layout-sm, margin-right, 0),));
+        list-style: decimal;
+
+        li {
+            margin-bottom: .25em;
+        }
+
+        ol {
+            @include bidi(((margin-left, $layout-xs, margin-right, 0),));
+            list-style: lower-alpha;
+            margin-bottom: 0;
+        }
+
+        ul {
+            @include bidi(((margin-left, $layout-xs, margin-right, 0),));
+            list-style: disc;
+            margin-bottom: 0;
+        }
+    }
+}

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -100,9 +100,9 @@
     },
     {
       "files": [
-        "css/firefox/releasenotes.scss"
+        "css/firefox/system-requirements.scss"
       ],
-      "name": "firefox_releasenotes"
+      "name": "firefox_system_requirements"
     },
     {
       "files": [


### PR DESCRIPTION
## Description

Convert System Requirements to Protocol 

## Issue / Bugzilla link

Fix #7335

## Testing

I did not try to put version specific icons on all these pages like I did the Release Notes. The icons are Release, Beta, Aurora, and Nightly.

The newsletter sign up has been removed from these pages. We can add it back once we have a Protocol port of it (in #7141).

- http://localhost:8000/en-US/firefox/54.0a2/system-requirements/
- http://localhost:8000/en-US/firefox/67.0beta/system-requirements/
- http://localhost:8000/en-US/firefox/57.0/system-requirements/
- http://localhost:8000/en-US/firefox/android/66.0.5/system-requirements/

There is no design spec to match. I borrowed heavily from the Privacy Notice page.

![Screenshot_2019-06-25 Firefox 57 0 System Requirements](https://user-images.githubusercontent.com/854701/60142153-71eb8280-976d-11e9-8405-5e96adaafdc1.png)
