### PR TITLE
Migrate firefox/browsers to Fluent (#8968)

### DIFF
--- a/bedrock/firefox/templates/firefox/browsers/index.html
+++ b/bedrock/firefox/templates/firefox/browsers/index.html
@@ -2,14 +2,12 @@
  # License, v. 2.0. If a copy of the MPL was not distributed with this
  # file, You can obtain one at http://mozilla.org/MPL/2.0/. #}
 
-{% add_lang_files "firefox/browsers" %}
-
 {% extends "firefox/base/base-protocol.html" %}
 {% from "macros.html" import google_play_button, fxa_email_form with context %}
 {% from "macros-protocol.html" import hero, feature_card with context %}
 
-{% block page_title %}{{ _('Get the browsers that put your privacy first — and always have') }}{% endblock %}
-{% block page_desc %}{{ _('Get the privacy you deserve. Enhanced Tracking Protection is automatic in every Firefox browser.') }}{% endblock %}
+{% block page_title %}{{ ftl('firefox-browsers-get-the-browsers-that-put') }}{% endblock %}
+{% block page_desc %}{{ ftl('firefox-browsers-get-the-privacy-you-deserve') }}{% endblock %}
 
 {% block page_css %}
   {{ css_bundle('firefox-browsers-products') }}
@@ -26,9 +24,8 @@
   <div class="c-block has-media-hide">
     <div class="c-block-container">
       <div class="c-block-body l-v-center">
-        {# L10n: The strong tag wraps a word that gets highlighted with a colorful underline for emphasis. The underline breaks if it is on two words, please omit the strong tags if they need to be around multiple words in your language #}
-        <h1 class="mzp-has-zap-11">{{ _('Get the <strong>browsers</strong> that put your privacy first — and always have') }}</h1>
-        <p>{{ _('Get the privacy you deserve. Enhanced Tracking Protection is automatic in every Firefox browser.') }}</p>
+        <h1 class="mzp-has-zap-11">{{ ftl('firefox-browsers-get-the-browsers-strong') }}</h1>
+        <p>{{ ftl('firefox-browsers-get-the-privacy-you-deserve') }}</p>
       </div>
       <div class="c-block-media l-fit-flush l-constrain-height">
         {{ high_res_img('img/firefox/browsers/hero.jpg', {'alt': '', 'class': 'c-block-media-img'}) }}
@@ -39,17 +36,17 @@
   <div class="mzp-l-content c-landing-grid">
     <div class="c-landing-grid-item">
       {{ high_res_img('img/firefox/browsers/desktop.jpg', {'alt': '', 'class': 'c-landing-grid-img', 'width': '327', 'height': '223'}) }}
-      <h2 class="c-landing-grid-title"><a href="{{ url('firefox.new') }}" data-cta-type="link" data-cta-text="Desktop">{{ _('Desktop') }}</a></h2>
-      <p>{{ _('Seriously private browsing. Firefox automatically blocks 2000+ online trackers from collecting information about what you do online.') }}</p>
+      <h2 class="c-landing-grid-title"><a href="{{ url('firefox.new') }}" data-cta-type="link" data-cta-text="Desktop">{{ ftl('firefox-browsers-desktop') }}</a></h2>
+      <p>{{ ftl('firefox-browsers-seriously-private-browsing') }}</p>
 
       <p id="desktop-download">
         {# Old IE users need to click a download button, the JS on the thank you page doesn't get them the right download if we send them there directly #}
         <!--[if IE]>
-          <a href="{{ url('firefox.new') }}" data-cta-type="link" data-cta-text="Firefox Desktop">{{ _('Download for Desktop') }}</a>
+          <a href="{{ url('firefox.new') }}" data-cta-type="link" data-cta-text="Firefox Desktop">{{ ftl('firefox-browsers-download-for-desktop') }}</a>
         <![endif]-->
         <!--[if !IE]><!-->
           {# Download link should be locale neutral see issue 7982 #}
-          <a id="qa-desktop-download" class="mzp-c-cta-link cta-download" href="/firefox/download/thanks/" data-link-type="Desktop" data-download-os="Desktop" data-download-version="standard">{{ _('Download for Desktop') }}</a></li>
+          <a id="qa-desktop-download" class="mzp-c-cta-link cta-download" href="/firefox/download/thanks/" data-link-type="Desktop" data-download-os="Desktop" data-download-version="standard">{{ ftl('firefox-browsers-download-for-desktop') }}</a></li>
         <!--<![endif]-->
       </p>
 
@@ -57,8 +54,8 @@
     </div>
     <div class="c-landing-grid-item">
       {{ high_res_img('img/firefox/browsers/mobile.jpg', {'alt': '', 'class': 'c-landing-grid-img', 'width': '327', 'height': '223'}) }}
-      <h2 class="c-landing-grid-title "><a class="mzp-c-cta-link" href="{{ url('firefox.mobile.index') }}" data-cta-type="link" data-cta-text="Mobile">{{ _('Mobile') }}</a></h2>
-      <p>{{ _('Take the same level of privacy — plus your passwords, search history, open tabs and more — with you wherever you go.') }}</p>
+      <h2 class="c-landing-grid-title "><a class="mzp-c-cta-link" href="{{ url('firefox.mobile.index') }}" data-cta-type="link" data-cta-text="Mobile">{{ ftl('firefox-browsers-mobile') }}</a></h2>
+      <p>{{ ftl('firefox-browsers-take-the-same-level-of-privacy') }}</p>
 
       <div class="appstore-android">
         {{ google_play_button(href=android_url, id='playStoreLink') }}
@@ -69,32 +66,32 @@
         </a>
       </div>
       <div id="menu-mobile-wrapper"  class="mzp-c-menu-list mzp-t-cta mzp-t-download">
-        <h3 class="mzp-c-menu-list-title">{{ _('Download for Mobile') }}</h3>
+        <h3 class="mzp-c-menu-list-title">{{ ftl('firefox-browsers-download-for-mobile') }}</h3>
         <ul class="mzp-c-menu-list-list" id="menu-mobile">
-          <li class="mzp-c-menu-list-item"><a href="{{ firefox_adjust_url('android', 'firefox_browsers') }}" rel="external noopener" data-link-type="download" data-display-name="Android" data-download-version="android" data-download-os="Android">Android</a></li>
-          <li class="mzp-c-menu-list-item"><a href="{{ firefox_adjust_url('ios', 'firefox_browsers') }}" rel="external noopener" data-link-type="download" data-display-name="iOS" data-download-version="ios" data-download-os="iOS">iOS</a></li>
-          <li class="mzp-c-menu-list-item t-getapp"><a href="{{ url('firefox.mobile.get-app') }}" data-cta-type="link" data-cta-text="Get App Mobile">{{ _('Send me a link') }}</a></li>
+          <li class="mzp-c-menu-list-item"><a href="{{ firefox_adjust_url('android', 'firefox_browsers') }}" rel="external noopener" data-link-type="download" data-display-name="Android" data-download-version="android" data-download-os="Android">{{ ftl('firefox-browsers-android') }}</a></li>
+          <li class="mzp-c-menu-list-item"><a href="{{ firefox_adjust_url('ios', 'firefox_browsers') }}" rel="external noopener" data-link-type="download" data-display-name="iOS" data-download-version="ios" data-download-os="iOS">{{ ftl('firefox-browsers-ios') }}</a></li>
+          <li class="mzp-c-menu-list-item t-getapp"><a href="{{ url('firefox.mobile.get-app') }}" data-cta-type="link" data-cta-text="Get App Mobile">{{ ftl('firefox-browsers-send-me-a-link') }}</a></li>
         </ul>
       </div>
       <p><a class="mzp-c-cta-link" href="{{ url('firefox.mobile.index') }}" data-cta-type="link" data-cta-text="Moblie Learn More">{{ ftl('ui-learn-more') }}</a></p>
     </div>
     <div class="c-landing-grid-item">
       {{ high_res_img('img/firefox/browsers/enterprise.jpg', {'alt': '', 'class': 'c-landing-grid-img', 'width': '327', 'height': '223'}) }}
-      <h2 class="c-landing-grid-title"><a href="{{ url('firefox.enterprise.index') }}" data-cta-type="link" data-cta-text="Enterprise">{{ _('Enterprise') }}</a></h2>
-      <p>{{ _('Get unmatched data protection with support cycles tailored to suit your company’s needs.') }}</p>
-      <p><a class="mzp-c-cta-link" href="{{ url('firefox.enterprise.index') }}#download" data-cta-type="link" data-cta-text="Enterprise packages">{{ _('Enterprise packages') }}</a></p>
+      <h2 class="c-landing-grid-title"><a href="{{ url('firefox.enterprise.index') }}" data-cta-type="link" data-cta-text="Enterprise">{{ ftl('firefox-browsers-enterprise') }}</a></h2>
+      <p>{{ ftl('firefox-browsers-get-unmatched-data-protection') }}</p>
+      <p><a class="mzp-c-cta-link" href="{{ url('firefox.enterprise.index') }}#download" data-cta-type="link" data-cta-text="Enterprise packages">{{ ftl('firefox-browsers-enterprise-packages') }}</a></p>
       <p><a class="mzp-c-cta-link" href="{{ url('firefox.enterprise.index') }}" data-cta-type="link" data-cta-text="Enterprise Learn More">{{ ftl('ui-learn-more') }}</a></p>
     </div>
     <div class="c-landing-grid-item">
       {{ high_res_img('img/firefox/browsers/reality.jpg', {'alt': '', 'class': 'c-landing-grid-img', 'width': '327', 'height': '223'}) }}
-      <h2 class="c-landing-grid-title"><a href="https://mixedreality.mozilla.org/firefox-reality{{ referrals }}" data-cta-type="link" data-cta-text="Reality">{{ _('Reality') }}</a></h2>
-      <p>{{ _('Go beyond two dimensions and enjoy the best immersive content from around the web.') }}</p>
+      <h2 class="c-landing-grid-title"><a href="https://mixedreality.mozilla.org/firefox-reality{{ referrals }}" data-cta-type="link" data-cta-text="Reality">{{ ftl('firefox-browsers-reality') }}</a></h2>
+      <p>{{ ftl('firefox-browsers-go-beyond-two-dimensions-and') }}</p>
       <p><a class="mzp-c-cta-link" href="https://mixedreality.mozilla.org/firefox-reality{{ referrals }}" data-cta-type="link" data-cta-text="Reality Learn More">{{ ftl('ui-learn-more') }}</a></p>
     </div>
     <div class="c-landing-grid-item c-landing-grid-wide">
       <div class="t-dev">
         {% call feature_card(
-          title='Developer Edition',
+          title=ftl('firefox-browsers-developer-edition'),
           heading_level=2,
           image_url='img/firefox/browsers/dev.png',
           include_highres_image=True,
@@ -103,9 +100,8 @@
           link_cta=learn_more,
           ga_title='Developer'
         ) %}
-        {# L10n: The strong tag wraps a word that gets highlighted with a colorful underline for emphasis. The underline breaks if it is on two words, please omit the strong tags if they need to be around multiple words in your language #}
-        <p class="c-dev-title mzp-has-zap-16">{{ _('Build sites and refine your code with Firefox <strong>DevTools</strong>') }}</p>
-        <p><a class="mzp-c-cta-link" href="{{ url('firefox.developer.index') }}" data-cta-type="link" data-cta-text="Developer Learn More">{{ _('Learn more about DevTools') }}</a></p>
+        <p class="c-dev-title mzp-has-zap-16">{{ ftl('firefox-browsers-build-sites-and-refine-your') }}</p>
+        <p><a class="mzp-c-cta-link" href="{{ url('firefox.developer.index') }}" data-cta-type="link" data-cta-text="Developer Learn More">{{ ftl('firefox-browsers-learn-more-about-devtools') }}</a></p>
         {% endcall %}
       </div>
     </div>
@@ -116,7 +112,7 @@
       <div class="fxa-form-cta">
         {{ fxa_email_form(
           entrypoint=_entrypoint,
-          form_title=_('Join Firefox and get the most out of every product — across every device.'),
+          form_title=ftl('firefox-browsers-join-firefox-and-get-the-most'),
           button_class='mzp-c-button mzp-t-product mzp-t-small'
           )
         }}
@@ -124,9 +120,7 @@
           {% set fxa_link = fxa_link_fragment(entrypoint=_entrypoint, action='signin', optional_parameters={'utm_campaign': 'browsers-footer'}) %}
           {% set fxa_attr = fxa_link ~ ' class="js-fxa-cta-link js-fxa-product-button" data-cta-type="link" data-cta-text="FxA Learn More"'|safe %}
           {% set accounts_attr = 'href="'|safe ~ url('firefox.accounts') ~ '"'|safe %}
-          {% trans %}
-            Already have an account? <a {{ fxa_attr }}>Sign In</a> or <a {{ accounts_attr }}>learn more</a> about joining Firefox.
-          {% endtrans %}
+          {{ ftl('firefox-browsers-already-have-an-account-sign') }}
         </p>
       </div>
     </div>

--- a/bedrock/firefox/urls.py
+++ b/bedrock/firefox/urls.py
@@ -30,7 +30,7 @@ urlpatterns = (
     url(r'^firefox/$', views.FirefoxHomeView.as_view(), name='firefox'),
     url(r'^firefox/all/$', views.firefox_all, name='firefox.all'),
     page('firefox/accounts', 'firefox/accounts.html', ftl_files=['firefox/accounts']),
-    page('firefox/browsers', 'firefox/browsers/index.html'),
+    page('firefox/browsers', 'firefox/browsers/index.html', ftl_files=['firefox/browsers']),
     page('firefox/products', 'firefox/products/index.html'),
     page('firefox/campaign', 'firefox/campaign/index.html'),
     page('firefox/flashback', 'firefox/flashback/index.html', active_locales=['en-US', 'de', 'fr']),

--- a/l10n/en/brands.ftl
+++ b/l10n/en/brands.ftl
@@ -52,6 +52,7 @@
 -brand-name-facebook-container = Facebook Container
 -brand-name-firefox-account = Firefox Account
 -brand-name-firefox-accounts = Firefox Accounts
+-brand-name-firefox-devtools = Firefox DevTools
 -brand-name-firefox-lockwise = Firefox Lockwise
 -brand-name-firefox-monitor = Firefox Monitor
 -brand-name-firefox-send = Firefox Send
@@ -59,6 +60,7 @@
 
 ## Firefox products (short names)
 
+-brand-name-devtools = DevTools
 -brand-name-lockwise = Lockwise
 -brand-name-monitor = Monitor
 -brand-name-send = Send

--- a/l10n/en/firefox/browsers.ftl
+++ b/l10n/en/firefox/browsers.ftl
@@ -1,0 +1,42 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+### URL: https://www-dev.allizom.org/firefox/browsers/
+
+# HTML page title
+firefox-browsers-get-the-browsers-that-put = Get the browsers that put your privacy first — and always have
+
+# HTML page description
+firefox-browsers-get-the-privacy-you-deserve = Get the privacy you deserve. Enhanced Tracking Protection is automatic in every { -brand-name-firefox } browser.
+
+# The strong tag wraps a word that gets highlighted with a colorful underline for emphasis. The underline breaks if it is on two words, please omit the strong tags if they need to be around multiple words in your language
+firefox-browsers-get-the-browsers-strong = Get the <strong>browsers</strong> that put your privacy first — and always have
+
+firefox-browsers-desktop = Desktop
+firefox-browsers-seriously-private-browsing = Seriously private browsing. { -brand-name-firefox } automatically blocks 2000+ online trackers from collecting information about what you do online.
+firefox-browsers-download-for-desktop = Download for Desktop
+firefox-browsers-mobile = Mobile
+firefox-browsers-take-the-same-level-of-privacy = Take the same level of privacy — plus your passwords, search history, open tabs and more — with you wherever you go.
+firefox-browsers-download-for-mobile = Download for Mobile
+firefox-browsers-send-me-a-link = Send me a link
+firefox-browsers-enterprise = { -brand-name-enterprise }
+firefox-browsers-get-unmatched-data-protection = Get unmatched data protection with support cycles tailored to suit your company’s needs.
+firefox-browsers-enterprise-packages = { -brand-name-enterprise } packages
+firefox-browsers-reality = { -brand-name-reality }
+firefox-browsers-go-beyond-two-dimensions-and = Go beyond two dimensions and enjoy the best immersive content from around the web.
+
+# The strong tag wraps a word that gets highlighted with a colorful underline for emphasis. The underline breaks if it is on two words, please omit the strong tags if they need to be around multiple words in your language
+firefox-browsers-build-sites-and-refine-your = Build sites and refine your code with { -brand-name-firefox } <strong>{ -brand-name-devtools }</strong>
+
+firefox-browsers-learn-more-about-devtools = Learn more about { -brand-name-devtools }
+firefox-browsers-join-firefox-and-get-the-most = Join { -brand-name-firefox } and get the most out of every product — across every device.
+
+# Variables:
+#   $fxa_attr (string) - anchor link url and attributes
+#   $accounts_attr (string) - anchor link url and attributes
+firefox-browsers-already-have-an-account-sign = Already have an account? <a { $fxa_attr }>Sign In</a> or <a { $accounts_attr }>learn more</a> about joining Firefox.
+
+firefox-browsers-android = { -brand-name-android }
+firefox-browsers-ios = { -brand-name-ios }
+firefox-browsers-developer-edition = { -brand-name-developer-edition }

--- a/lib/fluent_migrations/firefox/browsers/index.py
+++ b/lib/fluent_migrations/firefox/browsers/index.py
@@ -1,0 +1,133 @@
+from __future__ import absolute_import
+import fluent.syntax.ast as FTL
+from fluent.migrate.helpers import transforms_from
+from fluent.migrate.helpers import VARIABLE_REFERENCE, TERM_REFERENCE
+from fluent.migrate import REPLACE, COPY
+
+browsers = "firefox/browsers.lang"
+
+def migrate(ctx):
+    """Migrate bedrock/firefox/templates/firefox/browsers/index.html, part {index}."""
+
+    ctx.add_transforms(
+        "firefox/browsers.ftl",
+        "firefox/browsers.ftl",
+        transforms_from("""
+firefox-browsers-get-the-browsers-that-put = {COPY(browsers, "Get the browsers that put your privacy first — and always have",)}
+""", browsers=browsers) + [
+        FTL.Message(
+            id=FTL.Identifier("firefox-browsers-get-the-privacy-you-deserve"),
+            value=REPLACE(
+                browsers,
+                "Get the privacy you deserve. Enhanced Tracking Protection is automatic in every Firefox browser.",
+                {
+                    "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                }
+            )
+        ),
+    ] + transforms_from("""
+firefox-browsers-get-the-browsers-strong = {COPY(browsers, "Get the <strong>browsers</strong> that put your privacy first — and always have",)}
+firefox-browsers-desktop = {COPY(browsers, "Desktop",)}
+""", browsers=browsers) + [
+        FTL.Message(
+            id=FTL.Identifier("firefox-browsers-seriously-private-browsing"),
+            value=REPLACE(
+                browsers,
+                "Seriously private browsing. Firefox automatically blocks 2000+ online trackers from collecting information about what you do online.",
+                {
+                    "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                }
+            )
+        ),
+    ] + transforms_from("""
+firefox-browsers-download-for-desktop = {COPY(browsers, "Download for Desktop",)}
+firefox-browsers-mobile = {COPY(browsers, "Mobile",)}
+firefox-browsers-take-the-same-level-of-privacy = {COPY(browsers, "Take the same level of privacy — plus your passwords, search history, open tabs and more — with you wherever you go.",)}
+firefox-browsers-download-for-mobile = {COPY(browsers, "Download for Mobile",)}
+firefox-browsers-send-me-a-link = {COPY(browsers, "Send me a link",)}
+""", browsers=browsers) + [
+        FTL.Message(
+            id=FTL.Identifier("firefox-browsers-enterprise"),
+            value=REPLACE(
+                browsers,
+                "Enterprise",
+                {
+                    "Enterprise": TERM_REFERENCE("brand-name-enterprise"),
+                }
+            )
+        ),
+    ] + transforms_from("""
+firefox-browsers-get-unmatched-data-protection = {COPY(browsers, "Get unmatched data protection with support cycles tailored to suit your company’s needs.",)}
+""", browsers=browsers) + [
+        FTL.Message(
+            id=FTL.Identifier("firefox-browsers-enterprise-packages"),
+            value=REPLACE(
+                browsers,
+                "Enterprise packages",
+                {
+                    "Enterprise": TERM_REFERENCE("brand-name-enterprise"),
+                }
+            )
+        ),
+        FTL.Message(
+            id=FTL.Identifier("firefox-browsers-reality"),
+            value=REPLACE(
+                browsers,
+                "Reality",
+                {
+                    "Reality": TERM_REFERENCE("brand-name-reality"),
+                }
+            )
+        ),
+    ] + transforms_from("""
+firefox-browsers-go-beyond-two-dimensions-and = {COPY(browsers, "Go beyond two dimensions and enjoy the best immersive content from around the web.",)}
+""", browsers=browsers) + [
+        FTL.Message(
+            id=FTL.Identifier("firefox-browsers-build-sites-and-refine-your"),
+            value=REPLACE(
+                browsers,
+                "Build sites and refine your code with Firefox <strong>DevTools</strong>",
+                {
+                    "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                    "DevTools": TERM_REFERENCE("brand-name-devtools"),
+                }
+            )
+        ),
+        FTL.Message(
+            id=FTL.Identifier("firefox-browsers-learn-more-about-devtools"),
+            value=REPLACE(
+                browsers,
+                "Learn more about DevTools",
+                {
+                    "DevTools": TERM_REFERENCE("brand-name-devtools"),
+                }
+            )
+        ),
+        FTL.Message(
+            id=FTL.Identifier("firefox-browsers-join-firefox-and-get-the-most"),
+            value=REPLACE(
+                browsers,
+                "Join Firefox and get the most out of every product — across every device.",
+                {
+                    "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                }
+            )
+        ),
+        FTL.Message(
+            id=FTL.Identifier("firefox-browsers-already-have-an-account-sign"),
+            value=REPLACE(
+                browsers,
+                "Already have an account? <a %(fxa_attr)s>Sign In</a> or <a %(accounts_attr)s>learn more</a> about joining Firefox.",
+                {
+                    "%%": "%",
+                    "%(fxa_attr)s": VARIABLE_REFERENCE("fxa_attr"),
+                    "%(accounts_attr)s": VARIABLE_REFERENCE("accounts_attr"),
+                }
+            )
+        ),
+    ] + transforms_from("""
+firefox-browsers-android = { -brand-name-android }
+firefox-browsers-ios = { -brand-name-ios }
+firefox-browsers-developer-edition = { -brand-name-developer-edition }
+""", browsers=browsers)
+    )


### PR DESCRIPTION
## Description
- Migrates `firefox/browsers.lang` to `firefox/browsers.ftl`.
- Updates template to use Fluent IDs.

## Issue / Bugzilla link
#8968

## Testing
```
./manage.py fluent ftl lib/fluent_migrations/firefox/browsers/index.py ach af am an ar ast az azz be bg bn br bs ca cak crh cs cy da de dsb el en-CA en-GB eo es-AR es-CL es-ES es-MX et eu fa ff fi fr fy-NL ga-IE gd gl gn gu-IN he hi-IN hr hsb hto hu hy-AM ia id is it ja ka kab kk km kn ko lij lo lt ltg lv mk ml mr ms my nb-NO ne-NP nl nn-NO nv oc pa-IN pai pbb pl pt-BR pt-PT qvi rm ro ru si sk sl son sq sr sv-SE sw ta te th tl tr trs uk ur uz vi wo xh zam zh-CN zh-TW zu
```