### PR TITLE
Make ETags weak so that CDN can compress responses

### DIFF
--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -454,6 +454,7 @@ MIDDLEWARE = [
     'django_prometheus.middleware.PrometheusBeforeMiddleware',
     'allow_cidr.middleware.AllowCIDRMiddleware',
     'django.middleware.security.SecurityMiddleware',
+    'bedrock.base.middleware.WeakETagsMiddleware',
     'django.middleware.http.ConditionalGetMiddleware',
     'corsheaders.middleware.CorsMiddleware',
     'bedrock.mozorg.middleware.VaryNoCacheMiddleware',


### PR DESCRIPTION
Making the ETags "weak" was the suggestion we got from CloudFlare that should allow the CDN to do the compression for us, and in a way that respects a clients compression capabilities.

Fix #8983 again

## Testing

Inspecting response headers you should see the `etag` header value start with `W/`.