### PR TITLE
Fix transparency report base template

### DIFF
--- a/bedrock/mozorg/templates/mozorg/about/policy/transparency/index.html
+++ b/bedrock/mozorg/templates/mozorg/about/policy/transparency/index.html
@@ -2,7 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
 
-{% extends "mozorg/about-base.html" %}
+{% extends "base-pebbles.html" %}
 
 {% block page_title %}{{ _('Transparency') }}{% endblock %}
 {% set body_id = "about-transparency" %}

--- a/bedrock/mozorg/templates/mozorg/about/policy/transparency/report-base.html
+++ b/bedrock/mozorg/templates/mozorg/about/policy/transparency/report-base.html
@@ -2,7 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
 
-{% extends "mozorg/about-base.html" %}
+{% extends "base-pebbles.html" %}
 
 {% block page_title %}{{ _('Transparency Report') }}{% endblock %}
 {% block body_class %}sand about-transparency{% endblock %}


### PR DESCRIPTION
## Description
Another regression from https://github.com/mozilla/bedrock/commit/248e345e72861e0ed937235dfd5d418d98bcda3d

The transparency report pages are still using Pebbles and extending `mozorg/about-base.html`, which was just switched over to Protocol and the transparency pages lost some of their styling. Switching the base template back to Pebbles fixes that, and we'll work on porting them to Protocol another time.
