### PR TITLE
[fix #8691] Add Better Web terms and privacy pages

### DIFF
--- a/bedrock/legal/templates/legal/index.html
+++ b/bedrock/legal/templates/legal/index.html
@@ -57,6 +57,9 @@
     <a href="{{ url('legal.terms.services') }}">{{ _('Firefox Services') }}</a>
   </li>
   <li>
+    <a href="{{ url('legal.terms.betterweb') }}">{{ _('Firefox Better Web') }}</a>
+  </li>
+  <li>
     <a href="https://webmaker.org/#/legal">{{ _('Webmaker') }}</a>
   </li>
 </ul>

--- a/bedrock/legal/templates/legal/terms/betterweb.html
+++ b/bedrock/legal/templates/legal/terms/betterweb.html
@@ -1,0 +1,7 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+
+{% extends "legal/docs-base.html" %}
+
+{% block page_title %}{{ _('Firefox Better Web Terms of Service') }}{% endblock %}

--- a/bedrock/legal/urls.py
+++ b/bedrock/legal/urls.py
@@ -22,6 +22,9 @@ urlpatterns = (
     # requested in any other locale. (Bug 1248393)
     page('impressum', 'legal/impressum.html', active_locales=['de']),
 
+    url(r'^terms/betterweb/$', LegalDocView.as_view(template_name='legal/terms/betterweb.html', legal_doc_name='better_web_terms'),
+        name='legal.terms.betterweb'),
+
     url(r'^terms/mozilla/$', LegalDocView.as_view(template_name='legal/terms/mozilla.html', legal_doc_name='Websites_ToU'),
         name='legal.terms.mozilla'),
 

--- a/bedrock/privacy/templates/privacy/base-protocol.html
+++ b/bedrock/privacy/templates/privacy/base-protocol.html
@@ -33,6 +33,7 @@
   (url('privacy'), 'privacy-home', _('Mozilla Privacy')),
   (url('privacy.notices.websites'), 'privacy-websites', _('Mozilla Websites, Communications &amp; Cookies')),
   (url('privacy.notices.firefox'), 'privacy-quantum', _('Firefox Browser')),
+  (url('privacy.notices.firefox-betterweb'), 'privacy-betterweb', _('Firefox Better Web')),
   (url('privacy.notices.firefox-fire-tv'), 'privacy-fire-tv', _('Firefox for Fire TV')),
   (url('privacy.notices.firefox-reality'), 'privacy-reality', _('Firefox Reality')),
   (url('privacy.notices.firefox-os'), 'privacy-os', _('Firefox OS')),

--- a/bedrock/privacy/templates/privacy/index.html
+++ b/bedrock/privacy/templates/privacy/index.html
@@ -63,6 +63,14 @@
       {% endtrans %}
       </p>
     {% endif %}
+
+    {% if l10n_has_tag('privacy_sumo_032020') %}
+      <p>
+      {% trans sumo='https://support.mozilla.org/' %}
+        For product support requests, please <a href="{{ sumo }}">visit our forums</a>.
+      {% endtrans %}
+      </p>
+    {% endif %}
   </section>
 {% endblock %}
 

--- a/bedrock/privacy/templates/privacy/notices/firefox-betterweb.html
+++ b/bedrock/privacy/templates/privacy/notices/firefox-betterweb.html
@@ -1,0 +1,7 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+
+{% extends "privacy/notices/base-notice-paragraphs.html" %}
+
+{% set body_id = "privacy-betterweb" %}

--- a/bedrock/privacy/urls.py
+++ b/bedrock/privacy/urls.py
@@ -13,6 +13,7 @@ urlpatterns = (
     page('principles', 'privacy/principles.html'),
     page('faq', 'privacy/faq.html'),
     page('email', 'privacy/email.html', active_locales=['en-US', 'de', 'fr']),
+    url(r'^betterweb/$', views.firefox_betterweb_notices, name='privacy.notices.firefox-betterweb'),
     url(r'^firefox/$', views.firefox_notices, name='privacy.notices.firefox'),
     url(r'^firefox-os/$', views.firefox_os_notices, name='privacy.notices.firefox-os'),
     url(r'^firefox-fire-tv/$', views.firefox_fire_tv_notices, name='privacy.notices.firefox-fire-tv'),

--- a/bedrock/privacy/views.py
+++ b/bedrock/privacy/views.py
@@ -54,6 +54,10 @@ class FirefoxPrivacyDocView(PrivacyDocView):
 firefox_notices = FirefoxPrivacyDocView.as_view(
     legal_doc_name='firefox_privacy_notice')
 
+firefox_betterweb_notices = PrivacyDocView.as_view(
+    template_name='privacy/notices/firefox-betterweb.html',
+    legal_doc_name='better_web_privacy')
+
 firefox_os_notices = PrivacyDocView.as_view(
     template_name='privacy/notices/firefox-os.html',
     legal_doc_name='firefox_os_privacy_notice')


### PR DESCRIPTION
## Description
Updates legal docs, adds Terms and Privacy pages for Firefox Better Web, and also adds a SUMO link on the main privacy page.

## Issue / Bugzilla link
#8691 - Add Better Web terms and privacy pages
#7052 - Add support link to privacy contact section

## Testing
http://localhost:8000/privacy/
http://localhost:8000/privacy/betterweb/
http://localhost:8000/about/legal/
http://localhost:8000/about/legal/terms/betterweb/