### PR TITLE
Migrate firefox/welcome/3 to Fluent (Fixes #9043)

### DIFF
--- a/bedrock/firefox/templates/firefox/welcome/page3.html
+++ b/bedrock/firefox/templates/firefox/welcome/page3.html
@@ -1,14 +1,12 @@
 {# This Source Code Form is subject to the terms of the Mozilla Public
-  # License, v. 2.0. If a copy of the MPL was not distributed with this
-  # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
 
 {% from "macros-protocol.html" import hero with context %}
 
-{% add_lang_files "firefox/welcome/page3" %}
-
 {% extends "firefox/welcome/base.html" %}
 
-{% block page_title %}{{ _('Get the free account that protects your privacy. Join Firefox.') }}{% endblock %}
+{% block page_title %}{{ ftl('welcome-page3-get-the-free-account-that') }}{% endblock %}
 
 {% block page_image %}{{ static('img/firefox/template/page-image-master.jpg') }}{% endblock %}
 
@@ -19,8 +17,8 @@
 
 {% block content_intro %}
   {% call hero(
-    title=_('No account required. But you might want one.'),
-    desc=_('The Firefox browser collects so little data about you, we don’t even require your email address. But when you use it to create a Firefox account, we can protect your privacy across more of your online life.'),
+    title=ftl('welcome-page3-no-account-required-but-you'),
+    desc=ftl('welcome-page3-the-firefox-browser-collects'),
     class='mzp-t-firefox mzp-t-dark',
     include_cta=True,
     heading_level=1
@@ -29,7 +27,7 @@
     <p class="primary-cta">
       {{ fxa_button(
         entrypoint=_entrypoint,
-        button_text=_('Sign In'),
+        button_text=ftl('welcome-page3-sign-in'),
         optional_parameters={'utm_campaign': _utm_campaign, 'utm_content': 'top-cta'},
         optional_attributes={'data-cta-text': 'Sign In', 'data-cta-type': 'fxa-sync', 'data-cta-position': 'primary'}
       ) }}
@@ -44,9 +42,9 @@
         <img src="{{ static('protocol/img/logos/firefox/monitor/logo.svg') }}" alt="">
       </div>
 
-      <h3 class="c-picto-block-title">Firefox Monitor</h3>
+      <h3 class="c-picto-block-title">{{ ftl('welcome-page3-firefox-monitor') }}</h3>
       <div class="c-picto-block-body">
-        <p>{{ _('Have at least one company looking out for your data, instead of leaking it.') }}</p>
+        <p>{{ ftl('welcome-page3-have-at-least-one-company') }}</p>
       </div>
     </div>
 
@@ -54,9 +52,9 @@
       <div class="c-picto-block-image">
         <img src="{{ static('protocol/img/logos/firefox/lockwise/logo.svg') }}" alt="">
       </div>
-      <h3 class="c-picto-block-title">Firefox Lockwise</h3>
+      <h3 class="c-picto-block-title">{{ ftl('welcome-page3-firefox-lockwise') }}</h3>
       <div class="c-picto-block-body">
-        <p>{{ _('Never forget, reset or travel without your passwords again.') }}</p>
+        <p>{{ ftl('welcome-page3-never-forget-reset-or-travel') }}</p>
       </div>
     </div>
 
@@ -64,9 +62,9 @@
       <div class="c-picto-block-image">
         <img src="{{ static('img/logos/fbcontainer/logo-fbcontainer.svg') }}" alt="">
       </div>
-      <h3 class="c-picto-block-title">Facebook Container</h3>
+      <h3 class="c-picto-block-title">{{ ftl('welcome-page3-facebook-container') }}</h3>
       <div class="c-picto-block-body">
-        <p>{{ _('Get a container to keep Facebook out of your business.') }}</p>
+        <p>{{ ftl('welcome-page3-get-a-container-to-keep-facebook') }}</p>
       </div>
     </div>
 
@@ -74,9 +72,9 @@
       <div class="c-picto-block-image">
         <img src="{{ static('img/icons/pocket-outline-red.svg') }}" alt="" width="64">
       </div>
-      <h3 class="c-picto-block-title">Pocket</h3>
+      <h3 class="c-picto-block-title">{{ ftl('welcome-page3-pocket') }}</h3>
       <div class="c-picto-block-body">
-        <p>{{ _('Trade clickbait and fake news for quality content.') }}</p>
+        <p>{{ ftl('welcome-page3-trade-clickbait-and-fake-news') }}</p>
       </div>
     </div>
 
@@ -84,9 +82,9 @@
       <div class="c-picto-block-image">
         <img src="{{ static('protocol/img/logos/firefox/send/logo.svg') }}" alt="">
       </div>
-      <h3 class="c-picto-block-title">Firefox Send</h3>
+      <h3 class="c-picto-block-title">{{ ftl('welcome-page3-firefox-send') }}</h3>
       <div class="c-picto-block-body">
-        <p>{{ _('Send huge files to anyone you want, with self-destructing links.') }}</p>
+        <p>{{ ftl('welcome-page3-send-huge-files-to-anyone') }}</p>
       </div>
     </div>
   </div>
@@ -96,7 +94,7 @@
   <p class="secondary-cta">
     {{ fxa_button(
       entrypoint=_entrypoint,
-      button_text=_('Sign In'),
+      button_text=ftl('welcome-page3-sign-in'),
       optional_parameters={'utm_campaign': _utm_campaign, 'utm_content': 'bottom-cta'},
       optional_attributes={'data-cta-text': 'Sign In', 'data-cta-type': 'fxa-sync', 'data-cta-position': 'secondary'}
     ) }}
@@ -104,7 +102,11 @@
 {% endblock %}
 
 {% block content_utility %}
-  <p><strong><a href="https://support.mozilla.org/kb/firefox-browser-welcome-pages/?utm_source={{ _entrypoint }}&utm_medium=referral&utm_campaign={{ _utm_campaign }}&entrypoint={{ _entrypoint }}">{{ _('Why am I seeing this?') }}</a></strong></p>
+  <p>
+    <strong><a href="https://support.mozilla.org/kb/firefox-browser-welcome-pages/?utm_source={{ _entrypoint }}&utm_medium=referral&utm_campaign={{ _utm_campaign }}&entrypoint={{ _entrypoint }}">
+      {{ ftl('welcome-page3-why-am-i-seeing-this') }}
+    </a></strong>
+  </p>
 {% endblock %}
 
 {% block js %}

--- a/bedrock/firefox/urls.py
+++ b/bedrock/firefox/urls.py
@@ -108,7 +108,7 @@ urlpatterns = (
 
     url(r'^firefox/welcome/1/$', views.firefox_welcome_page1, name='firefox.welcome.page1'),
     page('firefox/welcome/2', 'firefox/welcome/page2.html', ftl_files=['firefox/welcome/page2']),
-    page('firefox/welcome/3', 'firefox/welcome/page3.html'),
+    page('firefox/welcome/3', 'firefox/welcome/page3.html', ftl_files=['firefox/welcome/page3']),
     page('firefox/welcome/4', 'firefox/welcome/page4.html'),
     page('firefox/welcome/5', 'firefox/welcome/page5.html'),
     page('firefox/welcome/6', 'firefox/welcome/page6.html'),

--- a/l10n/en/firefox/welcome/page3.ftl
+++ b/l10n/en/firefox/welcome/page3.ftl
@@ -1,0 +1,23 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+### URL: https://www-dev.allizom.org/firefox/welcome/3/
+
+# HTML page title
+welcome-page3-get-the-free-account-that = Get the free account that protects your privacy. Join { -brand-name-firefox }.
+
+welcome-page3-no-account-required-but-you = No account required. But you might want one.
+welcome-page3-the-firefox-browser-collects = The { -brand-name-firefox } browser collects so little data about you, we don’t even require your email address. But when you use it to create a { -brand-name-firefox-account }, we can protect your privacy across more of your online life.
+welcome-page3-sign-in = Sign In
+welcome-page3-firefox-monitor = { -brand-name-firefox-monitor }
+welcome-page3-have-at-least-one-company = Have at least one company looking out for your data, instead of leaking it.
+welcome-page3-firefox-lockwise = { -brand-name-firefox-lockwise }
+welcome-page3-never-forget-reset-or-travel = Never forget, reset or travel without your passwords again.
+welcome-page3-facebook-container = { -brand-name-facebook-container }
+welcome-page3-get-a-container-to-keep-facebook = Get a container to keep { -brand-name-facebook } out of your business.
+welcome-page3-pocket = { -brand-name-pocket }
+welcome-page3-trade-clickbait-and-fake-news = Trade clickbait and fake news for quality content.
+welcome-page3-firefox-send = { -brand-name-firefox-send }
+welcome-page3-send-huge-files-to-anyone = Send huge files to anyone you want, with self-destructing links.
+welcome-page3-why-am-i-seeing-this = Why am I seeing this?

--- a/lib/fluent_migrations/firefox/welcome/page3.py
+++ b/lib/fluent_migrations/firefox/welcome/page3.py
@@ -1,0 +1,64 @@
+from __future__ import absolute_import
+import fluent.syntax.ast as FTL
+from fluent.migrate.helpers import transforms_from
+from fluent.migrate.helpers import VARIABLE_REFERENCE, TERM_REFERENCE
+from fluent.migrate import REPLACE, COPY
+
+page3 = "firefox/welcome/page3.lang"
+
+def migrate(ctx):
+    """Migrate bedrock/firefox/templates/firefox/welcome/page3.html, part {index}."""
+
+    ctx.add_transforms(
+        "firefox/welcome/page3.ftl",
+        "firefox/welcome/page3.ftl",
+        [
+            FTL.Message(
+                id=FTL.Identifier("welcome-page3-get-the-free-account-that"),
+                value=REPLACE(
+                    page3,
+                    "Get the free account that protects your privacy. Join Firefox.",
+                    {
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                    }
+                )
+            ),
+        ] + transforms_from("""
+welcome-page3-no-account-required-but-you = {COPY(page3, "No account required. But you might want one.",)}
+""", page3=page3) + [
+            FTL.Message(
+                id=FTL.Identifier("welcome-page3-the-firefox-browser-collects"),
+                value=REPLACE(
+                    page3,
+                    "The Firefox browser collects so little data about you, we don’t even require your email address. But when you use it to create a Firefox account, we can protect your privacy across more of your online life.",
+                    {
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                        "Firefox account": TERM_REFERENCE("brand-name-firefox-account"),
+                    }
+                )
+            ),
+        ] + transforms_from("""
+welcome-page3-firefox-monitor = { -brand-name-firefox-monitor }
+welcome-page3-have-at-least-one-company = {COPY(page3, "Have at least one company looking out for your data, instead of leaking it.",)}
+welcome-page3-firefox-lockwise = { -brand-name-firefox-lockwise }
+welcome-page3-never-forget-reset-or-travel = {COPY(page3, "Never forget, reset or travel without your passwords again.",)}
+welcome-page3-facebook-container = { -brand-name-facebook-container }
+""", page3=page3) + [
+            FTL.Message(
+                id=FTL.Identifier("welcome-page3-get-a-container-to-keep-facebook"),
+                value=REPLACE(
+                    page3,
+                    "Get a container to keep Facebook out of your business.",
+                    {
+                        "Facebook": TERM_REFERENCE("brand-name-facebook"),
+                    }
+                )
+            ),
+        ] + transforms_from("""
+welcome-page3-pocket = { -brand-name-pocket }
+welcome-page3-trade-clickbait-and-fake-news = {COPY(page3, "Trade clickbait and fake news for quality content.",)}
+welcome-page3-firefox-send = { -brand-name-firefox-send }
+welcome-page3-send-huge-files-to-anyone = {COPY(page3, "Send huge files to anyone you want, with self-destructing links.",)}
+welcome-page3-why-am-i-seeing-this = {COPY(page3, "Why am I seeing this?",)}
+""", page3=page3)
+        )


### PR DESCRIPTION
## Description
- Migrates `firefox/welcome/page2.lang` to `firefox/welcome/page2.ftl`.
- Updates template to use Fluent IDs.

http://localhost:8000/en-US/firefox/welcome/3/

## Issue / Bugzilla link
#9043

## Testing
```
./manage.py l10n_update
```