### PR TITLE
removed rule for no-useless-escape

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -4,9 +4,6 @@ module.exports = {
         'jasmine': true
     },
     extends: '@mozilla-protocol/eslint-config',
-    rules: {
-        'no-useless-escape': 1,
-    },
     /**
      * Provide a set of overrides for `gulpfile.js` in the root directory.
      * Ideally we want to extend @mozilla-protocol/eslint-config/index-node,

--- a/media/js/base/site.js
+++ b/media/js/base/site.js
@@ -76,9 +76,9 @@
             ua = ua || navigator.userAgent;
 
             // On OS X, Safari and Chrome have underscores instead of dots
-            var match = ua.match(/Windows\ NT\ (\d+\.\d+)/) ||
-                        ua.match(/Mac\ OS\ X\ (\d+[\._]\d+)/) ||
-                        ua.match(/Android\ (\d+\.\d+)/);
+            var match = ua.match(/Windows NT (\d+\.\d+)/) ||
+                        ua.match(/Mac OS X (\d+[._]\d+)/) ||
+                        ua.match(/Android (\d+\.\d+)/);
 
             return match ? match[1].replace('_', '.') : undefined;
         },
@@ -186,7 +186,7 @@
         }
 
         // Add class to reflect if user agent is Firefox. Cherry-picked from mozilla-client.js.
-        var isFirefox = /\s(Firefox|FxiOS)/.test(navigator.userAgent) && !/Iceweasel|IceCat|SeaMonkey|Camino|like\ Firefox/i.test(navigator.userAgent);
+        var isFirefox = /\s(Firefox|FxiOS)/.test(navigator.userAgent) && !/Iceweasel|IceCat|SeaMonkey|Camino|like Firefox/i.test(navigator.userAgent);
 
         if (isFirefox) {
             h.className += ' is-firefox';


### PR DESCRIPTION
## Description
The PR for removing 'no-useless-escape' errors has been merged. So I removed rule for it as mentioned in https://github.com/mozilla/bedrock/issues/7747#issuecomment-533000634
## Issue / Bugzilla link
#7747 
## Testing
