### PR TITLE
redirect from /enterprise to /firefox/enterprise

### DIFF
--- a/bedrock/mozorg/redirects.py
+++ b/bedrock/mozorg/redirects.py
@@ -667,5 +667,5 @@ redirectpatterns = (
     redirect(r'^about/history/details/?$', 'mozorg.about.history'),
 
     # issue 7842
-    redirect(r'^enterprise/?$','/firefox/enterprise/'),
+    redirect(r'^enterprise/?$', '/firefox/enterprise/'),
 )

--- a/bedrock/mozorg/redirects.py
+++ b/bedrock/mozorg/redirects.py
@@ -665,4 +665,7 @@ redirectpatterns = (
 
     # issue 7435
     redirect(r'^about/history/details/?$', 'mozorg.about.history'),
+
+    # issue 7842
+    redirect(r'^enterprise/?$','/firefox/enterprise/'),
 )


### PR DESCRIPTION
## Description
Added a redirect from /enterprise to /firefox/enterprise
## Issue / Bugzilla link
#7842 
## Testing
