### PR TITLE
Fix issue /firefox/mobile-promo/ page shows mixed content in other languages. #9147

### DIFF
--- a/bedrock/firefox/templates/firefox/messaging-experiment/control.html
+++ b/bedrock/firefox/templates/firefox/messaging-experiment/control.html
@@ -5,8 +5,6 @@
   {% from "macros.html" import google_play_button, send_to_device with context %}
   {% from "macros-protocol.html" import hero with context %}
   
-  {% add_lang_files "firefox/welcome/page4" "firefox/sendto" %}
-  
   {% extends "firefox/messaging-experiment/base.html" %}
   
   {% block page_title %}{{ _('Download the Firefox Browser on your Mobile for iOS and Android') }}{% endblock %}


### PR DESCRIPTION
## Description
Fixing the mixed languages bug

## Issue / Bugzilla link
https://github.com/mozilla/bedrock/issues/9147
