### PR TITLE
Add a fallback to the en version of a brand term for Fluent strings

### DIFF
--- a/lib/l10n_utils/tests/test_files/l10n/de/mozorg/fluent.ftl
+++ b/lib/l10n_utils/tests/test_files/l10n/de/mozorg/fluent.ftl
@@ -1,3 +1,4 @@
 fluent-title = Title in German
 fluent-page-desc = Description in {$lang}
 fluent-header-title = German words and things
+fluent-brand = German { -brand-name-fluent }

--- a/lib/l10n_utils/tests/test_files/l10n/en/brands.ftl
+++ b/lib/l10n_utils/tests/test_files/l10n/en/brands.ftl
@@ -1,0 +1,1 @@
+-brand-name-fluent = Fluent

--- a/lib/l10n_utils/tests/test_files/l10n/en/mozorg/fluent.ftl
+++ b/lib/l10n_utils/tests/test_files/l10n/en/mozorg/fluent.ftl
@@ -4,10 +4,11 @@
 ##
 ## Required
 
-fluent-title = This is a test of the new Fluent L10n system
+fluent-title = This is a test of the new { -brand-name-fluent } L10n system
 fluent-page-desc = This is the {$lang} description
 
 ## Not required
 
-fluent-header-title = This is a test of the new Fluent L10n system
+fluent-header-title = This is a test of the new { -brand-name-fluent } L10n system
 brand-new-string = New string not yet available in all languages
+fluent-brand = English { -brand-name-fluent }

--- a/lib/l10n_utils/tests/test_files/l10n/fr/brands.ftl
+++ b/lib/l10n_utils/tests/test_files/l10n/fr/brands.ftl
@@ -1,0 +1,1 @@
+-brand-name-fluent = Couramment

--- a/lib/l10n_utils/tests/test_files/l10n/fr/mozorg/fluent.ftl
+++ b/lib/l10n_utils/tests/test_files/l10n/fr/mozorg/fluent.ftl
@@ -1,3 +1,4 @@
 fluent-title = Title in French
 fluent-header-title = French words and things
 brand-new-string = New french string not yet available in all languages
+fluent-brand = French { -brand-name-fluent }


### PR DESCRIPTION
In Fluent each term you use in a string has to be availalbe in that locale bundle. This is a bit of a hack around that. This change looks for the presence of a term ID in the translated string, and if it sees one it will add the string as a new ID to a new translation context with the en brands.ftl loaded so that it will attempt to use the default english terms.

I'll be adding a new term to a page to test and make sure it doesn't show in the translations and deploy a demo.