### PR TITLE
Fix test for whatsnew 60 [#9218]

### DIFF
--- a/tests/pages/firefox/whatsnew/whatsnew_60.py
+++ b/tests/pages/firefox/whatsnew/whatsnew_60.py
@@ -12,7 +12,7 @@ class FirefoxWhatsNew60Page(BasePage):
 
     URL_TEMPLATE = '/{locale}/firefox/60.0/whatsnew/all/{params}'
 
-    _account_button_locator = (By.CSS_SELECTOR, '.content-main .js-fxa-product-button')
+    _account_button_locator = (By.CSS_SELECTOR, '.wnp-content-main .js-fxa-product-button')
     _qr_code_locator = (By.CSS_SELECTOR, '#qr-wrapper img')
 
     def wait_for_page_to_load(self):


### PR DESCRIPTION
## Description
This updates the selector used to locate the FxA button on the evergreen whatsnew page. A class changed in #9404 which broke a test. My bad.

This failing test is currently blocking a production deployment for the big campaign that starts tomorrow.

## Testing

Run `tests/functional/firefox/whatsnew/test_whatsnew_60.py`