### PR TITLE
Added Mozilla Theme to the legal docs (fix #8355)

### DIFF
--- a/bedrock/base/templates/base-article.html
+++ b/bedrock/base/templates/base-article.html
@@ -9,6 +9,8 @@
 
 {% block body_id %}{{ body_id }}{% endblock %}
 
+{% block body_class %}{{ body_class }}{% endblock %}
+
 {% block content %}
   {% block main_feature %}{% endblock %}
   <div id="main-content" class="mzp-l-content{% if self.side_nav()|trim|length or self.side_extra()|trim|length %} mzp-has-sidebar mzp-l-sidebar-left{% endif %}">

--- a/bedrock/legal/templates/legal/docs-base.html
+++ b/bedrock/legal/templates/legal/docs-base.html
@@ -9,6 +9,8 @@
  {{ css_bundle('legal') }}
 {% endblock %}
 
+{% block body_class %}mzp-t-mozilla{% endblock %}
+
 {% block article %}
   <section itemscope itemtype="http://schema.org/Article">
     <div itemprop="articleBody" class="article-body">

--- a/bedrock/legal/templates/legal/fraud-report.html
+++ b/bedrock/legal/templates/legal/fraud-report.html
@@ -10,6 +10,8 @@
   {{ css_bundle('legal') }}
 {% endblock %}
 
+{% block body_class %}mzp-t-mozilla{% endblock %}
+
 {% block side_nav %}
 <nav class="mzp-c-sidemenu">
   <section class="mzp-c-sidemenu-summary mzp-js-toggle" aria-controls="sidebar-menu">

--- a/bedrock/legal/templates/legal/index.html
+++ b/bedrock/legal/templates/legal/index.html
@@ -10,6 +10,8 @@
   {{ css_bundle('legal') }}
 {% endblock %}
 
+{% block body_class %}mzp-t-mozilla{% endblock %}
+
 {% block side_nav %}
 <nav class="mzp-c-sidemenu">
   <section class="mzp-c-sidemenu-summary mzp-js-toggle" aria-controls="sidebar-menu">


### PR DESCRIPTION
## Description
Added Mozilla Theme to the legal docs. Now the headings are in Zilla.
## Issue / Bugzilla link
#8355 
## Testing
