### PR TITLE
fix bug #8867 added indexes to duplicate IDs

### DIFF
--- a/bedrock/exp/templates/exp/firefox/mobile.html
+++ b/bedrock/exp/templates/exp/firefox/mobile.html
@@ -50,7 +50,7 @@
               </button>
             </div>
             <div class="mobile-download-buttons-wrapper">
-              <ul class="mobile-download-buttons firefox" id="mobile-download-buttons-firefox">
+              <ul class="mobile-download-buttons firefox" id="mobile-download-buttons-firefox_1">
                 <li class="android">
                   {{ google_play_button(href=android_url, id='playStoreLink') }}
                 </li>
@@ -140,7 +140,7 @@
               </button>
             </div>
             <div class="mobile-download-buttons-wrapper">
-              <ul class="mobile-download-buttons firefox" id="mobile-download-buttons-firefox">
+              <ul class="mobile-download-buttons firefox" id="mobile-download-buttons-firefox_2">
                 <li class="android">
                   {{ google_play_button(href=android_url, id='playStoreLink') }}
                 </li>
@@ -185,7 +185,7 @@
       </div>
 
       <div class="mobile-download-buttons-wrapper">
-        <ul class="mobile-download-buttons firefox" id="mobile-download-buttons-firefox">
+        <ul class="mobile-download-buttons firefox" id="mobile-download-buttons-firefox_3">
           <li class="android">
             {{ google_play_button(href=android_url, id='playStoreLink') }}
           </li>

--- a/bedrock/firefox/templates/firefox/mobile/index.html
+++ b/bedrock/firefox/templates/firefox/mobile/index.html
@@ -47,7 +47,7 @@
               </button>
             </div>
             <div class="mobile-download-buttons-wrapper">
-              <ul class="mobile-download-buttons firefox" id="mobile-download-buttons-firefox">
+              <ul class="mobile-download-buttons firefox" id="mobile-download-buttons-firefox_1">
                 <li class="android">
                   {{ google_play_button(href=android_url, id='playStoreLink') }}
                 </li>
@@ -137,7 +137,7 @@
               </button>
             </div>
             <div class="mobile-download-buttons-wrapper">
-              <ul class="mobile-download-buttons firefox" id="mobile-download-buttons-firefox">
+              <ul class="mobile-download-buttons firefox" id="mobile-download-buttons-firefox_2">
                 <li class="android">
                   {{ google_play_button(href=android_url, id='playStoreLink') }}
                 </li>
@@ -182,7 +182,7 @@
       </div>
 
       <div class="mobile-download-buttons-wrapper">
-        <ul class="mobile-download-buttons firefox" id="mobile-download-buttons-firefox">
+        <ul class="mobile-download-buttons firefox" id="mobile-download-buttons-firefox_3">
           <li class="android">
             {{ google_play_button(href=android_url, id='playStoreLink') }}
           </li>


### PR DESCRIPTION
## Description
As mentioned by @alexgibson there were duplicate IDs on the webpages /en-US/firefox/mobile/ and en-US/exp/firefox/mobile/  to avoid future errors related to this bug I added indexes to the IDs, making them unique. The IDs were not declared in any static files.

## Issue / Bugzilla link
#8867 

## Testing
