### PR TITLE
Fix smart quote in /firefox/all/ page copy

### DIFF
--- a/bedrock/firefox/templates/firefox/all-unified.html
+++ b/bedrock/firefox/templates/firefox/all-unified.html
@@ -139,7 +139,7 @@
 
           <p class="c-download-error hidden">
             {% trans %}
-              Sorry, we couldn’t find the download you're looking for.
+              Sorry, we couldn’t find the download you’re looking for.
               Please try again, or select a download from the list below.
             {% endtrans %}
           </p>


### PR DESCRIPTION
Fixes a small error brought up during string extraction: https://github.com/mozilla-l10n/www.mozilla.org/pull/310#discussion_r299559069
