### PR TITLE
[fix #7975] Update trackers blocked

### DIFF
--- a/bedrock/firefox/templates/firefox/privacy/products.html
+++ b/bedrock/firefox/templates/firefox/privacy/products.html
@@ -87,8 +87,8 @@
     </ul>
   </div>
 
-  {# L10n: %s will automatically be replaced by a formatted number e.g. "More than 100,000,000 trackers blocked each day" #}
-  {% set trackers_title=_('More than %s trackers blocked each day for Firefox users worldwide')|format(100000000|l10n_format_number) %}
+  {# L10n: %s will automatically be replaced by a formatted number e.g. "More than 10,000,000,000 trackers blocked each day" #}
+  {% set trackers_title=_('More than %s trackers blocked each day for Firefox users worldwide')|format(10000000000|l10n_format_number) %}
   {% call call_out(
     title=trackers_title,
     class='privacy-products-tracker-counter mzp-t-dark',


### PR DESCRIPTION
## Description
Updates the number of trackers blocked from 100,000,000 to 10,000,000,000 (two more zeroes).

The number is a variable, not part of the string, so no l10n impact.

## Issue / Bugzilla link
#7975 

## Testing
http://localhost:8000/en-US/firefox/privacy/products/