### PR TITLE
Fix double encoded UTM params on /firefox page (Fixes #8163)

### DIFF
--- a/bedrock/exp/templates/exp/firefox/index.de.html
+++ b/bedrock/exp/templates/exp/firefox/index.de.html
@@ -34,7 +34,7 @@
 
 {% block body_id %}firefox-master{% endblock %}
 
-{% set referrals = '?utm_source=www.mozilla.org&amp;utm_medium=referral&amp;utm_campaign=firefox-home' %}
+{% set referrals = '?utm_source=www.mozilla.org&utm_medium=referral&utm_campaign=firefox-home' %}
 
 {% block content %}
 <main role="main" class="firefox-home">

--- a/bedrock/exp/templates/exp/firefox/index.html
+++ b/bedrock/exp/templates/exp/firefox/index.html
@@ -43,7 +43,7 @@
 
 {% block body_id %}firefox-master{% endblock %}
 
-{% set referrals = '?utm_source=www.mozilla.org&amp;utm_medium=referral&amp;utm_campaign=firefox-home' %}
+{% set referrals = '?utm_source=www.mozilla.org&utm_medium=referral&utm_campaign=firefox-home' %}
 
 {% block content %}
 <main role="main" class="firefox-home">

--- a/bedrock/firefox/templates/firefox/home/index-master.html
+++ b/bedrock/firefox/templates/firefox/home/index-master.html
@@ -36,7 +36,7 @@
 
 {% block body_id %}firefox-master{% endblock %}
 
-{% set referrals = '?utm_source=www.mozilla.org&amp;utm_medium=referral&amp;utm_campaign=firefox-home' %}
+{% set referrals = '?utm_source=www.mozilla.org&utm_medium=referral&utm_campaign=firefox-home' %}
 
 {# Setting all the strings here make it easy to use this page as a base template if we need to hard code the translation in bedrock #}
 {% set page_title = _('The browser is just the beginning') %}


### PR DESCRIPTION
## Description
- Fixes UTM param encoding for external links on the /firefox page.

## Issue / Bugzilla link
#8163

## Testing
Links should be appear as:

https://monitor.firefox.com/?utm_source=www.mozilla.org&utm_medium=referral&utm_campaign=firefox-home

Instead of:

https://monitor.firefox.com/?utm_source=www.mozilla.org&amp;utm_medium=referral&amp;utm_campaign=firefox-home