### PR TITLE
Firefox privacy hub headings should use Metropolis font

### DIFF
--- a/bedrock/firefox/templates/firefox/privacy/index.html
+++ b/bedrock/firefox/templates/firefox/privacy/index.html
@@ -17,7 +17,7 @@
   {{ css_bundle('firefox-privacy-promise') }}
 {% endblock %}
 
-{% block body_class %}privacy-promise{% endblock %}
+{% block body_class %}{{ super() }}privacy-promise{% endblock %}
 
 {% set _entrypoint = 'mozilla.org-privacy' %}
 {% set _utm_campaign = 'privacy' %}

--- a/bedrock/firefox/templates/firefox/privacy/products.html
+++ b/bedrock/firefox/templates/firefox/privacy/products.html
@@ -17,7 +17,7 @@
   {{ css_bundle('firefox-privacy-products') }}
 {% endblock %}
 
-{% block body_class %}privacy-products{% endblock %}
+{% block body_class %}{{ super() }} privacy-products{% endblock %}
 
 {% set _entrypoint = 'mozilla.org-privacy-products' %}
 {% set _utm_campaign = 'privacy-products' %}


### PR DESCRIPTION
## Description
- The /firefox/privacy/ pages should use Metropolis for headings.

## Issue / Bugzilla link
None