### PR TITLE
Update MOSS india page with l10n fallback strings

### DIFF
--- a/bedrock/mozorg/templates/mozorg/moss/mission-partners-india.html
+++ b/bedrock/mozorg/templates/mozorg/moss/mission-partners-india.html
@@ -21,15 +21,28 @@
   <h2 class="moss-section-heading">{{ _('About') }}</h2>
 
   <p class="moss-copy">
-  {% trans url1=url('mozorg.moss.mission-partners') %}
-    <strong>The Global Mission Partners: India track is now closed.</strong> All applications which would previously have been submitted to the Global Mission Partners: India track will now be considered under the Mission Partners track. Please see the <a href="{{ url1 }}">Mission Partners page</a> for more information.
-  {% endtrans %}
+  {% if l10n_has_tag('moss_updates_20191021') %}
+    {% trans url1=url('mozorg.moss.mission-partners') %}
+      <strong>The Global Mission Partners: India track is now closed.</strong>
+      All applications which would previously have been submitted to the Global
+      Mission Partners: India track will now be considered under the Mission
+      Partners track. Please see the <a href="{{ url1 }}">Mission Partners page</a>
+      for more information.
+    {% endtrans %}
+  {% else %}
+    {% trans url1=url('mozorg.about.manifesto') %}
+      The Global Mission Partners: India track is open to any open source or
+      free software project that is undertaking an activity which significantly
+      furthers Mozilla’s <a href="{{ url1 }}">mission</a>, and for which the
+      applicant(s) are based in India.
+    {% endtrans %}
+  {% endif %}
   </p>
 
   <div class="moss-ctas">
     <p class="moss-copy">{{ _('Ready to go?') }}</p>
 
-    <a href="{{ url('mozorg.moss.mission-partners') }}" rel="external" class="button">{{ _('Apply Now') }}</a>
+    <a href="{{ url('mozorg.moss.mission-partners') }}" class="button">{{ _('Apply Now') }}</a>
   </div>
 </section>
 
@@ -200,9 +213,16 @@
   <h2 class="moss-section-heading">{{ _('How to apply') }}</h2>
 
   <p class="moss-copy">
-  {% trans partners=url('mozorg.moss.mission-partners') %}
-    Please see the <a href="{{ partners }}">Mission Partners page</a> for more information on how to apply.
-  {% endtrans %}
+  {% if l10n_has_tag('moss_updates_20191021') %}
+    {% trans partners=url('mozorg.moss.mission-partners') %}
+      Please see the <a href="{{ partners }}">Mission Partners page</a>
+      for more information on how to apply.
+    {% endtrans %}
+  {% else %}
+    {% trans %}
+      To get started with your application, simply follow the link below.
+    {% endtrans %}
+  {% endif %}
   </p>
 
   <div class="moss-ctas">
@@ -210,7 +230,7 @@
       {{ _('I’m ready!') }}
     </p>
 
-    <a href="{{ url('mozorg.moss.mission-partners') }}" rel="external" class="button">{{ _('Apply Now') }}</a>
+    <a href="{{ url('mozorg.moss.mission-partners') }}" class="button">{{ _('Apply Now') }}</a>
   </div>
 </section>
 


### PR DESCRIPTION
I merged a change in https://github.com/mozilla/bedrock/commit/a14dabea7f02b336313fb9e7337c3c83ccfce125 without realising that one of the pages was translated for hi-IN. This is a PR to fix that.
