### PR TITLE
Increase the width of the level span by one pixel

### DIFF
--- a/media/css/security/components/level.scss
+++ b/media/css/security/components/level.scss
@@ -25,7 +25,7 @@ $image-path: '/media/protocol/img';
     font-weight: bold;
     line-height: 1;
     padding: 4px 2px 4px 4px;
-    width: 90px;
+    width: 91px;
 
     &.moderate {
         background: $color-yellow-10;

--- a/media/css/security/components/level.scss
+++ b/media/css/security/components/level.scss
@@ -25,7 +25,7 @@ $image-path: '/media/protocol/img';
     font-weight: bold;
     line-height: 1;
     padding: 4px 2px 4px 4px;
-    width: 91px;
+    min-width: 90px;
 
     &.moderate {
         background: $color-yellow-10;

--- a/media/css/security/components/level.scss
+++ b/media/css/security/components/level.scss
@@ -24,7 +24,7 @@ $image-path: '/media/protocol/img';
     font-style: normal;
     font-weight: bold;
     line-height: 1;
-    padding: 4px 2px 4px 4px;
+    padding: 4px;
     min-width: 90px;
 
     &.moderate {


### PR DESCRIPTION
On my computer at least, "MFA 2020-02" is width enough that it overflows to two lines. Increasing the width by one pixel puts it back on one line.