### PR TITLE
[WIP] Add scroll margin to release note items

### DIFF
--- a/media/css/firefox/releasenotes.scss
+++ b/media/css/firefox/releasenotes.scss
@@ -234,6 +234,7 @@ $image-path: '/media/protocol/img';
         border-bottom: 2px solid $color-marketing-gray-20;
         margin-bottom: $layout-sm;
         padding-bottom: $layout-sm;
+        scroll-margin-top: 88px;
 
         &:last-child {
             border-bottom: none;


### PR DESCRIPTION
## Description

Adds scroll-margin-top to release notes' list items to avoid sticky header from overlaying an item when using fragments (e.g. https://www.mozilla.org/en-US/firefox/83.0a1/releasenotes/#note-788467). This probably shouldn't have a hard-coded value, but I didn't manage to understand which SASS variables to use. 

## Issue / Bugzilla link

## Testing
