### PR TITLE
Use CI_COMMIT_REF_NAME set by gitlab by default for GIT_BRANCH

### DIFF
--- a/docker/bin/set_git_env_vars.sh
+++ b/docker/bin/set_git_env_vars.sh
@@ -12,7 +12,11 @@ if [[ "$GIT_TAG" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}(\.[0-9])?$ ]]; then
     export GIT_TAG_DATE_BASED=true
 fi
 if [[ -z "$GIT_BRANCH" ]]; then
-    export GIT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+    if [[ -n "$CI_COMMIT_REF_NAME" ]]; then
+        export GIT_BRANCH="$CI_COMMIT_REF_NAME"
+    else
+        export GIT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+    fi
     export BRANCH_NAME="$GIT_BRANCH"
 fi
 export BRANCH_NAME_SAFE="${BRANCH_NAME/\//-}"


### PR DESCRIPTION
Fix errors resulting in 404s on some static assets in dev now.