### PR TITLE
[#8564] Update WNP75 state logic

### DIFF
--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx75.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx75.html
@@ -30,7 +30,7 @@
   <section class="content-main">
     <div class="mzp-l-content">
 
-      <div class="mzp-c-emphasis-box show-signed-out">
+      <div class="mzp-c-emphasis-box show-sync">
         <img class="c-emphasis-box-hero" src="{{ static('img/firefox/whatsnew/whatsnew75/hero-sync.svg') }}" alt="">
         <h2 class="c-emphasis-box-title">{{ _('Pick up Firefox where you left off') }}</h2>
         <p>{{ _('Whether you’re using Firefox on your phone or computer, make sure all your important stuff — internet searches, passwords, open tabs — appears where you need it.') }}</p>
@@ -41,7 +41,7 @@
         </p>
       </div>
 
-      <div class="mzp-c-emphasis-box show-signed-in">
+      <div class="mzp-c-emphasis-box show-monitor">
         <img class="c-emphasis-box-hero" src="{{ static('img/firefox/whatsnew/whatsnew75/hero-monitor.svg') }}" alt="">
         <h2 class="c-emphasis-box-title">{{ _('Stay ahead of hackers') }}</h2>
         <p>{{ _('Now Firefox Monitor not only informs you if you’ve been involved in known online data breaches, it also lets you take action to resolve them and get closure.') }}</p>
@@ -61,7 +61,7 @@
   </section>
 
   <section class="content-extra">
-    <div class="mzp-l-content show-signed-out">
+    <div class="mzp-l-content show-sync">
 
       <div class="l-columns-three">
         <div class="c-picto-block">
@@ -99,7 +99,7 @@
       </div>
     </div>
 
-    <div class="mzp-l-content show-signed-in">
+    <div class="mzp-l-content show-monitor">
       <div class="l-columns-three">
         <div class="c-picto-block">
           <div class="c-picto-block-image">

--- a/media/css/firefox/whatsnew/whatsnew-75.scss
+++ b/media/css/firefox/whatsnew/whatsnew-75.scss
@@ -83,16 +83,16 @@ $image-path: '/media/protocol/img';
 //* -------------------------------------------------------------------------- */
 // Conditional content
 
-.show-signed-in {
+.show-monitor {
     display: none;
 }
 
-.state-fxa-supported-signed-in {
-    .show-signed-in {
+.state-fxa-has-devices {
+    .show-monitor {
         display: block;
     }
 
-    .show-signed-out {
+    .show-sync {
         display: none;
     }
 }

--- a/media/js/firefox/whatsnew/whatsnew-75.js
+++ b/media/js/firefox/whatsnew/whatsnew-75.js
@@ -19,6 +19,15 @@ if (typeof window.Mozilla === 'undefined') {
                 document.querySelector('.c-page-header').classList.add('show-up-to-date-message');
             }
         });
+
+        client.getFxaDetails(function(details) {
+            if (details.setup && details.browserServices.sync.mobileDevices > 0) {
+                document.getElementsByTagName('body')[0].classList.add('state-fxa-has-devices');
+            } else if (window.location.search.indexOf('has-devices=true') !== -1) {
+                // Fake the user state for testing purposes
+                document.getElementsByTagName('body')[0].classList.add('state-fxa-has-devices');
+            }
+        });
     }
 
 })(window.Mozilla);

--- a/media/js/firefox/whatsnew/whatsnew-75.js
+++ b/media/js/firefox/whatsnew/whatsnew-75.js
@@ -11,6 +11,7 @@ if (typeof window.Mozilla === 'undefined') {
     'use strict';
 
     var client = Mozilla.Client;
+    var body = document.getElementsByTagName('body')[0];
 
     // bug 1419573 - only show "Your Firefox is up to date" if it's the latest version.
     if (client.isFirefoxDesktop) {
@@ -21,11 +22,13 @@ if (typeof window.Mozilla === 'undefined') {
         });
 
         client.getFxaDetails(function(details) {
+            body.classList.remove('state-fxa-default');
+
             if (details.setup && details.browserServices.sync.mobileDevices > 0) {
-                document.getElementsByTagName('body')[0].classList.add('state-fxa-has-devices');
+                body.classList.add('state-fxa-has-devices');
             } else if (window.location.search.indexOf('has-devices=true') !== -1) {
                 // Fake the user state for testing purposes
-                document.getElementsByTagName('body')[0].classList.add('state-fxa-has-devices');
+                body.classList.add('state-fxa-has-devices');
             }
         });
     }

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -871,8 +871,6 @@
       "files": [
         "js/base/uitour-lib.js",
         "js/firefox/whatsnew/up-to-date.js",
-        "js/base/mozilla-fxa.js",
-        "js/base/mozilla-fxa-init.js",
         "js/base/mozilla-fxa-product-button.js",
         "js/base/mozilla-fxa-product-button-init.js",
         "js/firefox/whatsnew/whatsnew-75.js"

--- a/tests/functional/firefox/whatsnew/test_whatsnew_75.py
+++ b/tests/functional/firefox/whatsnew/test_whatsnew_75.py
@@ -17,5 +17,5 @@ def test_signed_out_sync_button_displayed(base_url, selenium):
 @pytest.mark.skip_if_not_firefox(reason='Whatsnew pages are shown to Firefox only.')
 @pytest.mark.nondestructive
 def test_signed_in_monitor_button_displayed(base_url, selenium):
-    page = FirefoxWhatsNew75Page(selenium, base_url, params='?signed-in=true').open()
+    page = FirefoxWhatsNew75Page(selenium, base_url, params='?has-devices=true').open()
     assert page.is_signed_in_monitor_button_displayed

--- a/tests/pages/firefox/whatsnew/whatsnew_75.py
+++ b/tests/pages/firefox/whatsnew/whatsnew_75.py
@@ -11,8 +11,8 @@ class FirefoxWhatsNew75Page(FirefoxBasePage):
 
     URL_TEMPLATE = '/{locale}/firefox/75.0/whatsnew/all/{params}'
 
-    _signed_out_sync_button_locator = (By.CSS_SELECTOR, '.show-signed-out .qa-sync-button')
-    _signed_in_monitor_button_locator = (By.CSS_SELECTOR, '.show-signed-in .qa-monitor-button')
+    _signed_out_sync_button_locator = (By.CSS_SELECTOR, '.show-sync .qa-sync-button')
+    _signed_in_monitor_button_locator = (By.CSS_SELECTOR, '.show-monitor .qa-monitor-button')
 
     def wait_for_page_to_load(self):
         self.wait.until(lambda s: self.seed_url in s.current_url)


### PR DESCRIPTION
## Description
We should only show the Monitor pitch to users signed into FxA with at least one mobile device. All others get the Sync pitch.

## Testing
https://www-demo3.allizom.org/firefox/75.0/whatsnew/all/

- [ ] Signed out users get Sync
- [ ] Signed in users with no devices get Sync
- [ ] Signed in users with one or more devices get Monitor
