### PR TITLE
Default browser string changes (Fixes #8475)

### DIFF
--- a/bedrock/firefox/templates/firefox/set-as-default/landing-page.html
+++ b/bedrock/firefox/templates/firefox/set-as-default/landing-page.html
@@ -35,9 +35,15 @@
     {% endcall %}
     <section class="card-set">
       <ul class="mzp-l-card-third mzp-l-content">
-      {{ picto_card(title=_('Choose automatic privacy'), desc=_('The internet keeps finding new ways to poach your personal data. Firefox is the only browser with a mission of finding new ways to protect you.'), class='privacy') }}
-      {{ picto_card(title=_('Choose freedom on every device'), desc=_('Firefox is fast and safe on Windows, iOS, Android, Linux...and across them all. We have no interest in locking you in or resetting your preferences.'), class='freedom') }}
-      {{ picto_card(title=_('Choose corporate independence'), desc=_('Firefox is the only major independent browser. Chrome, Edge and Brave are all built with code from Google, the world’s largest ad network.'), class='independence') }}
+      {% if l10n_has_tag('default-browser-012020') %}
+        {{ picto_card(title=_('Choose automatic privacy'), desc=_('Companies keep finding new ways to poach your personal data. Firefox is the browser with a mission of finding new ways to protect you.'), class='privacy') }}
+        {{ picto_card(title=_('Choose freedom on every device'), desc=_('Firefox is fast and safe on Windows, iOS, Android, Linux…and across them all. You deserve choices in browsers and devices, instead of decisions made for you.'), class='freedom') }}
+        {{ picto_card(title=_('Choose corporate independence'), desc=_('Firefox is the only major independent browser. Chrome, Edge and Brave are all built on Google code, which means giving Google even more control of the internet.'), class='independence') }}
+      {% else %}
+        {{ picto_card(title=_('Choose automatic privacy'), desc=_('The internet keeps finding new ways to poach your personal data. Firefox is the only browser with a mission of finding new ways to protect you.'), class='privacy') }}
+        {{ picto_card(title=_('Choose freedom on every device'), desc=_('Firefox is fast and safe on Windows, iOS, Android, Linux...and across them all. We have no interest in locking you in or resetting your preferences.'), class='freedom') }}
+        {{ picto_card(title=_('Choose corporate independence'), desc=_('Firefox is the only major independent browser. Chrome, Edge and Brave are all built with code from Google, the world’s largest ad network.'), class='independence') }}
+      {% endif %}
       </ul>
     </section>
   </main>

--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx73.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx73.html
@@ -79,7 +79,6 @@
     </div>
   </section>
 
-
   <section class="content-extra">
     <div class="mzp-l-content">
       <div class="l-columns-three">
@@ -89,7 +88,11 @@
           </div>
           <h3 class="c-picto-block-title">{{ _('Choose automatic privacy') }}</h3>
           <div class="c-picto-block-body">
-            <p>{{ _('The internet keeps finding new ways to poach your personal data. Firefox is the only browser with a mission of finding new ways to protect you.') }}</p>
+            {% if l10n_has_tag('default-browser-012020') %}
+              <p>{{ _('Companies keep finding new ways to poach your personal data. Firefox is the browser with a mission of finding new ways to protect you.') }}</p>
+            {% else %}
+              <p>{{ _('The internet keeps finding new ways to poach your personal data. Firefox is the only browser with a mission of finding new ways to protect you.') }}</p>
+            {% endif %}
           </div>
         </div>
 
@@ -100,9 +103,11 @@
 
           <h3 class="c-picto-block-title">{{ _('Choose freedom on every device') }}</h3>
           <div class="c-picto-block-body">
-            <p>
-              {{ _('Firefox is fast and safe on Windows, iOS, Android, Linux...and across them all. We have no interest in locking you in or resetting your preferences.') }}
-            </p>
+            {% if l10n_has_tag('default-browser-012020') %}
+              <p>{{ _('Firefox is fast and safe on Windows, iOS, Android, Linux…and across them all. You deserve choices in browsers and devices, instead of decisions made for you.') }}</p>
+            {% else %}
+              <p>{{ _('Firefox is fast and safe on Windows, iOS, Android, Linux...and across them all. We have no interest in locking you in or resetting your preferences.') }}</p>
+            {% endif %}
           </div>
         </div>
 
@@ -113,7 +118,11 @@
 
           <h3 class="c-picto-block-title">{{ _('Choose corporate independence') }}</h3>
           <div class="c-picto-block-body">
-            <p>{{ _('Firefox is the only major independent browser. Chrome, Edge and Brave are all built with code from Google, the world’s largest ad network.') }}</p>
+            {% if l10n_has_tag('default-browser-012020') %}
+              <p>{{ _('Firefox is the only major independent browser. Chrome, Edge and Brave are all built on Google code, which means giving Google even more control of the internet.') }}</p>
+            {% else %}
+              <p>{{ _('Firefox is the only major independent browser. Chrome, Edge and Brave are all built with code from Google, the world’s largest ad network.') }}</p>
+            {% endif %}
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Description
Add new strings to Firefox browser default landing  page and WNP 73 (new strings behind l10n tag).

http://localhost:8000/en-US/firefox/73.0/whatsnew/all/
http://localhost:8000/en-US/firefox/set-as-default/

## Issue / Bugzilla link
#8475