### PR TITLE
Update "Firefox Desktop" menu link to link to firefox/new #7917

### DIFF
--- a/bedrock/base/templates/includes/protocol/navigation/menu-mozilla/firefox.html
+++ b/bedrock/base/templates/includes/protocol/navigation/menu-mozilla/firefox.html
@@ -11,7 +11,7 @@
         <ul>
           <li>
             <section class="mzp-c-menu-item mzp-has-icon">
-              <a class="mzp-c-menu-item-link" href="{{ url('firefox') }}" data-link-name="Firefox Quantum Desktop Browser" data-link-type="nav" data-link-position="topnav" data-link-group="firefox">
+              <a class="mzp-c-menu-item-link" href="{{ url('firefox.new') }}" data-link-name="Firefox Quantum Desktop Browser" data-link-type="nav" data-link-position="topnav" data-link-group="firefox">
                 <img src="{{ static('img/logos/firefox/quantum/logo-sm.png') }}" class="mzp-c-menu-item-icon" width="24" height="24" alt="">
                 {% if LANG.startswith('en-') %}
                   <h4 class="mzp-c-menu-item-title">{{ _('Firefox Desktop Browser') }}</h4>

--- a/tests/pages/base.py
+++ b/tests/pages/base.py
@@ -73,8 +73,8 @@ class BasePage(Page):
         def open_firefox_desktop_page(self):
             self.open_navigation_menu(self._firefox_menu_locator)
             self.find_element(*self._firefox_desktop_page_locator).click()
-            from .firefox.home import FirefoxHomePage
-            return FirefoxHomePage(self.selenium, self.page.base_url).wait_for_page_to_load()
+            from .firefox.new.download import DownloadPage
+            return DownloadPage(self.selenium, self.page.base_url, params='').wait_for_page_to_load()
 
         def open_developer_edition_page(self):
             self.open_navigation_menu(self._developers_menu_locator)


### PR DESCRIPTION
## Description

Update "Firefox Desktop" menu link to link to firefox/new 

## Issue / Bugzilla link

#7917

## Testing

✅  Integrations rests passing here: https://ci.vpn1.moz.works/blue/organizations/jenkins/bedrock_multibranch_pipeline/detail/run-integration-tests/403/pipeline/