### PR TITLE
[fix #8951] Leadership page updates, June 1

### DIFF
--- a/bedrock/mozorg/templates/mozorg/about/leadership.html
+++ b/bedrock/mozorg/templates/mozorg/about/leadership.html
@@ -238,47 +238,6 @@
         </div>
       </article>
 
-      <article id="mary-ellen-muckerman" data-id="mary-ellen-muckerman" class="vcard has-bio" itemscope itemtype="http://schema.org/Person">
-        <figure class="headshot">
-          {{ high_res_img('img/mozorg/about/leadership/mary-ellen-muckerman.jpg', {'alt': '', 'width': '160', 'height': '160', 'class': 'photo', 'itemprop': 'image'}) }}
-          <figcaption><h4 class="fn" itemprop="name">Mary Ellen Muckerman</h4></figcaption>
-        </figure>
-
-        <div class="person-info">
-          <p class="title" itemprop="jobTitle">{{ _('Interim CMO') }}</p>
-          <p class="note">{{ _('Steering Committee') }}</p>
-
-          <ul class="elsewhere">
-            <li><a class="url book" itemprop="url" rel="external" href="https://mozillians.org/u/maryellen/">{{ _('Mozillians profile') }}</a></li>
-          </ul>
-
-          <ul class="utility">
-            <li><a class="file" rel="external" href="https://assets.mozilla.net/leadership/mozilla-mary-ellen-muckerman.zip">{{ _('Download photos') }}</a></li>
-            <li><a class="link" href="{{ url('mozorg.about.leadership') }}#mary-ellen-muckerman">{{ _('Link to this bio') }}</a></li>
-          </ul>
-        </div>
-
-        <div class="person-bio">
-          <p>
-          {% trans %}
-            Mary Ellen is the VP of Brand Engagement, responsible for the brand strategy positioning and narrative of Mozilla and Firefox, as well as the design and production of many of the engagement assets we develop to create relationships with people around the world.
-          {% endtrans %}
-          </p>
-
-          <p>
-          {% trans %}
-            Prior to joining Mozilla, Mary Ellen spent several years at Wolff Olins, a global brand consultancy where, as leader of their San Francisco office and the US strategy team, she worked with clients like Mozilla, the Smithsonian, Target and Google to help them identify what makes them unique and relevant to their audiences and then apply that strategic idea both internally, to guide their culture and capabilities, and externally, to influence their products, services and communications. Mary Ellen also held brand and marketing roles during her 10 years at Target and learned the retail ropes in regional marketing at McDonald’s and store management at The May Company Department Stores.
-          {% endtrans %}
-          </p>
-
-          <p>
-          {% trans %}
-            Mary Ellen holds a B.S. in Business from Miami University and an M.L.S. from the University of Minnesota.
-          {% endtrans %}
-          </p>
-        </div>
-      </article>
-
       <article id="adam-seligman" data-id="adam-seligman" class="vcard has-bio" itemscope itemtype="http://schema.org/Person">
         <figure class="headshot">
           {{ high_res_img('img/mozorg/about/leadership/adam-seligman.jpg', {'alt': '', 'width': '160', 'height': '160', 'class': 'photo', 'itemprop': 'image'}) }}
@@ -352,54 +311,6 @@
         </div>
       </article>
 
-      <article id="sean-white" data-id="sean-white" class="vcard has-bio" itemscope itemtype="http://schema.org/Person">
-        <figure class="headshot">
-          {{ high_res_img('img/mozorg/about/leadership/sean-white.jpg', {'alt': '', 'width': '160', 'height': '160', 'class': 'photo', 'itemprop': 'image'}) }}
-          <figcaption><h4 class="fn" itemprop="name">Sean White</h4></figcaption>
-        </figure>
-
-        <div class="person-info">
-          <p class="title" itemprop="jobTitle">{{ _('Chief R&amp;D Officer') }}</p>
-          <p class="note">{{ _('Steering Committee') }}</p>
-
-          <ul class="elsewhere">
-            <li><a class="url twitter" itemprop="url" rel="external" href="https://twitter.com/seanwhite">@seanwhite</a></li>
-            <li><a class="url book" itemprop="url" rel="external" href="https://mozillians.org/u/seanwhite/">{{ _('Mozillians profile') }}</a></li>
-          </ul>
-
-          <ul class="utility">
-            <li><a class="file" rel="external" href="https://assets.mozilla.net/leadership/mozilla-sean-white.zip">{{ _('Download photos') }}</a></li>
-            <li><a class="link" href="{{ url('mozorg.about.leadership') }}#sean-white">{{ _('Link to this bio') }}</a></li>
-          </ul>
-        </div>
-
-        <div class="person-bio">
-          <p>
-          {% trans %}
-            Sean White is a high-tech executive, entrepreneur, inventor, and musician who has spent his career leading innovative development of the experiences, systems, and technologies that enable creative expression, connect us to each other, and enhance our understanding of the world around us. He was most recently the founder and CEO of BrightSky Labs, a company he incubated while an EIR at Greylock Partners, and is currently teaching CS377m: HCI Issues in Mixed &amp; Augmented Reality at Stanford University.
-          {% endtrans %}
-          </p>
-
-          <p>
-          {% trans %}
-            Before Greylock Partners, Sean founded and built the Interaction Ecologies Group at Nokia, leading multiple innovative efforts in new mobile forms and experiences in the areas of wearables, Internet of Things, and augmented reality. His previous roles include Chief Technology Officer of NeoCarta Ventures, Vice President of Technology for Lycos, Inc. (acquired by Terra Networks), and Chief Technology Officer of WhoWhere? (acquired by Lycos). Prior to that, Sean was a project lead and member of the research staff at Paul Allen’s Interval Research Corporation. He holds Advisory Board positions with Perch, and Virtual Workflow, and previously held Advisory Board positions with NY Sun Works, Environmental Defense, Evite, Gravity and OpenVoice.
-          {% endtrans %}
-          </p>
-
-          <p>
-          {% trans %}
-            In addition to 30+ peer reviewed publications and 20+ patents granted or filed, Sean is a 2009 Tech Award Laureate for his work on computer vision-based mobile botanical species identification. He has lectured and taught in the Stanford Program in Human-Computer Interaction and at Columbia University, mentored for Engineers without Borders, and served as facilitator for the Clinton Global Initiative. He held an appointment as a Visiting Scientist at the Smithsonian Institution and served on the Steering Committee for IEEE’s International Symposium on Mixed and Augmented Reality (ISMAR).
-          {% endtrans %}
-          </p>
-
-          <p>
-          {% trans %}
-            Sean earned his B.S. and M.S. in Computer Science from Stanford University and his M.S. in Mechanical Engineering and Ph.D. in Computer Science from Columbia University.
-          {% endtrans %}
-          </p>
-        </div>
-      </article>
-
       <article id="katharina-borchert" data-id="katharina-borchert" class="vcard has-bio" itemscope itemtype="http://schema.org/Person">
         <figure class="headshot">
           {{ high_res_img('img/mozorg/about/leadership/katharina-borchert.jpg', {'alt': '', 'width': '160', 'height': '160', 'class': 'photo', 'itemprop': 'image'}) }}
@@ -436,6 +347,46 @@
           <p>
           {% trans %}
             Katharina studied law (with a focus on humanitarian law) and journalism in Hamburg and Lausanne. She previously worked at the UN Center for Human Rights.
+          {% endtrans %}
+          </p>
+        </div>
+      </article>
+
+      <article id="mary-ellen-muckerman" data-id="mary-ellen-muckerman" class="vcard has-bio" itemscope itemtype="http://schema.org/Person">
+        <figure class="headshot">
+          {{ high_res_img('img/mozorg/about/leadership/mary-ellen-muckerman.jpg', {'alt': '', 'width': '160', 'height': '160', 'class': 'photo', 'itemprop': 'image'}) }}
+          <figcaption><h4 class="fn" itemprop="name">Mary Ellen Muckerman</h4></figcaption>
+        </figure>
+
+        <div class="person-info">
+          <p class="title" itemprop="jobTitle">{{ _('Interim CMO') }}</p>
+
+          <ul class="elsewhere">
+            <li><a class="url book" itemprop="url" rel="external" href="https://mozillians.org/u/maryellen/">{{ _('Mozillians profile') }}</a></li>
+          </ul>
+
+          <ul class="utility">
+            <li><a class="file" rel="external" href="https://assets.mozilla.net/leadership/mozilla-mary-ellen-muckerman.zip">{{ _('Download photos') }}</a></li>
+            <li><a class="link" href="{{ url('mozorg.about.leadership') }}#mary-ellen-muckerman">{{ _('Link to this bio') }}</a></li>
+          </ul>
+        </div>
+
+        <div class="person-bio">
+          <p>
+          {% trans %}
+            Mary Ellen is the VP of Brand Engagement, responsible for the brand strategy positioning and narrative of Mozilla and Firefox, as well as the design and production of many of the engagement assets we develop to create relationships with people around the world.
+          {% endtrans %}
+          </p>
+
+          <p>
+          {% trans %}
+            Prior to joining Mozilla, Mary Ellen spent several years at Wolff Olins, a global brand consultancy where, as leader of their San Francisco office and the US strategy team, she worked with clients like Mozilla, the Smithsonian, Target and Google to help them identify what makes them unique and relevant to their audiences and then apply that strategic idea both internally, to guide their culture and capabilities, and externally, to influence their products, services and communications. Mary Ellen also held brand and marketing roles during her 10 years at Target and learned the retail ropes in regional marketing at McDonald’s and store management at The May Company Department Stores.
+          {% endtrans %}
+          </p>
+
+          <p>
+          {% trans %}
+            Mary Ellen holds a B.S. in Business from Miami University and an M.L.S. from the University of Minnesota.
           {% endtrans %}
           </p>
         </div>
@@ -880,6 +831,53 @@
         </div>
       </article>
 
+      <article id="sean-white" data-id="sean-white" class="vcard has-bio" itemscope itemtype="http://schema.org/Person">
+        <figure class="headshot">
+          {{ high_res_img('img/mozorg/about/leadership/sean-white.jpg', {'alt': '', 'width': '160', 'height': '160', 'class': 'photo', 'itemprop': 'image'}) }}
+          <figcaption><h4 class="fn" itemprop="name">Sean White</h4></figcaption>
+        </figure>
+
+        <div class="person-info">
+          <p class="title" itemprop="jobTitle">{{ _('Chief R&amp;D Officer') }}</p>
+
+          <ul class="elsewhere">
+            <li><a class="url twitter" itemprop="url" rel="external" href="https://twitter.com/seanwhite">@seanwhite</a></li>
+            <li><a class="url book" itemprop="url" rel="external" href="https://mozillians.org/u/seanwhite/">{{ _('Mozillians profile') }}</a></li>
+          </ul>
+
+          <ul class="utility">
+            <li><a class="file" rel="external" href="https://assets.mozilla.net/leadership/mozilla-sean-white.zip">{{ _('Download photos') }}</a></li>
+            <li><a class="link" href="{{ url('mozorg.about.leadership') }}#sean-white">{{ _('Link to this bio') }}</a></li>
+          </ul>
+        </div>
+
+        <div class="person-bio">
+          <p>
+          {% trans %}
+            Sean White is a high-tech executive, entrepreneur, inventor, and musician who has spent his career leading innovative development of the experiences, systems, and technologies that enable creative expression, connect us to each other, and enhance our understanding of the world around us. He was most recently the founder and CEO of BrightSky Labs, a company he incubated while an EIR at Greylock Partners, and is currently teaching CS377m: HCI Issues in Mixed &amp; Augmented Reality at Stanford University.
+          {% endtrans %}
+          </p>
+
+          <p>
+          {% trans %}
+            Before Greylock Partners, Sean founded and built the Interaction Ecologies Group at Nokia, leading multiple innovative efforts in new mobile forms and experiences in the areas of wearables, Internet of Things, and augmented reality. His previous roles include Chief Technology Officer of NeoCarta Ventures, Vice President of Technology for Lycos, Inc. (acquired by Terra Networks), and Chief Technology Officer of WhoWhere? (acquired by Lycos). Prior to that, Sean was a project lead and member of the research staff at Paul Allen’s Interval Research Corporation. He holds Advisory Board positions with Perch, and Virtual Workflow, and previously held Advisory Board positions with NY Sun Works, Environmental Defense, Evite, Gravity and OpenVoice.
+          {% endtrans %}
+          </p>
+
+          <p>
+          {% trans %}
+            In addition to 30+ peer reviewed publications and 20+ patents granted or filed, Sean is a 2009 Tech Award Laureate for his work on computer vision-based mobile botanical species identification. He has lectured and taught in the Stanford Program in Human-Computer Interaction and at Columbia University, mentored for Engineers without Borders, and served as facilitator for the Clinton Global Initiative. He held an appointment as a Visiting Scientist at the Smithsonian Institution and served on the Steering Committee for IEEE’s International Symposium on Mixed and Augmented Reality (ISMAR).
+          {% endtrans %}
+          </p>
+
+          <p>
+          {% trans %}
+            Sean earned his B.S. and M.S. in Computer Science from Stanford University and his M.S. in Mechanical Engineering and Ph.D. in Computer Science from Columbia University.
+          {% endtrans %}
+          </p>
+        </div>
+      </article>
+
     </div>{# end moco management #}
 
     <h3 class="group-title" id="mgmt-foundation"><a href="https://foundation.mozilla.org/">{{ _('Mozilla Foundation') }}</a></h3>
@@ -1190,7 +1188,7 @@
         <figure class="headshot">
           {{ high_res_img('img/mozorg/about/leadership/mitchell-baker.jpg', {'alt': '', 'width': '160', 'height': '160', 'class': 'photo', 'itemprop': 'image'}) }}
           {# L10n: This "Chair" is the chairperson of the board of directors, not something to sit on #}
-          <figcaption><h4 class="fn" itemprop="name">Mitchell Baker, {{ _('Chair') }}</h4></figcaption>
+          <figcaption><h4 class="fn" itemprop="name">Mitchell Baker</h4></figcaption>
         </figure>
       </li>
       <li class="vcard" itemscope itemtype="http://schema.org/Person">


### PR DESCRIPTION
## Description
Removed: 'Steering Committee' under Mary Ellen Muckerman and Sean White's names in the Management Teams section. Also reordered accordingly (we list steering committee members first, followed by C-level execs, followed by everyone else).

Removed: 'Chair' under Mitchell's name in the Board of Directors - Moco.

This needs to be live on **Monday, 1 June**

## Issue / Bugzilla link
#8951 

## Testing
http://localhost:8000/about/leadership/