### PR TITLE
[fix #9138] Add terms and privacy notice for Mozilla VPN

### DIFF
--- a/bedrock/legal/templates/legal/terms/mozilla-vpn.html
+++ b/bedrock/legal/templates/legal/terms/mozilla-vpn.html
@@ -1,0 +1,7 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+
+{% extends "legal/docs-base.html" %}
+
+{% block page_title %}{{ _('Mozilla VPN Terms of Service') }}{% endblock %}

--- a/bedrock/legal/urls.py
+++ b/bedrock/legal/urls.py
@@ -28,6 +28,9 @@ urlpatterns = (
     url(r'^terms/mozilla/$', LegalDocView.as_view(template_name='legal/terms/mozilla.html', legal_doc_name='Websites_ToU'),
         name='legal.terms.mozilla'),
 
+    url(r'^terms/mozilla-vpn/$', LegalDocView.as_view(template_name='legal/terms/mozilla-vpn.html',
+        legal_doc_name='Mozilla_VPN_ToS'), name='legal.terms.mozilla-vpn'),
+
     url(r'^terms/firefox/$', LegalDocView.as_view(template_name='legal/terms/firefox.html', legal_doc_name='firefox_about_rights'),
         name='legal.terms.firefox'),
 

--- a/bedrock/privacy/templates/privacy/base-protocol.html
+++ b/bedrock/privacy/templates/privacy/base-protocol.html
@@ -40,6 +40,7 @@
   (focus_url, 'privacy-focus', focus_name),
   (url('privacy.notices.firefox-private-network'), 'privacy-private-network', _('Firefox Private Network')),
   (url('privacy.notices.firefox-relay'), 'privacy-relay', _('Firefox Relay')),
+  (url('privacy.notices.mozilla-vpn'), 'mozilla-vpn', _('Mozilla VPN')),
   (url('privacy.notices.thunderbird'), 'privacy-thunderbird', _('Thunderbird')),
 ] -%}
 

--- a/bedrock/privacy/templates/privacy/notices/mozilla-vpn.html
+++ b/bedrock/privacy/templates/privacy/notices/mozilla-vpn.html
@@ -1,0 +1,9 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+
+{% extends "privacy/notices/base-notice-headings.html" %}
+
+{% set body_id = "mozilla-vpn" %}
+
+{% block article_header_logo %}{% endblock %}

--- a/bedrock/privacy/urls.py
+++ b/bedrock/privacy/urls.py
@@ -29,6 +29,7 @@ urlpatterns = (
     url(r'^firefox-monitor/$', views.firefox_monitor_notices, name='privacy.notices.firefox-monitor'),
     url(r'^firefox-private-network/$', views.firefox_private_network, name='privacy.notices.firefox-private-network'),
     url(r'^firefox-relay/$', views.firefox_relay_notices, name='privacy.notices.firefox-relay'),
+    url(r'^mozilla-vpn/$', views.mozilla_vpn, name='privacy.notices.mozilla-vpn'),
 
     page('archive', 'privacy/archive/index.html'),
     page('archive/firefox/2006-10', 'privacy/archive/firefox-2006-10.html'),

--- a/bedrock/privacy/views.py
+++ b/bedrock/privacy/views.py
@@ -111,6 +111,10 @@ firefox_private_network = PrivacyDocView.as_view(
     template_name='privacy/notices/firefox-private-network.html',
     legal_doc_name='Firefox_Private_Network_Beta_Privacy_Notice')
 
+mozilla_vpn = PrivacyDocView.as_view(
+    template_name='privacy/notices/mozilla-vpn.html',
+    legal_doc_name='mozilla_vpn_privacy_notice')
+
 
 @cache_page(60 * 60)  # cache for 1 hour
 def privacy(request):


### PR DESCRIPTION
## Description
Adds TOS and privacy policy pages for Mozilla VPN.

This needs to be live in production on **14 July, 2020**

## Issue / Bugzilla link
#9138 

## Testing
http://localhost:8000/about/legal/terms/mozilla-vpn/
http://localhost:8000/privacy/mozilla-vpn/

https://www-demo-pr-9140.herokuapp.com/about/legal/terms/mozilla-vpn/
https://www-demo-pr-9140.herokuapp.com/privacy/mozilla-vpn/