### PR TITLE
Add exp versions of the homepage and mobile (fixes #8795)

### DIFF
--- a/bedrock/exp/templates/exp/firefox/mobile.html
+++ b/bedrock/exp/templates/exp/firefox/mobile.html
@@ -1,0 +1,217 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+
+{% from "macros.html" import google_play_button, send_to_device with context %}
+{% from "macros-protocol.html" import feature_card, hero, call_out_compact with context %}
+
+{% extends "exp/base/base.html" %}
+
+{% block page_css %}
+  {{ css_bundle('exp-firefox-mobile') }}
+{% endblock %}
+
+{% block canonical_urls %}
+  {# Experimental pages should set canonical to the original page URL. #}
+  <link rel="canonical" href="{{ settings.CANONICAL_URL }}/{{ LANG }}/firefox/mobile/">
+{% endblock %}
+
+{% block page_title %}{{ _('Download the Firefox Browser on your Mobile for iOS and Android') }} | {{ _('Firefox') }}{% endblock %}
+{% block page_desc %}{{ _('Firefox Browser for Mobile blocks over 2000 trackers by default, giving you the privacy you deserve and the speed you need in a private mobile browser.') }}{% endblock %}
+{% block page_og_title %}{{ _('Get the mobile browser built for you, not advertisers') }} | {{ _('Firefox') }}{% endblock %}
+{% block page_og_desc %}{{ _('Check out Firefox again. It’s fast, private and on your side. For iOS and Android.') }}{% endblock %}
+
+{% set show_send_to_device = LANG in settings.SEND_TO_DEVICE_LOCALES %}
+{% set android_url = firefox_adjust_url('android', 'mobile-page') %}
+{% set ios_url = firefox_adjust_url('ios', 'mobile-page') %}
+
+{% block site_header %}
+  {% with hide_nav_download_button=True %}
+    {% include 'includes/protocol/navigation/menu-firefox/index.html' %}
+  {% endwith %}
+{% endblock %}
+
+{% block content %}
+  <main role="main">
+    <header class="mzp-c-hero mzp-t-firefox mzp-has-image t-hero-primary">
+      <div class="mzp-l-content">
+        <div class="mzp-c-hero-body">
+          <h1 class="mzp-c-hero-title"><span class="c-wordmark t-firefox">Firefox Browser</span></h1>
+
+          <div class="mzp-c-hero-desc">
+            <h3>{{ _('Get automatic privacy on mobile') }}</h3>
+            <p>{{ _('Super fast. Private by default. Blocks 2000+ online trackers.') }}</p>
+          </div>
+
+          <div class="mzp-c-hero-cta">
+            <div class="header-product-ctas hide-from-legacy-ie">
+              <button type="button" class="mzp-c-button mzp-t-product js-mobile" id="get-firefox" data-cta-type="button" data-cta-text="Get Firefox Mobile" data-cta-position="primary">
+                {{ _('Get Firefox Mobile') }}
+              </button>
+            </div>
+            <div class="mobile-download-buttons-wrapper">
+              <ul class="mobile-download-buttons firefox" id="mobile-download-buttons-firefox">
+                <li class="android">
+                  {{ google_play_button(href=android_url, id='playStoreLink') }}
+                </li>
+                <li class="ios">
+                  <a id="appStoreLink" href="{{ ios_url }}" data-link-type="download" data-download-os="iOS">
+                    <img src="{{ l10n_img('firefox/ios/btn-app-store.svg') }}" alt="{{ ftl('download-button-download-app-store') }}" width="152" height="45">
+                  </a>
+                </li>
+              </ul>
+            </div>
+          </div>
+        </div>
+      </div>
+    </header>
+
+    <section class="c-private t-private mzp-t-firefox">
+      <div class="mzp-l-content">
+        <h2>{{ _('Block online trackers and invasive ads') }}</h2>
+        <div class="c-private-cols">
+          <div class="c-private-col">
+            <img src="{{ static('img/firefox/mobile/protocol/screen-private.svg') }}" alt="" height="331" width="163">
+            <h3>{{ _('Privacy protection by default') }}</h3>
+            <p>{{ _('Leave no trace with <a href="%s">Private Browsing mode</a>. When you close out, your history and cookies are deleted.')|format(url('firefox.features.private-browsing')) }}</p>
+          </div>
+          <div class="c-private-col">
+            <img src="{{ static('img/firefox/mobile/protocol/screen-tracking.svg') }}" alt="" height="331" width="163">
+            <h3>{{ _('Stop companies from following you') }}</h3>
+            <p>{{ _('Stay off their radar with <a href="%s">Firefox Tracking Protection</a>')|format(url('firefox.features.adblocker')) }}</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="t-account">
+      <div class="mzp-l-content">
+          {% call feature_card(
+            title=_('Discover products that keep you safe'),
+            image_url='img/firefox/mobile/protocol/account.svg',
+            aspect_ratio='mzp-has-aspect-1-1',
+            class='mzp-l-card-feature-right-half mzp-t-firefox',
+            link_url=url('firefox.accounts'),
+            link_cta=ftl('ui-learn-more')
+          ) %}
+          <p>{{ _('Sync your history, passwords, and bookmarks. Send tabs across all of your devices.') }}</p>
+          {% endcall %}
+      </div>
+    </section>
+
+    <section>
+      <div class="mzp-l-content t-extend">
+        {% set extend_title = '<span>'|safe + _('Android only') + '</span><br>'|safe + _('Make Android your own') %}
+        {% call feature_card(
+          title=extend_title,
+          image_url='img/firefox/mobile/protocol/screen-frame.svg',
+          aspect_ratio='mzp-has-aspect-1-1',
+          class='mzp-l-card-feature-right-half mzp-t-firefox',
+        ) %}
+        <p>{{ _('Customize your Firefox mobile browser with <a href="%s">extensions</a> to block ads, manage passwords, stop Facebook from tracking you and more.')|format('https://addons.mozilla.org/firefox/extensions/') }}</p>
+        {% endcall %}
+      </div>
+      <div class="mzp-l-content t-theme">
+        {% set theme_title = '<span>'|safe + _('Android only') + '</span><br>'|safe + _('Find it fast with a smart search bar') %}
+        {% call feature_card(
+          title=theme_title,
+          image_url='img/firefox/mobile/protocol/screen-frame.svg',
+          aspect_ratio='mzp-has-aspect-1-1',
+          class='mzp-l-card-feature-left-half mzp-t-firefox',
+        ) %}
+        <p>{{ _('Firefox anticipates your needs with smart search suggestions and quick access to the sites you visit most.') }}</p>
+        {% endcall %}
+      </div>
+    </section>
+
+    <section class="mzp-c-hero mzp-t-firefox t-hero-secondary">
+      <div class="mzp-l-content">
+        <div class="mzp-c-hero-body">
+          <h2 class="mzp-c-hero-title end-hero"><span class="c-wordmark t-firefox">Firefox Browser</span></h2>
+
+          <div class="mzp-c-hero-desc">
+            <h3>{{ _('The privacy you deserve. The speed you need. ') }}</h3>
+          </div>
+
+          <div class="mzp-c-hero-cta">
+            <div class="header-product-ctas hide-from-legacy-ie">
+              <button type="button" class="mzp-c-button mzp-t-product js-mobile" id="get-firefox" data-cta-type="button" data-cta-text="Get Firefox Mobile" data-cta-position="secondary">
+                {{ _('Get Firefox Mobile') }}
+              </button>
+            </div>
+            <div class="mobile-download-buttons-wrapper">
+              <ul class="mobile-download-buttons firefox" id="mobile-download-buttons-firefox">
+                <li class="android">
+                  {{ google_play_button(href=android_url, id='playStoreLink') }}
+                </li>
+                <li class="ios">
+                  <a id="appStoreLink" href="{{ ios_url }}" data-link-type="download" data-download-os="iOS">
+                    <img src="{{ l10n_img('firefox/ios/btn-app-store.svg') }}" alt="{{ ftl('download-button-download-app-store') }}" width="152" height="45">
+                  </a>
+                </li>
+              </ul>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    {#
+      L10n: The content below is intended to be shown in a modal window when clicking any of the
+      'Download' buttons above. Depending on the button clicked, the content below will either
+      target/display copy for Firefox.
+
+      For supported locales, the Send to Device widget will be shown. If the user's locale
+      does not suppor the widget, a QR code will be shown.
+
+      For mobile devices, only the App/Play Store badges will be shown.
+    #}
+    <div id="modal" class="mzp-u-modal-content mzp-t-firefox">
+      <div id="modal-download-firefox" class="desktop-download">
+        <h2 class="modal-logo">Firefox</h2>
+        <h3>{{ _('Get Firefox for mobile') }}</h3>
+        {% if show_send_to_device %}
+          <p>{{ _('Send a download link to your phone. ') }}</p>
+          {{ send_to_device(include_title=False, message_set='fx-mobile-download-desktop', class='vertical') }}
+        {% else %}
+          <p>{{ _('Scan the QR code to get started') }}</p>
+          <div class="qr-code-wrapper">
+            <img src="{{ static('img/firefox/mobile/protocol/qr-firefox.png') }}"
+                 id="firefox-qr"
+                 data-mozillaonline-link="{{ static('img/firefox/mobile/protocol/qr-firefox-mozillaonline.png') }}"
+                 alt="QR code to scan for Firefox Focus.">
+          </div>
+        {% endif %}
+      </div>
+
+      <div class="mobile-download-buttons-wrapper">
+        <ul class="mobile-download-buttons firefox" id="mobile-download-buttons-firefox">
+          <li class="android">
+            {{ google_play_button(href=android_url, id='playStoreLink') }}
+          </li>
+          <li class="ios">
+            <a id="appStoreLink" href="{{ ios_url }}" data-link-type="download" data-download-os="iOS">
+              <img src="{{ l10n_img('firefox/ios/btn-app-store.svg') }}" alt="{{ ftl('download-button-download-app-store') }}" width="152" height="45">
+            </a>
+          </li>
+        </ul>
+      </div>
+
+    </div>
+  </main>
+{% endblock %}
+
+{% block structured_data %}
+  {
+    "@context": "https://schema.org/",
+    "@graph": [
+      {% include 'includes/structured-data/software/firefox-android-software.json' %}
+      ,
+      {% include 'includes/structured-data/software/firefox-ios-software.json' %}
+    ]
+  }
+{% endblock %}
+
+{% block js %}
+  {{ js_bundle('exp-firefox-mobile') }}
+{% endblock %}

--- a/bedrock/exp/templates/exp/home/home-de.html
+++ b/bedrock/exp/templates/exp/home/home-de.html
@@ -1,0 +1,132 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+
+{% extends "exp/home/home-en.html" %}
+
+{% block canonical_urls %}
+  {# Experimental pages should set canonical to the original page URL. #}
+  <link rel="canonical" href="{{ settings.CANONICAL_URL }}/{{ LANG }}/">
+{% endblock %}
+
+{% block page_title %}{{ _('Internet für Menschen, nicht für Profit') }}{% endblock %}
+
+{% block page_desc %}
+  {{ _('Mozilla ist die gemeinnützige Organisation hinter Firefox. Menschen sollten auch online die Kontrolle über ihr Leben haben. Dafür setzen wir uns ein.') }}
+{% endblock %}
+
+{% block main %}
+<main>
+  <header class="main-page-heading">
+    {# Main page h1 is hidden from view and exists mainly for SEO purposes #}
+    <h1>{{ self.page_title() }}</h1>
+  </header>
+
+  {% call download_banner(
+    title=_('Echte Privatsphäre statt leerer Versprechen'),
+    desc=_('Hol dir die Kontrolle über deine Privatsphäre auf jedes Gerät.'),
+    ) %}
+    {{ download_firefox(dom_id='download-primary', download_location='primary cta') }}
+  {% endcall %}
+
+  {% call download_banner_sticky(
+    title=_('Echte Privatsphäre statt<br> leerer Versprechen.')
+    ) %}
+    {{ download_firefox(dom_id='download-sticky', download_location='sticky cta', button_color='mzp-t-small') }}
+  {% endcall %}
+
+  {{ fxa_banner(
+    title=_('Tech mit R.E.S.P.E.K.T.'),
+    desc=_('Firefox respektiert deine Privatsphäre mit jedem einzelnen Produkt.'),
+    link_cta=_('Weitere Infos'),
+  )}}
+
+  {{ fxa_banner_sticky(
+    title=_('Tech mit R.E.S.P.E.K.T.'),
+    link_cta=_('Weitere Infos'),
+  )}}
+
+  <div class="mozilla-content">
+    <div class="mzp-l-content mzp-t-mozilla">
+      <div class="mzp-l-card-hero">
+        {{ content_card('card_1') }}
+        {{ content_card('card_2') }}
+        {{ content_card('card_3') }}
+        {{ content_card('card_4') }}
+        {{ content_card('card_5') }}
+      </div>
+
+      {{ billboard(
+        title=_('Für Dich & das Internet. <br>Schon seit 1998.'),
+        ga_title='Für Dich & das Internet. Schon seit 1998.',
+        desc=_('Mozilla setzt sich für ein gesundes Internet ein – und damit für die Menschen, die es nutzen. Damals. Heute. Morgen.'),
+        link_cta=_('Erfahre mehr über Mozilla'),
+        link_url=url('mozorg.about.manifesto'),
+        image_url='img/home/2018/billboard-more-power.png',
+        include_highres_image=True
+      )}}
+
+      <div class="mzp-l-card-half">
+        {{ content_card('card_6') }}
+        {{ content_card('card_7') }}
+      </div>
+
+      {{ billboard(
+        title=_('Technologien des offenen Webs.'),
+        ga_title='Technologien des offenen Webs.',
+        desc=_('Virtual Reality, IoT und mehr.'),
+        link_cta=_('Entdecke das Web der Zukunft'),
+        link_url='https://labs.mozilla.org/',
+        image_url='img/home/2018/billboard-open-minds.png',
+        include_highres_image=True,
+        reverse=True
+      )}}
+
+      <div class="mzp-l-card-half">
+        {{ content_card('card_8') }}
+        {{ content_card('card_9') }}
+      </div>
+
+      <div class="mzp-l-card-third">
+        {{ content_card('card_10') }}
+        {{ content_card('card_11') }}
+        {{ content_card('card_12') }}
+      </div>
+
+      <aside class="mzp-c-newsletter">
+        <div class="mzp-c-newsletter-image">
+          {{ high_res_img('img/home/2018/newsletter-graphic.png', {'alt': ''}) }}
+        </div>
+
+        <div class="newsletter-content">
+          {{ email_newsletter_form(
+            title=_('Du liebst das Internet?'),
+            subtitle=_('Hol dir den Firefox Newsletter und sorg mit uns zusammen dafür, dass das Web frei und offen für alle bleibt.'),
+            button_class='button-dark',
+            submit_text=_('Anmelden'),
+            protocol_component=True
+          )}}
+        </div>
+      </aside>
+    </div>
+  </div>{#-- /.mozilla-content --#}
+
+  {% call download_banner_secondary(
+    title=_('Bestimme selbst, was du teilst und mit wem.'),
+    sub_title=_('Hol dir den Browser, der Tracker automatisch blockiert.')
+  ) %}
+    {{ download_firefox(dom_id='download-secondary', download_location='secondary cta') }}
+  {% endcall %}
+
+  {% call call_out_compact(
+      title=_('Das Konto, das dich schützt, statt Profit mit dir zu machen.'),
+      desc=None,
+      class='fxaccount-secondary-cta mzp-t-product-firefox mzp-t-firefox mzp-t-dark',
+      heading_level=2
+    ) %}
+    <a href="{{ url('firefox.accounts') }}" class="mzp-c-button mzp-t-product mzp-t-dark" id="fxa-learn-secondary">{{ ftl('ui-learn-more') }}</a>
+  {% endcall %}
+
+</main>
+{% endblock %}
+

--- a/bedrock/exp/templates/exp/home/home-en.html
+++ b/bedrock/exp/templates/exp/home/home-en.html
@@ -1,0 +1,232 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+
+{% from "macros-protocol.html" import billboard, card, call_out_compact, content_card with context %}
+{% from "mozorg/home/includes/macros.html" import download_banner, download_banner_sticky, download_banner_secondary, fxa_banner, fxa_banner_sticky %}
+
+{% extends "exp/base/base.html" %}
+
+{% block canonical_urls %}
+  {# Experimental pages should set canonical to the original page URL. #}
+  <link rel="canonical" href="{{ settings.CANONICAL_URL }}/{{ LANG }}/">
+{% endblock %}
+
+{% block gtm_page_id %}data-gtm-page-id="Homepage"{% endblock %}
+
+{% block page_title %}{{ _('Internet for people, not profit') }}{% endblock %}
+
+{# Bug 1438302 Avoid duplicate content for en-CA and en-GB pages. #}
+{%- block page_title_suffix -%}
+  {% if LANG == 'en-CA' %}
+    — Mozilla (CA)
+  {% elif LANG == 'en-GB' %}
+    — Mozilla (UK)
+  {% else %}
+    — Mozilla
+  {% endif %}
+{%- endblock -%}
+
+{% block page_desc %}
+  {{ _('Mozilla is the not-for-profit behind the lightning fast Firefox browser. We put people over profit to give everyone more power online.') }}
+{% endblock %}
+
+{% block body_id %}home{% endblock %}
+
+{% block extra_meta %}
+<!-- validates bing webmaster tools -->
+<meta name="msvalidate.01" content="B7B177115A634927D608514DA17B2574">
+<!-- YouTube Verification -->
+<meta name="google-site-verification" content="U9a6gH32vLIykvntaDToj-ytYhlZ1AfAgVEKstixQIE">
+{% endblock %}
+
+{% block page_css %}
+  {{ css_bundle('exp-home-2018') }}
+
+  {% if switch('fundraising-banner') %}
+    {{ css_bundle('fundraising-banner') }}
+  {% endif %}
+{% endblock %}
+
+{% block page_banner %}
+  {% if switch('fundraising-banner') %}
+    {% include 'includes/banners/fundraiser.html' %}
+  {% endif %}
+{% endblock %}
+
+{% block content %}
+{% block main %}
+<main>
+  <header class="main-page-heading visually-hidden">
+    {# Main page h1 is hidden from view and exists mainly for SEO purposes #}
+    <h1>{{ self.page_title() }}</h1>
+  </header>
+
+  {% call download_banner(
+    title=_('Take back your privacy'),
+    desc=_('Get the browser that blocks 2000+ trackers — automatically'),
+    ) %}
+    {{ download_firefox(dom_id='download-primary', download_location='primary cta') }}
+  {% endcall %}
+
+  {% call download_banner_sticky(
+    title=_('Reclaim your privacy'),
+    ) %}
+    {{ download_firefox(dom_id='download-sticky', download_location='sticky cta', button_color='mzp-t-small') }}
+  {% endcall %}
+
+  {{ fxa_banner(
+    title=_('Firefox is more<br> than a browser')|safe,
+    desc=_('Meet our family of privacy-first products'),
+    link_cta=_('Meet the Family'),
+  )}}
+
+  {{ fxa_banner_sticky(
+    title=_('Get privacy beyond the browser'),
+    link_cta=ftl('ui-learn-more'),
+  )}}
+
+  <div class="mozilla-content">
+    <div class="mzp-l-content mzp-t-mozilla">
+      <div class="mzp-l-card-hero">
+        {{ content_card('card_1') }}
+        {{ content_card('card_2') }}
+        {{ content_card('card_3') }}
+        {{ content_card('card_4') }}
+        {{ content_card('card_5') }}
+      </div>
+
+      {{ billboard(
+        title=_('More power to you.'),
+        ga_title='More power to you.',
+        desc=_('Mozilla puts people before profit, creating products, technologies and programs that make the internet healthier for everyone.'),
+        link_cta=_('Learn more about us'),
+        link_url=url('mozorg.about'),
+        image_url='img/home/2018/billboard-more-power.png',
+        include_highres_image=True
+      )}}
+
+      {% if get_content_card(content_cards or page_content_cards, 'card_17') %}
+        <div class="mzp-l-card-quarter">
+          {{ content_card('card_14') }}
+          {{ content_card('card_15') }}
+          {{ content_card('card_16') }}
+          {{ content_card('card_17') }}
+        </div>
+      {% else %}
+        <div class="mzp-l-card-half">
+          {{ content_card('card_6') }}
+          {{ content_card('card_7') }}
+        </div>
+      {% endif %}
+    </div>
+
+    {% if switch('show_pocket_feed', ['en']) and pocket_articles %}
+    <aside class="pocket">
+      <div class="mzp-l-content">
+        <h3 class="section-heading">{{ _('What we’re reading:') }}</h3>
+        <p class="tagline">{{ _('Like this feed? <a href="%(url)s">Subscribe</a> via Pocket')|format(url='https://getpocket.com/@MozillaHQ') }}</p>
+        <div class="mzp-l-card-quarter">
+        {% for article in pocket_articles %}
+          {{ card(
+            class='mzp-c-card-extra-small',
+            tag_label=article.domain,
+            title=article.display_title,
+            ga_title='Pocket Link {}'.format(loop.index),
+            image_url=article.image_src or 'img/pocket/pocket-feed-default.png',
+            aspect_ratio='mzp-has-aspect-16-9',
+            link_url=article.url
+          ) }}
+        {% endfor %}
+        </div>
+      </div>
+    </aside>
+    {% endif %}
+
+    <div class="mzp-l-content mzp-t-mozilla">
+      <div class="mzp-l-card-half">
+        {{ content_card('card_8') }}
+        {{ content_card('card_9') }}
+      </div>
+
+      {{ billboard(
+        title=_('Support a healthy internet.'),
+        ga_title='Support a healthy internet.',
+        desc=_('The not-for-profit Mozilla Foundation supports open-source apps, web literacy curriculum, gender equality in tech and more.'),
+        link_cta=_('Visit the Mozilla Foundation'),
+        link_url='https://foundation.mozilla.org/?utm_source=www.mozilla.org&utm_medium=referral&utm_campaign=homepage&utm_content=billboard',
+        image_url='img/home/2018/billboard-healthy-internet.png',
+        include_highres_image=True,
+        reverse=True
+      )}}
+
+      <div class="mzp-l-card-half">
+        {{ content_card('card_10') }}
+        {{ content_card('card_11') }}
+      </div>
+
+      {{ billboard(
+        title=_('Open source. <br>Open minds.'),
+        ga_title='Open source. <br>Open minds.',
+        desc=_('Mozilla creates powerful web tech for everyone.'),
+        link_cta=_('Explore Mozilla technology'),
+        link_url='https://labs.mozilla.org/?utm_source=www.mozilla.org&utm_medium=referral&utm_campaign=homepage&utm_content=billboard',
+        image_url='img/home/2018/billboard-open-minds.png',
+        include_highres_image=True
+      )}}
+
+      <div class="mzp-l-card-half">
+        {{ content_card('card_12') }}
+        {{ content_card('card_13') }}
+      </div>
+
+      <aside class="mzp-c-newsletter">
+        <div class="mzp-c-newsletter-image">
+          {{ high_res_img('img/home/2018/newsletter-graphic.png', {'alt': ''}) }}
+        </div>
+
+        <div class="newsletter-content">
+          {% set newsletter_id = 'mozilla-foundation' if LANG.startswith('en-') else 'mozilla-and-you' %}
+          {{ email_newsletter_form(
+            newsletters=newsletter_id,
+            title=_('Love the Web?'),
+            subtitle=_('Get the Mozilla newsletter and help us keep it open and free.'),
+            button_class='button-dark',
+            submit_text=_('Sign up now'),
+            protocol_component=True
+          )}}
+        </div>
+      </aside>
+    </div>
+  </div>{#-- /.mozilla-content --#}
+
+  {% call download_banner_secondary(
+    title=_('Privacy over profit'),
+    sub_title=_('No shareholders. No data for sale.')
+  ) %}
+    {{ download_firefox(dom_id='download-secondary', download_location='secondary cta') }}
+  {% endcall %}
+
+  {% call call_out_compact(
+    title=_('The account that protects you rather than profits off you.'),
+    class='fxaccount-secondary-cta mzp-t-product-firefox mzp-t-firefox mzp-t-dark hide-from-legacy-ie',
+    heading_level=2
+  ) %}
+    <a href="{{ url('firefox.accounts') }}" class="mzp-c-button mzp-t-product mzp-t-dark" id="fxa-learn-secondary">{{ ftl('ui-learn-more') }}</a>
+  {% endcall %}
+
+</main>
+{% endblock %}
+{% endblock %}
+
+{% block js %}
+  {{ js_bundle('exp-home') }}
+
+  {% if switch('fundraising-banner') %}
+    {{ js_bundle('fundraising-banner') }}
+  {% endif %}
+{% endblock %}
+
+{% block structured_data %}
+  {% include 'includes/structured-data/organizations/mozilla-corporation-organisation.json' %}
+{% endblock %}

--- a/bedrock/exp/templates/exp/home/home-fr.html
+++ b/bedrock/exp/templates/exp/home/home-fr.html
@@ -1,0 +1,130 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+
+{% extends "exp/home/home-en.html" %}
+
+{% block canonical_urls %}
+  {# Experimental pages should set canonical to the original page URL. #}
+  <link rel="canonical" href="{{ settings.CANONICAL_URL }}/{{ LANG }}/">
+{% endblock %}
+
+{% block page_title %}Internet est un bien commun, nous le défendons.{% endblock %}
+
+{% block page_desc %}
+Le saviez-vous ? Mozilla, le concepteur de Firefox, se bat pour qu’Internet, une ressource publique mondiale, demeure ouverte et accessible à tous.
+{% endblock %}
+
+{% block main %}
+<main>
+  <header class="main-page-heading">
+    {# Main page h1 is hidden from view and exists mainly for SEO purposes #}
+    <h1>{{ self.page_title() }}</h1>
+  </header>
+
+  {% call download_banner(
+    title='Nous ne mettons pas le nez dans vos données.',
+    desc='Le respect de votre vie privée est notre priorité. Notre modèle financier ne dépendra jamais de la vente et de l’utilisation de vos données personnelles.',
+    ) %}
+    {{ download_firefox(dom_id='download-primary', download_location='primary cta') }}
+  {% endcall %}
+
+  {% call download_banner_sticky(
+    title='Votre vie privée ne regarde que vous.'
+    ) %}
+    {{ download_firefox(dom_id='download-sticky', download_location='sticky cta', button_color='mzp-t-small') }}
+  {% endcall %}
+
+  {{ fxa_banner(
+    title='Des technologies résolument à vos côtés.',
+    desc='Bien plus qu’un navigateur, Firefox c’est toute une gamme de produits qui respectent vraiment votre vie privée.',
+    link_cta='En savoir plus',
+  )}}
+
+  {{ fxa_banner_sticky(
+    title='Des technologies qui vous respectent.',
+    link_cta='Découvrir nos produits',
+  )}}
+
+  <div class="mozilla-content">
+    <div class="mzp-l-content mzp-t-mozilla">
+      <div class="mzp-l-card-hero">
+        {{ content_card('card_1') }}
+        {{ content_card('card_2') }}
+        {{ content_card('card_3') }}
+        {{ content_card('card_4') }}
+        {{ content_card('card_5') }}
+      </div>
+
+      {{ billboard(
+        title=_('Pour vous et pour Internet depuis 1998.'),
+        ga_title='Pour vous et pour Internet depuis 1998',
+        desc=_('Mozilla s’engage pour un Internet plus sain et plus accessible. Pour vous et pour demain.'),
+        link_cta=_('En savoir plus sur Mozilla'),
+        link_url=url('mozorg.about.manifesto'),
+        image_url='img/home/2018/billboard-more-power.png',
+        include_highres_image=True
+      )}}
+
+      <div class="mzp-l-card-half">
+        {{ content_card('card_6') }}
+        {{ content_card('card_7') }}
+      </div>
+
+      {{ billboard(
+        title=_('Technologies web open source :'),
+        ga_title='Technologies web open source',
+        desc=_('Réalité virtuelle, IoT et plus encore.'),
+        link_cta=_('Découvrez le web du futur'),
+        link_url='https://labs.mozilla.org/',
+        image_url='img/home/2018/billboard-open-minds.png',
+        include_highres_image=True,
+        reverse=True
+      )}}
+
+      <div class="mzp-l-card-half">
+        {{ content_card('card_8') }}
+        {{ content_card('card_9') }}
+      </div>
+      <div class="mzp-l-card-third">
+        {{ content_card('card_10') }}
+        {{ content_card('card_11') }}
+        {{ content_card('card_12') }}
+      </div>
+
+      <aside class="mzp-c-newsletter">
+        <div class="mzp-c-newsletter-image">
+          {{ high_res_img('img/home/2018/newsletter-graphic.png', {'alt': ''}) }}
+        </div>
+
+        <div class="newsletter-content">
+          {{ email_newsletter_form(
+            title=_('Vous adorez Internet ?'),
+            subtitle=_('Abonnez-vous à la newsletter Firefox et soutenez notre vision d’un Internet libre et sécurisé.'),
+            button_class='button-dark',
+            submit_text=_('S’abonner'),
+            protocol_component=True
+          )}}
+        </div>
+      </aside>
+    </div>
+  </div>{#-- /.mozilla-content --#}
+
+  {% call download_banner_secondary(
+    title='Retrouvez le respect que vous méritez.',
+    sub_title='Parcourir Internet avec Firefox, c’est adopter des technologies conçues pour protéger vos données personnelles.'
+  ) %}
+    {{ download_firefox(dom_id='download-secondary', download_location='secondary cta') }}
+  {% endcall %}
+
+  {% call call_out_compact(
+      title='Un compte qui vous protège sans profiter de vous.',
+      desc=None,
+      class='fxaccount-secondary-cta mzp-t-product-firefox mzp-t-firefox mzp-t-dark',
+      heading_level=2
+    ) %}
+    <a href="{{ url('firefox.accounts') }}" class="mzp-c-button mzp-t-product mzp-t-dark" id="fxa-learn-secondary">En savoir plus</a>
+  {% endcall %}
+
+</main>
+{% endblock %}

--- a/bedrock/exp/urls.py
+++ b/bedrock/exp/urls.py
@@ -17,4 +17,6 @@ urlpatterns = (
     page('firefox', 'exp/firefox/index.html', active_locales=['en-US', 'en-GB', 'en-CA', 'de']),
     url(r'^firefox/new/$', views.new, name='exp.firefox.new'),
     page('firefox', 'exp/firefox/index.html', active_locales=['en-US', 'en-GB', 'en-CA', 'de']),
+    page('firefox/mobile', 'exp/firefox/mobile.html'),
+    url(r'^$', views.home_view, name='exp.mozorg.home'),
 )

--- a/media/css/exp/home/home-2018.scss
+++ b/media/css/exp/home/home-2018.scss
@@ -1,0 +1,461 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+$font-path: '/media/fonts';
+$image-path: '/media/protocol/img';
+
+@import '../../../protocol/css/includes/lib';
+@import '../../../protocol/css/components/billboard';
+@import '../../../protocol/css/components/call-out';
+@import '../../../protocol/css/components/modal';
+@import '../../../protocol/css/components/newsletter-form';
+@import '../../../protocol/css/templates/card-layout';
+
+
+.mzp-c-navigation {
+    position: relative;
+    z-index: 4;
+}
+
+// Override global-nav z-index for sticky header CTA.
+.moz-global-nav {
+    z-index: 3;
+}
+
+// Override footer z-index to hide download sticky behind it.
+.mzp-c-footer {
+    position: relative;
+    z-index: 2;
+}
+
+.main-page-heading {
+    @include visually-hidden;
+}
+
+.mozilla-content {
+    margin-top: $spacing-lg;
+}
+
+
+//* -------------------------------------------------------------------------- */
+// Primary CTA (page top)
+
+.c-primary-cta {
+    background-color: $color-white;
+    min-height: 359px;
+    position: relative;
+    text-align: center;
+    z-index: 2; // so it hides the sticky CTA
+}
+
+.c-primary-cta-wrapper {
+    position: relative;
+    padding-top: $layout-sm;
+
+    p {
+        margin-bottom: 0;
+    }
+}
+
+.c-primary-cta-logo {
+    margin: 0 auto $spacing-lg auto;
+}
+
+.c-primary-cta-title {
+    @include text-title-lg;
+    margin-bottom: 0;
+}
+
+h3,
+h4 {
+    &.c-primary-cta-title-sub {
+        @include font-base;
+        @include text-title-sm;
+        max-width: 430px;
+        margin: 0 auto;
+    }
+}
+
+.c-primary-cta-desc {
+    @include text-body-lg;
+}
+
+.c-primary-cta-button {
+    margin-top: $layout-sm;
+}
+
+.mzp-c-button-download-container {
+    margin-bottom: 0;
+}
+
+@media #{$mq-md} {
+    .c-primary-cta-wrapper {
+        padding-bottom: $layout-sm;
+    }
+
+    .c-primary-cta-logo {
+        margin-bottom: $spacing-xl;
+    }
+}
+
+@media #{$mq-lg} {
+    .c-primary-cta {
+        @include bidi(((text-align, left, right),));
+        border-top: 100px solid $color-white; // to hide sticky CTA
+        margin-bottom: -100px;
+        position: relative;
+        top: -100px;
+
+        .c-primary-cta-wrapper {
+            @include border-box;
+            max-width: 50%;
+        }
+
+        .c-primary-cta-title-sub {
+            margin: 0;
+        }
+    }
+
+    .download-firefox-primary-cta {
+        background-image: url('/media/img/home/2018/browser.png'), url('/media/img/home/2018/bg-primary.svg');
+        background-size: 400px 278px, auto;
+        background-position: calc(50vw + 34px) 60px, calc(50vw - 41px) -78px;
+        background-repeat: no-repeat;
+
+        @media #{$mq-high-res} {
+            background-image: url('/media/img/home/2018/browser-high-res.png'), url('/media/img/home/2018/bg-primary.svg');
+        }
+    }
+
+    .fxaccount-primary-cta {
+        @include at2x('/media/img/home/2018/home.jpg', 815px, 362px);
+        background-position: 50vw 0;
+        background-repeat: no-repeat;
+    }
+
+    .mzp-c-navigation + #outer-wrapper .c-primary-cta {
+        border-top: 94px solid $color-white;
+        top: -94px;
+        margin-bottom: -94px;
+    }
+}
+
+
+//* -------------------------------------------------------------------------- */
+// Sticky CTA
+
+.c-sticky-cta {
+    background-color: $color-ink-80;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, .1);
+    color: $color-white;
+    position: fixed;
+    text-align: center;
+    top: 0;
+    width: 100%;
+    z-index: 1;
+
+    .no-js & {
+        // no javascript, no sticky
+        display: none;
+    }
+
+    .mzp-l-content {
+        padding-bottom: $spacing-md;
+        padding-top: $spacing-md;
+    }
+}
+
+.c-sticky-cta-wrapper {
+    position: relative;
+
+    p {
+        margin-bottom: 0;
+    }
+}
+
+.c-sticky-cta-title {
+    @include text-body-md;
+    @include at2x('#{$image-path}/logos/firefox/logo-sm.png', 40px, 40px);
+    background-position: top center;
+    background-repeat: no-repeat;
+    height: 0;
+    left: -6px;
+    margin-bottom: 0;
+    overflow: hidden;
+    position: absolute;
+    top: -4px;
+
+    .download-firefox-sticky-cta & {
+        @include at2x('/media/protocol/img/logos/firefox/browser/logo-sm.png', 40px, 40px);
+    }
+}
+
+.sticky-dismiss {
+    background: transparent;
+    border: 0;
+    bottom: 0;
+    cursor: pointer;
+    overflow: hidden;
+    padding: 0 0 0 $spacing-2xl;
+    position: absolute;
+    right: 0;
+    top: 0;
+    width: 0;
+    height: 40px;
+
+    &:after {
+        @include text-body-lg;
+        background: transparent url('#{$image-path}/icons/close-white.svg') center center no-repeat;
+        @include background-size(20px 20px);
+        content: '';
+        display: block;
+        height: 32px;
+        left: 0;
+        position: absolute;
+        right: 0;
+        top: $spacing-xs;
+        width: 32px;
+    }
+
+    &:hover:after,
+    &:focus:after {
+        @include transition(transform .1s ease-in-out);
+        @include transform(scale(1.1));
+    }
+
+    &:focus:after {
+        outline: 1px dotted $color-white;
+    }
+}
+
+@media #{$mq-md} {
+    .c-sticky-cta-title {
+        background-position: top left;
+        float: left;
+        height: 44px;
+        line-height: 44px;
+        padding-left: $layout-xl;
+        position: static;
+        text-align: left;
+    }
+
+    .c-sticky-cta-button {
+        margin-top: 0;
+        padding: 0 20px 0 40px;
+        position: absolute;
+        right: 0;
+        top: 0;
+    }
+
+    .sticky-dismiss {
+        right: -60px;
+
+        &:after {
+            line-height: 44px;
+            text-align: center;
+        }
+    }
+}
+
+@media #{$mq-lg} {
+    .c-sticky-cta-desc-sub {
+        display: block;
+        float: left;
+        line-height: 40px;
+    }
+}
+
+// Sticky CTA - Download Firefox
+.download-firefox-sticky-cta {
+
+    .download-button,
+    .download-list {
+        margin-bottom: 0;
+    }
+
+    .fx-privacy-link {
+        display: none;
+    }
+}
+
+
+
+//* -------------------------------------------------------------------------- */
+// Conditional content
+
+// Hide Firefox Account CTAs by default; show download unless we know otherwise.
+.fxaccount-primary-cta,
+.fxaccount-sticky-cta,
+.fxaccount-secondary-cta {
+    display: none;
+}
+
+// Hide download CTAs for people already using Firefox; promote Firefox Accounts instead.
+.is-firefox {
+    .download-firefox-primary-cta,
+    .download-firefox-sticky-cta,
+    .download-firefox-secondary-cta {
+        display: none;
+    }
+
+    .fxaccount-primary-cta,
+    .fxaccount-sticky-cta,
+    .fxaccount-secondary-cta {
+        display: block;
+    }
+
+    #fxaccount-sticky-cta {
+        display: none; // Never an FxA sticky on mobile
+
+        @media #{$mq-md} {
+            display: block;
+        }
+    }
+}
+
+
+/* -------------------------------------------------------------------------- */
+// Custom card styles for lazy-loaded images.
+
+.mzp-c-card {
+    .lazy-image-container .mzp-c-card-image {
+        opacity: 1;
+        transition: opacity 0.3s;
+    }
+
+    .lazy-image-container .mzp-c-card-image[data-src] {
+        opacity: 0;
+    }
+}
+
+
+/* -------------------------------------------------------------------------- */
+// Pocket highlights section.
+
+.pocket {
+    background: #f5f5f5;
+    margin: 20px 0;
+
+    .section-heading {
+        @include text-title-xs;
+        margin-bottom: $spacing-sm;
+    }
+
+    .tagline {
+        color: #676767;
+
+        a:link,
+        a:visited {
+            color: inherit;
+        }
+
+        a:hover,
+        a:active,
+        a:focus {
+            color: #000;
+        }
+    }
+
+    @media #{$mq-md} {
+        margin: $spacing-xl 0 0;
+        padding-top: $spacing-lg;
+    }
+}
+
+
+//* -------------------------------------------------------------------------- */
+// Secondary Download CTA (page bottom)
+
+.c-secondary-cta {
+    background-color: $color-ink-80;
+    color: #fff;
+    overflow: hidden;
+    position: relative;
+    text-align: center;
+    z-index: 2;
+
+    p {
+        margin-bottom: 0;
+    }
+}
+
+.c-secondary-cta-title {
+    @include at2x('#{$image-path}/logos/firefox/browser/logo-sm.png', 40px, 40px);
+    @include text-title-md;
+    background-position: center 35px;
+    background-repeat: no-repeat;
+    margin-bottom: $spacing-sm;
+    padding-top: 90px;
+}
+
+.c-secondary-cta-button {
+    margin-bottom: $spacing-lg;
+    margin-top: $spacing-xl;
+}
+
+@media #{$mq-lg} {
+    .c-secondary-cta {
+        @include bidi(((text-align, left, right),));
+        background-image: url('/media/img/home/2018/shield.svg'), url('/media/img/home/2018/bg-secondary.svg');
+        background-position: calc(50vw + 100px) 120px, 50vw 0;
+        background-repeat: no-repeat;
+        padding: $layout-xs 0 $layout-sm 0;
+    }
+
+    .c-secondary-cta-content {
+        max-width: 48%;
+    }
+    .c-secondary-cta-title {
+        background-position: left 35px;
+    }
+}
+
+@media #{$mq-xl} {
+    .c-secondary-cta {
+        background-position: calc(50vw + 30px) 120px, 45vw 0;
+    }
+}
+
+
+
+//* -------------------------------------------------------------------------- */
+// Secondary FxA CTA (page bottom)
+
+
+.fxaccount-secondary-cta.mzp-t-dark {
+    background-color: $color-ink-80;
+}
+
+.fxaccount-secondary-cta.mzp-t-product-firefox {
+    .mzp-c-call-out-content {
+        @include at2x('#{$image-path}/logos/firefox/logo-md.png', 64px, 64px);
+    }
+    .mzp-c-call-out-title {
+        margin-bottom: $spacing-md;
+    }
+}
+
+//* -------------------------------------------------------------------------- */
+// YouTube iframe responsive in modal.
+
+.ytcontainer-video {
+    max-width: 100%;
+
+    .video-container {
+        height: 0;
+        margin-bottom: $spacing-lg;
+        overflow: hidden;
+        padding-bottom: 56.25%;
+        position: relative;
+        width: 100%;
+    }
+
+    iframe {
+        height: 100%;
+        left: 0;
+        position: absolute;
+        top:0;
+        width: 100%;
+    }
+}

--- a/media/css/exp/home/home.scss
+++ b/media/css/exp/home/home.scss
@@ -1,0 +1,94 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+$font-path: '/media/fonts';
+$image-path: '/media/protocol/img';
+
+@import '../../../protocol/css/includes/lib';
+@import '../../../protocol/css/components/hero';
+@import '../../../protocol/css/components/billboard';
+@import '../../../protocol/css/components/newsletter-form';
+@import '../../../protocol/css/templates/card-layout';
+@import '../../../protocol/css/components/picto-card';
+
+//* -------------------------------------------------------------------------- */
+// Billboard
+
+// offset image override
+
+.mzp-c-billboard .mzp-c-billboard-image-container {
+    @media #{$mq-lg} {
+        margin: 0;
+        padding: $spacing-lg $spacing-sm;
+    }
+}
+
+//* -------------------------------------------------------------------------- */
+// Picto Cards
+
+/**
+* Picto card custom icon sizes.
+* These should be standardized into a `large` icon size.
+* https://github.com/mozilla/protocol/issues/382
+*/
+
+.mzp-c-card-picto .mzp-c-card-picto-content {
+    padding-top: 140px;
+
+    &:before {
+        background-color: transparent;
+        background-position: top left;
+        background-repeat: no-repeat;
+        height: 100px;
+        margin-left: -52px;
+        width: 100px;
+    }
+
+    @media #{$mq-lg} {
+        .mzp-c-card-picto-title {
+            @include text-title-sm;
+            margin-bottom: $spacing-xl;
+        }
+    }
+}
+
+.extensions .mzp-c-card-picto-content::before {
+    @include at2x('/media/img/home/externals-sprite.png', 100px, 300px);
+}
+
+.careers .mzp-c-card-picto-content::before {
+    @include at2x('/media/img/home/externals-sprite.png', 100px, 300px);
+    background-position: left -100px;
+}
+
+.help .mzp-c-card-picto-content::before {
+    @include at2x('/media/img/home/externals-sprite.png', 100px, 300px);
+    background-position: left -200px;
+}
+
+//* -------------------------------------------------------------------------- */
+// Two column section
+
+.c-column {
+    box-sizing: border-box;
+    display: block;
+    padding: $spacing-xl 0;
+
+    @media #{$mq-lg} {
+        float: left;
+        padding: 0 $spacing-2xl;
+        width: 50%;
+
+        &:first-child {
+            border-right: 1px solid rgba(0,0,0,.2);
+        }
+    }
+
+    .c-column-content {
+        @include bidi(((text-align, left, right),));
+        h2 {
+            margin-bottom: $spacing-xl;
+        }
+    }
+}

--- a/media/css/exp/mobile.scss
+++ b/media/css/exp/mobile.scss
@@ -1,0 +1,489 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+$font-path: '/media/fonts';
+$image-path: '/media/protocol/img';
+
+@import '../../protocol/css/includes/lib';
+@import '../../protocol/css/components/feature-card';
+@import '../../protocol/css/components/hero';
+@import '../../protocol/css/components/call-out';
+@import '../../protocol/css/components/modal';
+
+
+//* -------------------------------------------------------------------------- */
+
+// not yet recognized as valid by style lint, so we abstract it
+$mq-reduced-motion: 'screen and (prefers-reduced-motion: reduce)';
+
+main .mzp-l-content {
+    max-width: 400px;
+
+    @media #{$mq-md} {
+        max-width: $content-max;
+    }
+}
+
+
+//* -------------------------------------------------------------------------- */
+//  Download buttons
+
+.mobile-download-buttons li {
+    padding-top: $spacing-sm;
+    display: inline-block;
+}
+
+.modal-logo {
+    @include at2x('/media/protocol/img/logos/firefox/browser/logo-lg.png', auto, 100%);
+    @include image-replaced;
+    background-repeat: no-repeat;
+    background-position: center;
+}
+
+.header-product-ctas {
+    margin-bottom: $spacing-2xl;
+}
+
+// for android/iOS, hide widget/QR code in favor of app store badges
+.android,
+.ios {
+    .mobile-download-buttons-wrapper {
+        display: block;
+    }
+
+    .qr-code-wrapper,
+    #modal-wrapper .desktop-download,
+    #send-to-device {
+        display: none;
+    }
+
+    .header-product-ctas {
+        display: none;
+    }
+}
+
+// hide download links for one platform from the other
+.android .mobile-download-buttons .ios {
+    display: none;
+}
+
+.ios .mobile-download-buttons .android,
+.ios .mobile-download-buttons .android-apk {
+    display: none;
+}
+
+
+// very basic styling for no-JS visitors
+.no-js {
+    .header-product-ctas {
+        display: none;
+    }
+
+    .mobile-download-buttons-wrapper {
+        display: block;
+        text-align: center;
+    }
+
+    .mobile-download-buttons {
+        margin: 1em 0;
+
+        @media #{$mq-sm} {
+            @supports (display: flex) {
+                & {
+                    align-items: center;
+                    display: flex;
+                    flex-direction: column;
+                    margin: 1em auto;
+                    width: 340px;
+
+                    &.hidden {
+                        display: none;
+                    }
+
+                    li {
+                        margin: 0 auto; // so that a single item is centred
+                    }
+                }
+            }
+        }
+
+        .android-apk a {
+            display: inline-block;
+            margin: 10px 0;
+            @include text-body-sm;
+        }
+    }
+}
+
+//* -------------------------------------------------------------------------- */
+//  Wordmark
+
+.c-wordmark {
+    @include at2x('/media/protocol/img/logos/firefox/browser/logo-word-hor-sm.png', auto, 100%);
+    @include bidi(((padding-right, $spacing-sm, padding-left, 0),));
+    @include image-replaced;
+    background-position: top center;
+    background-repeat: no-repeat;
+    content: '';
+    display: block;
+
+    @media #{$mq-md} {
+        @include bidi(((background-position, top left, top right),));
+    }
+}
+
+.end-hero .c-wordmark {
+    background-position: center;
+}
+//* -------------------------------------------------------------------------- */
+// Hero
+
+.t-hero-primary {
+    &.mzp-c-hero {
+        text-align: center;
+        color: $color-ink-80;
+
+        &.mzp-t-firefox::after {
+            display: none;
+        }
+    }
+
+    .mzp-c-hero-desc {
+        @include text-title-sm;
+
+        p {
+            margin-bottom: $spacing-lg;
+        }
+    }
+
+    .mzp-c-button-download-container {
+        margin-bottom: 0;
+    }
+
+    @media #{$mq-md} {
+        &.mzp-c-hero.mzp-has-image {
+            background-image: url('/media/img/firefox/mobile/img-browser-mobile.svg'), url('/media/img/firefox/mobile/img-mobile-noodles.svg');
+            align-items: center;
+            text-align: left;
+            background-repeat: no-repeat;
+            background-size: contain;
+            background-position: top left calc(50vw + #{$layout-2xl}), top left 50vw;
+            display: flex;
+            min-height: 560px;
+            html[dir="rtl"] &{
+                background-position: top right calc(50vw + #{$spacing-md}), top right calc(50vw + #{$spacing-md});
+                text-align: right;
+            }
+        }
+
+        .end-hero .c-wordmark {
+            background-position: center;
+        }
+
+        .mzp-l-content {
+            width: 100%;
+        }
+    }
+
+    @media #{$mq-lg} {
+        .end-hero .c-wordmark {
+            background-position: center;
+        }
+    }
+}
+
+//* -------------------------------------------------------------------------- */
+// Private
+
+.t-private {
+    @include light-links;
+    background-color: $color-ink-80;
+    color: #fff;
+
+    h2 {
+        @include text-title-lg;
+        color: $color-pink-50;
+        margin-top: $spacing-md;
+    }
+
+    // protocol/issues#335
+    a:visited {
+        color: #ffffff;
+        opacity: 0.8;
+    }
+
+    a:hover,
+    a:focus,
+    a:active {
+        opacity: 1;
+    }
+}
+
+.c-private-col {
+    margin: $layout-xl 0;
+    text-align: center;
+
+    img {
+        margin: 0 auto;
+    }
+
+    h3 {
+        @include bidi(((text-align, left, right),));
+        @include text-title-sm;
+        margin-top: $spacing-2xl;
+    }
+
+    p {
+        @include bidi(((text-align, left, right),));
+        margin-top: $spacing-xl;
+    }
+}
+
+@media #{$mq-md} {
+
+    .t-private {
+        h2 {
+            margin-top: $layout-lg;
+            margin-left: auto;
+            margin-right: auto;
+            max-width: 800px;
+            text-align: center;
+        }
+    }
+
+    .c-private-cols {
+        @include bidi(((left, $layout-lg / 2, right, auto),));
+        margin: 0 auto;
+        max-width: 600px + ($layout-lg * 2);
+        position: relative;
+    }
+
+    .c-private-col {
+        @include bidi((
+            (float, left, right),
+            (text-align, left, right),
+        ));
+        @include border-box;
+        width: 50%;
+        padding: 0 ($layout-lg / 2);
+
+        img {
+            margin: 0;
+        }
+    }
+}
+
+
+//* -------------------------------------------------------------------------- */
+// Feature cards
+
+.mzp-c-card-feature {
+    .mzp-c-card-feature-media-wrapper,
+    .mzp-c-card-feature-content {
+        min-width: 0;
+    }
+
+    .mzp-c-card-feature-title {
+        @include text-title-lg;
+        color: $color-ink-80;
+    }
+
+    .mzp-c-card-feature-desc {
+        color: $color-marketing-gray-80;
+    }
+}
+
+//* -------------------------------------------------------------------------- */
+// Accounts
+
+
+.t-account {
+    background-color: $color-marketing-gray-10;
+    padding: $layout-md 0;
+
+    .mzp-c-card-feature-content-container {
+        max-width: 410px;
+    }
+}
+
+//* -------------------------------------------------------------------------- */
+// Customization
+
+
+.t-extend,
+.t-theme {
+    padding-top: 0;
+    padding-bottom: 0;
+
+    .mzp-c-card-feature {
+        margin-bottom: 0;
+    }
+
+    .mzp-c-card-feature-media {
+        padding-top: $layout-xl;
+
+        &:after {
+            border-bottom: 1px solid $color-marketing-gray-20;
+            content: '';
+            display: block;
+            height: 0;
+            max-width: 245px + 20px * 2;
+            margin: 0 auto;
+        }
+    }
+
+    .mzp-c-card-feature-content-container {
+        max-width: 325px;
+    }
+
+    .mzp-c-card-feature-title span {
+        @include text-body-md;
+        font-weight: normal;
+    }
+
+    img {
+        animation: custom 6s infinite step-end;
+        background-color: $color-yellow-20;
+        background-image: url('/media/img/firefox/mobile/protocol/extend-key.svg'), url('/media/img/firefox/mobile/protocol/extend-eye.svg'), url('/media/img/firefox/mobile/protocol/extend-star.svg');
+        background-position: 50% 75%, 500px 500px, 500px 500px;
+        background-repeat: no-repeat;
+        max-width: 245px;
+        vertical-align: bottom;
+    }
+
+    p {
+        margin-bottom: 0;
+    }
+}
+
+.t-theme {
+    margin-bottom: $layout-xl;
+
+    .mzp-c-card-feature-content {
+        justify-content: end;
+    }
+
+     img {
+         background-image: url('/media/img/firefox/mobile/protocol/theme-yellow.svg'), url('/media/img/firefox/mobile/protocol/theme-pink.svg'), url('/media/img/firefox/mobile/protocol/theme-violet.svg');
+     }
+}
+
+@media #{$mq-reduced-motion} {
+    .t-extend,
+    .t-theme {
+        img {
+            animation: none;
+        }
+    }
+}
+
+@keyframes custom {
+    0% {
+        background-position: 50% 75%, 500px 500px, 500px 500px;
+    }
+    33% {
+        background-position: 500px 500px, 50% 75%, 500px 500px;
+    }
+    66% {
+        background-position: 500px 500px, 500px 500px, 50% 75%;
+    }
+}
+
+//* -------------------------------------------------------------------------- */
+// secondary hero
+
+.t-hero-secondary {
+    &.mzp-c-hero {
+        &.mzp-t-firefox::after {
+            display: none;
+        }
+    }
+
+    .mzp-l-content {
+        padding-bottom: $layout-lg;
+    }
+}
+
+//* -------------------------------------------------------------------------- */
+//  Modal
+
+
+#modal-download-firefox {
+    display: none;
+}
+
+.mzp-c-modal-window {
+    padding-left: $spacing-sm;
+    padding-right: $spacing-sm;
+}
+.mzp-c-modal-inner {
+    background-color: transparent;
+    padding-left: 0;
+    padding-right: 0;
+
+    h3 {
+        @include text-title-md;
+        color: $color-ink-80;
+        margin-bottom: 0;
+
+        + p {
+            margin-bottom: $layout-md;
+        }
+    }
+
+    .mzp-c-modal-overlay-contents {
+        background: #fff;
+        color: #000;
+        padding: $layout-xs;
+        text-align: center;
+    }
+
+    a:link,
+    a:visited {
+        color: $color-link;
+        text-decoration: underline;
+    }
+
+    a:hover,
+    a:focus,
+    a:active {
+        color: $color-link-hover;
+        text-decoration: none;
+    }
+}
+
+@media #{$mq-sm} {
+    .mzp-c-modal-window {
+        padding-left: $layout-xs;
+        padding-right: $layout-xs;
+    }
+}
+
+@media #{$mq-md} {
+    .mzp-c-modal-inner {
+        max-width: 800px;
+        margin: 0 auto;
+        padding-left: $layout-md;
+        padding-right: $layout-md;
+
+        .mzp-c-modal-overlay-contents {
+            background: #fff;
+            color: #000;
+            padding: $layout-md;
+        }
+    }
+}
+
+
+//* -------------------------------------------------------------------------- */
+//  Send to Device overrides
+
+#send-to-device {
+    margin: 0 auto;
+    text-align: center;
+
+    footer {
+        display: none;
+    }
+}

--- a/media/js/exp/home.js
+++ b/media/js/exp/home.js
@@ -1,0 +1,92 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+(function($, Waypoint) {
+    'use strict';
+
+    // Lazyload images
+    Mozilla.LazyLoad.init();
+
+    /*
+    * Sticky CTA
+    */
+    var $stickyCTA = $(document.querySelectorAll('.c-sticky-cta'));
+    var hasCookies = typeof Mozilla.Cookies !== 'undefined' && Mozilla.Cookies.enabled();
+    $stickyCTA.attr('aria-hidden', 'true');
+
+    // init dismiss button
+    function initStickyCTA() {
+        // add and remove aria-hidden
+        var primaryTop = new Waypoint({
+            element: document.querySelectorAll('.c-primary-cta'),
+            handler: function(direction) {
+                if(direction === 'down') {
+                // becomes percivable as the user scrolls down
+                    $stickyCTA.removeAttr('aria-hidden');
+                } else {
+                // hidden again as they scroll up
+                    $stickyCTA.attr('aria-hidden', 'true');
+                }
+            }
+        });
+
+        // hide sticky at top to prevent revealing through overscroll
+        var $stickyWrapper = $stickyCTA.find('.c-sticky-cta-wrapper');
+        $stickyWrapper.hide();
+        var mozContent = new Waypoint({
+            element: document.querySelectorAll('.mozilla-content'),
+            handler: function(direction) {
+                if(direction === 'down') {
+                    // reveal sticky
+                    $stickyWrapper.show();
+                } else {
+                    // hide sticky
+                    $stickyWrapper.hide();
+                }
+            },
+            offset: 100
+        });
+
+        // add button
+        var $dismissButton = $('<button type="button" class="sticky-dismiss">').text('Dismiss this prompt.');
+        $dismissButton.appendTo($stickyWrapper);
+
+        // find all the buttons
+        var dismissButtons = $('.sticky-dismiss');
+        // listen for the click
+        dismissButtons.on('click', function() {
+            // destroy waypoints
+            primaryTop.destroy();
+            mozContent.destroy();
+
+            // dismiss the sticky banner
+            dismissStickyCTA();
+        });
+    }
+
+    // handle dismiss
+    function dismissStickyCTA() {
+        // remove element
+        $stickyCTA.remove();
+        // set cookie, if cookies are supported
+        if (hasCookies) {
+            var d = new Date();
+            d.setTime(d.getTime() + (30 * 24 * 60 * 60 * 1000)); // 30 days
+            Mozilla.Cookies.setItem('sticky-home-cta-dismissed', 'true', d, '/');
+        }
+    }
+
+    // Check if previously dismissed
+    if (hasCookies) {
+        if (!Mozilla.Cookies.getItem('sticky-home-cta-dismissed')) {
+            // init the button
+            initStickyCTA();
+        } else {
+            $stickyCTA.remove();
+        }
+    } else {
+        $stickyCTA.remove();
+    }
+
+})(window.jQuery, window.Waypoint);

--- a/media/js/exp/mobile.js
+++ b/media/js/exp/mobile.js
@@ -1,0 +1,28 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+(function() {
+    'use strict';
+
+    var modal = document.getElementById('modal');
+    var mobileButtons = document.querySelectorAll('.js-mobile');
+    var mobileContent = document.getElementById('modal-download-firefox');
+
+    for(var i = 0; i < mobileButtons.length; i++) {
+        mobileButtons[i].addEventListener('click', function() {
+            mobileContent.style.display = 'block';
+            Mzp.Modal.createModal(this, modal, {
+                closeText: window.Mozilla.Utils.trans('global-close'),
+                onDestroy: function() {
+                    mobileContent.style.display = 'none';
+                }
+            });
+        });
+    }
+
+    // initialize send to device widget
+    var form = new Mozilla.SendToDevice();
+    form.init();
+
+})();

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -229,6 +229,12 @@
     },
     {
       "files": [
+        "css/exp/home/home-2018.scss"
+      ],
+      "name": "exp-home-2018"
+    },
+    {
+      "files": [
         "css/base/banners/fundraiser.scss"
       ],
       "name": "fundraising-banner"
@@ -630,6 +636,13 @@
     {
       "files": [
         "css/protocol/components/send-to-device.scss",
+        "css/exp/mobile.scss"
+      ],
+      "name": "exp-firefox-mobile"
+    },
+    {
+      "files": [
+        "css/protocol/components/send-to-device.scss",
         "css/firefox/mobile/get-app.scss"
       ],
       "name": "firefox-mobile-get-app"
@@ -931,6 +944,18 @@
     },
     {
       "files": [
+        "protocol/js/protocol-modal.js",
+        "protocol/js/protocol-newsletter.js",
+        "js/base/mozilla-lazy-load.js",
+        "js/libs/jquery.waypoints.min.js",
+        "js/newsletter/form-protocol.js",
+        "js/mozorg/home/youtube.js",
+        "js/exp/home.js"
+      ],
+      "name": "exp-home"
+    },
+    {
+      "files": [
         "js/base/mozilla-banner.js",
         "js/mozorg/home/banner-init.js"
       ],
@@ -980,6 +1005,18 @@
         "js/firefox/mobile/mobile.js"
       ],
       "name": "firefox-mobile"
+    },
+    {
+      "files": [
+        "protocol/js/protocol-modal.js",
+        "js/libs/spin.min.js",
+        "js/base/send-to-device.js",
+        "js/libs/jquery.waypoints.min.js",
+        "js/libs/jquery.waypoints-sticky.min.js",
+        "js/hubs/sub-nav.js",
+        "js/exp/mobile.js"
+      ],
+      "name": "exp-firefox-mobile"
     },
     {
       "files": [

--- a/tests/functional/test_experiment_pages.py
+++ b/tests/functional/test_experiment_pages.py
@@ -19,7 +19,9 @@ def pytest_generate_tests(metafunc):
             'line or in a configuration file.')
     paths = (
         '/exp/firefox/',
-        '/exp/firefox/new/'
+        '/exp/firefox/new/',
+        '/exp/firefox/mobile/',
+        '/exp/'
     )
     metafunc.parametrize('url', [base_url + path for path in paths])
 


### PR DESCRIPTION
## Description
Adds firefox/mobile and the homepage to the exp app for convert tests.

## Issue / Bugzilla link
#8795

## Testing
[Creating exp pages docs.](https://bedrock.readthedocs.io/en/latest/abtest.html#creating-experimental-pages)