### PR TITLE
Migrate send-to-device widget to Fluent (Fixes #8658)

### DIFF
--- a/bedrock/base/templates/macros.html
+++ b/bedrock/base/templates/macros.html
@@ -61,22 +61,18 @@
         {% if title_text %}
           {{ title_text }}
         {% else %}
-          {{ _('Send Firefox to your smartphone or tablet') }}
+          {{ ftl('send-to-device-send-firefox') }}
         {% endif %}
         </h2>
       {% endif %}
-      <h2 class="thank-you hidden">{{ _('Your download link was sent.') }}</h2>
+      <h2 class="thank-you hidden">{{ ftl('send-to-device-your-download-link') }}</h2>
       <form class="send-to-device-form" action="{{ url('firefox.send-to-device-post') }}" method="post">
         <ul class="error-list hidden">
           <li class="sms">
-          {% if l10n_has_tag('sendto_updates_bug1395342') %}
-            {{ _('Sorry, we can’t send SMS messages to this phone number.') }}
-          {% else %}
-            {{ _('Sorry. This number isn’t valid. Please enter a U.S. phone number.') }}
-          {% endif %}
+            {{ ftl('send-to-device-sorry-we-cant-send', fallback='send-to-device-sorry-this-number') }}
           </li>
-          <li class="email">{{ _('Please enter an email address.') }}</li>
-          <li class="system">{{ _('An error occurred in our system. Please try again later.') }}</li>
+          <li class="email">{{ ftl('send-to-device-please-enter-an-email') }}</li>
+          <li class="system">{{ ftl('send-to-device-an-error-occured') }}</li>
         </ul>
         <div class="send-to-device-form-fields">
           <div class="platform-container">
@@ -86,30 +82,26 @@
             <input type="hidden" name="product" value="{{ product }}">
           </div>
           <div class="inline-field">
-            <label class="form-input-label" for="{{ id }}-input" data-alt="{% if l10n_has_tag('sendto_updates_bug1395342') %}{{ _('Enter your email or phone number') }}{% else %}{{ _('Enter your email or 10-digit phone number') }}{% endif %}">
+            <label class="form-input-label" for="{{ id }}-input" data-alt="{{ ftl('send-to-device-enter-your-email-or-phone', fallback='send-to-device-enter-your-email-or-phone-10-digit') }}">
               {% if input_label %}
                 {{ input_label }}
               {% else %}
-                {{ _('Enter your email') }}
+                {{ ftl('send-to-device-enter-your-email') }}
               {% endif %}
             </label>
             <div class="form-input">
               <input id="{{ id }}-input" class="send-to-device-input" name="phone-or-email" type="text" required>
             </div>
             <div class="form-submit">
-              <button type="submit" class="button mzp-c-button mzp-t-product">{{ _('Send') }}</button>
+              <button type="submit" class="button mzp-c-button mzp-t-product">{{ ftl('send-to-device-send') }}</button>
             </div>
           </div>
           <p class="legal sms">
             {% if legal_note_sms %}
               {{ legal_note_sms }}
             {% else %}
-              {% if l10n_has_tag('sendto_updates_bug1395342') %}
-                {{ _('SMS service available in select countries only. SMS &amp; data rates may apply.') }}
-              {% else %}
-                {{ _('SMS service available to U.S. phone numbers only. SMS &amp; data rates may apply.') }}
-              {% endif %}
-                {{ _('The intended recipient of the email or SMS must have consented.')}}
+                {{ ftl('send-to-device-sms-service-available-in-select', fallback='send-to-device-sms-service-available-to-us') }}
+                {{ ftl('send-to-device-intended-recipient-email-sms') }}
             {% endif %}
             <a href="{{ url('privacy.notices.websites') }}#campaigns" class="more">{{ ftl('ui-learn-more') }}</a>
           </p>
@@ -117,15 +109,15 @@
             {% if legal_note_email %}
               {{ legal_note_email }}
             {% else %}
-              {{ _('The intended recipient of the email must have consented.') }}
+              {{ ftl('send-to-device-intended-recipient-email') }}
             {% endif %}
             <a href="{{ url('privacy.notices.websites') }}#campaigns" class="more">{{ ftl('ui-learn-more') }}</a>
           </p>
         </div>
         <div class="thank-you hidden">
-          <p class="sms">{{ _('Check your device for the email or text message!') }}</p>
-          <p class="email">{{ _('Check your device for the email!') }}</p>
-          <a href="#" role="button" class="more send-another">{{ _('Send to another device') }}</a>
+          <p class="sms">{{ ftl('send-to-device-check-your-device-email-sms') }}</p>
+          <p class="email">{{ ftl('send-to-device-check-your-device-email') }}</p>
+          <a href="#" role="button" class="more send-another">{{ ftl('send-to-device-send-to-another') }}</a>
         </div>
         <div class="loading-spinner"></div>
       </form>

--- a/bedrock/firefox/templates/firefox/mobile/get-app.html
+++ b/bedrock/firefox/templates/firefox/mobile/get-app.html
@@ -4,7 +4,7 @@
 
 {% from "macros.html" import google_play_button, send_to_device with context %}
 
-{% add_lang_files "firefox/mobile-2019" "firefox/sendto" %}
+{% add_lang_files "firefox/mobile-2019" %}
 
 {% extends "firefox/base/base-protocol.html" %}
 

--- a/bedrock/firefox/templates/firefox/mobile/index.html
+++ b/bedrock/firefox/templates/firefox/mobile/index.html
@@ -5,7 +5,7 @@
 {% from "macros.html" import google_play_button, send_to_device with context %}
 {% from "macros-protocol.html" import feature_card, hero, call_out_compact with context %}
 
-{% add_lang_files "firefox/mobile-2019" "firefox/sendto" %}
+{% add_lang_files "firefox/mobile-2019" %}
 
 {% extends "firefox/base/base-protocol.html" %}
 

--- a/bedrock/firefox/templates/firefox/welcome/page4.html
+++ b/bedrock/firefox/templates/firefox/welcome/page4.html
@@ -5,7 +5,7 @@
 {% from "macros.html" import google_play_button, send_to_device with context %}
 {% from "macros-protocol.html" import hero with context %}
 
-{% add_lang_files "firefox/welcome/page4" "firefox/sendto" %}
+{% add_lang_files "firefox/welcome/page4" %}
 
 {% extends "firefox/welcome/base.html" %}
 

--- a/bedrock/firefox/templates/firefox/welcome/page5.html
+++ b/bedrock/firefox/templates/firefox/welcome/page5.html
@@ -5,7 +5,7 @@
 {% from "macros.html" import google_play_button, send_to_device with context %}
 {% from "macros-protocol.html" import hero with context %}
 
-{% add_lang_files "firefox/welcome/page5" "firefox/sendto" %}
+{% add_lang_files "firefox/welcome/page5" %}
 
 {% extends "firefox/welcome/base.html" %}
 

--- a/bedrock/firefox/templates/firefox/whatsnew/index-lite.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/index-lite.html
@@ -2,7 +2,7 @@
  # License, v. 2.0. If a copy of the MPL was not distributed with this
  # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
 
-{% add_lang_files "firefox/whatsnew" "firefox/sendto"%}
+{% add_lang_files "firefox/whatsnew" %}
 
 {% from "macros.html" import send_to_device with context %}
 

--- a/bedrock/firefox/templates/firefox/whatsnew/index-lite.id.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/index-lite.id.html
@@ -2,7 +2,7 @@
  # License, v. 2.0. If a copy of the MPL was not distributed with this
  # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
 
-{% add_lang_files "firefox/whatsnew" "firefox/sendto"%}
+{% add_lang_files "firefox/whatsnew" %}
 
 {% from "macros.html" import send_to_device with context %}
 

--- a/bedrock/firefox/templates/firefox/whatsnew/index.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/index.html
@@ -4,7 +4,7 @@
 
 {% from "macros.html" import send_to_device with context %}
 
-{% add_lang_files "firefox/whatsnew" "firefox/sendto" %}
+{% add_lang_files "firefox/whatsnew" %}
 
 {% extends "firefox/whatsnew/base.html" %}
 

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -238,7 +238,6 @@ FEED_CACHE = 3900
 DOTLANG_CACHE = config('DOTLANG_CACHE', default='1800' if DEBUG else '600', parser=int)
 
 # Global L10n files.
-# TODO Port DOTLANG_FILES to FLUENT_DEFAULT_FILES
 DOTLANG_FILES = ['main']
 FLUENT_DEFAULT_FILES = [
     'brands',
@@ -247,7 +246,8 @@ FLUENT_DEFAULT_FILES = [
     'fxa_form',
     'navigation',
     'newsletter_form',
-    'ui'
+    'send_to_device',
+    'ui',
 ]
 
 FLUENT_DEFAULT_PERCENT_REQUIRED = config('FLUENT_DEFAULT_PERCENT_REQUIRED', default='80', parser=int)

--- a/l10n/en/send_to_device.ftl
+++ b/l10n/en/send_to_device.ftl
@@ -1,0 +1,21 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+send-to-device-send-firefox = Send { -brand-name-firefox } to your smartphone or tablet
+send-to-device-your-download-link = Your download link was sent.
+send-to-device-sorry-we-cant-send = Sorry, we can’t send SMS messages to this phone number.
+send-to-device-sorry-this-number = Sorry. This number isn’t valid. Please enter a U.S. phone number.
+send-to-device-please-enter-an-email = Please enter an email address.
+send-to-device-an-error-occured = An error occurred in our system. Please try again later.
+send-to-device-enter-your-email = Enter your email
+send-to-device-enter-your-email-or-phone = Enter your email or phone number
+send-to-device-enter-your-email-or-phone-10-digit = Enter your email or 10-digit phone number
+send-to-device-send = Send
+send-to-device-sms-service-available-in-select = SMS service available in select countries only. SMS &amp; data rates may apply.
+send-to-device-sms-service-available-to-us = SMS service available to U.S. phone numbers only. SMS &amp; data rates may apply.
+send-to-device-intended-recipient-email-sms = The intended recipient of the email or SMS must have consented.
+send-to-device-intended-recipient-email = The intended recipient of the email must have consented.
+send-to-device-check-your-device-email-sms = Check your device for the email or text message!
+send-to-device-check-your-device-email = Check your device for the email!
+send-to-device-send-to-another = Send to another device

--- a/lib/fluent_migrations/firefox/send-to-device.py
+++ b/lib/fluent_migrations/firefox/send-to-device.py
@@ -1,0 +1,51 @@
+from __future__ import absolute_import
+import fluent.syntax.ast as FTL
+from fluent.migrate.helpers import transforms_from
+from fluent.migrate.helpers import VARIABLE_REFERENCE, TERM_REFERENCE
+from fluent.migrate import REPLACE, COPY
+
+send_to = "firefox/sendto.lang"
+
+def migrate(ctx):
+    """Migrate bedrock/base/templates/macros.html, part {index}."""
+
+    ctx.add_transforms(
+        "send_to_device.ftl",
+        "send_to_device.ftl",
+        [
+
+            FTL.Message(
+                id=FTL.Identifier("send-to-device-send-firefox"),
+                value=REPLACE(
+                    "firefox/sendto.lang",
+                    "Send Firefox to your smartphone or tablet",
+                    {
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                    }
+                )
+            ),
+        ]
+    )
+
+    ctx.add_transforms(
+        "send_to_device.ftl",
+        "send_to_device.ftl",
+        transforms_from("""
+send-to-device-your-download-link = {COPY(send_to, "Your download link was sent.",)}
+send-to-device-sorry-we-cant-send = {COPY(send_to, "Sorry, we can’t send SMS messages to this phone number.",)}
+send-to-device-sorry-this-number = {COPY(send_to, "Sorry. This number isn’t valid. Please enter a U.S. phone number.",)}
+send-to-device-please-enter-an-email = {COPY(send_to, "Please enter an email address.",)}
+send-to-device-an-error-occured = {COPY(send_to, "An error occurred in our system. Please try again later.",)}
+send-to-device-enter-your-email = {COPY(send_to, "Enter your email",)}
+send-to-device-enter-your-email-or-phone = {COPY(send_to, "Enter your email or phone number",)}
+send-to-device-enter-your-email-or-phone-10-digit = {COPY(send_to, "Enter your email or 10-digit phone number",)}
+send-to-device-send = {COPY(send_to, "Send",)}
+send-to-device-sms-service-available-in-select = {COPY(send_to, "SMS service available in select countries only. SMS &amp; data rates may apply.",)}
+send-to-device-sms-service-available-to-us = {COPY(send_to, "SMS service available to U.S. phone numbers only. SMS &amp; data rates may apply.",)}
+send-to-device-intended-recipient-email-sms = {COPY(send_to, "The intended recipient of the email or SMS must have consented.",)}
+send-to-device-intended-recipient-email = {COPY(send_to, "The intended recipient of the email must have consented.",)}
+send-to-device-check-your-device-email-sms = {COPY(send_to, "Check your device for the email or text message!",)}
+send-to-device-check-your-device-email = {COPY(send_to, "Check your device for the email!",)}
+send-to-device-send-to-another= {COPY(send_to, "Send to another device",)}
+""", send_to=send_to)
+        )


### PR DESCRIPTION
## Description
- Migrates `firefox/sendto.lang` to `send_to_device.ftl`.

## Issue / Bugzilla link
#8658

## Testing
```
./manage.py fluent ftl lib/fluent_migrations/firefox/send-to-device.py ach af am an ar ast az azz be bg bn br bs ca cak crh cs cy da de dsb el en-CA en-GB eo es-AR es-CL es-ES es-MX et eu fa ff fi fr fy-NL ga-IE gd gl gn gu-IN he hi-IN hr hsb hu hy-AM ia id is it ja ka kab kk km kn ko lij lo lt ltg lv mk ml mr ms my nb-NO ne-NP nl nn-NO nv oc pa-IN pl pt-BR pt-PT rm ro ru si sk sl son sq sr sv-SE sw ta te th tl tr uk ur uz vi xh zam zh-CN zh-TW zu
```