### PR TITLE
Fix the l10n_img helper in DEV mode

### DIFF
--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -335,6 +335,8 @@ STATICFILES_FINDERS = (
 STATICFILES_DIRS = (
     path('static_final'),
 )
+if DEBUG:
+    STATICFILES_DIRS += (path('media'),)
 
 
 def set_whitenoise_headers(headers, path, url):


### PR DESCRIPTION
Fix #6152

## Testing

I looked at /firefox/mobile/ which has the btn-app-store.svg l10n image in it. I looked at the source of the page with my change and without, and with this change the image path in the HTML was for the localized image.