### PR TITLE
Exclude contact JS bundle from landing page only (Fixes #9380)

### DIFF
--- a/bedrock/mozorg/templates/mozorg/contact/contact-base.html
+++ b/bedrock/mozorg/templates/mozorg/contact/contact-base.html
@@ -70,4 +70,8 @@
 {% endblock %}
 
 {% block js %}
+  {# Issue 9322 #}
+  {% if self.body_id() != 'contact-landing' %}
+    {{ js_bundle('contact-spaces') }}
+  {% endif %}
 {% endblock %}

--- a/bedrock/mozorg/templates/mozorg/contact/contact-landing.html
+++ b/bedrock/mozorg/templates/mozorg/contact/contact-landing.html
@@ -5,6 +5,7 @@
 {% extends "mozorg/contact/contact-base.html" %}
 
 {% block page_title %}{{ _('Contacts, Spaces and Communities') }} — {{ _('Contact us') }}{% endblock %}
+{% block body_id %}contact-landing{% endblock %}
 
 {% block tab_navigation %}
   {% with current = 'contact' %}


### PR DESCRIPTION
## Description
- Only exclude contact JS bundle from the /contact landing page

http://localhost:8000/en-US/contact/
http://localhost:8000/en-US/contact/spaces/

## Issue / Bugzilla link
#9380
#9322

## Testing
- [ ] /contact page should not throw a JS error.
- [ ] /contact/spaces/ page mobile menu should still open / close.