### PR TITLE
add firebird redirect [fixes 9113]

### DIFF
--- a/bedrock/firefox/redirects.py
+++ b/bedrock/firefox/redirects.py
@@ -461,7 +461,8 @@ redirectpatterns = (
     # Bug 654614 /blocklist -> addons.m.o/blocked
     redirect(r'^blocklist(/.*)?$', 'https://addons.mozilla.org/blocked/'),
 
-    redirect(r'^products/firebird$', 'firefox'),
+    redirect(r'^products/firebird/compare/?$','/firefox/browsers/compare/'),
+    redirect(r'^products/firebird/?$', 'firefox'),
     redirect(r'^products/firebird/download/$', 'firefox.new'),
     redirect(r'^products/firefox/add-engines\.html$',
              'https://addons.mozilla.org/search-engines.php'),

--- a/bedrock/firefox/redirects.py
+++ b/bedrock/firefox/redirects.py
@@ -461,7 +461,7 @@ redirectpatterns = (
     # Bug 654614 /blocklist -> addons.m.o/blocked
     redirect(r'^blocklist(/.*)?$', 'https://addons.mozilla.org/blocked/'),
 
-    redirect(r'^products/firebird/compare/?$','/firefox/browsers/compare/'),
+    redirect(r'^products/firebird/compare/?$', '/firefox/browsers/compare/'),
     redirect(r'^products/firebird/?$', 'firefox'),
     redirect(r'^products/firebird/download/$', 'firefox.new'),
     redirect(r'^products/firefox/add-engines\.html$',


### PR DESCRIPTION
## Description

Redirect links from Firebird comparison page to Firefox

## Issue / Bugzilla link

#9113

## Testing
http://localhost:8000/products/firebird/
http://localhost:8000/products/firebird/compare/
