### PR TITLE
Fix bug 1576673: Disable GA on Fx Privacy Notice

### DIFF
--- a/bedrock/privacy/templates/privacy/notices/firefox-quantum.html
+++ b/bedrock/privacy/templates/privacy/notices/firefox-quantum.html
@@ -12,3 +12,6 @@
   {{ super() }}
   {{ js_bundle('privacy_firefox') }}
 {% endblock %}
+
+{# disable GA on Fx Privacy Notice. Bug 1576673 #}
+{% block google_analytics %}{% endblock %}

--- a/bedrock/privacy/templates/privacy/notices/websites.html
+++ b/bedrock/privacy/templates/privacy/notices/websites.html
@@ -8,3 +8,6 @@
 {% block body_class %}mzp-t-mozilla format-none{% endblock%}
 
 {% block article_header_logo %}{{ static('img/trademarks/logo-mozm.png') }}{% endblock %}
+
+{# disable GA on the websites privacy policy. Bug 1576673 #}
+{% block google_analytics %}{% endblock %}


### PR DESCRIPTION
I could move this to a parent template and remove GA from all privacy notices since it's these notices where one learns about privacy options and opt-out procedures.