### PR TITLE
Allow views to specify multiple ftl or template files for lang activation list

### DIFF
--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -663,7 +663,11 @@ class DownloadThanksView(L10nTemplateView):
         'firefox/new/trailhead/exp-thanks.html': ['firefox/new/download'],
         'firefox/new/desktop/thanks.html': ['firefox/new/desktop'],
     }
-    ftl_activations = ['firefox/new/download', 'firefox/new/desktop']
+    activation_files = [
+        'firefox/new/download',
+        'firefox/new/desktop',
+        'firefox/new/protocol/thanks.html',
+    ]
 
     # place expected ?v= values in this list
     variations = ['a', 'b', 'c']
@@ -706,7 +710,11 @@ class NewView(L10nTemplateView):
         'firefox/new/trailhead/download-yandex.html': ['firefox/new/download', 'banners/firefox-mobile'],
         'firefox/new/desktop/download.html': ['firefox/new/desktop'],
     }
-    ftl_activations = ['firefox/new/download', 'firefox/new/desktop']
+    activation_files = [
+        'firefox/new/download',
+        'firefox/new/desktop',
+        'firefox/new/protocol/download.html',
+    ]
 
     # place expected ?v= values in this list
     variations = ['a', 'b']
@@ -776,6 +784,7 @@ class FirefoxHomeView(L10nTemplateView):
     ftl_files_map = {
         'firefox/home/index-master.html': ['firefox/home']
     }
+    activation_files = ['firefox/home', 'firefox/home/index-quantum.html']
 
     def get_template_names(self):
         if ftl_file_is_active('firefox/home'):

--- a/docs/l10n.rst
+++ b/docs/l10n.rst
@@ -352,9 +352,10 @@ FTL files for that template (or a single file name if that's all you need).
 
 If you need for your URL to use multiple Fluent files to determine the full list of active locales,
 for example when you are redesigning a page and have multiple templates in use for a single URL depending
-on locale, you can use the `ftl_activations` parameter. This should be a list of FTL filenames that should
-all be used when determining the full list of translations for the URL. Bedrock will gather the full list
-for each file and combine them into a single list so that the footer language switcher works properly.
+on locale, you can use the `activation_files` parameter. This should be a list of FTL filenames
+(or template file names if they are still using .lang) that should all be used when determining the full
+list of translations for the URL. Bedrock will gather the full list for each file and combine them into a
+single list so that the footer language switcher works properly.
 
 Using in a view function
 ~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
## Description

Follup to #9262. This changes the `ftl_activations` parameter to `activation_files` and allows devs to include template filenames in the list so that .lang activations will be included.

## Issue / Bugzilla link

Re #9251

## Testing

I tested by commenting out the template file name in the `activation_files` parameter on the `NewView` class and looking at the list of locales in the source of the `/firefox/new/` page. Then I uncommented the line and looked at the list and saw that it was significantly longer.