### PR TITLE
Update to Protocol 8.1.0

### DIFF
--- a/bedrock/firefox/templates/firefox/developer/index.html
+++ b/bedrock/firefox/templates/firefox/developer/index.html
@@ -76,22 +76,20 @@
   </section>
   <section class="t-newsletter">
     <div class="mzp-l-content">
-      <div class="mzp-c-newsletter">
-        {% if LANG.startswith('en-') %}
-          {{ email_newsletter_form(
-            'app-dev',
-            title='Get the most out of Firefox Developer Edition',
-            subtitle='Learn about Dev Edition and subscribe to the Mozilla Developer Newsletter.',
-            button_class='mzp-t-product mzp-t-small',
-            include_language=False,
-            protocol_component=True) }}
-        {% else %}
-          {{ email_newsletter_form(
-            protocol_component=True,
-            spinner_color='#fff',
-            button_class='mzp-c-button mzp-t-product') }}
-        {% endif %}
-      </div>
+      {% if LANG.startswith('en-') %}
+        {{ email_newsletter_form(
+          'app-dev',
+          title='Get the most out of Firefox Developer Edition',
+          subtitle='Learn about Dev Edition and subscribe to the Mozilla Developer Newsletter.',
+          button_class='mzp-t-product mzp-t-small',
+          include_language=False,
+          protocol_component=True) }}
+      {% else %}
+        {{ email_newsletter_form(
+          protocol_component=True,
+          spinner_color='#fff',
+          button_class='mzp-c-button mzp-t-product') }}
+      {% endif %}
     </div>
   </section>
 </main>

--- a/bedrock/firefox/templates/firefox/features/adblocker.html
+++ b/bedrock/firefox/templates/firefox/features/adblocker.html
@@ -48,7 +48,7 @@
     </div>
   </section>
 
-  <section class="mzp-l-content l-content-narrow">
+  <section class="mzp-l-content mzp-t-narrow">
     <h2 class="section-title">{{ _('Find the right ad blocker for you') }}</h2>
     <p>
       {% trans url='https://addons.mozilla.org/firefox/addon/adblocker-ultimate/?src=collection&collection_id=314d7111-6e17-485e-9946-315cb2f477e7' %}
@@ -67,7 +67,7 @@
     </p>
   </section>
 
-  <section class="mzp-l-content l-content-narrow">
+  <section class="mzp-l-content mzp-t-narrow">
     <h2 class="section-title">{{_('Create a tracker-free zone with Content Blocking') }}</h2>
     <p>
       {% trans privacy='https://restoreprivacy.com/firefox-privacy/', blocking='https://support.mozilla.org/kb/content-blocking' %}
@@ -80,7 +80,7 @@
     {{ high_res_img('firefox/features/adblocker/content-blocking-title.png', {'alt': '', 'class': 'mzp-c-billboard-image'}) }}
   </section>
 
-  <section class="mzp-l-content l-content-narrow">
+  <section class="mzp-l-content mzp-t-narrow">
     <h2 class="section-title">{{_('Choose your level of protection') }}</h2>
     <p>
       {% trans %}
@@ -89,7 +89,7 @@
     </p>
   </section>
 
-  <section class="mzp-l-content l-content-narrow">
+  <section class="mzp-l-content mzp-t-narrow">
     <h2 class="section-title">{{_('Go easy with Standard mode') }}</h2>
     <p>
       {% trans url=url('firefox.features.private-browsing') %}
@@ -102,7 +102,7 @@
     {{ high_res_img('firefox/features/adblocker/content-blocking.png', {'alt': '', 'class': 'mzp-c-billboard-image'}) }}
   </section>
 
-  <section class=" mzp-l-content l-content-narrow">
+  <section class=" mzp-l-content mzp-t-narrow">
     <h2 class="section-title">{{_('Get tough with Strict mode') }}</h2>
     <p>
       {% trans %}
@@ -111,7 +111,7 @@
     </p>
   </section>
 
-  <section class="mzp-l-content l-content-narrow">
+  <section class="mzp-l-content mzp-t-narrow">
     <h2 class="section-title">{{_('Do-it-yourself Custom mode') }}</h2>
     <p>
       {% trans %}
@@ -124,7 +124,7 @@
     {{ high_res_img('firefox/features/adblocker/content-blocking-custom.png', {'alt': '', 'class': 'mzp-c-billboard-image'}) }}
   </section>
 
-  <section class="mzp-l-content l-content-narrow">
+  <section class="mzp-l-content mzp-t-narrow">
     <h2 class="section-title">{{_('Cover your trail, block trackers') }}</h2>
     <p>
       {% trans %}
@@ -134,7 +134,7 @@
     {{ high_res_img('firefox/features/adblocker/custom-trackers.png', {'alt': ''}) }}
   </section>
 
-  <section class="mzp-l-content l-content-narrow">
+  <section class="mzp-l-content mzp-t-narrow">
     <h2 class="section-title">{{_('Take a bite out of cookies') }}</h2>
     <p>
       {% trans url='https://support.mozilla.org/kb/storage' %}
@@ -149,7 +149,7 @@
     {{ high_res_img('firefox/features/adblocker/third-party-cookies.png', {'alt': ''}) }}
   </section>
 
-  <section class="mzp-l-content l-content-narrow">
+  <section class="mzp-l-content mzp-t-narrow">
     <h2 class="section-title">{{_('Send a Do Not Track signal') }}</h2>
     <p>
       {% trans url='https://support.mozilla.org/kb/how-do-i-turn-do-not-track-feature' %}
@@ -159,7 +159,7 @@
     {{ high_res_img('firefox/features/adblocker/dnt_screenshot.png', {'alt': ''}) }}
   </section>
 
-  <section class="mzp-l-content l-content-narrow">
+  <section class="mzp-l-content mzp-t-narrow">
       <h2 class="section-title">{{_('Speed up thanks to ad blockers') }}</h2>
       <p>
         {% trans %}

--- a/bedrock/firefox/templates/firefox/firstrun/firstrun.html
+++ b/bedrock/firefox/templates/firefox/firstrun/firstrun.html
@@ -68,14 +68,12 @@
               {{_('Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.')}}
             {% endif %}</p>
           </div>
-          <aside class="c-box-emphasis" >
-            <div class="c-box-emphasis-content" id="fxaccounts-wrapper">
-              {{ fxa_email_form(
-                entrypoint=_entrypoint,
-                button_class='mzp-c-button mzp-t-product')
-              }}
-              <p class="fxa-signin">{{ _('Already have an account?') }} <a {{ fxa_link_fragment(entrypoint=_entrypoint, utm_campaign='fxa-embedded-form') }} class="js-fxa-cta-link">{{ _('Sign In') }}</a></p>
-            </div>
+          <aside class="mzp-c-box-emphasis" id="fxaccounts-wrapper">
+            {{ fxa_email_form(
+              entrypoint=_entrypoint,
+              button_class='mzp-c-button mzp-t-product')
+            }}
+            <p class="fxa-signin">{{ _('Already have an account?') }} <a {{ fxa_link_fragment(entrypoint=_entrypoint, utm_campaign='fxa-embedded-form') }} class="js-fxa-cta-link">{{ _('Sign In') }}</a></p>
           </aside>
         </div>
       </div>

--- a/bedrock/firefox/templates/firefox/unsupported-systems.html
+++ b/bedrock/firefox/templates/firefox/unsupported-systems.html
@@ -12,38 +12,36 @@
 {% endblock %}
 
 {% block content %}
-<main class="mzp-l-content">
-  <header class="l-narrow">
+<main class="mzp-l-content mzp-t-narrow">
+  <header class="">
       <a href="{{ url('firefox') }}">{{ high_res_img('logos/firefox/logo-quantum-wordmark-large.png', {'alt': 'Firefox', 'width': '210', 'height': '69'}) }}</a>
     <h1 class="c-header-main">{{ _('Thanks for choosing Firefox!') }}</h1>
     <p class="c-header-subhead">{{_('We’re sorry to report this, but your computer does not meet the minimum system requirements to run this version.')}}</p>
   </header>
 
-  <div class="l-narrow">
-    <section class="c-help-block">
-      <h2 class="c-help-block-title">{{ _('Need <span>Help?</span>') }}</h2>
-      <p>{{ _('Our Support page has plenty of answers, including full instructions for downloading and installing Firefox and a live chat feature to guide you through any tricky spots.') }}</p>
-      <a href="https://support.mozilla.org/products/firefox">{{ _('Visit Firefox Support') }}</a>
-    </section>
+  <section class="c-help-block">
+    <h2 class="c-help-block-title">{{ _('Need <span>Help?</span>') }}</h2>
+    <p>{{ _('Our Support page has plenty of answers, including full instructions for downloading and installing Firefox and a live chat feature to guide you through any tricky spots.') }}</p>
+    <a href="https://support.mozilla.org/products/firefox">{{ _('Visit Firefox Support') }}</a>
+  </section>
 
-    <section class="c-help-block">
-      <h2 class="c-help-block-title">{{ _('For more information on supported systems') }}</h2>
-      <a href="{{ url('firefox.sysreq') }}">{{ _('View System Requirements') }}</a>
-    </section>
+  <section class="c-help-block">
+    <h2 class="c-help-block-title">{{ _('For more information on supported systems') }}</h2>
+    <a href="{{ url('firefox.sysreq') }}">{{ _('View System Requirements') }}</a>
+  </section>
 
-    <div class="c-help-block">
-      <p>
-      {% trans %}
-        To make your computer more secure, we recommend upgrading your operating system to a newer version
-        as soon as possible (plus, you’ll be able to use Firefox!). But, if you can’t do so, here are some
-        alternate browsers that should be compatible with your current system:
-      {% endtrans %}
-      </p>
-      <ul class="mzp-u-list-styled">
-        <li>{{ _('<a href="%s">Opera</a> for Windows 95 and above and Mac OS 10.3 and above')|format('https://www.opera.com/') }}</li>
-        <li>{{ _('<a href="%s">iCab</a> for Mac OS 10.3 and above')|format('http://www.icab.de/') }}</li>
-      </ul>
-    </div>
+  <div class="c-help-block">
+    <p>
+    {% trans %}
+      To make your computer more secure, we recommend upgrading your operating system to a newer version
+      as soon as possible (plus, you’ll be able to use Firefox!). But, if you can’t do so, here are some
+      alternate browsers that should be compatible with your current system:
+    {% endtrans %}
+    </p>
+    <ul class="mzp-u-list-styled">
+      <li>{{ _('<a href="%s">Opera</a> for Windows 95 and above and Mac OS 10.3 and above')|format('https://www.opera.com/') }}</li>
+      <li>{{ _('<a href="%s">iCab</a> for Mac OS 10.3 and above')|format('http://www.icab.de/') }}</li>
+    </ul>
   </div>
 </main>
 {% endblock %}

--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx67.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx67.html
@@ -137,14 +137,12 @@
         <h2 class="c-sticky-signup-title">{{ _('Get the latest news from Mozilla and Firefox right in your inbox.') }}</h2>
         <button type="button" class="sticky-dismiss" data-parent="newsletter-sticky-form">{{ _('Close') }}</button>
       </div>
-      <div class="mzp-c-newsletter">
-        {{ email_newsletter_form(
-          protocol_component=True,
-          include_title=False,
-          spinner_color='#fff',
-          button_class='mzp-c-button mzp-t-product mzp-t-small')
-        }}
-      </div>
+      {{ email_newsletter_form(
+        protocol_component=True,
+        include_title=False,
+        spinner_color='#fff',
+        button_class='mzp-c-button mzp-t-product mzp-t-small')
+      }}
     </div>
     {% endif %}
   </section>

--- a/bedrock/mozorg/templates/mozorg/about/policy/lean-data/build-security.html
+++ b/bedrock/mozorg/templates/mozorg/about/policy/lean-data/build-security.html
@@ -19,7 +19,7 @@
 
 {% block content %}
 <section class="mzp-c-hero mzp-has-image">
-  <div class="mzp-l-content l-content-narrow">
+  <div class="mzp-l-content t-lg">
     <div class="mzp-c-hero-body">
       <h1 class="mzp-c-hero-title">{{ _('Build Security') }}</h1>
 
@@ -35,7 +35,7 @@
 </section>
 
 <section>
-  <div class="mzp-l-content l-content-narrow">
+  <div class="mzp-l-content mzp-t-narrow">
     <h2 class="c-section-title">{{ _('1. Who has access to your data?') }}</h2>
 
     <p>
@@ -106,7 +106,7 @@
 
 
 <section class="principles-other">
-  <div class="mzp-l-content l-content-narrow mzp-l-card-half">
+  <div class="mzp-l-content t-lg mzp-l-card-half">
 
     <div class="mzp-c-card mzp-has-aspect-1-1">
       <a class="mzp-c-card-block-link" href="{{ url('mozorg.about.policy.lean-data.stay-lean') }}">
@@ -136,7 +136,7 @@
 </section>
 
 <aside class="contact mzp-c-call-out-compact">
-  <div class="mzp-l-content l-content-narrow">
+  <div class="mzp-l-content mzp-t-narrow">
     <div class="mzp-c-call-out-content">
       <div class="mzp-c-call-out-container">
         <h3 class="mzp-c-call-out-title">{{ _('Drive the conversation in your organization.') }}</h3>

--- a/bedrock/mozorg/templates/mozorg/about/policy/lean-data/engage-users.html
+++ b/bedrock/mozorg/templates/mozorg/about/policy/lean-data/engage-users.html
@@ -19,7 +19,7 @@
 
 {% block content %}
 <section class="mzp-c-hero mzp-has-image">
-  <div class="mzp-l-content l-content-narrow">
+  <div class="mzp-l-content t-lg">
     <div class="mzp-c-hero-body">
       <h1 class="mzp-c-hero-title">{{ _('Engage Users') }}</h1>
 
@@ -35,7 +35,7 @@
 </section>
 
 <section>
-  <div class="mzp-l-content l-content-narrow">
+  <div class="mzp-l-content mzp-t-narrow">
 
     <h2 class="c-section-title">{{ _('1. Have you put your data collection in context?') }}</h2>
 
@@ -129,7 +129,7 @@
 </section>
 
 <section class="principles-other">
-  <div class="mzp-l-content l-content-narrow mzp-l-card-half">
+  <div class="mzp-l-content t-lg mzp-l-card-half">
 
     <div class="mzp-c-card mzp-has-aspect-1-1">
       <a class="mzp-c-card-block-link" href="{{ url('mozorg.about.policy.lean-data.stay-lean') }}">
@@ -159,7 +159,7 @@
 </section>
 
 <aside class="contact mzp-c-call-out-compact">
-  <div class="mzp-l-content l-content-narrow">
+  <div class="mzp-l-content">
     <div class="mzp-c-call-out-content">
       <div class="mzp-c-call-out-container">
         <h3 class="mzp-c-call-out-title">{{ _('Drive the conversation in your organization.') }}</h3>

--- a/bedrock/mozorg/templates/mozorg/about/policy/lean-data/stay-lean.html
+++ b/bedrock/mozorg/templates/mozorg/about/policy/lean-data/stay-lean.html
@@ -19,7 +19,7 @@
 
 {% block content %}
 <section class="mzp-c-hero mzp-has-image">
-  <div class="mzp-l-content l-content-narrow">
+  <div class="mzp-l-content t-lg">
     <div class="mzp-c-hero-body">
       <h1 class="mzp-c-hero-title">{{ _('Stay Lean') }}</h1>
 
@@ -34,7 +34,7 @@
   </div>
 </section>
 
-<section class="mzp-l-content l-content-narrow">
+<section class="mzp-l-content mzp-t-narrow">
   <h2 class="c-section-title">{{ _('1. What data do you have?') }}</h2>
 
   <p>{{ _('Understanding what data you collect is easier said than done – there is almost always more than you think.') }}</p>
@@ -109,7 +109,7 @@
 </section>
 
 <section class="principles-other">
-  <div class="mzp-l-content l-content-narrow mzp-l-card-half">
+  <div class="mzp-l-content t-lg mzp-l-card-half">
 
     <div class="mzp-c-card mzp-has-aspect-1-1">
       <a class="mzp-c-card-block-link" href="{{ url('mozorg.about.policy.lean-data.build-security') }}">
@@ -139,7 +139,7 @@
 </section>
 
 <aside class="contact mzp-c-call-out-compact">
-  <div class="mzp-l-content l-content-narrow">
+  <div class="mzp-l-content">
     <div class="mzp-c-call-out-content">
       <div class="mzp-c-call-out-container">
         <h3 class="mzp-c-call-out-title">{{ _('Drive the conversation in your organization.') }}</h3>

--- a/bedrock/privacy/templates/privacy/base-protocol.html
+++ b/bedrock/privacy/templates/privacy/base-protocol.html
@@ -61,10 +61,8 @@
       {% endif %}
     </header>
     <main class="privacy-body" itemprop="articleBody">
-      <div class="l-narrow">
       {% block sections %}
       {% endblock %}
-      </div>
     </main>
     <footer class="privacy-footnote">
       <div>

--- a/media/css/firefox/developer/includes/newsletter.scss
+++ b/media/css/firefox/developer/includes/newsletter.scss
@@ -18,11 +18,9 @@
         max-width: $content-sm;
     }
 
-    .mzp-c-newsletter {
-        display: block;
-        margin-bottom: 0;
-        padding: 0;
-        text-align: center;
+    .mzp-c-newsletter-form {
+        padding-top: 0;
+        @include font-size(14px);
 
         input[type=email] {
             border: 2px solid $color-gray-30;
@@ -37,11 +35,6 @@
         legend {
             @include font-size(14px);
         }
-    }
-
-    .mzp-c-newsletter-form {
-        padding-top: 0;
-        @include font-size(14px);
     }
 
     .mzp-c-newsletter-title {
@@ -86,10 +79,6 @@
 
         .mzp-l-content {
             max-width: $content-xl;
-        }
-
-        .mzp-c-newsletter {
-            text-align: left;
         }
 
         .mzp-c-newsletter-form {

--- a/media/css/firefox/enterprise/sla.scss
+++ b/media/css/firefox/enterprise/sla.scss
@@ -11,12 +11,6 @@ $font-path: '/media/fonts';
 
 $border: 2px solid $color-gray-20;
 
-.l-narrow {
-    margin: 0 auto;
-    max-width: 640px;
-    padding: 0 $spacing-lg;
-}
-
 .mzp-l-sidebar {
     position: -webkit-sticky;
     position: sticky;

--- a/media/css/firefox/features/adblocker.scss
+++ b/media/css/firefox/features/adblocker.scss
@@ -26,12 +26,11 @@ ul li span {
     }
 }
 
-.mzp-l-content.l-content-narrow {
-    max-width: $content-md;
-        p {
-            text-align: left;
-        }
+.mzp-l-content.mzp-t-narrow {
+    p {
+        text-align: left;
     }
+}
 
 .l-content-image {
     max-width: $content-lg;

--- a/media/css/firefox/firstrun/firstrun.scss
+++ b/media/css/firefox/firstrun/firstrun.scss
@@ -7,6 +7,7 @@ $image-path: '/media/protocol/img';
 $break-large: 1305px;
 
 @import '../../../protocol/css/includes/lib';
+@import '../../../protocol/css/components/emphasis-box';
 
 
 //* -------------------------------------------------------------------------- */
@@ -82,18 +83,8 @@ section .mzp-l-content, div.mzp-c-hero-image, .browser-logo img {
     text-align: center;
 }
 
-/* -------------------------------------------------------------------------- */
-// Emphasis Box style, this should go away when Protocal PR #441 is landed. Issue #385
-
-.c-box-emphasis {
-    background: $color-white;
-    border-radius: 6px;
-    box-shadow: 0 0 10px 0 $color-gray-30;
+.mzp-c-box-emphasis {
     text-align: center;
-
-    .c-box-emphasis-content {
-        padding: $spacing-xl;
-    }
 }
 
 @media #{$mq-sm} {

--- a/media/css/firefox/unsupported-systems.scss
+++ b/media/css/firefox/unsupported-systems.scss
@@ -7,15 +7,6 @@ $image-path: '/media/protocol/img';
 
 @import '../../protocol/css/includes/lib';
 
-.l-narrow {
-    margin: 0 auto;
-    max-width: 640px;
-
-    @media #{$mq-md} {
-        padding: 0 $spacing-lg;
-    }
-}
-
 .c-header-logo {
     @media #{$mq-sm} {
         margin-top: $layout-sm;

--- a/media/css/firefox/whatsnew/whatsnew-67.scss
+++ b/media/css/firefox/whatsnew/whatsnew-67.scss
@@ -383,13 +383,6 @@ main {
         }
     }
 
-    .mzp-c-newsletter {
-        @include bidi(((text-align, left, right),));
-        display: block;
-        padding: 0;
-        margin: 0 auto;
-    }
-
     .mzp-c-newsletter-form {
         padding-top: 0;
     }
@@ -431,10 +424,6 @@ main {
     }
 
     @media #{$mq-md} {
-        .mzp-c-newsletter {
-            margin: 0;
-        }
-
         .mzp-c-newsletter-content {
             @include bidi(((padding-right, 40%, padding-left, 0),));
             position: relative;

--- a/media/css/mozorg/lean-data.scss
+++ b/media/css/mozorg/lean-data.scss
@@ -10,7 +10,7 @@ $image-path: '/media/protocol/img';
 @import '../../protocol/css/components/hero';
 @import '../../protocol/css/templates/card-layout';
 
-.mzp-l-content.l-content-narrow {
+.t-lg {
     max-width: $content-lg;
 }
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Making mozilla.org awesome, one pebble at a time",
   "private": true,
   "dependencies": {
-    "@mozilla-protocol/core": "8.0.0",
+    "@mozilla-protocol/core": "8.1.0",
     "@mozilla-protocol/eslint-config": "^1.1.0",
     "ansi-colors": "4.1.1",
     "clean-css-cli": "4.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -138,10 +138,10 @@
     normalize-path "^2.0.1"
     through2 "^2.0.3"
 
-"@mozilla-protocol/core@8.0.0":
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/@mozilla-protocol/core/-/core-8.0.0.tgz#3b23c0bdc00f0585a8fbc88a36915b399cbd13e8"
-  integrity sha512-ZH4DYhdL/RjvFJymWxNEzCX7aIwwjsMsa0xmlxgasLALYpLR4UsT6zvwBSvpMEGuwBQJQG26I0FBaJNwU0BW2A==
+"@mozilla-protocol/core@8.1.0":
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/@mozilla-protocol/core/-/core-8.1.0.tgz#bcb47ddf60a6415e863bc731b5232b69f3030b12"
+  integrity sha512-otL2dpirCaiS2xpl4pNe9mCE7URge/WzXdZ80LO01bY+ualsbmpe/7ewyQE83Q4CjbwITcjdXydpWhjbcAmz2w==
 
 "@mozilla-protocol/eslint-config@^1.1.0":
   version "1.1.0"


### PR DESCRIPTION
## Description

- Update Protocol version to 8.1.0
- Use Protocol's emphasis box
- Convert narrow content to use mzp-t-narrow where possible
- Remove mzp-c-newsletter class from places where its styles were overridden (mostly in places that did not have an image to the left of the form)

## Issue / Bugzilla link

Fix #7734

## Testing

Remember to `make build`.

- Emphasis box: 
  - http://localhost:8000/en-US/firefox/64.0/firstrun/
- Narrow content:
  - http://localhost:8000/en-US/about/policy/lean-data/stay-lean/
  - http://localhost:8000/en-US/about/policy/lean-data/engage-users/
  - http://localhost:8000/en-US/about/policy/lean-data/build-security/
  - http://localhost:8000/en-US/firefox/features/adblocker/
  - http://localhost:8000/en-US/firefox/unsupported-systems/
  - http://localhost:8000/en-US/firefox/enterprise/sla/ (just removed a class that appeared to not be in use)
  - http://localhost:8000/en-US/privacy/firefox/ (just removed a class that appeared to not be in use)
  - intentionally left the system requirements template alone
- Newsletter:
  - http://localhost:8000/en-US/firefox/developer/
  - http://localhost:8000/en-US/firefox/67.0/whatsnew/
  - unchanged, check it didn't break: http://localhost:8000/en-US/about/governance/policies/
  - unchanged, check it didn't break: http://localhost:8000/en-US/
  - I left the older What's New pages alone because they will be decommissioned on their own