### PR TITLE
Update DE protection report CTA on whatsnew 70 (Fixes #8075)

### DIFF
--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx70-de.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx70-de.html
@@ -79,7 +79,7 @@
           <h3 class="c-picto-block-title">{{ _('Wir blocken über 2.000 Tracker – automatisch') }}</h3>
           <div class="c-picto-block-body">
             <p>{{ _('Alle Firefox Browser für Desktop und Mobile kommen mit standardmäßig eingestelltem verbesserten Tracking-Schutz.') }}</p>
-            <a class="mzp-c-cta-link show-firefox-desktop-70 js-open-about-protections" href="https://support.mozilla.org/kb/enhanced-tracking-protection-firefox-desktop/?utm_source={{ _entrypoint }}&utm_medium=referral&utm_campaign={{ _utm_campaign }}&entrypoint={{ _entrypoint }}" data-link-type="link" data-link-name="See what Firefox has blocked for you">{{ _('Sehen, was Firefox für dich geblockt hat') }}</a>
+            <a class="mzp-c-cta-link show-firefox-desktop-70 js-open-about-protections" href="https://support.mozilla.org/kb/enhanced-tracking-protection-firefox-desktop/?utm_source={{ _entrypoint }}&utm_medium=referral&utm_campaign={{ _utm_campaign }}&entrypoint={{ _entrypoint }}" data-link-type="link" data-link-name="See what Firefox has blocked for you">{{ _('Sieh, was Firefox für dich geblockt hat') }}</a>
 
             <a class="mzp-c-cta-link show-firefox-desktop-old" href="https://support.mozilla.org/kb/update-firefox-latest-release/?utm_source={{ _entrypoint }}&utm_medium=referral&utm_campaign={{ _utm_campaign }}&entrypoint={{ _entrypoint }}" data-link-type="link" data-link-name="Update your Firefox browser">{{ _('Firefox Browser updaten') }}</a>
 


### PR DESCRIPTION
## Description
String change due to typo.

## Issue / Bugzilla link
#8075

## Testing
[Copy doc](https://docs.google.com/spreadsheets/d/1jpLfL5-L3UqtBrEePRcFWJBmxcA0Ktwg9TH9kOLwByg/edit#gid=0)

"See what Firefox has blocked for you" CTA on German template is 
"Sieh, was Firefox für dich geblockt hat"