### PR TITLE
Fixes #7892, footer links to nightly points to incorrect platform

### DIFF
--- a/bedrock/base/templates/includes/protocol/footer/firefox-new.html
+++ b/bedrock/base/templates/includes/protocol/footer/firefox-new.html
@@ -60,9 +60,9 @@
             <li><a href="{{ url('firefox.channel.desktop') + '#beta' }}" data-link-type="footer" data-link-name="Beta">Beta</a></li>
             {# L10n: please do not translate the product name Beta #}
             <li><a href="{{ url('firefox.channel.android') + '#beta' }}" data-link-type="footer" data-link-name="Beta for Android">{{ _('Beta for Android') }}</a></li>
-            <li><a href="{{ url('firefox.channel.android') + '#nightly' }}" data-link-type="footer" data-link-name="Nightly">Nightly</a></li>
+            <li><a href="{{ url('firefox.channel.desktop') + '#nightly' }}" data-link-type="footer" data-link-name="Nightly">Nightly</a></li>
             {# L10n: please do not translate the product name Nightly #}
-            <li><a href="{{ url('firefox.channel.desktop') + '#nightly' }}" data-link-type="footer" data-link-name="Nightly for Android">{{ _('Nightly for Android') }}</a></li>
+            <li><a href="{{ url('firefox.channel.android') + '#nightly' }}" data-link-type="footer" data-link-name="Nightly for Android">{{ _('Nightly for Android') }}</a></li>
           </ul>
         </section>
       </div>


### PR DESCRIPTION
## Description

Fixes Nightly footer links to point to the expected platform

## Issue / Bugzilla link

#7892 

## Testing

1. Load up the Firefox /new page
2. Scroll to the footer
3. Link to `Nightly` should point to desktop download and `Nightly for Android` should point to Android download page respectively

@alexgibson r?
