### PR TITLE
Remove card description truncation Fix #7690

### DIFF
--- a/bedrock/base/templates/macros-protocol.html
+++ b/bedrock/base/templates/macros-protocol.html
@@ -113,7 +113,7 @@
     {% endif %}
       <h{{ heading_level }} class="mzp-c-card-title"><span>{{ title }}</span></h{{ heading_level }}>
     {% if desc %}
-      <p class="mzp-c-card-desc">{{ desc|truncatechars(140) }}</p>
+      <p class="mzp-c-card-desc">{{ desc }}</p>
     {% endif %}
     {% if meta %}
       <p class="mzp-c-card-meta">{{ meta }}</p>


### PR DESCRIPTION
## Description

Remove card description truncation.

I think the content team has been submitting sensible length strings and we have been clipping them in funny ways.

## Issue / Bugzilla link

Fix #7690

## Testing

No really long strings already in use?

