### PR TITLE
Small debugging improvement for release notes update

### DIFF
--- a/bedrock/releasenotes/management/commands/update_release_notes.py
+++ b/bedrock/releasenotes/management/commands/update_release_notes.py
@@ -21,7 +21,7 @@ class Command(BaseCommand):
         repo = GitRepo(settings.RELEASE_NOTES_PATH, settings.RELEASE_NOTES_REPO,
                        branch_name=settings.RELEASE_NOTES_BRANCH, name='Release Notes')
         self.output('Updating git repo')
-        repo.update()
+        self.output(repo.update())
         if not (options['force'] or repo.has_changes()):
             self.output('No release note updates')
             return

--- a/bin/cron.py
+++ b/bin/cron.py
@@ -73,7 +73,7 @@ class scheduled_job:
             raise
         else:
             set_updated_time(self.name)
-            self.log('finished successfully')
+            self.log('finished successfully\n')
 
     def log(self, message):
         msg = '[{}] Clock job {}@{}: {}'.format(

--- a/bin/cron.py
+++ b/bin/cron.py
@@ -73,7 +73,7 @@ class scheduled_job:
             raise
         else:
             set_updated_time(self.name)
-            self.log('finished successfully\n')
+            self.log('finished successfully')
 
     def log(self, message):
         msg = '[{}] Clock job {}@{}: {}'.format(

--- a/bin/run-db-upload.py
+++ b/bin/run-db-upload.py
@@ -85,10 +85,10 @@ def main(args):
     prev_data = get_prev_db_data()
     new_data = get_db_data()
     if not force and prev_data and prev_data['checksum'] == new_data['checksum']:
-        print('No update necessary\n')
+        print('No update necessary')
         return 0
 
-    print('Attempting a db update\n')
+    print('Attempting a db update')
 
     set_db_data(new_data)
     if '--no-upload' in args:

--- a/bin/run-db-upload.py
+++ b/bin/run-db-upload.py
@@ -85,8 +85,10 @@ def main(args):
     prev_data = get_prev_db_data()
     new_data = get_db_data()
     if not force and prev_data and prev_data['checksum'] == new_data['checksum']:
-        print('No update necessary')
+        print('No update necessary\n')
         return 0
+
+    print('Attempting a db update\n')
 
     set_db_data(new_data)
     if '--no-upload' in args:


### PR DESCRIPTION
## Description
We've had a few instances in dev of bedrock not being updated with release notes.
Adds a success message in the run-upload-db.py file, and adding newlines to both skips and successes.
Non-quiet release notes jobs will output the current hashes, and new hash, which should help debugging.

## Issue / Bugzilla link

## Testing
* clock container logs should be a little easier to read
* update_release_notes_job should have an additional log line (container script may not show this, as it has the quiet flag passed).