### PR TITLE
Add form functionality to sept landing page (#9334)

### DIFF
--- a/bedrock/firefox/forms.py
+++ b/bedrock/firefox/forms.py
@@ -6,6 +6,8 @@ import re
 
 from django import forms
 
+from bedrock.mozorg.forms import (HoneyPotWidget)
+
 
 class SendToDeviceWidgetForm(forms.Form):
     number = forms.CharField(max_length=20, min_length=4, required=False)
@@ -22,3 +24,21 @@ class SendToDeviceWidgetForm(forms.Form):
             number = re.sub(r'\D+', '', number)
 
         return number
+
+
+class UnfckForm(forms.Form):
+    unfck_field = forms.CharField(
+        max_length=500,
+        required=True,
+        widget=forms.Textarea(),
+    )
+
+    # honeypot
+    office_fax = forms.CharField(widget=HoneyPotWidget, required=False)
+
+    def clean_office_fax(self):
+        cleaned_data = super(UnfckForm, self).clean()
+        honeypot = cleaned_data.pop('office_fax', None)
+
+        if honeypot:
+            raise forms.ValidationError('Your submission could not be processed')

--- a/bedrock/firefox/forms.py
+++ b/bedrock/firefox/forms.py
@@ -6,7 +6,7 @@ import re
 
 from django import forms
 
-from bedrock.mozorg.forms import (HoneyPotWidget)
+from bedrock.mozorg.forms import HoneyPotWidget
 
 
 class SendToDeviceWidgetForm(forms.Form):
@@ -28,7 +28,7 @@ class SendToDeviceWidgetForm(forms.Form):
 
 class UnfckForm(forms.Form):
     unfck_field = forms.CharField(
-        max_length=500,
+        max_length=2000,
         required=True,
         widget=forms.Textarea(),
     )

--- a/bedrock/firefox/forms.py
+++ b/bedrock/firefox/forms.py
@@ -28,7 +28,7 @@ class SendToDeviceWidgetForm(forms.Form):
 
 class UnfckForm(forms.Form):
     unfck_field = forms.CharField(
-        max_length=2000,
+        max_length=280,
         required=True,
         widget=forms.Textarea(),
     )

--- a/bedrock/firefox/templates/firefox/campaign/unfck/emails/unfck.txt
+++ b/bedrock/firefox/templates/firefox/campaign/unfck/emails/unfck.txt
@@ -1,0 +1,5 @@
+Tell the world what you wanna unfck
+
+------------------------------------
+
+{{ unfck_field }}

--- a/bedrock/firefox/templates/firefox/campaign/unfck/emails/unfck.txt
+++ b/bedrock/firefox/templates/firefox/campaign/unfck/emails/unfck.txt
@@ -2,4 +2,4 @@ Tell the world what you wanna unfck
 
 ------------------------------------
 
-{{ unfck_field }}
+{{ unfck_field|bleach_tags }}

--- a/bedrock/firefox/templates/firefox/campaign/unfck/index.html
+++ b/bedrock/firefox/templates/firefox/campaign/unfck/index.html
@@ -99,8 +99,19 @@
         include_cta=True
         ) %}
         <div class="c-tell">
-          <textarea class="c-tell-input" placeholder="TODO: interaction"></textarea>
-          <button class="c-tell-button mzp-c-button mzp-t-secondary">Submit</button>
+          {% if form.errors %}
+            <p><strong>An error has occurred with your submission. Please review your information below and try again.</strong></p>
+          {% endif %}
+          {% if not form_success %}
+          <form name="firefox-unfck" id="unfck-form" class="c-unfck-form" action="{{ url('firefox.campaign.unfck') }}" method="post">
+            {{ csrf() }}
+            {{ field_with_attrs(form.unfck_field, class='c-tell-input'|safe, placeholder='TODO: some example text'|safe) }}
+            {{ field_with_attrs(form.office_fax) }}
+            <button type="submit" class="c-tell-button mzp-c-button mzp-t-secondary">Submit</button>
+          </form>
+          {% else %}
+            <p><strong>Thanks!</strong></p>
+          {% endif %}
         </div>
       {% endcall %}
   </div>

--- a/bedrock/firefox/tests/test_views.py
+++ b/bedrock/firefox/tests/test_views.py
@@ -839,7 +839,7 @@ class TestUnfckForm(TestCase):
 
     def test_form_missing_data(self):
         """
-        With incorrect data (missing email), form should not be valid
+        With incorrect data (blank text), form should not be valid
         """
         self.data.update(unfck_field='')
 

--- a/bedrock/firefox/urls.py
+++ b/bedrock/firefox/urls.py
@@ -6,8 +6,6 @@ from django.conf.urls import url
 import bedrock.releasenotes.views
 from bedrock.mozorg.util import page
 from bedrock.releasenotes import version_re
-from django.conf import settings
-from bedrock.redirects.util import redirect
 
 from bedrock.firefox import views
 from bedrock.utils import views as utils_views
@@ -171,13 +169,7 @@ urlpatterns = (
 
     # Issue 8536
     page('firefox/retention/thank-you', 'firefox/retention/thank-you.html'),
-)
 
-if settings.DEV:
-    urlpatterns += (
-        page('firefox/campaign/unfck', 'firefox/campaign/unfck/index.html'),
-    )
-else:
-    urlpatterns += (
-        redirect(r'^firefox/campaign/unfck(/.*)?', 'firefox', permanent=False),
-    )
+    # Issue 9334
+    url(r'^firefox/campaign/unfck/$', views.FirefoxUnfckView.as_view(), name='firefox.campaign.unfck'),
+)

--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -13,14 +13,20 @@ import basket
 import querystringsafe_base64
 from django.conf import settings
 from django.http import (
+    HttpResponseRedirect,
     HttpResponsePermanentRedirect,
     JsonResponse,
 )
+
+from django.core.mail import EmailMessage
+from django.template.loader import render_to_string
 from django.utils.cache import patch_response_headers
 from django.utils.encoding import force_text
-from django.views.decorators.csrf import csrf_exempt
+from django.views.decorators.csrf import csrf_exempt, csrf_protect
 from django.views.decorators.http import require_GET, require_POST
 from django.views.generic.base import TemplateView
+from django.utils.decorators import method_decorator
+from django.views.generic.edit import FormView
 from lib import l10n_utils
 from lib.l10n_utils import L10nTemplateView
 from lib.l10n_utils.dotlang import lang_file_is_active
@@ -35,6 +41,8 @@ from bedrock.firefox.forms import SendToDeviceWidgetForm
 from bedrock.newsletter.forms import NewsletterFooterForm
 from bedrock.releasenotes import version_re
 from bedrock.base.views import GeoRedirectView
+from .forms import (UnfckForm)
+
 
 UA_REGEXP = re.compile(r"Firefox/(%s)" % version_re)
 
@@ -58,6 +66,10 @@ STUB_VALUE_NAMES = [
     ('ua', '(not set)'),
 ]
 STUB_VALUE_RE = re.compile(r'^[a-z0-9-.%():_]+$', flags=re.IGNORECASE)
+
+UNFCK_EMAIL_FROM = 'Mozilla.com <noreply@mozilla.com>'
+UNFCK_EMAIL_SUBJECT = 'Tell the world what you wanna unfck'
+UNFCK_EMAIL_TO = ['TODO@mozilla.com']
 
 
 class InstallerHelpView(L10nTemplateView):
@@ -824,3 +836,46 @@ def firefox_welcome_page1(request):
 
     return l10n_utils.render(request, template_name, context,
                              ftl_files='firefox/welcome/page1')
+
+
+class FirefoxUnfckView(FormView):
+    form_class = UnfckForm
+    template_name = 'firefox/campaign/unfck/index.html'
+
+    def get(self, *args, **kwargs):
+        if not switch('firefox-unfck-landing'):
+            return HttpResponseRedirect(reverse('firefox'))
+
+        return super(FirefoxUnfckView, self).get(*args, **kwargs)
+
+    @method_decorator(csrf_protect)
+    def dispatch(self, request, *args, **kwargs):
+        return super(FirefoxUnfckView, self).dispatch(request, *args, **kwargs)
+
+    def get_context_data(self, **kwargs):
+        context = super(FirefoxUnfckView, self).get_context_data(**kwargs)
+        context['form_success'] = 'success' in self.request.GET
+        return context
+
+    def get_success_url(self):
+        return reverse('firefox.campaign.unfck') + '?success=True'
+
+    def form_valid(self, form):
+        self.send_email(form)
+        return super(FirefoxUnfckView, self).form_valid(form)
+
+    def send_email(self, form):
+        subject = UNFCK_EMAIL_SUBJECT
+        sender = UNFCK_EMAIL_FROM
+        to = UNFCK_EMAIL_TO
+        msg = render_to_string('firefox/campaign/unfck/emails/unfck.txt', form.cleaned_data,
+                               request=self.request)
+
+        email = EmailMessage(subject, msg, sender, to)
+        email.send()
+
+    def render_to_response(self, context, **response_kwargs):
+        return l10n_utils.render(self.request,
+                                 self.get_template_names(),
+                                 context,
+                                 **response_kwargs)

--- a/media/css/firefox/unfck.scss
+++ b/media/css/firefox/unfck.scss
@@ -442,6 +442,11 @@ main {
     }
 }
 
+// honeypot
+.super-priority-field {
+    display: none;
+}
+
 // --------------------------------------------------------------------------
 // section titles
 


### PR DESCRIPTION
## Description
- Adds form view & tests for the september landing page (heavily borrowed from the /press/ section).
- Moves logic for making page appear only on Dev from `urls.py` to a switch in `views.py` (needed for the unit tests).

## Issue / Bugzilla link
#9334
