### PR TITLE
Migrate Facebook Container page to Fluent (Fixes #9152)

### DIFF
--- a/bedrock/firefox/templates/firefox/facebookcontainer/index.html
+++ b/bedrock/firefox/templates/firefox/facebookcontainer/index.html
@@ -9,8 +9,8 @@
 
 {% set addon_url = "https://addons.mozilla.org/firefox/addon/facebook-container/?src=external-www.mozilla.org-facebookcontainer&utm_source=www.mozilla.org-facebookcontainer&utm_medium=referral" %}
 
-{% block page_title %}{{_('Facebook Container for Firefox | Prevent Facebook from seeing what websites you visit.')}}{% endblock %}
-{% block page_desc %}{{_('Millions of people around the world trust Firefox Web browsers on Android, iOS and desktop computers. Fast. Private. Download now!')}}{% endblock %}
+{% block page_title %}{{ ftl('facebook-container-facebook-container-for-firefox') }}{% endblock %}
+{% block page_desc %}{{ ftl('facebook-container-millions-of-people-around') }}{% endblock %}
 
 {% block page_css %}
   {{ css_bundle('firefox_facebook_container') }}
@@ -19,24 +19,22 @@
 {% block content %}
 <main role="main">
   {% call hero(
-    title=_('Facebook. Well contained. Keep the rest of your life to yourself.'),
+    title=ftl('facebook-container-facebook-well-contained-keep'),
     class='mzp-t-dark mzp-has-image mzp-t-product-firefox',
     include_cta=True,
     heading_level=1) %}
 
   <div class="mzp-c-hero-desc">
-    <a class="mzp-c-cta-link extension-cta" href="{{ addon_url }}">{{ _('Get the Facebook Container Extension') }}</a>
+    <a class="mzp-c-cta-link extension-cta" href="{{ addon_url }}">{{ ftl('facebook-container-get-the-facebook-container') }}</a>
 
     <div class="firefox-cta">
-      <p>{{ _('Download Firefox and get the Facebook Container Extension') }}</p>
+      <p>{{ ftl('facebook-container-download-firefox-and-get-the') }}</p>
       {{ download_firefox(alt_copy=ftl('download-button-download-firefox'), locale_in_transition=true, dom_id="download-firefox-cta") }}
     </div>
 
     <div class="mobile-cta">
-      <p>{{ _('The Facebook Container Extension is not available on mobile devices.') }}</p>
-      {# L10n: For German, all instances of the string 'Firefox Focus' must be 'Firefox Klar' (as done on https://www.mozilla.org/de/firefox/focus/) #}
-
-      <p>{{ _('Try <strong>Firefox Focus</strong>, the privacy browser for Android and iOS.') }}</p>
+      <p>{{ ftl('facebook-container-the-facebook-container-extension') }}</p>
+      <p>{{ ftl('facebook-container-try-firefox-focus-the-privacy') }}</p>
 
       <ul>
         <li>
@@ -74,34 +72,28 @@
 
   <section class="mzp-l-content mzp-l-card-third">
     <div class="mzp-c-card">
-      <h3 class="mzp-c-card-title">{{ _('Opt out on your terms') }}</h3>
+      <h3 class="mzp-c-card-title">{{ ftl('facebook-container-opt-out-on-your-terms') }}</h3>
       <p>
-      {% trans fbcontainer=addon_url %}
-        Facebook can track almost all your web activity and tie it to your Facebook identity. If that’s too much for you, the <a href="{{ fbcontainer }}">Facebook Container extension</a> isolates your identity into a separate container tab, making it harder for Facebook to track you on the web outside of Facebook.
-      {% endtrans %}
+      {{ ftl('facebook-container-facebook-can-track-almost', fbcontainer=addon_url) }}
       </p>
     </div>
     <div class="mzp-c-card">
-      <h3 class="mzp-c-card-title">{{ _('Install and contain') }}</h3>
+      <h3 class="mzp-c-card-title">{{ ftl('facebook-container-install-and-contain') }}</h3>
       <p>
-      {% trans fbcontainer=addon_url %}
-        Installing the <a href="{{ fbcontainer }}">extension</a> is easy and, once activated, will open Facebook in a blue tab each time you use it. Use and enjoy Facebook normally. Facebook will still be able to send you advertising and recommendations on their site, but it will be much harder for Facebook to use your activity collected <strong>off Facebook</strong> to send you ads and other targeted messages.
-      {% endtrans %}
+      {{ ftl('facebook-container-installing-the-extension-is', fbcontainer=addon_url) }}
       </p>
     </div>
     <div class="mzp-c-card">
-      <h3 class="mzp-c-card-title">{{ _('About Firefox and Mozilla') }}</h3>
+      <h3 class="mzp-c-card-title">{{ ftl('facebook-container-about-firefox-and-mozilla') }}</h3>
       <p>
-      {% trans mozilla=url('mozorg.home') %}
-        We’re backed by <a href="{{ mozilla }}">Mozilla</a>, the not-for-profit organization that puts people over profit to give everyone more power online. We created this extension because we believe that you should have easy-to-use tools that help you manage your privacy and security.
-      {% endtrans %}
+      {{ ftl('facebook-container-were-backed-by-mozilla-the', mozilla=url('mozorg.home')) }}
       </p>
     </div>
   </section>
 
   <section class="firefox-cta">
     {% call call_out_compact(
-      title=_('Browse freely with Firefox today.'),
+      title=ftl('facebook-container-browse-freely-with-firefox'),
       class='mzp-t-dark',
       heading_level=2)
     %}

--- a/bedrock/firefox/urls.py
+++ b/bedrock/firefox/urls.py
@@ -43,7 +43,7 @@ urlpatterns = (
     page('firefox/enterprise', 'firefox/enterprise/index.html'),
     page('firefox/enterprise/signup', 'firefox/enterprise/signup.html'),
     page('firefox/enterprise/signup/thanks', 'firefox/enterprise/signup-thanks.html'),
-    page('firefox/facebookcontainer', 'firefox/facebookcontainer/index.html'),
+    page('firefox/facebookcontainer', 'firefox/facebookcontainer/index.html', ftl_files=['firefox/facebook_container']),
 
     page('firefox/features', 'firefox/features/index.html',
          ftl_files=['firefox/features/shared', 'firefox/features/index']),

--- a/l10n/en/firefox/facebook_container.ftl
+++ b/l10n/en/firefox/facebook_container.ftl
@@ -1,0 +1,34 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+### URL: https://www-dev.allizom.org/firefox/facebookcontainer/
+
+facebook-container-facebook-container-for-firefox = { -brand-name-facebook-container } for { -brand-name-firefox } | Prevent { -brand-name-facebook } from seeing what websites you visit.
+facebook-container-millions-of-people-around = Millions of people around the world trust { -brand-name-firefox } Web browsers on { -brand-name-android }, { -brand-name-ios } and desktop computers. Fast. Private. Download now!
+facebook-container-facebook-well-contained-keep = { -brand-name-facebook }. Well contained. Keep the rest of your life to yourself.
+facebook-container-get-the-facebook-container = Get the { -brand-name-facebook-container } Extension
+facebook-container-download-firefox-and-get-the = Download { -brand-name-firefox } and get the { -brand-name-facebook-container } Extension
+facebook-container-the-facebook-container-extension = The { -brand-name-facebook-container } Extension is not available on mobile devices.
+
+# For German, the brand name for 'Firefox Focus' in brands.ftl should be changed to 'Firefox Klar'.
+facebook-container-try-firefox-focus-the-privacy = Try <strong>{ -brand-name-firefox-focus }</strong>, the privacy browser for { -brand-name-android } and { -brand-name-ios }.
+facebook-container-opt-out-on-your-terms = Opt out on your terms
+
+# Variables:
+#   $fbcontainer (url) - link to https://addons.mozilla.org/firefox/addon/facebook-container/
+facebook-container-facebook-can-track-almost = { -brand-name-facebook } can track almost all your web activity and tie it to your { -brand-name-facebook } identity. If that’s too much for you, the <a href="{ $fbcontainer }">{ -brand-name-facebook-container } extension</a> isolates your identity into a separate container tab, making it harder for { -brand-name-facebook } to track you on the web outside of { -brand-name-facebook }.
+
+facebook-container-install-and-contain = Install and contain
+
+# Variables:
+#   $fbcontainer (url) - link to https://addons.mozilla.org/firefox/addon/facebook-container/
+facebook-container-installing-the-extension-is = Installing the <a href="{ $fbcontainer }">extension</a> is easy and, once activated, will open { -brand-name-facebook } in a blue tab each time you use it. Use and enjoy { -brand-name-facebook } normally. { -brand-name-facebook } will still be able to send you advertising and recommendations on their site, but it will be much harder for { -brand-name-facebook } to use your activity collected <strong>off { -brand-name-facebook }</strong> to send you ads and other targeted messages.
+
+facebook-container-about-firefox-and-mozilla = About { -brand-name-firefox } and { -brand-name-mozilla }
+
+# Variables:
+#   $mozilla (url) - link to https://www.mozilla.org/
+facebook-container-were-backed-by-mozilla-the = We’re backed by <a href="{ $mozilla }">{ -brand-name-mozilla }</a>, the not-for-profit organization that puts people over profit to give everyone more power online. We created this extension because we believe that you should have easy-to-use tools that help you manage your privacy and security.
+
+facebook-container-browse-freely-with-firefox = Browse freely with { -brand-name-firefox } today.

--- a/lib/fluent_migrations/firefox/facebookcontainer/index.py
+++ b/lib/fluent_migrations/firefox/facebookcontainer/index.py
@@ -1,0 +1,158 @@
+from __future__ import absolute_import
+import fluent.syntax.ast as FTL
+from fluent.migrate.helpers import transforms_from
+from fluent.migrate.helpers import VARIABLE_REFERENCE, TERM_REFERENCE
+from fluent.migrate import REPLACE, COPY
+
+index = "firefox/facebookcontainer/index.lang"
+
+def migrate(ctx):
+    """Migrate bedrock/firefox/templates/firefox/facebookcontainer/index.html, part {index}."""
+
+    ctx.add_transforms(
+        "firefox/facebook_container.ftl",
+        "firefox/facebook_container.ftl",
+        [
+            FTL.Message(
+                id=FTL.Identifier("facebook-container-facebook-container-for-firefox"),
+                value=REPLACE(
+                    index,
+                    "Facebook Container for Firefox | Prevent Facebook from seeing what websites you visit.",
+                    {
+                        "Facebook": TERM_REFERENCE("brand-name-facebook"),
+                        "Facebook Container": TERM_REFERENCE("brand-name-facebook-container"),
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("facebook-container-millions-of-people-around"),
+                value=REPLACE(
+                    index,
+                    "Millions of people around the world trust Firefox Web browsers on Android, iOS and desktop computers. Fast. Private. Download now!",
+                    {
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                        "Android": TERM_REFERENCE("brand-name-android"),
+                        "iOS": TERM_REFERENCE("brand-name-ios"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("facebook-container-facebook-well-contained-keep"),
+                value=REPLACE(
+                    index,
+                    "Facebook. Well contained. Keep the rest of your life to yourself.",
+                    {
+                        "Facebook": TERM_REFERENCE("brand-name-facebook"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("facebook-container-get-the-facebook-container"),
+                value=REPLACE(
+                    index,
+                    "Get the Facebook Container Extension",
+                    {
+                        "Facebook Container": TERM_REFERENCE("brand-name-facebook-container"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("facebook-container-download-firefox-and-get-the"),
+                value=REPLACE(
+                    index,
+                    "Download Firefox and get the Facebook Container Extension",
+                    {
+                        "Facebook Container": TERM_REFERENCE("brand-name-facebook-container"),
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("facebook-container-the-facebook-container-extension"),
+                value=REPLACE(
+                    index,
+                    "The Facebook Container Extension is not available on mobile devices.",
+                    {
+                        "Facebook Container": TERM_REFERENCE("brand-name-facebook-container"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("facebook-container-try-firefox-focus-the-privacy"),
+                value=REPLACE(
+                    index,
+                    "Try <strong>Firefox Focus</strong>, the privacy browser for Android and iOS.",
+                    {
+                        "Firefox Focus": TERM_REFERENCE("brand-name-firefox-focus"),
+                        "Android": TERM_REFERENCE("brand-name-android"),
+                        "iOS": TERM_REFERENCE("brand-name-ios"),
+                    }
+                )
+            ),
+        ] + transforms_from("""
+facebook-container-opt-out-on-your-terms = {COPY(index, "Opt out on your terms",)}
+""", index=index) + [
+            FTL.Message(
+                id=FTL.Identifier("facebook-container-facebook-can-track-almost"),
+                value=REPLACE(
+                    index,
+                    "Facebook can track almost all your web activity and tie it to your Facebook identity. If that’s too much for you, the <a href=\"%(fbcontainer)s\">Facebook Container extension</a> isolates your identity into a separate container tab, making it harder for Facebook to track you on the web outside of Facebook.",
+                    {
+                        "%%": "%",
+                        "%(fbcontainer)s": VARIABLE_REFERENCE("fbcontainer"),
+                        "Facebook": TERM_REFERENCE("brand-name-facebook"),
+                        "Facebook Container": TERM_REFERENCE("brand-name-facebook-container"),
+                    }
+                )
+            ),
+        ] + transforms_from("""
+facebook-container-install-and-contain = {COPY(index, "Install and contain",)}
+""", index=index) + [
+            FTL.Message(
+                id=FTL.Identifier("facebook-container-installing-the-extension-is"),
+                value=REPLACE(
+                    index,
+                    "Installing the <a href=\"%(fbcontainer)s\">extension</a> is easy and, once activated, will open Facebook in a blue tab each time you use it. Use and enjoy Facebook normally. Facebook will still be able to send you advertising and recommendations on their site, but it will be much harder for Facebook to use your activity collected <strong>off Facebook</strong> to send you ads and other targeted messages.",
+                    {
+                        "%%": "%",
+                        "%(fbcontainer)s": VARIABLE_REFERENCE("fbcontainer"),
+                        "Facebook": TERM_REFERENCE("brand-name-facebook"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("facebook-container-about-firefox-and-mozilla"),
+                value=REPLACE(
+                    index,
+                    "About Firefox and Mozilla",
+                    {
+                        "Mozilla": TERM_REFERENCE("brand-name-mozilla"),
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("facebook-container-were-backed-by-mozilla-the"),
+                value=REPLACE(
+                    index,
+                    "We’re backed by <a href=\"%(mozilla)s\">Mozilla</a>, the not-for-profit organization that puts people over profit to give everyone more power online. We created this extension because we believe that you should have easy-to-use tools that help you manage your privacy and security.",
+                    {
+                        "%%": "%",
+                        "%(mozilla)s": VARIABLE_REFERENCE("mozilla"),
+                        "Mozilla": TERM_REFERENCE("brand-name-mozilla"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("facebook-container-browse-freely-with-firefox"),
+                value=REPLACE(
+                    index,
+                    "Browse freely with Firefox today.",
+                    {
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                    }
+                )
+            ),
+        ]
+        )


### PR DESCRIPTION
## Description
- Migrates `firefox/facebookcontainer/index.lang` to `firefox/facebook_container.ftl`
- Updates template to use Fluent IDs.

## Issue / Bugzilla link
#9152

## Testing
```
./manage.py l10n_update
```