### PR TITLE
Add sendKeys capability for BrowserStack sessions

### DIFF
--- a/bin/run-integration-tests.sh
+++ b/bin/run-integration-tests.sh
@@ -35,7 +35,7 @@ if [ "${DRIVER}" = "Remote" ]; then
 fi
 
 # Sauce Labs / Browser Stack arguments
-if [ "${DRIVER}" = "SauceLabs" ] || [ "${DRIVER}" = "BrowserStack" ]; then
+if [ "${DRIVER}" = "SauceLabs" ] || [ "${DRIVER}" = "BrowserStack" ] || [ "${DRIVER}" = "CrossBrowserTesting" ]; then
   CMD="${CMD} --capability browserName \"${BROWSER_NAME}\""
   if [ -n "${BROWSER_VERSION}" ]; then CMD="${CMD} --capability version \"${BROWSER_VERSION}\""; fi
   if [ -n "${PLATFORM}" ]; then CMD="${CMD} --capability platform \"${PLATFORM}\""; fi

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -28,8 +28,14 @@ def session_capabilities(pytestconfig, session_capabilities):
     if pytestconfig.getoption('driver') == 'SauceLabs':
         session_capabilities.setdefault('tags', []).append('bedrock')
 
-        # Avoid default SauceLabs proxy for IE8.
+        # Avoid default SauceLabs proxy for IE.
         session_capabilities['avoidProxy'] = True
+
+    if pytestconfig.getoption('driver') == 'BrowserStack':
+        session_capabilities.setdefault('tags', []).append('bedrock')
+
+        # https://www.browserstack.com/docs/automate/selenium/using-sendkeys-on-remote-IE11
+        session_capabilities['browserstack.sendKeys'] = True
 
     return session_capabilities
 


### PR DESCRIPTION
## Description
This should hopefully fix an issue we're seeing in BrowserStack where IE browsers sometimes don't enter form input text correctly.

## Issue / Bugzilla link
https://www.browserstack.com/docs/automate/selenium/using-sendkeys-on-remote-IE11