### PR TITLE
Fix missing yandex bundle name (Issue #8801)

### DIFF
--- a/bedrock/firefox/templates/firefox/new/trailhead/download-yandex.html
+++ b/bedrock/firefox/templates/firefox/new/trailhead/download-yandex.html
@@ -52,6 +52,6 @@
 
 {% block js %}
   {{ super() }}
-  {{ js_bundle('firefox_new_scene1_yandex') }}
+  {{ js_bundle('firefox_new_download_yandex') }}
 {% endblock %}
 


### PR DESCRIPTION
## Description
Fixes https://sentry.prod.mozaws.net/operations/bedrock-dev/issues/8015222/

```
ValueError: Missing staticfiles manifest entry for 'js/BUNDLES/firefox_new_scene1_yandex.js'
```

## Issue / Bugzilla link
#8801

## Testing
- [ ] `/ru/firefox/new/` page should load JS bundle as expected.