### PR TITLE
Only show Firefox Lite WNP to 79.0 and above (#9119)

### DIFF
--- a/bedrock/firefox/tests/test_base.py
+++ b/bedrock/firefox/tests/test_base.py
@@ -346,7 +346,7 @@ class TestWhatsNew(TestCase):
         """Should use id locale specific template for Firefox Lite"""
         req = self.rf.get('/firefox/whatsnew/')
         req.locale = 'id'
-        self.view(req, version='63.0')
+        self.view(req, version='79.0')
         template = render_mock.call_args[0][1]
         assert template == ['firefox/whatsnew/firefox-lite.id.html']
 
@@ -544,7 +544,7 @@ class TestWhatsNewFirefoxLite(TestCase):
         """Should use firefox-lite template for Africa for en-US locale"""
         req = self.rf.get('/firefox/whatsnew/africa/')
         req.locale = 'en-US'
-        self.view(req, version='78.0')
+        self.view(req, version='79.0')
         template = render_mock.call_args[0][1]
         assert template == ['firefox/whatsnew/firefox-lite.html']
 
@@ -552,7 +552,7 @@ class TestWhatsNewFirefoxLite(TestCase):
         """Should use firefox-lite template for India for en-US locale"""
         req = self.rf.get('/firefox/whatsnew/india/')
         req.locale = 'en-US'
-        self.view(req, version='78.0')
+        self.view(req, version='79.0')
         template = render_mock.call_args[0][1]
         assert template == ['firefox/whatsnew/firefox-lite.html']
 
@@ -561,9 +561,9 @@ class TestWhatsNewFirefoxLite(TestCase):
         """Should use regular whatsnew templates for other locales"""
         req = self.rf.get('/firefox/whatsnew/india/')
         req.locale = 'de'
-        self.view(req, version='78.0')
+        self.view(req, version='79.0')
         template = render_mock.call_args[0][1]
-        assert template == ['firefox/whatsnew/whatsnew-fx78.html']
+        assert template == ['firefox/whatsnew/whatsnew-fx79.html']
 
 
 @patch('bedrock.firefox.views.l10n_utils.render', return_value=HttpResponse())

--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -479,6 +479,15 @@ def show_default_account_whatsnew(version):
     return version >= Version('60.0')
 
 
+def show_firefox_lite_whatsnew(version):
+    try:
+        version = Version(version)
+    except ValueError:
+        return False
+
+    return version >= Version('79.0')
+
+
 class FirstrunView(l10n_utils.LangFilesMixin, TemplateView):
     def get(self, *args, **kwargs):
         version = self.kwargs.get('version') or ''
@@ -608,7 +617,7 @@ class WhatsnewView(L10nTemplateView):
                     template = 'firefox/whatsnew/index.html'
             else:
                 template = 'firefox/whatsnew/index.html'
-        elif locale == 'id':
+        elif locale == 'id' and show_firefox_lite_whatsnew(version):
             template = 'firefox/whatsnew/firefox-lite.id.html'
         elif version.startswith('79.') and ftl_file_is_active('firefox/whatsnew/whatsnew-fx79'):
             template = 'firefox/whatsnew/whatsnew-fx79.html'
@@ -670,8 +679,9 @@ class WhatsNewFirefoxLiteView(WhatsnewView):
         locale = l10n_utils.get_locale(self.request)
         version = self.kwargs.get('version') or ''
         channel = detect_channel(version)
+        pre_release_channels = ['nightly', 'alpha', 'beta']
 
-        if locale == 'en-US' and channel not in ['nightly', 'alpha', 'beta']:
+        if show_firefox_lite_whatsnew(version) and locale == 'en-US' and channel not in pre_release_channels:
             # return a list to conform with original intention
             template = ['firefox/whatsnew/firefox-lite.html']
         else:


### PR DESCRIPTION
## Description
- Restrict new Firefox Lite /whatsnew page to 79.0 and above.

## Issue / Bugzilla link
#9119

## Testing
Firefox Lite template:
- http://localhost:8000/id/firefox/79.0/whatsnew/all/
- http://localhost:8000/en-US/firefox/79.0/whatsnew/africa/
- http://localhost:8000/en-US/firefox/79.0/whatsnew/india/

Standard /whatsnew templates:
- http://localhost:8000/id/firefox/78.0/whatsnew/all/
- http://localhost:8000/en-US/firefox/78.0/whatsnew/africa/
- http://localhost:8000/en-US/firefox/78.0/whatsnew/india/