### PR TITLE
Fix #8293 truncated logo on \mobile for RTL languages

### DIFF
--- a/media/css/firefox/mobile/mobile.scss
+++ b/media/css/firefox/mobile/mobile.scss
@@ -158,7 +158,7 @@ main .mzp-l-content {
 //  Wordmark
 
 .c-wordmark {
-    @include at2x('/media/protocol/img/logos/firefox/browser/logo-word-hor-sm.png', auto, 100%);
+    @include at2x('/media/protocol/img/logos/firefox/browser/logo-word-hor-sm.png', contain);
     @include bidi(((padding-right, $spacing-sm, padding-left, 0),));
     @include image-replaced;
     background-position: top center;

--- a/media/css/firefox/mobile/mobile.scss
+++ b/media/css/firefox/mobile/mobile.scss
@@ -163,7 +163,6 @@ main .mzp-l-content {
     @include image-replaced;
     background-position: top center;
     background-repeat: no-repeat;
-    background-size: contain;
     content: '';
     display: block;
 

--- a/media/css/firefox/mobile/mobile.scss
+++ b/media/css/firefox/mobile/mobile.scss
@@ -163,6 +163,7 @@ main .mzp-l-content {
     @include image-replaced;
     background-position: top center;
     background-repeat: no-repeat;
+    background-size: contain;
     content: '';
     display: block;
 


### PR DESCRIPTION
## Description
Fixed the bug by adding backgound-size attribute for c-wordmark class in the mobile.scss.

## Issue / Bugzilla link
#8293 

## Testing
I have tested the change in local envirioment on the following pages:
localhost:8000/ar/firefox/mobile/
localhost:8000/he/firefox/mobile/
localhost:8000/fa/firefox/mobile/
(Following to check if the change doesn't have negative effects on non RTL)
localhost:8000/de/firefox/mobile/
localhost:8000/en-us/firefox/mobile/