### PR TITLE
Migrate global newsletter titles to Fluent (Issue #8657)

### DIFF
--- a/bedrock/firefox/templates/firefox/channel/base.html
+++ b/bedrock/firefox/templates/firefox/channel/base.html
@@ -60,8 +60,8 @@
     <div class="mzp-l-content">
       {{ email_newsletter_form(
         protocol_component=True,
-        title=_('<span>Firefox</span> + You'),
-        subtitle=_('Get Firefox tips, tricks, news and more')) }}
+        title=ftl('newsletter-form-firefox-and-you'),
+        subtitle=ftl('newsletter-form-get-firefox-tips')) }}
     </div>
   </section>
 </main>

--- a/bedrock/mozorg/templates/mozorg/base.html
+++ b/bedrock/mozorg/templates/mozorg/base.html
@@ -15,7 +15,7 @@
 
     <div class="newsletter-content">
       {% if LANG.startswith('en-') %}
-        {{ email_newsletter_form(protocol_component=true, newsletters='mozilla-foundation', title=_('Get Mozilla updates')) }}
+        {{ email_newsletter_form(protocol_component=true, newsletters='mozilla-foundation', title=ftl('newsletter-form-get-mozilla-updates')) }}
       {% else %}
         {{ email_newsletter_form(protocol_component=true) }}
       {% endif %}

--- a/l10n/en/newsletter_form.ftl
+++ b/l10n/en/newsletter_form.ftl
@@ -22,6 +22,10 @@ newsletter-form-im-okay-with-mozilla = I’m okay with { -brand-name-mozilla } h
 
 newsletter-form-we-will-only-send = We will only send you { -brand-name-mozilla }-related information.
 newsletter-form-if-you-havent-previously = If you haven’t previously confirmed a subscription to a { -brand-name-mozilla }-related newsletter, you may have to do so. Please check your inbox or your spam filter for an email from us.
+newsletter-form-firefox-and-you = <span>{ -brand-name-firefox }</span> + You
+newsletter-form-get-firefox-tips = Get { -brand-name-firefox } tips, tricks, news and more
+newsletter-form-keep-up-with = Keep up with<br> all things { -brand-name-firefox }.
+newsletter-form-get-mozilla-updates = Get { -brand-name-mozilla } updates
 newsletter-form-available-languages = Available Languages
 newsletter-form-select-country = Select country
 newsletter-form-sign-me-up = Sign me up

--- a/lib/fluent_migrations/newsletter/includes/newsletter.py
+++ b/lib/fluent_migrations/newsletter/includes/newsletter.py
@@ -60,6 +60,46 @@ newsletter-form-text = {COPY(main, "Text",)}
                     }
                 )
             ),
+            FTL.Message(
+                id=FTL.Identifier("newsletter-form-firefox-and-you"),
+                value=REPLACE(
+                    main,
+                    "<span>Firefox</span> + You",
+                    {
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("newsletter-form-get-firefox-tips"),
+                value=REPLACE(
+                    main,
+                    "Get Firefox tips, tricks, news and more",
+                    {
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("newsletter-form-keep-up-with"),
+                value=REPLACE(
+                    main,
+                    "Keep up with<br> all things Firefox.",
+                    {
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("newsletter-form-get-mozilla-updates"),
+                value=REPLACE(
+                    main,
+                    "Get Mozilla updates",
+                    {
+                        "Mozilla": TERM_REFERENCE("brand-name-mozilla"),
+                    }
+                )
+            ),
         ] + transforms_from("""
 newsletter-form-available-languages = {COPY(main, "Available Languages",)}
 newsletter-form-select-country = {COPY(main, "Select country",)}


### PR DESCRIPTION
## Description
- Migrates some global newsletter titles from `main.lang` that I missed in https://github.com/mozilla/bedrock/pull/8748

## Issue / Bugzilla link
#8657

## Testing

```
./manage.py l10n_update
```