### PR TITLE
Fix virtualenv creation in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,9 +33,7 @@ ENV PATH="/venv/bin:$PATH"
 
 COPY docker/bin/apt-install /usr/local/bin/
 RUN apt-install gettext build-essential libxml2-dev libxslt1-dev libxslt1.1
-
-RUN pip install virtualenv
-RUN virtualenv /venv
+RUN python -m venv /venv
 
 COPY requirements/base.txt requirements/prod.txt ./requirements/
 

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ help:
 	${MAKE} pull
 
 build: .docker-build-pull
-	${DC} build app assets
+	${DC} build --pull app assets
 	touch .docker-build
 
 pull: .env submodules
@@ -107,7 +107,7 @@ docs: .docker-build-pull
 	${MAKE} build-ci
 
 build-ci: .docker-build-pull
-	${DC_CI} build release
+	${DC_CI} build --pull release
 #	tag intermediate images using cache
 	${DC_CI} build app assets builder app-base
 	touch .docker-build-ci


### PR DESCRIPTION
The old way suddenly broke in that it no longer properly included pip. This changes to the default recommended way of creating a virtualenv in the Python 3.8 docs.

See https://docs.python.org/3/library/venv.html#creating-virtual-environments