### PR TITLE
Add a 2nd treatment to socialproof experiment

### DIFF
--- a/bedrock/firefox/templates/firefox/releases/notes.html
+++ b/bedrock/firefox/templates/firefox/releases/notes.html
@@ -210,6 +210,17 @@
       </div>
     {% endif %}
 
+    {% if variation == 'c' %}
+      <div id="social-proof">
+        {% call call_out_compact(
+          title=download_title,
+          class=product_class
+        ) %}
+          {{ download_button }}
+        {% endcall %}
+      </div>
+    {% endif %}
+
       {% for note in release_notes if note.tag == "Fixed" %}
         {% if loop.first %}
           <div class="mzp-l-content mzp-has-sidebar mzp-l-sidebar-left">

--- a/bedrock/releasenotes/views.py
+++ b/bedrock/releasenotes/views.py
@@ -85,7 +85,7 @@ def release_notes(request, version, product='Firefox'):
         raise Http404
 
     # ensure variant matches pre-defined value
-    if variant not in ['a', 'b']:  # place expected ?v= values in this list
+    if variant not in ['a', 'b', 'c']:  # place expected ?v= values in this list
         variant = None
 
     # Show a "coming soon" page for any unpublished Firefox releases

--- a/media/css/firefox/releasenotes.scss
+++ b/media/css/firefox/releasenotes.scss
@@ -31,10 +31,15 @@ $image-path: '/media/protocol/img';
         }
     }
 
-    .download-button {
+    blockquote + .download-button {
         @media #{$mq-md} {
             float: right;
         }
+    }
+
+    .mzp-c-call-out-compact {
+        background-color: $color-white;
+        margin-top: 0;
     }
 }
 

--- a/media/js/firefox/social-proof-experiment.js
+++ b/media/js/firefox/social-proof-experiment.js
@@ -23,13 +23,19 @@
                     'data-ex-variant': 'social-proof-v1',
                     'data-ex-name': 'CRO-Social-Proof-Experiment'
                 });
+            } else if (href.indexOf('v=c') !== -1) {
+                window.dataLayer.push({
+                    'data-ex-variant': 'social-proof-v2',
+                    'data-ex-name': 'CRO-Social-Proof-Experiment'
+                });
             }
         } else {
             var cop = new Mozilla.TrafficCop({
                 id: 'experiment_social_proof',
                 variations: {
-                    'v=a': 50,
-                    'v=b': 50
+                    'v=a': 34,
+                    'v=b': 33,
+                    'v=c': 33
                 }
             });
 


### PR DESCRIPTION
## Description

This PR adds a second treatment to the social proof experiment. The second treatment contains a download button but no social proof copy.

I flagged it on in dev (https://github.com/mozmeao/www-config/commit/f30e495c15c8aaa9cace413f91e21765e1bbb5c0#diff-dfacfa39463276824d4b2de8c7a34c6cR37) and tested in Chrome incognito: 

* all 3 variations were assigned by TrafficCop as expected
* all 3 look as expected on wide/narrow screens
* the dataLayer is populated with the expected variation name
* the injected download button works as expected

