### PR TITLE
[fix #8761] Delete resources link from enterprise subnav

### DIFF
--- a/bedrock/firefox/templates/firefox/enterprise/index.html
+++ b/bedrock/firefox/templates/firefox/enterprise/index.html
@@ -32,7 +32,6 @@
         <ul class="c-sub-navigation-list">
           <li class="c-sub-navigation-item"><a href="#overview">{{ _('Overview') }}</a></li>
           <li class="c-sub-navigation-item"><a href="#download">{{ _('Downloads') }}</a></li>
-          <li class="c-sub-navigation-item"><a href="#resources">{{ _('Resources') }}</a></li>
         </ul>
       </div>
     </div>


### PR DESCRIPTION
## Description
The resources section was removed but I missed the link in the subnav.

## Issue / Bugzilla link
#8761 
