### PR TITLE
Detect UITour failure / non-response on what's new page (Fixes #7671)

### DIFF
--- a/media/js/firefox/whatsnew/whatsnew-69.js
+++ b/media/js/firefox/whatsnew/whatsnew-69.js
@@ -5,6 +5,27 @@
 (function() {
     'use strict';
 
+    // Issue #7671 measure potential UITour failure for bug 1557153
+    function pingUITour() {
+        var startTime = performance.now();
+        var timeout = window.setTimeout(trackImpression, 1000, 'UITour Timeout');
+
+        Mozilla.UITour.ping(function() {
+            window.clearTimeout(timeout);
+            trackImpression('UITour Response');
+        });
+
+        function trackImpression(eLabel) {
+            var endTime = performance.now() - startTime;
+
+            window.dataLayer.push({
+                'eLabel': eLabel,
+                'data-response-time': endTime,
+                'event': 'non-interaction'
+            });
+        }
+    }
+
     // Prevent double-requesting Flow IDs. Inits signed out button even on non-firefox browsers (highly unlikely on this page, but you never know).
     if (Mozilla.Client.isFirefoxDesktop) {
         Mozilla.Client.getFxaDetails(function(details) {
@@ -17,4 +38,6 @@
     } else {
         Mozilla.MonitorButton.init('monitor-button-signed-out');
     }
+
+    pingUITour();
 })();


### PR DESCRIPTION
## Description
- Attempts to measure the % of people who may have a Firefox profile issue where UITour isn't working as expected.

## Issue / Bugzilla link
#7671