### PR TITLE
Migrate features/adblocker page to Fluent (#9146) [skip l10n]

### DIFF
--- a/bedrock/firefox/templates/firefox/features/adblocker.html
+++ b/bedrock/firefox/templates/firefox/features/adblocker.html
@@ -1,44 +1,37 @@
 {# This Source Code Form is subject to the terms of the Mozilla Public
-  # License, v. 2.0. If a copy of the MPL was not distributed with this
-  # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
 
 {% from "macros-protocol.html" import call_out, call_out_compact with context %}
 
- {% add_lang_files "firefox/adblocker" %}
+{% extends "firefox/base/base-protocol.html" %}
 
- {% extends "firefox/base/base-protocol.html" %}
+{% block page_title %}{{ ftl('features-adblocker-how-to-block-annoying') }}{% endblock %}
 
- {% block page_title %}{{ _('How to block annoying ads using an ad blocker') }}{% endblock %}
+{% block page_desc %}
+  {{ ftl('features-adblocker-how-to-stop-seeing-too') }}
+{% endblock %}
 
- {% block page_desc %}
-   {{ _('How to stop seeing too many ads and keep companies from following you around online. An ad blocker guide from the Firefox web browser.') }}
- {% endblock %}
-
- {% block page_css %}
-   {{ super() }}
-   {{ css_bundle('adblocker') }}
- {% endblock %}
+{% block page_css %}
+  {{ super() }}
+  {{ css_bundle('adblocker') }}
+{% endblock %}
 
 {% block body_class %}mzp-t-firefox{% endblock %}
 
- {% block content %}
-
+{% block content %}
   <section class="mzp-c-hero mzp-t-product-firefox">
     <div class="mzp-l-content">
       <div class="mzp-c-hero-body">
-        <h1 class="mzp-c-hero-title">{{ _('The ad blocker – a secret weapon against annoying ads.') }}</h1>
-        <h2 class="mzp-c-hero-subtitle">{{ _('So many ads, so little patience… It’s time to stop the madness.') }}</h2>
+        <h1 class="mzp-c-hero-title">{{ ftl('features-adblocker-the-ad-blocker-a-secret') }}</h1>
+        <h2 class="mzp-c-hero-subtitle">{{ ftl('features-adblocker-so-many-ads-so-little') }}</h2>
         <div class="mzp-c-hero-desc">
-          <p>{{ _('The average person sees an average of 4,000 ads a day. If you think that’s too many, an ad blocker is your new best friend.') }}</p>
+          <p>{{ ftl('features-adblocker-the-average-person-sees') }}</p>
           <p>
-            {% trans %}
-            An ad blocker is a piece of software that can be used to block ads, and they work in two ways. The first way is when an ad blocker blocks the signal from an advertiser’s server, so the ad never shows up on your page. Another way ad blockers work is by blocking out sections of a website that could be ads.
-            {% endtrans %}
+            {{ ftl('features-adblocker-an-ad-blocker-is-a-piece') }}
           </p>
           <p>
-            {% trans firefox=url('firefox.new'), addons='https://blog.mozilla.org/firefox/ad-blocker-roundup-5-adblockers-that-improve-your-internet-experience/' %}
-            These ads might be loud video ads, ads that follow you around the web, trackers, third-party cookies, and more. To use an ad blocker, you can search for ad blocker add-ons that are available in your browser. <a href="{{ firefox }}">Firefox</a>, for example, has <a href="{{ addons }}">this list of approved ad blocker add-ons</a>. Click on this list (or ad blockers that are approved for your browser) and see which fits your needs.
-            {% endtrans %}
+            {{ ftl('features-adblocker-these-ads-might-be-loud', firefox=url('firefox.new'), addons='https://blog.mozilla.org/firefox/ad-blocker-roundup-5-adblockers-that-improve-your-internet-experience/') }}
           </p>
         </div>
         <div class="mzp-c-hero-cta">
@@ -49,30 +42,22 @@
   </section>
 
   <section class="mzp-l-content mzp-t-content-md">
-    <h2 class="section-title">{{ _('Find the right ad blocker for you') }}</h2>
+    <h2 class="section-title">{{ ftl('features-adblocker-find-the-right-ad-blocker') }}</h2>
     <p>
-      {% trans url='https://addons.mozilla.org/firefox/addon/adblocker-ultimate/?src=collection&collection_id=314d7111-6e17-485e-9946-315cb2f477e7' %}
-      There’s <a href="{{ url }}">AdBlocker Ultimate</a> that gets rid of every single ad, but buyer beware. Some of your favorite newspapers and magazines rely on advertising. Too many people blocking their ads could put them out of business.
-      {% endtrans %}
+      {{ ftl('features-adblocker-theres-adblocker-ultimate', url='https://addons.mozilla.org/firefox/addon/adblocker-ultimate/?src=collection&collection_id=314d7111-6e17-485e-9946-315cb2f477e7') }}
     </p>
     <p>
-      {% trans url='https://addons.mozilla.org/firefox/addon/popup-blocker/?src=collection&collection_id=314d7111-6e17-485e-9946-315cb2f477e7' %}
-      Popup ads are the worst. Block them with <a href="{{ url }}">Popup Blocker</a> and never deal with another annoying popup again.
-      {% endtrans %}
+      {{ ftl('features-adblocker-popup-ads-are-the-worst', url='https://addons.mozilla.org/firefox/addon/popup-blocker/?src=collection&collection_id=314d7111-6e17-485e-9946-315cb2f477e7') }}
     </p>
     <p>
-      {% trans url='https://addons.mozilla.org/firefox/addon/adblock-for-firefox/?src=collection&collection_id=314d7111-6e17-485e-9946-315cb2f477e7' %}
-      One of the most popular ad blockers for Chrome, Safari and Firefox is <a href="{{ url }}">AdBlock</a>. Use it to block ads on Facebook, YouTube and Hulu.
-      {% endtrans %}
+      {{ ftl('features-adblocker-one-of-the-most-popular', url='https://addons.mozilla.org/firefox/addon/adblock-for-firefox/?src=collection&collection_id=314d7111-6e17-485e-9946-315cb2f477e7') }}
     </p>
   </section>
 
   <section class="mzp-l-content mzp-t-content-md">
-    <h2 class="section-title">{{_('Create a tracker-free zone with Content Blocking') }}</h2>
+    <h2 class="section-title">{{ftl('features-adblocker-create-a-tracker-free') }}</h2>
     <p>
-      {% trans privacy='https://restoreprivacy.com/firefox-privacy/', blocking='https://support.mozilla.org/kb/content-blocking' %}
-      On Firefox, you can use <a href="{{ privacy }}">Privacy</a> or <a href="{{ blocking }}">Content Blocking</a> settings to get even more control over ad trackers that serve you the ads.
-      {% endtrans %}
+      {{ ftl('features-adblocker-on-firefox-you-can-use', privacy='https://restoreprivacy.com/firefox-privacy/', blocking='https://support.mozilla.org/kb/content-blocking') }}
     </p>
   </section>
 
@@ -81,20 +66,16 @@
   </section>
 
   <section class="mzp-l-content mzp-t-content-md">
-    <h2 class="section-title">{{_('Choose your level of protection') }}</h2>
+    <h2 class="section-title">{{ftl('features-adblocker-choose-your-level-of-protection') }}</h2>
     <p>
-      {% trans %}
-      To start, click on the Firefox menu in the top right-hand corner of your screen. It looks like three lines stacked on top of each other. In the drop-down menu, click on Content Blocking. You should see a blue pop-up with different selections.
-      {% endtrans %}
+      {{ ftl('features-adblocker-to-start-click-on-the') }}
     </p>
   </section>
 
   <section class="mzp-l-content mzp-t-content-md">
-    <h2 class="section-title">{{_('Go easy with Standard mode') }}</h2>
+    <h2 class="section-title">{{ftl('features-adblocker-go-easy-with-standard') }}</h2>
     <p>
-      {% trans url=url('firefox.features.private-browsing') %}
-      If ads don’t bother you and you don’t mind being followed by trackers and third-party cookies, then the Standard setting should work for you. To get trackers off your tail in Standard mode, use a <a href="{{ url }}">Private Browsing</a> window.
-      {% endtrans %}
+      {{ ftl('features-adblocker-if-ads-dont-bother-you', url=url('firefox.features.private-browsing')) }}
     </p>
   </section>
 
@@ -103,20 +84,16 @@
   </section>
 
   <section class=" mzp-l-content mzp-t-content-md">
-    <h2 class="section-title">{{_('Get tough with Strict mode') }}</h2>
+    <h2 class="section-title">{{ftl('features-adblocker-get-tough-with-strict') }}</h2>
     <p>
-      {% trans %}
-      If seeing too many ads ruins your day, then the Strict mode is a better fit. This mode will block known third-party trackers and cookies in all Firefox windows.
-      {% endtrans %}
+      {{ ftl('features-adblocker-if-seeing-too-many-ads') }}
     </p>
   </section>
 
   <section class="mzp-l-content mzp-t-content-md">
-    <h2 class="section-title">{{_('Do-it-yourself Custom mode') }}</h2>
+    <h2 class="section-title">{{ftl('features-adblocker-do-it-yourself-custom') }}</h2>
     <p>
-      {% trans %}
-      The Custom setting gives you the ultimate choice. You can decide what you’re blocking, including trackers, cookies and more. If you allow cookies from a website, you’ll automatically be in Custom mode.
-      {% endtrans %}
+      {{ ftl('features-adblocker-the-custom-setting-gives') }}
     </p>
   </section>
 
@@ -125,56 +102,44 @@
   </section>
 
   <section class="mzp-l-content mzp-t-content-md">
-    <h2 class="section-title">{{_('Cover your trail, block trackers') }}</h2>
+    <h2 class="section-title">{{ftl('features-adblocker-cover-your-trail-block') }}</h2>
     <p>
-      {% trans %}
-      Click on the Trackers box and you’ll be able to block trackers in two ways. One way to block trackers is to do it when you’re working in a Private Window. Another way to do it is to block trackers in all windows. Keep in mind that if you choose to always block trackers, some pages might not load correctly.
-      {% endtrans %}
+      {{ ftl('features-adblocker-click-on-the-trackers') }}
     </p>
     {{ high_res_img('img/firefox/features/adblocker/custom-trackers.png', {'alt': ''}) }}
   </section>
 
   <section class="mzp-l-content mzp-t-content-md">
-    <h2 class="section-title">{{_('Take a bite out of cookies') }}</h2>
+    <h2 class="section-title">{{ftl('features-adblocker-take-a-bite-out-of-cookies') }}</h2>
     <p>
-      {% trans url='https://support.mozilla.org/kb/storage' %}
-      <a href="{{ url }}">Cookies</a> are sent by websites you visit. They live on your computer and monitor what you’ve been doing on a site. When an airline hikes your rates because you’ve looked at plane tickets once that day, that is the handiwork of a cookie.
-      {% endtrans %}
+      {{ ftl('features-adblocker-cookies-are-sent-by-websites', url='https://support.mozilla.org/kb/storage') }}
     </p>
     <p>
-      {% trans %}
-      In Firefox, you can block all third-party cookies or just those set by trackers. Be aware that blocking all cookies can break some sites.
-      {% endtrans %}
+      {{ ftl('features-adblocker-in-firefox-you-can-block') }}
     </p>
     {{ high_res_img('img/firefox/features/adblocker/third-party-cookies.png', {'alt': ''}) }}
   </section>
 
   <section class="mzp-l-content mzp-t-content-md">
-    <h2 class="section-title">{{_('Send a Do Not Track signal') }}</h2>
+    <h2 class="section-title">{{ftl('features-adblocker-send-a-do-not-track-signal') }}</h2>
     <p>
-      {% trans url='https://support.mozilla.org/kb/how-do-i-turn-do-not-track-feature' %}
-      If you don’t want your online behavior used for ads, you can send websites a polite “thanks but no thanks” letter by checking the <a href="{{ url }}">Do Not Track</a> option of Firefox. Participation is voluntary, but the websites that participate will stop tracking you immediately.
-      {% endtrans %}
+      {{ ftl('features-adblocker-if-you-dont-want-your', url='https://support.mozilla.org/kb/how-do-i-turn-do-not-track-feature') }}
     </p>
     {{ high_res_img('img/firefox/features/adblocker/dnt_screenshot.png', {'alt': ''}) }}
   </section>
 
   <section class="mzp-l-content mzp-t-content-md">
-      <h2 class="section-title">{{_('Speed up thanks to ad blockers') }}</h2>
+      <h2 class="section-title">{{ftl('features-adblocker-speed-up-thanks-to-ad') }}</h2>
       <p>
-        {% trans %}
-        In some cases, an ad blocker can help your browser go faster. When an ad is loading, it can slow down a website. At the same time, it takes longer to find what you’re looking for if you’re too busy closing yet another ad.
-        {% endtrans %}
+        {{ ftl('features-adblocker-in-some-cases-an-ad-blocker') }}
       </p>
       <p>
-        {% trans url=url('firefox.new') %}
-        If you want to learn more about ad blocking, there are hundreds of ad blocker extensions available for Firefox and other browsers. If want to try out the ad blockers Firefox uses, <a href="{{ url }}">click here to download</a> a browser that puts privacy first.
-        {% endtrans %}
+        {{ ftl('features-adblocker-if-you-want-to-learn-more', url=url('firefox.new')) }}
       </p>
     </section>
 
   {% call call_out_compact(
-    title=_('Take control of your browser.'),
+    title=ftl('features-adblocker-take-control-of-your-browser'),
     class='mzp-t-product-firefox mzp-t-firefox'
   ) %}
     <div class="download-firefox">
@@ -182,4 +147,4 @@
     </div>
   {% endcall %}
 
- {% endblock %}
+{% endblock %}

--- a/bedrock/firefox/urls.py
+++ b/bedrock/firefox/urls.py
@@ -48,7 +48,8 @@ urlpatterns = (
 
     page('firefox/features', 'firefox/features/index.html',
          ftl_files=['firefox/features/shared', 'firefox/features/index']),
-    page('firefox/features/adblocker', 'firefox/features/adblocker.html'),
+    page('firefox/features/adblocker', 'firefox/features/adblocker.html',
+         ftl_files=['firefox/features/adblocker']),
     page('firefox/features/bookmarks', 'firefox/features/bookmarks.html',
          ftl_files=['firefox/features/shared', 'firefox/features/bookmarks']),
     page('firefox/features/fast', 'firefox/features/fast.html',

--- a/l10n/en/brands.ftl
+++ b/l10n/en/brands.ftl
@@ -13,6 +13,7 @@
 -brand-name-facebook = Facebook
 -brand-name-github = GitHub
 -brand-name-google = Google
+-brand-name-hulu = Hulu
 -brand-name-microsoft = Microsoft
 -brand-name-mozilla = Mozilla
 -brand-name-mozilla-corporation = Mozilla Corporation

--- a/l10n/en/firefox/features/adblocker.ftl
+++ b/l10n/en/firefox/features/adblocker.ftl
@@ -1,0 +1,74 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+### URL: https://www-dev.allizom.org/firefox/features/adblocker/
+
+features-adblocker-how-to-block-annoying = How to block annoying ads using an ad blocker
+features-adblocker-how-to-stop-seeing-too = How to stop seeing too many ads and keep companies from following you around online. An ad blocker guide from the { -brand-name-firefox } web browser.
+features-adblocker-the-ad-blocker-a-secret = The ad blocker – a secret weapon against annoying ads.
+features-adblocker-so-many-ads-so-little = So many ads, so little patience… It’s time to stop the madness.
+features-adblocker-the-average-person-sees = The average person sees an average of 4,000 ads a day. If you think that’s too many, an ad blocker is your new best friend.
+features-adblocker-an-ad-blocker-is-a-piece = An ad blocker is a piece of software that can be used to block ads, and they work in two ways. The first way is when an ad blocker blocks the signal from an advertiser’s server, so the ad never shows up on your page. Another way ad blockers work is by blocking out sections of a website that could be ads.
+
+# Variables:
+#   $firefox (url) - link to https://www.mozilla.org/firefox/new/
+#   $addons (url) - link to https://blog.mozilla.org/firefox/ad-blocker-roundup-5-adblockers-that-improve-your-internet-experience/
+features-adblocker-these-ads-might-be-loud = These ads might be loud video ads, ads that follow you around the web, trackers, third-party cookies, and more. To use an ad blocker, you can search for ad blocker add-ons that are available in your browser. <a href="{ $firefox }">{ -brand-name-firefox }</a>, for example, has <a href="{ $addons }">this list of approved ad blocker add-ons</a>. Click on this list (or ad blockers that are approved for your browser) and see which fits your needs.
+
+features-adblocker-find-the-right-ad-blocker = Find the right ad blocker for you
+
+# Variables:
+#   $url (url) - link to https://addons.mozilla.org/firefox/addon/adblocker-ultimate/
+features-adblocker-theres-adblocker-ultimate = There’s <a href="{ $url }">AdBlocker Ultimate</a> that gets rid of every single ad, but buyer beware. Some of your favorite newspapers and magazines rely on advertising. Too many people blocking their ads could put them out of business.
+
+# Variables:
+#   $url (url) - link to https://addons.mozilla.org/firefox/addon/popup-blocker/
+features-adblocker-popup-ads-are-the-worst = Popup ads are the worst. Block them with <a href="{ $url }">Popup Blocker</a> and never deal with another annoying popup again.
+
+# Variables:
+#   $url (url) - link to https://addons.mozilla.org/firefox/addon/adblock-for-firefox/
+features-adblocker-one-of-the-most-popular = One of the most popular ad blockers for { -brand-name-chrome }, { -brand-name-safari } and { -brand-name-firefox } is <a href="{ $url }">AdBlock</a>. Use it to block ads on { -brand-name-facebook }, { -brand-name-youtube } and { -brand-name-hulu }.
+
+features-adblocker-create-a-tracker-free = Create a tracker-free zone with Content Blocking
+
+# Variables:
+#   $privacy (url) - link to https://restoreprivacy.com/firefox-privacy/
+#   $blocking (url) - link to https://support.mozilla.org/kb/content-blocking
+features-adblocker-on-firefox-you-can-use = On { -brand-name-firefox }, you can use <a href="{ $privacy }">Privacy</a> or <a href="{ $blocking }">Content Blocking</a> settings to get even more control over ad trackers that serve you the ads.
+
+features-adblocker-choose-your-level-of-protection = Choose your level of protection
+features-adblocker-to-start-click-on-the = To start, click on the { -brand-name-firefox } menu in the top right-hand corner of your screen. It looks like three lines stacked on top of each other. In the drop-down menu, click on Content Blocking. You should see a blue pop-up with different selections.
+features-adblocker-go-easy-with-standard = Go easy with Standard mode
+
+# Variables:
+#   $url (url) - link to https://www.mozilla.org/firefox/features/private-browsing/
+features-adblocker-if-ads-dont-bother-you = If ads don’t bother you and you don’t mind being followed by trackers and third-party cookies, then the Standard setting should work for you. To get trackers off your tail in Standard mode, use a <a href="{ $url }">Private Browsing</a> window.
+
+features-adblocker-get-tough-with-strict = Get tough with Strict mode
+features-adblocker-if-seeing-too-many-ads = If seeing too many ads ruins your day, then the Strict mode is a better fit. This mode will block known third-party trackers and cookies in all { -brand-name-firefox } windows.
+features-adblocker-do-it-yourself-custom = Do-it-yourself Custom mode
+features-adblocker-the-custom-setting-gives = The Custom setting gives you the ultimate choice. You can decide what you’re blocking, including trackers, cookies and more. If you allow cookies from a website, you’ll automatically be in Custom mode.
+features-adblocker-cover-your-trail-block = Cover your trail, block trackers
+features-adblocker-click-on-the-trackers = Click on the Trackers box and you’ll be able to block trackers in two ways. One way to block trackers is to do it when you’re working in a Private Window. Another way to do it is to block trackers in all windows. Keep in mind that if you choose to always block trackers, some pages might not load correctly.
+features-adblocker-take-a-bite-out-of-cookies = Take a bite out of cookies
+
+# Variables:
+#   $url (url) - link to https://support.mozilla.org/kb/storage
+features-adblocker-cookies-are-sent-by-websites = <a href="{ $url }">Cookies</a> are sent by websites you visit. They live on your computer and monitor what you’ve been doing on a site. When an airline hikes your rates because you’ve looked at plane tickets once that day, that is the handiwork of a cookie.
+
+features-adblocker-in-firefox-you-can-block = In { -brand-name-firefox }, you can block all third-party cookies or just those set by trackers. Be aware that blocking all cookies can break some sites.
+features-adblocker-send-a-do-not-track-signal = Send a Do Not Track signal
+
+# Variables:
+#   $url (url) - link to https://support.mozilla.org/kb/how-do-i-turn-do-not-track-feature
+features-adblocker-if-you-dont-want-your = If you don’t want your online behavior used for ads, you can send websites a polite “thanks but no thanks” letter by checking the <a href="{ $url }">Do Not Track</a> option of { -brand-name-firefox }. Participation is voluntary, but the websites that participate will stop tracking you immediately.
+
+features-adblocker-speed-up-thanks-to-ad = Speed up thanks to ad blockers
+features-adblocker-in-some-cases-an-ad-blocker = In some cases, an ad blocker can help your browser go faster. When an ad is loading, it can slow down a website. At the same time, it takes longer to find what you’re looking for if you’re too busy closing yet another ad.
+
+# Variables:
+#   $url (url) - link to https://www.mozilla.org/firefox/new/
+features-adblocker-if-you-want-to-learn-more = If you want to learn more about ad blocking, there are hundreds of ad blocker extensions available for { -brand-name-firefox } and other browsers. If want to try out the ad blockers { -brand-name-firefox } uses, <a href="{ $url }">click here to download</a> a browser that puts privacy first.
+
+features-adblocker-take-control-of-your-browser = Take control of your browser.

--- a/lib/fluent_migrations/firefox/features/adblocker.py
+++ b/lib/fluent_migrations/firefox/features/adblocker.py
@@ -1,0 +1,207 @@
+from __future__ import absolute_import
+import fluent.syntax.ast as FTL
+from fluent.migrate.helpers import transforms_from
+from fluent.migrate.helpers import VARIABLE_REFERENCE, TERM_REFERENCE
+from fluent.migrate import REPLACE, COPY
+
+adblocker = "firefox/adblocker.lang"
+
+def migrate(ctx):
+    """Migrate bedrock/firefox/templates/firefox/features/adblocker.html, part {index}."""
+
+    ctx.add_transforms(
+        "firefox/features/adblocker.ftl",
+        "firefox/features/adblocker.ftl",
+        transforms_from("""
+features-adblocker-how-to-block-annoying = {COPY(adblocker, "How to block annoying ads using an ad blocker",)}
+""", adblocker=adblocker) + [
+            FTL.Message(
+                id=FTL.Identifier("features-adblocker-how-to-stop-seeing-too"),
+                value=REPLACE(
+                    adblocker,
+                    "How to stop seeing too many ads and keep companies from following you around online. An ad blocker guide from the Firefox web browser.",
+                    {
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                    }
+                )
+            ),
+        ] + transforms_from("""
+features-adblocker-the-ad-blocker-a-secret = {COPY(adblocker, "The ad blocker – a secret weapon against annoying ads.",)}
+features-adblocker-so-many-ads-so-little = {COPY(adblocker, "So many ads, so little patience… It’s time to stop the madness.",)}
+features-adblocker-the-average-person-sees = {COPY(adblocker, "The average person sees an average of 4,000 ads a day. If you think that’s too many, an ad blocker is your new best friend.",)}
+features-adblocker-an-ad-blocker-is-a-piece = {COPY(adblocker, "An ad blocker is a piece of software that can be used to block ads, and they work in two ways. The first way is when an ad blocker blocks the signal from an advertiser’s server, so the ad never shows up on your page. Another way ad blockers work is by blocking out sections of a website that could be ads.",)}
+""", adblocker=adblocker) + [
+            FTL.Message(
+                id=FTL.Identifier("features-adblocker-these-ads-might-be-loud"),
+                value=REPLACE(
+                    adblocker,
+                    "These ads might be loud video ads, ads that follow you around the web, trackers, third-party cookies, and more. To use an ad blocker, you can search for ad blocker add-ons that are available in your browser. <a href=\"%(firefox)s\">Firefox</a>, for example, has <a href=\"%(addons)s\">this list of approved ad blocker add-ons</a>. Click on this list (or ad blockers that are approved for your browser) and see which fits your needs.",
+                    {
+                        "%%": "%",
+                        "%(firefox)s": VARIABLE_REFERENCE("firefox"),
+                        "%(addons)s": VARIABLE_REFERENCE("addons"),
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                    }
+                )
+            ),
+        ] + transforms_from("""
+features-adblocker-find-the-right-ad-blocker = {COPY(adblocker, "Find the right ad blocker for you",)}
+""", adblocker=adblocker) + [
+            FTL.Message(
+                id=FTL.Identifier("features-adblocker-theres-adblocker-ultimate"),
+                value=REPLACE(
+                    adblocker,
+                    "There’s <a href=\"%(url)s\">AdBlocker Ultimate</a> that gets rid of every single ad, but buyer beware. Some of your favorite newspapers and magazines rely on advertising. Too many people blocking their ads could put them out of business.",
+                    {
+                        "%%": "%",
+                        "%(url)s": VARIABLE_REFERENCE("url"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("features-adblocker-popup-ads-are-the-worst"),
+                value=REPLACE(
+                    adblocker,
+                    "Popup ads are the worst. Block them with <a href=\"%(url)s\">Popup Blocker</a> and never deal with another annoying popup again.",
+                    {
+                        "%%": "%",
+                        "%(url)s": VARIABLE_REFERENCE("url"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("features-adblocker-one-of-the-most-popular"),
+                value=REPLACE(
+                    adblocker,
+                    "One of the most popular ad blockers for Chrome, Safari and Firefox is <a href=\"%(url)s\">AdBlock</a>. Use it to block ads on Facebook, YouTube and Hulu.",
+                    {
+                        "%%": "%",
+                        "%(url)s": VARIABLE_REFERENCE("url"),
+                        "Facebook": TERM_REFERENCE("brand-name-facebook"),
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                        "YouTube": TERM_REFERENCE("brand-name-youtube"),
+                        "Chrome": TERM_REFERENCE("brand-name-chrome"),
+                        "Safari": TERM_REFERENCE("brand-name-safari"),
+                        "Hulu": TERM_REFERENCE("brand-name-hulu"),
+                    }
+                )
+            ),
+        ] + transforms_from("""
+features-adblocker-create-a-tracker-free = {COPY(adblocker, "Create a tracker-free zone with Content Blocking",)}
+""", adblocker=adblocker) + [
+            FTL.Message(
+                id=FTL.Identifier("features-adblocker-on-firefox-you-can-use"),
+                value=REPLACE(
+                    adblocker,
+                    "On Firefox, you can use <a href=\"%(privacy)s\">Privacy</a> or <a href=\"%(blocking)s\">Content Blocking</a> settings to get even more control over ad trackers that serve you the ads.",
+                    {
+                        "%%": "%",
+                        "%(privacy)s": VARIABLE_REFERENCE("privacy"),
+                        "%(blocking)s": VARIABLE_REFERENCE("blocking"),
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                    }
+                )
+            ),
+        ] + transforms_from("""
+features-adblocker-choose-your-level-of-protection = {COPY(adblocker, "Choose your level of protection",)}
+""", adblocker=adblocker) + [
+            FTL.Message(
+                id=FTL.Identifier("features-adblocker-to-start-click-on-the"),
+                value=REPLACE(
+                    adblocker,
+                    "To start, click on the Firefox menu in the top right-hand corner of your screen. It looks like three lines stacked on top of each other. In the drop-down menu, click on Content Blocking. You should see a blue pop-up with different selections.",
+                    {
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                    }
+                )
+            ),
+        ] + transforms_from("""
+features-adblocker-go-easy-with-standard = {COPY(adblocker, "Go easy with Standard mode",)}
+""", adblocker=adblocker) + [
+            FTL.Message(
+                id=FTL.Identifier("features-adblocker-if-ads-dont-bother-you"),
+                value=REPLACE(
+                    adblocker,
+                    "If ads don’t bother you and you don’t mind being followed by trackers and third-party cookies, then the Standard setting should work for you. To get trackers off your tail in Standard mode, use a <a href=\"%(url)s\">Private Browsing</a> window.",
+                    {
+                        "%%": "%",
+                        "%(url)s": VARIABLE_REFERENCE("url"),
+                    }
+                )
+            ),
+        ] + transforms_from("""
+features-adblocker-get-tough-with-strict = {COPY(adblocker, "Get tough with Strict mode",)}
+""", adblocker=adblocker) + [
+            FTL.Message(
+                id=FTL.Identifier("features-adblocker-if-seeing-too-many-ads"),
+                value=REPLACE(
+                    adblocker,
+                    "If seeing too many ads ruins your day, then the Strict mode is a better fit. This mode will block known third-party trackers and cookies in all Firefox windows.",
+                    {
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                    }
+                )
+            ),
+        ] + transforms_from("""
+features-adblocker-do-it-yourself-custom = {COPY(adblocker, "Do-it-yourself Custom mode",)}
+features-adblocker-the-custom-setting-gives = {COPY(adblocker, "The Custom setting gives you the ultimate choice. You can decide what you’re blocking, including trackers, cookies and more. If you allow cookies from a website, you’ll automatically be in Custom mode.",)}
+features-adblocker-cover-your-trail-block = {COPY(adblocker, "Cover your trail, block trackers",)}
+features-adblocker-click-on-the-trackers = {COPY(adblocker, "Click on the Trackers box and you’ll be able to block trackers in two ways. One way to block trackers is to do it when you’re working in a Private Window. Another way to do it is to block trackers in all windows. Keep in mind that if you choose to always block trackers, some pages might not load correctly.",)}
+features-adblocker-take-a-bite-out-of-cookies = {COPY(adblocker, "Take a bite out of cookies",)}
+""", adblocker=adblocker) + [
+            FTL.Message(
+                id=FTL.Identifier("features-adblocker-cookies-are-sent-by-websites"),
+                value=REPLACE(
+                    adblocker,
+                    "<a href=\"%(url)s\">Cookies</a> are sent by websites you visit. They live on your computer and monitor what you’ve been doing on a site. When an airline hikes your rates because you’ve looked at plane tickets once that day, that is the handiwork of a cookie.",
+                    {
+                        "%%": "%",
+                        "%(url)s": VARIABLE_REFERENCE("url"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("features-adblocker-in-firefox-you-can-block"),
+                value=REPLACE(
+                    adblocker,
+                    "In Firefox, you can block all third-party cookies or just those set by trackers. Be aware that blocking all cookies can break some sites.",
+                    {
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                    }
+                )
+            ),
+        ] + transforms_from("""
+features-adblocker-send-a-do-not-track-signal = {COPY(adblocker, "Send a Do Not Track signal",)}
+""", adblocker=adblocker) + [
+            FTL.Message(
+                id=FTL.Identifier("features-adblocker-if-you-dont-want-your"),
+                value=REPLACE(
+                    adblocker,
+                    "If you don’t want your online behavior used for ads, you can send websites a polite “thanks but no thanks” letter by checking the <a href=\"%(url)s\">Do Not Track</a> option of Firefox. Participation is voluntary, but the websites that participate will stop tracking you immediately.",
+                    {
+                        "%%": "%",
+                        "%(url)s": VARIABLE_REFERENCE("url"),
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                    }
+                )
+            ),
+        ] + transforms_from("""
+features-adblocker-speed-up-thanks-to-ad = {COPY(adblocker, "Speed up thanks to ad blockers",)}
+features-adblocker-in-some-cases-an-ad-blocker = {COPY(adblocker, "In some cases, an ad blocker can help your browser go faster. When an ad is loading, it can slow down a website. At the same time, it takes longer to find what you’re looking for if you’re too busy closing yet another ad.",)}
+""", adblocker=adblocker) + [
+            FTL.Message(
+                id=FTL.Identifier("features-adblocker-if-you-want-to-learn-more"),
+                value=REPLACE(
+                    adblocker,
+                    "If you want to learn more about ad blocking, there are hundreds of ad blocker extensions available for Firefox and other browsers. If want to try out the ad blockers Firefox uses, <a href=\"%(url)s\">click here to download</a> a browser that puts privacy first.",
+                    {
+                        "%%": "%",
+                        "%(url)s": VARIABLE_REFERENCE("url"),
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                    }
+                )
+            ),
+        ] + transforms_from("""
+features-adblocker-take-control-of-your-browser = {COPY(adblocker, "Take control of your browser.",)}
+""", adblocker=adblocker)
+        )


### PR DESCRIPTION
## Description
http://localhost:8000/en-US/firefox/features/adblocker/

## Issue / Bugzilla link
#9146

## Testing
```
./manage.py l10n_update
```