### PR TITLE
Update bug filing link for commit access.

### DIFF
--- a/bedrock/mozorg/templates/mozorg/about/governance/policies/commit.html
+++ b/bedrock/mozorg/templates/mozorg/about/governance/policies/commit.html
@@ -29,11 +29,11 @@
   <li>{% trans policy=url('mozorg.about.governance.policies.commit.access-policy') %}
     Read the <a href="{{ policy }}">Commit Access Policy</a>, and decide which level of access you need to apply for.
   {% endtrans %}</li>
-  <li>{% trans bug='https://bugzilla.mozilla.org/enter_bug.cgi?product=mozilla.org&component=Repository%20Account%20Requests' %}
+  <li>{% trans bug='https://mzl.la/2WIVD0v' %}
   <a href="{{ bug }}">File a bug</a> in the "Repository Account Requests" component.
   {% endtrans %}
     <ul>
-      <li>{{ _('Make the bug title of the form "Commit Access (Level X) for Fred Bloggs"') }}</li>
+      <li>{{ _('Make the bug title of the form "Commit Access (Level X) for Fred Bloggs fred@bloggs.com"') }}</li>
       <li>{{ _('Say what email address you want to use as your login name') }}</li>
       <li>{{ _('If you need access to particular trees on the exceptions list, list them') }}</li>
     </ul>


### PR DESCRIPTION
## Description

Per https://groups.google.com/forum/#!topic/mozilla.dev.platform/c57FBhCsHI0, we're trying to get commit access bugs to follow a standard template. The new link supports that.