### PR TITLE
remove qsurvey from bounty

### DIFF
--- a/bedrock/security/templates/security/bug-bounty/web-eligible-sites.html
+++ b/bedrock/security/templates/security/bug-bounty/web-eligible-sites.html
@@ -233,11 +233,6 @@
     <li>send.firefox.com</li>
   </ul>
 
-  <h3>Shield</h3>
-  <ul class="mzp-u-list-styled">
-    <li>qsurvey.mozilla.com</li>
-  </ul>
-
   <h3>Ship It</h3>
   <ul class="mzp-u-list-styled">
     <li>shipit-api.mozilla-releng.net</li>


### PR DESCRIPTION
## Description
This is an update of the eligible web properties to remove qsurvey from the web bounty

## Testing
Verify that formatting rendered properly for the new sites added.

## Required Reviewers
@april @g-k 
