### PR TITLE
Update whatsnew 70 headlines for FR/DE/EN (Fixes #8038)

### DIFF
--- a/bedrock/exp/templates/exp/firefox/whatsnew/whatsnew-fx70.html
+++ b/bedrock/exp/templates/exp/firefox/whatsnew/whatsnew-fx70.html
@@ -40,7 +40,7 @@
       <div class="mzp-c-box-emphasis">
         <img class="c-emphasis-box-logo" src="{{ static('img/logos/firefox/logo-monitor.svg') }}" alt="">
         <h2 class="c-emphasis-box-title">
-          Have you checked out Firefox Monitor?
+          Stay ahead of hackers. Check for data breaches with Firefox Monitor.
           <span class="show-fxa-supported-signed-in">It’s included with your Firefox account.</span>
         </h2>
         <p>Use Firefox Monitor to see if your info was compromised in another company’s data breach — and automatically get alerts when your info might be at risk.</p>

--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx70-de.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx70-de.html
@@ -37,7 +37,7 @@
       <div class="mzp-c-box-emphasis">
         <img class="c-emphasis-box-logo" src="{{ static('img/logos/firefox/logo-monitor.svg') }}" alt="">
         <h2 class="c-emphasis-box-title">
-          {{ _('Schon Firefox Monitor ausprobiert?') }}
+          {{ _('Sei Hackern einen Schritt voraus. Checke Datenleaks mit Firefox Monitor.') }}
           <span class="show-fxa-supported-signed-in">{{ _('Monitor kommt mit deinem Firefox-Konto') }}</span>
         </h2>
         <p>{{ _('Überprüfe mit Firefox Monitor, ob deine persönlichen Informationen bei Datenleaks anderer Unternehmen gefährdet wurden – und lass dich automatischen warnen, wenn deine Daten von Datenleaks betroffen sind.') }}</p>

--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx70-en.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx70-en.html
@@ -37,7 +37,7 @@
       <div class="mzp-c-box-emphasis">
         <img class="c-emphasis-box-logo" src="{{ static('img/logos/firefox/logo-monitor.svg') }}" alt="">
         <h2 class="c-emphasis-box-title">
-          {{ _('Have you checked out Firefox Monitor?') }}
+          {{ _('Stay ahead of hackers. Check for data breaches with Firefox Monitor.') }}
           <span class="show-fxa-supported-signed-in">{{ _('It’s included with your Firefox account.') }}</span>
         </h2>
         <p>{{ _('Use Firefox Monitor to see if your info was compromised in another company’s data breach — and automatically get alerts when your info might be at risk.') }}</p>

--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx70-fr.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx70-fr.html
@@ -37,7 +37,7 @@
       <div class="mzp-c-box-emphasis">
         <img class="c-emphasis-box-logo" src="{{ static('img/logos/firefox/logo-monitor.svg') }}" alt="">
         <h2 class="c-emphasis-box-title">
-          {{ _('Avez-vous testé Firefox Monitor ?') }}
+          {{ _('Vérifiez si vous avez été victime d’une fuite de données avec Firefox Monitor.') }}
           <span class="show-fxa-supported-signed-in">{{ _('Vous y avez accès grâce à votre compte Firefox') }}</span>
         </h2>
         <p>{{ _('Essayez Firefox Monitor pour savoir si vos informations personnelles ont été compromises par une fuite de donnée d’une autre entreprise recevez des alertes automatiques en cas de future fuite.') }}</p>


### PR DESCRIPTION
## Description
Update headlines for locale-specific /whatsnew 70 templates.

## Issue / Bugzilla link
#8038

## Testing
- [x] en:
**Stay ahead of hackers. Check for data breaches with Firefox Monitor.**

- [x] de:
**Sei Hackern einen Schritt voraus. Checke Datenleaks mit Firefox Monitor.**

- [x] fr:
**Vérifiez si vous avez été victime d’une fuite de données avec Firefox Monitor.**