### PR TITLE
Make simplified download button (Fixes #8860)

### DIFF
--- a/bedrock/base/templates/includes/protocol/navigation/nav-cta.html
+++ b/bedrock/base/templates/includes/protocol/navigation/nav-cta.html
@@ -5,7 +5,7 @@
 {% if not hide_nav_cta %}
   <div class="mzp-c-navigation-download">
     {% if not hide_nav_download_button %}
-      {{ download_firefox(alt_copy=ftl('download-button-download-firefox'), dom_id='protocol-nav-download-firefox', button_class='mzp-t-secondary mzp-t-md', download_location='nav') }}
+      {{ download_firefox_thanks(alt_copy=ftl('download-button-download-firefox'), dom_id='protocol-nav-download-firefox', button_class='mzp-t-secondary mzp-t-md', download_location='nav') }}
     {% endif %}
     {% if not hide_nav_get_account_button %}
     <div class="c-navigation-fxa-cta-container">

--- a/bedrock/exp/templates/exp/firefox/new/download.html
+++ b/bedrock/exp/templates/exp/firefox/new/download.html
@@ -59,7 +59,7 @@
         <p>{{ ftl('firefox-desktop-download-no-shady') }}</p>
 
         <div class="c-intro-download">
-          {{ download_firefox(locale_in_transition=True, download_location='primary cta') }}
+          {{ download_firefox_thanks(locale_in_transition=True, download_location='primary cta') }}
 
           <div class="c-intro-download-alt"><a href="{{ url('firefox.all') }}">{{ ftl('firefox-desktop-download-download-options') }}</a></div>
 

--- a/bedrock/exp/templates/exp/home/home-de.html
+++ b/bedrock/exp/templates/exp/home/home-de.html
@@ -28,7 +28,7 @@
     title=_('Echte Privatsphäre statt leerer Versprechen'),
     desc=_('Hol dir die Kontrolle über deine Privatsphäre auf jedes Gerät.'),
     ) %}
-    {{ download_firefox(dom_id='download-primary', download_location='primary cta') }}
+    {{ download_firefox_thanks(dom_id='download-primary', download_location='primary cta') }}
   {% endcall %}
 
   {{ fxa_banner(
@@ -105,7 +105,7 @@
     title=_('Bestimme selbst, was du teilst und mit wem.'),
     sub_title=_('Hol dir den Browser, der Tracker automatisch blockiert.')
   ) %}
-    {{ download_firefox(dom_id='download-secondary', download_location='secondary cta') }}
+    {{ download_firefox_thanks(dom_id='download-secondary', download_location='secondary cta') }}
   {% endcall %}
 
   {% call call_out_compact(

--- a/bedrock/exp/templates/exp/home/home-en.html
+++ b/bedrock/exp/templates/exp/home/home-en.html
@@ -68,7 +68,7 @@
     title=_('Take back your privacy'),
     desc=_('Get the browser that blocks 2000+ trackers — automatically'),
     ) %}
-    {{ download_firefox(dom_id='download-primary', download_location='primary cta') }}
+    {{ download_firefox_thanks(dom_id='download-primary', download_location='primary cta') }}
   {% endcall %}
 
   {{ fxa_banner(
@@ -194,7 +194,7 @@
     title=_('Privacy over profit'),
     sub_title=_('No shareholders. No data for sale.')
   ) %}
-    {{ download_firefox(dom_id='download-secondary', download_location='secondary cta') }}
+    {{ download_firefox_thanks(dom_id='download-secondary', download_location='secondary cta') }}
   {% endcall %}
 
   {% call call_out_compact(

--- a/bedrock/exp/templates/exp/home/home-fr.html
+++ b/bedrock/exp/templates/exp/home/home-fr.html
@@ -28,7 +28,7 @@ Le saviez-vous ? Mozilla, le concepteur de Firefox, se bat pour qu’Internet, u
     title='Nous ne mettons pas le nez dans vos données.',
     desc='Le respect de votre vie privée est notre priorité. Notre modèle financier ne dépendra jamais de la vente et de l’utilisation de vos données personnelles.',
     ) %}
-    {{ download_firefox(dom_id='download-primary', download_location='primary cta') }}
+    {{ download_firefox_thanks(dom_id='download-primary', download_location='primary cta') }}
   {% endcall %}
 
   {{ fxa_banner(
@@ -104,7 +104,7 @@ Le saviez-vous ? Mozilla, le concepteur de Firefox, se bat pour qu’Internet, u
     title='Retrouvez le respect que vous méritez.',
     sub_title='Parcourir Internet avec Firefox, c’est adopter des technologies conçues pour protéger vos données personnelles.'
   ) %}
-    {{ download_firefox(dom_id='download-secondary', download_location='secondary cta') }}
+    {{ download_firefox_thanks(dom_id='download-secondary', download_location='secondary cta') }}
   {% endcall %}
 
   {% call call_out_compact(

--- a/bedrock/firefox/templates/firefox/includes/download-button-thanks.html
+++ b/bedrock/firefox/templates/firefox/includes/download-button-thanks.html
@@ -1,0 +1,19 @@
+<div class="mzp-c-button-download-container c-button-download-thanks">
+  <a href="{{ transition_url }}"
+     id="{{ id }}"
+     class="mzp-c-button mzp-t-product {% if button_class %}{{ button_class }}{% else %}mzp-t-xl{% endif %}"
+     data-direct-link="{{ download_link_direct }}"
+     data-link-type="download"
+     {% if download_location %}data-download-location="{{ download_location }}"{% endif %}>
+    {% if alt_copy %}
+      {{ alt_copy }}
+    {% else %}
+      {{ ftl('download-button-download-firefox') }}
+    {% endif %}
+  </a>
+  <small class="mzp-c-button-download-privacy-link">
+    <a href="{{ url('privacy.notices.firefox') }}">
+      {{ ftl('download-button-firefox-privacy-notice') }}
+    </a>
+  </small>
+</div>

--- a/bedrock/firefox/templates/firefox/includes/download-button-thanks.html
+++ b/bedrock/firefox/templates/firefox/includes/download-button-thanks.html
@@ -1,7 +1,6 @@
-<div class="mzp-c-button-download-container c-button-download-thanks">
+<div id="{{ id }}" class="mzp-c-button-download-container c-button-download-thanks">
   <a href="{{ transition_url }}"
-     id="{{ id }}"
-     class="mzp-c-button mzp-t-product {% if button_class %}{{ button_class }}{% else %}mzp-t-xl{% endif %}"
+     class="download-link mzp-c-button mzp-t-product {% if button_class %}{{ button_class }}{% else %}mzp-t-xl{% endif %}"
      data-direct-link="{{ download_link_direct }}"
      data-link-type="download"
      {% if download_location %}data-download-location="{{ download_location }}"{% endif %}>

--- a/bedrock/firefox/templates/firefox/new/desktop/download.html
+++ b/bedrock/firefox/templates/firefox/new/desktop/download.html
@@ -48,7 +48,7 @@
         <p>{{ ftl('firefox-desktop-download-no-shady') }}</p>
 
         <div class="c-intro-download">
-          {{ download_firefox(locale_in_transition=True, download_location='primary cta') }}
+          {{ download_firefox_thanks(locale_in_transition=True, download_location='primary cta') }}
 
           <div class="c-intro-download-alt"><a href="{{ url('firefox.all') }}">{{ ftl('firefox-desktop-download-download-options') }}</a></div>
 
@@ -314,7 +314,7 @@
         </div>
       </div>
 
-      {{ download_firefox(dom_id='download-features', locale_in_transition=True, download_location='features cta') }}
+      {{ download_firefox_thanks(dom_id='download-features', locale_in_transition=True, download_location='features cta') }}
 
     </div>
   </section>
@@ -448,7 +448,7 @@
       </div>
     </div>
 
-    {{ download_firefox(dom_id='download-discover', locale_in_transition=True, download_location='discover cta') }}
+    {{ download_firefox_thanks(dom_id='download-discover', locale_in_transition=True, download_location='discover cta') }}
   </section>
 
   <section class="c-support">
@@ -491,7 +491,7 @@
 
   <a href="{{ url('firefox.accounts') }}" class="mzp-c-button mzp-t-product join-firefox-button" data-link-name="Get More From Firefox" data-link-type="button">{{ ftl('firefox-desktop-download-get-more-from-firefox') }}</a>
 
-  {{ download_firefox(dom_id='download-join-firefox-modal', alt_copy=ftl('firefox-desktop-download-just-download-the-browser'), button_class='mzp-t-secondary', locale_in_transition=True, download_location='other') }}
+  {{ download_firefox_thanks(dom_id='download-join-firefox-modal', alt_copy=ftl('firefox-desktop-download-just-download-the-browser'), button_class='mzp-t-secondary', locale_in_transition=True, download_location='other') }}
 </aside>
 {% endif %}
 

--- a/bedrock/firefox/templatetags/helpers.py
+++ b/bedrock/firefox/templatetags/helpers.py
@@ -175,6 +175,59 @@ def download_firefox(ctx, channel='release', platform='all',
 
 @library.global_function
 @jinja2.contextfunction
+def download_firefox_thanks(ctx, dom_id=None, locale=None, alt_copy=None, button_class=None,
+                            locale_in_transition=False, download_location=None):
+    """ Output a simple "download firefox" button that only points to /download/thanks/
+
+    :param ctx: context from calling template.
+    :param dom_id: Use this string as the id attr on the element.
+    :param locale: The locale of the download. Default to locale of request.
+    :param alt_copy: Specifies alternate copy to use for download buttons.
+    :param button_class: Classes to add to the download button, contains size mzp-t-xl by default
+    :param locale_in_transition: Include the page locale in transitional download link.
+    :param download_location: Specify the location of download button for
+            GA reporting: 'primary cta', 'nav', 'sub nav', or 'other'.
+    """
+
+    channel = 'release'
+    locale = locale or get_locale(ctx['request'])
+    funnelcake_id = ctx.get('funnelcake_id', False)
+    dom_id = dom_id or 'download-button-thanks'
+    transition_url = '/firefox/download/thanks/'
+    version = firefox_desktop.latest_version(channel)
+
+    if funnelcake_id:
+        # include funnelcake in /download/thanks/ URL
+        transition_url += '?f=%s' % funnelcake_id
+
+    if locale_in_transition:
+        transition_url = '/%s%s' % (locale, transition_url)
+
+    download_link_direct = firefox_desktop.get_download_url(
+        channel, version, 'win', locale,
+        force_direct=True,
+        force_full_installer=False,
+        force_funnelcake=False,
+        funnelcake_id=funnelcake_id,
+    )
+
+    data = {
+        'id': dom_id,
+        'transition_url': transition_url,
+        'download_link_direct': download_link_direct,
+        'alt_copy': alt_copy,
+        'button_class': button_class,
+        'download_location': download_location,
+        'fluent_l10n': ctx['fluent_l10n']
+    }
+
+    html = render_to_string('firefox/includes/download-button-thanks.html', data,
+                            request=ctx['request'])
+    return jinja2.Markup(html)
+
+
+@library.global_function
+@jinja2.contextfunction
 def download_firefox_desktop_list(ctx, channel='release', dom_id=None, locale=None,
                                   force_full_installer=False):
     """

--- a/bedrock/firefox/templatetags/helpers.py
+++ b/bedrock/firefox/templatetags/helpers.py
@@ -196,8 +196,9 @@ def download_firefox_thanks(ctx, dom_id=None, locale=None, alt_copy=None, button
     transition_url = '/firefox/download/thanks/'
     version = firefox_desktop.latest_version(channel)
 
+    # if there's a funnelcake param in the page URL e.g. ?f=123
     if funnelcake_id:
-        # include funnelcake in /download/thanks/ URL
+        # include param in transitional URL e.g. /firefox/download/thanks/?f=123
         transition_url += '?f=%s' % funnelcake_id
 
     if locale_in_transition:

--- a/bedrock/firefox/tests/test_helpers.py
+++ b/bedrock/firefox/tests/test_helpers.py
@@ -310,6 +310,57 @@ class TestDownloadButtons(TestCase):
         assert pq(list[0]).attr('class') == 'os_ios'
 
 
+class TestDownloadThanksButton(TestCase):
+
+    def get_l10n(self, locale):
+        return fluent_l10n([locale, 'en'], settings.FLUENT_DEFAULT_FILES)
+
+    def test_download_firefox_thanks_button(self):
+        """
+        Download link should point to /firefox/download/thanks/
+        """
+        rf = RequestFactory()
+        get_request = rf.get('/fake')
+        get_request.locale = 'en-US'
+        doc = pq(render("{{ download_firefox_thanks() }}",
+                        {'request': get_request, 'fluent_l10n': self.get_l10n(get_request.locale)}))
+
+        links = doc('.c-button-download-thanks > a')
+        assert links.length == 1
+
+        link = pq(links)
+        href = link.attr('href')
+
+        assert href == ('/firefox/download/thanks/')
+        assert link.attr('id') == 'download-button-thanks'
+        assert link.attr('data-link-type') == 'download'
+
+        # Direct attribute for legacy IE browsers should always be win 32bit
+        assert link.attr('data-direct-link') == 'https://download.mozilla.org/?product=firefox-stub&os=win&lang=en-US'
+
+    def test_download_firefox_thanks_attributes(self):
+        """
+        Download link should support custom attributes
+        """
+        rf = RequestFactory()
+        get_request = rf.get('/fake')
+        get_request.locale = 'en-US'
+        doc = pq(render("{{ download_firefox_thanks(dom_id='test-download', button_class='test-css-class', "
+                        "download_location='primary cta', locale_in_transition=True) }}",
+                        {'request': get_request, 'fluent_l10n': self.get_l10n(get_request.locale)}))
+
+        links = doc('.c-button-download-thanks > a')
+        assert links.length == 1
+
+        link = pq(links)
+        href = link.attr('href')
+
+        assert href == ('/en-US/firefox/download/thanks/')
+        assert link.attr('id') == 'test-download'
+        assert link.attr('data-download-location') == 'primary cta'
+        assert 'test-css-class' in link.attr('class')
+
+
 class TestDownloadList(TestCase):
 
     def latest_version(self):

--- a/bedrock/firefox/tests/test_helpers.py
+++ b/bedrock/firefox/tests/test_helpers.py
@@ -332,7 +332,7 @@ class TestDownloadThanksButton(TestCase):
         link = pq(links)
         href = link.attr('href')
 
-        assert href == ('/firefox/download/thanks/')
+        assert href == '/firefox/download/thanks/'
         assert button.attr('id') == 'download-button-thanks'
         assert link.attr('data-link-type') == 'download'
 
@@ -357,7 +357,7 @@ class TestDownloadThanksButton(TestCase):
         link = pq(links)
         href = link.attr('href')
 
-        assert href == ('/en-US/firefox/download/thanks/')
+        assert href == '/en-US/firefox/download/thanks/'
         assert button.attr('id') == 'test-download'
         assert link.attr('data-download-location') == 'primary cta'
         assert 'test-css-class' in link.attr('class')

--- a/bedrock/firefox/tests/test_helpers.py
+++ b/bedrock/firefox/tests/test_helpers.py
@@ -325,14 +325,15 @@ class TestDownloadThanksButton(TestCase):
         doc = pq(render("{{ download_firefox_thanks() }}",
                         {'request': get_request, 'fluent_l10n': self.get_l10n(get_request.locale)}))
 
-        links = doc('.c-button-download-thanks > a')
+        button = doc('.c-button-download-thanks')
+        links = doc('.c-button-download-thanks > .download-link')
         assert links.length == 1
 
         link = pq(links)
         href = link.attr('href')
 
         assert href == ('/firefox/download/thanks/')
-        assert link.attr('id') == 'download-button-thanks'
+        assert button.attr('id') == 'download-button-thanks'
         assert link.attr('data-link-type') == 'download'
 
         # Direct attribute for legacy IE browsers should always be win 32bit
@@ -349,14 +350,15 @@ class TestDownloadThanksButton(TestCase):
                         "download_location='primary cta', locale_in_transition=True) }}",
                         {'request': get_request, 'fluent_l10n': self.get_l10n(get_request.locale)}))
 
-        links = doc('.c-button-download-thanks > a')
+        button = doc('.c-button-download-thanks')
+        links = doc('.c-button-download-thanks > .download-link')
         assert links.length == 1
 
         link = pq(links)
         href = link.attr('href')
 
         assert href == ('/en-US/firefox/download/thanks/')
-        assert link.attr('id') == 'test-download'
+        assert button.attr('id') == 'test-download'
         assert link.attr('data-download-location') == 'primary cta'
         assert 'test-css-class' in link.attr('class')
 

--- a/bedrock/mozorg/templates/mozorg/home/home-de.html
+++ b/bedrock/mozorg/templates/mozorg/home/home-de.html
@@ -31,7 +31,7 @@
     title=_('Echte Privatsphäre statt leerer Versprechen'),
     desc=_('Hol dir die Kontrolle über deine Privatsphäre auf jedes Gerät.'),
     ) %}
-    {{ download_firefox(dom_id='download-primary', download_location='primary cta') }}
+    {{ download_firefox_thanks(dom_id='download-primary', download_location='primary cta') }}
   {% endcall %}
 
   {{ fxa_banner(
@@ -108,7 +108,7 @@
     title=_('Bestimme selbst, was du teilst und mit wem.'),
     sub_title=_('Hol dir den Browser, der Tracker automatisch blockiert.')
   ) %}
-    {{ download_firefox(dom_id='download-secondary', download_location='secondary cta') }}
+    {{ download_firefox_thanks(dom_id='download-secondary', download_location='secondary cta') }}
   {% endcall %}
 
   {% call call_out_compact(

--- a/bedrock/mozorg/templates/mozorg/home/home-en.html
+++ b/bedrock/mozorg/templates/mozorg/home/home-en.html
@@ -185,7 +185,7 @@
     title=_('Privacy over profit'),
     sub_title=_('No shareholders. No data for sale.')
   ) %}
-    {{ download_firefox(dom_id='download-secondary', download_location='secondary cta') }}
+    {{ download_firefox_thanks(dom_id='download-secondary', download_location='secondary cta') }}
   {% endcall %}
 
   {% call call_out_compact(

--- a/bedrock/mozorg/templates/mozorg/home/home-fr.html
+++ b/bedrock/mozorg/templates/mozorg/home/home-fr.html
@@ -32,7 +32,7 @@ Le saviez-vous ? Mozilla, le concepteur de Firefox, se bat pour qu’Internet, u
     title='Nous ne mettons pas le nez dans vos données.',
     desc='Le respect de votre vie privée est notre priorité. Notre modèle financier ne dépendra jamais de la vente et de l’utilisation de vos données personnelles.',
     ) %}
-    {{ download_firefox(dom_id='download-primary', download_location='primary cta') }}
+    {{ download_firefox_thanks(dom_id='download-primary', download_location='primary cta') }}
   {% endcall %}
 
   {{ fxa_banner(
@@ -108,7 +108,7 @@ Le saviez-vous ? Mozilla, le concepteur de Firefox, se bat pour qu’Internet, u
     title='Retrouvez le respect que vous méritez.',
     sub_title='Parcourir Internet avec Firefox, c’est adopter des technologies conçues pour protéger vos données personnelles.'
   ) %}
-    {{ download_firefox(dom_id='download-secondary', download_location='secondary cta') }}
+    {{ download_firefox_thanks(dom_id='download-secondary', download_location='secondary cta') }}
   {% endcall %}
 
   {% call call_out_compact(

--- a/bedrock/mozorg/templates/mozorg/home/home.html
+++ b/bedrock/mozorg/templates/mozorg/home/home.html
@@ -62,7 +62,7 @@ accessible to all.') }}
     browse.') }}
   </p>
 
-  {{ download_firefox(dom_id='download-intro', download_location='primary cta') }}
+  {{ download_firefox_thanks(dom_id='download-intro', download_location='primary cta') }}
   {% endcall %}
 
   <div class="mzp-l-content mzp-t-mozilla">

--- a/docs/download-buttons.rst
+++ b/docs/download-buttons.rst
@@ -1,0 +1,41 @@
+.. This Source Code Form is subject to the terms of the Mozilla Public
+.. License, v. 2.0. If a copy of the MPL was not distributed with this
+.. file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+.. _download-buttons:
+
+========================
+Firefox Download Buttons
+========================
+
+There are two Firefox download button helpers in bedrock to choose from. The first is a lightweight button
+that links directly to the ``/firefox/download/thanks/`` page. Its sole purpose is to facilitate downloading
+the main release version of Firefox.
+
+.. code-block:: jinja
+
+    {{ download_firefox_thanks() }}
+
+The second type of button is more heavy weight, and can be configured to download any build of Firefox (e.g.
+Release, Beta, Developer Edition, Nightly). It can also offer functionality such as direct (in-page) download
+links, so it comes with a lot more complexity and in-page markup.
+
+.. code-block:: jinja
+
+    {{ download_firefox() }}
+
+Which button should I use?
+--------------------------
+
+A good rule of thumb is to always use ``download_firefox_thanks()`` for regular landing pages (such as
+``/firefox/new/``) where the main release version of Firefox is the product being offered. For pages pages
+that require direct download links, or promote pre-release products (such as ``/firefox/channel/``)
+then ``download_firefox()`` should be used instead.
+
+Documentation
+-------------
+
+See `helpers.py`_ for documentation and supported parameters for both buttons.
+
+.. _helpers.py: https://github.com/mozilla/bedrock/blob/master/bedrock/firefox/templatetags/helpers.py
+

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -36,6 +36,7 @@ Contents
    banners
    uitour
    send-to-device
+   download-buttons
    firefox-accounts
    funnelcake
    abtest

--- a/media/css/exp/firefox/new/download.scss
+++ b/media/css/exp/firefox/new/download.scss
@@ -1491,7 +1491,7 @@ button.mzp-c-cta-link {
         margin-bottom: 0;
 
         // Hide the privacy link as there's already a one visible prior to clicking download.
-        .fx-privacy-link {
+        .mzp-c-button-download-privacy-link {
             display: none;
         }
     }

--- a/media/css/firefox/new/desktop/download.scss
+++ b/media/css/firefox/new/desktop/download.scss
@@ -1504,7 +1504,7 @@ button.mzp-c-cta-link {
         margin-bottom: 0;
 
         // Hide the privacy link as there's already a one visible prior to clicking download.
-        .fx-privacy-link {
+        .mzp-c-button-download-privacy-link {
             display: none;
         }
     }

--- a/media/js/base/base-page-init.js
+++ b/media/js/base/base-page-init.js
@@ -22,6 +22,7 @@
         var utils = Mozilla.Utils;
 
         utils.initMobileDownloadLinks();
+        utils.trackDownloadThanksButton();
 
         /* Bug 1264843: In partner distribution of desktop Firefox, switch the
         downloads to corresponding partner build of Firefox for Android. */

--- a/media/js/base/mozilla-utils.js
+++ b/media/js/base/mozilla-utils.js
@@ -21,6 +21,63 @@ if (typeof window.Mozilla === 'undefined') {
         }
     };
 
+    /**
+     * Get GA data attribute values for download_firefox_thanks() buttons.
+     * @param {Object} window.site
+     * @returns {Object} os, name, version
+     */
+    Utils.getDownloadAttributionValues = function(site) {
+        var data = {};
+        var platform = site.platform;
+
+        switch(platform) {
+        case 'windows':
+            data.os = 'Desktop';
+            data.name = site.isARM ? 'Windows ARM64/AArch64' : 'Windows 32-bit';
+            data.version = site.isARM ? 'win64-aarch64': 'win';
+            break;
+        case 'osx':
+            data.os = 'Desktop';
+            data.name = 'macOS';
+            data.version = 'osx';
+            break;
+        case 'linux':
+            data.os = 'Desktop';
+            data.name = site.archSize === 64 ? 'Linux 64-bit' : 'Linux 32-bit';
+            data.version = site.archSize === 64 ? 'linux64': 'linux';
+            break;
+        case 'ios':
+            data.os = 'iOS';
+            data.name = 'iOS';
+            data.version = 'ios';
+            break;
+        case 'android':
+            data.os = 'Android';
+            data.name = 'Android';
+            data.version = 'android';
+            break;
+        }
+
+        return data;
+    };
+
+    /**
+     * Set platfrom specific GA data attributes for download_firefox_thanks() buttons.
+     */
+    Utils.trackDownloadThanksButton = function() {
+        var downloadButton = document.querySelectorAll('.c-button-download-thanks > a');
+        var data = Utils.getDownloadAttributionValues(window.site);
+
+        for (var i = 0; i < downloadButton.length; ++i) {
+
+            if (data && data.os && data.name && data.version) {
+                downloadButton[i].setAttribute('data-display-os', data.os);
+                downloadButton[i].setAttribute('data-display-name', data.name);
+                downloadButton[i].setAttribute('data-download-version', data.version);
+            }
+        }
+    };
+
     // Replace Google Play links on Android devices to let them open the marketplace app
     Utils.initMobileDownloadLinks = function() {
         if (site.platform === 'android') {

--- a/media/js/base/mozilla-utils.js
+++ b/media/js/base/mozilla-utils.js
@@ -65,7 +65,7 @@ if (typeof window.Mozilla === 'undefined') {
      * Set platfrom specific GA data attributes for download_firefox_thanks() buttons.
      */
     Utils.trackDownloadThanksButton = function() {
-        var downloadButton = document.querySelectorAll('.c-button-download-thanks > a');
+        var downloadButton = document.querySelectorAll('.c-button-download-thanks > .download-link');
         var data = Utils.getDownloadAttributionValues(window.site);
 
         for (var i = 0; i < downloadButton.length; ++i) {

--- a/media/js/base/mozilla-utils.js
+++ b/media/js/base/mozilla-utils.js
@@ -71,7 +71,7 @@ if (typeof window.Mozilla === 'undefined') {
         for (var i = 0; i < downloadButton.length; ++i) {
 
             if (data && data.os && data.name && data.version) {
-                downloadButton[i].setAttribute('data-display-os', data.os);
+                downloadButton[i].setAttribute('data-download-os', data.os);
                 downloadButton[i].setAttribute('data-display-name', data.name);
                 downloadButton[i].setAttribute('data-download-version', data.version);
             }

--- a/media/js/base/stub-attribution.js
+++ b/media/js/base/stub-attribution.js
@@ -102,7 +102,7 @@ if (typeof window.Mozilla === 'undefined') {
         }
 
         // target download buttons and other-platforms modal links.
-        $('.download-list .download-link, .download-platform-list .download-link').each(function() {
+        $('.download-list .download-link, .c-button-download-thanks .download-link, .download-platform-list .download-link').each(function() {
             var link = this;
             var version;
             var directLink;

--- a/media/js/firefox/new/desktop/join-modal.js
+++ b/media/js/firefox/new/desktop/join-modal.js
@@ -26,7 +26,7 @@
     }
 
     var initFxAccountModal = function() {
-        var downloadLinkPrimary = document.querySelectorAll('.main-download .download-list .download-link[data-download-os="Desktop"]');
+        var downloadLinkPrimary = document.querySelectorAll('.main-download .c-button-download-thanks > a');
         for (var i = 0; i < downloadLinkPrimary.length; i++) {
             downloadLinkPrimary[i].addEventListener('click', showFxAModal, false);
         }

--- a/media/js/firefox/new/desktop/join-modal.js
+++ b/media/js/firefox/new/desktop/join-modal.js
@@ -26,7 +26,7 @@
     }
 
     var initFxAccountModal = function() {
-        var downloadLinkPrimary = document.querySelectorAll('.main-download .c-button-download-thanks > a');
+        var downloadLinkPrimary = document.querySelectorAll('.main-download .c-button-download-thanks > .download-link');
         for (var i = 0; i < downloadLinkPrimary.length; i++) {
             downloadLinkPrimary[i].addEventListener('click', showFxAModal, false);
         }

--- a/media/js/ie/base-page-init-ie.js
+++ b/media/js/ie/base-page-init-ie.js
@@ -5,6 +5,12 @@
 /**
  * General DOM ready handler applied to all pages in base template.
  */
+
+/* eslint-disable no-jquery/no-class */
+/* eslint-disable no-jquery/no-jquery-constructor */
+/* eslint-disable no-jquery/no-other-methods */
+/* eslint-disable no-jquery/no-ready-shorthand */
+
 $(document).ready(function() {
     'use strict';
 
@@ -18,3 +24,8 @@ $(document).ready(function() {
         $('html').addClass('loaded');
     });
 });
+
+/* eslint-enable no-jquery/no-class */
+/* eslint-enable no-jquery/no-jquery-constructor */
+/* eslint-enable no-jquery/no-other-methods */
+/* eslint-enable no-jquery/no-ready-shorthand */

--- a/media/js/ie/mozilla-utils-ie.js
+++ b/media/js/ie/mozilla-utils-ie.js
@@ -10,6 +10,15 @@ if (typeof window.Mozilla === 'undefined') {
 (function() {
     'use strict';
 
+    /* eslint-disable no-jquery/no-attr */
+    /* eslint-disable no-jquery/no-data */
+    /* eslint-disable no-jquery/no-each-collection */
+    /* eslint-disable no-jquery/no-event-shorthand */
+    /* eslint-disable no-jquery/no-find-collection */
+    /* eslint-disable no-jquery/no-jquery-constructor */
+    /* eslint-disable no-jquery/no-other-methods */
+    /* eslint-disable no-jquery/no-visibility */
+
     var UtilsIE = {};
 
     /**
@@ -27,7 +36,7 @@ if (typeof window.Mozilla === 'undefined') {
     // attach an event to all the download buttons to trigger the special
     // ie functionality if on ie
     UtilsIE.initDownloadLinks = function() {
-        $('.download-link').each(function() {
+        $('.download-link, .c-button-download-thanks > a').each(function() {
             var $el = $(this);
             $el.click(function() {
                 UtilsIE.triggerIEDownload($el.data('direct-link'));
@@ -46,5 +55,14 @@ if (typeof window.Mozilla === 'undefined') {
     };
 
     window.Mozilla.UtilsIE = UtilsIE;
+
+    /* eslint-enable no-jquery/no-attr */
+    /* eslint-enable no-jquery/no-data */
+    /* eslint-enable no-jquery/no-each-collection */
+    /* eslint-enable no-jquery/no-event-shorthand */
+    /* eslint-enable no-jquery/no-find-collection */
+    /* eslint-enable no-jquery/no-jquery-constructor */
+    /* eslint-enable no-jquery/no-other-methods */
+    /* eslint-enable no-jquery/no-visibility */
 
 })();

--- a/media/js/ie/mozilla-utils-ie.js
+++ b/media/js/ie/mozilla-utils-ie.js
@@ -36,11 +36,15 @@ if (typeof window.Mozilla === 'undefined') {
     // attach an event to all the download buttons to trigger the special
     // ie functionality if on ie
     UtilsIE.initDownloadLinks = function() {
-        $('.download-link, .c-button-download-thanks > a').each(function() {
+        $('.download-link').each(function() {
             var $el = $(this);
-            $el.click(function() {
-                UtilsIE.triggerIEDownload($el.data('direct-link'));
-            });
+            var directLink = $el.data('direct-link');
+
+            if (directLink) {
+                $el.click(function() {
+                    UtilsIE.triggerIEDownload(directLink);
+                });
+            }
         });
         $('.download-list').attr('role', 'presentation');
     };

--- a/tests/functional/firefox/new/test_download.py
+++ b/tests/functional/firefox/new/test_download.py
@@ -11,7 +11,7 @@ from pages.firefox.new.download import DownloadPage
 @pytest.mark.nondestructive
 def test_download_button_displayed(base_url, selenium):
     page = DownloadPage(selenium, base_url, params='').open()
-    assert page.download_button.is_displayed
+    assert page.is_download_button_displayed
 
 
 # Firefox and Internet Explorer don't cope well with file prompts whilst using Selenium.

--- a/tests/functional/firefox/new/test_download_yandex.py
+++ b/tests/functional/firefox/new/test_download_yandex.py
@@ -4,26 +4,26 @@
 
 import pytest
 
-from pages.firefox.new.download import DownloadPage
+from pages.firefox.new.download_yandex import YandexDownloadPage
 
 
 @pytest.mark.nondestructive
 def test_download_button_displayed(base_url, selenium):
-    page = DownloadPage(selenium, base_url, locale='ru', params='?geo=us').open()
+    page = YandexDownloadPage(selenium, base_url, locale='ru', params='?geo=us').open()
     assert page.download_button.is_displayed
     assert not page.is_yandex_download_button_displayed
 
 
 @pytest.mark.nondestructive
 def test_yandex_download_button_displayed(base_url, selenium):
-    page = DownloadPage(selenium, base_url, locale='ru', params='?geo=ru').open()
+    page = YandexDownloadPage(selenium, base_url, locale='ru', params='?geo=ru').open()
     assert not page.download_button.is_displayed
     assert page.is_yandex_download_button_displayed
 
 
 @pytest.mark.nondestructive
 def test_other_platforms_modal(base_url, selenium):
-    page = DownloadPage(selenium, base_url, locale='ru', params='?geo=us').open()
+    page = YandexDownloadPage(selenium, base_url, locale='ru', params='?geo=us').open()
     modal = page.open_other_platforms_modal()
     assert modal.is_displayed
     modal.close()

--- a/tests/functional/test_home.py
+++ b/tests/functional/test_home.py
@@ -18,7 +18,7 @@ def test_privacy_hero_button_is_displayed(base_url, selenium):
 @pytest.mark.nondestructive
 def test_download_button_is_displayed(base_url, selenium):
     page = HomePage(selenium, base_url, locale='en-US').open()
-    assert page.secondary_download_button.is_displayed
+    assert page.is_secondary_download_button_displayed
 
 
 @pytest.mark.skip_if_firefox(reason='Download button is displayed only to non-Firefox users')
@@ -27,17 +27,17 @@ def test_download_button_is_displayed(base_url, selenium):
 @pytest.mark.parametrize('locale', ['de', 'fr'])
 def test_download_button_is_displayed_rest_tier_1(locale, base_url, selenium):
     page = HomePage(selenium, base_url, locale=locale).open()
-    assert page.primary_download_button.is_displayed
-    assert page.secondary_download_button.is_displayed
+    assert page.is_primary_download_button_displayed
+    assert page.is_secondary_download_button_displayed
 
 
 @pytest.mark.skip_if_not_firefox(reason='Firefox Accounts CTA is displayed only to Firefox users')
 @pytest.mark.nondestructive
 def test_accounts_button_is_displayed(base_url, selenium):
     page = HomePage(selenium, base_url, locale='en-US').open()
-    assert not page.is_primary_accounts_button_displayed
+    assert not page.is_primary_download_button_displayed
     assert page.is_secondary_accounts_button_displayed
-    assert not page.secondary_download_button.is_displayed
+    assert not page.is_secondary_download_button_displayed
 
 
 @pytest.mark.skip_if_not_firefox(reason='Firefox Accounts CTA is displayed only to Firefox users')
@@ -47,12 +47,12 @@ def test_accounts_button_is_displayed_rest_tier_1(locale, base_url, selenium):
     page = HomePage(selenium, base_url, locale=locale).open()
     assert page.is_primary_accounts_button_displayed
     assert page.is_secondary_accounts_button_displayed
-    assert not page.primary_download_button.is_displayed
-    assert not page.secondary_download_button.is_displayed
+    assert not page.is_primary_download_button_displayed
+    assert not page.is_secondary_download_button_displayed
 
 
 @pytest.mark.sanity
 @pytest.mark.nondestructive
 def test_download_button_is_displayed_locales(base_url, selenium):
     page = HomePage(selenium, base_url, locale='es-ES').open()
-    assert page.intro_download_button.is_displayed
+    assert page.is_rest_of_world_download_button_displayed

--- a/tests/functional/test_navigation.py
+++ b/tests/functional/test_navigation.py
@@ -38,3 +38,19 @@ def test_mobile_navigation(base_url, selenium_mobile):
     page.navigation.show()
     about_page = page.navigation.open_about_page()
     assert about_page.seed_url in selenium_mobile.current_url
+
+
+@pytest.mark.nondestructive
+@pytest.mark.skip_if_firefox(reason='Firefox download button is shown only to non-Firefox users.')
+def test_navigation_download_firefox_button(base_url, selenium):
+    page = HomePage(selenium, base_url).open()
+    assert not page.navigation.is_firefox_accounts_button_displayed
+    assert page.navigation.is_firefox_download_button_displayed
+
+
+@pytest.mark.nondestructive
+@pytest.mark.skip_if_not_firefox(reason='Firefox Accounts button is shown only to Firefox users.')
+def test_navigation_firefox_account_button(base_url, selenium):
+    page = HomePage(selenium, base_url).open()
+    assert not page.navigation.is_firefox_download_button_displayed
+    assert page.navigation.is_firefox_accounts_button_displayed

--- a/tests/pages/base.py
+++ b/tests/pages/base.py
@@ -59,6 +59,16 @@ class BasePage(ScrollElementIntoView, Page):
         _firefox_desktop_page_locator = (By.CSS_SELECTOR, '.mzp-c-menu-item-link[data-link-name="Firefox Quantum Desktop Browser"]')
         _developer_edition_page_locator = (By.CSS_SELECTOR, '.mzp-c-menu-item-link[data-link-name="Firefox Developer Edition"]')
         _about_page_locator = (By.CSS_SELECTOR, '.mzp-c-menu-item-link[data-link-name="Mozilla"]')
+        _firefox_download_button_locator = (By.CSS_SELECTOR, '#protocol-nav-download-firefox > .download-link')
+        _firefox_account_button_locator = (By.CSS_SELECTOR, '.c-navigation-fxa-cta-container > .js-fxa-cta-link')
+
+        @property
+        def is_firefox_download_button_displayed(self):
+            return self.is_element_displayed(*self._firefox_download_button_locator)
+
+        @property
+        def is_firefox_accounts_button_displayed(self):
+            return self.is_element_displayed(*self._firefox_account_button_locator)
 
         def show(self):
             assert not self.is_displayed, 'Menu is already displayed'

--- a/tests/pages/firefox/new/download.py
+++ b/tests/pages/firefox/new/download.py
@@ -12,7 +12,7 @@ class DownloadPage(BasePage):
 
     URL_TEMPLATE = '/{locale}/firefox/new/{params}'
 
-    _download_button_locator = (By.ID, 'download-button-thanks')
+    _download_button_locator = (By.CSS_SELECTOR, '#download-button-thanks > .download-link')
     _platforms_modal_link_locator = (By.CLASS_NAME, 'js-platform-modal-button')
     _platforms_modal_content_locator = (By.CLASS_NAME, 'mzp-u-modal-content')
     _join_firefox_modal_content_locator = (By.CLASS_NAME, 'join-firefox-content')

--- a/tests/pages/firefox/new/download_yandex.py
+++ b/tests/pages/firefox/new/download_yandex.py
@@ -5,24 +5,27 @@
 from selenium.webdriver.common.by import By
 
 from pages.base import BasePage
+from pages.regions.download_button import DownloadButton
 from pages.regions.modal import ModalProtocol
 
 
-class DownloadPage(BasePage):
+class YandexDownloadPage(BasePage):
 
     URL_TEMPLATE = '/{locale}/firefox/new/{params}'
 
-    _download_button_locator = (By.ID, 'download-button-thanks')
+    _download_button_locator = (By.ID, 'download-button-desktop-release')
     _platforms_modal_link_locator = (By.CLASS_NAME, 'js-platform-modal-button')
     _platforms_modal_content_locator = (By.CLASS_NAME, 'mzp-u-modal-content')
     _join_firefox_modal_content_locator = (By.CLASS_NAME, 'join-firefox-content')
+    _yandex_download_button_locator = (By.CSS_SELECTOR, '.hero-yandex .mzp-c-button.mzp-t-product')
 
     @property
-    def is_download_button_displayed(self):
-        return self.is_element_displayed(*self._download_button_locator)
+    def download_button(self):
+        el = self.find_element(*self._download_button_locator)
+        return DownloadButton(self, root=el)
 
     def download_firefox(self):
-        self.find_element(*self._download_button_locator).click()
+        self.download_button.click()
         from pages.firefox.new.thank_you import ThankYouPage
         return ThankYouPage(self.selenium, self.base_url).wait_for_page_to_load()
 
@@ -32,8 +35,7 @@ class DownloadPage(BasePage):
         self.wait.until(lambda s: modal.displays(self._platforms_modal_content_locator))
         return modal
 
-    def open_join_firefox_modal(self):
-        modal = ModalProtocol(self)
-        self.find_element(*self._download_button_locator).click()
-        self.wait.until(lambda s: modal.displays(self._join_firefox_modal_content_locator))
-        return modal
+    @property
+    def is_yandex_download_button_displayed(self):
+        button = self.find_element(*self._yandex_download_button_locator)
+        return button.is_displayed() and 'https://yandex.ru/firefox/mozilla/' in button.get_attribute('href')

--- a/tests/pages/home.py
+++ b/tests/pages/home.py
@@ -5,13 +5,12 @@
 from selenium.webdriver.common.by import By
 
 from pages.base import BasePage
-from pages.regions.download_button import DownloadButton
 
 
 class HomePage(BasePage):
 
     _privacy_hero_button_locator = (By.CSS_SELECTOR, '.privacy-promise-hero .mzp-c-button')
-    _intro_download_button_locator = (By.ID, 'download-intro')  # legacy home page
+    _rest_of_world_download_button_locator = (By.ID, 'download-intro')  # legacy home page
     _primary_download_button_locator = (By.ID, 'download-primary')
     _secondary_download_button_locator = (By.ID, 'download-secondary')
     _primary_accounts_button_locator = (By.ID, 'fxa-learn-primary')
@@ -22,19 +21,16 @@ class HomePage(BasePage):
         return self.is_element_displayed(*self._privacy_hero_button_locator)
 
     @property
-    def intro_download_button(self):
-        el = self.find_element(*self._intro_download_button_locator)
-        return DownloadButton(self, root=el)
+    def is_rest_of_world_download_button_displayed(self):
+        return self.is_element_displayed(*self._rest_of_world_download_button_locator)
 
     @property
-    def primary_download_button(self):
-        el = self.find_element(*self._primary_download_button_locator)
-        return DownloadButton(self, root=el)
+    def is_primary_download_button_displayed(self):
+        return self.is_element_displayed(*self._primary_download_button_locator)
 
     @property
-    def secondary_download_button(self):
-        el = self.find_element(*self._secondary_download_button_locator)
-        return DownloadButton(self, root=el)
+    def is_secondary_download_button_displayed(self):
+        return self.is_element_displayed(*self._secondary_download_button_locator)
 
     @property
     def is_primary_accounts_button_displayed(self):

--- a/tests/pages/home.py
+++ b/tests/pages/home.py
@@ -10,9 +10,9 @@ from pages.base import BasePage
 class HomePage(BasePage):
 
     _privacy_hero_button_locator = (By.CSS_SELECTOR, '.privacy-promise-hero .mzp-c-button')
-    _rest_of_world_download_button_locator = (By.ID, 'download-intro')  # legacy home page
-    _primary_download_button_locator = (By.ID, 'download-primary')
-    _secondary_download_button_locator = (By.ID, 'download-secondary')
+    _rest_of_world_download_button_locator = (By.CSS_SELECTOR, '#download-intro > .download-link')  # legacy home page
+    _primary_download_button_locator = (By.CSS_SELECTOR, '#download-primary > .download-link')
+    _secondary_download_button_locator = (By.CSS_SELECTOR, '#download-secondary > .download-link')
     _primary_accounts_button_locator = (By.ID, 'fxa-learn-primary')
     _secondary_accounts_button_locator = (By.ID, 'fxa-learn-secondary')
 

--- a/tests/unit/spec/ie/mozilla-utils-ie.js
+++ b/tests/unit/spec/ie/mozilla-utils-ie.js
@@ -18,25 +18,45 @@ describe('mozilla-utils-ie.js', function() {
         });
     });
 
-    describe('initDownloadLinks', function () {
+    describe('initDownloadLinks (regular download button)', function () {
 
-        /* Append an HTML fixture to the document body
-         * for each test in the scope of this suite */
         beforeEach(function () {
-            $('<a class="download-link" data-direct-link="bar">foo</a>').appendTo('body');
+            var link = '<a class="download-link" data-direct-link="test-download-url">Download</a>';
+            document.body.insertAdjacentHTML('beforeend', link);
         });
 
-        /* Then after each test remove the fixture */
         afterEach(function() {
-            $('.download-link').remove();
+            document.querySelectorAll('.download-link').forEach(function(e)  {
+                e.parentNode.removeChild(e);
+            });
         });
 
         it('should call triggerIEDownload when clicked', function () {
             spyOn(Mozilla.UtilsIE, 'triggerIEDownload');
             Mozilla.UtilsIE.initDownloadLinks();
-            $('.download-link').trigger('click');
-            expect(Mozilla.UtilsIE.triggerIEDownload).toHaveBeenCalled();
+            document.querySelector('.download-link').click();
+            expect(Mozilla.UtilsIE.triggerIEDownload).toHaveBeenCalledWith('test-download-url');
+        });
+    });
+
+    describe('initDownloadLinks (/thanks download button)', function () {
+
+        beforeEach(function () {
+            var link = '<div class="c-button-download-thanks"><a data-direct-link="test-download-url">Download</a></div>';
+            document.body.insertAdjacentHTML('beforeend', link);
         });
 
+        afterEach(function() {
+            document.querySelectorAll('.c-button-download-thanks').forEach(function(e)  {
+                e.parentNode.removeChild(e);
+            });
+        });
+
+        it('should call triggerIEDownload when clicked', function () {
+            spyOn(Mozilla.UtilsIE, 'triggerIEDownload');
+            Mozilla.UtilsIE.initDownloadLinks();
+            document.querySelector('.c-button-download-thanks > a').click();
+            expect(Mozilla.UtilsIE.triggerIEDownload).toHaveBeenCalledWith('test-download-url');
+        });
     });
 });

--- a/tests/unit/spec/ie/mozilla-utils-ie.js
+++ b/tests/unit/spec/ie/mozilla-utils-ie.js
@@ -42,7 +42,7 @@ describe('mozilla-utils-ie.js', function() {
     describe('initDownloadLinks (/thanks download button)', function () {
 
         beforeEach(function () {
-            var link = '<div class="c-button-download-thanks"><a data-direct-link="test-download-url">Download</a></div>';
+            var link = '<div class="c-button-download-thanks"><a class="download-link" data-direct-link="test-download-url">Download</a></div>';
             document.body.insertAdjacentHTML('beforeend', link);
         });
 
@@ -55,7 +55,7 @@ describe('mozilla-utils-ie.js', function() {
         it('should call triggerIEDownload when clicked', function () {
             spyOn(Mozilla.UtilsIE, 'triggerIEDownload');
             Mozilla.UtilsIE.initDownloadLinks();
-            document.querySelector('.c-button-download-thanks > a').click();
+            document.querySelector('.c-button-download-thanks > .download-link').click();
             expect(Mozilla.UtilsIE.triggerIEDownload).toHaveBeenCalledWith('test-download-url');
         });
     });


### PR DESCRIPTION
## Description
- Adds a new simplified download button helper.
- Implements the simple button on the following pages / areas:
  - Download button in the global navigation.
  - Download buttons on http://localhost:8000/en-US/firefox/new/
  - Download buttons on home pages:
    - http://localhost:8000/en-US/
    - http://localhost:8000/de/
    - http://localhost:8000/fr/
    - http://localhost:8000/es-ES/

## Issue / Bugzilla link
#8860

## Testing
Demo: https://www-demo2.allizom.org/en-US/firefox/new/

- [x] Clicking download on a desktop browser navigates to /thanks and initiates a download as expected.
- [x] Clicking download in an old IE browser initiates a download via a popup, before navigating to /thanks as expected.
- [x] Clicking download on Android / iOS navigated to /thanks before redirecting to the app/play store.

Successful test run: https://gitlab.com/mozmeao/www-config/-/pipelines/188897807