### PR TITLE
Tweak random number generation for doubleclick pixel (#9128)

### DIFF
--- a/media/js/base/mozilla-pixel.js
+++ b/media/js/base/mozilla-pixel.js
@@ -43,8 +43,10 @@ if (typeof window.Mozilla === 'undefined') {
             pixel.src = pixels[i].replace(/\s/g, '');
 
             // Cache bust doubleclick pixel (see issue 9128)
+            // https://support.google.com/dcm/answer/2837746?hl=en
             if (pixels[i].indexOf('ad.doubleclick.net') !== -1) {
-                var num = Math.random() + '' * 10000000000000;
+                var axel = Math.random() + '';
+                var num = axel * 10000000000000;
                 pixel.src += ';num=' + num;
             }
 

--- a/tests/unit/spec/base/mozilla-pixel.js
+++ b/tests/unit/spec/base/mozilla-pixel.js
@@ -61,7 +61,7 @@ describe('mozilla-pixel.js', function() {
             spyOn(Mozilla.Pixel, 'getPixelData').and.returnValue(pixels);
             Mozilla.Pixel.init();
 
-            expect(document.querySelector('.moz-px').src).toContain(';num=0.853456456');
+            expect(document.querySelector('.moz-px').src).toContain(';num=8534564560000');
 
         });
     });


### PR DESCRIPTION
## Description
I made a small error in the random number generation in https://github.com/mozilla/bedrock/pull/9131. This follows Google's guideline more closely, as per: https://support.google.com/dcm/answer/2837746?hl=en

## Issue / Bugzilla link
#9128

## Testing
- [ ] `num` should no longer begin with a floating point `0.`