### PR TITLE
Fix missing image reference on /firefox/mobile

### DIFF
--- a/bedrock/firefox/templates/firefox/mobile/index.html
+++ b/bedrock/firefox/templates/firefox/mobile/index.html
@@ -175,7 +175,7 @@
           <div class="qr-code-wrapper">
             <img src="{{ static('img/firefox/mobile/protocol/qr-firefox.png') }}"
                  id="firefox-qr"
-                 data-mozillaonline-link="{{ static('img/firefox/mobile/qr-firefox-mozillaonline.png') }}"
+                 data-mozillaonline-link="{{ static('img/firefox/mobile/protocol/qr-firefox-mozillaonline.png') }}"
                  alt="QR code to scan for Firefox Focus.">
           </div>
         {% endif %}


### PR DESCRIPTION
Fixes: https://bedrock-dev.gcp.moz.works/sv-SE/firefox/mobile/

```
ValueError: Missing staticfiles manifest entry for 'img/firefox/mobile/qr-firefox-mozillaonline.png'
```


