### PR TITLE
Exclude GA on /privacy/thunderbird/ (Fixes #9426)

### DIFF
--- a/bedrock/privacy/templates/privacy/notices/thunderbird.html
+++ b/bedrock/privacy/templates/privacy/notices/thunderbird.html
@@ -8,3 +8,6 @@
 {% block body_class %}mzp-t-mozilla format-none{% endblock%}
 
 {% block article_header_logo %}{{ static('img/privacy/logo-thunderbird.png') }}{% endblock %}
+
+{# Disable GA on Thunderbird Privacy Notice. Issue 9426 #}
+{% block google_analytics %}{% endblock %}


### PR DESCRIPTION
## Description
Removes Google Analytics from Thunderbird privacy notice.

http://localhost:8000/en-US/privacy/thunderbird/

## Issue / Bugzilla link
https://github.com/mozilla/bedrock/issues/9426

## Testing
- [ ] GA JS bundle should not be present on the page