### PR TITLE
Use more specific base Python Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN gulp build --production
 ########
 # Python dependencies builder
 #
-FROM python:3-slim AS python-builder
+FROM python:3.7-slim-buster AS python-builder
 
 WORKDIR /app
 ENV LANG=C.UTF-8
@@ -46,7 +46,7 @@ RUN pip install --no-cache-dir -r requirements/prod.txt
 ########
 # django app container
 #
-FROM python:3-slim AS app-base
+FROM python:3.7-slim-buster AS app-base
 
 # Extra python env
 ENV PYTHONDONTWRITEBYTECODE=1


### PR DESCRIPTION
The image we were using (`python:3-slim`) just switched to Python 3.8 and lxml was failing to build using that. This uses the much more specific `python:3.7-slim-buster` tag so that this won't change for us unexpectedly again.

Fix #7927


## Description

## Issue / Bugzilla link

## Testing