### PR TITLE
Migrate download_button.lang to Fluent (Fixes #8654)

### DIFF
--- a/bedrock/base/templates/base-pebbles.html
+++ b/bedrock/base/templates/base-pebbles.html
@@ -84,7 +84,6 @@
       data-global-close="{{ _('Close') }}"
       data-global-next="{{ _('Next') }}"
       data-global-previous="{{ _('Previous') }}"
-      data-global-update-firefox="{{ _('Update your Firefox') }}"
       data-global-fx-out-of-date-banner-heading="{{ _('Your Firefox is out-of-date.') }}"
       data-global-fx-out-of-date-banner-message="{{ _('Get the most recent version to keep browsing securely.') }}"
       data-global-fx-out-of-date-banner-confirm="{{ _('Update Firefox') }}"

--- a/bedrock/base/templates/includes/protocol/navigation/nav-cta.html
+++ b/bedrock/base/templates/includes/protocol/navigation/nav-cta.html
@@ -5,7 +5,7 @@
 {% if not hide_nav_cta %}
   <div class="mzp-c-navigation-download">
     {% if not hide_nav_download_button %}
-      {{ download_firefox(alt_copy=ftl('navigation-download-firefox'), dom_id='protocol-nav-download-firefox', button_color='mzp-t-secondary mzp-t-small', download_location='nav') }}
+      {{ download_firefox(alt_copy=ftl('download-button-download-firefox'), dom_id='protocol-nav-download-firefox', button_color='mzp-t-secondary mzp-t-small', download_location='nav') }}
     {% endif %}
     {% if not hide_nav_get_account_button %}
       <div class="c-navigation-fxa-cta-container">

--- a/bedrock/base/templates/includes/sub-nav.html
+++ b/bedrock/base/templates/includes/sub-nav.html
@@ -13,7 +13,7 @@
         </ul>
       </div>
       <div class="sub-nav-download-wrapper">
-        {{ download_firefox(alt_copy=_('Download Firefox'), dom_id='sub-nav-download-firefox', download_location='sub nav') }}
+        {{ download_firefox(alt_copy=ftl('download-button-download-firefox'), dom_id='sub-nav-download-firefox', download_location='sub nav') }}
       </div>
     </div>
   </div>

--- a/bedrock/base/templates/macros.html
+++ b/bedrock/base/templates/macros.html
@@ -44,7 +44,7 @@
 {%- endmacro %}
 
 {% macro google_play_button(class_name='', extra_data_attributes={}, extra_img_attributes={}, href=settings.GOOGLE_PLAY_FIREFOX_LINK_UTMS, id='', product='Firefox', target='') -%}
-{% set optional_img_attributes = {'alt': _('Get it on Google Play'), 'width': '152', 'height': '45', 'l10n': True} %}
+{% set optional_img_attributes = {'alt': ftl('download-button-google-play'), 'width': '152', 'height': '45', 'l10n': True} %}
 {% do optional_img_attributes.update(extra_img_attributes) %}
 <a{% if class_name %} class="{{ class_name }}"{% endif %}{% if id %} id="{{ id }}"{% endif %}{% if target %} target="{{ target }}" rel="external noopener noreferrer"{% else %} rel="external"{% endif %} href="{{ href }}"{% if product in ['Firefox', 'Focus'] %} data-link-type="download" data-download-os="Android"{% endif %}{% if product == 'Firefox' %} data-mozillaonline-link="{{ settings.GOOGLE_PLAY_FIREFOX_LINK_MOZILLAONLINE }}"{% endif %}{% for attr, val in extra_data_attributes.items() %} data-{{ attr }}="{{ val }}"{% endfor %}>
   {{ high_res_img('img/firefox/android/btn-google-play.png', optional_img_attributes) }}

--- a/bedrock/firefox/templates/firefox/all-unified.html
+++ b/bedrock/firefox/templates/firefox/all-unified.html
@@ -150,7 +150,7 @@
           </p>
 
           <a href="#all-downloads" id="download-button-primary" class="mzp-c-button mzp-t-product" data-link-type="download" data-download-location="primary cta">
-            {{ _('Download Now') }}
+            {{ ftl('download-button-download-now') }}
           </a>
         </div>
       </form>

--- a/bedrock/firefox/templates/firefox/browsers/index.html
+++ b/bedrock/firefox/templates/firefox/browsers/index.html
@@ -65,7 +65,7 @@
       </div>
       <div class="appstore-ios">
         <a id="appStoreLink" href="{{ ios_url }}" data-link-type="download" data-download-os="iOS">
-          <img src="{{ l10n_img('firefox/ios/btn-app-store.svg') }}" alt="{{ _('Download on the App Store') }}" width="152" height="45">
+          <img src="{{ l10n_img('firefox/ios/btn-app-store.svg') }}" alt="{{ ftl('download-button-download-app-store') }}" width="152" height="45">
         </a>
       </div>
       <div id="menu-mobile-wrapper"  class="mzp-c-menu-list mzp-t-cta mzp-t-download">

--- a/bedrock/firefox/templates/firefox/campaign/index.html
+++ b/bedrock/firefox/templates/firefox/campaign/index.html
@@ -65,7 +65,7 @@
     image_url='img/firefox/new/trailhead/browser-window.svg',
     heading_level=1
   ) %}
-    {{ download_firefox(alt_copy=_('Download Now'), download_location='primary cta') }}
+    {{ download_firefox(alt_copy=ftl('download-button-download-now'), download_location='primary cta') }}
   {% endcall %}
 
   <section class="features">

--- a/bedrock/firefox/templates/firefox/compare/chrome.html
+++ b/bedrock/firefox/templates/firefox/compare/chrome.html
@@ -333,7 +333,7 @@
       </p>
 
       <aside class="secondary-download-cta">
-        {{ download_firefox(dom_id='download-secondary', alt_copy=_('Download Firefox'), download_location='secondary cta') }}
+        {{ download_firefox(dom_id='download-secondary', alt_copy=ftl('download-button-download-firefox'), download_location='secondary cta') }}
       </aside>
 
     </section>

--- a/bedrock/firefox/templates/firefox/compare/edge.html
+++ b/bedrock/firefox/templates/firefox/compare/edge.html
@@ -335,7 +335,7 @@
       </p>
 
       <aside class="secondary-download-cta">
-        {{ download_firefox(dom_id='download-secondary', alt_copy=_('Download Firefox'), download_location='secondary cta') }}
+        {{ download_firefox(dom_id='download-secondary', alt_copy=ftl('download-button-download-firefox'), download_location='secondary cta') }}
       </aside>
 
     </section>

--- a/bedrock/firefox/templates/firefox/compare/ie.html
+++ b/bedrock/firefox/templates/firefox/compare/ie.html
@@ -297,7 +297,7 @@
       </p>
 
       <aside class="secondary-download-cta">
-        {{ download_firefox(dom_id='download-secondary', alt_copy=_('Download Firefox'), download_location='secondary cta') }}
+        {{ download_firefox(dom_id='download-secondary', alt_copy=ftl('download-button-download-firefox'), download_location='secondary cta') }}
       </aside>
 
     </section>

--- a/bedrock/firefox/templates/firefox/compare/opera.html
+++ b/bedrock/firefox/templates/firefox/compare/opera.html
@@ -304,7 +304,7 @@
       </p>
 
       <aside class="secondary-download-cta">
-        {{ download_firefox(dom_id='download-secondary', alt_copy=_('Download Firefox'), download_location='secondary cta') }}
+        {{ download_firefox(dom_id='download-secondary', alt_copy=ftl('download-button-download-firefox'), download_location='secondary cta') }}
       </aside>
 
     </section>

--- a/bedrock/firefox/templates/firefox/compare/safari.html
+++ b/bedrock/firefox/templates/firefox/compare/safari.html
@@ -324,7 +324,7 @@
       </p>
 
       <aside class="secondary-download-cta">
-        {{ download_firefox(dom_id='download-secondary', alt_copy=_('Download Firefox'), download_location='secondary cta') }}
+        {{ download_firefox(dom_id='download-secondary', alt_copy=ftl('download-button-download-firefox'), download_location='secondary cta') }}
       </aside>
 
     </section>

--- a/bedrock/firefox/templates/firefox/facebookcontainer/index.html
+++ b/bedrock/firefox/templates/firefox/facebookcontainer/index.html
@@ -29,7 +29,7 @@
 
     <div class="firefox-cta">
       <p>{{ _('Download Firefox and get the Facebook Container Extension') }}</p>
-      {{ download_firefox(alt_copy=_('Download Firefox'), locale_in_transition=true, dom_id="download-firefox-cta") }}
+      {{ download_firefox(alt_copy=ftl('download-button-download-firefox'), locale_in_transition=true, dom_id="download-firefox-cta") }}
     </div>
 
     <div class="mobile-cta">
@@ -44,7 +44,7 @@
         </li>
         <li>
           <a id="appStoreLink" href="{{ focus_adjust_url('ios', 'fb-container-page') }}" data-link-type="download" data-download-os="iOS">
-            <img src="{{ l10n_img('firefox/ios/btn-app-store.svg') }}" alt="{{ _('Download on the App Store') }}" width="152" height="45">
+            <img src="{{ l10n_img('firefox/ios/btn-app-store.svg') }}" alt="{{ ftl('download-button-download-app-store') }}" width="152" height="45">
           </a>
         </li>
       </ul>
@@ -105,7 +105,7 @@
       class='mzp-t-dark',
       heading_level=2)
     %}
-    {{ download_firefox(alt_copy=_('Download Now'), locale_in_transition=true, dom_id="download-firefox-today") }}
+    {{ download_firefox(alt_copy=ftl('download-button-download-now'), dom_id="download-firefox-today") }}
     {% endcall %}
   </section>
 </main>

--- a/bedrock/firefox/templates/firefox/home/index-quantum.html
+++ b/bedrock/firefox/templates/firefox/home/index-quantum.html
@@ -46,7 +46,7 @@
           <p>{{ _('Fast for good.') }}</p>
         </div>
         <div class="mzp-c-hero-cta">
-          {{ download_firefox(dom_id='download-intro', alt_copy=_('Download now'), download_location='primary cta') }}
+          {{ download_firefox(dom_id='download-intro', alt_copy=ftl('download-button-download-now'), download_location='primary cta') }}
         </div>
       </div>
     </div>
@@ -224,7 +224,7 @@
       class='mzp-t-firefox mzp-t-product-firefox mzp-t-dark t-you'
       ) %}
       <div class="download-firefox">
-        {{ download_firefox(dom_id='footer-download', alt_copy=_('Download now'), download_location='other') }}
+        {{ download_firefox(dom_id='footer-download', alt_copy=ftl('download-button-download-now'), download_location='other') }}
       </div>
     {% endcall %}
   </div>

--- a/bedrock/firefox/templates/firefox/includes/download-button.html
+++ b/bedrock/firefox/templates/firefox/includes/download-button.html
@@ -6,13 +6,13 @@
   <div class="download download-dumb">
     <p role="heading" class="download-heading">
       {% if channel == 'beta' %}
-        {{ _('Firefox Beta') }}
+        {{ ftl('download-button-firefox-beta') }}
       {% elif channel == 'alpha' %}
-        {{ _('<span>Firefox</span> Developer Edition') }}
+        {{ ftl('download-button-firefox-developer-edition') }}
       {% elif channel == 'nightly' %}
-        {{ _('Firefox Nightly') }}
+        {{ ftl('download-button-firefox-nightly') }}
       {% else %}
-        {{ _('Download Firefox') }}
+        {{ ftl('download-button-download-firefox') }}
       {% endif %}  — {{ locale_name|safe }}
     </p>
     <ul>
@@ -45,17 +45,17 @@
   {% if show_desktop %}
     {# unrecognized/unsupported platform #}
     <div class="unrecognized-download">
-      <p>{{ _('Your system may not meet the requirements for Firefox, but you can try one of these versions:') }}</p>
+      <p>{{ ftl('download-button-your-system-may') }}</p>
       {{ alt_buttons(builds) }}
     </div>
     <p class="unsupported-download">
-      {{ _("Your system doesn't meet the <a href=\"%(url)s\">requirements</a> to run Firefox.")|format(url=firefox_url('desktop', 'sysreq', channel)) }}
+      {{ ftl('download-button-your-system-does-not', url=firefox_url('desktop', 'sysreq', channel)) }}
     </p>
     <p class="unsupported-download-osx">
-      {{ _("Your system doesn't meet the <a href=\"%(url)s\">requirements</a> to run Firefox.")|format(url='https://support.mozilla.org/kb/firefox-osx') }}
+      {{ ftl('download-button-your-system-does-not', url='https://support.mozilla.org/kb/firefox-osx') }}
     </p>
     <p class="linux-arm-download">
-      {{ _('Please follow <a href="%(url)s">these instructions</a> to install Firefox.')|format(url='https://support.mozilla.org/kb/install-firefox-linux') }}
+      {{ ftl('download-button-please-follow-these', url='https://support.mozilla.org/kb/install-firefox-linux') }}
     </p>
   {% endif %}
   <ul class="download-list">
@@ -77,25 +77,25 @@
             {% else %}
               {% if plat.os == 'android' %}
                 {% if channel == 'beta' %}
-                  {{ _('<span>Firefox Beta</span> for Android') }}
+                  {{ ftl('download-button-firefox-beta-android') }}
                 {% elif channel == 'alpha' %}
-                  {{ _('<span>Firefox Aurora</span> for Android') }}
+                  {{ ftl('download-button-firefox-aurora-android') }}
                 {% elif channel == 'nightly' %}
-                  {{ _('<span>Firefox Nightly</span> for Android') }}
+                  {{ ftl('download-button-firefox-nightly-android') }}
                 {% else %}
-                  {{ _('<span>Firefox</span> for Android') }}
+                  {{ ftl('download-button-firefox-android') }}
                 {% endif %}
               {% elif plat.os == 'ios' %}
-                {{ _('<span>Firefox</span> for iOS') }}
+                {{ ftl('download-button-firefox-ios') }}
               {% else %}
                 {% if channel == 'beta' %}
-                  {{ _('Firefox Beta') }}
+                  {{ ftl('download-button-firefox-beta') }}
                 {% elif channel == 'alpha' %}
-                  {{ _('<span>Firefox</span> Developer Edition') }}
+                  {{ ftl('download-button-firefox-developer-edition') }}
                 {% elif channel == 'nightly' %}
-                  {{ _('Firefox Nightly') }}
+                  {{ ftl('download-button-firefox-nightly') }}
                 {% else %}
-                  {{ _('Download Firefox') }}
+                  {{ ftl('download-button-download-firefox') }}
                 {% endif %}
               {% endif %}
             {% endif %}
@@ -105,11 +105,8 @@
     {% endfor %}
   </ul>
   <small class="fx-privacy-link mzp-c-button-download-privacy-link">
-    {% if LANG.startswith('en-') %}
-      {% set privacy_text = _('Firefox Privacy Notice') %}
-    {% else %}
-      {% set privacy_text = _('Firefox Privacy') %}
-    {% endif %}
-    <a href="{{ url('privacy.notices.firefox') }}">{{ privacy_text }}</a>
+    <a href="{{ url('privacy.notices.firefox') }}">
+      {{ ftl('download-button-firefox-privacy-notice', fallback='download-button-firefox-privacy') }}
+    </a>
   </small>
 </div>

--- a/bedrock/firefox/templates/firefox/lockwise/lockwise.html
+++ b/bedrock/firefox/templates/firefox/lockwise/lockwise.html
@@ -53,7 +53,7 @@
 
       <div class="mobile-download-buttons">
         <a href="{{ lockwise_adjust_url('ios', 'lockwise-page') }}" class="ios-button" data-cta-text="apple-app-store" data-cta-type="lockwise-app-store" data-cta-position="primary">
-          <img src="{{ l10n_img('firefox/ios/btn-app-store.svg') }}" alt="{{ _('Download on the App Store') }}" width="152" height="45">
+          <img src="{{ l10n_img('firefox/ios/btn-app-store.svg') }}" alt="{{ ftl('download-button-download-app-store') }}" width="152" height="45">
         </a>
         {{ google_play_button(href=lockwise_adjust_url('android', 'lockwise-page'), product='Lockwise', extra_data_attributes={'cta-type': 'lockwise-app-store', 'cta-text': 'google-play-store', 'cta-position': 'primary' } ) }}
       </div>
@@ -72,7 +72,7 @@
       <div class="mzp-c-hero-cta add-on-download for-non-firefox-users hidden" >
         <div class="mzp-c-button-download-container">
           <p >{{ _('Only in the Firefox Browser') }}</p>
-          {{ download_firefox(alt_copy=_('Download now'), download_location='primary cta') }}
+          {{ download_firefox(alt_copy=ftl('download-button-download-now'), download_location='primary cta') }}
         </div>
       </div>
 

--- a/bedrock/firefox/templates/firefox/mobile/get-app.html
+++ b/bedrock/firefox/templates/firefox/mobile/get-app.html
@@ -49,7 +49,7 @@
       </li>
       <li class="ios">
         <a id="app-store-link" href="{{ ios_url }}" data-link-type="download" data-download-os="iOS">
-          <img src="{{ l10n_img('firefox/ios/btn-app-store.svg') }}" alt="{{ _('Download on the App Store') }}" width="152" height="45">
+          <img src="{{ l10n_img('firefox/ios/btn-app-store.svg') }}" alt="{{ ftl('download-button-download-app-store') }}" width="152" height="45">
         </a>
       </li>
     </ul>

--- a/bedrock/firefox/templates/firefox/mobile/index.html
+++ b/bedrock/firefox/templates/firefox/mobile/index.html
@@ -53,7 +53,7 @@
                 </li>
                 <li class="ios">
                   <a id="appStoreLink" href="{{ ios_url }}" data-link-type="download" data-download-os="iOS">
-                    <img src="{{ l10n_img('firefox/ios/btn-app-store.svg') }}" alt="{{ _('Download on the App Store') }}" width="152" height="45">
+                    <img src="{{ l10n_img('firefox/ios/btn-app-store.svg') }}" alt="{{ ftl('download-button-download-app-store') }}" width="152" height="45">
                   </a>
                 </li>
               </ul>
@@ -143,7 +143,7 @@
                 </li>
                 <li class="ios">
                   <a id="appStoreLink" href="{{ ios_url }}" data-link-type="download" data-download-os="iOS">
-                    <img src="{{ l10n_img('firefox/ios/btn-app-store.svg') }}" alt="{{ _('Download on the App Store') }}" width="152" height="45">
+                    <img src="{{ l10n_img('firefox/ios/btn-app-store.svg') }}" alt="{{ ftl('download-button-download-app-store') }}" width="152" height="45">
                   </a>
                 </li>
               </ul>
@@ -188,7 +188,7 @@
           </li>
           <li class="ios">
             <a id="appStoreLink" href="{{ ios_url }}" data-link-type="download" data-download-os="iOS">
-              <img src="{{ l10n_img('firefox/ios/btn-app-store.svg') }}" alt="{{ _('Download on the App Store') }}" width="152" height="45">
+              <img src="{{ l10n_img('firefox/ios/btn-app-store.svg') }}" alt="{{ ftl('download-button-download-app-store') }}" width="152" height="45">
             </a>
           </li>
         </ul>

--- a/bedrock/firefox/templates/firefox/new/protocol/base_download.html
+++ b/bedrock/firefox/templates/firefox/new/protocol/base_download.html
@@ -73,7 +73,7 @@
 
           Bug 1290962
         #}
-        {{ download_firefox(alt_copy=_('Download Now'), locale_in_transition=True, download_location='primary cta') }}
+        {{ download_firefox(alt_copy=ftl('download-button-download-now'), locale_in_transition=True, download_location='primary cta') }}
 
         <ul class="small-links desktop">
           <li><button class="platform-modal-button js-platform-modal-button hidden" type="button">{{_('Advanced install options & other platforms') }}</button></li>
@@ -117,7 +117,7 @@
       </li>
       <li class="ios">
         <a href="{{ firefox_ios_url('mozorg-fxnew_page_scene1_modal-appstore-button') }}" data-link-type="download" data-download-os="iOS" data-download-location="other">
-          <img src="{{ l10n_img('firefox/ios/btn-app-store.svg') }}" alt="{{ _('Download on the App Store') }}" width="152" height="45">
+          <img src="{{ l10n_img('firefox/ios/btn-app-store.svg') }}" alt="{{ ftl('download-button-download-app-store') }}" width="152" height="45">
         </a>
       </li>
     </ul>
@@ -129,7 +129,7 @@
     <h4 class="other-platforms-title heading-mac">{{_('Download Firefox <br>for macOS') }}</h4>
     <h4 class="other-platforms-title heading-linux">{{_('Download Firefox <br>for Linux') }}</h4>
 
-    {{ download_firefox(dom_id='download-other-platforms-modal', alt_copy=_('Download Now'), locale_in_transition=True, download_location='other') }}
+    {{ download_firefox(dom_id='download-other-platforms-modal', alt_copy=ftl('download-button-download-now'), locale_in_transition=True, download_location='other') }}
   </section>
 </aside>
 

--- a/bedrock/firefox/templates/firefox/new/protocol/thanks.html
+++ b/bedrock/firefox/templates/firefox/new/protocol/thanks.html
@@ -19,7 +19,7 @@
         </li>
         <li>
           <a href="{{ firefox_ios_url('mozorg-scene_2-appstore-button') }}" data-link-type="download" data-download-os="iOS" data-download-location="other">
-            <img src="{{ l10n_img('firefox/ios/btn-app-store.svg') }}" alt="{{ _('Download on the App Store') }}" width="152" height="45">
+            <img src="{{ l10n_img('firefox/ios/btn-app-store.svg') }}" alt="{{ ftl('download-button-download-app-store') }}" width="152" height="45">
           </a>
         </li>
       </ul>

--- a/bedrock/firefox/templates/firefox/new/trailhead/download.html
+++ b/bedrock/firefox/templates/firefox/new/trailhead/download.html
@@ -30,7 +30,7 @@
     image_url='img/firefox/new/trailhead/browser-window.svg',
     heading_level=1
   ) %}
-    {{ download_firefox(alt_copy=_('Download Now'), locale_in_transition=True, download_location='primary cta') }}
+    {{ download_firefox(alt_copy=ftl('download-button-download-now'), locale_in_transition=True, download_location='primary cta') }}
 
     <ul class="small-links desktop">
       <li><button class="platform-modal-button js-platform-modal-button hidden" type="button">{{_('Advanced install options & other platforms') }}</button></li>
@@ -76,7 +76,7 @@
         </li>
         <li class="ios">
           <a href="{{ firefox_ios_url('mozorg-fxnew_page_scene1_modal-appstore-button') }}" data-link-type="download" data-download-os="iOS" data-download-location="other">
-            <img src="{{ l10n_img('firefox/ios/btn-app-store.svg') }}" alt="{{ _('Download on the App Store') }}" width="152" height="45">
+            <img src="{{ l10n_img('firefox/ios/btn-app-store.svg') }}" alt="{{ ftl('download-button-download-app-store') }}" width="152" height="45">
           </a>
         </li>
       </ul>
@@ -88,7 +88,7 @@
       <h4 class="other-platforms-title heading-mac">{{_('Download Firefox <br>for macOS') }}</h4>
       <h4 class="other-platforms-title heading-linux">{{_('Download Firefox <br>for Linux') }}</h4>
 
-      {{ download_firefox(dom_id='download-other-platforms-modal', alt_copy=_('Download Now'), locale_in_transition=True, download_location='other') }}
+      {{ download_firefox(dom_id='download-other-platforms-modal', alt_copy=ftl('download-button-download-now'), locale_in_transition=True, download_location='other') }}
     </section>
 </aside>
 

--- a/bedrock/firefox/templates/firefox/releases/release-notes.html
+++ b/bedrock/firefox/templates/firefox/releases/release-notes.html
@@ -10,7 +10,7 @@
   {% set product_name = release.product %}
   {% set download_button %}
     <a rel="external" href="{{ firefox_ios_url('mozorg-releasenotes_page-appstore-button') }}" data-link-type="download" data-download-os="iOS">
-      <img src="{{ l10n_img('firefox/ios/btn-app-store.svg') }}" alt="{{ _('Download on the App Store') }}">
+      <img src="{{ l10n_img('firefox/ios/btn-app-store.svg') }}" alt="{{ ftl('download-button-download-app-store') }}">
     </a>
   {% endset %}
 {% elif release.product == 'Firefox for Android' %}

--- a/bedrock/firefox/templates/firefox/releases/system_requirements.html
+++ b/bedrock/firefox/templates/firefox/releases/system_requirements.html
@@ -40,7 +40,7 @@
     title=_('Get the most recent version'),
     class='mzp-t-firefox mzp-t-product-firefox'
   ) %}
-    {{ download_firefox(alt_copy=_('Download Firefox'), download_location='primary cta') }}
+    {{ download_firefox(alt_copy=ftl('download-button-download-firefox'), download_location='primary cta') }}
   {% endcall %}
 
   <section class="all-download">

--- a/bedrock/firefox/templates/firefox/set-as-default/thanks.html
+++ b/bedrock/firefox/templates/firefox/set-as-default/thanks.html
@@ -37,7 +37,7 @@
       <p class="mzp-c-hero-desc">
         {{ _('Looks like you’re using a different browser right now. Make sure you have Firefox downloaded on your device.') }}
       </p>
-      {{ download_firefox(alt_copy=_('Download Firefox'), download_location='primary cta') }}
+      {{ download_firefox(alt_copy=ftl('download-button-download-firefox'), download_location='primary cta') }}
     </div>
     <div class="mzp-c-hero-desc thanks-state-not-default-desktop hide-from-legacy-ie">
       {# L10n: When a visitor sees this message a system dialog will also open on screen. #}

--- a/bedrock/firefox/templates/firefox/welcome/page4.html
+++ b/bedrock/firefox/templates/firefox/welcome/page4.html
@@ -60,7 +60,7 @@
       </li>
       <li class="c-store-badge-apple">
         <a id="appStoreLink" href="{{ ios_url }}" data-link-type="download" data-download-os="iOS">
-          <img src="{{ l10n_img('firefox/ios/btn-app-store.svg') }}" alt="{{ _('Download on the App Store') }}" width="152" height="45">
+          <img src="{{ l10n_img('firefox/ios/btn-app-store.svg') }}" alt="{{ ftl('download-button-download-app-store') }}" width="152" height="45">
         </a>
       </li>
     </ul>

--- a/bedrock/firefox/templates/firefox/welcome/page5.html
+++ b/bedrock/firefox/templates/firefox/welcome/page5.html
@@ -59,7 +59,7 @@
       </li>
       <li class="c-store-badge-apple">
         <a id="appStoreLink" href="{{ ios_url }}" data-link-type="download" data-download-os="iOS">
-          <img src="{{ l10n_img('firefox/ios/btn-app-store.svg') }}" alt="{{ _('Download on the App Store') }}" width="152" height="45">
+          <img src="{{ l10n_img('firefox/ios/btn-app-store.svg') }}" alt="{{ ftl('download-button-download-app-store') }}" width="152" height="45">
         </a>
       </li>
     </ul>

--- a/bedrock/firefox/templates/firefox/welcome/page6.html
+++ b/bedrock/firefox/templates/firefox/welcome/page6.html
@@ -62,7 +62,7 @@
       </li>
       <li>
         <a id="appStoreLink" href="{{ ios_url }}" data-link-type="download" data-download-os="iOS">
-          <img src="{{ l10n_img('firefox/ios/btn-app-store.svg') }}" alt="{{ _('Download on the App Store') }}" width="152" height="45">
+          <img src="{{ l10n_img('firefox/ios/btn-app-store.svg') }}" alt="{{ ftl('download-button-download-app-store') }}" width="152" height="45">
         </a>
       </li>
     </ul>

--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx73.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx73.html
@@ -55,7 +55,7 @@
           </li>
           <li>
             <a id="appStoreLink" href="{{ ios_url }}" data-link-type="download" data-download-os="iOS">
-              <img src="{{ l10n_img('firefox/ios/btn-app-store.svg') }}" alt="{{ _('Download on the App Store') }}" width="152" height="45">
+              <img src="{{ l10n_img('firefox/ios/btn-app-store.svg') }}" alt="{{ ftl('download-button-download-app-store') }}" width="152" height="45">
             </a>
           </li>
         </ul>

--- a/bedrock/firefox/templatetags/helpers.py
+++ b/bedrock/firefox/templatetags/helpers.py
@@ -7,6 +7,7 @@ from django_jinja import library
 from bedrock.firefox.firefox_details import firefox_desktop, firefox_android, firefox_ios
 from bedrock.base.urlresolvers import reverse
 from lib.l10n_utils import get_locale
+from lib.l10n_utils.fluent import fluent_l10n
 
 
 def desktop_builds(channel, builds=None, locale=None, force_direct=False,
@@ -164,7 +165,8 @@ def download_firefox(ctx, channel='release', platform='all',
         'show_ios': show_ios,
         'alt_copy': alt_copy,
         'button_color': button_color,
-        'download_location': download_location
+        'download_location': download_location,
+        'fluent_l10n': fluent_l10n([locale, 'en'], settings.FLUENT_DEFAULT_FILES)
     }
 
     html = render_to_string('firefox/includes/download-button.html', data,

--- a/bedrock/firefox/templatetags/helpers.py
+++ b/bedrock/firefox/templatetags/helpers.py
@@ -7,7 +7,6 @@ from django_jinja import library
 from bedrock.firefox.firefox_details import firefox_desktop, firefox_android, firefox_ios
 from bedrock.base.urlresolvers import reverse
 from lib.l10n_utils import get_locale
-from lib.l10n_utils.fluent import fluent_l10n
 
 
 def desktop_builds(channel, builds=None, locale=None, force_direct=False,
@@ -166,7 +165,7 @@ def download_firefox(ctx, channel='release', platform='all',
         'alt_copy': alt_copy,
         'button_color': button_color,
         'download_location': download_location,
-        'fluent_l10n': fluent_l10n([locale, 'en'], settings.FLUENT_DEFAULT_FILES)
+        'fluent_l10n': ctx['fluent_l10n']
     }
 
     html = render_to_string('firefox/includes/download-button.html', data,

--- a/bedrock/firefox/tests/test_helpers.py
+++ b/bedrock/firefox/tests/test_helpers.py
@@ -7,6 +7,7 @@ from django_jinja.backend import Jinja2
 from pyquery import PyQuery as pq
 
 from bedrock.mozorg.tests import TestCase
+from lib.l10n_utils.fluent import fluent_l10n
 
 jinja_env = Jinja2.get_default()
 
@@ -21,6 +22,9 @@ class TestDownloadButtons(TestCase):
     def latest_version(self):
         from product_details import product_details
         return product_details.firefox_versions['LATEST_FIREFOX_VERSION']
+
+    def get_l10n(self, locale):
+        return fluent_l10n([locale, 'en'], settings.FLUENT_DEFAULT_FILES)
 
     def check_desktop_links(self, links):
         """Desktop links should have the correct firefox version"""
@@ -60,7 +64,7 @@ class TestDownloadButtons(TestCase):
         get_request = rf.get('/fake')
         get_request.locale = 'fr'
         doc = pq(render("{{ download_firefox(force_direct=true) }}",
-                        {'request': get_request}))
+                        {'request': get_request, 'fluent_l10n': self.get_l10n(get_request.locale)}))
 
         # Check that the first 5 links are direct.
         links = doc('.download-list a')
@@ -81,7 +85,7 @@ class TestDownloadButtons(TestCase):
         get_request = rf.get('/fake')
         get_request.locale = 'fr'
         doc = pq(render("{{ download_firefox(locale_in_transition=true) }}",
-                        {'request': get_request}))
+                        {'request': get_request, 'fluent_l10n': self.get_l10n(get_request.locale)}))
 
         links = doc('.download-list a')
 
@@ -91,7 +95,7 @@ class TestDownloadButtons(TestCase):
             assert href == '/fr/firefox/download/thanks/'
 
         doc = pq(render("{{ download_firefox(locale_in_transition=false) }}",
-                        {'request': get_request}))
+                        {'request': get_request, 'fluent_l10n': self.get_l10n(get_request.locale)}))
 
         links = doc('.download-list a')
 
@@ -108,7 +112,7 @@ class TestDownloadButtons(TestCase):
         get_request = rf.get('/fake')
         get_request.locale = 'fr'
         doc = pq(render("{{ download_firefox(download_location='primary cta') }}",
-                        {'request': get_request}))
+                        {'request': get_request, 'fluent_l10n': self.get_l10n(get_request.locale)}))
 
         links = doc('.download-list a')
 
@@ -116,7 +120,8 @@ class TestDownloadButtons(TestCase):
             link = pq(link)
             assert link.attr('data-download-location') == 'primary cta'
 
-        doc = pq(render("{{ download_firefox() }}", {'request': get_request}))
+        doc = pq(render("{{ download_firefox() }}", {'request': get_request,
+                        'fluent_l10n': self.get_l10n(get_request.locale)}))
 
         links = doc('.download-list a')
 
@@ -133,7 +138,7 @@ class TestDownloadButtons(TestCase):
         get_request = rf.get('/fake')
         get_request.locale = 'fr'
         doc = pq(render("{{ download_firefox() }}",
-                        {'request': get_request}))
+                        {'request': get_request, 'fluent_l10n': self.get_l10n(get_request.locale)}))
 
         # The first 7 links should be for desktop.
         links = doc('.download-list a')
@@ -155,7 +160,7 @@ class TestDownloadButtons(TestCase):
         get_request = rf.get('/fake')
         get_request.locale = 'fr'
         doc = pq(render("{{ download_firefox('nightly', platform='desktop') }}",
-                        {'request': get_request}))
+                        {'request': get_request, 'fluent_l10n': self.get_l10n(get_request.locale)}))
 
         list = doc('.download-list li')
         assert list.length == 6
@@ -175,7 +180,7 @@ class TestDownloadButtons(TestCase):
         get_request = rf.get('/fake')
         get_request.locale = 'fr'
         doc = pq(render("{{ download_firefox('alpha', platform='desktop') }}",
-                        {'request': get_request}))
+                        {'request': get_request, 'fluent_l10n': self.get_l10n(get_request.locale)}))
 
         list = doc('.download-list li')
         assert list.length == 7
@@ -193,7 +198,7 @@ class TestDownloadButtons(TestCase):
         get_request = rf.get('/fake')
         get_request.locale = 'fr'
         doc = pq(render("{{ download_firefox('beta', platform='desktop') }}",
-                        {'request': get_request}))
+                        {'request': get_request, 'fluent_l10n': self.get_l10n(get_request.locale)}))
 
         list = doc('.download-list li')
         assert list.length == 7
@@ -211,7 +216,7 @@ class TestDownloadButtons(TestCase):
         get_request = rf.get('/fake')
         get_request.locale = 'fr'
         doc = pq(render("{{ download_firefox(platform='desktop') }}",
-                        {'request': get_request}))
+                        {'request': get_request, 'fluent_l10n': self.get_l10n(get_request.locale)}))
 
         list = doc('.download-list li')
         assert list.length == 7
@@ -228,7 +233,7 @@ class TestDownloadButtons(TestCase):
         rf = RequestFactory()
         get_request = rf.get('/fake')
         doc = pq(render("{{ download_firefox('nightly', platform='android') }}",
-                        {'request': get_request}))
+                        {'request': get_request, 'fluent_l10n': self.get_l10n('fr')}))
 
         list = doc('.download-list li')
         assert list.length == 1
@@ -246,7 +251,7 @@ class TestDownloadButtons(TestCase):
         rf = RequestFactory()
         get_request = rf.get('/fake')
         doc = pq(render("{{ download_firefox('beta', platform='android') }}",
-                        {'request': get_request}))
+                        {'request': get_request, 'fluent_l10n': self.get_l10n('fr')}))
 
         list = doc('.download-list li')
         assert list.length == 1
@@ -264,7 +269,7 @@ class TestDownloadButtons(TestCase):
         rf = RequestFactory()
         get_request = rf.get('/fake')
         doc = pq(render("{{ download_firefox(platform='android') }}",
-                        {'request': get_request}))
+                        {'request': get_request, 'fluent_l10n': self.get_l10n('fr')}))
 
         list = doc('.download-list li')
         assert list.length == 1
@@ -281,7 +286,7 @@ class TestDownloadButtons(TestCase):
         rf = RequestFactory()
         get_request = rf.get('/fake')
         doc = pq(render("{{ download_firefox(platform='ios') }}",
-                        {'request': get_request}))
+                        {'request': get_request, 'fluent_l10n': self.get_l10n('fr')}))
 
         list = doc('.download-list li')
         assert list.length == 1

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -239,8 +239,8 @@ DOTLANG_CACHE = config('DOTLANG_CACHE', default='1800' if DEBUG else '600', pars
 
 # Global L10n files.
 # TODO Port DOTLANG_FILES to FLUENT_DEFAULT_FILES
-DOTLANG_FILES = ['download_button', 'main']
-FLUENT_DEFAULT_FILES = ['brands', 'navigation', 'footer']
+DOTLANG_FILES = ['main']
+FLUENT_DEFAULT_FILES = ['brands', 'download_button', 'navigation', 'footer']
 
 FLUENT_DEFAULT_PERCENT_REQUIRED = config('FLUENT_DEFAULT_PERCENT_REQUIRED', default='80', parser=int)
 FLUENT_REPO = config('FLUENT_REPO', default='https://github.com/mozmeao/www-l10n')

--- a/l10n/en/brands.ftl
+++ b/l10n/en/brands.ftl
@@ -43,6 +43,10 @@
 -brand-name-nightly = Nightly
 -brand-name-reality = Reality
 
+## Firefox browsers (legacy)
+
+-brand-name-firefox-aurora = Firefox Aurora
+
 ## Firefox products
 
 -brand-name-facebook-container = Facebook Container
@@ -99,9 +103,12 @@
 -brand-name-linux = Linux
 -brand-name-mac = macOS
 -brand-name-windows = Windows
+-brand-name-xp = XP
+-brand-name-vista = Vista
 
 ## Apple products
 
+-brand-name-app-store = App Store
 -brand-name-ipad = iPad
 -brand-name-iphone = iPhone
 
@@ -115,4 +122,5 @@
 
 ## Google products
 
+-brand-name-google-play = Google Play
 -brand-name-youtube = YouTube

--- a/l10n/en/download_button.ftl
+++ b/l10n/en/download_button.ftl
@@ -12,9 +12,19 @@ download-button-supported-devices = Supported Devices
 download-button-whats-new = What’s New
 download-button-systems-languages = Systems &amp; Languages
 download-button-recommended = Recommended
+
+# Variables:
+#   $url (url) - link to https://support.mozilla.org/kb/end-support-windows-xp-and-vista
 download-button-mozilla-no-longer-provides = <a href="{ $url }">{ -brand-name-mozilla } no longer provides security updates for { -brand-name-firefox } on { -brand-name-windows } { -brand-name-xp } or { -brand-name-vista }</a>, but you can still download the final { -brand-name-windows } 32-bit version below.
+
+# Variables:
+#   $url (url) - link to https://support.mozilla.org/kb/install-firefox-linux
 download-button-please-follow-these = Please follow <a href="{ $url }">these instructions</a> to install { -brand-name-firefox }.
+
+# Variables:
+#   $url (url) - link to https://www.mozilla.org/firefox/system-requirements/
 download-button-your-system-does-not = Your system doesn't meet the <a href="{ $url }">requirements</a> to run { -brand-name-firefox }.
+
 download-button-firefox-other-platforms = { -brand-name-firefox } for Other Platforms & Languages
 download-button-update-your-firefox = Update your { -brand-name-firefox }
 download-button-get-firefox-android = Get { -brand-name-firefox } for { -brand-name-android }

--- a/l10n/en/download_button.ftl
+++ b/l10n/en/download_button.ftl
@@ -1,0 +1,34 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+download-button-download-now = Download Now
+download-button-free-download = Free Download
+download-button-firefox-beta = { -brand-name-firefox-beta }
+download-button-firefox-aurora = { -brand-name-firefox-aurora }
+download-button-firefox-developer-edition = <span>{ -brand-name-firefox }</span> { -brand-name-developer-edition }
+download-button-firefox-nightly = { -brand-name-firefox-nightly }
+download-button-supported-devices = Supported Devices
+download-button-whats-new = What’s New
+download-button-systems-languages = Systems &amp; Languages
+download-button-recommended = Recommended
+download-button-mozilla-no-longer-provides = <a href="{ $url }">{ -brand-name-mozilla } no longer provides security updates for { -brand-name-firefox } on { -brand-name-windows } { -brand-name-xp } or { -brand-name-vista }</a>, but you can still download the final { -brand-name-windows } 32-bit version below.
+download-button-please-follow-these = Please follow <a href="{ $url }">these instructions</a> to install { -brand-name-firefox }.
+download-button-your-system-does-not = Your system doesn't meet the <a href="{ $url }">requirements</a> to run { -brand-name-firefox }.
+download-button-firefox-other-platforms = { -brand-name-firefox } for Other Platforms & Languages
+download-button-update-your-firefox = Update your { -brand-name-firefox }
+download-button-get-firefox-android = Get { -brand-name-firefox } for { -brand-name-android }
+download-button-get-firefox-ios = Get { -brand-name-firefox } for { -brand-name-ios }
+download-button-google-play = Get it on { -brand-name-google-play }
+download-button-free-google-play = Get it free on { -brand-name-google-play }
+download-button-app-store = Get it free from the { -brand-name-app-store }
+download-button-download-app-store = Download on the { -brand-name-app-store }
+download-button-download-firefox = Download { -brand-name-firefox }
+download-button-your-system-may = Your system may not meet the requirements for { -brand-name-firefox }, but you can try one of these versions:
+download-button-firefox-beta-android = <span>{ -brand-name-firefox-beta }</span> for { -brand-name-android }
+download-button-firefox-aurora-android = <span>{ -brand-name-firefox-aurora }</span> for { -brand-name-android }
+download-button-firefox-nightly-android = <span>{ -brand-name-firefox-nightly }</span> for { -brand-name-android }
+download-button-firefox-android = <span>{ -brand-name-firefox }</span> for { -brand-name-android }
+download-button-firefox-ios = <span>{ -brand-name-firefox }</span> for { -brand-name-ios }
+download-button-firefox-privacy = { -brand-name-firefox } Privacy
+download-button-firefox-privacy-notice = { -brand-name-firefox } Privacy Notice

--- a/lib/fluent_migrations/firefox/includes/download-button.py
+++ b/lib/fluent_migrations/firefox/includes/download-button.py
@@ -1,0 +1,243 @@
+from __future__ import absolute_import
+import fluent.syntax.ast as FTL
+from fluent.migrate.helpers import transforms_from
+from fluent.migrate.helpers import VARIABLE_REFERENCE, TERM_REFERENCE
+from fluent.migrate import REPLACE, COPY
+
+download_button = "firefox/includes/download-button.lang"
+download_button = "download_button.lang"
+
+def migrate(ctx):
+    """Migrate bedrock/firefox/templates/firefox/includes/download-button.html, part {index}."""
+
+    ctx.add_transforms(
+        "download_button.ftl",
+        "download_button.ftl",
+        transforms_from("""
+download-button-download-now = {COPY(download_button, "Download now",)}
+download-button-free-download = {COPY(download_button, "Free Download",)}
+download-button-firefox-beta = { -brand-name-firefox-beta }
+download-button-firefox-aurora = { -brand-name-firefox-aurora }
+download-button-firefox-developer-edition = <span>{ -brand-name-firefox }</span> { -brand-name-developer-edition }
+download-button-firefox-nightly = { -brand-name-firefox-nightly }
+download-button-supported-devices = {COPY(download_button, "Supported Devices",)}
+download-button-whats-new = {COPY(download_button, "What’s New",)}
+download-button-systems-languages = {COPY(download_button, "Systems &amp; Languages",)}
+download-button-recommended = {COPY(download_button, "Recommended",)}
+""", download_button=download_button) + [
+            FTL.Message(
+                id=FTL.Identifier("download-button-mozilla-no-longer-provides"),
+                value=REPLACE(
+                    download_button,
+                    "<a href=\"%(url)s\">Mozilla no longer provides security updates for Firefox on Windows XP or Vista</a>, but you can still download the final Windows 32-bit version below.",
+                    {
+                        "%%": "%",
+                        "%(url)s": VARIABLE_REFERENCE("url"),
+                        "Mozilla": TERM_REFERENCE("brand-name-mozilla"),
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                        "Windows": TERM_REFERENCE("brand-name-windows"),
+                        "XP": TERM_REFERENCE("brand-name-xp"),
+                        "Vista": TERM_REFERENCE("brand-name-vista"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("download-button-please-follow-these"),
+                value=REPLACE(
+                    download_button,
+                    "Please follow <a href=\"%(url)s\">these instructions</a> to install Firefox.",
+                    {
+                        "%%": "%",
+                        "%(url)s": VARIABLE_REFERENCE("url"),
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("download-button-your-system-does-not"),
+                value=REPLACE(
+                    download_button,
+                    "Your system doesn't meet the <a href=\"%(url)s\">requirements</a> to run Firefox.",
+                    {
+                        "%%": "%",
+                        "%(url)s": VARIABLE_REFERENCE("url"),
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                    }
+                )
+            ),
+        ]
+    )
+
+    ctx.add_transforms(
+        "download_button.ftl",
+        "download_button.ftl",
+        [
+            FTL.Message(
+                id=FTL.Identifier("download-button-firefox-other-platforms"),
+                value=REPLACE(
+                    "download_button.lang",
+                    "Firefox for Other Platforms & Languages",
+                    {
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("download-button-update-your-firefox"),
+                value=REPLACE(
+                    "download_button.lang",
+                    "Update your Firefox",
+                    {
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("download-button-get-firefox-android"),
+                value=REPLACE(
+                    "download_button.lang",
+                    "Get Firefox for Android",
+                    {
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                        "Android": TERM_REFERENCE("brand-name-android"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("download-button-get-firefox-ios"),
+                value=REPLACE(
+                    "download_button.lang",
+                    "Get Firefox for iOS",
+                    {
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                        "iOS": TERM_REFERENCE("brand-name-ios"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("download-button-google-play"),
+                value=REPLACE(
+                    "download_button.lang",
+                    "Get it on Google Play",
+                    {
+                        "Google Play": TERM_REFERENCE("brand-name-google-play"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("download-button-free-google-play"),
+                value=REPLACE(
+                    "download_button.lang",
+                    "Get it free on Google Play",
+                    {
+                        "Google Play": TERM_REFERENCE("brand-name-google-play"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("download-button-app-store"),
+                value=REPLACE(
+                    "download_button.lang",
+                    "Get it free from the App Store",
+                    {
+                        "App Store": TERM_REFERENCE("brand-name-app-store"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("download-button-download-app-store"),
+                value=REPLACE(
+                    "download_button.lang",
+                    "Download on the App Store",
+                    {
+                        "App Store": TERM_REFERENCE("brand-name-app-store"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("download-button-download-firefox"),
+                value=REPLACE(
+                    "download_button.lang",
+                    "Download Firefox",
+                    {
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("download-button-your-system-may"),
+                value=REPLACE(
+                    "download_button.lang",
+                    "Your system may not meet the requirements for Firefox, but you can try one of these versions:",
+                    {
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("download-button-firefox-beta-android"),
+                value=REPLACE(
+                    "download_button.lang",
+                    "<span>Firefox Beta</span> for Android",
+                    {
+                        "Firefox Beta": TERM_REFERENCE("brand-name-firefox-beta"),
+                        "Android": TERM_REFERENCE("brand-name-android"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("download-button-firefox-aurora-android"),
+                value=REPLACE(
+                    "download_button.lang",
+                    "<span>Firefox Aurora</span> for Android",
+                    {
+                        "Firefox Aurora": TERM_REFERENCE("brand-name-firefox-aurora"),
+                        "Android": TERM_REFERENCE("brand-name-android"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("download-button-firefox-nightly-android"),
+                value=REPLACE(
+                    "download_button.lang",
+                    "<span>Firefox Nightly</span> for Android",
+                    {
+                        "Firefox Nightly": TERM_REFERENCE("brand-name-firefox-nightly"),
+                        "Android": TERM_REFERENCE("brand-name-android"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("download-button-firefox-android"),
+                value=REPLACE(
+                    "download_button.lang",
+                    "<span>Firefox</span> for Android",
+                    {
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                        "Android": TERM_REFERENCE("brand-name-android"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("download-button-firefox-ios"),
+                value=REPLACE(
+                    "download_button.lang",
+                    "<span>Firefox</span> for iOS",
+                    {
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                        "iOS": TERM_REFERENCE("brand-name-ios"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("download-button-firefox-privacy"),
+                value=REPLACE(
+                    "download_button.lang",
+                    "Firefox Privacy",
+                    {
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                    }
+                )
+            ),
+        ]
+    )


### PR DESCRIPTION
## Description
- Migrates `download_button.lang` to `download_button.ftl`
- Updates `download-button.html` to use new Fluent Id's.
- Updates all download buttons & store badges to use strings from `download_button.ftl`.

## Issue / Bugzilla link
#8654

## Testing

- [ ] Run `./manage.py fluent ftl lib/fluent_migrations/firefox/includes/download-button.py de fr` and make sure migrated translations appear ok?
- [ ] Did I miss any stray strings that relied on `download_button.lang`?

Successful test run: https://gitlab.com/mozmeao/www-config/pipelines/129904851