### PR TITLE
Add structured_data template block (#7653)

### DIFF
--- a/bedrock/base/templates/base-pebbles.html
+++ b/bedrock/base/templates/base-pebbles.html
@@ -127,6 +127,8 @@
     <!--[if !lte IE 8]><!-->
     {% block js %}{% endblock %}
 
+    {% block structured_data %}{% endblock %}
+
     {# Bug 1381776 #}
     {% block update_notification %}
       {% if switch('firefox-update-notification', ['en-US']) %}

--- a/bedrock/mozorg/templates/mozorg/home/home-en.html
+++ b/bedrock/mozorg/templates/mozorg/home/home-en.html
@@ -208,11 +208,6 @@
 
 </main>
 {% endblock %}
-
-{# https://github.com/mozilla/bedrock/issues/5741 #}
-{% block structured_data %}
-{% include 'mozorg/home/includes/structured-data.html' %}
-{% endblock %}
 {% endblock %}
 
 {% block js %}
@@ -220,4 +215,9 @@
   {% if switch('home-fundraising-sept2019') %}
     {{ js_bundle('home-fundraiser') }}
   {% endif %}
+{% endblock %}
+
+{# https://github.com/mozilla/bedrock/issues/5741 #}
+{% block structured_data %}
+{% include 'mozorg/home/includes/structured-data.html' %}
 {% endblock %}


### PR DESCRIPTION
## Description

Add structured_data template block to master template.

## Issue / Bugzilla link

Fix #7653 

## Testing

- [ ] Did not mess up any pages
- [ ] Existing structured data still displays on EN homepage
- [ ] Empty script tags do not appear when the `structured_data` block is empty