### PR TITLE
Switch Fluent configs over to Pontoon (Fixes #8648)

### DIFF
--- a/l10n/configs/pontoon.toml
+++ b/l10n/configs/pontoon.toml
@@ -116,17 +116,5 @@ locales = [
 ]
 
 [[paths]]
-    reference = "en/brands.ftl"
-    l10n = "{locale}/brands.ftl"
-[[paths]]
-    reference = "en/mozorg/mission.ftl"
-    l10n = "{locale}/mozorg/mission.ftl"
-[[paths]]
-    reference = "en/firefox/whatsnew/whatsnew-account.ftl"
-    l10n = "{locale}/firefox/whatsnew/whatsnew-account.ftl"
-[[paths]]
-    reference = "en/firefox/whatsnew/whatsnew.ftl"
-    l10n = "{locale}/firefox/whatsnew/whatsnew.ftl"
-[[paths]]
-    reference = "en/firefox/switch.ftl"
-    l10n = "{locale}/firefox/switch.ftl"
+    reference = "en/**/*.ftl"
+    l10n = "{locale}/**/*.ftl"

--- a/l10n/configs/vendor.toml
+++ b/l10n/configs/vendor.toml
@@ -39,16 +39,3 @@ locales = [
 #         "fr",
 #         "ru",
 #     ]
-
-[[paths]]
-    reference = "en/brands.ftl"
-    l10n = "{locale}/brands.ftl"
-[[paths]]
-    reference = "en/mozorg/mission.ftl"
-    l10n = "{locale}/mozorg/mission.ftl"
-[[paths]]
-    reference = "en/firefox/whatsnew/**/*.ftl"
-    l10n = "{locale}/firefox/whatsnew/**/*.ftl"
-[[paths]]
-    reference = "en/firefox/switch.ftl"
-    l10n = "{locale}/firefox/switch.ftl"


### PR DESCRIPTION
## Description
- Removes existing vendor config paths.
- Adds a wildcard path to cover all .ftl files for Pontoon.

## Issue / Bugzilla link
#8648

## Testing
- [ ] Is the wildcard path sufficient?
- [ ] Do I need to make any changes to `l10n/l10n-vendor.toml` or `l10n/l10n-pontoon.toml`?