### PR TITLE
Migrate /firefox/welcome/7/ to Fluent (Fixes #9083) [skip l10n]

### DIFF
--- a/bedrock/firefox/templates/firefox/welcome/page7.html
+++ b/bedrock/firefox/templates/firefox/welcome/page7.html
@@ -1,16 +1,13 @@
 {# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
 
 {% from "macros.html" import google_play_button, send_to_device with context %}
 {% from "macros-protocol.html" import hero with context %}
 
-{% add_lang_files "firefox/welcome/page7" %}
-
 {% extends "firefox/welcome/base.html" %}
 
-{# L10n: HTML page title #}
-{% block page_title %}{{ _('Make it harder for Facebook to track you') }}{% endblock %}
+{% block page_title %}{{ ftl('page7-make-it-harder-for-facebook') }}{% endblock %}
 
 {% block body_class %}{{ super() }} welcome-page7{% endblock %}
 
@@ -24,15 +21,17 @@
 
 {% block content_intro %}
 {% call hero(
-    title=_('It’s okay to like Facebook'),
-    desc=_('If you still kinda like Facebook but don’t trust them, then try the Facebook Container extension by Firefox and make it harder for them to track you around the web.'),
+    title=ftl('page7-its-okay-to-like-facebook'),
+    desc=ftl('page7-if-you-still-kinda-like-facebook'),
     class='mzp-t-firefox mzp-t-dark',
     include_cta=True,
     heading_level=1
   ) %}
 
   <p class="primary-cta">
-    <a href="https://addons.mozilla.org/firefox/addon/facebook-container/?src=external-www.mozilla.org-welcom-7&utm_source={{ _entrypoint }}&utm_medium=referral&utm_campaign={{ _utm_campaign }}" class="mzp-c-button mzp-t-product" id="facebook-container-button" rel="external">{{ _('Get Facebook Container') }}</a>
+    <a href="https://addons.mozilla.org/firefox/addon/facebook-container/?src=external-www.mozilla.org-welcom-7&utm_source={{ _entrypoint }}&utm_medium=referral&utm_campaign={{ _utm_campaign }}" class="mzp-c-button mzp-t-product" id="facebook-container-button" rel="external">
+      {{ ftl('page7-get-facebook-container') }}
+    </a>
   </p>
 
   {% endcall %}
@@ -45,10 +44,12 @@
         <img src="{{ static('img/icons/photo-orange.svg') }}" alt="">
       </div>
 
-      <h3 class="c-picto-block-title">{{ _('Do it for the ’Gram') }}</h3>
+      <h3 class="c-picto-block-title">{{ ftl('page7-do-it-for-the-gram') }}</h3>
       <div class="c-picto-block-body">
-        <p>{{ _('Facebook Container also works on other Facebook owned sites like Instagram, Facebook Messenger and Workplace.') }}</p>
-        <a href="https://addons.mozilla.org/firefox/addon/facebook-container/?utm_source={{ _entrypoint }}&utm_medium=referral&utm_campaign={{ _utm_campaign }}&entrypoint={{ _entrypoint }}" rel="external"><strong>{{ _('Make them unfollow you') }}</strong></a>
+        <p>{{ ftl('page7-facebook-container-also-works') }}</p>
+        <a href="https://addons.mozilla.org/firefox/addon/facebook-container/?utm_source={{ _entrypoint }}&utm_medium=referral&utm_campaign={{ _utm_campaign }}&entrypoint={{ _entrypoint }}" rel="external">
+          <strong>{{ ftl('page7-make-them-unfollow-you') }}</strong>
+        </a>
       </div>
     </div>
 
@@ -57,10 +58,12 @@
         <div class="c-picto-block-image">
           <img src="{{ static('img/icons/audio-pink.svg') }}" alt="">
         </div>
-        <h3 class="c-picto-block-title">{{ _('Listen to this') }}</h3>
+        <h3 class="c-picto-block-title">Listen to this</h3>
         <div class="c-picto-block-body">
-          <p>{{ _(' Why are companies like Google and Facebook doing everything they can to predict your behavior?') }}</p>
-          <a href="https://irlpodcast.org/season4/episode5/?utm_source={{ _entrypoint }}&utm_medium=referral&utm_campaign={{ _utm_campaign }}&entrypoint={{ _entrypoint }}" rel="external"><strong>{{ _('Listen to our IRL podcast') }}</strong></a>
+          <p>Why are companies like Google and Facebook doing everything they can to predict your behavior?</p>
+          <a href="https://irlpodcast.org/season4/episode5/?utm_source={{ _entrypoint }}&utm_medium=referral&utm_campaign={{ _utm_campaign }}&entrypoint={{ _entrypoint }}" rel="external">
+            <strong>Listen to our IRL podcast</strong>
+          </a>
         </div>
       </div>
     {% elif LANG == 'de' %}
@@ -71,7 +74,9 @@
         <h3 class="c-picto-block-title">Hör’s dir rein</h3>
         <div class="c-picto-block-body">
           <p>Im Netz der Tracker: Niemand sollte ohne Zustimmung online verfolgt werden dürfen. Warum Online-Tracking problematisch ist und was es für unsere Gesellschaft bedeutet?</p>
-          <a href="https://awebpodcast.org/staffel1/folge7/?utm_source={{ _entrypoint }}&utm_medium=referral&utm_campaign={{ _utm_campaign }}&entrypoint={{ _entrypoint }}" rel="external"><strong>Jetzt im aweb Podcast</strong></a>
+          <a href="https://awebpodcast.org/staffel1/folge7/?utm_source={{ _entrypoint }}&utm_medium=referral&utm_campaign={{ _utm_campaign }}&entrypoint={{ _entrypoint }}" rel="external">
+            <strong>Jetzt im aweb Podcast</strong>
+          </a>
         </div>
       </div>
     {% elif LANG == 'fr' %}
@@ -82,7 +87,9 @@
         <h3 class="c-picto-block-title">Les traqueurs de réseaux sociaux, c’est quoi exactement ?</h3>
         <div class="c-picto-block-body">
           <p>Les plateformes de réseaux sociaux déposent des traqueurs sur d’autres sites afin de suivre ce que vous faites en ligne.</p>
-          <a href="https://blog.mozilla.org/firefox/fr/que-sont-les-traqueurs-de-reseaux-sociaux/?utm_source={{ _entrypoint }}&utm_medium=referral&utm_campaign={{ _utm_campaign }}&entrypoint={{ _entrypoint }}"><strong>Apprendre à les contourner</strong></a>
+          <a href="https://blog.mozilla.org/firefox/fr/que-sont-les-traqueurs-de-reseaux-sociaux/?utm_source={{ _entrypoint }}&utm_medium=referral&utm_campaign={{ _utm_campaign }}&entrypoint={{ _entrypoint }}">
+            <strong>Apprendre à les contourner</strong>
+          </a>
         </div>
       </div>
     {% else %}
@@ -90,9 +97,9 @@
         <div class="c-picto-block-image">
           <img src="{{ static('img/icons/facebook-button.svg') }}" alt="">
         </div>
-        <h3 class="c-picto-block-title">{{ _('That sneaky little button') }}</h3>
+        <h3 class="c-picto-block-title">{{ ftl('page7-that-sneaky-little-button') }}</h3>
         <div class="c-picto-block-body">
-          <p>{{ _('Those innocent-looking F buttons from Facebook track your web activity, even if you don’t have an account. Facebook Container blocks them.') }}</p>
+          <p>{{ ftl('page7-those-innocent-looking-f-buttons') }}</p>
         </div>
       </div>
     {% endif %}
@@ -100,10 +107,12 @@
       <div class="c-picto-block-image">
         <img src="{{ static('protocol/img/logos/firefox/monitor/logo.svg') }}" alt="">
       </div>
-      <h3 class="c-picto-block-title">{{ _('Stay ahead of hackers') }}</h3>
+      <h3 class="c-picto-block-title">{{ ftl('page7-stay-ahead-of-hackers') }}</h3>
       <div class="c-picto-block-body">
-        <p>{{ _('Firefox Monitor lets you find out what hackers might already know about you and helps you stay a step ahead of them. (And it’s free.)') }}</p>
-        <a href="https://monitor.firefox.com/?utm_source={{ _entrypoint }}&utm_medium=referral&utm_campaign={{ _utm_campaign }}&entrypoint={{ _entrypoint }}"><strong>{{ _('Get Firefox Monitor') }}</strong></a>
+        <p>{{ ftl('page7-firefox-monitor-lets-you-find') }}</p>
+        <a href="https://monitor.firefox.com/?utm_source={{ _entrypoint }}&utm_medium=referral&utm_campaign={{ _utm_campaign }}&entrypoint={{ _entrypoint }}">
+          <strong>{{ ftl('page7-get-firefox-monitor') }}</strong>
+        </a>
       </div>
     </div>
   </div>
@@ -113,7 +122,9 @@
 {% block content_utility %}
 <p>
   <strong>
-    <a href="https://support.mozilla.org/kb/firefox-browser-welcome-pages/?utm_source={{ _entrypoint }}&utm_medium=referral&utm_campaign={{ _utm_campaign }}&entrypoint={{ _entrypoint }}">{{ _('Why am I seeing this?') }}</a>
+    <a href="https://support.mozilla.org/kb/firefox-browser-welcome-pages/?utm_source={{ _entrypoint }}&utm_medium=referral&utm_campaign={{ _utm_campaign }}&entrypoint={{ _entrypoint }}">
+      {{ ftl('page7-why-am-i-seeing-this') }}
+    </a>
   </strong>
 </p>
 {% endblock %}

--- a/bedrock/firefox/urls.py
+++ b/bedrock/firefox/urls.py
@@ -112,7 +112,7 @@ urlpatterns = (
     page('firefox/welcome/4', 'firefox/welcome/page4.html', ftl_files=['firefox/welcome/page4']),
     page('firefox/welcome/5', 'firefox/welcome/page5.html', ftl_files=['firefox/welcome/page5']),
     page('firefox/welcome/6', 'firefox/welcome/page6.html', ftl_files=['firefox/welcome/page6']),
-    page('firefox/welcome/7', 'firefox/welcome/page7.html'),
+    page('firefox/welcome/7', 'firefox/welcome/page7.html', ftl_files=['firefox/welcome/page7']),
     page('firefox/welcome/8', 'firefox/welcome/page8.html', ftl_files=['firefox/welcome/page8']),
 
     page('firefox/privacy-by-default', 'firefox/messaging-experiment/privacy_by_default.html'),

--- a/l10n/en/firefox/welcome/page7.ftl
+++ b/l10n/en/firefox/welcome/page7.ftl
@@ -1,0 +1,24 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+### URL: https://www-dev.allizom.org/firefox/welcome/7/
+
+# HTML page title
+page7-make-it-harder-for-facebook = Make it harder for { -brand-name-facebook } to track you
+
+page7-its-okay-to-like-facebook = It’s okay to like { -brand-name-facebook }
+page7-if-you-still-kinda-like-facebook = If you still kinda like { -brand-name-facebook } but don’t trust them, then try the { -brand-name-facebook-container } extension by { -brand-name-firefox } and make it harder for them to track you around the web.
+page7-get-facebook-container = Get { -brand-name-facebook-container }
+
+# "Do it for the 'Gram" is a slang phrase used when people do things in life just so they can take pictures to post on Instagram. Alternative: "It works on Instagram"
+page7-do-it-for-the-gram = Do it for the ’Gram
+
+page7-facebook-container-also-works = { -brand-name-facebook-container } also works on other { -brand-name-facebook } owned sites like { -brand-name-instagram }, { -brand-name-facebook-messenger } and { -brand-name-workplace }.
+page7-make-them-unfollow-you = Make them unfollow you
+page7-that-sneaky-little-button = That sneaky little button
+page7-those-innocent-looking-f-buttons = Those innocent-looking F buttons from { -brand-name-facebook } track your web activity, even if you don’t have an account. { -brand-name-facebook-container } blocks them.
+page7-stay-ahead-of-hackers = Stay ahead of hackers
+page7-firefox-monitor-lets-you-find = { -brand-name-firefox-monitor } lets you find out what hackers might already know about you and helps you stay a step ahead of them. (And it’s free.)
+page7-get-firefox-monitor = Get { -brand-name-firefox-monitor }
+page7-why-am-i-seeing-this = Why am I seeing this?

--- a/lib/fluent_migrations/firefox/welcome/page7.py
+++ b/lib/fluent_migrations/firefox/welcome/page7.py
@@ -1,0 +1,116 @@
+from __future__ import absolute_import
+import fluent.syntax.ast as FTL
+from fluent.migrate.helpers import transforms_from
+from fluent.migrate.helpers import VARIABLE_REFERENCE, TERM_REFERENCE
+from fluent.migrate import REPLACE, COPY
+
+page7 = "firefox/welcome/page7.lang"
+
+def migrate(ctx):
+    """Migrate bedrock/firefox/templates/firefox/welcome/page7.html, part {index}."""
+
+    ctx.add_transforms(
+        "firefox/welcome/page7.ftl",
+        "firefox/welcome/page7.ftl",
+        [
+            FTL.Message(
+                id=FTL.Identifier("page7-make-it-harder-for-facebook"),
+                value=REPLACE(
+                    page7,
+                    "Make it harder for Facebook to track you",
+                    {
+                        "Facebook": TERM_REFERENCE("brand-name-facebook"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("page7-its-okay-to-like-facebook"),
+                value=REPLACE(
+                    page7,
+                    "It’s okay to like Facebook",
+                    {
+                        "Facebook": TERM_REFERENCE("brand-name-facebook"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("page7-if-you-still-kinda-like-facebook"),
+                value=REPLACE(
+                    page7,
+                    "If you still kinda like Facebook but don’t trust them, then try the Facebook Container extension by Firefox and make it harder for them to track you around the web.",
+                    {
+                        "Facebook": TERM_REFERENCE("brand-name-facebook"),
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                        "Facebook Container": TERM_REFERENCE("brand-name-facebook-container"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("page7-get-facebook-container"),
+                value=REPLACE(
+                    page7,
+                    "Get Facebook Container",
+                    {
+                        "Facebook Container": TERM_REFERENCE("brand-name-facebook-container"),
+                    }
+                )
+            ),
+        ] + transforms_from("""
+page7-do-it-for-the-gram = {COPY(page7, "Do it for the ’Gram",)}
+""", page7=page7) + [
+            FTL.Message(
+                id=FTL.Identifier("page7-facebook-container-also-works"),
+                value=REPLACE(
+                    page7,
+                    "Facebook Container also works on other Facebook owned sites like Instagram, Facebook Messenger and Workplace.",
+                    {
+                        "Facebook": TERM_REFERENCE("brand-name-facebook"),
+                        "Facebook Container": TERM_REFERENCE("brand-name-facebook-container"),
+                        "Facebook Messenger": TERM_REFERENCE("brand-name-facebook-messenger"),
+                        "Instagram": TERM_REFERENCE("brand-name-instagram"),
+                        "Workplace": TERM_REFERENCE("brand-name-workplace"),
+                    }
+                )
+            ),
+        ] + transforms_from("""
+page7-make-them-unfollow-you = {COPY(page7, "Make them unfollow you",)}
+page7-that-sneaky-little-button = {COPY(page7, "That sneaky little button",)}
+""", page7=page7) + [
+            FTL.Message(
+                id=FTL.Identifier("page7-those-innocent-looking-f-buttons"),
+                value=REPLACE(
+                    page7,
+                    "Those innocent-looking F buttons from Facebook track your web activity, even if you don’t have an account. Facebook Container blocks them.",
+                    {
+                        "Facebook": TERM_REFERENCE("brand-name-facebook"),
+                        "Facebook Container": TERM_REFERENCE("brand-name-facebook-container"),
+                    }
+                )
+            ),
+        ] + transforms_from("""
+page7-stay-ahead-of-hackers = {COPY(page7, "Stay ahead of hackers",)}
+""", page7=page7) + [
+            FTL.Message(
+                id=FTL.Identifier("page7-firefox-monitor-lets-you-find"),
+                value=REPLACE(
+                    page7,
+                    "Firefox Monitor lets you find out what hackers might already know about you and helps you stay a step ahead of them. (And it’s free.)",
+                    {
+                        "Firefox Monitor": TERM_REFERENCE("brand-name-firefox-monitor"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("page7-get-firefox-monitor"),
+                value=REPLACE(
+                    page7,
+                    "Get Firefox Monitor",
+                    {
+                        "Firefox Monitor": TERM_REFERENCE("brand-name-firefox-monitor"),
+                    }
+                )
+            ),
+        ] + transforms_from("""
+page7-why-am-i-seeing-this = {COPY(page7, "Why am I seeing this?",)}
+""", page7=page7)
+        )


### PR DESCRIPTION
## Description
- Migrates `firefox/welcome/page7.lang` to `firefox/welcome/page7.ftl`.
- Updates template to use Fluent IDs.

http://localhost:8000/en-US/firefox/welcome/7/

## Issue / Bugzilla link
#9083

## Testing
```
./manage.py l10n_update
```