### PR TITLE
Update Facebook Container page (Fixes #9349)

### DIFF
--- a/bedrock/firefox/templates/firefox/facebookcontainer/index.html
+++ b/bedrock/firefox/templates/firefox/facebookcontainer/index.html
@@ -33,40 +33,45 @@
     </div>
 
     <div class="mobile-cta">
-      <p>{{ ftl('facebook-container-the-facebook-container-extension') }}</p>
-      <p>{{ ftl('facebook-container-try-firefox-focus-the-privacy') }}</p>
+      {% if ftl_has_messages('facebook-container-only-available-for-desktop', 'facebook-container-visit-to-get-for-desktop') %}
+        <p>{{ ftl('facebook-container-only-available-for-desktop') }}</p>
+        <p>{{ ftl('facebook-container-visit-to-get-for-desktop', url=url('firefox.new'), link_copy='www.mozilla.org/firefox/new/') }}</p>
+      {% else %}
+        <p>{{ ftl('facebook-container-the-facebook-container-extension') }}</p>
+      {% endif %}
 
-      <ul>
-        <li>
-          {{ google_play_button(href=focus_adjust_url('android', 'fb-container-page'), id='playStoreLink', product='Focus') }}
-        </li>
-        <li>
-          <a id="appStoreLink" href="{{ focus_adjust_url('ios', 'fb-container-page') }}" data-link-type="download" data-download-os="iOS">
-            <img src="{{ l10n_img('firefox/ios/btn-app-store.svg') }}" alt="{{ ftl('download-button-download-app-store') }}" width="152" height="45">
-          </a>
-        </li>
-      </ul>
+      {% if ftl_has_messages('facebook-container-get-firefox-android-ios') %}
+        <p>{{ ftl('facebook-container-get-firefox-android-ios') }}</p>
+
+        <ul>
+          <li>
+            {{ google_play_button(href=firefox_adjust_url('android', 'fb-container-page'), id='playStoreLink') }}
+          </li>
+          <li>
+            <a id="appStoreLink" href="{{ firefox_adjust_url('ios', 'fb-container-page') }}" data-link-type="download" data-download-os="iOS">
+              <img src="{{ l10n_img('firefox/ios/btn-app-store.svg') }}" alt="{{ ftl('download-button-download-app-store') }}" width="152" height="45">
+            </a>
+          </li>
+        </ul>
+      {% endif %}
     </div>
   </div>
 
   <aside class="fbcontainer-video">
-  {% if LANG == 'de' %}
-    <div class="video-container">
-      <iframe width="640" height="360" src="https://www.youtube-nocookie.com/embed/7yLoRVwuZlc?rel=0&amp;showinfo=0" frameborder="0" allow="encrypted-media" allowfullscreen>
-        <p><a href="https://www.youtube.com/watch?v=7yLoRVwuZlc">{{ ftl('ui-watch-the-video') }}</a></p>
-      </iframe>
-    </div>
-  {% else %}
-    <div class="moz-video-container">
-      <button class="moz-video-button mzp-c-button" type="button" aria-controls="fbcontainer-video">{{ ftl('ui-watch-the-video') }}</button>
+    {% if LANG == 'de' %}
+      <div class="video-container">
+        <iframe src="https://www.youtube-nocookie.com/embed/7yLoRVwuZlc?rel=0&amp;showinfo=0" frameborder="0" allow="encrypted-media" allowfullscreen>
+          <p><a href="https://www.youtube.com/watch?v=7yLoRVwuZlc">{{ ftl('ui-watch-the-video') }}</a></p>
+        </iframe>
+      </div>
+    {% else %}
       <div class="video-container">
         <video id="fbcontainer-video" preload="metadata" controls poster="{{ static('img/firefox/facebook-container/video-poster.png') }}" data-ga-label="Facebook Container Video">
           <source src="https://assets.mozilla.net/video/facebook-container/facebook-container.webm" type="video/webm">
           <source src="https://assets.mozilla.net/video/facebook-container/facebook-container.mp4" type="video/mp4">
         </video>
       </div>
-    </div>
-  {% endif %}
+    {% endif %}
   </aside>
   {% endcall %}
 

--- a/l10n/en/firefox/facebook_container.ftl
+++ b/l10n/en/firefox/facebook_container.ftl
@@ -9,10 +9,22 @@ facebook-container-millions-of-people-around = Millions of people around the wor
 facebook-container-facebook-well-contained-keep = { -brand-name-facebook }. Well contained. Keep the rest of your life to yourself.
 facebook-container-get-the-facebook-container = Get the { -brand-name-facebook-container } Extension
 facebook-container-download-firefox-and-get-the = Download { -brand-name-firefox } and get the { -brand-name-facebook-container } Extension
+facebook-container-only-available-for-desktop = The { -brand-name-facebook-container } Extension is currently only available for { -brand-name-firefox } for Desktop.
+
+# Variables:
+#   $link_copy (string) - www.mozilla.org/firefox/new/
+#   $url (url) - link to https://www.mozilla.org/firefox/new/
+facebook-container-visit-to-get-for-desktop = Visit <a href="{ $url }">{ $link_copy }</a> to get { -brand-name-firefox } for Desktop.
+
+# Outdated string
 facebook-container-the-facebook-container-extension = The { -brand-name-facebook-container } Extension is not available on mobile devices.
 
+facebook-container-get-firefox-android-ios = Get { -brand-name-firefox } for { -brand-name-android } and { -brand-name-ios } now.
+
+# Outdated string
 # For German, the brand name for 'Firefox Focus' in brands.ftl should be changed to 'Firefox Klar'.
 facebook-container-try-firefox-focus-the-privacy = Try <strong>{ -brand-name-firefox-focus }</strong>, the privacy browser for { -brand-name-android } and { -brand-name-ios }.
+
 facebook-container-opt-out-on-your-terms = Opt out on your terms
 
 # Variables:

--- a/media/css/firefox/facebook-container.scss
+++ b/media/css/firefox/facebook-container.scss
@@ -35,10 +35,19 @@ $image-path: '/media/protocol/img';
 // Video
 
 .video-container {
-    @include bidi((
-        (margin-right, $spacing-md, 0),
-        (margin-left, 0, $spacing-md)
-    ));
+    height: 0;
+    overflow: hidden;
+    padding-bottom: 56.25%;
+    position: relative;
+    width: 100%;
+
+    iframe {
+        height: 100%;
+        left: 0;
+        position: absolute;
+        top: 0;
+        width: 100%;
+    }
 }
 
 .fbcontainer-video {
@@ -47,16 +56,19 @@ $image-path: '/media/protocol/img';
             (left, 50%, auto),
             (right, auto, 50%)
         ));
+        align-items: center;
+        bottom: 0;
+        display: flex;
         padding: 0;
         position: absolute;
-        top: $spacing-xl;
-        width: 50%;
+        top: 0;
+        width: calc(50% - #{$spacing-xl * 2});
         z-index: 2;
     }
-}
 
-.moz-video-button {
-    visibility: hidden;
+    @media #{$mq-lg} {
+        width: calc(50% - #{$spacing-2xl * 2});
+    }
 }
 
 //* -------------------------------------------------------------------------- */

--- a/media/js/firefox/facebook-container-video.js
+++ b/media/js/firefox/facebook-container-video.js
@@ -27,8 +27,6 @@
     }
 
     function onLoad() {
-        var videoPoster = new Mozilla.VideoPosterHelper('.fbcontainer-video');
-        videoPoster.init();
         initVideoInteractionTracking();
     }
 

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -738,7 +738,6 @@
     },
     {
       "files": [
-        "js/base/mozilla-video-poster.js",
         "js/firefox/facebook-container-video.js"
       ],
       "name": "firefox_facebook_container_video"


### PR DESCRIPTION
## Description
- Change mobile CTA from Firefox Focus to Firefox for mobile.
- Fix video positioning CSS.

## Issue / Bugzilla link
#9349
https://github.com/mozilla/bedrock/issues/9347


## Testing
- [ ] Android and iOS devices should see the new CTA.
- [ ] Video for both `en` and `de` should be positioned correctly.