### PR TITLE
Exchange CTA buttons

### DIFF
--- a/bedrock/firefox/templates/firefox/messaging-experiment/privacy_by_default.html
+++ b/bedrock/firefox/templates/firefox/messaging-experiment/privacy_by_default.html
@@ -25,7 +25,7 @@
   
     <p class="primary-cta">
       <div>
-        <a class="mzp-c-button mzp-t-product js-open-about-protections" href="https://support.mozilla.org/kb/enhanced-tracking-protection-firefox-desktop?utm_source={{ _entrypoint }}&utm_medium=referral&utm_campaign={{ _utm_campaign }}&entrypoint={{ _entrypoint }}" data-cta-text="Check Out Your Protections" data-cta-type="button">{{ _('Check Out Your Protections') }}</a>
+        <a href="{{ url('firefox.privacy.index') }}" class="mzp-c-button mzp-t-product" data-cta-text="Find More Privacy Tools" data-cta-type="button">{{ _('Find More Privacy Tools') }}</a>
       </div>
     </p>
     {% endcall %}
@@ -66,9 +66,5 @@
         </div>
       </div>
     </div>
-  {% endblock %}
-  
-  {% block js %}
-    {{ js_bundle('default_privacy_messaging') }}
   {% endblock %}
   

--- a/bedrock/firefox/templates/firefox/messaging-experiment/privacy_by_default.html
+++ b/bedrock/firefox/templates/firefox/messaging-experiment/privacy_by_default.html
@@ -25,7 +25,7 @@
   
     <p class="primary-cta">
       <div>
-        <a href="{{ url('firefox.privacy.index') }}" class="mzp-c-button mzp-t-product" data-cta-text="Find More Privacy Tools" data-cta-type="button">{{ _('Find More Privacy Tools') }}</a>
+        <a href="{{ url('firefox.privacy.index') }}" class="mzp-c-button mzp-t-product" data-cta-text="Learn About Firefox Privacy" data-cta-type="button">{{ _('Learn About Firefox Privacy') }}</a>
       </div>
     </p>
     {% endcall %}

--- a/bedrock/firefox/templates/firefox/messaging-experiment/privacy_tools.html
+++ b/bedrock/firefox/templates/firefox/messaging-experiment/privacy_tools.html
@@ -22,7 +22,7 @@
   
     <p class="primary-cta">
       <div>
-        <a href="{{ url('firefox.privacy.products') }}" class="mzp-c-button mzp-t-product" data-cta-text="Find More Privacy Tools" data-cta-type="button">{{ _('Find More Privacy Tools') }}</a>
+        <a class="mzp-c-button mzp-t-product js-open-about-protections" href="https://support.mozilla.org/kb/enhanced-tracking-protection-firefox-desktop?utm_source={{ _entrypoint }}&utm_medium=referral&utm_campaign={{ _utm_campaign }}&entrypoint={{ _entrypoint }}" data-cta-text="Check Out Your Protections" data-cta-type="button">{{ _('Check Out Your Protections') }}</a>
       </div>
     </p>
     {% endcall %}
@@ -61,4 +61,8 @@
         </div>
       </div>
     </div>
+  {% endblock %}
+
+  {% block js %}
+    {{ js_bundle('default_privacy_messaging') }}
   {% endblock %}


### PR DESCRIPTION
@craigcook 
The tooling callout was meant to go to the protections report. While the privacy by default page was meant to go to the privacy promise page. I had it backwards.