### PR TITLE
[no bug] Update newsletter form subtitle and description

### DIFF
--- a/bedrock/exp/templates/exp/home/home-de.html
+++ b/bedrock/exp/templates/exp/home/home-de.html
@@ -90,7 +90,7 @@
         <div class="newsletter-content">
           {{ email_newsletter_form(
             title=_('Du liebst das Internet?'),
-            subtitle=_('Hol dir den Firefox Newsletter und sorg mit uns zusammen dafür, dass das Web frei und offen für alle bleibt.'),
+            desc=_('Hol dir den Firefox Newsletter und sorg mit uns zusammen dafür, dass das Web frei und offen für alle bleibt.'),
             button_class='button-dark',
             submit_text=_('Anmelden'),
             protocol_component=True

--- a/bedrock/exp/templates/exp/home/home-en.html
+++ b/bedrock/exp/templates/exp/home/home-en.html
@@ -179,7 +179,7 @@
           {{ email_newsletter_form(
             newsletters=newsletter_id,
             title=_('Love the Web?'),
-            subtitle=_('Get the Mozilla newsletter and help us keep it open and free.'),
+            desc=_('Get the Mozilla newsletter and help us keep it open and free.'),
             button_class='button-dark',
             submit_text=_('Sign up now'),
             protocol_component=True

--- a/bedrock/exp/templates/exp/home/home-fr.html
+++ b/bedrock/exp/templates/exp/home/home-fr.html
@@ -89,7 +89,7 @@ Le saviez-vous ? Mozilla, le concepteur de Firefox, se bat pour qu’Internet, u
         <div class="newsletter-content">
           {{ email_newsletter_form(
             title=_('Vous adorez Internet ?'),
-            subtitle=_('Abonnez-vous à la newsletter Firefox et soutenez notre vision d’un Internet libre et sécurisé.'),
+            desc=_('Abonnez-vous à la newsletter Firefox et soutenez notre vision d’un Internet libre et sécurisé.'),
             button_class='button-dark',
             submit_text=_('S’abonner'),
             protocol_component=True

--- a/bedrock/firefox/templates/firefox/channel/base.html
+++ b/bedrock/firefox/templates/firefox/channel/base.html
@@ -61,7 +61,7 @@
       {{ email_newsletter_form(
         protocol_component=True,
         title=ftl('newsletter-form-firefox-and-you'),
-        subtitle=ftl('newsletter-form-get-firefox-tips')) }}
+        desc=ftl('newsletter-form-get-firefox-tips')) }}
     </div>
   </section>
 </main>

--- a/bedrock/firefox/templates/firefox/developer/includes/alt-newsletter.html
+++ b/bedrock/firefox/templates/firefox/developer/includes/alt-newsletter.html
@@ -5,7 +5,7 @@
       {{ email_newsletter_form(
         'app-dev',
         title='Mozilla Developer Newsletter',
-        subtitle=_('Get developer news, tricks and resources <br /> sent straight to your inbox.'),
+        desc=_('Get developer news, tricks and resources <br /> sent straight to your inbox.'),
         button_class='mzp-t-product',
         include_language=False,
         protocol_component=True) }}

--- a/bedrock/firefox/templates/firefox/developer/index.html
+++ b/bedrock/firefox/templates/firefox/developer/index.html
@@ -83,7 +83,7 @@
         {{ email_newsletter_form(
           'app-dev',
           title='Get the most out of Firefox Developer Edition',
-          subtitle='Learn about Dev Edition and subscribe to the Mozilla Developer Newsletter.',
+          desc='Learn about Dev Edition and subscribe to the Mozilla Developer Newsletter.',
           button_class='mzp-t-product mzp-t-small',
           include_language=False,
           protocol_component=True) }}

--- a/bedrock/firefox/templates/firefox/retention/thank-you.html
+++ b/bedrock/firefox/templates/firefox/retention/thank-you.html
@@ -68,7 +68,7 @@
        newsletters='mozilla-foundation',
        protocol_component=True,
        title=_('Stay in touch for more cool stuff'),
-       subtitle=_('Get the latest & greatest from Firefox delivered straight to your inbox.'),
+       desc=_('Get the latest & greatest from Firefox delivered straight to your inbox.'),
        spinner_color='#fff')
     }}
   </div>

--- a/bedrock/foundation/templates/foundation/annualreport/2009/base.html
+++ b/bedrock/foundation/templates/foundation/annualreport/2009/base.html
@@ -41,7 +41,7 @@
 
       <div class="newsletter-content">
         {% if LANG.startswith('en-') %}
-          {{ email_newsletter_form(protocol_component=true, newsletters='mozilla-foundation', title=_('Sign up. Read up.<br> Make a difference.'), subtitle=_('Get the Mozilla newsletter and help us keep the Web free and open.'), button_class='button-red') }}
+          {{ email_newsletter_form(protocol_component=true, newsletters='mozilla-foundation', title=_('Sign up. Read up.<br> Make a difference.'), desc=_('Get the Mozilla newsletter and help us keep the Web free and open.'), button_class='button-red') }}
         {% else %}
           {{ email_newsletter_form(protocol_component=true, button_class='button-red') }}
         {% endif %}

--- a/bedrock/foundation/templates/foundation/annualreport/2010/base.html
+++ b/bedrock/foundation/templates/foundation/annualreport/2010/base.html
@@ -41,7 +41,7 @@
 
       <div class="newsletter-content">
         {% if LANG.startswith('en-') %}
-          {{ email_newsletter_form(protocol_component=true, newsletters='mozilla-foundation', title=_('Sign up. Read up.<br> Make a difference.'), subtitle=_('Get the Mozilla newsletter and help us keep the Web free and open.'), button_class='button-red') }}
+          {{ email_newsletter_form(protocol_component=true, newsletters='mozilla-foundation', title=_('Sign up. Read up.<br> Make a difference.'), desc=_('Get the Mozilla newsletter and help us keep the Web free and open.'), button_class='button-red') }}
         {% else %}
           {{ email_newsletter_form(protocol_component=true, button_class='button-red') }}
         {% endif %}

--- a/bedrock/foundation/templates/foundation/base.html
+++ b/bedrock/foundation/templates/foundation/base.html
@@ -47,7 +47,7 @@
 
       <div class="newsletter-content">
         {% if LANG.startswith('en-') %}
-          {{ email_newsletter_form(protocol_component=true, newsletters='mozilla-foundation', title=_('Sign up. Read up.<br> Make a difference.'), subtitle=_('Get the Mozilla newsletter and help us keep the Web free and open.'), button_class='button-red') }}
+          {{ email_newsletter_form(protocol_component=true, newsletters='mozilla-foundation', title=_('Sign up. Read up.<br> Make a difference.'), desc=_('Get the Mozilla newsletter and help us keep the Web free and open.'), button_class='button-red') }}
         {% else %}
           {{ email_newsletter_form(protocol_component=true, button_class='button-red') }}
         {% endif %}

--- a/bedrock/legal/templates/legal/index.html
+++ b/bedrock/legal/templates/legal/index.html
@@ -96,7 +96,7 @@
       {{ email_newsletter_form(
             protocol_component=True,
             title=_('Love the Web?'),
-            subtitle=_('Get the Mozilla newsletter and help us keep it open and free.')) }}
+            desc=_('Get the Mozilla newsletter and help us keep it open and free.')) }}
       {% else %}
       {{ email_newsletter_form() }}
       {% endif %}

--- a/bedrock/mozorg/templates/mozorg/about-base.html
+++ b/bedrock/mozorg/templates/mozorg/about-base.html
@@ -47,7 +47,7 @@
 
     <div class="newsletter-content">
       {% if LANG.startswith('en-') %}
-        {{ email_newsletter_form(protocol_component=true, newsletters='mozilla-foundation', title=_('Love the Web?'), subtitle=_('Get the Mozilla newsletter and help us keep it open and free.'), button_class='button-hollow button-light', spinner_color='#fff') }}
+        {{ email_newsletter_form(protocol_component=true, newsletters='mozilla-foundation', title=_('Love the Web?'), desc=_('Get the Mozilla newsletter and help us keep it open and free.'), button_class='button-hollow button-light', spinner_color='#fff') }}
       {% else %}
         {{ email_newsletter_form(protocol_component=true, button_class='button-hollow button-light', spinner_color='#fff') }}
       {% endif %}

--- a/bedrock/mozorg/templates/mozorg/about.html
+++ b/bedrock/mozorg/templates/mozorg/about.html
@@ -180,7 +180,7 @@
       {{ email_newsletter_form(
           newsletters=newsletter_id,
           title=_('Get The Mozilla Newsletter'),
-          subtitle=_('Stay informed about the issues affecting the internet, and learn how you can get involved in protecting the world’s newest public resource.'),
+          desc=_('Stay informed about the issues affecting the internet, and learn how you can get involved in protecting the world’s newest public resource.'),
           button_class='button-dark',
           submit_text=_('Subscribe'),
           protocol_component=True

--- a/bedrock/mozorg/templates/mozorg/about/manifesto.html
+++ b/bedrock/mozorg/templates/mozorg/about/manifesto.html
@@ -380,7 +380,7 @@
 
         <div class="newsletter-content">
           {% if LANG.startswith('en-') %}
-            {{ email_newsletter_form(protocol_component=True, newsletters='mozilla-foundation', title=_('Love the web?'), subtitle=_('Get the Mozilla newsletter and help us keep it open and free.'), spinner_color='#fff') }}
+            {{ email_newsletter_form(protocol_component=True, newsletters='mozilla-foundation', title=_('Love the web?'), desc=_('Get the Mozilla newsletter and help us keep it open and free.'), spinner_color='#fff') }}
           {% else %}
             {{ email_newsletter_form(protocol_component=True, spinner_color='#fff') }}
           {% endif %}

--- a/bedrock/mozorg/templates/mozorg/home/home-de.html
+++ b/bedrock/mozorg/templates/mozorg/home/home-de.html
@@ -87,7 +87,7 @@
         <div class="newsletter-content">
           {{ email_newsletter_form(
             title=_('Du liebst das Internet?'),
-            subtitle=_('Hol dir den Firefox Newsletter und sorg mit uns zusammen dafür, dass das Web frei und offen für alle bleibt.'),
+            desc=_('Hol dir den Firefox Newsletter und sorg mit uns zusammen dafür, dass das Web frei und offen für alle bleibt.'),
             button_class='button-dark',
             submit_text=_('Anmelden'),
             protocol_component=True

--- a/bedrock/mozorg/templates/mozorg/home/home-en.html
+++ b/bedrock/mozorg/templates/mozorg/home/home-en.html
@@ -176,7 +176,7 @@
           {{ email_newsletter_form(
             newsletters=newsletter_id,
             title=_('Love the Web?'),
-            subtitle=_('Get the Mozilla newsletter and help us keep it open and free.'),
+            desc=_('Get the Mozilla newsletter and help us keep it open and free.'),
             button_class='button-dark',
             submit_text=_('Sign up now'),
             protocol_component=True

--- a/bedrock/mozorg/templates/mozorg/home/home-fr.html
+++ b/bedrock/mozorg/templates/mozorg/home/home-fr.html
@@ -86,7 +86,7 @@ Le saviez-vous ? Mozilla, le concepteur de Firefox, se bat pour qu’Internet, u
         <div class="newsletter-content">
           {{ email_newsletter_form(
             title=_('Vous adorez Internet ?'),
-            subtitle=_('Abonnez-vous à la newsletter Firefox et soutenez notre vision d’un Internet libre et sécurisé.'),
+            desc=_('Abonnez-vous à la newsletter Firefox et soutenez notre vision d’un Internet libre et sécurisé.'),
             button_class='button-dark',
             submit_text=_('S’abonner'),
             protocol_component=True

--- a/bedrock/mozorg/templates/mozorg/internet-health/decentralization.html
+++ b/bedrock/mozorg/templates/mozorg/internet-health/decentralization.html
@@ -486,7 +486,7 @@
     <div class="content">
       {{ email_newsletter_form(newsletters='mozilla-foundation',
          title=_('Stay informed.'),
-         subtitle=_('Sign up. Read up. Get the Mozilla newsletter to stay smart on the issues affecting your life online.'),
+         desc=_('Sign up. Read up. Get the Mozilla newsletter to stay smart on the issues affecting your life online.'),
          button_class='button-light')
       }}
     </div>

--- a/bedrock/mozorg/templates/mozorg/internet-health/digital-inclusion.html
+++ b/bedrock/mozorg/templates/mozorg/internet-health/digital-inclusion.html
@@ -411,7 +411,7 @@
     <div class="content">
       {{ email_newsletter_form(newsletters='mozilla-foundation',
          title=_('Stay informed.'),
-         subtitle=_('Sign up. Read up. Get the Mozilla newsletter to stay smart on the issues affecting your life online.'),
+         desc=_('Sign up. Read up. Get the Mozilla newsletter to stay smart on the issues affecting your life online.'),
          button_class='button-light')
       }}
     </div>

--- a/bedrock/mozorg/templates/mozorg/internet-health/open-innovation.html
+++ b/bedrock/mozorg/templates/mozorg/internet-health/open-innovation.html
@@ -392,7 +392,7 @@
     <div class="content">
       {{ email_newsletter_form(newsletters='mozilla-foundation',
          title=_('Stay informed.'),
-         subtitle=_('Sign up. Read up. Get the Mozilla newsletter to stay smart on the issues affecting your life online.'),
+         desc=_('Sign up. Read up. Get the Mozilla newsletter to stay smart on the issues affecting your life online.'),
          button_class='button-light')
       }}
     </div>

--- a/bedrock/mozorg/templates/mozorg/internet-health/privacy-security.html
+++ b/bedrock/mozorg/templates/mozorg/internet-health/privacy-security.html
@@ -461,7 +461,7 @@
     <div class="content">
       {{ email_newsletter_form(newsletters='mozilla-foundation',
          title=_('Stay informed.'),
-         subtitle=_('Sign up. Read up. Get the Mozilla newsletter to stay smart on the issues affecting your life online.'),
+         desc=_('Sign up. Read up. Get the Mozilla newsletter to stay smart on the issues affecting your life online.'),
          button_class='button-light')
       }}
     </div>

--- a/bedrock/mozorg/templates/mozorg/internet-health/web-literacy.html
+++ b/bedrock/mozorg/templates/mozorg/internet-health/web-literacy.html
@@ -393,7 +393,7 @@
     <div class="content">
       {{ email_newsletter_form(newsletters='mozilla-foundation',
          title=_('Stay informed.'),
-         subtitle=_('Sign up. Read up. Get the Mozilla newsletter to stay smart on the issues affecting your life online.'),
+         desc=_('Sign up. Read up. Get the Mozilla newsletter to stay smart on the issues affecting your life online.'),
          button_class='button-light')
       }}
     </div>

--- a/bedrock/mozorg/templates/mozorg/mission.html
+++ b/bedrock/mozorg/templates/mozorg/mission.html
@@ -62,7 +62,7 @@
 
       <div class="newsletter-content">
         {% if LANG.startswith('en-') %}
-          {{ email_newsletter_form(protocol_component=true, newsletters='mozilla-foundation', title=_('Sign up. Read up.<br> Make a difference.'), subtitle=_('Get the Mozilla newsletter and help us keep the Web free and open.')) }}
+          {{ email_newsletter_form(protocol_component=true, newsletters='mozilla-foundation', title=_('Sign up. Read up.<br> Make a difference.'), desc=_('Get the Mozilla newsletter and help us keep the Web free and open.')) }}
         {% else %}
           {{ email_newsletter_form(protocol_component=true) }}
         {% endif %}

--- a/bedrock/mozorg/templates/mozorg/moss/base.html
+++ b/bedrock/mozorg/templates/mozorg/moss/base.html
@@ -54,7 +54,7 @@
         protocol_component=True,
         newsletters='mozilla-foundation',
         title=_('What’s next?'),
-        subtitle=_('Get the Mozilla newsletter for our latest tech news and more.'),
+        desc=_('Get the Mozilla newsletter for our latest tech news and more.'),
         spinner_color='#fff')
       }}
     </div>

--- a/bedrock/newsletter/templates/newsletter/includes/form-protocol.html
+++ b/bedrock/newsletter/templates/newsletter/includes/form-protocol.html
@@ -13,7 +13,10 @@
     <header class="mzp-c-newsletter-header">
       <h3 class="mzp-c-newsletter-title">{{ title|d(ftl('newsletter-form-get-firefox-news'), true) }}</h3>
       {% if subtitle %}
-      <p class="mzp-c-newsletter-tagline">{{ subtitle }}</p>
+      <h4 class="mzp-c-newsletter-subtitle">{{ subtitle }}</h4>
+      {% endif %}
+      {% if desc %}
+      <p class="mzp-c-newsletter-desc">{{ desc }}</p>
       {% endif %}
     </header>
     {% endif %}

--- a/bedrock/newsletter/templates/newsletter/includes/form.html
+++ b/bedrock/newsletter/templates/newsletter/includes/form.html
@@ -40,6 +40,9 @@
       {% if subtitle %}
         <h4>{{ subtitle }}</h4>
       {% endif %}
+      {% if desc %}
+        <p>{{ desc }}</p>
+      {% endif %}
       </div>
     {% endif %}
 

--- a/bedrock/newsletter/templates/newsletter/index.html
+++ b/bedrock/newsletter/templates/newsletter/index.html
@@ -14,7 +14,7 @@
     {{ email_newsletter_form(
       protocol_component=true,
       title=_('Read all about it in our <span>newsletter</span>'),
-      subtitle=_('Subscribe to updates and keep current with Mozilla news. It’s the perfect way for us to keep in touch!'),
+      desc=_('Subscribe to updates and keep current with Mozilla news. It’s the perfect way for us to keep in touch!'),
       newsletters='mozilla-foundation') }}
   </div>
 </main>

--- a/bedrock/newsletter/templatetags/helpers.py
+++ b/bedrock/newsletter/templatetags/helpers.py
@@ -18,7 +18,7 @@ log = logging.getLogger(__name__)
 @library.global_function
 @jinja2.contextfunction
 def email_newsletter_form(ctx, newsletters='mozilla-and-you', title=None,
-                          subtitle=None, include_country=True,
+                          subtitle=None, desc=None, include_country=True,
                           include_language=True, details=None,
                           use_thankyou=True, thankyou_head=None,
                           thankyou_content=None, footer=True,
@@ -41,6 +41,7 @@ def email_newsletter_form(ctx, newsletters='mozilla-and-you', title=None,
         id=newsletters,
         title=title,
         subtitle=subtitle,  # nested in/depends on include_title
+        desc=desc,  # nested in/depends on include_title
         include_country=include_country,
         include_language=include_language,
         details=details,

--- a/media/css/protocol/protocol.scss
+++ b/media/css/protocol/protocol.scss
@@ -21,3 +21,13 @@ $image-path: '/media/protocol/img';
         margin: $layout-xs auto 0;
     }
 }
+
+// Temporary styling until the newsletter component is updated in Protocol
+// https://github.com/mozilla/protocol/issues/578
+.mzp-c-newsletter-subtitle {
+    @include text-title-xs;
+}
+
+.mzp-c-newsletter-desc {
+    @include text-body-md;
+}


### PR DESCRIPTION
## Description
The new contribute page introduces a secondary title to the newsletter form, and on reviewing that I realize that what we've called a "subtitle" in the form macro isn't really a title. It's a `p` element and is used as more of a description and has the class `mzp-c-newsletter-tagline`, so the element class doesn't even match what we're calling it in the macro. This renames that element as "desc" and adds a new `h4` as "subtitle".

I filed https://github.com/mozilla/protocol/issues/578 to update the component upstream in Protocol but this implements it first in bedrock to unblock the new contribute page. And I made it a separate PR to simplify code review since this ends up touching a bunch of pages.

## Issue / Bugzilla link
N/A

## Testing
Did I miss any forms?
