### PR TITLE
Integrate FxA product button JS with China repack logic (Fixes #8328)

### DIFF
--- a/bedrock/mozorg/templatetags/misc.py
+++ b/bedrock/mozorg/templatetags/misc.py
@@ -868,7 +868,8 @@ def fxa_link_fragment(ctx, entrypoint, action='signup', optional_parameters=None
     fxa_url = _fxa_product_url(f'{settings.FXA_ENDPOINT}{action}', entrypoint, optional_parameters)
     mozillaonline_url = _fxa_product_url(f'{settings.FXA_ENDPOINT_MOZILLAONLINE}{action}', entrypoint, optional_parameters)
 
-    markup = (f'href="{fxa_url}" data-mozillaonline-link="{mozillaonline_url}"')
+    markup = (f'href="{fxa_url}" data-mozillaonline-link="{mozillaonline_url}" '
+              f'data-mozillaonline-action="{settings.FXA_ENDPOINT_MOZILLAONLINE}"')
 
     return jinja2.Markup(markup)
 
@@ -896,7 +897,8 @@ def fxa_button(ctx, entrypoint, button_text, action='signup', class_name=None, i
     mozillaonline_product_url = f'{settings.FXA_ENDPOINT_MOZILLAONLINE}{action}'
 
     mozillaonline_attribute = {
-        'data-mozillaonline-link': _fxa_product_url(mozillaonline_product_url, entrypoint, optional_parameters)
+        'data-mozillaonline-link': _fxa_product_url(mozillaonline_product_url, entrypoint, optional_parameters),
+        'data-mozillaonline-action': settings.FXA_ENDPOINT_MOZILLAONLINE
     }
 
     optional_attributes = optional_attributes or {}

--- a/bedrock/mozorg/tests/test_helper_misc.py
+++ b/bedrock/mozorg/tests/test_helper_misc.py
@@ -48,6 +48,7 @@ TEST_FIREFOX_TWITTER_ACCOUNTS = {
 }
 
 TEST_FXA_ENDPOINT = 'https://accounts.firefox.com/'
+TEST_FXA_MOZILLAONLINE_ENDPOINT = 'https://accounts.firefox.com.cn/'
 
 jinja_env = Jinja2.get_default()
 
@@ -1018,6 +1019,7 @@ class TestMonitorFxAButton(TestCase):
 
 
 @override_settings(FXA_ENDPOINT=TEST_FXA_ENDPOINT)
+@override_settings(FXA_ENDPOINT_MOZILLAONLINE=TEST_FXA_MOZILLAONLINE_ENDPOINT)
 class TestFxAButton(TestCase):
     rf = RequestFactory()
 
@@ -1042,7 +1044,8 @@ class TestFxAButton(TestCase):
             u'data-action="https://accounts.firefox.com/" class="js-fxa-cta-link js-fxa-product-button mzp-c-button mzp-t-product '
             u'fxa-main-cta-button" data-cta-text="Sign Up" data-cta-type="fxa-sync" data-cta-position="primary" '
             u'data-mozillaonline-link="https://accounts.firefox.com.cn/signup?entrypoint=mozilla.org-firefox-whatsnew73'
-            u'&form_type=button&utm_source=mozilla.org-firefox-whatsnew73&utm_medium=referral&utm_campaign=whatsnew73">Sign Up</a>')
+            u'&form_type=button&utm_source=mozilla.org-firefox-whatsnew73&utm_medium=referral&utm_campaign=whatsnew73" '
+            u'data-mozillaonline-action="https://accounts.firefox.com.cn/">Sign Up</a>')
         self.assertEqual(markup, expected)
 
     def test_fxa_button_signin(self):
@@ -1058,7 +1061,8 @@ class TestFxAButton(TestCase):
             u'data-action="https://accounts.firefox.com/" class="js-fxa-cta-link js-fxa-product-button mzp-c-button mzp-t-product '
             u'fxa-main-cta-button" data-cta-text="Sign In" data-cta-type="fxa-sync" data-cta-position="primary" '
             u'data-mozillaonline-link="https://accounts.firefox.com.cn/signin?entrypoint=mozilla.org-firefox-whatsnew73'
-            u'&form_type=button&utm_source=mozilla.org-firefox-whatsnew73&utm_medium=referral&utm_campaign=whatsnew73">Sign In</a>')
+            u'&form_type=button&utm_source=mozilla.org-firefox-whatsnew73&utm_medium=referral&utm_campaign=whatsnew73" '
+            u'data-mozillaonline-action="https://accounts.firefox.com.cn/">Sign In</a>')
         self.assertEqual(markup, expected)
 
     def test_fxa_button_email(self):
@@ -1074,11 +1078,13 @@ class TestFxAButton(TestCase):
             u'data-action="https://accounts.firefox.com/" class="js-fxa-cta-link js-fxa-product-button mzp-c-button mzp-t-product '
             u'fxa-main-cta-button" data-cta-text="Sign Up" data-cta-type="fxa-sync" data-cta-position="primary" '
             u'data-mozillaonline-link="https://accounts.firefox.com.cn/?action=email&entrypoint=mozilla.org-firefox-whatsnew73'
-            u'&form_type=button&utm_source=mozilla.org-firefox-whatsnew73&utm_medium=referral&utm_campaign=whatsnew73">Sign Up</a>')
+            u'&form_type=button&utm_source=mozilla.org-firefox-whatsnew73&utm_medium=referral&utm_campaign=whatsnew73" '
+            u'data-mozillaonline-action="https://accounts.firefox.com.cn/">Sign Up</a>')
         self.assertEqual(markup, expected)
 
 
 @override_settings(FXA_ENDPOINT=TEST_FXA_ENDPOINT)
+@override_settings(FXA_ENDPOINT_MOZILLAONLINE=TEST_FXA_MOZILLAONLINE_ENDPOINT)
 class TestFxALinkFragment(TestCase):
     rf = RequestFactory()
 
@@ -1096,5 +1102,6 @@ class TestFxALinkFragment(TestCase):
             u'href="https://accounts.firefox.com/signup?entrypoint=mozilla.org-firefox-whatsnew73&form_type=button'
             u'&utm_source=mozilla.org-firefox-whatsnew73&utm_medium=referral&utm_campaign=whatsnew73" '
             u'data-mozillaonline-link="https://accounts.firefox.com.cn/signup?entrypoint=mozilla.org-firefox-whatsnew73'
-            u'&form_type=button&utm_source=mozilla.org-firefox-whatsnew73&utm_medium=referral&utm_campaign=whatsnew73"')
+            u'&form_type=button&utm_source=mozilla.org-firefox-whatsnew73&utm_medium=referral&utm_campaign=whatsnew73" '
+            u'data-mozillaonline-action="https://accounts.firefox.com.cn/"')
         self.assertEqual(markup, expected)

--- a/media/js/base/base-page-init.js
+++ b/media/js/base/base-page-init.js
@@ -26,7 +26,7 @@
         /* Bug 1264843: In partner distribution of desktop Firefox, switch the
         downloads to corresponding partner build of Firefox for Android. */
         if (client.isFirefoxDesktop) {
-            client.getFirefoxDetails(utils.maybeSwitchToDistDownloadLinks);
+            client.getFirefoxDetails(utils.maybeSwitchToChinaRepackImages);
         }
 
         // if window.load happened already, fire onWindowLoad

--- a/media/js/base/mozilla-fxa-product-button.js
+++ b/media/js/base/mozilla-fxa-product-button.js
@@ -16,12 +16,11 @@ if (typeof window.Mozilla === 'undefined') {
         'https://accounts.firefox.com/',
         'https://monitor.firefox.com/',
         'https://getpocket.com/',
-        'https://latest.dev.lcip.org/'
+        'https://latest.dev.lcip.org/',
+        'https://accounts.firefox.com.cn/'
     ];
 
-    FxaProductButton.isSupported = function() {
-        return 'fetch' in window;
-    };
+    var _buttons;
 
     /**
      * Returns the hostname for a given URL.
@@ -33,75 +32,157 @@ if (typeof window.Mozilla === 'undefined') {
         return matches && matches[0];
     };
 
-    FxaProductButton.init = function() {
-        var buttons;
-
-        if (!FxaProductButton.isSupported()) {
-            return false;
-        }
-
-        // Collect all Fxa product buttons
-        buttons = document.getElementsByClassName('js-fxa-product-button');
-
-        // Exit if no valid button in DOM
-        if (buttons.length === 0) {
-            return;
-        }
-
+    /**
+     * Get tokens from FxA for analytics purposes.
+     * This is non-critical to the user flow.
+     */
+    FxaProductButton.fetchTokens = function(buttons) {
+        // assume the first button should dictate the metrics flow request
         var buttonURL = buttons[0].getAttribute('href');
+        var metricsURL = buttons[0].getAttribute('data-action') + 'metrics-flow';
 
         // strip url to everything after `?`
         var buttonURLParams = buttonURL.match(/\?(.*)/)[1];
-
-        var destURL = buttons[0].getAttribute('data-action') + 'metrics-flow';
 
         // collect values from Fxa product button
         var params = window._SearchParams.queryStringToObject(buttonURLParams);
 
         // add required params to the token fetch request
-        destURL += '?entrypoint=' + params.entrypoint;
-        destURL += '&form_type=' + params.form_type;
-        destURL += '&utm_source=' + params.utm_source;
+        metricsURL += '?form_type=' + params.form_type;
+        metricsURL += '&entrypoint=' + params.entrypoint;
+        metricsURL += '&utm_source=' + params.utm_source;
 
         // add optional utm params to the token fetch request
         if (params.utm_campaign) {
-            destURL += '&utm_campaign=' + params.utm_campaign;
+            metricsURL += '&utm_campaign=' + params.utm_campaign;
         }
 
         if (params.utm_content) {
-            destURL += '&utm_content=' + params.utm_content;
+            metricsURL += '&utm_content=' + params.utm_content;
         }
 
         if (params.utm_term) {
-            destURL += '&utm_term=' + params.utm_term;
+            metricsURL += '&utm_term=' + params.utm_term;
         }
 
         if (params.entrypoint_experiment) {
-            destURL += '&entrypoint_experiment=' + params.entrypoint_experiment;
+            metricsURL += '&entrypoint_experiment=' + params.entrypoint_experiment;
         }
 
         if (params.entrypoint_variation) {
-            destURL += '&entrypoint_variation=' + params.entrypoint_variation;
+            metricsURL += '&entrypoint_variation=' + params.entrypoint_variation;
         }
 
-        return fetch(destURL).then(function(resp) {
+        return fetch(metricsURL).then(function(resp) {
             return resp.json();
         }).then(function(r) {
             // add retrieved deviceID, flowBeginTime and flowId values to cta url
             var flowParams = '&deviceId=' + r.deviceId;
             flowParams += '&flowBeginTime=' + r.flowBeginTime;
             flowParams += '&flowId=' + r.flowId;
-
-            // applies url to all buttons and adds cta position
-            for (var i = 0; i < buttons.length; i++) {
-                var hostName = FxaProductButton.getHostName(buttons[i].href);
-                // check if link is in the FxA referral whitelist.
-                if (hostName && whitelist.indexOf(hostName) !== -1) {
-                    buttons[i].href += flowParams;
-                }
-            }
+            return flowParams;
         }).catch(function() {
             // silently fail: deviceId, flowBeginTime, flowId are not added to url.
+        });
+    };
+
+    /**
+     * Attaches metrics flow parameters to FxA links.
+     * @param {Object} Node List
+     * @param {String} flowParams
+     */
+    FxaProductButton.updateProductLinks = function(buttons, flowParams) {
+        // if flowParams are undefined (e.g. blocked by CORS), then do nothing.
+        if (!flowParams) {
+            return;
+        }
+
+        // applies url to all buttons and adds cta position
+        for (var i = 0; i < buttons.length; i++) {
+            var hostName = FxaProductButton.getHostName(buttons[i].href);
+            // check if link is in the FxA referral whitelist.
+            if (hostName && whitelist.indexOf(hostName) !== -1) {
+                buttons[i].href += flowParams;
+            }
+        }
+    };
+
+    /**
+     * Switches FxA links to point to mozillaonline FxA server for China repack.
+     * @param {Object} Node List
+     */
+    FxaProductButton.switchDistribution = function(buttons) {
+        for (var i = 0; i < buttons.length; i++) {
+            var mozillaonlineAction = buttons[i].getAttribute('data-mozillaonline-action');
+            var mozillaonlineLink = buttons[i].getAttribute('data-mozillaonline-link');
+
+            if (mozillaonlineAction && mozillaonlineLink) {
+                buttons[i].href = mozillaonlineLink;
+                buttons[i].setAttribute('data-action', mozillaonlineAction);
+            }
+        }
+    };
+
+    /**
+     * Checks for China repack, before making a metrics-flow request.
+     */
+    FxaProductButton.configureRequest = function() {
+        return new window.Promise(function(resolve) {
+            Mozilla.Client.getFirefoxDetails(function(data) {
+                var syncButtons = document.querySelectorAll('.js-fxa-product-button[data-mozillaonline-link]');
+                /**
+                 * Only switch to China repack URLs if there are Sync buttons on the page,
+                 * and if UITour call is successful (marked by data.accurate being true)
+                 */
+                if (syncButtons.length && data.accurate && data.distribution && data.distribution.toLowerCase() === 'mozillaonline') {
+                    FxaProductButton.switchDistribution(syncButtons);
+                    /**
+                     * Rather than waiting on requests from multiple servers,
+                     * only attach metrics params to Sync buttons for China repack
+                     * if there is more than one type of product button on a page.
+                     */
+                    FxaProductButton.fetchTokens(syncButtons).then(function(flowParams) {
+                        FxaProductButton.updateProductLinks(syncButtons, flowParams);
+                        resolve();
+                    });
+                } else {
+                    FxaProductButton.fetchTokens(_buttons).then(function(flowParams) {
+                        FxaProductButton.updateProductLinks(_buttons, flowParams);
+                        resolve();
+                    });
+                }
+            });
+        });
+    };
+
+    FxaProductButton.isSupported = function() {
+        return 'Promise' in window && 'fetch' in window;
+    };
+
+    FxaProductButton.init = function() {
+        if (!FxaProductButton.isSupported()) {
+            return false;
+        }
+
+        // Collect all Fxa product buttons
+        _buttons = document.getElementsByClassName('js-fxa-product-button');
+
+        return new window.Promise(function(resolve, reject) {
+            if (_buttons.length) {
+                // Configure Sync for Firefox desktop browsers
+                if (Mozilla.Client._isFirefoxDesktop()) {
+                    FxaProductButton.configureRequest().then(function() {
+                        resolve();
+                    });
+                } else {
+                    FxaProductButton.fetchTokens(_buttons).then(function(flowParams) {
+                        FxaProductButton.updateProductLinks(_buttons, flowParams);
+                        resolve();
+                    });
+                }
+            } else {
+                reject();
+            }
         });
     };
 

--- a/media/js/base/mozilla-utils.js
+++ b/media/js/base/mozilla-utils.js
@@ -26,18 +26,14 @@ if (typeof window.Mozilla === 'undefined') {
     };
 
     // Bug 1264843: link to China build of Fx4A, for display within Fx China repack
-    Utils.maybeSwitchToDistDownloadLinks = function(client) {
+    Utils.maybeSwitchToChinaRepackImages = function(client) {
         if (!client.distribution || client.distribution === 'default') {
             return;
         }
 
         var distribution = client.distribution.toLowerCase();
-        var links = document.querySelectorAll('a[data-' + distribution + '-link]');
         var images = document.querySelectorAll('img[data-' + distribution + '-link]');
-        for (var i = 0; i < links.length; i++) {
-            var distributionLink = links[i].getAttribute('data-' + distribution + '-link');
-            links[i].setAttribute('href', distributionLink);
-        }
+
         for (var j = 0; j < images.length; j++) {
             var distributionSrc = images[j].getAttribute('data-' + distribution + '-link');
             images[j].setAttribute('src', distributionSrc);

--- a/tests/unit/spec/base/mozilla-fxa-product-button.js
+++ b/tests/unit/spec/base/mozilla-fxa-product-button.js
@@ -8,8 +8,8 @@ describe('mozilla-fxa-product-button.js', function() {
     'use strict';
 
     beforeEach(function() {
-        var button = '<a class="js-fxa-product-button" href="https://monitor.firefox.com/oauth/init?form_type=button&amp;entrypoint=mozilla.org-firefox-accounts&amp;utm_source=mozilla.org-firefox-accounts&amp;utm_campaign=trailhead&amp;utm_medium=referral" data-action="https://accounts.firefox.com/" >Sign Up to Monitor</a>' +
-                     '<a class="js-fxa-product-button" href="https://getpocket.com/ff_signup?s=ffwelcome2&amp;form_type=button&amp;entrypoint=mozilla.org-firefox-welcome-2&amp;utm_source=mozilla.org-firefox-welcome-2&amp;utm_campaign=welcome-2-pocket&amp;utm_medium=referral" data-action="https://accounts.firefox.com/" >Activate Pocket</a>' +
+        var button = '<a class="js-fxa-product-button" href="https://accounts.firefox.com/signup?form_type=button&entrypoint=mozilla.org-whatsnew60&utm_source=mozilla.org-whatsnew60&utm_medium=referral&utm_campaign=whatsnew60&context=fx_desktop_v3" data-action="https://accounts.firefox.com/" data-mozillaonline-link="https://accounts.firefox.com.cn/signup?form_type=button&entrypoint=mozilla.org-whatsnew60&utm_source=mozilla.org-whatsnew60&utm_medium=referral&utm_campaign=whatsnew60&context=fx_desktop_v3" data-mozillaonline-action="https://accounts.firefox.com.cn/">Sign Up to Monitor</a>' +
+                     '<a class="js-fxa-product-button" href="https://getpocket.com/ff_signup?s=ffwelcome2&amp;form_type=button&amp;entrypoint=mozilla.org-firefox-welcome-2&amp;utm_source=mozilla.org-firefox-welcome-2&amp;utm_campaign=welcome-2-pocket&amp;utm_medium=referral" data-action="https://accounts.firefox.com/">Activate Pocket</a>' +
                      '<a class="js-fxa-product-button" href="https://www.mozilla.org/en-US/firefox/accounts/">Learn more</a>';
 
         var data = {
@@ -27,6 +27,7 @@ describe('mozilla-fxa-product-button.js', function() {
 
         document.body.insertAdjacentHTML('beforeend', button);
         spyOn(window, 'fetch').and.returnValue(window.Promise.resolve(mockResponse));
+        spyOn(Mozilla.Client, '_isFirefoxDesktop').and.returnValue(true);
     });
 
     afterEach(function() {
@@ -36,24 +37,61 @@ describe('mozilla-fxa-product-button.js', function() {
     });
 
     it('should make a single metrics flow request', function() {
+        spyOn(Mozilla.Client, 'getFirefoxDetails').and.callFake(function(callback) {
+            callback({
+                'accurate': true,
+                'distribution': undefined,
+            });
+        });
+
         return Mozilla.FxaProductButton.init().then(function() {
             expect(window.fetch).toHaveBeenCalledTimes(1);
-            expect(window.fetch).toHaveBeenCalledWith('https://accounts.firefox.com/metrics-flow?entrypoint=mozilla.org-firefox-accounts&form_type=button&utm_source=mozilla.org-firefox-accounts&utm_campaign=trailhead');
+            expect(window.fetch).toHaveBeenCalledWith('https://accounts.firefox.com/metrics-flow?form_type=button&entrypoint=mozilla.org-whatsnew60&utm_source=mozilla.org-whatsnew60&utm_campaign=whatsnew60');
         });
     });
 
     it('should attach flow parameters to button hrefs in the metrics response', function() {
+        spyOn(Mozilla.Client, 'getFirefoxDetails').and.callFake(function(callback) {
+            callback({
+                'accurate': true,
+                'distribution': undefined,
+            });
+        });
+
         return Mozilla.FxaProductButton.init().then(function() {
             var buttons = document.querySelectorAll('.js-fxa-product-button');
-            expect(buttons[0].href).toEqual('https://monitor.firefox.com/oauth/init?form_type=button&entrypoint=mozilla.org-firefox-accounts&utm_source=mozilla.org-firefox-accounts&utm_campaign=trailhead&utm_medium=referral&deviceId=848377ff6e3e4fc982307a316f4ca3d6&flowBeginTime=1573052386673&flowId=75f9a48a0f66c2f5919a0989605d5fa5dd04625ea5a2ee59b2d5d54637c566d1');
+            expect(buttons[0].href).toEqual('https://accounts.firefox.com/signup?form_type=button&entrypoint=mozilla.org-whatsnew60&utm_source=mozilla.org-whatsnew60&utm_medium=referral&utm_campaign=whatsnew60&context=fx_desktop_v3&deviceId=848377ff6e3e4fc982307a316f4ca3d6&flowBeginTime=1573052386673&flowId=75f9a48a0f66c2f5919a0989605d5fa5dd04625ea5a2ee59b2d5d54637c566d1');
             expect(buttons[1].href).toEqual('https://getpocket.com/ff_signup?s=ffwelcome2&form_type=button&entrypoint=mozilla.org-firefox-welcome-2&utm_source=mozilla.org-firefox-welcome-2&utm_campaign=welcome-2-pocket&utm_medium=referral&deviceId=848377ff6e3e4fc982307a316f4ca3d6&flowBeginTime=1573052386673&flowId=75f9a48a0f66c2f5919a0989605d5fa5dd04625ea5a2ee59b2d5d54637c566d1');
         });
     });
 
     it('should not attach flow parameters to button hrefs in the domain is invalid', function() {
+        spyOn(Mozilla.Client, 'getFirefoxDetails').and.callFake(function(callback) {
+            callback({
+                'accurate': true,
+                'distribution': undefined,
+            });
+        });
+
         return Mozilla.FxaProductButton.init().then(function() {
             var buttons = document.querySelectorAll('.js-fxa-product-button');
             expect(buttons[2].href).toEqual('https://www.mozilla.org/en-US/firefox/accounts/');
+        });
+    });
+
+    it('should switch to mozillaonline distribution when needed', function() {
+        spyOn(Mozilla.Client, 'getFirefoxDetails').and.callFake(function(callback) {
+            callback({
+                'accurate': true,
+                'distribution': 'mozillaonline',
+            });
+        });
+
+        return Mozilla.FxaProductButton.init().then(function() {
+            var buttons = document.querySelectorAll('.js-fxa-product-button');
+            expect(window.fetch).toHaveBeenCalledWith('https://accounts.firefox.com.cn/metrics-flow?form_type=button&entrypoint=mozilla.org-whatsnew60&utm_source=mozilla.org-whatsnew60&utm_campaign=whatsnew60');
+            expect(buttons[0].href).toEqual('https://accounts.firefox.com.cn/signup?form_type=button&entrypoint=mozilla.org-whatsnew60&utm_source=mozilla.org-whatsnew60&utm_medium=referral&utm_campaign=whatsnew60&context=fx_desktop_v3&deviceId=848377ff6e3e4fc982307a316f4ca3d6&flowBeginTime=1573052386673&flowId=75f9a48a0f66c2f5919a0989605d5fa5dd04625ea5a2ee59b2d5d54637c566d1');
+            expect(buttons[1].href).toEqual('https://getpocket.com/ff_signup?s=ffwelcome2&form_type=button&entrypoint=mozilla.org-firefox-welcome-2&utm_source=mozilla.org-firefox-welcome-2&utm_campaign=welcome-2-pocket&utm_medium=referral');
         });
     });
 });

--- a/tests/unit/spec/base/mozilla-utils.js
+++ b/tests/unit/spec/base/mozilla-utils.js
@@ -47,36 +47,36 @@ describe('mozilla-utils.js', function() {
         });
     });
 
-    describe('maybeSwitchToDistDownloadLinks', function() {
+    describe('maybeSwitchToChinaRepackImages', function() {
 
-        var $link;
-        var defaultHref = 'https://test.example.com/?id=org.mozilla.firefox';
-        var partnerAHref = defaultHref.replace('org.mozilla.firefox', 'com.partnera.firefox');
+        var $img;
+        var defaultSrc = '/img/placeholder.png';
+        var partnerASrc = '/img/foo.png';
 
         beforeEach(function () {
-            $link = $([
-                '<a href="' + defaultHref +
-                '" data-partnera-link="' + partnerAHref +
+            $img = $([
+                '<img src="' + defaultSrc +
+                '" data-partnera-link="' + partnerASrc +
                 '">download</a>'
             ].join()).appendTo('body');
         });
 
         afterEach(function() {
-            $link.remove();
+            $img.remove();
         });
 
-        it('should use specified download link for certain distributions', function () {
-            Mozilla.Utils.maybeSwitchToDistDownloadLinks({
+        it('should use specified image for certain distributions', function () {
+            Mozilla.Utils.maybeSwitchToChinaRepackImages({
                 distribution: 'PartnerA'
             });
-            expect($link.attr('href')).toEqual(partnerAHref);
+            expect($img[0].src).toContain(partnerASrc);
         });
 
-        it('should use default download link for other distributions', function () {
-            Mozilla.Utils.maybeSwitchToDistDownloadLinks({
+        it('should use default image for other distributions', function () {
+            Mozilla.Utils.maybeSwitchToChinaRepackImages({
                 distribution: 'PartnerB'
             });
-            expect($link.attr('href')).toEqual(defaultHref);
+            expect($img[0].src).toContain(defaultSrc);
         });
 
     });


### PR DESCRIPTION
## Description

Moves the mozillaonline link switching logic into `mozilla-fxa-product-button.js`, so we have tighter control over how and when FxA links are updated.

By controlling the order of events, this change should prevent metrics flow params being attached to https://accounts.firefox.com.cn/ from flow requests originating at https://accounts.firefox.com/.

## Issue / Bugzilla link
#8328

## Testing
Demo: https://www-demo1.allizom.org/en-US/firefox/60.0/whatsnew/all/

- Setup UITour permission for demo1.
- Open dev tools setting and make sure "Enable browser chrome and add-on debugging toolboxes" is checked.
- Open Firefox's "Browser Console" and set `distribution.id` by pasting `Services.prefs.getDefaultBranch("distribution.").setCharPref("id", "MozillaOnline");`.
- Visit https://www-demo1.allizom.org/en-US/firefox/60.0/whatsnew/all/.
- Once loaded, check the following:
  - [x] The Sync CTA button should point to https://accounts.firefox.com.cn/
  - [x] The same button should have metrics flow params attached. 
  - [x] The metrics request should have originated from https://accounts.firefox.com.cn/ (check in the network panel).

Note: after testing, restarting Firefox should reset the pref back to normal.

Successful test run: https://gitlab.com/mozmeao/www-config/pipelines/131381274