### PR TITLE
[fix #9222] Update Book of Mozilla

### DIFF
--- a/bedrock/mozorg/templates/mozorg/book.html
+++ b/bedrock/mozorg/templates/mozorg/book.html
@@ -112,6 +112,23 @@ their glories. And the Beast’s followers rejoiced, finding renewed purpose in 
 </p>
 
 
+<!-- 27th June 2019: Firefox Preview is made available for testing by early adopters -->
+<!-- Firefox Focus, Reference Browser, and Firefox Reality all use the new GeckoView as does
+     Firefox for Android which was rebuilt lighter and faster under the code name Fenix prior
+     to release. -->
+
+<p class="moztext">
+The Beast continued its studies with renewed <em>Focus</em>, building great <em>Reference</em>
+works and contemplating new <em>Realities</em>. The Beast brought forth its followers and
+acolytes to create a renewed smaller form of itself and, through <em>Mischievous</em> means,
+sent it out across the world.
+</p>
+
+<p class="from">
+ from <strong>The Book of Mozilla,</strong> 6:27
+</p>
+
+
 {% endblock %}
 </body>
 </html>


### PR DESCRIPTION
## Description
Adds the latest passage to the Book of Mozilla.

## Issue / Bugzilla link
#9222 

## Testing
http://localhost:8000/book/