### PR TITLE
Implement Generic CTA datalayer attributes (Fixes #7541)

### DIFF
--- a/bedrock/base/templates/includes/protocol/navigation/index.html
+++ b/bedrock/base/templates/includes/protocol/navigation/index.html
@@ -29,7 +29,7 @@
           {% endif %}
           {% if not hide_nav_get_account_button %}
             <div class="c-navigation-fxa-cta-container">
-              <a class="c-navigation-fxa-cta mzp-c-button mzp-t-secondary mzp-t-small mzp-t-product js-fxa-cta-link" {{ fxa_link_fragment(entrypoint='mozilla.org-globalnav', action='signup', utm_params={'campaign': 'globalnav', 'content': 'get-firefox-account', 'medium': 'referral', 'source': 'www.mozilla.org'}) }} data-link-name="Get a Firefox Account" data-link-type="FxA-Sync" data-cta-position="secondary cta" data-alt-href="{{ url('firefox.accounts') }}">
+              <a class="c-navigation-fxa-cta mzp-c-button mzp-t-secondary mzp-t-small mzp-t-product js-fxa-cta-link" {{ fxa_link_fragment(entrypoint='mozilla.org-globalnav', action='signup', utm_params={'campaign': 'globalnav', 'content': 'get-firefox-account', 'medium': 'referral', 'source': 'www.mozilla.org'}) }} data-cta-text="Get a Firefox Account" data-cta-type="FxA-Sync" data-cta-position="Navigation" data-alt-href="{{ url('firefox.accounts') }}">
                 {{ _('Get a Firefox Account') }}
               </a>
               <p class="c-navigation-fxa-cta-small-link"><a data-link-type="nav" data-link-name="Check out the Benefits" href="{{ url('firefox.accounts') }}">{{ _('Check out the Benefits') }}</a></p>

--- a/bedrock/base/templates/macros.html
+++ b/bedrock/base/templates/macros.html
@@ -250,13 +250,13 @@
 {%- endmacro %}
 
 {% macro fxa_cta_link(entrypoint, campaign, content, source, button_class, button_location, button_text, account_id, action='signin', medium='referral') %}
-  <a {{ fxa_link_fragment(entrypoint=entrypoint, action="{{ action }}", utm_params={'campaign': campaign, 'content': (content or request.path_info), 'source': source, 'medium': medium }) }} class="js-fxa-cta-link {{ button_class }}" data-link-name="Create account" data-link-type="FxA-Sync" data-cta-position="{{ button_location }}" id="{{ account_id }}">
+  <a {{ fxa_link_fragment(entrypoint=entrypoint, action="{{ action }}", utm_params={'campaign': campaign, 'content': (content or request.path_info), 'source': source, 'medium': medium }) }} class="js-fxa-cta-link {{ button_class }}" data-cta-text="Create account" data-cta-type="FxA-Sync" data-cta-position="{{ button_location }}" id="{{ account_id }}">
     {{ button_text }}
   </a>
 {%- endmacro %}
 
 {% macro monitor_button(entrypoint='', utm_source='', utm_campaign='', utm_content='', button_text='', button_class='mzp-c-button mzp-t-product') -%}
-  <a data-action="{{ settings.FXA_ENDPOINT }}" href="https://monitor.firefox.com/oauth/init?utm_source={{ utm_source }}&utm_campaign={{ utm_campaign }}&utm_content={{ utm_content }}&form_type=email&entrypoint={{ entrypoint }}" class="{{ button_class }}" id="fxa-monitor-submit" data-link-name="Continue" data-link-type="button">
+  <a data-action="{{ settings.FXA_ENDPOINT }}" href="https://monitor.firefox.com/oauth/init?utm_source={{ utm_source }}&utm_campaign={{ utm_campaign }}&utm_content={{ utm_content }}&form_type=email&entrypoint={{ entrypoint }}" class="{{ button_class }}" id="fxa-monitor-submit" data-cta-text="Sign In to Monitor" data-cta-type="FxA-Monitor">
     {% if button_text %}
       {{ button_text }}
     {% else %}
@@ -354,12 +354,12 @@
         {% endtrans %}
       </p>
 
-      <button 
-        type="submit" 
-        class="{{ button_class }}" 
-        id="fxa-email-form-submit" 
-        data-cta-type="FxA-Sync" 
-        data-cta-text="Register" 
+      <button
+        type="submit"
+        class="{{ button_class }}"
+        id="fxa-email-form-submit"
+        data-cta-type="FxA-Sync"
+        data-cta-text="Register"
         data-cta-position="Primary"
       >
       {% if button_text %}

--- a/bedrock/firefox/templates/firefox/accounts-2019.html
+++ b/bedrock/firefox/templates/firefox/accounts-2019.html
@@ -109,19 +109,19 @@
         </a>
       </li>
       <li class="c-product-list-item t-product-lockwise">
-        <a href="https://lockwise.firefox.com?utm_source={{ _utm_source }}&amp;utm_medium=referral&amp;utm_campaign={{ _utm_campaign }}&amp;utm_content=product-list-item&amp;entrypoint={{ _entrypoint }}" data-link-name="Firefox Lockwise" data-link-type="link">
+        <a href="https://lockwise.firefox.com?utm_source={{ _utm_source }}&amp;utm_medium=referral&amp;utm_campaign={{ _utm_campaign }}&amp;utm_content=product-list-item&amp;entrypoint={{ _entrypoint }}" data-cta-text="Firefox Lockwise" data-cta-type="FxA-Lockwise">
           <h3 class="c-product-list-title">Firefox <span>Lockwise</span></h3>
           <p class="c-product-list-desc">{{ _('Keep your passwords protected and portable.') }}</p>
         </a>
       </li>
       <li class="c-product-list-item t-product-monitor">
-        <a href="https://monitor.firefox.com?utm_source={{ _utm_source }}&amp;utm_medium=referral&amp;utm_campaign={{ _utm_campaign }}&amp;utm_content=product-list-item&amp;entrypoint={{ _entrypoint }}" data-link-name="Firefox Monitor" data-link-type="link">
+        <a href="https://monitor.firefox.com?utm_source={{ _utm_source }}&amp;utm_medium=referral&amp;utm_campaign={{ _utm_campaign }}&amp;utm_content=product-list-item&amp;entrypoint={{ _entrypoint }}" data-cta-text="Firefox Monitor" data-cta-type="FxA-Monitor">
           <h3 class="c-product-list-title">Firefox <span>Monitor</span></h3>
           <p class="c-product-list-desc">{{ _('Get a lookout for data breaches.') }}</p>
         </a>
       </li>
       <li class="c-product-list-item t-product-send">
-        <a href="https://send.firefox.com?utm_source={{ _utm_source }}&amp;utm_medium=referral&amp;utm_campaign={{ _utm_campaign }}&amp;utm_content=product-list-item&amp;entrypoint={{ _entrypoint }}" data-link-name="Firefox Send" data-link-type="link">
+        <a href="https://send.firefox.com?utm_source={{ _utm_source }}&amp;utm_medium=referral&amp;utm_campaign={{ _utm_campaign }}&amp;utm_content=product-list-item&amp;entrypoint={{ _entrypoint }}" data-cta-text="Firefox Send" data-cta-type="FxA-Sync">
           <h3 class="c-product-list-title">Firefox <span>Send</span></h3>
           <p class="c-product-list-desc">{{ _('Share large files without prying eyes.') }}</p>
         </a>

--- a/bedrock/firefox/templates/firefox/accounts.html
+++ b/bedrock/firefox/templates/firefox/accounts.html
@@ -313,7 +313,7 @@
             button_text=_('Create an Account'))
           }}
 
-          <p class="fxa-signin">{{ _('Already have an account?') }} <a {{ fxa_link_fragment(entrypoint='mozilla.org-accounts_page', action='signin', utm_params={'campaign': 'fxa-embedded-form', 'content': '/firefox/accounts/', 'source': 'accounts-page'}) }} class="js-fxa-cta-link">{{ _('Sign In') }}</a></p>
+          <p class="fxa-signin">{{ _('Already have an account?') }} <a {{ fxa_link_fragment(entrypoint='mozilla.org-accounts_page', action='signin', utm_params={'campaign': 'fxa-embedded-form', 'content': '/firefox/accounts/', 'source': 'accounts-page'}) }} data-cta-type="FxA-Sync" data-cta-text="Sign In" data-cta-position="Secondary" class="js-fxa-cta-link">{{ _('Sign In') }}</a></p>
         </div>
       </div>
 

--- a/bedrock/firefox/templates/firefox/concerts.html
+++ b/bedrock/firefox/templates/firefox/concerts.html
@@ -106,11 +106,11 @@
                     <input type="email" name="email" required placeholder="yourname@example.com">
                   </p>
                   <p>
-                    <button type="submit" class="mzp-c-button mzp-t-product" id="fxa-email-form-submit" data-button-name="Create an Account">Create an Account</button>
+                    <button type="submit" class="mzp-c-button mzp-t-product" id="fxa-email-form-submit" data-cta-type="FxA-Sync" data-cta-position="Primary">Create an Account</button>
                   </p>
                 </form>
 
-                <p class="signin">Already have a Firefox Account? <a id="fxa-sign-in" href="{{ settings.FXA_OAUTH_ENDPOINT }}/signup?client_id={{ settings.FXA_OAUTH_CLIENT_ID }}&scope=profile&action=email" rel="external">Sign in</a></p>
+                <p class="signin">Already have a Firefox Account? <a id="fxa-sign-in" href="{{ settings.FXA_OAUTH_ENDPOINT }}/signup?client_id={{ settings.FXA_OAUTH_CLIENT_ID }}&scope=profile&action=email" data-cta-type="FxA-Sync" data-cta-position="Primary" rel="external">Sign in</a></p>
               </div>
             </div>{#-- /.form-content --#}
 

--- a/bedrock/firefox/templates/firefox/new/scene1.html
+++ b/bedrock/firefox/templates/firefox/new/scene1.html
@@ -165,7 +165,7 @@
     utm_term='existing-users')
   }}
 
-  <p class="fxa-signin">{{ _('Already have an account?') }} <a {{ fxa_link_fragment(entrypoint='mozilla.org-firefox_new', utm_params={'campaign': 'fxa-embedded-form', 'content': '/firefox/new/', 'source': 'download-page'}) }} class="js-fxa-cta-link">{{ _('Sign In') }}</a></p>
+  <p class="fxa-signin">{{ _('Already have an account?') }} <a {{ fxa_link_fragment(entrypoint='mozilla.org-firefox_new', utm_params={'campaign': 'fxa-embedded-form', 'content': '/firefox/new/', 'source': 'download-page'}) }} class="js-fxa-cta-link" data-cta-type="FxA-Sync">{{ _('Sign In') }}</a></p>
 
   {{ download_firefox(dom_id='download-fxa-modal', alt_copy=_('Download Anyway'), button_color='button-hollow button-blue', locale_in_transition=True, download_location='other') }}
 </div>

--- a/bedrock/newsletter/templates/newsletter/includes/form-protocol.html
+++ b/bedrock/newsletter/templates/newsletter/includes/form-protocol.html
@@ -86,7 +86,7 @@
       </div>
 
       <p class="mzp-c-form-submit">
-        <button type="submit" id="newsletter-submit" class="mzp-c-button {{ button_class }}" data-button-name="Newsletter Sign Up">
+        <button type="submit" id="newsletter-submit" class="mzp-c-button {{ button_class }}" data-cta-type="Newsletter-{{ id }}" data-cta-text="Newsletter Sign Up">
           {% if submit_text %}
             {{ submit_text }}
           {% else %}

--- a/bedrock/newsletter/templates/newsletter/includes/form.html
+++ b/bedrock/newsletter/templates/newsletter/includes/form.html
@@ -76,7 +76,7 @@
     </div>
 
     <div class="form-submit">
-      <button type="submit" id="footer_email_submit" class="form-button {{ button_class }}" data-button-name="Newsletter Sign Up">
+      <button type="submit" id="footer_email_submit" class="form-button {{ button_class }}" data-cta-type="Newsletter-{{ id }}" data-cta-text="Newsletter Sign Up">
         {% if submit_text %}
           {{ submit_text }}
         {% else %}

--- a/docs/analytics.rst
+++ b/docs/analytics.rst
@@ -2,6 +2,8 @@
 .. License, v. 2.0. If a copy of the MPL was not distributed with this
 .. file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+.. _analytics:
+
 ============================
 Analytics
 ============================
@@ -54,27 +56,17 @@ Since GTM listeners pass the interacted element object to the dataLayer, the use
 
     When adding any new elements to a Bedrock page, please follow the below guidelines to ensure accurate analytics tracking.
 
-.. Important::
+For all generic CTA links and <button> elements, add these data attributes (* indicates a required attribute):
 
-    Do not use `data-link-type` and `data-button-name` attributes together or the event will be captured twice by GA.
-
-For all nav, footer, and CTA/button link elements, add these data attributes:
-
-+--------------------------+--------------------------------+
-|    Data Attribute        |        Expected Value          |
-+==========================+================================+
-|    data-link-type        | 'nav', 'footer', or 'button'   |
-+--------------------------+--------------------------------+
-|    data-link-name        | name or text of the link       |
-+--------------------------+--------------------------------+
-
-For all button elements, add this data attribute:
-
-+--------------------------+--------------------------------+
-|    Data Attribute        |        Expected Value          |
-+==========================+================================+
-|   data-button-name       | name or text of the link       |
-+--------------------------+--------------------------------+
++--------------------------+---------------------------------------------------------------------+
+|    Data Attribute        |        Expected Value                                               |
++==========================+=====================================================================+
+|    data-cta-type *       | Link type (e.g. 'Navigation', 'Footer', or 'Button')                |
++--------------------------+---------------------------------------------------------------------+
+|    data-cta-text         | name or text of the link                                            |
++--------------------------+---------------------------------------------------------------------+
+|    data-cta-position     | Location of CTA on the page (e.g. 'Primary', 'Secondary', 'Header') |
++--------------------------+---------------------------------------------------------------------+
 
 For all download buttons, add these data attributes:
 
@@ -85,18 +77,20 @@ For all download buttons, add these data attributes:
 +--------------------------+--------------------------------+
 |    data-download-os      | name or text of the link       |
 +--------------------------+--------------------------------+
-|   data-download-version  |'standard', 'developer', 'beta' |
+|    data-download-version |'standard', 'developer', 'beta' |
 +--------------------------+--------------------------------+
 
-For all links to accounts.firefox.com use these data attributes:
+For all links to accounts.firefox.com use these data attributes (* indicates a required attribute):
 
-+--------------------------+--------------------------------+
-|    Data Attribute        |        Expected Value          |
-+==========================+================================+
-|   data-link-type         | FxA-ServiceName (eg. FxA-Sync) |
-+--------------------------+--------------------------------+
-|   data-link-name         | name or text of the link       |
-+--------------------------+--------------------------------+
++--------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+|    Data Attribute        |        Expected Value                                                                                                                                                                                              |
++==========================+====================================================================================================================================================================================================================+
+|    data-cta-type *       | FxA-ServiceName (e.g. 'FxA-Sync', 'FxA-Monitor', 'FxA-Lockwise')                                                                                                                                                   |
++--------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+|    data-cta-text         | Name or text of the link (e.g. 'Sign Up', 'Join Now', 'Start Here'). We use this when the link text is not useful, as is the case with many FxA forms that say, 'Continue'. We replace 'Continue' with 'Register'. |
++--------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+|    data-cta-position     | Location of CTA on the page (e.g. 'Primary', 'Secondary', 'Header')                                                                                                                                                |
++--------------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 
 For all conditional banners, add the following calls.
 
@@ -154,18 +148,11 @@ When doing a/b tests configure something like the following.
 Some notes on how this looks in GA
 ----------------------------------
 
-``data-link-type="button"`` and ``data-link-name=""`` trigger a generic link
+``data-cta-type=""`` and ``data-cta-name=""`` trigger a generic link / buton
 click with the following structure:
 
     | Event Category: {{page ID}} Interactions
-    | Event Action: {{data-link-type}} click
-    | Event Label: {{data-link-name}}
-
-Any element that has a ``data-button-name=""`` triggers an event with this
-structure:
-
-    | Event Category: {{page ID}} Interactions
-    | Event Action: button click
-    | Event Label: {{data-button-name}}
+    | Event Action: {{data-cta-type}} click
+    | Event Label: {{data-cta-name}}
 
 

--- a/docs/firefox-accounts.rst
+++ b/docs/firefox-accounts.rst
@@ -108,18 +108,9 @@ If there are valid UTM parameters in the URL we should copy them onto the link t
 
 Adding the class `js-fxa-link-cta` will trigger the global JavaScript function that handles this. If you use the `fxa_cta_link` macro to generate the link this is added automatically. If you used `fxa_link_fragment` you will need to add it manually.
 
-DataLayer
-~~~~~~~~~
 
-For datalayer values in FxA links, please use the following standard format: `FxA-ServiceName`. Examples from our existing site:
+Google Analytics Guidelines
+---------------------------
 
-```
-data-link-type="FxA-Sync"
-```
-
-We may add other data link types later.
-
-You can combine this with `data-link-name` to provide more information.
-
-Do not use `data-link-type` and `data-button-name` together, GA will log two events instead of one.
+For GTM datalayer attribute values in FxA links, please use the :ref:`analytics<analytics>` documentation.
 


### PR DESCRIPTION
## Description
- Updates datalayer attributes to new spec provided in the issue.
- Documents the new spec.

## Issue / Bugzilla link
#7541

## Testing

The following templates should all conform to the new spec:

- [ ] macros.html
- [ ] /firefox/accounts/ (lockwise/send/monitor CTAs in secondary content block)
- [ ] global navigation ("Get a Firefox Account" CTA)
- [ ] Newsletter signup in newsletter/includes/form and form-protocol