### PR TITLE
Migrate firefox/all to Fluent (Fixes #8511)

### DIFF
--- a/bedrock/base/templates/product-all-unified-macros.html
+++ b/bedrock/base/templates/product-all-unified-macros.html
@@ -12,7 +12,7 @@
 
 {% macro select_version_list(id, version, disabled=False) %}
   {% set version_select_id = 'select_' ~ id ~ '_version' %}
-  <label for="{{ version_select_id }}" class="c-selection-label">{{ _('Which version would you like?') }}</label>
+  <label for="{{ version_select_id }}" class="c-selection-label">{{ ftl('firefox-all-which-version') }}</label>
   <select id="{{ version_select_id }}" class="c-selection-input" aria-controls="download-info"{% if disabled %} disabled{% endif %}>
     {# ESR can have two versions available. ESR Latest should always come first in the dropdown. #}
     {% if id == 'desktop_esr_next' %}
@@ -42,10 +42,9 @@
 {% endmacro %}
 
 {% macro select_platform_list(id, platforms, disabled=False) %}
-  <label for="{{ id }}" class="c-selection-label">{{ _('Select your preferred installer') }}</label>
-  <a href="#installer-help" class="c-button-help icon-installer-help" title="{{ _('Learn about installers') }}">
-    {# L10n: Used as an accessible label for a help button. The text is replaced with a "?" icon. #}
-    {{ _('Get help') }}
+  <label for="{{ id }}" class="c-selection-label">{{ ftl('firefox-all-select-your-preferred-installer') }}</label>
+  <a href="#installer-help" class="c-button-help icon-installer-help" title="{{ ftl('firefox-all-learn-about-installers')}}">
+    {{ ftl('firefox-all-get-help') }}
   </a>
   <select id="{{ id }}" class="c-selection-input" aria-controls="download-info"{% if disabled %} disabled{% endif %}>
     {% for p_name, p_label in platforms %}
@@ -55,7 +54,7 @@
 {% endmacro %}
 
 {% macro select_language_list(id, builds, disabled=False) %}
-  <label for="{{ id }}" class="c-selection-label">{{ _('Select your preferred language') }}</label>
+  <label for="{{ id }}" class="c-selection-label">{{ ftl('firefox-all-select-your-preferred-language') }}</label>
   <select id="{{ id }}" class="c-selection-input" aria-controls="download-info"{% if disabled %} disabled{% endif %}>
     {% for build in builds %}
       <option value="{{ build.locale }}"{% if build.locale == 'en-US' %} selected{% endif%}>
@@ -91,7 +90,7 @@
 
     <ul class="c-download-list">
     {% for p_name, p_label in platforms %}
-      <li>{{ build_link(build, p_name, p_label, _('Download %(product_label)s for %(platform)s in %(locale)s')|format(product_label=product_label, platform=p_label|replace('\n', ' '), locale=build.name_en)) }}</li>
+      <li>{{ build_link(build, p_name, p_label, ftl('firefox-all-download-product-for', product_label=product_label, platform=p_label|replace('\n', ' '), locale=build.name_en)) }}</li>
     {% endfor %}
     </ul>
   </li>

--- a/bedrock/firefox/firefox_details.py
+++ b/bedrock/firefox/firefox_details.py
@@ -11,7 +11,6 @@ from everett.manager import ListOf
 from product_details import ProductDetails
 
 from bedrock.base.waffle import config
-from lib.l10n_utils.dotlang import _lazy as _
 
 
 # TODO: port this to django-mozilla-product-details
@@ -46,12 +45,12 @@ class FirefoxDesktop(_ProductDetails):
 
     # Human-readable channel names
     channel_labels = {
-        'nightly': _('Firefox Nightly'),
-        'alpha': _('Developer Edition'),
-        'devedition': _('Developer Edition'),
-        'beta': _('Firefox Beta'),
-        'esr': _('Firefox Extended Support Release'),
-        'release': _('Firefox'),
+        'nightly': 'Firefox Nightly',
+        'alpha': 'Developer Edition',
+        'devedition': 'Developer Edition',
+        'beta': 'Firefox Beta',
+        'esr': 'Firefox Extended Support Release',
+        'release': 'Firefox',
     }
 
     # Version property names in product-details
@@ -305,8 +304,8 @@ class FirefoxDesktop(_ProductDetails):
 class FirefoxAndroid(_ProductDetails):
     # Human-readable architecture names
     platform_labels = OrderedDict([
-        ('arm', _('ARM devices\n(Android %s+)')),
-        ('x86', _('Intel devices\n(Android %s+ x86 CPU)')),
+        ('arm', 'ARM devices\n(Android %s+)'),
+        ('x86', 'Intel devices\n(Android %s+ x86 CPU)'),
     ])
 
     # Recommended/modern vs traditional/legacy platforms
@@ -315,9 +314,9 @@ class FirefoxAndroid(_ProductDetails):
 
     # Human-readable channel names
     channel_labels = {
-        'nightly': _('Firefox Nightly'),
-        'beta': _('Firefox Beta'),
-        'release': _('Firefox'),
+        'nightly': 'Firefox Nightly',
+        'beta': 'Firefox Beta',
+        'release': 'Firefox',
     }
 
     # Version property names in product-details
@@ -418,7 +417,7 @@ class FirefoxAndroid(_ProductDetails):
 
         for locale in locales:
             if locale == 'multi':
-                name_en = _('Multi-locale')
+                name_en = 'Multi-locale'
                 name_native = ''
             elif locale in self.languages:
                 name_en = self.languages[locale]['English']

--- a/bedrock/firefox/templates/firefox/all-unified.html
+++ b/bedrock/firefox/templates/firefox/all-unified.html
@@ -7,13 +7,11 @@
 {% extends "firefox/base/base-protocol.html" %}
 
 {%- block page_title -%}
-  {#- L10n: HTML page title. Replace "English (US)" with your local language. -#}
-  {{ _('Download the Firefox Browser in English (US) and more than 90 other languages') }}
+  {{ ftl('firefox-all-download-the-firefox') }}
 {%- endblock -%}
 
 {%- block page_desc -%}
-  {#- L10n: HTML page description, also used as the introductory text. -#}
-  {{ _('Everyone deserves access to the internet — your language should never be a barrier. That’s why — with the help of dedicated volunteers around the world — we make the Firefox Browser available in more than 90 languages.') }}
+  {{ ftl('firefox-all-everyone-deserves-access') }}
 {%- endblock -%}
 
 {% block page_css %}
@@ -36,64 +34,64 @@
   <div class="mzp-l-content">
     <div id="product-select-form" class="c-product-select-form" data-supported="true">
       <div class="c-intro">
-        <h1 class="c-intro-heading">{{ _('Choose which Firefox Browser to download in your language') }}</h1>
+        <h1 class="c-intro-heading">{{ ftl('firefox-all-choose-which-firefox') }}</h1>
         <p>{{ self.page_desc() }}</p>
         <div class="c-product-links" data-product="desktop_release">
           <ul>
-            <li><a href="{{ firefox_url('desktop', 'sysreq', 'release') }}">{{ _('Check the system requirements') }}</a></li>
-            <li><a href="{{ firefox_url('desktop', 'notes', 'release') }}">{{ _('Release notes') }}</a></li>
-            <li><a href="https://developer.mozilla.org/docs/Mozilla/Developer_guide/Source_Code">{{ _('Source code') }}</a></li>
+            <li><a href="{{ firefox_url('desktop', 'sysreq', 'release') }}">{{ ftl('firefox-all-check-the-system-requirements') }}</a></li>
+            <li><a href="{{ firefox_url('desktop', 'notes', 'release') }}">{{ ftl('firefox-all-release-notes') }}</a></li>
+            <li><a href="https://developer.mozilla.org/docs/Mozilla/Developer_guide/Source_Code">{{ ftl('firefox-all-source-code') }}</a></li>
           </ul>
         </div>
         <div class="c-product-links" data-product="desktop_beta">
           <ul>
-            <li><a href="{{ firefox_url('desktop', 'sysreq', 'beta') }}">{{ _('Check the system requirements') }}</a></li>
-            <li><a href="{{ firefox_url('desktop', 'notes', 'beta') }}">{{ _('Release notes') }}</a></li>
-            <li><a href="https://developer.mozilla.org/docs/Mozilla/Developer_guide/Source_Code">{{ _('Source code') }}</a></li>
+            <li><a href="{{ firefox_url('desktop', 'sysreq', 'beta') }}">{{ ftl('firefox-all-check-the-system-requirements') }}</a></li>
+            <li><a href="{{ firefox_url('desktop', 'notes', 'beta') }}">{{ ftl('firefox-all-release-notes') }}</a></li>
+            <li><a href="https://developer.mozilla.org/docs/Mozilla/Developer_guide/Source_Code">{{ ftl('firefox-all-source-code') }}</a></li>
           </ul>
         </div>
         <div class="c-product-links" data-product="desktop_developer">
           <ul>
-            <li><a href="{{ firefox_url('desktop', 'sysreq', 'alpha') }}">{{ _('Check the system requirements') }}</a></li>
-            <li><a href="{{ firefox_url('desktop', 'notes', 'alpha') }}">{{ _('Release notes') }}</a></li>
-            <li><a href="https://developer.mozilla.org/docs/Mozilla/Developer_guide/Source_Code">{{ _('Source code') }}</a></li>
+            <li><a href="{{ firefox_url('desktop', 'sysreq', 'alpha') }}">{{ ftl('firefox-all-check-the-system-requirements') }}</a></li>
+            <li><a href="{{ firefox_url('desktop', 'notes', 'alpha') }}">{{ ftl('firefox-all-release-notes') }}</a></li>
+            <li><a href="https://developer.mozilla.org/docs/Mozilla/Developer_guide/Source_Code">{{ ftl('firefox-all-source-code') }}</a></li>
           </ul>
         </div>
         <div class="c-product-links" data-product="desktop_nightly">
           <ul>
-            <li><a href="{{ firefox_url('desktop', 'sysreq', 'nightly') }}">{{ _('Check the system requirements') }}</a></li>
-            <li><a href="{{ firefox_url('desktop', 'notes', 'nightly') }}">{{ _('Release notes') }}</a></li>
-            <li><a href="https://developer.mozilla.org/docs/Mozilla/Developer_guide/Source_Code">{{ _('Source code') }}</a></li>
+            <li><a href="{{ firefox_url('desktop', 'sysreq', 'nightly') }}">{{ ftl('firefox-all-check-the-system-requirements') }}</a></li>
+            <li><a href="{{ firefox_url('desktop', 'notes', 'nightly') }}">{{ ftl('firefox-all-release-notes') }}</a></li>
+            <li><a href="https://developer.mozilla.org/docs/Mozilla/Developer_guide/Source_Code">{{ ftl('firefox-all-source-code') }}</a></li>
           </ul>
         </div>
         <div class="c-product-links" data-product="desktop_esr">
           <ul>
-            <li><a href="{{ firefox_url('desktop', 'sysreq', 'organizations') }}">{{ _('Check the system requirements') }}</a></li>
-            <li><a href="{{ firefox_url('desktop', 'notes', 'organizations') }}">{{ _('Release notes') }}</a></li>
-            <li><a href="https://developer.mozilla.org/docs/Mozilla/Developer_guide/Source_Code">{{ _('Source code') }}</a></li>
+            <li><a href="{{ firefox_url('desktop', 'sysreq', 'organizations') }}">{{ ftl('firefox-all-check-the-system-requirements') }}</a></li>
+            <li><a href="{{ firefox_url('desktop', 'notes', 'organizations') }}">{{ ftl('firefox-all-release-notes') }}</a></li>
+            <li><a href="https://developer.mozilla.org/docs/Mozilla/Developer_guide/Source_Code">{{ ftl('firefox-all-source-code') }}</a></li>
           </ul>
         </div>
         <div class="c-product-links" data-product="android_release">
           <ul>
-            <li><a href="{{ firefox_url('android', 'sysreq', 'release') }}">{{ _('Check the system requirements') }}</a></li>
-            <li><a href="{{ firefox_url('android', 'notes', 'release') }}">{{ _('Release notes') }}</a></li>
+            <li><a href="{{ firefox_url('android', 'sysreq', 'release') }}">{{ ftl('firefox-all-check-the-system-requirements') }}</a></li>
+            <li><a href="{{ firefox_url('android', 'notes', 'release') }}">{{ ftl('firefox-all-release-notes') }}</a></li>
           </ul>
         </div>
         <div class="c-product-links" data-product="android_beta">
           <ul>
-            <li><a href="{{ firefox_url('android', 'sysreq', 'beta') }}">{{ _('Check the system requirements') }}</a></li>
-            <li><a href="{{ firefox_url('android', 'notes', 'beta') }}">{{ _('Release notes') }}</a></li>
+            <li><a href="{{ firefox_url('android', 'sysreq', 'beta') }}">{{ ftl('firefox-all-check-the-system-requirements') }}</a></li>
+            <li><a href="{{ firefox_url('android', 'notes', 'beta') }}">{{ ftl('firefox-all-release-notes') }}</a></li>
           </ul>
         </div>
         <div class="c-product-links" data-product="android_nightly">
           <ul>
-            <li><a href="{{ firefox_url('android', 'sysreq', 'nightly') }}">{{ _('Check the system requirements') }}</a></li>
+            <li><a href="{{ firefox_url('android', 'sysreq', 'nightly') }}">{{ ftl('firefox-all-check-the-system-requirements') }}</a></li>
           </ul>
         </div>
         <div class="c-support-links">
           <ul>
-            <li><a href="{{ url('privacy.notices.firefox') }}">{{ _('Firefox Privacy Notice') }}</a></li>
-            <li><a href="https://support.mozilla.org/products/?utm_source=mozilla.org&utm_medium=referral&utm_campaign=need-help-link">{{ _('Need help?') }}</a></li>
+            <li><a href="{{ url('privacy.notices.firefox') }}">{{ ftl('firefox-all-firefox-privacy-notice') }}</a></li>
+            <li><a href="https://support.mozilla.org/products/?utm_source=mozilla.org&utm_medium=referral&utm_campaign=need-help-link">{{ ftl('firefox-all-need-help') }}</a></li>
           </ul>
         </div>
       </div>
@@ -101,11 +99,10 @@
         <fieldset>
           <p class="c-selection c-selection-product">
             <label for="select-product" class="c-selection-label">
-              {{ _('Which browser would you like to download?') }}
+              {{ ftl('firefox-all-which-browser-would') }}
             </label>
-            <a id="icon-browser-help" href="#browser-help" class="c-button-help" title="{{ _('Learn about Firefox browsers') }}">
-              {# L10n: Used as an accessible label for a help button. The text is replaced with a "?" icon. #}
-              {{ _('Get help') }}
+            <a id="icon-browser-help" href="#browser-help" class="c-button-help" title="{{ ftl('firefox-all-learn-about-firefox') }}">
+              {{ ftl('firefox-all-get-help') }}
             </a>
             {{ select_product_list(products, disabled=True) }}
           </p>
@@ -129,24 +126,21 @@
 
         <div id="download-info" class="c-download hidden" aria-live="polite">
           <p class="c-download-info">
-            {{ _('You are about to download:') }}
+            {{ ftl('firefox-all-you-are-about-to-download') }}
             <br>
             <br>
-            <span class="c-download-info-label">{{ _('Browser:') }}</span>
+            <span class="c-download-info-label">{{ ftl('firefox-all-browser') }}</span>
             <b class="c-download-info-content" id="download-info-product"></b>
             <br>
-            <span class="c-download-info-label">{{ _('Platform:') }}</span>
+            <span class="c-download-info-label">{{ ftl('firefox-all-platform') }}</span>
             <b class="c-download-info-content" id="download-info-platform"></b>
             <br>
-            <span class="c-download-info-label">{{ _('Language:') }}</span>
+            <span class="c-download-info-label">{{ ftl('firefox-all-language') }}</span>
             <b class="c-download-info-content" id="download-info-language"></b>
           </p>
 
           <p class="c-download-error hidden">
-            {% trans %}
-              Sorry, we couldn’t find the download you’re looking for.
-              Please try again, or select a download from the list below.
-            {% endtrans %}
+            { ftl('firefox-all-sorry-we-couldnt-find') }
           </p>
 
           <a href="#all-downloads" id="download-button-primary" class="mzp-c-button mzp-t-product" data-link-type="download" data-download-location="primary cta">
@@ -163,17 +157,16 @@
             <h3 class="mzp-c-sidemenu-label">{{ ftl('ui-menu') }}</h3>
           </section>
           <section class="mzp-c-sidemenu-main" id="sidebar-menu">
-            <h2 class="mzp-c-sidemenu-title">{{ _('Which browser would you like to download?') }}</h2>
+            <h2 class="mzp-c-sidemenu-title">{{ ftl('firefox-all-which-browser-would') }}</h2>
             <ul>
-              <li><a href="#firefox-desktop-release">Firefox</a></li>
-              <li><a href="#firefox-desktop-beta">Firefox <span>Beta</span></a></li>
-              <li><a href="#firefox-desktop-developer">Firefox <span>Developer Edition</span></a></li>
-              <li><a href="#firefox-desktop-nightly">Firefox <span>Nightly</span></a></li>
-              <li><a href="#firefox-desktop-esr">Firefox <span>Extended Support Release</span></a></li>
-              <li><a href="#firefox-android-release">Firefox Android</a></li>
-              <li><a href="#firefox-android-beta">Firefox Android <span>Beta</span></a></li>
-              <li><a href="#firefox-android-nightly">Firefox Android <span>Nightly</span></a></li>
-              <li><a href="#firefox-ios">Firefox iOS</a></li>
+              <li><a href="#firefox-desktop-release">{{ ftl('firefox-all-product-firefox') }}</a></li>
+              <li><a href="#firefox-desktop-beta">{{ ftl('firefox-all-product-firefox-beta') }}</a></li>
+              <li><a href="#firefox-desktop-developer">{{ ftl('firefox-all-product-firefox-developer') }}</a></li>
+              <li><a href="#firefox-desktop-nightly">{{ ftl('firefox-all-product-firefox-nightly') }}</a></li>
+              <li><a href="#firefox-desktop-esr">{{ ftl('firefox-all-product-firefox-esr') }}</a></li>
+              <li><a href="#firefox-android-release">{{ ftl('firefox-all-product-firefox-android') }}</a></li>
+              <li><a href="#firefox-android-beta">{{ ftl('firefox-all-product-firefox-android-beta') }}</a></li>
+              <li><a href="#firefox-android-nightly">{{ ftl('firefox-all-product-firefox-android-nightly') }}</a></li>
             </ul>
           </section>
         </nav>
@@ -181,51 +174,51 @@
 
       <div class="mzp-l-main">
         <section id="firefox-desktop-release" class="c-all-downloads-build">
-          <h2 class="c-product-heading">Firefox</h2>
+          <h2 class="c-product-heading">{{ ftl('firefox-all-product-firefox') }}</h2>
           <ul>
-            <li><a href="{{ firefox_url('desktop', 'sysreq', 'release') }}">{{ _('Check the system requirements') }}</a></li>
-            <li><a href="{{ firefox_url('desktop', 'notes', 'release') }}">{{ _('Release notes') }}</a></li>
-            <li><a href="https://developer.mozilla.org/docs/Mozilla/Developer_guide/Source_Code">{{ _('Source code') }}</a></li>
+            <li><a href="{{ firefox_url('desktop', 'sysreq', 'release') }}">{{ ftl('firefox-all-check-the-system-requirements') }}</a></li>
+            <li><a href="{{ firefox_url('desktop', 'notes', 'release') }}">{{ ftl('firefox-all-release-notes') }}</a></li>
+            <li><a href="https://developer.mozilla.org/docs/Mozilla/Developer_guide/Source_Code">{{ ftl('firefox-all-source-code') }}</a></li>
           </ul>
           {{ build_locale_list('desktop_release', desktop_release_channel_label, desktop_release_platforms, desktop_release_full_builds, 'release') }}
         </section>
 
         <section id="firefox-desktop-beta" class="c-all-downloads-build">
-          <h2 class="c-product-heading">Firefox <span>Beta</span></h2>
+          <h2 class="c-product-heading">{{ ftl('firefox-all-product-firefox-beta') }}</h2>
           <ul>
-            <li><a href="{{ firefox_url('desktop', 'sysreq', 'beta') }}">{{ _('Check the system requirements') }}</a></li>
-            <li><a href="{{ firefox_url('desktop', 'notes', 'beta') }}">{{ _('Release notes') }}</a></li>
-            <li><a href="https://developer.mozilla.org/docs/Mozilla/Developer_guide/Source_Code">{{ _('Source code') }}</a></li>
+            <li><a href="{{ firefox_url('desktop', 'sysreq', 'beta') }}">{{ ftl('firefox-all-check-the-system-requirements') }}</a></li>
+            <li><a href="{{ firefox_url('desktop', 'notes', 'beta') }}">{{ ftl('firefox-all-release-notes') }}</a></li>
+            <li><a href="https://developer.mozilla.org/docs/Mozilla/Developer_guide/Source_Code">{{ ftl('firefox-all-source-code') }}</a></li>
           </ul>
           {{ build_locale_list('desktop_beta', desktop_beta_channel_label, desktop_beta_platforms, desktop_beta_full_builds, 'beta') }}
         </section>
 
         <section id="firefox-desktop-developer" class="c-all-downloads-build">
-          <h2 class="c-product-heading">Firefox <span> Developer Edition</span></h2>
+          <h2 class="c-product-heading">{{ ftl('firefox-all-product-firefox-developer') }}</h2>
           <ul>
-            <li><a href="{{ firefox_url('desktop', 'sysreq', 'alpha') }}">{{ _('Check the system requirements') }}</a></li>
-            <li><a href="{{ firefox_url('desktop', 'notes', 'alpha') }}">{{ _('Release notes') }}</a></li>
-            <li><a href="https://developer.mozilla.org/docs/Mozilla/Developer_guide/Source_Code">{{ _('Source code') }}</a></li>
+            <li><a href="{{ firefox_url('desktop', 'sysreq', 'alpha') }}">{{ ftl('firefox-all-check-the-system-requirements') }}</a></li>
+            <li><a href="{{ firefox_url('desktop', 'notes', 'alpha') }}">{{ ftl('firefox-all-release-notes') }}</a></li>
+            <li><a href="https://developer.mozilla.org/docs/Mozilla/Developer_guide/Source_Code">{{ ftl('firefox-all-source-code') }}</a></li>
           </ul>
           {{ build_locale_list('desktop_developer', desktop_developer_channel_label, desktop_developer_platforms, desktop_developer_full_builds, 'alpha') }}
         </section>
 
         <section id="firefox-desktop-nightly" class="c-all-downloads-build">
-          <h2 class="c-product-heading">Firefox <span>Nightly</span></h2>
+          <h2 class="c-product-heading">{{ ftl('firefox-all-product-firefox-nightly') }}</h2>
           <ul>
-            <li><a href="{{ firefox_url('desktop', 'sysreq', 'nightly') }}">{{ _('Check the system requirements') }}</a></li>
-            <li><a href="{{ firefox_url('desktop', 'notes', 'nightly') }}">{{ _('Release notes') }}</a></li>
-            <li><a href="https://developer.mozilla.org/docs/Mozilla/Developer_guide/Source_Code">{{ _('Source code') }}</a></li>
+            <li><a href="{{ firefox_url('desktop', 'sysreq', 'nightly') }}">{{ ftl('firefox-all-check-the-system-requirements') }}</a></li>
+            <li><a href="{{ firefox_url('desktop', 'notes', 'nightly') }}">{{ ftl('firefox-all-release-notes') }}</a></li>
+            <li><a href="https://developer.mozilla.org/docs/Mozilla/Developer_guide/Source_Code">{{ ftl('firefox-all-source-code') }}</a></li>
           </ul>
           {{ build_locale_list('desktop_nightly', desktop_nightly_channel_label, desktop_nightly_platforms, desktop_nightly_full_builds, 'nightly') }}
         </section>
 
         <section id="firefox-desktop-esr" class="c-all-downloads-build">
-          <h2 class="c-product-heading">Firefox <span>Extended Support Release</span></h2>
+          <h2 class="c-product-heading">{{ ftl('firefox-all-product-firefox-esr') }}</h2>
           <ul>
-            <li><a href="{{ firefox_url('desktop', 'sysreq', 'organizations') }}">{{ _('Check the system requirements') }}</a></li>
-            <li><a href="{{ firefox_url('desktop', 'notes', 'organizations') }}">{{ _('Release notes') }}</a></li>
-            <li><a href="https://developer.mozilla.org/docs/Mozilla/Developer_guide/Source_Code">{{ _('Source code') }}</a></li>
+            <li><a href="{{ firefox_url('desktop', 'sysreq', 'organizations') }}">{{ ftl('firefox-all-check-the-system-requirements') }}</a></li>
+            <li><a href="{{ firefox_url('desktop', 'notes', 'organizations') }}">{{ ftl('firefox-all-release-notes') }}</a></li>
+            <li><a href="https://developer.mozilla.org/docs/Mozilla/Developer_guide/Source_Code">{{ ftl('firefox-all-source-code') }}</a></li>
           </ul>
 
           {% if desktop_esr_next_version %}
@@ -239,28 +232,28 @@
         </section>
 
         <section id="firefox-android-release" class="c-all-downloads-build">
-          <h2 class="c-product-heading">Firefox Android</h2>
+          <h2 class="c-product-heading">{{ ftl('firefox-all-product-firefox-android') }}</h2>
           <ul>
-            <li><a href="{{ firefox_url('android', 'sysreq', 'release') }}">{{ _('Check the system requirements') }}</a></li>
-            <li><a href="{{ firefox_url('android', 'notes', 'release') }}">{{ _('Release notes') }}</a></li>
+            <li><a href="{{ firefox_url('android', 'sysreq', 'release') }}">{{ ftl('firefox-all-check-the-system-requirements') }}</a></li>
+            <li><a href="{{ firefox_url('android', 'notes', 'release') }}">{{ ftl('firefox-all-release-notes') }}</a></li>
           </ul>
           {{ build_locale_list('android_release', android_release_channel_label, android_release_platforms, android_release_full_builds, 'release') }}
         </section>
 
         <section id="firefox-android-beta" class="c-all-downloads-build">
-          <h2 class="c-product-heading">Firefox Android <span>Beta</span></h2>
+          <h2 class="c-product-heading">{{ ftl('firefox-all-product-firefox-android-beta') }}</h2>
           <ul>
-            <li><a href="{{ firefox_url('android', 'sysreq', 'beta') }}">{{ _('Check the system requirements') }}</a></li>
-            <li><a href="{{ firefox_url('android', 'notes', 'beta') }}">{{ _('Release notes') }}</a></li>
+            <li><a href="{{ firefox_url('android', 'sysreq', 'beta') }}">{{ ftl('firefox-all-check-the-system-requirements') }}</a></li>
+            <li><a href="{{ firefox_url('android', 'notes', 'beta') }}">{{ ftl('firefox-all-release-notes') }}</a></li>
           </ul>
           {{ build_locale_list('android_beta', android_beta_channel_label, android_beta_platforms, android_beta_full_builds, 'beta') }}
         </section>
 
         <section id="firefox-android-nightly" class="c-all-downloads-build">
-          <h2 class="c-product-heading">Firefox Android <span>Nightly</span></h2>
+          <h2 class="c-product-heading">{{ ftl('firefox-all-product-firefox-android-nightly') }}</h2>
           <ul>
-            <li><a href="{{ firefox_url('android', 'sysreq', 'nightly') }}">{{ _('Check the system requirements') }}</a></li>
-            <li><a href="{{ firefox_url('android', 'notes', 'nightly') }}">{{ _('Release notes') }}</a></li>
+            <li><a href="{{ firefox_url('android', 'sysreq', 'nightly') }}">{{ ftl('firefox-all-check-the-system-requirements') }}</a></li>
+            <li><a href="{{ firefox_url('android', 'notes', 'nightly') }}">{{ ftl('firefox-all-release-notes') }}</a></li>
           </ul>
           {{ build_locale_list('android_nightly', android_nightly_channel_label, android_nightly_platforms, android_nightly_full_builds, 'nightly') }}
         </section>
@@ -273,23 +266,23 @@
   <ul>
     <li>
       <h2 class="c-help-title"><a href="{{ url('firefox.new') }}">Firefox</a></h2>
-      <p class="c-help-desc">{{ _('The standard Firefox browser — fast and private. If you’re not sure which Firefox to choose, choose this.') }}</p>
+      <p class="c-help-desc">{{ ftl('firefox-all-the-standard-firefox') }}</p>
     </li>
     <li>
       <h2 class="c-help-title"><a href="{{ url('firefox.channel.desktop') }}#beta">Firefox <span>Beta</span></a></h2>
-      <p class="c-help-desc">{{ _('Get a sneak peek at the latest Firefox browser features before they’re released.') }}</p>
+      <p class="c-help-desc">{{ ftl('firefox-all-get-a-sneak-peek-at') }}</p>
     </li>
     <li>
       <h2 class="c-help-title"><a href="{{ url('firefox.developer.index') }}">Firefox <span>Developer Edition</span></a></h2>
-      <p class="c-help-desc">{{ _('Test your sites against soon-to-be-released Firefox browser features with powerful, flexible DevTools that are on by default.') }}</p>
+      <p class="c-help-desc">{{ ftl('firefox-all-test-your-sites-against') }}</p>
     </li>
     <li>
       <h2 class="c-help-title"><a href="{{ url('firefox.channel.desktop') }}#nightly">Firefox <span>Nightly</span></a></h2>
-      <p class="c-help-desc">{{ _('The pre-alpha version for power users who like to hunt crashes and test new features as they’re coded.') }}</p>
+      <p class="c-help-desc">{{ ftl('firefox-all-the-pre-alpha-version') }}</p>
     </li>
     <li>
       <h2 class="c-help-title"><a href="{{ url('firefox.enterprise.index') }}">Firefox <span>Extended Support Release</span></a></h2>
-      <p class="c-help-desc">{{ _('Count on stability and ease of use with this Firefox browser built for enterprise.') }}</p>
+      <p class="c-help-desc">{{ ftl('firefox-all-count-on-stability-and') }}</p>
     </li>
   </ul>
 </div>
@@ -297,30 +290,21 @@
 <div id="installer-help" class="c-help mzp-u-modal-content">
   <ul>
     <li>
-      <h2 class="c-help-title">{{ _('64-bit installers') }}</h2>
+      <h2 class="c-help-title">{{ ftl('firefox-all-64-bit-installers') }}</h2>
       <p class="c-help-desc">
-        {% trans %}
-          Choose a 64-bit installer for computers with 64-bit processors, which allow them to allocate more RAM
-          to individual programs — particularly important for games and other demanding applications.
-        {% endtrans %}
+        {{ ftl('firefox-all-choose-a-64-bit-installer') }}
       </p>
     </li>
     <li>
-      <h2 class="c-help-title">{{ _('32-bit installers') }}</h2>
+      <h2 class="c-help-title">{{ ftl('firefox-all-32-bit-installers') }}</h2>
       <p class="c-help-desc">
-        {% trans url='https://support.mozilla.org/kb/choosing-firefox-cpu-architecture-windows-os' %}
-          Choose a 32-bit installer for computers with 32-bit processors — or for older or less powerful computers.
-          <a href="{{ url }}">If you aren’t sure</a> whether to choose a 64-bit or 32-bit installer, we recommend
-          you go with 32-bit.
-        {% endtrans %}
+        {{ ftl('firefox-all-choose-a-32-bit-installer', url='https://support.mozilla.org/kb/choosing-firefox-cpu-architecture-windows-os') }}
       </p>
     </li>
     <li>
-      <h2 class="c-help-title">{{ _('MSI installers') }}</h2>
+      <h2 class="c-help-title">{{ ftl('firefox-all-msi-installers') }}</h2>
       <p class="c-help-desc">
-        {% trans %}
-          Windows installers for corporate IT that simplify the configuration, deployment and management of the Firefox Browser.
-        {% endtrans %}
+        {{ ftl('firefox-all-windows-installers-for') }}
       </p>
     </li>
   </ul>

--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -24,7 +24,7 @@ from django.views.generic.base import TemplateView
 from lib import l10n_utils
 from lib.l10n_utils import L10nTemplateView
 from lib.l10n_utils.dotlang import lang_file_is_active
-from lib.l10n_utils.fluent import ftl_file_is_active
+from lib.l10n_utils.fluent import ftl, ftl_file_is_active
 from product_details.version_compare import Version
 
 from bedrock.base.urlresolvers import reverse
@@ -260,20 +260,21 @@ def send_to_device_ajax(request):
 
 
 def firefox_all(request):
+    ftl_files = 'firefox/all'
     product_android = firefox_android
     product_desktop = firefox_desktop
 
     # Human-readable product labels
     products = OrderedDict(
         [
-            ('desktop_release', 'Firefox'),
-            ('desktop_beta', 'Firefox Beta'),
-            ('desktop_developer', 'Firefox Developer Edition'),
-            ('desktop_nightly', 'Firefox Nightly'),
-            ('desktop_esr', 'Firefox Extended Support Release'),
-            ('android_release', 'Firefox Android'),
-            ('android_beta', 'Firefox Android Beta'),
-            ('android_nightly', 'Firefox Android Nightly'),
+            ('desktop_release', ftl('firefox-all-product-firefox', ftl_files=ftl_files)),
+            ('desktop_beta', ftl('firefox-all-product-firefox-beta', ftl_files=ftl_files)),
+            ('desktop_developer', ftl('firefox-all-product-firefox-developer', ftl_files=ftl_files)),
+            ('desktop_nightly', ftl('firefox-all-product-firefox-nightly', ftl_files=ftl_files)),
+            ('desktop_esr', ftl('firefox-all-product-firefox-esr', ftl_files=ftl_files)),
+            ('android_release', ftl('firefox-all-product-firefox-android', ftl_files=ftl_files)),
+            ('android_beta', ftl('firefox-all-product-firefox-android-beta', ftl_files=ftl_files)),
+            ('android_nightly', ftl('firefox-all-product-firefox-android-nightly', ftl_files=ftl_files)),
         ]
     )
 
@@ -377,7 +378,8 @@ def firefox_all(request):
         )
         context['desktop_esr_next_version'] = latest_esr_next_version_desktop
 
-    return l10n_utils.render(request, 'firefox/all-unified.html', context)
+    return l10n_utils.render(request, 'firefox/all-unified.html',
+                             context, ftl_files=ftl_files)
 
 
 def detect_channel(version):

--- a/l10n/en/firefox/all.ftl
+++ b/l10n/en/firefox/all.ftl
@@ -1,0 +1,63 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+### URL: https://www-dev.allizom.org/firefox/all/
+
+firefox-all-check-the-system-requirements = Check the system requirements
+firefox-all-release-notes = Release notes
+firefox-all-source-code = Source code
+firefox-all-need-help = Need help?
+firefox-all-which-browser-would = Which browser would you like to download?
+
+# Used as an accessible label for a help button. The text is replaced with a "?" icon.
+firefox-all-get-help = Get help
+
+firefox-all-you-are-about-to-download = You are about to download:
+firefox-all-browser = Browser:
+firefox-all-platform = Platform:
+firefox-all-language = Language:
+firefox-all-sorry-we-couldnt-find = Sorry, we couldn’t find the download you’re looking for. Please try again, or select a download from the list below.
+firefox-all-the-pre-alpha-version = The pre-alpha version for power users who like to hunt crashes and test new features as they’re coded.
+firefox-all-64-bit-installers = 64-bit installers
+firefox-all-choose-a-64-bit-installer = Choose a 64-bit installer for computers with 64-bit processors, which allow them to allocate more RAM to individual programs — particularly important for games and other demanding applications.
+firefox-all-32-bit-installers = 32-bit installers
+
+# HTML page title. Replace "English (US)" with your local language.
+firefox-all-download-the-firefox = Download the { -brand-name-firefox-browser } in English (US) and more than 90 other languages
+
+# HTML page description, also used as the introductory text.
+firefox-all-everyone-deserves-access = Everyone deserves access to the internet — your language should never be a barrier. That’s why — with the help of dedicated volunteers around the world — we make the { -brand-name-firefox-browser } available in more than 90 languages.
+
+firefox-all-choose-which-firefox = Choose which { -brand-name-firefox-browser } to download in your language
+firefox-all-firefox-privacy-notice = { -brand-name-firefox } Privacy Notice
+firefox-all-learn-about-firefox = Learn about { -brand-name-firefox } browsers
+firefox-all-the-standard-firefox = The standard { -brand-name-firefox } browser — fast and private. If you’re not sure which { -brand-name-firefox } to choose, choose this.
+firefox-all-get-a-sneak-peek-at = Get a sneak peek at the latest { -brand-name-firefox } browser features before they’re released.
+firefox-all-test-your-sites-against = Test your sites against soon-to-be-released { -brand-name-firefox } browser features with powerful, flexible DevTools that are on by default.
+firefox-all-count-on-stability-and = Count on stability and ease of use with this { -brand-name-firefox } browser built for enterprise.
+firefox-all-windows-installers-for = Windows installers for corporate IT that simplify the configuration, deployment and management of the { -brand-name-firefox-browser }.
+
+# Variables:
+#   $url (url) - link to https://support.mozilla.org/kb/choosing-firefox-cpu-architecture-windows-os
+firefox-all-choose-a-32-bit-installer = Choose a 32-bit installer for computers with 32-bit processors — or for older or less powerful computers. <a href="{ $url }">If you aren’t sure</a> whether to choose a 64-bit or 32-bit installer, we recommend you go with 32-bit.
+
+# Variables:
+#   $product_label (string) e.g. Firefox, Firefox Nightly
+#   $platform (string) e.g. Windows, macOS, Linux
+#   $locale(string) e.g. English (US), German, French
+firefox-all-download-product-for = Download { $product_label } for { $platform } in { $locale }
+
+firefox-all-msi-installers = MSI installers
+firefox-all-which-version = Which version would you like?
+firefox-all-select-your-preferred-installer = Select your preferred installer
+firefox-all-select-your-preferred-language = Select your preferred language
+firefox-all-learn-about-installers = Learn about installers
+firefox-all-product-firefox = { -brand-name-firefox }
+firefox-all-product-firefox-beta = { -brand-name-firefox-beta }
+firefox-all-product-firefox-developer = { -brand-name-firefox-developer-edition }
+firefox-all-product-firefox-nightly = { -brand-name-firefox-nightly }
+firefox-all-product-firefox-esr = { -brand-name-firefox-extended-support-release }
+firefox-all-product-firefox-android = { -brand-name-firefox } { -brand-name-android }
+firefox-all-product-firefox-android-beta = { -brand-name-firefox } { -brand-name-android } { -brand-name-beta }
+firefox-all-product-firefox-android-nightly = { -brand-name-firefox } { -brand-name-android } { -brand-name-nightly }

--- a/lib/fluent_migrations/firefox/all-unified.py
+++ b/lib/fluent_migrations/firefox/all-unified.py
@@ -1,0 +1,171 @@
+from __future__ import absolute_import
+import fluent.syntax.ast as FTL
+from fluent.migrate.helpers import transforms_from
+from fluent.migrate.helpers import VARIABLE_REFERENCE, TERM_REFERENCE
+from fluent.migrate import REPLACE, COPY
+
+all_unified = "firefox/all-unified.lang"
+
+def migrate(ctx):
+    """Migrate bedrock/firefox/templates/firefox/all-unified.html, part {index}."""
+
+    ctx.add_transforms(
+        "firefox/all.ftl",
+        "firefox/all.ftl",
+        transforms_from("""
+firefox-all-check-the-system-requirements = {COPY(all_unified, "Check the system requirements",)}
+firefox-all-release-notes = {COPY(all_unified, "Release notes",)}
+firefox-all-source-code = {COPY(all_unified, "Source code",)}
+firefox-all-need-help = {COPY(all_unified, "Need help?",)}
+firefox-all-which-browser-would = {COPY(all_unified, "Which browser would you like to download?",)}
+firefox-all-get-help = {COPY(all_unified, "Get help",)}
+firefox-all-you-are-about-to-download = {COPY(all_unified, "You are about to download:",)}
+firefox-all-browser = {COPY(all_unified, "Browser:",)}
+firefox-all-platform = {COPY(all_unified, "Platform:",)}
+firefox-all-language = {COPY(all_unified, "Language:",)}
+firefox-all-sorry-we-couldnt-find = {COPY(all_unified, "Sorry, we couldn’t find the download you’re looking for. Please try again, or select a download from the list below.",)}
+firefox-all-the-pre-alpha-version = {COPY(all_unified, "The pre-alpha version for power users who like to hunt crashes and test new features as they’re coded.",)}
+firefox-all-64-bit-installers = {COPY(all_unified, "64-bit installers",)}
+firefox-all-choose-a-64-bit-installer = {COPY(all_unified, "Choose a 64-bit installer for computers with 64-bit processors, which allow them to allocate more RAM to individual programs — particularly important for games and other demanding applications.",)}
+firefox-all-32-bit-installers = {COPY(all_unified, "32-bit installers",)}
+""", all_unified=all_unified) + [
+            FTL.Message(
+                id=FTL.Identifier("firefox-all-download-the-firefox"),
+                value=REPLACE(
+                    all_unified,
+                    "Download the Firefox Browser in English (US) and more than 90 other languages",
+                    {
+                        "Firefox Browser": TERM_REFERENCE("brand-name-firefox-browser"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("firefox-all-everyone-deserves-access"),
+                value=REPLACE(
+                    all_unified,
+                    "Everyone deserves access to the internet — your language should never be a barrier. That’s why — with the help of dedicated volunteers around the world — we make the Firefox Browser available in more than 90 languages.",
+                    {
+                        "Firefox Browser": TERM_REFERENCE("brand-name-firefox-browser"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("firefox-all-choose-which-firefox"),
+                value=REPLACE(
+                    all_unified,
+                    "Choose which Firefox Browser to download in your language",
+                    {
+                        "Firefox Browser": TERM_REFERENCE("brand-name-firefox-browser"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("firefox-all-firefox-privacy-notice"),
+                value=REPLACE(
+                    all_unified,
+                    "Firefox Privacy Notice",
+                    {
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("firefox-all-learn-about-firefox"),
+                value=REPLACE(
+                    all_unified,
+                    "Learn about Firefox browsers",
+                    {
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("firefox-all-the-standard-firefox"),
+                value=REPLACE(
+                    all_unified,
+                    "The standard Firefox browser — fast and private. If you’re not sure which Firefox to choose, choose this.",
+                    {
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("firefox-all-get-a-sneak-peek-at"),
+                value=REPLACE(
+                    all_unified,
+                    "Get a sneak peek at the latest Firefox browser features before they’re released.",
+                    {
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("firefox-all-test-your-sites-against"),
+                value=REPLACE(
+                    all_unified,
+                    "Test your sites against soon-to-be-released Firefox browser features with powerful, flexible DevTools that are on by default.",
+                    {
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("firefox-all-count-on-stability-and"),
+                value=REPLACE(
+                    all_unified,
+                    "Count on stability and ease of use with this Firefox browser built for enterprise.",
+                    {
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("firefox-all-windows-installers-for"),
+                value=REPLACE(
+                    all_unified,
+                    "Windows installers for corporate IT that simplify the configuration, deployment and management of the Firefox Browser.",
+                    {
+                        "Firefox Browser": TERM_REFERENCE("brand-name-firefox-browser"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("firefox-all-choose-a-32-bit-installer"),
+                value=REPLACE(
+                    all_unified,
+                    "Choose a 32-bit installer for computers with 32-bit processors — or for older or less powerful computers. <a href=\"%(url)s\">If you aren’t sure</a> whether to choose a 64-bit or 32-bit installer, we recommend you go with 32-bit.",
+                    {
+                        "%%": "%",
+                        "%(url)s": VARIABLE_REFERENCE("url"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("firefox-all-download-product-for"),
+                value=REPLACE(
+                    all_unified,
+                    "Download %(product_label)s for %(platform)s in %(locale)s",
+                    {
+                        "%%": "%",
+                        "%(product_label)s": VARIABLE_REFERENCE("product_label"),
+                        "%(platform)s": VARIABLE_REFERENCE("platform"),
+                        "%(locale)s": VARIABLE_REFERENCE("locale"),
+                    }
+                )
+            ),
+        ] + transforms_from("""
+firefox-all-msi-installers = {COPY(all_unified, "MSI installers",)}
+firefox-all-which-version = {COPY(all_unified, "Which version would you like?",)}
+firefox-all-select-your-preferred-installer = {COPY(all_unified, "Select your preferred installer",)}
+firefox-all-select-your-preferred-language = {COPY(all_unified, "Select your preferred language",)}
+firefox-all-learn-about-installers = {COPY(all_unified, "Learn about installers",)}
+firefox-all-product-firefox = { -brand-name-firefox }
+firefox-all-product-firefox-beta = { -brand-name-firefox-beta }
+firefox-all-product-firefox-developer = { -brand-name-firefox-developer-edition }
+firefox-all-product-firefox-nightly = { -brand-name-firefox-nightly }
+firefox-all-product-firefox-esr = { -brand-name-firefox-extended-support-release }
+firefox-all-product-firefox-android = { -brand-name-firefox } { -brand-name-android }
+firefox-all-product-firefox-android-beta = { -brand-name-firefox } { -brand-name-android } { -brand-name-beta }
+firefox-all-product-firefox-android-nightly = { -brand-name-firefox } { -brand-name-android } { -brand-name-nightly }
+""", all_unified=all_unified)
+        )


### PR DESCRIPTION
## Description
- Migrates `firefox/all-unified.lang` to `firefox/all.ftl`.
- Updates template and macros to use new Fluent IDs.

## Issue / Bugzilla link
#8511

## Testing

```
./manage.py fluent ftl lib/fluent_migrations/firefox/all-unified.py ach af am an ar ast az azz be bg bn br bs ca cak crh cs cy da de dsb el en-CA en-GB eo es-AR es-CL es-ES es-MX et eu fa ff fi fr fy-NL ga-IE gd gl gn gu-IN he hi-IN hr hsb hto hu hy-AM ia id is it ja ka kab kk km kn ko lij lo lt ltg lv mk ml mr ms my nb-NO ne-NP nl nn-NO nv oc pa-IN pai pbb pl pt-BR pt-PT qvi rm ro ru si sk sl son sq sr sv-SE sw ta te th tl tr trs uk ur uz vi wo xh zam zh-CN zh-TW zu
```

Successful test run: https://gitlab.com/mozmeao/www-config/pipelines/137224011