### PR TITLE
Adjust Firefox Lite product image positioning (#7991)

### DIFF
--- a/media/css/firefox/whatsnew/whatsnew-lite.scss
+++ b/media/css/firefox/whatsnew/whatsnew-lite.scss
@@ -197,7 +197,7 @@
 
             img {
                 position: absolute;
-                top: 180px;
+                top: 130px;
                 right: -20px;
                 max-width: 500px;
             }
@@ -213,7 +213,6 @@
         grid-template-columns: 40% 60%;
         .lite-kv {
             img {
-                top: 230px;
                 max-width: 650px;
             }
         }


### PR DESCRIPTION
## Description
Late request from stakeholder to bring the product image further above the fold.

## Issue / Bugzilla link
#7991