### PR TITLE
Welcome page 7, match UTM params on CTA links [fix #9261]

### DIFF
--- a/bedrock/firefox/templates/firefox/welcome/page7.html
+++ b/bedrock/firefox/templates/firefox/welcome/page7.html
@@ -29,7 +29,7 @@
   ) %}
 
   <p class="primary-cta">
-    <a href="https://addons.mozilla.org/firefox/addon/facebook-container/?src=external-www.mozilla.org-welcom-7&utm_source={{ _entrypoint }}&utm_medium=referral&utm_campaign={{ _utm_campaign }}" class="mzp-c-button mzp-t-product" id="facebook-container-button" rel="external">
+    <a href="https://addons.mozilla.org/firefox/addon/facebook-container/?src=external-www.mozilla.org-welcome-7&utm_source={{ _entrypoint }}&utm_medium=referral&utm_campaign={{ _utm_campaign }}" class="mzp-c-button mzp-t-product" id="facebook-container-button" rel="external">
       {{ ftl('page7-get-facebook-container') }}
     </a>
   </p>
@@ -47,7 +47,7 @@
       <h3 class="c-picto-block-title">{{ ftl('page7-do-it-for-the-gram') }}</h3>
       <div class="c-picto-block-body">
         <p>{{ ftl('page7-facebook-container-also-works') }}</p>
-        <a href="https://addons.mozilla.org/firefox/addon/facebook-container/?utm_source={{ _entrypoint }}&utm_medium=referral&utm_campaign={{ _utm_campaign }}&entrypoint={{ _entrypoint }}" rel="external">
+        <a href="https://addons.mozilla.org/firefox/addon/facebook-container/?src=external-www.mozilla.org-welcome-7&utm_source={{ _entrypoint }}&utm_medium=referral&utm_campaign={{ _utm_campaign }}" rel="external">
           <strong>{{ ftl('page7-make-them-unfollow-you') }}</strong>
         </a>
       </div>


### PR DESCRIPTION
## Description
Both CTA links to addons.mozilla.org should have identical UTM parameters.

This needs to be in prod **before 6 August 2020** because a campaign starting that day will be sending traffic to this page.

## Issue / Bugzilla link
#9261 

## Testing
http://localhost:8000/firefox/welcome/7/

- [ ] Primary button CTA in the hero and secondary link below the fold have matching params