### PR TITLE
Add link to download in another language on /thanks (Fixes #8116)

### DIFF
--- a/bedrock/firefox/templates/firefox/new/trailhead/thanks.html
+++ b/bedrock/firefox/templates/firefox/new/trailhead/thanks.html
@@ -61,6 +61,10 @@
     {{ picto_card(desc=_('It’s everything you need to know about <strong>staying safe online</strong>. '), class='safety') }}
     {{ picto_card(desc=_('It’s <strong>a community</strong> that believes tech can do better. '), class='community') }}
   </ul>
+
+  <p class="mzp-l-content download-another-language-link">
+    <a href="{{ firefox_url('desktop', 'all') }}">{{_('Download in another language') }}</a>
+  </p>
 </main>
 {% endblock %}
 

--- a/media/css/firefox/new/trailhead/thanks.scss
+++ b/media/css/firefox/new/trailhead/thanks.scss
@@ -195,10 +195,6 @@ main {
 
 .download-another-language-link {
     @include text-body-sm;
-    padding: $layout-md 0;
+    padding: $layout-sm 0;
     text-align: center;
-
-    @media #{$mq-lg} {
-        padding-bottom: $layout-lg 0;
-    }
 }

--- a/media/css/firefox/new/trailhead/thanks.scss
+++ b/media/css/firefox/new/trailhead/thanks.scss
@@ -192,3 +192,13 @@ main {
         }
     }
 }
+
+.download-another-language-link {
+    @include text-body-sm;
+    padding: $layout-md 0;
+    text-align: center;
+
+    @media #{$mq-lg} {
+        padding-bottom: $layout-lg 0;
+    }
+}


### PR DESCRIPTION
## Description
Adds "Download in another language" link to the bottom of `/firefox/download/thanks/` page.

## Issue / Bugzilla link
#8116

## Testing
- [x] String should already be localized.