### PR TITLE
[fix #7484] Fix whatsnew logo width

### DIFF
--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx67.0.5.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx67.0.5.html
@@ -24,7 +24,7 @@
 <main class="mzp-t-firefox">
   <header class="c-page-header">
     <div class="mzp-l-content c-page-header-inner">
-      {{ high_res_img('firefox/whatsnew_67/logo.png', {'alt': 'Firefox', 'width': '147', 'height': '55', 'class': 'c-page-header-logo-fx'}) }}
+      {{ high_res_img('firefox/whatsnew_67/logo.png', {'alt': 'Firefox', 'width': '159', 'height': '55', 'class': 'c-page-header-logo-fx'}) }}
       <h1 class="c-page-header-up-to-date"><span>{{ _('Congrats! You’re using the latest version of Firefox.') }}</span></h1>
     </div>
   </header>


### PR DESCRIPTION
## Description
Fixes the header logo width so it's no longer squished. The same template is shown to release, beta, and dev edition.

## Issue / Bugzilla link
#7484 

## Testing

- [x] Verify nonsquishedness.