### PR TITLE
Fix FxA auth links for non-Firefox browsers in nav and footer (Fixes #8044)

### DIFF
--- a/bedrock/base/templates/includes/protocol/footer/firefox.html
+++ b/bedrock/base/templates/includes/protocol/footer/firefox.html
@@ -46,8 +46,8 @@
             {{ _('Join') }}
           </h5>
           <ul class="mzp-c-footer-list">
-            <li><a {{ fxa_link_fragment(entrypoint='mozilla.org-firefoxfooter', action='signup', utm_campaign='footer', utm_content='join-sign-up') }} class="js-fxa-cta-link" rel="external noopener"  data-link-type="footer" data-link-name="Sign Up">{{ _('Sign Up') }}</a></li>
-            <li><a {{ fxa_link_fragment(entrypoint='mozilla.org-firefoxfooter', action='signin', utm_campaign='footer', utm_content='join-sign-in') }} class="js-fxa-cta-link" rel="external noopener"  data-link-type="footer" data-link-name="Sign In">{{ _('Sign In') }}</a></li>
+            <li class="fxa-signin"><a {{ fxa_link_fragment(entrypoint='mozilla.org-firefoxfooter', action='signup', utm_campaign='footer', utm_content='join-sign-up') }} class="js-fxa-cta-link" rel="external noopener"  data-link-type="footer" data-link-name="Sign Up">{{ _('Sign Up') }}</a></li>
+            <li class="fxa-signin"><a {{ fxa_link_fragment(entrypoint='mozilla.org-firefoxfooter', action='signin', utm_campaign='footer', utm_content='join-sign-in') }} class="js-fxa-cta-link" rel="external noopener"  data-link-type="footer" data-link-name="Sign In">{{ _('Sign In') }}</a></li>
             <li><a href="{{ url('firefox.accounts') }}" data-link-type="footer" data-link-name="Benefits">{{ _('Benefits') }}</a></li>
           </ul>
         </section>

--- a/bedrock/base/templates/includes/protocol/navigation/menu-firefox/join.html
+++ b/bedrock/base/templates/includes/protocol/navigation/menu-firefox/join.html
@@ -19,8 +19,8 @@
                 <p class="mzp-c-menu-item-desc">{{ _('Access all of Firefox with a single login — and get more from every product when you do.') }}</p>
               </a>
               <ul class="mzp-c-menu-item-list">
-                <li><a {{ fxa_link_fragment(entrypoint='mozilla.org-firefoxnav', action='signin', utm_campaign='nav', utm_content='join-sign-in') }} class="js-fxa-cta-link" rel="external noopener" data-link-name="Accounts Sign In" data-link-type="nav" data-link-position="subnav" data-link-group="browsers">{{ _('Sign In') }}</a></li>
-                <li><a {{ fxa_link_fragment(entrypoint='mozilla.org-firefoxnav', action='signup', utm_campaign='nav', utm_content='join-sign-up') }} class="js-fxa-cta-link" rel="external noopener" data-link-name="Accounts Sign Up" data-link-type="nav" data-link-position="subnav" data-link-group="browsers">{{ _('Sign Up') }}</a></li>
+                <li class="fxa-signin"><a {{ fxa_link_fragment(entrypoint='mozilla.org-firefoxnav', action='signin', utm_campaign='nav', utm_content='join-sign-in') }} class="js-fxa-cta-link" rel="external noopener" data-link-name="Accounts Sign In" data-link-type="nav" data-link-position="subnav" data-link-group="browsers">{{ _('Sign In') }}</a></li>
+                <li class="fxa-signin"><a {{ fxa_link_fragment(entrypoint='mozilla.org-firefoxnav', action='signup', utm_campaign='nav', utm_content='join-sign-up') }} class="js-fxa-cta-link" rel="external noopener" data-link-name="Accounts Sign Up" data-link-type="nav" data-link-position="subnav" data-link-group="browsers">{{ _('Sign Up') }}</a></li>
                 <li><a href="{{ url('firefox.accounts') }}" data-link-name="Benefits" data-link-type="nav" data-link-position="subnav" data-link-group="browsers">{{ _('Benefits') }}</a></li>
               </ul>
             </section>

--- a/media/js/base/mozilla-fxa-sign-in-link.js
+++ b/media/js/base/mozilla-fxa-sign-in-link.js
@@ -5,9 +5,6 @@
 (function() {
     'use strict';
 
-    var fxaSigninLink = document.querySelector('.fxa-signin a');
-    var fxaSigninURI = fxaSigninLink.href;
-
     // Remove a given paramater from a URL query string
     // Taken from https://stackoverflow.com/questions/16941104/remove-a-parameter-to-the-url-with-javascript
     function removeParam(key, sourceURL) {
@@ -31,14 +28,23 @@
 
     // Sync is Firefox only so remove the Sync params for non-Firefoxes
     if (!Mozilla.Client.isFirefox) {
-        // First remove the context param
-        var revisedFxaSigninURI = removeParam('context', fxaSigninURI);
+        var fxaSigninLink = document.querySelectorAll('.fxa-signin > a');
+        var fxaSigninURI;
+        var revisedFxaSigninURI;
+        var finalFxaSigninURI;
 
-        // Then remove the service param
-        var finalFxaSigninURI = removeParam('service', revisedFxaSigninURI);
+        for (var i = 0; i < fxaSigninLink.length; i++) {
+            fxaSigninURI = fxaSigninLink[i].href;
 
-        // Set the link
-        fxaSigninLink.href = finalFxaSigninURI;
+            // First remove the context param
+            revisedFxaSigninURI = removeParam('context', fxaSigninURI);
+
+            // Then remove the service param
+            finalFxaSigninURI = removeParam('service', revisedFxaSigninURI);
+
+            // Set the link
+            fxaSigninLink[i].href = finalFxaSigninURI;
+        }
     }
 })();
 

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -1389,7 +1389,6 @@
         "js/base/mozilla-fxa.js",
         "js/base/mozilla-fxa-init.js",
         "js/base/mozilla-fxa-form.js",
-        "js/base/mozilla-fxa-sign-in-link.js",
         "js/base/mozilla-fxa-product-button.js",
         "js/firefox/accounts-2019.js"
       ],
@@ -1400,7 +1399,6 @@
         "js/base/mozilla-fxa.js",
         "js/base/mozilla-fxa-init.js",
         "js/base/mozilla-fxa-form.js",
-        "js/base/mozilla-fxa-sign-in-link.js",
         "js/base/mozilla-fxa-product-button.js",
         "js/exp/firefox/accounts-2019.js"
       ],
@@ -1493,7 +1491,6 @@
         "js/base/uitour-lib.js",
         "js/base/mozilla-fxa-form.js",
         "js/base/mozilla-fxa-form-init.js",
-        "js/base/mozilla-fxa-sign-in-link.js",
         "js/firefox/privacy/products.js"
       ],
       "name": "firefox-privacy-products"
@@ -1528,6 +1525,7 @@
         "js/base/core-datalayer.js",
         "js/base/core-datalayer-init.js",
         "js/base/search-params.js",
+        "js/base/mozilla-fxa-sign-in-link.js",
         "js/base/fxa-utm-referral.js",
         "js/base/fxa-utm-referral-init.js"
       ],
@@ -1553,6 +1551,7 @@
         "js/base/core-datalayer.js",
         "js/base/core-datalayer-init.js",
         "js/base/search-params.js",
+        "js/base/mozilla-fxa-sign-in-link.js",
         "js/base/fxa-utm-referral.js",
         "js/base/fxa-utm-referral-init.js"
       ],
@@ -1577,7 +1576,9 @@
         "js/base/core-datalayer.js",
         "js/base/core-datalayer-init.js",
         "js/base/search-params.js",
-        "js/base/fxa-utm-referral.js"
+        "js/base/mozilla-fxa-sign-in-link.js",
+        "js/base/fxa-utm-referral.js",
+        "js/base/fxa-utm-referral-init.js"
       ],
       "name": "common-protocol-no-jquery"
     },


### PR DESCRIPTION
## Description
- Moves `mozilla-fxa-sign-in-link.js` into the common JS bundles

## Issue / Bugzilla link
#8044

## Testing
- [x] Auth via the "Sign Up" and "Sign In" links in the Firefox navigation / footer in a non-Firefox browser, should now take people into the regular account sign up / sign in flow.
- [x] Following the same links from a Firefox browser should take people into the Firefox Sync flow.