### PR TITLE
[fix #8278] Broken social links in Fx footer on pebbles pages

### DIFF
--- a/media/css/pebbles/components/_protocol-footer.scss
+++ b/media/css/pebbles/components/_protocol-footer.scss
@@ -51,8 +51,21 @@ $image-path: '/media/protocol/img';
     }
 }
 
+// bug fixes
+.mzp-c-footer-language {
+    float: none;
+}
 
-// bug fix, remove after backported to Protocol
-.mzp-c-footer-links-social li a {
-    background-repeat: no-repeat;
+.mzp-c-footer-links-social {
+    @include bidi(((text-align, left, right),));
+    max-width: none;
+    position: static;
+
+    li {
+        padding: 0 24px 16px 0;
+    }
+
+    li a {
+        background-repeat: no-repeat;
+    }
 }


### PR DESCRIPTION
## Description
The social icons in the Firefox footer on Pebbles-based pages were getting absolute positioning from the older/regular footer and needed a few extra overrides. It's a bit of a hack but can eventually go away with the rest of Pebbles.

## Issue / Bugzilla link
#8278 

## Testing
Some Pebbles-based Firefox pages:
http://localhost:8000/firefox/73.0a1/whatsnew/all/
http://localhost:8000/firefox/features/
http://localhost:8000/firefox/features/bookmarks/