### PR TITLE
Migrate /firefox to Fluent (#8968)

### DIFF
--- a/bedrock/firefox/templates/firefox/home/index-master.html
+++ b/bedrock/firefox/templates/firefox/home/index-master.html
@@ -2,22 +2,23 @@
  # License, v. 2.0. If a copy of the MPL was not distributed with this
  # file, You can obtain one at http://mozilla.org/MPL/2.0/. #}
 
-{% add_lang_files "firefox/home-master" %}
-
 {% extends "firefox/base/base-protocol.html" %}
 
 {% from "macros-protocol.html" import call_out, call_out_compact, feature_card with context %}
 
+{% block page_title %}{{ ftl('firefox-home-firefox-protect-your') }}{% endblock %}
+
 {# Bug 1438302 Avoid duplicate content for en-CA and en-GB pages. #}
 {% if LANG == 'en-CA' %}
-  {% set title_suffix = 'Firefox (CA)' %}
+  {% set title_suffix = ' — ' ~ ftl('firefox-home-mozilla') ~ ' (CA)' %}
 {% elif LANG == 'en-GB' %}
-  {% set title_suffix = 'Firefox (UK)' %}
+  {% set title_suffix = ' — ' ~ ftl('firefox-home-mozilla') ~ ' (UK)' %}
 {% else %}
-  {% set title_suffix = 'Firefox' %}
+  {% set title_suffix = ' — ' ~ ftl('firefox-home-mozilla') %}
 {% endif %}
-{% block page_title %}{{ _('Firefox - Protect your life online with privacy-first products') }}{% endblock %}
-{% block page_desc %}{{ _('Firefox is more than a browser. Learn more about Firefox products that handle your data with respect and are built for privacy anywhere you go online.') }}{% endblock %}
+{% block page_title_suffix %}{{ title_suffix }}{% endblock %}
+
+{% block page_desc %}{{ ftl('firefox-home-firefox-is-more-than') }}{% endblock %}
 {% block page_image %}{{ static('img/firefox/template/page-image-master.jpg') }}{% endblock %}
 {% block page_favicon %}{{ static('img/favicons/firefox/favicon.ico') }}{% endblock %}
 {% block page_favicon_large %}{{ static('img/favicons/firefox/favicon-196x196.png') }}{% endblock %}
@@ -38,87 +39,47 @@
 
 {% set referrals = '?utm_source=www.mozilla.org&utm_medium=referral&utm_campaign=firefox-home' %}
 
-{# Setting all the strings here make it easy to use this page as a base template if we need to hard code the translation in bedrock #}
-{% set page_title = _('The browser is just the beginning') %}
-{% set family_title = _('Meet our family of products') %}
-{% if LANG.startswith('en') %}
-  {% set browsers_trackers = 'Get 2000+ trackers off your trail — including Facebook' %}
-{% else %}
-  {% set browsers_trackers = _('Get 2,000+ trackers off your trail — including Facebook') %}
-{% endif %}
-{% set monitor_title = _('Know when hackers strike — and stay a step ahead') %}
-{% set monitor_cta = _('Start getting breach reports') %}
-{% set lockwise_title = _('Keep your passwords safe on every device') %}
-{% set lockwise_cta = _('Learn more about Lockwise') %}
-{# L10n: the strong tags around "respect" add a special underline, the underline breaks if it is on two words, please omit the strong tags if they need to be around multiple words in your language #}
-{% set promise_title = _('Get the <strong>respect</strong> you deserve') %}
-{% set promise_desc = _('Every single Firefox product honors our Personal Data Promise: <strong>Take less. Keep it safe. No secrets.</strong>')|safe %}
-{% set send_title = _('Share large files without prying eyes') %}
-{% set send_cta  = _('Start sending files safely') %}
-{% set pocket_title = _('Trade clickbait for quality content') %}
-{% set pocket_cta = _('Learn more about Pocket') %}
-{% set footer_title = _('One login. All your devices. A family of products that respect your <strong>privacy</strong>.') %}
-{% set join_firefox = _('Join Firefox') %}
-{% set join_learn_more = _('Learn more about joining Firefox') %}
-{% set learn_more  = ftl('ui-learn-more') %}
-{% set get_extension  = _('Get the browser extension') %}
-{% set get_facebook_container  = _('Get the Facebook Container extension') %}
-{% set get_browser = _('Download the browser') %}
-{% set get_app = _('Download the app') %}
-{% set get_desktop = _('Desktop') %}
-{% set get_android = 'Android' %}
-{% set get_ios = 'iOS' %}
-{% set get_mac = 'Mac' %}
-{% set get_amazon = 'Amazon' %}
-{% set product_browsers = _('Browsers') %}
-{% set product_monitor = 'Monitor' %}
-{% set product_send = 'Send' %}
-{% set product_lockwise = 'Lockwise' %}
-{% set product_pocket = 'Pocket' %}
-{% set browsers_url = url('firefox.browsers.index') %}
-
-
 {% block content %}
 <main role="main" class="firefox-home">
 
     <div class="c-lead">
       <div class="mzp-l-content">
-        <h1 class="c-lead-title">{{ page_title }}</h1>
+        <h1 class="c-lead-title">{{ ftl('firefox-home-the-browser-is-just') }}</h1>
       </div>
     </div>
 
     <div class="c-showcase">
       <div class="mzp-l-content">
-        <h2 class="c-showcase-title">{{ family_title }}</h2>
+        <h2 class="c-showcase-title">{{ ftl('firefox-home-meet-our-family-of') }}</h2>
         <ul class="c-showcase-list">
           <li>
-            <a class="mzp-c-cta-link" href="{{ browsers_url }}" data-cta-type="link" data-cta-text="Browsers">
+            <a class="mzp-c-cta-link" href="{{ url('firefox.browsers.index') }}" data-cta-type="link" data-cta-text="Browsers">
               <img alt="" src="{{ static('protocol/img/logos/firefox/browser/logo-md.png') }}" height="40" width="40"><br>
-              {{ product_browsers }}
+              {{ ftl('firefox-home-browsers') }}
             </a>
           </li>
           <li>
             <a class="mzp-c-cta-link" href="https://monitor.firefox.com{{ referrals }}" rel="external noopener" data-cta-type="link" data-cta-text="Monitor">
               <img alt="" src="{{ static('protocol/img/logos/firefox/monitor/logo-md.png') }}" height="40" width="40"><br>
-              {{ product_monitor }}
+              {{ ftl('firefox-home-monitor') }}
             </a>
           </li>
           <li>
             <a class="mzp-c-cta-link" href="https://send.firefox.com/{{ referrals }}" rel="external noopener" data-cta-type="link" data-cta-text="Send">
               <img alt="" src="{{ static('protocol/img/logos/firefox/send/logo-md.png') }}" height="40" width="40"><br>
-              {{ product_send }}
+              {{ ftl('firefox-home-send') }}
             </a>
           </li>
           <li>
               <a class="mzp-c-cta-link" href="{{ url('firefox.lockwise.lockwise') }}" rel="external noopener" data-cta-type="link" data-cta-text="Lockwise">
                 <img alt="" src="{{ static('protocol/img/logos/firefox/lockwise/logo-md.png') }}" height="40" width="40"><br>
-                {{ product_lockwise }}
+                {{ ftl('firefox-home-lockwise') }}
               </a>
             </li>
           <li>
             <a class="mzp-c-cta-link" href="https://getpocket.com/firefox_learnmore/{{ referrals }}" rel="external noopener" data-cta-type="link" data-cta-text="Pocket">
               <img alt="" src="{{ static('img/logos/pocket/logo.svg') }}" height="40" width="40"><br>
-              {{ product_pocket }}
+              {{ ftl('firefox-home-pocket') }}
             </a>
           </li>
         </ul>
@@ -127,7 +88,7 @@
 
     <div class="mzp-l-content">
       {% call feature_card(
-        title='Firefox Browser',
+        title=ftl('firefox-home-firefox-browser'),
         heading_level=3,
         image_url='img/firefox/home/browser.jpg',
         include_highres_image=True,
@@ -136,112 +97,112 @@
         ga_title='Trackers',
         media_after=True
       ) %}
-        <h4>{{ browsers_trackers }}</h4>
+        <h4>{{ ftl('firefox-home-get-trackers-off') }}</h4>
         <div id="test-menu-browsers-wrapper" class="mzp-c-menu-list mzp-t-cta mzp-t-download">
-          <h5 class="mzp-c-menu-list-title">{{ get_browser }}</h5>
+          <h5 class="mzp-c-menu-list-title">{{ ftl('firefox-home-download-the-browser') }}</h5>
           <ul class="mzp-c-menu-list-list" id="menu-browsers">
             {# Old IE users need to click a download button, the JS on the thank you page doesn't get them the right download if we send them there directly #}
             <!--[if IE]>
-              <li class="mzp-c-menu-list-item menu-desktop"><a href="{{ url('firefox.new') }}" data-cta-type="link" data-cta-text="Firefox Desktop">{{ get_desktop }}</a></li>
+              <li class="mzp-c-menu-list-item menu-desktop"><a href="{{ url('firefox.new') }}" data-cta-type="link" data-cta-text="Firefox Desktop">{{ ftl('firefox-home-desktop') }}</a></li>
             <![endif]-->
             <!--[if !IE]><!-->
               {# Download link should be locale neutral see issue 7982 #}
-              <li class="mzp-c-menu-list-item menu-desktop"><a href="/firefox/download/thanks/" data-link-type="Desktop" data-download-os="Desktop" data-download-version="standard">{{ get_desktop }}</a></li>
+              <li class="mzp-c-menu-list-item menu-desktop"><a href="/firefox/download/thanks/" data-link-type="Desktop" data-download-os="Desktop" data-download-version="standard">{{ ftl('firefox-home-desktop') }}</a></li>
             <!--<![endif]-->
-            <li class="mzp-c-menu-list-item menu-android"><a href="{{ firefox_adjust_url('android', 'firefox_home') }}" rel="external noopener" data-link-type="download" data-display-name="Android" data-download-version="android" data-download-os="Android"> {{ get_android }}</a></li>
-            <li class="mzp-c-menu-list-item menu-ios"><a href="{{ firefox_adjust_url('ios', 'firefox_home') }}" rel="external noopener" data-link-type="download" data-display-name="iOS" data-download-version="ios" data-download-os="iOS">{{ get_ios }}</a></li>
+            <li class="mzp-c-menu-list-item menu-android"><a href="{{ firefox_adjust_url('android', 'firefox_home') }}" rel="external noopener" data-link-type="download" data-display-name="Android" data-download-version="android" data-download-os="Android"> {{ ftl('firefox-home-android') }}</a></li>
+            <li class="mzp-c-menu-list-item menu-ios"><a href="{{ firefox_adjust_url('ios', 'firefox_home') }}" rel="external noopener" data-link-type="download" data-display-name="iOS" data-download-version="ios" data-download-os="iOS">{{ ftl('firefox-home-ios') }}</a></li>
           </ul>
         </div>
-        <p id="test-fbc" class="js-fx-only"><a class="mzp-c-cta-link" href="https://addons.mozilla.org/firefox/addon/facebook-container/{{ referrals }}">{{ get_facebook_container }}</a></p>
+        <p id="test-fbc" class="js-fx-only"><a class="mzp-c-cta-link" href="https://addons.mozilla.org/firefox/addon/facebook-container/{{ referrals }}">{{ ftl('firefox-home-get-the-facebook-container') }}</a></p>
       {% endcall %}
     </div>
 
     <div class="mzp-l-content">
         {% call feature_card(
-          title='Firefox Monitor',
+          title=ftl('firefox-home-firefox-monitor'),
           heading_level=3,
           image_url='img/firefox/home/master/monitor.svg',
           class='mzp-l-card-feature-right-half t-monitor',
           link_url='https://monitor.firefox.com/' + referrals,
-          link_cta=monitor_cta,
+          link_cta=ftl('firefox-home-start-getting-breach'),
           ga_title='Monitor',
           media_after=True
         ) %}
-        <h4>{{ monitor_title }}</h4>
+        <h4>{{ ftl('firefox-home-know-when-hackers-strike') }}</h4>
         {% endcall %}
     </div>
 
     <div class="mzp-l-content">
       {% call feature_card(
-        title='Firefox Lockwise',
+        title=ftl('firefox-home-firefox-lockwise'),
         heading_level=3,
         image_url='img/firefox/home/master/lockwise.svg',
         class='mzp-l-card-feature-left-half t-lockwise',
         ga_title='Lockwise',
         media_after=True
       ) %}
-      <h4>{{ lockwise_title }}</h4>
+      <h4>{{ ftl('firefox-home-keep-your-passwords') }}</h4>
         <div class="mzp-c-menu-list mzp-t-cta mzp-t-download">
-          <h5 class="mzp-c-menu-list-title">{{ get_app }}</h5>
+          <h5 class="mzp-c-menu-list-title">{{ ftl('firefox-home-download-the-app') }}</h5>
           <ul class="mzp-c-menu-list-list" id="menu-lockwise">
-            <li class="mzp-c-menu-list-item"><a href="{{ lockwise_adjust_url('android', 'firefox-home') }}" rel="external noopener" data-cta-type="link" data-cta-text="Download Lockwise for Android"> {{ get_android }}</a></li>
-            <li class="mzp-c-menu-list-item"><a href="{{ lockwise_adjust_url('ios', 'firefox-home') }}" rel="external noopener" data-cta-type="link" data-cta-text="Download Lockwise for iOS">{{ get_ios }}</a></li>
+            <li class="mzp-c-menu-list-item"><a href="{{ lockwise_adjust_url('android', 'firefox-home') }}" rel="external noopener" data-cta-type="link" data-cta-text="Download Lockwise for Android"> {{ ftl('firefox-home-android') }}</a></li>
+            <li class="mzp-c-menu-list-item"><a href="{{ lockwise_adjust_url('ios', 'firefox-home') }}" rel="external noopener" data-cta-type="link" data-cta-text="Download Lockwise for iOS">{{ ftl('firefox-home-ios') }}</a></li>
           </ul>
         </div>
-        <p><a class="mzp-c-cta-link" href="{{ url('firefox.lockwise.lockwise') }}" rel="external noopener" data-cta-type="link" data-cta-text="Lockwise Learn More">{{ lockwise_cta }}</a></p>
+        <p><a class="mzp-c-cta-link" href="{{ url('firefox.lockwise.lockwise') }}" rel="external noopener" data-cta-type="link" data-cta-text="Lockwise Learn More">{{ ftl('firefox-home-learn-more-about-lockwise') }}</a></p>
       {% endcall %}
     </div>
 
     <div class="t-promise mzp-t-dark">
       <div class="mzp-l-content">
           {% call feature_card(
-            title=promise_title,
+            title=ftl('firefox-home-get-the-respect-you'),
             heading_level=3,
             image_url='img/firefox/home/master/spacer.gif',
             class='mzp-l-card-feature-right-half',
             link_url=url('firefox.privacy.index'),
-            link_cta=learn_more,
+            link_cta=ftl('ui-learn-more'),
             ga_title='Promise',
             media_after=True
           ) %}
-            <p>{{ promise_desc }}</p>
+            <p>{{ ftl('firefox-home-every-single-firefox') }}</p>
           {% endcall %}
       </div>
     </div>
 
     <div class="mzp-l-content">
         {% call feature_card(
-          title='Firefox Send',
+          title=ftl('firefox-home-firefox-send'),
           heading_level=3,
           image_url='img/firefox/home/master/send.svg',
           class='mzp-l-card-feature-right-half t-send',
           link_url='https://send.firefox.com/' + referrals,
-          link_cta=send_cta,
+          link_cta=ftl('firefox-home-start-sending-files'),
           ga_title='Monitor',
           media_after=True
         ) %}
-        <h4>{{ send_title }}</h4>
+        <h4>{{ ftl('firefox-home-share-large-files-without') }}</h4>
         {% endcall %}
     </div>
 
     <div class="mzp-l-content">
         {% call feature_card(
-        title='Pocket',
+        title=ftl('firefox-home-pocket'),
         heading_level=3,
         image_url='img/firefox/home/master/pocket.svg',
         class='mzp-l-card-feature-left-half t-pocket',
         ga_title='Pocket',
         media_after=True
       ) %}
-      <h4>{{ pocket_title }}</h4>
+      <h4>{{ ftl('firefox-home-trade-clickbait-for') }}</h4>
         <div class="mzp-c-menu-list mzp-t-cta mzp-t-download">
-          <h5 class="mzp-c-menu-list-title">{{ get_app }}</h5>
+          <h5 class="mzp-c-menu-list-title">{{ ftl('firefox-home-download-the-app') }}</h5>
           <ul class="mzp-c-menu-list-list" id="menu-pocket">
-            <li class="mzp-c-menu-list-item"><a href="{{ pocket_adjust_url('android', 'firefox-home') }}" rel="external noopener" data-cta-type="link" data-cta-text="Download Pocket for Android"> {{ get_android }}</a></li>
-            <li class="mzp-c-menu-list-item"><a href="{{ pocket_adjust_url('ios', 'firefox-home') }}" rel="external noopener" data-cta-type="link" data-cta-text="Download Pocket for iOS">{{ get_ios }}</a></li>
+            <li class="mzp-c-menu-list-item"><a href="{{ pocket_adjust_url('android', 'firefox-home') }}" rel="external noopener" data-cta-type="link" data-cta-text="Download Pocket for Android"> {{ ftl('firefox-home-android') }}</a></li>
+            <li class="mzp-c-menu-list-item"><a href="{{ pocket_adjust_url('ios', 'firefox-home') }}" rel="external noopener" data-cta-type="link" data-cta-text="Download Pocket for iOS">{{ ftl('firefox-home-ios') }}</a></li>
           </ul>
         </div>
-        <p><a class="mzp-c-cta-link" href="https://getpocket.com/signup/{{ referrals }}" rel="external noopener" data-cta-type="link" data-cta-text="Download for iOS">{{ pocket_cta }}</a></p>
+        <p><a class="mzp-c-cta-link" href="https://getpocket.com/signup/{{ referrals }}" rel="external noopener" data-cta-type="link" data-cta-text="Download for iOS">{{ ftl('firefox-home-learn-more-about-pocket') }}</a></p>
       {% endcall %}
     </div>
 
@@ -250,48 +211,48 @@
         <div class="c-showcase t-small">
             <ul class="c-showcase-list">
               <li>
-                <a class="mzp-c-cta-link" href="{{ browsers_url }}" data-cta-type="link" data-cta-text="Browsers">
+                <a class="mzp-c-cta-link" href="{{ url('firefox.browsers.index') }}" data-cta-type="link" data-cta-text="Browsers">
                   <img alt="" src="{{ static('protocol/img/logos/firefox/browser/logo-md.png') }}" height="40" width="40"><br>
-                  {{ product_browsers }}
+                  {{ ftl('firefox-home-browsers') }}
                 </a>
               </li>
               <li>
                 <a class="mzp-c-cta-link" href="https://monitor.firefox.com{{ referrals }}" rel="external noopener" data-cta-type="link" data-cta-text="Monitor">
                   <img alt="" src="{{ static('protocol/img/logos/firefox/monitor/logo-md.png') }}" height="40" width="40"><br>
-                  {{ product_monitor }}
+                  {{ ftl('firefox-home-monitor') }}
                 </a>
               </li>
               <li>
                 <a class="mzp-c-cta-link" href="https://send.firefox.com/{{ referrals }}" rel="external noopener" data-cta-type="link" data-cta-text="Send">
                   <img alt="" src="{{ static('protocol/img/logos/firefox/send/logo-md.png') }}" height="40" width="40"><br>
-                  {{ product_send }}
+                  {{ ftl('firefox-home-send') }}
                 </a>
               </li>
               <li>
                 <a class="mzp-c-cta-link" href="{{ url('firefox.lockwise.lockwise') }}{{ referrals }}" rel="external noopener" data-cta-type="link" data-cta-text="Lockwise">
                   <img alt="" src="{{ static('protocol/img/logos/firefox/lockwise/logo-md.png') }}" height="40" width="40"><br>
-                  {{ product_lockwise }}
+                  {{ ftl('firefox-home-lockwise') }}
                 </a>
               </li>
               <li>
                 <a class="mzp-c-cta-link" href="https://getpocket.com{{ referrals }}" rel="external noopener" data-cta-type="link" data-cta-text="Pocket">
                   <img alt="" src="{{ static('img/logos/pocket/logo.svg') }}" height="40" width="40"><br>
-                  {{ product_pocket }}
+                  {{ ftl('firefox-home-pocket') }}
                 </a>
               </li>
             </ul>
         </div>
-        <h2 class="c-end-title">{{ footer_title }}</h2>
+        <h2 class="c-end-title">{{ ftl('firefox-home-one-login-all-your') }}</h2>
         <div class="mzp-c-button-download-container">
           {{ fxa_button(
             entrypoint='mozilla.org-firefox_home',
-            button_text=join_firefox,
+            button_text=ftl('firefox-home-join-firefox'),
             class_name='mzp-t-small',
             optional_parameters={'utm_campaign': 'firefox-home', 'utm_content': 'secondary-join-firefox'},
             optional_attributes={'data-cta-text': 'Join Firefox', 'data-cta-type': 'fxa-sync', 'data-cta-position': 'secondary'}
           ) }}
           <small class="mzp-c-button-download-privacy-link">
-            <a href="{{ url('firefox.accounts') }}">{{ join_learn_more }}</a>
+            <a href="{{ url('firefox.accounts') }}">{{ ftl('firefox-home-learn-more-about-joining') }}</a>
           </small>
         </div>
 

--- a/bedrock/firefox/tests/test_views.py
+++ b/bedrock/firefox/tests/test_views.py
@@ -730,16 +730,20 @@ class TestFirefoxHome(TestCase):
     def test_firefox_home(self, render_mock):
         req = RequestFactory().get('/firefox/')
         req.locale = 'en-US'
-        views.firefox_home(req)
-        render_mock.assert_called_once_with(req, 'firefox/home/index-master.html')
+        view = views.FirefoxHomeView.as_view()
+        view(req)
+        template = render_mock.call_args[0][1]
+        assert template == ['firefox/home/index-master.html']
 
     @patch('bedrock.firefox.views.l10n_utils.render')
-    @patch.object(views, 'lang_file_is_active', lambda *x: False)
+    @patch.object(views, 'ftl_file_is_active', lambda *x: False)
     def test_firefox_home_legacy(self, render_mock):
         req = RequestFactory().get('/firefox/')
         req.locale = 'fr'
-        views.firefox_home(req)
-        render_mock.assert_called_once_with(req, 'firefox/home/index-quantum.html')
+        view = views.FirefoxHomeView.as_view()
+        view(req)
+        template = render_mock.call_args[0][1]
+        assert template == ['firefox/home/index-quantum.html']
 
 
 class TestFirefoxWelcomePage1(TestCase):

--- a/bedrock/firefox/urls.py
+++ b/bedrock/firefox/urls.py
@@ -27,7 +27,7 @@ ios_sysreq_re = sysreq_re.replace(r'firefox', 'firefox/ios')
 
 
 urlpatterns = (
-    url(r'^firefox/$', views.firefox_home, name='firefox'),
+    url(r'^firefox/$', views.FirefoxHomeView.as_view(), name='firefox'),
     url(r'^firefox/all/$', views.firefox_all, name='firefox.all'),
     url(r'^firefox/accounts/$', views.firefox_accounts, name='firefox.accounts'),
     page('firefox/browsers', 'firefox/browsers/index.html'),

--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -807,14 +807,18 @@ class FeaturesPrivateBrowsingView(BlogPostsView):
     template_name = 'firefox/features/private-browsing.html'
 
 
-def firefox_home(request):
-    locale = l10n_utils.get_locale(request)
+class FirefoxHomeView(L10nTemplateView):
+    ftl_files_map = {
+        'firefox/home/index-master.html': ['firefox/home']
+    }
 
-    if lang_file_is_active('firefox/home-master', locale):
-        template_name = 'firefox/home/index-master.html'
-    else:
-        template_name = 'firefox/home/index-quantum.html'
-    return l10n_utils.render(request, template_name)
+    def get_template_names(self):
+        if ftl_file_is_active('firefox/home'):
+            template_name = 'firefox/home/index-master.html'
+        else:
+            template_name = 'firefox/home/index-quantum.html'
+
+        return [template_name]
 
 
 def firefox_accounts(request):

--- a/l10n/en/firefox/home.ftl
+++ b/l10n/en/firefox/home.ftl
@@ -1,0 +1,50 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+### URL: https://www-dev.allizom.org/firefox/
+
+firefox-home-firefox-protect-your = { -brand-name-firefox } - Protect your life online with privacy-first products
+firefox-home-firefox-is-more-than = { -brand-name-firefox } is more than a browser. Learn more about { -brand-name-firefox } products that handle your data with respect and are built for privacy anywhere you go online.
+firefox-home-the-browser-is-just = The browser is just the beginning
+firefox-home-meet-our-family-of = Meet our family of products
+firefox-home-get-trackers-off = Get 2,000+ trackers off your trail — including { -brand-name-facebook }
+firefox-home-know-when-hackers-strike = Know when hackers strike — and stay a step ahead
+firefox-home-start-getting-breach = Start getting breach reports
+firefox-home-keep-your-passwords = Keep your passwords safe on every device
+firefox-home-learn-more-about-lockwise = Learn more about { -brand-name-lockwise }
+
+# The strong tags around "respect" add a special underline. The underline breaks if it is on two words, so please omit the strong tags if they need to be around multiple words in your language.
+firefox-home-get-the-respect-you = Get the <strong>respect</strong> you deserve
+
+firefox-home-every-single-firefox = Every single { -brand-name-firefox } product honors our Personal Data Promise: <strong>Take less. Keep it safe. No secrets.</strong>
+firefox-home-share-large-files-without = Share large files without prying eyes
+firefox-home-start-sending-files = Start sending files safely
+firefox-home-trade-clickbait-for = Trade clickbait for quality content
+firefox-home-learn-more-about-pocket = Learn more about { -brand-name-pocket }
+
+# The strong tags around "privacy" add a special underline. The underline breaks if it is on two words, so please omit the strong tags if they need to be around multiple words in your language.
+firefox-home-one-login-all-your = One login. All your devices. A family of products that respect your <strong>privacy</strong>.
+
+firefox-home-join-firefox = Join { -brand-name-firefox }
+firefox-home-learn-more-about-joining = Learn more about joining { -brand-name-firefox }
+firefox-home-get-the-browser-extension = Get the browser extension
+firefox-home-get-the-facebook-container = Get the { -brand-name-facebook-container } extension
+firefox-home-download-the-browser = Download the browser
+firefox-home-download-the-app = Download the app
+firefox-home-desktop = Desktop
+firefox-home-browsers = Browsers
+firefox-home-android = { -brand-name-android }
+firefox-home-ios = { -brand-name-ios }
+firefox-home-monitor = { -brand-name-monitor }
+firefox-home-lockwise = { -brand-name-lockwise }
+firefox-home-send = { -brand-name-send }
+firefox-home-mozilla = { -brand-name-mozilla }
+firefox-home-pocket = { -brand-name-pocket }
+
+## The strings below are visually hidden in the page and replaced by logo wordmark images. They are still important for a11y and SEO.
+
+firefox-home-firefox-browser = { -brand-name-firefox-browser }
+firefox-home-firefox-monitor = { -brand-name-firefox-monitor }
+firefox-home-firefox-lockwise = { -brand-name-firefox-lockwise }
+firefox-home-firefox-send = { -brand-name-firefox-send }

--- a/lib/fluent_migrations/firefox/home/index-master.py
+++ b/lib/fluent_migrations/firefox/home/index-master.py
@@ -1,0 +1,137 @@
+from __future__ import absolute_import
+import fluent.syntax.ast as FTL
+from fluent.migrate.helpers import transforms_from
+from fluent.migrate.helpers import VARIABLE_REFERENCE, TERM_REFERENCE
+from fluent.migrate import REPLACE, COPY
+
+home_master = "firefox/home-master.lang"
+
+def migrate(ctx):
+    """Migrate bedrock/firefox/templates/firefox/home/index-master.html, part {index}."""
+
+    ctx.add_transforms(
+        "firefox/home.ftl",
+        "firefox/home.ftl",
+        [
+
+            FTL.Message(
+                id=FTL.Identifier("firefox-home-firefox-protect-your"),
+                value=REPLACE(
+                    home_master,
+                    "Firefox - Protect your life online with privacy-first products",
+                    {
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("firefox-home-firefox-is-more-than"),
+                value=REPLACE(
+                    home_master,
+                    "Firefox is more than a browser. Learn more about Firefox products that handle your data with respect and are built for privacy anywhere you go online.",
+                    {
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                    }
+                )
+            ),
+        ] + transforms_from("""
+firefox-home-the-browser-is-just = {COPY(home_master, "The browser is just the beginning",)}
+firefox-home-meet-our-family-of = {COPY(home_master, "Meet our family of products",)}
+""", home_master=home_master) + [
+            FTL.Message(
+                id=FTL.Identifier("firefox-home-get-trackers-off"),
+                value=REPLACE(
+                    home_master,
+                    "Get 2,000+ trackers off your trail — including Facebook",
+                    {
+                        "Facebook": TERM_REFERENCE("brand-name-facebook"),
+                    }
+                )
+            ),
+        ] + transforms_from("""
+firefox-home-know-when-hackers-strike = {COPY(home_master, "Know when hackers strike — and stay a step ahead",)}
+firefox-home-start-getting-breach = {COPY(home_master, "Start getting breach reports",)}
+firefox-home-keep-your-passwords = {COPY(home_master, "Keep your passwords safe on every device",)}
+""", home_master=home_master) + [
+            FTL.Message(
+                id=FTL.Identifier("firefox-home-learn-more-about-lockwise"),
+                value=REPLACE(
+                    home_master,
+                    "Learn more about Lockwise",
+                    {
+                        "Lockwise": TERM_REFERENCE("brand-name-lockwise"),
+                    }
+                )
+            ),
+        ] + transforms_from("""
+firefox-home-get-the-respect-you = {COPY(home_master, "Get the <strong>respect</strong> you deserve",)}
+""", home_master=home_master) + [
+            FTL.Message(
+                id=FTL.Identifier("firefox-home-every-single-firefox"),
+                value=REPLACE(
+                    home_master,
+                    "Every single Firefox product honors our Personal Data Promise: <strong>Take less. Keep it safe. No secrets.</strong>",
+                    {
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                    }
+                )
+            ),
+        ] + transforms_from("""
+firefox-home-share-large-files-without = {COPY(home_master, "Share large files without prying eyes",)}
+firefox-home-start-sending-files = {COPY(home_master, "Start sending files safely",)}
+firefox-home-trade-clickbait-for = {COPY(home_master, "Trade clickbait for quality content",)}
+""", home_master=home_master) + [
+            FTL.Message(
+                id=FTL.Identifier("firefox-home-learn-more-about-pocket"),
+                value=REPLACE(
+                    home_master,
+                    "Learn more about Pocket",
+                    {
+                        "Pocket": TERM_REFERENCE("brand-name-pocket"),
+                    }
+                )
+            ),
+        ] + transforms_from("""
+firefox-home-one-login-all-your = {COPY(home_master, "One login. All your devices. A family of products that respect your <strong>privacy</strong>.",)}
+""", home_master=home_master) + [
+            FTL.Message(
+                id=FTL.Identifier("firefox-home-learn-more-about-joining"),
+                value=REPLACE(
+                    home_master,
+                    "Learn more about joining Firefox",
+                    {
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                    }
+                )
+            ),
+        ] + transforms_from("""
+firefox-home-get-the-browser-extension = {COPY(home_master, "Get the browser extension",)}
+""", home_master=home_master) + [
+            FTL.Message(
+                id=FTL.Identifier("firefox-home-get-the-facebook-container"),
+                value=REPLACE(
+                    home_master,
+                    "Get the Facebook Container extension",
+                    {
+                        "Facebook Container": TERM_REFERENCE("brand-name-facebook-container"),
+                    }
+                )
+            ),
+        ] + transforms_from("""
+firefox-home-download-the-browser = {COPY(home_master, "Download the browser",)}
+firefox-home-download-the-app = {COPY(home_master, "Download the app",)}
+firefox-home-desktop = {COPY(home_master, "Desktop",)}
+firefox-home-browsers = {COPY(home_master, "Browsers",)}
+firefox-home-android = { -brand-name-android }
+firefox-home-ios = { -brand-name-ios }
+firefox-home-monitor = { -brand-name-monitor }
+firefox-home-lockwise = { -brand-name-lockwise }
+firefox-home-send = { -brand-name-send }
+firefox-home-mozilla = { -brand-name-mozilla }
+firefox-home-firefox-browser = { -brand-name-firefox-browser }
+firefox-home-firefox-monitor = { -brand-name-firefox-monitor }
+firefox-home-firefox-lockwise = { -brand-name-firefox-lockwise }
+firefox-home-firefox-send = { -brand-name-firefox-send }
+firefox-home-pocket = { -brand-name-pocket }
+""", home_master=home_master)
+        )


### PR DESCRIPTION
## Description
- Migrates `firefox/home-master.lang` to `firefox/home.ftl`.
- Updates template to use Fluent IDs.

## Issue / Bugzilla link
#8968

## Testing
```
./manage.py l10n_update
```