### PR TITLE
Fix legal docs Dead Mans Snitch configuration

### DIFF
--- a/bedrock/legal_docs/management/commands/update_legal_docs.py
+++ b/bedrock/legal_docs/management/commands/update_legal_docs.py
@@ -19,6 +19,10 @@ class Command(BaseCommand):
         if not self.quiet:
             print(msg)
 
+    def snitch(self):
+        if settings.LEGAL_DOCS_DMS_URL:
+            requests.get(settings.LEGAL_DOCS_DMS_URL)
+
     def handle(self, *args, **options):
         self.quiet = options['quiet']
         repo = GitRepo(settings.LEGAL_DOCS_PATH,
@@ -28,19 +32,20 @@ class Command(BaseCommand):
         self.output('Updating git repo')
         repo.update()
         if not (options['force'] or repo.has_changes()):
-            self.output('No content card updates')
+            self.output('No legal docs updates')
+            self.snitch()
             return
 
         self.output('Loading legal docs into database')
         count, errors = LegalDoc.objects.refresh()
-
         self.output(f'{count} legal docs successfully loaded')
-        self.output(f'Encountered {errors} errors while loading docs')
+        if errors:
+            self.output(f'Encountered {errors} errors while loading docs')
+        else:
+            # only set latest if there are no errors so that it will try the errors again next time
+            # also so that it will fail again and thus not ping the snitch so that we'll be notified
+            repo.set_db_latest()
+            self.output('Saved latest git repo state to database')
+            self.snitch()
 
-        repo.set_db_latest()
-
-        self.output('Saved latest git repo state to database')
         self.output('Done!')
-
-        if not errors and settings.LEGAL_DOCS_DMS_URL:
-            requests.get(settings.LEGAL_DOCS_DMS_URL)


### PR DESCRIPTION
Only update the repo state if there are no errors: this means that we'll get a DMS notification if there are errors, while still updating the docs that did not error. Also ping DMS when there are not updates so that the DMS will work properly.