### PR TITLE
[fix #8152] Add welcome page 3 for Sync

### DIFF
--- a/bedrock/exp/templates/exp/firefox/welcome/base.html
+++ b/bedrock/exp/templates/exp/firefox/welcome/base.html
@@ -28,17 +28,11 @@
 
   <section class="page-body">
     <div class="mzp-l-content mzp-t-narrow">
-      <div class="body-primary">
-        {% block content_primary %}{% endblock %}
-      </div>
+      {% block content_primary %}{% endblock %}
 
-      <div class="body-secondary">
-        {% block content_secondary %}{% endblock %}
-      </div>
+      {% block content_secondary %}{% endblock %}
 
-      <div class="secondary-cta">
-        {% block secondary_cta %}{% endblock %}
-      </div>
+      {% block secondary_cta %}{% endblock %}
     </div>
   </section>
 

--- a/bedrock/exp/templates/exp/firefox/welcome/page1.html
+++ b/bedrock/exp/templates/exp/firefox/welcome/page1.html
@@ -46,14 +46,17 @@
 {% endblock %}
 
 {% block content_primary %}
+<div class="body-primary">
   <h2 class="body-primary-title"><img src="{{ static('img/logos/monitor/monitor-wordmark.svg') }}" width="256" height="" alt="Firefox Monitor"></h2>
 
   <div class="body-primary-body">
     <p>Firefox Monitor shows you if your information has been leaked in a known data breach, and alerts you in case it happens in the future.</p>
   </div>
+</div>
 {% endblock %}
 
 {% block content_secondary %}
+<div class="body-secondary">
   <div class="c-picto-block t-adjacent-image">
     <div class="c-picto-block-image">
       <img src="{{ static('img/icons/private-browsing.svg') }}" alt="">
@@ -77,10 +80,11 @@
       </p>
     </div>
   </div>
+</div>
 {% endblock %}
 
 {% block secondary_cta %}
-  <p>
+  <p class="secondary-cta">
     {{ monitor_button(
       entrypoint=_entrypoint,
       utm_campaign=_utm_campaign,
@@ -99,5 +103,5 @@
 {% endblock %}
 
 {% block js %}
-  {{ js_bundle('exp_firefox_welcome_page1') }}
+  {{ js_bundle('exp_firefox_welcome_page') }}
 {% endblock %}

--- a/bedrock/firefox/templates/firefox/welcome/base.html
+++ b/bedrock/firefox/templates/firefox/welcome/base.html
@@ -28,17 +28,13 @@
 
   <section class="page-body">
     <div class="mzp-l-content mzp-t-narrow">
-      <div class="body-primary">
-        {% block content_primary %}{% endblock %}
-      </div>
 
-      <div class="body-secondary">
-        {% block content_secondary %}{% endblock %}
-      </div>
+      {% block content_primary %}{% endblock %}
 
-      <div class="secondary-cta">
-        {% block secondary_cta %}{% endblock %}
-      </div>
+      {% block content_secondary %}{% endblock %}
+
+      {% block secondary_cta %}{% endblock %}
+
     </div>
   </section>
 

--- a/bedrock/firefox/templates/firefox/welcome/page1.html
+++ b/bedrock/firefox/templates/firefox/welcome/page1.html
@@ -56,15 +56,18 @@
 {% endblock %}
 
 {% block content_primary %}
+<div class="body-primary">
   <h2 class="body-primary-title"><img src="{{ static('img/logos/monitor/monitor-wordmark.svg') }}" width="256" height="" alt="Firefox Monitor"></h2>
 
   <div class="body-primary-body">
     {# L10n: "Firefox Monitor" is a product name and shouldn't be translated. #}
     <p>{{ _('Firefox Monitor shows you if your information has been leaked in a known data breach, and alerts you in case it happens in the future.') }}</p>
   </div>
+</div>
 {% endblock %}
 
 {% block content_secondary %}
+<div class="body-secondary">
   <div class="c-picto-block t-adjacent-image">
     <div class="c-picto-block-image">
       <img src="{{ static('img/icons/private-browsing.svg') }}" alt="">
@@ -97,10 +100,11 @@
     </div>
   </div>
   {% endif %}
+</div>
 {% endblock %}
 
 {% block secondary_cta %}
-  <p>
+  <p class="secondary-cta">
     {{ monitor_button(
       entrypoint=_entrypoint,
       utm_campaign=_utm_campaign,
@@ -120,5 +124,5 @@
 {% endblock %}
 
 {% block js %}
-  {{ js_bundle('firefox_welcome_page1') }}
+  {{ js_bundle('firefox_welcome_page') }}
 {% endblock %}

--- a/bedrock/firefox/templates/firefox/welcome/page1.html
+++ b/bedrock/firefox/templates/firefox/welcome/page1.html
@@ -35,10 +35,7 @@
     desc=_('You’ve got the web browser that protects your privacy — now it’s time to get a lookout for hackers.'),
     class='mzp-t-firefox mzp-t-dark',
     include_cta=True,
-    heading_level=1,
-    image_url=None,
-    include_highres_image=False,
-    image_alt=''
+    heading_level=1
   ) %}
 
   <p class="primary-cta">

--- a/bedrock/firefox/templates/firefox/welcome/page2.html
+++ b/bedrock/firefox/templates/firefox/welcome/page2.html
@@ -37,6 +37,7 @@
 {% endblock %}
 
 {% block content_primary %}
+<div class="body-primary">
   <h2 class="body-primary-title"><img src="{{ static('protocol/img/logos/pocket/logo-word-horz.svg') }}" width="186" height="" alt="Pocket"></h2>
 
   <div class="body-primary-body">
@@ -44,9 +45,11 @@
 
     <img class="primary-image" src="{{ static('img/firefox/welcome/pocket-hero.svg') }}" width="700" height="" alt="">
   </div>
+</div>
 {% endblock %}
 
 {% block content_secondary %}
+<div class="body-secondary">
   <div class="c-picto-block t-adjacent-image">
     <div class="c-picto-block-image">
       <img src="{{ static('img/icons/pocket-outline-green.svg') }}" alt="">
@@ -68,12 +71,13 @@
       <p>{{ _('Pocket shows recommended stories every time you open a new tab. Save the ones that interest you.') }}</p>
     </div>
   </div>
+</div>
 {% endblock %}
 
 {% block secondary_cta %}
-    <p class="secondary-cta">
-      <a class="js-fxa-cta-link js-fxa-product-button mzp-c-button mzp-t-product" href="https://getpocket.com/ff_signup?s=ffwelcome2&form_type=button&entrypoint={{ _entrypoint }}&utm_source={{ _entrypoint }}&utm_campaign={{ _utm_campaign }}&utm_medium=referral" data-action="{{ settings.FXA_ENDPOINT }}" data-cta-text="activate pocket" data-cta-type="fxa-pocket" data-cta-position="secondary" rel="external noopener">{{ _('Activate Pocket') }}</a>
-    </p>
+  <p class="secondary-cta">
+    <a class="js-fxa-cta-link js-fxa-product-button mzp-c-button mzp-t-product" href="https://getpocket.com/ff_signup?s=ffwelcome2&form_type=button&entrypoint={{ _entrypoint }}&utm_source={{ _entrypoint }}&utm_campaign={{ _utm_campaign }}&utm_medium=referral" data-action="{{ settings.FXA_ENDPOINT }}" data-cta-text="activate pocket" data-cta-type="fxa-pocket" data-cta-position="secondary" rel="external noopener">{{ _('Activate Pocket') }}</a>
+  </p>
 {% endblock %}
 
 {% block content_utility %}
@@ -81,5 +85,5 @@
 {% endblock %}
 
 {% block js %}
-  {{ js_bundle('firefox_welcome_page2') }}
+  {{ js_bundle('firefox_welcome_page') }}
 {% endblock %}

--- a/bedrock/firefox/templates/firefox/welcome/page2.html
+++ b/bedrock/firefox/templates/firefox/welcome/page2.html
@@ -24,10 +24,7 @@
     desc=_('Discover and save stories in Pocket — and come back to them when you’re free.'),
     class='mzp-t-firefox mzp-t-dark',
     include_cta=True,
-    heading_level=1,
-    image_url=None,
-    include_highres_image=False,
-    image_alt=''
+    heading_level=1
   ) %}
 
     <p class="primary-cta">

--- a/bedrock/firefox/templates/firefox/welcome/page3.html
+++ b/bedrock/firefox/templates/firefox/welcome/page3.html
@@ -1,0 +1,106 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+  # License, v. 2.0. If a copy of the MPL was not distributed with this
+  # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+
+{% from "macros-protocol.html" import hero with context %}
+{% from "macros.html" import fxa_cta_link with context %}
+
+{% add_lang_files "firefox/welcome/page3" %}
+
+{% extends "firefox/welcome/base.html" %}
+
+{% block page_title %}{{ _('Get the free account that protects your privacy. Join Firefox.') }}{% endblock %}
+
+{% block page_image %}{{ static('img/firefox/template/page-image-master.jpg') }}{% endblock %}
+
+{% block body_class %}{{ super() }} welcome-page3{% endblock %}
+
+{% set _entrypoint = 'mozilla.org-firefox-welcome-3' %}
+{% set _utm_campaign = 'welcome-3-sync' %}
+
+{% block content_intro %}
+  {% call hero(
+    title=_('No account required. But you might want one.'),
+    desc=_('The Firefox browser collects so little data about you, we don’t even require your email address. But when you use it to create a Firefox account, we can protect your privacy across more of your online life.'),
+    class='mzp-t-firefox mzp-t-dark',
+    include_cta=True,
+    heading_level=1,
+    image_url=None,
+    include_highres_image=False,
+    image_alt=''
+  ) %}
+
+    <p class="primary-cta">
+      {{ fxa_cta_link(entrypoint=_entrypoint, action='signup', button_text='Sign In', button_class='mzp-c-button mzp-t-product js-fxa-product-button', utm_campaign=_utm_campaign, utm_content='top-cta') }}
+    </p>
+  {% endcall %}
+{% endblock %}
+
+{% block content_primary %}
+  <div class="body-primary">
+    <div class="c-picto-block t-adjacent-image">
+      <div class="c-picto-block-image">
+        <img src="{{ static('img/logos/firefox/logo-monitor.svg') }}" alt="">
+      </div>
+
+      <h3 class="c-picto-block-title">Firefox Monitor</h3>
+      <div class="c-picto-block-body">
+        <p>{{ _('Have at least one company looking out for your data, instead of leaking it.') }}</p>
+      </div>
+    </div>
+
+    <div class="c-picto-block t-adjacent-image">
+      <div class="c-picto-block-image">
+        <img src="{{ static('img/logos/firefox/logo-lockwise.svg') }}" alt="">
+      </div>
+      <h3 class="c-picto-block-title">Firefox Lockwise</h3>
+      <div class="c-picto-block-body">
+        <p>{{ _('Never forget, reset or travel without your passwords again.') }}</p>
+      </div>
+    </div>
+
+    <div class="c-picto-block t-adjacent-image">
+      <div class="c-picto-block-image">
+        <img src="{{ static('img/logos/fbcontainer/logo-fbcontainer.svg') }}" alt="">
+      </div>
+      <h3 class="c-picto-block-title">Facebook Container</h3>
+      <div class="c-picto-block-body">
+        <p>{{ _('Get a container to keep Facebook out of your business.') }}</p>
+      </div>
+    </div>
+
+    <div class="c-picto-block t-adjacent-image">
+      <div class="c-picto-block-image">
+        <img src="{{ static('img/icons/pocket-outline-red.svg') }}" alt="" width="64">
+      </div>
+      <h3 class="c-picto-block-title">Pocket</h3>
+      <div class="c-picto-block-body">
+        <p>{{ _('Trade clickbait and fake news for quality content.') }}</p>
+      </div>
+    </div>
+
+    <div class="c-picto-block t-adjacent-image">
+      <div class="c-picto-block-image">
+        <img src="{{ static('img/logos/firefox/logo-send.svg') }}" alt="">
+      </div>
+      <h3 class="c-picto-block-title">Firefox Send</h3>
+      <div class="c-picto-block-body">
+        <p>{{ _('Send huge files to anyone you want, with self-destructing links.') }}</p>
+      </div>
+    </div>
+  </div>
+{% endblock %}
+
+{% block secondary_cta %}
+  <p class="secondary-cta">
+    {{ fxa_cta_link(entrypoint=_entrypoint, action='signup', button_text='Sign In', button_class='mzp-c-button mzp-t-product js-fxa-product-button', utm_campaign=_utm_campaign, utm_content='bottom-cta') }}
+  </p>
+{% endblock %}
+
+{% block content_utility %}
+  <p><strong><a href="https://support.mozilla.org/kb/firefox-browser-welcome-pages/?utm_source={{ _entrypoint }}&utm_medium=referral&utm_campaign={{ _utm_campaign }}&entrypoint={{ _entrypoint }}">{{ _('Why am I seeing this?') }}</a></strong></p>
+{% endblock %}
+
+{% block js %}
+  {{ js_bundle('firefox_welcome_page') }}
+{% endblock %}

--- a/bedrock/firefox/templates/firefox/welcome/page3.html
+++ b/bedrock/firefox/templates/firefox/welcome/page3.html
@@ -24,14 +24,11 @@
     desc=_('The Firefox browser collects so little data about you, we don’t even require your email address. But when you use it to create a Firefox account, we can protect your privacy across more of your online life.'),
     class='mzp-t-firefox mzp-t-dark',
     include_cta=True,
-    heading_level=1,
-    image_url=None,
-    include_highres_image=False,
-    image_alt=''
+    heading_level=1
   ) %}
 
     <p class="primary-cta">
-      {{ fxa_cta_link(entrypoint=_entrypoint, action='signup', button_text='Sign In', button_class='mzp-c-button mzp-t-product js-fxa-product-button', utm_campaign=_utm_campaign, utm_content='top-cta') }}
+      {{ fxa_cta_link(entrypoint=_entrypoint, action='signup', button_text=_('Sign In'), button_class='mzp-c-button mzp-t-product js-fxa-product-button', utm_campaign=_utm_campaign, utm_content='top-cta') }}
     </p>
   {% endcall %}
 {% endblock %}
@@ -93,7 +90,7 @@
 
 {% block secondary_cta %}
   <p class="secondary-cta">
-    {{ fxa_cta_link(entrypoint=_entrypoint, action='signup', button_text='Sign In', button_class='mzp-c-button mzp-t-product js-fxa-product-button', utm_campaign=_utm_campaign, utm_content='bottom-cta') }}
+    {{ fxa_cta_link(entrypoint=_entrypoint, action='signup', button_text=_('Sign In'), button_class='mzp-c-button mzp-t-product js-fxa-product-button', utm_campaign=_utm_campaign, utm_content='bottom-cta') }}
   </p>
 {% endblock %}
 

--- a/bedrock/firefox/urls.py
+++ b/bedrock/firefox/urls.py
@@ -112,6 +112,7 @@ urlpatterns = (
 
     url(r'^firefox/welcome/1/$', views.firefox_welcome_page1, name='firefox.welcome.page1'),
     page('firefox/welcome/2', 'firefox/welcome/page2.html'),
+    page('firefox/welcome/3', 'firefox/welcome/page3.html'),
 
     page('firefox/switch', 'firefox/switch.html'),
     page('firefox/pocket', 'firefox/pocket.html'),

--- a/media/css/exp/firefox/welcome.scss
+++ b/media/css/exp/firefox/welcome.scss
@@ -52,12 +52,21 @@
 
     .primary-cta {
         margin: 0 auto;
+
+        .mzp-c-button {
+            min-width: 180px;
+        }
     }
 }
 
 .mzp-c-hero-title {
     @include text-display-lg;
     margin-bottom: $layout-sm;
+
+    .welcome-page1 &,
+    .welcome-page3 & {
+        @include text-display-md;
+    }
 }
 
 .mzp-c-hero-desc {
@@ -107,7 +116,8 @@
     &.t-adjacent-image {
         @include bidi((
             (padding-left, $layout-xl, 0),
-            (padding-right, 0, $layout-xl)
+            (padding-right, 0, $layout-xl),
+            (text-align, left, right),
         ));
         position: relative;
 
@@ -123,7 +133,7 @@
             ));
             display: block;
             margin: 0;
-            max-width: $layout-lg;
+            max-width: $layout-md;
             min-height: 0;
             position: absolute;
         }
@@ -140,6 +150,10 @@
 
     p {
         margin: 0 auto;
+    }
+
+    .mzp-c-button {
+        min-width: 180px;
     }
 }
 

--- a/media/css/firefox/welcome.scss
+++ b/media/css/firefox/welcome.scss
@@ -52,6 +52,10 @@
 
     .primary-cta {
         margin: 0 auto;
+
+        .mzp-c-button {
+            min-width: 180px;
+        }
     }
 }
 
@@ -59,7 +63,8 @@
     @include text-display-lg;
     margin-bottom: $layout-sm;
 
-    .welcome-page1 & {
+    .welcome-page1 &,
+    .welcome-page3 & {
         @include text-display-md;
     }
 }
@@ -111,7 +116,8 @@
     &.t-adjacent-image {
         @include bidi((
             (padding-left, $layout-xl, 0),
-            (padding-right, 0, $layout-xl)
+            (padding-right, 0, $layout-xl),
+            (text-align, left, right),
         ));
         position: relative;
 
@@ -127,7 +133,7 @@
             ));
             display: block;
             margin: 0;
-            max-width: $layout-lg;
+            max-width: $layout-md;
             min-height: 0;
             position: absolute;
         }
@@ -144,6 +150,10 @@
 
     p {
         margin: 0 auto;
+    }
+
+    .mzp-c-button {
+        min-width: 180px;
     }
 }
 

--- a/media/js/exp/firefox/welcome-page1-init.js
+++ b/media/js/exp/firefox/welcome-page1-init.js
@@ -1,9 +1,0 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-
-(function() {
-    'use strict';
-
-    Mozilla.FxaProductButton.init();
-})();

--- a/media/js/firefox/welcome-page1-init.js
+++ b/media/js/firefox/welcome-page1-init.js
@@ -1,9 +1,0 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-
-(function() {
-    'use strict';
-
-    Mozilla.FxaProductButton.init();
-})();

--- a/media/js/firefox/welcome-page2-init.js
+++ b/media/js/firefox/welcome-page2-init.js
@@ -1,9 +1,0 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
-
-(function() {
-    'use strict';
-
-    Mozilla.FxaProductButton.init();
-})();

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -943,23 +943,16 @@
     {
       "files": [
         "js/base/mozilla-fxa-product-button.js",
-        "js/firefox/welcome-page1-init.js"
+        "js/base/mozilla-fxa-product-button-init.js"
       ],
-      "name": "firefox_welcome_page1"
+      "name": "firefox_welcome_page"
     },
     {
       "files": [
         "js/base/mozilla-fxa-product-button.js",
-        "js/exp/firefox/welcome-page1-init.js"
+        "js/base/mozilla-fxa-product-button-init.js"
       ],
-      "name": "exp_firefox_welcome_page1"
-    },
-    {
-      "files": [
-        "js/base/mozilla-fxa-product-button.js",
-        "js/firefox/welcome-page2-init.js"
-      ],
-      "name": "firefox_welcome_page2"
+      "name": "exp_firefox_welcome_page"
     },
     {
       "files": [

--- a/tests/functional/firefox/test_welcome_page3.py
+++ b/tests/functional/firefox/test_welcome_page3.py
@@ -1,0 +1,14 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import pytest
+
+from pages.firefox.welcome.page3 import FirefoxWelcomePage3
+
+
+@pytest.mark.nondestructive
+def test_fxa_button_displayed(base_url, selenium):
+    page = FirefoxWelcomePage3(selenium, base_url).open()
+    assert page.is_primary_fxa_button_displayed
+    assert page.is_secondary_fxa_button_displayed

--- a/tests/pages/firefox/welcome/page3.py
+++ b/tests/pages/firefox/welcome/page3.py
@@ -1,0 +1,23 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from selenium.webdriver.common.by import By
+
+from pages.firefox.base import FirefoxBasePage
+
+
+class FirefoxWelcomePage3(FirefoxBasePage):
+
+    URL_TEMPLATE = '/{locale}/firefox/welcome/3/'
+
+    _fxa_primary_button_locator = (By.CSS_SELECTOR, '.primary-cta .js-fxa-product-button')
+    _fxa_secondary_button_locator = (By.CSS_SELECTOR, '.secondary-cta .js-fxa-product-button')
+
+    @property
+    def is_primary_fxa_button_displayed(self):
+        return self.is_element_displayed(*self._fxa_primary_button_locator)
+
+    @property
+    def is_secondary_fxa_button_displayed(self):
+        return self.is_element_displayed(*self._fxa_secondary_button_locator)


### PR DESCRIPTION
## Description
Adds a new welcome page promoting Firefox accounts with a Sync CTA, repurposing content from variant 7 of the WNP70 experiments.

This also makes a few minor changes to the base template and updates the other welcome pages accordingly, including the CRO copy of page 1.

And it consolidates to a shared JS bundle now that we have a single FxA button.

This needs to be in production before **21 November**.

## Issue / Bugzilla link
#8152 

## Testing
https://bedrock-demo-craigcook.oregon-b.moz.works/firefox/welcome/3/

- [x] Previous welcome pages still render and function after refactoring.
