### PR TITLE
Make sure jQuery is included if convert switch is set to off (#7508)

### DIFF
--- a/bedrock/exp/templates/exp/base/base.html
+++ b/bedrock/exp/templates/exp/base/base.html
@@ -11,6 +11,8 @@
     {# Pre-fetch the DNS lookup prior to loading the convert script #}
     <link rel="dns-prefetch" href="https://cdn-3.convertexperiments.com/">
     {{ js_bundle('convert') }}
+  {% else %}
+    {{ js_bundle('jquery') }}
   {% endif %}
 {% endblock %}
 


### PR DESCRIPTION
## Description
- Small followup to #7508, to make sure that jQuery is still loaded if the convert swithc is set to off.

## Issue / Bugzilla link
#7508

## Testing
- [ ] When `Dev=False` a JS error should no longer be thrown in the console.