### PR TITLE
Separate LANG and FTL file caches

### DIFF
--- a/bedrock/settings/__init__.py
+++ b/bedrock/settings/__init__.py
@@ -37,6 +37,17 @@ CACHES['l10n'] = {
     }
 }
 
+# cache for Fluent files
+CACHES['fluent'] = {
+    'BACKEND': 'bedrock.base.cache.SimpleDictCache',
+    'LOCATION': 'fluent',
+    'TIMEOUT': FLUENT_CACHE_TIMEOUT,
+    'OPTIONS': {
+        'MAX_ENTRIES': 5000,
+        'CULL_FREQUENCY': 4,  # 1/4 entries deleted if max reached
+    }
+}
+
 # cache for product details
 CACHES['product-details'] = {
     'BACKEND': 'bedrock.base.cache.SimpleDictCache',

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -234,7 +234,8 @@ LANGUAGE_URL_MAP = lazy(lazy_lang_url_map, dict)()
 LANGUAGES = lazy(lazy_langs, dict)()
 
 FEED_CACHE = 3900
-DOTLANG_CACHE = config('L10N_CACHE_TIMEOUT', default='10' if DEBUG else '600', parser=int)
+# 30 min during dev and 10 min in prod
+DOTLANG_CACHE = config('DOTLANG_CACHE', default='1800' if DEBUG else '600', parser=int)
 
 DOTLANG_FILES = ['navigation', 'download_button', 'main', 'footer']
 
@@ -245,6 +246,8 @@ FLUENT_REPO_PATH = GIT_REPOS_PATH / 'www-l10n'
 FLUENT_LOCAL_PATH = ROOT_PATH / 'l10n'
 FLUENT_L10N_TEAM_REPO = config('FLUENT_REPO', default='https://github.com/mozmeao/www-l10n')
 FLUENT_L10N_TEAM_REPO_PATH = GIT_REPOS_PATH / 'l10n-team'
+# 10 seconds during dev and 10 min in prod
+FLUENT_CACHE_TIMEOUT = config('FLUENT_CACHE_TIMEOUT', default='10' if DEBUG else '600', parser=int)
 # order matters. first sting found wins.
 FLUENT_PATHS = [
     # local FTL files

--- a/lib/l10n_utils/fluent.py
+++ b/lib/l10n_utils/fluent.py
@@ -23,7 +23,7 @@ __all__ = [
     'has_messages',
     'translate',
 ]
-cache = caches['l10n']
+cache = caches['fluent']
 REQUIRED_RE = re.compile(r'^required\b', re.MULTILINE | re.IGNORECASE)
 
 


### PR DESCRIPTION
A long cache timeout is desireable for LANG cache during dev, but a short one is best for Fluent. This allows us to have both.

Fix #8056