### PR TITLE
Turn CTA links into buttons on /firefox and /browsers (Fixes #8950)

### DIFF
--- a/media/css/firefox/browsers-products.scss
+++ b/media/css/firefox/browsers-products.scss
@@ -8,8 +8,8 @@ $image-path: '/media/protocol/img';
 @import '../../protocol/css/includes/lib';
 @import '../../protocol/css/components/emphasis-box';
 @import '../../protocol/css/components/feature-card';
-@import '../../protocol/css/components/menu-list';
 @import '../../protocol/css/components/zap';
+@import '../protocol/components/custom-menu-list';
 
 
 $send-svg: '<svg width="24px" height="24px" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd"><g transform="translate(3.000000, 1.000000)" stroke="#{$color-link-hover}" stroke-width="2"><path d="M2,16 L2,20 C2,21.1045695 2.8954305,22 4,22 L14,22 C15.1045695,22 16,21.1045695 16,20 L16,2 C16,0.8954305 15.1045695,-2.02906125e-16 14,0 L4,0 C2.8954305,2.02906125e-16 2,0.8954305 2,2 L2,6" stroke-linecap="round"></path><path d="M2,4 L16,4"></path><path d="M2,18 L16,18"></path><path d="M3.55271368e-15,11 L10,11" stroke-linecap="round" stroke-linejoin="round"></path><polyline stroke-linecap="round" stroke-linejoin="round" points="6 7 10 11 6 15"></polyline></g></g></svg>';
@@ -369,19 +369,37 @@ $url-download-link: svg-url($download-link);
 $url-download-link-hover: svg-url($download-link-hover);
 
 .cta-download {
-    padding-right: 24px;
+    border-radius: $border-radius-md;
+    border: 2px solid $color-marketing-gray-30;
+    display: block;
+    padding: $spacing-sm;
+    @include bidi((
+        (padding-right, ($spacing-sm + 42px), $spacing-sm),
+        (padding-left, $spacing-sm, ($spacing-sm + 42px)),
+    ));
     position: relative;
+    text-decoration: none;
+    transition: border-color 100ms ease, background-color 100ms ease;
+
+    &:hover {
+        background: $color-marketing-gray-20;
+        border-color: $color-marketing-gray-40;
+
+        &:before {
+            border-color: $color-marketing-gray-40;
+        }
+    }
 
     &:after {
         @include background-size(23px);
-        @include bidi(((right, 0, left, auto),));
+        @include bidi(((right, $spacing-md, left, auto),));
         background-image: $url-download-link;
-        background-position: center bottom;
+        background-position: center center;
         background-repeat: no-repeat;
-        bottom: 0;
+        top: 0;
         content: '';
         display: inline-block;
-        height: 23px;
+        height: 100%;
         position: absolute;
         width: 16px;
     }

--- a/media/css/firefox/enterprise/landing.scss
+++ b/media/css/firefox/enterprise/landing.scss
@@ -9,9 +9,9 @@ $image-path: '/media/protocol/img';
 @import '../../../protocol/css/components/call-out';
 @import '../../../protocol/css/components/feature-card';
 @import '../../../protocol/css/components/hero';
-@import '../../../protocol/css/components/menu-list';
 @import '../../../protocol/css/components/picto-card';
 @import '../../../protocol/css/templates/card-layout';
+@import '../../protocol/components/custom-menu-list';
 @import '../../protocol/components/sub-navigation';
 
 
@@ -295,75 +295,6 @@ html {
 
 .enterprise-download-subtitle {
     @include text-title-xxs;
-}
-
-
-// This custom styling should be replaced when the component is redesigned upstream in Protocol
-.mzp-c-menu-list.is-details {
-    display: block;
-
-    .mzp-c-menu-list-title.is-summary {
-        margin: 0;
-
-        button {
-            padding: $spacing-sm;
-            @include bidi((
-                (padding-right, ($spacing-sm + 42px), $spacing-sm),
-                (padding-left, $spacing-sm, ($spacing-sm + 42px)),
-            ));
-            border-radius: $border-radius-md;
-            border: 2px solid $color-marketing-gray-30;
-            text-decoration: none;
-            transition: border-color 100ms ease, background-color 100ms ease;
-
-            &:hover {
-                background: $color-marketing-gray-20;
-                border-color: $color-marketing-gray-40;
-
-                &:before {
-                    border-color: $color-marketing-gray-40;
-                }
-            }
-
-            &:focus,
-            &[aria-expanded='true'] {
-                background-color: transparent;
-                border-color: $color-link;
-                box-shadow: 0 0 2px 0 $color-blue-20;
-
-                &:before {
-                    border-color: $color-link;
-                }
-            }
-
-            &:before {
-                @include bidi((
-                    (right, 42px, left, auto),
-                    (border-left-width, 2px, 0),
-                    (border-right-width, 0, 2px),
-                ));
-                border-left: solid $color-marketing-gray-30;
-                content: '';
-                display: block;
-                height: 100%;
-                position: absolute;
-                top: 0;
-                transition: border-color 100ms ease;
-                width: 0;
-            }
-
-            &:after {
-                @include bidi(((right, 0, left, auto),));
-                background-position: center center;
-                height: 100%;
-                width: 42px;
-            }
-        }
-    }
-
-    .mzp-c-menu-list-list {
-        margin-top: $spacing-sm;
-    }
 }
 
 

--- a/media/css/firefox/home/master.scss
+++ b/media/css/firefox/home/master.scss
@@ -7,7 +7,7 @@ $image-path: '/media/protocol/img';
 
 @import '../../../protocol/css/includes/lib';
 @import '../../../protocol/css/components/feature-card';
-@import '../../../protocol/css/components/menu-list';
+@import '../../protocol/components/custom-menu-list';
 
 
 // conditional content

--- a/media/css/protocol/components/_custom-menu-list.scss
+++ b/media/css/protocol/components/_custom-menu-list.scss
@@ -1,0 +1,79 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+$font-path: '/media/fonts';
+$image-path: '/media/protocol/img';
+
+@import '../../../protocol/css/includes/lib';
+@import '../../../protocol/css/components/menu-list';
+
+// This custom styling should be replaced when the component is redesigned upstream in Protocol
+.mzp-c-menu-list.is-details {
+    display: block;
+
+    .mzp-c-menu-list-title.is-summary {
+        margin: 0;
+
+        button {
+            padding: $spacing-sm;
+            @include bidi((
+                (padding-right, ($spacing-sm + 42px), $spacing-sm),
+                (padding-left, $spacing-sm, ($spacing-sm + 42px)),
+                (text-align, left, right),
+            ));
+            border-radius: $border-radius-md;
+            border: 2px solid $color-marketing-gray-30;
+            text-decoration: none;
+            transition: border-color 100ms ease, background-color 100ms ease;
+
+            &:hover {
+                background: $color-marketing-gray-20;
+                border-color: $color-marketing-gray-40;
+
+                &:before {
+                    border-color: $color-marketing-gray-40;
+                }
+            }
+
+            &:focus,
+            &[aria-expanded='true'] {
+                background-color: transparent;
+                border-color: $color-link;
+                box-shadow: 0 0 2px 0 $color-blue-20;
+
+                &:before {
+                    border-color: $color-link;
+                }
+            }
+
+            &:before {
+                @include bidi((
+                    (right, 42px, left, auto),
+                    (border-left-width, 2px, 0),
+                    (border-right-width, 0, 2px),
+                ));
+                border-left: solid $color-marketing-gray-30;
+                content: '';
+                display: block;
+                height: 100%;
+                position: absolute;
+                top: 0;
+                transition: border-color 100ms ease;
+                width: 0;
+            }
+
+            &:after {
+                @include bidi(((right, 0, left, auto),));
+                background-position: center center;
+                height: 100%;
+                width: 42px;
+            }
+        }
+    }
+
+    .mzp-c-menu-list-list {
+        margin-top: $spacing-sm;
+        right: 0;
+    }
+}


### PR DESCRIPTION
## Description
Takes custom menu-list styles from `/enterprise/` and moves them to a component so they can be shared with `/browsers/` and `/products/`

- http://localhost:8000/en-US/firefox/
- http://localhost:8000/en-US/firefox/enterprise/
- http://localhost:8000/en-US/firefox/browsers/
- http://localhost:8000/en-US/firefox/products/

## Issue / Bugzilla link
#8950

## Testing
- [ ] Dropdowns / links on all four pages above should look consistent.