### PR TITLE
Change lifecycle page instrumentation to a better standard format

### DIFF
--- a/bedrock/firefox/templates/firefox/welcome/page1.html
+++ b/bedrock/firefox/templates/firefox/welcome/page1.html
@@ -29,8 +29,8 @@
 
     <p class="primary-cta">
       {{ monitor_button(
-        entrypoint='mozilla.org-firefox-lifecycle-resources',
-        utm_campaign='LifecycleP1',
+        entrypoint='mozilla.org-firefox-welcome-1',
+        utm_campaign='welcome-1-monitor',
         button_text=_('Check Your Breach Report'),
         cta_type="Lifecycle-Monitor",
       ) }}
@@ -64,7 +64,7 @@
     <div class="c-picto-block-body">
       <p>
       {# L10n: "Evite" is a proper name and shouldn't be translated. #}
-      {% trans evite_breach='https://blog.mozilla.org/firefox/evite-data-breach/?utm_source=mozilla.org-firefox-lifecycle-resources&utm_medium=referral&utm_campaign=LifecycleP1&entrypoint=mozilla.org-firefox-lifecycle-resources' %}
+      {% trans evite_breach='https://blog.mozilla.org/firefox/evite-data-breach/?utm_source=mozilla.org-firefox-welcome-1&utm_medium=referral&utm_campaign=welcome-1-monitor&entrypoint=mozilla.org-firefox-welcome-1' %}
         Were you one of 100,985,047 invited to the <a href="{{ evite_breach }}">Evite data breach “party”</a>?
       {% endtrans %}
       </p>
@@ -74,7 +74,7 @@
 {% endblock %}
 
 {% block content_utility %}
-  <p><strong><a href="https://support.mozilla.org/kb/firefox-browser-welcome-pages/?utm_source=mozilla.org-firefox-lifecycle-resources&utm_medium=referral&utm_campaign=LifecycleP1&entrypoint=mozilla.org-firefox-lifecycle-resources">{{ _('Why am I seeing this?') }}</a></strong></p>
+  <p><strong><a href="https://support.mozilla.org/kb/firefox-browser-welcome-pages/?utm_source=mozilla.org-firefox-welcome-1&utm_medium=referral&utm_campaign=welcome-1-monitor&entrypoint=mozilla.org-firefox-welcome-1">{{ _('Why am I seeing this?') }}</a></strong></p>
 {% endblock %}
 
 {% block js %}

--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -969,8 +969,8 @@ def firefox_welcome_page1(request):
 
     # get localized blog post URL for 2019 page
     breach_tips_query = (
-        '?utm_source=mozilla.org-firefox-lifecycle-resources&amp;utm_medium=referral'
-        '&amp;utm_campaign=LifecycleP1&ampentrypoint=mozilla.org-firefox-lifecycle-resources'
+        '?utm_source=mozilla.org-firefox-welcome-1&amp;utm_medium=referral'
+        '&amp;utm_campaign=welcome-1-monitor&ampentrypoint=mozilla.org-firefox-welcome-1'
     )
     breach_tips_url = BREACH_TIPS_URLS.get(locale, BREACH_TIPS_URLS['en-US'])
 

--- a/docs/firefox-accounts.rst
+++ b/docs/firefox-accounts.rst
@@ -17,6 +17,15 @@ Bedrock pages are often used to promote the creation of `Firefox Accounts`_ as a
     All query string parameters passed to the macros below need to pass the `query parameters validation
     <https://mozilla.github.io/application-services/docs/accounts/metrics.html#descriptions-of-metrics-related-query-parameters>`_ applied by the Firefox Accounts server.
 
+Conventions
+-----------
+
+When choosing URL parameter values, the following conventions help support uniformity in code and predictability in retroactive analysis.
+
+* Use lower case characters in parameter values.
+* Separate words in parameter values with hyphens.
+* Follow parameter naming patterns established in previous iterations of a page.
+
 Signup Form
 -----------
 


### PR DESCRIPTION
## Description

* Modifies parameters on lifecycle page 1 to anticipate lifecycle page 2
* Modifies parameters on lifecycle page 1 to correspond to conventions
* Documents conventions