### PR TITLE
Do not let data update failure stop the Docker build

### DIFF
--- a/bin/sync-all.sh
+++ b/bin/sync-all.sh
@@ -8,6 +8,6 @@ fi
 
 ./bin/run-db-download.py --force
 ./manage.py migrate --noinput
-./bin/run-db-update.sh --all
+./bin/run-db-update.sh --all || true
 ./manage.py l10n_update
 ./manage.py update_sitemaps


### PR DESCRIPTION
This change should still allow us to get DMS notifications
if the data fails to update during normal operation but will
avoid breaking the docker image build if some data fetch fails.