### PR TITLE
Stop double counting event on the firefox/lockwise page (Fixes #7941)

### DIFF
--- a/bedrock/exp/templates/exp/firefox/lockwise.de.html
+++ b/bedrock/exp/templates/exp/firefox/lockwise.de.html
@@ -44,10 +44,10 @@
     ) %}
 
       <div class="mobile-download-buttons">
-        <a href="{{ lockwise_adjust_url('ios', 'lockwise-page') }}" data-link-type="download" data-download-os="iOS" class="ios-button" data-cta-text="apple-app-store" data-cta-type="lockwise-app-store" data-cta-position="primary">
+        <a href="{{ lockwise_adjust_url('ios', 'lockwise-page') }}" class="ios-button" data-cta-text="apple-app-store" data-cta-type="lockwise-app-store" data-cta-position="primary">
           <img src="{{ l10n_img('firefox/ios/btn-app-store.svg') }}" alt="Im App Store downloaden" width="152" height="45">
         </a>
-        {{ google_play_button(href=lockwise_adjust_url('android', 'lockwise-page'), extra_data_attributes={'download-location': button_location, 'cta-type': 'lockwise-app-store', 'cta-text': 'google-play-store', 'cta-position': 'primary' } ) }}
+        {{ google_play_button(href=lockwise_adjust_url('android', 'lockwise-page'), product='lockwise', extra_data_attributes={'cta-type': 'lockwise-app-store', 'cta-text': 'google-play-store', 'cta-position': 'primary' } ) }}
       </div>
       <div class="mzp-c-hero-cta add-on-download for-firefox-69-and-below hidden">
         <div class="mzp-c-button-download-container">

--- a/bedrock/exp/templates/exp/firefox/lockwise.de.html
+++ b/bedrock/exp/templates/exp/firefox/lockwise.de.html
@@ -47,7 +47,7 @@
         <a href="{{ lockwise_adjust_url('ios', 'lockwise-page') }}" class="ios-button" data-cta-text="apple-app-store" data-cta-type="lockwise-app-store" data-cta-position="primary">
           <img src="{{ l10n_img('firefox/ios/btn-app-store.svg') }}" alt="Im App Store downloaden" width="152" height="45">
         </a>
-        {{ google_play_button(href=lockwise_adjust_url('android', 'lockwise-page'), product='lockwise', extra_data_attributes={'cta-type': 'lockwise-app-store', 'cta-text': 'google-play-store', 'cta-position': 'primary' } ) }}
+        {{ google_play_button(href=lockwise_adjust_url('android', 'lockwise-page'), product='Lockwise', extra_data_attributes={'cta-type': 'lockwise-app-store', 'cta-text': 'google-play-store', 'cta-position': 'primary' } ) }}
       </div>
       <div class="mzp-c-hero-cta add-on-download for-firefox-69-and-below hidden">
         <div class="mzp-c-button-download-container">

--- a/bedrock/exp/templates/exp/firefox/lockwise.html
+++ b/bedrock/exp/templates/exp/firefox/lockwise.html
@@ -47,7 +47,7 @@
         <a href="{{ lockwise_adjust_url('ios', 'lockwise-page') }}" class="ios-button" data-cta-text="apple-app-store" data-cta-type="lockwise-app-store" data-cta-position="primary">
           <img src="{{ l10n_img('firefox/ios/btn-app-store.svg') }}" alt="Download on the App Store" width="152" height="45">
         </a>
-        {{ google_play_button(href=lockwise_adjust_url('android', 'lockwise-page'), product='lockwise', extra_data_attributes={'cta-type': 'lockwise-app-store', 'cta-text': 'google-play-store', 'cta-position': 'primary' } ) }}
+        {{ google_play_button(href=lockwise_adjust_url('android', 'lockwise-page'), product='Lockwise', extra_data_attributes={'cta-type': 'lockwise-app-store', 'cta-text': 'google-play-store', 'cta-position': 'primary' } ) }}
       </div>
       <div class="mzp-c-hero-cta add-on-download for-firefox-69-and-below hidden">
         <div class="mzp-c-button-download-container">

--- a/bedrock/exp/templates/exp/firefox/lockwise.html
+++ b/bedrock/exp/templates/exp/firefox/lockwise.html
@@ -44,10 +44,10 @@
     ) %}
 
       <div class="mobile-download-buttons">
-        <a href="{{ lockwise_adjust_url('ios', 'lockwise-page') }}" data-link-type="download" data-download-os="iOS" class="ios-button" data-cta-text="apple-app-store" data-cta-type="lockwise-app-store" data-cta-position="primary">
+        <a href="{{ lockwise_adjust_url('ios', 'lockwise-page') }}" class="ios-button" data-cta-text="apple-app-store" data-cta-type="lockwise-app-store" data-cta-position="primary">
           <img src="{{ l10n_img('firefox/ios/btn-app-store.svg') }}" alt="Download on the App Store" width="152" height="45">
         </a>
-        {{ google_play_button(href=lockwise_adjust_url('android', 'lockwise-page'), extra_data_attributes={'download-location': button_location, 'cta-type': 'lockwise-app-store', 'cta-text': 'google-play-store', 'cta-position': 'primary' } ) }}
+        {{ google_play_button(href=lockwise_adjust_url('android', 'lockwise-page'), product='lockwise', extra_data_attributes={'cta-type': 'lockwise-app-store', 'cta-text': 'google-play-store', 'cta-position': 'primary' } ) }}
       </div>
       <div class="mzp-c-hero-cta add-on-download for-firefox-69-and-below hidden">
         <div class="mzp-c-button-download-container">

--- a/bedrock/firefox/templates/firefox/lockwise/lockwise.html
+++ b/bedrock/firefox/templates/firefox/lockwise/lockwise.html
@@ -52,10 +52,10 @@
     ) %}
 
       <div class="mobile-download-buttons">
-        <a href="{{ lockwise_adjust_url('ios', 'lockwise-page') }}" data-link-type="download" data-download-os="iOS" class="ios-button"  data-cta-text="apple-app-store" data-cta-type="lockwise-app-store" data-cta-position="primary">
+        <a href="{{ lockwise_adjust_url('ios', 'lockwise-page') }}" class="ios-button" data-cta-text="apple-app-store" data-cta-type="lockwise-app-store" data-cta-position="primary">
           <img src="{{ l10n_img('firefox/ios/btn-app-store.svg') }}" alt="{{ _('Download on the App Store') }}" width="152" height="45">
         </a>
-        {{ google_play_button(href=lockwise_adjust_url('android', 'lockwise-page'), extra_data_attributes={'download-location': button_location, 'cta-type': 'lockwise-app-store', 'cta-text': 'google-play-store', 'cta-position': 'primary' } ) }}
+        {{ google_play_button(href=lockwise_adjust_url('android', 'lockwise-page'), product='lockwise', extra_data_attributes={'cta-type': 'lockwise-app-store', 'cta-text': 'google-play-store', 'cta-position': 'primary' } ) }}
       </div>
       <div class="mzp-c-hero-cta add-on-download for-firefox-69-and-below hidden" >
         <div class="mzp-c-button-download-container">

--- a/bedrock/firefox/templates/firefox/lockwise/lockwise.html
+++ b/bedrock/firefox/templates/firefox/lockwise/lockwise.html
@@ -55,7 +55,7 @@
         <a href="{{ lockwise_adjust_url('ios', 'lockwise-page') }}" class="ios-button" data-cta-text="apple-app-store" data-cta-type="lockwise-app-store" data-cta-position="primary">
           <img src="{{ l10n_img('firefox/ios/btn-app-store.svg') }}" alt="{{ _('Download on the App Store') }}" width="152" height="45">
         </a>
-        {{ google_play_button(href=lockwise_adjust_url('android', 'lockwise-page'), product='lockwise', extra_data_attributes={'cta-type': 'lockwise-app-store', 'cta-text': 'google-play-store', 'cta-position': 'primary' } ) }}
+        {{ google_play_button(href=lockwise_adjust_url('android', 'lockwise-page'), product='Lockwise', extra_data_attributes={'cta-type': 'lockwise-app-store', 'cta-text': 'google-play-store', 'cta-position': 'primary' } ) }}
       </div>
       <div class="mzp-c-hero-cta add-on-download for-firefox-69-and-below hidden" >
         <div class="mzp-c-button-download-container">


### PR DESCRIPTION
## Description
- Removed GA events on app store badges that are double-counting as Firefox mobile downloads.

## Issue / Bugzilla link
#7941

## Testing
URLs:

- http://localhost:8000/en-US/firefox/lockwise/
- http://localhost:8000/en-US/exp/firefox/lockwise/
- http://localhost:8000/de/exp/firefox/lockwise/

Things to test:

- [ ] Badges **should have** `data-cta-text`, `data-cta-type`, and `data-cta-position` attributes.
- [ ] Badges **should not have** `data-link-type` or `data-download-os` attributes.