### PR TITLE
Standardize fxa_email_form UTM values. (Fixes #7387)

### DIFF
--- a/bedrock/base/templates/macros.html
+++ b/bedrock/base/templates/macros.html
@@ -292,7 +292,7 @@
 
     DO NOT include utm_source in this dictionary! (It's already a required param.)
 #}
-{% macro fxa_email_form(entrypoint, utm_source, style, class_name='fxa-email-form', utm_params={}, form_title='', intro_text='', button_text='', button_class='button button-blue') -%}
+{% macro fxa_email_form(entrypoint, utm_source, style, campaign, content, term, class_name='fxa-email-form', form_title='', intro_text='', button_text='', button_class='button button-blue') -%}
   {% set service  = 'sync' %}
   <form action="{{ settings.FXA_ENDPOINT }}" data-mozillaonline-action="{{ settings.FXA_ENDPOINT_MOZILLAONLINE }}" id="fxa-email-form" class="{{ class_name }}">
     <input type="hidden" name="action" value="email" />
@@ -304,14 +304,30 @@
     <input type="hidden" name="flow_id" value="" />
     <input type="hidden" name="flow_begin_time" value="" />
 
-    {# utm_source is required, other utm_ params are optional #}
+    {# utm_source is required #}
     <input type="hidden" name="utm_source" value={{ utm_source }} id="fxa-email-form-utm-source" />
-  {% for attr, val in utm_params.items() %}
-    <input type="hidden" name="utm_{{ attr }}" value="{{ val }}" id="fxa-email-form-utm-{{ attr }}" />
-  {% endfor %}
-  {% if style %}
-    <input type="hidden" name="style" value="{{ style }}" />
-  {% endif %}
+    <input type="hidden" name="utm_medium" value="referral" id="fxa-email-form-utm-medium" />
+
+    {# utm_campaign is used to identify specific marketing campaigns. (For example: trailhead or skyline) If there is one, the campaign name is appended to the default value of `fxa-embedded-form`. #}
+    {% if campaign %}
+      <input type="hidden" name="utm_campaign" value="{{ campaign }}-fxa-embedded-form" id="fxa-email-form-utm-campaign" />
+    {% else %}
+      <input type="hidden" name="utm_campaign" value="fxa-embedded-form" id="fxa-email-form-utm-campaign" />
+    {% endif %}
+
+    {# utm_content is optional. It should only be declared when there is new messaging associated with the form. (For example: `get-the-rest-of-firefox`) #}
+    {% if content %}
+      <input type="hidden" name="utm_content" value="{{ content }}" id="fxa-email-form-utm-content" />
+    {% endif %}
+
+    {# utm_term is optional. It is used for paid search keywords. This should be provided if needed. #}
+    {% if term %}
+      <input type="hidden" name="utm_term" value="{{ term }}" id="fxa-email-form-utm-term" />
+    {% endif %}
+
+    {% if style %}
+      <input type="hidden" name="style" value="{{ style }}" />
+    {% endif %}
 
     {% if form_title %}
       <h2 class="fxa-email-form-title">{{ form_title }}</h2>

--- a/bedrock/base/templates/macros.html
+++ b/bedrock/base/templates/macros.html
@@ -292,7 +292,7 @@
 
     DO NOT include utm_source in this dictionary! (It's already a required param.)
 #}
-{% macro fxa_email_form(entrypoint, utm_source, style, campaign, content, term, class_name='fxa-email-form', form_title='', intro_text='', button_text='', button_class='button button-blue') -%}
+{% macro fxa_email_form(entrypoint, utm_source, utm_campaign, utm_content, utm_term, style, class_name='fxa-email-form', form_title='', intro_text='', button_text='', button_class='button button-blue') -%}
   {% set service  = 'sync' %}
   <form action="{{ settings.FXA_ENDPOINT }}" data-mozillaonline-action="{{ settings.FXA_ENDPOINT_MOZILLAONLINE }}" id="fxa-email-form" class="{{ class_name }}">
     <input type="hidden" name="action" value="email" />
@@ -310,19 +310,19 @@
 
     {# utm_campaign is used to identify specific marketing campaigns. (For example: trailhead or skyline) If there is one, the campaign name is appended to the default value of `fxa-embedded-form`. #}
     {% if campaign %}
-      <input type="hidden" name="utm_campaign" value="{{ campaign }}-fxa-embedded-form" id="fxa-email-form-utm-campaign" />
+      <input type="hidden" name="utm_campaign" value="{{ utm_campaign }}-fxa-embedded-form" id="fxa-email-form-utm-campaign" />
     {% else %}
       <input type="hidden" name="utm_campaign" value="fxa-embedded-form" id="fxa-email-form-utm-campaign" />
     {% endif %}
 
     {# utm_content is optional. It should only be declared when there is new messaging associated with the form. (For example: `get-the-rest-of-firefox`) #}
     {% if content %}
-      <input type="hidden" name="utm_content" value="{{ content }}" id="fxa-email-form-utm-content" />
+      <input type="hidden" name="utm_content" value="{{ utm_content }}" id="fxa-email-form-utm-content" />
     {% endif %}
 
     {# utm_term is optional. It is used for paid search keywords. This should be provided if needed. #}
     {% if term %}
-      <input type="hidden" name="utm_term" value="{{ term }}" id="fxa-email-form-utm-term" />
+      <input type="hidden" name="utm_term" value="{{ utm_term }}" id="fxa-email-form-utm-term" />
     {% endif %}
 
     {% if style %}

--- a/bedrock/base/templates/macros.html
+++ b/bedrock/base/templates/macros.html
@@ -309,19 +309,19 @@
     <input type="hidden" name="utm_medium" value="referral" id="fxa-email-form-utm-medium" />
 
     {# utm_campaign is used to identify specific marketing campaigns. (For example: trailhead or skyline) If there is one, the campaign name is appended to the default value of `fxa-embedded-form`. #}
-    {% if campaign %}
+    {% if utm_campaign %}
       <input type="hidden" name="utm_campaign" value="{{ utm_campaign }}-fxa-embedded-form" id="fxa-email-form-utm-campaign" />
     {% else %}
       <input type="hidden" name="utm_campaign" value="fxa-embedded-form" id="fxa-email-form-utm-campaign" />
     {% endif %}
 
     {# utm_content is optional. It should only be declared when there is new messaging associated with the form. (For example: `get-the-rest-of-firefox`) #}
-    {% if content %}
+    {% if utm_content %}
       <input type="hidden" name="utm_content" value="{{ utm_content }}" id="fxa-email-form-utm-content" />
     {% endif %}
 
     {# utm_term is optional. It is used for paid search keywords. This should be provided if needed. #}
-    {% if term %}
+    {% if utm_term %}
       <input type="hidden" name="utm_term" value="{{ utm_term }}" id="fxa-email-form-utm-term" />
     {% endif %}
 

--- a/bedrock/firefox/templates/firefox/accounts-2019.html
+++ b/bedrock/firefox/templates/firefox/accounts-2019.html
@@ -59,8 +59,8 @@
       <p class="c-accounts-hero-desc">{{ _('See if you’ve been involved in an online data breach.') }}</p>
 
       {{ monitor_button(
-        entrypoint='mozilla.org-accounts_page',
-        utm_source='accounts_page',
+        entrypoint='mozilla.org-accounts-page',
+        utm_source='accounts-page',
         utm_campaign='accounts-trailhead'
       ) }}
     </div>
@@ -68,13 +68,13 @@
 
     <div class="c-accounts-form">
       {{ fxa_email_form(
-        entrypoint='mozilla.org-accounts_page',
-        utm_source='accounts-page',
+        entrypoint='mozilla.org-firefox-accounts',
+        utm_source='firefox-accounts',
         form_title=_('Join Firefox'),
         intro_text=_('Enter your email address to get started.'),
         button_class='mzp-c-button mzp-t-primary mzp-t-product',
         style='trailhead',
-        utm_params={'campaign': 'accounts-trailhead'})
+        campaign= 'trailhead')
       }}
 
       <p class="fxa-signin">{{ _('Already have an account?') }} <a {{ fxa_link_fragment(entrypoint='mozilla.org-accounts_page', action='signin', utm_params={'campaign': 'accounts-trailhead', 'content': 'form-upper', 'source': 'accounts_page'}) }} class="js-fxa-cta-link">{{ _('Sign In') }}</a></p>

--- a/bedrock/firefox/templates/firefox/accounts-2019.html
+++ b/bedrock/firefox/templates/firefox/accounts-2019.html
@@ -74,7 +74,7 @@
         intro_text=_('Enter your email address to get started.'),
         button_class='mzp-c-button mzp-t-primary mzp-t-product',
         style='trailhead',
-        campaign= 'trailhead')
+        campaign='trailhead')
       }}
 
       <p class="fxa-signin">{{ _('Already have an account?') }} <a {{ fxa_link_fragment(entrypoint='mozilla.org-accounts_page', action='signin', utm_params={'campaign': 'accounts-trailhead', 'content': 'form-upper', 'source': 'accounts_page'}) }} class="js-fxa-cta-link">{{ _('Sign In') }}</a></p>

--- a/bedrock/firefox/templates/firefox/accounts-2019.html
+++ b/bedrock/firefox/templates/firefox/accounts-2019.html
@@ -74,7 +74,7 @@
         intro_text=_('Enter your email address to get started.'),
         button_class='mzp-c-button mzp-t-primary mzp-t-product',
         style='trailhead',
-        campaign='trailhead')
+        utm_campaign='trailhead')
       }}
 
       <p class="fxa-signin">{{ _('Already have an account?') }} <a {{ fxa_link_fragment(entrypoint='mozilla.org-accounts_page', action='signin', utm_params={'campaign': 'accounts-trailhead', 'content': 'form-upper', 'source': 'accounts_page'}) }} class="js-fxa-cta-link">{{ _('Sign In') }}</a></p>

--- a/bedrock/firefox/templates/firefox/accounts-2019.html
+++ b/bedrock/firefox/templates/firefox/accounts-2019.html
@@ -69,12 +69,12 @@
     <div class="c-accounts-form">
       {{ fxa_email_form(
         entrypoint='mozilla.org-accounts_page',
-        utm_source='accounts_page',
+        utm_source='accounts-page',
         form_title=_('Join Firefox'),
         intro_text=_('Enter your email address to get started.'),
         button_class='mzp-c-button mzp-t-primary mzp-t-product',
         style='trailhead',
-        utm_params={'campaign': 'accounts-trailhead', 'content': 'form-upper', 'medium': 'referral'})
+        utm_params={'campaign': 'accounts-trailhead'})
       }}
 
       <p class="fxa-signin">{{ _('Already have an account?') }} <a {{ fxa_link_fragment(entrypoint='mozilla.org-accounts_page', action='signin', utm_params={'campaign': 'accounts-trailhead', 'content': 'form-upper', 'source': 'accounts_page'}) }} class="js-fxa-cta-link">{{ _('Sign In') }}</a></p>

--- a/bedrock/firefox/templates/firefox/accounts.html
+++ b/bedrock/firefox/templates/firefox/accounts.html
@@ -308,9 +308,10 @@
         <div class="show-fxa-supported-signed-out">
           {{ fxa_email_form(
             entrypoint='mozilla.org-accounts_page',
-            utm_source='accounts_page',
+            utm_source='accounts-page',
             button_class='mzp-c-button mzp-t-primary mzp-t-product',
-            button_text=_('Create an Account'))
+            button_text=_('Create an Account')),
+            utm_params={'campaign': 'accounts'})
           }}
 
           <p class="fxa-signin">{{ _('Already have an account?') }} <a {{ fxa_link_fragment(entrypoint='mozilla.org-accounts_page', action='signin', utm_params={'campaign': 'fxa-embedded-form', 'content': '/firefox/accounts/', 'source': 'accounts-page'}) }} class="js-fxa-cta-link">{{ _('Sign In') }}</a></p>

--- a/bedrock/firefox/templates/firefox/accounts.html
+++ b/bedrock/firefox/templates/firefox/accounts.html
@@ -307,11 +307,10 @@
 
         <div class="show-fxa-supported-signed-out">
           {{ fxa_email_form(
-            entrypoint='mozilla.org-accounts_page',
+            entrypoint='mozilla.org-firefox-accounts',
             utm_source='accounts-page',
             button_class='mzp-c-button mzp-t-primary mzp-t-product',
-            button_text=_('Create an Account')),
-            utm_params={'campaign': 'accounts'})
+            button_text=_('Create an Account'))
           }}
 
           <p class="fxa-signin">{{ _('Already have an account?') }} <a {{ fxa_link_fragment(entrypoint='mozilla.org-accounts_page', action='signin', utm_params={'campaign': 'fxa-embedded-form', 'content': '/firefox/accounts/', 'source': 'accounts-page'}) }} class="js-fxa-cta-link">{{ _('Sign In') }}</a></p>

--- a/bedrock/firefox/templates/firefox/developer/whatsnew-fx68-trailhead.html
+++ b/bedrock/firefox/templates/firefox/developer/whatsnew-fx68-trailhead.html
@@ -12,7 +12,7 @@
       button_class='mzp-c-button mzp-t-product mzp-t-small',
       utm_source='whatsnew68a2',
       style='trailhead',
-      campaign= 'trailhead')
+      campaign='trailhead')
   }}
 {% endblock %}
 

--- a/bedrock/firefox/templates/firefox/developer/whatsnew-fx68-trailhead.html
+++ b/bedrock/firefox/templates/firefox/developer/whatsnew-fx68-trailhead.html
@@ -12,7 +12,7 @@
       button_class='mzp-c-button mzp-t-product mzp-t-small',
       utm_source='whatsnew68a2',
       style='trailhead',
-      campaign='trailhead')
+      utm_campaign='trailhead')
   }}
 {% endblock %}
 

--- a/bedrock/firefox/templates/firefox/developer/whatsnew-fx68-trailhead.html
+++ b/bedrock/firefox/templates/firefox/developer/whatsnew-fx68-trailhead.html
@@ -12,7 +12,7 @@
       button_class='mzp-c-button mzp-t-product mzp-t-small',
       utm_source='whatsnew68a2',
       style='trailhead',
-      utm_params={'campaign': 'trailhead'})
+      campaign= 'trailhead')
   }}
 {% endblock %}
 

--- a/bedrock/firefox/templates/firefox/developer/whatsnew-fx68-trailhead.html
+++ b/bedrock/firefox/templates/firefox/developer/whatsnew-fx68-trailhead.html
@@ -12,7 +12,7 @@
       button_class='mzp-c-button mzp-t-product mzp-t-small',
       utm_source='whatsnew68a2',
       style='trailhead',
-      utm_params={'campaign': 'fxa-embedded-form', 'content': 'whatsnew', 'medium': 'referral'})
+      utm_params={'campaign': 'trailhead'})
   }}
 {% endblock %}
 

--- a/bedrock/firefox/templates/firefox/developer/whatsnew-fx68.html
+++ b/bedrock/firefox/templates/firefox/developer/whatsnew-fx68.html
@@ -10,8 +10,7 @@
 {{ fxa_email_form(
     entrypoint='mozilla.org-whatsnew68a2',
     button_class='mzp-c-button',
-    utm_source='whatsnew',
-    utm_params={'campaign': 'fxa-embedded-form', 'content': 'whatsnew', 'medium': 'referral'})
+    utm_source='whatsnew68'
 }}
 {% endblock %}
 

--- a/bedrock/firefox/templates/firefox/developer/whatsnew-fx68.html
+++ b/bedrock/firefox/templates/firefox/developer/whatsnew-fx68.html
@@ -10,7 +10,7 @@
 {{ fxa_email_form(
     entrypoint='mozilla.org-whatsnew68a2',
     button_class='mzp-c-button',
-    utm_source='whatsnew68'
+    utm_source='whatsnew68')
 }}
 {% endblock %}
 

--- a/bedrock/firefox/templates/firefox/developer/whatsnew-fx68.html
+++ b/bedrock/firefox/templates/firefox/developer/whatsnew-fx68.html
@@ -10,7 +10,7 @@
 {{ fxa_email_form(
     entrypoint='mozilla.org-whatsnew68a2',
     button_class='mzp-c-button',
-    utm_source='whatsnew68')
+    utm_source='whatsnew68a2')
 }}
 {% endblock %}
 

--- a/bedrock/firefox/templates/firefox/firstrun/firstrun-quantum.html
+++ b/bedrock/firefox/templates/firefox/firstrun/firstrun-quantum.html
@@ -65,7 +65,7 @@
       <div id="fxaccounts-wrapper">
         {{ fxa_email_form(
           entrypoint='mozilla.org-firstrun',
-          utm_source='firstrun,
+          utm_source='firstrun',
           button_class='mzp-c-button mzp-t-product')
         }}
 

--- a/bedrock/firefox/templates/firefox/firstrun/firstrun-quantum.html
+++ b/bedrock/firefox/templates/firefox/firstrun/firstrun-quantum.html
@@ -63,7 +63,11 @@
       {% endblock %}
       </header>
       <div id="fxaccounts-wrapper">
-        {{ fxa_email_form(entrypoint='mozilla.org-firstrun_page', utm_source='firstrun-page', utm_params={'campaign': 'fxa-embedded-form', 'content': 'firstrun-page', 'medium': 'referral'}, button_class='mzp-c-button mzp-t-product',) }}
+        {{ fxa_email_form(
+          entrypoint='mozilla.org-firstrun',
+          utm_source='firstrun,
+          button_class='mzp-c-button mzp-t-product')
+        }}
 
         <p class="fxa-signin">{{ _('Already have an account?') }} <a {{ fxa_link_fragment(entrypoint='mozilla.org-firstrun_page', utm_params={'campaign': 'fxa-embedded-form', 'medium': 'referral', 'content': 'firstrun-page', 'source': 'firstrun-page'}) }} class="js-fxa-cta-link">{{ _('Sign In') }}</a></p>
       </div>

--- a/bedrock/firefox/templates/firefox/new/scene1.html
+++ b/bedrock/firefox/templates/firefox/new/scene1.html
@@ -159,10 +159,11 @@
   <p class="fxa-intro">{{ _('Sync bookmarks, send tabs, save to Pocket and more with a Firefox Account.') }} <a href="{{ url('firefox.accounts') }}">{{ _('Learn more') }}</a></p>
 
   {{ fxa_email_form(
-    entrypoint='mozilla.org-firefox_new',
+    entrypoint='mozilla.org-firefox-new',
     button_text=_('Get a Firefox Account'),
     utm_source='firefox-new',
-    utm_params={'campaign': 'firefox-new', 'term': 'existing-users'}) }}
+    term='existing-users')
+  }}
 
   <p class="fxa-signin">{{ _('Already have an account?') }} <a {{ fxa_link_fragment(entrypoint='mozilla.org-firefox_new', utm_params={'campaign': 'fxa-embedded-form', 'content': '/firefox/new/', 'source': 'download-page'}) }} class="js-fxa-cta-link">{{ _('Sign In') }}</a></p>
 

--- a/bedrock/firefox/templates/firefox/new/scene1.html
+++ b/bedrock/firefox/templates/firefox/new/scene1.html
@@ -162,7 +162,7 @@
     entrypoint='mozilla.org-firefox-new',
     button_text=_('Get a Firefox Account'),
     utm_source='firefox-new',
-    term='existing-users')
+    utm_term='existing-users')
   }}
 
   <p class="fxa-signin">{{ _('Already have an account?') }} <a {{ fxa_link_fragment(entrypoint='mozilla.org-firefox_new', utm_params={'campaign': 'fxa-embedded-form', 'content': '/firefox/new/', 'source': 'download-page'}) }} class="js-fxa-cta-link">{{ _('Sign In') }}</a></p>

--- a/bedrock/firefox/templates/firefox/new/scene1.html
+++ b/bedrock/firefox/templates/firefox/new/scene1.html
@@ -158,7 +158,11 @@
   <h4 class="fxa-title">{{ _('You’ve already got the Firefox browser. Now get everything else Firefox.') }}</h4>
   <p class="fxa-intro">{{ _('Sync bookmarks, send tabs, save to Pocket and more with a Firefox Account.') }} <a href="{{ url('firefox.accounts') }}">{{ _('Learn more') }}</a></p>
 
-  {{ fxa_email_form(entrypoint='mozilla.org-firefox_new', button_text=_('Get a Firefox Account'), utm_source='firefox-new', utm_params={'campaign': 'firefox-new', 'content': 'firefox-new-fxa', 'term': 'existing-users', 'medium': 'referral'}) }}
+  {{ fxa_email_form(
+    entrypoint='mozilla.org-firefox_new',
+    button_text=_('Get a Firefox Account'),
+    utm_source='firefox-new',
+    utm_params={'campaign': 'firefox-new', 'term': 'existing-users'}) }}
 
   <p class="fxa-signin">{{ _('Already have an account?') }} <a {{ fxa_link_fragment(entrypoint='mozilla.org-firefox_new', utm_params={'campaign': 'fxa-embedded-form', 'content': '/firefox/new/', 'source': 'download-page'}) }} class="js-fxa-cta-link">{{ _('Sign In') }}</a></p>
 

--- a/bedrock/firefox/templates/firefox/whatsnew/beta/whatsnew-fx68-trailhead.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/beta/whatsnew-fx68-trailhead.html
@@ -12,7 +12,7 @@
       button_class='mzp-c-button mzp-t-product mzp-t-small',
       utm_source='whatsnew68beta',
       style='trailhead',
-      campaign='trailhead')
+      utm_campaign='trailhead')
   }}
 {% endblock %}
 

--- a/bedrock/firefox/templates/firefox/whatsnew/beta/whatsnew-fx68-trailhead.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/beta/whatsnew-fx68-trailhead.html
@@ -20,6 +20,6 @@
   {{ monitor_button(
     entrypoint='mozilla.org-whatsnew68beta',
     utm_source='whatsnew68beta',
-    utm_campaign='whatsnew68beta'
-  ) }}
+    utm_campaign='whatsnew68beta')
+  }}
 {% endblock %}

--- a/bedrock/firefox/templates/firefox/whatsnew/beta/whatsnew-fx68-trailhead.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/beta/whatsnew-fx68-trailhead.html
@@ -12,7 +12,7 @@
       button_class='mzp-c-button mzp-t-product mzp-t-small',
       utm_source='whatsnew68beta',
       style='trailhead',
-      utm_params={'campaign': 'trailhead'})
+      campaign='trailhead')
   }}
 {% endblock %}
 

--- a/bedrock/firefox/templates/firefox/whatsnew/beta/whatsnew-fx68-trailhead.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/beta/whatsnew-fx68-trailhead.html
@@ -12,7 +12,7 @@
       button_class='mzp-c-button mzp-t-product mzp-t-small',
       utm_source='whatsnew68beta',
       style='trailhead',
-      utm_params={'campaign': 'fxa-embedded-form', 'content': 'whatsnew', 'medium': 'referral'})
+      utm_params={'campaign': 'trailhead'})
   }}
 {% endblock %}
 

--- a/bedrock/firefox/templates/firefox/whatsnew/beta/whatsnew-fx68.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/beta/whatsnew-fx68.html
@@ -10,8 +10,7 @@
 {{ fxa_email_form(
     entrypoint='mozilla.org-whatsnew68beta',
     button_class='mzp-c-button',
-    utm_source='whatsnew',
-    utm_params={'campaign': 'fxa-embedded-form', 'content': 'whatsnew', 'medium': 'referral'})
+    utm_source='whatsnew68beta'
 }}
 {% endblock %}
 

--- a/bedrock/firefox/templates/firefox/whatsnew/beta/whatsnew-fx68.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/beta/whatsnew-fx68.html
@@ -10,7 +10,7 @@
 {{ fxa_email_form(
     entrypoint='mozilla.org-whatsnew68beta',
     button_class='mzp-c-button',
-    utm_source='whatsnew68beta'
+    utm_source='whatsnew68beta')
 }}
 {% endblock %}
 

--- a/bedrock/firefox/templates/firefox/whatsnew/fx64/whatsnew-fx64-base.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/fx64/whatsnew-fx64-base.html
@@ -35,7 +35,7 @@
 {% set fxa_utm_params = {
   'campaign': 'wnp64',
   'content': '/firefox/WNP/64/',
-  'source': 'wnp-64'
+  'source': 'whatsnew64'
 } %}
 
 {% block page_title %}{{ page_title }}{% endblock %}

--- a/bedrock/firefox/templates/firefox/whatsnew/fx64/whatsnew-fx64-base.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/fx64/whatsnew-fx64-base.html
@@ -3,7 +3,7 @@
 
 {% from "macros-protocol.html" import hero, call_out_compact with context %}
 
-{% from "macros.html" import fxa_email_form, fxa_link_fragment, google_play_button with context %}
+{% from "macros.html" import fxa_link_fragment, google_play_button with context %}
 
 {% add_lang_files "firefox/whatsnew_64" %}
 
@@ -31,12 +31,6 @@
   {% set sync_head = _('Send tabs instantly to your devices') %}
   {% set sync_desc = _('Send an open tab on one device to all your others with a single tap. Much easier than texting or emailing yourself those links.') %}
 {% endif %}
-
-{% set fxa_utm_params = {
-  'campaign': 'wnp64',
-  'content': '/firefox/WNP/64/',
-  'source': 'whatsnew64'
-} %}
 
 {% block page_title %}{{ page_title }}{% endblock %}
 {% block page_desc %}{{ page_desc }}{% endblock %}
@@ -68,8 +62,8 @@
    include_cta=True
   ) %}
   <p class="show-fxa-supported-signed-out show-fxa-default">
-    <a {{ fxa_link_fragment(entrypoint='mozilla.org-whatsnew64', action='signup', utm_params=fxa_utm_params) }} class="js-fxa-cta-link mzp-c-button mzp-t-product">{{ button_create }}</a><br>
-    <span class="wn64-signin">{{ login_desc }} <a {{ fxa_link_fragment(entrypoint='mozilla.org-whatsnew64', utm_params=fxa_utm_params) }} class="js-fxa-cta-link">{{ login_link }}</a></span>
+    <a {{ fxa_link_fragment(entrypoint='mozilla.org-whatsnew64', action='signup', utm_params={'source': 'whatsnew64'}) }} class="js-fxa-cta-link mzp-c-button mzp-t-product">{{ button_create }}</a><br>
+    <span class="wn64-signin">{{ login_desc }} <a {{ fxa_link_fragment(entrypoint='mozilla.org-whatsnew64', utm_params={'source': 'whatsnew64'}) }} class="js-fxa-cta-link">{{ login_link }}</a></span>
   </p>
   {% endcall %}
   {% call hero(
@@ -115,8 +109,8 @@
     class='mzp-t-firefox t-wn64 show-fxa-default show-fxa-supported-signed-out'
   ) %}
     <p>
-      <a {{ fxa_link_fragment(entrypoint='mozilla.org-whatsnew64', action='signup', utm_params=fxa_utm_params) }} class="js-fxa-cta-link mzp-c-button mzp-t-product">{{ button_create }}</a><br>
-      <span class="wn64-signin">{{ login_desc }} <a {{ fxa_link_fragment(entrypoint='mozilla.org-whatsnew64', utm_params=fxa_utm_params) }} class="js-fxa-cta-link">{{ login_link }}</a></span>
+      <a {{ fxa_link_fragment(entrypoint='mozilla.org-whatsnew64', action='signup', utm_params={'source': 'whatsnew64'}) }} class="js-fxa-cta-link mzp-c-button mzp-t-product">{{ button_create }}</a><br>
+      <span class="wn64-signin">{{ login_desc }} <a {{ fxa_link_fragment(entrypoint='mozilla.org-whatsnew64', utm_params={'source': 'whatsnew64'}) }} class="js-fxa-cta-link">{{ login_link }}</a></span>
     </p>
   {% endcall %}
 

--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx63.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx63.html
@@ -36,8 +36,8 @@
         {{ fxa_email_form(
             entrypoint='mozilla.org-whatsnew63',
             button_class='mzp-c-button',
-            utm_source='whatsnew',
-            utm_params={'campaign': 'fxa-embedded-form', 'content': 'whatsnew', 'medium': 'referral'})
+            utm_source='whatsnew63',
+            utm_params={'campaign': 'fxa-embedded-form', 'content': 'get-firefox-account', 'medium': 'referral'})
         }}
       </div>
     </div>

--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx63.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx63.html
@@ -36,8 +36,7 @@
         {{ fxa_email_form(
             entrypoint='mozilla.org-whatsnew63',
             button_class='mzp-c-button',
-            utm_source='whatsnew63',
-            utm_params={'campaign': 'fxa-embedded-form', 'content': 'get-firefox-account', 'medium': 'referral'})
+            utm_source='whatsnew63'
         }}
       </div>
     </div>

--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx63.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx63.html
@@ -36,7 +36,7 @@
         {{ fxa_email_form(
             entrypoint='mozilla.org-whatsnew63',
             button_class='mzp-c-button',
-            utm_source='whatsnew63'
+            utm_source='whatsnew63')
         }}
       </div>
     </div>

--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx65.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx65.html
@@ -33,7 +33,7 @@
         <div class="c-sticky-signup-content">
           <h2 class="c-sticky-signup-title">{{ _('Get your Firefox Account') }}</h2>
         </div>
-        {{ fxa_email_form(entrypoint='mozilla.org-whatsnew65', button_class='mzp-c-button', utm_source='whatsnew', utm_params={'campaign': 'fxa-embedded-form', 'content': 'whatsnew', 'medium': 'referral'})
+        {{ fxa_email_form(entrypoint='mozilla.org-whatsnew65', button_class='mzp-c-button', utm_source='whatsnew65', utm_params={'campaign': 'fxa-embedded-form', 'content': 'get-firefox-account', 'medium': 'referral'})
         }}
       </div>
     </div>

--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx65.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx65.html
@@ -36,7 +36,7 @@
         {{ fxa_email_form(
           entrypoint='mozilla.org-whatsnew65',
           button_class='mzp-c-button',
-          utm_source='whatsnew65'
+          utm_source='whatsnew65')
         }}
       </div>
     </div>

--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx65.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx65.html
@@ -33,7 +33,10 @@
         <div class="c-sticky-signup-content">
           <h2 class="c-sticky-signup-title">{{ _('Get your Firefox Account') }}</h2>
         </div>
-        {{ fxa_email_form(entrypoint='mozilla.org-whatsnew65', button_class='mzp-c-button', utm_source='whatsnew65', utm_params={'campaign': 'fxa-embedded-form', 'content': 'get-firefox-account', 'medium': 'referral'})
+        {{ fxa_email_form(
+          entrypoint='mozilla.org-whatsnew65',
+          button_class='mzp-c-button',
+          utm_source='whatsnew65'
         }}
       </div>
     </div>

--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx66.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx66.html
@@ -48,8 +48,8 @@
           {{ fxa_email_form(
               entrypoint='mozilla.org-whatsnew66',
               button_class='mzp-c-button',
-              utm_source='whatsnew',
-              utm_params={'campaign': 'fxa-embedded-form', 'content': 'whatsnew', 'medium': 'referral'})
+              utm_source='whatsnew66',
+              utm_params={'campaign': 'fxa-embedded-form', 'content': 'get-firefox-account', 'medium': 'referral'})
           }}
           {% endblock %}
         </div>

--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx66.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx66.html
@@ -16,12 +16,6 @@
   {{ css_bundle('firefox_whatsnew_66') }}
 {% endblock %}
 
-{% set fxa_utm_params = {
-  'campaign': 'wnp66',
-  'content': '/firefox/WNP/66/',
-  'source': 'wnp-66'
-} %}
-
 {% block body_class %}state-fxa-default{% endblock %}
 
 {% block site_header %}{% endblock %}

--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx66.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx66.html
@@ -42,8 +42,7 @@
           {{ fxa_email_form(
               entrypoint='mozilla.org-whatsnew66',
               button_class='mzp-c-button',
-              utm_source='whatsnew66',
-              utm_params={'campaign': 'fxa-embedded-form', 'content': 'get-firefox-account', 'medium': 'referral'})
+              utm_source='whatsnew66'
           }}
           {% endblock %}
         </div>

--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx66.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx66.html
@@ -42,7 +42,7 @@
           {{ fxa_email_form(
               entrypoint='mozilla.org-whatsnew66',
               button_class='mzp-c-button',
-              utm_source='whatsnew66'
+              utm_source='whatsnew66')
           }}
           {% endblock %}
         </div>

--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx67.0.5.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx67.0.5.html
@@ -40,7 +40,7 @@
                 button_class='mzp-c-button mzp-t-product mzp-t-small',
                 utm_source='whatsnew6705',
                 style='trailhead',
-                utm_params={'campaign': 'fxa-embedded-form', 'content': 'whatsnew', 'medium': 'referral'})
+                utm_params={'campaign': 'fxa-embedded-form', 'content': 'get-firefox-account', 'medium': 'referral'})
             }}
           {% endblock %}
         </div>

--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx67.0.5.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx67.0.5.html
@@ -40,7 +40,8 @@
                 button_class='mzp-c-button mzp-t-product mzp-t-small',
                 utm_source='whatsnew6705',
                 style='trailhead',
-                utm_params={'campaign': 'trailhead'})
+                campaign='trailhead',
+                content='get-the-rest-of-firefox')
             }}
           {% endblock %}
         </div>

--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx67.0.5.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx67.0.5.html
@@ -40,7 +40,7 @@
                 button_class='mzp-c-button mzp-t-product mzp-t-small',
                 utm_source='whatsnew6705',
                 style='trailhead',
-                utm_params={'campaign': 'fxa-embedded-form', 'content': 'get-firefox-account', 'medium': 'referral'})
+                utm_params={'campaign': 'trailhead'})
             }}
           {% endblock %}
         </div>

--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx67.0.5.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx67.0.5.html
@@ -40,8 +40,8 @@
                 button_class='mzp-c-button mzp-t-product mzp-t-small',
                 utm_source='whatsnew6705',
                 style='trailhead',
-                campaign='trailhead',
-                content='get-the-rest-of-firefox')
+                utm_campaign='trailhead',
+                utm_content='get-the-rest-of-firefox')
             }}
           {% endblock %}
         </div>

--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx67.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx67.html
@@ -17,11 +17,6 @@
   {{ css_bundle('firefox_whatsnew_67') }}
 {% endblock %}
 
-{% set fxa_utm_params = {
-  'campaign': 'fxa-embedded-form',
-  'content': 'get-firefox-account'
-} %}
-
 {% block body_class %}state-fxa-default{% endblock %}
 
 {% block site_header %}{% endblock %}
@@ -133,7 +128,7 @@
           entrypoint='mozilla.org-whatsnew67',
           button_class='mzp-c-button mzp-t-product mzp-t-small',
           utm_source='whatsnew67',
-          utm_params=fxa_utm_params)
+          content='unlock-benefits')
       }}
       {% endblock %}
     </div>

--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx67.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx67.html
@@ -18,9 +18,8 @@
 {% endblock %}
 
 {% set fxa_utm_params = {
-  'campaign': 'wnp67',
-  'content': '/firefox/WNP/67/',
-  'source': 'wnp-67'
+  'campaign': 'fxa-embedded-form',
+  'content': 'get-firefox-account'
 } %}
 
 {% block body_class %}state-fxa-default{% endblock %}
@@ -133,7 +132,7 @@
       {{ fxa_email_form(
           entrypoint='mozilla.org-whatsnew67',
           button_class='mzp-c-button mzp-t-product mzp-t-small',
-          utm_source='whatsnew',
+          utm_source='whatsnew67',
           utm_params=fxa_utm_params)
       }}
       {% endblock %}

--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx67.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx67.html
@@ -128,7 +128,7 @@
           entrypoint='mozilla.org-whatsnew67',
           button_class='mzp-c-button mzp-t-product mzp-t-small',
           utm_source='whatsnew67',
-          content='unlock-benefits')
+          utm_content='unlock-benefits')
       }}
       {% endblock %}
     </div>

--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx68-trailhead.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx68-trailhead.html
@@ -12,14 +12,14 @@
       button_class='mzp-c-button mzp-t-product mzp-t-small',
       utm_source='whatsnew68',
       style='trailhead',
-      campaign= 'trailhead'
-  ) }}
+      campaign='trailhead')
+  }}
 {% endblock %}
 
 {% block monitor_button %}
   {{ monitor_button(
     entrypoint='mozilla.org-whatsnew68',
     utm_source='whatsnew68-trailhead',
-    utm_campaign='wnp-monitor-cta'
-  ) }}
+    utm_campaign='wnp-monitor-cta')
+  }}
 {% endblock %}

--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx68-trailhead.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx68-trailhead.html
@@ -12,8 +12,8 @@
       button_class='mzp-c-button mzp-t-product mzp-t-small',
       utm_source='whatsnew68',
       style='trailhead',
-      utm_params={'campaign': 'trailhead'})
-  }}
+      campaign= 'trailhead'
+  ) }}
 {% endblock %}
 
 {% block monitor_button %}

--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx68-trailhead.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx68-trailhead.html
@@ -12,14 +12,14 @@
       button_class='mzp-c-button mzp-t-product mzp-t-small',
       utm_source='whatsnew68',
       style='trailhead',
-      utm_params={'campaign': 'fxa-embedded-form', 'content': 'whatsnew', 'medium': 'referral'})
+      utm_params={'campaign': 'fxa-embedded-form', 'content': 'get-firefox-account', 'medium': 'referral'})
   }}
 {% endblock %}
 
 {% block monitor_button %}
   {{ monitor_button(
     entrypoint='mozilla.org-whatsnew68',
-    utm_source='whatsnew68',
-    utm_campaign='whatsnew68'
+    utm_source='whatsnew68-trailhead',
+    utm_campaign='wnp-monitor-cta'
   ) }}
 {% endblock %}

--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx68-trailhead.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx68-trailhead.html
@@ -12,7 +12,7 @@
       button_class='mzp-c-button mzp-t-product mzp-t-small',
       utm_source='whatsnew68',
       style='trailhead',
-      utm_params={'campaign': 'fxa-embedded-form', 'content': 'get-firefox-account', 'medium': 'referral'})
+      utm_params={'campaign': 'trailhead'})
   }}
 {% endblock %}
 

--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx68-trailhead.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx68-trailhead.html
@@ -12,7 +12,7 @@
       button_class='mzp-c-button mzp-t-product mzp-t-small',
       utm_source='whatsnew68',
       style='trailhead',
-      campaign='trailhead')
+      utm_campaign='trailhead')
   }}
 {% endblock %}
 

--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx68.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx68.html
@@ -10,7 +10,7 @@
   {{ fxa_email_form(
       entrypoint='mozilla.org-whatsnew68',
       button_class='mzp-c-button mzp-t-product mzp-t-small',
-      utm_source='whatsnew68'
+      utm_source='whatsnew68')
   }}
 {% endblock %}
 

--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx68.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx68.html
@@ -10,8 +10,7 @@
   {{ fxa_email_form(
       entrypoint='mozilla.org-whatsnew68',
       button_class='mzp-c-button mzp-t-product mzp-t-small',
-      utm_source='whatsnew68',
-      utm_params={ 'campaign': 'fxa-embedded-form', 'content': 'get-firefox-account'})
+      utm_source='whatsnew68'
   }}
 {% endblock %}
 

--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx68.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx68.html
@@ -11,7 +11,7 @@
       entrypoint='mozilla.org-whatsnew68',
       button_class='mzp-c-button mzp-t-product mzp-t-small',
       utm_source='whatsnew68',
-      utm_params={ 'campaign': 'wnp68', 'content': '/firefox/WNP/68/', 'source': 'wnp-68'})
+      utm_params={ 'campaign': 'fxa-embedded-form', 'content': 'get-firefox-account'})
   }}
 {% endblock %}
 


### PR DESCRIPTION
## Description
There were some inconsistencies on different /whatsnew templates on format of utm params in the `fxa_email_form` macros, this PR should standardize them.

## Issue / Bugzilla link
#7387

## Testing
- Consistent UTM values across FxA referrals on /whatsnew pages.
- Any templates missed?