### PR TITLE
Add note to convert QA docs

### DIFF
--- a/docs/abtest.rst
+++ b/docs/abtest.rst
@@ -64,6 +64,11 @@ During review, the engineer will compare the following to the experiment plan:
 #. The distribution percentages are configured.
 #. The target URLs are configured.
 
+.. Note::
+
+    If you select more than one audience in convert it is joined in an OR fashion, not AND.
+
+
 Once the engineer is satisfied, the engineer (or someone else with write privileges) will:
 
 #. Add ``https://www.mozilla.org/*`` to the list of urls the experiment can run on.


### PR DESCRIPTION
## Description

Adds a note to the convert QA docs. [Reference](https://support.convert.com/hc/en-us/articles/115000009891-Defining-Audiences-for-your-Experience).