### PR TITLE
Add signed in state to evergreen WNP [fix #9245]

### DIFF
--- a/bedrock/firefox/templates/firefox/whatsnew/index-account.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/index-account.html
@@ -2,6 +2,8 @@
  # License, v. 2.0. If a copy of the MPL was not distributed with this
  # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
 
+{% from "macros.html" import send_to_device with context %}
+
 {% extends "firefox/whatsnew/base.html" %}
 
 {% block page_title %}{{ ftl('whatsnew-page-title') }}{% endblock %}
@@ -14,12 +16,15 @@
 {% block page_og_url %}{{ url('firefox.accounts') }}{% endblock %}
 
 {% block body_id %}firefox-whatsnew-account{% endblock %}
+{% block body_class %}{{ super() }} state-fxa-default{% endblock %}
 
 {% block site_header %}{% endblock %}
 
 {% block page_css %}
   {{ css_bundle('firefox_whatsnew_account') }}
 {% endblock %}
+
+{% set show_send_to_device = LANG in settings.SEND_TO_DEVICE_LOCALES %}
 
 {% block content %}
 <main role="main" class="content-wrapper mzp-t-firefox mzp-t-dark">
@@ -36,22 +41,52 @@
   </header>
 
   <section class="content-main">
-    <div class="mzp-l-content">
+    <div class="mzp-l-content mzp-t-content-md">
       <div class="mzp-c-emphasis-box">
-        <img class="c-emphasis-box-logo" src="{{ static('protocol/img/logos/firefox/logo-md.png') }}" alt="">
-        <h2 class="c-emphasis-box-title">
-          {{ ftl('whatsnew-account-main-headline') }}
-        </h2>
-        <p>{{ ftl('whatsnew-account-main-lead-in') }}</p>
-        <p class="cta">
-          {{ fxa_button(
-            entrypoint=entrypoint,
-            button_text=ftl('whatsnew-account-main-button'),
-            class_name='mzp-t-small',
-            optional_parameters={'utm_campaign': campaign},
-            optional_attributes={'data-cta-text': 'Sign In', 'data-cta-type': 'fxa-sync', 'data-cta-position': 'primary'}
-          ) }}
-        </p>
+
+      {# If user is signed out (or undetermined), promote account #}
+        <div class="show-fxa-supported-signed-out">
+          <img class="c-emphasis-box-logo" src="{{ static('protocol/img/logos/firefox/logo-md.png') }}" alt="">
+          <h2 class="c-emphasis-box-title">
+            {{ ftl('whatsnew-account-main-headline') }}
+          </h2>
+          <p>{{ ftl('whatsnew-account-main-lead-in') }}</p>
+          <p class="cta">
+            {{ fxa_button(
+              entrypoint=entrypoint,
+              button_text=ftl('whatsnew-account-main-button'),
+              class_name='mzp-t-small',
+              optional_parameters={'utm_campaign': campaign},
+              optional_attributes={'data-cta-text': 'Sign In', 'data-cta-type': 'fxa-sync', 'data-cta-position': 'primary'}
+            ) }}
+          </p>
+        </div>
+
+      {# If the user is signed in, promote mobile #}
+        <div class="show-fxa-supported-signed-in">
+          <img class="c-emphasis-box-logo" src="{{ static('protocol/img/logos/firefox/browser/logo-md.png') }}" alt="">
+        {# If user is in a locale with translated basket messages... #}
+        {% if show_send_to_device %}
+          <h2 class="c-emphasis-box-title">{{ ftl('whatsnew-account-signed-in-headline') }}</h2>
+          {# L10n: "You got it" here is a casual answer to the previous question, "Want privacy on every device?" #}
+          <p class="c-emphasis-box-tagline">{{ ftl('whatsnew-account-signed-in-lead-in') }}</p>
+          {# For users not in a locale with translated basket messages... #}
+        {% else %}
+          <h2 class="c-emphasis-box-title">{{ ftl('whatsnew-account-signed-in-qr-title') }}</h2>
+        {% endif %}
+
+        {# Only certain locales get send_to_device, else they see a QRCode. #}
+        {% if show_send_to_device %}
+          <div id="send-to-device-wrapper" class="primary-cta">
+            {{ send_to_device(include_title=False, message_set='fx-whatsnew', spinner_color='#fff;', class='vertical') }}
+          </div>
+        {% else %}
+          <div id="qr-wrapper" class="primary-cta">
+            <img src="{{ static('img/firefox/whatsnew/qrcode.png') }}" data-mozillaonline-link="{{ static('img/firefox/whatsnew/qrcode-mozillaonline.png') }}" width="250" height="250" alt="{{ ftl('whatsnew-account-qr-code-alt') }}">
+          </div>
+        {% endif %}
+        </div>
+
       </div>
     </div>
   </section>

--- a/bedrock/firefox/templates/firefox/whatsnew/index-account.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/index-account.html
@@ -67,10 +67,9 @@
           <img class="c-emphasis-box-logo" src="{{ static('protocol/img/logos/firefox/browser/logo-md.png') }}" alt="">
         {# If user is in a locale with translated basket messages... #}
         {% if show_send_to_device %}
-          <h2 class="c-emphasis-box-title">{{ ftl('whatsnew-account-signed-in-headline') }}</h2>
-          {# L10n: "You got it" here is a casual answer to the previous question, "Want privacy on every device?" #}
+          <h2 class="c-emphasis-box-title">{{ ftl('whatsnew-account-signed-in-headline', fallback='send-to-device-send-firefox') }}</h2>
           <p class="c-emphasis-box-tagline">{{ ftl('whatsnew-account-signed-in-lead-in') }}</p>
-          {# For users not in a locale with translated basket messages... #}
+        {# For users not in a locale with translated basket messages... #}
         {% else %}
           <h2 class="c-emphasis-box-title">{{ ftl('whatsnew-account-signed-in-qr-title') }}</h2>
         {% endif %}

--- a/l10n/en/firefox/whatsnew/whatsnew-account.ftl
+++ b/l10n/en/firefox/whatsnew/whatsnew-account.ftl
@@ -9,3 +9,11 @@
 whatsnew-account-main-headline = No account required. But you might want one.
 whatsnew-account-main-lead-in = The { -brand-name-firefox } browser collects so little data about you, we don’t even require your email address. But when you use it to create a { -brand-name-firefox } account, we can protect your privacy across more of your online life.
 whatsnew-account-main-button = Sign In
+
+##
+whatsnew-account-signed-in-headline = Get more done. Use { -brand-name-firefox } for mobile.
+whatsnew-account-signed-in-lead-in = Send a download link to your phone.
+whatsnew-account-signed-in-qr-title = Download { -brand-name-firefox } for your smartphone and tablet.
+
+# An accessible label for a QR code image
+whatsnew-account-qr-code-alt = Scan this QR code

--- a/media/css/firefox/whatsnew/whatsnew-account.scss
+++ b/media/css/firefox/whatsnew/whatsnew-account.scss
@@ -12,6 +12,7 @@ $image-path: '/media/protocol/img';
 
 .content-main {
     padding: 0;
+
     @media #{$mq-md} {
         padding-top: $spacing-2xl;
     }
@@ -70,10 +71,6 @@ $image-path: '/media/protocol/img';
         @include text-title-sm;
     }
 
-    .c-emphasis-box-tagline {
-        @include text-title-xs;
-    }
-
     .cta {
         margin: $spacing-xl 0 $spacing-sm;
     }
@@ -91,4 +88,40 @@ $image-path: '/media/protocol/img';
     background: $color-ink-80 url('/media/img/firefox/whatsnew/whatsnew_background.svg') no-repeat;
     @include background-size(100%);
     color: $color-white;
+}
+
+#send-to-device {
+    margin: 0 auto;
+    text-align: center;
+
+    .more,
+    .send-another {
+        color: $color-link;
+    }
+}
+
+.send-to-device-form {
+    .form-input-label {
+        color: $color-ink-80;
+    }
+
+    .inline-field {
+        margin-bottom: $spacing-md;
+    }
+}
+
+
+// Conditional content
+.show-fxa-supported-signed-in {
+    display: none;
+}
+
+.state-fxa-supported-signed-in {
+    .show-fxa-supported-signed-in {
+        display: block;
+    }
+
+    .show-fxa-supported-signed-out {
+        display: none;
+    }
 }

--- a/media/js/firefox/whatsnew/whatsnew-account.js
+++ b/media/js/firefox/whatsnew/whatsnew-account.js
@@ -1,0 +1,30 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// create namespace
+if (typeof window.Mozilla === 'undefined') {
+    window.Mozilla = {};
+}
+
+(function($, Mozilla) {
+    'use strict';
+
+    var client = Mozilla.Client;
+    var sendTo = document.getElementById('send-to-device');
+
+    if (sendTo) {
+        var form = new Mozilla.SendToDevice();
+        form.init();
+    }
+
+    // bug 1419573 - only show "Your Firefox is up to date" if it's the latest version.
+    if (client.isFirefoxDesktop) {
+        client.getFirefoxDetails(function(data) {
+            if (data.isUpToDate) {
+                document.querySelector('.c-page-header').classList.add('show-up-to-date-message');
+            }
+        });
+    }
+
+})(window.jQuery, window.Mozilla);

--- a/media/js/firefox/whatsnew/whatsnew-account.js
+++ b/media/js/firefox/whatsnew/whatsnew-account.js
@@ -7,7 +7,7 @@ if (typeof window.Mozilla === 'undefined') {
     window.Mozilla = {};
 }
 
-(function($, Mozilla) {
+(function(Mozilla) {
     'use strict';
 
     var client = Mozilla.Client;
@@ -17,14 +17,4 @@ if (typeof window.Mozilla === 'undefined') {
         var form = new Mozilla.SendToDevice();
         form.init();
     }
-
-    // bug 1419573 - only show "Your Firefox is up to date" if it's the latest version.
-    if (client.isFirefoxDesktop) {
-        client.getFirefoxDetails(function(data) {
-            if (data.isUpToDate) {
-                document.querySelector('.c-page-header').classList.add('show-up-to-date-message');
-            }
-        });
-    }
-
-})(window.jQuery, window.Mozilla);
+})(window.Mozilla);

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -348,6 +348,7 @@
     },
     {
       "files": [
+        "css/protocol/components/send-to-device.scss",
         "css/firefox/whatsnew/whatsnew-account.scss"
       ],
       "name": "firefox_whatsnew_account"
@@ -1166,8 +1167,13 @@
     {
       "files": [
         "js/firefox/whatsnew/up-to-date.js",
+        "js/base/mozilla-fxa.js",
+        "js/base/mozilla-fxa-init.js",
         "js/base/mozilla-fxa-product-button.js",
-        "js/base/mozilla-fxa-product-button-init.js"
+        "js/base/mozilla-fxa-product-button-init.js",
+        "js/base/send-to-device.js",
+        "js/libs/spin.min.js",
+        "js/firefox/whatsnew/whatsnew-account.js"
       ],
       "name": "firefox_whatsnew_account"
     },

--- a/tests/functional/firefox/whatsnew/test_whatsnew_60.py
+++ b/tests/functional/firefox/whatsnew/test_whatsnew_60.py
@@ -4,6 +4,7 @@
 
 import pytest
 
+from selenium.common.exceptions import TimeoutException
 from pages.firefox.whatsnew.whatsnew_60 import FirefoxWhatsNew60Page
 
 
@@ -12,3 +13,22 @@ from pages.firefox.whatsnew.whatsnew_60 import FirefoxWhatsNew60Page
 def test_account_buttons_displayed(base_url, selenium):
     page = FirefoxWhatsNew60Page(selenium, base_url, params='').open()
     assert page.is_account_button_displayed
+
+
+@pytest.mark.skip_if_not_firefox(reason='Whatsnew pages are shown to Firefox only.')
+@pytest.mark.nondestructive
+def test_send_to_device_success(base_url, selenium):
+    page = FirefoxWhatsNew60Page(selenium, base_url, params='?signed-in=true').open()
+    assert not page.is_qr_code_displayed
+    send_to_device = page.send_to_device
+    send_to_device.type_email('success@example.com')
+    send_to_device.click_send()
+    assert send_to_device.send_successful
+
+
+@pytest.mark.skip_if_not_firefox(reason='Whatsnew pages are shown to Firefox only.')
+@pytest.mark.nondestructive
+def test_send_to_device_fails_when_missing_required_fields(base_url, selenium):
+    page = FirefoxWhatsNew60Page(selenium, base_url, params='?signed-in=true').open()
+    with pytest.raises(TimeoutException):
+        page.send_to_device.click_send()

--- a/tests/functional/firefox/whatsnew/test_whatsnew_60.py
+++ b/tests/functional/firefox/whatsnew/test_whatsnew_60.py
@@ -32,3 +32,10 @@ def test_send_to_device_fails_when_missing_required_fields(base_url, selenium):
     page = FirefoxWhatsNew60Page(selenium, base_url, params='?signed-in=true').open()
     with pytest.raises(TimeoutException):
         page.send_to_device.click_send()
+
+
+@pytest.mark.skip_if_not_firefox(reason='Whatsnew pages are shown to Firefox only.')
+@pytest.mark.nondestructive
+def test_get_firefox_qr_code(base_url, selenium):
+    page = FirefoxWhatsNew60Page(selenium, base_url, locale='sv-SE', params='?signed-in=true').open()
+    assert page.is_qr_code_displayed

--- a/tests/pages/firefox/whatsnew/whatsnew_60.py
+++ b/tests/pages/firefox/whatsnew/whatsnew_60.py
@@ -5,6 +5,7 @@
 from selenium.webdriver.common.by import By
 
 from pages.base import BasePage
+from pages.regions.send_to_device import SendToDevice
 
 
 class FirefoxWhatsNew60Page(BasePage):
@@ -12,7 +13,22 @@ class FirefoxWhatsNew60Page(BasePage):
     URL_TEMPLATE = '/{locale}/firefox/60.0/whatsnew/all/{params}'
 
     _account_button_locator = (By.CSS_SELECTOR, '.content-main .js-fxa-product-button')
+    _qr_code_locator = (By.CSS_SELECTOR, '.qr-code img')
+
+    def wait_for_page_to_load(self):
+        self.wait.until(lambda s: self.seed_url in s.current_url)
+        el = self.find_element(By.TAG_NAME, 'body')
+        self.wait.until(lambda s: 'state-fxa-default' not in el.get_attribute('class'))
+        return self
 
     @property
     def is_account_button_displayed(self):
         return self.is_element_displayed(*self._account_button_locator)
+
+    @property
+    def send_to_device(self):
+        return SendToDevice(self)
+
+    @property
+    def is_qr_code_displayed(self):
+        return self.is_element_displayed(*self._qr_code_locator)

--- a/tests/pages/firefox/whatsnew/whatsnew_60.py
+++ b/tests/pages/firefox/whatsnew/whatsnew_60.py
@@ -13,7 +13,7 @@ class FirefoxWhatsNew60Page(BasePage):
     URL_TEMPLATE = '/{locale}/firefox/60.0/whatsnew/all/{params}'
 
     _account_button_locator = (By.CSS_SELECTOR, '.content-main .js-fxa-product-button')
-    _qr_code_locator = (By.CSS_SELECTOR, '.qr-code img')
+    _qr_code_locator = (By.CSS_SELECTOR, '#qr-wrapper img')
 
     def wait_for_page_to_load(self):
         self.wait.until(lambda s: self.seed_url in s.current_url)


### PR DESCRIPTION
## Description
Adds a signed-in state to the evergreen fallback WNP, shown to locales that haven't translated the current version's custom page or to any users updating to an older version that doesn't have an active custom page.

If the user is not signed into sync, we display a pitch to create an account (or sign in).
If the user is signed into sync, we display the send-to-device widget to promote Firefox mobile.

This adds a few new strings to `/firefox/whatsnew/whatsnew-account.ftl`

## Issue / Bugzilla link
#9245 

## Testing
http://localhost:8000/firefox/60.0/whatsnew/all/
http://localhost:8000/firefox/60.0/whatsnew/all/?signed-in=true

https://www-demo-pr-9276.herokuapp.com/firefox/60.0/whatsnew/all/
https://www-demo-pr-9276.herokuapp.com/firefox/60.0/whatsnew/all/?signed-in=true

- [x] Account promo is shown when signed out
- [x] Mobile widget is shown when signed in
- [x] Tests pass