### PR TITLE
Identify iPadOS as iOS and not macOS (Fixes #7299)

### DIFF
--- a/media/js/base/site.js
+++ b/media/js/base/site.js
@@ -52,7 +52,8 @@
             }
             if (pf.indexOf('iPhone') !== -1 ||
                     pf.indexOf('iPad') !== -1 ||
-                    pf.indexOf('iPod') !== -1 ) {
+                    pf.indexOf('iPod') !== -1 ||
+                    pf.indexOf('MacIntel') !== -1 && 'standalone' in navigator) {
                 return 'ios';
             }
             if (ua.indexOf('Mac OS X') !== -1) {

--- a/tests/unit/spec/base/site.js
+++ b/tests/unit/spec/base/site.js
@@ -3,6 +3,8 @@
  * Sinon docs: http://sinonjs.org/docs/
  */
 
+/* global sinon */
+
 describe('site.js', function () {
 
     'use strict';
@@ -52,6 +54,11 @@ describe('site.js', function () {
             expect(window.site.getPlatform('foo', 'iPad')).toBe('ios');
             expect(window.site.getPlatform('foo', 'iPod')).toBe('ios');
             expect(window.site.getPlatform('foo', 'iPhone Simulator')).toBe('ios');
+        });
+
+        it('should identify iPadOS', function () {
+            window.navigator.standalone = sinon.stub();
+            expect(window.site.getPlatform('foo', 'MacIntel')).toBe('ios');
         });
 
         it('should identify OSX', function () {


### PR DESCRIPTION
## Description
- Fixes iOS detection for iPad running iPadOS.

## Issue / Bugzilla link
#7299

## Testing
- [ ] Clicking a download button should redirect to the app store and not deliver a .dmg