### PR TITLE
Adjust Legal Docs Cache Timeout

### DIFF
--- a/bedrock/legal_docs/views.py
+++ b/bedrock/legal_docs/views.py
@@ -10,7 +10,8 @@ from django.views.generic import TemplateView
 from bedrock.legal_docs.models import LegalDoc
 from lib import l10n_utils
 
-CACHE_TIMEOUT = getattr(settings, 'LEGAL_DOCS_CACHE_TIMEOUT', 60 * 60)
+
+CACHE_TIMEOUT = settings.LEGAL_DOCS_CACHE_TIMEOUT
 
 
 def load_legal_doc(doc_name, locale):
@@ -44,7 +45,7 @@ class LegalDocView(TemplateView):
     * legal_doc_context_name: (default 'doc') template variable name for legal doc.
 
     This view automatically adds the `cache_page` decorator. The default timeout
-    is 1 hour, configurable by setting the `LEGAL_DOCS_CACHE_TIMEOUT` setting to change
+    is 10 minutes, configurable by setting the `LEGAL_DOCS_CACHE_TIMEOUT` setting to change
     the default for all views, or the `cache_timeout` property for an single instance.
 
     See `bedrock/privacy/views.py` for usage examples.

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -1364,6 +1364,7 @@ LEGAL_DOCS_PATH = GIT_REPOS_PATH / 'legal_docs'
 LEGAL_DOCS_REPO = config('LEGAL_DOCS_REPO', default='https://github.com/mozilla/legal-docs.git')
 LEGAL_DOCS_BRANCH = config('LEGAL_DOCS_BRANCH', default='master' if DEV else 'prod')
 LEGAL_DOCS_DMS_URL = config('LEGAL_DOCS_DMS_URL', default='')
+LEGAL_DOCS_CACHE_TIMEOUT = config('LEGAL_DOCS_CACHE_TIMEOUT', default='60' if DEV else '600', parser=int)
 
 MOFO_SECURITY_ADVISORIES_PATH = config('MOFO_SECURITY_ADVISORIES_PATH',
                                        default=git_repo_path('mofo_security_advisories'))


### PR DESCRIPTION
It was set to an hour for dev and prod. In the new system 10min on prod and 1min on dev is good and helps get changes out faster for the legal team.