### PR TITLE
Typo on FR homepage (Fix #8912)

### DIFF
--- a/bedrock/mozorg/templates/mozorg/home/home-fr.html
+++ b/bedrock/mozorg/templates/mozorg/home/home-fr.html
@@ -61,7 +61,7 @@ Le saviez-vous ? Mozilla, le concepteur de Firefox, se bat pour qu’Internet, u
         title=_('Technologies web open source :'),
         ga_title='Technologies web open source',
         desc=_('Réalité virtuelle, IoT et plus encore.'),
-        link_cta=_('Découvrez le web du futur'),
+        link_cta=_('Découvrez le Web du futur'),
         link_url='https://labs.mozilla.org/',
         image_url='img/home/2018/billboard-open-minds.png',
         include_highres_image=True,


### PR DESCRIPTION
## Description

Fix typo on French homepage.

## Issue / Bugzilla link

Fix #8912 

## Testing

http://localhost:8000/fr/