### PR TITLE
Add download call-out to bottom of /system-requirements (#8647)

### DIFF
--- a/bedrock/firefox/templates/firefox/releases/system_requirements.html
+++ b/bedrock/firefox/templates/firefox/releases/system_requirements.html
@@ -4,6 +4,8 @@
 
 {% extends "firefox/base/base-protocol.html" %}
 
+{% from "macros-protocol.html" import call_out, call_out_compact %}
+
 {% block gtm_page_id %}data-gtm-page-id="/firefox/system-requirements/"{% endblock %}
 
 {% set channel_name = '' if release.channel == 'Release' else release.channel %}
@@ -33,5 +35,17 @@
       </div>
     </main>
   </div>
+
+  {% call call_out_compact(
+    title=_('Get the most recent version'),
+    class='mzp-t-firefox mzp-t-product-firefox'
+  ) %}
+    {{ download_firefox(alt_copy=_('Download Firefox'), download_location='primary cta') }}
+  {% endcall %}
+
+  <section class="all-download">
+    <a href="{{ url('firefox.all') }}">{{ _('All Firefox downloads') }}</a>
+  </section>
+
   {% block sidebar %}{% endblock %}
 {% endblock %}

--- a/media/css/firefox/system-requirements.scss
+++ b/media/css/firefox/system-requirements.scss
@@ -4,7 +4,9 @@
 
 $font-path: '/media/fonts';
 $image-path: '/media/protocol/img';
+
 @import '../../protocol/css/includes/lib';
+@import '../../protocol/css/components/call-out';
 
 .l-narrow {
     margin: 0 auto;
@@ -161,3 +163,30 @@ $image-path: '/media/protocol/img';
         }
     }
 }
+
+/* -------------------------------------------------------------------------- */
+// Call-out
+
+.mzp-c-call-out-compact, .all-download {
+    display: none;
+}
+
+.is-modern-browser {
+    .mzp-c-call-out-compact {
+        display: block;
+    }
+
+    .all-download {
+        @include text-body-md;
+        background-color: $color-marketing-gray-30;
+        display: block;
+        font-weight: bold;
+        padding: $spacing-sm $layout-2xs;
+
+        @media #{$mq-md} {
+            text-align: center;
+        }
+    }
+}
+
+


### PR DESCRIPTION
## Description
Adds download call-out CTA to the bottom of /system-requirements.
https://trello.com/c/A6QrAkhX

## Issue / Bugzilla link
#8647

**Test Plan:** https://docs.google.com/document/d/1wmLD2vSXd4SYuMsIMCMRgTZj4mRTAmTBOQrvb0c1fSY/edit?usp=sharing
(We have decided to do pre/post analysis for this experiment.)

## Testing
- [x] Call-out is not shown to browsers who do not meet system requirements.
- [x] Download button instrumented correctly. (https://bedrock.readthedocs.io/en/latest/analytics.html)
- [x] Missing l10n concerns?