### PR TITLE
Scale Structured data to locales (Fixes #8522)

### DIFF
--- a/bedrock/base/templates/base-pebbles.html
+++ b/bedrock/base/templates/base-pebbles.html
@@ -122,14 +122,12 @@
     <!--[if !IE]><!-->
     {% block js %}{% endblock %}
 
-    {% if LANG == 'en-US' %}
-      {% if self.structured_data()|trim|length %}
-        <script type="application/ld+json">
-      {% endif %}
-      {% block structured_data %}{% endblock %}
-      {% if self.structured_data()|trim|length %}
-        </script>
-      {% endif %}
+    {% if self.structured_data()|trim|length %}
+      <script type="application/ld+json">
+    {% endif %}
+    {% block structured_data %}{% endblock %}
+    {% if self.structured_data()|trim|length %}
+      </script>
     {% endif %}
 
     {% if settings.DEV %}

--- a/bedrock/base/templates/includes/structured-data/breadcrumb/new.json
+++ b/bedrock/base/templates/includes/structured-data/breadcrumb/new.json
@@ -1,1 +1,30 @@
-{ "@context": "https://schema.org", "@type": "BreadcrumbList", "itemListElement": [{ "@type": "ListItem", "position": 1, "name": "Mozilla", "item": "https://www.mozilla.org" },{ "@type": "ListItem", "position": 2, "name": "English", "item": "https://www.mozilla.org/en-US/" },{ "@type": "ListItem", "position": 3, "name": "Firefox", "item": "https://www.mozilla.org/en-US/firefox/" },{ "@type": "ListItem", "position": 4, "name": "Download", "item": "https://www.mozilla.org/en-US/firefox/new/" }] }
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Mozilla",
+      "item": "{% filter absolute_url %}{{ settings.CANONICAL_URL }}{% endfilter %}"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "English",
+      "item": "{% filter absolute_url %}{{ url('mozorg.home') }}{% endfilter %}"
+    },
+    {
+      "@type": "ListItem",
+      "position": 3,
+      "name": "Firefox",
+      "item": "{% filter absolute_url %}{{ url('firefox') }}{% endfilter %}"
+    },
+    {
+      "@type": "ListItem",
+      "position": 4,
+      "name": "Download",
+      "item": "{% filter absolute_url %}{{ url('firefox.new') }}{% endfilter %}"
+    }
+  ]
+}

--- a/bedrock/base/templates/includes/structured-data/organizations/mozilla-corporation-organisation.json
+++ b/bedrock/base/templates/includes/structured-data/organizations/mozilla-corporation-organisation.json
@@ -67,12 +67,12 @@
     "sameAs": [
       "https://www.wikidata.org/wiki/Q550315",
       "https://{{ lang_short() }}.wikipedia.org/wiki/Firefox_for_Android",
-      "{{ play_store_url(settings.GOOGLE_PLAY_FIREFOX_LINK)|safe }}"
+      "{{ play_store_url('firefox')|safe }}"
     ],
     "offers":
     {
       "@type": "Offer",
-      "url": "{{ play_store_url(settings.GOOGLE_PLAY_FIREFOX_LINK)|safe }}",
+      "url": "{{ play_store_url('firefox')|safe }}",
       "priceCurrency": "USD",
       "price": "0",
       "availability": "https://schema.org/InStock"
@@ -98,7 +98,7 @@
       "@id": "{{ structured_data_id('firefoxbrand') }}"
     },
     "sameAs": [
-      "{{ play_store_url(settings.GOOGLE_PLAY_FIREFOX_BETA_LINK)|safe }}"
+      "{{ play_store_url('firefox_beta')|safe }}"
     ],
     "offers":
     {
@@ -312,12 +312,12 @@
       "@id": "{{ structured_data_id('firefoxbrand') }}"
     },
     "sameAs": [
-      "{{ play_store_url(settings.GOOGLE_PLAY_FIREFOX_LITE_LINK)|safe }}"
+      "{{ play_store_url('firefox_lite')|safe }}"
     ],
     "offers":
     {
       "@type": "Offer",
-      "url": "{{ play_store_url(settings.GOOGLE_PLAY_FIREFOX_LITE_LINK)|safe }}",
+      "url": "{{ play_store_url('firefox_lite')|safe }}",
       "priceCurrency": "USD",
       "price": "0",
       "availability": "https://schema.org/InStock"
@@ -341,8 +341,8 @@
     "sameAs": [
       "https://{{ lang_short() }}.wikipedia.org/wiki/Firefox_Lockwise",
       "https://www.wikidata.org/wiki/Q64829394",
-      "{{ play_store_url(settings.GOOGLE_PLAY_LOCKWISE_LINK)|safe }}",
-      "{{ app_store_url(settings.APPLE_APPSTORE_LOCKWISE_LINK) }}"
+      "{{ play_store_url('lockwise')|safe }}",
+      "{{ app_store_url('lockwise') }}"
     ],
     "offers":
     {
@@ -432,7 +432,7 @@
     "sameAs": [
       "https://www.wikidata.org/wiki/Q56316099",
       "https://{{ lang_short() }}.wikipedia.org/wiki/Firefox_Nightly",
-      "{{ play_store_url(settings.GOOGLE_PLAY_FIREFOX_NIGHTLY_LINK)|safe }}",
+      "{{ play_store_url('firefox_nightly')|safe }}",
       "https://blog.nightly.mozilla.org/",
       "https://twitter.com/FirefoxNightly"
     ],
@@ -464,7 +464,7 @@
       "https://{{ lang_short() }}.wikipedia.org/wiki/Firefox_Send",
       "https://send.firefox.com",
       "https://www.wikidata.org/wiki/Q62394165",
-      "{{ play_store_url(settings.GOOGLE_PLAY_FIREFOX_SEND_LINK)|safe }}"
+      "{{ play_store_url('firefox_send')|safe }}"
     ],
     "offers":
     {

--- a/bedrock/base/templates/includes/structured-data/organizations/mozilla-corporation-organisation.json
+++ b/bedrock/base/templates/includes/structured-data/organizations/mozilla-corporation-organisation.json
@@ -1,15 +1,15 @@
 {
   "@context": "http://schema.org",
   "@type": "Organization",
-  "@id": "https://www.mozilla.org/#organization",
+  "@id": "{{ structured_data_id('organization') }}",
   "name": "Mozilla",
   "alternateName": "MoCo",
   "legalName": "Mozilla Corporation",
   "description": "Mozilla makes browsers, apps, code and tools that put people before profit. Our mission: Keep the internet open and accessible to all.",
-  "url": "https://www.mozilla.org",
-  "logo": "{% filter trim|absolute_url %}{{ static('img/mozorg/mozilla-256.jpg') }}{% endfilter %}",
+  "url": "{% filter absolute_url %}{{ url('mozorg.home') }}{% endfilter %}",
+  "logo": "{% filter absolute_url %}{{ static('img/mozorg/mozilla-256.jpg') }}{% endfilter %}",
   "diversityPolicy": "https://blog.mozilla.org/inclusion/mozilla-workplace-transition-policy-guidelines/",
-  "ethicsPolicy": "https://www.mozilla.org/about/manifesto/",
+  "ethicsPolicy": "{% filter absolute_url %}{{ url('mozorg.about.manifesto') }}{% endfilter %}",
   "foundingDate": "2005-08-03",
   "founder": "Mitchell Baker",
   "sameAs": [
@@ -19,23 +19,23 @@
     "https://github.com/mozilla",
     "https://www.instagram.com/mozilla/",
     "https://www.youtube.com/user/Mozilla",
-    "https://en.wikipedia.org/wiki/Mozilla_Corporation",
+    "https://{{ lang_short() }}.wikipedia.org/wiki/Mozilla_Corporation",
     "https://www.linkedin.com/company/mozilla-corporation"
   ],
   "brand": [
   {
     "@type": "brand",
-    "@id": "https://www.mozilla.org/#mozilla",
-    "url": "https://www.mozilla.org",
-    "logo": "{% filter trim|absolute_url %}{{ static('img/mozorg/mozilla-256.jpg') }}{% endfilter %}",
+    "@id": "{{ structured_data_id('mozilla') }}",
+    "url": "{% filter absolute_url %}{{ url('mozorg.home') }}{% endfilter %}",
+    "logo": "{% filter absolute_url %}{{ static('img/mozorg/mozilla-256.jpg') }}{% endfilter %}",
     "name": "Mozilla",
-    "sameAs": ["https://en.wikipedia.org/wiki/Mozilla", "https://www.wikidata.org/wiki/Q9661"]
+    "sameAs": ["https://{{ lang_short() }}.wikipedia.org/wiki/Mozilla", "https://www.wikidata.org/wiki/Q9661"]
   },
   {
     "@type": "brand",
-    "@id": "https://www.mozilla.org/#firefoxbrand",
-    "url": "https://www.mozilla.org/firefox/",
-    "logo": "{% filter trim|absolute_url %}{{ static('protocol/img/logos/firefox/logo-lg-high-res.png') }}{% endfilter %}",
+    "@id": "{{ structured_data_id('firefoxbrand') }}",
+    "url": "{% filter absolute_url %}{{ url('firefox') }}{% endfilter %}",
+    "logo": "{% filter absolute_url %}{{ static('protocol/img/logos/firefox/logo-lg-high-res.png') }}{% endfilter %}",
     "name": "Firefox",
     "sameAs": [
       "https://twitter.com/firefox",
@@ -46,13 +46,13 @@
   "owns": [
   {
     "@type": "Product",
-    "@id": "https://www.mozilla.org/#firefoxandroid",
-    "url": "https://www.mozilla.org/firefox/mobile/",
-    "logo": "{% filter trim|absolute_url %}{{ static('protocol/img/logos/firefox/browser/logo-lg-high-res.png') }}{% endfilter %}",
+    "@id": "{{ structured_data_id('firefoxandroid') }}",
+    "url": "{% filter absolute_url %}{{ url('firefox.mobile.index') }}{% endfilter %}",
+    "logo": "{% filter absolute_url %}{{ static('protocol/img/logos/firefox/browser/logo-lg-high-res.png') }}{% endfilter %}",
     "image": [
-      "{% filter trim|absolute_url %}{{ static('img/structured-data/browser-android-1.jpg') }}{% endfilter %}",
-      "{% filter trim|absolute_url %}{{ static('img/structured-data/browser-android-2.jpg') }}{% endfilter %}",
-      "{% filter trim|absolute_url %}{{ static('img/structured-data/browser-android-3.jpg') }}{% endfilter %}"
+      "{% filter absolute_url %}{{ static('img/structured-data/browser-android-1.jpg') }}{% endfilter %}",
+      "{% filter absolute_url %}{{ static('img/structured-data/browser-android-2.jpg') }}{% endfilter %}",
+      "{% filter absolute_url %}{{ static('img/structured-data/browser-android-3.jpg') }}{% endfilter %}"
     ],
     "name": "Firefox Browser Android",
     "alternateName": [
@@ -62,17 +62,17 @@
     ],
     "brand":
     {
-      "@id": "https://www.mozilla.org/#firefoxbrand"
+      "@id": "{{ structured_data_id('firefoxbrand') }}"
     },
     "sameAs": [
       "https://www.wikidata.org/wiki/Q550315",
-      "https://en.wikipedia.org/wiki/Firefox_for_Android",
-      "https://play.google.com/store/apps/details?id=org.mozilla.firefox"
+      "https://{{ lang_short() }}.wikipedia.org/wiki/Firefox_for_Android",
+      "{{ play_store_url(settings.GOOGLE_PLAY_FIREFOX_LINK)|safe }}"
     ],
     "offers":
     {
       "@type": "Offer",
-      "url": "https://play.google.com/store/apps/details?id=org.mozilla.firefox",
+      "url": "{{ play_store_url(settings.GOOGLE_PLAY_FIREFOX_LINK)|safe }}",
       "priceCurrency": "USD",
       "price": "0",
       "availability": "https://schema.org/InStock"
@@ -80,13 +80,13 @@
   },
   {
     "@type": "Product",
-    "@id": "https://www.mozilla.org/#firefoxbeta",
-    "url": "https://www.mozilla.org/en-US/firefox/channel/desktop/",
-    "logo": "{% filter trim|absolute_url %}{{ static('protocol/img/logos/firefox/browser/beta/logo-lg-high-res.png') }}{% endfilter %}",
+    "@id": "{{ structured_data_id('firefoxbeta') }}",
+    "url": "{% filter absolute_url %}{{ url('firefox.channel.desktop') }}{% endfilter %}",
+    "logo": "{% filter absolute_url %}{{ static('protocol/img/logos/firefox/browser/beta/logo-lg-high-res.png') }}{% endfilter %}",
     "image": [
-      "{% filter trim|absolute_url %}{{ static('img/structured-data/browser-beta-1.png') }}{% endfilter %}",
-      "{% filter trim|absolute_url %}{{ static('img/structured-data/browser-beta-2.png') }}{% endfilter %}",
-      "{% filter trim|absolute_url %}{{ static('img/structured-data/browser-beta-3.png') }}{% endfilter %}"
+      "{% filter absolute_url %}{{ static('img/structured-data/browser-beta-1.png') }}{% endfilter %}",
+      "{% filter absolute_url %}{{ static('img/structured-data/browser-beta-2.png') }}{% endfilter %}",
+      "{% filter absolute_url %}{{ static('img/structured-data/browser-beta-3.png') }}{% endfilter %}"
     ],
     "name": "Firefox Browser Beta",
     "alternateName": [
@@ -95,15 +95,15 @@
     ],
     "brand":
     {
-      "@id": "https://www.mozilla.org/#firefoxbrand"
+      "@id": "{{ structured_data_id('firefoxbrand') }}"
     },
     "sameAs": [
-      "https://play.google.com/store/apps/details?id=org.mozilla.firefox_beta"
+      "{{ play_store_url(settings.GOOGLE_PLAY_FIREFOX_BETA_LINK)|safe }}"
     ],
     "offers":
     {
       "@type": "Offer",
-      "url": "https://www.mozilla.org/en-US/firefox/channel/desktop/",
+      "url": "{% filter absolute_url %}{{ url('firefox.channel.desktop') }}{% endfilter %}",
       "priceCurrency": "USD",
       "price": "0",
       "availability": "https://schema.org/InStock"
@@ -111,13 +111,13 @@
   },
   {
     "@type": "Product",
-    "@id": "https://www.mozilla.org/#firefoxbrowser",
-    "url": "https://www.mozilla.org/firefox/new/",
-    "logo": "{% filter trim|absolute_url %}{{ static('protocol/img/logos/firefox/browser/logo-lg-high-res.png') }}{% endfilter %}",
+    "@id": "{{ structured_data_id('firefoxbrowser') }}",
+    "url": "{% filter absolute_url %}{{ url('firefox.new') }}{% endfilter %}",
+    "logo": "{% filter absolute_url %}{{ static('protocol/img/logos/firefox/browser/logo-lg-high-res.png') }}{% endfilter %}",
     "image": [
-      "{% filter trim|absolute_url %}{{ static('img/structured-data/browser-1.png') }}{% endfilter %}",
-      "{% filter trim|absolute_url %}{{ static('img/firefox/new/trailhead/browser-window.svg') }}{% endfilter %}",
-      "{% filter trim|absolute_url %}{{ static('img/structured-data/browser-3.png') }}{% endfilter %}"
+      "{% filter absolute_url %}{{ static('img/structured-data/browser-1.png') }}{% endfilter %}",
+      "{% filter absolute_url %}{{ static('img/firefox/new/trailhead/browser-window.svg') }}{% endfilter %}",
+      "{% filter absolute_url %}{{ static('img/structured-data/browser-3.png') }}{% endfilter %}"
     ],
     "name": "Firefox Browser",
     "alternateName": [
@@ -127,16 +127,16 @@
     ],
     "brand":
     {
-      "@id": "https://www.mozilla.org/#firefoxbrand"
+      "@id": "{{ settings.CANONICAL_URL }}/#firefoxbrand{{ sd_lang_suffix }}"
     },
     "sameAs": [
       "https://www.wikidata.org/wiki/Q698",
-      "https://en.wikipedia.org/wiki/Firefox"
+      "https://{{ lang_short() }}.wikipedia.org/wiki/Firefox"
     ],
     "offers":
     {
       "@type": "Offer",
-      "url": "https://www.mozilla.org/firefox/new/",
+      "url": "{% filter absolute_url %}{{ url('firefox.new') }}{% endfilter %}",
       "priceCurrency": "USD",
       "price": "0",
       "availability": "https://schema.org/InStock"
@@ -144,13 +144,13 @@
   },
   {
     "@type": "Product",
-    "@id": "https://www.mozilla.org/#firefoxdeveloper",
-    "url": "https://www.mozilla.org/en-US/firefox/developer/",
-    "logo": "{% filter trim|absolute_url %}{{ static('protocol/img/logos/firefox/browser/developer/logo-lg-high-res.png') }}{% endfilter %}",
+    "@id": "{{ structured_data_id('firefoxdeveloper') }}",
+    "url": "{% filter absolute_url %}{{ url('firefox.developer.index') }}{% endfilter %}",
+    "logo": "{% filter absolute_url %}{{ static('protocol/img/logos/firefox/browser/developer/logo-lg-high-res.png') }}{% endfilter %}",
     "image": [
-      "{% filter trim|absolute_url %}{{ static('img/firefox/developer/hero-screenshot-high-res.png') }}{% endfilter %}",
-      "{% filter trim|absolute_url %}{{ static('protocol/img/logos/firefox/browser/developer/og.png') }}{% endfilter %}",
-      "{% filter trim|absolute_url %}{{ static('img/firefox/developer/hero-debugger-ani.gif') }}{% endfilter %}"
+      "{% filter absolute_url %}{{ static('img/firefox/developer/hero-screenshot-high-res.png') }}{% endfilter %}",
+      "{% filter absolute_url %}{{ static('protocol/img/logos/firefox/browser/developer/og.png') }}{% endfilter %}",
+      "{% filter absolute_url %}{{ static('img/firefox/developer/hero-debugger-ani.gif') }}{% endfilter %}"
     ],
     "name": "Firefox Browser Developer Edition ",
     "alternateName": [
@@ -159,15 +159,15 @@
     ],
     "brand":
     {
-      "@id": "https://www.mozilla.org/#firefoxbrand"
+      "@id": "{{ structured_data_id('firefoxbrand') }}"
     },
     "sameAs": [
-      "https://en.wikipedia.org/wiki/Firefox_Developer_Edition"
+      "https://{{ lang_short() }}.wikipedia.org/wiki/Firefox_Developer_Edition"
     ],
     "offers":
     {
       "@type": "Offer",
-      "url": "https://www.mozilla.org/en-US/firefox/developer/",
+      "url": "{% filter absolute_url %}{{ url('firefox.developer.index') }}{% endfilter %}",
       "priceCurrency": "USD",
       "price": "0",
       "availability": "https://schema.org/InStock"
@@ -175,13 +175,13 @@
   },
   {
     "@type": "Product",
-    "@id": "https://www.mozilla.org/#firefoxenterprise",
-    "url": "https://www.mozilla.org/en-US/firefox/enterprise/",
-    "logo": "{% filter trim|absolute_url %}{{ static('protocol/img/logos/firefox/browser/logo-lg-high-res.png') }}{% endfilter %}",
+    "@id": "{{ structured_data_id('firefoxenterprise') }}",
+    "url": "{% filter absolute_url %}{{ url('firefox.enterprise.index') }}{% endfilter %}",
+    "logo": "{% filter absolute_url %}{{ static('protocol/img/logos/firefox/browser/logo-lg-high-res.png') }}{% endfilter %}",
     "image": [
-      "{% filter trim|absolute_url %}{{ static('img/firefox/enterprise/fx-browser-img.svg') }}{% endfilter %}",
-      "{% filter trim|absolute_url %}{{ static('img/structured-data/browser-enterprise-1.png') }}{% endfilter %}",
-      "{% filter trim|absolute_url %}{{ static('img/structured-data/browser-enterprise-2.png') }}{% endfilter %}"
+      "{% filter absolute_url %}{{ static('img/firefox/enterprise/fx-browser-img.svg') }}{% endfilter %}",
+      "{% filter absolute_url %}{{ static('img/structured-data/browser-enterprise-1.png') }}{% endfilter %}",
+      "{% filter absolute_url %}{{ static('img/structured-data/browser-enterprise-2.png') }}{% endfilter %}"
     ],
     "name": "Firefox Browser Enterprise",
     "alternateName": [
@@ -190,7 +190,7 @@
     ],
     "brand":
     {
-      "@id": "https://www.mozilla.org/#firefoxbrand"
+      "@id": "{{ structured_data_id('firefoxbrand') }}"
     },
     "sameAs": [
       "https://www.youtube.com/watch?v=pnQUOFgj3oA"
@@ -205,13 +205,13 @@
   },
   {
     "@type": "Product",
-    "@id": "https://www.mozilla.org/#firefoxfiretv",
-    "url": "https://support.mozilla.org/en-US/kb/firefox-fire-tv",
-    "logo": "{% filter trim|absolute_url %}{{ static('protocol/img/logos/firefox/browser/logo-lg-high-res.png') }}{% endfilter %}",
+    "@id": "{{ structured_data_id('firefoxfiretv') }}",
+    "url": "https://support.mozilla.org/{{ LANG }}/kb/firefox-fire-tv",
+    "logo": "{% filter absolute_url %}{{ static('protocol/img/logos/firefox/browser/logo-lg-high-res.png') }}{% endfilter %}",
     "image": [
-      "{% filter trim|absolute_url %}{{ static('img/structured-data/browser-tv-1.png') }}{% endfilter %}",
-      "{% filter trim|absolute_url %}{{ static('img/structured-data/browser-tv-2.png') }}{% endfilter %}",
-      "{% filter trim|absolute_url %}{{ static('img/structured-data/browser-tv-3.png') }}{% endfilter %}"
+      "{% filter absolute_url %}{{ static('img/structured-data/browser-tv-1.png') }}{% endfilter %}",
+      "{% filter absolute_url %}{{ static('img/structured-data/browser-tv-2.png') }}{% endfilter %}",
+      "{% filter absolute_url %}{{ static('img/structured-data/browser-tv-3.png') }}{% endfilter %}"
     ],
     "name": "Firefox Browser Fire TV",
     "alternateName": [
@@ -220,15 +220,15 @@
     ],
     "brand":
     {
-      "@id": "https://www.mozilla.org/#firefoxbrand"
+      "@id": "{{ structured_data_id('firefoxbrand') }}"
     },
     "sameAs": [
-      "https://www.amazon.com/Mozilla-Firefox-for-Fire-TV/dp/B078B5YMPD"
+      "{{ settings.AMAZON_FIREFOX_FIRE_TV_LINK }}"
     ],
     "offers":
     {
       "@type": "Offer",
-      "url": "https://www.amazon.com/Mozilla-Firefox-for-Fire-TV/dp/B078B5YMPD",
+      "url": "{{ settings.AMAZON_FIREFOX_FIRE_TV_LINK }}",
       "priceCurrency": "USD",
       "price": "0",
       "availability": "https://schema.org/InStock"
@@ -236,13 +236,13 @@
   },
   {
     "@type": "Product",
-    "@id": "https://www.mozilla.org/#firefoxios",
-    "url": "https://www.mozilla.org/firefox/mobile/",
-    "logo": "{% filter trim|absolute_url %}{{ static('protocol/img/logos/firefox/browser/logo-lg-high-res.png') }}{% endfilter %}",
+    "@id": "{{ structured_data_id('firefoxios') }}",
+    "url": "{% filter absolute_url %}{{ url('firefox.mobile.index') }}{% endfilter %}",
+    "logo": "{% filter absolute_url %}{{ static('protocol/img/logos/firefox/browser/logo-lg-high-res.png') }}{% endfilter %}",
     "image": [
-      "{% filter trim|absolute_url %}{{ static('img/structured-data/browser-ios-1.png') }}{% endfilter %}",
-      "{% filter trim|absolute_url %}{{ static('img/structured-data/browser-ios-2.png') }}{% endfilter %}",
-      "{% filter trim|absolute_url %}{{ static('img/structured-data/browser-ios-3.png') }}{% endfilter %}"
+      "{% filter absolute_url %}{{ static('img/structured-data/browser-ios-1.png') }}{% endfilter %}",
+      "{% filter absolute_url %}{{ static('img/structured-data/browser-ios-2.png') }}{% endfilter %}",
+      "{% filter absolute_url %}{{ static('img/structured-data/browser-ios-3.png') }}{% endfilter %}"
     ],
     "name": "Firefox Browser iOS",
     "alternateName": [
@@ -252,17 +252,17 @@
     ],
     "brand":
     {
-      "@id": "https://www.mozilla.org/#firefoxbrand"
+      "@id": "{{ structured_data_id('firefoxbrand') }}"
     },
     "sameAs": [
       "https://www.wikidata.org/wiki/Q20820972",
-      "https://en.wikipedia.org/wiki/Firefox_for_iOS",
-      "https://apps.apple.com/us/app/firefox-private-safe-browser/id989804926"
+      "https://{{ lang_short() }}.wikipedia.org/wiki/Firefox_for_iOS",
+      "{{ firefox_ios_url() }}"
     ],
     "offers":
     {
       "@type": "Offer",
-      "url": "https://apps.apple.com/us/app/firefox-private-safe-browser/id989804926",
+      "url": "{{ firefox_ios_url() }}",
       "priceCurrency": "USD",
       "price": "0",
       "availability": "https://schema.org/InStock"
@@ -270,13 +270,13 @@
   },
   {
     "@type": "Product",
-    "@id": "https://www.mozilla.org/#firefoxlinux",
-    "url": "https://www.mozilla.org/en-US/firefox/linux/",
-    "logo": "{% filter trim|absolute_url %}{{ static('protocol/img/logos/firefox/browser/logo-lg-high-res.png') }}{% endfilter %}",
+    "@id": "{{ structured_data_id('firefoxlinux') }}",
+    "url": "{% filter absolute_url %}{{ url('firefox.new.scene1_linux') }}{% endfilter %}",
+    "logo": "{% filter absolute_url %}{{ static('protocol/img/logos/firefox/browser/logo-lg-high-res.png') }}{% endfilter %}",
     "image": [
-      "{% filter trim|absolute_url %}{{ static('img/firefox/new/browser-high-res.png') }}{% endfilter %}",
-      "{% filter trim|absolute_url %}{{ static('img/structured-data/browser-linux-2.png') }}{% endfilter %}",
-      "{% filter trim|absolute_url %}{{ static('img/structured-data/browser-linux-3.png') }}{% endfilter %}"
+      "{% filter absolute_url %}{{ static('img/firefox/new/browser-high-res.png') }}{% endfilter %}",
+      "{% filter absolute_url %}{{ static('img/structured-data/browser-linux-2.png') }}{% endfilter %}",
+      "{% filter absolute_url %}{{ static('img/structured-data/browser-linux-3.png') }}{% endfilter %}"
     ],
     "name": "Firefox Browser Linux",
     "alternateName": [
@@ -285,12 +285,12 @@
     ],
     "brand":
     {
-      "@id": "https://www.mozilla.org/#firefoxbrand"
+      "@id": "{{ structured_data_id('firefoxbrand') }}"
     },
     "offers":
     {
       "@type": "Offer",
-      "url": "https://www.mozilla.org/en-US/firefox/linux/",
+      "url": "{% filter absolute_url %}{{ url('firefox.new.scene1_linux') }}{% endfilter %}",
       "priceCurrency": "USD",
       "price": "0",
       "availability": "https://schema.org/InStock"
@@ -298,26 +298,26 @@
   },
   {
     "@type": "Product",
-    "@id": "https://www.mozilla.org/#firefoxlite",
-    "url": "https://support.mozilla.org/en-US/kb/get-started-firefox-lite",
-    "logo": "{% filter trim|absolute_url %}{{ static('img/logos/firefox/logo-lite.png') }}{% endfilter %}",
+    "@id": "{{ structured_data_id('firefoxlite') }}",
+    "url": "https://support.mozilla.org/{{ LANG }}/kb/get-started-firefox-lite",
+    "logo": "{% filter absolute_url %}{{ static('img/logos/firefox/logo-lite.png') }}{% endfilter %}",
     "image": [
-      "{% filter trim|absolute_url %}{{ static('img/structured-data/browser-lite-1.jpg') }}{% endfilter %}",
-      "{% filter trim|absolute_url %}{{ static('img/structured-data/browser-lite-2.jpg') }}{% endfilter %}",
-      "{% filter trim|absolute_url %}{{ static('img/structured-data/browser-lite-3.jpg') }}{% endfilter %}"
+      "{% filter absolute_url %}{{ static('img/structured-data/browser-lite-1.jpg') }}{% endfilter %}",
+      "{% filter absolute_url %}{{ static('img/structured-data/browser-lite-2.jpg') }}{% endfilter %}",
+      "{% filter absolute_url %}{{ static('img/structured-data/browser-lite-3.jpg') }}{% endfilter %}"
     ],
     "name": "Firefox Lite",
     "brand":
     {
-      "@id": "https://www.mozilla.org/#firefoxbrand"
+      "@id": "{{ structured_data_id('firefoxbrand') }}"
     },
     "sameAs": [
-      "https://play.google.com/store/apps/details?id=org.mozilla.rocket"
+      "{{ play_store_url(settings.GOOGLE_PLAY_FIREFOX_LITE_LINK)|safe }}"
     ],
     "offers":
     {
       "@type": "Offer",
-      "url": "https://play.google.com/store/apps/details?id=org.mozilla.rocket",
+      "url": "{{ play_store_url(settings.GOOGLE_PLAY_FIREFOX_LITE_LINK)|safe }}",
       "priceCurrency": "USD",
       "price": "0",
       "availability": "https://schema.org/InStock"
@@ -325,29 +325,29 @@
   },
   {
     "@type": "Product",
-    "@id": "https://www.mozilla.org/#firefoxlockwise",
-    "url": "https://www.mozilla.org/en-US/firefox/lockwise/",
-    "logo": "{% filter trim|absolute_url %}{{ static('protocol/img/logos/firefox/lockwise/logo-lg-high-res.png') }}{% endfilter %}",
+    "@id": "{{ structured_data_id('firefoxlockwise') }}",
+    "url": "{% filter absolute_url %}{{ url('firefox.lockwise.lockwise') }}{% endfilter %}",
+    "logo": "{% filter absolute_url %}{{ static('protocol/img/logos/firefox/lockwise/logo-lg-high-res.png') }}{% endfilter %}",
     "image": [
-      "{% filter trim|absolute_url %}{{ static('img/structured-data/lockwise.png') }}{% endfilter %}",
-      "{% filter trim|absolute_url %}{{ static('img/structured-data/lockwise-onboarding.png') }}{% endfilter %}",
-      "{% filter trim|absolute_url %}{{ static('img/structured-data/lockwise-autofill.png') }}{% endfilter %}"
+      "{% filter absolute_url %}{{ static('img/structured-data/lockwise.png') }}{% endfilter %}",
+      "{% filter absolute_url %}{{ static('img/structured-data/lockwise-onboarding.png') }}{% endfilter %}",
+      "{% filter absolute_url %}{{ static('img/structured-data/lockwise-autofill.png') }}{% endfilter %}"
     ],
     "name": "Firefox Lockwise",
     "brand":
     {
-      "@id": "https://www.mozilla.org/#firefoxbrand"
+      "@id": "{{ structured_data_id('firefoxbrand') }}"
     },
     "sameAs": [
-      "https://en.wikipedia.org/wiki/Firefox_Lockwise",
+      "https://{{ lang_short() }}.wikipedia.org/wiki/Firefox_Lockwise",
       "https://www.wikidata.org/wiki/Q64829394",
-      "https://play.google.com/store/apps/details?id=mozilla.lockbox",
-      "https://apps.apple.com/us/app/firefox-lockbox/id1314000270"
+      "{{ play_store_url(settings.GOOGLE_PLAY_LOCKWISE_LINK)|safe }}",
+      "{{ app_store_url(settings.APPLE_APPSTORE_LOCKWISE_LINK) }}"
     ],
     "offers":
     {
       "@type": "Offer",
-      "url": "https://www.mozilla.org/en-US/firefox/lockwise/",
+      "url": "{% filter absolute_url %}{{ url('firefox.lockwise.lockwise') }}{% endfilter %}",
       "priceCurrency": "USD",
       "price": "0",
       "availability": "https://schema.org/InStock"
@@ -355,13 +355,13 @@
   },
   {
     "@type": "Product",
-    "@id": "https://www.mozilla.org/#firefoxmac",
-    "url": "https://www.mozilla.org/en-US/firefox/mac/",
-    "logo": "{% filter trim|absolute_url %}{{ static('protocol/img/logos/firefox/browser/logo-lg-high-res.png') }}{% endfilter %}",
+    "@id": "{{ structured_data_id('firefoxmac') }}",
+    "url": "{% filter absolute_url %}{{ url('firefox.new.scene1_mac') }}{% endfilter %}",
+    "logo": "{% filter absolute_url %}{{ static('protocol/img/logos/firefox/browser/logo-lg-high-res.png') }}{% endfilter %}",
     "image": [
-      "{% filter trim|absolute_url %}{{ static('img/firefox/new/browser-high-res.png') }}{% endfilter %}",
-      "{% filter trim|absolute_url %}{{ static('img/structured-data/browser-mac-2.png') }}{% endfilter %}",
-      "{% filter trim|absolute_url %}{{ static('img/structured-data/browser-mac-3.png') }}{% endfilter %}"
+      "{% filter absolute_url %}{{ static('img/firefox/new/browser-high-res.png') }}{% endfilter %}",
+      "{% filter absolute_url %}{{ static('img/structured-data/browser-mac-2.png') }}{% endfilter %}",
+      "{% filter absolute_url %}{{ static('img/structured-data/browser-mac-3.png') }}{% endfilter %}"
     ],
     "name": "Firefox Browser Mac",
     "alternateName": [
@@ -370,12 +370,12 @@
     ],
     "brand":
     {
-      "@id": "https://www.mozilla.org/#firefoxbrand"
+      "@id": "{{ structured_data_id('firefoxbrand') }}"
     },
     "offers":
     {
       "@type": "Offer",
-      "url": "https://www.mozilla.org/en-US/firefox/mac/",
+      "url": "{% filter absolute_url %}{{ url('firefox.new.scene1_mac') }}{% endfilter %}",
       "priceCurrency": "USD",
       "price": "0",
       "availability": "https://schema.org/InStock"
@@ -383,28 +383,28 @@
   },
   {
     "@type": "Product",
-    "@id": "https://www.mozilla.org/#firefoxmonitor",
+    "@id": "{{ structured_data_id('firefoxmonitor') }}",
     "url": "https://monitor.firefox.com",
-    "logo": "{% filter trim|absolute_url %}{{ static('protocol/img/logos/firefox/monitor/logo-lg-high-res.png') }}{% endfilter %}",
+    "logo": "{% filter absolute_url %}{{ static('protocol/img/logos/firefox/monitor/logo-lg-high-res.png') }}{% endfilter %}",
     "image": [
-      "{% filter trim|absolute_url %}{{ static('img/structured-data/monitor.png') }}{% endfilter %}",
-      "{% filter trim|absolute_url %}{{ static('img/firefox/accounts/trailhead/value-respect-high-res.jpg') }}{% endfilter %}",
-      "{% filter trim|absolute_url %}{{ static('img/firefox/accounts/trailhead/value-knowledge-high-res.jpg') }}{% endfilter %}"
+      "{% filter absolute_url %}{{ static('img/structured-data/monitor.png') }}{% endfilter %}",
+      "{% filter absolute_url %}{{ static('img/firefox/accounts/trailhead/value-respect-high-res.jpg') }}{% endfilter %}",
+      "{% filter absolute_url %}{{ static('img/firefox/accounts/trailhead/value-knowledge-high-res.jpg') }}{% endfilter %}"
     ],
     "name": "Firefox Monitor",
     "brand":
     {
-      "@id": "https://www.mozilla.org/#firefoxbrand"
+      "@id": "{{ structured_data_id('firefoxbrand') }}"
     },
     "sameAs": [
       "https://www.wikidata.org/wiki/Q64828890",
       "https://monitor.firefox.com",
-      "https://en.wikipedia.org/wiki/Firefox_Monitor"
+      "https://{{ lang_short() }}.wikipedia.org/wiki/Firefox_Monitor"
     ],
     "offers":
     {
       "@type": "Offer",
-      "@id": "https://www.mozilla.org/#firefoxmonitor",
+      "@id": "{{ structured_data_id('firefoxmonitor') }}",
       "priceCurrency": "USD",
       "price": "0",
       "availability": "https://schema.org/InStock"
@@ -412,13 +412,13 @@
   },
   {
     "@type": "Product",
-    "@id": "https://www.mozilla.org/#firefoxnightly",
-    "url": "https://www.mozilla.org/en-US/firefox/channel/desktop/",
+    "@id": "{{ structured_data_id('firefoxnightly') }}",
+    "url": "{% filter absolute_url %}{{ url('firefox.channel.desktop') }}{% endfilter %}",
     "logo": "{% filter trim|absolute_url %}{{ static('protocol/img/logos/firefox/browser/nightly/logo-lg-high-res.png') }}{% endfilter %}",
     "image": [
-      "{% filter trim|absolute_url %}{{ static('img/structured-data/browser-nightly-1.png') }}{% endfilter %}",
-      "{% filter trim|absolute_url %}{{ static('img/structured-data/browser-nightly-2.png') }}{% endfilter %}",
-      "{% filter trim|absolute_url %}{{ static('img/structured-data/browser-nightly-3.gif') }}{% endfilter %}"
+      "{% filter absolute_url %}{{ static('img/structured-data/browser-nightly-1.png') }}{% endfilter %}",
+      "{% filter absolute_url %}{{ static('img/structured-data/browser-nightly-2.png') }}{% endfilter %}",
+      "{% filter absolute_url %}{{ static('img/structured-data/browser-nightly-3.gif') }}{% endfilter %}"
     ],
     "name": "Firefox Browser Nightly",
     "alternateName": [
@@ -427,19 +427,19 @@
     ],
     "brand":
     {
-      "@id": "https://www.mozilla.org/#firefoxbrand"
+      "@id": "{{ structured_data_id('firefoxbrand') }}"
     },
     "sameAs": [
       "https://www.wikidata.org/wiki/Q56316099",
-      "https://es.wikipedia.org/wiki/Firefox_Nightly",
-      "https://play.google.com/store/apps/details?id=org.mozilla.fennec_aurora",
+      "https://{{ lang_short() }}.wikipedia.org/wiki/Firefox_Nightly",
+      "{{ play_store_url(settings.GOOGLE_PLAY_FIREFOX_NIGHTLY_LINK)|safe }}",
       "https://blog.nightly.mozilla.org/",
       "https://twitter.com/FirefoxNightly"
     ],
     "offers":
     {
       "@type": "Offer",
-      "url": "https://www.mozilla.org/en-US/firefox/channel/desktop/",
+      "url": "{% filter absolute_url %}{{ url('firefox.channel.desktop') }}{% endfilter %}",
       "priceCurrency": "USD",
       "price": "0",
       "availability": "https://schema.org/InStock"
@@ -447,24 +447,24 @@
   },
   {
     "@type": "Product",
-    "@id": "https://www.mozilla.org/#firefoxsend",
+    "@id": "{{ structured_data_id('firefoxsend') }}",
     "url": "https://send.firefox.com",
-    "logo": "{% filter trim|absolute_url %}{{ static('protocol/img/logos/firefox/send/logo-lg-high-res.png') }}{% endfilter %}",
+    "logo": "{% filter absolute_url %}{{ static('protocol/img/logos/firefox/send/logo-lg-high-res.png') }}{% endfilter %}",
     "image": [
-      "{% filter trim|absolute_url %}{{ static('img/structured-data/send-1.png') }}{% endfilter %}",
-      "{% filter trim|absolute_url %}{{ static('img/structured-data/send-2.png') }}{% endfilter %}",
-      "{% filter trim|absolute_url %}{{ static('img/structured-data/send-3.png') }}{% endfilter %}"
+      "{% filter absolute_url %}{{ static('img/structured-data/send-1.png') }}{% endfilter %}",
+      "{% filter absolute_url %}{{ static('img/structured-data/send-2.png') }}{% endfilter %}",
+      "{% filter absolute_url %}{{ static('img/structured-data/send-3.png') }}{% endfilter %}"
     ],
     "name": "Firefox Send",
     "brand":
     {
-      "@id": "https://www.mozilla.org/#firefoxbrand"
+      "@id": "{{ structured_data_id('firefoxbrand') }}"
     },
     "sameAs": [
-      "https://en.wikipedia.org/wiki/Firefox_Send",
+      "https://{{ lang_short() }}.wikipedia.org/wiki/Firefox_Send",
       "https://send.firefox.com",
       "https://www.wikidata.org/wiki/Q62394165",
-      "https://play.google.com/store/apps/details?id=org.mozilla.firefoxsend"
+      "{{ play_store_url(settings.GOOGLE_PLAY_FIREFOX_SEND_LINK)|safe }}"
     ],
     "offers":
     {
@@ -477,13 +477,13 @@
   },
   {
     "@type": "Product",
-    "@id": "https://www.mozilla.org/#firefoxwindows",
-    "url": "https://www.mozilla.org/en-US/firefox/windows/",
-    "logo": "{% filter trim|absolute_url %}{{ static('protocol/img/logos/firefox/browser/logo-lg-high-res.png') }}{% endfilter %}",
+    "@id": "{{ structured_data_id('firefoxwindows') }}",
+    "url": "{% filter absolute_url %}{{ url('firefox.new.scene1_windows') }}{% endfilter %}",
+    "logo": "{% filter absolute_url %}{{ static('protocol/img/logos/firefox/browser/logo-lg-high-res.png') }}{% endfilter %}",
     "image": [
-      "{% filter trim|absolute_url %}{{ static('img/firefox/new/browser-high-res.png') }}{% endfilter %}",
-      "{% filter trim|absolute_url %}{{ static('img/firefox/new/trailhead/browser-window.svg') }}{% endfilter %}",
-      "{% filter trim|absolute_url %}{{ static('img/structured-data/browser-win-3.png') }}{% endfilter %}"
+      "{% filter absolute_url %}{{ static('img/firefox/new/browser-high-res.png') }}{% endfilter %}",
+      "{% filter absolute_url %}{{ static('img/firefox/new/trailhead/browser-window.svg') }}{% endfilter %}",
+      "{% filter absolute_url %}{{ static('img/structured-data/browser-win-3.png') }}{% endfilter %}"
     ],
     "name": "Firefox Browser Windows",
     "alternateName": [
@@ -492,12 +492,12 @@
     ],
     "brand":
     {
-      "@id": "https://www.mozilla.org/#firefoxbrand"
+      "@id": "{{ structured_data_id('firefoxbrand') }}"
     },
     "offers":
     {
       "@type": "Offer",
-      "url": "https://www.mozilla.org/en-US/firefox/windows/",
+      "url": "{% filter absolute_url %}{{ url('firefox.new.scene1_windows') }}{% endfilter %}",
       "priceCurrency": "USD",
       "price": "0",
       "availability": "https://schema.org/InStock"
@@ -506,13 +506,13 @@
   "parentOrganization":
   {
     "@type": "NGO",
-    "@id": "https://foundation.mozilla.org/#organisation",
+    "@id": "{{ structured_data_id('organisation', 'https://foundation.mozilla.org') }}",
     "name": "Mozilla Foundation",
-    "url": "https://foundation.mozilla.org",
+    "url": "https://foundation.mozilla.org/",
     "sameAs": [
       "https://www.wikidata.org/wiki/Q55672",
-      "https://foundation.mozilla.org",
-      "https://en.wikipedia.org/wiki/Mozilla_Foundation"
+      "https://foundation.mozilla.org/",
+      "https://{{ lang_short() }}.wikipedia.org/wiki/Mozilla_Foundation"
     ]
   }
 }

--- a/bedrock/base/templates/includes/structured-data/software/firefox-android-software.json
+++ b/bedrock/base/templates/includes/structured-data/software/firefox-android-software.json
@@ -13,12 +13,12 @@
   "sameAs": [
     "https://www.wikidata.org/wiki/Q550315",
     "https://{{ lang_short() }}.wikipedia.org/wiki/Firefox_for_Android",
-    "{{ play_store_url(settings.GOOGLE_PLAY_FIREFOX_LINK)|safe }}"
+    "{{ play_store_url('firefox')|safe }}"
   ],
   "offers":
   {
     "@type": "Offer",
-    "url": "{{ play_store_url(settings.GOOGLE_PLAY_FIREFOX_LINK)|safe }}",
+    "url": "{{ play_store_url('firefox')|safe }}",
     "priceCurrency": "USD",
     "price": "0",
     "availability": "https://schema.org/InStock"

--- a/bedrock/base/templates/includes/structured-data/software/firefox-android-software.json
+++ b/bedrock/base/templates/includes/structured-data/software/firefox-android-software.json
@@ -1,10 +1,10 @@
 {
   "@context": "https://schema.org/",
   "@type": "MobileApplication",
-  "@id": "https://www.mozilla.org/#firefoxandroid",
-  "url": "https://www.mozilla.org/firefox/mobile/",
+  "@id": "{{ structured_data_id('firefoxandroid') }}",
+  "url": "{% filter absolute_url %}{{ url('firefox.mobile.index') }}{% endfilter %}",
   "name": "Firefox Browser Android",
-  "image": "{% filter trim|absolute_url %}{{ static('protocol/img/logos/firefox/browser/logo-lg-high-res.png') }}{% endfilter %}",
+  "image": "{% filter absolute_url %}{{ static('protocol/img/logos/firefox/browser/logo-lg-high-res.png') }}{% endfilter %}",
   "alternateName": [
     "Firefox Android",
     "Firefox Browser for Android",
@@ -12,13 +12,13 @@
   ],
   "sameAs": [
     "https://www.wikidata.org/wiki/Q550315",
-    "https://en.wikipedia.org/wiki/Firefox_for_Android",
-    "https://play.google.com/store/apps/details?id=org.mozilla.firefox"
+    "https://{{ lang_short() }}.wikipedia.org/wiki/Firefox_for_Android",
+    "{{ play_store_url(settings.GOOGLE_PLAY_FIREFOX_LINK)|safe }}"
   ],
   "offers":
   {
     "@type": "Offer",
-    "url": "https://play.google.com/store/apps/details?id=org.mozilla.firefox",
+    "url": "{{ play_store_url(settings.GOOGLE_PLAY_FIREFOX_LINK)|safe }}",
     "priceCurrency": "USD",
     "price": "0",
     "availability": "https://schema.org/InStock"
@@ -29,19 +29,19 @@
   "author":
   {
     "@type": "Organization",
-    "@id": "https://www.mozilla.org/#organization",
+    "@id": "{{ structured_data_id('organization') }}",
     "name": "Mozilla Corporation"
   },
   "softwareHelp":
   {
     "@type": "Webpage",
-    "url": "https://support.mozilla.org/en-US/products/mobile"
+    "url": "https://support.mozilla.org/{{ LANG }}/products/mobile"
   },
-  "releaseNotes": "https://www.mozilla.org/en-US/firefox/android/notes/",
+  "releaseNotes": "{% filter absolute_url %}{{ url('firefox.notes', platform='android') }}{% endfilter %}",
   "isPartOf":
   {
-    "@id": "https://www.mozilla.org/#firefoxbrowser",
-    "url": "https://www.mozilla.org/firefox/new/",
+    "@id": "{{ structured_data_id('firefoxbrowser') }}",
+    "url": "{% filter absolute_url %}{{ url('firefox.new') }}{% endfilter %}",
     "name": "Firefox Browser"
   }
 }

--- a/bedrock/base/templates/includes/structured-data/software/firefox-beta-software.json
+++ b/bedrock/base/templates/includes/structured-data/software/firefox-beta-software.json
@@ -10,7 +10,7 @@
     "Firefox Beta Browser"
   ],
   "sameAs": [
-    "{{ play_store_url(settings.GOOGLE_PLAY_FIREFOX_BETA_LINK)|safe }}"
+    "{{ play_store_url('firefox_beta')|safe }}"
   ],
   "offers":
   {

--- a/bedrock/base/templates/includes/structured-data/software/firefox-beta-software.json
+++ b/bedrock/base/templates/includes/structured-data/software/firefox-beta-software.json
@@ -1,21 +1,21 @@
 {
   "@context": "https://schema.org/",
   "@type": "SoftwareApplication",
-  "@id": "https://www.mozilla.org/#firefoxbeta",
-  "url": "https://www.mozilla.org/en-US/firefox/channel/desktop/",
+  "@id": "{{ structured_data_id('firefoxbeta') }}",
+  "url": "{% filter absolute_url %}{{ url('firefox.channel.desktop') }}{% endfilter %}",
   "name": "Firefox Browser Beta",
-  "image": "{% filter trim|absolute_url %}{{ static('protocol/img/logos/firefox/browser/beta/logo-lg-high-res.png') }}{% endfilter %}",
+  "image": "{% filter absolute_url %}{{ static('protocol/img/logos/firefox/browser/beta/logo-lg-high-res.png') }}{% endfilter %}",
   "alternateName": [
     "Firefox Beta",
     "Firefox Beta Browser"
   ],
   "sameAs": [
-    "https://play.google.com/store/apps/details?id=org.mozilla.firefox_beta"
+    "{{ play_store_url(settings.GOOGLE_PLAY_FIREFOX_BETA_LINK)|safe }}"
   ],
   "offers":
   {
     "@type": "Offer",
-    "url": "https://www.mozilla.org/en-US/firefox/channel/desktop/",
+    "url": "{% filter absolute_url %}{{ url('firefox.channel.desktop') }}{% endfilter %}",
     "priceCurrency": "USD",
     "price": "0",
     "availability": "https://schema.org/InStock"
@@ -32,14 +32,14 @@
   "author":
   {
     "@type": "Organization",
-    "@id": "https://www.mozilla.org/#organization",
+    "@id": "{{ structured_data_id('organization') }}",
     "name": "Mozilla Corporation"
   },
-  "releaseNotes": "https://www.mozilla.org/en-US/firefox/beta/notes/",
+  "releaseNotes": "{% filter absolute_url %}{{ url('firefox.notes', channel='beta') }}{% endfilter %}",
   "isPartOf":
   {
-    "@id": "https://www.mozilla.org/#firefoxbrowser",
-    "url": "https://www.mozilla.org/firefox/new/",
+    "@id": "{{ structured_data_id('firefoxbrowser') }}",
+    "url": "{% filter absolute_url %}{{ url('firefox.new') }}{% endfilter %}",
     "name": "Firefox Browser"
   }
 }

--- a/bedrock/base/templates/includes/structured-data/software/firefox-browser-software.json
+++ b/bedrock/base/templates/includes/structured-data/software/firefox-browser-software.json
@@ -1,10 +1,10 @@
 {
   "@context": "https://schema.org/",
   "@type": "SoftwareApplication",
-  "@id": "https://www.mozilla.org/#firefoxbrowser",
-  "url": "https://www.mozilla.org/firefox/new/",
+  "@id": "{{ structured_data_id('firefoxbrowser') }}",
+  "url": "{% filter absolute_url %}{{ url('firefox.new') }}{% endfilter %}",
   "name": "Firefox Browser",
-  "image": "{% filter trim|absolute_url %}{{ static('protocol/img/logos/firefox/browser/logo-lg-high-res.png') }}{% endfilter %}",
+  "image": "{% filter absolute_url %}{{ static('protocol/img/logos/firefox/browser/logo-lg-high-res.png') }}{% endfilter %}",
   "alternateName": [
     "Firefox Desktop",
     "Firefox Browser for Desktop",
@@ -12,7 +12,7 @@
   ],
   "sameAs": [
     "https://www.wikidata.org/wiki/Q698",
-    "https://en.wikipedia.org/wiki/Firefox"
+    "https://{{ lang_short() }}.wikipedia.org/wiki/Firefox"
   ],
   "offers":
   {
@@ -32,69 +32,69 @@
   "author":
   {
     "@type": "Organization",
-    "@id": "https://www.mozilla.org/#organization",
+    "@id": "{{ structured_data_id('organization') }}",
     "name": "Mozilla Corporation"
   },
   "softwareHelp":
   {
     "@type": "Webpage",
-    "url": "https://support.mozilla.org/de/products/firefox"
+    "url": "https://support.mozilla.org/{{ LANG }}/products/firefox"
   },
-  "releaseNotes": "https://www.mozilla.org/en-US/firefox/notes/",
+  "releaseNotes": "{% filter absolute_url %}{{ url('firefox.notes') }}{% endfilter %}",
   "hasPart": [
   {
-    "@id": "https://www.mozilla.org/#firefoxandroid",
-    "url": "https://www.mozilla.org/firefox/mobile/",
+    "@id": "{{ structured_data_id('firefoxandroid') }}",
+    "url": "{% filter absolute_url %}{{ url('firefox.mobile.index') }}{% endfilter %}",
     "name": "Firefox Browser Android"
   },
   {
-    "@id": "https://www.mozilla.org/#firefoxios",
-    "url": "https://www.mozilla.org/firefox/mobile/",
+    "@id": "{{ structured_data_id('firefoxios') }}",
+    "url": "{% filter absolute_url %}{{ url('firefox.mobile.index') }}{% endfilter %}",
     "name": "Firefox Browser iOS"
   },
   {
-    "@id": "https://www.mozilla.org/#firefoxbeta",
-    "url": "https://www.mozilla.org/en-US/firefox/channel/desktop/",
+    "@id": "{{ structured_data_id('firefoxbeta') }}",
+    "url": "{% filter absolute_url %}{{ url('firefox.channel.desktop') }}{% endfilter %}",
     "name": "Firefox Browser Beta"
   },
   {
-    "@id": "https://www.mozilla.org/#firefoxdeveloper",
-    "url": "https://www.mozilla.org/en-US/firefox/developer/",
+    "@id": "{{ structured_data_id('firefoxdeveloper') }}",
+    "url": "{% filter absolute_url %}{{ url('firefox.developer.index') }}{% endfilter %}",
     "name": "Firefox Browser Developer Edition "
   },
   {
-    "@id": "https://www.mozilla.org/#firefoxenterprise",
-    "url": "https://www.mozilla.org/en-US/firefox/enterprise/",
+    "@id": "{{ structured_data_id('firefoxenterprise') }}",
+    "url": "{% filter absolute_url %}{{ url('firefox.enterprise.index') }}{% endfilter %}",
     "name": "Firefox Browser Enterprise"
   },
   {
-    "@id": "https://www.mozilla.org/#firefoxfiretv",
-    "url": "https://support.mozilla.org/en-US/kb/firefox-fire-tv",
+    "@id": "{{ structured_data_id('firefoxfiretv') }}",
+    "url": "https://support.mozilla.org/{{ LANG }}/kb/firefox-fire-tv",
     "name": "Firefox Browser Fire TV"
   },
   {
-    "@id": "https://www.mozilla.org/#firefoxlite",
-    "url": "https://support.mozilla.org/en-US/kb/get-started-firefox-lite",
+    "@id": "{{ structured_data_id('firefoxlite') }}",
+    "url": "https://support.mozilla.org/{{ LANG }}/kb/get-started-firefox-lite",
     "name": "Firefox Lite"
   },
   {
-    "@id": "https://www.mozilla.org/#firefoxnightly",
-    "url": "https://www.mozilla.org/en-US/firefox/channel/desktop/",
+    "@id": "{{ structured_data_id('firefoxnightly') }}",
+    "url": "{% filter absolute_url %}{{ url('firefox.channel.desktop') }}{% endfilter %}",
     "name": "Firefox Browser Nightly"
   },
   {
-    "@id": "https://www.mozilla.org/#firefoxmac",
-    "url": "https://www.mozilla.org/en-US/firefox/mac/",
+    "@id": "{{ structured_data_id('firefoxmac') }}",
+    "url": "{% filter absolute_url %}{{ url('firefox.new.scene1_mac') }}{% endfilter %}",
     "name": "Firefox Browser Mac"
   },
   {
-    "@id": "https://www.mozilla.org/#firefoxlinux",
-    "url": "https://www.mozilla.org/en-US/firefox/linux/",
+    "@id": "{{ structured_data_id('firefoxlinux') }}",
+    "url": "{% filter absolute_url %}{{ url('firefox.new.scene1_linux') }}{% endfilter %}",
     "name": "Firefox Browser Linux"
   },
   {
-    "@id": "https://www.mozilla.org/#firefoxwindows",
-    "url": "https://www.mozilla.org/en-US/firefox/windows/",
+    "@id": "{{ structured_data_id('firefoxwindows') }}",
+    "url": "{% filter absolute_url %}{{ url('firefox.new.scene1_windows') }}{% endfilter %}",
     "name": "Firefox Browser Windows"
   }]
 }

--- a/bedrock/base/templates/includes/structured-data/software/firefox-developer-software.json
+++ b/bedrock/base/templates/includes/structured-data/software/firefox-developer-software.json
@@ -1,10 +1,10 @@
 {
   "@context": "https://schema.org/",
   "@type": "SoftwareApplication",
-  "@id": "https://www.mozilla.org/#firefoxdeveloper",
-  "url": "https://www.mozilla.org/en-US/firefox/developer/",
+  "@id": "{{ structured_data_id('firefoxdeveloper') }}",
+  "url": "{% filter absolute_url %}{{ url('firefox.developer.index') }}{% endfilter %}",
   "name": "Firefox Browser Developer Edition ",
-  "image": "{% filter trim|absolute_url %}{{ static('protocol/img/logos/firefox/browser/developer/logo-lg-high-res.png') }}{% endfilter %}",
+  "image": "{% filter absolute_url %}{{ static('protocol/img/logos/firefox/browser/developer/logo-lg-high-res.png') }}{% endfilter %}",
   "alternateName": [
     "Firefox Developer Edition",
     "Firefox Developer Edition Browser"
@@ -27,14 +27,14 @@
   "author":
   {
     "@type": "Organization",
-    "@id": "https://www.mozilla.org/#organization",
+    "@id": "{{ structured_data_id('organization') }}",
     "name": "Mozilla Corporation"
   },
-  "releaseNotes": "https://www.mozilla.org/en-US/firefox/developer/notes/",
+  "releaseNotes": "{% filter absolute_url %}{{ url('firefox.notes', channel='developer') }}{% endfilter %}",
   "isPartOf":
   {
-    "@id": "https://www.mozilla.org/#firefoxbrowser",
-    "url": "https://www.mozilla.org/firefox/new/",
+    "@id": "{{ structured_data_id('firefoxbrowser') }}",
+    "url": "{% filter absolute_url %}{{ url('firefox.new') }}{% endfilter %}",
     "name": "Firefox Browser"
   }
 }

--- a/bedrock/base/templates/includes/structured-data/software/firefox-enterprise-software.json
+++ b/bedrock/base/templates/includes/structured-data/software/firefox-enterprise-software.json
@@ -1,10 +1,10 @@
 {
   "@context": "https://schema.org/",
   "@type": "SoftwareApplication",
-  "@id": "https://www.mozilla.org/#firefoxenterprise",
-  "url": "https://www.mozilla.org/en-US/firefox/enterprise/",
+  "@id": "{{ structured_data_id('firefoxenterprise') }}",
+  "url": "{% filter absolute_url %}{{ url('firefox.enterprise.index') }}{% endfilter %}",
   "name": "Firefox Browser Enterprise",
-  "image": "{% filter trim|absolute_url %}{{ static('protocol/img/logos/firefox/browser/logo-lg-high-res.png') }}{% endfilter %}",
+  "image": "{% filter absolute_url %}{{ static('protocol/img/logos/firefox/browser/logo-lg-high-res.png') }}{% endfilter %}",
   "alternateName": [
     "Firefox for Enterprise",
     "Firefox Browser for Enterprise"
@@ -28,18 +28,18 @@
   "author":
   {
     "@type": "Organization",
-    "@id": "https://www.mozilla.org/#organization",
+    "@id": "{{ structured_data_id('organization') }}",
     "name": "Mozilla Corporation"
   },
   "softwareHelp":
   {
     "@type": "Webpage",
-    "url": "https://support.mozilla.org/en-US/products/firefox-enterprise"
+    "url": "https://support.mozilla.org/{{ LANG }}/products/firefox-enterprise"
   },
   "isPartOf":
   {
-    "@id": "https://www.mozilla.org/#firefoxbrowser",
-    "url": "https://www.mozilla.org/firefox/new/",
+    "@id": "{{ structured_data_id('firefoxbrowser') }}",
+    "url": "{% filter absolute_url %}{{ url('firefox.new') }}{% endfilter %}",
     "name": "Firefox Browser"
   }
 }

--- a/bedrock/base/templates/includes/structured-data/software/firefox-fire-tv-software.json
+++ b/bedrock/base/templates/includes/structured-data/software/firefox-fire-tv-software.json
@@ -1,16 +1,16 @@
 {
   "@context": "https://schema.org/",
   "@type": "SoftwareApplication",
-  "@id": "https://www.mozilla.org/#firefoxfiretv",
-  "url": "https://support.mozilla.org/en-US/kb/firefox-fire-tv",
+  "@id": "{{ structured_data_id('firefoxfiretv') }}",
+  "url": "https://support.mozilla.org/{{ LANG }}/kb/firefox-fire-tv",
   "name": "Firefox Browser Fire TV",
-  "image": "{% filter trim|absolute_url %}{{ static('protocol/img/logos/firefox/browser/logo-lg-high-res.png') }}{% endfilter %}",
+  "image": "{% filter absolute_url %}{{ static('protocol/img/logos/firefox/browser/logo-lg-high-res.png') }}{% endfilter %}",
   "alternateName": [
     "Firefox for Fire TV",
     "Firefox Browser for Fire TV"
   ],
   "sameAs": [
-    "https://www.amazon.com/Mozilla-Firefox-for-Fire-TV/dp/B078B5YMPD"
+    "{{ settings.AMAZON_FIREFOX_FIRE_TV_LINK }}"
   ],
   "offers":
   {
@@ -26,18 +26,18 @@
   "author":
   {
     "@type": "Organization",
-    "@id": "https://www.mozilla.org/#organization",
+    "@id": "{{ structured_data_id('organization') }}",
     "name": "Mozilla Corporation"
   },
   "softwareHelp":
   {
     "@type": "Webpage",
-    "url": "https://support.mozilla.org/en-US/products/firefox-amazon-devices/firefox-fire-tv"
+    "url": "https://support.mozilla.org/{{ LANG }}/products/firefox-amazon-devices/firefox-fire-tv"
   },
   "isPartOf":
   {
-    "@id": "https://www.mozilla.org/#firefoxbrowser",
-    "url": "https://www.mozilla.org/firefox/new/",
+    "@id": "{{ structured_data_id('firefoxbrowser') }}",
+    "url": "{% filter absolute_url %}{{ url('firefox.new') }}{% endfilter %}",
     "name": "Firefox Browser"
   }
 }

--- a/bedrock/base/templates/includes/structured-data/software/firefox-ios-software.json
+++ b/bedrock/base/templates/includes/structured-data/software/firefox-ios-software.json
@@ -1,9 +1,9 @@
 {
   "@context": "https://schema.org/",
   "@type": "MobileApplication",
-  "@id": "https://www.mozilla.org/#firefoxios",
-  "url": "https://www.mozilla.org/firefox/mobile/",
-  "image": "{% filter trim|absolute_url %}{{ static('protocol/img/logos/firefox/browser/logo-lg-high-res.png') }}{% endfilter %}",
+  "@id": "{{ structured_data_id('firefoxios') }}",
+  "url": "{% filter absolute_url %}{{ url('firefox.mobile.index') }}{% endfilter %}",
+  "image": "{% filter absolute_url %}{{ static('protocol/img/logos/firefox/browser/logo-lg-high-res.png') }}{% endfilter %}",
   "name": "Firefox Browser iOS",
   "alternateName": [
     "Firefox iOS",
@@ -11,14 +11,17 @@
     "Firefox Browser for iOS"
   ],
   "sameAs": [
-    "https://www.wikidata.org/wiki/Q698",
-    "https://en.wikipedia.org/wiki/Firefox"
+    "https://www.wikidata.org/wiki/Q20820972",
+    "https://{{ lang_short() }}.wikipedia.org/wiki/Firefox_for_iOS",
+    "{{ firefox_ios_url() }}"
   ],
   "offers":
   {
     "@type": "Offer",
+    "url": "{{ firefox_ios_url() }}",
     "price": "0",
-    "priceCurrency": "USD"
+    "priceCurrency": "USD",
+    "availability": "https://schema.org/InStock"
   },
   "OperatingSystem": "iOS",
   "applicationCategory": "Browser",
@@ -26,19 +29,19 @@
   "author":
   {
     "@type": "Organization",
-    "@id": "https://www.mozilla.org/#organization",
+    "@id": "{{ structured_data_id('organization') }}",
     "name": "Mozilla Corporation"
   },
   "softwareHelp":
   {
     "@type": "Webpage",
-    "url": "https://support.mozilla.org/en-US/products/ios"
+    "url": "https://support.mozilla.org/{{ LANG }}/products/ios"
   },
-  "releaseNotes": "https://www.mozilla.org/en-US/firefox/ios/notes/",
+  "releaseNotes": "{% filter absolute_url %}{{ url('firefox.notes', platform='ios') }}{% endfilter %}",
   "isPartOf":
   {
-    "@id": "https://www.mozilla.org/#firefoxbrowser",
-    "url": "https://www.mozilla.org/firefox/new/",
+    "@id": "{{ structured_data_id('firefoxbrowser') }}",
+    "url": "{% filter absolute_url %}{{ url('firefox.new') }}{% endfilter %}",
     "name": "Firefox Browser"
   }
 }

--- a/bedrock/base/templates/includes/structured-data/software/firefox-linux-software.json
+++ b/bedrock/base/templates/includes/structured-data/software/firefox-linux-software.json
@@ -1,10 +1,10 @@
 {
   "@context": "https://schema.org/",
   "@type": "SoftwareApplication",
-  "@id": "https://www.mozilla.org/#firefoxlinux",
-  "url": "https://www.mozilla.org/en-US/firefox/linux/",
+  "@id": "{{ structured_data_id('firefoxlinux') }}",
+  "url": "{% filter absolute_url %}{{ url('firefox.new.scene1_linux') }}{% endfilter %}",
   "name": "Firefox Browser Linux",
-  "image": "{% filter trim|absolute_url %}{{ static('protocol/img/logos/firefox/browser/logo-lg-high-res.png') }}{% endfilter %}",
+  "image": "{% filter absolute_url %}{{ static('protocol/img/logos/firefox/browser/logo-lg-high-res.png') }}{% endfilter %}",
   "alternateName": [
     "Firefox Linux",
     "Firefox Browser for Linux"
@@ -21,13 +21,13 @@
   "author":
   {
     "@type": "Organization",
-    "@id": "https://www.mozilla.org/#organization",
+    "@id": "{{ structured_data_id('organization') }}",
     "name": "Mozilla Corporation"
   },
   "isPartOf":
   {
-    "@id": "https://www.mozilla.org/#firefoxbrowser",
-    "url": "https://www.mozilla.org/firefox/new/",
+    "@id": "{{ structured_data_id('firefoxbrowser') }}",
+    "url": "{% filter absolute_url %}{{ url('firefox.new') }}{% endfilter %}",
     "name": "Firefox Browser"
   }
 }

--- a/bedrock/base/templates/includes/structured-data/software/firefox-lite-software.json
+++ b/bedrock/base/templates/includes/structured-data/software/firefox-lite-software.json
@@ -1,12 +1,12 @@
 {
   "@context": "https://schema.org/",
   "@type": "MobileApplication",
-  "@id": "https://www.mozilla.org/#firefoxlite",
-  "url": "https://support.mozilla.org/en-US/kb/get-started-firefox-lite",
+  "@id": "{{ structured_data_id('firefoxlite') }}",
+  "url": "https://support.mozilla.org/{{ LANG }}/kb/get-started-firefox-lite",
   "name": "Firefox Lite",
-  "image": "{% filter trim|absolute_url %}{{ static('protocol/img/logos/firefox/browser/logo-lg-high-res.png') }}{% endfilter %}",
+  "image": "{% filter absolute_url %}{{ static('protocol/img/logos/firefox/browser/logo-lg-high-res.png') }}{% endfilter %}",
   "sameAs": [
-    "https://play.google.com/store/apps/details?id=org.mozilla.rocket"
+    "{{ settings.GOOGLE_PLAY_FIREFOX_LITE_LINK }}"
   ],
   "offers":
   {
@@ -20,18 +20,18 @@
   "author":
   {
     "@type": "Organization",
-    "@id": "https://www.mozilla.org/#organization",
+    "@id": "{{ structured_data_id('organization') }}",
     "name": "Mozilla Corporation"
   },
   "softwareHelp":
   {
     "@type": "Webpage",
-    "url": "https://support.mozilla.org/en-US/products/firefox-lite"
+    "url": "https://support.mozilla.org/{{ LANG }}/products/firefox-lite"
   },
   "isPartOf":
   {
-    "@id": "https://www.mozilla.org/#firefoxbrowser",
-    "url": "https://www.mozilla.org/firefox/new/",
+    "@id": "{{ structured_data_id('firefoxbrowser') }}",
+    "url": "{% filter absolute_url %}{{ url('firefox.new') }}{% endfilter %}",
     "name": "Firefox Browser"
   }
 }

--- a/bedrock/base/templates/includes/structured-data/software/firefox-lockwise-software.json
+++ b/bedrock/base/templates/includes/structured-data/software/firefox-lockwise-software.json
@@ -8,8 +8,8 @@
   "sameAs": [
     "https://{{ lang_short() }}.wikipedia.org/wiki/Firefox_Lockwise",
     "https://www.wikidata.org/wiki/Q64829394",
-    "{{ play_store_url(settings.GOOGLE_PLAY_LOCKWISE_LINK)|safe }}",
-    "{{ app_store_url(settings.APPLE_APPSTORE_LOCKWISE_LINK) }}"
+    "{{ play_store_url('lockwise')|safe }}",
+    "{{ app_store_url('lockwise') }}"
   ],
   "offers":
   {

--- a/bedrock/base/templates/includes/structured-data/software/firefox-lockwise-software.json
+++ b/bedrock/base/templates/includes/structured-data/software/firefox-lockwise-software.json
@@ -1,15 +1,15 @@
 {
   "@context": "https://schema.org/",
   "@type": "SoftwareApplication",
-  "@id": "https://www.mozilla.org/#firefoxlockwise",
-  "url": "https://www.mozilla.org/en-US/firefox/lockwise",
-  "image": "{% filter trim|absolute_url %}{{ static('protocol/img/logos/firefox/lockwise/logo-lg-high-res.png') }}{% endfilter %}",
+  "@id": "{{ structured_data_id('firefoxlockwise') }}",
+  "url": "{% filter absolute_url %}{{ url('firefox.lockwise.lockwise') }}{% endfilter %}",
+  "image": "{% filter absolute_url %}{{ static('protocol/img/logos/firefox/lockwise/logo-lg-high-res.png') }}{% endfilter %}",
   "name": "Firefox Lockwise",
   "sameAs": [
-    "https://en.wikipedia.org/wiki/Firefox_Lockwise",
+    "https://{{ lang_short() }}.wikipedia.org/wiki/Firefox_Lockwise",
     "https://www.wikidata.org/wiki/Q64829394",
-    "https://play.google.com/store/apps/details?id=mozilla.lockbox",
-    "https://apps.apple.com/us/app/firefox-lockbox/id1314000270"
+    "{{ play_store_url(settings.GOOGLE_PLAY_LOCKWISE_LINK)|safe }}",
+    "{{ app_store_url(settings.APPLE_APPSTORE_LOCKWISE_LINK) }}"
   ],
   "offers":
   {
@@ -27,12 +27,12 @@
   "author":
   {
     "@type": "Organization",
-    "@id": "https://www.mozilla.org/#organization",
+    "@id": "{{ structured_data_id('organization') }}",
     "name": "Mozilla Corporation"
   },
   "softwareHelp":
   {
     "@type": "Webpage",
-    "url": "https://support.mozilla.org/en-US/products/firefox-lockwise"
+    "url": "https://support.mozilla.org/{{ LANG }}/products/firefox-lockwise"
   }
 }

--- a/bedrock/base/templates/includes/structured-data/software/firefox-mac-software.json
+++ b/bedrock/base/templates/includes/structured-data/software/firefox-mac-software.json
@@ -1,10 +1,10 @@
 {
   "@context": "https://schema.org/",
   "@type": "SoftwareApplication",
-  "@id": "https://www.mozilla.org/#firefoxmac",
-  "url": "https://www.mozilla.org/en-US/firefox/mac/",
+  "@id": "{{ structured_data_id('firefoxmac') }}",
+  "url": "{% filter absolute_url %}{{ url('firefox.new.scene1_mac') }}{% endfilter %}",
   "name": "Firefox Browser Mac",
-  "image": "{% filter trim|absolute_url %}{{ static('protocol/img/logos/firefox/browser/logo-lg-high-res.png') }}{% endfilter %}",
+  "image": "{% filter absolute_url %}{{ static('protocol/img/logos/firefox/browser/logo-lg-high-res.png') }}{% endfilter %}",
   "alternateName": [
     "Firefox Mac",
     "Firefox Browser for Mac"
@@ -21,13 +21,13 @@
   "author":
   {
     "@type": "Organization",
-    "@id": "https://www.mozilla.org/#organization",
+    "@id": "{{ structured_data_id('organization') }}",
     "name": "Mozilla Corporation"
   },
   "isPartOf":
   {
-    "@id": "https://www.mozilla.org/#firefoxbrowser",
-    "url": "https://www.mozilla.org/firefox/new/",
+    "@id": "{{ structured_data_id('firefoxbrowser') }}",
+    "url": "{% filter absolute_url %}{{ url('firefox.new') }}{% endfilter %}",
     "name": "Firefox Browser"
   }
 }

--- a/bedrock/base/templates/includes/structured-data/software/firefox-monitor-software.json
+++ b/bedrock/base/templates/includes/structured-data/software/firefox-monitor-software.json
@@ -1,14 +1,14 @@
 {
   "@context": "https://schema.org/",
   "@type": "WebApplication",
-  "@id": "https://www.mozilla.org/#firefoxmonitor",
+  "@id": "{{ structured_data_id('firefoxmonitor') }}",
   "url": "https://monitor.firefox.com",
-  "image": "{% filter trim|absolute_url %}{{ static('protocol/img/logos/firefox/monitor/logo-lg-high-res.png') }}{% endfilter %}",
+  "image": "{% filter absolute_url %}{{ static('protocol/img/logos/firefox/monitor/logo-lg-high-res.png') }}{% endfilter %}",
   "name": "Firefox Monitor",
   "sameAs": [
     "https://www.wikidata.org/wiki/Q64828890",
     "https://monitor.firefox.com",
-    "https://en.wikipedia.org/wiki/Firefox_Monitor"
+    "https://{{ lang_short() }}.wikipedia.org/wiki/Firefox_Monitor"
   ],
   "offers":
   {
@@ -21,12 +21,12 @@
   "author":
   {
     "@type": "Organization",
-    "@id": "https://www.mozilla.org/#organization",
+    "@id": "{{ structured_data_id('organization') }}",
     "name": "Mozilla Corporation"
   },
   "softwareHelp":
   {
     "@type": "Webpage",
-    "url": "https://support.mozilla.org/en-US/kb/firefox-monitor"
+    "url": "https://support.mozilla.org/{{ LANG }}/kb/firefox-monitor"
   }
 }

--- a/bedrock/base/templates/includes/structured-data/software/firefox-nightly-software.json
+++ b/bedrock/base/templates/includes/structured-data/software/firefox-nightly-software.json
@@ -12,7 +12,7 @@
   "sameAs": [
     "https://www.wikidata.org/wiki/Q56316099",
     "https://{{ lang_short() }}.wikipedia.org/wiki/Firefox_Nightly",
-    "{{ play_store_url(settings.GOOGLE_PLAY_FIREFOX_NIGHTLY_LINK)|safe }}",
+    "{{ play_store_url('firefox_nightly')|safe }}",
     "https://blog.nightly.mozilla.org/",
     "https://twitter.com/FirefoxNightly"
   ],

--- a/bedrock/base/templates/includes/structured-data/software/firefox-nightly-software.json
+++ b/bedrock/base/templates/includes/structured-data/software/firefox-nightly-software.json
@@ -1,18 +1,18 @@
 {
   "@context": "https://schema.org/",
   "@type": "SoftwareApplication",
-  "@id": "https://www.mozilla.org/#firefoxnightly",
-  "url": "https://www.mozilla.org/en-US/firefox/channel/desktop/",
+  "@id": "{{ structured_data_id('firefoxnightly') }}",
+  "url": "{% filter absolute_url %}{{ url('firefox.channel.desktop') }}{% endfilter %}",
   "name": "Firefox Browser Nightly",
-  "image": "{% filter trim|absolute_url %}{{ static('protocol/img/logos/firefox/browser/nightly/logo-lg-high-res.png') }}{% endfilter %}",
+  "image": "{% filter absolute_url %}{{ static('protocol/img/logos/firefox/browser/nightly/logo-lg-high-res.png') }}{% endfilter %}",
   "alternateName": [
     "Firefox Nightly",
     "Firefox Nightly Browser"
   ],
   "sameAs": [
     "https://www.wikidata.org/wiki/Q56316099",
-    "https://es.wikipedia.org/wiki/Firefox_Nightly",
-    "https://play.google.com/store/apps/details?id=org.mozilla.fennec_aurora",
+    "https://{{ lang_short() }}.wikipedia.org/wiki/Firefox_Nightly",
+    "{{ play_store_url(settings.GOOGLE_PLAY_FIREFOX_NIGHTLY_LINK)|safe }}",
     "https://blog.nightly.mozilla.org/",
     "https://twitter.com/FirefoxNightly"
   ],
@@ -33,14 +33,14 @@
   "author":
   {
     "@type": "Organization",
-    "@id": "https://www.mozilla.org/#organization",
+    "@id": "{{ structured_data_id('organization') }}",
     "name": "Mozilla Corporation"
   },
-  "releaseNotes": "https://www.mozilla.org/en-US/firefox/nightly/notes/",
+  "releaseNotes": "{% filter absolute_url %}{{ url('firefox.notes', channel='nightly') }}{% endfilter %}",
   "isPartOf":
   {
-    "@id": "https://www.mozilla.org/#firefoxbrowser",
-    "url": "https://www.mozilla.org/firefox/new/",
+    "@id": "{{ structured_data_id('firefoxbrowser') }}",
+    "url": "{% filter absolute_url %}{{ url('firefox.new') }}{% endfilter %}",
     "name": "Firefox Browser"
   }
 }

--- a/bedrock/base/templates/includes/structured-data/software/firefox-send-software.json
+++ b/bedrock/base/templates/includes/structured-data/software/firefox-send-software.json
@@ -9,7 +9,7 @@
     "https://en.wikipedia.org/wiki/Firefox_Send",
     "https://send.firefox.com",
     "https://www.wikidata.org/wiki/Q62394165",
-    "{{ play_store_url(settings.GOOGLE_PLAY_FIREFOX_SEND_LINK)|safe }}"
+    "{{ play_store_url('firefox_send')|safe }}"
   ],
   "offers":
   {

--- a/bedrock/base/templates/includes/structured-data/software/firefox-send-software.json
+++ b/bedrock/base/templates/includes/structured-data/software/firefox-send-software.json
@@ -1,15 +1,15 @@
 {
   "@context": "https://schema.org/",
   "@type": "SoftwareApplication",
-  "@id": "https://www.mozilla.org/#firefoxbrowser",
+  "@id": "{{ structured_data_id('firefoxsend') }}",
   "url": "https://send.firefox.com",
-  "image": "{% filter trim|absolute_url %}{{ static('protocol/img/logos/firefox/send/logo-lg-high-res.png') }}{% endfilter %}",
+  "image": "{% filter absolute_url %}{{ static('protocol/img/logos/firefox/send/logo-lg-high-res.png') }}{% endfilter %}",
   "name": "Firefox Send",
   "sameAs": [
     "https://en.wikipedia.org/wiki/Firefox_Send",
     "https://send.firefox.com",
     "https://www.wikidata.org/wiki/Q62394165",
-    "https://play.google.com/store/apps/details?id=org.mozilla.firefoxsend"
+    "{{ play_store_url(settings.GOOGLE_PLAY_FIREFOX_SEND_LINK)|safe }}"
   ],
   "offers":
   {
@@ -26,7 +26,7 @@
   "author":
   {
     "@type": "Organization",
-    "@id": "https://www.mozilla.org/#organization",
+    "@id": "{{ structured_data_id('organization') }}",
     "name": "Mozilla Corporation"
   }
 }

--- a/bedrock/base/templates/includes/structured-data/software/firefox-windows-software.json
+++ b/bedrock/base/templates/includes/structured-data/software/firefox-windows-software.json
@@ -1,10 +1,10 @@
 {
   "@context": "https://schema.org/",
   "@type": "SoftwareApplication",
-  "@id": "https://www.mozilla.org/#firefoxwindows",
-  "url": "https://www.mozilla.org/en-US/firefox/windows/",
+  "@id": "{{ structured_data_id('firefoxwindows') }}",
+  "url": "{% filter absolute_url %}{{ url('firefox.new.scene1_windows') }}{% endfilter %}",
   "name": "Firefox Browser Windows",
-  "image": "{% filter trim|absolute_url %}{{ static('protocol/img/logos/firefox/browser/logo-lg-high-res.png') }}{% endfilter %}",
+  "image": "{% filter absolute_url %}{{ static('protocol/img/logos/firefox/browser/logo-lg-high-res.png') }}{% endfilter %}",
   "alternateName": [
     "Firefox Windows",
     "Firefox Browser for Windows"
@@ -21,13 +21,13 @@
   "author":
   {
     "@type": "Organization",
-    "@id": "https://www.mozilla.org/#organization",
+    "@id": "{{ structured_data_id('organization') }}",
     "name": "Mozilla Corporation"
   },
   "isPartOf":
   {
-    "@id": "https://www.mozilla.org/#firefoxbrowser",
-    "url": "https://www.mozilla.org/firefox/new/",
+    "@id": "{{ structured_data_id('firefoxbrowser') }}",
+    "url": "{% filter absolute_url %}{{ url('firefox.new') }}{% endfilter %}",
     "name": "Firefox Browser"
   }
 }

--- a/bedrock/firefox/templates/firefox/browsers/index.html
+++ b/bedrock/firefox/templates/firefox/browsers/index.html
@@ -139,16 +139,5 @@
 {% endblock %}
 
 {% block structured_data %}
-  {
-    "@context": "https://schema.org/",
-    "@graph": [
-      {% include 'includes/structured-data/software/firefox-browser-software.json' %}
-      ,
-      {% include 'includes/structured-data/software/firefox-beta-software.json' %}
-      ,
-      {% include 'includes/structured-data/software/firefox-developer-software.json' %}
-      ,
-      {% include 'includes/structured-data/software/firefox-enterprise-software.json' %}
-    ]
-  }
+  {% include 'includes/structured-data/software/firefox-browser-software.json' %}
 {% endblock %}

--- a/bedrock/firefox/templates/firefox/home/index-master.html
+++ b/bedrock/firefox/templates/firefox/home/index-master.html
@@ -302,3 +302,18 @@
 {% block js %}
   {{ js_bundle('firefox-master') }}
 {% endblock %}
+
+{% block structured_data %}
+  {
+    "@context": "https://schema.org/",
+    "@graph": [
+      {% include 'includes/structured-data/software/firefox-browser-software.json' %}
+      ,
+      {% include 'includes/structured-data/software/firefox-monitor-software.json' %}
+      ,
+      {% include 'includes/structured-data/software/firefox-lockwise-software.json' %}
+      ,
+      {% include 'includes/structured-data/software/firefox-send-software.json' %}
+    ]
+  }
+{% endblock %}

--- a/bedrock/firefox/templates/firefox/home/index-quantum.html
+++ b/bedrock/firefox/templates/firefox/home/index-quantum.html
@@ -234,3 +234,18 @@
 {% block js %}
   {{ js_bundle('firefox-quantum') }}
 {% endblock %}
+
+{% block structured_data %}
+  {
+    "@context": "https://schema.org/",
+    "@graph": [
+      {% include 'includes/structured-data/software/firefox-browser-software.json' %}
+      ,
+      {% include 'includes/structured-data/software/firefox-monitor-software.json' %}
+      ,
+      {% include 'includes/structured-data/software/firefox-lockwise-software.json' %}
+      ,
+      {% include 'includes/structured-data/software/firefox-send-software.json' %}
+    ]
+  }
+{% endblock %}

--- a/bedrock/firefox/templates/firefox/lockwise/lockwise.html
+++ b/bedrock/firefox/templates/firefox/lockwise/lockwise.html
@@ -95,4 +95,10 @@
   </main>
 {% endblock %}
 
-{% block js %}{{ js_bundle('lockwise') }}{% endblock %}
+{% block js %}
+  {{ js_bundle('lockwise') }}
+{% endblock %}
+
+{% block structured_data %}
+  {% include 'includes/structured-data/software/firefox-lockwise-software.json' %}
+{% endblock %}

--- a/bedrock/firefox/templates/firefox/new/trailhead/download.html
+++ b/bedrock/firefox/templates/firefox/new/trailhead/download.html
@@ -118,12 +118,12 @@
 {% endblock %}
 
 {% block structured_data %}
-{
-"@context": "https://schema.org/",
-"@graph": [
-{% include 'includes/structured-data/software/firefox-browser-software.json' %}
-,
-{% include 'includes/structured-data/breadcrumb/new.json' %}
-]
-}
+  {
+    "@context": "https://schema.org/",
+    "@graph": [
+      {% include 'includes/structured-data/software/firefox-browser-software.json' %}
+      ,
+      {% include 'includes/structured-data/breadcrumb/new.json' %}
+    ]
+  }
 {% endblock %}

--- a/bedrock/firefox/templates/firefox/products/index.html
+++ b/bedrock/firefox/templates/firefox/products/index.html
@@ -142,11 +142,11 @@
     "@graph": [
       {% include 'includes/structured-data/software/firefox-browser-software.json' %}
       ,
-      {% include 'includes/structured-data/software/firefox-beta-software.json' %}
+      {% include 'includes/structured-data/software/firefox-monitor-software.json' %}
       ,
-      {% include 'includes/structured-data/software/firefox-developer-software.json' %}
+      {% include 'includes/structured-data/software/firefox-lockwise-software.json' %}
       ,
-      {% include 'includes/structured-data/software/firefox-enterprise-software.json' %}
+      {% include 'includes/structured-data/software/firefox-send-software.json' %}
     ]
   }
 {% endblock %}

--- a/bedrock/mozorg/templates/mozorg/home/home-en.html
+++ b/bedrock/mozorg/templates/mozorg/home/home-en.html
@@ -211,7 +211,6 @@
   {% endif %}
 {% endblock %}
 
-
 {% block structured_data %}
   {% include 'includes/structured-data/organizations/mozilla-corporation-organisation.json' %}
 {% endblock %}

--- a/bedrock/mozorg/templates/mozorg/home/home.html
+++ b/bedrock/mozorg/templates/mozorg/home/home.html
@@ -198,3 +198,7 @@ accessible to all.') }}
 {% block js %}
 {{ js_bundle('newsletter') }}
 {% endblock %}
+
+{% block structured_data %}
+  {% include 'includes/structured-data/organizations/mozilla-corporation-organisation.json' %}
+{% endblock %}

--- a/bedrock/mozorg/templatetags/misc.py
+++ b/bedrock/mozorg/templatetags/misc.py
@@ -599,6 +599,51 @@ def ifeq(a, b, text):
     return jinja2.Markup(text if a == b else '')
 
 
+@library.global_function
+@jinja2.contextfunction
+def app_store_url(ctx, base_url):
+    """Returns a localised app store URL for a given product"""
+    locale = getattr(ctx['request'], 'locale', 'en-US')
+    countries = settings.APPLE_APPSTORE_COUNTRY_MAP
+    if locale in countries:
+        return base_url.format(country=countries[locale])
+    else:
+        return base_url.replace('/{country}/', '/')
+
+
+@library.global_function
+@jinja2.contextfunction
+def play_store_url(ctx, base_url):
+    """Returns a localised play store URL for a given product"""
+    locale = getattr(ctx['request'], 'locale', 'en-US')
+    return base_url + '&hl=' + locale.split('-')[0]
+
+
+@library.global_function
+@jinja2.contextfunction
+def structured_data_id(ctx, id, domain=None):
+    """
+    Returns an identifier for a structured data object based on
+    a supplied id e.g. https://www.mozilla.org/#firefoxbrowser
+    """
+    canonical = settings.CANONICAL_URL if not domain else domain
+    locale = getattr(ctx['request'], 'locale', 'en-US')
+    suffix = ''
+
+    if locale != 'en-US':
+        suffix = '-' + locale.lower()
+
+    return canonical + '/#' + id + suffix
+
+
+@library.global_function
+@jinja2.contextfunction
+def lang_short(ctx):
+    """Returns a shortened locale code e.g. en."""
+    locale = getattr(ctx['request'], 'locale', 'en-US')
+    return locale.split('-')[0]
+
+
 def _get_adjust_link(adjust_url, app_store_url, google_play_url, redirect, locale, adgroup, creative=None):
     link = adjust_url
     params = 'campaign=www.mozilla.org&adgroup=' + adgroup

--- a/bedrock/mozorg/templatetags/misc.py
+++ b/bedrock/mozorg/templatetags/misc.py
@@ -601,8 +601,9 @@ def ifeq(a, b, text):
 
 @library.global_function
 @jinja2.contextfunction
-def app_store_url(ctx, base_url):
+def app_store_url(ctx, product):
     """Returns a localised app store URL for a given product"""
+    base_url = getattr(settings, f'APPLE_APPSTORE_{product.upper()}_LINK')
     locale = getattr(ctx['request'], 'locale', 'en-US')
     countries = settings.APPLE_APPSTORE_COUNTRY_MAP
     if locale in countries:
@@ -613,10 +614,10 @@ def app_store_url(ctx, base_url):
 
 @library.global_function
 @jinja2.contextfunction
-def play_store_url(ctx, base_url):
+def play_store_url(ctx, product):
     """Returns a localised play store URL for a given product"""
-    locale = getattr(ctx['request'], 'locale', 'en-US')
-    return base_url + '&hl=' + locale.split('-')[0]
+    base_url = getattr(settings, f'GOOGLE_PLAY_{product.upper()}_LINK')
+    return f'{base_url}&hl={lang_short(ctx)}'
 
 
 @library.global_function

--- a/bedrock/mozorg/tests/test_helper_misc.py
+++ b/bedrock/mozorg/tests/test_helper_misc.py
@@ -694,8 +694,8 @@ class TestAppStoreURL(TestCase):
     def _render(self, locale):
         req = self.rf.get('/')
         req.locale = locale
-        base_url = settings.APPLE_APPSTORE_LOCKWISE_LINK
-        return render("{{ app_store_url('%s') }}" % base_url,
+        product = 'lockwise'
+        return render("{{ app_store_url('%s') }}" % product,
                       {'request': req})
 
     def test_app_store_url_no_locale(self):
@@ -720,8 +720,8 @@ class TestPlayStoreURL(TestCase):
     def _render(self, locale):
         req = self.rf.get('/')
         req.locale = locale
-        base_url = settings.GOOGLE_PLAY_LOCKWISE_LINK
-        return render("{{ play_store_url('%s') }}" % base_url,
+        product = 'lockwise'
+        return render("{{ play_store_url('%s') }}" % product,
                       {'request': req})
 
     def test_play_store_url_localized(self):

--- a/bedrock/mozorg/tests/test_helper_misc.py
+++ b/bedrock/mozorg/tests/test_helper_misc.py
@@ -688,6 +688,94 @@ def test_csrf():
     assert csrf in s
 
 
+class TestAppStoreURL(TestCase):
+    rf = RequestFactory()
+
+    def _render(self, locale):
+        req = self.rf.get('/')
+        req.locale = locale
+        base_url = settings.APPLE_APPSTORE_LOCKWISE_LINK
+        return render("{{ app_store_url('%s') }}" % base_url,
+                      {'request': req})
+
+    def test_app_store_url_no_locale(self):
+        """No locale, fallback to default URL"""
+        assert (self._render('') == 'https://itunes.apple.com/app/id1314000270?mt=8')
+
+    def test_app_store_url_default(self):
+        """should fallback to default URL"""
+        assert (self._render('ar') == 'https://itunes.apple.com/app/id1314000270?mt=8')
+        assert (self._render('zu') == 'https://itunes.apple.com/app/id1314000270?mt=8')
+
+    def test_app_store_url_localized(self):
+        """should return localized URL"""
+        assert (self._render('en-US') == 'https://itunes.apple.com/us/app/id1314000270?mt=8')
+        assert (self._render('es-ES') == 'https://itunes.apple.com/es/app/id1314000270?mt=8')
+        assert (self._render('de') == 'https://itunes.apple.com/de/app/id1314000270?mt=8')
+
+
+class TestPlayStoreURL(TestCase):
+    rf = RequestFactory()
+
+    def _render(self, locale):
+        req = self.rf.get('/')
+        req.locale = locale
+        base_url = settings.GOOGLE_PLAY_LOCKWISE_LINK
+        return render("{{ play_store_url('%s') }}" % base_url,
+                      {'request': req})
+
+    def test_play_store_url_localized(self):
+        """should return localized URL"""
+        assert (self._render('en-US') == 'https://play.google.com/store/apps/details?id=mozilla.lockbox&amp;hl=en')
+        assert (self._render('es-ES') == 'https://play.google.com/store/apps/details?id=mozilla.lockbox&amp;hl=es')
+        assert (self._render('de') == 'https://play.google.com/store/apps/details?id=mozilla.lockbox&amp;hl=de')
+
+
+class TestStructuredDataID(TestCase):
+    rf = RequestFactory()
+
+    def _render(self, locale, domain=None):
+        req = self.rf.get('/')
+        req.locale = locale
+        sd_id = 'firefoxbrowser'
+
+        if domain:
+            return render("{{{{ structured_data_id('{0}', '{1}') }}}}".format(
+                          sd_id, domain), {'request': req})
+
+        return render("{{ structured_data_id('%s') }}" % sd_id,
+                      {'request': req})
+
+    def test_structured_data_localized_id(self):
+        """should return localized id"""
+        assert (self._render('en-US') == 'https://www.mozilla.org/#firefoxbrowser')
+        assert (self._render('es-ES') == 'https://www.mozilla.org/#firefoxbrowser-es-es')
+        assert (self._render('de') == 'https://www.mozilla.org/#firefoxbrowser-de')
+
+    def test_structured_data_custom_domain_id(self):
+        """should return id for a custom domain"""
+        domain = 'https://foundation.mozilla.org'
+        assert (self._render('en-US', domain) == 'https://foundation.mozilla.org/#firefoxbrowser')
+        assert (self._render('es-ES', domain) == 'https://foundation.mozilla.org/#firefoxbrowser-es-es')
+        assert (self._render('de', domain) == 'https://foundation.mozilla.org/#firefoxbrowser-de')
+
+
+class TestLangShort(TestCase):
+    rf = RequestFactory()
+
+    def _render(self, locale, domain=None):
+        req = self.rf.get('/')
+        req.locale = locale
+
+        return render("{{ lang_short() }}", {'request': req})
+
+    def test_shortened_locales(self):
+        """should return a shortened locale code"""
+        assert (self._render('en-US') == 'en')
+        assert (self._render('es-ES') == 'es')
+        assert (self._render('de') == 'de')
+
+
 class TestFirefoxAdjustUrl(TestCase):
     rf = RequestFactory()
 

--- a/bedrock/settings/appstores.py
+++ b/bedrock/settings/appstores.py
@@ -108,6 +108,21 @@ APPLE_APPSTORE_LOCKWISE_LINK = 'https://itunes.apple.com/{country}/app/id1314000
 # Link to Lockwise on the Google Play store.
 GOOGLE_PLAY_LOCKWISE_LINK = 'https://play.google.com/store/apps/details?id=mozilla.lockbox'
 
+# Link to Firefox Beta on the Google Play Store.
+GOOGLE_PLAY_FIREFOX_BETA_LINK = 'https://play.google.com/store/apps/details?id=org.mozilla.firefox_beta'
+
+# Link to Firefox Nightly on the Google Play Store.
+GOOGLE_PLAY_FIREFOX_NIGHTLY_LINK = 'https://play.google.com/store/apps/details?id=org.mozilla.fennec_aurora'
+
+# Link to Firefox for Fire TV on Amazon Store.
+AMAZON_FIREFOX_FIRE_TV_LINK = 'https://www.amazon.com/Mozilla-Firefox-for-Fire-TV/dp/B078B5YMPD'
+
+# Link to Firefox Lite on the Google Play Store.
+GOOGLE_PLAY_FIREFOX_LITE_LINK = 'https://play.google.com/store/apps/details?id=org.mozilla.rocket'
+
+# Link to Firefox Send on the Google Play Store.
+GOOGLE_PLAY_FIREFOX_SEND_LINK = 'https://play.google.com/store/apps/details?id=org.mozilla.firefoxsend'
+
 # app.adjust.com links for all of the above products (Issue 7214)
 ADJUST_FIREFOX_URL = 'https://app.adjust.com/2uo1qc'
 ADJUST_FOCUS_URL = 'https://app.adjust.com/b8s7qo'

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -1210,6 +1210,9 @@ from .appstores import (GOOGLE_PLAY_FIREFOX_LINK, GOOGLE_PLAY_FIREFOX_LINK_UTMS,
                         APPLE_APPSTORE_KLAR_LINK, GOOGLE_PLAY_KLAR_LINK,
                         APPLE_APPSTORE_POCKET_LINK, GOOGLE_PLAY_POCKET_LINK,
                         APPLE_APPSTORE_LOCKWISE_LINK, GOOGLE_PLAY_LOCKWISE_LINK,
+                        GOOGLE_PLAY_FIREFOX_BETA_LINK, GOOGLE_PLAY_FIREFOX_NIGHTLY_LINK,
+                        AMAZON_FIREFOX_FIRE_TV_LINK, GOOGLE_PLAY_FIREFOX_LITE_LINK,
+                        GOOGLE_PLAY_FIREFOX_SEND_LINK,
                         ADJUST_FIREFOX_URL, ADJUST_FOCUS_URL,
                         ADJUST_KLAR_URL, ADJUST_POCKET_URL,
                         ADJUST_LOCKWISE_URL)
@@ -1499,3 +1502,4 @@ if config('SWITCH_TRACKING_PIXEL', default=str(DEV), parser=bool):
 
 # Issue 7508 - Convert.com experiment sandbox
 CONVERT_PROJECT_ID = ('10039-1003350' if DEV else '10039-1003343')
+


### PR DESCRIPTION
## Description
- Exposed structured data to more locales.
  - Adds helpers to generate structured data IDs, app store links, and shortened locale codes.
  - Moves app store links into `appstores.py`.
  - Use `url()` helper for generating links.

## Issue / Bugzilla link
#8522

## Testing
Demo: https://www-demo2.allizom.org/en-US/

Successful test run: https://gitlab.com/mozmeao/www-config/pipelines/120549500