### PR TITLE
Update comparison table on /new (Fixes #9359)

### DIFF
--- a/bedrock/exp/templates/exp/firefox/new/download.html
+++ b/bedrock/exp/templates/exp/firefox/new/download.html
@@ -147,9 +147,9 @@
                 </thead>
                 <tbody>
                   <tr>
-                    <th scope="row">{{ ftl('firefox-desktop-download-blocks-third-party') }}</th>
+                    <th scope="row">{{ ftl('firefox-desktop-download-blocks-third-party-default', fallback='firefox-desktop-download-blocks-third-party') }}</th>
                     <td>{{ picture('icon-check', 24, 24, ftl('firefox-desktop-download-yes')) }}</td>
-                    <td>{{ picture('icon-check', 24, 24, ftl('firefox-desktop-download-yes')) }}</td>
+                    <td>{{ picture('icon-dash', 24, 24, ftl('firefox-desktop-download-no')) }}</td>
                     <td>{{ picture('icon-check', 24, 24, ftl('firefox-desktop-download-yes')) }}</td>
                     <td>{{ picture('icon-check', 24, 24, ftl('firefox-desktop-download-yes')) }}</td>
                   </tr>

--- a/bedrock/firefox/templates/firefox/new/desktop/download.html
+++ b/bedrock/firefox/templates/firefox/new/desktop/download.html
@@ -136,9 +136,9 @@
                 </thead>
                 <tbody>
                   <tr>
-                    <th scope="row">{{ ftl('firefox-desktop-download-blocks-third-party') }}</th>
+                    <th scope="row">{{ ftl('firefox-desktop-download-blocks-third-party-default', fallback='firefox-desktop-download-blocks-third-party') }}</th>
                     <td>{{ picture('icon-check', 24, 24, ftl('firefox-desktop-download-yes')) }}</td>
-                    <td>{{ picture('icon-check', 24, 24, ftl('firefox-desktop-download-yes')) }}</td>
+                    <td>{{ picture('icon-dash', 24, 24, ftl('firefox-desktop-download-no')) }}</td>
                     <td>{{ picture('icon-check', 24, 24, ftl('firefox-desktop-download-yes')) }}</td>
                     <td>{{ picture('icon-check', 24, 24, ftl('firefox-desktop-download-yes')) }}</td>
                   </tr>

--- a/l10n/en/firefox/new/desktop.ftl
+++ b/l10n/en/firefox/new/desktop.ftl
@@ -30,6 +30,7 @@ firefox-desktop-download-compare-safari = { -brand-name-safari }
 firefox-desktop-download-yes = Yes
 firefox-desktop-download-no = No
 firefox-desktop-download-blocks-third-party = Blocks third-party tracking cookies
+firefox-desktop-download-blocks-third-party-default = Blocks third-party tracking cookies by default
 firefox-desktop-download-autoplay-blocking = Autoplay blocking
 firefox-desktop-download-blocks-social-trackers = Blocks social trackers
 # OS is short for "Operating System"


### PR DESCRIPTION
## Description
![image](https://user-images.githubusercontent.com/30483988/93146046-b761db80-f6a2-11ea-9fda-be14a5a7d3a0.png)

Adds "by default" to "Blocks third-party tracking cookies" table row and removes Chrome's check.

## Issue / Bugzilla link
#9359