### PR TITLE
Redirect /firefox/desktop to /firefox/new

### DIFF
--- a/bedrock/firefox/redirects.py
+++ b/bedrock/firefox/redirects.py
@@ -563,7 +563,7 @@ redirectpatterns = (
     redirect(r'^firefox/stats/', '/firefox/'),
 
     # bug 1416706
-    redirect(r'^firefox/desktop/?', 'firefox'),
+    redirect(r'^firefox/desktop/?', '/firefox/new/'),
 
     # bug 1418500
     redirect(r'^firefox/android/?$', 'firefox.mobile'),

--- a/bedrock/firefox/redirects.py
+++ b/bedrock/firefox/redirects.py
@@ -563,7 +563,7 @@ redirectpatterns = (
     redirect(r'^firefox/stats/', '/firefox/'),
 
     # bug 1416706
-    redirect(r'^firefox/desktop/?', '/firefox/new/'),
+    redirect(r'^firefox/desktop/?', 'firefox.new'),
 
     # bug 1418500
     redirect(r'^firefox/android/?$', 'firefox.mobile'),

--- a/tests/redirects/map_globalconf.py
+++ b/tests/redirects/map_globalconf.py
@@ -1203,7 +1203,7 @@ URLS = flatten((
     url_test('/styleguide/identity/firefox/color/', '/styleguide/'),
 
     # bug 1416706
-    url_test('/firefox/desktop/', '/firefox/'),
+    url_test('/firefox/desktop/', '/firefox/new/'),
 
     # bug 1416708
     url_test('/firefox/quantum/', '/firefox/'),


### PR DESCRIPTION
## Description
Redirect /firefox/desktop to /firefox/new instead of /firefox/

## Issue / Bugzilla link
#8174 
## Testing
