### PR TITLE
Enable MSI installers for ESR on /firefox/all/ (fix bug 1590667)

### DIFF
--- a/bedrock/firefox/firefox_details.py
+++ b/bedrock/firefox/firefox_details.py
@@ -83,11 +83,6 @@ class FirefoxDesktop(_ProductDetails):
         else:
             platforms = self.platform_labels.copy()
 
-        # Msi installers are not yet available for ESR builds.
-        if channel == 'esr' or channel == 'esr-next':
-            del platforms['win64-msi']
-            del platforms['win-msi']
-
         return list(platforms.items())
 
     def latest_version(self, channel='release'):

--- a/bedrock/firefox/tests/test_base.py
+++ b/bedrock/firefox/tests/test_base.py
@@ -141,7 +141,7 @@ class TestFirefoxAll(TestCase):
 
         desktop_esr_builds = len(self.firefox_desktop.get_filtered_full_builds('esr'))
         assert len(doc('.c-locale-list[data-product="desktop_esr"] > li')) == desktop_esr_builds
-        assert len(doc('.c-locale-list[data-product="desktop_esr"] > li[data-language="en-US"] > ul > li > a')) == 5
+        assert len(doc('.c-locale-list[data-product="desktop_esr"] > li[data-language="en-US"] > ul > li > a')) == 7
 
         android_release_builds = len(self.firefox_android.get_filtered_full_builds('release'))
         assert len(doc('.c-locale-list[data-product="android_release"] > li')) == android_release_builds


### PR DESCRIPTION
## Description
- MSI installers are now available for the new ESR release.

## Issue / Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1590667

## Testing
- [ ] 64bit / 32bit MSI installer links should be available on:
  - [ ] http://localhost:8000/en-US/firefox/all/
  - [ ] http://localhost:8000/en-US/firefox/organizations/all/