### PR TITLE
Exclude unrelated page content from search result snippets (Fixes #8739)

### DIFF
--- a/bedrock/base/templates/base-pebbles.html
+++ b/bedrock/base/templates/base-pebbles.html
@@ -86,8 +86,6 @@
       data-global-previous="{{ ftl('ui-previous') }}"
       {% block string_data %}{% endblock %}></div>
 
-    {% block page_banner %}{% endblock %}
-
     {% block site_header %}
       {% include 'includes/protocol/navigation/menu-mozilla/index.html' %}
     {% endblock %}
@@ -98,6 +96,9 @@
       {% block site_footer %}
         {% include 'includes/protocol/footer/mozilla.html' %}
       {% endblock %}
+
+      {# Banner is last in HTML as it's low priority for search engines and uses `data-nosnippet` (issue #8739) #}
+      {% block page_banner %}{% endblock %}
     </div>
 
     {% block site_js %}

--- a/bedrock/base/templates/includes/banners/base.html
+++ b/bedrock/base/templates/includes/banners/base.html
@@ -3,13 +3,16 @@
  # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
 
 <aside class="c-banner hide-from-legacy-ie {% if class_name %}{{ class_name }}{% endif %}" id="page-banner">
-  <button type="button" class="c-banner-close" id="page-banner-close"><span>{{ ftl('ui-close') }}</span></button>
-  <div class="mzp-l-content">
-    <h2 class="c-banner-title">
-      {% block banner_title %}{% endblock %}
-    </h2>
-    <div class="c-banner-content">
-      {% block banner_content %}{% endblock %}
+  {# Exclude banners from search result snippets using `data-nosnippet` (issue 8739) #}
+  <div class="c-banner-inner" data-nosnippet="true">
+    <button type="button" class="c-banner-close" id="page-banner-close"><span>{{ ftl('ui-close') }}</span></button>
+    <div class="mzp-l-content">
+      <h2 class="c-banner-title">
+        {% block banner_title %}{% endblock %}
+      </h2>
+      <div class="c-banner-content">
+        {% block banner_content %}{% endblock %}
+      </div>
     </div>
   </div>
 </aside>

--- a/bedrock/firefox/templates/firefox/includes/download-button.html
+++ b/bedrock/firefox/templates/firefox/includes/download-button.html
@@ -43,20 +43,20 @@
     {{ alt_buttons(builds) }}
   </div>
   {% if show_desktop %}
-    {# unrecognized/unsupported platform #}
-    <div class="unrecognized-download">
+    {# Unrecognized/unsupported messaging. Exclude from search result snippets using `data-nosnippet` (issue 8739) #}
+    <div class="unrecognized-download" data-nosnippet="true">
       <p>{{ ftl('download-button-your-system-may') }}</p>
       {{ alt_buttons(builds) }}
     </div>
-    <p class="unsupported-download">
-      {{ ftl('download-button-your-system-does-not', url=firefox_url('desktop', 'sysreq', channel)) }}
-    </p>
-    <p class="unsupported-download-osx">
-      {{ ftl('download-button-your-system-does-not', url='https://support.mozilla.org/kb/firefox-osx') }}
-    </p>
-    <p class="linux-arm-download">
-      {{ ftl('download-button-please-follow-these', url='https://support.mozilla.org/kb/install-firefox-linux') }}
-    </p>
+    <div class="unsupported-download" data-nosnippet="true">
+      <p>{{ ftl('download-button-your-system-does-not', url=firefox_url('desktop', 'sysreq', channel)) }}</p>
+    </div>
+    <div class="unsupported-download-osx" data-nosnippet="true">
+      <p>{{ ftl('download-button-your-system-does-not', url='https://support.mozilla.org/kb/firefox-osx') }}</p>
+    </div>
+    <div class="linux-arm-download" data-nosnippet="true">
+      <p>{{ ftl('download-button-please-follow-these', url='https://support.mozilla.org/kb/install-firefox-linux') }}</p>
+    </div>
   {% endif %}
   <ul class="download-list">
     {% for plat in builds %}

--- a/bedrock/firefox/tests/test_helpers.py
+++ b/bedrock/firefox/tests/test_helpers.py
@@ -129,6 +129,28 @@ class TestDownloadButtons(TestCase):
             link = pq(link)
             assert link.attr('data-download-location') is None
 
+    def test_download_nosnippet_attribute(self):
+        """
+        Unsupported messaging should be well formed <div>'s with data-nosnippet attribute (issue #8739).
+        """
+        rf = RequestFactory()
+        get_request = rf.get('/fake')
+        get_request.locale = 'fr'
+        doc = pq(render("{{ download_firefox() }}",
+                        {'request': get_request, 'fluent_l10n': self.get_l10n(get_request.locale)}))
+
+        unrecognised_message = doc('.unrecognized-download').empty().outerHtml()
+        assert unrecognised_message == '<div class="unrecognized-download" data-nosnippet="true"></div>'
+
+        unsupported_message = doc('.unsupported-download').empty().outerHtml()
+        assert unsupported_message == '<div class="unsupported-download" data-nosnippet="true"></div>'
+
+        unsupported_osx_message = doc('.unsupported-download-osx').empty().outerHtml()
+        assert unsupported_osx_message == '<div class="unsupported-download-osx" data-nosnippet="true"></div>'
+
+        linux_arm_message = doc('.linux-arm-download').empty().outerHtml()
+        assert linux_arm_message == '<div class="linux-arm-download" data-nosnippet="true"></div>'
+
     def test_button_has_data_attr_if_not_direct(self):
         """
         If the button points to the thank you page, it should have a

--- a/media/js/base/mozilla-banner.js
+++ b/media/js/base/mozilla-banner.js
@@ -10,7 +10,7 @@ if (typeof window.Mozilla === 'undefined') {
 (function() {
     'use strict';
 
-    var _fundraiser;
+    var _pageBanner;
 
     var Banner = {};
 
@@ -27,7 +27,7 @@ if (typeof window.Mozilla === 'undefined') {
 
     Banner.close = function() {
         // Remove the banner from the DOM.
-        _fundraiser.parentNode.removeChild(_fundraiser);
+        _pageBanner.parentNode.removeChild(_pageBanner);
 
         // Set a cookie to not display it again.
         Banner.setCookie(Banner.id);
@@ -42,8 +42,19 @@ if (typeof window.Mozilla === 'undefined') {
     };
 
     Banner.show = function() {
+        var outerWrapper = document.getElementById('outer-wrapper');
+
+        // if for some reason there's no outer-wrapper on the page, do nothing.
+        if (!outerWrapper) {
+            return;
+        }
+
+        // remove banner from bottom of page and reinsert at the top, after primary nav.
+        _pageBanner = _pageBanner.parentNode.removeChild(_pageBanner);
+        outerWrapper.insertBefore(_pageBanner, outerWrapper.firstChild);
+
         // display the banner
-        _fundraiser.classList.add('c-banner-is-visible');
+        _pageBanner.classList.add('c-banner-is-visible');
 
         // wire up close button
         document.getElementById('page-banner-close').addEventListener('click', Banner.close, false);
@@ -52,13 +63,13 @@ if (typeof window.Mozilla === 'undefined') {
     Banner.init = function(id) {
         var cookiesEnabled = typeof Mozilla.Cookies !== 'undefined' && Mozilla.Cookies.enabled();
 
-        _fundraiser = document.getElementById('page-banner');
+        _pageBanner = document.getElementById('page-banner');
 
         /**
          * If the banner does not exist on a page,
          * or there's not a valid banner ID then do nothing.
          */
-        if (!_fundraiser || typeof id !== 'string') {
+        if (!_pageBanner || typeof id !== 'string') {
             return false;
         }
 

--- a/tests/unit/spec/base/mozilla-banner.js
+++ b/tests/unit/spec/base/mozilla-banner.js
@@ -26,13 +26,16 @@ describe('mozilla-banner.js', function() {
         var bannerId = 'test-banner';
 
         beforeEach(function() {
-            var banner = '<aside id="page-banner"><button type="button" id="page-banner-close">Close</button></aside>';
-            document.body.insertAdjacentHTML('beforeend', banner);
+            var content = '<div id="outer-wrapper">' +
+                            '<h1>Some title</h1>' +
+                            '<aside id="page-banner"><button type="button" id="page-banner-close">Close</button></aside>' +
+                          '</div>';
+            document.body.insertAdjacentHTML('beforeend', content);
         });
 
         afterEach(function() {
-            var banner = document.getElementById('page-banner');
-            banner.parentNode.removeChild(banner);
+            var content = document.getElementById('outer-wrapper');
+            content.parentNode.removeChild(content);
 
             Mozilla.Banner.id = null;
         });
@@ -58,11 +61,17 @@ describe('mozilla-banner.js', function() {
         var bannerId = 'test-banner';
 
         beforeEach(function() {
-            var banner = '<aside id="page-banner"><button type="button" id="page-banner-close">Close</button></aside>';
-            document.body.insertAdjacentHTML('beforeend', banner);
+            var content = '<div id="outer-wrapper">' +
+                            '<h1>Some title</h1>' +
+                            '<aside id="page-banner"><button type="button" id="page-banner-close">Close</button></aside>' +
+                          '</div>';
+            document.body.insertAdjacentHTML('beforeend', content);
         });
 
         afterEach(function() {
+            var content = document.getElementById('outer-wrapper');
+            content.parentNode.removeChild(content);
+
             Mozilla.Banner.id = null;
         });
 


### PR DESCRIPTION
## Description
- Add `data-nosnippet` attributes to conditional messaging inside download buttons.
- Add `data-nosnippet` attribute to page banners.

## Issue / Bugzilla link
#8739

## Testing
Demo: 
- https://www-demo5.allizom.org/en-US/
- https://www-demo5.allizom.org/en-US/firefox/new/