### PR TITLE
Use brand name in missing shared /features string (#9187) [skip l10n]

### DIFF
--- a/l10n/en/firefox/features/shared.ftl
+++ b/l10n/en/firefox/features/shared.ftl
@@ -5,7 +5,7 @@
 ### URL: https://www-dev.allizom.org/firefox/features/
 
 features-shared-a-better-internet-experience = A better internet experience
-features-shared-more-firefox-features = More Firefox browser features
+features-shared-more-firefox-features = More { -brand-name-firefox } browser features
 
 features-shared-browse-faster = Browse faster
 features-shared-your-favorite-extensions = Your favorite extensions


### PR DESCRIPTION
## Description
L10n PR: https://github.com/mozilla-l10n/www-l10n/pull/82

## Issue / Bugzilla link
https://github.com/mozilla/bedrock/issues/9187