### PR TITLE
Fix typos in SOM 2018 (Fixes #8224)

### DIFF
--- a/bedrock/foundation/templates/foundation/annualreport/2018/index.html
+++ b/bedrock/foundation/templates/foundation/annualreport/2018/index.html
@@ -170,7 +170,7 @@
             {% trans %}
             In response to increasing public concern about data privacy and how people’s personal information is being
             used, many technology companies have answered by putting the onus to protect their privacy on users. In some
-            cases that has meant users being forced to change settings, pour over inaccessible terms of service, or take
+            cases that has meant users being forced to change settings, pore over inaccessible terms of service, or take
             control of complicated product features. In other instances, companies have resorted to promising easy
             access to online safety and privacy only to those who stay within the confines of their closed operating and
             device ecosystems.
@@ -303,7 +303,7 @@
           <p>
             {% trans venmo="https://foundation.mozilla.org/blog/venmo-are-you-listening-make-user-privacy-default/" %}
             Mozilla Foundation also pushed companies like <a href="{{ venmo }}">Venmo to adopt private-by-default
-              positions</a> on transactions. Advocating for consumers with other companies and arming them consumers with
+              positions</a> on transactions. Advocating for consumers with other companies and arming them with
             vital information at-a-glance was one way to empower people in their digital lives, helping them make better
             informed decisions about how and with whom they spend their time and money online.
             {% endtrans %}


### PR DESCRIPTION
## Description
Fixes typos in the 2018 State of Mozilla template.

## Issue / Bugzilla link
#8224 
