### PR TITLE
Download Firefox button is not shown on Lockwise page in IE11 (Fixes #7947)

### DIFF
--- a/media/js/firefox/lockwise/lockwise.js
+++ b/media/js/firefox/lockwise/lockwise.js
@@ -4,25 +4,30 @@
     var client = window.Mozilla.Client;
     var version = client._getFirefoxMajorVersion();
 
+    var firefox70 = document.querySelector('.for-firefox-70-and-above');
+    var firefox69 = document.querySelector('.for-firefox-69-and-below');
+    var nonFirefox = document.querySelector('.for-non-firefox-users');
+
     if (client.isMobile) {
-        document.querySelector('.for-firefox-70-and-above').remove();
-        document.querySelector('.for-firefox-69-and-below').remove();
-        document.querySelector('.for-non-firefox-users').remove();
+        firefox70.parentNode.removeChild(firefox70);
+        firefox69.parentNode.removeChild(firefox69);
+        nonFirefox.parentNode.removeChild(nonFirefox);
     }
-    else if ( !client.isFirefox ){
-        document.querySelector('.for-firefox-69-and-below').remove();
-        document.querySelector('.for-firefox-70-and-above').remove();
-        document.querySelector('.for-non-firefox-users').classList.remove('hidden');
+    else if (!client.isFirefox) {
+        firefox69.parentNode.removeChild(firefox69);
+        firefox70.parentNode.removeChild(firefox70);
+        nonFirefox.classList.remove('hidden');
     }
-    else if ( client.isFirefox === true && version < '70' ) {
-        document.querySelector('.for-firefox-70-and-above').remove();
-        document.querySelector('.for-non-firefox-users').remove();
-        document.querySelector('.for-firefox-69-and-below').classList.remove('hidden');
+    else if (client.isFirefox && version < '70') {
+        firefox70.parentNode.removeChild(firefox70);
+        nonFirefox.parentNode.removeChild(nonFirefox);
+        firefox69.classList.remove('hidden');
     }
-    else if ( client.isFirefox === true && version >= '70' ) {
-        document.querySelector('.for-firefox-69-and-below').remove();
-        document.querySelector('.for-non-firefox-users').remove();
-        document.querySelector('.for-firefox-70-and-above').classList.remove('hidden');
+    else if (client.isFirefox && version >= '70') {
+        firefox69.parentNode.removeChild(firefox69);
+        nonFirefox.parentNode.removeChild(nonFirefox);
+        firefox70.classList.remove('hidden');
+
         document.querySelector('#lockwise-button').addEventListener('click', function() {
             Mozilla.UITour.showHighlight('logins');
         });


### PR DESCRIPTION
# Description
Fixed IE11 bug described in the issue.

## Issue / Bugzilla link
#7947

## Testing
- [ ] Download Firefox button should be visible in IE11.