### PR TITLE
Remove superfluous JS bundle from opt-out confirmation page (Fixes #8527)

### DIFF
--- a/bedrock/newsletter/templates/newsletter/opt-out-confirmation.html
+++ b/bedrock/newsletter/templates/newsletter/opt-out-confirmation.html
@@ -78,7 +78,3 @@
   </div>{#-- /.content --#}
 </main>
 {% endblock %}
-
-{% block js %}
-  {{ js_bundle('newsletter-mozilla') }}
-{% endblock %}

--- a/bedrock/newsletter/templates/newsletter/opt-out-confirmation.html
+++ b/bedrock/newsletter/templates/newsletter/opt-out-confirmation.html
@@ -2,7 +2,7 @@
  # License, v. 2.0. If a copy of the MPL was not distributed with this
  # file, You can obtain one at http://mozilla.org/MPL/2.0/. #}
 
-{% extends 'base-pebbles.html' %}
+{% extends 'base-protocol-mozilla.html' %}
 
 {% block page_title %}{{ _('Cool. We hear you.') }}{% endblock page_title %}
 {% block page_desc %}{{ _('You’re now opted out of a series of emails about setting up your account.') }}{% endblock %}
@@ -15,7 +15,7 @@
 
 {% block content %}
 <main>
-  <div class="content">
+  <div class="mzp-l-content">
     <div class="inner-content">
       <header>
         <h1>{{ self.page_title() }}</h1>
@@ -52,7 +52,7 @@
                 <label for="id_email">{{ _('Your email address:') }}</label>
                 {{ field_with_attrs(form.email, placeholder=_('yourname@example.com'))|safe }}
               </div>
-              <button class="button button-hollow button-dark" type="submit">{{ _('Manage Preferences') }}</button>
+              <button class="mzp-c-button" type="submit">{{ _('Manage Preferences') }}</button>
             </div>
           </div>
 
@@ -60,7 +60,7 @@
 
         <aside>
           <h2>{{ _('Prefer to get information another way?') }}</h2>
-          <ul>
+          <ul class="mzp-u-list-styled">
             <li><a href="https://blog.mozilla.org/">{{ _('Check out our blogs') }}</a></li>
             <li><a href="https://support.mozilla.org/">{{ _('Get help') }}</a></li>
             <li><a href="{{ url('newsletter.firefox') }}">{{ _('Subscribe to occasional newsletter updates from Firefox') }}</a></li>

--- a/media/css/newsletter/newsletter-opt-out-confirmation.scss
+++ b/media/css/newsletter/newsletter-opt-out-confirmation.scss
@@ -2,19 +2,20 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-@import '../pebbles/includes/lib';
-@import '../hubs/sections';
-@import '../quantum/common';
+$font-path: '/media/fonts';
+$image-path: '/media/protocol/img';
+
+@import '../../protocol/css/includes/lib';
 
 /* -------------------------------------------------------------------------- */
 // Common elements
 
 
 main {
-    padding: 20px 0;
+    padding: $spacing-lg 0;
 
-    @media #{$mq-tablet} {
-        padding: 60px 0;
+    @media #{$mq-md} {
+        padding: $spacing-2xl 0;
     }
 }
 
@@ -27,18 +28,16 @@ main {
 
 header {
     h1 {
-        @include zilla-slab;
-        font-weight: bold;
-        margin-bottom: 40px;
+        margin-bottom: $spacing-xl;
     }
 
     .tagline {
         font-weight: bold;
     }
 
-    @media #{$mq-tablet} {
+    @media #{$mq-md} {
         .tagline {
-            @include font-size(24px);
+            @include text-display-md;
         }
     }
 }
@@ -47,7 +46,7 @@ header {
 // Email recovery form
 
 form {
-    margin-bottom: 60px;
+    margin-bottom: $spacing-2xl;
 
     .form-fields {
         max-width: 300px;
@@ -59,10 +58,8 @@ form {
     }
 
     input[type="email"] {
-        border-radius: 4px;
-        line-height: 1.1;
-        margin-bottom: 10px;
-        padding: 0.75em 20px;
+        margin-bottom: $spacing-sm;
+        padding: 0.75em $spacing-lg;
         width: 100%;
     }
 
@@ -72,7 +69,7 @@ form {
 }
 
 .errorlist li {
-    color: $color-mozred;
+    color: $color-red-60;
 }
 
 /* -------------------------------------------------------------------------- */
@@ -80,20 +77,8 @@ form {
 
 aside {
     h2 {
-        @include font-size-level4;
-        font-weight: bold;
+        @include text-display-sm;
         margin-bottom: 40px;
-    }
-
-    a:link,
-    a:visited {
-        color: #000;
-
-        &:hover,
-        &:active,
-        &:focus {
-            color: #555;
-        }
     }
 
     .social-links {


### PR DESCRIPTION
Looks like this was a superfluous JS bundle in the page, which was removed in https://github.com/mozilla/bedrock/pull/8502
