### PR TITLE
Update traffic-cop lib (Fixes #9209)

### DIFF
--- a/media/js/libs/mozilla-traffic-cop.js
+++ b/media/js/libs/mozilla-traffic-cop.js
@@ -3,8 +3,8 @@
 * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 // create namespace
-if (typeof window.Mozilla === 'undefined') {
-    window.Mozilla = {};
+if (typeof Mozilla === 'undefined') {
+    var Mozilla = {};
 }
 
 /**
@@ -79,9 +79,13 @@ Mozilla.TrafficCop = function(config) {
     // calculate and store total percentage of variations
     for (var v in this.variations) {
         if (this.variations.hasOwnProperty(v) && typeof this.variations[v] === 'number') {
-            this.totalPercentage += this.variations[v];
+            // multiply by 100 to allow for percentages to the hundredth
+            // (and avoid floating point math errors)
+            this.totalPercentage += (this.variations[v] * 100);
         }
     }
+
+    this.totalPercentage = this.totalPercentage / 100;
 
     return this;
 };
@@ -95,7 +99,6 @@ Mozilla.TrafficCop.referrerCookieName = 'mozilla-traffic-cop-original-referrer';
  * currently viewing a variation, and (possibly) redirects to a variation
  */
 Mozilla.TrafficCop.prototype.init = function() {
-    'use strict';
     // respect the DNT
     if (typeof Mozilla.dntEnabled === 'function' && Mozilla.dntEnabled()) {
         return;
@@ -126,7 +129,6 @@ Mozilla.TrafficCop.prototype.init = function() {
  * developer.
  */
 Mozilla.TrafficCop.prototype.initiateCustomCallbackRoutine = function() {
-    'use strict';
     // set a cookie to remember the chosen variation
     Mozilla.Cookies.setItem(this.id, this.chosenVariation || Mozilla.TrafficCop.noVariationCookieValue, this.cookieExpiresDate);
 
@@ -139,7 +141,6 @@ Mozilla.TrafficCop.prototype.initiateCustomCallbackRoutine = function() {
  * redirected. May result in no redirect.
  */
 Mozilla.TrafficCop.prototype.initiateRedirectRoutine = function() {
-    'use strict';
     var redirectUrl;
 
     // make sure current page doesn't match a variation
@@ -182,7 +183,6 @@ Mozilla.TrafficCop.prototype.initiateRedirectRoutine = function() {
  * of users.
  */
 Mozilla.TrafficCop.prototype.verifyConfig = function() {
-    'use strict';
     if (!this.id || typeof this.id !== 'string') {
         return false;
     }
@@ -205,7 +205,6 @@ Mozilla.TrafficCop.prototype.verifyConfig = function() {
  * 'date' param used only for unit testing.
  */
 Mozilla.TrafficCop.generateCookieExpiresDate = function(cookieExpires, date) {
-    'use strict';
     // default to null, meaning a session-length cookie
     var d = null;
 
@@ -221,7 +220,6 @@ Mozilla.TrafficCop.generateCookieExpiresDate = function(cookieExpires, date) {
  * Checks to see if user is currently viewing a variation.
  */
 Mozilla.TrafficCop.isRedirectVariation = function(variations, queryString) {
-    'use strict';
     var isVariation = false;
     queryString = queryString || window.location.search;
 
@@ -240,7 +238,6 @@ Mozilla.TrafficCop.isRedirectVariation = function(variations, queryString) {
  * Returns the variation chosen for the current user/experiment.
  */
 Mozilla.TrafficCop.chooseVariation = function(id, variations, totalPercentage) {
-    'use strict';
     var rando;
     var runningTotal;
     var choice = Mozilla.TrafficCop.noVariationCookieValue;
@@ -252,8 +249,9 @@ Mozilla.TrafficCop.chooseVariation = function(id, variations, totalPercentage) {
     // no cookie exists, or cookie has invalid variation, so choose a shiny new
     // variation
     } else {
-        // conjure a random number between 1 and 100 (inclusive)
-        rando = Math.floor(Math.random() * 100) + 1;
+        // conjure a random float between 1 and 100 (inclusive)
+        rando = Math.floor(Math.random() * 10000) + 1;
+        rando = rando/100;
 
         // make sure random number falls in the distribution range
         if (rando <= totalPercentage) {
@@ -282,7 +280,6 @@ Mozilla.TrafficCop.chooseVariation = function(id, variations, totalPercentage) {
  * which (if any) variation should be matched.
  */
 Mozilla.TrafficCop.generateRedirectUrl = function(chosenVariation, url) {
-    'use strict';
     var hash;
     var redirect;
     var urlParts;
@@ -311,12 +308,10 @@ Mozilla.TrafficCop.generateRedirectUrl = function(chosenVariation, url) {
 };
 
 Mozilla.TrafficCop.performRedirect = function(redirectURL) {
-    'use strict';
     window.location.href = redirectURL;
 };
 
 Mozilla.TrafficCop.setReferrerCookie = function(expirationDate, referrer) {
-    'use strict';
     // in order of precedence, referrer should be:
     // 1. custom value passed in via unit test
     // 2. value of document.referrer
@@ -327,12 +322,10 @@ Mozilla.TrafficCop.setReferrerCookie = function(expirationDate, referrer) {
 };
 
 Mozilla.TrafficCop.clearReferrerCookie = function() {
-    'use strict';
     Mozilla.Cookies.removeItem(Mozilla.TrafficCop.referrerCookieName);
 };
 
 // wrapper around document.referrer for better unit testing
 Mozilla.TrafficCop.getDocumentReferrer = function() {
-    'use strict';
     return document.referrer;
 };


### PR DESCRIPTION
## Description
Updates bedrock's Traffic Cop lib to the latest version from https://github.com/mozilla/trafficcop

## Issue / Bugzilla link
#9209

## Testing
- [ ] Visit http://localhost:8000/en-US/firefox/welcome/8/ and verify the experiment is still serving variations as expected.