### PR TITLE
Add new product FQDNs to Web Bounty Eligible sites

### DIFF
--- a/bedrock/security/templates/security/bug-bounty/web-eligible-sites.html
+++ b/bedrock/security/templates/security/bug-bounty/web-eligible-sites.html
@@ -209,6 +209,8 @@
   <ul class="mzp-u-list-styled">
     <li>getpocket.com</li>
     <li>api.getpocket.com</li>
+    <li>app.getpocket.com</li>
+    <li>widgets.getpocket.com</li>
   </ul>
 
   <h3>Premium Services</h3>

--- a/bedrock/security/templates/security/bug-bounty/web-eligible-sites.html
+++ b/bedrock/security/templates/security/bug-bounty/web-eligible-sites.html
@@ -203,6 +203,7 @@
   <h3>Payment Subscription</h3>
   <ul class="mzp-u-list-styled">
     <li>prod.fxa.mozilla-subhub.app</li>
+    <li>subscriptions.firefox.com</li>
   </ul>
 
   <h3>Pocket</h3>

--- a/bedrock/security/templates/security/bug-bounty/web-eligible-sites.html
+++ b/bedrock/security/templates/security/bug-bounty/web-eligible-sites.html
@@ -228,6 +228,11 @@
     <li>relay.firefox.com</li>
   </ul>
 
+  <h3>Send</h3>
+  <ul class="mzp-u-list-styled">
+    <li>send.firefox.com</li>
+  </ul>
+
   <h3>Shield</h3>
   <ul class="mzp-u-list-styled">
     <li>qsurvey.mozilla.com</li>
@@ -249,4 +254,10 @@
     <li>speaktome-2.services.mozilla.com</li>
     <li>speaktome.services.mozilla.com</li>
   </ul>
+
+  <h3>VPN</h3>
+  <ul class="mzp-u-list-styled">
+    <li>vpn.mozilla.org</li>
+  </ul>
+
 {% endblock %}

--- a/bedrock/security/templates/security/bug-bounty/web-eligible-sites.html
+++ b/bedrock/security/templates/security/bug-bounty/web-eligible-sites.html
@@ -223,6 +223,11 @@
     <li>fpn.firefox.com</li>
   </ul>
 
+  <h3>Private Relay</h3>
+  <ul class="mzp-u-list-styled">
+    <li>relay.firefox.com</li>
+  </ul>
+
   <h3>Shield</h3>
   <ul class="mzp-u-list-styled">
     <li>qsurvey.mozilla.com</li>


### PR DESCRIPTION
## Description
This is an update of the eligible web properties for new product initiatives

## Testing
Verify that formatting rendered properly for the new sites added.

## Required Reviewers
@moz-jvehent @bhourigan @april 