### PR TITLE
Fix JS error on FB Container page (Fixes #9437)

### DIFF
--- a/media/js/firefox/facebook-container-video.js
+++ b/media/js/firefox/facebook-container-video.js
@@ -16,6 +16,10 @@
     function initVideoInteractionTracking() {
         var video = document.getElementById('fbcontainer-video');
 
+        if (!video) {
+            return;
+        }
+
         video.addEventListener('play', function() {
             trackVideoInteraction(this.getAttribute('data-ga-label'), 'play');
         }, false);


### PR DESCRIPTION
## Description
Fixes a (harmless) JS error when viewing the German page (since that locale uses a youtube iframe instead of a native `<video>` element).

- http://localhost:8000/de/firefox/facebookcontainer/
- http://localhost:8000/en-US/firefox/facebookcontainer/

## Issue / Bugzilla link
#9437

## Testing
- [x] No JS error should be thrown on the /de/ page.
- [x] Video interaction tracking should still work as expected on the /en-US/page.