### PR TITLE
Update /new content for Skyline (Fixes #7851)

### DIFF
--- a/bedrock/firefox/templates/firefox/campaign/index-trailhead.html
+++ b/bedrock/firefox/templates/firefox/campaign/index-trailhead.html
@@ -54,9 +54,15 @@
 
 {% block content %}
 <main role="main" class="main-download" {% if v %}data-variant="{{ v }}"{% endif %}>
+  {% if l10n_has_tag('firefox-new-skyline') %}
+    {% set tagline = _('Automatic privacy is here. Download Firefox to block over 2000 trackers.') %}
+  {% else %}
+    {% set tagline = _('And start getting the respect you deserve with our family of privacy-first products.') %}
+  {% endif %}
+
   {% call hero(
     title=_('Get the latest Firefox browser.'),
-    desc=_('And start getting the respect you deserve with our family of privacy-first products.'),
+    desc=tagline,
     class='mzp-has-image mzp-t-dark',
     include_cta=True,
     image_url='img/firefox/new/trailhead/browser-window.svg',
@@ -67,9 +73,15 @@
 
   <section class="features">
     <ul class="mzp-l-card-third mzp-l-content">
-      {{ picto_card(title=_('Join Firefox'), desc=_('Connect to a whole family of respectful products, plus all the knowledge you need to protect yourself online.'), class='join') }}
-      {{ picto_card(title=_('Passwords made portable'), desc=_('<strong>Firefox Lockwise</strong> makes the passwords you save in Firefox available on all your devices.'), class='lockwise') }}
-      {{ picto_card(title=_('Protect your privacy'), desc=_('<strong>Private Browsing</strong> clears your history to keep it secret from anyone who uses your computer.'), class='private') }}
+      {% if l10n_has_tag('firefox-new-skyline') %}
+        {{ picto_card(title=_('See what’s being blocked'), desc=_('Firefox shows you how many data-collecting trackers are blocked with <strong>Enhanced Tracking Protection</strong>.'), class='skyline-etp') }}
+        {{ picto_card(title=_('Make your passwords portable'), desc=_('<strong>Firefox Lockwise</strong> makes the passwords you save in Firefox secure and available on all your devices.'), class='skyline-lockwise') }}
+        {{ picto_card(title=_('Watch for data breaches'), desc=_('<strong>Firefox Monitor</strong> alerts you if we know your information is a part of another company’s data breach. '), class='skyline-monitor') }}
+      {% else %}
+        {{ picto_card(title=_('Join Firefox'), desc=_('Connect to a whole family of respectful products, plus all the knowledge you need to protect yourself online.'), class='join') }}
+        {{ picto_card(title=_('Passwords made portable'), desc=_('<strong>Firefox Lockwise</strong> makes the passwords you save in Firefox available on all your devices.'), class='lockwise') }}
+        {{ picto_card(title=_('Protect your privacy'), desc=_('<strong>Private Browsing</strong> clears your history to keep it secret from anyone who uses your computer.'), class='private') }}
+      {% endif %}
     </ul>
   </section>
 </main>

--- a/bedrock/firefox/templates/firefox/new/trailhead/download.html
+++ b/bedrock/firefox/templates/firefox/new/trailhead/download.html
@@ -16,9 +16,15 @@
 
 {% block content %}
 <main role="main" class="main-download" {% if v %}data-variant="{{ v }}"{% endif %}>
+  {% if l10n_has_tag('firefox-new-skyline') %}
+    {% set tagline = _('Automatic privacy is here. Download Firefox to block over 2000 trackers.') %}
+  {% else %}
+    {% set tagline = _('And start getting the respect you deserve with our family of privacy-first products.') %}
+  {% endif %}
+
   {% call hero(
     title=_('Get the latest Firefox browser.'),
-    desc=_('And start getting the respect you deserve with our family of privacy-first products.'),
+    desc=tagline,
     class='mzp-has-image mzp-t-dark',
     include_cta=True,
     image_url='img/firefox/new/trailhead/browser-window.svg',
@@ -43,9 +49,15 @@
   {% endcall %}
   <section class="features">
     <ul class="mzp-l-card-third mzp-l-content">
-      {{ picto_card(title=_('Join Firefox'), desc=_('Connect to a whole family of respectful products, plus all the knowledge you need to protect yourself online.'), class='join') }}
-      {{ picto_card(title=_('Passwords made portable'), desc=_('<strong>Firefox Lockwise</strong> makes the passwords you save in Firefox available on all your devices.'), class='lockwise') }}
-      {{ picto_card(title=_('Protect your privacy'), desc=_('<strong>Private Browsing</strong> clears your history to keep it secret from anyone who uses your computer.'), class='private') }}
+      {% if l10n_has_tag('firefox-new-skyline') %}
+        {{ picto_card(title=_('See what’s being blocked'), desc=_('Firefox shows you how many data-collecting trackers are blocked with <strong>Enhanced Tracking Protection</strong>.'), class='skyline-etp') }}
+        {{ picto_card(title=_('Make your passwords portable'), desc=_('<strong>Firefox Lockwise</strong> makes the passwords you save in Firefox secure and available on all your devices.'), class='skyline-lockwise') }}
+        {{ picto_card(title=_('Watch for data breaches'), desc=_('<strong>Firefox Monitor</strong> alerts you if we know your information is a part of another company’s data breach. '), class='skyline-monitor') }}
+      {% else %}
+        {{ picto_card(title=_('Join Firefox'), desc=_('Connect to a whole family of respectful products, plus all the knowledge you need to protect yourself online.'), class='join') }}
+        {{ picto_card(title=_('Passwords made portable'), desc=_('<strong>Firefox Lockwise</strong> makes the passwords you save in Firefox available on all your devices.'), class='lockwise') }}
+        {{ picto_card(title=_('Protect your privacy'), desc=_('<strong>Private Browsing</strong> clears your history to keep it secret from anyone who uses your computer.'), class='private') }}
+      {% endif %}
     </ul>
   </section>
 </main>

--- a/media/css/firefox/campaign/download.scss
+++ b/media/css/firefox/campaign/download.scss
@@ -64,6 +64,10 @@ $image-path: '/media/protocol/img';
 .mzp-c-card-picto .mzp-c-card-picto-content {
     padding-top: 140px;
 
+    .mzp-c-card-picto-title {
+        margin-bottom: $spacing-lg;
+    }
+
     &:before {
         background-color: transparent;
         background-position: top left;
@@ -72,7 +76,6 @@ $image-path: '/media/protocol/img';
 
     @media #{$mq-lg} {
         .mzp-c-card-picto-title {
-            @include text-display-sm;
             margin-bottom: $spacing-xl;
         }
     }
@@ -97,4 +100,37 @@ $image-path: '/media/protocol/img';
     width: 113px;
     margin-left: -56px;
     background-image: url('/media/img/firefox/new/trailhead/icon-private.svg');
+}
+
+/* Skyline picto card updates */
+.skyline-etp.mzp-c-card-picto,
+.skyline-lockwise.mzp-c-card-picto,
+.skyline-monitor.mzp-c-card-picto {
+    .mzp-c-card-picto-content {
+        padding-top: 120px;
+    }
+}
+
+.skyline-etp .mzp-c-card-picto-content::before {
+    @include background-size(80px 96px);
+    background-image: url('/media/img/icons/gradient-shield.svg');
+    height: 96px;
+    margin-left: -40px;
+    width: 80px;
+}
+
+.skyline-lockwise .mzp-c-card-picto-content::before {
+    @include background-size(96px 96px);
+    background-image: url('/media/protocol/img/logos/firefox/lockwise/logo.svg');
+    height: 96px;
+    margin-left: -48px;
+    width: 96px;
+}
+
+.skyline-monitor .mzp-c-card-picto-content::before {
+    @include background-size(96px 96px);
+    background-image: url('/media/protocol/img/logos/firefox/monitor/logo.svg');
+    height: 96px;
+    margin-left: -48px;
+    width: 96px;
 }

--- a/media/css/firefox/new/trailhead/download.scss
+++ b/media/css/firefox/new/trailhead/download.scss
@@ -129,6 +129,10 @@ html.ios .mzp-c-hero {
 .mzp-c-card-picto .mzp-c-card-picto-content {
     padding-top: 140px;
 
+    .mzp-c-card-picto-title {
+        margin-bottom: $spacing-lg;
+    }
+
     &:before {
         background-color: transparent;
         background-position: top left;
@@ -137,7 +141,6 @@ html.ios .mzp-c-hero {
 
     @media #{$mq-lg} {
         .mzp-c-card-picto-title {
-            @include text-display-sm;
             margin-bottom: $spacing-xl;
         }
     }
@@ -162,6 +165,39 @@ html.ios .mzp-c-hero {
     width: 113px;
     margin-left: -56px;
     background-image: url('/media/img/firefox/new/trailhead/icon-private.svg');
+}
+
+/* Skyline picto card updates */
+.skyline-etp.mzp-c-card-picto,
+.skyline-lockwise.mzp-c-card-picto,
+.skyline-monitor.mzp-c-card-picto {
+    .mzp-c-card-picto-content {
+        padding-top: 120px;
+    }
+}
+
+.skyline-etp .mzp-c-card-picto-content::before {
+    @include background-size(80px 96px);
+    background-image: url('/media/img/icons/gradient-shield.svg');
+    height: 96px;
+    margin-left: -40px;
+    width: 80px;
+}
+
+.skyline-lockwise .mzp-c-card-picto-content::before {
+    @include background-size(96px 96px);
+    background-image: url('/media/protocol/img/logos/firefox/lockwise/logo.svg');
+    height: 96px;
+    margin-left: -48px;
+    width: 96px;
+}
+
+.skyline-monitor .mzp-c-card-picto-content::before {
+    @include background-size(96px 96px);
+    background-image: url('/media/protocol/img/logos/firefox/monitor/logo.svg');
+    height: 96px;
+    margin-left: -48px;
+    width: 96px;
 }
 
 //* ====================================================================== */


### PR DESCRIPTION
## Description
- Updates `/firefox/new/` and `/firefox/campaign/` with Skyline content, based on the outcome of https://github.com/mozilla/bedrock/issues/7857.

## Issue / Bugzilla link
#7851

## Testing
- [ ] New strings should all be behind an L10n conditional tag.