### PR TITLE
Add exp variant of EN unfck page

### DIFF
--- a/bedrock/exp/templates/exp/firefox/campaign/unfck/index.html
+++ b/bedrock/exp/templates/exp/firefox/campaign/unfck/index.html
@@ -1,0 +1,26 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+  # License, v. 2.0. If a copy of the MPL was not distributed with this
+  # file, You can obtain one at http://mozilla.org/MPL/2.0/. #}
+
+ {% extends "firefox/campaign/unfck/index.html" %}
+
+ {% block html_attrs %}{{ super() }} {% include 'exp/includes/id.html' %}{% endblock %}
+
+ {% block canonical_urls %}
+   {# Experimental pages should set canonical to the original page URL. #}
+   <link rel="canonical" href="{{ settings.CANONICAL_URL }}/{{ LANG }}/firefox/unfck/">
+ {% endblock %}
+
+ {% block page_og_url %}{{ settings.CANONICAL_URL }}/{{ LANG }}/firefox/unfck/{% endblock %}
+
+ {% block experiments %}
+   {% include 'exp/includes/convert.html' %}
+ {% endblock %}
+
+ {% block stub_attribution %}
+   {% include 'exp/includes/stub.html' %}
+ {% endblock %}
+
+ {% block site_js %}
+   {% include 'exp/includes/js.html' %}
+ {% endblock %}

--- a/bedrock/exp/templates/exp/firefox/campaign/unfck/index.html
+++ b/bedrock/exp/templates/exp/firefox/campaign/unfck/index.html
@@ -1,26 +1,26 @@
 {# This Source Code Form is subject to the terms of the Mozilla Public
-  # License, v. 2.0. If a copy of the MPL was not distributed with this
-  # file, You can obtain one at http://mozilla.org/MPL/2.0/. #}
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/. #}
 
- {% extends "firefox/campaign/unfck/index.html" %}
+{% extends "firefox/campaign/unfck/index.html" %}
 
- {% block html_attrs %}{{ super() }} {% include 'exp/includes/id.html' %}{% endblock %}
+{% block html_attrs %}{{ super() }} {% include 'exp/includes/id.html' %}{% endblock %}
 
- {% block canonical_urls %}
-   {# Experimental pages should set canonical to the original page URL. #}
-   <link rel="canonical" href="{{ settings.CANONICAL_URL }}/{{ LANG }}/firefox/unfck/">
- {% endblock %}
+{% block canonical_urls %}
+  {# Experimental pages should set canonical to the original page URL. #}
+  <link rel="canonical" href="{{ settings.CANONICAL_URL }}/{{ LANG }}/firefox/unfck/">
+{% endblock %}
 
- {% block page_og_url %}{{ settings.CANONICAL_URL }}/{{ LANG }}/firefox/unfck/{% endblock %}
+{% block page_og_url %}{{ settings.CANONICAL_URL }}/{{ LANG }}/firefox/unfck/{% endblock %}
 
- {% block experiments %}
-   {% include 'exp/includes/convert.html' %}
- {% endblock %}
+{% block experiments %}
+  {% include 'exp/includes/convert.html' %}
+{% endblock %}
 
- {% block stub_attribution %}
-   {% include 'exp/includes/stub.html' %}
- {% endblock %}
+{% block stub_attribution %}
+  {% include 'exp/includes/stub.html' %}
+{% endblock %}
 
- {% block site_js %}
-   {% include 'exp/includes/js.html' %}
- {% endblock %}
+{% block site_js %}
+  {% include 'exp/includes/js.html' %}
+{% endblock %}

--- a/bedrock/exp/urls.py
+++ b/bedrock/exp/urls.py
@@ -19,5 +19,5 @@ urlpatterns = (
     page('firefox/mobile', 'exp/firefox/mobile.html', ftl_files=['firefox/mobile']),
     url(r'^$', views.home_view, name='exp.mozorg.home'),
     page('firefox/accounts', 'exp/firefox/accounts.html', ftl_files=['firefox/accounts']),
-    page('firefox/unfck', 'exp/firefox/campaign/unfck/index.html', active_locales=['en-US', 'en-GB', 'en-CA']),
+    page('firefox/unfck', 'exp/firefox/campaign/unfck/index.html'),
 )

--- a/bedrock/exp/urls.py
+++ b/bedrock/exp/urls.py
@@ -19,4 +19,5 @@ urlpatterns = (
     page('firefox/mobile', 'exp/firefox/mobile.html', ftl_files=['firefox/mobile']),
     url(r'^$', views.home_view, name='exp.mozorg.home'),
     page('firefox/accounts', 'exp/firefox/accounts.html', ftl_files=['firefox/accounts']),
+    page('firefox/unfck', 'exp/firefox/campaign/unfck/index.html', active_locales=['en-US', 'en-GB', 'en-CA']),
 )


### PR DESCRIPTION
## Description

Add exp variant of EN unfck page.

## Issue / Bugzilla link

#9334 

## Testing

http://localhost:8000/en-US/exp/firefox/unfck/