### PR TITLE
Add missing links to FxA form on /browsers (Fixes #9073)

### DIFF
--- a/bedrock/firefox/templates/firefox/browsers/index.html
+++ b/bedrock/firefox/templates/firefox/browsers/index.html
@@ -120,7 +120,7 @@
           {% set fxa_link = fxa_link_fragment(entrypoint=_entrypoint, action='signin', optional_parameters={'utm_campaign': 'browsers-footer'}) %}
           {% set fxa_attr = fxa_link ~ ' class="js-fxa-cta-link js-fxa-product-button" data-cta-type="link" data-cta-text="FxA Learn More"'|safe %}
           {% set accounts_attr = 'href="'|safe ~ url('firefox.accounts') ~ '"'|safe %}
-          {{ ftl('firefox-browsers-already-have-an-account-sign') }}
+          {{ ftl('firefox-browsers-already-have-an-account-sign', accounts_attr=accounts_attr, fxa_attr=fxa_attr) }}
         </p>
       </div>
     </div>


### PR DESCRIPTION
## Description
- Adds missing link params to copy at the end of the FxA form on /browsers.

http://localhost:8000/en-US/firefox/browsers/

## Issue / Bugzilla link
#9073

## Testing
- [ ] Both links should now render correctly.