### PR TITLE
Fix numbered list syntax

### DIFF
--- a/docs/coding.rst
+++ b/docs/coding.rst
@@ -47,10 +47,10 @@ to optimize images before uploading them to the site.
 
 The script `img.sh` can be used to optimize images locally on the command line:
 
-# Before you run it for the first time you will need to run `yarn` to install dependencies
-# Add the image files to git's staging area `git add *`
-# Run the script `./bin/img.sh`
-# The optimized files will not automatically be staged, so be sure to add them before commiting
+#. Before you run it for the first time you will need to run `yarn` to install dependencies
+#. Add the image files to git's staging area `git add *`
+#. Run the script `./bin/img.sh`
+#. The optimized files will not automatically be staged, so be sure to add them before commiting
 
 The script will:
 


### PR DESCRIPTION
## Description

This PR fixes what appears to be a minor syntax issue in a numbered list in the [Optimizing images](https://bedrock.readthedocs.io/en/latest/coding.html#optimizing-images) section of the bedrock docs.

## Testing
The list is currently displaying with the `#` characters and no list formatting: 
<img width="727" alt="image" src="https://user-images.githubusercontent.com/58062/68085059-e8cb1300-fe12-11e9-9864-1767907d0f1e.png">
