### PR TITLE
[fix #7544] Fix legacy dev/aurora firstrun template

### DIFF
--- a/bedrock/firefox/tests/test_base.py
+++ b/bedrock/firefox/tests/test_base.py
@@ -580,7 +580,7 @@ class TestFirstRun(TestCase):
         req = self.rf.get('/en-US/firefox/firstrun/')
         self.view(req, version='56.0a2')
         template = render_mock.call_args[0][1]
-        assert template == ['firefox/firstrun/firstrun-quantum.html']
+        assert template == ['firefox/firstrun/firstrun.html']
 
     @override_settings(DEV=True)
     def test_fxdev_firstrun_57_0(self, render_mock):

--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -527,7 +527,7 @@ class FirstrunView(l10n_utils.LangFilesMixin, TemplateView):
             if show_57_dev_firstrun(version):
                 template = 'firefox/developer/firstrun.html'
             else:
-                template = 'firefox/firstrun/firstrun-quantum.html'
+                template = 'firefox/firstrun/firstrun.html'
         else:
             template = 'firefox/firstrun/firstrun.html'
 


### PR DESCRIPTION
## Description
`firstrun-quantum.html` was replaced/renamed in a64a4be72b0e41748c050ff1d0afdca8b95b8aa3 but we missed this reference to the old template.

## Issue / Bugzilla link
#7544 

## Testing
This template should only appear for Firefox alphas prior to v 57.0
