### PR TITLE
Transparency report 2018 h2

### DIFF
--- a/bedrock/mozorg/templates/mozorg/about/policy/transparency/includes/past-reports.html
+++ b/bedrock/mozorg/templates/mozorg/about/policy/transparency/includes/past-reports.html
@@ -9,6 +9,8 @@
     <nav>
       <h3>{{ _('Previous Reports') }}</h3>
       <ul>
+        <li><a href="{{ url('mozorg.about.policy.transparency.jul-dec-2018') }}">{{ _('July-December 2018') }}</a></li>
+        <li><a href="{{ url('mozorg.about.policy.transparency.jan-jun-2018') }}">{{ _('January-June 2018') }}</a></li>
         <li><a href="{{ url('mozorg.about.policy.transparency.jul-dec-2017') }}">{{ _('July-December 2017') }}</a></li>
         <li><a href="{{ url('mozorg.about.policy.transparency.jan-jun-2017') }}">{{ _('January-June 2017') }}</a></li>
         <li><a href="{{ url('mozorg.about.policy.transparency.jul-dec-2016') }}">{{ _('July-December 2016') }}</a></li>

--- a/bedrock/mozorg/templates/mozorg/about/policy/transparency/includes/reports-nav.html
+++ b/bedrock/mozorg/templates/mozorg/about/policy/transparency/includes/reports-nav.html
@@ -4,6 +4,6 @@
           <li><a class="button" href="{{ url('mozorg.about.policy.transparency.index') + '#definitions' }}">{{ _('Definitions') }}</a></li>
           {# This link should point to the latest report. Past reports are added to 'includes/past-reports.html' #}
           {# There are also links in the faq that need to be updated to point to the latest report. #}
-          <li><a class="button" href="{{ url('mozorg.about.policy.transparency.jan-jun-2018') }}">{{ _('January-June 2018 Report') }}</a></li>
+          <li><a class="button" href="{{ url('mozorg.about.policy.transparency.jan-jun-2019') }}">{{ _('January-June 2019 Report') }}</a></li>
         </ul>
       </nav>

--- a/bedrock/mozorg/templates/mozorg/about/policy/transparency/index.html
+++ b/bedrock/mozorg/templates/mozorg/about/policy/transparency/index.html
@@ -52,17 +52,11 @@
             <h3 data-accordion-role="tab">{{ _('What is the scope of the Transparency Report?') }}</h3>
             <div data-accordion-role="tabpanel">
               <p>
-                {# NOTE: Remember to update these links when publishing a new report. #}
-                {% set link_userdata=url('mozorg.about.policy.transparency.jan-jun-2018') + '#government-user-data' %}
-                {% set link_removal=url('mozorg.about.policy.transparency.jan-jun-2018') + '#government-content-removal' %}
-                {% set link_copytrade=url('mozorg.about.policy.transparency.jan-jun-2018') + '#copyright-trademark' %}
-                {% set link_supplement=url('mozorg.about.policy.transparency.jan-jun-2018') + '#supplement' %}
-
                 {% trans %}
-                  This report covers the Mozilla Foundation, Mozilla Corporation, and Pocket (from 2018). We report on <a href="{{ link_userdata }}">Government Demands for User Data</a>, <a href="{{ link_removal }}">Government Requests for Content Removal</a>, and <a href="{{ link_copytrade }}">Copyright and Trademark Requests</a>. We also include a <a href="{{ link_supplement }}">Supplement</a>, which provides additional information.
+                   The purpose is to provide public insight into the types of government demands we receive for our user data or to remove content; and requests from individuals or companies to remove content based on copyright or trademark claims.  Each report also includes a supplement describing our efforts to reform laws on privacy, surveillance, cybersecurity, and intellectual property for a healthier internet.
                 {% endtrans %}
 
-                {{ _('With each additional report that we publish, we’ll continue to re­evaluate how we can be more transparent.') }}
+                {{ _('With each additional report that we publish, we’ll continue to re­evaluate how we can be more transparent. To this end, starting in H2 2018, we started reporting on the number of requests we receive from individuals inquiring about their personal data.') }}
               </p>
             </div>
           </section>
@@ -177,8 +171,18 @@
               </p>
             </div>
           </section>
-        </div>
 
+          <section>
+            <h3 data-accordion-role="tab">{{ _('What do you mean by Personal Data Requests?') }}</h3>
+            <div data-accordion-role="tabpanel">
+              <p>
+                {{ _('We believe that everyone should have control over their personal data, understand how it’s obtained and used, and be able to access, modify, or delete it.  We extend these principles to all of our users regardless of when they submit a <a href="%s">Personal Data Request</a>, where they are located, or whether a data protection law (such as the GDPR) grants them express privacy rights. ')|format('#dfn-personal-data-request') }}
+                
+              </p>
+            </div>
+          </section>
+
+        </div>
       </div>
     </section>
 
@@ -229,6 +233,9 @@
 
           <dt id="dfn-pen-register-order">{{ _('Pen Register Order') }}</dt>
           <dd><p>{{ _('A Pen Register and Trap and Trace Order is a type of U.S. <a href="%s">Court Order</a> compelling a company to disclose data about a user’s real­time communications (excluding the content of the communications themselves) to law enforcement on an ongoing basis, usually for a period of 60 days.')|format('#dfn-court-order') }}</p></dd>
+
+          <dt id="dfn-personal-data-request">{{ _('Personal Data Request') }}</dt>
+          <dd><p>{{ _('A user-generated request about personal data such as how to delete, port, modify or access it.  For the purpose of our Transparency  Report, we count the number of requests received by email, post, or to our portal for Data Subject Access Requests.  We don’t count (or have metrics for) the number of such requests that our users process themselves through in-product features.') }}</p></dd>
 
           <dt id="dfn-search-warrant">{{ _('Search Warrant') }}</dt>
           <dd><p>{{ _('A document authorizing law enforcement to obtain user data issued by a neutral and detached magistrate on the basis of finding that “probable cause” exists to believe that the items being sought will be found in the place to be searched.') }}</p></dd>

--- a/bedrock/mozorg/templates/mozorg/about/policy/transparency/jan-jun-2019.html
+++ b/bedrock/mozorg/templates/mozorg/about/policy/transparency/jan-jun-2019.html
@@ -75,7 +75,7 @@
                   <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-natl-security-request' }}">{{ _('National Security Requests') }}</a> <sup><a href="#footnote-1">1</a></sup>
                 </th>
                 <td>0-249</td>
-                <td>{{ _('0') }}</td>
+                <td>{{ _('0-249') }}</td>
               </tr>
             </tbody>
           </table>
@@ -185,7 +185,7 @@
             </tbody>
           </table>
           <h3>{{ _('Personal Data Requests') }}</h3>
-          <p>{{ _('In the Reporting Period, we received 439 requests.') }}</p>
+          <p>{{ _('In the Reporting Period, we received 757 requests.') }}</p>
 
           <table class="data-table">
             <thread>

--- a/bedrock/mozorg/templates/mozorg/about/policy/transparency/jan-jun-2019.html
+++ b/bedrock/mozorg/templates/mozorg/about/policy/transparency/jan-jun-2019.html
@@ -1,0 +1,284 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+    # License, v. 2.0. If a copy of the MPL was not distributed with this
+    # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+  
+    {% extends "mozorg/about/policy/transparency/report-base.html" %}
+  
+    {% block page_title %}{{ _('Transparency Report - January-June, 2019') }}{% endblock %}
+  
+    {% block report_title %}
+      <h1>{{ _('Transparency Report') }} <span>{{ _('Reporting Period: January 1, 2019 to June 30, 2019') }}</span></h1>
+    {% endblock %}
+  
+    {% block report_body %}
+      <section class="section" id="government-user-data">
+        <h2 class="section-title" data-accordion-role="tab">{{ _('Government Demands for User Data') }}</h2>
+  
+        <div class="content" data-accordion-role="tabpanel">
+          <p>
+            {{ _('In the Reporting Period, Mozilla received the following.') }}
+          </p>
+  
+          <table class="data-table">
+            <thead>
+              <tr>
+                <th scope="col">{{ _('Legal Processes') }}</th>
+                <th scope="col">{{ _('Received') }}</th>
+                <th scope="col">{{ _('Data Produced') }}</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <th scope="row">
+                  <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-search-warrant' }}">{{ _('Search Warrants') }}</a>
+                </th>
+                <td>0</td>
+                <td>{{ _('0') }}</td>
+              </tr>
+              <tr>
+                <th scope="row">
+                  <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-subpoena' }}">{{ _('Subpoenas') }}</a>
+                </th>
+                <td>0</td>
+                <td>{{ _('0') }}</td>
+              </tr>
+              <tr>
+                <th scope="row">
+                  <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-court-order' }}">{{ _('Court Orders') }}</a>
+                </th>
+                <td>0</td>
+                <td>{{ _('0') }}</td>
+              </tr>
+              <tr>
+                <th scope="row">
+                  <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-wiretap-order' }}">{{ _('Wiretap Orders') }}</a>
+                </th>
+                <td>0</td>
+                <td>{{ _('0') }}</td>
+              </tr>
+              <tr>
+                <th scope="row">
+                  <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-pen-register-order' }}">{{ _('Pen Register Orders') }}</a>
+                </th>
+                <td>0</td>
+                <td>{{ _('0') }}</td>
+              </tr>
+              <tr>
+                <th scope="row">
+                  <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-emergency-request' }}">{{ _('Emergency Requests') }}</a>
+                </th>
+                <td>0</td>
+                <td>{{ _('0') }}</td>
+              </tr>
+              <tr>
+                <th scope="row">
+                  <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-natl-security-request' }}">{{ _('National Security Requests') }}</a> <sup><a href="#footnote-1">1</a></sup>
+                </th>
+                <td>0-249</td>
+                <td>{{ _('0') }}</td>
+              </tr>
+            </tbody>
+          </table>
+  
+          <aside class="footnotes">
+            <section id="footnote-1">
+              <p>{{ _('1. We seek to be as transparent as possible about the User Data Requests that we receive from government authorities. The reporting band listed is one of four reporting bands permitted under U.S. law for National Security Requests.') }}</p>
+            </section>
+          </aside>
+        </div>
+      </section>
+  
+      <section class="section" id="government-content-removal">
+        <h2 class="section-title" data-accordion-role="tab">{{ _('Government Demands for Content Removal') }}</h2>
+  
+        <div class="content" data-accordion-role="tabpanel">
+          <p>{{ _('In the Reporting Period, Mozilla did not receive any government requests for content removal from our services.') }}</p>
+  
+          <table class="data-table">
+            <thead>
+              <tr>
+                <th scope="col">{{ _('Requesting Country') }}</th>
+                <th scope="col">{{ _('Requests Received') }}</th>
+                <th scope="col">{{ _('Data Produced') }}</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <th scope="row">{{ _('N/A') }}</th>
+                <td>0</td>
+                <td>{{ _('N/A') }}</td>
+              </tr>
+            </tbody>
+          </table>
+  
+        </div>
+      </section>
+  
+      <section class="section" id="copyright-trademark">
+        <h2 class="section-title" data-accordion-role="tab">{{ _('Copyright and Trademark Requests') }}</h2>
+  
+        <div class="content" data-accordion-role="tabpanel">
+          <h3>{{ _('Copyright') }}</h3>
+          <p>{{ _('In the Reporting Period, we received 8 Copyright Takedown Notices and 0 Counter Notices.') }}</p>
+  
+          <table class="data-table">
+            <thead>
+              <tr>
+                <th scope="col">{{ _('Mozilla Service') }}</th>
+                <th scope="col">
+                  <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-takedown-notice' }}">{{ _('Takedown Notices') }}</a>
+                </th>
+                <th scope="col">
+                  <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-counter-notice' }}">{{ _('Counter Notices') }}</a>
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <th scope="row">{{ _('Firefox Add-ons') }}</th>
+                <td>7</td>
+                <td>0</td>
+              </tr>
+              <tr>
+                <th scope="row">{{ _('Pocket') }}</th>
+                <td>0</td>
+                <td>0</td>
+              </tr>
+              <tr>
+                <th scope="row">{{ _('Other Services') }}</th>
+                <td>1</td>
+                <td>0</td>
+              </tr>
+            </tbody>
+          </table>
+  
+          <h3>{{ _('Trademark') }}</h3>
+          <p>{{ _('In the Reporting Period, we received 4 Trademark Takedown Notices and 0 Counter Notices.') }}</p>
+  
+          <table class="data-table">
+            <thead>
+              <tr>
+                <th scope="col">{{ _('Mozilla Service') }}</th>
+                <th scope="col">
+                  <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-takedown-notice' }}">{{ _('Takedown Notices') }}</a>
+                </th>
+                <th scope="col">
+                  <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-counter-notice' }}">{{ _('Counter Notices') }}</a>
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <th scope="row">{{ _('Firefox Add-ons') }}</th>
+                <td>4</td>
+                <td>0</td>
+              </tr>
+              <tr>
+                <th scope="row">{{ _('Pocket') }}</th>
+                <td>0</td>
+                <td>0</td>
+              </tr>
+              <tr>
+                <th scope="row">{{ _('Other Services') }}</th>
+                <td>0</td>
+                <td>0</td>
+            </tbody>
+          </table>
+          <h3>{{ _('Personal Data Requests') }}</h3>
+          <p>{{ _('In the Reporting Period, we received 439 requests.') }}</p>
+
+          <table class="data-table">
+            <thread>
+              <th scope="col">{{ _('Service') }}</th>
+              <th scope="col">{{ _('Received') }}</th>
+            </thread>
+            <tbody>
+              <tr>
+                <th scope="row">{{ _('Mozilla') }}</th>
+                <td>427 <sup><a href="#notation">*</a></sup></td>
+              </tr>
+              <tr>
+                <th scope="row">{{ _('Pocket') }}</th>
+                <td>330</td>
+              </tr>
+            </tbody>
+          </table>
+          <aside class="footnotes">
+            <section id="notation">
+              <p>
+                {% trans privacy=url('privacy') %}
+                * During the Reporting Period we surfaced additional methods to contact us in our <a href="{{ privacy }}">Mozilla Privacy Policy</a>. This higher level visibility likely caused the increase in Personal Data Requests that we received compared to 2018 H2.
+                {% endtrans %}
+              </p>
+            </section>
+          </aside>
+        </div>
+      </section>
+  
+      <section class="section" id="supplement">
+        <h2 class="section-title" data-accordion-role="tab">{{ _('Supplement') }}</h2>
+  
+        <div class="content" data-accordion-role="tabpanel">
+          <h3>{{ _('Legislative Reform') }}</h3>
+          <p>
+            {% trans consumer='https://blog.mozilla.org/netpolicy/files/2019/04/Mozilla-U.S.-Consumer-Privacy-Bill-Blueprint-4.4.19-2.pdf',
+                     letter='https://blog.mozilla.org/netpolicy/files/2019/01/Mozilla-letter-re-FB-claims-of-data-partner.pdf' %}
+              During this reporting period, Mozilla continued our fight for greater data security and privacy across the globe. In the US, we released our <a href="{{ consumer }}">US Consumer Privacy Bill Blueprint</a> and we sent <a href="{{ letter }}">a letter to the US Congress</a> about Facebook data sharing. In the wake of the US Supreme Court’s Carpenter ruling, we released two studies for Firefox users on privacy expectations of location information shared online.
+            {% endtrans %}
+          </p>
+          <p>
+            {% trans kenyan='https://ca.go.ke/wp-content/uploads/2018/11/Mozilla-Submission-of-Comments-Kenya-Privacy-and-Data-Protection-Bill-2018.pdf',
+                     data='https://www.tespok.co.ke/?p=13513' %}
+              In Kenya, we advocated for a strong data protection law, and spoke out against <a href="{{ kenyan }}">Kenyan legislation for a new ID system</a> that would allow the government to collect the DNA, biometrics, and other sensitive data of everyone in Kenya. We also held a series of <a href="{{ data }}">Lean Data Practices workshops</a> in Nairobi with government, business, and civil society stakeholders. 
+            {% endtrans %}
+          </p>
+          <p>
+            {% trans cybersecurity='https://blog.mozilla.org/netpolicy/2017/10/03/vulnerability-disclosure-should-be-in-new-eu-cybersecurity-strategy/',
+                     seehere='https://blog.mozilla.org/netpolicy/files/2019/06/Sub-62-TOLA-Act.pdf' %}
+              The the <a href="{{ cybersecurity }}">EU Cybersecurity Act</a> included an important provision that we advocated for to grant ENISA (the EU Cybersecurity Agency) a mandate to work with Member States to stand up government vulnerability disclosure programs. We also continued to speak out against legislation in Australia that dangerously undermines encryption (see <a href="{{ seehere }}">here</a>); although there is much more progress needed, our advocacy did lead to a limited government vulnerability disclosure program.   
+            {% endtrans %} 
+          </p>
+          <p>
+            {% trans content='https://blog.mozilla.org/netpolicy/2018/11/21/the-eu-terrorist-content-regulation-a-threat-to-the-ecosystem-and-our-users-rights/',
+                     comments='https://blog.mozilla.org/netpolicy/2019/04/10/uk_online-harms/',
+                     liability='https://blog.mozilla.org/netpolicy/2019/01/02/india-attempts-to-turn-online-companies-into-censors-and-undermines-security-mozilla-responds/' %}
+              We continued to pushback on the <a href="{{ content }}">EU Terrorist Content Regulation</a>, and filed <a href="{{ comments }}">comments</a> against the UK government’s overreaching white paper on Online Harms, which had worrying effects on individual liberties and the competitive ecosystem. And we spoke out strongly against India’s proposed <a href="{{ liability }}">intermediary liability rules</a>, which would force all online intermediaries to censor and surveil their users and threatened encryption as well.   
+            {% endtrans %} 
+          </p>
+          
+          <h3>{{ _('Threat Indicators &amp; Data Disclosures') }}</h3>
+          <table class="data-table">
+            <thead>
+              <tr>
+                <th scope="col">{{ _('Type of Disclosure') }}</th>
+                <th scope="col">{{ _('Number of Disclosures') }}</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <th scope="row"><a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-threat-indicator' }}">{{ _('Cybersecurity Threat Indicator') }}</a></th>
+                <td>0</td>
+              </tr>
+              <tr>
+                <th scope="row">{{ _('Other <a href="%s">Specific User</a> Data Disclosure')|format(url('mozorg.about.policy.transparency.index') + '#dfn-specific-user') }}</th>
+                <td>0</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+    {% endblock %}
+  
+    {% block report_nav %}
+      <aside class="section nav-block">
+        <nav class="content nav-report two-up">
+          <ul>
+            <li><a class="button" href="{{ url('mozorg.about.policy.transparency.index') + '#faq' }}">{{ _('FAQ') }}</a></li>
+            <li><a class="button" href="{{ url('mozorg.about.policy.transparency.index') + '#definitions' }}">{{ _('Definitions') }}</a></li>
+          </ul>
+        </nav>
+  
+        {% include 'mozorg/about/policy/transparency/includes/past-reports.html' %}
+      </aside>
+    {% endblock %}
+  

--- a/bedrock/mozorg/templates/mozorg/about/policy/transparency/jul-dec-2018.html
+++ b/bedrock/mozorg/templates/mozorg/about/policy/transparency/jul-dec-2018.html
@@ -40,13 +40,13 @@
                   <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-subpoena' }}">{{ _('Subpoenas') }}</a>
                 </th>
                 <td>1<sup><a href="#footnote-1">1</a></sup></td>
-                <td>{{ _('No') }}</td>
+                <td>{{ _('0') }}</td>
               </tr>
               <tr>
                 <th scope="row">
                   <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-court-order' }}">{{ _('Court Orders') }}</a>
                 </th>
-                <td>0<sup><a href="#footnote-2">2</a></sup></td>
+                <td>0</td>
                 <td>{{ _('0') }}</td>
               </tr>
               <tr>
@@ -72,7 +72,7 @@
               </tr>
               <tr>
                 <th scope="row">
-                  <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-natl-security-request' }}">{{ _('National Security Requests') }}</a> <sup><a href="#footnote-3">3</a></sup>
+                  <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-natl-security-request' }}">{{ _('National Security Requests') }}</a> <sup><a href="#footnote-2">2</a></sup>
                 </th>
                 <td>0</td>
                 <td>{{ _('0') }}</td>
@@ -82,13 +82,10 @@
   
           <aside class="footnotes">
             <section id="footnote-1">
-              <p>{{ _('1. Issued to Mozilla Corporation in connection with Pocket.') }}</p>
+              <p>{{ _('1. Issued to Mozilla Corporation.') }}</p>
             </section>
             <section id="footnote-2">
-              <p>{{ _('2. Issued to Mozilla Corporation.') }}</p>
-            </section>
-            <section id="footnote-3">
-              <p>{{ _('3. None of the Mozilla Foundation, Mozilla Corporation or Pocket have ever received a National Security Request.') }}</p>
+              <p>{{ _('2. None of the Mozilla Foundation, Mozilla Corporation or Pocket have ever received a National Security Request.') }}</p>
             </section>
           </aside>
         </div>

--- a/bedrock/mozorg/templates/mozorg/about/policy/transparency/jul-dec-2018.html
+++ b/bedrock/mozorg/templates/mozorg/about/policy/transparency/jul-dec-2018.html
@@ -1,0 +1,279 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+    # License, v. 2.0. If a copy of the MPL was not distributed with this
+    # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+  
+    {% extends "mozorg/about/policy/transparency/report-base.html" %}
+  
+    {% block page_title %}{{ _('Transparency Report - July-December, 2018') }}{% endblock %}
+  
+    {% block report_title %}
+      <h1>{{ _('Transparency Report') }} <span>{{ _('Reporting Period: July 1, 2018 to December 31, 2018') }}</span></h1>
+    {% endblock %}
+  
+    {% block report_body %}
+      <section class="section" id="government-user-data">
+        <h2 class="section-title" data-accordion-role="tab">{{ _('Government Demands for User Data') }}</h2>
+  
+        <div class="content" data-accordion-role="tabpanel">
+          <p>
+            {{ _('In the Reporting Period, Mozilla received one subpoena for user data.') }}
+          </p>
+  
+          <table class="data-table">
+            <thead>
+              <tr>
+                <th scope="col">{{ _('Legal Processes') }}</th>
+                <th scope="col">{{ _('Received') }}</th>
+                <th scope="col">{{ _('Data Produced') }}</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <th scope="row">
+                  <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-search-warrant' }}">{{ _('Search Warrants') }}</a>
+                </th>
+                <td>0</td>
+                <td>{{ _('0') }}</td>
+              </tr>
+              <tr>
+                <th scope="row">
+                  <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-subpoena' }}">{{ _('Subpoenas') }}</a>
+                </th>
+                <td>1<sup><a href="#footnote-1">1</a></sup></td>
+                <td>{{ _('No') }}</td>
+              </tr>
+              <tr>
+                <th scope="row">
+                  <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-court-order' }}">{{ _('Court Orders') }}</a>
+                </th>
+                <td>0<sup><a href="#footnote-2">2</a></sup></td>
+                <td>{{ _('0') }}</td>
+              </tr>
+              <tr>
+                <th scope="row">
+                  <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-wiretap-order' }}">{{ _('Wiretap Orders') }}</a>
+                </th>
+                <td>0</td>
+                <td>{{ _('0') }}</td>
+              </tr>
+              <tr>
+                <th scope="row">
+                  <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-pen-register-order' }}">{{ _('Pen Register Orders') }}</a>
+                </th>
+                <td>0</td>
+                <td>{{ _('0') }}</td>
+              </tr>
+              <tr>
+                <th scope="row">
+                  <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-emergency-request' }}">{{ _('Emergency Requests') }}</a>
+                </th>
+                <td>0</td>
+                <td>{{ _('0') }}</td>
+              </tr>
+              <tr>
+                <th scope="row">
+                  <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-natl-security-request' }}">{{ _('National Security Requests') }}</a> <sup><a href="#footnote-3">3</a></sup>
+                </th>
+                <td>0</td>
+                <td>{{ _('0') }}</td>
+              </tr>
+            </tbody>
+          </table>
+  
+          <aside class="footnotes">
+            <section id="footnote-1">
+              <p>{{ _('1. Issued to Mozilla Corporation in connection with Pocket.') }}</p>
+            </section>
+            <section id="footnote-2">
+              <p>{{ _('2. Issued to Mozilla Corporation.') }}</p>
+            </section>
+            <section id="footnote-3">
+              <p>{{ _('3. None of the Mozilla Foundation, Mozilla Corporation or Pocket have ever received a National Security Request.') }}</p>
+            </section>
+          </aside>
+        </div>
+      </section>
+  
+      <section class="section" id="government-content-removal">
+        <h2 class="section-title" data-accordion-role="tab">{{ _('Government Demands for Content Removal') }}</h2>
+  
+        <div class="content" data-accordion-role="tabpanel">
+          <p>{{ _('In the Reporting Period, Mozilla did not receive any government requests for content removal from our services.') }}</p>
+  
+          <table class="data-table">
+            <thead>
+              <tr>
+                <th scope="col">{{ _('Requesting Country') }}</th>
+                <th scope="col">{{ _('Requests Received') }}</th>
+                <th scope="col">{{ _('Data Produced') }}</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <th scope="row">{{ _('N/A') }}</th>
+                <td>0</td>
+                <td>{{ _('0') }}</td>
+              </tr>
+            </tbody>
+          </table>
+  
+        </div>
+      </section>
+  
+      <section class="section" id="copyright-trademark">
+        <h2 class="section-title" data-accordion-role="tab">{{ _('Copyright and Trademark Requests') }}</h2>
+  
+        <div class="content" data-accordion-role="tabpanel">
+          <h3>{{ _('Copyright') }}</h3>
+          <p>{{ _('In the Reporting Period, we received 14 Copyright Takedown Notices and 0 Counter Notices.') }}</p>
+  
+          <table class="data-table">
+            <thead>
+              <tr>
+                <th scope="col">{{ _('Mozilla Service') }}</th>
+                <th scope="col">
+                  <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-takedown-notice' }}">{{ _('Takedown Notices') }}</a>
+                </th>
+                <th scope="col">
+                  <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-counter-notice' }}">{{ _('Counter Notices') }}</a>
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <th scope="row">{{ _('Firefox Add-ons') }}</th>
+                <td>14</td>
+                <td>0</td>
+              </tr>
+              <tr>
+                <th scope="row">{{ _('Pocket') }}</th>
+                <td>0</td>
+                <td>0</td>
+              </tr>
+              <tr>
+                <th scope="row">{{ _('Other Services') }}</th>
+                <td>0</td>
+                <td>0</td>
+              </tr>
+            </tbody>
+          </table>
+  
+          <h3>{{ _('Trademark') }}</h3>
+          <p>{{ _('In the Reporting Period, we received 20 Trademark Takedown Notices and 0 Counter Notices.') }}</p>
+  
+          <table class="data-table">
+            <thead>
+              <tr>
+                <th scope="col">{{ _('Mozilla Service') }}</th>
+                <th scope="col">
+                  <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-takedown-notice' }}">{{ _('Takedown Notices') }}</a>
+                </th>
+                <th scope="col">
+                  <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-counter-notice' }}">{{ _('Counter Notices') }}</a>
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <th scope="row">{{ _('Firefox Add-ons') }}</th>
+                <td>20</td>
+                <td>0</td>
+              </tr>
+              <tr>
+                <th scope="row">{{ _('Pocket') }}</th>
+                <td>0</td>
+                <td>0</td>
+              </tr>
+              <tr>
+                <th scope="row">{{ _('Other Services') }}</th>
+                <td>0</td>
+                <td>0</td>
+            </tbody>
+          </table>
+          <h3>{{ _('Personal Data Requests') }}</h3>
+          <p>{{ _('In the Reporting Period, we received 439 requests.') }}</p>
+
+          <table class="data-table">
+            <thread>
+              <th scope="col">{{ _('Service') }}</th>
+              <th scope="col">{{ _('Received') }}</th>
+            </thread>
+            <tbody>
+              <tr>
+                <th scope="row">{{ _('Mozilla') }}</th>
+                <td>33</td>
+              </tr>
+              <tr>
+                <th scope="row">{{ _('Pocket') }}</th>
+                <td>406</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+  
+      <section class="section" id="supplement">
+        <h2 class="section-title" data-accordion-role="tab">{{ _('Supplement') }}</h2>
+  
+        <div class="content" data-accordion-role="tabpanel">
+          <h3>{{ _('Legislative Reform') }}</h3>
+          <p>
+            {% trans india='https://blog.mozilla.org/netpolicy/2018/07/27/indian-draft-data-protection-bill/',
+                     kenya='https://ca.go.ke/wp-content/uploads/2018/11/Mozilla-Submission-of-Comments-Kenya-Privacy-and-Data-Protection-Bill-2018.pdf',
+                     brazil='https://blog.mozilla.org/netpolicy/2018/07/02/brazilian-data-protection-bill/',
+                     american='https://blog.mozilla.org/netpolicy/2018/11/20/mozilla-files-comments-on-ntias-proposed-american-privacy-framework/',
+                     workshop='https://blog.mozilla.org/netpolicy/2018/12/21/privacy-in-practice-mozilla-talks-lean-data-in-india/',
+                     panel='https://blog.mozilla.org/netpolicy/2018/09/19/lessons-from-carpenter-mozilla-panel-discussion-at-icdppc/' %}
+              During the Reporting Period, we continued fighting for strong data protection rules around the world, including work on the first data protection laws in <a href="{{ india }}">India</a>, <a href="{{ kenya }}">Kenya</a>, and <a href="{{ brazil }}">Brazil</a>, pushing for the swift adoption of the EU’s ePrivacy Regulation, and filing comment on the National Telecommunications and Information Administration’s proposed <a href="{{ american }}">American Privacy Framework</a> in the US.  We also held a <a href="{{ workshop }}">workshop in Delhi</a> with companies large and small on our Lean Data Practices framework, and held a <a href="{{ panel }}">panel</a> in Brussels on the recent US Supreme Court Carpenter decision, which extended warrant protections to cell site location information.
+            {% endtrans %}
+          </p>
+          <p>
+            {% trans government='https://blog.mozilla.org/netpolicy/2018/07/04/a-step-forward-for-government-vulnerability-disclosure-in-europe/',
+                     commented='https://blog.mozilla.org/netpolicy/2018/08/22/europe_lawful_access/',
+                     action='https://blog.mozilla.org/netpolicy/files/2019/06/Sub46.pdf' %}
+              Mozilla continued advocating for EU Member States to enact <a href="{{ government }}">government vulnerability disclosure programs in the EU Cybersecurity Act</a>, and <a href="{{ commented }}">commented</a> on the EU proposals around cross-border data access for law enforcement. In Australia, we <a href="{{ action }}">took action</a> on legislation that would give the government new powers to undermine encryption. 
+            {% endtrans %}
+          </p>
+          <p>
+            {% trans copyright='https://blog.mozilla.org/netpolicy/2018/09/07/eu-copyright-reform-the-facts/',
+                     content='https://blog.mozilla.org/netpolicy/2018/11/21/the-eu-terrorist-content-regulation-a-threat-to-the-ecosystem-and-our-users-rights/' %}
+              We also <a href="{{ copyright }}">engaged heavily on the EU Copyright Directive</a>, to minimise the damage to individuals’ rights and the open internet arising from the directive’s upload filters, and spoke out against the <a href="{{ content }}">EU’s Terrorist Content Regulation</a>.  
+            {% endtrans %} 
+          </p>
+          
+          <h3>{{ _('Threat Indicators &amp; Data Disclosures') }}</h3>
+          <table class="data-table">
+            <thead>
+              <tr>
+                <th scope="col">{{ _('Type of Disclosure') }}</th>
+                <th scope="col">{{ _('Number of Disclosures') }}</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <th scope="row"><a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-threat-indicator' }}">{{ _('Cybersecurity Threat Indicator') }}</a></th>
+                <td>0</td>
+              </tr>
+              <tr>
+                <th scope="row">{{ _('Other <a href="%s">Specific User</a> Data Disclosure')|format(url('mozorg.about.policy.transparency.index') + '#dfn-specific-user') }}</th>
+                <td>0</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+    {% endblock %}
+  
+    {% block report_nav %}
+      <aside class="section nav-block">
+        <nav class="content nav-report two-up">
+          <ul>
+            <li><a class="button" href="{{ url('mozorg.about.policy.transparency.index') + '#faq' }}">{{ _('FAQ') }}</a></li>
+            <li><a class="button" href="{{ url('mozorg.about.policy.transparency.index') + '#definitions' }}">{{ _('Definitions') }}</a></li>
+          </ul>
+        </nav>
+  
+        {% include 'mozorg/about/policy/transparency/includes/past-reports.html' %}
+      </aside>
+    {% endblock %}
+  

--- a/bedrock/mozorg/urls.py
+++ b/bedrock/mozorg/urls.py
@@ -79,6 +79,10 @@ urlpatterns = (
          'mozorg/about/policy/transparency/jul-dec-2017.html'),
     page('about/policy/transparency/jan-jun-2018',
          'mozorg/about/policy/transparency/jan-jun-2018.html'),
+    page('about/policy/transparency/jul-dec-2018',
+         'mozorg/about/policy/transparency/jul-dec-2018.html'),
+    page('about/policy/transparency/jan-jun-2019',
+         'mozorg/about/policy/transparency/jan-jun-2019.html'),
 
     page('contact', 'mozorg/contact/contact-landing.html'),
     page('contact/spaces', 'mozorg/contact/spaces/spaces-landing.html'),

--- a/media/css/mozorg/about-transparency.scss
+++ b/media/css/mozorg/about-transparency.scss
@@ -169,7 +169,7 @@
         padding: $gutter-width;
 
         li {
-            display: inline;
+            display: inline-block;
             margin: 0 10px .5em;
             position: relative;
 


### PR DESCRIPTION
## Description
Adds Transparency reports for H2/2018 and H1/2019 along with requested changes to the main Transparency page

about/policy/transparency/jul-dec-2018/
about/policy/transparency/jan-jun-2019/
## Issue / Bugzilla link
https://github.com/mozilla/bedrock/issues/7036
https://github.com/mozilla/bedrock/issues/7356
## Testing
All copy was provided, but we should keep an eye out for paste errors.