### PR TITLE
Fix privacy notice template name

### DIFF
--- a/bedrock/privacy/views.py
+++ b/bedrock/privacy/views.py
@@ -42,7 +42,7 @@ class PrivacyDocView(LegalDocView):
 
 
 class FirefoxPrivacyDocView(PrivacyDocView):
-    template_name = 'privacy/notices/firefox.html'
+    template_name = 'privacy/notices/base-notice-paragraphs.html'
 
     def get_legal_doc(self):
         doc = super(FirefoxPrivacyDocView, self).get_legal_doc()


### PR DESCRIPTION
## Description
`bedrock/privacy/templates/privacy/notices/firefox.html` was deleted in https://github.com/mozilla/bedrock/commit/248e345e72861e0ed937235dfd5d418d98bcda3d and we didn't realize it was still in use by some locales (for whatever reason, looks like some markdown style thing). This updates the view so all should use the `firefox-quantum.html` template.

My bad for not catching this in review 😞 

## Testing

Verify Firefox privacy notices load without error. Some effected locales to test are ro, hu, and el
