### PR TITLE
Fix /whatsnew page 72 logos (Fixes #8341)

### DIFF
--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx72.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx72.html
@@ -50,7 +50,7 @@
       <div class="l-columns-one c-picto-list">
         <div class="c-picto-block t-adjacent">
           <div class="c-picto-block-image">
-            <img src="{{ static('img/logos/firefox/logo-monitor.svg') }}" alt="">
+            <img src="{{ static('protocol/img/logos/firefox/monitor/logo.svg') }}" alt="">
           </div>
           <h3 class="c-picto-block-title">Firefox Monitor</h3>
           <div class="c-picto-block-body">
@@ -60,7 +60,7 @@
 
         <div class="c-picto-block t-adjacent">
           <div class="c-picto-block-image">
-            <img src="{{ static('img/logos/firefox/logo-lockwise.svg') }}" alt="">
+            <img src="{{ static('protocol/img/logos/firefox/lockwise/logo.svg') }}" alt="">
           </div>
           <h3 class="c-picto-block-title">Firefox Lockwise</h3>
           <div class="c-picto-block-body">
@@ -90,7 +90,7 @@
 
         <div class="c-picto-block t-adjacent">
           <div class="c-picto-block-image">
-            <img src="{{ static('img/logos/firefox/logo-send.svg') }}" alt="">
+            <img src="{{ static('protocol/img/logos/firefox/send/logo.svg') }}" alt="">
           </div>
           <h3 class="c-picto-block-title">Firefox Send</h3>
           <div class="c-picto-block-body">

--- a/bedrock/firefox/tests/test_base.py
+++ b/bedrock/firefox/tests/test_base.py
@@ -398,7 +398,7 @@ class TestWhatsNew(TestCase):
         req.locale = 'es-ES'
         self.view(req, version='72.0')
         template = render_mock.call_args[0][1]
-        assert template == ['firefox/whatsnew/index.html']
+        assert template == ['firefox/whatsnew/index-account.html']
 
     # end 72.0 whatsnew tests
 

--- a/tests/functional/firefox/whatsnew/test_whatsnew_72.py
+++ b/tests/functional/firefox/whatsnew/test_whatsnew_72.py
@@ -1,0 +1,15 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import pytest
+
+from pages.firefox.whatsnew.whatsnew_72 import FirefoxWhatsNew72Page
+
+
+@pytest.mark.skip_if_not_firefox(reason='Whatsnew pages are shown to Firefox only.')
+@pytest.mark.nondestructive
+def test_account_buttons_displayed(base_url, selenium):
+    page = FirefoxWhatsNew72Page(selenium, base_url, params='').open()
+    assert page.is_primary_account_button_displayed
+    assert page.is_secondary_account_button_displayed

--- a/tests/pages/firefox/whatsnew/whatsnew_72.py
+++ b/tests/pages/firefox/whatsnew/whatsnew_72.py
@@ -1,0 +1,23 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from selenium.webdriver.common.by import By
+
+from pages.firefox.base import FirefoxBasePage
+
+
+class FirefoxWhatsNew72Page(FirefoxBasePage):
+
+    URL_TEMPLATE = '/{locale}/firefox/72.0/whatsnew/all/{params}'
+
+    _primary_account_button_locator = (By.CSS_SELECTOR, '.content-main .js-fxa-product-button')
+    _secondary_account_button_locator = (By.CSS_SELECTOR, '.content-extra .js-fxa-product-button')
+
+    @property
+    def is_primary_account_button_displayed(self):
+        return self.is_element_displayed(*self._primary_account_button_locator)
+
+    @property
+    def is_secondary_account_button_displayed(self):
+        return self.is_element_displayed(*self._secondary_account_button_locator)


### PR DESCRIPTION
## Description
- Fixes logo image paths for 72 WNP.
- Adds functional test for the page.

http://localhost:8000/en-US/firefox/72.0/whatsnew/all/

## Issue / Bugzilla link
#8341

## Testing
Test run: https://gitlab.com/mozmeao/www-config/pipelines/104577579