### PR TITLE
Fix success message displayed above page headline on newsletter/recovery/ (Fixes #8217)

### DIFF
--- a/bedrock/newsletter/templates/newsletter/recovery.html
+++ b/bedrock/newsletter/templates/newsletter/recovery.html
@@ -10,13 +10,12 @@
 {% block page_title %}{{ _('Newsletter email recovery') }}{% endblock page_title %}
 
 {% block content %}
-  {% block main_feature %}
-    <div id="main-feature">
-      <h1>{{ _('Manage your <span>Newsletter Subscriptions</span>') }}</h1>
-    </div>
-  {% endblock %}
-
   {% if form %}
+    {% block main_feature %}
+      <div id="main-feature">
+        <h1>{{ _('Manage your <span>Newsletter Subscriptions</span>') }}</h1>
+      </div>
+    {% endblock %}
     <form method="post" action="{{ url('newsletter.recovery') }}" id="newsletter-recovery-form" class="container billboard">
       {% if form.non_field_errors() %}
         <div class="errorlist">


### PR DESCRIPTION
## Description
Remove the page headline after a successful submission on [newsletter/recovery/](https://www.mozilla.org/newsletter/recovery/)


![Снимок экрана от 2019-11-29 14-43-06](https://user-images.githubusercontent.com/40304614/69866990-9e746f00-12b6-11ea-813a-a78168bab796.png)


## Issue / Bugzilla link
#8217 
