### PR TITLE
Allow specification of multiple FTL files for locale activation

### DIFF
--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -662,6 +662,7 @@ class DownloadThanksView(L10nTemplateView):
         'firefox/new/trailhead/exp-thanks.html': ['firefox/new/download'],
         'firefox/new/desktop/thanks.html': ['firefox/new/desktop'],
     }
+    ftl_activations = ['firefox/new/download', 'firefox/new/desktop']
 
     # place expected ?v= values in this list
     variations = ['a', 'b', 'c']
@@ -704,6 +705,7 @@ class NewView(L10nTemplateView):
         'firefox/new/trailhead/download-yandex.html': ['firefox/new/download', 'banners/firefox-mobile'],
         'firefox/new/desktop/download.html': ['firefox/new/desktop'],
     }
+    ftl_activations = ['firefox/new/download', 'firefox/new/desktop']
 
     # place expected ?v= values in this list
     variations = ['a', 'b']

--- a/docs/l10n.rst
+++ b/docs/l10n.rst
@@ -350,6 +350,12 @@ FTL files for that template (or a single file name if that's all you need).
 
             return [template_name]
 
+If you need for your URL to use multiple Fluent files to determine the full list of active locales,
+for example when you are redesigning a page and have multiple templates in use for a single URL depending
+on locale, you can use the `ftl_activations` parameter. This should be a list of FTL filenames that should
+all be used when determining the full list of translations for the URL. Bedrock will gather the full list
+for each file and combine them into a single list so that the footer language switcher works properly.
+
 Using in a view function
 ~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/lib/l10n_utils/fluent.py
+++ b/lib/l10n_utils/fluent.py
@@ -190,7 +190,7 @@ def write_metadata(ftl_file, data):
 
 
 @memoize
-def get_active_locales(ftl_file, force=False):
+def get_active_locales(ftl_files, force=False):
     """Return the list of active locales for a Fluent file.
 
     If `settings.DEV` is `True` it will just return the full list of
@@ -200,13 +200,20 @@ def get_active_locales(ftl_file, force=False):
     if settings.DEV and not force:
         return settings.DEV_LANGUAGES
 
+    if isinstance(ftl_files, str):
+        ftl_files = [ftl_files]
+
     locales = {settings.LANGUAGE_CODE}
-    metadata = get_metadata(ftl_file)
-    if metadata and 'active_locales' in metadata:
-        locales.update(metadata['active_locales'])
-        i_locales = metadata.get('inactive_locales')
-        if i_locales:
-            locales.difference_update(i_locales)
+    for ftl_file in ftl_files:
+        file_locales = set()
+        metadata = get_metadata(ftl_file)
+        if metadata and 'active_locales' in metadata:
+            file_locales.update(metadata['active_locales'])
+            i_locales = metadata.get('inactive_locales')
+            if i_locales:
+                file_locales.difference_update(i_locales)
+
+        locales.update(file_locales)
 
     return sorted(locales)
 

--- a/lib/l10n_utils/tests/test_base.py
+++ b/lib/l10n_utils/tests/test_base.py
@@ -140,15 +140,23 @@ class TestL10nTemplateView(TestCase):
         view = l10n_utils.L10nTemplateView.as_view(template_name='dude.html',
                                                    ftl_files='dude')
         view(self.req)
-        render_mock.assert_called_with(self.req, ['dude.html'], ANY, ftl_files='dude')
+        render_mock.assert_called_with(self.req, ['dude.html'], ANY, ftl_files='dude', ftl_activations=None)
 
     def test_ftl_files_map(self, render_mock):
         view = l10n_utils.L10nTemplateView.as_view(template_name='dude.html',
                                                    ftl_files_map={'dude.html': 'dude'})
         view(self.req)
-        render_mock.assert_called_with(self.req, ['dude.html'], ANY, ftl_files='dude')
+        render_mock.assert_called_with(self.req, ['dude.html'], ANY, ftl_files='dude', ftl_activations=None)
         # no match means no FTL files
         view = l10n_utils.L10nTemplateView.as_view(template_name='dude.html',
                                                    ftl_files_map={'donny.html': 'donny'})
         view(self.req)
-        render_mock.assert_called_with(self.req, ['dude.html'], ANY, ftl_files=None)
+        render_mock.assert_called_with(self.req, ['dude.html'], ANY, ftl_files=None, ftl_activations=None)
+
+    def test_ftl_activations(self, render_mock):
+        view = l10n_utils.L10nTemplateView.as_view(template_name='dude.html',
+                                                   ftl_files='dude',
+                                                   ftl_activations=['dude', 'donny'])
+        view(self.req)
+        render_mock.assert_called_with(self.req, ['dude.html'], ANY, ftl_files='dude',
+                                       ftl_activations=['dude', 'donny'])

--- a/lib/l10n_utils/tests/test_fluent.py
+++ b/lib/l10n_utils/tests/test_fluent.py
@@ -114,6 +114,22 @@ class TestFluentTranslationUtils(TestCase):
         }
         assert fluent.get_active_locales('the/dude', force=True) == ['de', 'en-US', 'fr']
 
+    @override_settings(DEV=False)
+    @patch.object(fluent, 'get_metadata')
+    def test_get_active_locales_multiple_files(self, meta_mock):
+        meta_mock.side_effect = [
+            {'active_locales': ['de', 'fr', 'it']},
+            {'active_locales': ['en-CA', 'pt-BR', 'it']},
+        ]
+        assert fluent.get_active_locales(['the/dude', 'the/walter']) == [
+            'de',
+            'en-CA',
+            'en-US',
+            'fr',
+            'it',
+            'pt-BR',
+        ]
+
 
 @override_settings(FLUENT_PATHS=[L10N_PATH])
 class TestFluentViewTranslationUtils(TestCase):


### PR DESCRIPTION
## Issue / Bugzilla link

Fix #9251

## Testing

I tested locally by setting `DEV=False` and `SWITCH_NEW_REDESIGN=on`. With the current code you would see the new page but not the lang switcher, and with these changes you should see the full list.