### PR TITLE
Cache-bust doubleclick pixel on /download/thanks (Fixes #9128)

### DIFF
--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -1510,7 +1510,7 @@ CSP_FRAME_SRC = CSP_CHILD_SRC
 # Bug 1331069 - Double Click tracking pixel for download page.
 AVAILABLE_TRACKING_PIXELS = {
     'doubleclick': ('https://ad.doubleclick.net/ddm/activity/src=6417015;type=deskt0;cat=mozil0;dc_lat=;dc_rdid=;'
-                    'tag_for_child_directed_treatment=;ord=1;num=1?&_dc_ck=try'),
+                    'tag_for_child_directed_treatment=;tfua=;npa=;ord=1'),
 }
 ENABLED_PIXELS = config('ENABLED_PIXELS', default='doubleclick', parser=ListOf(str))
 TRACKING_PIXELS = [AVAILABLE_TRACKING_PIXELS[x] for x in ENABLED_PIXELS if x in AVAILABLE_TRACKING_PIXELS]

--- a/media/js/base/mozilla-pixel.js
+++ b/media/js/base/mozilla-pixel.js
@@ -21,13 +21,13 @@ if (typeof window.Mozilla === 'undefined') {
     var Pixel = {};
 
     Pixel.getPixelData = function() {
-        return $('#strings').data('pixels');
+        return document.getElementById('strings').getAttribute('data-pixels');
     };
 
     Pixel.setPixels = function() {
-        var $body = $('body');
+        var body = document.querySelector('body');
         var pixels = Pixel.getPixelData();
-        var $pixel;
+        var pixel;
 
         if (typeof pixels !== 'string' || pixels === '') {
             return;
@@ -37,13 +37,19 @@ if (typeof window.Mozilla === 'undefined') {
         pixels = pixels.split('::');
 
         for (var i = 0; i < pixels.length; i++) {
-            $pixel = $('<img />', {
-                width: '1',
-                height: '1',
-                src: pixels[i].replace(/\s/g, '')
-            });
-            $pixel.addClass('moz-px');
-            $body.append($pixel);
+            pixel = document.createElement('img');
+            pixel.width = 1;
+            pixel.height = 1;
+            pixel.src = pixels[i].replace(/\s/g, '');
+
+            // Cache bust doubleclick pixel (see issue 9128)
+            if (pixels[i].indexOf('ad.doubleclick.net') !== -1) {
+                var num = Math.random() + '' * 10000000000000;
+                pixel.src += ';num=' + num;
+            }
+
+            pixel.className = 'moz-px';
+            body.appendChild(pixel);
         }
     };
 

--- a/tests/unit/spec/base/mozilla-pixel.js
+++ b/tests/unit/spec/base/mozilla-pixel.js
@@ -3,12 +3,16 @@
  * Sinon docs: http://sinonjs.org/docs/
  */
 
+/* global sinon */
+
 describe('mozilla-pixel.js', function() {
 
     'use strict';
 
     afterEach(function() {
-        $('.moz-px').remove();
+        document.querySelectorAll('.moz-px').forEach(function(e) {
+            e.parentNode.removeChild(e);
+        });
     });
 
     describe('init', function() {
@@ -25,28 +29,40 @@ describe('mozilla-pixel.js', function() {
             spyOn(Mozilla, 'dntEnabled').and.returnValue(false);
             spyOn(Mozilla.Pixel, 'getPixelData').and.returnValue(pixels);
             Mozilla.Pixel.init();
-            expect($('.moz-px').length).toEqual(3);
+            expect(document.querySelectorAll('.moz-px').length).toEqual(3);
         });
 
         it('should add one pixel to document body', function() {
             spyOn(Mozilla, 'dntEnabled').and.returnValue(false);
             spyOn(Mozilla.Pixel, 'getPixelData').and.returnValue('/img/foo.png');
             Mozilla.Pixel.init();
-            expect($('.moz-px').length).toEqual(1);
+            expect(document.querySelectorAll('.moz-px').length).toEqual(1);
         });
 
         it('should not add pixel if data is undefined', function() {
             spyOn(Mozilla, 'dntEnabled').and.returnValue(false);
             spyOn(Mozilla.Pixel, 'getPixelData').and.returnValue(undefined);
             Mozilla.Pixel.init();
-            expect($('.moz-px').length).toEqual(0);
+            expect(document.querySelectorAll('.moz-px').length).toEqual(0);
         });
 
         it('should not add pixel if data is empty', function() {
             spyOn(Mozilla, 'dntEnabled').and.returnValue(false);
             spyOn(Mozilla.Pixel, 'getPixelData').and.returnValue('');
             Mozilla.Pixel.init();
-            expect($('.moz-px').length).toEqual(0);
+            expect(document.querySelectorAll('.moz-px').length).toEqual(0);
+        });
+
+        it('should cache bust doubleclick request', function() {
+            // this is a bit of a hack to avoid making real requests to ad.doubleclick.net in test runs.
+            var pixels = '/img/foo.png?ad.doubleclick.net/src=6417015';
+            Math.random = sinon.stub().returns(0.853456456);
+            spyOn(Mozilla, 'dntEnabled').and.returnValue(false);
+            spyOn(Mozilla.Pixel, 'getPixelData').and.returnValue(pixels);
+            Mozilla.Pixel.init();
+
+            expect(document.querySelector('.moz-px').src).toContain(';num=0.853456456');
+
         });
     });
 });


### PR DESCRIPTION
## Description
- Adds random number param to cache bust doubleclick request on /download/thanks/.
- Replaces jQuery code with vanilla JS.
- Adds test for cache bust param.

## Issue / Bugzilla link
#9128

## Testing

Test using a browser with DNT disabled:

- [ ] Pixel request should fire on /thanks/ as expected.
- [ ] Pixel request should contain a `num` parameter with a random value.