### PR TITLE
Hide the download button on nav experiment

### DIFF
--- a/bedrock/exp/templates/exp/firefox/new/download-nav.html
+++ b/bedrock/exp/templates/exp/firefox/new/download-nav.html
@@ -5,5 +5,7 @@
 {% extends "exp/firefox/new/download.html" %}
 
 {% block site_header %}
-  {% include 'includes/protocol/navigation/menu-firefox/index.html' %}
+  {% with hide_nav_download_button=True %}
+    {% include 'includes/protocol/navigation/menu-firefox/index.html' %}
+  {% endwith %}
 {% endblock %}


### PR DESCRIPTION
## Description
Fixes https://github.com/mozilla/bedrock/issues/8037#issuecomment-564104974, hiding the download button in the nav on /new/nav/ in the /exp templates.

## Issue / Bugzilla link

#8037 


