### PR TITLE
Update image helpers to always use the full path to the image

### DIFF
--- a/bedrock/base/templates/macros-protocol.html
+++ b/bedrock/base/templates/macros-protocol.html
@@ -7,11 +7,10 @@
 {% macro billboard(title, ga_title, desc, link_cta, link_url, image_url, include_highres_image=False, reverse=False, heading_level=2) -%}
 <section class="mzp-c-billboard {% if reverse %}mzp-l-billboard-left{% else %}mzp-l-billboard-right{% endif %}">
   <div class="mzp-c-billboard-image-container">
-    {% set image = image_url if include_highres_image else 'img/' + image_url %}
     {% if include_highres_image %}
-      {{ high_res_img(image, {'alt': '', 'class': 'mzp-c-billboard-image', 'width': '346', 'height': '346'}) }}
+      {{ high_res_img(image_url, {'alt': '', 'class': 'mzp-c-billboard-image', 'width': '346', 'height': '346'}) }}
     {% else %}
-      <img src="{{ static(image) }}" class="mzp-c-billboard-image" width="346" height="346" alt="">
+      <img src="{{ static(image_url) }}" class="mzp-c-billboard-image" width="346" height="346" alt="">
     {% endif %}
   </div>
   <div class="mzp-c-billboard-content">
@@ -47,11 +46,10 @@
   </div>
   {% if image_url %}
   <div class="mzp-c-hero-image">
-    {% set image = image_url if include_highres_image else 'img/' + image_url %}
     {% if include_highres_image %}
-      {{ high_res_img(image, {'alt': image_alt}) }}
+      {{ high_res_img(image_url, {'alt': image_alt}) }}
     {% else %}
-      <img src="{{ static(image) }}" alt="">
+      <img src="{{ static(image_url) }}" alt="">
     {% endif %}
   </div>
   {% endif %}
@@ -156,11 +154,10 @@
 {% macro feature_card_media(image_url, include_highres_image=False) %}
 <div class="mzp-c-card-feature-media-wrapper">
   <div class="mzp-c-card-feature-media">
-    {% set image = image_url if include_highres_image else 'img/' + image_url %}
     {% if include_highres_image %}
-      {{ high_res_img(image, {'alt': ''}) }}
+      {{ high_res_img(image_url, {'alt': ''}) }}
     {% else %}
-      <img src="{{ static(image) }}" alt="">
+      <img src="{{ static(image_url) }}" alt="">
     {% endif %}
   </div>
 </div>

--- a/bedrock/base/templates/macros.html
+++ b/bedrock/base/templates/macros.html
@@ -58,7 +58,7 @@
 {% set optional_img_attributes = {'alt': _('Get it on Google Play'), 'width': '152', 'height': '45', 'l10n': True} %}
 {% do optional_img_attributes.update(extra_img_attributes) %}
 <a{% if class_name %} class="{{ class_name }}"{% endif %}{% if id %} id="{{ id }}"{% endif %}{% if target %} target="{{ target }}" rel="external noopener noreferrer"{% else %} rel="external"{% endif %} href="{{ href }}"{% if product in ['Firefox', 'Focus'] %} data-link-type="download" data-download-os="Android"{% endif %}{% if product == 'Firefox' %} data-mozillaonline-link="{{ settings.GOOGLE_PLAY_FIREFOX_LINK_MOZILLAONLINE }}"{% endif %}{% for attr, val in extra_data_attributes.items() %} data-{{ attr }}="{{ val }}"{% endfor %}>
-  {{ high_res_img('firefox/android/btn-google-play.png', optional_img_attributes) }}
+  {{ high_res_img('img/firefox/android/btn-google-play.png', optional_img_attributes) }}
 </a>
 {%- endmacro %}
 

--- a/bedrock/exp/templates/exp/firefox/new/download.de.html
+++ b/bedrock/exp/templates/exp/firefox/new/download.de.html
@@ -26,7 +26,7 @@
     desc='Und damit eines der Firefox Produkte, für die deine Privatsphäre an erster Stelle steht.',
     class='mzp-has-image mzp-t-dark',
     include_cta=True,
-    image_url='firefox/new/trailhead/browser-window.svg',
+    image_url='img/firefox/new/trailhead/browser-window.svg',
     heading_level=1
   ) %}
     {{ download_firefox(alt_copy='Jetzt herunterladen', download_location='primary cta') }}

--- a/bedrock/exp/templates/exp/firefox/new/download.html
+++ b/bedrock/exp/templates/exp/firefox/new/download.html
@@ -34,7 +34,7 @@
     desc='And start getting the respect you deserve with our family of privacy-first products.',
     class='mzp-has-image mzp-t-dark',
     include_cta=True,
-    image_url='firefox/new/trailhead/browser-window.svg',
+    image_url='img/firefox/new/trailhead/browser-window.svg',
     heading_level=1
   ) %}
     {{ download_firefox(alt_copy='Download Now', download_location='primary cta') }}

--- a/bedrock/firefox/templates/firefox/accounts-2019.html
+++ b/bedrock/firefox/templates/firefox/accounts-2019.html
@@ -140,7 +140,7 @@
 <section class="c-accounts-value t-value-respect l-media-left">
   <div class="c-accounts-value-container">
     <div class="c-accounts-value-media">
-      {{ high_res_img('firefox/accounts/trailhead/value-respect.jpg', {'alt': '', 'width': '800', 'height': '600'}) }}
+      {{ high_res_img('img/firefox/accounts/trailhead/value-respect.jpg', {'alt': '', 'width': '800', 'height': '600'}) }}
     </div>
 
     <div class="c-accounts-value-content">
@@ -161,7 +161,7 @@
 <section class="c-accounts-value t-value-knowledge l-media-right">
   <div class="c-accounts-value-container">
     <div class="c-accounts-value-media">
-      {{ high_res_img('firefox/accounts/trailhead/value-knowledge.jpg', {'alt': '', 'width': '800', 'height': '600'}) }}
+      {{ high_res_img('img/firefox/accounts/trailhead/value-knowledge.jpg', {'alt': '', 'width': '800', 'height': '600'}) }}
     </div>
 
     <div class="c-accounts-value-content">

--- a/bedrock/firefox/templates/firefox/all.html
+++ b/bedrock/firefox/templates/firefox/all.html
@@ -74,9 +74,9 @@
 
 {% block site_header_logo %}
   {% if platform == 'desktop' and channel == 'alpha' %}
-    <h2><a href="{{ url('firefox.developer.index') }}">{{ high_res_img('logos/firefox/developer-wordmark-dark.png', {'alt': _('Firefox Developer Edition'), 'width': '260', 'height': '48'}) }}</a></h2>
+    <h2><a href="{{ url('firefox.developer.index') }}">{{ high_res_img('img/logos/firefox/developer-wordmark-dark.png', {'alt': _('Firefox Developer Edition'), 'width': '260', 'height': '48'}) }}</a></h2>
   {% elif channel == 'nightly' %}
-    <h2>{{ high_res_img('logos/firefox/nightly-wordmark-dark.png', {'alt': _('Firefox Nightly'), 'width': '305', 'height': '56'}) }}</h2>
+    <h2>{{ high_res_img('img/logos/firefox/nightly-wordmark-dark.png', {'alt': _('Firefox Nightly'), 'width': '305', 'height': '56'}) }}</h2>
   {% else %}
     {{ super() }}
   {% endif %}

--- a/bedrock/firefox/templates/firefox/base/base-resp.html
+++ b/bedrock/firefox/templates/firefox/base/base-resp.html
@@ -21,7 +21,7 @@
 {% block site_header %}
   <header id="masthead">
   {% block site_header_logo %}
-    <h2><a href="{{ url('firefox') }}">{{ high_res_img('logos/firefox/quantum/logo-word-hor-sm.png', {'alt': 'Firefox', 'width': '347', 'height': '64'}) }}</a></h2>
+    <h2><a href="{{ url('firefox') }}">{{ high_res_img('img/logos/firefox/quantum/logo-word-hor-sm.png', {'alt': 'Firefox', 'width': '347', 'height': '64'}) }}</a></h2>
   {% endblock %}
   </header>
 {% endblock %}

--- a/bedrock/firefox/templates/firefox/campaign/berlin/base-variation.html
+++ b/bedrock/firefox/templates/firefox/campaign/berlin/base-variation.html
@@ -27,7 +27,7 @@
   <section class="intro content-section">
     <div class="content">
       <div class="copy">
-        {{ high_res_img('logos/firefox/quantum/logo-word-hor-stack-white-lg.png', {'alt': 'Besser digital leben — mit Firefox', 'width': '288', 'height': '100', 'class': 'logo'}) }}
+        {{ high_res_img('img/logos/firefox/quantum/logo-word-hor-stack-white-lg.png', {'alt': 'Besser digital leben — mit Firefox', 'width': '288', 'height': '100', 'class': 'logo'}) }}
         {% block head_content %}
           <h1 id="main-heading">{% block main_heading %}Zeit für den Browser <br>mit Herz.{% endblock %}</h1>
         {% endblock %}

--- a/bedrock/firefox/templates/firefox/campaign/berlin/base.html
+++ b/bedrock/firefox/templates/firefox/campaign/berlin/base.html
@@ -27,7 +27,7 @@
   <section class="intro content-section">
     <div class="content">
       <div class="copy">
-        {{ high_res_img('logos/firefox/quantum/logo-word-hor-stack-white-lg.png', {'alt': 'Besser digital leben — mit Firefox', 'width': '288', 'height': '100', 'class': 'logo'}) }}
+        {{ high_res_img('img/logos/firefox/quantum/logo-word-hor-stack-white-lg.png', {'alt': 'Besser digital leben — mit Firefox', 'width': '288', 'height': '100', 'class': 'logo'}) }}
         {% block head_content %}
           <h1 id="main-heading">Zeit für <br />den Browser <br/>mit Herz.</h1>
         {% endblock %}

--- a/bedrock/firefox/templates/firefox/campaign/better-browser/base.html
+++ b/bedrock/firefox/templates/firefox/campaign/better-browser/base.html
@@ -25,7 +25,7 @@
   <section class="intro content-section">
     <div class="content">
       <div class="copy">
-        {{ high_res_img('logos/firefox/quantum/logo-lg.png', {'alt': 'Firefox', 'width': '100', 'height': '100', 'class': 'logo'}) }}
+        {{ high_res_img('img/logos/firefox/quantum/logo-lg.png', {'alt': 'Firefox', 'width': '100', 'height': '100', 'class': 'logo'}) }}
         {% block head_content %}{% endblock %}
         {% block primary_download_button %}
           {{ download_firefox(alt_copy=_('Download Now'), locale_in_transition=true, dom_id="download-firefox", download_location='primary cta', button_color='') }}

--- a/bedrock/firefox/templates/firefox/campaign/compare/base.html
+++ b/bedrock/firefox/templates/firefox/campaign/compare/base.html
@@ -37,7 +37,7 @@
           </div>
         </div>
 
-        {{ high_res_img('firefox/new/compare/hero-laptop.png', {'alt': '', 'width': '672', 'height': '402'}) }}
+        {{ high_res_img('img/firefox/new/compare/hero-laptop.png', {'alt': '', 'width': '672', 'height': '402'}) }}
       </div>
     </section>
 

--- a/bedrock/firefox/templates/firefox/campaign/index-trailhead.html
+++ b/bedrock/firefox/templates/firefox/campaign/index-trailhead.html
@@ -59,7 +59,7 @@
     desc=_('And start getting the respect you deserve with our family of privacy-first products.'),
     class='mzp-has-image mzp-t-dark',
     include_cta=True,
-    image_url='firefox/new/trailhead/browser-window.svg',
+    image_url='img/firefox/new/trailhead/browser-window.svg',
     heading_level=1
   ) %}
     {{ download_firefox(alt_copy=_('Download Now'), download_location='primary cta') }}

--- a/bedrock/firefox/templates/firefox/campaign/index.html
+++ b/bedrock/firefox/templates/firefox/campaign/index.html
@@ -30,7 +30,7 @@
   <div class="main-content">
     <div class="mzp-l-content">
       <header class="header-logos">
-        <h2 class="logo-firefox"><a href="{{ url('firefox') }}" title="{{ firefox_logo_title }}">{{ high_res_img('logos/firefox/quantum/logo-word-hor-white-sm.png', {'alt': firefox_logo_title, 'width': '216', 'height': '40'}) }}</a></h2>
+        <h2 class="logo-firefox"><a href="{{ url('firefox') }}" title="{{ firefox_logo_title }}">{{ high_res_img('img/logos/firefox/quantum/logo-word-hor-white-sm.png', {'alt': firefox_logo_title, 'width': '216', 'height': '40'}) }}</a></h2>
         <h2 class="logo-mozilla"><a href="{{ url('mozorg.home') }}" title="{{ mozilla_logo_title }}"><img src="{{ static('img/logos/mozilla/wordmark-dark.svg')}}" alt="{{ mozilla_logo_title }}" width="101" height="34"></a></h2>
       </header>
     </div>
@@ -39,7 +39,7 @@
       desc=_('Fast for good.'),
       class='mzp-has-image mzp-t-firefox mzp-t-dark',
       include_cta=True,
-      image_url='firefox/new/browser.png',
+      image_url='img/firefox/new/browser.png',
       include_highres_image=True,
       heading_level=1
     ) %}

--- a/bedrock/firefox/templates/firefox/concerts.html
+++ b/bedrock/firefox/templates/firefox/concerts.html
@@ -72,7 +72,7 @@
       <section class="mzp-c-card-feature mzp-has-aspect-16-9 mzp-l-card-feature-right-half mzp-t-firefox mzp-t-dark">
         <div class="mzp-c-card-feature-media-wrapper">
           <div class="mzp-c-card-feature-media">
-            {{ high_res_img('firefox/concerts/illo-fxaccount.png', {'alt': '', 'width': '568', 'height': '277'}) }}
+            {{ high_res_img('img/firefox/concerts/illo-fxaccount.png', {'alt': '', 'width': '568', 'height': '277'}) }}
           </div>
         </div>
         <div class="mzp-c-card-feature-content">

--- a/bedrock/firefox/templates/firefox/developer/firstrun.html
+++ b/bedrock/firefox/templates/firefox/developer/firstrun.html
@@ -23,7 +23,7 @@
 <main role="main">
   <section class="t-intro">
       <div class="mzp-l-content">
-        {{ high_res_img('logos/firefox/developer-wordmark.png', {'alt': '', 'width': '368', 'height': '68'}) }}
+        {{ high_res_img('img/logos/firefox/developer-wordmark.png', {'alt': '', 'width': '368', 'height': '68'}) }}
         <h1 class="intro-title">
         {% if l10n_has_tag('made_for_devs_102019') %}
           {# L10n: "Firefox Browser Developer Edition" is a product name and shouldn't be translated #}

--- a/bedrock/firefox/templates/firefox/developer/includes/nightly.html
+++ b/bedrock/firefox/templates/firefox/developer/includes/nightly.html
@@ -2,7 +2,7 @@
   <section class="mzp-c-card-feature mzp-has-aspect-3-2 mzp-l-card-feature-right-half">
     <div class="mzp-c-card-feature-media-wrapper">
       <div class="mzp-c-card-feature-media">
-          {{ high_res_img('firefox/developer/browser-nightly.png', {'alt': '', 'width': '334', 'height': '228'}) }}
+          {{ high_res_img('img/firefox/developer/browser-nightly.png', {'alt': '', 'width': '334', 'height': '228'}) }}
       </div>
     </div>
     <div class="mzp-c-card-feature-content">

--- a/bedrock/firefox/templates/firefox/developer/index.html
+++ b/bedrock/firefox/templates/firefox/developer/index.html
@@ -30,7 +30,7 @@
 <main role="main">
   <section class="t-intro">
     <div class="mzp-l-content">
-      {{ high_res_img('logos/firefox/developer-wordmark.png', {'alt': '', 'width': '368', 'height': '68'}) }}
+      {{ high_res_img('img/logos/firefox/developer-wordmark.png', {'alt': '', 'width': '368', 'height': '68'}) }}
       <h1 class="intro-title">Firefox Browser Developer Edition</h1>
       <p class="intro-tagline">{{ _('Welcome to your new favorite browser. Get the latest features, fast performance, and the development tools you need to build for the open web.') }}</p>
 
@@ -42,7 +42,7 @@
       </p>
     </div>
     <div class="intro-image">
-      {{ high_res_img('firefox/developer/hero-screenshot.png', {'alt': '', 'width': '1200', 'height': '337'}) }}
+      {{ high_res_img('img/firefox/developer/hero-screenshot.png', {'alt': '', 'width': '1200', 'height': '337'}) }}
     </div>
   </section>
 
@@ -63,7 +63,7 @@
       <section class="mzp-c-card-feature mzp-has-aspect-3-2 mzp-l-card-feature-right-half">
         <div class="mzp-c-card-feature-media-wrapper">
           <div class="mzp-c-card-feature-media">
-              {{ high_res_img('firefox/developer/browser.png', {'alt': '', 'width': '334', 'height': '228'}) }}
+              {{ high_res_img('img/firefox/developer/browser.png', {'alt': '', 'width': '334', 'height': '228'}) }}
           </div>
         </div>
         <div class="mzp-c-card-feature-content">

--- a/bedrock/firefox/templates/firefox/developer/whatsnew.html
+++ b/bedrock/firefox/templates/firefox/developer/whatsnew.html
@@ -23,7 +23,7 @@
 <main role="main">
   <section class="t-intro">
     <div class="mzp-l-content">
-      {{ high_res_img('logos/firefox/developer-wordmark.png', {'alt': '', 'width': '368', 'height': '68'}) }}
+      {{ high_res_img('img/logos/firefox/developer-wordmark.png', {'alt': '', 'width': '368', 'height': '68'}) }}
 
     {% if l10n_has_tag('made_for_devs_102019') %}
       {# L10n: "Firefox Browser Developer Edition" is a product name and shouldn't be translated #}

--- a/bedrock/firefox/templates/firefox/enterprise/index.html
+++ b/bedrock/firefox/templates/firefox/enterprise/index.html
@@ -38,7 +38,7 @@
   {% call hero(
     title=_('Get Firefox for your enterprise'),
     class='mzp-t-product-firefox mzp-has-image mzp-t-dark t-enterprise',
-    image_url='firefox/enterprise/fx-browser-img.svg',
+    image_url='img/firefox/enterprise/fx-browser-img.svg',
     include_cta=True,
     heading_level=1
   ) %}

--- a/bedrock/firefox/templates/firefox/enterprise/signup-thanks.html
+++ b/bedrock/firefox/templates/firefox/enterprise/signup-thanks.html
@@ -21,7 +21,7 @@
 {% block site_header %}
 <header class="enterprise-head">
   <div class="mzp-l-content">
-    {{ high_res_img('logos/firefox/quantum/logo-sm.png', {'alt': 'Firefox', 'width': '50', 'height': '50', 'class': 'enterprise-logo'}) }}
+    {{ high_res_img('img/logos/firefox/quantum/logo-sm.png', {'alt': 'Firefox', 'width': '50', 'height': '50', 'class': 'enterprise-logo'}) }}
     <span class="enterprise-name"><strong>Firefox Browser</strong> for Enterprise</span>
   </div>
 </header>

--- a/bedrock/firefox/templates/firefox/enterprise/signup.html
+++ b/bedrock/firefox/templates/firefox/enterprise/signup.html
@@ -21,7 +21,7 @@
 {% block site_header %}
 <header class="enterprise-head">
   <div class="mzp-l-content">
-    {{ high_res_img('logos/firefox/quantum/logo-sm.png', {'alt': 'Firefox', 'width': '50', 'height': '50', 'class': 'enterprise-logo'}) }}
+    {{ high_res_img('img/logos/firefox/quantum/logo-sm.png', {'alt': 'Firefox', 'width': '50', 'height': '50', 'class': 'enterprise-logo'}) }}
     <span class="enterprise-name"><strong>Firefox Browser</strong> for Enterprise</span>
   </div>
 </header>

--- a/bedrock/firefox/templates/firefox/facebookcontainer/index.html
+++ b/bedrock/firefox/templates/firefox/facebookcontainer/index.html
@@ -23,7 +23,7 @@
     <div class="content">
 
       <div class="copy">
-        {{ high_res_img('logos/firefox/quantum/logo-word-hor-white-sm.png', {'alt': '', 'width': '347', 'height': '64', 'class': 'firefox-logo'}) }}
+        {{ high_res_img('img/logos/firefox/quantum/logo-word-hor-white-sm.png', {'alt': '', 'width': '347', 'height': '64', 'class': 'firefox-logo'}) }}
         <header>
           <h1 class="title" id="main-heading">
             {{ _('Facebook. Well contained. Keep the rest of your life to yourself.') }}

--- a/bedrock/firefox/templates/firefox/features/adblocker.html
+++ b/bedrock/firefox/templates/firefox/features/adblocker.html
@@ -77,7 +77,7 @@
   </section>
 
   <section class="mzp-l-content l-content-image">
-    {{ high_res_img('firefox/features/adblocker/content-blocking-title.png', {'alt': '', 'class': 'mzp-c-billboard-image'}) }}
+    {{ high_res_img('img/firefox/features/adblocker/content-blocking-title.png', {'alt': '', 'class': 'mzp-c-billboard-image'}) }}
   </section>
 
   <section class="mzp-l-content mzp-t-narrow">
@@ -99,7 +99,7 @@
   </section>
 
   <section class="mzp-l-content l-content-image">
-    {{ high_res_img('firefox/features/adblocker/content-blocking.png', {'alt': '', 'class': 'mzp-c-billboard-image'}) }}
+    {{ high_res_img('img/firefox/features/adblocker/content-blocking.png', {'alt': '', 'class': 'mzp-c-billboard-image'}) }}
   </section>
 
   <section class=" mzp-l-content mzp-t-narrow">
@@ -121,7 +121,7 @@
   </section>
 
   <section class="mzp-l-content l-content-image">
-    {{ high_res_img('firefox/features/adblocker/content-blocking-custom.png', {'alt': '', 'class': 'mzp-c-billboard-image'}) }}
+    {{ high_res_img('img/firefox/features/adblocker/content-blocking-custom.png', {'alt': '', 'class': 'mzp-c-billboard-image'}) }}
   </section>
 
   <section class="mzp-l-content mzp-t-narrow">
@@ -131,7 +131,7 @@
       Click on the Trackers box and you’ll be able to block trackers in two ways. One way to block trackers is to do it when you’re working in a Private Window. Another way to do it is to block trackers in all windows. Keep in mind that if you choose to always block trackers, some pages might not load correctly.
       {% endtrans %}
     </p>
-    {{ high_res_img('firefox/features/adblocker/custom-trackers.png', {'alt': ''}) }}
+    {{ high_res_img('img/firefox/features/adblocker/custom-trackers.png', {'alt': ''}) }}
   </section>
 
   <section class="mzp-l-content mzp-t-narrow">
@@ -146,7 +146,7 @@
       In Firefox, you can block all third-party cookies or just those set by trackers. Be aware that blocking all cookies can break some sites.
       {% endtrans %}
     </p>
-    {{ high_res_img('firefox/features/adblocker/third-party-cookies.png', {'alt': ''}) }}
+    {{ high_res_img('img/firefox/features/adblocker/third-party-cookies.png', {'alt': ''}) }}
   </section>
 
   <section class="mzp-l-content mzp-t-narrow">
@@ -156,7 +156,7 @@
       If you don’t want your online behavior used for ads, you can send websites a polite “thanks but no thanks” letter by checking the <a href="{{ url }}">Do Not Track</a> option of Firefox. Participation is voluntary, but the websites that participate will stop tracking you immediately.
       {% endtrans %}
     </p>
-    {{ high_res_img('firefox/features/adblocker/dnt_screenshot.png', {'alt': ''}) }}
+    {{ high_res_img('img/firefox/features/adblocker/dnt_screenshot.png', {'alt': ''}) }}
   </section>
 
   <section class="mzp-l-content mzp-t-narrow">

--- a/bedrock/firefox/templates/firefox/features/index.html
+++ b/bedrock/firefox/templates/firefox/features/index.html
@@ -20,7 +20,7 @@
 <header class="main-header">
   <div class="content">
     <div class="header-image">
-      {{ high_res_img('firefox/features/quantum/devices.png', {'alt': '', 'width': '721', 'height': '553'}) }}
+      {{ high_res_img('img/firefox/features/quantum/devices.png', {'alt': '', 'width': '721', 'height': '553'}) }}
     </div>{#--/.header-image--#}
     <div class="header-content">
       <h1><span>{{ _('Firefox features') }}</span></h1>

--- a/bedrock/firefox/templates/firefox/features/safebrowser.html
+++ b/bedrock/firefox/templates/firefox/features/safebrowser.html
@@ -19,7 +19,7 @@
 {% block content %}
 <div class="mzp-c-hero">
   <div class="hero-content">
-    {{ high_res_img('logos/firefox/quantum/logo-sm.png', {'alt': 'Firefox', 'width': '50', 'height': '50'}) }}
+    {{ high_res_img('img/logos/firefox/quantum/logo-sm.png', {'alt': 'Firefox', 'width': '50', 'height': '50'}) }}
     <p>{{ _('Internet Security') }}</p>
     <h1>{{ _('Take the stress out of finding a safe browser.') }}</h1>
     <div class="download-firefox">

--- a/bedrock/firefox/templates/firefox/home/index-master.html
+++ b/bedrock/firefox/templates/firefox/home/index-master.html
@@ -124,7 +124,7 @@
       {% call feature_card(
         title='Firefox Browser',
         heading_level=3,
-        image_url='firefox/home/master/browser.png',
+        image_url='img/firefox/home/master/browser.png',
         include_highres_image=True,
         class='mzp-l-card-feature-left-half t-browsers',
         ga_title='Trackers',
@@ -152,7 +152,7 @@
         {% call feature_card(
           title='Firefox Monitor',
           heading_level=3,
-          image_url='firefox/home/master/monitor.svg',
+          image_url='img/firefox/home/master/monitor.svg',
           class='mzp-l-card-feature-right-half t-monitor',
           link_url='https://monitor.firefox.com/' + referrals,
           link_cta=monitor_cta,
@@ -167,7 +167,7 @@
       {% call feature_card(
         title='Firefox Lockwise',
         heading_level=3,
-        image_url='firefox/home/master/lockwise.svg',
+        image_url='img/firefox/home/master/lockwise.svg',
         class='mzp-l-card-feature-left-half t-lockwise',
         ga_title='Lockwise',
         media_after=True
@@ -189,7 +189,7 @@
           {% call feature_card(
             title=promise_title,
             heading_level=3,
-            image_url='firefox/home/master/spacer.gif',
+            image_url='img/firefox/home/master/spacer.gif',
             class='mzp-l-card-feature-right-half',
             link_url=url('privacy.notices.firefox'),
             link_cta=learn_more,
@@ -205,7 +205,7 @@
         {% call feature_card(
           title='Firefox Send',
           heading_level=3,
-          image_url='firefox/home/master/send.svg',
+          image_url='img/firefox/home/master/send.svg',
           class='mzp-l-card-feature-right-half t-send',
           link_url='https://send.firefox.com/' + referrals,
           link_cta=send_cta,
@@ -220,7 +220,7 @@
         {% call feature_card(
         title='Pocket',
         heading_level=3,
-        image_url='firefox/home/master/pocket.png',
+        image_url='img/firefox/home/master/pocket.png',
         include_highres_image=True,
         class='mzp-l-card-feature-left-half t-pocket',
         ga_title='Pocket',

--- a/bedrock/firefox/templates/firefox/home/index-quantum.html
+++ b/bedrock/firefox/templates/firefox/home/index-quantum.html
@@ -41,7 +41,7 @@
   <header class="mzp-c-hero mzp-t-firefox mzp-has-image">
     <div class="mzp-l-content">
       <div class="mzp-c-hero-body">
-        <h1 class="mzp-c-hero-title">{{ high_res_img('logos/firefox/quantum/logo-word-hor-sm.png', {'alt': 'Firefox', 'width': '216', 'height': '41'}) }}</h1>
+        <h1 class="mzp-c-hero-title">{{ high_res_img('img/logos/firefox/quantum/logo-word-hor-sm.png', {'alt': 'Firefox', 'width': '216', 'height': '41'}) }}</h1>
         <div class="mzp-c-hero-desc">
           <p>{{ _('Fast for good.') }}</p>
         </div>
@@ -91,7 +91,7 @@
       <div data-scroll-tracking="Sync your devices">
         {% call feature_card(
           title=_('Sync all your devices with a Firefox Account'),
-          image_url='firefox/home/quantum/desktop-account.svg',
+          image_url='img/firefox/home/quantum/desktop-account.svg',
           aspect_ratio='mzp-has-aspect-1-1',
           class='mzp-l-card-feature-right-half mzp-t-firefox t-sync',
           link_url=url('firefox.accounts'),
@@ -180,7 +180,7 @@
       <div data-scroll-tracking="30% lighter than chrome">
         {% call feature_card(
           title= _('30% lighter than Chrome'),
-          image_url='firefox/home/quantum/desktop-smooth.svg',
+          image_url='img/firefox/home/quantum/desktop-smooth.svg',
           aspect_ratio='mzp-has-aspect-1-1',
           class='mzp-l-card-feature-right-half mzp-t-firefox t-smooth',
           link_url='https://blog.mozilla.org/firefox/quantum-performance-test/',
@@ -206,7 +206,7 @@
         {% endif %}
         {% call feature_card(
           title=switch_title,
-          image_url='firefox/home/quantum/desktop-change.png',
+          image_url='img/firefox/home/quantum/desktop-change.png',
           include_highres_image=True,
           aspect_ratio='mzp-has-aspect-1-1',
           class='mzp-l-card-feature-left-half mzp-t-firefox t-switch',

--- a/bedrock/firefox/templates/firefox/installer-help.html
+++ b/bedrock/firefox/templates/firefox/installer-help.html
@@ -22,7 +22,7 @@
 
 {% block content %}
 <main class="mzp-l-content mzp-has-sidebar mzp-l-sidebar-right">
-  <h2><a href="{{ url('firefox') }}">{{ high_res_img('logos/firefox/quantum/logo-word-hor-sm.png', {'alt': 'Firefox', 'width': '347', 'height': '64'}) }}</a></h2>
+  <h2><a href="{{ url('firefox') }}">{{ high_res_img('img/logos/firefox/quantum/logo-word-hor-sm.png', {'alt': 'Firefox', 'width': '347', 'height': '64'}) }}</a></h2>
   <div class="mzp-l-main">
     <header>
       <h1 class="installer-help-title">{{ _('Your download was interrupted') }}</h1>

--- a/bedrock/firefox/templates/firefox/lockwise/lockwise.html
+++ b/bedrock/firefox/templates/firefox/lockwise/lockwise.html
@@ -28,17 +28,17 @@
 {% block content %}
   <main role="main">
     {% if LANG.startswith('en-') %}
-      {% set _img = 'firefox/lockwise/en.png'%}
+      {% set _img = 'img/firefox/lockwise/en.png'%}
     {% elif LANG == 'de' %}
-      {% set _img = 'firefox/lockwise/de.png'%}
+      {% set _img = 'img/firefox/lockwise/de.png'%}
     {% elif LANG == 'fr' %}
-      {% set _img = 'firefox/lockwise/fr.png'%}
+      {% set _img = 'img/firefox/lockwise/fr.png'%}
     {% elif LANG == 'it' %}
-      {% set _img = 'firefox/lockwise/it.png'%}
+      {% set _img = 'img/firefox/lockwise/it.png'%}
     {% elif LANG.startswith('es-') %}
-      {% set _img = 'firefox/lockwise/es.png'%}
+      {% set _img = 'img/firefox/lockwise/es.png'%}
     {% else %}
-      {% set _img = 'firefox/lockwise/en.png'%}
+      {% set _img = 'img/firefox/lockwise/en.png'%}
     {% endif %}
     {% call hero(
       title='Firefox Lockwise',

--- a/bedrock/firefox/templates/firefox/mobile.html
+++ b/bedrock/firefox/templates/firefox/mobile.html
@@ -78,7 +78,7 @@
             </div>
 
             <div class="header-product-image">
-              {{ high_res_img('firefox/mobile/phone-firefox.png', {'alt': _('Firefox'), 'width': '154', 'height': '309'}) }}
+              {{ high_res_img('img/firefox/mobile/phone-firefox.png', {'alt': _('Firefox'), 'width': '154', 'height': '309'}) }}
             </div>
           </section>{#--/#header-firefox--#}
 
@@ -117,7 +117,7 @@
             </div>
 
             <div class="header-product-image">
-              {{ high_res_img('firefox/mobile/phone-focus.png', {'alt': _('Firefox Focus'), 'width': '161', 'height': '324'}) }}
+              {{ high_res_img('img/firefox/mobile/phone-focus.png', {'alt': _('Firefox Focus'), 'width': '161', 'height': '324'}) }}
             </div>
           </section>
         </div>{#--/#header-product-content--#}
@@ -171,7 +171,7 @@
                 </p>
 
                 <div class="features-image-wrapper">
-                  {{ high_res_img('firefox/mobile/firefox-sync.png', {'alt': _('Sync'), 'width': '435', 'height': '364'}) }}
+                  {{ high_res_img('img/firefox/mobile/firefox-sync.png', {'alt': _('Sync'), 'width': '435', 'height': '364'}) }}
 
                   <ol class="features">
                     <li class="feature-sync">
@@ -194,7 +194,7 @@
                 </p>
 
                 <div class="features-image-wrapper">
-                  {{ high_res_img('firefox/mobile/firefox-privacy.png', {'alt': _('Privacy'), 'width': '464', 'height': '481'}) }}
+                  {{ high_res_img('img/firefox/mobile/firefox-privacy.png', {'alt': _('Privacy'), 'width': '464', 'height': '481'}) }}
 
                   <ol class="features">
                     <li class="feature-stop">
@@ -225,7 +225,7 @@
                 </p>
 
                 <div class="features-image-wrapper">
-                  {{ high_res_img('firefox/mobile/firefox-extensions.png', {'alt': _('Extensions & Customization'), 'width': '328', 'height': '527'}) }}
+                  {{ high_res_img('img/firefox/mobile/firefox-extensions.png', {'alt': _('Extensions & Customization'), 'width': '328', 'height': '527'}) }}
 
                   <ol class="features">
                     <li class="feature-extensions">
@@ -296,7 +296,7 @@
                 </p>
 
                 <div class="features-image-wrapper">
-                  {{ high_res_img('firefox/mobile/focus-privacy.png', {'alt': _('Sync'), 'width': '452', 'height': '469', 'l10n': True}) }}
+                  {{ high_res_img('img/firefox/mobile/focus-privacy.png', {'alt': _('Sync'), 'width': '452', 'height': '469', 'l10n': True}) }}
 
                   <ol class="features">
                     <li class="feature-block">
@@ -327,7 +327,7 @@
                 </p>
 
                 <div class="features-image-wrapper">
-                  {{ high_res_img('firefox/mobile/focus-speed.png', {'alt': _('Speed'), 'width': '408', 'height': '500'}) }}
+                  {{ high_res_img('img/firefox/mobile/focus-speed.png', {'alt': _('Speed'), 'width': '408', 'height': '500'}) }}
 
                   <ol class="features">
                     <li class="feature-speed">
@@ -359,7 +359,7 @@
                 {% endif %}
 
                 <div class="features-image-wrapper">
-                  {{ high_res_img('firefox/mobile/focus-lightweight.png', {'alt': _('Lightweight'), 'width': '298', 'height': '519'}) }}
+                  {{ high_res_img('img/firefox/mobile/focus-lightweight.png', {'alt': _('Lightweight'), 'width': '298', 'height': '519'}) }}
 
                 </div>{#--/.features-image-wrapper--#}
               </section>

--- a/bedrock/firefox/templates/firefox/new/base.html
+++ b/bedrock/firefox/templates/firefox/new/base.html
@@ -63,7 +63,7 @@
     {% block messages %}{% endblock %}
     <div class="content">
       <div class="header-logos">
-        <h2><a class="firefox" href="{{ url('firefox') }}" title="{{ firefox_logo_title }}">{{ high_res_img('logos/firefox/quantum/logo-word-hor-white-sm.png', {'alt': firefox_logo_title, 'width': '216', 'height': '40'}) }}</a></h2>
+        <h2><a class="firefox" href="{{ url('firefox') }}" title="{{ firefox_logo_title }}">{{ high_res_img('img/logos/firefox/quantum/logo-word-hor-white-sm.png', {'alt': firefox_logo_title, 'width': '216', 'height': '40'}) }}</a></h2>
         <h2><a class="mozilla" href="{{ url('mozorg.home') }}" title="{{ mozilla_logo_title }}"><img src="{{ static('img/logos/mozilla/wordmark-dark.svg')}}" alt="{{ mozilla_logo_title }}" width="101" height="34"></a></h2>
       </div>
       <div class="header-container">
@@ -72,7 +72,7 @@
           {% block main_content %}{% endblock %}
         </div>
         <div class="header-image">
-          {{ high_res_img('firefox/new/browser.png', {'alt': _('Screenshot'), 'width': '700', 'height': '529'}) }}
+          {{ high_res_img('img/firefox/new/browser.png', {'alt': _('Screenshot'), 'width': '700', 'height': '529'}) }}
         </div>
       </div>
     </div>

--- a/bedrock/firefox/templates/firefox/new/scene2.html
+++ b/bedrock/firefox/templates/firefox/new/scene2.html
@@ -80,7 +80,7 @@
 
   <div class="mzp-l-content">
     <div class="header-logos">
-      <h2><a class="firefox" href="{{ url('firefox') }}" title="{{ firefox_logo_title }}">{{ high_res_img('logos/firefox/quantum/logo-word-hor-white-sm.png', {'alt': firefox_logo_title, 'width': '216', 'height': '40'}) }}</a></h2>
+      <h2><a class="firefox" href="{{ url('firefox') }}" title="{{ firefox_logo_title }}">{{ high_res_img('img/logos/firefox/quantum/logo-word-hor-white-sm.png', {'alt': firefox_logo_title, 'width': '216', 'height': '40'}) }}</a></h2>
       <h2><a class="mozilla" href="{{ url('mozorg.home') }}" title="{{ mozilla_logo_title }}"><img src="{{ static('img/logos/mozilla/wordmark-dark.svg')}}" alt="{{ mozilla_logo_title }}" width="101" height="34"></a></h2>
     </div>
 

--- a/bedrock/firefox/templates/firefox/new/trailhead/download.html
+++ b/bedrock/firefox/templates/firefox/new/trailhead/download.html
@@ -21,7 +21,7 @@
     desc=_('And start getting the respect you deserve with our family of privacy-first products.'),
     class='mzp-has-image mzp-t-dark',
     include_cta=True,
-    image_url='firefox/new/trailhead/browser-window.svg',
+    image_url='img/firefox/new/trailhead/browser-window.svg',
     heading_level=1
   ) %}
     {{ download_firefox(alt_copy=_('Download Now'), locale_in_transition=True, download_location='primary cta') }}

--- a/bedrock/firefox/templates/firefox/new/yandex/base.html
+++ b/bedrock/firefox/templates/firefox/new/yandex/base.html
@@ -50,7 +50,7 @@
     {% block messages %}{% endblock %}
     <div class="content">
       <div class="header-logos">
-        <h2><a class="firefox" href="{{ url('firefox') }}" title="Firefox">{{ high_res_img('logos/firefox/quantum/logo-word-hor-white-sm.png', {'alt': 'Friefox', 'width': '216', 'height': '40'}) }}</a></h2>
+        <h2><a class="firefox" href="{{ url('firefox') }}" title="Firefox">{{ high_res_img('img/logos/firefox/quantum/logo-word-hor-white-sm.png', {'alt': 'Friefox', 'width': '216', 'height': '40'}) }}</a></h2>
         <h2><a class="mozilla" href="{{ url('mozorg.home') }}" title="Mozilla"><img src="{{ static('img/logos/mozilla/wordmark-dark.svg')}}" alt="Mozilla" width="101" height="34"></a></h2>
       </div>
       <div class="header-container">

--- a/bedrock/firefox/templates/firefox/pocket.html
+++ b/bedrock/firefox/templates/firefox/pocket.html
@@ -41,14 +41,14 @@
     </div>
 
     <div class="mzp-c-hero-image">
-      {{ high_res_img('firefox/products/pocket/pocket-hero.png', {'alt': ''}) }}
+      {{ high_res_img('img/firefox/products/pocket/pocket-hero.png', {'alt': ''}) }}
     </div>
   </section>
 
   <div id="pocket-popularity" class="mzp-l-content">
     {% call feature_card(
       title=_('Capture What Fascinates You'),
-      image_url='firefox/products/pocket/pocket-illo-reading.png',
+      image_url='img/firefox/products/pocket/pocket-illo-reading.png',
       include_highres_image=True,
       aspect_ratio='mzp-has-aspect-16-9',
       class='mzp-l-card-feature-right-third'

--- a/bedrock/firefox/templates/firefox/recommended.html
+++ b/bedrock/firefox/templates/firefox/recommended.html
@@ -35,7 +35,7 @@
         </div>
       </div>
 
-      {{ high_res_img('firefox/recommended/hero-laptop.png', {'alt': '', 'width': '672', 'height': '402'}) }}
+      {{ high_res_img('img/firefox/recommended/hero-laptop.png', {'alt': '', 'width': '672', 'height': '402'}) }}
     </div>
   </section>
 

--- a/bedrock/firefox/templates/firefox/testflight.html
+++ b/bedrock/firefox/templates/firefox/testflight.html
@@ -28,7 +28,7 @@
 <section id="intro">
   <div class="container">
     {# No more new logos! #}
-    {{ high_res_img('logos/firefox/quantum/logo-lg.png', {'alt': 'Firefox for iOS', 'width': '142', 'height': '142', 'id': 'header-logo' }) }}
+    {{ high_res_img('img/logos/firefox/quantum/logo-lg.png', {'alt': 'Firefox for iOS', 'width': '142', 'height': '142', 'id': 'header-logo' }) }}
 
     <header id="intro-header">
       {# L10n: line break below for visual formatting only #}

--- a/bedrock/firefox/templates/firefox/unsupported-systems.html
+++ b/bedrock/firefox/templates/firefox/unsupported-systems.html
@@ -14,7 +14,7 @@
 {% block content %}
 <main class="mzp-l-content mzp-t-narrow">
   <header class="">
-      <a href="{{ url('firefox') }}">{{ high_res_img('logos/firefox/quantum/logo-word-hor-sm.png', {'alt': 'Firefox', 'width': '347', 'height': '64'}) }}</a>
+      <a href="{{ url('firefox') }}">{{ high_res_img('img/logos/firefox/quantum/logo-word-hor-sm.png', {'alt': 'Firefox', 'width': '347', 'height': '64'}) }}</a>
     <h1 class="c-header-main">{{ _('Thanks for choosing Firefox!') }}</h1>
     <p class="c-header-subhead">{{_('We’re sorry to report this, but your computer does not meet the minimum system requirements to run this version.')}}</p>
   </header>

--- a/bedrock/firefox/templates/firefox/welcome/base.html
+++ b/bedrock/firefox/templates/firefox/welcome/base.html
@@ -19,7 +19,7 @@
 <main class="mzp-t-firefox">
   <header class="c-page-header">
     <div class="mzp-l-content c-page-header-inner">
-      {{ high_res_img('logos/firefox/quantum/logo-word-hor-lg.png', {'alt': 'Firefox', 'width': '216', 'height': '40', 'class': 'c-header-logo'}) }}
+      {{ high_res_img('img/logos/firefox/quantum/logo-word-hor-lg.png', {'alt': 'Firefox', 'width': '216', 'height': '40', 'class': 'c-header-logo'}) }}
       <p class="c-shoulder-cta"><a class="mzp-c-button mzp-t-secondary mzp-t-small mzp-t-product" href="{{ url('firefox.accounts') }}">{{ _('Join Firefox') }}</a></p>
     </div>
   </header>

--- a/bedrock/firefox/templates/firefox/whatsnew/fx64/whatsnew-fx64-base.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/fx64/whatsnew-fx64-base.html
@@ -47,12 +47,12 @@
 <main class="mzp-t-firefox">
   <header class="c-page-header">
     <div class="mzp-l-content c-page-header-inner">
-      {{ high_res_img('logos/firefox/quantum/logo-word-hor-sm.png', {'alt': 'Firefox', 'width': '298', 'height': '55', 'class': 'c-page-header-logo-fx'}) }}
+      {{ high_res_img('img/logos/firefox/quantum/logo-word-hor-sm.png', {'alt': 'Firefox', 'width': '298', 'height': '55', 'class': 'c-page-header-logo-fx'}) }}
       <h1 class="c-page-header-up-to-date">{{ latest }}</h1>
       <img src="{{ static('img/logos/mozilla/wordmark-dark.svg') }}" alt="Mozilla" width="112" height="32" class="c-page-header-logo-moz">
     </div>
   </header>
-  {% set content_blocking_image='firefox/whatsnew_64/hero.png' if DIR == 'ltr' else 'firefox/whatsnew_64/hero-rtl.png' %}
+  {% set content_blocking_image='img/firefox/whatsnew_64/hero.png' if DIR == 'ltr' else 'img/firefox/whatsnew_64/hero-rtl.png' %}
   {% call hero(
    title=hero_title_out,
    desc=hero_desc,
@@ -76,28 +76,28 @@
 
   <div class="mzp-l-content">
     <div class="wn64-benefit wn64-notes">
-      {{ high_res_img('firefox/whatsnew_64/fxa-notes.png', {'alt': '', 'width': '590', 'height': '590'}) }}
+      {{ high_res_img('img/firefox/whatsnew_64/fxa-notes.png', {'alt': '', 'width': '590', 'height': '590'}) }}
       <h3>{{ notes_head }}</h3>
       <p>{{ notes_desc }}</p>
       <p><a class="mzp-c-button wn64-benefit-link" data-app="notes" href="https://play.google.com/store/apps/details?id=org.mozilla.testpilot.notes">{{ notes_link }}</a></p>
     </div>
 
     <div class="wn64-benefit wn64-lockwise">
-      {{ high_res_img('firefox/whatsnew_64/fxa-lockwise.png', {'alt': '', 'width': '590', 'height': '590'}) }}
+      {{ high_res_img('img/firefox/whatsnew_64/fxa-lockwise.png', {'alt': '', 'width': '590', 'height': '590'}) }}
       <h3>{{ lockwise_head }}</h3>
       <p>{{ lockwise_desc }}</p>
       <p><a class="mzp-c-button wn64-benefit-link" data-app="lockwise" href="https://app.adjust.com/orzhlh0">{{ lockwise_link }}</a></p>
     </div>
 
     <div class="wn64-benefit wn64-pocket">
-      {{ high_res_img('firefox/whatsnew_64/fxa-pocket.png', {'alt': '', 'width': '590', 'height': '590'}) }}
+      {{ high_res_img('img/firefox/whatsnew_64/fxa-pocket.png', {'alt': '', 'width': '590', 'height': '590'}) }}
       <h3>{{ pocket_head }}</h3>
       <p>{{ pocket_desc }}</p>
       <p><a class="mzp-c-button wn64-benefit-link" data-app="pocket" href="https://getpocket.com/">{{ pocket_link }}</a></p>
     </div>
 
     <div class="wn64-benefit wn64-sync">
-      {{ high_res_img('firefox/whatsnew_64/fxa-sync.png', {'alt': '', 'width': '590', 'height': '590'}) }}
+      {{ high_res_img('img/firefox/whatsnew_64/fxa-sync.png', {'alt': '', 'width': '590', 'height': '590'}) }}
       <h3>{{ sync_head }}</h3>
       <p>{{ sync_desc }}</p>
     </div>

--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx63.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx63.html
@@ -22,7 +22,7 @@
 <main class="mzp-t-firefox">
   <header class="c-page-header">
     <div class="mzp-l-content c-page-header-inner">
-      {{ high_res_img('logos/firefox/quantum/logo-word-hor-sm.png', {'alt': 'Firefox', 'width': '298', 'height': '55', 'class': 'c-page-header-logo-fx'}) }}
+      {{ high_res_img('img/logos/firefox/quantum/logo-word-hor-sm.png', {'alt': 'Firefox', 'width': '298', 'height': '55', 'class': 'c-page-header-logo-fx'}) }}
       <h1 class="c-page-header-up-to-date">{{ _('Congrats! You’re using the latest version of Firefox.') }}</h1>
       <img src="{{ static('img/logos/mozilla/wordmark-dark.svg') }}" alt="Mozilla" width="112" height="32" class="c-page-header-logo-moz">
     </div>
@@ -52,7 +52,7 @@
     </div>
 
     <div class="mzp-c-hero-image">
-      {{ high_res_img('firefox/whatsnew_63/wnp63-hero.png', {'alt': ''}) }}
+      {{ high_res_img('img/firefox/whatsnew_63/wnp63-hero.png', {'alt': ''}) }}
     </div>
   </section>
 
@@ -67,7 +67,7 @@
       {% call feature_card(
         title=_('Built-In Tracking Controls'),
         ga_title='Built-In Tracking Controls',
-        image_url='firefox/whatsnew_63/wnp63-tracking-controls.png',
+        image_url='img/firefox/whatsnew_63/wnp63-tracking-controls.png',
         include_highres_image=True,
         aspect_ratio='mzp-has-aspect-3-2',
         class='mzp-l-card-feature-left-third tracking-controls',
@@ -107,7 +107,7 @@
       {% call feature_card(
         title=_('Secure Syncing Across Devices'),
         ga_title='Secure Syncing Across Devices',
-        image_url='firefox/whatsnew_63/wnp63-secure-sync-devices.png',
+        image_url='img/firefox/whatsnew_63/wnp63-secure-sync-devices.png',
         include_highres_image=True,
         class='mzp-l-card-feature-left-third sync',
         link_url=url('firefox.accounts'),

--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx65.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx65.html
@@ -22,7 +22,7 @@
 <main class="mzp-t-firefox">
   <header class="c-page-header">
     <div class="mzp-l-content c-page-header-inner">
-      {{ high_res_img('logos/firefox/quantum/logo-word-hor-sm.png', {'alt': 'Firefox', 'width': '298', 'height': '55', 'class': 'c-page-header-logo-fx'}) }}
+      {{ high_res_img('img/logos/firefox/quantum/logo-word-hor-sm.png', {'alt': 'Firefox', 'width': '298', 'height': '55', 'class': 'c-page-header-logo-fx'}) }}
       <h1 class="c-page-header-up-to-date">{{ _('Congrats! You’re using the latest version of Firefox.') }}</h1>
       <img src="{{ static('img/logos/mozilla/wordmark-dark.svg') }}" alt="Mozilla" width="112" height="32" class="c-page-header-logo-moz">
     </div>
@@ -72,7 +72,7 @@
     </div>
 
     <div class="mzp-c-hero-image">
-      {{ high_res_img('firefox/whatsnew_63/wnp63-hero.png', {'alt': ''}) }}
+      {{ high_res_img('img/firefox/whatsnew_63/wnp63-hero.png', {'alt': ''}) }}
     </div>
   </section>
 
@@ -86,7 +86,7 @@
       {% call feature_card(
         title=_('Built-In Tracking Controls'),
         ga_title='Built-In Tracking Controls',
-        image_url='firefox/whatsnew_63/wnp63-tracking-controls.png',
+        image_url='img/firefox/whatsnew_63/wnp63-tracking-controls.png',
         include_highres_image=True,
         aspect_ratio='mzp-has-aspect-3-2',
         class='mzp-l-card-feature-left-third tracking-controls',
@@ -126,7 +126,7 @@
       {% call feature_card(
         title=_('Secure Syncing Across Devices'),
         ga_title='Secure Syncing Across Devices',
-        image_url='firefox/whatsnew_63/wnp63-secure-sync-devices.png',
+        image_url='img/firefox/whatsnew_63/wnp63-secure-sync-devices.png',
         include_highres_image=True,
         class='mzp-l-card-feature-left-third sync',
         link_url=url('firefox.accounts'),

--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx66.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx66.html
@@ -25,7 +25,7 @@
 <main class="mzp-t-firefox">
   <header class="c-page-header">
     <div class="mzp-l-content c-page-header-inner">
-      {{ high_res_img('logos/firefox/quantum/logo-word-hor-sm.png', {'alt': 'Firefox', 'width': '298', 'height': '55', 'class': 'c-page-header-logo-fx'}) }}
+      {{ high_res_img('img/logos/firefox/quantum/logo-word-hor-sm.png', {'alt': 'Firefox', 'width': '298', 'height': '55', 'class': 'c-page-header-logo-fx'}) }}
       <h1 class="c-page-header-up-to-date">{{ _('Congrats! You’re using the latest version of Firefox.') }}</h1>
       <img src="{{ static('img/logos/mozilla/wordmark-dark.svg') }}" alt="Mozilla" width="112" height="32" class="c-page-header-logo-moz">
     </div>
@@ -69,7 +69,7 @@
     </section>
     {% endif %}
 
-  {% set content_blocking_image='firefox/whatsnew_64/hero.png' if DIR == 'ltr' else 'firefox/whatsnew_64/hero-rtl.png' %}
+  {% set content_blocking_image='img/firefox/whatsnew_64/hero.png' if DIR == 'ltr' else 'img/firefox/whatsnew_64/hero-rtl.png' %}
   {% call hero(
     title=_('One log-in. Power and security everywhere.'),
     class='mzp-has-image mzp-l-reverse show-fxa-default show-fxa-supported-signed-out',
@@ -107,14 +107,14 @@
 
   <div class="mzp-l-content">
     <div class="wn66-benefit wn66-send">
-      {{ high_res_img('firefox/whatsnew_66/fxa-send.png', {'alt': '', 'width': '590', 'height': '590'}) }}
+      {{ high_res_img('img/firefox/whatsnew_66/fxa-send.png', {'alt': '', 'width': '590', 'height': '590'}) }}
       <h3>{{_('Take total control of the files you share ')}}</h3>
       <p>{{_('Feel like a secret agent when you send files online, with a private, encrypted link that ‘self-destructs.’')}}</p>
       <p><a class="mzp-c-cta-link" data-app="send" href="https://send.firefox.com/?utm_source=www.mozilla.org&utm_medium=referral&utm_campaign=wnp66&utm_content=try-send&entrypoint=mozilla.org-whatsnew66">{{_('Try Firefox Send')}}</a></p>
     </div>
 
     <div class="wn66-benefit wn66-lockwise">
-      {{ high_res_img('firefox/whatsnew_64/fxa-lockwise.png', {'alt': '', 'width': '590', 'height': '590'}) }}
+      {{ high_res_img('img/firefox/whatsnew_64/fxa-lockwise.png', {'alt': '', 'width': '590', 'height': '590'}) }}
       {% if l10n_has_tag('lockwise_update_201906') %}
         <h3>{{_('Remember your passwords in Lockwise')}}</h3>
         <p>{{_('No more getting locked out of apps and websites. Lockwise secures all the passwords you’ve saved in Firefox and gives you easy access across all your iOS devices.')}}</p>
@@ -128,14 +128,14 @@
     </div>
 
     <div class="wn66-benefit wn66-pocket">
-      {{ high_res_img('firefox/whatsnew_64/fxa-pocket.png', {'alt': '', 'width': '590', 'height': '590'}) }}
+      {{ high_res_img('img/firefox/whatsnew_64/fxa-pocket.png', {'alt': '', 'width': '590', 'height': '590'}) }}
       <h3>{{_('Put quality content in your Pocket')}}</h3>
       <p>{{_('Discover the web’s best content, and absorb it anytime – even offline – on any device. Pocket’s listen feature will even read any article aloud to you. Get it all from the Firefox toolbar or the Pocket app.')}}</p>
       <p><button class="mzp-c-button wn66-benefit-link" data-app="pocket">{{_('Get the Pocket App')}}</button></p>
     </div>
 
     <div class="wn66-benefit wn66-notes">
-      {{ high_res_img('firefox/whatsnew_64/fxa-sync.png', {'alt': '', 'width': '590', 'height': '590'}) }}
+      {{ high_res_img('img/firefox/whatsnew_64/fxa-sync.png', {'alt': '', 'width': '590', 'height': '590'}) }}
       <h3>{{_('Pick up where you left off with Notes')}}</h3>
       {% if l10n_has_tag('wnp66_2019') %}
       <p>{{_('Your ideas and inspiration are secure and encrypted with Notes – and when you’re signed in to your Account, they sync from your desktop to your Android devices.')}}</p>

--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx67.0.5.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx67.0.5.html
@@ -23,7 +23,7 @@
 <main class="mzp-t-firefox">
   <header class="c-page-header">
     <div class="mzp-l-content c-page-header-inner">
-        {{ high_res_img('logos/firefox/quantum/logo-word-hor-sm.png', {'alt': 'Firefox', 'width': '216', 'height': '40', 'class': 'c-page-header-logo-fx'}) }}
+        {{ high_res_img('img/logos/firefox/quantum/logo-word-hor-sm.png', {'alt': 'Firefox', 'width': '216', 'height': '40', 'class': 'c-page-header-logo-fx'}) }}
       <h1 class="c-page-header-up-to-date"><span>{{ _('Congrats! You’re using the latest version of Firefox.') }}</span></h1>
     </div>
   </header>

--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx67.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx67.html
@@ -26,7 +26,7 @@
 <main class="mzp-t-firefox">
   <header class="mzp-l-content c-page-header">
     <div class="c-page-header-inner">
-        {{ high_res_img('logos/firefox/quantum/logo-word-hor-sm.png', {'alt': 'Firefox', 'width': '216', 'height': '40', 'class': 'c-page-header-logo-fx'}) }}
+        {{ high_res_img('img/logos/firefox/quantum/logo-word-hor-sm.png', {'alt': 'Firefox', 'width': '216', 'height': '40', 'class': 'c-page-header-logo-fx'}) }}
       <h1 class="c-page-header-up-to-date"><span>{{ _('Congrats! You’re using the latest version of Firefox.') }}</span></h1>
     </div>
   </header>
@@ -37,7 +37,7 @@
     {% call feature_card(
       title=_('New to your browser'),
       heading_level=3,
-      image_url='firefox/whatsnew_67/update.svg',
+      image_url='img/firefox/whatsnew_67/update.svg',
       include_highres_image=False,
       aspect_ratio='l-card-feature-right-66',
       class='wn67-intro'
@@ -57,7 +57,7 @@
         ga_title='Check Out Monitor',
         link_cta=_('Check Out Monitor'),
         link_url='https://monitor.firefox.com/?utm_source=www.mozilla.org&utm_medium=referral&utm_campaign=wnp67&utm_content=try-send&entrypoint=mozilla.org-whatsnew67',
-        image_url='firefox/whatsnew_67/monitor.svg',
+        image_url='img/firefox/whatsnew_67/monitor.svg',
         include_highres_image=False,
         aspect_ratio='mzp-l-card-feature-left-66',
         class='wn67-lockwise'
@@ -70,7 +70,7 @@
       {% if l10n_has_tag('lockwise_update_201906') %}
         {% call feature_card(
           title=_('Take your passwords everywhere with Lockwise'),
-          image_url='firefox/whatsnew_67/lockwise.svg',
+          image_url='img/firefox/whatsnew_67/lockwise.svg',
           include_highres_image=False,
           aspect_ratio='l-card-feature-right-66',
           class='wn67-lockwise'
@@ -81,7 +81,7 @@
       {% else %}
         {% call feature_card(
           title=_('Take your passwords everywhere with Lockbox'),
-          image_url='firefox/whatsnew_67/lockwise.svg',
+          image_url='img/firefox/whatsnew_67/lockwise.svg',
           include_highres_image=False,
           aspect_ratio='l-card-feature-right-66',
           class='wn67-lockwise'
@@ -93,7 +93,7 @@
 
       {% call feature_card(
         title=_('Put quality content in your Pocket'),
-        image_url='firefox/whatsnew_67/pocket.svg',
+        image_url='img/firefox/whatsnew_67/pocket.svg',
         include_highres_image=False,
         aspect_ratio='mzp-l-card-feature-left-66',
         class='wn67-lockwise'
@@ -106,7 +106,7 @@
       {% call feature_card(
         title=_('Share large files securely with Send'),
         ga_title='Try Firefox Send',
-        image_url='firefox/whatsnew_67/send.svg',
+        image_url='img/firefox/whatsnew_67/send.svg',
         include_highres_image=False,
         aspect_ratio='l-card-feature-right-66',
         class='wn67-lockwise'

--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx68-b.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx68-b.html
@@ -17,7 +17,7 @@
   <header class="c-page-header">
     <div class="mzp-l-content c-page-header-inner">
     {% block header_logo %}
-      {{ high_res_img('logos/firefox/quantum/logo-word-hor-sm.png', {'alt': 'Firefox', 'width': '216', 'height': '40', 'class': 'c-page-header-logo-fx'}) }}
+      {{ high_res_img('img/logos/firefox/quantum/logo-word-hor-sm.png', {'alt': 'Firefox', 'width': '216', 'height': '40', 'class': 'c-page-header-logo-fx'}) }}
     {% endblock %}
       <h1 class="c-page-header-up-to-date"><span>{{ _('Congrats! You’re using the latest version of Firefox.') }}</span></h1>
     </div>

--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx68-c.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx68-c.html
@@ -11,7 +11,7 @@
 {% block container_class %}{{ super() }} mzp-t-dark{% endblock %}
 
 {% block header_logo %}
-  {{ high_res_img('logos/firefox/quantum/logo-word-hor-white-sm.png', {'alt': 'Firefox', 'width': '216', 'height': '40', 'class': 'c-page-header-logo-fx'}) }}
+  {{ high_res_img('img/logos/firefox/quantum/logo-word-hor-white-sm.png', {'alt': 'Firefox', 'width': '216', 'height': '40', 'class': 'c-page-header-logo-fx'}) }}
 {% endblock %}
 
 {% block fxa_form %}

--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx68.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx68.html
@@ -22,7 +22,7 @@
       ga_title='Check Out Monitor',
       link_cta=_('Check Out Monitor'),
       link_url='https://monitor.firefox.com/?utm_source=www.mozilla.org&utm_medium=referral&utm_campaign=wnp68&utm_content=try-send&entrypoint=mozilla.org-whatsnew68',
-      image_url='firefox/whatsnew_67/monitor.svg',
+      image_url='img/firefox/whatsnew_67/monitor.svg',
       include_highres_image=False,
       aspect_ratio='mzp-l-card-feature-left-66',
       class='wn67-lockwise'
@@ -35,7 +35,7 @@
     {% if l10n_has_tag('lockwise_update_201906') %}
       {% call feature_card(
         title=_('Take your passwords everywhere with Lockwise'),
-        image_url='firefox/whatsnew_67/lockwise.svg',
+        image_url='img/firefox/whatsnew_67/lockwise.svg',
         include_highres_image=False,
         aspect_ratio='l-card-feature-right-66',
         class='wn67-lockwise'
@@ -46,7 +46,7 @@
     {% else %}
       {% call feature_card(
         title=_('Take your passwords everywhere with Lockbox'),
-        image_url='firefox/whatsnew_67/lockwise.svg',
+        image_url='img/firefox/whatsnew_67/lockwise.svg',
         include_highres_image=False,
         aspect_ratio='l-card-feature-right-66',
         class='wn67-lockwise'
@@ -58,7 +58,7 @@
 
     {% call feature_card(
       title=_('Put quality content in your Pocket'),
-      image_url='firefox/whatsnew_67/pocket.svg',
+      image_url='img/firefox/whatsnew_67/pocket.svg',
       include_highres_image=False,
       aspect_ratio='mzp-l-card-feature-left-66',
       class='wn67-lockwise'
@@ -71,7 +71,7 @@
     {% call feature_card(
       title=_('Share large files securely with Send'),
       ga_title='Try Firefox Send',
-      image_url='firefox/whatsnew_67/send.svg',
+      image_url='img/firefox/whatsnew_67/send.svg',
       include_highres_image=False,
       aspect_ratio='l-card-feature-right-66',
       class='wn67-lockwise'

--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx69.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx69.html
@@ -23,7 +23,7 @@
 <main class="content-wrapper mzp-t-firefox mzp-t-dark">
   <header class="c-page-header">
     <div class="mzp-l-content c-page-header-inner">
-      {{ high_res_img('logos/firefox/quantum/logo-word-hor-white-sm.png', {'alt': 'Firefox', 'width': '216', 'height': '40', 'class': 'c-page-header-logo-fx'}) }}
+      {{ high_res_img('img/logos/firefox/quantum/logo-word-hor-white-sm.png', {'alt': 'Firefox', 'width': '216', 'height': '40', 'class': 'c-page-header-logo-fx'}) }}
       <h1 class="c-page-header-up-to-date"><span>{{ _('Congrats! You’re using the latest version of Firefox.') }}</span></h1>
     </div>
   </header>

--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx70-de.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx70-de.html
@@ -25,7 +25,7 @@
 <main class="content-wrapper mzp-t-firefox mzp-t-dark">
   <header class="c-page-header">
     <div class="mzp-l-content c-page-header-inner">
-      {{ high_res_img('logos/firefox/quantum/logo-word-hor-white-sm.png', {'alt': 'Firefox', 'width': '216', 'height': '40', 'class': 'c-page-header-logo-fx'}) }}
+      {{ high_res_img('img/logos/firefox/quantum/logo-word-hor-white-sm.png', {'alt': 'Firefox', 'width': '216', 'height': '40', 'class': 'c-page-header-logo-fx'}) }}
       <div class="mzp-c-notification-bar mzp-t-success show-firefox-desktop-70">
         <p>{{ _('Perfekt! Du hast die neueste Version von Firefox.') }}</p>
       </div>

--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx70-en.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx70-en.html
@@ -25,7 +25,7 @@
 <main class="content-wrapper mzp-t-firefox mzp-t-dark">
   <header class="c-page-header">
     <div class="mzp-l-content c-page-header-inner">
-      {{ high_res_img('logos/firefox/quantum/logo-word-hor-white-sm.png', {'alt': 'Firefox', 'width': '216', 'height': '40', 'class': 'c-page-header-logo-fx'}) }}
+      {{ high_res_img('img/logos/firefox/quantum/logo-word-hor-white-sm.png', {'alt': 'Firefox', 'width': '216', 'height': '40', 'class': 'c-page-header-logo-fx'}) }}
       <div class="mzp-c-notification-bar mzp-t-success show-firefox-desktop-70">
         <p>{{ _('Congrats! You’re using the latest version of Firefox.') }}</p>
       </div>

--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx70-fr.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx70-fr.html
@@ -25,7 +25,7 @@
 <main class="content-wrapper mzp-t-firefox mzp-t-dark">
   <header class="c-page-header">
     <div class="mzp-l-content c-page-header-inner">
-      {{ high_res_img('logos/firefox/quantum/logo-word-hor-white-sm.png', {'alt': 'Firefox', 'width': '216', 'height': '40', 'class': 'c-page-header-logo-fx'}) }}
+      {{ high_res_img('img/logos/firefox/quantum/logo-word-hor-white-sm.png', {'alt': 'Firefox', 'width': '216', 'height': '40', 'class': 'c-page-header-logo-fx'}) }}
       <div class="mzp-c-notification-bar mzp-t-success show-firefox-desktop-70">
         <p>{{ _('Félicitations ! Vous utilisez la version la plus récente de Firefox.') }}</p>
       </div>

--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx70.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx70.html
@@ -25,7 +25,7 @@
 <main class="content-wrapper mzp-t-firefox">
   <header class="c-page-header">
     <div class="mzp-l-content c-page-header-inner">
-      {{ high_res_img('logos/firefox/quantum/logo-word-hor-white-sm.png', {'alt': 'Firefox', 'width': '216', 'height': '40', 'class': 'c-page-header-logo-fx'}) }}
+      {{ high_res_img('img/logos/firefox/quantum/logo-word-hor-white-sm.png', {'alt': 'Firefox', 'width': '216', 'height': '40', 'class': 'c-page-header-logo-fx'}) }}
       <div class="mzp-c-notification-bar mzp-t-success show-firefox-desktop-70">
         <p>{{ _('Congrats! You’re using the latest version of Firefox.') }}</p>
       </div>

--- a/bedrock/firefox/templates/firefox/windows-64-bit.html
+++ b/bedrock/firefox/templates/firefox/windows-64-bit.html
@@ -19,7 +19,7 @@
  {% block content %}
    <div class="mzp-c-hero">
      <div class="hero-content">
-       {{ high_res_img('logos/firefox/quantum/logo-sm.png', {'alt': 'Firefox', 'width': '50', 'height': '50'}) }}
+       {{ high_res_img('img/logos/firefox/quantum/logo-sm.png', {'alt': 'Firefox', 'width': '50', 'height': '50'}) }}
        <p>{{ _('64-bit') }}</p>
        <h1>{{ _('A more secure Firefox.') }}</h1>
        <div class="download-firefox">

--- a/bedrock/foundation/templates/foundation/annualreport/2011.html
+++ b/bedrock/foundation/templates/foundation/annualreport/2011.html
@@ -97,7 +97,7 @@
           <ul class="mob-topics">
             <li id="topic-firefox"><img src="{{ static('img/foundation/annualreport/2011/logo-firefox.png') }}" alt="">Firefox</li>
             <li id="topic-firefoxos"><img src="{{ static('img/foundation/annualreport/2011/logo-firefoxos.png') }}" alt="">Firefox OS</li>
-            <li id="topic-webmaker">{{ high_res_img('foundation/annualreport/2011/logo-webmaker.png', {'alt': ''}) }}Webmaker</li>
+            <li id="topic-webmaker">{{ high_res_img('img/foundation/annualreport/2011/logo-webmaker.png', {'alt': ''}) }}Webmaker</li>
           </ul>
 
           <div class="overlay">

--- a/bedrock/foundation/templates/foundation/trademarks/list.html
+++ b/bedrock/foundation/templates/foundation/trademarks/list.html
@@ -123,7 +123,7 @@ established in any of its products, features, service names, or logos.{% endtran
     </tr>
     <tr>
       <td>
-        {{ high_res_img('trademarks/lightbeam-logo.png', { 'alt': _('Lightbeam logo'), 'width': '100', 'height': '100' }) }}
+        {{ high_res_img('img/trademarks/lightbeam-logo.png', { 'alt': _('Lightbeam logo'), 'width': '100', 'height': '100' }) }}
       </td>
       <th>{{ _('Lightbeam') }}</th>
     </tr>
@@ -145,7 +145,7 @@ established in any of its products, features, service names, or logos.{% endtran
     </tr>
     <tr>
       <td>
-        {{ high_res_img('trademarks/logo-wordmark-webmaker.png', { 'alt': _('Webmaker logo'), 'width': '100', 'height': '100' }) }}
+        {{ high_res_img('img/trademarks/logo-wordmark-webmaker.png', { 'alt': _('Webmaker logo'), 'width': '100', 'height': '100' }) }}
       </td>
       <th>{{ _('Webmaker') }}</th>
     </tr>

--- a/bedrock/legal/templates/legal/firefox.html
+++ b/bedrock/legal/templates/legal/firefox.html
@@ -9,7 +9,7 @@
 {% block article %}
   <article class="section-content" itemscope itemtype="http://schema.org/Article">
     <header>
-        {{ high_res_img('logos/firefox/quantum/logo-lg.png', {'alt': 'Firefox', 'width': '70', 'height': '70'}) }}
+        {{ high_res_img('img/logos/firefox/quantum/logo-lg.png', {'alt': 'Firefox', 'width': '70', 'height': '70'}) }}
       <h1 class="mzp-c-article-title" itemprop="name">Firefox Notices</h1>
     </header>
     <div itemprop="articleBody">

--- a/bedrock/mozorg/templates/mozorg/about.html
+++ b/bedrock/mozorg/templates/mozorg/about.html
@@ -90,7 +90,7 @@
       ga_title='Corporation. Foundation. Not-for-profit.',
       link_cta=_('Learn about the Mozilla Foundation'),
       link_url='https://foundation.mozilla.org/',
-      image_url='mozorg/about/foundation.jpg',
+      image_url='img/mozorg/about/foundation.jpg',
       include_highres_image=True,
       aspect_ratio='mzp-has-aspect-3-2',
       class='mzp-l-card-feature-left-half t-foundation'
@@ -104,7 +104,7 @@
       desc=_('The principles we wrote in 1998 still guide us today. And in 2018, we created an addendum to emphasize inclusion, privacy and safety for everyone online.'),
       link_cta=_('Read The Manifesto'),
       link_url=url('mozorg.about.manifesto'),
-      image_url='home/2018/billboard-healthy-internet.png',
+      image_url='img/home/2018/billboard-healthy-internet.png',
       include_highres_image=True
   )}}
 </div>
@@ -172,7 +172,7 @@
 <div class="mzp-l-content">
   <aside class="mzp-c-newsletter">
     <div class="mzp-c-newsletter-image">
-      {{ high_res_img('home/2018/newsletter-graphic.png', {'alt': ''}) }}
+      {{ high_res_img('img/home/2018/newsletter-graphic.png', {'alt': ''}) }}
     </div>
 
     <div class="newsletter-content">

--- a/bedrock/mozorg/templates/mozorg/about/leadership.html
+++ b/bedrock/mozorg/templates/mozorg/about/leadership.html
@@ -35,9 +35,9 @@
       <span class="snap shot-thirteen"><span></span></span>
     </div>
     <div class="foreground">
-      <span class="snap shot-one"><span>{{ high_res_img('mozorg/about/leadership/header/snap-fore-msurman.jpg', {'alt': '', 'width': '230', 'height': '230'}) }}</span></span>
-      <span class="snap shot-two"><span>{{ high_res_img('mozorg/about/leadership/header/snap-fore-mbaker.jpg', {'alt': '', 'width': '230', 'height': '230'}) }}</span></span>
-      <span class="snap shot-three"><span>{{ high_res_img('mozorg/about/leadership/header/snap-fore-cbeard.jpg', {'alt': '', 'width': '230', 'height': '230'}) }}</span></span>
+      <span class="snap shot-one"><span>{{ high_res_img('img/mozorg/about/leadership/header/snap-fore-msurman.jpg', {'alt': '', 'width': '230', 'height': '230'}) }}</span></span>
+      <span class="snap shot-two"><span>{{ high_res_img('img/mozorg/about/leadership/header/snap-fore-mbaker.jpg', {'alt': '', 'width': '230', 'height': '230'}) }}</span></span>
+      <span class="snap shot-three"><span>{{ high_res_img('img/mozorg/about/leadership/header/snap-fore-cbeard.jpg', {'alt': '', 'width': '230', 'height': '230'}) }}</span></span>
     </div>
   </div>
 
@@ -79,7 +79,7 @@
     <div class="gallery mgmt-corp">
       <article id="mitchell-baker" data-id="mitchell-baker" class="vcard has-bio" itemscope itemtype="http://schema.org/Person">
         <figure class="headshot">
-          {{ high_res_img('mozorg/about/leadership/mitchell-baker.jpg', {'alt': '', 'width': '160', 'height': '160', 'class': 'photo', 'itemprop': 'image'}) }}
+          {{ high_res_img('img/mozorg/about/leadership/mitchell-baker.jpg', {'alt': '', 'width': '160', 'height': '160', 'class': 'photo', 'itemprop': 'image'}) }}
           <figcaption><h4 class="fn" itemprop="name">Mitchell Baker</h4></figcaption>
         </figure>
 
@@ -129,7 +129,7 @@
 
       <article id="chris-beard" data-id="chris-beard" class="vcard has-bio" itemscope itemtype="http://schema.org/Person">
         <figure class="headshot">
-          {{ high_res_img('mozorg/about/leadership/chris-beard.jpg', {'alt': '', 'width': '160', 'height': '160', 'class': 'photo', 'itemprop': 'image'}) }}
+          {{ high_res_img('img/mozorg/about/leadership/chris-beard.jpg', {'alt': '', 'width': '160', 'height': '160', 'class': 'photo', 'itemprop': 'image'}) }}
           <figcaption><h4 class="fn" itemprop="name">Chris Beard</h4></figcaption>
         </figure>
 
@@ -188,7 +188,7 @@
 
       <article id="dave-camp" data-id="dave-camp" class="vcard has-bio" itemscope itemtype="http://schema.org/Person">
         <figure class="headshot">
-          {{ high_res_img('mozorg/about/leadership/dave-camp.jpg', {'alt': '', 'width': '160', 'height': '160', 'class': 'photo', 'itemprop': 'image'}) }}
+          {{ high_res_img('img/mozorg/about/leadership/dave-camp.jpg', {'alt': '', 'width': '160', 'height': '160', 'class': 'photo', 'itemprop': 'image'}) }}
           <figcaption><h4 class="fn" itemprop="name">Dave Camp</h4></figcaption>
         </figure>
 
@@ -246,7 +246,7 @@
 
       <article id="michael-deangelo" data-id="michael-deangelo" class="vcard has-bio" itemscope itemtype="http://schema.org/Person">
         <figure class="headshot">
-          {{ high_res_img('mozorg/about/leadership/michael-deangelo.jpg', {'alt': '', 'width': '160', 'height': '160', 'class': 'photo', 'itemprop': 'image'}) }}
+          {{ high_res_img('img/mozorg/about/leadership/michael-deangelo.jpg', {'alt': '', 'width': '160', 'height': '160', 'class': 'photo', 'itemprop': 'image'}) }}
           <figcaption><h4 class="fn" itemprop="name">Michael DeAngelo</h4></figcaption>
         </figure>
 
@@ -280,7 +280,7 @@
 
       <article id="amy-keating" data-id="amy-keating" class="vcard has-bio" itemscope itemtype="http://schema.org/Person">
         <figure class="headshot">
-          {{ high_res_img('mozorg/about/leadership/amy-keating.jpg', {'alt': '', 'width': '160', 'height': '160', 'class': 'photo', 'itemprop': 'image'}) }}
+          {{ high_res_img('img/mozorg/about/leadership/amy-keating.jpg', {'alt': '', 'width': '160', 'height': '160', 'class': 'photo', 'itemprop': 'image'}) }}
           <figcaption><h4 class="fn" itemprop="name">Amy Keating</h4></figcaption>
         </figure>
 
@@ -316,7 +316,7 @@
 
       <article id="jascha-kaykas-wolff" data-id="jascha-kaykas-wolff" class="vcard has-bio" itemscope itemtype="http://schema.org/Person">
         <figure class="headshot">
-          {{ high_res_img('mozorg/about/leadership/jascha-kaykas-wolff.jpg', {'alt': '', 'width': '160', 'height': '160', 'class': 'photo', 'itemprop': 'image'}) }}
+          {{ high_res_img('img/mozorg/about/leadership/jascha-kaykas-wolff.jpg', {'alt': '', 'width': '160', 'height': '160', 'class': 'photo', 'itemprop': 'image'}) }}
           <figcaption><h4 class="fn" itemprop="name">Jascha Kaykas-Wolff</h4></figcaption>
         </figure>
 
@@ -369,7 +369,7 @@
 
       <article id="nate-weiner" data-id="nate-weiner" class="vcard has-bio" itemscope itemtype="http://schema.org/Person">
         <figure class="headshot">
-          {{ high_res_img('mozorg/about/leadership/nate-weiner.jpg', {'alt': '', 'width': '160', 'height': '160', 'class': 'photo', 'itemprop': 'image'}) }}
+          {{ high_res_img('img/mozorg/about/leadership/nate-weiner.jpg', {'alt': '', 'width': '160', 'height': '160', 'class': 'photo', 'itemprop': 'image'}) }}
           <figcaption><h4 class="fn" itemprop="name">Nate Weiner</h4></figcaption>
         </figure>
 
@@ -411,7 +411,7 @@
 
       <article id="roxi-wen" data-id="roxi-wen" class="vcard has-bio" itemscope itemtype="http://schema.org/Person">
         <figure class="headshot">
-          {{ high_res_img('mozorg/about/leadership/roxi-wen.jpg', {'alt': '', 'width': '160', 'height': '160', 'class': 'photo', 'itemprop': 'image'}) }}
+          {{ high_res_img('img/mozorg/about/leadership/roxi-wen.jpg', {'alt': '', 'width': '160', 'height': '160', 'class': 'photo', 'itemprop': 'image'}) }}
           <figcaption><h4 class="fn" itemprop="name">Roxi Wen</h4></figcaption>
         </figure>
 
@@ -441,7 +441,7 @@
 
       <article id="sean-white" data-id="sean-white" class="vcard has-bio" itemscope itemtype="http://schema.org/Person">
         <figure class="headshot">
-          {{ high_res_img('mozorg/about/leadership/sean-white.jpg', {'alt': '', 'width': '160', 'height': '160', 'class': 'photo', 'itemprop': 'image'}) }}
+          {{ high_res_img('img/mozorg/about/leadership/sean-white.jpg', {'alt': '', 'width': '160', 'height': '160', 'class': 'photo', 'itemprop': 'image'}) }}
           <figcaption><h4 class="fn" itemprop="name">Sean White</h4></figcaption>
         </figure>
 
@@ -488,7 +488,7 @@
 
       <article id="katharina-borchert" data-id="katharina-borchert" class="vcard has-bio" itemscope itemtype="http://schema.org/Person">
         <figure class="headshot">
-          {{ high_res_img('mozorg/about/leadership/katharina-borchert.jpg', {'alt': '', 'width': '160', 'height': '160', 'class': 'photo', 'itemprop': 'image'}) }}
+          {{ high_res_img('img/mozorg/about/leadership/katharina-borchert.jpg', {'alt': '', 'width': '160', 'height': '160', 'class': 'photo', 'itemprop': 'image'}) }}
           <figcaption><h4 class="fn" itemprop="name">Katharina Borchert</h4></figcaption>
         </figure>
 
@@ -528,7 +528,7 @@
 
       <article id="david-bryant" data-id="david-bryant" class="vcard has-bio" itemscope itemtype="http://schema.org/Person">
         <figure class="headshot">
-          {{ high_res_img('mozorg/about/leadership/david-bryant.jpg', {'alt': '', 'width': '160', 'height': '160', 'class': 'photo', 'itemprop': 'image'}) }}
+          {{ high_res_img('img/mozorg/about/leadership/david-bryant.jpg', {'alt': '', 'width': '160', 'height': '160', 'class': 'photo', 'itemprop': 'image'}) }}
           <figcaption><h4 class="fn" itemprop="name">David Bryant</h4></figcaption>
         </figure>
 
@@ -574,7 +574,7 @@
 
       <article id="susan-chen" data-id="susan-chen" class="vcard has-bio" itemscope itemtype="http://schema.org/Person">
         <figure class="headshot">
-          {{ high_res_img('mozorg/about/leadership/susan-chen.jpg', {'alt': '', 'width': '160', 'height': '160', 'class': 'photo', 'itemprop': 'image'}) }}
+          {{ high_res_img('img/mozorg/about/leadership/susan-chen.jpg', {'alt': '', 'width': '160', 'height': '160', 'class': 'photo', 'itemprop': 'image'}) }}
           <figcaption><h4 class="fn" itemprop="name">Susan Chen</h4></figcaption>
         </figure>
 
@@ -619,7 +619,7 @@
 
       <article id="alan-davidson" data-id="alan-davidson" class="vcard has-bio" itemscope itemtype="http://schema.org/Person">
         <figure class="headshot">
-          {{ high_res_img('mozorg/about/leadership/alan-davidson.jpg', {'alt': '', 'width': '160', 'height': '160', 'class': 'photo', 'itemprop': 'image'}) }}
+          {{ high_res_img('img/mozorg/about/leadership/alan-davidson.jpg', {'alt': '', 'width': '160', 'height': '160', 'class': 'photo', 'itemprop': 'image'}) }}
           <figcaption><h4 class="fn" itemprop="name">Alan Davidson</h4></figcaption>
         </figure>
 
@@ -660,7 +660,7 @@
 
       <article id="joe-hildebrand" data-id="joe-hildebrand" class="vcard has-bio" itemscope itemtype="http://schema.org/Person">
         <figure class="headshot">
-          {{ high_res_img('mozorg/about/leadership/joe-hildebrand.jpg', {'alt': '', 'width': '160', 'height': '160', 'class': 'photo', 'itemprop': 'image'}) }}
+          {{ high_res_img('img/mozorg/about/leadership/joe-hildebrand.jpg', {'alt': '', 'width': '160', 'height': '160', 'class': 'photo', 'itemprop': 'image'}) }}
           <figcaption><h4 class="fn" itemprop="name">Joe Hildebrand</h4></figcaption>
         </figure>
 
@@ -701,7 +701,7 @@
 
       <article id="matt-koidin" data-id="matt-koidin" class="vcard has-bio" itemscope itemtype="http://schema.org/Person">
         <figure class="headshot">
-          {{ high_res_img('mozorg/about/leadership/matt-koidin.jpg', {'alt': '', 'width': '160', 'height': '160', 'class': 'photo', 'itemprop': 'image'}) }}
+          {{ high_res_img('img/mozorg/about/leadership/matt-koidin.jpg', {'alt': '', 'width': '160', 'height': '160', 'class': 'photo', 'itemprop': 'image'}) }}
           <figcaption><h4 class="fn" itemprop="name">Matt Koidin</h4></figcaption>
         </figure>
 
@@ -748,7 +748,7 @@
 
       <article id="stan-leong" data-id="stan-leong" class="vcard has-bio" itemscope itemtype="http://schema.org/Person">
         <figure class="headshot">
-          {{ high_res_img('mozorg/about/leadership/stan-leong.jpg', {'alt': '', 'width': '160', 'height': '160', 'class': 'photo', 'itemprop': 'image'}) }}
+          {{ high_res_img('img/mozorg/about/leadership/stan-leong.jpg', {'alt': '', 'width': '160', 'height': '160', 'class': 'photo', 'itemprop': 'image'}) }}
           <figcaption><h4 class="fn" itemprop="name">Stan Leong</h4></figcaption>
         </figure>
 
@@ -789,7 +789,7 @@
 
       <article id="chris-lin" data-id="chris-lin" class="vcard has-bio" itemscope itemtype="http://schema.org/Person">
         <figure class="headshot">
-          {{ high_res_img('mozorg/about/leadership/chris-lin.jpg', {'alt': '', 'width': '160', 'height': '160', 'class': 'photo', 'itemprop': 'image'}) }}
+          {{ high_res_img('img/mozorg/about/leadership/chris-lin.jpg', {'alt': '', 'width': '160', 'height': '160', 'class': 'photo', 'itemprop': 'image'}) }}
           <figcaption><h4 class="fn" itemprop="name">Chris Lin</h4></figcaption>
         </figure>
 
@@ -818,7 +818,7 @@
 
       <article id="mary-ellen-muckerman" data-id="mary-ellen-muckerman" class="vcard has-bio" itemscope itemtype="http://schema.org/Person">
         <figure class="headshot">
-          {{ high_res_img('mozorg/about/leadership/mary-ellen-muckerman.jpg', {'alt': '', 'width': '160', 'height': '160', 'class': 'photo', 'itemprop': 'image'}) }}
+          {{ high_res_img('img/mozorg/about/leadership/mary-ellen-muckerman.jpg', {'alt': '', 'width': '160', 'height': '160', 'class': 'photo', 'itemprop': 'image'}) }}
           <figcaption><h4 class="fn" itemprop="name">Mary Ellen Muckerman</h4></figcaption>
         </figure>
 
@@ -857,7 +857,7 @@
 
       <article id="eric-rescorla" data-id="eric-rescorla" class="vcard has-bio" itemscope itemtype="http://schema.org/Person">
         <figure class="headshot">
-          {{ high_res_img('mozorg/about/leadership/eric-rescorla.jpg', {'alt': '', 'width': '160', 'height': '160', 'class': 'photo', 'itemprop': 'image'}) }}
+          {{ high_res_img('img/mozorg/about/leadership/eric-rescorla.jpg', {'alt': '', 'width': '160', 'height': '160', 'class': 'photo', 'itemprop': 'image'}) }}
           <figcaption><h4 class="fn" itemprop="name">Eric Rescorla</h4></figcaption>
         </figure>
 
@@ -909,7 +909,7 @@
 
       <article id="lindsey-shepard" data-id="lindsey-shepard" class="vcard has-bio" itemscope itemtype="http://schema.org/Person">
         <figure class="headshot">
-          {{ high_res_img('mozorg/about/leadership/lindsey-shepard.jpg', {'alt': '', 'width': '160', 'height': '160', 'class': 'photo', 'itemprop': 'image'}) }}
+          {{ high_res_img('img/mozorg/about/leadership/lindsey-shepard.jpg', {'alt': '', 'width': '160', 'height': '160', 'class': 'photo', 'itemprop': 'image'}) }}
           <figcaption><h4 class="fn" itemprop="name">Lindsey Shepard</h4></figcaption>
         </figure>
 
@@ -944,7 +944,7 @@
 
       <article id="reese-wood" data-id="reese-wood" class="vcard has-bio" itemscope itemtype="http://schema.org/Person">
         <figure class="headshot">
-          {{ high_res_img('mozorg/about/leadership/marissa-wood.jpg', {'alt': '', 'width': '160', 'height': '160', 'class': 'photo', 'itemprop': 'image'}) }}
+          {{ high_res_img('img/mozorg/about/leadership/marissa-wood.jpg', {'alt': '', 'width': '160', 'height': '160', 'class': 'photo', 'itemprop': 'image'}) }}
           <figcaption><h4 class="fn" itemprop="name">Marissa “Reese” Wood</h4></figcaption>
         </figure>
 
@@ -996,7 +996,7 @@
     <div class="gallery mgmt-foundation">
       <article id="mark-surman" data-id="mark-surman" class="vcard has-bio" itemscope itemtype="http://schema.org/Person">
         <figure class="headshot">
-          {{ high_res_img('mozorg/about/leadership/mark-surman.jpg', {'alt': '', 'width': '160', 'height': '160', 'class': 'photo', 'itemprop': 'image'}) }}
+          {{ high_res_img('img/mozorg/about/leadership/mark-surman.jpg', {'alt': '', 'width': '160', 'height': '160', 'class': 'photo', 'itemprop': 'image'}) }}
           <figcaption><h4 class="fn" itemprop="name">Mark Surman</h4></figcaption>
         </figure>
 
@@ -1055,7 +1055,7 @@
 
       <article id="ashley-boyd" data-id="ashley-boyd" class="vcard has-bio" itemscope itemtype="http://schema.org/Person">
         <figure class="headshot">
-          {{ high_res_img('mozorg/about/leadership/ashley-boyd.jpg', {'alt': '', 'width': '160', 'height': '160', 'class': 'photo', 'itemprop': 'image'}) }}
+          {{ high_res_img('img/mozorg/about/leadership/ashley-boyd.jpg', {'alt': '', 'width': '160', 'height': '160', 'class': 'photo', 'itemprop': 'image'}) }}
           <figcaption><h4 class="fn" itemprop="name">Ashley Boyd</h4></figcaption>
         </figure>
 
@@ -1107,7 +1107,7 @@
 
       <article id="angela-plohman" data-id="angela-plohman" class="vcard has-bio" itemscope itemtype="http://schema.org/Person">
         <figure class="headshot">
-          {{ high_res_img('mozorg/about/leadership/angela-plohman.jpg', {'alt': '', 'width': '160', 'height': '160', 'class': 'photo', 'itemprop': 'image'}) }}
+          {{ high_res_img('img/mozorg/about/leadership/angela-plohman.jpg', {'alt': '', 'width': '160', 'height': '160', 'class': 'photo', 'itemprop': 'image'}) }}
           <figcaption><h4 class="fn" itemprop="name">Angela Plohman</h4></figcaption>
         </figure>
 
@@ -1161,7 +1161,7 @@
       <li class="vcard" itemscope itemtype="http://schema.org/Person">
         <figure class="headshot">
           <a class="url" itemprop="url" rel="external" href="https://reps.mozilla.org/u/Irvin/">
-            {{ high_res_img('mozorg/about/leadership/irvin-chen.jpg', {'alt': '', 'width': '160', 'height': '160', 'class': 'photo', 'itemprop': 'image'}) }}
+            {{ high_res_img('img/mozorg/about/leadership/irvin-chen.jpg', {'alt': '', 'width': '160', 'height': '160', 'class': 'photo', 'itemprop': 'image'}) }}
             <figcaption><h4 class="fn" itemprop="name">Irvin Chen</h4></figcaption>
           </a>
         </figure>
@@ -1171,7 +1171,7 @@
       <li class="vcard" itemscope itemtype="http://schema.org/Person">
         <figure class="headshot">
           <a class="url" itemprop="url" rel="external" href="https://reps.mozilla.org/u/shahidfarooqui/">
-            {{ high_res_img('mozorg/about/leadership/shahid-farooqui.jpg', {'alt': '', 'width': '160', 'height': '160', 'class': 'photo', 'itemprop': 'image'}) }}
+            {{ high_res_img('img/mozorg/about/leadership/shahid-farooqui.jpg', {'alt': '', 'width': '160', 'height': '160', 'class': 'photo', 'itemprop': 'image'}) }}
             <figcaption><h4 class="fn" itemprop="name">Shahid Ali Farooqui</h4></figcaption>
           </a>
         </figure>
@@ -1181,7 +1181,7 @@
       <li class="vcard" itemscope itemtype="http://schema.org/Person">
         <figure class="headshot">
           <a class="url" itemprop="url" rel="external" href="https://reps.mozilla.org/u/yomanpatil/">
-            {{ high_res_img('mozorg/about/leadership/mayur-patil.jpg', {'alt': '', 'width': '160', 'height': '160', 'class': 'photo', 'itemprop': 'image'}) }}
+            {{ high_res_img('img/mozorg/about/leadership/mayur-patil.jpg', {'alt': '', 'width': '160', 'height': '160', 'class': 'photo', 'itemprop': 'image'}) }}
             <figcaption><h4 class="fn" itemprop="name">Mayur Patil</h4></figcaption>
           </a>
         </figure>
@@ -1191,7 +1191,7 @@
       <li class="vcard" itemscope itemtype="http://schema.org/Person">
         <figure class="headshot">
           <a class="url" itemprop="url" rel="external" href="https://reps.mozilla.org/u/prathamesh/">
-            {{ high_res_img('mozorg/about/leadership/prathamesh-chavan.jpg', {'alt': '', 'width': '160', 'height': '160', 'class': 'photo', 'itemprop': 'image'}) }}
+            {{ high_res_img('img/mozorg/about/leadership/prathamesh-chavan.jpg', {'alt': '', 'width': '160', 'height': '160', 'class': 'photo', 'itemprop': 'image'}) }}
             <figcaption><h4 class="fn" itemprop="name">Prathamesh Chavan</h4></figcaption>
           </a>
         </figure>
@@ -1201,7 +1201,7 @@
       <li class="vcard" itemscope itemtype="http://schema.org/Person">
         <figure class="headshot">
           <a class="url" itemprop="url" rel="external" href="https://reps.mozilla.org/u/Tuxxy/">
-            {{ high_res_img('mozorg/about/leadership/yuliana-jimenez.jpg', {'alt': '', 'width': '160', 'height': '160', 'class': 'photo', 'itemprop': 'image'}) }}
+            {{ high_res_img('img/mozorg/about/leadership/yuliana-jimenez.jpg', {'alt': '', 'width': '160', 'height': '160', 'class': 'photo', 'itemprop': 'image'}) }}
             <figcaption><h4 class="fn" itemprop="name">Yuliana R Jimenez</h4></figcaption>
           </a>
         </figure>
@@ -1211,7 +1211,7 @@
       <li class="vcard" itemscope itemtype="http://schema.org/Person">
         <figure class="headshot">
           <a class="url" itemprop="url" rel="external" href="https://reps.mozilla.org/u/MonicaBonilla/">
-            {{ high_res_img('mozorg/about/leadership/monica-bonilla.jpg', {'alt': '', 'width': '160', 'height': '160', 'class': 'photo', 'itemprop': 'image'}) }}
+            {{ high_res_img('img/mozorg/about/leadership/monica-bonilla.jpg', {'alt': '', 'width': '160', 'height': '160', 'class': 'photo', 'itemprop': 'image'}) }}
             <figcaption><h4 class="fn" itemprop="name">Mónica Bonilla</h4></figcaption>
           </a>
         </figure>
@@ -1221,7 +1221,7 @@
       <li class="vcard" itemscope itemtype="http://schema.org/Person">
         <figure class="headshot">
           <a class="url" itemprop="url" rel="external" href="https://reps.mozilla.org/u/yofiesetiawan/">
-            {{ high_res_img('mozorg/about/leadership/yofie-setiawan.jpg', {'alt': '', 'width': '160', 'height': '160', 'class': 'photo', 'itemprop': 'image'}) }}
+            {{ high_res_img('img/mozorg/about/leadership/yofie-setiawan.jpg', {'alt': '', 'width': '160', 'height': '160', 'class': 'photo', 'itemprop': 'image'}) }}
             <figcaption><h4 class="fn" itemprop="name">Yofie Setiawan</h4></figcaption>
           </a>
         </figure>
@@ -1231,7 +1231,7 @@
       <li class="vcard" itemscope itemtype="http://schema.org/Person">
         <figure class="headshot">
           <a class="url" itemprop="url" rel="external" href="https://mozillians.org/u/couci/">
-            {{ high_res_img('mozorg/about/leadership/konstantina-papadea.jpg', {'alt': '', 'width': '160', 'height': '160', 'class': 'photo', 'itemprop': 'image'}) }}
+            {{ high_res_img('img/mozorg/about/leadership/konstantina-papadea.jpg', {'alt': '', 'width': '160', 'height': '160', 'class': 'photo', 'itemprop': 'image'}) }}
             <figcaption><h4 class="fn" itemprop="name">Konstantina Papadea</h4></figcaption>
           </a>
         </figure>
@@ -1241,7 +1241,7 @@
       <li class="vcard" itemscope itemtype="http://schema.org/Person">
         <figure class="headshot">
           <a class="url" itemprop="url" rel="external" href="https://reps.mozilla.org/u/nukeador/">
-            {{ high_res_img('mozorg/about/leadership/ruben-martin.jpg', {'alt': '', 'width': '160', 'height': '160', 'class': 'photo', 'itemprop': 'image'}) }}
+            {{ high_res_img('img/mozorg/about/leadership/ruben-martin.jpg', {'alt': '', 'width': '160', 'height': '160', 'class': 'photo', 'itemprop': 'image'}) }}
             <figcaption><h4 class="fn" itemprop="name">Rubén Martin</h4></figcaption>
           </a>
         </figure>
@@ -1262,26 +1262,26 @@
     <ul class="gallery">
       <li class="vcard" itemscope itemtype="http://schema.org/Person">
         <figure class="headshot">
-          {{ high_res_img('mozorg/about/leadership/mitchell-baker.jpg', {'alt': '', 'width': '160', 'height': '160', 'class': 'photo', 'itemprop': 'image'}) }}
+          {{ high_res_img('img/mozorg/about/leadership/mitchell-baker.jpg', {'alt': '', 'width': '160', 'height': '160', 'class': 'photo', 'itemprop': 'image'}) }}
           {# L10n: This "Chair" is the chairperson of the board of directors, not something to sit on #}
           <figcaption><h4 class="fn" itemprop="name">Mitchell Baker, {{ _('Chair') }}</h4></figcaption>
         </figure>
       </li>
       <li class="vcard" itemscope itemtype="http://schema.org/Person">
         <figure class="headshot">
-          {{ high_res_img('mozorg/about/leadership/chris-beard.jpg', {'alt': '', 'width': '160', 'height': '160', 'class': 'photo', 'itemprop': 'image'}) }}
+          {{ high_res_img('img/mozorg/about/leadership/chris-beard.jpg', {'alt': '', 'width': '160', 'height': '160', 'class': 'photo', 'itemprop': 'image'}) }}
           <figcaption><h4 class="fn" itemprop="name">Chris Beard</h4></figcaption>
         </figure>
       </li>
       <li class="vcard" itemscope itemtype="http://schema.org/Person">
         <figure class="headshot">
-          {{ high_res_img('mozorg/about/leadership/julie-hanna.jpg', {'alt': '', 'width': '160', 'height': '160', 'class': 'photo', 'itemprop': 'image'}) }}
+          {{ high_res_img('img/mozorg/about/leadership/julie-hanna.jpg', {'alt': '', 'width': '160', 'height': '160', 'class': 'photo', 'itemprop': 'image'}) }}
           <figcaption><h4 class="fn" itemprop="name">Julie Hanna</h4></figcaption>
         </figure>
       </li>
       <li class="vcard" itemscope itemtype="http://schema.org/Person">
         <figure class="headshot">
-          {{ high_res_img('mozorg/about/leadership/karim-lakhani.jpg', {'alt': '', 'width': '160', 'height': '160', 'class': 'photo', 'itemprop': 'image'}) }}
+          {{ high_res_img('img/mozorg/about/leadership/karim-lakhani.jpg', {'alt': '', 'width': '160', 'height': '160', 'class': 'photo', 'itemprop': 'image'}) }}
           <figcaption><h4 class="fn" itemprop="name">Karim Lakhani</h4></figcaption>
         </figure>
       </li>
@@ -1291,38 +1291,38 @@
     <ul class="gallery">
       <li class="vcard" itemscope itemtype="http://schema.org/Person">
         <figure class="headshot">
-          {{ high_res_img('mozorg/about/leadership/mitchell-baker.jpg', {'alt': '', 'width': '160', 'height': '160', 'class': 'photo', 'itemprop': 'image'}) }}
+          {{ high_res_img('img/mozorg/about/leadership/mitchell-baker.jpg', {'alt': '', 'width': '160', 'height': '160', 'class': 'photo', 'itemprop': 'image'}) }}
           {# L10n: This "Chair" is the chairperson of the board of directors, not something to sit on #}
           <figcaption><h4 class="fn" itemprop="name">Mitchell Baker, {{ _('Chair') }}</h4></figcaption>
         </figure>
       </li>
       <li class="vcard" itemscope itemtype="http://schema.org/Person">
         <figure class="headshot">
-          {{ high_res_img('mozorg/about/leadership/brian-behlendorf.jpg', {'alt': '', 'width': '160', 'height': '160', 'class': 'photo', 'itemprop': 'image'}) }}
+          {{ high_res_img('img/mozorg/about/leadership/brian-behlendorf.jpg', {'alt': '', 'width': '160', 'height': '160', 'class': 'photo', 'itemprop': 'image'}) }}
           <figcaption><h4 class="fn" itemprop="name">Brian Behlendorf</h4></figcaption>
         </figure>
       </li>
       <li class="vcard" itemscope itemtype="http://schema.org/Person">
         <figure class="headshot">
-          {{ high_res_img('mozorg/about/leadership/ronaldo-lemos.jpg', {'alt': '', 'width': '160', 'height': '160', 'class': 'photo', 'itemprop': 'image'}) }}
+          {{ high_res_img('img/mozorg/about/leadership/ronaldo-lemos.jpg', {'alt': '', 'width': '160', 'height': '160', 'class': 'photo', 'itemprop': 'image'}) }}
           <figcaption><h4 class="fn" itemprop="name">Ronaldo Lemos</h4></figcaption>
         </figure>
       </li>
       <li class="vcard" itemscope itemtype="http://schema.org/Person">
         <figure class="headshot">
-          {{ high_res_img('mozorg/about/leadership/bob-lisbonne.jpg', {'alt': '', 'width': '160', 'height': '160', 'class': 'photo', 'itemprop': 'image'}) }}
+          {{ high_res_img('img/mozorg/about/leadership/bob-lisbonne.jpg', {'alt': '', 'width': '160', 'height': '160', 'class': 'photo', 'itemprop': 'image'}) }}
           <figcaption><h4 class="fn" itemprop="name">Bob Lisbonne</h4></figcaption>
         </figure>
       </li>
       <li class="vcard" itemscope itemtype="http://schema.org/Person">
         <figure class="headshot">
-          {{ high_res_img('mozorg/about/leadership/mohamed-nanabhay.jpg', {'alt': '', 'width': '160', 'height': '160', 'class': 'photo', 'itemprop': 'image', 'title': _('Photo by Joi Ito')}) }}
+          {{ high_res_img('img/mozorg/about/leadership/mohamed-nanabhay.jpg', {'alt': '', 'width': '160', 'height': '160', 'class': 'photo', 'itemprop': 'image', 'title': _('Photo by Joi Ito')}) }}
           <figcaption><h4 class="fn" itemprop="name">Mohamed Nanabhay</h4></figcaption>
         </figure>
       </li>
       <li class="vcard" itemscope itemtype="http://schema.org/Person">
         <figure class="headshot">
-          {{ high_res_img('mozorg/about/leadership/helen-turvey.jpg', {'alt': '', 'width': '160', 'height': '160', 'class': 'photo', 'itemprop': 'image'}) }}
+          {{ high_res_img('img/mozorg/about/leadership/helen-turvey.jpg', {'alt': '', 'width': '160', 'height': '160', 'class': 'photo', 'itemprop': 'image'}) }}
           <figcaption><h4 class="fn" itemprop="name">Helen Turvey</h4></figcaption>
         </figure>
       </li>

--- a/bedrock/mozorg/templates/mozorg/about/policy/lean-data/build-security.html
+++ b/bedrock/mozorg/templates/mozorg/about/policy/lean-data/build-security.html
@@ -30,7 +30,7 @@
   </div>
 
   <div class="mzp-c-hero-image">
-    {{ high_res_img('mozorg/about/lean-data/build-security-hero.png', {'alt': '', 'width': '424', 'height': '424'}) }}
+    {{ high_res_img('img/mozorg/about/lean-data/build-security-hero.png', {'alt': '', 'width': '424', 'height': '424'}) }}
   </div>
 </section>
 
@@ -111,7 +111,7 @@
     <div class="mzp-c-card mzp-has-aspect-1-1">
       <a class="mzp-c-card-block-link" href="{{ url('mozorg.about.policy.lean-data.stay-lean') }}">
         <div class="mzp-c-card-media-wrapper">
-          {{ high_res_img('mozorg/about/lean-data/stay-lean-hero.png', {'alt': '', 'width': '424', 'height': '424'}) }}
+          {{ high_res_img('img/mozorg/about/lean-data/stay-lean-hero.png', {'alt': '', 'width': '424', 'height': '424'}) }}
         </div>
         <div class="mzp-c-card-content">
           <h3 class="mzp-c-card-title">{{ _('Stay Lean') }}</h3>
@@ -123,7 +123,7 @@
     <div class="mzp-c-card mzp-has-aspect-1-1">
       <a class="mzp-c-card-block-link" href="{{ url('mozorg.about.policy.lean-data.engage-users') }}">
         <div class="mzp-c-card-media-wrapper">
-          {{ high_res_img('mozorg/about/lean-data/engage-users-hero.png', {'alt': '', 'width': '424', 'height': '424'}) }}
+          {{ high_res_img('img/mozorg/about/lean-data/engage-users-hero.png', {'alt': '', 'width': '424', 'height': '424'}) }}
         </div>
         <div class="mzp-c-card-content">
           <h3 class="mzp-c-card-title">{{ _('Engage Your Users') }}</h3>

--- a/bedrock/mozorg/templates/mozorg/about/policy/lean-data/engage-users.html
+++ b/bedrock/mozorg/templates/mozorg/about/policy/lean-data/engage-users.html
@@ -30,7 +30,7 @@
   </div>
 
   <div class="mzp-c-hero-image">
-    {{ high_res_img('mozorg/about/lean-data/engage-users-hero.png', {'alt': '', 'width': '424', 'height': '424'}) }}
+    {{ high_res_img('img/mozorg/about/lean-data/engage-users-hero.png', {'alt': '', 'width': '424', 'height': '424'}) }}
   </div>
 </section>
 
@@ -134,7 +134,7 @@
     <div class="mzp-c-card mzp-has-aspect-1-1">
       <a class="mzp-c-card-block-link" href="{{ url('mozorg.about.policy.lean-data.stay-lean') }}">
         <div class="mzp-c-card-media-wrapper">
-          {{ high_res_img('mozorg/about/lean-data/stay-lean-hero.png', {'alt': '', 'width': '424', 'height': '424'}) }}
+          {{ high_res_img('img/mozorg/about/lean-data/stay-lean-hero.png', {'alt': '', 'width': '424', 'height': '424'}) }}
         </div>
         <div class="mzp-c-card-content">
           <h3 class="mzp-c-card-title">{{ _('Stay Lean') }}</h3>
@@ -146,7 +146,7 @@
     <div class="mzp-c-card mzp-has-aspect-1-1">
       <a class="mzp-c-card-block-link" href="{{ url('mozorg.about.policy.lean-data.build-security') }}">
         <div class="mzp-c-card-media-wrapper">
-          {{ high_res_img('mozorg/about/lean-data/build-security-hero.png', {'alt': '', 'width': '424', 'height': '424'}) }}
+          {{ high_res_img('img/mozorg/about/lean-data/build-security-hero.png', {'alt': '', 'width': '424', 'height': '424'}) }}
         </div>
         <div class="mzp-c-card-content">
           <h3 class="mzp-c-card-title">{{ _('Build Security') }}</h3>

--- a/bedrock/mozorg/templates/mozorg/about/policy/lean-data/index.html
+++ b/bedrock/mozorg/templates/mozorg/about/policy/lean-data/index.html
@@ -29,7 +29,7 @@
   </div>
 
   <div class="mzp-c-hero-image">
-    {{ high_res_img('mozorg/about/lean-data/lean-data-hero.png', {'alt': '', 'width': '424', 'height': '424'}) }}
+    {{ high_res_img('img/mozorg/about/lean-data/lean-data-hero.png', {'alt': '', 'width': '424', 'height': '424'}) }}
   </div>
 </section>
 
@@ -57,7 +57,7 @@
     <div class="mzp-c-card mzp-has-aspect-1-1">
       <a class="mzp-c-card-block-link" href="{{ url('mozorg.about.policy.lean-data.stay-lean') }}">
         <div class="mzp-c-card-media-wrapper">
-          {{ high_res_img('mozorg/about/lean-data/stay-lean-hero.png', {'alt': '', 'width': '424', 'height': '424'}) }}
+          {{ high_res_img('img/mozorg/about/lean-data/stay-lean-hero.png', {'alt': '', 'width': '424', 'height': '424'}) }}
         </div>
         <div class="mzp-c-card-content">
           <h3 class="mzp-c-card-title">{{ _('Stay Lean') }}</h3>
@@ -69,7 +69,7 @@
     <div class="mzp-c-card mzp-has-aspect-1-1">
       <a class="mzp-c-card-block-link" href="{{ url('mozorg.about.policy.lean-data.build-security') }}">
         <div class="mzp-c-card-media-wrapper">
-          {{ high_res_img('mozorg/about/lean-data/build-security-hero.png', {'alt': '', 'width': '424', 'height': '424'}) }}
+          {{ high_res_img('img/mozorg/about/lean-data/build-security-hero.png', {'alt': '', 'width': '424', 'height': '424'}) }}
         </div>
         <div class="mzp-c-card-content">
           <h3 class="mzp-c-card-title">{{ _('Build Security') }}</h3>
@@ -81,7 +81,7 @@
     <div class="mzp-c-card mzp-has-aspect-1-1">
       <a class="mzp-c-card-block-link" href="{{ url('mozorg.about.policy.lean-data.engage-users') }}">
         <div class="mzp-c-card-media-wrapper">
-          {{ high_res_img('mozorg/about/lean-data/engage-users-hero.png', {'alt': '', 'width': '424', 'height': '424'}) }}
+          {{ high_res_img('img/mozorg/about/lean-data/engage-users-hero.png', {'alt': '', 'width': '424', 'height': '424'}) }}
         </div>
         <div class="mzp-c-card-content">
           <h3 class="mzp-c-card-title">{{ _('Engage Your Users') }}</h3>

--- a/bedrock/mozorg/templates/mozorg/about/policy/lean-data/stay-lean.html
+++ b/bedrock/mozorg/templates/mozorg/about/policy/lean-data/stay-lean.html
@@ -30,7 +30,7 @@
   </div>
 
   <div class="mzp-c-hero-image">
-    {{ high_res_img('mozorg/about/lean-data/stay-lean-hero.png', {'alt': '', 'width': '424', 'height': '424'}) }}
+    {{ high_res_img('img/mozorg/about/lean-data/stay-lean-hero.png', {'alt': '', 'width': '424', 'height': '424'}) }}
   </div>
 </section>
 
@@ -114,7 +114,7 @@
     <div class="mzp-c-card mzp-has-aspect-1-1">
       <a class="mzp-c-card-block-link" href="{{ url('mozorg.about.policy.lean-data.build-security') }}">
         <div class="mzp-c-card-media-wrapper">
-          {{ high_res_img('mozorg/about/lean-data/build-security-hero.png', {'alt': '', 'width': '424', 'height': '424'}) }}
+          {{ high_res_img('img/mozorg/about/lean-data/build-security-hero.png', {'alt': '', 'width': '424', 'height': '424'}) }}
         </div>
         <div class="mzp-c-card-content">
           <h3 class="mzp-c-card-title">{{ _('Build Security') }}</h3>
@@ -126,7 +126,7 @@
     <div class="mzp-c-card mzp-has-aspect-1-1">
       <a class="mzp-c-card-block-link" href="{{ url('mozorg.about.policy.lean-data.engage-users') }}">
         <div class="mzp-c-card-media-wrapper">
-          {{ high_res_img('mozorg/about/lean-data/engage-users-hero.png', {'alt': '', 'width': '424', 'height': '424'}) }}
+          {{ high_res_img('img/mozorg/about/lean-data/engage-users-hero.png', {'alt': '', 'width': '424', 'height': '424'}) }}
         </div>
         <div class="mzp-c-card-content">
           <h3 class="mzp-c-card-title">{{ _('Engage Your Users') }}</h3>

--- a/bedrock/mozorg/templates/mozorg/contact/communities/africa-middle-east/algeria.html
+++ b/bedrock/mozorg/templates/mozorg/contact/communities/africa-middle-east/algeria.html
@@ -27,7 +27,7 @@
         </ul>
 
         <figure class="feature-img">
-          {{ high_res_img('contact/osm/communities/algeria-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
+          {{ high_res_img('img/contact/osm/communities/algeria-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
         </figure>
       </div>
 

--- a/bedrock/mozorg/templates/mozorg/contact/communities/africa-middle-east/cameroon.html
+++ b/bedrock/mozorg/templates/mozorg/contact/communities/africa-middle-east/cameroon.html
@@ -26,7 +26,7 @@
         </ul>
 
         <figure class="feature-img">
-          {{ high_res_img('contact/osm/communities/cameroon-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
+          {{ high_res_img('img/contact/osm/communities/cameroon-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
         </figure>
       </div>
 

--- a/bedrock/mozorg/templates/mozorg/contact/communities/africa-middle-east/egypt.html
+++ b/bedrock/mozorg/templates/mozorg/contact/communities/africa-middle-east/egypt.html
@@ -29,7 +29,7 @@
         </ul>
 
         <figure class="feature-img">
-          {{ high_res_img('contact/osm/communities/egypt-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
+          {{ high_res_img('img/contact/osm/communities/egypt-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
         </figure>
       </div>
     </section>

--- a/bedrock/mozorg/templates/mozorg/contact/communities/africa-middle-east/ghana.html
+++ b/bedrock/mozorg/templates/mozorg/contact/communities/africa-middle-east/ghana.html
@@ -24,7 +24,7 @@
         </ul>
 
         <figure class="feature-img">
-          {{ high_res_img('contact/osm/communities/ghana-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
+          {{ high_res_img('img/contact/osm/communities/ghana-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
         </figure>
       </div>
     </section>

--- a/bedrock/mozorg/templates/mozorg/contact/communities/africa-middle-east/israel.html
+++ b/bedrock/mozorg/templates/mozorg/contact/communities/africa-middle-east/israel.html
@@ -26,7 +26,7 @@
         </ul>
 
         <figure class="feature-img">
-          {{ high_res_img('contact/osm/communities/israel-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
+          {{ high_res_img('img/contact/osm/communities/israel-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
         </figure>
       </div>
     </section>

--- a/bedrock/mozorg/templates/mozorg/contact/communities/africa-middle-east/ivory-coast.html
+++ b/bedrock/mozorg/templates/mozorg/contact/communities/africa-middle-east/ivory-coast.html
@@ -26,7 +26,7 @@
         </ul>
 
         <figure class="feature-img">
-          {{ high_res_img('contact/osm/communities/ivory-coast-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
+          {{ high_res_img('img/contact/osm/communities/ivory-coast-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
         </figure>
       </div>
     </section>

--- a/bedrock/mozorg/templates/mozorg/contact/communities/africa-middle-east/jordan.html
+++ b/bedrock/mozorg/templates/mozorg/contact/communities/africa-middle-east/jordan.html
@@ -23,7 +23,7 @@
         </ul>
 
         <figure class="feature-img">
-          {{ high_res_img('contact/osm/communities/jordan-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
+          {{ high_res_img('img/contact/osm/communities/jordan-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
         </figure>
       </div>
     </section>

--- a/bedrock/mozorg/templates/mozorg/contact/communities/africa-middle-east/kenya.html
+++ b/bedrock/mozorg/templates/mozorg/contact/communities/africa-middle-east/kenya.html
@@ -24,7 +24,7 @@
         </ul>
 
         <figure class="feature-img">
-          {{ high_res_img('contact/osm/communities/kenya-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
+          {{ high_res_img('img/contact/osm/communities/kenya-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
         </figure>
       </div>
     </section>

--- a/bedrock/mozorg/templates/mozorg/contact/communities/africa-middle-east/mauritius.html
+++ b/bedrock/mozorg/templates/mozorg/contact/communities/africa-middle-east/mauritius.html
@@ -27,7 +27,7 @@
         </ul>
 
         <figure class="feature-img">
-          {{ high_res_img('contact/osm/communities/mauritius-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
+          {{ high_res_img('img/contact/osm/communities/mauritius-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
         </figure>
       </div>
     </section>

--- a/bedrock/mozorg/templates/mozorg/contact/communities/africa-middle-east/palestine.html
+++ b/bedrock/mozorg/templates/mozorg/contact/communities/africa-middle-east/palestine.html
@@ -23,7 +23,7 @@
         </ul>
 
         <figure class="feature-img">
-          {{ high_res_img('contact/osm/communities/palestine-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
+          {{ high_res_img('img/contact/osm/communities/palestine-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
         </figure>
       </div>
     </section>

--- a/bedrock/mozorg/templates/mozorg/contact/communities/africa-middle-east/senegal.html
+++ b/bedrock/mozorg/templates/mozorg/contact/communities/africa-middle-east/senegal.html
@@ -29,7 +29,7 @@
         </ul>
 
         <figure class="feature-img">
-          {{ high_res_img('contact/osm/communities/senegal-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
+          {{ high_res_img('img/contact/osm/communities/senegal-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
         </figure>
       </div>
     </section>

--- a/bedrock/mozorg/templates/mozorg/contact/communities/africa-middle-east/tunisia.html
+++ b/bedrock/mozorg/templates/mozorg/contact/communities/africa-middle-east/tunisia.html
@@ -29,7 +29,7 @@
         </ul>
 
         <figure class="feature-img">
-          {{ high_res_img('contact/osm/communities/tunisia-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
+          {{ high_res_img('img/contact/osm/communities/tunisia-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
         </figure>
       </div>
     </section>

--- a/bedrock/mozorg/templates/mozorg/contact/communities/africa-middle-east/uganda.html
+++ b/bedrock/mozorg/templates/mozorg/contact/communities/africa-middle-east/uganda.html
@@ -24,7 +24,7 @@
         </ul>
 
         <figure class="feature-img">
-          {{ high_res_img('contact/osm/communities/uganda-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
+          {{ high_res_img('img/contact/osm/communities/uganda-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
         </figure>
       </div>
     </section>

--- a/bedrock/mozorg/templates/mozorg/contact/communities/africa-middle-east/zimbabwe.html
+++ b/bedrock/mozorg/templates/mozorg/contact/communities/africa-middle-east/zimbabwe.html
@@ -23,7 +23,7 @@
         </ul>
 
         <figure class="feature-img">
-          {{ high_res_img('contact/osm/communities/zimbabwe-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
+          {{ high_res_img('img/contact/osm/communities/zimbabwe-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
         </figure>
       </div>
     </section>

--- a/bedrock/mozorg/templates/mozorg/contact/communities/asia-south-pacific/australia.html
+++ b/bedrock/mozorg/templates/mozorg/contact/communities/asia-south-pacific/australia.html
@@ -24,7 +24,7 @@
         </ul>
 
         <figure class="feature-img">
-          {{ high_res_img('contact/osm/communities/australia-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
+          {{ high_res_img('img/contact/osm/communities/australia-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
         </figure>
       </div>
     </section>

--- a/bedrock/mozorg/templates/mozorg/contact/communities/asia-south-pacific/bangladesh.html
+++ b/bedrock/mozorg/templates/mozorg/contact/communities/asia-south-pacific/bangladesh.html
@@ -27,7 +27,7 @@
         </ul>
 
         <figure class="feature-img">
-          {{ high_res_img('contact/osm/communities/bangladesh-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
+          {{ high_res_img('img/contact/osm/communities/bangladesh-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
         </figure>
       </div>
     </section>

--- a/bedrock/mozorg/templates/mozorg/contact/communities/asia-south-pacific/cambodia.html
+++ b/bedrock/mozorg/templates/mozorg/contact/communities/asia-south-pacific/cambodia.html
@@ -25,7 +25,7 @@
         </ul>
 
         <figure class="feature-img">
-          {{ high_res_img('contact/osm/communities/cambodia-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
+          {{ high_res_img('img/contact/osm/communities/cambodia-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
         </figure>
       </div>
 

--- a/bedrock/mozorg/templates/mozorg/contact/communities/asia-south-pacific/china.html
+++ b/bedrock/mozorg/templates/mozorg/contact/communities/asia-south-pacific/china.html
@@ -25,7 +25,7 @@
         </ul>
 
         <figure class="feature-img">
-          {{ high_res_img('contact/osm/communities/china-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
+          {{ high_res_img('img/contact/osm/communities/china-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
         </figure>
       </div>
 

--- a/bedrock/mozorg/templates/mozorg/contact/communities/asia-south-pacific/hong-kong.html
+++ b/bedrock/mozorg/templates/mozorg/contact/communities/asia-south-pacific/hong-kong.html
@@ -28,7 +28,7 @@
         </ul>
 
         <figure class="feature-img">
-          {{ high_res_img('contact/osm/communities/hong-kong-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
+          {{ high_res_img('img/contact/osm/communities/hong-kong-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
         </figure>
       </div>
     </section>

--- a/bedrock/mozorg/templates/mozorg/contact/communities/asia-south-pacific/india.html
+++ b/bedrock/mozorg/templates/mozorg/contact/communities/asia-south-pacific/india.html
@@ -31,7 +31,7 @@
         </ul>
 
         <figure class="feature-img">
-          {{ high_res_img('contact/osm/communities/india-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
+          {{ high_res_img('img/contact/osm/communities/india-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
         </figure>
       </div>
 

--- a/bedrock/mozorg/templates/mozorg/contact/communities/asia-south-pacific/indonesia.html
+++ b/bedrock/mozorg/templates/mozorg/contact/communities/asia-south-pacific/indonesia.html
@@ -29,7 +29,7 @@
         </ul>
 
         <figure class="feature-img">
-          {{ high_res_img('contact/osm/communities/indonesia-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
+          {{ high_res_img('img/contact/osm/communities/indonesia-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
         </figure>
       </div>
 

--- a/bedrock/mozorg/templates/mozorg/contact/communities/asia-south-pacific/japan.html
+++ b/bedrock/mozorg/templates/mozorg/contact/communities/asia-south-pacific/japan.html
@@ -25,7 +25,7 @@
         </ul>
 
         <figure class="feature-img">
-          {{ high_res_img('contact/osm/communities/japan-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
+          {{ high_res_img('img/contact/osm/communities/japan-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
         </figure>
       </div>
 

--- a/bedrock/mozorg/templates/mozorg/contact/communities/asia-south-pacific/kerala.html
+++ b/bedrock/mozorg/templates/mozorg/contact/communities/asia-south-pacific/kerala.html
@@ -27,7 +27,7 @@
         </ul>
 
         <figure class="feature-img">
-          {{ high_res_img('contact/osm/communities/kerala-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
+          {{ high_res_img('img/contact/osm/communities/kerala-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
         </figure>
       </div>
     </section>

--- a/bedrock/mozorg/templates/mozorg/contact/communities/asia-south-pacific/malaysia.html
+++ b/bedrock/mozorg/templates/mozorg/contact/communities/asia-south-pacific/malaysia.html
@@ -29,7 +29,7 @@
         </ul>
 
         <figure class="feature-img">
-          {{ high_res_img('contact/osm/communities/malaysia-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
+          {{ high_res_img('img/contact/osm/communities/malaysia-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
         </figure>
       </div>
     </section>

--- a/bedrock/mozorg/templates/mozorg/contact/communities/asia-south-pacific/myanmar.html
+++ b/bedrock/mozorg/templates/mozorg/contact/communities/asia-south-pacific/myanmar.html
@@ -29,7 +29,7 @@
         </ul>
 
         <figure class="feature-img">
-          {{ high_res_img('contact/osm/communities/myanmar-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
+          {{ high_res_img('img/contact/osm/communities/myanmar-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
         </figure>
       </div>
 

--- a/bedrock/mozorg/templates/mozorg/contact/communities/asia-south-pacific/nepal.html
+++ b/bedrock/mozorg/templates/mozorg/contact/communities/asia-south-pacific/nepal.html
@@ -29,7 +29,7 @@
         </ul>
 
         <figure class="feature-img">
-          {{ high_res_img('contact/osm/communities/nepal-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
+          {{ high_res_img('img/contact/osm/communities/nepal-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
         </figure>
       </div>
     </section>

--- a/bedrock/mozorg/templates/mozorg/contact/communities/asia-south-pacific/pakistan.html
+++ b/bedrock/mozorg/templates/mozorg/contact/communities/asia-south-pacific/pakistan.html
@@ -27,7 +27,7 @@
           <li><a href="https://flickr.com/photos/mozpk" class="flickr">Flickr</a></li>
         </ul>
         <figure class="feature-img">
-          {{ high_res_img('contact/osm/communities/pakistan-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
+          {{ high_res_img('img/contact/osm/communities/pakistan-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
         </figure>
       </div>
     </section>

--- a/bedrock/mozorg/templates/mozorg/contact/communities/asia-south-pacific/philippines.html
+++ b/bedrock/mozorg/templates/mozorg/contact/communities/asia-south-pacific/philippines.html
@@ -29,7 +29,7 @@
         </ul>
 
         <figure class="feature-img">
-          {{ high_res_img('contact/osm/communities/philippines-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
+          {{ high_res_img('img/contact/osm/communities/philippines-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
         </figure>
       </div>
 

--- a/bedrock/mozorg/templates/mozorg/contact/communities/asia-south-pacific/singapore.html
+++ b/bedrock/mozorg/templates/mozorg/contact/communities/asia-south-pacific/singapore.html
@@ -19,7 +19,7 @@
         <h2>{{ _('Singapore') }}</h2>
 
         <figure class="feature-img">
-          {{ high_res_img('contact/osm/communities/singapore-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
+          {{ high_res_img('img/contact/osm/communities/singapore-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
         </figure>
       </div>
     </section>

--- a/bedrock/mozorg/templates/mozorg/contact/communities/asia-south-pacific/south-korea.html
+++ b/bedrock/mozorg/templates/mozorg/contact/communities/asia-south-pacific/south-korea.html
@@ -28,7 +28,7 @@
         </ul>
 
         <figure class="feature-img">
-          {{ high_res_img('contact/osm/communities/south-korea-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
+          {{ high_res_img('img/contact/osm/communities/south-korea-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
         </figure>
       </div>
 

--- a/bedrock/mozorg/templates/mozorg/contact/communities/asia-south-pacific/sri-lanka.html
+++ b/bedrock/mozorg/templates/mozorg/contact/communities/asia-south-pacific/sri-lanka.html
@@ -25,7 +25,7 @@
         </ul>
 
         <figure class="feature-img">
-          {{ high_res_img('contact/osm/communities/sri-lanka-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
+          {{ high_res_img('img/contact/osm/communities/sri-lanka-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
         </figure>
       </div>
     </section>

--- a/bedrock/mozorg/templates/mozorg/contact/communities/asia-south-pacific/taiwan.html
+++ b/bedrock/mozorg/templates/mozorg/contact/communities/asia-south-pacific/taiwan.html
@@ -31,7 +31,7 @@
         </ul>
 
         <figure class="feature-img">
-          {{ high_res_img('contact/osm/communities/taiwan-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
+          {{ high_res_img('img/contact/osm/communities/taiwan-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
         </figure>
       </div>
 

--- a/bedrock/mozorg/templates/mozorg/contact/communities/asia-south-pacific/thailand.html
+++ b/bedrock/mozorg/templates/mozorg/contact/communities/asia-south-pacific/thailand.html
@@ -25,7 +25,7 @@
         </ul>
 
         <figure class="feature-img">
-          {{ high_res_img('contact/osm/communities/thailand-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
+          {{ high_res_img('img/contact/osm/communities/thailand-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
         </figure>
       </div>
 

--- a/bedrock/mozorg/templates/mozorg/contact/communities/asia-south-pacific/vietnam.html
+++ b/bedrock/mozorg/templates/mozorg/contact/communities/asia-south-pacific/vietnam.html
@@ -25,7 +25,7 @@
         </ul>
 
         <figure class="feature-img">
-          {{ high_res_img('contact/osm/communities/vietnam-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
+          {{ high_res_img('img/contact/osm/communities/vietnam-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
         </figure>
       </div>
     </section>

--- a/bedrock/mozorg/templates/mozorg/contact/communities/europe/albania.html
+++ b/bedrock/mozorg/templates/mozorg/contact/communities/europe/albania.html
@@ -28,7 +28,7 @@
         </ul>
 
         <figure class="feature-img">
-          {{ high_res_img('contact/osm/communities/albania-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
+          {{ high_res_img('img/contact/osm/communities/albania-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
         </figure>
       </div>
 

--- a/bedrock/mozorg/templates/mozorg/contact/communities/europe/armenia.html
+++ b/bedrock/mozorg/templates/mozorg/contact/communities/europe/armenia.html
@@ -25,7 +25,7 @@
         </ul>
 
         <figure class="feature-img">
-          {{ high_res_img('contact/osm/communities/armenia-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
+          {{ high_res_img('img/contact/osm/communities/armenia-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
         </figure>
       </div>
     </section>

--- a/bedrock/mozorg/templates/mozorg/contact/communities/europe/austria.html
+++ b/bedrock/mozorg/templates/mozorg/contact/communities/europe/austria.html
@@ -23,7 +23,7 @@
         </ul>
 
         <figure class="feature-img">
-          {{ high_res_img('contact/osm/communities/austria-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
+          {{ high_res_img('img/contact/osm/communities/austria-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
         </figure>
       </div>
     </section>

--- a/bedrock/mozorg/templates/mozorg/contact/communities/europe/basque.html
+++ b/bedrock/mozorg/templates/mozorg/contact/communities/europe/basque.html
@@ -25,7 +25,7 @@
         </ul>
 
         <figure class="feature-img">
-          {{ high_res_img('contact/osm/communities/basque-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
+          {{ high_res_img('img/contact/osm/communities/basque-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
         </figure>
       </div>
     </section>

--- a/bedrock/mozorg/templates/mozorg/contact/communities/europe/belgium.html
+++ b/bedrock/mozorg/templates/mozorg/contact/communities/europe/belgium.html
@@ -27,7 +27,7 @@
         </ul>
 
         <figure class="feature-img">
-          {{ high_res_img('contact/osm/communities/belgium-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
+          {{ high_res_img('img/contact/osm/communities/belgium-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
         </figure>
       </div>
     </section>

--- a/bedrock/mozorg/templates/mozorg/contact/communities/europe/bosnia-and-herzegovina.html
+++ b/bedrock/mozorg/templates/mozorg/contact/communities/europe/bosnia-and-herzegovina.html
@@ -23,7 +23,7 @@
         </ul>
 
         <figure class="feature-img">
-          {{ high_res_img('contact/osm/communities/bosnia-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
+          {{ high_res_img('img/contact/osm/communities/bosnia-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
         </figure>
       </div>
     </section>

--- a/bedrock/mozorg/templates/mozorg/contact/communities/europe/bulgaria.html
+++ b/bedrock/mozorg/templates/mozorg/contact/communities/europe/bulgaria.html
@@ -24,7 +24,7 @@
         </ul>
 
         <figure class="feature-img">
-          {{ high_res_img('contact/osm/communities/bulgaria-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
+          {{ high_res_img('img/contact/osm/communities/bulgaria-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
         </figure>
       </div>
     </section>

--- a/bedrock/mozorg/templates/mozorg/contact/communities/europe/catalan.html
+++ b/bedrock/mozorg/templates/mozorg/contact/communities/europe/catalan.html
@@ -27,7 +27,7 @@
         </ul>
 
         <figure class="feature-img">
-          {{ high_res_img('contact/osm/communities/catalan-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
+          {{ high_res_img('img/contact/osm/communities/catalan-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
         </figure>
       </div>
     </section>

--- a/bedrock/mozorg/templates/mozorg/contact/communities/europe/croatia.html
+++ b/bedrock/mozorg/templates/mozorg/contact/communities/europe/croatia.html
@@ -27,7 +27,7 @@
         </ul>
 
         <figure class="feature-img">
-          {{ high_res_img('contact/osm/communities/croatia-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
+          {{ high_res_img('img/contact/osm/communities/croatia-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
         </figure>
       </div>
     </section>

--- a/bedrock/mozorg/templates/mozorg/contact/communities/europe/czech-republic.html
+++ b/bedrock/mozorg/templates/mozorg/contact/communities/europe/czech-republic.html
@@ -30,7 +30,7 @@
         </ul>
 
         <figure class="feature-img">
-          {{ high_res_img('contact/osm/communities/czech-republic-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
+          {{ high_res_img('img/contact/osm/communities/czech-republic-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
         </figure>
       </div>
 

--- a/bedrock/mozorg/templates/mozorg/contact/communities/europe/denmark.html
+++ b/bedrock/mozorg/templates/mozorg/contact/communities/europe/denmark.html
@@ -26,7 +26,7 @@
         </ul>
 
         <figure class="feature-img">
-          {{ high_res_img('contact/osm/communities/denmark-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
+          {{ high_res_img('img/contact/osm/communities/denmark-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
         </figure>
       </div>
     </section>

--- a/bedrock/mozorg/templates/mozorg/contact/communities/europe/estonia.html
+++ b/bedrock/mozorg/templates/mozorg/contact/communities/europe/estonia.html
@@ -26,7 +26,7 @@
         </ul>
 
         <figure class="feature-img">
-          {{ high_res_img('contact/osm/communities/estonia-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
+          {{ high_res_img('img/contact/osm/communities/estonia-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
         </figure>
       </div>
 

--- a/bedrock/mozorg/templates/mozorg/contact/communities/europe/finland.html
+++ b/bedrock/mozorg/templates/mozorg/contact/communities/europe/finland.html
@@ -23,7 +23,7 @@
         </ul>
 
         <figure class="feature-img">
-          {{ high_res_img('contact/osm/communities/finland-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
+          {{ high_res_img('img/contact/osm/communities/finland-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
         </figure>
       </div>
     </section>

--- a/bedrock/mozorg/templates/mozorg/contact/communities/europe/france.html
+++ b/bedrock/mozorg/templates/mozorg/contact/communities/europe/france.html
@@ -27,7 +27,7 @@
         </ul>
 
         <figure class="feature-img">
-          {{ high_res_img('contact/osm/communities/france-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
+          {{ high_res_img('img/contact/osm/communities/france-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
         </figure>
       </div>
 

--- a/bedrock/mozorg/templates/mozorg/contact/communities/europe/germany.html
+++ b/bedrock/mozorg/templates/mozorg/contact/communities/europe/germany.html
@@ -27,7 +27,7 @@
         </ul>
 
         <figure class="feature-img">
-          {{ high_res_img('contact/osm/communities/germany-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
+          {{ high_res_img('img/contact/osm/communities/germany-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
         </figure>
       </div>
 

--- a/bedrock/mozorg/templates/mozorg/contact/communities/europe/greece.html
+++ b/bedrock/mozorg/templates/mozorg/contact/communities/europe/greece.html
@@ -26,7 +26,7 @@
         </ul>
 
         <figure class="feature-img">
-          {{ high_res_img('contact/osm/communities/greece-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
+          {{ high_res_img('img/contact/osm/communities/greece-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
         </figure>
       </div>
 

--- a/bedrock/mozorg/templates/mozorg/contact/communities/europe/hungary.html
+++ b/bedrock/mozorg/templates/mozorg/contact/communities/europe/hungary.html
@@ -24,7 +24,7 @@
         </ul>
 
         <figure class="feature-img">
-          {{ high_res_img('contact/osm/communities/hungary-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
+          {{ high_res_img('img/contact/osm/communities/hungary-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
         </figure>
       </div>
     </section>

--- a/bedrock/mozorg/templates/mozorg/contact/communities/europe/ireland.html
+++ b/bedrock/mozorg/templates/mozorg/contact/communities/europe/ireland.html
@@ -27,7 +27,7 @@
         </ul>
 
         <figure class="feature-img">
-          {{ high_res_img('contact/osm/communities/ireland-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
+          {{ high_res_img('img/contact/osm/communities/ireland-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
         </figure>
       </div>
 

--- a/bedrock/mozorg/templates/mozorg/contact/communities/europe/italy.html
+++ b/bedrock/mozorg/templates/mozorg/contact/communities/europe/italy.html
@@ -26,7 +26,7 @@
         </ul>
 
         <figure class="feature-img">
-          {{ high_res_img('contact/osm/communities/italy-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
+          {{ high_res_img('img/contact/osm/communities/italy-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
         </figure>
       </div>
 

--- a/bedrock/mozorg/templates/mozorg/contact/communities/europe/kosovo.html
+++ b/bedrock/mozorg/templates/mozorg/contact/communities/europe/kosovo.html
@@ -23,7 +23,7 @@
         </ul>
 
         <figure class="feature-img">
-          {{ high_res_img('contact/osm/communities/kosovo-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
+          {{ high_res_img('img/contact/osm/communities/kosovo-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
         </figure>
       </div>
     </section>

--- a/bedrock/mozorg/templates/mozorg/contact/communities/europe/lithuania.html
+++ b/bedrock/mozorg/templates/mozorg/contact/communities/europe/lithuania.html
@@ -25,7 +25,7 @@
         </ul>
 
         <figure class="feature-img">
-          {{ high_res_img('contact/osm/communities/lithuania-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
+          {{ high_res_img('img/contact/osm/communities/lithuania-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
         </figure>
       </div>
     </section>

--- a/bedrock/mozorg/templates/mozorg/contact/communities/europe/macedonia.html
+++ b/bedrock/mozorg/templates/mozorg/contact/communities/europe/macedonia.html
@@ -26,7 +26,7 @@
         </ul>
 
         <figure class="feature-img">
-          {{ high_res_img('contact/osm/communities/macedonia-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
+          {{ high_res_img('img/contact/osm/communities/macedonia-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
         </figure>
       </div>
 

--- a/bedrock/mozorg/templates/mozorg/contact/communities/europe/montenegro.html
+++ b/bedrock/mozorg/templates/mozorg/contact/communities/europe/montenegro.html
@@ -27,7 +27,7 @@
         </ul>
 
         <figure class="feature-img">
-          {{ high_res_img('contact/osm/communities/montenegro-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
+          {{ high_res_img('img/contact/osm/communities/montenegro-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
         </figure>
       </div>
 

--- a/bedrock/mozorg/templates/mozorg/contact/communities/europe/norway.html
+++ b/bedrock/mozorg/templates/mozorg/contact/communities/europe/norway.html
@@ -24,7 +24,7 @@
         </ul>
 
         <figure class="feature-img">
-          {{ high_res_img('contact/osm/communities/norway-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
+          {{ high_res_img('img/contact/osm/communities/norway-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
         </figure>
       </div>
     </section>

--- a/bedrock/mozorg/templates/mozorg/contact/communities/europe/poland.html
+++ b/bedrock/mozorg/templates/mozorg/contact/communities/europe/poland.html
@@ -27,7 +27,7 @@
         </ul>
 
         <figure class="feature-img">
-          {{ high_res_img('contact/osm/communities/poland-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
+          {{ high_res_img('img/contact/osm/communities/poland-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
         </figure>
       </div>
 

--- a/bedrock/mozorg/templates/mozorg/contact/communities/europe/portugal.html
+++ b/bedrock/mozorg/templates/mozorg/contact/communities/europe/portugal.html
@@ -24,7 +24,7 @@
         </ul>
 
         <figure class="feature-img">
-          {{ high_res_img('contact/osm/communities/portugal-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
+          {{ high_res_img('img/contact/osm/communities/portugal-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
         </figure>
       </div>
     </section>

--- a/bedrock/mozorg/templates/mozorg/contact/communities/europe/romania.html
+++ b/bedrock/mozorg/templates/mozorg/contact/communities/europe/romania.html
@@ -28,7 +28,7 @@
         </ul>
 
         <figure class="feature-img">
-          {{ high_res_img('contact/osm/communities/romania-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
+          {{ high_res_img('img/contact/osm/communities/romania-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
         </figure>
       </div>
 

--- a/bedrock/mozorg/templates/mozorg/contact/communities/europe/russia.html
+++ b/bedrock/mozorg/templates/mozorg/contact/communities/europe/russia.html
@@ -28,7 +28,7 @@
         </ul>
 
         <figure class="feature-img">
-          {{ high_res_img('contact/osm/communities/russia-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
+          {{ high_res_img('img/contact/osm/communities/russia-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
         </figure>
       </div>
     </section>

--- a/bedrock/mozorg/templates/mozorg/contact/communities/europe/serbia.html
+++ b/bedrock/mozorg/templates/mozorg/contact/communities/europe/serbia.html
@@ -23,7 +23,7 @@
         </ul>
 
         <figure class="feature-img">
-          {{ high_res_img('contact/osm/communities/serbia-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
+          {{ high_res_img('img/contact/osm/communities/serbia-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
         </figure>
       </div>
     </section>

--- a/bedrock/mozorg/templates/mozorg/contact/communities/europe/slovakia.html
+++ b/bedrock/mozorg/templates/mozorg/contact/communities/europe/slovakia.html
@@ -23,7 +23,7 @@
         </ul>
 
         <figure class="feature-img">
-          {{ high_res_img('contact/osm/communities/slovakia-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
+          {{ high_res_img('img/contact/osm/communities/slovakia-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
         </figure>
       </div>
     </section>

--- a/bedrock/mozorg/templates/mozorg/contact/communities/europe/slovenia.html
+++ b/bedrock/mozorg/templates/mozorg/contact/communities/europe/slovenia.html
@@ -27,7 +27,7 @@
         </ul>
 
         <figure class="feature-img">
-          {{ high_res_img('contact/osm/communities/slovenia-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
+          {{ high_res_img('img/contact/osm/communities/slovenia-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
         </figure>
       </div>
 

--- a/bedrock/mozorg/templates/mozorg/contact/communities/europe/spain.html
+++ b/bedrock/mozorg/templates/mozorg/contact/communities/europe/spain.html
@@ -28,7 +28,7 @@
         </ul>
 
         <figure class="feature-img">
-          {{ high_res_img('contact/osm/communities/spain-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
+          {{ high_res_img('img/contact/osm/communities/spain-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
         </figure>
       </div>
     </section>

--- a/bedrock/mozorg/templates/mozorg/contact/communities/europe/sweden.html
+++ b/bedrock/mozorg/templates/mozorg/contact/communities/europe/sweden.html
@@ -25,7 +25,7 @@
         </ul>
 
         <figure class="feature-img">
-          {{ high_res_img('contact/osm/communities/sweden-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
+          {{ high_res_img('img/contact/osm/communities/sweden-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
         </figure>
       </div>
 

--- a/bedrock/mozorg/templates/mozorg/contact/communities/europe/switzerland.html
+++ b/bedrock/mozorg/templates/mozorg/contact/communities/europe/switzerland.html
@@ -26,7 +26,7 @@
         </ul>
 
         <figure class="feature-img">
-          {{ high_res_img('contact/osm/communities/switzerland-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
+          {{ high_res_img('img/contact/osm/communities/switzerland-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
         </figure>
       </div>
 

--- a/bedrock/mozorg/templates/mozorg/contact/communities/europe/the-netherlands.html
+++ b/bedrock/mozorg/templates/mozorg/contact/communities/europe/the-netherlands.html
@@ -28,7 +28,7 @@
         </ul>
 
         <figure class="feature-img">
-          {{ high_res_img('contact/osm/communities/the-netherlands-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
+          {{ high_res_img('img/contact/osm/communities/the-netherlands-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
         </figure>
       </div>
     </section>

--- a/bedrock/mozorg/templates/mozorg/contact/communities/europe/turkey.html
+++ b/bedrock/mozorg/templates/mozorg/contact/communities/europe/turkey.html
@@ -28,7 +28,7 @@
         </ul>
 
         <figure class="feature-img">
-          {{ high_res_img('contact/osm/communities/turkey-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
+          {{ high_res_img('img/contact/osm/communities/turkey-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
         </figure>
       </div>
     </section>

--- a/bedrock/mozorg/templates/mozorg/contact/communities/europe/ukraine.html
+++ b/bedrock/mozorg/templates/mozorg/contact/communities/europe/ukraine.html
@@ -23,7 +23,7 @@
         </ul>
 
         <figure class="feature-img">
-          {{ high_res_img('contact/osm/communities/ukraine-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
+          {{ high_res_img('img/contact/osm/communities/ukraine-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
         </figure>
       </div>
     </section>

--- a/bedrock/mozorg/templates/mozorg/contact/communities/europe/united-kingdom.html
+++ b/bedrock/mozorg/templates/mozorg/contact/communities/europe/united-kingdom.html
@@ -27,7 +27,7 @@
         </ul>
 
         <figure class="feature-img">
-          {{ high_res_img('contact/osm/communities/united-kingdom-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
+          {{ high_res_img('img/contact/osm/communities/united-kingdom-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
         </figure>
       </div>
     </section>

--- a/bedrock/mozorg/templates/mozorg/contact/communities/latin-america/argentina.html
+++ b/bedrock/mozorg/templates/mozorg/contact/communities/latin-america/argentina.html
@@ -26,7 +26,7 @@
         </ul>
 
         <figure class="feature-img">
-          {{ high_res_img('contact/osm/communities/argentina-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
+          {{ high_res_img('img/contact/osm/communities/argentina-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
         </figure>
       </div>
     </section>

--- a/bedrock/mozorg/templates/mozorg/contact/communities/latin-america/bolivia.html
+++ b/bedrock/mozorg/templates/mozorg/contact/communities/latin-america/bolivia.html
@@ -27,7 +27,7 @@
         </ul>
 
         <figure class="feature-img">
-          {{ high_res_img('contact/osm/communities/bolivia-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
+          {{ high_res_img('img/contact/osm/communities/bolivia-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
         </figure>
       </div>
 

--- a/bedrock/mozorg/templates/mozorg/contact/communities/latin-america/brazil.html
+++ b/bedrock/mozorg/templates/mozorg/contact/communities/latin-america/brazil.html
@@ -26,7 +26,7 @@
         </ul>
 
         <figure class="feature-img">
-          {{ high_res_img('contact/osm/communities/brazil-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
+          {{ high_res_img('img/contact/osm/communities/brazil-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
         </figure>
       </div>
 

--- a/bedrock/mozorg/templates/mozorg/contact/communities/latin-america/chile.html
+++ b/bedrock/mozorg/templates/mozorg/contact/communities/latin-america/chile.html
@@ -26,7 +26,7 @@
         </ul>
 
         <figure class="feature-img">
-          {{ high_res_img('contact/osm/communities/chile-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
+          {{ high_res_img('img/contact/osm/communities/chile-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
         </figure>
       </div>
 

--- a/bedrock/mozorg/templates/mozorg/contact/communities/latin-america/colombia.html
+++ b/bedrock/mozorg/templates/mozorg/contact/communities/latin-america/colombia.html
@@ -26,7 +26,7 @@
         </ul>
 
         <figure class="feature-img">
-          {{ high_res_img('contact/osm/communities/colombia-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
+          {{ high_res_img('img/contact/osm/communities/colombia-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
         </figure>
       </div>
     </section>

--- a/bedrock/mozorg/templates/mozorg/contact/communities/latin-america/costa-rica.html
+++ b/bedrock/mozorg/templates/mozorg/contact/communities/latin-america/costa-rica.html
@@ -25,7 +25,7 @@
         </ul>
 
         <figure class="feature-img">
-          {{ high_res_img('contact/osm/communities/costa-rica-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
+          {{ high_res_img('img/contact/osm/communities/costa-rica-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
         </figure>
       </div>
     </section>

--- a/bedrock/mozorg/templates/mozorg/contact/communities/latin-america/cuba.html
+++ b/bedrock/mozorg/templates/mozorg/contact/communities/latin-america/cuba.html
@@ -25,7 +25,7 @@
         </ul>
 
         <figure class="feature-img">
-          {{ high_res_img('contact/osm/communities/cuba-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
+          {{ high_res_img('img/contact/osm/communities/cuba-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
         </figure>
       </div>
     </section>

--- a/bedrock/mozorg/templates/mozorg/contact/communities/latin-america/ecuador.html
+++ b/bedrock/mozorg/templates/mozorg/contact/communities/latin-america/ecuador.html
@@ -25,7 +25,7 @@
         </ul>
 
         <figure class="feature-img">
-          {{ high_res_img('contact/osm/communities/ecuador-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
+          {{ high_res_img('img/contact/osm/communities/ecuador-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
         </figure>
       </div>
     </section>

--- a/bedrock/mozorg/templates/mozorg/contact/communities/latin-america/mexico.html
+++ b/bedrock/mozorg/templates/mozorg/contact/communities/latin-america/mexico.html
@@ -29,7 +29,7 @@
         </ul>
 
         <figure class="feature-img">
-          {{ high_res_img('contact/osm/communities/mexico-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
+          {{ high_res_img('img/contact/osm/communities/mexico-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
         </figure>
       </div>
 

--- a/bedrock/mozorg/templates/mozorg/contact/communities/latin-america/nicaragua.html
+++ b/bedrock/mozorg/templates/mozorg/contact/communities/latin-america/nicaragua.html
@@ -27,7 +27,7 @@
         </ul>
 
         <figure class="feature-img">
-          {{ high_res_img('contact/osm/communities/nicaragua-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
+          {{ high_res_img('img/contact/osm/communities/nicaragua-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
         </figure>
       </div>
 

--- a/bedrock/mozorg/templates/mozorg/contact/communities/latin-america/paraguay.html
+++ b/bedrock/mozorg/templates/mozorg/contact/communities/latin-america/paraguay.html
@@ -26,7 +26,7 @@
         </ul>
 
         <figure class="feature-img">
-          {{ high_res_img('contact/osm/communities/paraguay-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
+          {{ high_res_img('img/contact/osm/communities/paraguay-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
         </figure>
       </div>
 

--- a/bedrock/mozorg/templates/mozorg/contact/communities/latin-america/peru.html
+++ b/bedrock/mozorg/templates/mozorg/contact/communities/latin-america/peru.html
@@ -27,7 +27,7 @@
         </ul>
 
         <figure class="feature-img">
-          {{ high_res_img('contact/osm/communities/peru-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
+          {{ high_res_img('img/contact/osm/communities/peru-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
         </figure>
       </div>
 

--- a/bedrock/mozorg/templates/mozorg/contact/communities/latin-america/uruguay.html
+++ b/bedrock/mozorg/templates/mozorg/contact/communities/latin-america/uruguay.html
@@ -24,7 +24,7 @@
         </ul>
 
         <figure class="feature-img">
-          {{ high_res_img('contact/osm/communities/uruguay-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
+          {{ high_res_img('img/contact/osm/communities/uruguay-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
         </figure>
       </div>
     </section>

--- a/bedrock/mozorg/templates/mozorg/contact/communities/latin-america/venezuela.html
+++ b/bedrock/mozorg/templates/mozorg/contact/communities/latin-america/venezuela.html
@@ -28,7 +28,7 @@
         </ul>
 
         <figure class="feature-img">
-          {{ high_res_img('contact/osm/communities/venezuela-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
+          {{ high_res_img('img/contact/osm/communities/venezuela-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
         </figure>
       </div>
 

--- a/bedrock/mozorg/templates/mozorg/contact/communities/north-america/canada.html
+++ b/bedrock/mozorg/templates/mozorg/contact/communities/north-america/canada.html
@@ -24,7 +24,7 @@
         </ul>
 
         <figure class="feature-img">
-          {{ high_res_img('contact/osm/communities/canada-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
+          {{ high_res_img('img/contact/osm/communities/canada-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
         </figure>
       </div>
     </section>

--- a/bedrock/mozorg/templates/mozorg/contact/communities/north-america/united-states.html
+++ b/bedrock/mozorg/templates/mozorg/contact/communities/north-america/united-states.html
@@ -24,7 +24,7 @@
         </ul>
 
         <figure class="feature-img">
-          {{ high_res_img('contact/osm/communities/united-states-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
+          {{ high_res_img('img/contact/osm/communities/united-states-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
         </figure>
       </div>
     </section>

--- a/bedrock/mozorg/templates/mozorg/contact/communities/other/balkans.html
+++ b/bedrock/mozorg/templates/mozorg/contact/communities/other/balkans.html
@@ -28,7 +28,7 @@
         </ul>
 
         <figure class="feature-img">
-          {{ high_res_img('contact/osm/communities/balklans-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
+          {{ high_res_img('img/contact/osm/communities/balklans-small.png', {'alt': '', 'width': '380', 'height': '250'}) }}
         </figure>
       </div>
 

--- a/bedrock/mozorg/templates/mozorg/contact/spaces/beijing.html
+++ b/bedrock/mozorg/templates/mozorg/contact/spaces/beijing.html
@@ -33,7 +33,7 @@
         </p>
 
         <figure class="feature-img">
-          {{ high_res_img('contact/osm/spaces/beijing-small.png', {'alt': '', 'width': '460', 'height': '250'}) }}
+          {{ high_res_img('img/contact/osm/spaces/beijing-small.png', {'alt': '', 'width': '460', 'height': '250'}) }}
         </figure>
       </div>
 

--- a/bedrock/mozorg/templates/mozorg/contact/spaces/berlin.html
+++ b/bedrock/mozorg/templates/mozorg/contact/spaces/berlin.html
@@ -38,7 +38,7 @@
         </ul>
 
         <figure class="feature-img">
-          {{ high_res_img('contact/osm/spaces/berlin-small.png', {'alt': '', 'width': '460', 'height': '250'}) }}
+          {{ high_res_img('img/contact/osm/spaces/berlin-small.png', {'alt': '', 'width': '460', 'height': '250'}) }}
         </figure>
       </div>
 

--- a/bedrock/mozorg/templates/mozorg/contact/spaces/london.html
+++ b/bedrock/mozorg/templates/mozorg/contact/spaces/london.html
@@ -37,7 +37,7 @@
         </ul>
 
         <figure class="feature-img">
-          {{ high_res_img('contact/osm/spaces/london-small.png', {'alt': '', 'width': '460', 'height': '250'}) }}
+          {{ high_res_img('img/contact/osm/spaces/london-small.png', {'alt': '', 'width': '460', 'height': '250'}) }}
         </figure>
       </div>
 

--- a/bedrock/mozorg/templates/mozorg/contact/spaces/mountain-view.html
+++ b/bedrock/mozorg/templates/mozorg/contact/spaces/mountain-view.html
@@ -37,7 +37,7 @@
         </ul>
 
         <figure class="feature-img">
-          {{ high_res_img('contact/osm/spaces/mountain-view-small.png', {'alt': '', 'width': '460', 'height': '250'}) }}
+          {{ high_res_img('img/contact/osm/spaces/mountain-view-small.png', {'alt': '', 'width': '460', 'height': '250'}) }}
         </figure>
       </div>
 

--- a/bedrock/mozorg/templates/mozorg/contact/spaces/paris.html
+++ b/bedrock/mozorg/templates/mozorg/contact/spaces/paris.html
@@ -37,7 +37,7 @@
         </ul>
 
         <figure class="feature-img">
-          {{ high_res_img('contact/osm/spaces/paris-small.png', {'alt': '', 'width': '460', 'height': '250'}) }}
+          {{ high_res_img('img/contact/osm/spaces/paris-small.png', {'alt': '', 'width': '460', 'height': '250'}) }}
         </figure>
       </div>
 

--- a/bedrock/mozorg/templates/mozorg/contact/spaces/portland.html
+++ b/bedrock/mozorg/templates/mozorg/contact/spaces/portland.html
@@ -37,7 +37,7 @@
         </ul>
 
         <figure class="feature-img">
-          {{ high_res_img('contact/osm/spaces/portland-small.png', {'alt': '', 'width': '460', 'height': '250'}) }}
+          {{ high_res_img('img/contact/osm/spaces/portland-small.png', {'alt': '', 'width': '460', 'height': '250'}) }}
         </figure>
       </div>
 

--- a/bedrock/mozorg/templates/mozorg/contact/spaces/san-francisco.html
+++ b/bedrock/mozorg/templates/mozorg/contact/spaces/san-francisco.html
@@ -37,7 +37,7 @@
         </ul>
 
         <figure class="feature-img">
-          {{ high_res_img('contact/osm/spaces/san-francisco-small.png', {'alt': '', 'width': '460', 'height': '250'}) }}
+          {{ high_res_img('img/contact/osm/spaces/san-francisco-small.png', {'alt': '', 'width': '460', 'height': '250'}) }}
         </figure>
       </div>
 

--- a/bedrock/mozorg/templates/mozorg/contact/spaces/taipei.html
+++ b/bedrock/mozorg/templates/mozorg/contact/spaces/taipei.html
@@ -36,7 +36,7 @@
         </ul>
 
         <figure class="feature-img">
-          {{ high_res_img('contact/osm/spaces/taipei-small.png', {'alt': '', 'width': '460', 'height': '250'}) }}
+          {{ high_res_img('img/contact/osm/spaces/taipei-small.png', {'alt': '', 'width': '460', 'height': '250'}) }}
         </figure>
       </div>
 

--- a/bedrock/mozorg/templates/mozorg/contact/spaces/toronto.html
+++ b/bedrock/mozorg/templates/mozorg/contact/spaces/toronto.html
@@ -39,7 +39,7 @@
         </ul>
 
         <figure class="feature-img">
-          {{ high_res_img('contact/osm/spaces/toronto-small.png', {'alt': '', 'width': '460', 'height': '250'}) }}
+          {{ high_res_img('img/contact/osm/spaces/toronto-small.png', {'alt': '', 'width': '460', 'height': '250'}) }}
         </figure>
       </div>
 

--- a/bedrock/mozorg/templates/mozorg/contact/spaces/vancouver.html
+++ b/bedrock/mozorg/templates/mozorg/contact/spaces/vancouver.html
@@ -36,7 +36,7 @@
         </ul>
 
         <figure class="feature-img">
-          {{ high_res_img('contact/osm/spaces/vancouver-small.png', {'alt': '', 'width': '460', 'height': '250'}) }}
+          {{ high_res_img('img/contact/osm/spaces/vancouver-small.png', {'alt': '', 'width': '460', 'height': '250'}) }}
         </figure>
       </div>
 

--- a/bedrock/mozorg/templates/mozorg/developer/css-grid-demo.html
+++ b/bedrock/mozorg/templates/mozorg/developer/css-grid-demo.html
@@ -506,7 +506,7 @@
       <ol class="gallery inspector-steps">
         <li>
           <figure>
-            {{ high_res_img('mozorg/developer/css-grid/inspect-step1.jpg', {'alt': '', 'width': '440', 'height': '242', 'class': 'screenshot'}) }}
+            {{ high_res_img('img/mozorg/developer/css-grid/inspect-step1.jpg', {'alt': '', 'width': '440', 'height': '242', 'class': 'screenshot'}) }}
             <figcaption>
             {% trans %}
               In Firefox, right click and select “Inspect Element.”
@@ -516,9 +516,9 @@
         </li>
         <li>
           <figure>
-            {{ high_res_img('mozorg/developer/css-grid/inspect-step2.jpg', {'alt': '', 'width': '440', 'height': '242', 'class': 'screenshot'}) }}
+            {{ high_res_img('img/mozorg/developer/css-grid/inspect-step2.jpg', {'alt': '', 'width': '440', 'height': '242', 'class': 'screenshot'}) }}
             <figcaption>
-            {% trans grid_icon=high_res_img('mozorg/developer/css-grid/grid-icon.png', {'alt': 'Grid', 'width': '12', 'height': '12'}) %}
+            {% trans grid_icon=high_res_img('img/mozorg/developer/css-grid/grid-icon.png', {'alt': 'Grid', 'width': '12', 'height': '12'}) %}
               In the Developer Tools, find an element with a <code>display: grid;</code> declaration and click the {{ grid_icon }} icon.
             {% endtrans %}
             </figcaption>
@@ -526,7 +526,7 @@
         </li>
         <li>
           <figure>
-            {{ high_res_img('mozorg/developer/css-grid/inspect-step3.jpg', {'alt': '', 'width': '440', 'height': '242', 'class': 'screenshot'}) }}
+            {{ high_res_img('img/mozorg/developer/css-grid/inspect-step3.jpg', {'alt': '', 'width': '440', 'height': '242', 'class': 'screenshot'}) }}
             <figcaption>
             {% trans %}
               You'll see the grid overlaid on the page, including grid lines and tracks.

--- a/bedrock/mozorg/templates/mozorg/home/home-de.html
+++ b/bedrock/mozorg/templates/mozorg/home/home-de.html
@@ -59,7 +59,7 @@
         desc=_('Mozilla setzt sich für ein gesundes Internet ein – und damit für die Menschen, die es nutzen. Damals. Heute. Morgen.'),
         link_cta=_('Erfahre mehr über Mozilla'),
         link_url=url('mozorg.about.manifesto'),
-        image_url='home/2018/billboard-more-power.png',
+        image_url='img/home/2018/billboard-more-power.png',
         include_highres_image=True
       )}}
 
@@ -74,7 +74,7 @@
         desc=_('Virtual Reality, IoT und mehr.'),
         link_cta=_('Entdecke das Web der Zukunft'),
         link_url=url('mozorg.technology'),
-        image_url='home/2018/billboard-open-minds.png',
+        image_url='img/home/2018/billboard-open-minds.png',
         include_highres_image=True,
         reverse=True
       )}}
@@ -92,7 +92,7 @@
 
       <aside class="mzp-c-newsletter">
         <div class="mzp-c-newsletter-image">
-          {{ high_res_img('home/2018/newsletter-graphic.png', {'alt': ''}) }}
+          {{ high_res_img('img/home/2018/newsletter-graphic.png', {'alt': ''}) }}
         </div>
 
         <div class="newsletter-content">

--- a/bedrock/mozorg/templates/mozorg/home/home-en.html
+++ b/bedrock/mozorg/templates/mozorg/home/home-en.html
@@ -96,7 +96,7 @@
         desc=_('Mozilla puts people before profit, creating products, technologies and programs that make the internet healthier for everyone.'),
         link_cta=_('Learn more about us'),
         link_url=url('mozorg.about'),
-        image_url='home/2018/billboard-more-power.png',
+        image_url='img/home/2018/billboard-more-power.png',
         include_highres_image=True
       )}}
 
@@ -140,7 +140,7 @@
         desc=_('The not-for-profit Mozilla Foundation supports open-source apps, web literacy curriculum, gender equality in tech and more.'),
         link_cta=_('Visit the Mozilla Foundation'),
         link_url='https://foundation.mozilla.org/?utm_source=www.mozilla.org&utm_medium=referral&utm_campaign=homepage&utm_content=billboard',
-        image_url='home/2018/billboard-healthy-internet.png',
+        image_url='img/home/2018/billboard-healthy-internet.png',
         include_highres_image=True,
         reverse=True
       )}}
@@ -156,7 +156,7 @@
         desc=_('Mozilla creates powerful web tech for everyone.'),
         link_cta=_('Explore Mozilla technology'),
         link_url='https://labs.mozilla.org/?utm_source=www.mozilla.org&utm_medium=referral&utm_campaign=homepage&utm_content=billboard',
-        image_url='home/2018/billboard-open-minds.png',
+        image_url='img/home/2018/billboard-open-minds.png',
         include_highres_image=True
       )}}
 
@@ -167,7 +167,7 @@
 
       <aside class="mzp-c-newsletter">
         <div class="mzp-c-newsletter-image">
-          {{ high_res_img('home/2018/newsletter-graphic.png', {'alt': ''}) }}
+          {{ high_res_img('img/home/2018/newsletter-graphic.png', {'alt': ''}) }}
         </div>
 
         <div class="newsletter-content">

--- a/bedrock/mozorg/templates/mozorg/home/home-fr.html
+++ b/bedrock/mozorg/templates/mozorg/home/home-fr.html
@@ -59,7 +59,7 @@ Le saviez-vous ? Mozilla, le concepteur de Firefox, se bat pour qu’Internet, u
         desc=_('Mozilla s’engage pour un Internet plus sain et plus accessible. Pour vous et pour demain.'),
         link_cta=_('En savoir plus sur Mozilla'),
         link_url=url('mozorg.about.manifesto'),
-        image_url='home/2018/billboard-more-power.png',
+        image_url='img/home/2018/billboard-more-power.png',
         include_highres_image=True
       )}}
 
@@ -74,7 +74,7 @@ Le saviez-vous ? Mozilla, le concepteur de Firefox, se bat pour qu’Internet, u
         desc=_('Réalité virtuelle, IoT et plus encore.'),
         link_cta=_('Découvrez le web du futur'),
         link_url=url('mozorg.technology'),
-        image_url='home/2018/billboard-open-minds.png',
+        image_url='img/home/2018/billboard-open-minds.png',
         include_highres_image=True,
         reverse=True
       )}}
@@ -91,7 +91,7 @@ Le saviez-vous ? Mozilla, le concepteur de Firefox, se bat pour qu’Internet, u
 
       <aside class="mzp-c-newsletter">
         <div class="mzp-c-newsletter-image">
-          {{ high_res_img('home/2018/newsletter-graphic.png', {'alt': ''}) }}
+          {{ high_res_img('img/home/2018/newsletter-graphic.png', {'alt': ''}) }}
         </div>
 
         <div class="newsletter-content">

--- a/bedrock/mozorg/templates/mozorg/home/home.html
+++ b/bedrock/mozorg/templates/mozorg/home/home.html
@@ -79,7 +79,7 @@
         {{ download_firefox(dom_id='download-intro', download_location='primary cta') }}
       </div>{#--/.intro-content--#}
       <div class="intro-image">
-        {{ high_res_img('home/laptop.png', {'alt': '', 'width': '854', 'height': '536'}) }}
+        {{ high_res_img('img/home/laptop.png', {'alt': '', 'width': '854', 'height': '536'}) }}
       </div>
     </div>{#--/.content--#}
   </section>{#--/#quantum--#}

--- a/bedrock/mozorg/templates/mozorg/home/includes/macros.html
+++ b/bedrock/mozorg/templates/mozorg/home/includes/macros.html
@@ -6,7 +6,7 @@
 <section id="download-firefox-primary-cta" class="c-primary-cta download-firefox-primary-cta mzp-t-firefox">
   <div class="mzp-l-content">
     <div class="c-primary-cta-wrapper">
-      {{ high_res_img('logos/firefox/quantum/logo-word-hor-sm.png', {'alt': 'Firefox Browser', 'width': '210', 'height': '40', 'class': 'c-primary-cta-logo'}) }}
+      {{ high_res_img('img/logos/firefox/quantum/logo-word-hor-sm.png', {'alt': 'Firefox Browser', 'width': '210', 'height': '40', 'class': 'c-primary-cta-logo'}) }}
       <h3 class="c-primary-cta-title">{{ title }}</h3>
       <h3 class="c-primary-cta-title-sub">{{ sub_title }}</h3>
       <p class="c-primary-cta-desc-sub">{{ desc }}</p>

--- a/bedrock/mozorg/templates/mozorg/moss/_alittlebitmore.html
+++ b/bedrock/mozorg/templates/mozorg/moss/_alittlebitmore.html
@@ -3,7 +3,7 @@
 
   <ul class="moss-list moss-list-halves">
     <li>
-      {{ high_res_img('mozorg/moss/selection-committee.jpg', {'width': '450'}) }}
+      {{ high_res_img('img/mozorg/moss/selection-committee.jpg', {'width': '450'}) }}
 
       <h3 class="moss-subhead">{{ _('Selection Committee') }}</h3>
 
@@ -15,7 +15,7 @@
       </p>
     </li>
     <li>
-      {{ high_res_img('mozorg/moss/past-recipients.jpg', {'width': '450'}) }}
+      {{ high_res_img('img/mozorg/moss/past-recipients.jpg', {'width': '450'}) }}
 
       <h3 class="moss-subhead">{{ _('Past Recipients') }}</h3>
 

--- a/bedrock/mozorg/templates/mozorg/moss/index-092018.html
+++ b/bedrock/mozorg/templates/mozorg/moss/index-092018.html
@@ -100,7 +100,7 @@
 
   <ul class="moss-list moss-list-thirds">
     <li>
-      <h3>{{ high_res_img('mozorg/moss/tor.png', {'alt': 'Tor', 'width': '300', 'height': '169'}) }}</h3>
+      <h3>{{ high_res_img('img/mozorg/moss/tor.png', {'alt': 'Tor', 'width': '300', 'height': '169'}) }}</h3>
 
       <p class="moss-subhead">{{ _('$%(sum)s')|format(sum='152,500') }}</p>
 
@@ -116,7 +116,7 @@
       </p>
     </li>
     <li>
-      <h3>{{ high_res_img('mozorg/moss/tails.png', {'alt': 'Tails', 'width': '300', 'height': '169'}) }}</h3>
+      <h3>{{ high_res_img('img/mozorg/moss/tails.png', {'alt': 'Tails', 'width': '300', 'height': '169'}) }}</h3>
 
       <p class="moss-subhead">{{ _('$%(sum)s')|format(sum='77,000') }}</p>
 
@@ -132,7 +132,7 @@
       </p>
     </li>
     <li>
-      <h3>{{ high_res_img('mozorg/moss/caddy.png', {'alt': 'Caddy', 'width': '300', 'height': '169'}) }}</h3>
+      <h3>{{ high_res_img('img/mozorg/moss/caddy.png', {'alt': 'Caddy', 'width': '300', 'height': '169'}) }}</h3>
 
       <p class="moss-subhead">{{ _('$%(sum)s')|format(sum='50,000') }}</p>
 
@@ -147,7 +147,7 @@
       </p>
     </li>
     <li>
-      <h3>{{ high_res_img('mozorg/moss/godot.png', {'alt': 'Godot', 'width': '300', 'height': '169'}) }}</h3>
+      <h3>{{ high_res_img('img/mozorg/moss/godot.png', {'alt': 'Godot', 'width': '300', 'height': '169'}) }}</h3>
 
       <p class="moss-subhead">{{ _('$%(sum)s')|format(sum='20,000') }}</p>
 
@@ -163,7 +163,7 @@
       </p>
     </li>
     <li>
-      <h3>{{ high_res_img('mozorg/moss/securedrop.png', {'alt': 'SecureDrop', 'width': '300', 'height': '83'}) }}</h3>
+      <h3>{{ high_res_img('img/mozorg/moss/securedrop.png', {'alt': 'SecureDrop', 'width': '300', 'height': '83'}) }}</h3>
 
       <p class="moss-subhead">{{ _('$%(sum)s')|format(sum='250,000') }}</p>
 
@@ -176,7 +176,7 @@
       </p>
     </li>
     <li>
-      <h3>{{ high_res_img('mozorg/moss/nvaccess.png', {'alt': 'NV Access', 'width': '300', 'height': '169'}) }}</h3>
+      <h3>{{ high_res_img('img/mozorg/moss/nvaccess.png', {'alt': 'NV Access', 'width': '300', 'height': '169'}) }}</h3>
 
       <p class="moss-subhead">{{ _('$%(sum)s')|format(sum='15,000') }}</p>
 

--- a/bedrock/mozorg/templates/mozorg/moss/index.html
+++ b/bedrock/mozorg/templates/mozorg/moss/index.html
@@ -192,7 +192,7 @@
 
   <ul class="moss-list moss-list-thirds">
     <li>
-      <h3>{{ high_res_img('mozorg/moss/tor.png', {'alt': 'Tor', 'width': '300', 'height': '169'}) }}</h3>
+      <h3>{{ high_res_img('img/mozorg/moss/tor.png', {'alt': 'Tor', 'width': '300', 'height': '169'}) }}</h3>
 
       <p class="moss-subhead">{{ _('$%(sum)s')|format(sum='152,500') }}</p>
 
@@ -208,7 +208,7 @@
       </p>
     </li>
     <li>
-      <h3>{{ high_res_img('mozorg/moss/tails.png', {'alt': 'Tails', 'width': '300', 'height': '169'}) }}</h3>
+      <h3>{{ high_res_img('img/mozorg/moss/tails.png', {'alt': 'Tails', 'width': '300', 'height': '169'}) }}</h3>
 
       <p class="moss-subhead">{{ _('$%(sum)s')|format(sum='77,000') }}</p>
 
@@ -224,7 +224,7 @@
       </p>
     </li>
     <li>
-      <h3>{{ high_res_img('mozorg/moss/caddy.png', {'alt': 'Caddy', 'width': '300', 'height': '169'}) }}</h3>
+      <h3>{{ high_res_img('img/mozorg/moss/caddy.png', {'alt': 'Caddy', 'width': '300', 'height': '169'}) }}</h3>
 
       <p class="moss-subhead">{{ _('$%(sum)s')|format(sum='50,000') }}</p>
 
@@ -239,7 +239,7 @@
       </p>
     </li>
     <li>
-      <h3>{{ high_res_img('mozorg/moss/godot.png', {'alt': 'Godot', 'width': '300', 'height': '169'}) }}</h3>
+      <h3>{{ high_res_img('img/mozorg/moss/godot.png', {'alt': 'Godot', 'width': '300', 'height': '169'}) }}</h3>
 
       <p class="moss-subhead">{{ _('$%(sum)s')|format(sum='20,000') }}</p>
 
@@ -255,7 +255,7 @@
       </p>
     </li>
     <li>
-      <h3>{{ high_res_img('mozorg/moss/pears.png', {'alt': 'PeARS', 'width': '300', 'height': '169'}) }}</h3>
+      <h3>{{ high_res_img('img/mozorg/moss/pears.png', {'alt': 'PeARS', 'width': '300', 'height': '169'}) }}</h3>
 
       <p class="moss-subhead">{{ _('$%(sum)s')|format(sum='15,500') }}</p>
 
@@ -268,7 +268,7 @@
       </p>
     </li>
     <li>
-      <h3>{{ high_res_img('mozorg/moss/nvaccess.png', {'alt': 'NV Access', 'width': '300', 'height': '169'}) }}</h3>
+      <h3>{{ high_res_img('img/mozorg/moss/nvaccess.png', {'alt': 'NV Access', 'width': '300', 'height': '169'}) }}</h3>
 
       <p class="moss-subhead">{{ _('$%(sum)s')|format(sum='15,000') }}</p>
 

--- a/bedrock/mozorg/templatetags/misc.py
+++ b/bedrock/mozorg/templatetags/misc.py
@@ -161,7 +161,6 @@ def field_with_attrs(bfield, **kwargs):
 @library.global_function
 @jinja2.contextfunction
 def platform_img(ctx, url, optional_attributes=None):
-    url = _strip_img_prefix(url)
     optional_attributes = optional_attributes or {}
     img_urls = {}
     platforms = optional_attributes.pop('platforms', ALL_FX_PLATFORMS)
@@ -176,9 +175,7 @@ def platform_img(ctx, url, optional_attributes=None):
     img_attrs = {}
     for platform, image in img_urls.items():
         if is_l10n:
-            image = l10n_img_file_name(ctx, image)
-        else:
-            image = path.join('img', image)
+            image = l10n_img_file_name(ctx, _strip_img_prefix(image))
 
         if find_static(image):
             key = 'data-src-' + platform
@@ -204,14 +201,15 @@ def platform_img(ctx, url, optional_attributes=None):
 @library.global_function
 @jinja2.contextfunction
 def high_res_img(ctx, url, optional_attributes=None):
-    url = _strip_img_prefix(url)
-    url_high_res = convert_to_high_res(url)
     if optional_attributes and optional_attributes.pop('l10n', False) is True:
+        url = _strip_img_prefix(url)
+        url_high_res = convert_to_high_res(url)
         url = l10n_img(ctx, url)
         url_high_res = l10n_img(ctx, url_high_res)
     else:
-        url = static(path.join('img', url))
-        url_high_res = static(path.join('img', url_high_res))
+        url_high_res = convert_to_high_res(url)
+        url = static(url)
+        url_high_res = static(url_high_res)
 
     if optional_attributes:
         class_name = optional_attributes.pop('class', '')

--- a/bedrock/mozorg/tests/test_helper_misc.py
+++ b/bedrock/mozorg/tests/test_helper_misc.py
@@ -56,9 +56,7 @@ def render(s, context=None):
 
 def test_convert_to_high_res():
     assert misc.convert_to_high_res('/media/img/the.dude.png') == '/media/img/the.dude-high-res.png'
-    assert (
-        misc.convert_to_high_res('/media/thats-a-bummer-man.jpg') ==
-        '/media/thats-a-bummer-man-high-res.jpg')
+    assert misc.convert_to_high_res('/media/thats-a-bummer-man.jpg') == '/media/thats-a-bummer-man-high-res.jpg'
 
 
 @patch('bedrock.mozorg.templatetags.misc._l10n_media_exists')
@@ -75,66 +73,44 @@ class TestImgL10n(TestCase):
     def test_works_for_default_lang(self, media_exists_mock):
         """Should output correct path for default lang always."""
         media_exists_mock.return_value = True
-        assert (
-            self._render('en-US', 'dino/head.png') ==
-            static('img/l10n/en-US/dino/head.png'))
-        assert (
-            self._render('en-US', 'img/dino/head.png') ==
-            static('img/l10n/en-US/dino/head.png'))
+        assert self._render('en-US', 'dino/head.png') == static('img/l10n/en-US/dino/head.png')
+        assert self._render('en-US', 'img/dino/head.png') == static('img/l10n/en-US/dino/head.png')
 
-        assert (
-            self._render('en-US', 'dino/does-not-exist.png') ==
-            static('img/l10n/en-US/dino/does-not-exist.png'))
+        assert self._render('en-US', 'dino/does-not-exist.png') == static('img/l10n/en-US/dino/does-not-exist.png')
 
     def test_works_for_other_lang(self, media_exists_mock):
         """Should use the request lang if file exists."""
         media_exists_mock.return_value = True
-        assert (
-            self._render('de', 'dino/head.png') ==
-            static('img/l10n/de/dino/head.png'))
-        assert (
-            self._render('de', 'img/dino/head.png') ==
-            static('img/l10n/de/dino/head.png'))
+        assert self._render('de', 'dino/head.png') == static('img/l10n/de/dino/head.png')
+        assert self._render('de', 'img/dino/head.png') == static('img/l10n/de/dino/head.png')
 
     def test_defaults_when_lang_file_missing(self, media_exists_mock):
         """Should use default lang when file doesn't exist for lang."""
         media_exists_mock.return_value = False
-        assert (
-            self._render('is', 'dino/head.png') ==
-            static('img/l10n/en-US/dino/head.png'))
+        assert self._render('is', 'dino/head.png') == static('img/l10n/en-US/dino/head.png')
 
     def test_latam_spanishes_fallback_to_european_spanish(self, media_exists_mock):
         """Should use es-ES image when file doesn't exist for lang."""
         media_exists_mock.side_effect = [False, True]
-        assert (
-            self._render('es-AR', 'dino/head.png') ==
-            static('img/l10n/es-ES/dino/head.png'))
+        assert self._render('es-AR', 'dino/head.png') == static('img/l10n/es-ES/dino/head.png')
 
         media_exists_mock.reset_mock()
         media_exists_mock.side_effect = [False, True]
-        assert (
-            self._render('es-CL', 'dino/head.png') ==
-            static('img/l10n/es-ES/dino/head.png'))
+        assert self._render('es-CL', 'dino/head.png') == static('img/l10n/es-ES/dino/head.png')
 
         media_exists_mock.reset_mock()
         media_exists_mock.side_effect = [False, True]
-        assert (
-            self._render('es-MX', 'dino/head.png') ==
-            static('img/l10n/es-ES/dino/head.png'))
+        assert self._render('es-MX', 'dino/head.png') == static('img/l10n/es-ES/dino/head.png')
 
         media_exists_mock.reset_mock()
         media_exists_mock.side_effect = [False, True]
-        assert (
-            self._render('es', 'dino/head.png') ==
-            static('img/l10n/es-ES/dino/head.png'))
+        assert self._render('es', 'dino/head.png') == static('img/l10n/es-ES/dino/head.png')
 
     def test_file_not_checked_for_default_lang(self, media_exists_mock):
         """
         Should not check filesystem for default lang, but should for others.
         """
-        assert (
-            self._render('en-US', 'dino/does-not-exist.png') ==
-            static('img/l10n/en-US/dino/does-not-exist.png'))
+        assert self._render('en-US', 'dino/does-not-exist.png') == static('img/l10n/en-US/dino/does-not-exist.png')
         assert not media_exists_mock.called
 
         self._render('is', 'dino/does-not-exist.png')
@@ -258,8 +234,8 @@ class TestPlatformImg(TestCase):
     def test_platform_img_no_optional_attributes(self, find_static):
         """Should return expected markup without optional attributes"""
         markup = self._render('test.png')
-        self.assertIn(u'data-src-windows="/media/img/test-windows.png"', markup)
-        self.assertIn(u'data-src-mac="/media/img/test-mac.png"', markup)
+        self.assertIn(u'data-src-windows="/media/test-windows.png"', markup)
+        self.assertIn(u'data-src-mac="/media/test-mac.png"', markup)
         markup = self._render('img/test.png')
         self.assertIn(u'data-src-windows="/media/img/test-windows.png"', markup)
         self.assertIn(u'data-src-mac="/media/img/test-mac.png"', markup)
@@ -272,8 +248,8 @@ class TestPlatformImg(TestCase):
     def test_platform_img_with_high_res(self, find_static):
         """Should return expected markup with high resolution image attrs"""
         markup = self._render('test.png', {'high-res': True})
-        self.assertIn(u'data-src-windows-high-res="/media/img/test-windows-high-res.png"', markup)
-        self.assertIn(u'data-src-mac-high-res="/media/img/test-mac-high-res.png"', markup)
+        self.assertIn(u'data-src-windows-high-res="/media/test-windows-high-res.png"', markup)
+        self.assertIn(u'data-src-mac-high-res="/media/test-mac-high-res.png"', markup)
         self.assertIn(u'data-high-res="true"', markup)
         markup = self._render('img/test.png', {'high-res': True})
         self.assertIn(u'data-src-windows-high-res="/media/img/test-windows-high-res.png"', markup)
@@ -374,8 +350,7 @@ class TestDonateUrl(TestCase):
 
     def test_donate_url_no_locale(self):
         """No locale, fallback to default page"""
-        assert (
-            self._render('', 'mozillaorg_footer') ==
+        assert self._render('', 'mozillaorg_footer') == (
             'https://donate.mozilla.org//'
             '?presets=100,50,25,15&amp;amount=50'
             '&amp;utm_source=mozilla.org&amp;utm_medium=referral'
@@ -383,8 +358,7 @@ class TestDonateUrl(TestCase):
 
     def test_donate_url_english(self):
         """en-US locale, default page"""
-        assert (
-            self._render('en-US', 'mozillaorg_footer') ==
+        assert self._render('en-US', 'mozillaorg_footer') == (
             'https://donate.mozilla.org/en-US/'
             '?presets=100,50,25,15&amp;amount=50'
             '&amp;utm_source=mozilla.org&amp;utm_medium=referral'
@@ -392,8 +366,7 @@ class TestDonateUrl(TestCase):
 
     def test_donate_url_spanish(self):
         """es-MX locale, a localized page"""
-        assert (
-            self._render('es-MX', 'mozillaorg_footer') ==
+        assert self._render('es-MX', 'mozillaorg_footer') == (
             'https://donate.mozilla.org/es-MX/'
             '?presets=100,50,25,15&amp;amount=15'
             '&amp;utm_source=mozilla.org&amp;utm_medium=referral'
@@ -401,8 +374,7 @@ class TestDonateUrl(TestCase):
 
     def test_donate_url_other_locale(self):
         """No page for locale, fallback to default page"""
-        assert (
-            self._render('pt-PT', 'mozillaorg_footer') ==
+        assert self._render('pt-PT', 'mozillaorg_footer') == (
             'https://donate.mozilla.org/pt-PT/'
             '?presets=100,50,25,15&amp;amount=50'
             '&amp;utm_source=mozilla.org&amp;utm_medium=referral'
@@ -463,16 +435,12 @@ class TestHighResImg(TestCase):
         expected = (
             u'<img class="" src="/media/img/test.png" '
             u'srcset="/media/img/test-high-res.png 1.5x">')
-        markup = self._render('test.png')
-        self.assertEqual(markup, expected)
         markup = self._render('img/test.png')
-        self.assertEqual(markup, expected)
-        markup = self._render('/img/test.png')
         self.assertEqual(markup, expected)
 
     def test_high_res_img_with_optional_attributes(self):
         """Should return expected markup with optional attributes"""
-        markup = self._render('test.png', {'data-test-attr': 'test', 'class': 'logo'})
+        markup = self._render('img/test.png', {'data-test-attr': 'test', 'class': 'logo'})
         expected = (
             u'<img class="logo" src="/media/img/test.png" '
             u'srcset="/media/img/test-high-res.png 1.5x" '
@@ -569,8 +537,8 @@ class TestAbsoluteURLFilter(TestCase):
     static_url_full = 'https://mozorg.cdn.mozilla.net/static/'
     image_path = 'img/mozorg/mozilla-256.jpg'
     inline_template = "{{ static('%s')|absolute_url }}" % image_path
-    block_template = ("{% filter absolute_url %}{% block page_image %}" +
-                      "{{ static('%s') }}" % image_path + "{% endblock %}{% endfilter %}")
+    block_template = "{% filter absolute_url %}{% block page_image %}" + \
+                     "{{ static('%s') }}" % image_path + "{% endblock %}{% endfilter %}"
 
     def _render(self, template):
         return render(template, {'request': self.rf.get('/')})
@@ -640,16 +608,13 @@ class TestFirefoxIOSURL(TestCase):
 
     def test_firefox_ios_url_param(self):
         """should return default or localized URL with ct param"""
-        assert (
-            self._render('', 'mozorg') ==
+        assert self._render('', 'mozorg') == (
             'https://itunes.apple.com'
             '/app/firefox-private-safe-browser/id989804926?ct=mozorg')
-        assert (
-            self._render('en-US', 'mozorg') ==
+        assert self._render('en-US', 'mozorg') == (
             'https://itunes.apple.com/us'
             '/app/firefox-private-safe-browser/id989804926?ct=mozorg')
-        assert (
-            self._render('es-ES', 'mozorg') ==
+        assert self._render('es-ES', 'mozorg') == (
             'https://itunes.apple.com/es'
             '/app/firefox-private-safe-browser/id989804926?ct=mozorg')
 

--- a/docs/coding.rst
+++ b/docs/coding.rst
@@ -86,15 +86,15 @@ For images that include a high-resolution alternative for displays with a high p
 
 .. code-block:: python
 
-    high_res_img('firefox/new/firefox-logo.png', {'alt': 'Firefox', 'width': '200', 'height': '100'})
+    high_res_img('img/firefox/new/firefox-logo.png', {'alt': 'Firefox', 'width': '200', 'height': '100'})
 
-The `high_res_img()` function will automatically look for the image in the URL parameter suffixed with `'-high-res'`, e.g. `firefox/new/firefox-logo-high-res.png` and switch to it if the display has high pixel density.
+The `high_res_img()` function will automatically look for the image in the URL parameter suffixed with `'-high-res'`, e.g. `img/firefox/new/firefox-logo-high-res.png` and switch to it if the display has high pixel density.
 
 `high_res_img()` supports localized images by setting the `'l10n'` parameter to `True`:
 
 .. code-block:: python
 
-    high_res_img('firefox/new/firefox-logo.png', {'l10n': True, 'alt': 'Firefox', 'width': '200', 'height': '100'})
+    high_res_img('img/firefox/new/firefox-logo.png', {'l10n': True, 'alt': 'Firefox', 'width': '200', 'height': '100'})
 
 When using localization, `high_res_img()` will look for images in the appropriate locale folder. In the above example, for the `de` locale, both standard and high-res versions of the image should be located at `media/img/l10n/de/firefox/new/`.
 
@@ -114,7 +114,7 @@ Finally, for outputting an image that differs depending on the platform being us
 
 .. code-block:: python
 
-    platform_img('firefox/new/browser.png', {'alt': 'Firefox screenshot'})
+    platform_img('img/firefox/new/browser.png', {'alt': 'Firefox screenshot'})
 
 `platform_img()` will automatically look for the images `browser-mac.png`, `browser-win.png`, `browser-linux.png`, etc. Platform image also supports hi-res images by adding `'high-res': True` to the list of optional attributes.
 
@@ -122,7 +122,7 @@ Finally, for outputting an image that differs depending on the platform being us
 
 .. code-block:: python
 
-    platform_img('firefox/new/firefox-logo.png', {'l10n': True, 'alt': 'Firefox screenshot'})
+    platform_img('img/firefox/new/firefox-logo.png', {'l10n': True, 'alt': 'Firefox screenshot'})
 
 When using localization, `platform_img()` will look for images in the appropriate locale folder. In the above example, for the `es-ES` locale, all platform versions of the image should be located at `media/img/l10n/es-ES/firefox/new/`.
 


### PR DESCRIPTION
This is less magic, and allows images to be used with the helpers from outside of the `media/img` directory. Unfortunately it means adding `img/` to all of the uses of the helpers.

Fix #7863