### PR TITLE
Make download link on /firefox locale neutral (Fixes #7982)

### DIFF
--- a/bedrock/exp/templates/exp/firefox/index.de.html
+++ b/bedrock/exp/templates/exp/firefox/index.de.html
@@ -101,6 +101,7 @@
               <li class="mzp-c-menu-list-item"><a href="{{ url('firefox.new') }}">Browser downloaden</a></li>
             <![endif]-->
             <!--[if !IE]><!-->
+              {# Download link should be locale neutral see issue 7982 #}
               <li class="mzp-c-menu-list-item"><a href="/firefox/download/thanks/" data-link-type="Desktop" data-download-os="Desktop" data-download-version="standard">Desktop</a></li>
             <!--<![endif]-->
             <li class="mzp-c-menu-list-item"><a href="{{ firefox_adjust_url('android', 'firefox_home') }}" rel="external noopener" data-link-type="download" data-display-name="Android" data-download-version="android" data-download-os="Android"> Android</a></li>

--- a/bedrock/exp/templates/exp/firefox/index.html
+++ b/bedrock/exp/templates/exp/firefox/index.html
@@ -110,6 +110,7 @@
               <li class="mzp-c-menu-list-item"><a href="{{ url('firefox.new') }}">Download the browser</a></li>
             <![endif]-->
             <!--[if !IE]><!-->
+              {# Download link should be locale neutral see issue 7982 #}
               <li class="mzp-c-menu-list-item"><a href="/firefox/download/thanks/" data-link-type="Desktop" data-download-os="Desktop" data-download-version="standard">Desktop</a></li>
             <!--<![endif]-->
             <li class="mzp-c-menu-list-item"><a href="{{ firefox_adjust_url('android', 'firefox_home') }}" rel="external noopener" data-link-type="download" data-display-name="Android" data-download-version="android" data-download-os="Android"> Android</a></li>

--- a/bedrock/firefox/templates/firefox/home/index-master.html
+++ b/bedrock/firefox/templates/firefox/home/index-master.html
@@ -142,7 +142,8 @@
               <li class="mzp-c-menu-list-item"><a href="{{ url('firefox.new') }}">{{ get_desktop }}</a></li>
             <![endif]-->
             <!--[if !IE]><!-->
-              <li class="mzp-c-menu-list-item"><a href="{{ url('firefox.download.thanks') }}" data-link-type="Desktop" data-download-os="Desktop" data-download-version="standard">{{ get_desktop }}</a></li>
+              {# Download link should be locale neutral see issue 7982 #}
+              <li class="mzp-c-menu-list-item"><a href="/firefox/download/thanks/" data-link-type="Desktop" data-download-os="Desktop" data-download-version="standard">{{ get_desktop }}</a></li>
             <!--<![endif]-->
             <li class="mzp-c-menu-list-item"><a href="{{ firefox_adjust_url('android', 'firefox_home') }}" rel="external noopener" data-link-type="download" data-display-name="Android" data-download-version="android" data-download-os="Android"> {{ get_android }}</a></li>
             <li class="mzp-c-menu-list-item"><a href="{{ firefox_adjust_url('ios', 'firefox_home') }}" rel="external noopener" data-link-type="download" data-display-name="iOS" data-download-version="ios" data-download-os="iOS">{{ get_ios }}</a></li>


### PR DESCRIPTION
## Description
Removes the locale from the download link on the new `/firefox` page, so that people can get their preffered build even though the page may not be available in their language.

## Issue / Bugzilla link
#7982

## Testing
- [ ] Link should point to `/firefox/download/thanks/` instead of `/%LOCALE%/firefox/download/thanks/`