### PR TITLE
Corrected icon for win64-msi

### DIFF
--- a/media/css/firefox/all/all.less
+++ b/media/css/firefox/all/all.less
@@ -169,6 +169,9 @@
             &.win64 a {
                 background-position: 0 -40px;
             }
+            &.win64-msi a {
+                background-position: 0 -40px;
+            }
             &.linux a {
                 background-position: 0 -160px;
             }


### PR DESCRIPTION
## Description
This PR changes win64-msi icon from 32 bit windows to 64 bit windows.
## Issue / Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1566138
