### PR TITLE
Fix newsletter form submission on /channel page (Fixes #8690)

### DIFF
--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -757,7 +757,8 @@
   "js": [
     {
       "files": [
-        "protocol/js/protocol-newsletter.js"
+        "protocol/js/protocol-newsletter.js",
+        "js/newsletter/form-protocol.js"
       ],
       "name": "firefox_channel"
     },


### PR DESCRIPTION
## Description
- Fixes broken newsletter signup form on http://localhost:8000/en-US/firefox/channel/desktop/

## Issue / Bugzilla link
#8690

## Testing
- [ ] "Thanks" message should be seen on form submission.