### PR TITLE
Port manifesto page to Protocol (Fixes #8504)

### DIFF
--- a/bedrock/mozorg/templates/mozorg/about/manifesto.html
+++ b/bedrock/mozorg/templates/mozorg/about/manifesto.html
@@ -1,12 +1,14 @@
 {# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
 
-{% if not l10n_has_tag('manifesto_landing') %}
-  {#- Show the old page if the landing page is not localized yet -#}
-  {% include 'mozorg/about/manifesto-details.html' %}
-{% else %}
-  {#- Show the redesigned landing page -#}
+{% from "macros-protocol.html" import call_out with context %}
+
+{% extends "base-protocol-mozilla.html" %}
+
+{% set_lang_files "mozorg/about/manifesto" %}
+
+{% from 'macros.html' import twitter_share_url with context %}
 
 {% if l10n_has_tag('addendum_title_042018') %}
   {% set addendum_title_translated = true %}
@@ -20,10 +22,6 @@
   {% set addendum_translated = false %}
 {% endif %}
 
-{% extends 'base-pebbles.html' %}
-
-{% from 'macros.html' import twitter_share_url with context %}
-
 {% block page_title %}{{ _('The Mozilla Manifesto') }}{% endblock %}
 {% block page_title_suffix %}{% endblock %}
 
@@ -35,19 +33,10 @@
 {% block page_desc %}{{ page_description }}{% endblock %}
 
 {% block body_id %}manifesto-landing{% endblock %}
-{% block body_attrs %}{{ super() }} data-global-nav-current-link="about-us"{% endblock %}
-
-{% block string_data %}
-  data-principle-read-more='{{ _('See more…') }}'
-  data-principle-nav-prev='{{ _('Previous principle') }}'
-  data-principle-nav-next='{{ _('Next principle') }}'
-{% endblock %}
 
 {% block page_css %}
   {{ css_bundle('manifesto') }}
 {% endblock %}
-
-{% block site_header_logo %}{% endblock %}
 
 {% macro twitter_link(content_id, text) -%}
   {{ twitter_share_url('https://mzl.la/manifesto', text|truncate(102, False, '…')) }}
@@ -104,291 +93,304 @@
 {% block content %}
 <main role="main" itemscope itemtype="http://schema.org/Article">
   <article role="article" itemprop="articleBody">
-  {% if addendum_translated %}
-    <header>
-    {% if addendum_title_translated %}
-      <h1 itemprop="name" class="manifesto-title manifesto-title-addendum">{{ _('The Mozilla Manifesto Addendum') }}</h1>
-    {% else %}
-      <h1 itemprop="name" class="manifesto-title manifesto-title-addendum">{{ self.page_title() }}</h1>
+    {% if addendum_translated %}
+      <section>
+        <div class="mzp-l-content mzp-t-narrow">
+          <header>
+            {% if addendum_title_translated %}
+              <h1 itemprop="name" class="manifesto-title">{{ _('The Mozilla Manifesto Addendum') }}</h1>
+            {% else %}
+              <h1 itemprop="name" class="manifesto-title">{{ self.page_title() }}</h1>
+            {% endif %}
+          </header>
+          <h2 class="addendum-subtitle">{{ _('Pledge for a Healthy Internet') }}</h2>
+          <p>{{ _('The open, global internet is the most powerful communication and collaboration resource we have ever seen. It embodies some of our deepest hopes for human progress. It enables new opportunities for learning, building a sense of shared humanity, and solving the pressing problems facing people everywhere.') }}</p>
+          <p>{{ _('Over the last decade we have seen this promise fulfilled in many ways. We have also seen the power of the internet used to magnify divisiveness, incite violence, promote hatred, and intentionally manipulate fact and reality. We have learned that we should more explicitly set out our aspirations for the human experience of the internet. We do so now.') }}</p>
+        </div>
+        <div class="mzp-l-content">
+          <ol class="addendum-list">
+            <li>{{ _('We are committed to an internet that includes all the peoples of the earth — where a person’s demographic characteristics do not determine their online access, opportunities, or quality of experience.') }}</li>
+            <li>{{ _('We are committed to an internet that promotes civil discourse, human dignity, and individual expression.') }}</li>
+            <li>{{ _('We are committed to an internet that elevates critical thinking, reasoned argument, shared knowledge, and verifiable facts.') }}</li>
+            <li>{{ _('We are committed to an internet that catalyzes collaboration among diverse communities working together for the common good.') }}</li>
+          </ol>
+        </div>
+      </section>
+
+      {% call call_out(
+        title=_('Show Your Support'),
+        desc=_('An internet with these qualities will not come to life on its own. Individuals and organizations must embed these aspirations into internet technology and into the human experience with the internet. The Mozilla Manifesto and Addendum represent Mozilla’s commitment to advancing these aspirations. We aim to work together with people and organizations everywhere who share these goals to make the internet an even better place for everyone.'),
+        class='share-addendum',
+        include_cta=True
+      ) %}
+        <p><a class="mzp-c-button button-manifesto js-manifesto-share" target="_blank" rel="noopener noreferrer" href="{{ twitter_link('custom', _('I support the vision of a better, healthier internet from @mozilla, will you join me?')) }}" data-link-type="social share" data-link-name="Twitter">{{  _('Share on Twitter') }}</a></p>
+      {% endcall %}
+
     {% endif %}
-    </header>
-    <section>
-      <h2 class="addendum-subtitle">{{ _('Pledge for a Healthy Internet') }}</h2>
-      <p class="addendum-paragraph">{{ _('The open, global internet is the most powerful communication and collaboration resource we have ever seen. It embodies some of our deepest hopes for human progress. It enables new opportunities for learning, building a sense of shared humanity, and solving the pressing problems facing people everywhere.') }}</p>
-      <p class="addendum-paragraph">{{ _('Over the last decade we have seen this promise fulfilled in many ways. We have also seen the power of the internet used to magnify divisiveness, incite violence, promote hatred, and intentionally manipulate fact and reality. We have learned that we should more explicitly set out our aspirations for the human experience of the internet. We do so now.') }}</p>
-      <ol class="addendum-list">
-        <li>{{ _('We are committed to an internet that includes all the peoples of the earth — where a person’s demographic characteristics do not determine their online access, opportunities, or quality of experience.') }}</li>
-        <li>{{ _('We are committed to an internet that promotes civil discourse, human dignity, and individual expression.') }}</li>
-        <li>{{ _('We are committed to an internet that elevates critical thinking, reasoned argument, shared knowledge, and verifiable facts. ') }}</li>
-        <li>{{ _('We are committed to an internet that catalyzes collaboration among diverse communities working together for the common good. ') }}</li>
-      </ol>
-      <div class="share-addendum">
-        <h2 class="share-head">{{ _('Show Your Support') }}</h2>
-        <p class="share-paragraph">{{ _('An internet with these qualities will not come to life on its own. Individuals and organizations must embed these aspirations into internet technology and into the human experience with the internet. The Mozilla Manifesto and Addendum represent Mozilla’s commitment to advancing these aspirations. We aim to work together with people and organizations everywhere who share these goals to make the internet an even better place for everyone.') }}</p>
-        <p class="share-button-outter"><a class="button button-manifesto js-manifesto-share" target="_blank" rel="noopener noreferrer" href="{{ twitter_link('custom', _('I support the vision of a better, healthier internet from @mozilla, will you join me?')) }}" data-link-type="social share" data-link-name="Twitter">{{  _('Share on Twitter') }}</a></p>
-      </div>
-    </section>
-  {% endif %}
-    <section id="sec-principles">
-      <header class="content principles-header">
-        {# If the addendum has not been translated, this section is first, so display the page title.
-           If the addendum is translated, a page title displays above it.
-           If the addendum's title has not been translated, the page title displays there, don't repeat it here.
-           If the addendum title is translated, we can label this section with the page title. #}
-        {% if not addendum_translated or (addendum_translated and addendum_title_translated) %}
-          <h1 itemprop="name" class="manifesto-title">{{ self.page_title() }}</h1>
-        {% endif %}
-        <h2 class="principles-head">{{ _('<strong>Our 10</strong> Principles') }}</h2>
-      </header>
-      <div id="principles">
-        <section class="principle" id="principle-01" data-ga-quote-number="1" data-ga-quote="modern life">
-          <header class="principle-header">
-            <h3><span class="principle-number">{{ principle_number_01 }}</span> {{principle_text_01 }}</h3>
-          </header>
-          <section class="principle-more">
-            <h4>{{ _('Learn more') }}</h4>
-            <ul class="resources">
-              <li><a href="http://openbadges.org/">{{ _('Use Open Badges to share your skills and interests') }}</a></li>
-              <li>
-                <a href="http://mozillascience.org/">
-                  {% if addendum_translated %}
-                    {{ _('Explore how the web impacts science') }}
-                  {% else %}
-                    {{ _('Explore how the Web impacts science') }}
-                  {% endif %}
-                </a>
-              </li>
-              <li><a href="https://opennews.org/getinvolved/">{{ _('Learn about open source code in journalism') }}</a></li>
-            </ul>
-          </section>
-        </section>
-        <section class="principle" id="principle-02" data-ga-quote-number="2" data-ga-quote="public resource">
-          <header class="principle-header">
-            <h3><span class="principle-number">{{ principle_number_02 }}</span> {{ principle_text_02 }}</h3>
-          </header>
-          <section class="principle-more">
-            <h4>{{ _('Learn more') }}</h4>
-            <ul class="resources">
-              <li>
-                <a href="https://blog.mozilla.org/netpolicy/">
-                  {% if addendum_translated %}
-                    {{ _('Read about open internet policy initiatives and developments') }}
-                  {% else %}
-                    {{ _('Read about open Internet policy initiatives and developments') }}
-                  {% endif %}
-                </a>
-              </li>
-              <li>
-                <a href="https://teach.mozilla.org/web-literacy/participate/open-practice/">
-                  {% if addendum_translated %}
-                    {{ _('Explore how to help keep the web open') }}
-                  {% else %}
-                    {{ _('Explore how to help keep the Web open') }}
-                  {% endif %}
-                </a>
-              </li>
-            </ul>
-          </section>
-        </section>
-        <section class="principle" id="principle-03" data-ga-quote-number="3" data-ga-quote="enrich lives">
-          <header class="principle-header">
-            <h3><span class="principle-number">{{ principle_number_03 }}</span> {{ principle_text_03 }}</h3>
-          </header>
-          <section class="principle-more">
-            <h4>{{ _('Learn more') }}</h4>
-            <ul class="resources">
-              <li>
-                <a href="https://blog.mozilla.org/blog/2014/04/09/firefox-os-and-medic-mobile-use-the-web-to-connect-the-world-to-healthcare/">
-                  {% if addendum_translated %}
-                    {{ _('See how the web can connect the world to healthcare') }}
-                  {% else %}
-                    {{ _('See how the Web can connect the world to healthcare') }}
-                  {% endif %}
-                </a>
-              </li>
-              <li>
-                <a href="https://teach.mozilla.org/web-literacy/read/navigate/">
-                  {% if addendum_translated %}
-                    {{ _('Explore how the web works') }}
-                  {% else %}
-                    {{ _('Explore how the Web works') }}
-                  {% endif %}
-                </a>
-              </li>
-            </ul>
-          </section>
-        </section>
-        <section class="principle" id="principle-04" data-ga-quote-number="4" data-ga-quote="individual security">
-          <header class="principle-header">
-            <h3><span class="principle-number">{{ principle_number_04 }}</span> {{ principle_text_04 }}</h3>
-          </header>
-          <section class="principle-more">
-            <h4>{{ _('Learn more') }}</h4>
-            <ul class="resources">
-              <li><a href="{{ url('mozorg.internet-health.privacy-security') }}">{{ _('See how Mozilla works to put your privacy first') }}</a></li>
-              <li><a href="https://blog.mozilla.org/netpolicy/">{{ _('Read about developments in privacy and data safety') }}</a></li>
-              <li><a href="https://teach.mozilla.org/web-literacy/participate/protect/">{{ _('Learn more about how to protect yourself online') }}</a></li>
-            </ul>
-          </section>
-        </section>
-        <section class="principle" id="principle-05" data-ga-quote-number="5" data-ga-quote="shape internet">
-          <header class="principle-header">
-            <h3><span class="principle-number">{{ principle_number_05 }}</span> {{ principle_text_05 }}</h3>
-          </header>
-          <section class="principle-more">
-            <h4>{{ _('Learn more') }}</h4>
-            <ul class="resources">
-              <li>
-                <a href="https://teach.mozilla.org/tools/">
-                  {% if addendum_translated %}
-                    {{ _('Use these free tools to teach the web') }}
-                  {% else %}
-                    {{ _('Use these free tools to teach the Web') }}
-                  {% endif %}
-                </a>
-              </li>
-              <li>
-                <a href="https://teach.mozilla.org/web-literacy/write/compose/">
-                  {% if addendum_translated %}
-                    {{ _('Learn about creating and curating content for the web') }}
-                  {% else %}
-                    {{ _('Learn about creating and curating content for the Web') }}
-                  {% endif %}
-                </a>
-              </li>
-            </ul>
-          </section>
-        </section>
-        <section class="principle" id="principle-06" data-ga-quote-number="6" data-ga-quote="internet effectiveness">
-          <header class="principle-header">
-            <h3><span class="principle-number">{{ principle_number_06 }}</span> {{ principle_text_06 }}</h3>
-          </header>
-          <section class="principle-more">
-            <h4>{{ _('Learn more') }}</h4>
-            <ul class="resources">
-              <li><a href="http://ascendproject.org/">{{ _('Add new voices to open source technology') }}</a></li>
-              <li><a href="https://support.mozilla.org/kb/how-do-i-turn-do-not-track-feature">{{ _('Set your Do Not Track preference') }}</a></li>
-              <li>
-                <a href="https://teach.mozilla.org/web-literacy/read/navigate/">
-                  {% if addendum_translated %}
-                    {{ _('Understand the web ecosystem') }}
-                  {% else %}
-                    {{ _('Understand the Web ecosystem') }}
-                  {% endif %}
-                </a>
-              </li>
-            </ul>
-          </section>
-        </section>
-        <section class="principle" id="principle-07" data-ga-quote-number="7" data-ga-quote="open source">
-          <header class="principle-header">
-            <h3><span class="principle-number">{{ principle_number_07 }}</span> {{ principle_text_07 }}</h3>
-          </header>
-          <section class="principle-more">
-            <h4>{{ _('Learn more') }}</h4>
-            <ul class="resources">
-              <li>
-                <a href="https://teach.mozilla.org/web-literacy/participate/open-practice/">
-                  {% if addendum_translated %}
-                    {{ _('Explore how open practices keep the web accessible') }}
-                  {% else %}
-                    {{ _('Explore how open practices keep the Web accessible') }}
-                  {% endif %}
-                </a>
-              </li>
-              <li><a href="https://teach.mozilla.org/web-literacy/write/remix/">{{ _('Learn how to remix content to create something new') }}</a></li>
-              <li>
-                <a href="https://teach.mozilla.org/web-literacy/write/code/">
-                  {% if addendum_translated %}
-                    {{ _('Learn how to maximize the interactive potential of the web') }}
-                  {% else %}
-                    {{ _('Learn how to maximize the interactive potential of the Web') }}
-                  {% endif %}
-                </a>
-              </li>
-            </ul>
-          </section>
-        </section>
-        <section class="principle" id="principle-08" data-ga-quote-number="8" data-ga-quote="transparent process">
-          <header class="principle-header">
-            <h3><span class="principle-number">{{ principle_number_08 }}</span> {{ principle_text_08 }}</h3>
-          </header>
-          <section class="principle-more">
-            <h4>{{ _('Learn more') }}</h4>
-            <ul class="resources">
-              <li><a href="https://groups.google.com/forum/#!forum/mozilla.governance">{{ _('Participate in our governance forum') }}</a></li>
-              {% if l10n_has_tag('join-us') %}
-                <li><a href="{{ url('mozorg.contribute.index') }}">{{ _('Join us as a volunteer') }}</a></li>
-              {% endif %}
-              <li><a href="https://teach.mozilla.org/web-literacy/skills/">{{ _('Learn how to collaborate online') }}</a></li>
-            </ul>
-          </section>
-        </section>
-        <section class="principle" id="principle-09" data-ga-quote-number="9" data-ga-quote="commercial involvement">
-          <header class="principle-header">
-            <h3><span class="principle-number">{{ principle_number_09 }}</span> {{ principle_text_09 }}</h3>
-          </header>
-          <section class="principle-more">
-            <h4>{{ _('Learn more') }}</h4>
-            <ul class="resources">
-              <li>
-                <a href="https://addons.mozilla.org/firefox/addon/lightbeam/">
-                  {% if addendum_translated %}
-                    {{ _('Visualize who you interact with on the web with Lightbeam') }}
-                  {% else %}
-                    {{ _('Visualize who you interact with on the Web with Lightbeam') }}
-                  {% endif %}
-                </a>
-              </li>
-              <li>
-                <a href="https://teach.mozilla.org/web-literacy/participate/share/">
-                  {% if addendum_translated %}
-                    {{ _('Learn about creating web resources with others') }}
-                  {% else %}
-                    {{ _('Learn about creating Web resources with others') }}
-                  {% endif %}
-                </a>
-              </li>
-            </ul>
-          </section>
-        </section>
-        <section class="principle" id="principle-10" data-ga-quote-number="10" data-ga-quote="magnify benefit">
-          <header class="principle-header">
-            <h3><span class="principle-number">{{ principle_number_10 }}</span> {{ principle_text_10 }}</h3>
-          </header>
-          <section class="principle-more">
-            <h4>{{ _('Learn more') }}</h4>
-            <ul class="resources">
-              <li><a href="https://teach.mozilla.org/events/">{{ _('Host or join a Maker Party') }}</a></li>
-              <li><a href="https://teach.mozilla.org/web-literacy/skills/">{{ _('Learn how to build online collaboration skills') }}</a></li>
-            </ul>
-          </section>
-        </section>
-      </div>
-      <footer class="content principles-foot">
-        {% if addendum_translated %}
-          <p><a class="button button-manifesto js-manifesto-share" target="_blank" rel="noopener noreferrer" href="{{ twitter_link('custom', _('I support the vision of a better, healthier internet from @mozilla, will you join me?')) }}" data-link-type="social share" data-link-name="Twitter">{{  _('Share on Twitter') }}</a></p>
-        {% endif %}
-        <p><a class="manifesto-details" href="{{ url('mozorg.about.manifesto-details') }}">{{ _('Read the entire manifesto') }}</a></p>
-      </footer>
-    </section>
-    <aside class="section section-newsletter" id="newsletter-subscribe">
-      <div class="content">
-        {% if LANG.startswith('en-') %}
-            {{ email_newsletter_form(newsletters='mozilla-foundation', title=_('Love the web?'), subtitle=_('Get the Mozilla newsletter and help us keep it open and free.'), button_class='button-hollow button-light', spinner_color='#fff') }}
-          {% else %}
-            {{ email_newsletter_form(button_class='button-hollow button-light', spinner_color='#fff') }}
+    <div class="mzp-l-content">
+      <section id="sec-principles">
+        <header class="principles-header">
+          {# If the addendum has not been translated, this section is first, so display the page title.
+             If the addendum is translated, a page title displays above it.
+             If the addendum's title has not been translated, the page title displays there, don't repeat it here.
+             If the addendum title is translated, we can label this section with the page title. #}
+          {% if not addendum_translated or (addendum_translated and addendum_title_translated) %}
+            <h1 itemprop="name" class="manifesto-title">{{ self.page_title() }}</h1>
           {% endif %}
-      </div>
-    </aside>
+          <h2 class="principles-head">{{ _('<strong>Our 10</strong> Principles') }}</h2>
+        </header>
+        <div id="principles">
+          <section class="principle">
+            <header class="principle-header">
+              <h3><span class="principle-number">{{ principle_number_01 }}</span> {{principle_text_01 }}</h3>
+            </header>
+            <section class="principle-more">
+              <h4>{{ _('Learn more') }}</h4>
+              <ul class="mzp-u-list-styled">
+                <li><a href="http://openbadges.org/">{{ _('Use Open Badges to share your skills and interests') }}</a></li>
+                <li>
+                  <a href="http://mozillascience.org/">
+                    {% if addendum_translated %}
+                      {{ _('Explore how the web impacts science') }}
+                    {% else %}
+                      {{ _('Explore how the Web impacts science') }}
+                    {% endif %}
+                  </a>
+                </li>
+                <li><a href="https://opennews.org/getinvolved/">{{ _('Learn about open source code in journalism') }}</a></li>
+              </ul>
+            </section>
+          </section>
+          <section class="principle">
+            <header class="principle-header">
+              <h3><span class="principle-number">{{ principle_number_02 }}</span> {{ principle_text_02 }}</h3>
+            </header>
+            <section class="principle-more">
+              <h4>{{ _('Learn more') }}</h4>
+              <ul class="mzp-u-list-styled">
+                <li>
+                  <a href="https://blog.mozilla.org/netpolicy/">
+                    {% if addendum_translated %}
+                      {{ _('Read about open internet policy initiatives and developments') }}
+                    {% else %}
+                      {{ _('Read about open Internet policy initiatives and developments') }}
+                    {% endif %}
+                  </a>
+                </li>
+                <li>
+                  <a href="https://teach.mozilla.org/web-literacy/participate/open-practice/">
+                    {% if addendum_translated %}
+                      {{ _('Explore how to help keep the web open') }}
+                    {% else %}
+                      {{ _('Explore how to help keep the Web open') }}
+                    {% endif %}
+                  </a>
+                </li>
+              </ul>
+            </section>
+          </section>
+          <section class="principle">
+            <header class="principle-header">
+              <h3><span class="principle-number">{{ principle_number_03 }}</span> {{ principle_text_03 }}</h3>
+            </header>
+            <section class="principle-more">
+              <h4>{{ _('Learn more') }}</h4>
+              <ul class="mzp-u-list-styled">
+                <li>
+                  <a href="https://blog.mozilla.org/blog/2014/04/09/firefox-os-and-medic-mobile-use-the-web-to-connect-the-world-to-healthcare/">
+                    {% if addendum_translated %}
+                      {{ _('See how the web can connect the world to healthcare') }}
+                    {% else %}
+                      {{ _('See how the Web can connect the world to healthcare') }}
+                    {% endif %}
+                  </a>
+                </li>
+                <li>
+                  <a href="https://teach.mozilla.org/web-literacy/read/navigate/">
+                    {% if addendum_translated %}
+                      {{ _('Explore how the web works') }}
+                    {% else %}
+                      {{ _('Explore how the Web works') }}
+                    {% endif %}
+                  </a>
+                </li>
+              </ul>
+            </section>
+          </section>
+          <section class="principle">
+            <header class="principle-header">
+              <h3><span class="principle-number">{{ principle_number_04 }}</span> {{ principle_text_04 }}</h3>
+            </header>
+            <section class="principle-more">
+              <h4>{{ _('Learn more') }}</h4>
+              <ul class="mzp-u-list-styled">
+                <li><a href="{{ url('mozorg.internet-health.privacy-security') }}">{{ _('See how Mozilla works to put your privacy first') }}</a></li>
+                <li><a href="https://blog.mozilla.org/netpolicy/">{{ _('Read about developments in privacy and data safety') }}</a></li>
+                <li><a href="https://teach.mozilla.org/web-literacy/participate/protect/">{{ _('Learn more about how to protect yourself online') }}</a></li>
+              </ul>
+            </section>
+          </section>
+          <section class="principle">
+            <header class="principle-header">
+              <h3><span class="principle-number">{{ principle_number_05 }}</span> {{ principle_text_05 }}</h3>
+            </header>
+            <section class="principle-more">
+              <h4>{{ _('Learn more') }}</h4>
+              <ul class="mzp-u-list-styled">
+                <li>
+                  <a href="https://teach.mozilla.org/tools/">
+                    {% if addendum_translated %}
+                      {{ _('Use these free tools to teach the web') }}
+                    {% else %}
+                      {{ _('Use these free tools to teach the Web') }}
+                    {% endif %}
+                  </a>
+                </li>
+                <li>
+                  <a href="https://teach.mozilla.org/web-literacy/write/compose/">
+                    {% if addendum_translated %}
+                      {{ _('Learn about creating and curating content for the web') }}
+                    {% else %}
+                      {{ _('Learn about creating and curating content for the Web') }}
+                    {% endif %}
+                  </a>
+                </li>
+              </ul>
+            </section>
+          </section>
+          <section class="principle">
+            <header class="principle-header">
+              <h3><span class="principle-number">{{ principle_number_06 }}</span> {{ principle_text_06 }}</h3>
+            </header>
+            <section class="principle-more">
+              <h4>{{ _('Learn more') }}</h4>
+              <ul class="mzp-u-list-styled">
+                <li><a href="http://ascendproject.org/">{{ _('Add new voices to open source technology') }}</a></li>
+                <li><a href="https://support.mozilla.org/kb/how-do-i-turn-do-not-track-feature">{{ _('Set your Do Not Track preference') }}</a></li>
+                <li>
+                  <a href="https://teach.mozilla.org/web-literacy/read/navigate/">
+                    {% if addendum_translated %}
+                      {{ _('Understand the web ecosystem') }}
+                    {% else %}
+                      {{ _('Understand the Web ecosystem') }}
+                    {% endif %}
+                  </a>
+                </li>
+              </ul>
+            </section>
+          </section>
+          <section class="principle">
+            <header class="principle-header">
+              <h3><span class="principle-number">{{ principle_number_07 }}</span> {{ principle_text_07 }}</h3>
+            </header>
+            <section class="principle-more">
+              <h4>{{ _('Learn more') }}</h4>
+              <ul class="mzp-u-list-styled">
+                <li>
+                  <a href="https://teach.mozilla.org/web-literacy/participate/open-practice/">
+                    {% if addendum_translated %}
+                      {{ _('Explore how open practices keep the web accessible') }}
+                    {% else %}
+                      {{ _('Explore how open practices keep the Web accessible') }}
+                    {% endif %}
+                  </a>
+                </li>
+                <li><a href="https://teach.mozilla.org/web-literacy/write/remix/">{{ _('Learn how to remix content to create something new') }}</a></li>
+                <li>
+                  <a href="https://teach.mozilla.org/web-literacy/write/code/">
+                    {% if addendum_translated %}
+                      {{ _('Learn how to maximize the interactive potential of the web') }}
+                    {% else %}
+                      {{ _('Learn how to maximize the interactive potential of the Web') }}
+                    {% endif %}
+                  </a>
+                </li>
+              </ul>
+            </section>
+          </section>
+          <section class="principle">
+            <header class="principle-header">
+              <h3><span class="principle-number">{{ principle_number_08 }}</span> {{ principle_text_08 }}</h3>
+            </header>
+            <section class="principle-more">
+              <h4>{{ _('Learn more') }}</h4>
+              <ul class="mzp-u-list-styled">
+                <li><a href="https://groups.google.com/forum/#!forum/mozilla.governance">{{ _('Participate in our governance forum') }}</a></li>
+                {% if l10n_has_tag('join-us') %}
+                  <li><a href="{{ url('mozorg.contribute.index') }}">{{ _('Join us as a volunteer') }}</a></li>
+                {% endif %}
+                <li><a href="https://teach.mozilla.org/web-literacy/skills/">{{ _('Learn how to collaborate online') }}</a></li>
+              </ul>
+            </section>
+          </section>
+          <section class="principle">
+            <header class="principle-header">
+              <h3><span class="principle-number">{{ principle_number_09 }}</span> {{ principle_text_09 }}</h3>
+            </header>
+            <section class="principle-more">
+              <h4>{{ _('Learn more') }}</h4>
+              <ul class="mzp-u-list-styled">
+                <li>
+                  <a href="https://addons.mozilla.org/firefox/addon/lightbeam/">
+                    {% if addendum_translated %}
+                      {{ _('Visualize who you interact with on the web with Lightbeam') }}
+                    {% else %}
+                      {{ _('Visualize who you interact with on the Web with Lightbeam') }}
+                    {% endif %}
+                  </a>
+                </li>
+                <li>
+                  <a href="https://teach.mozilla.org/web-literacy/participate/share/">
+                    {% if addendum_translated %}
+                      {{ _('Learn about creating web resources with others') }}
+                    {% else %}
+                      {{ _('Learn about creating Web resources with others') }}
+                    {% endif %}
+                  </a>
+                </li>
+              </ul>
+            </section>
+          </section>
+          <section class="principle">
+            <header class="principle-header">
+              <h3><span class="principle-number">{{ principle_number_10 }}</span> {{ principle_text_10 }}</h3>
+            </header>
+            <section class="principle-more">
+              <h4>{{ _('Learn more') }}</h4>
+              <ul class="mzp-u-list-styled">
+                <li><a href="https://teach.mozilla.org/events/">{{ _('Host or join a Maker Party') }}</a></li>
+                <li><a href="https://teach.mozilla.org/web-literacy/skills/">{{ _('Learn how to build online collaboration skills') }}</a></li>
+              </ul>
+            </section>
+          </section>
+        </div>
+        <footer class="content principles-foot">
+          {% if addendum_translated %}
+            <p><a class="mzp-c-button button-manifesto js-manifesto-share" target="_blank" rel="noopener noreferrer" href="{{ twitter_link('custom', _('I support the vision of a better, healthier internet from @mozilla, will you join me?')) }}" data-link-type="social share" data-link-name="Twitter">{{  _('Share on Twitter') }}</a></p>
+          {% endif %}
+          <p><a class="mzp-c-cta-link" href="{{ url('mozorg.about.manifesto-details') }}">{{ _('Read the entire manifesto') }}</a></p>
+        </footer>
+      </section>
+    </div>
+    <div class="mzp-l-content">
+      <aside class="mzp-c-newsletter">
+        <div class="mzp-c-newsletter-image">
+          {{ high_res_img('img/home/2018/newsletter-graphic.png', {'alt': ''}) }}
+        </div>
+
+        <div class="newsletter-content">
+          {% if LANG.startswith('en-') %}
+            {{ email_newsletter_form(protocol_component=True, newsletters='mozilla-foundation', title=_('Love the web?'), subtitle=_('Get the Mozilla newsletter and help us keep it open and free.'), spinner_color='#fff') }}
+          {% else %}
+            {{ email_newsletter_form(protocol_component=True, spinner_color='#fff') }}
+          {% endif %}
+        </div>
+      </aside>
+    </div>
   </article>
 </main>
-
 {% endblock %}
 
 {% block js %}
   {{ js_bundle('manifesto') }}
 {% endblock %}
-
-  {#- End the redesigned landing page -#}
-{% endif %}

--- a/media/css/mozorg/manifesto.scss
+++ b/media/css/mozorg/manifesto.scss
@@ -2,283 +2,75 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-@import '../pebbles/includes/lib';
-@import '../pebbles/components/newsletter';
-@import '../hubs/sections';
+$font-path: '/media/fonts';
+$image-path: '/media/protocol/img';
 
-$addendum-blue: #16AABF;
-
-/* needs to be at the top so other classes can over-ride the mixin defaults */
-.manifesto-title-addendum,
-.addendum-subtitle,
-.addendum-paragraph,
-.share-head,
-.share-paragraph {
-    padding: 0 $mobile-content-padding;
-    max-width: 700px;
-
-    @media #{$mq-tablet} {
-        padding: 0 $tablet-content-padding;
-    }
-
-    @media #{$mq-desktop} {
-        @include span(8);
-        float: none; // needs to over-ride span()
-        margin: 0 auto; // needs to over-ride span()
-        padding: 0;
-    }
-
-    @media #{$mq-desktop-wide} {
-        @include span(6);
-        float: none; // needs to over-ride span()
-        margin: 0 auto; // needs to over-ride span()
-    }
-}
-
-
-/*
-Manifesto
-====================================================================== */
+@import '../../protocol/css/includes/lib';
+@import '../../protocol/css/components/call-out';
+@import '../../protocol/css/components/newsletter-form';
 
 .manifesto-title {
-    @include open-sans;
-    @include font-size-level4;
-    margin-bottom: 15px;
-}
-
-.manifesto-details {
-    @include font-size-level5;
-    @include open-sans;
-    color: $color-text-primary;
-    display: inline-block;
-    font-weight: bold;
-    text-decoration: none;
-
-    &:after {
-        @include background-size(cover);
-        background-image: url('/media/img/mozorg/about/manifesto/cta-arrow.svg');
-        background-position: 0 0;
-        content: '';
-        display: inline-block;
-        height: 12px;
-        margin-left: 10px;
-        position: relative;
-        right: 0;
-        transition: right 100ms ease-in-out;
-        width: 14px;
-
-        html[dir="rtl"] & {
-            margin-left: 0;
-            margin-right: 10px;
-            transform: rotate(180deg);
-        }
-    }
-
-    &:link,
-    &:visited {
-        color: $color-text-primary;
-
-        &:hover,
-        &:focus,
-        &:active {
-            color: $color-text-primary;
-            text-decoration: underline;
-
-            &:after {
-                right: -4px;
-
-                html[dir="rtl"] & {
-                    right: 4px;
-                }
-            }
-        }
-    }
-
-    @media #{$mq-tablet} {
-        margin-bottom: $tablet-content-padding;
-    }
-
-    @media #{$mq-desktop-wide} {
-        margin-bottom: $desktop-content-padding;
-    }
+    @include text-display-sm;
+    margin-top: $spacing-2xl;
 }
 
 /*
 Addendum
 ====================================================================== */
 
-.manifesto-title-addendum {
-    padding-top: $mobile-content-padding;
-
-    @media #{$mq-tablet} {
-        padding-top: $tablet-content-padding;
-    }
-
-    @media #{$mq-desktop-wide} {
-        padding-top: $desktop-content-padding;
-    }
-}
-
 .addendum-subtitle {
-    @include font-size-huge;
-    line-height: 1;
-    margin-bottom: 0.6em;
+    @include text-display-xxl;
 }
 
 .addendum-list {
     @include clearfix;
-    @include font-size-level3;
-    margin: 2em ($mobile-content-padding * 2) 0;
-
-    @media #{$mq-tablet} {
-        margin-bottom: 2em;
-        margin-left: ($tablet-content-padding * 2);
-        margin-right: ($tablet-content-padding * 2);
-    }
-
-    @media #{$mq-desktop-wide} {
-        margin-left: auto;
-        margin-right: auto;
-        max-width: $width-max-content;
-    }
 
     li {
-        padding-bottom: 60px;
-        padding-top: 40px;
+        @include font-mozilla;
+        @include text-display-sm;
+        padding-bottom: $spacing-2xl;
+        padding-top: $spacing-xl;
         position: relative;
 
-        @media #{$mq-desktop-wide} {
+        @media #{$mq-xl} {
             @include border-box;
-            float: left;
-            line-height: 1.25;
-            margin-left: $desktop-content-padding;
-            margin-right: $desktop-content-padding;
-            width: calc(50% - #{$desktop-content-padding * 1.5});
-
-            html[dir="rtl"] {
-                float: right;
-            }
+            @include bidi(((float, left, right),));
+            @include grid-half;
+            padding: $spacing-xl $spacing-md $spacing-2xl;
         }
 
         &:nth-child(odd) {
-            clear: left;
-            margin-right: 0;
+            @include bidi(((clear, left, right),));
         }
 
         &:before {
-            background-color: $color-text-primary;
+            @include bidi(((left, 0, right, auto),));
+            background-color: $color-black;
             content: '';
             display: block;
             height: 7px;
-            left: 0;
             position: absolute;
             top: 0;
             width: 80px;
-
-            html[dir="rtl"] & {
-                left: auto;
-                right: 0;
-            }
         }
     }
 }
-
-.addendum-paragraph {
-    @include font-size-level5;
-    @include open-sans;
-    margin-bottom: 1.25em;
-}
-
 
 /*
 Share section
 ====================================================================== */
 
 .share-addendum {
-    @include open-sans;
-    background-color: #b9e5ec;
-    margin-bottom: $mobile-content-padding * 2;
-    padding: ($mobile-content-padding * 2) 0;
-
-    @media #{$mq-tablet} {
-        margin-bottom: 20px;
-        padding: $tablet-content-padding 0;
-    }
-
-    @media #{$mq-desktop} {
-        margin-bottom: 55px;
-        padding: $desktop-content-padding 0;
-    }
+    background-color: $color-blue-5;
 }
 
-.share-button-outter {
-    margin: $mobile-content-padding 0 0 0;
-    text-align: center;
-
-    @media #{$mq-tablet} {
-        margin-top: 60px;
-    }
+.button-manifesto {
+    margin-top: $spacing-lg;
 }
-
-.share-head {
-    @include font-size-level4;
-    margin-bottom: 15px;
-}
-
-a.button.button-manifesto {
-    background-color: $addendum-blue;
-    border-color: $addendum-blue;
-    padding-left: 25px + 25px + 15px; // left padding + icon width + right padding
-    position: relative;
-
-    html[dir="rtl"] & {
-        padding-left: 40px;
-        padding-right: 25px + 25px + 15px; // left padding + icon width + right padding
-    }
-
-    &:hover,
-    &:focus,
-    &:active {
-        background-color: darken(#149bae, 2%);
-        border-color: darken(#149bae, 2%);
-    }
-
-    &:before {
-        background-image: url('/media/img/logos/social/social-icon-sprite.svg');
-        background-position: 0 0;
-        background-size: cover;
-        content: '';
-        display: inline-block;
-        height: 20px;
-        left: 25px;
-        position: absolute;
-        top: 1.1em;
-        width: 25px;
-
-        html[dir="rtl"] & {
-            left: auto;
-            right: 25px;
-        }
-    }
-}
-
 
 /*
 Principles
 ====================================================================== */
-
-.principles-header {
-    padding-top: $mobile-content-padding;
-
-    @media #{$mq-tablet} {
-        margin-bottom: 1.5em;
-        padding-top: $tablet-content-padding;
-    }
-
-    @media #{$mq-desktop-wide} {
-        padding-top: $desktop-content-padding;
-    }
-}
 
 .principles-foot {
     text-align: center;
@@ -287,85 +79,58 @@ Principles
 .principle {
     @include border-box;
     @include clearfix;
-    margin: 0 auto;
-    max-width: $width-max-content;
-    padding: $mobile-content-padding;
+    padding: $spacing-lg 0;
 }
 
-@media #{$mq-tablet} {
+@media #{$mq-md} {
     .principle {
-        padding: 0 $tablet-content-padding $tablet-content-padding $tablet-content-padding;
+        padding-bottom: $spacing-xl;
     }
 }
 
-@media #{$mq-desktop} {
+@media #{$mq-lg} {
     .principle {
-        padding: 0 $desktop-content-padding $desktop-content-padding $desktop-content-padding;
+        padding-bottom: $spacing-2xl;
     }
 }
 
 .principle-number {
-    @include font-size(20px);
-    @include open-sans;
+    @include text-display-xs;
     display: block;
     font-weight: bold;
-    margin-bottom: 0.8em;
-    text-decoration: none;
+    margin-bottom: $spacing-sm;
 }
 
 .principle-header {
     h3 {
-        @include font-size-level2;
+        @include text-display-md;
         font-weight: normal;
-
-        @media #{$mq-desktop} {
-            @include font-size(44px);
-        }
     }
 
-    @media #{$mq-tablet} {
-        @include span(7);
+    @media #{$mq-md} {
+        @include colspan(7);
+        @include bidi(((float, left, right),));
         padding: 0;
-
-        html[dir="rtl"] & {
-            float: right;
-        }
     }
 }
 
 .principle-more {
-    @include open-sans;
-    @include font-size-level6;
-    margin-top: $mobile-content-padding;
-
-    @media #{$mq-tablet} {
-        @include span(5);
-        margin-top: 0;
-        padding: 0;
-        padding-left: $tablet-content-padding;
-
-        html[dir="rtl"] & {
-            float: right;
-            padding-left: 0;
-            padding-right: $tablet-content-padding;
-        }
-    }
-
-    @media #{$mq-desktop} {
-        padding-left: $desktop-content-padding;
-    }
+    margin-top: $spacing-lg;
 
     h4 {
-        font-size: inherit;
-        line-height: 1.6;
-        margin-bottom: 1em;
+        @include text-display-xxs;
     }
 
-    ul {
-        margin-bottom: 0;
+    @media #{$mq-md} {
+        @include bidi((
+            (float, left, right),
+            (padding-left, $spacing-xl, padding-right, 0),
+        ));
+        @include colspan(5);
+        margin-top: 0;
     }
 
-    li {
-        margin-bottom: 0.5em;
+    @media #{$mq-lg} {
+        @include bidi(((padding-left, $spacing-2xl, padding-right, 0),));
     }
 }

--- a/media/img/mozorg/about/manifesto/cta-arrow.svg
+++ b/media/img/mozorg/about/manifesto/cta-arrow.svg
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<svg id="cta-arrow" width="14px" height="12px" viewBox="0 0 14 12" xmlns="http://www.w3.org/2000/svg">
-  <path d="M0 7.3h9l-2.8 2.9L8 12l6-6-6-6-1.8 1.8L9 4.7H0z"/>
-</svg>

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -1396,6 +1396,8 @@
     },
     {
       "files": [
+        "protocol/js/protocol-newsletter.js",
+        "js/newsletter/form-protocol.js",
         "js/mozorg/manifesto.js"
       ],
       "name": "manifesto"


### PR DESCRIPTION
## Description
- Port /about/manifesto/ page to Protocol.
- Remove L10n tag `manifesto_landing`, as all enabled locales have it set to active.

## Issue / Bugzilla link
#8504

## Testing
- [x] No regressions for L10n.
- [x] No regressions for CSS responsiveness.