### PR TITLE
Add platform download page tests (Fixes #8604)

### DIFF
--- a/tests/functional/firefox/new/test_platform.py
+++ b/tests/functional/firefox/new/test_platform.py
@@ -1,0 +1,35 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import pytest
+
+from pages.firefox.new.platform import PlatformDownloadPage
+
+
+@pytest.mark.sanity
+@pytest.mark.nondestructive
+@pytest.mark.parametrize('slug', ['windows', 'mac', 'linux'])
+def test_download_button_displayed(slug, base_url, selenium):
+    page = PlatformDownloadPage(selenium, base_url, slug=slug).open()
+    assert page.download_button.is_displayed
+
+
+# Firefox and Internet Explorer don't cope well with file prompts whilst using Selenium.
+@pytest.mark.skip_if_firefox(reason='http://saucelabs.com/jobs/5a8a62a7620f489d92d6193fa67cf66b')
+@pytest.mark.skip_if_internet_explorer(reason='https://github.com/SeleniumHQ/selenium/issues/448')
+@pytest.mark.nondestructive
+@pytest.mark.parametrize('slug', ['windows', 'mac', 'linux'])
+def test_click_download_button(slug, base_url, selenium):
+    page = PlatformDownloadPage(selenium, base_url, slug=slug).open()
+    thank_you_page = page.download_firefox()
+    assert thank_you_page.seed_url in selenium.current_url
+
+
+@pytest.mark.nondestructive
+@pytest.mark.parametrize('slug', ['windows', 'mac', 'linux'])
+def test_other_platforms_modal(slug, base_url, selenium):
+    page = PlatformDownloadPage(selenium, base_url, slug=slug).open()
+    modal = page.open_other_platforms_modal()
+    assert modal.is_displayed
+    modal.close()

--- a/tests/pages/firefox/new/platform.py
+++ b/tests/pages/firefox/new/platform.py
@@ -1,0 +1,34 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from selenium.webdriver.common.by import By
+
+from pages.base import BasePage
+from pages.regions.download_button import DownloadButton
+from pages.regions.modal import ModalProtocol
+
+
+class PlatformDownloadPage(BasePage):
+
+    URL_TEMPLATE = '/{locale}/firefox/{slug}/'
+
+    _download_button_locator = (By.ID, 'download-button-desktop-release')
+    _platforms_modal_link_locator = (By.CLASS_NAME, 'js-platform-modal-button')
+    _platforms_modal_content_locator = (By.CLASS_NAME, 'mzp-u-modal-content')
+
+    @property
+    def download_button(self):
+        el = self.find_element(*self._download_button_locator)
+        return DownloadButton(self, root=el)
+
+    def download_firefox(self):
+        self.download_button.click()
+        from pages.firefox.new.thank_you import ThankYouPage
+        return ThankYouPage(self.selenium, self.base_url).wait_for_page_to_load()
+
+    def open_other_platforms_modal(self):
+        modal = ModalProtocol(self)
+        self.find_element(*self._platforms_modal_link_locator).click()
+        self.wait.until(lambda s: modal.displays(self._platforms_modal_content_locator))
+        return modal


### PR DESCRIPTION
## Description
Adds functional test coverage for `/windows/`, `/mac/`, and `/linux/` download pages.

## Issue / Bugzilla link
#8604

## Testing
Successful test run: https://gitlab.com/mozmeao/www-config/pipelines/142725753