### PR TITLE
WNP80, hide Android promo with switch for en-US/CA [fix #9319]

### DIFF
--- a/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx80.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/whatsnew-fx80.html
@@ -66,7 +66,7 @@ data-whatsnew80-redirect-url="{{ settings.FXA_ENDPOINT + 'sms/?' + utm_params }}
 
   <section class="content-extra">
     <div class="mzp-l-content">
-      <div class="l-columns-three">
+      <div class="{% if switch('firefox-whatsnew80-daylight-en-us', ['en-US', 'en-CA']) %}l-columns-three{% elif LANG in ['en-US', 'en-CA'] %}l-columns-two{% else %}l-columns-three{% endif %}">
 
         <div class="c-picto-block">
           <div class="c-picto-block-image">
@@ -88,6 +88,7 @@ data-whatsnew80-redirect-url="{{ settings.FXA_ENDPOINT + 'sms/?' + utm_params }}
           </div>
         </div>
 
+      {% if switch('firefox-whatsnew80-daylight-en-us', ['en-US', 'en-CA']) %}
         <div class="c-picto-block">
           <div class="c-picto-block-image">
             <img src="{{ static('img/firefox/whatsnew/whatsnew80/icon-fxandroid.png') }}" width="48" alt="">
@@ -97,6 +98,19 @@ data-whatsnew80-redirect-url="{{ settings.FXA_ENDPOINT + 'sms/?' + utm_params }}
             <p>{{ ftl('whatsnew80-our-latest-version') }}</p>
           </div>
         </div>
+      {% elif LANG in ['en-US', 'en-CA'] %}
+        {# Show nothing #}
+      {% else %}
+        <div class="c-picto-block">
+          <div class="c-picto-block-image">
+            <img src="{{ static('img/firefox/whatsnew/whatsnew80/icon-fxandroid.png') }}" width="48" alt="">
+          </div>
+          <h3 class="c-picto-block-title">{{ ftl('whatsnew80-new-firefox-android') }}</h3>
+          <div class="c-picto-block-body">
+            <p>{{ ftl('whatsnew80-our-latest-version') }}</p>
+          </div>
+        </div>
+      {% endif %}
 
       </div>
     </div>

--- a/l10n/en-US/firefox/whatsnew/whatsnew-fx80.ftl
+++ b/l10n/en-US/firefox/whatsnew/whatsnew-fx80.ftl
@@ -1,0 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+### URL: https://www-dev.allizom.org/firefox/80.0/whatsnew/all/
+
+whatsnew80-our-latest-version = Our latest version of { -brand-name-firefox } features lightning-fast page loads and a clean new design that makes it easier to get more things done, more quickly.


### PR DESCRIPTION
## Description

The new Firefox for Android is releasing to most locales on the 25th (the same date as Firefox 80 for desktop) but it's being delayed in en-US and en-CA until the 27th. WNP80 promotes the new Android browser, but we shouldn't show that promo to en-US and en-CA until it's actually available in those locales.

This puts the Android blurb behind the switch `firefox-whatsnew80-daylight-en-us` only for en-US and en-CA; all other locales will be able to see it by default.

This also fixes a typo, but avoids altering the original string by treating en-US as a locale (I've already submitted the same via Pontoon for en-CA and en-GB).

We need to get this to production on **Monday the 24th** ahead of the Fx80 release.

## Issue / Bugzilla link
#9319 

## Testing
http://localhost:8000/en-US/firefox/80.0/whatsnew/

- [x] In Prod mode (switch off), the Android promo is hidden in en-US and en-CA
- [x] In Prod mode (switch off), the Android promo is visible in other locales
- [x] In Dev mode (switch on), the Android promo is visible in en-US and en-CA (as well as all others)
- [ ] English locales show "lightning" instead of "lightening"