### PR TITLE
Move share links, update movie url (#9334)

### DIFF
--- a/bedrock/firefox/templates/firefox/campaign/unfck/index.html
+++ b/bedrock/firefox/templates/firefox/campaign/unfck/index.html
@@ -85,28 +85,6 @@
   <h2 class="c-section-title">The Checklist</h2>
 
   <div class="mzp-l-content mzp-t-content-lg">
-    {% set share_text='2020 might be fcked, but the internet doesn’t have to be. Here are 5 easy ways we can all help turn things around.' %}
-    {% set share_url = 'http://mzl.la/unfck' %}
-
-    {% set tw = 'https://www.twitter.com/intent/tweet?url=' + share_url|urlencode + '&text=' + share_text|urlencode + '&hashtags=unfckTheInternet' %}
-    {% set fb = 'http://facebook.com/sharer.php?u=' + share_url|urlencode + '&quote=' + share_text|urlencode %}
-
-    {% call item(
-      title='Share the internet love',
-      info='There’s a lot to unfck, but we’re powerful together. Tell your friends you browse with your values, and get them in on this conversation.',
-      alt='Click the unfck button.',
-      include_cta=True,
-      id='share',
-      src_name='button'
-    ) %}
-      <p class="c-item-cta">
-        <a id="js-tweet" class="mzp-c-cta-link" href="{{ tw }}" target="_blank" rel="external noopener" data-cta-type="link" data-cta-text="Checklist: share">Tweet this</a></p>
-      </p>
-      <!-- <p class="c-item-cta">
-        <a id="js-fb" class="mzp-c-cta-link" href="{{ fb }}" target="_blank" rel="external noopener" data-cta-type="link" data-cta-text="Checklist: share">Facebook this</a></p>
-      </p> -->
-    {% endcall %}
-
     {% call item(
       title='Shine a light on political ads',
       info='What you see online is not what your across-the-aisle uncle does. Hold Facebook advertisers accountable for misinformation by sharing the political ads you see to a public database.',
@@ -127,7 +105,7 @@
       src_name='highfive'
       ) %}
       <p class="c-item-cta">
-        <a class="mzp-c-cta-link" href="https://www.thesocialdilemma.com/" target="_blank" rel="external noopener" data-cta-type="link" data-cta-text="Checklist: netflix">Watch the Doc</a></p>
+        <a class="mzp-c-cta-link" href="https://www.thesocialdilemma.com/take-action/" target="_blank" rel="external noopener" data-cta-type="link" data-cta-text="Checklist: netflix">Watch the Doc</a></p>
       </p>
       <!-- <p class="c-item-cta">
         <a class="mzp-c-cta-link" href="#" target="_blank" rel="external noopener" data-cta-type="link" data-cta-text="Checklist: reading list">Read Diverse Voices</a></p>
@@ -165,6 +143,28 @@
       id='join',
       src_name='un',
     ) %}{% endcall %} -->
+
+    {% set share_text='2020 might be fcked, but the internet doesn’t have to be. Here are 5 easy ways we can all help turn things around.' %}
+    {% set share_url = 'http://mzl.la/unfck' %}
+
+    {% set tw = 'https://www.twitter.com/intent/tweet?url=' + share_url|urlencode + '&text=' + share_text|urlencode + '&hashtags=unfckTheInternet' %}
+    {% set fb = 'http://facebook.com/sharer.php?u=' + share_url|urlencode + '&quote=' + share_text|urlencode %}
+
+    {% call item(
+      title='Share the internet love',
+      info='There’s a lot to unfck, but we’re powerful together. Tell your friends you browse with your values, and get them in on this conversation.',
+      alt='Click the unfck button.',
+      include_cta=True,
+      id='share',
+      src_name='button'
+    ) %}
+      <p class="c-item-cta">
+        <a id="js-tw" class="mzp-c-cta-link" href="{{ tw }}" target="_blank" rel="external noopener" data-cta-type="link" data-cta-text="Checklist: share">Tweet this</a></p>
+      </p>
+      <p class="c-item-cta">
+        <a id="js-fb" class="mzp-c-cta-link" href="{{ fb }}" target="_blank" rel="external noopener" data-cta-type="link" data-cta-text="Checklist: share">Facebook this</a></p>
+      </p>
+    {% endcall %}
 
   </div>
 

--- a/bedrock/firefox/templates/firefox/campaign/unfck/index.html
+++ b/bedrock/firefox/templates/firefox/campaign/unfck/index.html
@@ -98,7 +98,7 @@
 
     {% call item(
       title='Watch The Social Dilemma',
-      info='Got a love-hate relationship with social media? There’s a reason. This Netlfix documentary from Exposure Labs and the Center for Humane Tech unpacks the issues of attention and addiction. But they’re not the only ones. Catch the full spectrum of voices in this conversation.',
+      info='Got a love-hate relationship with social media? There’s a reason. This Netflix documentary from Exposure Labs and the Center for Humane Tech unpacks the issues of attention and addiction. But they’re not the only ones. Catch the full spectrum of voices in this conversation.',
       alt='One fck given. High five!',
       include_cta=True,
       id='social',
@@ -171,7 +171,7 @@
   <h2 class="c-section-title u-visually-hidden">What we’re doing</h2>
 
   <div class="mzp-l-content mzp-t-content-xl c-cards">
-    <div class="mzp-l-card-third">
+    <div class="mzp-l-card-half">
       <!-- {{ card(
         title='Here’s how Firefox unfcks the internet',
         ga_title='card-unfck',

--- a/media/js/firefox/campaign/unfck.js
+++ b/media/js/firefox/campaign/unfck.js
@@ -36,11 +36,11 @@
         var link_href = e.target.href;
         var service = '';
 
-        if(link_href.includes('twitter')) {
+        if(link_href.indexOf('twitter') > -1) {
             openTwitterSubwin(link_href);
             service = 'twitter';
             e.preventDefault();
-        } else if(link_href.includes('facebook')) {
+        } else if(link_href.indexOf('facebook') > -1) {
             openFacebookSubwin(link_href);
             service = 'facebook';
             e.preventDefault();

--- a/media/js/firefox/campaign/unfck.js
+++ b/media/js/firefox/campaign/unfck.js
@@ -28,33 +28,39 @@
     }
 
     // FB Share
-    // function shareFacebook(url, text, image) {
-    //     open('http://facebook.com/sharer.php?s=100&p[url]=' + url + '&p[images][0]=' + image + '&p[title]=' + text, 'fbshare', 'height=380,width=660,resizable=0,toolbar=0,menubar=0,status=0,location=0,scrollbars=0');
-    //     // mobile: open('https://m.facebook.com/sharer/sharer.php?u=' + urlLocation + '&picture=' + image + '&description=' + text, 'facebookshare');
-    // }
+    function openFacebookSubwin(url) {
+        open(url, 'fb_share', 'height=380,width=660,resizable=0,toolbar=0,menubar=0,status=0,location=0,scrollbars=0').focus();
+    }
 
     function handleShareLinkClick(e) {
-        var href = e.target.href;
+        var link_href = e.target.href;
+        var service = '';
+
+        if(link_href.includes('twitter')) {
+            openTwitterSubwin(link_href);
+            service = 'twitter';
+            e.preventDefault();
+        } else if(link_href.includes('facebook')) {
+            openFacebookSubwin(link_href);
+            service = 'facebook';
+            e.preventDefault();
+        }
 
         // Track the event in GA
         window.dataLayer.push({
             'event': 'in-page-interaction',
             'eAction': 'checklist',
-            'eLabel': 'share',
+            'eLabel': 'share to ' + service,
         });
-
-        // Open Twitter in a sub window
-        openTwitterSubwin(href);
-        e.preventDefault();
     }
 
     function onLoad() {
         // Set up twitter link handler
-        var shareLinks = document.querySelectorAll('#js-tweet');
+        var tw = document.getElementById('js-tw');
+        var fb = document.getElementById('js-fb');
 
-        for (var i = 0; i < shareLinks.length; i++) {
-            shareLinks[i].addEventListener('click', handleShareLinkClick, false);
-        }
+        tw.addEventListener('click', handleShareLinkClick, false);
+        fb.addEventListener('click', handleShareLinkClick, false);
     }
 
     window.Mozilla.run(onLoad);


### PR DESCRIPTION
## Description

Three small changes to unfuck landing page. Move the share link to the bottom, add the JS for the Facebok share, and point to a different landing page for the movie.

## Issue / Bugzilla link

#9334 

## Testing

http://localhost:8000/en-US/firefox/unfck/