### PR TITLE
Changed url() to re_path() for Django 2.2 updates

### DIFF
--- a/bedrock/urls.py
+++ b/bedrock/urls.py
@@ -4,7 +4,7 @@
 
 from django.conf import settings
 from django.conf.urls import handler404
-from django.urls import include, re_path
+from django.urls import include, path
 
 from django.utils.module_loading import import_string
 
@@ -18,25 +18,25 @@ handler500 = 'bedrock.base.views.server_error_view'
 
 urlpatterns = (
     # Main pages
-    re_path(r'^foundation/', include('bedrock.foundation.urls')),
-    re_path(r'^grants/', include('bedrock.grants.urls')),
-    re_path(r'^about/legal/', include('bedrock.legal.urls')),
-    re_path(r'^press/', include('bedrock.press.urls')),
-    re_path(r'^privacy/', include('bedrock.privacy.urls')),
-    re_path(r'^styleguide/', include('bedrock.styleguide.urls')),
-    re_path(r'^security/', include('bedrock.security.urls')),
-    re_path(r'', include('bedrock.firefox.urls')),
-    re_path(r'', include('bedrock.mozorg.urls')),
-    re_path(r'', include('bedrock.newsletter.urls')),
-    re_path(r'^etc/', include('bedrock.etc.urls')),
-    re_path(r'^exp/', include('bedrock.exp.urls')),
+    path('foundation/', include('bedrock.foundation.urls')),
+    path('grants/', include('bedrock.grants.urls')),
+    path('about/legal/', include('bedrock.legal.urls')),
+    path('press/', include('bedrock.press.urls')),
+    path('privacy/', include('bedrock.privacy.urls')),
+    path('styleguide/', include('bedrock.styleguide.urls')),
+    path('security/', include('bedrock.security.urls')),
+    path('', include('bedrock.firefox.urls')),
+    path('', include('bedrock.mozorg.urls')),
+    path('', include('bedrock.newsletter.urls')),
+    path('etc/', include('bedrock.etc.urls')),
+    path('exp/', include('bedrock.exp.urls')),
 
-    re_path(r'^healthz/$', watchman_views.ping, name="watchman.ping"),
-    re_path(r'^readiness/$', watchman_views.status, name="watchman.status"),
-    re_path(r'^healthz-cron/$', base_views.cron_health_check),
-    re_path(r'^csp-violation-capture$', base_views.csp_violation_capture,
+    path('healthz/', watchman_views.ping, name="watchman.ping"),
+    path('readiness/', watchman_views.status, name="watchman.status"),
+    path('healthz-cron/', base_views.cron_health_check),
+    path('csp-violation-capture', base_views.csp_violation_capture,
         name='csp-violation-capture'),
-    re_path(r'^country-code\.json$', base_views.geolocate,
+    path('country-code\.json', base_views.geolocate,
         name='geolocate')
 )
 
@@ -46,6 +46,6 @@ if settings.DEBUG:
         return import_string(handler404)(request, '')
 
     urlpatterns += (
-        re_path(r'^404/$', show404),
-        re_path(r'^500/$', import_string(handler500)),
+        path('404/', show404),
+        path('500/', import_string(handler500)),
     )

--- a/bedrock/urls.py
+++ b/bedrock/urls.py
@@ -3,7 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 from django.conf import settings
-from django.conf.urls import handler404, include, url
+from django.urls import handler404, include, re_path
 
 from django.utils.module_loading import import_string
 
@@ -17,25 +17,25 @@ handler500 = 'bedrock.base.views.server_error_view'
 
 urlpatterns = (
     # Main pages
-    url(r'^foundation/', include('bedrock.foundation.urls')),
-    url(r'^grants/', include('bedrock.grants.urls')),
-    url(r'^about/legal/', include('bedrock.legal.urls')),
-    url(r'^press/', include('bedrock.press.urls')),
-    url(r'^privacy/', include('bedrock.privacy.urls')),
-    url(r'^styleguide/', include('bedrock.styleguide.urls')),
-    url(r'^security/', include('bedrock.security.urls')),
-    url(r'', include('bedrock.firefox.urls')),
-    url(r'', include('bedrock.mozorg.urls')),
-    url(r'', include('bedrock.newsletter.urls')),
-    url(r'^etc/', include('bedrock.etc.urls')),
-    url(r'^exp/', include('bedrock.exp.urls')),
+    re_path(r'^foundation/', include('bedrock.foundation.urls')),
+    re_path(r'^grants/', include('bedrock.grants.urls')),
+    re_path(r'^about/legal/', include('bedrock.legal.urls')),
+    re_path(r'^press/', include('bedrock.press.urls')),
+    re_path(r'^privacy/', include('bedrock.privacy.urls')),
+    re_path(r'^styleguide/', include('bedrock.styleguide.urls')),
+    re_path(r'^security/', include('bedrock.security.urls')),
+    re_path(r'', include('bedrock.firefox.urls')),
+    re_path(r'', include('bedrock.mozorg.urls')),
+    re_path(r'', include('bedrock.newsletter.urls')),
+    re_path(r'^etc/', include('bedrock.etc.urls')),
+    re_path(r'^exp/', include('bedrock.exp.urls')),
 
-    url(r'^healthz/$', watchman_views.ping, name="watchman.ping"),
-    url(r'^readiness/$', watchman_views.status, name="watchman.status"),
-    url(r'^healthz-cron/$', base_views.cron_health_check),
-    url(r'^csp-violation-capture$', base_views.csp_violation_capture,
+    re_path(r'^healthz/$', watchman_views.ping, name="watchman.ping"),
+    re_path(r'^readiness/$', watchman_views.status, name="watchman.status"),
+    re_path(r'^healthz-cron/$', base_views.cron_health_check),
+    re_path(r'^csp-violation-capture$', base_views.csp_violation_capture,
         name='csp-violation-capture'),
-    url(r'^country-code\.json$', base_views.geolocate,
+    re_path(r'^country-code\.json$', base_views.geolocate,
         name='geolocate')
 )
 
@@ -45,6 +45,6 @@ if settings.DEBUG:
         return import_string(handler404)(request, '')
 
     urlpatterns += (
-        url(r'^404/$', show404),
-        url(r'^500/$', import_string(handler500)),
+        re_path(r'^404/$', show404),
+        re_path(r'^500/$', import_string(handler500)),
     )

--- a/bedrock/urls.py
+++ b/bedrock/urls.py
@@ -1,3 +1,5 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
@@ -13,11 +15,10 @@ from watchman import views as watchman_views
 
 # The default django 500 handler doesn't run the ContextProcessors, which breaks
 # the base template page. So we replace it with one that does!
+
 handler500 = 'bedrock.base.views.server_error_view'
 
-
-urlpatterns = (
-    # Main pages
+urlpatterns = (  # Main pages
     path('foundation/', include('bedrock.foundation.urls')),
     path('grants/', include('bedrock.grants.urls')),
     path('about/legal/', include('bedrock.legal.urls')),
@@ -30,22 +31,20 @@ urlpatterns = (
     path('', include('bedrock.newsletter.urls')),
     path('etc/', include('bedrock.etc.urls')),
     path('exp/', include('bedrock.exp.urls')),
-
-    path('healthz/', watchman_views.ping, name="watchman.ping"),
-    path('readiness/', watchman_views.status, name="watchman.status"),
+    path('healthz/', watchman_views.ping, name='watchman.ping'),
+    path('readiness/', watchman_views.status, name='watchman.status'),
     path('healthz-cron/', base_views.cron_health_check),
     path('csp-violation-capture', base_views.csp_violation_capture,
-        name='csp-violation-capture'),
-    path('country-code\.json', base_views.geolocate,
-        name='geolocate')
-)
+         name='csp-violation-capture'),
+    path('country-code.json', base_views.geolocate, name='geolocate'),
+    )
 
 if settings.DEBUG:
+
 
     def show404(request):
         return import_string(handler404)(request, '')
 
-    urlpatterns += (
-        path('404/', show404),
-        path('500/', import_string(handler500)),
-    )
+
+    urlpatterns += (path('404/', show404), path('500/',
+                    import_string(handler500)))

--- a/bedrock/urls.py
+++ b/bedrock/urls.py
@@ -47,4 +47,7 @@ if settings.DEBUG:
 
 
     urlpatterns += (path('404/', show404), path('500/',
-                    import_string(handler500)))
+    urlpatterns += (
+        path('404/', show404), 
+        path('500/', import_string(handler500)),
+    )

--- a/bedrock/urls.py
+++ b/bedrock/urls.py
@@ -3,7 +3,8 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 from django.conf import settings
-from django.urls import handler404, include, re_path
+from django.conf.urls import handler404
+from django.urls import include, re_path
 
 from django.utils.module_loading import import_string
 


### PR DESCRIPTION
## Description
I have changed url() function to re_path() function which is more better for Django 2.2 version and also have changed imported modules from django.conf.urls to django.urls

## Issue / Bugzilla link

## Testing
