### PR TITLE
Add installer_help_experiment bundle to installer-help-b (bugfix)

### DIFF
--- a/bedrock/firefox/templates/firefox/installer-help-b.html
+++ b/bedrock/firefox/templates/firefox/installer-help-b.html
@@ -114,3 +114,9 @@
 {% endblock %}
 
 {% block js %}{% endblock %}
+
+{% block experiments %}
+  {% if switch('installer-help-experiment', ['en-US']) %}
+    {{ js_bundle('installer_help_experiment') }}
+  {% endif %}
+{% endblock %}


### PR DESCRIPTION
## Description
Adds missing JS bundle to experiment variant template `installer-help-b.html` (#8731)
