### PR TITLE
Fix version number for multiple ESR on /firefox/all (Fixes #7406)

### DIFF
--- a/bedrock/base/templates/product-all-unified-macros.html
+++ b/bedrock/base/templates/product-all-unified-macros.html
@@ -16,7 +16,7 @@
   <select id="{{ version_select_id }}" class="c-selection-input" aria-controls="download-info"{% if disabled %} disabled{% endif %}>
     <option value="{{ id }}">{{ version }}</option>
     {% if id == 'desktop_esr' and desktop_esr_next_version %}
-      <option value="desktop_esr_next">{{ version }}</option>
+      <option value="desktop_esr_next">{{ desktop_esr_next_version }}</option>
     {% endif %}
   </select>
 {% endmacro %}


### PR DESCRIPTION
## Description
- Fixes incorrect version number for esr_next.

## Issue / Bugzilla link
#7406

## Testing
- [ ] Each version should be listed correctly in the drop down.