### PR TITLE
Fix image reference on /mobile/get-app/ page

### DIFF
--- a/bedrock/firefox/templates/firefox/mobile/get-app.html
+++ b/bedrock/firefox/templates/firefox/mobile/get-app.html
@@ -4,7 +4,7 @@
 
 {% from "macros.html" import google_play_button, send_to_device with context %}
 
-{% add_lang_files "firefox/sendto" %}
+{% add_lang_files "firefox/mobile-2019" "firefox/sendto" %}
 
 {% extends "firefox/base/base-protocol.html" %}
 
@@ -37,7 +37,7 @@
     {% else %}
       <p>{{ _('Scan the QR code to get started') }}</p>
       <div class="qr-code-wrapper">
-        <img src="{{ static('img/firefox/mobile/protocol/qr-firefox.png') }}" id="firefox-qr" data-mozillaonline-link="{{ static('img/firefox/mobile/qr-firefox-mozillaonline.png') }}" alt="{{ _('QR code to scan for Firefox') }}">
+        <img src="{{ static('img/firefox/mobile/protocol/qr-firefox.png') }}" id="firefox-qr" data-mozillaonline-link="{{ static('img/firefox/mobile/protocol/qr-firefox-mozillaonline.png') }}" alt="{{ _('QR code to scan for Firefox') }}">
       </div>
     {% endif %}
   </section>


### PR DESCRIPTION
Fixes https://www.mozilla.org/fa/firefox/mobile/get-app/

Also adds the `firefox/mobile-2019` lang file, as the page was using `firefox/send-to` for activation status, which can't be used on its own (the strings for the page were originally taken from /mobile).

```
ValueError: Missing staticfiles manifest entry for 'img/firefox/mobile/qr-firefox-mozillaonline.png'
```