### PR TITLE
Remove button-green from Pebbles. (Fixes #5703, download button contrast.)

### DIFF
--- a/bedrock/firefox/templates/firefox/campaign/berlin/base-variation.html
+++ b/bedrock/firefox/templates/firefox/campaign/berlin/base-variation.html
@@ -59,7 +59,7 @@
       <div class="download-contain">
         <h2>Besser digital leben — mit Firefox.</h2>
         <div class="download-button-wrapper">
-          {{ download_firefox(alt_copy='Jetzt herunterladen', locale_in_transition=true, dom_id="download-firefox-today", button_color='button-green') }}
+          {{ download_firefox(alt_copy='Jetzt herunterladen', locale_in_transition=true, dom_id="download-firefox-today") }}
         </div>
       </div>
     </div>

--- a/bedrock/firefox/templates/firefox/campaign/berlin/base.html
+++ b/bedrock/firefox/templates/firefox/campaign/berlin/base.html
@@ -107,7 +107,7 @@
       <div class="download-contain">
         <h2>Besser digital leben – mit Firefox.</h2>
         <div class="download-button-wrapper">
-          {{ download_firefox(alt_copy='Jetzt herunterladen', locale_in_transition=true, dom_id="download-firefox-today", button_color='button-green') }}
+          {{ download_firefox(alt_copy='Jetzt herunterladen', locale_in_transition=true, dom_id="download-firefox-today") }}
         </div>
       </div>
     </div>

--- a/bedrock/firefox/templates/firefox/campaign/berlin/scene1-auf-deiner-seite.html
+++ b/bedrock/firefox/templates/firefox/campaign/berlin/scene1-auf-deiner-seite.html
@@ -9,7 +9,7 @@
 {% block body_class %}ads{% endblock %}
 
 {% block primary_download_button %}
-  {{ download_firefox(alt_copy='Jetzt herunterladen', locale_in_transition=true, dom_id="download-firefox", download_location='primary cta', button_color='button-green') }}
+  {{ download_firefox(alt_copy='Jetzt herunterladen', locale_in_transition=true, dom_id="download-firefox", download_location='primary cta') }}
 {% endblock %}
 
 {% block main_heading %}Zeit für den Browser auf Deiner&nbsp;Seite{% endblock %}

--- a/bedrock/firefox/templates/firefox/campaign/berlin/scene1-aus-gruenden.html
+++ b/bedrock/firefox/templates/firefox/campaign/berlin/scene1-aus-gruenden.html
@@ -11,7 +11,7 @@
 {% endblock %}
 
 {% block primary_download_button %}
-  {{ download_firefox(alt_copy='Jetzt herunterladen', locale_in_transition=true, dom_id="download-firefox", download_location='primary cta', button_color='button-green') }}
+  {{ download_firefox(alt_copy='Jetzt herunterladen', locale_in_transition=true, dom_id="download-firefox", download_location='primary cta') }}
 {% endblock %}
 
 {% block media %}

--- a/bedrock/firefox/templates/firefox/campaign/berlin/scene1-gesch.html
+++ b/bedrock/firefox/templates/firefox/campaign/berlin/scene1-gesch.html
@@ -9,7 +9,7 @@
 {% block body_class %}gesch{% endblock %}
 
 {% block primary_download_button %}
-  {{ download_firefox(alt_copy='Jetzt herunterladen', locale_in_transition=true, dom_id="download-firefox", download_location='primary cta', button_color='button-green') }}
+  {{ download_firefox(alt_copy='Jetzt herunterladen', locale_in_transition=true, dom_id="download-firefox", download_location='primary cta') }}
 {% endblock %}
 
 {% block main_heading %}Zeit für mehr<br> Geschwindigkeit{% endblock %}

--- a/bedrock/firefox/templates/firefox/campaign/berlin/scene1-herz.html
+++ b/bedrock/firefox/templates/firefox/campaign/berlin/scene1-herz.html
@@ -9,7 +9,7 @@
 {% block body_class %}herz{% endblock %}
 
 {% block primary_download_button %}
-  {{ download_firefox(alt_copy='Jetzt herunterladen', locale_in_transition=true, dom_id="download-firefox", download_location='primary cta', button_color='button-green') }}
+  {{ download_firefox(alt_copy='Jetzt herunterladen', locale_in_transition=true, dom_id="download-firefox", download_location='primary cta') }}
 {% endblock %}
 
 {% block js %}

--- a/bedrock/firefox/templates/firefox/campaign/berlin/scene1-privat.html
+++ b/bedrock/firefox/templates/firefox/campaign/berlin/scene1-privat.html
@@ -9,7 +9,7 @@
 {% block body_class %}privat{% endblock %}
 
 {% block primary_download_button %}
-  {{ download_firefox(alt_copy='Jetzt herunterladen', locale_in_transition=true, dom_id="download-firefox", download_location='primary cta', button_color='button-green') }}
+  {{ download_firefox(alt_copy='Jetzt herunterladen', locale_in_transition=true, dom_id="download-firefox", download_location='primary cta') }}
 {% endblock %}
 
 {% block main_heading %}Zeit für mehr<br> Privatsphäre{% endblock %}

--- a/bedrock/firefox/templates/firefox/campaign/berlin/scene1.html
+++ b/bedrock/firefox/templates/firefox/campaign/berlin/scene1.html
@@ -7,7 +7,7 @@
 {% extends "firefox/campaign/berlin/base.html" %}
 
 {% block primary_download_button %}
-  {{ download_firefox(alt_copy='Jetzt herunterladen', locale_in_transition=true, dom_id="download-firefox", download_location='primary cta', button_color='button-green') }}
+  {{ download_firefox(alt_copy='Jetzt herunterladen', locale_in_transition=true, dom_id="download-firefox", download_location='primary cta') }}
 {% endblock %}
 
 {% block js %}

--- a/bedrock/firefox/templates/firefox/includes/download-button.html
+++ b/bedrock/firefox/templates/firefox/includes/download-button.html
@@ -18,7 +18,7 @@
     <ul>
       {% for plat in builds -%}
         <li><a href="{{ plat.download_link_direct or plat.download_link }}"
-               class="download-link button button-green mzp-c-button mzp-t-product"
+               class="download-link button mzp-c-button mzp-t-product"
                data-link-type="download"
                data-download-version="{{ plat.os }}"
                {% if plat.os == 'android' %}data-download-os="Android"

--- a/bedrock/firefox/templatetags/helpers.py
+++ b/bedrock/firefox/templatetags/helpers.py
@@ -100,7 +100,7 @@ def ios_builds(channel, builds=None):
 def download_firefox(ctx, channel='release', platform='all',
                      dom_id=None, locale=None, force_direct=False,
                      force_full_installer=False, force_funnelcake=False,
-                     alt_copy=None, button_color='button-green',
+                     alt_copy=None, button_color='button-blue',
                      locale_in_transition=False, download_location=None):
     """ Output a "download firefox" button.
 
@@ -115,7 +115,7 @@ def download_firefox(ctx, channel='release', platform='all',
     :param force_funnelcake: Force the download version for en-US Windows to be
             'latest', which bouncer will translate to the funnelcake build.
     :param alt_copy: Specifies alternate copy to use for download buttons.
-    :param button_color: Color of download button. Default to 'button-green'.
+    :param button_color: Color of download button. Default to 'button-blue'.
     :param locale_in_transition: Include the page locale in transitional download link.
     :param download_location: Specify the location of download button for
             GA reporting: 'primary cta', 'nav', 'sub nav', or 'other'.

--- a/media/css/firefox/campaign/berlin-variation.scss
+++ b/media/css/firefox/campaign/berlin-variation.scss
@@ -39,13 +39,13 @@ body {
     }
 }
 
-a.button:link.button-green:hover,
-a.button:link.button-green:focus,
-a.button:visited.button-green:hover,
-a.button:visited.button-green:focus {
+a.button:link.button-blue:hover,
+a.button:link.button-blue:focus,
+a.button:visited.button-blue:hover,
+a.button:visited.button-blue:focus {
         background-color: #fff;
-        border-color: darken($color-button-green, 5%);
-        color: darken($color-button-green, 5%);
+        border-color: darken($color-button-blue, 5%);
+        color: darken($color-button-blue, 5%);
 }
 
 /* -------------------------------------------------------------------------- */

--- a/media/css/pebbles/components/_buttons.scss
+++ b/media/css/pebbles/components/_buttons.scss
@@ -61,18 +61,6 @@ a.button:visited {
         }
     }
 
-    &.button-green {
-        background-color: $color-button-green;
-        border-color: $color-button-green;
-        color: $color-button-light;
-
-        &:hover,
-        &:focus {
-            background-color: saturate(darken($color-button-green, 5%), 10%);
-            border-color: saturate(darken($color-button-green, 5%), 10%);
-        }
-    }
-
     &.button-red {
         background-color: $color-mozred;
         border-color: $color-mozred;

--- a/media/css/pebbles/includes/_variables.scss
+++ b/media/css/pebbles/includes/_variables.scss
@@ -54,9 +54,8 @@ $color-link-yellow:     #ffbb38;
 // Button colors
 $color-button-light:    #fff;
 $color-button-dark:     #00539f;
-$color-button-green:    #12bc00;
 $color-button-orange:   #f26c23;
-$color-button-blue:     #0060df;
+$color-button-blue:     #0250bb;
 
 // Content widths
 $width-phone:           300px;


### PR DESCRIPTION
## Description
Removes the `.button-green` and `$color-button-green` class and variable from Pebbles. Pebbles will be removed per bedrock's technical roadmap (and potentially these templates, see: #8427), but I thought this would be a worthwhile quickfix for an outstanding issue.

## Issue / Bugzilla link
#5703

## Testing

- [ ] http://localhost:8000/de/firefox/campaign/?xv=berlin
- [ ] http://localhost:8000/de/firefox/campaign/?xv=aus-gruenden
- [ ] http://localhost:8000/de/firefox/campaign/?xv=herz
- [ ] http://localhost:8000/de/firefox/campaign/?xv=geschwindigkeit
- [ ] http://localhost:8000/de/firefox/campaign/?xv=privatsphare
- [ ] http://localhost:8000/de/firefox/campaign/?xv=auf-deiner-seite
- [ ] missing any templates?
- [ ] tests needing updated?