### PR TITLE
Add Heroku support for Review apps

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,0 +1,26 @@
+{
+  "name": "Mozilla Bedrock Demos",
+  "description": "Demo deployments for changes to Mozilla Bedrock.",
+  "website": "https://www.mozilla.org",
+  "repository": "https://github.com/mozilla/bedrock",
+  "logo": "https://www.mozilla.org/media/img/mozorg/mozilla-256.jpg",
+  "success_url": "/healthz-cron/",
+  "stack": "container",
+  "env": {
+    "ALLOWED_HOSTS": "*",
+    "CONTENT_CARDS_URL": "https://www-dev.allizom.org/media/",
+    "CSP_DEFAULT_SRC": "*.allizom.org",
+    "CSP_EXTRA_FRAME_SRC": "*.mozaws.net",
+    "DB_DOWNLOAD_IGNORE_GIT": "True",
+    "DEBUG": "False",
+    "DEV": "True",
+    "GTM_CONTAINER_ID": "GTM-MW3R8V",
+    "LOG_LEVEL": "INFO",
+    "PROD_DETAILS_STORAGE": "product_details.storage.PDDatabaseStorage",
+    "RUN_SUPERVISOR": "True",
+    "SECRET_KEY": {
+      "description": "A secret key for verifying the integrity of signed cookies, though we don't use them.",
+      "generator": "secret"
+    }
+  }
+}

--- a/bin/sync-all.sh
+++ b/bin/sync-all.sh
@@ -6,6 +6,13 @@ if [ ! -e ./manage.py ]; then
     cd $script_parent_dir
 fi
 
+# for heroku demos
+# heroku doesn't pull git submodules
+if [[ ! -d ./vendor-local/src/legal-docs/firefox_privacy_notice ]]; then
+    rm -rf ./vendor-local/src/legal-docs
+    git clone --depth 1 https://github.com/mozilla/legal-docs.git vendor-local/src/legal-docs
+fi
+
 ./bin/run-db-download.py --force
 ./manage.py migrate --noinput
 ./bin/run-db-update.sh --all || true

--- a/heroku.yml
+++ b/heroku.yml
@@ -1,0 +1,3 @@
+build:
+  docker:
+    web: Dockerfile


### PR DESCRIPTION
With the decommissioning of Deis Workflow our method of creating a demo instance using a named branch will be going away. This is an attempt to use [Heroku Review Apps](https://devcenter.heroku.com/articles/github-integration-review-apps) to replace that. Once this merges I can enable Review Apps for our new `www-demo` Heroku Pipeline and we can try it out. It should create a new deployment for every pull-request and update the PR with a link to it.

Will fix https://github.com/mozmeao/infra/issues/1164