### PR TITLE
Remove screenshotgo pages (fixes #8619)

### DIFF
--- a/bedrock/legal/templates/legal/terms/firefox-screenshotgo.html
+++ b/bedrock/legal/templates/legal/terms/firefox-screenshotgo.html
@@ -1,7 +1,0 @@
-{# This Source Code Form is subject to the terms of the Mozilla Public
- # License, v. 2.0. If a copy of the MPL was not distributed with this
- # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
-
-{% extends "legal/docs-base.html" %}
-
-{% block page_title %}{{ _('Firefox ScreenshotGo: About Your Rights') }}{% endblock %}

--- a/bedrock/legal/urls.py
+++ b/bedrock/legal/urls.py
@@ -40,9 +40,6 @@ urlpatterns = (
     url(r'^terms/firefox-reality/$', LegalDocView.as_view(template_name='legal/terms/firefox-reality.html',
         legal_doc_name='firefox_reality_about_rights'), name='legal.terms.firefox-reality'),
 
-    url(r'^terms/firefox-screenshotgo/$', LegalDocView.as_view(template_name='legal/terms/firefox-screenshotgo.html',
-        legal_doc_name='firefox_screenshotgo_about_rights'), name='legal.terms.firefox-screenshotgo'),
-
     page('terms/firefox-private-network', 'legal/terms/firefox-private-network.html'),
 
     url(r'^terms/thunderbird/$', LegalDocView.as_view(template_name='legal/terms/thunderbird.html', legal_doc_name='thunderbird_about_rights'),

--- a/bedrock/privacy/templates/privacy/notices/firefox-screenshotgo.html
+++ b/bedrock/privacy/templates/privacy/notices/firefox-screenshotgo.html
@@ -1,9 +1,0 @@
-{# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
-
-{% extends "privacy/notices/base-notice-paragraphs.html" %}
-
-{% set body_id = "privacy-screenshotgo" %}
-
-{% block article_header_logo %}{{ static('img/logos/firefox/logo-screenshotgo.png') }}{% endblock %}

--- a/bedrock/privacy/urls.py
+++ b/bedrock/privacy/urls.py
@@ -21,7 +21,6 @@ urlpatterns = (
     url(r'^firefox-reality/$', views.firefox_reality_notices, name='privacy.notices.firefox-reality'),
     redirect(r'^firefox-rocket/$', 'privacy.notices.firefox-lite', locale_prefix=False),
     url(r'^firefox-lite/$', views.firefox_lite_notices, name='privacy.notices.firefox-lite'),
-    url(r'^firefox-screenshotgo/$', views.firefox_screenshotgo_notices, name='privacy.notices.firefox-screenshotgo'),
     # bug 1319207 - special URL for Firefox Focus in de locale
     url(r'^firefox-klar/$', views.firefox_focus_notices, name='privacy.notices.firefox-klar'),
     url(r'^thunderbird/$', views.thunderbird_notices, name='privacy.notices.thunderbird'),

--- a/bedrock/privacy/views.py
+++ b/bedrock/privacy/views.py
@@ -86,10 +86,6 @@ firefox_reality_notices = PrivacyDocView.as_view(
     template_name='privacy/notices/firefox-reality.html',
     legal_doc_name='firefox_reality_privacy_notice')
 
-firefox_screenshotgo_notices = PrivacyDocView.as_view(
-    template_name='privacy/notices/firefox-screenshotgo.html',
-    legal_doc_name='firefox_screenshotgo_privacy_notice')
-
 thunderbird_notices = PrivacyDocView.as_view(
     template_name='privacy/notices/thunderbird.html',
     legal_doc_name='thunderbird_privacy_policy')


### PR DESCRIPTION
## Description
Removes:
- http://localhost:8000/en-US/privacy/firefox-screenshotgo/
- http://localhost:8000/en-US/about/legal/terms/firefox-screenshotgo/

## Issue / Bugzilla link
#8619

## Testing
- [x] both URLs should 404 as requested in the issue.