### PR TITLE
Show WNP70 template for Firefox Beta 73 update (Fixes #8450)

### DIFF
--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx70-de.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx70-de.html
@@ -100,7 +100,7 @@
 
   <aside class="mzp-l-content c-utilities">
     <p>
-    {% trans notes=url('firefox.notes') %}
+    {% trans notes=url('firefox.releases.index') if not version else '/firefox/%s/releasenotes/'|format(version) %}
       Lies die <a href="{{ notes }}">Versionshinweise</a>, um mehr über die Neuerungen in deinem Firefox Browser zu erfahren.
     {% endtrans %}
     </p>

--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx70-en.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx70-en.html
@@ -100,7 +100,7 @@
 
   <aside class="mzp-l-content c-utilities">
     <p>
-    {% trans notes=url('firefox.notes') %}
+    {% trans notes=url('firefox.releases.index') if not version else '/firefox/%s/releasenotes/'|format(version) %}
       Read the <a href="{{ notes }}">Release Notes</a> to know more about what’s new in your Firefox Browser.
     {% endtrans %}
     </p>

--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx70-fr.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx70-fr.html
@@ -100,7 +100,7 @@
 
   <aside class="mzp-l-content c-utilities">
     <p>
-    {% trans notes=url('firefox.notes') %}
+    {% trans notes=url('firefox.releases.index') if not version else '/firefox/%s/releasenotes/'|format(version) %}
       Consultez les <a href="{{ notes }}">notes de version</a> pour en savoir plus sur les nouveautés de votre navigateur Firefox.
     {% endtrans %}
     </p>

--- a/bedrock/firefox/tests/test_base.py
+++ b/bedrock/firefox/tests/test_base.py
@@ -182,16 +182,16 @@ class TestWhatsNew(TestCase):
     def test_context_variables_whatsnew_beta(self, render_mock):
         """Should pass the correct context variables for beta channel"""
         req = self.rf.get('/en-US/firefox/whatsnew/')
-        self.view(req, version='72.0beta')
+        self.view(req, version='74.0beta')
         template = render_mock.call_args[0][1]
         ctx = render_mock.call_args[0][2]
         assert template == ['firefox/whatsnew/whatsnew-fx70-en.html']
-        assert ctx['version'] == '72.0beta'
-        assert ctx['analytics_version'] == '72beta'
-        assert ctx['entrypoint'] == 'mozilla.org-whatsnew72beta'
-        assert ctx['campaign'] == 'whatsnew72beta'
-        assert ctx['utm_params'] == ('utm_source=mozilla.org-whatsnew72beta&utm_medium=referral'
-                                     '&utm_campaign=whatsnew72beta&entrypoint=mozilla.org-whatsnew72beta')
+        assert ctx['version'] == '74.0beta'
+        assert ctx['analytics_version'] == '74beta'
+        assert ctx['entrypoint'] == 'mozilla.org-whatsnew74beta'
+        assert ctx['campaign'] == 'whatsnew74beta'
+        assert ctx['utm_params'] == ('utm_source=mozilla.org-whatsnew74beta&utm_medium=referral'
+                                     '&utm_campaign=whatsnew74beta&entrypoint=mozilla.org-whatsnew74beta')
 
     @override_settings(DEV=True)
     def test_context_variables_whatsnew_developer(self, render_mock):
@@ -240,10 +240,10 @@ class TestWhatsNew(TestCase):
     # begin beta whatsnew tests
 
     @override_settings(DEV=True)
-    def test_fx_72beta_whatsnew(self, render_mock):
+    def test_fx_74beta_whatsnew(self, render_mock):
         """Should show Fx70 whatsnew template"""
         req = self.rf.get('/en-US/firefox/whatsnew/')
-        self.view(req, version='72.0beta')
+        self.view(req, version='74.0beta')
         template = render_mock.call_args[0][1]
         assert template == ['firefox/whatsnew/whatsnew-fx70-en.html']
 

--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -575,7 +575,7 @@ class WhatsnewView(L10nTemplateView):
             else:
                 template = 'firefox/whatsnew/index.html'
         elif channel == 'beta':
-            if version.startswith('72.'):
+            if version.startswith('74.'):
                 if locale in ['en-US', 'en-CA', 'en-GB']:
                     template = 'firefox/whatsnew/whatsnew-fx70-en.html'
                 elif locale == 'de':

--- a/tests/functional/firefox/whatsnew/test_whatsnew_beta_74.py
+++ b/tests/functional/firefox/whatsnew/test_whatsnew_beta_74.py
@@ -4,18 +4,18 @@
 
 import pytest
 
-from pages.firefox.whatsnew.whatsnew_beta_72 import FirefoxWhatsNew72betaPage
+from pages.firefox.whatsnew.whatsnew_beta_74 import FirefoxWhatsNew74betaPage
 
 
 @pytest.mark.skip_if_not_firefox(reason='Whatsnew pages are shown to Firefox only.')
 @pytest.mark.nondestructive
 def test_signed_out_monitor_button_displayed(base_url, selenium):
-    page = FirefoxWhatsNew72betaPage(selenium, base_url, params='').open()
+    page = FirefoxWhatsNew74betaPage(selenium, base_url, params='').open()
     assert page.is_signed_out_monitor_button_displayed
 
 
 @pytest.mark.skip_if_not_firefox(reason='Whatsnew pages are shown to Firefox only.')
 @pytest.mark.nondestructive
 def test_signed_in_monitor_button_displayed(base_url, selenium):
-    page = FirefoxWhatsNew72betaPage(selenium, base_url, params='?signed-in=true').open()
+    page = FirefoxWhatsNew74betaPage(selenium, base_url, params='?signed-in=true').open()
     assert page.is_signed_in_monitor_button_displayed

--- a/tests/pages/firefox/whatsnew/whatsnew_beta_74.py
+++ b/tests/pages/firefox/whatsnew/whatsnew_beta_74.py
@@ -7,9 +7,9 @@ from selenium.webdriver.common.by import By
 from pages.firefox.base import FirefoxBasePage
 
 
-class FirefoxWhatsNew72betaPage(FirefoxBasePage):
+class FirefoxWhatsNew74betaPage(FirefoxBasePage):
 
-    URL_TEMPLATE = '/{locale}/firefox/72.0beta/whatsnew/all/{params}'
+    URL_TEMPLATE = '/{locale}/firefox/74.0beta/whatsnew/all/{params}'
 
     _signed_out_monitor_button_locator = (By.CSS_SELECTOR, '.show-fxa-supported-signed-out .js-fxa-product-button')
     _signed_in_monitor_button_locator = (By.CSS_SELECTOR, '.show-fxa-supported-signed-in .js-fxa-product-button')


### PR DESCRIPTION
## Description
- Shows the template from `/firefox/70.0/whatsnew/all/` at `/firefox/74.0beta/whatsnew/all/`.
- Also updates the release notes link to point to the version URL for the specific release, as opposed to always the latest version.

http://localhost:8000/en-US/firefox/74.0beta/whatsnew/all/
http://localhost:8000/de/firefox/74.0beta/whatsnew/all/
http://localhost:8000/fr/firefox/74.0beta/whatsnew/all/

## Issue / Bugzilla link
#8450

## Testing
- [ ] The correct template should be displayed.
- [ ] Release notes link should point to `/firefox/74.0beta/releasenotes/` instead of `/firefox/72.0.2/releasenotes/`.