### PR TITLE
Fluent active locales should be all of them in DEV mode

### DIFF
--- a/lib/l10n_utils/fluent.py
+++ b/lib/l10n_utils/fluent.py
@@ -76,9 +76,6 @@ class FluentL10n(FluentLocalization):
 
     @cached_property
     def active_locales(self):
-        if settings.DEV:
-            return settings.DEV_LANGUAGES if settings.DEV else settings.PROD_LANGUAGES
-
         # first resource is the one to check for activation
         return get_active_locales(self.resource_ids[0])
 
@@ -159,7 +156,16 @@ def write_metadata(ftl_file, data):
 
 
 @memoize
-def get_active_locales(ftl_file):
+def get_active_locales(ftl_file, force=False):
+    """Return the list of active locales for a Fluent file.
+
+    If `settings.DEV` is `True` it will just return the full list of
+    available languages. You can pass `force=True` to override this
+    behavior.
+    """
+    if settings.DEV and not force:
+        return settings.DEV_LANGUAGES
+
     locales = {settings.LANGUAGE_CODE}
     metadata = get_metadata(ftl_file)
     if metadata and 'active_locales' in metadata:

--- a/lib/l10n_utils/management/commands/active_locales.py
+++ b/lib/l10n_utils/management/commands/active_locales.py
@@ -29,7 +29,7 @@ class Command(BaseCommand):
         parser.add_argument('ftl_file')
 
     def print_report(self):
-        active_locales = get_active_locales(self.filename)
+        active_locales = get_active_locales(self.filename, force=True)
         num_locales = len(active_locales)
         if num_locales == 1:
             self.stdout.write(f'There is 1 active locale for {self.filename}:')


### PR DESCRIPTION
This will ensure that all functions that use `fluent.get_active_locales` treat all locales as active when `DEV=True`.