### PR TITLE
Fix iOS app store link on /new experiment page (Fixes #9071)

### DIFF
--- a/bedrock/firefox/templates/firefox/new/desktop/download.html
+++ b/bedrock/firefox/templates/firefox/new/desktop/download.html
@@ -20,6 +20,8 @@
 
 {% set referrals = '?utm_source=www.mozilla.org&utm_medium=referral&utm_campaign=firefox-desktop' %}
 
+{% set ios_url = app_store_url('firefox') %}
+
 {% block content %}
 <main role="main" class="main-download" {% if v %}data-variant="{{ v }}"{% endif %}>
 


### PR DESCRIPTION
## Description

Fixes broken iOS app store badge link

http://localhost:8000/en-US/firefox/new/?v=b

## Issue / Bugzilla link
#9071

## Testing
- [ ] Both the in-page button and the top page banner badges should work when clicked.