### PR TITLE
Add /firefox/accounts/ page to CRO sandbox (Fixes #7507)

### DIFF
--- a/bedrock/exp/templates/exp/base/base-firefox.html
+++ b/bedrock/exp/templates/exp/base/base-firefox.html
@@ -16,3 +16,11 @@
 {% block twitter_id %}firefox{% endblock %}
 
 {% block body_class %}mzp-t-firefox{% endblock %}
+
+{% block site_header %}
+  {% include 'includes/protocol/navigation/menu-firefox/index.html' %}
+{% endblock %}
+
+{% block site_footer %}
+  {% include 'includes/protocol/footer/firefox.html' %}
+{% endblock %}

--- a/bedrock/exp/templates/exp/firefox/accounts-2019.html
+++ b/bedrock/exp/templates/exp/firefox/accounts-2019.html
@@ -1,0 +1,161 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. #}
+
+{% from "macros-protocol.html" import feature_card with context %}
+{% from "macros.html" import fxa_email_form, fxa_link_fragment, monitor_button with context %}
+
+{% extends "exp/base/base-firefox.html" %}
+
+{% block canonical_urls %}
+  {# Experimental pages should set canonical to the original page URL. #}
+  <link rel="canonical" href="{{ settings.CANONICAL_URL }}/{{ LANG }}/firefox/accounts/">
+{% endblock %}
+
+{% block page_og_url %}{{ settings.CANONICAL_URL }}/{{ LANG }}/firefox/accounts/{% endblock %}
+
+{% set _entrypoint = 'mozilla.org-firefox-accounts' %}
+{% set _utm_source = 'mozilla.org-firefox-accounts' %}
+{% set _utm_campaign = 'trailhead' %}
+
+{%- block page_title -%}There is a way to protect your privacy. Join Firefox.{%- endblock -%}
+
+{%- block page_desc -%}Take your stand against an industry that’s selling your data to third parties. Stay smart and safe online with technology that fights for you.{%- endblock -%}
+
+{% block page_image %}{{ static('img/firefox/template/page-image-master.jpg') }}{% endblock %}
+
+{% block page_css %}
+ {{ css_bundle('exp_firefox_accounts_2019') }}
+{% endblock %}
+
+{% block body_class %}firefox-accounts mzp-t-firefox state-fxa-default {% endblock %}
+
+{% block site_header %}
+  {% with hide_nav_get_account_button=True %}
+    {% include 'includes/protocol/navigation/menu-firefox/nav-switch.html' %}
+  {% endwith %}
+{% endblock %}
+
+{% block content %}
+
+<section class="c-accounts-hero">
+  <div class="mzp-l-content">
+    <div class="c-accounts-hero-body c-accounts-hero-body-default">
+      <h1 class="c-accounts-hero-title">There is a way to protect your privacy. <span>Join Firefox.</span></h1>
+
+      <p class="c-accounts-hero-desc">Take your stand against an industry that’s making you the product.</p>
+    </div>
+
+    <div class="c-accounts-hero-body c-accounts-hero-body-signed-in is-js-dependent">
+      <h2 class="c-accounts-hero-title">You’re signed <br>in to Firefox. <br><span>Now try Firefox Monitor.</span></h2>
+
+      <p class="c-accounts-hero-desc">See if you’ve been involved in an online data breach.</p>
+
+      {{ monitor_button(
+        entrypoint=_entrypoint,
+        utm_campaign=_utm_campaign
+      ) }}
+    </div>
+
+    <div class="c-accounts-form">
+      {{ fxa_email_form(
+        entrypoint=_entrypoint,
+        form_title='Join Firefox',
+        intro_text='Enter your email address to get started.',
+        button_class='mzp-c-button mzp-t-primary mzp-t-product',
+        style='trailhead',
+        utm_campaign=_utm_campaign)
+      }}
+
+      <p class="fxa-signin">Already have an account? <a {{ fxa_link_fragment(entrypoint=_entrypoint, action='signin', utm_campaign=_utm_campaign, utm_content='form-upper') }} class="js-fxa-cta-link">Sign In</a></p>
+    </div>
+  </div>
+</section>
+
+<section class="c-accounts-products">
+  <div class="mzp-l-content">
+    <h2 class="c-section-title">Meet our family of privacy-first products.</h2>
+
+    <ul class="c-product-list">
+      <li class="c-product-list-item t-product-firefox">
+        <a href="{{ url('firefox') }}">
+          <h3 class="c-product-list-title">Firefox Browser</h3>
+          <p class="c-product-list-desc">Travel the internet with protection, on every device.</p>
+        </a>
+      </li>
+      <li class="c-product-list-item t-product-lockwise">
+        <a href="{{ url('firefox.lockwise.lockwise') }}" data-cta-text="Firefox Lockwise" data-cta-type="fxa-lockwise">
+          <h3 class="c-product-list-title">Firefox Lockwise</h3>
+          <p class="c-product-list-desc">Keep your passwords protected and portable.</p>
+        </a>
+      </li>
+      <li class="c-product-list-item t-product-monitor">
+        <a href="https://monitor.firefox.com?utm_source={{ _utm_source }}&amp;utm_medium=referral&amp;utm_campaign={{ _utm_campaign }}&amp;utm_content=product-list-item&amp;entrypoint={{ _entrypoint }}" data-cta-text="Firefox Monitor" data-cta-type="FxA-Monitor">
+          <h3 class="c-product-list-title">Firefox Monitor</h3>
+          <p class="c-product-list-desc">Get a lookout for data breaches.</p>
+        </a>
+      </li>
+      <li class="c-product-list-item t-product-send">
+        <a href="https://send.firefox.com?utm_source={{ _utm_source }}&amp;utm_medium=referral&amp;utm_campaign={{ _utm_campaign }}&amp;utm_content=product-list-item&amp;entrypoint={{ _entrypoint }}" data-cta-text="Firefox Send" data-cta-type="FxA-Sync">
+          <h3 class="c-product-list-title">Firefox Send</h3>
+          <p class="c-product-list-desc">Share large files without prying eyes.</p>
+        </a>
+      </li>
+    </ul>
+
+    <p class="c-accounts-products-tagline">Get it all on every device, without feeling trapped in a single operating system.</p>
+  </div>
+</section>
+
+
+<section class="c-accounts-value t-value-respect l-media-left">
+  <div class="c-accounts-value-container">
+    <div class="c-accounts-value-media">
+      {{ high_res_img('firefox/accounts/trailhead/value-respect.jpg', {'alt': '', 'width': '800', 'height': '600'}) }}
+    </div>
+
+    <div class="c-accounts-value-content">
+      <h3 class="c-accounts-value-title">Get the respect you deserve.</h3>
+
+      <p>You’ll always get the truth from us. Everything we make and do honors our <a href="{{ promise_url }}">Personal Data Promise</a>:</p>
+
+      <p><strong>Take less.<br> Keep it safe.<br> No secrets.</strong></p>
+    </div>
+  </div>
+</section>
+
+<section class="c-accounts-value t-value-knowledge l-media-right">
+  <div class="c-accounts-value-container">
+    <div class="c-accounts-value-media">
+      {{ high_res_img('firefox/accounts/trailhead/value-knowledge.jpg', {'alt': '', 'width': '800', 'height': '600'}) }}
+    </div>
+
+    <div class="c-accounts-value-content">
+      <h3 class="c-accounts-value-title">Get the knowledge to keep you safe.</h3>
+      <p class="c-accounts-value-desc">Learn everything you need to know (but don’t yet) about staying smart and safe online, from some of the world’s foremost experts.</p>
+    </div>
+  </div>
+</section>
+
+<section class="c-accounts-movement">
+  <div class="mzp-l-content">
+    <h2 class="c-section-title">And be part of protecting the internet for future generations.</h2>
+
+    <div class="c-accounts-movement-container">
+      <div class="c-accounts-movement-item t-movement-build">
+        <h3 class="c-accounts-movement-title">Help us build a better Firefox for all.</h3>
+        <p class="c-accounts-movement-desc">Get into the open source spirit by test-driving upcoming products.</p>
+      </div>
+
+      <div class="c-accounts-movement-item t-movement-bigtech">
+        <h3 class="c-accounts-movement-title">Help us keep Big Tech in check.</h3>
+        <p class="c-accounts-movement-desc">We support communities all over the world standing up for a healthier internet. Add your voice to the fight.</p>
+      </div>
+    </div>
+  </div>
+</section>
+{% endblock %}
+
+{% block js %}
+  {{ js_bundle('exp_firefox_accounts_2019') }}
+{% endblock %}

--- a/bedrock/exp/templates/exp/firefox/accounts-2019.html
+++ b/bedrock/exp/templates/exp/firefox/accounts-2019.html
@@ -32,7 +32,7 @@
 
 {% block site_header %}
   {% with hide_nav_get_account_button=True %}
-    {% include 'includes/protocol/navigation/menu-firefox/nav-switch.html' %}
+    {% include 'includes/protocol/navigation/menu-firefox/index.html' %}
   {% endwith %}
 {% endblock %}
 
@@ -111,13 +111,13 @@
 <section class="c-accounts-value t-value-respect l-media-left">
   <div class="c-accounts-value-container">
     <div class="c-accounts-value-media">
-      {{ high_res_img('firefox/accounts/trailhead/value-respect.jpg', {'alt': '', 'width': '800', 'height': '600'}) }}
+      {{ high_res_img('img/firefox/accounts/trailhead/value-respect.jpg', {'alt': '', 'width': '800', 'height': '600'}) }}
     </div>
 
     <div class="c-accounts-value-content">
       <h3 class="c-accounts-value-title">Get the respect you deserve.</h3>
 
-      <p>You’ll always get the truth from us. Everything we make and do honors our <a href="{{ promise_url }}">Personal Data Promise</a>:</p>
+      <p>You’ll always get the truth from us. Everything we make and do honors our <a href="https://blog.mozilla.org/firefox/firefox-data-privacy-promise/?utm_source=www.mozilla.org&utm_medium=referral&utm_campaign=accounts-trailhead&utm_content=accounts-value&utm_term=respect-you-deserve">Personal Data Promise</a>:</p>
 
       <p><strong>Take less.<br> Keep it safe.<br> No secrets.</strong></p>
     </div>
@@ -127,7 +127,7 @@
 <section class="c-accounts-value t-value-knowledge l-media-right">
   <div class="c-accounts-value-container">
     <div class="c-accounts-value-media">
-      {{ high_res_img('firefox/accounts/trailhead/value-knowledge.jpg', {'alt': '', 'width': '800', 'height': '600'}) }}
+      {{ high_res_img('img/firefox/accounts/trailhead/value-knowledge.jpg', {'alt': '', 'width': '800', 'height': '600'}) }}
     </div>
 
     <div class="c-accounts-value-content">

--- a/bedrock/exp/templates/exp/firefox/new/base.html
+++ b/bedrock/exp/templates/exp/firefox/new/base.html
@@ -8,9 +8,11 @@
 {% extends "exp/base/base-firefox.html" %}
 
 {% block canonical_urls %}
-  {# the SEM campaign page should set canonical to the /firefox/new/ page. #}
+  {# Experimental pages should set canonical to the original page URL. #}
   <link rel="canonical" href="{{ settings.CANONICAL_URL }}/{{ LANG }}/firefox/new/">
 {% endblock %}
+
+{% block page_og_url %}{{ settings.CANONICAL_URL }}/{{ LANG }}/firefox/new/{% endblock %}
 
 {# All stylesheets are loaded in extrahead to serve legacy IE basic styles #}
 {% block extrahead %}

--- a/bedrock/exp/urls.py
+++ b/bedrock/exp/urls.py
@@ -8,4 +8,5 @@ from bedrock.mozorg.util import page
 urlpatterns = (
     page('opt-out', 'exp/opt-out.html'),
     page('firefox/new', 'exp/firefox/new/download.html', active_locales=['en-US', 'en-GB', 'en-CA', 'de']),
+    page('firefox/accounts', 'exp/firefox/accounts-2019.html'),
 )

--- a/media/css/exp/firefox/accounts-2019.scss
+++ b/media/css/exp/firefox/accounts-2019.scss
@@ -1,0 +1,564 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+@import '../../../protocol/css/includes/lib';
+
+.c-section-title {
+    @include text-display-md;
+    max-width: $content-sm;
+    margin: 0 auto $layout-xl;
+    text-align: center;
+}
+
+
+//* -------------------------------------------------------------------------- */
+// Hero
+
+.c-accounts-hero {
+    padding: $spacing-lg 0;
+    text-align: center;
+
+    .c-accounts-hero-body-signed-in {
+        display: none;
+    }
+
+    .c-accounts-hero-title {
+        @include text-display-lg;
+        background: transparent url('/media/protocol/img/logos/firefox/logo-word-hor.svg') center top no-repeat;
+        @include background-size(150px, 48px);
+        margin-bottom: $spacing-xl;
+        padding-top: (60px + $spacing-2xl);
+
+        span {
+            color: $color-red-50;
+        }
+    }
+
+    .c-accounts-hero-desc {
+        @include text-body-lg;
+    }
+
+    .state-fxa-supported-signed-in & {
+        .c-accounts-hero-body-default {
+            display: none;
+        }
+
+        .c-accounts-hero-body-signed-in {
+            display: block;
+        }
+    }
+
+    @media #{$mq-md} {
+        background: transparent url('/media/img/firefox/accounts/trailhead/accounts-hero-logged-out.svg') right -720px top no-repeat;
+        @include background-size(1660px 275px);
+
+        .state-fxa-supported-signed-in & {
+            @include background-size(2188px 275px);
+            background-image: url('/media/img/firefox/accounts/trailhead/accounts-hero-logged-in.svg');
+            background-position: right -960px top -40px;
+        }
+    }
+
+    @media #{$mq-lg} {
+        @include background-size(3441px 570px);
+        @include bidi(((text-align, left, right),));
+        background-position: center top;
+        min-height: 560px;
+
+        .state-fxa-supported-signed-in & {
+            @include background-size(3500px 440px);
+            background-position: center top;
+            min-height: 420px;
+        }
+
+        .c-accounts-hero-body {
+            @include grid-half;
+            @include bidi(((float, left, right),));
+        }
+
+        .c-accounts-hero-title {
+            @include bidi(((background-position, left top, right top),));
+            max-width: 12em;
+        }
+
+        @supports (display: grid) {
+            & > .mzp-l-content {
+                display: grid;
+                grid-template-columns: repeat(2, 1fr);
+                grid-column-gap: $spacing-2xl;
+            }
+
+            .c-accounts-hero-body {
+                float: none;
+                width: auto;
+            }
+        }
+    }
+}
+
+
+
+//* -------------------------------------------------------------------------- */
+// FxA signup form
+
+.c-accounts-form {
+    background: $color-white;
+    border-radius: 6px;
+    box-shadow: 0 0 16px 0 rgba(0, 0, 0, .15);
+    margin: $layout-lg auto 0;
+    max-width: 330px;
+    padding: $spacing-lg;
+    text-align: center;
+
+    .fxa-email-form-title {
+        @include text-display-sm;
+    }
+
+    .state-fxa-supported-signed-in & {
+        display: none;
+    }
+
+    .mzp-c-button {
+        width: 100%;
+    }
+
+    .fxa-signin {
+        @include text-body-sm;
+        margin-top: $spacing-lg;
+    }
+
+    @media #{$mq-lg} {
+        @include bidi(((float, right, left),));
+        margin-top: (60px + $spacing-2xl);
+
+        @supports (display: grid) {
+            float: none;
+        }
+    }
+}
+
+
+//* -------------------------------------------------------------------------- */
+// Products
+
+.c-product-list {
+    max-width: $content-md;
+    margin: $spacing-2xl auto;
+
+    @media #{$mq-sm} {
+        @supports (display: grid) {
+            display: grid;
+            grid-template-columns: repeat(2, 1fr);
+            grid-gap: $layout-md $layout-lg;
+        }
+    }
+}
+
+.c-product-list-item {
+    margin: 0 auto $layout-lg;
+    text-align: center;
+    max-width: $content-xs;
+
+    a:link,
+    a:visited {
+        display: block;
+        text-decoration: none;
+
+        .c-product-list-title {
+            color: $color-off-black;
+        }
+
+        .c-product-list-desc {
+            text-decoration: underline;
+        }
+
+        &:hover,
+        &:focus,
+        &:active {
+            .c-product-list-desc {
+                text-decoration: none;
+            }
+        }
+    }
+
+    @media #{$mq-sm} {
+        @include bidi(((text-align, left, right),));
+
+        @supports (display: grid) {
+            margin: 0;
+        }
+    }
+}
+
+.c-product-list-title {
+    @include image-replaced;
+    @include text-display-sm;
+    background-position: center top;
+    background-repeat: no-repeat;
+    margin: 0 auto $spacing-lg;
+    height: 50px;
+
+    .t-product-firefox & {
+        @include at2x('/media/img/logos/firefox/quantum/logo-word-hor-stack-md.png', 144px, 50px);
+    }
+
+    .t-product-lockwise & {
+        @include at2x('/media/protocol/img/logos/firefox/lockwise/logo-word-hor-stack-md.png', 154px, 50px);
+    }
+
+    .t-product-monitor & {
+        @include at2x('/media/protocol/img/logos/firefox/monitor/logo-word-hor-stack-md.png', 138px, 50px);
+    }
+
+    .t-product-send & {
+        @include at2x('/media/protocol/img/logos/firefox/send/logo-word-hor-stack-md.png', 130px, 50px);
+    }
+
+    @media #{$mq-sm} {
+        @include bidi(((background-position, left top, right top),));
+        margin: 0 0 $spacing-lg;
+    }
+
+    @media #{$mq-md} {
+        height: 64px;
+
+        .t-product-firefox & {
+            @include background-size(184px,  64px);
+        }
+
+        .t-product-lockwise & {
+            @include background-size(197px, 64px);
+        }
+
+        .t-product-monitor & {
+            @include background-size(176px, 64px);
+        }
+
+        .t-product-send & {
+            @include background-size(167px, 64px);
+        }
+    }
+}
+
+.c-product-list-desc {
+    @include text-body-lg;
+}
+
+.c-accounts-products-tagline {
+    @include font-size(32px);
+    font-weight: bold;
+    color: $color-red-50;
+    max-width: $content-md;
+    margin: $layout-lg auto;
+    text-align: center;
+}
+
+
+//* -------------------------------------------------------------------------- */
+// Value propositions
+
+.c-accounts-value {
+    @include text-body-lg;
+    margin-bottom: $layout-lg;
+
+    .c-accounts-value-container {
+        overflow: hidden;
+    }
+
+    .c-accounts-value-content {
+        @include border-box;
+        min-width: $content-xs;
+        padding: $layout-xs;
+    }
+
+    .c-accounts-value-media {
+        @include clearfix;
+        margin-bottom: $spacing-xl;
+        padding: $layout-xs;
+        max-width: 800px;
+    }
+
+    &.l-media-left .c-accounts-value-media {
+        @include bidi((
+            (margin-left, -25%, auto),
+            (margin-right, auto, -25%),
+        ));
+
+        img {
+            @include bidi((
+                (float, left, right),
+                (margin-left, -10%, auto),
+                (margin-right, auto, -10%),
+                (transform, none, scaleX(-1)),
+            ));
+        }
+    }
+
+    &.l-media-right .c-accounts-value-media {
+        @include bidi((
+            (margin-left, auto, -25%),
+            (margin-right, -25%, auto),
+        ));
+
+        img {
+            @include bidi((
+                (float, right, left),
+                (margin-left, auto, -10%),
+                (margin-right, -10%, auto),
+                (transform, none, scaleX(-1)),
+            ));
+        }
+    }
+
+    @media #{$mq-sm} {
+        &.l-media-left .c-accounts-value-media,
+        &.l-media-right .c-accounts-value-media {
+            margin-left: 0;
+            margin-right: 0;
+        }
+    }
+
+    @media #{$mq-md} {
+        .c-accounts-value-container {
+            margin: 0 auto;
+            max-width: $content-md;
+            padding: 0 $layout-xl;
+        }
+
+        @supports (display: grid) {
+            .c-accounts-value-container {
+                align-items: center;
+                display: grid;
+                grid-column-gap: $layout-lg;
+                grid-template-columns: repeat(2, 1fr);
+                margin: 0;
+                max-width: none;
+                padding: 0;
+            }
+
+            .c-accounts-value-media {
+                grid-row: 1;
+                padding: 0;
+
+                img {
+                    float: none;
+                    width: 800px;
+                }
+            }
+
+            .c-accounts-value-content {
+                grid-row: 1;
+                max-width: ($content-max / 2) - $spacing-lg;
+                padding: 0;
+            }
+
+            &.l-media-left {
+                .c-accounts-value-content {
+                    @include bidi((
+                        (padding-left, 0, $layout-lg),
+                        (padding-right, $layout-lg, 0),
+                    ));
+                    grid-column: 2;
+                }
+
+                .c-accounts-value-media {
+                    @include bidi((
+                        (margin-left, -25%, 0),
+                        (margin-right, 0, -25%),
+                    ));
+                    grid-column: 1;
+                    justify-self: end;
+
+                    img {
+                        @include bidi((
+                            (float, right, left),
+                            (transform, none, scaleX(-1)),
+                        ));
+                    }
+                }
+            }
+
+            &.l-media-right {
+                .c-accounts-value-content {
+                    @include bidi((
+                        (padding-right, 0, $layout-lg),
+                        (padding-left, $layout-lg, 0),
+                    ));
+                    grid-column: 1;
+                    justify-self: end;
+                }
+
+                .c-accounts-value-media {
+                    @include bidi((
+                        (margin-left, 0, -25%),
+                        (margin-right, -25%, 0),
+                    ));
+                    grid-column: 2;
+                    justify-self: start;
+
+                    img {
+                        @include bidi((
+                            (float, left, right),
+                            (transform, none, scaleX(-1)),
+                        ));
+                    }
+                }
+            }
+        }
+
+        @media #{$mq-lg} {
+            &.l-media-left .c-accounts-value-content {
+                @include bidi((
+                    (padding-left, 0, $layout-xl),
+                    (padding-right, $layout-xl, 0),
+                ));
+            }
+
+            &.l-media-right .c-accounts-value-content {
+                @include bidi((
+                    (padding-right, 0, $layout-xl),
+                    (padding-left, $layout-xl, 0),
+                ));
+            }
+        }
+    }
+}
+
+.c-accounts-value-title {
+    @include text-display-md;
+}
+
+
+//* -------------------------------------------------------------------------- */
+// Join the movement
+
+.c-accounts-movement .c-section-title {
+    @include font-size(32px);
+    font-weight: bold;
+    color: $color-red-50;
+    max-width: $content-md;
+    margin: 0 auto $layout-lg;
+    text-align: center;
+}
+
+.c-accounts-movement-container {
+    margin: $layout-xl auto;
+
+    @media #{$mq-md} {
+        @supports (display: grid) {
+            display: grid;
+            grid-template-columns: repeat(2, 1fr);
+            grid-template-rows: 2;
+            grid-column-gap: $layout-lg;
+        }
+    }
+}
+
+.c-accounts-movement-item {
+    @include background-size(50px, 50px);
+    @include border-box;
+    background-position: center top;
+    background-repeat: no-repeat;
+    margin: 0 auto $layout-lg;
+    max-width: $content-sm;
+    padding-top: $layout-lg + 10px;
+    text-align: center;
+
+    &.t-movement-build {
+        background-image: url('/media/img/firefox/accounts/trailhead/icon-experiments.svg');
+    }
+
+    &.t-movement-bigtech {
+        background-image: url('/media/img/firefox/accounts/trailhead/icon-inbox.svg');
+    }
+
+    @media #{$mq-md} {
+        @include bidi((
+            (background-position, left $spacing-sm, right $spacing-sm),
+            (padding-left, $layout-lg + 10px, 0),
+            (padding-right, 0, $layout-lg + 10px),
+            (text-align, left, right),
+        ));
+        padding-top: 0;
+
+        @supports (display: grid) {
+            max-width: none;
+            margin: 0;
+        }
+    }
+}
+
+.c-accounts-movement-title {
+    @include text-display-md;
+}
+
+.c-accounts-movement-desc {
+    @include text-body-lg;
+}
+
+
+//* -------------------------------------------------------------------------- */
+// Flip backgrounds for right-to-left languages
+
+[dir='rtl'] {
+    .c-accounts-hero {
+        background-image: none;
+        overflow-x: hidden;
+        position: relative;
+
+        & > .mzp-l-content {
+            z-index: 2;
+        }
+
+
+        @media #{$mq-md} {
+            &:after {
+                @include background-size(1660px 275px);
+                background-image: url('/media/img/firefox/accounts/trailhead/accounts-hero-logged-out.svg');
+                background-position: center top;
+                background-repeat: no-repeat;
+                content: '';
+                display: block;
+                height: 275px;
+                left: 10%;
+                margin-left: -830px;
+                position: absolute;
+                top: 0;
+                transform: scaleX(-1);
+                width: 1660px;
+                z-index: 1;
+            }
+        }
+
+        @media #{$mq-lg} {
+            &:after {
+                @include background-size(3441px 570px);
+                height: 570px;
+                left: 50%;
+                margin-left: -1720px;
+                width: 3441px;
+            }
+        }
+    }
+
+    @media #{$mq-md} {
+        .state-fxa-supported-signed-in .c-accounts-hero:after {
+            @include background-size(2188px 275px);
+            background-image: url('/media/img/firefox/accounts/trailhead/accounts-hero-logged-in.svg');
+            height: 275px;
+            margin-left: -1094px;
+            width: 2188px;
+        }
+    }
+
+    @media #{$mq-lg} {
+        .state-fxa-supported-signed-in .c-accounts-hero:after {
+            @include background-size(3500px 440px);
+            height: 440px;
+            margin-left: -1750px;
+            width: 3500px;
+        }
+    }
+}
+

--- a/media/js/exp/firefox/accounts-2019.js
+++ b/media/js/exp/firefox/accounts-2019.js
@@ -1,0 +1,21 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+(function() {
+    'use strict';
+
+    // Prevent double-requesting Flow IDs, inits FxaForm even on non-firefox browsers.
+    if (Mozilla.Client.isFirefoxDesktop) {
+        Mozilla.Client.getFxaDetails(function(details) {
+            if (details.setup) {
+                Mozilla.MonitorButton.init();
+            } else {
+                Mozilla.FxaForm.init();
+            }
+        });
+    } else {
+        Mozilla.FxaForm.init();
+    }
+
+})(window.Mozilla);

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -812,6 +812,14 @@
     {
       "files": [
         "css/base/mozilla-fxa-state.scss",
+        "css/base/mozilla-fxa-form.scss",
+        "css/exp/firefox/accounts-2019.scss"
+      ],
+      "name": "exp_firefox_accounts_2019"
+    },
+    {
+      "files": [
+        "css/base/mozilla-fxa-state.scss",
         "css/firefox/concerts.scss"
       ],
       "name": "firefox_concert_series"
@@ -1464,6 +1472,17 @@
         "js/firefox/accounts-2019.js"
       ],
       "name": "firefox_accounts_2019"
+    },
+    {
+      "files": [
+        "js/base/mozilla-fxa.js",
+        "js/base/mozilla-fxa-init.js",
+        "js/base/mozilla-fxa-form.js",
+        "js/base/mozilla-fxa-sign-in-link.js",
+        "js/base/mozilla-monitor-button.js",
+        "js/exp/firefox/accounts-2019.js"
+      ],
+      "name": "exp_firefox_accounts_2019"
     },
     {
       "files": [


### PR DESCRIPTION
## Description

- Adds an en-US only version of /firefox/accounts/ at /exp/firefox/accounts/

## Issue / Bugzilla link
#7802

## Testing
- [x] Experiment page should look & function the same as regular page.
- [x] Experiment page should load Convert JS (when DNT is disabled).
- [x] Experimental page should have a canonical URL that points to original URL.
