### PR TITLE
[bugfix] flowParams in fxa fetch request appending `undefined` to button hrefs.

### DIFF
--- a/media/js/base/mozilla-monitor-button.js
+++ b/media/js/base/mozilla-monitor-button.js
@@ -60,7 +60,7 @@ if (typeof window.Mozilla === 'undefined') {
             return resp.json();
         }).then(function(r) {
             // add retrieved deviceID, flowBeginTime and flowId values to cta url
-            var flowParams += '&deviceId=' + r.deviceId;
+            var flowParams = '&deviceId=' + r.deviceId;
             flowParams += '&flowBeginTime=' + r.flowBeginTime;
             flowParams += '&flowId=' + r.flowId;
             // applies url to all buttons and adds cta position

--- a/media/js/base/mozilla-monitor-button.js
+++ b/media/js/base/mozilla-monitor-button.js
@@ -59,9 +59,8 @@ if (typeof window.Mozilla === 'undefined') {
         fetch(destURL).then(function(resp) {
             return resp.json();
         }).then(function(r) {
-            var flowParams;
             // add retrieved deviceID, flowBeginTime and flowId values to cta url
-            flowParams += '&deviceId=' + r.deviceId;
+            var flowParams += '&deviceId=' + r.deviceId;
             flowParams += '&flowBeginTime=' + r.flowBeginTime;
             flowParams += '&flowId=' + r.flowId;
             // applies url to all buttons and adds cta position

--- a/media/js/firefox/welcome-page2.js
+++ b/media/js/firefox/welcome-page2.js
@@ -61,7 +61,7 @@ if (typeof window.Mozilla === 'undefined') {
             return resp.json();
         }).then(function(r) {
             // add retrieved deviceID, flowBeginTime and flowId values to cta url
-            var flowParams += '&deviceId=' + r.deviceId;
+            var flowParams = '&deviceId=' + r.deviceId;
             flowParams += '&flowBeginTime=' + r.flowBeginTime;
             flowParams += '&flowId=' + r.flowId;
             // applies url to all buttons and adds cta position

--- a/media/js/firefox/welcome-page2.js
+++ b/media/js/firefox/welcome-page2.js
@@ -60,9 +60,8 @@ if (typeof window.Mozilla === 'undefined') {
         fetch(destURL).then(function(resp) {
             return resp.json();
         }).then(function(r) {
-            var flowParams;
             // add retrieved deviceID, flowBeginTime and flowId values to cta url
-            flowParams += '&deviceId=' + r.deviceId;
+            var flowParams += '&deviceId=' + r.deviceId;
             flowParams += '&flowBeginTime=' + r.flowBeginTime;
             flowParams += '&flowId=' + r.flowId;
             // applies url to all buttons and adds cta position


### PR DESCRIPTION
## Description
Value of variable [`flowParams`](https://github.com/mozilla/bedrock/blob/master/media/js/base/mozilla-monitor-button.js#L62) in monitor button and pocket button fxa fetch requests contained value `undefined` before appending fetch request values.

This was causing the bug of `utm_medium=referralundefined` on button hrefs.