### PR TITLE
Standardize params on /firefox/accounts/

### DIFF
--- a/bedrock/firefox/templates/firefox/accounts-2019.html
+++ b/bedrock/firefox/templates/firefox/accounts-2019.html
@@ -7,6 +7,10 @@
 
 {% extends "firefox/base-protocol.html" %}
 
+{% set _entrypoint = 'mozilla.org-firefox-accounts' %}
+{% set _utm_source = 'mozilla.org-firefox-accounts' %}
+{% set _utm_campaign = 'trailhead' %}
+
 {%- block page_title -%}
   {# L10n: HTML page title #}
   {%- if l10n_has_tag('accounts-metadata-072019') -%}
@@ -59,25 +63,29 @@
       <p class="c-accounts-hero-desc">{{ _('See if you’ve been involved in an online data breach.') }}</p>
 
       {{ monitor_button(
-        entrypoint='mozilla.org-accounts-page',
-        utm_source='accounts-page',
-        utm_campaign='accounts-trailhead'
+        entrypoint= _entrypoint,
+        utm_source=_utm_source,
+        utm_campaign=_utm_campaign
       ) }}
     </div>
     {% endif %}
 
     <div class="c-accounts-form">
       {{ fxa_email_form(
-        entrypoint='mozilla.org-firefox-accounts',
-        utm_source='firefox-accounts',
+        entrypoint=_entrypoint,
+        utm_source=_utm_source,
         form_title=_('Join Firefox'),
         intro_text=_('Enter your email address to get started.'),
         button_class='mzp-c-button mzp-t-primary mzp-t-product',
         style='trailhead',
-        utm_campaign='trailhead')
+        utm_campaign=_utm_campaign)
       }}
 
-      <p class="fxa-signin">{{ _('Already have an account?') }} <a {{ fxa_link_fragment(entrypoint='mozilla.org-accounts_page', action='signin', utm_params={'campaign': 'accounts-trailhead', 'content': 'form-upper', 'source': 'accounts_page'}) }} class="js-fxa-cta-link">{{ _('Sign In') }}</a></p>
+      <p class="fxa-signin">{{ _('Already have an account?') }} <a {{ fxa_link_fragment(
+        entrypoint=_entrypoint,
+        action='signin',
+        utm_params={'campaign': _utm_campaign, 'content': 'form-upper', 'source': _utm_source }
+        ) }} class="js-fxa-cta-link">{{ _('Sign In') }}</a></p>
     </div>
   </div>
 </section>
@@ -101,19 +109,19 @@
         </a>
       </li>
       <li class="c-product-list-item t-product-lockwise">
-        <a href="https://lockwise.firefox.com?utm_source=www.mozilla.org&amp;utm_medium=referral&amp;utm_campaign=accounts-trailhead&amp;utm_content=product-list-item&amp;entrypoint=mozilla.org-accounts_page" data-link-name="Firefox Lockwise" data-link-type="link">
+        <a href="https://lockwise.firefox.com?utm_source={{ _utm_source }}&amp;utm_medium=referral&amp;utm_campaign={{ _utm_campaign }}&amp;utm_content=product-list-item&amp;entrypoint={{ _entrypoint }}" data-link-name="Firefox Lockwise" data-link-type="link">
           <h3 class="c-product-list-title">Firefox <span>Lockwise</span></h3>
           <p class="c-product-list-desc">{{ _('Keep your passwords protected and portable.') }}</p>
         </a>
       </li>
       <li class="c-product-list-item t-product-monitor">
-        <a href="https://monitor.firefox.com?utm_source=www.mozilla.org&amp;utm_medium=referral&amp;utm_campaign=accounts-trailhead&amp;utm_content=product-list-item&amp;entrypoint=mozilla.org-accounts_page" data-link-name="Firefox Monitor" data-link-type="link">
+        <a href="https://monitor.firefox.com?utm_source={{ _utm_source }}&amp;utm_medium=referral&amp;utm_campaign={{ _utm_campaign }}&amp;utm_content=product-list-item&amp;entrypoint={{ _entrypoint }}" data-link-name="Firefox Monitor" data-link-type="link">
           <h3 class="c-product-list-title">Firefox <span>Monitor</span></h3>
           <p class="c-product-list-desc">{{ _('Get a lookout for data breaches.') }}</p>
         </a>
       </li>
       <li class="c-product-list-item t-product-send">
-        <a href="https://send.firefox.com?utm_source=www.mozilla.org&amp;utm_medium=referral&amp;utm_campaign=accounts-trailhead&amp;utm_content=product-list-item&amp;entrypoint=mozilla.org-accounts_page" data-link-name="Firefox Send" data-link-type="link">
+        <a href="https://send.firefox.com?utm_source={{ _utm_source }}&amp;utm_medium=referral&amp;utm_campaign={{ _utm_campaign }}&amp;utm_content=product-list-item&amp;entrypoint={{ _entrypoint }}" data-link-name="Firefox Send" data-link-type="link">
           <h3 class="c-product-list-title">Firefox <span>Send</span></h3>
           <p class="c-product-list-desc">{{ _('Share large files without prying eyes.') }}</p>
         </a>


### PR DESCRIPTION
## Description

In https://github.com/mozilla/bedrock/blob/d83bd3934b6014886e986a7073303b0e75b83292/bedrock/firefox/templates/firefox/accounts-2019.html#L61-L80 there are 3 different entrypoints for the same page. We need these to be uniform.

The template includes 6 referral links that include utm and entrypoint parameters; all 6 should have the same values in those params.

This PR sets those params in variables and interpolates the variables in the referral links, to help keep these parameters uniform. 

