### PR TITLE
Rename `extraURLCampaignParams` to `extraURLParams` in FxA UITour

### DIFF
--- a/media/js/base/uitour-lib.js
+++ b/media/js/base/uitour-lib.js
@@ -197,17 +197,18 @@ if (typeof window.Mozilla === 'undefined') {
     /**
     * Request the browser open the Firefox Accounts page.
     *
-    * @param {Object} extraURLCampaignParams - An object containing additional
-    * paramaters for the URL opened by the browser for reasons of promotional
+    * @param {Object} extraURLParams - An object containing additional
+    * parameters for the URL opened by the browser for reasons of promotional
     * campaign tracking. Each attribute of the object must have a name that
-    * begins with "utm_" and a value that is a string. The name must contain
-    * only alphanumeric characters, dashes or underscores (meaning
-    * that you are limited to values that don't need encoding, as any such
-    * characters in the name will be rejected.)
+    * is a string, is "flow_id", "flow_begin_time", "device_id" or begins
+    * with `utm_` and contains only only alphanumeric characters, dashes or
+    * underscores. The values may be any string and will automatically be encoded.
+    * For Flow metrics, see details at https://mozilla.github.io/ecosystem-platform/docs/fxa-engineering/fxa-metrics#content-server
+    * @since 79 renamed from `extraURLCampaignParams` to `extraURLParams
    */
-    Mozilla.UITour.showFirefoxAccounts = function(extraURLCampaignParams) {
+    Mozilla.UITour.showFirefoxAccounts = function(extraURLParams) {
         _sendEvent('showFirefoxAccounts', {
-            extraURLCampaignParams: JSON.stringify(extraURLCampaignParams)
+            extraURLParams: JSON.stringify(extraURLParams)
         });
     };
 


### PR DESCRIPTION
Adds `"flow_id", "flow_begin_time", "device_id"` field support

@alexgibson r?

## Description

From Firefox 79 we can now also send "flow_id", "flow_begin_time", "device_id" as part of the UI tour.


## Issue / Bugzilla link

Related to https://bugzilla.mozilla.org/show_bug.cgi?id=1635219
Related to https://bugzilla.mozilla.org/show_bug.cgi?id=1635213
Related to https://github.com/mozilla/bedrock/pull/8914

## Testing

Local testing.





