### PR TITLE
Throw an error in DEBUG mode when a static file path starts with a slash

### DIFF
--- a/bedrock/base/templatetags/helpers.py
+++ b/bedrock/base/templatetags/helpers.py
@@ -113,6 +113,9 @@ def urlencode(txt):
 
 @library.global_function
 def static(path):
+    if settings.DEBUG and path.startswith('/'):
+        raise ValueError('Static paths must not begin with a slash')
+
     return staticfiles_storage.url(path)
 
 


### PR DESCRIPTION
I tried to do more with this but due to the way the site works in dev mode we can't really check for the existance of files since they won't exist in a lot of cases due to bundles and compiled CSS and things only being present on the assets container. Hopefully this will help catch some errors in dev that previously were hard to spot.