### PR TITLE
Add build-test job to .gitlab-ci.yml

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -24,6 +24,16 @@ build:
     - FROM_DOCKER_REPOSITORY=mozorg/bedrock docker/bin/push2dockerhub.sh
     - bin/upload-staticfiles.sh
 
+build-test:
+  stage: build
+  only:
+    - build-test
+  tags:
+    - oregon-b-shell
+  script:
+    - make clean build-ci
+    - FROM_DOCKER_REPOSITORY=mozorg/bedrock_test docker/bin/push2dockerhub.sh
+
 .update-config:
   stage: update-config
   tags:


### PR DESCRIPTION
This job enables building custom test images by pushing to the `build-test` branch. See https://gitlab.com/mozmeao/bedrock/pipelines/101797359 (also linked from the ci/gitlab/build-test details below) for example of this job.