### PR TITLE
H1 2020 Transparency Report

### DIFF
--- a/bedrock/mozorg/templates/mozorg/about/policy/transparency/includes/past-reports.html
+++ b/bedrock/mozorg/templates/mozorg/about/policy/transparency/includes/past-reports.html
@@ -7,6 +7,7 @@
 <nav class="prev-reports-nav">
   <h3>{{ _('Previous Reports') }}</h3>
   <ul>
+    <li><a href="{{ url('mozorg.about.policy.transparency.jul-dec-2019') }}">{{ _('July-December 2019 Report') }}</a></li>
     <li><a href="{{ url('mozorg.about.policy.transparency.jan-jun-2019') }}">{{ _('January-June 2019') }}</a></li>
     <li><a href="{{ url('mozorg.about.policy.transparency.jul-dec-2018') }}">{{ _('July-December 2018') }}</a></li>
     <li><a href="{{ url('mozorg.about.policy.transparency.jan-jun-2018') }}">{{ _('January-June 2018') }}</a></li>

--- a/bedrock/mozorg/templates/mozorg/about/policy/transparency/includes/reports-nav.html
+++ b/bedrock/mozorg/templates/mozorg/about/policy/transparency/includes/reports-nav.html
@@ -10,7 +10,7 @@
     {# This link should point to the latest report. Past reports are added to 'includes/past-reports.html' #}
     {# There are also links in the faq that need to be updated to point to the latest report. #}
     <li>
-      <a class="mzp-c-button" href="{{ url('mozorg.about.policy.transparency.jul-dec-2019') }}">{{ _('July-December 2019 Report') }}</a>
+      <a class="mzp-c-button" href="{{ url('mozorg.about.policy.transparency.jan-jun-2020') }}">{{ _('January-June 2020 Report') }}</a>
     </li>
   </ul>
 </nav>

--- a/bedrock/mozorg/templates/mozorg/about/policy/transparency/jan-jun-2020.html
+++ b/bedrock/mozorg/templates/mozorg/about/policy/transparency/jan-jun-2020.html
@@ -1,0 +1,259 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+
+{% extends "mozorg/about/policy/transparency/report-base.html" %}
+
+{% block page_title %}Transparency Report - January-June 2020{% endblock %}
+
+{% block report_title %}
+<h1>Transparency Report <span>Reporting Period: January 1, 2020 to June 30, 2020</span></h1>
+{% endblock %}
+
+{% block report_body %}
+<section id="government-user-data" class="c-collapsible-section">
+  <h2 class="c-collapsible-section-heading" data-accordion-role="tab">Government Demands for User Data</h2>
+
+  <div data-accordion-role="tabpanel">
+    <p>
+      In the Reporting Period, Mozilla received the following.
+    </p>
+
+    <table class="mzp-u-data-table">
+      <thead>
+        <tr>
+          <th scope="col">Legal Processes</th>
+          <th scope="col">Received</th>
+          <th scope="col">Data Produced</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <th scope="row">
+            <a
+              href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-search-warrant' }}">Search Warrants</a>
+          </th>
+          <td>1</td>
+          <td>1</td>
+        </tr>
+        <tr>
+          <th scope="row">
+            <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-subpoena' }}">Subpoenas</a>
+          </th>
+          <td>4</td>
+          <td>2</td>
+        </tr>
+        <tr>
+          <th scope="row">
+            <a
+              href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-court-order' }}">Court Orders</a>
+          </th>
+          <td>2</td>
+          <td>1</td>
+        </tr>
+        <tr>
+          <th scope="row">
+            <a
+              href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-wiretap-order' }}">Wiretap Orders</a>
+          </th>
+          <td>TK</td>
+          <td>TK</td>
+        </tr>
+        <tr>
+          <th scope="row">
+            <a
+              href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-pen-register-order' }}">Pen Register Orders</a>
+          </th>
+          <td>TK</td>
+          <td>TK</td>
+        </tr>
+        <tr>
+          <th scope="row">
+            <a
+              href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-emergency-request' }}">Emergency Requests</a>
+          </th>
+          <td>TK</td>
+          <td>TK</td>
+        </tr>
+        <tr>
+          <th scope="row">
+            <a
+              href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-natl-security-request' }}">National Security Requests</a>
+            <sup><a href="#footnote-1">1</a></sup>
+          </th>
+          <td>0-249</td>
+          <td>0-249</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <aside class="footnotes">
+      <p id="footnote-1">
+        We seek to be as transparent as possible about the User Data Requests that we receive from government authorities. The reporting band listed is one of four reporting bands permitted under U.S. law for National Security Requests.
+      </p>
+    </aside>
+  </div>
+</section>
+
+<section id="government-content-removal" class="c-collapsible-section">
+  <h2 class="c-collapsible-section-heading" data-accordion-role="tab">Government Demands for Content Removal</h2>
+
+  <div data-accordion-role="tabpanel">
+    <p>
+      In the Reporting Period, Mozilla received 2 government requests for content removal from our services.
+    </p>
+
+    <table class="mzp-u-data-table">
+      <thead>
+        <tr>
+          <th scope="col">Requesting Country</th>
+          <th scope="col">Requests Received</th>
+          <th scope="col">Data Produced</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <th scope="row">USA</th>
+          <td>2</td>
+          <td>2</td>
+        </tr>
+      </tbody>
+    </table>
+
+  </div>
+</section>
+
+<section id="copyright-trademark" class="c-collapsible-section">
+  <h2 class="c-collapsible-section-heading" data-accordion-role="tab">Copyright and Trademark Requests</h2>
+
+  <div data-accordion-role="tabpanel">
+    <h3>Copyright</h3>
+    <p>In the Reporting Period, we received 23 Copyright Takedown Notices and 0 Counter Notices.</p>
+
+    <table class="mzp-u-data-table">
+      <thead>
+        <tr>
+          <th scope="col">Mozilla Service</th>
+          <th scope="col">
+            <a
+              href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-takedown-notice' }}">Takedown Notices</a>
+          </th>
+          <th scope="col">
+            <a
+              href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-counter-notice' }}">Counter Notices</a>
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <th scope="row">Firefox Add-ons</th>
+          <td>16</td>
+          <td>0</td>
+        </tr>
+        <tr>
+          <th scope="row">Pocket</th>
+          <td>0</td>
+          <td>0</td>
+        </tr>
+        <tr>
+          <th scope="row">Other Services</th>
+          <td>7</td>
+          <td>0</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <h3>Trademark</h3>
+    <p>In the Reporting Period, we received 8 Trademark Takedown Notices and 0 Counter Notices.</p>
+
+    <table class="mzp-u-data-table">
+      <thead>
+        <tr>
+          <th scope="col">Mozilla Service</th>
+          <th scope="col">
+            <a
+              href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-takedown-notice' }}">Takedown Notices</a>
+          </th>
+          <th scope="col">
+            <a
+              href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-counter-notice' }}">Counter Notices</a>
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <th scope="row">Firefox Add-ons</th>
+          <td>8</td>
+          <td>0</td>
+        </tr>
+        <tr>
+          <th scope="row">Pocket</th>
+          <td>0</td>
+          <td>0</td>
+        </tr>
+        <tr>
+          <th scope="row">Other Services</th>
+          <td>0</td>
+          <td>0</td>
+      </tbody>
+    </table>
+    <h3>Personal Data Requests</h3>
+    <p>In the Reporting Period, we received 1,058 requests.</p>
+
+    <table class="mzp-u-data-table">
+      <thread>
+        <th scope="col">Service</th>
+        <th scope="col">Received</th>
+      </thread>
+      <tbody>
+        <tr>
+          <th scope="row">Mozilla</th>
+          <td>320</td>
+        </tr>
+        <tr>
+          <th scope="row">Pocket</th>
+          <td>738</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</section>
+
+<section id="supplement" class="c-collapsible-section">
+  <h2 class="c-collapsible-section-heading" data-accordion-role="tab">Supplement</h2>
+
+  <div data-accordion-role="tabpanel">
+    <h3>Legislative Reform</h3>
+    <p>During this reporting period, Mozilla kept up the fight for strong privacy and data protection across the globe. After the government of India rolled out a mandatory contact tracing app, we joined civil society allies in <a target="_blank" href="https://www.reuters.com/article/us-health-coronavirus-india-app/india-orders-coronavirus-tracing-app-for-all-workers-idUSKBN22E07K">calling for data protection and oversight</a> resulting in removal of the requirement for Indians to install the app and a <a href="https://www.reuters.com/article/us-health-coronavirus-india-app/india-makes-source-code-of-contact-tracing-app-public-idUSKBN23231S">commitment to open sourcing</a> it as well. We also <a href="https://blog.mozilla.org/netpolicy/files/2020/06/India-Joint-Parliamentary-Committee-Submission-Data-Protection-Bill-2019-25.02.2020.pdf">filed comments</a> with India’s Parliamentary Joint Committee on The Personal Data Protection Bill warning of the legislation’s glaring loophole for unchecked government surveillance. In hopes of mitigating the inherent privacy risks of using biometric data, we also <a href="https://blog.mozilla.org/netpolicy/2020/06/22/mozillas-response-to-eu-commission-public-consultation-on-ai/">responded to the EU’s public consultation on AI</a> and continue to engage with the European Commission on the upcoming Digital Services Act. In a major win, the Supreme Court of Kenya struck down the <a href="https://blog.mozilla.org/netpolicy/2019/02/08/kenya-government-mandates-dna-linked-national-id-without-data-protection-law/">country’s mandatory biometric identity system</a>, in a case which we filed an affidavit in. As many countries look to biometric-based digital ID platforms, we offered recommendations and guardrails in advancing the concept of openness for national biometric ID systems through our <a href="https://blog.mozilla.org/netpolicy/2020/01/22/what-could-an-open-id-system-look-like-recommendations-and-guardrails-for-national-biometric-id-projects/">open ID white paper</a>.</p>
+
+    <p>To protect Americans’ metadata, we called for elimination of the Call Detail Record program in the <a href="https://blog.mozilla.org/netpolicy/2020/02/24/goals-for-usa-freedom-reauthorization-reforms-access-and-transparency/">reauthorization of USA FREEDOM Act</a> along with greater transparency and better access to government-held information for amici curiae in the Foreign Intelligence Surveillance Court (FISC). Furthermore, we continued our opposition to Australia’s exceptional access law – the Telecommunications and Other Legislation Amendment – aided by Mozilla Distinguished Engineer Martin Thomson who <a href="https://www.inslm.gov.au/sites/default/files/2020-03/tola-transcript-public-hearing-day-1-20-feb-2020.pdf">testified at a hearing</a> held by Australia’s Independent National Security Legislation Monitor. In Mexico, we filed <a href="https://blog.mozilla.org/netpolicy/files/2020/08/Mexico-Net-Neutrality-Filing-031020-formatted_filed.pdf">comments</a> to the telecom regulator on their draft net neutrality guidelines which displayed loopholes allowing zero-rating, government shutdowns, and failed to adequately protect privacy. We also joined with the Center for Democracy & Technology to <a href="https://blog.mozilla.org/netpolicy/files/2020/06/2020-06-08-NTIA-filing-CDT-Mozilla.pdf">file comments</a> recommending that U.S. officials oppose the creation of a “New IP” internet architecture more suitable for centralized control and less privacy-respecting than the internet offers today. In India, we advocated for the assurance of respect of privacy as a fundamental right in our <a href="https://blog.mozilla.org/netpolicy/files/2020/05/India-NODE-Consultation-Mozilla-Response-31052020.pdf">submission</a> to the government on their National Open Digital Ecosystems (NODE) strategy.</p>
+
+    <p>We highlighted serious concerns with the Indian government’s proposed intermediary liability rules, joining with Cloudflare and Github to <a href="https://blog.mozilla.org/netpolicy/2020/01/07/open-letter-to-minister-rs-prasad-by-mozilla-github-and-cloudflare-release-the-most-recent-draft-of-intermediary-liability-rules-assuage-concerns-voiced-during-public-consultation/">pen an open letter</a>, prompting the government to delay these rules and <a href="https://www.bloomberg.com/news/articles/2020-02-12/400-million-social-media-users-set-to-lose-anonymity-in-india">claim</a> the final regulations will apply the toughest obligations only to the largest social media platforms. We expressed concern around threats to free speech and the undermining of strong encryption in our <a href="https://blog.mozilla.org/netpolicy/2020/03/05/mozilla-statement-on-earn-it-act/">statement on the EARN IT Act</a> in the US, and provided guidance to the EU on how to avoid flawed one-size-fits-all or otherwise misguided regulations through a <a href="https://blog.mozilla.org/netpolicy/2020/02/19/the-new-eu-digital-strategy-a-good-start-but-more-to-be-done/">new EU Digital Strategy</a> – which will outline the next five years of EU tech policy. We remain concerned by the spread of traceability around the world, and put forth <a href="https://blog.mozilla.org/netpolicy/2020/06/29/brazils-fake-news-law-harms-privacy-security-and-free-expression/">an analysis</a> of <a href="https://legis.senado.leg.br/sdleg-getter/documento?dm=8127649&ts=1593563111041&disposition=inline">Brazil’s fake news bill</a> which has since passed the Senate but still includes dangerous data retention and surveillance provisions as it heads to the Chamber of Deputies.</p>
+
+
+    <h3>Voluntary Threat Indicators & Data Disclosures</h3>
+    <table class="mzp-u-data-table">
+      <thead>
+        <tr>
+          <th scope="col">Type of Disclosure</th>
+          <th scope="col">Number of Disclosures</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <th scope="row"><a
+              href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-threat-indicator' }}">Cybersecurity Threat Indicator</a>
+          </th>
+          <td>0</td>
+        </tr>
+        <tr>
+          <th scope="row">
+            Other <a href="{{ url('mozorg.about.policy.transparency.index') + '#dfn-specific-user' }}">Specific User</a> Data Disclosure
+          </th>
+          <td>0</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</section>
+{% endblock %}

--- a/bedrock/mozorg/urls.py
+++ b/bedrock/mozorg/urls.py
@@ -78,6 +78,8 @@ urlpatterns = (
          'mozorg/about/policy/transparency/jan-jun-2019.html'),
     page('about/policy/transparency/jul-dec-2019',
          'mozorg/about/policy/transparency/jul-dec-2019.html'),
+    page('about/policy/transparency/jan-jun-2020',
+         'mozorg/about/policy/transparency/jan-jun-2020.html'),
 
     page('contact', 'mozorg/contact/contact-landing.html'),
     page('contact/spaces', 'mozorg/contact/spaces/spaces-landing.html'),


### PR DESCRIPTION
## Description

Create new page for the H1 2020 Transparency Report  and update nav/links on root Transparency page.
## Issue / Bugzilla link

#9335 

## Testing

- 2020 Report: https://www-demo-pr-9422.herokuapp.com/en-US/about/policy/transparency/jan-jun-2020/
- Transparency root page: https://www-demo-pr-9422.herokuapp.com/en-US/about/policy/transparency/
