### PR TITLE
[no bug] Add anchor to non-profit section of desktop version of /new

### DIFF
--- a/bedrock/firefox/templates/firefox/new/desktop/download.html
+++ b/bedrock/firefox/templates/firefox/new/desktop/download.html
@@ -368,7 +368,7 @@
     </ul>
   </section>
 
-  <section class="mzp-l-content t-company">
+  <section id="non-profit" class="mzp-l-content t-company">
     <h2 class="c-section-title mzp-has-zap-9">Backed by the <strong>non-profit</strong> that puts people first</h2>
 
     <div class="mzp-l-card-half">


### PR DESCRIPTION
## Description

Add anchor to non-profit section of desktop version of /new

## Issue / Bugzilla link

No bug.

## Testing

http://localhost:8000/en-US/firefox/new/?xv=desktop#non-profit
