### PR TITLE
[fix #7547] Adjust WNP68 experiment

### DIFF
--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx68-trailhead.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx68-trailhead.html
@@ -8,10 +8,12 @@
 
 {% block experiments %}
   {% if switch('experiment_whatsnew_68', ['en-US','en-CA','en-GB','fr','de']) %}
-    {% if LANG in ['en-US', 'en-GB'] %}
-      {{ js_bundle('experiment-whatsnew-68-enUSGB') }}
+    {% if LANG == 'en-US' %}
+      {{ js_bundle('experiment-whatsnew-68-enUS') }}
     {% elif LANG == 'en-CA' %}
       {{ js_bundle('experiment-whatsnew-68-enCA') }}
+    {% elif LANG == 'en-GB' %}
+      {{ js_bundle('experiment-whatsnew-68-enGB') }}
     {% elif LANG == 'fr' %}
       {{ js_bundle('experiment-whatsnew-68-fr') }}
     {% elif LANG == 'de' %}

--- a/media/js/firefox/whatsnew/experiment-whatsnew-68-de.js
+++ b/media/js/firefox/whatsnew/experiment-whatsnew-68-de.js
@@ -30,11 +30,11 @@
         var deckard = new Mozilla.TrafficCop({
             id: 'experiment_firefox_whatsnew_68',
             variations: {
-                'v=a': 2,  // control
-                'v=b': 2,  // new layout, light
-                'v=c': 2,  // new layout, dark
-                'v=d': 2,  // notification favicon
-                'v=e': 2   // monitor CTA
+                'v=a': 10,  // control
+                'v=b': 10,  // new layout, light
+                'v=c': 10,  // new layout, dark
+                'v=d': 10,  // notification favicon
+                'v=e': 10   // monitor CTA
             }
         });
 

--- a/media/js/firefox/whatsnew/experiment-whatsnew-68-enGB.js
+++ b/media/js/firefox/whatsnew/experiment-whatsnew-68-enGB.js
@@ -30,11 +30,11 @@
         var deckard = new Mozilla.TrafficCop({
             id: 'experiment_firefox_whatsnew_68',
             variations: {
-                'v=a': 14,  // control
-                'v=b': 14,  // new layout, light
-                'v=c': 14,  // new layout, dark
-                'v=d': 14,  // notification favicon
-                'v=e': 14   // monitor CTA
+                'v=a': 2,  // control
+                'v=b': 2,  // new layout, light
+                'v=c': 2,  // new layout, dark
+                'v=d': 2,  // notification favicon
+                'v=e': 2   // monitor CTA
             }
         });
 

--- a/media/js/firefox/whatsnew/experiment-whatsnew-68-enUS.js
+++ b/media/js/firefox/whatsnew/experiment-whatsnew-68-enUS.js
@@ -30,11 +30,11 @@
         var deckard = new Mozilla.TrafficCop({
             id: 'experiment_firefox_whatsnew_68',
             variations: {
-                'v=a': 1,  // control
-                'v=b': 1,  // new layout, light
-                'v=c': 1,  // new layout, dark
-                'v=d': 1,  // notification favicon
-                'v=e': 1   // monitor CTA
+                'v=a': 5,  // control
+                'v=b': 5,  // new layout, light
+                'v=c': 5,  // new layout, dark
+                'v=d': 5,  // notification favicon
+                'v=e': 5   // monitor CTA
             }
         });
 

--- a/media/js/firefox/whatsnew/experiment-whatsnew-68-fr.js
+++ b/media/js/firefox/whatsnew/experiment-whatsnew-68-fr.js
@@ -30,11 +30,11 @@
         var deckard = new Mozilla.TrafficCop({
             id: 'experiment_firefox_whatsnew_68',
             variations: {
-                'v=a': 3,  // control
-                'v=b': 3,  // new layout, light
-                'v=c': 3,  // new layout, dark
-                'v=d': 3,  // notification favicon
-                'v=e': 3   // monitor CTA
+                'v=a': 14,  // control
+                'v=b': 14,  // new layout, light
+                'v=c': 14,  // new layout, dark
+                'v=d': 14,  // notification favicon
+                'v=e': 14   // monitor CTA
             }
         });
 

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -1024,9 +1024,9 @@
       "files": [
         "js/libs/mozilla-traffic-cop.js",
         "js/base/mozilla-client.js",
-        "js/firefox/whatsnew/experiment-whatsnew-68-enUSGB.js"
+        "js/firefox/whatsnew/experiment-whatsnew-68-enUS.js"
       ],
-      "name": "experiment-whatsnew-68-enUSGB"
+      "name": "experiment-whatsnew-68-enUS"
     },
     {
       "files": [
@@ -1035,6 +1035,14 @@
         "js/firefox/whatsnew/experiment-whatsnew-68-enCA.js"
       ],
       "name": "experiment-whatsnew-68-enCA"
+    },
+    {
+      "files": [
+        "js/libs/mozilla-traffic-cop.js",
+        "js/base/mozilla-client.js",
+        "js/firefox/whatsnew/experiment-whatsnew-68-enGB.js"
+      ],
+      "name": "experiment-whatsnew-68-enGB"
     },
     {
       "files": [


### PR DESCRIPTION
## Description
Actual traffic to the experiment (see original issue #7457 ) has been lower than anticipated (possibly as a result of some other instrumentation issues recently uncovered) so we need to bump up the percentages to reach statistical significance in a timely manner.

The new traffic split for each variant, in each locale:

- en-US: 5%
- en-CA: 14%
- en-GB: 2%
- de: 10%
- fr: 14%

This also splits US and GB since they're different percentages now.

## Issue / Bugzilla link
#7547 

