### PR TITLE
[fix bug #1640569] home page, clear floats in the two column section

### DIFF
--- a/bedrock/mozorg/templates/mozorg/home/home.html
+++ b/bedrock/mozorg/templates/mozorg/home/home.html
@@ -74,7 +74,7 @@ accessible to all.') }}
     image_url='img/home/dino.svg'
     )}}
 
-    <section>
+    <section class="c-column-container">
       <div class="c-column">
         <div class="c-column-content">
           <h2>{{ _('Our impact') }}</h2>

--- a/media/css/mozorg/home/home.scss
+++ b/media/css/mozorg/home/home.scss
@@ -27,11 +27,9 @@ $image-path: '/media/protocol/img';
 //* -------------------------------------------------------------------------- */
 // Picto Cards
 
-/**
-* Picto card custom icon sizes.
-* These should be standardized into a `large` icon size.
-* https://github.com/mozilla/protocol/issues/382
-*/
+// Picto card custom icon sizes.
+// These should be standardized into a `large` icon size.
+// https://github.com/mozilla/protocol/issues/382
 
 .mzp-c-card-picto .mzp-c-card-picto-content {
     padding-top: 140px;
@@ -67,8 +65,13 @@ $image-path: '/media/protocol/img';
     background-position: left -200px;
 }
 
+
 //* -------------------------------------------------------------------------- */
 // Two column section
+
+.c-column-container {
+    @include clearfix;
+}
 
 .c-column {
     box-sizing: border-box;
@@ -87,6 +90,7 @@ $image-path: '/media/protocol/img';
 
     .c-column-content {
         @include bidi(((text-align, left, right),));
+
         h2 {
             margin-bottom: $spacing-xl;
         }


### PR DESCRIPTION
## Description
The two column "Impact and Innovations" section can collide with floats in the picto card section below when they're not the same height. This adds a clearfix to the column container to prevent that.

The bug was filed by a localizer working on the Taiwanese version but it likely happens in other locales as well.

![image](https://user-images.githubusercontent.com/205591/86045327-48a8a680-ba00-11ea-8c60-16715b5d996b.png)

## Issue / Bugzilla link
https://bugzilla.mozilla.org/show_bug.cgi?id=1640569

## Testing
http://localhost:8000/zh-TW/

The row of picto cards should line up correctly because the two columns above them are now contained.