### PR TITLE
Fix #9278

### DIFF
--- a/bedrock/exp/templates/exp/firefox/new/download.html
+++ b/bedrock/exp/templates/exp/firefox/new/download.html
@@ -469,20 +469,22 @@
 
   <aside id="mobile-banner" class="show-android show-ios" data-nosnippet>
     <div class="c-mobile">
-      <div class="c-mobile-text">
-        <h1 class="c-logo t-browser-word-hor-white-xs">{{ ftl('firefox-desktop-download-firefox-browser') }}</h1>
-        <h2 class="mzp-has-zap-7 mzp-u-title-md show-android">{{ ftl('firefox-desktop-download-get-firefox-android') }}</h2>
-        <h2 class="mzp-has-zap-7 mzp-u-title-md show-ios">{{ ftl('firefox-desktop-download-get-firefox-ios') }}</h2>
+      <div class="mzp-l-content">
+        <div class="c-mobile-text">
+          <h1 class="c-logo t-browser-word-hor-white-xs">{{ ftl('firefox-desktop-download-firefox-browser') }}</h1>
+          <h2 class="mzp-has-zap-7 mzp-u-title-md show-android">{{ ftl('firefox-desktop-download-get-firefox-android') }}</h2>
+          <h2 class="mzp-has-zap-7 mzp-u-title-md show-ios">{{ ftl('firefox-desktop-download-get-firefox-ios') }}</h2>
 
-        <p>{{ ftl('firefox-desktop-download-download-the-mobile') }}</p>
+          <p>{{ ftl('firefox-desktop-download-download-the-mobile') }}</p>
 
-        <div class="show-android">
-          {{ google_play_button() }}
-        </div>
-        <div class="show-ios">
-          <a href="{{ ios_url }}" data-link-type="download" data-download-os="iOS">
-            <img src="{{ l10n_img('firefox/ios/btn-app-store.svg') }}" alt="{{ ftl('download-button-download-app-store') }}" width="152" height="45">
-          </a>
+          <div class="show-android">
+            {{ google_play_button() }}
+          </div>
+          <div class="show-ios">
+            <a href="{{ ios_url }}" data-link-type="download" data-download-os="iOS">
+              <img src="{{ l10n_img('firefox/ios/btn-app-store.svg') }}" alt="{{ ftl('download-button-download-app-store') }}" width="152" height="45">
+            </a>
+          </div>
         </div>
       </div>
     </div>

--- a/bedrock/firefox/templates/firefox/new/desktop/download.html
+++ b/bedrock/firefox/templates/firefox/new/desktop/download.html
@@ -458,20 +458,22 @@
 
   <aside id="mobile-banner" class="show-android show-ios" data-nosnippet>
     <div class="c-mobile">
-      <div class="c-mobile-text">
-        <h1 class="c-logo t-browser-word-hor-white-xs">{{ ftl('firefox-desktop-download-firefox-browser') }}</h1>
-        <h2 class="mzp-has-zap-7 mzp-u-title-md show-android">{{ ftl('firefox-desktop-download-get-firefox-android') }}</h2>
-        <h2 class="mzp-has-zap-7 mzp-u-title-md show-ios">{{ ftl('firefox-desktop-download-get-firefox-ios') }}</h2>
+      <div class="mzp-l-content">
+        <div class="c-mobile-text">
+          <h1 class="c-logo t-browser-word-hor-white-xs">{{ ftl('firefox-desktop-download-firefox-browser') }}</h1>
+          <h2 class="mzp-has-zap-7 mzp-u-title-md show-android">{{ ftl('firefox-desktop-download-get-firefox-android') }}</h2>
+          <h2 class="mzp-has-zap-7 mzp-u-title-md show-ios">{{ ftl('firefox-desktop-download-get-firefox-ios') }}</h2>
 
-        <p>{{ ftl('firefox-desktop-download-download-the-mobile') }}</p>
+          <p>{{ ftl('firefox-desktop-download-download-the-mobile') }}</p>
 
-        <div class="show-android">
-          {{ google_play_button() }}
-        </div>
-        <div class="show-ios">
-          <a href="{{ ios_url }}" data-link-type="download" data-download-os="iOS">
-            <img src="{{ l10n_img('firefox/ios/btn-app-store.svg') }}" alt="{{ ftl('download-button-download-app-store') }}" width="152" height="45">
-          </a>
+          <div class="show-android">
+            {{ google_play_button() }}
+          </div>
+          <div class="show-ios">
+            <a href="{{ ios_url }}" data-link-type="download" data-download-os="iOS">
+              <img src="{{ l10n_img('firefox/ios/btn-app-store.svg') }}" alt="{{ ftl('download-button-download-app-store') }}" width="152" height="45">
+            </a>
+          </div>
         </div>
       </div>
     </div>

--- a/media/css/exp/firefox/new/download.scss
+++ b/media/css/exp/firefox/new/download.scss
@@ -1337,7 +1337,6 @@ button.mzp-c-cta-link {
                          top 15% left 100px;
     background-repeat: no-repeat;
     color: $color-white;
-    padding: $layout-lg $h-grid-xs;
     position: relative;
     overflow-x: hidden;
 
@@ -1348,7 +1347,6 @@ button.mzp-c-cta-link {
                              top 100px left,
                              bottom right,
                              top 15% center;
-        padding: $layout-lg $layout-lg;
     }
 
     @media #{$mq-lg} {
@@ -1358,7 +1356,6 @@ button.mzp-c-cta-link {
                              top 100px left,
                              bottom right,
                              top 15% center;
-        padding: $layout-lg $layout-xl;
     }
 
     .loaded & {
@@ -1384,15 +1381,15 @@ button.mzp-c-cta-link {
                 (left, 60%, right, auto),
                 (margin-left, $h-grid-xs / 2, margin-left, 0),
             ));
+            background-position: top center;
             background-repeat: no-repeat;
             border-radius: $border-radius-sm;
+            bottom: $layout-lg;
             content: '';
             display: block;
             position: absolute;
             top: $layout-lg;
-            bottom: $layout-lg;
-            width: 100%;
-            max-width: 275px;
+            width: 40%;
 
             &,
             .android & {
@@ -1408,7 +1405,6 @@ button.mzp-c-cta-link {
             @include bidi(((padding-right, $h-grid-xs / 2, padding-left, 0),));
             @include border-box;
             max-width: 60%;
-            margin: 0 auto;
         }
     }
 
@@ -1433,7 +1429,6 @@ button.mzp-c-cta-link {
 
         .c-mobile-text {
             @include bidi(((padding-right, $h-grid-lg / 2, padding-left, 0),));
-            max-width: $content-xl;
         }
     }
 }

--- a/media/css/firefox/new/desktop/download.scss
+++ b/media/css/firefox/new/desktop/download.scss
@@ -1337,7 +1337,6 @@ button.mzp-c-cta-link {
                          top 15% left 100px;
     background-repeat: no-repeat;
     color: $color-white;
-    padding: $layout-lg $h-grid-xs;
     position: relative;
     overflow-x: hidden;
 
@@ -1348,7 +1347,6 @@ button.mzp-c-cta-link {
                              top 100px left,
                              bottom right,
                              top 15% center;
-        padding: $layout-lg $layout-lg;
     }
 
     @media #{$mq-lg} {
@@ -1358,7 +1356,6 @@ button.mzp-c-cta-link {
                              top 100px left,
                              bottom right,
                              top 15% center;
-        padding: $layout-lg $layout-xl;
     }
 
     .loaded & {
@@ -1384,15 +1381,15 @@ button.mzp-c-cta-link {
                 (left, 60%, right, auto),
                 (margin-left, $h-grid-xs / 2, margin-left, 0),
             ));
+            background-position: top center;
             background-repeat: no-repeat;
             border-radius: $border-radius-sm;
+            bottom: $layout-lg;
             content: '';
             display: block;
             position: absolute;
             top: $layout-lg;
-            bottom: $layout-lg;
-            width: 100%;
-            max-width: 275px;
+            width: 40%;
 
             &,
             .android & {
@@ -1408,7 +1405,6 @@ button.mzp-c-cta-link {
             @include bidi(((padding-right, $h-grid-xs / 2, padding-left, 0),));
             @include border-box;
             max-width: 60%;
-            margin: 0 auto;
         }
     }
 
@@ -1433,7 +1429,6 @@ button.mzp-c-cta-link {
 
         .c-mobile-text {
             @include bidi(((padding-right, $h-grid-lg / 2, padding-left, 0),));
-            max-width: $content-xl;
         }
     }
 }


### PR DESCRIPTION
## Description

Stop text from overlapping image in mobile. Updates to both the default and exp template.

## Issue / Bugzilla link

Fix #9278

## Testing

http://localhost:8000/en-US/firefox/new/

In ios or android, or you can spoof it by changing the body class from `osx` to `android` or `ios`
