### PR TITLE
Migrate /firefox/lockwise to Fluent (Fixes #9016)

### DIFF
--- a/bedrock/base/templates/includes/protocol/footer/firefox.html
+++ b/bedrock/base/templates/includes/protocol/footer/firefox.html
@@ -33,7 +33,7 @@
             {{ ftl('footer-products') }}
           </h5>
           <ul class="mzp-c-footer-list">
-            <li><a href="{{ url('firefox.lockwise.lockwise') }}" data-link-type="footer" data-link-name="Lockwise">{{ ftl('footer-lockwise') }}</a></li>
+            <li><a href="{{ url('firefox.products.lockwise') }}" data-link-type="footer" data-link-name="Lockwise">{{ ftl('footer-lockwise') }}</a></li>
             <li><a href="https://monitor.firefox.com/?utm_source=www.mozilla.org&utm_medium=referral&utm_campaign=footer&utm_content=monitor" data-link-type="footer" data-link-name="Monitor">{{ ftl('footer-monitor') }}</a></li>
             <li><a href="https://send.firefox.com/?utm_source=www.mozilla.org&utm_medium=referral&utm_campaign=footer&utm_content=send" data-link-type="footer" data-link-name="Send">{{ ftl('footer-send') }}</a></li>
             <li><a href="{{ url('firefox.browsers.index') }}" data-link-type="footer" data-link-name="Browsers">{{ ftl('footer-browsers') }}</a></li>

--- a/bedrock/base/templates/includes/protocol/navigation/menu-firefox/products.html
+++ b/bedrock/base/templates/includes/protocol/navigation/menu-firefox/products.html
@@ -13,7 +13,7 @@
         <ul>
           <li>
             <section class="mzp-c-menu-item mzp-has-icon">
-              <a class="mzp-c-menu-item-link" href="{{ url('firefox.lockwise.lockwise') }}" data-link-name="Lockwise" data-link-type="nav" data-link-position="topnav" data-link-group="products">
+              <a class="mzp-c-menu-item-link" href="{{ url('firefox.products.lockwise') }}" data-link-name="Lockwise" data-link-type="nav" data-link-position="topnav" data-link-group="products">
                 <img class="mzp-c-menu-item-icon" src="{{ static('protocol/img/logos/firefox/lockwise/logo-xs.png') }}" class="mzp-c-menu-item-icon" alt="" width="24" height="24" loading="lazy">
                 <h4 class="mzp-c-menu-item-title">{{ ftl('navigation-firefox-lockwise') }}</h4>
                 <p class="mzp-c-menu-item-desc">{{ ftl('navigation-take-the-passwords-youve') }}</p>

--- a/bedrock/base/templates/includes/structured-data/organizations/mozilla-corporation-organisation.json
+++ b/bedrock/base/templates/includes/structured-data/organizations/mozilla-corporation-organisation.json
@@ -327,7 +327,7 @@
   {
     "@type": "Product",
     "@id": "{{ structured_data_id('firefoxlockwise') }}",
-    "url": "{% filter absolute_url %}{{ url('firefox.lockwise.lockwise') }}{% endfilter %}",
+    "url": "{% filter absolute_url %}{{ url('firefox.products.lockwise') }}{% endfilter %}",
     "logo": "{% filter absolute_url %}{{ static('protocol/img/logos/firefox/lockwise/logo-lg-high-res.png') }}{% endfilter %}",
     "image": [
       "{% filter absolute_url %}{{ static('img/structured-data/lockwise.png') }}{% endfilter %}",
@@ -348,7 +348,7 @@
     "offers":
     {
       "@type": "Offer",
-      "url": "{% filter absolute_url %}{{ url('firefox.lockwise.lockwise') }}{% endfilter %}",
+      "url": "{% filter absolute_url %}{{ url('firefox.products.lockwise') }}{% endfilter %}",
       "priceCurrency": "USD",
       "price": "0",
       "availability": "https://schema.org/InStock"

--- a/bedrock/base/templates/includes/structured-data/software/firefox-lockwise-software.json
+++ b/bedrock/base/templates/includes/structured-data/software/firefox-lockwise-software.json
@@ -2,7 +2,7 @@
   "@context": "https://schema.org/",
   "@type": "SoftwareApplication",
   "@id": "{{ structured_data_id('firefoxlockwise') }}",
-  "url": "{% filter absolute_url %}{{ url('firefox.lockwise.lockwise') }}{% endfilter %}",
+  "url": "{% filter absolute_url %}{{ url('firefox.products.lockwise') }}{% endfilter %}",
   "image": "{% filter absolute_url %}{{ static('protocol/img/logos/firefox/lockwise/logo-lg-high-res.png') }}{% endfilter %}",
   "name": "Firefox Lockwise",
   "sameAs": [

--- a/bedrock/exp/templates/exp/firefox/accounts.html
+++ b/bedrock/exp/templates/exp/firefox/accounts.html
@@ -115,7 +115,7 @@
         </a>
       </li>
       <li class="c-product-list-item t-product-lockwise">
-        <a href="{{ url('firefox.lockwise.lockwise') }}" data-cta-text="Firefox Lockwise" data-cta-type="fxa-lockwise">
+        <a href="{{ url('firefox.products.lockwise') }}" data-cta-text="Firefox Lockwise" data-cta-type="fxa-lockwise">
           <h3 class="c-product-list-title">{{ ftl('firefox-accounts-firefox-lockwise') }}</h3>
           <p class="c-product-list-desc">{{ ftl('firefox-accounts-keep-your-passwords') }}</p>
         </a>

--- a/bedrock/exp/templates/exp/firefox/index.html
+++ b/bedrock/exp/templates/exp/firefox/index.html
@@ -66,7 +66,7 @@
             </a>
           </li>
           <li>
-              <a class="mzp-c-cta-link" href="{{ url('firefox.lockwise.lockwise') }}" rel="external noopener" data-cta-type="link" data-cta-text="Lockwise">
+              <a class="mzp-c-cta-link" href="{{ url('firefox.products.lockwise') }}" rel="external noopener" data-cta-type="link" data-cta-text="Lockwise">
                 <img alt="" src="{{ static('protocol/img/logos/firefox/lockwise/logo-md.png') }}" height="40" width="40"><br>
                 {{ ftl('firefox-home-lockwise') }}
               </a>
@@ -144,7 +144,7 @@
             <li class="mzp-c-menu-list-item"><a href="{{ lockwise_adjust_url('ios', 'firefox-home') }}" rel="external noopener" data-cta-type="link" data-cta-text="Download Lockwise for iOS">{{ ftl('firefox-home-ios') }}</a></li>
           </ul>
         </div>
-        <p><a class="mzp-c-cta-link" href="{{ url('firefox.lockwise.lockwise') }}" rel="external noopener" data-cta-type="link" data-cta-text="Lockwise Learn More">{{ ftl('firefox-home-learn-more-about-lockwise') }}</a></p>
+        <p><a class="mzp-c-cta-link" href="{{ url('firefox.products.lockwise') }}" rel="external noopener" data-cta-type="link" data-cta-text="Lockwise Learn More">{{ ftl('firefox-home-learn-more-about-lockwise') }}</a></p>
       {% endcall %}
     </div>
 
@@ -224,7 +224,7 @@
                 </a>
               </li>
               <li>
-                <a class="mzp-c-cta-link" href="{{ url('firefox.lockwise.lockwise') }}{{ referrals }}" rel="external noopener" data-cta-type="link" data-cta-text="Lockwise">
+                <a class="mzp-c-cta-link" href="{{ url('firefox.products.lockwise') }}{{ referrals }}" rel="external noopener" data-cta-type="link" data-cta-text="Lockwise">
                   <img alt="" src="{{ static('protocol/img/logos/firefox/lockwise/logo-md.png') }}" height="40" width="40"><br>
                   {{ ftl('firefox-home-lockwise') }}
                 </a>

--- a/bedrock/firefox/templates/firefox/accounts.html
+++ b/bedrock/firefox/templates/firefox/accounts.html
@@ -108,7 +108,7 @@
         </a>
       </li>
       <li class="c-product-list-item t-product-lockwise">
-        <a href="{{ url('firefox.lockwise.lockwise') }}" data-cta-text="Firefox Lockwise" data-cta-type="fxa-lockwise">
+        <a href="{{ url('firefox.products.lockwise') }}" data-cta-text="Firefox Lockwise" data-cta-type="fxa-lockwise">
           <h3 class="c-product-list-title">{{ ftl('firefox-accounts-firefox-lockwise') }}</h3>
           <p class="c-product-list-desc">{{ ftl('firefox-accounts-keep-your-passwords') }}</p>
         </a>

--- a/bedrock/firefox/templates/firefox/browsers/compare/brave.html
+++ b/bedrock/firefox/templates/firefox/browsers/compare/brave.html
@@ -85,7 +85,7 @@
 
       <p>{{ ftl('compare-brave-on-the-other-side-of-the-coin', attrs='href="https://addons.mozilla.org/firefox/addon/adblock-plus/" rel="external noopener" data-cta-text="Adblock Plus" data-cta-type="link"'|safe) }}</p>
 
-      <p>{{ ftl('compare-brave-there-are-a-few-of-braves', lockwise='href="%s" data-cta-type="link" data-cta-name="Lockwise"'|safe|format(url('firefox.lockwise.lockwise')),
+      <p>{{ ftl('compare-brave-there-are-a-few-of-braves', lockwise='href="%s" data-cta-type="link" data-cta-name="Lockwise"'|safe|format(url('firefox.products.lockwise')),
           extension='href="https://addons.mozilla.org/addon/https-everywhere/" rel="external noopener" data-cta-text="HTTPS Everywhere" data-cta-type="link"'|safe,
           privacy='href="%s" data-cta-type="link" data-cta-name="Privacy Report"'|safe|format(url('firefox.privacy.products'))) }}</p>
 

--- a/bedrock/firefox/templates/firefox/browsers/compare/ie.html
+++ b/bedrock/firefox/templates/firefox/browsers/compare/ie.html
@@ -82,7 +82,7 @@
 
       <img src="{{ static('img/firefox/compare/compare-privacy-locks.svg') }}" alt="" height="217" width="320" class="compare-details-image">
 
-      <p>{{ ftl('compare-ie-so-whats-the-solution-if-your', fallback='compare-ie-so-whats-the-solution-if-your-fallback', lockwise='href="%s" data-cta-type="link" data-cta-name="Lockwise"'|safe|format(url('firefox.lockwise.lockwise')),
+      <p>{{ ftl('compare-ie-so-whats-the-solution-if-your', fallback='compare-ie-so-whats-the-solution-if-your-fallback', lockwise='href="%s" data-cta-type="link" data-cta-name="Lockwise"'|safe|format(url('firefox.products.lockwise')),
                  privacy='href="%s" data-cta-type="link" data-cta-name="privacy policy"'|safe|format(url('privacy.notices.firefox'))) }}</p>
 
       {% include '/firefox/browsers/compare/includes/download-menu-list.html' %}

--- a/bedrock/firefox/templates/firefox/browsers/compare/safari.html
+++ b/bedrock/firefox/templates/firefox/browsers/compare/safari.html
@@ -84,7 +84,7 @@
 
       <p>{{ ftl('compare-safari-our-private-browsing-mode', attrs='href="https://addons.mozilla.org/firefox/addon/facebook-container/" rel="external noopener" data-cta-text="Facebook Container" data-cta-type="link"'|safe) }}</p>
 
-      <p>{{ ftl('compare-safari-as-far-as-security-goes-firefox', lockwise='href="%s" data-cta-type="link" data-cta-name="Lockwise"'|safe|format(url('firefox.lockwise.lockwise')), monitor='href="https://monitor.firefox.com/" rel="external noopener" data-cta-text="Monitor" data-cta-type="link"'|safe) }}</p>
+      <p>{{ ftl('compare-safari-as-far-as-security-goes-firefox', lockwise='href="%s" data-cta-type="link" data-cta-name="Lockwise"'|safe|format(url('firefox.products.lockwise')), monitor='href="https://monitor.firefox.com/" rel="external noopener" data-cta-text="Monitor" data-cta-type="link"'|safe) }}</p>
 
       <p>{{ ftl('compare-safari-if-you-choose-to-use-safari') }}</p>
 

--- a/bedrock/firefox/templates/firefox/features/safebrowser.html
+++ b/bedrock/firefox/templates/firefox/features/safebrowser.html
@@ -80,7 +80,7 @@
         {% endtrans %}
       </p>
       <p>
-        {% trans url=url('firefox.lockwise.lockwise') %}
+        {% trans url=url('firefox.products.lockwise') %}
         On <a href="{{ url }} ">Firefox Lockwise</a>, you can take your passwords with you and not worry about their security. They’re all in one place and protected on desktop, phone or tablet.
         {% endtrans %}
       </p>

--- a/bedrock/firefox/templates/firefox/home/index-master.html
+++ b/bedrock/firefox/templates/firefox/home/index-master.html
@@ -71,7 +71,7 @@
             </a>
           </li>
           <li>
-              <a class="mzp-c-cta-link" href="{{ url('firefox.lockwise.lockwise') }}" rel="external noopener" data-cta-type="link" data-cta-text="Lockwise">
+              <a class="mzp-c-cta-link" href="{{ url('firefox.products.lockwise') }}" rel="external noopener" data-cta-type="link" data-cta-text="Lockwise">
                 <img alt="" src="{{ static('protocol/img/logos/firefox/lockwise/logo-md.png') }}" height="40" width="40"><br>
                 {{ ftl('firefox-home-lockwise') }}
               </a>
@@ -149,7 +149,7 @@
             <li class="mzp-c-menu-list-item"><a href="{{ lockwise_adjust_url('ios', 'firefox-home') }}" rel="external noopener" data-cta-type="link" data-cta-text="Download Lockwise for iOS">{{ ftl('firefox-home-ios') }}</a></li>
           </ul>
         </div>
-        <p><a class="mzp-c-cta-link" href="{{ url('firefox.lockwise.lockwise') }}" rel="external noopener" data-cta-type="link" data-cta-text="Lockwise Learn More">{{ ftl('firefox-home-learn-more-about-lockwise') }}</a></p>
+        <p><a class="mzp-c-cta-link" href="{{ url('firefox.products.lockwise') }}" rel="external noopener" data-cta-type="link" data-cta-text="Lockwise Learn More">{{ ftl('firefox-home-learn-more-about-lockwise') }}</a></p>
       {% endcall %}
     </div>
 
@@ -229,7 +229,7 @@
                 </a>
               </li>
               <li>
-                <a class="mzp-c-cta-link" href="{{ url('firefox.lockwise.lockwise') }}{{ referrals }}" rel="external noopener" data-cta-type="link" data-cta-text="Lockwise">
+                <a class="mzp-c-cta-link" href="{{ url('firefox.products.lockwise') }}{{ referrals }}" rel="external noopener" data-cta-type="link" data-cta-text="Lockwise">
                   <img alt="" src="{{ static('protocol/img/logos/firefox/lockwise/logo-md.png') }}" height="40" width="40"><br>
                   {{ ftl('firefox-home-lockwise') }}
                 </a>

--- a/bedrock/firefox/templates/firefox/privacy/products.html
+++ b/bedrock/firefox/templates/firefox/privacy/products.html
@@ -127,7 +127,7 @@
       ) %}
         <p>{{ ftl('firefox-privacy-hub-the-passwords-and-credentials') }}</p>
         <p>
-          <a class="mzp-c-cta-link" href="{{ url('firefox.lockwise.lockwise' )}}" data-cta-type="fxa-lockwise" data-cta-position="secondary">
+          <a class="mzp-c-cta-link" href="{{ url('firefox.products.lockwise' )}}" data-cta-type="fxa-lockwise" data-cta-position="secondary">
             {{ ftl('firefox-privacy-hub-learn-more-about-lockwise') }}
           </a>
         </p>

--- a/bedrock/firefox/templates/firefox/products/index.html
+++ b/bedrock/firefox/templates/firefox/products/index.html
@@ -71,7 +71,7 @@
     </div>
     <div class="c-landing-grid-item">
       <img src="{{ static('img/firefox/products/lockwise.svg') }}" class="c-landing-grid-img" alt="" width="316" height="223">
-      <h2 class="c-landing-grid-title"><a href="{{ url('firefox.lockwise.lockwise') }}" data-cta-type="link" data-cta-text="Firefox Lockwise">{{ ftl('firefox-products-firefox-lockwise') }}</a></h2>
+      <h2 class="c-landing-grid-title"><a href="{{ url('firefox.products.lockwise') }}" data-cta-type="link" data-cta-text="Firefox Lockwise">{{ ftl('firefox-products-firefox-lockwise') }}</a></h2>
       <p>{{ ftl('firefox-products-keep-your-passwords-safe-and') }}</p>
       <div id="menu-lockwise-wrapper"  class="mzp-c-menu-list mzp-t-cta mzp-t-download">
         <h3 class="mzp-c-menu-list-title">{{ ftl('firefox-products-download-lockwise') }}</h3>
@@ -81,7 +81,7 @@
           <li class="mzp-c-menu-list-item"><a href="{{ lockwise_adjust_url('ios', 'firefox_products') }}" rel="external noopener" data-cta-type="link" data-cta-text="Download Lockwise iOS">{{ ftl('firefox-products-ios') }}</a></li>
         </ul>
       </div>
-      <p><a class="mzp-c-cta-link" href="{{ url('firefox.lockwise.lockwise') }}" rel="external noopener" data-cta-type="link" data-cta-text="Lockwise Learn More">{{ ftl('firefox-products-learn-more-about-lockwise') }}</a></p>
+      <p><a class="mzp-c-cta-link" href="{{ url('firefox.products.lockwise') }}" rel="external noopener" data-cta-type="link" data-cta-text="Lockwise Learn More">{{ ftl('firefox-products-learn-more-about-lockwise') }}</a></p>
     </div>
     <div class="c-landing-grid-item">
       <img src="{{ static('img/firefox/products/send.svg') }}" class="c-landing-grid-img" alt="" width="316" height="223">

--- a/bedrock/firefox/templates/firefox/products/lockwise.html
+++ b/bedrock/firefox/templates/firefox/products/lockwise.html
@@ -2,8 +2,6 @@
  # License, v. 2.0. If a copy of the MPL was not distributed with this
  # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
 
-{% add_lang_files "firefox/products/lockwise" %}
-
 {% from "macros.html" import google_play_button with context %}
 {% from "macros-protocol.html" import hero, picto_card with context %}
 
@@ -14,9 +12,9 @@
 {% block page_favicon_large %}{{ static('img/favicons/firefox/lockwise/favicon-196x196.png') }}{% endblock %}
 {% block page_ios_icon %}{{ static('img/favicons/firefox/lockwise/apple-touch-icon.png') }}{% endblock %}
 
-{% block page_title %}{{_('Firefox Lockwise — password manager —  take your passwords everywhere')}}{% endblock %}
+{% block page_title %}{{ ftl('lockwise-firefox-lockwise-password') }}{% endblock %}
 
-{% block page_desc %}{{ _('Firefox Lockwise lets you securely access the passwords you’ve saved in Firefox from anywhere — even outside of the browser. Features 256-bit encryption and Face/Touch ID.') }}{% endblock %}
+{% block page_desc %}{{ ftl('lockwise-firefox-lockwise-lets-you') }}{% endblock %}
 
 {% block page_css %}
   {{ css_bundle('lockwise') }}
@@ -41,9 +39,9 @@
       {% set _img = 'img/firefox/lockwise/en.png'%}
     {% endif %}
     {% call hero(
-      title='Firefox Lockwise',
-      subheading=_('Take your passwords everywhere'),
-      desc=_('Securely access the passwords you’ve saved in Firefox from anywhere — even outside of the browser.'),
+      title=ftl('lockwise-firefox-lockwise'),
+      subheading=ftl('lockwise-take-your-passwords-everywhere'),
+      desc=ftl('lockwise-securely-access-the-passwords'),
       class='mzp-c-hero mzp-has-image lockwise-hero',
       image_url= _img,
       include_cta=True,
@@ -59,19 +57,21 @@
       </div>
       <div class="mzp-c-hero-cta add-on-download for-firefox-69-and-below hidden" >
         <div class="mzp-c-button-download-container">
-          <p>{{ _('Try Lockwise now') }}</p>
-          <a href="https://github.com/mozilla-lockwise/lockwise-addon/releases/download/2.2.5-alpha/lockwise-signed.xpi" class="mzp-c-button mzp-t-product" data-cta-type="lockwise-install" data-cta-position="primary">{{ _('Install for Firefox') }}</a>
+          <p>{{ ftl('lockwise-try-lockwise-now') }}</p>
+          <a href="https://github.com/mozilla-lockwise/lockwise-addon/releases/download/2.2.5-alpha/lockwise-signed.xpi" class="mzp-c-button mzp-t-product" data-cta-type="lockwise-install" data-cta-position="primary">
+            {{ ftl('lockwise-install-for-firefox') }}
+          </a>
         </div>
       </div>
       <div class="mzp-c-hero-cta add-on-download for-firefox-70-and-above hidden" >
         <div class="mzp-c-button-download-container">
-          <p >{{ _('Try Lockwise now') }}</p>
-          <button class="mzp-c-button mzp-t-product" id="lockwise-button" data-cta-type="lockwise-open-in-fx" data-cta-position="primary">{{ _('Open in Firefox') }} </button>
+          <p>{{ ftl('lockwise-try-lockwise-now') }}</p>
+          <button class="mzp-c-button mzp-t-product" id="lockwise-button" data-cta-type="lockwise-open-in-fx" data-cta-position="primary">{{ ftl('lockwise-open-in-firefox') }} </button>
         </div>
       </div>
       <div class="mzp-c-hero-cta add-on-download for-non-firefox-users hidden" >
         <div class="mzp-c-button-download-container">
-          <p >{{ _('Only in the Firefox Browser') }}</p>
+          <p>{{ ftl('lockwise-only-in-the-firefox-browser') }}</p>
           {{ download_firefox(alt_copy=ftl('download-button-download-now'), download_location='primary cta') }}
         </div>
       </div>
@@ -80,15 +80,21 @@
 
     <div class="mzp-t-dark">
       <section class="mzp-l-card-third mzp-l-content">
-        {{ picto_card(title=_('256-bit encryption protects you while syncing'), class='encryption') }}
-        {{ picto_card(title=_('Get to your passwords securely with Face or Touch ID'), class='touch') }}
-        {{ picto_card(title=_('Your privacy comes first.') ~ ' ' ~ _('We keep your data safe, never sold.'), class='privacy') }}
+        {{ picto_card(title=ftl('lockwise-256-bit-encryption-protects'), class='encryption') }}
+        {{ picto_card(title=ftl('lockwise-get-to-your-passwords-securely'), class='touch') }}
+        {{ picto_card(title=ftl('lockwise-your-privacy-comes-first') ~ ' ' ~ ftl('lockwise-we-keep-your-data-safe'), class='privacy') }}
       </section>
       <section class="mzp-l-content">
         <section class="links">
-          <a href='https://support.mozilla.org/products/firefox-lockwise?utm_source=www.mozilla.org-lockwise&amp;utm_campaign=Lockwise&amp;utm_medium=referral' >{{ _('Support') }}</a>
-          <a href='https://support.mozilla.org/kb/firefox-lockwise-and-privacy'>{{ _('Your Privacy') }}</a>
-          <a href='https://github.com/mozilla-lockwise'>{{ _('GitHub') }}</a>
+          <a href="https://support.mozilla.org/products/firefox-lockwise?utm_source=www.mozilla.org-lockwise&amp;utm_campaign=Lockwise&amp;utm_medium=referral">
+            {{ ftl('lockwise-support') }}
+          </a>
+          <a href="https://support.mozilla.org/kb/firefox-lockwise-and-privacy">
+            {{ ftl('lockwise-your-privacy') }}
+          </a>
+          <a href="https://github.com/mozilla-lockwise">
+            {{ ftl('lockwise-github') }}
+          </a>
         </section>
       </section>
     </div>

--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx70-de.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx70-de.html
@@ -89,7 +89,7 @@
           <h3 class="c-picto-block-title">{{ _('Schütze deine Passwörter und nimm sie mit') }}</h3>
           <div class="c-picto-block-body">
             <p>{{ _('In Firefox Lockwise kannst du deine Passwörter sicher aufbewahren und verwalten. UND: Du kannst dich warnen lassen, wenn du ein Passwort unbedingt ändern solltest.') }}</p>
-            <a class="mzp-c-cta-link js-open-lockwise" href="{{ url('firefox.lockwise.lockwise') }}">{{ _('Zu Lockwise') }}</a>
+            <a class="mzp-c-cta-link js-open-lockwise" href="{{ url('firefox.products.lockwise') }}">{{ _('Zu Lockwise') }}</a>
           </div>
         </div>
       </div>

--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx70-en.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx70-en.html
@@ -89,7 +89,7 @@
           <h3 class="c-picto-block-title">{{ _('Keep your passwords protected and portable') }}</h3>
           <div class="c-picto-block-body">
             <p>{{ _('Safely store and manage your passwords with Lockwise, and get alerted when you need to change them.') }}</p>
-            <a class="mzp-c-cta-link js-open-lockwise" href="{{ url('firefox.lockwise.lockwise') }}">{{ _('Go to Lockwise') }}</a>
+            <a class="mzp-c-cta-link js-open-lockwise" href="{{ url('firefox.products.lockwise') }}">{{ _('Go to Lockwise') }}</a>
           </div>
         </div>
       </div>

--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx70-fr.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx70-fr.html
@@ -89,7 +89,7 @@
           <h3 class="c-picto-block-title">{{ _('Protégez vos mots de passe et gardez-les à portée de main') }}</h3>
           <div class="c-picto-block-body">
             <p>{{ _('Avec Firefox Lockwise, vous pouvez stocker et gérer vos mots de passe de manière sécurisée. En plus, on vous prévient si jamais vous avez besoin de changer un mot de passe.') }}</p>
-            <a class="mzp-c-cta-link js-open-lockwise" href="{{ url('firefox.lockwise.lockwise') }}">{{ _('Découvrir Lockwise') }}</a>
+            <a class="mzp-c-cta-link js-open-lockwise" href="{{ url('firefox.products.lockwise') }}">{{ _('Découvrir Lockwise') }}</a>
           </div>
         </div>
       </div>

--- a/bedrock/firefox/urls.py
+++ b/bedrock/firefox/urls.py
@@ -153,7 +153,7 @@ urlpatterns = (
     page('firefox/browsers/windows-64-bit', 'firefox/browsers/windows-64-bit.html'),
 
     # Lockwise
-    page('firefox/lockwise', 'firefox/lockwise/lockwise.html'),
+    page('firefox/lockwise', 'firefox/products/lockwise.html', ftl_files=['firefox/products/lockwise']),
 
     # Issue 7765, 7709
     page('firefox/privacy', 'firefox/privacy/index.html', ftl_files=['firefox/privacy-hub']),

--- a/bedrock/foundation/templates/foundation/annualreport/2018/index.html
+++ b/bedrock/foundation/templates/foundation/annualreport/2018/index.html
@@ -455,7 +455,7 @@
           </p>
           <p>
             {% trans vpn="https://www.engadget.com/2018/10/23/mozilla-firefox-protonvpn-test/",
-            lockwise=url('firefox.lockwise.lockwise'),
+            lockwise=url('firefox.products.lockwise'),
             launched="https://blog.mozilla.org/blog/2018/09/25/introducing-firefox-monitor-helping-people-take-control-after-a-data-breach/",
             monitor="https://monitor.firefox.com/" %}
             In 2018, we began testing a new paid virtual private network (<a href="{{ vpn }}">VPN</a>) service in

--- a/l10n/en/firefox/products/lockwise.ftl
+++ b/l10n/en/firefox/products/lockwise.ftl
@@ -1,0 +1,26 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+### URL: https://www-dev.allizom.org/firefox/lockwise/
+
+# HTML page title
+lockwise-firefox-lockwise-password = { -brand-name-firefox-lockwise } — password manager — take your passwords everywhere
+
+# HTML page description
+lockwise-firefox-lockwise-lets-you = { -brand-name-firefox-lockwise } lets you securely access the passwords you’ve saved in { -brand-name-firefox } from anywhere — even outside of the browser. Features 256-bit encryption and Face/Touch ID.
+
+lockwise-firefox-lockwise = { -brand-name-firefox-lockwise }
+lockwise-take-your-passwords-everywhere = Take your passwords everywhere
+lockwise-securely-access-the-passwords = Securely access the passwords you’ve saved in { -brand-name-firefox } from anywhere — even outside of the browser.
+lockwise-try-lockwise-now = Try { -brand-name-lockwise } now
+lockwise-install-for-firefox = Install for { -brand-name-firefox }
+lockwise-open-in-firefox = Open in { -brand-name-firefox }
+lockwise-only-in-the-firefox-browser = Only in the { -brand-name-firefox-browser }
+lockwise-256-bit-encryption-protects = 256-bit encryption protects you while syncing
+lockwise-get-to-your-passwords-securely = Get to your passwords securely with Face or Touch ID
+lockwise-your-privacy-comes-first = Your privacy comes first.
+lockwise-we-keep-your-data-safe = We keep your data safe, never sold.
+lockwise-support = Support
+lockwise-your-privacy = Your Privacy
+lockwise-github = { -brand-name-github }

--- a/lib/fluent_migrations/firefox/lockwise/lockwise.py
+++ b/lib/fluent_migrations/firefox/lockwise/lockwise.py
@@ -1,0 +1,100 @@
+from __future__ import absolute_import
+import fluent.syntax.ast as FTL
+from fluent.migrate.helpers import transforms_from
+from fluent.migrate.helpers import VARIABLE_REFERENCE, TERM_REFERENCE
+from fluent.migrate import REPLACE, COPY
+
+lockwise = "firefox/products/lockwise.lang"
+
+def migrate(ctx):
+    """Migrate bedrock/firefox/templates/firefox/lockwise/lockwise.html, part {index}."""
+
+    ctx.add_transforms(
+        "firefox/products/lockwise.ftl",
+        "firefox/products/lockwise.ftl",
+        [
+            FTL.Message(
+                id=FTL.Identifier("lockwise-firefox-lockwise-password"),
+                value=REPLACE(
+                    lockwise,
+                    "Firefox Lockwise — password manager — take your passwords everywhere",
+                    {
+                        "Firefox Lockwise": TERM_REFERENCE("brand-name-firefox-lockwise"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("lockwise-firefox-lockwise-lets-you"),
+                value=REPLACE(
+                    lockwise,
+                    "Firefox Lockwise lets you securely access the passwords you’ve saved in Firefox from anywhere — even outside of the browser. Features 256-bit encryption and Face/Touch ID.",
+                    {
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                        "Firefox Lockwise": TERM_REFERENCE("brand-name-firefox-lockwise"),
+                    }
+                )
+            ),
+        ] + transforms_from("""
+lockwise-firefox-lockwise = { -brand-name-firefox-lockwise }
+lockwise-take-your-passwords-everywhere = {COPY(lockwise, "Take your passwords everywhere",)}
+""", lockwise=lockwise) + [
+            FTL.Message(
+                id=FTL.Identifier("lockwise-securely-access-the-passwords"),
+                value=REPLACE(
+                    lockwise,
+                    "Securely access the passwords you’ve saved in Firefox from anywhere — even outside of the browser.",
+                    {
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("lockwise-try-lockwise-now"),
+                value=REPLACE(
+                    lockwise,
+                    "Try Lockwise now",
+                    {
+                        "Lockwise": TERM_REFERENCE("brand-name-lockwise"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("lockwise-install-for-firefox"),
+                value=REPLACE(
+                    lockwise,
+                    "Install for Firefox",
+                    {
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("lockwise-open-in-firefox"),
+                value=REPLACE(
+                    lockwise,
+                    "Open in Firefox",
+                    {
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("lockwise-only-in-the-firefox-browser"),
+                value=REPLACE(
+                    lockwise,
+                    "Only in the Firefox Browser",
+                    {
+                        "Firefox Browser": TERM_REFERENCE("brand-name-firefox-browser"),
+                    }
+                )
+            ),
+        ] + transforms_from("""
+lockwise-256-bit-encryption-protects = {COPY(lockwise, "256-bit encryption protects you while syncing",)}
+lockwise-get-to-your-passwords-securely = {COPY(lockwise, "Get to your passwords securely with Face or Touch ID",)}
+lockwise-your-privacy-comes-first = {COPY(lockwise, "Your privacy comes first.",)}
+lockwise-we-keep-your-data-safe = {COPY(lockwise, "We keep your data safe, never sold.",)}
+lockwise-support = {COPY(lockwise, "Support",)}
+lockwise-your-privacy = {COPY(lockwise, "Your Privacy",)}
+lockwise-github = { -brand-name-github }
+""", lockwise=lockwise)
+        )


### PR DESCRIPTION
## Description
- Migrates `firefox/products/lockwise.lang` to `firefox/products/lockwise.ftl`
- Moves template from `firefox/lockwise/lockwise.html` to `firefox/products/lockwise.html`
- Updates template to use Fluent Ids.

## Issue / Bugzilla link
#9016

## Testing
```
./manage.py l10n_update
```

Successful test run: https://gitlab.com/mozmeao/www-config/-/pipelines/155643331