### PR TITLE
Minor UI fixes on /firefox/mobile/ (Fixes #8137)

### DIFF
--- a/bedrock/firefox/templates/firefox/mobile-2019.html
+++ b/bedrock/firefox/templates/firefox/mobile-2019.html
@@ -36,7 +36,7 @@
           <h1 class="mzp-c-hero-title"><span class="c-wordmark t-firefox">Firefox Browser</span></h1>
 
           <div class="mzp-c-hero-desc">
-            <p>{{ _('Get automatic privacy on mobile') }}</p>
+            <h3>{{ _('Get automatic privacy on mobile') }}</h3>
             <p>{{ _('Super fast. Private by default. Blocks 2000+ online trackers.') }}</p>
           </div>
 
@@ -129,7 +129,7 @@
           <h2 class="mzp-c-hero-title end-hero"><span class="c-wordmark t-firefox">Firefox Browser</span></h2>
 
           <div class="mzp-c-hero-desc">
-            <p>{{ _('The privacy you deserve. The speed you need. ') }}</p>
+            <h3>{{ _('The privacy you deserve. The speed you need. ') }}</h3>
           </div>
 
           <div class="mzp-c-hero-cta">
@@ -197,7 +197,7 @@
           </li>
         </ul>
       </div>
-      
+
     </div>
   </main>
 {% endblock %}

--- a/media/css/firefox/mobile-protocol.scss
+++ b/media/css/firefox/mobile-protocol.scss
@@ -36,7 +36,7 @@ main .mzp-l-content {
 //* -------------------------------------------------------------------------- */
 //  Download buttons
 
-li {
+.mobile-download-buttons li {
     padding-top: $spacing-sm;
     display: inline-block;
 }
@@ -143,18 +143,17 @@ li {
 //  Wordmark
 
 .c-wordmark {
-
     @include at2x('/media/protocol/img/logos/firefox/browser/logo-word-hor-sm.png', auto, 100%);
+    @include bidi(((padding-right, $spacing-sm, padding-left, 0),));
     @include image-replaced;
-    @include bidi((
-        (background-position, top left, top right),
-        (padding-right, $spacing-sm, padding-left, 0),
-    ));
-
+    background-position: top center;
     background-repeat: no-repeat;
     content: '';
     display: block;
-    @include image-replaced;
+
+    @media #{$mq-md} {
+        @include bidi(((background-position, top left, top right),));
+    }
 }
 
 .end-hero .c-wordmark {
@@ -175,13 +174,6 @@ li {
 
     .mzp-c-hero-desc {
         @include text-display-sm;
-
-        p:first-child {
-            @include text-display-lg;
-            font-weight: bold;
-            margin-bottom: $spacing-md;
-            color: $fx-purple;
-        }
 
         p {
             margin-bottom: $spacing-lg;
@@ -218,11 +210,6 @@ li {
     }
 
     @media #{$mq-lg} {
-        .mzp-c-hero-desc {
-            p:first-child {
-                @include text-display-xl;
-            }
-        }
         .end-hero .c-wordmark {
             background-position: center;
         }
@@ -434,12 +421,6 @@ li {
         &.mzp-t-firefox::after {
             display: none;
         }
-    }
-
-    .mzp-c-hero-desc {
-        @include text-display-lg;
-        color: $fx-purple;
-        font-weight: bold;
     }
 
     .mzp-l-content {


### PR DESCRIPTION
## Description
- Fix nav link alignment.
- Use headings for hero sections.
- Center wordmark alignment on small viewports.

## Issue / Bugzilla link
#8137

## Testing
- [x] Nav should look consitent with other pages.
- [x] Headings should use Metropolis font.
- [x] Firefox Browser wordmark should be centered on small screens, and left/right aligned on large screens.