### PR TITLE
[#7656] Use backgrounds for accounts page logos

### DIFF
--- a/bedrock/firefox/templates/firefox/accounts-2019.html
+++ b/bedrock/firefox/templates/firefox/accounts-2019.html
@@ -99,33 +99,25 @@
     <ul class="c-product-list">
       <li class="c-product-list-item t-product-firefox">
         <a href="{{ url('firefox') }}">
-          <h3 class="c-product-list-title">
-            {{ high_res_img('logos/firefox/quantum/logo-word-hor-stack-md.png', {'alt': 'Firefox Browser', 'width': '276', 'height': '96' }) }}
-          </h3>
+          <h3 class="c-product-list-title">Firefox Browser</h3>
           <p class="c-product-list-desc">{{ _('Travel the internet with protection, on every device.') }}</p>
         </a>
       </li>
       <li class="c-product-list-item t-product-lockwise">
         <a href="https://lockwise.firefox.com?utm_source={{ _utm_source }}&amp;utm_medium=referral&amp;utm_campaign={{ _utm_campaign }}&amp;utm_content=product-list-item&amp;entrypoint={{ _entrypoint }}" data-cta-text="Firefox Lockwise" data-cta-type="FxA-Lockwise">
-          <h3 class="c-product-list-title">
-            {{ high_res_img('/protocol/img/logos/firefox/lockwise/logo-word-hor-stack-md.png', {'alt': 'Firefox Lockwise', 'width': '276', 'height': '96' }) }}
-          </h3>
+          <h3 class="c-product-list-title">Firefox Lockwise</h3>
           <p class="c-product-list-desc">{{ _('Keep your passwords protected and portable.') }}</p>
         </a>
       </li>
       <li class="c-product-list-item t-product-monitor">
         <a href="https://monitor.firefox.com?utm_source={{ _utm_source }}&amp;utm_medium=referral&amp;utm_campaign={{ _utm_campaign }}&amp;utm_content=product-list-item&amp;entrypoint={{ _entrypoint }}" data-cta-text="Firefox Monitor" data-cta-type="FxA-Monitor">
-          <h3 class="c-product-list-title">
-            {{ high_res_img('/protocol/img/logos/firefox/monitor/logo-word-hor-stack-md.png', {'alt': 'Firefox Monitor', 'width': '276', 'height': '96' }) }}
-          </h3>
+          <h3 class="c-product-list-title">Firefox Monitor</h3>
           <p class="c-product-list-desc">{{ _('Get a lookout for data breaches.') }}</p>
         </a>
       </li>
       <li class="c-product-list-item t-product-send">
         <a href="https://send.firefox.com?utm_source={{ _utm_source }}&amp;utm_medium=referral&amp;utm_campaign={{ _utm_campaign }}&amp;utm_content=product-list-item&amp;entrypoint={{ _entrypoint }}" data-cta-text="Firefox Send" data-cta-type="FxA-Sync">
-          <h3 class="c-product-list-title">
-              {{ high_res_img('/protocol/img/logos/firefox/send/logo-word-hor-stack-md.png', {'alt': 'Firefox Send', 'width': '276', 'height': '96' }) }}
-          </h3>
+          <h3 class="c-product-list-title">Firefox Send</h3>
           <p class="c-product-list-desc">{{ _('Share large files without prying eyes.') }}</p>
         </a>
       </li>

--- a/media/css/firefox/accounts-2019.scss
+++ b/media/css/firefox/accounts-2019.scss
@@ -2,7 +2,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-
 @import '../../protocol/css/includes/lib';
 
 .c-section-title {
@@ -193,12 +192,31 @@
 }
 
 .c-product-list-title {
+    @include image-replaced;
     @include text-display-sm;
+    background-position: center top;
+    background-repeat: no-repeat;
     margin: 0 auto $spacing-lg;
-    min-height: 50px;
-    width: 180px;
+    height: 64px;
+
+    .t-product-firefox & {
+        @include at2x('/media/img/logos/firefox/quantum/logo-word-hor-stack-md.png', 184px, 64px);
+    }
+
+    .t-product-lockwise & {
+        @include at2x('/media/protocol/img/logos/firefox/lockwise/logo-word-hor-stack-md.png', 197px, 64px);
+    }
+
+    .t-product-monitor & {
+        @include at2x('/media/protocol/img/logos/firefox/monitor/logo-word-hor-stack-md.png', 176px, 64px);
+    }
+
+    .t-product-send & {
+        @include at2x('/media/protocol/img/logos/firefox/send/logo-word-hor-stack-md.png', 167px, 64px);
+    }
 
     @media #{$mq-sm} {
+        @include bidi(((background-position, left top, right top),));
         margin: 0 0 $spacing-lg;
     }
 }

--- a/media/css/firefox/accounts-2019.scss
+++ b/media/css/firefox/accounts-2019.scss
@@ -219,6 +219,26 @@
         @include bidi(((background-position, left top, right top),));
         margin: 0 0 $spacing-lg;
     }
+
+    @media #{$mq-md} {
+        height: 64px;
+
+        .t-product-firefox & {
+            @include background-size(184px,  64px);
+        }
+
+        .t-product-lockwise & {
+            @include background-size(197px, 64px);
+        }
+
+        .t-product-monitor & {
+            @include background-size(176px, 64px);
+        }
+
+        .t-product-send & {
+            @include background-size(167px, 64px);
+        }
+    }
 }
 
 .c-product-list-desc {

--- a/media/css/firefox/accounts-2019.scss
+++ b/media/css/firefox/accounts-2019.scss
@@ -197,22 +197,22 @@
     background-position: center top;
     background-repeat: no-repeat;
     margin: 0 auto $spacing-lg;
-    height: 64px;
+    height: 50px;
 
     .t-product-firefox & {
-        @include at2x('/media/img/logos/firefox/quantum/logo-word-hor-stack-md.png', 184px, 64px);
+        @include at2x('/media/img/logos/firefox/quantum/logo-word-hor-stack-md.png', 144px, 50px);
     }
 
     .t-product-lockwise & {
-        @include at2x('/media/protocol/img/logos/firefox/lockwise/logo-word-hor-stack-md.png', 197px, 64px);
+        @include at2x('/media/protocol/img/logos/firefox/lockwise/logo-word-hor-stack-md.png', 154px, 50px);
     }
 
     .t-product-monitor & {
-        @include at2x('/media/protocol/img/logos/firefox/monitor/logo-word-hor-stack-md.png', 176px, 64px);
+        @include at2x('/media/protocol/img/logos/firefox/monitor/logo-word-hor-stack-md.png', 138px, 50px);
     }
 
     .t-product-send & {
-        @include at2x('/media/protocol/img/logos/firefox/send/logo-word-hor-stack-md.png', 167px, 64px);
+        @include at2x('/media/protocol/img/logos/firefox/send/logo-word-hor-stack-md.png', 130px, 50px);
     }
 
     @media #{$mq-sm} {


### PR DESCRIPTION
## Description

The accounts page was changed in #7806 to use inline images from Protocol with the `high_res_img()` helper, but that helper rewrites part of the file path so it ends up being a 404, even though it works locally.

Until we can refactor the helper to handle Protocol assets, a quick fix is to use image replacement for these logos (the CSS gets the path right).