### PR TITLE
Fixed JS error on /contact page

### DIFF
--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -1140,12 +1140,6 @@
     {
       "files": [
         "js/base/mozilla-lazy-load.js",
-        "js/firefox/home/master.js"
-      ],
-      "name": "firefox-master"
-    },
-    {
-      "files": [
         "js/base/mozilla-fxa.js",
         "js/base/mozilla-fxa-init.js",
         "js/base/mozilla-fxa-form.js",


### PR DESCRIPTION
## Description
```
Uncaught TypeError: can't access property "setAttribute", e is null
    <anonymous> https://www.mozilla.org/media/js/BUNDLES/contact-spaces.8c743e70c527.js:1
    <anonymous> https://www.mozilla.org/media/js/BUNDLES/contact-spaces.8c743e70c527.js:1
```

- Removing [here](https://github.com/mozilla/bedrock/blob/master/media/static-bundles.json#L1092-L1097)

## Issue / Bugzilla link
Fixes #9322 

## Testing
