### PR TITLE
Add Firefox for FireTV to Firefox nav

### DIFF
--- a/bedrock/base/templates/includes/protocol/navigation/menu-firefox/browsers.html
+++ b/bedrock/base/templates/includes/protocol/navigation/menu-firefox/browsers.html
@@ -72,6 +72,15 @@
               </ul>
             </section>
           </li>
+          <li>
+            <section class="mzp-c-menu-item mzp-has-icon">
+              <a class="mzp-c-menu-item-link" href="https://www.amazon.com/Mozilla-Firefox-for-Fire-TV/dp/B078B5YMPD" data-link-name="Firefox for Fire TV" data-link-type="nav" data-link-position="topnav" data-link-group="firefox">
+                <svg class="mzp-c-menu-item-icon" width="24" height="24" xmlns="http://www.w3.org/2000/svg"><path d="M3 3h18a3 3 0 0 1 3 3v12a3 3 0 0 1-3 3H3a3 3 0 0 1-3-3V6a3 3 0 0 1 3-3zm0 2a1 1 0 0 0-1 1v12a1 1 0 0 0 1 1h18a1 1 0 0 0 1-1V6a1 1 0 0 0-1-1H3zm13.496 6.132a1 1 0 0 1 0 1.736l-7 4A1 1 0 0 1 8 16V8a1 1 0 0 1 1.496-.868l7 4zM10 9.723v4.554L13.984 12 10 9.723z" fill="#000" fill-rule="nonzero"/></svg>
+                <h4 class="mzp-c-menu-item-title">{{ _('Firefox for Fire TV') }}</h4>
+                <p class="mzp-c-menu-item-desc">{{ _('Watch videos and browse the internet on your Amazon Fire TV.') }}</p>
+              </a>
+            </section>
+          </li>
         </ul>
       </div>
       <!-- waiting for browsers page to be ready


### PR DESCRIPTION
## Description

Add Firefox for FireTV to Firefox nav. Direct copy of the text in the Mozilla nav so it should not be a problem for l10n.

## Issue / Bugzilla link

n/a and I did get the okay from JRouse.

## Testing

http://localhost:8000/en-US/firefox/