### PR TITLE
Fix #9558 - Revise Pocket hero text on the EN homepage

### DIFF
--- a/bedrock/mozorg/templates/mozorg/home/home-en.html
+++ b/bedrock/mozorg/templates/mozorg/home/home-en.html
@@ -91,7 +91,7 @@
   <div class="mzp-t-mozilla">
       {% call hero(
         title='Welcome to the web, sunny side up',
-        desc='Over 10 million people rely on Pocket to discover the best articles, stories and videos on the web. As part of the Firefox family, privacy is paramount.',
+        desc='Millions of people rely on Pocket to save and discover the best articles, stories and videos on the web. As part of the Firefox family, Pocket has the same dedication to privacy.',
         class='pocket-sunny-hero mzp-has-image mzp-t-mozilla mzp-l-reverse mzp-t-product-firefox',
         image_url='img/home/2020/pocket-hero.jpg',
         include_highres_image=True,

--- a/bedrock/mozorg/templates/mozorg/home/home-en.html
+++ b/bedrock/mozorg/templates/mozorg/home/home-en.html
@@ -90,7 +90,7 @@
   </div>
   <div class="mzp-t-mozilla">
       {% call hero(
-        title='Welcome to the sunny side of the web.',
+        title='Welcome to the web, sunny side up',
         desc='Over 10 million people rely on Pocket to discover the best articles, stories and videos on the web. As part of the Firefox family, privacy is paramount.',
         class='pocket-sunny-hero mzp-has-image mzp-t-mozilla mzp-l-reverse mzp-t-product-firefox',
         image_url='img/home/2020/pocket-hero.jpg',


### PR DESCRIPTION
## Description

Revise Pocket hero title text and copy on the EN homepage. 

## Issue / Bugzilla link

#9558

## Testing

Local: http://localhost:8000/en-US/
Live Demo: https://www-demo-pr-9559.herokuapp.com

## Preview screenshot

<img width="1530" alt="image" src="https://user-images.githubusercontent.com/2692333/96311042-357d0f00-0fce-11eb-9e22-6cd9eeced6f1.png">

