### PR TITLE
Fix "browser" typo on Enterprise page title

### DIFF
--- a/bedrock/firefox/templates/firefox/enterprise/index.html
+++ b/bedrock/firefox/templates/firefox/enterprise/index.html
@@ -7,7 +7,7 @@
 {% from "macros-protocol.html" import hero with context %}
 
 {% block page_title_prefix %}{% endblock %}
-{% block page_title %}{{_('Firefox Broswer for Enterprise | Firefox')}}{% endblock %}
+{% block page_title %}{{_('Firefox Browser for Enterprise | Firefox')}}{% endblock %}
 {% block page_desc %}{{_('A managed version of the super-fast new Firefox.')}}{% endblock %}
 
 {% block page_css %}


### PR DESCRIPTION
I spotted a typo in the page title and wanted to quickly fix it. 😁 