### PR TITLE
[fix #8496] Enterprise page, swap the Mac and Windows 32 links

### DIFF
--- a/bedrock/firefox/templates/firefox/enterprise/index.html
+++ b/bedrock/firefox/templates/firefox/enterprise/index.html
@@ -101,7 +101,7 @@
           custom_desc=True
         ) %}
           <ul class="mzp-u-list-styled">
-            <li>{{ _('The latest <a href="%s">Firefox browser</a>')|format('https://download.mozilla.org/?product=firefox-latest-ssl&os=win') }}</li>
+            <li>{{ _('The latest <a href="%s">Firefox browser</a>')|format('https://download.mozilla.org/?product=firefox-latest-ssl&os=osx') }}</li>
             <li>{{ _('The latest <a href="%s">Firefox Extended Support Release (ESR)</a>')|format('https://support.mozilla.org/kb/firefox-esr-release-cycle') }}</li>
             <li>{{ _('Sample <a href="%s">plist for configuration profile</a>')|format('https://github.com/mozilla/policy-templates/blob/master/mac/org.mozilla.firefox.plist') }}</li>
             <li><a href="https://support.mozilla.org/kb/deploying-firefox-macos-using-pkg-and-jamf">{{ _('PKG installer') }}</a></li>
@@ -118,7 +118,7 @@
           custom_desc=True
         ) %}
           <ul class="mzp-u-list-styled">
-            <li>{{ _('The latest <a href="%s">Firefox browser</a>')|format('https://download.mozilla.org/?product=firefox-latest-ssl&os=osx') }}</li>
+            <li>{{ _('The latest <a href="%s">Firefox browser</a>')|format('https://download.mozilla.org/?product=firefox-latest-ssl&os=win') }}</li>
             <li>{{ _('The latest <a href="%s">Firefox Extended Support Release (ESR)</a>')|format('https://support.mozilla.org/kb/firefox-esr-release-cycle') }}</li>
             <li><a href="https://support.mozilla.org/kb/deploy-firefox-msi-installers">{{ _('MSI Installer') }}</a></li>
             <li><a href="https://support.mozilla.org/kb/legacy-browser-support-extension-windows">{{ _('Legacy browser support') }}</a></li>


### PR DESCRIPTION
## Description
The Mac and Windows download links got their URLs crossed. This swaps them the right way around. Replaces #8497 where it was previously reviewed and approved, this is just putting it on a rebased branch to make sure tests pass.

## Issue / Bugzilla link
#8496