### PR TITLE
Allow normal "img/" path prefix for helper functions

### DIFF
--- a/bedrock/mozorg/templatetags/misc.py
+++ b/bedrock/mozorg/templatetags/misc.py
@@ -30,6 +30,10 @@ from bedrock.firefox.firefox_details import firefox_ios
 ALL_FX_PLATFORMS = ('windows', 'linux', 'mac', 'android', 'ios')
 
 
+def _strip_img_prefix(url):
+    return re.sub(r'^/?img/', '', url)
+
+
 def _l10n_media_exists(type, locale, url):
     """ checks if a localized media file exists for the locale """
     return find_static(path.join(type, 'l10n', locale, url)) is not None
@@ -100,6 +104,7 @@ def l10n_img(ctx, url):
         $ROOT/media/img/l10n/fr/firefoxos/screenshot.png
 
     """
+    url = _strip_img_prefix(url)
     return static(l10n_img_file_name(ctx, url))
 
 
@@ -156,6 +161,7 @@ def field_with_attrs(bfield, **kwargs):
 @library.global_function
 @jinja2.contextfunction
 def platform_img(ctx, url, optional_attributes=None):
+    url = _strip_img_prefix(url)
     optional_attributes = optional_attributes or {}
     img_urls = {}
     platforms = optional_attributes.pop('platforms', ALL_FX_PLATFORMS)
@@ -198,6 +204,7 @@ def platform_img(ctx, url, optional_attributes=None):
 @library.global_function
 @jinja2.contextfunction
 def high_res_img(ctx, url, optional_attributes=None):
+    url = _strip_img_prefix(url)
     url_high_res = convert_to_high_res(url)
     if optional_attributes and optional_attributes.pop('l10n', False) is True:
         url = l10n_img(ctx, url)
@@ -227,12 +234,14 @@ def high_res_img(ctx, url, optional_attributes=None):
 @jinja2.contextfunction
 def lazy_img(ctx, image_url, placeholder_url, include_highres_image=False,
              optional_attributes=None, highres_image_url=None):
+    placeholder_url = _strip_img_prefix(placeholder_url)
     placeholder = static(path.join('img', placeholder_url))
 
     external_img = re.match(r'^https?://', image_url, flags=re.I)
 
     # image could be external
     if not external_img:
+        image_url = _strip_img_prefix(image_url)
         image = static(path.join('img', image_url))
     else:
         image = image_url

--- a/bedrock/mozorg/tests/test_helper_misc.py
+++ b/bedrock/mozorg/tests/test_helper_misc.py
@@ -78,6 +78,9 @@ class TestImgL10n(TestCase):
         assert (
             self._render('en-US', 'dino/head.png') ==
             static('img/l10n/en-US/dino/head.png'))
+        assert (
+            self._render('en-US', 'img/dino/head.png') ==
+            static('img/l10n/en-US/dino/head.png'))
 
         assert (
             self._render('en-US', 'dino/does-not-exist.png') ==
@@ -88,6 +91,9 @@ class TestImgL10n(TestCase):
         media_exists_mock.return_value = True
         assert (
             self._render('de', 'dino/head.png') ==
+            static('img/l10n/de/dino/head.png'))
+        assert (
+            self._render('de', 'img/dino/head.png') ==
             static('img/l10n/de/dino/head.png'))
 
     def test_defaults_when_lang_file_missing(self, media_exists_mock):
@@ -254,6 +260,9 @@ class TestPlatformImg(TestCase):
         markup = self._render('test.png')
         self.assertIn(u'data-src-windows="/media/img/test-windows.png"', markup)
         self.assertIn(u'data-src-mac="/media/img/test-mac.png"', markup)
+        markup = self._render('img/test.png')
+        self.assertIn(u'data-src-windows="/media/img/test-windows.png"', markup)
+        self.assertIn(u'data-src-mac="/media/img/test-mac.png"', markup)
 
     def test_platform_img_with_optional_attributes(self, find_static):
         """Should return expected markup with optional attributes"""
@@ -266,12 +275,19 @@ class TestPlatformImg(TestCase):
         self.assertIn(u'data-src-windows-high-res="/media/img/test-windows-high-res.png"', markup)
         self.assertIn(u'data-src-mac-high-res="/media/img/test-mac-high-res.png"', markup)
         self.assertIn(u'data-high-res="true"', markup)
+        markup = self._render('img/test.png', {'high-res': True})
+        self.assertIn(u'data-src-windows-high-res="/media/img/test-windows-high-res.png"', markup)
+        self.assertIn(u'data-src-mac-high-res="/media/img/test-mac-high-res.png"', markup)
+        self.assertIn(u'data-high-res="true"', markup)
 
     def test_platform_img_with_l10n(self, find_static):
         """Should return expected markup with l10n image path"""
         l10n_url_win = self._render_l10n('test-windows.png')
         l10n_url_mac = self._render_l10n('test-mac.png')
         markup = self._render('test.png', {'l10n': True})
+        self.assertIn(u'data-src-windows="' + l10n_url_win + '"', markup)
+        self.assertIn(u'data-src-mac="' + l10n_url_mac + '"', markup)
+        markup = self._render('/img/test.png', {'l10n': True})
         self.assertIn(u'data-src-windows="' + l10n_url_win + '"', markup)
         self.assertIn(u'data-src-mac="' + l10n_url_mac + '"', markup)
 
@@ -444,10 +460,14 @@ class TestHighResImg(TestCase):
 
     def test_high_res_img_no_optional_attributes(self):
         """Should return expected markup without optional attributes"""
-        markup = self._render('test.png')
         expected = (
             u'<img class="" src="/media/img/test.png" '
             u'srcset="/media/img/test-high-res.png 1.5x">')
+        markup = self._render('test.png')
+        self.assertEqual(markup, expected)
+        markup = self._render('img/test.png')
+        self.assertEqual(markup, expected)
+        markup = self._render('/img/test.png')
         self.assertEqual(markup, expected)
 
     def test_high_res_img_with_optional_attributes(self):
@@ -467,6 +487,14 @@ class TestHighResImg(TestCase):
         expected = (
             u'<img class="" src="' + l10n_url + '" '
             u'srcset="' + l10n_hr_url + ' 1.5x">')
+        self.assertEqual(markup, expected)
+
+        l10n_url = self._render_l10n('img/test.png')
+        l10n_hr_url = misc.convert_to_high_res(l10n_url)
+        markup = self._render('test.png', {'l10n': True})
+        expected = (
+            u'<img class="" src="' + l10n_url + '" '
+                                                u'srcset="' + l10n_hr_url + ' 1.5x">')
         self.assertEqual(markup, expected)
 
     def test_high_res_img_with_l10n_and_optional_attributes(self):


### PR DESCRIPTION
Functions like `l10n_img`, `platform_img`, `lazy_img`, and `high_res_img` all wanted the image path to be passed in without the `img/` prefix, but the normal `static` function did want that.  This change allows the developer to be consistent and use the same path for all of the image calls.