### PR TITLE
[fix #9237] Fix tracking on protection report clicks

### DIFF
--- a/media/js/firefox/new/desktop/download.js
+++ b/media/js/firefox/new/desktop/download.js
@@ -183,13 +183,14 @@
 
     function handleOpenProtectionReport(e) {
         e.preventDefault();
-        Mozilla.UITour.showProtectionReport();
 
         window.dataLayer.push({
             'event': 'in-page-interaction',
             'eAction': 'link click',
             'eLabel': 'See your protection report'
         });
+
+        Mozilla.UITour.showProtectionReport();
     }
 
     if (client.isFirefoxDesktop) {

--- a/media/js/firefox/privacy/messaging-experiment.js
+++ b/media/js/firefox/privacy/messaging-experiment.js
@@ -9,13 +9,14 @@
 
     function handleOpenProtectionReport(e) {
         e.preventDefault();
-        Mozilla.UITour.showProtectionReport();
 
         window.dataLayer.push({
             'event': 'in-page-interaction',
             'eAction': 'link click',
             'eLabel': 'Check Out Your Protections'
         });
+
+        Mozilla.UITour.showProtectionReport();
     }
 
     if (client.isFirefoxDesktop) {

--- a/media/js/firefox/privacy/products.js
+++ b/media/js/firefox/privacy/products.js
@@ -9,13 +9,14 @@
 
     function handleOpenProtectionReport(e) {
         e.preventDefault();
-        Mozilla.UITour.showProtectionReport();
 
         window.dataLayer.push({
             'event': 'in-page-interaction',
             'eAction': 'link click',
             'eLabel': 'See what Firefox has blocked for you'
         });
+
+        Mozilla.UITour.showProtectionReport();
     }
 
     if (client.isFirefoxDesktop) {

--- a/media/js/firefox/whatsnew/whatsnew-76.js
+++ b/media/js/firefox/whatsnew/whatsnew-76.js
@@ -7,13 +7,14 @@
 
     function handleOpenProtectionReport(e) {
         e.preventDefault();
-        Mozilla.UITour.showProtectionReport();
 
         window.dataLayer.push({
             'event': 'in-page-interaction',
             'eAction': 'link click',
             'eLabel': 'View your protection report'
         });
+
+        Mozilla.UITour.showProtectionReport();
     }
 
     Mozilla.UITour.ping(function() {

--- a/media/js/firefox/whatsnew/whatsnew-79.js
+++ b/media/js/firefox/whatsnew/whatsnew-79.js
@@ -15,13 +15,14 @@
 
     function handleOpenProtectionReport(e) {
         e.preventDefault();
-        Mozilla.UITour.showProtectionReport();
 
         window.dataLayer.push({
             'event': 'in-page-interaction',
             'eAction': 'link click',
             'eLabel': 'See your Report'
         });
+
+        Mozilla.UITour.showProtectionReport();
     }
 
     if (client.isFirefoxDesktop) {


### PR DESCRIPTION
## Description
We've been launching about:protections before the dataLayer.push, so most of the time the dataLayer never updates and we've failed to count those clicks. This just reorders events so dataLater.push fires first.

## Issue / Bugzilla link
#9237 

## Testing
http://localhost:8000/firefox/78.0/whatsnew/
http://localhost:8000/firefox/79.0/whatsnew/
http://localhost:8000/firefox/privacy/products/
http://localhost:8000/firefox/new/?v=b
http://localhost:8000/firefox/privacy-tools/