### PR TITLE
Fix `mobile-protocol.scss` (Fixes #8170)

### DIFF
--- a/media/css/firefox/mobile-protocol.scss
+++ b/media/css/firefox/mobile-protocol.scss
@@ -13,13 +13,6 @@ $image-path: '/media/protocol/img';
 
 
 //* -------------------------------------------------------------------------- */
-// Page specific variables and over-rides
-
-$fx-body: #42425A;
-$fx-blue: #0A84FF;
-$fx-pink: #FF2889;
-$fx-purple: #20123A;
-$fx-yellow: #FFE55B;
 
 // not yet recognized as valid by style lint, so we abstract it
 $mq-reduced-motion: 'screen and (prefers-reduced-motion: reduce)';
@@ -165,7 +158,7 @@ main .mzp-l-content {
 .t-hero-primary {
     &.mzp-c-hero {
         text-align: center;
-        color: $fx-purple;
+        color: $color-off-black;
 
         &.mzp-t-firefox::after {
             display: none;
@@ -221,12 +214,12 @@ main .mzp-l-content {
 
 .t-private {
     @include light-links;
-    background-color: $fx-purple;
+    background-color: $color-off-black;
     color: #fff;
 
     h2 {
         @include text-display-lg;
-        color: $fx-pink;
+        color: $color-pink-50;
         margin-top: $spacing-md;
     }
 
@@ -309,11 +302,11 @@ main .mzp-l-content {
 
     .mzp-c-card-feature-title {
         @include text-display-lg;
-        color: $fx-purple;
+        color: $color-off-black;
     }
 
     .mzp-c-card-feature-desc {
-        color: $fx-body;
+        color: $color-gray-80;
     }
 }
 
@@ -367,7 +360,7 @@ main .mzp-l-content {
 
     img {
         animation: custom 6s infinite step-end;
-        background-color: $fx-yellow;
+        background-color: $color-yellow-20;
         background-image: url('/media/img/firefox/mobile/protocol/extend-key.svg'), url('/media/img/firefox/mobile/protocol/extend-eye.svg'), url('/media/img/firefox/mobile/protocol/extend-star.svg');
         background-position: 50% 75%, 500px 500px, 500px 500px;
         background-repeat: no-repeat;
@@ -447,7 +440,7 @@ main .mzp-l-content {
 
     h3 {
         @include text-display-md;
-        color: $fx-purple;
+        color: $color-off-black;
         margin-bottom: 0;
 
         + p {


### PR DESCRIPTION
## Description
Replaced 
```
$fx-body: #42425A;
$fx-blue: #0A84FF;
$fx-pink: #FF2889;
$fx-purple: #20123A;
$fx-yellow: #FFE55B;
```
with [Protocol Colors](https://protocol.mozilla.org/fundamentals/color.html) in `mobile-protocol.scss`.

## Issue
#8170