### PR TITLE
Use brand terms in firefox/switch Fluent migration (Fixes #8595)

### DIFF
--- a/bedrock/firefox/templates/firefox/switch.html
+++ b/bedrock/firefox/templates/firefox/switch.html
@@ -54,20 +54,15 @@
           </a>
         </li>
         <li>
-          {# L10n: the string below is for a referral Twitter message. #}
           {% set tweet_text = ftl('switch-firefox-makes-switching-fast-tweet') %}
           <a class="twitter" data-link-type="social share" data-link-name="Twitter" href="https://www.twitter.com/intent/tweet?url={{ share_url|urlencode }}&text={{ tweet_text|urlencode }}">
             {{ ftl('switch-send-a-tweet') }}
           </a>
         </li>
         <li>
-          {# L10n: the string below is the subject line for an email referral message. #}
           {% set email_subject = ftl('switch-switch-to-firefox')|mailtoencode %}
-          {# L10n: the string below is the introduction of the email referral message body. #}
           {% set email_intro = ftl('switch-hey')|mailtoencode %}
-          {# L10n: the string below is the first sentance of the email referral message body. #}
           {% set email_start = ftl('switch-firefox-makes-switching-fast-email')|mailtoencode %}
-          {# L10n: the string below is the second sentance of the email referral message body. At the end of the string after the colon, a URL will be added automatically. #}
           {% set email_end = ftl('switch-check-it-out')|mailtoencode %}
 
           {% set email_body = email_intro + '%0D%0A%0D%0A' + email_start + '%0D%0A%0D%0A' + email_end + '%20' + share_url|urlencode %}

--- a/docs/fluent-conversion.rst
+++ b/docs/fluent-conversion.rst
@@ -49,6 +49,29 @@ The existing recipe will already have the template name as prefix, though.
 You can also choose to remove strings from the conversion, if you just
 want to convert a subset of the strings.
 
+If you want to handle things such as updating existing translations to use
+brand terms as placeholders, you can update the recipe to replace existing
+string content by using the ``REPLACE()`` helper:
+
+.. code-block:: python
+
+    ctx.add_transforms(
+        "firefox/switch.ftl",
+        "firefox/switch.ftl",
+        [
+            FTL.Message(
+                id=FTL.Identifier("switch-switching-to-firefox-is-fast"),
+                value=REPLACE(
+                    "firefox/switch.lang",
+                    "Switching to Firefox is fast, easy and risk-free, because Firefox imports your bookmarks, autofills, passwords and preferences from Chrome.",
+                    {
+                        "Firefox": TERM_REFERENCE("brand-name-firefox")
+                    }
+                )
+            ),
+        ]
+    )
+
 Once you're happy with the recipe, you can create the Fluent files and the template.
 
 Convert a .lang file to English .ftl

--- a/docs/fluent-conversion.rst
+++ b/docs/fluent-conversion.rst
@@ -65,7 +65,8 @@ string content by using the ``REPLACE()`` helper:
                     "firefox/switch.lang",
                     "Switching to Firefox is fast, easy and risk-free, because Firefox imports your bookmarks, autofills, passwords and preferences from Chrome.",
                     {
-                        "Firefox": TERM_REFERENCE("brand-name-firefox")
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                        "Chrome": TERM_REFERENCE("brand-name-chrome")
                     }
                 )
             ),

--- a/l10n/en/brands.ftl
+++ b/l10n/en/brands.ftl
@@ -7,3 +7,4 @@
 
 -brand-name-firefox = Firefox
 -brand-name-firefox-browser = Firefox Browser
+-brand-name-chrome = Chrome

--- a/l10n/en/firefox/switch-en.ftl
+++ b/l10n/en/firefox/switch-en.ftl
@@ -5,4 +5,4 @@
 ### TODO: Merge the content here with switch.ftl to expose new string.
 ### This file is just a hack to avoid new content in the migration.
 
-switch-spread-the-word = Spread the word about { -brand-name-firefox } and help your favorite people say goodbye to Chrome.
+switch-spread-the-word = Spread the word about { -brand-name-firefox } and help your favorite people say goodbye to { -brand-name-chrome }.

--- a/l10n/en/firefox/switch-en.ftl
+++ b/l10n/en/firefox/switch-en.ftl
@@ -5,4 +5,4 @@
 ### TODO: Merge the content here with switch.ftl to expose new string.
 ### This file is just a hack to avoid new content in the migration.
 
-switch-spread-the-word = Spread the word about Firefox and help your favorite people say goodbye to Chrome.
+switch-spread-the-word = Spread the word about { -brand-name-firefox } and help your favorite people say goodbye to Chrome.

--- a/l10n/en/firefox/switch.ftl
+++ b/l10n/en/firefox/switch.ftl
@@ -4,21 +4,21 @@
 
 ### URL: https://www-dev.allizom.org/firefox/switch/
 
-switch-switch-from-chrome = Switch from Chrome to Firefox in just a few minutes
-switch-switching-to-firefox-is-fast = Switching to Firefox is fast, easy and risk-free, because Firefox imports your bookmarks, autofills, passwords and preferences from Chrome.
-switch-switching-to-firefox-page-description = Switching to Firefox is fast, easy and risk-free. Firefox imports your bookmarks, autofills, passwords and preferences from Chrome.
+switch-switch-from-chrome = Switch from Chrome to { -brand-name-firefox } in just a few minutes
+switch-switching-to-firefox-is-fast = Switching to { -brand-name-firefox } is fast, easy and risk-free, because { -brand-name-firefox } imports your bookmarks, autofills, passwords and preferences from Chrome.
+switch-switching-to-firefox-page-description = Switching to { -brand-name-firefox } is fast, easy and risk-free. { -brand-name-firefox } imports your bookmarks, autofills, passwords and preferences from Chrome.
 switch-select-what-to-take = Select what to take from Chrome.
-switch-let-firefox-do-the-rest = Let Firefox do the rest.
+switch-let-firefox-do-the-rest = Let { -brand-name-firefox } do the rest.
 switch-enjoy-the-web-faster = Enjoy the web faster, all set up for you.
 switch-download-and-switch = Download and switch
-switch-use-firefox-and-still-chrome = You can use Firefox and still have Chrome. Chrome won’t change on your machine one bit.
-switch-share-with-your-friends = Share with your friends how to switch to Firefox
+switch-use-firefox-and-still-chrome = You can use { -brand-name-firefox } and still have Chrome. Chrome won’t change on your machine one bit.
+switch-share-with-your-friends = Share with your friends how to switch to { -brand-name-firefox }
 switch-share-to-facebook = Share to Facebook
-switch-firefox-makes-switching-fast-tweet = 🔥 Firefox makes switching from Chrome really fast. Try it out!
+switch-firefox-makes-switching-fast-tweet = 🔥 { -brand-name-firefox } makes switching from Chrome really fast. Try it out!
 switch-send-a-tweet = Send a tweet
-switch-switch-to-firefox = Switch to Firefox
+switch-switch-to-firefox = Switch to { -brand-name-firefox }
 switch-hey = Hey,
-switch-firefox-makes-switching-fast-email = Firefox makes switching from Chrome really fast. I like it a lot, and you should try it.
+switch-firefox-makes-switching-fast-email = { -brand-name-firefox } makes switching from Chrome really fast. I like it a lot, and you should try it.
 switch-check-it-out = Check it out and let me know what you think:
 switch-send-an-email = Send an email
-switch-still-not-convinced = Still not convinced that switching to Firefox is easy?
+switch-still-not-convinced = Still not convinced that switching to { -brand-name-firefox } is easy?

--- a/l10n/en/firefox/switch.ftl
+++ b/l10n/en/firefox/switch.ftl
@@ -4,21 +4,21 @@
 
 ### URL: https://www-dev.allizom.org/firefox/switch/
 
-switch-switch-from-chrome = Switch from Chrome to { -brand-name-firefox } in just a few minutes
-switch-switching-to-firefox-is-fast = Switching to { -brand-name-firefox } is fast, easy and risk-free, because { -brand-name-firefox } imports your bookmarks, autofills, passwords and preferences from Chrome.
-switch-switching-to-firefox-page-description = Switching to { -brand-name-firefox } is fast, easy and risk-free. { -brand-name-firefox } imports your bookmarks, autofills, passwords and preferences from Chrome.
-switch-select-what-to-take = Select what to take from Chrome.
+switch-switch-from-chrome = Switch from { -brand-name-chrome } to { -brand-name-firefox } in just a few minutes
+switch-switching-to-firefox-is-fast = Switching to { -brand-name-firefox } is fast, easy and risk-free, because { -brand-name-firefox } imports your bookmarks, autofills, passwords and preferences from { -brand-name-chrome }.
+switch-switching-to-firefox-page-description = Switching to { -brand-name-firefox } is fast, easy and risk-free. { -brand-name-firefox } imports your bookmarks, autofills, passwords and preferences from { -brand-name-chrome }.
+switch-select-what-to-take = Select what to take from { -brand-name-chrome }.
 switch-let-firefox-do-the-rest = Let { -brand-name-firefox } do the rest.
+switch-use-firefox-and-still-chrome = You can use { -brand-name-firefox } and still have { -brand-name-chrome }. { -brand-name-chrome } won’t change on your machine one bit.
+switch-share-with-your-friends = Share with your friends how to switch to { -brand-name-firefox }
+switch-firefox-makes-switching-fast-tweet = 🔥 { -brand-name-firefox } makes switching from { -brand-name-chrome } really fast. Try it out!
+switch-switch-to-firefox = Switch to { -brand-name-firefox }
+switch-firefox-makes-switching-fast-email = { -brand-name-firefox } makes switching from { -brand-name-chrome } really fast. I like it a lot, and you should try it.
+switch-still-not-convinced = Still not convinced that switching to { -brand-name-firefox } is easy?
 switch-enjoy-the-web-faster = Enjoy the web faster, all set up for you.
 switch-download-and-switch = Download and switch
-switch-use-firefox-and-still-chrome = You can use { -brand-name-firefox } and still have Chrome. Chrome won’t change on your machine one bit.
-switch-share-with-your-friends = Share with your friends how to switch to { -brand-name-firefox }
 switch-share-to-facebook = Share to Facebook
-switch-firefox-makes-switching-fast-tweet = 🔥 { -brand-name-firefox } makes switching from Chrome really fast. Try it out!
 switch-send-a-tweet = Send a tweet
-switch-switch-to-firefox = Switch to { -brand-name-firefox }
 switch-hey = Hey,
-switch-firefox-makes-switching-fast-email = { -brand-name-firefox } makes switching from Chrome really fast. I like it a lot, and you should try it.
 switch-check-it-out = Check it out and let me know what you think:
 switch-send-an-email = Send an email
-switch-still-not-convinced = Still not convinced that switching to { -brand-name-firefox } is easy?

--- a/lib/fluent_migrations/firefox/switch.py
+++ b/lib/fluent_migrations/firefox/switch.py
@@ -13,23 +13,120 @@ def migrate(ctx):
         "firefox/switch.ftl",
         "firefox/switch.ftl",
         transforms_from("""
-switch-switch-from-chrome = {COPY(switch, "Switch from Chrome to Firefox in just a few minutes",)}
-switch-switching-to-firefox-is-fast = {COPY(switch, "Switching to Firefox is fast, easy and risk-free, because Firefox imports your bookmarks, autofills, passwords and preferences from Chrome.",)}
-switch-switching-to-firefox-page-description = {COPY(switch, "Switching to Firefox is fast, easy and risk-free. Firefox imports your bookmarks, autofills, passwords and preferences from Chrome.",)}
 switch-select-what-to-take = {COPY(switch, "Select what to take from Chrome.",)}
-switch-let-firefox-do-the-rest = {COPY(switch, "Let Firefox do the rest.",)}
 switch-enjoy-the-web-faster = {COPY(switch, "Enjoy the web faster, all set up for you.",)}
 switch-download-and-switch = {COPY(switch, "Download and switch",)}
-switch-use-firefox-and-still-chrome = {COPY(switch, "You can use Firefox and still have Chrome. Chrome won’t change on your machine one bit.",)}
-switch-share-with-your-friends = {COPY(switch, "Share with your friends how to switch to Firefox",)}
 switch-share-to-facebook = {COPY(switch, "Share to Facebook",)}
-switch-firefox-makes-switching-fast-tweet = {COPY(switch, "🔥 Firefox makes switching from Chrome really fast. Try it out!",)}
 switch-send-a-tweet = {COPY(switch, "Send a tweet",)}
-switch-switch-to-firefox = {COPY(switch, "Switch to Firefox",)}
 switch-hey = {COPY(switch, "Hey,",)}
-switch-firefox-makes-switching-fast-email = {COPY(switch, "Firefox makes switching from Chrome really fast. I like it a lot, and you should try it.",)}
 switch-check-it-out = {COPY(switch, "Check it out and let me know what you think:",)}
 switch-send-an-email = {COPY(switch, "Send an email",)}
-switch-still-not-convinced = {COPY(switch, "Still not convinced that switching to Firefox is easy?",)}
 """, switch=switch)
         )
+
+    ctx.add_transforms(
+        "firefox/switch.ftl",
+        "firefox/switch.ftl",
+        [
+            FTL.Message(
+                id=FTL.Identifier("switch-switch-from-chrome"),
+                value=REPLACE(
+                    "firefox/switch.lang",
+                    "Switch from Chrome to Firefox in just a few minutes",
+                    {
+                        "Firefox": TERM_REFERENCE("brand-name-firefox")
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("switch-switching-to-firefox-is-fast"),
+                value=REPLACE(
+                    "firefox/switch.lang",
+                    "Switching to Firefox is fast, easy and risk-free, because Firefox imports your bookmarks, autofills, passwords and preferences from Chrome.",
+                    {
+                        "Firefox": TERM_REFERENCE("brand-name-firefox")
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("switch-switching-to-firefox-page-description"),
+                value=REPLACE(
+                    "firefox/switch.lang",
+                    "Switching to Firefox is fast, easy and risk-free. Firefox imports your bookmarks, autofills, passwords and preferences from Chrome.",
+                    {
+                        "Firefox": TERM_REFERENCE("brand-name-firefox")
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("switch-let-firefox-do-the-rest"),
+                value=REPLACE(
+                    "firefox/switch.lang",
+                    "Let Firefox do the rest.",
+                    {
+                        "Firefox": TERM_REFERENCE("brand-name-firefox")
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("switch-use-firefox-and-still-chrome"),
+                value=REPLACE(
+                    "firefox/switch.lang",
+                    "You can use Firefox and still have Chrome. Chrome won’t change on your machine one bit.",
+                    {
+                        "Firefox": TERM_REFERENCE("brand-name-firefox")
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("switch-share-with-your-friends"),
+                value=REPLACE(
+                    "firefox/switch.lang",
+                    "Share with your friends how to switch to Firefox",
+                    {
+                        "Firefox": TERM_REFERENCE("brand-name-firefox")
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("switch-firefox-makes-switching-fast-tweet"),
+                value=REPLACE(
+                    "firefox/switch.lang",
+                    "🔥 Firefox makes switching from Chrome really fast. Try it out!",
+                    {
+                        "Firefox": TERM_REFERENCE("brand-name-firefox")
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("switch-switch-to-firefox"),
+                value=REPLACE(
+                    "firefox/switch.lang",
+                    "Switch to Firefox",
+                    {
+                        "Firefox": TERM_REFERENCE("brand-name-firefox")
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("switch-firefox-makes-switching-fast-email"),
+                value=REPLACE(
+                    "firefox/switch.lang",
+                    "Firefox makes switching from Chrome really fast. I like it a lot, and you should try it.",
+                    {
+                        "Firefox": TERM_REFERENCE("brand-name-firefox")
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("switch-still-not-convinced"),
+                value=REPLACE(
+                    "firefox/switch.lang",
+                    "Still not convinced that switching to Firefox is easy?",
+                    {
+                        "Firefox": TERM_REFERENCE("brand-name-firefox")
+                    }
+                )
+            ),
+        ]
+    )

--- a/lib/fluent_migrations/firefox/switch.py
+++ b/lib/fluent_migrations/firefox/switch.py
@@ -12,21 +12,6 @@ def migrate(ctx):
     ctx.add_transforms(
         "firefox/switch.ftl",
         "firefox/switch.ftl",
-        transforms_from("""
-switch-select-what-to-take = {COPY(switch, "Select what to take from Chrome.",)}
-switch-enjoy-the-web-faster = {COPY(switch, "Enjoy the web faster, all set up for you.",)}
-switch-download-and-switch = {COPY(switch, "Download and switch",)}
-switch-share-to-facebook = {COPY(switch, "Share to Facebook",)}
-switch-send-a-tweet = {COPY(switch, "Send a tweet",)}
-switch-hey = {COPY(switch, "Hey,",)}
-switch-check-it-out = {COPY(switch, "Check it out and let me know what you think:",)}
-switch-send-an-email = {COPY(switch, "Send an email",)}
-""", switch=switch)
-        )
-
-    ctx.add_transforms(
-        "firefox/switch.ftl",
-        "firefox/switch.ftl",
         [
             FTL.Message(
                 id=FTL.Identifier("switch-switch-from-chrome"),
@@ -34,7 +19,8 @@ switch-send-an-email = {COPY(switch, "Send an email",)}
                     "firefox/switch.lang",
                     "Switch from Chrome to Firefox in just a few minutes",
                     {
-                        "Firefox": TERM_REFERENCE("brand-name-firefox")
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                        "Chrome": TERM_REFERENCE("brand-name-chrome")
                     }
                 )
             ),
@@ -44,7 +30,8 @@ switch-send-an-email = {COPY(switch, "Send an email",)}
                     "firefox/switch.lang",
                     "Switching to Firefox is fast, easy and risk-free, because Firefox imports your bookmarks, autofills, passwords and preferences from Chrome.",
                     {
-                        "Firefox": TERM_REFERENCE("brand-name-firefox")
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                        "Chrome": TERM_REFERENCE("brand-name-chrome")
                     }
                 )
             ),
@@ -54,7 +41,18 @@ switch-send-an-email = {COPY(switch, "Send an email",)}
                     "firefox/switch.lang",
                     "Switching to Firefox is fast, easy and risk-free. Firefox imports your bookmarks, autofills, passwords and preferences from Chrome.",
                     {
-                        "Firefox": TERM_REFERENCE("brand-name-firefox")
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                        "Chrome": TERM_REFERENCE("brand-name-chrome")
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("switch-select-what-to-take"),
+                value=REPLACE(
+                    "firefox/switch.lang",
+                    "Select what to take from Chrome.",
+                    {
+                        "Chrome": TERM_REFERENCE("brand-name-chrome")
                     }
                 )
             ),
@@ -74,7 +72,8 @@ switch-send-an-email = {COPY(switch, "Send an email",)}
                     "firefox/switch.lang",
                     "You can use Firefox and still have Chrome. Chrome won’t change on your machine one bit.",
                     {
-                        "Firefox": TERM_REFERENCE("brand-name-firefox")
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                        "Chrome": TERM_REFERENCE("brand-name-chrome")
                     }
                 )
             ),
@@ -94,7 +93,8 @@ switch-send-an-email = {COPY(switch, "Send an email",)}
                     "firefox/switch.lang",
                     "🔥 Firefox makes switching from Chrome really fast. Try it out!",
                     {
-                        "Firefox": TERM_REFERENCE("brand-name-firefox")
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                        "Chrome": TERM_REFERENCE("brand-name-chrome")
                     }
                 )
             ),
@@ -114,7 +114,8 @@ switch-send-an-email = {COPY(switch, "Send an email",)}
                     "firefox/switch.lang",
                     "Firefox makes switching from Chrome really fast. I like it a lot, and you should try it.",
                     {
-                        "Firefox": TERM_REFERENCE("brand-name-firefox")
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                        "Chrome": TERM_REFERENCE("brand-name-chrome")
                     }
                 )
             ),
@@ -130,3 +131,17 @@ switch-send-an-email = {COPY(switch, "Send an email",)}
             ),
         ]
     )
+
+    ctx.add_transforms(
+        "firefox/switch.ftl",
+        "firefox/switch.ftl",
+        transforms_from("""
+switch-enjoy-the-web-faster = {COPY(switch, "Enjoy the web faster, all set up for you.",)}
+switch-download-and-switch = {COPY(switch, "Download and switch",)}
+switch-share-to-facebook = {COPY(switch, "Share to Facebook",)}
+switch-send-a-tweet = {COPY(switch, "Send a tweet",)}
+switch-hey = {COPY(switch, "Hey,",)}
+switch-check-it-out = {COPY(switch, "Check it out and let me know what you think:",)}
+switch-send-an-email = {COPY(switch, "Send an email",)}
+""", switch=switch)
+        )


### PR DESCRIPTION
## Description
- Updates the existing Fluent migration to use brand name placeholders in the translations.
- Add an example to our Fluent conversion docs.

Disclaimer: I managed to piece this together by browsing through existing migration files for Firefox in [mozilla-central](https://hg.mozilla.org/mozilla-central/file/tip/python/l10n/fluent_migrations/bug_1600528_browser_context.py). I couldn't find much documentation, and was working on a couple of key pointers from Flod. That said, it seems to be working.

## Issue / Bugzilla link
#8595

## Testing
- [ ] I ran `./manage.py fluent ftl lib/fluent_migrations/firefox/switch.py de it` and it migrated the .lang content for those locales and updated the copy to use the brand names correctly.
- [ ] Translations should still appear as expected.