### PR TITLE
Fix broken accounts links on /products and /browsers/ (Fixes #8586)

### DIFF
--- a/bedrock/firefox/templates/firefox/browsers/index.html
+++ b/bedrock/firefox/templates/firefox/browsers/index.html
@@ -121,10 +121,9 @@
           )
         }}
         <p class="fxa-signin account-signin">
-          {% set fxa_link = fxa_link_fragment(entrypoint=_entrypoint, action='signin', utm_campaign='browsers_footer') %}
-          {% set fxa_attr = 'href="{{ fxa_link }}" class="js-fxa-cta-link" data-cta-type="link" data-cta-text="FxA Learn More"'|safe %}
-          {% set accounts_link = url('firefox.accounts') %}
-          {% set accounts_attr = 'href="{{ accounts_link }}"'|safe %}
+          {% set fxa_link = fxa_link_fragment(entrypoint=_entrypoint, action='signin', utm_campaign='browsers-footer') %}
+          {% set fxa_attr = fxa_link ~ ' class="js-fxa-cta-link" data-cta-type="link" data-cta-text="FxA Learn More"'|safe %}
+          {% set accounts_attr = 'href="'|safe ~ url('firefox.accounts') ~ '"'|safe %}
           {% trans %}
             Already have an account? <a {{ fxa_attr }}>Sign In</a> or <a {{ accounts_attr }}>learn more</a> about joining Firefox.
           {% endtrans %}

--- a/bedrock/firefox/templates/firefox/products/index.html
+++ b/bedrock/firefox/templates/firefox/products/index.html
@@ -119,10 +119,9 @@
           )
         }}
         <p class="fxa-signin account-signin">
-          {% set fxa_link = fxa_link_fragment(entrypoint=_entrypoint, action='signin', utm_campaign='browsers_footer') %}
-          {% set fxa_attr = 'href="{{ fxa_link }}" class="js-fxa-cta-link" data-cta-type="link" data-cta-text="FxA Learn More"'|safe %}
-          {% set accounts_link = url('firefox.accounts') %}
-          {% set accounts_attr = 'href="{{ accounts_link }}"'|safe %}
+          {% set fxa_link = fxa_link_fragment(entrypoint=_entrypoint, action='signin', utm_campaign='products-footer') %}
+          {% set fxa_attr = fxa_link ~ ' class="js-fxa-cta-link" data-cta-type="link" data-cta-text="FxA Learn More"'|safe %}
+          {% set accounts_attr = 'href="'|safe ~ url('firefox.accounts') ~ '"'|safe %}
           {% trans %}
             Already have an account? <a {{ fxa_attr }}>Sign In</a> or <a {{ accounts_attr }}>learn more</a> about joining Firefox.
           {% endtrans %}

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -1150,8 +1150,6 @@
         "js/base/mozilla-fxa-init.js",
         "js/base/mozilla-fxa-form.js",
         "js/base/mozilla-fxa-form-init.js",
-        "js/base/mozilla-fxa-link.js",
-        "js/base/mozilla-fxa-link-init.js",
         "js/base/uitour-lib.js",
         "js/firefox/browsers-products.js"
       ],


### PR DESCRIPTION
## Description
- Fixes account links on `/firefox/products/` and `/firefox/browsers/` pages.
- Removes duplicate `mozilla-fxa-link.js` script from the page's bundle which was encoding URL params twice.

## Issue / Bugzilla link
#8586

## Testing
- [x] Links on both pages should now be well formed with the correct destinations.