### PR TITLE
Pass through UTM parameters for Firefox Monitor referrals (#7585)

### DIFF
--- a/bedrock/base/templates/macros.html
+++ b/bedrock/base/templates/macros.html
@@ -208,7 +208,7 @@
     {% do fxa_queries.append('utm_term=' ~ utm_term) %}
   {% endif %}
 
-  <a data-action="{{ settings.FXA_ENDPOINT }}" href="https://monitor.firefox.com/oauth/init?{{ fxa_queries|join('&') }}" {% if button_class %}class="{{ button_class }}"{% endif %} id="{{ button_id }}" data-cta-text="{% if button_text %}{{ button_text }}{% else %}Sign In to Monitor{% endif %}" data-cta-type="{% if cta_type %}{{ cta_type }}{% else %}fxa-monitor{% endif %}" data-cta-position="{% if cta_position %}{{ cta_position }}{% else %}primary{% endif %}">
+  <a data-action="{{ settings.FXA_ENDPOINT }}" href="https://monitor.firefox.com/oauth/init?{{ fxa_queries|join('&') }}" class="js-fxa-cta-link {% if button_class %}{{ button_class }}{% endif %}" id="{{ button_id }}" data-cta-text="{% if button_text %}{{ button_text }}{% else %}Sign In to Monitor{% endif %}" data-cta-type="{% if cta_type %}{{ cta_type }}{% else %}fxa-monitor{% endif %}" data-cta-position="{% if cta_position %}{{ cta_position }}{% else %}primary{% endif %}">
     {% if button_text %}
       {{ button_text }}
     {% else %}

--- a/media/js/base/fxa-utm-referral-init.js
+++ b/media/js/base/fxa-utm-referral-init.js
@@ -1,0 +1,12 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+(function () {
+    'use strict';
+
+    var urlParams = new window._SearchParams().utmParams();
+
+    // Track external UTM referrals for Firefox Accounts related CTAs.
+    Mozilla.UtmUrl.init(urlParams);
+})();

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -1560,7 +1560,8 @@
         "js/base/core-datalayer.js",
         "js/base/core-datalayer-init.js",
         "js/base/search-params.js",
-        "js/base/fxa-utm-referral.js"
+        "js/base/fxa-utm-referral.js",
+        "js/base/fxa-utm-referral-init.js"
       ],
       "name": "common"
     },
@@ -1583,7 +1584,8 @@
         "js/base/core-datalayer.js",
         "js/base/core-datalayer-init.js",
         "js/base/search-params.js",
-        "js/base/fxa-utm-referral.js"
+        "js/base/fxa-utm-referral.js",
+        "js/base/fxa-utm-referral-init.js"
       ],
       "name": "common-protocol"
     },

--- a/tests/unit/spec/base/fxa-utm-referral.js
+++ b/tests/unit/spec/base/fxa-utm-referral.js
@@ -7,6 +7,21 @@ describe('fxa-utm-referral.js', function() {
 
     'use strict';
 
+    describe('getHostName', function() {
+
+        it('should return a hostname as expected', function() {
+            var url1 = 'https://monitor.firefox.com/oauth/init?form_type=button&entrypoint=mozilla.org-firefox-accounts';
+            var url2 = 'https://accounts.firefox.com/?utm_campaign=campaign-one&utm_source=source-one&utm_content=content-one';
+            expect(Mozilla.UtmUrl.getHostName(url1)).toEqual('https://monitor.firefox.com/');
+            expect(Mozilla.UtmUrl.getHostName(url2)).toEqual('https://accounts.firefox.com/');
+        });
+
+        it('should return null if no match is found', function() {
+            var url = 'thedude';
+            expect(Mozilla.UtmUrl.getHostName(url)).toBeNull();
+        });
+    });
+
     describe('getAttributionData', function () {
 
         it('should return a valid object unchanged', function () {
@@ -189,7 +204,7 @@ describe('fxa-utm-referral.js', function() {
 
     });
 
-    describe('getAttributionData.init', function () {
+    describe('init', function () {
 
         beforeEach(function () {
             // link to change
@@ -197,7 +212,7 @@ describe('fxa-utm-referral.js', function() {
                 '<div id="test-links">' +
                 '<a id="test-expected" class="js-fxa-cta-link" href="https://accounts.firefox.com/?service=sync&amp;action=email&amp;context=fx_desktop_v3&amp;entrypoint=mozilla.org-accounts_page&amp;utm_content=accounts-page-top-cta&amp;utm_source=accounts-page&amp;utm_medium=referral&amp;utm_campaign=fxa-benefits-page" data-mozillaonline-link="https://accounts.firefox.com.cn/?service=sync&amp;action=email&amp;context=fx_desktop_v3&amp;entrypoint=mozilla.org-accounts_page&amp;utm_content=accounts-page-top-cta&amp;utm_source=accounts-page&amp;utm_medium=referral&amp;utm_campaign=fxa-benefits-page">Create a Firefox Account</a>' +
                 '<a id="test-not-accounts" class="js-fxa-cta-link" href="https://www.mozilla.org/?service=sync&amp;action=email&amp;context=fx_desktop_v3&amp;entrypoint=mozilla.org-accounts_page&amp;utm_content=accounts-page-top-cta&amp;utm_source=accounts-page&amp;utm_medium=referral&amp;utm_campaign=fxa-benefits-page" data-mozillaonline-link="https://accounts.firefox.com.cn/?service=sync&amp;action=email&amp;context=fx_desktop_v3&amp;entrypoint=mozilla.org-accounts_page&amp;utm_content=accounts-page-top-cta&amp;utm_source=accounts-page&amp;utm_medium=referral&amp;utm_campaign=fxa-benefits-page">Create a Firefox Account</a>' +
-                '<a id="test-second-expected" class="js-fxa-cta-link" href="https://accounts.firefox.com/signup?service=sync&amp;context=fx_desktop_v3&amp;entrypoint=mozilla.org-globalnav&amp;utm_content=get-firefox-account&amp;utm_source=www.mozilla.org&amp;utm_medium=referral&amp;utm_campaign=globalnav" data-mozillaonline-link="https://accounts.firefox.com.cn/signup?service=sync&amp;context=fx_desktop_v3&amp;entrypoint=mozilla.org-globalnav&amp;utm_content=get-firefox-account&amp;utm_source=www.mozilla.org&amp;utm_medium=referral&amp;utm_campaign=globalnav">Create a Firefox Account</a>' +
+                '<a id="test-second-expected" class="js-fxa-cta-link" href="https://monitor.firefox.com/oauth/init?form_type=button&amp;entrypoint=mozilla.org-firefox-accounts&amp;utm_content=accounts-page-top-cta&amp;utm_source=accounts-page&amp;utm_medium=referral&amp;utm_campaign=fxa-benefits-page" data-mozillaonline-link="https://accounts.firefox.com.cn/?service=sync&amp;action=email&amp;context=fx_desktop_v3&amp;entrypoint=mozilla.org-accounts_page&amp;utm_content=accounts-page-top-cta&amp;utm_source=mozilla.org-accounts_page&amp;utm_medium=referral&amp;utm_campaign=fxa-benefits-page">Sign In to Firefox Monitor</a>' +
                 '</div>';
 
             $(links).appendTo('body');
@@ -216,7 +231,7 @@ describe('fxa-utm-referral.js', function() {
                 'utm_campaign': 'campaign-two'
             };
 
-            Mozilla.UtmUrl.getAttributionData.init(data);
+            Mozilla.UtmUrl.init(data);
 
             var expected = document.getElementById('test-expected');
             var expectedHref = expected.getAttribute('href');
@@ -224,7 +239,7 @@ describe('fxa-utm-referral.js', function() {
             var secondExpectedHref = secondExpected.getAttribute('href');
 
             expect(expectedHref).toEqual('https://accounts.firefox.com/?service=sync&action=email&context=fx_desktop_v3&entrypoint=mozilla.org-accounts_page&utm_source=source-two&utm_campaign=campaign-two&utm_content=content-two&utm_term=term-two&utm_medium=medium-two');
-            expect(secondExpectedHref).toEqual('https://accounts.firefox.com/signup?service=sync&context=fx_desktop_v3&entrypoint=mozilla.org-globalnav&utm_source=source-two&utm_campaign=campaign-two&utm_content=content-two&utm_term=term-two&utm_medium=medium-two');
+            expect(secondExpectedHref).toEqual('https://monitor.firefox.com/oauth/init?form_type=button&entrypoint=mozilla.org-firefox-accounts&utm_source=source-two&utm_campaign=campaign-two&utm_content=content-two&utm_term=term-two&utm_medium=medium-two');
         });
 
         it('updates the data-mozilla-online attribute of links with class js-fxa-cta-link', function () {
@@ -236,21 +251,18 @@ describe('fxa-utm-referral.js', function() {
                 'utm_campaign': 'campaign-two'
             };
 
-            Mozilla.UtmUrl.getAttributionData.init(data);
+            Mozilla.UtmUrl.init(data);
 
             var expected = document.getElementById('test-expected');
             var expectedOnline = expected.getAttribute('data-mozillaonline-link');
-            var secondExpected = document.getElementById('test-second-expected');
-            var secondExpectedOnline = secondExpected.getAttribute('data-mozillaonline-link');
 
             expect(expectedOnline).toEqual('https://accounts.firefox.com.cn/?service=sync&action=email&context=fx_desktop_v3&entrypoint=mozilla.org-accounts_page&utm_source=source-two&utm_campaign=campaign-two&utm_content=content-two&utm_term=term-two&utm_medium=medium-two');
-            expect(secondExpectedOnline).toEqual('https://accounts.firefox.com.cn/signup?service=sync&context=fx_desktop_v3&entrypoint=mozilla.org-globalnav&utm_source=source-two&utm_campaign=campaign-two&utm_content=content-two&utm_term=term-two&utm_medium=medium-two');
         });
 
         it('does not make change if there are no UTM params', function () {
             var data = {};
 
-            Mozilla.UtmUrl.getAttributionData.init(data);
+            Mozilla.UtmUrl.init(data);
 
             var expected = document.getElementById('test-expected');
             var expectedHref = expected.getAttribute('href');
@@ -260,7 +272,7 @@ describe('fxa-utm-referral.js', function() {
             expect(expectedOnline).toEqual('https://accounts.firefox.com.cn/?service=sync&action=email&context=fx_desktop_v3&entrypoint=mozilla.org-accounts_page&utm_content=accounts-page-top-cta&utm_source=accounts-page&utm_medium=referral&utm_campaign=fxa-benefits-page');
         });
 
-        it('does not make changes if the link is not a link to accounts.firefox.com', function () {
+        it('does not make changes if the link is not in the FxA referral whitelist', function () {
             var data = {
                 'utm_source': 'source-two',
                 'utm_content': 'content-two',
@@ -269,7 +281,7 @@ describe('fxa-utm-referral.js', function() {
                 'utm_campaign': 'campaign-two'
             };
 
-            Mozilla.UtmUrl.getAttributionData.init(data);
+            Mozilla.UtmUrl.init(data);
 
             var unexpected = document.getElementById('test-not-accounts');
             var unexpectedHref = unexpected.getAttribute('href');
@@ -278,7 +290,5 @@ describe('fxa-utm-referral.js', function() {
             expect(unexpectedHref).toEqual('https://www.mozilla.org/?service=sync&action=email&context=fx_desktop_v3&entrypoint=mozilla.org-accounts_page&utm_content=accounts-page-top-cta&utm_source=accounts-page&utm_medium=referral&utm_campaign=fxa-benefits-page');
             expect(unexpectedOnline).toEqual('https://accounts.firefox.com.cn/?service=sync&action=email&context=fx_desktop_v3&entrypoint=mozilla.org-accounts_page&utm_content=accounts-page-top-cta&utm_source=accounts-page&utm_medium=referral&utm_campaign=fxa-benefits-page');
         });
-
-
     });
 });


### PR DESCRIPTION
## Description
- Rather than trying to fix #7585 all in one go, I'm splitting this up into separate PRs. This one addresses only the Firefox Monitor button macro.

## Issue / Bugzilla link
#7585

## Testing
- [x] Visiting http://127.0.0.1:8000/en-US/firefox/accounts/?utm_source=test&utm_campaign=test&utm_term=test&utm_medium=test&utm_content=test when signed-in to a Firefox Account should add the UTM parameters to the Firefox Monitor CTA link.
- [x] No other regressions with existing functionality.