### PR TITLE
Migrate newsletter preference center to Fluent (Fixes #9401)

### DIFF
--- a/bedrock/mozorg/forms.py
+++ b/bedrock/mozorg/forms.py
@@ -12,16 +12,12 @@ from django.urls import reverse
 from django.forms import widgets
 from django.utils.safestring import mark_safe
 
-from lib.l10n_utils.dotlang import _
-from lib.l10n_utils.dotlang import _lazy
-from lib.l10n_utils.fluent import ftl
+from lib.l10n_utils.fluent import ftl, ftl_lazy
 
 
-FORMATS = (('H', _lazy('HTML')), ('T', _lazy('Text')))
+FORMATS = (('H', ftl_lazy('newsletter-form-html')), ('T', ftl_lazy('newsletter-form-text')))
 LANGS_TO_STRIP = ['en-US', 'es']
 PARENTHETIC_RE = re.compile(r' \([^)]+\)$')
-LANG_FILES = ['firefox/partners/index', 'mozorg/contribute',
-              'mozorg/contribute/index', 'mozorg/newsletters']
 
 
 def strip_parenthetical(lang_name):
@@ -54,7 +50,7 @@ class HoneyPotWidget(widgets.TextInput):
     """Render a text field to (hopefully) trick bots. Will be used on many pages."""
 
     def render(self, name, value, attrs=None, renderer=None):
-        honeypot_txt = _(u'Leave this field empty.')
+        honeypot_txt = ftl('newsletter-form-leave-this-field-empty')
         # semi-randomized in case we have more than one per page.
         # this is maybe/probably overthought
         honeypot_id = 'office-fax-' + str(randrange(1001)) + '-' + str(datetime.now().strftime("%Y%m%d%H%M%S%f"))

--- a/bedrock/newsletter/forms.py
+++ b/bedrock/newsletter/forms.py
@@ -9,8 +9,7 @@ from django import forms
 from django.core.exceptions import ValidationError
 from django.forms import widgets
 from django.utils.safestring import mark_safe
-from lib.l10n_utils.dotlang import _
-from lib.l10n_utils.fluent import ftl_lazy
+from lib.l10n_utils.fluent import ftl, ftl_lazy
 from product_details import product_details
 
 from bedrock.mozorg.forms import (FORMATS, EmailInput, PrivacyWidget,
@@ -18,8 +17,6 @@ from bedrock.mozorg.forms import (FORMATS, EmailInput, PrivacyWidget,
 from bedrock.newsletter import utils
 
 _newsletters_re = re.compile(r'^[\w,-]+$')
-
-LANG_FILES = ['mozorg/newsletters']
 
 
 def validate_newsletters(newsletters):
@@ -74,8 +71,8 @@ class BooleanTabularRadioSelect(widgets.RadioSelect):
 
     def __init__(self, attrs=None):
         choices = (
-            ('true', _('Yes')),
-            ('false', _('No')),
+            ('true', ftl('newsletter-form-yes')),
+            ('false', ftl('newsletter-form-no')),
         )
         super(BooleanTabularRadioSelect, self).__init__(attrs, choices)
 
@@ -203,7 +200,9 @@ class ManageSubscriptionsForm(forms.Form):
         valid_newsletters = utils.get_newsletters()
         for newsletter in self.newsletters:
             if newsletter not in valid_newsletters:
-                msg = _("%s is not a valid newsletter") % newsletter
+                msg = ftl('newsletters-is-not-a-valid-newsletter',
+                          newsletter=newsletter,
+                          ftl_files=['mozorg/newsletters'])
                 raise ValidationError(msg)
         return super(ManageSubscriptionsForm, self).clean()
 

--- a/bedrock/newsletter/templates/newsletter/base.html
+++ b/bedrock/newsletter/templates/newsletter/base.html
@@ -5,9 +5,8 @@
 {% extends 'base-protocol.html' %}
 
 {# Base template for newsletter pages #}
-{% set_lang_files "mozorg/newsletters" %}
 
-{% block page_title %}{{ _('Newsletter Subscriptions') }}{% endblock page_title %}
+{% block page_title %}{{ ftl('newsletters-newsletter-subscriptions') }}{% endblock page_title %}
 
 {% block site_css %}
   {{ super() }}

--- a/bedrock/newsletter/templates/newsletter/confirm.html
+++ b/bedrock/newsletter/templates/newsletter/confirm.html
@@ -4,26 +4,24 @@
 
 {% extends 'newsletter/base.html' %}
 
-{% set_lang_files "mozorg/newsletters" %}
-
 {% block gtm_page_id %}data-gtm-page-id="/newsletter/confirm/"{% endblock %}
 
 {# "noindex" pages should not have the canonical or hreflang tags: bug 1442331 #}
 {% block canonical_urls %}<meta name="robots" content="noindex,follow">{% endblock %}
 
-{% block page_title %}{{ _('Newsletter confirm') }}{% endblock page_title %}
+{% block page_title %}{{ ftl('newsletters-newsletter-confirm') }}{% endblock page_title %}
 
 {% block content %}
 <main role="main">
   <div class="mzp-l-content mzp-t-content-md">
     {% if success %}
-      <h1>{{ _('Thanks for Subscribing!') }}</h1>
-      <p>{{ _('Your newsletter subscription has been confirmed.') }}</p>
-      <p>{{ _('Please be sure to add our sending address: mozilla@e.mozilla.org to your address book to ensure we always reach your inbox.') }}</p>
+      <h1>{{ ftl('newsletters-thanks-for-subscribing') }}</h1>
+      <p>{{ ftl('newsletters-your-newsletter-subscription') }}</p>
+      <p>{{ ftl('newsletters-please-be-sure-to-add-our') }}</p>
     {% elif token_error %}
-      <p>{{ _('The supplied link has expired. You will receive a new one in the next newsletter.') }}</p>
+      <p>{{ ftl('newsletters-the-supplied-link-has-expired') }}</p>
     {% elif generic_error %}
-      <p>{{ _('Something is amiss with our system, sorry! Please try again later.') }}</p>
+      <p>{{ ftl('newsletters-something-is-amiss-with') }}</p>
     {% endif %}
   </div>
 </main>

--- a/bedrock/newsletter/templates/newsletter/developer.html
+++ b/bedrock/newsletter/templates/newsletter/developer.html
@@ -4,17 +4,9 @@
 
 {% extends 'base-protocol-mozilla.html' %}
 
-{% set_lang_files "mozorg/newsletters" %}
+{% block page_title %}{{ ftl('newsletters-love-the-web-so-do-we') }}{% endblock page_title %}
 
-{% block page_title %}{{ _('Love the web? So do we!') }}{% endblock page_title %}
-
-{% block page_desc %}
-  {% if l10n_has_tag('developer_page_desc_082018') %}
-    {{ _('Unlock the world of web development with our weekly Mozilla Developer Newsletter. Each edition brings you coding techniques and best practices, MDN updates, info about emerging technologies, developer tools tips, and more.') }}
-  {% else %}
-    {{ _('Join thousands of developers like you who are learning the best of web development.') }}
-  {% endif %}
-{% endblock %}
+{% block page_desc %}{{ ftl('newsletters-unlock-the-world-of-web', fallback='newsletters-join-thousands-of-developers')}}{% endblock %}
 
 {% block body_class %}{{ super() }} newsletter-developer{% endblock %}
 

--- a/bedrock/newsletter/templates/newsletter/existing.html
+++ b/bedrock/newsletter/templates/newsletter/existing.html
@@ -4,8 +4,6 @@
 
 {% extends 'newsletter/base.html' %}
 
-{% set_lang_files "mozorg/newsletters" %}
-
 {# Template used for a user to manage their subscriptions #}
 
 {% block gtm_page_id %}data-gtm-page-id="/newsletter/existing/"{% endblock %}
@@ -17,36 +15,36 @@
 
 {% block content %}
 <main role="main">
-  <div class="mzp-l-content">
-    <header>
-      {% if did_confirm %}
-      <h1>{{ _('Thanks for Subscribing!') }}</h1>
+  <header class="mzp-l-content mzp-t-content-lg">
+    {% if did_confirm %}
+      <h1>{{ ftl('newsletters-thanks-for-subscribing') }}</h1>
 
       <p>
-        {{ _('You’re awesome!') }}
-        {{ _('And we’re not just saying that because you trusted us with your email address.') }}
-        {{ _('Please be sure to add mozilla@e.mozilla.org to your address book to ensure we always reach your inbox.')
-        }}
+        {{ ftl('newsletters-youre-awesome') }}
+        {{ ftl('newsletters-and-were-not-just-saying') }}
+        {{ ftl('newsletters-please-be-sure-to-add-mozillaemozillaorg') }}
       </p>
 
       <p>
-        {{ _('Mozilla touches on a variety of important issues.') }}
-        {{ _('Open your inbox (and your heart) even more — take a look at other topics we cover.') }}
+        {{ ftl('newsletters-mozilla-touches-on-a-variety') }}
+        {{ ftl('newsletters-open-your-inbox-and-your') }}
       </p>
-      {% else %}
-      <h1>{{ _('Manage your Email Preferences') }}</h1>
+    {% else %}
+      <h1>{{ ftl('newsletters-manage-your-email-preferences') }}</h1>
 
       {% if switch('newsletter-maintenance-mode') %}
-      <div class="mzp-c-emphasis-box">
-        <p>{{ _('This page is in maintenance mode and is temporarily unavailable.') }}</p>
-        <p>{{ _('To update your email preferences, please check back in a little while. Thanks!') }}</p>
-      </div>
+        <div class="mzp-c-emphasis-box">
+          <p>{{ ftl('newsletters-this-page-is-in-maintenance') }}</p>
+          <p>{{ ftl('newsletters-to-update-your-email-preferences') }}</p>
+        </div>
       {% else %}
-      <p>{{ _('We love sharing updates about all the awesome things happening at Mozilla.') }}</p>
-      <p>{{ _('Set your preferences below to make sure you always receive the news you want.') }}</p>
+        <p>{{ ftl('newsletters-we-love-sharing-updates') }}</p>
+        <p>{{ ftl('newsletters-set-your-preferences-below') }}</p>
       {% endif %}
-      {% endif %}
-    </header>
+    {% endif %}
+  </header>
+
+  <div class="mzp-l-content">
 
     <section>
       {% if formset and not switch('newsletter-maintenance-mode') %}
@@ -65,51 +63,37 @@
             </div>
             {% endif %}
 
-            <label>{{ _('Your email address:') }}</label>
+            <label>{{ ftl('newsletters-your-email-address') }}</label>
             {{ email }}
 
             {% set country = form['country'] %}
             <div class="{% if country.errors %}error-msg{% endif %}">
-              {% if l10n_has_tag('country_region_122019') %}
-              {{ form.country.label_tag(_('Country or region:')) }}
-              {% else %}
-              {{ form.country.label_tag(_('Country:')) }}
-              {% endif %}
+              {{ form.country.label_tag(ftl('newsletters-country-or-region', fallback='newsletters-country')) }}
               {{ country }}
               {{ country.errors }}
             </div>
 
             {% set lang = form['lang'] %}
             <div class="{% if lang.errors %}error-msg{% endif %}">
-              {{ form.lang.label_tag(_('Language:')) }}
+              {{ form.lang.label_tag(ftl('newsletters-language')) }}
               {{ lang }}
               {{ lang.errors }}
-              <small>{{ _('Not all subscriptions are supported in all the languages listed. Almost all are
-                offered in English, German and French.') }}</small>
+              <small>{{ ftl('newsletters-not-all-subscriptions-are') }}</small>
             </div>
 
             <div>
-              {{ form.format.label_tag(_('Format:')) }}
+              {{ form.format.label_tag(ftl('newsletters-format')) }}
               {{ form['format'] }}
               {{ form['format'].errors }}
-              <small>{{ _('Text subscribers will receive an email twice a year to confirm continuation of
-                the subscription. Those emails may include HTML.') }}</small>
+              <small>{{ ftl('newsletters-text-subscribers-will-receive') }}</small>
             </div>
 
             <aside>
-              <p>{{ _('Many of our communications are related to an account you’ve signed up for, such as Firefox
-                Accounts, MDN Web Docs, or Add-on Developer. To manage one of your accounts or see a list of all the
-                accounts visit our <a href="%s">account management support page</a>.')|format('https://support.mozilla.org/kb/managing-account-data')
-                }}</p>
+              <p>{{ ftl('newsletters-many-of-our-communications', url='https://support.mozilla.org/kb/managing-account-data') }}</p>
 
-              <p>{{ _('To get access to the whole world of Firefox products, knowledge and services in one account,
-                join
-                us! Learn more about the benefits <a href="%s">here</a>.')|format(url('firefox.accounts')) }}</p>
+              <p>{{ ftl('newsletters-to-get-access-to-the-whole', url=url('firefox.accounts')) }}</p>
 
-              <p>{{ _('There are many ways to engage with Mozilla and Firefox. If you didn’t find what you were
-                looking
-                for here, check out our <a href="%s">community pages</a>.')|format(url('mozorg.about.forums.forums'))
-                }}</p>
+              <p>{{ ftl('newsletters-there-are-many-ways-to', url=url('mozorg.about.forums.forums')) }}</p>
             </aside>
           </div> <!-- close #basic-settings -->
         </div>
@@ -120,7 +104,7 @@
               <thead>
                 <tr>
                   <th></th>
-                  <th colspan="2">{{ _('Subscribe') }}</th>
+                  <th colspan="2">{{ ftl('newsletters-subscribe') }}</th>
                 </tr>
               </thead>
               <tbody>
@@ -137,14 +121,14 @@
                     </p>
                   </th>
                   <td>
-                    {{ formpart.subscribed_check.label_tag(_('Subscribe')) }}
+                    {{ formpart.subscribed_check.label_tag(ftl('newsletters-subscribe')) }}
                     {{ formpart.subscribed_check }}
                   </td>
                 </tr>
                 {% endfor %}
                 <tr>
                   <th>
-                    {{ form.remove_all.label_tag(_('Remove me from all the subscriptions on this page')) }}
+                    {{ form.remove_all.label_tag(ftl('newsletters-remove-me-from-all-the')) }}
                   </th>
                   <td>
                     {{ form['remove_all'] }}
@@ -153,7 +137,7 @@
               </tbody>
             </table>
 
-            <input type="submit" value="{{ _('Save Preferences') }}" class="mzp-c-button">
+            <input type="submit" value="{{ ftl('newsletters-save-preferences') }}" class="mzp-c-button">
           </div>
         </div>
       </form>

--- a/bedrock/newsletter/templates/newsletter/firefox.html
+++ b/bedrock/newsletter/templates/newsletter/firefox.html
@@ -4,10 +4,8 @@
 
 {% extends 'base-protocol.html' %}
 
-{% set_lang_files "mozorg/newsletters" %}
-
-{% block page_title %}{{ _('Put more fox in your inbox.') }}{% endblock page_title %}
-{% block page_desc %}{{ _('See where the Web can take you with monthly Firefox tips, tricks and Internet intel.') }}{% endblock %}
+{% block page_title %}{{ ftl('newsletters-put-more-fox-in-your-inbox') }}{% endblock page_title %}
+{% block page_desc %}{{ ftl('newsletters-see-where-the-web-can-take') }}{% endblock %}
 
 {% block body_class %}{{ super() }} newsletter-mozilla{% endblock %}
 

--- a/bedrock/newsletter/templates/newsletter/fxa-error.html
+++ b/bedrock/newsletter/templates/newsletter/fxa-error.html
@@ -4,11 +4,9 @@
 
 {% extends 'newsletter/recovery.html' %}
 
-{% set_lang_files "mozorg/newsletters" %}
-
 {# "noindex" pages should not have the canonical or hreflang tags: bug 1442331 #}
 {% block canonical_urls %}<meta name="robots" content="noindex,follow">{% endblock %}
 
 {% block messages %}
-  <p>{{ _('We are sorry, but there was a problem with our system. Please try again later!') }}</p>
+  <p>{{ ftl('newsletters-we-are-sorry-but-there') }}</p>
 {% endblock %}

--- a/bedrock/newsletter/templates/newsletter/index.html
+++ b/bedrock/newsletter/templates/newsletter/index.html
@@ -4,16 +4,14 @@
 
 {% extends 'newsletter/base.html' %}
 
-{% set_lang_files "mozorg/newsletters" %}
-
-{% block page_title %}{{ _('Mozilla Newsletter') }}{% endblock %}
+{% block page_title %}{{ ftl('newsletters-mozilla-newsletter') }}{% endblock %}
 
 {% block content %}
 <main role="main">
   <div class="mzp-l-content mzp-t-content-sm">
     {{ email_newsletter_form(
-      title=_('Read all about it in our <span>newsletter</span>'),
-      desc=_('Subscribe to updates and keep current with Mozilla news. It’s the perfect way for us to keep in touch!'),
+      title=ftl('newsletters-read-all-about-it-in-our-newsletter'),
+      desc=ftl('newsletters-subscribe-to-updates-and-keep'),
       newsletters='mozilla-foundation') }}
   </div>
 </main>

--- a/bedrock/newsletter/templates/newsletter/mozilla.html
+++ b/bedrock/newsletter/templates/newsletter/mozilla.html
@@ -4,23 +4,10 @@
 
 {% extends 'base-protocol-mozilla.html' %}
 
-{% set_lang_files "mozorg/newsletters" %}
-
-{% block page_title %}
-  {# L10n: line break for visual formatting #}
-  {% if l10n_has_tag('mozilla_newsletter_copy') %}
-    {{ _('Sign up, read up,<br> stay informed.') }}
-  {% else %}
-    {{ _('Sign up. Read up.<br> Make a difference.') }}
-  {% endif %}
-{% endblock page_title %}
+{% block page_title %}{{ ftl('newsletters-sign-up-read-up-stay-informed', fallback='newsletters-sign-up-read-up-make-a-difference') }}{% endblock page_title %}
 
 {% block page_desc %}
-  {% if l10n_has_tag('mozilla_newsletter_copy') %}
-    {{ _('Get smart on the issues affecting your life online.') }}
-  {% else %}
-    {{ _('Get the Mozilla newsletter to stay informed about issues challenging the health of the Internet and to discover how you can get involved.') }}
-  {% endif %}
+  {{ ftl('newsletters-get-smart-on-the-issues', fallback='newsletters-get-the-mozilla-newsletter') }}
 {% endblock %}
 
 {% block body_class %}{{ super() }} newsletter-mozilla{% endblock %}

--- a/bedrock/newsletter/templates/newsletter/opt-out-confirmation.html
+++ b/bedrock/newsletter/templates/newsletter/opt-out-confirmation.html
@@ -4,8 +4,8 @@
 
 {% extends 'base-protocol-mozilla.html' %}
 
-{% block page_title %}{{ _('Cool. We hear you.') }}{% endblock page_title %}
-{% block page_desc %}{{ _('You’re now opted out of a series of emails about setting up your account.') }}{% endblock %}
+{% block page_title %}{{ ftl('opt-out-confirmation-cool-we-hear') }}{% endblock page_title %}
+{% block page_desc %}{{ ftl('opt-out-confirmation-youre-now-opted') }}{% endblock %}
 
 {% block canonical_urls %}<meta name="robots" content="noindex">{% endblock %}
 
@@ -33,11 +33,7 @@
         <div class="mzp-c-form">
           <header class="mzp-c-form-header">
             <p>
-              {% trans %}
-                You’ll continue to receive other emails you’re subscribed to, along with occasional
-                important updates about your account. To manage all your subscriptions, enter your
-                email below — we need to make sure we’re talking to the right person.
-              {% endtrans %}
+              {{ ftl('opt-out-confirmation-youll-continue') }}
             </p>
           </header>
 
@@ -48,28 +44,28 @@
           {% endif %}
           <div class="mzp-c-field mzp-l-stretch">
             {{ form.email.errors }}
-            <label for="id_email" class="mzp-c-field-label">{{ _('Your email address:') }}</label>
-            {{ field_with_attrs(form.email, placeholder=_('yourname@example.com')|safe, class='mzp-c-field-control'|safe) }}
+            <label for="id_email" class="mzp-c-field-label">{{ ftl('opt-out-confirmation-your-email') }}</label>
+            {{ field_with_attrs(form.email, placeholder=ftl('opt-out-confirmation-yournameexamplecom')|safe, class='mzp-c-field-control'|safe) }}
           </div>
           <div class="mzp-c-button-container mzp-l-stretch">
-            <button class="mzp-c-button" type="submit">{{ _('Manage Preferences') }}</button>
+            <button class="mzp-c-button" type="submit">{{ ftl('opt-out-confirmation-manage-preferences') }}</button>
           </div>
         </div>
       </form>
 
       <aside>
-        <h2>{{ _('Prefer to get information another way?') }}</h2>
+        <h2>{{ ftl('opt-out-confirmation-prefer-to-get') }}</h2>
         <ul class="mzp-u-list-styled">
-          <li><a href="https://blog.mozilla.org/">{{ _('Check out our blogs') }}</a></li>
-          <li><a href="https://support.mozilla.org/">{{ _('Get help') }}</a></li>
-          <li><a href="{{ url('newsletter.firefox') }}">{{ _('Subscribe to occasional newsletter updates from Firefox') }}</a></li>
+          <li><a href="https://blog.mozilla.org/">{{ ftl('opt-out-confirmation-check-out-our') }}</a></li>
+          <li><a href="https://support.mozilla.org/">{{ ftl('opt-out-confirmation-get-help') }}</a></li>
+          <li><a href="{{ url('newsletter.firefox') }}">{{ ftl('opt-out-confirmation-subscribe-to') }}</a></li>
         </ul>
 
         <ul class="social-links">
-          <li><a class="instagram" href="https://www.instagram.com/mozilla/" data-link-type="footer" data-link-name="Instagram (@mozilla)">{{ _('Instagram') }}<span> (@mozilla)</span></a></li>
-          <li><a class="youtube" href="https://www.youtube.com/firefoxchannel" data-link-type="footer" data-link-name="YouTube (firefoxchannel)">{{ _('YouTube') }}<span> (firefoxchannel)</span></a></li>
-          <li><a class="facebook" href="https://www.facebook.com/Firefox" data-link-type="footer" data-link-name="Facebook (Firefox)">{{ _('Facebook') }}<span> (Firefox)</span></a></li>
-          <li><a class="twitter" href="{{ firefox_twitter_url() }}" data-link-type="footer" data-link-name="Twitter (@firefox)">{{ _('Twitter') }}<span> (@firefox)</span></a></li>
+          <li><a class="instagram" href="https://www.instagram.com/mozilla/" data-link-type="footer" data-link-name="Instagram (@mozilla)">{{ ftl('opt-out-confirmation-instagram') }}<span> (@mozilla)</span></a></li>
+          <li><a class="youtube" href="https://www.youtube.com/firefoxchannel" data-link-type="footer" data-link-name="YouTube (firefoxchannel)">{{ ftl('opt-out-confirmation-youtube') }}<span> (firefoxchannel)</span></a></li>
+          <li><a class="facebook" href="https://www.facebook.com/Firefox" data-link-type="footer" data-link-name="Facebook (Firefox)">{{ ftl('opt-out-confirmation-facebook') }}<span> (Firefox)</span></a></li>
+          <li><a class="twitter" href="{{ firefox_twitter_url() }}" data-link-type="footer" data-link-name="Twitter (@firefox)">{{ ftl('opt-out-confirmation-twitter') }}<span> (@firefox)</span></a></li>
         </ul>
       </aside>
     {% endif %}

--- a/bedrock/newsletter/templates/newsletter/recovery.html
+++ b/bedrock/newsletter/templates/newsletter/recovery.html
@@ -4,17 +4,15 @@
 
 {% extends 'newsletter/base.html' %}
 
-{% set_lang_files "mozorg/newsletters" %}
-
 {# "noindex" pages should not have the canonical or hreflang tags: bug 1442331 #}
 {% block canonical_urls %}<meta name="robots" content="noindex,follow">{% endblock %}
 
-{% block page_title %}{{ _('Newsletter email recovery') }}{% endblock page_title %}
+{% block page_title %}{{ ftl('newsletters-newsletter-email-recovery') }}{% endblock page_title %}
 
 {% block content %}
   <main role="main" class="mzp-l-content mzp-t-content-sm">
     {% block messages %}
-    <h1 class="mzp-u-title-sm">{{ _('Manage your <span>Newsletter Subscriptions</span>') }}</h1>
+    <h1 class="mzp-u-title-sm">{{ ftl('newsletters-manage-your-newsletter') }}</h1>
       {% if messages %}
         <ul>
           {% for message in messages %}
@@ -27,7 +25,7 @@
     {% if form %}
       <form method="post" action="{{ url('newsletter.recovery') }}" id="newsletter-recovery-form" class="mzp-c-form">
         <header class="mzp-c-newsletter-header">
-          <p>{{ _('Enter your email address and we’ll send you a link to your email preference center.') }}</p>
+          <p>{{ ftl('newsletters-enter-your-email-address') }}</p>
         </header>
 
         {% if form.non_field_errors() %}
@@ -38,7 +36,7 @@
 
         <div class="mzp-c-field mzp-l-stretch {% if form.email.errors %} mzp-is-error{% endif %}">
           <label for="id_email" class="mzp-c-field-label">
-            {{ _('Your email address:') }}
+            {{ ftl('newsletters-your-email-address') }}
             {% if form.email.errors %}
               <em class="mzp-c-fieldnote">{{ form.email.errors }}</em>
             {% endif %}
@@ -46,7 +44,7 @@
           {{ field_with_attrs(form.email, class='mzp-c-field-control'|safe) }}
         </div>
         <div class="mzp-c-button-container mzp-l-stretch">
-          <button class="mzp-c-button" id="newsletter-submit" type="submit">{{ _('Send me a link') }}</button>
+          <button class="mzp-c-button" id="newsletter-submit" type="submit">{{ ftl('newsletters-send-me-a-link') }}</button>
         </div>
       </form>
     {% endif %}

--- a/bedrock/newsletter/templates/newsletter/updated.html
+++ b/bedrock/newsletter/templates/newsletter/updated.html
@@ -6,8 +6,6 @@
 
 {% extends 'newsletter/base.html' %}
 
-{% set_lang_files "mozorg/newsletters" %}
-
 {# "noindex" pages should not have the canonical or hreflang tags: bug 1442331 #}
 {% block canonical_urls %}<meta name="robots" content="noindex,follow">{% endblock %}
 
@@ -29,14 +27,14 @@
       <div class="mzp-l-content mzp-t-content-md">
         <section class="c-updated-block">
           <header class="c-updated-block-header">
-            <h1>{{ _('You’ve been unsubscribed.') }}</h1>
-            <h2>{{ _('We’re sorry to see you go.')}}</h2>
+            <h1>{{ ftl('newsletters-youve-been-unsubscribed') }}</h1>
+            <h2>{{ ftl('newsletters-were-sorry-to-see-you-go') }}</h2>
           </header>
 
           <form action="{{ url('newsletter.updated') }}" method="post" class="c-updated-block-content c-updated-form">
             <input type="hidden" name="unsub" value="2" />
             <input type="hidden" name="token" value="{{ token }}" />
-            <h4>{{_('Would you mind telling us why you’re leaving?') }}</h4>
+            <h4>{{ ftl('newsletters-would-you-mind-telling-us') }}</h4>
             {% for i, reason in reasons %}
               <label>
                 <input type="checkbox" id="unsub{{ i }}" name="reason{{ i }}">
@@ -45,11 +43,11 @@
             {% endfor %}
             <label>
               <input type="checkbox" id="unsub99" name="reason-text-p">
-              {{ _('Other…') }}<br>
+              {{ ftl('newsletters-other') }}<br>
               <textarea cols="35" rows="3" name="reason-text"></textarea>
             </label>
             <div class="mzp-c-button-container mzp-l-align-center">
-              <input type="submit" value="{{_('Submit') }}" class="mzp-c-button" name="feedback" />
+              <input type="submit" value="{{ ftl('newsletters-submit') }}" class="mzp-c-button" name="feedback" />
             </div>
           </form>
         </section>
@@ -58,56 +56,56 @@
       <div class="mzp-l-content mzp-t-content-md">
         <section class="c-updated-block">
           <header class="c-updated-block-header">
-            <h1>{{ _('You’ve been unsubscribed.') }}</h1>
-            <h2>{{ _('We’re sorry to see you go.')}}</h2>
-            <p>{{ _('Thanks for telling us why you’re leaving.') }}</p>
+            <h1>{{ ftl('newsletters-youve-been-unsubscribed') }}</h1>
+            <h2>{{ ftl('newsletters-were-sorry-to-see-you-go') }}</h2>
+            <p>{{ ftl('newsletters-thanks-for-telling-us-why') }}</p>
           </header>
         </section>
       </div>
     {% else %}
       <div class="mzp-l-content">
         <section class="c-updated-block">
-          {% if l10n_has_tag('newsletter_confirm_0320') %}
+          {% if ftl_has_messages('newsletters-consider-it-done',
+                                 'newsletters-back-to-email-preferences',
+                                 'newsletters-here-are-a-few-things') %}
             <header class="c-updated-block-header">
-              <h1>{{ _('Consider it done') }}</h1>
+              <h1>{{ ftl('newsletters-consider-it-done') }}</h1>
 
               <p class="c-updated-back-link">
-                <a href="#" class="back-button hide-from-legacy-ie">{{ _('Back to email preferences') }}</a>
+                <a href="#" class="back-button hide-from-legacy-ie">{{ ftl('newsletters-back-to-email-preferences') }}</a>
               </p>
             </header>
 
-
-
             <section class="c-updated-block-content">
               <h2 class="c-updated-block-header">
-                {{ _('Here are a few things to dig into while you’re waiting for your next email.') }}
+                {{ ftl('newsletters-here-are-a-few-things') }}
               </h2>
 
               <div class="mzp-l-card-third">
                 {{ card(
-                  title=_('Take your privacy with you'),
+                  title=ftl('newsletters-take-your-privacy'),
                   ga_title='Take your privacy with you',
-                  desc=_('Travel the internet with protection on all your devices.'),
-                  cta=_('Download the App'),
+                  desc=ftl('newsletters-travel-the-internet'),
+                  cta=ftl('newsletters-download-the-app'),
                   image_url='img/newsletter/confirm/mobile.png',
                   aspect_ratio='mzp-has-aspect-16-9',
                   link_url=url('firefox.mobile.index'),
                 )}}
 
                 {{ card(
-                  title=_('Check for data breaches'),
+                  title=ftl('newsletters-check-for-data-breaches'),
                   ga_title='Check for data breaches',
-                  desc=_('Firefox Monitor is a free service that lets you see if you’ve been involved in an online data breach.'),
-                  cta=_('Sign In to Monitor'),
+                  desc=ftl('newsletters-firefox-monitor-is-a-free'),
+                  cta=ftl('newsletters-sign-in-to-monitor'),
                   image_url='img/newsletter/confirm/monitor.png',
                   aspect_ratio='mzp-has-aspect-16-9',
                   link_url='https://monitor.firefox.com/',
                 )}}
 
                 {{ card(
-                  title=_('Meet our parent brand'),
+                  title=ftl('newsletters-meet-our-parent-brand'),
                   ga_title='Meet our parent brand',
-                  desc=_('Mozilla, the not-for-profit behind Firefox, puts people over profit in everything we say, build, and do.'),
+                  desc=ftl('newsletters-mozilla-the-non-for-profit'),
                   cta=ftl('ui-learn-more'),
                   image_url='img/newsletter/confirm/mozilla.png',
                   aspect_ratio='mzp-has-aspect-16-9',
@@ -116,35 +114,35 @@
               </div>
             </section>
           {% else %}
-            <h2 class="c-updated-block-header">{{ _('While here, why not check out some more Firefox awesomeness.') }}</h2>
+            <h2 class="c-updated-block-header">{{ ftl('newsletters-while-here-why-not-check') }}</h2>
 
             <div class="mzp-l-card-third">
               <div class="mzp-l-card-third">
                 {{ card(
-                  title=_('Get up and go'),
+                  title=ftl('newsletters-get-up-and-go'),
                   ga_title='Get up and go',
-                  desc=_('It’s your Web anywhere you go.'),
-                  cta=_('Get Firefox for mobile!'),
+                  desc=ftl('newsletters-its-your-web-anywhere-you'),
+                  cta=ftl('newsletters-get-firefox-for-mobile'),
                   image_url='img/newsletter/confirm/mobile.png',
                   aspect_ratio='mzp-has-aspect-16-9',
                   link_url=url('firefox.mobile.index'),
                 )}}
 
                 {{ card(
-                  title=_('Added extras'),
+                  title=ftl('newsletters-added-extras'),
                   ga_title='Added extras',
-                  desc=_('Make Firefox do more with add-ons.'),
-                  cta=_('Find out how!'),
+                  desc=ftl('newsletters-make-firefox-do-more-with'),
+                  cta=ftl('newsletters-find-out-how'),
                   image_url='img/newsletter/confirm/addons.png',
                   aspect_ratio='mzp-has-aspect-16-9',
                   link_url='https://addons.mozilla.org/',
                 )}}
 
                 {{ card(
-                  title=_('About us'),
+                  title=ftl('newsletters-about-us'),
                   ga_title='About us',
-                  desc=_('What’s Mozilla all about?'),
-                  cta=_('We’re glad you asked!'),
+                  desc=ftl('newsletters-whats-mozilla-all-about'),
+                  cta=ftl('newsletters-were-glad-you-asked'),
                   image_url='img/newsletter/confirm/mozilla.png',
                   aspect_ratio='mzp-has-aspect-16-9',
                   link_url=url('mozorg.about'),

--- a/bedrock/newsletter/tests/test_footer_form.py
+++ b/bedrock/newsletter/tests/test_footer_form.py
@@ -1,3 +1,4 @@
+from django.test.utils import override_settings
 from bedrock.base.urlresolvers import reverse
 from mock import patch
 from pyquery import PyQuery as pq
@@ -13,6 +14,7 @@ class TestNewsletterFooter(TestCase):
     def setUp(self):
         self.view_name = 'newsletter.subscribe'
 
+    @override_settings(DEV=True)
     def test_country_selected(self):
         """
         The correct country for the locale should be initially selected.
@@ -33,6 +35,7 @@ class TestNewsletterFooter(TestCase):
         doc = pq(resp.content)
         assert doc('#id_country option[selected="selected"]').val() == 'br'
 
+    @override_settings(DEV=True)
     def test_language_selected(self):
         """
         The correct language for the locale should be initially selected or

--- a/bedrock/newsletter/tests/test_views.py
+++ b/bedrock/newsletter/tests/test_views.py
@@ -19,7 +19,6 @@ from bedrock.newsletter.views import (
     invalid_email_address,
     newsletter_subscribe,
     recovery_text,
-    unknown_address_text,
     updated,
 )
 
@@ -513,10 +512,6 @@ class TestRecoveryView(TestCase):
         rsp = self.client.post(self.url, data)
         self.assertTrue(mock_basket.called)
         self.assertEqual(200, rsp.status_code)
-        form = rsp.context['form']
-        expected_error = unknown_address_text % \
-            reverse('newsletter.subscribe')
-        self.assertIn(expected_error, form.errors['email'])
 
     @patch('django.contrib.messages.add_message', autospec=True)
     @patch('basket.send_recovery_message', autospec=True)

--- a/bedrock/newsletter/urls.py
+++ b/bedrock/newsletter/urls.py
@@ -52,9 +52,9 @@ urlpatterns = (
         name='newsletter.opt-out-confirmation'),
 
     # Branded signup pages for individual newsletters
-    page('newsletter/mozilla', 'newsletter/mozilla.html'),
-    page('newsletter/firefox', 'newsletter/firefox.html'),
-    page('newsletter/developer', 'newsletter/developer.html'),
-    page('newsletter/country/success', 'newsletter/country_success.html'),
-    page('newsletter/fxa-error', 'newsletter/fxa-error.html'),
+    page('newsletter/mozilla', 'newsletter/mozilla.html', ftl_files=['mozorg/newsletters']),
+    page('newsletter/firefox', 'newsletter/firefox.html', ftl_files=['mozorg/newsletters']),
+    page('newsletter/developer', 'newsletter/developer.html', ftl_files=['mozorg/newsletters']),
+    page('newsletter/country/success', 'newsletter/country_success.html', ftl_files=['mozorg/newsletters']),
+    page('newsletter/fxa-error', 'newsletter/fxa-error.html', ftl_files=['mozorg/newsletters']),
 )

--- a/bedrock/newsletter/views.py
+++ b/bedrock/newsletter/views.py
@@ -21,8 +21,7 @@ from django.shortcuts import redirect
 from django.utils.safestring import mark_safe
 from django.views.decorators.cache import never_cache
 from jinja2 import Markup
-from lib.l10n_utils.dotlang import _, _lazy, lang_file_has_tag
-from lib.l10n_utils.fluent import ftl
+from lib.l10n_utils.fluent import ftl, ftl_lazy
 
 from bedrock.base import waffle
 from bedrock.base.urlresolvers import reverse
@@ -36,163 +35,144 @@ from .forms import (CountrySelectForm, EmailForm, ManageSubscriptionsForm,
 
 log = commonware.log.getLogger('b.newsletter')
 
-LANG_FILES = ['mozorg/newsletters']
-general_error = _lazy(u'We are sorry, but there was a problem '
-                      u'with our system. Please try again later!')
-thank_you_new = _lazy(u'Your email preferences have been successfully updated.')
-thank_you = _lazy(u'Thanks for updating your email preferences.')
-bad_token = _lazy(u'The supplied link has expired or is not valid. You will '
-                  u'receive a new one in the next newsletter, or below you '
-                  u'can request an email with the link.')
-recovery_text = _lazy(
-    u'Success! An email has been sent to you with your preference center '
-    u'link. Thanks!')
+FTL_FILES = ['mozorg/newsletters']
 
-# NOTE: Must format a link into this: (https://www.mozilla.org/newsletter/)
-unknown_address_text = _lazy(
-    u'This email address is not in our system. Please double check your '
-    u'address or <a href="%s">subscribe to our newsletters.</a>')
-
-invalid_email_address = _lazy(u'This is not a valid email address. '
-                              u'Please check the spelling.')
+general_error = ftl_lazy('newsletters-we-are-sorry-but-there', ftl_files=FTL_FILES)
+thank_you = ftl_lazy('newsletters-your-email-preferences',
+                     fallback='newsletters-thanks-for-updating-your',
+                     ftl_files=FTL_FILES)
+bad_token = ftl_lazy('newsletters-the-supplied-link-has-expired-long', ftl_files=FTL_FILES)
+recovery_text = ftl_lazy('newsletters-success-an-email-has-been-sent', ftl_files=FTL_FILES)
+invalid_email_address = ftl_lazy('newsletters-this-is-not-a-valid-email', ftl_files=FTL_FILES)
 
 NEWSLETTER_STRINGS = {
     u'about-mozilla': {
-        'description': _lazy(u'Join Mozillians all around the world and learn about impactful opportunities to support Mozilla\u2019s mission.'),
-        'title': _lazy(u'Mozilla Community')},
+        'description': ftl_lazy('newsletters-join-mozillians-all-around', ftl_files=FTL_FILES),
+        'title': ftl_lazy('newsletters-mozilla-community', ftl_files=FTL_FILES)},
     u'about-standards': {
-        'title': _lazy(u'About Standards')},
+        'title': ftl_lazy('newsletters-about-standards', ftl_files=FTL_FILES)},
     u'addon-dev': {
-        'title': _lazy(u'Addon Development')},
+        'title': ftl_lazy('newsletters-addon-development', ftl_files=FTL_FILES)},
     u'affiliates': {
-        'description': _lazy(u'A monthly newsletter to keep you up to date with the '
-                             u'Firefox Affiliates program.'),
-        'title': _lazy(u'Firefox Affiliates')},
+        'description': ftl_lazy('newsletters-a-monthly-newsletter-affiliates', ftl_files=FTL_FILES),
+        'title': ftl_lazy('newsletters-firefox-affiliates', ftl_files=FTL_FILES)},
     u'ambassadors': {
-        'description': _lazy(u'A monthly newsletter on how to get involved with Mozilla on your campus. '),
-        'title': _lazy(u'Firefox Student Ambassadors')},
+        'description': ftl_lazy('newsletters-a-monthly-newsletter-ambassadors', ftl_files=FTL_FILES),
+        'title': ftl_lazy('newsletters-firefox-student-ambassadors', ftl_files=FTL_FILES)},
     u'app-dev': {
-        'description': _lazy(u'A developer\u2019s guide to highlights of Web platform '
-                             u'innovations, best practices, new documentation and more.'),
-        'title': _lazy(u'Developer Newsletter')},
+        'description': ftl_lazy('newsletters-a-developers-guide', ftl_files=FTL_FILES),
+        'title': ftl_lazy('newsletters-developer-newsletter', ftl_files=FTL_FILES)},
     u'aurora': {
-        'description': _lazy(u'Aurora'),
-        'title': _lazy(u'Aurora')},
+        'description': ftl_lazy('newsletters-aurora', ftl_files=FTL_FILES),
+        'title': ftl_lazy('newsletters-aurora', ftl_files=FTL_FILES)},
     u'beta': {
-        'description': _lazy(u'Read about the latest features for Firefox desktop and mobile '
-                             u'before the final release.'),
-        'title': _lazy(u'Beta News')},
+        'description': ftl_lazy('newsletters-read-about-the-latest-features', ftl_files=FTL_FILES),
+        'title': ftl_lazy('newsletters-beta-news', ftl_files=FTL_FILES)},
     u'download-firefox-android': {
-        'title': _lazy(u'Download Firefox for Android')},
+        'title': ftl_lazy('newsletters-download-firefox-for-android', ftl_files=FTL_FILES)},
     u'download-firefox-androidsn': {
-        'title': _lazy(u'Get Firefox for Android')},
+        'title': ftl_lazy('newsletters-get-firefox-for-android', ftl_files=FTL_FILES)},
     u'download-firefox-androidsnus': {
-        'title': _lazy(u'Get Firefox for Android')},
+        'title': ftl_lazy('newsletters-get-firefox-for-android', ftl_files=FTL_FILES)},
     u'download-firefox-ios': {
-        'title': _lazy(u'Download Firefox for iOS')},
+        'title': ftl_lazy('newsletters-download-firefox-for-ios', ftl_files=FTL_FILES)},
     u'download-firefox-mobile': {
-        'title': _lazy(u'Download Firefox for Mobile')},
+        'title': ftl_lazy('newsletters-download-firefox-for-mobile', ftl_files=FTL_FILES)},
     u'drumbeat': {
-        'title': _lazy(u'Drumbeat Newsgroup')},
+        'title': ftl_lazy('newsletters-drumbeat-newsgroup', ftl_files=FTL_FILES)},
     u'firefox-accounts-journey': {
-        'description': _lazy(u'Get the most out of your Firefox Account.'),
-        'title': _lazy(u'Firefox Accounts Tips')},
+        'description': ftl_lazy('newsletters-get-the-most-firefox-account', ftl_files=FTL_FILES),
+        'title': ftl_lazy('newsletters-firefox-accounts-tips', ftl_files=FTL_FILES)},
     u'firefox-desktop': {
-        'description': _lazy(u'Don\u2019t miss the latest announcements about our desktop browser.'),
-        'title': _lazy(u'Firefox for desktop')},
+        'description': ftl_lazy('newsletters-dont-miss-the-latest', ftl_files=FTL_FILES),
+        'title': ftl_lazy('newsletters-firefox-for-desktop', ftl_files=FTL_FILES)},
     u'firefox-flicks': {
-        'description': _lazy(u'Periodic email updates about our annual international film competition.'),
-        'title': _lazy(u'Firefox Flicks')},
+        'description': ftl_lazy('newsletters-periodic-email-updates', ftl_files=FTL_FILES),
+        'title': ftl_lazy('newsletters-firefox-flicks', ftl_files=FTL_FILES)},
     u'firefox-ios': {
-        'description': _lazy(u'Be the first to know when Firefox is available for iOS devices.'),
-        'title': _lazy(u'Firefox iOS')},
+        'description': ftl_lazy('newsletters-be-the-first-to-know', ftl_files=FTL_FILES),
+        'title': ftl_lazy('newsletters-firefox-ios', ftl_files=FTL_FILES)},
     u'firefox-os': {
-        'description': _lazy(u'Don\u2019t miss important news and updates about your Firefox OS device.'),
-        'title': _lazy(u'Firefox OS smartphone owner?')},
+        'description': ftl_lazy('newsletters-dont-miss-important-news', ftl_files=FTL_FILES),
+        'title': ftl_lazy('newsletters-firefox-os-smartphone-owner', ftl_files=FTL_FILES)},
     u'firefox-os-news': {
-        'description': _lazy(u'A monthly newsletter and special announcements on how to get the most '
-                             u'from your Firefox OS device, including the latest features and coolest '
-                             u'Firefox Marketplace apps.'),
-        'title': _lazy(u'Firefox OS + You')},
+        'description': ftl_lazy('newsletters-a-monthly-newsletter-and-special', ftl_files=FTL_FILES),
+        'title': ftl_lazy('newsletters-firefox-os-and-you', ftl_files=FTL_FILES)},
     u'firefox-tips': {
-        'description': _lazy(u'Get a weekly tip on how to super-charge your Firefox experience.'),
-        'title': _lazy(u'Firefox Weekly Tips')},
+        'description': ftl_lazy('newsletters-get-a-weekly-tip', ftl_files=FTL_FILES),
+        'title': ftl_lazy('newsletters-firefox-weekly-tips', ftl_files=FTL_FILES)},
     u'get-android-embed': {
-        'title': _lazy(u'Get Firefox for Android')},
+        'title': ftl_lazy('newsletters-get-firefox-for-android', ftl_files=FTL_FILES)},
     u'get-android-notembed': {
-        'title': _lazy(u'Get Firefox for Android')},
+        'title': ftl_lazy('newsletters-get-firefox-for-android', ftl_files=FTL_FILES)},
     u'get-involved': {
-        'title': _lazy(u'Get Involved')},
+        'title': ftl_lazy('newsletters-get-involved', ftl_files=FTL_FILES)},
     u'internet-health-report': {
-        'title': _lazy(u'Internet Health Report'),
-        'description': _lazy(u'Keep up with our annual compilation of research and stories on the issues of privacy '
-                             u'&amp; security, openness, digital inclusion, decentralization, and web literacy.')},
+        'title': ftl_lazy('newsletters-insights',
+                          fallback='newsletters-internet-health-report',
+                          ftl_files=FTL_FILES),
+        'description': ftl_lazy('newsletters-mozilla-published-articles-and-deep',
+                                fallback='newsletters-keep-up-with-our-annual',
+                                ftl_files=FTL_FILES)},
     u'join-mozilla': {
-        'title': _lazy(u'Join Mozilla')},
+        'title': ftl_lazy('newsletters-join-mozilla', ftl_files=FTL_FILES)},
     u'knowledge-is-power': {
-        'description': _lazy(u'Get all the knowledge you need to stay safer and smarter online.'),
-        'title': _lazy(u'Knowledge is Power')},
+        'description': ftl_lazy('newsletters-get-all-the-knowledge', ftl_files=FTL_FILES),
+        'title': ftl_lazy('newsletters-knowledge-is-power', ftl_files=FTL_FILES)},
     u'labs': {
-        'title': _lazy(u'About Labs')},
+        'title': ftl_lazy('newsletters-about-labs', ftl_files=FTL_FILES)},
     u'maker-party': {
-        'description': u"Mozilla's largest celebration of making and learning on the web.",
-        'title': _lazy(u'Maker Party')},
+        'description': ftl_lazy('newsletters-mozillas-largest-celebration', ftl_files=FTL_FILES),
+        'title': ftl_lazy('newsletters-maker-party', ftl_files=FTL_FILES)},
     u'marketplace': {
-        'description': _lazy(u'Discover the latest, coolest HTML5 apps on Firefox OS.'),
-        'title': _lazy(u'Firefox OS')},
+        'description': ftl_lazy('newsletters-discover-the-latest', ftl_files=FTL_FILES),
+        'title': ftl_lazy('newsletters-firefox-os', ftl_files=FTL_FILES)},
     u'marketplace-android': {
-        'title': _lazy(u'Android')},
+        'title': ftl_lazy('newsletters-android', ftl_files=FTL_FILES)},
     u'marketplace-desktop': {
-        'title': _lazy(u'Desktop')},
+        'title': ftl_lazy('newsletters-desktop', ftl_files=FTL_FILES)},
     u'mobile': {
-        'description': _lazy(u'Keep up with releases and news about Firefox for Android.'),
-        'title': _lazy(u'Firefox for Android')},
+        'description': ftl_lazy('newsletters-keep-up-with-releases', ftl_files=FTL_FILES),
+        'title': ftl_lazy('newsletters-firefox-for-android', ftl_files=FTL_FILES)},
     u'mozilla-and-you': {
-        'description': _lazy(u'Get how-tos, advice and news to make your Firefox experience work best for you.'),
-        'title': _lazy(u'Firefox News')},
+        'description': ftl_lazy('newsletters-get-how-tos', ftl_files=FTL_FILES),
+        'title': ftl_lazy('newsletters-firefox-news', ftl_files=FTL_FILES)},
     u'mozilla-festival': {
-        'description': u"Special announcements about Mozilla's annual, hands-on festival "
-                       u"dedicated to forging the future of the open Web.",
-        'title': _lazy(u'Mozilla Festival')},
+        'description': ftl_lazy('newsletters-special-announcements-about-mozilla', ftl_files=FTL_FILES),
+        'title': ftl_lazy('newsletters-mozilla-festival', ftl_files=FTL_FILES)},
     u'mozilla-foundation': {
-        'description': _lazy(u'Regular updates to keep you informed and active in our fight for a better internet.'),
-        'title': _lazy(u'Mozilla News')},
+        'description': ftl_lazy('newsletters-regular-updates-to-keep', ftl_files=FTL_FILES),
+        'title': ftl_lazy('newsletters-mozilla-news', ftl_files=FTL_FILES)},
     u'mozilla-general': {
-        'description': _lazy(u'Special announcements and messages from the team dedicated to keeping '
-                             u'the Web free and open.'),
-        'title': _lazy(u'Mozilla')},
+        'description': ftl_lazy('newsletters-special-accouncements-and-messages', ftl_files=FTL_FILES),
+        'title': ftl_lazy('newsletters-mozilla', ftl_files=FTL_FILES)},
     u'mozilla-learning-network': {
-        'description': _lazy(u'Updates from our global community, helping people learn the most '
-                             u'important skills of our age: the ability to read, write and participate '
-                             u'in the digital world.'),
-        'title': _lazy(u'Mozilla Learning Network')},
+        'description': ftl_lazy('newsletters-updates-from-our-global', ftl_files=FTL_FILES),
+        'title': ftl_lazy('newsletters-mozilla-learning-network', ftl_files=FTL_FILES)},
     u'mozilla-phone': {
-        'description': _lazy(u'Email updates for vouched Mozillians on mozillians.org.'),
-        'title': _lazy(u'Mozillians')},
+        'description': ftl_lazy('newsletters-email-updates-from-vouched', ftl_files=FTL_FILES),
+        'title': ftl_lazy('newsletters-mozillians', ftl_files=FTL_FILES)},
     u'mozilla-technology': {
-        'description': _lazy(u"We're building the technology of the future. Come explore with us."),
-        'title': _lazy(u'Mozilla Labs')},
+        'description': ftl_lazy('newsletters-were-building-the-technology', ftl_files=FTL_FILES),
+        'title': ftl_lazy('newsletters-mozilla-labs', ftl_files=FTL_FILES)},
     u'os': {
-        'description': _lazy(u'Firefox OS news, tips, launch information and where to buy.'),
-        'title': _lazy(u'Firefox OS')},
+        'description': ftl_lazy('newsletters-firefox-os-news', ftl_files=FTL_FILES),
+        'title': ftl_lazy('newsletters-firefox-os', ftl_files=FTL_FILES)},
     u'shape-web': {
-        'description': _lazy(u'News and information related to the health of the web.'),
-        'title': _lazy(u'Shape of the Web')},
+        'description': ftl_lazy('newsletters-news-and-information', ftl_files=FTL_FILES),
+        'title': ftl_lazy('newsletters-shapre-of-the-web', ftl_files=FTL_FILES)},
     u'student-reps': {
-        'description': _lazy(u'Former University program from 2008-2011, now retired and relaunched as '
-                             u'the Firefox Student Ambassadors program.'),
-        'title': _lazy(u'Student Reps')},
+        'description': ftl_lazy('newsletters-former-university-program', ftl_files=FTL_FILES),
+        'title': ftl_lazy('newsletters-student-reps', ftl_files=FTL_FILES)},
     u'take-action-for-the-internet': {
-        'description': _lazy(u'Add your voice to petitions, events and initiatives '
-                             u'that fight for the future of the web.'),
-        'title': _lazy(u'Take Action for the Internet')},
+        'description': ftl_lazy('newsletters-add-your-voice', ftl_files=FTL_FILES),
+        'title': ftl_lazy('newsletters-take-action', ftl_files=FTL_FILES)},
     u'test-pilot': {
-        'description': _lazy(u'Help us make a better Firefox for you by test-driving '
-                             u'our latest products and features.'),
-        'title': _lazy(u'New Product Testing')},
+        'description': ftl_lazy('newsletters-help-us-make-a-better', ftl_files=FTL_FILES),
+        'title': ftl_lazy('newsletters-new-product-testing', ftl_files=FTL_FILES)},
     u'webmaker': {
-        'description': _lazy(u'Special announcements helping you get the most out of Webmaker.'),
-        'title': _lazy(u'Webmaker')},
+        'description': ftl_lazy('newsletters-special-announcements-helping-you', ftl_files=FTL_FILES),
+        'title': ftl_lazy('newsletters-webmaker', ftl_files=FTL_FILES)},
 }
 
 
@@ -270,7 +250,8 @@ def confirm(request, token):
             'newsletter/confirm.html',
             {'success': success,
              'generic_error': generic_error,
-             'token_error': token_error})
+             'token_error': token_error},
+            ftl_files=FTL_FILES)
 
 
 @never_cache
@@ -299,7 +280,7 @@ def existing(request, token=None):
         return redirect(reverse('newsletter.recovery'))
 
     if waffle.switch('newsletter-maintenance-mode'):
-        return l10n_utils.render(request, 'newsletter/existing.html')
+        return l10n_utils.render(request, 'newsletter/existing.html', ftl_files=FTL_FILES)
 
     unsub_parm = None
 
@@ -326,7 +307,7 @@ def existing(request, token=None):
             # we'd probably fail to subscribe them anyway.
             log.exception("Basket timeout")
             messages.add_message(request, messages.ERROR, general_error)
-            return l10n_utils.render(request, 'newsletter/existing.html')
+            return l10n_utils.render(request, 'newsletter/existing.html', ftl_files=FTL_FILES)
         except basket.BasketException as e:
             log.exception("FAILED to get user from token (%s)", e.desc)
 
@@ -362,11 +343,6 @@ def existing(request, token=None):
                 else:
                     title = nstrings['title']
                 description = nstrings.get('description', u'')
-            else:
-                # Firefox Marketplace for Desktop/Android/Firefox OS should be
-                # shorten in the titles
-                title = _(data['title'].replace('Firefox Marketplace for ', ''))
-                description = _(data['description'])
 
             form_data = {
                 'title': Markup(title),
@@ -449,7 +425,8 @@ def existing(request, token=None):
                         request, messages.ERROR, general_error
                     )
                     return l10n_utils.render(request,
-                                             'newsletter/existing.html')
+                                             'newsletter/existing.html',
+                                             ftl_files=FTL_FILES)
 
             # If they chose to remove all, tell basket that they've opted out
             if remove_all:
@@ -461,7 +438,8 @@ def existing(request, token=None):
                         request, messages.ERROR, general_error
                     )
                     return l10n_utils.render(request,
-                                             'newsletter/existing.html')
+                                             'newsletter/existing.html',
+                                             ftl_files=FTL_FILES)
                 # We need to pass their token to the next view
                 url = reverse('newsletter.updated') \
                     + "?unsub=%s&token=%s" % (UNSUB_UNSUBSCRIBED_ALL, token)
@@ -505,17 +483,17 @@ def existing(request, token=None):
 
     return l10n_utils.render(request,
                              'newsletter/existing.html',
-                             context)
+                             context,
+                             ftl_files=FTL_FILES)
 
 
 # Possible reasons for unsubscribing
 REASONS = [
-    _lazy(u"You send too many emails."),
-    _lazy(u"Your content wasn't relevant to me."),
-    _lazy(u"Your email design was too hard to read."),
-    _lazy(u"I didn't sign up for this."),
-    _lazy(u"I'm keeping in touch with Mozilla on Facebook and Twitter "
-          "instead."),
+    ftl_lazy('newsletters-you-send-too-many-emails', ftl_files=FTL_FILES),
+    ftl_lazy('newsletters-your-content-wasnt-relevant', ftl_files=FTL_FILES),
+    ftl_lazy('newsletters-your-email-design', ftl_files=FTL_FILES),
+    ftl_lazy('newsletters-i-didnt-sign-up', ftl_files=FTL_FILES),
+    ftl_lazy('newsletters-im-keeping-in-touch', ftl_files=FTL_FILES),
 ]
 
 
@@ -554,13 +532,7 @@ def updated(request):
 
     # Say thank you unless we're saying something more specific
     if not unsub:
-        locale = l10n_utils.get_locale(request)
-
-        if lang_file_has_tag('mozorg/newsletters', locale, 'newsletter_confirm_0320'):
-            success_message = thank_you_new
-        else:
-            success_message = thank_you
-        messages.add_message(request, messages.INFO, success_message)
+        messages.add_message(request, messages.INFO, thank_you)
 
     if request.method == 'POST' and reasons_submitted and token:
         # Tell basket about their reasons
@@ -587,7 +559,8 @@ def updated(request):
     }
     return l10n_utils.render(request,
                              'newsletter/updated.html',
-                             context)
+                             context,
+                             ftl_files=FTL_FILES)
 
 
 @never_cache
@@ -612,7 +585,9 @@ def recovery(request):
                     # Tell them, give them a link to go subscribe if they want
                     url = reverse('newsletter.subscribe')
                     form.errors['email'] = \
-                        form.error_class([unknown_address_text % url])
+                        form.error_class([ftl('newsletters-this-email-address-is-not',
+                                              url=url,
+                                              ftl_files=FTL_FILES)])
                 else:
                     # Log the details
                     log.exception("Error sending recovery message")
@@ -632,10 +607,12 @@ def recovery(request):
     # This view is shared between two different templates. For context see bug 1442129.
     if '/newsletter/opt-out-confirmation/' in request.get_full_path():
         template = "newsletter/opt-out-confirmation.html"
+        ftl_files = ['newsletter/opt-out-confirmation']
     else:
         template = "newsletter/recovery.html"
+        ftl_files = FTL_FILES
 
-    return l10n_utils.render(request, template, {'form': form})
+    return l10n_utils.render(request, template, {'form': form}, ftl_files=ftl_files)
 
 
 def newsletter_subscribe(request):
@@ -701,6 +678,6 @@ def newsletter_subscribe(request):
             if not errors:
                 ctx['success'] = True
 
-            return l10n_utils.render(request, 'newsletter/index.html', ctx)
+            return l10n_utils.render(request, 'newsletter/index.html', ctx, ftl_files=FTL_FILES)
 
-    return l10n_utils.render(request, 'newsletter/index.html')
+    return l10n_utils.render(request, 'newsletter/index.html', ftl_files=FTL_FILES)

--- a/l10n/configs/pontoon.toml
+++ b/l10n/configs/pontoon.toml
@@ -116,5 +116,35 @@ locales = [
 ]
 
 [[paths]]
+    reference = "en/mozorg/newsletters.ftl"
+    l10n = "{locale}/mozorg/newsletters.ftl"
+    locales = [
+        "bg",
+        "cs",
+        "de",
+        "es-ES",
+        "fr",
+        "hu",
+        "id",
+        "it",
+        "nl",
+        "pl",
+        "pt-BR",
+        "ru",
+        "zh-TW",
+    ]
+[[paths]]
+    reference = "en/newsletter/opt-out-confirmation.ftl"
+    l10n = "{locale}/newsletter/opt-out-confirmation.ftl"
+    locales = [
+        "de",
+        "es-ES",
+        "fr",
+        "id",
+        "pl",
+        "pt-BR",
+        "ru"
+    ]
+[[paths]]
     reference = "en/**/*.ftl"
     l10n = "{locale}/**/*.ftl"

--- a/l10n/en/brands.ftl
+++ b/l10n/en/brands.ftl
@@ -72,6 +72,11 @@
 -brand-name-send = Send
 -brand-name-sync = Sync
 
+## Firefox products (legacy)
+
+-brand-name-firefox-marketplace = Firefox Marketplace
+-brand-name-firefox-os = Firefox OS
+
 ## Pocket
 
 -brand-name-pocket = Pocket
@@ -81,7 +86,9 @@
 -brand-name-bugzilla = Bugzilla
 -brand-name-mozilla-common-voice = Mozilla Common Voice
 -brand-name-mozilla-developer-network = Mozilla Developer Network
+-brand-name-mozilla-festival = Mozilla Festival
 -brand-name-mozilla-hubs = Mozilla Hubs
+-brand-name-mozilla-labs = Mozilla Labs
 -brand-name-mozilla-vpn = Mozilla VPN
 -brand-name-mdn-web-docs = MDN Web Docs
 -brand-name-thunderbird = Thunderbird
@@ -91,6 +98,10 @@
 -brand-name-common-voice = Common Voice
 -brand-name-hubs = Hubs
 -brand-name-mdn = MDN
+
+## Mozilla projects (legacy)
+
+-brand-name-webmaker = Webmaker
 
 ## Open Source projects
 

--- a/l10n/en/mozorg/newsletters.ftl
+++ b/l10n/en/mozorg/newsletters.ftl
@@ -1,0 +1,380 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+### NOTE: These strings are used for newsletter elements (subscription forms, preferences management, etc.)
+
+# Page title the subscription preferences page
+newsletters-newsletter-subscriptions = Newsletter Subscriptions
+
+# Page titlefor https://www-dev.allizom.org/newsletter/
+newsletters-mozilla-newsletter = { -brand-name-mozilla } Newsletter
+
+# Headline for https://www-dev.allizom.org/newsletter/
+newsletters-read-all-about-it-in-our-newsletter = Read all about it in our <span>newsletter</span>
+
+# Subtitle for https://www-dev.allizom.org/newsletter/
+newsletters-subscribe-to-updates-and-keep = Subscribe to updates and keep current with { -brand-name-mozilla } news. It’s the perfect way for us to keep in touch!
+
+# Page title the subscription confirmation page
+newsletters-newsletter-confirm = Newsletter confirm
+
+newsletters-thanks-for-subscribing = Thanks for Subscribing!
+newsletters-your-newsletter-subscription = Your newsletter subscription has been confirmed.
+newsletters-please-be-sure-to-add-our = Please be sure to add our sending address: mozilla@e.mozilla.org to your address book to ensure we always reach your inbox.
+newsletters-the-supplied-link-has-expired = The supplied link has expired. You will receive a new one in the next newsletter.
+newsletters-something-is-amiss-with = Something is amiss with our system, sorry! Please try again later.
+newsletters-youre-awesome = You’re awesome!
+newsletters-and-were-not-just-saying = And we’re not just saying that because you trusted us with your email address.
+newsletters-please-be-sure-to-add-mozillaemozillaorg = Please be sure to add mozilla@e.mozilla.org to your address book to ensure we always reach your inbox.
+newsletters-mozilla-touches-on-a-variety = { -brand-name-mozilla } touches on a variety of important issues.
+newsletters-open-your-inbox-and-your = Open your inbox (and your heart) even more — take a look at other topics we cover.
+newsletters-manage-your-email-preferences = Manage your Email Preferences
+newsletters-this-page-is-in-maintenance = This page is in maintenance mode and is temporarily unavailable.
+newsletters-to-update-your-email-preferences = To update your email preferences, please check back in a little while. Thanks!
+newsletters-we-love-sharing-updates = We love sharing updates about all the awesome things happening at { -brand-name-mozilla }.
+newsletters-set-your-preferences-below = Set your preferences below to make sure you always receive the news you want.
+
+# Form field label
+newsletters-your-email-address = Your email address:
+
+# Form field label
+newsletters-country-or-region = Country or region:
+
+# Form field label
+newsletters-country = Country:
+
+# Form field label
+newsletters-language = Language:
+
+newsletters-not-all-subscriptions-are = Not all subscriptions are supported in all the languages listed. Almost all are offered in English, German and French.
+
+# Form field label
+newsletters-format = Format:
+
+newsletters-text-subscribers-will-receive = Text subscribers will receive an email twice a year to confirm continuation of the subscription. Those emails may include HTML.
+
+# Variables:
+#   $url (url) - link to https://support.mozilla.org/kb/managing-account-data
+newsletters-many-of-our-communications = Many of our communications are related to an account you’ve signed up for, such as { -brand-name-firefox-accounts }, { -brand-name-mdn-web-docs }, or Add-on Developer. To manage one of your accounts or see a list of all the accounts, visit our <a href="{ $url }">account management support page</a>.
+
+# Variables:
+#   $url (url) - link to https://www.mozilla.org/firefox/accounts/
+newsletters-to-get-access-to-the-whole = To get access to the whole world of { -brand-name-firefox } products, knowledge and services in one account, join us! Learn more about the benefits <a href="{ $url }">here</a>.
+
+# Variables:
+#   $url (url) - link to https://www.mozilla.org/about/forums/
+newsletters-there-are-many-ways-to = There are many ways to engage with { -brand-name-mozilla } and { -brand-name-firefox }. If you didn’t find what you were looking for here, check out our <a href="{ $url }">community pages</a>.
+
+# Variables:
+#   $newsletter (string) - newsletter name
+newsletters-is-not-a-valid-newsletter = { $newsletter } is not a valid newsletter
+
+newsletters-subscribe = Subscribe
+newsletters-remove-me-from-all-the = Remove me from all the subscriptions on this page
+newsletters-save-preferences = Save Preferences
+
+# Page title for https://www-dev.allizom.org/newsletter/recovery/
+newsletters-newsletter-email-recovery = Newsletter email recovery
+
+# Headline for https://www-dev.allizom.org/newsletter/recovery/
+newsletters-manage-your-newsletter = Manage your <span>Newsletter Subscriptions</span>
+
+# Subtitle for https://www-dev.allizom.org/newsletter/recovery/
+newsletters-enter-your-email-address = Enter your email address and we’ll send you a link to your email preference center.
+
+newsletters-send-me-a-link = Send me a link
+newsletters-youve-been-unsubscribed = You’ve been unsubscribed.
+newsletters-were-sorry-to-see-you-go = We’re sorry to see you go.
+newsletters-would-you-mind-telling-us = Would you mind telling us why you’re leaving?
+newsletters-other = Other…
+newsletters-submit = Submit
+newsletters-thanks-for-telling-us-why = Thanks for telling us why you’re leaving.
+newsletters-while-here-why-not-check = While here, why not check out some more { -brand-name-firefox } awesomeness.
+newsletters-get-up-and-go = Get up and go
+newsletters-its-your-web-anywhere-you = It’s your Web anywhere you go.
+newsletters-get-firefox-for-mobile = Get { -brand-name-firefox } for mobile!
+newsletters-added-extras = Added extras
+newsletters-make-firefox-do-more-with = Make { -brand-name-firefox } do more with add-ons.
+newsletters-find-out-how = Find out how!
+newsletters-about-us = About us
+newsletters-whats-mozilla-all-about = What’s { -brand-name-mozilla } all about?
+newsletters-were-glad-you-asked = We’re glad you asked!
+
+# Headline for https://www-dev.allizom.org/newsletter/developer/
+newsletters-love-the-web-so-do-we = Love the web? So do we!
+
+# Subtitle for https://www-dev.allizom.org/newsletter/developer/
+newsletters-unlock-the-world-of-web = Unlock the world of web development with our weekly { -brand-name-mozilla } Developer Newsletter. Each edition brings you coding techniques and best practices, { -brand-name-mdn } updates, info about emerging technologies, developer tools tips, and more.
+
+# Obsolete string
+newsletters-join-thousands-of-developers = Join thousands of developers like you who are learning the best of web development.
+
+# Headline for https://www-dev.allizom.org/newsletter/firefox/
+newsletters-put-more-fox-in-your-inbox = Put more fox in your inbox.
+
+# Subtitle for https://www-dev.allizom.org/newsletter/firefox/
+newsletters-see-where-the-web-can-take = See where the Web can take you with monthly { -brand-name-firefox } tips, tricks and Internet intel.
+
+newsletters-we-are-sorry-but-there = We are sorry, but there was a problem with our system. Please try again later!
+newsletters-thanks-for-updating-your = Thanks for updating your email preferences.
+newsletters-the-supplied-link-has-expired-long = The supplied link has expired or is not valid. You will receive a new one in the next newsletter, or below you can request an email with the link.
+newsletters-success-an-email-has-been-sent = Success! An email has been sent to you with your preference center link. Thanks!
+newsletters-this-is-not-a-valid-email = This is not a valid email address. Please check the spelling.
+newsletters-you-send-too-many-emails = You send too many emails.
+newsletters-your-content-wasnt-relevant = Your content wasn't relevant to me.
+newsletters-your-email-design = Your email design was too hard to read.
+newsletters-i-didnt-sign-up = I didn't sign up for this.
+
+# Variables:
+#   $url (url) - link to https://www.mozilla.org/newsletter/
+newsletters-this-email-address-is-not = This email address is not in our system. Please double check your address or <a href="{ $url }">subscribe to our newsletters.</a>
+
+newsletters-im-keeping-in-touch = I'm keeping in touch with { -brand-name-mozilla } on { -brand-name-facebook } and { -brand-name-twitter } instead.
+
+# Headline for https://www.mozilla.org/newsletter/mozilla/
+newsletters-sign-up-read-up-stay-informed = Sign up, read up,<br> stay informed.
+
+# Obsolete string
+newsletters-sign-up-read-up-make-a-difference = Sign up. Read up.<br> Make a difference.
+
+# Subtitle for https://www.mozilla.org/newsletter/mozilla/
+newsletters-get-smart-on-the-issues = Get smart on the issues affecting your life online.
+
+# Obsolete string
+newsletters-get-the-mozilla-newsletter = Get the { -brand-name-mozilla } newsletter to stay informed about issues challenging the health of the Internet and to discover how you can get involved.
+
+newsletters-your-email-preferences = Your email preferences have been successfully updated.
+newsletters-consider-it-done = Consider it done
+newsletters-back-to-email-preferences = Back to email preferences
+newsletters-here-are-a-few-things = Here are a few things to dig into while you’re waiting for your next email.
+newsletters-take-your-privacy = Take your privacy with you
+newsletters-travel-the-internet = Travel the internet with protection on all your devices.
+newsletters-download-the-app = Download the App
+newsletters-check-for-data-breaches = Check for data breaches
+newsletters-firefox-monitor-is-a-free = { -brand-name-firefox-monitor } is a free service that lets you see if you’ve been involved in an online data breach.
+newsletters-sign-in-to-monitor = Sign In to { -brand-name-monitor }
+newsletters-meet-our-parent-brand = Meet our parent brand
+newsletters-mozilla-the-non-for-profit = { -brand-name-mozilla }, the not-for-profit behind { -brand-name-firefox }, puts people over profit in everything we say, build, and do.
+
+# Name for the newsletter in Newsletter subscription page
+newsletters-about-standards = About Standards
+
+# Name for the newsletter in Newsletter subscription page
+newsletters-addon-development = Add-on Development
+
+# Name for the newsletter in Newsletter subscription page
+newsletters-developer-newsletter = Developer Newsletter
+
+# Description for the newsletter in Newsletter subscription page (Developer Newsletter)
+newsletters-a-developers-guide = A developer's guide to highlights of Web platform innovations, best practices, new documentation and more.
+
+# Name for the newsletter in Newsletter subscription page
+newsletters-drumbeat-newsgroup = Drumbeat Newsgroup
+
+# Name for the newsletter in Newsletter subscription page
+newsletters-firefox-for-desktop = { -brand-name-firefox } for desktop
+
+# Description for the newsletter in Newsletter subscription page (Firefox for desktop)
+newsletters-dont-miss-the-latest = Don’t miss the latest announcements about our desktop browser.
+
+# Name for the newsletter in Newsletter subscription page
+newsletters-get-involved = Get Involved
+
+# Name for the newsletter in Newsletter subscription page
+newsletters-insights = Insights
+
+# Obsolete string
+newsletters-internet-health-report = Internet Health Report
+
+# Description for the newsletter in Newsletter subscription page (Insights))
+newsletters-mozilla-published-articles-and-deep = { -brand-name-mozilla } publishes articles and deep dives on issues around internet health and trustworthy AI, including our annual Internet Health Report.
+
+# Obsolete string
+newsletters-keep-up-with-our-annual = Keep up with our annual compilation of research and stories on the issues of privacy &amp; security, openness, digital inclusion, decentralization, and web literacy.
+
+# Name for the newsletter in Newsletter subscription page
+newsletters-knowledge-is-power = Knowledge is Power
+
+# Description for the newsletter in Newsletter subscription page (Knowledge is Power)
+newsletters-get-all-the-knowledge = Get all the knowledge you need to stay safer and smarter online.
+
+# Name for the newsletter in Newsletter subscription page
+newsletters-about-labs = About Labs
+
+# Name for the newsletter in Newsletter subscription page
+newsletters-desktop = Desktop
+
+# Name for the newsletter in Newsletter subscription page
+newsletters-mozillians = Mozillians
+
+# Description for the newsletter in Newsletter subscription page (Mozillians)
+newsletters-email-updates-from-vouched = Email updates for vouched Mozillians on mozillians.org.
+
+# Name for the newsletter in Newsletter subscription page
+newsletters-shapre-of-the-web = Shape of the Web
+
+# Description for the newsletter in Newsletter subscription page (Shape of the Web)
+newsletters-news-and-information = News and information related to the health of the web.
+
+# Name for the newsletter in Newsletter subscription page
+newsletters-student-reps = Student Reps
+
+# Description for the newsletter in Newsletter subscription page (Student Reps)
+newsletters-former-university-program = Former University program from 2008-2011, now retired and relaunched as the Firefox Student Ambassadors program.
+
+# Name for the newsletter in Newsletter subscription page
+newsletters-take-action = Take Action for the Internet
+
+# Description for the newsletter in Newsletter subscription page (Take Action for the Internet)
+newsletters-add-your-voice = Add your voice to petitions, events and initiatives that fight for the future of the web.
+
+# Name for the newsletter in Newsletter subscription page
+newsletters-new-product-testing = New Product Testing
+
+# Description for the newsletter in Newsletter subscription page (New Product Testing)
+newsletters-help-us-make-a-better = Help us make a better { -brand-name-firefox } for you by test-driving our latest products and features.
+
+# Name for the newsletter in Newsletter subscription page
+newsletters-mozilla-community = { -brand-name-mozilla } Community
+
+# Description for the newsletter in Newsletter subscription page (Mozilla Community)
+newsletters-join-mozillians-all-around = Join Mozillians all around the world and learn about impactful opportunities to support { -brand-name-mozilla }’s mission.
+
+# Name for the newsletter in Newsletter subscription page
+newsletters-firefox-affiliates = { -brand-name-firefox } Affiliates
+
+# Description for the newsletter in Newsletter subscription page (Firefox Affiliates)
+newsletters-a-monthly-newsletter-affiliates = A monthly newsletter to keep you up to date with the { -brand-name-firefox } Affiliates program.
+
+# Name for the newsletter in Newsletter subscription page
+newsletters-firefox-student-ambassadors = { -brand-name-firefox } Student Ambassadors
+
+# Description for the newsletter in Newsletter subscription page (Firefox Student Ambassadors)
+newsletters-a-monthly-newsletter-ambassadors = A monthly newsletter on how to get involved with { -brand-name-mozilla } on your campus.
+
+# Name for the newsletter in Newsletter subscription page
+newsletters-aurora = { -brand-name-aurora }
+
+# Name for the newsletter in Newsletter subscription page
+newsletters-beta-news = { -brand-name-beta } News
+
+# Description for the newsletter in Newsletter subscription page (Beta News)
+newsletters-read-about-the-latest-features = Read about the latest features for { -brand-name-firefox } desktop and mobile before the final release.
+
+# Name for the newsletter in Newsletter subscription page
+newsletters-download-firefox-for-android = Download { -brand-name-firefox } for { -brand-name-android }
+
+# Name for the newsletter in Newsletter subscription page
+newsletters-get-firefox-for-android = Get { -brand-name-firefox } for { -brand-name-android }
+
+# Name for the newsletter in Newsletter subscription page
+newsletters-download-firefox-for-ios = Download { -brand-name-firefox } for { -brand-name-ios }
+
+# Name for the newsletter in Newsletter subscription page
+newsletters-download-firefox-for-mobile = Download { -brand-name-firefox } for Mobile
+
+# Name for the newsletter in Newsletter subscription page
+newsletters-firefox-accounts-tips = { -brand-name-firefox-accounts } Tips
+
+# Description for the newsletter in Newsletter subscription page (Firefox Account Tips)
+newsletters-get-the-most-firefox-account = Get the most out of your { -brand-name-firefox-account }.
+
+# Name for the newsletter in Newsletter subscription page
+newsletters-firefox-flicks = { -brand-name-firefox } Flicks
+
+# Description for the newsletter in Newsletter subscription page (Firefox Flicks)
+newsletters-periodic-email-updates = Periodic email updates about our annual international film competition.
+
+# Name for the newsletter in Newsletter subscription page
+newsletters-firefox-ios = { -brand-name-firefox } { -brand-name-ios }
+
+# Description for the newsletter in Newsletter subscription page (Firefox iOS)
+newsletters-be-the-first-to-know = Be the first to know when { -brand-name-firefox } is available for { -brand-name-ios } devices.
+
+# Name for the newsletter in Newsletter subscription page
+newsletters-firefox-os-smartphone-owner = { -brand-name-firefox-os } smartphone owner?
+
+# Description for the newsletter in Newsletter subscription page (Firefox OS smartphone owner?)
+newsletters-dont-miss-important-news = Don’t miss important news and updates about your { -brand-name-firefox-os } device.
+
+# Name for the newsletter in Newsletter subscription page
+newsletters-firefox-os-and-you = { -brand-name-firefox-os } + You
+
+# Description for the newsletter in Newsletter subscription page (Firefox OS + You)
+newsletters-a-monthly-newsletter-and-special = A monthly newsletter and special announcements on how to get the most from your { -brand-name-firefox-os } device, including the latest features and coolest { -brand-name-firefox-marketplace } apps.
+
+# Name for the newsletter in Newsletter subscription page
+newsletters-firefox-weekly-tips = { -brand-name-firefox } Weekly Tips
+
+# Description for the newsletter in Newsletter subscription page (Firefox Weekly Tips)
+newsletters-get-a-weekly-tip = Get a weekly tip on how to super-charge your { -brand-name-firefox } experience.
+
+# Name for the newsletter in Newsletter subscription page
+newsletters-join-mozilla = Join { -brand-name-mozilla }
+
+# Name for the newsletter in Newsletter subscription page
+newsletters-maker-party = Maker Party
+
+# Description for the newsletter in Newsletter subscription page (Maker Party)
+newsletters-mozillas-largest-celebration = { -brand-name-mozilla }'s largest celebration of making and learning on the web.
+
+# Name for the newsletter in Newsletter subscription page
+newsletters-firefox-os = { -brand-name-firefox-os }
+
+# Description for the newsletter in Newsletter subscription page (Firefox OS)
+newsletters-discover-the-latest = Discover the latest, coolest HTML5 apps on { -brand-name-firefox-os }.
+
+# Description for the newsletter in Newsletter subscription page (Firefox OS)
+newsletters-firefox-os-news = { -brand-name-firefox-os } news, tips, launch information and where to buy.
+
+# Name for the newsletter in Newsletter subscription page
+newsletters-firefox-for-android = { -brand-name-firefox } for { -brand-name-android }
+
+# Description for the newsletter in Newsletter subscription page (Firefox for Android)
+newsletters-keep-up-with-releases = Keep up with releases and news about { -brand-name-firefox } for { -brand-name-android }.
+
+# Name for the newsletter in Newsletter subscription page
+newsletters-firefox-news = { -brand-name-firefox } News
+
+# Description for the newsletter in Newsletter subscription page (Firefox News)
+newsletters-get-how-tos = Get how-tos, advice and news to make your { -brand-name-firefox } experience work best for you.
+
+# Name for the newsletter in Newsletter subscription page
+newsletters-mozilla-festival = { -brand-name-mozilla-festival }
+
+# Description for the newsletter in Newsletter subscription page (Mozilla Festival)
+newsletters-special-announcements-about-mozilla = Special announcements about { -brand-name-mozilla }'s annual, hands-on festival dedicated to forging the future of the open Web.
+
+# Name for the newsletter in Newsletter subscription page
+newsletters-mozilla-news = { -brand-name-mozilla } News
+
+# Description for the newsletter in Newsletter subscription page (Mozilla News)
+newsletters-regular-updates-to-keep = Regular updates to keep you informed and active in our fight for a better internet.
+
+# Name for the newsletter in Newsletter subscription page
+newsletters-mozilla = { -brand-name-mozilla }
+
+# Description for the newsletter in Newsletter subscription page (Mozilla)
+newsletters-special-accouncements-and-messages = Special announcements and messages from the team dedicated to keeping the Web free and open.
+
+# Name for the newsletter in Newsletter subscription page
+newsletters-mozilla-learning-network = { -brand-name-mozilla } Learning Network
+
+# Description for the newsletter in Newsletter subscription page (Mozilla Learning Network)
+newsletters-updates-from-our-global = Updates from our global community, helping people learn the most important skills of our age: the ability to read, write and participate in the digital world.
+
+# Name for the newsletter in Newsletter subscription page
+newsletters-mozilla-labs = { -brand-name-mozilla-labs }
+
+# Description for the newsletter in Newsletter subscription page (Mozilla Labs)
+newsletters-were-building-the-technology = We're building the technology of the future. Come explore with us.
+
+# Name for the newsletter in Newsletter subscription page
+newsletters-webmaker = { -brand-name-webmaker }
+
+# Description for the newsletter in Newsletter subscription page (Webmaker)
+newsletters-special-announcements-helping-you = Special announcements helping you get the most out of { -brand-name-webmaker }.
+
+# Name for the newsletter in Newsletter subscription page
+newsletters-android = { -brand-name-android }

--- a/l10n/en/newsletter/opt-out-confirmation.ftl
+++ b/l10n/en/newsletter/opt-out-confirmation.ftl
@@ -1,0 +1,43 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+### URL: https://www-dev.allizom.org/newsletter/opt-out-confirmation/
+
+# HTML page title
+opt-out-confirmation-cool-we-hear = Cool. We hear you.
+
+# HTML page descripiton
+opt-out-confirmation-youre-now-opted = You’re now opted out of a series of emails about setting up your account.
+
+opt-out-confirmation-youll-continue = You’ll continue to receive other emails you’re subscribed to, along with occasional important updates about your account. To manage all your subscriptions, enter your email below — we need to make sure we’re talking to the right person.
+
+# Field of a form
+opt-out-confirmation-your-email = Your email address:
+
+# Only localize "yourname". Do not touch @example.com.
+opt-out-confirmation-yournameexamplecom = yourname@example.com
+
+# This is a button
+opt-out-confirmation-manage-preferences = Manage Preferences
+opt-out-confirmation-prefer-to-get = Prefer to get information another way?
+
+# Link to https://blog.mozilla.org/
+opt-out-confirmation-check-out-our = Check out our blogs
+
+# Link to https://support.mozilla.org/
+opt-out-confirmation-get-help = Get help
+
+opt-out-confirmation-subscribe-to = Subscribe to occasional newsletter updates from { -brand-name-firefox }
+
+# Link to https://www.instagram.com/mozilla/
+opt-out-confirmation-instagram = { -brand-name-instagram }
+
+# Link to https://www.youtube.com/firefoxchannel
+opt-out-confirmation-youtube = { -brand-name-youtube }
+
+# Link to https://www.facebook.com/Firefox
+opt-out-confirmation-facebook = { -brand-name-facebook }
+
+# Link to https://twitter.com/firefox
+opt-out-confirmation-twitter = { -brand-name-twitter }

--- a/l10n/en/newsletter_form.ftl
+++ b/l10n/en/newsletter_form.ftl
@@ -32,3 +32,6 @@ newsletter-form-select-country = Select country
 newsletter-form-sign-me-up = Sign me up
 newsletter-form-sign-up-now = Sign Up Now
 newsletter-form-thanks = Thanks!
+newsletter-form-leave-this-field-empty = Leave this field empty.
+newsletter-form-yes = Yes
+newsletter-form-no = No

--- a/lib/fluent_migrations/newsletter/index.py
+++ b/lib/fluent_migrations/newsletter/index.py
@@ -1,0 +1,819 @@
+from __future__ import absolute_import
+import fluent.syntax.ast as FTL
+from fluent.migrate.helpers import transforms_from
+from fluent.migrate.helpers import VARIABLE_REFERENCE, TERM_REFERENCE
+from fluent.migrate import REPLACE, COPY
+
+newsletters = "mozorg/newsletters.lang"
+
+def migrate(ctx):
+    """Migrate bedrock/newsletter/templates/newsletter/index.html, part {index}."""
+
+    ctx.add_transforms(
+        "mozorg/newsletters.ftl",
+        "mozorg/newsletters.ftl",
+        transforms_from("""
+newsletters-newsletter-subscriptions = {COPY(newsletters, "Newsletter Subscriptions",)}
+""", newsletters=newsletters)
+        )
+
+    ctx.add_transforms(
+        "mozorg/newsletters.ftl",
+        "mozorg/newsletters.ftl",
+        [
+            FTL.Message(
+                id=FTL.Identifier("newsletters-mozilla-newsletter"),
+                value=REPLACE(
+                    newsletters,
+                    "Mozilla Newsletter",
+                    {
+                        "Mozilla": TERM_REFERENCE("brand-name-mozilla"),
+                    }
+                )
+            ),
+        ] + transforms_from("""
+newsletters-read-all-about-it-in-our-newsletter = {COPY(newsletters, "Read all about it in our <span>newsletter</span>",)}
+""", newsletters=newsletters) + [
+            FTL.Message(
+                id=FTL.Identifier("newsletters-subscribe-to-updates-and-keep"),
+                value=REPLACE(
+                    newsletters,
+                    "Subscribe to updates and keep current with Mozilla news. It’s the perfect way for us to keep in touch!",
+                    {
+                        "Mozilla": TERM_REFERENCE("brand-name-mozilla"),
+                    }
+                )
+            ),
+        ]
+        )
+
+    ctx.add_transforms(
+        "mozorg/newsletters.ftl",
+        "mozorg/newsletters.ftl",
+        transforms_from("""
+newsletters-newsletter-confirm = {COPY(newsletters, "Newsletter confirm",)}
+newsletters-thanks-for-subscribing = {COPY(newsletters, "Thanks for Subscribing!",)}
+newsletters-your-newsletter-subscription = {COPY(newsletters, "Your newsletter subscription has been confirmed.",)}
+newsletters-please-be-sure-to-add-our = {COPY(newsletters, "Please be sure to add our sending address: mozilla@e.mozilla.org to your address book to ensure we always reach your inbox.",)}
+newsletters-the-supplied-link-has-expired = {COPY(newsletters, "The supplied link has expired. You will receive a new one in the next newsletter.",)}
+newsletters-something-is-amiss-with = {COPY(newsletters, "Something is amiss with our system, sorry! Please try again later.",)}
+""", newsletters=newsletters)
+        )
+
+    ctx.add_transforms(
+        "mozorg/newsletters.ftl",
+        "mozorg/newsletters.ftl",
+        transforms_from("""
+newsletters-youre-awesome = {COPY(newsletters, "You’re awesome!",)}
+newsletters-and-were-not-just-saying = {COPY(newsletters, "And we’re not just saying that because you trusted us with your email address.",)}
+newsletters-please-be-sure-to-add-mozillaemozillaorg = {COPY(newsletters, "Please be sure to add mozilla@e.mozilla.org to your address book to ensure we always reach your inbox.",)}
+""", newsletters=newsletters) + [
+            FTL.Message(
+                id=FTL.Identifier("newsletters-mozilla-touches-on-a-variety"),
+                value=REPLACE(
+                    newsletters,
+                    "Mozilla touches on a variety of important issues.",
+                    {
+                        "Mozilla": TERM_REFERENCE("brand-name-mozilla"),
+                    }
+                )
+            ),
+        ] + transforms_from("""
+newsletters-open-your-inbox-and-your = {COPY(newsletters, "Open your inbox (and your heart) even more — take a look at other topics we cover.",)}
+newsletters-manage-your-email-preferences = {COPY(newsletters, "Manage your Email Preferences",)}
+newsletters-this-page-is-in-maintenance = {COPY(newsletters, "This page is in maintenance mode and is temporarily unavailable.",)}
+newsletters-to-update-your-email-preferences = {COPY(newsletters, "To update your email preferences, please check back in a little while. Thanks!",)}
+""", newsletters=newsletters) + [
+            FTL.Message(
+                id=FTL.Identifier("newsletters-we-love-sharing-updates"),
+                value=REPLACE(
+                    newsletters,
+                    "We love sharing updates about all the awesome things happening at Mozilla.",
+                    {
+                        "Mozilla": TERM_REFERENCE("brand-name-mozilla"),
+                    }
+                )
+            ),
+        ] + transforms_from("""
+newsletters-set-your-preferences-below = {COPY(newsletters, "Set your preferences below to make sure you always receive the news you want.",)}
+newsletters-your-email-address = {COPY(newsletters, "Your email address:",)}
+newsletters-country-or-region = {COPY(newsletters, "Country or region:",)}
+newsletters-country = {COPY(newsletters, "Country:",)}
+newsletters-language = {COPY(newsletters, "Language:",)}
+newsletters-not-all-subscriptions-are = {COPY(newsletters, "Not all subscriptions are supported in all the languages listed. Almost all are offered in English, German and French.",)}
+newsletters-format = {COPY(newsletters, "Format:",)}
+newsletters-text-subscribers-will-receive = {COPY(newsletters, "Text subscribers will receive an email twice a year to confirm continuation of the subscription. Those emails may include HTML.",)}
+""", newsletters=newsletters) + [
+            FTL.Message(
+                id=FTL.Identifier("newsletters-many-of-our-communications"),
+                value=REPLACE(
+                    newsletters,
+                    "Many of our communications are related to an account you’ve signed up for, such as Firefox Accounts, MDN Web Docs, or Add-on Developer. To manage one of your accounts or see a list of all the accounts visit our <a href=\"%s\">account management support page</a>.",
+                    {
+                        "%%": "%",
+                        "%s": VARIABLE_REFERENCE("url"),
+                        "Firefox Accounts": TERM_REFERENCE("brand-name-firefox-accounts"),
+                        "MDN Web Docs": TERM_REFERENCE("brand-name-mdn-web-docs"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("newsletters-to-get-access-to-the-whole"),
+                value=REPLACE(
+                    newsletters,
+                    "To get access to the whole world of Firefox products, knowledge and services in one account, join us! Learn more about the benefits <a href=\"%s\">here</a>.",
+                    {
+                        "%%": "%",
+                        "%s": VARIABLE_REFERENCE("url"),
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("newsletters-there-are-many-ways-to"),
+                value=REPLACE(
+                    newsletters,
+                    "There are many ways to engage with Mozilla and Firefox. If you didn’t find what you were looking for here, check out our <a href=\"%s\">community pages</a>.",
+                    {
+                        "%%": "%",
+                        "%s": VARIABLE_REFERENCE("url"),
+                        "Mozilla": TERM_REFERENCE("brand-name-mozilla"),
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("newsletters-is-not-a-valid-newsletter"),
+                value=REPLACE(
+                    newsletters,
+                    "%s is not a valid newsletter",
+                    {
+                        "%%": "%",
+                        "%s": VARIABLE_REFERENCE("newsletter"),
+                    }
+                )
+            ),
+
+        ] + transforms_from("""
+newsletters-subscribe = {COPY(newsletters, "Subscribe",)}
+newsletters-remove-me-from-all-the = {COPY(newsletters, "Remove me from all the subscriptions on this page",)}
+newsletters-save-preferences = {COPY(newsletters, "Save Preferences",)}
+""", newsletters=newsletters)
+        )
+
+    ctx.add_transforms(
+        "mozorg/newsletters.ftl",
+        "mozorg/newsletters.ftl",
+        transforms_from("""
+newsletters-newsletter-email-recovery = {COPY(newsletters, "Newsletter email recovery",)}
+newsletters-manage-your-newsletter = {COPY(newsletters, "Manage your <span>Newsletter Subscriptions</span>",)}
+newsletters-enter-your-email-address = {COPY(newsletters, "Enter your email address and we’ll send you a link to your email preference center.",)}
+newsletters-send-me-a-link = {COPY(newsletters, "Send me a link",)}
+""", newsletters=newsletters)
+        )
+
+    ctx.add_transforms(
+        "mozorg/newsletters.ftl",
+        "mozorg/newsletters.ftl",
+        transforms_from("""
+newsletters-youve-been-unsubscribed = {COPY(newsletters, "You’ve been unsubscribed.",)}
+newsletters-were-sorry-to-see-you-go = {COPY(newsletters, "We’re sorry to see you go.",)}
+newsletters-would-you-mind-telling-us = {COPY(newsletters, "Would you mind telling us why you’re leaving?",)}
+newsletters-other = {COPY(newsletters, "Other…",)}
+newsletters-submit = {COPY(newsletters, "Submit",)}
+newsletters-thanks-for-telling-us-why = {COPY(newsletters, "Thanks for telling us why you’re leaving.",)}
+""", newsletters=newsletters) + [
+            FTL.Message(
+                id=FTL.Identifier("newsletters-while-here-why-not-check"),
+                value=REPLACE(
+                    newsletters,
+                    "While here, why not check out some more Firefox awesomeness.",
+                    {
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                    }
+                )
+            ),
+        ] + transforms_from("""
+newsletters-get-up-and-go = {COPY(newsletters, "Get up and go",)}
+newsletters-its-your-web-anywhere-you = {COPY(newsletters, "It’s your Web anywhere you go.",)}
+""", newsletters=newsletters) + [
+            FTL.Message(
+                id=FTL.Identifier("newsletters-get-firefox-for-mobile"),
+                value=REPLACE(
+                    newsletters,
+                    "Get Firefox for mobile!",
+                    {
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                    }
+                )
+            ),
+        ] + transforms_from("""
+newsletters-added-extras = {COPY(newsletters, "Added extras",)}
+""", newsletters=newsletters) + [
+            FTL.Message(
+                id=FTL.Identifier("newsletters-make-firefox-do-more-with"),
+                value=REPLACE(
+                    newsletters,
+                    "Make Firefox do more with add-ons.",
+                    {
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                    }
+                )
+            ),
+        ] + transforms_from("""
+newsletters-find-out-how = {COPY(newsletters, "Find out how!",)}
+newsletters-about-us = {COPY(newsletters, "About us",)}
+""", newsletters=newsletters) + [
+            FTL.Message(
+                id=FTL.Identifier("newsletters-whats-mozilla-all-about"),
+                value=REPLACE(
+                    newsletters,
+                    "What’s Mozilla all about?",
+                    {
+                        "Mozilla": TERM_REFERENCE("brand-name-mozilla"),
+                    }
+                )
+            ),
+        ] + transforms_from("""
+newsletters-were-glad-you-asked = {COPY(newsletters, "We’re glad you asked!",)}
+""", newsletters=newsletters)
+        )
+
+    ctx.add_transforms(
+        "mozorg/newsletters.ftl",
+        "mozorg/newsletters.ftl",
+        transforms_from("""
+newsletters-love-the-web-so-do-we = {COPY(newsletters, "Love the web? So do we!",)}
+""", newsletters=newsletters) + [
+            FTL.Message(
+                id=FTL.Identifier("newsletters-unlock-the-world-of-web"),
+                value=REPLACE(
+                    newsletters,
+                    "Unlock the world of web development with our weekly Mozilla Developer Newsletter. Each edition brings you coding techniques and best practices, MDN updates, info about emerging technologies, developer tools tips, and more.",
+                    {
+                        "Mozilla": TERM_REFERENCE("brand-name-mozilla"),
+                        "MDN": TERM_REFERENCE("brand-name-mdn"),
+                    }
+                )
+            ),
+        ] + transforms_from("""
+newsletters-join-thousands-of-developers = {COPY(newsletters, "Join thousands of developers like you who are learning the best of web development.",)}
+""", newsletters=newsletters)
+        )
+
+    ctx.add_transforms(
+        "mozorg/newsletters.ftl",
+        "mozorg/newsletters.ftl",
+        transforms_from("""
+newsletters-put-more-fox-in-your-inbox = {COPY(newsletters, "Put more fox in your inbox.",)}
+""", newsletters=newsletters) + [
+            FTL.Message(
+                id=FTL.Identifier("newsletters-see-where-the-web-can-take"),
+                value=REPLACE(
+                    newsletters,
+                    "See where the Web can take you with monthly Firefox tips, tricks and Internet intel.",
+                    {
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                    }
+                )
+            ),
+        ]
+        )
+
+    ctx.add_transforms(
+        "mozorg/newsletters.ftl",
+        "mozorg/newsletters.ftl",
+        transforms_from("""
+newsletters-we-are-sorry-but-there = {COPY(newsletters, "We are sorry, but there was a problem with our system. Please try again later!",)}
+newsletters-thanks-for-updating-your = {COPY(newsletters, "Thanks for updating your email preferences.",)}
+newsletters-the-supplied-link-has-expired-long = {COPY(newsletters, "The supplied link has expired or is not valid. You will receive a new one in the next newsletter, or below you can request an email with the link.",)}
+newsletters-success-an-email-has-been-sent = {COPY(newsletters, "Success! An email has been sent to you with your preference center link. Thanks!",)}
+newsletters-this-is-not-a-valid-email = {COPY(newsletters, "This is not a valid email address. Please check the spelling.",)}
+newsletters-about-standards = {COPY(newsletters, "About Standards",)}
+newsletters-addon-development = {COPY(newsletters, "Addon Development",)}
+newsletters-a-developers-guide = {COPY(newsletters, "A developer's guide to highlights of Web platform innovations, best practices, new documentation and more.",)}
+newsletters-developer-newsletter = {COPY(newsletters, "Developer Newsletter",)}
+newsletters-drumbeat-newsgroup = {COPY(newsletters, "Drumbeat Newsgroup",)}
+newsletters-dont-miss-the-latest = {COPY(newsletters, "Don’t miss the latest announcements about our desktop browser.",)}
+newsletters-periodic-email-updates = {COPY(newsletters, "Periodic email updates about our annual international film competition.",)}
+newsletters-get-involved = {COPY(newsletters, "Get Involved",)}
+newsletters-internet-health-report = {COPY(newsletters, "Internet Health Report",)}
+newsletters-keep-up-with-our-annual = {COPY(newsletters, "Keep up with our annual compilation of research and stories on the issues of privacy &amp; security, openness, digital inclusion, decentralization, and web literacy.",)}
+newsletters-get-all-the-knowledge = {COPY(newsletters, "Get all the knowledge you need to stay safer and smarter online.",)}
+newsletters-knowledge-is-power = {COPY(newsletters, "Knowledge is Power",)}
+newsletters-about-labs = {COPY(newsletters, "About Labs",)}
+newsletters-maker-party = {COPY(newsletters, "Maker Party",)}
+newsletters-desktop = {COPY(newsletters, "Desktop",)}
+newsletters-regular-updates-to-keep = {COPY(newsletters, "Regular updates to keep you informed and active in our fight for a better internet.",)}
+newsletters-special-accouncements-and-messages = {COPY(newsletters, "Special announcements and messages from the team dedicated to keeping the Web free and open.",)}
+newsletters-updates-from-our-global = {COPY(newsletters, "Updates from our global community, helping people learn the most important skills of our age: the ability to read, write and participate in the digital world.",)}
+newsletters-email-updates-from-vouched = {COPY(newsletters, "Email updates for vouched Mozillians on mozillians.org.",)}
+newsletters-mozillians = {COPY(newsletters, "Mozillians",)}
+newsletters-were-building-the-technology = {COPY(newsletters, "We're building the technology of the future. Come explore with us.",)}
+newsletters-news-and-information = {COPY(newsletters, "News and information related to the health of the web.",)}
+newsletters-shapre-of-the-web = {COPY(newsletters, "Shape of the Web",)}
+newsletters-former-university-program = {COPY(newsletters, "Former University program from 2008-2011, now retired and relaunched as the Firefox Student Ambassadors program.")}
+newsletters-student-reps = {COPY(newsletters, "Student Reps",)}
+newsletters-add-your-voice = {COPY(newsletters, "Add your voice to petitions, events and initiatives that fight for the future of the web.",)}
+newsletters-take-action = {COPY(newsletters, "Take Action for the Internet",)}
+newsletters-new-product-testing = {COPY(newsletters, "New Product Testing",)}
+newsletters-you-send-too-many-emails = {COPY(newsletters, "You send too many emails.",)}
+newsletters-your-content-wasnt-relevant = {COPY(newsletters, "Your content wasn't relevant to me.",)}
+newsletters-your-email-design = {COPY(newsletters, "Your email design was too hard to read.",)}
+newsletters-i-didnt-sign-up = {COPY(newsletters, "I didn't sign up for this.",)}
+""", newsletters=newsletters) + [
+            FTL.Message(
+                id=FTL.Identifier("newsletters-this-email-address-is-not"),
+                value=REPLACE(
+                    newsletters,
+                    "This email address is not in our system. Please double check your address or <a href=\"%s\">subscribe to our newsletters.</a>",
+                    {
+                        "%%": "%",
+                        "%s": VARIABLE_REFERENCE("url"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("newsletters-join-mozillians-all-around"),
+                value=REPLACE(
+                    newsletters,
+                    "Join Mozillians all around the world and learn about impactful opportunities to support Mozilla’s mission.",
+                    {
+                        "Mozilla": TERM_REFERENCE("brand-name-mozilla"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("newsletters-mozilla-community"),
+                value=REPLACE(
+                    newsletters,
+                    "Mozilla Community",
+                    {
+                        "Mozilla": TERM_REFERENCE("brand-name-mozilla"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("newsletters-a-monthly-newsletter-affiliates"),
+                value=REPLACE(
+                    newsletters,
+                    "A monthly newsletter to keep you up to date with the Firefox Affiliates program.",
+                    {
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("newsletters-firefox-affiliates"),
+                value=REPLACE(
+                    newsletters,
+                    "Firefox Affiliates",
+                    {
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("newsletters-a-monthly-newsletter-ambassadors"),
+                value=REPLACE(
+                    newsletters,
+                    "A monthly newsletter on how to get involved with Mozilla on your campus.",
+                    {
+                        "Mozilla": TERM_REFERENCE("brand-name-mozilla"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("newsletters-firefox-student-ambassadors"),
+                value=REPLACE(
+                    newsletters,
+                    "Firefox Student Ambassadors",
+                    {
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("newsletters-aurora"),
+                value=REPLACE(
+                    newsletters,
+                    "Aurora",
+                    {
+                        "Aurora": TERM_REFERENCE("brand-name-aurora"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("newsletters-read-about-the-latest-features"),
+                value=REPLACE(
+                    newsletters,
+                    "Read about the latest features for Firefox desktop and mobile before the final release.",
+                    {
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("newsletters-beta-news"),
+                value=REPLACE(
+                    newsletters,
+                    "Beta News",
+                    {
+                        "Beta": TERM_REFERENCE("brand-name-beta"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("newsletters-download-firefox-for-android"),
+                value=REPLACE(
+                    newsletters,
+                    "Download Firefox for Android",
+                    {
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                        "Android": TERM_REFERENCE("brand-name-android"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("newsletters-get-firefox-for-android"),
+                value=REPLACE(
+                    newsletters,
+                    "Get Firefox for Android",
+                    {
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                        "Android": TERM_REFERENCE("brand-name-android"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("newsletters-download-firefox-for-ios"),
+                value=REPLACE(
+                    newsletters,
+                    "Download Firefox for iOS",
+                    {
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                        "iOS": TERM_REFERENCE("brand-name-ios"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("newsletters-download-firefox-for-mobile"),
+                value=REPLACE(
+                    newsletters,
+                    "Download Firefox for Mobile",
+                    {
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("newsletters-get-the-most-firefox-account"),
+                value=REPLACE(
+                    newsletters,
+                    "Get the most out of your Firefox Account.",
+                    {
+                        "Firefox Account": TERM_REFERENCE("brand-name-firefox-account"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("newsletters-firefox-accounts-tips"),
+                value=REPLACE(
+                    newsletters,
+                    "Firefox Accounts Tips",
+                    {
+                        "Firefox Accounts": TERM_REFERENCE("brand-name-firefox-accounts"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("newsletters-firefox-for-desktop"),
+                value=REPLACE(
+                    newsletters,
+                    "Firefox for desktop",
+                    {
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("newsletters-firefox-flicks"),
+                value=REPLACE(
+                    newsletters,
+                    "Firefox Flicks",
+                    {
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("newsletters-be-the-first-to-know"),
+                value=REPLACE(
+                    newsletters,
+                    "Be the first to know when Firefox is available for iOS devices.",
+                    {
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                        "iOS": TERM_REFERENCE("brand-name-ios"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("newsletters-firefox-ios"),
+                value=REPLACE(
+                    newsletters,
+                    "Firefox iOS",
+                    {
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                        "iOS": TERM_REFERENCE("brand-name-ios"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("newsletters-dont-miss-important-news"),
+                value=REPLACE(
+                    newsletters,
+                    "Don’t miss important news and updates about your Firefox OS device.",
+                    {
+                        "Firefox OS": TERM_REFERENCE("brand-name-firefox-os"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("newsletters-firefox-os-smartphone-owner"),
+                value=REPLACE(
+                    newsletters,
+                    "Firefox OS smartphone owner?",
+                    {
+                        "Firefox OS": TERM_REFERENCE("brand-name-firefox-os"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("newsletters-a-monthly-newsletter-and-special"),
+                value=REPLACE(
+                    newsletters,
+                    "A monthly newsletter and special announcements on how to get the most from your Firefox OS device, including the latest features and coolest Firefox Marketplace apps.",
+                    {
+                        "Firefox OS": TERM_REFERENCE("brand-name-firefox-os"),
+                        "Firefox Marketplace": TERM_REFERENCE("brand-name-firefox-marketplace"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("newsletters-firefox-os-and-you"),
+                value=REPLACE(
+                    newsletters,
+                    "Firefox OS + You",
+                    {
+                        "Firefox OS": TERM_REFERENCE("brand-name-firefox-os"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("newsletters-get-a-weekly-tip"),
+                value=REPLACE(
+                    newsletters,
+                    "Get a weekly tip on how to super-charge your Firefox experience.",
+                    {
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("newsletters-firefox-weekly-tips"),
+                value=REPLACE(
+                    newsletters,
+                    "Firefox Weekly Tips",
+                    {
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("newsletters-join-mozilla"),
+                value=REPLACE(
+                    newsletters,
+                    "Join Mozilla",
+                    {
+                        "Mozilla": TERM_REFERENCE("brand-name-mozilla"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("newsletters-mozillas-largest-celebration"),
+                value=REPLACE(
+                    newsletters,
+                    "Mozilla's largest celebration of making and learning on the web.",
+                    {
+                        "Mozilla": TERM_REFERENCE("brand-name-mozilla"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("newsletters-discover-the-latest"),
+                value=REPLACE(
+                    newsletters,
+                    "Discover the latest, coolest HTML5 apps on Firefox OS.",
+                    {
+                        "Firefox OS": TERM_REFERENCE("brand-name-firefox-os"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("newsletters-firefox-os"),
+                value=REPLACE(
+                    newsletters,
+                    "Firefox OS",
+                    {
+                        "Firefox OS": TERM_REFERENCE("brand-name-firefox-os"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("newsletters-android"),
+                value=REPLACE(
+                    newsletters,
+                    "Android",
+                    {
+                        "Android": TERM_REFERENCE("brand-name-android"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("newsletters-keep-up-with-releases"),
+                value=REPLACE(
+                    newsletters,
+                    "Keep up with releases and news about Firefox for Android.",
+                    {
+                        "Android": TERM_REFERENCE("brand-name-android"),
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("newsletters-firefox-for-android"),
+                value=REPLACE(
+                    newsletters,
+                    "Firefox for Android",
+                    {
+                        "Android": TERM_REFERENCE("brand-name-android"),
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("newsletters-get-how-tos"),
+                value=REPLACE(
+                    newsletters,
+                    "Get how-tos, advice and news to make your Firefox experience work best for you.",
+                    {
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("newsletters-firefox-news"),
+                value=REPLACE(
+                    newsletters,
+                    "Firefox News",
+                    {
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("newsletters-special-announcements-about-mozilla"),
+                value=REPLACE(
+                    newsletters,
+                    "Special announcements about Mozilla's annual, hands-on festival dedicated to forging the future of the open Web.",
+                    {
+                        "Mozilla": TERM_REFERENCE("brand-name-mozilla"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("newsletters-mozilla-festival"),
+                value=REPLACE(
+                    newsletters,
+                    "Mozilla Festival",
+                    {
+                        "Mozilla Festival": TERM_REFERENCE("brand-name-mozilla-festival"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("newsletters-mozilla-news"),
+                value=REPLACE(
+                    newsletters,
+                    "Mozilla News",
+                    {
+                        "Mozilla": TERM_REFERENCE("brand-name-mozilla"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("newsletters-mozilla"),
+                value=REPLACE(
+                    newsletters,
+                    "Mozilla",
+                    {
+                        "Mozilla": TERM_REFERENCE("brand-name-mozilla"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("newsletters-mozilla-learning-network"),
+                value=REPLACE(
+                    newsletters,
+                    "Mozilla Learning Network",
+                    {
+                        "Mozilla": TERM_REFERENCE("brand-name-mozilla"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("newsletters-mozilla-labs"),
+                value=REPLACE(
+                    newsletters,
+                    "Mozilla Labs",
+                    {
+                        "Mozilla Labs": TERM_REFERENCE("brand-name-mozilla-labs"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("newsletters-firefox-os-news"),
+                value=REPLACE(
+                    newsletters,
+                    "Firefox OS news, tips, launch information and where to buy.",
+                    {
+                        "Firefox OS": TERM_REFERENCE("brand-name-firefox-os"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("newsletters-help-us-make-a-better"),
+                value=REPLACE(
+                    newsletters,
+                    "Help us make a better Firefox for you by test-driving our latest products and features.",
+                    {
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("newsletters-special-announcements-helping-you"),
+                value=REPLACE(
+                    newsletters,
+                    "Special announcements helping you get the most out of Webmaker.",
+                    {
+                        "Webmaker": TERM_REFERENCE("brand-name-webmaker"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("newsletters-webmaker"),
+                value=REPLACE(
+                    newsletters,
+                    "Webmaker",
+                    {
+                        "Webmaker": TERM_REFERENCE("brand-name-webmaker"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("newsletters-im-keeping-in-touch"),
+                value=REPLACE(
+                    newsletters,
+                    "I'm keeping in touch with Mozilla on Facebook and Twitter instead.",
+                    {
+                        "Mozilla": TERM_REFERENCE("brand-name-mozilla"),
+                        "Facebook": TERM_REFERENCE("brand-name-facebook"),
+                        "Twitter": TERM_REFERENCE("brand-name-twitter"),
+                    }
+                )
+            ),
+
+        ]
+        )
+
+    ctx.add_transforms(
+        "mozorg/newsletters.ftl",
+        "mozorg/newsletters.ftl",
+        transforms_from("""
+newsletters-sign-up-read-up-stay-informed = {COPY(newsletters, "Sign up, read up,<br> stay informed.",)}
+newsletters-sign-up-read-up-make-a-difference = {COPY(newsletters, "Sign up. Read up.<br> Make a difference.",)}
+newsletters-get-smart-on-the-issues = {COPY(newsletters, "Get smart on the issues affecting your life online.",)}
+""", newsletters=newsletters) + [
+            FTL.Message(
+                id=FTL.Identifier("newsletters-get-the-mozilla-newsletter"),
+                value=REPLACE(
+                    newsletters,
+                    "Get the Mozilla newsletter to stay informed about issues challenging the health of the Internet and to discover how you can get involved.",
+                    {
+                        "Mozilla": TERM_REFERENCE("brand-name-mozilla"),
+                    }
+                )
+            ),
+        ]
+        )

--- a/lib/fluent_migrations/newsletter/opt-out-confirmation.py
+++ b/lib/fluent_migrations/newsletter/opt-out-confirmation.py
@@ -1,0 +1,37 @@
+from __future__ import absolute_import
+import fluent.syntax.ast as FTL
+from fluent.migrate.helpers import transforms_from
+from fluent.migrate.helpers import VARIABLE_REFERENCE, TERM_REFERENCE
+from fluent.migrate import REPLACE, COPY
+
+opt_out_confirmation = "newsletter/opt-out-confirmation.lang"
+
+def migrate(ctx):
+    """Migrate bedrock/newsletter/templates/newsletter/opt-out-confirmation.html, part {index}."""
+
+    ctx.add_transforms(
+        "newsletter/opt-out-confirmation.ftl",
+        "newsletter/opt-out-confirmation.ftl",
+        transforms_from("""
+opt-out-confirmation-cool-we-hear = {COPY(opt_out_confirmation, "Cool. We hear you.",)}
+opt-out-confirmation-youre-now-opted = {COPY(opt_out_confirmation, "You’re now opted out of a series of emails about setting up your account.",)}
+opt-out-confirmation-youll-continue = {COPY(opt_out_confirmation, "You’ll continue to receive other emails you’re subscribed to, along with occasional important updates about your account. To manage all your subscriptions, enter your email below — we need to make sure we’re talking to the right person.",)}
+opt-out-confirmation-your-email = {COPY(opt_out_confirmation, "Your email address:",)}
+opt-out-confirmation-yournameexamplecom = {COPY(opt_out_confirmation, "yourname@example.com",)}
+opt-out-confirmation-manage-preferences = {COPY(opt_out_confirmation, "Manage Preferences",)}
+opt-out-confirmation-prefer-to-get = {COPY(opt_out_confirmation, "Prefer to get information another way?",)}
+opt-out-confirmation-check-out-our = {COPY(opt_out_confirmation, "Check out our blogs",)}
+opt-out-confirmation-get-help = {COPY(opt_out_confirmation, "Get help",)}
+""", opt_out_confirmation=opt_out_confirmation) + [
+            FTL.Message(
+                id=FTL.Identifier("opt-out-confirmation-subscribe-to"),
+                value=REPLACE(
+                    opt_out_confirmation,
+                    "Subscribe to occasional newsletter updates from Firefox",
+                    {
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                    }
+                )
+            ),
+        ]
+        )


### PR DESCRIPTION
## Description
- Migrates `/newsletter/` app from .lang to Fluent

## Issue / Bugzilla link
#8659
#9401

## Testing
- http://localhost:8000/en-US/newsletter/
- http://localhost:8000/en-US/newsletter/existing/*TOKEN*/
- http://localhost:8000/en-US/newsletter/confirm/*TOKEN*/
- http://localhost:8000/en-US/newsletter/country/*TOKEN*/
- http://localhost:8000/en-US/newsletter/updated/
- http://localhost:8000/en-US/newsletter/recovery/
- http://localhost:8000/en-US/newsletter/mozilla/
- http://localhost:8000/en-US/newsletter/firefox/
- http://localhost:8000/en-US/newsletter/developer/
- http://localhost:8000/en-US/newsletter/fxa-error/
- http://localhost:8000/en-US/newsletter/opt-out-confirmation/
- http://localhost:8000/en-US/newsletter/country/success/