### PR TITLE
Only one h1 on /firefox/new/ (Fixes #9330)

### DIFF
--- a/bedrock/exp/templates/exp/firefox/new/download.html
+++ b/bedrock/exp/templates/exp/firefox/new/download.html
@@ -471,7 +471,7 @@
     <div class="c-mobile">
       <div class="mzp-l-content">
         <div class="c-mobile-text">
-          <h1 class="c-logo t-browser-word-hor-white-xs">{{ ftl('firefox-desktop-download-firefox-browser') }}</h1>
+          <h2 class="c-logo t-browser-word-hor-white-xs">{{ ftl('firefox-desktop-download-firefox-browser') }}</h2>
           <h2 class="mzp-has-zap-7 mzp-u-title-md show-android">{{ ftl('firefox-desktop-download-get-firefox-android') }}</h2>
           <h2 class="mzp-has-zap-7 mzp-u-title-md show-ios">{{ ftl('firefox-desktop-download-get-firefox-ios') }}</h2>
 

--- a/bedrock/firefox/templates/firefox/new/desktop/download.html
+++ b/bedrock/firefox/templates/firefox/new/desktop/download.html
@@ -460,7 +460,7 @@
     <div class="c-mobile">
       <div class="mzp-l-content">
         <div class="c-mobile-text">
-          <h1 class="c-logo t-browser-word-hor-white-xs">{{ ftl('firefox-desktop-download-firefox-browser') }}</h1>
+          <h2 class="c-logo t-browser-word-hor-white-xs">{{ ftl('firefox-desktop-download-firefox-browser') }}</h2>
           <h2 class="mzp-has-zap-7 mzp-u-title-md show-android">{{ ftl('firefox-desktop-download-get-firefox-android') }}</h2>
           <h2 class="mzp-has-zap-7 mzp-u-title-md show-ios">{{ ftl('firefox-desktop-download-get-firefox-ios') }}</h2>
 


### PR DESCRIPTION
## Description
Change the mobile banner product heading from an h1 to h2.

## Issue / Bugzilla link
#9330

## Testing
- [ ] Mobile banner heading should visually look the same after the change.