### PR TITLE
[fix #7839] Add download links to leadership page

### DIFF
--- a/bedrock/mozorg/templates/mozorg/about/leadership.html
+++ b/bedrock/mozorg/templates/mozorg/about/leadership.html
@@ -94,6 +94,7 @@
           </ul>
 
           <ul class="utility">
+            <li><a class="file" rel="external" href="https://assets.mozilla.net/leadership/mozilla-mitchell-baker.zip">{{ _('Download photos') }}</a></li>
             <li><a class="link" href="{{ url('mozorg.about.leadership') }}#mitchell-baker">{{ _('Link to this bio') }}</a></li>
           </ul>
         </div>
@@ -143,6 +144,7 @@
           </ul>
 
           <ul class="utility">
+            <li><a class="file" rel="external" href="https://assets.mozilla.net/leadership/mozilla-chris-beard.zip">{{ _('Download photos') }}</a></li>
             <li><a class="link" href="{{ url('mozorg.about.leadership') }}#chris-beard">{{ _('Link to this bio') }}</a></li>
           </ul>
         </div>
@@ -201,6 +203,7 @@
           </ul>
 
           <ul class="utility">
+            <li><a class="file" rel="external" href="https://assets.mozilla.net/leadership/mozilla-dave-camp.zip">{{ _('Download photos') }}</a></li>
             <li><a class="link" href="{{ url('mozorg.about.leadership') }}#dave-camp">{{ _('Link to this bio') }}</a></li>
           </ul>
         </div>
@@ -259,6 +262,7 @@
           </ul>
 
           <ul class="utility">
+            <li><a class="file" rel="external" href="https://assets.mozilla.net/leadership/mozilla-michael-deangelo.zip">{{ _('Download photos') }}</a></li>
             <li><a class="link" href="{{ url('mozorg.about.leadership') }}#michael-deangelo">{{ _('Link to this bio') }}</a></li>
           </ul>
         </div>
@@ -289,6 +293,7 @@
           <p class="note">{{ _('Steering Committee') }}</p>
 
           <ul class="utility">
+            <li><a class="file" rel="external" href="https://assets.mozilla.net/leadership/mozilla-amy-keating.zip">{{ _('Download photos') }}</a></li>
             <li><a class="link" href="{{ url('mozorg.about.leadership') }}#amy-keating">{{ _('Link to this bio') }}</a></li>
           </ul>
         </div>
@@ -330,6 +335,7 @@
           </ul>
 
           <ul class="utility">
+            <li><a class="file" rel="external" href="https://assets.mozilla.net/leadership/mozilla-jascha-kaykas-wolff.zip">{{ _('Download photos') }}</a></li>
             <li><a class="link" href="{{ url('mozorg.about.leadership') }}#jascha-kaykas-wolff">{{ _('Link to this bio') }}</a></li>
           </ul>
         </div>
@@ -378,6 +384,7 @@
           <p class="note">{{ _('Steering Committee') }}</p>
 
           <ul class="utility">
+            <li><a class="file" rel="external" href="https://assets.mozilla.net/leadership/mozilla-nate-weiner.zip">{{ _('Download photos') }}</a></li>
             <li><a class="link" href="{{ url('mozorg.about.leadership') }}#nate-weiner">{{ _('Link to this bio') }}</a></li>
           </ul>
         </div>
@@ -420,6 +427,7 @@
           <p class="note">{{ _('Steering Committee') }}</p>
 
           <ul class="utility">
+            <li><a class="file" rel="external" href="https://assets.mozilla.net/leadership/mozilla-roxi-wen.zip">{{ _('Download photos') }}</a></li>
             <li><a class="link" href="{{ url('mozorg.about.leadership') }}#roxi-wen">{{ _('Link to this bio') }}</a></li>
           </ul>
         </div>
@@ -455,6 +463,7 @@
           </ul>
 
           <ul class="utility">
+            <li><a class="file" rel="external" href="https://assets.mozilla.net/leadership/mozilla-sean-white.zip">{{ _('Download photos') }}</a></li>
             <li><a class="link" href="{{ url('mozorg.about.leadership') }}#sean-white">{{ _('Link to this bio') }}</a></li>
           </ul>
         </div>
@@ -501,6 +510,7 @@
           </ul>
 
           <ul class="utility">
+            <li><a class="file" rel="external" href="https://assets.mozilla.net/leadership/mozilla-katharina-borchert.zip">{{ _('Download photos') }}</a></li>
             <li><a class="link" href="{{ url('mozorg.about.leadership') }}#katharina-borchert">{{ _('Link to this bio') }}</a></li>
           </ul>
         </div>
@@ -541,6 +551,7 @@
           </ul>
 
           <ul class="utility">
+            <li><a class="file" rel="external" href="https://assets.mozilla.net/leadership/mozilla-david-bryant.zip">{{ _('Download photos') }}</a></li>
             <li><a class="link" href="{{ url('mozorg.about.leadership') }}#david-bryant">{{ _('Link to this bio') }}</a></li>
           </ul>
         </div>
@@ -586,6 +597,7 @@
           </ul>
 
           <ul class="utility">
+            <li><a class="file" rel="external" href="https://assets.mozilla.net/leadership/mozilla-susan-chen.zip">{{ _('Download photos') }}</a></li>
             <li><a class="link" href="{{ url('mozorg.about.leadership') }}#susan-chen">{{ _('Link to this bio') }}</a></li>
           </ul>
         </div>
@@ -627,6 +639,7 @@
           <p class="title" itemprop="jobTitle">{{ _('VP, Global Policy, Trust and Security') }}</p>
 
           <ul class="utility">
+            <li><a class="file" rel="external" href="https://assets.mozilla.net/leadership/mozilla-alan-davidson.zip">{{ _('Download photos') }}</a></li>
             <li><a class="link" href="{{ url('mozorg.about.leadership') }}#alan-davidson">{{ _('Link to this bio') }}</a></li>
           </ul>
         </div>
@@ -668,6 +681,7 @@
           <p class="title" itemprop="jobTitle">{{ _('VP of Engineering, Firefox') }}</p>
 
           <ul class="utility">
+            <li><a class="file" rel="external" href="https://assets.mozilla.net/leadership/mozilla-joe-hildebrand.zip">{{ _('Download photos') }}</a></li>
             <li><a class="link" href="{{ url('mozorg.about.leadership') }}#joe-hildebrand">{{ _('Link to this bio') }}</a></li>
           </ul>
         </div>
@@ -709,6 +723,7 @@
           <p class="title" itemprop="jobTitle">{{ _('VP and General Manager, Pocket') }}</p>
 
           <ul class="utility">
+            <li><a class="file" rel="external" href="https://assets.mozilla.net/leadership/mozilla-matt-koidin.zip">{{ _('Download photos') }}</a></li>
             <li><a class="link" href="{{ url('mozorg.about.leadership') }}#matt-koidin">{{ _('Link to this bio') }}</a></li>
           </ul>
         </div>
@@ -756,6 +771,7 @@
           <p class="title" itemprop="jobTitle">{{ _('VP and General Manager, Emerging Markets ') }}</p>
 
           <ul class="utility">
+            <li><a class="file" rel="external" href="https://assets.mozilla.net/leadership/mozilla-stand-leong.zip">{{ _('Download photos') }}</a></li>
             <li><a class="link" href="{{ url('mozorg.about.leadership') }}#stan-leong">{{ _('Link to this bio') }}</a></li>
           </ul>
         </div>
@@ -797,6 +813,7 @@
           <p class="title" itemprop="jobTitle">{{ _('VP, Information Technology') }}</p>
 
           <ul class="utility">
+            <li><a class="file" rel="external" href="https://assets.mozilla.net/leadership/mozilla-chris-lin.zip">{{ _('Download photos') }}</a></li>
             <li><a class="link" href="{{ url('mozorg.about.leadership') }}#chris-lin">{{ _('Link to this bio') }}</a></li>
           </ul>
         </div>
@@ -830,6 +847,7 @@
           </ul>
 
           <ul class="utility">
+            <li><a class="file" rel="external" href="https://assets.mozilla.net/leadership/mozilla-mary-ellen-muckerman.zip">{{ _('Download photos') }}</a></li>
             <li><a class="link" href="{{ url('mozorg.about.leadership') }}#mary-ellen-muckerman">{{ _('Link to this bio') }}</a></li>
           </ul>
         </div>
@@ -870,6 +888,7 @@
           </ul>
 
           <ul class="utility">
+            <li><a class="file" rel="external" href="https://assets.mozilla.net/leadership/mozilla-eric-rescorla.zip">{{ _('Download photos') }}</a></li>
             <li><a class="link" href="{{ url('mozorg.about.leadership') }}#eric-rescorla">{{ _('Link to this bio') }}</a></li>
           </ul>
         </div>
@@ -917,6 +936,7 @@
           <p class="title" itemprop="jobTitle">{{ _('VP, Product Marketing') }}</p>
 
           <ul class="utility">
+            <li><a class="file" rel="external" href="https://assets.mozilla.net/leadership/mozilla-lindsey-shepard.zip">{{ _('Download photos') }}</a></li>
             <li><a class="link" href="{{ url('mozorg.about.leadership') }}#lindsey-shepard">{{ _('Link to this bio') }}</a></li>
           </ul>
         </div>
@@ -952,6 +972,7 @@
           <p class="title" itemprop="jobTitle">{{ _('VP, Product') }}</p>
 
           <ul class="utility">
+            <li><a class="file" rel="external" href="https://assets.mozilla.net/leadership/mozilla-marissa-wood.zip">{{ _('Download photos') }}</a></li>
             <li><a class="link" href="{{ url('mozorg.about.leadership') }}#reese-wood">{{ _('Link to this bio') }}</a></li>
           </ul>
         </div>

--- a/bedrock/mozorg/templates/mozorg/about/leadership.html
+++ b/bedrock/mozorg/templates/mozorg/about/leadership.html
@@ -771,7 +771,7 @@
           <p class="title" itemprop="jobTitle">{{ _('VP and General Manager, Emerging Markets ') }}</p>
 
           <ul class="utility">
-            <li><a class="file" rel="external" href="https://assets.mozilla.net/leadership/mozilla-stand-leong.zip">{{ _('Download photos') }}</a></li>
+            <li><a class="file" rel="external" href="https://assets.mozilla.net/leadership/mozilla-stan-leong.zip">{{ _('Download photos') }}</a></li>
             <li><a class="link" href="{{ url('mozorg.about.leadership') }}#stan-leong">{{ _('Link to this bio') }}</a></li>
           </ul>
         </div>


### PR DESCRIPTION
## Description
Adds links to download photos. Zip files reside on assets.mozilla.net

## Issue / Bugzilla link
#7839 

## Testing
http://localhost:8000/en-US/about/leadership/

- [ ] "Download photos" link appears on all MoCo exec profiles (in the modal)
- [ ] Each link points to the correct zip file for each person (no botched copypasta)
- [ ] None are a 404 (no incorrect filenames or missing uploads)