### PR TITLE
Use releng product-details repo directly

### DIFF
--- a/bedrock/mozorg/tests/test_commands.py
+++ b/bedrock/mozorg/tests/test_commands.py
@@ -25,7 +25,7 @@ class TestUpdateProductDetailsFiles(TestCase):
     def test_handle_diff_loads_all(self):
         with patch.multiple(self.command, update_file_data=DEFAULT, validate_data=DEFAULT,
                             file_storage=DEFAULT, load_changes=DEFAULT, repo=DEFAULT):
-            options = dict(quiet=False, database='default')
+            options = dict(quiet=False, database='default', force=False)
             self.command.update_file_data.return_value = True
             self.command.handle(**options)
             assert self.command.file_storage.all_json_files.called
@@ -36,7 +36,7 @@ class TestUpdateProductDetailsFiles(TestCase):
     def test_handle_error_no_set_latest(self):
         with patch.multiple(self.command, update_file_data=DEFAULT, validate_data=DEFAULT,
                             file_storage=DEFAULT, load_changes=DEFAULT, repo=DEFAULT):
-            options = dict(quiet=False, database='default')
+            options = dict(quiet=False, database='default', force=False)
             self.command.update_file_data.return_value = True
             self.command.load_changes.side_effect = Exception('broke yo')
             with self.assertRaises(Exception):
@@ -49,7 +49,7 @@ class TestUpdateProductDetailsFiles(TestCase):
     def test_handle_no_diff_does_nothing(self):
         with patch.multiple(self.command, update_file_data=DEFAULT, validate_data=DEFAULT,
                             file_storage=DEFAULT, load_changes=DEFAULT, repo=DEFAULT):
-            options = dict(quiet=False, database='default')
+            options = dict(quiet=False, database='default', force=False)
             self.command.update_file_data.return_value = False
             self.command.handle(**options)
             assert not self.command.file_storage.all_json_files.called

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -91,10 +91,6 @@ TEST_RUNNER = 'django.test.runner.DiscoverRunner'
 # http://www.i18nguy.com/unicode/language-identifiers.html
 LANGUAGE_CODE = 'en-US'
 
-# Use Ship It as the source for product_details
-PROD_DETAILS_URL = config('PROD_DETAILS_URL',
-                          default='https://product-details.mozilla.org/1.0/')
-
 # Tells the product_details module where to find our local JSON files.
 # This ultimately controls how LANGUAGES are constructed.
 PROD_DETAILS_CACHE_NAME = 'product-details'
@@ -105,12 +101,10 @@ PROD_DETAILS_STORAGE = config('PROD_DETAILS_STORAGE',
 PROD_DETAILS_JSON_REPO_PATH = config('PROD_DETAILS_JSON_REPO_PATH',
                                      default=path('product_details_json'))
 PROD_DETAILS_JSON_REPO_URI = config('PROD_DETAILS_JSON_REPO_URI',
-                                    default='https://github.com/mozilla/product-details-json.git')
+                                    default='https://github.com/mozilla-releng/product-details.git')
+PROD_DETAILS_JSON_REPO_BRANCH = config('PROD_DETAILS_JSON_REPO_BRANCH', default='production')
 # path to updated p-d data for testing before loading into DB
-PROD_DETAILS_TEST_DIR = str(Path(PROD_DETAILS_JSON_REPO_PATH).joinpath('product-details'))
-# if the repo is cloned it will be most up-to-date
-if Path(PROD_DETAILS_TEST_DIR).is_dir():
-    PROD_DETAILS_DIR = PROD_DETAILS_TEST_DIR
+PROD_DETAILS_TEST_DIR = str(Path(PROD_DETAILS_JSON_REPO_PATH).joinpath('public', '1.0'))
 
 # Accepted locales
 PROD_LANGUAGES = ('ach', 'af', 'an', 'ar', 'ast', 'az', 'azz', 'be', 'bg',


### PR DESCRIPTION
Instead of scraping product-details.mozilla.org we can directly use the source files for that from a git repo managed by release engineering.

Fix #6998