### PR TITLE
Updating contribute-base.less to fix italic addresses on /contribute/events/.

### DIFF
--- a/media/css/mozorg/contribute/contribute-base.less
+++ b/media/css/mozorg/contribute/contribute-base.less
@@ -1007,6 +1007,7 @@ textarea:focus {
     border-collapse: collapse;
     width: 100%;
     margin: 0 auto 40px;
+    font-style: normal;
 
     td,
     th {

--- a/media/css/mozorg/contribute/contribute-base.less
+++ b/media/css/mozorg/contribute/contribute-base.less
@@ -1008,6 +1008,10 @@ textarea:focus {
     width: 100%;
     margin: 0 auto 40px;
 
+    address {
+        font-style: normal;
+    }
+
     td,
     th {
         text-align: left;
@@ -1035,10 +1039,6 @@ textarea:focus {
 
     .event-name {
         width: 40%;
-    }
-
-    address {
-        font-style: normal;
     }
 }
 

--- a/media/css/mozorg/contribute/contribute-base.less
+++ b/media/css/mozorg/contribute/contribute-base.less
@@ -1007,8 +1007,7 @@ textarea:focus {
     border-collapse: collapse;
     width: 100%;
     margin: 0 auto 40px;
-    font-style: normal;
-
+    
     td,
     th {
         text-align: left;
@@ -1036,6 +1035,10 @@ textarea:focus {
 
     .event-name {
         width: 40%;
+    }
+
+    address {
+        font-style: normal;
     }
 }
 

--- a/media/css/mozorg/contribute/contribute-base.less
+++ b/media/css/mozorg/contribute/contribute-base.less
@@ -1007,7 +1007,7 @@ textarea:focus {
     border-collapse: collapse;
     width: 100%;
     margin: 0 auto 40px;
-    
+
     td,
     th {
         text-align: left;


### PR DESCRIPTION
## Closes #7398
- Added `font-style: normal;` in .events-table. 

## Issue / Bugzilla link
[Issue #7398](https://github.com/mozilla/bedrock/issues/7398)
## Testing
Manual