### PR TITLE
Update UITour library for showProtectionReport (Fixes #7753)

### DIFF
--- a/docs/uitour.rst
+++ b/docs/uitour.rst
@@ -632,6 +632,19 @@ Opens about:newtab in the same tab.
 
     This function is only available in Firefox 51 onward.
 
+showProtectionReport();
+^^^^^^^^^^^^^^^^^^^^^^^
+
+Opens about:protections in the same tab.
+
+.. code-block:: javascript
+
+    Mozilla.UITour.showProtectionReport();
+
+.. Important::
+
+    This function is only available in Firefox 70 onward.
+
 .. _Mozilla Central: http://dxr.mozilla.org/mozilla-central/source/browser/components/uitour/UITour-lib.js
 .. _Telemetry: https://wiki.mozilla.org/Telemetry
 .. _FHR: https://support.mozilla.org/en-US/kb/firefox-health-report-understand-your-browser-perf

--- a/media/js/base/uitour-lib.js
+++ b/media/js/base/uitour-lib.js
@@ -172,6 +172,14 @@ if (typeof window.Mozilla === 'undefined') {
         _sendEvent('showNewTab');
     };
 
+    /**
+    * Loads about:protections in the tour tab.
+    * @since 70
+    */
+    Mozilla.UITour.showProtectionReport = function() {
+        _sendEvent('showProtectionReport');
+    };
+
     Mozilla.UITour.getConfiguration = function(configName, callback) {
         _sendEvent('getConfiguration', {
             callbackID: _waitForCallback(callback),


### PR DESCRIPTION
## Description
- Adds a new UITour function required for Skyline related pages.

## Issue / Bugzilla link
#7753

## Testing
Please make sure you have enabled UITour for local testing, using the [instructions here](https://bedrock.readthedocs.io/en/latest/uitour.html#local-development).

1. Open http://127.0.0.1:8000/en-US/privacy/firefox/
2. Open the Web Console.
3. Paste Mozilla.UITour.showProtectionReport();

Expected result:

The `about:protections` page should open in the same tab.