### PR TITLE
Migrate footer to Fluent (Fixes #8663)

### DIFF
--- a/bedrock/base/templates/includes/protocol/footer/firefox.html
+++ b/bedrock/base/templates/includes/protocol/footer/firefox.html
@@ -10,99 +10,92 @@
       <div class="mzp-c-footer-sections">
         <section class="mzp-c-footer-section">
           <h5 class="mzp-c-footer-heading">
-            Firefox
+            {{ ftl('footer-firefox') }}
           </h5>
           <ul class="mzp-c-footer-list">
-            <li><a href="{{ url('firefox.privacy.index') }}" data-link-type="footer" data-link-name="Privacy">{{ _('Privacy') }}</a></li>
-            <li><a href="{{ press_blog_url() }}" data-link-type="footer" data-link-name="Press">{{ _('Press') }}</a>
-            <li><a href="https://mozilla.design/?utm_source=www.mozilla.org&utm_medium=referral&utm_campaign=footer&utm_content=design" data-link-type="footer" data-link-name="Brand Standards">{{ _('Brand Standards') }}</a>
+            <li><a href="{{ url('firefox.privacy.index') }}" data-link-type="footer" data-link-name="Privacy">{{ ftl('footer-privacy') }}</a></li>
+            <li><a href="{{ press_blog_url() }}" data-link-type="footer" data-link-name="Press">{{ ftl('footer-press') }}</a>
+            <li><a href="https://mozilla.design/?utm_source=www.mozilla.org&utm_medium=referral&utm_campaign=footer&utm_content=design" data-link-type="footer" data-link-name="Brand Standards">{{ ftl('footer-brand-standards') }}</a>
           </ul>
         </section>
         <section class="mzp-c-footer-section">
           <h5 class="mzp-c-footer-heading">
-            {{ _('Browsers') }}
+            {{ ftl('footer-browsers') }}
           </h5>
           <ul class="mzp-c-footer-list">
-            <li><a href="{{ url('firefox.new') }}" data-link-type="footer" data-link-name="Desktop">{{ _('Desktop') }}</a></li>
-            <li><a href="{{ url('firefox.mobile.index') }}" data-link-type="footer" data-link-name="Mobile">{{ _('Mobile') }}</a></li>
-            <li><a href="https://mixedreality.mozilla.org/?utm_source=www.mozilla.org&utm_medium=referral&utm_campaign=footer&utm_content=reality" data-link-type="footer" data-link-name="Reality">Reality</a></li>
-            <li><a href="{{ url('firefox.enterprise.index') }}" data-link-type="footer" data-link-name="Enterprise">{{ _('Enterprise') }}</a></li>
+            <li><a href="{{ url('firefox.new') }}" data-link-type="footer" data-link-name="Desktop">{{ ftl('footer-desktop') }}</a></li>
+            <li><a href="{{ url('firefox.mobile.index') }}" data-link-type="footer" data-link-name="Mobile">{{ ftl('footer-mobile') }}</a></li>
+            <li><a href="https://mixedreality.mozilla.org/?utm_source=www.mozilla.org&utm_medium=referral&utm_campaign=footer&utm_content=reality" data-link-type="footer" data-link-name="Reality">{{ ftl('footer-reality') }}</a></li>
+            <li><a href="{{ url('firefox.enterprise.index') }}" data-link-type="footer" data-link-name="Enterprise">{{ ftl('footer-enterprise') }}</a></li>
           </ul>
         </section>
         <section class="mzp-c-footer-section">
           <h5 class="mzp-c-footer-heading">
-            {{ _('Products') }}
+            {{ ftl('footer-products') }}
           </h5>
           <ul class="mzp-c-footer-list">
-            <li><a href="{{ url('firefox.lockwise.lockwise') }}" data-link-type="footer" data-link-name="Lockwise">Lockwise</a></li>
-            <li><a href="https://monitor.firefox.com/?utm_source=www.mozilla.org&utm_medium=referral&utm_campaign=footer&utm_content=monitor" data-link-type="footer" data-link-name="Monitor">Monitor</a></li>
-            <li><a href="https://send.firefox.com/?utm_source=www.mozilla.org&utm_medium=referral&utm_campaign=footer&utm_content=send" data-link-type="footer" data-link-name="Send">Send</a></li>
-            {% if LANG.startswith('en-') %}<li><a href="{{ url('firefox.browsers.index') }}" data-link-type="footer" data-link-name="Browsers">{{ _('Browsers') }}</a></li>{% endif %}
-            <li><a href="https://getpocket.com/?utm_source=www.mozilla.org&utm_medium=referral&utm_campaign=footer&utm_content=pocket" data-link-type="footer" data-link-name="Pocket">Pocket</a></li>
+            <li><a href="{{ url('firefox.lockwise.lockwise') }}" data-link-type="footer" data-link-name="Lockwise">{{ ftl('footer-lockwise') }}</a></li>
+            <li><a href="https://monitor.firefox.com/?utm_source=www.mozilla.org&utm_medium=referral&utm_campaign=footer&utm_content=monitor" data-link-type="footer" data-link-name="Monitor">{{ ftl('footer-monitor') }}</a></li>
+            <li><a href="https://send.firefox.com/?utm_source=www.mozilla.org&utm_medium=referral&utm_campaign=footer&utm_content=send" data-link-type="footer" data-link-name="Send">{{ ftl('footer-send') }}</a></li>
+            {% if LANG.startswith('en-') %}<li><a href="{{ url('firefox.browsers.index') }}" data-link-type="footer" data-link-name="Browsers">{{ ftl('footer-browsers') }}</a></li>{% endif %}
+            <li><a href="https://getpocket.com/?utm_source=www.mozilla.org&utm_medium=referral&utm_campaign=footer&utm_content=pocket" data-link-type="footer" data-link-name="Pocket">{{ ftl('footer-pocket') }}</a></li>
           </ul>
         </section>
         <section class="mzp-c-footer-section">
           <h5 class="mzp-c-footer-heading">
-            {{ _('Join') }}
+            {{ ftl('footer-join') }}
           </h5>
           <ul class="mzp-c-footer-list">
-            <li class="fxa-signin"><a {{ fxa_link_fragment(entrypoint='mozilla.org-firefoxfooter', action='signup', utm_campaign='footer', utm_content='join-sign-up') }} class="js-fxa-cta-link" rel="external noopener"  data-link-type="footer" data-link-name="Sign Up">{{ _('Sign Up') }}</a></li>
-            <li class="fxa-signin"><a {{ fxa_link_fragment(entrypoint='mozilla.org-firefoxfooter', action='signin', utm_campaign='footer', utm_content='join-sign-in') }} class="js-fxa-cta-link" rel="external noopener"  data-link-type="footer" data-link-name="Sign In">{{ _('Sign In') }}</a></li>
-            <li><a href="{{ url('firefox.accounts') }}" data-link-type="footer" data-link-name="Benefits">{{ _('Benefits') }}</a></li>
+            <li class="fxa-signin"><a {{ fxa_link_fragment(entrypoint='mozilla.org-firefoxfooter', action='signup', utm_campaign='footer', utm_content='join-sign-up') }} class="js-fxa-cta-link" rel="external noopener"  data-link-type="footer" data-link-name="Sign Up">{{ ftl('footer-sign-up') }}</a></li>
+            <li class="fxa-signin"><a {{ fxa_link_fragment(entrypoint='mozilla.org-firefoxfooter', action='signin', utm_campaign='footer', utm_content='join-sign-in') }} class="js-fxa-cta-link" rel="external noopener"  data-link-type="footer" data-link-name="Sign In">{{ ftl('footer-sign-in') }}</a></li>
+            <li><a href="{{ url('firefox.accounts') }}" data-link-type="footer" data-link-name="Benefits">{{ ftl('footer-benefits') }}</a></li>
           </ul>
         </section>
         <section class="mzp-c-footer-section">
           <h5 class="mzp-c-footer-heading">
-            {{ _('Developers') }}
+            {{ ftl('footer-developers') }}
           </h5>
           <ul class="mzp-c-footer-list">
-            <li><a href="{{ url('firefox.developer.index') }}" data-link-type="footer" data-link-name="Developer Edition">Developer Edition</a></li>
-            <li><a href="{{ url('firefox.channel.desktop') + '#beta' }}" data-link-type="footer" data-link-name="Beta">Beta</a></li>
-            {# L10n: please do not translate the product name Beta #}
-            <li><a href="{{ url('firefox.channel.android') + '#beta' }}" data-link-type="footer" data-link-name="Beta for Android">{{ _('Beta for Android') }}</a></li>
-            <li><a href="{{ url('firefox.channel.desktop') + '#nightly' }}" data-link-type="footer" data-link-name="Nightly">Nightly</a></li>
-            {# L10n: please do not translate the product name Nightly #}
-            <li><a href="{{ url('firefox.channel.android') + '#nightly' }}" data-link-type="footer" data-link-name="Nightly for Android">{{ _('Nightly for Android') }}</a></li>
+            <li><a href="{{ url('firefox.developer.index') }}" data-link-type="footer" data-link-name="Developer Edition">{{ ftl('footer-developer-edition') }}</a></li>
+            <li><a href="{{ url('firefox.channel.desktop') + '#beta' }}" data-link-type="footer" data-link-name="Beta">{{ ftl('footer-beta') }}</a></li>
+            <li><a href="{{ url('firefox.channel.android') + '#beta' }}" data-link-type="footer" data-link-name="Beta for Android">{{ ftl('footer-beta-for-android') }}</a></li>
+            <li><a href="{{ url('firefox.channel.desktop') + '#nightly' }}" data-link-type="footer" data-link-name="Nightly">{{ ftl('footer-nightly') }}</a></li>
+            <li><a href="{{ url('firefox.channel.android') + '#nightly' }}" data-link-type="footer" data-link-name="Nightly for Android">{{ ftl('footer-nightly-for-android') }}</a></li>
           </ul>
         </section>
         <section class="mzp-c-footer-section mzp-c-has-lang">
           <div class="mzp-c-footer-language">
-            {% include 'includes/protocol/lang-switcher.html' %}
+           {% include 'includes/protocol/lang-switcher.html' %}
           </div>
           <ul class="mzp-c-footer-links-social">
-            <li><a class="twitter" href="https://twitter.com/firefox" data-link-type="footer" data-link-name="Twitter (@firefox)">{{ _('Twitter') }}<span> (@firefox)</span></a></li>
-            <li><a class="instagram" href="https://www.instagram.com/firefox/" data-link-type="footer" data-link-name="Instagram (@firefox)">{{ _('Instagram') }}<span> (@firefox)</span></a></li>
-            <li><a class="youtube" href="https://www.youtube.com/user/firefoxchannel" data-link-type="footer" data-link-name="YouTube (@firefoxchannel)">{{ _('YouTube') }}<span> (@firefoxchannel)</span></a></li>
+            <li><a class="twitter" href="https://twitter.com/firefox" data-link-type="footer" data-link-name="Twitter (@firefox)">{{ ftl('footer-twitter') }}<span> (@firefox)</span></a></li>
+            <li><a class="instagram" href="https://www.instagram.com/firefox/" data-link-type="footer" data-link-name="Instagram (@firefox)">{{ ftl('footer-instagram') }}<span> (@firefox)</span></a></li>
+            <li><a class="youtube" href="https://www.youtube.com/user/firefoxchannel" data-link-type="footer" data-link-name="YouTube (@firefoxchannel)">{{ ftl('footer-youtube') }}<span> (@firefoxchannel)</span></a></li>
           </ul>
         </section>
       </div>
     </nav>
     <nav class="mzp-c-footer-secondary">
       <div class="mzp-c-footer-primary-logo">
-        <a href="{{ url('mozorg.home') }}" data-link-type="footer" data-link-name="Mozilla">{{ _('Mozilla') }}</a>
+        <a href="{{ url('mozorg.home') }}" data-link-type="footer" data-link-name="Mozilla">{{ ftl('footer-mozilla') }}</a>
       </div>
       <div class="mzp-c-footer-legal">
         <div class="mzp-c-footer-license">
           {% set moco_link = 'href="%s" data-link-type="footer" data-link-name="Mozilla Corporation"'|safe|format(url('mozorg.home')) %}
           {% set mofo_link = 'href="https://foundation.mozilla.org" rel="external noopener" data-link-type="footer" data-link-name="Mozilla Foundation"'|safe %}
           <p>
-          {% trans %}
-            Visit <a {{ moco_link }}>Mozilla Corporation’s</a> not-for-profit parent, the <a {{ mofo_link }}>Mozilla Foundation</a>.
-          {% endtrans %}
+          {{ ftl('footer-visit-mozilla-corporations') }}
           </p>
           <p>
-          {%- trans url=url('foundation.licensing.website-content') -%}
-              Portions of this content are ©1998–{{ current_year }} by individual mozilla.org
-              contributors. Content available under a <a rel="license" href="{{ url }}">Creative Commons license</a>.
-          {%- endtrans -%}
+          {{ ftl('footer-portions-of-this-content', url=url('foundation.licensing.website-content'), current_year=current_year|string) }}
           </p>
         </div>
         <ul class="mzp-c-footer-terms">
           <li><a href="{{ url('mozorg.home') }}" data-link-type="footer" data-link-name="mozilla.org">mozilla.org</a></li>
-          <li><a href="{{ url('privacy') }}" data-link-type="footer" data-link-name="Privacy">{{ _('Privacy') }}</a></li>
-          <li><a href="{{ url('privacy.notices.websites') }}" data-link-type="footer" data-link-name="Privacy">{{ _('Website Privacy Notice') }}</a></li>
-          <li><a href="{{ url('privacy.notices.websites') }}#cookies" data-link-type="footer" data-link-name="Cookies">{{ _('Cookies') }}</a></li>
-          <li><a href="{{ url('legal.index') }}" data-link-type="footer" data-link-name="Legal">{{ _('Legal') }}</a></li>
+          <li><a href="{{ url('privacy') }}" data-link-type="footer" data-link-name="Privacy">{{ ftl('footer-privacy') }}</a></li>
+          <li><a href="{{ url('privacy.notices.websites') }}" data-link-type="footer" data-link-name="Privacy">{{ ftl('footer-websites-privacy-notice') }}</a></li>
+          <li><a href="{{ url('privacy.notices.websites') }}#cookies" data-link-type="footer" data-link-name="Cookies">{{ ftl('footer-websites-cookies') }}</a></li>
+          <li><a href="{{ url('legal.index') }}" data-link-type="footer" data-link-name="Legal">{{ ftl('footer-websites-legal') }}</a></li>
         </ul>
       </div>
     </nav>

--- a/bedrock/base/templates/includes/protocol/footer/mozilla.html
+++ b/bedrock/base/templates/includes/protocol/footer/mozilla.html
@@ -6,75 +6,70 @@
   <div class="mzp-l-content">
     <nav class="mzp-c-footer-primary">
       <div class="mzp-c-footer-primary-logo">
-        <a href="{{ url('mozorg.home') }}" data-link-type="footer" data-link-name="Mozilla">{{ _('Mozilla') }}</a>
+        <a href="{{ url('mozorg.home') }}" data-link-type="footer" data-link-name="Mozilla">{{ ftl('footer-mozilla') }}</a>
       </div>
       <div class="mzp-c-footer-sections">
         <section class="mzp-c-footer-section">
           <h5 class="mzp-c-footer-heading">
-            {{ _('Company') }}
+            {{ ftl('footer-company') }}
           </h5>
           <ul class="mzp-c-footer-list">
-            <li><a href="{{ url('mozorg.about') }}" data-link-type="footer" data-link-name="About">{{ _('About') }}</a></li>
-            <li><a href="{{ press_blog_url() }}" data-link-type="footer" data-link-name="Press Center">{{ _('Press Center') }}</a>
-            <li><a href="https://careers.mozilla.org/?utm_source=www.mozilla.org&utm_medium=referral&utm_campaign=footer&utm_content=company" data-link-type="footer" data-link-name="Careers">{{ _('Careers') }}</a>
+            <li><a href="{{ url('mozorg.about') }}" data-link-type="footer" data-link-name="About">{{ ftl('footer-about') }}</a></li>
+            <li><a href="{{ press_blog_url() }}" data-link-type="footer" data-link-name="Press Center">{{ ftl('footer-press-center') }}</a>
+            <li><a href="https://careers.mozilla.org/?utm_source=www.mozilla.org&utm_medium=referral&utm_campaign=footer&utm_content=company" data-link-type="footer" data-link-name="Careers">{{ ftl('footer-careers') }}</a>
           </ul>
         </section>
         <section class="mzp-c-footer-section">
           <h5 class="mzp-c-footer-heading">
-            {{ _('Developers') }}
+            {{ ftl('footer-developers') }}
           </h5>
           <ul class="mzp-c-footer-list">
-            <li><a href="{{ url('firefox.channel.desktop') }}" data-link-type="footer" data-link-name="Test New Features">{{ _('Test New Features') }}</a></li>
-            <li><a href="https://developer.mozilla.org/?utm_source=www.mozilla.org&utm_medium=referral&utm_campaign=footer&utm_content=developers" data-link-type="footer" data-link-name="MDN Web Docs">{{ _('MDN Web Docs') }}</a></li>
-            <li><a href="https://developer.mozilla.org/docs/Tools/?utm_source=www.mozilla.org&utm_medium=referral&utm_campaign=footer&utm_content=developers" data-link-type="footer" data-link-name="Tools">{{ _('Tools') }}</a></li>
+            <li><a href="{{ url('firefox.channel.desktop') }}" data-link-type="footer" data-link-name="Test New Features">{{ ftl('footer-test-new-features') }}</a></li>
+            <li><a href="https://developer.mozilla.org/?utm_source=www.mozilla.org&utm_medium=referral&utm_campaign=footer&utm_content=developers" data-link-type="footer" data-link-name="MDN Web Docs">{{ ftl('footer-mdn-web-docs') }}</a></li>
+            <li><a href="https://developer.mozilla.org/docs/Tools/?utm_source=www.mozilla.org&utm_medium=referral&utm_campaign=footer&utm_content=developers" data-link-type="footer" data-link-name="Tools">{{ ftl('footer-tools') }}</a></li>
           </ul>
         </section>
         <section class="mzp-c-footer-section">
           <h5 class="mzp-c-footer-heading">
-            {{ _('Resources') }}
+            {{ ftl('footer-resources') }}
           </h5>
           <ul class="mzp-c-footer-list">
-            <li><a href="{{ url('privacy') }}" data-link-type="footer" data-link-name="Privacy">{{ _('Privacy') }}</a></li>
-            <li><a href="{{ url('mozorg.contact.contact-landing') }}" data-link-type="footer" data-link-name="Contact Us">{{ _('Contact') }}</a></li>
+            <li><a href="{{ url('privacy') }}" data-link-type="footer" data-link-name="Privacy">{{ ftl('footer-privacy') }}</a></li>
+            <li><a href="{{ url('mozorg.contact.contact-landing') }}" data-link-type="footer" data-link-name="Contact Us">{{ ftl('footer-contact') }}</a></li>
           </ul>
         </section>
         <section class="mzp-c-footer-section">
           <h5 class="mzp-c-footer-heading">
-            {{ _('Product Help') }}
+            {{ ftl('footer-product-help') }}
           </h5>
           <ul class="mzp-c-footer-list">
-            <li><a href="https://support.mozilla.org/?utm_source=www.mozilla.org&utm_medium=referral&utm_campaign=footer&utm_content=help" data-link-type="footer" data-link-name="Support">{{ _('Support') }}</a></li>
-            <li><a href="https://bugzilla.mozilla.org/" data-link-type="footer" data-link-name="File a Bug">{{ _('File a Bug') }}</a></li>
+            <li><a href="https://support.mozilla.org/?utm_source=www.mozilla.org&utm_medium=referral&utm_campaign=footer&utm_content=help" data-link-type="footer" data-link-name="Support">{{ ftl('footer-support') }}</a></li>
+            <li><a href="https://bugzilla.mozilla.org/" data-link-type="footer" data-link-name="File a Bug">{{ ftl('footer-file-a-bug') }}</a></li>
           </ul>
         </section>
       </div>
     </nav>
     <nav class="mzp-c-footer-secondary">
       <div class="mzp-c-footer-language">
-        {% include 'includes/protocol/lang-switcher.html' %}
+       {% include 'includes/protocol/lang-switcher.html' %}
       </div>
       <ul class="mzp-c-footer-links-social">
-        <li><a class="twitter" href="https://twitter.com/mozilla" data-link-type="footer" data-link-name="Twitter (@mozilla)">{{ _('Twitter') }}<span> (@mozilla)</span></a></li>
-        <li><a class="instagram" href="https://www.instagram.com/mozilla/" data-link-type="footer" data-link-name="Instagram (@mozilla)">{{ _('Instagram') }}<span> (@mozilla)</span></a></li>
+        <li><a class="twitter" href="https://twitter.com/mozilla" data-link-type="footer" data-link-name="Twitter (@mozilla)">{{ ftl('footer-twitter') }}<span> (@mozilla)</span></a></li>
+        <li><a class="instagram" href="https://www.instagram.com/mozilla/" data-link-type="footer" data-link-name="Instagram (@mozilla)">{{ ftl('footer-instagram') }}<span> (@mozilla)</span></a></li>
       </ul>
       <div class="mzp-c-footer-legal">
         <p class="mzp-c-footer-license">
           {% set moco_link = 'href="%s" data-link-type="footer" data-link-name="Mozilla Corporation"'|safe|format(url('mozorg.home')) %}
           {% set mofo_link = 'href="https://foundation.mozilla.org" rel="external noopener" data-link-type="footer" data-link-name="Mozilla Foundation"'|safe %}
-          {% trans %}
-            Visit <a {{ moco_link }}>Mozilla Corporation’s</a> not-for-profit parent, the <a {{ mofo_link }}>Mozilla Foundation</a>.
-          {% endtrans %}<br>
-          {%- trans url=url('foundation.licensing.website-content') -%}
-              Portions of this content are ©1998–{{ current_year }} by individual mozilla.org
-              contributors. Content available under a <a rel="license" href="{{ url }}">Creative Commons license</a>.
-          {%- endtrans -%}
+          {{ ftl('footer-visit-mozilla-corporations') }}<br>
+          {{ ftl('footer-portions-of-this-content', url=url('foundation.licensing.website-content'), current_year=current_year|string) }}
         </p>
         <ul class="mzp-c-footer-terms">
-          <li><a href="{{ url('privacy') }}" data-link-type="footer" data-link-name="Privacy">{{ _('Privacy') }}</a></li>
-          <li><a href="{{ url('privacy.notices.websites') }}" data-link-type="footer" data-link-name="Privacy">{{ _('Website Privacy Notice') }}</a></li>
-          <li><a href="{{ url('privacy.notices.websites') }}#cookies" data-link-type="footer" data-link-name="Cookies">{{ _('Cookies') }}</a></li>
-          <li><a href="{{ url('legal.index') }}" data-link-type="footer" data-link-name="Legal">{{ _('Legal') }}</a></li>
-          <li><a href="{{ url('mozorg.about.governance.policies.participation') }}" data-link-type="footer" data-link-name="Community Participation Guidelines">{{ _('Community Participation Guidelines') }}</a></li>
+          <li><a href="{{ url('privacy') }}" data-link-type="footer" data-link-name="Privacy">{{ ftl('footer-privacy') }}</a></li>
+          <li><a href="{{ url('privacy.notices.websites') }}" data-link-type="footer" data-link-name="Privacy">{{ ftl('footer-websites-privacy-notice') }}</a></li>
+          <li><a href="{{ url('privacy.notices.websites') }}#cookies" data-link-type="footer" data-link-name="Cookies">{{ ftl('footer-websites-cookies') }}</a></li>
+          <li><a href="{{ url('legal.index') }}" data-link-type="footer" data-link-name="Legal">{{ ftl('footer-websites-legal') }}</a></li>
+          <li><a href="{{ url('mozorg.about.governance.policies.participation') }}" data-link-type="footer" data-link-name="Community Participation Guidelines">{{ ftl('footer-community-participation-guidelines') }}</a></li>
         </ul>
       </div>
     </nav>

--- a/bedrock/base/templates/includes/protocol/lang-switcher.html
+++ b/bedrock/base/templates/includes/protocol/lang-switcher.html
@@ -1,18 +1,18 @@
 {# This Source Code Form is subject to the terms of the Mozilla Public
-  # License, v. 2.0. If a copy of the MPL was not distributed with this
-  # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
 
- {% if translations|length > 1 %}
- <form id="lang_form" class="mzp-c-language-switcher mzp-t-dark" method="get" action="#">
-  <a class="mzp-c-language-switcher-link" href="{{ url('mozorg.locales') }}">{{ _('Language') }}</a>
-  <label for="page-language-select">{{ _('Language') }}</label>
-  <select id="page-language-select" class="mzp-js-language-switcher-select" name="lang" dir="ltr">
-    {% for code, label in translations|dictsort -%}
-      {# Don't escape the label as it may include entity references
-       # like "Português (do&nbsp;Brasil)" (Bug 861149) #}
-      <option lang="{{ code }}" value="{{ code }}"{{ code|ifeq(LANG, " selected") }}>{{ label|safe|replace('English (US)', 'English') }}</option>
-    {% endfor %}
-  </select>
-  <button type="submit">{{ _('Go') }}</button>
- </form>
- {% endif %}
+{% if translations|length > 1 %}
+  <form id="lang_form" class="mzp-c-language-switcher mzp-t-dark" method="get" action="#">
+    <a class="mzp-c-language-switcher-link" href="{{ url('mozorg.locales') }}">{{ ftl('footer-language') }}</a>
+    <label for="page-language-select">{{ ftl('footer-language') }}</label>
+    <select id="page-language-select" class="mzp-js-language-switcher-select" name="lang" dir="ltr">
+      {% for code, label in translations|dictsort -%}
+        {# Don't escape the label as it may include entity references
+        # like "Português (do&nbsp;Brasil)" (Bug 861149) #}
+        <option lang="{{ code }}" value="{{ code }}"{{ code|ifeq(LANG, " selected") }}>{{ label|safe|replace('English (US)', 'English') }}</option>
+      {% endfor %}
+    </select>
+    <button type="submit">{{ ftl('footer-go') }}</button>
+  </form>
+{% endif %}

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -239,8 +239,8 @@ DOTLANG_CACHE = config('DOTLANG_CACHE', default='1800' if DEBUG else '600', pars
 
 # Global L10n files.
 # TODO Port DOTLANG_FILES to FLUENT_DEFAULT_FILES
-DOTLANG_FILES = ['download_button', 'main', 'footer']
-FLUENT_DEFAULT_FILES = ['brands', 'navigation']
+DOTLANG_FILES = ['download_button', 'main']
+FLUENT_DEFAULT_FILES = ['brands', 'navigation', 'footer']
 
 FLUENT_DEFAULT_PERCENT_REQUIRED = config('FLUENT_DEFAULT_PERCENT_REQUIRED', default='80', parser=int)
 FLUENT_REPO = config('FLUENT_REPO', default='https://github.com/mozmeao/www-l10n')

--- a/l10n/en/footer.ftl
+++ b/l10n/en/footer.ftl
@@ -1,0 +1,52 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+footer-firefox = { -brand-name-firefox }
+footer-privacy = Privacy
+footer-press = Press
+footer-brand-standards = Brand Standards
+footer-browsers = Browsers
+footer-desktop = Desktop
+footer-mobile = Mobile
+footer-reality = { -brand-name-reality }
+footer-enterprise = { -brand-name-enterprise }
+footer-products = Products
+footer-lockwise = { -brand-name-lockwise }
+footer-monitor = { -brand-name-monitor }
+footer-send = { -brand-name-send }
+footer-pocket = { -brand-name-pocket }
+footer-join = Join
+footer-sign-up = Sign Up
+footer-sign-in = Sign In
+footer-benefits = Benefits
+footer-developers = Developers
+footer-developer-edition = { -brand-name-developer-edition }
+footer-beta = { -brand-name-beta }
+footer-nightly = { -brand-name-nightly }
+footer-nightly-for-android = { -brand-name-nightly } for { -brand-name-android }
+footer-beta-for-android = { -brand-name-beta } for { -brand-name-android }
+footer-visit-mozilla-corporations = Visit <a { $moco_link }>{ -brand-name-mozilla-corporation }’s</a> not-for-profit parent, the <a { $mofo_link }>{ -brand-name-mozilla-foundation }</a>.
+footer-portions-of-this-content = Portions of this content are ©1998–{ $current_year } by individual mozilla.org contributors. Content available under a <a rel="license" href="{ $url }">{ -brand-name-creative-commons } license</a>.
+footer-mozilla = { -brand-name-mozilla }
+footer-company = Company
+footer-about = About
+footer-press-center = Press Center
+footer-careers = Careers
+footer-test-new-features = Test New Features
+footer-mdn-web-docs = { -brand-name-mdn-web-docs }
+footer-tools = Tools
+footer-resources = Resources
+footer-contact = Contact
+footer-product-help = Product Help
+footer-support = Support
+footer-file-a-bug = File a Bug
+footer-community-participation-guidelines = Community Participation Guidelines
+footer-websites-privacy-notice = Website Privacy Notice
+footer-websites-cookies = Cookies
+footer-websites-legal = Legal
+footer-language = Language
+footer-go = Go
+footer-twitter = { -brand-name-twitter }
+footer-instagram = { -brand-name-instagram }
+footer-youtube = { -brand-name-youtube }

--- a/l10n/en/navigation.ftl
+++ b/l10n/en/navigation.ftl
@@ -109,7 +109,6 @@ navigation-products = Products
 navigation-mozilla = { -brand-name-mozilla }
 navigation-mozilla-foundation = { -brand-name-mozilla-foundation }
 navigation-mozilla-corporation = { -brand-name-mozilla-corporation }
-navigation-mozilla = { -brand-name-mozilla }
 navigation-firefox-developer-edition = { -brand-name-firefox-developer-edition }
 navigation-firefox-beta = { -brand-name-firefox-beta }
 navigation-firefox-nightly = { -brand-name-firefox-nightly }

--- a/lib/fluent_migrations/includes/protocol/footer/footer.py
+++ b/lib/fluent_migrations/includes/protocol/footer/footer.py
@@ -1,0 +1,125 @@
+from __future__ import absolute_import
+import fluent.syntax.ast as FTL
+from fluent.migrate.helpers import transforms_from
+from fluent.migrate.helpers import VARIABLE_REFERENCE, TERM_REFERENCE
+from fluent.migrate import REPLACE, COPY
+
+footer = "footer.lang"
+main = "main.lang"
+
+def migrate(ctx):
+    """Migrate bedrock/base/templates/includes/protocol/footer/footer.html, part {index}."""
+
+    ctx.add_transforms(
+        "footer.ftl",
+        "footer.ftl",
+        transforms_from("""
+footer-firefox = { -brand-name-firefox }
+footer-privacy = {COPY(main, "Privacy",)}
+footer-press = {COPY(footer, "Press",)}
+footer-brand-standards = {COPY(footer, "Brand Standards",)}
+footer-browsers = {COPY(footer, "Browsers",)}
+footer-desktop = {COPY(main, "Desktop",)}
+footer-mobile = {COPY(main, "Mobile",)}
+footer-reality = { -brand-name-reality }
+footer-enterprise = { -brand-name-enterprise }
+footer-products = {COPY(footer, "Products",)}
+footer-lockwise = { -brand-name-lockwise }
+footer-monitor = { -brand-name-monitor }
+footer-send = { -brand-name-send }
+footer-pocket = { -brand-name-pocket }
+footer-join = {COPY(footer, "Join",)}
+footer-sign-up = {COPY(footer, "Sign Up",)}
+footer-sign-in = {COPY(footer, "Sign In",)}
+footer-benefits = {COPY(footer, "Benefits",)}
+footer-developers = {COPY(footer, "Developers",)}
+footer-developer-edition = { -brand-name-developer-edition }
+footer-beta = { -brand-name-beta }
+footer-nightly = { -brand-name-nightly }
+""", footer=footer, main=main)
+    )
+
+    ctx.add_transforms(
+        "footer.ftl",
+        "footer.ftl",
+        [
+            FTL.Message(
+                id=FTL.Identifier("footer-nightly-for-android"),
+                value=REPLACE(
+                    "footer.lang",
+                    "Nightly for Android",
+                    {
+                        "Nightly": TERM_REFERENCE("brand-name-nightly"),
+                        "Android": TERM_REFERENCE("brand-name-android"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("footer-beta-for-android"),
+                value=REPLACE(
+                    "footer.lang",
+                    "Beta for Android",
+                    {
+                        "Beta": TERM_REFERENCE("brand-name-beta"),
+                        "Android": TERM_REFERENCE("brand-name-android"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("footer-visit-mozilla-corporations"),
+                value=REPLACE(
+                    "footer.lang",
+                    "Visit <a %(moco_link)s>Mozilla Corporation’s</a> not-for-profit parent, the <a %(mofo_link)s>Mozilla Foundation</a>.",
+                    {
+                        "%%": "%",
+                        "%(moco_link)s": VARIABLE_REFERENCE("moco_link"),
+                        "%(mofo_link)s": VARIABLE_REFERENCE("mofo_link"),
+                        "Mozilla Corporation": TERM_REFERENCE("brand-name-mozilla-corporation"),
+                        "Mozilla Foundation": TERM_REFERENCE("brand-name-mozilla-foundation"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("footer-portions-of-this-content"),
+                value=REPLACE(
+                    "footer.lang",
+                    "Portions of this content are ©1998–%(current_year)s by individual mozilla.org contributors. Content available under a <a rel=\"license\" href=\"%(url)s\">Creative Commons license</a>.",
+                    {
+                        "%%": "%",
+                        "%(current_year)s": VARIABLE_REFERENCE("current_year"),
+                        "%(url)s": VARIABLE_REFERENCE("url"),
+                        "Creative Commons": TERM_REFERENCE("brand-name-creative-commons"),
+                    }
+                )
+            ),
+        ]
+    )
+
+    ctx.add_transforms(
+        "footer.ftl",
+        "footer.ftl",
+        transforms_from("""
+footer-mozilla = { -brand-name-mozilla }
+footer-company = {COPY(footer, "Company",)}
+footer-about = {COPY(main, "About",)}
+footer-press-center = {COPY(main, "Press Center",)}
+footer-careers = {COPY(footer, "Careers",)}
+footer-test-new-features = {COPY(footer, "Test New Features",)}
+footer-mdn-web-docs = { -brand-name-mdn-web-docs }
+footer-tools = {COPY(footer, "Tools",)}
+footer-resources = {COPY(footer, "Resources",)}
+footer-contact = {COPY(footer, "Contact",)}
+footer-product-help = {COPY(footer, "Product Help",)}
+footer-support = {COPY(footer, "Support",)}
+footer-file-a-bug = {COPY(footer, "File a Bug",)}
+footer-community-participation-guidelines = {COPY(footer, "Community Participation Guidelines",)}
+footer-websites-privacy-notice = {COPY(main, "Website Privacy Notice",)}
+footer-websites-cookies = {COPY(main, "Cookies",)}
+footer-websites-legal = {COPY(main, "Legal",)}
+footer-language = {COPY(main, "Language",)}
+footer-go = {COPY(main, "Go",)}
+footer-twitter = { -brand-name-twitter }
+footer-instagram = { -brand-name-instagram }
+footer-youtube = { -brand-name-youtube }
+""", footer=footer, main=main)
+    )


### PR DESCRIPTION
## Description
- Migrate footer.lang to footer.ftl
- Update footer templates to use Fluent string IDs.


## Issue / Bugzilla link
https://github.com/mozilla/bedrock/issues/8663

## Testing
- First make sure translations are up to date by running `./manage.py l10n_update`.

Successful test run: https://gitlab.com/mozmeao/www-config/pipelines/128782618