### PR TITLE
Add Download string to download_button.ftl (#8657)

### DIFF
--- a/bedrock/firefox/templates/firefox/channel/android.html
+++ b/bedrock/firefox/templates/firefox/channel/android.html
@@ -36,7 +36,7 @@
     desc=_('Try the latest Android features, before they get released to the rest of the world.'),
     class='mzp-t-product-beta mzp-t-firefox') %}
 
-    {{ download_firefox('beta', platform='android', alt_copy=_('Download'), dom_id="android-beta-download") }}
+    {{ download_firefox('beta', platform='android', alt_copy=ftl('download-button-download'), dom_id="android-beta-download") }}
   {% endcall %}
 
   <div class="l-notes mzp-l-content">
@@ -78,7 +78,7 @@
     desc=_('Check out new Android features in their earliest stages. Enjoy at your own risk.'),
     class='mzp-t-product-nightly mzp-t-firefox') %}
 
-    {{ download_firefox('nightly', platform='android', alt_copy=_('Download'), dom_id="android-nightly-download") }}
+    {{ download_firefox('nightly', platform='android', alt_copy=ftl('download-button-download'), dom_id="android-nightly-download") }}
   {% endcall %}
 
   <div class="l-notes mzp-l-content">

--- a/bedrock/firefox/templates/firefox/channel/desktop.html
+++ b/bedrock/firefox/templates/firefox/channel/desktop.html
@@ -31,7 +31,7 @@
     desc=_('Test about-to-be-released features in the most stable pre-release build.'),
     class='mzp-t-product-beta mzp-t-firefox') %}
 
-    {{ download_firefox('beta', platform='desktop', force_direct=True, alt_copy=_('Download'), dom_id="desktop-beta-download") }}
+    {{ download_firefox('beta', platform='desktop', force_direct=True, alt_copy=ftl('download-button-download'), dom_id="desktop-beta-download") }}
   {% endcall %}
 
   <div class="l-notes mzp-l-content">
@@ -72,7 +72,7 @@
     desc=_('Build, test, scale and more with the only browser built just for developers.'),
     class='mzp-t-product-developer mzp-t-firefox') %}
 
-    {{ download_firefox('alpha', platform='desktop', force_direct=True, alt_copy=_('Download'), dom_id="desktop-developer-download") }}
+    {{ download_firefox('alpha', platform='desktop', force_direct=True, alt_copy=ftl('download-button-download'), dom_id="desktop-developer-download") }}
   {% endcall %}
   </section>
 
@@ -111,7 +111,7 @@
       desc=_('Get a sneak peek at our next generation web browser, and help us make it the best browser it can be: try Firefox Nightly.'),
       class='mzp-t-product-nightly mzp-t-firefox') %}
 
-      {{ download_firefox('nightly', platform='desktop', force_direct=True, alt_copy=_('Download'), dom_id="desktop-nightly-download") }}
+      {{ download_firefox('nightly', platform='desktop', force_direct=True, alt_copy=ftl('download-button-download'), dom_id="desktop-nightly-download") }}
     {% endcall %}
   {% else %}
     {% call call_out_compact(
@@ -119,7 +119,7 @@
       desc=_('Test brand new features daily (or… nightly). Enjoy at your own risk.'),
       class='mzp-t-product-nightly mzp-t-firefox') %}
 
-      {{ download_firefox('nightly', platform='desktop', force_direct=True, alt_copy=_('Download'), dom_id="desktop-nightly-download") }}
+      {{ download_firefox('nightly', platform='desktop', force_direct=True, alt_copy=ftl('download-button-download'), dom_id="desktop-nightly-download") }}
     {% endcall %}
   {% endif %}
 

--- a/bedrock/firefox/templates/firefox/enterprise/index.html
+++ b/bedrock/firefox/templates/firefox/enterprise/index.html
@@ -49,7 +49,7 @@
     </p>
     <div class="cta-container">
       <div class="mzp-c-button-download-container">
-        <a id="primary-download-button" href="#download" class="mzp-c-button mzp-t-product">{{ _('Download') }}</a>
+        <a id="primary-download-button" href="#download" class="mzp-c-button mzp-t-product">{{ ftl('download-button-download') }}</a>
         <a href="{{ url('privacy.notices.firefox') }}" class="mzp-c-button-download-privacy-link">{{ _('Firefox Privacy Notice') }}</a>
       </div>
     </div>

--- a/bedrock/firefox/templates/firefox/products/index.html
+++ b/bedrock/firefox/templates/firefox/products/index.html
@@ -56,7 +56,7 @@
       <h2 class="c-landing-grid-title "><a class="mzp-c-cta-link" href="{{ url('firefox.browsers.index') }}" data-cta-type="link" data-cta-text="Firefox browsers">{{ _('Firefox browsers') }}</a></h2>
       <p>{{ _('Get the browsers that block 2000+ data trackers automatically. Enhanced Tracking Protection comes standard in every Firefox browser.') }}</p>
       <div id="menu-browsers-wrapper" class="mzp-c-menu-list mzp-t-cta mzp-t-download">
-        <h3 class="mzp-c-menu-list-title">{{ _('Download') }}</h3>
+        <h3 class="mzp-c-menu-list-title">{{ ftl('download-button-download') }}</h3>
         <ul class="mzp-c-menu-list-list" id="menu-browsers">
           {# Old IE users need to click a download button, the JS on the thank you page doesn't get them the right download if we send them there directly #}
           <!--[if IE]>

--- a/l10n/en/download_button.ftl
+++ b/l10n/en/download_button.ftl
@@ -42,3 +42,4 @@ download-button-firefox-android = <span>{ -brand-name-firefox }</span> for { -br
 download-button-firefox-ios = <span>{ -brand-name-firefox }</span> for { -brand-name-ios }
 download-button-firefox-privacy = { -brand-name-firefox } Privacy
 download-button-firefox-privacy-notice = { -brand-name-firefox } Privacy Notice
+download-button-download = Download

--- a/lib/fluent_migrations/firefox/includes/download-button.py
+++ b/lib/fluent_migrations/firefox/includes/download-button.py
@@ -6,6 +6,7 @@ from fluent.migrate import REPLACE, COPY
 
 download_button = "firefox/includes/download-button.lang"
 download_button = "download_button.lang"
+main = "main.lang"
 
 def migrate(ctx):
     """Migrate bedrock/firefox/templates/firefox/includes/download-button.html, part {index}."""
@@ -241,3 +242,11 @@ download-button-recommended = {COPY(download_button, "Recommended",)}
             ),
         ]
     )
+
+    ctx.add_transforms(
+        "download_button.ftl",
+        "download_button.ftl",
+        transforms_from("""
+download-button-download = {COPY(main, "Download",)}
+""", main=main)
+        )


### PR DESCRIPTION
## Description
- Add missing "Download" string to `download_button.ftl` (migrated from `main.lang`).
- Update templates to use new fluent ID.

## Issue / Bugzilla link
#8657

## Testing
- `./manage.py fluent ftl lib/fluent_migrations/firefox/includes/download-button.py de fr`