### PR TITLE
Remove nav from /new exp page #8773

### DIFF
--- a/bedrock/exp/templates/exp/firefox/new/download.html
+++ b/bedrock/exp/templates/exp/firefox/new/download.html
@@ -27,22 +27,6 @@
 {#- This will appear as <meta property="og:description"> which can be used for social share -#}
 {% block page_og_desc %}Faster page loading, less memory usage and packed with features, the new Firefox is here.{% endblock %}
 
-{% block page_css %}
-  {% if v == 'b' %}
-  <style>
-    .mzp-c-navigation.top-header-navigation {
-      display: none;
-    }
-  </style>
-  {% endif %}
-{% endblock %}
-
-{% block site_header %}
-  {% if v in ['b','c'] %}
-    {% include 'includes/protocol/navigation/menu-firefox/index.html' %}
-  {% endif %}
-{% endblock %}
-
 {% block content %}
 <main role="main" class="main-download" {% if v %}data-variant="{{ v }}"{% endif %}>
   {% call hero(

--- a/bedrock/exp/views.py
+++ b/bedrock/exp/views.py
@@ -16,7 +16,7 @@ def new(request):
         experience = None
 
     # ensure variant matches pre-defined value
-    if variant not in ['a', 'b', 'c']:  # place expected ?v= values in this list
+    if variant not in ['']:  # place expected ?v= values in this list
         variant = None
 
     # no harm done by passing 'v' to template, even when no experiment is running


### PR DESCRIPTION
## Description

Remove nav from /new exp page

## Issue / Bugzilla link

See #8773

## Testing

http://localhost:8000/en-US/exp/firefox/new/