### PR TITLE
Clean untracked directories as well as files in 'make clean'; fix #7866

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,8 +75,8 @@ clean:
 	-rm -rf static_build/
 #	state files
 	-rm -f .docker-build*
-# clean untracked files
-	git clean -f
+# clean untracked files & directories
+	git clean -d -f
 
 lint: .docker-build-pull
 	${DC} run test flake8


### PR DESCRIPTION
#Description

Add a `-d` argument to the `git clean` flag executed as part of `make clean` to remove untracked directories as well as files. See https://git-scm.com/docs/git-clean#Documentation/git-clean.txt--d

## Issue / Bugzilla link

#7866 

## Testing

1. create a new directory & file
2. `make clean`
3. See that the untracked directory is now removed.
