### PR TITLE
Optimize functional tests (Fixes #9444)

### DIFF
--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -94,14 +94,14 @@ e.g. ``tests/functional/test_newsletter.py``:
 
 .. code-block:: bash
 
-    $ py.test --base-url http://localhost:8000 --driver Firefox --html tests/functional/results.html tests/functional/test_newsletter.py
+    $ py.test --base-url http://localhost:8000 --driver Firefox --html tests/functional/results.html tests/functional/firefox/new/test_download.py
 
 To run a single test you can filter using the ``-k`` argument supplied with a keyword
-e.g. ``-k test_successful_sign_up``:
+e.g. ``-k test_download_button_displayed``:
 
 .. code-block:: bash
 
-  $ py.test --base-url http://localhost:8000 --driver Firefox --html tests/functional/results.html tests/functional/test_newsletter.py -k test_successful_sign_up
+  $ py.test --base-url http://localhost:8000 --driver Firefox --html tests/functional/results.html tests/functional/firefox/new/test_download.py -k test_download_button_displayed
 
 You can also easily run the tests against any bedrock environment by specifying the
 ``--base-url`` argument. For example, to run all functional tests against dev:
@@ -191,27 +191,44 @@ you can also read the `pytest markers`_ documentation for more options.
         assert not page.text_format_selected
         assert not page.privacy_policy_accepted
 
+Smoke tests
+~~~~~~~~~~~
+
+Smoke tests are considered to be our most critical tests that must pass in a wide range
+of web browsers, including Internet Explorer 11. The number of smoke tests we run should
+be enough to cover our most critical pages where legacy browser support is important.
+
+.. code-block:: python
+
+    import pytest
+
+    @pytest.mark.smoke
+    @pytest.mark.nondestructive
+    def test_download_button_displayed(base_url, selenium):
+        page = DownloadPage(selenium, base_url, params='').open()
+        assert page.is_download_button_displayed
+
+You can run smoke tests only by adding ``-m smoke`` when running the test suite on the
+command line.
 
 Sanity tests
 ~~~~~~~~~~~~
 
-Sanity tests are considered to be our most critical tests that must pass in a wide range
-of web browsers, including old versions of Internet Explorer. Sanity tests are run
-automatically post deployment on a wider range of browsers & platforms than we run the
-full suite against. The number of sanity tests we run should remain small, but cover our
-most critical pages where legacy browser support is important. Sanity tests are typically
-run after a tagged commit to master (see :ref:`tagged-commit`).
+Sanity tests behave in much the same way as smoke tests, but will also run against Internet
+Explorer 9, which is a browser that does not receive 1st class CSS/JS support (except on
+certain download pages such as /firefox/new/). The number of sanity tests we run should be
+small and cover only a handful key of pages.
 
 .. code-block:: python
 
     import pytest
 
     @pytest.mark.sanity
+    @pytest.mark.smoke
     @pytest.mark.nondestructive
-    def test_click_download_button(base_url, selenium):
-        page = FirefoxNewPage(base_url, selenium).open()
-        page.download_firefox()
-        assert page.is_thank_you_message_displayed
+    def test_download_button_displayed(base_url, selenium):
+        page = DownloadPage(selenium, base_url, params='').open()
+        assert page.is_download_button_displayed
 
 You can run sanity tests only by adding ``-m sanity`` when running the test suite on the
 command line.

--- a/tests/functional/firefox/browsers/compare/test_browsers.py
+++ b/tests/functional/firefox/browsers/compare/test_browsers.py
@@ -15,20 +15,8 @@ from pages.firefox.browsers.compare import BrowserComparisonPage
     ('/opera/'),
     ('/brave/'),
     ('/ie/')])
-def test_download_buttons_is_displayed(slug, base_url, selenium):
-    page = BrowserComparisonPage(selenium, base_url, slug=slug).open()
-    assert page.secondary_download_button.is_displayed
-
-
-@pytest.mark.nondestructive
-@pytest.mark.parametrize('slug', [
-    ('/chrome/'),
-    ('/edge/'),
-    ('/safari/'),
-    ('/opera/'),
-    ('/brave/'),
-    ('/ie/')])
-def test_browser_menu_list_is_open(slug, base_url, selenium):
+def test_download_links_are_displayed(slug, base_url, selenium):
     page = BrowserComparisonPage(selenium, base_url, slug=slug).open()
     page.browser_menu_list.click()
     assert page.browser_menu_list.list_is_open
+    assert page.secondary_download_button.is_displayed

--- a/tests/functional/firefox/browsers/compare/test_index.py
+++ b/tests/functional/firefox/browsers/compare/test_index.py
@@ -7,6 +7,7 @@ import pytest
 from pages.firefox.browsers.compare import BrowserComparisonPage
 
 
+@pytest.mark.smoke
 @pytest.mark.nondestructive
 def test_download_buttons_are_displayed(base_url, selenium):
     page = BrowserComparisonPage(selenium, base_url, slug='/').open()

--- a/tests/functional/firefox/browsers/test_windows_64_bit.py
+++ b/tests/functional/firefox/browsers/test_windows_64_bit.py
@@ -7,6 +7,7 @@ import pytest
 from pages.firefox.browsers.windows_64_bit import Windows64BitPage
 
 
+@pytest.mark.smoke
 @pytest.mark.nondestructive
 def test_download_button_is_displayed(base_url, selenium):
     page = Windows64BitPage(selenium, base_url).open()

--- a/tests/functional/firefox/channel/test_android.py
+++ b/tests/functional/firefox/channel/test_android.py
@@ -7,6 +7,7 @@ import pytest
 from pages.firefox.channel.android import ChannelAndroidPage
 
 
+@pytest.mark.smoke
 @pytest.mark.nondestructive
 def test_download_buttons_are_displayed(base_url, selenium):
     page = ChannelAndroidPage(selenium, base_url).open()

--- a/tests/functional/firefox/channel/test_desktop.py
+++ b/tests/functional/firefox/channel/test_desktop.py
@@ -7,6 +7,7 @@ import pytest
 from pages.firefox.channel.desktop import ChannelDesktopPage
 
 
+@pytest.mark.smoke
 @pytest.mark.nondestructive
 def test_download_buttons_are_displayed(base_url, selenium):
     page = ChannelDesktopPage(selenium, base_url).open()

--- a/tests/functional/firefox/new/test_download.py
+++ b/tests/functional/firefox/new/test_download.py
@@ -7,6 +7,7 @@ import pytest
 from pages.firefox.new.download import DownloadPage
 
 
+@pytest.mark.smoke
 @pytest.mark.sanity
 @pytest.mark.nondestructive
 def test_download_button_displayed(base_url, selenium):

--- a/tests/functional/firefox/new/test_download_yandex.py
+++ b/tests/functional/firefox/new/test_download_yandex.py
@@ -7,23 +7,20 @@ import pytest
 from pages.firefox.new.download_yandex import YandexDownloadPage
 
 
+@pytest.mark.smoke
 @pytest.mark.nondestructive
-def test_download_button_displayed(base_url, selenium):
+def test_download_buttons_are_displayed(base_url, selenium):
     page = YandexDownloadPage(selenium, base_url, locale='ru', params='?geo=us').open()
     assert page.download_button.is_displayed
     assert not page.is_yandex_download_button_displayed
+    modal = page.open_other_platforms_modal()
+    assert modal.is_displayed
+    modal.close()
 
 
+@pytest.mark.smoke
 @pytest.mark.nondestructive
 def test_yandex_download_button_displayed(base_url, selenium):
     page = YandexDownloadPage(selenium, base_url, locale='ru', params='?geo=ru').open()
     assert not page.download_button.is_displayed
     assert page.is_yandex_download_button_displayed
-
-
-@pytest.mark.nondestructive
-def test_other_platforms_modal(base_url, selenium):
-    page = YandexDownloadPage(selenium, base_url, locale='ru', params='?geo=us').open()
-    modal = page.open_other_platforms_modal()
-    assert modal.is_displayed
-    modal.close()

--- a/tests/functional/firefox/new/test_platform.py
+++ b/tests/functional/firefox/new/test_platform.py
@@ -7,12 +7,15 @@ import pytest
 from pages.firefox.new.platform import PlatformDownloadPage
 
 
-@pytest.mark.sanity
+@pytest.mark.smoke
 @pytest.mark.nondestructive
 @pytest.mark.parametrize('slug', ['windows', 'mac', 'linux'])
-def test_download_button_displayed(slug, base_url, selenium):
+def test_download_buttons_are_displayed(slug, base_url, selenium):
     page = PlatformDownloadPage(selenium, base_url, slug=slug).open()
     assert page.download_button.is_displayed
+    modal = page.open_other_platforms_modal()
+    assert modal.is_displayed
+    modal.close()
 
 
 # Firefox and Internet Explorer don't cope well with file prompts whilst using Selenium.
@@ -24,12 +27,3 @@ def test_click_download_button(slug, base_url, selenium):
     page = PlatformDownloadPage(selenium, base_url, slug=slug).open()
     thank_you_page = page.download_firefox()
     assert thank_you_page.seed_url in selenium.current_url
-
-
-@pytest.mark.nondestructive
-@pytest.mark.parametrize('slug', ['windows', 'mac', 'linux'])
-def test_other_platforms_modal(slug, base_url, selenium):
-    page = PlatformDownloadPage(selenium, base_url, slug=slug).open()
-    modal = page.open_other_platforms_modal()
-    assert modal.is_displayed
-    modal.close()

--- a/tests/functional/firefox/privacy/test_products.py
+++ b/tests/functional/firefox/privacy/test_products.py
@@ -7,6 +7,7 @@ import pytest
 from pages.firefox.privacy.products import FirefoxPrivacyProductsPage
 
 
+@pytest.mark.smoke
 @pytest.mark.skip_if_firefox(reason='Download buttons are shown to non-Firefox browsers only')
 @pytest.mark.nondestructive
 def test_download_button_displayed(base_url, selenium):

--- a/tests/functional/firefox/test_all.py
+++ b/tests/functional/firefox/test_all.py
@@ -9,6 +9,7 @@ import pytest
 from pages.firefox.all import FirefoxAllPage
 
 
+@pytest.mark.smoke
 @pytest.mark.nondestructive
 def test_firefox_release(base_url, selenium):
     page = FirefoxAllPage(selenium, base_url).open()
@@ -20,6 +21,7 @@ def test_firefox_release(base_url, selenium):
     assert 'product=firefox-latest-ssl' and 'os=win64' and 'lang=en-US' in page.download_link
 
 
+@pytest.mark.smoke
 @pytest.mark.nondestructive
 def test_firefox_beta(base_url, selenium):
     page = FirefoxAllPage(selenium, base_url).open()
@@ -31,6 +33,7 @@ def test_firefox_beta(base_url, selenium):
     assert 'product=firefox-beta-latest-ssl' and 'os=osx' and 'lang=de' in page.download_link
 
 
+@pytest.mark.smoke
 @pytest.mark.nondestructive
 def test_firefox_developer(base_url, selenium):
     page = FirefoxAllPage(selenium, base_url).open()
@@ -42,6 +45,7 @@ def test_firefox_developer(base_url, selenium):
     assert 'product=firefox-devedition-latest-ssl' and 'os=linux64' and 'lang=en-US' in page.download_link
 
 
+@pytest.mark.smoke
 @pytest.mark.nondestructive
 def test_firefox_nightly(base_url, selenium):
     page = FirefoxAllPage(selenium, base_url).open()
@@ -53,6 +57,7 @@ def test_firefox_nightly(base_url, selenium):
     assert 'product=firefox-nightly-latest-ssl' and 'os=win' and 'lang=de' in page.download_link
 
 
+@pytest.mark.smoke
 @pytest.mark.nondestructive
 def test_firefox_esr(base_url, selenium):
     page = FirefoxAllPage(selenium, base_url).open()
@@ -64,6 +69,7 @@ def test_firefox_esr(base_url, selenium):
     assert 'product=firefox-esr-latest-ssl' and 'os=linux' and 'lang=en-US' in page.download_link
 
 
+@pytest.mark.smoke
 @pytest.mark.nondestructive
 def test_firefox_android(base_url, selenium):
     page = FirefoxAllPage(selenium, base_url).open()
@@ -74,6 +80,7 @@ def test_firefox_android(base_url, selenium):
     assert 'product=fennec-latest' and 'os=android-x86' and 'lang=multi' in page.download_link
 
 
+@pytest.mark.smoke
 @pytest.mark.nondestructive
 def test_firefox_android_beta(base_url, selenium):
     page = FirefoxAllPage(selenium, base_url).open()
@@ -84,6 +91,7 @@ def test_firefox_android_beta(base_url, selenium):
     assert 'product=fennec-beta-latest' and 'os=android' and 'lang=multi' in page.download_link
 
 
+@pytest.mark.smoke
 @pytest.mark.nondestructive
 def test_firefox_android_nightly(base_url, selenium):
     page = FirefoxAllPage(selenium, base_url).open()

--- a/tests/functional/firefox/test_browsers.py
+++ b/tests/functional/firefox/test_browsers.py
@@ -8,6 +8,7 @@ from urllib.parse import unquote
 from pages.firefox.browsers.landing import FirefoxBrowsersPage
 
 
+@pytest.mark.smoke
 @pytest.mark.nondestructive
 def test_primary_download_button_displayed(base_url, selenium):
     page = FirefoxBrowsersPage(selenium, base_url).open()

--- a/tests/functional/firefox/test_developer.py
+++ b/tests/functional/firefox/test_developer.py
@@ -7,6 +7,7 @@ import pytest
 from pages.firefox.developer import DeveloperPage
 
 
+@pytest.mark.smoke
 @pytest.mark.nondestructive
 def test_download_buttons_are_displayed(base_url, selenium):
     page = DeveloperPage(selenium, base_url).open()

--- a/tests/functional/firefox/test_enterprise.py
+++ b/tests/functional/firefox/test_enterprise.py
@@ -7,15 +7,11 @@ import pytest
 from pages.firefox.enterprise.landing import EnterprisePage
 
 
+@pytest.mark.smoke
 @pytest.mark.nondestructive
-def test_primary_download_button_displayed(base_url, selenium):
+def test_primary_download_links_are_displayed(base_url, selenium):
     page = EnterprisePage(selenium, base_url).open()
     assert page.is_primary_download_button_displayed
-
-
-@pytest.mark.nondestructive
-def test_download_lists(base_url, selenium):
-    page = EnterprisePage(selenium, base_url).open()
     page.win64_download_list.click()
     assert page.win64_download_list.list_is_open
     page.win32_download_list.click()

--- a/tests/functional/firefox/test_facebook_container.py
+++ b/tests/functional/firefox/test_facebook_container.py
@@ -14,6 +14,7 @@ def test_facebook_container_link_is_displayed(base_url, selenium):
     assert page.is_facebook_container_link_displayed
 
 
+@pytest.mark.smoke
 @pytest.mark.skip_if_firefox(reason='Firefox download button is shown only to non-Firefox users.')
 @pytest.mark.nondestructive
 def test_firefox_download_button_is_displayed(base_url, selenium):

--- a/tests/functional/firefox/test_home.py
+++ b/tests/functional/firefox/test_home.py
@@ -7,6 +7,7 @@ import pytest
 from pages.firefox.home import FirefoxHomePage
 
 
+@pytest.mark.smoke
 @pytest.mark.nondestructive
 def test_download_menu_list_displays(base_url, selenium):
     page = FirefoxHomePage(selenium, base_url).open()
@@ -19,10 +20,3 @@ def test_download_menu_list_displays(base_url, selenium):
 def test_fb_container_fx(base_url, selenium):
     page = FirefoxHomePage(selenium, base_url).open()
     assert page.fb_container_is_displayed
-
-
-@pytest.mark.nondestructive
-@pytest.mark.skip_if_firefox(reason='FB Container link hidden from non Firefox users.')
-def test_fb_container_non_fx(base_url, selenium):
-    page = FirefoxHomePage(selenium, base_url).open()
-    assert not page.fb_container_is_displayed

--- a/tests/functional/firefox/test_installer_help.py
+++ b/tests/functional/firefox/test_installer_help.py
@@ -8,6 +8,7 @@ from pages.firefox.installer_help import InstallerHelpPage
 
 
 @pytest.mark.sanity
+@pytest.mark.smoke
 @pytest.mark.nondestructive
 def test_download_buttons_displayed(base_url, selenium):
     page = InstallerHelpPage(selenium, base_url).open()

--- a/tests/functional/firefox/test_ios_testflight.py
+++ b/tests/functional/firefox/test_ios_testflight.py
@@ -4,7 +4,6 @@
 
 import pytest
 
-from selenium.common.exceptions import TimeoutException
 from pages.firefox.ios_testflight import iOSTestFlightPage
 
 
@@ -22,7 +21,7 @@ def test_signup_default_values(base_url, selenium):
 
 
 @pytest.mark.nondestructive
-def test_successful_sign_up(base_url, selenium):
+def test_sign_up_success(base_url, selenium):
     page = iOSTestFlightPage(selenium, base_url).open()
     page.expand_form()
     page.type_email('success@example.com')
@@ -34,8 +33,12 @@ def test_successful_sign_up(base_url, selenium):
 
 
 @pytest.mark.nondestructive
-def test_sign_up_fails_when_missing_required_fields(base_url, selenium):
+def test_sign_up_failure(base_url, selenium):
     page = iOSTestFlightPage(selenium, base_url).open()
     page.expand_form()
-    with pytest.raises(TimeoutException):
-        page.click_sign_me_up()
+    page.type_email('invalid@email')
+    page.select_text_format()
+    page.accept_privacy_policy()
+    page.accept_terms()
+    page.click_sign_me_up(expected_result='error')
+    assert page.is_form_error_displayed

--- a/tests/functional/firefox/test_lockwise.py
+++ b/tests/functional/firefox/test_lockwise.py
@@ -14,6 +14,7 @@ def test_mobile_buttons_are_displayed(base_url, selenium):
     assert page.is_play_store_button_displayed
 
 
+@pytest.mark.smoke
 @pytest.mark.skip_if_firefox(reason='Download button is displayed only to non-Firefox users')
 @pytest.mark.nondestructive
 def test_download_button_is_displayed(base_url, selenium):

--- a/tests/functional/firefox/test_mobile.py
+++ b/tests/functional/firefox/test_mobile.py
@@ -4,13 +4,12 @@
 
 import pytest
 
-from selenium.common.exceptions import TimeoutException
 from pages.firefox.mobile import FirefoxMobilePage
 
 
-# mobile - send to device
+@pytest.mark.smoke
 @pytest.mark.nondestructive
-def test_get_firefox_send_to_device_success(base_url, selenium):
+def test_send_to_device_success(base_url, selenium):
     page = FirefoxMobilePage(selenium, base_url).open()
     assert not page.is_firefox_qr_code_displayed
     send_to_device = page.send_to_device
@@ -19,13 +18,17 @@ def test_get_firefox_send_to_device_success(base_url, selenium):
     assert send_to_device.send_successful
 
 
+@pytest.mark.smoke
 @pytest.mark.nondestructive
-def test_get_firefox_send_to_device_fails_when_missing_required_fields(base_url, selenium):
+def test_send_to_device_failure(base_url, selenium):
     page = FirefoxMobilePage(selenium, base_url).open()
-    with pytest.raises(TimeoutException):
-        page.send_to_device.click_send()
+    send_to_device = page.send_to_device
+    send_to_device.type_email('invalid@email')
+    send_to_device.click_send(expected_result='error')
+    assert send_to_device.is_form_error_displayed
 
-# mobile - qr code
+
+@pytest.mark.smoke
 @pytest.mark.nondestructive
 def test_get_firefox_qr_code(base_url, selenium):
     page = FirefoxMobilePage(selenium, base_url, locale='sv-SE').open()

--- a/tests/functional/firefox/test_mobile_get_app.py
+++ b/tests/functional/firefox/test_mobile_get_app.py
@@ -4,7 +4,6 @@
 
 import pytest
 
-from selenium.common.exceptions import TimeoutException
 from pages.firefox.mobile_get_app import FirefoxMobileGetAppPage
 
 
@@ -19,7 +18,9 @@ def test_send_to_device_success(base_url, selenium):
 
 
 @pytest.mark.nondestructive
-def test_send_to_device_fails_when_missing_required_fields(base_url, selenium):
+def test_send_to_device_failure(base_url, selenium):
     page = FirefoxMobileGetAppPage(selenium, base_url).open()
-    with pytest.raises(TimeoutException):
-        page.send_to_device.click_send()
+    send_to_device = page.send_to_device
+    send_to_device.type_email('invalid@email')
+    send_to_device.click_send(expected_result='error')
+    assert send_to_device.is_form_error_displayed

--- a/tests/functional/firefox/test_nightly.py
+++ b/tests/functional/firefox/test_nightly.py
@@ -7,6 +7,7 @@ import pytest
 from pages.firefox.nightly import FirstRunPage
 
 
+@pytest.mark.skip_if_not_firefox(reason='Firstrun page is shown to Firefox only.')
 @pytest.mark.nondestructive
 def test_first_run(base_url, selenium):
     page = FirstRunPage(selenium, base_url).open()

--- a/tests/functional/firefox/test_pocket.py
+++ b/tests/functional/firefox/test_pocket.py
@@ -7,6 +7,7 @@ import pytest
 from pages.firefox.pocket import FirefoxPocketPage
 
 
+@pytest.mark.smoke
 @pytest.mark.nondestructive
 def test_pocket_learn_more_button(base_url, selenium):
     page = FirefoxPocketPage(selenium, base_url).open()

--- a/tests/functional/firefox/test_releasenotes.py
+++ b/tests/functional/firefox/test_releasenotes.py
@@ -77,6 +77,7 @@ def test_primary_download_button_ios_displayed(base_url, selenium):
     assert page.is_primary_app_store_button_displayed
 
 
+@pytest.mark.smoke
 @pytest.mark.nondestructive
 def test_secondary_download_button_release_displayed(base_url, selenium):
     page = FirefoxReleaseNotesPage(selenium, base_url, slug='75.0').open()
@@ -107,6 +108,7 @@ def test_secondary_download_button_nightly_displayed(base_url, selenium):
     assert page.secondary_download_button_nightly.is_displayed
 
 
+@pytest.mark.smoke
 @pytest.mark.nondestructive
 def test_secondary_download_button_esr_displayed(base_url, selenium):
     page = FirefoxReleaseNotesPage(selenium, base_url, slug='68.8.0').open()
@@ -137,6 +139,7 @@ def test_secondary_download_button_ios_displayed(base_url, selenium):
     assert page.is_secondary_app_store_button_displayed
 
 
+@pytest.mark.smoke
 @pytest.mark.nondestructive
 def test_open_pre_releases_menu(base_url, selenium):
     page = FirefoxReleaseNotesPage(selenium, base_url, slug='75.0').open()

--- a/tests/functional/firefox/test_switch.py
+++ b/tests/functional/firefox/test_switch.py
@@ -7,6 +7,7 @@ import pytest
 from pages.firefox.switch import FirefoxSwitchPage
 
 
+@pytest.mark.smoke
 @pytest.mark.nondestructive
 def test_download_button_displayed(base_url, selenium):
     page = FirefoxSwitchPage(selenium, base_url).open()

--- a/tests/functional/firefox/test_unfck.py
+++ b/tests/functional/firefox/test_unfck.py
@@ -7,6 +7,7 @@ import pytest
 from pages.firefox.unfck import FirefoxUnfckPage
 
 
+@pytest.mark.smoke
 @pytest.mark.skip_if_firefox(reason='Download button is displayed only to non-Firefox users')
 @pytest.mark.nondestructive
 @pytest.mark.parametrize('locale', [

--- a/tests/functional/firefox/welcome/test_welcome_page4.py
+++ b/tests/functional/firefox/welcome/test_welcome_page4.py
@@ -4,7 +4,6 @@
 
 import pytest
 
-from selenium.common.exceptions import TimeoutException
 from pages.firefox.welcome.page4 import FirefoxWelcomePage4
 
 
@@ -18,7 +17,7 @@ def test_get_firefox_qr_code(base_url, selenium):
 
 @pytest.mark.skip_if_not_firefox(reason='Welcome pages are shown to Firefox only.')
 @pytest.mark.nondestructive
-def test_primary_get_firefox_send_to_device_success(base_url, selenium):
+def test_send_to_device_success(base_url, selenium):
     page = FirefoxWelcomePage4(selenium, base_url).open()
     assert not page.is_firefox_qr_code_displayed
     send_to_device = page.send_to_device
@@ -29,7 +28,9 @@ def test_primary_get_firefox_send_to_device_success(base_url, selenium):
 
 @pytest.mark.skip_if_not_firefox(reason='Welcome pages are shown to Firefox only.')
 @pytest.mark.nondestructive
-def test_get_firefox_send_to_device_fails_when_missing_required_fields(base_url, selenium):
+def test_send_to_device_failure(base_url, selenium):
     page = FirefoxWelcomePage4(selenium, base_url).open()
-    with pytest.raises(TimeoutException):
-        page.send_to_device.click_send()
+    send_to_device = page.send_to_device
+    send_to_device.type_email('invalid@email')
+    send_to_device.click_send(expected_result='error')
+    assert send_to_device.is_form_error_displayed

--- a/tests/functional/firefox/welcome/test_welcome_page5.py
+++ b/tests/functional/firefox/welcome/test_welcome_page5.py
@@ -4,7 +4,6 @@
 
 import pytest
 
-from selenium.common.exceptions import TimeoutException
 from pages.firefox.welcome.page5 import FirefoxWelcomePage5
 
 
@@ -29,7 +28,7 @@ def test_get_firefox_qr_code(base_url, selenium):
 
 @pytest.mark.skip_if_not_firefox(reason='Welcome pages are shown to Firefox only.')
 @pytest.mark.nondestructive
-def test_primary_get_firefox_send_to_device_success(base_url, selenium):
+def test_send_to_device_success(base_url, selenium):
     page = FirefoxWelcomePage5(selenium, base_url).open()
     modal = page.click_primary_modal_button()
     assert modal.is_displayed
@@ -43,9 +42,11 @@ def test_primary_get_firefox_send_to_device_success(base_url, selenium):
 
 @pytest.mark.skip_if_not_firefox(reason='Welcome pages are shown to Firefox only.')
 @pytest.mark.nondestructive
-def test_get_firefox_send_to_device_fails_when_missing_required_fields(base_url, selenium):
+def test_send_to_device_failure(base_url, selenium):
     page = FirefoxWelcomePage5(selenium, base_url).open()
     modal = page.click_primary_modal_button()
     assert modal.is_displayed
-    with pytest.raises(TimeoutException):
-        page.send_to_device.click_send()
+    send_to_device = page.send_to_device
+    send_to_device.type_email('invalid@email')
+    send_to_device.click_send(expected_result='error')
+    assert send_to_device.is_form_error_displayed

--- a/tests/functional/firefox/welcome/test_welcome_page6.py
+++ b/tests/functional/firefox/welcome/test_welcome_page6.py
@@ -4,7 +4,6 @@
 
 import pytest
 
-from selenium.common.exceptions import TimeoutException
 from pages.firefox.welcome.page6 import FirefoxWelcomePage6
 
 
@@ -42,9 +41,11 @@ def test_send_to_device_success(base_url, selenium):
 
 @pytest.mark.skip_if_not_firefox(reason='Welcome pages are shown to Firefox only.')
 @pytest.mark.nondestructive
-def test_send_to_device_fails_when_missing_required_fields(base_url, selenium):
+def test_send_to_device_failure(base_url, selenium):
     page = FirefoxWelcomePage6(selenium, base_url, params='?default=true').open()
     modal = page.click_modal_button()
     assert modal.is_displayed
-    with pytest.raises(TimeoutException):
-        page.send_to_device.click_send()
+    send_to_device = page.send_to_device
+    send_to_device.type_email('invalid@email')
+    send_to_device.click_send(expected_result='error')
+    assert send_to_device.is_form_error_displayed

--- a/tests/functional/firefox/whatsnew/test_whatsnew.py
+++ b/tests/functional/firefox/whatsnew/test_whatsnew.py
@@ -4,7 +4,6 @@
 
 import pytest
 
-from selenium.common.exceptions import TimeoutException
 from pages.firefox.whatsnew.whatsnew import FirefoxWhatsNewPage
 
 
@@ -21,7 +20,9 @@ def test_send_to_device_success(base_url, selenium):
 
 @pytest.mark.skip_if_not_firefox(reason='Whatsnew pages are shown to Firefox only.')
 @pytest.mark.nondestructive
-def test_send_to_device_fails_when_missing_required_fields(base_url, selenium):
+def test_send_to_device_failure(base_url, selenium):
     page = FirefoxWhatsNewPage(selenium, base_url).open()
-    with pytest.raises(TimeoutException):
-        page.send_to_device.click_send()
+    send_to_device = page.send_to_device
+    send_to_device.type_email('invalid@email')
+    send_to_device.click_send(expected_result='error')
+    assert send_to_device.is_form_error_displayed

--- a/tests/functional/firefox/whatsnew/test_whatsnew_60.py
+++ b/tests/functional/firefox/whatsnew/test_whatsnew_60.py
@@ -4,7 +4,6 @@
 
 import pytest
 
-from selenium.common.exceptions import TimeoutException
 from pages.firefox.whatsnew.whatsnew_60 import FirefoxWhatsNew60Page
 
 
@@ -28,10 +27,12 @@ def test_send_to_device_success(base_url, selenium):
 
 @pytest.mark.skip_if_not_firefox(reason='Whatsnew pages are shown to Firefox only.')
 @pytest.mark.nondestructive
-def test_send_to_device_fails_when_missing_required_fields(base_url, selenium):
+def test_send_to_device_failure(base_url, selenium):
     page = FirefoxWhatsNew60Page(selenium, base_url, params='?signed-in=true').open()
-    with pytest.raises(TimeoutException):
-        page.send_to_device.click_send()
+    send_to_device = page.send_to_device
+    send_to_device.type_email('invalid@email')
+    send_to_device.click_send(expected_result='error')
+    assert send_to_device.is_form_error_displayed
 
 
 @pytest.mark.skip_if_not_firefox(reason='Whatsnew pages are shown to Firefox only.')

--- a/tests/functional/firefox/whatsnew/test_whatsnew_80.py
+++ b/tests/functional/firefox/whatsnew/test_whatsnew_80.py
@@ -4,7 +4,6 @@
 
 import pytest
 
-from selenium.common.exceptions import TimeoutException
 from pages.firefox.whatsnew.whatsnew_80 import FirefoxWhatsNew80Page
 
 
@@ -21,10 +20,12 @@ def test_send_to_device_success(base_url, selenium):
 
 @pytest.mark.skip_if_not_firefox(reason='Whatsnew pages are shown to Firefox only.')
 @pytest.mark.nondestructive
-def test_send_to_device_fails_when_missing_required_fields(base_url, selenium):
+def test_send_to_device_failure(base_url, selenium):
     page = FirefoxWhatsNew80Page(selenium, base_url, params='').open()
-    with pytest.raises(TimeoutException):
-        page.send_to_device.click_send()
+    send_to_device = page.send_to_device
+    send_to_device.type_email('invalid@email')
+    send_to_device.click_send(expected_result='error')
+    assert send_to_device.is_form_error_displayed
 
 
 @pytest.mark.skip_if_not_firefox(reason='Whatsnew pages are shown to Firefox only.')

--- a/tests/functional/firefox/whatsnew/test_whatsnew_81.py
+++ b/tests/functional/firefox/whatsnew/test_whatsnew_81.py
@@ -4,7 +4,6 @@
 
 import pytest
 
-from selenium.common.exceptions import TimeoutException
 from pages.firefox.whatsnew.whatsnew_81 import FirefoxWhatsNew81Page
 
 
@@ -20,7 +19,9 @@ def test_send_to_device_success(base_url, selenium):
 
 @pytest.mark.skip_if_not_firefox(reason='Whatsnew pages are shown to Firefox only.')
 @pytest.mark.nondestructive
-def test_send_to_device_fails_when_missing_required_fields(base_url, selenium):
+def test_send_to_device_failure(base_url, selenium):
     page = FirefoxWhatsNew81Page(selenium, base_url, params='').open()
-    with pytest.raises(TimeoutException):
-        page.send_to_device.click_send()
+    send_to_device = page.send_to_device
+    send_to_device.type_email('invalid@email')
+    send_to_device.click_send(expected_result='error')
+    assert send_to_device.is_form_error_displayed

--- a/tests/functional/firefox/whatsnew/test_whatsnew_africa.py
+++ b/tests/functional/firefox/whatsnew/test_whatsnew_africa.py
@@ -7,7 +7,6 @@ import pytest
 from pages.firefox.whatsnew.whatsnew_africa import FirefoxWhatsNewAfricaPage
 
 
-@pytest.mark.skip(reason='https://github.com/mozilla/bedrock/issues/9189')
 @pytest.mark.skip_if_not_firefox(reason='Whatsnew pages are shown to Firefox only.')
 @pytest.mark.nondestructive
 def test_africa_qr_code_displayed(base_url, selenium):

--- a/tests/functional/firefox/whatsnew/test_whatsnew_india.py
+++ b/tests/functional/firefox/whatsnew/test_whatsnew_india.py
@@ -7,7 +7,6 @@ import pytest
 from pages.firefox.whatsnew.whatsnew_india import FirefoxWhatsNewIndiaPage
 
 
-@pytest.mark.skip(reason='https://github.com/mozilla/bedrock/issues/9189')
 @pytest.mark.skip_if_not_firefox(reason='Whatsnew pages are shown to Firefox only.')
 @pytest.mark.nondestructive
 def test_india_qr_code_displayed(base_url, selenium):

--- a/tests/functional/newsletter/test_newsletter_embed.py
+++ b/tests/functional/newsletter/test_newsletter_embed.py
@@ -3,7 +3,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import pytest
-from selenium.common.exceptions import TimeoutException
 
 from pages.home import HomePage
 from pages.about import AboutPage
@@ -15,6 +14,7 @@ from pages.newsletter.firefox import FirefoxNewsletterPage
 from pages.newsletter.mozilla import MozillaNewsletterPage
 
 
+@pytest.mark.smoke
 @pytest.mark.nondestructive
 @pytest.mark.parametrize('page_class', [
     HomePage,
@@ -33,6 +33,7 @@ def test_newsletter_default_values(page_class, base_url, selenium):
     assert page.newsletter.is_privacy_policy_link_displayed
 
 
+@pytest.mark.smoke
 @pytest.mark.nondestructive
 @pytest.mark.parametrize('page_class', [
     HomePage,
@@ -43,7 +44,7 @@ def test_newsletter_default_values(page_class, base_url, selenium):
     DeveloperNewsletterPage,
     FirefoxNewsletterPage,
     MozillaNewsletterPage])
-def test_newsletter_successful_sign_up(page_class, base_url, selenium):
+def test_newsletter_sign_up_success(page_class, base_url, selenium):
     page = page_class(selenium, base_url).open()
     page.newsletter.expand_form()
     page.newsletter.type_email('success@example.com')
@@ -54,6 +55,7 @@ def test_newsletter_successful_sign_up(page_class, base_url, selenium):
     assert page.newsletter.sign_up_successful
 
 
+@pytest.mark.smoke
 @pytest.mark.nondestructive
 @pytest.mark.parametrize('page_class', [
     HomePage,
@@ -64,8 +66,12 @@ def test_newsletter_successful_sign_up(page_class, base_url, selenium):
     DeveloperNewsletterPage,
     FirefoxNewsletterPage,
     MozillaNewsletterPage])
-def test_newsletter_sign_up_fails_when_missing_required_fields(page_class, base_url, selenium):
+def test_newsletter_sign_up_failure(page_class, base_url, selenium):
     page = page_class(selenium, base_url).open()
     page.newsletter.expand_form()
-    with pytest.raises(TimeoutException):
-        page.newsletter.click_sign_me_up()
+    page.newsletter.type_email('invalid@email')
+    page.newsletter.select_country('United Kingdom')
+    page.newsletter.select_text_format()
+    page.newsletter.accept_privacy_policy()
+    page.newsletter.click_sign_me_up(expected_result='error')
+    assert page.newsletter.is_form_error_displayed

--- a/tests/functional/test_contact.py
+++ b/tests/functional/test_contact.py
@@ -21,15 +21,8 @@ def test_tab_navigation(base_url, selenium):
 
 @pytest.mark.nondestructive
 @pytest.mark.parametrize('slug', [
-    ('mountain-view'),
-    ('beijing'),
-    ('berlin'),
-    ('london'),
-    ('paris'),
     ('portland'),
     ('san-francisco'),
-    ('taipei'),
-    ('toronto'),
     ('vancouver')])
 def test_spaces_menus(slug, base_url, selenium):
     page = SpacesPage(selenium, base_url, slug=slug).open()

--- a/tests/functional/test_home.py
+++ b/tests/functional/test_home.py
@@ -15,6 +15,7 @@ def test_privacy_hero_button_is_displayed(base_url, selenium):
 
 @pytest.mark.skip_if_firefox(reason='Download button is displayed only to non-Firefox users')
 @pytest.mark.sanity
+@pytest.mark.smoke
 @pytest.mark.nondestructive
 def test_download_button_is_displayed(base_url, selenium):
     page = HomePage(selenium, base_url, locale='en-US').open()
@@ -23,6 +24,7 @@ def test_download_button_is_displayed(base_url, selenium):
 
 @pytest.mark.skip_if_firefox(reason='Download button is displayed only to non-Firefox users')
 @pytest.mark.sanity
+@pytest.mark.smoke
 @pytest.mark.nondestructive
 @pytest.mark.parametrize('locale', ['de', 'fr'])
 def test_download_button_is_displayed_rest_tier_1(locale, base_url, selenium):
@@ -52,6 +54,7 @@ def test_accounts_button_is_displayed_rest_tier_1(locale, base_url, selenium):
 
 
 @pytest.mark.sanity
+@pytest.mark.smoke
 @pytest.mark.nondestructive
 def test_download_button_is_displayed_locales(base_url, selenium):
     page = HomePage(selenium, base_url, locale='es-ES').open()

--- a/tests/functional/test_lean_data.py
+++ b/tests/functional/test_lean_data.py
@@ -9,10 +9,7 @@ from pages.lean_data import LeanDataPage
 
 @pytest.mark.nondestructive
 @pytest.mark.parametrize('slug', [
-    ('/'),
-    ('/stay-lean/'),
-    ('/build-security/'),
-    ('/engage-users/')])
+    ('/')])
 def test_contact_button_is_displayed(slug, base_url, selenium):
     page = LeanDataPage(selenium, base_url, slug=slug).open()
     assert page.is_contact_button_displayed

--- a/tests/functional/test_navigation.py
+++ b/tests/functional/test_navigation.py
@@ -7,6 +7,7 @@ import pytest
 from pages.home import HomePage
 
 
+@pytest.mark.smoke
 @pytest.mark.nondestructive
 def test_navigation(base_url, selenium):
     page = HomePage(selenium, base_url).open()
@@ -22,6 +23,7 @@ def test_navigation(base_url, selenium):
     assert about_page.seed_url in selenium.current_url
 
 
+@pytest.mark.smoke
 @pytest.mark.nondestructive
 def test_mobile_navigation(base_url, selenium_mobile):
     page = HomePage(selenium_mobile, base_url).open()
@@ -40,6 +42,7 @@ def test_mobile_navigation(base_url, selenium_mobile):
     assert about_page.seed_url in selenium_mobile.current_url
 
 
+@pytest.mark.smoke
 @pytest.mark.nondestructive
 @pytest.mark.skip_if_firefox(reason='Firefox download button is shown only to non-Firefox users.')
 def test_navigation_download_firefox_button(base_url, selenium):

--- a/tests/pages/firefox/ios_testflight.py
+++ b/tests/pages/firefox/ios_testflight.py
@@ -22,6 +22,11 @@ class iOSTestFlightPage(BasePage):
     _text_format_locator = (By.ID, 'format-text')
     _thank_you_locator = (By.ID, 'newsletter-thanks')
     _form_details_locator = (By.ID, 'newsletter-details')
+    _error_list_locator = (By.ID, 'newsletter-errors')
+
+    @property
+    def is_form_error_displayed(self):
+        return self.is_element_displayed(*self._error_list_locator)
 
     @property
     def email(self):
@@ -69,9 +74,12 @@ class iOSTestFlightPage(BasePage):
         el.click()
         assert el.is_selected(), 'Terms have not been accepted'
 
-    def click_sign_me_up(self):
+    def click_sign_me_up(self, expected_result=None):
         self.find_element(*self._submit_button_locator).click()
-        self.wait.until(expected.visibility_of_element_located(self._thank_you_locator))
+        if expected_result == 'error':
+            self.wait.until(expected.visibility_of_element_located(self._error_list_locator))
+        else:
+            self.wait.until(expected.visibility_of_element_located(self._thank_you_locator))
 
     def select_text_format(self):
         self.find_element(*self._text_format_locator).click()

--- a/tests/pages/regions/newsletter.py
+++ b/tests/pages/regions/newsletter.py
@@ -20,6 +20,7 @@ class NewsletterEmbedForm(Region):
     _privacy_policy_link_locator = (By.CSS_SELECTOR, 'label[for="privacy"] a')
     _submit_button_locator = (By.ID, 'newsletter-submit')
     _thank_you_locator = (By.CSS_SELECTOR, '#newsletter-thanks h3')
+    _error_list_locator = (By.ID, 'newsletter-errors')
 
     def expand_form(self):
         # scroll newsletter into view before expanding the form
@@ -36,6 +37,10 @@ class NewsletterEmbedForm(Region):
     @property
     def is_form_detail_displayed(self):
         return self.is_element_displayed(*self._form_details_locator)
+
+    @property
+    def is_form_error_displayed(self):
+        return self.is_element_displayed(*self._error_list_locator)
 
     @property
     def email(self):
@@ -85,9 +90,12 @@ class NewsletterEmbedForm(Region):
     def is_privacy_policy_link_displayed(self):
         return self.is_element_displayed(*self._privacy_policy_link_locator)
 
-    def click_sign_me_up(self):
+    def click_sign_me_up(self, expected_result=None):
         self.find_element(*self._submit_button_locator).click()
-        self.wait.until(expected.visibility_of_element_located(self._thank_you_locator))
+        if expected_result == 'error':
+            self.wait.until(expected.visibility_of_element_located(self._error_list_locator))
+        else:
+            self.wait.until(expected.visibility_of_element_located(self._thank_you_locator))
 
     @property
     def sign_up_successful(self):

--- a/tests/pages/regions/send_to_device.py
+++ b/tests/pages/regions/send_to_device.py
@@ -14,13 +14,21 @@ class SendToDevice(BaseRegion):
     _email_locator = (By.CSS_SELECTOR, '.send-to-device-input')
     _submit_button_locator = (By.CSS_SELECTOR, '.send-to-device .mzp-c-button')
     _thank_you_locator = (By.CSS_SELECTOR, '.thank-you')
+    _error_list_locator = (By.CLASS_NAME, 'mzp-c-form-errors')
+
+    @property
+    def is_form_error_displayed(self):
+        return self.is_element_displayed(*self._error_list_locator)
 
     def type_email(self, value):
         self.find_element(*self._email_locator).send_keys(value)
 
-    def click_send(self):
+    def click_send(self, expected_result=None):
         self.scroll_element_into_view(*self._submit_button_locator).click()
-        self.wait.until(expected.visibility_of_element_located(self._thank_you_locator))
+        if expected_result == 'error':
+            self.wait.until(expected.visibility_of_element_located(self._error_list_locator))
+        else:
+            self.wait.until(expected.visibility_of_element_located(self._thank_you_locator))
 
     @property
     def send_successful(self):


### PR DESCRIPTION
## Description
- Add a new `smoke` marker so we won't have to run the entire suite of tests in IE.
- Speed up tests that previously relied on an expected timeout to pass.
- Remove a small number of tests that weren't adding much value.
- Update docs.

## Issue / Bugzilla link
#9444

## Testing
https://gitlab.com/mozmeao/www-config/-/pipelines/201832091