### PR TITLE
Update Selenium to 3.141.0 (Fixes #7419)

### DIFF
--- a/docker/bin/run_integration_tests.sh
+++ b/docker/bin/run_integration_tests.sh
@@ -8,11 +8,12 @@ MARK_EXPRESSION="not headless and not download"
 case $1 in
   chrome)
     BROWSER_NAME=chrome
+    BROWSER_VERSION=latest
     PLATFORM="Windows 10"
     ;;
   firefox)
     BROWSER_NAME=firefox
-    BROWSER_VERSION="57.0"
+    BROWSER_VERSION=latest
     PLATFORM="Windows 10"
     ;;
   ie)

--- a/jenkins/global.yml
+++ b/jenkins/global.yml
@@ -1,6 +1,5 @@
 environment:
-  SELENIUM_VERSION: 3.5.0
-  DOCKER_SELENIUM_VERSION: 3.5.3-astatine
+  SELENIUM_VERSION: 3.141.0
 
 regions:
   frankfurt:

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -105,15 +105,15 @@ pytest-django==3.4.8 \
 pytest-html==1.20.0 \
     --hash=sha256:648b7ba1d6035cc021d607e9d44f4dc06e916bdb04e09572dd04fb82eecab9ed \
     --hash=sha256:a7c65cdd9d5e4d09cef2f500ca801f80c1110204f24e5b84d019c6f919b15e9e
-pytest-selenium==1.16.0 \
-    --hash=sha256:18c5db66512efcf6db9e32cfe8dcd0b69ef11ac1e8b9a4ce8a1b4813e6c73c9a \
-    --hash=sha256:c4d5a73d501f9fb3afb70e781f6fc2106a7b5f64387ed449b15eb1df61fa7915
+pytest-selenium==1.17.0 \
+    --hash=sha256:caf049839d12297e01f0521a968e44ae854f4eca1afd80b28f6a2510df02c883 \
+    --hash=sha256:e8034ebabc3b55fad57bfb97e7b0b2137532dbc65f33706e1ce1ed8e547caa1a
 pytest-variables==1.7.1 \
     --hash=sha256:59c00b95779657532ac5f8209b28b5d447c8b4bc4210c1d6bdf9a42aa201f9b0 \
     --hash=sha256:7808b77b643b9f8a24f1ee1c32132648b1c62ab93956f20fe101dde66db6d09a
-selenium==3.5.0 \
-    --hash=sha256:69b479bdfa1ab2fee86a75086f7d5c6ef93cdad8cb6521cb0596554c6722f3eb \
-    --hash=sha256:267418f5fde1a4f8c180e5b8f45bd57c6d45b1f7d8fa5ad699a48e9a98fa79a3
+selenium==3.141.0 \
+    --hash=sha256:2d7131d7bc5a5b99a2d9b04aaf2612c411b03b8ca1b1ee8d3de5845a9be2cb3c \
+    --hash=sha256:deaf32b60ad91a4611b98d8002757f29e6f2c2d5fcaf202e1c9ad06d6772300d
 pytest-xdist==1.28.0 \
     --hash=sha256:b0bb4b0293ee8657b9eb3ff334a3b6aac4db74fd4a86b81e1982c879237a47eb \
     --hash=sha256:f83a485293e81fd57c8a5a85a3f12473a532c5ca7dec518857cbb72766bb526c


### PR DESCRIPTION
## Description
- Updates selenium and pytest-selenium to latest versions.
- Use 'latest' shortcut for setting browser version on Firefox / Chrome in SauceLabs runs.

## Issue / Bugzilla link
#7419

## Testing
Successful test run: https://ci.vpn1.moz.works/blue/organizations/jenkins/bedrock_multibranch_pipeline/detail/run-integration-tests/431/pipeline