### PR TITLE
Expose new string in firefox/switch.ftl

### DIFF
--- a/bedrock/firefox/urls.py
+++ b/bedrock/firefox/urls.py
@@ -113,7 +113,7 @@ urlpatterns = (
     page('firefox/welcome/6', 'firefox/welcome/page6.html'),
     page('firefox/welcome/7', 'firefox/welcome/page7.html'),
 
-    page('firefox/switch', 'firefox/switch.html', ftl_files=['firefox/switch', 'firefox/switch-en']),
+    page('firefox/switch', 'firefox/switch.html', ftl_files=['firefox/switch']),
     page('firefox/pocket', 'firefox/pocket.html'),
 
     # Issue 6604, SEO firefox/new pages

--- a/l10n/en/firefox/switch-en.ftl
+++ b/l10n/en/firefox/switch-en.ftl
@@ -1,8 +1,0 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, You can obtain one at http://mozilla.org/MPL/2.0/.
-
-### TODO: Merge the content here with switch.ftl to expose new string.
-### This file is just a hack to avoid new content in the migration.
-
-switch-spread-the-word = Spread the word about { -brand-name-firefox } and help your favorite people say goodbye to { -brand-name-chrome }.

--- a/l10n/en/firefox/switch.ftl
+++ b/l10n/en/firefox/switch.ftl
@@ -10,6 +10,7 @@ switch-switching-to-firefox-page-description = Switching to { -brand-name-firefo
 switch-select-what-to-take = Select what to take from { -brand-name-chrome }.
 switch-let-firefox-do-the-rest = Let { -brand-name-firefox } do the rest.
 switch-use-firefox-and-still-chrome = You can use { -brand-name-firefox } and still have { -brand-name-chrome }. { -brand-name-chrome } won’t change on your machine one bit.
+switch-spread-the-word = Spread the word about { -brand-name-firefox } and help your favorite people say goodbye to { -brand-name-chrome }.
 switch-share-with-your-friends = Share with your friends how to switch to { -brand-name-firefox }
 switch-firefox-makes-switching-fast-tweet = 🔥 { -brand-name-firefox } makes switching from { -brand-name-chrome } really fast. Try it out!
 switch-switch-to-firefox = Switch to { -brand-name-firefox }


### PR DESCRIPTION
## Description
Adds a new string to `switch.ftl` that was never exposed for L10n prior to the migration from .lang. Exposing this now will prevent the `firefox/switch-en.ftl` file (which was added as a temporary workaround) from being picked up by automation. This will also give us another pre-launch test of the process.

## Issue / Bugzilla link
N/A
