### PR TITLE
welcome/4 SMS bugfix.

### DIFF
--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -1320,7 +1320,7 @@ SEND_TO_DEVICE_MESSAGE_SETS = {
         }
     },
     'firefox-mobile-welcome': {
-        'sms_countries': config('STD_SMS_COUNTRIES_DEFAULT', default='US', parser=ListOf(str)),
+        'sms_countries': config('STD_SMS_COUNTRIES_MOBILE_WELCOME', default='US,DE,FR', parser=ListOf(str)),
         'sms': {
             'all': 'firefox-mobile-welcome',
         },


### PR DESCRIPTION
## Description

Enable SMS for US, DE, FR

`'sms_countries': config('STD_SMS_COUNTRIES_MOBILE_WELCOME', default='US,DE,FR', parser=ListOf(str)),`