### PR TITLE
[no bug] Redirect browser comparison pages

### DIFF
--- a/bedrock/firefox/redirects.py
+++ b/bedrock/firefox/redirects.py
@@ -649,6 +649,11 @@ redirectpatterns = (
     redirect(r'^/firefox/windows-64-bit/?$', 'firefox.browsers.windows-64-bit'),
     redirect(r'^/firefox/best-browser/?$', 'firefox.browsers.best-browser'),
 
-    # issue 8765
-    redirect(r'^/firefox/browsers/compare/edge/?$', 'firefox.compare.index', permanent=False),
+    # issue 8765 - temporarily disable browser comparison pages
+    redirect(r'^/firefox/browsers/compare/?$', 'firefox', permanent=False),
+    redirect(r'^/firefox/browsers/compare/chrome/?$', 'firefox', permanent=False),
+    redirect(r'^/firefox/browsers/compare/edge/?$', 'firefox', permanent=False),
+    redirect(r'^/firefox/browsers/compare/ie/?$', 'firefox', permanent=False),
+    redirect(r'^/firefox/browsers/compare/opera/?$', 'firefox', permanent=False),
+    redirect(r'^/firefox/browsers/compare/safari/?$', 'firefox', permanent=False),
 )

--- a/tests/redirects/map_globalconf.py
+++ b/tests/redirects/map_globalconf.py
@@ -1346,5 +1346,10 @@ URLS = flatten((
     url_test('/etc/firefox/retention/{thank-you-a/,thank-you-b/,thank-you-referral/}', '/firefox/retention/thank-you/'),
 
     # Issue 8765
-    url_test('/firefox/browsers/compare/edge/', '/firefox/browsers/compare/', status_code=requests.codes.found),
+    url_test('/firefox/browsers/compare/', '/firefox/', status_code=requests.codes.found),
+    url_test('/firefox/browsers/compare/chrome/', '/firefox/', status_code=requests.codes.found),
+    url_test('/firefox/browsers/compare/edge/', '/firefox/', status_code=requests.codes.found),
+    url_test('/firefox/browsers/compare/ie/', '/firefox/', status_code=requests.codes.found),
+    url_test('/firefox/browsers/compare/opera/', '/firefox/', status_code=requests.codes.found),
+    url_test('/firefox/browsers/compare/safari/', '/firefox/', status_code=requests.codes.found),
 ))


### PR DESCRIPTION
## Description
Adds a 302 temporary redirect for all the browser comparison pages

## Testing
These should all redirect to /firefox

- [ ] http://localhost:8000/firefox/browsers/compare/
- [ ] http://localhost:8000/firefox/browsers/compare/chrome/
- [ ] http://localhost:8000/firefox/browsers/compare/edge/
- [ ] http://localhost:8000/firefox/browsers/compare/ie/
- [ ] http://localhost:8000/firefox/browsers/compare/opera/
- [ ] http://localhost:8000/firefox/browsers/compare/safari/