### PR TITLE
git add .gitlab-ci.yml after updating TEST_IMAGE

### DIFF
--- a/bin/update_config.sh
+++ b/bin/update_config.sh
@@ -21,6 +21,7 @@ done
 
 TEST_IMAGE=mozorg/bedrock_test:${GIT_COMMIT}
 sed -i -e "s|TEST_IMAGE: .*|TEST_IMAGE: ${TEST_IMAGE}|;s|image: mozorg/bedrock_test.*|image: ${TEST_IMAGE}|" .gitlab-ci.yml
+git add .gitlab-ci.yml
 
 git commit -m "set image to ${DEPLOYMENT_DOCKER_IMAGE} in ${CLUSTERS}" || echo "nothing new to commit"
 git push


### PR DESCRIPTION
## Description

Integration tests are still running mozorg/bedrock_test:latest images instead of the image built for the job due to a missing `git add` statement.

@alexgibson this should fix the issue you found during the last `run-integration-tests` pipeline.