### PR TITLE
Change Firefox pages to have wide twitter image

### DIFF
--- a/bedrock/base/templates/base-pebbles.html
+++ b/bedrock/base/templates/base-pebbles.html
@@ -33,7 +33,7 @@
     <meta property="og:title" content="{% filter striptags|e %}{% block page_og_title %}{{ self.page_title_full() }}{% endblock %}{% endfilter %}">
     <meta property="og:description" content="{% filter striptags|e %}{% block page_og_desc %}{{ self.page_desc() }}{% endblock %}{% endfilter %}">
     <meta property="fb:page_id" content="{% block facebook_id %}262134952380{# facebook.com/mozilla #}{% endblock %}">
-    <meta name="twitter:card" content="summary">
+    <meta name="twitter:card" content="{% block twitter_card %}summary{% endblock %}">
     <meta name="twitter:site" content="@{% block twitter_id %}mozilla{% endblock %}">
     <meta name="twitter:domain" content="mozilla.org">
     <meta name="twitter:app:name:googleplay" content="{% block android_app_name %}{{ _('Firefox') }}{% endblock %}">

--- a/bedrock/base/templates/base-resp.html
+++ b/bedrock/base/templates/base-resp.html
@@ -33,7 +33,7 @@
     <meta property="og:title" content="{% filter striptags|e %}{% block page_og_title %}{{ self.page_title_full() }}{% endblock %}{% endfilter %}">
     <meta property="og:description" content="{% filter striptags|e %}{% block page_og_desc %}{{ self.page_desc() }}{% endblock %}{% endfilter %}">
     <meta property="fb:page_id" content="{% block facebook_id %}262134952380{# facebook.com/mozilla #}{% endblock %}">
-    <meta name="twitter:card" content="summary">
+    <meta name="twitter:card" content="{% block twitter_card %}summary{% endblock %}">
     <meta name="twitter:site" content="@{% block twitter_id %}mozilla{% endblock %}">
     <meta name="twitter:domain" content="mozilla.org">
     <meta name="twitter:app:name:googleplay" content="{% block android_app_name %}{{ _('Firefox') }}{% endblock %}">

--- a/bedrock/firefox/templates/firefox/base/base-pebbles.html
+++ b/bedrock/firefox/templates/firefox/base/base-pebbles.html
@@ -11,6 +11,7 @@
 {% block page_favicon %}{{ static('img/favicons/firefox/browser/favicon.ico') }}{% endblock %}
 {% block page_favicon_large %}{{ static('img/favicons/firefox/browser/favicon-196x196.png') }}{% endblock %}
 {% block page_ios_icon %}{{ static('img/favicons/firefox/browser/apple-touch-icon.png') }}{% endblock %}
+{% block twitter_card %}summary_large_image{% endblock %}
 
 {% block facebook_id %}14696440021{# facebook.com/Firefox #}{% endblock %}
 {% block twitter_id %}firefox{% endblock %}

--- a/bedrock/firefox/templates/firefox/base/base-protocol.html
+++ b/bedrock/firefox/templates/firefox/base/base-protocol.html
@@ -11,6 +11,7 @@
 {% block page_favicon %}{{ static('img/favicons/firefox/browser/favicon.ico') }}{% endblock %}
 {% block page_favicon_large %}{{ static('img/favicons/firefox/browser/favicon-196x196.png') }}{% endblock %}
 {% block page_ios_icon %}{{ static('img/favicons/firefox/browser/apple-touch-icon.png') }}{% endblock %}
+{% block twitter_card %}summary_large_image{% endblock %}
 
 {% block facebook_id %}14696440021{# facebook.com/Firefox #}{% endblock %}
 {% block twitter_id %}firefox{% endblock %}

--- a/bedrock/firefox/templates/firefox/base/base-resp.html
+++ b/bedrock/firefox/templates/firefox/base/base-resp.html
@@ -14,6 +14,7 @@
 {% block page_favicon %}{{ static('img/favicons/firefox/browser/favicon.ico') }}{% endblock %}
 {% block page_favicon_large %}{{ static('img/favicons/firefox/browser/favicon-196x196.png') }}{% endblock %}
 {% block page_ios_icon %}{{ static('img/favicons/firefox/browser/apple-touch-icon.png') }}{% endblock %}
+{% block twitter_card %}summary_large_image{% endblock %}
 
 {% block facebook_id %}14696440021{# facebook.com/Firefox #}{% endblock %}
 {% block twitter_id %}firefox{% endblock %}


### PR DESCRIPTION
## Description

- Make the twitter card size into an editable block in the template.
- Edit the Firefox base template to use wider cards (we got wide open graph images for all Firefox products with the last logo update)

## Issue / Bugzilla link

n/a

## Testing

- large cards are configured on firefox pages
- `summary` is still the default on Mozilla pages