### PR TITLE
[fix #7887] Show whatsnew70 to beta users

### DIFF
--- a/bedrock/firefox/templates/firefox/whatsnew/beta/whatsnew-fx70-de.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/beta/whatsnew-fx70-de.html
@@ -1,0 +1,114 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+  # License, v. 2.0. If a copy of the MPL was not distributed with this
+  # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+
+{% from "macros.html" import monitor_button, fxa_cta_link with context %}
+
+{% extends "firefox/base/base-protocol.html" %}
+
+{% block page_title %}{{ _('Was gibt’s Neues von Firefox? – Mehr Privatsphäre, mehr Schutz') }}{% endblock %}
+
+{% block page_css %}
+  {{ css_bundle('firefox_whatsnew_70') }}
+{% endblock %}
+
+{% block body_class %}state-fxa-default{% endblock %}
+
+{% set _entrypoint = 'mozilla.org-whatsnew70-beta' %}
+{% set _utm_campaign = 'whatsnew70-beta' %}
+
+{% block site_header %}{% endblock %}
+
+{% block content %}
+<main class="content-wrapper mzp-t-firefox mzp-t-dark">
+  <header class="c-page-header">
+    <div class="mzp-l-content c-page-header-inner">
+      {{ high_res_img('logos/firefox/quantum/logo-word-hor-white-sm.png', {'alt': 'Firefox', 'width': '216', 'height': '40', 'class': 'c-page-header-logo-fx'}) }}
+      <div class="mzp-c-notification-bar mzp-t-success show-firefox-desktop-70">
+        <p>{{ _('Perfekt! Du hast die neueste Version von Firefox.') }}</p>
+      </div>
+    </div>
+  </header>
+
+  <section class="content-main">
+    <div class="mzp-l-content">
+      <div class="mzp-c-box-emphasis">
+        <img class="c-emphasis-box-logo" src="{{ static('img/logos/firefox/logo-monitor.svg') }}" alt="">
+        <h2 class="c-emphasis-box-title">
+          {{ _('Schon Firefox Monitor ausprobiert?') }}
+          <span class="show-fxa-supported-signed-in">{{ _('Monitor kommt mit deinem Firefox-Konto') }}</span>
+        </h2>
+        <p>{{ _('Überprüfe mit Firefox Monitor, ob deine persönlichen Informationen bei Datenleaks anderer Unternehmen gefährdet wurden – und lass dich automatischen warnen, wenn deine Daten von Datenleaks betroffen sind.') }}</p>
+
+        <div class="show-fxa-supported-signed-out show-fxa-default show-fxa-not-fx">
+          {{ monitor_button(
+            entrypoint=_entrypoint,
+            cta_type='FxA-Monitor',
+            cta_position='Primary',
+            utm_campaign=_utm_campaign,
+            button_text=_('Für Monitor anmelden')
+          ) }}
+        </div>
+
+        <div class="show-fxa-supported-signed-in">
+          {{ monitor_button(
+            entrypoint=_entrypoint,
+            cta_type='FxA-Monitor',
+            cta_position='Primary',
+            utm_campaign=_utm_campaign,
+            button_text=_('Einloggen')
+          ) }}
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="content-extra">
+    <div class="mzp-l-content">
+      <div class="l-columns-two">
+        <div class="c-picto-block">
+          <div class="c-picto-block-image">
+            <img src="{{ static('img/firefox/glyphs/tracking-protection.svg') }}" alt="">
+          </div>
+
+          <h3 class="c-picto-block-title">{{ _('Wir blocken über 2.000 Tracker – automatisch') }}</h3>
+          <div class="c-picto-block-body">
+            <p>{{ _('Alle Firefox Browser für Desktop und Mobile kommen mit standardmäßig eingestelltem verbesserten Tracking-Schutz.') }}</p>
+            <a class="mzp-c-cta-link show-firefox-desktop-70 js-open-about-protections" href="https://support.mozilla.org/kb/enhanced-tracking-protection-firefox-desktop/?utm_source={{ _entrypoint }}&utm_medium=referral&utm_campaign={{ _utm_campaign }}&entrypoint={{ _entrypoint }}" data-link-type="link" data-link-name="See what Firefox has blocked for you">{{ _('Sehen, was Firefox für dich geblockt hat') }}</a>
+
+            <a class="mzp-c-cta-link show-firefox-desktop-old" href="https://support.mozilla.org/kb/update-firefox-latest-release/?utm_source={{ _entrypoint }}&utm_medium=referral&utm_campaign={{ _utm_campaign }}&entrypoint={{ _entrypoint }}" data-link-type="link" data-link-name="Update your Firefox browser">{{ _('Firefox Browser updaten') }}</a>
+
+            <div class="show-fxa-not-fx show-fxa-unsupported">
+              {{ download_firefox(alt_copy=_('Lad dir den Firefox Browser herunter'), download_location='secondary cta', button_color='mzp-c-button mzp-t-primary mzp-t-product') }}
+            </div>
+          </div>
+        </div>
+
+        <div class="c-picto-block">
+          <div class="c-picto-block-image">
+            <img src="{{ static('img/logos/firefox/logo-lockwise.svg') }}" alt="">
+          </div>
+
+          <h3 class="c-picto-block-title">{{ _('Schütze deine Passwörter und nimm sie mit') }}</h3>
+          <div class="c-picto-block-body">
+            <p>{{ _('In Firefox Lockwise kannst du deine Passwörter sicher aufbewahren und verwalten. UND: Du kannst dich warnen lassen, wenn du ein Passwort unbedingt ändern solltest.') }}</p>
+            <a class="mzp-c-cta-link js-open-lockwise" href="https://support.mozilla.org/kb/enhanced-tracking-protection-firefox-desktop/?utm_source={{ _entrypoint }}&utm_medium=referral&utm_campaign={{ _utm_campaign }}&entrypoint={{ _entrypoint }}">{{ _('Zu Lockwise') }}</a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <aside class="mzp-l-content c-utilities">
+    <p>
+    {% trans notes=firefox_url('desktop', 'notes', 'beta') %}
+      Lies die <a href="{{ notes }}">Versionshinweise</a>, um mehr über die Neuerungen in deinem Firefox Browser zu erfahren.
+    {% endtrans %}
+    </p>
+  </aside>
+</main>
+{% endblock %}
+
+{% block js %}
+  {{ js_bundle('firefox_whatsnew_70_variants') }}
+{% endblock %}

--- a/bedrock/firefox/templates/firefox/whatsnew/beta/whatsnew-fx70-en.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/beta/whatsnew-fx70-en.html
@@ -1,0 +1,114 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+  # License, v. 2.0. If a copy of the MPL was not distributed with this
+  # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+
+{% from "macros.html" import monitor_button, fxa_cta_link with context %}
+
+{% extends "firefox/base/base-protocol.html" %}
+
+{% block page_title %}{{ _('What’s new with Firefox - More privacy, more protections.') }}{% endblock %}
+
+{% block page_css %}
+  {{ css_bundle('firefox_whatsnew_70') }}
+{% endblock %}
+
+{% block body_class %}state-fxa-default{% endblock %}
+
+{% set _entrypoint = 'mozilla.org-whatsnew70-beta' %}
+{% set _utm_campaign = 'whatsnew70-beta' %}
+
+{% block site_header %}{% endblock %}
+
+{% block content %}
+<main class="content-wrapper mzp-t-firefox mzp-t-dark">
+  <header class="c-page-header">
+    <div class="mzp-l-content c-page-header-inner">
+      {{ high_res_img('logos/firefox/quantum/logo-word-hor-white-sm.png', {'alt': 'Firefox', 'width': '216', 'height': '40', 'class': 'c-page-header-logo-fx'}) }}
+      <div class="mzp-c-notification-bar mzp-t-success show-firefox-desktop-70">
+        <p>{{ _('Congrats! You’re using the latest version of Firefox.') }}</p>
+      </div>
+    </div>
+  </header>
+
+  <section class="content-main">
+    <div class="mzp-l-content">
+      <div class="mzp-c-box-emphasis">
+        <img class="c-emphasis-box-logo" src="{{ static('img/logos/firefox/logo-monitor.svg') }}" alt="">
+        <h2 class="c-emphasis-box-title">
+          {{ _('Have you checked out Firefox Monitor?') }}
+          <span class="show-fxa-supported-signed-in">{{ _('It’s included with your Firefox account.') }}</span>
+        </h2>
+        <p>{{ _('Use Firefox Monitor to see if your info was compromised in another company’s data breach — and automatically get alerts when your info might be at risk.') }}</p>
+
+        <div class="show-fxa-supported-signed-out show-fxa-default show-fxa-not-fx">
+          {{ monitor_button(
+            entrypoint=_entrypoint,
+            cta_type='FxA-Monitor',
+            cta_position='Primary',
+            utm_campaign=_utm_campaign,
+            button_text=_('Sign Up for Monitor')
+          ) }}
+        </div>
+
+        <div class="show-fxa-supported-signed-in">
+          {{ monitor_button(
+            entrypoint=_entrypoint,
+            cta_type='FxA-Monitor',
+            cta_position='Primary',
+            utm_campaign=_utm_campaign,
+            button_text=_('Sign In')
+          ) }}
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="content-extra">
+    <div class="mzp-l-content">
+      <div class="l-columns-two">
+        <div class="c-picto-block">
+          <div class="c-picto-block-image">
+            <img src="{{ static('img/firefox/glyphs/tracking-protection.svg') }}" alt="">
+          </div>
+
+          <h3 class="c-picto-block-title">{{ _('2000+ types of trackers blocked — automatically') }}</h3>
+          <div class="c-picto-block-body">
+            <p>{{ _('Firefox mobile and desktop browsers have Enhanced Tracking Protection on by default.') }}</p>
+            <a class="mzp-c-cta-link show-firefox-desktop-70 js-open-about-protections" href="https://support.mozilla.org/kb/enhanced-tracking-protection-firefox-desktop/?utm_source={{ _entrypoint }}&utm_medium=referral&utm_campaign={{ _utm_campaign }}&entrypoint={{ _entrypoint }}" data-link-type="link" data-link-name="See what Firefox has blocked for you">{{ _('See what Firefox has blocked for you') }}</a>
+
+            <a class="mzp-c-cta-link show-firefox-desktop-old" href="https://support.mozilla.org/kb/update-firefox-latest-release/?utm_source={{ _entrypoint }}&utm_medium=referral&utm_campaign={{ _utm_campaign }}&entrypoint={{ _entrypoint }}" data-link-type="link" data-link-name="Update your Firefox browser">{{ _('Update your Firefox browser') }}</a>
+
+            <div class="show-fxa-not-fx show-fxa-unsupported">
+              {{ download_firefox(alt_copy=_('Download the Firefox browser'), download_location='secondary cta', button_color='mzp-c-button mzp-t-primary mzp-t-product') }}
+            </div>
+          </div>
+        </div>
+
+        <div class="c-picto-block">
+          <div class="c-picto-block-image">
+            <img src="{{ static('img/logos/firefox/logo-lockwise.svg') }}" alt="">
+          </div>
+
+          <h3 class="c-picto-block-title">{{ _('Keep your passwords protected and portable') }}</h3>
+          <div class="c-picto-block-body">
+            <p>{{ _('Safely store and manage your passwords with Lockwise, and get alerted when you need to change them.') }}</p>
+            <a class="mzp-c-cta-link js-open-lockwise" href="https://support.mozilla.org/kb/enhanced-tracking-protection-firefox-desktop/?utm_source={{ _entrypoint }}&utm_medium=referral&utm_campaign={{ _utm_campaign }}&entrypoint={{ _entrypoint }}">{{ _('Go to Lockwise') }}</a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <aside class="mzp-l-content c-utilities">
+    <p>
+    {% trans notes=firefox_url('desktop', 'notes', 'beta') %}
+      Read the <a href="{{ notes }}">Release Notes</a> to know more about what’s new in your Firefox Browser.
+    {% endtrans %}
+    </p>
+  </aside>
+</main>
+{% endblock %}
+
+{% block js %}
+  {{ js_bundle('firefox_whatsnew_70_variants') }}
+{% endblock %}

--- a/bedrock/firefox/templates/firefox/whatsnew/beta/whatsnew-fx70-fr.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/beta/whatsnew-fx70-fr.html
@@ -1,0 +1,114 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+  # License, v. 2.0. If a copy of the MPL was not distributed with this
+  # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+
+{% from "macros.html" import monitor_button, fxa_cta_link with context %}
+
+{% extends "firefox/base/base-protocol.html" %}
+
+{% block page_title %}{{ _('Quoi de neuf chez Firefox ? Encore plus de respect de la vie privée et plus de protection.') }}{% endblock %}
+
+{% block page_css %}
+  {{ css_bundle('firefox_whatsnew_70') }}
+{% endblock %}
+
+{% block body_class %}state-fxa-default{% endblock %}
+
+{% set _entrypoint = 'mozilla.org-whatsnew70-beta' %}
+{% set _utm_campaign = 'whatsnew70-beta' %}
+
+{% block site_header %}{% endblock %}
+
+{% block content %}
+<main class="content-wrapper mzp-t-firefox mzp-t-dark">
+  <header class="c-page-header">
+    <div class="mzp-l-content c-page-header-inner">
+      {{ high_res_img('logos/firefox/quantum/logo-word-hor-white-sm.png', {'alt': 'Firefox', 'width': '216', 'height': '40', 'class': 'c-page-header-logo-fx'}) }}
+      <div class="mzp-c-notification-bar mzp-t-success show-firefox-desktop-70">
+        <p>{{ _('Félicitations ! Vous utilisez la version la plus récente de Firefox.') }}</p>
+      </div>
+    </div>
+  </header>
+
+  <section class="content-main">
+    <div class="mzp-l-content">
+      <div class="mzp-c-box-emphasis">
+        <img class="c-emphasis-box-logo" src="{{ static('img/logos/firefox/logo-monitor.svg') }}" alt="">
+        <h2 class="c-emphasis-box-title">
+          {{ _('Avez-vous testé Firefox Monitor ?') }}
+          <span class="show-fxa-supported-signed-in">{{ _('Vous y avez accès grâce à votre compte Firefox') }}</span>
+        </h2>
+        <p>{{ _('Essayez Firefox Monitor pour savoir si vos informations personnelles ont été compromises par une fuite de donnée d’une autre entreprise recevez des alertes automatiques en cas de future fuite.') }}</p>
+
+        <div class="show-fxa-supported-signed-out show-fxa-default show-fxa-not-fx">
+          {{ monitor_button(
+            entrypoint=_entrypoint,
+            cta_type='FxA-Monitor',
+            cta_position='Primary',
+            utm_campaign=_utm_campaign,
+            button_text=_('S’inscrire à Monitor')
+          ) }}
+        </div>
+
+        <div class="show-fxa-supported-signed-in">
+          {{ monitor_button(
+            entrypoint=_entrypoint,
+            cta_type='FxA-Monitor',
+            cta_position='Primary',
+            utm_campaign=_utm_campaign,
+            button_text=_('Se connecter')
+          ) }}
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="content-extra">
+    <div class="mzp-l-content">
+      <div class="l-columns-two">
+        <div class="c-picto-block">
+          <div class="c-picto-block-image">
+            <img src="{{ static('img/firefox/glyphs/tracking-protection.svg') }}" alt="">
+          </div>
+
+          <h3 class="c-picto-block-title">{{ _('Plus de 2000 traqueurs bloqués automatiquement') }}</h3>
+          <div class="c-picto-block-body">
+            <p>{{ _('Les navigateurs Firefox pour ordinateur et mobile disposent de la protection renforcée contre le pistage activée par défaut.') }}</p>
+            <a class="mzp-c-cta-link mzp-t-product show-firefox-desktop-70 js-open-about-protections" href="https://support.mozilla.org/kb/enhanced-tracking-protection-firefox-desktop/?utm_source={{ _entrypoint }}&utm_medium=referral&utm_campaign={{ _utm_campaign }}&entrypoint={{ _entrypoint }}" data-link-type="link" data-link-name="See what Firefox has blocked for you">{{ _('Visualiser ce que Firefox a bloqué pour vous') }}</a>
+
+            <a class="mzp-c-cta-link show-firefox-desktop-old" href="https://support.mozilla.org/kb/update-firefox-latest-release/?utm_source={{ _entrypoint }}&utm_medium=referral&utm_campaign={{ _utm_campaign }}&entrypoint={{ _entrypoint }}" data-link-type="link" data-link-name="Update your Firefox browser">{{ _('Mettre à jour Firefox') }}</a>
+
+            <div class="show-fxa-not-fx show-fxa-unsupported">
+              {{ download_firefox(alt_copy=_('Télécharger le navigateur Firefox'), download_location='secondary cta', button_color='mzp-c-button mzp-t-primary mzp-t-product') }}
+            </div>
+          </div>
+        </div>
+
+        <div class="c-picto-block">
+          <div class="c-picto-block-image">
+            <img src="{{ static('img/logos/firefox/logo-lockwise.svg') }}" alt="">
+          </div>
+
+          <h3 class="c-picto-block-title">{{ _('Protégez vos mots de passe et gardez-les à portée de main') }}</h3>
+          <div class="c-picto-block-body">
+            <p>{{ _('Avec Firefox Lockwise, vous pouvez stocker et gérer vos mots de passe de manière sécurisée. En plus, on vous prévient si jamais vous avez besoin de changer un mot de passe.') }}</p>
+            <a class="mzp-c-cta-link js-open-lockwise" href="https://support.mozilla.org/kb/enhanced-tracking-protection-firefox-desktop/?utm_source={{ _entrypoint }}&utm_medium=referral&utm_campaign={{ _utm_campaign }}&entrypoint={{ _entrypoint }}">{{ _('Découvrir Lockwise') }}</a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <aside class="mzp-l-content c-utilities">
+    <p>
+    {% trans notes=firefox_url('desktop', 'notes', 'beta') %}
+      Consultez les <a href="{{ notes }}">notes de version</a> pour en savoir plus sur les nouveautés de votre navigateur Firefox.
+    {% endtrans %}
+    </p>
+  </aside>
+</main>
+{% endblock %}
+
+{% block js %}
+  {{ js_bundle('firefox_whatsnew_70_variants') }}
+{% endblock %}

--- a/bedrock/firefox/templates/firefox/whatsnew/beta/whatsnew-fx70.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/beta/whatsnew-fx70.html
@@ -1,0 +1,110 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+  # License, v. 2.0. If a copy of the MPL was not distributed with this
+  # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+
+{% from "macros.html" import monitor_button with context %}
+
+{% add_lang_files "firefox/whatsnew_70" %}
+
+{% extends "firefox/base/base-protocol.html" %}
+
+{% block page_title %}{{ _('What’s new with Firefox - More privacy, more protections.') }}{% endblock %}
+
+{% block page_css %}
+  {{ css_bundle('firefox_whatsnew_70') }}
+{% endblock %}
+
+{% block body_class %}state-fxa-default{% endblock %}
+
+{% set _entrypoint = 'mozilla.org-whatsnew70-beta' %}
+{% set _utm_campaign = 'whatsnew70-beta' %}
+
+{% block site_header %}{% endblock %}
+
+{% block content %}
+<main class="content-wrapper mzp-t-firefox">
+  <header class="c-page-header">
+    <div class="mzp-l-content c-page-header-inner">
+      {{ high_res_img('logos/firefox/quantum/logo-word-hor-white-sm.png', {'alt': 'Firefox', 'width': '216', 'height': '40', 'class': 'c-page-header-logo-fx'}) }}
+      <div class="mzp-c-notification-bar mzp-t-success show-firefox-desktop-70">
+        <p>{{ _('Congrats! You’re using the latest version of Firefox.') }}</p>
+      </div>
+    </div>
+  </header>
+
+  <section class="content-main">
+    <div class="mzp-l-content">
+      <div class="mzp-c-box-emphasis">
+        <img class="c-emphasis-box-logo" src="{{ static('img/firefox/glyphs/tracking-protection.svg') }}" alt="">
+        <h2 class="c-emphasis-box-title">
+          {{ _('Now you can see how we’re protecting your privacy.') }}
+        </h2>
+        <p>{{ _('We made Enhanced Tracking Protection because no one should be able to follow you online without your permission. And now you can see just how many data-collecting trackers Firefox has blocked for you — along with other ways our products protect your privacy.') }}</p>
+
+        <a class="mzp-c-button mzp-t-product show-firefox-desktop-70 js-open-about-protections" href="https://support.mozilla.org/kb/enhanced-tracking-protection-firefox-desktop/?utm_source={{ _entrypoint }}&utm_medium=referral&utm_campaign={{ _utm_campaign }}&entrypoint={{ _entrypoint }}" data-link-type="link" data-link-name="See what Firefox has blocked for you">{{ _('See what Firefox has blocked for you') }}</a>
+
+        <a class="mzp-c-button mzp-t-product show-firefox-desktop-old" href="https://support.mozilla.org/kb/update-firefox-latest-release/?utm_source={{ _entrypoint }}&utm_medium=referral&utm_campaign={{ _utm_campaign }}&entrypoint={{ _entrypoint }}" data-link-type="link" data-link-name="Update your Firefox browser">{{ _('Update your Firefox browser') }}</a>
+
+        <div class="show-fxa-not-fx show-fxa-unsupported">
+          {{ download_firefox(alt_copy=_('Download the Firefox browser'), download_location='primary cta', button_color='mzp-c-button mzp-t-primary mzp-t-product') }}
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="content-extra mzp-t-dark">
+    <div class="mzp-l-content">
+      <h3 class="c-section-title-secondary">{{ _('Also view personalized protection updates from these services:') }}</h3>
+      <div class="l-columns-two">
+
+        <div class="c-picto-block">
+          <div class="c-picto-block-image">
+            <img src="{{ static('img/logos/firefox/logo-monitor.svg') }}" alt="">
+          </div>
+
+          <h3 class="c-picto-block-title">{{ _('Firefox Monitor') }}</h3>
+          <div class="c-picto-block-body">
+            <p>{{ _('See if you were a part of another company’s data breach, and sign up for future alerts.') }}</p>
+
+            {{ monitor_button(
+              entrypoint=_entrypoint,
+              cta_type='FxA-Monitor',
+              cta_position='Primary',
+              utm_campaign=_utm_campaign,
+              button_class='mzp-c-cta-link',
+              button_text=_('Go to Monitor')
+            ) }}
+
+          </div>
+        </div>
+
+        <div class="c-picto-block">
+          <div class="c-picto-block-image">
+            <img src="{{ static('img/logos/firefox/logo-lockwise.svg') }}" alt="">
+          </div>
+
+          <h3 class="c-picto-block-title">{{ _('Firefox Lockwise') }}</h3>
+          <div class="c-picto-block-body">
+            <p>{{ _('Safely store and manage your passwords with Lockwise, and get alerted when you need to change them.') }}</p>
+            <a class="mzp-c-cta-link js-open-lockwise" href="https://support.mozilla.org/kb/enhanced-tracking-protection-firefox-desktop/?utm_source={{ _entrypoint }}&utm_medium=referral&utm_campaign={{ _utm_campaign }}&entrypoint={{ _entrypoint }}">{{ _('Go to Lockwise') }}</a>
+          </div>
+        </div>
+
+      </div>
+    </div>
+  </section>
+
+  <aside class="mzp-l-content c-utilities mzp-t-dark">
+    <p>
+    {% trans notes=firefox_url('desktop', 'notes', 'beta') %}
+      Read the <a href="{{ notes }}">Release Notes</a> to know more about what’s new in your Firefox Browser.
+    {% endtrans %}
+    </p>
+  </aside>
+
+</main>
+{% endblock %}
+
+{% block js %}
+  {{ js_bundle('firefox_whatsnew_70') }}
+{% endblock %}

--- a/bedrock/firefox/tests/test_base.py
+++ b/bedrock/firefox/tests/test_base.py
@@ -280,6 +280,22 @@ class TestWhatsNew(TestCase):
         template = render_mock.call_args[0][1]
         assert template == ['firefox/whatsnew/beta/whatsnew-fx68.html']
 
+    @override_settings(DEV=True)
+    def test_fx_beta_70_0_whatsnew(self, render_mock):
+        """Should show beta 70 English template"""
+        req = self.rf.get('/en-US/firefox/whatsnew/')
+        self.view(req, version='70.0beta')
+        template = render_mock.call_args[0][1]
+        assert template == ['firefox/whatsnew/beta/whatsnew-fx70-en.html']
+
+    @override_settings(DEV=True)
+    def test_fx_beta_70_0_whatsnew_non_locales(self, render_mock):
+        """Should show beta 70 fallback template"""
+        req = self.rf.get('/ru/firefox/whatsnew/')
+        self.view(req, version='70.0beta')
+        template = render_mock.call_args[0][1]
+        assert template == ['firefox/whatsnew/beta/whatsnew-fx70.html']
+
     # end beta whatsnew tests
 
     # begin dev edition whatsnew tests

--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -622,6 +622,15 @@ class WhatsnewView(l10n_utils.LangFilesMixin, TemplateView):
                     template = 'firefox/whatsnew/beta/whatsnew-fx68-trailhead.html'
                 else:
                     template = 'firefox/whatsnew/beta/whatsnew-fx68.html'
+            elif version.startswith('70.'):
+                if locale in ['en-US', 'en-CA', 'en-GB']:
+                    template = 'firefox/whatsnew/beta/whatsnew-fx70-en.html'
+                elif locale == 'de':
+                    template = 'firefox/whatsnew/beta/whatsnew-fx70-de.html'
+                elif locale == 'fr':
+                    template = 'firefox/whatsnew/beta/whatsnew-fx70-fr.html'
+                else:
+                    template = 'firefox/whatsnew/beta/whatsnew-fx70.html'
             else:
                 template = 'firefox/whatsnew/index.html'
         elif locale == 'id':


### PR DESCRIPTION
## Description
Shows the WNP70 page to 70beta users. This is a little hacky, I don't like this much repetition of content but I also didn't want to try to rework the base templates too much so it's mostly just copying them wholesale and changing some params.

## Issue / Bugzilla link
#7887 

## Testing
- [ ] All the same conditional behavior as release WNP70, nothing broken
- [ ] Release notes link at the bottom should point to the beta notes on all variants
- [ ] Analytics params include "beta" on all variants