### PR TITLE
remove fxa-signin class from footer list items

### DIFF
--- a/bedrock/base/templates/includes/protocol/footer/firefox.html
+++ b/bedrock/base/templates/includes/protocol/footer/firefox.html
@@ -44,7 +44,7 @@
             {{ ftl('footer-join') }}
           </h5>
           <ul class="mzp-c-footer-list">
-            <li class="fxa-signin">
+            <li>
               {{ fxa_button(
                 entrypoint='mozilla.org-firefoxfooter',
                 button_text=ftl('footer-sign-up'),
@@ -54,7 +54,7 @@
                 optional_attributes={'data-cta-text': 'Sign Up', 'data-cta-type': 'fxa-sync', 'data-cta-position': 'footer'}
               ) }}
             </li>
-            <li class="fxa-signin">
+            <li>
               {{ fxa_button(
                 entrypoint='mozilla.org-firefoxfooter',
                 button_text=ftl('footer-sign-in'),


### PR DESCRIPTION
The class is not needed for this element. This should fix bug 9327

## Description
This fixes an issue where some links in the footer receive additional styles when a FxA form is on the page

This class appears to be unnecessary for the footer (the only scss files that referenced this class were for the FxA signup). If this is true, a new unique class is not needed, and removing from the footer should suffice. 

## Issue / Bugzilla link
fixes bug #9327 
