### PR TITLE
Migrate firefox/welcome/4/ to Fluent (Fixes #9054) [skip l10n]

### DIFF
--- a/bedrock/firefox/templates/firefox/welcome/page4.html
+++ b/bedrock/firefox/templates/firefox/welcome/page4.html
@@ -1,16 +1,13 @@
 {# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
 
 {% from "macros.html" import google_play_button, send_to_device with context %}
 {% from "macros-protocol.html" import hero with context %}
 
-{% add_lang_files "firefox/welcome/page4" %}
-
 {% extends "firefox/welcome/base.html" %}
 
-{# L10n: HTML page title #}
-{% block page_title %}{{ _('Download the Firefox Browser on your Mobile for iOS and Android') }}{% endblock %}
+{% block page_title %}{{ ftl('welcome-page4-download-the-firefox-browser') }}{% endblock %}
 
 {% block body_class %}{{ super() }} welcome-page4{% endblock %}
 
@@ -24,8 +21,8 @@
 {# L10n: the strong tag here is to underline Firefox. #}
 {% block content_intro %}
 {% call hero(
-    title=_('Wallet. Keys. Phone. <strong>Firefox.</strong>'),
-    desc=_('Take privacy with you on every device — and leave the data trackers behind.'),
+    title=ftl('welcome-page4-wallet-keys-phone-firefox'),
+    desc=ftl('welcome-page4-take-privacy-with-you-on-every'),
     class='mzp-t-firefox mzp-t-dark',
     include_cta=True,
     heading_level=1
@@ -33,21 +30,20 @@
 
   <p class="primary-cta">
     <button class="js-modal-link mzp-c-button mzp-t-product" data-cta-position="primary" data-cta-type="button" data-cta-text="Get the Firefox App">
-      {{ _('Get the Firefox App') }}
+      {{ ftl('welcome-page4-get-the-firefox-app') }}
     </button>
   </p>
 
   {% endcall %}
 
   <div id="modal" class="mzp-u-modal-content mzp-l-content">
-    <h2 class="modal-title">{{ _('Get Firefox on your Phone') }}</h2>
+    <h2 class="modal-title">{{ ftl('welcome-page4-get-firefox-on-your-phone') }}</h2>
 
     {% if show_send_to_device %}
-      <p>{{ _('Send the download link right to your phone or email.') }}</p>
+      <p>{{ ftl('welcome-page4-send-the-download-link-right') }}</p>
       {{ send_to_device(include_title=False, class='vertical', message_set='firefox-mobile-welcome') }}
     {% else %}
-      {# L10n: This string is reused from firefox/whatsnew #}
-      <p>{{ _('Download Firefox for your smartphone and tablet.') }}</p>
+      <p>{{ ftl('welcome-page4-download-firefox-for-your') }}</p>
       <div class="qr-code-wrapper">
         <img src="{{ static('img/firefox/welcome/welcome-qr-firefox.png') }}" id="firefox-qr"
           alt="">
@@ -69,8 +65,8 @@
 
 {% block content_primary %}
 <div class="body-primary">
-  <img class="primary-image" src="{{ static('img/firefox/welcome/mobile-hero.png') }}" width="700" height="" alt="{{ _('Download Firefox for your smartphone and tablet.') }}">
-  <p class="primary-image-desc">{{ _('“Firefox: Private, Safe Browser” on iOS or Android.') }}</p>
+  <img class="primary-image" src="{{ static('img/firefox/welcome/mobile-hero.png') }}" width="700" height="" alt="{{ ftl('welcome-page4-download-firefox-for-your') }}">
+  <p class="primary-image-desc">{{ ftl('welcome-page4-firefox-private-safe-browser') }}</p>
 </div>
 
 {% endblock %}
@@ -81,8 +77,7 @@
     <img src="{{ static('img/icons/gradient-shield.svg') }}" alt="">
   </div>
 
-  {# L10n: "off your trail" is an expression for not being followed around. #}
-  <h3 class="c-picto-block-title">{{ _('Get data trackers off your trail') }}</h3>
+  <h3 class="c-picto-block-title">{{ ftl('welcome-page4-get-data-trackers-off-your') }}</h3>
   <div class="c-picto-block-body">
     <p>
       {% set frende = ['en-US', 'en-GB', 'en-CA', 'de', 'fr', 'es-ES'] %}
@@ -92,9 +87,7 @@
         {% set privacy = url('firefox.privacy.products') %}
       {% endif %}
 
-      {% trans %}
-      Enhanced Tracking Protection <a href="{{ privacy }}">blocks 2000+ trackers</a> from chasing you around the web.
-      {% endtrans %}
+      {{ ftl('welcome-page4-enhanced-tracking-protection', privacy=privacy) }}
     </p>
   </div>
 </div>
@@ -104,10 +97,9 @@
     <img src="{{ static('img/icons/eraser.svg') }}" alt="">
   </div>
 
-  {# L10n: "Leave no trace" is an expression for leaving nothing behind. #}
-  <h3 class="c-picto-block-title">{{ _('Leave no trace') }}</h3>
+  <h3 class="c-picto-block-title">{{ ftl('welcome-page4-leave-no-trace') }}</h3>
   <div class="c-picto-block-body">
-    <p>{{ _('Automatically clear your history and cookies with Private Browsing mode.') }}</p>
+    <p>{{ ftl('welcome-page4-automatically-clear-your-history') }}</p>
   </div>
 </div>
 
@@ -116,9 +108,9 @@
     <img src="{{ static('img/icons/arrows.svg') }}" alt="">
   </div>
 
-  <h3 class="c-picto-block-title">{{ _('Take it all with you') }}</h3>
+  <h3 class="c-picto-block-title">{{ ftl('welcome-page4-take-it-all-with-you') }}</h3>
   <div class="c-picto-block-body">
-    <p>{{ _('Don’t walk out the door without your bookmarks, tabs, notes, and passwords.') }}</p>
+    <p>{{ ftl('welcome-page4-dont-walk-out-the-door-without') }}</p>
   </div>
 </div>
 {% endblock %}
@@ -126,7 +118,7 @@
 {% block secondary_cta %}
 <p class="secondary-cta">
   <button class="js-modal-link mzp-c-button mzp-t-product" data-cta-position="secondary" data-cta-type="button" data-cta-text="Get the Firefox App">
-    {{ _('Get the Firefox App') }}
+    {{ ftl('welcome-page4-get-the-firefox-app') }}
   </button>
 </p>
 {% endblock %}
@@ -134,7 +126,9 @@
 {% block content_utility %}
 <p>
   <strong>
-    <a href="https://support.mozilla.org/kb/firefox-browser-welcome-pages/?utm_source={{ _entrypoint }}&utm_medium=referral&utm_campaign={{ _utm_campaign }}&entrypoint={{ _entrypoint }}">{{ _('Why am I seeing this?') }}</a>
+    <a href="https://support.mozilla.org/kb/firefox-browser-welcome-pages/?utm_source={{ _entrypoint }}&utm_medium=referral&utm_campaign={{ _utm_campaign }}&entrypoint={{ _entrypoint }}">
+      {{ ftl('welcome-page4-why-am-i-seeing-this') }}
+    </a>
   </strong>
 </p>
 {% endblock %}

--- a/bedrock/firefox/urls.py
+++ b/bedrock/firefox/urls.py
@@ -109,7 +109,7 @@ urlpatterns = (
     url(r'^firefox/welcome/1/$', views.firefox_welcome_page1, name='firefox.welcome.page1'),
     page('firefox/welcome/2', 'firefox/welcome/page2.html', ftl_files=['firefox/welcome/page2']),
     page('firefox/welcome/3', 'firefox/welcome/page3.html', ftl_files=['firefox/welcome/page3']),
-    page('firefox/welcome/4', 'firefox/welcome/page4.html'),
+    page('firefox/welcome/4', 'firefox/welcome/page4.html', ftl_files=['firefox/welcome/page4']),
     page('firefox/welcome/5', 'firefox/welcome/page5.html'),
     page('firefox/welcome/6', 'firefox/welcome/page6.html'),
     page('firefox/welcome/7', 'firefox/welcome/page7.html'),

--- a/l10n/en/firefox/welcome/page4.ftl
+++ b/l10n/en/firefox/welcome/page4.ftl
@@ -1,0 +1,31 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+### URL: https://www-dev.allizom.org/firefox/welcome/4/
+
+# HTML page title
+welcome-page4-download-the-firefox-browser = Download the { -brand-name-firefox-browser } on your Mobile for { -brand-name-ios } and { -brand-name-android }
+
+welcome-page4-wallet-keys-phone-firefox = Wallet. Keys. Phone. <strong>{ -brand-name-firefox }.</strong>
+welcome-page4-take-privacy-with-you-on-every = Take privacy with you on every device — and leave the data trackers behind.
+welcome-page4-get-the-firefox-app = Get the { -brand-name-firefox } App
+welcome-page4-get-firefox-on-your-phone = Get { -brand-name-firefox } on your Phone
+welcome-page4-send-the-download-link-right = Send the download link right to your phone or email.
+welcome-page4-download-firefox-for-your = Download { -brand-name-firefox } for your smartphone and tablet.
+welcome-page4-firefox-private-safe-browser = “{ -brand-name-firefox }: Private, Safe Browser” on { -brand-name-ios } or { -brand-name-android }.
+
+# "off your trail" is an expression for not being followed around.
+welcome-page4-get-data-trackers-off-your = Get data trackers off your trail
+
+# Variables:
+#   $privacy (url) - link to https://www.mozilla.org/firefox/privacy/products/ or https://support.mozilla.org/kb/enhanced-tracking-protection-firefox-desktop depending on locale.
+welcome-page4-enhanced-tracking-protection = Enhanced Tracking Protection <a href="{ $privacy }">blocks 2000+ trackers</a> from chasing you around the web.
+
+# "Leave no trace" is an expression for leaving nothing behind.
+welcome-page4-leave-no-trace = Leave no trace
+
+welcome-page4-automatically-clear-your-history = Automatically clear your history and cookies with Private Browsing mode.
+welcome-page4-take-it-all-with-you = Take it all with you
+welcome-page4-dont-walk-out-the-door-without = Don’t walk out the door without your bookmarks, tabs, notes, and passwords.
+welcome-page4-why-am-i-seeing-this = Why am I seeing this?

--- a/lib/fluent_migrations/firefox/welcome/page4.py
+++ b/lib/fluent_migrations/firefox/welcome/page4.py
@@ -1,0 +1,107 @@
+from __future__ import absolute_import
+import fluent.syntax.ast as FTL
+from fluent.migrate.helpers import transforms_from
+from fluent.migrate.helpers import VARIABLE_REFERENCE, TERM_REFERENCE
+from fluent.migrate import REPLACE, COPY
+
+page4 = "firefox/welcome/page4.lang"
+
+def migrate(ctx):
+    """Migrate bedrock/firefox/templates/firefox/welcome/page4.html, part {index}."""
+
+    ctx.add_transforms(
+        "firefox/welcome/page4.ftl",
+        "firefox/welcome/page4.ftl",
+        [
+            FTL.Message(
+                id=FTL.Identifier("welcome-page4-download-the-firefox-browser"),
+                value=REPLACE(
+                    page4,
+                    "Download the Firefox Browser on your Mobile for iOS and Android",
+                    {
+                        "Firefox Browser": TERM_REFERENCE("brand-name-firefox-browser"),
+                        "iOS": TERM_REFERENCE("brand-name-ios"),
+                        "Android": TERM_REFERENCE("brand-name-android"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("welcome-page4-wallet-keys-phone-firefox"),
+                value=REPLACE(
+                    page4,
+                    "Wallet. Keys. Phone. <strong>Firefox.</strong>",
+                    {
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                    }
+                )
+            ),
+        ] + transforms_from("""
+welcome-page4-take-privacy-with-you-on-every = {COPY(page4, "Take privacy with you on every device — and leave the data trackers behind.",)}
+""", page4=page4) + [
+            FTL.Message(
+                id=FTL.Identifier("welcome-page4-get-the-firefox-app"),
+                value=REPLACE(
+                    page4,
+                    "Get the Firefox App",
+                    {
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("welcome-page4-get-firefox-on-your-phone"),
+                value=REPLACE(
+                    page4,
+                    "Get Firefox on your Phone",
+                    {
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                    }
+                )
+            ),
+        ] + transforms_from("""
+welcome-page4-send-the-download-link-right = {COPY(page4, "Send the download link right to your phone or email.",)}
+""", page4=page4) + [
+            FTL.Message(
+                id=FTL.Identifier("welcome-page4-download-firefox-for-your"),
+                value=REPLACE(
+                    page4,
+                    "Download Firefox for your smartphone and tablet.",
+                    {
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("welcome-page4-firefox-private-safe-browser"),
+                value=REPLACE(
+                    page4,
+                    "“Firefox: Private, Safe Browser” on iOS or Android.",
+                    {
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                        "iOS": TERM_REFERENCE("brand-name-ios"),
+                        "Android": TERM_REFERENCE("brand-name-android"),
+                    }
+                )
+            ),
+        ] + transforms_from("""
+welcome-page4-get-data-trackers-off-your = {COPY(page4, "Get data trackers off your trail",)}
+""", page4=page4) + [
+            FTL.Message(
+                id=FTL.Identifier("welcome-page4-enhanced-tracking-protection"),
+                value=REPLACE(
+                    page4,
+                    "Enhanced Tracking Protection <a href=\"%(privacy)s\">blocks 2000+ trackers</a> from chasing you around the web.",
+                    {
+                        "%%": "%",
+                        "%(privacy)s": VARIABLE_REFERENCE("privacy"),
+                    }
+                )
+            ),
+        ] + transforms_from("""
+welcome-page4-leave-no-trace = {COPY(page4, "Leave no trace",)}
+welcome-page4-automatically-clear-your-history = {COPY(page4, "Automatically clear your history and cookies with Private Browsing mode.",)}
+welcome-page4-take-it-all-with-you = {COPY(page4, "Take it all with you",)}
+welcome-page4-dont-walk-out-the-door-without = {COPY(page4, "Don’t walk out the door without your bookmarks, tabs, notes, and passwords.",)}
+welcome-page4-why-am-i-seeing-this = {COPY(page4, "Why am I seeing this?",)}
+""", page4=page4)
+        )


### PR DESCRIPTION
## Description
- Migrates `firefox/welcome/page4.lang` to `firefox/welcome/page4.ftl`.
- Updates template to use Fluent IDs.

http://localhost:8000/en-US/firefox/welcome/4/

## Issue / Bugzilla link
#9054

## Testing
```
./manage.py l10n_update
```