### PR TITLE
[#7574] Small copy fixes for browser comparison pages

### DIFF
--- a/bedrock/firefox/templates/firefox/compare/chrome.html
+++ b/bedrock/firefox/templates/firefox/compare/chrome.html
@@ -41,6 +41,7 @@
         </p>
 
         <p>
+          {# L10n: "we've been heads down" means we've been hard at work. Alternative: "we've been hard at work." "Heads down" is when someone is looking down to avoid distractions and focus on the immediate task in front of them. #}
           {% trans %}
           Fast-forward to today, the competitive landscape for browsers has changed with many people beginning to question just what is happening to their online data such as browsing history, passwords, and other sensitive information. A lot has changed since 2008 when Chrome came onto the scene. At Firefox, we’ve been heads down, working to redesign our interface and provide users with an ever growing number of privacy and performance enhancements as well as plenty of handy browser tools.
           {% endtrans %}
@@ -122,14 +123,16 @@
       </p>
 
       <p>
+        {# L10n: "Beside the point" means that a subject might be worth noting, but isn't the main focus (the point) of the discussion. Alternative: "but that's not the real issue." #}
         {% trans %}
-        While Chrome proves to be a safe web browser, its privacy record is questionable. Google actually collects a disturbingly large amount of data from its users including location, search history and site visits. Google makes its case for data collection saying it’s doing it to improve its services—like helping you find a sweater or a coffee shop like the one you previously bought or visited. However, others might disagree, making the point that Google is actually gathering an unprecedented amount of data for its own marketing purposes. They tout that they're keeping your information private from hackers, but that's beside the point. Google itself runs the world's largest advertising network, thanks in large part to data they harvest from their users.
+        While Chrome proves to be a safe web browser, its privacy record is questionable. Google actually collects a disturbingly large amount of data from its users including location, search history and site visits. Google makes its case for data collection saying it’s doing it to improve its services – like helping you find a sweater or a coffee shop like the one you previously bought or visited. However, others might disagree, making the point that Google is actually gathering an unprecedented amount of data for its own marketing purposes. They tout that they’re keeping your information private from hackers, but that’s beside the point. Google itself runs the world’s largest advertising network, thanks in large part to data they harvest from their users.
         {% endtrans %}
       </p>
 
       <p>
+        {# L10n: To "draw the line" is to establish a boundary that should not be crossed. Alternative: "it's up to you to decide whether or not or where your limit is with sharing things (...)". #}
         {% trans %}
-        Ultimately, it’s up to you to decide whether or not or when to draw the line in the sand with sharing things like your search history and shopping history. But if you’re anything like most people, you’ve probably searched for some things on the internet that you would rather keep private.
+        Ultimately, it’s up to you to decide whether or not or where to draw the line with sharing things like your search history and shopping history. But if you’re anything like most people, you’ve probably searched for some things on the internet that you would rather keep private.
         {% endtrans %}
       </p>
 
@@ -224,7 +227,7 @@
       </p>
 
       <p>
-        {# L10n: "gets the nod" here means Chrome is the winner. It's an idiom that indicates making a selection, like someone nodding their head in approval. #}
+        {# L10n: "gets the nod" here means Chrome is the winner. Alternative: "While Chrome wins the contest with add-ons and extensions". "Getting the nod" indicates making a selection, like someone nodding their head in approval. #}
         {% trans %}
         While Chrome gets the nod with add-ons and extensions, Firefox has a nicely curated set of built-in features, such as the incredibly handy screen capture tool, and reading mode feature which strips away everything from the page except the text from the article you’re reading.
         {% endtrans %}
@@ -311,6 +314,7 @@
       </header>
 
       <p>
+        {# L10n: "Neck and neck" means they are evenly matched. Alternative: "evenly matched". "Baked-in" means it's included, not added in later. Alternatives: "built-in" or "included". #}
         {% trans %}
         We think it’s fair to say Firefox and Chrome are really neck and neck in terms of portability and utility, with Chrome having a slight edge in utility because of its huge library of extensions and add-on features. But in terms of Privacy, Firefox wins the day with our commitment to preserving our users’ online data and providing free baked-in services like password managers that also alert you if there happens to be a data breach involving your credentials.
         {% endtrans %}

--- a/bedrock/firefox/templates/firefox/compare/edge.html
+++ b/bedrock/firefox/templates/firefox/compare/edge.html
@@ -236,6 +236,7 @@
       </p>
 
       <p>
+        {# L10n: "Out of the gate" means from the very start. Alternative: "From the start,". Race horses are held behind a gate that is opened to release all the horses at the same time at the start of the race, so a horse that leads the race from the very start is said to lead "right out of the gate." #}
         {% trans %}
         Out of the gate, Firefox has more features and integrations built into the browser and readily available on download. And while both browsers have a tremendous number of add-ons and extensions available, Edge’s compatibility with Google’s Chromium platform gives it the advantage in terms of sheer numbers.
         {% endtrans %}
@@ -290,13 +291,13 @@
 
       <p>
         {% trans %}
-        With Internet Explorer, Microsoft learned from its lack of availability across platforms and made Edge available for macOS and Android. The software is now readily available on iOS, Android, and Windows and Mac.
+        With Internet Explorer, Microsoft learned from its lack of availability across platforms and made Edge available for macOS and Android. The software is now readily available on iOS, Android, Windows and Mac.
         {% endtrans %}
       </p>
 
       <p>
         {% trans attrs='href="%s" data-cta-type="link" data-cta-name="free account"'|safe|format(url('firefox.accounts')) %}
-        Firefox has been available on iOS, Android, Windows, macOS, and Linux for years. And as you would expect with any modern browser, Firefox lets you log in with a <a {{ attrs }}>free account</a> and sync data such as passwords, browsing history, bookmarks, and open tabs between your computer, tablet. and phone. It also allows you to sync across platforms as well.
+        Firefox has been available on iOS, Android, Windows, macOS and Linux for years. And as you would expect with any modern browser, Firefox lets you log in with a <a %(attrs)s>free account</a> and sync data such as passwords, browsing history, bookmarks, and open tabs between your computer, tablet and phone. It also allows you to sync across platforms as well.
         {% endtrans %}
       </p>
 

--- a/bedrock/firefox/templates/firefox/compare/ie.html
+++ b/bedrock/firefox/templates/firefox/compare/ie.html
@@ -255,6 +255,7 @@
         </table>
 
       <p>
+        {# L10n: "sunset" here means Microsoft is officially ending production of Internet Explorer. Alternative: "retire" #}
         {% trans %}
         As Microsoft has made the move to sunset the Internet Explorer browser, it no longer supports any version for iOS, and has never been available for Android. Which means unless you’re running a Windows-based laptop or desktop, you won’t have access to your bookmarks, browsing history, saved passwords, and other information that modern browsers sync across devices.
         {% endtrans %}
@@ -262,7 +263,7 @@
 
       <p>
         {% trans %}
-        Firefox works on any platform, including Windows, Mac, Linux, Android and iOS. Which also means  you can sync all your information across platforms. So if you’re browsing on a Windows-based laptop, you can pick up where you left off when you move to browsing on your iPhone or Android device. This convenience should come standard with any modern web browser, and is sorely lacking with Internet Explorer.
+        Firefox works on any platform, including Windows, macOS, Linux, Android and iOS. Which also means  you can sync all your information across platforms. So if you’re browsing on a Windows-based laptop, you can pick up where you left off when you move to browsing on your iPhone or Android device. This convenience should come standard with any modern web browser, and is sorely lacking with Internet Explorer.
         {% endtrans %}
       </p>
 
@@ -283,7 +284,7 @@
 
       <p>
         {# Download link should be locale neutral. See issue #7982 #}
-        {# L10n: "Nana" is a common nickname for a grandmother in many English-speaking countries. Use a similar name for your language or culture. #}
+        {# L10n: "Nana" is a common nickname for a grandmother in many English-speaking countries. Use a similar name for a grandmother in your language or culture. #}
         {% trans attrs='href="/firefox/download/thanks/" data-cta-type="link" data-cta-name="download Firefox"'|safe %}
         Our opinion is just to go with a trusted, private browser with a track record of delivering a great experience across devices. In a head-to-head comparison, it’s really no contest at all. Firefox is hands down the winner across all assessment categories. If you do find yourself at Nana’s house firing up Internet Explorer, maybe you want to do Nana a favor and <a {{ attrs }}>download Firefox</a> for her.
         {% endtrans %}

--- a/bedrock/firefox/templates/firefox/compare/opera.html
+++ b/bedrock/firefox/templates/firefox/compare/opera.html
@@ -259,9 +259,9 @@
         </table>
 
       <p>
-        {# L10n: "Ex" is a former partner or spouse, as in "ex-boyfriend" or "ex-wife." #}
+        {# L10n: "Ex" is a former partner or spouse, as in "ex-boyfriend" or "ex-wife." Alternative: "former partner" #}
         {% trans %}
-        Both Firefox and Opera are compatible across every major device including Windows, Mac, Linux, Android and iOS. Firefox account holders can easily sync their bookmarks, passwords, open tabs, and browsing history across all their signed into devices. The same is true for Opera users with an account. However, many sites, especially old sites that haven’t been updated in years, block the latest version of Opera entirely. So if visiting places like your Ex’s old blog is important, take heed, you may not be able to access some of the dustier corners of the internet if you use Opera.
+        Both Firefox and Opera are compatible across every platform including Windows, Mac, Linux, Android and iOS. Firefox account holders can easily sync their bookmarks, passwords, open tabs, and browsing history across all their signed into devices. The same is true for Opera users with an account. However, many sites, especially old sites that haven’t been updated in years, block the latest version of Opera entirely. So if visiting places like your Ex’s old blog is important, take heed, you may not be able to access some of the dustier corners of the internet if you use Opera.
         {% endtrans %}
       </p>
 

--- a/bedrock/firefox/templates/firefox/compare/safari.html
+++ b/bedrock/firefox/templates/firefox/compare/safari.html
@@ -96,6 +96,7 @@
       </p>
 
       <p>
+        {# L10n: "Standing on the soap box" means trying to spread a persuasive message to the masses. Alternative: "We've been spreading the message about privacy for a long time." Soap used to come in wooden crates, and this idiom refers to activists or preachers who would stand on an empty soap box on a street corner to speak to a crowd. #}
         {% trans %}
         Like Safari, we at Firefox have made a point of focusing on privacy and security. But unlike Safari, we’ve been standing on the privacy soap box for a long time. In fact, Mozilla (our parent company) was one of the first voices in the tech community to sound the alarm for online privacy.
         {% endtrans %}
@@ -213,7 +214,7 @@
 
       <p>
         {% trans pocket='href="https://getpocket.com/" rel="external noopener" data-cta-text="Pocket" data-cta-type="link"'|safe, send='href="https://send.firefox.com/" rel="external noopener" data-cta-text="Send" data-cta-type="link"'|safe %}
-        Also, when you sign up for a Firefox account you get access to some unique services like Screenshots, <a {{ pocket }}>Pocket</a> and <a {{ send }}>Send</a> that integrate directly into the browser. Screenshots is a feature built right into the Firefox browser, allowing you to copy or download any or all part of a web page. When you save the screenshot, you can also choose which folder you want to find it in, instead of cluttering your desktop. The Pocket for Firefox button lets you save web pages and videos to Pocket in just one click, so you can read a clean, distraction-free version whenever and wherever you want — even offline. With Send you can share large files with end-to-end encryption and a variety of security controls, such as the ability to set an expiration time for a file link to expire, the number of downloads, and whether to add an optional password for an extra layer of security.
+        Also, when you sign up for a Firefox account you get access to some unique services like Screenshots, <a %(pocket)s>Pocket</a> and <a %(send)s>Send</a> that integrate directly into the browser. Screenshots is a feature built right into the Firefox browser, allowing you to copy or download any or all part of a web page. When you save the screenshot, you can also choose which folder you want to find it in, instead of cluttering your desktop. The Pocket for Firefox button lets you save web pages and videos to Pocket in just one click, so you can read a clean, distraction-free version whenever and wherever you want — even offline. With Send, you can share large files with end-to-end encryption and a variety of security controls, such as the ability to set an expiration time for a file link to expire, the number of downloads, and whether to add an optional password for an extra layer of security.
         {% endtrans %}
       </p>
 


### PR DESCRIPTION
## Description

A few grammar and punctuation fixes came up during review of the extracted strings. (See https://github.com/mozilla-l10n/www.mozilla.org/pull/371)

