### PR TITLE
Catch URL errors in the Firefox Nightly Notes Feed

### DIFF
--- a/bedrock/releasenotes/views.py
+++ b/bedrock/releasenotes/views.py
@@ -7,6 +7,7 @@ from operator import attrgetter
 
 from django.conf import settings
 from django.http import Http404, HttpResponseRedirect
+from django.urls import NoReverseMatch
 
 from lib import l10n_utils
 
@@ -190,7 +191,10 @@ def nightly_feed(request):
     releases = get_releases_or_404('firefox', 'nightly', 5)
 
     for release in releases:
-        link = reverse('firefox.desktop.releasenotes', args=(release.version, 'release'))
+        try:
+            link = reverse('firefox.desktop.releasenotes', args=(release.version, 'release'))
+        except NoReverseMatch:
+            continue
 
         for note in release.notes:
             if note.id in notes:

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -279,6 +279,7 @@ NOINDEX_URLS = [
     r'^firefox/dedicated-profiles/',
     r'^firefox/installer-help/',
     r'^firefox/this-browser-comes-highly-recommended/',
+    r'^firefox/nightly/notes/feed/$',
     r'^firefox.*/all/$',
     r'^firefox/content-blocking/start/$',
     r'^firefox/enterprise/signup/',


### PR DESCRIPTION
An invalid version string in release notes was causing a NoReverseMatch error to be thrown in the Nightly Notes Feed (/firefox/nightly/notes/feed/). This was also being indexed for the sitemap, so it caused the build to fail. This both skips releases with this error in the feed and removes the feed from the sitemap.

Fix #7966