### PR TITLE
adding 2020 funding update section to index page

### DIFF
--- a/bedrock/mozorg/templates/mozorg/moss/index.html
+++ b/bedrock/mozorg/templates/mozorg/moss/index.html
@@ -26,6 +26,18 @@
   </div>
 </div>
 
+<div class="t-medium">
+  <section class="mzp-l-content moss-section">
+    <h2 class="moss-section-heading">{{ _('2020 Funding Update') }}</h2>
+
+    <p>
+    {% trans blogpost='https://blog.mozilla.org/blog/2020/08/11/changing-world-changing-mozilla/' %}
+      Due to the <a href="{{ blogpost }}">recently-announced restructuring at Mozilla</a>, MOSS is not currently accepting applications and will not be making any new awards this year. We are conducting a comprehensive review of the program and hope to share information about future award cycles in 2021.
+    {% endtrans %}
+    </p>
+  </section>
+</div>
+
 <section>
   <div class="t-medium">
     <div class="mzp-l-content">


### PR DESCRIPTION
## Description

Just adding a section on the main page of the MOSS sub-site to let folks know that our application is currently closed as a result of MoCo restructuring. Thanks!
