### PR TITLE
[no bug] update 'meet the firefox family' link to got to firefox home

### DIFF
--- a/bedrock/mozorg/templates/mozorg/home/includes/macros.html
+++ b/bedrock/mozorg/templates/mozorg/home/includes/macros.html
@@ -61,7 +61,7 @@
       <p class="c-primary-cta-desc">{{ desc }}</p>
       {%- endif -%}
       <p class="c-primary-cta-button">
-        <a data-link-name="{{ link_cta }}" data-link-type="button" data-cta-position="primary cta" href="{{ url('firefox.accounts') }}" class="mzp-c-button mzp-t-product" id="fxa-learn-primary">{{ link_cta }}</a>
+        <a data-link-name="{{ link_cta }}" data-link-type="button" data-cta-position="primary cta" href="{{ url('firefox') }}" class="mzp-c-button mzp-t-product" id="fxa-learn-primary">{{ link_cta }}</a>
       </p>
     </div>
   </div>


### PR DESCRIPTION
## Description

Update 'meet the firefox family' link to got to firefox home page.

## Issue / Bugzilla link

n/a (discussed this with the brand team and it has been okayed)

## Testing

Visit http://localhost:8000/en-US/ in Firefox and check that the "meet the family" button goes to the Firefox homepage.
