### PR TITLE
Display Page titles in the Next and Previous buttons (fixes #5101)

### DIFF
--- a/bedrock/firefox/templates/firefox/mobile/index.html
+++ b/bedrock/firefox/templates/firefox/mobile/index.html
@@ -68,12 +68,12 @@
         <h2>{{ _('Block online trackers and invasive ads') }}</h2>
         <div class="c-private-cols">
           <div class="c-private-col">
-            <img src="{{ static('img/firefox/mobile/protocol/screen-private.svg') }}" alt="" height="331" width="163">
+            <img src="{{ static('img/firefox/mobile/protocol/screen-private.svg') }}" height="331" width="163">
             <h3>{{ _('Privacy protection by default') }}</h3>
             <p>{{ _('Leave no trace with <a href="%s">Private Browsing mode</a>. When you close out, your history and cookies are deleted.')|format(url('firefox.features.private-browsing')) }}</p>
           </div>
           <div class="c-private-col">
-            <img src="{{ static('img/firefox/mobile/protocol/screen-tracking.svg') }}" alt="" height="331" width="163">
+            <img src="{{ static('img/firefox/mobile/protocol/screen-tracking.svg') }}" height="331" width="163">
             <h3>{{ _('Stop companies from following you') }}</h3>
             <p>{{ _('Stay off their radar with <a href="%s">Firefox Tracking Protection</a>')|format(url('firefox.features.adblocker')) }}</p>
           </div>

--- a/bedrock/firefox/templates/firefox/mobile/index.html
+++ b/bedrock/firefox/templates/firefox/mobile/index.html
@@ -68,12 +68,12 @@
         <h2>{{ _('Block online trackers and invasive ads') }}</h2>
         <div class="c-private-cols">
           <div class="c-private-col">
-            <img src="{{ static('img/firefox/mobile/protocol/screen-private.svg') }}" height="331" width="163">
+            <img src="{{ static('img/firefox/mobile/protocol/screen-private.svg') }}" alt="" height="331" width="163">
             <h3>{{ _('Privacy protection by default') }}</h3>
             <p>{{ _('Leave no trace with <a href="%s">Private Browsing mode</a>. When you close out, your history and cookies are deleted.')|format(url('firefox.features.private-browsing')) }}</p>
           </div>
           <div class="c-private-col">
-            <img src="{{ static('img/firefox/mobile/protocol/screen-tracking.svg') }}" height="331" width="163">
+            <img src="{{ static('img/firefox/mobile/protocol/screen-tracking.svg') }}" alt="" height="331" width="163">
             <h3>{{ _('Stop companies from following you') }}</h3>
             <p>{{ _('Stay off their radar with <a href="%s">Firefox Tracking Protection</a>')|format(url('firefox.features.adblocker')) }}</p>
           </div>

--- a/docs/_templates/footer.html
+++ b/docs/_templates/footer.html
@@ -53,3 +53,4 @@
     {%- block extrafooter %} {% endblock %}
   
   </footer>
+  

--- a/docs/_templates/footer.html
+++ b/docs/_templates/footer.html
@@ -1,0 +1,55 @@
+<footer>
+    {% if (theme_prev_next_buttons_location == 'bottom' or theme_prev_next_buttons_location == 'both') and (next or prev) %}
+      <div class="rst-footer-buttons" role="navigation" aria-label="footer navigation">
+        {% if next %}
+          <a href="{{ next.link|e }}" class="btn btn-neutral float-right" title="{{ next.title|striptags|e }}" accesskey="n" rel="next">{{ next.title|striptags|e }} <span class="fa fa-arrow-circle-right"></span></a>
+        {% endif %}
+        {% if prev %}
+          <a href="{{ prev.link|e }}" class="btn btn-neutral float-left" title="{{ prev.title|striptags|e }}" accesskey="p" rel="prev"><span class="fa fa-arrow-circle-left"></span> {{ prev.title|striptags|e }}</a>
+        {% endif %}
+      </div>
+    {% endif %}
+  
+    <hr/>
+  
+    <div role="contentinfo">
+      <p>
+      {%- if show_copyright %}
+        {%- if hasdoc('copyright') %}
+          {% set path = pathto('copyright') %}
+          {% set copyright = copyright|e %}
+          &copy; <a href="{{ path }}">{% trans %}Copyright{% endtrans %}</a> {{ copyright }}
+        {%- else %}
+          {% set copyright = copyright|e %}
+          &copy; {% trans %}Copyright{% endtrans %} {{ copyright }}
+        {%- endif %}
+      {%- endif %}
+  
+      {%- if build_id and build_url %}
+        <span class="build">
+          {# Translators: Build is a noun, not a verb #}
+          {% trans %}Build{% endtrans %}
+          <a href="{{ build_url }}">{{ build_id }}</a>.
+        </span>
+      {%- elif commit %}
+        <span class="commit">
+          {% trans %}Revision{% endtrans %} <code>{{ commit }}</code>.
+        </span>
+      {%- elif last_updated %}
+        <span class="lastupdated">
+          {% trans last_updated=last_updated|e %}Last updated on {{ last_updated }}.{% endtrans %}
+        </span>
+      {%- endif %}
+  
+      </p>
+    </div>
+  
+    {%- if show_sphinx %}
+      {% set sphinx_web = '<a href="http://sphinx-doc.org/">Sphinx</a>' %}
+      {% set readthedocs_web = '<a href="https://readthedocs.org">Read the Docs</a>'  %}
+        {% trans sphinx_web=sphinx_web, readthedocs_web=readthedocs_web %}Built with {{ sphinx_web }} using a{% endtrans %} <a href="https://github.com/rtfd/sphinx_rtd_theme">{% trans %}theme{% endtrans %}</a> {% trans %}provided by {{ readthedocs_web }}{% endtrans %}.
+    {%- endif %}
+  
+    {%- block extrafooter %} {% endblock %}
+  
+  </footer>


### PR DESCRIPTION
## Description
Added the `footer.html` from [Sphinx-RTD theme](https://github.com/readthedocs/sphinx_rtd_theme/blob/master/sphinx_rtd_theme/footer.html) to override button text. 

## Issue / Bugzilla link
fix bug #5101 