### PR TITLE
Experiment: installer-help redesign. (#8602)

### DIFF
--- a/bedrock/firefox/templates/firefox/installer-help-b.html
+++ b/bedrock/firefox/templates/firefox/installer-help-b.html
@@ -34,7 +34,7 @@
 <main class="mzp-l-content">
   <section class="mzp-c-hero">
     <div class="mzp-c-hero-body">
-      <h1 class="mzp-c-hero-title">{{ _('Hmm... your download was interrupted') }}</h1>
+      <h1 class="mzp-c-hero-title">{{ _('Hmm… your download was interrupted') }}</h1>
       <div class="mzp-c-hero-desc">
         <p>
           {{ _('That happens sometimes. Let’s try something different.') }}
@@ -50,7 +50,7 @@
 
   {% if installer_channel %}
     <section class="installer-channel-card mzp-c-card mzp-c-card-extra-small">
-      {{ high_res_img(channel_logo, {'alt': 'Firefox', 'width': '347', 'height': '64'}) }}
+      {{ high_res_img(channel_logo, {'alt': 'Firefox Browser', 'width': '347', 'height': '64'}) }}
       <div class="mzp-c-card-content">
         {{ download_firefox(installer_channel, force_direct=True, force_full_installer=True, locale=installer_lang, button_color='mzp-t-small', alt_copy=_('Download Now')) }}
       </div>
@@ -58,7 +58,7 @@
   {% else %}
     <div class="mzp-l-card-quarter">
       <section class="mzp-c-card mzp-c-card-extra-small">
-        {{ high_res_img('protocol/img/logos/firefox/browser/logo-word-hor-sm.png', {'alt': 'Firefox', 'width': '347', 'height': '64', 'class': 'mzp-c-card-image'}) }}
+        {{ high_res_img('protocol/img/logos/firefox/browser/logo-word-hor-sm.png', {'alt': 'Firefox Browser', 'width': '347', 'height': '64', 'class': 'mzp-c-card-image'}) }}
         <div class="mzp-c-card-content">
           <p class="mzp-c-card-desc">
             {{ _('Get the latest. Automatic privacy is here. Download Firefox to block over 2000 trackers.') }}
@@ -68,7 +68,7 @@
       </section>
 
       <section class="mzp-c-card mzp-c-card-extra-small">
-        {{ high_res_img('protocol/img/logos/firefox/browser/beta/logo-word-hor-sm.png', {'alt': 'Firefox', 'width': '347', 'height': '64', 'class': 'mzp-c-card-image'}) }}
+        {{ high_res_img('protocol/img/logos/firefox/browser/beta/logo-word-hor-sm.png', {'alt': 'Firefox Beta Browser', 'width': '347', 'height': '64', 'class': 'mzp-c-card-image'}) }}
         <div class="mzp-c-card-content">
           <p class="mzp-c-card-desc">
             {{ _('Test about-to-be released features in the most stable pre-release build.') }}
@@ -78,7 +78,7 @@
       </section>
 
       <section class="mzp-c-card mzp-c-card-extra-small">
-        {{ high_res_img('protocol/img/logos/firefox/browser/developer/logo-word-hor-sm.png', {'alt': 'Firefox', 'class': 'mzp-c-card-image'}) }}
+        {{ high_res_img('protocol/img/logos/firefox/browser/developer/logo-word-hor-sm.png', {'alt': 'Firefox Developer Browser', 'class': 'mzp-c-card-image'}) }}
         <div class="mzp-c-card-content">
           <p class="mzp-c-card-desc">
             {{ _('Build, test, scale and more with the only browser built just for developers.') }}
@@ -88,7 +88,7 @@
       </section>
 
       <section class="mzp-c-card mzp-c-card-extra-small">
-        {{ high_res_img('protocol/img/logos/firefox/browser/nightly/logo-word-hor-sm.png', {'alt': 'Firefox', 'width': '347', 'height': '64', 'class': 'mzp-c-card-image'}) }}
+        {{ high_res_img('protocol/img/logos/firefox/browser/nightly/logo-word-hor-sm.png', {'alt': 'Firefox Nightly Browser', 'width': '347', 'height': '64', 'class': 'mzp-c-card-image'}) }}
         <div class="mzp-c-card-content">
           <p class="mzp-c-card-desc">
             {{ _('Peek at our next generation web browser, and help us make it the best browser it can be.') }}
@@ -102,7 +102,11 @@
   <section class="install-help">
     <div>
       <h2>{{ _('Need help installing?') }}</h2>
-      <p>{{ _('If you still need help installing, <a href="https://support.mozilla.org/kb/install-firefox-windows">read the tutorial in our Support section.</a>') }}</p>
+      <p>
+        {% trans sumoe='https://support.mozilla.org/kb/install-firefox-windows' %}
+          If you still need help installing, <a href="{{ sumo }}">read the tutorial in our Support section.</a>
+        {% endtrans %}
+      </p>
     </div>
   </section>
 

--- a/bedrock/firefox/templates/firefox/installer-help-b.html
+++ b/bedrock/firefox/templates/firefox/installer-help-b.html
@@ -1,0 +1,112 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+
+{% extends "/firefox/base/base-protocol.html" %}
+
+{# "noindex" pages should not have the canonical or hreflang tags: bug 1442331 #}
+{% block canonical_urls %}<meta name="robots" content="noindex,follow">{% endblock %}
+
+{% block page_title %}{{ _('Your download was interrupted') }}{% endblock %}
+{% block body_id %}installer-help{% endblock %}
+
+{% block page_css %}
+  {{ css_bundle('installer_help_b') }}
+{% endblock %}
+
+{% block site_header %}
+  {% with hide_nav_cta=True %}
+    {% include 'includes/protocol/navigation/menu-firefox/index.html' %}
+  {% endwith %}
+{% endblock %}
+
+{% if installer_channel == 'beta' %}
+  {% set channel_logo = 'protocol/img/logos/firefox/browser/beta/logo-word-hor-sm.png' %}
+{% elif installer_channel == 'alpha' %}
+  {% set channel_logo = 'protocol/img/logos/firefox/browser/developer/logo-word-hor-sm.png' %}
+{% elif installer_channel == 'nightly' %}
+  {% set channel_logo = 'protocol/img/logos/firefox/browser/nightly/logo-word-hor-sm.png' %}
+{% else %}
+  {% set channel_logo = 'protocol/img/logos/firefox/browser/logo-word-hor-sm.png' %}
+{% endif %}
+
+{% block content %}
+<main class="mzp-l-content">
+  <section class="mzp-c-hero">
+    <div class="mzp-c-hero-body">
+      <h1 class="mzp-c-hero-title">{{ _('Hmm... your download was interrupted') }}</h1>
+      <div class="mzp-c-hero-desc">
+        <p>
+          {{ _('That happens sometimes. Let’s try something different.') }}
+          {% if installer_channel %}
+            <span>{{ _('This download should work better for you.') }}</span>
+          {% else %}
+            <span>{{ _('Choose a download below.') }}</span>
+          {% endif %}
+        </p>
+      </div>
+    </div>
+  </section>
+
+  {% if installer_channel %}
+    <section class="installer-channel-card mzp-c-card mzp-c-card-extra-small">
+      {{ high_res_img(channel_logo, {'alt': 'Firefox', 'width': '347', 'height': '64'}) }}
+      <div class="mzp-c-card-content">
+        {{ download_firefox(installer_channel, force_direct=True, force_full_installer=True, locale=installer_lang, button_color='mzp-t-small', alt_copy=_('Download Now')) }}
+      </div>
+    </section>
+  {% else %}
+    <div class="mzp-l-card-quarter">
+      <section class="mzp-c-card mzp-c-card-extra-small">
+        {{ high_res_img('protocol/img/logos/firefox/browser/logo-word-hor-sm.png', {'alt': 'Firefox', 'width': '347', 'height': '64', 'class': 'mzp-c-card-image'}) }}
+        <div class="mzp-c-card-content">
+          <p class="mzp-c-card-desc">
+            {{ _('Get the latest. Automatic privacy is here. Download Firefox to block over 2000 trackers.') }}
+          </p>
+          {{ download_firefox(force_direct=True, force_full_installer=True, locale=installer_lang, button_color='mzp-t-secondary mzp-t-small', alt_copy=_('Download Now')) }}
+        </div>
+      </section>
+
+      <section class="mzp-c-card mzp-c-card-extra-small">
+        {{ high_res_img('protocol/img/logos/firefox/browser/beta/logo-word-hor-sm.png', {'alt': 'Firefox', 'width': '347', 'height': '64', 'class': 'mzp-c-card-image'}) }}
+        <div class="mzp-c-card-content">
+          <p class="mzp-c-card-desc">
+            {{ _('Test about-to-be released features in the most stable pre-release build.') }}
+          </p>
+          {{ download_firefox('beta', force_direct=True, force_full_installer=True, locale=installer_lang, button_color='mzp-t-secondary mzp-t-small', alt_copy=_('Download Now')) }}
+        </div>
+      </section>
+
+      <section class="mzp-c-card mzp-c-card-extra-small">
+        {{ high_res_img('protocol/img/logos/firefox/browser/developer/logo-word-hor-sm.png', {'alt': 'Firefox', 'class': 'mzp-c-card-image'}) }}
+        <div class="mzp-c-card-content">
+          <p class="mzp-c-card-desc">
+            {{ _('Build, test, scale and more with the only browser built just for developers.') }}
+          </p>
+          {{ download_firefox('alpha', platform='desktop', force_direct=True, force_full_installer=True, locale=installer_lang, button_color='mzp-t-secondary mzp-t-small', alt_copy=_('Download Now')) }}
+        </div>
+      </section>
+
+      <section class="mzp-c-card mzp-c-card-extra-small">
+        {{ high_res_img('protocol/img/logos/firefox/browser/nightly/logo-word-hor-sm.png', {'alt': 'Firefox', 'width': '347', 'height': '64', 'class': 'mzp-c-card-image'}) }}
+        <div class="mzp-c-card-content">
+          <p class="mzp-c-card-desc">
+            {{ _('Peek at our next generation web browser, and help us make it the best browser it can be.') }}
+          </p>
+          {{ download_firefox('nightly', platform='desktop', force_direct=True, force_full_installer=True, locale=installer_lang, button_color='mzp-t-secondary mzp-t-small', alt_copy=_('Download Now')) }}
+        </div>
+      </section>
+    </div>
+  {% endif %}
+
+  <section class="install-help">
+    <div>
+      <h2>{{ _('Need help installing?') }}</h2>
+      <p>{{ _('If you still need help installing, <a href="https://support.mozilla.org/kb/install-firefox-windows">read the tutorial in our Support section.</a>') }}</p>
+    </div>
+  </section>
+
+</main>
+{% endblock %}
+
+{% block js %}{% endblock %}

--- a/bedrock/firefox/templates/firefox/installer-help.html
+++ b/bedrock/firefox/templates/firefox/installer-help.html
@@ -67,3 +67,9 @@
 {% endblock %}
 
 {% block js %}{% endblock  %}
+
+{% block experiments %}
+  {% if switch('installer-help-experiment', ['en-US']) %}
+    {{ js_bundle('installer_help_experiment') }}
+  {% endif %}
+{% endblock %}

--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -65,6 +65,12 @@ def installer_help(request):
     installer_lang = request.GET.get('installer_lang', None)
     installer_channel = request.GET.get('channel', None)
     context = {'installer_lang': None, 'installer_channel': None}
+    template = 'firefox/installer-help.html'
+    variant = request.GET.get('v', None)
+
+    # ensure variant matches pre-defined value
+    if variant not in ['a', 'b']:  # place expected ?v= values in this list
+        variant = None
 
     if installer_lang and installer_lang in firefox_desktop.languages:
         context['installer_lang'] = installer_lang
@@ -75,7 +81,10 @@ def installer_help(request):
         else:
             context['installer_channel'] = installer_channel
 
-    return l10n_utils.render(request, 'firefox/installer-help.html', context)
+    if variant == 'b':
+        template = 'firefox/installer-help-b.html'
+
+    return l10n_utils.render(request, template, context)
 
 
 @require_GET

--- a/media/css/firefox/installer-help-b.scss
+++ b/media/css/firefox/installer-help-b.scss
@@ -1,0 +1,38 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+$font-path: '/media/fonts';
+$image-path: '/media/protocol/img';
+
+@import "../../protocol/css/includes/lib";
+@import '../../protocol/css/components/hero';
+@import '../../protocol/css/templates/card-layout';
+
+.mzp-c-card {
+    .mzp-c-card-desc {
+        margin: $spacing-xl 0;
+        height: $layout-lg;
+    }
+
+    .download-button, .download-link {
+        width: 100%;
+        margin-top: $spacing-sm;
+    }
+}
+
+.installer-channel-card {
+    margin: 0 auto $spacing-2xl auto;
+    float: none;
+    text-align: center;
+}
+
+.install-help {
+    margin: 0 auto $spacing-2xl auto;
+    max-width: $content-xs;
+    text-align: center;
+
+    h2 {
+        @include text-display-xs;
+    }
+}

--- a/media/js/firefox/installer-help-experiment.js
+++ b/media/js/firefox/installer-help-experiment.js
@@ -1,0 +1,34 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+(function (Mozilla) {
+    'use strict';
+
+    /* update dataLayer with experiment info */
+    var href = window.location.href;
+    if (href.indexOf('v=') !== -1) {
+        if (href.indexOf('v=a') !== -1) {
+            window.dataLayer.push({
+                'data-ex-variant': 'installer-help-control',
+                'data-ex-name': 'CRO-Installer-Help-Experiment'
+            });
+        } else if (href.indexOf('v=b') !== -1) {
+            window.dataLayer.push({
+                'data-ex-variant': 'installer-help-v1',
+                'data-ex-name': 'CRO-Installer-Help-Experiment'
+            });
+        }
+    } else {
+        var cop = new Mozilla.TrafficCop({
+            id: 'experiment_installer_help',
+            variations: {
+                'v=a': 27,
+                'v=b': 27
+            }
+        });
+
+        cop.init();
+    }
+
+})(window.Mozilla);

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -63,6 +63,12 @@
     },
     {
       "files": [
+        "css/firefox/installer-help-b.scss"
+      ],
+      "name": "installer_help_b"
+    },
+    {
+      "files": [
         "css/mozorg/participation-reporting.scss"
       ],
       "name": "participation-reporting"
@@ -1406,6 +1412,12 @@
         "js/base/error-pages.js"
       ],
       "name": "page_not_found"
+    },
+    {
+      "files": [
+        "js/firefox/installer-help-experiment.js"
+      ],
+      "name": "installer_help_experiment"
     }
   ]
 }

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -1415,6 +1415,7 @@
     },
     {
       "files": [
+        "js/libs/mozilla-traffic-cop.js",
         "js/firefox/installer-help-experiment.js"
       ],
       "name": "installer_help_experiment"


### PR DESCRIPTION
## Description
Testing conversion rate of a redesigned firefox/installer-help page.

## Issue / Bugzilla link
#8602

## Testing
**demo:** https://www-demo5.allizom.org/en-US/firefox/installer-help/?v=b

- [ ] **[Test plan](https://docs.google.com/document/d/1nI6GlQjZ3mH7_J_Dsdgpd2Ia7hke0lDxgwT7BrvvJwU/edit?usp=sharing)**: 54% of users entered into experiment total. Half of those receive control and half receive variation (27% each)
- [ ] If no channel passed users receives all download buttons and updated copy.
- [ ] If channel passed user receives appropriate download button. 
