### PR TITLE
[no bug] Typo fix on CPG community hotline

### DIFF
--- a/bedrock/mozorg/templates/mozorg/about/governance/policies/community-hotline.html
+++ b/bedrock/mozorg/templates/mozorg/about/governance/policies/community-hotline.html
@@ -22,7 +22,7 @@
 
   <p>
   {% trans howto=url('mozorg.about.governance.policies.reporting') %}
-    To report violations of the Community Participation Guidelines <strong>in Mozilla’s communities</strong>, please click the “Report” button below. For more information on how to take and give a report please read “<a href="{{ howto }}">How to Report</a>”.
+    To report violations of the Community Participation Guidelines <strong>in Mozilla’s communities</strong>, please click the “Report” button below. For more information on how to take and give a report, please read “<a href="{{ howto }}">How to Report</a>”.
   {% endtrans %}
   </p>
 


### PR DESCRIPTION
## Description
@peiying2 spotted a missing comma in https://github.com/mozilla-l10n/www.mozilla.org/pull/362#discussion_r367712845