### PR TITLE
Update browser comparison version disclaimer [fix #9481]

### DIFF
--- a/bedrock/firefox/templates/firefox/browsers/compare/brave.html
+++ b/bedrock/firefox/templates/firefox/browsers/compare/brave.html
@@ -243,7 +243,7 @@
 
       <div class="compare-content compare-version-disclaimer">
         <p>
-          {{ ftl('compare-shared-the-comparisons-made-here') }}
+          {{ ftl('compare-shared-the-comparisons-made-here-updated', fallback='compare-shared-the-comparisons-made-here') }}
           <br>
           {{ ftl('compare-shared-brand-name-firefox') }} (81) |
           {{ ftl('compare-shared-brand-name-brave') }} (1.14.81)

--- a/bedrock/firefox/templates/firefox/browsers/compare/chrome.html
+++ b/bedrock/firefox/templates/firefox/browsers/compare/chrome.html
@@ -240,7 +240,7 @@
 
       <div class="compare-content compare-version-disclaimer">
         <p>
-          {{ ftl('compare-shared-the-comparisons-made-here') }}
+          {{ ftl('compare-shared-the-comparisons-made-here-updated', fallback='compare-shared-the-comparisons-made-here') }}
           <br>
           {{ ftl('compare-shared-brand-name-firefox') }} (81) |
           {{ ftl('compare-shared-brand-name-chrome') }} (85)

--- a/bedrock/firefox/templates/firefox/browsers/compare/edge.html
+++ b/bedrock/firefox/templates/firefox/browsers/compare/edge.html
@@ -238,7 +238,7 @@
 
       <div class="compare-content compare-version-disclaimer">
         <p>
-          {{ ftl('compare-shared-the-comparisons-made-here') }}
+          {{ ftl('compare-shared-the-comparisons-made-here-updated', fallback='compare-shared-the-comparisons-made-here') }}
           <br>
           {{ ftl('compare-shared-brand-name-firefox') }} (81) |
           {{ ftl('compare-shared-brand-name-edge') }} (85)

--- a/bedrock/firefox/templates/firefox/browsers/compare/ie.html
+++ b/bedrock/firefox/templates/firefox/browsers/compare/ie.html
@@ -233,7 +233,7 @@
 
       <div class="compare-content compare-version-disclaimer">
         <p>
-          {{ ftl('compare-shared-the-comparisons-made-here') }}
+          {{ ftl('compare-shared-the-comparisons-made-here-updated', fallback='compare-shared-the-comparisons-made-here') }}
           <br>
           {{ ftl('compare-shared-brand-name-firefox') }} (81) |
           {{ ftl('compare-shared-brand-name-ie') }} (11)

--- a/bedrock/firefox/templates/firefox/browsers/compare/index.html
+++ b/bedrock/firefox/templates/firefox/browsers/compare/index.html
@@ -355,7 +355,7 @@
 
       <div class="compare-content compare-version-disclaimer">
         <p>
-          {{ ftl('compare-shared-the-comparisons-made-here') }}
+          {{ ftl('compare-shared-the-comparisons-made-here-updated', fallback='compare-shared-the-comparisons-made-here') }}
           <br>
           {{ ftl('compare-shared-brand-name-firefox') }} (81) |
           {{ ftl('compare-shared-brand-name-chrome') }} (85) |

--- a/bedrock/firefox/templates/firefox/browsers/compare/opera.html
+++ b/bedrock/firefox/templates/firefox/browsers/compare/opera.html
@@ -235,7 +235,7 @@
 
       <div class="compare-content compare-version-disclaimer">
         <p>
-          {{ ftl('compare-shared-the-comparisons-made-here') }}
+          {{ ftl('compare-shared-the-comparisons-made-here-updated', fallback='compare-shared-the-comparisons-made-here') }}
           <br>
           {{ ftl('compare-shared-brand-name-firefox') }} (81) |
           {{ ftl('compare-shared-brand-name-opera') }} (67)

--- a/bedrock/firefox/templates/firefox/browsers/compare/safari.html
+++ b/bedrock/firefox/templates/firefox/browsers/compare/safari.html
@@ -248,7 +248,7 @@
 
       <div class="compare-content compare-version-disclaimer">
         <p>
-          {{ ftl('compare-shared-the-comparisons-made-here') }}
+          {{ ftl('compare-shared-the-comparisons-made-here-updated', fallback='compare-shared-the-comparisons-made-here') }}
           <br>
           {{ ftl('compare-shared-brand-name-firefox') }} (81) |
           {{ ftl('compare-shared-brand-name-safari') }} (14)

--- a/l10n/en/firefox/browsers/compare/shared.ftl
+++ b/l10n/en/firefox/browsers/compare/shared.ftl
@@ -47,6 +47,10 @@ compare-shared-utility-strong = <strong>Utility</strong>
 # The strong tag wraps a word that gets highlighted with a colorful underline for emphasis. If the translation include multiple words, please choose a word to emphasize and wrap that word in the strong tag.
 compare-shared-portability-strong = <strong>Portability</strong>
 compare-shared-overall-assessment = Overall Assessment
+
+compare-shared-the-comparisons-made-here-updated = The comparisons made here were done so with default settings and across browser release versions as follows:
+
+# Obsolete string
 compare-shared-the-comparisons-made-here = The comparisons made here were done so across browser release versions as follows:
 compare-shared-this-page-updated-semi-quarterly = This page updated semi-quarterly to reflect latest versioning and may not always reflect latest updates.
 compare-shared-brand-name-firefox = { -brand-name-firefox }


### PR DESCRIPTION
## Description
Updates the disclaimer intro to clarify that comparisons were made with default settings.

## Issue / Bugzilla link
#9481 

## Testing
http://localhost:8000/firefox/browsers/compare/ (and subpages)