### PR TITLE
Remove autofill from /switch page (Fixes #8651)

### DIFF
--- a/bedrock/firefox/templates/firefox/switch.html
+++ b/bedrock/firefox/templates/firefox/switch.html
@@ -7,7 +7,7 @@
 {% from "macros-protocol.html" import hero, picto_card with context %}
 
 {% block page_title %}{{ ftl('switch-switch-from-chrome') }}{% endblock %}
-{% block page_desc %}{{ ftl('switch-switching-to-firefox-is-fast') }}{% endblock %}
+{% block page_desc %}{{ ftl('switch-switching-to-firefox-is-fast-updated', fallback='switch-switching-to-firefox-is-fast') }}{% endblock %}
 
 {% block page_css %}
   {{ css_bundle('firefox-switch') }}
@@ -19,7 +19,7 @@
 <main>
   {% call hero(
     title=ftl('switch-switch-from-chrome'),
-    desc=ftl('switch-switching-to-firefox-page-description'),
+    desc=ftl('switch-switching-to-firefox-page-description-updated', 'switch-switching-to-firefox-page-description'),
     class='mzp-has-image mzp-t-product-firefox t-switch',
     include_cta=False,
     heading_level=1

--- a/bedrock/firefox/urls.py
+++ b/bedrock/firefox/urls.py
@@ -123,7 +123,7 @@ urlpatterns = (
     page('firefox/privacy-tools', 'firefox/messaging-experiment/privacy_tools.html'),
     page('firefox/mobile-promo', 'firefox/messaging-experiment/control.html'),
 
-    page('firefox/switch', 'firefox/switch.html', ftl_files=['firefox/switch', 'firefox/switch-en']),
+    page('firefox/switch', 'firefox/switch.html', ftl_files=['firefox/switch']),
     page('firefox/pocket', 'firefox/pocket.html'),
 
     # Issue 6604, SEO firefox/new pages

--- a/l10n/en/firefox/switch.ftl
+++ b/l10n/en/firefox/switch.ftl
@@ -5,7 +5,9 @@
 ### URL: https://www-dev.allizom.org/firefox/switch/
 
 switch-switch-from-chrome = Switch from { -brand-name-chrome } to { -brand-name-firefox } in just a few minutes
+switch-switching-to-firefox-is-fast-updated = Switching to { -brand-name-firefox } is fast, easy and risk-free, because { -brand-name-firefox } imports your bookmarks, passwords and preferences from { -brand-name-chrome }.
 switch-switching-to-firefox-is-fast = Switching to { -brand-name-firefox } is fast, easy and risk-free, because { -brand-name-firefox } imports your bookmarks, autofills, passwords and preferences from { -brand-name-chrome }.
+switch-switching-to-firefox-page-description-updated = Switching to { -brand-name-firefox } is fast, easy and risk-free. { -brand-name-firefox } imports your bookmarks, passwords and preferences from { -brand-name-chrome }.
 switch-switching-to-firefox-page-description = Switching to { -brand-name-firefox } is fast, easy and risk-free. { -brand-name-firefox } imports your bookmarks, autofills, passwords and preferences from { -brand-name-chrome }.
 switch-select-what-to-take = Select what to take from { -brand-name-chrome }.
 switch-let-firefox-do-the-rest = Let { -brand-name-firefox } do the rest.
@@ -18,7 +20,7 @@ switch-firefox-makes-switching-fast-email = { -brand-name-firefox } makes switch
 switch-still-not-convinced = Still not convinced that switching to { -brand-name-firefox } is easy?
 switch-enjoy-the-web-faster = Enjoy the web faster, all set up for you.
 switch-download-and-switch = Download and switch
-switch-share-to-facebook = Share to Facebook
+switch-share-to-facebook = Share to { -brand-name-facebook }
 switch-send-a-tweet = Send a tweet
 switch-hey = Hey,
 switch-check-it-out = Check it out and let me know what you think:


### PR DESCRIPTION
## Description
Removes mention of "autofill" from /firefox/switch/ page as it's something we no longer import.

## Issue / Bugzilla link
#8651

## Testing
- [ ] Both page description and page title should no longer mention "autofill"