### PR TITLE
Pass utm params from upstream referrals on fxa_email_form (Fixes #8001)

### DIFF
--- a/media/js/base/mozilla-fxa-product-button.js
+++ b/media/js/base/mozilla-fxa-product-button.js
@@ -37,7 +37,7 @@ if (typeof window.Mozilla === 'undefined') {
 
         var destURL = buttons[0].getAttribute('data-action') + 'metrics-flow';
 
-        // collect values from monitor button
+        // collect values from Fxa product button
         var params = window._SearchParams.queryStringToObject(buttonURLParams);
 
         // add required params to the token fetch request


### PR DESCRIPTION
## Description
Refactors `mozilla-fxa-form.js` to check for utm parameters on the url before applying it's own.

## Issue / Bugzilla link
#8001

## Testing

- [x] Should apply url utm parameter values to corresponding hidden input field values if present.
- [x] If there are no utm parameters on the url, it's own values are passed.
- [x] utm parameters are validated. 

- http://localhost:8000/en-US/firefox/accounts/?utm_campaign=firstrun&utm_medium=referral&utm_source=activity-stream&utm_term=trailhead-join

![Screen Shot 2019-11-11 at 3 17 25 PM](https://user-images.githubusercontent.com/30483988/68628872-b49cc580-0496-11ea-9cdc-4c2769da8e8b.png)

- http://localhost:8000/en-US/firefox/accounts/

![Screen Shot 2019-11-11 at 3 20 11 PM](https://user-images.githubusercontent.com/30483988/68628897-cf6f3a00-0496-11ea-84e9-fc7032e531aa.png)

