### PR TITLE
Whatsnew experiment template should extend /exp/ base template (Fixes #8246)

### DIFF
--- a/bedrock/exp/templates/exp/firefox/whatsnew/whatsnew-fx71.html
+++ b/bedrock/exp/templates/exp/firefox/whatsnew/whatsnew-fx71.html
@@ -4,9 +4,10 @@
 
 {% from "macros.html" import monitor_button, fxa_cta_link with context %}
 
-{% add_lang_files "firefox/whatsnew_71" %}
+{% extends "exp/base/base-firefox.html" %}
 
-{% extends "firefox/base/base-protocol.html" %}
+{# "noindex" pages should not have the canonical or hreflang tags: bug 1442331 #}
+{% block canonical_urls %}<meta name="robots" content="noindex,follow">{% endblock %}
 
 {% block page_title %}What’s new with Firefox - More privacy, more protections.{% endblock %}
 


### PR DESCRIPTION
## Description

http://localhost:8000/en-US/exp/firefox/71.0/whatsnew/all/

## Issue / Bugzilla link
#8246

## Testing
- [x] Convert bundle should be loaded
- [x] Page should be no index