### PR TITLE
Update the TOS and PN for FPN (Fixes #8558)

### DIFF
--- a/bedrock/legal/templates/legal/terms/firefox-private-network.html
+++ b/bedrock/legal/templates/legal/terms/firefox-private-network.html
@@ -95,7 +95,7 @@
     <h2>{{ _('Browser Protection') }}</h2>
     <p>
       {% trans %}
-      When you sign up for FPN Browser Protection, you get a certain number of per month. Each time you turn FPN Browser
+      When you sign up for FPN Browser Protection, you get a certain number of passes per month. Each time you turn FPN Browser
       Protection on, you claim one of your passes and it runs without stopping. Once you use all your
       passes, you will not be able to use FPN Browser Protection until the next month, when you receive a new set of passes.
       Unused passes cannot be transferred month-to-month.

--- a/bedrock/legal/templates/legal/terms/firefox-private-network.html
+++ b/bedrock/legal/templates/legal/terms/firefox-private-network.html
@@ -51,7 +51,7 @@
 
     <ol>
       <li>{{ _('FPN Browser Protection, which protects your web browsing within Firefox, and') }}</li>
-      <li>{{ _('FPN Full-device Protection, which protects all your device’s internet connections.') }}</li>
+      <li>{{ _('FPN Full-Device Protection, which protects all your device’s internet connections.') }}</li>
     </ol>
 
     <p>
@@ -95,9 +95,9 @@
     <h2>{{ _('Browser Protection') }}</h2>
     <p>
       {% trans %}
-      When you sign up for FPN Browser Protection, you get four passes per month. Each time you turn FPN Browser
-      Protection on, you claim one of your passes and it runs for eight hours without stopping. Once you use all four
-      passes, you will not be able to use FPN Browser Protection until the next month, when you receive 4 new passes.
+      When you sign up for FPN Browser Protection, you get a certain number of per month. Each time you turn FPN Browser
+      Protection on, you claim one of your passes and it runs without stopping. Once you use all your
+      passes, you will not be able to use FPN Browser Protection until the next month, when you receive a new set of passes.
       Unused passes cannot be transferred month-to-month.
       {% endtrans %}
     </p>
@@ -107,7 +107,7 @@
       <li>
         <p>
           {% trans %}
-          <strong>Payment.</strong> We offer the FPN Full-device Protection service as a monthly, automatically renewing
+          <strong>Payment.</strong> We offer the FPN Full-Device Protection service as a monthly, automatically renewing
           subscription. When you sign up, you authorize us to charge the payment card you provide for the subscription
           fees for the first month of the FPN service. Your plan renews automatically each month, and you authorize us
           to charge the monthly subscription fees each month.
@@ -126,10 +126,10 @@
       <li>
         <p>
           {% trans %}
-          <strong>30-Day Guarantee.</strong> The first time you subscribe to FPN Full-device Protection, you may cancel
+          <strong>30-Day Guarantee.</strong> The first time you subscribe to FPN Full-Device Protection, you may cancel
           your account within the first 30 days, and if you request it, Mozilla will refund your first month
-          subscription. This offer only applies the first time you subscribe to FPN Full-device Protection. If you
-          decide to subscribe to FPN Full-device Protection after cancelling, you are not eligible for the 30-day money
+          subscription. This offer only applies the first time you subscribe to FPN Full-Device Protection. If you
+          decide to subscribe to FPN Full-Device Protection after cancelling, you are not eligible for the 30-day money
           back guarantee.
           {% endtrans %}
         </p>
@@ -142,7 +142,7 @@
     <h2>{{ _('Cancellation') }}</h2>
     <p>
       {% trans %}
-      You may cancel your subscription to the FPN Full-device Protection at any time by clicking the “Cancel
+      You may cancel your subscription to the FPN Full-Device Protection at any time by clicking the “Cancel
       Subscription” link in any email that we send you and deactivating your subscription. If you choose to cancel,
       auto-renewal will stop, we will not charge you for any future payment periods, and you will lose access to the
       service at the end of the current billing cycle.

--- a/bedrock/privacy/templates/privacy/notices/firefox-private-network.html
+++ b/bedrock/privacy/templates/privacy/notices/firefox-private-network.html
@@ -48,7 +48,7 @@
     <div>
       <ol class="mzp-u-list-styled">
         <li>{{ _('FPN Browser Protection, which protects your web browsing within Firefox, and' ) }}</li>
-        <li>{{ _('FPN Full-Device Protection, which protects all your device’s internet connections.') }}</li>
+        <li>{{ _('FPN Full-Device (VPN) Protection, which protects all your device’s internet connections.') }}</li>
       </ol>
       <p>
         {{ _('Our partner for FPN Browser Protection is Cloudflare. Our partner for FPN Full-device Protection is Mullvad.') }}
@@ -81,8 +81,7 @@
     </div>
     <h3>
       {% trans %}
-      Enabling this Service keeps your Firefox web browsing activity private from your internet service provider, and
-      most of your web traffic, by encrypting and routing it through our partners’ networks instead.
+      Enabling this Service keeps most of your internet activity private from your internet service provider by encrypting and routing it through our partners’ networks instead.
       {% endtrans %}
     </h3>
     <div>
@@ -115,7 +114,7 @@
           <p>
             {% trans %}
             <strong>Mozilla receives information about how many passes you’ve used.</strong> When you sign up for FPN
-            Browser Protection, you get 4 passes per month. Mozilla receives information about how many of your passes
+            Browser Protection, you get a certain number of passes per month. Mozilla receives information about how many of your passes
             you’ve used and associates that information with your Firefox Account.
             {% endtrans %}
           </p>


### PR DESCRIPTION
## Description
Copy was an out-of-date version (oct 18)


- [ ] The FPN [Terms of Service page](https://www.mozilla.org/about/legal/terms/firefox-private-network/) is updated with [this copy](https://docs.google.com/document/d/1xY5d7PIGqmQ9JPD4HAnTMHfxOC4-7SACrjRMJBal2w8/edit#)

- [ ] The FPN [Privacy Notice page](https://www.mozilla.org/privacy/firefox-private-network/) is updated with [this copy](https://docs.google.com/document/d/1b_sAb8Z_6EXNPmEqnr51xtzKUxOtrchLyCY9N5GFgV8/edit)

## Issue / Bugzilla link
#8558