### PR TITLE
Convert monitor button macro to Python helper (Fixes #8167)

### DIFF
--- a/bedrock/base/templates/macros.html
+++ b/bedrock/base/templates/macros.html
@@ -193,45 +193,6 @@
   </a>
 {%- endmacro %}
 
-{# Docs: https://bedrock.readthedocs.io/en/latest/firefox-accounts.html#linking-to-monitorfirefoxcom #}
-{% macro monitor_button(entrypoint, entrypoint_experiment=None, entrypoint_variation=None, form_type='button', utm_campaign=None, utm_content=None, utm_term=None, button_text=None, button_class='mzp-c-button mzp-t-product', cta_type=None, cta_position=None) -%}
-  {% set fxa_queries = [
-    'form_type=' ~ form_type,
-    'entrypoint=' ~ entrypoint,
-    'utm_source=' ~ entrypoint,
-    'utm_campaign=' ~ utm_campaign,
-    'utm_medium=referral'
-  ] %}
-
-  {# utm_content is optional #}
-  {% if utm_content %}
-    {% do fxa_queries.append('utm_content=' ~ utm_content) %}
-  {% endif %}
-
-  {# utm_term is optional #}
-  {% if utm_term %}
-    {% do fxa_queries.append('utm_term=' ~ utm_term) %}
-  {% endif %}
-
-  {# entrypoint_experiment is optional #}
-  {% if entrypoint_experiment %}
-    {% do fxa_queries.append('entrypoint_experiment=' ~ entrypoint_experiment) %}
-  {% endif %}
-
-  {# entrypoint_variation is optional #}
-  {% if entrypoint_variation %}
-    {% do fxa_queries.append('entrypoint_variation=' ~ entrypoint_variation) %}
-  {% endif %}
-
-  <a data-action="{{ settings.FXA_ENDPOINT }}" href="https://monitor.firefox.com/oauth/init?{{ fxa_queries|join('&') }}" class="js-fxa-cta-link js-fxa-product-button {% if button_class %}{{ button_class }}{% endif %}" data-cta-text="{% if button_text %}{{ button_text }}{% else %}Sign In to Monitor{% endif %}" data-cta-type="{% if cta_type %}{{ cta_type }}{% else %}fxa-monitor{% endif %}" data-cta-position="{% if cta_position %}{{ cta_position }}{% else %}primary{% endif %}">
-    {% if button_text %}
-      {{ button_text }}
-    {% else %}
-      {{ _('Sign In to Monitor') }}
-    {% endif %}
-  </a>
-{%- endmacro %}
-
 {# Docs: https://bedrock.readthedocs.io/en/latest/firefox-accounts.html#signup-form #}
 {% macro fxa_email_form(entrypoint, entrypoint_experiment, entrypoint_variation, utm_campaign=None, utm_content=None, utm_term=None, style=None, class_name='fxa-email-form', form_title=None, intro_text=none, button_text=None, button_class='button button-blue') -%}
   {% set service  = 'sync' %}

--- a/bedrock/exp/templates/exp/firefox/accounts-2019.html
+++ b/bedrock/exp/templates/exp/firefox/accounts-2019.html
@@ -53,7 +53,7 @@
 
       {{ monitor_fxa_button(
         entrypoint=_entrypoint,
-        button_text=_('Sign In to Monitor'),
+        button_text='Sign In to Monitor',
         optional_parameters={'utm_campaign': _utm_campaign},
         optional_attributes={'data-cta-text': 'Sign In to Monitor', 'data-cta-type': 'fxa-monitor', 'data-cta-position': 'primary'})
       }}

--- a/bedrock/exp/templates/exp/firefox/accounts-2019.html
+++ b/bedrock/exp/templates/exp/firefox/accounts-2019.html
@@ -3,7 +3,7 @@
  # file, You can obtain one at http://mozilla.org/MPL/2.0/. #}
 
 {% from "macros-protocol.html" import feature_card with context %}
-{% from "macros.html" import fxa_email_form, fxa_link_fragment, monitor_button with context %}
+{% from "macros.html" import fxa_email_form, fxa_link_fragment with context %}
 
 {% extends "exp/base/base-firefox.html" %}
 
@@ -51,10 +51,12 @@
 
       <p class="c-accounts-hero-desc">See if you’ve been involved in an online data breach.</p>
 
-      {{ monitor_button(
+      {{ monitor_fxa_button(
         entrypoint=_entrypoint,
-        utm_campaign=_utm_campaign
-      ) }}
+        button_text=_('Sign In to Monitor'),
+        optional_parameters={'utm_campaign': _utm_campaign},
+        optional_attributes={'data-cta-text': 'Sign In to Monitor', 'data-cta-type': 'fxa-monitor', 'data-cta-position': 'primary'})
+      }}
     </div>
 
     <div class="c-accounts-form">

--- a/bedrock/exp/templates/exp/firefox/welcome/page1.html
+++ b/bedrock/exp/templates/exp/firefox/welcome/page1.html
@@ -3,7 +3,6 @@
  # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
 
 {% from "macros-protocol.html" import hero with context %}
-{% from "macros.html" import monitor_button with context %}
 
 {% extends "exp/firefox/welcome/base.html" %}
 
@@ -33,13 +32,12 @@
   ) %}
 
   <p class="primary-cta">
-    {{ monitor_button(
+    {{ monitor_fxa_button(
       entrypoint=_entrypoint,
-      utm_campaign=_utm_campaign,
       button_text='Check Your Breach Report',
-      cta_type=_cta_type,
-      cta_position='primary'
-    ) }}
+      optional_parameters={'utm_campaign': _utm_campaign},
+      optional_attributes={'data-cta-text': 'Check Your Breach Report', 'data-cta-type': _cta_type, 'data-cta-position': 'primary'})
+    }}
   </p>
 
   {% endcall %}
@@ -85,13 +83,12 @@
 
 {% block secondary_cta %}
   <p class="secondary-cta">
-    {{ monitor_button(
+    {{ monitor_fxa_button(
       entrypoint=_entrypoint,
-      utm_campaign=_utm_campaign,
       button_text='Check Your Breach Report',
-      cta_type=_cta_type,
-      cta_position='secondary'
-    ) }}
+      optional_parameters={'utm_campaign': _utm_campaign},
+      optional_attributes={'data-cta-text': 'Check Your Breach Report', 'data-cta-type': _cta_type, 'data-cta-position': 'secondary'})
+    }}
   </p>
 {% endblock %}
 

--- a/bedrock/exp/templates/exp/firefox/welcome/page1.html
+++ b/bedrock/exp/templates/exp/firefox/welcome/page1.html
@@ -17,6 +17,7 @@
 
 {% set _entrypoint = 'mozilla.org-firefox-welcome-1' %}
 {% set _utm_campaign = 'welcome-1-monitor' %}
+{% set _utm_content = 'on-track-protected' %}
 {% set _cta_type = 'lifecycle-monitor' %}
 
 {% block content_intro %}
@@ -35,7 +36,7 @@
     {{ monitor_fxa_button(
       entrypoint=_entrypoint,
       button_text='Check Your Breach Report',
-      optional_parameters={'utm_campaign': _utm_campaign},
+      optional_parameters={'utm_campaign': _utm_campaign, 'utm_content': _utm_content},
       optional_attributes={'data-cta-text': 'Check Your Breach Report', 'data-cta-type': _cta_type, 'data-cta-position': 'primary'})
     }}
   </p>
@@ -86,7 +87,7 @@
     {{ monitor_fxa_button(
       entrypoint=_entrypoint,
       button_text='Check Your Breach Report',
-      optional_parameters={'utm_campaign': _utm_campaign},
+      optional_parameters={'utm_campaign': _utm_campaign, 'utm_content': _utm_content},
       optional_attributes={'data-cta-text': 'Check Your Breach Report', 'data-cta-type': _cta_type, 'data-cta-position': 'secondary'})
     }}
   </p>

--- a/bedrock/exp/templates/exp/firefox/whatsnew/whatsnew-fx71.html
+++ b/bedrock/exp/templates/exp/firefox/whatsnew/whatsnew-fx71.html
@@ -2,7 +2,7 @@
  # License, v. 2.0. If a copy of the MPL was not distributed with this
  # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
 
-{% from "macros.html" import monitor_button, fxa_cta_link with context %}
+{% from "macros.html" import fxa_cta_link with context %}
 
 {% extends "exp/base/base-firefox.html" %}
 

--- a/bedrock/firefox/templates/firefox/accounts-2019.html
+++ b/bedrock/firefox/templates/firefox/accounts-2019.html
@@ -3,7 +3,7 @@
   # file, You can obtain one at http://mozilla.org/MPL/2.0/. #}
 
 {% from "macros-protocol.html" import feature_card with context %}
-{% from "macros.html" import fxa_email_form, fxa_link_fragment, monitor_button with context %}
+{% from "macros.html" import fxa_email_form, fxa_link_fragment with context %}
 
 {% extends "firefox/base/base-protocol.html" %}
 
@@ -65,10 +65,12 @@
 
       <p class="c-accounts-hero-desc">{{ _('See if you’ve been involved in an online data breach.') }}</p>
 
-      {{ monitor_button(
+      {{ monitor_fxa_button(
         entrypoint=_entrypoint,
-        utm_campaign=_utm_campaign
-      ) }}
+        button_text=_('Sign In to Monitor'),
+        optional_parameters={'utm_campaign': _utm_campaign},
+        optional_attributes={'data-cta-text': 'Sign In to Monitor', 'data-cta-type': 'fxa-monitor', 'data-cta-position': 'primary'})
+      }}
     </div>
     {% endif %}
 

--- a/bedrock/firefox/templates/firefox/welcome/page1.html
+++ b/bedrock/firefox/templates/firefox/welcome/page1.html
@@ -3,7 +3,6 @@
   # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
 
 {% from "macros-protocol.html" import hero with context %}
-{% from "macros.html" import monitor_button with context %}
 
 {% add_lang_files "firefox/welcome/page1" %}
 
@@ -39,14 +38,12 @@
   ) %}
 
   <p class="primary-cta">
-    {{ monitor_button(
+    {{ monitor_fxa_button(
       entrypoint=_entrypoint,
-      utm_campaign=_utm_campaign,
-      utm_content=_utm_content,
-      button_text=_('Check Your Breach Report'),
-      cta_type=_cta_type,
-      cta_position='primary'
-    ) }}
+      button_text='Check Your Breach Report',
+      optional_parameters={'utm_campaign': _utm_campaign},
+      optional_attributes={'data-cta-text': 'Check Your Breach Report', 'data-cta-type': _cta_type, 'data-cta-position': 'primary'})
+    }}
   </p>
 
   {% endcall %}
@@ -102,14 +99,12 @@
 
 {% block secondary_cta %}
   <p class="secondary-cta">
-    {{ monitor_button(
+    {{ monitor_fxa_button(
       entrypoint=_entrypoint,
-      utm_campaign=_utm_campaign,
-      utm_content=_utm_content,
-      button_text=_('Check Your Breach Report'),
-      cta_type=_cta_type,
-      cta_position='secondary'
-    ) }}
+      button_text='Check Your Breach Report',
+      optional_parameters={'utm_campaign': _utm_campaign},
+      optional_attributes={'data-cta-text': 'Check Your Breach Report', 'data-cta-type': _cta_type, 'data-cta-position': 'secondary'})
+    }}
   </p>
 {% endblock %}
 

--- a/bedrock/firefox/templates/firefox/welcome/page1.html
+++ b/bedrock/firefox/templates/firefox/welcome/page1.html
@@ -40,8 +40,8 @@
   <p class="primary-cta">
     {{ monitor_fxa_button(
       entrypoint=_entrypoint,
-      button_text='Check Your Breach Report',
-      optional_parameters={'utm_campaign': _utm_campaign},
+      button_text=_('Check Your Breach Report'),
+      optional_parameters={'utm_campaign': _utm_campaign, 'utm_content': _utm_content},
       optional_attributes={'data-cta-text': 'Check Your Breach Report', 'data-cta-type': _cta_type, 'data-cta-position': 'primary'})
     }}
   </p>
@@ -101,8 +101,8 @@
   <p class="secondary-cta">
     {{ monitor_fxa_button(
       entrypoint=_entrypoint,
-      button_text='Check Your Breach Report',
-      optional_parameters={'utm_campaign': _utm_campaign},
+      button_text=_('Check Your Breach Report'),
+      optional_parameters={'utm_campaign': _utm_campaign, 'utm_content': _utm_content},
       optional_attributes={'data-cta-text': 'Check Your Breach Report', 'data-cta-type': _cta_type, 'data-cta-position': 'secondary'})
     }}
   </p>

--- a/bedrock/firefox/templates/firefox/whatsnew/beta/whatsnew-fx72-de.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/beta/whatsnew-fx72-de.html
@@ -2,7 +2,7 @@
   # License, v. 2.0. If a copy of the MPL was not distributed with this
   # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
 
-{% from "macros.html" import monitor_button, fxa_cta_link with context %}
+{% from "macros.html" import fxa_cta_link with context %}
 
 {% add_lang_files "firefox/whatsnew_70" %}
 
@@ -43,25 +43,21 @@
         <p>{{ _('Überprüfe mit Firefox Monitor, ob deine persönlichen Informationen bei Datenlecks anderer Unternehmen gefährdet wurden – und lass dich automatisch warnen, wenn deine Daten betroffen sind.') }}</p>
 
         <div class="show-fxa-supported-signed-out show-fxa-default show-fxa-not-fx">
-          {{ monitor_button(
+          {{ monitor_fxa_button(
             entrypoint=_entrypoint,
-            cta_type='FxA-Monitor',
-            cta_position='Primary',
-            utm_campaign=_utm_campaign,
-            utm_content=_utm_content,
-            button_text=_('Für Monitor anmelden')
-          ) }}
+            button_text=_('Für Monitor anmelden'),
+            optional_parameters={'utm_campaign': _utm_campaign, 'utm_content': _utm_content},
+            optional_attributes={'data-cta-text': 'Sign Up for Monitor', 'data-cta-type': 'fxa-monitor', 'data-cta-position': 'primary'})
+          }}
         </div>
 
         <div class="show-fxa-supported-signed-in">
-          {{ monitor_button(
+          {{ monitor_fxa_button(
             entrypoint=_entrypoint,
-            cta_type='FxA-Monitor',
-            cta_position='Primary',
-            utm_campaign=_utm_campaign,
-            utm_content=_utm_content,
-            button_text=_('Einloggen')
-          ) }}
+            button_text=_('Einloggen'),
+            optional_parameters={'utm_campaign': _utm_campaign, 'utm_content': _utm_content},
+            optional_attributes={'data-cta-text': 'Sign In', 'data-cta-type': 'fxa-monitor', 'data-cta-position': 'primary'})
+          }}
         </div>
       </div>
     </div>

--- a/bedrock/firefox/templates/firefox/whatsnew/beta/whatsnew-fx72-de.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/beta/whatsnew-fx72-de.html
@@ -46,7 +46,7 @@
           {{ monitor_fxa_button(
             entrypoint=_entrypoint,
             button_text=_('Für Monitor anmelden'),
-            optional_parameters={'utm_campaign': _utm_campaign, 'utm_content': _utm_content},
+            optional_parameters={'utm_campaign': _utm_campaign},
             optional_attributes={'data-cta-text': 'Sign Up for Monitor', 'data-cta-type': 'fxa-monitor', 'data-cta-position': 'primary'})
           }}
         </div>
@@ -55,7 +55,7 @@
           {{ monitor_fxa_button(
             entrypoint=_entrypoint,
             button_text=_('Einloggen'),
-            optional_parameters={'utm_campaign': _utm_campaign, 'utm_content': _utm_content},
+            optional_parameters={'utm_campaign': _utm_campaign},
             optional_attributes={'data-cta-text': 'Sign In', 'data-cta-type': 'fxa-monitor', 'data-cta-position': 'primary'})
           }}
         </div>

--- a/bedrock/firefox/templates/firefox/whatsnew/beta/whatsnew-fx72-en.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/beta/whatsnew-fx72-en.html
@@ -47,7 +47,7 @@
           {{ monitor_fxa_button(
             entrypoint=_entrypoint,
             button_text=_('Sign Up for Monitor'),
-            optional_parameters={'utm_campaign': _utm_campaign, 'utm_content': _utm_content},
+            optional_parameters={'utm_campaign': _utm_campaign},
             optional_attributes={'data-cta-text': 'Sign Up for Monitor', 'data-cta-type': 'fxa-monitor', 'data-cta-position': 'primary'})
           }}
         </div>
@@ -56,7 +56,7 @@
           {{ monitor_fxa_button(
             entrypoint=_entrypoint,
             button_text=_('Sign In'),
-            optional_parameters={'utm_campaign': _utm_campaign, 'utm_content': _utm_content},
+            optional_parameters={'utm_campaign': _utm_campaign},
             optional_attributes={'data-cta-text': 'Sign In', 'data-cta-type': 'fxa-monitor', 'data-cta-position': 'primary'})
           }}
         </div>

--- a/bedrock/firefox/templates/firefox/whatsnew/beta/whatsnew-fx72-en.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/beta/whatsnew-fx72-en.html
@@ -2,7 +2,7 @@
   # License, v. 2.0. If a copy of the MPL was not distributed with this
   # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
 
-{% from "macros.html" import monitor_button, fxa_cta_link with context %}
+{% from "macros.html" import fxa_cta_link with context %}
 
 {% add_lang_files "firefox/whatsnew_70" %}
 
@@ -44,23 +44,21 @@
 
       {% block monitor_cta %}
         <div class="show-fxa-supported-signed-out show-fxa-default show-fxa-not-fx">
-          {{ monitor_button(
+          {{ monitor_fxa_button(
             entrypoint=_entrypoint,
-            cta_type='FxA-Monitor',
-            cta_position='Primary',
-            utm_campaign=_utm_campaign,
-            button_text=_('Sign Up for Monitor')
-          ) }}
+            button_text=_('Sign Up for Monitor'),
+            optional_parameters={'utm_campaign': _utm_campaign, 'utm_content': _utm_content},
+            optional_attributes={'data-cta-text': 'Sign Up for Monitor', 'data-cta-type': 'fxa-monitor', 'data-cta-position': 'primary'})
+          }}
         </div>
 
         <div class="show-fxa-supported-signed-in">
-          {{ monitor_button(
+          {{ monitor_fxa_button(
             entrypoint=_entrypoint,
-            cta_type='FxA-Monitor',
-            cta_position='Primary',
-            utm_campaign=_utm_campaign,
-            button_text=_('Sign In')
-          ) }}
+            button_text=_('Sign In'),
+            optional_parameters={'utm_campaign': _utm_campaign, 'utm_content': _utm_content},
+            optional_attributes={'data-cta-text': 'Sign In', 'data-cta-type': 'fxa-monitor', 'data-cta-position': 'primary'})
+          }}
         </div>
       {% endblock %}
       </div>

--- a/bedrock/firefox/templates/firefox/whatsnew/beta/whatsnew-fx72-fr.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/beta/whatsnew-fx72-fr.html
@@ -2,7 +2,7 @@
   # License, v. 2.0. If a copy of the MPL was not distributed with this
   # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
 
-{% from "macros.html" import monitor_button, fxa_cta_link with context %}
+{% from "macros.html" import fxa_cta_link with context %}
 
 {% add_lang_files "firefox/whatsnew_70" %}
 
@@ -43,25 +43,21 @@
         <p>{{ _('Essayez Firefox Monitor pour savoir si vos informations personnelles ont été compromises par une fuite de données d’une autre entreprise. Recevez des alertes automatiques en cas de future fuite.') }}</p>
 
         <div class="show-fxa-supported-signed-out show-fxa-default show-fxa-not-fx">
-          {{ monitor_button(
+          {{ monitor_fxa_button(
             entrypoint=_entrypoint,
-            cta_type='FxA-Monitor',
-            cta_position='Primary',
-            utm_campaign=_utm_campaign,
-            utm_content=_utm_content,
-            button_text=_('S’inscrire à Monitor')
-          ) }}
+            button_text=_('S’inscrire à Monitor'),
+            optional_parameters={'utm_campaign': _utm_campaign, 'utm_content': _utm_content},
+            optional_attributes={'data-cta-text': 'Sign Up for Monitor', 'data-cta-type': 'fxa-monitor', 'data-cta-position': 'primary'})
+          }}
         </div>
 
         <div class="show-fxa-supported-signed-in">
-          {{ monitor_button(
+          {{ monitor_fxa_button(
             entrypoint=_entrypoint,
-            cta_type='FxA-Monitor',
-            cta_position='Primary',
-            utm_campaign=_utm_campaign,
-            utm_content=_utm_content,
-            button_text=_('Se connecter')
-          ) }}
+            button_text=_('Se connecter'),
+            optional_parameters={'utm_campaign': _utm_campaign, 'utm_content': _utm_content},
+            optional_attributes={'data-cta-text': 'Sign In', 'data-cta-type': 'fxa-monitor', 'data-cta-position': 'primary'})
+          }}
         </div>
       </div>
     </div>

--- a/bedrock/firefox/templates/firefox/whatsnew/beta/whatsnew-fx72-fr.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/beta/whatsnew-fx72-fr.html
@@ -46,7 +46,7 @@
           {{ monitor_fxa_button(
             entrypoint=_entrypoint,
             button_text=_('S’inscrire à Monitor'),
-            optional_parameters={'utm_campaign': _utm_campaign, 'utm_content': _utm_content},
+            optional_parameters={'utm_campaign': _utm_campaign},
             optional_attributes={'data-cta-text': 'Sign Up for Monitor', 'data-cta-type': 'fxa-monitor', 'data-cta-position': 'primary'})
           }}
         </div>
@@ -55,7 +55,7 @@
           {{ monitor_fxa_button(
             entrypoint=_entrypoint,
             button_text=_('Se connecter'),
-            optional_parameters={'utm_campaign': _utm_campaign, 'utm_content': _utm_content},
+            optional_parameters={'utm_campaign': _utm_campaign},
             optional_attributes={'data-cta-text': 'Sign In', 'data-cta-type': 'fxa-monitor', 'data-cta-position': 'primary'})
           }}
         </div>

--- a/bedrock/firefox/templates/firefox/whatsnew/index-account.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/index-account.html
@@ -2,7 +2,7 @@
  # License, v. 2.0. If a copy of the MPL was not distributed with this
  # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
 
-{% from "macros.html" import monitor_button, fxa_cta_link with context %}
+{% from "macros.html" import fxa_cta_link with context %}
 
 {% extends "firefox/whatsnew/base.html" %}
 

--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx67.0.5.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx67.0.5.html
@@ -60,9 +60,9 @@
           {% block monitor_button %}
             {{ monitor_fxa_button(
               entrypoint='mozilla.org-whatsnew6705',
-              button_text=_('Sign Up for Monitor'),
+              button_text=_('Sign In to Monitor'),
               optional_parameters={'utm_campaign': 'whatsnew6705'},
-              optional_attributes={'data-cta-text': 'Sign Up for Monitor', 'data-cta-type': 'fxa-monitor', 'data-cta-position': 'primary'})
+              optional_attributes={'data-cta-text': 'Sign In to Monitor', 'data-cta-type': 'fxa-monitor', 'data-cta-position': 'primary'})
             }}
           {% endblock %}
         </div>

--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx67.0.5.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx67.0.5.html
@@ -2,7 +2,7 @@
   # License, v. 2.0. If a copy of the MPL was not distributed with this
   # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
 
-{% from "macros.html" import fxa_email_form, monitor_button with context %}
+{% from "macros.html" import fxa_email_form with context %}
 
 {% add_lang_files "firefox/whatsnew_67.0.5" %}
 
@@ -58,10 +58,12 @@
           <h2>{{ _('Including Firefox Monitor, your watchful eye for data breaches') }}</h2>
           <p>{{ _('See if your info was compromised in another company’s data breach, and get automatically signed up for future alerts.') }}</p>
           {% block monitor_button %}
-            {{ monitor_button(
+            {{ monitor_fxa_button(
               entrypoint='mozilla.org-whatsnew6705',
-              utm_campaign='whatsnew6705'
-            ) }}
+              button_text=_('Sign Up for Monitor'),
+              optional_parameters={'utm_campaign': 'whatsnew6705'},
+              optional_attributes={'data-cta-text': 'Sign Up for Monitor', 'data-cta-type': 'fxa-monitor', 'data-cta-position': 'primary'})
+            }}
           {% endblock %}
         </div>
       {% endblock %}

--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx68-trailhead.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx68-trailhead.html
@@ -16,8 +16,10 @@
 {% endblock %}
 
 {% block monitor_button %}
-  {{ monitor_button(
+  {{ monitor_fxa_button(
     entrypoint='mozilla.org-whatsnew68',
-    utm_campaign='wnp-monitor-cta')
+    button_text=_('Sign Up for Monitor'),
+    optional_parameters={'utm_campaign': 'wnp-monitor-cta'},
+    optional_attributes={'data-cta-text': 'Sign Up for Monitor', 'data-cta-type': 'fxa-monitor', 'data-cta-position': 'primary'})
   }}
 {% endblock %}

--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx68-trailhead.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx68-trailhead.html
@@ -18,8 +18,8 @@
 {% block monitor_button %}
   {{ monitor_fxa_button(
     entrypoint='mozilla.org-whatsnew68',
-    button_text=_('Sign Up for Monitor'),
+    button_text=_('Sign In to Monitor'),
     optional_parameters={'utm_campaign': 'wnp-monitor-cta'},
-    optional_attributes={'data-cta-text': 'Sign Up for Monitor', 'data-cta-type': 'fxa-monitor', 'data-cta-position': 'primary'})
+    optional_attributes={'data-cta-text': 'Sign In to Monitor', 'data-cta-type': 'fxa-monitor', 'data-cta-position': 'primary'})
   }}
 {% endblock %}

--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx69.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx69.html
@@ -55,7 +55,7 @@
         {{ monitor_fxa_button(
           entrypoint='mozilla.org-firefox-whatsnew69',
           button_text=_('Sign In'),
-          optional_parameters={'utm_campaign': 'whatsnew69', 'utm_content': 'whatsnew69-signed-out'},
+          optional_parameters={'utm_campaign': 'whatsnew69', 'utm_content': 'whatsnew69-signed-in'},
           optional_attributes={'data-cta-text': 'Sign In', 'data-cta-type': 'fxa-monitor', 'data-cta-position': 'primary'})
         }}
       </div>

--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx69.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx69.html
@@ -2,8 +2,6 @@
   # License, v. 2.0. If a copy of the MPL was not distributed with this
   # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
 
-{% from "macros.html" import monitor_button with context %}
-
 {% add_lang_files "firefox/whatsnew_69" %}
 
 {% extends "firefox/whatsnew/base.html" %}
@@ -41,12 +39,12 @@
         </h2>
         <p>{{ _('Sign up to see if your info was compromised in another company’s data breach, and automatically get alerts when your info might be at risk.') }}</p>
 
-        {{ monitor_button(
+        {{ monitor_fxa_button(
           entrypoint='mozilla.org-firefox-whatsnew69',
-          utm_campaign='whatsnew69',
-          utm_content='whatsnew69-signed-out',
-          button_text=_('Sign Up for Monitor')
-        ) }}
+          button_text=_('Sign Up for Monitor'),
+          optional_parameters={'utm_campaign': 'whatsnew69', 'utm_content': 'whatsnew69-signed-out'},
+          optional_attributes={'data-cta-text': 'Sign Up for Monitor', 'data-cta-type': 'fxa-monitor', 'data-cta-position': 'primary'})
+        }}
       </div>
 
       <div class="c-emphasis-box show-fxa-supported-signed-in">
@@ -54,12 +52,12 @@
         <h2 class="c-emphasis-box-title">{{ _('Have you checked out Firefox Monitor? It’s included with your Firefox account.') }}</h2>
         <p>{{ _('Use Firefox Monitor to see if your info was compromised in another company’s data breach — and get automatically signed up for future alerts.') }}</p>
 
-        {{ monitor_button(
+        {{ monitor_fxa_button(
           entrypoint='mozilla.org-firefox-whatsnew69',
-          utm_campaign='whatsnew69',
-          utm_content='whatsnew69-signed-in',
-          button_text=_('Sign In')
-        ) }}
+          button_text=_('Sign In'),
+          optional_parameters={'utm_campaign': 'whatsnew69', 'utm_content': 'whatsnew69-signed-out'},
+          optional_attributes={'data-cta-text': 'Sign In', 'data-cta-type': 'fxa-monitor', 'data-cta-position': 'primary'})
+        }}
       </div>
     </div>
   </section>

--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx70-de.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx70-de.html
@@ -2,7 +2,7 @@
   # License, v. 2.0. If a copy of the MPL was not distributed with this
   # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
 
-{% from "macros.html" import monitor_button, fxa_cta_link with context %}
+{% from "macros.html" import fxa_cta_link with context %}
 
 {% add_lang_files "firefox/whatsnew_70" %}
 
@@ -44,25 +44,21 @@
         <p>{{ _('Überprüfe mit Firefox Monitor, ob deine persönlichen Informationen bei Datenlecks anderer Unternehmen gefährdet wurden – und lass dich automatisch warnen, wenn deine Daten betroffen sind.') }}</p>
 
         <div class="show-fxa-supported-signed-out show-fxa-default show-fxa-not-fx">
-          {{ monitor_button(
+          {{ monitor_fxa_button(
             entrypoint=_entrypoint,
-            cta_type='FxA-Monitor',
-            cta_position='Primary',
-            utm_campaign=_utm_campaign,
-            utm_content=_utm_content,
-            button_text=_('Für Monitor anmelden')
-          ) }}
+            button_text=_('Für Monitor anmelden'),
+            optional_parameters={'utm_campaign': _utm_campaign, 'utm_content': _utm_content},
+            optional_attributes={'data-cta-text': 'Sign Up for Monitor', 'data-cta-type': 'fxa-monitor', 'data-cta-position': 'primary'})
+          }}
         </div>
 
         <div class="show-fxa-supported-signed-in">
-          {{ monitor_button(
+          {{ monitor_fxa_button(
             entrypoint=_entrypoint,
-            cta_type='FxA-Monitor',
-            cta_position='Primary',
-            utm_campaign=_utm_campaign,
-            utm_content=_utm_content,
-            button_text=_('Einloggen')
-          ) }}
+            button_text=_('Einloggen'),
+            optional_parameters={'utm_campaign': _utm_campaign, 'utm_content': _utm_content},
+            optional_attributes={'data-cta-text': 'Sign In', 'data-cta-type': 'fxa-monitor', 'data-cta-position': 'primary'})
+          }}
         </div>
       </div>
     </div>

--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx70-en.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx70-en.html
@@ -2,7 +2,7 @@
   # License, v. 2.0. If a copy of the MPL was not distributed with this
   # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
 
-{% from "macros.html" import monitor_button, fxa_cta_link with context %}
+{% from "macros.html" import fxa_cta_link with context %}
 
 {% add_lang_files "firefox/whatsnew_70" %}
 
@@ -44,23 +44,21 @@
 
       {% block monitor_cta %}
         <div class="show-fxa-supported-signed-out show-fxa-default show-fxa-not-fx">
-          {{ monitor_button(
+          {{ monitor_fxa_button(
             entrypoint=_entrypoint,
-            cta_type='FxA-Monitor',
-            cta_position='Primary',
-            utm_campaign=_utm_campaign,
-            button_text=_('Sign Up for Monitor')
-          ) }}
+            button_text=_('Sign Up for Monitor'),
+            optional_parameters={'utm_campaign': _utm_campaign},
+            optional_attributes={'data-cta-text': 'Sign Up for Monitor', 'data-cta-type': 'fxa-monitor', 'data-cta-position': 'primary'})
+          }}
         </div>
 
         <div class="show-fxa-supported-signed-in">
-          {{ monitor_button(
+          {{ monitor_fxa_button(
             entrypoint=_entrypoint,
-            cta_type='FxA-Monitor',
-            cta_position='Primary',
-            utm_campaign=_utm_campaign,
-            button_text=_('Sign In')
-          ) }}
+            button_text=_('Sign In'),
+            optional_parameters={'utm_campaign': _utm_campaign},
+            optional_attributes={'data-cta-text': 'Sign In', 'data-cta-type': 'fxa-monitor', 'data-cta-position': 'primary'})
+          }}
         </div>
       {% endblock %}
       </div>

--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx70-fr.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx70-fr.html
@@ -2,7 +2,7 @@
   # License, v. 2.0. If a copy of the MPL was not distributed with this
   # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
 
-{% from "macros.html" import monitor_button, fxa_cta_link with context %}
+{% from "macros.html" import fxa_cta_link with context %}
 
 {% add_lang_files "firefox/whatsnew_70" %}
 
@@ -44,25 +44,21 @@
         <p>{{ _('Essayez Firefox Monitor pour savoir si vos informations personnelles ont été compromises par une fuite de données d’une autre entreprise. Recevez des alertes automatiques en cas de future fuite.') }}</p>
 
         <div class="show-fxa-supported-signed-out show-fxa-default show-fxa-not-fx">
-          {{ monitor_button(
+          {{ monitor_fxa_button(
             entrypoint=_entrypoint,
-            cta_type='FxA-Monitor',
-            cta_position='Primary',
-            utm_campaign=_utm_campaign,
-            utm_content=_utm_content,
-            button_text=_('S’inscrire à Monitor')
-          ) }}
+            button_text=_('S’inscrire à Monitor'),
+            optional_parameters={'utm_campaign': _utm_campaign, 'utm_content': _utm_content},
+            optional_attributes={'data-cta-text': 'Sign Up for Monitor', 'data-cta-type': 'fxa-monitor', 'data-cta-position': 'primary'})
+          }}
         </div>
 
         <div class="show-fxa-supported-signed-in">
-          {{ monitor_button(
+          {{ monitor_fxa_button(
             entrypoint=_entrypoint,
-            cta_type='FxA-Monitor',
-            cta_position='Primary',
-            utm_campaign=_utm_campaign,
-            utm_content=_utm_content,
-            button_text=_('Se connecter')
-          ) }}
+            button_text=_('Se connecter'),
+            optional_parameters={'utm_campaign': _utm_campaign, 'utm_content': _utm_content},
+            optional_attributes={'data-cta-text': 'Sign In', 'data-cta-type': 'fxa-monitor', 'data-cta-position': 'primary'})
+          }}
         </div>
       </div>
     </div>

--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx71.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx71.html
@@ -2,7 +2,7 @@
  # License, v. 2.0. If a copy of the MPL was not distributed with this
  # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
 
-{% from "macros.html" import monitor_button, fxa_cta_link with context %}
+{% from "macros.html" import fxa_cta_link with context %}
 
 {% add_lang_files "firefox/whatsnew_71" %}
 

--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx72.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx72.html
@@ -2,7 +2,7 @@
  # License, v. 2.0. If a copy of the MPL was not distributed with this
  # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
 
-{% from "macros.html" import monitor_button, fxa_cta_link with context %}
+{% from "macros.html" import fxa_cta_link with context %}
 
 {% add_lang_files "firefox/whatsnew_71" %}
 

--- a/bedrock/mozorg/templatetags/misc.py
+++ b/bedrock/mozorg/templatetags/misc.py
@@ -772,7 +772,7 @@ def monitor_fxa_button(ctx, entrypoint, button_text, class_name=None, optional_p
     In Template
     -----------
 
-        {{ monitor_fxa_button(entrypoint='mozilla.org-firefox-pocket', button_text='Try Pocket Now') }}
+        {{ monitor_fxa_button(entrypoint='mozilla.org-firefox-accounts', button_text='Sign In to Monitor') }}
     """
     product_url = 'https://monitor.firefox.com/oauth/init'
     return _fxa_product_button(product_url, entrypoint, button_text, class_name, optional_parameters, optional_attributes)

--- a/bedrock/mozorg/templatetags/misc.py
+++ b/bedrock/mozorg/templatetags/misc.py
@@ -758,3 +758,21 @@ def pocket_fxa_button(ctx, entrypoint, button_text, class_name=None, optional_pa
     """
     product_url = 'https://getpocket.com/ff_signup'
     return _fxa_product_button(product_url, entrypoint, button_text, class_name, optional_parameters, optional_attributes)
+
+
+@library.global_function
+@jinja2.contextfunction
+def monitor_fxa_button(ctx, entrypoint, button_text, class_name=None, optional_parameters=None, optional_attributes=None):
+    """
+    Render a monitor.firefox.com link with required params for FxA authentication.
+
+    Examples
+    ========
+
+    In Template
+    -----------
+
+        {{ monitor_fxa_button(entrypoint='mozilla.org-firefox-pocket', button_text='Try Pocket Now') }}
+    """
+    product_url = 'https://monitor.firefox.com/oauth/init'
+    return _fxa_product_button(product_url, entrypoint, button_text, class_name, optional_parameters, optional_attributes)

--- a/bedrock/mozorg/tests/test_helper_misc.py
+++ b/bedrock/mozorg/tests/test_helper_misc.py
@@ -894,3 +894,30 @@ class TestPocketFxAButton(TestCase):
             u'class="js-fxa-cta-link js-fxa-product-button mzp-c-button mzp-t-product pocket-main-cta-button" '
             u'data-cta-text="Try Pocket Now" data-cta-type="activate pocket" data-cta-position="primary">Try Pocket Now</a>')
         self.assertEqual(markup, expected)
+
+
+@override_settings(FXA_ENDPOINT=TEST_FXA_ENDPOINT)
+class TestMonitorFxAButton(TestCase):
+    rf = RequestFactory()
+
+    def _render(self, entrypoint, button_text, class_name=None, optional_parameters=None,
+                optional_attributes=None):
+        req = self.rf.get('/')
+        req.locale = 'en-US'
+        return render("{{{{ monitor_fxa_button('{0}', '{1}', '{2}', {3}, {4}) }}}}".format(
+                      entrypoint, button_text, class_name, optional_parameters, optional_attributes),
+                      {'request': req})
+
+    def test_monitor_fxa_button(self):
+        """Should return expected markup"""
+        markup = self._render(entrypoint='mozilla.org-firefox-accounts', button_text='Sign In to Monitor',
+                              class_name='monitor-main-cta-button', optional_parameters={'utm_campaign': 'skyline'},
+                              optional_attributes={'data-cta-text': 'Sign In to Monitor', 'data-cta-type':
+                                                   'fxa-monitor', 'data-cta-position': 'primary'})
+        expected = (
+            u'<a href="https://monitor.firefox.com/oauth/init?entrypoint=mozilla.org-firefox-accounts&form_type=button'
+            u'&utm_source=mozilla.org-firefox-accounts&utm_medium=refferal&utm_campaign=skyline" '
+            u'data-action="https://accounts.firefox.com/" class="js-fxa-cta-link js-fxa-product-button mzp-c-button '
+            u'mzp-t-product monitor-main-cta-button" data-cta-text="Sign In to Monitor" data-cta-type="fxa-monitor" '
+            u'data-cta-position="primary">Sign In to Monitor</a>')
+        self.assertEqual(markup, expected)

--- a/docs/firefox-accounts.rst
+++ b/docs/firefox-accounts.rst
@@ -207,22 +207,14 @@ Invoking the macro will automatically include a set of default UTM parameters as
 Linking to monitor.firefox.com
 -------------------------------
 
-The ``monitor_button`` macro is designed to help create a valid *call to action* (CTA) link to https://monitor.firefox.com.
+Use the ``monitor_button`` helper to link to https://monitor.firefox.com/ via a Firefox Accounts auth flow.
 
 Usage
 ~~~~~
 
-To use the button in a Jinja template, first import the `monitor_button` macro:
-
 .. code-block:: jinja
 
-    {% from "macros.html" import monitor_button with context %}
-
-A button can then be invoked using:
-
-.. code-block:: jinja
-
-    {{ monitor_button(entrypoint='mozilla.org-firefox-accounts')}}
+    {{ monitor_fxa_button(entrypoint=_entrypoint, button_text='Sign Up for Monitor') }}
 
 The templates's respective JavaScript bundle should also include the following dependencies:
 
@@ -233,48 +225,13 @@ The templates's respective JavaScript bundle should also include the following d
 
 This script will automatically handle things like tracking metrics flow (in the same way we do for https://accounts.firefox.com).
 
-Configuration
-~~~~~~~~~~~~~
-
-The macro provides parameters as follows (* indicates a required parameter)
-
-+----------------------------+------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------+-------------------------------------------------+
-|    Parameter name          |                                                       Definition                                                       |                          Format                          |                    Example                      |
-+============================+========================================================================================================================+==========================================================+=================================================+
-|    entrypoint*             | Unambiguous identifier for which page of the site is the referrer.                                                     | 'mozilla.org-directory-page'                             | 'mozilla.org-firefox-accounts'                  |
-+----------------------------+------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------+-------------------------------------------------+
-|    entrypoint_experiment   | Used to identify experiments.                                                                                          | Experiment ID                                            | 'whatsnew-headlines'                            |
-+----------------------------+------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------+-------------------------------------------------+
-|    entrypoint_variation    | Used to track page variations in multivariate tests. Usually just a number or letter but could be a short keyword.     | Variant identifier                                       | 'b'                                             |
-+----------------------------+------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------+-------------------------------------------------+
-|    form_type               | The type of form to display. Defaults to: 'button'.                                                                    | String                                                   | 'email'                                         |
-+----------------------------+------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------+-------------------------------------------------+
-|    button_text             | The button copy to be used in the call to action.  Default to a well localized string.                                 | Localizable string                                       | _('Sign In to Monitor')                         |
-+----------------------------+------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------+-------------------------------------------------+
-|    button_class            | A class name to be applied to the link (typically for styling with CSS).                                               | String of one or more class names                        | 'mzp-c-button mzp-t-primary mzp-t-product'      |
-+----------------------------+------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------+-------------------------------------------------+
-|    button_id               | A unique ID to apply to the link, for cases where multiple buttons appear on the same page.                            | String                                                   | 'fxa-monitor-submit'                            |
-+----------------------------+------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------+-------------------------------------------------+
-|    cta_type                | Used to indicate the type of button. Defaults to ``fxa-monitor``                                                       | Brief keyword                                            | 'lifecycle-monitor'                             |
-+----------------------------+------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------+-------------------------------------------------+
-|    cta_position            | Used to differentiate buttons in the event of multiples. Defaults to ``primary``                                       | Brief keyword                                            | 'secondary'                                     |
-+----------------------------+------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------+-------------------------------------------------+
-|    utm_campaign*           | Used to identify specific marketing campaigns. Should have default value which is descriptive of the page component.   | Campaign name appended to default value                  | 'accounts-page-hero'                            |
-+----------------------------+------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------+-------------------------------------------------+
-|    utm_term                | Used for paid search keywords.                                                                                         | Brief keyword                                            | 'existing-users'                                |
-+----------------------------+------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------+-------------------------------------------------+
-|    utm_content             | It should only be declared when there is more than one piece of content on a page linking to the same place.           | Description of content, or name of experiment treatment  | 'get-the-rest-of-firefox'                       |
-+----------------------------+------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------+-------------------------------------------------+
-
-Invoking the macro will automatically include a set of default UTM parameters as query string values:
-
-- ``utm_source`` is automatically assigned the value of the ``entrypoint`` parameter.
-- ``utm_medium`` is automatically set as the value of ``referral``.
-
 Linking to getpocket.com
 ------------------------
 
 Use the ``pocket_fxa_button`` helper to link to https://getpocket.com/ via a Firefox Accounts auth flow.
+
+Usage
+~~~~~
 
 .. code-block:: jinja
 
@@ -288,14 +245,14 @@ The templates's respective JavaScript bundle should also include the following d
     js/base/mozilla-fxa-product-button-init.js
 
 FxA button helper configuration
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+-------------------------------
 
-The ``pocket_fxa_button`` helper supports the following parameters:
+Both the ``pocket_fxa_button`` and ``monitor_fxa_button`` helpers support the following parameters:
 
 +----------------------------+------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------+--------------------------------------------------------------------------------------------------------+
 |    Parameter name          |                                                       Definition                                                       |                          Format                          |                                                Example                                                 |
 +============================+========================================================================================================================+==========================================================+========================================================================================================+
-|    entrypoint*             | Unambiguous identifier for which page of the site is the referrer.                                                     | 'mozilla.org-firefox-pocket'                             | 'mozilla.org-firefox-pocket'                                                                           |
+|    entrypoint*             | Unambiguous identifier for which page of the site is the referrer. This also serves as a value for 'utm_source'.       | 'mozilla.org-firefox-pocket'                             | 'mozilla.org-firefox-pocket'                                                                           |
 +----------------------------+------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------+--------------------------------------------------------------------------------------------------------+
 |    button_text*            | The button copy to be used in the call to action.  Default to a well localized string.                                 | Localizable string                                       | _('Try Pocket Now')                                                                                    |
 +----------------------------+------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------+--------------------------------------------------------------------------------------------------------+

--- a/docs/firefox-accounts.rst
+++ b/docs/firefox-accounts.rst
@@ -207,7 +207,7 @@ Invoking the macro will automatically include a set of default UTM parameters as
 Linking to monitor.firefox.com
 -------------------------------
 
-Use the ``monitor_button`` helper to link to https://monitor.firefox.com/ via a Firefox Accounts auth flow.
+Use the ``monitor_fxa_button`` helper to link to https://monitor.firefox.com/ via a Firefox Accounts auth flow.
 
 Usage
 ~~~~~


### PR DESCRIPTION
## Description
- Adds global `monitor_fxa_button` helper.
- Removes `monitor_button` macro.
- Adds tests for new helper.
- Updates templates to use helper.

URLs:

- [ ] http://localhost:8000/en-US/firefox/accounts/
- [ ] http://localhost:8000/en-US/exp/firefox/accounts/
- [ ] http://localhost:8000/en-US/firefox/welcome/1/
- [ ] http://localhost:8000/en-US/exp/firefox/welcome/1/
- [ ] http://localhost:8000/en-US/firefox/67.0.5/whatsnew/all/
- [ ] http://localhost:8000/en-US/firefox/68.0/whatsnew/all/
- [ ] http://localhost:8000/en-US/firefox/69.0/whatsnew/all/
- [ ] http://localhost:8000/en-US/firefox/70.0/whatsnew/all/
- [ ] http://localhost:8000/de/firefox/70.0/whatsnew/all/
- [ ] http://localhost:8000/fr/firefox/70.0/whatsnew/all/
- [ ] http://localhost:8000/en-US/firefox/71.0/whatsnew/all/
- [ ] http://localhost:8000/en-US/exp/firefox/71.0/whatsnew/all/
- [ ] http://localhost:8000/en-US/firefox/72.0beta/whatsnew/all/
- [ ] http://localhost:8000/de/firefox/72.0beta/whatsnew/all/
- [ ] http://localhost:8000/fr/firefox/72.0beta/whatsnew/all/

## Issue / Bugzilla link
#8167

## Testing
- [ ] No regressions in FxA auth with Monitor.
- [ ] Expected params should be present for each template.
- [ ] FxA metrics flow params should still be present on links.

Successful test run: https://gitlab.com/mozmeao/www-config/pipelines/104635921