### PR TITLE
Fix typos on German and French whatsnew 70 headlines. (Fixes #8075)

### DIFF
--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx70-de.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx70-de.html
@@ -38,10 +38,10 @@
       <div class="mzp-c-box-emphasis">
         <img class="c-emphasis-box-logo" src="{{ static('img/logos/firefox/logo-monitor.svg') }}" alt="">
         <h2 class="c-emphasis-box-title">
-          {{ _('Sei Hackern einen Schritt voraus. Checke Datenleaks mit Firefox Monitor.') }}
-          <span class="show-fxa-supported-signed-in">{{ _('Monitor kommt mit deinem Firefox-Konto') }}</span>
+          {{ _('Sei Hackern einen Schritt voraus. Checke Datenlecks mit Firefox Monitor.') }}
+          <span class="show-fxa-supported-signed-in">{{ _('Monitor kommt mit deinem Firefox-Konto.') }}</span>
         </h2>
-        <p>{{ _('Überprüfe mit Firefox Monitor, ob deine persönlichen Informationen bei Datenleaks anderer Unternehmen gefährdet wurden – und lass dich automatischen warnen, wenn deine Daten von Datenleaks betroffen sind.') }}</p>
+        <p>{{ _('Überprüfe mit Firefox Monitor, ob deine persönlichen Informationen bei Datenlecks anderer Unternehmen gefährdet wurden – und lass dich automatisch warnen, wenn deine Daten betroffen sind.') }}</p>
 
         <div class="show-fxa-supported-signed-out show-fxa-default show-fxa-not-fx">
           {{ monitor_button(

--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx70-fr.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx70-fr.html
@@ -39,9 +39,9 @@
         <img class="c-emphasis-box-logo" src="{{ static('img/logos/firefox/logo-monitor.svg') }}" alt="">
         <h2 class="c-emphasis-box-title">
           {{ _('Vérifiez si vous avez été victime d’une fuite de données avec Firefox Monitor.') }}
-          <span class="show-fxa-supported-signed-in">{{ _('Vous y avez accès grâce à votre compte Firefox') }}</span>
+          <span class="show-fxa-supported-signed-in">{{ _('Vous pouvez y accéder avec votre compte Firefox.') }}</span>
         </h2>
-        <p>{{ _('Essayez Firefox Monitor pour savoir si vos informations personnelles ont été compromises par une fuite de donnée d’une autre entreprise recevez des alertes automatiques en cas de future fuite.') }}</p>
+        <p>{{ _('Essayez Firefox Monitor pour savoir si vos informations personnelles ont été compromises par une fuite de donnée d’une autre entreprise. Recevez des alertes automatiques en cas de future fuite.') }}</p>
 
         <div class="show-fxa-supported-signed-out show-fxa-default show-fxa-not-fx">
           {{ monitor_button(


### PR DESCRIPTION
## Description
Fixes German and French language hero headline and body typos on whatsnew 70.

## Issue / Bugzilla link
#8075

## Testing
[Copy doc.](https://docs.google.com/spreadsheets/d/1jpLfL5-L3UqtBrEePRcFWJBmxcA0Ktwg9TH9kOLwByg/edit#gid=0)

**ENGLISH**
**hero headline**
- [ ] Stay ahead of hackers. Check for data breaches with Firefox Monitor. It’s included with your Firefox account.

**hero body**
- [ ] Use Firefox Monitor to see if your info was compromised in another company’s data breach — and automatically get alerts when your info might be at risk.

---
**GERMAN**
https://bedrock-demo-achurchwell.oregon-b.moz.works/de/firefox/70.0/whatsnew/all/

**hero headline**
- [x] Sei Hackern einen Schritt voraus. Checke Datenlecks mit Firefox Monitor. Monitor kommt mit deinem Firefox-Konto.

**hero body**
- [x] Überprüfe mit Firefox Monitor, ob deine persönlichen Informationen bei Datenlecks anderer Unternehmen gefährdet wurden – und lass dich automatisch warnen, wenn deine Daten betroffen sind.
---

**FRENCH**
https://bedrock-demo-achurchwell.oregon-b.moz.works/fr/firefox/70.0/whatsnew/all/

**hero headline**
- [x] Vérifiez si vous avez été victime d’une fuite de données avec Firefox Monitor. Vous pouvez y accéder avec votre compte Firefox.

**hero body**
- [x] Essayez Firefox Monitor pour savoir si vos informations personnelles ont été compromises par une fuite de donnée d’une autre entreprise. Recevez des alertes automatiques en cas de future fuite.
