### PR TITLE
Newsletter on firefox/channel/ pages should be inside emphasis box. (Fixes #8357)

### DIFF
--- a/bedrock/firefox/templates/firefox/channel/base.html
+++ b/bedrock/firefox/templates/firefox/channel/base.html
@@ -56,7 +56,7 @@
   </ul>
   {% endcall %}
 
-  <section class="t-newsletter">
+  <section class="mzp-c-emphasis-box t-newsletter">
     <div class="mzp-l-content">
       {{ email_newsletter_form(
         protocol_component=True,

--- a/bedrock/firefox/templates/firefox/channel/base.html
+++ b/bedrock/firefox/templates/firefox/channel/base.html
@@ -56,7 +56,7 @@
   </ul>
   {% endcall %}
 
-  <section class="mzp-c-emphasis-box t-newsletter">
+  <section class="t-newsletter">
     <div class="mzp-l-content">
       {{ email_newsletter_form(
         protocol_component=True,

--- a/media/css/firefox/channel.scss
+++ b/media/css/firefox/channel.scss
@@ -83,8 +83,6 @@ $image-path: '/media/protocol/img';
 // styles from developer/includes/newsletter.scss
 
 .t-newsletter {
-    background: #08204e url("/media/img/firefox/developer/newsletter-bg.5cb53dbe3960.svg") center bottom no-repeat;
-    background-size: cover;
     padding: $layout-md $layout-xs;
     .mzp-l-content {
         max-width: $content-sm;

--- a/media/css/firefox/channel.scss
+++ b/media/css/firefox/channel.scss
@@ -83,11 +83,17 @@ $image-path: '/media/protocol/img';
 // styles from developer/includes/newsletter.scss
 
 .t-newsletter {
+    background: #08204e url("/media/img/firefox/developer/newsletter-bg.5cb53dbe3960.svg") center bottom no-repeat;
+    background-size: cover;
+    padding: $layout-md $layout-xs;
     .mzp-l-content {
         max-width: $content-sm;
         min-width: 0;
         padding-bottom: $layout-md;
         padding-top: $layout-md;
+        background: $color-white;
+        border-radius: 6px;
+        box-shadow: 0 4px 16px 0 $color-gray-60;
     }
 
     .mzp-c-newsletter-form {


### PR DESCRIPTION
## Description
Updates the newsletter on the firefox/channel pages to follow style of newsletter on firefox/developer.

## Issue / Bugzilla link
#8357 
