### PR TITLE
[no bug] WNP77, use self-hosted video for zh-CN

### DIFF
--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx77.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx77.html
@@ -37,9 +37,16 @@
 
         <div class="video-container">
           <div class="video-content">
+          {# YouTube is blocked in China so zh-CN gets an alternative, self-hosted video. If we run into bandwidth trouble we can turn the video off and zh-CN falls back to the 76 page. #}
+          {% if switch('firefox-whatsnew77-video-zhCN', ['zh-CN']) %}
+            <video id="pip-video" preload="metadata" controls poster="{{ static('img/firefox/whatsnew/whatsnew77/video-poster.jpg') }}" data-ga-label="Red Panda Cubs - Firefox + Woodland Park Zoo">
+              <source src="https://assets.mozilla.net/video/red-pandas.webm" type="video/webm">
+            </video>
+          {% else %}
             <a class="video-play js-video-play" href="https://youtu.be/F-nFQryDB0s" data-id="F-nFQryDB0s" data-video-title="Red Panda Cubs - Firefox + Woodland Park Zoo" title="{{ _('Play the video') }}">
               <img src="{{ static('img/firefox/whatsnew/whatsnew77/video-poster.jpg') }}" alt="">
             </a>
+          {% endif %}
           </div>
         </div>
       </div>
@@ -87,5 +94,9 @@
 {% endblock %}
 
 {% block js %}
+{% if switch('firefox-whatsnew77-video-zhCN', ['zh-CN']) %}
+  {{ js_bundle('firefox_whatsnew_77_zhCN') }}
+{% else %}
   {{ js_bundle('firefox_whatsnew_77') }}
+{% endif %}
 {% endblock %}

--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx77.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx77.html
@@ -39,7 +39,7 @@
           <div class="video-content">
           {# YouTube is blocked in China so zh-CN gets an alternative, self-hosted video. If we run into bandwidth trouble we can turn the video off and zh-CN falls back to the 76 page. #}
           {% if switch('firefox-whatsnew77-video-zhCN', ['zh-CN']) %}
-            <video id="pip-video" preload="metadata" controls poster="{{ static('img/firefox/whatsnew/whatsnew77/video-poster.jpg') }}" data-ga-label="Red Panda Cubs - Firefox + Woodland Park Zoo">
+            <video id="pip-video" preload="metadata" controls poster="{{ static('img/firefox/whatsnew/whatsnew77/video-poster.jpg') }}" data-video-title="Red Panda Cubs - Firefox + Woodland Park Zoo">
               <source src="https://assets.mozilla.net/video/red-pandas.webm" type="video/webm">
             </video>
           {% else %}

--- a/bedrock/firefox/tests/test_base.py
+++ b/bedrock/firefox/tests/test_base.py
@@ -495,6 +495,16 @@ class TestWhatsNew(TestCase):
         template = render_mock.call_args[0][1]
         assert template == ['firefox/whatsnew/whatsnew-fx77.html']
 
+    @patch.dict(os.environ, SWITCH_FIREFOX_WHATSNEW77_VIDEO_ZHCN='False')
+    @patch.object(fx_views, 'lang_file_is_active', lambda *x: True)
+    def test_fx_77_0_0_zhCN(self, render_mock):
+        """Should use whatsnew-fx76 template for zh-CN if video switch is OFF"""
+        req = self.rf.get('/firefox/whatsnew/')
+        req.locale = 'zh-CN'
+        self.view(req, version='77.0')
+        template = render_mock.call_args[0][1]
+        assert template == ['firefox/whatsnew/whatsnew-fx76.html']
+
     # end 77.0 whatsnew tests
 
 

--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -591,7 +591,12 @@ class WhatsnewView(L10nTemplateView):
         elif locale == 'id':
             template = 'firefox/whatsnew/index-lite.id.html'
         elif version.startswith('77.') and lang_file_is_active('firefox/whatsnew_77', locale):
-            template = 'firefox/whatsnew/whatsnew-fx77.html'
+            # YouTube is blocked in China so zh-CN gets an alternative, self-hosted video.
+            # If we run into bandwidth trouble we can turn the video off and zh-CN falls back to the 76 page.
+            if locale == 'zh-CN' and not switch('firefox-whatsnew77-video-zhCN'):
+                template = 'firefox/whatsnew/whatsnew-fx76.html'
+            else:
+                template = 'firefox/whatsnew/whatsnew-fx77.html'
         elif version.startswith('76.') and lang_file_is_active('firefox/whatsnew_76', locale):
             template = 'firefox/whatsnew/whatsnew-fx76.html'
         elif version.startswith('75.') and lang_file_is_active('firefox/whatsnew_75', locale):

--- a/media/css/firefox/whatsnew/whatsnew-77.scss
+++ b/media/css/firefox/whatsnew/whatsnew-77.scss
@@ -76,6 +76,10 @@ $image-path: '/media/protocol/img';
     }
 }
 
+.moz-video-button {
+    visibility: hidden;
+}
+
 
 //* -------------------------------------------------------------------------- */
 // Emphasis box

--- a/media/js/firefox/whatsnew/whatsnew-77-zhCN.js
+++ b/media/js/firefox/whatsnew/whatsnew-77-zhCN.js
@@ -1,0 +1,37 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+(function() {
+    'use strict';
+
+    function trackVideoInteraction(title, state) {
+        window.dataLayer.push({
+            'event': 'video-interaction',
+            'videoTitle': title,
+            'interaction': state
+        });
+    }
+
+    function initVideoInteractionTracking() {
+        var video = document.getElementById('pip-video');
+
+        video.addEventListener('play', function() {
+            trackVideoInteraction(this.getAttribute('data-video-title'), 'video play');
+        }, false);
+
+        video.addEventListener('pause', function() {
+            var action = this.currentTime === this.duration ? 'video complete' : 'video paused';
+            trackVideoInteraction(this.getAttribute('data-video-title'), action);
+        }, false);
+    }
+
+    function onLoad() {
+        var videoPoster = new Mozilla.VideoPosterHelper('.pip-video');
+        videoPoster.init();
+        initVideoInteractionTracking();
+    }
+
+    window.Mozilla.run(onLoad);
+
+})();

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -880,6 +880,15 @@
     },
     {
       "files": [
+        "js/base/uitour-lib.js",
+        "js/firefox/whatsnew/up-to-date.js",
+        "js/base/mozilla-video-poster.js",
+        "js/firefox/whatsnew/whatsnew-77-zhCN.js"
+      ],
+      "name": "firefox_whatsnew_77_zhCN"
+    },
+    {
+      "files": [
         "protocol/js/protocol-newsletter.js"
       ],
       "name": "legal"


### PR DESCRIPTION
## Description
YouTube is blocked in China, so we'll show a self-hosted video to zh-CN. Other locales should still get the YouTube embed.

This is behind the switch `firefox-whatsnew77-video-zhCN` so in case we approach exceeding our bandwidth we can quickly turn it off and zh-CN should fall back to the WNP76 template.

The 77 release is **2020-06-02** so we need to get this into production before then. Marking as P1.

## Testing
http://localhost:8000/zh-CN/firefox/77.0/whatsnew/all/
https://www-demo3.allizom.org/zh-CN/firefox/77.0/whatsnew/all/

- [x] zh-CN gets the self-hosted video when the switch is on
- [x] zh-CN gets the WNP76 template when the switch is off