### PR TITLE
Activate new footer for more translated locales

### DIFF
--- a/bedrock/base/templates/includes/protocol/footer/firefox.html
+++ b/bedrock/base/templates/includes/protocol/footer/firefox.html
@@ -2,8 +2,8 @@
   # License, v. 2.0. If a copy of the MPL was not distributed with this
   # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
 
- {% if LANG.startswith('en-') or LANG in ['de'] %}
-   {% include 'includes/protocol/footer/firefox-new.html' %}
- {% else %}
-   {% include 'includes/protocol/footer/mozilla.html' %}
- {% endif %}
+{% if LANG.startswith('en-') or LANG.startswith('es-') or LANG in ['be', 'ca', 'cy', 'de', 'eu', 'fr', 'fy-NL', 'gn', 'hr', 'hsb', 'hu', 'ia', 'id', 'it', 'ka', 'nb-NO', 'pl', 'pt-BR', 'ru', 'sl', 'sq', 'sv-SE', 'tr', 'vi', 'zh-CN', 'zh-TW'] %}
+  {% include 'includes/protocol/footer/firefox-new.html' %}
+{% else %}
+  {% include 'includes/protocol/footer/mozilla.html' %}
+{% endif %}

--- a/bedrock/base/templates/includes/protocol/footer/mozilla.html
+++ b/bedrock/base/templates/includes/protocol/footer/mozilla.html
@@ -2,7 +2,7 @@
  # License, v. 2.0. If a copy of the MPL was not distributed with this
  # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
 
-{% if LANG.startswith('en-') or LANG in ['de'] %}
+{% if LANG.startswith('en-') or LANG.startswith('es-') or LANG in ['be', 'ca', 'cy', 'de', 'eu', 'fr', 'fy-NL', 'gn', 'hr', 'hsb', 'hu', 'ia', 'id', 'it', 'ka', 'nb-NO', 'pl', 'pt-BR', 'ru', 'sl', 'sq', 'sv-SE', 'tr', 'vi', 'zh-CN', 'zh-TW'] %}
   {% include 'includes/protocol/footer/mozilla-new.html' %}
 {% else %}
   {% include 'includes/protocol/footer/mozilla-old.html' %}


### PR DESCRIPTION
## Description

Enable the new footer for more locales

## Issue / Bugzilla link

n/a

## Testing
- new mozilla and firefox footers available in more languages
- no errors rendering new mozilla footer, old mozilla footer, or new firefox footer