### PR TITLE
Remove button_id argument from monitor button macro.

### DIFF
--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx69.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx69.html
@@ -42,7 +42,6 @@
         <p>{{ _('Sign up to see if your info was compromised in another company’s data breach, and automatically get alerts when your info might be at risk.') }}</p>
 
         {{ monitor_button(
-          button_id='monitor-button-signed-out',
           entrypoint='mozilla.org-firefox-whatsnew69',
           utm_campaign='whatsnew69',
           utm_content='whatsnew69-signed-out',
@@ -56,7 +55,6 @@
         <p>{{ _('Use Firefox Monitor to see if your info was compromised in another company’s data breach — and get automatically signed up for future alerts.') }}</p>
 
         {{ monitor_button(
-          button_id='monitor-button-signed-in',
           entrypoint='mozilla.org-firefox-whatsnew69',
           utm_campaign='whatsnew69',
           utm_content='whatsnew69-signed-in',


### PR DESCRIPTION
## Description
`button_id` was removed as an argument for the `monitor_button` macro in #7973