### PR TITLE
Make stub attribution work for legacy IE browsers (Fixes #9350)

### DIFF
--- a/media/js/base/stub-attribution.js
+++ b/media/js/base/stub-attribution.js
@@ -103,14 +103,23 @@ if (typeof window.Mozilla === 'undefined') {
 
         // target download buttons and other-platforms modal links.
         $('.download-list .download-link, .download-platform-list .download-link').each(function() {
+            var link = this;
             var version;
-            // If this is a transitional download link do nothing.
-            if (this.href && this.href.indexOf('/firefox/download/thanks/') === -1) {
+            var directLink;
+            // Append stub attribution data to direct download links.
+            if (link.href && link.href.indexOf('https://download.mozilla.org') !== -1) {
 
-                version = $(this).data('downloadVersion');
+                version = link.getAttribute('data-download-version');
                 // Append attribution params to Windows 32bit, 64bit, and MSI installer links.
                 if (version && (/win/.test(version))) {
-                    this.href = Mozilla.StubAttribution.appendToDownloadURL(this.href, data);
+                    link.href = Mozilla.StubAttribution.appendToDownloadURL(link.href, data);
+                }
+            } else if (link.href && link.href.indexOf('/firefox/download/thanks/') !== -1) {
+                // Append stub data to direct-link data attributes on transitional links for old IE browsers (Issue #9350)
+                directLink = link.getAttribute('data-direct-link');
+
+                if (directLink) {
+                    link.setAttribute('data-direct-link', Mozilla.StubAttribution.appendToDownloadURL(directLink, data));
                 }
             }
         });

--- a/tests/unit/spec/base/stub-attribution.js
+++ b/tests/unit/spec/base/stub-attribution.js
@@ -345,20 +345,20 @@ describe('stub-attribution.js', function() {
 
         /* eslint-disable camelcase */
         var data = {
-            attribution_code: 'foo',
-            attribution_sig: 'bar'
+            attribution_code: 'test-code',
+            attribution_sig: 'test-sig'
         };
         /* eslint-enable camelcase */
 
         var winUrl = 'https://download.mozilla.org/?product=firefox-stub&os=win&lang=en-US';
         var win64Url = 'https://download.mozilla.org/?product=firefox-50.0b11-SSL&os=win64&lang=en-US';
-        var transitionalUrl = '/firefox/download/thanks/';
+        var transitionalUrl = 'https://www.mozilla.org/firefox/download/thanks/';
 
         beforeEach(function() {
             var downloadMarkup = '<ul class="download-list">' +
-                                    '<li><a class="download-link" data-download-version="win" href="' + transitionalUrl +'">Download</a></li>' +
-                                    '<li><a class="download-link" data-download-version="win" href="' + winUrl+ '">Download</a></li>' +
-                                    '<li><a class="download-link" data-download-version="win64" href="' + win64Url + '">Download</a></li>' +
+                                    '<li><a id="link-transitional" class="download-link" data-download-version="win" href="' + transitionalUrl +'" data-direct-link="' + winUrl + '">Download</a></li>' +
+                                    '<li><a id="link-direct-win" class="download-link" data-download-version="win" href="' + winUrl+ '">Download</a></li>' +
+                                    '<li><a id="link-direct-win64" class="download-link" data-download-version="win64" href="' + win64Url + '">Download</a></li>' +
                                  '</ul>';
             $(downloadMarkup).appendTo('body');
         });
@@ -369,11 +369,12 @@ describe('stub-attribution.js', function() {
 
         it('should update download links with attribution data as expected', function() {
             spyOn(Mozilla.StubAttribution, 'meetsRequirements').and.returnValue(true);
-            spyOn(Mozilla.StubAttribution, 'appendToDownloadURL');
+            //spyOn(Mozilla.StubAttribution, 'appendToDownloadURL');
             Mozilla.StubAttribution.updateBouncerLinks(data);
-            expect(Mozilla.StubAttribution.appendToDownloadURL.calls.count()).toEqual(2);
-            expect(Mozilla.StubAttribution.appendToDownloadURL).toHaveBeenCalledWith(winUrl, data);
-            expect(Mozilla.StubAttribution.appendToDownloadURL).toHaveBeenCalledWith(win64Url, data);
+            expect(document.getElementById('link-transitional').href).toEqual('https://www.mozilla.org/firefox/download/thanks/');
+            expect(document.getElementById('link-transitional').getAttribute('data-direct-link')).toEqual('https://download.mozilla.org/?product=firefox-stub&os=win&lang=en-US&attribution_code=test-code&attribution_sig=test-sig');
+            expect(document.getElementById('link-direct-win').href).toEqual('https://download.mozilla.org/?product=firefox-stub&os=win&lang=en-US&attribution_code=test-code&attribution_sig=test-sig');
+            expect(document.getElementById('link-direct-win64').href).toEqual('https://download.mozilla.org/?product=firefox-50.0b11-SSL&os=win64&lang=en-US&attribution_code=test-code&attribution_sig=test-sig');
         });
 
         it('should do nothing if stub attribution requirements are not satisfied', function() {


### PR DESCRIPTION
## Description
- Add stub attribution data to `data-direct-link` attributes for legacy IE browsers.
- Update tests.

## Issue / Bugzilla link
#9350

## Testing
Demo: https://www-demo3.allizom.org/en-US/

1. Using IE 8/9 on Windows, navigate to the demo URL above.
2. Open IE developer tools, try to inspect the DOM of the download button in the nav.
3. Find a download link and inspect the attributes.
4. Verify `attribution_code` and `attribution_sig` params have been appended to the URL (see screenshot below).
5. Click download, and verify you still get the expected FF installer.

<img width="1675" alt="image" src="https://user-images.githubusercontent.com/400117/93097722-d4e07680-f69d-11ea-8652-ef38731357cc.png">
