### PR TITLE
exp/firefox/accounts base bugfix. [no bug]

### DIFF
--- a/bedrock/exp/templates/exp/firefox/accounts.html
+++ b/bedrock/exp/templates/exp/firefox/accounts.html
@@ -5,7 +5,7 @@
 {% from "macros-protocol.html" import feature_card with context %}
 {% from "macros.html" import fxa_email_form with context %}
 
-{% extends "firefox/base/base-protocol.html" %}
+{% extends "exp/base/base-firefox.html" %}
 
 {% set _entrypoint = 'mozilla.org-firefox-accounts' %}
 {% set _utm_source = 'mozilla.org-firefox-accounts' %}


### PR DESCRIPTION
## Description

The new firefox/accounts experiment template is extending the wrong base & is missing the convert JS required to run experiments on it. (ex: `https://cdn-3.convertexperiments.com/`)