### PR TITLE
add data-cta-text params

### DIFF
--- a/bedrock/firefox/templates/firefox/welcome/page8.html
+++ b/bedrock/firefox/templates/firefox/welcome/page8.html
@@ -64,7 +64,7 @@
         heading_level=1
       ) %}
       <p class="primary-cta protection-report">
-        <a href="https://support.mozilla.org/kb/enhanced-tracking-protection-firefox-desktop/?utm_source={{ _utm_source }}&utm_medium=referral&utm_campaign={{ _utm_campaign }}&utm_content={{_utm_content}}" class="mzp-c-button mzp-t-product" id="button" rel="external">
+        <a href="https://support.mozilla.org/kb/enhanced-tracking-protection-firefox-desktop/?utm_source={{ _utm_source }}&utm_medium=referral&utm_campaign={{ _utm_campaign }}&utm_content={{_utm_content}}" class="mzp-c-button mzp-t-product" id="button" rel="external" data-cta-text="View your report - no JS" data-cta-type="button">
           {{ ftl('welcome-page8-view-your-protection-report') }}
         </a>
       </p>
@@ -91,7 +91,7 @@
             </div>
           </div>
         <p class="primary-cta protection-report">
-          <a href="https://support.mozilla.org/kb/enhanced-tracking-protection-firefox-desktop/?utm_source={{ _utm_source }}&utm_medium=referral&utm_campaign={{ _utm_campaign }}&utm_content={{_utm_content}}" class="mzp-c-button mzp-t-product" id="button" rel="external">
+          <a href="https://support.mozilla.org/kb/enhanced-tracking-protection-firefox-desktop/?utm_source={{ _utm_source }}&utm_medium=referral&utm_campaign={{ _utm_campaign }}&utm_content={{_utm_content}}" class="mzp-c-button mzp-t-product" id="button" rel="external" data-cta-text="View your report - no JS" data-cta-type="button">
             {{ ftl('welcome-page8-view-your-protection-report') }}
           </a>
         </p>
@@ -119,7 +119,7 @@
           </div>
 
         <p class="primary-cta protection-report">
-          <a href="https://support.mozilla.org/kb/enhanced-tracking-protection-firefox-desktop/?utm_source={{ _utm_source }}&utm_medium=referral&utm_campaign={{ _utm_campaign }}&utm_content={{_utm_content}}" class="mzp-c-button mzp-t-product" id="button" rel="external">
+          <a href="https://support.mozilla.org/kb/enhanced-tracking-protection-firefox-desktop/?utm_source={{ _utm_source }}&utm_medium=referral&utm_campaign={{ _utm_campaign }}&utm_content={{_utm_content}}" class="mzp-c-button mzp-t-product" id="button" rel="external" data-cta-text="View your report - no JS" data-cta-type="button">
             {{ ftl('welcome-page8-view-your-protection-report') }}
           </a>
         </p>
@@ -135,7 +135,7 @@
         heading_level=1
       ) %}
       <p class="primary-cta protection-report">
-        <a href="https://support.mozilla.org/kb/enhanced-tracking-protection-firefox-desktop/?utm_source={{ _utm_source }}&utm_medium=referral&utm_campaign={{ _utm_campaign }}&utm_content={{_utm_content}}" class="mzp-c-button mzp-t-product" id="button" rel="external">
+        <a href="https://support.mozilla.org/kb/enhanced-tracking-protection-firefox-desktop/?utm_source={{ _utm_source }}&utm_medium=referral&utm_campaign={{ _utm_campaign }}&utm_content={{_utm_content}}" class="mzp-c-button mzp-t-product" id="button" rel="external" data-cta-text="View your report - no JS" data-cta-type="button">
           {{ ftl('welcome-page8-view-your-protection-report') }}
         </a>
       </p>
@@ -166,7 +166,7 @@
       <h3 class="c-picto-block-title">{{ ftl('welcome-page8-firefox-monitor') }}</h3>
       <div class="c-picto-block-body">
         <p>{{ ftl('welcome-page8-see-what-youve-been') }}</p>
-        <a id="monitor-link" href="https://monitor.firefox.com/?utm_source={{ _utm_source }}&utm_medium=referral&utm_campaign={{ _utm_campaign }}&utm_content={{_utm_content}}" >
+        <a id="monitor-link" href="https://monitor.firefox.com/?utm_source={{ _utm_source }}&utm_medium=referral&utm_campaign={{ _utm_campaign }}&utm_content={{_utm_content}}" data-cta-text="go to monitor" data-cta-type="button">
           <strong>{{ ftl('welcome-page8-go-to-monitor') }}</strong>
         </a>
       </div>
@@ -180,7 +180,7 @@
         <h3 class="c-picto-block-title">{{ ftl('welcome-page8-facebook-container') }}</h3>
         <div class="c-picto-block-body">
           <p>{{ ftl('welcome-page8-stay-connected') }}</p>
-          <a id="fb-container-link" href="https://addons.mozilla.org/firefox/addon/facebook-container/?src=mozilla.org-welcome-8-hvt&utm_source={{ _utm_source }}&utm_medium=referral&utm_campaign={{ _utm_campaign }}&utm_content={{_utm_content}}" >
+          <a id="fb-container-link" href="https://addons.mozilla.org/firefox/addon/facebook-container/?src=mozilla.org-welcome-8-hvt&utm_source={{ _utm_source }}&utm_medium=referral&utm_campaign={{ _utm_campaign }}&utm_content={{_utm_content}}"data-cta-text="go to fb container" data-cta-type="button" >
             <strong>{{ ftl('welcome-page8-add-facebook-container') }}</strong>
           </a>
         </div>

--- a/bedrock/firefox/templates/firefox/welcome/page8.html
+++ b/bedrock/firefox/templates/firefox/welcome/page8.html
@@ -64,7 +64,7 @@
         heading_level=1
       ) %}
       <p class="primary-cta protection-report">
-        <a href="https://support.mozilla.org/kb/enhanced-tracking-protection-firefox-desktop/?utm_source={{ _utm_source }}&utm_medium=referral&utm_campaign={{ _utm_campaign }}&utm_content={{_utm_content}}" class="mzp-c-button mzp-t-product" id="button" rel="external" data-cta-text="View your report - no JS" data-cta-type="button">
+        <a href="https://support.mozilla.org/kb/enhanced-tracking-protection-firefox-desktop/?utm_source={{ _utm_source }}&utm_medium=referral&utm_campaign={{ _utm_campaign }}&utm_content={{_utm_content}}" class="mzp-c-button mzp-t-product" id="button" rel="external" data-cta-position="primary" data-cta-text="View your report" data-cta-type="button">
           {{ ftl('welcome-page8-view-your-protection-report') }}
         </a>
       </p>
@@ -91,7 +91,7 @@
             </div>
           </div>
         <p class="primary-cta protection-report">
-          <a href="https://support.mozilla.org/kb/enhanced-tracking-protection-firefox-desktop/?utm_source={{ _utm_source }}&utm_medium=referral&utm_campaign={{ _utm_campaign }}&utm_content={{_utm_content}}" class="mzp-c-button mzp-t-product" id="button" rel="external" data-cta-text="View your report - no JS" data-cta-type="button">
+          <a href="https://support.mozilla.org/kb/enhanced-tracking-protection-firefox-desktop/?utm_source={{ _utm_source }}&utm_medium=referral&utm_campaign={{ _utm_campaign }}&utm_content={{_utm_content}}" class="mzp-c-button mzp-t-product" id="button" rel="external" data-cta-position="primary" data-cta-text="View your report" data-cta-type="button">
             {{ ftl('welcome-page8-view-your-protection-report') }}
           </a>
         </p>
@@ -119,7 +119,7 @@
           </div>
 
         <p class="primary-cta protection-report">
-          <a href="https://support.mozilla.org/kb/enhanced-tracking-protection-firefox-desktop/?utm_source={{ _utm_source }}&utm_medium=referral&utm_campaign={{ _utm_campaign }}&utm_content={{_utm_content}}" class="mzp-c-button mzp-t-product" id="button" rel="external" data-cta-text="View your report - no JS" data-cta-type="button">
+          <a href="https://support.mozilla.org/kb/enhanced-tracking-protection-firefox-desktop/?utm_source={{ _utm_source }}&utm_medium=referral&utm_campaign={{ _utm_campaign }}&utm_content={{_utm_content}}" class="mzp-c-button mzp-t-product" id="button" rel="external" data-cta-position="primary" data-cta-text="View your report" data-cta-type="button">
             {{ ftl('welcome-page8-view-your-protection-report') }}
           </a>
         </p>
@@ -135,7 +135,7 @@
         heading_level=1
       ) %}
       <p class="primary-cta protection-report">
-        <a href="https://support.mozilla.org/kb/enhanced-tracking-protection-firefox-desktop/?utm_source={{ _utm_source }}&utm_medium=referral&utm_campaign={{ _utm_campaign }}&utm_content={{_utm_content}}" class="mzp-c-button mzp-t-product" id="button" rel="external" data-cta-text="View your report - no JS" data-cta-type="button">
+        <a href="https://support.mozilla.org/kb/enhanced-tracking-protection-firefox-desktop/?utm_source={{ _utm_source }}&utm_medium=referral&utm_campaign={{ _utm_campaign }}&utm_content={{_utm_content}}" class="mzp-c-button mzp-t-product" id="button" rel="external" data-cta-position="primary" data-cta-text="View your report" data-cta-type="button">
           {{ ftl('welcome-page8-view-your-protection-report') }}
         </a>
       </p>
@@ -153,7 +153,7 @@
       <h3 class="c-picto-block-title">{{ ftl('welcome-page8-enhanced-tracking-protection') }}</h3>
       <div class="c-picto-block-body">
         <p>{{ ftl('welcome-page8-automatically-block-sites') }}</p>
-        <a class="protection-report" href="https://support.mozilla.org/kb/enhanced-tracking-protection-firefox-desktop/?utm_source={{ _utm_source }}&utm_medium=referral&utm_campaign={{ _utm_campaign }}&utm_content={{_utm_content}}" data-cta-text="See what’s blocked" data-cta-type="button">
+        <a class="protection-report" href="https://support.mozilla.org/kb/enhanced-tracking-protection-firefox-desktop/?utm_source={{ _utm_source }}&utm_medium=referral&utm_campaign={{ _utm_campaign }}&utm_content={{_utm_content}}" data-cta-position="secondary" data-cta-text="See what’s blocked" data-cta-type="button">
           <strong>{{ ftl('welcome-page8-see-whats-blocked') }}</strong>
         </a>
       </div>


### PR DESCRIPTION
links below the fold and the main CTA (when JS is not enabled) are lacking data-cta-text params - this fixes that.
Luckily we did included UTM params and so have a decent record of click throughs on below-the-fold links.
r? @craigcook 

~This may not need to be merged, but adding it awaiting on the teams decision.~ 
Team has decided this is good to go. please take note of the timestamp when this is pushed to production
