### PR TITLE
[fix #7413] Remove TriageBot from Nightly WNP

### DIFF
--- a/bedrock/firefox/templates/firefox/nightly_whatsnew.html
+++ b/bedrock/firefox/templates/firefox/nightly_whatsnew.html
@@ -74,12 +74,6 @@
             {% endtrans %}
           </p>
           <p>
-            {% trans triagebot='https://triagebot.mozilla.org/' %}
-              Would you be willing to help us triage unconfirmed bugs in Bugzilla? Then maybe
-              <a href="%(triagebot)s">TriageBot</a> could be of interest to you.
-            {% endtrans %}
-          </p>
-          <p>
             {% trans irc='ircs://irc.mozilla.org/nightly' %}
               You can also interact with the Nightly community on IRC in the <a href="%(irc)s">#nightly</a> channel.
               Feel free to ask questions and talk about features, regressions or crashes you may be experiencing.


### PR DESCRIPTION
## Description
TriageBot was just decommissioned, so we shouldn't mention it or link to it any more. I couldn't find any mentions of it other than the Nightly whatsnew page.

This page is localized but since this is just a deletion it shouldn't need an l10n tag.

## Issue / Bugzilla link
#7413 
