### PR TITLE
update Discourse links on a couple pages

### DIFF
--- a/bedrock/firefox/templates/firefox/developer/includes/engage.html
+++ b/bedrock/firefox/templates/firefox/developer/includes/engage.html
@@ -4,7 +4,7 @@
     <section class="speak-up">
       <h3>{{ _('Speak up') }}</h3>
       <p>{{ _('Feedback makes us better. Tell us how we can improve the browser and Developer tools.') }}</p>
-      <p class="cta"><a href="https://discourse.mozilla-community.org/c/devtools" class="button button-hollow">{{ _('Join the conversation') }}</a></p>
+      <p class="cta"><a href="https://discourse.mozilla.org/c/devtools" class="button button-hollow">{{ _('Join the conversation') }}</a></p>
     </section>
 
     <section class="get-involved">

--- a/bedrock/mozorg/templates/mozorg/about/forums/forums.html
+++ b/bedrock/mozorg/templates/mozorg/about/forums/forums.html
@@ -84,7 +84,7 @@
           </div>
           <ul class="subscribe">
             {% if forum.id in mdn_forums %}
-              <li>{{ _('Follow:') }} <a href="https://discourse.mozilla-community.org/c/mdn">{{ _('MDN category on Discourse') }}</a></li>
+              <li>{{ _('Follow:') }} <a href="https://discourse.mozilla.org/c/mdn">{{ _('MDN category on Discourse') }}</a></li>
               <li>{{ _('Email-in:') }} <a href="mailto:mdn@mozilla-community.org">mdn@mozilla-community.org</a></li>
               <li>{{ _('Archives, up to June 2017:') }} <a href="https://groups.google.com/group/{{ forum.id }}/topics">{{ _('%s Google Group')|format(forum.id) }}</a></li>
             {% elif forum.id.startswith('mozilla.') %}


### PR DESCRIPTION
## Description

There were a couple links to discourse.mozilla-community.org. This is just updating them to point directly to discourse.mozilla.org. 

## Issue / Bugzilla link

## Testing
