### PR TITLE
Update daylight promo banner [fix #9412]

### DIFF
--- a/bedrock/base/templates/includes/banners/daylight/daylight-promo.html
+++ b/bedrock/base/templates/includes/banners/daylight/daylight-promo.html
@@ -1,0 +1,43 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+
+{% from "macros.html" import google_play_button with context %}
+
+{% set has_banner_copy = ftl_has_messages('banner-firefox-daylight-promo-title',
+                                          'banner-firefox-daylight-promo-button') %}
+
+{% set android_url = firefox_adjust_url('android', 'firefox-daylight-promo-banner') %}
+{% set ios_url = firefox_adjust_url('ios', 'firefox-daylight-promo-banner') %}
+
+{% if has_banner_copy %}
+<aside class="c-banner hide-from-legacy-ie mzp-t-firefox" id="firefox-daylight-promo">
+  {# Exclude banners from search result snippets using `data-nosnippet` (issue 8739) #}
+  <div class="c-banner-inner" data-nosnippet="true">
+    <button type="button" class="c-banner-close"><span>{{ ftl('ui-close') }}</span></button>
+    <div class="mzp-l-content">
+      <div class="c-banner-main">
+
+        <h2 class="c-banner-title">{{ ftl('banner-firefox-daylight-promo-title') }}</h2>
+
+        <div class="c-cta hidden-on-mobile">
+          <a href="{{ url('firefox.mobile.get-app') }}" class="mzp-c-button mzp-t-secondary" data-cta-type="link" data-cta-text="Get It Now" data-cta-position="banner">{{ ftl('banner-firefox-daylight-promo-button') }}</a>
+        </div>
+
+        <div class="c-cta hidden-on-desktop mobile-download-buttons">
+          <div class="android">
+            {{ google_play_button(href=android_url, id='play-store-link') }}
+          </div>
+
+          <div class="ios">
+            <a id="app-store-link" href="{{ ios_url }}" data-link-type="download" data-download-os="iOS">
+              <img src="{{ l10n_img('firefox/ios/btn-app-store.svg') }}" alt="{{ ftl('download-button-download-app-store') }}" width="152" height="45">
+            </a>
+          </div>
+        </div>
+
+      </div>
+    </div>
+  </div>
+</aside>
+{% endif %}

--- a/bedrock/firefox/templates/firefox/browsers/index.html
+++ b/bedrock/firefox/templates/firefox/browsers/index.html
@@ -15,11 +15,19 @@
   {% if switch('firefox-daylight-launch-banner') %}
     {{ css_bundle('daylight-launch-banner') }}
   {% endif %}
+
+  {% if switch('firefox-daylight-promo-banner') %}
+    {{ css_bundle('daylight-promo-banner') }}
+  {% endif %}
 {% endblock %}
 
 {% block page_banner %}
   {% if switch('firefox-daylight-launch-banner') %}
     {% include 'includes/banners/daylight/daylight-launch.html' %}
+  {% endif %}
+
+  {% if switch('firefox-daylight-promo-banner') %}
+    {% include 'includes/banners/daylight/daylight-promo.html' %}
   {% endif %}
 {% endblock %}
 
@@ -144,6 +152,10 @@
 
   {% if switch('firefox-daylight-launch-banner') %}
     {{ js_bundle('daylight-launch-banner') }}
+  {% endif %}
+
+  {% if switch('firefox-daylight-promo-banner') %}
+    {{ js_bundle('daylight-promo-banner') }}
   {% endif %}
 {% endblock %}
 

--- a/bedrock/firefox/templates/firefox/home/index-master.html
+++ b/bedrock/firefox/templates/firefox/home/index-master.html
@@ -31,6 +31,10 @@
   {% if switch('firefox-daylight-launch-banner') %}
     {{ css_bundle('daylight-launch-banner') }}
   {% endif %}
+
+  {% if switch('firefox-daylight-promo-banner') %}
+    {{ css_bundle('daylight-promo-banner') }}
+  {% endif %}
 {% endblock %}
 
 {% block extrahead %}
@@ -46,6 +50,10 @@
 {% block page_banner %}
   {% if switch('firefox-daylight-launch-banner') %}
     {% include 'includes/banners/daylight/daylight-launch.html' %}
+  {% endif %}
+
+  {% if switch('firefox-daylight-promo-banner') %}
+    {% include 'includes/banners/daylight/daylight-promo.html' %}
   {% endif %}
 {% endblock %}
 
@@ -249,6 +257,10 @@
 
   {% if switch('firefox-daylight-launch-banner') %}
     {{ js_bundle('daylight-launch-banner') }}
+  {% endif %}
+
+  {% if switch('firefox-daylight-promo-banner') %}
+    {{ js_bundle('daylight-promo-banner') }}
   {% endif %}
 {% endblock %}
 

--- a/bedrock/firefox/templates/firefox/mobile/index.html
+++ b/bedrock/firefox/templates/firefox/mobile/index.html
@@ -13,6 +13,10 @@
   {% if switch('firefox-daylight-launch-banner') %}
     {{ css_bundle('daylight-launch-banner') }}
   {% endif %}
+
+  {% if switch('firefox-daylight-promo-banner') %}
+    {{ css_bundle('daylight-promo-banner') }}
+  {% endif %}
 {% endblock %}
 
 {% block page_title %}{{ ftl('firefox-mobile-download-the-firefox-browser') }} | {{ ftl('firefox-mobile-firefox') }}{% endblock %}
@@ -27,6 +31,10 @@
 {% block page_banner %}
   {% if switch('firefox-daylight-launch-banner') %}
     {% include 'includes/banners/daylight/daylight-launch.html' %}
+  {% endif %}
+
+  {% if switch('firefox-daylight-promo-banner') %}
+    {% include 'includes/banners/daylight/daylight-promo.html' %}
   {% endif %}
 {% endblock %}
 
@@ -206,6 +214,10 @@
 
   {% if switch('firefox-daylight-launch-banner') %}
     {{ js_bundle('daylight-launch-banner') }}
+  {% endif %}
+
+  {% if switch('firefox-daylight-promo-banner') %}
+    {{ js_bundle('daylight-promo-banner') }}
   {% endif %}
 {% endblock %}
 

--- a/bedrock/firefox/templates/firefox/products/index.html
+++ b/bedrock/firefox/templates/firefox/products/index.html
@@ -15,11 +15,19 @@
   {% if switch('firefox-daylight-launch-banner') %}
     {{ css_bundle('daylight-launch-banner') }}
   {% endif %}
+
+  {% if switch('firefox-daylight-promo-banner') %}
+    {{ css_bundle('daylight-promo-banner') }}
+  {% endif %}
 {% endblock %}
 
 {% block page_banner %}
   {% if switch('firefox-daylight-launch-banner') %}
     {% include 'includes/banners/daylight/daylight-launch.html' %}
+  {% endif %}
+
+  {% if switch('firefox-daylight-promo-banner') %}
+    {% include 'includes/banners/daylight/daylight-promo.html' %}
   {% endif %}
 {% endblock %}
 
@@ -137,6 +145,10 @@
 
   {% if switch('firefox-daylight-launch-banner') %}
     {{ js_bundle('daylight-launch-banner') }}
+  {% endif %}
+
+  {% if switch('firefox-daylight-promo-banner') %}
+    {{ js_bundle('daylight-promo-banner') }}
   {% endif %}
 {% endblock %}
 

--- a/bedrock/mozorg/templates/mozorg/home/home-de.html
+++ b/bedrock/mozorg/templates/mozorg/home/home-de.html
@@ -18,6 +18,10 @@
   {% if switch('firefox-daylight-launch-banner') %}
     {{ css_bundle('daylight-launch-banner') }}
   {% endif %}
+
+  {% if switch('firefox-daylight-promo-banner') %}
+    {{ css_bundle('daylight-promo-banner') }}
+  {% endif %}
 {% endblock %}
 
 {% block main %}

--- a/bedrock/mozorg/templates/mozorg/home/home-en.html
+++ b/bedrock/mozorg/templates/mozorg/home/home-en.html
@@ -43,11 +43,19 @@
   {% if switch('firefox-daylight-launch-banner') %}
     {{ css_bundle('daylight-launch-banner') }}
   {% endif %}
+
+  {% if switch('firefox-daylight-promo-banner') %}
+    {{ css_bundle('daylight-promo-banner') }}
+  {% endif %}
 {% endblock %}
 
 {% block page_banner %}
   {% if switch('firefox-daylight-launch-banner') %}
     {% include 'includes/banners/daylight/daylight-launch.html' %}
+  {% endif %}
+
+  {% if switch('firefox-daylight-promo-banner') %}
+    {% include 'includes/banners/daylight/daylight-promo.html' %}
   {% endif %}
 {% endblock %}
 
@@ -205,6 +213,10 @@
 
   {% if switch('firefox-daylight-launch-banner') %}
     {{ js_bundle('daylight-launch-banner') }}
+  {% endif %}
+
+  {% if switch('firefox-daylight-promo-banner') %}
+    {{ js_bundle('daylight-promo-banner') }}
   {% endif %}
 {% endblock %}
 

--- a/bedrock/mozorg/templates/mozorg/home/home-fr.html
+++ b/bedrock/mozorg/templates/mozorg/home/home-fr.html
@@ -20,7 +20,7 @@ Le saviez-vous ? Mozilla, le concepteur de Firefox, se bat pour qu’Internet, u
   {% endif %}
 
   {% if switch('firefox-daylight-promo-banner') %}
-    {% include 'includes/banners/daylight/daylight-promo.html' %}
+    {{ css_bundle('daylight-promo-banner') }}
   {% endif %}
 {% endblock %}
 

--- a/bedrock/mozorg/templates/mozorg/home/home-fr.html
+++ b/bedrock/mozorg/templates/mozorg/home/home-fr.html
@@ -18,6 +18,10 @@ Le saviez-vous ? Mozilla, le concepteur de Firefox, se bat pour qu’Internet, u
   {% if switch('firefox-daylight-launch-banner') %}
     {{ css_bundle('daylight-launch-banner') }}
   {% endif %}
+
+  {% if switch('firefox-daylight-promo-banner') %}
+    {% include 'includes/banners/daylight/daylight-promo.html' %}
+  {% endif %}
 {% endblock %}
 
 

--- a/bedrock/mozorg/templates/mozorg/home/home.html
+++ b/bedrock/mozorg/templates/mozorg/home/home.html
@@ -38,11 +38,19 @@ accessible to all.') }}
   {% if switch('firefox-daylight-launch-banner') %}
     {{ css_bundle('daylight-launch-banner') }}
   {% endif %}
+
+  {% if switch('firefox-daylight-promo-banner') %}
+    {% include 'includes/banners/daylight/daylight-promo.html' %}
+  {% endif %}
 {% endblock %}
 
 {% block page_banner %}
   {% if switch('firefox-daylight-launch-banner') %}
     {% include 'includes/banners/daylight/daylight-launch.html' %}
+  {% endif %}
+
+  {% if switch('firefox-daylight-promo-banner') %}
+    {% include 'includes/banners/daylight/daylight-promo.html' %}
   {% endif %}
 {% endblock %}
 
@@ -209,6 +217,10 @@ accessible to all.') }}
 
   {% if switch('firefox-daylight-launch-banner') %}
     {{ js_bundle('daylight-launch-banner') }}
+  {% endif %}
+
+  {% if switch('firefox-daylight-promo-banner') %}
+    {{ js_bundle('daylight-promo-banner') }}
   {% endif %}
 {% endblock %}
 

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -248,6 +248,7 @@ DOTLANG_CACHE = config('DOTLANG_CACHE', default='1800' if DEBUG else '600', pars
 DOTLANG_FILES = ['main']
 FLUENT_DEFAULT_FILES = [
     'banners/firefox-daylight-launch',
+    'banners/firefox-daylight-promo',
     'brands',
     'download_button',
     'footer',

--- a/l10n/en/banners/firefox-daylight-promo.ftl
+++ b/l10n/en/banners/firefox-daylight-promo.ftl
@@ -1,0 +1,6 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+banner-firefox-daylight-promo-title = The NEW { -brand-name-firefox } for { -brand-name-android } and { -brand-name-ios } is here
+banner-firefox-daylight-promo-button = Get It Now

--- a/media/css/base/banners/daylight-promo.scss
+++ b/media/css/base/banners/daylight-promo.scss
@@ -45,8 +45,9 @@ $image-path: '/media/protocol/img';
         }
 
         .c-cta {
-            padding: 0 $spacing-xl;
             line-height: 0;
+            min-width: 180px;
+            padding: 0 $spacing-xl;
         }
     }
 
@@ -56,8 +57,8 @@ $image-path: '/media/protocol/img';
         display: none;
     }
 
-    .android,
-    .ios {
+    .android &,
+    .ios & {
         .hidden-on-desktop {
             display: inline;
         }
@@ -67,7 +68,7 @@ $image-path: '/media/protocol/img';
         }
     }
 
-    .android .mobile-download-buttons {
+    .android & .mobile-download-buttons {
         .android {
             display: inline-block;
         }
@@ -77,7 +78,7 @@ $image-path: '/media/protocol/img';
         }
     }
 
-    .ios .mobile-download-buttons {
+    .ios & .mobile-download-buttons {
         .ios {
             display: inline-block;
         }

--- a/media/css/base/banners/daylight-promo.scss
+++ b/media/css/base/banners/daylight-promo.scss
@@ -7,13 +7,12 @@ $image-path: '/media/protocol/img';
 
 @import '../../../protocol/css/includes/lib';
 
-#firefox-daylight-launch {
+#firefox-daylight-promo {
     &.c-banner {
         @include clearfix;
         background: $color-orange-70 linear-gradient(to right, #fca134, #e1294f);
         border-bottom: 1px solid rgba(0, 0, 0, .25) inset;
         color: $color-ink-80;
-        padding: $layout-xs 0;
         position: relative;
         z-index: 3;
 
@@ -29,64 +28,61 @@ $image-path: '/media/protocol/img';
         }
     }
 
-    .c-banner-main {
-        @media #{$mq-sm} {
-            @include grid-two-thirds;
-        }
-
-        @media #{$mq-md} {
-            @include grid-half;
-        }
-    }
-
     .c-banner-title {
-        @include text-title-md;
+        @include bidi(((padding-right, $spacing-lg, 0), (padding-left, 0, $spacing-lg),)); // make room for the close button
+        @include text-title-xs;
     }
 
-    .c-banner-intro {
-        @include font-firefox;
-        @include font-size(21px);
-    }
-
-    .c-banner-image {
-        display: none;
-
-        img {
-            max-width: none;
+    @media #{$mq-md} {
+        .c-banner-main {
+            display: flex;
+            align-items: center;
         }
 
-        @media #{$mq-sm} {
-            @include bidi((
-                (right, 0, auto),
-                (left, auto, 0),
-            ));
-            @include grid-third;
-            bottom: 0;
-            display: block;
-            height: 100%;
-            overflow: hidden;
-            padding: $layout-sm 0;
-            position: absolute;
-            text-align: center;
-            top: 0;
+        .c-banner-title {
+            margin: 0;
+            padding: 0;
         }
 
-        @media #{$mq-md} {
-            @include grid-half;
+        .c-cta {
+            padding: 0 $spacing-xl;
+            line-height: 0;
         }
     }
+
 
     // Conditional content
     .hidden-on-desktop {
         display: none;
     }
 
-    .android {
+    .android,
+    .ios {
         .hidden-on-desktop {
-            display: block;
+            display: inline;
         }
 
         .hidden-on-mobile {
+            display: none;
+        }
+    }
+
+    .android .mobile-download-buttons {
+        .android {
+            display: inline-block;
+        }
+
+        .ios {
+            display: none;
+        }
+    }
+
+    .ios .mobile-download-buttons {
+        .ios {
+            display: inline-block;
+        }
+
+        .android {
             display: none;
         }
     }

--- a/media/js/mozorg/home/daylight-promo-banner-init.js
+++ b/media/js/mozorg/home/daylight-promo-banner-init.js
@@ -1,0 +1,14 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+(function() {
+    'use strict';
+
+    function onLoad() {
+        window.Mozilla.Banner.init('firefox-daylight-promo');
+    }
+
+    window.Mozilla.run(onLoad);
+
+})();

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -258,6 +258,12 @@
     },
     {
       "files": [
+        "css/base/banners/daylight-promo.scss"
+      ],
+      "name": "daylight-promo-banner"
+    },
+    {
+      "files": [
         "css/protocol/common-old-ie.scss"
       ],
       "name": "common-old-ie"
@@ -1001,6 +1007,13 @@
         "js/mozorg/home/daylight-launch-banner-init.js"
       ],
       "name": "daylight-launch-banner"
+    },
+    {
+      "files": [
+        "js/base/banners/mozilla-banner.js",
+        "js/mozorg/home/daylight-promo-banner-init.js"
+      ],
+      "name": "daylight-promo-banner"
     },
     {
       "files": [


### PR DESCRIPTION
## Description
Adds a new minimal banner promoting the new Firefox for Android and iOS. This will replace the previous banner but I ended up building it as a separate banner so we can get this into production ahead of time and control them both with separate switches. We don't intend to make the switch until Oct 8 (pending release of Fx 29 for iOS). Doing this weird double-banner/separate-switch treatment gives us more control on the timing. We'll turn the old one off at the same time as we turn the new one on, then we can delete the old one in a follow-up PR.

## Issue / Bugzilla link
#9412 

## Testing
http://localhost:8000/
http://localhost:8000/firefox/
http://localhost:8000/firefox/products/
http://localhost:8000/firefox/mobile/
http://localhost:8000/firefox/browsers/

The banner is hidden if the strings aren't translated so you won't see it in non-English locales while testing.

You'll see both banners stacked in dev mode (because both switches will default to ON; we won't let that happen in prod). You can close the old banner to see what the new one should look like by itself.
