### PR TITLE
Adjust /fraud-report/ notification location

### DIFF
--- a/bedrock/legal/templates/legal/fraud-report.html
+++ b/bedrock/legal/templates/legal/fraud-report.html
@@ -27,6 +27,20 @@
 {% endblock %}
 
 {% block article %}
+
+{% if form_submitted %}
+<aside class="mzp-c-notification-bar mzp-t-success">
+  <p><strong>{{ _('Your report has been sent.') }}</strong></p>
+  <p>{{ _('Thank you for your help. It’s our community that makes us great.') }}</p>
+</aside>
+{% endif %}
+
+{% if form_error %}
+<aside class="mzp-c-notification-bar mzp-t-error">
+  <p><strong>{{ _('An error has occurred with your submission. Please review your information and try again.') }}</strong></p>
+</aside>
+{% endif %}
+
 {# L10n: The line break below is for visual formatting only #}
 <h1 class="mzp-c-article-title">{{_('Protect the Fox<br> (and More!)')}}</h1>
 <h2>{{ _('Help us safeguard Mozilla’s trademarks by reporting misuse.') }}</h2>
@@ -91,11 +105,6 @@
   {% if not form_submitted or (form_submitted and form_error) %}
   <h2>{{ _('Fraud Report') }}</h2>
 
-  {% if form_error %}
-  <aside class="mzp-c-notification-bar mzp-t-error">
-    <p><strong>{{ _('An error has occurred with your submission. Please review your information and try again.') }}</strong></p>
-  </aside>
-  {% endif %}
   <form action="{{ url('legal.fraud-report') }}" method="post" name="reportForm" id="reportForm" enctype="multipart/form-data">
 
     <input type="hidden" name="csrfmiddlewaretoken" value="{{ csrf_token }}">
@@ -161,11 +170,6 @@
     </div>
     <button type="submit" name="submit_form" class="mzp-c-button">{{ _('Send Report') }}</button>
   </form>
-  {% else %}
-  <aside class="mzp-c-notification-bar mzp-t-success">
-    <p><strong>{{ _('Your report has been sent.') }}</strong></p>
-    <p>{{ _('Thank you for your help. It’s our community that makes us great.') }}</p>
-  </aside>
 {% endif %}
 </section>
 

--- a/bedrock/legal/templates/legal/fraud-report.html
+++ b/bedrock/legal/templates/legal/fraud-report.html
@@ -88,9 +88,9 @@
 </section>
 
 <section>
+  {% if not form_submitted or (form_submitted and form_error) %}
   <h2>{{ _('Fraud Report') }}</h2>
 
-  {% if not form_submitted or (form_submitted and form_error) %}
   {% if form_error %}
   <aside class="mzp-c-notification-bar mzp-t-error">
     <p><strong>{{ _('An error has occurred with your submission. Please review your information and try again.') }}</strong></p>

--- a/media/css/legal/legal.scss
+++ b/media/css/legal/legal.scss
@@ -67,8 +67,8 @@ $image-path: '/media/protocol/img';
 /* -------------------------------------------------------------------------- */
 // Form
 
-.mzp-c-notification-bar {
-    margin-bottom: $spacing-md;
+#outer-wrapper .mzp-c-notification-bar {
+    margin-bottom: $spacing-xl;
 }
 
 .super-priority-field {

--- a/media/css/protocol/protocol.scss
+++ b/media/css/protocol/protocol.scss
@@ -18,7 +18,7 @@ $image-path: '/media/protocol/img';
 // Already fixed upstream in https://github.com/mozilla/protocol/commit/548e7ce3070372e7fe92f268fb3847e911d5038e
 @media #{$mq-sm} {
     #outer-wrapper .mzp-c-notification-bar {
-        margin: $layout-xs auto $spacing-xl;
+        margin: $layout-xs auto 0;
     }
 }
 

--- a/media/css/protocol/protocol.scss
+++ b/media/css/protocol/protocol.scss
@@ -18,7 +18,7 @@ $image-path: '/media/protocol/img';
 // Already fixed upstream in https://github.com/mozilla/protocol/commit/548e7ce3070372e7fe92f268fb3847e911d5038e
 @media #{$mq-sm} {
     #outer-wrapper .mzp-c-notification-bar {
-        margin: $layout-xs auto 0;
+        margin: $layout-xs auto $spacing-xl;
     }
 }
 


### PR DESCRIPTION
## Description
I moved both the Success and Error notifications to render at the top instead of bottom, and made the h2 'Fraud Report' no longer render upon successful form submission since it would then have nothing under it.

## Issue / Bugzilla link
#9177

## Testing
For Success notification, visit: http://localhost:8000/en-US/about/legal/fraud-report/?submitted=True

For Error notification, visit: http://localhost:8000/en-US/about/legal/fraud-report/
And enter in an invalid url before submitting