### PR TITLE
Add vanity redirect for donate.mozilla.org (Fixes #8949)

### DIFF
--- a/bedrock/mozorg/redirects.py
+++ b/bedrock/mozorg/redirects.py
@@ -703,10 +703,10 @@ redirectpatterns = (
     redirect(r'^contact/communities(/.*)?', 'https://community.mozilla.org/groups/'),
 
     # Issue 8641
-    redirect('technology/what-is-a-browser', 'firefox.browsers.what-is-a-browser'),
-    redirect('technology/update-your-browser', 'firefox.browsers.update-browser'),
-    redirect('technology/incognito-browser', 'firefox.browsers.incognito-browser'),
-    redirect('technology/browser-history', 'firefox.browsers.browser-history'),
+    redirect(r'^technology/what-is-a-browser/?$', 'firefox.browsers.what-is-a-browser'),
+    redirect(r'^technology/update-your-browser/?$', 'firefox.browsers.update-browser'),
+    redirect(r'^technology/incognito-browser/?$', 'firefox.browsers.incognito-browser'),
+    redirect(r'^technology/browser-history/?$', 'firefox.browsers.browser-history'),
 
     # Issue 8536
     redirect(r'^etc/firefox/retention(/.*)?', 'firefox.retention.thank-you'),
@@ -719,4 +719,10 @@ redirectpatterns = (
 
     # Issue 8375
     redirect(r'^internet-health(/.*)?', 'https://foundation.mozilla.org/internet-health/'),
+
+    # Issue 8949
+    redirect(r'^donate/?$', 'https://donate.mozilla.org/', query={
+        'utm_source': 'mozilla.org',
+        'utm_content': 'shortlink',
+    }),
 )

--- a/tests/redirects/map_globalconf.py
+++ b/tests/redirects/map_globalconf.py
@@ -1371,4 +1371,7 @@ URLS = flatten((
 
     # Issue 8375
     url_test('/internet-health/{,privacy-security/}', 'https://foundation.mozilla.org/internet-health/'),
+
+    # Issue 8949
+    url_test('/donate/', 'https://donate.mozilla.org/?utm_source=mozilla.org&utm_content=shortlink'),
 ))


### PR DESCRIPTION
## Description
- Adds redirect for `/dontate` to donate.mozilla.org.

## Issue / Bugzilla link
#8949