### PR TITLE
Show regular Sync button to signed out Firefox users on 75 WNP (Fixes #8770)

### DIFF
--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx75.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx75.html
@@ -35,9 +35,19 @@
         <h2 class="c-emphasis-box-title">{{ _('Pick up Firefox where you left off') }}</h2>
         <p>{{ _('Whether you’re using Firefox on your phone or computer, make sure all your important stuff — internet searches, passwords, open tabs — appears where you need it.') }}</p>
 
-        <p class="cta">
+        <p class="cta show-sign-in">
+          {{ fxa_button(
+            entrypoint=entrypoint,
+            button_text=_('Sync your phone'),
+            class_name='qa-sync-sign-in-button',
+            optional_parameters={'utm_campaign': campaign, 'utm_content': 'whatsnew75-sync'},
+            optional_attributes={'data-cta-text': 'Sync your phone', 'data-cta-type': 'whatsnew-75-sync', 'data-cta-position': 'primary'}
+          ) }}
+        </p>
+
+        <p class="cta show-connect-device">
           {# NOTE: The '/connect_another_device/' landing page is new so this is a kludge that duplicates the fxa_cta_link macro. If we do this again we should make a macro/helper for this button. #}
-          <a href="{{ settings.FXA_ENDPOINT }}connect_another_device/?form_type=button&entrypoint={{ entrypoint }}&utm_source={{ entrypoint }}&utm_medium=referral&utm_campaign={{ campaign }}&utm_content=whatsnew75-sync&context=fx_desktop_v3" data-action="{{ settings.FXA_ENDPOINT }}" data-mozillaonline-link="{{ settings.FXA_ENDPOINT_MOZILLAONLINE }}connect_another_device/?form_type=button&entrypoint={{ entrypoint }}&utm_source={{ entrypoint }}&utm_medium=referral&utm_campaign={{ campaign }}&utm_content=whatsnew75-sync&context=fx_desktop_v3" data-cta-type="whatsnew-75-sync" data-cta-position="primary" class="mzp-c-button mzp-t-product js-fxa-product-button qa-sync-button" rel="external">{{ _('Sync your phone') }}</a>
+          <a href="{{ settings.FXA_ENDPOINT }}connect_another_device/?form_type=button&entrypoint={{ entrypoint }}&utm_source={{ entrypoint }}&utm_medium=referral&utm_campaign={{ campaign }}&utm_content=whatsnew75-sync&context=fx_desktop_v3" data-action="{{ settings.FXA_ENDPOINT }}" data-mozillaonline-link="{{ settings.FXA_ENDPOINT_MOZILLAONLINE }}connect_another_device/?form_type=button&entrypoint={{ entrypoint }}&utm_source={{ entrypoint }}&utm_medium=referral&utm_campaign={{ campaign }}&utm_content=whatsnew75-sync&context=fx_desktop_v3" data-cta-type="whatsnew-75-sync" data-cta-position="primary" class="mzp-c-button mzp-t-product js-fxa-product-button qa-sync-connect-device-button" rel="external">{{ _('Sync your phone') }}</a>
         </p>
       </div>
 

--- a/media/css/firefox/whatsnew/whatsnew-75.scss
+++ b/media/css/firefox/whatsnew/whatsnew-75.scss
@@ -87,6 +87,10 @@ $image-path: '/media/protocol/img';
     display: none;
 }
 
+.show-connect-device {
+    display: none;
+}
+
 .state-fxa-has-devices {
     .show-monitor {
         display: block;
@@ -94,6 +98,16 @@ $image-path: '/media/protocol/img';
 
     .show-sync {
         display: none;
+    }
+}
+
+.state-fxa-has-no-devices {
+    .show-sign-in {
+        display: none;
+    }
+
+    .show-connect-device {
+        display: block;
     }
 }
 

--- a/media/js/firefox/whatsnew/whatsnew-75.js
+++ b/media/js/firefox/whatsnew/whatsnew-75.js
@@ -24,11 +24,13 @@ if (typeof window.Mozilla === 'undefined') {
         client.getFxaDetails(function(details) {
             body.classList.remove('state-fxa-default');
 
-            if (details.setup && details.browserServices.sync.mobileDevices > 0) {
+            // if signed in with more than one device, show the Monitor CTA.
+            if ((details.setup && details.browserServices.sync.mobileDevices > 0) || window.location.search.indexOf('has-devices=true') !== -1) {
                 body.classList.add('state-fxa-has-devices');
-            } else if (window.location.search.indexOf('has-devices=true') !== -1) {
-                // Fake the user state for testing purposes
-                body.classList.add('state-fxa-has-devices');
+            }
+            // else if signed in with no other devices, show connect device CTA.
+            else if ((details.setup && details.browserServices.sync.mobileDevices === 0) || window.location.search.indexOf('has-no-devices=true') !== -1) {
+                body.classList.add('state-fxa-has-no-devices');
             }
         });
     }

--- a/tests/functional/firefox/whatsnew/test_whatsnew_75.py
+++ b/tests/functional/firefox/whatsnew/test_whatsnew_75.py
@@ -19,3 +19,10 @@ def test_signed_out_sync_button_displayed(base_url, selenium):
 def test_signed_in_monitor_button_displayed(base_url, selenium):
     page = FirefoxWhatsNew75Page(selenium, base_url, params='?has-devices=true').open()
     assert page.is_signed_in_monitor_button_displayed
+
+
+@pytest.mark.skip_if_not_firefox(reason='Whatsnew pages are shown to Firefox only.')
+@pytest.mark.nondestructive
+def test_signed_in_connect_device_button_displayed(base_url, selenium):
+    page = FirefoxWhatsNew75Page(selenium, base_url, params='?has-no-devices=true').open()
+    assert page.is_signed_in_connect_device_button_displayed

--- a/tests/pages/firefox/whatsnew/whatsnew_75.py
+++ b/tests/pages/firefox/whatsnew/whatsnew_75.py
@@ -11,7 +11,8 @@ class FirefoxWhatsNew75Page(FirefoxBasePage):
 
     URL_TEMPLATE = '/{locale}/firefox/75.0/whatsnew/all/{params}'
 
-    _signed_out_sync_button_locator = (By.CSS_SELECTOR, '.show-sync .qa-sync-button')
+    _signed_out_sync_button_locator = (By.CSS_SELECTOR, '.show-sync .qa-sync-sign-in-button')
+    _signed_in_connect_device_button_locator = (By.CSS_SELECTOR, '.show-sync .qa-sync-connect-device-button')
     _signed_in_monitor_button_locator = (By.CSS_SELECTOR, '.show-monitor .qa-monitor-button')
 
     def wait_for_page_to_load(self):
@@ -27,3 +28,7 @@ class FirefoxWhatsNew75Page(FirefoxBasePage):
     @property
     def is_signed_in_monitor_button_displayed(self):
         return self.is_element_displayed(*self._signed_in_monitor_button_locator)
+
+    @property
+    def is_signed_in_connect_device_button_displayed(self):
+        return self.is_element_displayed(*self._signed_in_connect_device_button_locator)


### PR DESCRIPTION
## Description
- Adds a third state to /firefox75.0/whatsnew/ for Firefox users who are signed out of Sync.

## Issue / Bugzilla link
#8770

## Testing
- [x] Signed out Firefox users should get the regular Sync URL.
- [x] Signed in Firefox users with no other devices should get connect another device URL.
- [x] Signed in Firefox users with one or more devices already synced should get Monitor CTA.