### PR TITLE
[#8578] Enterprise page - align download menus, update tests

### DIFF
--- a/bedrock/firefox/templates/firefox/enterprise/index.html
+++ b/bedrock/firefox/templates/firefox/enterprise/index.html
@@ -79,82 +79,82 @@
 
       <div class="enterprise-download-lists">
 
-        <section class="enterprise-download-block">
-          <div class="enterprise-download-header">
-            <h3 class="enteprise-download-title platform-win64">{{ _('Windows 64-bit') }}</h3>
+        <section class="enterprise-download-block platform-win64">
+          <h3 class="enterprise-download-title">{{ _('Windows 64-bit') }}</h3>
 
-            <div class="mzp-c-menu-list mzp-t-cta mzp-t-download" id="win64-download-list">
-              <h4 class="mzp-c-menu-list-title">{{ _('Select your download') }}</h4>
-              <ul class="mzp-c-menu-list-list">
-                <li class="mzp-c-menu-list-item"><a href="https://download.mozilla.org/?product=firefox-latest-ssl&os=win64&lang={{ LANG }}">{{ _('Firefox browser') }}</a></li>
-                <li class="mzp-c-menu-list-item"><a href="https://download.mozilla.org/?product=firefox-msi-latest-ssl&os=win64&lang={{ LANG }}">{{ _('Firefox browser - MSI installer') }}</a></l>
-                <li class="mzp-c-menu-list-item"><a href="https://download.mozilla.org/?product=firefox-esr-latest-ssl&os=win64&lang={{ LANG }}">{{ _('Firefox Extended Support Release (ESR)') }}</a></li>
-                <li class="mzp-c-menu-list-item"><a href="https://download.mozilla.org/?product=firefox-esr-msi-latest-ssl&os=win64&lang={{ LANG }}">{{ _('Firefox Extended Support Release (ESR) - MSI installer') }}</a></l>
-              </ul>
-            </div>
+          <div class="mzp-c-menu-list mzp-t-cta mzp-t-download" id="win64-download-list">
+            <h4 class="mzp-c-menu-list-title">{{ _('Select your download') }}</h4>
+            <ul class="mzp-c-menu-list-list">
+              <li class="mzp-c-menu-list-item"><a href="https://download.mozilla.org/?product=firefox-latest-ssl&os=win64&lang={{ LANG }}">{{ _('Firefox browser') }}</a></li>
+              <li class="mzp-c-menu-list-item"><a href="https://download.mozilla.org/?product=firefox-msi-latest-ssl&os=win64&lang={{ LANG }}">{{ _('Firefox browser - MSI installer') }}</a></l>
+              <li class="mzp-c-menu-list-item"><a href="https://download.mozilla.org/?product=firefox-esr-latest-ssl&os=win64&lang={{ LANG }}">{{ _('Firefox Extended Support Release (ESR)') }}</a></li>
+              <li class="mzp-c-menu-list-item"><a href="https://download.mozilla.org/?product=firefox-esr-msi-latest-ssl&os=win64&lang={{ LANG }}">{{ _('Firefox Extended Support Release (ESR) - MSI installer') }}</a></l>
+            </ul>
           </div>
 
-          <h4 class="enteprise-download-subtitle">{{ _('Support') }}</h4>
-          <ul class="mzp-u-list-styled">
-            <li><a href="https://support.mozilla.org/kb/deploy-firefox-msi-installers/{{ utm_params }}">{{ _('MSI installers') }}</a></li>
-            <li><a href="https://support.mozilla.org/kb/legacy-browser-support-extension-windows/{{ utm_params }}">{{ _('Legacy browser support') }}</a></li>
-            <li><a href="https://support.mozilla.org/kb/customizing-firefox-using-group-policy-windows/{{ utm_params }}">{{ _('ADMX templates') }}</a></li>
-            <li><a href="https://assets.mozilla.net/pdf/Firefox.for.Enterprise.Browser.Deployment.Guide.pdf">{{ _('Deployment guide') }}</a></li>
-            <li><a href="https://github.com/mozilla/policy-templates/blob/master/README.md">{{ _('Policy documentation') }}</a></li>
-            <li><a href="https://support.mozilla.org/kb/where-find-release-notes-firefox-enterprise/{{ utm_params }}">{{ _('Release Notes') }}</a></li>
-            <li><a href="https://support.mozilla.org/products/firefox-enterprise/{{ utm_params }}">{{ _('Documentation and Community Support') }}</a></li>
-          </ul>
+          <div class="enterprise-download-support">
+            <h4 class="enterprise-download-subtitle">{{ _('Support') }}</h4>
+            <ul class="mzp-u-list-styled">
+              <li><a href="https://support.mozilla.org/kb/deploy-firefox-msi-installers/{{ utm_params }}">{{ _('MSI installers') }}</a></li>
+              <li><a href="https://support.mozilla.org/kb/legacy-browser-support-extension-windows/{{ utm_params }}">{{ _('Legacy browser support') }}</a></li>
+              <li><a href="https://support.mozilla.org/kb/customizing-firefox-using-group-policy-windows/{{ utm_params }}">{{ _('ADMX templates') }}</a></li>
+              <li><a href="https://assets.mozilla.net/pdf/Firefox.for.Enterprise.Browser.Deployment.Guide.pdf">{{ _('Deployment guide') }}</a></li>
+              <li><a href="https://github.com/mozilla/policy-templates/blob/master/README.md">{{ _('Policy documentation') }}</a></li>
+              <li><a href="https://support.mozilla.org/kb/where-find-release-notes-firefox-enterprise/{{ utm_params }}">{{ _('Release Notes') }}</a></li>
+              <li><a href="https://support.mozilla.org/products/firefox-enterprise/{{ utm_params }}">{{ _('Documentation and Community Support') }}</a></li>
+            </ul>
+          </div>
         </section>
 
-        <section class="enterprise-download-block">
-          <div class="enterprise-download-header">
-            <h3 class="enteprise-download-title platform-mac">{{ _('macOS') }}</h3>
+        <section class="enterprise-download-block platform-mac">
+          <h3 class="enterprise-download-title">{{ _('macOS') }}</h3>
 
-            <div class="mzp-c-menu-list mzp-t-cta mzp-t-download" id="mac-download-list">
-              <h4 class="mzp-c-menu-list-title">{{ _('Select your download') }}</h4>
-              <ul class="mzp-c-menu-list-list">
-                <li class="mzp-c-menu-list-item"><a href="https://download.mozilla.org/?product=firefox-latest-ssl&os=osx&lang={{ LANG }}">{{ _('Firefox browser') }}</a></li>
-                <li class="mzp-c-menu-list-item"><a href="https://download.mozilla.org/?product=firefox-esr-latest-ssl&os=osx&lang={{ LANG }}">{{ _('Firefox Extended Support Release (ESR)') }}</a></li>
-              </ul>
-            </div>
+          <div class="mzp-c-menu-list mzp-t-cta mzp-t-download" id="mac-download-list">
+            <h4 class="mzp-c-menu-list-title">{{ _('Select your download') }}</h4>
+            <ul class="mzp-c-menu-list-list">
+              <li class="mzp-c-menu-list-item"><a href="https://download.mozilla.org/?product=firefox-latest-ssl&os=osx&lang={{ LANG }}">{{ _('Firefox browser') }}</a></li>
+              <li class="mzp-c-menu-list-item"><a href="https://download.mozilla.org/?product=firefox-esr-latest-ssl&os=osx&lang={{ LANG }}">{{ _('Firefox Extended Support Release (ESR)') }}</a></li>
+            </ul>
           </div>
 
-          <h4 class="enteprise-download-subtitle">{{ _('Support') }}</h4>
-          <ul class="mzp-u-list-styled">
-            <li>{{ _('Sample <a href="%s">plist for configuration profile</a>')|format('https://github.com/mozilla/policy-templates/blob/master/mac/org.mozilla.firefox.plist') }}</li>
-            <li><a href="https://support.mozilla.org/kb/deploying-firefox-macos-using-pkg-and-jamf/{{ utm_params }}">{{ _('PKG installer') }}</a></li>
-            <li><a href="https://assets.mozilla.net/pdf/Firefox.for.Enterprise.Browser.Deployment.Guide.pdf">{{ _('Deployment guide') }}</a></li>
-            <li><a href="https://github.com/mozilla/policy-templates/blob/master/README.md">{{ _('Policy documentation') }}</a></li>
-            <li><a href="https://support.mozilla.org/kb/where-find-release-notes-firefox-enterprise/{{ utm_params }}">{{ _('Release Notes') }}</a></li>
-            <li><a href="https://support.mozilla.org/products/firefox-enterprise/{{ utm_params }}">{{ _('Documentation and Community Support') }}</a></li>
-          </ul>
+          <div class="enterprise-download-support">
+            <h4 class="enterprise-download-subtitle">{{ _('Support') }}</h4>
+            <ul class="mzp-u-list-styled">
+              <li>{{ _('Sample <a href="%s">plist for configuration profile</a>')|format('https://github.com/mozilla/policy-templates/blob/master/mac/org.mozilla.firefox.plist') }}</li>
+              <li><a href="https://support.mozilla.org/kb/deploying-firefox-macos-using-pkg-and-jamf/{{ utm_params }}">{{ _('PKG installer') }}</a></li>
+              <li><a href="https://assets.mozilla.net/pdf/Firefox.for.Enterprise.Browser.Deployment.Guide.pdf">{{ _('Deployment guide') }}</a></li>
+              <li><a href="https://github.com/mozilla/policy-templates/blob/master/README.md">{{ _('Policy documentation') }}</a></li>
+              <li><a href="https://support.mozilla.org/kb/where-find-release-notes-firefox-enterprise/{{ utm_params }}">{{ _('Release Notes') }}</a></li>
+              <li><a href="https://support.mozilla.org/products/firefox-enterprise/{{ utm_params }}">{{ _('Documentation and Community Support') }}</a></li>
+            </ul>
+          </div>
         </section>
 
-        <section class="enterprise-download-block">
-          <div class="enterprise-download-header">
-            <h3 class="enteprise-download-title platform-win32">{{ _('Windows 32-bit') }}</h3>
+        <section class="enterprise-download-block platform-win32">
+          <h3 class="enterprise-download-title">{{ _('Windows 32-bit') }}</h3>
 
-            <div class="mzp-c-menu-list mzp-t-cta mzp-t-download" id="win32-download-list">
-              <h4 class="mzp-c-menu-list-title">{{ _('Select your download') }}</h4>
-              <ul class="mzp-c-menu-list-list">
-                <li class="mzp-c-menu-list-item"><a href="https://download.mozilla.org/?product=firefox-latest-ssl&os=win&lang={{ LANG }}">{{ _('Firefox browser') }}</a></li>
-                <li class="mzp-c-menu-list-item"><a href="https://download.mozilla.org/?product=firefox-msi-latest-ssl&os=win&lang={{ LANG }}">{{ _('Firefox browser - MSI installer') }}</a></l>
-                <li class="mzp-c-menu-list-item"><a href="https://download.mozilla.org/?product=firefox-esr-latest-ssl&os=win&lang={{ LANG }}">{{ _('Firefox Extended Support Release (ESR)') }}</a></li>
-                <li class="mzp-c-menu-list-item"><a href="https://download.mozilla.org/?product=firefox-esr-msi-latest-ssl&os=win&lang={{ LANG }}">{{ _('Firefox Extended Support Release (ESR) - MSI installer') }}</a></l>
-              </ul>
-            </div>
+          <div class="mzp-c-menu-list mzp-t-cta mzp-t-download" id="win32-download-list">
+            <h4 class="mzp-c-menu-list-title">{{ _('Select your download') }}</h4>
+            <ul class="mzp-c-menu-list-list">
+              <li class="mzp-c-menu-list-item"><a href="https://download.mozilla.org/?product=firefox-latest-ssl&os=win&lang={{ LANG }}">{{ _('Firefox browser') }}</a></li>
+              <li class="mzp-c-menu-list-item"><a href="https://download.mozilla.org/?product=firefox-msi-latest-ssl&os=win&lang={{ LANG }}">{{ _('Firefox browser - MSI installer') }}</a></l>
+              <li class="mzp-c-menu-list-item"><a href="https://download.mozilla.org/?product=firefox-esr-latest-ssl&os=win&lang={{ LANG }}">{{ _('Firefox Extended Support Release (ESR)') }}</a></li>
+              <li class="mzp-c-menu-list-item"><a href="https://download.mozilla.org/?product=firefox-esr-msi-latest-ssl&os=win&lang={{ LANG }}">{{ _('Firefox Extended Support Release (ESR) - MSI installer') }}</a></l>
+            </ul>
           </div>
 
-          <h4 class="enteprise-download-subtitle">{{ _('Support') }}</h4>
-          <ul class="mzp-u-list-styled">
-            <li><a href="https://support.mozilla.org/kb/deploy-firefox-msi-installers/{{ utm_params }}">{{ _('MSI installers') }}</a></li>
-            <li><a href="https://support.mozilla.org/kb/legacy-browser-support-extension-windows/{{ utm_params }}">{{ _('Legacy browser support') }}</a></li>
-            <li><a href="https://support.mozilla.org/kb/customizing-firefox-using-group-policy-windows/{{ utm_params }}">{{ _('ADMX templates') }}</a></li>
-            <li><a href="https://assets.mozilla.net/pdf/Firefox.for.Enterprise.Browser.Deployment.Guide.pdf">{{ _('Deployment guide') }}</a></li>
-            <li><a href="https://github.com/mozilla/policy-templates/blob/master/README.md">{{ _('Policy documentation') }}</a></li>
-            <li><a href="https://support.mozilla.org/kb/where-find-release-notes-firefox-enterprise/{{ utm_params }}">{{ _('Release Notes') }}</a></li>
-            <li><a href="https://support.mozilla.org/products/firefox-enterprise/{{ utm_params }}">{{ _('Documentation and Community Support') }}</a></li>
-          </ul>
+          <div class="enterprise-download-support">
+            <h4 class="enterprise-download-subtitle">{{ _('Support') }}</h4>
+            <ul class="mzp-u-list-styled">
+              <li><a href="https://support.mozilla.org/kb/deploy-firefox-msi-installers/{{ utm_params }}">{{ _('MSI installers') }}</a></li>
+              <li><a href="https://support.mozilla.org/kb/legacy-browser-support-extension-windows/{{ utm_params }}">{{ _('Legacy browser support') }}</a></li>
+              <li><a href="https://support.mozilla.org/kb/customizing-firefox-using-group-policy-windows/{{ utm_params }}">{{ _('ADMX templates') }}</a></li>
+              <li><a href="https://assets.mozilla.net/pdf/Firefox.for.Enterprise.Browser.Deployment.Guide.pdf">{{ _('Deployment guide') }}</a></li>
+              <li><a href="https://github.com/mozilla/policy-templates/blob/master/README.md">{{ _('Policy documentation') }}</a></li>
+              <li><a href="https://support.mozilla.org/kb/where-find-release-notes-firefox-enterprise/{{ utm_params }}">{{ _('Release Notes') }}</a></li>
+              <li><a href="https://support.mozilla.org/products/firefox-enterprise/{{ utm_params }}">{{ _('Documentation and Community Support') }}</a></li>
+            </ul>
+          </div>
         </section>
       </div>
 

--- a/media/css/firefox/enterprise/landing.scss
+++ b/media/css/firefox/enterprise/landing.scss
@@ -186,20 +186,70 @@ html {
     @media #{$mq-md} {
         .enterprise-download-lists {
             display: grid;
-            grid-gap: 0 $spacing-2xl;
+            grid-column-gap: $layout-md;
             grid-template-columns: repeat(3, 1fr);
-            margin-bottom: $spacing-2xl;
+            grid-template-areas:
+                'title-col1    title-col2    title-col3'
+                'list-col1     list-col2     list-col3'
+                'support-col1  support-col2  support-col3';
+            margin-bottom: $layout-md;
         }
+
+        .enterprise-download-block {
+            display: contents;
+            margin-bottom: 0;
+        }
+
+        .platform-win64 {
+            .enterprise-download-title {
+                grid-area: title-col1;
+            }
+
+            .mzp-c-menu-list {
+                grid-area: list-col1;
+            }
+
+            .enterprise-download-support {
+                grid-area: support-col1;
+            }
+        }
+
+        .platfom-mac {
+            .enterprise-download-title {
+                grid-area: title-col2;
+            }
+
+            .mzp-c-menu-list {
+                grid-area: list-col2;
+            }
+
+            .enterprise-download-support {
+                grid-area: support-col2;
+            }
+        }
+
+        .platform-win32 {
+            .enterprise-download-title {
+                grid-area: title-col3;
+            }
+
+            .mzp-c-menu-list {
+                grid-area: list-col3;
+            }
+
+            .enterprise-download-support {
+                grid-area: support-col3;
+            }
+        }
+
     }
 }
 
-.enterprise-download-header {
-    padding: 0 0 $spacing-xl;
-    margin: 0 0 $spacing-xl;
-    border-bottom: 1px solid $color-marketing-gray-30;
+.enterprise-download-block {
+    margin-bottom: $layout-lg;
 }
 
-.enteprise-download-title {
+.enterprise-download-title {
     @include bidi((
         (padding-left, $layout-lg, 0),
         (padding-right, 0, $layout-lg),
@@ -221,23 +271,29 @@ html {
         width: 48px;
     }
 
-    &.platform-win64:before {
+    .platform-win64 &:before {
         background-image: url('/media/img/firefox/enterprise/icon-win64.svg');
         background-size: 39px 40px;
     }
 
-    &.platform-mac:before {
+    .platform-mac &:before {
         background-image: url('/media/img/firefox/enterprise/icon-mac.svg');
         background-size: 32px 40px;
     }
 
-    &.platform-win32:before {
+    .platform-win32 &:before {
         background-image: url('/media/img/firefox/enterprise/icon-win32.svg');
         background-size: 39px 40px;
     }
 }
 
-.enteprise-download-subtitle {
+.enterprise-download-support {
+    padding-top: $spacing-xl;
+    margin-top: $spacing-xl;
+    border-top: 1px solid $color-marketing-gray-30;
+}
+
+.enterprise-download-subtitle {
     @include text-display-xxs;
 }
 

--- a/tests/functional/firefox/test_enterprise.py
+++ b/tests/functional/firefox/test_enterprise.py
@@ -14,8 +14,11 @@ def test_primary_download_button_displayed(base_url, selenium):
 
 
 @pytest.mark.nondestructive
-def test_download_lists_displayed(base_url, selenium):
+def test_download_lists(base_url, selenium):
     page = EnterprisePage(selenium, base_url).open()
-    assert page.is_win64_download_list_displayed
-    assert page.is_win32_download_list_displayed
-    assert page.is_mac_download_list_displayed
+    page.win64_download_list.click()
+    assert page.win64_download_list.list_is_open
+    page.win32_download_list.click()
+    assert page.win32_download_list.list_is_open
+    page.mac_download_list.click()
+    assert page.mac_download_list.list_is_open

--- a/tests/pages/firefox/enterprise/landing.py
+++ b/tests/pages/firefox/enterprise/landing.py
@@ -5,6 +5,7 @@
 from selenium.webdriver.common.by import By
 
 from pages.firefox.base import FirefoxBasePage
+from pages.regions.menu_list import MenuList
 
 
 class EnterprisePage(FirefoxBasePage):
@@ -12,22 +13,25 @@ class EnterprisePage(FirefoxBasePage):
     URL_TEMPLATE = '/{locale}/firefox/enterprise/'
 
     _primary_download_button_locator = (By.ID, 'primary-download-button')
-    _win64_download_list_locator = (By.CSS_SELECTOR, '#win64-download-list.is-details')
-    _win32_download_list_locator = (By.CSS_SELECTOR, '#win32-download-list.is-details')
-    _mac_download_list_locator = (By.CSS_SELECTOR, '#mac-download-list.is-details')
+    _win64_download_list_locator = (By.ID, 'win64-download-list')
+    _win32_download_list_locator = (By.ID, 'win32-download-list')
+    _mac_download_list_locator = (By.ID, 'mac-download-list')
 
     @property
     def is_primary_download_button_displayed(self):
         return self.is_element_displayed(*self._primary_download_button_locator)
 
     @property
-    def is_win64_download_list_displayed(self):
-        return self.is_element_displayed(*self._win64_download_list_locator)
+    def win64_download_list(self):
+        el = self.find_element(*self._win64_download_list_locator)
+        return MenuList(self, root=el)
 
     @property
-    def is_win32_download_list_displayed(self):
-        return self.is_element_displayed(*self._win32_download_list_locator)
+    def win32_download_list(self):
+        el = self.find_element(*self._win32_download_list_locator)
+        return MenuList(self, root=el)
 
     @property
-    def is_mac_download_list_displayed(self):
-        return self.is_element_displayed(*self._mac_download_list_locator)
+    def mac_download_list(self):
+        el = self.find_element(*self._mac_download_list_locator)
+        return MenuList(self, root=el)


### PR DESCRIPTION
## Description
These were some improvements suggested in code review on https://github.com/mozilla/bedrock/pull/8722 but we punted them at the time so we could get the essential page updates live. Finally following up now.

## Testing
http://localhost:8000/firefox/enterprise/

- [ ] Do the download lists align horizontally at various breakpoints?
- [ ] Do the tests pass?