### PR TITLE
[fix #7667] Update Enterprise SLA help link

### DIFF
--- a/bedrock/firefox/templates/firefox/enterprise/sla.html
+++ b/bedrock/firefox/templates/firefox/enterprise/sla.html
@@ -95,8 +95,8 @@
       <section id="services-contact" class="mzp-c-details">
         <h3>{{ _('Contact Information') }}</h3>
         <p>
-        {% trans enterprise='https://mozilla.force.com/enterprise' %}
-          Incidents and service requests can be created directly via our Mozilla Enterprise Client Service Desk web portal at <a rel="noopener" target="_blank" href="{{ enterprise }}">https://mozilla.force.com/enterprise</a>.
+        {% trans enterprisehelp='https://enterprise-help.mozilla.com' %}
+          Incidents and service requests can be created directly via our Mozilla Enterprise Client Service Desk web portal at <a rel="noopener" target="_blank" href="{{ enterprisehelp }}">{{ enterprisehelp }}</a>.
         {% endtrans %}
         </p>
       </section>
@@ -555,8 +555,8 @@
 
         <ul class="mzp-u-list-styled">
           <li>
-            {% trans servicedesk='https://mozilla.force.com/enterprise' %}
-            Incidents will be captured via the Mozilla Enterprise Client Service Desk portal at <a rel="noopener" target="_blank" href="{{ servicedesk }}">https://mozilla.force.com/enterprise</a>.
+            {% trans enterprisehelp='https://enterprise-help.mozilla.com' %}
+            Incidents will be captured via the Mozilla Enterprise Client Service Desk portal at <a rel="noopener" target="_blank" href="{{ enterprisehelp }}">{{ enterprisehelp }}</a>.
             {% endtrans %}
           </li>
           <li>


### PR DESCRIPTION
## Description
Changes `https://mozilla.force.com/enterprise` to `https://enterprise-help.mozilla.com`, and also replaces the URL in copy with the same variable (which I should have done in the first place). This page isn't localized so there should be no impact on the string changes.

## Issue / Bugzilla link
#7667 
