### PR TITLE
Redirect /mobile to /firefox/mobile. (Fixes #8749)

### DIFF
--- a/bedrock/firefox/redirects.py
+++ b/bedrock/firefox/redirects.py
@@ -237,7 +237,10 @@ redirectpatterns = (
              '/{prod}/{vers}/{channel}notes/{page}'),
 
     # bug 767614 superceeded by bug 957711 and 1003718 and 1239960
-    redirect(r'^(mobile|fennec)/?$', 'firefox'),
+    redirect(r'^(fennec)/?$', 'firefox'),
+
+    # issue 8749
+    redirect(r'^(mobile)/?$', '/firefox/mobile/'),
 
     # bug 876668
     redirect(r'^mobile/customize(?:/.*)?$', '/firefox/mobile/'),

--- a/tests/redirects/map_globalconf.py
+++ b/tests/redirects/map_globalconf.py
@@ -753,7 +753,10 @@ URLS = flatten((
     # bug 961010
     url_test('/mobile/credits/credits-people-list.html', '/credits/'),
 
-    url_test('/{mobile,fennec}/', '/firefox/'),
+    url_test('/fennec/', '/firefox/'),
+
+    # issue 8749
+    url_test('/mobile/', '/firefox/mobile/'),
 
     # bug 876668
     url_test('/mobile/customize/', '/firefox/mobile/'),


### PR DESCRIPTION
## Description
Redirects /mobile to /firefox/mobile

## Issue / Bugzilla link
#8749