### PR TITLE
Pass through UTM parameters for Pocket referrals. (Fixes  #8008)

### DIFF
--- a/bedrock/firefox/templates/firefox/welcome/page2.html
+++ b/bedrock/firefox/templates/firefox/welcome/page2.html
@@ -31,7 +31,7 @@
   ) %}
 
     <p class="primary-cta">
-      <a class="js-pocket-button mzp-c-button mzp-t-product" href="https://getpocket.com/ff_signup?s=ffwelcome2&form_type=button&entrypoint={{ _entrypoint }}&utm_source={{ _entrypoint }}&utm_campaign={{ _utm_campaign }}&utm_medium=referral" data-action="{{ settings.FXA_ENDPOINT }}" data-cta-text="activate pocket" data-cta-type="fxa-pocket" data-cta-position="primary" rel="external noopener">{{ _('Activate Pocket') }}</a>
+      <a class="js-fxa-cta-link js-pocket-button mzp-c-button mzp-t-product" href="https://getpocket.com/ff_signup?s=ffwelcome2&form_type=button&entrypoint={{ _entrypoint }}&utm_source={{ _entrypoint }}&utm_campaign={{ _utm_campaign }}&utm_medium=referral" data-action="{{ settings.FXA_ENDPOINT }}" data-cta-text="activate pocket" data-cta-type="fxa-pocket" data-cta-position="primary" rel="external noopener">{{ _('Activate Pocket') }}</a>
     </p>
   {% endcall %}
 {% endblock %}
@@ -72,7 +72,7 @@
 
 {% block secondary_cta %}
     <p class="secondary-cta">
-      <a class="js-pocket-button mzp-c-button mzp-t-product" href="https://getpocket.com/ff_signup?s=ffwelcome2&form_type=button&entrypoint={{ _entrypoint }}&utm_source={{ _entrypoint }}&utm_campaign={{ _utm_campaign }}&utm_medium=referral" data-action="{{ settings.FXA_ENDPOINT }}" data-cta-text="activate pocket" data-cta-type="fxa-pocket" data-cta-position="secondary" rel="external noopener">{{ _('Activate Pocket') }}</a>
+      <a class="js-fxa-cta-link js-pocket-button mzp-c-button mzp-t-product" href="https://getpocket.com/ff_signup?s=ffwelcome2&form_type=button&entrypoint={{ _entrypoint }}&utm_source={{ _entrypoint }}&utm_campaign={{ _utm_campaign }}&utm_medium=referral" data-action="{{ settings.FXA_ENDPOINT }}" data-cta-text="activate pocket" data-cta-type="fxa-pocket" data-cta-position="secondary" rel="external noopener">{{ _('Activate Pocket') }}</a>
     </p>
 {% endblock %}
 

--- a/media/js/base/fxa-utm-referral.js
+++ b/media/js/base/fxa-utm-referral.js
@@ -96,7 +96,6 @@ if (typeof window.Mozilla === 'undefined') {
     UtmUrl.init = function (urlParams) {
         var params = UtmUrl.getAttributionData(urlParams);
         var ctaLinks = document.getElementsByClassName('js-fxa-cta-link');
-        console.log(ctaLinks);
 
         // If there are no utm params on the page, do nothing.
         if (!params) {

--- a/media/js/base/fxa-utm-referral.js
+++ b/media/js/base/fxa-utm-referral.js
@@ -15,6 +15,7 @@ if (typeof window.Mozilla === 'undefined') {
     var whitelist = [
         'https://accounts.firefox.com/',
         'https://monitor.firefox.com/',
+        'https://getpocket.com/',
         'https://latest.dev.lcip.org/'
     ];
 
@@ -95,6 +96,7 @@ if (typeof window.Mozilla === 'undefined') {
     UtmUrl.init = function (urlParams) {
         var params = UtmUrl.getAttributionData(urlParams);
         var ctaLinks = document.getElementsByClassName('js-fxa-cta-link');
+        console.log(ctaLinks);
 
         // If there are no utm params on the page, do nothing.
         if (!params) {

--- a/tests/unit/spec/base/fxa-utm-referral.js
+++ b/tests/unit/spec/base/fxa-utm-referral.js
@@ -12,8 +12,11 @@ describe('fxa-utm-referral.js', function() {
         it('should return a hostname as expected', function() {
             var url1 = 'https://monitor.firefox.com/oauth/init?form_type=button&entrypoint=mozilla.org-firefox-accounts';
             var url2 = 'https://accounts.firefox.com/?utm_campaign=campaign-one&utm_source=source-one&utm_content=content-one';
+            var url3 = 'https://getpocket.com/ff_signup?s=ffwelcome2&form_type=button&entrypoint=mozilla.org-firefox-welcome-2&utm_source=source-one&utm_campaign=campaign-one';
+
             expect(Mozilla.UtmUrl.getHostName(url1)).toEqual('https://monitor.firefox.com/');
             expect(Mozilla.UtmUrl.getHostName(url2)).toEqual('https://accounts.firefox.com/');
+            expect(Mozilla.UtmUrl.getHostName(url3)).toEqual('https://getpocket.com/');
         });
 
         it('should return null if no match is found', function() {
@@ -213,6 +216,7 @@ describe('fxa-utm-referral.js', function() {
                 '<a id="test-expected" class="js-fxa-cta-link" href="https://accounts.firefox.com/?service=sync&amp;action=email&amp;context=fx_desktop_v3&amp;entrypoint=mozilla.org-accounts_page&amp;utm_content=accounts-page-top-cta&amp;utm_source=accounts-page&amp;utm_medium=referral&amp;utm_campaign=fxa-benefits-page" data-mozillaonline-link="https://accounts.firefox.com.cn/?service=sync&amp;action=email&amp;context=fx_desktop_v3&amp;entrypoint=mozilla.org-accounts_page&amp;utm_content=accounts-page-top-cta&amp;utm_source=accounts-page&amp;utm_medium=referral&amp;utm_campaign=fxa-benefits-page">Create a Firefox Account</a>' +
                 '<a id="test-not-accounts" class="js-fxa-cta-link" href="https://www.mozilla.org/?service=sync&amp;action=email&amp;context=fx_desktop_v3&amp;entrypoint=mozilla.org-accounts_page&amp;utm_content=accounts-page-top-cta&amp;utm_source=accounts-page&amp;utm_medium=referral&amp;utm_campaign=fxa-benefits-page" data-mozillaonline-link="https://accounts.firefox.com.cn/?service=sync&amp;action=email&amp;context=fx_desktop_v3&amp;entrypoint=mozilla.org-accounts_page&amp;utm_content=accounts-page-top-cta&amp;utm_source=accounts-page&amp;utm_medium=referral&amp;utm_campaign=fxa-benefits-page">Create a Firefox Account</a>' +
                 '<a id="test-second-expected" class="js-fxa-cta-link" href="https://monitor.firefox.com/oauth/init?form_type=button&amp;entrypoint=mozilla.org-firefox-accounts&amp;utm_content=accounts-page-top-cta&amp;utm_source=accounts-page&amp;utm_medium=referral&amp;utm_campaign=fxa-benefits-page" data-mozillaonline-link="https://accounts.firefox.com.cn/?service=sync&amp;action=email&amp;context=fx_desktop_v3&amp;entrypoint=mozilla.org-accounts_page&amp;utm_content=accounts-page-top-cta&amp;utm_source=mozilla.org-accounts_page&amp;utm_medium=referral&amp;utm_campaign=fxa-benefits-page">Sign In to Firefox Monitor</a>' +
+                '<a id="test-third-expected" class="js-fxa-cta-link" href="https://getpocket.com/ff_signup?s=ffwelcome2&form_type=button&entrypoint=mozilla.org-firefox-welcome-2&utm_source=mozilla.org-firefox-welcome-2&utm_campaign=welcome-2-pocket&utm_medium=referral">Activate Pocket</a>' +
                 '</div>';
 
             $(links).appendTo('body');
@@ -237,9 +241,12 @@ describe('fxa-utm-referral.js', function() {
             var expectedHref = expected.getAttribute('href');
             var secondExpected = document.getElementById('test-second-expected');
             var secondExpectedHref = secondExpected.getAttribute('href');
+            var thirdExpected = document.getElementById('test-third-expected');
+            var thirdExpectedHref = thirdExpected.getAttribute('href');
 
             expect(expectedHref).toEqual('https://accounts.firefox.com/?service=sync&action=email&context=fx_desktop_v3&entrypoint=mozilla.org-accounts_page&utm_source=source-two&utm_campaign=campaign-two&utm_content=content-two&utm_term=term-two&utm_medium=medium-two');
             expect(secondExpectedHref).toEqual('https://monitor.firefox.com/oauth/init?form_type=button&entrypoint=mozilla.org-firefox-accounts&utm_source=source-two&utm_campaign=campaign-two&utm_content=content-two&utm_term=term-two&utm_medium=medium-two');
+            expect(thirdExpectedHref).toEqual('https://getpocket.com/ff_signup?s=ffwelcome2&form_type=button&entrypoint=mozilla.org-firefox-welcome-2&utm_source=source-two&utm_campaign=campaign-two&utm_content=content-two&utm_term=term-two&utm_medium=medium-two');
         });
 
         it('updates the data-mozilla-online attribute of links with class js-fxa-cta-link', function () {


### PR DESCRIPTION
## Description
Pocket button cta no longer overwrites utm parameters.

## Issue / Bugzilla link
#8008

## Testing
- http://localhost:8000/firefox/welcome/2/

pocket button `href` contains values of:
```
&form_type=button
&entrypoint=mozilla.org-firefox-welcome-2
&utm_source=mozilla.org-firefox-welcome-2
&utm_campaign=welcome-2-pocket
&utm_medium=referral
```

- http://localhost:8000/firefox/welcome/2/?utm_campaign=awesomecampaign&utm_medium=referral&utm_source=coolplace&utm_term=thisisaterm

pocket button `href` contains values of:
```
&form_type=button
&entrypoint=mozilla.org-firefox-welcome-2
&utm_source=coolplace
&utm_campaign=awesomecampaign
&utm_term=thisisaterm
&utm_medium=referral
```
