### PR TITLE
Fix Fluent error on supported nonlocale pages

### DIFF
--- a/bedrock/mozorg/tests/test_util.py
+++ b/bedrock/mozorg/tests/test_util.py
@@ -7,8 +7,6 @@
 import os
 
 from django.test import RequestFactory
-from django.test.utils import override_settings
-
 from mock import ANY, patch
 
 from bedrock.mozorg.tests import TestCase
@@ -16,7 +14,6 @@ from bedrock.mozorg.util import (
     get_fb_like_locale,
     page,
 )
-
 
 ROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'test_files')
 
@@ -44,53 +41,30 @@ class TestGetFacebookLikeLocale(TestCase):
         assert get_fb_like_locale('zz-ZZ') == 'en_US'
 
 
-@patch('bedrock.mozorg.util.django_render')
 @patch('bedrock.mozorg.util.l10n_utils')
 class TestPageUtil(TestCase):
     def setUp(self):
         self.rf = RequestFactory()
 
-    @override_settings(SUPPORTED_NONLOCALES=['dude'])
-    def test_locale_redirect_exclusion(self, l10n_mock, djrender_mock):
-        """A url with a prefix in SUPPORTED_NONLOCALES should use normal render."""
-        url = page('dude/abides', 'dude/abides.html', donny='alive')
-        url.callback(self.rf.get('/dude/abides/'))
-        assert not l10n_mock.render.called
-        djrender_mock.assert_called_with(ANY, 'dude/abides.html', {'urlname': 'dude.abides',
-                                                                   'donny': 'alive'})
-
-    @override_settings(SUPPORTED_NONLOCALES=['dude'])
-    def test_locale_redirect_non_exclusion(self, l10n_mock, djrender_mock):
-        """A url with a prefix not in SUPPORTED_NONLOCALES should use l10n render."""
+    def test_locale_redirect(self, l10n_mock):
+        """Should use l10n render."""
         url = page('walter/abides', 'walter/abides.html', donny='ashes')
         url.callback(self.rf.get('/walter/abides/'))
-        assert not djrender_mock.called
         l10n_mock.render.assert_called_with(ANY, 'walter/abides.html', {'urlname': 'walter.abides',
                                                                         'donny': 'ashes'}, ftl_files=None)
 
-    @override_settings(SUPPORTED_NONLOCALES=['dude'])
-    def test_locale_redirect_exclusion_nested(self, l10n_mock, djrender_mock):
-        """The final URL is what should be tested against the setting."""
-        url = page('abides', 'abides.html', donny='alive')
-        url.callback(self.rf.get('/dude/abides/'))
-        assert not l10n_mock.render.called
-        djrender_mock.assert_called_with(ANY, 'abides.html', {'urlname': 'abides',
-                                                              'donny': 'alive'})
-
-    @override_settings(SUPPORTED_NONLOCALES=['dude'])
-    def test_locale_redirect_works_home_page(self, l10n_mock, djrender_mock):
+    def test_locale_redirect_works_home_page(self, l10n_mock):
         """Make sure the home page still works. "/" is a special case."""
         url = page('', 'index.html')
         url.callback(self.rf.get('/'))
-        assert not djrender_mock.called
         l10n_mock.render.assert_called_with(ANY, 'index.html', {'urlname': 'index'}, ftl_files=None)
 
-    def test_url_name_set_from_template(self, l10n_mock, djrender_mock):
+    def test_url_name_set_from_template(self, l10n_mock):
         """If not provided the URL pattern name should be set from the template path."""
         url = page('lebowski/urban_achievers', 'lebowski/achievers.html')
         assert url.name == 'lebowski.achievers'
 
-    def test_url_name_set_from_param(self, l10n_mock, djrender_mock):
+    def test_url_name_set_from_param(self, l10n_mock):
         """If provided the URL pattern name should be set from the parameter."""
         url = page('lebowski/urban_achievers', 'lebowski/achievers.html',
                    url_name='proud.we.are.of.all.of.them')

--- a/bedrock/mozorg/util.py
+++ b/bedrock/mozorg/util.py
@@ -6,7 +6,6 @@ import os
 
 from django.conf import settings
 from django.conf.urls import url
-from django.shortcuts import render as django_render
 from django.views.decorators.csrf import csrf_exempt
 
 import commonware.log
@@ -63,13 +62,8 @@ def page(name, tmpl, decorators=None, url_name=None, ftl_files=None, **kwargs):
             # Name this in New Relic to differentiate pages
             newrelic.agent.set_transaction_name(
                 'mozorg.util.page:' + url_name.replace('.', '_'))
+
         kwargs.setdefault('urlname', url_name)
-
-        # skip l10n if path exempt
-        name_prefix = request.path_info.split('/', 2)[1]
-        if name_prefix in settings.SUPPORTED_NONLOCALES:
-            return django_render(request, tmpl, kwargs)
-
         return l10n_utils.render(request, tmpl, kwargs, ftl_files=ftl_files)
 
     # This is for graphite so that we can differentiate pages

--- a/lib/l10n_utils/__init__.py
+++ b/lib/l10n_utils/__init__.py
@@ -13,7 +13,6 @@ from django.utils.translation.trans_real import parse_accept_lang_header
 from django.views.generic import TemplateView
 
 from bedrock.base.urlresolvers import split_path
-
 from .dotlang import get_translations_native_names
 from .fluent import fluent_l10n
 from .gettext import translations_for_template
@@ -52,6 +51,10 @@ def render(request, template, context=None, ftl_files=None, **kwargs):
     l10n = None
     ftl_files = ftl_files or context.get('ftl_files')
     locale = get_locale(request)
+
+    # is this a non-locale page?
+    name_prefix = request.path_info.split('/', 2)[1]
+    nonlocale = name_prefix in settings.SUPPORTED_NONLOCALES
 
     # Make sure we have a single template
     if isinstance(template, list):
@@ -93,7 +96,7 @@ def render(request, template, context=None, ftl_files=None, **kwargs):
     context['translations'] = get_translations_native_names(translations)
 
     # Look for localized template
-    if hasattr(request, 'locale'):
+    if not nonlocale and getattr(request, 'locale', None):
         # Redirect to one of the user's accept languages or the site's default
         # language (en-US) if the current locale not active
         if request.locale not in translations:

--- a/lib/l10n_utils/tests/test_dotlang.py
+++ b/lib/l10n_utils/tests/test_dotlang.py
@@ -445,6 +445,7 @@ class TestTranslationList(TestCase):
         from product_details import product_details
         request = HttpRequest()
         request.path = '/' + lang + '/' + view_name + '/'
+        request.path_info = request.path
         request.locale = lang
         template = view_name.replace('-', '_') + '.html'
         with patch('lib.l10n_utils.django_render') as django_render:

--- a/lib/l10n_utils/tests/test_template.py
+++ b/lib/l10n_utils/tests/test_template.py
@@ -128,6 +128,7 @@ class TestNoLocale(TestCase):
         # (can happen on 500 error path, for example)
         get_l10n_path.return_value = None
         request = Mock(spec=object)
+        request.path_info = '/some/path/'
         # Note: no .locale on request
         # Should not cause an exception
         render(request, '500.html')


### PR DESCRIPTION
This change results in passing every page render through the l10n system, even ones in the SUPPORTED_NONLOCALE list.

Fix #8680