### PR TITLE
Add Firefox Relay terms of service (Fixes #9240)

### DIFF
--- a/bedrock/legal/templates/legal/terms/firefox-relay.html
+++ b/bedrock/legal/templates/legal/terms/firefox-relay.html
@@ -1,0 +1,7 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+
+{% extends "legal/docs-base.html" %}
+
+{% block page_title %}Firefox Relay Terms of Service{% endblock %}

--- a/bedrock/legal/urls.py
+++ b/bedrock/legal/urls.py
@@ -46,6 +46,9 @@ urlpatterns = (
     url(r'^terms/firefox-private-network/$', LegalDocView.as_view(template_name='legal/terms/firefox-private-network.html',
         legal_doc_name='Firefox_Private_Network_ToS'), name='legal.terms.firefox-private-network'),
 
+    url(r'^terms/firefox-relay/$', LegalDocView.as_view(template_name='legal/terms/firefox-relay.html',
+        legal_doc_name='firefox_relay_ToS'), name='legal.terms.firefox-relay'),
+
     url(r'^terms/thunderbird/$', LegalDocView.as_view(template_name='legal/terms/thunderbird.html', legal_doc_name='thunderbird_about_rights'),
         name='legal.terms.thunderbird'),
 


### PR DESCRIPTION
## Description
http://localhost:8000/en-US/about/legal/terms/firefox-relay/

## Issue / Bugzilla link
https://github.com/mozilla/bedrock/issues/9240