### PR TITLE
Improve GA download reporting for legacy / unknown browsers (Fixes #9535)

### DIFF
--- a/media/js/base/mozilla-utils.js
+++ b/media/js/base/mozilla-utils.js
@@ -56,6 +56,10 @@ if (typeof window.Mozilla === 'undefined') {
             data.name = 'Android';
             data.version = 'android';
             break;
+        default:
+            data.os = 'Unsupported';
+            data.name = 'Unsupported';
+            data.version = 'unsupported';
         }
 
         return data;

--- a/media/js/ie/mozilla-utils-ie.js
+++ b/media/js/ie/mozilla-utils-ie.js
@@ -47,6 +47,13 @@ if (typeof window.Mozilla === 'undefined') {
             }
         });
         $('.download-list').attr('role', 'presentation');
+
+        $('.c-button-download-thanks > .download-link').each(function() {
+            var $el = $(this);
+            $el.attr('data-download-os', 'Desktop');
+            $el.attr('data-display-name', 'Windows 32-bit');
+            $el.attr('data-download-version', 'win');
+        });
     };
 
     UtilsIE.initNavigation = function() {

--- a/tests/unit/spec/base/mozilla-utils.js
+++ b/tests/unit/spec/base/mozilla-utils.js
@@ -174,5 +174,17 @@ describe('mozilla-utils.js', function() {
                 version: 'android'
             });
         });
+
+        it('should return expected values for unsupported / unknown platforms', function () {
+            var site = {
+                platform: 'other'
+            };
+            var result = Mozilla.Utils.getDownloadAttributionValues(site);
+            expect(result).toEqual({
+                os: 'Unsupported',
+                name: 'Unsupported',
+                version: 'unsupported'
+            });
+        });
     });
 });

--- a/tests/unit/spec/ie/mozilla-utils-ie.js
+++ b/tests/unit/spec/ie/mozilla-utils-ie.js
@@ -58,5 +58,13 @@ describe('mozilla-utils-ie.js', function() {
             document.querySelector('.c-button-download-thanks > .download-link').click();
             expect(Mozilla.UtilsIE.triggerIEDownload).toHaveBeenCalledWith('test-download-url');
         });
+
+        it('should set expected data attributes for analytics', function() {
+            var link = document.querySelector('.c-button-download-thanks > .download-link');
+            Mozilla.UtilsIE.initDownloadLinks();
+            expect(link.getAttribute('data-download-os')).toEqual('Desktop');
+            expect(link.getAttribute('data-display-name')).toEqual('Windows 32-bit');
+            expect(link.getAttribute('data-download-version')).toEqual('win');
+        });
     });
 });


### PR DESCRIPTION
## Description
- Fixes GA bug where old IE browsers are not setting download event label correctly.
- Add 'Unsupported' fallback label for other platforms.

## Issue / Bugzilla link
#9535

## Testing
Demo: https://www-demo2.allizom.org/en-US/

- [x] Correct data attributes should be viewable on download links is old IE browsers:

<img width="1672" alt="image" src="https://user-images.githubusercontent.com/400117/95721539-a76df500-0c6a-11eb-9206-68b7faff7cc8.png">