### PR TITLE
Update metrics-flow parameters and stop double-requesting flow IDs

### DIFF
--- a/bedrock/base/templates/macros.html
+++ b/bedrock/base/templates/macros.html
@@ -307,9 +307,10 @@
     <input type="hidden" name="service" value="{{ service }}" />
     <input type="hidden" name="entrypoint" value="{{ entrypoint }}" id="fxa-email-form-entrypoint" />
     <input type="hidden" name="form_type" value="email" />
-    {# flow_id and flow_begin_time will be populated via JS on page load #}
+    {# device_id, flow_id and flow_begin_time will be populated via JS on page load #}
     <input type="hidden" name="flow_id" value="" />
     <input type="hidden" name="flow_begin_time" value="" />
+    <input type="hidden" name="device_id" value="" />
     <input type="hidden" name="utm_source" value={{ entrypoint }} id="fxa-email-form-utm-source" />
     <input type="hidden" name="utm_medium" value="referral" id="fxa-email-form-utm-medium" />
 

--- a/bedrock/firefox/templates/firefox/concerts.html
+++ b/bedrock/firefox/templates/firefox/concerts.html
@@ -95,6 +95,7 @@
                   <input type="hidden" name="state" id="state" value="">
                   <input type="hidden" name="flow_id" id="flow_id" value="">
                   <input type="hidden" name="flow_begin_time" id="flow_begin_time" value="">
+                  <input type="hidden" name="device_id" id="device_id" value="">
                   <input type="hidden" name="action" value="email">
                   <input type="hidden" name="utm_source" id="utm_source" value="mozilla.org">
                   <input type="hidden" name="utm_medium" id="utm_medium" value="concerts-landing-page">

--- a/docs/firefox-accounts.rst
+++ b/docs/firefox-accounts.rst
@@ -46,6 +46,7 @@ The templates's respective JavaScript and CSS bundles should also include the fo
 .. code-block:: text
 
     js/base/mozilla-fxa-form.js
+    js/base/mozilla-fxa-form-init.js
 
 This script will automatically handle things like tracking metrics flow (see the Tracking Signups section below), as well as configuring Sync and distribution ID (e.g. the China re-pack) for Firefox browsers.
 
@@ -206,11 +207,12 @@ A button can then be invoked using:
 
     {{ monitor_button(entrypoint='mozilla.org-firefox-accounts')}}
 
-The templates's respective JavaScript bundle should also include the following dependency:
+The templates's respective JavaScript bundle should also include the following dependencies:
 
 .. code-block:: text
 
     js/base/mozilla-monitor-button.js
+    js/base/mozilla-monitor-button-init.js
 
 This script will automatically handle things like tracking metrics flow (in the same way we do for https://accounts.firefox.com).
 

--- a/media/js/base/mozilla-fxa-form-init.js
+++ b/media/js/base/mozilla-fxa-form-init.js
@@ -1,0 +1,9 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+(function() {
+    'use strict';
+
+    Mozilla.FxaForm.init();
+})();

--- a/media/js/base/mozilla-fxa-form.js
+++ b/media/js/base/mozilla-fxa-form.js
@@ -7,80 +7,88 @@ if (typeof window.Mozilla === 'undefined') {
     window.Mozilla = {};
 }
 
-Mozilla.FxaForm = (function(Mozilla) {
+(function(Mozilla) {
     'use strict';
 
-    var fxaForm = document.getElementById('fxa-email-form');
-    var fxaSubmitButton = document.getElementById('fxa-email-form-submit');
-    var fxaFormContextField = fxaForm.querySelector('[name="context"]');
-    var fxaFormServiceField = fxaForm.querySelector('[name="service"]');
-    var supportsFetch = 'fetch' in window;
+    var FxaForm = {};
 
-    // swap form action for Fx China re-pack
-    function init() {
-        // disable form while we check distribution
-        fxaSubmitButton.disabled = true;
+    FxaForm.init= function(){
+        var fxaForm = document.getElementById('fxa-email-form');
+        var fxaSubmitButton = document.getElementById('fxa-email-form-submit');
+        var fxaFormContextField = fxaForm.querySelector('[name="context"]');
+        var fxaFormServiceField = fxaForm.querySelector('[name="service"]');
+        var supportsFetch = 'fetch' in window;
 
-        var mozillaonlineAction = fxaForm.dataset.mozillaonlineAction;
+        // swap form action for Fx China re-pack
+        function init() {
+            // disable form while we check distribution
+            fxaSubmitButton.disabled = true;
 
-        if (mozillaonlineAction) {
-            Mozilla.Client.getFirefoxDetails(function(data) {
-                // only switch to China re-pack URL if UITour call is successful
-                // (marked by data.accurate being true)
-                if (data.accurate && data.distribution && data.distribution.toLowerCase() === 'mozillaonline') {
-                    fxaForm.action = mozillaonlineAction;
-                }
+            var mozillaonlineAction = fxaForm.dataset.mozillaonlineAction;
 
+            if (mozillaonlineAction) {
+                Mozilla.Client.getFirefoxDetails(function(data) {
+                    // only switch to China re-pack URL if UITour call is successful
+                    // (marked by data.accurate being true)
+                    if (data.accurate && data.distribution && data.distribution.toLowerCase() === 'mozillaonline') {
+                        fxaForm.action = mozillaonlineAction;
+                    }
+
+                    fetchTokens();
+                });
+            } else {
                 fetchTokens();
+            }
+        }
+
+        // get tokens from FxA for analytics purposes
+        function fetchTokens() {
+            if (!supportsFetch) {
+                return;
+            }
+
+            fxaSubmitButton.disabled = false;
+
+            var destURL = fxaForm.getAttribute('action') + 'metrics-flow';
+            var entrypoint = document.getElementById('fxa-email-form-entrypoint');
+            var utmSource = document.getElementById('fxa-email-form-utm-source');
+            var utmCampaign = document.getElementById('fxa-email-form-utm-campaign');
+
+            // add required params to the token fetch request
+            destURL += '?form_type=email';
+            destURL += '&entrypoint=' + entrypoint.value;
+            destURL += '&utm_source=' + utmSource.value;
+
+            // pass utm_campaign if available
+            if (utmCampaign) {
+                destURL += '&utm_campaign=' + utmCampaign.value;
+            }
+
+            fetch(destURL).then(function(resp) {
+                return resp.json();
+            }).then(function(r) {
+                fxaForm.querySelector('[name="device_id"]').value = r.deviceId;
+                fxaForm.querySelector('[name="flow_id"]').value = r.flowId;
+                fxaForm.querySelector('[name="flow_begin_time"]').value = r.flowBeginTime;
+            }).catch(function() {
+                // silently fail, leaving flow_id and flow_begin_time as default empty value
             });
-        } else {
-            fetchTokens();
-        }
-    }
-
-    // get tokens from FxA for analytics purposes
-    function fetchTokens() {
-        if (!supportsFetch) {
-            return;
         }
 
-        fxaSubmitButton.disabled = false;
-
-        var destURL = fxaForm.getAttribute('action') + 'metrics-flow';
-        var entrypoint = document.getElementById('fxa-email-form-entrypoint');
-        var utmSource = document.getElementById('fxa-email-form-utm-source');
-        var utmCampaign = document.getElementById('fxa-email-form-utm-campaign');
-
-        // add required params to the token fetch request
-        destURL += '?form_type=email';
-        destURL += '&entrypoint=' + entrypoint.value;
-        destURL += '&utm_source=' + utmSource.value;
-
-        // pass utm_campaign if available
-        if (utmCampaign) {
-            destURL += '&utm_campaign=' + utmCampaign.value;
+        if (fxaForm) {
+            // Sync is Firefox for desktop only.
+            if (Mozilla.Client.isFirefoxDesktop) {
+                init();
+            } else {
+                // Omit the fields required for sync.
+                // This allows non-Firefoxes to create accounts.
+                fxaForm.removeChild(fxaFormContextField);
+                fxaForm.removeChild(fxaFormServiceField);
+                fetchTokens();
+            }
         }
+    };
 
-        fetch(destURL).then(function(resp) {
-            return resp.json();
-        }).then(function(r) {
-            fxaForm.querySelector('[name="flow_id"]').value = r.flowId;
-            fxaForm.querySelector('[name="flow_begin_time"]').value = r.flowBeginTime;
-        }).catch(function() {
-            // silently fail, leaving flow_id and flow_begin_time as default empty value
-        });
-    }
+    window.Mozilla.FxaForm = FxaForm;
 
-    if (fxaForm) {
-        // Sync is Firefox for desktop only.
-        if (Mozilla.Client.isFirefoxDesktop) {
-            init();
-        } else {
-            // Omit the fields required for sync.
-            // This allows non-Firefoxes to create accounts.
-            fxaForm.removeChild(fxaFormContextField);
-            fxaForm.removeChild(fxaFormServiceField);
-            fetchTokens();
-        }
-    }
 })(window.Mozilla);

--- a/media/js/base/mozilla-fxa-form.js
+++ b/media/js/base/mozilla-fxa-form.js
@@ -53,15 +53,25 @@ if (typeof window.Mozilla === 'undefined') {
             var entrypoint = document.getElementById('fxa-email-form-entrypoint');
             var utmSource = document.getElementById('fxa-email-form-utm-source');
             var utmCampaign = document.getElementById('fxa-email-form-utm-campaign');
+            var utmContent = document.getElementById('fxa-email-form-utm-content');
+            var utmTerm = document.getElementById('fxa-email-form-utm-term');
 
             // add required params to the token fetch request
             destURL += '?form_type=email';
             destURL += '&entrypoint=' + entrypoint.value;
             destURL += '&utm_source=' + utmSource.value;
 
-            // pass utm_campaign if available
+            // add optional utm params to the token fetch request
             if (utmCampaign) {
                 destURL += '&utm_campaign=' + utmCampaign.value;
+            }
+
+            if (utmContent) {
+                destURL += '&utm_content=' + utmContent.value;
+            }
+
+            if (utmTerm) {
+                destURL += '&utm_term=' + utmTerm.value;
             }
 
             fetch(destURL).then(function(resp) {

--- a/media/js/base/mozilla-monitor-button-init.js
+++ b/media/js/base/mozilla-monitor-button-init.js
@@ -1,0 +1,9 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+(function() {
+    'use strict';
+
+    Mozilla.MonitorButton.init();
+})();

--- a/media/js/base/mozilla-monitor-button.js
+++ b/media/js/base/mozilla-monitor-button.js
@@ -38,17 +38,22 @@ if (typeof window.Mozilla === 'undefined') {
         var params = window._SearchParams.queryStringToObject(buttonURLParams);
 
         // add required params to the token fetch request
-        if (params.utm_content) {
-            destURL += '&utm_content=' + params.utm_content;
-        }
+        destURL += '?entrypoint=' + params.entrypoint;
+        destURL += '&form_type=' + params.form_type;
+        destURL += '&utm_source=' + params.utm_source;
 
+        // add optional utm params to the token fetch request
         if (params.utm_campaign) {
             destURL += '&utm_campaign=' + params.utm_campaign;
         }
 
-        destURL += '?entrypoint=' + params.entrypoint;
-        destURL += '&form_type=' + params.form_type;
-        destURL += '&utm_source=' + params.utm_source;
+        if (params.utm_content) {
+            destURL += '&utm_content=' + params.utm_content;
+        }
+
+        if (params.utm_term) {
+            destURL += '&utm_term=' + params.utm_term;
+        }
 
         fetch(destURL).then(function(resp) {
             return resp.json();

--- a/media/js/base/mozilla-monitor-button.js
+++ b/media/js/base/mozilla-monitor-button.js
@@ -7,30 +7,62 @@ if (typeof window.Mozilla === 'undefined') {
     window.Mozilla = {};
 }
 
-Mozilla.MonitorButton = (function() {
+(function() {
     'use strict';
 
-    var monitorButton = document.getElementById('fxa-monitor-submit');
+    var MonitorButton = {};
 
-    // fetch request
-    var supportsFetch = 'fetch' in window;
+    MonitorButton.init = function(buttonId){
 
-    if (!supportsFetch || !monitorButton) {
-        return;
-    }
+        // check for custom buttonId, used in case of multiple buttons.
+        if(!buttonId){
+            buttonId = 'fxa-monitor-submit';
+        }
 
-    var buttonURL = monitorButton.getAttribute('href');
-    var destURL = monitorButton.getAttribute('data-action') + 'metrics-flow';
+        var monitorButton = document.getElementById(buttonId);
 
-    fetch(destURL).then(function(resp) {
-        return resp.json();
-    }).then(function(r) {
-        // add retrieved flowBeginTime and flowId values to cta url
-        buttonURL += '&flowBeginTime=' + r.flowBeginTime;
-        buttonURL += '&flowId=' + r.flowId;
-        monitorButton.setAttribute('href', buttonURL);
-    }).catch(function() {
-        // silently fail, leaving flow_id and flow_begin_time as default empty value
-    });
+        // fetch request
+        var supportsFetch = 'fetch' in window;
+
+        if (!supportsFetch || !monitorButton) {
+            return;
+        }
+
+        var buttonURL = monitorButton.getAttribute('href');
+        // strip url to everything after `?`
+        var buttonURLParams = buttonURL.match(/\?(.*)/)[1];
+
+        var destURL = monitorButton.getAttribute('data-action') + 'metrics-flow';
+
+        // collect values from monitor button
+        var params = window._SearchParams.queryStringToObject(buttonURLParams);
+
+        // add required params to the token fetch request
+        if (params.utm_content) {
+            destURL += '&utm_content=' + params.utm_content;
+        }
+
+        if (params.utm_campaign) {
+            destURL += '&utm_campaign=' + params.utm_campaign;
+        }
+
+        destURL += '?entrypoint=' + params.entrypoint;
+        destURL += '&form_type=' + params.form_type;
+        destURL += '&utm_source=' + params.utm_source;
+
+        fetch(destURL).then(function(resp) {
+            return resp.json();
+        }).then(function(r) {
+            // add retrieved deviceID, flowBeginTime and flowId values to cta url
+            buttonURL += '&deviceId=' + r.deviceId;
+            buttonURL += '&flowBeginTime=' + r.flowBeginTime;
+            buttonURL += '&flowId=' + r.flowId;
+            monitorButton.setAttribute('href', buttonURL);
+        }).catch(function() {
+            // silently fail: deviceId, flowBeginTime, flowId are not added to url.
+        });
+    };
+
+    window.Mozilla.MonitorButton = MonitorButton;
 })();
 

--- a/media/js/firefox/accounts-2019.js
+++ b/media/js/firefox/accounts-2019.js
@@ -41,4 +41,17 @@
         fxaSigninLink.href = finalFxaSigninURI;
     }
 
+    // Prevent double-requesting Flow IDs, inits FxaForm even on non-firefox browsers.
+    if (Mozilla.Client.isFirefoxDesktop) {
+        Mozilla.Client.getFxaDetails(function(details) {
+            if (details.setup) {
+                Mozilla.MonitorButton.init();
+            } else {
+                Mozilla.FxaForm.init();
+            }
+        });
+    } else {
+        Mozilla.FxaForm.init();
+    }
+
 })(window.Mozilla);

--- a/media/js/firefox/concerts.js
+++ b/media/js/firefox/concerts.js
@@ -12,7 +12,6 @@ function onYouTubeIframeAPIReady() {
     Mozilla.firefoxConcertsOnYouTubeIframeAPIReady();
 }
 
-
 (function(Mozilla) {
     'use strict';
 
@@ -28,7 +27,7 @@ function onYouTubeIframeAPIReady() {
     // take params from URL and pass through signup button
     ConcertPage.passThroughParams = function() {
         var params = window.location.search.slice(1);
-        ['source','medium','campaign','content'].forEach(function(p) {
+        ['source', 'medium', 'campaign', 'content'].forEach(function(p) {
             var param = 'utm_' + p;
             if (params.indexOf(param) >= 0) {
                 var regex = RegExp(param + '=([^\#\&\?]+).*$');
@@ -178,7 +177,6 @@ function onYouTubeIframeAPIReady() {
     };
     window.Mozilla.ConcertPage = ConcertPage;
 
-
     var stateStorageKey = 'fxaOauthState';
     var verifiedStorageKey = 'fxaOauthVerified';
     var cookieDays = 14;
@@ -197,11 +195,13 @@ function onYouTubeIframeAPIReady() {
         Next, we retrieve metrics information from an asynchronous FxA call. When this
         call completes, the submit button on the form is enabled.
     */
+
     function initOauth() {
         var fxaFormWrapper = document.getElementById('fxa-form-wrapper');
         var metricsFlowEndpoint = fxaFormWrapper.getAttribute('data-fxa-metrics-endpoint');
         var flowIdField = document.getElementById('flow_id');
         var flowBeginTimeField = document.getElementById('flow_begin_time');
+        var deviceIdField = document.getElementById('device_id');
         var stateField = document.getElementById('state');
         var fxaSignIn = document.getElementById('fxa-sign-in');
 
@@ -236,10 +236,11 @@ function onYouTubeIframeAPIReady() {
             fetch(destURL).then(function(resp) {
                 return resp.json();
             }).then(function(r) {
+                deviceIdField.value = r.deviceId;
                 flowIdField.value = r.flowId;
                 flowBeginTimeField.value = r.flowBeginTime;
             }).catch(function() {
-                // silently fail, leaving flow_id and flow_begin_time as default empty value
+                // silently fail, leaving device_id, flow_id and flow_begin_time as default empty value
             });
         }
     }
@@ -299,7 +300,6 @@ function onYouTubeIframeAPIReady() {
         initializeClock('countdown-one', showtimeOne);
     }
 
-
     // Set up modal for the email privacy link
     var content = document.querySelector('.mzp-u-modal-content');
     var trigger = document.querySelector('.email-privacy-link');
@@ -319,7 +319,6 @@ function onYouTubeIframeAPIReady() {
             'eLabel': 'How will Mozilla use my email?'
         });
     }, false);
-
 
     // Video
     var videoLink = document.querySelector('.js-video-play');

--- a/media/js/firefox/whatsnew/account-conditional-ctas.js
+++ b/media/js/firefox/whatsnew/account-conditional-ctas.js
@@ -1,0 +1,16 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+(function(Mozilla) {
+    'use strict';
+
+    Mozilla.Client.getFxaDetails(function(details){
+        if(details.setup){
+            Mozilla.MonitorButton.init();
+        }else{
+            Mozilla.FxaForm.init();
+        }
+    });
+
+})(window.Mozilla);

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -939,6 +939,7 @@
         "js/base/mozilla-fxa.js",
         "js/base/mozilla-fxa-init.js",
         "js/base/mozilla-fxa-form.js",
+        "js/base/mozilla-fxa-form-init.js",
         "js/firefox/whatsnew/whatsnew-63.js"
       ],
       "name": "firefox_whatsnew_63"
@@ -959,6 +960,7 @@
         "js/base/mozilla-fxa.js",
         "js/base/mozilla-fxa-init.js",
         "js/base/mozilla-fxa-form.js",
+        "js/base/mozilla-fxa-form-init.js",
         "js/firefox/whatsnew/whatsnew-65.js"
       ],
       "name": "firefox_whatsnew_65"
@@ -976,6 +978,7 @@
         "js/base/mozilla-fxa.js",
         "js/base/mozilla-fxa-init.js",
         "js/base/mozilla-fxa-form.js",
+        "js/base/mozilla-fxa-form-init.js",
         "protocol/js/protocol-modal.js",
         "js/firefox/whatsnew/whatsnew-66.js"
       ],
@@ -987,6 +990,7 @@
         "js/base/mozilla-fxa.js",
         "js/base/mozilla-fxa-init.js",
         "js/base/mozilla-fxa-form.js",
+        "js/base/mozilla-fxa-form-init.js",
         "protocol/js/protocol-modal.js",
         "js/firefox/whatsnew/whatsnew-67.js"
       ],
@@ -999,7 +1003,8 @@
         "js/base/mozilla-fxa-init.js",
         "js/base/mozilla-fxa-form.js",
         "js/base/mozilla-monitor-button.js",
-        "js/firefox/whatsnew/up-to-date.js"
+        "js/firefox/whatsnew/up-to-date.js",
+        "js/firefox/whatsnew/account-conditional-ctas.js"
       ],
       "name": "firefox_whatsnew_67.0.5"
     },
@@ -1009,6 +1014,7 @@
         "js/base/mozilla-fxa.js",
         "js/base/mozilla-fxa-init.js",
         "js/base/mozilla-monitor-button.js",
+        "js/base/mozilla-monitor-button-init.js",
         "js/firefox/whatsnew/up-to-date.js"
       ],
       "name": "firefox_whatsnew_68E_monitor"
@@ -1088,6 +1094,7 @@
     {
       "files": [
         "js/base/mozilla-fxa-form.js",
+        "js/base/mozilla-fxa-form-init.js",
         "js/firefox/new/scene1_fxa_modal.js"
       ],
       "name": "firefox_new_scene1_fxa_modal"
@@ -1375,6 +1382,7 @@
         "js/base/mozilla-fxa.js",
         "js/base/mozilla-fxa-init.js",
         "js/base/mozilla-fxa-form.js",
+        "js/base/mozilla-fxa-form-init.js",
         "js/firefox/accounts.js"
       ],
       "name": "firefox_accounts"
@@ -1402,6 +1410,7 @@
     {
       "files": [
         "js/base/mozilla-fxa-form.js",
+        "js/base/mozilla-fxa-form-init.js",
         "js/firefox/firstrun/firstrun_quantum.js"
       ],
       "name": "firefox_firstrun_quantum"


### PR DESCRIPTION
## Description
Replaces #7546

## Issue / Bugzilla link
#7531
#7533
#7532

## Testing
This has already been reviewed pretty well. The additional commits make a bug fix that was breaking the monitor button flow request if an optional parameter was present, and also update the docs.