### PR TITLE
Put Pocket FxA button on /firefox/pocket page (Fixes #8059)

### DIFF
--- a/bedrock/firefox/templates/firefox/pocket.html
+++ b/bedrock/firefox/templates/firefox/pocket.html
@@ -20,6 +20,9 @@
 
 {% block body_id %}pocket-landing{% endblock %}
 
+{% set _source = 'ffpocket' %}
+{% set _entrypoint = 'mozilla.org-firefox-pocket' %}
+
 {% set lazy_image_placeholder = 'mozorg/developer/hub/placeholder.png' %}
 
 {% block content %}
@@ -36,8 +39,7 @@
         </div>
 
         <div class="mzp-c-hero-cta">
-          <p><a id="pocket-button-primary" href="https://getpocket.com/firefox_learnmore" class="mzp-c-button mzp-t-dark" rel="external">{{ _('Learn More') }}</a></p>
-          <p class="note">{{ _('Already have an account?') }} <a href="https://getpocket.com/login" rel="external">{{ _('Log in') }}</a></p>
+          <p>{{ pocket_fxa_button(entrypoint=_entrypoint, button_text=_('Try Pocket Now'), optional_parameters={'s': _source}, optional_attributes={'data-cta-text': 'Try Pocket Now', 'data-cta-type': 'activate pocket', 'data-cta-position': 'primary'}) }}</p>
         </div>
       </div>
     </div>
@@ -101,8 +103,7 @@
         </h2>
 
         <div class="mzp-c-hero-cta">
-          <p><a id="pocket-button-secondary" href="https://getpocket.com/firefox_learnmore" class="mzp-c-button mzp-t-dark" rel="external">{{ _('Try Pocket Now') }}</a></p>
-          <p class="note">{{ _('Already have an account?') }} <a href="https://getpocket.com/login" rel="external">{{ _('Log in') }}</a></p>
+          <p>{{ pocket_fxa_button(entrypoint=_entrypoint, button_text=_('Try Pocket Now'), optional_parameters={'s': _source}, optional_attributes={'data-cta-text': 'Try Pocket Now', 'data-cta-type': 'activate pocket', 'data-cta-position': 'secondary'}) }}</p>
         </div>
       </div>
     </div>

--- a/bedrock/firefox/templates/firefox/welcome/page2.html
+++ b/bedrock/firefox/templates/firefox/welcome/page2.html
@@ -1,6 +1,6 @@
 {# This Source Code Form is subject to the terms of the Mozilla Public
-  # License, v. 2.0. If a copy of the MPL was not distributed with this
-  # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
 
 {% from "macros-protocol.html" import hero with context %}
 
@@ -15,6 +15,7 @@
 
 {% block body_class %}{{ super() }} welcome-page2{% endblock %}
 
+{% set _source = 'ffwelcome2' %}
 {% set _entrypoint = 'mozilla.org-firefox-welcome-2' %}
 {% set _utm_campaign = 'welcome-2-pocket' %}
 
@@ -28,7 +29,7 @@
   ) %}
 
     <p class="primary-cta">
-      <a class="js-fxa-cta-link js-fxa-product-button mzp-c-button mzp-t-product" href="https://getpocket.com/ff_signup?s=ffwelcome2&form_type=button&entrypoint={{ _entrypoint }}&utm_source={{ _entrypoint }}&utm_campaign={{ _utm_campaign }}&utm_medium=referral" data-action="{{ settings.FXA_ENDPOINT }}" data-cta-text="activate pocket" data-cta-type="fxa-pocket" data-cta-position="primary" rel="external noopener">{{ _('Activate Pocket') }}</a>
+      {{ pocket_fxa_button(entrypoint=_entrypoint, button_text=_('Activate Pocket'), optional_parameters={'s': _source, 'utm_campaign': _utm_campaign}, optional_attributes={'data-cta-text': 'Activate Pocket', 'data-cta-type': 'activate pocket', 'data-cta-position': 'primary'}) }}
     </p>
   {% endcall %}
 {% endblock %}
@@ -73,7 +74,7 @@
 
 {% block secondary_cta %}
   <p class="secondary-cta">
-    <a class="js-fxa-cta-link js-fxa-product-button mzp-c-button mzp-t-product" href="https://getpocket.com/ff_signup?s=ffwelcome2&form_type=button&entrypoint={{ _entrypoint }}&utm_source={{ _entrypoint }}&utm_campaign={{ _utm_campaign }}&utm_medium=referral" data-action="{{ settings.FXA_ENDPOINT }}" data-cta-text="activate pocket" data-cta-type="fxa-pocket" data-cta-position="secondary" rel="external noopener">{{ _('Activate Pocket') }}</a>
+    {{ pocket_fxa_button(entrypoint=_entrypoint, button_text=_('Activate Pocket'), optional_parameters={'s': _source, 'utm_campaign': _utm_campaign}, optional_attributes={'data-cta-text': 'Activate Pocket', 'data-cta-type': 'activate pocket', 'data-cta-position': 'secondary'}) }}
   </p>
 {% endblock %}
 

--- a/bedrock/mozorg/templatetags/misc.py
+++ b/bedrock/mozorg/templatetags/misc.py
@@ -718,3 +718,43 @@ def lockwise_adjust_url(ctx, redirect, adgroup, creative=None):
     locale = getattr(ctx['request'], 'locale', 'en-US')
 
     return _get_adjust_link(adjust_url, app_store_url, play_store_url, redirect, locale, adgroup, creative)
+
+
+def _fxa_product_button(product_url, entrypoint, button_text, class_name=None, optional_parameters=None, optional_attributes=None):
+    href = f'{product_url}?entrypoint={entrypoint}&form_type=button&utm_source={entrypoint}&utm_medium=refferal'
+    css_class = 'js-fxa-cta-link js-fxa-product-button mzp-c-button mzp-t-product'
+    attrs = ''
+
+    if optional_parameters:
+        params = '&'.join('%s=%s' % (param, val) for param, val in optional_parameters.items())
+        href += f'&{params}'
+
+    if optional_attributes:
+        attrs += ' '.join('%s="%s"' % (attr, val) for attr, val in optional_attributes.items())
+
+    if class_name:
+        css_class += f' {class_name}'
+
+    markup = (f'<a href="{href}" data-action="{settings.FXA_ENDPOINT}" class="{css_class}" {attrs}>'
+              f'{button_text}'
+              f'</a>')
+
+    return jinja2.Markup(markup)
+
+
+@library.global_function
+@jinja2.contextfunction
+def pocket_fxa_button(ctx, entrypoint, button_text, class_name=None, optional_parameters=None, optional_attributes=None):
+    """
+    Render a getpocket.com link with required params for FxA authentication.
+
+    Examples
+    ========
+
+    In Template
+    -----------
+
+        {{ pocket_fxa_button(entrypoint='mozilla.org-firefox-pocket', button_text='Try Pocket Now') }}
+    """
+    product_url = 'https://getpocket.com/ff_signup'
+    return _fxa_product_button(product_url, entrypoint, button_text, class_name, optional_parameters, optional_attributes)

--- a/docs/firefox-accounts.rst
+++ b/docs/firefox-accounts.rst
@@ -271,11 +271,45 @@ Invoking the macro will automatically include a set of default UTM parameters as
 - ``utm_source`` is automatically assigned the value of the ``entrypoint`` parameter.
 - ``utm_medium`` is automatically set as the value of ``referral``.
 
+Linking to getpocket.com
+------------------------
+
+Use the ``pocket_fxa_button`` helper to link to https://getpocket.com/ via a Firefox Accounts auth flow.
+
+.. code-block:: jinja
+
+    {{ pocket_fxa_button(entrypoint='mozilla.org-firefox-pocket', button_text='Try Pocket Now', optional_parameters={'s': 'ffpocket'}) }}
+
+The templates's respective JavaScript bundle should also include the following dependencies:
+
+.. code-block:: text
+
+    js/base/mozilla-fxa-product-button.js
+    js/base/mozilla-fxa-product-button-init.js
+
+FxA button helper configuration
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The ``pocket_fxa_button`` helper supports the following parameters:
+
++----------------------------+------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------+--------------------------------------------------------------------------------------------------------+
+|    Parameter name          |                                                       Definition                                                       |                          Format                          |                                                Example                                                 |
++============================+========================================================================================================================+==========================================================+========================================================================================================+
+|    entrypoint*             | Unambiguous identifier for which page of the site is the referrer.                                                     | 'mozilla.org-firefox-pocket'                             | 'mozilla.org-firefox-pocket'                                                                           |
++----------------------------+------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------+--------------------------------------------------------------------------------------------------------+
+|    button_text*            | The button copy to be used in the call to action.  Default to a well localized string.                                 | Localizable string                                       | _('Try Pocket Now')                                                                                    |
++----------------------------+------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------+--------------------------------------------------------------------------------------------------------+
+|    class_name              | A class name to be applied to the link (typically for styling with CSS).                                               | String of one or more class names                        | 'pocket-main-cta-button'                                                                               |
++----------------------------+------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------+--------------------------------------------------------------------------------------------------------+
+|    optional_parameters     | An dictionary of key value pairs containing additional parameters to append the the href.                              | Dictionary                                               | {'s': 'ffpocket'}                                                                                      |
++----------------------------+------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------+--------------------------------------------------------------------------------------------------------+
+|    optiona_attributes      | An dictionary of key value pairs containing additional data attributes to include in the button.                       | Dictionary                                               | {'data-cta-text': 'Try Pocket Now', 'data-cta-type': 'activate pocket','data-cta-position': 'primary'} |
++----------------------------+------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------+--------------------------------------------------------------------------------------------------------+
 
 Tracking Sign-ups / Sign-ins
 ----------------------------
 
-For both Firefox Accounts form submissions and Firefox Monitor referrals, we also pass ``device_id``, ``flow_id`` and ``flow_begin_time`` parameters to track top-of-funnel metrics. These are values fetched from a metrics flow API endpoint, and are instered back into the form / link along with the other standard referral parameters. This functionality is handled by ``mozilla-fxa-form.js`` and ``mozilla-fxa-product-button.js`` respectively.
+For Firefox Accounts product referrals we also pass ``device_id``, ``flow_id`` and ``flow_begin_time`` parameters to track top-of-funnel metrics. These are values fetched from a metrics flow API endpoint, and are instered back into the form / link along with the other standard referral parameters. This functionality is handled by ``mozilla-fxa-form.js`` and ``mozilla-fxa-product-button.js`` respectively.
 
 .. Important::
 
@@ -294,7 +328,7 @@ The behavior is as follows:
 
 .. Important::
 
-    Links generated by the ``fxa_email_form`` and ``fxa_cta_link`` will automatically be covered by this script. For links generated using the ``fxa_link_fragment`` macro, you will need to manually add a CSS class of ``js-fxa-cta-link`` to trigger the function. This script does not yet cover the monitor button or signup form macro.
+    Links generated by the FxA button macros and helpers will automatically be covered by this script. For links generated using the ``fxa_link_fragment`` macro, you will need to manually add a CSS class of ``js-fxa-cta-link`` to trigger the function. This script does not yet cover the signup form macro.
 
 
 Google Analytics Guidelines

--- a/media/css/firefox/pocket.scss
+++ b/media/css/firefox/pocket.scss
@@ -80,7 +80,7 @@ $image-path: '/media/protocol/img';
 }
 
 #pocket-sidekick {
-    background: #44a1ff linear-gradient(to top, #44a1ff 0%, #0060df 73%, #2a4189 100%);
+    background: #44a1ff linear-gradient(to top, #00b3f4 0%, #0090ed 72%, #0060df 100%);
     margin-bottom: 0;
     margin-top: $spacing-xl;
 

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -1597,6 +1597,8 @@
     {
       "files": [
         "js/base/mozilla-lazy-load.js",
+        "js/base/mozilla-fxa-product-button.js",
+        "js/base/mozilla-fxa-product-button-init.js",
         "js/firefox/pocket.js"
       ],
       "name": "product_pocket"

--- a/tests/pages/firefox/pocket.py
+++ b/tests/pages/firefox/pocket.py
@@ -11,8 +11,8 @@ class FirefoxPocketPage(FirefoxBasePage):
 
     URL_TEMPLATE = '/{locale}/firefox/pocket/'
 
-    _pocket_primary_button_locator = (By.ID, 'pocket-button-primary')
-    _pocket_secondary_button_locator = (By.ID, 'pocket-button-secondary')
+    _pocket_primary_button_locator = (By.CSS_SELECTOR, '#pocket-hero .js-fxa-product-button')
+    _pocket_secondary_button_locator = (By.CSS_SELECTOR, '#pocket-sidekick .js-fxa-product-button')
 
     @property
     def is_pocket_primary_button_displayed(self):


### PR DESCRIPTION
## Description
- Adds an FxA CTA button to the /firefox/pocket/ page.
- Adds a new dedicated Python helper for creating FxA product buttons.
- Adds unit tests for the helper.
- Updates documentation.

## Issue / Bugzilla link
#8059

## Testing
- http://localhost:8000/en-US/firefox/pocket/
- http://localhost:8000/en-US/firefox/welcome/2/

Things to check:
- [ ] Both pages link to the Pocket FxA signup flow as expected.
- [ ] New button works with metric flow JS.
- [ ] Documentation makes sense?

Integration test run: https://ci.vpn1.moz.works/blue/organizations/jenkins/bedrock_multibranch_pipeline/detail/run-integration-tests/457/pipeline