### PR TITLE
Port firefox/products page to Fluent (Fixes #9001)

### DIFF
--- a/bedrock/firefox/templates/firefox/products/index.html
+++ b/bedrock/firefox/templates/firefox/products/index.html
@@ -2,14 +2,12 @@
  # License, v. 2.0. If a copy of the MPL was not distributed with this
  # file, You can obtain one at http://mozilla.org/MPL/2.0/. #}
 
-{% add_lang_files "firefox/products" %}
-
 {% extends "firefox/base/base-protocol.html" %}
 {% from "macros.html" import google_play_button, fxa_email_form with context %}
 {% from "macros-protocol.html" import hero, feature_card with context %}
 
-{% block page_title %}{{ _('Firefox is more than a browser') }}{% endblock %}
-{% block page_desc %}{{ _('It’s a whole family of products designed to keep you safer and smarter online.') }}{% endblock %}
+{% block page_title %}{{ ftl('firefox-products-firefox-is-more-than-a-browser') }}{% endblock %}
+{% block page_desc %}{{ ftl('firefox-products-its-a-whole-family-of-products') }}{% endblock %}
 
 {% block page_css %}
   {{ css_bundle('firefox-browsers-products') }}
@@ -26,9 +24,8 @@
   <div class="c-block has-media-hide t-products">
     <div class="c-block-container">
       <div class="c-block-body l-v-center">
-        {# L10n: The strong tag wraps a word that gets highlighted with a colorful underline for emphasis. The underline breaks if it is on two words, please omit the strong tags if they need to be around multiple words in your language #}
-        <h1 class="mzp-has-zap-14">{{ _('Firefox is <strong>more</strong> than a browser') }}</h1>
-        <p>{{ _('It’s a whole family of products designed to keep you safer and smarter online.') }}</p>
+        <h1 class="mzp-has-zap-14">{{ ftl('firefox-products-firefox-is-more-than-a-browser-emphasis') }}</h1>
+        <p>{{ ftl('firefox-products-its-a-whole-family-of-products') }}</p>
       </div>
       <div class="c-block-media l-fit-flush-top l-constrain-width">
         {{ high_res_img('img/firefox/products/hero.jpg', {'alt': '', 'class': 'c-block-media-img', 'width': '670', 'height': '464'}) }}
@@ -39,12 +36,12 @@
   <div class="mzp-l-content c-landing-grid">
     <div class="c-landing-grid-item">
       <img src="{{ static('img/firefox/products/monitor.svg') }}" class="c-landing-grid-img" alt="" width="316" height="223">
-      <h2 class="c-landing-grid-title"><a href="https://monitor.firefox.com{{ referrals }}" data-cta-type="link" data-cta-text="Firefox Monitor">Firefox Monitor</a></h2>
-      <p>{{ _('See if your personal information has been compromised in a corporate data breach, and sign up for future alerts.') }}</p>
-      <p><a class="mzp-c-cta-link" href="https://monitor.firefox.com/{{ referrals }}" data-cta-type="link" data-cta-text="Check for breaches">{{ _('Check for breaches') }}</a></p>
+      <h2 class="c-landing-grid-title"><a href="https://monitor.firefox.com{{ referrals }}" data-cta-type="link" data-cta-text="Firefox Monitor">{{ ftl('firefox-products-firefox-monitor') }}</a></h2>
+      <p>{{ ftl('firefox-products-see-if-your-personal-information') }}</p>
+      <p><a class="mzp-c-cta-link" href="https://monitor.firefox.com/{{ referrals }}" data-cta-type="link" data-cta-text="Check for breaches">{{ ftl('firefox-products-check-for-breaches') }}</a></p>
       <p id="qa-monitor-button-wrapper">{{ monitor_fxa_button(
         entrypoint='mozilla.org-firefox-products',
-        button_text=_('Sign up for breach alerts'),
+        button_text=ftl('firefox-products-sign-up-for-breach-alerts'),
         class_name='mzp-c-cta-link',
         is_button_class=False,
         optional_parameters={'utm_campaign': 'firefox-products'},
@@ -53,59 +50,59 @@
     </div>
     <div class="c-landing-grid-item">
       {{ high_res_img('img/firefox/products/browsers.jpg', {'alt': '', 'class': 'c-landing-grid-img', 'width': '316', 'height': '223'}) }}
-      <h2 class="c-landing-grid-title "><a class="mzp-c-cta-link" href="{{ url('firefox.browsers.index') }}" data-cta-type="link" data-cta-text="Firefox browsers">{{ _('Firefox browsers') }}</a></h2>
-      <p>{{ _('Get the browsers that block 2000+ data trackers automatically. Enhanced Tracking Protection comes standard in every Firefox browser.') }}</p>
+      <h2 class="c-landing-grid-title "><a class="mzp-c-cta-link" href="{{ url('firefox.browsers.index') }}" data-cta-type="link" data-cta-text="Firefox browsers">{{ ftl('firefox-products-firefox-browsers') }}</a></h2>
+      <p>{{ ftl('firefox-products-get-the-browsers-that-block') }}</p>
       <div id="menu-browsers-wrapper" class="mzp-c-menu-list mzp-t-cta mzp-t-download">
         <h3 class="mzp-c-menu-list-title">{{ ftl('download-button-download') }}</h3>
         <ul class="mzp-c-menu-list-list" id="menu-browsers">
           {# Old IE users need to click a download button, the JS on the thank you page doesn't get them the right download if we send them there directly #}
           <!--[if IE]>
-            <li class="mzp-c-menu-list-item menu-desktop"><a href="{{ url('firefox.new') }}" data-cta-type="link" data-cta-text="Firefox Desktop">{{ _('Desktop') }}</a></li>
+            <li class="mzp-c-menu-list-item menu-desktop"><a href="{{ url('firefox.new') }}" data-cta-type="link" data-cta-text="Firefox Desktop">{{ ftl('firefox-products-desktop') }}</a></li>
           <![endif]-->
           <!--[if !IE]><!-->
             {# Download link should be locale neutral see issue 7982 #}
-            <li class="mzp-c-menu-list-item menu-desktop"><a href="/firefox/download/thanks/" data-link-type="Desktop" data-download-os="Desktop" data-download-version="standard">{{ _('Desktop') }}</a></li>
+            <li class="mzp-c-menu-list-item menu-desktop"><a href="/firefox/download/thanks/" data-link-type="Desktop" data-download-os="Desktop" data-download-version="standard">{{ ftl('firefox-products-desktop') }}</a></li>
           <!--<![endif]-->
-          <li class="mzp-c-menu-list-item menu-android"><a href="{{ firefox_adjust_url('android', 'firefox_home') }}" rel="external noopener" data-link-type="download" data-display-name="Android" data-download-version="android" data-download-os="Android">Android</a></li>
-          <li class="mzp-c-menu-list-item menu-ios"><a href="{{ firefox_adjust_url('ios', 'firefox_home') }}" rel="external noopener" data-link-type="download" data-display-name="iOS" data-download-version="ios" data-download-os="iOS">iOS</a></li>
+          <li class="mzp-c-menu-list-item menu-android"><a href="{{ firefox_adjust_url('android', 'firefox_home') }}" rel="external noopener" data-link-type="download" data-display-name="Android" data-download-version="android" data-download-os="Android">{{ ftl('firefox-products-android') }}</a></li>
+          <li class="mzp-c-menu-list-item menu-ios"><a href="{{ firefox_adjust_url('ios', 'firefox_home') }}" rel="external noopener" data-link-type="download" data-display-name="iOS" data-download-version="ios" data-download-os="iOS">{{ ftl('firefox-products-ios') }}</a></li>
         </ul>
       </div>
-      <p><a class="mzp-c-cta-link" href="{{ url('firefox.browsers.index') }}" data-cta-type="link" data-cta-text="See all browsers">{{ _('See all browsers') }}</a></p>
+      <p><a class="mzp-c-cta-link" href="{{ url('firefox.browsers.index') }}" data-cta-type="link" data-cta-text="See all browsers">{{ ftl('firefox-products-see-all-browsers') }}</a></p>
     </div>
     <div class="c-landing-grid-item">
       <img src="{{ static('img/firefox/products/lockwise.svg') }}" class="c-landing-grid-img" alt="" width="316" height="223">
-      <h2 class="c-landing-grid-title"><a href="{{ url('firefox.lockwise.lockwise') }}" data-cta-type="link" data-cta-text="Firefox Lockwise">Firefox Lockwise</a></h2>
-      <p>{{ _('Keep your passwords safe, and access them across all your synced devices.') }}</p>
+      <h2 class="c-landing-grid-title"><a href="{{ url('firefox.lockwise.lockwise') }}" data-cta-type="link" data-cta-text="Firefox Lockwise">{{ ftl('firefox-products-firefox-lockwise') }}</a></h2>
+      <p>{{ ftl('firefox-products-keep-your-passwords-safe-and') }}</p>
       <div id="menu-lockwise-wrapper"  class="mzp-c-menu-list mzp-t-cta mzp-t-download">
-        <h3 class="mzp-c-menu-list-title">{{ _('Download Lockwise') }}</h3>
+        <h3 class="mzp-c-menu-list-title">{{ ftl('firefox-products-download-lockwise') }}</h3>
         <ul class="mzp-c-menu-list-list" id="menu-lockwise">
-          <li class="mzp-c-menu-list-item hidden" id="js-lockwise-desktop"><button class="c-menu-list-link" id="lockwise-button" data-cta-type="lockwise-open-in-fx" data-cta-position="card" type="button">{{ _('Open in Firefox') }}</button></li>
-          <li class="mzp-c-menu-list-item"><a href="{{ lockwise_adjust_url('android', 'firefox_products') }}" rel="external noopener" data-cta-type="link" data-cta-text="Download Lockwise Android">Android</a></li>
-          <li class="mzp-c-menu-list-item"><a href="{{ lockwise_adjust_url('ios', 'firefox_products') }}" rel="external noopener" data-cta-type="link" data-cta-text="Download Lockwise iOS">iOS</a></li>
+          <li class="mzp-c-menu-list-item hidden" id="js-lockwise-desktop"><button class="c-menu-list-link" id="lockwise-button" data-cta-type="lockwise-open-in-fx" data-cta-position="card" type="button">{{ ftl('firefox-products-open-in-firefox') }}</button></li>
+          <li class="mzp-c-menu-list-item"><a href="{{ lockwise_adjust_url('android', 'firefox_products') }}" rel="external noopener" data-cta-type="link" data-cta-text="Download Lockwise Android">{{ ftl('firefox-products-android') }}</a></li>
+          <li class="mzp-c-menu-list-item"><a href="{{ lockwise_adjust_url('ios', 'firefox_products') }}" rel="external noopener" data-cta-type="link" data-cta-text="Download Lockwise iOS">{{ ftl('firefox-products-ios') }}</a></li>
         </ul>
       </div>
-      <p><a class="mzp-c-cta-link" href="{{ url('firefox.lockwise.lockwise') }}" rel="external noopener" data-cta-type="link" data-cta-text="Lockwise Learn More">{{ _('Learn more about Lockwise') }}</a></p>
+      <p><a class="mzp-c-cta-link" href="{{ url('firefox.lockwise.lockwise') }}" rel="external noopener" data-cta-type="link" data-cta-text="Lockwise Learn More">{{ ftl('firefox-products-learn-more-about-lockwise') }}</a></p>
     </div>
     <div class="c-landing-grid-item">
       <img src="{{ static('img/firefox/products/send.svg') }}" class="c-landing-grid-img" alt="" width="316" height="223">
-      <h2 class="c-landing-grid-title"><a href="https://send.firefox.com{{ referrals }}">Firefox Send</a></h2>
-      <p>{{ _('Send your large files and sensitive documents safely, up to 2.5G.') }}</p>
-      <p><a class="mzp-c-cta-link" href="https://send.firefox.com{{ referrals }}" data-cta-type="link" data-cta-text="Send a file">{{ _('Send a file') }}</a></p>
+      <h2 class="c-landing-grid-title"><a href="https://send.firefox.com{{ referrals }}">{{ ftl('firefox-products-firefox-send') }}</a></h2>
+      <p>{{ ftl('firefox-products-send-your-large-files-and') }}</p>
+      <p><a class="mzp-c-cta-link" href="https://send.firefox.com{{ referrals }}" data-cta-type="link" data-cta-text="Send a file">{{ ftl('firefox-products-send-a-file') }}</a></p>
     </div>
     <div class="c-landing-grid-item">
       <img src="{{ static('img/firefox/products/pocket.svg') }}" class="c-landing-grid-img" alt="" width="316" height="223">
-      <h2 class="c-landing-grid-title"><a href="https://send.firefox.com{{ referrals }}">Pocket</a></h2>
-      <p>{{ _('Discover the best content on the web — and consume it wherever and whenever you want.') }}</p>
+      <h2 class="c-landing-grid-title"><a href="https://send.firefox.com{{ referrals }}">{{ ftl('firefox-products-pocket') }}</a></h2>
+      <p>{{ ftl('firefox-products-discover-the-best-content') }}</p>
       <div id="menu-pocket-wrapper"  class="mzp-c-menu-list mzp-t-cta mzp-t-download">
-        <h3 class="mzp-c-menu-list-title">{{ _('Get Pocket') }}</h3>
+        <h3 class="mzp-c-menu-list-title">{{ ftl('firefox-products-get-pocket') }}</h3>
         <ul class="mzp-c-menu-list-list" id="menu-pocket">
-          <li class="mzp-c-menu-list-item t-web"><a href="https://getpocket.com/firefox_learnmore/{{ referrals }}" rel="external noopener" data-cta-type="link" data-cta-text="Pocket for Desktop">{{ _('Desktop') }}</a></li>
-          <li class="mzp-c-menu-list-item"><a href="{{ pocket_adjust_url('android', 'firefox_products') }}" rel="external noopener" data-cta-type="link" data-cta-text="Download Pocket Android">Android</a></li>
-          <li class="mzp-c-menu-list-item"><a href="{{ pocket_adjust_url('ios', 'firefox_products') }}" rel="external noopener" data-cta-type="link" data-cta-text="Download Pocket iOS">iOS</a></li>
+          <li class="mzp-c-menu-list-item t-web"><a href="https://getpocket.com/firefox_learnmore/{{ referrals }}" rel="external noopener" data-cta-type="link" data-cta-text="Pocket for Desktop">{{ ftl('firefox-products-desktop') }}</a></li>
+          <li class="mzp-c-menu-list-item"><a href="{{ pocket_adjust_url('android', 'firefox_products') }}" rel="external noopener" data-cta-type="link" data-cta-text="Download Pocket Android">{{ ftl('firefox-products-android') }}</a></li>
+          <li class="mzp-c-menu-list-item"><a href="{{ pocket_adjust_url('ios', 'firefox_products') }}" rel="external noopener" data-cta-type="link" data-cta-text="Download Pocket iOS">{{ ftl('firefox-products-ios') }}</a></li>
         </ul>
       </div>
 
-      <p><a class="mzp-c-cta-link" href="https://getpocket.com/firefox_learnmore/{{ referrals }}" rel="external noopener" data-cta-type="link" data-cta-text="Pocket">{{ _('Learn more about Pocket') }}</a></p>
+      <p><a class="mzp-c-cta-link" href="https://getpocket.com/firefox_learnmore/{{ referrals }}" rel="external noopener" data-cta-type="link" data-cta-text="Pocket">{{ ftl('firefox-products-learn-more-about-pocket') }}</a></p>
     </div>
   </div>
 
@@ -114,7 +111,7 @@
       <div class="fxa-form-cta">
         {{ fxa_email_form(
           entrypoint=_entrypoint,
-          form_title=_('Join Firefox and get the most out of every product — across every device.'),
+          form_title=ftl('firefox-products-join-firefox-and-get-the-most'),
           button_class='mzp-c-button mzp-t-product mzp-t-small'
           )
         }}
@@ -122,9 +119,7 @@
           {% set fxa_link = fxa_link_fragment(entrypoint=_entrypoint, action='signin', optional_parameters={'utm_campaign': 'products-footer'}) %}
           {% set fxa_attr = fxa_link ~ ' class="js-fxa-cta-link js-fxa-product-button" data-cta-type="link" data-cta-text="FxA Learn More"'|safe %}
           {% set accounts_attr = 'href="'|safe ~ url('firefox.accounts') ~ '"'|safe %}
-          {% trans %}
-            Already have an account? <a {{ fxa_attr }}>Sign In</a> or <a {{ accounts_attr }}>learn more</a> about joining Firefox.
-          {% endtrans %}
+          {{ ftl('firefox-products-already-have-an-account-sign', fxa_attr=fxa_attr, accounts_attr=accounts_attr) }}
         </p>
       </div>
     </div>

--- a/bedrock/firefox/urls.py
+++ b/bedrock/firefox/urls.py
@@ -32,7 +32,7 @@ urlpatterns = (
     url(r'^firefox/all/$', views.firefox_all, name='firefox.all'),
     page('firefox/accounts', 'firefox/accounts.html', ftl_files=['firefox/accounts']),
     page('firefox/browsers', 'firefox/browsers/index.html', ftl_files=['firefox/browsers']),
-    page('firefox/products', 'firefox/products/index.html'),
+    page('firefox/products', 'firefox/products/index.html', ftl_files=['firefox/products']),
     page('firefox/campaign', 'firefox/campaign/index.html'),
     page('firefox/flashback', 'firefox/flashback/index.html', active_locales=['en-US', 'de', 'fr']),
     page('firefox/channel/desktop', 'firefox/channel/desktop.html'),

--- a/l10n/en/firefox/products.ftl
+++ b/l10n/en/firefox/products.ftl
@@ -1,0 +1,43 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+### URL: https://www-dev.allizom.org/firefox/products/
+
+# HTML page title
+firefox-products-firefox-is-more-than-a-browser = { -brand-name-firefox } is more than a browser
+
+# HTML page description
+firefox-products-its-a-whole-family-of-products = It’s a whole family of products designed to keep you safer and smarter online.
+
+# The strong tag wraps a word that gets highlighted with a colorful underline for emphasis. The underline breaks if it is on two words, please omit the strong tags if they need to be around multiple words in your language
+firefox-products-firefox-is-more-than-a-browser-emphasis = { -brand-name-firefox } is <strong>more</strong> than a browser
+
+firefox-products-firefox-monitor = { -brand-name-firefox-monitor }
+firefox-products-see-if-your-personal-information = See if your personal information has been compromised in a corporate data breach, and sign up for future alerts.
+firefox-products-check-for-breaches = Check for breaches
+firefox-products-sign-up-for-breach-alerts = Sign up for breach alerts
+firefox-products-firefox-browsers = { -brand-name-firefox } browsers
+firefox-products-get-the-browsers-that-block = Get the browsers that block 2000+ data trackers automatically. Enhanced Tracking Protection comes standard in every { -brand-name-firefox } browser.
+firefox-products-desktop = Desktop
+firefox-products-android = { -brand-name-android }
+firefox-products-ios = { -brand-name-ios }
+firefox-products-see-all-browsers = See all browsers
+firefox-products-firefox-lockwise = { -brand-name-firefox-lockwise }
+firefox-products-keep-your-passwords-safe-and = Keep your passwords safe, and access them across all your synced devices.
+firefox-products-download-lockwise = Download { -brand-name-lockwise }
+firefox-products-open-in-firefox = Open in { -brand-name-firefox }
+firefox-products-learn-more-about-lockwise = Learn more about { -brand-name-lockwise }
+firefox-products-firefox-send = { -brand-name-firefox-send }
+firefox-products-send-your-large-files-and = Send your large files and sensitive documents safely, up to 2.5G.
+firefox-products-send-a-file = Send a file
+firefox-products-pocket = { -brand-name-pocket }
+firefox-products-discover-the-best-content = Discover the best content on the web — and consume it wherever and whenever you want.
+firefox-products-get-pocket = Get { -brand-name-pocket }
+firefox-products-learn-more-about-pocket = Learn more about { -brand-name-pocket }
+firefox-products-join-firefox-and-get-the-most = Join { -brand-name-firefox } and get the most out of every product — across every device.
+
+# Variables:
+#   $fxa_attr (string) - anchor link url and attributes
+#   $accounts_attr (string) - anchor link url and attributes
+firefox-products-already-have-an-account-sign = Already have an account? <a { $fxa_attr }>Sign In</a> or <a { $accounts_attr }>learn more</a> about joining { -brand-name-firefox }.

--- a/lib/fluent_migrations/firefox/products/index.py
+++ b/lib/fluent_migrations/firefox/products/index.py
@@ -1,0 +1,154 @@
+from __future__ import absolute_import
+import fluent.syntax.ast as FTL
+from fluent.migrate.helpers import transforms_from
+from fluent.migrate.helpers import VARIABLE_REFERENCE, TERM_REFERENCE
+from fluent.migrate import REPLACE, COPY
+
+products = "firefox/products.lang"
+
+def migrate(ctx):
+    """Migrate bedrock/firefox/templates/firefox/products/index.html, part {index}."""
+
+    ctx.add_transforms(
+        "firefox/products.ftl",
+        "firefox/products.ftl",
+        [
+            FTL.Message(
+                id=FTL.Identifier("firefox-products-firefox-is-more-than-a-browser"),
+                value=REPLACE(
+                    products,
+                    "Firefox is more than a browser",
+                    {
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                    }
+                )
+            ),
+        ] + transforms_from("""
+firefox-products-its-a-whole-family-of-products = {COPY(products, "It’s a whole family of products designed to keep you safer and smarter online.",)}
+""", products=products) + [
+        FTL.Message(
+            id=FTL.Identifier("firefox-products-firefox-is-more-than-a-browser-emphasis"),
+            value=REPLACE(
+                products,
+                "Firefox is <strong>more</strong> than a browser",
+                {
+                    "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                }
+            )
+        ),
+    ] + transforms_from("""
+firefox-products-firefox-monitor = { -brand-name-firefox-monitor }
+firefox-products-see-if-your-personal-information = {COPY(products, "See if your personal information has been compromised in a corporate data breach, and sign up for future alerts.",)}
+firefox-products-check-for-breaches = {COPY(products, "Check for breaches",)}
+firefox-products-sign-up-for-breach-alerts = {COPY(products, "Sign up for breach alerts",)}
+""", products=products) + [
+        FTL.Message(
+            id=FTL.Identifier("firefox-products-firefox-browsers"),
+            value=REPLACE(
+                products,
+                "Firefox browsers",
+                {
+                    "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                }
+            )
+        ),
+        FTL.Message(
+            id=FTL.Identifier("firefox-products-get-the-browsers-that-block"),
+            value=REPLACE(
+                products,
+                "Get the browsers that block 2000+ data trackers automatically. Enhanced Tracking Protection comes standard in every Firefox browser.",
+                {
+                    "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                }
+            )
+        ),
+    ] + transforms_from("""
+firefox-products-desktop = {COPY(products, "Desktop",)}
+firefox-products-android = { -brand-name-android }
+firefox-products-ios = { -brand-name-ios }
+firefox-products-see-all-browsers = {COPY(products, "See all browsers",)}
+firefox-products-firefox-lockwise = { -brand-name-firefox-lockwise }
+firefox-products-keep-your-passwords-safe-and = {COPY(products, "Keep your passwords safe, and access them across all your synced devices.",)}
+""", products=products) + [
+        FTL.Message(
+            id=FTL.Identifier("firefox-products-download-lockwise"),
+            value=REPLACE(
+                products,
+                "Download Lockwise",
+                {
+                    "Lockwise": TERM_REFERENCE("brand-name-lockwise"),
+                }
+            )
+        ),
+        FTL.Message(
+            id=FTL.Identifier("firefox-products-open-in-firefox"),
+            value=REPLACE(
+                products,
+                "Open in Firefox",
+                {
+                    "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                }
+            )
+        ),
+        FTL.Message(
+            id=FTL.Identifier("firefox-products-learn-more-about-lockwise"),
+            value=REPLACE(
+                products,
+                "Learn more about Lockwise",
+                {
+                    "Lockwise": TERM_REFERENCE("brand-name-lockwise"),
+                }
+            )
+        ),
+    ] + transforms_from("""
+firefox-products-firefox-send = { -brand-name-firefox-send }
+firefox-products-send-your-large-files-and = {COPY(products, "Send your large files and sensitive documents safely, up to 2.5G.",)}
+firefox-products-send-a-file = {COPY(products, "Send a file",)}
+firefox-products-pocket = { -brand-name-pocket }
+firefox-products-discover-the-best-content = {COPY(products, "Discover the best content on the web — and consume it wherever and whenever you want.",)}
+""", products=products) + [
+        FTL.Message(
+            id=FTL.Identifier("firefox-products-get-pocket"),
+            value=REPLACE(
+                products,
+                "Get Pocket",
+                {
+                    "Pocket": TERM_REFERENCE("brand-name-pocket"),
+                }
+            )
+        ),
+        FTL.Message(
+            id=FTL.Identifier("firefox-products-learn-more-about-pocket"),
+            value=REPLACE(
+                products,
+                "Learn more about Pocket",
+                {
+                    "Pocket": TERM_REFERENCE("brand-name-pocket"),
+                }
+            )
+        ),
+        FTL.Message(
+            id=FTL.Identifier("firefox-products-join-firefox-and-get-the-most"),
+            value=REPLACE(
+                products,
+                "Join Firefox and get the most out of every product — across every device.",
+                {
+                    "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                }
+            )
+        ),
+        FTL.Message(
+            id=FTL.Identifier("firefox-products-already-have-an-account-sign"),
+            value=REPLACE(
+                products,
+                "Already have an account? <a %(fxa_attr)s>Sign In</a> or <a %(accounts_attr)s>learn more</a> about joining Firefox.",
+                {
+                    "%%": "%",
+                    "%(fxa_attr)s": VARIABLE_REFERENCE("fxa_attr"),
+                    "%(accounts_attr)s": VARIABLE_REFERENCE("accounts_attr"),
+                    "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                }
+            )
+        ),
+    ]
+)


### PR DESCRIPTION
## Description
- Migrates `firefox/products.lang` to `firefox/products.ftl`
- Updates template to use new Fluent IDs.

## Issue / Bugzilla link
#9001

## Testing
```
./manage.py l10n_update
```