### PR TITLE
Migrate /firefox/welcome/6/ to Fluent (Fixes #9080) [skip l10n]

### DIFF
--- a/bedrock/firefox/templates/firefox/welcome/page6.html
+++ b/bedrock/firefox/templates/firefox/welcome/page6.html
@@ -1,16 +1,13 @@
 {# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
 
 {% from "macros.html" import google_play_button, send_to_device with context %}
 {% from "macros-protocol.html" import hero with context %}
 
-{% add_lang_files "firefox/welcome/page6" %}
-
 {% extends "firefox/welcome/base.html" %}
 
-{# L10n: HTML page title #}
-{% block page_title %}{{ _('Make Firefox your default browser') }}{% endblock %}
+{% block page_title %}{{ ftl('welcome-page6-make-firefox-your-default') }}{% endblock %}
 
 {% block body_class %}{{ super() }} welcome-page6{% endblock %}
 
@@ -23,8 +20,8 @@
 
 {% block content_intro %}
   {% call hero(
-    title=_('Make sure you’re protected, every time you get online'),
-    desc=_('When you choose Firefox, you support a better web for you and everyone else. Now take the next step to protect yourself.'),
+    title=ftl('welcome-page6-make-sure-youre-protected'),
+    desc=ftl('welcome-page6-when-you-choose-firefox-you'),
     class='mzp-t-firefox mzp-t-dark',
     include_cta=True,
     heading_level=1
@@ -32,26 +29,28 @@
 
   <div class="primary-cta">
     <div class="state-not-default">
-      <a id="set-as-default-button" href="{{ url('firefox.set-as-default.thanks') }}" class="mzp-c-button mzp-t-product" data-cta-text="Make Firefox your default browser" data-cta-type="button">{{ _('Make Firefox your default browser') }}</a>
+      <a id="set-as-default-button" href="{{ url('firefox.set-as-default.thanks') }}" class="mzp-c-button mzp-t-product" data-cta-text="Make Firefox your default browser" data-cta-type="button">
+        {{ ftl('welcome-page6-make-firefox-your-default') }}
+      </a>
     </div>
     <div class="state-is-default">
-      <button type="button" class="mzp-c-button mzp-t-product js-modal-link">{{ _('Get the Firefox App') }}</button>
+      <button type="button" class="mzp-c-button mzp-t-product js-modal-link">{{ ftl('welcome-page6-get-the-firefox-app') }}</button>
     </div>
   </div>
   {% endcall %}
 
   <aside id="modal" class="mzp-u-modal-content mzp-l-content">
-    <h3 class="modal-title">{{ _('Get Firefox on your Phone') }}</h3>
+    <h3 class="modal-title">{{ ftl('welcome-page6-get-firefox-on-your-phone') }}</h3>
 
     {% if show_send_to_device %}
       {{ send_to_device(include_title=False, message_set='fx-whatsnew', class='vertical') }}
     {% else %}
-      <p>{{ _('Scan the QR code to get started') }}</p>
+      <p>{{ ftl('welcome-page6-scan-the-qr-code-to-get-started') }}</p>
       <div class="qr-code-wrapper">
         <img src="{{ static('img/firefox/mobile/protocol/qr-firefox.png') }}"
             id="firefox-qr"
             data-mozillaonline-link="{{ static('img/firefox/mobile/protocol/qr-firefox-mozillaonline.png') }}"
-            alt="{{ _('QR code to scan for Firefox') }}">
+            alt="{{ ftl('welcome-page6-qr-code-to-scan-for-firefox') }}">
       </div>
     {% endif %}
 
@@ -75,9 +74,9 @@
         <img src="{{ static('img/icons/privacy.svg') }}" alt="">
       </div>
 
-      <h3 class="c-picto-block-title">{{ _('Choose automatic privacy') }}</h3>
+      <h3 class="c-picto-block-title">{{ ftl('welcome-page6-choose-automatic-privacy') }}</h3>
       <div class="c-picto-block-body">
-        <p>{{ _('Companies keep finding new ways to poach your personal data. Firefox is the browser with a mission of finding new ways to protect you.') }}</p>
+        <p>{{ ftl('welcome-page6-companies-keep-finding-new') }}</p>
       </div>
     </div>
 
@@ -85,9 +84,9 @@
       <div class="c-picto-block-image">
         <img src="{{ static('img/icons/mobile-desktop.svg') }}" alt="">
       </div>
-      <h3 class="c-picto-block-title">{{ _('Choose freedom on every device') }}</h3>
+      <h3 class="c-picto-block-title">{{ ftl('welcome-page6-choose-freedom-on-every-device') }}</h3>
       <div class="c-picto-block-body">
-        <p>{{ _('Firefox is fast and safe on Windows, iOS, Android, Linux… and across them all. You deserve choices in browsers and devices, instead of decisions made for you.') }}</p>
+        <p>{{ ftl('welcome-page6-firefox-is-fast-and-safe-on') }}</p>
       </div>
     </div>
 
@@ -95,9 +94,9 @@
       <div class="c-picto-block-image">
         <img src="{{ static('img/icons/mountain.svg') }}" alt="">
       </div>
-      <h3 class="c-picto-block-title">{{ _('Choose corporate independence') }}</h3>
+      <h3 class="c-picto-block-title">{{ ftl('welcome-page6-choose-corporate-independence') }}</h3>
       <div class="c-picto-block-body">
-        <p>{{ _('Firefox is the only major independent browser. Chrome, Edge and Brave are all built on Google code, which means giving Google even more control of the internet.') }}</p>
+        <p>{{ ftl('welcome-page6-firefox-is-the-only-major') }}</p>
       </div>
     </div>
   </div>
@@ -106,7 +105,9 @@
 {% block content_utility %}
 <p>
   <strong>
-    <a href="https://support.mozilla.org/kb/firefox-browser-welcome-pages/?utm_source={{ _entrypoint }}&utm_medium=referral&utm_campaign={{ _utm_campaign }}&entrypoint={{ _entrypoint }}">{{ _('Why am I seeing this?') }}</a>
+    <a href="https://support.mozilla.org/kb/firefox-browser-welcome-pages/?utm_source={{ _entrypoint }}&utm_medium=referral&utm_campaign={{ _utm_campaign }}&entrypoint={{ _entrypoint }}">
+      {{ ftl('welcome-page6-why-am-i-seeing-this') }}
+    </a>
   </strong>
 </p>
 {% endblock %}

--- a/bedrock/firefox/urls.py
+++ b/bedrock/firefox/urls.py
@@ -111,7 +111,7 @@ urlpatterns = (
     page('firefox/welcome/3', 'firefox/welcome/page3.html', ftl_files=['firefox/welcome/page3']),
     page('firefox/welcome/4', 'firefox/welcome/page4.html', ftl_files=['firefox/welcome/page4']),
     page('firefox/welcome/5', 'firefox/welcome/page5.html', ftl_files=['firefox/welcome/page5']),
-    page('firefox/welcome/6', 'firefox/welcome/page6.html'),
+    page('firefox/welcome/6', 'firefox/welcome/page6.html', ftl_files=['firefox/welcome/page6']),
     page('firefox/welcome/7', 'firefox/welcome/page7.html'),
     page('firefox/welcome/8', 'firefox/welcome/page8.html'),
 

--- a/l10n/en/firefox/welcome/page6.ftl
+++ b/l10n/en/firefox/welcome/page6.ftl
@@ -1,0 +1,22 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+### URL: https://www-dev.allizom.org/firefox/welcome/6/
+
+# HTML page title
+welcome-page6-make-firefox-your-default = Make { -brand-name-firefox } your default browser
+
+welcome-page6-make-sure-youre-protected = Make sure you’re protected, every time you get online
+welcome-page6-when-you-choose-firefox-you = When you choose { -brand-name-firefox }, you support a better web for you and everyone else. Now take the next step to protect yourself.
+welcome-page6-get-the-firefox-app = Get the { -brand-name-firefox } App
+welcome-page6-get-firefox-on-your-phone = Get { -brand-name-firefox } on your Phone
+welcome-page6-scan-the-qr-code-to-get-started = Scan the QR code to get started
+welcome-page6-qr-code-to-scan-for-firefox = QR code to scan for { -brand-name-firefox }
+welcome-page6-choose-automatic-privacy = Choose automatic privacy
+welcome-page6-companies-keep-finding-new = Companies keep finding new ways to poach your personal data. { -brand-name-firefox } is the browser with a mission of finding new ways to protect you.
+welcome-page6-choose-freedom-on-every-device = Choose freedom on every device
+welcome-page6-firefox-is-fast-and-safe-on = { -brand-name-firefox } is fast and safe on { -brand-name-windows }, { -brand-name-ios }, { -brand-name-android }, { -brand-name-linux }… and across them all. You deserve choices in browsers and devices, instead of decisions made for you.
+welcome-page6-choose-corporate-independence = Choose corporate independence
+welcome-page6-firefox-is-the-only-major = { -brand-name-firefox } is the only major independent browser. { -brand-name-chrome }, { -brand-name-edge } and { -brand-name-brave } are all built on { -brand-name-google } code, which means giving { -brand-name-google } even more control of the internet.
+welcome-page6-why-am-i-seeing-this = Why am I seeing this?

--- a/lib/fluent_migrations/firefox/welcome/page6.py
+++ b/lib/fluent_migrations/firefox/welcome/page6.py
@@ -1,0 +1,122 @@
+from __future__ import absolute_import
+import fluent.syntax.ast as FTL
+from fluent.migrate.helpers import transforms_from
+from fluent.migrate.helpers import VARIABLE_REFERENCE, TERM_REFERENCE
+from fluent.migrate import REPLACE, COPY
+
+page6 = "firefox/welcome/page6.lang"
+
+def migrate(ctx):
+    """Migrate bedrock/firefox/templates/firefox/welcome/page6.html, part {index}."""
+
+    ctx.add_transforms(
+        "firefox/welcome/page6.ftl",
+        "firefox/welcome/page6.ftl",
+        [
+            FTL.Message(
+                id=FTL.Identifier("welcome-page6-make-firefox-your-default"),
+                value=REPLACE(
+                    page6,
+                    "Make Firefox your default browser",
+                    {
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                    }
+                )
+            ),
+        ] + transforms_from("""
+welcome-page6-make-sure-youre-protected = {COPY(page6, "Make sure you’re protected, every time you get online",)}
+""", page6=page6) + [
+            FTL.Message(
+                id=FTL.Identifier("welcome-page6-when-you-choose-firefox-you"),
+                value=REPLACE(
+                    page6,
+                    "When you choose Firefox, you support a better web for you and everyone else. Now take the next step to protect yourself.",
+                    {
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("welcome-page6-get-the-firefox-app"),
+                value=REPLACE(
+                    page6,
+                    "Get the Firefox App",
+                    {
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("welcome-page6-get-firefox-on-your-phone"),
+                value=REPLACE(
+                    page6,
+                    "Get Firefox on your Phone",
+                    {
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                    }
+                )
+            ),
+        ] + transforms_from("""
+welcome-page6-scan-the-qr-code-to-get-started = {COPY(page6, "Scan the QR code to get started",)}
+""", page6=page6) + [
+            FTL.Message(
+                id=FTL.Identifier("welcome-page6-qr-code-to-scan-for-firefox"),
+                value=REPLACE(
+                    page6,
+                    "QR code to scan for Firefox",
+                    {
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                    }
+                )
+            ),
+        ] + transforms_from("""
+welcome-page6-choose-automatic-privacy = {COPY(page6, "Choose automatic privacy",)}
+""", page6=page6) + [
+            FTL.Message(
+                id=FTL.Identifier("welcome-page6-companies-keep-finding-new"),
+                value=REPLACE(
+                    page6,
+                    "Companies keep finding new ways to poach your personal data. Firefox is the browser with a mission of finding new ways to protect you.",
+                    {
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                    }
+                )
+            ),
+        ] + transforms_from("""
+welcome-page6-choose-freedom-on-every-device = {COPY(page6, "Choose freedom on every device",)}
+""", page6=page6) + [
+            FTL.Message(
+                id=FTL.Identifier("welcome-page6-firefox-is-fast-and-safe-on"),
+                value=REPLACE(
+                    page6,
+                    "Firefox is fast and safe on Windows, iOS, Android, Linux… and across them all. You deserve choices in browsers and devices, instead of decisions made for you.",
+                    {
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                        "Android": TERM_REFERENCE("brand-name-android"),
+                        "Windows": TERM_REFERENCE("brand-name-windows"),
+                        "Linux": TERM_REFERENCE("brand-name-linux"),
+                        "iOS": TERM_REFERENCE("brand-name-ios"),
+                    }
+                )
+            ),
+        ] + transforms_from("""
+welcome-page6-choose-corporate-independence = {COPY(page6, "Choose corporate independence",)}
+""", page6=page6) + [
+            FTL.Message(
+                id=FTL.Identifier("welcome-page6-firefox-is-the-only-major"),
+                value=REPLACE(
+                    page6,
+                    "Firefox is the only major independent browser. Chrome, Edge and Brave are all built on Google code, which means giving Google even more control of the internet.",
+                    {
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                        "Google": TERM_REFERENCE("brand-name-google"),
+                        "Chrome": TERM_REFERENCE("brand-name-chrome"),
+                        "Brave": TERM_REFERENCE("brand-name-brave"),
+                        "Edge": TERM_REFERENCE("brand-name-edge"),
+                    }
+                )
+            ),
+        ] + transforms_from("""
+welcome-page6-why-am-i-seeing-this = {COPY(page6, "Why am I seeing this?",)}
+""", page6=page6)
+        )


### PR DESCRIPTION
## Description
- Migrates `firefox/welcome/page6.lang` to `firefox/welcome/page6.ftl`.
- Updates template to use Fluent IDs.

http://localhost:8000/en-US/firefox/welcome/6/

## Issue / Bugzilla link
#9080

## Testing
```
./manage.py l10n_update
```