### PR TITLE
[fix #8771] Update independent features page copy

### DIFF
--- a/bedrock/firefox/templates/firefox/features/independent.html
+++ b/bedrock/firefox/templates/firefox/features/independent.html
@@ -34,12 +34,21 @@
       <div class="key-feature-content">
         <h2>{{ _('No strings attached') }}</h2>
         <p>
+      {% if l10n_has_tag('independent_042020') %}
+        {% trans %}
+          Firefox is built by a non-profit. That means we can do things that others
+          can’t, like build new products and features without a hidden agenda. We
+          champion your right to privacy with tools like Private Browsing with Tracking
+          Protection.
+        {% endtrans %}
+      {% else %}
         {% trans %}
           Firefox is built by a non-profit. That means we can do things that others
           can’t, like build new products and features without a hidden agenda. We
           champion your right to privacy with tools like Private Browsing with Tracking
           Protection, which go beyond what Google Chrome and Microsoft Edge offer.
         {% endtrans %}
+      {% endif %}
         </p>
       </div>
     </section>

--- a/bedrock/firefox/templates/firefox/features/index.html
+++ b/bedrock/firefox/templates/firefox/features/index.html
@@ -93,13 +93,15 @@
           <h3>{{ _('Browse faster') }}</h3>
         </a>
       </li>
-      {% if l10n_has_tag('firefox_features_compare_browsers') %}
-      <li class="features-list-item compare">
-        <a href="{{ url('firefox.compare.index') }}" data-link-type="link" data-link-name="Compare Browsers">
-          <h3>{{ _('Compare Browsers') }}</h3>
-        </a>
-      </li>
-      {% endif %}
+    {# Temporarily remove comparison pages
+     # {% if l10n_has_tag('firefox_features_compare_browsers') %}
+     # <li class="features-list-item compare">
+     #   <a href="{{ url('firefox.compare.index') }}" data-link-type="link" data-link-name="Compare Browsers">
+     #     <h3>{{ _('Compare Browsers') }}</h3>
+     #   </a>
+     # </li>
+     # {% endif %}
+     #}
     </ul>
   </div>
 </section>


### PR DESCRIPTION
## Description
Uses the l10n tag `independent_042020` (I'll submit a string update shortly).

## Issue / Bugzilla link
#8771 

## Testing
http://localhost:8000/firefox/features/independent/