### PR TITLE
Add functional tests for firefox/lockwise page (Fixes #7899)

### DIFF
--- a/tests/functional/firefox/test_lockwise.py
+++ b/tests/functional/firefox/test_lockwise.py
@@ -1,0 +1,21 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import pytest
+
+from pages.firefox.lockwise import LockwisePage
+
+
+@pytest.mark.nondestructive
+def test_mobile_buttons_are_displayed(base_url, selenium):
+    page = LockwisePage(selenium, base_url).open()
+    assert page.is_app_store_button_displayed
+    assert page.is_play_store_button_displayed
+
+
+@pytest.mark.skip_if_firefox(reason='Download button is displayed only to non-Firefox users')
+@pytest.mark.nondestructive
+def test_download_button_is_displayed(base_url, selenium):
+    page = LockwisePage(selenium, base_url).open()
+    assert page.download_button.is_displayed

--- a/tests/functional/test_about.py
+++ b/tests/functional/test_about.py
@@ -7,7 +7,6 @@ import pytest
 from pages.about import AboutPage
 
 
-@pytest.mark.skip(reason='https://github.com/mozilla/bedrock/issues/7118')
 @pytest.mark.nondestructive
 def test_read_mission_button_displayed(base_url, selenium):
     page = AboutPage(selenium, base_url).open()

--- a/tests/pages/firefox/lockwise.py
+++ b/tests/pages/firefox/lockwise.py
@@ -1,0 +1,30 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from selenium.webdriver.common.by import By
+
+from pages.firefox.base import FirefoxBasePage
+from pages.regions.download_button import DownloadButton
+
+
+class LockwisePage(FirefoxBasePage):
+
+    URL_TEMPLATE = '/{locale}/firefox/lockwise/'
+
+    _app_store_button_locator = (By.CSS_SELECTOR, '.mobile-download-buttons > a[data-cta-text="apple-app-store"]')
+    _play_store_button_locator = (By.CSS_SELECTOR, '.mobile-download-buttons > a[data-cta-text="google-play-store"]')
+    _download_button_locator = (By.ID, 'download-button-desktop-release')
+
+    @property
+    def is_app_store_button_displayed(self):
+        return self.is_element_displayed(*self._app_store_button_locator)
+
+    @property
+    def is_play_store_button_displayed(self):
+        return self.is_element_displayed(*self._play_store_button_locator)
+
+    @property
+    def download_button(self):
+        el = self.find_element(*self._download_button_locator)
+        return DownloadButton(self, root=el)


### PR DESCRIPTION
## Description
Adds some base functional tests for the lockwise page so that we have some coverage.

Note: we can't test the Firefox button states here until we update to the newer version of Selenium.

## Issue / Bugzilla link
#7899

## Testing
Successful test run: https://ci.vpn1.moz.works/blue/organizations/jenkins/bedrock_multibranch_pipeline/detail/run-integration-tests/410/pipeline