### PR TITLE
Display 4 cards in 3rd row of EN homepage if there are 17 cards (#8744)

### DIFF
--- a/bedrock/mozorg/templates/mozorg/home/home-en.html
+++ b/bedrock/mozorg/templates/mozorg/home/home-en.html
@@ -103,10 +103,19 @@
         include_highres_image=True
       )}}
 
-      <div class="mzp-l-card-half">
-        {{ content_card('card_6') }}
-        {{ content_card('card_7') }}
-      </div>
+      {% if get_content_card(content_cards or page_content_cards, 'card_17') %}
+        <div class="mzp-l-card-quarter">
+          {{ content_card('card_14') }}
+          {{ content_card('card_15') }}
+          {{ content_card('card_16') }}
+          {{ content_card('card_17') }}
+        </div>
+      {% else %}
+        <div class="mzp-l-card-half">
+          {{ content_card('card_6') }}
+          {{ content_card('card_7') }}
+        </div>
+      {% endif %}
     </div>
 
     {% if switch('show_pocket_feed', ['en']) and pocket_articles %}


### PR DESCRIPTION
## Description

Temporarily moving from 2 two 4 cards in the row above the pocket recommendations. This change will check to see if there are 17 cards and change the layout accordingly.

Because of the difference in card sizes between the 2 and 4 card layout the conditional row will not use the card 6 and 7 data.

This means the change here and the change in www-admin are independent of each other. Either change can go first

## Issue / Bugzilla link

Fix #8744

## Testing

- Up on [demo3](https://www-demo3.allizom.org/en-US/) and pulling all 17 cards from www-admin. 
- Other demos have 17 cards of data but not the new homepage file.
- Pushing master to the `dev` branch of www-admin will trigger the state where demo3 has updated homepage code but not updated content cards.