### PR TITLE
fix #8501: (firefox/channel) change picto card base element from 'li' to 'section'

### DIFF
--- a/bedrock/firefox/templates/firefox/channel/base.html
+++ b/bedrock/firefox/templates/firefox/channel/base.html
@@ -48,6 +48,7 @@
     title=_('See something that isn’t working? Let us know.'),
     heading_level=2,
     class='bugzilla',
+    base_el='section',
     custom_desc=True) %}
 
   <ul>


### PR DESCRIPTION
## Description

Removes the stray list item bullet point around the [picto card](https://protocol.mozilla.org/patterns/molecules/picto-card.html) in  [Firefox Channel page](https://www.mozilla.org/en-US/firefox/channel/desktop/).

**Safari:**
<img width="500" alt="ff-channel-safari" src="https://user-images.githubusercontent.com/4765455/85656541-de4dda00-b67e-11ea-8a1f-747ae6485cb1.png">
**Chrome:**
<img width="500" alt="ff-channel-chrome" src="https://user-images.githubusercontent.com/4765455/85656580-ea399c00-b67e-11ea-961c-531256bdd38e.png">
## Issue / Bugzilla link

#8501 

## Testing
1. `make build`
2. `make run`
3. Visit http://localhost:8000/en-US/firefox/channel/desktop/
4. Bullet point is gone 👋 
