### PR TITLE
Add b and c variants of exp/firefox/new page (#8773)

### DIFF
--- a/bedrock/exp/templates/exp/firefox/new/download.html
+++ b/bedrock/exp/templates/exp/firefox/new/download.html
@@ -27,9 +27,18 @@
 {#- This will appear as <meta property="og:description"> which can be used for social share -#}
 {% block page_og_desc %}Faster page loading, less memory usage and packed with features, the new Firefox is here.{% endblock %}
 
+{% block page_css %}
+  {% if v == 'b' %}
+  <style>
+    .mzp-c-navigation.top-header-navigation {
+      display: none;
+    }
+  </style>
+  {% endif %}
+{% endblock %}
+
 {% block site_header %}
-  {# experience value to include nav is obfuscated to avoid contents of address bar impacting experiment #}
-  {% if experience == 'nv' %}
+  {% if v in ['b','c'] %}
     {% include 'includes/protocol/navigation/menu-firefox/index.html' %}
   {% endif %}
 {% endblock %}

--- a/bedrock/exp/views.py
+++ b/bedrock/exp/views.py
@@ -18,11 +18,11 @@ def new(request):
     variant = request.GET.get('v', None)
 
     # ensure experience matches pre-defined value
-    if experience not in ['nv']:  # place expected ?xv= values in this list
-        variant = None
+    if experience not in ['']:  # place expected ?xv= values in this list
+        experience = None
 
     # ensure variant matches pre-defined value
-    if variant not in ['a', 'b']:  # place expected ?v= values in this list
+    if variant not in ['a', 'b', 'c']:  # place expected ?v= values in this list
         variant = None
 
     # no harm done by passing 'v' to template, even when no experiment is running


### PR DESCRIPTION
## Description

Add b and c variants of exp/firefox/new page. Both have nav menu but b does not display it. A is control.

## Issue / Bugzilla link

#8773

## Testing

-http://localhost:8000/en-US/exp/firefox/new/?v=a
-http://localhost:8000/en-US/exp/firefox/new/?v=b
-http://localhost:8000/en-US/exp/firefox/new/?v=c