### PR TITLE
Define a localization config for Fluent /whatsnew page (Fixes #8326)

### DIFF
--- a/l10n/configs/pontoon.toml
+++ b/l10n/configs/pontoon.toml
@@ -116,5 +116,11 @@ locales = [
 ]
 
 [[paths]]
-    reference = "en/**/*.ftl"
-    l10n = "{locale}/**/*.ftl"
+    reference = "en/mozorg/mission.ftl"
+    l10n = "{locale}/mozorg/mission.ftl"
+[[paths]]
+    reference = "en/firefox/whatsnew/whatsnew-account.ftl"
+    l10n = "{locale}/firefox/whatsnew/whatsnew-account.ftl"
+[[paths]]
+    reference = "en/firefox/whatsnew/whatsnew.ftl"
+    l10n = "{locale}/firefox/whatsnew/whatsnew.ftl"

--- a/l10n/configs/vendor.toml
+++ b/l10n/configs/vendor.toml
@@ -43,3 +43,6 @@ locales = [
 [[paths]]
     reference = "en/mozorg/mission.ftl"
     l10n = "{locale}/mozorg/mission.ftl"
+[[paths]]
+    reference = "en/firefox/whatsnew/*.ftl"
+    l10n = "{locale}/firefox/whatsnew/*.ftl"

--- a/l10n/configs/vendor.toml
+++ b/l10n/configs/vendor.toml
@@ -44,5 +44,5 @@ locales = [
     reference = "en/mozorg/mission.ftl"
     l10n = "{locale}/mozorg/mission.ftl"
 [[paths]]
-    reference = "en/firefox/whatsnew/*.ftl"
-    l10n = "{locale}/firefox/whatsnew/*.ftl"
+    reference = "en/firefox/whatsnew/**/*.ftl"
+    l10n = "{locale}/firefox/whatsnew/**/*.ftl"


### PR DESCRIPTION
## Description
- Adds a default configuration rule for Fluent /whatsnew pages, for broad staff + vendor + community locale coverage.

Note: community is already [configured here](https://github.com/mozilla/bedrock/blob/master/l10n/configs/pontoon.toml#L118-L120) with a wildcard rule.

## Issue / Bugzilla link
#8326

## Testing
- [ ] Did i get this right? (check for typos)