### PR TITLE
[fix #7799] redirect welcome/1 to welcome/1/ (with trailing slash)

### DIFF
--- a/bedrock/firefox/urls.py
+++ b/bedrock/firefox/urls.py
@@ -108,7 +108,7 @@ urlpatterns = (
     url('^firefox/stub_attribution_code/$', views.stub_attribution_code,
         name='firefox.stub_attribution_code'),
 
-    url(r'^firefox/welcome/1', views.firefox_welcome_page1, name='firefox.welcome.page1'),
+    url(r'^firefox/welcome/1/$', views.firefox_welcome_page1, name='firefox.welcome.page1'),
 
     page('firefox/switch', 'firefox/switch.html'),
     page('firefox/pocket', 'firefox/pocket.html'),


### PR DESCRIPTION
## Description
Updates the URL regex to require a trailing slash.

## Issue / Bugzilla link
#7799 