### PR TITLE
Remove Chris Beard and Michael DeAngelo from legal/impressum [no bug]

### DIFF
--- a/bedrock/legal/templates/legal/impressum.html
+++ b/bedrock/legal/templates/legal/impressum.html
@@ -26,12 +26,6 @@
   <h2>Vertretungsberechtigte Personen:</h2>
   <ul class="mzp-u-list-styled">
     <li itemscope itemtype="http://schema.org/Person">
-      <span itemprop="name">Chris Beard</a>
-    </li>
-    <li itemscope itemtype="http://schema.org/Person">
-      <span itemprop="name">Michael DeAngelo</a>
-    </li>
-    <li itemscope itemtype="http://schema.org/Person">
       <span itemprop="name">Roxi Wen</a>
     </li>
     <li itemscope itemtype="http://schema.org/Person">


### PR DESCRIPTION
## Description
Removes mention of Chris Beard and Michael DeAngelo from legal/impressum
(noticed when reviewing a pull request.)
