### PR TITLE
Build images and update oregon-b/bedrock-test deployment

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -24,6 +24,17 @@ build:
     - FROM_DOCKER_REPOSITORY=mozorg/bedrock docker/bin/push2dockerhub.sh
     - bin/upload-staticfiles.sh
 
+build-test:
+  stage: build
+  only:
+    - run-integration-tests
+  tags:
+    - oregon-b-shell
+  script:
+    - make clean build-ci
+    - FROM_DOCKER_REPOSITORY=mozorg/bedrock_test docker/bin/push2dockerhub.sh
+    - FROM_DOCKER_REPOSITORY=mozorg/bedrock docker/bin/push2dockerhub.sh
+
 .update-config:
   stage: update-config
   tags:
@@ -45,6 +56,14 @@ stage:
   variables:
     CLUSTERS: iowa-a
     NAMESPACE: bedrock-stage
+
+test:
+  extends: .update-config
+  only:
+    - run-integration-tests
+  variables:
+    CLUSTERS: oregon-b
+    NAMESPACE: bedrock-test
 
 prod:
   extends: .update-config


### PR DESCRIPTION
This restores the `git push run-integration-tests` workflow previously implemented with Jenkins & Deis Workflow, but now with Gitlab & a dedicated deployment in oregon-b.

See also: 
  - mozmeao/www-config#255 
  - mozmeao/infra#1185

The latest push to `run-integration-tests` (this branch) triggered https://gitlab.com/mozmeao/bedrock/pipelines/101844478 which in turn triggered https://gitlab.com/mozmeao/www-config/pipelines/101844766
