### PR TITLE
Add vanity redirect for openletter [fix #9560]

### DIFF
--- a/bedrock/mozorg/redirects.py
+++ b/bedrock/mozorg/redirects.py
@@ -728,4 +728,10 @@ redirectpatterns = (
 
     redirect(r'^about/governance/policies/security/plugin-whitelist-policy/?$', 'https://wiki.mozilla.org/Plugins/Firefox_Whitelist'),
     redirect(r'^about/governance/policies/security-group/tld-idn/?$', 'https://wiki.mozilla.org/IDN_Display_Algorithm'),
+
+    # Issue 9560
+    redirect(r'^openletter/?$', 'https://foundation.mozilla.org/blog/mozilla-urges-facebook-and-twitter-halt-dangerous-recommendations/', query={
+        'utm_source': 'mozilla.org',
+        'utm_content': 'shortlink',
+    }),
 )

--- a/tests/redirects/map_globalconf.py
+++ b/tests/redirects/map_globalconf.py
@@ -1373,4 +1373,7 @@ URLS = flatten((
 
     # issue 9148
     url_test('/firefox/campaign/', '/firefox/new/'),
+
+    # Issue 9560
+    url_test('/openletter/', 'https://foundation.mozilla.org/blog/mozilla-urges-facebook-and-twitter-halt-dangerous-recommendations/?utm_source=mozilla.org&utm_content=shortlink'),
 ))

--- a/tests/redirects/map_globalconf.py
+++ b/tests/redirects/map_globalconf.py
@@ -1375,5 +1375,8 @@ URLS = flatten((
     url_test('/firefox/campaign/', '/firefox/new/'),
 
     # Issue 9560
-    url_test('/openletter/', 'https://foundation.mozilla.org/blog/mozilla-urges-facebook-and-twitter-halt-dangerous-recommendations/?utm_source=mozilla.org&utm_content=shortlink'),
+    url_test('/openletter/', 'https://foundation.mozilla.org/blog/mozilla-urges-facebook-and-twitter-halt-dangerous-recommendations/', query={
+    	'utm_source': 'mozilla.org',
+    	'utm_content': 'shortlink',
+    }),
 ))

--- a/tests/redirects/map_globalconf.py
+++ b/tests/redirects/map_globalconf.py
@@ -1376,7 +1376,7 @@ URLS = flatten((
 
     # Issue 9560
     url_test('/openletter/', 'https://foundation.mozilla.org/blog/mozilla-urges-facebook-and-twitter-halt-dangerous-recommendations/', query={
-    	'utm_source': 'mozilla.org',
-    	'utm_content': 'shortlink',
+        'utm_source': 'mozilla.org',
+        'utm_content': 'shortlink',
     }),
 ))


### PR DESCRIPTION
## Description
Adds a redirect for /openletter to a blog post (currently password protected) at foundation.mozilla.org.

**This needs to be live early on Monday, 19 October.**

## Issue / Bugzilla link
#9560 

## Testing
http://localhost:8000/openletter

Should redirect to `https://foundation.mozilla.org/blog/mozilla-urges-facebook-and-twitter-halt-dangerous-recommendations/?utm_source=mozilla.org&utm_content=shortlink`