### PR TITLE
Exclude Sentry JS from IE < 10 (#8444)

### DIFF
--- a/bedrock/base/templates/base-protocol.html
+++ b/bedrock/base/templates/base-protocol.html
@@ -104,7 +104,9 @@
     {# Issue 8444 #}
     {% block sentry_client %}
       {% if settings.SENTRY_DSN and switch('sentry-js') %}
-        {{ js_bundle('sentry') }}
+        <!--[if !IE]><!-->
+          {{ js_bundle('sentry') }}
+        <!--<![endif]-->
       {% endif %}
     {% endblock %}
 


### PR DESCRIPTION
## Description
As per https://docs.sentry.io/platforms/javascript/troubleshooting/supported-browsers/

## Issue / Bugzilla link
#8444

## Testing
- [ ] Sentry JS snippet should not run in old IE browsers