### PR TITLE
Remove tracking.services.mozilla.com from eligible sites

### DIFF
--- a/bedrock/security/templates/security/bug-bounty/web-eligible-sites.html
+++ b/bedrock/security/templates/security/bug-bounty/web-eligible-sites.html
@@ -162,7 +162,6 @@
   <h3>Tracking Protection</h3>
   <ul class="mzp-u-list-styled">
     <li>shavar.services.mozilla.com</li>
-    <li>tracking.services.mozilla.com</li>
   </ul>
 
   <h2 id="core-sites"><b>Core</b></h2>


### PR DESCRIPTION
Removes tracking.services.mozilla.com from the list of eligible bug bounty sites, since it no longer exists.