### PR TITLE
Fix unclosed </div> on firefox/enterprise (Fixes #7819)

### DIFF
--- a/bedrock/firefox/templates/firefox/enterprise/index.html
+++ b/bedrock/firefox/templates/firefox/enterprise/index.html
@@ -69,6 +69,7 @@
         {{ picto_card(title=_('Choose your release cadence'), desc=_('Get rapid releases to make sure you get the latest features faster, or go extended to ensure a super stable experience.'), class='release') }}
       </ul>
     </section>
+  </div>
 
   <div class="mzp-l-content">
     <section id="download" class="enterprise-section enterprise-download">


### PR DESCRIPTION
## Description
Fixes a displaye issue in IE 11.

## Issue / Bugzilla link
#7819

## Testing
- [ ] Footer should now display full width of the page in IE 11.