### PR TITLE
Port Transparency Report pages to Protocol (Fixes #7530)

### DIFF
--- a/bedrock/mozorg/templates/mozorg/about/policy/transparency/includes/past-reports.html
+++ b/bedrock/mozorg/templates/mozorg/about/policy/transparency/includes/past-reports.html
@@ -2,21 +2,17 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
 
-
 {# Add links to previous reports as new reports are published. #}
-<div class="nav-previous">
-  <div class="content">
-    <nav>
-      <h3>{{ _('Previous Reports') }}</h3>
-      <ul>
-        <li><a href="{{ url('mozorg.about.policy.transparency.jul-dec-2018') }}">{{ _('July-December 2018') }}</a></li>
-        <li><a href="{{ url('mozorg.about.policy.transparency.jan-jun-2018') }}">{{ _('January-June 2018') }}</a></li>
-        <li><a href="{{ url('mozorg.about.policy.transparency.jul-dec-2017') }}">{{ _('July-December 2017') }}</a></li>
-        <li><a href="{{ url('mozorg.about.policy.transparency.jan-jun-2017') }}">{{ _('January-June 2017') }}</a></li>
-        <li><a href="{{ url('mozorg.about.policy.transparency.jul-dec-2016') }}">{{ _('July-December 2016') }}</a></li>
-        <li><a href="{{ url('mozorg.about.policy.transparency.jan-jun-2016') }}">{{ _('January-June 2016') }}</a></li>
-        <li><a href="{{ url('mozorg.about.policy.transparency.jan-dec-2015') }}">{{ _('January-December 2015') }}</a></li>
-      </ul>
-    </nav>
-  </div>
-</div>
+
+<nav class="prev-reports-nav">
+  <h3>{{ _('Previous Reports') }}</h3>
+  <ul>
+    <li><a href="{{ url('mozorg.about.policy.transparency.jul-dec-2018') }}">{{ _('July-December 2018') }}</a></li>
+    <li><a href="{{ url('mozorg.about.policy.transparency.jan-jun-2018') }}">{{ _('January-June 2018') }}</a></li>
+    <li><a href="{{ url('mozorg.about.policy.transparency.jul-dec-2017') }}">{{ _('July-December 2017') }}</a></li>
+    <li><a href="{{ url('mozorg.about.policy.transparency.jan-jun-2017') }}">{{ _('January-June 2017') }}</a></li>
+    <li><a href="{{ url('mozorg.about.policy.transparency.jul-dec-2016') }}">{{ _('July-December 2016') }}</a></li>
+    <li><a href="{{ url('mozorg.about.policy.transparency.jan-jun-2016') }}">{{ _('January-June 2016') }}</a></li>
+    <li><a href="{{ url('mozorg.about.policy.transparency.jan-dec-2015') }}">{{ _('January-December 2015') }}</a></li>
+  </ul>
+</nav>

--- a/bedrock/mozorg/templates/mozorg/about/policy/transparency/includes/reports-nav.html
+++ b/bedrock/mozorg/templates/mozorg/about/policy/transparency/includes/reports-nav.html
@@ -1,9 +1,17 @@
-      <nav class="content nav-report three-up">
-        <ul>
-          <li><a class="button" href="{{ url('mozorg.about.policy.transparency.index') + '#faq' }}">{{ _('FAQ') }}</a></li>
-          <li><a class="button" href="{{ url('mozorg.about.policy.transparency.index') + '#definitions' }}">{{ _('Definitions') }}</a></li>
-          {# This link should point to the latest report. Past reports are added to 'includes/past-reports.html' #}
-          {# There are also links in the faq that need to be updated to point to the latest report. #}
-          <li><a class="button" href="{{ url('mozorg.about.policy.transparency.jan-jun-2019') }}">{{ _('January-June 2019 Report') }}</a></li>
-        </ul>
-      </nav>
+<nav class="reports-nav">
+  <ul>
+    <li>
+      <a class="mzp-c-button" href="{{ url('mozorg.about.policy.transparency.index') + '#faq' }}">{{ _('FAQ') }}</a>
+    </li>
+    <li>
+      <a class="mzp-c-button"
+        href="{{ url('mozorg.about.policy.transparency.index') + '#definitions' }}">{{ _('Definitions') }}</a>
+    </li>
+    {# This link should point to the latest report. Past reports are added to 'includes/past-reports.html' #}
+    {# There are also links in the faq that need to be updated to point to the latest report. #}
+    <li>
+      <a class="mzp-c-button"
+        href="{{ url('mozorg.about.policy.transparency.jan-jun-2019') }}">{{ _('January-June 2019 Report') }}</a>
+    </li>
+  </ul>
+</nav>

--- a/bedrock/mozorg/templates/mozorg/about/policy/transparency/index.html
+++ b/bedrock/mozorg/templates/mozorg/about/policy/transparency/index.html
@@ -38,7 +38,7 @@
     {% include 'mozorg/about/policy/transparency/includes/past-reports.html' %}
   </aside>
 
-  <div id="faq" class="mzp-l-content">
+  <div id="faq" class="mzp-l-content l-content-narrow">
     <h2>{{ _('Frequently Asked Questions') }}</h2>
 
     <section class="mzp-c-details">
@@ -159,7 +159,7 @@
     </section>
   </div>
 
-  <div id="definitions" class="mzp-l-content">
+  <div id="definitions" class="mzp-l-content l-content-narrow">
     <h2>{{ _('Definitions') }}</h2>
 
     <dl>

--- a/bedrock/mozorg/templates/mozorg/about/policy/transparency/index.html
+++ b/bedrock/mozorg/templates/mozorg/about/policy/transparency/index.html
@@ -2,260 +2,272 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
 
-{% extends "base-pebbles.html" %}
+{% extends "base-protocol.html" %}
 
 {% block page_title %}{{ _('Transparency') }}{% endblock %}
-{% set body_id = "about-transparency" %}
-{% block body_class %}about-transparency{% endblock %}
 
 {% block page_css %}
-  {{ css_bundle('about-transparency') }}
+{{ css_bundle('about-transparency') }}
 {% endblock %}
 
 {% block js %}
-  {{ js_bundle('about-transparency') }}
+{{ js_bundle('about-transparency') }}
 {% endblock %}
 
 {% block content %}
-  <main role="main">
-    <header class="title-bar">
-      <div class="content">
-        <h1>{{ _('Transparency') }}</h1>
-      </div>
-    </header>
+<main role="main">
+  <header class="c-page-header">
+    <div class="mzp-l-content l-content-narrow">
+      <h1>{{ _('Transparency') }}</h1>
+    </div>
+  </header>
 
-    <section class="section" id="introduction">
-      <div class="content">
+  <div class="mzp-l-content l-content-narrow">
+    <p>
+      {{ _('Transparency is a key part of how Mozilla approaches user trust.') }}
+      {{ _('As an open source project that relies on open development, we build transparency into the way we write our code.') }}
+      {{ _('Additionally, our product documentation and notices describe how our products work and how we handle user data.') }}
+    </p>
+    <p>
+      {{ _('With this transparency in mind, we intend to publish bi­-annual transparency reports that help provide additional transparency to government disclosures and takedown requests.') }}
+    </p>
+  </div>
+
+  <aside>
+    {% include 'mozorg/about/policy/transparency/includes/reports-nav.html' %}
+    {% include 'mozorg/about/policy/transparency/includes/past-reports.html' %}
+  </aside>
+
+  <div id="faq" class="mzp-l-content">
+    <h2>{{ _('Frequently Asked Questions') }}</h2>
+
+    <section class="mzp-c-details">
+      <h3>{{ _('What is the scope of the Transparency Report?') }}</h3>
+      <p>
+        {% trans %}
+        The purpose is to provide public insight into the types of government demands we receive for our user data or to
+        remove content; and requests from individuals or companies to remove content based on copyright or trademark
+        claims. Each report also includes a supplement describing our efforts to reform laws on privacy, surveillance,
+        cybersecurity, and intellectual property for a healthier internet.
+        {% endtrans %}
+      </p>
+      <p>
+        {{ _('With each additional report that we publish, we’ll continue to re­evaluate how we can be more transparent. To this end, starting in H2 2018, we started reporting on the number of requests we receive from individuals inquiring about their personal data.') }}
+      </p>
+    </section>
+
+    <section class="mzp-c-details">
+      <h3>{{ ('How does Mozilla handle Government Demands for User Data?') }}</h3>
+      <p>
+        {{ _('As explained in our <a href="%s">Privacy Policy</a>, we will comply with a request for user data when the law requires it.')|format(url('privacy')) }}
+      </p>
+      <p>
+        {{ _('Mozilla requires valid <a href="%s">Legal Process</a> to compel the disclosure of Specific User data to the government; such as a legitimate and properly scoped court order, or a search warrant supported by probable cause and issued by an appropriate law enforcement authority.')|format(url('mozorg.about.policy.transparency.index') + '#dfn-legal-process') }}
+        {{ _('We interpret requests narrowly, and we will oppose unlawful or overbroad requests for specific user data.') }}
+      </p>
+      <p>
+        {{ _('Recipients of <a href="%s">National Security Requests</a> can only publish reporting bands instead of specific figures.')|format(url('mozorg.about.policy.transparency.index') + '#dfn-natl-security-request') }}
+        {{ _('If we receive such a request, we may challenge these reporting bands, in addition to opposing any unlawful or overbroad requests.') }}
+      </p>
+    </section>
+
+    <section class="mzp-c-details">
+      <h3>{{ ('How does Mozilla handle Gag Orders?') }}</h3>
+      <p>
+        {{ _('We don’t believe it is appropriate for the government to indefinitely delay a company from providing user notice.  We will take steps to enforce this belief for gag orders that meet any of the following criteria:') }}
+      </p>
+
+      <p>
+        {{ _('<strong>Unreasonable Duration</strong> - Any gag order with an unspecified duration or with a duration longer than one year.  This time period may be changed if specific facts in the case lead us to believe that a longer time period is reasonable.  We support policy proposals to codify into a federal statute shorter durations of one year or less, consistent with Section 9-13.700 of the DOJ U.S. Attorneys’ Manual.') }}
+      </p>
+      <p>
+        {{ _('<strong>Unreasonable Scope</strong> - Any gag order that would prevent us from disclosing the existence of legal process in our transparency report.') }}
+      </p>
+      <p>
+        {{ _('<strong>Unreasonable Number of Impacted Users</strong> - Any gag order that appears to affect more than 50 users, or where specific facts suggest that the order affects users we can reasonably determine are unrelated to the activity under investigation, such as users of a shared computer or IP address.') }}
+      </p>
+      <p>
+        {{ _('<strong>Unreasonable Impact on Free Expression</strong> - Specific facts of the case raise free expression issues (such as cases involving journalists or the press). ') }}
+      </p>
+    </section>
+
+    <section class="mzp-c-details">
+      <h3>{{ _('How does Mozilla handle voluntary disclosures and Emergency Requests?') }}</h3>
+      <p>
+        {{ _('The law authorizes us to disclose information to governmental entities in emergencies and we may do so if we have a good faith belief that it is reasonably necessary to protect the rights, property or safety of people.') }}
+      </p>
+      <p>
+        {{ _('If we receive an <a href="%s">Emergency Request</a>, we require it to be certified in writing by a government officer describing the nature of the emergency and how the information requested might prevent the harm. Additionally, we may attempt to verify information before responding.')|format('#dfn-emergency-request') }}
+      </p>
+    </section>
+
+    <section class="mzp-c-details">
+      <h3>{{ _('How does Mozilla handle copyright removal requests?') }}</h3>
+      <div>
         <p>
-          {{ _('Transparency is a key part of how Mozilla approaches user trust.') }}
-          {{ _('As an open source project that relies on open development, we build transparency into the way we write our code.') }}
-          {{ _('Additionally, our product documentation and notices describe how our products work and how we handle user data.') }}
+          {{ _('See <a href="%s">here</a> to read our process for handling reports of copyright infringement.')|format(url('legal.report-infringement')) }}
         </p>
+      </div>
+    </section>
 
+    <section class="mzp-c-details">
+      <h3>{{ _('How does Mozilla handle trademark removal requests?') }}</h3>
+      <p>
+        {{ _('See <a href="%s">here</a> to read our process for handling reports of trademark infringement.')|format(url('legal.report-infringement')) }}
+      </p>
+    </section>
+
+    <section class="mzp-c-details">
+      <h3>{{ _('When does Mozilla notify users about a Specific User disclosure?') }}</h3>
+
+      <p>
+        {{ _('As described in our <a href="%s">Privacy Policy</a>, we will notify impacted users when we receive a Specific User request unless we are legally prohibited from doing so.')|format(url('privacy')) }}
+        {{ _('Sometimes companies are legally required to delay user notification, but we will notify impacted users after the required delay expires.') }}
+        {{ _('We don’t believe it is appropriate for the government to indefinitely delay a company from providing user notice and we will take steps to enforce this belief.') }}
+      </p>
+
+      <p>
+        {{ _('In some cases when we make a voluntary disclosure, we may choose to skip or delay notification if we have a good faith belief that it is reasonably necessary to protect the rights, property or safety of people.') }}
+      </p>
+
+      <p>
+        {{ _('If a legal request draws attention to a user’s ongoing violation of our terms of use, we may choose to take action to prevent further abuse, such as account termination, which may notify the user that we are aware of misconduct.') }}
+      </p>
+    </section>
+
+    <section class="mzp-c-details">
+      <h3>{{ _('When does Mozilla notify users about a copyright or trademark request?') }}</h3>
+      <p>
+        {{ _('Users are notified if we receive a <a href="%s">Takedown Notice</a> related to their submission on a Mozilla service.')|format('#dfn-takedown-notice') }}
+        {{ _('We also try to publicly post copies of the Takedown Notices (with personal data redacted) to sites such as <a href="%s">MozWiki</a> and <a href="%s">Lumen Database</a> (formerly known as the Chilling Effects project).')|format('https://wiki.mozilla.org/Legal/Infringement_Notices','https://lumendatabase.org/') }}
+      </p>
+    </section>
+
+    <section class="mzp-c-details">
+      <h3>{{ _('What does the Supplement cover?') }}</h3>
+      <p>
+        {{ _('This section of our report covers situations that don’t fit into our reporting categories.') }}
+        {{ _('For example, to the extent we are legally permitted, we may include voluntary disclosures as well as legal and policy activities that we engaged in during the reporting period to further government transparency.') }}
+      </p>
+    </section>
+
+    <section class="mzp-c-details">
+      <h3>{{ _('What do you mean by Personal Data Requests?') }}</h3>
+      <p>
+        {{ _('We believe that everyone should have control over their personal data, understand how it’s obtained and used, and be able to access, modify, or delete it.  We extend these principles to all of our users regardless of when they submit a <a href="%s">Personal Data Request</a>, where they are located, or whether a data protection law (such as the GDPR) grants them express privacy rights. ')|format('#dfn-personal-data-request') }}
+      </p>
+    </section>
+  </div>
+
+  <div id="definitions" class="mzp-l-content">
+    <h2>{{ _('Definitions') }}</h2>
+
+    <dl>
+      <dt id="dfn-counter-notice">{{ _('Counter Notice') }}</dt>
+      <dd>
         <p>
-          {{ _('With this transparency in mind, we intend to publish bi­-annual transparency reports that help provide additional transparency to government disclosures and takedown requests.') }}
+          {{ _('Documentation that meets the counter notification requirements <a href="%s">set forth here</a> in response to a <a href="%s">Takedown Notice</a>.')|format(url('legal.report-infringement'), url('mozorg.about.policy.transparency.index') + '#dfn-takedown-notice') }}
         </p>
-      </div>
-    </section>
+      </dd>
 
-    <aside class="section nav-block">
-      {% include 'mozorg/about/policy/transparency/includes/reports-nav.html' %}
-      {% include 'mozorg/about/policy/transparency/includes/past-reports.html' %}
-    </aside>
+      <dt id="dfn-court-order">{{ _('Court Order') }}</dt>
+      <dd>
+        <p>
+          {{ _('An order issued by a judge or magistrate compelling a company to engage or refrain from certain action.') }}
+        </p>
+      </dd>
 
-    <section class="section section-extra section-faq" id="faq">
-      <div class="content">
-        <h2 class="section-title">{{ _('Frequently Asked Questions') }}</h2>
+      <dt id="dfn-threat-indicator">{{ _('Cybersecurity Threat Indicator') }}</dt>
+      <dd>
+        <p>
+          {{ _('Pieces of information about a threat to a computer network or system, such as a vulnerability, piece of malicious code, or the IP address of an attacker. This definition is based on the Cybersecurity Information Sharing Act of 2015 (CISA); the full definition is at <a href="%s">6 U.S.C. § 1501(6)</a>.')|format('http://uscode.house.gov/view.xhtml?req=%28title:6%20section:1501%20edition:prelim%29%20OR%20%28granuleid:USC-prelim-title6-section1501%29&f=treesort&edition=prelim&num=0&jumpTo=true') }}
+        </p>
+      </dd>
 
-        <div class="accordion accordion-auto-init">
-          <section>
-            <h3 data-accordion-role="tab">{{ _('What is the scope of the Transparency Report?') }}</h3>
-            <div data-accordion-role="tabpanel">
-              <p>
-                {% trans %}
-                   The purpose is to provide public insight into the types of government demands we receive for our user data or to remove content; and requests from individuals or companies to remove content based on copyright or trademark claims.  Each report also includes a supplement describing our efforts to reform laws on privacy, surveillance, cybersecurity, and intellectual property for a healthier internet.
-                {% endtrans %}
+      <dt id="dfn-emergency-request">{{ _('Emergency Request') }}</dt>
+      <dd>
+        <p>
+          {{ _('A request from a government agency seeking information on an expedited basis in connection with an emergency, typically involving death or serious injury.') }}
+        </p>
+      </dd>
 
-                {{ _('With each additional report that we publish, we’ll continue to re­evaluate how we can be more transparent. To this end, starting in H2 2018, we started reporting on the number of requests we receive from individuals inquiring about their personal data.') }}
-              </p>
-            </div>
-          </section>
+      <dt id="dfn-legal-process">{{ _('Legal Process') }}</dt>
+      <dd>
+        <p>
+          {% trans
+                link_emergency_req='#dfn-emergency-request',
+                link_court_order='#dfn-court-order',
+                link_natl_security='#dfn-natl-security-request',
+                link_pen_register='#dfn-pen-register-order',
+                link_search_warrant='#dfn-search-warrant',
+                link_subpoena='#dfn-subpoena',
+                link_wiretap='#dfn-wiretap-order'
+              %}
+          Examples of legal processes include: <a href="{{ link_emergency_req }}">Emergency Request</a>, <a
+            href="{{ link_court_order }}">Court Order</a>, <a href="{{ link_natl_security }}">National Security
+            Request</a>, <a href="{{ link_pen_register }}">Pen Register Order</a>, <a
+            href="{{ link_search_warrant }}">Search Warrant</a>, <a href="{{ link_subpoena }}">Subpoena</a> and <a
+            href="{{ link_wiretap }}">Wiretap Order</a>.
+          {% endtrans %}
+        </p>
+      </dd>
 
-          <section>
-            <h3 data-accordion-role="tab">{{ ('How does Mozilla handle Government Demands for User Data?') }}</h3>
-            <div data-accordion-role="tabpanel">
-              <p>
-                {{ _('As explained in our <a href="%s">Privacy Policy</a>, we will comply with a request for user data when the law requires it.')|format(url('privacy')) }}
-              </p>
+      <dt id="dfn-natl-security-request">{{ _('National Security Request') }}</dt>
+      <dd>
+        <p>
+          {{ _('A National Security Letter issued under 18 U.S.C.§2709, a Court Order issued under the Foreign Intelligence Surveillance Act or any other classified request for user information issued in the U.S.') }}
+        </p>
+      </dd>
 
-              <p>
-                {{ _('Mozilla requires valid <a href="%s">Legal Process</a> to compel the disclosure of Specific User data to the government; such as a legitimate and properly scoped court order, or a search warrant supported by probable cause and issued by an appropriate law enforcement authority.')|format(url('mozorg.about.policy.transparency.index') + '#dfn-legal-process') }}
-                {{ _('We interpret requests narrowly, and we will oppose unlawful or overbroad requests for specific user data.') }}
-              </p>
+      <dt id="dfn-pen-register-order">{{ _('Pen Register Order') }}</dt>
+      <dd>
+        <p>
+          {{ _('A Pen Register and Trap and Trace Order is a type of U.S. <a href="%s">Court Order</a> compelling a company to disclose data about a user’s real­time communications (excluding the content of the communications themselves) to law enforcement on an ongoing basis, usually for a period of 60 days.')|format('#dfn-court-order') }}
+        </p>
+      </dd>
 
-              <p>
-                {{ _('Recipients of <a href="%s">National Security Requests</a> can only publish reporting bands instead of specific figures.')|format(url('mozorg.about.policy.transparency.index') + '#dfn-natl-security-request') }}
-                {{ _('If we receive such a request, we may challenge these reporting bands, in addition to opposing any unlawful or overbroad requests.') }}
-              </p>
-            </div>
-          </section>
+      <dt id="dfn-personal-data-request">{{ _('Personal Data Request') }}</dt>
+      <dd>
+        <p>
+          {{ _('A user-generated request about personal data such as how to delete, port, modify or access it.  For the purpose of our Transparency  Report, we count the number of requests received by email, post, or to our portal for Data Subject Access Requests.  We don’t count (or have metrics for) the number of such requests that our users process themselves through in-product features.') }}
+        </p>
+      </dd>
 
-          <section>
-            <h3 data-accordion-role="tab">{{ ('How does Mozilla handle Gag Orders?') }}</h3>
-            <div data-accordion-role="tabpanel">
-              <p>
-                {{ _('We don’t believe it is appropriate for the government to indefinitely delay a company from providing user notice.  We will take steps to enforce this belief for gag orders that meet any of the following criteria:') }}
-              </p>
+      <dt id="dfn-search-warrant">{{ _('Search Warrant') }}</dt>
+      <dd>
+        <p>
+          {{ _('A document authorizing law enforcement to obtain user data issued by a neutral and detached magistrate on the basis of finding that “probable cause” exists to believe that the items being sought will be found in the place to be searched.') }}
+        </p>
+      </dd>
 
-              <p>
-                {{ _('<strong>Unreasonable Duration</strong> - Any gag order with an unspecified duration or with a duration longer than one year.  This time period may be changed if specific facts in the case lead us to believe that a longer time period is reasonable.  We support policy proposals to codify into a federal statute shorter durations of one year or less, consistent with Section 9-13.700 of the DOJ U.S. Attorneys’ Manual.') }}
-              </p>
-              <p>
-                {{ _('<strong>Unreasonable Scope</strong> - Any gag order that would prevent us from disclosing the existence of legal process in our transparency report.') }}
-              </p>
-              <p>
-                {{ _('<strong>Unreasonable Number of Impacted Users</strong> - Any gag order that appears to affect more than 50 users, or where specific facts suggest that the order affects users we can reasonably determine are unrelated to the activity under investigation, such as users of a shared computer or IP address.') }}
-              </p>
-              <p>
-                {{ _('<strong>Unreasonable Impact on Free Expression</strong> - Specific facts of the case raise free expression issues (such as cases involving journalists or the press). ') }}
-              </p>
+      <dt id="dfn-specific-user">{{ _('Specific User') }}</dt>
+      <dd>
+        <p>{{ _('An identifiable user of Mozilla’s products and services.') }}</p>
+      </dd>
 
-            </div>
-          </section>
+      <dt id="dfn-subpoena">{{ _('Subpoena') }}</dt>
+      <dd>
+        <p>
+          {{ _('A formal request for the production of evidence or testimony that can be issued by a government agency or court. Judicial review is not necessarily required.') }}
+        </p>
+      </dd>
 
-          <section>
-            <h3 data-accordion-role="tab">{{ _('How does Mozilla handle voluntary disclosures and Emergency Requests?') }}</h3>
-            <div data-accordion-role="tabpanel">
-              <p>
-                {{ _('The law authorizes us to disclose information to governmental entities in emergencies and we may do so if we have a good faith belief that it is reasonably necessary to protect the rights, property or safety of people.') }}
-              </p>
+      <dt id="dfn-takedown-notice">{{ _('Takedown Notice') }}</dt>
+      <dd>
+        <p>
+          {{ _('Documentation that meets the requirements set forth in our <a href="%s">reporting copyright or trademark infringement page</a>.')|format(url('legal.report-infringement')) }}
+        </p>
+      </dd>
 
-              <p>
-                {{ _('If we receive an <a href="%s">Emergency Request</a>, we require it to be certified in writing by a government officer describing the nature of the emergency and how the information requested might prevent the harm. Additionally, we may attempt to verify information before responding.')|format('#dfn-emergency-request') }}
-              </p>
-            </div>
-          </section>
-
-          <section>
-            <h3 data-accordion-role="tab">{{ _('How does Mozilla handle copyright removal requests?') }}</h3>
-            <div data-accordion-role="tabpanel">
-              <p>
-                {{ _('See <a href="%s">here</a> to read our process for handling reports of copyright infringement.')|format(url('legal.report-infringement')) }}
-              </p>
-            </div>
-          </section>
-
-          <section>
-            <h3 data-accordion-role="tab">{{ _('How does Mozilla handle trademark removal requests?') }}</h3>
-            <div data-accordion-role="tabpanel">
-              <p>
-                {{ _('See <a href="%s">here</a> to read our process for handling reports of trademark infringement.')|format(url('legal.report-infringement')) }}
-              </p>
-            </div>
-          </section>
-
-          <section>
-            <h3 data-accordion-role="tab">{{ _('When does Mozilla notify users about a Specific User disclosure?') }}</h3>
-            <div data-accordion-role="tabpanel">
-              <p>
-                {{ _('As described in our <a href="%s">Privacy Policy</a>, we will notify impacted users when we receive a Specific User request unless we are legally prohibited from doing so.')|format(url('privacy')) }}
-                {{ _('Sometimes companies are legally required to delay user notification, but we will notify impacted users after the required delay expires.') }}
-                {{ _('We don’t believe it is appropriate for the government to indefinitely delay a company from providing user notice and we will take steps to enforce this belief.') }}
-              </p>
-
-              <p>
-                {{ _('In some cases when we make a voluntary disclosure, we may choose to skip or delay notification if we have a good faith belief that it is reasonably necessary to protect the rights, property or safety of people.') }}
-              </p>
-
-              <p>
-                {{ _('If a legal request draws attention to a user’s ongoing violation of our terms of use, we may choose to take action to prevent further abuse, such as account termination, which may notify the user that we are aware of misconduct.') }}
-              </p>
-            </div>
-          </section>
-
-          <section>
-            <h3 data-accordion-role="tab">{{ _('When does Mozilla notify users about a copyright or trademark request?') }}</h3>
-            <div data-accordion-role="tabpanel">
-              <p>
-                {{ _('Users are notified if we receive a <a href="%s">Takedown Notice</a> related to their submission on a Mozilla service.')|format('#dfn-takedown-notice') }}
-                {{ _('We also try to publicly post copies of the Takedown Notices (with personal data redacted) to sites such as <a href="%s">MozWiki</a> and <a href="%s">Lumen Database</a> (formerly known as the Chilling Effects project).')|format('https://wiki.mozilla.org/Legal/Infringement_Notices','https://lumendatabase.org/') }}
-            </div>
-          </section>
-
-          <section>
-            <h3 data-accordion-role="tab">{{ _('What does the Supplement cover?') }}</h3>
-            <div data-accordion-role="tabpanel">
-              <p>
-                {{ _('This section of our report covers situations that don’t fit into our reporting categories.') }}
-                {{ _('For example, to the extent we are legally permitted, we may include voluntary disclosures as well as legal and policy activities that we engaged in during the reporting period to further government transparency.') }}
-              </p>
-            </div>
-          </section>
-
-          <section>
-            <h3 data-accordion-role="tab">{{ _('What do you mean by Personal Data Requests?') }}</h3>
-            <div data-accordion-role="tabpanel">
-              <p>
-                {{ _('We believe that everyone should have control over their personal data, understand how it’s obtained and used, and be able to access, modify, or delete it.  We extend these principles to all of our users regardless of when they submit a <a href="%s">Personal Data Request</a>, where they are located, or whether a data protection law (such as the GDPR) grants them express privacy rights. ')|format('#dfn-personal-data-request') }}
-                
-              </p>
-            </div>
-          </section>
-
-        </div>
-      </div>
-    </section>
-
-    <section class="section section-extra section-defs" id="definitions">
-      <div class="content">
-        <h2 class="section-title">{{ _('Definitions') }}</h2>
-
-        <dl class="prose">
-          <dt id="dfn-counter-notice">{{ _('Counter Notice') }}</dt>
-          <dd>
-            <p>{{ _('Documentation that meets the counter notification requirements <a href="%s">set forth here</a> in response to a <a href="%s">Takedown Notice</a>.')|format(url('legal.report-infringement'), url('mozorg.about.policy.transparency.index') + '#dfn-takedown-notice') }}</p>
-          </dd>
-
-          <dt id="dfn-court-order">{{ _('Court Order') }}</dt>
-          <dd>
-            <p>{{ _('An order issued by a judge or magistrate compelling a company to engage or refrain from certain action.') }}</p>
-          </dd>
-
-          <dt id="dfn-threat-indicator">{{ _('Cybersecurity Threat Indicator') }}</dt>
-          <dd>
-            <p>{{ _('Pieces of information about a threat to a computer network or system, such as a vulnerability, piece of malicious code, or the IP address of an attacker. This definition is based on the Cybersecurity Information Sharing Act of 2015 (CISA); the full definition is at <a href="%s">6 U.S.C. § 1501(6)</a>.')|format('http://uscode.house.gov/view.xhtml?req=%28title:6%20section:1501%20edition:prelim%29%20OR%20%28granuleid:USC-prelim-title6-section1501%29&f=treesort&edition=prelim&num=0&jumpTo=true') }}</p>
-          </dd>
-
-          <dt id="dfn-emergency-request">{{ _('Emergency Request') }}</dt>
-          <dd>
-            <p>{{ _('A request from a government agency seeking information on an expedited basis in connection with an emergency, typically involving death or serious injury.') }}</p>
-          </dd>
-
-          <dt id="dfn-legal-process">{{ _('Legal Process') }}</dt>
-          <dd>
-            <p>
-            {% trans
-              link_emergency_req='#dfn-emergency-request',
-              link_court_order='#dfn-court-order',
-              link_natl_security='#dfn-natl-security-request',
-              link_pen_register='#dfn-pen-register-order',
-              link_search_warrant='#dfn-search-warrant',
-              link_subpoena='#dfn-subpoena',
-              link_wiretap='#dfn-wiretap-order'
-            %}
-            Examples of legal processes include: <a href="{{ link_emergency_req }}">Emergency Request</a>, <a href="{{ link_court_order }}">Court Order</a>, <a href="{{ link_natl_security }}">National Security Request</a>, <a href="{{ link_pen_register }}">Pen Register Order</a>, <a href="{{ link_search_warrant }}">Search Warrant</a>, <a href="{{ link_subpoena }}">Subpoena</a> and <a href="{{ link_wiretap }}">Wiretap Order</a>.
-            {% endtrans %}
-            </p>
-          </dd>
-
-          <dt id="dfn-natl-security-request">{{ _('National Security Request') }}</dt>
-          <dd><p>{{ _('A National Security Letter issued under 18 U.S.C.§2709, a Court Order issued under the Foreign Intelligence Surveillance Act or any other classified request for user information issued in the U.S.') }}</p></dd>
-
-          <dt id="dfn-pen-register-order">{{ _('Pen Register Order') }}</dt>
-          <dd><p>{{ _('A Pen Register and Trap and Trace Order is a type of U.S. <a href="%s">Court Order</a> compelling a company to disclose data about a user’s real­time communications (excluding the content of the communications themselves) to law enforcement on an ongoing basis, usually for a period of 60 days.')|format('#dfn-court-order') }}</p></dd>
-
-          <dt id="dfn-personal-data-request">{{ _('Personal Data Request') }}</dt>
-          <dd><p>{{ _('A user-generated request about personal data such as how to delete, port, modify or access it.  For the purpose of our Transparency  Report, we count the number of requests received by email, post, or to our portal for Data Subject Access Requests.  We don’t count (or have metrics for) the number of such requests that our users process themselves through in-product features.') }}</p></dd>
-
-          <dt id="dfn-search-warrant">{{ _('Search Warrant') }}</dt>
-          <dd><p>{{ _('A document authorizing law enforcement to obtain user data issued by a neutral and detached magistrate on the basis of finding that “probable cause” exists to believe that the items being sought will be found in the place to be searched.') }}</p></dd>
-
-          <dt id="dfn-specific-user">{{ _('Specific User') }}</dt>
-          <dd><p>{{ _('An identifiable user of Mozilla’s products and services.') }}</p></dd>
-
-          <dt id="dfn-subpoena">{{ _('Subpoena') }}</dt>
-          <dd><p>{{ _('A formal request for the production of evidence or testimony that can be issued by a government agency or court. Judicial review is not necessarily required.') }}</p></dd>
-
-          <dt id="dfn-takedown-notice">{{ _('Takedown Notice') }}</dt>
-          <dd><p>{{ _('Documentation that meets the requirements set forth in our <a href="%s">reporting copyright or trademark infringement page</a>.')|format(url('legal.report-infringement')) }}</p></dd>
-
-          <dt id="dfn-wiretap-order">{{ _('Wiretap Order') }}</dt>
-          <dd><p>{{ _('A type of U.S. Court Order compelling a company to disclose the metadata and content of a user’s real­time communications to law enforcement on an ongoing basis, usually for a period of 30 days.') }}</p></dd>
-        </dl>
-      </div>
-    </section>
-
-  </main>
+      <dt id="dfn-wiretap-order">{{ _('Wiretap Order') }}</dt>
+      <dd>
+        <p>
+          {{ _('A type of U.S. Court Order compelling a company to disclose the metadata and content of a user’s real­time communications to law enforcement on an ongoing basis, usually for a period of 30 days.') }}
+        </p>
+      </dd>
+    </dl>
+  </div>
+</main>
 {% endblock %}
 
 {% block email_form %}{% endblock %}

--- a/bedrock/mozorg/templates/mozorg/about/policy/transparency/jan-dec-2015.html
+++ b/bedrock/mozorg/templates/mozorg/about/policy/transparency/jan-dec-2015.html
@@ -7,189 +7,201 @@
 {% block page_title %}{{ _('Transparency Report - 2015') }}{% endblock %}
 
 {% block report_title %}
-  <h1>{{ _('Transparency Report') }} <span>{{ _('Reporting Period: January 1, 2015 to December 31, 2015') }}</span></h1>
+<h1>{{ _('Transparency Report') }} <span>{{ _('Reporting Period: January 1, 2015 to December 31, 2015') }}</span></h1>
 {% endblock %}
 
 {% block report_body %}
-  <section class="section" id="government-user-data">
-    <h2 class="section-title" data-accordion-role="tab">{{ _('Government Demands for User Data') }}</h2>
+<section id="government-user-data" class="c-collapsible-section">
+  <h2 class="c-collapsible-section-heading" data-accordion-role="tab">{{ _('Government Demands for User Data') }}</h2>
 
-    <div class="content" data-accordion-role="tabpanel">
-      <p>
-        {{ _('In the Reporting Period, Mozilla did not receive any government demands through Legal Processes for user data.') }}
-      </p>
+  <div data-accordion-role="tabpanel">
+    <p>
+      {{ _('In the Reporting Period, Mozilla did not receive any government demands through Legal Processes for user data.') }}
+    </p>
 
-      <table class="data-table">
-        <thead>
-          <tr>
-            <th scope="col">{{ _('Legal Processes') }}</th>
-            <th scope="col">{{ _('Received') }}</th>
-            <th scope="col">{{ _('Data Produced') }}</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <th scope="row">
-              <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-search-warrant' }}">{{ _('Search Warrants') }}</a>
-            </th>
-            <td>0</td>
-            <td>{{ _('N/A') }}</td>
-          </tr>
-          <tr>
-            <th scope="row">
-              <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-subpoena' }}">{{ _('Subpoenas') }}</a>
-            </th>
-            <td>0</td>
-            <td>{{ _('N/A') }}</td>
-          </tr>
-          <tr>
-            <th scope="row">
-              <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-court-order' }}">{{ _('Court Orders') }}</a>
-            </th>
-            <td>0</td>
-            <td>{{ _('N/A') }}</td>
-          </tr>
-          <tr>
-            <th scope="row">
-              <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-wiretap-order' }}">{{ _('Wiretap Orders') }}</a>
-            </th>
-            <td>0</td>
-            <td>{{ _('N/A') }}</td>
-          </tr>
-          <tr>
-            <th scope="row">
-              <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-pen-register-order' }}">{{ _('Pen Register Orders') }}</a>
-            </th>
-            <td>0</td>
-            <td>{{ _('N/A') }}</td>
-          </tr>
-          <tr>
-            <th scope="row">
-              <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-emergency-request' }}">{{ _('Emergency Requests') }}</a>
-            </th>
-            <td>0</td>
-            <td>{{ _('N/A') }}</td>
-          </tr>
-          <tr>
-            <th scope="row">
-              <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-natl-security-request' }}">{{ _('National Security Requests') }}</a> <sup><a href="#footnote-1">1</a></sup>
-            </th>
-            <td>0</td>
-            <td>{{ _('N/A') }}</td>
-          </tr>
-        </tbody>
-      </table>
+    <table class="mzp-u-data-table">
+      <thead>
+        <tr>
+          <th scope="col">{{ _('Legal Processes') }}</th>
+          <th scope="col">{{ _('Received') }}</th>
+          <th scope="col">{{ _('Data Produced') }}</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <th scope="row">
+            <a
+              href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-search-warrant' }}">{{ _('Search Warrants') }}</a>
+          </th>
+          <td>0</td>
+          <td>{{ _('N/A') }}</td>
+        </tr>
+        <tr>
+          <th scope="row">
+            <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-subpoena' }}">{{ _('Subpoenas') }}</a>
+          </th>
+          <td>0</td>
+          <td>{{ _('N/A') }}</td>
+        </tr>
+        <tr>
+          <th scope="row">
+            <a
+              href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-court-order' }}">{{ _('Court Orders') }}</a>
+          </th>
+          <td>0</td>
+          <td>{{ _('N/A') }}</td>
+        </tr>
+        <tr>
+          <th scope="row">
+            <a
+              href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-wiretap-order' }}">{{ _('Wiretap Orders') }}</a>
+          </th>
+          <td>0</td>
+          <td>{{ _('N/A') }}</td>
+        </tr>
+        <tr>
+          <th scope="row">
+            <a
+              href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-pen-register-order' }}">{{ _('Pen Register Orders') }}</a>
+          </th>
+          <td>0</td>
+          <td>{{ _('N/A') }}</td>
+        </tr>
+        <tr>
+          <th scope="row">
+            <a
+              href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-emergency-request' }}">{{ _('Emergency Requests') }}</a>
+          </th>
+          <td>0</td>
+          <td>{{ _('N/A') }}</td>
+        </tr>
+        <tr>
+          <th scope="row">
+            <a
+              href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-natl-security-request' }}">{{ _('National Security Requests') }}</a>
+            <sup><a href="#footnote-1">1</a></sup>
+          </th>
+          <td>0</td>
+          <td>{{ _('N/A') }}</td>
+        </tr>
+      </tbody>
+    </table>
 
-      <aside class="footnotes">
-        <section id="footnote-1">
-          <p>{{ _('1. Mozilla has never received a National Security Request.') }}</p>
-        </section>
-      </aside>
-    </div>
-  </section>
+    <aside class="footnotes">
+      <p>{{ _('1. Mozilla has never received a National Security Request.') }}</p>
+    </aside>
+  </div>
+</section>
 
-  <section class="section" id="government-content-removal">
-    <h2 class="section-title" data-accordion-role="tab">{{ _('Government Demands for Content Removal') }}</h2>
+<section id="government-content-removal" class="c-collapsible-section">
+  <h2 class="c-collapsible-section-heading" data-accordion-role="tab">{{ _('Government Demands for Content Removal') }}
+  </h2>
 
-    <div class="content" data-accordion-role="tabpanel">
-      <p>{{ _('In the Reporting Period, Mozilla did not receive any government requests for content removal from our services.') }}</p>
+  <div data-accordion-role="tabpanel">
+    <p>
+      {{ _('In the Reporting Period, Mozilla did not receive any government requests for content removal from our services.') }}
+    </p>
 
-      <table class="data-table">
-        <thead>
-          <tr>
-            <th scope="col">{{ _('Requesting Country') }}</th>
-            <th scope="col">{{ _('Requests Received') }}</th>
-            <th scope="col">{{ _('Data Produced') }}</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <th scope="row">{{ _('N/A') }}</th>
-            <td>0</td>
-            <td>{{ _('N/A') }}</td>
-          </tr>
-        </tbody>
-      </table>
+    <table class="mzp-u-data-table">
+      <thead>
+        <tr>
+          <th scope="col">{{ _('Requesting Country') }}</th>
+          <th scope="col">{{ _('Requests Received') }}</th>
+          <th scope="col">{{ _('Data Produced') }}</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <th scope="row">{{ _('N/A') }}</th>
+          <td>0</td>
+          <td>{{ _('N/A') }}</td>
+        </tr>
+      </tbody>
+    </table>
 
-    </div>
-  </section>
+  </div>
+</section>
 
-  <section class="section" id="copyright-trademark">
-    <h2 class="section-title" data-accordion-role="tab">{{ _('Copyright and Trademark Requests') }}</h2>
+<section id="copyright-trademark" class="c-collapsible-section">
+  <h2 class="c-collapsible-section-heading" data-accordion-role="tab">{{ _('Copyright and Trademark Requests') }}</h2>
 
-    <div class="content" data-accordion-role="tabpanel">
-      <h3>{{ _('Copyright') }}</h3>
-      <p>{{ _('In the Reporting Period, we received 29 Copyright Takedown Notices and 2 Counter Notices.') }}</p>
+  <div data-accordion-role="tabpanel">
+    <h3>{{ _('Copyright') }}</h3>
+    <p>{{ _('In the Reporting Period, we received 29 Copyright Takedown Notices and 2 Counter Notices.') }}</p>
 
-      <table class="data-table">
-        <thead>
-          <tr>
-            <th scope="col">{{ _('Mozilla Service') }}</th>
-            <th scope="col">
-              <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-takedown-notice' }}">{{ _('Takedown Notices') }}</a>
-            </th>
-            <th scope="col">
-              <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-counter-notice' }}">{{ _('Counter Notices') }}</a>
-            </th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <th scope="row">{{ _('Firefox Add-ons (Themes)') }}</th>
-            <td>24</td>
-            <td>2</td>
-          </tr>
-          <tr>
-            <th scope="row">{{ _('Firefox Marketplace (Apps)') }}</th>
-            <td>4</td>
-            <td>0</td>
-          </tr>
-          <tr>
-            <th scope="row">{{ _('Mozilla Developer Network') }}</th>
-            <td>1</td>
-            <td>0</td>
-          </tr>
-        </tbody>
-      </table>
+    <table class="mzp-u-data-table">
+      <thead>
+        <tr>
+          <th scope="col">{{ _('Mozilla Service') }}</th>
+          <th scope="col">
+            <a
+              href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-takedown-notice' }}">{{ _('Takedown Notices') }}</a>
+          </th>
+          <th scope="col">
+            <a
+              href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-counter-notice' }}">{{ _('Counter Notices') }}</a>
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <th scope="row">{{ _('Firefox Add-ons (Themes)') }}</th>
+          <td>24</td>
+          <td>2</td>
+        </tr>
+        <tr>
+          <th scope="row">{{ _('Firefox Marketplace (Apps)') }}</th>
+          <td>4</td>
+          <td>0</td>
+        </tr>
+        <tr>
+          <th scope="row">{{ _('Mozilla Developer Network') }}</th>
+          <td>1</td>
+          <td>0</td>
+        </tr>
+      </tbody>
+    </table>
 
-      <h3>{{ _('Trademark') }}</h3>
-      <p>{{ _('In the Reporting Period, we received 10 Trademark Takedown Notices and 0 Counter Notices.') }}</p>
+    <h3>{{ _('Trademark') }}</h3>
+    <p>{{ _('In the Reporting Period, we received 10 Trademark Takedown Notices and 0 Counter Notices.') }}</p>
 
-      <table class="data-table">
-        <thead>
-          <tr>
-            <th scope="col">{{ _('Mozilla Service') }}</th>
-            <th scope="col">
-              <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-takedown-notice' }}">{{ _('Takedown Notices') }}</a>
-            </th>
-            <th scope="col">
-              <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-counter-notice' }}">{{ _('Counter Notices') }}</a>
-            </th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <th scope="row">{{ _('Firefox Add-ons (Extensions)') }}</th>
-            <td>8</td>
-            <td>0</td>
-          </tr>
-          <tr>
-            <th scope="row">{{ _('Firefox Marketplace (Apps)') }}</th>
-            <td>2</td>
-            <td>0</td>
-          </tr>
-        </tbody>
-      </table>
+    <table class="mzp-u-data-table">
+      <thead>
+        <tr>
+          <th scope="col">{{ _('Mozilla Service') }}</th>
+          <th scope="col">
+            <a
+              href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-takedown-notice' }}">{{ _('Takedown Notices') }}</a>
+          </th>
+          <th scope="col">
+            <a
+              href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-counter-notice' }}">{{ _('Counter Notices') }}</a>
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <th scope="row">{{ _('Firefox Add-ons (Extensions)') }}</th>
+          <td>8</td>
+          <td>0</td>
+        </tr>
+        <tr>
+          <th scope="row">{{ _('Firefox Marketplace (Apps)') }}</th>
+          <td>2</td>
+          <td>0</td>
+        </tr>
+      </tbody>
+    </table>
 
-    </div>
-  </section>
+  </div>
+</section>
 
-  <section class="section" id="supplement">
-    <h2 class="section-title" data-accordion-role="tab">{{ _('Supplement') }}</h2>
+<section id="supplement" class="c-collapsible-section">
+  <h2 class="c-collapsible-section-heading" data-accordion-role="tab">{{ _('Supplement') }}</h2>
 
-    <div class="content" data-accordion-role="tabpanel">
-      <h3>{{ _('Legislative Reform') }}</h3>
-      <p>
+  <div data-accordion-role="tabpanel">
+    <h3>{{ _('Legislative Reform') }}</h3>
+    <p>
       {% trans
           link_reform='https://blog.mozilla.org/netpolicy/2015/04/14/stop-mass-surveillance-under-the-patriot-act/',
           link_london='https://blog.mozilla.org/netpolicy/2015/12/04/uk-ip-bill-is-a-threat-to-privacy-security-and-trust-online/',
@@ -197,52 +209,61 @@
           link_paris='https://blog.mozilla.org/netpolicy/2015/05/12/french-national-assembly-advances-dangerous-mass-surveillance-law/',
           link_ottawa='https://blog.mozilla.org/netpolicy/2015/03/25/information-sharing-debates-continuing-in-problematic-directions/'
       %}
-        In the Reporting Period, we mobilized for <a href="{{ link_reform }}">surveillance reform in the US</a> and pushed back against overbroad intelligence laws from <a href="{{ link_london }}">London</a> to <a href="{{ link_berlin }}">Berlin</a> to <a href="{{ link_paris }}">Paris</a> to <a href="{{ link_ottawa }}">Ottawa</a>.
+      In the Reporting Period, we mobilized for <a href="{{ link_reform }}">surveillance reform in the US</a> and pushed
+      back against overbroad intelligence laws from <a href="{{ link_london }}">London</a> to <a
+        href="{{ link_berlin }}">Berlin</a> to <a href="{{ link_paris }}">Paris</a> to <a
+        href="{{ link_ottawa }}">Ottawa</a>.
       {% endtrans %}
       {% trans
           link_cisa='https://blog.mozilla.org/netpolicy/2015/03/02/mozilla-statement-on-cisa/',
           link_delphi='https://blog.mozilla.org/netpolicy/2015/07/28/experts-develop-cybersecurity-recommendations/'
       %}
-        We were also active in the realm of cybersecurity, <a href="{{ link_cisa }}">speaking out early against overbroad portions of the Cybersecurity Information Sharing Act</a> (CISA), and convening more than 30 leading cybersecurity experts from a wide variety ofbackgrounds to identify pro­defense <a href="{{ link_delphi }}">Cybersecurity Delphi Project</a>.
+      We were also active in the realm of cybersecurity, <a href="{{ link_cisa }}">speaking out early against overbroad
+        portions of the Cybersecurity Information Sharing Act</a> (CISA), and convening more than 30 leading
+      cybersecurity experts from a wide variety ofbackgrounds to identify pro­defense <a
+        href="{{ link_delphi }}">Cybersecurity Delphi Project</a>.
       {% endtrans %}
-      </p>
+    </p>
 
-      <h3>{{ _('Sharing of Cybersecurity Threat Indicators') }}</h3>
+    <h3>{{ _('Sharing of Cybersecurity Threat Indicators') }}</h3>
 
-      <table class="data-table">
-        <tr>
-          <th scope="row">
-            <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-threat-indicator' }}">{{ _('Cybersecurity Threat Indicator') }}</a>
-          </th>
-          <td>1</td>
-        </tr>
-      </table>
+    <table class="mzp-u-data-table">
+      <tr>
+        <th scope="row">
+          <a
+            href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-threat-indicator' }}">{{ _('Cybersecurity Threat Indicator') }}</a>
+        </th>
+        <td>1</td>
+      </tr>
+    </table>
 
-      <p>
-        {{ _('The Cybersecurity Information Sharing Act of 2015 (CISA) provided a framework for companies to voluntarily share cybersecurity threat indicators with each other, as well as with the government, to prevent cyber attacks.') }}
-        {{ _('We believe this type of sharing is appropriate under some circumstances and encourage companies to be transparent with their users when this occurs.') }}
-      </p>
+    <p>
+      {{ _('The Cybersecurity Information Sharing Act of 2015 (CISA) provided a framework for companies to voluntarily share cybersecurity threat indicators with each other, as well as with the government, to prevent cyber attacks.') }}
+      {{ _('We believe this type of sharing is appropriate under some circumstances and encourage companies to be transparent with their users when this occurs.') }}
+    </p>
 
-      <p>
-        {{ _('In the Reporting Period, Bugzilla experienced a security incident, which we reported about on Mozilla’s <a href="%s">security blog</a>.')|format('https://blog.mozilla.org/security/2015/09/04/improving-security-for-bugzilla/') }}
-        {{ _('As permitted by law, we voluntarily shared IP addresses associated with the security incident with the Federal Bureau of Investigation (FBI).') }}
-        {{ _('Although this occurred prior to the passage of CISA, the IP addresses are examples of cybersecurity threat indicators and relevant for purposes of transparency reporting.') }}
-      </p>
+    <p>
+      {{ _('In the Reporting Period, Bugzilla experienced a security incident, which we reported about on Mozilla’s <a href="%s">security blog</a>.')|format('https://blog.mozilla.org/security/2015/09/04/improving-security-for-bugzilla/') }}
+      {{ _('As permitted by law, we voluntarily shared IP addresses associated with the security incident with the Federal Bureau of Investigation (FBI).') }}
+      {{ _('Although this occurred prior to the passage of CISA, the IP addresses are examples of cybersecurity threat indicators and relevant for purposes of transparency reporting.') }}
+    </p>
 
-      <h3>{{ _('<a href="%s">Specific User</a> Data Disclosures')|format(url('mozorg.about.policy.transparency.index') + '#dfn-specific-user') }}</h3>
+    <h3>
+      {{ _('<a href="%s">Specific User</a> Data Disclosures')|format(url('mozorg.about.policy.transparency.index') + '#dfn-specific-user') }}
+    </h3>
 
-      <table class="data-table">
-        <tr>
-          <th scope="row">{{ _('CyberTipline disclosure') }}</th>
-          <td>1</td>
-        </tr>
-      </table>
+    <table class="mzp-u-data-table">
+      <tr>
+        <th scope="row">{{ _('CyberTipline disclosure') }}</th>
+        <td>1</td>
+      </tr>
+    </table>
 
-      <p>
-        {{ _('Information about possible child sexual exploitation can be voluntarily reported by anyone to the National Center for Missing &amp; Exploited Children’s (NCMEC) <a href="%s">CyberTipline</a>.')|format('http://www.missingkids.org/cybertipline') }}
-        {{ _('We take this issue seriously.') }}
-        {{ _('In the Reporting Period, Mozilla disclosed Specific User data to the NCMEC in connection with a Theme that was submitted (but not published) to Firefox Add­ons (“AMO”) and implicated child sexual exploitation.') }}
-      </p>
-    </div>
-  </section>
+    <p>
+      {{ _('Information about possible child sexual exploitation can be voluntarily reported by anyone to the National Center for Missing &amp; Exploited Children’s (NCMEC) <a href="%s">CyberTipline</a>.')|format('http://www.missingkids.org/cybertipline') }}
+      {{ _('We take this issue seriously.') }}
+      {{ _('In the Reporting Period, Mozilla disclosed Specific User data to the NCMEC in connection with a Theme that was submitted (but not published) to Firefox Add­ons (“AMO”) and implicated child sexual exploitation.') }}
+    </p>
+  </div>
+</section>
 {% endblock %}

--- a/bedrock/mozorg/templates/mozorg/about/policy/transparency/jan-jun-2016.html
+++ b/bedrock/mozorg/templates/mozorg/about/policy/transparency/jan-jun-2016.html
@@ -7,186 +7,198 @@
 {% block page_title %}{{ _('Transparency Report - January–June, 2016') }}{% endblock %}
 
 {% block report_title %}
-  <h1>{{ _('Transparency Report') }} <span>{{ _('Reporting Period: January 1, 2016 to June 30, 2016') }}</span></h1>
+<h1>{{ _('Transparency Report') }} <span>{{ _('Reporting Period: January 1, 2016 to June 30, 2016') }}</span></h1>
 {% endblock %}
 
 {% block report_body %}
-  <section class="section" id="government-user-data">
-    <h2 class="section-title" data-accordion-role="tab">{{ _('Government Demands for User Data') }}</h2>
+<section id="government-user-data" class="c-collapsible-section">
+  <h2 class="c-collapsible-section-heading" data-accordion-role="tab">{{ _('Government Demands for User Data') }}</h2>
 
-    <div class="content" data-accordion-role="tabpanel">
-      <p>
-        {{ _('In the Reporting Period, Mozilla did not receive any government demands through Legal Processes for user data.') }}
-      </p>
+  <div data-accordion-role="tabpanel">
+    <p>
+      {{ _('In the Reporting Period, Mozilla did not receive any government demands through Legal Processes for user data.') }}
+    </p>
 
-      <table class="data-table">
-        <thead>
-          <tr>
-            <th scope="col">{{ _('Legal Processes') }}</th>
-            <th scope="col">{{ _('Received') }}</th>
-            <th scope="col">{{ _('Data Produced') }}</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <th scope="row">
-              <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-search-warrant' }}">{{ _('Search Warrants') }}</a>
-            </th>
-            <td>0</td>
-            <td>{{ _('N/A') }}</td>
-          </tr>
-          <tr>
-            <th scope="row">
-              <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-subpoena' }}">{{ _('Subpoenas') }}</a>
-            </th>
-            <td>0</td>
-            <td>{{ _('N/A') }}</td>
-          </tr>
-          <tr>
-            <th scope="row">
-              <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-court-order' }}">{{ _('Court Orders') }}</a>
-            </th>
-            <td>0</td>
-            <td>{{ _('N/A') }}</td>
-          </tr>
-          <tr>
-            <th scope="row">
-              <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-wiretap-order' }}">{{ _('Wiretap Orders') }}</a>
-            </th>
-            <td>0</td>
-            <td>{{ _('N/A') }}</td>
-          </tr>
-          <tr>
-            <th scope="row">
-              <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-pen-register-order' }}">{{ _('Pen Register Orders') }}</a>
-            </th>
-            <td>0</td>
-            <td>{{ _('N/A') }}</td>
-          </tr>
-          <tr>
-            <th scope="row">
-              <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-emergency-request' }}">{{ _('Emergency Requests') }}</a>
-            </th>
-            <td>0</td>
-            <td>{{ _('N/A') }}</td>
-          </tr>
-          <tr>
-            <th scope="row">
-              <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-natl-security-request' }}">{{ _('National Security Requests') }}</a> <sup><a href="#footnote-1">1</a></sup>
-            </th>
-            <td>0</td>
-            <td>{{ _('N/A') }}</td>
-          </tr>
-        </tbody>
-      </table>
+    <table class="mzp-u-data-table">
+      <thead>
+        <tr>
+          <th scope="col">{{ _('Legal Processes') }}</th>
+          <th scope="col">{{ _('Received') }}</th>
+          <th scope="col">{{ _('Data Produced') }}</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <th scope="row">
+            <a
+              href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-search-warrant' }}">{{ _('Search Warrants') }}</a>
+          </th>
+          <td>0</td>
+          <td>{{ _('N/A') }}</td>
+        </tr>
+        <tr>
+          <th scope="row">
+            <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-subpoena' }}">{{ _('Subpoenas') }}</a>
+          </th>
+          <td>0</td>
+          <td>{{ _('N/A') }}</td>
+        </tr>
+        <tr>
+          <th scope="row">
+            <a
+              href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-court-order' }}">{{ _('Court Orders') }}</a>
+          </th>
+          <td>0</td>
+          <td>{{ _('N/A') }}</td>
+        </tr>
+        <tr>
+          <th scope="row">
+            <a
+              href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-wiretap-order' }}">{{ _('Wiretap Orders') }}</a>
+          </th>
+          <td>0</td>
+          <td>{{ _('N/A') }}</td>
+        </tr>
+        <tr>
+          <th scope="row">
+            <a
+              href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-pen-register-order' }}">{{ _('Pen Register Orders') }}</a>
+          </th>
+          <td>0</td>
+          <td>{{ _('N/A') }}</td>
+        </tr>
+        <tr>
+          <th scope="row">
+            <a
+              href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-emergency-request' }}">{{ _('Emergency Requests') }}</a>
+          </th>
+          <td>0</td>
+          <td>{{ _('N/A') }}</td>
+        </tr>
+        <tr>
+          <th scope="row">
+            <a
+              href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-natl-security-request' }}">{{ _('National Security Requests') }}</a>
+            <sup><a href="#footnote-1">1</a></sup>
+          </th>
+          <td>0</td>
+          <td>{{ _('N/A') }}</td>
+        </tr>
+      </tbody>
+    </table>
 
-      <aside class="footnotes">
-        <section id="footnote-1">
-          <p>{{ _('1. Mozilla has never received a National Security Request.') }}</p>
-        </section>
-      </aside>
-    </div>
-  </section>
+    <aside class="footnotes">
+      <p>{{ _('1. Mozilla has never received a National Security Request.') }}</p>
+    </aside>
+  </div>
+</section>
 
-  <section class="section" id="government-content-removal">
-    <h2 class="section-title" data-accordion-role="tab">{{ _('Government Demands for Content Removal') }}</h2>
+<section id="government-content-removal" class="c-collapsible-section">
+  <h2 class="c-collapsible-section-heading" data-accordion-role="tab">{{ _('Government Demands for Content Removal') }}
+  </h2>
 
-    <div class="content" data-accordion-role="tabpanel">
-      <p>{{ _('In the Reporting Period, Mozilla did not receive any government requests for content removal from our services.') }}</p>
+  <div data-accordion-role="tabpanel">
+    <p>
+      {{ _('In the Reporting Period, Mozilla did not receive any government requests for content removal from our services.') }}
+    </p>
 
-      <table class="data-table">
-        <thead>
-          <tr>
-            <th scope="col">{{ _('Requesting Country') }}</th>
-            <th scope="col">{{ _('Requests Received') }}</th>
-            <th scope="col">{{ _('Data Produced') }}</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <th scope="row">{{ _('N/A') }}</th>
-            <td>0</td>
-            <td>{{ _('N/A') }}</td>
-          </tr>
-        </tbody>
-      </table>
+    <table class="mzp-u-data-table">
+      <thead>
+        <tr>
+          <th scope="col">{{ _('Requesting Country') }}</th>
+          <th scope="col">{{ _('Requests Received') }}</th>
+          <th scope="col">{{ _('Data Produced') }}</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <th scope="row">{{ _('N/A') }}</th>
+          <td>0</td>
+          <td>{{ _('N/A') }}</td>
+        </tr>
+      </tbody>
+    </table>
 
-    </div>
-  </section>
+  </div>
+</section>
 
-  <section class="section" id="copyright-trademark">
-    <h2 class="section-title" data-accordion-role="tab">{{ _('Copyright and Trademark Requests') }}</h2>
+<section id="copyright-trademark" class="c-collapsible-section">
+  <h2 class="c-collapsible-section-heading" data-accordion-role="tab">{{ _('Copyright and Trademark Requests') }}</h2>
 
-    <div class="content" data-accordion-role="tabpanel">
-      <h3>{{ _('Copyright') }}</h3>
-      <p>{{ _('In the Reporting Period, we received 4 Copyright Takedown Notices and 0 Counter Notices.') }}</p>
+  <div data-accordion-role="tabpanel">
+    <h3>{{ _('Copyright') }}</h3>
+    <p>{{ _('In the Reporting Period, we received 4 Copyright Takedown Notices and 0 Counter Notices.') }}</p>
 
-      <table class="data-table">
-        <thead>
-          <tr>
-            <th scope="col">{{ _('Mozilla Service') }}</th>
-            <th scope="col">
-              <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-takedown-notice' }}">{{ _('Takedown Notices') }}</a>
-            </th>
-            <th scope="col">
-              <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-counter-notice' }}">{{ _('Counter Notices') }}</a>
-            </th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <th scope="row">{{ _('Firefox Add-ons') }}</th>
-            <td>4</td>
-            <td>0</td>
-          </tr>
-          <tr>
-            <th scope="row">{{ _('Firefox Marketplace (Apps)') }}</th>
-            <td>0</td>
-            <td>0</td>
-          </tr>
-        </tbody>
-      </table>
+    <table class="mzp-u-data-table">
+      <thead>
+        <tr>
+          <th scope="col">{{ _('Mozilla Service') }}</th>
+          <th scope="col">
+            <a
+              href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-takedown-notice' }}">{{ _('Takedown Notices') }}</a>
+          </th>
+          <th scope="col">
+            <a
+              href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-counter-notice' }}">{{ _('Counter Notices') }}</a>
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <th scope="row">{{ _('Firefox Add-ons') }}</th>
+          <td>4</td>
+          <td>0</td>
+        </tr>
+        <tr>
+          <th scope="row">{{ _('Firefox Marketplace (Apps)') }}</th>
+          <td>0</td>
+          <td>0</td>
+        </tr>
+      </tbody>
+    </table>
 
-      <h3>{{ _('Trademark') }}</h3>
-      <p>{{ _('In the Reporting Period, we received 4 Trademark Takedown Notices and 0 Counter Notices') }}</p>
+    <h3>{{ _('Trademark') }}</h3>
+    <p>{{ _('In the Reporting Period, we received 4 Trademark Takedown Notices and 0 Counter Notices') }}</p>
 
-      <table class="data-table">
-        <thead>
-          <tr>
-            <th scope="col">{{ _('Mozilla Service') }}</th>
-            <th scope="col">
-              <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-takedown-notice' }}">{{ _('Takedown Notices') }}</a>
-            </th>
-            <th scope="col">
-              <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-counter-notice' }}">{{ _('Counter Notices') }}</a>
-            </th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <th scope="row">{{ _('Firefox Add-ons') }}</th>
-            <td>3</td>
-            <td>0</td>
-          </tr>
-          <tr>
-            <th scope="row">{{ _('Firefox Marketplace (Apps)') }}</th>
-            <td>1</td>
-            <td>0</td>
-          </tr>
-        </tbody>
-      </table>
+    <table class="mzp-u-data-table">
+      <thead>
+        <tr>
+          <th scope="col">{{ _('Mozilla Service') }}</th>
+          <th scope="col">
+            <a
+              href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-takedown-notice' }}">{{ _('Takedown Notices') }}</a>
+          </th>
+          <th scope="col">
+            <a
+              href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-counter-notice' }}">{{ _('Counter Notices') }}</a>
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <th scope="row">{{ _('Firefox Add-ons') }}</th>
+          <td>3</td>
+          <td>0</td>
+        </tr>
+        <tr>
+          <th scope="row">{{ _('Firefox Marketplace (Apps)') }}</th>
+          <td>1</td>
+          <td>0</td>
+        </tr>
+      </tbody>
+    </table>
 
-    </div>
-  </section>
+  </div>
+</section>
 
-  <section class="section" id="supplement">
-    <h2 class="section-title" data-accordion-role="tab">{{ _('Supplement') }}</h2>
+<section id="supplement" class="c-collapsible-section">
+  <h2 class="c-collapsible-section-heading" data-accordion-role="tab">{{ _('Supplement') }}</h2>
 
-    <div class="content" data-accordion-role="tabpanel">
-      <h3>{{ _('Legislative Reform') }}</h3>
-      <p>
+  <div data-accordion-role="tabpanel">
+    <h3>{{ _('Legislative Reform') }}</h3>
+    <p>
       {% trans %}
-        In the Reporting Period, we advocated for stronger encryption, privacy, and security practices.
+      In the Reporting Period, we advocated for stronger encryption, privacy, and security practices.
       {% endtrans %}
 
       {% trans
@@ -195,47 +207,63 @@
           link_disclosure='https://blog.mozilla.org/blog/2016/05/11/advanced-disclosure-needed-to-keep-users-secure/',
           link_brief='https://blog.mozilla.org/blog/2016/03/03/standing-up-with-apple-to-fight-for-everyones-security/',
           link_letter='http://www.digital4th.org/wp-content/uploads/2016/05/ECPA-Provider-Emergency-Letter.pdf' %}
-        We ran a large scale <a href="{{ link_encryption }}">education campaign on encryption</a>, proposed <a href="{{ link_principles }}">Surveillance Principles</a> for government adoption, spoke out on the importance of <a href="{{ link_disclosure }}">disclosing security vulnerabilities</a> to affected companies in judicial proceedings, and joined with other tech companies to <a href="{{ link_brief }}">file a brief</a> arguing against backdoors in the Apple and FBI dispute and a <a href="{{ link_letter }}">letter to the U.S. Senate Judiciary Committee</a> opposing legislation that would compel companies to disclose the content of user communications without judicial oversight.
+      We ran a large scale <a href="{{ link_encryption }}">education campaign on encryption</a>, proposed <a
+        href="{{ link_principles }}">Surveillance Principles</a> for government adoption, spoke out on the importance of
+      <a href="{{ link_disclosure }}">disclosing security vulnerabilities</a> to affected companies in judicial
+      proceedings, and joined with other tech companies to <a href="{{ link_brief }}">file a brief</a> arguing against
+      backdoors in the Apple and FBI dispute and a <a href="{{ link_letter }}">letter to the U.S. Senate Judiciary
+        Committee</a> opposing legislation that would compel companies to disclose the content of user communications
+      without judicial oversight.
       {% endtrans %}
-      </p>
+    </p>
 
-      <p>
+    <p>
       {% trans link_us1='https://blog.mozilla.org/netpolicy/2016/03/07/challenges-to-openness-under-u-s-copyright-law/',
           link_us2='https://blog.mozilla.org/netpolicy/2016/04/05/reining-in-abuses-of-the-dmca-notice-system/',
           link_eu1='https://blog.mozilla.org/netpolicy/files/2016/05/Mozilla-IPRED-filing-April-2016.pdf',
           link_eu2='https://blog.mozilla.org/netpolicy/2016/05/02/this-is-what-a-rightsholder-looks-like-in-2016/',
           link_fcc='https://blog.mozilla.org/netpolicy/files/2016/05/Comments-on-NPRM-for-Broadband-Privacy.pdf'
            %}
-        In the realm of copyright, we filed comment on two U.S. Copyright Office consultations (<a href="{{ link_us1 }}">here</a> and <a href="{{ link_us2 }}">here</a>) and spoke out about the European Commission’s proposed overhaul of the EU’s copyright laws (<a href="{{ link_eu1 }}">here</a> and <a href="{{ link_eu2 }}">here</a>). We also commented on the U.S. Federal Communications Commission <a href="{{ link_fcc }}">recently proposed framework for broadband privacy</a>.
+      In the realm of copyright, we filed comment on two U.S. Copyright Office consultations (<a
+        href="{{ link_us1 }}">here</a> and <a href="{{ link_us2 }}">here</a>) and spoke out about the European
+      Commission’s proposed overhaul of the EU’s copyright laws (<a href="{{ link_eu1 }}">here</a> and <a
+        href="{{ link_eu2 }}">here</a>). We also commented on the U.S. Federal Communications Commission <a
+        href="{{ link_fcc }}">recently proposed framework for broadband privacy</a>.
       {% endtrans %}
 
       {% trans
           link_fund='https://blog.mozilla.org/blog/2016/06/09/help-make-open-source-secure/',
           link_leandata=url('mozorg.about.policy.lean-data.index') %}
-         In addition, we launched the <a href="{{ link_fund }}">Secure Open Source Fund</a> to promote security auditing and patching of widely used open source technologies and our <a href="{{ link_leandata }}">Lean Data Initiative</a> to encourage companies to be responsible in their use and stewardship of data.
+      In addition, we launched the <a href="{{ link_fund }}">Secure Open Source Fund</a> to promote security auditing
+      and patching of widely used open source technologies and our <a href="{{ link_leandata }}">Lean Data
+        Initiative</a> to encourage companies to be responsible in their use and stewardship of data.
       {% endtrans %}
-      </p>
+    </p>
 
-      <h3>{{ _('Threat Indicators &amp; Data Disclosures') }}</h3>
-      <table class="data-table">
-        <thead>
-          <tr>
-            <th scope="col">{{ _('Type of Disclosure') }}</th>
-            <th scope="col">{{ _('Number of Disclosures') }}</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <th scope="row"><a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-threat-indicator' }}">{{ _('Cybersecurity Threat Indicator') }}</a></th>
-            <td>0</td>
-          </tr>
-          <tr>
-            <th scope="row">{{ _('Other <a href="%s">Specific User</a> Data Disclosure')|format(url('mozorg.about.policy.transparency.index') + '#dfn-specific-user') }}</th>
-            <td>0</td>
-          </tr>
-        </tbody>
-      </table>
+    <h3>{{ _('Threat Indicators &amp; Data Disclosures') }}</h3>
+    <table class="mzp-u-data-table">
+      <thead>
+        <tr>
+          <th scope="col">{{ _('Type of Disclosure') }}</th>
+          <th scope="col">{{ _('Number of Disclosures') }}</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <th scope="row"><a
+              href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-threat-indicator' }}">{{ _('Cybersecurity Threat Indicator') }}</a>
+          </th>
+          <td>0</td>
+        </tr>
+        <tr>
+          <th scope="row">
+            {{ _('Other <a href="%s">Specific User</a> Data Disclosure')|format(url('mozorg.about.policy.transparency.index') + '#dfn-specific-user') }}
+          </th>
+          <td>0</td>
+        </tr>
+      </tbody>
+    </table>
 
-    </div>
-  </section>
+  </div>
+</section>
 {% endblock %}

--- a/bedrock/mozorg/templates/mozorg/about/policy/transparency/jan-jun-2017.html
+++ b/bedrock/mozorg/templates/mozorg/about/policy/transparency/jan-jun-2017.html
@@ -7,259 +7,274 @@
 {% block page_title %}{{ _('Transparency Report - January–June, 2017') }}{% endblock %}
 
 {% block report_title %}
-  <h1>{{ _('Transparency Report') }} <span>{{ _('Reporting Period: January 1, 2017 to June 30, 2017') }}</span></h1>
+<h1>{{ _('Transparency Report') }} <span>{{ _('Reporting Period: January 1, 2017 to June 30, 2017') }}</span></h1>
 {% endblock %}
 
 {% block report_body %}
-  <section class="section" id="government-user-data">
-    <h2 class="section-title" data-accordion-role="tab">{{ _('Government Demands for User Data') }}</h2>
+<section id="government-user-data" class="c-collapsible-section">
+  <h2 class="c-collapsible-section-heading" data-accordion-role="tab">{{ _('Government Demands for User Data') }}</h2>
 
-    <div class="content" data-accordion-role="tabpanel">
+  <div data-accordion-role="tabpanel">
+    <p>
+      {{ _('In the Reporting Period, Mozilla did not receive any government demands through Legal Processes for user data.') }}
+    </p>
+
+    <table class="mzp-u-data-table">
+      <thead>
+        <tr>
+          <th scope="col">{{ _('Legal Processes') }}</th>
+          <th scope="col">{{ _('Received') }}</th>
+          <th scope="col">{{ _('Data Produced') }}</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <th scope="row">
+            <a
+              href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-search-warrant' }}">{{ _('Search Warrants') }}</a>
+          </th>
+          <td>0</td>
+          <td>{{ _('N/A') }}</td>
+        </tr>
+        <tr>
+          <th scope="row">
+            <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-subpoena' }}">{{ _('Subpoenas') }}</a>
+            <sup><a href="#footnote-1">1</a></sup>
+          </th>
+          <td>1</td>
+          <td>{{ _('None') }}</td>
+        </tr>
+        <tr>
+          <th scope="row">
+            <a
+              href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-court-order' }}">{{ _('Court Orders') }}</a>
+          </th>
+          <td>0</td>
+          <td>{{ _('N/A') }}</td>
+        </tr>
+        <tr>
+          <th scope="row">
+            <a
+              href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-wiretap-order' }}">{{ _('Wiretap Orders') }}</a>
+          </th>
+          <td>0</td>
+          <td>{{ _('N/A') }}</td>
+        </tr>
+        <tr>
+          <th scope="row">
+            <a
+              href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-pen-register-order' }}">{{ _('Pen Register Orders') }}</a>
+          </th>
+          <td>0</td>
+          <td>{{ _('N/A') }}</td>
+        </tr>
+        <tr>
+          <th scope="row">
+            <a
+              href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-emergency-request' }}">{{ _('Emergency Requests') }}</a>
+          </th>
+          <td>0</td>
+          <td>{{ _('N/A') }}</td>
+        </tr>
+        <tr>
+          <th scope="row">
+            <a
+              href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-natl-security-request' }}">{{ _('National Security Requests') }}</a>
+            <sup><a href="#footnote-2">2</a></sup>
+          </th>
+          <td>0</td>
+          <td>{{ _('N/A') }}</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <aside class="footnotes">
       <p>
-        {{ _('In the Reporting Period, Mozilla did not receive any government demands through Legal Processes for user data.') }}
+        {{ _('1. Amended on <time datetime="2017-09-29">September 29, 2017</time> to include 1 subpoena received in May 2017 to which we did not produce data.') }}
       </p>
+      <p>{{ _('2. Mozilla has never received a National Security Request.') }}</p>
+    </aside>
+  </div>
+</section>
 
-      <table class="data-table">
-        <thead>
-          <tr>
-            <th scope="col">{{ _('Legal Processes') }}</th>
-            <th scope="col">{{ _('Received') }}</th>
-            <th scope="col">{{ _('Data Produced') }}</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <th scope="row">
-              <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-search-warrant' }}">{{ _('Search Warrants') }}</a>
-            </th>
-            <td>0</td>
-            <td>{{ _('N/A') }}</td>
-          </tr>
-          <tr>
-            <th scope="row">
-              <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-subpoena' }}">{{ _('Subpoenas') }}</a> <sup><a href="#footnote-1">1</a></sup>
-            </th>
-            <td>1</td>
-            <td>{{ _('None') }}</td>
-          </tr>
-          <tr>
-            <th scope="row">
-              <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-court-order' }}">{{ _('Court Orders') }}</a>
-            </th>
-            <td>0</td>
-            <td>{{ _('N/A') }}</td>
-          </tr>
-          <tr>
-            <th scope="row">
-              <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-wiretap-order' }}">{{ _('Wiretap Orders') }}</a>
-            </th>
-            <td>0</td>
-            <td>{{ _('N/A') }}</td>
-          </tr>
-          <tr>
-            <th scope="row">
-              <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-pen-register-order' }}">{{ _('Pen Register Orders') }}</a>
-            </th>
-            <td>0</td>
-            <td>{{ _('N/A') }}</td>
-          </tr>
-          <tr>
-            <th scope="row">
-              <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-emergency-request' }}">{{ _('Emergency Requests') }}</a>
-            </th>
-            <td>0</td>
-            <td>{{ _('N/A') }}</td>
-          </tr>
-          <tr>
-            <th scope="row">
-              <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-natl-security-request' }}">{{ _('National Security Requests') }}</a> <sup><a href="#footnote-2">2</a></sup>
-            </th>
-            <td>0</td>
-            <td>{{ _('N/A') }}</td>
-          </tr>
-        </tbody>
-      </table>
+<section id="government-content-removal" class="c-collapsible-section">
+  <h2 class="c-collapsible-section-heading" data-accordion-role="tab">{{ _('Government Demands for Content Removal') }}
+  </h2>
 
-      <aside class="footnotes">
-        <section id="footnote-1">
-          <p>{{ _('1. Amended on <time datetime="2017-09-29">September 29, 2017</time> to include 1 subpoena received in May 2017 to which we did not produce data.') }}</p>
-        </section>
-        <section id="footnote-2">
-          <p>{{ _('2. Mozilla has never received a National Security Request.') }}</p>
-        </section>
-      </aside>
-    </div>
-  </section>
+  <div data-accordion-role="tabpanel">
+    <p>
+      {{ _('In the Reporting Period, Mozilla did not receive any government requests for content removal from our services.') }}
+    </p>
 
-  <section class="section" id="government-content-removal">
-    <h2 class="section-title" data-accordion-role="tab">{{ _('Government Demands for Content Removal') }}</h2>
+    <table class="mzp-u-data-table">
+      <thead>
+        <tr>
+          <th scope="col">{{ _('Requesting Country') }}</th>
+          <th scope="col">{{ _('Requests Received') }}</th>
+          <th scope="col">{{ _('Data Produced') }}</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <th scope="row">{{ _('N/A') }}</th>
+          <td>0</td>
+          <td>{{ _('N/A') }}</td>
+        </tr>
+      </tbody>
+    </table>
 
-    <div class="content" data-accordion-role="tabpanel">
-      <p>{{ _('In the Reporting Period, Mozilla did not receive any government requests for content removal from our services.') }}</p>
+  </div>
+</section>
 
-      <table class="data-table">
-        <thead>
-          <tr>
-            <th scope="col">{{ _('Requesting Country') }}</th>
-            <th scope="col">{{ _('Requests Received') }}</th>
-            <th scope="col">{{ _('Data Produced') }}</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <th scope="row">{{ _('N/A') }}</th>
-            <td>0</td>
-            <td>{{ _('N/A') }}</td>
-          </tr>
-        </tbody>
-      </table>
+<section id="copyright-trademark" class="c-collapsible-section">
+  <h2 class="c-collapsible-section-heading" data-accordion-role="tab">{{ _('Copyright and Trademark Requests') }}</h2>
 
-    </div>
-  </section>
+  <div data-accordion-role="tabpanel">
+    <h3>{{ _('Copyright') }}</h3>
+    <p>{{ _('In the Reporting Period, we received 4 Copyright Takedown Notices and 0 Counter Notices.') }}</p>
 
-  <section class="section" id="copyright-trademark">
-    <h2 class="section-title" data-accordion-role="tab">{{ _('Copyright and Trademark Requests') }}</h2>
+    <table class="mzp-u-data-table">
+      <thead>
+        <tr>
+          <th scope="col">{{ _('Mozilla Service') }}</th>
+          <th scope="col">
+            <a
+              href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-takedown-notice' }}">{{ _('Takedown Notices') }}</a>
+          </th>
+          <th scope="col">
+            <a
+              href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-counter-notice' }}">{{ _('Counter Notices') }}</a>
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <th scope="row">{{ _('Firefox Add-ons') }}</th>
+          <td>3</td>
+          <td>0</td>
+        </tr>
+        <tr>
+          <th scope="row">{{ _('Firefox Marketplace (Apps)') }}</th>
+          <td>1</td>
+          <td>0</td>
+        </tr>
+      </tbody>
+    </table>
 
-    <div class="content" data-accordion-role="tabpanel">
-      <h3>{{ _('Copyright') }}</h3>
-      <p>{{ _('In the Reporting Period, we received 4 Copyright Takedown Notices and 0 Counter Notices.') }}</p>
+    <h3>{{ _('Trademark') }}</h3>
+    <p>{{ _('In the Reporting Period, we received 71 Trademark Takedown Notices and 1 Counter Notice') }}</p>
 
-      <table class="data-table">
-        <thead>
-          <tr>
-            <th scope="col">{{ _('Mozilla Service') }}</th>
-            <th scope="col">
-              <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-takedown-notice' }}">{{ _('Takedown Notices') }}</a>
-            </th>
-            <th scope="col">
-              <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-counter-notice' }}">{{ _('Counter Notices') }}</a>
-            </th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <th scope="row">{{ _('Firefox Add-ons') }}</th>
-            <td>3</td>
-            <td>0</td>
-          </tr>
-          <tr>
-            <th scope="row">{{ _('Firefox Marketplace (Apps)') }}</th>
-            <td>1</td>
-            <td>0</td>
-          </tr>
-        </tbody>
-      </table>
+    <table class="mzp-u-data-table">
+      <thead>
+        <tr>
+          <th scope="col">{{ _('Mozilla Service') }}</th>
+          <th scope="col">
+            <a
+              href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-takedown-notice' }}">{{ _('Takedown Notices') }}</a>
+          </th>
+          <th scope="col">
+            <a
+              href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-counter-notice' }}">{{ _('Counter Notices') }}</a>
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <th scope="row">{{ _('Firefox Add-ons') }}</th>
+          <td>71</td>
+          <td>1</td>
+        </tr>
+        <tr>
+          <th scope="row">{{ _('Firefox Marketplace (Apps)') }}</th>
+          <td>0</td>
+          <td>0</td>
+        </tr>
+      </tbody>
+    </table>
 
-      <h3>{{ _('Trademark') }}</h3>
-      <p>{{ _('In the Reporting Period, we received 71 Trademark Takedown Notices and 1 Counter Notice') }}</p>
+  </div>
+</section>
 
-      <table class="data-table">
-        <thead>
-          <tr>
-            <th scope="col">{{ _('Mozilla Service') }}</th>
-            <th scope="col">
-              <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-takedown-notice' }}">{{ _('Takedown Notices') }}</a>
-            </th>
-            <th scope="col">
-              <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-counter-notice' }}">{{ _('Counter Notices') }}</a>
-            </th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <th scope="row">{{ _('Firefox Add-ons') }}</th>
-            <td>71</td>
-            <td>1</td>
-          </tr>
-          <tr>
-            <th scope="row">{{ _('Firefox Marketplace (Apps)') }}</th>
-            <td>0</td>
-            <td>0</td>
-          </tr>
-        </tbody>
-      </table>
+<section id="supplement" class="c-collapsible-section">
+  <h2 class="c-collapsible-section-heading" data-accordion-role="tab">{{ _('Supplement') }}</h2>
 
-    </div>
-  </section>
+  <div data-accordion-role="tabpanel">
+    <h3>{{ _('Legislative Reform') }}</h3>
 
-  <section class="section" id="supplement">
-    <h2 class="section-title" data-accordion-role="tab">{{ _('Supplement') }}</h2>
-
-    <div class="content" data-accordion-role="tabpanel">
-      <h3>{{ _('Legislative Reform') }}</h3>
-
-      <p>
+    <p>
       {% trans link_patch='https://blog.mozilla.org/netpolicy/2017/05/17/working-together-towards-secure-internet-vep-reform/' %}
-        In the Reporting Period, we worked to <a href="{{ link_patch }}">support the introduction of the Protecting Our Ability to Counter Hacking (PATCH) Act</a>, which codifies and includes important reforms to the U.S. Government’s process for handling vulnerabilities.
+      In the Reporting Period, we worked to <a href="{{ link_patch }}">support the introduction of the Protecting Our
+        Ability to Counter Hacking (PATCH) Act</a>, which codifies and includes important reforms to the U.S.
+      Government’s process for handling vulnerabilities.
       {% endtrans %}
 
       {% trans link_amicus='https://blog.mozilla.org/blog/2017/01/06/fighting-back-against-unlawful-warrants-and-indefinite-gag-orders-to-protect-internet-privacy-and-security/' %}
-        We joined with other major technology companies to file an <a href="{{ link_amicus }}">amicus brief</a> supporting Facebook’s ability to challenge both a search warrant and an accompanying indefinite gag order.
+      We joined with other major technology companies to file an <a href="{{ link_amicus }}">amicus brief</a> supporting
+      Facebook’s ability to challenge both a search warrant and an accompanying indefinite gag order.
       {% endtrans %}
 
       {% trans link_govhack1='http://cyberlaw.stanford.edu/events/government-hacking-assessing-and-mitigating-security-risk',
           link_govhack2='http://cyberlaw.stanford.edu/blog/2017/05/government-hacking-evidence-and-vulnerability-disclosure-court' %}
-        We continued to sponsor a speaker series on <a href="{{ link_govhack1 }}">government</a> <a href="{{ link_govhack2 }}">hacking</a>.
+      We continued to sponsor a speaker series on <a href="{{ link_govhack1 }}">government</a> <a
+        href="{{ link_govhack2 }}">hacking</a>.
       {% endtrans %}
-      </p>
+    </p>
 
-      <p>
+    <p>
       {% trans link_dmca='https://blog.mozilla.org/netpolicy/2017/02/21/we-are-all-creators-now/' %}
-        We filed comment with the U.S. Copyright Office on their <a href="{{ link_dmca }}">review of Section 512 of the Digital Millennium Copyright Act</a> (DMCA).
+      We filed comment with the U.S. Copyright Office on their <a href="{{ link_dmca }}">review of Section 512 of the
+        Digital Millennium Copyright Act</a> (DMCA).
       {% endtrans %}
 
       {% trans link_eucopyright='http://www.ipprotheinternet.com/interviews/interview.php?interview_id=116',
           link_eprivacy='https://blog.mozilla.org/netpolicy/2017/06/07/engaging-e-privacy-european-parliament/',
           link_dataecon='https://blog.mozilla.org/netpolicy/files/2017/04/Mozilla-EU-Data-Economy-submission.pdf' %}
-        In the EU, we’ve worked to influence the EU Commission’s <a href="{{ link_eucopyright }}">ongoing copyright reform efforts</a>, and continued to engage with the EU <a href="{{ link_eprivacy }}">e-Privacy Regulation</a> and <a href="{{ link_dataecon }}">Data Economy consultation</a>.
+      In the EU, we’ve worked to influence the EU Commission’s <a href="{{ link_eucopyright }}">ongoing copyright reform
+        efforts</a>, and continued to engage with the EU <a href="{{ link_eprivacy }}">e-Privacy Regulation</a> and <a
+        href="{{ link_dataecon }}">Data Economy consultation</a>.
       {% endtrans %}
 
       {% trans link_aadhaar='https://blog.mozilla.org/netpolicy/2017/05/26/aadhaar-isnt-progress/' %}
-        Together with the Mozilla Community in India, we also <a href="{{ link_aadhaar }}">published an op-ed</a> highlighting the need for privacy protections in Aadhaar, the Indian national biometric identity system.
+      Together with the Mozilla Community in India, we also <a href="{{ link_aadhaar }}">published an op-ed</a>
+      highlighting the need for privacy protections in Aadhaar, the Indian national biometric identity system.
       {% endtrans %}
-      </p>
+    </p>
 
-      <h3>{{ _('Threat Indicators &amp; Data Disclosures') }}</h3>
-      <table class="data-table">
-        <thead>
-          <tr>
-            <th scope="col">{{ _('Type of Disclosure') }}</th>
-            <th scope="col">{{ _('Number of Disclosures') }}</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <th scope="row"><a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-threat-indicator' }}">{{ _('Cybersecurity Threat Indicator') }}</a></th>
-            <td>0</td>
-          </tr>
-          <tr>
-            <th scope="row">{{ _('Other <a href="%s">Specific User</a> Data Disclosure')|format(url('mozorg.about.policy.transparency.index') + '#dfn-specific-user') }}</th>
-            <td>1<sup>*</sup></td>
-          </tr>
-        </tbody>
-      </table>
+    <h3>{{ _('Threat Indicators &amp; Data Disclosures') }}</h3>
+    <table class="mzp-u-data-table">
+      <thead>
+        <tr>
+          <th scope="col">{{ _('Type of Disclosure') }}</th>
+          <th scope="col">{{ _('Number of Disclosures') }}</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <th scope="row"><a
+              href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-threat-indicator' }}">{{ _('Cybersecurity Threat Indicator') }}</a>
+          </th>
+          <td>0</td>
+        </tr>
+        <tr>
+          <th scope="row">
+            {{ _('Other <a href="%s">Specific User</a> Data Disclosure')|format(url('mozorg.about.policy.transparency.index') + '#dfn-specific-user') }}
+          </th>
+          <td>1<sup>*</sup></td>
+        </tr>
+      </tbody>
+    </table>
 
-      <footer class="footnotes">
-        <p class="footnote" id="footnote1">
+    <aside class="footnotes">
+      <p>
         {% trans link_cybertipline='http://www.missingkids.org/cybertipline' %}
-          * Information about possible child sexual exploitation can be voluntarily reported by anyone to the National Center for Missing & Exploited Children’s (NCMEC) <a href="{{ link_cybertipline }}">CyberTipline</a>. We take this issue seriously. In the Reporting Period, Mozilla disclosed Specific User data to the NCMEC in connection with content that was uploaded to a Mozilla service and implicated child sexual exploitation.
+        * Information about possible child sexual exploitation can be voluntarily reported by anyone to the National
+        Center for Missing & Exploited Children’s (NCMEC) <a href="{{ link_cybertipline }}">CyberTipline</a>. We take
+        this issue seriously. In the Reporting Period, Mozilla disclosed Specific User data to the NCMEC in connection
+        with content that was uploaded to a Mozilla service and implicated child sexual exploitation.
         {% endtrans %}
-        </p>
-      </footer>
+      </p>
+    </aside>
 
-    </div>
-  </section>
-{% endblock %}
-
-{% block report_nav %}
-  <aside class="section nav-block">
-    <nav class="content nav-report two-up">
-      <ul>
-        <li><a class="button" href="{{ url('mozorg.about.policy.transparency.index') + '#faq' }}">{{ _('FAQ') }}</a></li>
-        <li><a class="button" href="{{ url('mozorg.about.policy.transparency.index') + '#definitions' }}">{{ _('Definitions') }}</a></li>
-      </ul>
-    </nav>
-
-    {% include 'mozorg/about/policy/transparency/includes/past-reports.html' %}
-  </aside>
+  </div>
+</section>
 {% endblock %}

--- a/bedrock/mozorg/templates/mozorg/about/policy/transparency/jan-jun-2018.html
+++ b/bedrock/mozorg/templates/mozorg/about/policy/transparency/jan-jun-2018.html
@@ -2,256 +2,268 @@
   # License, v. 2.0. If a copy of the MPL was not distributed with this
   # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
 
-  {% extends "mozorg/about/policy/transparency/report-base.html" %}
+{% extends "mozorg/about/policy/transparency/report-base.html" %}
 
-  {% block page_title %}{{ _('Transparency Report - January-June, 2018') }}{% endblock %}
+{% block page_title %}{{ _('Transparency Report - January-June, 2018') }}{% endblock %}
 
-  {% block report_title %}
-    <h1>{{ _('Transparency Report') }} <span>{{ _('Reporting Period: January 1, 2018 to June 30, 2018') }}</span></h1>
-  {% endblock %}
+{% block report_title %}
+<h1>{{ _('Transparency Report') }} <span>{{ _('Reporting Period: January 1, 2018 to June 30, 2018') }}</span></h1>
+{% endblock %}
 
-  {% block report_body %}
-    <section class="section" id="government-user-data">
-      <h2 class="section-title" data-accordion-role="tab">{{ _('Government Demands for User Data') }}</h2>
+{% block report_body %}
+<section id="government-user-data" class="c-collapsible-section">
+  <h2 class="c-collapsible-section-heading" data-accordion-role="tab">{{ _('Government Demands for User Data') }}</h2>
 
-      <div class="content" data-accordion-role="tabpanel">
-        <p>
-          {{ _('In the Reporting Period, Mozilla received 1 Court Order and 1 Subpoena for user data.') }}
-        </p>
+  <div data-accordion-role="tabpanel">
+    <p>
+      {{ _('In the Reporting Period, Mozilla received 1 Court Order and 1 Subpoena for user data.') }}
+    </p>
 
-        <table class="data-table">
-          <thead>
-            <tr>
-              <th scope="col">{{ _('Legal Processes') }}</th>
-              <th scope="col">{{ _('Received') }}</th>
-              <th scope="col">{{ _('Data Produced') }}</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <th scope="row">
-                <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-search-warrant' }}">{{ _('Search Warrants') }}</a>
-              </th>
-              <td>0</td>
-              <td>{{ _('N/A') }}</td>
-            </tr>
-            <tr>
-              <th scope="row">
-                <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-subpoena' }}">{{ _('Subpoenas') }}</a>
-              </th>
-              <td>1<sup><a href="#footnote-1">1</a></sup></td>
-              <td>{{ _('No') }}</td>
-            </tr>
-            <tr>
-              <th scope="row">
-                <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-court-order' }}">{{ _('Court Orders') }}</a>
-              </th>
-              <td>1<sup><a href="#footnote-2">2</a></sup></td>
-              <td>{{ _('No') }}</td>
-            </tr>
-            <tr>
-              <th scope="row">
-                <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-wiretap-order' }}">{{ _('Wiretap Orders') }}</a>
-              </th>
-              <td>0</td>
-              <td>{{ _('N/A') }}</td>
-            </tr>
-            <tr>
-              <th scope="row">
-                <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-pen-register-order' }}">{{ _('Pen Register Orders') }}</a>
-              </th>
-              <td>0</td>
-              <td>{{ _('N/A') }}</td>
-            </tr>
-            <tr>
-              <th scope="row">
-                <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-emergency-request' }}">{{ _('Emergency Requests') }}</a>
-              </th>
-              <td>0</td>
-              <td>{{ _('N/A') }}</td>
-            </tr>
-            <tr>
-              <th scope="row">
-                <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-natl-security-request' }}">{{ _('National Security Requests') }}</a> <sup><a href="#footnote-3">3</a></sup>
-              </th>
-              <td>0</td>
-              <td>{{ _('N/A') }}</td>
-            </tr>
-          </tbody>
-        </table>
+    <table class="mzp-u-data-table">
+      <thead>
+        <tr>
+          <th scope="col">{{ _('Legal Processes') }}</th>
+          <th scope="col">{{ _('Received') }}</th>
+          <th scope="col">{{ _('Data Produced') }}</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <th scope="row">
+            <a
+              href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-search-warrant' }}">{{ _('Search Warrants') }}</a>
+          </th>
+          <td>0</td>
+          <td>{{ _('N/A') }}</td>
+        </tr>
+        <tr>
+          <th scope="row">
+            <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-subpoena' }}">{{ _('Subpoenas') }}</a>
+          </th>
+          <td>1<sup><a href="#footnote-1">1</a></sup></td>
+          <td>{{ _('No') }}</td>
+        </tr>
+        <tr>
+          <th scope="row">
+            <a
+              href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-court-order' }}">{{ _('Court Orders') }}</a>
+          </th>
+          <td>1<sup><a href="#footnote-2">2</a></sup></td>
+          <td>{{ _('No') }}</td>
+        </tr>
+        <tr>
+          <th scope="row">
+            <a
+              href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-wiretap-order' }}">{{ _('Wiretap Orders') }}</a>
+          </th>
+          <td>0</td>
+          <td>{{ _('N/A') }}</td>
+        </tr>
+        <tr>
+          <th scope="row">
+            <a
+              href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-pen-register-order' }}">{{ _('Pen Register Orders') }}</a>
+          </th>
+          <td>0</td>
+          <td>{{ _('N/A') }}</td>
+        </tr>
+        <tr>
+          <th scope="row">
+            <a
+              href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-emergency-request' }}">{{ _('Emergency Requests') }}</a>
+          </th>
+          <td>0</td>
+          <td>{{ _('N/A') }}</td>
+        </tr>
+        <tr>
+          <th scope="row">
+            <a
+              href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-natl-security-request' }}">{{ _('National Security Requests') }}</a>
+            <sup><a href="#footnote-3">3</a></sup>
+          </th>
+          <td>0</td>
+          <td>{{ _('N/A') }}</td>
+        </tr>
+      </tbody>
+    </table>
 
-        <aside class="footnotes">
-          <section id="footnote-1">
-            <p>{{ _('1. Issued to Mozilla Corporation in connection with Pocket.') }}</p>
-          </section>
-          <section id="footnote-2">
-            <p>{{ _('2. Issued to Mozilla Corporation.') }}</p>
-          </section>
-          <section id="footnote-3">
-            <p>{{ _('3. None of the Mozilla Foundation, Mozilla Corporation or Pocket have ever received a National Security Request.') }}</p>
-          </section>
-        </aside>
-      </div>
-    </section>
+    <aside class="footnotes">
+      <p>{{ _('1. Issued to Mozilla Corporation in connection with Pocket.') }}</p>
+      <p>{{ _('2. Issued to Mozilla Corporation.') }}</p>
+      <p>
+        {{ _('3. None of the Mozilla Foundation, Mozilla Corporation or Pocket have ever received a National Security Request.') }}
+      </p>
+    </aside>
+  </div>
+</section>
 
-    <section class="section" id="government-content-removal">
-      <h2 class="section-title" data-accordion-role="tab">{{ _('Government Demands for Content Removal') }}</h2>
+<section id="government-content-removal" class="c-collapsible-section">
+  <h2 class="c-collapsible-section-heading" data-accordion-role="tab">{{ _('Government Demands for Content Removal') }}
+  </h2>
 
-      <div class="content" data-accordion-role="tabpanel">
-        <p>{{ _('In the Reporting Period, Mozilla did not receive any government requests for content removal from our services.') }}</p>
+  <div data-accordion-role="tabpanel">
+    <p>
+      {{ _('In the Reporting Period, Mozilla did not receive any government requests for content removal from our services.') }}
+    </p>
 
-        <table class="data-table">
-          <thead>
-            <tr>
-              <th scope="col">{{ _('Requesting Country') }}</th>
-              <th scope="col">{{ _('Requests Received') }}</th>
-              <th scope="col">{{ _('Data Produced') }}</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <th scope="row">{{ _('N/A') }}</th>
-              <td>0</td>
-              <td>{{ _('N/A') }}</td>
-            </tr>
-          </tbody>
-        </table>
+    <table class="mzp-u-data-table">
+      <thead>
+        <tr>
+          <th scope="col">{{ _('Requesting Country') }}</th>
+          <th scope="col">{{ _('Requests Received') }}</th>
+          <th scope="col">{{ _('Data Produced') }}</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <th scope="row">{{ _('N/A') }}</th>
+          <td>0</td>
+          <td>{{ _('N/A') }}</td>
+        </tr>
+      </tbody>
+    </table>
 
-      </div>
-    </section>
+  </div>
+</section>
 
-    <section class="section" id="copyright-trademark">
-      <h2 class="section-title" data-accordion-role="tab">{{ _('Copyright and Trademark Requests') }}</h2>
+<section id="copyright-trademark" class="c-collapsible-section">
+  <h2 class="c-collapsible-section-heading" data-accordion-role="tab">{{ _('Copyright and Trademark Requests') }}</h2>
 
-      <div class="content" data-accordion-role="tabpanel">
-        <h3>{{ _('Copyright') }}</h3>
-        <p>{{ _('In the Reporting Period, we received 5 Copyright Takedown Notices and 0 Counter Notices.') }}</p>
+  <div data-accordion-role="tabpanel">
+    <h3>{{ _('Copyright') }}</h3>
+    <p>{{ _('In the Reporting Period, we received 5 Copyright Takedown Notices and 0 Counter Notices.') }}</p>
 
-        <table class="data-table">
-          <thead>
-            <tr>
-              <th scope="col">{{ _('Mozilla Service') }}</th>
-              <th scope="col">
-                <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-takedown-notice' }}">{{ _('Takedown Notices') }}</a>
-              </th>
-              <th scope="col">
-                <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-counter-notice' }}">{{ _('Counter Notices') }}</a>
-              </th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <th scope="row">{{ _('Firefox Add-ons') }}</th>
-              <td>5</td>
-              <td>0</td>
-            </tr>
-            <tr>
-              <th scope="row">{{ _('Pocket') }}</th>
-              <td>0</td>
-              <td>0</td>
-            </tr>
-            <tr>
-              <th scope="row">{{ _('Other Services') }}</th>
-              <td>0</td>
-              <td>0</td>
-            </tr>
-          </tbody>
-        </table>
+    <table class="mzp-u-data-table">
+      <thead>
+        <tr>
+          <th scope="col">{{ _('Mozilla Service') }}</th>
+          <th scope="col">
+            <a
+              href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-takedown-notice' }}">{{ _('Takedown Notices') }}</a>
+          </th>
+          <th scope="col">
+            <a
+              href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-counter-notice' }}">{{ _('Counter Notices') }}</a>
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <th scope="row">{{ _('Firefox Add-ons') }}</th>
+          <td>5</td>
+          <td>0</td>
+        </tr>
+        <tr>
+          <th scope="row">{{ _('Pocket') }}</th>
+          <td>0</td>
+          <td>0</td>
+        </tr>
+        <tr>
+          <th scope="row">{{ _('Other Services') }}</th>
+          <td>0</td>
+          <td>0</td>
+        </tr>
+      </tbody>
+    </table>
 
-        <h3>{{ _('Trademark') }}</h3>
-        <p>{{ _('In the Reporting Period, we received 6 Trademark Takedown Notices and 0 Counter Notices.') }}</p>
+    <h3>{{ _('Trademark') }}</h3>
+    <p>{{ _('In the Reporting Period, we received 6 Trademark Takedown Notices and 0 Counter Notices.') }}</p>
 
-        <table class="data-table">
-          <thead>
-            <tr>
-              <th scope="col">{{ _('Mozilla Service') }}</th>
-              <th scope="col">
-                <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-takedown-notice' }}">{{ _('Takedown Notices') }}</a>
-              </th>
-              <th scope="col">
-                <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-counter-notice' }}">{{ _('Counter Notices') }}</a>
-              </th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <th scope="row">{{ _('Firefox Add-ons') }}</th>
-              <td>6</td>
-              <td>0</td>
-            </tr>
-            <tr>
-              <th scope="row">{{ _('Pocket') }}</th>
-              <td>0</td>
-              <td>0</td>
-            </tr>
-            <tr>
-              <th scope="row">{{ _('Other Services') }}</th>
-              <td>0</td>
-              <td>0</td>
-          </tbody>
-        </table>
+    <table class="mzp-u-data-table">
+      <thead>
+        <tr>
+          <th scope="col">{{ _('Mozilla Service') }}</th>
+          <th scope="col">
+            <a
+              href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-takedown-notice' }}">{{ _('Takedown Notices') }}</a>
+          </th>
+          <th scope="col">
+            <a
+              href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-counter-notice' }}">{{ _('Counter Notices') }}</a>
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <th scope="row">{{ _('Firefox Add-ons') }}</th>
+          <td>6</td>
+          <td>0</td>
+        </tr>
+        <tr>
+          <th scope="row">{{ _('Pocket') }}</th>
+          <td>0</td>
+          <td>0</td>
+        </tr>
+        <tr>
+          <th scope="row">{{ _('Other Services') }}</th>
+          <td>0</td>
+          <td>0</td>
+      </tbody>
+    </table>
 
-      </div>
-    </section>
+  </div>
+</section>
 
-    <section class="section" id="supplement">
-      <h2 class="section-title" data-accordion-role="tab">{{ _('Supplement') }}</h2>
+<section id="supplement" class="c-collapsible-section">
+  <h2 class="c-collapsible-section-heading" data-accordion-role="tab">{{ _('Supplement') }}</h2>
 
-      <div class="content" data-accordion-role="tabpanel">
-        <h3>{{ _('Legislative Reform') }}</h3>
+  <div data-accordion-role="tabpanel">
+    <h3>{{ _('Legislative Reform') }}</h3>
 
-        <p>
-          {% trans india='https://blog.mozilla.org/netpolicy/2018/03/30/effective-rights-protective-procedures-tackling-illegal-content-mozilla-files-comment-european-commission/',
+    <p>
+      {% trans india='https://blog.mozilla.org/netpolicy/2018/03/30/effective-rights-protective-procedures-tackling-illegal-content-mozilla-files-comment-european-commission/',
                    california='https://blog.mozilla.org/netpolicy/2018/06/26/privacy-progress-and-protections-for-california/',
                    carpenter='https://blog.mozilla.org/netpolicy/2018/06/22/the-supreme-court-scores-a-win-for-privacy/' %}
-            In this Reporting Period, Mozilla continued to push for strong privacy protections around the world including work on the e-Privacy Regulation in Europe, <a href="{{india}}">India’s first data protection law</a>, <a href="{{ california }}">California’s Privacy Act</a>, as well as engagement on discussions about a privacy law at the US federal level. Additionally, in Carpenter, a case where <a href="{{ carpenter }}">we filed an amicus brief</a>, the US Supreme Court found that the government must get a warrant to obtain records of where someone’s cell phone has been.
-          {% endtrans %}
-        </p>
-        <p>
-          {% trans europe='https://blog.mozilla.org/netpolicy/2018/04/24/mozilla-publishes-recommendations-on-government-vulnerability-disclosure-in-europe/',
+      In this Reporting Period, Mozilla continued to push for strong privacy protections around the world including work
+      on the e-Privacy Regulation in Europe, <a href="{{india}}">India’s first data protection law</a>, <a
+        href="{{ california }}">California’s Privacy Act</a>, as well as engagement on discussions about a privacy law
+      at the US federal level. Additionally, in Carpenter, a case where <a href="{{ carpenter }}">we filed an amicus
+        brief</a>, the US Supreme Court found that the government must get a warrant to obtain records of where
+      someone’s cell phone has been.
+      {% endtrans %}
+    </p>
+    <p>
+      {% trans europe='https://blog.mozilla.org/netpolicy/2018/04/24/mozilla-publishes-recommendations-on-government-vulnerability-disclosure-in-europe/',
                    recommendations='https://www.ceps.eu/publications/software-vulnerability-disclosure-europe-technology-policies-and-legal-challenges' %}
-          We also continued our engagement with European stakeholders around <a href="{{ europe }}">government vulnerability disclosure in Europe</a>, including through our participation in the Centre for European Policy Studies Task Force on Software Vulnerability Disclosure which published its <a href="{{ recommendations }}">recommendations</a> in June.
-          {% endtrans %}
-        </p>
-        <p>
-          {% trans reform='https://blog.mozilla.org/netpolicy/2018/06/22/jurivote/',
+      We also continued our engagement with European stakeholders around <a href="{{ europe }}">government vulnerability
+        disclosure in Europe</a>, including through our participation in the Centre for European Policy Studies Task
+      Force on Software Vulnerability Disclosure which published its <a href="{{ recommendations }}">recommendations</a>
+      in June.
+      {% endtrans %}
+    </p>
+    <p>
+      {% trans reform='https://blog.mozilla.org/netpolicy/2018/06/22/jurivote/',
                    illegal='https://blog.mozilla.org/netpolicy/2018/03/30/effective-rights-protective-procedures-tackling-illegal-content-mozilla-files-comment-european-commission/' %}
-          We were also deeply engaged on other fronts in Europe, including <a href="{{ reform }}">pushing for better copyright reform</a>, filing on the <a href="{{ illegal }}">European Commission’s consultation on illegal content</a>, fighting for additional protections as part of the EU’s E-Evidence proposal around cross-border data access, and engaging on discussions about the EU’s terrorist content regulation.
-          {% endtrans %}
-        </p>
+      We were also deeply engaged on other fronts in Europe, including <a href="{{ reform }}">pushing for better
+        copyright reform</a>, filing on the <a href="{{ illegal }}">European Commission’s consultation on illegal
+        content</a>, fighting for additional protections as part of the EU’s E-Evidence proposal around cross-border
+      data access, and engaging on discussions about the EU’s terrorist content regulation.
+      {% endtrans %}
+    </p>
 
-        <h3>{{ _('Threat Indicators &amp; Data Disclosures') }}</h3>
-        <table class="data-table">
-          <thead>
-            <tr>
-              <th scope="col">{{ _('Type of Disclosure') }}</th>
-              <th scope="col">{{ _('Number of Disclosures') }}</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <th scope="row"><a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-threat-indicator' }}">{{ _('Cybersecurity Threat Indicator') }}</a></th>
-              <td>0</td>
-            </tr>
-            <tr>
-              <th scope="row">{{ _('Other <a href="%s">Specific User</a> Data Disclosure')|format(url('mozorg.about.policy.transparency.index') + '#dfn-specific-user') }}</th>
-              <td>0</td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
-    </section>
-  {% endblock %}
-
-  {% block report_nav %}
-    <aside class="section nav-block">
-      <nav class="content nav-report two-up">
-        <ul>
-          <li><a class="button" href="{{ url('mozorg.about.policy.transparency.index') + '#faq' }}">{{ _('FAQ') }}</a></li>
-          <li><a class="button" href="{{ url('mozorg.about.policy.transparency.index') + '#definitions' }}">{{ _('Definitions') }}</a></li>
-        </ul>
-      </nav>
-
-      {% include 'mozorg/about/policy/transparency/includes/past-reports.html' %}
-    </aside>
-  {% endblock %}
+    <h3>{{ _('Threat Indicators &amp; Data Disclosures') }}</h3>
+    <table class="mzp-u-data-table">
+      <thead>
+        <tr>
+          <th scope="col">{{ _('Type of Disclosure') }}</th>
+          <th scope="col">{{ _('Number of Disclosures') }}</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <th scope="row"><a
+              href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-threat-indicator' }}">{{ _('Cybersecurity Threat Indicator') }}</a>
+          </th>
+          <td>0</td>
+        </tr>
+        <tr>
+          <th scope="row">
+            {{ _('Other <a href="%s">Specific User</a> Data Disclosure')|format(url('mozorg.about.policy.transparency.index') + '#dfn-specific-user') }}
+          </th>
+          <td>0</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</section>
+{% endblock %}

--- a/bedrock/mozorg/templates/mozorg/about/policy/transparency/jan-jun-2019.html
+++ b/bedrock/mozorg/templates/mozorg/about/policy/transparency/jan-jun-2019.html
@@ -1,284 +1,304 @@
 {# This Source Code Form is subject to the terms of the Mozilla Public
     # License, v. 2.0. If a copy of the MPL was not distributed with this
     # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
-  
-    {% extends "mozorg/about/policy/transparency/report-base.html" %}
-  
-    {% block page_title %}{{ _('Transparency Report - January-June, 2019') }}{% endblock %}
-  
-    {% block report_title %}
-      <h1>{{ _('Transparency Report') }} <span>{{ _('Reporting Period: January 1, 2019 to June 30, 2019') }}</span></h1>
-    {% endblock %}
-  
-    {% block report_body %}
-      <section class="section" id="government-user-data">
-        <h2 class="section-title" data-accordion-role="tab">{{ _('Government Demands for User Data') }}</h2>
-  
-        <div class="content" data-accordion-role="tabpanel">
-          <p>
-            {{ _('In the Reporting Period, Mozilla received the following.') }}
-          </p>
-  
-          <table class="data-table">
-            <thead>
-              <tr>
-                <th scope="col">{{ _('Legal Processes') }}</th>
-                <th scope="col">{{ _('Received') }}</th>
-                <th scope="col">{{ _('Data Produced') }}</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr>
-                <th scope="row">
-                  <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-search-warrant' }}">{{ _('Search Warrants') }}</a>
-                </th>
-                <td>0</td>
-                <td>{{ _('0') }}</td>
-              </tr>
-              <tr>
-                <th scope="row">
-                  <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-subpoena' }}">{{ _('Subpoenas') }}</a>
-                </th>
-                <td>0</td>
-                <td>{{ _('0') }}</td>
-              </tr>
-              <tr>
-                <th scope="row">
-                  <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-court-order' }}">{{ _('Court Orders') }}</a>
-                </th>
-                <td>0</td>
-                <td>{{ _('0') }}</td>
-              </tr>
-              <tr>
-                <th scope="row">
-                  <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-wiretap-order' }}">{{ _('Wiretap Orders') }}</a>
-                </th>
-                <td>0</td>
-                <td>{{ _('0') }}</td>
-              </tr>
-              <tr>
-                <th scope="row">
-                  <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-pen-register-order' }}">{{ _('Pen Register Orders') }}</a>
-                </th>
-                <td>0</td>
-                <td>{{ _('0') }}</td>
-              </tr>
-              <tr>
-                <th scope="row">
-                  <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-emergency-request' }}">{{ _('Emergency Requests') }}</a>
-                </th>
-                <td>0</td>
-                <td>{{ _('0') }}</td>
-              </tr>
-              <tr>
-                <th scope="row">
-                  <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-natl-security-request' }}">{{ _('National Security Requests') }}</a> <sup><a href="#footnote-1">1</a></sup>
-                </th>
-                <td>0-249</td>
-                <td>{{ _('0-249') }}</td>
-              </tr>
-            </tbody>
-          </table>
-  
-          <aside class="footnotes">
-            <section id="footnote-1">
-              <p>{{ _('1. We seek to be as transparent as possible about the User Data Requests that we receive from government authorities. The reporting band listed is one of four reporting bands permitted under U.S. law for National Security Requests.') }}</p>
-            </section>
-          </aside>
-        </div>
-      </section>
-  
-      <section class="section" id="government-content-removal">
-        <h2 class="section-title" data-accordion-role="tab">{{ _('Government Demands for Content Removal') }}</h2>
-  
-        <div class="content" data-accordion-role="tabpanel">
-          <p>{{ _('In the Reporting Period, Mozilla did not receive any government requests for content removal from our services.') }}</p>
-  
-          <table class="data-table">
-            <thead>
-              <tr>
-                <th scope="col">{{ _('Requesting Country') }}</th>
-                <th scope="col">{{ _('Requests Received') }}</th>
-                <th scope="col">{{ _('Data Produced') }}</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr>
-                <th scope="row">{{ _('N/A') }}</th>
-                <td>0</td>
-                <td>{{ _('N/A') }}</td>
-              </tr>
-            </tbody>
-          </table>
-  
-        </div>
-      </section>
-  
-      <section class="section" id="copyright-trademark">
-        <h2 class="section-title" data-accordion-role="tab">{{ _('Copyright and Trademark Requests') }}</h2>
-  
-        <div class="content" data-accordion-role="tabpanel">
-          <h3>{{ _('Copyright') }}</h3>
-          <p>{{ _('In the Reporting Period, we received 8 Copyright Takedown Notices and 0 Counter Notices.') }}</p>
-  
-          <table class="data-table">
-            <thead>
-              <tr>
-                <th scope="col">{{ _('Mozilla Service') }}</th>
-                <th scope="col">
-                  <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-takedown-notice' }}">{{ _('Takedown Notices') }}</a>
-                </th>
-                <th scope="col">
-                  <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-counter-notice' }}">{{ _('Counter Notices') }}</a>
-                </th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr>
-                <th scope="row">{{ _('Firefox Add-ons') }}</th>
-                <td>7</td>
-                <td>0</td>
-              </tr>
-              <tr>
-                <th scope="row">{{ _('Pocket') }}</th>
-                <td>0</td>
-                <td>0</td>
-              </tr>
-              <tr>
-                <th scope="row">{{ _('Other Services') }}</th>
-                <td>1</td>
-                <td>0</td>
-              </tr>
-            </tbody>
-          </table>
-  
-          <h3>{{ _('Trademark') }}</h3>
-          <p>{{ _('In the Reporting Period, we received 4 Trademark Takedown Notices and 0 Counter Notices.') }}</p>
-  
-          <table class="data-table">
-            <thead>
-              <tr>
-                <th scope="col">{{ _('Mozilla Service') }}</th>
-                <th scope="col">
-                  <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-takedown-notice' }}">{{ _('Takedown Notices') }}</a>
-                </th>
-                <th scope="col">
-                  <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-counter-notice' }}">{{ _('Counter Notices') }}</a>
-                </th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr>
-                <th scope="row">{{ _('Firefox Add-ons') }}</th>
-                <td>4</td>
-                <td>0</td>
-              </tr>
-              <tr>
-                <th scope="row">{{ _('Pocket') }}</th>
-                <td>0</td>
-                <td>0</td>
-              </tr>
-              <tr>
-                <th scope="row">{{ _('Other Services') }}</th>
-                <td>0</td>
-                <td>0</td>
-            </tbody>
-          </table>
-          <h3>{{ _('Personal Data Requests') }}</h3>
-          <p>{{ _('In the Reporting Period, we received 757 requests.') }}</p>
 
-          <table class="data-table">
-            <thread>
-              <th scope="col">{{ _('Service') }}</th>
-              <th scope="col">{{ _('Received') }}</th>
-            </thread>
-            <tbody>
-              <tr>
-                <th scope="row">{{ _('Mozilla') }}</th>
-                <td>427 <sup><a href="#notation">*</a></sup></td>
-              </tr>
-              <tr>
-                <th scope="row">{{ _('Pocket') }}</th>
-                <td>330</td>
-              </tr>
-            </tbody>
-          </table>
-          <aside class="footnotes">
-            <section id="notation">
-              <p>
-                {% trans privacy=url('privacy') %}
-                * During the Reporting Period we surfaced additional methods to contact us in our <a href="{{ privacy }}">Mozilla Privacy Policy</a>. This higher level visibility likely caused the increase in Personal Data Requests that we received compared to 2018 H2.
-                {% endtrans %}
-              </p>
-            </section>
-          </aside>
-        </div>
+{% extends "mozorg/about/policy/transparency/report-base.html" %}
+
+{% block page_title %}{{ _('Transparency Report - January-June, 2019') }}{% endblock %}
+
+{% block report_title %}
+<h1>{{ _('Transparency Report') }} <span>{{ _('Reporting Period: January 1, 2019 to June 30, 2019') }}</span></h1>
+{% endblock %}
+
+{% block report_body %}
+<section id="government-user-data" class="c-collapsible-section">
+  <h2 class="c-collapsible-section-heading" data-accordion-role="tab">{{ _('Government Demands for User Data') }}</h2>
+
+  <div data-accordion-role="tabpanel">
+    <p>
+      {{ _('In the Reporting Period, Mozilla received the following.') }}
+    </p>
+
+    <table class="mzp-u-data-table">
+      <thead>
+        <tr>
+          <th scope="col">{{ _('Legal Processes') }}</th>
+          <th scope="col">{{ _('Received') }}</th>
+          <th scope="col">{{ _('Data Produced') }}</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <th scope="row">
+            <a
+              href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-search-warrant' }}">{{ _('Search Warrants') }}</a>
+          </th>
+          <td>0</td>
+          <td>{{ _('0') }}</td>
+        </tr>
+        <tr>
+          <th scope="row">
+            <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-subpoena' }}">{{ _('Subpoenas') }}</a>
+          </th>
+          <td>0</td>
+          <td>{{ _('0') }}</td>
+        </tr>
+        <tr>
+          <th scope="row">
+            <a
+              href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-court-order' }}">{{ _('Court Orders') }}</a>
+          </th>
+          <td>0</td>
+          <td>{{ _('0') }}</td>
+        </tr>
+        <tr>
+          <th scope="row">
+            <a
+              href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-wiretap-order' }}">{{ _('Wiretap Orders') }}</a>
+          </th>
+          <td>0</td>
+          <td>{{ _('0') }}</td>
+        </tr>
+        <tr>
+          <th scope="row">
+            <a
+              href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-pen-register-order' }}">{{ _('Pen Register Orders') }}</a>
+          </th>
+          <td>0</td>
+          <td>{{ _('0') }}</td>
+        </tr>
+        <tr>
+          <th scope="row">
+            <a
+              href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-emergency-request' }}">{{ _('Emergency Requests') }}</a>
+          </th>
+          <td>0</td>
+          <td>{{ _('0') }}</td>
+        </tr>
+        <tr>
+          <th scope="row">
+            <a
+              href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-natl-security-request' }}">{{ _('National Security Requests') }}</a>
+            <sup><a href="#footnote-1">1</a></sup>
+          </th>
+          <td>0-249</td>
+          <td>{{ _('0-249') }}</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <aside class="footnotes">
+      <p>
+        {{ _('1. We seek to be as transparent as possible about the User Data Requests that we receive from government authorities. The reporting band listed is one of four reporting bands permitted under U.S. law for National Security Requests.') }}
+      </p>
+    </aside>
+  </div>
+</section>
+
+<section id="government-content-removal" class="c-collapsible-section">
+  <h2 class="c-collapsible-section-heading" data-accordion-role="tab">{{ _('Government Demands for Content Removal') }}</h2>
+
+  <div data-accordion-role="tabpanel">
+    <p>
+      {{ _('In the Reporting Period, Mozilla did not receive any government requests for content removal from our services.') }}
+    </p>
+
+    <table class="mzp-u-data-table">
+      <thead>
+        <tr>
+          <th scope="col">{{ _('Requesting Country') }}</th>
+          <th scope="col">{{ _('Requests Received') }}</th>
+          <th scope="col">{{ _('Data Produced') }}</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <th scope="row">{{ _('N/A') }}</th>
+          <td>0</td>
+          <td>{{ _('N/A') }}</td>
+        </tr>
+      </tbody>
+    </table>
+
+  </div>
+</section>
+
+<section id="copyright-trademark" class="c-collapsible-section">
+  <h2 class="c-collapsible-section-heading" data-accordion-role="tab">{{ _('Copyright and Trademark Requests') }}</h2>
+
+  <div data-accordion-role="tabpanel">
+    <h3>{{ _('Copyright') }}</h3>
+    <p>{{ _('In the Reporting Period, we received 8 Copyright Takedown Notices and 0 Counter Notices.') }}</p>
+
+    <table class="mzp-u-data-table">
+      <thead>
+        <tr>
+          <th scope="col">{{ _('Mozilla Service') }}</th>
+          <th scope="col">
+            <a
+              href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-takedown-notice' }}">{{ _('Takedown Notices') }}</a>
+          </th>
+          <th scope="col">
+            <a
+              href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-counter-notice' }}">{{ _('Counter Notices') }}</a>
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <th scope="row">{{ _('Firefox Add-ons') }}</th>
+          <td>7</td>
+          <td>0</td>
+        </tr>
+        <tr>
+          <th scope="row">{{ _('Pocket') }}</th>
+          <td>0</td>
+          <td>0</td>
+        </tr>
+        <tr>
+          <th scope="row">{{ _('Other Services') }}</th>
+          <td>1</td>
+          <td>0</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <h3>{{ _('Trademark') }}</h3>
+    <p>{{ _('In the Reporting Period, we received 4 Trademark Takedown Notices and 0 Counter Notices.') }}</p>
+
+    <table class="mzp-u-data-table">
+      <thead>
+        <tr>
+          <th scope="col">{{ _('Mozilla Service') }}</th>
+          <th scope="col">
+            <a
+              href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-takedown-notice' }}">{{ _('Takedown Notices') }}</a>
+          </th>
+          <th scope="col">
+            <a
+              href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-counter-notice' }}">{{ _('Counter Notices') }}</a>
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <th scope="row">{{ _('Firefox Add-ons') }}</th>
+          <td>4</td>
+          <td>0</td>
+        </tr>
+        <tr>
+          <th scope="row">{{ _('Pocket') }}</th>
+          <td>0</td>
+          <td>0</td>
+        </tr>
+        <tr>
+          <th scope="row">{{ _('Other Services') }}</th>
+          <td>0</td>
+          <td>0</td>
+      </tbody>
+    </table>
+    <h3>{{ _('Personal Data Requests') }}</h3>
+    <p>{{ _('In the Reporting Period, we received 757 requests.') }}</p>
+
+    <table class="mzp-u-data-table">
+      <thread>
+        <th scope="col">{{ _('Service') }}</th>
+        <th scope="col">{{ _('Received') }}</th>
+      </thread>
+      <tbody>
+        <tr>
+          <th scope="row">{{ _('Mozilla') }}</th>
+          <td>427 <sup><a href="#notation">*</a></sup></td>
+        </tr>
+        <tr>
+          <th scope="row">{{ _('Pocket') }}</th>
+          <td>330</td>
+        </tr>
+      </tbody>
+    </table>
+    <aside class="footnotes">
+      <section id="notation">
+        <p>
+          {% trans privacy=url('privacy') %}
+          * During the Reporting Period we surfaced additional methods to contact us in our <a
+            href="{{ privacy }}">Mozilla Privacy Policy</a>. This higher level visibility likely caused the increase in
+          Personal Data Requests that we received compared to 2018 H2.
+          {% endtrans %}
+        </p>
       </section>
-  
-      <section class="section" id="supplement">
-        <h2 class="section-title" data-accordion-role="tab">{{ _('Supplement') }}</h2>
-  
-        <div class="content" data-accordion-role="tabpanel">
-          <h3>{{ _('Legislative Reform') }}</h3>
-          <p>
-            {% trans consumer='https://blog.mozilla.org/netpolicy/files/2019/04/Mozilla-U.S.-Consumer-Privacy-Bill-Blueprint-4.4.19-2.pdf',
+    </aside>
+  </div>
+</section>
+
+<section id="supplement" class="c-collapsible-section">
+  <h2 class="c-collapsible-section-heading" data-accordion-role="tab">{{ _('Supplement') }}</h2>
+
+  <div data-accordion-role="tabpanel">
+    <h3>{{ _('Legislative Reform') }}</h3>
+    <p>
+      {% trans consumer='https://blog.mozilla.org/netpolicy/files/2019/04/Mozilla-U.S.-Consumer-Privacy-Bill-Blueprint-4.4.19-2.pdf',
                      letter='https://blog.mozilla.org/netpolicy/files/2019/01/Mozilla-letter-re-FB-claims-of-data-partner.pdf' %}
-              During this reporting period, Mozilla continued our fight for greater data security and privacy across the globe. In the US, we released our <a href="{{ consumer }}">US Consumer Privacy Bill Blueprint</a> and we sent <a href="{{ letter }}">a letter to the US Congress</a> about Facebook data sharing. In the wake of the US Supreme Court’s Carpenter ruling, we released two studies for Firefox users on privacy expectations of location information shared online.
-            {% endtrans %}
-          </p>
-          <p>
-            {% trans kenyan='https://ca.go.ke/wp-content/uploads/2018/11/Mozilla-Submission-of-Comments-Kenya-Privacy-and-Data-Protection-Bill-2018.pdf',
+      During this reporting period, Mozilla continued our fight for greater data security and privacy across the globe.
+      In the US, we released our <a href="{{ consumer }}">US Consumer Privacy Bill Blueprint</a> and we sent <a
+        href="{{ letter }}">a letter to the US Congress</a> about Facebook data sharing. In the wake of the US Supreme
+      Court’s Carpenter ruling, we released two studies for Firefox users on privacy expectations of location
+      information shared online.
+      {% endtrans %}
+    </p>
+    <p>
+      {% trans kenyan='https://ca.go.ke/wp-content/uploads/2018/11/Mozilla-Submission-of-Comments-Kenya-Privacy-and-Data-Protection-Bill-2018.pdf',
                      data='https://www.tespok.co.ke/?p=13513' %}
-              In Kenya, we advocated for a strong data protection law, and spoke out against <a href="{{ kenyan }}">Kenyan legislation for a new ID system</a> that would allow the government to collect the DNA, biometrics, and other sensitive data of everyone in Kenya. We also held a series of <a href="{{ data }}">Lean Data Practices workshops</a> in Nairobi with government, business, and civil society stakeholders. 
-            {% endtrans %}
-          </p>
-          <p>
-            {% trans cybersecurity='https://blog.mozilla.org/netpolicy/2017/10/03/vulnerability-disclosure-should-be-in-new-eu-cybersecurity-strategy/',
+      In Kenya, we advocated for a strong data protection law, and spoke out against <a href="{{ kenyan }}">Kenyan
+        legislation for a new ID system</a> that would allow the government to collect the DNA, biometrics, and other
+      sensitive data of everyone in Kenya. We also held a series of <a href="{{ data }}">Lean Data Practices
+        workshops</a> in Nairobi with government, business, and civil society stakeholders.
+      {% endtrans %}
+    </p>
+    <p>
+      {% trans cybersecurity='https://blog.mozilla.org/netpolicy/2017/10/03/vulnerability-disclosure-should-be-in-new-eu-cybersecurity-strategy/',
                      seehere='https://blog.mozilla.org/netpolicy/files/2019/06/Sub-62-TOLA-Act.pdf' %}
-              The the <a href="{{ cybersecurity }}">EU Cybersecurity Act</a> included an important provision that we advocated for to grant ENISA (the EU Cybersecurity Agency) a mandate to work with Member States to stand up government vulnerability disclosure programs. We also continued to speak out against legislation in Australia that dangerously undermines encryption (see <a href="{{ seehere }}">here</a>); although there is much more progress needed, our advocacy did lead to a limited government vulnerability disclosure program.   
-            {% endtrans %} 
-          </p>
-          <p>
-            {% trans content='https://blog.mozilla.org/netpolicy/2018/11/21/the-eu-terrorist-content-regulation-a-threat-to-the-ecosystem-and-our-users-rights/',
+      The the <a href="{{ cybersecurity }}">EU Cybersecurity Act</a> included an important provision that we advocated
+      for to grant ENISA (the EU Cybersecurity Agency) a mandate to work with Member States to stand up government
+      vulnerability disclosure programs. We also continued to speak out against legislation in Australia that
+      dangerously undermines encryption (see <a href="{{ seehere }}">here</a>); although there is much more progress
+      needed, our advocacy did lead to a limited government vulnerability disclosure program.
+      {% endtrans %}
+    </p>
+    <p>
+      {% trans content='https://blog.mozilla.org/netpolicy/2018/11/21/the-eu-terrorist-content-regulation-a-threat-to-the-ecosystem-and-our-users-rights/',
                      comments='https://blog.mozilla.org/netpolicy/2019/04/10/uk_online-harms/',
                      liability='https://blog.mozilla.org/netpolicy/2019/01/02/india-attempts-to-turn-online-companies-into-censors-and-undermines-security-mozilla-responds/' %}
-              We continued to pushback on the <a href="{{ content }}">EU Terrorist Content Regulation</a>, and filed <a href="{{ comments }}">comments</a> against the UK government’s overreaching white paper on Online Harms, which had worrying effects on individual liberties and the competitive ecosystem. And we spoke out strongly against India’s proposed <a href="{{ liability }}">intermediary liability rules</a>, which would force all online intermediaries to censor and surveil their users and threatened encryption as well.   
-            {% endtrans %} 
-          </p>
-          
-          <h3>{{ _('Threat Indicators &amp; Data Disclosures') }}</h3>
-          <table class="data-table">
-            <thead>
-              <tr>
-                <th scope="col">{{ _('Type of Disclosure') }}</th>
-                <th scope="col">{{ _('Number of Disclosures') }}</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr>
-                <th scope="row"><a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-threat-indicator' }}">{{ _('Cybersecurity Threat Indicator') }}</a></th>
-                <td>0</td>
-              </tr>
-              <tr>
-                <th scope="row">{{ _('Other <a href="%s">Specific User</a> Data Disclosure')|format(url('mozorg.about.policy.transparency.index') + '#dfn-specific-user') }}</th>
-                <td>0</td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
-      </section>
-    {% endblock %}
-  
-    {% block report_nav %}
-      <aside class="section nav-block">
-        <nav class="content nav-report two-up">
-          <ul>
-            <li><a class="button" href="{{ url('mozorg.about.policy.transparency.index') + '#faq' }}">{{ _('FAQ') }}</a></li>
-            <li><a class="button" href="{{ url('mozorg.about.policy.transparency.index') + '#definitions' }}">{{ _('Definitions') }}</a></li>
-          </ul>
-        </nav>
-  
-        {% include 'mozorg/about/policy/transparency/includes/past-reports.html' %}
-      </aside>
-    {% endblock %}
-  
+      We continued to pushback on the <a href="{{ content }}">EU Terrorist Content Regulation</a>, and filed <a
+        href="{{ comments }}">comments</a> against the UK government’s overreaching white paper on Online Harms, which
+      had worrying effects on individual liberties and the competitive ecosystem. And we spoke out strongly against
+      India’s proposed <a href="{{ liability }}">intermediary liability rules</a>, which would force all online
+      intermediaries to censor and surveil their users and threatened encryption as well.
+      {% endtrans %}
+    </p>
+
+    <h3>{{ _('Threat Indicators &amp; Data Disclosures') }}</h3>
+    <table class="mzp-u-data-table">
+      <thead>
+        <tr>
+          <th scope="col">{{ _('Type of Disclosure') }}</th>
+          <th scope="col">{{ _('Number of Disclosures') }}</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <th scope="row"><a
+              href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-threat-indicator' }}">{{ _('Cybersecurity Threat Indicator') }}</a>
+          </th>
+          <td>0</td>
+        </tr>
+        <tr>
+          <th scope="row">
+            {{ _('Other <a href="%s">Specific User</a> Data Disclosure')|format(url('mozorg.about.policy.transparency.index') + '#dfn-specific-user') }}
+          </th>
+          <td>0</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</section>
+{% endblock %}

--- a/bedrock/mozorg/templates/mozorg/about/policy/transparency/jul-dec-2016.html
+++ b/bedrock/mozorg/templates/mozorg/about/policy/transparency/jul-dec-2016.html
@@ -7,185 +7,197 @@
 {% block page_title %}{{ _('Transparency Report - July–December, 2016') }}{% endblock %}
 
 {% block report_title %}
-  <h1>{{ _('Transparency Report') }} <span>{{ _('Reporting Period: July 1, 2016 to December 31, 2016') }}</span></h1>
+<h1>{{ _('Transparency Report') }} <span>{{ _('Reporting Period: July 1, 2016 to December 31, 2016') }}</span></h1>
 {% endblock %}
 
 {% block report_body %}
-  <section class="section" id="government-user-data">
-    <h2 class="section-title" data-accordion-role="tab">{{ _('Government Demands for User Data') }}</h2>
+<section id="government-user-data" class="c-collapsible-section">
+  <h2 class="c-collapsible-section-heading" data-accordion-role="tab">{{ _('Government Demands for User Data') }}</h2>
 
-    <div class="content" data-accordion-role="tabpanel">
-      <p>
-        {{ _('In the Reporting Period, Mozilla did not receive any government demands through Legal Processes for user data.') }}
-      </p>
+  <div data-accordion-role="tabpanel">
+    <p>
+      {{ _('In the Reporting Period, Mozilla did not receive any government demands through Legal Processes for user data.') }}
+    </p>
 
-      <table class="data-table">
-        <thead>
-          <tr>
-            <th scope="col">{{ _('Legal Processes') }}</th>
-            <th scope="col">{{ _('Received') }}</th>
-            <th scope="col">{{ _('Data Produced') }}</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <th scope="row">
-              <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-search-warrant' }}">{{ _('Search Warrants') }}</a>
-            </th>
-            <td>0</td>
-            <td>{{ _('N/A') }}</td>
-          </tr>
-          <tr>
-            <th scope="row">
-              <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-subpoena' }}">{{ _('Subpoenas') }}</a>
-            </th>
-            <td>0</td>
-            <td>{{ _('N/A') }}</td>
-          </tr>
-          <tr>
-            <th scope="row">
-              <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-court-order' }}">{{ _('Court Orders') }}</a>
-            </th>
-            <td>0</td>
-            <td>{{ _('N/A') }}</td>
-          </tr>
-          <tr>
-            <th scope="row">
-              <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-wiretap-order' }}">{{ _('Wiretap Orders') }}</a>
-            </th>
-            <td>0</td>
-            <td>{{ _('N/A') }}</td>
-          </tr>
-          <tr>
-            <th scope="row">
-              <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-pen-register-order' }}">{{ _('Pen Register Orders') }}</a>
-            </th>
-            <td>0</td>
-            <td>{{ _('N/A') }}</td>
-          </tr>
-          <tr>
-            <th scope="row">
-              <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-emergency-request' }}">{{ _('Emergency Requests') }}</a>
-            </th>
-            <td>0</td>
-            <td>{{ _('N/A') }}</td>
-          </tr>
-          <tr>
-            <th scope="row">
-              <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-natl-security-request' }}">{{ _('National Security Requests') }}</a> <sup><a href="#footnote-1">1</a></sup>
-            </th>
-            <td>0</td>
-            <td>{{ _('N/A') }}</td>
-          </tr>
-        </tbody>
-      </table>
+    <table class="mzp-u-data-table">
+      <thead>
+        <tr>
+          <th scope="col">{{ _('Legal Processes') }}</th>
+          <th scope="col">{{ _('Received') }}</th>
+          <th scope="col">{{ _('Data Produced') }}</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <th scope="row">
+            <a
+              href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-search-warrant' }}">{{ _('Search Warrants') }}</a>
+          </th>
+          <td>0</td>
+          <td>{{ _('N/A') }}</td>
+        </tr>
+        <tr>
+          <th scope="row">
+            <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-subpoena' }}">{{ _('Subpoenas') }}</a>
+          </th>
+          <td>0</td>
+          <td>{{ _('N/A') }}</td>
+        </tr>
+        <tr>
+          <th scope="row">
+            <a
+              href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-court-order' }}">{{ _('Court Orders') }}</a>
+          </th>
+          <td>0</td>
+          <td>{{ _('N/A') }}</td>
+        </tr>
+        <tr>
+          <th scope="row">
+            <a
+              href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-wiretap-order' }}">{{ _('Wiretap Orders') }}</a>
+          </th>
+          <td>0</td>
+          <td>{{ _('N/A') }}</td>
+        </tr>
+        <tr>
+          <th scope="row">
+            <a
+              href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-pen-register-order' }}">{{ _('Pen Register Orders') }}</a>
+          </th>
+          <td>0</td>
+          <td>{{ _('N/A') }}</td>
+        </tr>
+        <tr>
+          <th scope="row">
+            <a
+              href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-emergency-request' }}">{{ _('Emergency Requests') }}</a>
+          </th>
+          <td>0</td>
+          <td>{{ _('N/A') }}</td>
+        </tr>
+        <tr>
+          <th scope="row">
+            <a
+              href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-natl-security-request' }}">{{ _('National Security Requests') }}</a>
+            <sup><a href="#footnote-1">1</a></sup>
+          </th>
+          <td>0</td>
+          <td>{{ _('N/A') }}</td>
+        </tr>
+      </tbody>
+    </table>
 
-      <aside class="footnotes">
-        <section id="footnote-1">
-          <p>{{ _('1. Mozilla has never received a National Security Request.') }}</p>
-        </section>
-      </aside>
-    </div>
-  </section>
+    <aside class="footnotes">
+      <p>{{ _('1. Mozilla has never received a National Security Request.') }}</p>
+    </aside>
+  </div>
+</section>
 
-  <section class="section" id="government-content-removal">
-    <h2 class="section-title" data-accordion-role="tab">{{ _('Government Demands for Content Removal') }}</h2>
+<section id="government-content-removal" class="c-collapsible-section">
+  <h2 class="c-collapsible-section-heading" data-accordion-role="tab">{{ _('Government Demands for Content Removal') }}
+  </h2>
 
-    <div class="content" data-accordion-role="tabpanel">
-      <p>{{ _('In the Reporting Period, Mozilla did not receive any government requests for content removal from our services.') }}</p>
+  <div data-accordion-role="tabpanel">
+    <p>
+      {{ _('In the Reporting Period, Mozilla did not receive any government requests for content removal from our services.') }}
+    </p>
 
-      <table class="data-table">
-        <thead>
-          <tr>
-            <th scope="col">{{ _('Requesting Country') }}</th>
-            <th scope="col">{{ _('Requests Received') }}</th>
-            <th scope="col">{{ _('Data Produced') }}</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <th scope="row">{{ _('N/A') }}</th>
-            <td>0</td>
-            <td>{{ _('N/A') }}</td>
-          </tr>
-        </tbody>
-      </table>
+    <table class="mzp-u-data-table">
+      <thead>
+        <tr>
+          <th scope="col">{{ _('Requesting Country') }}</th>
+          <th scope="col">{{ _('Requests Received') }}</th>
+          <th scope="col">{{ _('Data Produced') }}</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <th scope="row">{{ _('N/A') }}</th>
+          <td>0</td>
+          <td>{{ _('N/A') }}</td>
+        </tr>
+      </tbody>
+    </table>
 
-    </div>
-  </section>
+  </div>
+</section>
 
-  <section class="section" id="copyright-trademark">
-    <h2 class="section-title" data-accordion-role="tab">{{ _('Copyright and Trademark Requests') }}</h2>
+<section id="copyright-trademark" class="c-collapsible-section">
+  <h2 class="c-collapsible-section-heading" data-accordion-role="tab">{{ _('Copyright and Trademark Requests') }}</h2>
 
-    <div class="content" data-accordion-role="tabpanel">
-      <h3>{{ _('Copyright') }}</h3>
-      <p>{{ _('In the Reporting Period, we received 4 Copyright Takedown Notices and 0 Counter Notices.') }}</p>
+  <div data-accordion-role="tabpanel">
+    <h3>{{ _('Copyright') }}</h3>
+    <p>{{ _('In the Reporting Period, we received 4 Copyright Takedown Notices and 0 Counter Notices.') }}</p>
 
-      <table class="data-table">
-        <thead>
-          <tr>
-            <th scope="col">{{ _('Mozilla Service') }}</th>
-            <th scope="col">
-              <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-takedown-notice' }}">{{ _('Takedown Notices') }}</a>
-            </th>
-            <th scope="col">
-              <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-counter-notice' }}">{{ _('Counter Notices') }}</a>
-            </th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <th scope="row">{{ _('Firefox Add-ons') }}</th>
-            <td>4</td>
-            <td>0</td>
-          </tr>
-          <tr>
-            <th scope="row">{{ _('Firefox Marketplace (Apps)') }}</th>
-            <td>0</td>
-            <td>0</td>
-          </tr>
-        </tbody>
-      </table>
+    <table class="mzp-u-data-table">
+      <thead>
+        <tr>
+          <th scope="col">{{ _('Mozilla Service') }}</th>
+          <th scope="col">
+            <a
+              href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-takedown-notice' }}">{{ _('Takedown Notices') }}</a>
+          </th>
+          <th scope="col">
+            <a
+              href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-counter-notice' }}">{{ _('Counter Notices') }}</a>
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <th scope="row">{{ _('Firefox Add-ons') }}</th>
+          <td>4</td>
+          <td>0</td>
+        </tr>
+        <tr>
+          <th scope="row">{{ _('Firefox Marketplace (Apps)') }}</th>
+          <td>0</td>
+          <td>0</td>
+        </tr>
+      </tbody>
+    </table>
 
-      <h3>{{ _('Trademark') }}</h3>
-      <p>{{ _('In the Reporting Period, we received 65 Trademark Takedown Notices and 1 Counter Notice') }}</p>
+    <h3>{{ _('Trademark') }}</h3>
+    <p>{{ _('In the Reporting Period, we received 65 Trademark Takedown Notices and 1 Counter Notice') }}</p>
 
-      <table class="data-table">
-        <thead>
-          <tr>
-            <th scope="col">{{ _('Mozilla Service') }}</th>
-            <th scope="col">
-              <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-takedown-notice' }}">{{ _('Takedown Notices') }}</a>
-            </th>
-            <th scope="col">
-              <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-counter-notice' }}">{{ _('Counter Notices') }}</a>
-            </th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <th scope="row">{{ _('Firefox Add-ons') }}</th>
-            <td>65</td>
-            <td>1</td>
-          </tr>
-          <tr>
-            <th scope="row">{{ _('Firefox Marketplace (Apps)') }}</th>
-            <td>0</td>
-            <td>0</td>
-          </tr>
-        </tbody>
-      </table>
+    <table class="mzp-u-data-table">
+      <thead>
+        <tr>
+          <th scope="col">{{ _('Mozilla Service') }}</th>
+          <th scope="col">
+            <a
+              href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-takedown-notice' }}">{{ _('Takedown Notices') }}</a>
+          </th>
+          <th scope="col">
+            <a
+              href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-counter-notice' }}">{{ _('Counter Notices') }}</a>
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <th scope="row">{{ _('Firefox Add-ons') }}</th>
+          <td>65</td>
+          <td>1</td>
+        </tr>
+        <tr>
+          <th scope="row">{{ _('Firefox Marketplace (Apps)') }}</th>
+          <td>0</td>
+          <td>0</td>
+        </tr>
+      </tbody>
+    </table>
 
-    </div>
-  </section>
+  </div>
+</section>
 
-  <section class="section" id="supplement">
-    <h2 class="section-title" data-accordion-role="tab">{{ _('Supplement') }}</h2>
+<section id="supplement" class="c-collapsible-section">
+  <h2 class="c-collapsible-section-heading" data-accordion-role="tab">{{ _('Supplement') }}</h2>
 
-    <div class="content" data-accordion-role="tabpanel">
-      <h3>{{ _('Legislative Reform') }}</h3>
+  <div data-accordion-role="tabpanel">
+    <h3>{{ _('Legislative Reform') }}</h3>
 
-      <p>
+    <p>
       {% trans
           shared_responsibility='https://blog.mozilla.org/blog/2016/09/13/cybersecurity-is-a-shared-responsibility/',
           security_vuln='https://blog.mozilla.org/netpolicy/2016/09/19/improving-government-disclosure-of-security-vulnerabilities/',
@@ -195,49 +207,56 @@
           eu_privacy='https://blog.mozilla.org/netpolicy/files/2017/01/Mozilla-Filing_E-Privacy-Survey.pdf',
           india_cloud='https://blog.mozilla.org/netpolicy/files/2016/07/Mozilla-Submissions-TRAI-Consultation-on-Cloud-Computing.pdf'
       %}
-        In the Reporting Period, we highlighted the need to see
-        <a href="{{ shared_responsibility }}">cybersecurity as a shared responsibility</a>,
-        called for <a href="{{ security_vuln }}">reform of how the U.S. Government handles security vulnerabilities</a>
-        and sponsored a speaker series on <a href="{{ speaker_gov }}">government</a>
-        <a href="{{ speaker_hack }}">hacking</a>. Together with other
-        tech companies, we <a href="{{ gag_orders }}">advocated against the U.S. Government’s use of unlimited indefinite gag orders</a>.
-        We also filed comments on the <a href="{{ eu_privacy }}">EU’s proposed e-Privacy Regulation</a> as well as
-        <a href="{{ india_cloud }}">India’s proposed Cloud Computing regulations</a>.
+      In the Reporting Period, we highlighted the need to see
+      <a href="{{ shared_responsibility }}">cybersecurity as a shared responsibility</a>,
+      called for <a href="{{ security_vuln }}">reform of how the U.S. Government handles security vulnerabilities</a>
+      and sponsored a speaker series on <a href="{{ speaker_gov }}">government</a>
+      <a href="{{ speaker_hack }}">hacking</a>. Together with other
+      tech companies, we <a href="{{ gag_orders }}">advocated against the U.S. Government’s use of unlimited indefinite
+        gag orders</a>.
+      We also filed comments on the <a href="{{ eu_privacy }}">EU’s proposed e-Privacy Regulation</a> as well as
+      <a href="{{ india_cloud }}">India’s proposed Cloud Computing regulations</a>.
       {% endtrans %}
-      </p>
+    </p>
 
-      <p>
+    <p>
       {% trans
           eu_copyright='https://www.changecopyright.org/',
           dmca_1201='https://blog.mozilla.org/netpolicy/files/2017/01/AdditionalCommentsonSection1201Study.pdf',
           berec_neutrality='https://blog.mozilla.org/netpolicy/files/2016/07/Mozilla-comments-on-draft-BEREC-guidelines-of-EU-net-neutrality-rules.pdf'
       %}
-        We also <a href="{{ eu_copyright }}">campaigned to reform Europe’s copyright laws</a>,
-        filed comments with the U.S. Copyright Office on their <a href="{{ dmca_1201 }}">review of Section 1201 of the Digital Millennium Copyright Act</a>,
-        and filed <a href="{{ berec_neutrality }}">comments with the Body of European Regulators of Electronic Communications on their net neutrality implementation guidelines</a>.
+      We also <a href="{{ eu_copyright }}">campaigned to reform Europe’s copyright laws</a>,
+      filed comments with the U.S. Copyright Office on their <a href="{{ dmca_1201 }}">review of Section 1201 of the
+        Digital Millennium Copyright Act</a>,
+      and filed <a href="{{ berec_neutrality }}">comments with the Body of European Regulators of Electronic
+        Communications on their net neutrality implementation guidelines</a>.
       {% endtrans %}
-      </p>
+    </p>
 
-      <h3>{{ _('Threat Indicators &amp; Data Disclosures') }}</h3>
-      <table class="data-table">
-        <thead>
-          <tr>
-            <th scope="col">{{ _('Type of Disclosure') }}</th>
-            <th scope="col">{{ _('Number of Disclosures') }}</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <th scope="row"><a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-threat-indicator' }}">{{ _('Cybersecurity Threat Indicator') }}</a></th>
-            <td>0</td>
-          </tr>
-          <tr>
-            <th scope="row">{{ _('Other <a href="%s">Specific User</a> Data Disclosure')|format(url('mozorg.about.policy.transparency.index') + '#dfn-specific-user') }}</th>
-            <td>0</td>
-          </tr>
-        </tbody>
-      </table>
+    <h3>{{ _('Threat Indicators &amp; Data Disclosures') }}</h3>
+    <table class="mzp-u-data-table">
+      <thead>
+        <tr>
+          <th scope="col">{{ _('Type of Disclosure') }}</th>
+          <th scope="col">{{ _('Number of Disclosures') }}</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <th scope="row"><a
+              href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-threat-indicator' }}">{{ _('Cybersecurity Threat Indicator') }}</a>
+          </th>
+          <td>0</td>
+        </tr>
+        <tr>
+          <th scope="row">
+            {{ _('Other <a href="%s">Specific User</a> Data Disclosure')|format(url('mozorg.about.policy.transparency.index') + '#dfn-specific-user') }}
+          </th>
+          <td>0</td>
+        </tr>
+      </tbody>
+    </table>
 
-    </div>
-  </section>
+  </div>
+</section>
 {% endblock %}

--- a/bedrock/mozorg/templates/mozorg/about/policy/transparency/jul-dec-2017.html
+++ b/bedrock/mozorg/templates/mozorg/about/policy/transparency/jul-dec-2017.html
@@ -7,249 +7,256 @@
 {% block page_title %}{{ _('Transparency Report - July-December, 2017') }}{% endblock %}
 
 {% block report_title %}
-  <h1>{{ _('Transparency Report') }} <span>{{ _('Reporting Period: July 1, 2017 to December 31, 2017') }}</span></h1>
+<h1>{{ _('Transparency Report') }} <span>{{ _('Reporting Period: July 1, 2017 to December 31, 2017') }}</span></h1>
 {% endblock %}
 
 {% block report_body %}
-  <section class="section" id="government-user-data">
-    <h2 class="section-title" data-accordion-role="tab">{{ _('Government Demands for User Data') }}</h2>
+<section id="government-user-data" class="c-collapsible-section">
+  <h2 class="c-collapsible-section-heading" data-accordion-role="tab">{{ _('Government Demands for User Data') }}</h2>
 
-    <div class="content" data-accordion-role="tabpanel">
-      <p>
-        {{ _('In the Reporting Period, Mozilla received 1 Court Order for user data.') }}
-      </p>
+  <div data-accordion-role="tabpanel">
+    <p>
+      {{ _('In the Reporting Period, Mozilla received 1 Court Order for user data.') }}
+    </p>
 
-      <table class="data-table">
-        <thead>
-          <tr>
-            <th scope="col">{{ _('Legal Processes') }}</th>
-            <th scope="col">{{ _('Received') }}</th>
-            <th scope="col">{{ _('Data Produced') }}</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <th scope="row">
-              <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-search-warrant' }}">{{ _('Search Warrants') }}</a>
-            </th>
-            <td>0</td>
-            <td>{{ _('N/A') }}</td>
-          </tr>
-          <tr>
-            <th scope="row">
-              <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-subpoena' }}">{{ _('Subpoenas') }}</a>
-            </th>
-            <td>0</td>
-            <td>{{ _('N/A') }}</td>
-          </tr>
-          <tr>
-            <th scope="row">
-              <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-court-order' }}">{{ _('Court Orders') }}</a>
-            </th>
-            <td>1</td>
-            <td>{{ _('Yes') }}</td>
-          </tr>
-          <tr>
-            <th scope="row">
-              <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-wiretap-order' }}">{{ _('Wiretap Orders') }}</a>
-            </th>
-            <td>0</td>
-            <td>{{ _('N/A') }}</td>
-          </tr>
-          <tr>
-            <th scope="row">
-              <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-pen-register-order' }}">{{ _('Pen Register Orders') }}</a>
-            </th>
-            <td>0</td>
-            <td>{{ _('N/A') }}</td>
-          </tr>
-          <tr>
-            <th scope="row">
-              <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-emergency-request' }}">{{ _('Emergency Requests') }}</a>
-            </th>
-            <td>0</td>
-            <td>{{ _('N/A') }}</td>
-          </tr>
-          <tr>
-            <th scope="row">
-              <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-natl-security-request' }}">{{ _('National Security Requests') }}</a> <sup><a href="#footnote-1">1</a></sup>
-            </th>
-            <td>0</td>
-            <td>{{ _('N/A') }}</td>
-          </tr>
-        </tbody>
-      </table>
+    <table class="mzp-u-data-table">
+      <thead>
+        <tr>
+          <th scope="col">{{ _('Legal Processes') }}</th>
+          <th scope="col">{{ _('Received') }}</th>
+          <th scope="col">{{ _('Data Produced') }}</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <th scope="row">
+            <a
+              href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-search-warrant' }}">{{ _('Search Warrants') }}</a>
+          </th>
+          <td>0</td>
+          <td>{{ _('N/A') }}</td>
+        </tr>
+        <tr>
+          <th scope="row">
+            <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-subpoena' }}">{{ _('Subpoenas') }}</a>
+          </th>
+          <td>0</td>
+          <td>{{ _('N/A') }}</td>
+        </tr>
+        <tr>
+          <th scope="row">
+            <a
+              href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-court-order' }}">{{ _('Court Orders') }}</a>
+          </th>
+          <td>1</td>
+          <td>{{ _('Yes') }}</td>
+        </tr>
+        <tr>
+          <th scope="row">
+            <a
+              href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-wiretap-order' }}">{{ _('Wiretap Orders') }}</a>
+          </th>
+          <td>0</td>
+          <td>{{ _('N/A') }}</td>
+        </tr>
+        <tr>
+          <th scope="row">
+            <a
+              href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-pen-register-order' }}">{{ _('Pen Register Orders') }}</a>
+          </th>
+          <td>0</td>
+          <td>{{ _('N/A') }}</td>
+        </tr>
+        <tr>
+          <th scope="row">
+            <a
+              href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-emergency-request' }}">{{ _('Emergency Requests') }}</a>
+          </th>
+          <td>0</td>
+          <td>{{ _('N/A') }}</td>
+        </tr>
+        <tr>
+          <th scope="row">
+            <a
+              href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-natl-security-request' }}">{{ _('National Security Requests') }}</a>
+            <sup><a href="#footnote-1">1</a></sup>
+          </th>
+          <td>0</td>
+          <td>{{ _('N/A') }}</td>
+        </tr>
+      </tbody>
+    </table>
 
-      <aside class="footnotes">
-        <section id="footnote-1">
-          <p>{{ _('1. Mozilla has never received a National Security Request.') }}</p>
-        </section>
-      </aside>
-    </div>
-  </section>
+    <aside class="footnotes">
+      <p>{{ _('1. Mozilla has never received a National Security Request.') }}</p>
+    </aside>
+  </div>
+</section>
 
-  <section class="section" id="government-content-removal">
-    <h2 class="section-title" data-accordion-role="tab">{{ _('Government Demands for Content Removal') }}</h2>
+<section class="c-collapsible-section">
+  <h2 class="c-collapsible-section-heading" data-accordion-role="tab">{{ _('Government Demands for Content Removal') }}
+  </h2>
 
-    <div class="content" data-accordion-role="tabpanel">
-      <p>{{ _('In the Reporting Period, Mozilla did not receive any government requests for content removal from our services.') }}</p>
+  <div data-accordion-role="tabpanel">
+    <p>
+      {{ _('In the Reporting Period, Mozilla did not receive any government requests for content removal from our services.') }}
+    </p>
 
-      <table class="data-table">
-        <thead>
-          <tr>
-            <th scope="col">{{ _('Requesting Country') }}</th>
-            <th scope="col">{{ _('Requests Received') }}</th>
-            <th scope="col">{{ _('Data Produced') }}</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <th scope="row">{{ _('N/A') }}</th>
-            <td>0</td>
-            <td>{{ _('N/A') }}</td>
-          </tr>
-        </tbody>
-      </table>
+    <table class="mzp-u-data-table">
+      <thead>
+        <tr>
+          <th scope="col">{{ _('Requesting Country') }}</th>
+          <th scope="col">{{ _('Requests Received') }}</th>
+          <th scope="col">{{ _('Data Produced') }}</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <th scope="row">{{ _('N/A') }}</th>
+          <td>0</td>
+          <td>{{ _('N/A') }}</td>
+        </tr>
+      </tbody>
+    </table>
 
-    </div>
-  </section>
+  </div>
+</section>
 
-  <section class="section" id="copyright-trademark">
-    <h2 class="section-title" data-accordion-role="tab">{{ _('Copyright and Trademark Requests') }}</h2>
+<section id="copyright-trademark" class="c-collapsible-section">
+  <h2 class="c-collapsible-section-heading" data-accordion-role="tab">{{ _('Copyright and Trademark Requests') }}</h2>
 
-    <div class="content" data-accordion-role="tabpanel">
-      <h3>{{ _('Copyright') }}</h3>
-      <p>{{ _('In the Reporting Period, we received 7 Copyright Takedown Notices and 0 Counter Notices.') }}</p>
+  <div data-accordion-role="tabpanel">
+    <h3>{{ _('Copyright') }}</h3>
+    <p>{{ _('In the Reporting Period, we received 7 Copyright Takedown Notices and 0 Counter Notices.') }}</p>
 
-      <table class="data-table">
-        <thead>
-          <tr>
-            <th scope="col">{{ _('Mozilla Service') }}</th>
-            <th scope="col">
-              <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-takedown-notice' }}">{{ _('Takedown Notices') }}</a>
-            </th>
-            <th scope="col">
-              <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-counter-notice' }}">{{ _('Counter Notices') }}</a>
-            </th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <th scope="row">{{ _('Firefox Add-ons') }}</th>
-            <td>7</td>
-            <td>0</td>
-          </tr>
-        </tbody>
-      </table>
+    <table class="mzp-u-data-table">
+      <thead>
+        <tr>
+          <th scope="col">{{ _('Mozilla Service') }}</th>
+          <th scope="col">
+            <a
+              href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-takedown-notice' }}">{{ _('Takedown Notices') }}</a>
+          </th>
+          <th scope="col">
+            <a
+              href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-counter-notice' }}">{{ _('Counter Notices') }}</a>
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <th scope="row">{{ _('Firefox Add-ons') }}</th>
+          <td>7</td>
+          <td>0</td>
+        </tr>
+      </tbody>
+    </table>
 
-      <h3>{{ _('Trademark') }}</h3>
-      <p>{{ _('In the Reporting Period, we received 7 Trademark Takedown Notices and 0 Counter Notices.') }}</p>
+    <h3>{{ _('Trademark') }}</h3>
+    <p>{{ _('In the Reporting Period, we received 7 Trademark Takedown Notices and 0 Counter Notices.') }}</p>
 
-      <table class="data-table">
-        <thead>
-          <tr>
-            <th scope="col">{{ _('Mozilla Service') }}</th>
-            <th scope="col">
-              <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-takedown-notice' }}">{{ _('Takedown Notices') }}</a>
-            </th>
-            <th scope="col">
-              <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-counter-notice' }}">{{ _('Counter Notices') }}</a>
-            </th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <th scope="row">{{ _('Firefox Add-ons') }}</th>
-            <td>7</td>
-            <td>0</td>
-          </tr>
-        </tbody>
-      </table>
+    <table class="mzp-u-data-table">
+      <thead>
+        <tr>
+          <th scope="col">{{ _('Mozilla Service') }}</th>
+          <th scope="col">
+            <a
+              href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-takedown-notice' }}">{{ _('Takedown Notices') }}</a>
+          </th>
+          <th scope="col">
+            <a
+              href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-counter-notice' }}">{{ _('Counter Notices') }}</a>
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <th scope="row">{{ _('Firefox Add-ons') }}</th>
+          <td>7</td>
+          <td>0</td>
+        </tr>
+      </tbody>
+    </table>
 
-    </div>
-  </section>
+  </div>
+</section>
 
-  <section class="section" id="supplement">
-    <h2 class="section-title" data-accordion-role="tab">{{ _('Supplement') }}</h2>
+<section class="c-collapsible-section">
+  <h2 class="c-collapsible-section-heading" data-accordion-role="tab">{{ _('Supplement') }}</h2>
 
-    <div class="content" data-accordion-role="tabpanel">
-      <h3>{{ _('Legislative Reform') }}</h3>
+  <div data-accordion-role="tabpanel">
+    <h3>{{ _('Legislative Reform') }}</h3>
 
-      <p>
-        {% trans charter='https://blog.mozilla.org/netpolicy/2017/11/15/white-house-releases-new-vep-charter/',
+    <p>
+      {% trans charter='https://blog.mozilla.org/netpolicy/2017/11/15/white-house-releases-new-vep-charter/',
                  advocated='https://blog.mozilla.org/netpolicy/2017/10/03/vulnerability-disclosure-should-be-in-new-eu-cybersecurity-strategy/' %}
-          In the Reporting Period, Mozilla continued to push for reforms to the
-          U.S. Government’s process for handling security vulnerabilities,
-          culminating in the release by the White House of a
-          <a href="{{ charter }}">new charter</a> for the Vulnerabilities
-          Equities Process. We also <a href="{{ advocated }}">advocated</a> for
-          European governments to develop government vulnerability disclosure
-          review processes to be included in the forthcoming EU Cybersecurity
-          Act, including as members of the Centre for European Policy Studies
-          Task Force on Software Vulnerability Disclosure.
-        {% endtrans %}
-      </p>
-      <p>
-        {% trans vocal='https://blog.mozilla.org/netpolicy/2017/11/16/need-aadhaar-to-investigate-lost-package/',
+      In the Reporting Period, Mozilla continued to push for reforms to the
+      U.S. Government’s process for handling security vulnerabilities,
+      culminating in the release by the White House of a
+      <a href="{{ charter }}">new charter</a> for the Vulnerabilities
+      Equities Process. We also <a href="{{ advocated }}">advocated</a> for
+      European governments to develop government vulnerability disclosure
+      review processes to be included in the forthcoming EU Cybersecurity
+      Act, including as members of the Centre for European Policy Studies
+      Task Force on Software Vulnerability Disclosure.
+      {% endtrans %}
+    </p>
+    <p>
+      {% trans vocal='https://blog.mozilla.org/netpolicy/2017/11/16/need-aadhaar-to-investigate-lost-package/',
                  regulation='https://blog.mozilla.org/netpolicy/2017/10/12/mozilla-releases-recommendations-draft-eu-eprivacy-regulation/',
                  crossborder='https://blog.mozilla.org/netpolicy/files/2017/10/Mozilla-e-evidence-submission.pdf',
                  copyright='http://copybuzz.com/copyright/interview-raegan-macdonald/' %}
-          We’ve been <a href="{{ vocal }}">vocal</a> in the debate around
-          India’s first data protection law, and we continued to engage with
-          Europe’s <a href="{{ regulation }}">e-Privacy Regulation</a>. We've
-          also contributed to the development of the EU's approach to
-          <a href="{{ crossborder }}">cross-border access to data</a>, and
-          worked to influence the EU Commission’s ongoing
-          <a href="{{ copyright }}">copyright reform</a> efforts.
-        {% endtrans %}
-      </p>
+      We’ve been <a href="{{ vocal }}">vocal</a> in the debate around
+      India’s first data protection law, and we continued to engage with
+      Europe’s <a href="{{ regulation }}">e-Privacy Regulation</a>. We've
+      also contributed to the development of the EU's approach to
+      <a href="{{ crossborder }}">cross-border access to data</a>, and
+      worked to influence the EU Commission’s ongoing
+      <a href="{{ copyright }}">copyright reform</a> efforts.
+      {% endtrans %}
+    </p>
+    <p>
+      {% trans urging='https://blog.mozilla.org/wp-content/uploads/2017/08/No.-16-402-ac-Technology-Companies1.pdf' %}
+      In July 2017, Mozilla joined with other technology companies in an amicus brief urging the Supreme Court of the
+      United States to reexamine how the 4th Amendment and search warrant requirements should apply in our digital era.
+      {% endtrans %}
+    </p>
+
+    <h3>{{ _('Threat Indicators &amp; Data Disclosures') }}</h3>
+    <table class="mzp-u-data-table">
+      <thead>
+        <tr>
+          <th scope="col">{{ _('Type of Disclosure') }}</th>
+          <th scope="col">{{ _('Number of Disclosures') }}</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <th scope="row"><a
+              href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-threat-indicator' }}">{{ _('Cybersecurity Threat Indicator') }}</a>
+          </th>
+          <td>0</td>
+        </tr>
+        <tr>
+          <th scope="row">
+            {{ _('Other <a href="%s">Specific User</a> Data Disclosure')|format(url('mozorg.about.policy.transparency.index') + '#dfn-specific-user') }}
+          </th>
+          <td>1<sup>*</sup></td>
+        </tr>
+      </tbody>
+    </table>
+
+    <aside class="footnotes">
       <p>
-        {% trans urging='https://blog.mozilla.org/wp-content/uploads/2017/08/No.-16-402-ac-Technology-Companies1.pdf' %}
-          In July 2017, Mozilla joined with other technology companies in an amicus brief urging the Supreme Court of the United States to reexamine how the 4th Amendment and search warrant requirements should apply in our digital era.
+        {% trans link_cybertipline='http://www.missingkids.org/cybertipline' %}
+        * Information about possible child sexual exploitation can be voluntarily reported by anyone to the National
+        Center for Missing & Exploited Children’s (NCMEC) <a href="{{ link_cybertipline }}">CyberTipline</a>. We take
+        this issue seriously. In the Reporting Period, Mozilla disclosed Specific User data to the NCMEC in connection
+        with content that was uploaded to a Mozilla service and implicated child sexual exploitation.
         {% endtrans %}
       </p>
+    </aside>
 
-      <h3>{{ _('Threat Indicators &amp; Data Disclosures') }}</h3>
-      <table class="data-table">
-        <thead>
-          <tr>
-            <th scope="col">{{ _('Type of Disclosure') }}</th>
-            <th scope="col">{{ _('Number of Disclosures') }}</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <th scope="row"><a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-threat-indicator' }}">{{ _('Cybersecurity Threat Indicator') }}</a></th>
-            <td>0</td>
-          </tr>
-          <tr>
-            <th scope="row">{{ _('Other <a href="%s">Specific User</a> Data Disclosure')|format(url('mozorg.about.policy.transparency.index') + '#dfn-specific-user') }}</th>
-            <td>1<sup>*</sup></td>
-          </tr>
-        </tbody>
-      </table>
-
-      <footer class="footnotes">
-        <p class="footnote" id="footnote1">
-        {% trans link_cybertipline='http://www.missingkids.org/cybertipline' %}
-          * Information about possible child sexual exploitation can be voluntarily reported by anyone to the National Center for Missing & Exploited Children’s (NCMEC) <a href="{{ link_cybertipline }}">CyberTipline</a>. We take this issue seriously. In the Reporting Period, Mozilla disclosed Specific User data to the NCMEC in connection with content that was uploaded to a Mozilla service and implicated child sexual exploitation.
-        {% endtrans %}
-        </p>
-      </footer>
-
-    </div>
-  </section>
-{% endblock %}
-
-{% block report_nav %}
-  <aside class="section nav-block">
-    <nav class="content nav-report two-up">
-      <ul>
-        <li><a class="button" href="{{ url('mozorg.about.policy.transparency.index') + '#faq' }}">{{ _('FAQ') }}</a></li>
-        <li><a class="button" href="{{ url('mozorg.about.policy.transparency.index') + '#definitions' }}">{{ _('Definitions') }}</a></li>
-      </ul>
-    </nav>
-
-    {% include 'mozorg/about/policy/transparency/includes/past-reports.html' %}
-  </aside>
+  </div>
+</section>
 {% endblock %}

--- a/bedrock/mozorg/templates/mozorg/about/policy/transparency/jul-dec-2018.html
+++ b/bedrock/mozorg/templates/mozorg/about/policy/transparency/jul-dec-2018.html
@@ -1,276 +1,290 @@
 {# This Source Code Form is subject to the terms of the Mozilla Public
     # License, v. 2.0. If a copy of the MPL was not distributed with this
     # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
-  
-    {% extends "mozorg/about/policy/transparency/report-base.html" %}
-  
-    {% block page_title %}{{ _('Transparency Report - July-December, 2018') }}{% endblock %}
-  
-    {% block report_title %}
-      <h1>{{ _('Transparency Report') }} <span>{{ _('Reporting Period: July 1, 2018 to December 31, 2018') }}</span></h1>
-    {% endblock %}
-  
-    {% block report_body %}
-      <section class="section" id="government-user-data">
-        <h2 class="section-title" data-accordion-role="tab">{{ _('Government Demands for User Data') }}</h2>
-  
-        <div class="content" data-accordion-role="tabpanel">
-          <p>
-            {{ _('In the Reporting Period, Mozilla received one subpoena for user data.') }}
-          </p>
-  
-          <table class="data-table">
-            <thead>
-              <tr>
-                <th scope="col">{{ _('Legal Processes') }}</th>
-                <th scope="col">{{ _('Received') }}</th>
-                <th scope="col">{{ _('Data Produced') }}</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr>
-                <th scope="row">
-                  <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-search-warrant' }}">{{ _('Search Warrants') }}</a>
-                </th>
-                <td>0</td>
-                <td>{{ _('0') }}</td>
-              </tr>
-              <tr>
-                <th scope="row">
-                  <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-subpoena' }}">{{ _('Subpoenas') }}</a>
-                </th>
-                <td>1<sup><a href="#footnote-1">1</a></sup></td>
-                <td>{{ _('0') }}</td>
-              </tr>
-              <tr>
-                <th scope="row">
-                  <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-court-order' }}">{{ _('Court Orders') }}</a>
-                </th>
-                <td>0</td>
-                <td>{{ _('0') }}</td>
-              </tr>
-              <tr>
-                <th scope="row">
-                  <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-wiretap-order' }}">{{ _('Wiretap Orders') }}</a>
-                </th>
-                <td>0</td>
-                <td>{{ _('0') }}</td>
-              </tr>
-              <tr>
-                <th scope="row">
-                  <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-pen-register-order' }}">{{ _('Pen Register Orders') }}</a>
-                </th>
-                <td>0</td>
-                <td>{{ _('0') }}</td>
-              </tr>
-              <tr>
-                <th scope="row">
-                  <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-emergency-request' }}">{{ _('Emergency Requests') }}</a>
-                </th>
-                <td>0</td>
-                <td>{{ _('0') }}</td>
-              </tr>
-              <tr>
-                <th scope="row">
-                  <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-natl-security-request' }}">{{ _('National Security Requests') }}</a> <sup><a href="#footnote-2">2</a></sup>
-                </th>
-                <td>0</td>
-                <td>{{ _('0') }}</td>
-              </tr>
-            </tbody>
-          </table>
-  
-          <aside class="footnotes">
-            <section id="footnote-1">
-              <p>{{ _('1. Issued to Mozilla Corporation.') }}</p>
-            </section>
-            <section id="footnote-2">
-              <p>{{ _('2. None of the Mozilla Foundation, Mozilla Corporation or Pocket have ever received a National Security Request.') }}</p>
-            </section>
-          </aside>
-        </div>
-      </section>
-  
-      <section class="section" id="government-content-removal">
-        <h2 class="section-title" data-accordion-role="tab">{{ _('Government Demands for Content Removal') }}</h2>
-  
-        <div class="content" data-accordion-role="tabpanel">
-          <p>{{ _('In the Reporting Period, Mozilla did not receive any government requests for content removal from our services.') }}</p>
-  
-          <table class="data-table">
-            <thead>
-              <tr>
-                <th scope="col">{{ _('Requesting Country') }}</th>
-                <th scope="col">{{ _('Requests Received') }}</th>
-                <th scope="col">{{ _('Data Produced') }}</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr>
-                <th scope="row">{{ _('N/A') }}</th>
-                <td>0</td>
-                <td>{{ _('0') }}</td>
-              </tr>
-            </tbody>
-          </table>
-  
-        </div>
-      </section>
-  
-      <section class="section" id="copyright-trademark">
-        <h2 class="section-title" data-accordion-role="tab">{{ _('Copyright and Trademark Requests') }}</h2>
-  
-        <div class="content" data-accordion-role="tabpanel">
-          <h3>{{ _('Copyright') }}</h3>
-          <p>{{ _('In the Reporting Period, we received 14 Copyright Takedown Notices and 0 Counter Notices.') }}</p>
-  
-          <table class="data-table">
-            <thead>
-              <tr>
-                <th scope="col">{{ _('Mozilla Service') }}</th>
-                <th scope="col">
-                  <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-takedown-notice' }}">{{ _('Takedown Notices') }}</a>
-                </th>
-                <th scope="col">
-                  <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-counter-notice' }}">{{ _('Counter Notices') }}</a>
-                </th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr>
-                <th scope="row">{{ _('Firefox Add-ons') }}</th>
-                <td>14</td>
-                <td>0</td>
-              </tr>
-              <tr>
-                <th scope="row">{{ _('Pocket') }}</th>
-                <td>0</td>
-                <td>0</td>
-              </tr>
-              <tr>
-                <th scope="row">{{ _('Other Services') }}</th>
-                <td>0</td>
-                <td>0</td>
-              </tr>
-            </tbody>
-          </table>
-  
-          <h3>{{ _('Trademark') }}</h3>
-          <p>{{ _('In the Reporting Period, we received 20 Trademark Takedown Notices and 0 Counter Notices.') }}</p>
-  
-          <table class="data-table">
-            <thead>
-              <tr>
-                <th scope="col">{{ _('Mozilla Service') }}</th>
-                <th scope="col">
-                  <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-takedown-notice' }}">{{ _('Takedown Notices') }}</a>
-                </th>
-                <th scope="col">
-                  <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-counter-notice' }}">{{ _('Counter Notices') }}</a>
-                </th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr>
-                <th scope="row">{{ _('Firefox Add-ons') }}</th>
-                <td>20</td>
-                <td>0</td>
-              </tr>
-              <tr>
-                <th scope="row">{{ _('Pocket') }}</th>
-                <td>0</td>
-                <td>0</td>
-              </tr>
-              <tr>
-                <th scope="row">{{ _('Other Services') }}</th>
-                <td>0</td>
-                <td>0</td>
-            </tbody>
-          </table>
-          <h3>{{ _('Personal Data Requests') }}</h3>
-          <p>{{ _('In the Reporting Period, we received 439 requests.') }}</p>
 
-          <table class="data-table">
-            <thread>
-              <th scope="col">{{ _('Service') }}</th>
-              <th scope="col">{{ _('Received') }}</th>
-            </thread>
-            <tbody>
-              <tr>
-                <th scope="row">{{ _('Mozilla') }}</th>
-                <td>33</td>
-              </tr>
-              <tr>
-                <th scope="row">{{ _('Pocket') }}</th>
-                <td>406</td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
-      </section>
-  
-      <section class="section" id="supplement">
-        <h2 class="section-title" data-accordion-role="tab">{{ _('Supplement') }}</h2>
-  
-        <div class="content" data-accordion-role="tabpanel">
-          <h3>{{ _('Legislative Reform') }}</h3>
-          <p>
-            {% trans india='https://blog.mozilla.org/netpolicy/2018/07/27/indian-draft-data-protection-bill/',
-                     kenya='https://ca.go.ke/wp-content/uploads/2018/11/Mozilla-Submission-of-Comments-Kenya-Privacy-and-Data-Protection-Bill-2018.pdf',
-                     brazil='https://blog.mozilla.org/netpolicy/2018/07/02/brazilian-data-protection-bill/',
-                     american='https://blog.mozilla.org/netpolicy/2018/11/20/mozilla-files-comments-on-ntias-proposed-american-privacy-framework/',
-                     workshop='https://blog.mozilla.org/netpolicy/2018/12/21/privacy-in-practice-mozilla-talks-lean-data-in-india/',
-                     panel='https://blog.mozilla.org/netpolicy/2018/09/19/lessons-from-carpenter-mozilla-panel-discussion-at-icdppc/' %}
-              During the Reporting Period, we continued fighting for strong data protection rules around the world, including work on the first data protection laws in <a href="{{ india }}">India</a>, <a href="{{ kenya }}">Kenya</a>, and <a href="{{ brazil }}">Brazil</a>, pushing for the swift adoption of the EU’s ePrivacy Regulation, and filing comment on the National Telecommunications and Information Administration’s proposed <a href="{{ american }}">American Privacy Framework</a> in the US.  We also held a <a href="{{ workshop }}">workshop in Delhi</a> with companies large and small on our Lean Data Practices framework, and held a <a href="{{ panel }}">panel</a> in Brussels on the recent US Supreme Court Carpenter decision, which extended warrant protections to cell site location information.
-            {% endtrans %}
-          </p>
-          <p>
-            {% trans government='https://blog.mozilla.org/netpolicy/2018/07/04/a-step-forward-for-government-vulnerability-disclosure-in-europe/',
+{% extends "mozorg/about/policy/transparency/report-base.html" %}
+
+{% block page_title %}{{ _('Transparency Report - July-December, 2018') }}{% endblock %}
+
+{% block report_title %}
+<h1>{{ _('Transparency Report') }} <span>{{ _('Reporting Period: July 1, 2018 to December 31, 2018') }}</span></h1>
+{% endblock %}
+
+{% block report_body %}
+<section id="government-user-data" class="c-collapsible-section">
+  <h2 class="c-collapsible-section-heading" data-accordion-role="tab">{{ _('Government Demands for User Data') }}</h2>
+
+  <div data-accordion-role="tabpanel">
+    <p>
+      {{ _('In the Reporting Period, Mozilla received one subpoena for user data.') }}
+    </p>
+
+    <table class="mzp-u-data-table">
+      <thead>
+        <tr>
+          <th scope="col">{{ _('Legal Processes') }}</th>
+          <th scope="col">{{ _('Received') }}</th>
+          <th scope="col">{{ _('Data Produced') }}</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <th scope="row">
+            <a
+              href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-search-warrant' }}">{{ _('Search Warrants') }}</a>
+          </th>
+          <td>0</td>
+          <td>{{ _('0') }}</td>
+        </tr>
+        <tr>
+          <th scope="row">
+            <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-subpoena' }}">{{ _('Subpoenas') }}</a>
+          </th>
+          <td>1<sup><a href="#footnote-1">1</a></sup></td>
+          <td>{{ _('0') }}</td>
+        </tr>
+        <tr>
+          <th scope="row">
+            <a
+              href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-court-order' }}">{{ _('Court Orders') }}</a>
+          </th>
+          <td>0</td>
+          <td>{{ _('0') }}</td>
+        </tr>
+        <tr>
+          <th scope="row">
+            <a
+              href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-wiretap-order' }}">{{ _('Wiretap Orders') }}</a>
+          </th>
+          <td>0</td>
+          <td>{{ _('0') }}</td>
+        </tr>
+        <tr>
+          <th scope="row">
+            <a
+              href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-pen-register-order' }}">{{ _('Pen Register Orders') }}</a>
+          </th>
+          <td>0</td>
+          <td>{{ _('0') }}</td>
+        </tr>
+        <tr>
+          <th scope="row">
+            <a
+              href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-emergency-request' }}">{{ _('Emergency Requests') }}</a>
+          </th>
+          <td>0</td>
+          <td>{{ _('0') }}</td>
+        </tr>
+        <tr>
+          <th scope="row">
+            <a
+              href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-natl-security-request' }}">{{ _('National Security Requests') }}</a>
+            <sup><a href="#footnote-2">2</a></sup>
+          </th>
+          <td>0</td>
+          <td>{{ _('0') }}</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <aside class="footnotes">
+      <p>{{ _('1. Issued to Mozilla Corporation.') }}</p>
+      <p>
+        {{ _('2. None of the Mozilla Foundation, Mozilla Corporation or Pocket have ever received a National Security Request.') }}
+      </p>
+    </aside>
+  </div>
+</section>
+
+<section id="government-content-removal" class="c-collapsible-section">
+  <h2 class="c-collapsible-section-heading" data-accordion-role="tab">{{ _('Government Demands for Content Removal') }}
+  </h2>
+
+  <div data-accordion-role="tabpanel">
+    <p>
+      {{ _('In the Reporting Period, Mozilla did not receive any government requests for content removal from our services.') }}
+    </p>
+
+    <table class="mzp-u-data-table">
+      <thead>
+        <tr>
+          <th scope="col">{{ _('Requesting Country') }}</th>
+          <th scope="col">{{ _('Requests Received') }}</th>
+          <th scope="col">{{ _('Data Produced') }}</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <th scope="row">{{ _('N/A') }}</th>
+          <td>0</td>
+          <td>{{ _('0') }}</td>
+        </tr>
+      </tbody>
+    </table>
+
+  </div>
+</section>
+
+<section id="copyright-trademark" class="c-collapsible-section">
+  <h2 class="c-collapsible-section-heading" data-accordion-role="tab">{{ _('Copyright and Trademark Requests') }}</h2>
+
+  <div data-accordion-role="tabpanel">
+    <h3>{{ _('Copyright') }}</h3>
+    <p>{{ _('In the Reporting Period, we received 14 Copyright Takedown Notices and 0 Counter Notices.') }}</p>
+
+    <table class="mzp-u-data-table">
+      <thead>
+        <tr>
+          <th scope="col">{{ _('Mozilla Service') }}</th>
+          <th scope="col">
+            <a
+              href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-takedown-notice' }}">{{ _('Takedown Notices') }}</a>
+          </th>
+          <th scope="col">
+            <a
+              href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-counter-notice' }}">{{ _('Counter Notices') }}</a>
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <th scope="row">{{ _('Firefox Add-ons') }}</th>
+          <td>14</td>
+          <td>0</td>
+        </tr>
+        <tr>
+          <th scope="row">{{ _('Pocket') }}</th>
+          <td>0</td>
+          <td>0</td>
+        </tr>
+        <tr>
+          <th scope="row">{{ _('Other Services') }}</th>
+          <td>0</td>
+          <td>0</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <h3>{{ _('Trademark') }}</h3>
+    <p>{{ _('In the Reporting Period, we received 20 Trademark Takedown Notices and 0 Counter Notices.') }}</p>
+
+    <table class="mzp-u-data-table">
+      <thead>
+        <tr>
+          <th scope="col">{{ _('Mozilla Service') }}</th>
+          <th scope="col">
+            <a
+              href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-takedown-notice' }}">{{ _('Takedown Notices') }}</a>
+          </th>
+          <th scope="col">
+            <a
+              href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-counter-notice' }}">{{ _('Counter Notices') }}</a>
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <th scope="row">{{ _('Firefox Add-ons') }}</th>
+          <td>20</td>
+          <td>0</td>
+        </tr>
+        <tr>
+          <th scope="row">{{ _('Pocket') }}</th>
+          <td>0</td>
+          <td>0</td>
+        </tr>
+        <tr>
+          <th scope="row">{{ _('Other Services') }}</th>
+          <td>0</td>
+          <td>0</td>
+      </tbody>
+    </table>
+    <h3>{{ _('Personal Data Requests') }}</h3>
+    <p>{{ _('In the Reporting Period, we received 439 requests.') }}</p>
+
+    <table class="mzp-u-data-table">
+      <thread>
+        <th scope="col">{{ _('Service') }}</th>
+        <th scope="col">{{ _('Received') }}</th>
+      </thread>
+      <tbody>
+        <tr>
+          <th scope="row">{{ _('Mozilla') }}</th>
+          <td>33</td>
+        </tr>
+        <tr>
+          <th scope="row">{{ _('Pocket') }}</th>
+          <td>406</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</section>
+
+<section id="supplement" class="c-collapsible-section">
+  <h2 class="c-collapsible-section-heading" data-accordion-role="tab">{{ _('Supplement') }}</h2>
+
+  <div data-accordion-role="tabpanel">
+    <h3>{{ _('Legislative Reform') }}</h3>
+    <p>
+      {% trans india='https://blog.mozilla.org/netpolicy/2018/07/27/indian-draft-data-protection-bill/',
+                      kenya='https://ca.go.ke/wp-content/uploads/2018/11/Mozilla-Submission-of-Comments-Kenya-Privacy-and-Data-Protection-Bill-2018.pdf',
+                      brazil='https://blog.mozilla.org/netpolicy/2018/07/02/brazilian-data-protection-bill/',
+                      american='https://blog.mozilla.org/netpolicy/2018/11/20/mozilla-files-comments-on-ntias-proposed-american-privacy-framework/',
+                      workshop='https://blog.mozilla.org/netpolicy/2018/12/21/privacy-in-practice-mozilla-talks-lean-data-in-india/',
+                      panel='https://blog.mozilla.org/netpolicy/2018/09/19/lessons-from-carpenter-mozilla-panel-discussion-at-icdppc/' %}
+      During the Reporting Period, we continued fighting for strong data protection rules around the world, including
+      work on the first data protection laws in <a href="{{ india }}">India</a>, <a href="{{ kenya }}">Kenya</a>, and <a
+        href="{{ brazil }}">Brazil</a>, pushing for the swift adoption of the EU’s ePrivacy Regulation, and filing
+      comment on the National Telecommunications and Information Administration’s proposed <a
+        href="{{ american }}">American Privacy Framework</a> in the US. We also held a <a href="{{ workshop }}">workshop
+        in Delhi</a> with companies large and small on our Lean Data Practices framework, and held a <a
+        href="{{ panel }}">panel</a> in Brussels on the recent US Supreme Court Carpenter decision, which extended
+      warrant protections to cell site location information.
+      {% endtrans %}
+    </p>
+    <p>
+      {% trans government='https://blog.mozilla.org/netpolicy/2018/07/04/a-step-forward-for-government-vulnerability-disclosure-in-europe/',
                      commented='https://blog.mozilla.org/netpolicy/2018/08/22/europe_lawful_access/',
                      action='https://blog.mozilla.org/netpolicy/files/2019/06/Sub46.pdf' %}
-              Mozilla continued advocating for EU Member States to enact <a href="{{ government }}">government vulnerability disclosure programs in the EU Cybersecurity Act</a>, and <a href="{{ commented }}">commented</a> on the EU proposals around cross-border data access for law enforcement. In Australia, we <a href="{{ action }}">took action</a> on legislation that would give the government new powers to undermine encryption. 
-            {% endtrans %}
-          </p>
-          <p>
-            {% trans copyright='https://blog.mozilla.org/netpolicy/2018/09/07/eu-copyright-reform-the-facts/',
+      Mozilla continued advocating for EU Member States to enact <a href="{{ government }}">government vulnerability
+        disclosure programs in the EU Cybersecurity Act</a>, and <a href="{{ commented }}">commented</a> on the EU
+      proposals around cross-border data access for law enforcement. In Australia, we <a href="{{ action }}">took
+        action</a> on legislation that would give the government new powers to undermine encryption.
+      {% endtrans %}
+    </p>
+    <p>
+      {% trans copyright='https://blog.mozilla.org/netpolicy/2018/09/07/eu-copyright-reform-the-facts/',
                      content='https://blog.mozilla.org/netpolicy/2018/11/21/the-eu-terrorist-content-regulation-a-threat-to-the-ecosystem-and-our-users-rights/' %}
-              We also <a href="{{ copyright }}">engaged heavily on the EU Copyright Directive</a>, to minimise the damage to individuals’ rights and the open internet arising from the directive’s upload filters, and spoke out against the <a href="{{ content }}">EU’s Terrorist Content Regulation</a>.  
-            {% endtrans %} 
-          </p>
-          
-          <h3>{{ _('Threat Indicators &amp; Data Disclosures') }}</h3>
-          <table class="data-table">
-            <thead>
-              <tr>
-                <th scope="col">{{ _('Type of Disclosure') }}</th>
-                <th scope="col">{{ _('Number of Disclosures') }}</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr>
-                <th scope="row"><a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-threat-indicator' }}">{{ _('Cybersecurity Threat Indicator') }}</a></th>
-                <td>0</td>
-              </tr>
-              <tr>
-                <th scope="row">{{ _('Other <a href="%s">Specific User</a> Data Disclosure')|format(url('mozorg.about.policy.transparency.index') + '#dfn-specific-user') }}</th>
-                <td>0</td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
-      </section>
-    {% endblock %}
-  
-    {% block report_nav %}
-      <aside class="section nav-block">
-        <nav class="content nav-report two-up">
-          <ul>
-            <li><a class="button" href="{{ url('mozorg.about.policy.transparency.index') + '#faq' }}">{{ _('FAQ') }}</a></li>
-            <li><a class="button" href="{{ url('mozorg.about.policy.transparency.index') + '#definitions' }}">{{ _('Definitions') }}</a></li>
-          </ul>
-        </nav>
-  
-        {% include 'mozorg/about/policy/transparency/includes/past-reports.html' %}
-      </aside>
-    {% endblock %}
-  
+      We also <a href="{{ copyright }}">engaged heavily on the EU Copyright Directive</a>, to minimise the damage to
+      individuals’ rights and the open internet arising from the directive’s upload filters, and spoke out against the
+      <a href="{{ content }}">EU’s Terrorist Content Regulation</a>.
+      {% endtrans %}
+    </p>
+
+    <h3>{{ _('Threat Indicators &amp; Data Disclosures') }}</h3>
+    <table class="mzp-u-data-table">
+      <thead>
+        <tr>
+          <th scope="col">{{ _('Type of Disclosure') }}</th>
+          <th scope="col">{{ _('Number of Disclosures') }}</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <th scope="row"><a
+              href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-threat-indicator' }}">{{ _('Cybersecurity Threat Indicator') }}</a>
+          </th>
+          <td>0</td>
+        </tr>
+        <tr>
+          <th scope="row">
+            {{ _('Other <a href="%s">Specific User</a> Data Disclosure')|format(url('mozorg.about.policy.transparency.index') + '#dfn-specific-user') }}
+          </th>
+          <td>0</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</section>
+{% endblock %}

--- a/bedrock/mozorg/templates/mozorg/about/policy/transparency/report-base.html
+++ b/bedrock/mozorg/templates/mozorg/about/policy/transparency/report-base.html
@@ -2,41 +2,38 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
 
-{% extends "base-pebbles.html" %}
+{% extends "base-protocol.html" %}
 
 {% block page_title %}{{ _('Transparency Report') }}{% endblock %}
-{% block body_class %}sand about-transparency{% endblock %}
 
 {% block page_css %}
-  {{ css_bundle('about-transparency') }}
+{{ css_bundle('about-transparency') }}
 {% endblock %}
 
 {% block js %}
-  {{ js_bundle('about-transparency') }}
+{{ js_bundle('about-transparency') }}
 {% endblock %}
 
 {% block content %}
-  <main role="main">
-    <header class="title-bar">
-      <div class="content">
+<main role="main">
+  <header class="c-page-header">
+    <div class="mzp-l-content l-content-narrow">
       {% block report_title %}{% endblock %}
-      </div>
-    </header>
-
-  <div class="content">
-    <div id="report-sections" class="report accordion">
-    {% block report_body %}{% endblock %}
     </div>
+  </header>
+
+  <div class="mzp-l-content l-content-narrow">
+    {% block report_body %}{% endblock %}
   </div>
 
   {% block report_nav %}
-  <aside class="section nav-block">
+  <aside>
     {% include 'mozorg/about/policy/transparency/includes/reports-nav.html' %}
     {% include 'mozorg/about/policy/transparency/includes/past-reports.html' %}
   </aside>
   {% endblock %}
 
-  </main>
+</main>
 {% endblock %}
 
 {% block email_form %}{% endblock %}

--- a/media/css/mozorg/about-transparency.scss
+++ b/media/css/mozorg/about-transparency.scss
@@ -35,6 +35,7 @@ dd {
         margin: $spacing-sm;
 
         a {
+            display: block;
             min-width: ($content-md / 3);
         }
 

--- a/media/css/mozorg/about-transparency.scss
+++ b/media/css/mozorg/about-transparency.scss
@@ -31,21 +31,17 @@ dd {
     margin: 0 auto;
     text-align: center;
 
-    a {
-        width: $content-xs;
+    li {
         margin: $spacing-sm;
-    }
 
-    @media #{$mq-md} {
-        li {
+        a {
+            min-width: ($content-md / 3);
+        }
+
+        @media #{$mq-md} {
             display: inline-block;
-
-            a {
-                min-width: ($content-md / 3);
-            }
         }
     }
-
 }
 
 .prev-reports-nav {

--- a/media/css/mozorg/about-transparency.scss
+++ b/media/css/mozorg/about-transparency.scss
@@ -2,189 +2,131 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-@import '../pebbles/includes/lib';
+@import '../../protocol/css/includes/lib';
+@import '../../protocol/css/components/article';
+@import '../../protocol/css/includes/mixins/details';
 
-.section {
-    @include clearfix;
-    padding: $gutter-width 0;
+//* -------------------------------------------------------------------------- */
+// Index
 
-    @media #{$mq-tablet} {
-        padding: ($gutter-width * 2) 0;
-    }
+dt {
+    @include font-mozilla;
+    @include text-display-xs;
+    font-weight: bold;
+    margin-top: $spacing-sm;
 }
 
-.content {
-    @include border-box;
+dd {
+    padding: $spacing-sm;
+}
+
+//* -------------------------------------------------------------------------- */
+// Base Template
+
+.l-content-narrow {
+    max-width: $content-lg;
+}
+
+.reports-nav {
     margin: 0 auto;
-    overflow: visible;
-    padding: 0 $gutter-width;
-    max-width: $width-desktop;
-}
+    text-align: center;
 
-.section-extra h3 {
-    @include font-size(20px);
-}
-
-.section#introduction {
-    p:last-child {
-        margin-bottom: 0;
+    a {
+        width: $content-xs;
+        margin: $spacing-sm;
     }
-}
 
-.title-bar {
-    background: #000;
-    padding: $gutter-width 0;
+    @media #{$mq-md} {
+        li {
+            display: inline-block;
 
-    h1 {
-        color: #fff;
-        margin: 0;
-
-        span {
-            @include font-size-level4;
-            display: block;
-            margin: .5em 0 0;
+            a {
+                min-width: ($content-md / 3);
+            }
         }
     }
 
-    @media #{$mq-tablet} {
-        padding: ($gutter-width * 2) 0;
-    }
 }
 
-.accordion .section-title {
-    margin-bottom: .5em;
-}
+.prev-reports-nav {
+    margin: 0 auto $layout-md;
+    text-align: center;
 
-.accordion-initialized .section-title {
-    margin-bottom: 0;
-}
-
-#report-sections.accordion-initialized [data-accordion-role='tab'] {
-    @include border-box;
-    overflow: visible;
-    padding: 0 20px 0 40px;
-}
-
-#report-sections.accordion-initialized [data-accordion-role='tabpanel'] {
-    @include border-box;
-    margin-top: 1em;
-    padding: 0 20px 0 40px;
-}
-
-.section-extra .section-title {
-    @include font-size(32px);
-    margin-bottom: 1em;
-}
-
-.section-defs dt {
-    position: relative;
-}
-.section-defs dt:target:before {
-    content: '\25B8'; // right solid triangle
-    color: #000;
-    position: absolute;
-    left: -20px;
-}
-
-.footnotes {
-    @include font-size(14px);
-}
-
-.nav-report {
-    ul {
-        @include font-size(20px);
-        list-style: none;
-        margin: 0;
-        text-align: center;
-    }
-
-    li {
-        display: inline-block;
-        margin: 0 10px;
-    }
-
-    &.two-up li,
-    &.three-up li {
-        display: block;
-        margin: 0 0 10px;
-    }
-
-    a.button {
-        @include border-box;
-        width: 100%;
-        display: block;
-        text-align: center;
-    }
-
-    span {
-        display: block;
-    }
-
-    @media #{$mq-tablet} {
-        ul {
-            @include flexbox;
-            margin: 0 -10px;
-        }
-
-        a.button {
-            height: 100%;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-        }
-
-        &.two-up li {
-            margin: 0 10px;
-            width: 50%;
-        }
-
-        &.three-up li {
-            margin: 0 10px;
-            width: 33.3%;
-        }
-    }
-}
-
-.nav-previous {
-    @include border-box;
-    padding: $gutter-width $gutter-width 0;
-    margin: $gutter-width 10px 0;
-
-    ul {
-        list-style: none;
-        margin: 0;
-    }
-
-    li {
-        display: block;
-        margin: 0 0 .5em;
-
-        &:first-child {
-            margin-left: 0;
-        }
-    }
-
-    @media #{$mq-tablet} {
-        margin: $gutter-width auto -40px;
-        padding: $gutter-width;
+    @media #{$mq-md} {
+        width: $content-md;
 
         li {
             display: inline-block;
-            margin: 0 10px .5em;
             position: relative;
 
-            &:after {
-                content: '•';
-                position: absolute;
-                right: -22px;
-                text-align: center;
-                top: 0;
-                width: 20px;
+            a {
+                margin: $spacing-sm;
             }
 
-            &:last-child:after {
-                content: '';
+            &:not(:last-child):after {
+                content: '•';
+                position: absolute;
             }
         }
     }
 }
+
+//* -------------------------------------------------------------------------- */
+// Report Template
+
+.c-page-header {
+    @include font-mozilla;
+    @include text-display-xs;
+    background: $color-black;
+    color: $color-white;
+
+    span {
+        @include text-display-xs;
+        display: block;
+        margin-top: $spacing-md;
+    }
+}
+
+.mzp-c-article {
+    margin: 0 auto $layout-lg;
+}
+
+h2 {
+    @include font-mozilla;
+    @include text-display-md;
+    margin-top: $spacing-2xl;
+}
+
+h3 {
+    @include font-mozilla;
+    @include text-display-sm;
+    margin-top: $spacing-2xl;
+}
+
+.footnotes {
+    @include text-body-sm;
+}
+
+//* -------------------------------------------------------------------------- */
+// Collapsible Sections
+
+  .c-collapsible-section button {
+    @include font-mozilla;
+    @include summary;
+    @include text-display-md;
+    background: transparent;
+    border: none;
+    cursor: pointer;
+    font-weight: bold;
+    padding-right: 48px;
+    text-align: inherit;
+    width: 100%;
+  }
+
+  .c-collapsible-section button[aria-expanded=true]:before {
+      @include summary-open;
+  }
+
+  .c-collapsible-section .is-closed[aria-hidden=true] {
+      display: none;
+  }

--- a/media/js/mozorg/about-transparency.js
+++ b/media/js/mozorg/about-transparency.js
@@ -2,56 +2,17 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-(function($, Mozilla) {
+(function () {
     'use strict';
-
-    var reportSections = $('#report-sections');
-    var $faq = $('#faq .accordion-auto-init');
-    var _retries = 0;
-
-    function initReportSections(matches) {
-        if (matches) {
-            Mozilla.Accordion.destroyAccordionById('report-sections');
+    var _mqWide = matchMedia('(max-width: 767px)');
+    if (_mqWide.matches) {
+        window.Mzp.Details.init('.c-collapsible-section-heading');
+    }
+    _mqWide.addListener(function (mq) {
+        if (mq.matches) {
+            window.Mzp.Details.init('.c-collapsible-section-heading');
         } else {
-            new Mozilla.Accordion(reportSections);
+            window.Mzp.Details.destroy('.c-collapsible-section-heading');
         }
-    }
-
-    if (reportSections.length && typeof matchMedia !== 'undefined') {
-        var queryWide = matchMedia('(min-width: 760px)');
-        initReportSections(queryWide.matches);
-
-        queryWide.addListener(function(mq) {
-            initReportSections(mq.matches);
-        });
-    }
-
-    function scrollToAnchor() {
-        var hash = window.location.hash.replace('#', '');
-
-        if (hash) {
-            var element = document.getElementById(hash);
-
-            if (element && typeof element.scrollIntoView === 'function') {
-                element.scrollIntoView(true);
-            }
-        }
-    }
-
-    function checkForAccordionInit() {
-        var delay = 300;
-
-        if ($faq.hasClass('accordion-initialized')) {
-            setTimeout(scrollToAnchor, delay);
-        } else if (_retries < 3) {
-            _retries += 1;
-            setTimeout(checkForAccordionInit, delay);
-        }
-    }
-
-    // Bug 1299943 scroll hash/element into view after faq accordion has initialized.
-    if ($faq.length) {
-        checkForAccordionInit();
-    }
-
-})(window.jQuery, window.Mozilla);
+    });
+})();

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -346,7 +346,6 @@
     },
     {
       "files": [
-        "css/base/mozilla-accordion.less",
         "css/mozorg/about-transparency.scss"
       ],
       "name": "about-transparency"
@@ -1266,8 +1265,6 @@
     },
     {
       "files": [
-        "js/base/mozilla-accordion.js",
-        "js/base/mozilla-accordion-gatrack.js",
         "js/mozorg/about-transparency.js"
       ],
       "name": "about-transparency"


### PR DESCRIPTION
## Description
Updated Transparency Report templates to use Protocol.

## Issue / Bugzilla link
#7530 

## Testing
http://localhost:8000/about/policy/transparency/
All templates under /about/policy/transparency/ are no longer using Pebbles.
