### PR TITLE
Dev Edition: add “made for devs” section

### DIFF
--- a/bedrock/firefox/templates/firefox/developer/firstrun.html
+++ b/bedrock/firefox/templates/firefox/developer/firstrun.html
@@ -24,7 +24,14 @@
   <section class="t-intro">
       <div class="mzp-l-content">
         {{ high_res_img('logos/firefox/developer-wordmark.png', {'alt': '', 'width': '368', 'height': '68'}) }}
-        <h1 class="intro-title">{{ _('Welcome to the all-new Firefox Quantum: Developer Edition') }}</h1>
+        <h1 class="intro-title">
+        {% if l10n_has_tag('made_for_devs_102019') %}
+          {# L10n: "Firefox Developer Edition" is a product name and shouldn't be translated #}
+          {{ _('Welcome to Firefox Developer Edition') }}
+        {% else %}
+          {{ _('Welcome to the all-new Firefox Quantum: Developer Edition') }}
+        {% endif %}
+        </h1>
         <p class="intro-tagline">{{ _('Firefox has been rebuilt from the ground-up to be faster, sleeker, and more powerful than ever.') }}</p>
 
         {% include '/firefox/developer/includes/intro-features.html' %}
@@ -35,7 +42,11 @@
 
   {% include '/firefox/developer/includes/highlights.html' %}
 
-  {% include '/firefox/developer/includes/performance.html' %}
+  {% if l10n_has_tag('made_for_devs_102019') %}
+    {% include '/firefox/developer/includes/for-developers.html' %}
+  {% else %}
+    {% include '/firefox/developer/includes/performance.html' %}
+  {% endif %}
 
   {% include '/firefox/developer/includes/features.html' %}
 

--- a/bedrock/firefox/templates/firefox/developer/firstrun.html
+++ b/bedrock/firefox/templates/firefox/developer/firstrun.html
@@ -26,8 +26,8 @@
         {{ high_res_img('logos/firefox/developer-wordmark.png', {'alt': '', 'width': '368', 'height': '68'}) }}
         <h1 class="intro-title">
         {% if l10n_has_tag('made_for_devs_102019') %}
-          {# L10n: "Firefox Developer Edition" is a product name and shouldn't be translated #}
-          {{ _('Welcome to Firefox Developer Edition') }}
+          {# L10n: "Firefox Browser Developer Edition" is a product name and shouldn't be translated #}
+          {{ _('Welcome to Firefox Browser Developer Edition') }}
         {% else %}
           {{ _('Welcome to the all-new Firefox Quantum: Developer Edition') }}
         {% endif %}

--- a/bedrock/firefox/templates/firefox/developer/includes/alt-newsletter.html
+++ b/bedrock/firefox/templates/firefox/developer/includes/alt-newsletter.html
@@ -1,21 +1,19 @@
 <section class="t-newsletter">
   <div class="mzp-l-content">
-      <div class="mzp-c-newsletter">
-        {% if LANG.startswith('en-') %}
-          {# L10n: line break for visual formatting #}
-          {{ email_newsletter_form(
-            'app-dev',
-            title='Mozilla Developer Newsletter',
-            subtitle=_('Get developer news, tricks and resources <br /> sent straight to your inbox.'),
-            button_class='mzp-t-product',
-            include_language=False,
-            protocol_component=True) }}
-        {% else %}
-          {{ email_newsletter_form(
-            protocol_component=True,
-            spinner_color='#fff',
-            button_class='mzp-c-button mzp-t-product') }}
-        {% endif %}
-      </div>
+    {% if LANG.startswith('en-') %}
+      {# L10n: line break for visual formatting #}
+      {{ email_newsletter_form(
+        'app-dev',
+        title='Mozilla Developer Newsletter',
+        subtitle=_('Get developer news, tricks and resources <br /> sent straight to your inbox.'),
+        button_class='mzp-t-product',
+        include_language=False,
+        protocol_component=True) }}
+    {% else %}
+      {{ email_newsletter_form(
+        protocol_component=True,
+        spinner_color='#fff',
+        button_class='mzp-c-button mzp-t-product') }}
+    {% endif %}
   </div>
 </section>

--- a/bedrock/firefox/templates/firefox/developer/includes/for-developers.html
+++ b/bedrock/firefox/templates/firefox/developer/includes/for-developers.html
@@ -7,7 +7,7 @@
     </div>
     <div class="mzp-c-card-feature-content">
       <div class="mzp-c-card-feature-content-container">
-        <h2 class="mzp-c-card-feature-title">Firefox Developer Edition</h2>
+        <h2 class="mzp-c-card-feature-title">Firefox Browser Developer Edition</h2>
         <div class="mzp-c-card-feature-desc">
           <p class="c-subtitle">{{ _('The browser made for developers') }}</p>
           <p>

--- a/bedrock/firefox/templates/firefox/developer/includes/for-developers.html
+++ b/bedrock/firefox/templates/firefox/developer/includes/for-developers.html
@@ -1,0 +1,34 @@
+<section class="mzp-l-content t-performance" id="for-devs">
+  <div class="mzp-c-card-feature mzp-has-aspect-3-2 mzp-l-card-feature-left-half">
+    <div class="mzp-c-card-feature-media-wrapper">
+      <div class="mzp-c-card-feature-media">
+        <img src="/media/img/firefox/developer/stylo-engine.svg" alt="">
+      </div>
+    </div>
+    <div class="mzp-c-card-feature-content">
+      <div class="mzp-c-card-feature-content-container">
+        <h2 class="mzp-c-card-feature-title">Firefox Developer Edition</h2>
+        <div class="mzp-c-card-feature-desc">
+          <p class="c-subtitle">{{ _('The browser made for developers') }}</p>
+          <p>
+          {% trans %}
+            All the latest developer tools in beta, plus <strong>experimental features</strong> like the Multi-line Console Editor and WebSocket Inspector.
+          {% endtrans %}
+          </p>
+
+          <p>
+          {% trans %}
+            A <strong>separate profile and path</strong> so you can easily run it alongside Release or Beta Firefox.
+          {% endtrans %}
+          </p>
+
+          <p>
+          {% trans %}
+          Preferences <strong>tailored for web developers</strong>: Browser and remote debugging are enabled by default, as are the dark theme and developer toolbar button.
+          {% endtrans %}
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>

--- a/bedrock/firefox/templates/firefox/developer/index.html
+++ b/bedrock/firefox/templates/firefox/developer/index.html
@@ -31,7 +31,7 @@
   <section class="t-intro">
     <div class="mzp-l-content">
       {{ high_res_img('logos/firefox/developer-wordmark.png', {'alt': '', 'width': '368', 'height': '68'}) }}
-      <h1 class="intro-title">Firefox Developer Edition</h1>
+      <h1 class="intro-title">Firefox Browser Developer Edition</h1>
       <p class="intro-tagline">{{ _('Welcome to your new favorite browser. Get the latest features, fast performance, and the development tools you need to build for the open web.') }}</p>
 
       {{ download_firefox('alpha', platform='desktop', dom_id='intro-download', button_color='button-arrow', download_location='primary cta') }}

--- a/bedrock/firefox/templates/firefox/developer/index.html
+++ b/bedrock/firefox/templates/firefox/developer/index.html
@@ -31,7 +31,7 @@
   <section class="t-intro">
     <div class="mzp-l-content">
       {{ high_res_img('logos/firefox/developer-wordmark.png', {'alt': '', 'width': '368', 'height': '68'}) }}
-      <h1 class="intro-title">{{ _('Firefox Quantum: Developer Edition') }}</h1>
+      <h1 class="intro-title">Firefox Developer Edition</h1>
       <p class="intro-tagline">{{ _('Welcome to your new favorite browser. Get the latest features, fast performance, and the development tools you need to build for the open web.') }}</p>
 
       {{ download_firefox('alpha', platform='desktop', dom_id='intro-download', button_color='button-arrow', download_location='primary cta') }}
@@ -46,7 +46,11 @@
     </div>
   </section>
 
-  {% include '/firefox/developer/includes/performance.html' %}
+  {% if l10n_has_tag('made_for_devs_102019') %}
+    {% include '/firefox/developer/includes/for-developers.html' %}
+  {% else %}
+    {% include '/firefox/developer/includes/performance.html' %}
+  {% endif %}
 
   {% include '/firefox/developer/includes/highlights.html' %}
 

--- a/bedrock/firefox/templates/firefox/developer/whatsnew.html
+++ b/bedrock/firefox/templates/firefox/developer/whatsnew.html
@@ -26,8 +26,8 @@
       {{ high_res_img('logos/firefox/developer-wordmark.png', {'alt': '', 'width': '368', 'height': '68'}) }}
 
     {% if l10n_has_tag('made_for_devs_102019') %}
-      {# L10n: "Firefox Developer Edition" is a product name and shouldn't be translated #}
-      <h1 class="intro-title">{{ _('Congrats. You now have Firefox Developer Edition.') }}</h1>
+      {# L10n: "Firefox Browser Developer Edition" is a product name and shouldn't be translated #}
+      <h1 class="intro-title">{{ _('Congrats. You now have Firefox Browser Developer Edition.') }}</h1>
       <p class="intro-tagline">{{ _('Welcome to your new favorite browser. Get the latest features, fast performance, and the development tools you need to build for the open web.') }}</p>
     {% else %}
       <h1 class="intro-title">{{ _('Congrats. You now have Firefox Quantum: Developer Edition.') }}</h1>

--- a/bedrock/firefox/templates/firefox/developer/whatsnew.html
+++ b/bedrock/firefox/templates/firefox/developer/whatsnew.html
@@ -24,8 +24,15 @@
   <section class="t-intro">
     <div class="mzp-l-content">
       {{ high_res_img('logos/firefox/developer-wordmark.png', {'alt': '', 'width': '368', 'height': '68'}) }}
+
+    {% if l10n_has_tag('made_for_devs_102019') %}
+      {# L10n: "Firefox Developer Edition" is a product name and shouldn't be translated #}
+      <h1 class="intro-title">{{ _('Congrats. You now have Firefox Developer Edition.') }}</h1>
+      <p class="intro-tagline">{{ _('Welcome to your new favorite browser. Get the latest features, fast performance, and the development tools you need to build for the open web.') }}</p>
+    {% else %}
       <h1 class="intro-title">{{ _('Congrats. You now have Firefox Quantum: Developer Edition.') }}</h1>
       <p class="intro-tagline">{{ _('This isn’t just an update. This is Firefox Quantum: A brand new Firefox that has been rebuilt from the ground-up to be faster, sleeker, and more powerful than ever.') }}</p>
+    {% endif %}
 
       {% include '/firefox/developer/includes/intro-features.html' %}
     </div>
@@ -35,7 +42,11 @@
 
   {% include '/firefox/developer/includes/highlights.html' %}
 
-  {% include '/firefox/developer/includes/performance.html' %}
+  {% if l10n_has_tag('made_for_devs_102019') %}
+    {% include '/firefox/developer/includes/for-developers.html' %}
+  {% else %}
+    {% include '/firefox/developer/includes/performance.html' %}
+  {% endif %}
 
   {% include '/firefox/developer/includes/features.html' %}
 

--- a/media/css/firefox/developer/includes/intro.scss
+++ b/media/css/firefox/developer/includes/intro.scss
@@ -17,6 +17,7 @@
     background-position: top center;
     background-repeat: no-repeat;
     margin: $layout-sm auto;
+    max-width: $content-md;
 }
 
 .intro-tagline {

--- a/media/css/firefox/developer/includes/newsletter.scss
+++ b/media/css/firefox/developer/includes/newsletter.scss
@@ -42,7 +42,7 @@
         margin-bottom: $layout-2xs;
     }
 
-    .mzp-c-newsletter-tagline{
+    .mzp-c-newsletter-tagline {
         margin-bottom: $layout-sm;
 
         br {


### PR DESCRIPTION
## Description
Replaces the "Performance" section with a "made for developers" section along with some other copy changes to remove the "quantum" name. Uses the l10n tag `made_for_devs_102019`.

We might get a new graphic at some point but this was a hasty copy update ahead of an expected press story. DevRel is hoping to get this live early on 10 October if possible, but it's not mission-critical and it was a last minute request so we'll do what we can.

## Issue / Bugzilla link
https://github.com/firefox-devtools/ux/issues/93

## Testing
https://bedrock-demo-craigcook.oregon-b.moz.works/firefox/developer/
https://bedrock-demo-craigcook.oregon-b.moz.works/firefox/70.0a2/whatsnew/
https://bedrock-demo-craigcook.oregon-b.moz.works/firefox/70.0a2/firstrun/
