### PR TITLE
Add Windows ARM64/AArch64 builds to /firefox/all/ (Fixes #8929)

### DIFF
--- a/bedrock/firefox/firefox_details.py
+++ b/bedrock/firefox/firefox_details.py
@@ -30,6 +30,7 @@ class FirefoxDesktop(_ProductDetails):
     platform_labels = OrderedDict([
         ('win64', 'Windows 64-bit'),
         ('win64-msi', 'Windows 64-bit MSI'),
+        ('win64-aarch64', 'Windows ARM64/AArch64'),
         ('win', 'Windows 32-bit'),
         ('win-msi', 'Windows 32-bit MSI'),
         ('osx', 'macOS'),
@@ -39,7 +40,7 @@ class FirefoxDesktop(_ProductDetails):
 
     # Recommended/modern vs traditional/legacy platforms
     platform_classification = OrderedDict([
-        ('recommended', ('win64', 'win64-msi', 'osx', 'linux64')),
+        ('recommended', ('win64', 'win64-msi', 'win64-aarch64', 'osx', 'linux64')),
         ('traditional', ('linux', 'win', 'win-msi')),
     ])
 

--- a/bedrock/firefox/templates/firefox/all-unified.html
+++ b/bedrock/firefox/templates/firefox/all-unified.html
@@ -307,6 +307,12 @@
         {{ ftl('firefox-all-windows-installers-for') }}
       </p>
     </li>
+    <li>
+      <h2 class="c-help-title">{{ ftl('firefox-all-arm64-installers') }}</h2>
+      <p class="c-help-desc">
+        {{ ftl('firefox-all-arm64-installers-optimized') }}
+      </p>
+    </li>
   </ul>
 </div>
 {% endblock %}

--- a/bedrock/firefox/tests/test_base.py
+++ b/bedrock/firefox/tests/test_base.py
@@ -131,23 +131,23 @@ class TestFirefoxAll(TestCase):
 
         desktop_release_builds = len(self.firefox_desktop.get_filtered_full_builds('release'))
         assert len(doc('.c-locale-list[data-product="desktop_release"] > li')) == desktop_release_builds
-        assert len(doc('.c-locale-list[data-product="desktop_release"] > li[data-language="en-US"] > ul > li > a')) == 7
+        assert len(doc('.c-locale-list[data-product="desktop_release"] > li[data-language="en-US"] > ul > li > a')) == 8
 
         desktop_beta_builds = len(self.firefox_desktop.get_filtered_full_builds('beta'))
         assert len(doc('.c-locale-list[data-product="desktop_beta"] > li')) == desktop_beta_builds
-        assert len(doc('.c-locale-list[data-product="desktop_beta"] > li[data-language="en-US"] > ul > li > a')) == 7
+        assert len(doc('.c-locale-list[data-product="desktop_beta"] > li[data-language="en-US"] > ul > li > a')) == 8
 
         desktop_developer_builds = len(self.firefox_desktop.get_filtered_full_builds('alpha'))
         assert len(doc('.c-locale-list[data-product="desktop_developer"] > li')) == desktop_developer_builds
-        assert len(doc('.c-locale-list[data-product="desktop_developer"] > li[data-language="en-US"] > ul > li > a')) == 7
+        assert len(doc('.c-locale-list[data-product="desktop_developer"] > li[data-language="en-US"] > ul > li > a')) == 8
 
         desktop_nightly_builds = len(self.firefox_desktop.get_filtered_full_builds('nightly'))
         assert len(doc('.c-locale-list[data-product="desktop_nightly"] > li')) == desktop_nightly_builds
-        assert len(doc('.c-locale-list[data-product="desktop_nightly"] > li[data-language="en-US"] > ul > li > a')) == 7
+        assert len(doc('.c-locale-list[data-product="desktop_nightly"] > li[data-language="en-US"] > ul > li > a')) == 8
 
         desktop_esr_builds = len(self.firefox_desktop.get_filtered_full_builds('esr'))
         assert len(doc('.c-locale-list[data-product="desktop_esr"] > li')) == desktop_esr_builds
-        assert len(doc('.c-locale-list[data-product="desktop_esr"] > li[data-language="en-US"] > ul > li > a')) == 7
+        assert len(doc('.c-locale-list[data-product="desktop_esr"] > li[data-language="en-US"] > ul > li > a')) == 8
 
         android_release_builds = len(self.firefox_android.get_filtered_full_builds('release'))
         assert len(doc('.c-locale-list[data-product="android_release"] > li')) == android_release_builds

--- a/bedrock/firefox/tests/test_helpers.py
+++ b/bedrock/firefox/tests/test_helpers.py
@@ -162,16 +162,16 @@ class TestDownloadButtons(TestCase):
         doc = pq(render("{{ download_firefox() }}",
                         {'request': get_request, 'fluent_l10n': self.get_l10n(get_request.locale)}))
 
-        # The first 7 links should be for desktop.
+        # The first 8 links should be for desktop.
         links = doc('.download-list a')
 
-        for link in links[:7]:
+        for link in links[:8]:
             assert (
                 pq(link).attr('data-direct-link')
                 .startswith('https://download.mozilla.org'))
 
-        # The eighth link is mobile and should not have the attr
-        assert pq(links[7]).attr('data-direct-link') is None
+        # The ninth link is mobile and should not have the attr
+        assert pq(links[8]).attr('data-direct-link') is None
 
     def test_nightly_desktop(self):
         """
@@ -185,13 +185,14 @@ class TestDownloadButtons(TestCase):
                         {'request': get_request, 'fluent_l10n': self.get_l10n(get_request.locale)}))
 
         list = doc('.download-list li')
-        assert list.length == 6
+        assert list.length == 7
         assert pq(list[0]).attr('class') == 'os_win'
         assert pq(list[1]).attr('class') == 'os_win64-msi'
-        assert pq(list[2]).attr('class') == 'os_win-msi'
-        assert pq(list[3]).attr('class') == 'os_osx'
-        assert pq(list[4]).attr('class') == 'os_linux64'
-        assert pq(list[5]).attr('class') == 'os_linux'
+        assert pq(list[2]).attr('class') == 'os_win64-aarch64'
+        assert pq(list[3]).attr('class') == 'os_win-msi'
+        assert pq(list[4]).attr('class') == 'os_osx'
+        assert pq(list[5]).attr('class') == 'os_linux64'
+        assert pq(list[6]).attr('class') == 'os_linux'
         # stub disabled for now for non-en-US locales
         # bug 1339870
         # assert 'stub' in pq(pq(list[1]).find('a')[0]).attr('href')
@@ -205,14 +206,15 @@ class TestDownloadButtons(TestCase):
                         {'request': get_request, 'fluent_l10n': self.get_l10n(get_request.locale)}))
 
         list = doc('.download-list li')
-        assert list.length == 7
+        assert list.length == 8
         assert pq(list[0]).attr('class') == 'os_win64'
         assert pq(list[1]).attr('class') == 'os_win64-msi'
-        assert pq(list[2]).attr('class') == 'os_win'
-        assert pq(list[3]).attr('class') == 'os_win-msi'
-        assert pq(list[4]).attr('class') == 'os_osx'
-        assert pq(list[5]).attr('class') == 'os_linux64'
-        assert pq(list[6]).attr('class') == 'os_linux'
+        assert pq(list[2]).attr('class') == 'os_win64-aarch64'
+        assert pq(list[3]).attr('class') == 'os_win'
+        assert pq(list[4]).attr('class') == 'os_win-msi'
+        assert pq(list[5]).attr('class') == 'os_osx'
+        assert pq(list[6]).attr('class') == 'os_linux64'
+        assert pq(list[7]).attr('class') == 'os_linux'
 
     def test_beta_desktop(self):
         """The Beta channel should not have Windows 64 build yet"""
@@ -223,14 +225,15 @@ class TestDownloadButtons(TestCase):
                         {'request': get_request, 'fluent_l10n': self.get_l10n(get_request.locale)}))
 
         list = doc('.download-list li')
-        assert list.length == 7
+        assert list.length == 8
         assert pq(list[0]).attr('class') == 'os_win64'
         assert pq(list[1]).attr('class') == 'os_win64-msi'
-        assert pq(list[2]).attr('class') == 'os_win'
-        assert pq(list[3]).attr('class') == 'os_win-msi'
-        assert pq(list[4]).attr('class') == 'os_osx'
-        assert pq(list[5]).attr('class') == 'os_linux64'
-        assert pq(list[6]).attr('class') == 'os_linux'
+        assert pq(list[2]).attr('class') == 'os_win64-aarch64'
+        assert pq(list[3]).attr('class') == 'os_win'
+        assert pq(list[4]).attr('class') == 'os_win-msi'
+        assert pq(list[5]).attr('class') == 'os_osx'
+        assert pq(list[6]).attr('class') == 'os_linux64'
+        assert pq(list[7]).attr('class') == 'os_linux'
 
     def test_firefox_desktop(self):
         """The Release channel should not have Windows 64 build yet"""
@@ -241,14 +244,15 @@ class TestDownloadButtons(TestCase):
                         {'request': get_request, 'fluent_l10n': self.get_l10n(get_request.locale)}))
 
         list = doc('.download-list li')
-        assert list.length == 7
+        assert list.length == 8
         assert pq(list[0]).attr('class') == 'os_win64'
         assert pq(list[1]).attr('class') == 'os_win64-msi'
-        assert pq(list[2]).attr('class') == 'os_win'
-        assert pq(list[3]).attr('class') == 'os_win-msi'
-        assert pq(list[4]).attr('class') == 'os_osx'
-        assert pq(list[5]).attr('class') == 'os_linux64'
-        assert pq(list[6]).attr('class') == 'os_linux'
+        assert pq(list[2]).attr('class') == 'os_win64-aarch64'
+        assert pq(list[3]).attr('class') == 'os_win'
+        assert pq(list[4]).attr('class') == 'os_win-msi'
+        assert pq(list[5]).attr('class') == 'os_osx'
+        assert pq(list[6]).attr('class') == 'os_linux64'
+        assert pq(list[7]).attr('class') == 'os_linux'
 
     def test_latest_nightly_android(self):
         """The download button should have a Google Play link"""
@@ -349,14 +353,15 @@ class TestDownloadList(TestCase):
 
         # Check that links classes are ordered as expected.
         list = doc('.download-platform-list li')
-        assert list.length == 7
+        assert list.length == 8
         assert pq(list[0]).attr('class') == 'os_win64'
         assert pq(list[1]).attr('class') == 'os_win64-msi'
-        assert pq(list[2]).attr('class') == 'os_osx'
-        assert pq(list[3]).attr('class') == 'os_linux64'
-        assert pq(list[4]).attr('class') == 'os_linux'
-        assert pq(list[5]).attr('class') == 'os_win'
-        assert pq(list[6]).attr('class') == 'os_win-msi'
+        assert pq(list[2]).attr('class') == 'os_win64-aarch64'
+        assert pq(list[3]).attr('class') == 'os_osx'
+        assert pq(list[4]).attr('class') == 'os_linux64'
+        assert pq(list[5]).attr('class') == 'os_linux'
+        assert pq(list[6]).attr('class') == 'os_win'
+        assert pq(list[7]).attr('class') == 'os_win-msi'
 
         links = doc('.download-platform-list a')
 
@@ -381,14 +386,15 @@ class TestDownloadList(TestCase):
 
         # Check that links classes are ordered as expected.
         list = doc('.download-platform-list li')
-        assert list.length == 7
+        assert list.length == 8
         assert pq(list[0]).attr('class') == 'os_win64'
         assert pq(list[1]).attr('class') == 'os_win64-msi'
-        assert pq(list[2]).attr('class') == 'os_osx'
-        assert pq(list[3]).attr('class') == 'os_linux64'
-        assert pq(list[4]).attr('class') == 'os_linux'
-        assert pq(list[5]).attr('class') == 'os_win'
-        assert pq(list[6]).attr('class') == 'os_win-msi'
+        assert pq(list[2]).attr('class') == 'os_win64-aarch64'
+        assert pq(list[3]).attr('class') == 'os_osx'
+        assert pq(list[4]).attr('class') == 'os_linux64'
+        assert pq(list[5]).attr('class') == 'os_linux'
+        assert pq(list[6]).attr('class') == 'os_win'
+        assert pq(list[7]).attr('class') == 'os_win-msi'
 
         links = doc('.download-platform-list a')
 
@@ -410,13 +416,14 @@ class TestDownloadList(TestCase):
 
         # Check that links classes are ordered as expected.
         list = doc('.download-platform-list li')
-        assert list.length == 6
+        assert list.length == 7
         assert pq(list[0]).attr('class') == 'os_win'
         assert pq(list[1]).attr('class') == 'os_win64-msi'
-        assert pq(list[2]).attr('class') == 'os_osx'
-        assert pq(list[3]).attr('class') == 'os_linux64'
-        assert pq(list[4]).attr('class') == 'os_linux'
-        assert pq(list[5]).attr('class') == 'os_win-msi'
+        assert pq(list[2]).attr('class') == 'os_win64-aarch64'
+        assert pq(list[3]).attr('class') == 'os_osx'
+        assert pq(list[4]).attr('class') == 'os_linux64'
+        assert pq(list[5]).attr('class') == 'os_linux'
+        assert pq(list[6]).attr('class') == 'os_win-msi'
 
         links = doc('.download-platform-list a')
 

--- a/l10n/en/firefox/all.ftl
+++ b/l10n/en/firefox/all.ftl
@@ -37,6 +37,8 @@ firefox-all-get-a-sneak-peek-at = Get a sneak peek at the latest { -brand-name-f
 firefox-all-test-your-sites-against = Test your sites against soon-to-be-released { -brand-name-firefox } browser features with powerful, flexible DevTools that are on by default.
 firefox-all-count-on-stability-and = Count on stability and ease of use with this { -brand-name-firefox } browser built for enterprise.
 firefox-all-windows-installers-for = Windows installers for corporate IT that simplify the configuration, deployment and management of the { -brand-name-firefox-browser }.
+firefox-all-arm64-installers = ARM64/AArch64 installers
+firefox-all-arm64-installers-optimized = ARM64/AArch64 installers optimized for Snapdragon-powered { -brand-name-windows } PCs.
 
 # Variables:
 #   $url (url) - link to https://support.mozilla.org/kb/choosing-firefox-cpu-architecture-windows-os

--- a/media/css/pebbles/components/_buttons-download.scss
+++ b/media/css/pebbles/components/_buttons-download.scss
@@ -105,6 +105,7 @@ ul.download-list {
 // OS detection
 .download-button .os_win64,
 .download-button .os_win64-msi,
+.download-button .os_win64-aarch64,
 .download-button .os_linux,
 .download-button .os_linux64,
 // Uncomment this to enable the win64 download buttons:

--- a/media/css/protocol/components/_download-button.scss
+++ b/media/css/protocol/components/_download-button.scss
@@ -75,6 +75,7 @@ ul.download-list {
 // OS detection
 .download-button .os_win64,
 .download-button .os_win64-msi,
+.download-button .os_win64-aarch64,
 .download-button .os_linux,
 .download-button .os_linux64,
 // Uncomment this to enable the win64 download buttons:


### PR DESCRIPTION
## Description
- Add Windows ARM64/AArch64 builds to /firefox/all/ and (/firefox/new/ modal).

http://127.0.0.1:8000/en-US/firefox/all/
http://127.0.0.1:8000/en-US/firefox/new/

## Issue / Bugzilla link
#8929

## Testing
Successful test run: https://gitlab.com/mozmeao/www-config/-/pipelines/163494753