### PR TITLE
Add Firefox Relay legal docs

### DIFF
--- a/bedrock/privacy/templates/privacy/base-protocol.html
+++ b/bedrock/privacy/templates/privacy/base-protocol.html
@@ -39,6 +39,7 @@
   (url('privacy.notices.firefox-os'), 'privacy-os', _('Firefox OS')),
   (focus_url, 'privacy-focus', focus_name),
   (url('privacy.notices.firefox-private-network'), 'privacy-private-network', _('Firefox Private Network')),
+  (url('privacy.notices.firefox-relay'), 'privacy-relay', _('Firefox Relay')),
   (url('privacy.notices.thunderbird'), 'privacy-thunderbird', _('Thunderbird')),
 ] -%}
 

--- a/bedrock/privacy/templates/privacy/notices/firefox-relay.html
+++ b/bedrock/privacy/templates/privacy/notices/firefox-relay.html
@@ -1,0 +1,9 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+
+{% extends "privacy/notices/base-notice.html" %}
+
+{% set body_id = "privacy-relay" %}
+
+{% block article_header_logo %}{{ static('protocol/img/logos/firefox/logo.svg') }}{% endblock %}

--- a/bedrock/privacy/urls.py
+++ b/bedrock/privacy/urls.py
@@ -28,6 +28,7 @@ urlpatterns = (
     url(r'^facebook/$', views.facebook_notices, name='privacy.notices.facebook'),
     url(r'^firefox-monitor/$', views.firefox_monitor_notices, name='privacy.notices.firefox-monitor'),
     page('firefox-private-network', 'privacy/notices/firefox-private-network.html'),
+    url(r'^firefox-relay/$', views.firefox_relay_notices, name='privacy.notices.firefox-relay'),
 
     page('archive', 'privacy/archive/index.html'),
     page('archive/firefox/2006-10', 'privacy/archive/firefox-2006-10.html'),

--- a/bedrock/privacy/views.py
+++ b/bedrock/privacy/views.py
@@ -103,6 +103,10 @@ firefox_monitor_notices = PrivacyDocView.as_view(
     template_name='privacy/notices/firefox-monitor.html',
     legal_doc_name='firefox_monitor_terms_privacy')
 
+firefox_relay_notices = PrivacyDocView.as_view(
+    template_name='privacy/notices/firefox-relay.html',
+    legal_doc_name='firefox_relay_privacy_notice')
+
 
 @cache_page(60 * 60)  # cache for 1 hour
 def privacy(request):


### PR DESCRIPTION
## Description

Adds new privacy notice for Firefox Relay. 
This needs to be live in production on **23 June**

Updates the rest of legal-docs as well.

## Testing

http://localhost:8000/privacy/firefox-relay/