### PR TITLE
String fix for Safari comparison page

### DIFF
--- a/l10n/en/firefox/browsers/compare/safari.ftl
+++ b/l10n/en/firefox/browsers/compare/safari.ftl
@@ -42,7 +42,7 @@ compare-safari-like-safari-firefox-encourages = Like { -brand-name-safari }, { -
 
 # Variables:
 #   $pocket (string) - link to getpocket.com with additional attributes for analytics
-compare-safari-also-when-you-sign-up-for-updated = Also, when you sign up for a { -brand-name-firefox } account you get access to unique services like <a { $pocket }>{ -brand-name-pocket }</a> that integrate directly into the browser. The { -brand-name-pocket } for { -brand-name-firefox } button lets you save web pages and videos to { -brand-name-pocket } in just one click, so you can read a clean, distraction-free version whenever and wherever you want — even offline.
+compare-safari-also-when-you-sign-up-for-updated = Also, when you sign up for a { -brand-name-firefox } account, you get access to unique services like <a { $pocket }>{ -brand-name-pocket }</a> that integrate directly into the browser. The { -brand-name-pocket } for { -brand-name-firefox } button lets you save web pages and videos to { -brand-name-pocket } in just one click, so you can read a clean, distraction-free version whenever and wherever you want — even offline.
 
 # Obsolete string
 # Variables:


### PR DESCRIPTION
## Description
Adding a comma to the string that was updated in #9416 

## Issue / Bugzilla link
https://github.com/mozilla-l10n/www-l10n/pull/108#discussion_r491034377
