### PR TITLE
Change 'Emeritus' board members to 'Former' on /leadership page

### DIFF
--- a/bedrock/mozorg/templates/mozorg/about/leadership.html
+++ b/bedrock/mozorg/templates/mozorg/about/leadership.html
@@ -1261,7 +1261,7 @@
       </li>
     </ul>
 
-    <h3 class="group-title">{{ _('Emeritus Board Members') }}</h3>
+    <h3 class="group-title">{{ _('Former Board Members') }}</h3>
 
     <div class="gallery">
       <article id="reid-hoffman" class="vcard" itemscope itemtype="http://schema.org/Person">


### PR DESCRIPTION
## Description
- As per a request from Mitchell

## Issue / Bugzilla link
N/A