### PR TITLE
Update Daylight banner title [fix #9351]

### DIFF
--- a/bedrock/base/templates/includes/banners/daylight/daylight-launch.html
+++ b/bedrock/base/templates/includes/banners/daylight/daylight-launch.html
@@ -15,7 +15,7 @@
     <button type="button" class="c-banner-close"><span>{{ ftl('ui-close') }}</span></button>
     <div class="mzp-l-content">
       <div class="c-banner-main">
-        <h2 class="c-banner-title">{{ ftl('banner-firefox-daylight-launch-title') }}</h2>
+        <h2 class="c-banner-title">{{ ftl('banner-firefox-daylight-launch-title-updated', fallback='banner-firefox-daylight-launch-title') }}</h2>
         <p class="c-banner-intro">{{ ftl('banner-firefox-daylight-launch-intro') }}</p>
 
         <div class="c-cta hidden-on-mobile">

--- a/l10n/en/banners/firefox-daylight-launch.ftl
+++ b/l10n/en/banners/firefox-daylight-launch.ftl
@@ -3,5 +3,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 banner-firefox-daylight-launch-title = Introducing our latest release of { -brand-name-firefox } for { -brand-name-android } — { -brand-name-firefox-daylight }.
+banner-firefox-daylight-launch-title-updated = Introducing the NEW { -brand-name-firefox } for { -brand-name-android } — { -brand-name-firefox-daylight }
 banner-firefox-daylight-launch-intro = Dramatically redesigned to be faster, easy to use, customizable and private.
 banner-firefox-daylight-launch-button = Get It Now


### PR DESCRIPTION
## Description
Updates the Daylight banner headline, keeping the old one as a fallback.

## Issue / Bugzilla link
#9351 
