### PR TITLE
Simplify site.js by removing ancient platforms (Fixes #8454)

### DIFF
--- a/bedrock/firefox/templates/firefox/includes/download-button.html
+++ b/bedrock/firefox/templates/firefox/includes/download-button.html
@@ -48,12 +48,6 @@
       <p>{{ ftl('download-button-your-system-may') }}</p>
       {{ alt_buttons(builds) }}
     </div>
-    <div class="unsupported-download" data-nosnippet="true">
-      <p>{{ ftl('download-button-your-system-does-not', url=firefox_url('desktop', 'sysreq', channel)) }}</p>
-    </div>
-    <div class="unsupported-download-osx" data-nosnippet="true">
-      <p>{{ ftl('download-button-your-system-does-not', url='https://support.mozilla.org/kb/firefox-osx') }}</p>
-    </div>
     <div class="linux-arm-download" data-nosnippet="true">
       <p>{{ ftl('download-button-please-follow-these', url='https://support.mozilla.org/kb/install-firefox-linux') }}</p>
     </div>

--- a/bedrock/firefox/tests/test_helpers.py
+++ b/bedrock/firefox/tests/test_helpers.py
@@ -142,12 +142,6 @@ class TestDownloadButtons(TestCase):
         unrecognised_message = doc('.unrecognized-download').empty().outerHtml()
         assert unrecognised_message == '<div class="unrecognized-download" data-nosnippet="true"></div>'
 
-        unsupported_message = doc('.unsupported-download').empty().outerHtml()
-        assert unsupported_message == '<div class="unsupported-download" data-nosnippet="true"></div>'
-
-        unsupported_osx_message = doc('.unsupported-download-osx').empty().outerHtml()
-        assert unsupported_osx_message == '<div class="unsupported-download-osx" data-nosnippet="true"></div>'
-
         linux_arm_message = doc('.linux-arm-download').empty().outerHtml()
         assert linux_arm_message == '<div class="linux-arm-download" data-nosnippet="true"></div>'
 

--- a/media/css/hubs/_sub-nav.scss
+++ b/media/css/hubs/_sub-nav.scss
@@ -240,9 +240,7 @@
         visibility: visible;
     }
 
-    .other .moz-sub-nav.stuck #sub-nav-download-firefox,
-    .oldwin .moz-sub-nav.stuck #sub-nav-download-firefox,
-    .oldmac .moz-sub-nav.stuck #sub-nav-download-firefox {
+    .other .moz-sub-nav.stuck #sub-nav-download-firefox {
         display: none;
     }
 }

--- a/media/css/pebbles/components/_buttons-download.scss
+++ b/media/css/pebbles/components/_buttons-download.scss
@@ -95,8 +95,6 @@ ul.download-list {
     .ios-download,
     .linux-arm-download,
     .unrecognized-download,
-    .unsupported-download,
-    .unsupported-download-osx,
     .nojs-download {
         display: none;
     }
@@ -108,8 +106,6 @@ ul.download-list {
 .download-button .os_win64-aarch64,
 .download-button .os_linux,
 .download-button .os_linux64,
-// Uncomment this to enable the win64 download buttons:
-// .win7up.x86.x64 .download-button .os_win,
 .android .download-button-desktop,
 .windows.arm .download-button .os_win,
 .linux.arm .download-button .os_linux,
@@ -124,8 +120,6 @@ ul.download-list {
     display: none !important;
 }
 
-// Uncomment this to enable the win64 download buttons:
-// .win7up.x86.x64 .download-button .os_win64,
 .linux .download-button .os_linux,
 .linux.x86.x64 .download-button .os_linux64,
 .windows .download-button .os_win,
@@ -134,27 +128,21 @@ ul.download-list {
 .android .download-button .os_android,
 .download-button-android .os_android,
 .android .download-button-desktop .download-list,
-.android .download-button-desktop small.os_win,
 .download-button-ios .os_ios,
 .ios .download-button .os_ios,
 .ios .download-button .ios-download,
 .ios .download-button-desktop .download-list,
-.other .download-button-android .download-list,
-.other .download-button small.os_win {
+.other .download-button-android .download-list {
     display: block !important;
 }
 
-.linux.arm .download-button .linux-arm-download,
-.oldwin .download-button .unsupported-download,
-.oldmac .download-button .unsupported-download {
+.linux.arm .download-button .linux-arm-download {
     display: block;
     max-width: 250px;
 }
 
 // Hide the privacy link if platform is unsupported.
-.linux.arm .download-button .fx-privacy-link,
-.oldwin .download-button .fx-privacy-link,
-.oldmac .download-button .fx-privacy-link {
+.linux.arm .download-button .fx-privacy-link {
     display: none;
 }
 
@@ -170,22 +158,6 @@ ul.download-list {
     .unrecognized-download {
         display: block;
     }
-}
-
-// Android architecture detection
-.download-button .download-list .os_android.x86,
-.download-button .download-other.os_android .arm,
-.android.x86 .download-button .download-list .os_android.armv7up,
-.android.x86 .download-button .download-other.os_android .x86 {
-    display: none !important;
-}
-
-.android.x86 .download-button .download-list .os_android.x86 {
-    display: block !important;
-}
-
-.android.x86 .download-button .download-other.os_android .armv7up {
-    display: inline !important;
 }
 
 /* stylelint-enable */

--- a/media/css/protocol/components/_download-button.scss
+++ b/media/css/protocol/components/_download-button.scss
@@ -65,8 +65,6 @@ ul.download-list {
     .ios-download,
     .linux-arm-download,
     .unrecognized-download,
-    .unsupported-download,
-    .unsupported-download-osx,
     .nojs-download {
         display: none;
     }
@@ -78,8 +76,6 @@ ul.download-list {
 .download-button .os_win64-aarch64,
 .download-button .os_linux,
 .download-button .os_linux64,
-// Uncomment this to enable the win64 download buttons:
-// .win7up.x86.x64 .download-button .os_win,
 .android .download-button-desktop,
 .windows.arm .download-button .os_win,
 .linux.arm .download-button .os_linux,
@@ -94,8 +90,6 @@ ul.download-list {
     display: none !important;
 }
 
-// Uncomment this to enable the win64 download buttons:
-// .win7up.x86.x64 .download-button .os_win64,
 .linux .download-button .os_linux,
 .linux.x86.x64 .download-button .os_linux64,
 .windows .download-button .os_win,
@@ -104,27 +98,21 @@ ul.download-list {
 .android .download-button .os_android,
 .download-button-android .os_android,
 .android .download-button-desktop .download-list,
-.android .download-button-desktop small.os_win,
 .download-button-ios .os_ios,
 .ios .download-button .os_ios,
 .ios .download-button .ios-download,
 .ios .download-button-desktop .download-list,
-.other .download-button-android .download-list,
-.other .download-button small.os_win {
+.other .download-button-android .download-list {
     display: block !important;
 }
 
-.linux.arm .download-button .linux-arm-download,
-.oldwin .download-button .unsupported-download,
-.oldmac .download-button .unsupported-download {
+.linux.arm .download-button .linux-arm-download {
     display: block;
     max-width: 250px;
 }
 
 // Hide the privacy link if platform is unsupported.
-.linux.arm .download-button .fx-privacy-link,
-.oldwin .download-button .fx-privacy-link,
-.oldmac .download-button .fx-privacy-link {
+.linux.arm .download-button .fx-privacy-link {
     display: none;
 }
 
@@ -140,22 +128,6 @@ ul.download-list {
     .unrecognized-download {
         display: block;
     }
-}
-
-// Android architecture detection
-.download-button .download-list .os_android.x86,
-.download-button .download-other.os_android .arm,
-.android.x86 .download-button .download-list .os_android.armv7up,
-.android.x86 .download-button .download-other.os_android .x86 {
-    display: none !important;
-}
-
-.android.x86 .download-button .download-list .os_android.x86 {
-    display: block !important;
-}
-
-.android.x86 .download-button .download-other.os_android .armv7up {
-    display: inline !important;
 }
 
 /* stylelint-enable */

--- a/media/css/protocol/components/_navigation.scss
+++ b/media/css/protocol/components/_navigation.scss
@@ -25,9 +25,7 @@
  * Hide nav download button on unsupported systems to prevent
  * taking over large amounts of screen real estate.
  */
-html.other,
-html.oldwin,
-html.oldmac {
+html.other {
     .mzp-c-navigation .mzp-c-navigation-download {
         display: none;
     }

--- a/media/css/protocol/hubs/_sub-nav.scss
+++ b/media/css/protocol/hubs/_sub-nav.scss
@@ -239,9 +239,7 @@ $image-path: '/media/protocol/img';
         visibility: visible;
     }
 
-    .other .moz-sub-nav.stuck #sub-nav-download-firefox,
-    .oldwin .moz-sub-nav.stuck #sub-nav-download-firefox,
-    .oldmac .moz-sub-nav.stuck #sub-nav-download-firefox {
+    .other .moz-sub-nav.stuck #sub-nav-download-firefox {
         display: none;
     }
 }

--- a/media/js/base/site.js
+++ b/media/js/base/site.js
@@ -6,36 +6,11 @@
     'use strict';
     window.site = {
         getPlatform: function (ua, pf) {
-            // Firefox OS navigator.platform is an empty string, which equates to a falsey value in JS
-            // Ths means we must use an ugly ternary statement here to make testing easier.
-            pf = (pf === '') ? '' : pf || navigator.platform;
+            pf = pf || navigator.platform;
             ua = ua || navigator.userAgent;
 
-            if (/Win(16|9[x58]|NT( [1234]| 5\.0| [^0-9]|[^ -]|$))/.test(ua) ||
-                    /Windows ([MC]E|9[x58]|3\.1|4\.10|NT( [1234]\D| 5\.0| [^0-9]|[^ ]|$))/.test(ua) ||
-                    /Windows_95/.test(ua)) {
-                /**
-                 * Officially unsupported platforms are Windows 95, 98, ME, NT 4.x, 2000
-                 * These regular expressions match:
-                 *  - Win16
-                 *  - Win9x
-                 *  - Win95
-                 *  - Win98
-                 *  - WinNT (not followed by version or followed by version <= 5)
-                 *  - Windows ME
-                 *  - Windows CE
-                 *  - Windows 9x
-                 *  - Windows 95
-                 *  - Windows 98
-                 *  - Windows 3.1
-                 *  - Windows 4.10
-                 *  - Windows NT (not followed by version or followed by version <= 5)
-                 *  - Windows_95
-                 */
-                return 'oldwin';
-            }
             if (pf.indexOf('Win32') !== -1 ||
-                    pf.indexOf('Win64') !== -1) {
+                pf.indexOf('Win64') !== -1) {
                 return 'windows';
             }
             if (/android/i.test(ua)) {
@@ -45,28 +20,16 @@
                 return 'linux';
             }
             if (pf.indexOf('MacPPC') !== -1) {
-                return 'oldmac';
-            }
-            if (/Mac OS X 10.[0-8]\D/.test(ua)) {
-                return 'oldmac';
+                return 'other';
             }
             if (pf.indexOf('iPhone') !== -1 ||
-                    pf.indexOf('iPad') !== -1 ||
-                    pf.indexOf('iPod') !== -1 ||
-                    pf.indexOf('MacIntel') !== -1 && 'standalone' in navigator) {
+                pf.indexOf('iPad') !== -1 ||
+                pf.indexOf('iPod') !== -1 ||
+                pf.indexOf('MacIntel') !== -1 && 'standalone' in navigator) { // iPadOS
                 return 'ios';
             }
-            if (ua.indexOf('Mac OS X') !== -1) {
+            if (ua.indexOf('Mac OS X') !== -1 && !/Mac OS X 10.[0-8]\D/.test(ua)) {
                 return 'osx';
-            }
-            if (ua.indexOf('MSIE 5.2') !== -1) {
-                return 'oldmac';
-            }
-            if (pf.indexOf('Mac') !== -1) {
-                return 'oldmac';
-            }
-            if (pf === '' && /Firefox/.test(ua)) {
-                return 'fxos';
             }
 
             return 'other';
@@ -110,12 +73,6 @@
                 return 'armv8';
             }
 
-            // PowerPC
-            re = /PowerPC|PPC/i;
-            if (re.test(pf) || re.test(ua)) {
-                return 'ppc';
-            }
-
             // We can't detect the type info. It's probably x86 but unsure.
             // For example, iOS may be running on ARM-based Apple A7 processor
             return 'x86';
@@ -155,15 +112,10 @@
         var _version = version ? parseFloat(version) : 0;
 
         if (platform === 'windows') {
-            // Add class to allow Windows XP/Vista users to download Firefox 52 ESR, though these
-            // legacy platforms are now officially unsupported
+            // Add class for Windows XP/Vista users to display
+            // unsupported messaging on /download/thanks/ page.
             if (_version >= 5.1 && _version <= 6) {
                 h.className += ' xpvista';
-            }
-
-            // Add class to support downloading Firefox for Windows 64-bit on Windows 7 and later
-            if (_version >= 6.1) {
-                h.className += ' win7up';
             }
         } else {
             h.className = h.className.replace('windows', platform);
@@ -174,18 +126,16 @@
         var archSize = window.site.archSize = window.site.getArchSize();
         var isARM = archType.match(/armv(\d+)/);
 
+        // Used for Windows and Linux ARM processor detection.
         if (archType !== 'x86') {
             h.className = h.className.replace('x86', archType);
 
             if (isARM) {
                 h.className += ' arm';
-
-                // Add class to support downloading Firefox for Android on ARMv7 and later
-                if (parseFloat(isARM[1]) >= 7) {
-                    h.className += ' armv7up';
-                }
             }
         }
+
+        // Used for 64bit download link on Linux.
         if (archSize === 64) {
             h.className += ' x64';
         }

--- a/tests/unit/spec/base/site.js
+++ b/tests/unit/spec/base/site.js
@@ -11,22 +11,10 @@ describe('site.js', function () {
 
     describe('getPlatform', function () {
 
-        it('should identify old-Windows', function () {
-            expect(window.site.getPlatform('Mozilla/4.0 (compatible; MSIE 4.01; Windows 95)', 'foo')).toBe('oldwin');
-            expect(window.site.getPlatform('Mozilla/4.0 (compatible; MSIE 4.01; Windows 98)', 'foo')).toBe('oldwin');
-            expect(window.site.getPlatform('Mozilla/2.0 (compatible; MSIE 3.0; Windows 3.1)', 'foo')).toBe('oldwin');
-            expect(window.site.getPlatform('Mozilla/4.0 (compatible; MSIE 5.05; Windows NT 4.0)', 'foo')).toBe('oldwin');
-        });
-
         it('should identify Windows', function () {
-            expect(window.site.getPlatform('foo', 'Win32')).toBe('windows');
-            expect(window.site.getPlatform('foo', 'Win64')).toBe('windows');
             expect(window.site.getPlatform('Mozilla/5.0 (compatible; MSIE 8.0; Windows NT 5.1; Trident/4.0; .NET CLR 1.1.4322; .NET CLR 2.0.50727)', 'Win64')).toBe('windows');
             expect(window.site.getPlatform('Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 7.1; Trident/5.0)', 'Win32')).toBe('windows');
-            // Win 10/IE 11
             expect(window.site.getPlatform('Mozilla/5.0 (Windows NT 6.4; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/36.0.1985.143 Safari/537.36 Edge/12.0', 'Win32')).toBe('windows');
-            // Win 10 Preview/IE 11
-            expect(window.site.getPlatform('Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2249.0 Safari/537.36', 'Win64')).toBe('windows');
         });
 
         it('should identify Android', function () {
@@ -40,13 +28,12 @@ describe('site.js', function () {
         });
 
         it('should identify old-Mac', function () {
-            expect(window.site.getPlatform('foo', 'MacPPC')).toBe('oldmac');
-            expect(window.site.getPlatform('foo', 'Mac')).toBe('oldmac');
-            expect(window.site.getPlatform('Mozilla/5.0 (Macintosh; U; PPC Mac OS X 10_5_8; ja-jp) AppleWebKit/533.20.25 (KHTML, like Gecko) Version/5.0.4 Safari/533.20.27', 'foo')).toBe('oldmac');
-            expect(window.site.getPlatform('Mozilla/5.0 (Macintosh; U; PPC Mac OS X 10_4_11; nl-nl) AppleWebKit/533.16 (KHTML, like Gecko) Version/4.1 Safari/533.16', 'foo')).toBe('oldmac');
-            expect(window.site.getPlatform('Mozilla/4.0 (compatible; MSIE 5.23; Mac_PowerPC)', 'foo')).toBe('oldmac');
-            expect(window.site.getPlatform('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_7_3) AppleWebKit/534.55.3 (KHTML, like Gecko) Version/5.1.3 Safari/534.53.10', 'foo')).toBe('oldmac');
-            expect(window.site.getPlatform('Mozilla/5.0 (Macintosh; Intel Mac OS X 10.8; rv:21.0) Gecko/20100101 Firefox/21.0', 'foo')).toBe('oldmac');
+            expect(window.site.getPlatform('Mozilla/5.0 (Macintosh; U; PPC Mac OS X 10_5_8; ja-jp) AppleWebKit/533.20.25 (KHTML, like Gecko) Version/5.0.4 Safari/533.20.27', 'foo')).toBe('other');
+            expect(window.site.getPlatform('Mozilla/5.0 (Macintosh; U; PPC Mac OS X 10_4_11; nl-nl) AppleWebKit/533.16 (KHTML, like Gecko) Version/4.1 Safari/533.16', 'foo')).toBe('other');
+            expect(window.site.getPlatform('Mozilla/4.0 (compatible; MSIE 5.23; Mac_PowerPC)', 'foo')).toBe('other');
+            expect(window.site.getPlatform('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_7_3) AppleWebKit/534.55.3 (KHTML, like Gecko) Version/5.1.3 Safari/534.53.10', 'foo')).toBe('other');
+            expect(window.site.getPlatform('Mozilla/5.0 (Macintosh; Intel Mac OS X 10.8; rv:21.0) Gecko/20100101 Firefox/21.0', 'foo')).toBe('other');
+            expect(window.site.getPlatform('Mozilla/4.0 (compatible; MSIE 5.23; Mac_PowerPC)', 'foo')).toBe('other');
         });
 
         it('should identify iOS', function () {
@@ -64,13 +51,6 @@ describe('site.js', function () {
         it('should identify OSX', function () {
             expect(window.site.getPlatform('Mozilla/5.0 (Macintosh; Intel Mac OS X 10.12; rv:53.0) Gecko/20100101 Firefox/53.0', 'foo')).toBe('osx');
             expect(window.site.getPlatform('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10) AppleWebKit/538.10.3 (KHTML, like Gecko) Chrome/21.0.1180.89 Safari/537.1', 'foo')).toBe('osx');
-        });
-
-        it('should identify Firefox OS', function () {
-            expect(window.site.getPlatform('Mozilla/5.0 (Mobile; rv:26.0) Gecko/26.0 Firefox/26.0', '')).toBe('fxos');
-            expect(window.site.getPlatform('Mozilla/5.0 (Tablet; rv:26.0) Gecko/26.0 Firefox/26.0', '')).toBe('fxos');
-            // Firefox OS TV
-            expect(window.site.getPlatform('Mozilla/5.0 (FreeBSD; Viera; rv:34.0) Gecko/20100101 Firefox/34.0', '')).toBe('fxos');
         });
     });
 
@@ -115,10 +95,6 @@ describe('site.js', function () {
             expect(window.site.getArchType('Mozilla/5.0 (X11; Ubuntu; Linux armv7l; rv:32.0) Gecko/20100101 Firefox/32.0', 'Linux armv7l')).toBe('armv7');
             expect(window.site.getArchType('Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; ARM; Trident/6.0)')).toBe('armv7');
             expect(window.site.getArchType('Mozilla/5.0 (Windows Phone 8.1; ARM; Trident/7.0; Touch; rv:11; IEMobile/11.0; NOKIA; Lumia 928) like Gecko')).toBe('armv7');
-        });
-
-        it('should identify PowerPC', function () {
-            expect(window.site.getArchType('Mozilla/5.0 (Macintosh; U; PPC Mac OS X 10.4; en-US; rv:1.9.2.22) Gecko/20110902 Firefox/3.6.22', 'MacPPC')).toBe('ppc');
         });
     });
 


### PR DESCRIPTION
## Description

Demo: https://www-demo1.allizom.org/en-US/

- Removes "unsupported" messaging from download buttons:
- Defaults unknown systems to "undetermined" messaging
- Removes unused detection for Firefox OS.
- Removes unused logic for Windows 64bit download links. (the stub installer handles detection)
- Removes detection for Android architecture (download buttons all link to the Play Store, so this is now redundant?)

## Issue / Bugzilla link
#8454

## Testing
Successful test run: https://gitlab.com/mozmeao/www-config/-/pipelines/162469319