### PR TITLE
Fix URL mismatch on /firefox/retention/thank-you/ (Fixes #9087)

### DIFF
--- a/bedrock/firefox/templates/firefox/retention/thank-you.html
+++ b/bedrock/firefox/templates/firefox/retention/thank-you.html
@@ -42,7 +42,7 @@
       <article>
         <h2>{{ _('Make Firefox your default browser') }}</h2>
         <div class="time">{{ _('1 min action') }}</div>
-        <a data-link-type="link" data-link-name="Set as your default" href="{{ url('firefox.set-as-default.landing-page') }}">{{ _('Set as your default') }}</a>
+        <a data-link-type="link" data-link-name="Set as your default" href="{{ url('firefox.set-as-default.landing') }}">{{ _('Set as your default') }}</a>
       </article>
       <article>
         <h2>{{ _('Get Firefox on your phone') }}</h2>


### PR DESCRIPTION
Regression from https://github.com/mozilla/bedrock/pull/9027

Issue: https://github.com/mozilla/bedrock/issues/9087