### PR TITLE
Fix get_default_gateway_linux()

### DIFF
--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -1401,6 +1401,7 @@ def get_default_gateway_linux():
                     continue
 
                 return socket.inet_ntoa(struct.pack("<L", int(fields[2], 16)))
+        return 'localhost'
     except IOError:
         return 'localhost'
 


### PR DESCRIPTION
## Description
Returns 'localhost' if a gateway is not found in /proc/net/route.

## Issue / Bugzilla link
#8103 

## Testing

- [ ] A default gateway should be returned if an IOError does not occur and if one is not found in `/proc/net/route`