### PR TITLE
Fix missing Dev Edition landing page wordmarks

### DIFF
--- a/bedrock/firefox/templates/firefox/developer/firstrun.html
+++ b/bedrock/firefox/templates/firefox/developer/firstrun.html
@@ -23,7 +23,7 @@
 <main role="main">
   <section class="t-intro">
       <div class="mzp-l-content">
-        {{ high_res_img('/img/logos/firefox/developer-wordmark.png', {'alt': '', 'width': '368', 'height': '68'}) }}
+        {{ high_res_img('logos/firefox/developer-wordmark.png', {'alt': '', 'width': '368', 'height': '68'}) }}
         <h1 class="intro-title">{{ _('Welcome to the all-new Firefox Quantum: Developer Edition') }}</h1>
         <p class="intro-tagline">{{ _('Firefox has been rebuilt from the ground-up to be faster, sleeker, and more powerful than ever.') }}</p>
 

--- a/bedrock/firefox/templates/firefox/developer/index.html
+++ b/bedrock/firefox/templates/firefox/developer/index.html
@@ -31,6 +31,7 @@
 <main role="main">
   <section class="t-intro">
     <div class="mzp-l-content">
+      {{ high_res_img('/img/logos/firefox/developer-wordmark.png', {'alt': '', 'width': '368', 'height': '68'}) }}
       <h1 class="intro-title">{{ _('Firefox Quantum: Developer Edition') }}</h1>
       <p class="intro-tagline">{{ _('Welcome to your new favorite browser. Get the latest features, fast performance, and the development tools you need to build for the open web.') }}</p>
 

--- a/bedrock/firefox/templates/firefox/developer/whatsnew.html
+++ b/bedrock/firefox/templates/firefox/developer/whatsnew.html
@@ -23,6 +23,7 @@
 <main role="main">
   <section class="t-intro">
     <div class="mzp-l-content">
+      {{ high_res_img('/img/logos/firefox/developer-wordmark.png', {'alt': '', 'width': '368', 'height': '68'}) }}
       <h1 class="intro-title">{{ _('Congrats. You now have Firefox Quantum: Developer Edition.') }}</h1>
       <p class="intro-tagline">{{ _('This isn’t just an update. This is Firefox Quantum: A brand new Firefox that has been rebuilt from the ground-up to be faster, sleeker, and more powerful than ever.') }}</p>
 


### PR DESCRIPTION
## Description
- Fixes missing image reference on dev edition /firstrun page.
- Add wordmark back to /whatsnew and /developer pages.

## Issue / Bugzilla link
N/A

## Testing
- [x] All 3 pages should display the logo.