### PR TITLE
Fixing microdata error on events

### DIFF
--- a/bedrock/mozorg/templates/mozorg/contribute/events.html
+++ b/bedrock/mozorg/templates/mozorg/contribute/events.html
@@ -27,7 +27,7 @@
             <tr itemscope itemtype="http://schema.org/Event">
               <td class="event-date"><time itemprop="startDate endDate" datetime="{{ event.start_time.isoformat() }}">{{ event.start_time|l10n_format_date }}</time></td>
               <td itemprop="name" class="event-name" scope="row">{% if event.url %}<a itemprop="url" href="{{ event.url }}">{% endif %}{{ event.title|safe }}{% if event.url %}</a>{% endif %}</td>
-              <td itemprop="location">{{ event.location|safe }}</td>
+              <td itemprop="location" itemscope itemtype="https://schema.org/Place"><span itemprop="https://schema.org/Address">{{ event.location|safe }}</span></td>
             </tr>
           {% endfor %}
         </tbody>

--- a/bedrock/mozorg/templates/mozorg/contribute/events.html
+++ b/bedrock/mozorg/templates/mozorg/contribute/events.html
@@ -27,7 +27,7 @@
             <tr itemscope itemtype="http://schema.org/Event">
               <td class="event-date"><time itemprop="startDate endDate" datetime="{{ event.start_time.isoformat() }}">{{ event.start_time|l10n_format_date }}</time></td>
               <td itemprop="name" class="event-name" scope="row">{% if event.url %}<a itemprop="url" href="{{ event.url }}">{% endif %}{{ event.title|safe }}{% if event.url %}</a>{% endif %}</td>
-              <td itemprop="location" itemscope itemtype="https://schema.org/Place"><span itemprop="https://schema.org/Address">{{ event.location|safe }}</span></td>
+              <td itemprop="location" itemscope itemtype="https://schema.org/Place"><address itemprop="https://schema.org/address">{{ event.location|safe }}</address></td>
             </tr>
           {% endfor %}
         </tbody>


### PR DESCRIPTION
## Description
Search Console and the [structured data testing tool](https://search.google.com/structured-data/testing-tool#url=https%3A%2F%2Fwww.mozilla.org%2Fen-US%2Fcontribute%2Fevents%2F) throws errors, as "location" is from type "thing". I fixed that, so we can be aware of errors occuring around our brands and products. The location should be now type = Place and the venue is set as Adress. The warnings will remain.

## Issue / Bugzilla link

## Testing
