### PR TITLE
[fix #9235] Remove FB Container from zh-CN on /welcome/8/

### DIFF
--- a/bedrock/firefox/templates/firefox/welcome/page8.html
+++ b/bedrock/firefox/templates/firefox/welcome/page8.html
@@ -172,7 +172,7 @@
       </div>
     </div>
 
-    {% if LANG != 'zh-TW' %}
+    {% if LANG != 'zh-CN' %}
       <div class="c-picto-block t-adjacent-image">
         <div class="c-picto-block-image">
           <img src="{{ static('img/logos/fbcontainer/logo-fbcontainer.svg') }}" width="48px" alt="">


### PR DESCRIPTION
## Description
Template was hiding it from zh-TW but that should be zh-CN

## Issue / Bugzilla link
#9235 

## Testing
http://localhost:8000/zh-CN/firefox/welcome/8/