### PR TITLE
Add ability to commit and push changes to Fluent repo

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -72,3 +72,9 @@ prod:
   variables:
     CLUSTERS: frankfurt iowa-a
     NAMESPACE: bedrock-prod
+
+fluent:
+  only:
+    - triggers
+  script:
+    - bin/process-ftl.sh

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -245,8 +245,10 @@ FLUENT_DEFAULT_FILES = ['brands', 'navigation', 'footer']
 FLUENT_DEFAULT_PERCENT_REQUIRED = config('FLUENT_DEFAULT_PERCENT_REQUIRED', default='80', parser=int)
 FLUENT_REPO = config('FLUENT_REPO', default='https://github.com/mozmeao/www-l10n')
 FLUENT_REPO_PATH = GIT_REPOS_PATH / 'www-l10n'
+# will be something like "<github username>:<github token>"
+FLUENT_REPO_AUTH = config('FLUENT_REPO_AUTH', default='')
 FLUENT_LOCAL_PATH = ROOT_PATH / 'l10n'
-FLUENT_L10N_TEAM_REPO = config('FLUENT_REPO', default='https://github.com/mozilla-l10n/www-l10n')
+FLUENT_L10N_TEAM_REPO = config('FLUENT_L10N_TEAM_REPO', default='https://github.com/mozilla-l10n/www-l10n')
 FLUENT_L10N_TEAM_REPO_PATH = GIT_REPOS_PATH / 'l10n-team'
 # 10 seconds during dev and 10 min in prod
 FLUENT_CACHE_TIMEOUT = config('FLUENT_CACHE_TIMEOUT', default='10' if DEBUG else '600', parser=int)
@@ -1502,4 +1504,3 @@ if config('SWITCH_TRACKING_PIXEL', default=str(DEV), parser=bool):
 
 # Issue 7508 - Convert.com experiment sandbox
 CONVERT_PROJECT_ID = ('10039-1003350' if DEV else '10039-1003343')
-

--- a/bedrock/utils/git.py
+++ b/bedrock/utils/git.py
@@ -155,6 +155,12 @@ class GitRepo:
 
         return repo_base
 
+    def remote_url_auth(self, auth):
+        url = self.clean_remote_url
+        # remove https://
+        url = url[8:]
+        return f'https://{auth}@{url}'
+
     def set_db_latest(self, latest_ref=None):
         latest_ref = latest_ref or self.current_hash
         rs, created = GitRepoState.objects.get_or_create(

--- a/bin/process-ftl.sh
+++ b/bin/process-ftl.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -exo pipefail
+
+DOCKER_IMAGE=mozorg/bedrock:latest
+
+docker pull "$DOCKER_IMAGE"
+docker run --rm \
+    -e FLUENT_REPO \
+    -e FLUENT_REPO_AUTH \
+    -e FLUENT_L10N_TEAM_REPO \
+    "$DOCKER_IMAGE" \
+    python manage.py process_ftl --push


### PR DESCRIPTION
Add a --push argument to the `process_ftl` management command and add a gitlab automation to run this command.

Fix #7705

## Testing

I ran this locally by running the following command:

```
env FLUENT_REPO=https://github.com/pmac/www-l10n \
    docker run --rm -it \
    -e FLUENT_REPO \
    -e FLUENT_REPO_AUTH \
    -v "$PWD/lib:/app/lib:delegated" \
    mozorg/bedrock:latest \
    python manage.py process_ftl --push
```

If you had a use with access and a personal access token you could add another environment variable `FLUENT_REPO_AUTH` with `<github user>:<github token>` format and it would successfully push as well. 