### PR TITLE
Fix modal download button on /new (Fixes #9256)

### DIFF
--- a/bedrock/firefox/templates/firefox/new/desktop/download.html
+++ b/bedrock/firefox/templates/firefox/new/desktop/download.html
@@ -480,19 +480,19 @@
     </h2>
     <span id="next"></span>
   </aside>
-
-  {% if show_firefox_join_modal %}
-  <aside class="mzp-u-modal-content join-firefox-content">
-    <h4 class="join-firefox-title">{{ ftl('firefox-desktop-download-youve-already-got-the-browser') }}</h4>
-    <p class="join-firefox-intro">{{ ftl('firefox-desktop-download-watch-for-hackers-with') }}</p>
-
-    <a href="{{ url('firefox.accounts') }}" class="mzp-c-button mzp-t-product join-firefox-button" data-link-name="Get More From Firefox" data-link-type="button">{{ ftl('firefox-desktop-download-get-more-from-firefox') }}</a>
-
-    {{ download_firefox(dom_id='download-join-firefox-modal', alt_copy=ftl('firefox-desktop-download-just-download-the-browser'), button_color='mzp-t-secondary', locale_in_transition=True, download_location='other') }}
-  </aside>
-  {% endif %}
-
 </main>
+
+{% if show_firefox_join_modal %}
+<aside class="mzp-u-modal-content join-firefox-content">
+  <h4 class="join-firefox-title">{{ ftl('firefox-desktop-download-youve-already-got-the-browser') }}</h4>
+  <p class="join-firefox-intro">{{ ftl('firefox-desktop-download-watch-for-hackers-with') }}</p>
+
+  <a href="{{ url('firefox.accounts') }}" class="mzp-c-button mzp-t-product join-firefox-button" data-link-name="Get More From Firefox" data-link-type="button">{{ ftl('firefox-desktop-download-get-more-from-firefox') }}</a>
+
+  {{ download_firefox(dom_id='download-join-firefox-modal', alt_copy=ftl('firefox-desktop-download-just-download-the-browser'), button_color='mzp-t-secondary', locale_in_transition=True, download_location='other') }}
+</aside>
+{% endif %}
+
 {% endblock %}
 
 {% block js %}

--- a/media/js/firefox/new/desktop/join-modal.js
+++ b/media/js/firefox/new/desktop/join-modal.js
@@ -26,7 +26,7 @@
     }
 
     var initFxAccountModal = function() {
-        var downloadLinkPrimary = document.querySelectorAll('.download-list .download-link[data-download-os="Desktop"]');
+        var downloadLinkPrimary = document.querySelectorAll('.main-download .download-list .download-link[data-download-os="Desktop"]');
         for (var i = 0; i < downloadLinkPrimary.length; i++) {
             downloadLinkPrimary[i].addEventListener('click', showFxAModal, false);
         }


### PR DESCRIPTION
## Description
The modal was triggering on every download button in the page, including the button that's already within the modal.

## Issue / Bugzilla link
https://github.com/mozilla/bedrock/issues/9256

## Testing
- [ ] Clicking "Just Download The Browser" should download the browser.