### PR TITLE
Only show browser comparison pages in DEV mode

### DIFF
--- a/bedrock/firefox/urls.py
+++ b/bedrock/firefox/urls.py
@@ -6,6 +6,8 @@ from django.conf.urls import url
 import bedrock.releasenotes.views
 from bedrock.mozorg.util import page
 from bedrock.releasenotes import version_re
+from django.conf import settings
+from bedrock.redirects.util import redirect
 
 from bedrock.firefox import views
 
@@ -129,21 +131,6 @@ urlpatterns = (
 
     page('firefox/features/safebrowser', 'firefox/features/safebrowser.html'),
 
-    page('firefox/browsers/compare', 'firefox/browsers/compare/index.html',
-         ftl_files=['firefox/browsers/compare/index', 'firefox/browsers/compare/shared']),
-    page('firefox/browsers/compare/brave', 'firefox/browsers/compare/brave.html',
-         ftl_files=['firefox/browsers/compare/brave', 'firefox/browsers/compare/shared']),
-    page('firefox/browsers/compare/chrome', 'firefox/browsers/compare/chrome.html',
-         ftl_files=['firefox/browsers/compare/chrome', 'firefox/browsers/compare/shared']),
-    page('firefox/browsers/compare/edge', 'firefox/browsers/compare/edge.html',
-         ftl_files=['firefox/browsers/compare/edge', 'firefox/browsers/compare/shared']),
-    page('firefox/browsers/compare/ie', 'firefox/browsers/compare/ie.html',
-         ftl_files=['firefox/browsers/compare/ie', 'firefox/browsers/compare/shared']),
-    page('firefox/browsers/compare/opera', 'firefox/browsers/compare/opera.html',
-         ftl_files=['firefox/browsers/compare/opera', 'firefox/browsers/compare/shared']),
-    page('firefox/browsers/compare/safari', 'firefox/browsers/compare/safari.html',
-         ftl_files=['firefox/browsers/compare/safari', 'firefox/browsers/compare/shared']),
-
     # Issue 8641
     page('firefox/browsers/best-browser', 'firefox/browsers/best-browser.html'),
     page('firefox/browsers/browser-history', 'firefox/browsers/browser-history.html'),
@@ -167,3 +154,25 @@ urlpatterns = (
     # Issue 8536
     page('firefox/retention/thank-you', 'firefox/retention/thank-you.html'),
 )
+
+if settings.DEV:
+    urlpatterns += (
+        page('firefox/browsers/compare', 'firefox/browsers/compare/index.html',
+             ftl_files=['firefox/browsers/compare/index', 'firefox/browsers/compare/shared']),
+        page('firefox/browsers/compare/brave', 'firefox/browsers/compare/brave.html',
+             ftl_files=['firefox/browsers/compare/brave', 'firefox/browsers/compare/shared']),
+        page('firefox/browsers/compare/chrome', 'firefox/browsers/compare/chrome.html',
+             ftl_files=['firefox/browsers/compare/chrome', 'firefox/browsers/compare/shared']),
+        page('firefox/browsers/compare/edge', 'firefox/browsers/compare/edge.html',
+             ftl_files=['firefox/browsers/compare/edge', 'firefox/browsers/compare/shared']),
+        page('firefox/browsers/compare/ie', 'firefox/browsers/compare/ie.html',
+             ftl_files=['firefox/browsers/compare/ie', 'firefox/browsers/compare/shared']),
+        page('firefox/browsers/compare/opera', 'firefox/browsers/compare/opera.html',
+             ftl_files=['firefox/browsers/compare/opera', 'firefox/browsers/compare/shared']),
+        page('firefox/browsers/compare/safari', 'firefox/browsers/compare/safari.html',
+             ftl_files=['firefox/browsers/compare/safari', 'firefox/browsers/compare/shared']),
+    )
+else:
+    urlpatterns += (
+        redirect(r'^firefox/browsers/compare(/.*)?', 'firefox', permanent=False),
+    )


### PR DESCRIPTION
**Note:** we should only merge this **if** we need to deploy to production **before** we get a go-ahead on the comparison pages. We can also just wait to push prod.

## Description
The browser comparison pages are finished, but it was only after they merged that I learned we're still waiting for a final go/no-go from leadership before publishing them, and we won't get word until tomorrow (25 June) at the earliest. 

Since the pages already merged we're effectively blocked from doing a production push until we have permission to relaunch the comparison pages. However, l10n is already in progress so we need to make sure the pages are still available on dev/demo, so I don't want to revert the commit or redirect the URLs. I considered putting the pages behind a switch but I think that would entail routing them through a view (don't think we can do switches in urls.py) and this dev mode rule was simpler.

tl;dr: this is a quick-and-dirty hack just to unblock us from pushing production. We might not even need it.

## Testing
http://localhost:8000/firefox/browsers/compare/ (and sub-pages)

- [ ] Pages should load normally when `DEV=True`
- [ ] Pages should redirect to /firefox when `DEV=False`
