### PR TITLE
Remove enterprise packages

### DIFF
--- a/bedrock/firefox/templates/firefox/enterprise/index.html
+++ b/bedrock/firefox/templates/firefox/enterprise/index.html
@@ -85,11 +85,11 @@
           <ul class="mzp-u-list-styled">
             <li>{{ _('The latest <a href="%s">Firefox browser</a>')|format('https://download.mozilla.org/?product=firefox-latest-ssl&os=win64') }}</li>
             <li>{{ _('The latest <a href="%s">Firefox Extended Support Release (ESR)</a>')|format('https://support.mozilla.org/kb/firefox-esr-release-cycle') }}</li>
-            <li>{{ _('<a href="%s">MSI Installer</a>')|format('https://support.mozilla.org/kb/deploy-firefox-msi-installers') }}</li>
-            <li>{{ _('<a href="%s">Legacy browser</a> support')|format('https://support.mozilla.org/kb/legacy-browser-support-extension-windows') }}</li>
-            <li>{{ _('<a href="%s">ADMX templates</a>'|format('https://support.mozilla.org/kb/customizing-firefox-using-group-policy-windows')) }}</li>
-            {# <li>{{ _('Deployment guide') }}</li> -#}
-            <li>{{ _('<a href="%s">Policy documentation</a>'|format('https://github.com/mozilla/policy-templates/blob/master/README.md')) }}</li>
+            <li><a href="https://support.mozilla.org/kb/deploy-firefox-msi-installers">{{ _('MSI Installer') }}</a></li>
+            <li><a href="https://support.mozilla.org/kb/legacy-browser-support-extension-windows">{{ _('Legacy browser support') }}</a></li>
+            <li><a href="https://support.mozilla.org/kb/customizing-firefox-using-group-policy-windows">{{ _('ADMX templates') }}</a></li>
+            <li><a href="https://assets.mozilla.net/pdf/Firefox.for.Enterprise.Browser.Deployment.Guide.pdf">{{ _('Deployment guide') }}</a></li>
+            <li><a href="https://github.com/mozilla/policy-templates/blob/master/README.md">{{ _('Policy documentation') }}</a></li>
           </ul>
 
         {% endcall %}
@@ -104,9 +104,9 @@
             <li>{{ _('The latest <a href="%s">Firefox browser</a>')|format('https://download.mozilla.org/?product=firefox-latest-ssl&os=win') }}</li>
             <li>{{ _('The latest <a href="%s">Firefox Extended Support Release (ESR)</a>')|format('https://support.mozilla.org/kb/firefox-esr-release-cycle') }}</li>
             <li>{{ _('Sample <a href="%s">plist for configuration profile</a>')|format('https://github.com/mozilla/policy-templates/blob/master/mac/org.mozilla.firefox.plist') }}</li>
-            <li>{{ _('<a href="%s">PKG installer</a>')|format('https://support.mozilla.org/kb/deploying-firefox-macos-using-pkg-and-jamf') }}</li>
-            {# <li>{{ _('Deployment guide') }}</li> -#}
-            <li>{{ _('<a href="%s">Policy documentation</a>'|format('https://github.com/mozilla/policy-templates/blob/master/README.md')) }}</li>
+            <li><a href="https://support.mozilla.org/kb/deploying-firefox-macos-using-pkg-and-jamf">{{ _('PKG installer') }}</a></li>
+            <li><a href="https://assets.mozilla.net/pdf/Firefox.for.Enterprise.Browser.Deployment.Guide.pdf">{{ _('Deployment guide') }}</a></li>
+            <li><a href="https://github.com/mozilla/policy-templates/blob/master/README.md">{{ _('Policy documentation') }}</a></li>
           </ul>
 
         {% endcall %}
@@ -120,11 +120,11 @@
           <ul class="mzp-u-list-styled">
             <li>{{ _('The latest <a href="%s">Firefox browser</a>')|format('https://download.mozilla.org/?product=firefox-latest-ssl&os=osx') }}</li>
             <li>{{ _('The latest <a href="%s">Firefox Extended Support Release (ESR)</a>')|format('https://support.mozilla.org/kb/firefox-esr-release-cycle') }}</li>
-            <li>{{ _('<a href="%s">MSI Installer</a>')|format('https://support.mozilla.org/kb/deploy-firefox-msi-installers') }}</li>
-            <li>{{ _('<a href="%s">Legacy browser</a> support')|format('https://support.mozilla.org/kb/legacy-browser-support-extension-windows') }}</li>
-            <li>{{ _('<a href="%s">ADMX templates</a>'|format('https://support.mozilla.org/kb/customizing-firefox-using-group-policy-windows')) }}</li>
-            {# <li>{{ _('Deployment guide') }}</li> -#}
-            <li>{{ _('<a href="%s">Policy documentation</a>'|format('https://github.com/mozilla/policy-templates/blob/master/README.md')) }}</li>
+            <li><a href="https://support.mozilla.org/kb/deploy-firefox-msi-installers">{{ _('MSI Installer') }}</a></li>
+            <li><a href="https://support.mozilla.org/kb/legacy-browser-support-extension-windows">{{ _('Legacy browser support') }}</a></li>
+            <li><a href="https://support.mozilla.org/kb/customizing-firefox-using-group-policy-windows">{{ _('ADMX templates') }}</a></li>
+            <li><a href="https://assets.mozilla.net/pdf/Firefox.for.Enterprise.Browser.Deployment.Guide.pdf">{{ _('Deployment guide') }}</a></li>
+            <li><a href="https://github.com/mozilla/policy-templates/blob/master/README.md">{{ _('Policy documentation') }}</a></li>
           </ul>
 
         {% endcall %}

--- a/bedrock/firefox/templates/firefox/enterprise/index.html
+++ b/bedrock/firefox/templates/firefox/enterprise/index.html
@@ -101,12 +101,12 @@
           custom_desc=True
         ) %}
           <ul class="mzp-u-list-styled">
-            <li>{{ _('The latest Firefox browser') }}</li>
-            <li>{{ _('The latest Firefox ESR') }}</li>
-            <li>{{ _('Sample plist for configuration profile') }}</li>
-            <li>{{ _('PKG installer') }}</li>
-            <li>{{ _('Deployment guide') }}</li>
-            <li>{{ _('Policy documentation') }}</li>
+            <li>{{ _('The latest <a href="%s">Firefox browser</a>')|format('https://download.mozilla.org/?product=firefox-latest-ssl&os=win') }}</li>
+            <li>{{ _('The latest <a href="%s">Firefox Extended Support Release (ESR)</a>')|format('https://support.mozilla.org/kb/firefox-esr-release-cycle') }}</li>
+            <li>{{ _('Sample <a href="%s">plist for configuration profile</a>')|format('https://github.com/mozilla/policy-templates/blob/master/mac/org.mozilla.firefox.plist') }}</li>
+            <li>{{ _('<a href="%s">PKG installer</a>')|format('https://support.mozilla.org/kb/deploying-firefox-macos-using-pkg-and-jamf') }}</li>
+            {# <li>{{ _('Deployment guide') }}</li> -#}
+            <li>{{ _('<a href="%s">Policy documentation</a>'|format('https://github.com/mozilla/policy-templates/blob/master/README.md')) }}</li>
           </ul>
 
         {% endcall %}

--- a/bedrock/firefox/templates/firefox/enterprise/index.html
+++ b/bedrock/firefox/templates/firefox/enterprise/index.html
@@ -83,13 +83,13 @@
           custom_desc=True
         ) %}
           <ul class="mzp-u-list-styled">
-            <li>{{ _('The latest Firefox browser') }}</li>
+            <li>{{ _('The latest <a href="%s">Firefox browser</a>')|format('https://download.mozilla.org/?product=firefox-latest-ssl&os=win64') }}</li>
             <li>{{ _('The latest <a href="%s">Firefox Extended Support Release (ESR)</a>')|format('https://support.mozilla.org/kb/firefox-esr-release-cycle') }}</li>
-            <li><a href="https://support.mozilla.org/kb/deploy-firefox-msi-installers">{{ _('MSI Installer') }}</a></li>
+            <li>{{ _('<a href="%s">MSI Installer</a>')|format('https://support.mozilla.org/kb/deploy-firefox-msi-installers') }}</li>
             <li>{{ _('<a href="%s">Legacy browser</a> support')|format('https://support.mozilla.org/kb/legacy-browser-support-extension-windows') }}</li>
-            <li><a href="https://support.mozilla.org/kb/customizing-firefox-using-group-policy-windows">{{ _('ADMX templates') }}</a></li>
-            <li>{{ _('Deployment guide') }}</li>
-            <li>{{ _('Policy documentation') }}</li>
+            <li>{{ _('<a href="%s">ADMX templates</a>'|format('https://support.mozilla.org/kb/customizing-firefox-using-group-policy-windows')) }}</li>
+            {# <li>{{ _('Deployment guide') }}</li> -#}
+            <li>{{ _('<a href="%s">Policy documentation</a>'|format('https://github.com/mozilla/policy-templates/blob/master/README.md')) }}</li>
           </ul>
 
         {% endcall %}

--- a/bedrock/firefox/templates/firefox/enterprise/index.html
+++ b/bedrock/firefox/templates/firefox/enterprise/index.html
@@ -73,7 +73,7 @@
 
   <div class="mzp-l-content">
     <section id="download" class="enterprise-section enterprise-download">
-      <h2 class="enterprise-section-title">{{ _('Enterprise package downloads') }}</h2>
+      <h2 class="enterprise-section-title">{{ _('Enterprise downloads') }}</h2>
 
       <ul class="mzp-l-card-third enterprise-download-lists">
         {% call picto_card(
@@ -92,15 +92,6 @@
             <li>{{ _('Policy documentation') }}</li>
           </ul>
 
-          <div class="cta-container">
-            <div class="mzp-c-button-download-container">
-              <a id="package-win64-download-button" href="https://mozilla.box.com/s/5uvc1hjsimtx3wvs9qdpbda47h2tix5c" class="mzp-c-button mzp-t-product" data-cta-type="Enterprise-Package" data-cta-text="Windows64" data-cta-position="Primary">
-                {{ _('Download') }}
-              </a>
-              <a href="{{ url('privacy.notices.firefox') }}" class="mzp-c-button-download-privacy-link">{{ _('Firefox Privacy Notice') }}</a>
-            </div>
-          </div>
-
         {% endcall %}
 
         {% call picto_card(
@@ -117,15 +108,6 @@
             <li>{{ _('Deployment guide') }}</li>
             <li>{{ _('Policy documentation') }}</li>
           </ul>
-
-          <div class="cta-container">
-            <div class="mzp-c-button-download-container">
-              <a id="package-mac-download-button" href="https://mozilla.box.com/s/qd58fn88r0zxg3pw132ul489egxqvi6k" class="mzp-c-button mzp-t-product" data-cta-type="Enterprise-Package" data-cta-text="Mac" data-cta-position="Primary">
-                {{ _('Download') }}
-              </a>
-              <a href="{{ url('privacy.notices.firefox') }}" class="mzp-c-button-download-privacy-link">{{ _('Firefox Privacy Notice') }}</a>
-            </div>
-          </div>
 
         {% endcall %}
 
@@ -145,14 +127,6 @@
             <li>{{ _('Policy documentation') }}</li>
           </ul>
 
-          <div class="cta-container">
-            <div class="mzp-c-button-download-container">
-              <a id="package-win32-download-button" href="https://mozilla.box.com/s/yjerfy3sgre39mve7n5jjtcy9p10vf3k" class="mzp-c-button mzp-t-product" data-cta-type="Enterprise-Package" data-cta-text="Windows32" data-cta-position="Primary">
-                {{ _('Download') }}
-              </a>
-              <a href="{{ url('privacy.notices.firefox') }}" class="mzp-c-button-download-privacy-link">{{ _('Firefox Privacy Notice') }}</a>
-            </div>
-          </div>
         {% endcall %}
       </ul>
 

--- a/bedrock/firefox/templates/firefox/enterprise/index.html
+++ b/bedrock/firefox/templates/firefox/enterprise/index.html
@@ -118,13 +118,13 @@
           custom_desc=True
         ) %}
           <ul class="mzp-u-list-styled">
-            <li>{{ _('The latest Firefox browser') }}</li>
-            <li>{{ _('The latest Firefox ESR') }}</li>
-            <li>{{ _('MSI Installer') }}</li>
-            <li>{{ _('Legacy browser support') }}</li>
-            <li>{{ _('ADMX templates') }}</li>
-            <li>{{ _('Deployment guide') }}</li>
-            <li>{{ _('Policy documentation') }}</li>
+            <li>{{ _('The latest <a href="%s">Firefox browser</a>')|format('https://download.mozilla.org/?product=firefox-latest-ssl&os=osx') }}</li>
+            <li>{{ _('The latest <a href="%s">Firefox Extended Support Release (ESR)</a>')|format('https://support.mozilla.org/kb/firefox-esr-release-cycle') }}</li>
+            <li>{{ _('<a href="%s">MSI Installer</a>')|format('https://support.mozilla.org/kb/deploy-firefox-msi-installers') }}</li>
+            <li>{{ _('<a href="%s">Legacy browser</a> support')|format('https://support.mozilla.org/kb/legacy-browser-support-extension-windows') }}</li>
+            <li>{{ _('<a href="%s">ADMX templates</a>'|format('https://support.mozilla.org/kb/customizing-firefox-using-group-policy-windows')) }}</li>
+            {# <li>{{ _('Deployment guide') }}</li> -#}
+            <li>{{ _('<a href="%s">Policy documentation</a>'|format('https://github.com/mozilla/policy-templates/blob/master/README.md')) }}</li>
           </ul>
 
         {% endcall %}

--- a/tests/functional/firefox/test_enterprise.py
+++ b/tests/functional/firefox/test_enterprise.py
@@ -11,11 +11,3 @@ from pages.firefox.enterprise.landing import EnterprisePage
 def test_primary_download_button_displayed(base_url, selenium):
     page = EnterprisePage(selenium, base_url).open()
     assert page.is_primary_download_button_displayed
-
-
-@pytest.mark.nondestructive
-def test_package_download_buttons_displayed(base_url, selenium):
-    page = EnterprisePage(selenium, base_url).open()
-    assert page.is_package_win64_download_button_displayed
-    assert page.is_package_mac_download_button_displayed
-    assert page.is_package_win32_download_button_displayed

--- a/tests/pages/firefox/enterprise/landing.py
+++ b/tests/pages/firefox/enterprise/landing.py
@@ -12,65 +12,7 @@ class EnterprisePage(FirefoxBasePage):
     URL_TEMPLATE = '/{locale}/firefox/enterprise/'
 
     _primary_download_button_locator = (By.ID, 'primary-download-button')
-    _comparison_download_button_locator = (By.ID, 'comparison-download-button')
-    _comparison_sales_button_locator = (By.ID, 'comparison-sales-button')
-    _comparison_tab_button_basic_locator = (By.ID, 'pager-tab-button-basic')
-    _comparison_tab_button_premium_locator = (By.ID, 'pager-tab-button-premium')
-    _comparison_basic_plan_locator = (By.ID, 'pager-page-basic')
-    _comparison_premium_plan_locator = (By.ID, 'pager-page-premium')
-    _package_win64_download_button_locator = (By.ID, 'package-win64-download-button')
-    _package_mac_download_button_locator = (By.ID, 'package-mac-download-button')
-    _package_win32_download_button_locator = (By.ID, 'package-win32-download-button')
 
     @property
     def is_primary_download_button_displayed(self):
         return self.is_element_displayed(*self._primary_download_button_locator)
-
-    @property
-    def is_comparison_download_button_displayed(self):
-        return self.is_element_displayed(*self._comparison_download_button_locator)
-
-    @property
-    def is_comparison_sales_button_displayed(self):
-        return self.is_element_displayed(*self._comparison_sales_button_locator)
-
-    @property
-    def is_comparison_basic_tab_button_displayed(self):
-        return self.is_element_displayed(*self._comparison_tab_button_basic_locator)
-
-    @property
-    def is_comparison_premium_tab_button_displayed(self):
-        return self.is_element_displayed(*self._comparison_tab_button_premium_locator)
-
-    @property
-    def is_comparison_premium_plan_displayed(self):
-        return self.is_element_displayed(*self._comparison_premium_plan_locator)
-
-    @property
-    def is_comparison_basic_plan_displayed(self):
-        return self.is_element_displayed(*self._comparison_basic_plan_locator)
-
-    @property
-    def is_package_win64_download_button_displayed(self):
-        return self.is_element_displayed(*self._package_win64_download_button_locator)
-
-    @property
-    def is_package_mac_download_button_displayed(self):
-        return self.is_element_displayed(*self._package_mac_download_button_locator)
-
-    @property
-    def is_package_win32_download_button_displayed(self):
-        return self.is_element_displayed(*self._package_win32_download_button_locator)
-
-    def click_premium_plan_tab_button(self):
-        self.find_element(*self._comparison_tab_button_premium_locator).click()
-        self.wait.until(lambda s: self.is_comparison_premium_plan_displayed)
-
-    def click_basic_plan_tab_button(self):
-        self.find_element(*self._comparison_tab_button_basic_locator).click()
-        self.wait.until(lambda s: self.is_comparison_basic_plan_displayed)
-
-    def click_contact_sales_button(self):
-        self.find_element(*self._comparison_sales_button_locator).click()
-        from pages.firefox.enterprise.signup import EnterpriseSignUpPage
-        return EnterpriseSignUpPage(self.selenium, self.base_url).wait_for_page_to_load()


### PR DESCRIPTION
This replaces/supersedes https://github.com/mozilla/bedrock/pull/8489

## Description

⏰ URGENT: these box.com links are now removed and outdated and should be removed from the website ASAP.

- This PR removes the download links/buttons for the packages that were manually created and hosted at box.com.

- It also adds direct links to the various items that Enterprise/ESR folks may want to quickly access (this keeps everything in one useful location).

- Links to deployment guide PDF at assets.mozilla.net

## Issue / Bugzilla link

Resolves #8424 

## Testing

Before:

<img width="1478" alt="Screen Shot 2020-02-06 at 10 11 21 AM" src="https://user-images.githubusercontent.com/49511/73960996-1075bf80-48c9-11ea-8285-1659b7ecbca6.png">


After:

<img width="1481" alt="Screen Shot 2020-02-06 at 10 08 07 AM" src="https://user-images.githubusercontent.com/49511/73960914-efad6a00-48c8-11ea-9cb0-bf747fb16fb9.png">
