### PR TITLE
Removed duplicate logo on /firefox/accounts

### DIFF
--- a/media/css/exp/firefox/accounts-2019.scss
+++ b/media/css/exp/firefox/accounts-2019.scss
@@ -25,8 +25,6 @@
 
     .c-accounts-hero-title {
         @include text-display-lg;
-        background: transparent url('/media/protocol/img/logos/firefox/logo-word-hor.svg') center top no-repeat;
-        @include background-size(150px, 48px);
         margin-bottom: $spacing-xl;
         padding-top: (60px + $spacing-2xl);
 

--- a/media/css/firefox/accounts-2019.scss
+++ b/media/css/firefox/accounts-2019.scss
@@ -25,8 +25,6 @@
 
     .c-accounts-hero-title {
         @include text-display-lg;
-        background: transparent url('/media/protocol/img/logos/firefox/logo-word-hor.svg') center top no-repeat;
-        @include background-size(150px, 48px);
         margin-bottom: $spacing-xl;
         padding-top: (60px + $spacing-2xl);
 


### PR DESCRIPTION
## Description
There was a duplicate logo above headline
## Issue / Bugzilla link
Fixes #8118 
## Testing
