### PR TITLE
Remove pathlib2

### DIFF
--- a/bedrock/contentcards/models.py
+++ b/bedrock/contentcards/models.py
@@ -6,7 +6,7 @@ from django.db import models, transaction
 
 from django_extensions.db.fields.json import JSONField
 from jinja2 import Markup
-from pathlib2 import Path
+from pathlib import Path
 
 from bedrock.base.urlresolvers import reverse
 

--- a/bedrock/contentcards/tests/test_models.py
+++ b/bedrock/contentcards/tests/test_models.py
@@ -2,7 +2,7 @@
 from django.test import override_settings
 
 from jinja2 import Markup
-from pathlib2 import Path
+from pathlib import Path
 
 from bedrock.contentcards import models
 from bedrock.mozorg.tests import TestCase

--- a/bedrock/mozorg/tests/test_commands.py
+++ b/bedrock/mozorg/tests/test_commands.py
@@ -5,7 +5,7 @@
 from django.test import override_settings
 
 from mock import patch, DEFAULT
-from pathlib2 import Path
+from pathlib import Path
 
 from bedrock.mozorg.tests import TestCase
 from bedrock.mozorg.management.commands import update_product_details_files

--- a/bedrock/pocketfeed/tests/test_models.py
+++ b/bedrock/pocketfeed/tests/test_models.py
@@ -6,7 +6,7 @@ from bedrock.pocketfeed.models import PocketArticle
 import json
 import pytest
 import responses
-from pathlib2 import Path
+from pathlib import Path
 
 
 TEST_DATA = Path(__file__).with_name('test_data')

--- a/bedrock/releasenotes/tests/test_base.py
+++ b/bedrock/releasenotes/tests/test_base.py
@@ -9,7 +9,7 @@ from django.test.utils import override_settings
 
 from bedrock.base.urlresolvers import reverse
 from mock import patch, Mock
-from pathlib2 import Path
+from pathlib import Path
 
 from bedrock.firefox.firefox_details import FirefoxDesktop
 from bedrock.mozorg.tests import TestCase
@@ -52,9 +52,7 @@ class TestReleaseViews(TestCase):
 
     @patch('bedrock.releasenotes.models.get_release')
     def test_get_release_or_404(self, get_release):
-        assert (
-            views.get_release_or_404('version', 'product') ==
-            get_release.return_value)
+        assert views.get_release_or_404('version', 'product') == get_release.return_value
         get_release.assert_called_with('product', 'version', None, False)
         get_release.return_value = None
         with self.assertRaises(Http404):
@@ -89,9 +87,7 @@ class TestReleaseViews(TestCase):
         get_release_or_404.assert_called_with('27.0', 'Firefox', True)
         assert self.last_ctx['version'] == '27.0'
         assert self.last_ctx['release'] == mock_release
-        assert (
-            self.mock_render.call_args[0][1] ==
-            mock_release_notes_template.return_value)
+        assert self.mock_render.call_args[0][1] == mock_release_notes_template.return_value
         mock_equiv_rel_url.assert_called_with(mock_release)
         mock_release_notes_template.assert_called_with(
             mock_release.channel, 'Firefox', 34)
@@ -120,39 +116,21 @@ class TestReleaseViews(TestCase):
         get_release_or_404.assert_called_with('27.0.1', 'Firefox')
         assert self.last_ctx['release'] == get_release_or_404.return_value
         assert self.last_ctx['version'] == '27.0.1'
-        assert (
-            self.mock_render.call_args[0][1] ==
-            'firefox/releases/system_requirements.html')
+        assert self.mock_render.call_args[0][1] == 'firefox/releases/system_requirements.html'
 
     def test_release_notes_template(self):
         """
         Should return correct template name based on channel
         and product
         """
-        assert (
-            views.release_notes_template('Nightly', 'Firefox') ==
-            'firefox/releases/nightly-notes.html')
-        assert (
-            views.release_notes_template('Aurora', 'Firefox') ==
-            'firefox/releases/aurora-notes.html')
-        assert (
-            views.release_notes_template('Aurora', 'Firefox', 35) ==
-            'firefox/releases/dev-browser-notes.html')
-        assert (
-            views.release_notes_template('Aurora', 'Firefox', 34) ==
-            'firefox/releases/aurora-notes.html')
-        assert (
-            views.release_notes_template('Beta', 'Firefox') ==
-            'firefox/releases/beta-notes.html')
-        assert (
-            views.release_notes_template('Release', 'Firefox') ==
-            'firefox/releases/release-notes.html')
-        assert (
-            views.release_notes_template('ESR', 'Firefox') ==
-            'firefox/releases/esr-notes.html')
-        assert (
-            views.release_notes_template('', '') ==
-            'firefox/releases/release-notes.html')
+        assert views.release_notes_template('Nightly', 'Firefox') == 'firefox/releases/nightly-notes.html'
+        assert views.release_notes_template('Aurora', 'Firefox') == 'firefox/releases/aurora-notes.html'
+        assert views.release_notes_template('Aurora', 'Firefox', 35) == 'firefox/releases/dev-browser-notes.html'
+        assert views.release_notes_template('Aurora', 'Firefox', 34) == 'firefox/releases/aurora-notes.html'
+        assert views.release_notes_template('Beta', 'Firefox') == 'firefox/releases/beta-notes.html'
+        assert views.release_notes_template('Release', 'Firefox') == 'firefox/releases/release-notes.html'
+        assert views.release_notes_template('ESR', 'Firefox') == 'firefox/releases/esr-notes.html'
+        assert views.release_notes_template('', '') == 'firefox/releases/release-notes.html'
 
     @override_settings(DEV=False)
     def test_non_public_release(self):
@@ -181,9 +159,8 @@ class TestReleaseViews(TestCase):
         Should return the url for the equivalent android release
         """
         release = Mock()
-        assert (
-            views.equivalent_release_url(release) ==
-            release.equivalent_android_release.return_value.get_absolute_url.return_value)
+        assert views.equivalent_release_url(release) == \
+            release.equivalent_android_release.return_value.get_absolute_url.return_value
 
     def test_desktop_equivalent_release_url(self):
         """
@@ -191,9 +168,8 @@ class TestReleaseViews(TestCase):
         """
         release = Mock()
         release.equivalent_android_release.return_value = None
-        assert (
-            views.equivalent_release_url(release) ==
-            release.equivalent_desktop_release.return_value.get_absolute_url.return_value)
+        assert views.equivalent_release_url(release) == \
+            release.equivalent_desktop_release.return_value.get_absolute_url.return_value
 
     def test_get_download_url_android(self):
         """
@@ -217,18 +193,14 @@ class TestReleaseViews(TestCase):
 
     def test_check_url(self):
         with self.activate('en-US'):
-            assert (
-                views.check_url('Firefox for Android', '45.0') ==
-                'https://support.mozilla.org/kb/will-firefox-work-my-mobile-device')
-            assert (
-                views.check_url('Firefox for Android', '46.0') ==
-                '/en-US/firefox/android/46.0/system-requirements/')
-            assert (
-                views.check_url('Firefox for iOS', '1.4') ==
-                '/en-US/firefox/ios/1.4/system-requirements/')
-            assert (
-                views.check_url('Firefox', '42.0') ==
-                '/en-US/firefox/42.0/system-requirements/')
+            assert views.check_url('Firefox for Android', '45.0') == \
+                'https://support.mozilla.org/kb/will-firefox-work-my-mobile-device'
+            assert views.check_url('Firefox for Android', '46.0') == \
+                '/en-US/firefox/android/46.0/system-requirements/'
+            assert views.check_url('Firefox for iOS', '1.4') == \
+                '/en-US/firefox/ios/1.4/system-requirements/'
+            assert views.check_url('Firefox', '42.0') == \
+                '/en-US/firefox/42.0/system-requirements/'
 
     @override_settings(DEV=False)
     def test_nightly_feed(self):
@@ -274,9 +246,7 @@ class TestReleaseNotesIndex(TestCase):
             assert releases[4][1]['minor'] == ['33.0.1', '33.0.2', '33.0.3']
             assert releases[6][0] == 31.0
             assert releases[6][1]['major'] == '31.0'
-            assert (
-                releases[6][1]['minor'] ==
-                ['31.1.0', '31.1.1', '31.2.0', '31.3.0', '31.4.0', '31.5.0'])
+            assert releases[6][1]['minor'] == ['31.1.0', '31.1.1', '31.2.0', '31.3.0', '31.4.0', '31.5.0']
 
 
 class TestNotesRedirects(TestCase):

--- a/bedrock/releasenotes/tests/test_models.py
+++ b/bedrock/releasenotes/tests/test_models.py
@@ -8,7 +8,7 @@ from django.core.cache import caches
 from django.test.utils import override_settings
 
 from mock import call, patch
-from pathlib2 import Path
+from pathlib import Path
 
 from bedrock.mozorg.tests import TestCase
 from bedrock.releasenotes import models

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -12,7 +12,7 @@ from django.utils.functional import lazy
 
 import dj_database_url
 from everett.manager import ListOf
-from pathlib2 import Path
+from pathlib import Path
 
 from bedrock.base.config_manager import config
 

--- a/bedrock/utils/git.py
+++ b/bedrock/utils/git.py
@@ -12,7 +12,7 @@ from django.conf import settings
 from django.utils.encoding import force_str
 
 import timeago
-from pathlib2 import Path
+from pathlib import Path
 
 from bedrock.utils.models import GitRepoState
 

--- a/bedrock/wordpress/tests/test_models.py
+++ b/bedrock/wordpress/tests/test_models.py
@@ -5,7 +5,7 @@ from bedrock.wordpress import models
 
 import pytest
 import responses
-from pathlib2 import Path
+from pathlib import Path
 
 
 TEST_DATA = Path(__file__).with_name('test_data')

--- a/bin/cron.py
+++ b/bin/cron.py
@@ -8,7 +8,7 @@ from time import time
 
 import babis
 from apscheduler.schedulers.blocking import BlockingScheduler
-from pathlib2 import Path
+from pathlib import Path
 
 
 # ROOT path of the project. A pathlib.Path object.

--- a/lib/l10n_utils/tests/test_dotlang.py
+++ b/lib/l10n_utils/tests/test_dotlang.py
@@ -13,7 +13,7 @@ from django.test.utils import override_settings
 
 from django_jinja.backend import Jinja2
 from mock import patch
-from pathlib2 import Path
+from pathlib import Path
 from pyquery import PyQuery as pq
 
 from bedrock.mozorg.tests import TestCase
@@ -194,13 +194,9 @@ class TestDotlang(TestCase):
         self.assertDictEqual(parsed, expected)
 
     def test_format_identifier_re(self):
-        assert (
-            FORMAT_IDENTIFIER_RE.findall('%s %s') ==
-            [('%s', ''), ('%s', '')])
+        assert FORMAT_IDENTIFIER_RE.findall('%s %s') == [('%s', ''), ('%s', '')]
 
-        assert (
-            FORMAT_IDENTIFIER_RE.findall('%(foo_bar)s %s') ==
-            [('%(foo_bar)s', 'foo_bar'), ('%s', '')])
+        assert FORMAT_IDENTIFIER_RE.findall('%(foo_bar)s %s') == [('%(foo_bar)s', 'foo_bar'), ('%s', '')]
 
     @override_settings(
         DEV=False,
@@ -216,9 +212,7 @@ class TestDotlang(TestCase):
             result = translate(expected, [path])
         assert expected == result
         assert len(mail.outbox) == 1
-        assert (
-            mail.outbox[0].subject ==
-            '[bedrock] locale/fr/%s.lang is corrupted' % path)
+        assert mail.outbox[0].subject == '[bedrock] locale/fr/%s.lang is corrupted' % path
         mail.outbox = []
 
     @override_settings(
@@ -394,8 +388,7 @@ class TestDotlang(TestCase):
         # have to call __str__ directly because the value is a Mock
         # object, and the `str()` function throws an exception.
         dude_says.__str__()
-        trans_patch.assert_called_with(dirty_string, ['donnie', 'walter'] +
-                                       settings.DOTLANG_FILES)
+        trans_patch.assert_called_with(dirty_string, ['donnie', 'walter'] + settings.DOTLANG_FILES)
 
     @patch('lib.l10n_utils.dotlang.translate')
     def test_gettext_works_without_extra_lang_files(self, trans_patch):

--- a/lib/l10n_utils/tests/test_template.py
+++ b/lib/l10n_utils/tests/test_template.py
@@ -8,7 +8,7 @@ from django.test import RequestFactory, override_settings
 from django_jinja.backend import Jinja2
 from jinja2.nodes import Block
 from mock import patch, ANY, Mock
-from pathlib2 import Path
+from pathlib import Path
 from pyquery import PyQuery as pq
 import pytest
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -155,9 +155,6 @@ contextlib2==0.5.4 \
 django_csp==3.5 \
     --hash=sha256:04600237701e6d6ff78ed7d41209ff923988148bf292c128f6b474b9befe444f \
     --hash=sha256:8b9997df89a7a936d7c397e051367f974aa1d1a97d0b32acb4300087b3bed071
-pathlib2==2.1.0 \
-    --hash=sha256:24e0b33e1333b55e73c9d1e9a8342417d519f7789a9d3b440f4acd00ea45157e \
-    --hash=sha256:deb3a960c1d55868dfbcac98432358b92ba89d95029cddd4040db1f27405055c
 querystringsafe_base64==1.1.1 \
     --hash=sha256:bad9187c0406456020ee354be7f51d2e0dfc262dadde0449cbdd1fd78d437eed
 funcsigs==1.0.2 \


### PR DESCRIPTION
pathlib2 is a backport of the Python 3.4+ standard library pathlib. This PR just removes the now superfluous library and switches all code to use the stdlib version. It also cleans up some flake8 errors in some of the files updated.