### PR TITLE
[#8108] Use white logo on legacy whatsnew

### DIFF
--- a/bedrock/firefox/templates/firefox/whatsnew/index.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/index.html
@@ -32,7 +32,7 @@
 <main class="content-wrapper mzp-t-firefox">
   <header class="c-page-header main-header">
     <div class="mzp-l-content c-page-header-inner">
-      <img src="{{ static('protocol/img/logos/mozilla/black.svg') }}"  alt="Mozilla" width="78" height="22" class="c-page-header-logo-moz">
+      <img src="{{ static('protocol/img/logos/mozilla/white.svg') }}"  alt="Mozilla" width="78" height="22" class="c-page-header-logo-moz">
       <div class="mzp-c-notification-bar mzp-t-success">
         <p>{{ _('Your Firefox is up to date.') }}</p>
       </div>


### PR DESCRIPTION
## Description
The header background was changed in #8119 but it still uses the black Mozilla logo. This switches to the white one in keeping with brand guidelines.

## Issue / Bugzilla link
#8108 