### PR TITLE
Add firefox/mobile send-to-device experiment. (fixes #8899)

### DIFF
--- a/bedrock/firefox/templates/firefox/mobile/index.html
+++ b/bedrock/firefox/templates/firefox/mobile/index.html
@@ -22,6 +22,11 @@
 {% set android_url = firefox_adjust_url('android', 'mobile-page') %}
 {% set ios_url = firefox_adjust_url('ios', 'mobile-page') %}
 
+
+{% if variation == 'b' %}
+ {% set hero_class = 'v-b' %}
+{% endif %}
+
 {% block site_header %}
   {% with hide_nav_download_button=True %}
     {% include 'includes/protocol/navigation/menu-firefox/index.html' %}
@@ -30,7 +35,7 @@
 
 {% block content %}
   <main role="main">
-    <header class="mzp-c-hero mzp-t-firefox mzp-has-image t-hero-primary">
+    <header class="mzp-c-hero mzp-t-firefox mzp-has-image t-hero-primary {{ hero_class }}">
       <div class="mzp-l-content">
         <div class="mzp-c-hero-body">
           <h1 class="mzp-c-hero-title"><span class="c-wordmark t-firefox">Firefox Browser</span></h1>
@@ -41,11 +46,13 @@
           </div>
 
           <div class="mzp-c-hero-cta">
+          {% if variation != 'b' %}
             <div class="header-product-ctas hide-from-legacy-ie">
               <button type="button" class="mzp-c-button mzp-t-product js-mobile" id="get-firefox" data-cta-type="button" data-cta-text="Get Firefox Mobile" data-cta-position="primary">
                 {{ _('Get Firefox Mobile') }}
               </button>
             </div>
+            {% endif %}
             <div class="mobile-download-buttons-wrapper">
               <ul class="mobile-download-buttons firefox" id="mobile-download-buttons-firefox_1">
                 <li class="android">
@@ -60,6 +67,13 @@
             </div>
           </div>
         </div>
+        {% if variation == 'b' %}
+        <div class="c-inline-form">
+          <h3>{{ _('Get Firefox for mobile') }}</h3>
+          <p>{{ _('Send a download link to your phone. ') }}</p>
+          {{ send_to_device(include_title=False, message_set='fx-mobile-download-desktop', class='vertical') }}
+        </div>
+        {% endif %}
       </div>
     </header>
 
@@ -211,4 +225,10 @@
 
 {% block js %}
   {{ js_bundle('firefox-mobile') }}
+{% endblock %}
+
+{% block experiments %}
+  {% if switch('experiment-firefox-mobile', ['en-US']) %}
+    {{ js_bundle('firefox-mobile-s2d-experiment') }}
+  {% endif %}
 {% endblock %}

--- a/bedrock/firefox/urls.py
+++ b/bedrock/firefox/urls.py
@@ -9,6 +9,8 @@ from bedrock.releasenotes import version_re
 
 from bedrock.firefox import views
 
+from bedrock.utils.views import VariationTemplateView
+
 latest_re = r'^firefox(?:/(?P<version>%s))?/%s/$'
 firstrun_re = latest_re % (version_re, 'firstrun')
 whatsnew_re = latest_re % (version_re, 'whatsnew')
@@ -61,7 +63,11 @@ urlpatterns = (
         views.FeaturesPrivateBrowsingView.as_view(),
         name='firefox.features.private-browsing'),
     url(r'^firefox/ios/testflight/$', views.ios_testflight, name='firefox.ios.testflight'),
-    page('firefox/mobile', 'firefox/mobile/index.html'),
+
+    url('^firefox/mobile/$', VariationTemplateView.as_view(template_name='firefox/mobile/index.html',
+        template_context_variations=['a', 'b']),
+        name='firefox.mobile.index'),
+
     page('firefox/mobile/get-app', 'firefox/mobile/get-app.html'),
     url('^firefox/send-to-device-post/$', views.send_to_device_ajax,
         name='firefox.send-to-device-post'),

--- a/media/css/firefox/mobile/mobile.scss
+++ b/media/css/firefox/mobile/mobile.scss
@@ -11,6 +11,44 @@ $image-path: '/media/protocol/img';
 @import '../../../protocol/css/components/call-out';
 @import '../../../protocol/css/components/modal';
 
+//* -------------------------------------------------------------------------- */
+//  Inline form variation
+
+.c-inline-form {
+    background: $color-white;
+    border-radius: $border-radius-md;
+    box-shadow: $box-shadow-md;
+    margin: 0 auto $spacing-xl;
+    max-width: 330px;
+    padding: $spacing-lg $spacing-2xl;
+    text-align: center;
+
+    .form-input-label {
+        text-align: left;
+    }
+
+    .legal {
+        @include text-body-xs;
+    }
+
+    h3 {
+        @include text-title-sm;
+        margin-bottom: $spacing-lg;
+    }
+
+    p {
+        @include text-body-lg;
+    }
+
+    @media #{$mq-lg} {
+        @include bidi(((float, right, left),));
+
+        @supports (display: grid) {
+            float: none;
+        }
+    }
+}
+
 
 //* -------------------------------------------------------------------------- */
 
@@ -147,6 +185,39 @@ main .mzp-l-content {
         &.mzp-t-firefox::after {
             display: none;
         }
+
+        &.v-b {
+            .mzp-c-hero-body {
+                margin: 0 auto $spacing-2xl;
+                width: 100%;
+
+                .mzp-c-hero-cta {
+                    float: none;
+                }
+            }
+
+            @media #{$mq-lg} {
+                .mzp-c-hero-body {
+                    @include grid-half;
+                    @include bidi(((float, left, right),));
+                    margin: unset;
+                }
+
+                @supports (display: grid) {
+                    & > .mzp-l-content {
+                        display: grid;
+                        grid-template-columns: repeat(2, 1fr);
+                        grid-column-gap: $spacing-2xl;
+                    }
+
+                    .mzp-c-hero-body {
+                        float: none;
+                        width: auto;
+                        margin-right: auto;
+                    }
+                }
+            }
+        }
     }
 
     .mzp-c-hero-desc {
@@ -174,6 +245,13 @@ main .mzp-l-content {
             html[dir="rtl"] &{
                 background-position: top right calc(50vw + #{$spacing-md}), top right calc(50vw + #{$spacing-md});
                 text-align: right;
+            }
+
+            &.v-b {
+                @include background-size(1200px 275px);
+                background-image: url('/media/img/firefox/mobile/img-mobile-noodles.svg');
+                background-position: top left calc(50vw + #{$spacing-md});
+                padding: 0;
             }
         }
 
@@ -481,7 +559,6 @@ main .mzp-l-content {
 
 #send-to-device {
     margin: 0 auto;
-    text-align: center;
 
     footer {
         display: none;

--- a/media/js/firefox/mobile/experiment-mobile.js
+++ b/media/js/firefox/mobile/experiment-mobile.js
@@ -1,0 +1,43 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+(function (Mozilla) {
+    'use strict';
+
+    /* update dataLayer with experiment info */
+    var href = window.location.href;
+    var platform = window.site.platform;
+    var isMobile = /^(android|ios|fxos)$/.test(platform);
+
+    var initTrafficCop = function () {
+        if (href.indexOf('v=') !== -1) {
+            if (href.indexOf('v=a') !== -1) {
+                window.dataLayer.push({
+                    'data-ex-variant': 'firefox-mobile-send-to-device-control',
+                    'data-ex-name': 'CRO-Firefox-Mobile-Send-to-Device-Experiment'
+                });
+            } else if (href.indexOf('v=b') !== -1) {
+                window.dataLayer.push({
+                    'data-ex-variant': 'firefox-mobile-send-to-device-v1',
+                    'data-ex-name': 'CRO-Firefox-Mobile-Send-to-Device-Experiment'
+                });
+            }
+        } else {
+            var cop = new Mozilla.TrafficCop({
+                id: 'experiment_firefox_mobile',
+                variations: {
+                    'v=a': 23,
+                    'v=b': 23
+                }
+            });
+
+            cop.init();
+        }
+    };
+
+    if (!isMobile) {
+        initTrafficCop();
+    }
+
+})(window.Mozilla);

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -1029,6 +1029,13 @@
     },
     {
       "files": [
+        "js/libs/mozilla-traffic-cop.js",
+        "js/firefox/mobile/experiment-mobile.js"
+      ],
+      "name": "firefox-mobile-s2d-experiment"
+    },
+    {
+      "files": [
         "protocol/js/protocol-modal.js",
         "js/libs/spin.min.js",
         "js/base/send-to-device.js",

--- a/tests/functional/firefox/test_mobile.py
+++ b/tests/functional/firefox/test_mobile.py
@@ -10,6 +10,7 @@ from pages.firefox.mobile import FirefoxMobilePage
 
 # mobile - send to device
 @pytest.mark.nondestructive
+@pytest.mark.skip(reason="temporary skip for A/B test")
 def test_get_firefox_send_to_device_success(base_url, selenium):
     page = FirefoxMobilePage(selenium, base_url).open()
     modal = page.click_get_firefox_button()
@@ -22,6 +23,7 @@ def test_get_firefox_send_to_device_success(base_url, selenium):
 
 
 @pytest.mark.nondestructive
+@pytest.mark.skip(reason="temporary skip for A/B test")
 def test_get_firefox_send_to_device_fails_when_missing_required_fields(base_url, selenium):
     page = FirefoxMobilePage(selenium, base_url).open()
     modal = page.click_get_firefox_button()
@@ -31,6 +33,7 @@ def test_get_firefox_send_to_device_fails_when_missing_required_fields(base_url,
 
 # mobile - qr code
 @pytest.mark.nondestructive
+@pytest.mark.skip(reason="temporary skip for A/B test")
 def test_get_firefox_qr_code(base_url, selenium):
     page = FirefoxMobilePage(selenium, base_url, locale='sv-SE').open()
     modal = page.click_get_firefox_button()


### PR DESCRIPTION
## Description
Adds variant view on firefox/mobile & traffic cop JS for an experiment to test the performance of the send to device widget inside & outside modal.

(See issue for test plan & CRO team card)

## Issue / Bugzilla link
#8899
