### PR TITLE
Use the UITour for the FxA flow

### DIFF
--- a/docs/firefox-accounts.rst
+++ b/docs/firefox-accounts.rst
@@ -37,6 +37,20 @@ predictability in retroactive analysis.
     <https://mozilla.github.io/application-services/docs/accounts/metrics.html#descriptions-of-metrics-related-query-parameters>`_
     rules applied by the Firefox Accounts server.
 
+UITour Flow
+-----------
+
+Since Firefox 80 the FxA links and email forms use the UITour to show the Firefox Accounts page and log the browser
+into Sync or an Account. For non-Firefox browsers or if the UITour is not available the flow uses normal links that
+allow users to log into FxA as a website only without connecting the Firefox Desktop client.
+This UITour flow allows the Firefox browser to determine the correct FxA server and authentication flow.
+This transition was introduced to later migrate Firefox Desktop to an OAuth based client authentication flow.
+
+The current code automatically detects if you are in the supported browser for this flow and updates links and forms
+to drive them through the UITour API. The UITour ``showFirefoxAccounts`` action supports flow id parameters,
+UTM parameters and the email data field.
+
+We hope to remove the legacy non-UITour login logic after 1 or 2 ESRs.
 
 Signup Form
 -----------

--- a/docs/uitour.rst
+++ b/docs/uitour.rst
@@ -48,6 +48,13 @@ Note that ``browser.uitour.testingOrigins`` can be a comma separated list of dom
     must also exclude the domain protocol e.g. ``https://``. A browser restart is also required
     after adding an allowed domain.
 
+    If you are working on Firefox Accounts integration, you can use the ``identity.fxaccounts.autoconfig.uri``
+    config property to change the Accounts server. For example, to change it to stage environment use this value:
+    ``https://accounts.stage.mozaws.net/``. Restart the browser and make sure the configuration updated.
+    ``identity.fxaccounts.remote.root`` preference should now point to ``https://accounts.stage.mozaws.net``.
+    If it has not changed for some reason, update it manually.
+    Ref: https://mozilla-services.readthedocs.io/en/latest/howtos/run-fxa.html
+
 JavaScript API
 --------------
 

--- a/media/js/base/fxa-utm-referral.js
+++ b/media/js/base/fxa-utm-referral.js
@@ -14,9 +14,12 @@ if (typeof window.Mozilla === 'undefined') {
 
     var allowedList = [
         'https://accounts.firefox.com/',
+        'https://accounts.firefox.com.cn/',
+        'https://accounts.stage.mozaws.net/',
         'https://monitor.firefox.com/',
         'https://getpocket.com/',
-        'https://latest.dev.lcip.org/'
+        'https://latest.dev.lcip.org/',
+        'https://stable.dev.lcip.org/'
     ];
 
     /**

--- a/media/js/base/mozilla-fxa-link.js
+++ b/media/js/base/mozilla-fxa-link.js
@@ -12,6 +12,13 @@ if (typeof window.Mozilla === 'undefined') {
 
     var FxaLink = {};
     var client = Mozilla.Client;
+    var allowedList = [
+        'https://accounts.firefox.com/',
+        'https://accounts.stage.mozaws.net/',
+        'https://latest.dev.lcip.org/',
+        'https://stable.dev.lcip.org/',
+        'https://accounts.firefox.com.cn/'
+    ];
 
     /**
      * Configures Sync for Firefox browsers.
@@ -35,14 +42,62 @@ if (typeof window.Mozilla === 'undefined') {
     };
 
     /**
+     * Returns the hostname for a given URL.
+     * @param {String} url.
+     * @returns {String} hostname.
+     */
+    FxaLink.getHostName = function(url) {
+        var matches = url.match(/^https?:\/\/(?:[^/?#]+)(?:[/?#]|$)/i);
+        return matches && matches[0];
+    };
+
+    /**
+     * Intercept event handler for FxA links and forms, lets the browser drive the FxA Flow using
+     * the `showFirefoxAccounts` UITour API. Attaches several UTM parameters from the current page
+     * that will be forwarded to the browser and later on to FxA services.
+     * @param event {Event}
+     * @private
+     */
+    FxaLink.interceptFxANavigation = function(event) {
+        event.preventDefault();
+        var search = new URL(event.target.href).search;
+        var urlParams = new window._SearchParams(search).params;
+        var extraURLParams = {};
+        var allowedChars = /^[\w/.%-]+$/;
+        var knownParams = ['flow_id', 'flow_begin_time', 'device_id',
+            'entrypoint', 'entrypoint_experiment', 'entrypoint_variation',
+            'utm_source', 'utm_campaign', 'utm_content', 'utm_term', 'utm_medium'];
+
+        for (var i = 0; i < knownParams.length; i++) {
+            var known = knownParams[i];
+            if (Object.prototype.hasOwnProperty.call(urlParams, known)) {
+                var param = decodeURIComponent(urlParams[known]);
+                if ((allowedChars).test(param)) {
+                    extraURLParams[known] = param;
+                }
+            }
+        }
+        var entrypoint = extraURLParams.entrypoint;
+        // 'entrypoint' is sent separately and should not be in the extras
+        delete extraURLParams.entrypoint;
+        return Mozilla.UITour.showFirefoxAccounts(extraURLParams, entrypoint);
+    };
+
+    /**
      * Updates FxA links with Sync params.
      * Only applicable for Firefox desktop user agents.
      */
-    FxaLink.init = function() {
+    FxaLink.init = function(callback) {
+        callback = callback || function noop() {
+            // do nothing
+        };
         if (!client._isFirefoxDesktop()) {
             return;
         }
 
+        var userVer = parseFloat(client._getFirefoxVersion());
+        var useUITourForFxA = userVer >= 80 && typeof Mozilla.UITour !== 'undefined';
+        var self = this;
         var fxaSigninLink = document.querySelectorAll('.js-fxa-cta-link');
 
         for (var i = 0; i < fxaSigninLink.length; i++) {
@@ -57,9 +112,32 @@ if (typeof window.Mozilla === 'undefined') {
                 link.setAttribute('data-mozillaonline-link', FxaLink.updateURL(mozillaOnlineLink));
             }
         }
+
+        if (useUITourForFxA) {
+            Mozilla.UITour.ping(function() {
+                for (var i = 0; i < fxaSigninLink.length; i++) {
+                    var link = fxaSigninLink[i];
+                    var hostName = FxaLink.getHostName(link.href);
+                    // check if link is in the FxA referral allowedList domains.
+                    if (hostName && allowedList.indexOf(hostName) === -1) {
+                        continue;
+                    }
+                    link.setAttribute('role', 'button');
+                    link.oncontextmenu = function(e) {
+                        e.preventDefault();
+                    };
+                    // intercept the flow and submit the form using the UITour API instead.
+                    // In the future we should fully migrate to this API for Firefox Desktop login.
+                    link.addEventListener('auxclick', self.interceptFxANavigation);
+                    link.addEventListener('click', self.interceptFxANavigation);
+                }
+                callback();
+            });
+        } else {
+            callback();
+        }
     };
 
     window.Mozilla.FxaLink = FxaLink;
 
 })();
-

--- a/media/js/base/mozilla-fxa-product-button.js
+++ b/media/js/base/mozilla-fxa-product-button.js
@@ -77,9 +77,9 @@ if (typeof window.Mozilla === 'undefined') {
             return resp.json();
         }).then(function(r) {
             // add retrieved deviceID, flowBeginTime and flowId values to cta url
-            var flowParams = '&deviceId=' + r.deviceId;
-            flowParams += '&flowBeginTime=' + r.flowBeginTime;
-            flowParams += '&flowId=' + r.flowId;
+            var flowParams = '&device_id=' + r.deviceId;
+            flowParams += '&flow_begin_time=' + r.flowBeginTime;
+            flowParams += '&flow_id=' + r.flowId;
             return flowParams;
         }).catch(function() {
             // silently fail: deviceId, flowBeginTime, flowId are not added to url.

--- a/media/js/base/uitour-lib.js
+++ b/media/js/base/uitour-lib.js
@@ -197,17 +197,22 @@ if (typeof window.Mozilla === 'undefined') {
     /**
     * Request the browser open the Firefox Accounts page.
     *
-    * @param {Object} extraURLParams - An object containing additional
+    * @param {Object} [extraURLParams] - An optional object containing additional
     * parameters for the URL opened by the browser for reasons of promotional
     * campaign tracking. Each attribute of the object must have a name that
-    * is a string, is "flow_id", "flow_begin_time", "device_id" or begins
-    * with `utm_` and contains only only alphanumeric characters, dashes or
-    * underscores. The values may be any string and will automatically be encoded.
+    * is a string, is "flow_id", "flow_begin_time", "device_id", "entrypoint_experiment",
+    * "entrypoint_variation" or begins with `utm_` and contains only only alphanumeric
+    * characters, dashes or underscores. The values may be any string and will automatically be encoded.
     * For Flow metrics, see details at https://mozilla.github.io/ecosystem-platform/docs/fxa-engineering/fxa-metrics#content-server
-    * @since 79 renamed from `extraURLCampaignParams` to `extraURLParams
-   */
-    Mozilla.UITour.showFirefoxAccounts = function(extraURLParams) {
+    * @since 79 renamed from `extraURLCampaignParams` to `extraURLParams`
+    * @param {String} [email] - the optional FxA email value.
+    * @param {String} [entrypoint] - the optional FxA entrypoint value. If not set, the browser will report `uitour`.
+    * @since 80 added the "entrypoint" option.
+    */
+    Mozilla.UITour.showFirefoxAccounts = function(extraURLParams, entrypoint, email) {
         _sendEvent('showFirefoxAccounts', {
+            email: email,
+            entrypoint: entrypoint,
             extraURLParams: JSON.stringify(extraURLParams)
         });
     };

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -810,7 +810,6 @@
     },
     {
       "files": [
-        "js/base/uitour-lib.js",
         "js/libs/spin.min.js",
         "protocol/js/protocol-modal.js",
         "js/base/send-to-device.js",
@@ -820,21 +819,18 @@
     },
     {
       "files": [
-        "js/base/uitour-lib.js",
         "js/firefox/welcome/welcome8.js"
       ],
       "name": "firefox_welcome_page8"
     },
     {
       "files": [
-        "js/base/uitour-lib.js",
         "js/firefox/privacy/messaging-experiment.js"
       ],
       "name": "default_privacy_messaging"
     },
     {
       "files": [
-        "js/base/uitour-lib.js",
         "js/base/mozilla-fxa.js",
         "js/base/mozilla-fxa-init.js",
         "js/base/mozilla-fxa-product-button.js",
@@ -846,7 +842,6 @@
     },
     {
       "files": [
-        "js/base/uitour-lib.js",
         "js/firefox/whatsnew/up-to-date.js",
         "js/base/mozilla-fxa-product-button.js",
         "js/base/mozilla-fxa-product-button-init.js"
@@ -855,7 +850,6 @@
     },
     {
       "files": [
-        "js/base/uitour-lib.js",
         "js/firefox/whatsnew/up-to-date.js",
         "js/libs/spin.min.js",
         "protocol/js/protocol-modal.js",
@@ -866,7 +860,6 @@
     },
     {
       "files": [
-        "js/base/uitour-lib.js",
         "js/firefox/whatsnew/up-to-date.js",
         "js/firefox/whatsnew/whatsnew-74.js"
       ],
@@ -874,7 +867,6 @@
     },
     {
       "files": [
-        "js/base/uitour-lib.js",
         "js/firefox/whatsnew/up-to-date.js",
         "js/base/mozilla-fxa-product-button.js",
         "js/base/mozilla-fxa-product-button-init.js",
@@ -884,7 +876,6 @@
     },
     {
       "files": [
-        "js/base/uitour-lib.js",
         "js/firefox/whatsnew/up-to-date.js",
         "js/firefox/whatsnew/whatsnew-76.js"
       ],
@@ -892,7 +883,6 @@
     },
     {
       "files": [
-        "js/base/uitour-lib.js",
         "js/firefox/whatsnew/up-to-date.js",
         "js/firefox/whatsnew/whatsnew-77.js"
       ],
@@ -900,7 +890,6 @@
     },
     {
       "files": [
-        "js/base/uitour-lib.js",
         "js/firefox/whatsnew/up-to-date.js",
         "js/base/mozilla-video-poster.js",
         "js/firefox/whatsnew/whatsnew-77-zhCN.js"
@@ -915,7 +904,6 @@
     },
     {
       "files": [
-        "js/base/uitour-lib.js",
         "js/firefox/lockwise/lockwise.js"
       ],
       "name": "lockwise"
@@ -935,7 +923,6 @@
     },
     {
       "files": [
-        "js/base/uitour-lib.js",
         "js/firefox/new/desktop/download.js"
       ],
       "name": "firefox_desktop_download"
@@ -1089,7 +1076,6 @@
     },
     {
       "files": [
-        "js/base/uitour-lib.js",
         "js/privacy/privacy-firefox.js"
       ],
       "name": "privacy_firefox"
@@ -1102,7 +1088,6 @@
     },
     {
       "files": [
-        "js/base/uitour-lib.js",
         "js/firefox/set-as-default/thanks.js"
       ],
       "name": "firefox-default-thanks"
@@ -1130,7 +1115,6 @@
         "js/base/mozilla-fxa-init.js",
         "js/base/mozilla-fxa-form.js",
         "js/base/mozilla-fxa-form-init.js",
-        "js/base/uitour-lib.js",
         "js/firefox/browsers-products.js"
       ],
       "name": "firefox-browsers-products"
@@ -1225,7 +1209,6 @@
     },
     {
       "files": [
-        "js/base/uitour-lib.js",
         "js/base/send-to-device.js",
         "js/libs/spin.min.js",
         "js/firefox/whatsnew/up-to-date.js",
@@ -1242,7 +1225,6 @@
     },
     {
       "files": [
-        "js/base/uitour-lib.js",
         "js/firefox/whatsnew/up-to-date.js",
         "js/base/mozilla-fxa-product-button.js",
         "js/base/mozilla-fxa-product-button-init.js"
@@ -1253,14 +1235,12 @@
       "files": [
         "js/base/send-to-device.js",
         "js/libs/spin.min.js",
-        "js/base/uitour-lib.js",
         "js/firefox/whatsnew/whatsnew-id.js"
       ],
       "name": "whatsnew_lite"
     },
     {
       "files": [
-        "js/base/uitour-lib.js",
         "js/base/mozilla-fxa-form.js",
         "js/base/mozilla-fxa-form-init.js",
         "js/firefox/privacy/products.js"
@@ -1306,6 +1286,7 @@
         "js/base/core-datalayer.js",
         "js/base/core-datalayer-init.js",
         "js/base/search-params.js",
+        "js/base/uitour-lib.js",
         "js/base/mozilla-fxa-link.js",
         "js/base/mozilla-fxa-link-init.js",
         "js/base/fxa-utm-referral.js",
@@ -1333,6 +1314,7 @@
         "js/base/core-datalayer.js",
         "js/base/core-datalayer-init.js",
         "js/base/search-params.js",
+        "js/base/uitour-lib.js",
         "js/base/mozilla-fxa-link.js",
         "js/base/mozilla-fxa-link-init.js",
         "js/base/fxa-utm-referral.js",
@@ -1359,6 +1341,7 @@
         "js/base/core-datalayer.js",
         "js/base/core-datalayer-init.js",
         "js/base/search-params.js",
+        "js/base/uitour-lib.js",
         "js/base/mozilla-fxa-link.js",
         "js/base/mozilla-fxa-link-init.js",
         "js/base/fxa-utm-referral.js",

--- a/tests/unit/spec/base/mozilla-fxa-product-button.js
+++ b/tests/unit/spec/base/mozilla-fxa-product-button.js
@@ -60,8 +60,8 @@ describe('mozilla-fxa-product-button.js', function() {
 
         return Mozilla.FxaProductButton.init().then(function() {
             var buttons = document.querySelectorAll('.js-fxa-product-button');
-            expect(buttons[0].href).toEqual('https://accounts.firefox.com/signup?form_type=button&entrypoint=mozilla.org-whatsnew60&utm_source=mozilla.org-whatsnew60&utm_medium=referral&utm_campaign=whatsnew60&context=fx_desktop_v3&deviceId=848377ff6e3e4fc982307a316f4ca3d6&flowBeginTime=1573052386673&flowId=75f9a48a0f66c2f5919a0989605d5fa5dd04625ea5a2ee59b2d5d54637c566d1');
-            expect(buttons[1].href).toEqual('https://getpocket.com/ff_signup?s=ffwelcome2&form_type=button&entrypoint=mozilla.org-firefox-welcome-2&utm_source=mozilla.org-firefox-welcome-2&utm_campaign=welcome-2-pocket&utm_medium=referral&deviceId=848377ff6e3e4fc982307a316f4ca3d6&flowBeginTime=1573052386673&flowId=75f9a48a0f66c2f5919a0989605d5fa5dd04625ea5a2ee59b2d5d54637c566d1');
+            expect(buttons[0].href).toEqual('https://accounts.firefox.com/signup?form_type=button&entrypoint=mozilla.org-whatsnew60&utm_source=mozilla.org-whatsnew60&utm_medium=referral&utm_campaign=whatsnew60&context=fx_desktop_v3&device_id=848377ff6e3e4fc982307a316f4ca3d6&flow_begin_time=1573052386673&flow_id=75f9a48a0f66c2f5919a0989605d5fa5dd04625ea5a2ee59b2d5d54637c566d1');
+            expect(buttons[1].href).toEqual('https://getpocket.com/ff_signup?s=ffwelcome2&form_type=button&entrypoint=mozilla.org-firefox-welcome-2&utm_source=mozilla.org-firefox-welcome-2&utm_campaign=welcome-2-pocket&utm_medium=referral&device_id=848377ff6e3e4fc982307a316f4ca3d6&flow_begin_time=1573052386673&flow_id=75f9a48a0f66c2f5919a0989605d5fa5dd04625ea5a2ee59b2d5d54637c566d1');
         });
     });
 
@@ -90,7 +90,7 @@ describe('mozilla-fxa-product-button.js', function() {
         return Mozilla.FxaProductButton.init().then(function() {
             var buttons = document.querySelectorAll('.js-fxa-product-button');
             expect(window.fetch).toHaveBeenCalledWith('https://accounts.firefox.com.cn/metrics-flow?form_type=button&entrypoint=mozilla.org-whatsnew60&utm_source=mozilla.org-whatsnew60&utm_campaign=whatsnew60');
-            expect(buttons[0].href).toEqual('https://accounts.firefox.com.cn/signup?form_type=button&entrypoint=mozilla.org-whatsnew60&utm_source=mozilla.org-whatsnew60&utm_medium=referral&utm_campaign=whatsnew60&context=fx_desktop_v3&deviceId=848377ff6e3e4fc982307a316f4ca3d6&flowBeginTime=1573052386673&flowId=75f9a48a0f66c2f5919a0989605d5fa5dd04625ea5a2ee59b2d5d54637c566d1');
+            expect(buttons[0].href).toEqual('https://accounts.firefox.com.cn/signup?form_type=button&entrypoint=mozilla.org-whatsnew60&utm_source=mozilla.org-whatsnew60&utm_medium=referral&utm_campaign=whatsnew60&context=fx_desktop_v3&device_id=848377ff6e3e4fc982307a316f4ca3d6&flow_begin_time=1573052386673&flow_id=75f9a48a0f66c2f5919a0989605d5fa5dd04625ea5a2ee59b2d5d54637c566d1');
             expect(buttons[1].href).toEqual('https://getpocket.com/ff_signup?s=ffwelcome2&form_type=button&entrypoint=mozilla.org-firefox-welcome-2&utm_source=mozilla.org-firefox-welcome-2&utm_campaign=welcome-2-pocket&utm_medium=referral');
         });
     });


### PR DESCRIPTION
Ref: https://bugzilla.mozilla.org/show_bug.cgi?id=1635219

@rfk @alexgibson this is a draft of the changes we could make to route all the FxA links and forms using the UITour. Alex, see the chart below, we are working on moving the login to OAuth and to be able to generate OAuth urls we would need to "Create the FxA url" in Desktop.

TODO

* [x] Figure out the /metrics flow params. Those might need changes in Desktop :(
* [x] Should we convert the links into `<buttons>` instead? Otherwise the "non-sync" link can be copy pasted and opened

![Bedrock UITour](https://user-images.githubusercontent.com/128755/81759942-11a02500-9494-11ea-8a14-abdc2e2724ad.png)
