### PR TITLE
Show default /whatsnew page for 70.0 > 70.0.2 update (Fixes #8091)

### DIFF
--- a/bedrock/firefox/tests/test_base.py
+++ b/bedrock/firefox/tests/test_base.py
@@ -398,6 +398,14 @@ class TestWhatsNew(TestCase):
         template = render_mock.call_args[0][1]
         assert template == ['firefox/whatsnew/index.html']
 
+    def test_fx_70_0_2(self, render_mock):
+        """Should use default whatsnew template for 70.0.2 when updating from 70.0"""
+        req = self.rf.get('/firefox/whatsnew/?oldversion=70.0')
+        req.locale = 'en-US'
+        self.view(req, version='70.0.2')
+        template = render_mock.call_args[0][1]
+        assert template == ['firefox/whatsnew/index.html']
+
     # end 70.0 whatsnew tests
 
 

--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -494,6 +494,15 @@ def show_57_dev_firstrun(version):
     return version >= Version('57.0')
 
 
+def show_70_0_2_whatsnew(oldversion):
+    try:
+        oldversion = Version(oldversion)
+    except ValueError:
+        return False
+
+    return oldversion >= Version('70.0')
+
+
 def redirect_old_firstrun(version):
     try:
         version = Version(version)
@@ -602,6 +611,8 @@ class WhatsnewView(l10n_utils.LangFilesMixin, TemplateView):
             template = 'firefox/whatsnew/index.html'
         elif locale == 'id':
             template = 'firefox/whatsnew/index-lite.id.html'
+        elif version == '70.0.2' and show_70_0_2_whatsnew(oldversion):
+            template = 'firefox/whatsnew/index.html'
         elif version.startswith('70.'):
             if locale in ['en-US', 'en-CA', 'en-GB']:
                 template = 'firefox/whatsnew/whatsnew-fx70-en.html'


### PR DESCRIPTION
## Description
Shows the default /whatsnew page for users updating from 70.0 -> 70.0.2.

## Issue / Bugzilla link
#8091

## Testing
- [x] Should show 70.0 WNP: http://127.0.0.1:8000/en-US/firefox/70.0.2/whatsnew/all/?oldversion=69.0
- [x] Should show default WNP: http://127.0.0.1:8000/en-US/firefox/70.0.2/whatsnew/all/?oldversion=70.0
- [x] Should show default WNP: http://127.0.0.1:8000/en-US/firefox/70.0.2/whatsnew/all/?oldversion=70.0.1