### PR TITLE
[#8033] Fix experiment fetch params

### DIFF
--- a/media/js/base/mozilla-monitor-button.js
+++ b/media/js/base/mozilla-monitor-button.js
@@ -57,11 +57,11 @@ if (typeof window.Mozilla === 'undefined') {
         }
 
         if (params.entrypoint_experiment) {
-            destURL += '&entrypoint_experiment' + params.entrypoint_experiment;
+            destURL += '&entrypoint_experiment=' + params.entrypoint_experiment;
         }
 
         if (params.entrypoint_variation) {
-            destURL += '&entrypoint_variation' + params.entrypoint_variation;
+            destURL += '&entrypoint_variation=' + params.entrypoint_variation;
         }
 
         fetch(destURL).then(function(resp) {


### PR DESCRIPTION
## Description
The new parameters being included with the fetch were missing their `=` resulting in a malformed URL (not causing an error, just those params were being ignored by FxA). My bad.

## Testing
Several variants use this script:

http://localhost:8000/en-US/firefox/70.0/whatsnew/all/?v=1
http://localhost:8000/en-US/firefox/70.0/whatsnew/all/?v=2
http://localhost:8000/en-US/firefox/70.0/whatsnew/all/?v=5
http://localhost:8000/en-US/firefox/70.0/whatsnew/all/?v=6
http://localhost:8000/en-US/firefox/70.0/whatsnew/all/?v=7

Check the network request in dev tools. 

Before (no `=` on last two params): `metrics-flow?entrypoint=mozilla.org-whatsnew70&form_type=button&utm_source=mozilla.org-whatsnew70&utm_campaign=whatsnew70&utm_content=top-cta&entrypoint_experimentwhatsnew70&entrypoint_variation7`

It should be:
`metrics-flow?entrypoint=mozilla.org-whatsnew70&form_type=button&utm_source=mozilla.org-whatsnew70&utm_campaign=whatsnew70&utm_content=top-cta&entrypoint_experiment=whatsnew70&entrypoint_variation=7`
