### PR TITLE
Update sandstone & pebbles nav styles. (Fixes #7430)

### DIFF
--- a/media/css/hubs/_sub-nav.scss
+++ b/media/css/hubs/_sub-nav.scss
@@ -186,6 +186,8 @@
 // Near-total copy pasta from global-nav.html. TODO: DRY this up
 
 #sub-nav-download-firefox {
+    -moz-osx-font-smoothing: grayscale;
+    -webkit-font-smoothing: antialiased;
     margin: 7px 0 0;
     opacity: 0;
     transform: translateY(-100px);
@@ -205,8 +207,8 @@
         @include font-size-small;
         background-color: #fff;
         border-radius: 2px;
-        border: 2px solid $color-button-green;
-        color: $color-button-green;
+        border: 2px solid $color-button-blue;
+        color: $color-button-blue;
         display: inline-block;
         font-weight: bold;
         padding: .5em 20px;
@@ -220,7 +222,7 @@
         &:hover,
         &:focus,
         &:active {
-            background-color: $color-button-green;
+            background-color: $color-button-blue;
             color: #fff;
             transition: color .1s ease-in-out, background-color .1s ease-in-out;
         }

--- a/media/css/pebbles/components/_protocol-nav.scss
+++ b/media/css/pebbles/components/_protocol-nav.scss
@@ -2,18 +2,18 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-$font-path: '/media/fonts';
-$image-path: '/media/protocol/img';
+$font-path: "/media/fonts";
+$image-path: "/media/protocol/img";
 
 // Protocol components for navigation.
-@import '../../../protocol/css/components/card';
-@import '../../../protocol/css/components/menu';
-@import '../../../protocol/css/components/menu-item';
-@import '../../../protocol/css/components/navigation';
-@import '../../../protocol/css/base/includes/animations';
+@import "../../../protocol/css/components/card";
+@import "../../../protocol/css/components/menu";
+@import "../../../protocol/css/components/menu-item";
+@import "../../../protocol/css/components/navigation";
+@import "../../../protocol/css/base/includes/animations";
 
 // Bedrock specific navigation overrides.
-@import '../../protocol/components/navigation';
+@import "../../protocol/components/navigation";
 
 /**
  * Pebbles specific overrides for download button in main navigation.
@@ -24,16 +24,15 @@ $image-path: '/media/protocol/img';
             background-color: transparent;
             background-image: none;
             border-radius: 2px;
-            color: #12bc00;
-            border: 2px solid #12bc00;
+            border: 2px solid #0060df;
             box-shadow: none;
-            line-height: 1.125;
+            color: #0060df;
             padding: $spacing-sm $spacing-md;
 
             &:hover,
             &:focus {
-                background-color: #12bc00;
-                border-color: #12bc00;
+                background-color: #0060df;
+                border-color: #0060df;
                 color: $color-white;
             }
         }
@@ -50,6 +49,8 @@ $image-path: '/media/protocol/img';
  * 2. Because of 1, pages also set a base font-size of 112.5% on <html>, so compensate proportionally.
  */
 .mzp-c-navigation {
+    -moz-osx-font-smoothing: grayscale;
+    -webkit-font-smoothing: antialiased;
 
     .mzp-c-menu-title {
         @include font-size(14px);
@@ -57,7 +58,6 @@ $image-path: '/media/protocol/img';
 }
 
 .mzp-c-menu-item {
-
     .mzp-c-menu-item-title {
         @include font-size(16px);
         font-weight: bold;
@@ -87,19 +87,19 @@ $image-path: '/media/protocol/img';
         background-color: transparent;
         background-image: none;
         border-radius: 2px;
-        border: 2px solid #12bc00;
+        border: 2px solid #0060df;
         box-shadow: none;
-        color: #12bc00;
+        color: #0060df;
         display: inline-block;
-        font-weight: bold;
-        line-height: 1.125;
+        font-weight: 700;
         padding: $spacing-sm $spacing-md;
         text-decoration: none;
+        line-height: 1.3;
 
         &:hover,
         &:focus {
-            background-color: #12bc00;
-            border-color: #12bc00;
+            background-color: #0060df;
+            border-color: #0060df;
             color: $color-white;
         }
     }

--- a/media/css/pebbles/includes/_variables.scss
+++ b/media/css/pebbles/includes/_variables.scss
@@ -56,7 +56,7 @@ $color-button-light:    #fff;
 $color-button-dark:     #00539f;
 $color-button-green:    #12bc00;
 $color-button-orange:   #f26c23;
-$color-button-blue:     $color-quantum-blue;
+$color-button-blue:     #0060df;
 
 // Content widths
 $width-phone:           300px;

--- a/media/css/pebbles/includes/_variables.scss
+++ b/media/css/pebbles/includes/_variables.scss
@@ -54,7 +54,7 @@ $color-link-yellow:     #ffbb38;
 // Button colors
 $color-button-light:    #fff;
 $color-button-dark:     #00539f;
-$color-button-green:    #16da00;
+$color-button-green:    #12bc00;
 $color-button-orange:   #f26c23;
 $color-button-blue:     $color-quantum-blue;
 

--- a/media/css/sandstone/lib.less
+++ b/media/css/sandstone/lib.less
@@ -55,7 +55,7 @@
 
 @mozillaRed: #c13832;
 
-@buttonGreen: #16da00;
+@buttonGreen: #12bc00;
 @buttonGreenDark: darken(@buttonGreen, 10%);
 @buttonTextColor: #fff;
 @buttonBlue: #43a6e2;

--- a/media/css/sandstone/protocol-nav.scss
+++ b/media/css/sandstone/protocol-nav.scss
@@ -2,38 +2,37 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-$font-path: '/media/fonts';
-$image-path: '/media/protocol/img';
+$font-path: "/media/fonts";
+$image-path: "/media/protocol/img";
 
 // Protocol components for navigation.
-@import '../../protocol/css/components/card';
-@import '../../protocol/css/components/menu';
-@import '../../protocol/css/components/menu-item';
-@import '../../protocol/css/components/navigation';
-@import '../../protocol/css/base/includes/animations';
+@import "../../protocol/css/components/card";
+@import "../../protocol/css/components/menu";
+@import "../../protocol/css/components/menu-item";
+@import "../../protocol/css/components/navigation";
+@import "../../protocol/css/base/includes/animations";
 
 // Bedrock specific navigation overrides.
-@import '../protocol/components/navigation';
+@import "../protocol/components/navigation";
 
 /**
  * Sandstone specific overrides for download button in main navigation.
  */
- .mzp-c-navigation-download {
+.mzp-c-navigation-download {
     .download-button {
         .download-link {
             background-color: transparent;
             background-image: none;
             border-radius: 2px;
-            color: #12bc00;
-            border: 2px solid #12bc00;
+            border: 2px solid #0060df;
             box-shadow: none;
-            line-height: 1.125;
+            color: #0060df;
             padding: $spacing-sm $spacing-md;
 
             &:hover,
             &:focus {
-                background-color: #12bc00;
-                border-color: #12bc00;
+                background-color: #0060df;
+                border-color: #0060df;
                 color: $color-white;
             }
         }
@@ -64,24 +63,26 @@ $image-path: '/media/protocol/img';
 
 // Global FxA CTA experiment: issue #6629
 .mzp-c-navigation {
+    -moz-osx-font-smoothing: grayscale;
+    -webkit-font-smoothing: antialiased;
+
     .c-navigation-fxa-cta {
         @include font-size(16px);
         background-color: transparent;
         background-image: none;
         border-radius: 2px;
-        border: 2px solid #12bc00;
+        border: 2px solid #0060df;
         box-shadow: none;
-        color: #12bc00;
+        color: #0060df;
         display: inline-block;
-        font-weight: bold;
-        line-height: 1.125;
+        font-weight: 700;
         padding: $spacing-sm $spacing-md;
         text-decoration: none;
 
         &:hover,
         &:focus {
-            background-color: #12bc00;
-            border-color: #12bc00;
+            background-color: #0060df;
+            border-color: #0060df;
             color: $color-white;
         }
     }
@@ -100,6 +101,5 @@ $image-path: '/media/protocol/img';
             color: inherit;
             text-decoration: underline;
         }
-
     }
 }


### PR DESCRIPTION
## Description
- Updates the "Download Firefox" and "Get a Firefox Account" nav CTA's on pebbles and sandstone templates to match (more closely, not exact) to the protocol nav styles.

- Changes more neon shade of green used in pebbles and sandstone to the slightly darker shade we have used other places.

![Screen Shot 2019-07-16 at 5 08 57 PM](https://user-images.githubusercontent.com/30483988/61338017-7ba45b00-a7ec-11e9-8dfb-aed5db88749e.png)
![Screen Shot 2019-07-16 at 5 08 41 PM](https://user-images.githubusercontent.com/30483988/61338018-7ba45b00-a7ec-11e9-9f44-de526da7147f.png)


## Issue / Bugzilla link
#7430

## Testing
- non-firefox and firefox browsers.
- breaks old template design accidentally?