### PR TITLE
Add switch to Firefox Lite /whatnsew page (Fixes #9189)

### DIFF
--- a/bedrock/firefox/tests/test_base.py
+++ b/bedrock/firefox/tests/test_base.py
@@ -386,6 +386,7 @@ class TestWhatsNewFirefoxLite(TestCase):
         self.view = fx_views.WhatsNewFirefoxLiteView.as_view()
         self.rf = RequestFactory(HTTP_USER_AGENT='Firefox')
 
+    @patch.dict(os.environ, SWITCH_FIREFOX_LITE_WHATSNEW='True')
     def test_fx_lite_africa(self, render_mock):
         """Should use firefox-lite template for Africa for en-US locale"""
         req = self.rf.get('/firefox/whatsnew/africa/')
@@ -394,6 +395,7 @@ class TestWhatsNewFirefoxLite(TestCase):
         template = render_mock.call_args[0][1]
         assert template == ['firefox/whatsnew/firefox-lite.html']
 
+    @patch.dict(os.environ, SWITCH_FIREFOX_LITE_WHATSNEW='True')
     def test_fx_lite_india(self, render_mock):
         """Should use firefox-lite template for India for en-US locale"""
         req = self.rf.get('/firefox/whatsnew/india/')

--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -485,6 +485,9 @@ def show_firefox_lite_whatsnew(version):
     except ValueError:
         return False
 
+    if not switch('firefox-lite-whatsnew'):
+        return False
+
     return version >= Version('79.0')
 
 

--- a/tests/functional/firefox/whatsnew/test_whatsnew_africa.py
+++ b/tests/functional/firefox/whatsnew/test_whatsnew_africa.py
@@ -7,6 +7,7 @@ import pytest
 from pages.firefox.whatsnew.whatsnew_africa import FirefoxWhatsNewAfricaPage
 
 
+@pytest.mark.skip(reason='https://github.com/mozilla/bedrock/issues/9189')
 @pytest.mark.skip_if_not_firefox(reason='Whatsnew pages are shown to Firefox only.')
 @pytest.mark.nondestructive
 def test_africa_qr_code_displayed(base_url, selenium):

--- a/tests/functional/firefox/whatsnew/test_whatsnew_id.py
+++ b/tests/functional/firefox/whatsnew/test_whatsnew_id.py
@@ -7,6 +7,7 @@ import pytest
 from pages.firefox.whatsnew.whatsnew_id import FirefoxWhatsNewIDPage
 
 
+@pytest.mark.skip(reason='https://github.com/mozilla/bedrock/issues/9189')
 @pytest.mark.skip_if_not_firefox(reason='Whatsnew pages are shown to Firefox only.')
 @pytest.mark.nondestructive
 def test_firefox_lite_qr_code(base_url, selenium):

--- a/tests/functional/firefox/whatsnew/test_whatsnew_india.py
+++ b/tests/functional/firefox/whatsnew/test_whatsnew_india.py
@@ -7,6 +7,7 @@ import pytest
 from pages.firefox.whatsnew.whatsnew_india import FirefoxWhatsNewIndiaPage
 
 
+@pytest.mark.skip(reason='https://github.com/mozilla/bedrock/issues/9189')
 @pytest.mark.skip_if_not_firefox(reason='Whatsnew pages are shown to Firefox only.')
 @pytest.mark.nondestructive
 def test_india_qr_code_displayed(base_url, selenium):


### PR DESCRIPTION
## Description
Puts updated Firefox Lite /whatsnew page behind a switch.

http://localhost:8000/en-US/firefox/79.0/whatsnew/africa/
http://localhost:8000/en-US/firefox/79.0/whatsnew/india/
http://localhost:8000/id/firefox/79.0/whatsnew/all/

## Issue / Bugzilla link
#9189

## Testing
- [x] Firefox Lite templates are visible at the above URLs when `Dev=True` in your `.env`.
- [x] Standard /whatsnew templates are shown at same URLs when `Dev=False`.