### PR TITLE
Show survey (per locale) in /contribute page

### DIFF
--- a/bedrock/mozorg/templates/mozorg/contribute/contribute-base.html
+++ b/bedrock/mozorg/templates/mozorg/contribute/contribute-base.html
@@ -120,6 +120,9 @@
   </section>
   {% endblock contrib_footer %}
 </main>
+
+{% block cta %}{% endblock %}
+
 {% endblock content %}
 
 {% block email_form %}{% endblock %}

--- a/bedrock/mozorg/templates/mozorg/contribute/index.html
+++ b/bedrock/mozorg/templates/mozorg/contribute/index.html
@@ -150,7 +150,27 @@
 
 {% endblock contrib_content %}
 
+{% block cta %}
+
+  {% set localized_surveys = {'en-US': 'GHJYW6D'} %}
+
+  {% if LANG in localized_surveys and switch('contribute-survey') %}
+    <div id="survey-message">
+      <span class="survey-invite">
+        Hello! Would you be willing to take a minute to answer a few questions?
+      </span>
+      <a class="survey-button" href="https://www.surveymonkey.com/r/{{ localized_surveys[LANG] }}">
+        Sure. I’ll help.
+      </a>
+    </div>
+  {% endif %}
+
+{% endblock %}
+
 {% block js %}
   {{ js_bundle('contribute-base') }}
   {{ js_bundle('contribute-landing') }}
+  {% if switch('contribute-survey') %}
+    {{ js_bundle('contribute-survey') }}
+  {% endif %}
 {% endblock %}

--- a/media/css/mozorg/contribute/contribute-base.less
+++ b/media/css/mozorg/contribute/contribute-base.less
@@ -1832,3 +1832,37 @@ textarea:focus {
     }
 
 }
+
+#survey-message {
+    .border-box;
+    .font-size(12px);
+    background: #fff0b3;
+    bottom: 0;
+    display: none;
+    min-height: 30px;
+    overflow: hidden;
+    padding: 10px 20px;
+    position: fixed;
+    text-align: center;
+    width: 100%;
+    z-index: 90;
+    transform: translateY(100%);
+
+    .survey-button {
+        background-color: #00b6e0;
+        border-radius: 2px;
+        color: #fff;
+        height: 20px;
+        margin-left: 10px;
+        padding: 2px 5px;
+    }
+
+    &.show {
+        display: block;
+    }
+
+    &.show.animate {
+        transition: transform .25s ease-in;
+        transform: translateY(0);
+    }
+}

--- a/media/js/mozorg/contribute/contribute-survey.js
+++ b/media/js/mozorg/contribute/contribute-survey.js
@@ -1,0 +1,16 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+(function($) {
+    'use strict';
+
+    $(document).ready(function() {
+        var $survey = $('#survey-message');
+        $survey.addClass('show');
+        setTimeout(function() {
+            $survey.addClass('animate');
+        }, 500);
+    });
+
+})(window.jQuery);

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -916,6 +916,12 @@
     },
     {
       "files": [
+        "js/mozorg/contribute/contribute-survey.js"
+      ],
+      "name": "contribute-survey"
+    },
+    {
+      "files": [
         "js/firefox/new/variation-scene1.js",
         "js/firefox/campaign/berlin-scene1-variation.js"
       ],

--- a/tests/functional/contribute/test_contribute.py
+++ b/tests/functional/contribute/test_contribute.py
@@ -8,6 +8,7 @@ from pages.contribute.contribute import ContributePage
 
 
 @pytest.mark.nondestructive
+@pytest.mark.skip(reason='https://github.com/mozilla/bedrock/issues/7314')
 def test_play_video(base_url, selenium):
     page = ContributePage(selenium, base_url).open()
     video = page.play_video()


### PR DESCRIPTION
## Description
Shows up a `surveygizmo` survey in /contribute page. The survey is going to be different per locale. Currently only focusing in `en-US`. This is going to be extended for the rest of top 5 locales of this page.

## Issue / Bugzilla link
#7314 

## Testing
I've already tested locally that different (dummy) surveys shows up per different locale. For now `en-US` shows up as expected. 
