### PR TITLE
 RTL styling issues on /firefox/browsers/ page

### DIFF
--- a/media/css/firefox/browsers-products.scss
+++ b/media/css/firefox/browsers-products.scss
@@ -549,6 +549,7 @@ $url-download-link-hover: svg-url($download-link-hover);
             right: $layout-md;
             bottom: $layout-md;
             left: calc(560px + #{$layout-md * 2});
+            z-index:0;
         }
     }
 
@@ -561,6 +562,8 @@ $url-download-link-hover: svg-url($download-link-hover);
 
 // form
 .fxa-form-cta {
+    position:relative;
+    z-index:1;
     @include text-body-xs;
     max-width: 560px;
     margin: 0 auto;

--- a/media/css/firefox/browsers-products.scss
+++ b/media/css/firefox/browsers-products.scss
@@ -540,19 +540,17 @@ $url-download-link-hover: svg-url($download-link-hover);
         max-width: 100%;
 
         &:after {
+            @include bidi((
+                (right, $layout-md, calc(560px + #{$layout-md * 2})),
+                (left, calc(560px + #{$layout-md * 2}), $layout-md),
+            ));
             content: '';
             background: url('/media/img/firefox/browsers/fxa.svg') center center no-repeat;
             background-size: contain;
             display: block;
             position: absolute;
             top: $layout-md;
-            right: $layout-md;
             bottom: $layout-md;
-            left: calc(560px + #{$layout-md * 2});
-            @include bidi((
-                (right, $layout-md, calc(560px + #{$layout-md * 2})),
-                (left, calc(560px + #{$layout-md * 2}), $layout-md),
-            ));
         }
     }
 

--- a/media/css/firefox/browsers-products.scss
+++ b/media/css/firefox/browsers-products.scss
@@ -549,7 +549,10 @@ $url-download-link-hover: svg-url($download-link-hover);
             right: $layout-md;
             bottom: $layout-md;
             left: calc(560px + #{$layout-md * 2});
-            z-index:0;
+            @include bidi((
+                (right, $layout-md, calc(560px + #{$layout-md * 2})),
+                (left, calc(560px + #{$layout-md * 2}), $layout-md),
+            ));
         }
     }
 
@@ -562,8 +565,6 @@ $url-download-link-hover: svg-url($download-link-hover);
 
 // form
 .fxa-form-cta {
-    position:relative;
-    z-index:1;
     @include text-body-xs;
     max-width: 560px;
     margin: 0 auto;


### PR DESCRIPTION
## Description
I made a small change that will fix this issue, by utilizing z-index to make sure the image is underneath the form container at all times, so the image cannot ever make the form unusable by being in front of it.

## Issue / Bugzilla link
#9110 

## Testing
http://localhost:8000/ar/firefox/browsers/