### PR TITLE
Test language switcher on /firefox instead

### DIFF
--- a/tests/functional/test_l10n.py
+++ b/tests/functional/test_l10n.py
@@ -6,12 +6,12 @@ import random
 
 import pytest
 
-from pages.firefox.new.download import DownloadPage
+from pages.firefox.home import FirefoxHomePage
 
 
 @pytest.mark.nondestructive
 def test_change_language(base_url, selenium):
-    page = DownloadPage(selenium, base_url, params='').open()
+    page = FirefoxHomePage(selenium, base_url, params='').open()
     initial = page.footer.language
     # avoid selecting the same language or locales that have homepage redirects
     excluded = [initial, 'ja', 'ja-JP-mac', 'zh-CN']


### PR DESCRIPTION
## Description

Temporarily moving the test to /firefox while we sort out what's up with the language switcher on the redesigned /new page.

## Issue / Bugzilla link

No bug because it's possible merging https://github.com/mozilla-l10n/www-l10n/pull/83 will solve the problem.

## Testing

Passed locally.