### PR TITLE
Add correct branch percentages, add custom params for protections link

### DIFF
--- a/media/js/firefox/welcome/welcome8-traffic-cop.js
+++ b/media/js/firefox/welcome/welcome8-traffic-cop.js
@@ -35,10 +35,10 @@
                 id: 'welcome8_experiment_hvt_visual',
                 cookieExpires: 0,
                 variations: {
-                    'v=text': 12.5,
-                    'v=image': 12.5,
-                    'v=animation': 12.5,
-                    'v=header-text': 12.5,
+                    'v=text': 2.5,
+                    'v=image': 2.5,
+                    'v=animation': 2.5,
+                    'v=header-text': 2.5,
                 }
             });
             cop.init();

--- a/media/js/firefox/welcome/welcome8.js
+++ b/media/js/firefox/welcome/welcome8.js
@@ -16,10 +16,26 @@
         });
     }
 
+    function handleOpenProtectionReportLink(e) {
+        e.preventDefault();
+        Mozilla.UITour.showProtectionReport();
+
+        window.dataLayer.push({
+            'event': 'in-page-interaction',
+            'eAction': 'link click',
+            'eLabel': 'See what`s blocked'
+        });
+    }
+
     Mozilla.UITour.ping(function() {
-        document.querySelectorAll('.protection-report').forEach(
+        document.querySelectorAll('.protection-report.primary-cta').forEach(
             function(button) {
                 button.addEventListener('click', handleOpenProtectionReport, false);
+            }
+        );
+        document.querySelectorAll('.protection-report:not(.primary-cta)').forEach(
+            function(button) {
+                button.addEventListener('click', handleOpenProtectionReportLink, false);
             }
         );
     });


### PR DESCRIPTION
r? @alexgibson @craigcook 

For the High Velocity Testing moments page, we have re-calculated the percentage for traffic cop to be 2.5% per branch, totalling 10%. 

I would like to separate data collection on the main CTA leading to the protections report, and the link in the body which also leads to the protections report, so edited the `eLabel` for that particular link to separate it from the button.
