### PR TITLE
Random dot on chrome #8501

### DIFF
--- a/bedrock/base/templates/macros-protocol.html
+++ b/bedrock/base/templates/macros-protocol.html
@@ -197,7 +197,7 @@
 
 
 {# Picto Card: https://protocol.mozilla.org/patterns/molecules/picto-card.html #}
-{% macro picto_card(title=None, desc=None, class=None, heading_level=2, base_el='li', custom_desc=False) -%}
+{% macro picto_card(title=None, desc=None, class=None, heading_level=2, base_el='div', custom_desc=False) -%}
 <{{ base_el }} class="mzp-c-card-picto {% if class %}{{ class }}{% endif %}">
   <div class="mzp-c-card-picto-content">
     {% if title %}<h{{ heading_level }} class="mzp-c-card-picto-title">{{ title }}</h{{ heading_level }}>{% endif %}

--- a/bedrock/exp/templates/exp/firefox/mobile.html
+++ b/bedrock/exp/templates/exp/firefox/mobile.html
@@ -50,7 +50,7 @@
               </button>
             </div>
             <div class="mobile-download-buttons-wrapper">
-              <ul class="mobile-download-buttons firefox" id="mobile-download-buttons-firefox">
+              <ul class="mobile-download-buttons firefox" id="mobile-download-buttons-firefox_1">
                 <li class="android">
                   {{ google_play_button(href=android_url, id='playStoreLink') }}
                 </li>
@@ -140,7 +140,7 @@
               </button>
             </div>
             <div class="mobile-download-buttons-wrapper">
-              <ul class="mobile-download-buttons firefox" id="mobile-download-buttons-firefox">
+              <ul class="mobile-download-buttons firefox" id="mobile-download-buttons-firefox_2">
                 <li class="android">
                   {{ google_play_button(href=android_url, id='playStoreLink') }}
                 </li>
@@ -185,7 +185,7 @@
       </div>
 
       <div class="mobile-download-buttons-wrapper">
-        <ul class="mobile-download-buttons firefox" id="mobile-download-buttons-firefox">
+        <ul class="mobile-download-buttons firefox" id="mobile-download-buttons-firefox_3">
           <li class="android">
             {{ google_play_button(href=android_url, id='playStoreLink') }}
           </li>

--- a/bedrock/firefox/templates/firefox/mobile/index.html
+++ b/bedrock/firefox/templates/firefox/mobile/index.html
@@ -47,7 +47,7 @@
               </button>
             </div>
             <div class="mobile-download-buttons-wrapper">
-              <ul class="mobile-download-buttons firefox" id="mobile-download-buttons-firefox">
+              <ul class="mobile-download-buttons firefox" id="mobile-download-buttons-firefox_1">
                 <li class="android">
                   {{ google_play_button(href=android_url, id='playStoreLink') }}
                 </li>
@@ -137,7 +137,7 @@
               </button>
             </div>
             <div class="mobile-download-buttons-wrapper">
-              <ul class="mobile-download-buttons firefox" id="mobile-download-buttons-firefox">
+              <ul class="mobile-download-buttons firefox" id="mobile-download-buttons-firefox_2">
                 <li class="android">
                   {{ google_play_button(href=android_url, id='playStoreLink') }}
                 </li>
@@ -182,7 +182,7 @@
       </div>
 
       <div class="mobile-download-buttons-wrapper">
-        <ul class="mobile-download-buttons firefox" id="mobile-download-buttons-firefox">
+        <ul class="mobile-download-buttons firefox" id="mobile-download-buttons-firefox_3">
           <li class="android">
             {{ google_play_button(href=android_url, id='playStoreLink') }}
           </li>


### PR DESCRIPTION
## Description
Random dot due to the macro making _**li**_ elements. Instead changed the _li_ to _div_ as mentioned by @craigcook for better semantics.

## Issue / Bugzilla link
#8501 

## Testing
