### PR TITLE
Migrate firefox/privacy pages to Fluent (Fixes #9006)

### DIFF
--- a/bedrock/firefox/templates/firefox/privacy/base.html
+++ b/bedrock/firefox/templates/firefox/privacy/base.html
@@ -2,8 +2,6 @@
  # License, v. 2.0. If a copy of the MPL was not distributed with this
  # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
 
-{% add_lang_files "firefox/privacy-hub" %}
-
 {% extends "firefox/base/base-protocol.html" %}
 
 {% block page_image %}{{ static('img/firefox/template/page-image-master.jpg') }}{% endblock %}
@@ -22,7 +20,7 @@
   {% block hub_content %}{% endblock %}
 
   {{ call_out(
-    title=_('Read the <a href="%s">Privacy Notice</a> for our products')|format(url('privacy.notices.firefox')),
+    title=ftl('firefox-privacy-hub-read-the-privacy-notice-for', url=url('privacy.notices.firefox')),
     class='call-out-privacy')
   }}
 </main>

--- a/bedrock/firefox/templates/firefox/privacy/includes/subnav.html
+++ b/bedrock/firefox/templates/firefox/privacy/includes/subnav.html
@@ -5,20 +5,20 @@
 <nav class="c-sub-navigation">
   <div class="mzp-l-content">
     <div class="c-sub-navigation-content">
-      <h2 class="c-sub-navigation-title">{{ _('Privacy') }}</h2>
+      <h2 class="c-sub-navigation-title">{{ ftl('firefox-privacy-privacy') }}</h2>
       <ul class="c-sub-navigation-list">
         <li class="c-sub-navigation-item privacy-promise">
           {% if active == 'promise' %}
-            {{ _('Our Promise') }}
+            {{ ftl('firefox-privacy-our-promise') }}
           {% else %}
-            <a href="{{ url('firefox.privacy.index') }}">{{ _('Our Promise') }}</a>
+            <a href="{{ url('firefox.privacy.index') }}">{{ ftl('firefox-privacy-our-promise') }}</a>
           {% endif %}
         </li>
         <li class="c-sub-navigation-item privacy-products">
           {% if active == 'products' %}
-            {{ _('Our Products') }}
+            {{ ftl('firefox-privacy-our-products') }}
           {% else %}
-            <a href="{{ url('firefox.privacy.products') }}">{{ _('Our Products') }}</a>
+            <a href="{{ url('firefox.privacy.products') }}">{{ ftl('firefox-privacy-our-products') }}</a>
           {% endif %}
         </li>
       </ul>

--- a/bedrock/firefox/templates/firefox/privacy/index.html
+++ b/bedrock/firefox/templates/firefox/privacy/index.html
@@ -2,14 +2,12 @@
  # License, v. 2.0. If a copy of the MPL was not distributed with this
  # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
 
-{% add_lang_files "firefox/privacy-hub" %}
-
 {% from "macros-protocol.html" import call_out, feature_card, hero, picto_card, hero with context %}
 
 {% extends "firefox/privacy/base.html" %}
 
-{% block page_title_full %}{{_('Firefox Privacy Promise')}}{% endblock %}
-{% block page_desc %}{{_('Firefox takes less data, keeps it safe, and with no secrets.')}}{% endblock %}
+{% block page_title_full %}{{ ftl('firefox-privacy-hub-firefox-privacy-promise') }}{% endblock %}
+{% block page_desc %}{{ ftl('firefox-privacy-hub-firefox-takes-less-data-keeps') }}{% endblock %}
 
 {% block page_css %}
   {{ super() }}
@@ -30,49 +28,41 @@
 {% block hub_content %}
 
   {% call hero(
-    title=_('Firefox products are designed to protect your <strong>privacy</strong>')|safe,
+    title=ftl('firefox-privacy-hub-firefox-products-are-designed')|safe,
     class='privacy-promise-hero mzp-has-image mzp-t-dark',
     image_url='img/firefox/privacy/promise/privacy-hero.png',
     include_highres_image=True,
     include_cta=True,
     heading_level=1
   ) %}
-    <p class="privacy-promise-hero-desc">
-      {{ _('You should be able to decide who sees your personal info. Not just among your friends, but with every advertiser and company on the internet — including us.') }}
-    </p>
+    <p class="privacy-promise-hero-desc">{{ ftl('firefox-privacy-hub-you-should-be-able-to-decide') }}</p>
   {% endcall %}
 
   {{ call_out(
-    title=_('That’s why everything we make and do honors our Personal Data Promise'),
+    title=ftl('firefox-privacy-hub-thats-why-everything-we-make'),
     class='call-out-data-promise')
   }}
 
   <div class="mzp-l-content">
     {% call feature_card(
-      title=_('Take Less'),
+      title=ftl('firefox-privacy-hub-take-less'),
       image_url='img/firefox/privacy/promise/less.jpg',
       include_highres_image=True,
       aspect_ratio='mzp-has-aspect-3-2',
       class='privacy-promise-feature mzp-l-card-feature-right-half'
     ) %}
-      <h3 class="privacy-promise-sub-title">{{ _('We make a point of knowing less about you') }}</h3>
-      <p>
-      {% trans %}
-        All tech companies collect data to improve their products. But it doesn’t need to include
-        so much of your personal info. The only data we want is the data that serves you in the end.
-        We ask ourselves: do we actually need this? What do we need it for? And when can we delete it?
-      {% endtrans %}
-      </p>
+      <h3 class="privacy-promise-sub-title">{{ ftl('firefox-privacy-hub-we-make-a-point-of-knowing') }}</h3>
+      <p>{{ ftl('firefox-privacy-hub-all-tech-companies-collect') }}</p>
     {% endcall %}
 
     {% call feature_card(
-      title=_('Keep it safe'),
+      title=ftl('firefox-privacy-hub-keep-it-safe'),
       image_url='img/firefox/privacy/promise/safe.jpg',
       include_highres_image=True,
       aspect_ratio='mzp-has-aspect-3-2',
       class='privacy-promise-feature mzp-l-card-feature-left-half'
     ) %}
-      <h3 class="privacy-promise-sub-title">{{ _('We do the hard work to protect your personal info') }}</h3>
+      <h3 class="privacy-promise-sub-title">{{ ftl('firefox-privacy-hub-we-do-the-hard-work-to-protect') }}</h3>
       <p>
         {# Our lean-data page is en-US only, so only link to it for English locales. #}
         {% if LANG.startswith('en') %}
@@ -81,31 +71,23 @@
           stop iterating on our processes. We prioritize your privacy. We invest in it. We’re committed
           to it. We even <a href="{{ url('mozorg.about.policy.lean-data.index') }}">teach other companies how to do it</a>.
         {% else %}
-          {% trans %}
-            Data security is complicated — or at least it should be. Which is why we take the extra steps
-            to classify the data we have, maintain rules for how we store and protect each type, and never
-            stop iterating on our processes. We prioritize your privacy. We invest in it. We’re committed
-            to it. We even teach other companies how to do it.
-          {% endtrans %}
+          {{ ftl('firefox-privacy-hub-data-security-is-complicated') }}
         {% endif %}
       </p>
     {% endcall %}
 
     {% call feature_card(
-      title=_('No secrets'),
+      title=ftl('firefox-privacy-hub-no-secrets'),
       image_url='img/firefox/privacy/promise/secrets.jpg',
       include_highres_image=True,
       aspect_ratio='mzp-has-aspect-3-2',
       class='privacy-promise-feature mzp-l-card-feature-right-half'
     ) %}
-      <h3 class="privacy-promise-sub-title">{{ _('You’ll always know where you stand with us') }}</h3>
+      <h3 class="privacy-promise-sub-title">{{ ftl('firefox-privacy-hub-youll-always-know-where-you') }}</h3>
       <p>
-      {% trans privacy=url('privacy.notices.firefox'), meetings='https://wiki.mozilla.org/WeeklyUpdates?utm_source=' ~ _entrypoint ~ '&utm_medium=referral&utm_campaign=' ~ _utm_campaign ~ '&entrypoint=' ~ _entrypoint %}
-        There’s no hidden agenda here. Our business doesn’t depend on secretly abusing your trust.
-        Our <a href="{{ privacy }}">Privacy Notice</a> is actually readable. Anyone in the world can attend
-        our <a href="{{ meetings }}">weekly company meetings</a>. If you want to dig into every datapoint
-        we collect, our code is open. And so are we.
-      {% endtrans %}
+        {{ ftl('firefox-privacy-hub-theres-no-hidden-agenda-here',
+               meetings='https://wiki.mozilla.org/WeeklyUpdates?utm_source=' ~ _entrypoint ~ '&utm_medium=referral&utm_campaign=' ~ _utm_campaign ~ '&entrypoint=' ~ _entrypoint,
+               privacy=url('privacy.notices.firefox')) }}
       </p>
     {% endcall %}
   </div>
@@ -113,26 +95,24 @@
   <div class="privacy-promise-learn-more">
     <ul class="mzp-l-content mzp-l-card-half">
       {% call picto_card(
-        title=_('Why trust Firefox?'),
+        title=ftl('firefox-privacy-hub-why-trust-firefox'),
         class='trust',
         custom_desc=True
       ) %}
         <p>
-        {% trans foundation='https://foundation.mozilla.org/?utm_source=' ~ _entrypoint ~ '&utm_medium=referral&utm_campaign=' ~ _utm_campaign ~ '&entrypoint=' ~ _entrypoint %}
-          Because we put people first. In fact, we’re backed by a <a href="{{ foundation }}">non-profit</a>.
-          From day one, it’s been our mission to protect the internet and everyone on it
-        {% endtrans %}
+          {{ ftl('firefox-privacy-hub-because-we-put-people-first',
+                 foundation='https://foundation.mozilla.org/?utm_source=' ~ _entrypoint ~ '&utm_medium=referral&utm_campaign=' ~ _utm_campaign ~ '&entrypoint=' ~ _entrypoint) }}
         </p>
-        <p><a href="{{ url('mozorg.mission') }}">{{ _('Learn more about our mission') }}</a></p>
+        <p><a href="{{ url('mozorg.mission') }}">{{ ftl('firefox-privacy-hub-learn-more-about-our-mission') }}</a></p>
       {% endcall %}
 
       {% call picto_card(
-        title=_('Your privacy, by the product'),
+        title=ftl('firefox-privacy-hub-your-privacy-by-the-product'),
         class='privacy',
         custom_desc=True
       ) %}
-        <p>{{ _('Firefox products work differently — because they’re designed to protect your privacy first.') }}</p>
-        <p><a href="{{ url('firefox.privacy.products') }}">{{ _('Learn about our products') }}</a></p>
+        <p>{{ ftl('firefox-privacy-hub-firefox-products-work-differently') }}</p>
+        <p><a href="{{ url('firefox.privacy.products') }}">{{ ftl('firefox-privacy-hub-learn-about-our-products') }}</a></p>
       {% endcall %}
     </ul>
   </div>

--- a/bedrock/firefox/templates/firefox/privacy/products.html
+++ b/bedrock/firefox/templates/firefox/privacy/products.html
@@ -2,15 +2,13 @@
  # License, v. 2.0. If a copy of the MPL was not distributed with this
  # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
 
-{% add_lang_files "firefox/privacy-hub" %}
-
 {% from "macros.html" import fxa_email_form with context %}
 {% from "macros-protocol.html" import call_out, feature_card, picto_card, hero with context %}
 
 {% extends "firefox/privacy/base.html" %}
 
-{% block page_title_full %}{{_('Firefox privacy, by the product')}}{% endblock %}
-{% block page_desc %}{{_('Firefox protects your privacy in every product.')}}{% endblock %}
+{% block page_title_full %}{{ ftl('firefox-privacy-hub-firefox-privacy-by-the') }}{% endblock %}
+{% block page_desc %}{{ ftl('firefox-privacy-hub-firefox-protects-your-privacy') }}{% endblock %}
 
 {% block page_css %}
   {{ super() }}
@@ -31,13 +29,13 @@
 {% block hub_content %}
 
   {{ call_out(
-    title=_('Firefox <strong>protects</strong> your privacy in every product')|safe,
+    title=ftl('firefox-privacy-hub-firefox-protects-your-privacy-strong')|safe,
     class='privacy-products-call-out-main',
     heading_level=1)
   }}
 
   {% call hero(
-    title='Firefox Browser',
+    title=ftl('firefox-privacy-hub-firefox-browser'),
     class='privacy-products-hero mzp-has-image mzp-t-dark t-medium',
     image_url='img/firefox/privacy/products/report.svg',
     l10n_image=True,
@@ -45,127 +43,131 @@
     heading_level=2
   ) %}
     <h3 class="privacy-products-hero-sub-title">
-      {% if LANG.startswith('en') %}
-        2000+ trackers blocked — automatically
-      {% else %}
-        {{ _('2,000+ trackers blocked — automatically') }}
-      {% endif %}
+      {{ ftl('firefox-privacy-hub-2000-trackers-blocked-automatically') }}
     </h3>
 
-    <p>
-    {% trans %}
-      Tracking has become an epidemic online: companies follow every move,
-      click and purchase, collecting data to predict and influence what
-      you’ll do next. We think that’s a gross invasion of your privacy.
-      That’s why Firefox mobile and desktop browsers have Enhanced Tracking
-      Protection on by default.
-    {% endtrans %}
-    </p>
+    <p>{{ ftl('firefox-privacy-hub-tracking-has-become-an') }}</p>
 
     <p class="show-mobile hide-from-legacy-ie">
-      <strong>{{ _('If you want to see what Firefox is blocking for you, visit this page on your Firefox desktop browser.') }}</strong>
+      <strong>{{ ftl('firefox-privacy-hub-if-you-want-to-see-what') }}</strong>
     </p>
 
     <p class="show-firefox-desktop-70 hide-from-legacy-ie">
       <a class="mzp-c-cta-link js-open-about-protections" href="https://support.mozilla.org/en-US/kb/enhanced-tracking-protection-firefox-desktop/?utm_source={{ _entrypoint }}&utm_medium=referral&utm_campaign={{ _utm_campaign }}&entrypoint={{ _entrypoint }}">
-        {{ _('See what Firefox has blocked for you') }}
+        {{ ftl('firefox-privacy-hub-see-what-firefox-has-blocked') }}
       </a>
     </p>
 
-    {# L10n: "Enhanced Tracking Protection" is a feature name; it should be capitalized. #}
-    <p class="privacy-products-hero-tagline show-default show-firefox-desktop-old">{{ _('Get Enhanced Tracking Protection') }}</p>
+    <p class="privacy-products-hero-tagline show-default show-firefox-desktop-old">
+      {{ ftl('firefox-privacy-hub-get-enhanced-tracking-protection') }}
+    </p>
 
     <div class="show-default">
-      {{ download_firefox(dom_id='download-button-primary-non-firefox', alt_copy=_('Download the Firefox browser'), download_location='primary cta') }}
+      {{ download_firefox(dom_id='download-button-primary-non-firefox', alt_copy=ftl('firefox-privacy-hub-download-the-firefox-browser'), download_location='primary cta') }}
     </div>
 
     <p class="show-firefox-desktop-old hide-from-legacy-ie">
       <a class="mzp-c-cta-link" href="https://support.mozilla.org/kb/update-firefox-latest-release/?utm_source={{ _entrypoint }}&utm_medium=referral&utm_campaign={{ _utm_campaign }}&entrypoint={{ _entrypoint }}">
-        {{_ ('Update your Firefox browser') }}
+        {{ ftl('firefox-privacy-hub-update-your-firefox-browser') }}
       </a>
     </p>
   {% endcall %}
 
   <div class="privacy-products-etp">
     <ul class="mzp-l-content mzp-l-card-third mzp-t-dark">
-      {{ picto_card(title=_('Invisible to the top trackers'), desc=_('Meet four of the most common categories of trackers — who won’t meet you.'), class='invisible', heading_level=3) }}
-      {{ picto_card(title=_('Always in your control'), desc=_('Want to customize what gets blocked? Your settings are only one click away.'), class='control', heading_level=3) }}
-      {{ picto_card(title=_('Protection beyond tracking'), desc=_('If you have a Firefox account, you can also see how we’re helping you protect your personal info and passwords.'), class='protection', heading_level=3) }}
+      {{ picto_card(title=ftl('firefox-privacy-hub-invisible-to-the-top-trackers'), desc=ftl('firefox-privacy-hub-meet-four-of-the-most-common'), class='invisible', heading_level=3) }}
+      {{ picto_card(title=ftl('firefox-privacy-hub-always-in-your-control'), desc=ftl('firefox-privacy-hub-want-to-customize-what'), class='control', heading_level=3) }}
+      {{ picto_card(title=ftl('firefox-privacy-hub-protection-beyond-tracking'), desc=ftl('firefox-privacy-hub-if-you-have-a-firefox-account'), class='protection', heading_level=3) }}
     </ul>
   </div>
 
-  {# L10n: %s will automatically be replaced by a formatted number e.g. "More than 10,000,000,000 trackers blocked each day" #}
-  {% set trackers_title=_('More than %s trackers blocked each day for Firefox users worldwide')|format(10000000000|l10n_format_number) %}
   {% call call_out(
-    title=trackers_title,
+    title=ftl('firefox-privacy-hub-more-than-s-trackers-blocked', trackers=10000000000),
     class='privacy-products-tracker-counter mzp-t-dark',
     include_cta=True
   ) %}
     <p class="show-firefox-desktop-70 hide-from-legacy-ie">
       <a class="mzp-c-cta-link js-open-about-protections" href="https://support.mozilla.org/kb/enhanced-tracking-protection-firefox-desktop/?utm_source={{ _entrypoint }}&utm_medium=referral&utm_campaign={{ _utm_campaign }}&entrypoint={{ _entrypoint }}">
-        {{ _('See what Firefox has blocked for you') }}
+        {{ ftl('firefox-privacy-hub-see-what-firefox-has-blocked') }}
       </a>
     </p>
 
     <div class="show-default">
-      {{ download_firefox(dom_id='download-button-secondary-non-firefox', alt_copy=_('Download the Firefox browser'), download_location='secondary cta') }}
+      {{ download_firefox(dom_id='download-button-secondary-non-firefox', alt_copy=ftl('firefox-privacy-hub-download-the-firefox-browser'), download_location='secondary cta') }}
     </div>
 
     <p class="show-firefox-desktop-old hide-from-legacy-ie">
-      <a class="mzp-c-cta-link" href="https://support.mozilla.org/kb/update-firefox-latest-release/?utm_source={{ _entrypoint }}&utm_medium=referral&utm_campaign={{ _utm_campaign }}&entrypoint={{ _entrypoint }}">{{_ ('Update your Firefox browser') }}</a>
+      <a class="mzp-c-cta-link" href="https://support.mozilla.org/kb/update-firefox-latest-release/?utm_source={{ _entrypoint }}&utm_medium=referral&utm_campaign={{ _utm_campaign }}&entrypoint={{ _entrypoint }}">
+        {{ ftl('firefox-privacy-hub-update-your-firefox-browser') }}
+      </a>
     </p>
   {% endcall %}
 
   <div class="privacy-products-list t-medium">
     <div class="mzp-l-content">
       {% call feature_card(
-        title='Firefox Monitor',
+        title=ftl('firefox-privacy-hub-firefox-monitor'),
         image_url='img/firefox/privacy/products/monitor.svg',
         class='privacy-products-monitor has-logo mzp-l-card-feature-left-half',
         media_after=True
       ) %}
-        <p>{{ _('When you enter your email address in Firefox Monitor, we forget it immediately after we’ve checked for a match in known data breaches — unless you authorize us to continue monitoring new breaches for your personal information.') }}</p>
-        <p><a class="mzp-c-cta-link" href="https://monitor.firefox.com/?utm_source={{ _entrypoint }}&utm_medium=referral&utm_campaign={{ _utm_campaign }}&entrypoint={{ _entrypoint }}" data-cta-type="fxa-monitor" data-cta-position="secondary">{{ _('Check for breaches') }}</a></p>
+        <p>{{ ftl('firefox-privacy-hub-when-you-enter-your-email') }}</p>
+        <p>
+          <a class="mzp-c-cta-link" href="https://monitor.firefox.com/?utm_source={{ _entrypoint }}&utm_medium=referral&utm_campaign={{ _utm_campaign }}&entrypoint={{ _entrypoint }}" data-cta-type="fxa-monitor" data-cta-position="secondary">
+          {{ ftl('firefox-privacy-hub-check-for-breaches') }}
+          </a>
+        </p>
       {% endcall %}
 
       {% call feature_card(
-        title='Firefox Lockwise',
+        title=ftl('firefox-privacy-hub-firefox-lockwise'),
         image_url='img/firefox/privacy/products/lockwise.svg',
         class='privacy-products-lockwise has-logo mzp-l-card-feature-right-half',
         media_after=True
       ) %}
-        <p>{{ _('The passwords and credentials you save in Firefox Lockwise are encrypted on all your devices, so not even we can see them.') }}</p>
-        {# L10n: "Lockwise" is a proper name; it should be capitalized and should not be translated. #}
-        <p><a class="mzp-c-cta-link" href="{{ url('firefox.lockwise.lockwise' )}}" data-cta-type="fxa-lockwise" data-cta-position="secondary">{{ _('Learn more about Lockwise') }}</a></p>
+        <p>{{ ftl('firefox-privacy-hub-the-passwords-and-credentials') }}</p>
+        <p>
+          <a class="mzp-c-cta-link" href="{{ url('firefox.lockwise.lockwise' )}}" data-cta-type="fxa-lockwise" data-cta-position="secondary">
+            {{ ftl('firefox-privacy-hub-learn-more-about-lockwise') }}
+          </a>
+        </p>
       {% endcall %}
 
       {% call feature_card(
-        title='Firefox Send',
+        title=ftl('firefox-privacy-hub-firefox-send'),
         image_url='img/firefox/privacy/products/send.svg',
         class='privacy-products-send has-logo mzp-l-card-feature-left-half',
         media_after=True
       ) %}
-        <p>{{ _('We can’t see the names or content of the large files you share through Firefox Send because they’re encrypted end-to-end — you choose who sees what you send, and you can even set an expiration date and password.') }}</p>
-        <p><a class="mzp-c-cta-link" href="https://send.firefox.com/?utm_source={{ _entrypoint }}&utm_medium=referral&utm_campaign={{ _utm_campaign }}&entrypoint={{ _entrypoint }}" data-cta-type="fxa-send" data-cta-position="secondary">{{ _('Send a file') }}</a></p>
+        <p>{{ ftl('firefox-privacy-hub-we-cant-see-the-names-or') }}</p>
+        <p>
+          <a class="mzp-c-cta-link" href="https://send.firefox.com/?utm_source={{ _entrypoint }}&utm_medium=referral&utm_campaign={{ _utm_campaign }}&entrypoint={{ _entrypoint }}" data-cta-type="fxa-send" data-cta-position="secondary">
+            {{ ftl('firefox-privacy-hub-send-a-file') }}
+          </a>
+        </p>
       {% endcall %}
 
       {% call feature_card(
-        title='Pocket',
+        title=ftl('firefox-privacy-hub-pocket'),
         image_url='img/firefox/privacy/products/pocket.png',
         include_highres_image=True,
         class='privacy-products-pocket has-logo mzp-l-card-feature-right-half',
         media_after=True
       ) %}
-        <p>{{ _('Pocket recommends high-quality, human-curated articles without collecting your browsing history or sharing your personal information with advertisers.') }}</p>
-        <p><a class="mzp-c-cta-link" href="https://getpocket.com/firefox_learnmore/?utm_source={{ _entrypoint }}&utm_medium=referral&utm_campaign={{ _utm_campaign }}&entrypoint={{ _entrypoint }}" data-cta-type="pocket" data-cta-position="secondary">{{ _('Get Pocket') }}</a></p>
+        <p>{{ ftl('firefox-privacy-hub-pocket-recommends-high') }}</p>
+        <p>
+          <a class="mzp-c-cta-link" href="https://getpocket.com/firefox_learnmore/?utm_source={{ _entrypoint }}&utm_medium=referral&utm_campaign={{ _utm_campaign }}&entrypoint={{ _entrypoint }}" data-cta-type="pocket" data-cta-position="secondary">
+            {{ ftl('firefox-privacy-hub-get-pocket') }}
+          </a>
+        </p>
       {% endcall %}
 
       <section class="privacy-products-accounts mzp-c-card-feature mzp-l-card-feature-left-half">
         <div class="mzp-c-card-feature-content">
           <div class="mzp-c-card-feature-content-container">
-            <h2 class="mzp-c-card-feature-title">{{ _('Your Firefox account') }}</h2>
+            <h2 class="mzp-c-card-feature-title">{{ ftl('firefox-privacy-hub-your-firefox-account') }}</h2>
             <div class="mzp-c-card-feature-desc">
-              {{ _('All the information synced through your Firefox account — from browser history to passwords — is encrypted. And your account password is the only key.') }}
+              {{ ftl('firefox-privacy-hub-all-the-information-synced') }}
             </div>
           </div>
         </div>
@@ -174,18 +176,17 @@
             <div class="mzp-c-emphasis-box">
               {{ fxa_email_form(
                 entrypoint=_entrypoint,
-                form_title=_('Take your privacy and bookmarks everywhere with a Firefox account.'),
+                form_title=ftl('firefox-privacy-hub-take-your-privacy-and-bookmarks'),
                 button_class='mzp-c-button mzp-t-primary mzp-t-product',
                 style='trailhead',
                 utm_campaign=_utm_campaign)
               }}
 
               <p class="fxa-signin">
-              {% trans sign_in=fxa_link_fragment(entrypoint=_entrypoint, action='signin', optional_parameters={'utm_campaign': _utm_campaign}),
-                       class_name='js-fxa-cta-link js-fxa-product-button',
-                       learn_more=url('firefox.accounts') %}
-                Already have an account? <a {{ sign_in }} class="{{ class_name }}">Sign In</a> or <a href="{{ learn_more }}">learn more</a> about joining Firefox.
-              {% endtrans %}
+              {{ ftl('firefox-privacy-hub-already-have-an-account',
+                     sign_in=fxa_link_fragment(entrypoint=_entrypoint, action='signin', optional_parameters={'utm_campaign': _utm_campaign}),
+                     class_name='js-fxa-cta-link js-fxa-product-button',
+                     learn_more=url('firefox.accounts') )}}
               </p>
             </div>
           </div>

--- a/bedrock/firefox/urls.py
+++ b/bedrock/firefox/urls.py
@@ -143,8 +143,8 @@ urlpatterns = (
     page('firefox/lockwise', 'firefox/lockwise/lockwise.html'),
 
     # Issue 7765, 7709
-    page('firefox/privacy', 'firefox/privacy/index.html'),
-    page('firefox/privacy/products', 'firefox/privacy/products.html'),
+    page('firefox/privacy', 'firefox/privacy/index.html', ftl_files=['firefox/privacy-hub']),
+    page('firefox/privacy/products', 'firefox/privacy/products.html', ftl_files=['firefox/privacy-hub']),
 
     # Issue 8432
     page('firefox/set-as-default/thanks', 'firefox/set-as-default/thanks.html'),

--- a/l10n/en/firefox/privacy-hub.ftl
+++ b/l10n/en/firefox/privacy-hub.ftl
@@ -1,0 +1,103 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+### URL: https://www-dev.allizom.org/firefox/privacy/
+
+# HTML page title
+firefox-privacy-hub-firefox-privacy-promise = { -brand-name-firefox } Privacy Promise
+
+# HTML page description
+firefox-privacy-hub-firefox-takes-less-data-keeps = { -brand-name-firefox } takes less data, keeps it safe, and with no secrets.
+
+# The strong tag wraps a word that gets highlighted with a colorful underline for emphasis. The underline breaks if it is on two words, please omit the strong tags if they need to be around multiple words in your language
+firefox-privacy-hub-firefox-products-are-designed = { -brand-name-firefox } products are designed to protect your <strong>privacy</strong>
+
+# Sub navigation title
+firefox-privacy-privacy = Privacy
+
+# Sub navigation link
+firefox-privacy-our-promise = Our Promise
+
+# Sub navigation link
+firefox-privacy-our-products = Our Products
+
+firefox-privacy-hub-you-should-be-able-to-decide = You should be able to decide who sees your personal info. Not just among your friends, but with every advertiser and company on the internet — including us.
+firefox-privacy-hub-thats-why-everything-we-make = That’s why everything we make and do honors our Personal Data Promise
+firefox-privacy-hub-take-less = Take Less
+firefox-privacy-hub-we-make-a-point-of-knowing = We make a point of knowing less about you
+firefox-privacy-hub-all-tech-companies-collect = All tech companies collect data to improve their products. But it doesn’t need to include so much of your personal info. The only data we want is the data that serves you in the end. We ask ourselves: do we actually need this? What do we need it for? And when can we delete it?
+firefox-privacy-hub-keep-it-safe = Keep it safe
+firefox-privacy-hub-we-do-the-hard-work-to-protect = We do the hard work to protect your personal info
+firefox-privacy-hub-data-security-is-complicated = Data security is complicated — or at least it should be. Which is why we take the extra steps to classify the data we have, maintain rules for how we store and protect each type, and never stop iterating on our processes. We prioritize your privacy. We invest in it. We’re committed to it. We even teach other companies how to do it.
+firefox-privacy-hub-no-secrets = No secrets
+firefox-privacy-hub-youll-always-know-where-you = You’ll always know where you stand with us
+
+# Variables:
+#   $privacy (url) - link to https://www.mozilla.org/privacy/firefox/
+#   $meetings (url) - link to https://wiki.mozilla.org/
+firefox-privacy-hub-theres-no-hidden-agenda-here = There’s no hidden agenda here. Our business doesn’t depend on secretly abusing your trust. Our <a href="{ $privacy }">Privacy Notice</a> is actually readable. Anyone in the world can attend our <a href="{ $meetings }">weekly company meetings</a>. If you want to dig into every datapoint we collect, our code is open. And so are we.
+
+firefox-privacy-hub-why-trust-firefox = Why trust { -brand-name-firefox }?
+
+# Variables:
+#   $foundation (url) - link to https://foundation.mozilla.org/
+firefox-privacy-hub-because-we-put-people-first = Because we put people first. In fact, we’re backed by a <a href="{ $foundation }">non-profit</a>. From day one, it’s been our mission to protect the internet and everyone on it.
+
+firefox-privacy-hub-learn-more-about-our-mission = Learn more about our mission
+firefox-privacy-hub-your-privacy-by-the-product = Your privacy, by the product
+firefox-privacy-hub-firefox-products-work-differently = { -brand-name-firefox } products work differently — because they’re designed to protect your privacy first.
+firefox-privacy-hub-learn-about-our-products = Learn about our products
+firefox-privacy-hub-firefox-privacy-by-the = { -brand-name-firefox } privacy, by the product
+firefox-privacy-hub-firefox-protects-your-privacy = { -brand-name-firefox } protects your privacy in every product.
+firefox-privacy-hub-firefox-protects-your-privacy-strong = { -brand-name-firefox } <strong>protects</strong> your privacy in every product
+firefox-privacy-hub-firefox-browser = { -brand-name-firefox-browser }
+firefox-privacy-hub-2000-trackers-blocked-automatically = 2,000+ trackers blocked — automatically
+
+# "Enhanced Tracking Protection" is a feature name; it should be capitalized
+firefox-privacy-hub-tracking-has-become-an = Tracking has become an epidemic online: companies follow every move, click and purchase, collecting data to predict and influence what you’ll do next. We think that’s a gross invasion of your privacy. That’s why { -brand-name-firefox } mobile and desktop browsers have Enhanced Tracking Protection on by default.
+
+firefox-privacy-hub-if-you-want-to-see-what = If you want to see what { -brand-name-firefox } is blocking for you, visit this page on your { -brand-name-firefox } desktop browser.
+firefox-privacy-hub-see-what-firefox-has-blocked = See what { -brand-name-firefox } has blocked for you
+
+# "Enhanced Tracking Protection" is a feature name; it should be capitalized
+firefox-privacy-hub-get-enhanced-tracking-protection = Get Enhanced Tracking Protection
+
+firefox-privacy-hub-download-the-firefox-browser = Download the { -brand-name-firefox } browser
+firefox-privacy-hub-update-your-firefox-browser = Update your { -brand-name-firefox } browser
+firefox-privacy-hub-invisible-to-the-top-trackers = Invisible to the top trackers
+firefox-privacy-hub-meet-four-of-the-most-common = Meet four of the most common categories of trackers — who won’t meet you.
+firefox-privacy-hub-always-in-your-control = Always in your control
+firefox-privacy-hub-want-to-customize-what = Want to customize what gets blocked? Your settings are only one click away.
+firefox-privacy-hub-protection-beyond-tracking = Protection beyond tracking
+firefox-privacy-hub-if-you-have-a-firefox-account = If you have a { -brand-name-firefox-account }, you can also see how we’re helping you protect your personal info and passwords.
+
+# Variables:
+#   $trackers (number) - localized number total of trackers blocked by Firefox users worldwide
+firefox-privacy-hub-more-than-s-trackers-blocked = More than { $trackers } trackers blocked each day for { -brand-name-firefox } users worldwide
+
+firefox-privacy-hub-firefox-monitor = { -brand-name-firefox-monitor }
+firefox-privacy-hub-when-you-enter-your-email = When you enter your email address in { -brand-name-firefox-monitor }, we forget it immediately after we’ve checked for a match in known data breaches — unless you authorize us to continue monitoring new breaches for your personal information.
+firefox-privacy-hub-check-for-breaches = Check for breaches
+firefox-privacy-hub-firefox-lockwise = { -brand-name-firefox-lockwise }
+firefox-privacy-hub-the-passwords-and-credentials = The passwords and credentials you save in { -brand-name-firefox-lockwise } are encrypted on all your devices, so not even we can see them.
+firefox-privacy-hub-learn-more-about-lockwise = Learn more about { -brand-name-lockwise }
+firefox-privacy-hub-firefox-send = { -brand-name-firefox-send }
+firefox-privacy-hub-we-cant-see-the-names-or = We can’t see the names or content of the large files you share through { -brand-name-firefox-send } because they’re encrypted end-to-end — you choose who sees what you send, and you can even set an expiration date and password.
+firefox-privacy-hub-send-a-file = Send a file
+firefox-privacy-hub-pocket = { -brand-name-pocket }
+firefox-privacy-hub-pocket-recommends-high = { -brand-name-pocket } recommends high-quality, human-curated articles without collecting your browsing history or sharing your personal information with advertisers.
+firefox-privacy-hub-get-pocket = Get { -brand-name-pocket }
+firefox-privacy-hub-your-firefox-account = Your { -brand-name-firefox-account }
+firefox-privacy-hub-all-the-information-synced = All the information synced through your { -brand-name-firefox-account } — from browser history to passwords — is encrypted. And your account password is the only key.
+firefox-privacy-hub-take-your-privacy-and-bookmarks = Take your privacy and bookmarks everywhere with a { -brand-name-firefox-account }.
+
+# Variables:
+#   $signin (string) - anchor link url and attributes
+#   $class_name (string) - CSS class name for sign in link
+#   $learn_more (url) - link to https://www.mozilla.org/firefox/accounts/
+firefox-privacy-hub-already-have-an-account = Already have an account? <a { $sign_in } class="{ $class_name }">Sign In</a> or <a href="{ $learn_more }">learn more</a> about joining { -brand-name-firefox }.
+
+# Variables:
+#   $url (url) - link to https://www.mozilla.org/privacy/firefox/
+firefox-privacy-hub-read-the-privacy-notice-for = Read the <a href="{ $url }">Privacy Notice</a> for our products

--- a/lib/fluent_migrations/firefox/privacy.py
+++ b/lib/fluent_migrations/firefox/privacy.py
@@ -1,0 +1,361 @@
+from __future__ import absolute_import
+import fluent.syntax.ast as FTL
+from fluent.migrate.helpers import transforms_from
+from fluent.migrate.helpers import VARIABLE_REFERENCE, TERM_REFERENCE
+from fluent.migrate import REPLACE, COPY
+
+privacy_hub = "firefox/privacy-hub.lang"
+
+def migrate(ctx):
+    """Migrate bedrock/firefox/templates/firefox/privacy/base.html, part {index}."""
+
+    ctx.add_transforms(
+        "firefox/privacy-hub.ftl",
+        "firefox/privacy-hub.ftl",
+        [
+            FTL.Message(
+                id=FTL.Identifier("firefox-privacy-hub-firefox-privacy-promise"),
+                value=REPLACE(
+                    privacy_hub,
+                    "Firefox Privacy Promise",
+                    {
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("firefox-privacy-hub-firefox-takes-less-data-keeps"),
+                value=REPLACE(
+                    privacy_hub,
+                    "Firefox takes less data, keeps it safe, and with no secrets.",
+                    {
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("firefox-privacy-hub-firefox-products-are-designed"),
+                value=REPLACE(
+                    privacy_hub,
+                    "Firefox products are designed to protect your <strong>privacy</strong>",
+                    {
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                    }
+                )
+            ),
+        ] + transforms_from("""
+firefox-privacy-privacy = {COPY(privacy_hub, "Privacy",)}
+firefox-privacy-our-promise = {COPY(privacy_hub, "Our Promise",)}
+firefox-privacy-our-products = {COPY(privacy_hub, "Our Products",)}
+firefox-privacy-hub-you-should-be-able-to-decide = {COPY(privacy_hub, "You should be able to decide who sees your personal info. Not just among your friends, but with every advertiser and company on the internet — including us.",)}
+firefox-privacy-hub-thats-why-everything-we-make = {COPY(privacy_hub, "That’s why everything we make and do honors our Personal Data Promise",)}
+firefox-privacy-hub-take-less = {COPY(privacy_hub, "Take Less",)}
+firefox-privacy-hub-we-make-a-point-of-knowing = {COPY(privacy_hub, "We make a point of knowing less about you",)}
+firefox-privacy-hub-all-tech-companies-collect = {COPY(privacy_hub, "All tech companies collect data to improve their products. But it doesn’t need to include so much of your personal info. The only data we want is the data that serves you in the end. We ask ourselves: do we actually need this? What do we need it for? And when can we delete it?",)}
+firefox-privacy-hub-keep-it-safe = {COPY(privacy_hub, "Keep it safe",)}
+firefox-privacy-hub-we-do-the-hard-work-to-protect = {COPY(privacy_hub, "We do the hard work to protect your personal info",)}
+firefox-privacy-hub-data-security-is-complicated = {COPY(privacy_hub, "Data security is complicated — or at least it should be. Which is why we take the extra steps to classify the data we have, maintain rules for how we store and protect each type, and never stop iterating on our processes. We prioritize your privacy. We invest in it. We’re committed to it. We even teach other companies how to do it.",)}
+firefox-privacy-hub-no-secrets = {COPY(privacy_hub, "No secrets",)}
+firefox-privacy-hub-youll-always-know-where-you = {COPY(privacy_hub, "You’ll always know where you stand with us",)}
+""", privacy_hub=privacy_hub) + [
+            FTL.Message(
+                id=FTL.Identifier("firefox-privacy-hub-theres-no-hidden-agenda-here"),
+                value=REPLACE(
+                    privacy_hub,
+                    "There’s no hidden agenda here. Our business doesn’t depend on secretly abusing your trust. Our <a href=\"%(privacy)s\">Privacy Notice</a> is actually readable. Anyone in the world can attend our <a href=\"%(meetings)s\">weekly company meetings</a>. If you want to dig into every datapoint we collect, our code is open. And so are we.",
+                    {
+                        "%%": "%",
+                        "%(privacy)s": VARIABLE_REFERENCE("privacy"),
+                        "%(meetings)s": VARIABLE_REFERENCE("meetings"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("firefox-privacy-hub-why-trust-firefox"),
+                value=REPLACE(
+                    privacy_hub,
+                    "Why trust Firefox?",
+                    {
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("firefox-privacy-hub-because-we-put-people-first"),
+                value=REPLACE(
+                    privacy_hub,
+                    "Because we put people first. In fact, we’re backed by a <a href=\"%(foundation)s\">non-profit</a>. From day one, it’s been our mission to protect the internet and everyone on it",
+                    {
+                        "%%": "%",
+                        "%(foundation)s": VARIABLE_REFERENCE("foundation"),
+                    }
+                )
+            ),
+        ] + transforms_from("""
+firefox-privacy-hub-learn-more-about-our-mission = {COPY(privacy_hub, "Learn more about our mission",)}
+firefox-privacy-hub-your-privacy-by-the-product = {COPY(privacy_hub, "Your privacy, by the product",)}
+""", privacy_hub=privacy_hub) + [
+            FTL.Message(
+                id=FTL.Identifier("firefox-privacy-hub-firefox-products-work-differently"),
+                value=REPLACE(
+                    privacy_hub,
+                    "Firefox products work differently — because they’re designed to protect your privacy first.",
+                    {
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                    }
+                )
+            ),
+        ] + transforms_from("""
+firefox-privacy-hub-learn-about-our-products = {COPY(privacy_hub, "Learn about our products",)}
+""", privacy_hub=privacy_hub) + [
+            FTL.Message(
+                id=FTL.Identifier("firefox-privacy-hub-firefox-privacy-by-the"),
+                value=REPLACE(
+                    privacy_hub,
+                    "Firefox privacy, by the product",
+                    {
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("firefox-privacy-hub-firefox-protects-your-privacy"),
+                value=REPLACE(
+                    privacy_hub,
+                    "Firefox protects your privacy in every product.",
+                    {
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("firefox-privacy-hub-firefox-protects-your-privacy-strong"),
+                value=REPLACE(
+                    privacy_hub,
+                    "Firefox <strong>protects</strong> your privacy in every product",
+                    {
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                    }
+                )
+            ),
+        ] + transforms_from("""
+firefox-privacy-hub-firefox-browser = { -brand-name-firefox-browser }
+firefox-privacy-hub-2000-trackers-blocked-automatically = {COPY(privacy_hub, "2,000+ trackers blocked — automatically",)}
+""", privacy_hub=privacy_hub) + [
+            FTL.Message(
+                id=FTL.Identifier("firefox-privacy-hub-tracking-has-become-an"),
+                value=REPLACE(
+                    privacy_hub,
+                    "Tracking has become an epidemic online: companies follow every move, click and purchase, collecting data to predict and influence what you’ll do next. We think that’s a gross invasion of your privacy. That’s why Firefox mobile and desktop browsers have Enhanced Tracking Protection on by default.",
+                    {
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("firefox-privacy-hub-if-you-want-to-see-what"),
+                value=REPLACE(
+                    privacy_hub,
+                    "If you want to see what Firefox is blocking for you, visit this page on your Firefox desktop browser.",
+                    {
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("firefox-privacy-hub-see-what-firefox-has-blocked"),
+                value=REPLACE(
+                    privacy_hub,
+                    "See what Firefox has blocked for you",
+                    {
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                    }
+                )
+            ),
+        ] + transforms_from("""
+firefox-privacy-hub-get-enhanced-tracking-protection = {COPY(privacy_hub, "Get Enhanced Tracking Protection",)}
+""", privacy_hub=privacy_hub) + [
+            FTL.Message(
+                id=FTL.Identifier("firefox-privacy-hub-download-the-firefox-browser"),
+                value=REPLACE(
+                    privacy_hub,
+                    "Download the Firefox browser",
+                    {
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("firefox-privacy-hub-update-your-firefox-browser"),
+                value=REPLACE(
+                    privacy_hub,
+                    "Update your Firefox browser",
+                    {
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                    }
+                )
+            ),
+        ] + transforms_from("""
+firefox-privacy-hub-invisible-to-the-top-trackers = {COPY(privacy_hub, "Invisible to the top trackers",)}
+firefox-privacy-hub-meet-four-of-the-most-common = {COPY(privacy_hub, "Meet four of the most common categories of trackers — who won’t meet you.",)}
+firefox-privacy-hub-always-in-your-control = {COPY(privacy_hub, "Always in your control",)}
+firefox-privacy-hub-want-to-customize-what = {COPY(privacy_hub, "Want to customize what gets blocked? Your settings are only one click away.",)}
+firefox-privacy-hub-protection-beyond-tracking = {COPY(privacy_hub, "Protection beyond tracking",)}
+""", privacy_hub=privacy_hub) + [
+            FTL.Message(
+                id=FTL.Identifier("firefox-privacy-hub-if-you-have-a-firefox-account"),
+                value=REPLACE(
+                    privacy_hub,
+                    "If you have a Firefox account, you can also see how we’re helping you protect your personal info and passwords.",
+                    {
+                        "Firefox account": TERM_REFERENCE("brand-name-firefox-account"),
+                        "Firefox Account": TERM_REFERENCE("brand-name-firefox-account"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("firefox-privacy-hub-more-than-s-trackers-blocked"),
+                value=REPLACE(
+                    privacy_hub,
+                    "More than %s trackers blocked each day for Firefox users worldwide",
+                    {
+                        "%%": "%",
+                        "%s": VARIABLE_REFERENCE("trackers"),
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                    }
+                )
+            ),
+        ] + transforms_from("""
+firefox-privacy-hub-firefox-monitor = { -brand-name-firefox-monitor }
+""", privacy_hub=privacy_hub) + [
+            FTL.Message(
+                id=FTL.Identifier("firefox-privacy-hub-when-you-enter-your-email"),
+                value=REPLACE(
+                    privacy_hub,
+                    "When you enter your email address in Firefox Monitor, we forget it immediately after we’ve checked for a match in known data breaches — unless you authorize us to continue monitoring new breaches for your personal information.",
+                    {
+                        "Firefox Monitor": TERM_REFERENCE("brand-name-firefox-monitor"),
+                    }
+                )
+            ),
+        ] + transforms_from("""
+firefox-privacy-hub-check-for-breaches = {COPY(privacy_hub, "Check for breaches",)}
+firefox-privacy-hub-firefox-lockwise = { -brand-name-firefox-lockwise }
+""", privacy_hub=privacy_hub) + [
+            FTL.Message(
+                id=FTL.Identifier("firefox-privacy-hub-the-passwords-and-credentials"),
+                value=REPLACE(
+                    privacy_hub,
+                    "The passwords and credentials you save in Firefox Lockwise are encrypted on all your devices, so not even we can see them.",
+                    {
+                        "Firefox Lockwise": TERM_REFERENCE("brand-name-firefox-lockwise"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("firefox-privacy-hub-learn-more-about-lockwise"),
+                value=REPLACE(
+                    privacy_hub,
+                    "Learn more about Lockwise",
+                    {
+                        "Lockwise": TERM_REFERENCE("brand-name-lockwise"),
+                    }
+                )
+            ),
+        ] + transforms_from("""
+firefox-privacy-hub-firefox-send = { -brand-name-firefox-send }
+""", privacy_hub=privacy_hub) + [
+            FTL.Message(
+                id=FTL.Identifier("firefox-privacy-hub-we-cant-see-the-names-or"),
+                value=REPLACE(
+                    privacy_hub,
+                    "We can’t see the names or content of the large files you share through Firefox Send because they’re encrypted end-to-end — you choose who sees what you send, and you can even set an expiration date and password.",
+                    {
+                        "Firefox Send": TERM_REFERENCE("brand-name-firefox-send"),
+                    }
+                )
+            ),
+        ] + transforms_from("""
+firefox-privacy-hub-send-a-file = {COPY(privacy_hub, "Send a file",)}
+firefox-privacy-hub-pocket = { -brand-name-pocket }
+""", privacy_hub=privacy_hub) + [
+            FTL.Message(
+                id=FTL.Identifier("firefox-privacy-hub-pocket-recommends-high"),
+                value=REPLACE(
+                    privacy_hub,
+                    "Pocket recommends high-quality, human-curated articles without collecting your browsing history or sharing your personal information with advertisers.",
+                    {
+                        "Pocket": TERM_REFERENCE("brand-name-pocket"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("firefox-privacy-hub-get-pocket"),
+                value=REPLACE(
+                    privacy_hub,
+                    "Get Pocket",
+                    {
+                        "Pocket": TERM_REFERENCE("brand-name-pocket"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("firefox-privacy-hub-your-firefox-account"),
+                value=REPLACE(
+                    privacy_hub,
+                    "Your Firefox account",
+                    {
+                        "Firefox account": TERM_REFERENCE("brand-name-firefox-account"),
+                        "Firefox Account": TERM_REFERENCE("brand-name-firefox-account"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("firefox-privacy-hub-all-the-information-synced"),
+                value=REPLACE(
+                    privacy_hub,
+                    "All the information synced through your Firefox account — from browser history to passwords — is encrypted. And your account password is the only key.",
+                    {
+                        "Firefox account": TERM_REFERENCE("brand-name-firefox-account"),
+                        "Firefox Account": TERM_REFERENCE("brand-name-firefox-account"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("firefox-privacy-hub-take-your-privacy-and-bookmarks"),
+                value=REPLACE(
+                    privacy_hub,
+                    "Take your privacy and bookmarks everywhere with a Firefox account.",
+                    {
+                        "Firefox account": TERM_REFERENCE("brand-name-firefox-account"),
+                        "Firefox Account": TERM_REFERENCE("brand-name-firefox-account"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("firefox-privacy-hub-already-have-an-account"),
+                value=REPLACE(
+                    privacy_hub,
+                    "Already have an account? <a %(sign_in)s class=\"%(class_name)s\">Sign In</a> or <a href=\"%(learn_more)s\">learn more</a> about joining Firefox.",
+                    {
+                        "%%": "%",
+                        "%(sign_in)s": VARIABLE_REFERENCE("sign_in"),
+                        "%(class_name)s": VARIABLE_REFERENCE("class_name"),
+                        "%(learn_more)s": VARIABLE_REFERENCE("learn_more"),
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("firefox-privacy-hub-read-the-privacy-notice-for"),
+                value=REPLACE(
+                    privacy_hub,
+                    "Read the <a href=\"%s\">Privacy Notice</a> for our products",
+                    {
+                        "%%": "%",
+                        "%s": VARIABLE_REFERENCE("url"),
+                    }
+                )
+            ),
+        ]
+        )


### PR DESCRIPTION
## Description

- Migrates `firefox/privacy-hub.lang` to `firefox/privacy-hub.ftl`
- Updates privacy hub pages to use Fluent IDs:
  - http://localhost:8000/en-US/firefox/privacy/
  - http://localhost:8000/en-US/firefox/privacy/products/

## Issue / Bugzilla link
#9006

## Testing
```
./manage.py l10n_update
```