### PR TITLE
Update Protocol to 11.0.2

### DIFF
--- a/media/css/base/banners/fundraiser.scss
+++ b/media/css/base/banners/fundraiser.scss
@@ -51,6 +51,7 @@ $image-path: '/media/protocol/img';
     margin-bottom: $spacing-lg;
 
     label {
+        color: $color-white;
         display: inline-block;
 
         &:first-child {

--- a/media/css/base/banners/includes/_base.scss
+++ b/media/css/base/banners/includes/_base.scss
@@ -39,7 +39,7 @@ $image-path: '/media/protocol/img';
 
 .c-banner-title {
     @include font-mozilla;
-    @include text-display-lg;
+    @include text-title-lg;
 
     @media #{$mq-lg} {
         @include bidi((

--- a/media/css/base/banners/moss-covid.scss
+++ b/media/css/base/banners/moss-covid.scss
@@ -15,10 +15,10 @@ $image-path: '/media/protocol/img';
 }
 
 .c-banner-title {
-    @include text-display-md;
+    @include text-title-md;
 }
 
 .c-banner-content {
-    @include text-display-xs;
+    @include text-title-xs;
     @include font-mozilla;
 }

--- a/media/css/base/page-not-found.scss
+++ b/media/css/base/page-not-found.scss
@@ -20,7 +20,7 @@ main {
 }
 
 .error-helper { // Fallback content only
-    @include text-display-xs;
+    @include text-title-xs;
     padding-top: $spacing-lg;
 }
 

--- a/media/css/exp/firefox/accounts-2019.scss
+++ b/media/css/exp/firefox/accounts-2019.scss
@@ -5,7 +5,7 @@
 @import '../../../protocol/css/includes/lib';
 
 .c-section-title {
-    @include text-display-md;
+    @include text-title-md;
     max-width: $content-sm;
     margin: 0 auto $layout-xl;
     text-align: center;
@@ -24,7 +24,7 @@
     }
 
     .c-accounts-hero-title {
-        @include text-display-lg;
+        @include text-title-lg;
         margin-bottom: $spacing-xl;
         padding-top: (60px + $spacing-2xl);
 
@@ -110,7 +110,7 @@
     text-align: center;
 
     .fxa-email-form-title {
-        @include text-display-sm;
+        @include text-title-sm;
     }
 
     .state-fxa-supported-signed-in & {
@@ -191,7 +191,7 @@
 
 .c-product-list-title {
     @include image-replaced;
-    @include text-display-sm;
+    @include text-title-sm;
     background-position: center top;
     background-repeat: no-repeat;
     margin: 0 auto $spacing-lg;
@@ -424,7 +424,7 @@
 }
 
 .c-accounts-value-title {
-    @include text-display-md;
+    @include text-title-md;
 }
 
 
@@ -488,7 +488,7 @@
 }
 
 .c-accounts-movement-title {
-    @include text-display-md;
+    @include text-title-md;
 }
 
 .c-accounts-movement-desc {

--- a/media/css/exp/firefox/index.scss
+++ b/media/css/exp/firefox/index.scss
@@ -41,7 +41,7 @@ $image-path: '/media/protocol/img';
         max-width: $content-sm;
 
         h4 {
-            @include text-display-sm;
+            @include text-title-sm;
             margin-bottom: $layout-sm;
         }
     }
@@ -171,7 +171,7 @@ $image-path: '/media/protocol/img';
 }
 
 .c-showcase-title {
-    @include text-display-sm;
+    @include text-title-sm;
     margin-bottom: $spacing-lg;
 }
 
@@ -308,7 +308,7 @@ $image-path: '/media/protocol/img';
 }
 
 .c-end-title {
-    @include text-display-md;
+    @include text-title-md;
     color: #fff;
     margin-bottom: $spacing-2xl;
     margin-top: $layout-md;

--- a/media/css/exp/firefox/lockwise.scss
+++ b/media/css/exp/firefox/lockwise.scss
@@ -78,7 +78,7 @@ h1 {
 }
 
 .hero-subheading {
-    @include text-display-md;
+    @include text-title-md;
 }
 
 @media #{$mq-sm} {

--- a/media/css/exp/firefox/welcome.scss
+++ b/media/css/exp/firefox/welcome.scss
@@ -60,12 +60,12 @@
 }
 
 .mzp-c-hero-title {
-    @include text-display-lg;
+    @include text-title-lg;
     margin-bottom: $layout-sm;
 
     .welcome-page1 &,
     .welcome-page3 & {
-        @include text-display-md;
+        @include text-title-md;
     }
 }
 
@@ -103,7 +103,7 @@
     padding: 0 $layout-md;
 
     .c-picto-block-title {
-        @include text-display-xs;
+        @include text-title-xs;
     }
 
     .c-picto-block-image {

--- a/media/css/exp/firefox/whatsnew/whatsnew-71.scss
+++ b/media/css/exp/firefox/whatsnew/whatsnew-71.scss
@@ -18,13 +18,13 @@ $image-path: '/media/protocol/img';
 }
 
 .c-section-title-secondary {
-    @include text-display-xxs;
+    @include text-title-xxs;
     margin: 0 auto $layout-md;
     max-width: $content-md - ($layout-md * 2);
 }
 
 .c-section-title {
-    @include text-display-sm;
+    @include text-title-sm;
     margin: 0 auto $layout-md;
     max-width: $content-md - ($layout-md * 2);
     text-align: center;
@@ -67,11 +67,11 @@ $image-path: '/media/protocol/img';
     }
 
     .c-emphasis-box-title {
-        @include text-display-sm;
+        @include text-title-sm;
     }
 
     .c-emphasis-box-tagline {
-        @include text-display-xs;
+        @include text-title-xs;
     }
 
     .cta {
@@ -99,7 +99,7 @@ $image-path: '/media/protocol/img';
     padding: 0 $layout-md;
 
     .c-picto-block-title {
-        @include text-display-xs;
+        @include text-title-xs;
     }
 
     .c-picto-block-image {
@@ -155,7 +155,7 @@ $image-path: '/media/protocol/img';
     }
 
     .c-picto-block-body.t-big {
-        @include text-display-xs;
+        @include text-title-xs;
         min-height: 60px;
     }
 }

--- a/media/css/firefox/accounts-2019.scss
+++ b/media/css/firefox/accounts-2019.scss
@@ -5,7 +5,7 @@
 @import '../../protocol/css/includes/lib';
 
 .c-section-title {
-    @include text-display-md;
+    @include text-title-md;
     max-width: $content-sm;
     margin: 0 auto $layout-xl;
     text-align: center;
@@ -24,7 +24,7 @@
     }
 
     .c-accounts-hero-title {
-        @include text-display-lg;
+        @include text-title-lg;
         margin-bottom: $spacing-xl;
         padding-top: (60px + $spacing-2xl);
 
@@ -110,7 +110,7 @@
     text-align: center;
 
     .fxa-email-form-title {
-        @include text-display-sm;
+        @include text-title-sm;
     }
 
     .state-fxa-supported-signed-in & {
@@ -191,7 +191,7 @@
 
 .c-product-list-title {
     @include image-replaced;
-    @include text-display-sm;
+    @include text-title-sm;
     background-position: center top;
     background-repeat: no-repeat;
     margin: 0 auto $spacing-lg;
@@ -424,7 +424,7 @@
 }
 
 .c-accounts-value-title {
-    @include text-display-md;
+    @include text-title-md;
 }
 
 
@@ -488,7 +488,7 @@
 }
 
 .c-accounts-movement-title {
-    @include text-display-md;
+    @include text-title-md;
 }
 
 .c-accounts-movement-desc {

--- a/media/css/firefox/all/all-unified.scss
+++ b/media/css/firefox/all/all-unified.scss
@@ -139,6 +139,7 @@ $image-path: '/media/protocol/img';
     background-repeat: no-repeat;
     display: inline-block;
     height: 21px;
+    padding-bottom: $spacing-sm;
     vertical-align: middle;
     width: 21px;
 }

--- a/media/css/firefox/all/all-unified.scss
+++ b/media/css/firefox/all/all-unified.scss
@@ -112,7 +112,7 @@ $image-path: '/media/protocol/img';
     .c-intro-heading {
         @include at2x('/media/protocol/img/logos/firefox/browser/logo-sm.png', 64px, 64px);
         @include bidi(((background-position, top left, top right),));
-        @include text-display-lg;
+        @include text-title-lg;
         background-repeat: no-repeat;
         margin-bottom: $spacing-xl;
         padding-top: 64px + $spacing-lg;
@@ -222,7 +222,7 @@ $image-path: '/media/protocol/img';
 }
 
 .c-product-heading {
-    @include text-display-md;
+    @include text-title-md;
     background: $color-white;
     padding: $spacing-md 0;
     position: -webkit-sticky;
@@ -235,7 +235,7 @@ $image-path: '/media/protocol/img';
 }
 
 .c-product-subheading {
-    @include text-display-sm;
+    @include text-title-sm;
 }
 
 .c-locale-list {
@@ -247,10 +247,10 @@ $image-path: '/media/protocol/img';
     }
 
     .c-locale-label {
-        @include text-display-sm;
+        @include text-title-sm;
 
         span {
-            @include text-display-xs;
+            @include text-title-xs;
             display: block;
             font-weight: normal;
         }
@@ -312,7 +312,7 @@ $image-path: '/media/protocol/img';
     }
 
     .c-help-title {
-        @include text-display-xs;
+        @include text-title-xs;
 
         span {
             font-weight: normal;

--- a/media/css/firefox/browsers-products.scss
+++ b/media/css/firefox/browsers-products.scss
@@ -104,7 +104,7 @@ main .mzp-l-content {
     text-align: center;
 
     h1 {
-        @include text-display-xl;
+        @include text-title-xl;
     }
 
     p {
@@ -462,7 +462,7 @@ $url-download-link-hover: svg-url($download-link-hover);
 }
 
 .c-dev-title {
-    @include text-display-sm;
+    @include text-title-sm;
     @include font-firefox;
     font-weight: bold;
 }
@@ -505,9 +505,9 @@ $url-download-link-hover: svg-url($download-link-hover);
 // FxA account signup form
 
 // box around form
-.t-account {
+.mzp-c-emphasis-box.t-account {
     @include light-links;
-    background: linear-gradient($color-violet-50 -100%, $color-ink-80);
+    background: $color-ink-80 linear-gradient($color-violet-50 -100%, $color-ink-80);
     color: $color-white;
     margin: 0 auto $v-grid-xs auto;
     position: relative;
@@ -565,6 +565,7 @@ $url-download-link-hover: svg-url($download-link-hover);
     .field {
         label {
             @include text-body-sm;
+            color: $color-white;
         }
 
         input[type="email"] {

--- a/media/css/firefox/browsers/best-browser.scss
+++ b/media/css/firefox/browsers/best-browser.scss
@@ -23,7 +23,7 @@ $image-path: '/media/protocol/img';
 
         h1 {
             @include font-base;
-            @include text-display-lg;
+            @include text-title-lg;
             margin: 0 auto $spacing-2xl;
             max-width: 580px;
         }
@@ -54,7 +54,7 @@ $image-path: '/media/protocol/img';
 
         h2 {
             @include font-base;
-            @include text-display-lg;
+            @include text-title-lg;
         }
     }
 }

--- a/media/css/firefox/browsers/browser-history.scss
+++ b/media/css/firefox/browsers/browser-history.scss
@@ -14,11 +14,11 @@ $image-path: '/media/protocol/img';
     margin: 0 auto $layout-lg;
 
     .mzp-c-article-title {
-        @include text-display-lg;
+        @include text-title-lg;
     }
 
     .c-section-title {
-        @include text-display-sm;
+        @include text-title-sm;
         margin-top: $layout-md;
     }
 

--- a/media/css/firefox/browsers/incognito-browser.scss
+++ b/media/css/firefox/browsers/incognito-browser.scss
@@ -14,16 +14,16 @@ $image-path: '/media/protocol/img';
     margin: 0 auto $layout-lg;
 
     .mzp-c-article-title {
-        @include text-display-lg;
+        @include text-title-lg;
     }
 
     .c-section-title-large {
-        @include text-display-md;
+        @include text-title-md;
         margin-top: $layout-md;
     }
 
     .c-section-title {
-        @include text-display-sm;
+        @include text-title-sm;
         margin-top: $layout-md;
     }
 

--- a/media/css/firefox/browsers/update-browser.scss
+++ b/media/css/firefox/browsers/update-browser.scss
@@ -14,11 +14,11 @@ $image-path: '/media/protocol/img';
     margin: 0 auto $layout-lg;
 
     .mzp-c-article-title {
-        @include text-display-lg;
+        @include text-title-lg;
     }
 
     .c-section-title {
-        @include text-display-sm;
+        @include text-title-sm;
         margin-top: $layout-md;
     }
 

--- a/media/css/firefox/browsers/what-is-a-browser.scss
+++ b/media/css/firefox/browsers/what-is-a-browser.scss
@@ -13,11 +13,11 @@ $image-path: '/media/protocol/img';
     margin: 0 auto $layout-lg;
 
     .mzp-c-article-title {
-        @include text-display-lg;
+        @include text-title-lg;
     }
 
     .c-section-title {
-        @include text-display-sm;
+        @include text-title-sm;
         margin-top: $layout-md;
     }
 

--- a/media/css/firefox/browsers/windows-64-bit.scss
+++ b/media/css/firefox/browsers/windows-64-bit.scss
@@ -19,7 +19,7 @@ $image-path: '/media/protocol/img';
     .hero-content {
         padding-top: $layout-xl;
         h1 {
-            @include text-display-lg;
+            @include text-title-lg;
             margin: 0 auto $spacing-2xl;
             @media #{$mq-lg} {
                 width: 400px;
@@ -44,7 +44,7 @@ $image-path: '/media/protocol/img';
         margin-bottom: $layout-lg;
 
         h2 {
-            @include text-display-lg;
+            @include text-title-lg;
         }
     }
 

--- a/media/css/firefox/compare/compare.scss
+++ b/media/css/firefox/compare/compare.scss
@@ -219,7 +219,7 @@ $image-path: "/media/protocol/img";
     thead {
         th {
             @include font-firefox;
-            @include text-display-xs;
+            @include text-title-xs;
             background-color: $color-white;
             border-bottom: 3px solid $color-marketing-gray-20;
             border-top: 3px solid $color-marketing-gray-20;

--- a/media/css/firefox/developer/developer.scss
+++ b/media/css/firefox/developer/developer.scss
@@ -25,14 +25,14 @@
 }
 
 .c-subtitle {
-    @include text-display-sm;
+    @include text-title-sm;
     @include font-firefox;
-    line-height: $text-display-line-height;
+    line-height: $text-title-line-height;
     font-weight: bold;
     margin-bottom: $spacing-md;
 
     .t-features & {
-        @include text-display-md;
+        @include text-title-md;
         margin: 0 auto $layout-md;
         max-width: $content-lg;
 

--- a/media/css/firefox/developer/includes/features.scss
+++ b/media/css/firefox/developer/includes/features.scss
@@ -6,7 +6,7 @@
 }
 
 .c-feature-name {
-    @include text-display-xs;
+    @include text-title-xs;
 }
 
 .c-feature-img {

--- a/media/css/firefox/developer/includes/intro.scss
+++ b/media/css/firefox/developer/includes/intro.scss
@@ -13,7 +13,7 @@
 }
 
 .intro-title {
-    @include text-display-lg;
+    @include text-title-lg;
     background-position: top center;
     background-repeat: no-repeat;
     margin: $layout-sm auto;

--- a/media/css/firefox/enterprise/landing.scss
+++ b/media/css/firefox/enterprise/landing.scss
@@ -41,7 +41,7 @@ html {
     margin-bottom: $layout-md;
 
     .enterprise-section-title {
-        @include text-display-md;
+        @include text-title-md;
         margin: 0 auto $layout-xs;
         max-width: 18em;
         text-align: center;
@@ -93,7 +93,7 @@ html {
 
    &.mzp-t-product-firefox .mzp-c-hero-title {
        @include at2x('/media/protocol/img/logos/firefox/browser/logo-word-hor-white-sm.png', auto, 48px);
-       @include text-display-xl;
+       @include text-title-xl;
        padding-top: $layout-lg + 48px;
    }
 
@@ -254,7 +254,7 @@ html {
         (padding-left, $layout-lg, 0),
         (padding-right, 0, $layout-lg),
     ));
-    @include text-display-sm;
+    @include text-title-sm;
     margin-bottom: $spacing-lg;
     min-height: 48px;
     position: relative;
@@ -294,7 +294,7 @@ html {
 }
 
 .enterprise-download-subtitle {
-    @include text-display-xxs;
+    @include text-title-xxs;
 }
 
 

--- a/media/css/firefox/enterprise/signup.scss
+++ b/media/css/firefox/enterprise/signup.scss
@@ -10,7 +10,7 @@ $image-path: '/media/protocol/img';
 
 .enterprise-head {
     @include clearfix;
-    @include text-display-xs;
+    @include text-title-xs;
     background-color: $color-ink-80;
     color: #fff;
 }
@@ -30,7 +30,7 @@ $image-path: '/media/protocol/img';
     margin-bottom: 60px;
 
     h1 {
-        @include text-display-md;
+        @include text-title-md;
         margin-bottom: 20px;
     }
 
@@ -114,10 +114,10 @@ $image-path: '/media/protocol/img';
 }
 
 h1.thanks-head {
-    @include text-display-md;
+    @include text-title-md;
     margin-bottom: 60px;
 }
 
 h2.thanks-subhead {
-    @include text-display-sm;
+    @include text-title-sm;
 }

--- a/media/css/firefox/features/adblocker.scss
+++ b/media/css/firefox/features/adblocker.scss
@@ -48,19 +48,19 @@ ul li span {
     }
 
     h3 {
-        @include text-display-sm;
+        @include text-title-sm;
     }
 }
 
 section.mzp-c-hero {
     padding: 0;
     .mzp-c-hero-subtitle {
-        @include text-display-sm;
+        @include text-title-sm;
     }
 }
 
 .section-title {
-    @include text-display-sm;
+    @include text-title-sm;
     text-align: center;
 }
 

--- a/media/css/firefox/features/safebrowser.scss
+++ b/media/css/firefox/features/safebrowser.scss
@@ -21,7 +21,7 @@ $image-path: '/media/protocol/img';
         padding-bottom: $layout-xl;
         h1 {
             @include font-base;
-            @include text-display-lg;
+            @include text-title-lg;
             margin: 0 auto $spacing-2xl;
             max-width: 580px;
         }
@@ -52,7 +52,7 @@ $image-path: '/media/protocol/img';
 
         h2 {
             @include font-base;
-            @include text-display-lg;
+            @include text-title-lg;
         }
     }
 }

--- a/media/css/firefox/firstrun/firstrun.scss
+++ b/media/css/firefox/firstrun/firstrun.scss
@@ -52,7 +52,7 @@ section .mzp-l-content, div.mzp-c-hero-image, .browser-logo img {
 }
 
 .mzp-c-hero-title {
-    @include text-display-lg;
+    @include text-title-lg;
 }
 
 .fxa-email-field {
@@ -61,7 +61,7 @@ section .mzp-l-content, div.mzp-c-hero-image, .browser-logo img {
 
 .fxa-email-form-intro, .fxa-email-form-intro strong {
     font-weight: bold;
-    @include text-display-xs;
+    @include text-title-xs;
     display: inline;
 }
 

--- a/media/css/firefox/flashback/flashback.scss
+++ b/media/css/firefox/flashback/flashback.scss
@@ -30,7 +30,7 @@ $image-path: '/media/protocol/img';
     color: $color-yellow-30;
 
     h1 {
-        @include text-display-xxl;
+        @include text-title-xxl;
     }
 
     p {
@@ -55,15 +55,15 @@ $image-path: '/media/protocol/img';
     padding-bottom: $layout-2xl;
 
     h1 {
-        @include text-display-xl;
+        @include text-title-xl;
     }
 
     p {
         @include font-firefox;
-        @include text-display-lg;
+        @include text-title-lg;
         color: #fff;
         font-weight: bold;
-        line-height: $text-display-line-height;
+        line-height: $text-title-line-height;
         margin: $layout-lg auto;
     }
 }

--- a/media/css/firefox/home/master.scss
+++ b/media/css/firefox/home/master.scss
@@ -54,7 +54,7 @@ $image-path: '/media/protocol/img';
         max-width: $content-sm;
 
         h4 {
-            @include text-display-sm;
+            @include text-title-sm;
             margin-bottom: $layout-sm;
         }
     }
@@ -184,7 +184,7 @@ $image-path: '/media/protocol/img';
 }
 
 .c-showcase-title {
-    @include text-display-sm;
+    @include text-title-sm;
     margin-bottom: $spacing-lg;
 }
 
@@ -322,7 +322,7 @@ $image-path: '/media/protocol/img';
 }
 
 .c-end-title {
-    @include text-display-md;
+    @include text-title-md;
     color: #fff;
     margin-bottom: $spacing-2xl;
     margin-top: $layout-md;

--- a/media/css/firefox/home/quantum.scss
+++ b/media/css/firefox/home/quantum.scss
@@ -32,7 +32,7 @@ main .mzp-l-content {
 }
 
 .mzp-c-hero-desc {
-    @include text-display-xxl;
+    @include text-title-xxl;
     @include font-firefox;
     font-weight: bold;
     margin-bottom: $layout-md;
@@ -80,7 +80,7 @@ main .mzp-l-content {
 
     @media #{$mq-lg} {
         .mzp-c-card-feature-title {
-            @include text-display-lg;
+            @include text-title-lg;
         }
     }
 }
@@ -92,13 +92,13 @@ main .mzp-l-content {
 .c-trio {
 
     h2 {
-        @include text-display-lg;
+        @include text-title-lg;
         margin-top: $layout-lg;
         text-align: center;
     }
 
     h3 {
-        @include text-display-sm;
+        @include text-title-sm;
     }
 
     ul {

--- a/media/css/firefox/installer-help-redesign.scss
+++ b/media/css/firefox/installer-help-redesign.scss
@@ -33,6 +33,6 @@ $image-path: '/media/protocol/img';
     text-align: center;
 
     h2 {
-        @include text-display-xs;
+        @include text-title-xs;
     }
 }

--- a/media/css/firefox/installer-help.scss
+++ b/media/css/firefox/installer-help.scss
@@ -10,11 +10,11 @@ $image-path: '/media/protocol/img';
 @import '../../protocol/css/components/emphasis-box';
 
 .installer-help-title {
-    @include text-display-md;
+    @include text-title-md;
 }
 
 .installer-help-subtitle {
-    @include text-display-xs;
+    @include text-title-xs;
     font-weight: normal;
 }
 
@@ -24,7 +24,7 @@ $image-path: '/media/protocol/img';
 }
 
 .installer-help-emphasis-title {
-    @include text-display-xs;
+    @include text-title-xs;
 }
 
 .installer-help-emphasis-tagline {

--- a/media/css/firefox/lockwise/lockwise.scss
+++ b/media/css/firefox/lockwise/lockwise.scss
@@ -78,7 +78,7 @@ h1 {
 }
 
 .hero-subheading {
-    @include text-display-md;
+    @include text-title-md;
 }
 
 @media #{$mq-sm} {

--- a/media/css/firefox/mobile/get-app.scss
+++ b/media/css/firefox/mobile/get-app.scss
@@ -16,7 +16,7 @@ main {
 
     h1 {
         @include at2x('/media/protocol/img/logos/firefox/browser/logo-sm.png', 64px, 64px);
-        @include text-display-md;
+        @include text-title-md;
         background-position: top center;
         background-repeat: no-repeat;
         padding-top: 64px + $spacing-lg;

--- a/media/css/firefox/mobile/mobile.scss
+++ b/media/css/firefox/mobile/mobile.scss
@@ -150,7 +150,7 @@ main .mzp-l-content {
     }
 
     .mzp-c-hero-desc {
-        @include text-display-sm;
+        @include text-title-sm;
 
         p {
             margin-bottom: $spacing-lg;
@@ -202,7 +202,7 @@ main .mzp-l-content {
     color: #fff;
 
     h2 {
-        @include text-display-lg;
+        @include text-title-lg;
         color: $color-pink-50;
         margin-top: $spacing-md;
     }
@@ -230,7 +230,7 @@ main .mzp-l-content {
 
     h3 {
         @include bidi(((text-align, left, right),));
-        @include text-display-sm;
+        @include text-title-sm;
         margin-top: $spacing-2xl;
     }
 
@@ -285,7 +285,7 @@ main .mzp-l-content {
     }
 
     .mzp-c-card-feature-title {
-        @include text-display-lg;
+        @include text-title-lg;
         color: $color-ink-80;
     }
 
@@ -423,7 +423,7 @@ main .mzp-l-content {
     padding-right: 0;
 
     h3 {
-        @include text-display-md;
+        @include text-title-md;
         color: $color-ink-80;
         margin-bottom: 0;
 

--- a/media/css/firefox/new/trailhead/download.scss
+++ b/media/css/firefox/new/trailhead/download.scss
@@ -232,7 +232,7 @@ html.ios .mzp-c-hero {
     text-align: center;
 
     .other-platforms-title {
-        @include text-display-sm;
+        @include text-title-sm;
         margin-bottom: $spacing-2xl;
     }
 
@@ -363,7 +363,7 @@ html.ios .mzp-c-hero {
     text-align: center;
 
     .join-firefox-title {
-        @include text-display-sm;
+        @include text-title-sm;
     }
 
     .join-firefox-button {

--- a/media/css/firefox/new/trailhead/thanks-b.scss
+++ b/media/css/firefox/new/trailhead/thanks-b.scss
@@ -16,13 +16,13 @@ $image-path: '/media/protocol/img';
     background: transparent;
 
     .mzp-c-call-out-title {
-        @include text-display-xl;
+        @include text-title-xl;
         max-width: 610px;
         margin: 0 auto;
     }
 
     h2 {
-        @include text-display-sm;
+        @include text-title-sm;
         margin-top: $spacing-md;
         text-align: center;
     }
@@ -37,10 +37,10 @@ $image-path: '/media/protocol/img';
     padding: 0 $layout-md;
 
     .c-picto-block-title {
-        @include text-display-xxs;
+        @include text-title-xxs;
 
         &:before {
-            @include text-display-xxs;
+            @include text-title-xxs;
             background: $color-dark-gray-20;
             border-radius: 50%;
             color: $color-white;
@@ -83,7 +83,7 @@ $image-path: '/media/protocol/img';
     text-align: center;
 
     h3 {
-        @include text-display-xs;
+        @include text-title-xs;
         color: $color-ink-60;
         margin: $spacing-md $spacing-2xl;
     }

--- a/media/css/firefox/new/trailhead/thanks.scss
+++ b/media/css/firefox/new/trailhead/thanks.scss
@@ -36,6 +36,10 @@ $image-path: '/media/protocol/img';
             display: block;
         }
     }
+
+    @media #{$mq-sm} {
+        margin: $layout-xs auto 0;
+    }
 }
 
 main {

--- a/media/css/firefox/new/trailhead/thanks.scss
+++ b/media/css/firefox/new/trailhead/thanks.scss
@@ -65,7 +65,7 @@ main {
     background: transparent;
 
     .mzp-c-call-out-title {
-        @include text-display-xl;
+        @include text-title-xl;
         max-width: 610px;
         margin: 0 auto;
     }

--- a/media/css/firefox/new/trailhead/thanks.scss
+++ b/media/css/firefox/new/trailhead/thanks.scss
@@ -36,10 +36,6 @@ $image-path: '/media/protocol/img';
             display: block;
         }
     }
-
-    @media #{$mq-sm} {
-        margin: $layout-xs auto 0;
-    }
 }
 
 main {

--- a/media/css/firefox/nightly-firstrun.scss
+++ b/media/css/firefox/nightly-firstrun.scss
@@ -37,7 +37,7 @@ main {
     padding-top: 0;
 
     .contribute-title {
-        @include text-display-xs;
+        @include text-title-xs;
         font-weight: normal;
         margin: $spacing-lg auto;
         max-width: 580px;
@@ -80,6 +80,6 @@ main {
     h4,
     h5,
     h6 {
-        @include text-display-sm;
+        @include text-title-sm;
     }
 }

--- a/media/css/firefox/pocket.scss
+++ b/media/css/firefox/pocket.scss
@@ -85,7 +85,7 @@ $image-path: '/media/protocol/img';
     margin-top: $spacing-xl;
 
     .mzp-c-hero-title {
-        @include text-display-md;
+        @include text-title-md;
         margin-bottom: $layout-md;
     }
 

--- a/media/css/firefox/privacy/common.scss
+++ b/media/css/firefox/privacy/common.scss
@@ -21,7 +21,7 @@ $image-path: '/media/protocol/img';
     background-color: $color-white;
 
     .mzp-c-call-out-title {
-        @include text-display-xs;
+        @include text-title-xs;
         background: url('/media/img/firefox/privacy/icon-privacy.svg') top center no-repeat;
         padding-top: 70px + $spacing-lg;
     }

--- a/media/css/firefox/privacy/products.scss
+++ b/media/css/firefox/privacy/products.scss
@@ -20,7 +20,7 @@ $image-path: '/media/protocol/img';
     background-color: $color-white;
 
     .mzp-c-call-out-title {
-        @include text-display-lg;
+        @include text-title-lg;
         margin: $spacing-md 0;
 
         strong {
@@ -51,7 +51,7 @@ $image-path: '/media/protocol/img';
     }
 
     .privacy-products-hero-sub-title {
-        @include text-display-md;
+        @include text-title-md;
     }
 
     .privacy-products-hero-tagline {

--- a/media/css/firefox/privacy/promise.scss
+++ b/media/css/firefox/privacy/promise.scss
@@ -66,7 +66,7 @@ $image-path: '/media/protocol/img';
     background: $color-white;
 
     .mzp-c-call-out-title {
-        @include text-display-sm;
+        @include text-title-sm;
     }
 }
 
@@ -81,7 +81,7 @@ $image-path: '/media/protocol/img';
     }
 
     .privacy-promise-sub-title {
-        @include text-display-xs;
+        @include text-title-xs;
     }
 
     &:last-child {

--- a/media/css/firefox/releasenotes.scss
+++ b/media/css/firefox/releasenotes.scss
@@ -22,7 +22,7 @@ $image-path: '/media/protocol/img';
         display: inline-block;
 
         h3 {
-            @include text-display-xs;
+            @include text-title-xs;
             margin-bottom: $spacing-sm;
         }
 
@@ -195,7 +195,7 @@ $image-path: '/media/protocol/img';
 
 .c-release-version {
     @include font-base;
-    @include text-display-xl;
+    @include text-title-xl;
 }
 
 .c-release-first-text,
@@ -206,22 +206,22 @@ $image-path: '/media/protocol/img';
 .mzp-l-content {
     .c-release-product {
         @include font-base;
-        @include text-display-xxs;
+        @include text-title-xxs;
     }
      .c-release-date {
         @include font-base;
-        @include text-display-xxs;
+        @include text-title-xxs;
     }
 
     .c-release-first-title,
     .c-release-draft-title {
         @include font-base;
-        @include text-display-xxs;
+        @include text-title-xxs;
         font-weight: bold;
 
         // pushes the text down after the big release-version text
         &:before {
-            @include text-display-xl;
+            @include text-title-xl;
             content: '.';
             display: block;
             visibility: hidden;
@@ -230,7 +230,7 @@ $image-path: '/media/protocol/img';
 
     h3 {
         @include font-base;
-        @include text-display-xs;
+        @include text-title-xs;
         margin-bottom: $layout-sm;
     }
 }

--- a/media/css/firefox/releases-index.scss
+++ b/media/css/firefox/releases-index.scss
@@ -8,7 +8,7 @@ $image-path: '/media/protocol/img';
 
 
 .c-logo {
-    @include text-display-xs;
+    @include text-title-xs;
     color: inherit;
     display: inline-block;
     font-weight: bold;
@@ -59,7 +59,7 @@ $image-path: '/media/protocol/img';
 }
 
 .mzp-l-content h1 {
-    @include text-display-lg;
+    @include text-title-lg;
 }
 
 .c-release-list {

--- a/media/css/firefox/retention/thank-you.scss
+++ b/media/css/firefox/retention/thank-you.scss
@@ -73,7 +73,7 @@ main {
         }
 
         p {
-            @include text-display-sm;
+            @include text-title-sm;
             max-width: 800px;
         }
     }
@@ -93,7 +93,7 @@ main {
             width: 100%;
 
             h2 {
-                @include text-display-xs;
+                @include text-title-xs;
                 color: $color-black;
             }
 

--- a/media/css/firefox/set-as-default/thanks.scss
+++ b/media/css/firefox/set-as-default/thanks.scss
@@ -14,17 +14,17 @@ $image-path: '/media/protocol/img';
 
 .thanks-hero.mzp-t-product-firefox {
     .mzp-c-hero-title {
-        @include text-display-xl;
+        @include text-title-xl;
         @include background-size(60px 60px);
         padding-top: 84px;
     }
 
     .mzp-c-hero-desc {
-        @include text-display-xs;
+        @include text-title-xs;
     }
 
     .thanks-help-text {
-        @include text-display-xxs;
+        @include text-title-xxs;
         margin-top: $layout-lg;
     }
 }
@@ -139,5 +139,5 @@ $image-path: '/media/protocol/img';
 }
 
 .thanks-extra-links-heading {
-    @include text-display-xs;
+    @include text-title-xs;
 }

--- a/media/css/firefox/system-requirements.scss
+++ b/media/css/firefox/system-requirements.scss
@@ -64,7 +64,7 @@ $image-path: '/media/protocol/img';
     }
 
     h1 {
-        @include text-display-xs;
+        @include text-title-xs;
         font-weight: bold;
     }
 
@@ -108,16 +108,16 @@ $image-path: '/media/protocol/img';
 
 .mzp-c-article {
     h1 {
-        @include text-display-lg;
+        @include text-title-lg;
         margin-bottom: $layout-md;
     }
 
     h2 {
-        @include text-display-md;
+        @include text-title-md;
     }
 
     h3 {
-        @include text-display-xs;
+        @include text-title-xs;
     }
 
     // copied straight out of Protocol because we can't add the utility class to the lists

--- a/media/css/firefox/testflight.scss
+++ b/media/css/firefox/testflight.scss
@@ -21,7 +21,7 @@ $image-path: '/media/protocol/img';
 // Newsletter Form
 
 h4 {
-    @include text-display-sm;
+    @include text-title-sm;
 }
 
 .mzp-c-newsletter-form {

--- a/media/css/firefox/unsupported-systems.scss
+++ b/media/css/firefox/unsupported-systems.scss
@@ -15,7 +15,7 @@ $image-path: '/media/protocol/img';
 }
 
 .c-header-main {
-    @include text-display-md;
+    @include text-title-md;
     margin-top: $spacing-lg;
 }
 
@@ -28,5 +28,5 @@ $image-path: '/media/protocol/img';
 }
 
 .c-help-block-title {
-    @include text-display-xs;
+    @include text-title-xs;
 }

--- a/media/css/firefox/welcome.scss
+++ b/media/css/firefox/welcome.scss
@@ -72,7 +72,7 @@ $image-path: '/media/protocol/img';
 }
 
 .mzp-c-hero-title {
-    @include text-display-lg;
+    @include text-title-lg;
     margin-bottom: $layout-sm;
 
     .welcome-page1 &,
@@ -80,7 +80,7 @@ $image-path: '/media/protocol/img';
     .welcome-page5 &,
     .welcome-page6 &,
     .welcome-page7 & {
-        @include text-display-md;
+        @include text-title-md;
     }
 
     .welcome-page4 & {
@@ -109,7 +109,7 @@ $image-path: '/media/protocol/img';
     }
 
     .primary-image-desc {
-        @include text-display-xxs;
+        @include text-title-xxs;
         font-style: italic;
         margin: $layout-sm 0 $layout-xl 0;
     }
@@ -130,7 +130,7 @@ $image-path: '/media/protocol/img';
     padding: 0 $layout-md;
 
     .c-picto-block-title {
-        @include text-display-xs;
+        @include text-title-xs;
     }
 
     .c-picto-block-image {
@@ -219,7 +219,7 @@ $image-path: '/media/protocol/img';
     }
 
     .modal-title {
-        @include text-display-sm;
+        @include text-title-sm;
         margin-top: $spacing-xl;
     }
 }
@@ -263,7 +263,7 @@ $image-path: '/media/protocol/img';
     padding: 0;
 
     .modal-title {
-        @include text-display-md;
+        @include text-title-md;
         color: $color-ink-80;
         margin-bottom: 0;
 

--- a/media/css/firefox/whatsnew/whatsnew-70.scss
+++ b/media/css/firefox/whatsnew/whatsnew-70.scss
@@ -19,7 +19,7 @@ $image-path: '/media/protocol/img';
 }
 
 .c-section-title-secondary {
-    @include text-display-xxs;
+    @include text-title-xxs;
     margin: 0 auto $layout-md;
     max-width: $content-md - ($layout-md * 2);
 }
@@ -52,7 +52,7 @@ $image-path: '/media/protocol/img';
     }
 
     .c-emphasis-box-title {
-        @include text-display-sm;
+        @include text-title-sm;
     }
 
 
@@ -77,7 +77,7 @@ $image-path: '/media/protocol/img';
     padding: 0 $layout-md;
 
     .c-picto-block-title {
-        @include text-display-xs;
+        @include text-title-xs;
     }
 
     .c-picto-block-image {

--- a/media/css/firefox/whatsnew/whatsnew-71.scss
+++ b/media/css/firefox/whatsnew/whatsnew-71.scss
@@ -18,13 +18,13 @@ $image-path: '/media/protocol/img';
 }
 
 .c-section-title-secondary {
-    @include text-display-xxs;
+    @include text-title-xxs;
     margin: 0 auto $layout-md;
     max-width: $content-md - ($layout-md * 2);
 }
 
 .c-section-title {
-    @include text-display-sm;
+    @include text-title-sm;
     margin: 0 auto $layout-md;
     max-width: $content-md - ($layout-md * 2);
     text-align: center;
@@ -67,11 +67,11 @@ $image-path: '/media/protocol/img';
     }
 
     .c-emphasis-box-title {
-        @include text-display-sm;
+        @include text-title-sm;
     }
 
     .c-emphasis-box-tagline {
-        @include text-display-xs;
+        @include text-title-xs;
     }
 
     .cta {
@@ -99,7 +99,7 @@ $image-path: '/media/protocol/img';
     padding: 0 $layout-md;
 
     .c-picto-block-title {
-        @include text-display-xs;
+        @include text-title-xs;
     }
 
     .c-picto-block-image {
@@ -155,7 +155,7 @@ $image-path: '/media/protocol/img';
     }
 
     .c-picto-block-body.t-big {
-        @include text-display-xs;
+        @include text-title-xs;
         min-height: 60px;
     }
 }

--- a/media/css/firefox/whatsnew/whatsnew-73.scss
+++ b/media/css/firefox/whatsnew/whatsnew-73.scss
@@ -56,11 +56,11 @@ $image-path: '/media/protocol/img';
     }
 
     .c-emphasis-box-title {
-        @include text-display-sm;
+        @include text-title-sm;
     }
 
     .c-emphasis-box-tagline {
-        @include text-display-xs;
+        @include text-title-xs;
     }
 
     .cta {
@@ -115,7 +115,7 @@ $image-path: '/media/protocol/img';
     padding: 0 $layout-md;
 
     .c-picto-block-title {
-        @include text-display-xs;
+        @include text-title-xs;
     }
 
     .c-picto-block-image {
@@ -173,7 +173,7 @@ $image-path: '/media/protocol/img';
     padding-right: 0;
 
     h3 {
-        @include text-display-md;
+        @include text-title-md;
         color: $color-ink-80;
         margin-bottom: 0;
     }

--- a/media/css/firefox/whatsnew/whatsnew-74.scss
+++ b/media/css/firefox/whatsnew/whatsnew-74.scss
@@ -55,11 +55,11 @@ $image-path: '/media/protocol/img';
     }
 
     .c-emphasis-box-title {
-        @include text-display-sm;
+        @include text-title-sm;
     }
 
     .c-emphasis-box-tagline {
-        @include text-display-xs;
+        @include text-title-xs;
     }
 
     .cta {
@@ -114,7 +114,7 @@ $image-path: '/media/protocol/img';
     padding: 0 $layout-md;
 
     .c-picto-block-title {
-        @include text-display-xs;
+        @include text-title-xs;
     }
 
     .c-picto-block-image {

--- a/media/css/firefox/whatsnew/whatsnew-75.scss
+++ b/media/css/firefox/whatsnew/whatsnew-75.scss
@@ -60,11 +60,11 @@ $image-path: '/media/protocol/img';
     }
 
     .c-emphasis-box-title {
-        @include text-display-sm;
+        @include text-title-sm;
     }
 
     .c-emphasis-box-tagline {
-        @include text-display-xs;
+        @include text-title-xs;
     }
 
     .cta {
@@ -123,7 +123,7 @@ $image-path: '/media/protocol/img';
     padding: 0 $layout-md;
 
     .c-picto-block-title {
-        @include text-display-xs;
+        @include text-title-xs;
     }
 
     .c-picto-block-image {

--- a/media/css/firefox/whatsnew/whatsnew-76.scss
+++ b/media/css/firefox/whatsnew/whatsnew-76.scss
@@ -60,11 +60,11 @@ $image-path: '/media/protocol/img';
     }
 
     .c-emphasis-box-title {
-        @include text-display-sm;
+        @include text-title-sm;
     }
 
     .c-emphasis-box-tagline {
-        @include text-display-xs;
+        @include text-title-xs;
     }
 
     .cta {
@@ -102,7 +102,7 @@ $image-path: '/media/protocol/img';
     padding: 0 $layout-md;
 
     .c-picto-block-title {
-        @include text-display-xs;
+        @include text-title-xs;
     }
 
     .c-picto-block-image {

--- a/media/css/firefox/whatsnew/whatsnew-account.scss
+++ b/media/css/firefox/whatsnew/whatsnew-account.scss
@@ -18,13 +18,13 @@ $image-path: '/media/protocol/img';
 }
 
 .c-section-title-secondary {
-    @include text-display-xxs;
+    @include text-title-xxs;
     margin: 0 auto $layout-md;
     max-width: $content-md - ($layout-md * 2);
 }
 
 .c-section-title {
-    @include text-display-sm;
+    @include text-title-sm;
     margin: 0 auto $layout-md;
     max-width: $content-md - ($layout-md * 2);
     text-align: center;
@@ -67,11 +67,11 @@ $image-path: '/media/protocol/img';
     }
 
     .c-emphasis-box-title {
-        @include text-display-sm;
+        @include text-title-sm;
     }
 
     .c-emphasis-box-tagline {
-        @include text-display-xs;
+        @include text-title-xs;
     }
 
     .cta {

--- a/media/css/firefox/whatsnew/whatsnew-lite-in.scss
+++ b/media/css/firefox/whatsnew/whatsnew-lite-in.scss
@@ -15,7 +15,7 @@
     text-align: center;
 
     .c-page-header-up-to-date {
-        @include text-display-xs;
+        @include text-title-xs;
 
         display: none;
         font-weight: normal;
@@ -138,7 +138,7 @@
         font-weight: normal;
         margin-bottom: 0;
         text-align: start;
-        @include text-display-lg;
+        @include text-title-lg;
         @media #{$mq-xl} {
             font-size: 4rem;
         }
@@ -163,7 +163,7 @@
 }
 
 .lite-text {
-    @include text-display-sm;
+    @include text-title-sm;
     @include font-firefox;
     margin: 0 auto $spacing-lg;
     padding: $spacing-lg 0;

--- a/media/css/firefox/whatsnew/whatsnew-lite.scss
+++ b/media/css/firefox/whatsnew/whatsnew-lite.scss
@@ -15,7 +15,7 @@
     text-align: center;
 
     .c-page-header-up-to-date {
-        @include text-display-xs;
+        @include text-title-xs;
 
         display: none;
         font-weight: normal;
@@ -138,7 +138,7 @@
     }
 
     h2 {
-        @include text-display-lg;
+        @include text-title-lg;
         @include font-firefox;
         font-weight: normal;
         font-size: 2rem;
@@ -170,7 +170,7 @@
 }
 
 .lite-text {
-    @include text-display-sm;
+    @include text-title-sm;
     @include font-firefox;
     margin: 0 auto $spacing-lg;
     padding: $spacing-lg 0;

--- a/media/css/firefox/whatsnew/whatsnew-nightly.scss
+++ b/media/css/firefox/whatsnew/whatsnew-nightly.scss
@@ -43,7 +43,7 @@ $image-path: '/media/protocol/img';
     }
 
     .c-emphasis-box-title {
-        @include text-display-sm;
+        @include text-title-sm;
         text-align: center;
     }
 }

--- a/media/css/firefox/whatsnew/whatsnew.scss
+++ b/media/css/firefox/whatsnew/whatsnew.scss
@@ -21,7 +21,7 @@ $image-path: '/media/protocol/img';
     text-align: center;
 
     .main-title {
-        @include text-display-md;
+        @include text-title-md;
 
         br {
             display: none;
@@ -29,7 +29,7 @@ $image-path: '/media/protocol/img';
     }
 
     .main-tagline {
-        @include text-display-sm;
+        @include text-title-sm;
     }
 
     header {

--- a/media/css/firefox/whatsnew/whatsnew.scss
+++ b/media/css/firefox/whatsnew/whatsnew.scss
@@ -69,6 +69,12 @@ $image-path: '/media/protocol/img';
     @include background-size(100%);
 }
 
-.send-to-device-form .inline-field {
-    margin-bottom: $spacing-md;
+.send-to-device-form {
+    label {
+        color: $color-white;
+    }
+
+    .inline-field {
+        margin-bottom: $spacing-md;
+    }
 }

--- a/media/css/foundation/annual-report.scss
+++ b/media/css/foundation/annual-report.scss
@@ -181,7 +181,7 @@
 
     p {
         @include font-mozilla;
-        @include text-display-sm;
+        @include text-title-sm;
         font-style: italic;
         margin-bottom: 0;
     }
@@ -193,11 +193,11 @@
 
     .c-copy-wrapper {
         h2 {
-            @include text-display-sm;
+            @include text-title-sm;
         }
 
         h3 {
-            @include text-display-xs;
+            @include text-title-xs;
         }
 
         img {

--- a/media/css/grants/grants.scss
+++ b/media/css/grants/grants.scss
@@ -8,7 +8,7 @@
     margin: $layout-md 0;
 
     .c-grants-info-title {
-        @include text-display-xxs;
+        @include text-title-xxs;
     }
 
     li {

--- a/media/css/legal/legal.scss
+++ b/media/css/legal/legal.scss
@@ -14,16 +14,16 @@ $image-path: '/media/protocol/img';
 
 .mzp-c-article {
     h1 {
-        @include text-display-xl;
+        @include text-title-xl;
     }
 
     h2 {
-        @include text-display-sm;
+        @include text-title-sm;
         margin-top: $spacing-lg;
     }
 
     h3 {
-        @include text-display-xs;
+        @include text-title-xs;
     }
 }
 

--- a/media/css/mozorg/about-patents.scss
+++ b/media/css/mozorg/about-patents.scss
@@ -22,11 +22,11 @@ ol li ol {
 
 #faq {
     h2 {
-        @include text-display-lg;
+        @include text-title-lg;
     }
 
     h3 {
-        @include text-display-xs;
+        @include text-title-xs;
         @include font-base;
     }
 

--- a/media/css/mozorg/about-transparency.scss
+++ b/media/css/mozorg/about-transparency.scss
@@ -11,7 +11,7 @@
 
 dt {
     @include font-mozilla;
-    @include text-display-xs;
+    @include text-title-xs;
     font-weight: bold;
     margin-top: $spacing-sm;
 }
@@ -73,12 +73,12 @@ dd {
 
 .c-page-header {
     @include font-mozilla;
-    @include text-display-xs;
+    @include text-title-xs;
     background: $color-black;
     color: $color-white;
 
     span {
-        @include text-display-xs;
+        @include text-title-xs;
         display: block;
         margin-top: $spacing-md;
     }
@@ -90,13 +90,13 @@ dd {
 
 h2 {
     @include font-mozilla;
-    @include text-display-md;
+    @include text-title-md;
     margin-top: $spacing-2xl;
 }
 
 h3 {
     @include font-mozilla;
-    @include text-display-sm;
+    @include text-title-sm;
     margin-top: $spacing-2xl;
 }
 
@@ -110,7 +110,7 @@ h3 {
   .c-collapsible-section button {
     @include font-mozilla;
     @include summary;
-    @include text-display-md;
+    @include text-title-md;
     background: transparent;
     border: none;
     cursor: pointer;

--- a/media/css/mozorg/about.scss
+++ b/media/css/mozorg/about.scss
@@ -69,7 +69,7 @@ $image-path: '/media/protocol/img';
 // Page title
 
 .c-page-title {
-    @include text-display-sm;
+    @include text-title-sm;
     margin-top: $spacing-xs;
     margin-bottom: $spacing-md;
 

--- a/media/css/mozorg/contact-spaces.scss
+++ b/media/css/mozorg/contact-spaces.scss
@@ -170,7 +170,7 @@ $image-path: '/media/protocol/img';
     margin-bottom: $spacing-xl;
 
     h2 {
-        @include text-display-md;
+        @include text-title-md;
     }
 
     .card {

--- a/media/css/mozorg/contribute/contribute.scss
+++ b/media/css/mozorg/contribute/contribute.scss
@@ -32,7 +32,7 @@ $image-path: '/media/protocol/img';
 }
 
 .contribute-section-subheading {
-    @include text-display-xs;
+    @include text-title-xs;
 }
 
 .contribute-section-lead-in {
@@ -53,7 +53,7 @@ $image-path: '/media/protocol/img';
         text-align: center;
 
         strong {
-            @include text-display-md;
+            @include text-title-md;
             display: block;
         }
     }

--- a/media/css/mozorg/home/home-2018.scss
+++ b/media/css/mozorg/home/home-2018.scss
@@ -63,7 +63,7 @@ $image-path: '/media/protocol/img';
 }
 
 .c-primary-cta-title {
-    @include text-display-lg;
+    @include text-title-lg;
     margin-bottom: 0;
 }
 
@@ -71,7 +71,7 @@ h3,
 h4 {
     &.c-primary-cta-title-sub {
         @include font-base;
-        @include text-display-sm;
+        @include text-title-sm;
         max-width: 430px;
         margin: 0 auto;
     }
@@ -338,7 +338,7 @@ h4 {
     margin: 20px 0;
 
     .section-heading {
-        @include text-display-xs;
+        @include text-title-xs;
         margin-bottom: $spacing-sm;
     }
 
@@ -382,7 +382,7 @@ h4 {
 
 .c-secondary-cta-title {
     @include at2x('#{$image-path}/logos/firefox/browser/logo-sm.png', 40px, 40px);
-    @include text-display-md;
+    @include text-title-md;
     background-position: center 35px;
     background-repeat: no-repeat;
     margin-bottom: $spacing-sm;

--- a/media/css/mozorg/home/home.scss
+++ b/media/css/mozorg/home/home.scss
@@ -47,7 +47,7 @@ $image-path: '/media/protocol/img';
 
     @media #{$mq-lg} {
         .mzp-c-card-picto-title {
-            @include text-display-sm;
+            @include text-title-sm;
             margin-bottom: $spacing-xl;
         }
     }

--- a/media/css/mozorg/leadership.scss
+++ b/media/css/mozorg/leadership.scss
@@ -37,7 +37,7 @@ $image-path: '/media/protocol/img';
 
 // Headings
 .section-title {
-    @include text-display-md;
+    @include text-title-md;
     margin: .5em 0;
 }
 
@@ -47,7 +47,7 @@ $image-path: '/media/protocol/img';
 }
 
 .group-title {
-    @include text-display-sm;
+    @include text-title-sm;
     margin: 1em 0;
     padding-top: .75em;
     border-top: 2px solid $color-marketing-gray-30;
@@ -107,7 +107,7 @@ $image-path: '/media/protocol/img';
     }
 
     .fn {
-        @include text-display-xxs;
+        @include text-title-xxs;
         font-weight: bold;
     }
 
@@ -298,12 +298,12 @@ $image-path: '/media/protocol/img';
     }
 
     .fn {
-        @include text-display-md;
+        @include text-title-md;
         text-align: left;
     }
 
     .title {
-        @include text-display-sm;
+        @include text-title-sm;
     }
 
     .person-bio {
@@ -396,7 +396,7 @@ $image-path: '/media/protocol/img';
 
         .fn {
             @include bidi(((text-align, left, right),));
-            @include text-display-md;
+            @include text-title-md;
             color: $color-black;
             text-decoration: none;
         }
@@ -407,7 +407,7 @@ $image-path: '/media/protocol/img';
     }
 
     .title {
-        @include text-display-xs;
+        @include text-title-xs;
         font-weight: bold;
     }
 

--- a/media/css/mozorg/lean-data.scss
+++ b/media/css/mozorg/lean-data.scss
@@ -15,11 +15,11 @@ $image-path: '/media/protocol/img';
 }
 
 .c-section-title {
-    @include text-display-md;
+    @include text-title-md;
 }
 
 .c-subsection-title {
-    @include text-display-sm;
+    @include text-title-sm;
 }
 
 .u-center {

--- a/media/css/mozorg/locales.scss
+++ b/media/css/mozorg/locales.scss
@@ -16,7 +16,7 @@ $image-path: '/media/protocol/img';
     text-align: center;
 
     .c-simple-header-title {
-        @include text-display-md;
+        @include text-title-md;
     }
 
     @media #{$mq-md} {
@@ -28,7 +28,7 @@ $image-path: '/media/protocol/img';
     margin: $layout-md 0;
 
     .c-block-list-title {
-        @include text-display-sm;
+        @include text-title-sm;
         border-bottom: 1px solid $color-marketing-gray-30;
         padding-bottom: $spacing-md;
     }

--- a/media/css/mozorg/manifesto.scss
+++ b/media/css/mozorg/manifesto.scss
@@ -10,7 +10,7 @@ $image-path: '/media/protocol/img';
 @import '../../protocol/css/components/newsletter-form';
 
 .manifesto-title {
-    @include text-display-sm;
+    @include text-title-sm;
     margin-top: $spacing-2xl;
 }
 
@@ -19,7 +19,7 @@ Addendum
 ====================================================================== */
 
 .addendum-subtitle {
-    @include text-display-xxl;
+    @include text-title-xxl;
 }
 
 .addendum-list {
@@ -27,7 +27,7 @@ Addendum
 
     li {
         @include font-mozilla;
-        @include text-display-sm;
+        @include text-title-sm;
         padding-bottom: $spacing-2xl;
         padding-top: $spacing-xl;
         position: relative;
@@ -95,7 +95,7 @@ Principles
 }
 
 .principle-number {
-    @include text-display-xs;
+    @include text-title-xs;
     display: block;
     font-weight: bold;
     margin-bottom: $spacing-sm;
@@ -103,7 +103,7 @@ Principles
 
 .principle-header {
     h3 {
-        @include text-display-md;
+        @include text-title-md;
         font-weight: normal;
     }
 
@@ -118,7 +118,7 @@ Principles
     margin-top: $spacing-lg;
 
     h4 {
-        @include text-display-xxs;
+        @include text-title-xxs;
     }
 
     @media #{$mq-md} {

--- a/media/css/mozorg/moss.scss
+++ b/media/css/mozorg/moss.scss
@@ -22,7 +22,7 @@ $image-path: '/media/protocol/img';
 // Sections & headings
 
 .moss-section-heading {
-    @include text-display-md;
+    @include text-title-md;
     margin-bottom: $spacing-xl;
 
     @media #{$mq-md} {
@@ -31,7 +31,7 @@ $image-path: '/media/protocol/img';
 }
 
 .moss-section-subhead {
-    @include text-display-sm;
+    @include text-title-sm;
 
     @media #{$mq-md} {
         text-align: center;
@@ -68,7 +68,7 @@ $image-path: '/media/protocol/img';
     }
 
     .page-heading {
-        @include text-display-md;
+        @include text-title-md;
         text-align: center;
         margin-bottom: 0;
     }

--- a/media/css/mozorg/participation-reporting.scss
+++ b/media/css/mozorg/participation-reporting.scss
@@ -29,7 +29,7 @@ $image-path: '/media/protocol/img';
 }
 
 .mzp-c-article blockquote {
-    @include text-display-xs;
+    @include text-title-xs;
     line-height: 1.5;
     font-weight: normal;
 }

--- a/media/css/newsletter/newsletter-developer.scss
+++ b/media/css/newsletter/newsletter-developer.scss
@@ -29,7 +29,7 @@ $image-path: '/media/protocol/img';
         height: 290px;
 
         .page-title {
-            @include text-display-xl;
+            @include text-title-xl;
             margin-top: 150px;
         }
     }
@@ -52,7 +52,7 @@ $image-path: '/media/protocol/img';
     padding: $spacing-lg 0;
 
     h2 {
-        @include text-display-xs;
+        @include text-title-xs;
         color: $color-blue-70;
         font-weight: normal;
         line-height: 1.3;

--- a/media/css/newsletter/newsletter-firefox.scss
+++ b/media/css/newsletter/newsletter-firefox.scss
@@ -55,12 +55,12 @@ $image-path: '/media/protocol/img';
     padding: $spacing-lg 0;
 
     h1 {
-        @include text-display-xl;
+        @include text-title-xl;
         text-align: center;
     }
 
     h2 {
-        @include text-display-xs;
+        @include text-title-xs;
         color: $color-ink-80;
         font-weight: normal;
         margin: $spacing-lg auto $spacing-xl;

--- a/media/css/newsletter/newsletter-mozilla.scss
+++ b/media/css/newsletter/newsletter-mozilla.scss
@@ -63,7 +63,7 @@ $image-path: '/media/protocol/img';
     background: $color-white;
 
     h2 {
-        @include text-display-xs;
+        @include text-title-xs;
         color: $color-red-60;
         font-weight: normal;
         margin: $spacing-lg auto $spacing-xl;

--- a/media/css/newsletter/newsletter-opt-out-confirmation.scss
+++ b/media/css/newsletter/newsletter-opt-out-confirmation.scss
@@ -37,7 +37,7 @@ header {
 
     @media #{$mq-md} {
         .tagline {
-            @include text-display-md;
+            @include text-title-md;
         }
     }
 }
@@ -77,7 +77,7 @@ form {
 
 aside {
     h2 {
-        @include text-display-sm;
+        @include text-title-sm;
         margin-bottom: 40px;
     }
 

--- a/media/css/newsletter/newsletter.scss
+++ b/media/css/newsletter/newsletter.scss
@@ -16,12 +16,12 @@ $image-path: '/media/protocol/img';
 // Global styles.
 
 h1 {
-    @include text-display-md;
+    @include text-title-md;
     margin-bottom: $layout-sm;
 }
 
 h2 {
-    @include text-display-xs;
+    @include text-title-xs;
 }
 
 main {
@@ -37,7 +37,7 @@ main {
 }
 
 .error-msg, .errorlist {
-    @include text-display-xxs;
+    @include text-title-xxs;
     color: $color-red-60;
     display: block;
     font-weight: bold;
@@ -82,7 +82,7 @@ main {
 
     form {
         h4 {
-            @include text-display-xxs;
+            @include text-title-xxs;
         }
 
         p {
@@ -165,12 +165,12 @@ main {
     }
 
     h3 {
-        @include text-display-md;
+        @include text-title-md;
         margin-bottom: $spacing-2xl;
     }
 
     h4 {
-        @include text-display-xs;
+        @include text-title-xs;
     }
 
     .c-updated-form {

--- a/media/css/press/press.scss
+++ b/media/css/press/press.scss
@@ -13,7 +13,7 @@ $image-path: '/media/protocol/img';
     min-height: $content-sm;
 
     h2 {
-        @include text-display-xs;
+        @include text-title-xs;
     }
 }
 
@@ -53,7 +53,7 @@ fieldset {
 }
 
 .error-msg, .errorlist {
-    @include text-display-xxs;
+    @include text-title-xxs;
     color: $color-red-60;
     display: block;
     font-weight: bold;

--- a/media/css/privacy/privacy-email.scss
+++ b/media/css/privacy/privacy-email.scss
@@ -9,7 +9,7 @@ $image-path: '/media/protocol/img';
 @import '../../protocol/css/components/article';
 
 .mzp-c-article-title {
-    @include text-display-md;
+    @include text-title-md;
 }
 
 @media #{$mq-md} {

--- a/media/css/privacy/privacy-protocol.scss
+++ b/media/css/privacy/privacy-protocol.scss
@@ -82,7 +82,7 @@ $border: 2px solid $color-marketing-gray-20;
     }
 
     h1 {
-        @include text-display-xs;
+        @include text-title-xs;
         font-weight: bold;
     }
 
@@ -111,7 +111,7 @@ $border: 2px solid $color-marketing-gray-20;
     padding-bottom: $layout-xs;
 
     h2 {
-        @include text-display-lg;
+        @include text-title-lg;
     }
 }
 
@@ -130,7 +130,7 @@ $border: 2px solid $color-marketing-gray-20;
     }
 
     h3 {
-        @include text-display-xs;
+        @include text-title-xs;
         margin: $layout-sm 0;
     }
 
@@ -266,7 +266,7 @@ $border: 2px solid $color-marketing-gray-20;
 #privacy-principles {
 
     ol {
-        @include text-display-md;
+        @include text-title-md;
         @include font-mozilla;
         font-weight: bold;
         margin-left: 1.15em;

--- a/media/css/protocol/components/send-to-device.scss
+++ b/media/css/protocol/components/send-to-device.scss
@@ -11,7 +11,7 @@ $image-path: '/media/protocol/img';
     max-width: 500px;
 
     h2.thank-you {
-        @include text-display-xs;
+        @include text-title-xs;
     }
 
     .thank-you p {

--- a/media/css/protocol/protocol.scss
+++ b/media/css/protocol/protocol.scss
@@ -12,3 +12,12 @@ $image-path: '/media/protocol/img';
 @import 'components/navigation';
 @import 'components/download-button';
 @import 'components/footer';
+
+
+// This bug fix can be removed in the next Protocol version greater 11.0.2
+// Already fixed upstream in https://github.com/mozilla/protocol/commit/548e7ce3070372e7fe92f268fb3847e911d5038e
+@media #{$mq-sm} {
+    .mzp-c-notification-bar {
+        margin: $layout-xs auto 0;
+    }
+}

--- a/media/css/protocol/protocol.scss
+++ b/media/css/protocol/protocol.scss
@@ -17,7 +17,7 @@ $image-path: '/media/protocol/img';
 // This bug fix can be removed in the next Protocol version greater 11.0.2
 // Already fixed upstream in https://github.com/mozilla/protocol/commit/548e7ce3070372e7fe92f268fb3847e911d5038e
 @media #{$mq-sm} {
-    .mzp-c-notification-bar {
+    #outer-wrapper .mzp-c-notification-bar {
         margin: $layout-xs auto 0;
     }
 }

--- a/media/css/protocol/protocol.scss
+++ b/media/css/protocol/protocol.scss
@@ -12,8 +12,3 @@ $image-path: '/media/protocol/img';
 @import 'components/navigation';
 @import 'components/download-button';
 @import 'components/footer';
-
-// Can be removed once https://github.com/mozilla/protocol/issues/549 is fixed.
-.mzp-c-notification-bar {
-    @include border-box;
-}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Making mozilla.org awesome, one pebble at a time",
   "private": true,
   "dependencies": {
-    "@mozilla-protocol/core": "^11.0.1",
+    "@mozilla-protocol/core": "^11.0.2",
     "@mozilla-protocol/eslint-config": "^1.1.0",
     "ansi-colors": "4.1.1",
     "clean-css-cli": "4.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -138,10 +138,10 @@
     normalize-path "^2.0.1"
     through2 "^2.0.3"
 
-"@mozilla-protocol/core@^11.0.1":
-  version "11.0.1"
-  resolved "https://registry.yarnpkg.com/@mozilla-protocol/core/-/core-11.0.1.tgz#1f86a272db0fa705e8abbc171a83ff4c59b15433"
-  integrity sha512-z2vX1OMWZV1ZTTkAEhDpGOqMGhbkENXpgPFQ5G9E2neQhCxFKFrS9BVlXN9H3BvNwbkJJhxXEfyMFb6OtFD0Sg==
+"@mozilla-protocol/core@^11.0.2":
+  version "11.0.2"
+  resolved "https://registry.yarnpkg.com/@mozilla-protocol/core/-/core-11.0.2.tgz#d87bae1dc7294ed862868368c24557447195a7d2"
+  integrity sha512-482Bqtqm9dBK4Ik+OvTR4TAS5n3dycKB/bJT0BgcKnOEJCqATjyjXMd8aDgKzO+49dSwT6wqPcjqCxbaQJWL4Q==
 
 "@mozilla-protocol/eslint-config@^1.1.0":
   version "1.1.0"


### PR DESCRIPTION
## Description
Updates Protocol to [v11.0.2](https://github.com/mozilla/protocol/blob/master/CHANGELOG.md#1102)

This update includes the sticky nav but I haven't actually changed the nav in bedrock, we're only gaining the ability. Unblocks #8675 

## Testing
This ended up touching almost every css file because it renames the `text-display-*` mixins to `text-title-*` and I should have caught them all, but the old `text-display-*` ones are aliased so nothing should break even if I missed some. But it's worth giving it a fairly careful look to make sure I didn't get overzealous in my find/replace.

It also updates base form label styling and now declares a text color, so be on the lookout for forms on dark backgrounds where the labels might no longer inherit their color. I only found a few but I could have missed some.

There are minor updates to notification bars and the emphasis box but they should be superficial.

