### PR TITLE
Add monitor_button params and retrieve deviceId from metrics-flow requests. (Fixes #7531, #7533, #7532)

### DIFF
--- a/bedrock/base/templates/macros.html
+++ b/bedrock/base/templates/macros.html
@@ -300,9 +300,10 @@
     <input type="hidden" name="service" value="{{ service }}" />
     <input type="hidden" name="entrypoint" value="{{ entrypoint }}" id="fxa-email-form-entrypoint" />
     <input type="hidden" name="form_type" value="email" />
-    {# flow_id and flow_begin_time will be populated via JS on page load #}
+    {# device_id, flow_id and flow_begin_time will be populated via JS on page load #}
     <input type="hidden" name="flow_id" value="" />
     <input type="hidden" name="flow_begin_time" value="" />
+    <input type="hidden" name="device_id" value="" />
 
     {# utm_source is required #}
     <input type="hidden" name="utm_source" value={{ utm_source }} id="fxa-email-form-utm-source" />
@@ -354,12 +355,12 @@
         {% endtrans %}
       </p>
 
-      <button 
-        type="submit" 
-        class="{{ button_class }}" 
-        id="fxa-email-form-submit" 
-        data-cta-type="FxA-Sync" 
-        data-cta-text="Register" 
+      <button
+        type="submit"
+        class="{{ button_class }}"
+        id="fxa-email-form-submit"
+        data-cta-type="FxA-Sync"
+        data-cta-text="Register"
         data-cta-position="Primary"
       >
       {% if button_text %}

--- a/bedrock/firefox/templates/firefox/concerts.html
+++ b/bedrock/firefox/templates/firefox/concerts.html
@@ -95,6 +95,7 @@
                   <input type="hidden" name="state" id="state" value="">
                   <input type="hidden" name="flow_id" id="flow_id" value="">
                   <input type="hidden" name="flow_begin_time" id="flow_begin_time" value="">
+                  <input type="hidden" name="device_id" id="device_id" value="">
                   <input type="hidden" name="action" value="email">
                   <input type="hidden" name="utm_source" id="utm_source" value="mozilla.org">
                   <input type="hidden" name="utm_medium" id="utm_medium" value="concerts-landing-page">

--- a/media/js/base/mozilla-fxa-form-init.js
+++ b/media/js/base/mozilla-fxa-form-init.js
@@ -1,0 +1,9 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+(function() {
+    'use strict';
+
+    Mozilla.FxaForm.init();
+})();

--- a/media/js/base/mozilla-fxa-form.js
+++ b/media/js/base/mozilla-fxa-form.js
@@ -64,6 +64,7 @@ Mozilla.FxaForm = (function(Mozilla) {
         fetch(destURL).then(function(resp) {
             return resp.json();
         }).then(function(r) {
+            fxaForm.querySelector('[name="device_id"]').value = r.deviceId;
             fxaForm.querySelector('[name="flow_id"]').value = r.flowId;
             fxaForm.querySelector('[name="flow_begin_time"]').value = r.flowBeginTime;
         }).catch(function() {

--- a/media/js/base/mozilla-fxa-form.js
+++ b/media/js/base/mozilla-fxa-form.js
@@ -7,81 +7,88 @@ if (typeof window.Mozilla === 'undefined') {
     window.Mozilla = {};
 }
 
-Mozilla.FxaForm = (function(Mozilla) {
+(function(Mozilla) {
     'use strict';
 
-    var fxaForm = document.getElementById('fxa-email-form');
-    var fxaSubmitButton = document.getElementById('fxa-email-form-submit');
-    var fxaFormContextField = fxaForm.querySelector('[name="context"]');
-    var fxaFormServiceField = fxaForm.querySelector('[name="service"]');
-    var supportsFetch = 'fetch' in window;
+    var FxaForm = {};
 
-    // swap form action for Fx China re-pack
-    function init() {
-        // disable form while we check distribution
-        fxaSubmitButton.disabled = true;
+    FxaForm.init= function(){
+        var fxaForm = document.getElementById('fxa-email-form');
+        var fxaSubmitButton = document.getElementById('fxa-email-form-submit');
+        var fxaFormContextField = fxaForm.querySelector('[name="context"]');
+        var fxaFormServiceField = fxaForm.querySelector('[name="service"]');
+        var supportsFetch = 'fetch' in window;
 
-        var mozillaonlineAction = fxaForm.dataset.mozillaonlineAction;
+        // swap form action for Fx China re-pack
+        function init() {
+            // disable form while we check distribution
+            fxaSubmitButton.disabled = true;
 
-        if (mozillaonlineAction) {
-            Mozilla.Client.getFirefoxDetails(function(data) {
-                // only switch to China re-pack URL if UITour call is successful
-                // (marked by data.accurate being true)
-                if (data.accurate && data.distribution && data.distribution.toLowerCase() === 'mozillaonline') {
-                    fxaForm.action = mozillaonlineAction;
-                }
+            var mozillaonlineAction = fxaForm.dataset.mozillaonlineAction;
 
+            if (mozillaonlineAction) {
+                Mozilla.Client.getFirefoxDetails(function(data) {
+                    // only switch to China re-pack URL if UITour call is successful
+                    // (marked by data.accurate being true)
+                    if (data.accurate && data.distribution && data.distribution.toLowerCase() === 'mozillaonline') {
+                        fxaForm.action = mozillaonlineAction;
+                    }
+
+                    fetchTokens();
+                });
+            } else {
                 fetchTokens();
+            }
+        }
+
+        // get tokens from FxA for analytics purposes
+        function fetchTokens() {
+            if (!supportsFetch) {
+                return;
+            }
+
+            fxaSubmitButton.disabled = false;
+
+            var destURL = fxaForm.getAttribute('action') + 'metrics-flow';
+            var entrypoint = document.getElementById('fxa-email-form-entrypoint');
+            var utmSource = document.getElementById('fxa-email-form-utm-source');
+            var utmCampaign = document.getElementById('fxa-email-form-utm-campaign');
+
+            // add required params to the token fetch request
+            destURL += '?form_type=email';
+            destURL += '&entrypoint=' + entrypoint.value;
+            destURL += '&utm_source=' + utmSource.value;
+
+            // pass utm_campaign if available
+            if (utmCampaign) {
+                destURL += '&utm_campaign=' + utmCampaign.value;
+            }
+
+            fetch(destURL).then(function(resp) {
+                return resp.json();
+            }).then(function(r) {
+                fxaForm.querySelector('[name="device_id"]').value = r.deviceId;
+                fxaForm.querySelector('[name="flow_id"]').value = r.flowId;
+                fxaForm.querySelector('[name="flow_begin_time"]').value = r.flowBeginTime;
+            }).catch(function() {
+                // silently fail, leaving flow_id and flow_begin_time as default empty value
             });
-        } else {
-            fetchTokens();
-        }
-    }
-
-    // get tokens from FxA for analytics purposes
-    function fetchTokens() {
-        if (!supportsFetch) {
-            return;
         }
 
-        fxaSubmitButton.disabled = false;
-
-        var destURL = fxaForm.getAttribute('action') + 'metrics-flow';
-        var entrypoint = document.getElementById('fxa-email-form-entrypoint');
-        var utmSource = document.getElementById('fxa-email-form-utm-source');
-        var utmCampaign = document.getElementById('fxa-email-form-utm-campaign');
-
-        // add required params to the token fetch request
-        destURL += '?form_type=email';
-        destURL += '&entrypoint=' + entrypoint.value;
-        destURL += '&utm_source=' + utmSource.value;
-
-        // pass utm_campaign if available
-        if (utmCampaign) {
-            destURL += '&utm_campaign=' + utmCampaign.value;
+        if (fxaForm) {
+            // Sync is Firefox for desktop only.
+            if (Mozilla.Client.isFirefoxDesktop) {
+                init();
+            } else {
+                // Omit the fields required for sync.
+                // This allows non-Firefoxes to create accounts.
+                fxaForm.removeChild(fxaFormContextField);
+                fxaForm.removeChild(fxaFormServiceField);
+                fetchTokens();
+            }
         }
+    };
 
-        fetch(destURL).then(function(resp) {
-            return resp.json();
-        }).then(function(r) {
-            fxaForm.querySelector('[name="device_id"]').value = r.deviceId;
-            fxaForm.querySelector('[name="flow_id"]').value = r.flowId;
-            fxaForm.querySelector('[name="flow_begin_time"]').value = r.flowBeginTime;
-        }).catch(function() {
-            // silently fail, leaving flow_id and flow_begin_time as default empty value
-        });
-    }
+    window.Mozilla.FxaForm = FxaForm;
 
-    if (fxaForm) {
-        // Sync is Firefox for desktop only.
-        if (Mozilla.Client.isFirefoxDesktop) {
-            init();
-        } else {
-            // Omit the fields required for sync.
-            // This allows non-Firefoxes to create accounts.
-            fxaForm.removeChild(fxaFormContextField);
-            fxaForm.removeChild(fxaFormServiceField);
-            fetchTokens();
-        }
-    }
 })(window.Mozilla);

--- a/media/js/base/mozilla-monitor-button-init.js
+++ b/media/js/base/mozilla-monitor-button-init.js
@@ -1,0 +1,9 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+(function() {
+    'use strict';
+
+    Mozilla.MonitorButton.init();
+})();

--- a/media/js/base/mozilla-monitor-button.js
+++ b/media/js/base/mozilla-monitor-button.js
@@ -26,7 +26,9 @@ Mozilla.MonitorButton = (function () {
     var destURL = monitorButton.getAttribute('data-action') + 'metrics-flow';
 
     // collect values from monitor button
-    var utmParams = _SearchParams.queryStringToObject(buttonURL);
+    var utmParams = window._SearchParams.queryStringToObject(buttonURL);
+
+    console.log(utmParams);
 
     var utmSource = utmParams.utm_source;
     var utmCampaign = utmParams.utm_campaign;

--- a/media/js/base/mozilla-monitor-button.js
+++ b/media/js/base/mozilla-monitor-button.js
@@ -38,11 +38,11 @@ if (typeof window.Mozilla === 'undefined') {
         var params = window._SearchParams.queryStringToObject(buttonURLParams);
 
         // add required params to the token fetch request
-        destURL += '&entrypoint=' + params.entrypoint;
+        destURL += '?entrypoint=' + params.entrypoint;
         destURL += '&form_type=' + params.form_type;
-        destURL += '&utm_campaign=' + params.campaign;
-        destURL += '&utm_content=' + params.content;
-        destURL += '&utm_source=' + params.source;
+        destURL += '&utm_campaign=' + params.utm_campaign;
+        destURL += '&utm_content=' + params.utm_content;
+        destURL += '&utm_source=' + params.utm_source;
 
         fetch(destURL).then(function(resp) {
             return resp.json();

--- a/media/js/base/mozilla-monitor-button.js
+++ b/media/js/base/mozilla-monitor-button.js
@@ -7,40 +7,56 @@ if (typeof window.Mozilla === 'undefined') {
     window.Mozilla = {};
 }
 
-Mozilla.MonitorButton = (function() {
+(function() {
     'use strict';
 
-    var monitorButton = document.getElementById('fxa-monitor-submit');
+    var MonitorButton = {};
 
-    // fetch request
-    var supportsFetch = 'fetch' in window;
+    MonitorButton.init = function(buttonId){
 
-    if (!supportsFetch || !monitorButton) {
-        return;
-    }
+        // check for custom buttonId, used in case of multiple buttons.
+        if(!buttonId){
+            buttonId = 'fxa-monitor-submit';
+        }
 
-    var buttonURL = monitorButton.getAttribute('href');
-    // strip url to everything after `?`
-    var buttonURLParams = buttonURL.match(/\?(.*)/)[1];
+        var monitorButton = document.getElementById(buttonId);
 
-    var destURL = monitorButton.getAttribute('data-action') + 'metrics-flow';
+        // fetch request
+        var supportsFetch = 'fetch' in window;
 
-    // collect values from monitor button
-    var params = window._SearchParams.queryStringToObject(buttonURLParams);
+        if (!supportsFetch || !monitorButton) {
+            return;
+        }
 
-    // add required params to the token fetch request
-    destURL += '&' + params;
+        var buttonURL = monitorButton.getAttribute('href');
+        // strip url to everything after `?`
+        var buttonURLParams = buttonURL.match(/\?(.*)/)[1];
 
-    fetch(destURL).then(function(resp) {
-        return resp.json();
-    }).then(function(r) {
-        // add retrieved deviceID, flowBeginTime and flowId values to cta url
-        buttonURL += '&deviceId=' + r.deviceId;
-        buttonURL += '&flowBeginTime=' + r.flowBeginTime;
-        buttonURL += '&flowId=' + r.flowId;
-        monitorButton.setAttribute('href', buttonURL);
-    }).catch(function() {
-        // silently fail: deviceId, flowBeginTime, flowId are not added to url.
-    });
+        var destURL = monitorButton.getAttribute('data-action') + 'metrics-flow';
+
+        // collect values from monitor button
+        var params = window._SearchParams.queryStringToObject(buttonURLParams);
+
+        // add required params to the token fetch request
+        destURL += '&entrypoint=' + params.entrypoint;
+        destURL += '&form_type=' + params.form_type;
+        destURL += '&utm_campaign=' + params.campaign;
+        destURL += '&utm_content=' + params.content;
+        destURL += '&utm_source=' + params.source;
+
+        fetch(destURL).then(function(resp) {
+            return resp.json();
+        }).then(function(r) {
+            // add retrieved deviceID, flowBeginTime and flowId values to cta url
+            buttonURL += '&deviceId=' + r.deviceId;
+            buttonURL += '&flowBeginTime=' + r.flowBeginTime;
+            buttonURL += '&flowId=' + r.flowId;
+            monitorButton.setAttribute('href', buttonURL);
+        }).catch(function() {
+            // silently fail: deviceId, flowBeginTime, flowId are not added to url.
+        });
+    };
+
+    window.Mozilla.MonitorButton = MonitorButton;
 })();
 

--- a/media/js/base/mozilla-monitor-button.js
+++ b/media/js/base/mozilla-monitor-button.js
@@ -38,10 +38,16 @@ if (typeof window.Mozilla === 'undefined') {
         var params = window._SearchParams.queryStringToObject(buttonURLParams);
 
         // add required params to the token fetch request
+        if (params.utm_content) {
+            destURL += '&utm_content=' + params.utm_content;
+        }
+
+        if (params.utm_campaign) {
+            destURL += '&utm_campaign=' + params.utm_campaign;
+        }
+
         destURL += '?entrypoint=' + params.entrypoint;
         destURL += '&form_type=' + params.form_type;
-        destURL += '&utm_campaign=' + params.utm_campaign;
-        destURL += '&utm_content=' + params.utm_content;
         destURL += '&utm_source=' + params.utm_source;
 
         fetch(destURL).then(function(resp) {

--- a/media/js/base/mozilla-monitor-button.js
+++ b/media/js/base/mozilla-monitor-button.js
@@ -7,7 +7,7 @@ if (typeof window.Mozilla === 'undefined') {
     window.Mozilla = {};
 }
 
-Mozilla.MonitorButton = (function () {
+Mozilla.MonitorButton = (function() {
     'use strict';
 
     var monitorButton = document.getElementById('fxa-monitor-submit');
@@ -21,39 +21,25 @@ Mozilla.MonitorButton = (function () {
 
     var buttonURL = monitorButton.getAttribute('href');
     // strip url to everything after `?`
-    buttonURL = buttonURL.match(/\?(.*)/)[1];
+    var buttonURLParams = buttonURL.match(/\?(.*)/)[1];
 
     var destURL = monitorButton.getAttribute('data-action') + 'metrics-flow';
 
     // collect values from monitor button
-    var utmParams = window._SearchParams.queryStringToObject(buttonURL);
-
-    console.log(utmParams);
-
-    var utmSource = utmParams.utm_source;
-    var utmCampaign = utmParams.utm_campaign;
-    var entrypoint = utmParams.entrypoint;
-    var formType = utmParams.form_type;
+    var params = window._SearchParams.queryStringToObject(buttonURLParams);
 
     // add required params to the token fetch request
-    destURL += '?' + formType;
-    destURL += '&' + entrypoint;
-    destURL += '&' + utmSource;
+    destURL += '&' + params;
 
-    // pass utm_campaign if available
-    if (utmCampaign) {
-        destURL += '&' + utmCampaign;
-    }
-
-    fetch(destURL).then(function (resp) {
+    fetch(destURL).then(function(resp) {
         return resp.json();
-    }).then(function (r) {
+    }).then(function(r) {
         // add retrieved deviceID, flowBeginTime and flowId values to cta url
         buttonURL += '&deviceId=' + r.deviceId;
         buttonURL += '&flowBeginTime=' + r.flowBeginTime;
         buttonURL += '&flowId=' + r.flowId;
         monitorButton.setAttribute('href', buttonURL);
-    }).catch(function () {
+    }).catch(function() {
         // silently fail: deviceId, flowBeginTime, flowId are not added to url.
     });
 })();

--- a/media/js/firefox/accounts-2019.js
+++ b/media/js/firefox/accounts-2019.js
@@ -41,4 +41,17 @@
         fxaSigninLink.href = finalFxaSigninURI;
     }
 
+    // Prevent double-requesting Flow IDs, inits FxaForm even on non-firefox browsers.
+    if (Mozilla.Client.isFirefoxDesktop) {
+        Mozilla.Client.getFxaDetails(function(details) {
+            if (details.setup) {
+                Mozilla.MonitorButton.init();
+            } else {
+                Mozilla.FxaForm.init();
+            }
+        });
+    } else {
+        Mozilla.FxaForm.init();
+    }
+
 })(window.Mozilla);

--- a/media/js/firefox/concerts.js
+++ b/media/js/firefox/concerts.js
@@ -12,8 +12,7 @@ function onYouTubeIframeAPIReady() {
     Mozilla.firefoxConcertsOnYouTubeIframeAPIReady();
 }
 
-
-(function (Mozilla) {
+(function(Mozilla) {
     'use strict';
 
     var ConcertPage = {
@@ -26,9 +25,9 @@ function onYouTubeIframeAPIReady() {
     var _requestComplete = false;
 
     // take params from URL and pass through signup button
-    ConcertPage.passThroughParams = function () {
+    ConcertPage.passThroughParams = function() {
         var params = window.location.search.slice(1);
-        ['source', 'medium', 'campaign', 'content'].forEach(function (p) {
+        ['source', 'medium', 'campaign', 'content'].forEach(function(p) {
             var param = 'utm_' + p;
             if (params.indexOf(param) >= 0) {
                 var regex = RegExp(param + '=([^\#\&\?]+).*$');
@@ -40,14 +39,14 @@ function onYouTubeIframeAPIReady() {
         });
     };
 
-    ConcertPage.getLocation = function () {
+    ConcertPage.getLocation = function() {
         // should /country-code.json be slow to load,
         // just show the regular messaging after 3 seconds waiting.
         _geoTimeout = setTimeout(ConcertPage.onRequestComplete, 3000);
 
         var xhr = new window.XMLHttpRequest();
 
-        xhr.onload = function (r) {
+        xhr.onload = function(r) {
             var country = 'none';
 
             // make sure status is in the acceptable range
@@ -69,7 +68,7 @@ function onYouTubeIframeAPIReady() {
         xhr.send();
     };
 
-    ConcertPage.hasGeoOverride = function (location) {
+    ConcertPage.hasGeoOverride = function(location) {
         var loc = location || window.location.search;
         if (loc.indexOf('geo=') !== -1) {
             var urlRe = /geo=([a-z]{2})/i;
@@ -82,7 +81,7 @@ function onYouTubeIframeAPIReady() {
         return false;
     };
 
-    ConcertPage.verifyLocation = function (location) {
+    ConcertPage.verifyLocation = function(location) {
         if (location) {
             return location !== ConcertPage.US_COUNTRY_CODE;
         }
@@ -90,7 +89,7 @@ function onYouTubeIframeAPIReady() {
         return false;
     };
 
-    ConcertPage.onRequestComplete = function (data) {
+    ConcertPage.onRequestComplete = function(data) {
         var country = typeof data === 'string' ? data : 'none';
 
         clearTimeout(_geoTimeout);
@@ -106,7 +105,7 @@ function onYouTubeIframeAPIReady() {
         }
     };
 
-    ConcertPage.updatePageContent = function () {
+    ConcertPage.updatePageContent = function() {
         if (ConcertPage.shouldShowConcert() === 'false') {
             ConcertPage.showExcludedContent();
         } else {
@@ -114,40 +113,40 @@ function onYouTubeIframeAPIReady() {
         }
     };
 
-    ConcertPage.showConcertContent = function () {
+    ConcertPage.showConcertContent = function() {
         // Add styling hook for us-specific CSS.
         document.body.classList.add('state-in-us');
     };
 
-    ConcertPage.showExcludedContent = function () {
+    ConcertPage.showExcludedContent = function() {
         // Add styling hook for excluded-specific CSS.
         document.body.classList.add('state-not-us');
     };
 
-    ConcertPage.shouldShowConcert = function () {
+    ConcertPage.shouldShowConcert = function() {
         // Is user in the US?
         return ConcertPage.verifyLocation(ConcertPage.getCookie(ConcertPage.COOKIE_ID));
     };
 
-    ConcertPage.cookieExpiresDate = function (date) {
+    ConcertPage.cookieExpiresDate = function(date) {
         var d = date || new Date();
         d.setTime(d.getTime() + (ConcertPage.COOKIE_EXPIRATION_DAYS * 24 * 60 * 60 * 1000));
         return d.toUTCString();
     };
 
-    ConcertPage.setCookie = function (country) {
+    ConcertPage.setCookie = function(country) {
         Mozilla.Cookies.setItem(ConcertPage.COOKIE_ID, country, ConcertPage.cookieExpiresDate());
     };
 
-    ConcertPage.getCookie = function (id) {
+    ConcertPage.getCookie = function(id) {
         return Mozilla.Cookies.getItem(id);
     };
 
-    ConcertPage.hasCookie = function () {
+    ConcertPage.hasCookie = function() {
         return Mozilla.Cookies.hasItem(ConcertPage.COOKIE_ID);
     };
 
-    ConcertPage.init = function () {
+    ConcertPage.init = function() {
         ConcertPage.passThroughParams();
 
         var cookiesEnabled = typeof Mozilla.Cookies !== 'undefined' || Mozilla.Cookies.enabled();
@@ -178,7 +177,6 @@ function onYouTubeIframeAPIReady() {
     };
     window.Mozilla.ConcertPage = ConcertPage;
 
-
     var stateStorageKey = 'fxaOauthState';
     var verifiedStorageKey = 'fxaOauthVerified';
     var cookieDays = 14;
@@ -197,6 +195,7 @@ function onYouTubeIframeAPIReady() {
         Next, we retrieve metrics information from an asynchronous FxA call. When this
         call completes, the submit button on the form is enabled.
     */
+
     function initOauth() {
         var fxaFormWrapper = document.getElementById('fxa-form-wrapper');
         var metricsFlowEndpoint = fxaFormWrapper.getAttribute('data-fxa-metrics-endpoint');
@@ -234,13 +233,13 @@ function onYouTubeIframeAPIReady() {
             // add required params to the token fetch request
             destURL += '?entrypoint=concerts&form_type=email&utm_campaign=firefox-concert-series-q4-2018&utm_source=mozilla.org';
 
-            fetch(destURL).then(function (resp) {
+            fetch(destURL).then(function(resp) {
                 return resp.json();
-            }).then(function (r) {
+            }).then(function(r) {
                 deviceIdField.value = r.deviceId;
                 flowIdField.value = r.flowId;
                 flowBeginTimeField.value = r.flowBeginTime;
-            }).catch(function () {
+            }).catch(function() {
                 // silently fail, leaving device_id, flow_id and flow_begin_time as default empty value
             });
         }
@@ -301,13 +300,12 @@ function onYouTubeIframeAPIReady() {
         initializeClock('countdown-one', showtimeOne);
     }
 
-
     // Set up modal for the email privacy link
     var content = document.querySelector('.mzp-u-modal-content');
     var trigger = document.querySelector('.email-privacy-link');
     var title = document.querySelector('.email-privacy h3');
 
-    trigger.addEventListener('click', function (e) {
+    trigger.addEventListener('click', function(e) {
         e.preventDefault();
         Mzp.Modal.createModal(e.target, content, {
             title: title.innerHTML,
@@ -321,7 +319,6 @@ function onYouTubeIframeAPIReady() {
             'eLabel': 'How will Mozilla use my email?'
         });
     }, false);
-
 
     // Video
     var videoLink = document.querySelector('.js-video-play');
@@ -340,7 +337,7 @@ function onYouTubeIframeAPIReady() {
 
         videoLink.setAttribute('role', 'button');
 
-        videoLink.addEventListener('click', function (e) {
+        videoLink.addEventListener('click', function(e) {
             e.preventDefault();
 
             new YT.Player(videoLink, {
@@ -364,7 +361,7 @@ function onYouTubeIframeAPIReady() {
             function onPlayerStateChange(event) {
                 var state;
 
-                switch (event.data) {
+                switch(event.data) {
                 case YT.PlayerState.PLAYING:
                     state = 'video play';
                     break;

--- a/media/js/firefox/concerts.js
+++ b/media/js/firefox/concerts.js
@@ -13,7 +13,7 @@ function onYouTubeIframeAPIReady() {
 }
 
 
-(function(Mozilla) {
+(function (Mozilla) {
     'use strict';
 
     var ConcertPage = {
@@ -26,9 +26,9 @@ function onYouTubeIframeAPIReady() {
     var _requestComplete = false;
 
     // take params from URL and pass through signup button
-    ConcertPage.passThroughParams = function() {
+    ConcertPage.passThroughParams = function () {
         var params = window.location.search.slice(1);
-        ['source','medium','campaign','content'].forEach(function(p) {
+        ['source', 'medium', 'campaign', 'content'].forEach(function (p) {
             var param = 'utm_' + p;
             if (params.indexOf(param) >= 0) {
                 var regex = RegExp(param + '=([^\#\&\?]+).*$');
@@ -40,14 +40,14 @@ function onYouTubeIframeAPIReady() {
         });
     };
 
-    ConcertPage.getLocation = function() {
+    ConcertPage.getLocation = function () {
         // should /country-code.json be slow to load,
         // just show the regular messaging after 3 seconds waiting.
         _geoTimeout = setTimeout(ConcertPage.onRequestComplete, 3000);
 
         var xhr = new window.XMLHttpRequest();
 
-        xhr.onload = function(r) {
+        xhr.onload = function (r) {
             var country = 'none';
 
             // make sure status is in the acceptable range
@@ -69,7 +69,7 @@ function onYouTubeIframeAPIReady() {
         xhr.send();
     };
 
-    ConcertPage.hasGeoOverride = function(location) {
+    ConcertPage.hasGeoOverride = function (location) {
         var loc = location || window.location.search;
         if (loc.indexOf('geo=') !== -1) {
             var urlRe = /geo=([a-z]{2})/i;
@@ -82,7 +82,7 @@ function onYouTubeIframeAPIReady() {
         return false;
     };
 
-    ConcertPage.verifyLocation = function(location) {
+    ConcertPage.verifyLocation = function (location) {
         if (location) {
             return location !== ConcertPage.US_COUNTRY_CODE;
         }
@@ -90,7 +90,7 @@ function onYouTubeIframeAPIReady() {
         return false;
     };
 
-    ConcertPage.onRequestComplete = function(data) {
+    ConcertPage.onRequestComplete = function (data) {
         var country = typeof data === 'string' ? data : 'none';
 
         clearTimeout(_geoTimeout);
@@ -106,7 +106,7 @@ function onYouTubeIframeAPIReady() {
         }
     };
 
-    ConcertPage.updatePageContent = function() {
+    ConcertPage.updatePageContent = function () {
         if (ConcertPage.shouldShowConcert() === 'false') {
             ConcertPage.showExcludedContent();
         } else {
@@ -114,40 +114,40 @@ function onYouTubeIframeAPIReady() {
         }
     };
 
-    ConcertPage.showConcertContent = function() {
+    ConcertPage.showConcertContent = function () {
         // Add styling hook for us-specific CSS.
         document.body.classList.add('state-in-us');
     };
 
-    ConcertPage.showExcludedContent = function() {
+    ConcertPage.showExcludedContent = function () {
         // Add styling hook for excluded-specific CSS.
         document.body.classList.add('state-not-us');
     };
 
-    ConcertPage.shouldShowConcert = function() {
+    ConcertPage.shouldShowConcert = function () {
         // Is user in the US?
         return ConcertPage.verifyLocation(ConcertPage.getCookie(ConcertPage.COOKIE_ID));
     };
 
-    ConcertPage.cookieExpiresDate = function(date) {
+    ConcertPage.cookieExpiresDate = function (date) {
         var d = date || new Date();
         d.setTime(d.getTime() + (ConcertPage.COOKIE_EXPIRATION_DAYS * 24 * 60 * 60 * 1000));
         return d.toUTCString();
     };
 
-    ConcertPage.setCookie = function(country) {
+    ConcertPage.setCookie = function (country) {
         Mozilla.Cookies.setItem(ConcertPage.COOKIE_ID, country, ConcertPage.cookieExpiresDate());
     };
 
-    ConcertPage.getCookie = function(id) {
+    ConcertPage.getCookie = function (id) {
         return Mozilla.Cookies.getItem(id);
     };
 
-    ConcertPage.hasCookie = function() {
+    ConcertPage.hasCookie = function () {
         return Mozilla.Cookies.hasItem(ConcertPage.COOKIE_ID);
     };
 
-    ConcertPage.init = function() {
+    ConcertPage.init = function () {
         ConcertPage.passThroughParams();
 
         var cookiesEnabled = typeof Mozilla.Cookies !== 'undefined' || Mozilla.Cookies.enabled();
@@ -202,6 +202,7 @@ function onYouTubeIframeAPIReady() {
         var metricsFlowEndpoint = fxaFormWrapper.getAttribute('data-fxa-metrics-endpoint');
         var flowIdField = document.getElementById('flow_id');
         var flowBeginTimeField = document.getElementById('flow_begin_time');
+        var deviceIdField = document.getElementById('device_id');
         var stateField = document.getElementById('state');
         var fxaSignIn = document.getElementById('fxa-sign-in');
 
@@ -233,13 +234,14 @@ function onYouTubeIframeAPIReady() {
             // add required params to the token fetch request
             destURL += '?entrypoint=concerts&form_type=email&utm_campaign=firefox-concert-series-q4-2018&utm_source=mozilla.org';
 
-            fetch(destURL).then(function(resp) {
+            fetch(destURL).then(function (resp) {
                 return resp.json();
-            }).then(function(r) {
+            }).then(function (r) {
+                deviceIdField.value = r.deviceId;
                 flowIdField.value = r.flowId;
                 flowBeginTimeField.value = r.flowBeginTime;
-            }).catch(function() {
-                // silently fail, leaving flow_id and flow_begin_time as default empty value
+            }).catch(function () {
+                // silently fail, leaving device_id, flow_id and flow_begin_time as default empty value
             });
         }
     }
@@ -305,7 +307,7 @@ function onYouTubeIframeAPIReady() {
     var trigger = document.querySelector('.email-privacy-link');
     var title = document.querySelector('.email-privacy h3');
 
-    trigger.addEventListener('click', function(e) {
+    trigger.addEventListener('click', function (e) {
         e.preventDefault();
         Mzp.Modal.createModal(e.target, content, {
             title: title.innerHTML,
@@ -338,7 +340,7 @@ function onYouTubeIframeAPIReady() {
 
         videoLink.setAttribute('role', 'button');
 
-        videoLink.addEventListener('click', function(e) {
+        videoLink.addEventListener('click', function (e) {
             e.preventDefault();
 
             new YT.Player(videoLink, {
@@ -362,7 +364,7 @@ function onYouTubeIframeAPIReady() {
             function onPlayerStateChange(event) {
                 var state;
 
-                switch(event.data) {
+                switch (event.data) {
                 case YT.PlayerState.PLAYING:
                     state = 'video play';
                     break;

--- a/media/js/firefox/whatsnew/account-conditional-ctas.js
+++ b/media/js/firefox/whatsnew/account-conditional-ctas.js
@@ -1,0 +1,16 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+(function(Mozilla) {
+    'use strict';
+
+    Mozilla.Client.getFxaDetails(function(details){
+        if(details.setup){
+            Mozilla.MonitorButton.init();
+        }else{
+            Mozilla.FxaForm.init();
+        }
+    });
+
+})(window.Mozilla);

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -1006,7 +1006,8 @@
         "js/base/mozilla-fxa-init.js",
         "js/base/mozilla-fxa-form.js",
         "js/base/mozilla-monitor-button.js",
-        "js/firefox/whatsnew/up-to-date.js"
+        "js/firefox/whatsnew/up-to-date.js",
+        "js/firefox/whatsnew/account-conditional-ctas.js"
       ],
       "name": "firefox_whatsnew_67.0.5"
     },
@@ -1016,6 +1017,7 @@
         "js/base/mozilla-fxa.js",
         "js/base/mozilla-fxa-init.js",
         "js/base/mozilla-monitor-button.js",
+        "js/base/mozilla-monitor-button-init.js",
         "js/firefox/whatsnew/up-to-date.js"
       ],
       "name": "firefox_whatsnew_68E_monitor"
@@ -1398,7 +1400,8 @@
         "js/base/mozilla-fxa-init.js",
         "js/base/mozilla-fxa-form.js",
         "js/base/mozilla-monitor-button.js",
-        "js/firefox/accounts-2019.js"
+        "js/firefox/accounts-2019.js",
+        "js/firefox/whatsnew/account-conditional-ctas.js"
       ],
       "name": "firefox_accounts_2019"
     },

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -946,7 +946,7 @@
         "js/base/mozilla-fxa.js",
         "js/base/mozilla-fxa-init.js",
         "js/base/mozilla-fxa-form.js",
-        "js/base/mozilla-fxa-form.init.js",
+        "js/base/mozilla-fxa-form-init.js",
         "js/firefox/whatsnew/whatsnew-63.js"
       ],
       "name": "firefox_whatsnew_63"
@@ -967,7 +967,7 @@
         "js/base/mozilla-fxa.js",
         "js/base/mozilla-fxa-init.js",
         "js/base/mozilla-fxa-form.js",
-        "js/base/mozilla-fxa-form.init.js",
+        "js/base/mozilla-fxa-form-init.js",
         "js/firefox/whatsnew/whatsnew-65.js"
       ],
       "name": "firefox_whatsnew_65"
@@ -985,7 +985,7 @@
         "js/base/mozilla-fxa.js",
         "js/base/mozilla-fxa-init.js",
         "js/base/mozilla-fxa-form.js",
-        "js/base/mozilla-fxa-form.init.js",
+        "js/base/mozilla-fxa-form-init.js",
         "protocol/js/protocol-modal.js",
         "js/firefox/whatsnew/whatsnew-66.js"
       ],
@@ -997,7 +997,7 @@
         "js/base/mozilla-fxa.js",
         "js/base/mozilla-fxa-init.js",
         "js/base/mozilla-fxa-form.js",
-        "js/base/mozilla-fxa-form.init.js",
+        "js/base/mozilla-fxa-form-init.js",
         "protocol/js/protocol-modal.js",
         "js/firefox/whatsnew/whatsnew-67.js"
       ],
@@ -1101,7 +1101,7 @@
     {
       "files": [
         "js/base/mozilla-fxa-form.js",
-        "js/base/mozilla-fxa-form.init.js",
+        "js/base/mozilla-fxa-form-init.js",
         "js/firefox/new/scene1_fxa_modal.js"
       ],
       "name": "firefox_new_scene1_fxa_modal"
@@ -1395,7 +1395,7 @@
         "js/base/mozilla-fxa.js",
         "js/base/mozilla-fxa-init.js",
         "js/base/mozilla-fxa-form.js",
-        "js/base/mozilla-fxa-form.init.js",
+        "js/base/mozilla-fxa-form-init.js",
         "js/firefox/accounts.js"
       ],
       "name": "firefox_accounts"
@@ -1405,7 +1405,7 @@
         "js/base/mozilla-fxa.js",
         "js/base/mozilla-fxa-init.js",
         "js/base/mozilla-fxa-form.js",
-        "js/base/mozilla-fxa-form.init.js",
+        "js/base/mozilla-fxa-form-init.js",
         "js/base/mozilla-monitor-button.js",
         "js/firefox/accounts-2019.js"
       ],
@@ -1424,7 +1424,7 @@
     {
       "files": [
         "js/base/mozilla-fxa-form.js",
-        "js/base/mozilla-fxa-form.init.js",
+        "js/base/mozilla-fxa-form-init.js",
         "js/firefox/firstrun/firstrun_quantum.js"
       ],
       "name": "firefox_firstrun_quantum"

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -1405,7 +1405,6 @@
         "js/base/mozilla-fxa.js",
         "js/base/mozilla-fxa-init.js",
         "js/base/mozilla-fxa-form.js",
-        "js/base/mozilla-fxa-form-init.js",
         "js/base/mozilla-monitor-button.js",
         "js/firefox/accounts-2019.js"
       ],

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -946,6 +946,7 @@
         "js/base/mozilla-fxa.js",
         "js/base/mozilla-fxa-init.js",
         "js/base/mozilla-fxa-form.js",
+        "js/base/mozilla-fxa-form.init.js",
         "js/firefox/whatsnew/whatsnew-63.js"
       ],
       "name": "firefox_whatsnew_63"
@@ -966,6 +967,7 @@
         "js/base/mozilla-fxa.js",
         "js/base/mozilla-fxa-init.js",
         "js/base/mozilla-fxa-form.js",
+        "js/base/mozilla-fxa-form.init.js",
         "js/firefox/whatsnew/whatsnew-65.js"
       ],
       "name": "firefox_whatsnew_65"
@@ -983,6 +985,7 @@
         "js/base/mozilla-fxa.js",
         "js/base/mozilla-fxa-init.js",
         "js/base/mozilla-fxa-form.js",
+        "js/base/mozilla-fxa-form.init.js",
         "protocol/js/protocol-modal.js",
         "js/firefox/whatsnew/whatsnew-66.js"
       ],
@@ -994,6 +997,7 @@
         "js/base/mozilla-fxa.js",
         "js/base/mozilla-fxa-init.js",
         "js/base/mozilla-fxa-form.js",
+        "js/base/mozilla-fxa-form.init.js",
         "protocol/js/protocol-modal.js",
         "js/firefox/whatsnew/whatsnew-67.js"
       ],
@@ -1097,6 +1101,7 @@
     {
       "files": [
         "js/base/mozilla-fxa-form.js",
+        "js/base/mozilla-fxa-form.init.js",
         "js/firefox/new/scene1_fxa_modal.js"
       ],
       "name": "firefox_new_scene1_fxa_modal"
@@ -1390,6 +1395,7 @@
         "js/base/mozilla-fxa.js",
         "js/base/mozilla-fxa-init.js",
         "js/base/mozilla-fxa-form.js",
+        "js/base/mozilla-fxa-form.init.js",
         "js/firefox/accounts.js"
       ],
       "name": "firefox_accounts"
@@ -1399,9 +1405,9 @@
         "js/base/mozilla-fxa.js",
         "js/base/mozilla-fxa-init.js",
         "js/base/mozilla-fxa-form.js",
+        "js/base/mozilla-fxa-form.init.js",
         "js/base/mozilla-monitor-button.js",
-        "js/firefox/accounts-2019.js",
-        "js/firefox/whatsnew/account-conditional-ctas.js"
+        "js/firefox/accounts-2019.js"
       ],
       "name": "firefox_accounts_2019"
     },
@@ -1418,6 +1424,7 @@
     {
       "files": [
         "js/base/mozilla-fxa-form.js",
+        "js/base/mozilla-fxa-form.init.js",
         "js/firefox/firstrun/firstrun_quantum.js"
       ],
       "name": "firefox_firstrun_quantum"


### PR DESCRIPTION
## Description
1. Send additional parameters to FxA servers during metrics-flow request for monitor button.
2. Retrieve new deviceId value from FxA requests.

## Issue / Bugzilla link
#7531
#7533
#7532

## Testing
Adds to monitor button FxA metrics-flow fetch. [`js/base/mozilla-monitor-button.js`]:
- `entrypoint` 
- `form_type`
- utm parameters

_Values follow [our uniform schema](https://github.com/mozilla/bedrock/issues/7417)._

All [metrics-flow requests](https://github.com/mozilla/bedrock/search?q=flow_id&unscoped_q=flow_id) now collect `deviceId` value from FxA.
