### PR TITLE
Convert FxA macro buttons to python helpers (Fixes #8185)

### DIFF
--- a/bedrock/base/templates/includes/protocol/footer/firefox.html
+++ b/bedrock/base/templates/includes/protocol/footer/firefox.html
@@ -2,8 +2,6 @@
  # License, v. 2.0. If a copy of the MPL was not distributed with this
  # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
 
-{% from "macros.html" import fxa_link_fragment with context %}
-
 <footer class="mzp-c-footer mzp-t-firefox" id="colophon">
   <div class="mzp-l-content">
     <nav class="mzp-c-footer-primary">
@@ -46,8 +44,27 @@
             {{ ftl('footer-join') }}
           </h5>
           <ul class="mzp-c-footer-list">
-            <li class="fxa-signin"><a {{ fxa_link_fragment(entrypoint='mozilla.org-firefoxfooter', action='signup', utm_campaign='footer', utm_content='join-sign-up') }} class="js-fxa-cta-link" rel="external noopener"  data-link-type="footer" data-link-name="Sign Up">{{ ftl('footer-sign-up') }}</a></li>
-            <li class="fxa-signin"><a {{ fxa_link_fragment(entrypoint='mozilla.org-firefoxfooter', action='signin', utm_campaign='footer', utm_content='join-sign-in') }} class="js-fxa-cta-link" rel="external noopener"  data-link-type="footer" data-link-name="Sign In">{{ ftl('footer-sign-in') }}</a></li>
+            <li class="fxa-signin">
+              {{ fxa_button(
+                entrypoint='mozilla.org-firefoxfooter',
+                button_text=ftl('footer-sign-up'),
+                is_button_class=False,
+                include_metrics=False,
+                optional_parameters={'utm_campaign': 'footer', 'utm_content': 'join-sign-up'},
+                optional_attributes={'data-cta-text': 'Sign Up', 'data-cta-type': 'fxa-sync', 'data-cta-position': 'footer'}
+              ) }}
+            </li>
+            <li class="fxa-signin">
+              {{ fxa_button(
+                entrypoint='mozilla.org-firefoxfooter',
+                button_text=ftl('footer-sign-in'),
+                action='signin',
+                is_button_class=False,
+                include_metrics=False,
+                optional_parameters={'utm_campaign': 'footer', 'utm_content': 'join-sign-in'},
+                optional_attributes={'data-cta-text': 'Sign In', 'data-cta-type': 'fxa-sync', 'data-cta-position': 'footer'}
+              ) }}
+            </li>
             <li><a href="{{ url('firefox.accounts') }}" data-link-type="footer" data-link-name="Benefits">{{ ftl('footer-benefits') }}</a></li>
           </ul>
         </section>

--- a/bedrock/base/templates/includes/protocol/navigation/menu-firefox/index.html
+++ b/bedrock/base/templates/includes/protocol/navigation/menu-firefox/index.html
@@ -2,8 +2,6 @@
  # License, v. 2.0. If a copy of the MPL was not distributed with this
  # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
 
-{% from "macros.html" import fxa_link_fragment with context %}
-
 <div class="mzp-c-navigation top-header-navigation mzp-t-firefox">
   <div class="mzp-c-navigation-l-content">
     <div class="mzp-c-navigation-container">

--- a/bedrock/base/templates/includes/protocol/navigation/menu-firefox/join.html
+++ b/bedrock/base/templates/includes/protocol/navigation/menu-firefox/join.html
@@ -2,8 +2,6 @@
  # License, v. 2.0. If a copy of the MPL was not distributed with this
  # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
 
-{% from "macros.html" import fxa_link_fragment with context %}
-
 <li class="mzp-c-menu-category mzp-has-drop-down mzp-js-expandable">
   <a class="mzp-c-menu-title" href="{{ url('firefox.accounts') }}" aria-haspopup="true" aria-controls="mzp-c-menu-panel-join">{{ ftl('navigation-join') }}</a>
   <div class="mzp-c-menu-panel mzp-has-card" id="mzp-c-menu-panel-join">
@@ -19,8 +17,27 @@
                 <p class="mzp-c-menu-item-desc">{{ ftl('navigation-access-all-of-firefox') }}</p>
               </a>
               <ul class="mzp-c-menu-item-list">
-                <li class="fxa-signin"><a {{ fxa_link_fragment(entrypoint='mozilla.org-firefoxnav', action='signin', utm_campaign='nav', utm_content='join-sign-in') }} class="js-fxa-cta-link" rel="external noopener" data-link-name="Accounts Sign In" data-link-type="nav" data-link-position="subnav" data-link-group="browsers">{{ ftl('navigation-sign-in') }}</a></li>
-                <li class="fxa-signin"><a {{ fxa_link_fragment(entrypoint='mozilla.org-firefoxnav', action='signup', utm_campaign='nav', utm_content='join-sign-up') }} class="js-fxa-cta-link" rel="external noopener" data-link-name="Accounts Sign Up" data-link-type="nav" data-link-position="subnav" data-link-group="browsers">{{ ftl('navigation-sign-up') }}</a></li>
+                <li class="fxa-signin">
+                  {{ fxa_button(
+                    entrypoint='mozilla.org-firefoxnav',
+                    button_text=ftl('navigation-sign-in'),
+                    action='signin',
+                    is_button_class=False,
+                    include_metrics=False,
+                    optional_parameters={'utm_campaign': 'navigation', 'utm_content': 'join-sign-in'},
+                    optional_attributes={'data-cta-text': 'Sign In', 'data-cta-type': 'fxa-sync', 'data-cta-position': 'navigation'}
+                  ) }}
+                </li>
+                <li class="fxa-signin">
+                  {{ fxa_button(
+                    entrypoint='mozilla.org-firefoxnav',
+                    button_text=ftl('navigation-sign-up'),
+                    is_button_class=False,
+                    include_metrics=False,
+                    optional_parameters={'utm_campaign': 'navigation', 'utm_content': 'join-sign-up'},
+                    optional_attributes={'data-cta-text': 'Sign Up', 'data-cta-type': 'fxa-sync', 'data-cta-position': 'navigation'}
+                  ) }}
+                </li>
                 <li><a href="{{ url('firefox.accounts') }}" data-link-name="Benefits" data-link-type="nav" data-link-position="subnav" data-link-group="browsers">{{ ftl('navigation-benefits') }}</a></li>
               </ul>
             </section>

--- a/bedrock/base/templates/includes/protocol/navigation/menu-mozilla/index.html
+++ b/bedrock/base/templates/includes/protocol/navigation/menu-mozilla/index.html
@@ -2,8 +2,6 @@
  # License, v. 2.0. If a copy of the MPL was not distributed with this
  # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
 
-{% from "macros.html" import fxa_link_fragment with context %}
-
 <div class="mzp-c-navigation top-header-navigation">
   <div class="mzp-c-navigation-l-content">
     <div class="mzp-c-navigation-container">

--- a/bedrock/base/templates/includes/protocol/navigation/nav-cta.html
+++ b/bedrock/base/templates/includes/protocol/navigation/nav-cta.html
@@ -8,12 +8,16 @@
       {{ download_firefox(alt_copy=ftl('download-button-download-firefox'), dom_id='protocol-nav-download-firefox', button_color='mzp-t-secondary mzp-t-small', download_location='nav') }}
     {% endif %}
     {% if not hide_nav_get_account_button %}
-      <div class="c-navigation-fxa-cta-container">
-        <a class="c-navigation-fxa-cta mzp-c-button mzp-t-secondary mzp-t-small mzp-t-product js-fxa-cta-link" {{ fxa_link_fragment(entrypoint='mozilla.org-globalnav', action='signup', utm_campaign='globalnav', utm_content='get-firefox-account') }} data-cta-text="Get a Firefox Account" data-cta-type="FxA-Sync" data-cta-position="Navigation" data-alt-href="{{ url('firefox.accounts') }}">
-          {{ ftl('navigation-get-a-firefox-account') }}
-        </a>
-        <p class="c-navigation-fxa-cta-small-link"><a data-link-type="nav" data-link-name="Check out the Benefits" href="{{ url('firefox.accounts') }}">{{ ftl('navigation-check-out-the-benefits') }}</a></p>
-      </div>
+    <div class="c-navigation-fxa-cta-container">
+      {{ fxa_button(
+        entrypoint='mozilla.org-globalnav',
+        button_text=ftl('navigation-get-a-firefox-account'),
+        class_name='mzp-t-secondary mzp-t-small c-navigation-fxa-cta',
+        optional_parameters={'utm_campaign': 'navigation', 'utm_content': 'get-firefox-account'},
+        optional_attributes={'data-cta-text': 'Get a Firefox Account', 'data-cta-type': 'fxa-sync', 'data-cta-position': 'navigation', 'data-alt-href': url('firefox.accounts')}
+      ) }}
+      <p class="c-navigation-fxa-cta-small-link"><a data-link-type="nav" data-link-name="Check out the Benefits" href="{{ url('firefox.accounts') }}">{{ ftl('navigation-check-out-the-benefits') }}</a></p>
+    </div>
     {% endif %}
   </div>
 {% endif %}

--- a/bedrock/base/templates/includes/protocol/navigation/nav-cta.html
+++ b/bedrock/base/templates/includes/protocol/navigation/nav-cta.html
@@ -11,6 +11,7 @@
     <div class="c-navigation-fxa-cta-container">
       {{ fxa_button(
         entrypoint='mozilla.org-globalnav',
+        include_metrics=False,
         button_text=ftl('navigation-get-a-firefox-account'),
         class_name='mzp-t-secondary mzp-t-small c-navigation-fxa-cta',
         optional_parameters={'utm_campaign': 'navigation', 'utm_content': 'get-firefox-account'},

--- a/bedrock/base/templates/macros.html
+++ b/bedrock/base/templates/macros.html
@@ -133,60 +133,6 @@
   </section>
 {%- endmacro %}
 
-{# Docs: https://bedrock.readthedocs.io/en/latest/firefox-accounts.html#linking-to-accountsfirefoxcom #}
-{% macro fxa_link_fragment(entrypoint, entrypoint_experiment=None, entrypoint_variation=None, action='signin', form_type='button', utm_campaign=None, utm_content=None, utm_term=None) -%}
-  {% set fxa_path = '' %}
-  {% set fxa_queries = [
-    'form_type=' ~ form_type,
-    'entrypoint=' ~ entrypoint,
-    'utm_source=' ~ entrypoint,
-    'utm_medium=referral'
-  ] %}
-
-  {% if action == 'signup' %}
-    {% set fxa_path = 'signup?' %}
-  {% elif action == 'signin' %}
-    {% set fxa_path = 'signin?' %}
-  {% else %}
-    {% do fxa_queries.insert(0, 'action=email') %}
-  {% endif %}
-
-  {# utm_campaign is optional #}
-  {% if utm_campaign %}
-    {% do fxa_queries.append('utm_campaign=' ~ utm_campaign) %}
-  {% endif %}
-
-  {# utm_content is optional #}
-  {% if utm_content %}
-    {% do fxa_queries.append('utm_content=' ~ utm_content) %}
-  {% endif %}
-
-  {# utm_term is optional #}
-  {% if utm_term %}
-    {% do fxa_queries.append('utm_term=' ~ utm_term) %}
-  {% endif %}
-
-  {# entrypoint_experiment is optional #}
-  {% if entrypoint_experiment %}
-    {% do fxa_queries.append('entrypoint_experiment=' ~ entrypoint_experiment) %}
-  {% endif %}
-
-  {# entrypoint_variation is optional #}
-  {% if entrypoint_variation %}
-    {% do fxa_queries.append('entrypoint_variation=' ~ entrypoint_variation) %}
-  {% endif %}
-
-  href="{{ settings.FXA_ENDPOINT }}{{ fxa_path }}{{ fxa_queries|join('&') }}" data-mozillaonline-link="{{ settings.FXA_ENDPOINT_MOZILLAONLINE }}{{ fxa_path }}{{ fxa_queries|join('&') }}"
-
-{%- endmacro %}
-
-{# Docs: https://bedrock.readthedocs.io/en/latest/firefox-accounts.html#linking-to-accountsfirefoxcom #}
-{% macro fxa_cta_link(entrypoint, button_text, entrypoint_experiment=None, entrypoint_variation=None, form_type='button', action='signin', account_id=None, button_class=None, utm_campaign=None, utm_content=None, utm_term=None) %}
-  <a data-action="{{ settings.FXA_ENDPOINT }}" {{ fxa_link_fragment(entrypoint=entrypoint, entrypoint_experiment=entrypoint_experiment, entrypoint_variation=entrypoint_variation, form_type=form_type, action=action, utm_campaign=utm_campaign, utm_content=utm_content, utm_term=utm_term) }} class="js-fxa-cta-link{% if button_class %} {{ button_class }}{% endif %}" data-cta-text="Create account" data-cta-type="fxa-sync" data-cta-position="{{ button_location }}" {%if account_id %}id="{{ account_id }}"{% endif %}>
-    {{ button_text }}
-  </a>
-{%- endmacro %}
-
 {# Docs: https://bedrock.readthedocs.io/en/latest/firefox-accounts.html#signup-form #}
 {% macro fxa_email_form(entrypoint, entrypoint_experiment, entrypoint_variation, context=None, utm_campaign=None, utm_content=None, utm_term=None, style=None, class_name='fxa-email-form', form_title=None, intro_text=none, button_text=None, button_class='button button-blue') -%}
   <form action="{{ settings.FXA_ENDPOINT }}" data-mozillaonline-action="{{ settings.FXA_ENDPOINT_MOZILLAONLINE }}" id="fxa-email-form" class="{{ class_name }}">

--- a/bedrock/exp/templates/exp/firefox/accounts-2019.html
+++ b/bedrock/exp/templates/exp/firefox/accounts-2019.html
@@ -3,7 +3,7 @@
  # file, You can obtain one at http://mozilla.org/MPL/2.0/. #}
 
 {% from "macros-protocol.html" import feature_card with context %}
-{% from "macros.html" import fxa_email_form, fxa_link_fragment with context %}
+{% from "macros.html" import fxa_email_form with context %}
 
 {% extends "exp/base/base-firefox.html" %}
 
@@ -69,7 +69,18 @@
         utm_campaign=_utm_campaign)
       }}
 
-      <p class="fxa-signin">Already have an account? <a {{ fxa_link_fragment(entrypoint=_entrypoint, action='signin', utm_campaign=_utm_campaign, utm_content='form-upper') }} class="js-fxa-cta-link">Sign In</a></p>
+      <p class="fxa-signin">
+        Already have an account?
+
+        {{ fxa_button(
+          entrypoint=_entrypoint,
+          button_text='Sign In',
+          action='signin',
+          is_button_class=False,
+          optional_parameters={'utm_campaign': _utm_campaign, 'utm_content': 'form-upper'},
+          optional_attributes={'data-cta-text': 'Sign In', 'data-cta-type': 'fxa-sync', 'data-cta-position': 'primary'}
+        ) }}
+      </p>
     </div>
   </div>
 </section>

--- a/bedrock/exp/templates/exp/firefox/index.de.html
+++ b/bedrock/exp/templates/exp/firefox/index.de.html
@@ -2,7 +2,6 @@
  # License, v. 2.0. If a copy of the MPL was not distributed with this
  # file, You can obtain one at http://mozilla.org/MPL/2.0/. #}
 
-{% from "macros.html" import fxa_cta_link with context %}
 {% from "macros-protocol.html" import call_out, call_out_compact, feature_card with context %}
 
 {% extends "exp/base/base-firefox.html" %}
@@ -240,7 +239,13 @@
         </div>
         <h2 class="c-end-title">Ein Login. Auf all deinen Geräten. Eine ganze Reihe an Produkten, die deine <strong>Privatsphäre</strong> respektieren.</h2>
         <div class="mzp-c-button-download-container">
-          {{ fxa_cta_link(entrypoint='mozilla.org-firefox_home', action='signup', button_text='Join Firefox', button_class='mzp-c-button mzp-t-product mzp-t-small', utm_campaign='firefox-home', utm_content='secondary-join-firefox') }}
+          {{ fxa_button(
+            entrypoint='mozilla.org-firefox_home',
+            button_text='Komm zu Firefox',
+            class_name='mzp-t-small',
+            optional_parameters={'utm_campaign': 'firefox-home', 'utm_content': 'secondary-join-firefox'},
+            optional_attributes={'data-cta-text': 'Join Firefox', 'data-cta-type': 'fxa-sync', 'data-cta-position': 'secondary'}
+          ) }}
           <small class="mzp-c-button-download-privacy-link">
             <a href="{{ url('firefox.accounts') }}">Was es bedeutet, Firefox zu nutzen</a>
           </small>

--- a/bedrock/exp/templates/exp/firefox/index.html
+++ b/bedrock/exp/templates/exp/firefox/index.html
@@ -2,7 +2,6 @@
  # License, v. 2.0. If a copy of the MPL was not distributed with this
  # file, You can obtain one at http://mozilla.org/MPL/2.0/. #}
 
-{% from "macros.html" import fxa_cta_link with context %}
 {% from "macros-protocol.html" import call_out, call_out_compact, feature_card with context %}
 
 {% extends "exp/base/base-firefox.html" %}
@@ -249,7 +248,13 @@
         </div>
         <h2 class="c-end-title">One login. All your devices. A family of products that respect your <strong>privacy</strong>.</h2>
         <div class="mzp-c-button-download-container">
-          {{ fxa_cta_link(entrypoint='mozilla.org-firefox_home', action='signup', button_text='Join Firefox', button_class='mzp-c-button mzp-t-product mzp-t-small', utm_campaign='firefox-home', utm_content='secondary-join-firefox') }}
+          {{ fxa_button(
+            entrypoint='mozilla.org-firefox_home',
+            button_text='Join Firefox',
+            class_name='mzp-t-small',
+            optional_parameters={'utm_campaign': 'firefox-home', 'utm_content': 'secondary-join-firefox'},
+            optional_attributes={'data-cta-text': 'Join Firefox', 'data-cta-type': 'fxa-sync', 'data-cta-position': 'secondary'}
+          ) }}
           <small class="mzp-c-button-download-privacy-link">
             <a href="{{ url('firefox.accounts') }}">Learn more about joining Firefox</a>
           </small>

--- a/bedrock/exp/templates/exp/firefox/whatsnew/whatsnew-fx71.html
+++ b/bedrock/exp/templates/exp/firefox/whatsnew/whatsnew-fx71.html
@@ -2,8 +2,6 @@
  # License, v. 2.0. If a copy of the MPL was not distributed with this
  # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
 
-{% from "macros.html" import fxa_cta_link with context %}
-
 {% extends "exp/base/base-firefox.html" %}
 
 {# "noindex" pages should not have the canonical or hreflang tags: bug 1442331 #}
@@ -40,7 +38,15 @@
         </h2>
         <p>The Firefox browser collects so little data about you, we don’t even require your email address. But when you use it to create a Firefox account, we can protect your privacy across more of your online life.</p>
 
-        <p class="cta">{{ fxa_cta_link(entrypoint=_entrypoint, action='signup', button_text='Sign In', button_class='mzp-c-button mzp-t-product mzp-t-small js-fxa-product-button', utm_campaign=_utm_campaign, utm_content='top-cta') }}</p>
+        <p class="cta">
+          {{ fxa_button(
+            entrypoint=_entrypoint,
+            button_text='Sign In',
+            class_name='mzp-t-small',
+            optional_parameters={'utm_campaign': _utm_campaign, 'utm_content': 'top-cta'},
+            optional_attributes={'data-cta-text': 'Sign In', 'data-cta-type': 'fxa-sync', 'data-cta-position': 'primary'}
+          ) }}
+        </p>
       </div>
     </div>
   </section>
@@ -100,7 +106,15 @@
         </div>
       </div>
 
-      <p class="cta">{{ fxa_cta_link(entrypoint=_entrypoint, action='signup', button_text='Get a Firefox Account', button_class='mzp-c-button mzp-t-product mzp-t-small js-fxa-product-button', utm_campaign=_utm_campaign, utm_content='bottom-cta') }}</p>
+      <p class="cta">
+        {{ fxa_button(
+          entrypoint=_entrypoint,
+          button_text='Get a Firefox Account',
+          class_name='mzp-t-small',
+          optional_parameters={'utm_campaign': _utm_campaign, 'utm_content': 'bottom-cta'},
+          optional_attributes={'data-cta-text': 'Get a Firefox Account', 'data-cta-type': 'fxa-sync', 'data-cta-position': 'secondary'}
+        ) }}
+      </p>
     </div>
   </section>
 

--- a/bedrock/firefox/templates/firefox/accounts-2019.html
+++ b/bedrock/firefox/templates/firefox/accounts-2019.html
@@ -3,7 +3,7 @@
   # file, You can obtain one at http://mozilla.org/MPL/2.0/. #}
 
 {% from "macros-protocol.html" import feature_card with context %}
-{% from "macros.html" import fxa_email_form, fxa_link_fragment with context %}
+{% from "macros.html" import fxa_email_form with context %}
 
 {% extends "firefox/base/base-protocol.html" %}
 
@@ -84,7 +84,17 @@
         utm_campaign=_utm_campaign)
       }}
 
-      <p class="fxa-signin">{{ _('Already have an account?') }} <a {{ fxa_link_fragment(entrypoint=_entrypoint, action='signin', utm_campaign=_utm_campaign, utm_content='form-upper') }} class="js-fxa-cta-link">{{ _('Sign In') }}</a></p>
+      <p class="fxa-signin">
+        {{ _('Already have an account?') }}
+
+        {{ fxa_button(
+          entrypoint=_entrypoint,
+          button_text=_('Sign In'),
+          action='signin',
+          is_button_class=False,
+          optional_parameters={'utm_campaign': _utm_campaign, 'utm_content': 'form-upper'},
+          optional_attributes={'data-cta-text': 'Sign In', 'data-cta-type': 'fxa-sync', 'data-cta-position': 'primary'}
+        ) }}
     </div>
   </div>
 </section>

--- a/bedrock/firefox/templates/firefox/browsers/index.html
+++ b/bedrock/firefox/templates/firefox/browsers/index.html
@@ -5,7 +5,7 @@
 {% add_lang_files "firefox/browsers" %}
 
 {% extends "firefox/base/base-protocol.html" %}
-{% from "macros.html" import google_play_button, fxa_email_form, fxa_link_fragment with context %}
+{% from "macros.html" import google_play_button, fxa_email_form with context %}
 {% from "macros-protocol.html" import hero, feature_card with context %}
 
 {% block page_title %}{{ _('Get the browsers that put your privacy first — and always have') }}{% endblock %}
@@ -121,8 +121,8 @@
           )
         }}
         <p class="fxa-signin account-signin">
-          {% set fxa_link = fxa_link_fragment(entrypoint=_entrypoint, action='signin', utm_campaign='browsers-footer') %}
-          {% set fxa_attr = fxa_link ~ ' class="js-fxa-cta-link" data-cta-type="link" data-cta-text="FxA Learn More"'|safe %}
+          {% set fxa_link = fxa_link_fragment(entrypoint=_entrypoint, action='signin', optional_parameters={'utm_campaign': 'browsers-footer'}) %}
+          {% set fxa_attr = fxa_link ~ ' class="js-fxa-cta-link js-fxa-product-button" data-cta-type="link" data-cta-text="FxA Learn More"'|safe %}
           {% set accounts_attr = 'href="'|safe ~ url('firefox.accounts') ~ '"'|safe %}
           {% trans %}
             Already have an account? <a {{ fxa_attr }}>Sign In</a> or <a {{ accounts_attr }}>learn more</a> about joining Firefox.

--- a/bedrock/firefox/templates/firefox/firstrun/firstrun.html
+++ b/bedrock/firefox/templates/firefox/firstrun/firstrun.html
@@ -4,7 +4,7 @@
 
 {% add_lang_files "firefox/new/quantum" %}
 
-{% from "macros.html" import fxa_email_form, fxa_link_fragment with context %}
+{% from "macros.html" import fxa_email_form with context %}
 
 {% extends "firefox/base/base-protocol.html" %}
 
@@ -59,7 +59,18 @@
               entrypoint=_entrypoint,
               button_class='mzp-c-button mzp-t-product')
             }}
-            <p class="fxa-signin">{{ _('Already have an account?') }} <a {{ fxa_link_fragment(entrypoint=_entrypoint, utm_campaign='fxa-embedded-form') }} class="js-fxa-cta-link">{{ _('Sign In') }}</a></p>
+            <p class="fxa-signin">
+              {{ _('Already have an account?') }}
+
+              {{ fxa_button(
+                entrypoint=_entrypoint,
+                button_text='Sign In',
+                action='signin',
+                is_button_class=False,
+                optional_parameters={'utm_campaign': 'fxa-embedded-form'},
+                optional_attributes={'data-cta-text': 'Sign In', 'data-cta-type': 'fxa-sync', 'data-cta-position': 'primary'}
+              ) }}
+            </p>
           </aside>
         </div>
       </div>

--- a/bedrock/firefox/templates/firefox/home/index-master.html
+++ b/bedrock/firefox/templates/firefox/home/index-master.html
@@ -5,7 +5,7 @@
 {% add_lang_files "firefox/home-master" %}
 
 {% extends "firefox/base/base-protocol.html" %}
-{% from "macros.html" import fxa_cta_link with context %}
+
 {% from "macros-protocol.html" import call_out, call_out_compact, feature_card with context %}
 
 {# Bug 1438302 Avoid duplicate content for en-CA and en-GB pages. #}
@@ -287,7 +287,13 @@
         </div>
         <h2 class="c-end-title">{{ footer_title }}</h2>
         <div class="mzp-c-button-download-container">
-          {{ fxa_cta_link(entrypoint='mozilla.org-firefox_home', action='signup', button_text=join_firefox, button_class='mzp-c-button mzp-t-product mzp-t-small', utm_campaign='firefox-home', utm_content='secondary-join-firefox') }}
+          {{ fxa_button(
+            entrypoint='mozilla.org-firefox_home',
+            button_text=join_firefox,
+            class_name='mzp-t-small',
+            optional_parameters={'utm_campaign': 'firefox-home', 'utm_content': 'secondary-join-firefox'},
+            optional_attributes={'data-cta-text': 'Join Firefox', 'data-cta-type': 'fxa-sync', 'data-cta-position': 'secondary'}
+          ) }}
           <small class="mzp-c-button-download-privacy-link">
             <a href="{{ url('firefox.accounts') }}">{{ join_learn_more }}</a>
           </small>

--- a/bedrock/firefox/templates/firefox/privacy/index.html
+++ b/bedrock/firefox/templates/firefox/privacy/index.html
@@ -4,7 +4,6 @@
 
 {% add_lang_files "firefox/privacy-hub" %}
 
-{% from "macros.html" import fxa_email_form, fxa_link_fragment with context %}
 {% from "macros-protocol.html" import call_out, feature_card, hero, picto_card, hero with context %}
 
 {% extends "firefox/privacy/base.html" %}

--- a/bedrock/firefox/templates/firefox/privacy/products.html
+++ b/bedrock/firefox/templates/firefox/privacy/products.html
@@ -4,7 +4,7 @@
 
 {% add_lang_files "firefox/privacy-hub" %}
 
-{% from "macros.html" import fxa_email_form, fxa_link_fragment with context %}
+{% from "macros.html" import fxa_email_form with context %}
 {% from "macros-protocol.html" import call_out, feature_card, picto_card, hero with context %}
 
 {% extends "firefox/privacy/base.html" %}
@@ -181,9 +181,9 @@
               }}
 
               <p class="fxa-signin">
-              {% trans sign_in=fxa_link_fragment(entrypoint=_entrypoint, action='signin', utm_campaign=_utm_campaign),
-                        class_name='js-fxa-cta-link',
-                        learn_more=url('firefox.accounts') %}
+              {% trans sign_in=fxa_link_fragment(entrypoint=_entrypoint, action='signin', optional_parameters={'utm_campaign': _utm_campaign}),
+                       class_name='js-fxa-cta-link js-fxa-product-button',
+                       learn_more=url('firefox.accounts') %}
                 Already have an account? <a {{ sign_in }} class="{{ class_name }}">Sign In</a> or <a href="{{ learn_more }}">learn more</a> about joining Firefox.
               {% endtrans %}
               </p>

--- a/bedrock/firefox/templates/firefox/products/index.html
+++ b/bedrock/firefox/templates/firefox/products/index.html
@@ -5,7 +5,7 @@
 {% add_lang_files "firefox/products" %}
 
 {% extends "firefox/base/base-protocol.html" %}
-{% from "macros.html" import google_play_button, fxa_email_form, fxa_link_fragment with context %}
+{% from "macros.html" import google_play_button, fxa_email_form with context %}
 {% from "macros-protocol.html" import hero, feature_card with context %}
 
 {% block page_title %}{{ _('Firefox is more than a browser') }}{% endblock %}
@@ -119,8 +119,8 @@
           )
         }}
         <p class="fxa-signin account-signin">
-          {% set fxa_link = fxa_link_fragment(entrypoint=_entrypoint, action='signin', utm_campaign='products-footer') %}
-          {% set fxa_attr = fxa_link ~ ' class="js-fxa-cta-link" data-cta-type="link" data-cta-text="FxA Learn More"'|safe %}
+          {% set fxa_link = fxa_link_fragment(entrypoint=_entrypoint, action='signin', optional_parameters={'utm_campaign': 'products-footer'}) %}
+          {% set fxa_attr = fxa_link ~ ' class="js-fxa-cta-link js-fxa-product-button" data-cta-type="link" data-cta-text="FxA Learn More"'|safe %}
           {% set accounts_attr = 'href="'|safe ~ url('firefox.accounts') ~ '"'|safe %}
           {% trans %}
             Already have an account? <a {{ fxa_attr }}>Sign In</a> or <a {{ accounts_attr }}>learn more</a> about joining Firefox.

--- a/bedrock/firefox/templates/firefox/welcome/page3.html
+++ b/bedrock/firefox/templates/firefox/welcome/page3.html
@@ -3,7 +3,6 @@
   # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
 
 {% from "macros-protocol.html" import hero with context %}
-{% from "macros.html" import fxa_cta_link with context %}
 
 {% add_lang_files "firefox/welcome/page3" %}
 
@@ -28,7 +27,12 @@
   ) %}
 
     <p class="primary-cta">
-      {{ fxa_cta_link(entrypoint=_entrypoint, action='signup', button_text=_('Sign In'), button_class='mzp-c-button mzp-t-product js-fxa-product-button', utm_campaign=_utm_campaign, utm_content='top-cta') }}
+      {{ fxa_button(
+        entrypoint=_entrypoint,
+        button_text=_('Sign In'),
+        optional_parameters={'utm_campaign': _utm_campaign, 'utm_content': 'top-cta'},
+        optional_attributes={'data-cta-text': 'Sign In', 'data-cta-type': 'fxa-sync', 'data-cta-position': 'primary'}
+      ) }}
     </p>
   {% endcall %}
 {% endblock %}
@@ -90,7 +94,12 @@
 
 {% block secondary_cta %}
   <p class="secondary-cta">
-    {{ fxa_cta_link(entrypoint=_entrypoint, action='signup', button_text=_('Sign In'), button_class='mzp-c-button mzp-t-product js-fxa-product-button', utm_campaign=_utm_campaign, utm_content='bottom-cta') }}
+    {{ fxa_button(
+      entrypoint=_entrypoint,
+      button_text=_('Sign In'),
+      optional_parameters={'utm_campaign': _utm_campaign, 'utm_content': 'bottom-cta'},
+      optional_attributes={'data-cta-text': 'Sign In', 'data-cta-type': 'fxa-sync', 'data-cta-position': 'secondary'}
+    ) }}
   </p>
 {% endblock %}
 

--- a/bedrock/firefox/templates/firefox/whatsnew/index-account.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/index-account.html
@@ -2,8 +2,6 @@
  # License, v. 2.0. If a copy of the MPL was not distributed with this
  # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
 
-{% from "macros.html" import fxa_cta_link with context %}
-
 {% extends "firefox/whatsnew/base.html" %}
 
 {% block page_title %}{{ ftl('whatsnew-page-title') }}{% endblock %}
@@ -45,8 +43,15 @@
           {{ ftl('whatsnew-account-main-headline') }}
         </h2>
         <p>{{ ftl('whatsnew-account-main-lead-in') }}</p>
-
-        <p class="cta">{{ fxa_cta_link(entrypoint=entrypoint, action='signup', button_text=ftl('whatsnew-account-main-button'), button_class='mzp-c-button mzp-t-product mzp-t-small js-fxa-product-button', utm_campaign=campaign) }}</p>
+        <p class="cta">
+          {{ fxa_button(
+            entrypoint=entrypoint,
+            button_text=ftl('whatsnew-account-main-button'),
+            class_name='mzp-t-small',
+            optional_parameters={'utm_campaign': campaign},
+            optional_attributes={'data-cta-text': 'Sign In', 'data-cta-type': 'fxa-sync', 'data-cta-position': 'primary'}
+          ) }}
+        </p>
       </div>
     </div>
   </section>

--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx70-de.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx70-de.html
@@ -1,8 +1,6 @@
 {# This Source Code Form is subject to the terms of the Mozilla Public
-  # License, v. 2.0. If a copy of the MPL was not distributed with this
-  # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
-
-{% from "macros.html" import fxa_cta_link with context %}
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
 
 {% add_lang_files "firefox/whatsnew_70" %}
 

--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx70-en.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx70-en.html
@@ -1,8 +1,6 @@
 {# This Source Code Form is subject to the terms of the Mozilla Public
-  # License, v. 2.0. If a copy of the MPL was not distributed with this
-  # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
-
-{% from "macros.html" import fxa_cta_link with context %}
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
 
 {% add_lang_files "firefox/whatsnew_70" %}
 

--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx70-fr.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx70-fr.html
@@ -1,8 +1,6 @@
 {# This Source Code Form is subject to the terms of the Mozilla Public
-  # License, v. 2.0. If a copy of the MPL was not distributed with this
-  # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
-
-{% from "macros.html" import fxa_cta_link with context %}
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
 
 {% add_lang_files "firefox/whatsnew_70" %}
 

--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx71.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx71.html
@@ -2,8 +2,6 @@
  # License, v. 2.0. If a copy of the MPL was not distributed with this
  # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
 
-{% from "macros.html" import fxa_cta_link with context %}
-
 {% add_lang_files "firefox/whatsnew_71" %}
 
 {% extends "firefox/whatsnew/base.html" %}
@@ -36,7 +34,15 @@
         </h2>
         <p>{{ _('The Firefox browser collects so little data about you, we don’t even require your email address. But when you use it to create a Firefox account, we can protect your privacy across more of your online life.') }}</p>
 
-        <p class="cta">{{ fxa_cta_link(entrypoint=entrypoint, action='signup', button_text=_('Sign In'), button_class='mzp-c-button mzp-t-product mzp-t-small js-fxa-product-button', utm_campaign=campaign, utm_content='top-cta') }}</p>
+        <p class="cta">
+          {{ fxa_button(
+            entrypoint=entrypoint,
+            button_text=_('Sign In'),
+            class_name='mzp-t-small',
+            optional_parameters={'utm_campaign': campaign, 'utm_content': 'top-cta'},
+            optional_attributes={'data-cta-text': 'Sign In', 'data-cta-type': 'fxa-sync', 'data-cta-position': 'primary'}
+          ) }}
+        </p>
       </div>
     </div>
   </section>
@@ -96,7 +102,15 @@
         </div>
       </div>
 
-      <p class="cta">{{ fxa_cta_link(entrypoint=entrypoint, action='signup', button_text=_('Get a Firefox Account'), button_class='mzp-c-button mzp-t-product mzp-t-small js-fxa-product-button', utm_campaign=campaign, utm_content='bottom-cta') }}</p>
+      <p class="cta">
+        {{ fxa_button(
+          entrypoint=entrypoint,
+          button_text=_('Get a Firefox Account'),
+          class_name='mzp-t-small',
+          optional_parameters={'utm_campaign': campaign, 'utm_content': 'bottom-cta'},
+          optional_attributes={'data-cta-text': 'Get a Firefox Account', 'data-cta-type': 'fxa-sync', 'data-cta-position': 'secondary'}
+        ) }}
+      </p>
     </div>
   </section>
 

--- a/bedrock/mozorg/templatetags/misc.py
+++ b/bedrock/mozorg/templatetags/misc.py
@@ -858,7 +858,7 @@ def fxa_link_fragment(ctx, entrypoint, action='signup', optional_parameters=None
 
         {% set signin = fxa_link_fragment(entrypoint='mozilla.org-firefox-accounts') %}
         {% set class_name = 'js-fxa-cta-link js-fxa-product-button' %}
-        <p>Already have an account? <a {{ sign_in }} {{ class_name }}>Sign In</a> to start syncing.</p>
+        <p>Already have an account? <a {{ sign_in }} class="{{ class_name }}">Sign In</a> to start syncing.</p>
     """
 
     if action == 'email':
@@ -898,10 +898,8 @@ def fxa_button(ctx, entrypoint, button_text, action='signup', class_name=None, i
         'data-mozillaonline-link': _fxa_product_url(mozillaonline_product_url, entrypoint, optional_parameters)
     }
 
-    if optional_attributes:
-        optional_attributes.update(mozillaonline_attribute)
-    else:
-        optional_attributes = mozillaonline_attribute
+    optional_attributes = optional_attributes or {}
+    optional_attributes.update(mozillaonline_attribute)
 
     return _fxa_product_button(product_url, entrypoint, button_text, class_name, is_button_class, include_metrics,
                                optional_parameters, optional_attributes)

--- a/bedrock/mozorg/templatetags/misc.py
+++ b/bedrock/mozorg/templatetags/misc.py
@@ -766,18 +766,28 @@ def lockwise_adjust_url(ctx, redirect, adgroup, creative=None):
     return _get_adjust_link(adjust_url, app_store_url, play_store_url, redirect, locale, adgroup, creative)
 
 
-def _fxa_product_button(product_url, entrypoint, button_text, class_name=None, is_button_class=True,
-                        optional_parameters=None, optional_attributes=None):
-    href = f'{product_url}?entrypoint={entrypoint}&form_type=button&utm_source={entrypoint}&utm_medium=refferal'
-    css_class = 'js-fxa-cta-link js-fxa-product-button'
-    attrs = ''
+def _fxa_product_url(product_url, entrypoint, optional_parameters=None):
+    separator = '&' if '?' in product_url else '?'
+    url = f'{product_url}{separator}entrypoint={entrypoint}&form_type=button&utm_source={entrypoint}&utm_medium=referral'
 
     if optional_parameters:
         params = '&'.join('%s=%s' % (param, val) for param, val in optional_parameters.items())
-        href += f'&{params}'
+        url += f'&{params}'
+
+    return url
+
+
+def _fxa_product_button(product_url, entrypoint, button_text, class_name=None, is_button_class=True,
+                        include_metrics=True, optional_parameters=None, optional_attributes=None):
+    href = _fxa_product_url(product_url, entrypoint, optional_parameters)
+    css_class = 'js-fxa-cta-link'
+    attrs = ''
 
     if optional_attributes:
         attrs += ' '.join('%s="%s"' % (attr, val) for attr, val in optional_attributes.items())
+
+    if include_metrics:
+        css_class += ' js-fxa-product-button'
 
     if is_button_class:
         css_class += ' mzp-c-button mzp-t-product'
@@ -794,7 +804,8 @@ def _fxa_product_button(product_url, entrypoint, button_text, class_name=None, i
 
 @library.global_function
 @jinja2.contextfunction
-def pocket_fxa_button(ctx, entrypoint, button_text, class_name=None, is_button_class=True, optional_parameters=None, optional_attributes=None):
+def pocket_fxa_button(ctx, entrypoint, button_text, class_name=None, is_button_class=True, include_metrics=True,
+                      optional_parameters=None, optional_attributes=None):
     """
     Render a getpocket.com link with required params for FxA authentication.
 
@@ -807,12 +818,14 @@ def pocket_fxa_button(ctx, entrypoint, button_text, class_name=None, is_button_c
         {{ pocket_fxa_button(entrypoint='mozilla.org-firefox-pocket', button_text='Try Pocket Now') }}
     """
     product_url = 'https://getpocket.com/ff_signup'
-    return _fxa_product_button(product_url, entrypoint, button_text, class_name, is_button_class, optional_parameters, optional_attributes)
+    return _fxa_product_button(product_url, entrypoint, button_text, class_name, is_button_class, include_metrics,
+                               optional_parameters, optional_attributes)
 
 
 @library.global_function
 @jinja2.contextfunction
-def monitor_fxa_button(ctx, entrypoint, button_text, class_name=None, is_button_class=True, optional_parameters=None, optional_attributes=None):
+def monitor_fxa_button(ctx, entrypoint, button_text, class_name=None, is_button_class=True, include_metrics=True,
+                       optional_parameters=None, optional_attributes=None):
     """
     Render a monitor.firefox.com link with required params for FxA authentication.
 
@@ -825,4 +838,70 @@ def monitor_fxa_button(ctx, entrypoint, button_text, class_name=None, is_button_
         {{ monitor_fxa_button(entrypoint='mozilla.org-firefox-accounts', button_text='Sign In to Monitor') }}
     """
     product_url = 'https://monitor.firefox.com/oauth/init'
-    return _fxa_product_button(product_url, entrypoint, button_text, class_name, is_button_class, optional_parameters, optional_attributes)
+    return _fxa_product_button(product_url, entrypoint, button_text, class_name, is_button_class, include_metrics,
+                               optional_parameters, optional_attributes)
+
+
+@library.global_function
+@jinja2.contextfunction
+def fxa_link_fragment(ctx, entrypoint, action='signup', optional_parameters=None):
+    """
+    Returns `href` and `data-mozillaonline-link` attributes as a string fragment.
+    This is useful for inline links that appear inside a string of localized copy,
+    such as a paragraph.
+
+    Examples
+    ========
+
+    In Template
+    -----------
+
+        {% set signin = fxa_link_fragment(entrypoint='mozilla.org-firefox-accounts') %}
+        {% set class_name = 'js-fxa-cta-link js-fxa-product-button' %}
+        <p>Already have an account? <a {{ sign_in }} {{ class_name }}>Sign In</a> to start syncing.</p>
+    """
+
+    if action == 'email':
+        action = '?action=email'
+
+    fxa_url = _fxa_product_url(f'{settings.FXA_ENDPOINT}{action}', entrypoint, optional_parameters)
+    mozillaonline_url = _fxa_product_url(f'{settings.FXA_ENDPOINT_MOZILLAONLINE}{action}', entrypoint, optional_parameters)
+
+    markup = (f'href="{fxa_url}" data-mozillaonline-link="{mozillaonline_url}"')
+
+    return jinja2.Markup(markup)
+
+
+@library.global_function
+@jinja2.contextfunction
+def fxa_button(ctx, entrypoint, button_text, action='signup', class_name=None, is_button_class=True,
+               include_metrics=True, optional_parameters=None, optional_attributes=None):
+    """
+    Render a accounts.firefox.com link with required params for FxA authentication.
+
+    Examples
+    ========
+
+    In Template
+    -----------
+
+        {{ fxa_button(entrypoint='mozilla.org-firefox-accounts', button_text='Sign In') }}
+    """
+
+    if action == 'email':
+        action = '?action=email'
+
+    product_url = f'{settings.FXA_ENDPOINT}{action}'
+    mozillaonline_product_url = f'{settings.FXA_ENDPOINT_MOZILLAONLINE}{action}'
+
+    mozillaonline_attribute = {
+        'data-mozillaonline-link': _fxa_product_url(mozillaonline_product_url, entrypoint, optional_parameters)
+    }
+
+    if optional_attributes:
+        optional_attributes.update(mozillaonline_attribute)
+    else:
+        optional_attributes = mozillaonline_attribute
+
+    return _fxa_product_button(product_url, entrypoint, button_text, class_name, is_button_class, include_metrics,
+                               optional_parameters, optional_attributes)

--- a/bedrock/mozorg/tests/test_helper_misc.py
+++ b/bedrock/mozorg/tests/test_helper_misc.py
@@ -962,23 +962,24 @@ class TestPocketAdjustUrl(TestCase):
 class TestPocketFxAButton(TestCase):
     rf = RequestFactory()
 
-    def _render(self, entrypoint, button_text, class_name=None, is_button_class=True, optional_parameters=None,
-                optional_attributes=None):
+    def _render(self, entrypoint, button_text, class_name=None, is_button_class=True, include_metrics=True,
+                optional_parameters=None, optional_attributes=None):
         req = self.rf.get('/')
         req.locale = 'en-US'
-        return render("{{{{ pocket_fxa_button('{0}', '{1}', '{2}', {3}, {4}, {5}) }}}}".format(
-                      entrypoint, button_text, class_name, is_button_class, optional_parameters, optional_attributes),
-                      {'request': req})
+        return render("{{{{ pocket_fxa_button('{0}', '{1}', '{2}', {3}, {4}, {5}, {6}) }}}}".format(
+                      entrypoint, button_text, class_name, is_button_class, include_metrics,
+                      optional_parameters, optional_attributes), {'request': req})
 
     def test_pocket_fxa_button(self):
         """Should return expected markup"""
         markup = self._render(entrypoint='mozilla.org-firefox-pocket', button_text='Try Pocket Now',
-                              class_name='pocket-main-cta-button', is_button_class=True, optional_parameters={'s': 'ffpocket', 'foo': 'bar'},
+                              class_name='pocket-main-cta-button', is_button_class=True, include_metrics=True,
+                              optional_parameters={'s': 'ffpocket', 'foo': 'bar'},
                               optional_attributes={'data-cta-text': 'Try Pocket Now', 'data-cta-type': 'activate pocket',
                                                    'data-cta-position': 'primary'})
         expected = (
             u'<a href="https://getpocket.com/ff_signup?entrypoint=mozilla.org-firefox-pocket&form_type=button'
-            u'&utm_source=mozilla.org-firefox-pocket&utm_medium=refferal&s=ffpocket&foo=bar" data-action="https://accounts.firefox.com/" '
+            u'&utm_source=mozilla.org-firefox-pocket&utm_medium=referral&s=ffpocket&foo=bar" data-action="https://accounts.firefox.com/" '
             u'class="js-fxa-cta-link js-fxa-product-button mzp-c-button mzp-t-product pocket-main-cta-button" '
             u'data-cta-text="Try Pocket Now" data-cta-type="activate pocket" data-cta-position="primary">Try Pocket Now</a>')
         self.assertEqual(markup, expected)
@@ -988,24 +989,108 @@ class TestPocketFxAButton(TestCase):
 class TestMonitorFxAButton(TestCase):
     rf = RequestFactory()
 
-    def _render(self, entrypoint, button_text, class_name=None, is_button_class=False, optional_parameters=None,
-                optional_attributes=None):
+    def _render(self, entrypoint, button_text, class_name=None, is_button_class=False, include_metrics=True,
+                optional_parameters=None, optional_attributes=None):
         req = self.rf.get('/')
         req.locale = 'en-US'
-        return render("{{{{ monitor_fxa_button('{0}', '{1}', '{2}', {3}, {4}, {5}) }}}}".format(
-                      entrypoint, button_text, class_name, is_button_class, optional_parameters, optional_attributes),
-                      {'request': req})
+        return render("{{{{ monitor_fxa_button('{0}', '{1}', '{2}', {3}, {4}, {5}, {6}) }}}}".format(
+                      entrypoint, button_text, class_name, is_button_class, include_metrics,
+                      optional_parameters, optional_attributes), {'request': req})
 
     def test_monitor_fxa_button(self):
         """Should return expected markup"""
         markup = self._render(entrypoint='mozilla.org-firefox-accounts', button_text='Sign In to Monitor',
-                              class_name='monitor-main-cta-button', is_button_class=False, optional_parameters={'utm_campaign': 'skyline'},
+                              class_name='monitor-main-cta-button', is_button_class=False, include_metrics=True,
+                              optional_parameters={'utm_campaign': 'skyline'},
                               optional_attributes={'data-cta-text': 'Sign In to Monitor', 'data-cta-type':
                                                    'fxa-monitor', 'data-cta-position': 'primary'})
         expected = (
             u'<a href="https://monitor.firefox.com/oauth/init?entrypoint=mozilla.org-firefox-accounts&form_type=button'
-            u'&utm_source=mozilla.org-firefox-accounts&utm_medium=refferal&utm_campaign=skyline" '
+            u'&utm_source=mozilla.org-firefox-accounts&utm_medium=referral&utm_campaign=skyline" '
             u'data-action="https://accounts.firefox.com/" class="js-fxa-cta-link js-fxa-product-button '
             u'monitor-main-cta-button" data-cta-text="Sign In to Monitor" data-cta-type="fxa-monitor" '
             u'data-cta-position="primary">Sign In to Monitor</a>')
+        self.assertEqual(markup, expected)
+
+
+@override_settings(FXA_ENDPOINT=TEST_FXA_ENDPOINT)
+class TestFxAButton(TestCase):
+    rf = RequestFactory()
+
+    def _render(self, entrypoint, button_text, action='signup', class_name=None, is_button_class=True, include_metrics=True,
+                optional_parameters=None, optional_attributes=None):
+        req = self.rf.get('/')
+        req.locale = 'en-US'
+        return render("{{{{ fxa_button('{0}', '{1}', '{2}', '{3}', {4}, {5}, {6}, {7}) }}}}".format(
+                      entrypoint, button_text, action, class_name, is_button_class, include_metrics,
+                      optional_parameters, optional_attributes), {'request': req})
+
+    def test_fxa_button_signup(self):
+        """Should return expected markup"""
+        markup = self._render(entrypoint='mozilla.org-firefox-whatsnew73', button_text='Sign Up', action='signup',
+                              class_name='fxa-main-cta-button', is_button_class=True, include_metrics=True,
+                              optional_parameters={'utm_campaign': 'whatsnew73'},
+                              optional_attributes={'data-cta-text': 'Sign Up', 'data-cta-type':
+                                                   'fxa-sync', 'data-cta-position': 'primary'})
+        expected = (
+            u'<a href="https://accounts.firefox.com/signup?entrypoint=mozilla.org-firefox-whatsnew73&form_type=button'
+            u'&utm_source=mozilla.org-firefox-whatsnew73&utm_medium=referral&utm_campaign=whatsnew73" '
+            u'data-action="https://accounts.firefox.com/" class="js-fxa-cta-link js-fxa-product-button mzp-c-button mzp-t-product '
+            u'fxa-main-cta-button" data-cta-text="Sign Up" data-cta-type="fxa-sync" data-cta-position="primary" '
+            u'data-mozillaonline-link="https://accounts.firefox.com.cn/signup?entrypoint=mozilla.org-firefox-whatsnew73'
+            u'&form_type=button&utm_source=mozilla.org-firefox-whatsnew73&utm_medium=referral&utm_campaign=whatsnew73">Sign Up</a>')
+        self.assertEqual(markup, expected)
+
+    def test_fxa_button_signin(self):
+        """Should return expected markup"""
+        markup = self._render(entrypoint='mozilla.org-firefox-whatsnew73', button_text='Sign In', action='signin',
+                              class_name='fxa-main-cta-button', is_button_class=True, include_metrics=True,
+                              optional_parameters={'utm_campaign': 'whatsnew73'},
+                              optional_attributes={'data-cta-text': 'Sign In', 'data-cta-type':
+                                                   'fxa-sync', 'data-cta-position': 'primary'})
+        expected = (
+            u'<a href="https://accounts.firefox.com/signin?entrypoint=mozilla.org-firefox-whatsnew73&form_type=button'
+            u'&utm_source=mozilla.org-firefox-whatsnew73&utm_medium=referral&utm_campaign=whatsnew73" '
+            u'data-action="https://accounts.firefox.com/" class="js-fxa-cta-link js-fxa-product-button mzp-c-button mzp-t-product '
+            u'fxa-main-cta-button" data-cta-text="Sign In" data-cta-type="fxa-sync" data-cta-position="primary" '
+            u'data-mozillaonline-link="https://accounts.firefox.com.cn/signin?entrypoint=mozilla.org-firefox-whatsnew73'
+            u'&form_type=button&utm_source=mozilla.org-firefox-whatsnew73&utm_medium=referral&utm_campaign=whatsnew73">Sign In</a>')
+        self.assertEqual(markup, expected)
+
+    def test_fxa_button_email(self):
+        """Should return expected markup"""
+        markup = self._render(entrypoint='mozilla.org-firefox-whatsnew73', button_text='Sign Up', action='email',
+                              class_name='fxa-main-cta-button', is_button_class=True, include_metrics=True,
+                              optional_parameters={'utm_campaign': 'whatsnew73'},
+                              optional_attributes={'data-cta-text': 'Sign Up', 'data-cta-type':
+                                                   'fxa-sync', 'data-cta-position': 'primary'})
+        expected = (
+            u'<a href="https://accounts.firefox.com/?action=email&entrypoint=mozilla.org-firefox-whatsnew73&form_type=button'
+            u'&utm_source=mozilla.org-firefox-whatsnew73&utm_medium=referral&utm_campaign=whatsnew73" '
+            u'data-action="https://accounts.firefox.com/" class="js-fxa-cta-link js-fxa-product-button mzp-c-button mzp-t-product '
+            u'fxa-main-cta-button" data-cta-text="Sign Up" data-cta-type="fxa-sync" data-cta-position="primary" '
+            u'data-mozillaonline-link="https://accounts.firefox.com.cn/?action=email&entrypoint=mozilla.org-firefox-whatsnew73'
+            u'&form_type=button&utm_source=mozilla.org-firefox-whatsnew73&utm_medium=referral&utm_campaign=whatsnew73">Sign Up</a>')
+        self.assertEqual(markup, expected)
+
+
+@override_settings(FXA_ENDPOINT=TEST_FXA_ENDPOINT)
+class TestFxALinkFragment(TestCase):
+    rf = RequestFactory()
+
+    def _render(self, entrypoint, action='signup', optional_parameters=None):
+        req = self.rf.get('/')
+        req.locale = 'en-US'
+        return render("{{{{ fxa_link_fragment('{0}', '{1}', {2}) }}}}".format(
+                      entrypoint, action, optional_parameters), {'request': req})
+
+    def test_fxa_button_signup(self):
+        """Should return expected markup"""
+        markup = self._render(entrypoint='mozilla.org-firefox-whatsnew73', action='signup',
+                              optional_parameters={'utm_campaign': 'whatsnew73'})
+        expected = (
+            u'href="https://accounts.firefox.com/signup?entrypoint=mozilla.org-firefox-whatsnew73&form_type=button'
+            u'&utm_source=mozilla.org-firefox-whatsnew73&utm_medium=referral&utm_campaign=whatsnew73" '
+            u'data-mozillaonline-link="https://accounts.firefox.com.cn/signup?entrypoint=mozilla.org-firefox-whatsnew73'
+            u'&form_type=button&utm_source=mozilla.org-firefox-whatsnew73&utm_medium=referral&utm_campaign=whatsnew73"')
         self.assertEqual(markup, expected)

--- a/docs/firefox-accounts.rst
+++ b/docs/firefox-accounts.rst
@@ -8,30 +8,40 @@
 Firefox Accounts Referrals
 ==========================
 
-Bedrock pages are often used to promote the creation of `Firefox Accounts`_ as a main *call to action* (CTA). This is typically accomplished using either a signup form, or a prominent link/button. Bedrock templates can take advantage of a series of helper macros, which can help to standardize referrals.
+Marketing pages often promote the creation of a `Firefox Account`_ as a common *call to action* (CTA).
+This is typically accomplished using either a signup form, or a prominent link/button. To accomplish
+this, bedrock templates can take advantage of a series of helpers which can be used to standardize
+referrals.
 
-.. _Firefox Accounts: https://accounts.firefox.com
+.. Note::
 
-.. Important::
+    The helpers below can typically be shown to all browsers, but some also feature logic specific
+    to Firefox, such as signing users into `Sync`_.
 
-    All query string parameters passed to the macros below need to pass the `query parameters validation
-    <https://mozilla.github.io/application-services/docs/accounts/metrics.html#descriptions-of-metrics-related-query-parameters>`_ applied by the Firefox Accounts server.
+.. _Sync: https://support.mozilla.org/kb/how-do-i-set-sync-my-computer
+.. _Firefox Account: https://accounts.firefox.com
 
 Conventions
 -----------
 
-When choosing URL parameter values, the following conventions help support uniformity in code and predictability in retroactive analysis.
+When choosing URL parameter values, the following conventions help to support uniformity in code and
+predictability in retroactive analysis.
 
 * Use lower case characters in parameter values.
 * Separate words in parameter values with hyphens.
 * Follow parameter naming patterns established in previous iterations of a page.
 
+.. Important::
+
+    All query string parameters also need to pass the `validation
+    <https://mozilla.github.io/application-services/docs/accounts/metrics.html#descriptions-of-metrics-related-query-parameters>`_
+    rules applied by the Firefox Accounts server.
+
+
 Signup Form
 -----------
 
-The Firefox Accounts signup form is used as a top of funnel entry point to the account creation flow. This form is shown to all browsers, but it also features some Firefox-specific logic related to signing users into `Sync`_.
-
-.. _Sync: https://support.mozilla.org/kb/how-do-i-set-sync-my-computer
+Use the ``fxa_email_form`` macro to display an account signup form on a page.
 
 Usage
 ~~~~~
@@ -48,7 +58,7 @@ The form can then be invoked using:
 
     {{ fxa_email_form(entrypoint='mozilla.org-firefox-accounts') }}
 
-The templates's respective JavaScript and CSS bundles should also include the following dependencies:
+The template's respective JavaScript and CSS bundles should also include the following dependencies:
 
 **Javascript:**
 
@@ -57,20 +67,20 @@ The templates's respective JavaScript and CSS bundles should also include the fo
     js/base/mozilla-fxa-form.js
     js/base/mozilla-fxa-form-init.js
 
-This script will automatically handle things like tracking metrics flow (see the Tracking Signups section below), as well as configuring Sync and distribution ID (e.g. the China re-pack) for Firefox browsers.
-
 **CSS:**
 
 .. code-block:: text
 
     css/base/mozilla-fxa-form.scss
 
-This Sass file contains some useful default styling for the form.
+The JavaScript files will automatically handle things adding metrics parameters, as well as
+configuring Sync and distribution ID (e.g. the China re-pack) for Firefox browsers. The CSS
+file contains some default styling for the signup form.
 
 Configuration
 ~~~~~~~~~~~~~
 
-The macro provides parameters as follows (* indicates a required parameter)
+The signup form macro accepts the following parameters (* indicates a required parameter)
 
 +----------------------------+----------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------+-------------------------------------------------+
 |    Parameter name          |                                                       Definition                                                           |                          Format                          |                    Example                      |
@@ -106,15 +116,161 @@ Invoking the macro will automatically include a set of default UTM parameters as
 - ``utm_campaign`` is automatically set as the value of ``fxa-embedded-form``. This can be prefixed with a custom value by passing a ``utm_campaign`` value to the macro. For example, ``utm_campaign='trailhead'`` would result in a value of ``trailhead-fxa-embedded-form``.
 - ``utm_medium`` is automatically set as the value of ``referral``.
 
+
+Linking to accounts.firefox.com
+-------------------------------
+
+Use the ``fxa_button`` helper to create a CTA button or link to https://accounts.firefox.com/.
+
+Usage
+~~~~~
+
+.. code-block:: jinja
+
+    {{ fxa_button(entrypoint='mozilla.org-firefox-accounts', button_text='Sign In') }}
+
+.. Note::
+
+    There is also a ``fxa_link_fragment`` helper which will construct only valid ``href``
+    and ``data-mozillaonline-link`` properties. This is useful when constructing an
+    inline link inside a paragraph, for example.
+
+For more information on the available parameters, read the "CTA button parameters"
+section further below.
+
+
+Linking to monitor.firefox.com
+-------------------------------
+
+Use the ``monitor_fxa_button`` helper to link to https://monitor.firefox.com/ via a
+Firefox Accounts auth flow.
+
+Usage
+~~~~~
+
+.. code-block:: jinja
+
+    {{ monitor_fxa_button(entrypoint=_entrypoint, button_text='Sign Up for Monitor') }}
+
+For more information on the available parameters, read the "CTA button parameters"
+section further below.
+
+
+Linking to getpocket.com
+------------------------
+
+Use the ``pocket_fxa_button`` helper to link to https://getpocket.com/ via a
+Firefox Accounts auth flow.
+
+Usage
+~~~~~
+
+.. code-block:: jinja
+
+    {{ pocket_fxa_button(entrypoint='mozilla.org-firefox-pocket', button_text='Try Pocket Now', optional_parameters={'s': 'ffpocket'}) }}
+
+For more information on the available parameters, read the "CTA button parameters"
+section below.
+
+
+CTA button parameters
+---------------------
+
+The ``fxa_button``, ``pocket_fxa_button``, and ``monitor_fxa_button`` helpers
+all support the same standard parameters:
+
++----------------------------+------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------+--------------------------------------------------------------------------------------------------------+
+|    Parameter name          |                                                       Definition                                                       |                          Format                          |                                                Example                                                 |
++============================+========================================================================================================================+==========================================================+========================================================================================================+
+|    entrypoint*             | Unambiguous identifier for which page of the site is the referrer. This also serves as a value for 'utm_source'.       | 'mozilla.org-firefox-pocket'                             | 'mozilla.org-firefox-pocket'                                                                           |
++----------------------------+------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------+--------------------------------------------------------------------------------------------------------+
+|    button_text*            | The button copy to be used in the call to action.  Default to a well localized string.                                 | Localizable string                                       | _('Try Pocket Now')                                                                                    |
++----------------------------+------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------+--------------------------------------------------------------------------------------------------------+
+|    class_name              | A class name to be applied to the link (typically for styling with CSS).                                               | String of one or more class names                        | 'pocket-main-cta-button'                                                                               |
++----------------------------+------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------+--------------------------------------------------------------------------------------------------------+
+|    is_button_class         | A boolean value that dictates if the CTA should be styled as a button or a link. Defaults to 'True'.                   | Boolean                                                  | True or False                                                                                          |
++----------------------------+------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------+--------------------------------------------------------------------------------------------------------+
+|    include_metrics         | A boolean value that dictates if metrics parameters should be added to the button href. Defaults to 'True'.            | Boolean                                                  | True or False                                                                                          |
++----------------------------+------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------+--------------------------------------------------------------------------------------------------------+
+|    optional_parameters     | An dictionary of key value pairs containing additional parameters to append the the href.                              | Dictionary                                               | {'s': 'ffpocket'}                                                                                      |
++----------------------------+------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------+--------------------------------------------------------------------------------------------------------+
+|    optiona_attributes      | An dictionary of key value pairs containing additional data attributes to include in the button.                       | Dictionary                                               | {'data-cta-text': 'Try Pocket Now', 'data-cta-type': 'activate pocket','data-cta-position': 'primary'} |
++----------------------------+------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------+--------------------------------------------------------------------------------------------------------+
+
+.. Note::
+
+    The ``fxa_button`` helper also supports an additional ``action`` parameter,
+    which accepts the values ``signup``, ``signin``, and ``email`` for
+    configuring the type of authentication flow.
+
+
+CTA button dependencies
+-----------------------
+
+When using any of the FxA button helpers, a templates's respective JavaScript
+bundle should also include the following dependencies:
+
+.. code-block:: text
+
+    js/base/mozilla-fxa-product-button.js
+    js/base/mozilla-fxa-product-button-init.js
+
+This script automatically adds metrics parameters to the button ``href``:
+
+- ``deviceId``
+- ``flowId``
+- ``flowBeginTime``
+
+These are values are fetched from an API endpoint, and are instered back into
+the destination link along with the other standard referral parameters.
+
+.. Important::
+
+    Requests to metrics API endpoints should only be made when an associated CTA is
+    visibly displayed on a page. For example, if a page contains both a Firefox Accounts
+    signup form and a Firefox Monitor button, but only one CTA is displayed at any one
+    time, then only the metrics request associated with that CTA should occur. For links
+    generated using the ``fxa_link_fragment`` helper, you will also need to manually
+    add a CSS class of ``js-fxa-product-button`` to trigger the script.
+
+
+Tracking External Referrers
+---------------------------
+
+If the URL of a bedrock page contains existing UTM parameters on page load, bedrock will
+attempt to automatically use those values to replace the inline UTM parameters in
+Firefox Accounts links. This is handled using a client side script in the site common
+bundle which can be found in ``/media/js/base/fxa-utm-referral.js``.
+
+The behavior is as follows:
+
+- UTM paramters will only be replaced if the page URL contains both a valid ``utm_source`` and ``utm_campaign`` parameter. All other UTM parameters are considered optional, but will still be passed as long as the required parameters exist.
+- If the above criteria is satisfied, then UTM parameters on FxA links will be replaced in their entirety with the UTM parameters from the page URL. This is to avoid mixing referral data from different campaigns.
+
+.. Important::
+
+    Links generated by the FxA button helpers will automatically be covered by this
+    script. For links generated using the ``fxa_link_fragment`` helper, you will
+    need to manually add a CSS class of ``js-fxa-cta-link`` to trigger the behavior.
+
+
 Handling Distribution (aka China Repack)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+----------------------------------------
 
-The China repack of Firefox points to https://accounts.firefox.com.cn/ by default for accounts signups. To compensate for this on https://www.mozilla.org (so we don't send those visitors to the wrong place), we rely on :ref:`UITour<ui-tour>` to check the distribution ID of the browser. If the distribution ID is ``mozillaonline`` (i.e. China repack), then we replace our accounts endpoints with the alternate domain specified in the ``data-mozillaonline-link`` attribute. The logic to handle this is self contained in the macro, and in ``mozilla-fxa-form.js``.
+The China repack of Firefox points to https://accounts.firefox.com.cn/ by default for
+accounts signups. To compensate for this on https://www.mozilla.org (so we don't send
+those visitors to the wrong place), we rely on :ref:`UITour<ui-tour>` to check the
+distribution ID of the browser. If the distribution ID is ``mozillaonline``
+(i.e. China repack), then we replace our accounts endpoints with the alternate domain
+specified in the ``data-mozillaonline-link`` attribute. The logic to handle this is
+self contained in the associated helper scripts and handled automatically.
 
-Testing The Form
-~~~~~~~~~~~~~~~~
 
-Testing the form signup flow on a non-production environment requires some additional configuration.
+Testing Signup Flows
+--------------------
+
+Testing the Firefox Account signup flows on a non-production environment requires
+some additional configuration.
 
 **Configuring bedrock:**
 
@@ -134,163 +290,10 @@ Follow the `instructions`_ provided by the FxA team. These instructions will lau
 new Firefox instance with the necessary config already set. In the new instance of
 Firefox:
 
-#. Navigate to the page containing the Firefox Accounts form
+#. Navigate to the page containing the Firefox Accounts CTA.
 #. If testing locally, be sure to use ``127.0.0.1`` instead of ``localhost``
 
 .. _instructions: https://github.com/vladikoff/fxa-dev-launcher#basic-usage-example-in-os-x
-
-
-Linking to accounts.firefox.com
--------------------------------
-
-The ``fxa_cta_link`` macro is designed to help create a valid *call to action* (CTA) link to https://accounts.firefox.com, with all the necessary query string parameters. This macro will also generate a valid ``data-mozillaonline-link`` attribute needed for the China repack distribution.
-
-Usage
-~~~~~
-
-To use the link in a Jinja template, first import the `fxa_cta_link` macro:
-
-.. code-block:: jinja
-
-    {% from "macros.html" import fxa_cta_link with context %}
-
-A link can then be invoked using:
-
-.. code-block:: jinja
-
-    {{ fxa_cta_link(
-        entrypoint='mozilla.org-firefox-accounts',
-        button_text=_('Create a Firefox Account')
-    }}
-
-The following scripts, included in the base bundle for every page, are responsible for configuring Sync for Firefox desktop browsers.
-
-.. code-block:: text
-
-    js/base/mozilla-fxa-link.js
-    js/base/mozilla-fxa-link-init.js
-
-Configuration
-~~~~~~~~~~~~~
-
-The macro provides parameters as follows (* indicates a required parameter)
-
-+----------------------------+------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------+-------------------------------------------------+
-|    Parameter name          |                                                       Definition                                                       |                          Format                          |                    Example                      |
-+============================+========================================================================================================================+==========================================================+=================================================+
-|    entrypoint*             | Unambiguous identifier for which page of the site is the referrer.                                                     | 'mozilla.org-directory-page'                             | 'mozilla.org-firefox-accounts'                  |
-+----------------------------+------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------+-------------------------------------------------+
-|    entrypoint_experiment   | Used to identify experiments.                                                                                          | Experiment ID                                            | 'whatsnew-headlines'                            |
-+----------------------------+------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------+-------------------------------------------------+
-|    entrypoint_variation    | Used to track page variations in multivariate tests. Usually just a number or letter but could be a short keyword.     | Variant identifier                                       | 'b'                                             |
-+----------------------------+------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------+-------------------------------------------------+
-|    action                  | The type of action the link will perform. Defaults to 'signin'.                                                        | String                                                   | 'signup'                                        |
-+----------------------------+------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------+-------------------------------------------------+
-|    button_text*            | The button copy to be used in the call to action.                                                                      | Localizable string                                       | _('Create a Firefox Account')                   |
-+----------------------------+------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------+-------------------------------------------------+
-|    account_id              | An HTML 'id' to be added to the link.                                                                                  | String                                                   | 'account-hero-button'                           |
-+----------------------------+------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------+-------------------------------------------------+
-|    button_class            | A CSS class names to be applied to the link.                                                                           | String of one or more CSS class names                    | 'mzp-c-button mzp-t-primary mzp-t-product'      |
-+----------------------------+------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------+-------------------------------------------------+
-|    utm_campaign*           | Used to identify specific marketing campaigns. Should have default value which is descriptive of the page element.     | Campaign name appended to default value                  | 'accounts-page-hero'                            |
-+----------------------------+------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------+-------------------------------------------------+
-|    utm_term                | Used for paid search keywords.                                                                                         | Brief keyword                                            | 'existing-users'                                |
-+----------------------------+------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------+-------------------------------------------------+
-|    utm_content             | It should only be declared when there is more than one piece of content on a page linking to the same place.           | Description of content, or name of experiment treatment  | 'get-the-rest-of-firefox'                       |
-+----------------------------+------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------+-------------------------------------------------+
-
-Invoking the macro will automatically include a set of default UTM parameters as query string values:
-
-- ``utm_source`` is automatically assigned the value of the ``entrypoint`` parameter.
-- ``utm_medium`` is automatically set as the value of ``referral``.
-
-.. Note::
-
-    There is also a ``fxa_link_fragment`` macro which will construct only valid ``href`` and ``data-mozillaonline-link`` properties. This is useful when constructing an inline link inside a paragraph, for example. The ``fxa_link_fragment`` will accept the same ``entrypoint``, ``action`` and ``utm_*`` values as the ``fxa_cta_link`` macro.
-
-
-Linking to monitor.firefox.com
--------------------------------
-
-Use the ``monitor_fxa_button`` helper to link to https://monitor.firefox.com/ via a Firefox Accounts auth flow.
-
-Usage
-~~~~~
-
-.. code-block:: jinja
-
-    {{ monitor_fxa_button(entrypoint=_entrypoint, button_text='Sign Up for Monitor') }}
-
-The templates's respective JavaScript bundle should also include the following dependencies:
-
-.. code-block:: text
-
-    js/base/mozilla-fxa-product-button.js
-    js/base/mozilla-fxa-product-button-init.js
-
-This script will automatically handle things like tracking metrics flow (in the same way we do for https://accounts.firefox.com).
-
-Linking to getpocket.com
-------------------------
-
-Use the ``pocket_fxa_button`` helper to link to https://getpocket.com/ via a Firefox Accounts auth flow.
-
-Usage
-~~~~~
-
-.. code-block:: jinja
-
-    {{ pocket_fxa_button(entrypoint='mozilla.org-firefox-pocket', button_text='Try Pocket Now', optional_parameters={'s': 'ffpocket'}) }}
-
-The templates's respective JavaScript bundle should also include the following dependencies:
-
-.. code-block:: text
-
-    js/base/mozilla-fxa-product-button.js
-    js/base/mozilla-fxa-product-button-init.js
-
-FxA button helper configuration
--------------------------------
-
-Both the ``pocket_fxa_button`` and ``monitor_fxa_button`` helpers support the following parameters:
-
-+----------------------------+------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------+--------------------------------------------------------------------------------------------------------+
-|    Parameter name          |                                                       Definition                                                       |                          Format                          |                                                Example                                                 |
-+============================+========================================================================================================================+==========================================================+========================================================================================================+
-|    entrypoint*             | Unambiguous identifier for which page of the site is the referrer. This also serves as a value for 'utm_source'.       | 'mozilla.org-firefox-pocket'                             | 'mozilla.org-firefox-pocket'                                                                           |
-+----------------------------+------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------+--------------------------------------------------------------------------------------------------------+
-|    button_text*            | The button copy to be used in the call to action.  Default to a well localized string.                                 | Localizable string                                       | _('Try Pocket Now')                                                                                    |
-+----------------------------+------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------+--------------------------------------------------------------------------------------------------------+
-|    class_name              | A class name to be applied to the link (typically for styling with CSS).                                               | String of one or more class names                        | 'pocket-main-cta-button'                                                                               |
-+----------------------------+------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------+--------------------------------------------------------------------------------------------------------+
-|    optional_parameters     | An dictionary of key value pairs containing additional parameters to append the the href.                              | Dictionary                                               | {'s': 'ffpocket'}                                                                                      |
-+----------------------------+------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------+--------------------------------------------------------------------------------------------------------+
-|    optiona_attributes      | An dictionary of key value pairs containing additional data attributes to include in the button.                       | Dictionary                                               | {'data-cta-text': 'Try Pocket Now', 'data-cta-type': 'activate pocket','data-cta-position': 'primary'} |
-+----------------------------+------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------+--------------------------------------------------------------------------------------------------------+
-
-Tracking Sign-ups / Sign-ins
-----------------------------
-
-For Firefox Accounts product referrals we also pass ``device_id``, ``flow_id`` and ``flow_begin_time`` parameters to track top-of-funnel metrics. These are values fetched from a metrics flow API endpoint, and are instered back into the form / link along with the other standard referral parameters. This functionality is handled by ``mozilla-fxa-form.js`` and ``mozilla-fxa-product-button.js`` respectively.
-
-.. Important::
-
-    Requests to metrics API endpoints should only be made when an associated CTA is visibly displayed on a page. For example, if a page contains both a Firefox Accounts signup form and a Firefox Monitor button, but only one CTA is displayed at any one time, then only the metrics request associated with that CTA should occur.
-
-
-Tracking External Referrers
----------------------------
-
-If the URL of a bedrock page contains existing UTM parameters on page load, bedrock will attempt to automatically use those values to replace the inline UTM parameters in Firefox Accounts links. This is handled using a client side script in the site common bundle which can be found in ``/media/js/base/fxa-utm-referral.js``.
-
-The behavior is as follows:
-
-- UTM paramters will only be replaced if the page URL contains both a valid ``utm_source`` and ``utm_campaign`` parameter. All other UTM parameters are considered optional, but will still be passed as long as the required parameters exist.
-- If the above criteria is satisfied, then UTM parameters on FxA links will be replaced in their entirety with the UTM parameters from the page URL. This is to avoid mixing referral data from different campaigns.
-
-.. Important::
-
-    Links generated by the FxA button macros and helpers will automatically be covered by this script. For links generated using the ``fxa_link_fragment`` macro, you will need to manually add a CSS class of ``js-fxa-cta-link`` to trigger the function. This script does not yet cover the signup form macro.
 
 
 Google Analytics Guidelines

--- a/media/js/base/mozilla-fxa-product-button.js
+++ b/media/js/base/mozilla-fxa-product-button.js
@@ -12,8 +12,25 @@ if (typeof window.Mozilla === 'undefined') {
 
     var FxaProductButton = {};
 
+    var whitelist = [
+        'https://accounts.firefox.com/',
+        'https://monitor.firefox.com/',
+        'https://getpocket.com/',
+        'https://latest.dev.lcip.org/'
+    ];
+
     FxaProductButton.isSupported = function() {
         return 'fetch' in window;
+    };
+
+    /**
+     * Returns the hostname for a given URL.
+     * @param {String} url.
+     * @returns {String} hostname.
+     */
+    FxaProductButton.getHostName = function(url) {
+        var matches = url.match(/^https?:\/\/(?:[^/?#]+)(?:[/?#]|$)/i);
+        return matches && matches[0];
     };
 
     FxaProductButton.init = function() {
@@ -77,7 +94,11 @@ if (typeof window.Mozilla === 'undefined') {
 
             // applies url to all buttons and adds cta position
             for (var i = 0; i < buttons.length; i++) {
-                buttons[i].href += flowParams;
+                var hostName = FxaProductButton.getHostName(buttons[i].href);
+                // check if link is in the FxA referral whitelist.
+                if (hostName && whitelist.indexOf(hostName) !== -1) {
+                    buttons[i].href += flowParams;
+                }
             }
         }).catch(function() {
             // silently fail: deviceId, flowBeginTime, flowId are not added to url.

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -1055,6 +1055,8 @@
     },
     {
       "files": [
+        "js/base/mozilla-fxa-product-button.js",
+        "js/base/mozilla-fxa-product-button-init.js",
         "js/base/mozilla-lazy-load.js",
         "js/firefox/home/master.js"
       ],

--- a/tests/pages/firefox/accounts.py
+++ b/tests/pages/firefox/accounts.py
@@ -12,7 +12,7 @@ class FirefoxAccountsPage(FirefoxBasePage):
 
     URL_TEMPLATE = '/{locale}/firefox/accounts/{params}'
 
-    _firefox_monitor_button_locator = (By.CLASS_NAME, 'js-fxa-product-button')
+    _firefox_monitor_button_locator = (By.CSS_SELECTOR, '.c-accounts-hero-body-signed-in .js-fxa-product-button')
 
     def wait_for_page_to_load(self):
         self.wait.until(lambda s: self.seed_url in s.current_url)

--- a/tests/unit/spec/base/mozilla-fxa-product-button.js
+++ b/tests/unit/spec/base/mozilla-fxa-product-button.js
@@ -9,7 +9,8 @@ describe('mozilla-fxa-product-button.js', function() {
 
     beforeEach(function() {
         var button = '<a class="js-fxa-product-button" href="https://monitor.firefox.com/oauth/init?form_type=button&amp;entrypoint=mozilla.org-firefox-accounts&amp;utm_source=mozilla.org-firefox-accounts&amp;utm_campaign=trailhead&amp;utm_medium=referral" data-action="https://accounts.firefox.com/" >Sign Up to Monitor</a>' +
-                     '<a class="js-fxa-product-button" href="https://getpocket.com/ff_signup?s=ffwelcome2&amp;form_type=button&amp;entrypoint=mozilla.org-firefox-welcome-2&amp;utm_source=mozilla.org-firefox-welcome-2&amp;utm_campaign=welcome-2-pocket&amp;utm_medium=referral" data-action="https://accounts.firefox.com/" >Activate Pocket</a>';
+                     '<a class="js-fxa-product-button" href="https://getpocket.com/ff_signup?s=ffwelcome2&amp;form_type=button&amp;entrypoint=mozilla.org-firefox-welcome-2&amp;utm_source=mozilla.org-firefox-welcome-2&amp;utm_campaign=welcome-2-pocket&amp;utm_medium=referral" data-action="https://accounts.firefox.com/" >Activate Pocket</a>' +
+                     '<a class="js-fxa-product-button" href="https://www.mozilla.org/en-US/firefox/accounts/">Learn more</a>';
 
         var data = {
             'deviceId': '848377ff6e3e4fc982307a316f4ca3d6',
@@ -46,6 +47,13 @@ describe('mozilla-fxa-product-button.js', function() {
             var buttons = document.querySelectorAll('.js-fxa-product-button');
             expect(buttons[0].href).toEqual('https://monitor.firefox.com/oauth/init?form_type=button&entrypoint=mozilla.org-firefox-accounts&utm_source=mozilla.org-firefox-accounts&utm_campaign=trailhead&utm_medium=referral&deviceId=848377ff6e3e4fc982307a316f4ca3d6&flowBeginTime=1573052386673&flowId=75f9a48a0f66c2f5919a0989605d5fa5dd04625ea5a2ee59b2d5d54637c566d1');
             expect(buttons[1].href).toEqual('https://getpocket.com/ff_signup?s=ffwelcome2&form_type=button&entrypoint=mozilla.org-firefox-welcome-2&utm_source=mozilla.org-firefox-welcome-2&utm_campaign=welcome-2-pocket&utm_medium=referral&deviceId=848377ff6e3e4fc982307a316f4ca3d6&flowBeginTime=1573052386673&flowId=75f9a48a0f66c2f5919a0989605d5fa5dd04625ea5a2ee59b2d5d54637c566d1');
+        });
+    });
+
+    it('should not attach flow parameters to button hrefs in the domain is invalid', function() {
+        return Mozilla.FxaProductButton.init().then(function() {
+            var buttons = document.querySelectorAll('.js-fxa-product-button');
+            expect(buttons[2].href).toEqual('https://www.mozilla.org/en-US/firefox/accounts/');
         });
     });
 });


### PR DESCRIPTION
## Description
- Removes `fxa_cta_link` and `fxa_link_fragment` macros.
- Replaces with `fxa_button` and `fxa_link_fragment` python helpers.
- Adds unit tests 🎉
- Updates documentation.

URLs:
- http://localhost:8000/en-US/firefox/ (navigation and footer links, navigation FxA button, FxA button at bottom of page)
- http://localhost:8000/en-US/firefox/accounts/
- http://localhost:8000/en-US/exp/firefox/accounts/
- http://localhost:8000/de/exp/firefox/
- http://localhost:8000/en-US/exp/firefox/
- http://localhost:8000/en-US/exp/firefox/71.0/whatsnew/all/
- http://localhost:8000/en-US/firefox/browsers/
- http://localhost:8000/en-US/firefox/firstrun/
- http://localhost:8000/en-US/firefox/new/ (legacy template)
- http://localhost:8000/en-US/firefox/privacy/products/
- http://localhost:8000/en-US/firefox/products/
- http://localhost:8000/en-US/firefox/welcome/3/
- http://localhost:8000/en-US/firefox/60.0/whatsnew/all/
- http://localhost:8000/en-US/firefox/71.0/whatsnew/all/

## Issue / Bugzilla link
#8185

## Testing
- [ ] I made a couple of small consistency improvements to tracking parameters, but largely the buttons and links should all contain the same paths and parameters?

Successful test run: https://gitlab.com/mozmeao/www-config/pipelines/123942605