### PR TITLE
Update UITour to take advantage of new FxA capabilities (Fixes #8200)

### DIFF
--- a/media/js/base/mozilla-client.js
+++ b/media/js/base/mozilla-client.js
@@ -17,7 +17,34 @@ if (typeof window.Mozilla === 'undefined') {
      * @see {@link https://developer.mozilla.org/en-US/docs/Gecko_user_agent_string_reference}
      */
     var Client = {};
-    var FxALastSupported = 40; // the FxAccounts team provided this number in bug 1457004#c21 they don't want to support anything beneath it
+
+    /**
+     * Minimum Firefox version supported by FxA.
+     * https://mozilla.github.io/ecosystem-platform/docs/fxa-engineering/fxa-dev-process#browser-support
+     */
+    Client.FxALastSupported = 60;
+
+    /**
+     * Account services OAuth client ID table.
+     * https://docs.telemetry.mozilla.org/datasets/fxa_metrics/attribution.html#service-attribution
+     */
+    Client.FxaServices = {
+        'amo-web': 'a4907de5fa9d78fc',
+        'fenix-sync': 'a2270f727f45f648',
+        'firefox-addons': '3a1f53aabe17ba32',
+        'firefox-lockwise-android': 'e7ce535d93522896',
+        'firefox-lockwise-ios': '98adfa37698f255b',
+        'firefox-monitor': '802d56ef2a9af9fa',
+        'firefox-notes-android': '7f368c6886429f19',
+        'firefox-notes-desktop': 'a3dbd8c5a6fd93e2',
+        'firefox-screenshots': '5e75409a5a3f096d',
+        'firefox-send-android': '20f7931c9054d833',
+        'firefox-send-web': '1f30e32975ae5112',
+        'fxa-content': 'ea3ca969f8c6bb0d',
+        'mozilla-email-preferences': 'c40f32fd2938f0b6',
+        'pocket-mobile': '7377719276ad44ee',
+        'pocket-web': '749818d3f2e7857f'
+    };
 
     /**
      * Detect whether the user's browser is Firefox on any platform. This includes WebKit-based Firefox for iOS.
@@ -325,18 +352,18 @@ if (typeof window.Mozilla === 'undefined') {
      * Use the async mozUITour API of Firefox to retrieve the user's FxA info. See
      * http://bedrock.readthedocs.org/en/latest/uitour.html for details.
      *
-     * FxA was previously branded as Sync.
-     *
      * The various states here are... complicated
      * This is the intention:
      *     - firefox: true if Firefox
      *     - legacy: true if older than FxALastSupported
      *     - mobile: false | android | ios
-     *     - setup: true if Fx >= 29 and logged into FxA
-     *     - desktopDevices & mobileDevices
-     *          - if logged in and Fx >= 50: the number of linked devices
-     *          - if logged in and Fx < 50 && Fx > 29: 'unknown'
-     *          - if logged out or Fx < 29 or not Fx: false
+     *     - setup: true if Fx >= 29 and logged into *Sync*.
+     *              true if Fx >= 74 and logged into *FxA*.
+     *     - browserServices.sync
+     *              setup: logged into Sync.
+     *              desktopDevices: number of desktop devices synced.
+     *              mobileDevices: number of mobile devices synced.
+     *              totalDevices: number of total devices synced.
      * Notes:
      * - Fx < 50 has FxA and UITour support but the API does not return device counts
      * - Fx < FxALastSupported accounts.firefox.com does not work
@@ -349,73 +376,136 @@ if (typeof window.Mozilla === 'undefined') {
      * @param  {Function} callback - callback function to be executed with the FxA details
      * @return {None}
      */
+
     Client.getFxaDetails = function (callback) {
         // Fire the callback function immediately if FxaDetails are already defined
         if (Client.FxaDetails) {
             callback(Client.FxaDetails);
-
             return;
         }
-        // set up the object with default values of false
+
+        var request = {
+            name: null,
+            callback: null
+        };
+
+        // Set up the object with default values of false
         var details = {
             'firefox': false,
             'legacy': false,
             'mobile': false,
             'setup': false,
-            'desktopDevices': false,
-            'mobileDevices': false
+            'browserServices': {
+                'sync': {
+                    'setup': false,
+                    'desktopDevices': false,
+                    'mobileDevices': false,
+                    'totalDevices': false
+                }
+            }
         };
 
-        // override object values as we get more information
-        if(Client.isFirefoxAndroid) {
+        // Override object values as we get more information
+        if (Client._isFirefoxAndroid()) {
             details.firefox = true;
             details.mobile = 'android';
             returnFxaDetails();
-        } else if (Client.isFirefoxiOS) {
+            return;
+        } else if (Client._isFirefoxiOS()) {
             details.firefox = true;
             details.mobile = 'ios';
             returnFxaDetails();
-        } else if(Client.isFirefoxDesktop) {
+            return;
+        } else if (Client._isFirefoxDesktop()) {
             details.firefox = true;
-            // firefox desktop
-            var userVer = Client._getFirefoxVersion();
-            if(parseFloat(userVer) < 29) {
+            var userVer = parseFloat(Client._getFirefoxVersion());
+
+            if (userVer < 29) {
                 // UITour not supported
                 details.legacy = true;
+                returnFxaDetails();
+                return;
             } else {
                 // UITour supported
                 // still note if it's older than accounts.firefox.com supports
-                if (parseFloat(userVer) < FxALastSupported) {
+                if (userVer < Client.FxALastSupported) {
                     details.legacy = true;
                 }
 
                 // callbackID to make sure we're responding to our request
                 var callbackID = Math.random().toString(36).replace(/[^a-z]+/g, '');
 
-                // UITour API response event handler, checks for callbackID
-                var listener = function (event) {
+                // UITour API response event handler for 'sync', checks for callbackID
+                var listenerSync = function (event) {
                     if (!event.detail || !event.detail.data || event.detail.callbackID !== callbackID) {
                         return;
                     }
-                    window.clearTimeout(timer);
-                    document.removeEventListener('mozUITourResponse', listener, false);
 
-                    // device counts
-                    // device counts are only available in Fx50+, fallback 'unknown' if not detectable
-                    details.setup = Object.prototype.hasOwnProperty.call(event.detail.data, 'setup') ? event.detail.data.setup : 'unknown';
-                    details.desktopDevices = Object.prototype.hasOwnProperty.call(event.detail.data, 'desktopDevices') ? event.detail.data.desktopDevices : 'unknown';
-                    details.mobileDevices = Object.prototype.hasOwnProperty.call(event.detail.data, 'mobileDevices') ? event.detail.data.mobileDevices : 'unknown';
+                    var config = event.detail.data;
+
+                    // Clear the timeout and remove the event listener.
+                    window.clearTimeout(timer);
+                    document.removeEventListener('mozUITourResponse', listenerSync, false);
+
+                    /**
+                     * Account signed-in state
+                     * Assume being signed-in to Sync equals being signed in to an account.
+                     */
+                    details.setup = config.setup;
+
+                    /**
+                     * Browser services
+                     * Device counts are only available in Fx50+, fallback 'unknown' if not detectable
+                     */
+                    details.browserServices.sync = {
+                        setup: config.setup,
+                        desktopDevices: Object.prototype.hasOwnProperty.call(config, 'desktopDevices') ? config.desktopDevices : 'unknown',
+                        mobileDevices: Object.prototype.hasOwnProperty.call(config, 'mobileDevices') ? config.mobileDevices : 'unknown',
+                        totalDevices: Object.prototype.hasOwnProperty.call(config, 'totalDevices') ? config.totalDevices : 'unknown'
+                    };
 
                     returnFxaDetails();
                 };
 
+                // UITour API response event handler for 'fxa', checks for callbackID
+                var listenerFxA = function (event) {
+                    if (!event.detail || !event.detail.data || event.detail.callbackID !== callbackID) {
+                        return;
+                    }
+
+                    var config = event.detail.data;
+
+                    // Clear the timeout and remove the event listener.
+                    window.clearTimeout(timer);
+                    document.removeEventListener('mozUITourResponse', listenerFxA, false);
+
+                    // Account signed-in state
+                    details.setup = config.setup;
+
+                    // Browser services (Sync is the only service here currently).
+                    details.browserServices = config.browserServices;
+
+                    returnFxaDetails();
+                };
+
+                // Query Firefox Account signed In stage via 'fxa' config.
+                if (userVer >= 74) {
+                    request.name = 'fxa';
+                    request.callback = listenerFxA;
+                }
+                // UITour supported but client must use legacy 'sync' configuration call.
+                else {
+                    request.name = 'sync';
+                    request.callback = listenerSync;
+                }
+
                 // Trigger the UITour API and start listening for the reponse
-                document.addEventListener('mozUITourResponse', listener, false);
+                document.addEventListener('mozUITourResponse', request.callback, false);
                 document.dispatchEvent(new CustomEvent('mozUITour', {
                     'bubbles': true,
                     'detail': {
                         'action': 'getConfiguration',
-                        'data': { 'configuration': 'sync', 'callbackID': callbackID }
+                        'data': { 'configuration': request.name, 'callbackID': callbackID }
                     }
                 }));
             }
@@ -431,6 +521,98 @@ if (typeof window.Mozilla === 'undefined') {
         var timer = window.setTimeout(returnFxaDetails, 400);
     };
 
+    Client.getFxaConnections = function(callback) {
+        // Fire the callback function immediately if FxaDetails are already defined
+        if (Client.FxaConnections) {
+            callback(Client.FxaConnections);
+            return;
+        }
+
+        // Set up the object with default values of false
+        var details = {
+            'setup': false,
+            'unsupported': false,
+            'firefox': false,
+            'numOtherDevices': false,
+            'numDevicesByType': {},
+            'accountServices': {}
+        };
+
+        var userVer = parseFloat(Client._getFirefoxVersion());
+
+        if (!Client._isFirefoxDesktop()) {
+            // UITour not supported
+            details.unsupported = true;
+            returnFxaConnections();
+            return;
+        }
+
+        details.firefox = true;
+
+        // fxaConnections API not supported
+        if (userVer < 74) {
+            details.unsupported = true;
+            returnFxaConnections();
+            return;
+        }
+
+        // callbackID to make sure we're responding to our request
+        var callbackID = Math.random().toString(36).replace(/[^a-z]+/g, '');
+
+        // UITour API response event handler for 'fxaConnections', checks for callbackID
+        var listener = function (event) {
+            if (!event.detail || !event.detail.data || event.detail.callbackID !== callbackID) {
+                return;
+            }
+
+            var config = event.detail.data;
+
+            // Clear the timeout and remove the event listener.
+            window.clearTimeout(timer);
+            document.removeEventListener('mozUITourResponse', listener, false);
+
+            // Account signed-in state
+            details.setup = config.setup;
+
+            // Additional number of devices authenticated using the same account.
+            details.numOtherDevices = config.numOtherDevices;
+
+            // Additional devices types (we're mainly interested in mobile and desktop).
+            for (var device in config.numDevicesByType) {
+                if (Object.prototype.hasOwnProperty.call(config.numDevicesByType, device)) {
+                    details.numDevicesByType[device] = config.numDevicesByType[device];
+                }
+            }
+
+            // Account services (recently accessed).
+            for (var service in config.accountServices) {
+                if (Object.prototype.hasOwnProperty.call(config.accountServices, service)) {
+                    details.accountServices[service] = config.accountServices[service];
+                }
+            }
+
+            returnFxaConnections();
+        };
+
+        // Trigger the UITour API and start listening for the reponse
+        document.addEventListener('mozUITourResponse', listener, false);
+        document.dispatchEvent(new CustomEvent('mozUITour', {
+            'bubbles': true,
+            'detail': {
+                'action': 'getConfiguration',
+                'data': { 'configuration': 'fxaConnections', 'callbackID': callbackID }
+            }
+        }));
+
+        function returnFxaConnections() {
+            window.clearTimeout(timer);
+            Client.FxaConnections = details;
+            callback(details);
+        }
+
+        // Fire the fallback function should the remote API call be unreasonably slow.
+        var timer = window.setTimeout(returnFxaConnections, 2000);
+    };
 
     // Append static properties for faster access
     Client.isFirefox = Client._isFirefox();

--- a/media/js/firefox/whatsnew/account-conditional-ctas.js
+++ b/media/js/firefox/whatsnew/account-conditional-ctas.js
@@ -5,10 +5,10 @@
 (function(Mozilla) {
     'use strict';
 
-    Mozilla.Client.getFxaDetails(function(details){
-        if(details.setup){
+    Mozilla.Client.getFxaDetails(function(details) {
+        if (details.setup) {
             Mozilla.FxaProductButton.init();
-        }else{
+        } else {
             Mozilla.FxaForm.init();
         }
     });

--- a/tests/unit/spec/base/mozilla-client.js
+++ b/tests/unit/spec/base/mozilla-client.js
@@ -534,8 +534,103 @@ describe('mozilla-client.js', function() {
             expect(typeof window.Mozilla.Client.FxaDetails.legacy).toEqual('boolean');
             expect(typeof window.Mozilla.Client.FxaDetails.mobile).toEqual('boolean');
             expect(typeof window.Mozilla.Client.FxaDetails.setup).toEqual('boolean');
-            expect(typeof window.Mozilla.Client.FxaDetails.desktopDevices).toEqual('boolean');
-            expect(typeof window.Mozilla.Client.FxaDetails.mobileDevices).toEqual('boolean');
+            expect(typeof window.Mozilla.Client.FxaDetails.browserServices.sync.desktopDevices).toEqual('boolean');
+            expect(typeof window.Mozilla.Client.FxaDetails.browserServices.sync.mobileDevices).toEqual('boolean');
+            expect(typeof window.Mozilla.Client.FxaDetails.browserServices.sync.totalDevices).toEqual('boolean');
+        });
+
+        it('should identify Firefox for desktop as expected', function() {
+            var callback1 = jasmine.createSpy('callback1');
+            spyOn(Mozilla.Client, '_isFirefoxDesktop').and.returnValue(true);
+
+            window.Mozilla.Client.getFxaDetails(callback1);
+            jasmine.clock().tick(500);
+            expect(callback1).toHaveBeenCalled();
+            expect(typeof window.Mozilla.Client.FxaDetails.firefox).toBeTruthy();
+        });
+
+        it('should identify Firefox for Android as expected', function() {
+            var callback1 = jasmine.createSpy('callback1');
+            spyOn(Mozilla.Client, '_isFirefoxAndroid').and.returnValue(true);
+
+            window.Mozilla.Client.getFxaDetails(callback1);
+            jasmine.clock().tick(500);
+            expect(callback1).toHaveBeenCalled();
+            expect(window.Mozilla.Client.FxaDetails.firefox).toBeTruthy();
+            expect(window.Mozilla.Client.FxaDetails.mobile).toEqual('android');
+        });
+
+        it('should identify Firefox for iOS as expected', function() {
+            var callback1 = jasmine.createSpy('callback1');
+            spyOn(Mozilla.Client, '_isFirefoxiOS').and.returnValue(true);
+
+            window.Mozilla.Client.getFxaDetails(callback1);
+            jasmine.clock().tick(500);
+            expect(callback1).toHaveBeenCalled();
+            expect(window.Mozilla.Client.FxaDetails.firefox).toBeTruthy();
+            expect(window.Mozilla.Client.FxaDetails.mobile).toEqual('ios');
+        });
+
+        it('should identify legacy Firefox browsers as expected', function() {
+            var callback1 = jasmine.createSpy('callback1');
+            spyOn(Mozilla.Client, '_isFirefoxDesktop').and.returnValue(true);
+            spyOn(Mozilla.Client, '_getFirefoxVersion').and.returnValue(Mozilla.Client.FxALastSupported - 1);
+
+            window.Mozilla.Client.getFxaDetails(callback1);
+            jasmine.clock().tick(500);
+            expect(callback1).toHaveBeenCalled();
+            expect(window.Mozilla.Client.FxaDetails.firefox).toBeTruthy();
+            expect(window.Mozilla.Client.FxaDetails.legacy).toBeTruthy();
+        });
+
+    });
+
+    describe('getFxaConnections', function () {
+
+        beforeEach(function () {
+            jasmine.clock().install();
+        });
+
+        afterEach(function () {
+            delete window.Mozilla.Client.FxaConnections;
+            jasmine.clock().uninstall();
+        });
+
+        it('should fire the callback function with a FxaConnections details object', function() {
+            var callback1 = jasmine.createSpy('callback1');
+
+            window.Mozilla.Client.getFxaConnections(callback1);
+            jasmine.clock().tick(2100);
+            expect(callback1).toHaveBeenCalled();
+            expect(typeof window.Mozilla.Client.FxaConnections.firefox).toEqual('boolean');
+            expect(typeof window.Mozilla.Client.FxaConnections.unsupported).toEqual('boolean');
+            expect(typeof window.Mozilla.Client.FxaConnections.setup).toEqual('boolean');
+            expect(typeof window.Mozilla.Client.FxaConnections.numOtherDevices).toEqual('boolean');
+            expect(typeof window.Mozilla.Client.FxaConnections.numDevicesByType).toEqual('object');
+            expect(typeof window.Mozilla.Client.FxaConnections.accountServices).toEqual('object');
+        });
+
+        it('should identify legacy Firefox browsers as expected', function() {
+            var callback1 = jasmine.createSpy('callback1');
+            spyOn(Mozilla.Client, '_isFirefoxDesktop').and.returnValue(true);
+            spyOn(Mozilla.Client, '_getFirefoxVersion').and.returnValue(72);
+
+            window.Mozilla.Client.getFxaConnections(callback1);
+            jasmine.clock().tick(2100);
+            expect(callback1).toHaveBeenCalled();
+            expect(window.Mozilla.Client.FxaConnections.firefox).toBeTruthy();
+            expect(window.Mozilla.Client.FxaConnections.unsupported).toBeTruthy();
+        });
+
+        it('should identify non Firefox browsers as expected', function() {
+            var callback1 = jasmine.createSpy('callback1');
+            spyOn(Mozilla.Client, '_isFirefoxDesktop').and.returnValue(false);
+
+            window.Mozilla.Client.getFxaConnections(callback1);
+            jasmine.clock().tick(2100);
+            expect(callback1).toHaveBeenCalled();
+            expect(window.Mozilla.Client.FxaConnections.firefox).toBeFalsy();
+            expect(window.Mozilla.Client.FxaConnections.unsupported).toBeTruthy();
         });
 
     });


### PR DESCRIPTION
## Description
- Updates `Client.getFxaDetails()` with new functionality to determine sign-in state.
  - Newer clients (FF >= 74) use `fxa` configuration call.
  - Older clients (FF < 74) fallback to legacy `sync` configuration call.
- Adds new `Client.getFxaConnections()` function to query services recently used.

## Issue / Bugzilla link
#8200

## Testing
Demo: https://www-demo3.allizom.org/en-US/firefox/accounts/

- [x] `Client.getFxaDetails()` should continue to work in both old and newer Firefoxen.
- [x] `Client.getFxaConnections()` should work as expected in FF >= 74.

Successful test run: https://gitlab.com/mozmeao/www-config/pipelines/116435502