### PR TITLE
Trademark copy changes [fixed  #7622]

### DIFF
--- a/bedrock/foundation/templates/foundation/trademarks/distribution-policy.html
+++ b/bedrock/foundation/templates/foundation/trademarks/distribution-policy.html
@@ -4,16 +4,16 @@
 
 {% extends "foundation/base.html" %}
 
-{% block page_title %}{{ _('Distribution of Firefox with Mozilla Trademarks') }}{% endblock %}
+{% block page_title %}{{ _('Distribution Policy for Mozilla Software') }}{% endblock %}
 
 {% block article_title %}
-  {{ _('Distribution of Firefox with Mozilla Trademarks') }}
+  {{ _('Distribution Policy for Mozilla Software') }}
 {% endblock %}
 
 {% block article_content %}
   <p>
     {% trans license=url('mozorg.mpl.index') %}
-      What you can and cannot do with our Firefox software products and code – independent of our trademarks – is governed by a separate document, the <a href="{{ license }}">Mozilla Public License</a>. In turn, the Mozilla Public License does not contain any rules on our trademarks, as is expressly mentioned in its section 2.1. "Grants":
+      What you can and cannot do with our software products and code – independent of our trademarks – is governed by the relevant software licenses. For example, most Firefox code is released under the <a href="{{ license }}">Mozilla Public License</a> version 2.0. The Mozilla Public License does not contain grant permission to use Mozilla trademarks, as is set out in its section 2.1. "Grants":
     {% endtrans %}
   </p>
 
@@ -22,12 +22,12 @@
   </blockquote>
 
   <p>
-    {% trans %}
-      If you wish to distribute Firefox branded with our trademarks, you must comply with the Mozilla Public License, the Mozilla Trademark Guidelines and either the below Unaltered Firefox Distribution Policy or the terms of a written distribution agreement with Mozilla.
+    {% trans trademark_guidlines=url('foundation.trademarks.policy') %}
+      In the following, the term “Mozilla software” refers to software developed and/or distributed by Mozilla or by one of its affiliates. If you wish to distribute Firefox and other Mozilla software branded with our trademarks, you must comply with the relevant software licenses, the <a href="{{ trademark_guidlines }}">Mozilla Trademark Guidelines</a> and either the Unaltered Software Distribution Policy or the terms of a written distribution agreement with Mozilla.
     {% endtrans %}
   </p>
 
-  <h2>{{ _('Unaltered Firefox Distribution Policy') }}</h2>
+  <h2>{{ _('Unaltered Software Distribution Policy') }}</h2>
 
   <p>
     {% trans mozorg=url('mozorg.home') %}
@@ -35,26 +35,28 @@
     {% endtrans %}
   </p>
   <ul class="mzp-u-list-styled">
-    <li>{{_('You may not charge for Firefox. That means:') }}
+    <li>{{_('You may not charge for the software. That means:') }}
       <ul>
         <li>{{ _('Distribution may not be subject to any fee.') }}</li>
         <li>{{ _('Distribution may not be tied to purchasing a product or service.') }}</li>
       </ul>
     </li>
 
-    <li>{{ _('You may not collect personal information in the context of your distribution of Firefox.') }}</li>
+    <li>{{ _('You may not collect personal information in the context of your distribution of the software.') }}</li>
 
-    <li>{{ _('You may not add to, remove, or change any part of Firefox, including the Mozilla trademarks themselves. For example, you may not add any extensions to Firefox.') }}</li>
+    <li>{{ _('You may not add to, remove, or change any part of the software, including the Mozilla trademarks themselves. For example, you may not add any extensions to Firefox.') }}</li>
 
-    <li>{{ _('You may not modify the installation process of Firefox or use it to install any other themes, plugins, extensions, or software.') }}</li>
+    <li>{{ _('You may not modify the installation process of the software or use it to install any other themes, plugins, extensions, or software.') }}</li>
 
     <li>
-      {% trans %}
-      We suggest that if you want to distribute Firefox, you do so by linking to official downloads of Firefox at <a href="{{ mozorg }}">Mozilla.org</a> to help ensure safe, reliable downloads. If you wish to directly distribute copies of Firefox yourself, you must distribute the latest stable version available at <a href="{{ mozorg }}">Mozilla.org</a>.
+      {% trans 
+      mozorg=url('mozorg.home'), 
+      mozdownloads=url('firefox.new') %}
+      We suggest that if you want to distribute Mozilla software, you do so by linking to official downloads of Firefox at <a href="{{ mozorg }}">Mozilla.org</a> to help ensure safe, reliable downloads. If you wish to directly distribute copies of Firefox yourself, you must distribute the latest stable version available at <a href="{{ mozdownloads }}">Mozilla.org</a>.
       {% endtrans %}
     </li>
 
-    <li>{{ _('When distributing you must distribute the most recent version of Firefox.') }}</li>
+    <li>{{ _('When distributing you must distribute the most recent version of Firefox and other Mozilla software.') }}</li>
 
     <li>
       {% trans %}
@@ -65,7 +67,7 @@
 
   <p>
     {% trans %}
-    Mozilla reserves the right to change this Unaltered Firefox Distribution Policy by posting changes on this webpage.
+    Mozilla reserves the right to change this Unaltered Software Distribution Policy by posting changes on this webpage.
     {% endtrans %}
   </p>
 
@@ -73,7 +75,7 @@
 
   <p>
     {% trans %}
-    The open source nature of Firefox allows you to freely download and modify the Firefox source code. However, if you make <em>any</em> changes to Firefox, you may not redistribute that product using <em>any</em> Mozilla trademark without Mozilla’s prior written consent and, typically, a distribution agreement with Mozilla.  For example, you may not distribute a modified form of Firefox and continue to call it Firefox.
+    The open source nature of Firefox and other Mozilla software allows you to freely download and modify the Firefox source code. However, if you make <em>any</em> changes to Firefox or other Mozilla software, you may not redistribute that product using <em>any</em> Mozilla trademark without Mozilla’s prior written consent and, typically, a distribution agreement with Mozilla.  For example, you may not distribute a modified form of Firefox and continue to call it Firefox.
     {% endtrans %}
   </p>
 
@@ -92,7 +94,13 @@
 
   <p>
     {% trans permissions="mailto:trademark-permissions@mozilla.com" %}
-    If you wish to distribute a modified version of Firefox with Mozilla trademarks please contact us with your request at <a href="{{ permissions }}">trademark-permissions@mozilla.com</a>.
+    If you wish to distribute a modified version of Firefox or other Mozilla software with Mozilla trademarks please contact us with your request at <a href="{{ permissions }}">trademark-permissions@mozilla.com</a>.
+    {% endtrans %}
+  </p>
+  <h4>{{ _('Mozilla General Trademark Guidelines') }}</h4>
+  <p>
+    {% trans trademark_guidlines=url('foundation.trademarks.policy') %}
+    Mozilla’s general <a href="{{ trademark_guidlines }}" >trademark guidelines</a> include more information about permitted uses of our trademarks.
     {% endtrans %}
   </p>
 

--- a/bedrock/foundation/templates/foundation/trademarks/policy.html
+++ b/bedrock/foundation/templates/foundation/trademarks/policy.html
@@ -12,11 +12,11 @@
 
 {% block article_content %}
 
-  <p>{{ _('When using Mozilla trademarks you must comply with these Mozilla Trademark Guidelines.') }}</p>
+  <p>{% trans openSource=url('foundation.licensing') %}Mozilla is an open <a href="{{ openSource }}">source company</a>. Because we make our code available to download and modify, proper use of our trademarks is essential to inform users whether or not Mozilla stands behind a product or service. When using Mozilla trademarks you must comply with these Mozilla Trademark Guidelines.{% endtrans %}</p>
 
-  <p>{% trans list=url('foundation.trademarks.list') %}A list of Mozilla’s and its affiliates’ trademarks can be found here: <a href="{{ list }}">Trademarks List</a>.  As used in these Mozilla Trademark Guidelines, (a) references to a ‘Mozilla trademark’ shall apply as well to Mozilla’s affiliates’ trademarks, and (b) these Mozilla Trademark Guidelines apply to Mozilla’s affiliates’ trademarks, unless specified otherwise below.{% endtrans %}</p>
+  <p>{% trans list=url('foundation.trademarks.list') %}A list of Mozilla’s and its affiliates’ trademarks can be found here: <a href="{{ list }}">Trademarks List</a>. However, that is not a complete list of our names, logos, and brand features, all of which are subject to these guidelines.{% endtrans %}</p>
 
-  <p>{% trans report=url('legal.fraud-report') %}If you want to report a misuse of a Mozilla trademark, contact us here:<br>
+  <p>{% trans report=url('legal.fraud-report') %}If you want to report misuse of a Mozilla trademark, please contact us here:<br>
   <a href="{{ report }}">https://www.mozilla.org/about/legal/fraud-report/</a>{% endtrans %}</p>
 
   <h2>{{ _('When do I need specific permission to use a Mozilla trademark?') }}</h2>
@@ -25,17 +25,19 @@
 
   <ul class="mzp-u-list-styled">
 
-    <li>{{ _('Use Mozilla wordmarks in text to refer to and/or link to Mozilla and/or applicable Mozilla programs, products, services and technologies.') }}</li>
+    <li>{{ _('Use Mozilla wordmarks in text to truthfully refer to and/or link to unmodified Mozilla programs, products, services and technologies.') }}</li>
 
-    <li>{{ _('Use Mozilla logos to link to the applicable programs, products, services and technologies.') }}</li>
+    <li>{{ _('Use Mozilla logos in visuals to truthfully refer to and/or to link to the applicable programs, products, services and technologies hosted on Mozilla servers.') }}</li>
 
     <li>{{ _('Describe a Firefox Add-on in accordance with the <a href="#firefox-add-on">Firefox Add-on Guidelines</a>.') }}</li>
+
+    <li>{{ _('Use Mozilla wordmarks to explain disclose that your software is based on Mozilla’s open source code, or is compatible with Mozilla’s software, in accordance with the <a href="#open-source-guidelines">Open Source Project Guidelines</a> below.') }}
 
     <li>{{ _('Describe a social media account, page, or community in accordance with the <a href="#social-media">Social Media Guidelines</a>.') }}</li>
 
   </ul>
 
-  <p>{% trans trademarks="mailto:trademark-permissions@mozilla.com" %}<strong>All other uses of a Mozilla trademark require our prior written permission.</strong> This includes, without limiting the generality of the above, any use of a Mozilla trademark in a domain name. Contact us at <a href="{{ trademarks }}">trademark-permissions@mozilla.com</a> for more information.{% endtrans %}</p>
+  <p>{% trans trademarks="mailto:trademark-permissions@mozilla.com" %}<strong>All other uses of a Mozilla trademark require our prior written permission.</strong> This includes any use of a Mozilla trademark in a domain name. Contact us at <a href="{{ trademarks }}">trademark-permissions@mozilla.com</a> for more information.{% endtrans %}</p>
 
   <h2>{{ _('When allowed, how should I use a Mozilla trademark?') }}</h2>
 
@@ -45,20 +47,16 @@
 
   <ul class="mzp-u-list-styled">
 
-    <li>{{ _('Give a Mozilla logo adequate spacing from the other elements on the web page or document (see the Mozilla Logo and Firefox Logo Guidelines below).') }}</li>
+    <li>{{ _('Give a Mozilla logo adequate spacing from the other elements on the web page or document (see the <a href="#logo-guidelines">Mozilla Logo and Firefox Logo Guidelines</a> below).') }}</li>
 
     <li>
       {% trans list=url('foundation.trademarks.list') %}Use the Mozilla trademark exactly as shown in the <a href="{{ list }}">Trademarks List</a>.{% endtrans %}
-      <ul>
-        <li>{{ _('Don’t abbreviate a Mozilla wordmark or combine it with other words.') }}</li>
-        <li>{{ _('Don’t alter a Mozilla logo design or combine it with other images.') }}</li>
-      </ul>
     </li>
 
     <li>
       {{ _('Use Mozilla wordmarks only as an adjective, never as a noun or verb. Do not use them in plural or possessive forms.') }}
       <ul>
-        <li>{{ _('Instead, use the generic term for our product or service following the trademark.') }}</li>
+        <li>{{ _('Instead, use the generic term for the Mozilla product or service following the trademark.') }}</li>
         <li>{{ _('For example: Firefox web browser, Pocket app.') }}</li>
       </ul>
     </li>
@@ -76,36 +74,35 @@
 
   <ul class="mzp-u-list-styled">
 
-    <li>{{ _('Don’t use Mozilla trademarks unless specifically permitted under these General Guidelines or the Additional Guidelines below.') }}</li>
-
     <li>{{ _('Don’t use Mozilla trademarks in the name of your business, product, service, app, domain name, publication, or other offering.') }}</li>
 
-    <li>{{ _('Don’t use marks, logos, slogans, domain names, or designs that are confusingly similar to Mozilla trademarks.') }}</li>
+    <li>{{ _('Don’t use marks, logos, company names, slogans, domain names, or designs that are confusingly similar to Mozilla trademarks.') }}</li>
 
-    <li>{{ _('Don’t use Mozilla trademarks in a way that implies affiliation with, or sponsorship, endorsement, or approval by Mozilla of your products or services.') }}</li>
+    <li>{{ _('Don’t use Mozilla trademarks in a way that incorrectly implies affiliation with, or sponsorship, endorsement, or approval by Mozilla of your products or services.') }}</li>
 
-    <li>{{ _('Don’t display Mozilla trademarks more prominently than your product or service name.') }}</li>
+    <li>{{ _('Don’t display Mozilla trademarks more prominently than your product, service, or company name.') }}</li>
 
-    <li>{{ _('Don’t use Mozilla trademarks on merchandise for sale (e.g., selling t-shirts, mugs, etc.)
-or other commercial use.') }}</li>
+    <li>{{ _('Don’t use Mozilla trademarks on merchandise for sale (e.g., selling t-shirts, mugs, etc.)') }}</li>
 
-    <li>{{ _('Don’t modify Mozilla’s trademarks, combine them with any other symbols, words, or images, or incorporate them into a tagline or slogan.') }}</li>
+    <li>{{ _('Don’t use Mozilla trademarks for any other form of commercial use (e.g. offering technical support services), unless such use is limited to a truthful and descriptive reference (e.g. “Independent technical support for Mozilla’s Firefox browser”).') }}</li>
 
-    <li>{{ _('Don’t use Mozilla trademarks in a way that is misleading, unfair, defamatory, libelous, disparaging, obscene, or sullies Mozilla’s reputation.') }}</li>
-
-    <li>{{ _('Don’t use Mozilla trademarks in association with any illegal activities or materials.') }}</li>
+    <li>{{ _('Don’t modify Mozilla’s trademarks, abbreviate them, or combine them with any other symbols, words, or images, or incorporate them into a tagline or slogan.') }}</li>
 
   </ul>
 
   <h3>{{ _('Additional Guidelines') }}</h3>
 
-  <h4>{{ _('Mozilla Logo and Firefox Logo Guidelines') }}</h4>
+  <h4>{{ _('Software Distribution Guidelines') }}</h4>
 
-  <p>{{ _('In addition to the General Guidelines above, the Mozilla Style Guide has detailed information on proper usage of the Mozilla logo and the Firefox logo. See the respective pages for more information:') }}</p>
+  <p>{% trans distribution=url('foundation.trademarks.distribution-policy') %} Our <a href="{{ distribution }}">distribution policy</a> contains additional guidelines that apply to distribution of the Firefox Browser and other Mozilla software.{% endtrans %} </p>
 
-  <p>{% trans mlogo=("https://mozilla.design/mlogo") %}Mozilla Logo: <a href="{{ mlogo }}">https://mozilla.design/mlogo</a>{% endtrans %}</p>
+  <h4 id="logo-guidelines">{{ _('Mozilla Logo and Firefox Logo Guidelines') }}</h4>
 
-  <p>{% trans firefox=("https://design.firefox.com/photon/visuals/product-identity-assets.html")%}Firefox Logo: <a href="{{ firefox }}">https://design.firefox.com/photon/visuals/product-identity-assets.html</a>{% endtrans %}</p>
+  <p>{{ _('If your use of a logo is permitted under the General Guidelines above, hen please refer to the Mozilla Style Guide for detailed information on proper usage.') }}</p>
+
+  <p>{{ _('Mozilla Logo:') }} <a href="https://mozilla.design/mozilla/logo-usage/">https://mozilla.design/mozilla/logo-usage/</a></p>
+
+  <p>{{ _('Firefox Logo:') }} <a href="https://design.firefox.com/photon/visuals/product-identity-assets.html">https://design.firefox.com/photon/visuals/product-identity-assets.html</a></p>
 
   <h4 id="firefox-add-on">{{ _('Firefox Add-on Guidelines') }}</h4>
 
@@ -129,9 +126,77 @@ or other commercial use.') }}</li>
 
   <p>{% trans %}For example, you cannot name your account, page, or community “Firefox Representatives” or “Mozilla Software.” However, it would be acceptable to name your account, page, or community “Fans of Firefox” or “Information about Mozilla Software” as long as you do not use the Firefox or Mozilla logos or otherwise suggest any affiliation with Mozilla.{% endtrans %}</p>
 
-  <h4>{{ _('Firefox Distribution Guidelines') }}</h4>
+  <h4 id="open-source-guidelines">{{ _('Open Source Project Guidelines') }}</h4>
 
-  <p>{% trans guidelines = url('foundation.trademarks.distribution-policy') %}<a href="{{ guidelines }}">Click here</a> for additional guidelines that apply to distribution of the Firefox Browser.{% endtrans %}</p>
+  <p>{% trans %}The specific license for each of Mozilla’s software products and code says what you can and cannot do with the code itself but does not give permission to use Mozilla’s trademarks. If you choose to build on or modify Mozilla’s open source code for your own project.{% endtrans %}</p>
+  
+  <h4>{{ _('You Must:') }}</h4>
+
+  <ul>
+  
+    <li>{{ _('Follow the terms of the Open Source License(s) for Mozilla software products and code.') }}</li>
+
+    <li>{{ _('Choose branding, logos, and trademarks that denotes your own unique identity so as to clearly signal to users that there is no affiliation with or endorsement by Mozilla.') }}</li>
+
+    <li>{{ _('Follow the General Guidelines, above.') }}</li>
+  
+  </ul>
+
+  <h4>{{ _('You Must NOT:') }}</h4>
+
+  <ul>
+
+    <li>{{ _('Use any Mozilla trademark in connection with the user-facing name or branding of your project.') }}</li>
+
+    <li>{{ _('Use any Mozilla trademark or any part of any Mozilla trademark to incorrectly suggest or give the impression your software is actually published by, affiliated with, or endorsed by Mozilla.') }}
+
+      <p>{{ _('For example, please do not name your project, [Something]-fox, Moz-[Something], or [Something]-zilla. ') }}</p>
+
+    </li>
+
+  </ul>
+
+  <h4>{{ _('You May:') }}</h4>
+
+  <ul>
+
+    <li>{{ _('State in words (not using logos or images) that your product “works with” or “is compatible” with certain Mozilla software products, if that is true. ') }}</li>
+
+    <li>{{ _('State in words (not using logos or images) that your project is based on Mozilla open source technology, if that is true, as long as you also include a statement that your project is not officially associated with Mozilla or its products. ') }}
+
+      <p>{{ _('For instance, you may state that your project:') }}</p>
+
+      <ul>
+
+        <li>{{ _('“is proudly built from Mozilla’s open source GeckoView software”') }}</li>
+
+        <li>{{ _('“adapted from Mozilla’s open source Boot2Gecko”') }}</li>
+
+      </ul>
+
+      <p>{{ _('as long as you also include the statement equally prominently: ') }}</p>
+
+      <ul>
+
+        <li>{{ _('“[Brand Name] and [Product Name] are not officially associated with Mozilla or its products.”') }}</li>
+
+      </ul>
+
+    </li>
+
+  </ul>
+
+  <h4>{{ _('Cloud-based Services') }}</h4>
+
+  <p>{{ _('If you offer a cloud-based service that provides remote access to Mozilla software, it is important that you do so in a way that does not confuse users about who is offering the service. You must not use Mozilla trademarks in the name of your product or service. ') }}</>
+
+  <p>{{ _('You may state in words (not using logos or images) that your product or service features or provides access to unaltered Mozilla software, if this is true.') }}
+
+  <p>{{ _('For example: ') }}</p>
+
+  <p>{{ _('Acceptable: [Your Product Name] featuring Mozilla’s Firefox browser') }}</p>
+
+  <p>{{ _('Incorrect: Firefox [Your Product Name]') }}</p>
 
   <h4>{{ _('Mozilla Community Guidelines') }}</h4>
 


### PR DESCRIPTION
## Description
Updating copy changes for our Trademark policy
## Issue / Bugzilla link
#7622
The new copy can be found here:  https://docs.google.com/document/d/1p4Lr4EQMmzsRHwtt3OYyl9eObALTBjdnie5Oqku9y48/

