### PR TITLE
firefox/mobile page, show app store badges on mobile platforms [fix #9289]

### DIFF
--- a/bedrock/firefox/templates/firefox/mobile/index.html
+++ b/bedrock/firefox/templates/firefox/mobile/index.html
@@ -43,6 +43,8 @@
               <button type="button" class="mzp-c-button mzp-t-product js-mobile" id="get-firefox" data-cta-type="button" data-cta-text="Get Firefox Mobile" data-cta-position="primary">
                 {{ ftl('firefox-mobile-get-firefox-mobile') }}
               </button>
+            </div>
+
             <div class="mobile-download-buttons-wrapper">
               <ul class="mobile-download-buttons firefox" id="mobile-download-buttons-firefox_1">
                 <li class="android">
@@ -135,6 +137,7 @@
                 {{ ftl('firefox-mobile-get-firefox-mobile') }}
               </button>
             </div>
+
             <div class="mobile-download-buttons-wrapper">
               <ul class="mobile-download-buttons firefox" id="mobile-download-buttons-firefox_2">
                 <li class="android">


### PR DESCRIPTION
## Description
There is a CSS rule to hide the main CTA button (which opens the send-to-device widget) on mobile platforms, but the store badges were in the same container so were also being hidden.

## Issue / Bugzilla link
#9289 

## Testing
http://localhost:8000/firefox/mobile/
https://www-demo-pr-9292.herokuapp.com/firefox/mobile/

Test on both Android and iOS (either using a real device, browserstack, or just fake it by changing the root class to `android` or `ios` with dev tools). Also check both the main hero at the top of the page and the secondary one at the bottom.

- [x] Main CTA button is hidden on mobile
- [x] Google Play badge is shown on Android
- [x] Apple App Store badge is shown on iOS