### PR TITLE
Fix potential ftl_files memory leak

### DIFF
--- a/lib/l10n_utils/__init__.py
+++ b/lib/l10n_utils/__init__.py
@@ -64,7 +64,9 @@ def render(request, template, context=None, ftl_files=None, **kwargs):
         if isinstance(ftl_files, str):
             ftl_files = [ftl_files]
 
-        ftl_files.extend(settings.FLUENT_DEFAULT_FILES)
+        # do not use list.extend() or += here to avoid modifying
+        # the original list passed to the function
+        ftl_files = ftl_files + settings.FLUENT_DEFAULT_FILES
 
         context['fluent_l10n'] = l10n = fluent_l10n([locale, 'en'],
                                                     ftl_files)

--- a/lib/l10n_utils/tests/test_base.py
+++ b/lib/l10n_utils/tests/test_base.py
@@ -95,6 +95,15 @@ class TestRender(TestCase):
         self._test(path, template, 'es-CL', 'es-CL,es;q=0.7,en;q=0.3',
                    302, '/es-ES/firefox/new/', add_active_locales=locales)
 
+    def test_ftl_files_unmodified(self):
+        """A list passed to the ftl_files parameter should not be modified in place"""
+        ftl_files = ['dude', 'walter']
+        path = '/firefox/new/'
+        template = 'firefox/new.html'
+        req = RequestFactory().get(path)
+        l10n_utils.render(req, template, ftl_files=ftl_files)
+        assert ftl_files == ['dude', 'walter']
+
 
 class TestGetAcceptLanguages(TestCase):
     def _test(self, accept_lang, list):


### PR DESCRIPTION
If a list of ftl_files that was defined in the view was passed to render() it would have updated the original list in place with the list of default files, and this would have incresed the size of the list every call to render() for that function.

I noticed this while reviewing another l10n related PR.