### PR TITLE
Remove references to IRC

### DIFF
--- a/bedrock/mozorg/templates/mozorg/about/forums/forums.html
+++ b/bedrock/mozorg/templates/mozorg/about/forums/forums.html
@@ -106,9 +106,7 @@
 <h2 id="chat">{{ _('Realtime Chat') }}</h2>
 
 <p>
-{{ _('You can talk to people in the community in real time by logging on <a href="%(irc_url)s">Mozilla’s chat server</a>
-with an <a href="%(irchelp_url)s">IRC</a> client.')|format(irc_url='https://wiki.mozilla.org/IRC', irchelp_url='http://www.irchelp.org/') }}
-{{ _('<strong>Please</strong> read the <abbr title="Message Of The Day">/motd</abbr>.') }}
+{{ _('You can talk to people in the community in real time by logging on <a href="%(chat_url)s">Mozilla’s chat server</a>.')|format(chat_url='https://wiki.mozilla.org/Matrix') }}
 </p>
 
 <h2 id="guidelines">{{ _('Usage Guidelines') }}</h2>

--- a/bedrock/mozorg/templates/mozorg/contact/communities/africa-middle-east/algeria.html
+++ b/bedrock/mozorg/templates/mozorg/contact/communities/africa-middle-east/algeria.html
@@ -23,7 +23,6 @@
           <li><a href="https://lists.mozilla.org/listinfo/community-algeria" class="email">{{ _('Mailing list') }}</a></li>
           <li><a href="https://twitter.com/MozillaAlgeria" class="twitter">@MozillaAlgeria</a></li>
           <li><a href="https://facebook.com/MozillaAlgeria" class="facebook">Facebook</a></li>
-          <li><a href="irc://irc.mozilla.org/mozilla-algeria" class="irc">IRC: #mozilla-algeria</a></li>
         </ul>
 
         <figure class="feature-img">

--- a/bedrock/mozorg/templates/mozorg/contact/communities/africa-middle-east/egypt.html
+++ b/bedrock/mozorg/templates/mozorg/contact/communities/africa-middle-east/egypt.html
@@ -25,7 +25,6 @@
           <li><a href="http://mozilla-eg.org/contact" class="email">{{ _('Contact') }}</a></li>
           <li><a href="https://twitter.com/MozillaEgypt" class="twitter">@MozillaEgypt</a></li>
           <li><a href="https://www.facebook.com/MozillaEgypt" class="facebook">Facebook</a></li>
-          <li><a href="irc://irc.mozilla.org/mozilla-eg" class="irc">IRC: #mozilla-eg</a></li>
         </ul>
 
         <figure class="feature-img">

--- a/bedrock/mozorg/templates/mozorg/contact/communities/africa-middle-east/israel.html
+++ b/bedrock/mozorg/templates/mozorg/contact/communities/africa-middle-east/israel.html
@@ -22,7 +22,6 @@
           <li><a href="http://mozilla.org.il/" class="website">mozilla.org.il</a></li>
           <li><a href="https://twitter.com/MozillaIsrael" class="twitter">@MozillaIsrael</a></li>
           <li><a href="https://facebook.com/MozillaIsrael" class="facebook">Facebook</a></li>
-          <li><a href="irc://irc.mozilla.org/mozilla.il" class="irc">IRC: #mozilla.il</a></li>
         </ul>
 
         <figure class="feature-img">

--- a/bedrock/mozorg/templates/mozorg/contact/communities/africa-middle-east/ivory-coast.html
+++ b/bedrock/mozorg/templates/mozorg/contact/communities/africa-middle-east/ivory-coast.html
@@ -22,7 +22,6 @@
           <li><a href="http://mozilla-cotedivoire.org" class="website">mozilla-cotedivoire.org</a></li>
           <li><a href="https://www.twitter.com/mozillaci" class="twitter">@mozillaci</a></li>
           <li><a href="https://www.facebook.com/mozillaci" class="facebook">Facebook</a></li>
-          <li><a href="irc://irc.mozilla.org/mozillaci" class="irc">IRC: #mozillaci</a></li>
         </ul>
 
         <figure class="feature-img">

--- a/bedrock/mozorg/templates/mozorg/contact/communities/africa-middle-east/mauritius.html
+++ b/bedrock/mozorg/templates/mozorg/contact/communities/africa-middle-east/mauritius.html
@@ -21,7 +21,6 @@
         <ul class="extra">
           <li><a href="http://mozmoris.wordpress.com/" class="website">mozmoris.wordpress.com</a></li>
           <li><a href="mailto:community-india@lists.mozilla.org" class="email">{{ _('Mailing list') }}</a></li>
-          <li><a href="irc://irc.mozilla.org/ganesh" class="irc">IRC: #ganesh</a></li>
           <li><a href="https://twitter.com/onlygan" class="twitter">@onlygan</a></li>
           <li><a href="https://www.facebook.com/MozillaMauritius" class="facebook">Facebook</a></li>
         </ul>

--- a/bedrock/mozorg/templates/mozorg/contact/communities/africa-middle-east/senegal.html
+++ b/bedrock/mozorg/templates/mozorg/contact/communities/africa-middle-east/senegal.html
@@ -25,7 +25,6 @@
           <li><a href="https://lists.mozilla.org/listinfo/community-senegal" class="email">{{ _('Mailing List') }}</a></li>
           <li><a href="https://twitter.com/mozillasn" class="twitter">@mozillasn</a></li>
           <li><a href="https://www.facebook.com/mozillaSN" class="facebook">Facebook</a></li>
-          <li><a href="irc://irc.mozilla.org/mozillasn" class="irc">IRC: #mozillasn</a></li>
         </ul>
 
         <figure class="feature-img">

--- a/bedrock/mozorg/templates/mozorg/contact/communities/africa-middle-east/tunisia.html
+++ b/bedrock/mozorg/templates/mozorg/contact/communities/africa-middle-east/tunisia.html
@@ -25,7 +25,6 @@
           <li><a href="https://lists.mozilla.org/listinfo/community-tunisia" class="email">{{ _('Mailing List') }}</a></li>
           <li><a href="https://twitter.com/MozillaTunisia" class="twitter">@MozillaTunisia</a></li>
           <li><a href=" http://www.facebook.com/MozillaTunisia" class="facebook">Facebook</a></li>
-          <li><a href="irc://irc.mozilla.org/mozillatunisia" class="irc">IRC: #mozillatunisia</a></li>
         </ul>
 
         <figure class="feature-img">

--- a/bedrock/mozorg/templates/mozorg/contact/communities/asia-south-pacific/australia.html
+++ b/bedrock/mozorg/templates/mozorg/contact/communities/asia-south-pacific/australia.html
@@ -20,7 +20,6 @@
 
         <ul class="extra">
           <li><a href="https://lists.mozilla.org/listinfo/community-australia" class="email">{{ _('Mailing list') }}</a></li>
-          <li><a href="irc://irc.mozilla.org/australia" class="irc">IRC: #australia</a></li>
         </ul>
 
         <figure class="feature-img">

--- a/bedrock/mozorg/templates/mozorg/contact/communities/asia-south-pacific/bangladesh.html
+++ b/bedrock/mozorg/templates/mozorg/contact/communities/asia-south-pacific/bangladesh.html
@@ -21,7 +21,6 @@
         <ul class="extra">
           <li><a href="http://www.mozillabd.org" class="website">www.mozillabd.org</a></li>
           <li><a href="https://lists.mozilla.org/listinfo/community-bangladesh" class="email">{{ _('Mailing list') }}</a></li>
-          <li><a href="irc://irc.mozilla.org/bangladesh" class="irc">IRC: #bangladesh</a></li>
           <li><a href="https://twitter.com/MozillaBD" class="twitter">@MozillaBD</a></li>
           <li><a href="https://facebook.com/MozillaBD" class="facebook">Facebook</a></li>
         </ul>

--- a/bedrock/mozorg/templates/mozorg/contact/communities/asia-south-pacific/india.html
+++ b/bedrock/mozorg/templates/mozorg/contact/communities/asia-south-pacific/india.html
@@ -23,7 +23,6 @@
         <ul class="extra">
           <li><a href="https://mozillaindia.org" class="website">mozillaindia.org</a></li>
           <li><a href="https://lists.mozilla.org/listinfo/community-india" class="email">{{ _('Mailing list') }}</a></li>
-          <li><a href="irc://irc.mozilla.org/india" class="irc">IRC: #india</a></li>
           <li><a href="https://twitter.com/MozillaIN" class="twitter">@MozillaIN</a></li>
           <li><a href="https://www.facebook.com/mozillaindia" class="facebook">Facebook</a></li>
           <li><a href="http://www.youtube.com/user/MozillaIndia" class="youtube">YouTube</a></li>

--- a/bedrock/mozorg/templates/mozorg/contact/communities/asia-south-pacific/kerala.html
+++ b/bedrock/mozorg/templates/mozorg/contact/communities/asia-south-pacific/kerala.html
@@ -23,7 +23,6 @@
           <li><a href="https://lists.mozilla.org/listinfo/community-kerala" class="email">{{ _('Mailing list') }}</a></li>
           <li><a href="https://twitter.com/mozillakerala" class="twitter">@mozillakerala</a></li>
           <li><a href="https://www.facebook.com/MozillaKerala" class="facebook">Facebook</a></li>
-          <li><a href="irc://irc.mozilla.org/kerala" class="irc">IRC: #kerala</a></li>
         </ul>
 
         <figure class="feature-img">

--- a/bedrock/mozorg/templates/mozorg/contact/communities/asia-south-pacific/malaysia.html
+++ b/bedrock/mozorg/templates/mozorg/contact/communities/asia-south-pacific/malaysia.html
@@ -23,7 +23,6 @@
         <ul class="extra">
           <li><a href="http://mozilla.my" class="website">mozilla.my</a></li>
           <li><a href="https://lists.mozilla.org/listinfo/community-malaysia" class="email">{{ _('Mailing list') }}</a></li>
-          <li><a href="irc://irc.mozilla.org/mozmy" class="irc">IRC: #mozmy</a></li>
           <li><a href="https://twitter.com/MozillaMy" class="twitter">@MozillaMy</a></li>
           <li><a href="https://www.facebook.com/MozillaMalaysia" class="facebook">Facebook</a></li>
         </ul>

--- a/bedrock/mozorg/templates/mozorg/contact/communities/asia-south-pacific/myanmar.html
+++ b/bedrock/mozorg/templates/mozorg/contact/communities/asia-south-pacific/myanmar.html
@@ -23,7 +23,6 @@
         <ul class="extra">
           <li><a href="http://mozillamyanmar.org/" class="website">mozillamyanmar.org</a></li>
           <li><a href="https://lists.mozilla.org/listinfo/dev-l10n-my" class="email">{{ _('Mailing list') }}</a></li>
-          <li><a href="irc://irc.mozilla.org/mozmm" class="irc">IRC: #mozmm</a></li>
           <li><a href="https://twitter.com/MozillaMyanmar" class="twitter">@MozillaMyanmar</a></li>
           <li><a href="https://www.facebook.com/mozillamyanmar" class="facebook">Facebook</a></li>
         </ul>

--- a/bedrock/mozorg/templates/mozorg/contact/communities/asia-south-pacific/nepal.html
+++ b/bedrock/mozorg/templates/mozorg/contact/communities/asia-south-pacific/nepal.html
@@ -23,7 +23,6 @@
         <ul class="extra">
           <li><a href="http://www.mozilla-nepal.org" class="website">mozilla-nepal.org</a></li>
           <li><a href="https://lists.mozilla.org/listinfo/community-nepal" class="email">{{ _('Mailing list') }}</a></li>
-          <li><a href="irc://irc.mozilla.org/nepal" class="irc">IRC: #nepal</a></li>
           <li><a href="https://twitter.com/MozillaNepal" class="twitter">@MozillaNepal</a></li>
           <li><a href="https://www.facebook.com/MozillaNepal" class="facebook">Facebook</a></li>
         </ul>

--- a/bedrock/mozorg/templates/mozorg/contact/communities/asia-south-pacific/pakistan.html
+++ b/bedrock/mozorg/templates/mozorg/contact/communities/asia-south-pacific/pakistan.html
@@ -22,7 +22,6 @@
           <li><a href="https://lists.mozilla.org/listinfo/community-pakistan" class="email">{{ _('Mailing list') }}</a></li>
           <li><a href="https://www.twitter.com/MozPk" class="twitter">@MozPk</a></li>
           <li><a href="https://www.facebook.com/MozPk" class="facebook">Facebook</a></li>
-          <li><a href="irc://irc.mozilla.org/pakistan" class="irc">IRC: #pakistan</a></li>
           <li><a href="https://instagram.com/mozillapakistan" class="instagram">Instagram</a></li>
           <li><a href="https://flickr.com/photos/mozpk" class="flickr">Flickr</a></li>
         </ul>

--- a/bedrock/mozorg/templates/mozorg/contact/communities/asia-south-pacific/philippines.html
+++ b/bedrock/mozorg/templates/mozorg/contact/communities/asia-south-pacific/philippines.html
@@ -23,7 +23,6 @@
         <ul class="extra">
           <li><a href="http://www.mozillaphilippines.org" class="website">mozillaphilippines.org</a></li>
           <li><a href="https://lists.mozilla.org/listinfo/community-philippines" class="email">{{ _('Mailing list') }}</a></li>
-          <li><a href="irc://irc.mozilla.org/mozilla-ph" class="irc">IRC: #mozilla-ph</a></li>
           <li><a href="https://twitter.com/MozillaPH" class="twitter">@MozillaPH</a></li>
           <li><a href="https://www.facebook.com/mozillaphilippines" class="facebook">Facebook</a></li>
         </ul>

--- a/bedrock/mozorg/templates/mozorg/contact/communities/asia-south-pacific/taiwan.html
+++ b/bedrock/mozorg/templates/mozorg/contact/communities/asia-south-pacific/taiwan.html
@@ -23,7 +23,6 @@
         <ul class="extra">
           <li><a href="http://moztw.org" class="website">moztw.org</a></li>
           <li><a href="https://lists.mozilla.org/listinfo/community-taiwan" class="email">{{ _('Mailing list') }}</a></li>
-          <li><a href="irc://irc.mozilla.org/mozilla-taiwan" class="irc">IRC: #mozilla-taiwan</a></li>
           <li><a href="https://twitter.com/Foxmosa" class="twitter">@Foxmosa</a></li>
           <li><a href="https://www.facebook.com/MozTW" class="facebook">Facebook</a></li>
           <li><a href="https://plus.google.com/communities/110692367205504504391" class="gplus">Google+</a></li>

--- a/bedrock/mozorg/templates/mozorg/contact/communities/europe/catalan.html
+++ b/bedrock/mozorg/templates/mozorg/contact/communities/europe/catalan.html
@@ -23,7 +23,6 @@
           <li><a href="http://llistes.softcatala.org/mailman/listinfo/mozillacat" class="email">{{ _('Mailing list') }}</a></li>
           <li><a href="https://twitter.com/mozillacat" class="twitter">@mozillacat</a></li>
           <li><a href="https://www.facebook.com/mozillacat" class="facebook">Facebook</a></li>
-          <li><a href="irc://irc.mozilla.org/mozilla-cat" class="irc">IRC: #mozilla-cat</a></li>
         </ul>
 
         <figure class="feature-img">

--- a/bedrock/mozorg/templates/mozorg/contact/communities/europe/croatia.html
+++ b/bedrock/mozorg/templates/mozorg/contact/communities/europe/croatia.html
@@ -22,7 +22,6 @@
           <li><a href="http://mozilla-hr.org" class="website">mozilla-hr.org</a></li>
           <li><a href="https://twitter.com/MozillaHrvatska" class="twitter">@MozillaHrvatska</a></li>
           <li><a href="https://www.facebook.com/mozilla.hrvatska" class="facebook">Facebook</a></li>
-          <li><a href="irc://irc.mozilla.org/croatia" class="irc">IRC: #croatia</a></li>
           <li><a href="https://lists.mozilla.org/listinfo/community-croatia" class="email">{{ _('Mailing list') }}</a></li>
         </ul>
 

--- a/bedrock/mozorg/templates/mozorg/contact/communities/europe/denmark.html
+++ b/bedrock/mozorg/templates/mozorg/contact/communities/europe/denmark.html
@@ -22,7 +22,6 @@
           <li><a href="http://mozilladanmark.dk/" class="website">mozilladanmark.dk</a></li>
           <li><a href="http://forum.mozilladanmark.dk/" class="email">{{ _('Forum') }}</a></li>
           <li><a href="https://lists.mozilla.org/listinfo/community-denmark" class="email">{{ _('Mailing list') }}</a></li>
-          <li><a href="irc://irc.mozilla.org/mozilla.dk" class="irc">IRC: #mozilla.dk</a></li>
         </ul>
 
         <figure class="feature-img">

--- a/bedrock/mozorg/templates/mozorg/contact/communities/europe/france.html
+++ b/bedrock/mozorg/templates/mozorg/contact/communities/europe/france.html
@@ -23,7 +23,6 @@
           <li><a href="http://mozfr.org/liste" class="email">{{ _('Mailing list') }}</a></li>
           <li><a href="https://twitter.com/mozilla_fr" class="twitter">@mozilla_fr</a></li>
           <li><a href="https://www.facebook.com/frmozilla" class="facebook">Facebook</a></li>
-          <li><a href="irc://irc.mozilla.org/frenchmoz" class="irc">IRC: #frenchmoz</a></li>
         </ul>
 
         <figure class="feature-img">

--- a/bedrock/mozorg/templates/mozorg/contact/communities/europe/germany.html
+++ b/bedrock/mozorg/templates/mozorg/contact/communities/europe/germany.html
@@ -23,7 +23,6 @@
           <li><a href="https://lists.mozilla.org/listinfo/community-german" class="email">{{ _('Mailing list') }}</a></li>
           <li><a href="https://twitter.com/mozilla_deutsch" class="twitter">@mozilla_deutsch</a></li>
           <li><a href="https://www.facebook.com/mozilla.de" class="facebook">Facebook</a></li>
-          <li><a href="irc://irc.mozilla.org/mozilla.de" class="irc">IRC: #mozilla.de</a></li>
         </ul>
 
         <figure class="feature-img">

--- a/bedrock/mozorg/templates/mozorg/contact/communities/europe/greece.html
+++ b/bedrock/mozorg/templates/mozorg/contact/communities/europe/greece.html
@@ -22,7 +22,6 @@
           <li><a href="https://lists.mozilla.org/listinfo/community-greece" class="email">{{ _('Mailing list') }}</a></li>
           <li><a href="https://twitter.com/mozillagreece" class="twitter">@mozillagreece</a></li>
           <li><a href="https://www.facebook.com/MozillaGreece" class="facebook">Facebook</a></li>
-          <li><a href="irc://irc.mozilla.org/greece" class="irc">IRC: #greece</a></li>
         </ul>
 
         <figure class="feature-img">

--- a/bedrock/mozorg/templates/mozorg/contact/communities/europe/ireland.html
+++ b/bedrock/mozorg/templates/mozorg/contact/communities/europe/ireland.html
@@ -23,7 +23,6 @@
           <li><a href="https://lists.mozilla.org/listinfo/community-ireland" class="email">{{ _('Mailing list') }}</a></li>
           <li><a href="https://twitter.com/MozillaIreland" class="twitter">@MozillaIreland</a></li>
           <li><a href="https://www.facebook.com/MozillaIreland" class="facebook">Facebook</a></li>
-          <li><a href="irc://irc.mozilla.org/mozireland" class="irc">IRC: #mozireland</a></li>
         </ul>
 
         <figure class="feature-img">

--- a/bedrock/mozorg/templates/mozorg/contact/communities/europe/macedonia.html
+++ b/bedrock/mozorg/templates/mozorg/contact/communities/europe/macedonia.html
@@ -22,7 +22,6 @@
           <li><a href="http://mozilla.mk/" class="website">mozilla.mk</a></li>
           <li><a href="https://lists.softver.org.mk/listinfo/ossm-members" class="email">{{ _('Mailing list') }}</a></li>
           <li><a href="https://twitter.com/Mozilla_MK" class="twitter">@Mozilla_MK</a></li>
-          <li><a href="irc://irc.mozilla.org/balkans" class="irc">IRC: #balkans</a></li>
         </ul>
 
         <figure class="feature-img">

--- a/bedrock/mozorg/templates/mozorg/contact/communities/europe/poland.html
+++ b/bedrock/mozorg/templates/mozorg/contact/communities/europe/poland.html
@@ -23,7 +23,6 @@
           <li><a href="https://mail.mozilla.org/listinfo/community-poland" class="email">{{ _('Mailing list') }}</a></li>
           <li><a href="https://twitter.com/MozillaPolska" class="twitter">@MozillaPolska</a></li>
           <li><a href="https://www.facebook.com/MozillaPolska" class="facebook">Facebook</a></li>
-          <li><a href="irc://irc.mozilla.org/aviarypl" class="irc">IRC: #aviarypl</a></li>
         </ul>
 
         <figure class="feature-img">

--- a/bedrock/mozorg/templates/mozorg/contact/communities/europe/romania.html
+++ b/bedrock/mozorg/templates/mozorg/contact/communities/europe/romania.html
@@ -24,7 +24,6 @@
           <li><a href="https://groups.google.com/forum/#!forum/mozilla-ro" class="email">{{ _('Forum') }}</a></li>
           <li><a href="http://twitter.com/mozillaro" class="twitter">@mozillaro</a></li>
           <li><a href="https://www.facebook.com/MozillaRomania" class="facebook">Facebook</a></li>
-          <li><a href="irc://irc.mozilla.org/romania" class="irc">IRC: #romania</a></li>
         </ul>
 
         <figure class="feature-img">

--- a/bedrock/mozorg/templates/mozorg/contact/communities/europe/russia.html
+++ b/bedrock/mozorg/templates/mozorg/contact/communities/europe/russia.html
@@ -24,7 +24,6 @@
           <li><a href="http://forum.mozilla-russia.org" class="email">{{ _('Forum') }}</a></li>
           <li><a href="https://twitter.com/mozilla_russia" class="twitter">@mozilla_russia</a></li>
           <li><a href="https://www.facebook.com/mozillarussia" class="facebook">Facebook</a></li>
-          <li><a href="irc://irc.mozilla.org/mozilla-ru" class="irc">IRC: #mozilla-ru</a></li>
         </ul>
 
         <figure class="feature-img">

--- a/bedrock/mozorg/templates/mozorg/contact/communities/europe/slovenia.html
+++ b/bedrock/mozorg/templates/mozorg/contact/communities/europe/slovenia.html
@@ -23,7 +23,6 @@
           <li><a href="mailto:info@mozilla.si" class="email">info@mozilla.si</a></li>
           <li><a href="https://twitter.com/MozillaSi" class="twitter">@MozillaSi</a></li>
           <li><a href="https://www.facebook.com/mozillaslovenija" class="facebook">Facebook</a></li>
-          <li><a href="irc://irc.mozilla.org/slozilla" class="irc">IRC: #slozilla</a></li>
         </ul>
 
         <figure class="feature-img">

--- a/bedrock/mozorg/templates/mozorg/contact/communities/europe/spain.html
+++ b/bedrock/mozorg/templates/mozorg/contact/communities/europe/spain.html
@@ -24,7 +24,6 @@
           <li><a href="https://www.mozilla-hispano.org/foro/viewforum.php?f=6" class="email">{{ _('Forum') }}</a></li>
           <li><a href="https://twitter.com/mozilla_hispano" class="twitter">@mozilla_hispano</a></li>
           <li><a href="https://www.facebook.com/mozillahispano" class="facebook">Facebook</a></li>
-          <li><a href="irc://irc.mozilla.org/mozilla-hispano" class="irc">IRC: #mozilla-hispano</a></li>
         </ul>
 
         <figure class="feature-img">

--- a/bedrock/mozorg/templates/mozorg/contact/communities/europe/sweden.html
+++ b/bedrock/mozorg/templates/mozorg/contact/communities/europe/sweden.html
@@ -21,7 +21,6 @@
         <ul class="extra">
           <li><a href="https://lists.mozilla.org/listinfo/community-sweden" class="email">{{ _('Mailing list') }}</a></li>
           <li><a href="https://twitter.com/MozillaSweden" class="twitter">@MozillaSweden</a></li>
-          <li><a href="irc://irc.mozilla.org/mozilla.se" class="irc">IRC: #mozilla.se</a></li>
         </ul>
 
         <figure class="feature-img">

--- a/bedrock/mozorg/templates/mozorg/contact/communities/europe/switzerland.html
+++ b/bedrock/mozorg/templates/mozorg/contact/communities/europe/switzerland.html
@@ -22,7 +22,6 @@
           <li><a href="http://www.mozilla.ch/" class="website">www.mozilla.ch</a></li>
           <li><a href="https://lists.mozilla.org/listinfo/community-switzerland" class="email">{{ _('Mailing list') }}</a></li>
           <li><a href="https://twitter.com/MozillaCH" class="twitter">@MozillaCH</a></li>
-          <li><a href="irc://irc.mozilla.org/mozilla.ch" class="irc">IRC: #mozilla.ch</a></li>
         </ul>
 
         <figure class="feature-img">

--- a/bedrock/mozorg/templates/mozorg/contact/communities/europe/the-netherlands.html
+++ b/bedrock/mozorg/templates/mozorg/contact/communities/europe/the-netherlands.html
@@ -24,7 +24,6 @@
           <li><a href="https://www.mozilla-nl.org/" class="website">www.mozilla-nl.org</a></li>
           <li><a href="https://twitter.com/mozilla_nl" class="twitter">@mozilla_nl</a></li>
           <li><a href="https://www.facebook.com/MozillaNederland/" class="facebook">Facebook</a></li>
-          <li><a href="irc://irc.mozilla.org/mozilla.nl" class="irc">IRC: #mozilla.nl</a></li>
         </ul>
 
         <figure class="feature-img">

--- a/bedrock/mozorg/templates/mozorg/contact/communities/europe/united-kingdom.html
+++ b/bedrock/mozorg/templates/mozorg/contact/communities/europe/united-kingdom.html
@@ -22,7 +22,6 @@
 
         <ul class="extra">
           <li><a href="https://mozilla.org.uk/" class="website">mozilla.org.uk</a></li>
-          <li><a href="irc://irc.mozilla.org/uk" class="irc">IRC: #uk</a></li>
           <li><a href="https://lists.mozilla.org/listinfo/community-uk" class="email">{{ _('Mailing list') }}</a></li>
         </ul>
 

--- a/bedrock/mozorg/templates/mozorg/contact/communities/latin-america/mexico.html
+++ b/bedrock/mozorg/templates/mozorg/contact/communities/latin-america/mexico.html
@@ -23,7 +23,6 @@
         <ul class="extra">
           <li><a href="http://www.mozilla-mexico.org" class="website">mozilla-mexico.org</a></li>
           <li><a href="https://lists.mozilla.org/listinfo/community-mexico" class="email">{{ _('Mailing list') }}</a></li>
-          <li><a href="irc://irc.mozilla.org/mozilla-mexico" class="irc">IRC: #mozilla-mexico</a></li>
           <li><a href="https://twitter.com/mozillamx" class="twitter">@MozillaMX</a></li>
           <li><a href="https://www.facebook.com/mozillamx" class="facebook">Facebook</a></li>
         </ul>

--- a/bedrock/mozorg/templates/mozorg/contact/communities/latin-america/venezuela.html
+++ b/bedrock/mozorg/templates/mozorg/contact/communities/latin-america/venezuela.html
@@ -24,7 +24,6 @@
           <li><a href="https://groups.google.com/group/mozillavenezuela" class="email">{{ _('Mailing list') }}</a></li>
           <li><a href="https://twitter.com/MozillaVE" class="twitter">@MozillaVE</a></li>
           <li><a href="https://www.facebook.com/pages/mozillavenezuela/354484842068" class="facebook">Facebook</a></li>
-          <li><a href="irc://irc.mozilla.org/mozilla-venezuela" class="irc">IRC: #mozilla-venezuela</a></li>
         </ul>
 
         <figure class="feature-img">

--- a/bedrock/mozorg/templates/mozorg/contact/communities/north-america/canada.html
+++ b/bedrock/mozorg/templates/mozorg/contact/communities/north-america/canada.html
@@ -19,7 +19,6 @@
         <h2>{{ _('Canada') }}</h2>
 
         <ul class="extra">
-          <li><a href="irc://irc.mozilla.org/canada" class="irc">IRC: #canada</a></li>
           <li><a href="https://lists.mozilla.org/listinfo/community-canada" class="email">{{ _('Mailing list') }}</a></li>
         </ul>
 

--- a/bedrock/mozorg/templates/mozorg/contact/communities/other/arabic.html
+++ b/bedrock/mozorg/templates/mozorg/contact/communities/other/arabic.html
@@ -27,7 +27,6 @@
           <li><a href="https://lists.mozilla.org/listinfo/community-arab-world" class="email">{{ _('Mailing list') }}</a></li>
           <li><a href="https://twitter.com/ArabicMozilla" class="twitter">@ArabicMozilla</a></li>
           <li><a href="https://www.facebook.com/mozillaarabiccommunity" class="facebook">Facebook</a></li>
-          <li><a href="irc://irc.mozilla.org/arabicmozilla" class="irc">IRC: #arabicmozilla</a></li>
         </ul>
 
         <figure class="feature-img">

--- a/bedrock/mozorg/templates/mozorg/contact/communities/other/balkans.html
+++ b/bedrock/mozorg/templates/mozorg/contact/communities/other/balkans.html
@@ -22,8 +22,7 @@
       <div class="card">
         <h2>{{ _('Balkans') }}</h2>
         <ul class="extra">
-          <li><a class="email" href="irc://irc.mozilla.org/balkans">IRC: balkans</a></li>
-          <li><a class="irc" href="https://lists.mozilla.org/listinfo/community-balkans">{{ _('Mailing list') }}</a></li>
+          <li><a class="email" href="https://lists.mozilla.org/listinfo/community-balkans">{{ _('Mailing list') }}</a></li>
           <li><a class="flickr" href="https://www.flickr.com/search/?q=mozbalkans10">Flickr sets</a> </li>
         </ul>
 

--- a/bedrock/mozorg/templates/mozorg/contact/communities/other/francophone.html
+++ b/bedrock/mozorg/templates/mozorg/contact/communities/other/francophone.html
@@ -27,7 +27,6 @@
           <li><a href="http://mozfr.org/liste" class="email">{{ _('Mailing list') }}</a></li>
           <li><a href="https://twitter.com/mozilla_fr" class="twitter">@mozilla_fr</a></li>
           <li><a href="https://www.facebook.com/frmozilla" class="facebook">Facebook</a></li>
-          <li><a href="irc://irc.mozilla.org/frenchmoz" class="irc">IRC: #frenchmoz</a></li>
         </ul>
 
         <figure class="feature-img">

--- a/bedrock/mozorg/templates/mozorg/contact/communities/other/hispano.html
+++ b/bedrock/mozorg/templates/mozorg/contact/communities/other/hispano.html
@@ -27,7 +27,6 @@
           <li><a href="https://lists.mozilla.org/listinfo/hispano-general" class="email">{{ _('Mailing list') }}</a></li>
           <li><a href="https://twitter.com/mozilla_hispano" class="twitter">@mozilla_hispano</a></li>
           <li><a href="https://www.facebook.com/mozillahispano" class="facebook">Facebook</a></li>
-          <li><a href="irc://irc.mozilla.org/mozilla-hispano" class="irc">IRC: #mozilla-hispano</a></li>
         </ul>
 
         <figure class="feature-img">

--- a/bedrock/mozorg/templates/mozorg/contact/contact-landing.html
+++ b/bedrock/mozorg/templates/mozorg/contact/contact-landing.html
@@ -51,7 +51,6 @@
             <li><a href="https://facebook.com/mozilla" hreflang="en-US" rel="external">{{ _('Facebook') }}</a></li>
             <li><a href="https://twitter.com/mozilla" hreflang="en-US" rel="external">{{ _('Twitter') }}</a></li>
             <li><a href="{{ url('mozorg.about.forums.forums') }}">{{ _('Forums &amp; e-mail lists') }}</a></li>
-            <li><a href="https://wiki.mozilla.org/IRC">{{ _('IRC channels') }}</a></li>
           </ul>
         </div>
 

--- a/bedrock/mozorg/templates/mozorg/contact/spaces/base.html
+++ b/bedrock/mozorg/templates/mozorg/contact/spaces/base.html
@@ -33,7 +33,6 @@
   </ul>
 
   <ul class="meta-contact">
-    <li>IRC: <a href="irc://irc.mozilla.org/MozillaSpaces">#MozillaSpaces</a></li>
     <li><a href="https://twitter.com/MozillaSpaces">@MozillaSpaces</a></li>
   </ul>
 </aside>

--- a/bedrock/mozorg/templates/mozorg/contribute/contribute-base.html
+++ b/bedrock/mozorg/templates/mozorg/contribute/contribute-base.html
@@ -67,7 +67,6 @@
         <ul>
           <li><a href="{{ url('mozorg.contact.communities.communities-landing') }}">{{ _('Mozilla communities') }}</a></li>
           <li><a href="{{ url('mozorg.about.forums.forums') }}">{{ _('Mailing lists') }}</a></li>
-          <li><a href="https://wiki.mozilla.org/IRC" rel="external">{{ _('IRC channels') }}</a></li>
         </ul>
       </div>
 


### PR DESCRIPTION
I think this is everything. I did change the link on about/forums/ to point to the Matrix entry on wiki.m.o because that page is untranslated. I was going to do the same for the contribute footer but it is well translated and we don't have a good translated string I could use for "realtime chat" or the like. Suggestions welcome.

Fix #8650