### PR TITLE
Revert "Only show browser comparison pages in DEV mode"

### DIFF
--- a/bedrock/firefox/urls.py
+++ b/bedrock/firefox/urls.py
@@ -6,8 +6,6 @@ from django.conf.urls import url
 import bedrock.releasenotes.views
 from bedrock.mozorg.util import page
 from bedrock.releasenotes import version_re
-from django.conf import settings
-from bedrock.redirects.util import redirect
 
 from bedrock.firefox import views
 
@@ -131,6 +129,21 @@ urlpatterns = (
 
     page('firefox/features/safebrowser', 'firefox/features/safebrowser.html'),
 
+    page('firefox/browsers/compare', 'firefox/browsers/compare/index.html',
+         ftl_files=['firefox/browsers/compare/index', 'firefox/browsers/compare/shared']),
+    page('firefox/browsers/compare/brave', 'firefox/browsers/compare/brave.html',
+         ftl_files=['firefox/browsers/compare/brave', 'firefox/browsers/compare/shared']),
+    page('firefox/browsers/compare/chrome', 'firefox/browsers/compare/chrome.html',
+         ftl_files=['firefox/browsers/compare/chrome', 'firefox/browsers/compare/shared']),
+    page('firefox/browsers/compare/edge', 'firefox/browsers/compare/edge.html',
+         ftl_files=['firefox/browsers/compare/edge', 'firefox/browsers/compare/shared']),
+    page('firefox/browsers/compare/ie', 'firefox/browsers/compare/ie.html',
+         ftl_files=['firefox/browsers/compare/ie', 'firefox/browsers/compare/shared']),
+    page('firefox/browsers/compare/opera', 'firefox/browsers/compare/opera.html',
+         ftl_files=['firefox/browsers/compare/opera', 'firefox/browsers/compare/shared']),
+    page('firefox/browsers/compare/safari', 'firefox/browsers/compare/safari.html',
+         ftl_files=['firefox/browsers/compare/safari', 'firefox/browsers/compare/shared']),
+
     # Issue 8641
     page('firefox/browsers/best-browser', 'firefox/browsers/best-browser.html'),
     page('firefox/browsers/browser-history', 'firefox/browsers/browser-history.html'),
@@ -154,25 +167,3 @@ urlpatterns = (
     # Issue 8536
     page('firefox/retention/thank-you', 'firefox/retention/thank-you.html'),
 )
-
-if settings.DEV:
-    urlpatterns += (
-        page('firefox/browsers/compare', 'firefox/browsers/compare/index.html',
-             ftl_files=['firefox/browsers/compare/index', 'firefox/browsers/compare/shared']),
-        page('firefox/browsers/compare/brave', 'firefox/browsers/compare/brave.html',
-             ftl_files=['firefox/browsers/compare/brave', 'firefox/browsers/compare/shared']),
-        page('firefox/browsers/compare/chrome', 'firefox/browsers/compare/chrome.html',
-             ftl_files=['firefox/browsers/compare/chrome', 'firefox/browsers/compare/shared']),
-        page('firefox/browsers/compare/edge', 'firefox/browsers/compare/edge.html',
-             ftl_files=['firefox/browsers/compare/edge', 'firefox/browsers/compare/shared']),
-        page('firefox/browsers/compare/ie', 'firefox/browsers/compare/ie.html',
-             ftl_files=['firefox/browsers/compare/ie', 'firefox/browsers/compare/shared']),
-        page('firefox/browsers/compare/opera', 'firefox/browsers/compare/opera.html',
-             ftl_files=['firefox/browsers/compare/opera', 'firefox/browsers/compare/shared']),
-        page('firefox/browsers/compare/safari', 'firefox/browsers/compare/safari.html',
-             ftl_files=['firefox/browsers/compare/safari', 'firefox/browsers/compare/shared']),
-    )
-else:
-    urlpatterns += (
-        redirect(r'^firefox/browsers/compare(/.*)?', 'firefox', permanent=False),
-    )


### PR DESCRIPTION
## Description
This reverts commit 7013fd755fd030313f0af8ae78daf7307996e802 thus publishing the browser comparison pages.

## Testing
The pages should load normally when `DEV=False`