### PR TITLE
Exclude id locale from /whatsnew pages in Fluent config (Fixes #9100)

### DIFF
--- a/l10n/configs/special-templates.toml
+++ b/l10n/configs/special-templates.toml
@@ -14,3 +14,10 @@ basepath = ".."
 #         "de",
 #         "fr",
 #     ]
+
+[[paths]]
+    reference = "en/firefox/whatsnew/**/*.ftl"
+    l10n = "{locale}/firefox/whatsnew/**/*.ftl"
+    locales = [
+        "id",
+    ]


### PR DESCRIPTION
Fixes: #9100
