### PR TITLE
Hide Firefox Send [fix #9316]

### DIFF
--- a/bedrock/base/templates/includes/protocol/footer/firefox.html
+++ b/bedrock/base/templates/includes/protocol/footer/firefox.html
@@ -35,7 +35,9 @@
           <ul class="mzp-c-footer-list">
             <li><a href="{{ url('firefox.products.lockwise') }}" data-link-type="footer" data-link-name="Lockwise">{{ ftl('footer-lockwise') }}</a></li>
             <li><a href="https://monitor.firefox.com/?utm_source=www.mozilla.org&utm_medium=referral&utm_campaign=footer&utm_content=monitor" data-link-type="footer" data-link-name="Monitor">{{ ftl('footer-monitor') }}</a></li>
+          {% if switch('firefox-send-active') %}
             <li><a href="https://send.firefox.com/?utm_source=www.mozilla.org&utm_medium=referral&utm_campaign=footer&utm_content=send" data-link-type="footer" data-link-name="Send">{{ ftl('footer-send') }}</a></li>
+          {% endif %}
             <li><a href="{{ url('firefox.browsers.index') }}" data-link-type="footer" data-link-name="Browsers">{{ ftl('footer-browsers') }}</a></li>
             <li><a href="https://getpocket.com/?utm_source=www.mozilla.org&utm_medium=referral&utm_campaign=footer&utm_content=pocket" data-link-type="footer" data-link-name="Pocket">{{ ftl('footer-pocket') }}</a></li>
           </ul>

--- a/bedrock/base/templates/includes/protocol/navigation/menu-firefox/products.html
+++ b/bedrock/base/templates/includes/protocol/navigation/menu-firefox/products.html
@@ -41,6 +41,7 @@
           </li>
         </ul>
         <ul>
+        {% if switch('firefox-send-active') %}
           <li>
             <section class="mzp-c-menu-item mzp-has-icon">
               <a class="mzp-c-menu-item-link" href="https://send.firefox.com/{{ referral|safe }}" data-link-name="Send" data-link-type="nav" data-link-position="topnav" data-link-group="products">
@@ -50,6 +51,7 @@
               </a>
             </section>
           </li>
+        {% endif %}
           <li>
             <section class="mzp-c-menu-item mzp-has-icon">
               <a class="mzp-c-menu-item-link" href="https://getpocket.com/{{ referral|safe }}" data-link-name="Pocket" data-link-type="nav" data-link-position="topnav" data-link-group="products">

--- a/bedrock/exp/templates/exp/firefox/accounts.html
+++ b/bedrock/exp/templates/exp/firefox/accounts.html
@@ -70,7 +70,7 @@
     </div>
     {% endif %}
 
-    <div class="c-accounts-form">
+    <div class="mzp-c-emphasis-box c-accounts-form">
       {{ fxa_email_form(
         entrypoint=_entrypoint,
         form_title=ftl('firefox-accounts-join-firefox'),
@@ -107,7 +107,7 @@
       {% endif %}
     </h2>
 
-    <ul class="c-product-list">
+    <ul class="c-product-list {% if switch('firefox-send-active') %}l-columns-two{% else %}l-columns-three{% endif %}">
       <li class="c-product-list-item t-product-firefox">
         <a href="{{ url('firefox.new') }}">
           <h3 class="c-product-list-title">{{ ftl('firefox-accounts-firefox-browser') }}</h3>

--- a/bedrock/exp/templates/exp/firefox/accounts.html
+++ b/bedrock/exp/templates/exp/firefox/accounts.html
@@ -126,12 +126,14 @@
           <p class="c-product-list-desc">{{ ftl('firefox-accounts-get-a-lookout-for') }}</p>
         </a>
       </li>
+    {% if switch('firefox-send-active') %}
       <li class="c-product-list-item t-product-send">
         <a href="https://send.firefox.com?utm_source={{ _utm_source }}&amp;utm_medium=referral&amp;utm_campaign={{ _utm_campaign }}&amp;utm_content=product-list-item&amp;entrypoint={{ _entrypoint }}" data-cta-text="Firefox Send" data-cta-type="FxA-Sync">
           <h3 class="c-product-list-title">{{ ftl('firefox-accounts-firefox-send') }}</h3>
           <p class="c-product-list-desc">{{ ftl('firefox-accounts-share-large-files') }}</p>
         </a>
       </li>
+    {% endif %}
     </ul>
 
     <p class="c-accounts-products-tagline">

--- a/bedrock/exp/templates/exp/firefox/index.html
+++ b/bedrock/exp/templates/exp/firefox/index.html
@@ -59,12 +59,14 @@
               {{ ftl('firefox-home-monitor') }}
             </a>
           </li>
+        {% if switch('firefox-send-active') %}
           <li>
             <a class="mzp-c-cta-link" href="https://send.firefox.com/{{ referrals }}" rel="external noopener" data-cta-type="link" data-cta-text="Send">
               <img alt="" src="{{ static('protocol/img/logos/firefox/send/logo-md.png') }}" height="40" width="40"><br>
               {{ ftl('firefox-home-send') }}
             </a>
           </li>
+        {% endif %}
           <li>
               <a class="mzp-c-cta-link" href="{{ url('firefox.products.lockwise') }}" rel="external noopener" data-cta-type="link" data-cta-text="Lockwise">
                 <img alt="" src="{{ static('protocol/img/logos/firefox/lockwise/logo-md.png') }}" height="40" width="40"><br>
@@ -165,6 +167,7 @@
       </div>
     </div>
 
+  {% if switch('firefox-send-active') %}
     <div class="mzp-l-content">
         {% call feature_card(
           title=ftl('firefox-home-firefox-send'),
@@ -179,6 +182,7 @@
         <h4>{{ ftl('firefox-home-share-large-files-without') }}</h4>
         {% endcall %}
     </div>
+  {% endif %}
 
     <div class="mzp-l-content">
         {% call feature_card(
@@ -217,12 +221,14 @@
                   {{ ftl('firefox-home-monitor') }}
                 </a>
               </li>
+            {% if switch('firefox-send-active') %}
               <li>
                 <a class="mzp-c-cta-link" href="https://send.firefox.com/{{ referrals }}" rel="external noopener" data-cta-type="link" data-cta-text="Send">
                   <img alt="" src="{{ static('protocol/img/logos/firefox/send/logo-md.png') }}" height="40" width="40"><br>
                   {{ ftl('firefox-home-send') }}
                 </a>
               </li>
+            {% endif %}
               <li>
                 <a class="mzp-c-cta-link" href="{{ url('firefox.products.lockwise') }}{{ referrals }}" rel="external noopener" data-cta-type="link" data-cta-text="Lockwise">
                   <img alt="" src="{{ static('protocol/img/logos/firefox/lockwise/logo-md.png') }}" height="40" width="40"><br>

--- a/bedrock/firefox/templates/firefox/accounts.html
+++ b/bedrock/firefox/templates/firefox/accounts.html
@@ -100,7 +100,7 @@
       {% endif %}
     </h2>
 
-    <ul class="c-product-list">
+    <ul class="c-product-list {% if switch('firefox-send-active') %}l-columns-two{% else %}l-columns-three{% endif %}">
       <li class="c-product-list-item t-product-firefox">
         <a href="{{ url('firefox.new') }}">
           <h3 class="c-product-list-title">{{ ftl('firefox-accounts-firefox-browser') }}</h3>
@@ -119,12 +119,14 @@
           <p class="c-product-list-desc">{{ ftl('firefox-accounts-get-a-lookout-for') }}</p>
         </a>
       </li>
+    {% if switch('firefox-send-active') %}
       <li class="c-product-list-item t-product-send">
         <a href="https://send.firefox.com?utm_source={{ _utm_source }}&amp;utm_medium=referral&amp;utm_campaign={{ _utm_campaign }}&amp;utm_content=product-list-item&amp;entrypoint={{ _entrypoint }}" data-cta-text="Firefox Send" data-cta-type="FxA-Sync">
           <h3 class="c-product-list-title">{{ ftl('firefox-accounts-firefox-send') }}</h3>
           <p class="c-product-list-desc">{{ ftl('firefox-accounts-share-large-files') }}</p>
         </a>
       </li>
+    {% endif %}
     </ul>
 
     <p class="c-accounts-products-tagline">

--- a/bedrock/firefox/templates/firefox/home/index-master.html
+++ b/bedrock/firefox/templates/firefox/home/index-master.html
@@ -74,12 +74,14 @@
               {{ ftl('firefox-home-monitor') }}
             </a>
           </li>
+        {% if switch('firefox-send-active') %}
           <li>
             <a class="mzp-c-cta-link" href="https://send.firefox.com/{{ referrals }}" rel="external noopener" data-cta-type="link" data-cta-text="Send">
               <img alt="" src="{{ static('protocol/img/logos/firefox/send/logo-md.png') }}" height="40" width="40"><br>
               {{ ftl('firefox-home-send') }}
             </a>
           </li>
+        {% endif %}
           <li>
               <a class="mzp-c-cta-link" href="{{ url('firefox.products.lockwise') }}" rel="external noopener" data-cta-type="link" data-cta-text="Lockwise">
                 <img alt="" src="{{ static('protocol/img/logos/firefox/lockwise/logo-md.png') }}" height="40" width="40"><br>
@@ -180,6 +182,7 @@
       </div>
     </div>
 
+  {% if switch('firefox-send-active') %}
     <div class="mzp-l-content">
         {% call feature_card(
           title=ftl('firefox-home-firefox-send'),
@@ -194,6 +197,7 @@
         <h4>{{ ftl('firefox-home-share-large-files-without') }}</h4>
         {% endcall %}
     </div>
+  {% endif %}
 
     <div class="mzp-l-content">
         {% call feature_card(
@@ -232,12 +236,14 @@
                   {{ ftl('firefox-home-monitor') }}
                 </a>
               </li>
+            {% if switch('firefox-send-active') %}
               <li>
                 <a class="mzp-c-cta-link" href="https://send.firefox.com/{{ referrals }}" rel="external noopener" data-cta-type="link" data-cta-text="Send">
                   <img alt="" src="{{ static('protocol/img/logos/firefox/send/logo-md.png') }}" height="40" width="40"><br>
                   {{ ftl('firefox-home-send') }}
                 </a>
               </li>
+            {% endif %}
               <li>
                 <a class="mzp-c-cta-link" href="{{ url('firefox.products.lockwise') }}{{ referrals }}" rel="external noopener" data-cta-type="link" data-cta-text="Lockwise">
                   <img alt="" src="{{ static('protocol/img/logos/firefox/lockwise/logo-md.png') }}" height="40" width="40"><br>

--- a/bedrock/firefox/templates/firefox/privacy/products.html
+++ b/bedrock/firefox/templates/firefox/privacy/products.html
@@ -133,6 +133,7 @@
         </p>
       {% endcall %}
 
+    {% if switch('firefox-send-active') %}
       {% call feature_card(
         title=ftl('firefox-privacy-hub-firefox-send'),
         image_url='img/firefox/privacy/products/send.svg',
@@ -146,12 +147,18 @@
           </a>
         </p>
       {% endcall %}
+    {% endif %}
+
+      {% set pocket_card_layout_class = 'privacy-products-pocket has-logo mzp-l-card-feature-left-half' %}
+    {% if switch('firefox-send-active') %}
+      {% set pocket_card_layout_class = 'privacy-products-pocket has-logo mzp-l-card-feature-right-half' %}
+    {% endif %}
 
       {% call feature_card(
         title=ftl('firefox-privacy-hub-pocket'),
         image_url='img/firefox/privacy/products/pocket.png',
         include_highres_image=True,
-        class='privacy-products-pocket has-logo mzp-l-card-feature-right-half',
+        class=pocket_card_layout_class,
         media_after=True
       ) %}
         <p>{{ ftl('firefox-privacy-hub-pocket-recommends-high') }}</p>

--- a/bedrock/firefox/templates/firefox/products/index.html
+++ b/bedrock/firefox/templates/firefox/products/index.html
@@ -93,12 +93,14 @@
       </div>
       <p><a class="mzp-c-cta-link" href="{{ url('firefox.products.lockwise') }}" rel="external noopener" data-cta-type="link" data-cta-text="Lockwise Learn More">{{ ftl('firefox-products-learn-more-about-lockwise') }}</a></p>
     </div>
+  {% if switch('firefox-send-active') %}
     <div class="c-landing-grid-item">
       <img src="{{ static('img/firefox/products/send.svg') }}" class="c-landing-grid-img" alt="" width="316" height="223">
       <h2 class="c-landing-grid-title"><a href="https://send.firefox.com{{ referrals }}">{{ ftl('firefox-products-firefox-send') }}</a></h2>
       <p>{{ ftl('firefox-products-send-your-large-files-and') }}</p>
       <p><a class="mzp-c-cta-link" href="https://send.firefox.com{{ referrals }}" data-cta-type="link" data-cta-text="Send a file">{{ ftl('firefox-products-send-a-file') }}</a></p>
     </div>
+  {% endif %}
     <div class="c-landing-grid-item">
       <img src="{{ static('img/firefox/products/pocket.svg') }}" class="c-landing-grid-img" alt="" width="316" height="223">
       <h2 class="c-landing-grid-title"><a href="https://send.firefox.com{{ referrals }}">{{ ftl('firefox-products-pocket') }}</a></h2>

--- a/bedrock/firefox/templates/firefox/welcome/page3.html
+++ b/bedrock/firefox/templates/firefox/welcome/page3.html
@@ -77,7 +77,7 @@
         <p>{{ ftl('welcome-page3-trade-clickbait-and-fake-news') }}</p>
       </div>
     </div>
-
+  {% if switch('firefox-send-active') %}
     <div class="c-picto-block t-adjacent-image">
       <div class="c-picto-block-image">
         <img src="{{ static('protocol/img/logos/firefox/send/logo.svg') }}" alt="">
@@ -87,6 +87,7 @@
         <p>{{ ftl('welcome-page3-send-huge-files-to-anyone') }}</p>
       </div>
     </div>
+  {% endif %}
   </div>
 {% endblock %}
 

--- a/media/css/exp/firefox/accounts.scss
+++ b/media/css/exp/firefox/accounts.scss
@@ -3,11 +3,12 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 @import '../../../protocol/css/includes/lib';
+@import '../../../protocol/css/components/emphasis-box';
 @import '../../protocol/components/fxa-form';
 
 .c-section-title {
     @include text-title-md;
-    max-width: $content-sm;
+    max-width: $content-sm + $layout-xl;
     margin: 0 auto $layout-xl;
     text-align: center;
 }
@@ -102,15 +103,11 @@
 // FxA signup form
 
 .c-accounts-form {
-    background: $color-white;
-    border-radius: $border-radius-md;
-    box-shadow: $box-shadow-md;
     margin: $layout-lg auto 0;
     max-width: 330px;
-    padding: $spacing-lg;
     text-align: center;
 
-    .fxa-email-form-title {
+    .mzp-c-form-heading {
         @include text-title-sm;
     }
 
@@ -118,13 +115,8 @@
         display: none;
     }
 
-    .mzp-c-button {
-        width: 100%;
-    }
-
     .fxa-signin {
-        @include text-body-sm;
-        margin-top: $spacing-lg;
+        margin-bottom: 0;
     }
 
     @media #{$mq-lg} {
@@ -142,22 +134,36 @@
 // Products
 
 .c-product-list {
-    max-width: $content-md;
     margin: $spacing-2xl auto;
+    max-width: $content-sm;
 
-    @media #{$mq-sm} {
+    @media #{$mq-md} {
         @supports (display: grid) {
-            display: grid;
-            grid-template-columns: repeat(2, 1fr);
-            grid-gap: $layout-md $layout-lg;
+            &.l-columns-two {
+                display: grid;
+                grid-gap: $layout-md;
+                grid-template-columns: repeat(2, 1fr);
+                max-width: $content-md;
+            }
+        }
+    }
+
+    @media #{$mq-lg} {
+        @supports (display: grid) {
+            &.l-columns-three {
+                display: grid;
+                grid-gap: $layout-md;
+                grid-template-columns: repeat(3, 1fr);
+                max-width: $content-lg;
+            }
         }
     }
 }
 
 .c-product-list-item {
     margin: 0 auto $layout-lg;
-    text-align: center;
     max-width: $content-xs;
+    text-align: center;
 
     a:link,
     a:visited {
@@ -181,10 +187,10 @@
         }
     }
 
-    @media #{$mq-sm} {
-        @include bidi(((text-align, left, right),));
-
+    @media #{$mq-lg} {
         @supports (display: grid) {
+            @include bidi(((text-align, left, right),));
+            max-width: none;
             margin: 0;
         }
     }
@@ -214,13 +220,9 @@
         @include at2x('/media/protocol/img/logos/firefox/send/logo-word-hor-stack-md.png', 130px, 50px);
     }
 
-    @media #{$mq-sm} {
-        @include bidi(((background-position, left top, right top),));
-        margin: 0 0 $spacing-lg;
-    }
-
     @media #{$mq-md} {
         height: 64px;
+        margin: 0 0 $spacing-lg;
 
         .t-product-firefox & {
             @include background-size(184px,  64px);

--- a/media/css/firefox/accounts-2019.scss
+++ b/media/css/firefox/accounts-2019.scss
@@ -8,7 +8,7 @@
 
 .c-section-title {
     @include text-title-md;
-    max-width: $content-sm;
+    max-width: $content-sm + $layout-xl;
     margin: 0 auto $layout-xl;
     text-align: center;
 }
@@ -134,22 +134,36 @@
 // Products
 
 .c-product-list {
-    max-width: $content-md;
     margin: $spacing-2xl auto;
+    max-width: $content-sm;
 
-    @media #{$mq-sm} {
+    @media #{$mq-md} {
         @supports (display: grid) {
-            display: grid;
-            grid-template-columns: repeat(2, 1fr);
-            grid-gap: $layout-md $layout-lg;
+            &.l-columns-two {
+                display: grid;
+                grid-gap: $layout-md;
+                grid-template-columns: repeat(2, 1fr);
+                max-width: $content-md;
+            }
+        }
+    }
+
+    @media #{$mq-lg} {
+        @supports (display: grid) {
+            &.l-columns-three {
+                display: grid;
+                grid-gap: $layout-md;
+                grid-template-columns: repeat(3, 1fr);
+                max-width: $content-lg;
+            }
         }
     }
 }
 
 .c-product-list-item {
     margin: 0 auto $layout-lg;
-    text-align: center;
     max-width: $content-xs;
+    text-align: center;
 
     a:link,
     a:visited {
@@ -173,10 +187,10 @@
         }
     }
 
-    @media #{$mq-sm} {
-        @include bidi(((text-align, left, right),));
-
+    @media #{$mq-lg} {
         @supports (display: grid) {
+            @include bidi(((text-align, left, right),));
+            max-width: none;
             margin: 0;
         }
     }
@@ -206,13 +220,9 @@
         @include at2x('/media/protocol/img/logos/firefox/send/logo-word-hor-stack-md.png', 130px, 50px);
     }
 
-    @media #{$mq-sm} {
-        @include bidi(((background-position, left top, right top),));
-        margin: 0 0 $spacing-lg;
-    }
-
     @media #{$mq-md} {
         height: 64px;
+        margin: 0 0 $spacing-lg;
 
         .t-product-firefox & {
             @include background-size(184px,  64px);
@@ -230,6 +240,13 @@
             @include background-size(167px, 64px);
         }
     }
+
+    @media #{$mq-lg} {
+        @supports (display: grid) {
+            @include bidi(((background-position, left top, right top),));
+        }
+    }
+
 }
 
 .c-product-list-desc {


### PR DESCRIPTION
## Description
Removes promotional references/links to Firefox Send, hiding them temporarily behind the switch `firefox-send-active`. Send is hidden by default when the switch is OFF, so we can quickly switch it ON and unhide Send when/if Send becomes available again (and we'd follow that up with some cleanup to remove the switch and make it permanent again).

## Issue / Bugzilla link
#9316 

## Testing
Note that the switch hides Send when it's OFF and switches are treated as ON in dev mode. You'll need to test locally in prod mode to verify it's hidden.

Send should be removed from:

Main nav
Footer
http://localhost:8000/firefox/
http://localhost:8000/exp/firefox/
http://localhost:8000/firefox/products/
http://localhost:8000/firefox/accounts/
http://localhost:8000/exp/firefox/accounts/
http://localhost:8000/firefox/privacy/products/
http://localhost:8000/firefox/welcome/3/
