### PR TITLE
Add functional tests for releasenotes pages (Fixes #7388)

### DIFF
--- a/bedrock/firefox/templates/firefox/releases/aurora-notes.html
+++ b/bedrock/firefox/templates/firefox/releases/aurora-notes.html
@@ -7,16 +7,22 @@
 {% if release.product == 'Firefox for Android' %}
   {% set page_id = 'data-gtm-page-id="/firefox/android/auroranotes/"' %}
   {% set product_class = 'mzp-t-dark mzp-t-product-nightly' %}
-  {% set download_button %}
-    {{ download_firefox('nightly', platform='android', alt_copy=_('Download Firefox for Android Nightly')) }}
+  {% set download_button_primary %}
+    {{ download_firefox('nightly', platform='android', alt_copy=_('Download Firefox for Android Nightly'), dom_id="download-android-nightly-primary") }}
+  {% endset %}
+  {% set download_button_secondary %}
+    {{ download_firefox('nightly', platform='android', alt_copy=_('Download Firefox for Android Nightly'), dom_id="download-android-nightly-secondary") }}
   {% endset %}
   {% set download_all_link = firefox_url('android', 'all', channel='nightly') %}
 {% elif release.product == 'Firefox' %}
   {% set page_id = 'data-gtm-page-id="/firefox/auroranotes/"' %}
   {% set product_class = 'mzp-t-dark mzp-t-product-developer t-aurora' %}
   {% set download_title = _('Build, test, scale and more with the only browser built just for developers.') %}
-  {% set download_button %}
-    {{ download_firefox('alpha', platform='desktop', force_direct=True, alt_copy=_('Download Firefox Developer Edition')) }}
+  {% set download_button_primary %}
+    {{ download_firefox('alpha', platform='desktop', force_direct=True, alt_copy=_('Download Firefox Developer Edition'), dom_id="download-dev-edition-primary") }}
+  {% endset %}
+  {% set download_button_secondary %}
+    {{ download_firefox('alpha', platform='desktop', force_direct=True, alt_copy=_('Download Firefox Developer Edition'), dom_id="download-dev-edition-secondary") }}
   {% endset %}
   {% set download_all_link = firefox_url('desktop', 'all', channel='alpha') %}
 {% endif %}

--- a/bedrock/firefox/templates/firefox/releases/beta-notes.html
+++ b/bedrock/firefox/templates/firefox/releases/beta-notes.html
@@ -8,14 +8,20 @@
 
 {% if release.product == 'Firefox for Android' %}
   {% set page_id = 'data-gtm-page-id="/firefox/android/beta/releasenotes"' %}
-  {% set download_button %}
-    {{ download_firefox('beta', platform='android', alt_copy=_('Download Firefox for Android Beta')) }}
+  {% set download_button_primary %}
+    {{ download_firefox('beta', platform='android', alt_copy=_('Download Firefox for Android Beta'), dom_id="download-android-beta-primary") }}
+  {% endset %}
+  {% set download_button_secondary %}
+    {{ download_firefox('beta', platform='android', alt_copy=_('Download Firefox for Android Beta'), dom_id="download-android-beta-secondary") }}
   {% endset %}
   {% set download_all_link = firefox_url('android', 'all', channel='beta') %}
 {% elif release.product == 'Firefox' %}
   {% set page_id = 'data-gtm-page-id="/firefox/beta/releasenotes/"' %}
-  {% set download_button %}
-    {{ download_firefox('beta', platform='desktop', force_direct=True, alt_copy=_('Download Firefox Beta')) }}
+  {% set download_button_primary %}
+    {{ download_firefox('beta', platform='desktop', force_direct=True, alt_copy=_('Download Firefox Beta'), dom_id="download-beta-primary") }}
+  {% endset %}
+  {% set download_button_secondary %}
+    {{ download_firefox('beta', platform='desktop', force_direct=True, alt_copy=_('Download Firefox Beta'), dom_id="download-beta-secondary") }}
   {% endset %}
   {% set download_all_link = firefox_url('desktop', 'all', channel='beta') %}
 {% endif %}

--- a/bedrock/firefox/templates/firefox/releases/dev-browser-notes.html
+++ b/bedrock/firefox/templates/firefox/releases/dev-browser-notes.html
@@ -7,8 +7,11 @@
 {% set page_id = 'data-gtm-page-id="/firefox/auroranotes/"' %}
 {% set product_name = 'Firefox Developer Edition' %}
 {% set product_class = 'mzp-t-dark mzp-t-product-developer' %}
-{% set download_button %}
- {{ download_firefox('alpha', platform='desktop', force_direct=True, alt_copy=_('Download Firefox Developer Edition')) }}
+{% set download_button_primary %}
+ {{ download_firefox('alpha', platform='desktop', force_direct=True, alt_copy=_('Download Firefox Developer Edition'), dom_id="download-dev-edition-primary") }}
+{% endset %}
+{% set download_button_secondary %}
+ {{ download_firefox('alpha', platform='desktop', force_direct=True, alt_copy=_('Download Firefox Developer Edition'), dom_id="download-dev-edition-secondary") }}
 {% endset %}
 
 {% set download_all_link = firefox_url('desktop', 'all', channel='alpha') %}

--- a/bedrock/firefox/templates/firefox/releases/esr-notes.html
+++ b/bedrock/firefox/templates/firefox/releases/esr-notes.html
@@ -6,8 +6,11 @@
 
 {% set page_id ='data-gtm-page-id="/firefox/esr/releasenotes/"' %}
 
-{% set download_button %}
-  {{ download_firefox('esr', platform='desktop', force_direct=True, alt_copy=_('Download Firefox ESR')) }}
+{% set download_button_primary %}
+  {{ download_firefox('esr', platform='desktop', force_direct=True, alt_copy=_('Download Firefox ESR'), dom_id="download-esr-primary") }}
+{% endset %}
+{% set download_button_secondary %}
+  {{ download_firefox('esr', platform='desktop', force_direct=True, alt_copy=_('Download Firefox ESR'), dom_id="download-esr-secondary") }}
 {% endset %}
 
 {% set download_all_link = firefox_url('desktop', 'all', channel='organizations') %}

--- a/bedrock/firefox/templates/firefox/releases/nightly-notes.html
+++ b/bedrock/firefox/templates/firefox/releases/nightly-notes.html
@@ -24,8 +24,12 @@
   {% set primary_heading = _('See what landed recently in <span>Firefox Nightly</span>!') %}
 {% endif %}
 
-{% set download_button %}
-  {{ download_firefox('nightly', platform='desktop', force_direct=True, alt_copy=_('Download Firefox Nightly')) }}
+{% set download_button_primary %}
+  {{ download_firefox('nightly', platform='desktop', force_direct=True, alt_copy=_('Download Firefox Nightly'), dom_id="download-nightly-primary") }}
+{% endset %}
+
+{% set download_button_secondary %}
+  {{ download_firefox('nightly', platform='desktop', force_direct=True, alt_copy=_('Download Firefox Nightly'), dom_id="download-nightly-secondary") }}
 {% endset %}
 
 {% set download_all_link = firefox_url('desktop', 'all', channel='nightly') %}

--- a/bedrock/firefox/templates/firefox/releases/notes.html
+++ b/bedrock/firefox/templates/firefox/releases/notes.html
@@ -80,10 +80,10 @@
             class='mzp-t-firefox ' + product_class,
             include_cta=True,
           ) %}
-            {% if download_button %}
+            {% if download_button_primary %}
               <div class="c-download-cta">
               {% block top_download_buttons %}
-                {{ download_button }}
+                {{ download_button_primary }}
               {% endblock %}
               </div>
             {% endif %}
@@ -343,7 +343,7 @@
       title=download_title,
       class='mzp-t-firefox ' + product_class
     ) %}
-      {{ download_button }}
+      {{ download_button_secondary }}
     {% endcall %}
 
     {% if download_all_link %}

--- a/bedrock/firefox/templates/firefox/releases/release-notes.html
+++ b/bedrock/firefox/templates/firefox/releases/release-notes.html
@@ -8,23 +8,34 @@
 {% if release.product == 'Firefox for iOS' %}
   {% set page_id = 'data-gtm-page-id="/firefox/ios/releasenotes/"' %}
   {% set product_name = release.product %}
-  {% set download_button %}
-    <a rel="external" href="{{ firefox_ios_url('mozorg-releasenotes_page-appstore-button') }}" data-link-type="download" data-download-os="iOS">
+  {% set download_button_primary %}
+    <a id="download-ios-primary" rel="external" href="{{ firefox_ios_url('mozorg-releasenotes_page-appstore-button') }}" data-link-type="download" data-download-os="iOS">
+      <img src="{{ l10n_img('firefox/ios/btn-app-store.svg') }}" alt="{{ ftl('download-button-download-app-store') }}">
+    </a>
+  {% endset %}
+  {% set download_button_secondary %}
+    <a id="download-ios-secondary" rel="external" href="{{ firefox_ios_url('mozorg-releasenotes_page-appstore-button') }}" data-link-type="download" data-download-os="iOS">
       <img src="{{ l10n_img('firefox/ios/btn-app-store.svg') }}" alt="{{ ftl('download-button-download-app-store') }}">
     </a>
   {% endset %}
 {% elif release.product == 'Firefox for Android' %}
   {% set page_id = 'data-gtm-page-id="/firefox/android/releasenotes/"' %}
   {% set product_name = 'Firefox for Android' %}
-  {% set download_button %}
-    {{ google_play_button() }}
+  {% set download_button_primary %}
+    {{ google_play_button(id='download-android-primary') }}
+  {% endset %}
+  {% set download_button_secondary %}
+    {{ google_play_button(id='download-android-secondary') }}
   {% endset %}
   {% set download_all_link = firefox_url('android', 'all', channel=channel_name|lower()) %}
 {% elif release.product == 'Firefox' %}
   {% set product_name = 'Firefox' %}
   {% set primary_heading =  _('See what’s new in Firefox!') if release.is_latest else _('Firefox Release Notes') %}
-  {% set download_button %}
-    {{ download_firefox() }}
+  {% set download_button_primary %}
+    {{ download_firefox(dom_id='download-release-primary') }}
+  {% endset %}
+  {% set download_button_secondary %}
+    {{ download_firefox(dom_id='download-release-secondary') }}
   {% endset %}
   {% set download_all_link = firefox_url('desktop', 'all', channel='release') %}
 {% endif %}

--- a/tests/functional/firefox/test_releasenotes.py
+++ b/tests/functional/firefox/test_releasenotes.py
@@ -1,0 +1,144 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import pytest
+
+from pages.firefox.releasenotes import FirefoxReleaseNotesPage
+
+
+@pytest.mark.skip_if_firefox(reason='Download button is displayed only to non-Firefox users')
+@pytest.mark.nondestructive
+def test_primary_download_button_release_displayed(base_url, selenium):
+    page = FirefoxReleaseNotesPage(selenium, base_url, slug='75.0').open()
+    assert page.primary_download_button_release.is_displayed
+
+
+@pytest.mark.skip_if_firefox(reason='Download button is displayed only to non-Firefox users')
+@pytest.mark.nondestructive
+def test_primary_download_button_beta_displayed(base_url, selenium):
+    page = FirefoxReleaseNotesPage(selenium, base_url, slug='77.0beta').open()
+    assert page.primary_download_button_beta.is_displayed
+
+
+@pytest.mark.skip_if_firefox(reason='Download button is displayed only to non-Firefox users')
+@pytest.mark.nondestructive
+def test_primary_download_button_aurora_displayed(base_url, selenium):
+    page = FirefoxReleaseNotesPage(selenium, base_url, slug='34.0a2').open()
+    assert page.primary_download_button_aurora.is_displayed
+
+
+@pytest.mark.skip_if_firefox(reason='Download button is displayed only to non-Firefox users')
+@pytest.mark.nondestructive
+def test_primary_download_button_dev_edition_displayed(base_url, selenium):
+    page = FirefoxReleaseNotesPage(selenium, base_url, slug='54.0a2').open()
+    assert page.primary_download_button_dev_edition.is_displayed
+
+
+@pytest.mark.skip_if_firefox(reason='Download button is displayed only to non-Firefox users')
+@pytest.mark.nondestructive
+def test_primary_download_button_nightly_displayed(base_url, selenium):
+    page = FirefoxReleaseNotesPage(selenium, base_url, slug='68.8.0').open()
+    assert page.primary_download_button_esr.is_displayed
+
+
+@pytest.mark.skip_if_firefox(reason='Download button is displayed only to non-Firefox users')
+@pytest.mark.nondestructive
+def test_primary_download_button_esr_displayed(base_url, selenium):
+    page = FirefoxReleaseNotesPage(selenium, base_url, slug='78.0a1').open()
+    assert page.primary_download_button_nightly.is_displayed
+
+
+@pytest.mark.skip_if_firefox(reason='Play Store button is displayed only to non-Firefox users')
+@pytest.mark.nondestructive
+def test_primary_download_button_android_displayed(base_url, selenium):
+    page = FirefoxReleaseNotesPage(selenium, base_url, slug='android/68.8.0').open()
+    assert page.is_primary_play_store_button_displayed
+
+
+@pytest.mark.skip_if_firefox(reason='Play Store button is displayed only to non-Firefox users')
+@pytest.mark.nondestructive
+def test_primary_download_button_android_beta_displayed(base_url, selenium):
+    page = FirefoxReleaseNotesPage(selenium, base_url, slug='android/68.7beta').open()
+    assert page.primary_download_button_android_beta.is_displayed
+
+
+@pytest.mark.skip_if_firefox(reason='Download button is displayed only to non-Firefox users')
+@pytest.mark.nondestructive
+def test_primary_download_button_android_nightly_displayed(base_url, selenium):
+    page = FirefoxReleaseNotesPage(selenium, base_url, slug='android/54.0a2').open()
+    assert page.primary_download_button_android_nightly.is_displayed
+
+
+@pytest.mark.skip_if_firefox(reason='App Store button is displayed only to non-Firefox users')
+@pytest.mark.nondestructive
+def test_primary_download_button_ios_displayed(base_url, selenium):
+    page = FirefoxReleaseNotesPage(selenium, base_url, slug='ios/25.0').open()
+    assert page.is_primary_app_store_button_displayed
+
+
+@pytest.mark.nondestructive
+def test_secondary_download_button_release_displayed(base_url, selenium):
+    page = FirefoxReleaseNotesPage(selenium, base_url, slug='75.0').open()
+    assert page.secondary_download_button_release.is_displayed
+
+
+@pytest.mark.nondestructive
+def test_secondary_download_button_beta_displayed(base_url, selenium):
+    page = FirefoxReleaseNotesPage(selenium, base_url, slug='77.0beta').open()
+    assert page.secondary_download_button_beta.is_displayed
+
+
+@pytest.mark.nondestructive
+def test_secondary_download_button_aurora_displayed(base_url, selenium):
+    page = FirefoxReleaseNotesPage(selenium, base_url, slug='34.0a2').open()
+    assert page.secondary_download_button_aurora.is_displayed
+
+
+@pytest.mark.nondestructive
+def test_secondary_download_button_dev_edition_displayed(base_url, selenium):
+    page = FirefoxReleaseNotesPage(selenium, base_url, slug='54.0a2').open()
+    assert page.secondary_download_button_dev_edition.is_displayed
+
+
+@pytest.mark.nondestructive
+def test_secondary_download_button_nightly_displayed(base_url, selenium):
+    page = FirefoxReleaseNotesPage(selenium, base_url, slug='78.0a1').open()
+    assert page.secondary_download_button_nightly.is_displayed
+
+
+@pytest.mark.nondestructive
+def test_secondary_download_button_esr_displayed(base_url, selenium):
+    page = FirefoxReleaseNotesPage(selenium, base_url, slug='68.8.0').open()
+    assert page.secondary_download_button_esr.is_displayed
+
+
+@pytest.mark.nondestructive
+def test_secondary_download_button_android_displayed(base_url, selenium):
+    page = FirefoxReleaseNotesPage(selenium, base_url, slug='android/68.8.0').open()
+    assert page.is_secondary_play_store_button_displayed
+
+
+@pytest.mark.nondestructive
+def test_secondary_download_button_android_beta_displayed(base_url, selenium):
+    page = FirefoxReleaseNotesPage(selenium, base_url, slug='android/68.7beta').open()
+    assert page.secondary_download_button_android_beta.is_displayed
+
+
+@pytest.mark.nondestructive
+def test_secondary_download_button_android_nightly_displayed(base_url, selenium):
+    page = FirefoxReleaseNotesPage(selenium, base_url, slug='android/54.0a2').open()
+    assert page.secondary_download_button_android_nightly.is_displayed
+
+
+@pytest.mark.nondestructive
+def test_secondary_download_button_ios_displayed(base_url, selenium):
+    page = FirefoxReleaseNotesPage(selenium, base_url, slug='ios/25.0').open()
+    assert page.is_secondary_app_store_button_displayed
+
+
+@pytest.mark.nondestructive
+def test_open_pre_releases_menu(base_url, selenium):
+    page = FirefoxReleaseNotesPage(selenium, base_url, slug='75.0').open()
+    page.open_pre_releases_menu()
+    assert page.is_pre_releases_menu_displayed

--- a/tests/pages/firefox/releasenotes.py
+++ b/tests/pages/firefox/releasenotes.py
@@ -1,0 +1,140 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from selenium.webdriver.common.by import By
+
+from pages.base import BasePage
+from pages.regions.download_button import DownloadButton
+
+
+class FirefoxReleaseNotesPage(BasePage):
+
+    URL_TEMPLATE = '/{locale}/firefox/{slug}/releasenotes/'
+
+    _primary_download_button_release_locator = (By.ID, 'download-release-primary')
+    _secondary_download_button_release_locator = (By.ID, 'download-release-secondary')
+    _primary_download_button_beta_locator = (By.ID, 'download-beta-primary')
+    _secondary_download_button_beta_locator = (By.ID, 'download-beta-secondary')
+    _primary_download_button_aurora_locator = (By.ID, 'download-dev-edition-primary')
+    _secondary_download_button_aurora_locator = (By.ID, 'download-dev-edition-secondary')
+    _primary_download_button_dev_edition_locator = (By.ID, 'download-dev-edition-primary')
+    _secondary_download_button_dev_edition_locator = (By.ID, 'download-dev-edition-secondary')
+    _primary_download_button_nightly_locator = (By.ID, 'download-nightly-primary')
+    _secondary_download_button_nightly_locator = (By.ID, 'download-nightly-secondary')
+    _primary_download_button_esr_locator = (By.ID, 'download-esr-primary')
+    _secondary_download_button_esr_locator = (By.ID, 'download-esr-secondary')
+    _primary_download_button_android_beta_locator = (By.ID, 'download-android-beta-primary')
+    _secondary_download_button_android_beta_locator = (By.ID, 'download-android-beta-secondary')
+    _primary_download_button_android_nightly_locator = (By.ID, 'download-android-nightly-primary')
+    _secondary_download_button_android_nightly_locator = (By.ID, 'download-android-nightly-secondary')
+    _primary_play_store_button_locator = (By.ID, 'download-android-primary')
+    _secondary_play_store_button_locator = (By.ID, 'download-android-secondary')
+    _primary_app_store_button_locator = (By.ID, 'download-ios-primary')
+    _secondary_app_store_button_locator = (By.ID, 'download-ios-secondary')
+    _pre_releases_menu_link_locator = (By.CSS_SELECTOR, '#release-nav .mzp-c-menu-title[aria-controls="release-other"')
+    _pre_releases_menu_locator = (By.ID, 'release-other')
+
+    @property
+    def primary_download_button_release(self):
+        el = self.find_element(*self._primary_download_button_release_locator)
+        return DownloadButton(self, root=el)
+
+    @property
+    def secondary_download_button_release(self):
+        el = self.find_element(*self._secondary_download_button_release_locator)
+        return DownloadButton(self, root=el)
+
+    @property
+    def primary_download_button_beta(self):
+        el = self.find_element(*self._primary_download_button_beta_locator)
+        return DownloadButton(self, root=el)
+
+    @property
+    def secondary_download_button_beta(self):
+        el = self.find_element(*self._secondary_download_button_beta_locator)
+        return DownloadButton(self, root=el)
+
+    @property
+    def primary_download_button_aurora(self):
+        el = self.find_element(*self._primary_download_button_aurora_locator)
+        return DownloadButton(self, root=el)
+
+    @property
+    def secondary_download_button_aurora(self):
+        el = self.find_element(*self._secondary_download_button_aurora_locator)
+        return DownloadButton(self, root=el)
+
+    @property
+    def primary_download_button_dev_edition(self):
+        el = self.find_element(*self._primary_download_button_dev_edition_locator)
+        return DownloadButton(self, root=el)
+
+    @property
+    def secondary_download_button_dev_edition(self):
+        el = self.find_element(*self._secondary_download_button_dev_edition_locator)
+        return DownloadButton(self, root=el)
+
+    @property
+    def primary_download_button_nightly(self):
+        el = self.find_element(*self._primary_download_button_nightly_locator)
+        return DownloadButton(self, root=el)
+
+    @property
+    def secondary_download_button_nightly(self):
+        el = self.find_element(*self._secondary_download_button_nightly_locator)
+        return DownloadButton(self, root=el)
+
+    @property
+    def primary_download_button_esr(self):
+        el = self.find_element(*self._primary_download_button_esr_locator)
+        return DownloadButton(self, root=el)
+
+    @property
+    def secondary_download_button_esr(self):
+        el = self.find_element(*self._secondary_download_button_esr_locator)
+        return DownloadButton(self, root=el)
+
+    @property
+    def primary_download_button_android_beta(self):
+        el = self.find_element(*self._primary_download_button_android_beta_locator)
+        return DownloadButton(self, root=el)
+
+    @property
+    def secondary_download_button_android_beta(self):
+        el = self.find_element(*self._secondary_download_button_android_beta_locator)
+        return DownloadButton(self, root=el)
+
+    @property
+    def primary_download_button_android_nightly(self):
+        el = self.find_element(*self._primary_download_button_android_nightly_locator)
+        return DownloadButton(self, root=el)
+
+    @property
+    def secondary_download_button_android_nightly(self):
+        el = self.find_element(*self._secondary_download_button_android_nightly_locator)
+        return DownloadButton(self, root=el)
+
+    @property
+    def is_primary_play_store_button_displayed(self):
+        return self.is_element_displayed(*self._primary_play_store_button_locator)
+
+    @property
+    def is_secondary_play_store_button_displayed(self):
+        return self.is_element_displayed(*self._secondary_play_store_button_locator)
+
+    @property
+    def is_primary_app_store_button_displayed(self):
+        return self.is_element_displayed(*self._primary_app_store_button_locator)
+
+    @property
+    def is_secondary_app_store_button_displayed(self):
+        return self.is_element_displayed(*self._secondary_app_store_button_locator)
+
+    @property
+    def is_pre_releases_menu_displayed(self):
+        return self.is_element_displayed(*self._pre_releases_menu_locator)
+
+    def open_pre_releases_menu(self):
+        self.scroll_element_into_view(*self._pre_releases_menu_link_locator).click()
+        self.wait.until(lambda s: self.is_pre_releases_menu_displayed)


### PR DESCRIPTION
## Description
Adds functional tests for release notes pages.

## Issue / Bugzilla link
#7388

## Testing
Successful test run: https://gitlab.com/mozmeao/www-config/pipelines/143244492