### PR TITLE
Remove bin entry for browser-sync in package.json (Fixes #/9067)

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,9 +48,6 @@
     "svgo": "^1.2.2",
     "tinypng-cli": "^0.0.7"
   },
-  "bin": {
-    "browser-sync": "/.bin/browser-sync"
-  },
   "scripts": {
     "start": "concurrently --kill-others \"python manage.py runserver 0.0.0.0:8080\" \"gulp\""
   }


### PR DESCRIPTION
## Description
Removes a warning in the console when installing dependencies.

## Issue / Bugzilla link
https://github.com/mozilla/bedrock/issues/9067

## Testing
- [x] Running `yarn` should no longer output the warning.
- [x] Browser-sync should still work as expected.