### PR TITLE
Migrate firefox/welcome/5/ to Fluent (Fixes #9069) [skip l10n]

### DIFF
--- a/bedrock/firefox/templates/firefox/welcome/page5.html
+++ b/bedrock/firefox/templates/firefox/welcome/page5.html
@@ -1,16 +1,13 @@
 {# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
 
 {% from "macros.html" import google_play_button, send_to_device with context %}
 {% from "macros-protocol.html" import hero with context %}
 
-{% add_lang_files "firefox/welcome/page5" %}
-
 {% extends "firefox/welcome/base.html" %}
 
-{# L10n: HTML page title #}
-{% block page_title %}{{ _('Firefox Lockwise — password manager — take your passwords everywhere') }}{% endblock %}
+{% block page_title %}{{ ftl('welcome-page5-firefox-lockwise-password') }}{% endblock %}
 
 {% block page_image %}{{ static('protocol/img/logos/firefox/lockwise/og.png') }}{% endblock %}
 
@@ -25,8 +22,8 @@
 
 {% block content_intro %}
 {% call hero(
-    title=_('There’s an easier way to deal with your passwords'),
-    desc=_('Let Firefox save them for you. Then use Firefox Lockwise to safely access your passwords across all your apps, on all of your devices.'),
+    title=ftl('welcome-page5-theres-an-easier-way-to-deal'),
+    desc=ftl('welcome-page5-let-firefox-save-them-for'),
     class='mzp-t-firefox mzp-t-dark',
     include_cta=True,
     heading_level=1
@@ -34,22 +31,22 @@
 
   <p class="primary-cta">
     <button class="js-modal-link mzp-c-button mzp-t-product" data-cta-position="primary" data-cta-type="button" data-cta-text="Get the Lockwise App">
-      {{ _('Get the Lockwise App') }}
+      {{ ftl('welcome-page5-get-the-lockwise-app') }}
     </button>
   </p>
 
   {% endcall %}
 
   <div id="modal" class="mzp-u-modal-content mzp-l-content">
-    <h2 class="modal-title">{{ _('Get Firefox Lockwise on your Phone') }}</h2>
+    <h2 class="modal-title">{{ ftl('welcome-page5-get-firefox-lockwise-on-your') }}</h2>
 
   {% if show_send_to_device %}
-    <p>{{ _('Send the download link right to your phone or email.') }}</p>
+    <p>{{ ftl('welcome-page5-send-the-download-link-right') }}</p>
     {{ send_to_device(include_title=False, class='vertical', message_set='lockwise-welcome-download') }}
   {% else %}
-    <p>{{ _('Download Firefox Lockwise for your smartphone and tablet.') }}</p>
+    <p>{{ ftl('welcome-page5-download-firefox-lockwise') }}</p>
     <div class="qr-code-wrapper">
-      <img src="{{ static('img/firefox/welcome/welcome-qr-lockwise.png') }}" id="lockwise-qr" alt="{{ _('Scan this QR code') }}">
+      <img src="{{ static('img/firefox/welcome/welcome-qr-lockwise.png') }}" id="lockwise-qr" alt="{{ ftl('welcome-page5-scan-this-qr-code') }}">
     </div>
   {% endif %}
 
@@ -68,7 +65,9 @@
 
 {% block content_primary %}
   <div class="body-primary">
-    <h2 class="body-primary-title"><img src="{{ static('protocol/img/logos/firefox/lockwise/logo-word-ver.svg') }}" width="208" height="" alt="Firefox Lockwise"></h2>
+    <h2 class="body-primary-title">
+      <img src="{{ static('protocol/img/logos/firefox/lockwise/logo-word-ver.svg') }}" width="208" height="" alt="{{ ftl('welcome-page5-firefox-lockwise') }}">
+    </h2>
   </div>
 {% endblock %}
 
@@ -79,9 +78,9 @@
         <img src="{{ static('img/icons/key.svg') }}" alt="">
       </div>
 
-      <h3 class="c-picto-block-title">{{ _('Sync up safely') }}</h3>
+      <h3 class="c-picto-block-title">{{ ftl('welcome-page5-sync-up-safely') }}</h3>
       <div class="c-picto-block-body">
-        <p>{{ _('With 256-bit encryption, your passwords always travel to your devices securely.') }}</p>
+        <p>{{ ftl('welcome-page5-with-256-bit-encryption-your') }}</p>
       </div>
     </div>
 
@@ -89,9 +88,9 @@
       <div class="c-picto-block-image">
         <img src="{{ static('img/icons/password.svg') }}" alt="">
       </div>
-      <h3 class="c-picto-block-title">{{ _('No more making up new passwords') }}</h3>
+      <h3 class="c-picto-block-title">{{ ftl('welcome-page5-no-more-making-up-new-passwords') }}</h3>
       <div class="c-picto-block-body">
-        <p>{{ _('Lockwise will recommend new, strong passwords whenever you set up a new login.') }}</p>
+        <p>{{ ftl('welcome-page5-lockwise-will-recommend-new') }}</p>
       </div>
     </div>
 
@@ -99,9 +98,9 @@
       <div class="c-picto-block-image">
         <img src="{{ static('img/icons/email-alert.svg') }}" alt="">
       </div>
-      <h3 class="c-picto-block-title">{{ _('Help during a breach') }}</h3>
+      <h3 class="c-picto-block-title">{{ ftl('welcome-page5-help-during-a-breach') }}</h3>
       <div class="c-picto-block-body">
-        <p>{{ _('Lockwise will let you know if your saved logins have been part of a corporate data breach, so you can change them asap.') }}</p>
+        <p>{{ ftl('welcome-page5-lockwise-will-let-you-know') }}</p>
       </div>
     </div>
   </div>
@@ -110,7 +109,7 @@
 {% block secondary_cta %}
 <p class="secondary-cta">
   <button class="js-modal-link mzp-c-button mzp-t-product" data-cta-position="secondary" data-cta-type="button" data-cta-text="Get the Lockwise App">
-    {{ _('Get the Lockwise App') }}
+    {{ ftl('welcome-page5-get-the-lockwise-app') }}
   </button>
 </p>
 {% endblock %}
@@ -118,11 +117,13 @@
 {% block content_utility %}
 <p>
   <strong>
-    <a href="https://support.mozilla.org/kb/firefox-browser-welcome-pages/?utm_source={{ _entrypoint }}&utm_medium=referral&utm_campaign={{ _utm_campaign }}&entrypoint={{ _entrypoint }}">{{ _('Why am I seeing this?') }}</a>
+    <a href="https://support.mozilla.org/kb/firefox-browser-welcome-pages/?utm_source={{ _entrypoint }}&utm_medium=referral&utm_campaign={{ _utm_campaign }}&entrypoint={{ _entrypoint }}">
+      {{ ftl('welcome-page5-why-am-i-seeing-this') }}
+    </a>
   </strong>
 </p>
 {% endblock %}
 
 {% block js %}
-{{ js_bundle('firefox_welcome_page5') }}
+  {{ js_bundle('firefox_welcome_page5') }}
 {% endblock %}

--- a/bedrock/firefox/urls.py
+++ b/bedrock/firefox/urls.py
@@ -110,7 +110,7 @@ urlpatterns = (
     page('firefox/welcome/2', 'firefox/welcome/page2.html', ftl_files=['firefox/welcome/page2']),
     page('firefox/welcome/3', 'firefox/welcome/page3.html', ftl_files=['firefox/welcome/page3']),
     page('firefox/welcome/4', 'firefox/welcome/page4.html', ftl_files=['firefox/welcome/page4']),
-    page('firefox/welcome/5', 'firefox/welcome/page5.html'),
+    page('firefox/welcome/5', 'firefox/welcome/page5.html', ftl_files=['firefox/welcome/page5']),
     page('firefox/welcome/6', 'firefox/welcome/page6.html'),
     page('firefox/welcome/7', 'firefox/welcome/page7.html'),
     page('firefox/welcome/8', 'firefox/welcome/page8.html'),

--- a/l10n/en/firefox/welcome/page5.ftl
+++ b/l10n/en/firefox/welcome/page5.ftl
@@ -1,0 +1,24 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+### URL: https://www-dev.allizom.org/firefox/welcome/5/
+
+# HTML page title
+welcome-page5-firefox-lockwise-password = { -brand-name-firefox-lockwise } — password manager — take your passwords everywhere
+
+welcome-page5-theres-an-easier-way-to-deal = There’s an easier way to deal with your passwords
+welcome-page5-let-firefox-save-them-for = Let { -brand-name-firefox } save them for you. Then use { -brand-name-firefox-lockwise } to safely access your passwords across all your apps, on all of your devices.
+welcome-page5-get-the-lockwise-app = Get the { -brand-name-lockwise } App
+welcome-page5-get-firefox-lockwise-on-your = Get { -brand-name-firefox-lockwise } on your Phone
+welcome-page5-send-the-download-link-right = Send the download link right to your phone or email.
+welcome-page5-download-firefox-lockwise = Download { -brand-name-firefox-lockwise } for your smartphone and tablet.
+welcome-page5-scan-this-qr-code = Scan this QR code
+welcome-page5-firefox-lockwise = { -brand-term-firefox-lockwise }
+welcome-page5-sync-up-safely = Sync up safely
+welcome-page5-with-256-bit-encryption-your = With 256-bit encryption, your passwords always travel to your devices securely.
+welcome-page5-no-more-making-up-new-passwords = No more making up new passwords
+welcome-page5-lockwise-will-recommend-new = { -brand-name-lockwise } will recommend new, strong passwords whenever you set up a new login.
+welcome-page5-help-during-a-breach = Help during a breach
+welcome-page5-lockwise-will-let-you-know = { -brand-name-lockwise } will let you know if your saved logins have been part of a corporate data breach, so you can change them ASAP.
+welcome-page5-why-am-i-seeing-this = Why am I seeing this?

--- a/lib/fluent_migrations/firefox/welcome/page5.py
+++ b/lib/fluent_migrations/firefox/welcome/page5.py
@@ -1,0 +1,106 @@
+from __future__ import absolute_import
+import fluent.syntax.ast as FTL
+from fluent.migrate.helpers import transforms_from
+from fluent.migrate.helpers import VARIABLE_REFERENCE, TERM_REFERENCE
+from fluent.migrate import REPLACE, COPY
+
+page5 = "firefox/welcome/page5.lang"
+
+def migrate(ctx):
+    """Migrate bedrock/firefox/templates/firefox/welcome/page5.html, part {index}."""
+
+    ctx.add_transforms(
+        "firefox/welcome/page5.ftl",
+        "firefox/welcome/page5.ftl",
+        [
+            FTL.Message(
+                id=FTL.Identifier("welcome-page5-firefox-lockwise-password"),
+                value=REPLACE(
+                    page5,
+                    "Firefox Lockwise — password manager — take your passwords everywhere",
+                    {
+                        "Firefox Lockwise": TERM_REFERENCE("brand-name-firefox-lockwise"),
+                    }
+                )
+            ),
+        ] + transforms_from("""
+welcome-page5-theres-an-easier-way-to-deal = {COPY(page5, "There’s an easier way to deal with your passwords",)}
+""", page5=page5) + [
+            FTL.Message(
+                id=FTL.Identifier("welcome-page5-let-firefox-save-them-for"),
+                value=REPLACE(
+                    page5,
+                    "Let Firefox save them for you. Then use Firefox Lockwise to safely access your passwords across all your apps, on all of your devices.",
+                    {
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                        "Firefox Lockwise": TERM_REFERENCE("brand-name-firefox-lockwise"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("welcome-page5-get-the-lockwise-app"),
+                value=REPLACE(
+                    page5,
+                    "Get the Lockwise App",
+                    {
+                        "Lockwise": TERM_REFERENCE("brand-name-lockwise"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("welcome-page5-get-firefox-lockwise-on-your"),
+                value=REPLACE(
+                    page5,
+                    "Get Firefox Lockwise on your Phone",
+                    {
+                        "Firefox Lockwise": TERM_REFERENCE("brand-name-firefox-lockwise"),
+                    }
+                )
+            ),
+        ] + transforms_from("""
+welcome-page5-send-the-download-link-right = {COPY(page5, "Send the download link right to your phone or email.",)}
+""", page5=page5) + [
+            FTL.Message(
+                id=FTL.Identifier("welcome-page5-download-firefox-lockwise"),
+                value=REPLACE(
+                    page5,
+                    "Download Firefox Lockwise for your smartphone and tablet.",
+                    {
+                        "Firefox Lockwise": TERM_REFERENCE("brand-name-firefox-lockwise"),
+                    }
+                )
+            ),
+        ] + transforms_from("""
+welcome-page5-scan-this-qr-code = {COPY(page5, "Scan this QR code",)}
+welcome-page5-firefox-lockwise = { -brand-term-firefox-lockwise }
+welcome-page5-sync-up-safely = {COPY(page5, "Sync up safely",)}
+welcome-page5-with-256-bit-encryption-your = {COPY(page5, "With 256-bit encryption, your passwords always travel to your devices securely.",)}
+welcome-page5-no-more-making-up-new-passwords = {COPY(page5, "No more making up new passwords",)}
+""", page5=page5) + [
+            FTL.Message(
+                id=FTL.Identifier("welcome-page5-lockwise-will-recommend-new"),
+                value=REPLACE(
+                    page5,
+                    "Lockwise will recommend new, strong passwords whenever you set up a new login.",
+                    {
+                        "Lockwise": TERM_REFERENCE("brand-name-lockwise"),
+                    }
+                )
+            ),
+        ] + transforms_from("""
+welcome-page5-help-during-a-breach = {COPY(page5, "Help during a breach",)}
+""", page5=page5) + [
+            FTL.Message(
+                id=FTL.Identifier("welcome-page5-lockwise-will-let-you-know"),
+                value=REPLACE(
+                    page5,
+                    "Lockwise will let you know if your saved logins have been part of a corporate data breach, so you can change them asap.",
+                    {
+                        "Lockwise": TERM_REFERENCE("brand-name-lockwise"),
+                    }
+                )
+            ),
+        ] + transforms_from("""
+welcome-page5-why-am-i-seeing-this = {COPY(page5, "Why am I seeing this?",)}
+""", page5=page5)
+        )


### PR DESCRIPTION
## Description
- Migrates `firefox/welcome/page5.lang` to `firefox/welcome/page5.ftl`.
- Updates template to use Fluent IDs.

http://localhost:8000/en-US/firefox/welcome/5/

## Issue / Bugzilla link
#9069

## Testing
```
./manage.py l10n_update
```