### PR TITLE
Add lifecycle page 1 to CRO Sandbox (Fixes #7802)

### DIFF
--- a/bedrock/exp/templates/exp/firefox/welcome/base.html
+++ b/bedrock/exp/templates/exp/firefox/welcome/base.html
@@ -1,0 +1,51 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+
+{% extends "exp/base/base-firefox.html" %}
+
+{# "noindex" pages should not have the canonical or hreflang tags: bug 1442331 #}
+{% block canonical_urls %}<meta name="robots" content="noindex,follow">{% endblock %}
+
+{% block page_css %}
+  {{ css_bundle('exp_firefox_welcome') }}
+{% endblock %}
+
+{% block page_image %}{{ static('img/firefox/template/page-image-master.jpg') }}{% endblock %}
+
+{% block site_header %}{% endblock %}
+
+{% block content %}
+<main class="mzp-t-firefox">
+  <header class="c-page-header">
+    <div class="mzp-l-content c-page-header-inner">
+      {{ high_res_img('protocol/img/logos/firefox/browser/logo-word-hor-lg.png', {'alt': 'Firefox', 'width': '216', 'height': '40', 'class': 'c-header-logo'}) }}
+      <p class="c-shoulder-cta"><a class="mzp-c-button mzp-t-secondary mzp-t-small mzp-t-product" href="{{ url('firefox.accounts') }}">Join Firefox</a></p>
+    </div>
+  </header>
+
+  {% block content_intro %}{% endblock %}
+
+  <section class="page-body">
+    <div class="mzp-l-content mzp-t-narrow">
+      <div class="body-primary">
+        {% block content_primary %}{% endblock %}
+      </div>
+
+      <div class="body-secondary">
+        {% block content_secondary %}{% endblock %}
+      </div>
+
+      <div class="secondary-cta">
+        {% block secondary_cta %}{% endblock %}
+      </div>
+    </div>
+  </section>
+
+  <aside class="page-footer">
+    <div class="mzp-l-content mzp-t-narrow c-utilities">
+      {% block content_utility %}{% endblock %}
+    </div>
+  </aside>
+</main>
+{% endblock %}

--- a/bedrock/exp/templates/exp/firefox/welcome/page1.html
+++ b/bedrock/exp/templates/exp/firefox/welcome/page1.html
@@ -1,0 +1,103 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+
+{% from "macros-protocol.html" import hero with context %}
+{% from "macros.html" import monitor_button with context %}
+
+{% extends "exp/firefox/welcome/base.html" %}
+
+{% block page_title %}More than a browser - Firefox Monitor is your lookout for hackers{% endblock %}
+{% block page_desc %}Take the next step to protect your privacy online with the Firefox family of products.{% endblock %}
+
+{% block page_og_url %}{{ settings.CANONICAL_URL }}/{{ LANG }}/firefox/welcome/1/{% endblock %}
+
+{% block page_image %}{{ static('img/firefox/template/page-image-master.jpg') }}{% endblock %}
+
+{% block body_class %}{{ super() }} welcome-page1{% endblock %}
+
+{% set _entrypoint = 'mozilla.org-firefox-welcome-1' %}
+{% set _utm_campaign = 'welcome-1-monitor' %}
+{% set _cta_type = 'lifecycle-monitor' %}
+
+{% block content_intro %}
+  {% call hero(
+    title='You’re on track to stay protected',
+    desc='You’ve got the web browser that protects your privacy — now it’s time to get a lookout for hackers.',
+    class='mzp-t-firefox mzp-t-dark',
+    include_cta=True,
+    heading_level=1,
+    image_url=None,
+    include_highres_image=False,
+    image_alt=''
+  ) %}
+
+  <p class="primary-cta">
+    {{ monitor_button(
+      entrypoint=_entrypoint,
+      utm_campaign=_utm_campaign,
+      button_text='Check Your Breach Report',
+      cta_type=_cta_type,
+      cta_position='primary'
+    ) }}
+  </p>
+
+  {% endcall %}
+{% endblock %}
+
+{% block content_primary %}
+  <h2 class="body-primary-title"><img src="{{ static('img/logos/monitor/monitor-wordmark.svg') }}" width="256" height="" alt="Firefox Monitor"></h2>
+
+  <div class="body-primary-body">
+    <p>Firefox Monitor shows you if your information has been leaked in a known data breach, and alerts you in case it happens in the future.</p>
+  </div>
+{% endblock %}
+
+{% block content_secondary %}
+  <div class="c-picto-block t-adjacent-image">
+    <div class="c-picto-block-image">
+      <img src="{{ static('img/icons/private-browsing.svg') }}" alt="">
+    </div>
+
+    <h3 class="c-picto-block-title">Stay ahead of hackers</h3>
+    <div class="c-picto-block-body">
+      <p>Find ways to protect your info with <a href="https://blog.mozilla.org/firefox/what-to-do-after-a-data-breach/?utm_source=mozilla.org-firefox-welcome-1&utm_medium=referral&utm_campaign=welcome-1-monitor&entrypoint=mozilla.org-firefox-welcome-1">Monitor Security Tips</a>.</p>
+    </div>
+  </div>
+
+  <div class="c-picto-block t-adjacent-image">
+    <div class="c-picto-block-image">
+      <img src="{{ static('img/icons/warning.svg') }}" alt="">
+    </div>
+
+    <h3 class="c-picto-block-title">Stay in the know</h3>
+    <div class="c-picto-block-body">
+      <p>
+        Were you one of 100,985,047 invited to the <a href="https://blog.mozilla.org/firefox/evite-data-breach/?utm_source=mozilla.org-firefox-welcome-1&utm_medium=referral&utm_campaign=welcome-1-monitor&entrypoint=mozilla.org-firefox-welcome-1">Evite data breach “party”</a>?
+      </p>
+    </div>
+  </div>
+{% endblock %}
+
+{% block secondary_cta %}
+  <p>
+    {{ monitor_button(
+      entrypoint=_entrypoint,
+      utm_campaign=_utm_campaign,
+      button_text='Check Your Breach Report',
+      cta_type=_cta_type,
+      cta_position='secondary'
+    ) }}
+  </p>
+{% endblock %}
+
+{% block content_utility %}
+  <p><strong><a href="https://support.mozilla.org/kb/firefox-browser-welcome-pages/?utm_source=mozilla.org-firefox-welcome-1&utm_medium=referral&utm_campaign=welcome-1-monitor&entrypoint=mozilla.org-firefox-welcome-1">{{ _('Why am I seeing this?') }}</a></strong></p>
+  {% if switch('lifecycle_page1_survey', ['en-US']) %}
+  <p><a class="c-survey-link"href="https://qsurvey.mozilla.com/s3/Firefox-Page" rel="external noopener">Share feedback about this page</a></p>
+  {% endif %}
+{% endblock %}
+
+{% block js %}
+  {{ js_bundle('exp_firefox_welcome_page1') }}
+{% endblock %}

--- a/bedrock/exp/urls.py
+++ b/bedrock/exp/urls.py
@@ -11,4 +11,6 @@ urlpatterns = (
     page('firefox/new', 'exp/firefox/new/download.html', active_locales=['en-US', 'en-GB', 'en-CA', 'de']),
     page('firefox/accounts', 'exp/firefox/accounts-2019.html'),
     page('firefox/lockwise', 'exp/firefox/lockwise.html', active_locales=['en-US', 'en-GB', 'en-CA', 'de']),
+    page('firefox', 'exp/firefox/index.html', active_locales=['en-US', 'en-GB', 'en-CA', 'de']),
+    page('firefox/welcome/1', 'exp/firefox/welcome/page1.html'),
 )

--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -924,7 +924,7 @@ def firefox_welcome_page1(request):
     # get localized blog post URL for 2019 page
     breach_tips_query = (
         '?utm_source=mozilla.org-firefox-welcome-1&amp;utm_medium=referral'
-        '&amp;utm_campaign=welcome-1-monitor&ampentrypoint=mozilla.org-firefox-welcome-1'
+        '&amp;utm_campaign=welcome-1-monitor&amp;entrypoint=mozilla.org-firefox-welcome-1'
     )
     breach_tips_url = BREACH_TIPS_URLS.get(locale, BREACH_TIPS_URLS['en-US'])
 

--- a/media/css/exp/firefox/welcome.scss
+++ b/media/css/exp/firefox/welcome.scss
@@ -1,0 +1,164 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+@import '../../../protocol/css/includes/lib';
+
+
+//* -------------------------------------------------------------------------- */
+// Page header
+
+.c-page-header {
+    background: $color-white;
+}
+
+.c-header-logo {
+    display: block;
+    margin: 0 auto;
+
+    @media #{$mq-md} {
+        display: inline;
+        margin: 0;
+    }
+}
+
+.c-shoulder-cta {
+    margin: $spacing-md 0 0;
+    text-align: center;
+
+    @media #{$mq-md} {
+        @include bidi((
+            (float, right, left),
+            (text-align, left, right),
+        ));
+        margin: 0;
+    }
+}
+
+
+//* -------------------------------------------------------------------------- */
+// Page hero
+
+.mzp-c-hero-body {
+    @include border-box;
+    margin: 0 auto;
+    max-width: $content-md;
+    padding: $layout-xs 0;
+    text-align: center;
+
+    @media #{$mq-md} {
+        padding: $layout-md $layout-xl;
+    }
+
+    .primary-cta {
+        margin: 0 auto;
+    }
+}
+
+.mzp-c-hero-title {
+    @include text-display-lg;
+    margin-bottom: $layout-sm;
+}
+
+.mzp-c-hero-desc {
+    @include text-body-lg;
+    margin-bottom: $layout-sm;
+}
+
+
+//* -------------------------------------------------------------------------- */
+// Primary content
+
+.body-primary {
+    @include text-body-lg;
+    margin: $layout-md auto $layout-lg;
+    text-align: center;
+
+    .primary-image {
+        margin: $layout-sm auto 0;
+    }
+
+    .primary-cta {
+        margin: $layout-md auto 0;
+    }
+}
+
+//* -------------------------------------------------------------------------- */
+// Secondary content
+// To be replaced by revamped picto card. See https://github.com/mozilla/protocol/issues/382
+
+.c-picto-block {
+    @include border-box;
+    margin: 0 auto $spacing-2xl;
+    max-width: $content-md - ($layout-md * 2);
+    padding: 0 $layout-md;
+
+    .c-picto-block-title {
+        @include text-display-xs;
+    }
+
+    .c-picto-block-image {
+        align-items: center;
+        display: flex;
+        margin-bottom: $spacing-md;
+        min-height: $layout-md;
+    }
+
+    &.t-adjacent-image {
+        @include bidi((
+            (padding-left, $layout-xl, 0),
+            (padding-right, 0, $layout-xl)
+        ));
+        position: relative;
+
+        & + & {
+            border-top: 1px solid $color-gray-30;
+            padding-top: $layout-md;
+        }
+
+        .c-picto-block-image {
+            @include bidi((
+                (left, 0, auto),
+                (right, auto, 0)
+            ));
+            display: block;
+            margin: 0;
+            max-width: $layout-lg;
+            min-height: 0;
+            position: absolute;
+        }
+    }
+}
+
+//* -------------------------------------------------------------------------- */
+// Secondary CTA
+
+.secondary-cta {
+    @include text-body-lg;
+    margin: $layout-lg auto $layout-sm;
+    text-align: center;
+
+    p {
+        margin: 0 auto;
+    }
+}
+
+.c-utilities {
+    @include text-body-sm;
+    max-width: $content-md;
+    text-align: center;
+
+    .c-survey-link {
+        font-weight: bold;
+    }
+}
+
+
+//* -------------------------------------------------------------------------- */
+// Dark theme
+
+.mzp-c-hero.mzp-t-dark {
+    @include light-links;
+    background-color: $color-off-black;
+    color: $color-white;
+}

--- a/media/js/exp/firefox/welcome-page1-init.js
+++ b/media/js/exp/firefox/welcome-page1-init.js
@@ -1,0 +1,9 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+(function() {
+    'use strict';
+
+    Mozilla.MonitorButton.init();
+})();

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -903,6 +903,12 @@
         "css/firefox/welcome.scss"
       ],
       "name": "firefox_welcome"
+    },
+    {
+      "files": [
+        "css/exp/firefox/welcome.scss"
+      ],
+      "name": "exp_firefox_welcome"
     }
   ],
   "js": [
@@ -963,6 +969,13 @@
         "js/firefox/welcome-page1-init.js"
       ],
       "name": "firefox_welcome_page1"
+    },
+    {
+      "files": [
+        "js/base/mozilla-monitor-button.js",
+        "js/exp/firefox/welcome-page1-init.js"
+      ],
+      "name": "exp_firefox_welcome_page1"
     },
     {
       "files": [

--- a/tests/functional/test_experiment_pages.py
+++ b/tests/functional/test_experiment_pages.py
@@ -1,0 +1,34 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import pytest
+import requests
+
+
+TIMEOUT = 60
+
+
+def pytest_generate_tests(metafunc):
+    if 'not headless' in metafunc.config.option.markexpr:
+        return  # test deslected by mark expression
+    base_url = metafunc.config.option.base_url
+    if not base_url:
+        pytest.skip(
+            'This test requires a base URL to be specified on the command '
+            'line or in a configuration file.')
+    paths = (
+        '/exp/firefox/',
+        '/exp/firefox/accounts/',
+        '/exp/firefox/new/',
+        '/exp/firefox/welcome/1/',
+        '/exp/firefox/lockwise/'
+    )
+    metafunc.parametrize('url', [base_url + path for path in paths])
+
+
+@pytest.mark.headless
+@pytest.mark.nondestructive
+def test_experiment_pages(url):
+    r = requests.head(url, allow_redirects=True, timeout=TIMEOUT)
+    assert requests.codes.ok == r.status_code


### PR DESCRIPTION
## Description

- Adds an en-US only version of /firefox/welcome/1/ at /exp/firefox/welcome/1/
- Adds headless tests for /exp/ pages.

## Issue / Bugzilla link
#7802

## Testing
- [x] Experiment page should look & function the same as regular page.
- [x] Experiment page should load Convert JS (when DNT is disabled).
- [x] Experimental page be noindex (to match the original)

Successful test run: https://ci.vpn1.moz.works/blue/organizations/jenkins/bedrock_multibranch_pipeline/detail/run-integration-tests/373/pipeline