### PR TITLE
Migrate firefox/welcome/2/ to Fluent (Fixes #9034) [skip l10n]

### DIFF
--- a/bedrock/firefox/templates/firefox/welcome/base.html
+++ b/bedrock/firefox/templates/firefox/welcome/base.html
@@ -1,6 +1,6 @@
 {# This Source Code Form is subject to the terms of the Mozilla Public
-  # License, v. 2.0. If a copy of the MPL was not distributed with this
-  # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
 
 {% extends "firefox/base/base-protocol.html" %}
 

--- a/bedrock/firefox/templates/firefox/welcome/page2.html
+++ b/bedrock/firefox/templates/firefox/welcome/page2.html
@@ -4,12 +4,9 @@
 
 {% from "macros-protocol.html" import hero with context %}
 
-{% add_lang_files "firefox/welcome/page2" %}
-
 {% extends "firefox/welcome/base.html" %}
 
-{# L10n: "Pocket" is a product name and shouldn't be translated. #}
-{% block page_title %}{{ _('Pocket - Save news, videos, stories and more') }}{% endblock %}
+{% block page_title %}{{ ftl('welcome-page2-pocket-save-news-videos-stories') }}{% endblock %}
 
 {% block page_image %}{{ static('img/logos/pocket/og.png') }}{% endblock %}
 
@@ -21,25 +18,25 @@
 
 {% block content_intro %}
   {% call hero(
-    title=_('Your time online is worth protecting'),
-    desc=_('Discover and save stories in Pocket — and come back to them when you’re free.'),
+    title=ftl('welcome-page2-your-time-online-is-worth'),
+    desc=ftl('welcome-page2-discover-and-save-stories'),
     class='mzp-t-firefox mzp-t-dark',
     include_cta=True,
     heading_level=1
   ) %}
 
     <p class="primary-cta">
-      {{ pocket_fxa_button(entrypoint=_entrypoint, button_text=_('Activate Pocket'), optional_parameters={'s': _source, 'utm_campaign': _utm_campaign}, optional_attributes={'data-cta-text': 'Activate Pocket', 'data-cta-type': 'activate pocket', 'data-cta-position': 'primary'}) }}
+      {{ pocket_fxa_button(entrypoint=_entrypoint, button_text=ftl('welcome-page2-activate-pocket'), optional_parameters={'s': _source, 'utm_campaign': _utm_campaign}, optional_attributes={'data-cta-text': 'Activate Pocket', 'data-cta-type': 'activate pocket', 'data-cta-position': 'primary'}) }}
     </p>
   {% endcall %}
 {% endblock %}
 
 {% block content_primary %}
 <div class="body-primary">
-  <h2 class="body-primary-title"><img src="{{ static('protocol/img/logos/pocket/logo-word-horz.svg') }}" width="186" height="" alt="Pocket"></h2>
+  <h2 class="body-primary-title"><img src="{{ static('protocol/img/logos/pocket/logo-word-horz.svg') }}" width="186" height="" alt="{{ ftl('welcome-page2-pocket') }}"></h2>
 
   <div class="body-primary-body">
-    <p>{{ _('Pocket is built right into Firefox, so you can easily save stories as you find them, then read them later on any device.') }}</p>
+    <p>{{ ftl('welcome-page2-pocket-is-built-right-into') }}</p>
 
     <img class="primary-image" src="{{ static('img/firefox/welcome/pocket-hero.svg') }}" width="700" height="" alt="">
   </div>
@@ -53,9 +50,9 @@
       <img src="{{ static('img/icons/pocket-outline-green.svg') }}" alt="">
     </div>
 
-    <h3 class="c-picto-block-title">{{ _('Save content from everywhere') }}</h3>
+    <h3 class="c-picto-block-title">{{ ftl('welcome-page2-save-content-from-everywhere') }}</h3>
     <div class="c-picto-block-body">
-      <p>{{ _('Grab articles, videos, and links from any website by clicking the Pocket icon in your browser toolbar.') }}</p>
+      <p>{{ ftl('welcome-page2-grab-articles-videos-and-links') }}</p>
     </div>
   </div>
 
@@ -64,9 +61,9 @@
       <img src="{{ static('img/icons/navigate-green.svg') }}" alt="">
     </div>
 
-    <h3 class="c-picto-block-title">{{ _('Discover new stories') }}</h3>
+    <h3 class="c-picto-block-title">{{ ftl('welcome-page2-discover-new-stories') }}</h3>
     <div class="c-picto-block-body">
-      <p>{{ _('Pocket shows recommended stories every time you open a new tab. Save the ones that interest you.') }}</p>
+      <p>{{ ftl('welcome-page2-pocket-shows-recommended-stories') }}</p>
     </div>
   </div>
 </div>
@@ -74,12 +71,16 @@
 
 {% block secondary_cta %}
   <p class="secondary-cta">
-    {{ pocket_fxa_button(entrypoint=_entrypoint, button_text=_('Activate Pocket'), optional_parameters={'s': _source, 'utm_campaign': _utm_campaign}, optional_attributes={'data-cta-text': 'Activate Pocket', 'data-cta-type': 'activate pocket', 'data-cta-position': 'secondary'}) }}
+    {{ pocket_fxa_button(entrypoint=_entrypoint, button_text=ftl('welcome-page2-activate-pocket'), optional_parameters={'s': _source, 'utm_campaign': _utm_campaign}, optional_attributes={'data-cta-text': 'Activate Pocket', 'data-cta-type': 'activate pocket', 'data-cta-position': 'secondary'}) }}
   </p>
 {% endblock %}
 
 {% block content_utility %}
-  <p><strong><a href="https://support.mozilla.org/kb/firefox-browser-welcome-pages/?utm_source={{ _entrypoint }}&utm_medium=referral&utm_campaign={{ _utm_campaign }}&entrypoint={{ _entrypoint }}">{{ _('Why am I seeing this?') }}</a></strong></p>
+  <p>
+    <strong><a href="https://support.mozilla.org/kb/firefox-browser-welcome-pages/?utm_source={{ _entrypoint }}&utm_medium=referral&utm_campaign={{ _utm_campaign }}&entrypoint={{ _entrypoint }}">
+      {{ ftl('welcome-page2-why-am-i-seeing-this') }}
+    </a></strong>
+  </p>
 {% endblock %}
 
 {% block js %}

--- a/bedrock/firefox/urls.py
+++ b/bedrock/firefox/urls.py
@@ -107,7 +107,7 @@ urlpatterns = (
         name='firefox.stub_attribution_code'),
 
     url(r'^firefox/welcome/1/$', views.firefox_welcome_page1, name='firefox.welcome.page1'),
-    page('firefox/welcome/2', 'firefox/welcome/page2.html'),
+    page('firefox/welcome/2', 'firefox/welcome/page2.html', ftl_files=['firefox/welcome/page2']),
     page('firefox/welcome/3', 'firefox/welcome/page3.html'),
     page('firefox/welcome/4', 'firefox/welcome/page4.html'),
     page('firefox/welcome/5', 'firefox/welcome/page5.html'),

--- a/l10n/en/firefox/welcome/page2.ftl
+++ b/l10n/en/firefox/welcome/page2.ftl
@@ -1,0 +1,19 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+### URL: https://www-dev.allizom.org/firefox/welcome/2/
+
+# HTML page title
+welcome-page2-pocket-save-news-videos-stories = { -brand-name-pocket } - Save news, videos, stories and more
+
+welcome-page2-your-time-online-is-worth = Your time online is worth protecting
+welcome-page2-discover-and-save-stories = Discover and save stories in { -brand-name-pocket } — and come back to them when you’re free.
+welcome-page2-activate-pocket = Activate { -brand-name-pocket }
+welcome-page2-pocket = { -brand-name-pocket }
+welcome-page2-pocket-is-built-right-into = { -brand-name-pocket } is built right into { -brand-name-firefox }, so you can easily save stories as you find them, then read them later on any device.
+welcome-page2-save-content-from-everywhere = Save content from everywhere
+welcome-page2-grab-articles-videos-and-links = Grab articles, videos, and links from any website by clicking the { -brand-name-pocket } icon in your browser toolbar.
+welcome-page2-discover-new-stories = Discover new stories
+welcome-page2-pocket-shows-recommended-stories = { -brand-name-pocket } shows recommended stories every time you open a new tab. Save the ones that interest you.
+welcome-page2-why-am-i-seeing-this = Why am I seeing this?

--- a/lib/fluent_migrations/firefox/welcome/page2.py
+++ b/lib/fluent_migrations/firefox/welcome/page2.py
@@ -1,0 +1,92 @@
+from __future__ import absolute_import
+import fluent.syntax.ast as FTL
+from fluent.migrate.helpers import transforms_from
+from fluent.migrate.helpers import VARIABLE_REFERENCE, TERM_REFERENCE
+from fluent.migrate import REPLACE, COPY
+
+page2 = "firefox/welcome/page2.lang"
+
+def migrate(ctx):
+    """Migrate bedrock/firefox/templates/firefox/welcome/page2.html, part {index}."""
+
+    ctx.add_transforms(
+        "firefox/welcome/page2.ftl",
+        "firefox/welcome/page2.ftl",
+        [
+            FTL.Message(
+                id=FTL.Identifier("welcome-page2-pocket-save-news-videos-stories"),
+                value=REPLACE(
+                    page2,
+                    "Pocket - Save news, videos, stories and more",
+                    {
+                        "Pocket": TERM_REFERENCE("brand-name-pocket"),
+                    }
+                )
+            ),
+        ] + transforms_from("""
+welcome-page2-your-time-online-is-worth = {COPY(page2, "Your time online is worth protecting",)}
+""", page2=page2) + [
+            FTL.Message(
+                id=FTL.Identifier("welcome-page2-discover-and-save-stories"),
+                value=REPLACE(
+                    page2,
+                    "Discover and save stories in Pocket — and come back to them when you’re free.",
+                    {
+                        "Pocket": TERM_REFERENCE("brand-name-pocket"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("welcome-page2-activate-pocket"),
+                value=REPLACE(
+                    page2,
+                    "Activate Pocket",
+                    {
+                        "Pocket": TERM_REFERENCE("brand-name-pocket"),
+                    }
+                )
+            ),
+        ] + transforms_from("""
+welcome-page2-pocket = { -brand-name-pocket }
+""", page2=page2) + [
+            FTL.Message(
+                id=FTL.Identifier("welcome-page2-pocket-is-built-right-into"),
+                value=REPLACE(
+                    page2,
+                    "Pocket is built right into Firefox, so you can easily save stories as you find them, then read them later on any device.",
+                    {
+                        "Pocket": TERM_REFERENCE("brand-name-pocket"),
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                    }
+                )
+            ),
+        ] + transforms_from("""
+welcome-page2-save-content-from-everywhere = {COPY(page2, "Save content from everywhere",)}
+""", page2=page2) + [
+            FTL.Message(
+                id=FTL.Identifier("welcome-page2-grab-articles-videos-and-links"),
+                value=REPLACE(
+                    page2,
+                    "Grab articles, videos, and links from any website by clicking the Pocket icon in your browser toolbar.",
+                    {
+                        "Pocket": TERM_REFERENCE("brand-name-pocket"),
+                    }
+                )
+            ),
+        ] + transforms_from("""
+welcome-page2-discover-new-stories = {COPY(page2, "Discover new stories",)}
+""", page2=page2) + [
+            FTL.Message(
+                id=FTL.Identifier("welcome-page2-pocket-shows-recommended-stories"),
+                value=REPLACE(
+                    page2,
+                    "Pocket shows recommended stories every time you open a new tab. Save the ones that interest you.",
+                    {
+                        "Pocket": TERM_REFERENCE("brand-name-pocket"),
+                    }
+                )
+            ),
+        ] + transforms_from("""
+welcome-page2-why-am-i-seeing-this = {COPY(page2, "Why am I seeing this?",)}
+""", page2=page2)
+        )


### PR DESCRIPTION
## Description
- Migrates `firefox/welcome/page2.lang` to `firefox/welcome/page2.ftl`.
- Updates template to use Fluent IDs.

http://localhost:8000/en-US/firefox/welcome/2/

## Issue / Bugzilla link
#9038

## Testing
```
./manage.py l10n_update
```