### PR TITLE
[fix #7911] Add survey to lifecycle page 1

### DIFF
--- a/bedrock/firefox/templates/firefox/welcome/page1.html
+++ b/bedrock/firefox/templates/firefox/welcome/page1.html
@@ -74,7 +74,12 @@
 {% endblock %}
 
 {% block content_utility %}
-  <p><strong><a href="https://support.mozilla.org/kb/firefox-browser-welcome-pages/?utm_source=mozilla.org-firefox-welcome-1&utm_medium=referral&utm_campaign=welcome-1-monitor&entrypoint=mozilla.org-firefox-welcome-1">{{ _('Why am I seeing this?') }}</a></strong></p>
+  <p>
+    <strong><a href="https://support.mozilla.org/kb/firefox-browser-welcome-pages/?utm_source=mozilla.org-firefox-welcome-1&utm_medium=referral&utm_campaign=welcome-1-monitor&entrypoint=mozilla.org-firefox-welcome-1">{{ _('Why am I seeing this?') }}</a></strong>
+  {% if switch('lifecycle_page1_survey', ['en-US']) %}
+    <a class="c-survey-link"href="https://qsurvey.mozilla.com/s3/Firefox-Page" rel="external noopener">Feedback</a>
+  {% endif %}
+  </p>
 {% endblock %}
 
 {% block js %}

--- a/media/css/firefox/welcome.scss
+++ b/media/css/firefox/welcome.scss
@@ -122,6 +122,11 @@
     @include text-body-sm;
     max-width: $content-md;
     text-align: center;
+
+    .c-survey-link {
+        font-weight: bold;
+        margin-left: $spacing-lg;
+    }
 }
 
 


### PR DESCRIPTION
## Description
Adds a link to a survey behind the switch `lifecycle_page1_survey`

## Issue / Bugzilla link
#7911 