### PR TITLE
Animate global nav button (Fixes #9009)

### DIFF
--- a/media/css/protocol/components/_navigation.scss
+++ b/media/css/protocol/components/_navigation.scss
@@ -100,3 +100,34 @@ html.is-firefox.android .mzp-c-navigation {
         display: none;
     }
 }
+
+// Animate the navigation secondary CTA button.
+@keyframes bounce {
+    10%, 25%, 40%, 49% {
+        animation-timing-function: cubic-bezier(.39, .58, .57, 1);
+        transform: translate3d(0, 0, 0);
+    }
+    20%, 22% {
+        animation-timing-function: ease-in-out;
+        transform: translate3d(0, -8px, 0);
+    }
+    35% {
+        animation-timing-function: ease-in-out;
+        transform: translate3d(0, -5px, 0);
+    }
+    45% {
+        animation-timing-function: ease-in-out;
+        transform: translate3d(0, -1.5px, 0);
+    }
+}
+
+.nav-button-is-ready .mzp-c-navigation-download .mzp-c-button {
+    animation: bounce 2s .5s;
+    transform-origin: center bottom;
+
+    @media (prefers-reduced-motion: reduce) {
+        animation: none;
+    }
+}
+
+

--- a/media/js/base/protocol/init-navigation.js
+++ b/media/js/base/protocol/init-navigation.js
@@ -43,7 +43,7 @@
         }
     }
 
-    function initFxAButton() {
+    function initNavButton() {
         if (typeof Mozilla.Client === 'undefined') {
             return false;
         }
@@ -51,13 +51,13 @@
         var nav = document.querySelector('.mzp-c-navigation');
         var fxaButton = document.querySelector('.mzp-c-navigation .c-navigation-fxa-cta');
 
-        // User should be on Firefox desktop, nav should be present on page, and the FxA button should exist.
-        if (!Mozilla.Client.isFirefoxDesktop || !nav || !fxaButton) {
+        // Nav should be present on page.
+        if (!nav) {
             return false;
         }
 
-        // Button is hidden from most locales for now so make sure it exists before we mess with it.
-        if (fxaButton) {
+        // Check that FxA button exists on the page, and visitor is using Firefox Desktop.
+        if (fxaButton && Mozilla.Client.isFirefoxDesktop) {
             var fxaButtonAltHref = fxaButton.getAttribute('data-alt-href');
 
             // Update the button if user is signed in
@@ -68,9 +68,12 @@
                 }
             });
         }
+
+        // Add a CSS hook for animating the nav button (issue #9009)
+        nav.classList.add('nav-button-is-ready');
     }
 
-    initFxAButton();
+    initNavButton();
 
     Mzp.Menu.init({
         onMenuOpen: handleOnMenuOpen


### PR DESCRIPTION
## Description
- Adds a subtle bounce animation to the navigation CTA button (both download and FxA) shortly after page load.

## Issue / Bugzilla link
#9009

## Testing
- [x] Nav download button (non-Firefox browsers) should show the animation.
- [x] Nav FxA button (Firefox browsers) should also show the animation.