### PR TITLE
Sort active locales in fluent metadata automation

### DIFF
--- a/lib/l10n_utils/management/commands/process_ftl.py
+++ b/lib/l10n_utils/management/commands/process_ftl.py
@@ -136,6 +136,6 @@ class Command(BaseCommand):
 
         if new_activations:
             active_locales.extend(new_activations)
-            metadata['active_locales'] = active_locales
+            metadata['active_locales'] = sorted(active_locales)
             write_metadata(ftl_file, metadata)
             self.stdout.write(f'Activated {len(new_activations)} new locales for {ftl_file}')


### PR DESCRIPTION
@alexgibson I noticed a problem in the reivew of the PR in that it'd be better to keep the locales sorted.

PR in question: https://github.com/mozmeao/www-l10n/pull/2/