### PR TITLE
Fix websites privacy notice expanders and page title (Fixes #7645)

### DIFF
--- a/bedrock/privacy/templates/privacy/notices/base-notice-paragraphs.html
+++ b/bedrock/privacy/templates/privacy/notices/base-notice-paragraphs.html
@@ -13,7 +13,7 @@
 {% do doc.select('body > section > section ul')|htmlattr(class="mzp-u-list-styled") %}
 {% do doc.select('body > section > section ol')|htmlattr(class="mzp-u-list-styled") %}
 
-{% block page_title %}{{ doc.h1.string }}{% endblock %}
+{% block page_title %}{{ doc.h1.string|join|safe }}{% endblock %}
 
 {% block body_id %}firefox-notice{% endblock %}
 {% block body_class %}{{ super() }} format-paragraphs{% endblock %}

--- a/bedrock/privacy/templates/privacy/notices/websites.html
+++ b/bedrock/privacy/templates/privacy/notices/websites.html
@@ -5,7 +5,7 @@
 {% extends "privacy/notices/base-notice-paragraphs.html" %}
 
 {% set body_id = "privacy-websites" %}
-{% block body_class %}mzp-t-mozilla format-none{% endblock%}
+{% block body_class %}{{ super() }} mzp-t-mozilla{% endblock%}
 
 {% block article_header_logo %}{{ static('img/trademarks/logo-mozm.png') }}{% endblock %}
 

--- a/bedrock/privacy/templates/privacy/notices/websites.html
+++ b/bedrock/privacy/templates/privacy/notices/websites.html
@@ -5,7 +5,7 @@
 {% extends "privacy/notices/base-notice-paragraphs.html" %}
 
 {% set body_id = "privacy-websites" %}
-{% block body_class %}{{ super() }} mzp-t-mozilla{% endblock%}
+{% block body_class %}mzp-t-mozilla format-paragraphs{% endblock%}
 
 {% block article_header_logo %}{{ static('img/trademarks/logo-mozm.png') }}{% endblock %}
 


### PR DESCRIPTION
## Description
- Fixes bug described in the issue.

## Issue / Bugzilla link
#7645

## Testing
- [x] Expanders should toggle.
- [x] Page title should be properly escaped.