### PR TITLE
Add communication promise string to Firefox newsletters (Fixes #7460)

### DIFF
--- a/bedrock/newsletter/templates/newsletter/includes/form-protocol.html
+++ b/bedrock/newsletter/templates/newsletter/includes/form-protocol.html
@@ -99,7 +99,14 @@
         {% if details %}
           <span class="mzp-c-fieldnote">{{ details }}</span>
         {% else %}
-          <span class="mzp-c-fieldnote">{{ ftl('newsletter-form-we-will-only-send') }}</span>
+            <span class="mzp-c-fieldnote">
+              {# Issue 7460 `mozilla-and-you` is the ID for the Firefox newsletter, because history... #}
+              {% if id == 'mozilla-and-you' %}
+                {{ ftl('newsletter-form-we-will-only-send-firefox', fallback='newsletter-form-we-will-only-send') }}
+              {% else %}
+                {{ ftl('newsletter-form-we-will-only-send') }}
+              {% endif %}
+            </span>
         {% endif %}
       </p>
     </fieldset>

--- a/bedrock/newsletter/templates/newsletter/includes/form.html
+++ b/bedrock/newsletter/templates/newsletter/includes/form.html
@@ -91,7 +91,14 @@
         </p>
       {% else %}
         <p class="form-details">
-          <small>{{ ftl('newsletter-form-we-will-only-send') }}</small>
+          <small>
+            {# Issue 7460 `mozilla-and-you` is the ID for the Firefox newsletter, because history... #}
+            {% if id == 'mozilla-and-you' %}
+              {{ ftl('newsletter-form-we-will-only-send-firefox', fallback='newsletter-form-we-will-only-send') }}
+            {% else %}
+              {{ ftl('newsletter-form-we-will-only-send') }}
+            {% endif %}
+          </small>
         </p>
       {% endif %}
 

--- a/l10n/en/newsletter_form.ftl
+++ b/l10n/en/newsletter_form.ftl
@@ -21,6 +21,7 @@ newsletter-form-get-firefox-news = Get { -brand-name-firefox } news
 newsletter-form-im-okay-with-mozilla = I’m okay with { -brand-name-mozilla } handling my info as explained in <a href="{ $url }">this Privacy Notice</a>
 
 newsletter-form-we-will-only-send = We will only send you { -brand-name-mozilla }-related information.
+newsletter-form-we-will-only-send-firefox = We will only send you { -brand-name-firefox }-related information.
 newsletter-form-if-you-havent-previously = If you haven’t previously confirmed a subscription to a { -brand-name-mozilla }-related newsletter, you may have to do so. Please check your inbox or your spam filter for an email from us.
 newsletter-form-firefox-and-you = <span>{ -brand-name-firefox }</span> + You
 newsletter-form-get-firefox-tips = Get { -brand-name-firefox } tips, tricks, news and more

--- a/media/css/firefox/channel.scss
+++ b/media/css/firefox/channel.scss
@@ -135,7 +135,7 @@ $image-path: '/media/protocol/img';
     }
 
     .mzp-c-fieldnote {
-        display: none;
+        margin-top: $spacing-xs;
     }
 
     .mzp-c-newsletter-thanks {


### PR DESCRIPTION
## Description
Adds "We will only send you Firefox-related information" string to Firefox related newsletters.

- https://www-demo2.allizom.org/en-US/firefox/channel/desktop/
- https://www-demo2.allizom.org/en-US/newsletter/firefox/

## Issue / Bugzilla link
#7460

## Testing
- [ ] Only Firefox related newsletters should contain the new string. Mozilla newsletters should contain the standard string.