### PR TITLE
Migrate default /whatsnew page to Fluent (Fixes #9194)

### DIFF
--- a/bedrock/firefox/templates/firefox/whatsnew/includes/header.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/includes/header.html
@@ -1,16 +1,11 @@
-<header class="main-header">
-  <div class="content">
-    <div class="inner-container">
-      <div class="mozilla-logo">
-        <a href="{{ url('mozorg.home') }}" data-link-type="nav" data-link-name="Mozilla">Mozilla</a>
-      </div>
-      <h1 class="up-to-date-messaging hidden">
-      {% if custom_message %}
-        {{ custom_message }}
-      {% else %}
-        {{ _('Your Firefox is up to date.') }}
-      {% endif %}
-      </h1>
+<header class="c-page-header">
+  <div class="mzp-l-content c-page-header-inner">
+    {{ high_res_img('protocol/img/logos/firefox/browser/logo-word-hor-white-sm.png', {'alt': 'Firefox', 'width': '216', 'height': '40', 'class': 'c-page-header-logo-fx'}) }}
+    <div class="mzp-c-notification-bar mzp-t-success up-to-date">
+      <p>{{ ftl('whatsnew-up-to-date-notification') }}</p>
+    </div>
+    <div class="mzp-c-notification-bar out-of-date">
+      <p>{{ ftl('whatsnew-out-of-date-notification') }}</p>
     </div>
   </div>
 </header>

--- a/bedrock/firefox/templates/firefox/whatsnew/index-account.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/index-account.html
@@ -23,17 +23,7 @@
 
 {% block content %}
 <main role="main" class="content-wrapper mzp-t-firefox mzp-t-dark">
-  <header class="c-page-header">
-    <div class="mzp-l-content c-page-header-inner">
-      {{ high_res_img('protocol/img/logos/firefox/browser/logo-word-hor-white-sm.png', {'alt': 'Firefox', 'width': '216', 'height': '40', 'class': 'c-page-header-logo-fx'}) }}
-      <div class="mzp-c-notification-bar mzp-t-success up-to-date">
-        <p>{{ ftl('whatsnew-up-to-date-notification') }}</p>
-      </div>
-      <div class="mzp-c-notification-bar out-of-date">
-        <p>{{ ftl('whatsnew-out-of-date-notification') }}</p>
-      </div>
-    </div>
-  </header>
+  {% include 'firefox/whatsnew/includes/header.html' %}
 
   <section class="content-main">
     <div class="mzp-l-content">

--- a/bedrock/firefox/templates/firefox/whatsnew/index.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/index.html
@@ -4,16 +4,12 @@
 
 {% from "macros.html" import send_to_device with context %}
 
-{% add_lang_files "firefox/whatsnew" %}
-
 {% extends "firefox/whatsnew/base.html" %}
 
-{% block page_title %}{{_('Download Firefox for Android and iOS')}}{% endblock %}
+{% block page_title %}{{ftl('whatsnew-s2d-download-firefox-for-android')}}{% endblock %}
 
 {#- This will appear as <meta property="og:description"> which can be used for social share -#}
-{% block page_og_desc %}
-  {{_('Firefox is non-profit, non-corporate, non-compromised. Choosing Firefox isn’t just choosing a browser. It’s a vote for personal freedom.')}}
-{% endblock %}
+{% block page_og_desc %}{{ ftl('whatsnew-page-description') }}{% endblock %}
 
 {% block body_id %}firefox-whatsnew{% endblock %}
 {% block body_class %}{% endblock %}
@@ -30,31 +26,22 @@
 
 {% block content %}
 <main class="content-wrapper mzp-t-firefox">
-  <header class="c-page-header main-header">
-    <div class="mzp-l-content c-page-header-inner">
-      <img src="{{ static('protocol/img/logos/mozilla/white.svg') }}"  alt="Mozilla" width="78" height="22" class="c-page-header-logo-moz">
-      <div class="mzp-c-notification-bar mzp-t-success up-to-date">
-        <p>{{ _('Your Firefox is up to date.') }}</p>
-      </div>
-    </div>
-  </header>
+  {% include 'firefox/whatsnew/includes/header.html' %}
 
   <section class="main-content{% if show_send_to_device %} show-send-to-device{% endif %}">
     <div class="mzp-l-content t-content-lg">
       <header>
       {# If user is in a locale with translated basket messages... #}
       {% if show_send_to_device %}
-        {% if l10n_has_tag('whatsnew_headline_04112019') %}
-          <h1 class="main-title">{{ _('Want privacy on every device?') }}</h1>
-          {# L10n: "You got it" here is a casual answer to the previous question, "Want privacy on every device?" #}
-          <p class="main-tagline">{{ _('You got it. Get Firefox for mobile.') }}</p>
+        {% if ftl_has_messages('whatsnew-s2d-want-privacy-on-every-device', 'whatsnew-s2d-you-got-it-get-firefox-for') %}
+          <h1 class="main-title">{{ ftl('whatsnew-s2d-want-privacy-on-every-device') }}</h1>
+          <p class="main-tagline">{{ ftl('whatsnew-s2d-you-got-it-get-firefox-for') }}</p>
         {% else %}
-          {# L10n: Line break below is for visual formatting only #}
-          <h1 class="main-title">{{ _('Send Firefox to your phone<br> and unleash your Internet.') }}</h1>
+          <h1 class="main-title">{{ ftl('whatsnew-s2d-send-firefox-to-your-phone') }}</h1>
         {% endif %}
       {# For users not in a locale with translated basket messages... #}
       {% else %}
-        <h1 class="main-title">{{ _('Download Firefox for your smartphone and tablet.') }}</h1>
+        <h1 class="main-title">{{ ftl('whatsnew-s2d-download-firefox-for-your') }}</h1>
       {% endif %}
       </header>
 

--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx79.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx79.html
@@ -21,17 +21,7 @@
 
 {% block content %}
 <main class="content-wrapper mzp-t-firefox mzp-t-dark">
-  <header class="c-page-header">
-    <div class="mzp-l-content c-page-header-inner">
-      {{ high_res_img('protocol/img/logos/firefox/browser/logo-word-hor-white-sm.png', {'alt': 'Firefox', 'width': '216', 'height': '40', 'class': 'c-page-header-logo-fx'}) }}
-      <div class="mzp-c-notification-bar mzp-t-success up-to-date">
-        <p>{{ ftl('whatsnew-up-to-date-notification') }}</p>
-      </div>
-      <div class="mzp-c-notification-bar out-of-date">
-        <p>{{ ftl('whatsnew-out-of-date-notification') }}</p>
-      </div>
-    </div>
-  </header>
+  {% include 'firefox/whatsnew/includes/header.html' %}
 
   <section class="content-main">
     <div class="mzp-l-content">

--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -549,9 +549,10 @@ class WhatsNewRedirectorView(GeoRedirectView):
 class WhatsnewView(L10nTemplateView):
 
     ftl_files_map = {
-        'firefox/whatsnew/index-account.html': ['firefox/whatsnew/whatsnew-account', 'firefox/whatsnew/whatsnew'],
-        'firefox/whatsnew/whatsnew-fx79.html': ['firefox/whatsnew/whatsnew-fx79', 'firefox/whatsnew/whatsnew'],
         'firefox/nightly/whatsnew.html': ['firefox/nightly/whatsnew', 'firefox/whatsnew/whatsnew'],
+        'firefox/whatsnew/index-account.html': ['firefox/whatsnew/whatsnew-account', 'firefox/whatsnew/whatsnew'],
+        'firefox/whatsnew/index.html': ['firefox/whatsnew/whatsnew-s2d', 'firefox/whatsnew/whatsnew'],
+        'firefox/whatsnew/whatsnew-fx79.html': ['firefox/whatsnew/whatsnew-fx79', 'firefox/whatsnew/whatsnew'],
     }
 
     def get_context_data(self, **kwargs):

--- a/l10n/en/firefox/whatsnew/whatsnew-s2d.ftl
+++ b/l10n/en/firefox/whatsnew/whatsnew-s2d.ftl
@@ -1,0 +1,16 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+### URL: https://www-dev.allizom.org/firefox/whatsnew/all/
+
+whatsnew-s2d-download-firefox-for-android = Download { -brand-name-firefox } for { -brand-name-android } and { -brand-name-ios }
+whatsnew-s2d-want-privacy-on-every-device = Want privacy on every device?
+
+# "You got it" here is a casual answer to the previous question, "Want privacy on every device?"
+whatsnew-s2d-you-got-it-get-firefox-for = You got it. Get { -brand-name-firefox } for mobile.
+
+# Line break is for visual formatting only
+whatsnew-s2d-send-firefox-to-your-phone = Send { -brand-name-firefox } to your phone<br> and unleash your Internet.
+
+whatsnew-s2d-download-firefox-for-your = Download { -brand-name-firefox } for your smartphone and tablet.

--- a/lib/fluent_migrations/firefox/whatsnew/index.py
+++ b/lib/fluent_migrations/firefox/whatsnew/index.py
@@ -1,0 +1,63 @@
+from __future__ import absolute_import
+import fluent.syntax.ast as FTL
+from fluent.migrate.helpers import transforms_from
+from fluent.migrate.helpers import VARIABLE_REFERENCE, TERM_REFERENCE
+from fluent.migrate import REPLACE, COPY
+
+index = "firefox/whatsnew/index.lang"
+whatsnew = "firefox/whatsnew.lang"
+
+def migrate(ctx):
+    """Migrate bedrock/firefox/templates/firefox/whatsnew/index.html, part {index}."""
+
+    ctx.add_transforms(
+        "firefox/whatsnew/whatsnew-s2d.ftl",
+        "firefox/whatsnew/whatsnew-s2d.ftl",
+        [
+            FTL.Message(
+                id=FTL.Identifier("whatsnew-s2d-download-firefox-for-android"),
+                value=REPLACE(
+                    whatsnew,
+                    "Download Firefox for Android and iOS",
+                    {
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                        "Android": TERM_REFERENCE("brand-name-android"),
+                        "iOS": TERM_REFERENCE("brand-name-ios"),
+                    }
+                )
+            ),
+        ] + transforms_from("""
+whatsnew-s2d-want-privacy-on-every-device = {COPY(whatsnew, "Want privacy on every device?",)}
+""", whatsnew=whatsnew) + [
+            FTL.Message(
+                id=FTL.Identifier("whatsnew-s2d-you-got-it-get-firefox-for"),
+                value=REPLACE(
+                    whatsnew,
+                    "You got it. Get Firefox for mobile.",
+                    {
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("whatsnew-s2d-send-firefox-to-your-phone"),
+                value=REPLACE(
+                    whatsnew,
+                    "Send Firefox to your phone<br> and unleash your Internet.",
+                    {
+                        "Firefox": TERM_REFERENCE("brand-name-firefox")
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("whatsnew-s2d-download-firefox-for-your"),
+                value=REPLACE(
+                    whatsnew,
+                    "Download Firefox for your smartphone and tablet.",
+                    {
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                    }
+                )
+            ),
+        ]
+        )

--- a/media/css/firefox/whatsnew/whatsnew.scss
+++ b/media/css/firefox/whatsnew/whatsnew.scss
@@ -22,6 +22,8 @@ $image-path: '/media/protocol/img';
 
     .main-title {
         @include text-title-md;
+        margin: 0 auto;
+        max-width: 15em;
 
         br {
             display: none;
@@ -33,15 +35,19 @@ $image-path: '/media/protocol/img';
     }
 
     header {
-        @include at2x('/media/protocol/img/logos/firefox/browser/logo-word-hor-white-sm.png', 174px, 32px);
+        @include at2x('/media/protocol/img/logos/firefox/browser/logo-sm.png', 64px, 64px);
         background-position: top center;
         background-repeat: no-repeat;
-        padding-top: 48px;
-        margin-bottom: 48px;
+        padding-top: 64px + $spacing-md;
+        margin-bottom: $spacing-xl;
     }
 
     &.show-send-to-device {
         @include bidi(((text-align, left, right),));
+
+        .main-title {
+            max-width: none;
+        }
 
         header {
             @include bidi(((background-position, left top, right top),));
@@ -56,11 +62,6 @@ $image-path: '/media/protocol/img';
 
     @media #{$mq-md} {
         padding: 10vh 0;
-
-        header {
-            background-size: 260px 48px;
-            padding-top: $layout-lg;
-        }
     }
 }
 


### PR DESCRIPTION
## Description
- Migrates default /whatsnew page (S2D widget) to Fluent
- Use shared header for Fluent /whatsnew pages

http://localhost:8000/en-US/firefox/whatsnew/all/

## Issue / Bugzilla link
#9194

## Testing
```
./manage.py l10n_update
```