### PR TITLE
Fix channel page title (Fixes #9352)

### DIFF
--- a/bedrock/firefox/templates/firefox/channel/desktop.html
+++ b/bedrock/firefox/templates/firefox/channel/desktop.html
@@ -5,7 +5,7 @@
 {% extends "firefox/channel/base.html" %}
 
 {% block page_title %}
-  {{ ftl('firefox-channel-try-new-features-in-a-pre', fallback='firefox-channel-download-and-test-future')}}
+  {{ ftl('firefox-channel-download-and-test-future') }}
 {% endblock %}
 
 {% block page_desc %}


### PR DESCRIPTION
## Description
Fix page title on http://localhost:8000/en-US/firefox/channel/desktop/

## Issue / Bugzilla link
https://github.com/mozilla/bedrock/issues/9352

## Testing
- [x] Title should read `Download and test future releases of Firefox for desktop, Android and iOS.`