### PR TITLE
Fixed #9322 - Removed Spaces JS bundle from root contact template

### DIFF
--- a/bedrock/mozorg/templates/mozorg/contact/contact-base.html
+++ b/bedrock/mozorg/templates/mozorg/contact/contact-base.html
@@ -70,5 +70,4 @@
 {% endblock %}
 
 {% block js %}
-  {{ js_bundle('contact-spaces') }}
 {% endblock %}


### PR DESCRIPTION
## Description

This PR updates the parent Contract page template to remote the Spaces JS bundle. (As it's not used/needed on this page) 


## Issue / Bugzilla link

https://github.com/mozilla/bedrock/issues/9322

## Testing

Test the following URLs: 
- `/contact`
- `/contact/spaces/`
