### PR TITLE
[fix #8223] Update newsletter country label

### DIFF
--- a/bedrock/newsletter/forms.py
+++ b/bedrock/newsletter/forms.py
@@ -263,7 +263,10 @@ class NewsletterFooterForm(forms.Form):
             lang, country = lang.split('-', 1)
         else:
             country = ''
-            regions.insert(0, ('', _lazy('Select country')))
+            if locale.startswith('en'):
+                regions.insert(0, ('', _lazy('Select country or region')))
+            else:
+                regions.insert(0, ('', _lazy('Select country')))
         lang_choices = get_lang_choices(newsletters)
         languages = [x[0] for x in lang_choices]
         if lang not in languages:

--- a/bedrock/newsletter/forms.py
+++ b/bedrock/newsletter/forms.py
@@ -9,7 +9,7 @@ from django import forms
 from django.core.exceptions import ValidationError
 from django.forms import widgets
 from django.utils.safestring import mark_safe
-from lib.l10n_utils.dotlang import _, _lazy
+from lib.l10n_utils.dotlang import _, _lazy, lang_file_has_tag
 from product_details import product_details
 
 from bedrock.mozorg.forms import (FORMATS, EmailInput, PrivacyWidget,
@@ -263,7 +263,10 @@ class NewsletterFooterForm(forms.Form):
             lang, country = lang.split('-', 1)
         else:
             country = ''
-            regions.insert(0, ('', _lazy('Select country')))
+            if lang_file_has_tag('mozorg/newsletters', locale, 'country_region_122019'):
+                regions.insert(0, ('', _lazy('Select country or region')))
+            else:
+                regions.insert(0, ('', _lazy('Select country')))
         lang_choices = get_lang_choices(newsletters)
         languages = [x[0] for x in lang_choices]
         if lang not in languages:

--- a/bedrock/newsletter/forms.py
+++ b/bedrock/newsletter/forms.py
@@ -263,10 +263,7 @@ class NewsletterFooterForm(forms.Form):
             lang, country = lang.split('-', 1)
         else:
             country = ''
-            if locale.startswith('en'):
-                regions.insert(0, ('', _lazy('Select country or region')))
-            else:
-                regions.insert(0, ('', _lazy('Select country')))
+            regions.insert(0, ('', _lazy('Select country')))
         lang_choices = get_lang_choices(newsletters)
         languages = [x[0] for x in lang_choices]
         if lang not in languages:

--- a/bedrock/newsletter/templates/newsletter/country.html
+++ b/bedrock/newsletter/templates/newsletter/country.html
@@ -7,7 +7,7 @@
 
 {% block body_id %}newsletter-country{% endblock body_id %}
 
-{% block page_title %}Newsletter Country{% endblock page_title %}
+{% block page_title %}Newsletter Country or Region{% endblock page_title %}
 
 {% block content %}
   {% if switch('newsletter-maintenance-mode') %}
@@ -21,7 +21,7 @@
     <div id="main-feature">
       <h1>Thanks for updating your info with us!</h1>
       <p>
-        Simply select your country from the list below and hit "submit."<br>
+        Simply select your country or region from the list below and hit "submit."<br>
         We've pre-filled what we think is correct, but make sure to check that it's right
         before clicking the button. Thanks!
       </p>

--- a/bedrock/newsletter/templates/newsletter/country_success.html
+++ b/bedrock/newsletter/templates/newsletter/country_success.html
@@ -5,11 +5,11 @@
 
 {% block body_id %}newsletter-country-success{% endblock body_id %}
 
-{% block page_title %}Newsletter Country{% endblock page_title %}
+{% block page_title %}Newsletter Country or Region{% endblock page_title %}
 
 {% block content %}
   <div id="main-feature">
-    <h1>Thanks for updating your country!</h1>
+    <h1>Thanks for updating your country or region!</h1>
     <section class="billboard">
     <p>We'll now be able to keep you up to date on interesting things happening near you.</p>
     <p>Please be sure to add our sending address: mozilla@e.mozilla.org to your address book to ensure we always reach your inbox.</p>

--- a/bedrock/newsletter/templates/newsletter/existing.html
+++ b/bedrock/newsletter/templates/newsletter/existing.html
@@ -72,7 +72,11 @@
 
         {% set country = form['country'] %}
         <div class="field country-field {% if country.errors %}field-error{% endif %}">
+        {% if l10n_has_tag('country_region_122019') %}
+          {{ form.country.label_tag(_('Country or region:')) }}
+        {% else %}
           {{ form.country.label_tag(_('Country:')) }}
+        {% endif %}
           <div class="field-contents">
             {{ country }}
           </div>


### PR DESCRIPTION
## Description
Updates newsletter "Country" labels to "Country or region", to encompass places that are distinct regions but not separate countries.

Strings were already added in https://github.com/mozilla-l10n/www.mozilla.org/pull/357

## Issue / Bugzilla link
#8223 