### PR TITLE
Fix typo on /fr/firefox/70.0/whatsnew/ (Fix bug 1594001)

### DIFF
--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx70-fr.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx70-fr.html
@@ -41,7 +41,7 @@
           {{ _('Vérifiez si vous avez été victime d’une fuite de données avec Firefox Monitor.') }}
           <span class="show-fxa-supported-signed-in">{{ _('Vous pouvez y accéder avec votre compte Firefox.') }}</span>
         </h2>
-        <p>{{ _('Essayez Firefox Monitor pour savoir si vos informations personnelles ont été compromises par une fuite de donnée d’une autre entreprise. Recevez des alertes automatiques en cas de future fuite.') }}</p>
+        <p>{{ _('Essayez Firefox Monitor pour savoir si vos informations personnelles ont été compromises par une fuite de données d’une autre entreprise. Recevez des alertes automatiques en cas de future fuite.') }}</p>
 
         <div class="show-fxa-supported-signed-out show-fxa-default show-fxa-not-fx">
           {{ monitor_button(


### PR DESCRIPTION
## Issue / Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1594001
