### PR TITLE
Use dockerized aws-cli for s3 sync of static files

### DIFF
--- a/bin/aws-docker
+++ b/bin/aws-docker
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -eo pipefail
+docker run --rm \
+           -v "${HOME}/.aws:/home/webdev/.aws:ro" \
+           -v "$(pwd):/app" \
+           mozmeao/aws-cli:latest "$@"

--- a/bin/upload-staticfiles.sh
+++ b/bin/upload-staticfiles.sh
@@ -32,7 +32,7 @@ bin/move_hashed_staticfiles.py "${TMP_DIR}" "${TMP_DIR_HASHED}"
 
 for BUCKET in "${BUCKETS[@]}"; do
     # hashed filenames
-    aws s3 sync \
+    bin/aws-docker s3 sync \
         --acl public-read \
         --cache-control "max-age=315360000, public, immutable" \
         --profile bedrock-media \
@@ -40,7 +40,7 @@ for BUCKET in "${BUCKETS[@]}"; do
     # non-hashed filenames
     # may not need to include non-hashed files
     # TODO look into this if this is slow or makes the bucket too large
-    aws s3 sync \
+    bin/aws-docker s3 sync \
         --acl public-read \
         --cache-control "max-age=21600, public" \
         --profile bedrock-media \


### PR DESCRIPTION
This will use the [docker image from this repo](https://github.com/mozmeao/aws-cli-docker) which includes a mime type definition for webp (`image/webp`). It'll be challenging to test this before merging to master, so we should discuss before doing so.

Fix #8470 