### PR TITLE
Add functional tests for sept landing pages (Fixes #9465)

### DIFF
--- a/tests/functional/firefox/test_unfck.py
+++ b/tests/functional/firefox/test_unfck.py
@@ -1,0 +1,30 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import pytest
+
+from pages.firefox.unfck import FirefoxUnfckPage
+
+
+@pytest.mark.skip_if_firefox(reason='Download button is displayed only to non-Firefox users')
+@pytest.mark.nondestructive
+@pytest.mark.parametrize('locale', [
+    ('en-US'),
+    ('de')])
+def test_download_button_displayed(locale, base_url, selenium):
+    page = FirefoxUnfckPage(selenium, base_url, locale=locale).open()
+    assert page.download_button.is_displayed
+
+
+@pytest.mark.skip_if_not_firefox(reason='App Store buttons are displayed only to Firefox users')
+def test_app_store_buttons_displayed(base_url, selenium):
+    page = FirefoxUnfckPage(selenium, base_url).open()
+    assert page.is_play_store_button_displayed
+    assert page.is_app_store_button_displayed
+
+
+@pytest.mark.skip_if_not_firefox(reason='Facebook Container button is displayed only to Firefox users')
+def test_facebook_container_button_displayed(base_url, selenium):
+    page = FirefoxUnfckPage(selenium, base_url, locale='de').open()
+    assert page.is_facebook_container_button_displayed

--- a/tests/pages/firefox/unfck.py
+++ b/tests/pages/firefox/unfck.py
@@ -1,0 +1,35 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from selenium.webdriver.common.by import By
+
+from pages.base import BasePage
+from pages.regions.download_button import DownloadButton
+
+
+class FirefoxUnfckPage(BasePage):
+
+    URL_TEMPLATE = '/{locale}/firefox/unfck/'
+
+    _download_button_locator = (By.ID, 'download-button-desktop-release')
+    _play_store_button_locator = (By.ID, 'playStoreLink')
+    _app_store_button_locator = (By.ID, 'appStoreLink')
+    _facebook_container_button_locator = (By.CSS_SELECTOR, '.c-button-fb-container')
+
+    @property
+    def download_button(self):
+        el = self.find_element(*self._download_button_locator)
+        return DownloadButton(self, root=el)
+
+    @property
+    def is_play_store_button_displayed(self):
+        return self.is_element_displayed(*self._play_store_button_locator)
+
+    @property
+    def is_app_store_button_displayed(self):
+        return self.is_element_displayed(*self._app_store_button_locator)
+
+    @property
+    def is_facebook_container_button_displayed(self):
+        return self.is_element_displayed(*self._facebook_container_button_locator)


### PR DESCRIPTION
## Description
add tests for conditional primary CTAs on en-US and de landing pages.

## Issue / Bugzilla link
https://github.com/mozilla/bedrock/issues/9465

## Testing
Successful test run https://gitlab.com/mozmeao/www-config/-/pipelines/196814184