### PR TITLE
[fix #9050] Remove “beta” from FPN terms and privacy policy

### DIFF
--- a/bedrock/legal/templates/legal/terms/firefox-private-network.html
+++ b/bedrock/legal/templates/legal/terms/firefox-private-network.html
@@ -4,12 +4,12 @@
 
 {% extends "legal/docs-base.html" %}
 
-{% block page_title %}{{ _('Firefox Private Network (Beta) Terms of Service') }}{% endblock %}
+{% block page_title %}{{ _('Firefox Private Network Terms of Service') }}{% endblock %}
 
 {% block article %}
 <article class="section-content" itemscope itemtype="http://schema.org/Article">
   <div itemprop="articleBody" class="article-body">
-    <h1>{{ _('Firefox Private Network (Beta) Terms of Service') }}</h1>
+    <h1>{{ _('Firefox Private Network Terms of Service') }}</h1>
     <p><time>{{ _('Version 2.0, effective December 3, 2019') }}</time></p>
 
     <p>

--- a/bedrock/privacy/templates/privacy/notices/firefox-private-network.html
+++ b/bedrock/privacy/templates/privacy/notices/firefox-private-network.html
@@ -13,7 +13,7 @@
 
 {% block article_header_logo %}{{ static('protocol/img/logos/firefox/browser/logo-md.png') }}{% endblock %}
 
-{% block title %}{{ _('Firefox Private Network (Beta) Privacy Notice') }}{% endblock %}
+{% block title %}{{ _('Firefox Private Network Privacy Notice') }}{% endblock %}
 {% block time %}{{ _('Version 2.0, dated December 3, 2019') }}{% endblock %}
 
 {% block lead_in %}


### PR DESCRIPTION
## Description
Remove "(Beta)" from page titles.

## Issue / Bugzilla link
#9050 

## Testing
http://localhost:8000/privacy/firefox-private-network/
http://localhost:8000/about/legal/terms/firefox-private-network/