### PR TITLE
Add a test attribute to thanks page [fix #9389]

### DIFF
--- a/bedrock/firefox/templates/firefox/new/desktop/thanks.html
+++ b/bedrock/firefox/templates/firefox/new/desktop/thanks.html
@@ -6,6 +6,9 @@
 
 {% extends "firefox/new/desktop/base.html" %}
 
+{# FxA automated tests use this attribute to verify the page #}
+{% block html_attrs %}data-test-fxa-template="firefox-download-thanks"{% endblock %}
+
 {# "scene2" page should not be indexed to avoid it appearing in search results: issue 7024 #}
 {% block canonical_urls %}<meta name="robots" content="noindex,follow">{% endblock %}
 

--- a/bedrock/firefox/templates/firefox/new/protocol/base.html
+++ b/bedrock/firefox/templates/firefox/new/protocol/base.html
@@ -8,9 +8,6 @@
 
 {% extends "firefox/base/base-protocol.html" %}
 
-{# FxA automated tests use this attribute to verify the page #}
-{% block html_attrs %}data-test-fxa-template="firefox-download-thanks"{% endblock %}
-
 {% block page_title_prefix %}{{_('Download Firefox')}} — {% endblock %}
 
 {%- block page_title -%}{{_('Free Web Browser')}}{%- endblock -%}

--- a/bedrock/firefox/templates/firefox/new/protocol/base.html
+++ b/bedrock/firefox/templates/firefox/new/protocol/base.html
@@ -8,6 +8,9 @@
 
 {% extends "firefox/base/base-protocol.html" %}
 
+{# FxA automated tests use this attribute to verify the page #}
+{% block html_attrs %}data-test-fxa-template="firefox-download-thanks"{% endblock %}
+
 {% block page_title_prefix %}{{_('Download Firefox')}} — {% endblock %}
 
 {%- block page_title -%}{{_('Free Web Browser')}}{%- endblock -%}

--- a/bedrock/firefox/templates/firefox/new/trailhead/thanks.html
+++ b/bedrock/firefox/templates/firefox/new/trailhead/thanks.html
@@ -6,6 +6,9 @@
 
 {% extends "firefox/new/trailhead/base.html" %}
 
+{# FxA automated tests use this attribute to verify the page #}
+{% block html_attrs %}data-test-fxa-template="firefox-download-thanks"{% endblock %}
+
 {# "scene2" page should not be indexed to avoid it appearing in search results: issue 7024 #}
 {% block canonical_urls %}<meta name="robots" content="noindex,follow">{% endblock %}
 


### PR DESCRIPTION
## Description
This adds the attribute `data-test-fxa-template="firefox-download-thanks"` to the /download/thanks/ template root element, which FxA tests can use to verify the page loads.

There's likely another way to verify a page in a test, but they've been using a CSS selector to look for an element already and this may be easier than completely rewriting their tests. Once this lands they can update their tests to look for the selector `html[data-test-fxa-template="firefox-download-thanks"]`

## Issue / Bugzilla link
#9389 