### PR TITLE
Port FxA Email form to Fluent (Issue #8657)

### DIFF
--- a/bedrock/base/templates/macros.html
+++ b/bedrock/base/templates/macros.html
@@ -183,21 +183,18 @@
     {% if intro_text %}
       {{ intro_text }}
     {% else %}
-      {{ _('<strong>Enter your email</strong> to access Firefox Accounts.') }}
+      {{ ftl('fxa-form-enter-your-email') }}
     {% endif %}
     </p>
 
     <div class="fxa-email-field-container">
       <p class="field">
-        <label for="fxa-email-field">{{ _('Email address') }}</label>
+        <label for="fxa-email-field">{{ ftl('fxa-form-email-address') }}</label>
         <input type="email" name="email" id="fxa-email-field" class="fxa-email-field" placeholder="user@example.com" required>
       </p>
 
       <p class="agreement">
-        {% trans url1='https://accounts.firefox.com/legal/terms', url2='https://accounts.firefox.com/legal/privacy' %}
-          By proceeding, you agree to the <a href="{{ url1 }}">Terms of Service</a> and
-          <a href="{{ url2 }}">Privacy Notice</a>.
-        {% endtrans %}
+        {{ ftl('fxa-form-by-proceeding', url1='https://accounts.firefox.com/legal/terms', url2='https://accounts.firefox.com/legal/privacy') }}
       </p>
 
       <button
@@ -211,7 +208,7 @@
       {% if button_text %}
         {{ button_text }}
       {% else %}
-        {{ _('Continue') }}
+        {{ ftl('fxa-form-continue') }}
       {% endif %}
       </button>
     </div>

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -240,7 +240,7 @@ DOTLANG_CACHE = config('DOTLANG_CACHE', default='1800' if DEBUG else '600', pars
 # Global L10n files.
 # TODO Port DOTLANG_FILES to FLUENT_DEFAULT_FILES
 DOTLANG_FILES = ['main']
-FLUENT_DEFAULT_FILES = ['brands', 'download_button', 'navigation', 'footer']
+FLUENT_DEFAULT_FILES = ['brands', 'download_button', 'navigation', 'footer', 'fxa_form']
 
 FLUENT_DEFAULT_PERCENT_REQUIRED = config('FLUENT_DEFAULT_PERCENT_REQUIRED', default='80', parser=int)
 FLUENT_REPO = config('FLUENT_REPO', default='https://github.com/mozmeao/www-l10n')

--- a/l10n/en/fxa_form.ftl
+++ b/l10n/en/fxa_form.ftl
@@ -1,0 +1,15 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+fxa-form-enter-your-email = <strong>Enter your email</strong> to access { -brand-name-firefox-accounts }.
+
+# Variables:
+#   $url1 (url) - link to https://accounts.firefox.com/legal/terms
+#   $url2 (url) - link to https://accounts.firefox.com/legal/privacy
+fxa-form-by-proceeding = By proceeding, you agree to the <a href="{ $url1 }">Terms of Service</a> and <a href="{ $url2 }">Privacy Notice</a>.
+
+fxa-form-email-address = Email address
+fxa-form-continue = Continue
+fxa-form-create-account = Create account
+fxa-form-get-the-app = Get the app

--- a/lib/fluent_migrations/firefox/fxa-form.py
+++ b/lib/fluent_migrations/firefox/fxa-form.py
@@ -1,0 +1,51 @@
+from __future__ import absolute_import
+import fluent.syntax.ast as FTL
+from fluent.migrate.helpers import transforms_from
+from fluent.migrate.helpers import VARIABLE_REFERENCE, TERM_REFERENCE
+from fluent.migrate import REPLACE, COPY
+
+main = "main.lang"
+
+def migrate(ctx):
+    """Migrate bedrock/base/templates/macros.html, part {index}."""
+
+    ctx.add_transforms(
+        "fxa_form.ftl",
+        "fxa_form.ftl",
+        [
+
+            FTL.Message(
+                id=FTL.Identifier("fxa-form-enter-your-email"),
+                value=REPLACE(
+                    "main.lang",
+                    "<strong>Enter your email</strong> to access Firefox Accounts.",
+                    {
+                        "Firefox Accounts": TERM_REFERENCE("brand-name-firefox-accounts"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("fxa-form-by-proceeding"),
+                value=REPLACE(
+                    "main.lang",
+                    "By proceeding, you agree to the <a href=\"%(url1)s\">Terms of Service</a> and <a href=\"%(url2)s\">Privacy Notice</a>.",
+                    {
+                        "%%": "%",
+                        "%(url1)s": VARIABLE_REFERENCE("url1"),
+                        "%(url2)s": VARIABLE_REFERENCE("url2"),
+                    }
+                )
+            ),
+        ]
+    )
+
+    ctx.add_transforms(
+        "fxa_form.ftl",
+        "fxa_form.ftl",
+        transforms_from("""
+fxa-form-email-address = {COPY(main, "Email address",)}
+fxa-form-continue = {COPY(main, "Continue",)}
+fxa-form-create-account = {COPY(main, "Create account",)}
+fxa-form-get-the-app = {COPY(main, "Get the app",)}
+""", main=main)
+        )


### PR DESCRIPTION
## Description
- Migrate FxA form strings from `main.lang` to `fxa_form.ftl`
- Update macro to use Fluent string IDs.

## Issue / Bugzilla link
#8657

## Testing
- Run `./manage.py l10n_update` before testing other languages.