### PR TITLE
[bugfix] Activate DE and FR locales for whatsnew 70

### DIFF
--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx70-de.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx70-de.html
@@ -4,6 +4,8 @@
 
 {% from "macros.html" import monitor_button, fxa_cta_link with context %}
 
+{% add_lang_files "firefox/whatsnew_70" %}
+
 {% extends "firefox/base/base-protocol.html" %}
 
 {% block page_title %}{{ _('Was gibt’s Neues von Firefox? – Mehr Privatsphäre, mehr Schutz') }}{% endblock %}

--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx70-en.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx70-en.html
@@ -4,6 +4,8 @@
 
 {% from "macros.html" import monitor_button, fxa_cta_link with context %}
 
+{% add_lang_files "firefox/whatsnew_70" %}
+
 {% extends "firefox/base/base-protocol.html" %}
 
 {% block page_title %}{{ _('What’s new with Firefox - More privacy, more protections.') }}{% endblock %}

--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx70-fr.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx70-fr.html
@@ -4,6 +4,8 @@
 
 {% from "macros.html" import monitor_button, fxa_cta_link with context %}
 
+{% add_lang_files "firefox/whatsnew_70" %}
+
 {% extends "firefox/base/base-protocol.html" %}
 
 {% block page_title %}{{ _('Quoi de neuf chez Firefox ? Encore plus de respect de la vie privée et plus de protection.') }}{% endblock %}


### PR DESCRIPTION
## Description
DE and FR have hard-coded templates for the whatsnew page for Firefox 70. This activates them for prod.

## Issue / Bugzilla link
#7677 
