### PR TITLE
Update fxa_link_fragment to use signin not login (#7783)

### DIFF
--- a/bedrock/firefox/templates/firefox/developer/whatsnew-fx68.html
+++ b/bedrock/firefox/templates/firefox/developer/whatsnew-fx68.html
@@ -20,13 +20,13 @@
   {{ fxa_cta_link(entrypoint=_entrypoint, action='signup', button_text=_('Create a Firefox Account'), button_class='mzp-c-button mzp-t-product', utm_campaign='wnp68a2', utm_content='accounts-page-top-cta') }}<br>
 
   {% if l10n_has_tag('wnp66_log_in') %}
-  {% set link = fxa_link_fragment(entrypoint=_entrypoint, action='login', utm_campaign='wnp68a2', utm_content='accounts-page-top-cta') %}
+  {% set link = fxa_link_fragment(entrypoint=_entrypoint, action='signin', utm_campaign='wnp68a2', utm_content='accounts-page-top-cta') %}
   <span class="wn64-signin">
     {{ _('Have an account? <a %s >Log in</a>')|format(link) }}
   </span>
   {% else %}
   <span class="wn64-signin">
-    <a {{ fxa_link_fragment(entrypoint=_entrypoint, action='login', utm_campaign='wnp68a2', utm_content='accounts-page-top-cta') }} class="js-fxa-cta-link">{{ _('Already have an account?') }}</a>
+    <a {{ fxa_link_fragment(entrypoint=_entrypoint, utm_campaign='wnp68a2', utm_content='accounts-page-top-cta') }} class="js-fxa-cta-link">{{ _('Already have an account?') }}</a>
   </span>
   {% endif %}
 </p>

--- a/bedrock/firefox/templates/firefox/whatsnew/beta/whatsnew-fx68.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/beta/whatsnew-fx68.html
@@ -20,13 +20,13 @@
   </a><br>
 
   {% if l10n_has_tag('wnp66_log_in') %}
-  {% set link = fxa_link_fragment(entrypoint='mozilla.org-whatsnew68beta', action='login', utm_campaign='wnp68beta', utm_content='accounts-page-top-cta') %}
+  {% set link = fxa_link_fragment(entrypoint='mozilla.org-whatsnew68beta', action='signin', utm_campaign='wnp68beta', utm_content='accounts-page-top-cta') %}
   <span class="wn64-signin">
     {{ _('Have an account? <a %s >Log in</a>')|format(link) }}
   </span>
   {% else %}
   <span class="wn64-signin">
-    <a {{ fxa_link_fragment(entrypoint='mozilla.org-whatsnew68beta', action='login', utm_campaign='wnp68beta', utm_content='accounts-page-top-cta') }} class="js-fxa-cta-link">{{ _('Already have an account?') }}</a>
+    <a {{ fxa_link_fragment(entrypoint='mozilla.org-whatsnew68beta', utm_campaign='wnp68beta', utm_content='accounts-page-top-cta') }} class="js-fxa-cta-link">{{ _('Already have an account?') }}</a>
   </span>
   {% endif %}
 </p>

--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx66.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx66.html
@@ -83,13 +83,13 @@
     {{ fxa_cta_link(entrypoint='mozilla.org-whatsnew66', action='signup', button_text=_('Create a Firefox Account'), button_class='mzp-c-button mzp-t-product', utm_campaign='wnp66', utm_content='accounts-page-top-cta') }}<br>
 
     {% if l10n_has_tag('wnp66_log_in') %}
-    {% set link = fxa_link_fragment(entrypoint='mozilla.org-whatsnew66', action='login', utm_campaign='wnp66', utm_content='accounts-page-top-cta') %}
+    {% set link = fxa_link_fragment(entrypoint='mozilla.org-whatsnew66', action='signin', utm_campaign='wnp66', utm_content='accounts-page-top-cta') %}
     <span class="wn64-signin">
       {{ _('Have an account? <a %s >Log in</a>')|format(link) }}
     </span>
     {% else %}
     <span class="wn64-signin">
-      <a {{ fxa_link_fragment(entrypoint='mozilla.org-whatsnew66', action='login', utm_campaign='wnp66', utm_content='accounts-page-top-cta') }} class="js-fxa-cta-link">{{ _('Already have an account?') }}</a>
+      <a {{ fxa_link_fragment(entrypoint='mozilla.org-whatsnew66', utm_campaign='wnp66', utm_content='accounts-page-top-cta') }} class="js-fxa-cta-link">{{ _('Already have an account?') }}</a>
     </span>
     {% endif %}
   </p>


### PR DESCRIPTION
## Description

- Updated links to login to sign in explicitly
- Updated links to "already have an account" to use the default flow, which checks an email address to see if an account exists

## Issue / Bugzilla link

Fix #7783

## Testing

Visit in Firefox logged-out of accounts:

- http://localhost:8000/en-US/firefox/66.0/whatsnew/all/
- I can't figure out the URLs for the dev and beta pages 😅 I think they should be here https://github.com/mozilla/bedrock/pull/7073 but I can't find the strings on those pages.