### PR TITLE
Redirect to send tab sumo article

### DIFF
--- a/bedrock/firefox/redirects.py
+++ b/bedrock/firefox/redirects.py
@@ -598,7 +598,8 @@ redirectpatterns = (
     # fxa
     redirect(r'^firefox/accounts/features/?', 'firefox.accounts'),
     redirect(r'^firefox/features/sync/?', 'firefox.accounts'),
-    redirect(r'^firefox/features/send-tabs/?', 'firefox.accounts'),
+    # bug 1577449
+    redirect(r'^firefox/features/send-tabs/?', 'https://support.mozilla.org/kb/send-tab-firefox-desktop-other-devices'),
 
     # issue 6512
     redirect(r'^firefox/firefox\.html$', 'firefox.new'),


### PR DESCRIPTION
## Description

This is the Firefox send tab menu:

<img width="375" alt="Screen Shot 2019-09-20 at 1 26 40 PM" src="https://user-images.githubusercontent.com/6424575/65346265-4defdf80-dbaa-11e9-97d1-73cb6590512c.png">

The "learn about send tab" menu item links to a marketing page that was removed. Let's redirect users to the sumo page instead.

## Issue / Bugzilla link

See bug 1577449.

## Testing
