### PR TITLE
Fix JS error on /whatsnew pages (Fixes #9455)

### DIFF
--- a/bedrock/firefox/templates/firefox/nightly/whatsnew.html
+++ b/bedrock/firefox/templates/firefox/nightly/whatsnew.html
@@ -56,5 +56,5 @@
 {% endblock %}
 
 {% block js %}
-  {{ js_bundle('firefox_whatsnew') }}
+  {{ js_bundle('firefox_nightly_whatsnew') }}
 {% endblock %}

--- a/media/js/firefox/whatsnew/whatsnew.js
+++ b/media/js/firefox/whatsnew/whatsnew.js
@@ -17,15 +17,4 @@ if (typeof window.Mozilla === 'undefined') {
         form.init();
     }
 
-    var client = Mozilla.Client;
-
-    // bug 1419573 - only show "Your Firefox is up to date" if it's the latest version.
-    if (client.isFirefoxDesktop) {
-        client.getFirefoxDetails(function(data) {
-            if (data.isUpToDate) {
-                document.querySelector('.main-header').classList.add('show-up-to-date-message');
-            }
-        });
-    }
-
 })(window.jQuery, window.Mozilla);

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -1209,6 +1209,12 @@
     },
     {
       "files": [
+        "js/firefox/whatsnew/up-to-date.js"
+      ],
+      "name": "firefox_nightly_whatsnew"
+    },
+    {
+      "files": [
         "js/firefox/whatsnew/up-to-date.js",
         "js/base/mozilla-fxa.js",
         "js/base/mozilla-fxa-init.js",


### PR DESCRIPTION
## Description
Fixes JS error on the following pages:
- http://localhost:8000/en-US/firefox/whatsnew/all/
- http://localhost:8000/en-US/firefox/70.0a1/whatsnew/all/

## Issue / Bugzilla link
#9455

## Testing
- [x] Firefox up-to-date notification should still be displayed on both pages.