### PR TITLE
Expose /contribute for L10n (Fixes #9151)

### DIFF
--- a/bedrock/mozorg/templates/mozorg/contribute/contribute-2020.html
+++ b/bedrock/mozorg/templates/mozorg/contribute/contribute-2020.html
@@ -8,7 +8,7 @@
   {{ css_bundle('contribute-2020') }}
 {% endblock %}
 
-{% block page_title %}Volunteer Opportunities at Mozilla{% endblock %}
+{% block page_title %}{{ ftl('contribute-page-title') }}{% endblock %}
 
 {% block body_class %}{{ super() }} contribute{% endblock %}
 
@@ -18,11 +18,8 @@
 <main role="main">
   <div class="mzp-l-content contribute-intro">
     <header class="contribute-intro-content">
-      <h1 class="contribute-intro-heading">Your talents are needed for a better internet</h1>
-      <p>Mozilla is a non-profit organization working to ensure the internet
-        is open and welcoming to all. And we need your help. By joining our
-        community, you can help drive innovation, enhance accountability and
-        trust and make the internet a better place for everyone.</p>
+      <h1 class="contribute-intro-heading">{{ ftl('contribute-page-heading') }}</h1>
+      <p>{{ ftl('contribute-page-intro') }}</p>
     </header>
 
     <div class="contribute-intro-media-wrapper">
@@ -34,7 +31,7 @@
 
   <section class="contribute-hero">
     <div class="mzp-l-content">
-      <h2>{{ _('How you can contribute…') }}</h2>
+      <h2>{{ ftl('contribute-how-heading') }}</h2>
     </div>
 
     <div class="mzp-l-content mzp-l-card-quarter contribute-card-container">
@@ -48,13 +45,11 @@
           </div>
           <div class="mzp-c-card-content contribute-card-content">
             <div class="contribute-card-content-tags">
-              <div class="mzp-c-card-tag contribute-card-tag-bold">Non Technical</div>
-              <div class="mzp-c-card-tag">Individual and event organization</div>
+              <div class="mzp-c-card-tag contribute-card-tag-bold">{{ ftl('contribute-tag-non-technical ') }}</div>
+              <div class="mzp-c-card-tag">{{ ftl('contribute-tag-individual-event') }}</div>
             </div>
-            <h2 class="mzp-c-card-title">Translate content</h2>
-            <p class="mzp-c-card-desc">The internet is only global if it’s
-              understood everywhere. Help us translate Mozilla’s products and
-              websites into your local language.</p>
+            <h2 class="mzp-c-card-title">{{ ftl('contribute-task-translate-heading') }}</h2>
+            <p class="mzp-c-card-desc">{{ ftl('contribute-task-translate-desc') }}</p>
           </div>
         </a>
       </section>
@@ -69,12 +64,11 @@
           </div>
           <div class="mzp-c-card-content contribute-card-content">
             <div class="contribute-card-content-tags">
-              <div class="mzp-c-card-tag contribute-card-tag-bold">Technical</div>
-              <div class="mzp-c-card-tag">Individual</div>
+              <div class="mzp-c-card-tag contribute-card-tag-bold">{{ ftl('contribute-tag-technical') }}</div>
+              <div class="mzp-c-card-tag">{{ ftl('contribute-tag-individual') }}</div>
             </div>
-            <h2 class="mzp-c-card-title">Contribute to the Mozilla codebase</h2>
-            <p class="mzp-c-card-desc">Actively improve Mozilla’s products by
-              contributing to a variety of development opportunities.</p>
+            <h2 class="mzp-c-card-title">{{ ftl('contribute-task-mozilla-codebase-heading') }}</h2>
+            <p class="mzp-c-card-desc">{{ ftl('contribute-task-mozilla-codebase-desc') }}</p>
           </div>
         </a>
       </section>
@@ -89,13 +83,11 @@
           </div>
           <div class="mzp-c-card-content contribute-card-content">
             <div class="contribute-card-content-tags">
-              <div class="mzp-c-card-tag contribute-card-tag-bold">Support</div>
-              <div class="mzp-c-card-tag">Individual and event organization</div>
+              <div class="mzp-c-card-tag contribute-card-tag-bold">{{ ftl('contribute-tag-support') }}</div>
+              <div class="mzp-c-card-tag">{{ ftl('contribute-tag-individual-event') }}</div>
             </div>
-            <h2 class="mzp-c-card-title">Individual and event organization</h2>
-            <p class="mzp-c-card-desc">Help make Mozilla’s products easy to
-              use. Answer user's "help" questions as part of the Mozilla Support
-              Community forums.</p>
+            <h2 class="mzp-c-card-title">{{ ftl('contribute-tag-individual-event') }}</h2>
+            <p class="mzp-c-card-desc">{{ ftl('contribute-task-support-desc') }}.</p>
           </div>
         </a>
       </section>
@@ -110,13 +102,11 @@
           </div>
           <div class="mzp-c-card-content contribute-card-content">
             <div class="contribute-card-content-tags">
-              <div class="mzp-c-card-tag contribute-card-tag-bold">Technical and Non-technical</div>
+              <div class="mzp-c-card-tag contribute-card-tag-bold">{{ ftl('contribute-tag-technical-non-technical') }}</div>
             </div>
 
-            <h2 class="mzp-c-card-title">Join the community</h2>
-            <p class="mzp-c-card-desc">Want to get more involved in the
-              Mozilla community? Check out all the volunteer opportunities in our
-              Community Portal.</p>
+            <h2 class="mzp-c-card-title">{{ ftl('contribute-task-join-heading ') }}</h2>
+            <p class="mzp-c-card-desc">{{ ftl('contribute-task-join-desc') }}</p>
           </div>
         </a>
       </section>
@@ -126,39 +116,36 @@
   <section class="mzp-l-content">
     <div class="contribute-mission">
       <div class="contribute-mission-intro">
-        <h2 class="contribute-mission-title">Our Mission</h2>
-        <p>Our mission is to ensure the internet is a global public resource,
-          open and accessible to all. An internet that truly puts people first,
-          where individuals can shape their own experience and are empowered, safe
-          and independent.</p>
+        <h2 class="contribute-mission-title">{{ ftl('contribute-mission-heading') }}</h2>
+        <p>{{ ftl('contribute-mission-desc') }}</p>
       </div>
 
       <ul class="contribute-mission-cards">
         <li class="contribute-mission-card">
           <a href="{{ url('mozorg.about') }}">
-            <h3 class="contribute-mission-learn-icon">Learn about Mozilla</h3>
-            <p>Read our manifesto</p>
+            <h3 class="contribute-mission-learn-icon">{{ ftl('contribute-learn') }}</h3>
+            <p>{{ ftl('contribute-read-manifesto') }}</p>
           </a>
         </li>
 
         <li class="contribute-mission-card">
           <a href="https://community.mozilla.org/events/{{ utm_params }}">
-            <h3 class="contribute-mission-event-icon">Find an event</h3>
-            <p>Meet our passionate volunteers</p>
+            <h3 class="contribute-mission-event-icon">{{ ftl('contribute-find-event') }}</h3>
+            <p>{{ ftl('contribute-meet-volunteers') }}</p>
           </a>
         </li>
 
         <li class="contribute-mission-card">
           <a href="{{ donate_url('contribute-page') }}">
-            <h3 class="contribute-mission-donate-icon">Donate</h3>
-            <p>Help fund our mission</p>
+            <h3 class="contribute-mission-donate-icon">{{ ftl('contribute-donate') }}</h3>
+            <p>{{ ftl('contribute-help-fund') }}</p>
           </a>
         </li>
 
         <li class="contribute-mission-card">
           <a href="https://twitter.com/mozilla">
-            <h3 class="contribute-mission-follow-icon">Follow Mozilla</h3>
-            <p>News and volunteer opportunities</p>
+            <h3 class="contribute-mission-follow-icon">{{ ftl('contribute-follow-mozilla') }}</h3>
+            <p>{{ ftl('contribute-opportunities') }}</p>
           </a>
         </li>
       </div>
@@ -176,18 +163,10 @@
 
       <div class="contribute-feature-content">
         <div class="contribute-feature-content-container">
-          <h2>Made by passionate people like you</h2>
+          <h2>{{ ftl('contribute-made-by-heading') }}</h2>
           <div class="contribute-feature-desc">
-            <p>When you contribute to Mozilla, you become part of a worldwide
-              community made up of people from around the globe who believe
-              that we all have a role in ensuring that the internet remains a force
-              for good.</p>
-
-            <p>We believe community collaboration is vital to
-              creating an internet that is diverse, innovative, and
-              accountable to the people who need it most. Whether you have a background in
-              tech, community organizing, or just a computer and some free
-              time, you can help us make the internet a better place.</p>
+            <p>{{ ftl('contribute-made-by-desc') }}</p>
+            <p>{{ ftl('contribute-made-by-desc-cont') }}</p>
           </div>
         </div>
       </div>
@@ -202,9 +181,9 @@
 
       <div class="newsletter-content">
         {{ email_newsletter_form(
-          title=_('Not sure yet?'),
-          subtitle=_('Get community and contribution news to your inbox'),
-          desc=_('Subscribe to our newsletter, join Mozillians all around the world, and learn about impactful opportunities to support Mozilla’s mission.'),
+          title=ftl('contribute-newsletter-heading'),
+          subtitle=ftl('contribute-newsletter-sub-heading'),
+          desc=ftl('contribute-newsletter-desc'),
           newsletters='about-mozilla',
           include_language=False)
         }}
@@ -215,13 +194,12 @@
   <section class="contribute-banner-wrapper">
     <div class="contribute-banner contribute-banner-gethelp">
       <div class="contribute-banner-content">
-        <h2 class="contribute-banner-gethelp-title">Get Help</h2>
-        <p>Mozilla has a dedicated team of volunteers to help with whatever
-          issues you may be experiencing.</p>
+        <h2 class="contribute-banner-gethelp-title">{{ ftl('contribute-support-heading') }}</h2>
+        <p>{{ ftl('contribute-support-desc') }}</p>
       </div>
       <div class="contribute-banner-cta">
         <a href="https://support.mozilla.org/{{ utm_params }}" class="mzp-c-button mzp-t-product">
-          Mozilla Support
+          {{ ftl('contribute-mozilla-support')}}
         </a>
       </div>
     </div>
@@ -229,15 +207,13 @@
     <div class="contribute-banner contribute-banner-problems">
       <div class="contribute-banner-content">
         <div class="contribute-banner-problems-title-wrapper">
-          <h2 class="contribute-banner-problems-title"><span>Problems with a web page?</span></h2>
+          <h2 class="contribute-banner-problems-title"><span>{{ ftl('contribute-web-compat-heading') }}</span></h2>
         </div>
-        <p>If your experience of a website differs between browsers then you may
-          have discovered a web compatibility issue. We would love to know about
-          it!</p>
+        <p>{{ ftl('contribute-web-compat-desc') }}</p>
       </div>
       <div class="contribute-banner-cta">
         <a href="https://webcompat.com/{{ utm_params }}" class="mzp-c-button">
-          Report an issue
+          {{ ftl('contribute-report-issue') }}
         </a>
       </div>
     </div>

--- a/bedrock/mozorg/templates/mozorg/contribute/contribute-2020.html
+++ b/bedrock/mozorg/templates/mozorg/contribute/contribute-2020.html
@@ -87,7 +87,7 @@
               <div class="mzp-c-card-tag">{{ ftl('contribute-tag-individual-event') }}</div>
             </div>
             <h2 class="mzp-c-card-title">{{ ftl('contribute-tag-individual-event') }}</h2>
-            <p class="mzp-c-card-desc">{{ ftl('contribute-task-support-desc') }}.</p>
+            <p class="mzp-c-card-desc">{{ ftl('contribute-task-support-desc') }}</p>
           </div>
         </a>
       </section>

--- a/bedrock/mozorg/tests/test_views.py
+++ b/bedrock/mozorg/tests/test_views.py
@@ -88,16 +88,20 @@ class TestContribute(TestCase):
     def setUp(self):
         self.rf = RequestFactory()
 
-    # Load the new page for English
+    @patch.object(views, 'ftl_file_is_active', lambda *x: True)
     def test_contribute_en_template(self, render_mock):
-        req = RequestFactory().get('/contribute/')
+        req = RequestFactory().get('/contribute')
         req.locale = 'en-US'
-        views.contribute(req)
-        render_mock.assert_called_once_with(req, 'mozorg/contribute/contribute-2020.html')
+        view = views.ContributeView.as_view()
+        view(req)
+        template = render_mock.call_args[0][1]
+        assert template == ['mozorg/contribute/contribute-2020.html']
 
-    # Load the old page for other locales
+    @patch.object(views, 'ftl_file_is_active', lambda *x: False)
     def test_contribute_locale_template(self, render_mock):
-        req = RequestFactory().get('/contribute/')
+        req = RequestFactory().get('/contribute')
         req.locale = 'es-ES'
-        views.contribute(req)
-        render_mock.assert_called_once_with(req, 'mozorg/contribute/index.html')
+        view = views.ContributeView.as_view()
+        view(req)
+        template = render_mock.call_args[0][1]
+        assert template == ['mozorg/contribute/index.html']

--- a/bedrock/mozorg/urls.py
+++ b/bedrock/mozorg/urls.py
@@ -106,7 +106,7 @@ urlpatterns = (
     page('MPL/2.0/differences', 'mozorg/mpl/2.0/differences.html'),
     page('MPL/2.0/permissive-code-into-mpl', 'mozorg/mpl/2.0/permissive-code-into-mpl.html'),
 
-    url('^contribute/$', views.contribute, name='mozorg.contribute.index'),
+    url('^contribute/$', views.ContributeView.as_view(), name='mozorg.contribute.index'),
 
     page('moss', 'mozorg/moss/index.html'),
     page('moss/foundational-technology', 'mozorg/moss/foundational-technology.html'),

--- a/bedrock/mozorg/views.py
+++ b/bedrock/mozorg/views.py
@@ -7,6 +7,8 @@ from django.shortcuts import render as django_render
 from django.views.decorators.http import require_safe
 from django.views.generic import TemplateView
 from lib import l10n_utils
+from lib.l10n_utils import L10nTemplateView
+from lib.l10n_utils.fluent import ftl_file_is_active
 
 from bedrock.contentcards.models import get_page_content_cards
 from bedrock.mozorg.credits import CreditsFile
@@ -128,11 +130,15 @@ def home_view(request):
     return l10n_utils.render(request, template_name, ctx)
 
 
-def contribute(request):
-    locale = l10n_utils.get_locale(request)
+class ContributeView(L10nTemplateView):
+    ftl_files_map = {
+        'mozorg/contribute/contribute-2020.html': ['mozorg/contribute']
+    }
 
-    if locale.startswith('en-'):
-        template = 'mozorg/contribute/contribute-2020.html'
-    else:
-        template = 'mozorg/contribute/index.html'
-    return l10n_utils.render(request, template)
+    def get_template_names(self):
+        if ftl_file_is_active('mozorg/contribute'):
+            template_name = 'mozorg/contribute/contribute-2020.html'
+        else:
+            template_name = 'mozorg/contribute/index.html'
+
+        return [template_name]

--- a/l10n/en/mozorg/contribute.ftl
+++ b/l10n/en/mozorg/contribute.ftl
@@ -23,7 +23,7 @@ contribute-task-translate-heading = Translate content
 contribute-task-translate-desc = The internet is only global if it’s understood everywhere. Help us translate { -brand-name-mozilla } products and websites into your local language.
 contribute-task-mozilla-codebase-heading = Contribute to the { -brand-name-mozilla } codebase
 contribute-task-mozilla-codebase-desc = Actively improve { -brand-name-mozilla } products by contributing to a variety of development opportunities.
-contribute-task-support-desc = Help make { -brand-name-mozilla } products easy to use. Answer user’s "help" questions as part of the { -brand-name-mozilla } Support Community forums.
+contribute-task-support-desc = Help make { -brand-name-mozilla } products easy to use. Answer people’s “help” questions as part of the { -brand-name-mozilla } Support Community forums.
 contribute-task-join-heading = Join the community
 contribute-task-join-desc = Want to get more involved in the { -brand-name-mozilla } community? Check out all the volunteer opportunities in our Community Portal.
 

--- a/l10n/en/mozorg/contribute.ftl
+++ b/l10n/en/mozorg/contribute.ftl
@@ -1,0 +1,65 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+### URL: https://www-dev.allizom.org/contribute/
+
+## Page heading
+
+contribute-page-title = Volunteer Opportunities at { -brand-name-mozilla }
+contribute-page-heading = Your talents are needed for a better internet
+contribute-page-intro = { -brand-name-mozilla } is a non-profit organization working to ensure the internet is open and welcoming to all. And we need your help. By joining our community, you can help drive innovation, enhance accountability and trust and make the internet a better place for everyone.
+contribute-how-heading = How you can contribute…
+
+## Contribution tasks
+
+contribute-tag-non-technical = Non Technical
+contribute-tag-technical = Technical
+contribute-tag-technical-non-technical = Technical and Non-technical
+contribute-tag-individual-event = Individual and event organization
+contribute-tag-individual = Individual
+contribute-tag-support = Support
+contribute-task-translate-heading = Translate content
+contribute-task-translate-desc = The internet is only global if it’s understood everywhere. Help us translate { -brand-name-mozilla } products and websites into your local language.
+contribute-task-mozilla-codebase-heading = Contribute to the { -brand-name-mozilla } codebase
+contribute-task-mozilla-codebase-desc = Actively improve { -brand-name-mozilla } products by contributing to a variety of development opportunities.
+contribute-task-support-desc = Help make { -brand-name-mozilla } products easy to use. Answer user’s "help" questions as part of the { -brand-name-mozilla } Support Community forums.
+contribute-task-join-heading = Join the community
+contribute-task-join-desc = Want to get more involved in the { -brand-name-mozilla } community? Check out all the volunteer opportunities in our Community Portal.
+
+## Mission
+
+contribute-mission-heading = Our Mission
+contribute-mission-desc = Our mission is to ensure the internet is a global public resource, open and accessible to all. An internet that truly puts people first, where individuals can shape their own experience and are empowered, safe and independent.
+contribute-learn = Learn about { -brand-name-mozilla }
+contribute-read-manifesto = Read our manifesto
+contribute-find-event = Find an event
+contribute-meet-volunteers = Meet our passionate volunteers
+contribute-donate = Donate
+contribute-help-fund = Help fund our mission
+contribute-follow-mozilla = Follow { -brand-name-mozilla }
+contribute-opportunities = News and volunteer opportunities
+
+## Made by
+
+contribute-made-by-heading = Made by passionate people like you
+contribute-made-by-desc = When you contribute to { -brand-name-mozilla }, you become part of a worldwide community made up of people from around the globe who believe that we all have a role in ensuring that the internet remains a force for good.
+contribute-made-by-desc-cont = We believe community collaboration is vital to creating an internet that is diverse, innovative, and accountable to the people who need it most. Whether you have a background in tech, community organizing, or just a computer and some free time, you can help us make the internet a better place.
+
+## Newsletter
+
+contribute-newsletter-heading = Not sure yet?
+contribute-newsletter-sub-heading = Get community and contribution news to your inbox
+contribute-newsletter-desc = Subscribe to our newsletter, join Mozillians all around the world, and learn about impactful opportunities to support the { -brand-name-mozilla } mission.
+
+## Support
+
+contribute-support-heading = Get Help
+contribute-support-desc = { -brand-name-mozilla } has a dedicated team of volunteers to help with whatever issues you may be experiencing.
+contribute-mozilla-support = { -brand-name-mozilla } Support
+
+## Web compat
+
+contribute-web-compat-heading = Problems with a web page?
+contribute-web-compat-desc = If your experience of a website differs between browsers then you may have discovered a web compatibility issue. We would love to know about it!
+contribute-report-issue = Report an issue


### PR DESCRIPTION
## Description
- Adds `mozorg/contribute.ftl`
- Converts `/contribute/` page to use Fluent IDs.
- Updates view tests.

## Issue / Bugzilla link
#9151

## Testing
- [x] Did I miss any strings?
- [x] Did I miss any brand names?