### PR TITLE
Add process_ftl command for updating bedrock ftl git repo

### DIFF
--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -241,10 +241,11 @@ DOTLANG_FILES = ['navigation', 'download_button', 'main', 'footer']
 
 # TODO create these files by porting from their .lang equivalents
 FLUENT_DEFAULT_FILES = ['brands', 'navigation', 'footer', 'download_button']
+FLUENT_DEFAULT_PERCENT_REQUIRED = config('FLUENT_DEFAULT_PERCENT_REQUIRED', default='80', parser=int)
 FLUENT_REPO = config('FLUENT_REPO', default='https://github.com/mozmeao/www-l10n')
 FLUENT_REPO_PATH = GIT_REPOS_PATH / 'www-l10n'
 FLUENT_LOCAL_PATH = ROOT_PATH / 'l10n'
-FLUENT_L10N_TEAM_REPO = config('FLUENT_REPO', default='https://github.com/mozmeao/www-l10n')
+FLUENT_L10N_TEAM_REPO = config('FLUENT_REPO', default='https://github.com/mozilla-l10n/www-l10n')
 FLUENT_L10N_TEAM_REPO_PATH = GIT_REPOS_PATH / 'l10n-team'
 # 10 seconds during dev and 10 min in prod
 FLUENT_CACHE_TIMEOUT = config('FLUENT_CACHE_TIMEOUT', default='10' if DEBUG else '600', parser=int)

--- a/bedrock/utils/git.py
+++ b/bedrock/utils/git.py
@@ -68,9 +68,18 @@ class GitRepo:
     def diff(self, start_hash, end_hash):
         """Return a 2 tuple: (modified files, deleted files)"""
         diff_out = StringIO(self.git('diff', '--name-status', start_hash, end_hash))
+        return self._parse_git_status(diff_out)
+
+    def modified_files(self):
+        """Return a list of new or modified files according to git"""
+        self.git('add', '.')
+        status = StringIO(self.git('status', '--porcelain'))
+        return self._parse_git_status(status)
+
+    def _parse_git_status(self, lines):
         modified = set()
         removed = set()
-        for line in diff_out:
+        for line in lines:
             parts = line.split()
             # delete
             if parts[0] == 'D':
@@ -123,6 +132,9 @@ class GitRepo:
 
     def reset(self, new_head):
         self.git('reset', '--hard', new_head)
+
+    def clean(self):
+        self.git('clean', '-fd')
 
     def get_db_latest(self):
         try:

--- a/lib/l10n_utils/fluent.py
+++ b/lib/l10n_utils/fluent.py
@@ -84,6 +84,9 @@ class FluentL10n(FluentLocalization):
 
     @cached_property
     def percent_translated(self):
+        if not self._message_ids:
+            return 0
+
         return (float(len(self._localized_message_ids)) / float(len(self._message_ids))) * 100
 
     def has_message(self, message_id):
@@ -136,6 +139,15 @@ def get_metadata(ftl_file):
             return json.load(mdf)
     except (IOError, ValueError):
         return {}
+
+
+def write_metadata(ftl_file, data):
+    metadata_path = get_metadata_file_path(ftl_file)
+    if not metadata_path.exists():
+        metadata_path.parent.mkdir(parents=True, exist_ok=True)
+
+    with metadata_path.open('w') as mdf:
+        json.dump(data, mdf, indent=2, sort_keys=True)
 
 
 @memoize

--- a/lib/l10n_utils/management/commands/process_ftl.py
+++ b/lib/l10n_utils/management/commands/process_ftl.py
@@ -54,12 +54,19 @@ class Command(BaseCommand):
                                'See above for details.')
 
     def update_l10n_team_files(self):
-        self.l10n_repo.clean()
+        try:
+            # this will fail on first run
+            self.l10n_repo.clean()
+        except FileNotFoundError:
+            pass
         self.l10n_repo.update()
         self.stdout.write('Updated l10n team .ftl files')
 
     def update_fluent_files(self):
-        self.meao_repo.clean()
+        try:
+            self.meao_repo.clean()
+        except FileNotFoundError:
+            pass
         self.meao_repo.update()
         self.stdout.write('Updated .ftl files')
 

--- a/lib/l10n_utils/management/commands/process_ftl.py
+++ b/lib/l10n_utils/management/commands/process_ftl.py
@@ -1,16 +1,36 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
+import shutil
 from io import StringIO
 
-from django.core.management.base import BaseCommand
+from django.core.management.base import BaseCommand, CommandError
 from django.conf import settings
 
+from fluent.syntax.parser import FluentParser, ParseError
+
 from bedrock.utils.git import GitRepo
+from lib.l10n_utils.fluent import fluent_l10n, get_metadata, write_metadata
+
+
+class NoisyFluentParser(FluentParser):
+    """A parser that will raise exceptions.
+
+    The one from fluent.syntax doesn't raise exceptions, but will
+    return instances of fluent.syntax.ast.Junk instead.
+    """
+    def get_entry_or_junk(self, ps):
+        """Allow the ParseError to bubble up"""
+        entry = self.get_entry(ps)
+        ps.expect_line_end()
+        return entry
 
 
 class Command(BaseCommand):
     help = 'Processes .ftl files from l10n team for use in bedrock'
+    meao_repo = None
+    l10n_repo = None
+    parser = None
 
     def add_arguments(self, parser):
         parser.add_argument('-q', '--quiet', action='store_true', dest='quiet', default=False,
@@ -20,15 +40,95 @@ class Command(BaseCommand):
         if options['quiet']:
             self.stdout._out = StringIO()
 
+        self.parser = NoisyFluentParser()
+        self.l10n_repo = GitRepo(settings.FLUENT_L10N_TEAM_REPO_PATH, settings.FLUENT_L10N_TEAM_REPO)
+        self.meao_repo = GitRepo(settings.FLUENT_REPO_PATH, settings.FLUENT_REPO)
         self.update_fluent_files()
         self.update_l10n_team_files()
+        no_errors = self.copy_ftl_files()
+        self.set_activation()
+        if no_errors:
+            self.stdout.write('There were no errors found in the .ftl files.')
+        else:
+            raise CommandError('Some errors were discovered in some .ftl files and they were not updated.'
+                               'See above for details.')
 
     def update_l10n_team_files(self):
-        repo = GitRepo(settings.FLUENT_L10N_TEAM_REPO_PATH, settings.FLUENT_L10N_TEAM_REPO)
-        repo.update()
+        self.l10n_repo.clean()
+        self.l10n_repo.update()
         self.stdout.write('Updated l10n team .ftl files')
 
     def update_fluent_files(self):
-        repo = GitRepo(settings.FLUENT_REPO_PATH, settings.FLUENT_REPO)
-        repo.update()
+        self.meao_repo.clean()
+        self.meao_repo.update()
         self.stdout.write('Updated .ftl files')
+
+    def copy_ftl_files(self):
+        count = 0
+        errors = []
+        for filepath in self.l10n_repo.path.rglob('*.ftl'):
+            relative_filepath = filepath.relative_to(self.l10n_repo.path)
+            if not self.lint_ftl_file(filepath):
+                errors.append(relative_filepath)
+                continue
+
+            to_filepath = self.meao_repo.path.joinpath(relative_filepath)
+            to_filepath.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(str(filepath), str(to_filepath))
+            count += 1
+            self.stdout.write('.', ending='')
+            self.stdout.flush()
+
+        self.stdout.write(f'\nCopied {count} .ftl files')
+        if errors:
+            self.stdout.write('The following files had parse errors and were not copied:')
+            for fpath in errors:
+                self.stdout.write(f'- {fpath}')
+            return False
+
+        return True
+
+    def lint_ftl_file(self, filepath):
+        with filepath.open() as ftl:
+            try:
+                self.parser.parse(ftl.read())
+            except ParseError:
+                return False
+
+            return True
+
+    def set_activation(self):
+        updated_ftl = set()
+        modified, _ = self.meao_repo.modified_files()
+        for fname in modified:
+            locale, ftl_name = fname.split('/', 1)
+            updated_ftl.add(ftl_name)
+
+        for ftl_name in updated_ftl:
+            self.calculate_activation(ftl_name)
+
+    def calculate_activation(self, ftl_file):
+        translations = self.meao_repo.path.glob(f'*/{ftl_file}')
+        metadata = get_metadata(ftl_file)
+        active_locales = metadata.get('active_locales', [])
+        inactive_locales = metadata.get('inactive_locales', [])
+        percent_required = metadata.get('percent_required', settings.FLUENT_DEFAULT_PERCENT_REQUIRED)
+        all_locales = {str(x.relative_to(self.meao_repo.path)).split('/', 1)[0] for x in translations}
+        locales_to_check = all_locales.difference(['en'], active_locales, inactive_locales)
+        new_activations = []
+        for locale in locales_to_check:
+            l10n = fluent_l10n([locale, 'en'], [ftl_file])
+            if not l10n.has_required_messages:
+                continue
+
+            percent_trans = l10n.percent_translated
+            if percent_trans < percent_required:
+                continue
+
+            new_activations.append(locale)
+
+        if new_activations:
+            active_locales.extend(new_activations)
+            metadata['active_locales'] = active_locales
+            write_metadata(ftl_file, metadata)
+            self.stdout.write(f'Activated {len(new_activations)} new locales for {ftl_file}')


### PR DESCRIPTION
This command does multiple things:

1. Update both the mozmeao/www-l10n repo and the mozilla-l10n/www-l10n one.
2. Copy all of the .ftl files from the mozilla-l10n repo to mozmeao
3. Check if they are valid .ftl files, and if not do not copy them
4. Check all of the successfully copied ones for activation rules
5. Write any newly activated locales to the metadata files

After running `./manage.py process_ftl` your local repo in `git-repos/www-l10n` should be full of any changes which you can then commit and push to the mozmeao/www-l10n repo. This will eventually be run by autmation, but this should help for now.

Re #7705