### PR TITLE
Add Join Firefox modal to /firefox/new/ (Fixes #7232)

### DIFF
--- a/bedrock/firefox/templates/firefox/new/trailhead/download.html
+++ b/bedrock/firefox/templates/firefox/new/trailhead/download.html
@@ -77,10 +77,26 @@
       {{ download_firefox(dom_id='download-other-platforms-modal', alt_copy=_('Download Now'), locale_in_transition=True, download_location='other') }}
     </section>
 </aside>
+
+{% if l10n_has_tag('join_firefox_072019') %}
+<aside class="mzp-u-modal-content join-firefox-content">
+  {# L10n: The phrase “Now get even more from Firefox” is in specific reference to signing up for an account, which unlocks access to all our new products and services. #}
+  <h4 class="join-firefox-title">{{ _('You’ve already got the browser. Now get even more from Firefox.') }}</h4>
+  <p class="join-firefox-intro">{{ _('Watch for hackers with Firefox Monitor, protect passwords with Firefox Lockwise, and more.') }}</p>
+
+  <a href="{{ url('firefox.accounts') }}" class="mzp-c-button mzp-t-product join-firefox-button" data-link-name="Get More From Firefox" data-link-type="button">{{ _('Get More From Firefox') }}</a>
+
+  {{ download_firefox(dom_id='download-join-firefox-modal', alt_copy=_('Just Download The Browser'), button_color='mzp-t-secondary', locale_in_transition=True, download_location='other') }}
+</aside>
+{% endif %}
 {% endblock %}
 
 {% block js %}
   {{ js_bundle('firefox_new_download') }}
+
+  {% if l10n_has_tag('join_firefox_072019') %}
+    {{ js_bundle('firefox_new_download_join_modal') }}
+  {% endif %}
 
   {% if switch('stub-attribution-macos') %}
     {{ js_bundle('stub-attribution-macos') }}

--- a/media/css/firefox/new/trailhead/download.scss
+++ b/media/css/firefox/new/trailhead/download.scss
@@ -302,8 +302,8 @@ html.ios .mzp-c-hero {
     background: $color-white;
     color: $color-off-black;
     margin-top: $spacing-lg;
-    text-align: center;
     padding: $spacing-lg;
+    text-align: center;
 
     .join-firefox-title {
         @include text-display-sm;
@@ -333,7 +333,7 @@ html.ios .mzp-c-hero {
  * These should be standardized into a narrow theme.
  * https://github.com/mozilla/protocol/issues/358
  */
- .mzp-c-modal {
+.mzp-c-modal {
 
     .mzp-c-modal-window > .mzp-c-modal-inner {
         background: transparent;

--- a/media/css/firefox/new/trailhead/download.scss
+++ b/media/css/firefox/new/trailhead/download.scss
@@ -295,16 +295,48 @@ html.ios .mzp-c-hero {
     display: block;
 }
 
+//* ====================================================================== */
+//  Join Firefox modal
+
+.join-firefox-content {
+    background: $color-white;
+    color: $color-off-black;
+    margin-top: $spacing-lg;
+    text-align: center;
+    padding: $spacing-lg;
+
+    .join-firefox-title {
+        @include text-display-sm;
+    }
+
+    .join-firefox-button {
+        margin-bottom: $spacing-lg;
+    }
+
+    .mzp-c-button,
+    .mzp-c-button-download-container {
+        width: 100%;
+    }
+
+    .mzp-c-button-download-container {
+        margin-bottom: 0;
+
+        // Hide the privacy link as there's already a one visible prior to clicking download.
+        .fx-privacy-link {
+            display: none;
+        }
+    }
+}
+
 /**
  * Custom narrow modal style.
  * These should be standardized into a narrow theme.
  * https://github.com/mozilla/protocol/issues/358
  */
-.mzp-c-modal.other-platforms-modal {
+ .mzp-c-modal {
 
     .mzp-c-modal-window > .mzp-c-modal-inner {
         background: transparent;
-        max-width: 960px;
         padding: $spacing-xl 0 0;
 
         header {
@@ -315,6 +347,23 @@ html.ios .mzp-c-hero {
 
     .mzp-c-modal-close {
         @include bidi(((right, 0, left, auto),));
+    }
+}
+
+/**
+ * Custom narrow modal style.
+ * These should be standardized into a narrow theme.
+ * https://github.com/mozilla/protocol/issues/358
+ */
+.other-platforms-modal {
+    .mzp-c-modal-window > .mzp-c-modal-inner {
+        max-width: 960px;
+    }
+}
+
+.join-firefox-modal {
+    .mzp-c-modal-window > .mzp-c-modal-inner {
+        max-width: 580px;
     }
 }
 

--- a/media/js/firefox/new/trailhead/join-modal.js
+++ b/media/js/firefox/new/trailhead/join-modal.js
@@ -1,0 +1,62 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// This relies on base/mozilla-modal.js, included in the firefox_new_scene1 bundle
+
+(function() {
+    'use strict';
+
+    var client = window.Mozilla.Client;
+    var joinFirefoxContent = document.querySelector('.join-firefox-content');
+
+    function showFxAModal(e) {
+        e.preventDefault();
+
+        // Open the modal
+        Mzp.Modal.createModal(this, joinFirefoxContent, {
+            title: e.target.textContent,
+            className: 'join-firefox-modal'
+        });
+
+        // Count the click in GA
+        window.dataLayer.push({
+            'event': 'in-page-interaction',
+            'eAction': 'link click',
+            'eLabel': 'Current Firefox user downloading Firefox'
+        });
+    }
+
+    var initFxAccountModal = function() {
+        var downloadLinkPrimary = document.querySelectorAll('#download-button-desktop-release .download-list .download-link[data-download-os="Desktop"]');
+        var downloadLinkSecondary = document.querySelectorAll('#download-other-platforms-modal .download-list .download-link[data-download-os="Desktop"]');
+
+
+        for (var j = 0; j < downloadLinkPrimary.length; j++) {
+            downloadLinkPrimary[j].addEventListener('click', showFxAModal, false);
+        }
+
+        for (var k = 0; k < downloadLinkSecondary.length; k++) {
+            downloadLinkSecondary[k].addEventListener('click', showFxAModal, false);
+        }
+
+        // Don't trigger the modal for signed in users
+        client.getFxaDetails(function(details) {
+            if (details.setup) {
+                for (var i = 0; i < downloadLinkPrimary.length; i++) {
+                    downloadLinkPrimary[i].removeEventListener('click', showFxAModal, false);
+                }
+
+                for (var j = 0; j < downloadLinkSecondary.length; j++) {
+                    downloadLinkSecondary[j].removeEventListener('click', showFxAModal, false);
+                }
+            }
+        });
+    };
+
+    // Only Firefox desktop 57+ (post-quantum) should get the FxA modal
+    if (client.isFirefoxDesktop && client._getFirefoxMajorVersion() >= '57') {
+        initFxAccountModal();
+    }
+
+})();

--- a/media/js/firefox/new/trailhead/join-modal.js
+++ b/media/js/firefox/new/trailhead/join-modal.js
@@ -29,15 +29,9 @@
 
     var initFxAccountModal = function() {
         var downloadLinkPrimary = document.querySelectorAll('#download-button-desktop-release .download-list .download-link[data-download-os="Desktop"]');
-        var downloadLinkSecondary = document.querySelectorAll('#download-other-platforms-modal .download-list .download-link[data-download-os="Desktop"]');
 
-
-        for (var j = 0; j < downloadLinkPrimary.length; j++) {
-            downloadLinkPrimary[j].addEventListener('click', showFxAModal, false);
-        }
-
-        for (var k = 0; k < downloadLinkSecondary.length; k++) {
-            downloadLinkSecondary[k].addEventListener('click', showFxAModal, false);
+        for (var i = 0; i < downloadLinkPrimary.length; i++) {
+            downloadLinkPrimary[i].addEventListener('click', showFxAModal, false);
         }
 
         // Don't trigger the modal for signed in users
@@ -45,10 +39,6 @@
             if (details.setup) {
                 for (var i = 0; i < downloadLinkPrimary.length; i++) {
                     downloadLinkPrimary[i].removeEventListener('click', showFxAModal, false);
-                }
-
-                for (var j = 0; j < downloadLinkSecondary.length; j++) {
-                    downloadLinkSecondary[j].removeEventListener('click', showFxAModal, false);
                 }
             }
         });

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -1067,6 +1067,12 @@
     },
     {
       "files": [
+        "js/firefox/new/trailhead/join-modal.js"
+      ],
+      "name": "firefox_new_download_join_modal"
+    },
+    {
+      "files": [
         "js/firefox/new/scene2.js"
       ],
       "name": "firefox_new_thanks"

--- a/tests/functional/firefox/new/test_download.py
+++ b/tests/functional/firefox/new/test_download.py
@@ -30,3 +30,12 @@ def test_other_platforms_modal(base_url, selenium):
     modal = page.open_other_platforms_modal()
     assert modal.is_displayed
     modal.close()
+
+
+@pytest.mark.nondestructive
+@pytest.mark.skip_if_not_firefox(reason='Join Firefox form is only displayed to Firefox users')
+def test_firefox_account_modal(base_url, selenium):
+    page = DownloadPage(selenium, base_url, params='').open()
+    modal = page.open_join_firefox_modal()
+    assert modal.is_displayed
+    modal.close()

--- a/tests/pages/firefox/new/download.py
+++ b/tests/pages/firefox/new/download.py
@@ -18,6 +18,7 @@ class DownloadPage(FirefoxBasePage):
     _platforms_modal_content_locator = (By.CLASS_NAME, 'mzp-u-modal-content')
     _legacy_platforms_modal_link_locator = (By.ID, 'other-platforms-modal-link')
     _legacy_platforms_modal_content_locator = (By.ID, 'other-platforms')
+    _join_firefox_modal_content_locator = (By.CLASS_NAME, 'join-firefox-content')
 
     @property
     def download_button(self):
@@ -39,4 +40,10 @@ class DownloadPage(FirefoxBasePage):
         modal = Modal(self)
         self.find_element(*self._legacy_platforms_modal_link_locator).click()
         self.wait.until(lambda s: modal.displays(self._legacy_platforms_modal_content_locator))
+        return modal
+
+    def open_join_firefox_modal(self):
+        modal = ModalProtocol(self)
+        self.download_button.click()
+        self.wait.until(lambda s: modal.displays(self._join_firefox_modal_content_locator))
         return modal


### PR DESCRIPTION
## Description
- Adds a join Firefox modal to /firefox/new/.
  - Modal is shown when clicking "Download Now"
  - Modal is shown only to Firefox users who aren't already signed-in to an account.

## Issue / Bugzilla link
#7232

## Testing
Demo URL: https://www-demo5.allizom.org/en-US/firefox/new/

Successful integration test run: https://ci.vpn1.moz.works/blue/organizations/jenkins/bedrock_multibranch_pipeline/detail/run-integration-tests/344/pipeline