### PR TITLE
Compare master and stage hash during deployment

### DIFF
--- a/bin/tag-release.sh
+++ b/bin/tag-release.sh
@@ -22,9 +22,9 @@ done
 # compare master and stage
 echo "Comparing master branch to staging..."
 git fetch "$moz_git_remote"
-stage_hash=`git rev-parse $moz_git_remote/stage`
-master_hash=`git rev-parse master`
-if [ $stage_hash != $master_hash ]; then
+stage_hash=$(git rev-parse "${moz_git_remote}/stage")
+master_hash=$(git rev-parse master)
+if [[ "$stage_hash" != "$master_hash" ]]; then
     read -p "Master branch does NOT match stage branch! Are you sure you want to continue? (Type Override to continue, n to cancel)" no_match
     if [ "$no_match" == "${no_match#[Override]}" ]; then
         # do not continue tagging release

--- a/bin/tag-release.sh
+++ b/bin/tag-release.sh
@@ -19,9 +19,25 @@ while [[ $# -ge 1 ]]; do
   shift # past argument or value
 done
 
+# compare master and stage
+echo "Comparing master branch to staging..."
+git fetch "$moz_git_remote"
+stage_hash=`git rev-parse $moz_git_remote/stage`
+master_hash=`git rev-parse master`
+if [ $stage_hash != $master_hash ]; then
+    read -p "Master branch does NOT match stage branch! Are you sure you want to continue? (Type Override to continue, n to cancel)" no_match
+    if [ "$no_match" == "${no_match#[Override]}" ]; then
+        # do not continue tagging release
+        echo "Cancelled."
+        exit
+    fi
+else
+    echo "✓ Master branch matches staging."
+fi
+
 # prompt for confirmation, evaluate after first letter typed
-read -p "Did you test on stage first? If not, are you sure you want to skip going to stage? (y to continue, n to cancel)" -n 1 stage
-echo    # because the user doesn't press enter anymore we have to add a new line here for readability
+read -p "Did the tests pass on staging? (y to continue, n to cancel)" -n 1 stage
+echo    # because the user doesn't press enter after answering we have to add a new line here for readability
 if [ "$stage" == "${stage#[Yy]}" ]; then
     # $stage doesn't start with y or Y
     echo "Cancelled."


### PR DESCRIPTION
## Description

- Checks `master` and `stage` to make sure a tagged release matches what is on staging
- Fixes the double question that was hurting my head

## Issue / Bugzilla link

No bug this has just been, er, bugging me.

## Testing
