### PR TITLE
Lazy load smaller icons in Firefox products nav menu (Fix #8981)

### DIFF
--- a/bedrock/base/templates/includes/protocol/navigation/menu-firefox/join.html
+++ b/bedrock/base/templates/includes/protocol/navigation/menu-firefox/join.html
@@ -12,7 +12,7 @@
           <li>
             <section class="mzp-c-menu-item mzp-has-icon">
               <a class="mzp-c-menu-item-link" href="{{ url('firefox.accounts') }}" data-link-name="Join Firefox" data-link-type="nav" data-link-position="topnav" data-link-group="join">
-                <img class="mzp-c-menu-item-icon" src="{{ static('protocol/img/logos/firefox/logo.svg') }}" class="mzp-c-menu-item-icon" alt="" width="24" height="24">
+                <img class="mzp-c-menu-item-icon" src="{{ static('protocol/img/logos/firefox/logo-xs.png') }}" class="mzp-c-menu-item-icon" alt="" width="24" height="24" loading="lazy">
                 <h4 class="mzp-c-menu-item-title">{{ ftl('navigation-join-firefox') }}</h4>
                 <p class="mzp-c-menu-item-desc">{{ ftl('navigation-access-all-of-firefox') }}</p>
               </a>
@@ -44,10 +44,9 @@
           </li>
         </ul>
       </div>
-      <!-- waiting for product page to be ready
       <div class="mzp-c-menu-panel-card">
         <section class="mzp-c-card mzp-c-card-extra-small mzp-has-aspect-16-9">
-          <a class="mzp-c-card-block-link" href="#TKTK" data-link-name="Firefox Family" data-link-type="nav" data-link-position="card" data-link-group="join">
+          <a class="mzp-c-card-block-link" href="{{ url('firefox.products.index') }}" data-link-name="Firefox Family" data-link-type="nav" data-link-position="card" data-link-group="join">
             <div class="mzp-c-card-media-wrapper">
               <img class="mzp-c-card-image" src="{{ static('img/placeholder.png') }}" data-src="{{ static('img/nav/cards/master.jpg') }}" data-srcset="{{ static('img/nav/cards/master-high-res.jpg') }}" alt="">
               <noscript>
@@ -61,7 +60,6 @@
           </a>
         </section>
       </div>
-      -->
     </div><!-- close .mzp-c-menu-panel-container -->
   </div><!-- close .mzp-c-menu-panel -->
 </li><!-- close join -->

--- a/bedrock/base/templates/includes/protocol/navigation/menu-firefox/products.html
+++ b/bedrock/base/templates/includes/protocol/navigation/menu-firefox/products.html
@@ -14,7 +14,7 @@
           <li>
             <section class="mzp-c-menu-item mzp-has-icon">
               <a class="mzp-c-menu-item-link" href="{{ url('firefox.lockwise.lockwise') }}" data-link-name="Lockwise" data-link-type="nav" data-link-position="topnav" data-link-group="products">
-                <img class="mzp-c-menu-item-icon" src="{{ static('protocol/img/logos/firefox/lockwise/logo.svg') }}" class="mzp-c-menu-item-icon" alt="" width="24" height="24">
+                <img class="mzp-c-menu-item-icon" src="{{ static('protocol/img/logos/firefox/lockwise/logo-xs.png') }}" class="mzp-c-menu-item-icon" alt="" width="24" height="24" loading="lazy">
                 <h4 class="mzp-c-menu-item-title">{{ ftl('navigation-firefox-lockwise') }}</h4>
                 <p class="mzp-c-menu-item-desc">{{ ftl('navigation-take-the-passwords-youve') }}</p>
               </a>
@@ -28,7 +28,7 @@
           <li>
             <section class="mzp-c-menu-item mzp-has-icon">
               <a class="mzp-c-menu-item-link" href="https://monitor.firefox.com/{{ referral|safe }}" data-link-name="Monitor" data-link-type="nav" data-link-position="topnav" data-link-group="products">
-                <img class="mzp-c-menu-item-icon" src="{{ static('protocol/img/logos/firefox/monitor/logo.svg') }}" class="mzp-c-menu-item-icon" alt="" width="24" height="24">
+                <img class="mzp-c-menu-item-icon" src="{{ static('protocol/img/logos/firefox/monitor/logo-xs.png') }}" class="mzp-c-menu-item-icon" alt="" width="24" height="24" loading="lazy">
                 <h4 class="mzp-c-menu-item-title">{{ ftl('navigation-firefox-monitor') }}</h4>
                 <p class="mzp-c-menu-item-desc">{{ ftl('navigation-see-if-your-personal') }}</p>
               </a>
@@ -44,7 +44,7 @@
           <li>
             <section class="mzp-c-menu-item mzp-has-icon">
               <a class="mzp-c-menu-item-link" href="https://send.firefox.com/{{ referral|safe }}" data-link-name="Send" data-link-type="nav" data-link-position="topnav" data-link-group="products">
-                <img class="mzp-c-menu-item-icon" src="{{ static('protocol/img/logos/firefox/send/logo.svg') }}" class="mzp-c-menu-item-icon" alt="" width="24" height="24">
+                <img class="mzp-c-menu-item-icon" src="{{ static('protocol/img/logos/firefox/send/logo-xs.png') }}" class="mzp-c-menu-item-icon" alt="" width="24" height="24" loading="lazy">
                 <h4 class="mzp-c-menu-item-title">{{ ftl('navigation-firefox-send') }}</h4>
                 <p class="mzp-c-menu-item-desc">{{ ftl('navigation-share-large-files-safely') }}</p>
               </a>

--- a/bedrock/base/templates/includes/protocol/navigation/menu-mozilla/developers.html
+++ b/bedrock/base/templates/includes/protocol/navigation/menu-mozilla/developers.html
@@ -12,7 +12,7 @@
           <li>
             <section class="mzp-c-menu-item mzp-has-icon">
               <a class="mzp-c-menu-item-link" href="{{ url('firefox.developer.index') }}" data-link-name="Firefox Developer Edition" data-link-type="nav" data-link-position="topnav" data-link-group="developers">
-                <img src="{{ static('protocol/img/logos/firefox/browser/developer/logo-sm.png') }}" class="mzp-c-menu-item-icon" width="24" height="24" alt="">
+                <img src="{{ static('protocol/img/logos/firefox/browser/developer/logo-sm.png') }}" class="mzp-c-menu-item-icon" width="24" height="24" alt="" loading="lazy">
                 <h4 class="mzp-c-menu-item-title">{{ ftl('navigation-firefox-developer-edition') }}</h4>
                 <p class="mzp-c-menu-item-desc">{{ ftl('navigation-firefox-built-just-for') }}</p>
               </a>
@@ -21,7 +21,7 @@
           <li>
             <section class="mzp-c-menu-item mzp-has-icon">
               <a class="mzp-c-menu-item-link" href="{{ url('firefox.channel.desktop') }}#beta" data-link-name="Firefox Beta" data-link-type="nav" data-link-position="topnav" data-link-group="developers">
-                <img src="{{ static('protocol/img/logos/firefox/browser/beta/logo-sm.png') }}" class="mzp-c-menu-item-icon" width="24" height="24" alt="">
+                <img src="{{ static('protocol/img/logos/firefox/browser/beta/logo-sm.png') }}" class="mzp-c-menu-item-icon" width="24" height="24" alt="" loading="lazy">
                 <h4 class="mzp-c-menu-item-title">{{ ftl('navigation-firefox-beta') }}</h4>
                 <p class="mzp-c-menu-item-desc">{{ ftl('navigation-test-soon-to-be-released') }}</p>
               </a>
@@ -30,7 +30,7 @@
           <li>
               <section class="mzp-c-menu-item mzp-has-icon">
                 <a class="mzp-c-menu-item-link" href="{{ url('firefox.channel.desktop') }}#nightly" data-link-name="Firefox Nightly" data-link-type="nav" data-link-position="topnav" data-link-group="developers">
-                  <img src="{{ static('protocol/img/logos/firefox/browser/nightly/logo-sm.png') }}" class="mzp-c-menu-item-icon" width="24" height="24" alt="">
+                  <img src="{{ static('protocol/img/logos/firefox/browser/nightly/logo-sm.png') }}" class="mzp-c-menu-item-icon" width="24" height="24" alt="" loading="lazy">
                   <h4 class="mzp-c-menu-item-title">{{ ftl('navigation-firefox-nightly') }}</h4>
                   <p class="mzp-c-menu-item-desc">{{ ftl('navigation-preview-the-latest-build') }}</p>
                 </a>

--- a/bedrock/base/templates/includes/protocol/navigation/menu-mozilla/firefox.html
+++ b/bedrock/base/templates/includes/protocol/navigation/menu-mozilla/firefox.html
@@ -12,7 +12,7 @@
           <li>
             <section class="mzp-c-menu-item mzp-has-icon">
               <a class="mzp-c-menu-item-link" href="{{ url('firefox.new') }}" data-link-name="Firefox Quantum Desktop Browser" data-link-type="nav" data-link-position="topnav" data-link-group="firefox">
-                <img src="{{ static('protocol/img/logos/firefox/browser/logo-sm.png') }}" class="mzp-c-menu-item-icon" width="24" height="24" alt="">
+                <img src="{{ static('protocol/img/logos/firefox/browser/logo-sm.png') }}" class="mzp-c-menu-item-icon" width="24" height="24" alt="" loading="lazy">
                   <h4 class="mzp-c-menu-item-title">{{ ftl('navigation-firefox-browser-for-desktop') }}</h4>
                 <p class="mzp-c-menu-item-desc">{{ ftl('navigation-get-the-browser-that-gives') }}</p>
               </a>


### PR DESCRIPTION
## Description

- switched to smaller .png files for icons
- added `loading=lazy` to icons
- also found a link to the products page that I uncommented

## Issue / Bugzilla link

Fix #8981 

## Testing

The Firefox menu is only on pages under /firefox.