### PR TITLE
[#8033] WNP70 experiment fixes

### DIFF
--- a/bedrock/firefox/templates/firefox/whatsnew/exp/whatsnew-fx70-0.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/exp/whatsnew-fx70-0.html
@@ -6,3 +6,29 @@
 
 {% set _entrypoint_experiment = 'whatsnew70' %}
 {% set _entrypoint_variation = '0' %}
+
+{% block monitor_cta %}
+  <div class="show-fxa-supported-signed-out show-fxa-default show-fxa-not-fx">
+    {{ monitor_button(
+      entrypoint=_entrypoint,
+      entrypoint_experiment=_entrypoint_experiment,
+      entrypoint_variation=_entrypoint_variation,
+      cta_type='FxA-Monitor',
+      cta_position='Primary',
+      utm_campaign=_utm_campaign,
+      button_text=_('Sign Up for Monitor')
+    ) }}
+  </div>
+
+  <div class="show-fxa-supported-signed-in">
+    {{ monitor_button(
+      entrypoint=_entrypoint,
+      entrypoint_experiment=_entrypoint_experiment,
+      entrypoint_variation=_entrypoint_variation,
+      cta_type='FxA-Monitor',
+      cta_position='Primary',
+      utm_campaign=_utm_campaign,
+      button_text=_('Sign In')
+    ) }}
+  </div>
+{% endblock %}

--- a/bedrock/firefox/templates/firefox/whatsnew/exp/whatsnew-fx70-2.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/exp/whatsnew-fx70-2.html
@@ -38,7 +38,7 @@
       <div class="mzp-c-emphasis-box">
         <img class="c-emphasis-box-logo" src="{{ static('img/logos/firefox/logo-monitor.svg') }}" alt="">
         <h2 class="c-emphasis-box-title">{{ _('You have nothing to hide. And so much to protect.') }}</h2>
-        <p>{{ _('Like your SSN, credit card, mom’s maiden name — all the sensitive account info that can get into the wrong hands during a data breach. Let Firefox Monitor be your lookout for breaches, so you can keep your info safe.') }}</p>
+        <p>{{ _('Like your <abbr title="Social Security Number">SSN</abbr>, credit card, mom’s maiden name — all the sensitive account info that can get into the wrong hands during a data breach. Let Firefox Monitor be your lookout for breaches, so you can keep your info safe.') }}</p>
 
         <div class="show-fxa-supported-signed-out show-fxa-default show-fxa-not-fx">
           {{ monitor_button(

--- a/bedrock/firefox/templates/firefox/whatsnew/exp/whatsnew-fx70-2.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/exp/whatsnew-fx70-2.html
@@ -38,7 +38,7 @@
       <div class="mzp-c-emphasis-box">
         <img class="c-emphasis-box-logo" src="{{ static('img/logos/firefox/logo-monitor.svg') }}" alt="">
         <h2 class="c-emphasis-box-title">{{ _('You have nothing to hide. And so much to protect.') }}</h2>
-        <p>{{ _('Like your SSN, credit card info, mom’s maiden name — all the sensitive account info that can get into the wrong hands during a data breach. Let Firefox Monitor be your lookout for breaches, so you can keep your info safe.') }}</p>
+        <p>{{ _('Like your SSN, credit card, mom’s maiden name — all the sensitive account info that can get into the wrong hands during a data breach. Let Firefox Monitor be your lookout for breaches, so you can keep your info safe.') }}</p>
 
         <div class="show-fxa-supported-signed-out show-fxa-default show-fxa-not-fx">
           {{ monitor_button(

--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx70-en.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx70-en.html
@@ -24,7 +24,6 @@
 
 {% set _entrypoint = 'mozilla.org-whatsnew70' %}
 {% set _utm_campaign = 'whatsnew70' %}
-{% set _entrypoint_experiment = None %}
 
 {% block site_header %}{% endblock %}
 

--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx70-en.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx70-en.html
@@ -48,11 +48,10 @@
         </h2>
         <p>{{ _('Use Firefox Monitor to see if your info was compromised in another company’s data breach — and automatically get alerts when your info might be at risk.') }}</p>
 
+      {% block monitor_cta %}
         <div class="show-fxa-supported-signed-out show-fxa-default show-fxa-not-fx">
           {{ monitor_button(
             entrypoint=_entrypoint,
-            entrypoint_experiment=_entrypoint_experiment,
-            entrypoint_variation=_entrypoint_variation,
             cta_type='FxA-Monitor',
             cta_position='Primary',
             utm_campaign=_utm_campaign,
@@ -63,14 +62,13 @@
         <div class="show-fxa-supported-signed-in">
           {{ monitor_button(
             entrypoint=_entrypoint,
-            entrypoint_experiment=_entrypoint_experiment,
-            entrypoint_variation=_entrypoint_variation,
             cta_type='FxA-Monitor',
             cta_position='Primary',
             utm_campaign=_utm_campaign,
             button_text=_('Sign In')
           ) }}
         </div>
+      {% endblock %}
       </div>
     </div>
   </section>

--- a/media/css/firefox/whatsnew/whatsnew-70-experiment.scss
+++ b/media/css/firefox/whatsnew/whatsnew-70-experiment.scss
@@ -96,6 +96,10 @@ $image-path: '/media/protocol/img';
         color: $color-off-black;
     }
 
+    abbr {
+        text-decoration: none;
+    }
+
     .c-emphasis-box-logo {
         display: block;
         margin: 0 auto $spacing-lg;


### PR DESCRIPTION
## Description
Two minor fixes:

- Remove “info” on v2
- Remove `_entrypoint_experiment = None` from v0 parent template

## Testing

When loading v=0, that `_entrypoint_experiment = None` in the parent template was nullifying the value it should have gotten from the child template. So we need to make sure both the `entrypoint_experiment` and `entrypoint_variation` params are being added to the CTA button on v=0 (the control) but NOT being added on the regular, non-experiment page (with no ?v= param).