### PR TITLE
Removed jQuery from mozilla-lazy-load.js & mozilla-smoothscroll.js (Fixes #8381)

### DIFF
--- a/media/js/base/mozilla-lazy-load.js
+++ b/media/js/base/mozilla-lazy-load.js
@@ -73,16 +73,18 @@ if (typeof window.Mozilla === 'undefined') {
      * @param _selector (String) - CSS selector for target images e.g. '.list-item img'.
      */
     LazyLoad.loadAllFallback = function(_selector) {
-        $(_selector).each(function() {
-            var srcset = this.getAttribute('data-srcset');
+        var nodeList = document.querySelectorAll(_selector);
+        for(var ni = 0; ni < nodeList.length; ni++) {
+            var self = nodeList[ni];
+            var srcset = self.getAttribute('data-srcset');
 
             if (srcset) {
-                this.srcset = srcset;
+                self.srcset = srcset;
             }
 
-            this.src = this.getAttribute('data-src');
-            this.onload = LazyLoad.onImageLoad;
-        });
+            self.src = self.getAttribute('data-src');
+            self.onload = LazyLoad.onImageLoad;
+        }
     };
 
     /**

--- a/media/js/base/mozilla-smoothscroll.js
+++ b/media/js/base/mozilla-smoothscroll.js
@@ -13,7 +13,6 @@ Mozilla.smoothScroll = (function() {
     'use strict';
 
     var _smoothScroll;
-    var $htmlBody;
 
     var _init = function(unitTest) {
         var hasSmoothScroll;
@@ -29,16 +28,6 @@ Mozilla.smoothScroll = (function() {
         if (hasSmoothScroll) {
             _smoothScroll = function(opts) {
                 window.scrollTo(opts);
-            };
-        // otherwise, use jQuery if it's available
-        } else if (window.jQuery) {
-            $htmlBody = $('html, body');
-
-            _smoothScroll = function(opts) {
-                $htmlBody.animate({
-                    scrollTop: opts.top,
-                    scrollLeft: opts.left
-                }, 400);
             };
         // default to regular ol' jump scrolling
         } else {

--- a/tests/unit/spec/base/mozilla-smoothscroll.js
+++ b/tests/unit/spec/base/mozilla-smoothscroll.js
@@ -24,38 +24,16 @@ describe('mozilla-smoothscroll.js', function () {
             });
         });
 
-        it('should use jQuery fallback when smooth scrolling is not supported', function () {
-            spyOn(window, 'scrollTo');
-            spyOn($.fn, 'animate');
-
-            Mozilla.smoothScroll({
-                top: 200,
-                unitTest: 'jQuery'
-            });
-
-            expect(window.scrollTo).not.toHaveBeenCalled();
-            expect($.fn.animate).toHaveBeenCalledWith({
-                scrollTop: 200,
-                scrollLeft: 0
-            }, 400);
-        });
-
-        it('should use legacy window.scrollTo when neither smooth scrolling nor jQuery are available', function () {
-            // take away jQuery for a minute
-            var jQueryBack = window.jQuery;
-            window.jQuery = undefined;
+        it('should use legacy window.scrollTo when smooth scrolling is not available', function () {
 
             spyOn(window, 'scrollTo');
 
             Mozilla.smoothScroll({
                 top: 200,
-                unitTest: 'fallback'
+                unitTest: 'fallback' // disable smoothScroll
             });
 
             expect(window.scrollTo).toHaveBeenCalledWith(200, 0);
-
-            // bring jQuery back
-            window.jQuery = jQueryBack;
         });
     });
 });


### PR DESCRIPTION

## Description

For mozilla-lazy-load.js:
1. Only one occurrence of $, which was replaced with querySelectorAll

For mozilla-smoothscroll.js:
1. Removed a unit test spec which expected jQuery functions to be called
2. Modified a unit test spec to not refer to window.jQuery


## Issue / Bugzilla link

https://github.com/mozilla/bedrock/issues/8381

## Testing

I've run the units tests via `karma start karma.conf.js`