### PR TITLE
Fix firefox/accounts form for Firefox on iOS (Fixes #7483)

### DIFF
--- a/media/js/base/mozilla-fxa-form.js
+++ b/media/js/base/mozilla-fxa-form.js
@@ -72,8 +72,8 @@ Mozilla.FxaForm = (function(Mozilla) {
     }
 
     if (fxaForm) {
-        // Sync is Firefox only
-        if (Mozilla.Client.isFirefox) {
+        // Sync is Firefox for desktop only.
+        if (Mozilla.Client.isFirefoxDesktop) {
             init();
         } else {
             // Omit the fields required for sync.


### PR DESCRIPTION
## Description
- Fixes JavaScript error preventing the /accounts form working for Firefox on iOS.
- [Debugging notes here](https://github.com/mozilla/bedrock/issues/7483#issuecomment-516027881).

## Issue / Bugzilla link
#7483

## Testing
Demo: https://bedrock-demo-agibson.oregon-b.moz.works/firefox/accounts/

- [ ] Visit /firefox/accounts/ on Firefox for iOS and the main CTA button should be blue (and not disabled).