### PR TITLE
Additional ctas on welcome/1 and /2 (Fixes #7961)

### DIFF
--- a/bedrock/base/templates/macros.html
+++ b/bedrock/base/templates/macros.html
@@ -189,7 +189,7 @@
 {%- endmacro %}
 
 {# Docs: https://bedrock.readthedocs.io/en/latest/firefox-accounts.html#linking-to-monitorfirefoxcom #}
-{% macro monitor_button(entrypoint, form_type='button', utm_campaign=None, utm_content=None, utm_term=None, button_text=None, button_class='mzp-c-button mzp-t-product', button_id='fxa-monitor-submit', cta_type=None, cta_position=None) -%}
+{% macro monitor_button(entrypoint, form_type='button', utm_campaign=None, utm_content=None, utm_term=None, button_text=None, button_class='mzp-c-button mzp-t-product', cta_type=None, cta_position=None) -%}
   {% set fxa_queries = [
     'form_type=' ~ form_type,
     'entrypoint=' ~ entrypoint,
@@ -208,7 +208,7 @@
     {% do fxa_queries.append('utm_term=' ~ utm_term) %}
   {% endif %}
 
-  <a data-action="{{ settings.FXA_ENDPOINT }}" href="https://monitor.firefox.com/oauth/init?{{ fxa_queries|join('&') }}" class="js-fxa-cta-link {% if button_class %}{{ button_class }}{% endif %}" id="{{ button_id }}" data-cta-text="{% if button_text %}{{ button_text }}{% else %}Sign In to Monitor{% endif %}" data-cta-type="{% if cta_type %}{{ cta_type }}{% else %}fxa-monitor{% endif %}" data-cta-position="{% if cta_position %}{{ cta_position }}{% else %}primary{% endif %}">
+  <a data-action="{{ settings.FXA_ENDPOINT }}" href="https://monitor.firefox.com/oauth/init?{{ fxa_queries|join('&') }}" class="js-fxa-cta-link js-monitor-button {% if button_class %}{{ button_class }}{% endif %}" data-cta-text="{% if button_text %}{{ button_text }}{% else %}Sign In to Monitor{% endif %}" data-cta-type="{% if cta_type %}{{ cta_type }}{% else %}fxa-monitor{% endif %}" data-cta-position="{% if cta_position %}{{ cta_position }}{% else %}primary{% endif %}">
     {% if button_text %}
       {{ button_text }}
     {% else %}

--- a/bedrock/firefox/templates/firefox/welcome/base.html
+++ b/bedrock/firefox/templates/firefox/welcome/base.html
@@ -35,6 +35,10 @@
       <div class="body-secondary">
         {% block content_secondary %}{% endblock %}
       </div>
+
+      <div class="secondary-cta">
+        {% block secondary_cta %}{% endblock %}
+      </div>
     </div>
   </section>
 

--- a/bedrock/firefox/templates/firefox/welcome/page1.html
+++ b/bedrock/firefox/templates/firefox/welcome/page1.html
@@ -18,18 +18,30 @@
 
 {% set _entrypoint = 'mozilla.org-firefox-welcome-1' %}
 {% set _utm_campaign = 'welcome-1-monitor' %}
+{% set _cta_type = 'lifecycle-monitor' %}
 
 {% block content_intro %}
   {% call hero(
     title=_('You’re on track to stay protected'),
     desc=_('You’ve got the web browser that protects your privacy — now it’s time to get a lookout for hackers.'),
     class='mzp-t-firefox mzp-t-dark',
-    include_cta=False,
+    include_cta=True,
     heading_level=1,
     image_url=None,
     include_highres_image=False,
     image_alt=''
   ) %}
+
+  <p class="primary-cta">
+    {{ monitor_button(
+      entrypoint=_entrypoint,
+      utm_campaign=_utm_campaign,
+      button_text=_('Check Your Breach Report'),
+      cta_type=_cta_type,
+      cta_position='primary'
+    ) }}
+  </p>
+
   {% endcall %}
 {% endblock %}
 
@@ -39,15 +51,6 @@
   <div class="body-primary-body">
     {# L10n: "Firefox Monitor" is a product name and shouldn't be translated. #}
     <p>{{ _('Firefox Monitor shows you if your information has been leaked in a known data breach, and alerts you in case it happens in the future.') }}</p>
-
-    <p class="primary-cta">
-      {{ monitor_button(
-        entrypoint=_entrypoint,
-        utm_campaign=_utm_campaign,
-        button_text=_('Check Your Breach Report'),
-        cta_type="Lifecycle-Monitor",
-      ) }}
-    </p>
   </div>
 {% endblock %}
 
@@ -84,6 +87,18 @@
     </div>
   </div>
   {% endif %}
+{% endblock %}
+
+{% block secondary_cta %}
+  <p>
+    {{ monitor_button(
+      entrypoint=_entrypoint,
+      utm_campaign=_utm_campaign,
+      button_text=_('Check Your Breach Report'),
+      cta_type=_cta_type,
+      cta_position='secondary'
+    ) }}
+  </p>
 {% endblock %}
 
 {% block content_utility %}

--- a/bedrock/firefox/templates/firefox/welcome/page2.html
+++ b/bedrock/firefox/templates/firefox/welcome/page2.html
@@ -23,12 +23,16 @@
     title=_('Your time online is worth protecting'),
     desc=_('Discover and save stories in Pocket — and come back to them when you’re free.'),
     class='mzp-t-firefox mzp-t-dark',
-    include_cta=False,
+    include_cta=True,
     heading_level=1,
     image_url=None,
     include_highres_image=False,
     image_alt=''
   ) %}
+
+    <p class="primary-cta">
+      <a class="js-pocket-button mzp-c-button mzp-t-product" href="https://getpocket.com/ff_signup?s=ffwelcome2&form_type=button&entrypoint={{ _entrypoint }}&utm_source={{ _entrypoint }}&utm_campaign={{ _utm_campaign }}&utm_medium=referral" data-action="{{ settings.FXA_ENDPOINT }}" data-cta-text="activate pocket" data-cta-type="fxa-pocket" data-cta-position="primary" rel="external noopener">{{ _('Activate Pocket') }}</a>
+    </p>
   {% endcall %}
 {% endblock %}
 
@@ -39,10 +43,6 @@
     <p>{{ _('Pocket is built right into Firefox, so you can easily save stories as you find them, then read them later on any device.') }}</p>
 
     <img class="primary-image" src="{{ static('img/firefox/welcome/pocket-hero.svg') }}" width="700" height="" alt="">
-
-    <p class="primary-cta">
-      <a id="pocket-cta" class="mzp-c-button mzp-t-product" href="https://getpocket.com/ff_signup?s=ffwelcome2&form_type=button&entrypoint={{ _entrypoint }}&utm_source={{ _entrypoint }}&utm_campaign={{ _utm_campaign }}&utm_medium=referral" data-action="{{ settings.FXA_ENDPOINT }}" data-cta-text="Activate Pocket" data-cta-type="FxA-Pocket" data-cta-position="Primary" rel="external noopener">{{ _('Activate Pocket') }}</a>
-    </p>
   </div>
 {% endblock %}
 
@@ -68,6 +68,12 @@
       <p>{{ _('Pocket shows recommended stories every time you open a new tab. Save the ones that interest you.') }}</p>
     </div>
   </div>
+{% endblock %}
+
+{% block secondary_cta %}
+    <p class="secondary-cta">
+      <a class="js-pocket-button mzp-c-button mzp-t-product" href="https://getpocket.com/ff_signup?s=ffwelcome2&form_type=button&entrypoint={{ _entrypoint }}&utm_source={{ _entrypoint }}&utm_campaign={{ _utm_campaign }}&utm_medium=referral" data-action="{{ settings.FXA_ENDPOINT }}" data-cta-text="activate pocket" data-cta-type="fxa-pocket" data-cta-position="secondary" rel="external noopener">{{ _('Activate Pocket') }}</a>
+    </p>
 {% endblock %}
 
 {% block content_utility %}

--- a/docs/analytics.rst
+++ b/docs/analytics.rst
@@ -59,13 +59,13 @@ Since GTM listeners pass the interacted element object to the dataLayer, the use
 For all generic CTA links and <button> elements, add these data attributes (* indicates a required attribute):
 
 +--------------------------+---------------------------------------------------------------------+
-|    Data Attribute        |        Expected Value                                               |
+|    Data Attribute        |        Expected Value (lowercase)                                   |
 +==========================+=====================================================================+
-|    data-cta-type *       | Link type (e.g. 'Navigation', 'Footer', or 'Button')                |
+|    data-cta-type *       | Link type (e.g. 'navigation', 'footer', or 'button')                |
 +--------------------------+---------------------------------------------------------------------+
 |    data-cta-text         | name or text of the link                                            |
 +--------------------------+---------------------------------------------------------------------+
-|    data-cta-position     | Location of CTA on the page (e.g. 'Primary', 'Secondary', 'Header') |
+|    data-cta-position     | Location of CTA on the page (e.g. 'primary', 'secondary', 'header') |
 +--------------------------+---------------------------------------------------------------------+
 
 For all download buttons, add these data attributes:

--- a/media/css/firefox/welcome.scss
+++ b/media/css/firefox/welcome.scss
@@ -47,7 +47,11 @@
     text-align: center;
 
     @media #{$mq-md} {
-        padding: $layout-lg $layout-xl;
+        padding: $layout-md $layout-xl;
+    }
+
+    .primary-cta {
+        margin: 0 auto;
     }
 }
 
@@ -58,6 +62,7 @@
 
 .mzp-c-hero-desc {
     @include text-body-lg;
+    margin-bottom: $layout-sm;
 }
 
 
@@ -66,8 +71,8 @@
 
 .body-primary {
     @include text-body-lg;
+    margin: $layout-md auto $layout-lg;
     text-align: center;
-    margin: $layout-md auto $layout-xl;
 
     .primary-image {
         margin: $layout-sm auto 0;
@@ -107,8 +112,8 @@
         position: relative;
 
         & + & {
-            padding-top: $layout-md;
             border-top: 1px solid $color-gray-30;
+            padding-top: $layout-md;
         }
 
         .c-picto-block-image {
@@ -118,10 +123,23 @@
             ));
             display: block;
             margin: 0;
-            position: absolute;
-            min-height: 0;
             max-width: $layout-lg;
+            min-height: 0;
+            position: absolute;
         }
+    }
+}
+
+//* -------------------------------------------------------------------------- */
+// Secondary CTA
+
+.secondary-cta {
+    @include text-body-lg;
+    margin: $layout-lg auto $layout-sm;
+    text-align: center;
+
+    p {
+        margin: 0 auto;
     }
 }
 
@@ -141,29 +159,7 @@
 // Dark theme
 
 .mzp-c-hero.mzp-t-dark {
+    @include light-links;
     background-color: $color-off-black;
     color: $color-white;
-
-    :link {
-        color: $color-white;
-
-        &:hover,
-        &:focus {
-            color: $color-pink-5;
-        }
-
-        &:active,
-        &:focus {
-            background-color: transparentize($color-white, .95);
-        }
-    }
-
-    :visited {
-        color: $color-pink-10;
-
-        &:hover,
-        &:focus {
-            color: $color-white;
-        }
-    }
 }

--- a/media/js/base/mozilla-monitor-button.js
+++ b/media/js/base/mozilla-monitor-button.js
@@ -15,17 +15,17 @@ if (typeof window.Mozilla === 'undefined') {
     MonitorButton.init = function() {
         var buttons;
 
+        // Exit if no fetch support
+        var supportsFetch = 'fetch' in window;
+        if (!supportsFetch) {
+            return;
+        }
+
         // Collect all monitor buttons
         buttons = document.getElementsByClassName('js-monitor-button');
 
         // Exit if no valid button in DOM
         if (buttons.length === 0) {
-            return;
-        }
-
-        // Exit if no fetch support
-        var supportsFetch = 'fetch' in window;
-        if (!supportsFetch) {
             return;
         }
 

--- a/media/js/base/mozilla-monitor-button.js
+++ b/media/js/base/mozilla-monitor-button.js
@@ -12,27 +12,28 @@ if (typeof window.Mozilla === 'undefined') {
 
     var MonitorButton = {};
 
-    MonitorButton.init = function(buttonId){
+    MonitorButton.init = function() {
+        var buttons;
 
-        // check for custom buttonId, used in case of multiple buttons.
-        if(!buttonId){
-            buttonId = 'fxa-monitor-submit';
-        }
+        // Collect all monitor buttons
+        buttons = document.getElementsByClassName('js-monitor-button');
 
-        var monitorButton = document.getElementById(buttonId);
-
-        // fetch request
-        var supportsFetch = 'fetch' in window;
-
-        if (!supportsFetch || !monitorButton) {
+        // Exit if no valid button in DOM
+        if (buttons.length === 0) {
             return;
         }
 
-        var buttonURL = monitorButton.getAttribute('href');
+        // Exit if no fetch support
+        var supportsFetch = 'fetch' in window;
+        if (!supportsFetch) {
+            return;
+        }
+
+        var buttonURL = buttons[0].getAttribute('href');
         // strip url to everything after `?`
         var buttonURLParams = buttonURL.match(/\?(.*)/)[1];
 
-        var destURL = monitorButton.getAttribute('data-action') + 'metrics-flow';
+        var destURL = buttons[0].getAttribute('data-action') + 'metrics-flow';
 
         // collect values from monitor button
         var params = window._SearchParams.queryStringToObject(buttonURLParams);
@@ -58,11 +59,15 @@ if (typeof window.Mozilla === 'undefined') {
         fetch(destURL).then(function(resp) {
             return resp.json();
         }).then(function(r) {
+            var flowParams;
             // add retrieved deviceID, flowBeginTime and flowId values to cta url
-            buttonURL += '&deviceId=' + r.deviceId;
-            buttonURL += '&flowBeginTime=' + r.flowBeginTime;
-            buttonURL += '&flowId=' + r.flowId;
-            monitorButton.setAttribute('href', buttonURL);
+            flowParams += '&deviceId=' + r.deviceId;
+            flowParams += '&flowBeginTime=' + r.flowBeginTime;
+            flowParams += '&flowId=' + r.flowId;
+            // applies url to all buttons and adds cta position
+            for (var i=0; i<buttons.length; i++) {
+                buttons[i].href += flowParams;
+            }
         }).catch(function() {
             // silently fail: deviceId, flowBeginTime, flowId are not added to url.
         });

--- a/media/js/firefox/welcome-page1-init.js
+++ b/media/js/firefox/welcome-page1-init.js
@@ -1,0 +1,9 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+(function() {
+    'use strict';
+
+    Mozilla.MonitorButton.init();
+})();

--- a/media/js/firefox/welcome-page2.js
+++ b/media/js/firefox/welcome-page2.js
@@ -12,24 +12,30 @@ if (typeof window.Mozilla === 'undefined') {
 
     var PocketButton = {};
 
-    PocketButton.init = function(){
+    PocketButton.init = function() {
+        var buttons;
 
-        var pocketButton = document.getElementById('pocket-cta');
+        // Collect all monitor buttons
+        buttons = document.getElementsByClassName('js-pocket-button');
 
-        // fetch request
-        var supportsFetch = 'fetch' in window;
-
-        if (!supportsFetch || !pocketButton) {
+        // Exit if no valid button in DOM
+        if (buttons.length === 0) {
             return;
         }
 
-        var buttonURL = pocketButton.getAttribute('href');
+        // Exit if no fetch support
+        var supportsFetch = 'fetch' in window;
+        if (!supportsFetch) {
+            return;
+        }
+
+        var buttonURL = buttons[0].getAttribute('href');
         // strip url to everything after `?`
         var buttonURLParams = buttonURL.match(/\?(.*)/)[1];
 
-        var destURL = pocketButton.getAttribute('data-action') + 'metrics-flow';
+        var destURL = buttons[0].getAttribute('data-action') + 'metrics-flow';
 
-        // collect values from pocket button
+        // collect values from monitor button
         var params = window._SearchParams.queryStringToObject(buttonURLParams);
 
         // add required params to the token fetch request
@@ -53,11 +59,15 @@ if (typeof window.Mozilla === 'undefined') {
         fetch(destURL).then(function(resp) {
             return resp.json();
         }).then(function(r) {
+            var flowParams;
             // add retrieved deviceID, flowBeginTime and flowId values to cta url
-            buttonURL += '&deviceId=' + r.deviceId;
-            buttonURL += '&flowBeginTime=' + r.flowBeginTime;
-            buttonURL += '&flowId=' + r.flowId;
-            pocketButton.setAttribute('href', buttonURL);
+            flowParams += '&deviceId=' + r.deviceId;
+            flowParams += '&flowBeginTime=' + r.flowBeginTime;
+            flowParams += '&flowId=' + r.flowId;
+            // applies url to all buttons and adds cta position
+            for (var i=0; i<buttons.length; i++) {
+                buttons[i].href += flowParams;
+            }
         }).catch(function() {
             // silently fail: deviceId, flowBeginTime, flowId are not added to url.
         });

--- a/media/js/firefox/welcome-page2.js
+++ b/media/js/firefox/welcome-page2.js
@@ -15,6 +15,12 @@ if (typeof window.Mozilla === 'undefined') {
     PocketButton.init = function() {
         var buttons;
 
+        // Exit if no fetch support
+        var supportsFetch = 'fetch' in window;
+        if (!supportsFetch) {
+            return;
+        }
+
         // Collect all monitor buttons
         buttons = document.getElementsByClassName('js-pocket-button');
 
@@ -23,11 +29,6 @@ if (typeof window.Mozilla === 'undefined') {
             return;
         }
 
-        // Exit if no fetch support
-        var supportsFetch = 'fetch' in window;
-        if (!supportsFetch) {
-            return;
-        }
 
         var buttonURL = buttons[0].getAttribute('href');
         // strip url to everything after `?`

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -965,7 +965,7 @@
     {
       "files": [
         "js/base/mozilla-monitor-button.js",
-        "js/base/mozilla-monitor-button-init.js"
+        "js/firefox/welcome-page1-init.js"
       ],
       "name": "firefox_welcome_page1"
     },

--- a/tests/functional/firefox/test_welcome_page1.py
+++ b/tests/functional/firefox/test_welcome_page1.py
@@ -10,4 +10,5 @@ from pages.firefox.welcome.page1 import FirefoxWelcomePage1
 @pytest.mark.nondestructive
 def test_monitor_button_displayed(base_url, selenium):
     page = FirefoxWelcomePage1(selenium, base_url).open()
-    assert page.is_monitor_button_displayed
+    assert page.is_primary_monitor_button_displayed
+    assert page.is_secondary_monitor_button_displayed

--- a/tests/functional/firefox/test_welcome_page2.py
+++ b/tests/functional/firefox/test_welcome_page2.py
@@ -10,4 +10,5 @@ from pages.firefox.welcome.page2 import FirefoxWelcomePage2
 @pytest.mark.nondestructive
 def test_pocket_button_displayed(base_url, selenium):
     page = FirefoxWelcomePage2(selenium, base_url).open()
-    assert page.is_pocket_button_displayed
+    assert page.is_primary_pocket_button_displayed
+    assert page.is_secondary_pocket_button_displayed

--- a/tests/pages/firefox/accounts.py
+++ b/tests/pages/firefox/accounts.py
@@ -12,7 +12,7 @@ class FirefoxAccountsPage(FirefoxBasePage):
 
     URL_TEMPLATE = '/{locale}/firefox/accounts/{params}'
 
-    _firefox_monitor_button_locator = (By.ID, 'fxa-monitor-submit')
+    _firefox_monitor_button_locator = (By.CLASS_NAME, 'js-monitor-button')
 
     def wait_for_page_to_load(self):
         self.wait.until(lambda s: self.seed_url in s.current_url)

--- a/tests/pages/firefox/welcome/page1.py
+++ b/tests/pages/firefox/welcome/page1.py
@@ -11,8 +11,13 @@ class FirefoxWelcomePage1(FirefoxBasePage):
 
     URL_TEMPLATE = '/{locale}/firefox/welcome/1/'
 
-    _monitor_button_locator = (By.ID, 'fxa-monitor-submit')
+    _monitor_primary_button_locator = (By.CSS_SELECTOR, '.primary-cta .js-monitor-button')
+    _monitor_secondary_button_locator = (By.CSS_SELECTOR, '.secondary-cta .js-monitor-button')
 
     @property
-    def is_monitor_button_displayed(self):
-        return self.is_element_displayed(*self._monitor_button_locator)
+    def is_primary_monitor_button_displayed(self):
+        return self.is_element_displayed(*self._monitor_primary_button_locator)
+
+    @property
+    def is_secondary_monitor_button_displayed(self):
+        return self.is_element_displayed(*self._monitor_secondary_button_locator)

--- a/tests/pages/firefox/welcome/page2.py
+++ b/tests/pages/firefox/welcome/page2.py
@@ -11,8 +11,13 @@ class FirefoxWelcomePage2(FirefoxBasePage):
 
     URL_TEMPLATE = '/{locale}/firefox/welcome/2/'
 
-    _pocket_button_locator = (By.ID, 'pocket-cta')
+    _pocket_primary_button_locator = (By.CSS_SELECTOR, '.primary-cta .js-pocket-button')
+    _pocket_secondary_button_locator = (By.CSS_SELECTOR, '.secondary-cta .js-pocket-button')
 
     @property
-    def is_pocket_button_displayed(self):
-        return self.is_element_displayed(*self._pocket_button_locator)
+    def is_primary_pocket_button_displayed(self):
+        return self.is_element_displayed(*self._pocket_primary_button_locator)
+
+    @property
+    def is_secondary_pocket_button_displayed(self):
+        return self.is_element_displayed(*self._pocket_secondary_button_locator)


### PR DESCRIPTION
## Description
Continuation of PR #7954 
⚠️ **Blocking #7834**

Modifies monitor button and pocket button FxA flow begin scripts:
- ensures only one fetch request is made no matter how many ctas.
- every button receives the same `deviceId`, `flowBeginTime`, and `flowId`
- does not require unique ID's for each button. (uses class hook `js-monitor-button`)

_note_: 
- removing `button_id` from docs because this PR makes it so button ID is no longer the way we differentiate different buttons.

## Issue
#7961

## Testing

- does this change break previous implementations of the monitor button macro?
- ctas reflect the same `deviceId`, `flowBeginTime`, and `flowId` values?