### PR TITLE
Make GA event fire before opening the protection report

### DIFF
--- a/media/js/firefox/welcome/welcome8-traffic-cop.js
+++ b/media/js/firefox/welcome/welcome8-traffic-cop.js
@@ -35,10 +35,10 @@
                 id: 'welcome8_experiment_hvt_visual',
                 cookieExpires: 0,
                 variations: {
-                    'v=text': 2.5,
-                    'v=image': 2.5,
-                    'v=animation': 2.5,
-                    'v=header-text': 2.5,
+                    'v=text': 3,
+                    'v=image': 3,
+                    'v=animation': 3,
+                    'v=header-text': 3,
                 }
             });
             cop.init();

--- a/media/js/firefox/welcome/welcome8.js
+++ b/media/js/firefox/welcome/welcome8.js
@@ -7,24 +7,22 @@
 
     function handleOpenProtectionReport(e) {
         e.preventDefault();
-        Mozilla.UITour.showProtectionReport();
-
         window.dataLayer.push({
             'event': 'in-page-interaction',
             'eAction': 'link click',
             'eLabel': 'View your protection report'
         });
+        Mozilla.UITour.showProtectionReport();
     }
 
     function handleOpenProtectionReportLink(e) {
         e.preventDefault();
-        Mozilla.UITour.showProtectionReport();
-
         window.dataLayer.push({
             'event': 'in-page-interaction',
             'eAction': 'link click',
             'eLabel': 'See what`s blocked'
         });
+        Mozilla.UITour.showProtectionReport();
     }
 
     Mozilla.UITour.ping(function() {


### PR DESCRIPTION
r? @craigcook 

It seems we are not getting an expected amoung of "link click" events, and the event may not be firing because the page navigates away to the protection report before the event is being added to the data layer. This makes the event fire before the navigation. 

note, this is a bug in all places where protection report is being opened, and will need to be updated in those places in the future.