### PR TITLE
Add /whatsnew 70 page to CRO app (Fixes #7855)

### DIFF
--- a/bedrock/exp/templates/exp/firefox/whatsnew/whatsnew-fx70.html
+++ b/bedrock/exp/templates/exp/firefox/whatsnew/whatsnew-fx70.html
@@ -1,0 +1,115 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+
+{% from "macros.html" import monitor_button, fxa_cta_link with context %}
+
+{% extends "exp/base/base-firefox.html" %}
+
+{% block page_title %}What’s new with Firefox - More privacy, more protections.{% endblock %}
+
+{# "noindex" pages should not have the canonical or hreflang tags: bug 1442331 #}
+{% block canonical_urls %}<meta name="robots" content="noindex,follow">{% endblock %}
+
+{% block page_og_url %}{{ settings.CANONICAL_URL }}/{{ LANG }}/firefox/new/{% endblock %}
+
+{% block page_css %}
+  {{ css_bundle('exp_firefox_whatsnew_70') }}
+{% endblock %}
+
+{% block body_class %}state-fxa-default{% endblock %}
+
+{% set _entrypoint = 'mozilla.org-whatsnew70' %}
+{% set _utm_campaign = 'whatsnew70' %}
+
+{% block site_header %}{% endblock %}
+
+{% block content %}
+<main class="content-wrapper mzp-t-firefox mzp-t-dark">
+  <header class="c-page-header">
+    <div class="mzp-l-content c-page-header-inner">
+      {{ high_res_img('protocol/img/logos/firefox/browser/logo-word-hor-white-sm.png', {'alt': 'Firefox', 'width': '216', 'height': '40', 'class': 'c-page-header-logo-fx'}) }}
+      <div class="mzp-c-notification-bar mzp-t-success show-firefox-desktop-70">
+        <p>Congrats! You’re using the latest version of Firefox.</p>
+      </div>
+    </div>
+  </header>
+
+  <section class="content-main">
+    <div class="mzp-l-content">
+      <div class="mzp-c-box-emphasis">
+        <img class="c-emphasis-box-logo" src="{{ static('img/logos/firefox/logo-monitor.svg') }}" alt="">
+        <h2 class="c-emphasis-box-title">
+          Have you checked out Firefox Monitor?
+          <span class="show-fxa-supported-signed-in">It’s included with your Firefox account.</span>
+        </h2>
+        <p>Use Firefox Monitor to see if your info was compromised in another company’s data breach — and automatically get alerts when your info might be at risk.</p>
+
+        <div class="show-fxa-supported-signed-out show-fxa-default show-fxa-not-fx">
+          {{ monitor_button(
+            entrypoint=_entrypoint,
+            cta_type='FxA-Monitor',
+            cta_position='Primary',
+            utm_campaign=_utm_campaign,
+            button_text='Sign Up for Monitor'
+          ) }}
+        </div>
+
+        <div class="show-fxa-supported-signed-in">
+          {{ monitor_button(
+            entrypoint=_entrypoint,
+            cta_type='FxA-Monitor',
+            cta_position='Primary',
+            utm_campaign=_utm_campaign,
+            button_text='Sign In'
+          ) }}
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="content-extra">
+    <div class="mzp-l-content">
+      <div class="l-columns-two">
+        <div class="c-picto-block">
+          <div class="c-picto-block-image">
+            <img src="{{ static('img/firefox/glyphs/tracking-protection.svg') }}" alt="">
+          </div>
+
+          <h3 class="c-picto-block-title">2000+ types of trackers blocked — automatically</h3>
+          <div class="c-picto-block-body">
+            <p>Firefox mobile and desktop browsers have Enhanced Tracking Protection on by default.</p>
+            <a class="mzp-c-cta-link show-firefox-desktop-70 js-open-about-protections" href="https://support.mozilla.org/kb/enhanced-tracking-protection-firefox-desktop/?utm_source={{ _entrypoint }}&utm_medium=referral&utm_campaign={{ _utm_campaign }}&entrypoint={{ _entrypoint }}" data-link-type="link" data-link-name="See what Firefox has blocked for you">See what Firefox has blocked for you</a>
+
+            <a class="mzp-c-cta-link show-firefox-desktop-old" href="https://support.mozilla.org/kb/update-firefox-latest-release/?utm_source={{ _entrypoint }}&utm_medium=referral&utm_campaign={{ _utm_campaign }}&entrypoint={{ _entrypoint }}" data-link-type="link" data-link-name="Update your Firefox browser">Update your Firefox browser</a>
+
+            <div class="show-fxa-not-fx show-fxa-unsupported">
+              {{ download_firefox(alt_copy='Download the Firefox browser', download_location='secondary cta', button_color='mzp-c-button mzp-t-primary mzp-t-product') }}
+            </div>
+          </div>
+        </div>
+
+        <div class="c-picto-block">
+          <div class="c-picto-block-image">
+            <img src="{{ static('img/logos/firefox/logo-lockwise.svg') }}" alt="">
+          </div>
+
+          <h3 class="c-picto-block-title">Keep your passwords protected and portable</h3>
+          <div class="c-picto-block-body">
+            <p>Safely store and manage your passwords with Lockwise, and get alerted when you need to change them.</p>
+            <a class="mzp-c-cta-link js-open-lockwise" href="{{ url('firefox.lockwise.lockwise') }}">Go to Lockwise</a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <aside class="mzp-l-content c-utilities">
+    <p>Read the <a href="{{ url('firefox.notes') }}">Release Notes</a> to know more about what’s new in your Firefox Browser.</p>
+  </aside>
+</main>
+{% endblock %}
+
+{% block js %}
+  {{ js_bundle('exp_firefox_whatsnew_70_variants') }}
+{% endblock %}

--- a/bedrock/exp/urls.py
+++ b/bedrock/exp/urls.py
@@ -2,8 +2,15 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from bedrock.mozorg.util import page
+from django.conf.urls import url
 
+from bedrock.mozorg.util import page
+from bedrock.releasenotes import version_re
+from bedrock.exp import views
+
+
+latest_re = r'^firefox(?:/(?P<version>%s))?/%s/$'
+whatsnew_re_all = latest_re % (version_re, 'whatsnew/all')
 
 urlpatterns = (
     page('opt-out', 'exp/opt-out.html'),
@@ -13,4 +20,5 @@ urlpatterns = (
     page('firefox/lockwise', 'exp/firefox/lockwise.html', active_locales=['en-US', 'en-GB', 'en-CA', 'de']),
     page('firefox', 'exp/firefox/index.html', active_locales=['en-US', 'en-GB', 'en-CA', 'de']),
     page('firefox/welcome/1', 'exp/firefox/welcome/page1.html'),
+    url(whatsnew_re_all, views.WhatsnewView.as_view(), name='exp.firefox.whatsnew.all'),
 )

--- a/bedrock/exp/views.py
+++ b/bedrock/exp/views.py
@@ -1,0 +1,11 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from django.views.generic.base import TemplateView
+from lib import l10n_utils
+
+
+class WhatsnewView(l10n_utils.LangFilesMixin, TemplateView):
+    def get_template_names(self):
+        return ['exp/firefox/whatsnew/whatsnew-fx70.html']

--- a/media/css/exp/firefox/whatsnew/whatsnew-70.scss
+++ b/media/css/exp/firefox/whatsnew/whatsnew-70.scss
@@ -1,0 +1,208 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+$font-path: '/media/fonts';
+$image-path: '/media/protocol/img';
+
+@import '../../../../protocol/css/includes/lib';
+@import '../../../protocol/components/state-fxa';
+@import '../../../../protocol/css/components/emphasis-box';
+@import '../../../../protocol/css/components/notification-bar';
+
+.content-main {
+    padding: 0;
+    @media #{$mq-md} {
+        padding-top: $spacing-2xl;
+    }
+}
+
+.c-section-title-secondary {
+    @include text-display-xxs;
+    margin: 0 auto $layout-md;
+    max-width: $content-md - ($layout-md * 2);
+}
+
+.c-utilities {
+    @include text-body-sm;
+    max-width: $content-md;
+    text-align: center;
+}
+
+.mzp-c-cta-link:link {
+    border-bottom: 1px solid;
+    font-weight: normal;
+    text-decoration: none;
+
+    &:hover,
+    &:active,
+    &:focus {
+        @include transition(border-bottom-color 100ms ease-in-out);
+        border-bottom-color: transparent;
+    }
+}
+
+
+//* -------------------------------------------------------------------------- */
+// Up-to-date page header
+
+.c-page-header {
+    background: transparent;
+}
+
+.mzp-c-notification-bar {
+    color: $color-off-black;
+    display: none;
+    margin: $layout-xs;
+
+    .is-up-to-date {
+        display: block;
+    }
+}
+
+.c-page-header-inner {
+    align-items: center;
+    display: grid;
+    grid-template-columns: 1fr;
+}
+
+.c-page-header-up-to-date {
+    margin: 0 $layout-sm;
+}
+
+.c-page-header-logo-fx {
+    min-width: 216px;
+}
+
+@media #{$mq-md} {
+    .c-page-header-inner {
+        align-items: center;
+        display: grid;
+        grid-template-columns: 1fr max-content 1fr;
+    }
+}
+
+
+//* -------------------------------------------------------------------------- */
+// Emphasis box
+
+.mzp-c-box-emphasis {
+    @include border-box;
+    color: $color-off-black;
+    margin: 0 auto $layout-sm;
+    max-width: $content-md - ($layout-md * 2);
+    padding: $spacing-xl;
+    text-align: center;
+
+    :link {
+        color: $color-off-black;
+    }
+
+    .c-emphasis-box-logo {
+        display: block;
+        margin: 0 auto $spacing-lg;
+        width: 50px;
+    }
+
+    .c-emphasis-box-title {
+        @include text-display-sm;
+    }
+
+
+    @media #{$mq-md} {
+        padding: $spacing-xl $layout-md;
+
+        .c-emphasis-box-title br {
+            display: block;
+        }
+    }
+}
+
+
+//* -------------------------------------------------------------------------- */
+// Extra content
+// To be replaced by revamped picto card. See https://github.com/mozilla/protocol/issues/382
+
+.c-picto-block {
+    @include border-box;
+    margin: 0 auto $spacing-2xl;
+    max-width: $content-md - ($layout-md * 2);
+    padding: 0 $layout-md;
+
+    .c-picto-block-title {
+        @include text-display-xs;
+    }
+
+    .c-picto-block-image {
+        align-items: center;
+        display: flex;
+        margin-bottom: $spacing-md;
+        width: $layout-md;
+    }
+}
+
+@media #{$mq-md} {
+    .l-columns-two {
+        display: flex;
+        margin: 0 auto;
+        max-width: $content-md - ($layout-md * 2);
+        padding: 0 $layout-md;
+        flex-wrap: wrap;
+
+        .c-picto-block {
+            flex: 1 1 50%;
+            padding: 0 ($spacing-md + 4);
+        }
+    }
+}
+
+.content-wrapper {
+    background: $color-off-black url('/media/img/firefox/whatsnew_70/whatsnew_background.svg') no-repeat;
+    @include background-size(100%);
+    color: $color-white;
+}
+
+
+//* -------------------------------------------------------------------------- */
+// Conditional Content
+
+body.state-fxa-supported-signed-in {
+    span.show-fxa-supported-signed-in {
+        display: inline;
+    }
+}
+
+.show-firefox-desktop-70, .show-firefox-desktop-old {
+    display: none;
+    &.mzp-c-button {
+        display: none;
+    }
+}
+
+.state-firefox-desktop-70 {
+    .show-firefox-desktop-70 {
+        display: inline-block;
+
+        &.mzp-c-cta-link {
+            display: inline;
+        }
+    }
+
+    .show-firefox-desktop-old {
+        display: none;
+    }
+}
+
+.state-firefox-desktop-old {
+    .show-firefox-desktop-old {
+        display: inline-block;
+
+        &.mzp-c-cta-link {
+            display: inline;
+        }
+    }
+
+    .show-firefox-desktop-70 {
+        display: none;
+    }
+}

--- a/media/js/exp/firefox/whatsnew/whatsnew-70.js
+++ b/media/js/exp/firefox/whatsnew/whatsnew-70.js
@@ -1,0 +1,59 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+(function() {
+    'use strict';
+
+    var client = Mozilla.Client;
+
+    function handleOpenProtectionReport(e) {
+        e.preventDefault();
+        Mozilla.UITour.showProtectionReport();
+
+        window.dataLayer.push({
+            'event': 'in-page-interaction',
+            'eAction': 'link click',
+            'eLabel': 'See what Firefox has blocked for you'
+        });
+    }
+
+    function handleOpenLockwise(e) {
+        e.preventDefault();
+        Mozilla.UITour.showHighlight('logins');
+
+        window.dataLayer.push({
+            'event': 'in-page-interaction',
+            'eAction': 'link click',
+            'eLabel': 'Update your Firefox browser'
+        });
+    }
+
+    if (client.isFirefoxDesktop) {
+        if (client._getFirefoxMajorVersion() >= 70) {
+            // show "See what Firefox has blocked for you" links.
+            document.querySelector('main').classList.add('state-firefox-desktop-70');
+
+            // Intercept link clicks to open about:protections page using UITour.
+            Mozilla.UITour.ping(function() {
+                var protectionReportLinks = document.querySelectorAll('.js-open-about-protections');
+                var lockwiseLinks = document.querySelectorAll('.js-open-lockwise');
+
+                // For UI Tour CTAs, we will treat these more as an action rather than a page navigation.
+                for (var i = 0; i < protectionReportLinks.length; i++) {
+                    // Hide fallback links.
+                    protectionReportLinks[i].addEventListener('click', handleOpenProtectionReport, false);
+                }
+
+                for (var j = 0; j < lockwiseLinks.length; j++) {
+                    lockwiseLinks[j].setAttribute('role', 'button');
+                    lockwiseLinks[j].addEventListener('click', handleOpenLockwise, false);
+                }
+            });
+        } else {
+            // show "Update your Firefox browser" links.
+            document.querySelector('main').classList.add('state-firefox-desktop-old');
+        }
+    }
+
+})(window.Mozilla);

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -541,6 +541,12 @@
     },
     {
       "files": [
+        "css/exp/firefox/whatsnew/whatsnew-70.scss"
+      ],
+      "name": "exp_firefox_whatsnew_70"
+    },
+    {
+      "files": [
         "css/mozorg/contribute/contribute-embed.less"
       ],
       "name": "contribute-embed"
@@ -1047,6 +1053,18 @@
         "js/firefox/whatsnew/whatsnew-70.js"
       ],
       "name": "firefox_whatsnew_70_variants"
+    },
+    {
+      "files": [
+        "js/base/uitour-lib.js",
+        "js/base/mozilla-fxa.js",
+        "js/base/mozilla-fxa-init.js",
+        "js/base/mozilla-monitor-button.js",
+        "js/base/mozilla-monitor-button-init.js",
+        "js/firefox/whatsnew/up-to-date.js",
+        "js/exp/firefox/whatsnew/whatsnew-70.js"
+      ],
+      "name": "exp_firefox_whatsnew_70_variants"
     },
     {
       "files": [

--- a/tests/functional/test_experiment_pages.py
+++ b/tests/functional/test_experiment_pages.py
@@ -22,7 +22,8 @@ def pytest_generate_tests(metafunc):
         '/exp/firefox/accounts/',
         '/exp/firefox/new/',
         '/exp/firefox/welcome/1/',
-        '/exp/firefox/lockwise/'
+        '/exp/firefox/lockwise/',
+        '/exp/firefox/70.0/whatsnew/all/'
     )
     metafunc.parametrize('url', [base_url + path for path in paths])
 


### PR DESCRIPTION
## Description
Adds WNP 70 to the CRO sandbox:

http://localhost:8000/en-US/exp/firefox/70.0/whatsnew/all/

## Issue / Bugzilla link
#7855

## Testing
- [x] Page should load convert bundle
- [x] Page should be noindex