### PR TITLE
Update Legal Docs for Firefox Lite (Fixes #7978)

### DIFF
--- a/bedrock/legal/templates/legal/terms/firefox-lite-reward.html
+++ b/bedrock/legal/templates/legal/terms/firefox-lite-reward.html
@@ -1,0 +1,7 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+
+{% extends "legal/docs-base.html" %}
+
+{% block page_title %}{{ _('Firefox Lite: About Your Rights') }}{% endblock %}

--- a/bedrock/legal/templates/legal/terms/firefox-lite.html
+++ b/bedrock/legal/templates/legal/terms/firefox-lite.html
@@ -1,0 +1,7 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+
+{% extends "legal/docs-base.html" %}
+
+{% block page_title %}{{ _('Firefox Lite: About Your Rights') }}{% endblock %}

--- a/bedrock/legal/urls.py
+++ b/bedrock/legal/urls.py
@@ -28,6 +28,12 @@ urlpatterns = (
     url(r'^terms/firefox/$', LegalDocView.as_view(template_name='legal/terms/firefox.html', legal_doc_name='firefox_about_rights'),
         name='legal.terms.firefox'),
 
+    url(r'^terms/firefox-lite/$', LegalDocView.as_view(template_name='legal/terms/firefox-lite.html',
+        legal_doc_name='firefox_lite_contentservices_ToS'), name='legal.terms.firefox-lite'),
+
+    url(r'^terms/firefox-lite/reward/$', LegalDocView.as_view(template_name='legal/terms/firefox-lite-reward.html',
+        legal_doc_name='firefox_lite_contentservices_reward'), name='legal.terms.firefox-lite-reward'),
+
     url(r'^terms/firefox-reality/$', LegalDocView.as_view(template_name='legal/terms/firefox-reality.html',
         legal_doc_name='firefox_reality_about_rights'), name='legal.terms.firefox-reality'),
 


### PR DESCRIPTION
## Description
Updates privacy and legal terms pages for Firefox Lite.

## Issue / Bugzilla link
#7978

## Testing
- http://127.0.0.1:8000/en-US/privacy/firefox-lite/
- http://127.0.0.1:8000/en-US/about/legal/terms/firefox-lite/
- http://127.0.0.1:8000/en-US/about/legal/terms/firefox-lite/reward/