### PR TITLE
Migrate common UI strings from main.lang to Fluent (Fixes #8657)

### DIFF
--- a/bedrock/base/templates/base-pebbles.html
+++ b/bedrock/base/templates/base-pebbles.html
@@ -81,12 +81,9 @@
 
   <body {% if self.body_id() %}id="{% block body_id %}{% endblock %}" {% endif %}class="html-{{ DIR }} {% block body_class %}{% endblock %}" {% block body_attrs %}{% endblock %}>
     <div id="strings"
-      data-global-close="{{ _('Close') }}"
-      data-global-next="{{ _('Next') }}"
-      data-global-previous="{{ _('Previous') }}"
-      data-global-fx-out-of-date-banner-heading="{{ _('Your Firefox is out-of-date.') }}"
-      data-global-fx-out-of-date-banner-message="{{ _('Get the most recent version to keep browsing securely.') }}"
-      data-global-fx-out-of-date-banner-confirm="{{ _('Update Firefox') }}"
+      data-global-close="{{ ftl('ui-close') }}"
+      data-global-next="{{ ftl('ui-next') }}"
+      data-global-previous="{{ ftl('ui-previous') }}"
       {% block string_data %}{% endblock %}></div>
 
     {% block page_banner %}{% endblock %}

--- a/bedrock/base/templates/includes/banners/base.html
+++ b/bedrock/base/templates/includes/banners/base.html
@@ -3,7 +3,7 @@
  # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
 
 <aside class="c-banner hide-from-legacy-ie {% if class_name %}{{ class_name }}{% endif %}" id="page-banner">
-  <button type="button" class="c-banner-close" id="page-banner-close"><span>{{ _('Close') }}</span></button>
+  <button type="button" class="c-banner-close" id="page-banner-close"><span>{{ ftl('ui-close') }}</span></button>
   <div class="mzp-l-content">
     <h2 class="c-banner-title">
       {% block banner_title %}{% endblock %}

--- a/bedrock/base/templates/macros-protocol.html
+++ b/bedrock/base/templates/macros-protocol.html
@@ -137,7 +137,7 @@
         </div>
       </div>
       <figcaption>
-        <p>{% if desc %}{{ desc }}{% endif %} <a href="{{ link_url }}">{{ _('Learn more') }}</a></p>
+        <p>{% if desc %}{{ desc }}{% endif %} <a href="{{ link_url }}">{{ ftl('ui-learn-more') }}</a></p>
       </figcaption>
     </figure>
   </div>
@@ -228,7 +228,7 @@
 {% macro sidemenu_lists(arr, body_id='') -%}
   <nav class="mzp-c-sidemenu">
     <section class="mzp-c-sidemenu-summary mzp-js-toggle" aria-controls="sidebar-menu">
-      <h3 class="mzp-c-sidemenu-label">{{ _('Menu') }}</h3>
+      <h3 class="mzp-c-sidemenu-label">{{ ftl('ui-menu') }}</h3>
       <ul>
         <li>{{ arr[0][0][2]|e }}</li>
         {% for menu in arr %}

--- a/bedrock/base/templates/macros.html
+++ b/bedrock/base/templates/macros.html
@@ -111,7 +111,7 @@
               {% endif %}
                 {{ _('The intended recipient of the email or SMS must have consented.')}}
             {% endif %}
-            <a href="{{ url('privacy.notices.websites') }}#campaigns" class="more">{{ _('Learn more')}}</a>
+            <a href="{{ url('privacy.notices.websites') }}#campaigns" class="more">{{ ftl('ui-learn-more') }}</a>
           </p>
           <p class="legal email">
             {% if legal_note_email %}
@@ -119,7 +119,7 @@
             {% else %}
               {{ _('The intended recipient of the email must have consented.') }}
             {% endif %}
-            <a href="{{ url('privacy.notices.websites') }}#campaigns" class="more">{{ _('Learn more')}}</a>
+            <a href="{{ url('privacy.notices.websites') }}#campaigns" class="more">{{ ftl('ui-learn-more') }}</a>
           </p>
         </div>
         <div class="thank-you hidden">

--- a/bedrock/firefox/templates/firefox/all-unified.html
+++ b/bedrock/firefox/templates/firefox/all-unified.html
@@ -160,7 +160,7 @@
       <div class="mzp-l-sidebar">
         <nav class="mzp-c-sidemenu">
           <section class="mzp-c-sidemenu-summary mzp-js-toggle" aria-controls="sidebar-menu">
-            <h3 class="mzp-c-sidemenu-label">{{ _('Menu') }}</h3>
+            <h3 class="mzp-c-sidemenu-label">{{ ftl('ui-menu') }}</h3>
           </section>
           <section class="mzp-c-sidemenu-main" id="sidebar-menu">
             <h2 class="mzp-c-sidemenu-title">{{ _('Which browser would you like to download?') }}</h2>

--- a/bedrock/firefox/templates/firefox/browsers/index.html
+++ b/bedrock/firefox/templates/firefox/browsers/index.html
@@ -53,7 +53,7 @@
         <!--<![endif]-->
       </p>
 
-      <p><a class="mzp-c-cta-link" href="{{ url('firefox.new') }}" data-cta-type="link" data-cta-text="Desktop Learn More">{{ _('Learn more') }}</a></p>
+      <p><a class="mzp-c-cta-link" href="{{ url('firefox.new') }}" data-cta-type="link" data-cta-text="Desktop Learn More">{{ ftl('ui-learn-more') }}</a></p>
     </div>
     <div class="c-landing-grid-item">
       {{ high_res_img('img/firefox/browsers/mobile.jpg', {'alt': '', 'class': 'c-landing-grid-img', 'width': '327', 'height': '223'}) }}
@@ -76,20 +76,20 @@
           <li class="mzp-c-menu-list-item t-getapp"><a href="{{ url('firefox.mobile.get-app') }}" data-cta-type="link" data-cta-text="Get App Mobile">{{ _('Send me a link') }}</a></li>
         </ul>
       </div>
-      <p><a class="mzp-c-cta-link" href="{{ url('firefox.mobile.index') }}" data-cta-type="link" data-cta-text="Moblie Learn More">{{ _('Learn more') }}</a></p>
+      <p><a class="mzp-c-cta-link" href="{{ url('firefox.mobile.index') }}" data-cta-type="link" data-cta-text="Moblie Learn More">{{ ftl('ui-learn-more') }}</a></p>
     </div>
     <div class="c-landing-grid-item">
       {{ high_res_img('img/firefox/browsers/enterprise.jpg', {'alt': '', 'class': 'c-landing-grid-img', 'width': '327', 'height': '223'}) }}
       <h2 class="c-landing-grid-title"><a href="{{ url('firefox.enterprise.index') }}" data-cta-type="link" data-cta-text="Enterprise">{{ _('Enterprise') }}</a></h2>
       <p>{{ _('Get unmatched data protection with support cycles tailored to suit your company’s needs.') }}</p>
       <p><a class="mzp-c-cta-link" href="{{ url('firefox.enterprise.index') }}#download" data-cta-type="link" data-cta-text="Enterprise packages">{{ _('Enterprise packages') }}</a></p>
-      <p><a class="mzp-c-cta-link" href="{{ url('firefox.enterprise.index') }}" data-cta-type="link" data-cta-text="Enterprise Learn More">{{ _('Learn more') }}</a></p>
+      <p><a class="mzp-c-cta-link" href="{{ url('firefox.enterprise.index') }}" data-cta-type="link" data-cta-text="Enterprise Learn More">{{ ftl('ui-learn-more') }}</a></p>
     </div>
     <div class="c-landing-grid-item">
       {{ high_res_img('img/firefox/browsers/reality.jpg', {'alt': '', 'class': 'c-landing-grid-img', 'width': '327', 'height': '223'}) }}
       <h2 class="c-landing-grid-title"><a href="https://mixedreality.mozilla.org/firefox-reality{{ referrals }}" data-cta-type="link" data-cta-text="Reality">{{ _('Reality') }}</a></h2>
       <p>{{ _('Go beyond two dimensions and enjoy the best immersive content from around the web.') }}</p>
-      <p><a class="mzp-c-cta-link" href="https://mixedreality.mozilla.org/firefox-reality{{ referrals }}" data-cta-type="link" data-cta-text="Reality Learn More">{{ _('Learn more') }}</a></p>
+      <p><a class="mzp-c-cta-link" href="https://mixedreality.mozilla.org/firefox-reality{{ referrals }}" data-cta-type="link" data-cta-text="Reality Learn More">{{ ftl('ui-learn-more') }}</a></p>
     </div>
     <div class="c-landing-grid-item c-landing-grid-wide">
       <div class="t-dev">

--- a/bedrock/firefox/templates/firefox/channel/android.html
+++ b/bedrock/firefox/templates/firefox/channel/android.html
@@ -60,7 +60,7 @@
         {% endtrans %}
       {% else %}
         {{_('Firefox Beta automatically sends feedback to Mozilla.')}}
-        <a href="{{ url('privacy.notices.firefox') + '#pre-release' }}">{{_('Learn more')}}</a>
+        <a href="{{ url('privacy.notices.firefox') + '#pre-release' }}">{{ ftl('ui-learn-more') }}</a>
       {% endif %}
     </p>
     <p>
@@ -94,7 +94,7 @@
       {% endtrans %}
     {% else %}
       {{_('Firefox Nightly automatically sends feedback to Mozilla.')}}
-      <a href="{{ url('privacy.notices.firefox') + '#pre-release' }}">{{_('Learn more')}}</a>
+      <a href="{{ url('privacy.notices.firefox') + '#pre-release' }}">{{ ftl('ui-learn-more') }}</a>
     {% endif %}
   </div>
 </section>

--- a/bedrock/firefox/templates/firefox/channel/desktop.html
+++ b/bedrock/firefox/templates/firefox/channel/desktop.html
@@ -55,7 +55,7 @@
         {% endtrans %}
       {% else %}
         {{_('Firefox Beta automatically sends feedback to Mozilla.')}}
-        <a href="{{ url('privacy.notices.firefox') + '#pre-release' }}">{{_('Learn more')}}</a>
+        <a href="{{ url('privacy.notices.firefox') + '#pre-release' }}">{{ ftl('ui-learn-more') }}</a>
       {% endif %}
     </p>
     <p>
@@ -79,7 +79,7 @@
   <div class="l-notes mzp-l-content">
     <ul>
       <li><a href="{{ firefox_url('desktop', 'notes', 'developer') }}">{{_('Release Notes')}}</a></li>
-      <li><a href="{{ url('firefox.developer.index') }}">{{_('Learn more')}}</a></li>
+      <li><a href="{{ url('firefox.developer.index') }}">{{ ftl('ui-learn-more') }}</a></li>
       <li>
         <a href="{{ firefox_url('desktop', 'all', 'developer') }}">
         {% if l10n_has_tag('firefox_channel_bug1387466') %}
@@ -98,7 +98,7 @@
       {%- endtrans -%}
     {% else %}
       {{_('Firefox Developer Edition automatically sends feedback to Mozilla.')}}
-      <a href="{{ url('privacy.notices.firefox') + '#pre-release' }}">{{_('Learn more')}}</a>
+      <a href="{{ url('privacy.notices.firefox') + '#pre-release' }}">{{ ftl('ui-learn-more') }}</a>
     {% endif %}
     </p>
   </div>
@@ -145,7 +145,7 @@
         {% endtrans %}
       {% else %}
         {{_('Firefox Nightly automatically sends feedback to Mozilla.')}}
-        <a href="{{ url('privacy.notices.firefox') + '#pre-release' }}">{{_('Learn more')}}</a>
+        <a href="{{ url('privacy.notices.firefox') + '#pre-release' }}">{{ ftl('ui-learn-more') }}</a>
       {% endif %}
     </p>
   </div>

--- a/bedrock/firefox/templates/firefox/channel/ios.html
+++ b/bedrock/firefox/templates/firefox/channel/ios.html
@@ -33,7 +33,7 @@
 
     <a href="{{ url('firefox.ios.testflight') }}" class="mzp-c-button mzp-t-product testflight-cta">{{_('Sign up now')}}</a>
     <small class="learn-more">
-      <a href="{{ url('firefox.mobile.index') }}">{{_('Learn more')}}</a>
+      <a href="{{ url('firefox.mobile.index') }}">{{ ftl('ui-learn-more') }}</a>
     </small>
   {% endcall %}
 </section>

--- a/bedrock/firefox/templates/firefox/developer/includes/highlights.html
+++ b/bedrock/firefox/templates/firefox/developer/includes/highlights.html
@@ -15,7 +15,7 @@
           hint about how to fix the problem.
         {% endtrans %}
         </p>
-        <p><a class="mzp-c-cta-link" rel="external" href="https://hacks.mozilla.org/2019/10/firefox-70-a-bountiful-release-for-all/#developertools">{{ _('Learn more') }}</a></p>
+        <p><a class="mzp-c-cta-link" rel="external" href="https://hacks.mozilla.org/2019/10/firefox-70-a-bountiful-release-for-all/#developertools">{{ ftl('ui-learn-more') }}</a></p>
       </div>
     {% endif %}
     <div class="c-gallery-item" id="devtools">
@@ -31,7 +31,7 @@
         can target multiple browsers and is built in React and Redux.
       {% endtrans %}
       </p>
-      <p><a class="mzp-c-cta-link" rel="external" href="https://mozilladevelopers.github.io/playground/debugger/">{{ _('Learn more') }}</a></p>
+      <p><a class="mzp-c-cta-link" rel="external" href="https://mozilladevelopers.github.io/playground/debugger/">{{ ftl('ui-learn-more') }}</a></p>
     </div>
 
     <div class="c-gallery-item" id="cssgrid">
@@ -48,7 +48,7 @@
         transformations on the grid and much more.
       {% endtrans %}
       </p>
-      <p><a class="mzp-c-cta-link" rel="external" href="https://mozilladevelopers.github.io/playground/css-grid/">{{ _('Learn more') }}</a></p>
+      <p><a class="mzp-c-cta-link" rel="external" href="https://mozilladevelopers.github.io/playground/css-grid/">{{ ftl('ui-learn-more') }}</a></p>
     </div>
 
     {% if l10n_has_tag('new_features_20180830') %}
@@ -76,7 +76,7 @@
             {% endtrans %}
           {% endif %}
           </p>
-          <p><a class="mzp-c-cta-link" rel="external" href="https://developer.mozilla.org/docs/Tools/Page_Inspector/How_to/Edit_CSS_shapes">{{ _('Learn more') }}</a></p>
+          <p><a class="mzp-c-cta-link" rel="external" href="https://developer.mozilla.org/docs/Tools/Page_Inspector/How_to/Edit_CSS_shapes">{{ ftl('ui-learn-more') }}</a></p>
         </div>
       {% endif %}
 
@@ -94,7 +94,7 @@
           as the font source, weight, style and more.
         {% endtrans %}
         </p>
-        <p><a class="mzp-c-cta-link" rel="external" href="https://developer.mozilla.org/docs/Tools/Page_Inspector/How_to/Edit_fonts">{{ _('Learn more') }}</a></p>
+        <p><a class="mzp-c-cta-link" rel="external" href="https://developer.mozilla.org/docs/Tools/Page_Inspector/How_to/Edit_fonts">{{ ftl('ui-learn-more') }}</a></p>
       </div>
     {% endif %}
   </div>

--- a/bedrock/firefox/templates/firefox/developer/includes/intro-features.html
+++ b/bedrock/firefox/templates/firefox/developer/includes/intro-features.html
@@ -2,16 +2,16 @@
   <li class="c-gallery-item">
     <img class="icon" src="{{ static('img/firefox/developer/devtools-icon.svg') }}" alt="">
     <h3 class="c-title">{{ _('Firefox Devtools') }}</h3>
-    <p><a href="#devtools" class="mzp-c-cta-link">{{ _('Learn more') }}</a></p>
+    <p><a href="#devtools" class="mzp-c-cta-link">{{ ftl('ui-learn-more') }}</a></p>
   </li>
   <li class="c-gallery-item">
     <img class="icon" src="{{ static('img/firefox/developer/css-grid-icon.svg') }}" alt="">
     <h3 class="c-title">{{ _('Master CSS Grid') }}</h3>
-    <p><a href="#cssgrid" class="mzp-c-cta-link">{{ _('Learn more') }}</a></p>
+    <p><a href="#cssgrid" class="mzp-c-cta-link">{{ ftl('ui-learn-more') }}</a></p>
   </li>
   <li class="c-gallery-item">
     <img class="icon" src="{{ static('img/firefox/developer/next-gen-icon.svg') }}" alt="">
     <h3 class="c-title">{{ _('Next-Gen CSS Engine') }}</h3>
-    <p><a href="#nextgen" class="mzp-c-cta-link">{{ _('Learn more') }}</a></p>
+    <p><a href="#nextgen" class="mzp-c-cta-link">{{ ftl('ui-learn-more')}}</a></p>
   </li>
 </ul>

--- a/bedrock/firefox/templates/firefox/developer/includes/performance.html
+++ b/bedrock/firefox/templates/firefox/developer/includes/performance.html
@@ -15,7 +15,7 @@
               Firefox Quantum includes a new CSS engine, written in Rust, that has state-of-the-art innovations and is blazingly fast.
             {% endtrans %}
           </p>
-          <p class="mzp-c-cta-link"><a href="https://hacks.mozilla.org/2017/08/inside-a-super-fast-css-engine-quantum-css-aka-stylo/">{{ _('Learn more') }}</a></p>
+          <p class="mzp-c-cta-link"><a href="https://hacks.mozilla.org/2017/08/inside-a-super-fast-css-engine-quantum-css-aka-stylo/">{{ ftl('ui-learn-more') }}</a></p>
         </div>
       </div>
     </div>

--- a/bedrock/firefox/templates/firefox/developer/index.html
+++ b/bedrock/firefox/templates/firefox/developer/index.html
@@ -38,7 +38,7 @@
 
       <p class="intro-feedback-note">
         {{ _('Firefox Developer Edition automatically sends feedback to Mozilla.') }}
-        <a href="{{ url('privacy.notices.firefox') }}#pre-release" class="more">{{ _('Learn more') }}</a>
+        <a href="{{ url('privacy.notices.firefox') }}#pre-release" class="more">{{ ftl('ui-learn-more') }}</a>
       </p>
     </div>
     <div class="intro-image">

--- a/bedrock/firefox/templates/firefox/facebookcontainer/index.html
+++ b/bedrock/firefox/templates/firefox/facebookcontainer/index.html
@@ -55,12 +55,12 @@
   {% if LANG == 'de' %}
     <div class="video-container">
       <iframe width="640" height="360" src="https://www.youtube-nocookie.com/embed/7yLoRVwuZlc?rel=0&amp;showinfo=0" frameborder="0" allow="encrypted-media" allowfullscreen>
-        <p><a href="https://www.youtube.com/watch?v=7yLoRVwuZlc">{{ _('Watch the video') }}</a></p>
+        <p><a href="https://www.youtube.com/watch?v=7yLoRVwuZlc">{{ ftl('ui-watch-the-video') }}</a></p>
       </iframe>
     </div>
   {% else %}
     <div class="moz-video-container">
-      <button class="moz-video-button mzp-c-button" type="button" aria-controls="fbcontainer-video">{{ _('Watch the video') }}</button>
+      <button class="moz-video-button mzp-c-button" type="button" aria-controls="fbcontainer-video">{{ ftl('ui-watch-the-video') }}</button>
       <div class="video-container">
         <video id="fbcontainer-video" preload="metadata" controls poster="{{ static('img/firefox/facebook-container/video-poster.png') }}" data-ga-label="Facebook Container Video">
           <source src="https://assets.mozilla.net/video/facebook-container/facebook-container.webm" type="video/webm">

--- a/bedrock/firefox/templates/firefox/home/index-master.html
+++ b/bedrock/firefox/templates/firefox/home/index-master.html
@@ -60,7 +60,7 @@
 {% set footer_title = _('One login. All your devices. A family of products that respect your <strong>privacy</strong>.') %}
 {% set join_firefox = _('Join Firefox') %}
 {% set join_learn_more = _('Learn more about joining Firefox') %}
-{% set learn_more  = _('Learn more') %}
+{% set learn_more  = ftl('ui-learn-more') %}
 {% set get_extension  = _('Get the browser extension') %}
 {% set get_facebook_container  = _('Get the Facebook Container extension') %}
 {% set get_browser = _('Download the browser') %}

--- a/bedrock/firefox/templates/firefox/home/index-quantum.html
+++ b/bedrock/firefox/templates/firefox/home/index-quantum.html
@@ -184,7 +184,7 @@
           aspect_ratio='mzp-has-aspect-1-1',
           class='mzp-l-card-feature-right-half mzp-t-firefox t-smooth',
           link_url='https://blog.mozilla.org/firefox/quantum-performance-test/',
-          link_cta=_('Learn More')
+          link_cta=ftl('ui-learn-more')
         ) %}
         <p>
           {% trans url='https://blog.mozilla.org/firefox/de/firefox-quantum-superschnell-und-schont-den-speicher/' if LANG == 'de' else 'https://blog.mozilla.org/firefox/quantum-performance-test/' %}
@@ -211,7 +211,7 @@
           aspect_ratio='mzp-has-aspect-1-1',
           class='mzp-l-card-feature-left-half mzp-t-firefox t-switch',
           link_url=url('firefox.switch'),
-          link_cta=_('Learn More')
+          link_cta=ftl('ui-learn-more')
           ) %}
           <p>{{ switch_desc }}</p>
         {% endcall %}

--- a/bedrock/firefox/templates/firefox/mobile/index.html
+++ b/bedrock/firefox/templates/firefox/mobile/index.html
@@ -89,7 +89,7 @@
             aspect_ratio='mzp-has-aspect-1-1',
             class='mzp-l-card-feature-right-half mzp-t-firefox',
             link_url=url('firefox.accounts'),
-            link_cta=_('Learn more')
+            link_cta=ftl('ui-learn-more')
           ) %}
           <p>{{ _('Sync your history, passwords, and bookmarks. Send tabs across all of your devices.') }}</p>
           {% endcall %}

--- a/bedrock/firefox/templates/firefox/retention/thank-you.html
+++ b/bedrock/firefox/templates/firefox/retention/thank-you.html
@@ -57,7 +57,7 @@
       <article>
         <h2>{{ _('Make the Internet a safer place') }}</h2>
         <div class="time">{{ _('4 min read') }}</div>
-        <a data-link-type="link" data-link-name="Make the Internet as Safer Place" href="{{ url('mozorg.internet-health.privacy-security') }}">{{ _('Learn more') }}</a>
+        <a data-link-type="link" data-link-name="Make the Internet as Safer Place" href="{{ url('mozorg.internet-health.privacy-security') }}">{{ ftl('ui-learn-more') }}</a>
       </article>
     </section>
   </div>

--- a/bedrock/firefox/templates/firefox/switch.html
+++ b/bedrock/firefox/templates/firefox/switch.html
@@ -72,7 +72,7 @@
         </li>
       </ul>
 
-      <p>{{ ftl('switch-still-not-convinced') }} <a href="https://support.mozilla.org/kb/switching-chrome-firefox">{{ _('Learn more') }}</a></p>
+      <p>{{ ftl('switch-still-not-convinced') }} <a href="https://support.mozilla.org/kb/switching-chrome-firefox">{{ ftl('ui-learn-more') }}</a></p>
     </div>
   </section>
 </main>

--- a/bedrock/mozorg/templates/mozorg/about-base.html
+++ b/bedrock/mozorg/templates/mozorg/about-base.html
@@ -26,13 +26,13 @@
   <div class="side-reference">
     <h4 class="side-reference-title">{{ _('Our Products') }}</h4>
     <p>{{ _('Software and other innovations designed to advance our mission.') }}</p>
-    <a class="more" href="{{ url('firefox') }}">{{ _('Learn More') }}</a>
+    <a class="more" href="{{ url('firefox') }}">{{ ftl('ui-learn-more') }}</a>
   </div>
 
   <div class="side-reference">
     <h4 class="side-reference-title">{{ _('Get Involved') }}</h4>
     <p>{{ _('Become a volunteer contributor in a number of different areas.') }}</p>
-    <a class="more" href="{{ url('mozorg.contribute.index') }}">{{ _('Learn More') }}</a>
+    <a class="more" href="{{ url('mozorg.contribute.index') }}">{{ ftl('ui-learn-more') }}</a>
   </div>
 
   {% block sidebar_extra %}{% endblock %}

--- a/bedrock/mozorg/templates/mozorg/about/manifesto.html
+++ b/bedrock/mozorg/templates/mozorg/about/manifesto.html
@@ -145,7 +145,7 @@
               <h3><span class="principle-number">{{ principle_number_01 }}</span> {{principle_text_01 }}</h3>
             </header>
             <section class="principle-more">
-              <h4>{{ _('Learn more') }}</h4>
+              <h4>{{ ftl('ui-learn-more') }}</h4>
               <ul class="mzp-u-list-styled">
                 <li><a href="http://openbadges.org/">{{ _('Use Open Badges to share your skills and interests') }}</a></li>
                 <li>
@@ -166,7 +166,7 @@
               <h3><span class="principle-number">{{ principle_number_02 }}</span> {{ principle_text_02 }}</h3>
             </header>
             <section class="principle-more">
-              <h4>{{ _('Learn more') }}</h4>
+              <h4>{{ ftl('ui-learn-more') }}</h4>
               <ul class="mzp-u-list-styled">
                 <li>
                   <a href="https://blog.mozilla.org/netpolicy/">
@@ -194,7 +194,7 @@
               <h3><span class="principle-number">{{ principle_number_03 }}</span> {{ principle_text_03 }}</h3>
             </header>
             <section class="principle-more">
-              <h4>{{ _('Learn more') }}</h4>
+              <h4>{{ ftl('ui-learn-more') }}</h4>
               <ul class="mzp-u-list-styled">
                 <li>
                   <a href="https://blog.mozilla.org/blog/2014/04/09/firefox-os-and-medic-mobile-use-the-web-to-connect-the-world-to-healthcare/">
@@ -222,7 +222,7 @@
               <h3><span class="principle-number">{{ principle_number_04 }}</span> {{ principle_text_04 }}</h3>
             </header>
             <section class="principle-more">
-              <h4>{{ _('Learn more') }}</h4>
+              <h4>{{ ftl('ui-learn-more') }}</h4>
               <ul class="mzp-u-list-styled">
                 <li><a href="{{ url('mozorg.internet-health.privacy-security') }}">{{ _('See how Mozilla works to put your privacy first') }}</a></li>
                 <li><a href="https://blog.mozilla.org/netpolicy/">{{ _('Read about developments in privacy and data safety') }}</a></li>
@@ -235,7 +235,7 @@
               <h3><span class="principle-number">{{ principle_number_05 }}</span> {{ principle_text_05 }}</h3>
             </header>
             <section class="principle-more">
-              <h4>{{ _('Learn more') }}</h4>
+              <h4>{{ ftl('ui-learn-more') }}</h4>
               <ul class="mzp-u-list-styled">
                 <li>
                   <a href="https://teach.mozilla.org/tools/">
@@ -263,7 +263,7 @@
               <h3><span class="principle-number">{{ principle_number_06 }}</span> {{ principle_text_06 }}</h3>
             </header>
             <section class="principle-more">
-              <h4>{{ _('Learn more') }}</h4>
+              <h4>{{ ftl('ui-learn-more') }}</h4>
               <ul class="mzp-u-list-styled">
                 <li><a href="http://ascendproject.org/">{{ _('Add new voices to open source technology') }}</a></li>
                 <li><a href="https://support.mozilla.org/kb/how-do-i-turn-do-not-track-feature">{{ _('Set your Do Not Track preference') }}</a></li>
@@ -284,7 +284,7 @@
               <h3><span class="principle-number">{{ principle_number_07 }}</span> {{ principle_text_07 }}</h3>
             </header>
             <section class="principle-more">
-              <h4>{{ _('Learn more') }}</h4>
+              <h4>{{ ftl('ui-learn-more') }}</h4>
               <ul class="mzp-u-list-styled">
                 <li>
                   <a href="https://teach.mozilla.org/web-literacy/participate/open-practice/">
@@ -313,7 +313,7 @@
               <h3><span class="principle-number">{{ principle_number_08 }}</span> {{ principle_text_08 }}</h3>
             </header>
             <section class="principle-more">
-              <h4>{{ _('Learn more') }}</h4>
+              <h4>{{ ftl('ui-learn-more') }}</h4>
               <ul class="mzp-u-list-styled">
                 <li><a href="https://groups.google.com/forum/#!forum/mozilla.governance">{{ _('Participate in our governance forum') }}</a></li>
                 {% if l10n_has_tag('join-us') %}
@@ -328,7 +328,7 @@
               <h3><span class="principle-number">{{ principle_number_09 }}</span> {{ principle_text_09 }}</h3>
             </header>
             <section class="principle-more">
-              <h4>{{ _('Learn more') }}</h4>
+              <h4>{{ ftl('ui-learn-more') }}</h4>
               <ul class="mzp-u-list-styled">
                 <li>
                   <a href="https://addons.mozilla.org/firefox/addon/lightbeam/">
@@ -356,7 +356,7 @@
               <h3><span class="principle-number">{{ principle_number_10 }}</span> {{ principle_text_10 }}</h3>
             </header>
             <section class="principle-more">
-              <h4>{{ _('Learn more') }}</h4>
+              <h4>{{ ftl('ui-learn-more') }}</h4>
               <ul class="mzp-u-list-styled">
                 <li><a href="https://teach.mozilla.org/events/">{{ _('Host or join a Maker Party') }}</a></li>
                 <li><a href="https://teach.mozilla.org/web-literacy/skills/">{{ _('Learn how to build online collaboration skills') }}</a></li>

--- a/bedrock/mozorg/templates/mozorg/home/home-de.html
+++ b/bedrock/mozorg/templates/mozorg/home/home-de.html
@@ -121,7 +121,7 @@
       class='fxaccount-secondary-cta mzp-t-product-firefox mzp-t-firefox mzp-t-dark',
       heading_level=2
     ) %}
-    <a href="{{ url('firefox.accounts') }}" class="mzp-c-button mzp-t-product mzp-t-dark" id="fxa-learn-secondary">{{ _('Learn More') }}</a>
+    <a href="{{ url('firefox.accounts') }}" class="mzp-c-button mzp-t-product mzp-t-dark" id="fxa-learn-secondary">{{ ftl('ui-learn-more') }}</a>
   {% endcall %}
 
 </main>

--- a/bedrock/mozorg/templates/mozorg/home/home-en.html
+++ b/bedrock/mozorg/templates/mozorg/home/home-en.html
@@ -80,7 +80,7 @@
 
   {{ fxa_banner_sticky(
     title=_('Get privacy beyond the browser'),
-    link_cta=_('Learn More'),
+    link_cta=ftl('ui-learn-more'),
   )}}
 
   <div class="mozilla-content">
@@ -209,7 +209,7 @@
     class='fxaccount-secondary-cta mzp-t-product-firefox mzp-t-firefox mzp-t-dark hide-from-legacy-ie',
     heading_level=2
   ) %}
-    <a href="{{ url('firefox.accounts') }}" class="mzp-c-button mzp-t-product mzp-t-dark" id="fxa-learn-secondary">{{ _('Learn More') }}</a>
+    <a href="{{ url('firefox.accounts') }}" class="mzp-c-button mzp-t-product mzp-t-dark" id="fxa-learn-secondary">{{ ftl('ui-learn-more') }}</a>
   {% endcall %}
 
 </main>

--- a/bedrock/mozorg/templates/mozorg/internet-health/privacy-security.html
+++ b/bedrock/mozorg/templates/mozorg/internet-health/privacy-security.html
@@ -484,7 +484,7 @@
     <div class="kz rd" id="kz10"></div>
     <div class="kz bl" id="kz11"></div>
     <div class="kz pr" id="kz12"></div>
-    <div class="kz au" id="kz13"><a id="kzkid" href="https://www.youtube.com/watch?v=cRpdIrq7Rbo" rel="external">{{ _('Watch the video') }}</a></div>
+    <div class="kz au" id="kz13"><a id="kzkid" href="https://www.youtube.com/watch?v=cRpdIrq7Rbo" rel="external">{{ ftl('ui-watch-the-video') }}</a></div>
     <div class="kz gr" id="kz14"></div>
     <div class="kz rd" id="kz15"></div>
     <div class="kz bl" id="kz16"></div>

--- a/bedrock/mozorg/templates/mozorg/manifesto-base.html
+++ b/bedrock/mozorg/templates/mozorg/manifesto-base.html
@@ -28,13 +28,13 @@
   <div class="side-reference">
     <h4 class="side-reference-title">{{ _('Our Products') }}</h4>
     <p>{{ _('Software and other innovations designed to advance our mission.') }}</p>
-    <a class="more" href="{{ url('firefox') }}">{{ _('Learn More') }}</a>
+    <a class="more" href="{{ url('firefox') }}">{{ ftl('ui-learn-more') }}</a>
   </div>
 
   <div class="side-reference">
     <h4 class="side-reference-title">{{ _('Get Involved') }}</h4>
     <p>{{ _('Become a volunteer contributor in a number of different areas.') }}</p>
-    <a class="more" href="{{ url('mozorg.contribute.index') }}">{{ _('Learn More') }}</a>
+    <a class="more" href="{{ url('mozorg.contribute.index') }}">{{ ftl('ui-learn-more') }}</a>
   </div>
 
   {% block sidebar_extra %}{% endblock %}

--- a/bedrock/mozorg/templates/mozorg/moss/index.html
+++ b/bedrock/mozorg/templates/mozorg/moss/index.html
@@ -44,7 +44,7 @@
     ) %}
       <p>{{ _('The Foundational Technology track supports open source projects that Mozilla relies on, either as an embedded part of our products or as part of our everyday work.') }}</p>
       <div class="moss-track-cta">
-        <p><a href="{{ url('mozorg.moss.foundational-technology') }}">{{ _('Learn More') }}</a></p>
+        <p><a href="{{ url('mozorg.moss.foundational-technology') }}">{{ ftl('ui-learn-more') }}</a></p>
         <p><a href="https://mozilla.fluxx.io/apply/MOSS" rel="external" class="mzp-c-button">{{ _('Apply Now') }}</a></p>
       </div>
     {% endcall %}
@@ -57,7 +57,7 @@
     ) %}
       <p>{{ _('The Mission Partners track supports open source projects that significantly advance Mozilla’s mission.') }}</p>
       <div class="moss-track-cta">
-        <p><a href="{{ url('mozorg.moss.mission-partners') }}">{{ _('Learn More') }}</a></p>
+        <p><a href="{{ url('mozorg.moss.mission-partners') }}">{{ ftl('ui-learn-more') }}</a></p>
         <p><a href="https://mozilla.fluxx.io/apply/MOSS" rel="external" class="mzp-c-button">{{ _('Apply Now') }}</a></p>
       </div>
     {% endcall %}
@@ -70,7 +70,7 @@
     ) %}
       <p>{{ _('The Secure Open Source (“SOS”) track supports security audits for widely used open source software projects as well as the remedial work needed to rectify the problems found.') }}</p>
       <div class="moss-track-cta">
-        <p><a href="{{ url('mozorg.moss.secure-open-source') }}">{{ _('Learn More') }}</a></p>
+        <p><a href="{{ url('mozorg.moss.secure-open-source') }}">{{ ftl('ui-learn-more') }}</a></p>
         <p><a href="https://docs.google.com/a/mozilla.com/forms/d/e/1FAIpQLScLwANEOvLBE6gnFVoiamqHOYzzkaChpdQJ7f0PlZGmfyy94w/viewform" rel="external" class="mzp-c-button">{{ _('Nominate Now') }}</a></p>
       </div>
     {% endcall %}

--- a/bedrock/mozorg/templates/mozorg/videotag.html
+++ b/bedrock/mozorg/templates/mozorg/videotag.html
@@ -15,7 +15,7 @@
         <source src="{{ videos[ft] }}" type="{{ mime[ft] }}">
     {% endif %}
   {% endfor %}
-  <p>{{ _('Watch the video') }}</p>
+  <p>{{ ftl('ui-watch-the-video') }}</p>
   <ul>
     {% for ft in filetypes %}
       {% if ft in videos %}

--- a/bedrock/mozorg/templatetags/misc.py
+++ b/bedrock/mozorg/templatetags/misc.py
@@ -318,7 +318,8 @@ def video(ctx, *args, **kwargs):
         'h': 360,
         'autoplay': False,
         'preload': False,
-        'id': 'htmlPlayer'
+        'id': 'htmlPlayer',
+        'fluent_l10n': ctx['fluent_l10n'],
     }
 
     data.update(**kwargs)

--- a/bedrock/mozorg/tests/test_helper_misc.py
+++ b/bedrock/mozorg/tests/test_helper_misc.py
@@ -16,6 +16,7 @@ from pyquery import PyQuery as pq
 from bedrock.base.templatetags.helpers import static
 from bedrock.mozorg.templatetags import misc
 from bedrock.mozorg.tests import TestCase
+from lib.l10n_utils.fluent import fluent_l10n
 
 
 TEST_FILES_ROOT = os.path.join(os.path.dirname(os.path.abspath(__file__)),
@@ -172,10 +173,13 @@ class TestVideoTag(TestCase):
     moz_video = 'http://videos.mozilla.org/serv/flux/example.%s'
     nomoz_video = 'http://example.org/example.%s'
 
+    def get_l10n(self, locale):
+        return fluent_l10n([locale, 'en'], settings.FLUENT_DEFAULT_FILES)
+
     def _render(self, template):
         req = self.rf.get('/')
         req.locale = 'en-US'
-        return render(template, {'request': req})
+        return render(template, {'request': req, 'fluent_l10n': self.get_l10n(req.locale)})
 
     def test_empty(self):
         # No video, no output.

--- a/bedrock/newsletter/templates/newsletter/updated.html
+++ b/bedrock/newsletter/templates/newsletter/updated.html
@@ -103,7 +103,7 @@
                   title=_('Meet our parent brand'),
                   ga_title='Meet our parent brand',
                   desc=_('Mozilla, the not-for-profit behind Firefox, puts people over profit in everything we say, build, and do.'),
-                  cta=_('Learn more'),
+                  cta=ftl('ui-learn-more'),
                   image_url='img/newsletter/confirm/mozilla.png',
                   aspect_ratio='mzp-has-aspect-16-9',
                   link_url=url('mozorg.about'),

--- a/bedrock/privacy/templates/privacy/archive/base-resp.html
+++ b/bedrock/privacy/templates/privacy/archive/base-resp.html
@@ -9,8 +9,8 @@
 {% block body_class %}{{ super() }} format-none{% endblock %}
 
 {% block string_data %}
-  data-details-open-text="{{ _('Learn More') }}"
-  data-details-close-text="{{ _('Show Less') }}"
+  data-details-open-text="{{ ftl('ui-learn-more') }}"
+  data-details-close-text="{{ ftl('ui-show-less') }}"
 {% endblock %}
 
 {% block article_header_logo %}{{ static('img/trademarks/logo-mozm.png') }}{% endblock %}

--- a/bedrock/privacy/templates/privacy/notices/base-notice-paragraphs.html
+++ b/bedrock/privacy/templates/privacy/notices/base-notice-paragraphs.html
@@ -5,8 +5,8 @@
 {% extends "privacy/base-protocol.html" %}
 
 {% block string_data %}
-  data-details-open-text="{{ _('Learn More') }}"
-  data-details-close-text="{{ _('Show Less') }}"
+  data-details-open-text="{{ ftl('ui-learn-more') }}"
+  data-details-close-text="{{ ftl('ui-show-less') }}"
 {% endblock %}
 
 {% do doc.select('body > section > section > p')|htmlattr(class='summary') %}

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -246,7 +246,8 @@ FLUENT_DEFAULT_FILES = [
     'footer',
     'fxa_form',
     'navigation',
-    'newsletter_form'
+    'newsletter_form',
+    'ui'
 ]
 
 FLUENT_DEFAULT_PERCENT_REQUIRED = config('FLUENT_DEFAULT_PERCENT_REQUIRED', default='80', parser=int)

--- a/l10n/en/ui.ftl
+++ b/l10n/en/ui.ftl
@@ -1,0 +1,21 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+## Common user interface (ui) strings used in global templates and shared widgets.
+
+ui-back-to-home-page = Back to home page
+ui-return-to-top = Return to top
+ui-close = Close
+ui-previous = Previous
+ui-next = Next
+ui-watch-the-video = Watch the video
+ui-replay = Replay
+ui-share = Share
+ui-menu = Menu
+ui-please-turn-on-javascript = Please turn on JavaScript to display this page correctly.
+ui-show-more = Show More
+ui-show-less = Show Less
+ui-show-all = Show All
+ui-hide-all = Hide All
+ui-learn-more = Learn more

--- a/lib/fluent_migrations/ui.py
+++ b/lib/fluent_migrations/ui.py
@@ -1,0 +1,32 @@
+from __future__ import absolute_import
+import fluent.syntax.ast as FTL
+from fluent.migrate.helpers import transforms_from
+from fluent.migrate.helpers import VARIABLE_REFERENCE, TERM_REFERENCE
+from fluent.migrate import REPLACE, COPY
+
+main = "main.lang"
+
+def migrate(ctx):
+    """Migrate common UI strings from main.lang, part {index}."""
+
+    ctx.add_transforms(
+        "ui.ftl",
+        "ui.ftl",
+        transforms_from("""
+ui-back-to-home-page = {COPY(main, "Back to home page",)}
+ui-return-to-top = {COPY(main, "Return to top",)}
+ui-close = {COPY(main, "Close",)}
+ui-previous = {COPY(main, "Previous",)}
+ui-next = {COPY(main, "Next",)}
+ui-watch-the-video = {COPY(main, "Watch the video",)}
+ui-replay = {COPY(main, "Replay",)}
+ui-share = {COPY(main, "Share",)}
+ui-menu = {COPY(main, "Menu",)}
+ui-please-turn-on-javascript = {COPY(main, "Please turn on JavaScript to display this page correctly.",)}
+ui-show-more = {COPY(main, "Show More",)}
+ui-show-less = {COPY(main, "Show Less",)}
+ui-show-all = {COPY(main, "Show All",)}
+ui-hide-all = {COPY(main, "Hide All",)}
+ui-learn-more = {COPY(main, "Learn more",)}
+""", main=main)
+        )


### PR DESCRIPTION
## Description
- Migrates common UI string from `main.lang` to `ui.ftl`.
- Updates templates to use new Fluent IDs.

Note to reviewer: I've been somewhat selective here in what we migrate, by trying to stick to generic UI strings that are common and/or heavily used. There are _a lot_ of old strings in `main.lang`, and we want to try and move away from a creating files of global, unrelated or ungrouped strings in Fluent. Pontoon will now suggest similar / matching strings to localizers from other files, so global shared strings like aren't needed as they used to be.

This PR is the last of what I propose we migrate from `main.lang`. Templates that still rely on strings from there can continue to use them, until we come to port those pages to Fluent. At that stage they can be migrated to other files.

That said, I'm open to adding any further suggestions that may still be migrated [from here](https://github.com/mozilla-l10n/www.mozilla.org/blob/master/en-US/main.lang).

## Issue / Bugzilla link
#8657

## Testing
- [ ] Are there any other common UI related strings worth importing?
- [ ] Did I miss any references to the strings migrated here that still need updating?

Successful test run: https://gitlab.com/mozmeao/www-config/pipelines/136185630