### PR TITLE
Use recipes for Fluent migration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -92,7 +92,7 @@ FROM app-base AS devapp
 CMD ["./bin/run-tests.sh"]
 
 RUN apt-install make
-COPY requirements/base.txt requirements/dev.txt requirements/docs.txt ./requirements/
+COPY requirements/base.txt requirements/dev.txt requirements/migration.txt requirements/docs.txt ./requirements/
 RUN pip install --no-cache-dir -r requirements/dev.txt
 RUN pip install --no-cache-dir -r requirements/docs.txt
 COPY ./setup.cfg ./

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -255,7 +255,8 @@ FLUENT_PATHS = [
     # remote FTL files from l10n team
     FLUENT_REPO_PATH,
 ]
-FLUENT_MIGRATIONS_PATH = ROOT_PATH / 'l10n' / 'bedrock_migrations'
+FLUENT_MIGRATIONS = 'lib.fluent_migrations'
+FLUENT_MIGRATIONS_PATH = ROOT_PATH / 'lib' / 'fluent_migrations'
 
 # Paths that don't require a locale code in the URL.
 # matches the first url component (e.g. mozilla.org/gameon/)

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -255,6 +255,7 @@ FLUENT_PATHS = [
     # remote FTL files from l10n team
     FLUENT_REPO_PATH,
 ]
+FLUENT_MIGRATIONS_PATH = ROOT_PATH / 'l10n' / 'bedrock_migrations'
 
 # Paths that don't require a locale code in the URL.
 # matches the first url component (e.g. mozilla.org/gameon/)

--- a/docs/fluent-conversion.rst
+++ b/docs/fluent-conversion.rst
@@ -14,39 +14,74 @@ from .lang to .ftl files. This document will cover the usage of these.
 If you've got a translated page you'd like to convert as-is to the Fluent system
 then you can follow this procedure to get a big head start.
 
-Convert a .lang file to English .ftl
-====================================
+The key concept in converting a page to Fluent is a recipe. The recipe is a
+piece of python code that can programmatically generate a Fluent file. It can
+use existing Fluent files as templates, and .lang localizations as data sources.
 
-The first step is to convert an existing english .lang file into an equivalent
-.ftl file in the ``en`` folder of the ``l10n`` directory in bedrock. Let's say
-for example you have a file called ``mozorg/mission.lang``; you would run:
+All the functionality is provided by the ``fluent`` management command via
+subcommands for each phase.
+
+Create a recipe from a template
+===============================
+
+The first step is to create the recipe. Let's say you want to convert
+``bedrock/mozorg/templates/mozorg/mission.html``, then you'll run
+
 
 .. code-block:: bash
 
     $ make run-shell
-    $ ./manage.py lang_to_ftl mozorg/mission
+    $ ./manage.py fluent recipe bedrock/mozorg/templates/mozorg/mission.html
 
-This should create ``l10n/en/mozorg/mission.ftl`` which has all of the strings,
-generated string IDs, and a comment above each one containing the md5 hash
-of the original string ID so that we can later match the new string IDs to the
-proper places in the template. After you've run this and created the new file
-you should inspect the file for any problems and tweak the new Fluent string
-IDs to adhere to any standards you want or to make more sense.
+This will parse all of the calls to ``_()`` and the ``trans`` blocks, process the strings in the
+same way the old string extraction process did, and create new Fluent string IDs.
+It will generate the recipe in ``lib/fluent_migrations/mozorg/mission.py``. The recipe name is based
+on the template name after ``templates``.
 
-Convert a template
-==================
+Sanitize recipe
+===============
 
-Once you have your new .ftl file you'll want to convert the template that used
-the original .lang file to use the new system. To do that you'll do the following
+The recipe creates migrations for each localizable string in the template,
+with some possibly bad string IDs. At this point, you want to change
+the IDs to be conforming with the best practices laid out in the l10n docs.
+The existing recipe will already have the template name as prefix, though.
+
+You can also choose to remove strings from the conversion, if you just
+want to convert a subset of the strings.
+
+Once you're happy with the recipe, you can create the Fluent files and the template.
+
+Convert a .lang file to English .ftl
+====================================
+
+The next step is to convert an existing english .lang file into an equivalent
+.ftl file in the ``en`` folder of the ``l10n`` directory in bedrock. Let's
+continue with the example of ``mission.html``; you would run:
+
+.. code-block:: bash
+
+    $ make run-shell
+    $ ./manage.py fluent ftl bedrock/mozorg/templates/mozorg/mission.html
+
+This should create ``l10n/en/mozorg/mission.ftl`` which has all of the strings
+in the order in which they appear in the template.
+
+You want to sanitize this Fluent file by adding license headers, file comments
+with staging URLs, as well as comments individual strings or groups of strings.
+
+Convert the template
+====================
+
+With the recipe created in the first step, you'll do the following
 (assuming your docker shell is still running):
 
 .. code-block:: bash
 
-    $ ./manage.py template_to_ftl mozorg/mission bedrock/mozorg/templates/mozorg/mission.html
+    $ ./manage.py fluent template bedrock/mozorg/templates/mozorg/mission.html
 
-This will parse all of the calls to ``_()`` and the ``trans`` blocks, process the strings in the
-same way the old string extraction process did, and match them to the new Fluent string IDs. It
-will then take this mapping of IDs and replace all of the old calls with new calls to ``ftl()``.
+This will reparse the template much in the same way it did when creating the recipe.
+It will inspect the recipe to see which legacy strings map to which ID, that you've
+chosen when you sanitized the recipe. It will then take this mapping of IDs and replace all of the old calls with new calls to ``ftl()``.
 If there are any issues you should see warnings printed to your screen, but always inspect the new
 template and give the page a test run to make sure all is working as expected.
 
@@ -85,30 +120,17 @@ files in our fluent files repo.
 
 .. code-block:: bash
 
-    $ ./manage.py port_lang_translations mozorg/mission
+    $ ./manage.py fluent ftl bedrock/mozorg/templates/mozorg/mission.html de it
+    $ ./manage.py fluent ftl lib/fluent_migrations/mozorg/mission.py de it
 
-This will do several things:
+This is the same command we used to create the original ``en`` Fluent file.
+As you can see, you can specify both the template path here as well as the
+recipe path.
 
-1. Update the local repos for .lang files and .ftl files.
-2. Find and port all of the .lang files in all locale directories
-   into .ftl files in the ``git-repos/www-l10n/`` directory.
-3. Look up which locales are currently active via the .lang files
-   and record that info into a metadata file for the particular
-   .ftl file e.g. ``git-repos/www-l10n/metadata/mozorg/mission.json``.
+Before you run this, make sure to update the local clones of your l10n repositories.
 
-Clean up
-========
-
-Once all of that is done and you're happy with the results you need to remove the porting artifacts.
-This is mainly the string ID hash comments from the new "en" .ftl files. To clean them you run the
-``clean_ftl`` command.
-
-.. code-block:: bash
-
-    $ ./manage.py clean_ftl mozorg/mission
-
-You can specify more than one file. By default it looks in the ``l10n/en/`` folder, but if you give a full
-or relative path to an existing file it will clean that one.
+This command will use the Fluent file you edited as template, read the legacy translations
+from ``locale`` and write the generated Fluent files for each locale into the ``git-repos/www-l10n/`` directory.
 
 Commit
 ======

--- a/lib/l10n_utils/management/commands/_fluent.py
+++ b/lib/l10n_utils/management/commands/_fluent.py
@@ -8,7 +8,7 @@ import re
 from django.conf import settings
 
 from lib.l10n_utils.utils import strip_whitespace
-from fluent.migrate.context import MergeContext
+from fluent.migrate.context import MigrationContext
 
 
 def migration_name(template):
@@ -34,7 +34,7 @@ def get_migration_context(recipe_or_template, locale='en'):
         locale = settings.LANGUAGE_CODE
     else:
         ref_dir = settings.FLUENT_LOCAL_PATH / 'en'
-    context = MergeContext(
+    context = MigrationContext(
         locale, ref_dir, settings.LOCALES_PATH / locale
     )
     migration.migrate(context)

--- a/lib/l10n_utils/management/commands/_fluent.py
+++ b/lib/l10n_utils/management/commands/_fluent.py
@@ -18,10 +18,14 @@ def migration_name(template):
     return template.relative_to(parent).with_suffix('')
 
 
-def get_migration_context(template, locale='en'):
-    'Create the merge context associated with the template'
-    pkg_name = '.'.join(('',) + migration_name(template).parts)
-    migration = import_module(pkg_name, 'l10n.bedrock_migrations')
+def get_migration_context(recipe_or_template, locale='en'):
+    'Create the merge context associated with the template or recipe'
+    if recipe_or_template.suffix == '.py':
+        name = recipe_or_template.resolve().relative_to(settings.FLUENT_MIGRATIONS_PATH).with_suffix('')
+    else:
+        name = migration_name(recipe_or_template)
+    pkg_name = '.'.join(('',) + name.parts)
+    migration = import_module(pkg_name, settings.FLUENT_MIGRATIONS)
     no_reference = locale == 'en'
     if no_reference:
         ref_dir = None

--- a/lib/l10n_utils/management/commands/_fluent.py
+++ b/lib/l10n_utils/management/commands/_fluent.py
@@ -7,6 +7,7 @@ import re
 
 from django.conf import settings
 
+from lib.l10n_utils.utils import strip_whitespace
 from fluent.migrate.context import MergeContext
 
 
@@ -40,9 +41,18 @@ def get_migration_context(recipe_or_template, locale='en'):
     return context
 
 
-ADD_LANG_RE = re.compile(r'{% add_lang_files (.*?) %}')
+def trans_to_lang(string):
+    string = strip_whitespace(string)
+    return TRANS_PLACEABLE_RE.sub(
+        lambda m: '%({})s'.format(m.group('var')),
+        string
+    )
+
+
+ADD_LANG_RE = re.compile(r'{% (?:add|set)_lang_files (.*?) %}')
 GETTEXT_RE = re.compile(r'\b_\([\'"](?P<string>.+?)[\'"]\)'
                         r'(\s*\|\s*format\((?P<args>\w.+?)\))?', re.S)
 TRANS_BLOCK_RE = re.compile(r'{%-?\s+trans\s+((?P<args>\w.+?)\s+)?-?%\}\s*'
                             r'(?P<string>.+?)'
                             r'\s*{%-?\s+endtrans\s+-?%\}', re.S)
+TRANS_PLACEABLE_RE = re.compile(r'{{\s*(?P<var>\w+)\s*}}')

--- a/lib/l10n_utils/management/commands/_fluent.py
+++ b/lib/l10n_utils/management/commands/_fluent.py
@@ -1,0 +1,21 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import re
+
+
+def migration_name(template):
+    'Derive migration name from template name'
+    for parent in template.parents:
+        if parent.name == 'templates':
+            break
+    return template.relative_to(parent).with_suffix('')
+
+
+ADD_LANG_RE = re.compile(r'{% add_lang_files (.*?) %}')
+GETTEXT_RE = re.compile(r'\b_\([\'"](?P<string>.+?)[\'"]\)'
+                        r'(\s*\|\s*format\((?P<args>\w.+?)\))?', re.S)
+TRANS_BLOCK_RE = re.compile(r'{%-?\s+trans\s+((?P<args>\w.+?)\s+)?-?%\}\s*'
+                            r'(?P<string>.+?)'
+                            r'\s*{%-?\s+endtrans\s+-?%\}', re.S)

--- a/lib/l10n_utils/management/commands/_fluent.py
+++ b/lib/l10n_utils/management/commands/_fluent.py
@@ -21,6 +21,13 @@ def migration_name(template):
     return template.relative_to(parent).with_suffix('')
 
 
+def template_name(recipe):
+    'Find template for a migration recipe path'
+    name = recipe.resolve().relative_to(settings.FLUENT_MIGRATIONS_PATH).with_suffix('.html')
+    candidates = list(Path('bedrock').glob(f'*/templates/{name}'))
+    return candidates[0]
+
+
 def get_migration_context(recipe_or_template, locale='en'):
     'Create the merge context associated with the template or recipe'
     if recipe_or_template.suffix == '.py':

--- a/lib/l10n_utils/management/commands/_fluent_activation.py
+++ b/lib/l10n_utils/management/commands/_fluent_activation.py
@@ -1,0 +1,29 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from ._fluent import (
+    get_lang_files,
+    template_name,
+)
+from lib.l10n_utils.dotlang import get_translations_for_langfile
+
+
+class Activation:
+    def __init__(self, cmd):
+        self.stdout = cmd.stdout
+        self.dependencies = {}
+
+    def handle(self, recipe_or_template):
+        if recipe_or_template.suffix == '.py':
+            template = template_name(recipe_or_template)
+        else:
+            template = recipe_or_template
+        with template.open('r') as tfh:
+            template_str = tfh.read()
+        lang_files = get_lang_files(template, template_str)
+        for lang_file in lang_files:
+            locales = get_translations_for_langfile(lang_file)
+            # XXX TODO
+            # Where do we go from here
+            print(locales)

--- a/lib/l10n_utils/management/commands/_fluent_ftl.py
+++ b/lib/l10n_utils/management/commands/_fluent_ftl.py
@@ -13,9 +13,9 @@ class FTLCreator:
     def __init__(self, cmd):
         self.stdout = cmd.stdout
 
-    def handle(self, template, locale):
+    def handle(self, recipe_or_template, locale):
         no_reference = locale == 'en'
-        context = get_migration_context(template, locale=locale)
+        context = get_migration_context(recipe_or_template, locale=locale)
         if no_reference:
             context.create_references_from_transforms()
             base = settings.FLUENT_LOCAL_PATH

--- a/lib/l10n_utils/management/commands/_fluent_ftl.py
+++ b/lib/l10n_utils/management/commands/_fluent_ftl.py
@@ -17,7 +17,6 @@ class FTLCreator:
         no_reference = locale == 'en'
         context = get_migration_context(recipe_or_template, locale=locale)
         if no_reference:
-            context.create_references_from_transforms()
             base = settings.FLUENT_LOCAL_PATH
         else:
             base = settings.FLUENT_REPO_PATH

--- a/lib/l10n_utils/management/commands/_fluent_ftl.py
+++ b/lib/l10n_utils/management/commands/_fluent_ftl.py
@@ -1,0 +1,28 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from django.conf import settings
+
+from ._fluent import (
+    get_migration_context,
+)
+
+
+class FTLCreator:
+    def __init__(self, cmd):
+        self.stdout = cmd.stdout
+
+    def handle(self, template, locale):
+        no_reference = locale == 'en'
+        context = get_migration_context(template, locale=locale)
+        if no_reference:
+            context.create_references_from_transforms()
+            base = settings.FLUENT_LOCAL_PATH
+        else:
+            base = settings.FLUENT_REPO_PATH
+        for path, contents in context.serialize_changeset(None).items():
+            en_path = base / locale / path
+            en_path.parent.mkdir(parents=True, exist_ok=True)
+            with en_path.open('w') as ftl_file:
+                ftl_file.write(contents)

--- a/lib/l10n_utils/management/commands/_fluent_recipe.py
+++ b/lib/l10n_utils/management/commands/_fluent_recipe.py
@@ -3,8 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import re
-from collections import defaultdict, OrderedDict
-from pathlib import Path
+from collections import defaultdict
 
 from django.conf import settings
 from django.utils.html import strip_tags
@@ -12,8 +11,8 @@ from django.utils.text import slugify
 
 from ._fluent import (
     migration_name,
+    get_lang_files,
     trans_to_lang,
-    ADD_LANG_RE,
     GETTEXT_RE,
     TRANS_BLOCK_RE,
 )
@@ -77,7 +76,7 @@ class Recipe:
     def handle(self, template):
         with template.open('r') as tfp:
             template_str = tfp.read()
-        lang_files = self.get_lang_files(template, template_str)
+        lang_files = get_lang_files(template, template_str)
         lang_ids = self.get_lang_ids(template_str)
         ids_for_file = self.get_ids_for_file(lang_ids, lang_files)
         recipe = RECIPE_INTRO
@@ -92,19 +91,6 @@ class Recipe:
                 transforms=transforms
             )
         self.write_recipe_for(template, recipe)
-
-    def get_lang_files(self, template, template_str):
-        lang_files = []
-        for add_lang in ADD_LANG_RE.finditer(template_str):
-            for p in re.findall(r'"(.*?)"', add_lang.group(1)):
-                f = Path(p).with_suffix('.lang')
-                lang_files.append(f)
-        if not lang_files:
-            lang_files.append(Path(str(template).split('/templates/')[1]).with_suffix('.lang'))
-        return OrderedDict(
-            (f, f.stem.replace('-', '_'))
-            for f in lang_files
-        )
 
     def get_lang_ids(self, template_str):
         found = []

--- a/lib/l10n_utils/management/commands/_fluent_recipe.py
+++ b/lib/l10n_utils/management/commands/_fluent_recipe.py
@@ -10,13 +10,14 @@ from django.conf import settings
 from django.utils.html import strip_tags
 from django.utils.text import slugify
 
+from ._fluent import (
+    migration_name,
+    ADD_LANG_RE,
+    GETTEXT_RE,
+    TRANS_BLOCK_RE,
+)
 
-ADD_LANG_RE = re.compile(r'{% add_lang_files (.*?) %}')
-GETTEXT_RE = re.compile(r'\b_\([\'"](?P<string>.+?)[\'"]\)'
-                        r'(\s*\|\s*format\((?P<args>\w.+?)\))?', re.S)
-TRANS_BLOCK_RE = re.compile(r'{%-?\s+trans\s+((?P<args>\w.+?)\s+)?-?%\}\s*'
-                            r'(?P<string>.+?)'
-                            r'\s*{%-?\s+endtrans\s+-?%\}', re.S)
+
 STR_VARIABLE_RE = re.compile(r'%(?P<var>\(\w+\))?s')
 RECIPE_INTRO = '''\
 from __future__ import absolute_import
@@ -201,11 +202,7 @@ class Recipe:
         )
 
     def write_recipe_for(self, template, recipe):
-        # Find templates dir to get relative path
-        for parent in template.parents:
-            if parent.name == 'templates':
-                break
-        relpath = template.relative_to(parent).with_suffix('.py')
+        relpath = migration_name(template).with_suffix('.py')
         mod = relpath.parent
         (settings.FLUENT_MIGRATIONS_PATH / mod).mkdir(parents=True, exist_ok=True)
         for mod in relpath.parents:

--- a/lib/l10n_utils/management/commands/_fluent_recipe.py
+++ b/lib/l10n_utils/management/commands/_fluent_recipe.py
@@ -1,0 +1,218 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import re
+from collections import defaultdict, OrderedDict
+from pathlib import Path
+
+from django.conf import settings
+from django.utils.html import strip_tags
+from django.utils.text import slugify
+
+
+ADD_LANG_RE = re.compile(r'{% add_lang_files (.*?) %}')
+GETTEXT_RE = re.compile(r'\b_\([\'"](?P<string>.+?)[\'"]\)'
+                        r'(\s*\|\s*format\((?P<args>\w.+?)\))?', re.S)
+TRANS_BLOCK_RE = re.compile(r'{%-?\s+trans\s+((?P<args>\w.+?)\s+)?-?%\}\s*'
+                            r'(?P<string>.+?)'
+                            r'\s*{%-?\s+endtrans\s+-?%\}', re.S)
+STR_VARIABLE_RE = re.compile(r'%(?P<var>\(\w+\))?s')
+RECIPE_INTRO = '''\
+from __future__ import absolute_import
+import fluent.syntax.ast as FTL
+from fluent.migrate.helpers import transforms_from
+from fluent.migrate.helpers import VARIABLE_REFERENCE, TERM_REFERENCE
+from fluent.migrate import REPLACE, COPY
+
+'''
+
+RECIPE_SIGNATURE = '''\
+
+def migrate(ctx):
+    """Migrate {}, part {{index}}."""
+
+'''
+
+ADD_TRANSFORMS = '''\
+    ctx.add_transforms(
+        "{ftl_file}",
+        "{ftl_file}",
+        {transforms}
+        )
+'''
+
+SIMPLE_WRAPPER = '''\
+transforms_from("""
+{copies}
+""", {from_path}={from_path})\
+'''
+
+REPLACE_TEMPLATE = '''\
+            FTL.Message(
+                id=FTL.Identifier("{fluent_id}"),
+                value=REPLACE(
+                    {from_path},
+                    "{lang_string}",
+                    {{
+                        "%%": "%",
+{replacements}
+                    }}
+                )
+            ),
+'''
+
+VAR_REPLACE = '''\
+                        "{lit}": VARIABLE_REFERENCE("{var}"),\
+'''
+
+
+class Recipe:
+    def __init__(self, cmd):
+        self.stdout = cmd.stdout
+
+    def handle(self, template):
+        with template.open('r') as tfp:
+            template_str = tfp.read()
+        lang_files = self.get_lang_files(template, template_str)
+        lang_ids = self.get_lang_ids(template_str)
+        ids_for_file = self.get_ids_for_file(lang_ids, lang_files)
+        recipe = RECIPE_INTRO
+        for legacy, variable in lang_files.items():
+            recipe += f'{variable} = "{legacy}"\n'
+        recipe += RECIPE_SIGNATURE.format(template)
+
+        for from_path, ids in ids_for_file.items():
+            transforms = self.get_transforms(template.stem, ids, lang_files[from_path])
+            recipe += ADD_TRANSFORMS.format(
+                ftl_file=from_path.with_suffix('.ftl'),
+                transforms=transforms
+            )
+        self.write_recipe_for(template, recipe)
+
+    def get_lang_files(self, template, template_str):
+        lang_files = []
+        for add_lang in ADD_LANG_RE.finditer(template_str):
+            for p in re.findall(r'"(.*?)"', add_lang.group(1)):
+                f = Path(p).with_suffix('.lang')
+                lang_files.append(f)
+        if not lang_files:
+            lang_files.append(Path(str(template).split('/templates/')[1]).with_suffix('.lang'))
+        return OrderedDict(
+            (f, f.stem.replace('-', '_'))
+            for f in lang_files
+        )
+
+    def get_lang_ids(self, template_str):
+        normalize = re.compile('\n *')
+        found = []
+        found.extend(GETTEXT_RE.finditer(template_str))
+        found.extend(TRANS_BLOCK_RE.finditer(template_str))
+        found.sort(key=lambda m: m.start())
+        return {
+            normalize.sub(' ', m.group('string')): m.groupdict()
+            for m in found
+        }
+
+    def get_ids_for_file(self, lang_ids, lang_files):
+        from compare_locales.parser import getParser
+        parser = getParser('foo.lang')
+        ids_for_file = defaultdict(list)
+        for lf in lang_files.keys():
+            f = settings.LOCALES_PATH / 'en-US' / lf
+            parser.readFile(str(f))
+            mapping = parser.parse()
+            for string_id in lang_ids.keys():
+                if string_id in mapping:
+                    ids_for_file[lf].append(string_id)
+        return ids_for_file
+
+    def get_transforms(self, id_stem, lang_ids, from_path):
+        transforms = ''
+        simple_transforms = []
+        replaces = []
+        for lang_string in lang_ids:
+            fluent_id = self.string_to_ftl_id(id_stem, lang_string)
+            if STR_VARIABLE_RE.search(lang_string):
+                if simple_transforms:
+                    if transforms:
+                        transforms += ' + '
+                    transforms += SIMPLE_WRAPPER.format(
+                        copies='\n'.join(simple_transforms),
+                        from_path=from_path
+                    )
+                    simple_transforms = []
+                replaces.append(self.create_replace(from_path, fluent_id, lang_string))
+            else:
+                if replaces:
+                    if transforms:
+                        transforms += ' + '
+                    transforms += '[\n'
+                    transforms += ''.join(replaces)
+                    transforms += '        ]'
+                    replaces = []
+                escaped_lang_string = lang_string.replace('"', r'\"')
+                simple_transforms.append(f'{fluent_id} = {"{"}COPY({from_path}, "{escaped_lang_string}",){"}"}')
+        if simple_transforms:
+            if transforms:
+                transforms += ' + '
+            transforms += SIMPLE_WRAPPER.format(
+                copies='\n'.join(simple_transforms),
+                from_path=from_path
+            )
+        if replaces:
+            if transforms:
+                transforms += ' + '
+            transforms += '[\n'
+            transforms += ''.join(replaces)
+            transforms += '        ]'
+        return transforms
+
+    def string_to_ftl_id(self, id_stem, string):
+        string = strip_tags(string)
+        slug_parts = slugify(string).split('-')
+        slug = id_stem
+        for part in slug_parts:
+            slug = '-'.join([slug, part])
+            if len(slug) > 30:
+                break
+
+        return slug
+
+    def create_replace(self, from_path, fluent_id, lang_string):
+        replacers = {}
+        for m in STR_VARIABLE_RE.finditer(lang_string):
+            varname = m.group('var')
+            if varname is None:
+                varname = 'missing-var'
+            else:
+                varname = varname[1:-1]
+            if varname not in replacers:
+                replacers[varname] = m.group()
+        replacements = '\n'.join(
+            VAR_REPLACE.format(lit=lit, var=var)
+            for var, lit in replacers.items()
+        )
+        return REPLACE_TEMPLATE.format(
+            fluent_id=fluent_id,
+            from_path=from_path,
+            lang_string=lang_string.replace('"', r'\"'),
+            replacements=replacements
+        )
+
+    def write_recipe_for(self, template, recipe):
+        # Find templates dir to get relative path
+        for parent in template.parents:
+            if parent.name == 'templates':
+                break
+        relpath = template.relative_to(parent).with_suffix('.py')
+        mod = relpath.parent
+        (settings.FLUENT_MIGRATIONS_PATH / mod).mkdir(parents=True, exist_ok=True)
+        for mod in relpath.parents:
+            init = settings.FLUENT_MIGRATIONS_PATH / mod / '__init__.py'
+            if init.is_file():
+                break
+            with init.open('w') as ifd:
+                ifd.write('')
+        with (settings.FLUENT_MIGRATIONS_PATH / relpath).open('w') as rfd:
+            rfd.write(recipe)

--- a/lib/l10n_utils/management/commands/_fluent_templater.py
+++ b/lib/l10n_utils/management/commands/_fluent_templater.py
@@ -36,7 +36,7 @@ class Templater:
 
     def gettext_to_fluent(self, m):
         lang_id = strip_whitespace(m['string'])
-        if not lang_id in self.dependencies:
+        if lang_id not in self.dependencies:
             return m.group()
         args = ''
         if m['args']:
@@ -45,7 +45,7 @@ class Templater:
 
     def trans_to_fluent(self, m):
         lang_id = trans_to_lang(m['string'])
-        if not lang_id in self.dependencies:
+        if lang_id not in self.dependencies:
             return m.group()
         args = ''
         if m['args']:

--- a/lib/l10n_utils/management/commands/_fluent_templater.py
+++ b/lib/l10n_utils/management/commands/_fluent_templater.py
@@ -1,0 +1,47 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from importlib import import_module
+
+from django.conf import settings
+
+from fluent.migrate.context import MergeContext
+
+from ._fluent import (
+    migration_name,
+    GETTEXT_RE,
+)
+
+
+class Templater:
+    def __init__(self, cmd):
+        self.stdout = cmd.stdout
+        self.dependencies = {}
+
+    def handle(self, template):
+        self.dependencies.update(self.get_dependencies(template))
+        with template.open('r') as tfp:
+            template_str = tfp.read()
+        template_str = GETTEXT_RE.sub(self.to_fluent, template_str)
+        outname = template.stem + '_ftl.html'
+        with template.with_name(outname).open('w') as tfp:
+            tfp.write(template_str)
+
+    def get_dependencies(self, template):
+        pkg_name = '.'.join(('',) + migration_name(template).parts)
+        migration = import_module(pkg_name, 'l10n.bedrock_migrations')
+        context = MergeContext(
+            settings.LANGUAGE_CODE, None, settings.LOCALES_PATH / settings.LANGUAGE_CODE
+        )
+        migration.migrate(context)
+        deps = {}
+        for (fluent_file, fluent_id), lang_set in context.dependencies.items():
+            for _, lang_string in lang_set:
+                deps[lang_string] = fluent_id
+        return deps
+
+    def to_fluent(self, m):
+        if not m.group('string') in self.dependencies:
+            return m.group()
+        return f"ftl('{self.dependencies[m.group('string')]}')"

--- a/lib/l10n_utils/management/commands/_fluent_templater.py
+++ b/lib/l10n_utils/management/commands/_fluent_templater.py
@@ -2,14 +2,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from importlib import import_module
-
-from django.conf import settings
-
-from fluent.migrate.context import MergeContext
-
 from ._fluent import (
-    migration_name,
+    get_migration_context,
     GETTEXT_RE,
 )
 
@@ -29,12 +23,7 @@ class Templater:
             tfp.write(template_str)
 
     def get_dependencies(self, template):
-        pkg_name = '.'.join(('',) + migration_name(template).parts)
-        migration = import_module(pkg_name, 'l10n.bedrock_migrations')
-        context = MergeContext(
-            settings.LANGUAGE_CODE, None, settings.LOCALES_PATH / settings.LANGUAGE_CODE
-        )
-        migration.migrate(context)
+        context = get_migration_context(template)
         deps = {}
         for (fluent_file, fluent_id), lang_set in context.dependencies.items():
             for _, lang_string in lang_set:

--- a/lib/l10n_utils/management/commands/fluent.py
+++ b/lib/l10n_utils/management/commands/fluent.py
@@ -21,12 +21,19 @@ class Command(BaseCommand):
             description='Create migration recipe from template'
         )
         recipe_parser.add_argument('template', type=Path)
+        template_parser = subparsers.add_parser(
+            'template',
+            description='Create template and Fluent file with recipe'
+        )
+        template_parser.add_argument('template', type=Path)
 
     def handle(self, subcommand, **kwargs):
         if subcommand in (None, 'help'):
             return self.handle_help(**kwargs)
         if subcommand == 'recipe':
             return self.create_recipe(**kwargs)
+        if subcommand == 'template':
+            return self.create_template(**kwargs)
 
     def handle_help(self, **kwargs):
         self.stdout.write('''\
@@ -36,6 +43,8 @@ To migrate a template from .lang to Fluent, use the subcommands like so
 
 # edit IDs in lib/fluent_migrations/app/some.py
 
+./manage.py fluent template bedrock/app/templates/app/some.html
+
 More documentation on https://bedrock.readthedocs.io/en/latest/fluent-conversion.html.
         ''')
 
@@ -43,3 +52,8 @@ More documentation on https://bedrock.readthedocs.io/en/latest/fluent-conversion
         from ._fluent_recipe import Recipe
         recipe = Recipe(self)
         recipe.handle(template)
+
+    def create_template(self, template, **kwargs):
+        from ._fluent_templater import Templater
+        templater = Templater(self)
+        templater.handle(template)

--- a/lib/l10n_utils/management/commands/fluent.py
+++ b/lib/l10n_utils/management/commands/fluent.py
@@ -16,14 +16,26 @@ class Command(BaseCommand):
             title='subcommand', dest='subcommand'
         )
         subparsers.add_parser('help')
+
         recipe_parser = subparsers.add_parser(
             'recipe',
             description='Create migration recipe from template'
         )
         recipe_parser.add_argument('template', type=Path)
+
+        ftl_parser = subparsers.add_parser(
+            'ftl',
+            description='Create Fluent file with existing recipe'
+        )
+        ftl_parser.add_argument('template', type=Path)
+        ftl_parser.add_argument(
+            'locales', nargs='*', default=['en'], metavar='ab-CD',
+            help='Locale codes to create ftl files for'
+        )
+
         template_parser = subparsers.add_parser(
             'template',
-            description='Create template and Fluent file with recipe'
+            description='Create template_ftl.html file with existing recipe'
         )
         template_parser.add_argument('template', type=Path)
 
@@ -32,6 +44,8 @@ class Command(BaseCommand):
             return self.handle_help(**kwargs)
         if subcommand == 'recipe':
             return self.create_recipe(**kwargs)
+        if subcommand == 'ftl':
+            return self.create_ftl(**kwargs)
         if subcommand == 'template':
             return self.create_template(**kwargs)
 
@@ -44,6 +58,7 @@ To migrate a template from .lang to Fluent, use the subcommands like so
 # edit IDs in lib/fluent_migrations/app/some.py
 
 ./manage.py fluent template bedrock/app/templates/app/some.html
+./manage.py fluent ftl bedrock/app/templates/app/some.html
 
 More documentation on https://bedrock.readthedocs.io/en/latest/fluent-conversion.html.
         ''')
@@ -57,3 +72,9 @@ More documentation on https://bedrock.readthedocs.io/en/latest/fluent-conversion
         from ._fluent_templater import Templater
         templater = Templater(self)
         templater.handle(template)
+
+    def create_ftl(self, template, locales, **kwargs):
+        from ._fluent_ftl import FTLCreator
+        ftl_creator = FTLCreator(self)
+        for locale in locales:
+            ftl_creator.handle(template, locale)

--- a/lib/l10n_utils/management/commands/fluent.py
+++ b/lib/l10n_utils/management/commands/fluent.py
@@ -1,0 +1,45 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from pathlib import Path
+
+from django.core.management.base import BaseCommand, CommandError
+
+
+class Command(BaseCommand):
+    help = 'Convert a template to use Fluent for l10n'
+    requires_system_checks = False
+
+    def add_arguments(self, parser):
+        subparsers = parser.add_subparsers(
+            title='subcommand', dest='subcommand'
+        )
+        subparsers.add_parser('help')
+        recipe_parser = subparsers.add_parser(
+            'recipe',
+            description='Create migration recipe from template'
+        )
+        recipe_parser.add_argument('template', type=Path)
+
+    def handle(self, subcommand, **kwargs):
+        if subcommand in (None, 'help'):
+            return self.handle_help(**kwargs)
+        if subcommand == 'recipe':
+            return self.create_recipe(**kwargs)
+
+    def handle_help(self, **kwargs):
+        self.stdout.write('''\
+To migrate a template from .lang to Fluent, use the subcommands like so
+
+./manage.py fluent recipe bedrock/app/templates/app/some.html
+
+# edit IDs in lib/fluent_migrations/app/some.py
+
+More documentation on https://bedrock.readthedocs.io/en/latest/fluent-conversion.html.
+        ''')
+
+    def create_recipe(self, template, **kwargs):
+        from ._fluent_recipe import Recipe
+        recipe = Recipe(self)
+        recipe.handle(template)

--- a/lib/l10n_utils/management/commands/fluent.py
+++ b/lib/l10n_utils/management/commands/fluent.py
@@ -4,7 +4,7 @@
 
 from pathlib import Path
 
-from django.core.management.base import BaseCommand, CommandError
+from django.core.management.base import BaseCommand
 
 
 class Command(BaseCommand):
@@ -27,7 +27,10 @@ class Command(BaseCommand):
             'ftl',
             description='Create Fluent file with existing recipe'
         )
-        ftl_parser.add_argument('template', type=Path)
+        ftl_parser.add_argument(
+            'recipe_or_template', type=Path,
+            help='Path to the recipe or the template from which the recipe was generated'
+        )
         ftl_parser.add_argument(
             'locales', nargs='*', default=['en'], metavar='ab-CD',
             help='Locale codes to create ftl files for'
@@ -73,8 +76,8 @@ More documentation on https://bedrock.readthedocs.io/en/latest/fluent-conversion
         templater = Templater(self)
         templater.handle(template)
 
-    def create_ftl(self, template, locales, **kwargs):
+    def create_ftl(self, recipe_or_template, locales, **kwargs):
         from ._fluent_ftl import FTLCreator
         ftl_creator = FTLCreator(self)
         for locale in locales:
-            ftl_creator.handle(template, locale)
+            ftl_creator.handle(recipe_or_template, locale)

--- a/lib/l10n_utils/management/commands/fluent.py
+++ b/lib/l10n_utils/management/commands/fluent.py
@@ -3,6 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 from pathlib import Path
+import textwrap
 
 from django.core.management.base import BaseCommand
 
@@ -43,28 +44,27 @@ class Command(BaseCommand):
         template_parser.add_argument('template', type=Path)
 
     def handle(self, subcommand, **kwargs):
-        if subcommand in (None, 'help'):
-            return self.handle_help(**kwargs)
         if subcommand == 'recipe':
             return self.create_recipe(**kwargs)
         if subcommand == 'ftl':
             return self.create_ftl(**kwargs)
         if subcommand == 'template':
             return self.create_template(**kwargs)
+        return self.handle_help(**kwargs)
 
     def handle_help(self, **kwargs):
-        self.stdout.write('''\
-To migrate a template from .lang to Fluent, use the subcommands like so
+        self.stdout.write(textwrap.dedent('''\
+            To migrate a template from .lang to Fluent, use the subcommands like so
 
-./manage.py fluent recipe bedrock/app/templates/app/some.html
+            ./manage.py fluent recipe bedrock/app/templates/app/some.html
 
-# edit IDs in lib/fluent_migrations/app/some.py
+            # edit IDs in lib/fluent_migrations/app/some.py
 
-./manage.py fluent template bedrock/app/templates/app/some.html
-./manage.py fluent ftl bedrock/app/templates/app/some.html
+            ./manage.py fluent template bedrock/app/templates/app/some.html
+            ./manage.py fluent ftl bedrock/app/templates/app/some.html
 
-More documentation on https://bedrock.readthedocs.io/en/latest/fluent-conversion.html.
-        ''')
+            More documentation on https://bedrock.readthedocs.io/en/latest/fluent-conversion.html.
+        '''))
 
     def create_recipe(self, template, **kwargs):
         from ._fluent_recipe import Recipe

--- a/lib/l10n_utils/management/commands/fluent.py
+++ b/lib/l10n_utils/management/commands/fluent.py
@@ -43,6 +43,15 @@ class Command(BaseCommand):
         )
         template_parser.add_argument('template', type=Path)
 
+        activation_parser = subparsers.add_parser(
+            'activation',
+            description='Port activation data from .lang for a recipe/template'
+        )
+        activation_parser.add_argument(
+            'recipe_or_template', type=Path,
+            help='Path to the recipe or the template from which the recipe was generated'
+        )
+
     def handle(self, subcommand, **kwargs):
         if subcommand == 'recipe':
             return self.create_recipe(**kwargs)
@@ -50,6 +59,8 @@ class Command(BaseCommand):
             return self.create_ftl(**kwargs)
         if subcommand == 'template':
             return self.create_template(**kwargs)
+        if subcommand == 'activation':
+            return self.activation(**kwargs)
         return self.handle_help(**kwargs)
 
     def handle_help(self, **kwargs):
@@ -81,3 +92,8 @@ class Command(BaseCommand):
         ftl_creator = FTLCreator(self)
         for locale in locales:
             ftl_creator.handle(recipe_or_template, locale)
+
+    def activation(self, recipe_or_template, **kwargs):
+        from ._fluent_activation import Activation
+        activation = Activation(self)
+        activation.handle(recipe_or_template)

--- a/lib/l10n_utils/tests/test_migration.py
+++ b/lib/l10n_utils/tests/test_migration.py
@@ -1,0 +1,29 @@
+# coding=utf-8
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from django.test import TestCase
+
+from lib.l10n_utils.management.commands import _fluent
+
+
+class TestTrans(TestCase):
+    def test_trans(self):
+        input = '''
+        {% trans %}
+        Just some text
+        {% endtrans %}
+
+        {% trans one='value' , two=url('privacy.notices.firefox') %}
+        There's {{one}} and
+        {{ two  }} things to check here.
+        {%  endtrans  %}
+        '''
+        lang_strings = []
+        for trans_match in _fluent.TRANS_BLOCK_RE.finditer(input):
+            lang_strings.append(_fluent.trans_to_lang(trans_match['string']))
+        assert len(lang_strings) == 2
+        assert lang_strings[0] == 'Just some text'
+        assert lang_strings[1] == "There's %(one)s and %(two)s things to check here."

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,5 +1,7 @@
 -r base.txt
 
+-r migration.txt
+
 Pygments==2.2.0 \
     --hash=sha256:78f3f434bcc5d6ee09020f92ba487f95ba50f1e3ef83ae96b9d5ffa1bab25c5d \
     --hash=sha256:dbae1046def0efb574852fab9e90209b23f556367b5a320c0bcb871c77c3e8cc

--- a/requirements/migration.txt
+++ b/requirements/migration.txt
@@ -1,0 +1,14 @@
+cl-ext.lang==0.1.0 \
+    --hash=sha256:90b94aaee4afecbf2a9be3cd65656940f38edea3ddde14b93a02a9e1ee5d1f72 \
+    --hash=sha256:662fcccc1ff77063dd9d6bad770c26d1345cf4cf01e679eab136e80f3ec2935c
+compare-locales==7.4.0 \
+    --hash=sha256:4ae77d39373b06c201c97bf48e40412fecc8e1c4ebb3c8c21948d5168e6eef30 \
+    --hash=sha256:27146925202beb995172862eab18314dc442fc10026d30f0c42be58d57dd0b8d
+fluent.migrate==0.7.1 \
+    --hash=sha256:6a1ebb5df97d2590e35b6fb8d665d6d2e20aac3e6962706854baefb7ac0002a0 \
+    --hash=sha256:00e0fc0bbd1b3573dee174134fad6286a9212619c709f5a91cd6e528b4e91f6e
+parsimonious==0.8.1 \
+    --hash=sha256:3add338892d580e0cb3b1a39e4a1b427ff9f687858fdd61097053742391a9f6b
+pytoml==0.1.21 \
+   --hash=sha256:57a21e6347049f73bfb62011ff34cd72774c031b9828cb628a752225136dfc33 \
+   --hash=sha256:8eecf7c8d0adcff3b375b09fe403407aa9b645c499e5ab8cac670ac4a35f61e7

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,6 +16,7 @@ exclude=
     product_details_json
     community_data
     www_config
+    lib/fluent_migrations
 
 [tool:pytest]
 # Hiding warnings for now, the noise is making test fixes harder


### PR DESCRIPTION
## Description

This uses `fluent.migrate` behind the scenes to convert templates to Fluent. The rough overview of the new flow would be

```bash
./manage.py fluent recipe path/to/template.html
./manage.py fluent ftl path/to/template.html
./manage.py fluent template path/to/template.html
```

with manual edits after the `recipe` step to create good IDs, and after the `ftl` step to create good comments.

## Issue / Bugzilla link

#8045 is probably the core of this, but also #7877 

## Testing

This requires a few branches on the l10n libraries side, but I managed to migrate the `bedrock/firefox/templates/firefox/new/scene1.html` template, with `en` and localized Fluent files.

The docs are not yet where I'd like them to be, but I wanted to put this out there already.

## Todo
* [x] Finalize `.lang` patch in `compare-locales`. Has a review already, just needs follow-ups.
* [x] trans blocks
* [x] Limit change scope in `fluent.migrate`, get that reviewed and published.
* [x] Probably create an extra requirements file to use when creating and running migrations.

## Follow-ups
* Activation logic
* Cleanup