### PR TITLE
Update 'Personal Data Promise' link on /firefox/accounts/ page (Fixes #7967)

### DIFF
--- a/bedrock/exp/templates/exp/firefox/accounts-2019.html
+++ b/bedrock/exp/templates/exp/firefox/accounts-2019.html
@@ -117,7 +117,7 @@
     <div class="c-accounts-value-content">
       <h3 class="c-accounts-value-title">Get the respect you deserve.</h3>
 
-      <p>You’ll always get the truth from us. Everything we make and do honors our <a href="https://blog.mozilla.org/firefox/firefox-data-privacy-promise/?utm_source=www.mozilla.org&utm_medium=referral&utm_campaign=accounts-trailhead&utm_content=accounts-value&utm_term=respect-you-deserve">Personal Data Promise</a>:</p>
+      <p>You’ll always get the truth from us. Everything we make and do honors our <a href="{{ url('firefox.privacy.index') }}">Personal Data Promise</a>:</p>
 
       <p><strong>Take less.<br> Keep it safe.<br> No secrets.</strong></p>
     </div>

--- a/bedrock/firefox/templates/firefox/accounts-2019.html
+++ b/bedrock/firefox/templates/firefox/accounts-2019.html
@@ -147,7 +147,7 @@
       <h3 class="c-accounts-value-title">{{ _('Get the respect you deserve.') }}</h3>
 
       <p>
-      {% trans promise=promise_url|safe %}
+      {% trans promise=url('firefox.privacy.index') %}
         You’ll always get the truth from us. Everything we make and do honors our <a href="{{ promise }}">Personal Data Promise</a>:
       {% endtrans %}
       </p>

--- a/bedrock/firefox/tests/test_views.py
+++ b/bedrock/firefox/tests/test_views.py
@@ -992,15 +992,6 @@ class TestFirefoxHome(TestCase):
         render_mock.assert_called_once_with(req, 'firefox/home/index-quantum.html')
 
 
-class TestAccountsPage(TestCase):
-    @patch('bedrock.firefox.views.l10n_utils.render')
-    def test_accounts_page_2019(self, render_mock):
-        req = RequestFactory().get('/firefox/accounts/')
-        req.locale = 'en-US'
-        views.firefox_accounts(req)
-        render_mock.assert_called_once_with(req, 'firefox/accounts-2019.html', ANY)
-
-
 class TestFirefoxWelcomePage1(TestCase):
     @patch('bedrock.firefox.views.l10n_utils.render')
     def test_firefox_welcome_page1(self, render_mock):

--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -923,28 +923,8 @@ def firefox_concerts(request):
         return HttpResponseRedirect(reverse('firefox'))
 
 
-PROMISE_BLOG_URLS = {
-    'de': 'https://blog.mozilla.org/firefox/de/firefox-versprechen-fuer-deine-persoenlichen-daten/',
-    'fr': 'https://blog.mozilla.org/firefox/fr/engagements-concernant-les-donnees-personnelles-de-firefox/',
-    'en-US': 'https://blog.mozilla.org/firefox/firefox-data-privacy-promise/',
-}
-
-
 def firefox_accounts(request):
-    locale = l10n_utils.get_locale(request)
-
-    # get localized blog post URL for 2019 page
-    promise_query = (
-        '?utm_source=www.mozilla.org&amp;utm_medium=referral&amp;utm_campaign=accounts-trailhead'
-        '&amp;utm_content=accounts-value&amp;utm_term=respect-you-deserve'
-    )
-    promise_url = PROMISE_BLOG_URLS.get(locale, PROMISE_BLOG_URLS['en-US'])
-
-    context = {'promise_url': promise_url + promise_query}
-
-    template_name = 'firefox/accounts-2019.html'
-
-    return l10n_utils.render(request, template_name, context)
+    return l10n_utils.render(request, 'firefox/accounts-2019.html')
 
 
 def election_with_cards(request):


### PR DESCRIPTION
# Description
- Updates link on /firefox/accounts/ to point to /firefox/privacy/
- Removes old blog URL logic from view.

## Issue / Bugzilla link
#7967

## Testing
- [x] No other links to the blog post should remain.