### PR TITLE
Order mission.ftl per template, add comments (Fixes #7821)

### DIFF
--- a/l10n/en/mozorg/mission.ftl
+++ b/l10n/en/mozorg/mission.ftl
@@ -1,32 +1,38 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 ### URL: https://www-dev.allizom.org/mission/
 
+mission-were-building-a-better-internet = We’re building a better Internet
+
+mission-our-mission-is-to-ensure-the-internet = Our mission is to ensure the Internet is a global public resource, open and accessible to all. An Internet that truly puts people first, where individuals can shape their own experience and are empowered, safe and independent.
+
+# Only shown if mission-our-mission-is-to-ensure-the-internet is not translated
+mission-our-mission-is-to-promote-openness = Our mission is to promote openness, innovation & opportunity on the Web.
+
+mission-at-mozilla-were-a-global-community = At Mozilla, we’re a global community of technologists, thinkers and builders working together to keep the Internet alive and accessible, so people worldwide can be informed contributors and creators of the Web.
+
+mission-we-believe-this-act-of-human-collaboration = We believe this act of human collaboration across an open platform is essential to individual growth and our collective future.
+
+# Variables:
+#   $url (url) - link to https://www.mozilla.org/about/manifesto/
 mission-read-the-mozilla-manifesto-to-learn = Read the <a href="{ $url }">Mozilla Manifesto</a> to learn even more about the values and principles that guide the pursuit of our mission.
 
 mission-watch-the-video-above-to-learn-more = Watch the video above to learn more about who we are, where we came from and how we’re making the Web better for you.
 
-mission-at-mozilla-were-a-global-community = At Mozilla, we’re a global community of technologists, thinkers and builders working together to keep the Internet alive and accessible, so people worldwide can be informed contributors and creators of the Web.
-
-mission-topics-include-support-products = Topics include support, products, and technologies
+mission-get-involved = Get involved
 
 mission-volunteer-opportunities-in-a-number = Volunteer opportunities in a number of different areas
 
-mission-we-believe-this-act-of-human-collaboration = We believe this act of human collaboration across an open platform is essential to individual growth and our collective future.
-
-mission-were-building-a-better-internet = We’re building a better Internet
-
-mission-our-structure-organization-and-the = Our structure, organization, and the broader Mozilla community
+mission-history = History
 
 mission-where-we-come-from-and-how-we-got = Where we come from and how we got to where we are
 
-mission-get-involved = Get involved
-
 mission-forums = Forums
 
-mission-our-mission-is-to-ensure-the-internet = Our mission is to ensure the Internet is a global public resource, open and accessible to all. An Internet that truly puts people first, where individuals can shape their own experience and are empowered, safe and independent.
-
-mission-our-mission-is-to-promote-openness = Our mission is to promote openness, innovation & opportunity on the Web.
-
-mission-history = History
+mission-topics-include-support-products = Topics include support, products, and technologies
 
 mission-governance = Governance
 
+mission-our-structure-organization-and-the = Our structure, organization, and the broader Mozilla community


### PR DESCRIPTION
## Description

Order `mission.ftl`, and add some comments.

I left the IDs alone, though I'm not sure how easy they're to maintain.

I'm still not sure what to do with the second paragraph. The first paragraph is two sentences and one string, the second paragraph is two sentences and two strings. CC @gueroJeff and @peiying2  for input.

We have at least these options:

* adjust the IDs to indicate that they're one paragraph
* and/or put them on one group comment
* or join the two strings into one (needs #8087 , but then is fairly trivial to execute)

## Issue / Bugzilla link

#7821 

## Testing
