### PR TITLE
Redirect /products/firefox/ to /firefox/products/ (Fixes #9008)

### DIFF
--- a/bedrock/firefox/redirects.py
+++ b/bedrock/firefox/redirects.py
@@ -471,7 +471,6 @@ redirectpatterns = (
     redirect(r'^products/firefox/buttons\.html$', '/contribute/friends/'),
     redirect(r'^products/firefox/download', 'firefox.new'),
     redirect(r'^products/firefox/get$', 'firefox.new'),
-    redirect(r'^products/firefox/$', 'firefox'),
     redirect(r'^products/firefox/live-bookmarks', '/firefox/features/'),
     redirect(r'^products/firefox/mirrors\.html$', 'http://www-archive.mozilla.org/mirrors.html'),
     redirect(r'^products/firefox/releases/$', '/firefox/releases/'),
@@ -500,7 +499,9 @@ redirectpatterns = (
 
     # bug 857246 redirect /products/firefox/start/  to start.mozilla.org
     redirect(r'^products/firefox/start/?$', 'http://start.mozilla.org'),
-    redirect(r'^products/firefox', 'firefox'),
+
+    # issue 9008
+    redirect(r'^products/firefox(/.*)?$', 'firefox.products.index'),
 
     # bug 1260423
     redirect(r'^firefox/choose/?$', 'firefox.new'),

--- a/tests/redirects/map_301.py
+++ b/tests/redirects/map_301.py
@@ -1718,7 +1718,7 @@ URLS = flatten((
     url_test('/products/firefox/download', '/firefox/new/'),
     url_test('/products/firefox/download.html', '/firefox/new/'),
     url_test('/products/firefox/get', '/firefox/new/'),
-    url_test('/products/firefox/', '/firefox/'),
+    url_test('/products/firefox/', '/firefox/products/'),
     url_test('/products/firefox/live-bookmarks', '/firefox/features/'),
     url_test('/products/firefox/live-bookmarks.html', '/firefox/features/'),
     url_test('/products/firefox/mirrors.html', 'http://www-archive.mozilla.org/mirrors.html'),

--- a/tests/redirects/map_globalconf.py
+++ b/tests/redirects/map_globalconf.py
@@ -1049,7 +1049,7 @@ URLS = flatten((
 
     # Bug 654614 /blocklist -> addons.m.o/blocked
     url_test('/blocklist/', 'https://addons.mozilla.org/blocked/'),
-    url_test('/products/firefox/{,stuff/}', '/firefox/'),
+    url_test('/products/firefox/{,stuff/}', '/firefox/products/'),
 
     # Bug 784411
     url_test('/about/mission/', '/mission/'),


### PR DESCRIPTION
#9008