### PR TITLE
update TEST_IMAGE in www-config .gitlab-ci.yml

### DIFF
--- a/bin/update_config.sh
+++ b/bin/update_config.sh
@@ -18,5 +18,9 @@ for CLUSTER in ${CLUSTERS:=iowa-a}; do
         fi
     done
 done
+
+TEST_IMAGE=mozorg/bedrock_test:${GIT_COMMIT}
+sed -i -e "s|TEST_IMAGE: .*|TEST_IMAGE: ${TEST_IMAGE}|;s|image: mozorg/bedrock_test.*|image: ${TEST_IMAGE}|" .gitlab-ci.yml
+
 git commit -m "set image to ${DEPLOYMENT_DOCKER_IMAGE} in ${CLUSTERS}" || echo "nothing new to commit"
 git push


### PR DESCRIPTION
## Description

Now that https://github.com/mozmeao/www-config/pull/245 has landed with support for the `TEST_IMAGE` variable, we can automatically update it for pushes to master, stage & prod to ensure that we are always testing with an image that matches the commit we are deploying.