### PR TITLE
Make /whatsnew urls use the new Geo redirector view class (Fixes #7637)

### DIFF
--- a/bedrock/firefox/urls.py
+++ b/bedrock/firefox/urls.py
@@ -12,6 +12,7 @@ from bedrock.firefox import views
 latest_re = r'^firefox(?:/(?P<version>%s))?/%s/$'
 firstrun_re = latest_re % (version_re, 'firstrun')
 whatsnew_re = latest_re % (version_re, 'whatsnew')
+whatsnew_re_all = latest_re % (version_re, 'whatsnew/all')
 tracking_protection_re = latest_re % (version_re, 'tracking-protection/start')
 content_blocking_re = latest_re % (version_re, 'content-blocking/start')
 platform_re = '(?P<platform>android|ios)'
@@ -71,7 +72,8 @@ urlpatterns = (
     url(r'^firefox/installer-help/$', views.installer_help,
         name='firefox.installer-help'),
     url(firstrun_re, views.FirstrunView.as_view(), name='firefox.firstrun'),
-    url(whatsnew_re, views.WhatsnewView.as_view(), name='firefox.whatsnew'),
+    url(whatsnew_re, views.WhatsNewRedirectorView.as_view(), name='firefox.whatsnew'),
+    url(whatsnew_re_all, views.WhatsnewView.as_view(), name='firefox.whatsnew.all'),
     url(tracking_protection_re, views.TrackingProtectionTourView.as_view(),
         name='firefox.tracking-protection-tour.start'),
     url(content_blocking_re, views.ContentBlockingTourView.as_view(),

--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -35,6 +35,7 @@ from bedrock.firefox.forms import SendToDeviceWidgetForm
 from bedrock.newsletter.forms import NewsletterFooterForm
 from bedrock.releasenotes import version_re
 from bedrock.wordpress.views import BlogPostsView
+from bedrock.base.views import GeoRedirectView
 
 UA_REGEXP = re.compile(r"Firefox/(%s)" % version_re)
 
@@ -533,6 +534,17 @@ class FirstrunView(l10n_utils.LangFilesMixin, TemplateView):
 
         # return a list to conform with original intention
         return [template]
+
+
+class WhatsNewRedirectorView(GeoRedirectView):
+    geo_urls = {}
+    default_url = 'firefox.whatsnew.all'
+
+    def get_redirect_url(self, *args, **kwargs):
+        if 'version' in kwargs and kwargs['version'] is None:
+            del kwargs['version']
+
+        return super().get_redirect_url(*args, **kwargs)
 
 
 class WhatsnewView(l10n_utils.LangFilesMixin, TemplateView):

--- a/tests/pages/firefox/whatsnew.py
+++ b/tests/pages/firefox/whatsnew.py
@@ -10,7 +10,7 @@ from pages.regions.send_to_device import SendToDevice
 
 class FirefoxWhatsNewPage(FirefoxBasePage):
 
-    URL_TEMPLATE = '/{locale}/firefox/whatsnew/'
+    URL_TEMPLATE = '/{locale}/firefox/whatsnew/all/'
 
     _qr_code_locator = (By.CSS_SELECTOR, '.qr-code img')
 


### PR DESCRIPTION
## Description
- Changes our current /whatsnew/ page URLs to use the new `GeoRedirectView` class.

Note: We're not yet doing any geo-specific pages, so for now everything will redirect to `/whatsnew/all/`. For example, `/firefox/70.0/whatsnew/` will redirect to `/firefox/70.0/whatsnew/all/` (which is the default, global view).

## Issue / Bugzilla link
#7637

## Testing
Successful test run: https://ci.vpn1.moz.works/blue/organizations/jenkins/bedrock_multibranch_pipeline/detail/run-integration-tests/364/pipeline