### PR TITLE
Privacy preferences button is missing on /privacy/firefox/ (Fixes #7758)

### DIFF
--- a/media/js/privacy/privacy-firefox.js
+++ b/media/js/privacy/privacy-firefox.js
@@ -52,7 +52,7 @@
     // Don't execute if features aren't supported and client isn't desktop Firefox
     if (supportsBaselineJS() && Mozilla.Client.isFirefoxDesktop) {
         strings = document.getElementById('strings');
-        topicHeaders = document.querySelectorAll('.privacy-body > div > section');
+        topicHeaders = document.querySelectorAll('.privacy-body > section');
         initialTopic = topicHeaders[0].querySelector('section > *:last-child');
 
         // check that the UITour works (requires base/uitour-lib.js)


### PR DESCRIPTION
## Description
- Fixes bug described in the issue linked below.

## Issue / Bugzilla link
https://github.com/mozilla/bedrock/issues/7758

## Testing
Please test using Firefox, with [UITour enabled](https://bedrock.readthedocs.io/en/latest/uitour.html#local-development) for local development.
- [x] Button should be visible after expanding the "Improve performance and stability for users everywhere" section.
- [x] No JS error in the console.