### PR TITLE
Make running locally in prod mode easier

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,9 @@ build: .docker-build-pull
 	${DC} build --pull app assets
 	touch .docker-build
 
+build-prod: .docker-build-pull
+	${DC} build --pull release
+
 pull: .env submodules
 	-GIT_COMMIT= ${DC} pull release app assets builder app-base
 	touch .docker-build-pull
@@ -48,6 +51,9 @@ rebuild: clean build
 
 run: .docker-build-pull
 	${DC} up assets app
+
+run-prod: .docker-build-pull
+	${DC} up release
 
 stop:
 	${DC} stop
@@ -115,4 +121,4 @@ build-ci: .docker-build-pull
 test-ci: .docker-build-ci
 	${DC_CI} run test-image
 
-.PHONY: all clean build pull submodules docs lint run stop kill run-shell shell test test-image rebuild build-ci test-ci fresh-data djshell
+.PHONY: all clean build pull submodules docs lint run stop kill run-shell shell test test-image rebuild build-ci test-ci fresh-data djshell run-prod build-prod

--- a/bin/run-prod.sh
+++ b/bin/run-prod.sh
@@ -1,8 +1,16 @@
 #!/bin/bash -xe
-NEW_RELIC_CONFIG_FILE=newrelic.ini newrelic-admin run-program \
-gunicorn wsgi.app:application -b 0.0.0.0:${PORT:-8000} \
-                              -w ${WEB_CONCURRENCY:-2} \
-                              --error-logfile - \
-                              --access-logfile - \
-                              --log-level ${LOGLEVEL:-info} \
-                              --worker-class ${GUNICORN_WORKER_CLASS:-meinheld.gmeinheld.MeinheldWorker}
+
+function run-gunicorn () {
+    if [[ -z "$NEW_RELIC_LICENSE_KEY" ]]; then
+        gunicorn "$@"
+    else
+        NEW_RELIC_CONFIG_FILE=newrelic.ini newrelic-admin run-program gunicorn "$@"
+    fi
+}
+
+run-gunicorn wsgi.app:application -b 0.0.0.0:${PORT:-8000} \
+                                  -w ${WEB_CONCURRENCY:-2} \
+                                  --error-logfile - \
+                                  --access-logfile - \
+                                  --log-level ${LOGLEVEL:-info} \
+                                  --worker-class ${GUNICORN_WORKER_CLASS:-meinheld.gmeinheld.MeinheldWorker}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -79,6 +79,22 @@ services:
         GIT_SHA: ${GIT_COMMIT:-latest}
         BRANCH_NAME: ${BRANCH_NAME:-latest}
     image: mozorg/bedrock:${BRANCH_AND_COMMIT:-latest}
+    env_file: .env
+    ports:
+      - "8000:8000"
+    volumes:
+      - ./bedrock/:/app/bedrock:delegated
+      - ./bin/:/app/bin:delegated
+      - ./docker/:/app/docker:delegated
+      - ./etc/:/app/etc:delegated
+      - ./lib/:/app/lib:delegated
+      - ./root_files/:/app/root_files:delegated
+      - ./scripts/:/app/scripts:delegated
+      - ./vendor-local/:/app/vendor-local:delegated
+      - ./wsgi/:/app/wsgi:delegated
+      - ./locale/:/app/locale:delegated
+      - ./l10n/:/app/l10n:delegated
+      - ./git-repos/:/app/git-repos:delegated
 
   builder:
     build:

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -209,6 +209,33 @@ from the browsersync service. We've not seen issues with this, but since it is m
 could conflict with something on the page itself. Please let us know if you suspect this is happening for you. This notification
 can be disabled in the browsersync options in the ``gulpfile.js`` by setting ``notify: false`` in the ``browser-sync`` task.
 
+Prod Mode
+---------
+
+There are certain things about the site that behave differently when running locally in dev mode using Django's development
+server than they do when running in the way it runs in production. Static assets that work fine locally can be a problem
+in production if referenced improperly, and the normal error pages won't work unless ``DEBUG==False`` and doing that will
+make the site throw errors since the Django server doesn't have access to all of the built static assets. So we have a couple
+of extra Docker commands (via make) that you can use to run the site locally in a more prod-like way.
+
+First you should ensure that your ``.env`` file is setup the way you need. This usually means adding ``DEBUG=False``
+and ``DEV=False``, though you may want ``DEV=True`` if you want the site to act more like www-dev.allizom.org in that all
+feature switches are ``On`` and all locales are active for every page. After that you can run the following:
+
+.. code-block:: bash
+
+    $ make run-prod
+
+This will run the latest bedrock image using your local bedrock files and templates, but not your local static assets. If you
+need an updated image just run ``make pull``.
+
+If you need to include the changes you've made to your local static files (images, css, js, etc.) then you have to build the
+image first:
+
+.. code-block:: bash
+
+    $ make build-prod run-prod
+
 Legal Docs
 ==========
 


### PR DESCRIPTION
This will give us some commands to more easily build and run the prod Docker image locally. It will run using your local version of the Django app, but not the media, which must be built separately.

## Using

If you want to run things locally as if they're prod and see changes in templates or Python files you can simply:

```
make pull run-prod
```

That will pull the latest prod image and run it in prod mode locally. If you need to build new static assets (images, CSS, JS, etc.) then you can do:

```
make build-prod run-prod
```

Let me know what you think.

Re #8636