### PR TITLE
Remove locale from hreflang x-default (Fixes #8513)

### DIFF
--- a/bedrock/base/templates/includes/canonical-url.html
+++ b/bedrock/base/templates/includes/canonical-url.html
@@ -1,5 +1,5 @@
     <link rel="canonical" href="{{ settings.CANONICAL_URL + '/' + LANG + canonical_path }}">
-    <link rel="alternate" hreflang="x-default" href="{{ settings.CANONICAL_URL }}/{{ settings.LANGUAGE_CODE }}{{ canonical_path }}">
+    <link rel="alternate" hreflang="x-default" href="{{ settings.CANONICAL_URL }}{{ canonical_path }}">
     {% if translations -%}
       {%- for code, label in translations|dictsort -%}
         {%- set alt_url = alternate_url(canonical_path, code) -%}


### PR DESCRIPTION
## Description
Remove locale from hreflang x-default

## Issue / Bugzilla link
#8513

## Testing
- [ ] Locale should be excluded from x-default hreflang in the `<head>` of each respective page.