### PR TITLE
Add exp/firefox/new version with nav #8037

### DIFF
--- a/bedrock/exp/templates/exp/firefox/new/download-nav.html
+++ b/bedrock/exp/templates/exp/firefox/new/download-nav.html
@@ -1,0 +1,9 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+
+{% extends "exp/firefox/new/download.html" %}
+
+{% block site_header %}
+  {% include 'includes/protocol/navigation/menu-firefox/index.html' %}
+{% endblock %}

--- a/bedrock/exp/urls.py
+++ b/bedrock/exp/urls.py
@@ -16,6 +16,7 @@ urlpatterns = (
     page('opt-out', 'exp/opt-out.html'),
     page('firefox', 'exp/firefox/index.html', active_locales=['en-US', 'en-GB', 'en-CA', 'de']),
     page('firefox/new', 'exp/firefox/new/download.html', active_locales=['en-US', 'en-GB', 'en-CA', 'de']),
+    page('firefox/new/nav', 'exp/firefox/new/download-nav.html'),
     page('firefox/accounts', 'exp/firefox/accounts-2019.html'),
     page('firefox/lockwise', 'exp/firefox/lockwise.html', active_locales=['en-US', 'en-GB', 'en-CA', 'de']),
     page('firefox', 'exp/firefox/index.html', active_locales=['en-US', 'en-GB', 'en-CA', 'de']),


### PR DESCRIPTION
## Description

Adds a version of exp/firefox/new with the navigation menu on it. It displays at http://localhost:8000/en-US/exp/firefox/new/nav/

## Issue / Bugzilla link

See #8037

## Testing

http://localhost:8000/en-US/exp/firefox/new/nav/

- [x] no index
- [x] convert JS loads