### PR TITLE
Only show nightly or dev edition CTA when appropriate channel (Fixes #8579)

### DIFF
--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -43,7 +43,8 @@ INSTALLER_CHANNElS = [
     'release',
     'beta',
     'alpha',
-    # 'nightly',  # soon
+    'nightly',
+    'aurora',  # deprecated name for dev edition
 ]
 SEND_TO_DEVICE_MESSAGE_SETS = settings.SEND_TO_DEVICE_MESSAGE_SETS
 
@@ -69,7 +70,10 @@ def installer_help(request):
         context['installer_lang'] = installer_lang
 
     if installer_channel and installer_channel in INSTALLER_CHANNElS:
-        context['installer_channel'] = installer_channel
+        if installer_channel == 'aurora':
+            context['installer_channel'] = 'alpha'
+        else:
+            context['installer_channel'] = installer_channel
 
     return l10n_utils.render(request, 'firefox/installer-help.html', context)
 


### PR DESCRIPTION
## Description
- Only show nightly download if `?channel=nightly`
- Only show dev edition download if `?channel=alpha` or `aurora`

## Issue / Bugzilla link
#8579

## Testing
- [ ] tests needing updating?