### PR TITLE
Swap the Mac and Windows 32 download links to be as expected

### DIFF
--- a/bedrock/firefox/templates/firefox/enterprise/index.html
+++ b/bedrock/firefox/templates/firefox/enterprise/index.html
@@ -101,7 +101,7 @@
           custom_desc=True
         ) %}
           <ul class="mzp-u-list-styled">
-            <li>{{ _('The latest <a href="%s">Firefox browser</a>')|format('https://download.mozilla.org/?product=firefox-latest-ssl&os=win') }}</li>
+            <li>{{ _('The latest <a href="%s">Firefox browser</a>')|format('https://download.mozilla.org/?product=firefox-latest-ssl&os=osx') }}</li>
             <li>{{ _('The latest <a href="%s">Firefox Extended Support Release (ESR)</a>')|format('https://support.mozilla.org/kb/firefox-esr-release-cycle') }}</li>
             <li>{{ _('Sample <a href="%s">plist for configuration profile</a>')|format('https://github.com/mozilla/policy-templates/blob/master/mac/org.mozilla.firefox.plist') }}</li>
             <li><a href="https://support.mozilla.org/kb/deploying-firefox-macos-using-pkg-and-jamf">{{ _('PKG installer') }}</a></li>
@@ -118,7 +118,7 @@
           custom_desc=True
         ) %}
           <ul class="mzp-u-list-styled">
-            <li>{{ _('The latest <a href="%s">Firefox browser</a>')|format('https://download.mozilla.org/?product=firefox-latest-ssl&os=osx') }}</li>
+            <li>{{ _('The latest <a href="%s">Firefox browser</a>')|format('https://download.mozilla.org/?product=firefox-latest-ssl&os=win') }}</li>
             <li>{{ _('The latest <a href="%s">Firefox Extended Support Release (ESR)</a>')|format('https://support.mozilla.org/kb/firefox-esr-release-cycle') }}</li>
             <li><a href="https://support.mozilla.org/kb/deploy-firefox-msi-installers">{{ _('MSI Installer') }}</a></li>
             <li><a href="https://support.mozilla.org/kb/legacy-browser-support-extension-windows">{{ _('Legacy browser support') }}</a></li>


### PR DESCRIPTION
## Description

I must have made a copy/paste error and put the Win32 download link where the Mac should go, and vice versa. 😊 

## Issue / Bugzilla link

Resolves #8496 