### PR TITLE
[bugfix] whatsnew page for Firefox 70 papercuts. (Fixes #7910, bug 1579940)

### DIFF
--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx70-de.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx70-de.html
@@ -94,7 +94,7 @@
           <h3 class="c-picto-block-title">{{ _('Schütze deine Passwörter und nimm sie mit') }}</h3>
           <div class="c-picto-block-body">
             <p>{{ _('In Firefox Lockwise kannst du deine Passwörter sicher aufbewahren und verwalten. UND: Du kannst dich warnen lassen, wenn du ein Passwort unbedingt ändern solltest.') }}</p>
-            <a class="mzp-c-cta-link js-open-lockwise" href="https://support.mozilla.org/kb/enhanced-tracking-protection-firefox-desktop/?utm_source={{ _entrypoint }}&utm_medium=referral&utm_campaign={{ _utm_campaign }}&entrypoint={{ _entrypoint }}">{{ _('Zu Lockwise') }}</a>
+            <a class="mzp-c-cta-link js-open-lockwise" href="{{ url('firefox.lockwise.lockwise') }}">{{ _('Zu Lockwise') }}</a>
           </div>
         </div>
       </div>

--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx70-en.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx70-en.html
@@ -94,7 +94,7 @@
           <h3 class="c-picto-block-title">{{ _('Keep your passwords protected and portable') }}</h3>
           <div class="c-picto-block-body">
             <p>{{ _('Safely store and manage your passwords with Lockwise, and get alerted when you need to change them.') }}</p>
-            <a class="mzp-c-cta-link js-open-lockwise" href="https://support.mozilla.org/kb/enhanced-tracking-protection-firefox-desktop/?utm_source={{ _entrypoint }}&utm_medium=referral&utm_campaign={{ _utm_campaign }}&entrypoint={{ _entrypoint }}">{{ _('Go to Lockwise') }}</a>
+            <a class="mzp-c-cta-link js-open-lockwise" href="{{ url('firefox.lockwise.lockwise') }}">{{ _('Go to Lockwise') }}</a>
           </div>
         </div>
       </div>

--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx70-fr.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx70-fr.html
@@ -94,7 +94,7 @@
           <h3 class="c-picto-block-title">{{ _('Protégez vos mots de passe et gardez-les à portée de main') }}</h3>
           <div class="c-picto-block-body">
             <p>{{ _('Avec Firefox Lockwise, vous pouvez stocker et gérer vos mots de passe de manière sécurisée. En plus, on vous prévient si jamais vous avez besoin de changer un mot de passe.') }}</p>
-            <a class="mzp-c-cta-link js-open-lockwise" href="https://support.mozilla.org/kb/enhanced-tracking-protection-firefox-desktop/?utm_source={{ _entrypoint }}&utm_medium=referral&utm_campaign={{ _utm_campaign }}&entrypoint={{ _entrypoint }}">{{ _('Découvrir Lockwise') }}</a>
+            <a class="mzp-c-cta-link js-open-lockwise" href="{{ url('firefox.lockwise.lockwise') }}">{{ _('Découvrir Lockwise') }}</a>
           </div>
         </div>
       </div>

--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx70.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx70.html
@@ -41,7 +41,7 @@
         </h2>
         <p>{{ _('We made Enhanced Tracking Protection because no one should be able to follow you online without your permission. And now you can see just how many data-collecting trackers Firefox has blocked for you — along with other ways our products protect your privacy.') }}</p>
 
-        <a class="mzp-c-button mzp-t-product show-firefox-desktop-70 js-open-about-protections" href="https://support.mozilla.org/kb/enhanced-tracking-protection-firefox-desktop/?utm_source={{ _entrypoint }}&utm_medium=referral&utm_campaign={{ _utm_campaign }}&entrypoint={{ _entrypoint }}" data-link-type="link" data-link-name="See what Firefox has blocked for you">{{ _('See what Firefox has blocked for you') }}</a>
+        <a class="mzp-c-button mzp-t-product show-firefox-desktop-70 js-open-about-protections" href="https://support.mozilla.org/kb/enhanced-tracking-protection-firefox-desktop/?utm_source={{ _entrypoint }}&utm_medium=referral&utm_campaign={{ _utm_campaign }}&entrypoint={{ _entrypoint }}" data-link-type="link" data-link-name="See what Firefox has blocked for you" data-cta-type="Protection-Report" data-cta-position="Primary">{{ _('See what Firefox has blocked for you') }}</a>
 
         <a class="mzp-c-button mzp-t-product show-firefox-desktop-old" href="https://support.mozilla.org/kb/update-firefox-latest-release/?utm_source={{ _entrypoint }}&utm_medium=referral&utm_campaign={{ _utm_campaign }}&entrypoint={{ _entrypoint }}" data-link-type="link" data-link-name="Update your Firefox browser">{{ _('Update your Firefox browser') }}</a>
 
@@ -86,7 +86,7 @@
           <h3 class="c-picto-block-title">{{ _('Firefox Lockwise') }}</h3>
           <div class="c-picto-block-body">
             <p>{{ _('Safely store and manage your passwords with Lockwise, and get alerted when you need to change them.') }}</p>
-            <a class="mzp-c-cta-link js-open-lockwise" href="https://support.mozilla.org/kb/enhanced-tracking-protection-firefox-desktop/?utm_source={{ _entrypoint }}&utm_medium=referral&utm_campaign={{ _utm_campaign }}&entrypoint={{ _entrypoint }}">{{ _('Go to Lockwise') }}</a>
+            <a class="mzp-c-cta-link js-open-lockwise" href="{{ url('firefox.lockwise.lockwise') }}">{{ _('Go to Lockwise') }}</a>
           </div>
         </div>
 

--- a/media/js/firefox/whatsnew/whatsnew-70.js
+++ b/media/js/firefox/whatsnew/whatsnew-70.js
@@ -42,7 +42,6 @@
                 // For UI Tour CTAs, we will treat these more as an action rather than a page navigation.
                 for (var i = 0; i < protectionReportLinks.length; i++) {
                     // Hide fallback links.
-                    protectionReportLinks[i].href = 'about:protections';
                     protectionReportLinks[i].addEventListener('click', handleOpenProtectionReport, false);
                 }
 


### PR DESCRIPTION
## Description
Updates Lockwise CTA links. (Point to firefox/lockwise as uitour fallback.)
[QA Feedback](https://docs.google.com/spreadsheets/d/1Eo4OfeydNmJaWMyTVK_0ODyI4bku1L5rrtXpK_3XC0c/edit#gid=850719639)

## Issue / Bugzilla link
#7910
[1579940](https://bugzilla.mozilla.org/show_bug.cgi?id=1579940)
