### PR TITLE
Selecting ESR on /all should let me download an MSI installer (Fixes #7410)

### DIFF
--- a/bedrock/base/templates/product-all-unified-macros.html
+++ b/bedrock/base/templates/product-all-unified-macros.html
@@ -14,7 +14,11 @@
   {% set version_select_id = 'select_' ~ id ~ '_version' %}
   <label for="{{ version_select_id }}" class="c-selection-label">{{ _('Which version would you like?') }}</label>
   <select id="{{ version_select_id }}" class="c-selection-input" aria-controls="download-info"{% if disabled %} disabled{% endif %}>
-    <option value="{{ id }}">{{ version }}</option>
+    {# ESR can have two versions available. ESR Latest should always come first in the dropdown. #}
+    {% if id == 'desktop_esr_next' %}
+      <option value="desktop_esr">{{ desktop_esr_latest_version }}</option>
+    {% endif %}
+      <option value="{{ id }}">{{ version }}</option>
     {% if id == 'desktop_esr' and desktop_esr_next_version %}
       <option value="desktop_esr_next">{{ desktop_esr_next_version }}</option>
     {% endif %}

--- a/bedrock/firefox/templates/firefox/all-unified.html
+++ b/bedrock/firefox/templates/firefox/all-unified.html
@@ -109,14 +109,19 @@
             </a>
             {{ select_product_list(products, disabled=True) }}
           </p>
-          {# Show the ESR version select dropdown if there are multiple ESR's available. #}
-          {% set hide_esr_version_select = False if desktop_esr_next_version else True %}
 
           {{ product_options('desktop_release', desktop_release_platforms, desktop_release_full_builds, desktop_release_latest_version, disabled=True, hide_version=True, hide_language=False) }}
           {{ product_options('desktop_beta', desktop_beta_platforms, desktop_beta_full_builds, desktop_beta_latest_version, disabled=True, hide_version=True, hide_language=False) }}
           {{ product_options('desktop_developer', desktop_developer_platforms, desktop_developer_full_builds, desktop_developer_latest_version, disabled=True, hide_version=True, hide_language=False) }}
           {{ product_options('desktop_nightly', desktop_nightly_platforms, desktop_nightly_full_builds, desktop_nightly_latest_version, disabled=True, hide_version=True, hide_language=False) }}
+
+          {# Show the ESR version select dropdown if there are multiple ESR's available. #}
+          {% set hide_esr_version_select = not desktop_esr_next_version %}
           {{ product_options('desktop_esr', desktop_esr_platforms, desktop_esr_full_builds, desktop_esr_latest_version, disabled=True, hide_version=hide_esr_version_select, hide_language=False) }}
+          {% if desktop_esr_next_version %}
+            {{ product_options('desktop_esr_next', desktop_esr_platforms_next, desktop_esr_full_builds_next, desktop_esr_next_version, disabled=True, hide_version=hide_esr_version_select, hide_language=False) }}
+          {% endif %}
+
           {{ product_options('android_release', android_release_platforms, android_release_full_builds, android_release_latest_version, disabled=True, hide_version=True, hide_language=True) }}
           {{ product_options('android_beta', android_beta_platforms, android_beta_full_builds, android_beta_latest_version, disabled=True, hide_version=True, hide_language=True) }}
           {{ product_options('android_nightly', android_nightly_platforms, android_nightly_full_builds, android_nightly_latest_version, disabled=True, hide_version=True, hide_language=True) }}

--- a/media/css/firefox/all/all-unified.scss
+++ b/media/css/firefox/all/all-unified.scss
@@ -64,6 +64,17 @@ $image-path: '/media/protocol/img';
         }
     }
 
+    &[data-current="desktop_esr_next"] {
+        .c-selection-options[data-product="desktop_esr_next"] {
+            display: block;
+        }
+
+        // ESR Next has the same product links as regular ESR
+        .c-product-links[data-product="desktop_esr"] {
+            display: block;
+        }
+    }
+
     &[data-current="android_release"] {
         .c-selection-options[data-product="android_release"] {
             display: block;

--- a/media/js/firefox/all/all-downloads-unified.js
+++ b/media/js/firefox/all/all-downloads-unified.js
@@ -56,12 +56,20 @@
     };
 
     /**
-     * Set the currently selected product. The data-attribute on the <form> is
+     * Show the form for the currently selected product. The data-attribute on the <form> is
      * used to display the appropriate options for each individual product item.
      * @param {String} product `id`.
      */
-    FirefoxDownloader.setProductSelection = function(id) {
+    FirefoxDownloader.setFormSelection = function(id) {
         form.setAttribute('data-current', id);
+    };
+
+    /**
+     * Get the currently displayed product form.
+     * @returns {String} product `id`.
+     */
+    FirefoxDownloader.getFormSelection = function() {
+        return form.getAttribute('data-current');
     };
 
     /**
@@ -69,7 +77,17 @@
      * @returns {Object} product `id` and `label`.
      */
     FirefoxDownloader.getProductSelection = function() {
-        return FirefoxDownloader.getSelectOption(productSelect);
+        var product = FirefoxDownloader.getSelectOption(productSelect);
+
+        // ESR can have two versions available but it's listed as a single product in the dropdown.
+        if (product.id === 'desktop_esr') {
+            var version = FirefoxDownloader.getFormSelection();
+            if (version === 'desktop_esr_next') {
+                product.id = version;
+            }
+        }
+
+        return product;
     };
 
     /**
@@ -269,7 +287,7 @@
      * @param {Object} event object.
      */
     FirefoxDownloader.onProductChange = function(e) {
-        FirefoxDownloader.setProductSelection(e.target.value);
+        FirefoxDownloader.setFormSelection(e.target.value);
         FirefoxDownloader.generateDownloadURL();
     };
 
@@ -277,7 +295,12 @@
      * Product ESR input <select> handler.
      * @param {Object} event object.
      */
-    FirefoxDownloader.onVersionChange = function() {
+    FirefoxDownloader.onVersionChange = function(e) {
+        // ESR can have two versions available in product details.
+        if (e.target.value === 'desktop_esr' || e.target.value === 'desktop_esr_next') {
+            FirefoxDownloader.setFormSelection(e.target.value);
+        }
+        FirefoxDownloader.setAllSelectOptions(e.target.value, versionSelect);
         FirefoxDownloader.generateDownloadURL();
     };
 
@@ -358,7 +381,7 @@
         }
 
         if (pageLang && product.id && product.label) {
-            FirefoxDownloader.setProductSelection(product.id);
+            FirefoxDownloader.setFormSelection(product.id);
             FirefoxDownloader.setAllSelectOptions(pageLang, languageSelect);
             FirefoxDownloader.generateDownloadURL();
             FirefoxDownloader.enableForm();

--- a/tests/unit/spec/firefox/all/all-downloads-unified.js
+++ b/tests/unit/spec/firefox/all/all-downloads-unified.js
@@ -273,6 +273,67 @@ describe('all-downloads-unified.js', function() {
 
     });
 
+    describe('getProductSelection', function() {
+        it('should return the selected product', function() {
+            var product = {
+                id: 'desktop_esr',
+                label: 'Firefox Extended Support Release'
+            };
+
+            spyOn(Mozilla.FirefoxDownloader, 'getSelectOption').and.returnValue(product);
+            spyOn(Mozilla.FirefoxDownloader, 'getFormSelection');
+            expect(Mozilla.FirefoxDownloader.getProductSelection()).toEqual(product);
+        });
+
+        it('should return the correct ESR product', function() {
+            var next = 'desktop_esr_next';
+            var product = {
+                id: 'desktop_esr',
+                label: 'Firefox Extended Support Release'
+            };
+
+            spyOn(Mozilla.FirefoxDownloader, 'getSelectOption').and.returnValue(product);
+            spyOn(Mozilla.FirefoxDownloader, 'getFormSelection').and.returnValue(next);
+            var result = Mozilla.FirefoxDownloader.getProductSelection();
+            expect(result.id).toEqual(next);
+            expect(result.label).toEqual(product.label);
+        });
+    });
+
+    describe('onVersionChange', function() {
+        it('should update the form fields and generate a download URL', function() {
+            var e = {
+                target: {
+                    value: 'desktop_release'
+                }
+            };
+
+            spyOn(Mozilla.FirefoxDownloader, 'setFormSelection');
+            spyOn(Mozilla.FirefoxDownloader, 'setAllSelectOptions');
+            spyOn(Mozilla.FirefoxDownloader, 'generateDownloadURL');
+
+            Mozilla.FirefoxDownloader.onVersionChange(e);
+            expect(Mozilla.FirefoxDownloader.setFormSelection).not.toHaveBeenCalled();
+            expect(Mozilla.FirefoxDownloader.setAllSelectOptions).toHaveBeenCalledWith(e.target.value, jasmine.any(Object));
+            expect(Mozilla.FirefoxDownloader.generateDownloadURL).toHaveBeenCalled();
+        });
+
+        it('should update the product selection for ESR', function() {
+            var e = {
+                target: {
+                    value: 'desktop_esr_next'
+                }
+            };
+
+            spyOn(Mozilla.FirefoxDownloader, 'setFormSelection');
+            spyOn(Mozilla.FirefoxDownloader, 'setAllSelectOptions');
+            spyOn(Mozilla.FirefoxDownloader, 'generateDownloadURL');
+
+            Mozilla.FirefoxDownloader.onVersionChange(e);
+            expect(Mozilla.FirefoxDownloader.setFormSelection).toHaveBeenCalledWith(e.target.value);
+        });
+    });
+
     describe('init', function() {
         var platform = 'windows';
         var language = 'de';
@@ -282,7 +343,7 @@ describe('all-downloads-unified.js', function() {
         };
 
         beforeEach(function() {
-            spyOn(Mozilla.FirefoxDownloader, 'setProductSelection');
+            spyOn(Mozilla.FirefoxDownloader, 'setFormSelection');
             spyOn(Mozilla.FirefoxDownloader, 'setAllSelectOptions');
             spyOn(Mozilla.FirefoxDownloader, 'generateDownloadURL');
             spyOn(Mozilla.FirefoxDownloader, 'enableForm');


### PR DESCRIPTION
## Description
- Enables MSI installers for Firefox ESR 68.0esr on `/firefox/all/`

## Issue / Bugzilla link
#7410

## Testing
- [ ] MSI installers **should be** available for download when selecting ESR version **68.0esr**.
- [ ] MSI installers **should not be** available for download when selecting ESR version **60.8.0esr**.
- [ ] There should be no other regressions in product selection.

Successful integration test run: https://ci.vpn1.moz.works/blue/organizations/jenkins/bedrock_multibranch_pipeline/detail/run-integration-tests/347/pipeline