### PR TITLE
Remove pebbles import from one-off pages

### DIFF
--- a/media/css/mozorg/book.scss
+++ b/media/css/mozorg/book.scss
@@ -2,8 +2,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-@import '../pebbles/includes/lib';
-
 html {
     background: maroon;
     color: white;

--- a/media/css/mozorg/credits.scss
+++ b/media/css/mozorg/credits.scss
@@ -2,8 +2,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-@import '../pebbles/includes/lib';
-
 html {
     background-color: #FFFFFF;
 }

--- a/media/css/mozorg/namespaces.scss
+++ b/media/css/mozorg/namespaces.scss
@@ -2,8 +2,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-@import '../pebbles/includes/lib';
-
 body {
     font-family: sans-serif;
     font-size: 16px;


### PR DESCRIPTION
## Description
These pages are all one-offs and have no dependencies on Pebbles:

- http://localhost:8000/book/
- http://localhost:8000/credits/
- http://localhost:8000/keymaster/gatekeeper/there.is.only.xul

## Issue / Bugzilla link
N/A

## Testing
- [ ] Pages should still render the same with no regressions.