### PR TITLE
[#8564] WNP75, hide signed-in content when signed out

### DIFF
--- a/media/css/firefox/whatsnew/whatsnew-75.scss
+++ b/media/css/firefox/whatsnew/whatsnew-75.scss
@@ -83,10 +83,8 @@ $image-path: '/media/protocol/img';
 //* -------------------------------------------------------------------------- */
 // Conditional content
 
-.state-fxa-default {
-    .show-signed-in {
-        display: none;
-    }
+.show-signed-in {
+    display: none;
 }
 
 .state-fxa-supported-signed-in {


### PR DESCRIPTION
## Description
I made a dumb mistake in #8673 and committed a bit of code I should have removed (artifact of local testing).

`.show-signed-in` should always be hidden *except* when the user is signed in. Hanging it from the `.state-fxa-default` class breaks because that class is removed/replaced when FxA is supported (so any modern Firefox) even if signed out.

## Testing
- [x] Monitor CTA is shown to signed-in Firefox
- [x] Sync CTA is shown in all other cases (signed-out Firefox, old Firefox, non-Firefox)