### PR TITLE
Add wnp77 moments template experiment. (#8683)

### DIFF
--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx77-b.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx77-b.html
@@ -1,0 +1,77 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+
+{% add_lang_files "firefox/whatsnew_77" %}
+{% extends "firefox/welcome/base.html" %}
+
+{% from "macros-protocol.html" import hero with context %}
+
+{% block page_title %}{{ _('What’s new with Firefox') }}{% endblock %}
+{% block page_desc %}{{ _('Take the next step to protect your privacy online with the Firefox family of products.') }}{% endblock %}
+
+{% block body_class %}{{ super() }} wnp77{% endblock %}
+
+{% block content_intro %}
+  <div class="mzp-c-notification-bar mzp-t-success up-to-date">
+    <p>{{ _('Congrats! You’re using the latest version of Firefox.') }}</p>
+  </div>
+
+  {% call hero(
+    title=_('Picture-in-Picture this'),
+    desc=_('Got things to do and things to watch? Do both with Picture-in-Picture.'),
+    class='mzp-t-firefox mzp-t-dark',
+    include_cta=True,
+    heading_level=1
+  ) %}
+
+  <div class="video-container">
+    <div class="video-content">
+      <a class="video-play js-video-play" href="https://youtu.be/F-nFQryDB0s" data-id="F-nFQryDB0s" data-video-title="Red Panda Cubs - Firefox + Woodland Park Zoo" title="{{ _('Play the video') }}">
+        <img src="{{ static('img/firefox/whatsnew/whatsnew77/video-poster.jpg') }}" alt="">
+      </a>
+    </div>
+  </div>
+
+  <p><strong>{{ _('Try it out with these cuddly red pandas.') }}</strong> {{ _('Press play and hover your cursor over the video. Then click the blue button to pop the video out.') }}</p>
+
+  {% endcall %}
+{% endblock %}
+
+{% block content_secondary %}
+<div class="body-secondary">
+  <h2>{{ _('Ways we’ve been using Picture-in-Picture') }}</h2>
+  <div class="c-picto-block">
+    <div class="c-picto-block-image">
+      <img src="{{ static('img/firefox/whatsnew/whatsnew77/pip-lecture.svg') }}" alt="">
+    </div>
+    <h3 class="c-picto-block-title">{{ _('Watching a lecture or meeting while you take notes') }}</h3>
+  </div>
+
+  <div class="c-picto-block">
+    <div class="c-picto-block-image">
+      <img src="{{ static('img/firefox/whatsnew/whatsnew77/pip-cook.svg') }}" alt="">
+    </div>
+    <h3 class="c-picto-block-title">{{ _('Keeping a tutorial video open with a recipe while you cook or bake') }}</h3>
+  </div>
+
+  <div class="c-picto-block">
+    <div class="c-picto-block-image">
+      <img src="{{ static('img/firefox/whatsnew/whatsnew77/pip-entertain.svg') }}" alt="">
+    </div>
+    <h3 class="c-picto-block-title">{{ _('Entertaining cats, dogs and kids while you get work done') }}</h3>
+  </div>
+</div>
+
+<aside class="c-utilities">
+  <p>
+  {% trans notes=url('firefox.notes') %}
+    Read the <a href="{{ notes }}">Release Notes</a> to know more about what’s new in your Firefox Browser.
+  {% endtrans %}
+  </p>
+</aside>
+{% endblock %}
+
+{% block js %}
+  {{ js_bundle('firefox_whatsnew_77') }}
+{% endblock %}

--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx77.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx77.html
@@ -100,3 +100,11 @@
   {{ js_bundle('firefox_whatsnew_77') }}
 {% endif %}
 {% endblock %}
+
+{% block experiments %}
+  {% if switch('experiment-whatsnew-77', ['en-US']) %}
+    {{ js_bundle('firefox_whatsnew_77_experiment') }}
+  {% endif %}
+{% endblock %}
+
+

--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -560,6 +560,7 @@ class WhatsnewView(L10nTemplateView):
 
     def get_template_names(self):
         locale = l10n_utils.get_locale(self.request)
+        variation = self.request.GET.get('v', None)
 
         version = self.kwargs.get('version') or ''
         oldversion = self.request.GET.get('oldversion', '')
@@ -595,6 +596,8 @@ class WhatsnewView(L10nTemplateView):
             # If we run into bandwidth trouble we can turn the video off and zh-CN falls back to the 76 page.
             if locale == 'zh-CN' and not switch('firefox-whatsnew77-video-zhCN'):
                 template = 'firefox/whatsnew/whatsnew-fx76.html'
+            elif variation == '2' and locale == 'en-US':
+                template = 'firefox/whatsnew/whatsnew-fx77-b.html'
             else:
                 template = 'firefox/whatsnew/whatsnew-fx77.html'
         elif version.startswith('76.') and lang_file_is_active('firefox/whatsnew_76', locale):

--- a/media/css/firefox/welcome.scss
+++ b/media/css/firefox/welcome.scss
@@ -8,6 +8,91 @@ $image-path: '/media/protocol/img';
 @import '../../protocol/css/includes/lib';
 @import '../../protocol/css/components/modal';
 
+//* -------------------------------------------------------------------------- */
+// WNP77 Experiment
+@import '../../protocol/css/components/notification-bar';
+
+.wnp77 {
+    .mzp-c-hero {
+        position: relative;
+
+        .mzp-c-hero-body {
+            margin-top: $layout-sm;
+        }
+    }
+
+    .mzp-c-notification-bar {
+        left: 0;
+        margin-left: auto;
+        margin-right: auto;
+        position: absolute;
+        right: 0;
+        z-index: 2;
+    }
+
+    .body-secondary {
+        padding: $layout-sm 0;
+
+        h2 {
+            @include text-display-sm;
+            text-align: center;
+            margin-bottom: $layout-lg;
+        }
+
+        .c-picto-block {
+            overflow: auto;
+
+            .c-picto-block-image {
+                float: left;
+                margin-right: $layout-sm;
+            }
+        }
+    }
+
+    // Video
+    .video-container {
+        max-width: 500px;
+        margin: 0 auto $spacing-lg;
+    }
+
+    .video-content {
+        @include aspect-ratio(16, 9);
+
+        iframe {
+            height: 100%;
+            width: 100%;
+        }
+
+        .video-play {
+            display: block;
+
+            &:after {
+                background: url('/media/img/icons/video-play.svg') top left no-repeat;
+                content: '';
+                height: 100px;
+                left: 50%;
+                margin: -50px 0 0 -50px;
+                opacity: 0.7;
+                position: absolute;
+                top: 50%;
+                transition: opacity 150ms ease-in-out, transform 150ms ease-in-out;
+                width: 100px;
+                z-index: 2;
+            }
+
+            &:hover:after,
+            &:focus:after {
+                opacity: 1;
+                transform: scale(1.1);
+            }
+        }
+    }
+
+    .moz-video-button {
+        visibility: hidden;
+    }
+
+}
 
 //* -------------------------------------------------------------------------- */
 // Page header
@@ -88,7 +173,8 @@ $image-path: '/media/protocol/img';
     .welcome-page5 &,
     .welcome-page6 &,
     .welcome-page7 &,
-    .welcome-page8 & {
+    .welcome-page8 &,
+    .wnp77 & {
         @include text-title-md;
     }
 

--- a/media/js/firefox/whatsnew/whatsnew-77-exp.js
+++ b/media/js/firefox/whatsnew/whatsnew-77-exp.js
@@ -1,0 +1,43 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+(function (Mozilla) {
+    'use strict';
+
+    /* update dataLayer with experiment info */
+    var href = window.location.href;
+    var platform = window.site.platform;
+    var isMobile = /^(android|ios|fxos)$/.test(platform);
+
+    var initTrafficCop = function () {
+        if (href.indexOf('v=') !== -1) {
+            if (href.indexOf('v=1') !== -1) {
+                window.dataLayer.push({
+                    'data-ex-variant': 'whatsnew-77-control',
+                    'data-ex-name': 'CRO-Whatsnew-77-Experiment'
+                });
+            } else if (href.indexOf('v=2') !== -1) {
+                window.dataLayer.push({
+                    'data-ex-variant': 'whatsnew-77-v1',
+                    'data-ex-name': 'CRO-Whatsnew-77-Experiment'
+                });
+            }
+        } else {
+            var cop = new Mozilla.TrafficCop({
+                id: 'experiment_whatsnew_77',
+                variations: {
+                    'v=1': 2,
+                    'v=2': 2
+                }
+            });
+
+            cop.init();
+        }
+    };
+
+    if (!isMobile) {
+        initTrafficCop();
+    }
+
+})(window.Mozilla);

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -883,6 +883,13 @@
     },
     {
       "files": [
+        "js/libs/mozilla-traffic-cop.js",
+        "js/firefox/whatsnew/whatsnew-77-exp.js"
+      ],
+      "name": "firefox_whatsnew_77_experiment"
+    },
+    {
+      "files": [
         "protocol/js/protocol-newsletter.js"
       ],
       "name": "legal"


### PR DESCRIPTION
## Description

Adds an A/B traffic cop experiment to the whatsnew page for Firefox 77.

[Test plan](https://docs.google.com/document/d/1tAdN48r7BRjosHBXdZTyLl1gwNdkSJC-GNHRBQOHngg/edit?usp=sharing)
_Traffic Distribution Per Group: 2%_

➡️  test plan calls for this experiment to launch friday 6/12

## Issue / Bugzilla link
#8683 

## Testing

- [x] no broken strings.
- [x] video GTM works for both variations.