### PR TITLE
Remove trailing bracket

### DIFF
--- a/bedrock/firefox/templates/firefox/accounts-2019.html
+++ b/bedrock/firefox/templates/firefox/accounts-2019.html
@@ -114,7 +114,7 @@
       {% if has_signed_in_copy %}
         {{ _('Get it all on every device, without feeling trapped in a single operating system.') }}
       {% else %}
-        {{ _('And get it all on every device, without feeling trapped in a single operating system.') }}}
+        {{ _('And get it all on every device, without feeling trapped in a single operating system.') }}
       {% endif %}
     </p>
   </div>


### PR DESCRIPTION
Removing an extra bracket showing up for locales that are not using the latest copy

![image](https://user-images.githubusercontent.com/1294206/60164399-c8a09d00-97fd-11e9-8d11-bc9c422d7665.png)
