### PR TITLE
[#9019] Evade traffic cop in /new functional tests

### DIFF
--- a/tests/functional/firefox/new/test_download.py
+++ b/tests/functional/firefox/new/test_download.py
@@ -6,11 +6,14 @@ import pytest
 
 from pages.firefox.new.download import DownloadPage
 
+# ?v=a param added temporarily to evade a traffic cop experiment
+# See https://github.com/mozilla/bedrock/issues/9019
+
 
 @pytest.mark.sanity
 @pytest.mark.nondestructive
 def test_download_button_displayed(base_url, selenium):
-    page = DownloadPage(selenium, base_url, params='').open()
+    page = DownloadPage(selenium, base_url, params='?v=a').open()
     assert page.download_button.is_displayed
 
 
@@ -19,14 +22,14 @@ def test_download_button_displayed(base_url, selenium):
 @pytest.mark.skip_if_internet_explorer(reason='https://github.com/SeleniumHQ/selenium/issues/448')
 @pytest.mark.nondestructive
 def test_click_download_button(base_url, selenium):
-    page = DownloadPage(selenium, base_url, params='').open()
+    page = DownloadPage(selenium, base_url, params='?v=a').open()
     thank_you_page = page.download_firefox()
     assert thank_you_page.seed_url in selenium.current_url
 
 
 @pytest.mark.nondestructive
 def test_other_platforms_modal(base_url, selenium):
-    page = DownloadPage(selenium, base_url, params='').open()
+    page = DownloadPage(selenium, base_url, params='?v=a').open()
     modal = page.open_other_platforms_modal()
     assert modal.is_displayed
     modal.close()
@@ -35,7 +38,7 @@ def test_other_platforms_modal(base_url, selenium):
 @pytest.mark.nondestructive
 @pytest.mark.skip_if_not_firefox(reason='Join Firefox form is only displayed to Firefox users')
 def test_firefox_account_modal(base_url, selenium):
-    page = DownloadPage(selenium, base_url, params='').open()
+    page = DownloadPage(selenium, base_url, params='?v=a').open()
     modal = page.open_join_firefox_modal()
     assert modal.is_displayed
     modal.close()


### PR DESCRIPTION
## Description
The download page redesign experiment directs 3% of visitors to the new page. There's a slight chance automated functional tests would fail if they get that page and can't find the elements the tests are expecting, thus halting a deployment. Since there's not currently an easy way to exclude functional tests from traffic cop (see #8917) this just adds the `?v=a` param to the URL to make sure tests always get the old page design.

## Testing

1. Run `tests/functional/firefox/new/test_download.py`
2. Ensure the browser loads `/firefox/new/?v=a` and that tests pass
3. If you want to be extra-sure, you can set the B variant to 100% in the traffic cop config (`/media/js/firefox/new/desktop/exp.js`)