### PR TITLE
Add coarse UA detection to stub attribution (Fixes #8405)

### DIFF
--- a/bedrock/firefox/tests/test_views.py
+++ b/bedrock/firefox/tests/test_views.py
@@ -50,6 +50,7 @@ class TestStubAttributionCode(TestCase):
             'content': '(not set)',
             'experiment': '(not set)',
             'variation': '(not set)',
+            'ua': '(not set)',
         }
         req = self._get_request({'dude': 'abides'})
         resp = views.stub_attribution_code(req)
@@ -65,7 +66,7 @@ class TestStubAttributionCode(TestCase):
         self.assertDictEqual(attrs, final_params)
         self.assertEqual(
             data['attribution_sig'],
-            '5560dd96b10040c7c386ae8080233b43b8661c44f249101ecbab8370847962c1',
+            'e0eff8af228709c6f99d8a57699e36e8152698146e0992c7f491e91905eec5f4',
         )
 
     def test_no_valid_param_data(self):
@@ -77,6 +78,7 @@ class TestStubAttributionCode(TestCase):
             'content': '(not set)',
             'experiment': '(not set)',
             'variation': '(not set)',
+            'ua': '(not set)',
         }
         req = self._get_request(params)
         resp = views.stub_attribution_code(req)
@@ -92,7 +94,7 @@ class TestStubAttributionCode(TestCase):
         self.assertDictEqual(attrs, final_params)
         self.assertEqual(
             data['attribution_sig'],
-            '5560dd96b10040c7c386ae8080233b43b8661c44f249101ecbab8370847962c1',
+            'e0eff8af228709c6f99d8a57699e36e8152698146e0992c7f491e91905eec5f4',
         )
 
     def test_some_valid_param_data(self):
@@ -104,6 +106,7 @@ class TestStubAttributionCode(TestCase):
             'content': '(not set)',
             'experiment': '(not set)',
             'variation': '(not set)',
+            'ua': '(not set)',
         }
         req = self._get_request(params)
         resp = views.stub_attribution_code(req)
@@ -119,7 +122,7 @@ class TestStubAttributionCode(TestCase):
         self.assertDictEqual(attrs, final_params)
         self.assertEqual(
             data['attribution_sig'],
-            '4e03561fc04c080caf0f9f6b4d8cb24c707a4dc5a8929af65881e166d2cca826',
+            '248b763a1848f0a5e4a4ce169b38c5810511b198aed731091e065b8fd6b02e23',
         )
 
     def test_campaign_data_too_long(self):
@@ -132,6 +135,7 @@ class TestStubAttributionCode(TestCase):
             'but%7cI%7ctake%7ccomfort%7cin%7cthat' * 6,
             'experiment': '(not set)',
             'variation': '(not set)',
+            'ua': 'chrome',
         }
         final_params = {
             'source': 'brandt',
@@ -140,10 +144,11 @@ class TestStubAttributionCode(TestCase):
             '|thatThe|Dude|abides|I|dont|know|about|you|but|I|take|comfort|in|thatThe'
             '|Dude|abides|I|dont|know|about|you|but|I|take|comfort|in|thatThe|Dude|abides'
             '|I|dont|know|about|you|but|I|take|comfort|in|thatThe|Dude|abides|I|dont|know'
-            '|about|you|but|I|take|comfort|in|thatThe|Dude|abides|I|dont|know|about_',
+            '|about|you|but|I|take|comfort|in|thatThe|Dude|abides|I|dont|_',
             'content': 'A144_A000_0000000',
             'experiment': '(not set)',
             'variation': '(not set)',
+            'ua': 'chrome',
         }
         req = self._get_request(params)
         resp = views.stub_attribution_code(req)
@@ -159,7 +164,7 @@ class TestStubAttributionCode(TestCase):
         self.assertDictEqual(attrs, final_params)
         self.assertEqual(
             data['attribution_sig'],
-            '1818f48f6f2ab260cec86e41b660040144d020dce6a33ff0d0ec84090695a89f',
+            'ed35e1ed1167806f7744bdbb62c4e1d781c8800df6f2dca09fe63877caa9e167',
         )
 
     def test_other_data_too_long_not_campaign(self):
@@ -180,7 +185,7 @@ class TestStubAttributionCode(TestCase):
         self.assertDictEqual(data, final_params)
 
     def test_returns_valid_data(self):
-        params = {'utm_source': 'brandt', 'utm_medium': 'aether', 'experiment': 'firefox-new', 'variation': '1'}
+        params = {'utm_source': 'brandt', 'utm_medium': 'aether', 'experiment': 'firefox-new', 'variation': '1', 'ua': 'chrome'}
         final_params = {
             'source': 'brandt',
             'medium': 'aether',
@@ -188,6 +193,7 @@ class TestStubAttributionCode(TestCase):
             'content': '(not set)',
             'experiment': 'firefox-new',
             'variation': '1',
+            'ua': 'chrome',
         }
         req = self._get_request(params)
         resp = views.stub_attribution_code(req)
@@ -203,7 +209,7 @@ class TestStubAttributionCode(TestCase):
         self.assertDictEqual(attrs, final_params)
         self.assertEqual(
             data['attribution_sig'],
-            '33b626262f3520b2fea479a0c922e766918a320bda32c710cb638f02b656c5db',
+            '8987babc249a7128b3cd32b11623645cc490ae1709e560249176a2622f288a79',
         )
 
     def test_handles_referrer(self):
@@ -215,6 +221,7 @@ class TestStubAttributionCode(TestCase):
             'content': '(not set)',
             'experiment': '(not set)',
             'variation': '(not set)',
+            'ua': '(not set)',
         }
         req = self._get_request(params)
         resp = views.stub_attribution_code(req)
@@ -230,7 +237,7 @@ class TestStubAttributionCode(TestCase):
         self.assertDictEqual(attrs, final_params)
         self.assertEqual(
             data['attribution_sig'],
-            '4e03561fc04c080caf0f9f6b4d8cb24c707a4dc5a8929af65881e166d2cca826',
+            '248b763a1848f0a5e4a4ce169b38c5810511b198aed731091e065b8fd6b02e23',
         )
 
     def test_handles_referrer_no_source(self):
@@ -245,6 +252,7 @@ class TestStubAttributionCode(TestCase):
             'content': '(not set)',
             'experiment': '(not set)',
             'variation': '(not set)',
+            'ua': '(not set)',
         }
         req = self._get_request(params)
         resp = views.stub_attribution_code(req)
@@ -260,7 +268,7 @@ class TestStubAttributionCode(TestCase):
         self.assertDictEqual(attrs, final_params)
         self.assertEqual(
             data['attribution_sig'],
-            '6bd49cd7e1d88f47f2beca56d2216e7c49cb76aee193ff5c5aca34b5318781e8',
+            '70461f833cc24a4c16a68fda95629c3f5d6bb377d64ae032679a49b4de016679',
         )
 
     def test_handles_referrer_utf8(self):
@@ -278,6 +286,7 @@ class TestStubAttributionCode(TestCase):
             'content': '(not set)',
             'experiment': '(not set)',
             'variation': '(not set)',
+            'ua': '(not set)',
         }
         req = self._get_request(params)
         resp = views.stub_attribution_code(req)
@@ -293,7 +302,7 @@ class TestStubAttributionCode(TestCase):
         self.assertDictEqual(attrs, final_params)
         self.assertEqual(
             data['attribution_sig'],
-            '5560dd96b10040c7c386ae8080233b43b8661c44f249101ecbab8370847962c1',
+            'e0eff8af228709c6f99d8a57699e36e8152698146e0992c7f491e91905eec5f4',
         )
 
     @override_settings(STUB_ATTRIBUTION_RATE=0.2)

--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -56,6 +56,7 @@ STUB_VALUE_NAMES = [
     ('utm_content', '(not set)'),
     ('experiment', '(not set)'),
     ('variation', '(not set)'),
+    ('ua', '(not set)'),
 ]
 STUB_VALUE_RE = re.compile(r'^[a-z0-9-.%():_]+$', flags=re.IGNORECASE)
 

--- a/media/js/base/stub-attribution.js
+++ b/media/js/base/stub-attribution.js
@@ -156,6 +156,38 @@ if (typeof window.Mozilla === 'undefined') {
     };
 
     /**
+     * Returns a browser name based on coarse UA string detection for only major browsers.
+     * Other browsers (or modified UAs) that have strings that look like one of the top default user agent strings are treated as false positives.
+     * @param {String} ua - Optional user agent string to facilitate testing.
+     * @returns {String} - Browser name.
+     */
+    StubAttribution.getUserAgent = function(ua) {
+        ua = typeof ua !== 'undefined' ? ua : navigator.userAgent;
+
+        if (/MSIE|Trident/i.test(ua)) {
+            return 'ie';
+        }
+
+        if (/Edg|Edge/i.test(ua)) {
+            return 'edge';
+        }
+
+        if (/Firefox/.test(ua)) {
+            return 'firefox';
+        }
+
+        if (/Opera/.test(ua)) {
+            return 'opera';
+        }
+
+        if (/Chrome/.test(ua)) {
+            return 'chrome';
+        }
+
+        return 'other';
+    };
+
+    /**
      * Gets utm parameters and referrer information from the web page if they exist.
      * @param {String} ref - Optional referrer to facilitate testing.
      * @return {Object} - Stub attribution data object.
@@ -166,6 +198,7 @@ if (typeof window.Mozilla === 'undefined') {
         var experiment = params.get('experiment');
         var variation = params.get('variation');
         var referrer = typeof ref !== 'undefined' ? ref : document.referrer;
+        var ua = StubAttribution.getUserAgent();
 
         /* eslint-disable camelcase */
         var data = {
@@ -174,6 +207,7 @@ if (typeof window.Mozilla === 'undefined') {
             utm_campaign: utms.utm_campaign,
             utm_content: utms.utm_content,
             referrer: referrer,
+            ua : ua,
             experiment: experiment,
             variation: variation
         };

--- a/tests/unit/spec/base/stub-attribution.js
+++ b/tests/unit/spec/base/stub-attribution.js
@@ -26,11 +26,12 @@ describe('stub-attribution.js', function() {
         beforeEach(function() {
             /* eslint-disable camelcase */
             data = {
-                utm_source: 'foo',
-                utm_medium: 'bar',
-                utm_campaign: 'fizz',
-                utm_content: 'buzz',
-                referrer: 'https://www.google.com'
+                utm_source: 'desktop-snippet',
+                utm_medium: 'referral',
+                utm_campaign: 'F100_4242_otherstuff_in_here',
+                utm_content: 'rel-esr',
+                referrer: '',
+                ua: 'chrome',
             };
             /* eslint-enable camelcase */
 
@@ -138,6 +139,43 @@ describe('stub-attribution.js', function() {
         });
     });
 
+    describe('getUserAgent', function() {
+
+        var ie8 = 'Mozilla/5.0 (compatible; MSIE 8.0; Windows NT 6.1; Trident/4.0; GTB7.4; InfoPath.2; SV1; .NET CLR 3.3.69573; WOW64; en-US)';
+        var ie9 = 'Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; WOW64; Trident/5.0; SLCC2; Media Center PC 6.0; InfoPath.3; MS-RTC LM 8; Zune 4.7)';
+        var ie10 = 'Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 7.0; InfoPath.3; .NET CLR 3.1.40767; Trident/6.0; en-IN)';
+        var ie11 = 'Mozilla/5.0 (Windows NT 6.1; WOW64; Trident/7.0; AS; rv:11.0) like Gecko';
+        var ff = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.14; rv:72.0) Gecko/20100101 Firefox/72.0';
+        var opera = 'Opera/9.80 (X11; Linux i686; Ubuntu/14.10) Presto/2.12.388 Version/12.16';
+        var chrome = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.130 Safari/537.36';
+        var edgeium = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.74 Safari/537.36 Edg/79.0.309.43';
+        var edge = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML like Gecko) Chrome/51.0.2704.79 Safari/537.36 Edge/14.14931';
+
+        it('should identify Internet Explorer', function() {
+            expect(Mozilla.StubAttribution.getUserAgent(ie8)).toEqual('ie');
+            expect(Mozilla.StubAttribution.getUserAgent(ie9)).toEqual('ie');
+            expect(Mozilla.StubAttribution.getUserAgent(ie10)).toEqual('ie');
+            expect(Mozilla.StubAttribution.getUserAgent(ie11)).toEqual('ie');
+        });
+
+        it('should identify Edge', function() {
+            expect(Mozilla.StubAttribution.getUserAgent(edge)).toEqual('edge');
+            expect(Mozilla.StubAttribution.getUserAgent(edgeium)).toEqual('edge');
+        });
+
+        it('should identify Firefox', function() {
+            expect(Mozilla.StubAttribution.getUserAgent(ff)).toEqual('firefox');
+        });
+
+        it('should identify Opera', function() {
+            expect(Mozilla.StubAttribution.getUserAgent(opera)).toEqual('opera');
+        });
+
+        it('should identify Chrome', function() {
+            expect(Mozilla.StubAttribution.getUserAgent(chrome)).toEqual('chrome');
+        });
+    });
+
     describe('getAttributionData', function() {
 
         it('should return attribution data if utm params are present', function() {
@@ -159,12 +197,14 @@ describe('stub-attribution.js', function() {
                 utm_campaign: 'F100_4242_otherstuff_in_here',
                 utm_content: 'rel-esr',
                 referrer: '',
+                ua: 'chrome',
                 experiment: undefined,
                 variation: undefined
             };
             /* eslint-enable camelcase */
 
             spyOn(window._SearchParams.prototype, 'utmParams').and.returnValue(utms);
+            spyOn(Mozilla.StubAttribution, 'getUserAgent').and.returnValue('chrome');
             var result = Mozilla.StubAttribution.getAttributionData(referrer);
             expect(result).toEqual(data);
         });
@@ -188,12 +228,14 @@ describe('stub-attribution.js', function() {
                 utm_campaign: undefined,
                 utm_content: undefined,
                 referrer: 'https://www.mozilla.org/en-US/',
+                ua: 'chrome',
                 experiment: undefined,
                 variation: undefined
             };
             /* eslint-enable camelcase */
 
             spyOn(window._SearchParams.prototype, 'utmParams').and.returnValue(utms);
+            spyOn(Mozilla.StubAttribution, 'getUserAgent').and.returnValue('chrome');
             var result = Mozilla.StubAttribution.getAttributionData(referrer);
             expect(result).toEqual(data);
         });
@@ -217,12 +259,14 @@ describe('stub-attribution.js', function() {
                 utm_campaign: undefined,
                 utm_content: undefined,
                 referrer: '',
+                ua: 'chrome',
                 experiment: undefined,
                 variation: undefined
             };
             /* eslint-enable camelcase */
 
             spyOn(window._SearchParams.prototype, 'utmParams').and.returnValue(utms);
+            spyOn(Mozilla.StubAttribution, 'getUserAgent').and.returnValue('chrome');
             var result = Mozilla.StubAttribution.getAttributionData(referrer);
             expect(result).toEqual(data);
         });
@@ -246,6 +290,7 @@ describe('stub-attribution.js', function() {
                 utm_campaign: undefined,
                 utm_content: undefined,
                 referrer: '',
+                ua: 'chrome',
                 experiment: 'firefox-new',
                 variation: 1
             };
@@ -255,6 +300,7 @@ describe('stub-attribution.js', function() {
             spyOn(window._SearchParams.prototype, 'get').and.callFake(function(key) {
                 return key === 'experiment' ? 'firefox-new' : 1;
             });
+            spyOn(Mozilla.StubAttribution, 'getUserAgent').and.returnValue('chrome');
             var result = Mozilla.StubAttribution.getAttributionData(referrer);
             expect(result).toEqual(data);
         });


### PR DESCRIPTION
## Description
- Adds a new `ua` parameter to stub attribution.

## Issue / Bugzilla link
#8405

## Testing
Demo: https://www-demo5.allizom.org/en-US/