### PR TITLE
Fix db data upload path issue

### DIFF
--- a/bin/db_s3_utils.py
+++ b/bin/db_s3_utils.py
@@ -4,8 +4,9 @@ from os import getenv
 from subprocess import check_output, CalledProcessError
 
 
+JSON_DATA_FILE_NAME = 'bedrock_db_info.json'
 DATA_PATH = getenv('DATA_PATH', 'data')
-JSON_DATA_FILE = getenv('AWS_DB_JSON_DATA_FILE', f'{DATA_PATH}/bedrock_db_info.json')
+JSON_DATA_FILE = getenv('AWS_DB_JSON_DATA_FILE', f'{DATA_PATH}/{JSON_DATA_FILE_NAME}')
 DB_FILE = f'{DATA_PATH}/bedrock.db'
 CACHE = {}
 BLOCKSIZE = 65536

--- a/bin/run-db-download.py
+++ b/bin/run-db-download.py
@@ -10,7 +10,7 @@ from db_s3_utils import (
     get_git_sha,
     get_prev_db_data,
     set_db_data,
-    JSON_DATA_FILE,
+    JSON_DATA_FILE_NAME,
     DB_FILE,
     DATA_PATH,
 )
@@ -30,7 +30,7 @@ def get_file_url(filename):
 
 def download_db_info():
     try:
-        resp = requests.get(get_file_url(os.path.basename(JSON_DATA_FILE)))
+        resp = requests.get(get_file_url(JSON_DATA_FILE_NAME))
         resp.raise_for_status()
     except requests.RequestException:
         return None

--- a/bin/run-db-upload.py
+++ b/bin/run-db-upload.py
@@ -13,6 +13,7 @@ from db_s3_utils import (
     get_prev_db_data,
     set_db_data,
     JSON_DATA_FILE,
+    JSON_DATA_FILE_NAME,
     DB_FILE,
 )
 
@@ -57,7 +58,7 @@ def upload_db_data(db_data):
 
     try:
         # after successful file upload, upload json metadata
-        s3.upload_file(JSON_DATA_FILE, BUCKET_NAME, JSON_DATA_FILE,
+        s3.upload_file(JSON_DATA_FILE, BUCKET_NAME, JSON_DATA_FILE_NAME,
                        ExtraArgs={'ACL': 'public-read'})
     except Boto3Error:
         return 'ERROR: Failed to upload the new database info file: %s' % db_data


### PR DESCRIPTION
This is a thing that was missed in #8900. The DB data info file is now created in a subsdirectory of the project, and was being uploaded to the same subdirectory of the s3 bucket, even though it needs to be in the root of the bucket.