### PR TITLE
Add vanity URL redirect for EKR’s blog

### DIFF
--- a/bedrock/mozorg/redirects.py
+++ b/bedrock/mozorg/redirects.py
@@ -707,4 +707,7 @@ redirectpatterns = (
 
     # Issue 8374
     redirect(r'^plugincheck/?$', 'https://support.mozilla.org/kb/npapi-plugins/'),
+
+    # Vanity URL for EKR's blog
+    redirect(r'^ekr/?$', 'https://blog.mozilla.org/blog/author/ekrmozilla-com/'),
 )

--- a/bedrock/mozorg/templates/mozorg/about/leadership.html
+++ b/bedrock/mozorg/templates/mozorg/about/leadership.html
@@ -772,7 +772,7 @@
         <div class="person-bio">
           <p>
           {% trans %}
-            Eric is CTO of the Firefox team at Mozilla. In this role he leads the long-term technical strategy for Firefox, He also partners with the Engineering and Product organizations to set the short-term technical direction.
+            Eric is CTO of the Firefox team at Mozilla. In this role he leads the long-term technical strategy for Firefox. He also partners with the Engineering and Product organizations to set the short-term technical direction.
           {% endtrans %}
           </p>
 

--- a/tests/redirects/map_globalconf.py
+++ b/tests/redirects/map_globalconf.py
@@ -1355,4 +1355,6 @@ URLS = flatten((
 
     # Issue 8374
     url_test('/plugincheck/', 'https://support.mozilla.org/kb/npapi-plugins/'),
+
+    url_test('/ekr/', 'https://blog.mozilla.org/blog/author/ekrmozilla-com/'),
 ))


### PR DESCRIPTION
## Description
Redirects mozilla.org/ekr/ to https://blog.mozilla.org/blog/author/ekrmozilla-com/

## Issue / Bugzilla link
https://github.com/mozilla/blogdotmozilladotorg/issues/18

## Testing
Make sure it works and the test passes.