### PR TITLE
[fix #8135] Fx privacy hub, add space to body class

### DIFF
--- a/bedrock/firefox/templates/firefox/privacy/index.html
+++ b/bedrock/firefox/templates/firefox/privacy/index.html
@@ -17,7 +17,7 @@
   {{ css_bundle('firefox-privacy-promise') }}
 {% endblock %}
 
-{% block body_class %}{{ super() }}privacy-promise{% endblock %}
+{% block body_class %}{{ super() }} privacy-promise{% endblock %}
 
 {% set _entrypoint = 'mozilla.org-privacy' %}
 {% set _utm_campaign = 'privacy' %}


### PR DESCRIPTION
## Description
Fixes the body class so the theme can apply the heading font.

## Issue / Bugzilla link
#8135 