### PR TITLE
Add ConditionalGetMiddleware

### DIFF
--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -401,6 +401,7 @@ MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
     'bedrock.mozorg.middleware.MozorgRequestTimingMiddleware',
     'django_statsd.middleware.GraphiteMiddleware',
+    'django.middleware.http.ConditionalGetMiddleware',
     'corsheaders.middleware.CorsMiddleware',
     'bedrock.mozorg.middleware.VaryNoCacheMiddleware',
     'bedrock.base.middleware.BasicAuthMiddleware',


### PR DESCRIPTION
Brings back support for Etags and NotModified responses.  It seems support for these were lost in the Django 2 upgrade.

Fix #7617