### PR TITLE
Fix image-replaced heading Safari bug (Fixes #8084)

### DIFF
--- a/media/css/exp/firefox/index.scss
+++ b/media/css/exp/firefox/index.scss
@@ -89,6 +89,7 @@ $image-path: '/media/protocol/img';
         background-repeat: no-repeat;
         margin-bottom: $spacing-lg;
         min-height: 40px;
+        text-indent: -120%; // image-replacement Safari bug see issue #8084
     }
 }
 

--- a/media/css/firefox/home/master.scss
+++ b/media/css/firefox/home/master.scss
@@ -89,6 +89,7 @@ $image-path: '/media/protocol/img';
         background-repeat: no-repeat;
         margin-bottom: $spacing-lg;
         min-height: 40px;
+        text-indent: -120%; // image-replacement Safari bug see issue #8084
     }
 }
 

--- a/media/css/firefox/privacy/products.scss
+++ b/media/css/firefox/privacy/products.scss
@@ -185,6 +185,7 @@ $image-path: '/media/protocol/img';
                 background-repeat: no-repeat;
                 margin-bottom: $spacing-lg;
                 min-height: 40px;
+                text-indent: -120%; // image-replacement Safari bug see issue #8084
             }
         }
 


### PR DESCRIPTION
## Description
Fixes a Safari layout bug effecting image replaced headlines within a grid layout.

- http://localhost:8000/en-US/firefox/
- http://localhost:8000/en-US/firefox/privacy/products/

## Issue / Bugzilla link
#8084

## Testing
- [ ] Layout should be fixed in Safari.
- [ ] Image replaced headlines should still appear ok in other browsers.