### PR TITLE
Add firefox/faq (#9490, Fixes #9491, #9498)

### DIFF
--- a/bedrock/firefox/redirects.py
+++ b/bedrock/firefox/redirects.py
@@ -572,8 +572,8 @@ redirectpatterns = (
     redirect(r'^firefox/focus/?$', 'firefox.mobile.index'),
     redirect(r'^firefox/ios/?$', 'firefox.mobile.index'),
 
-    # bug 1416708
-    redirect(r'^firefox/quantum/?', 'firefox'),
+    # issue 9502
+    redirect(r'^firefox/quantum/?', '/firefox/browsers/quantum/'),
 
     # bug 1421584, issue 7491
     redirect(r'^firefox/organizations/faq/?$', 'firefox.enterprise.index'),

--- a/bedrock/firefox/templates/firefox/faq.html
+++ b/bedrock/firefox/templates/firefox/faq.html
@@ -102,4 +102,5 @@
   </section>
 </div>
 
+{% include '/firefox/includes/structured-data-firefox-faq.html' %}
 {% endblock %}

--- a/bedrock/firefox/templates/firefox/faq.html
+++ b/bedrock/firefox/templates/firefox/faq.html
@@ -1,0 +1,105 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+  # License, v. 2.0. If a copy of the MPL was not distributed with this
+  # file, You can obtain one at http://mozilla.org/MPL/2.0/. #}
+
+{% extends "firefox/base/base-protocol.html" %}
+
+{% from "macros-protocol.html" import hero with context %}
+
+{% block page_title %}{{ ftl('page-title') }}{% endblock %}
+{% block page_desc %}{{ ftl('whether-you-searched-privacy') }}{% endblock %}
+
+{% block page_css %}
+  {{ css_bundle('firefox-faq') }}
+{% endblock %}
+
+{% block content %}
+<div class="mzp-l-content">
+
+  {% call hero(
+    title=ftl('firefox-faq'),
+    class='mzp-has-image mzp-t-firefox mzp-t-product-firefox',
+    image_url='img/firefox/browsers/quantum/browser.jpg',
+    include_highres_image=True,
+    include_cta=True,
+    heading_level=1
+  ) %}
+
+  <p>{{ ftl('whether-you-searched-independant') }}</p>
+  {{ download_firefox_thanks() }}
+
+  {% endcall %}
+
+  <section class="mzp-l-content mzp-t-content-md">
+    <ul>
+      <li>
+        <h2>{{ ftl('what-is-firefox') }}</h2>
+        <p>{{ ftl('the-firefox-browser',
+              url=url('firefox.browsers.index'),
+              url2=url('firefox.products.index')) }}</p>
+      </li>
+      <li>
+        <h2>{{ ftl('how-do-i') }}</h2>
+        <p>{{ ftl('you-can-easily',
+              url=url('firefox.new'),
+              url2=url('firefox.new.protocol.download_windows'),
+              url3=url('firefox.new.protocol.download_mac'),
+              url4=url('firefox.new.protocol.download_linux'),
+              url5=url('firefox.mobile.index')
+              )}}</p>
+      </li>
+      <li>
+        <h2>{{ ftl('is-firefox-free') }}</h2>
+        <p>{{ ftl('yep-the-firefox') }}</p>
+        <small>{{ ftl('related-questions-free') }}</small>
+      </li>
+      <li>
+        <h2>{{ ftl('is-chrome-better') }}</h2>
+        <p>{{ ftl('no-we-dont') }}</p>
+        {{ ftl('see-how-firefox', url=url('firefox.browsers.compare.chrome')) }}
+        <small>{{ ftl('related-questions-better') }}</small>
+      </li>
+      <li>
+        <h2>{{ ftl('is-firefox-safe-download') }}</h2>
+        <p>{{ ftl('protecting-your-privacy', url=url('firefox.new')) }}</p>
+      </li>
+      <li>
+        <h2>{{ ftl('is-firefox-safe') }}</h2>
+        <p>{{ ftl('not-only-is', url=url('firefox.privacy.products')) }}</p>
+        <small>{{ ftl('related-questions-safe') }}</small>
+      </li>
+      <li>
+        <h2>{{ ftl('does-firefox-sell') }}</h2>
+        <p>{{ ftl('nope-never-have', url=url('firefox.privacy.index')) }}</p>
+      </li>
+      <li>
+        <h2>{{ ftl('why-is-firefox') }}</h2>
+        <p>{{ ftl('firefox-isnt-slow') }}</p>
+      </li>
+      <li>
+        <h2>{{ ftl('is-firefox-chromium') }}</h2>
+        <p>{{ ftl('firefox-is-not') }}</p>
+      </li>
+      <li>
+        <h2>{{ ftl('does-firefox-use') }}</h2>
+        <p>{{ ftl('firefoxs-default-search',
+              url='https://support.mozilla.org/kb/change-your-default-search-settings-firefox/?utm_source=www.mozilla.org-firefox-faq&amp;utm_medium=referral&amp;utm_campaign=seo') }}</p>
+      </li>
+      <li>
+        <h2>{{ ftl('does-firefox-have') }}</h2>
+        <p>{{ ftl('firefox-does-not',
+              url='https://fpn.firefox.com/?utm_source=www.mozilla.org-firefox-faq&amp;utm_medium=referral&amp;utm_campaign=seo',
+              url2='https://vpn.mozilla.org/?utm_source=www.mozilla.org-firefox-faq&amp;utm_medium=referral&amp;utm_campaign=seo') }}</p>
+        <small>{{ ftl('related-questions-ip') }}</small>
+      </li>
+      <li>
+        <h2>{{ ftl('who-owns-firefox') }}</h2>
+        <p>{{ ftl('firefox-is-made', url='https://foundation.mozilla.org/?utm_source=www.mozilla.org-firefox-faq&amp;utm_medium=referral&amp;utm_campaign=seo', url2=url('foundation.moco')) }}</p>
+        <small>{{ ftl('related-questions-who') }}</small>
+      </li>
+    </ul>
+    {{ download_firefox_thanks() }}
+  </section>
+</div>
+
+{% endblock %}

--- a/bedrock/firefox/templates/firefox/faq.html
+++ b/bedrock/firefox/templates/firefox/faq.html
@@ -31,7 +31,7 @@
   {% endcall %}
 
   <section class="mzp-l-content mzp-t-content-md">
-    <ul>
+    <ul class="faq-list">
       <li>
         <h2>{{ ftl('what-is-firefox') }}</h2>
         <p>{{ ftl('the-firefox-browser',
@@ -56,7 +56,7 @@
       <li>
         <h2>{{ ftl('is-chrome-better') }}</h2>
         <p>{{ ftl('no-we-dont') }}</p>
-        {{ ftl('see-how-firefox', url=url('firefox.browsers.compare.chrome')) }}
+        <p>{{ ftl('see-how-firefox', url=url('firefox.browsers.compare.chrome')) }}</p>
         <small>{{ ftl('related-questions-better') }}</small>
       </li>
       <li>

--- a/bedrock/firefox/templates/firefox/includes/structured-data-firefox-faq.html
+++ b/bedrock/firefox/templates/firefox/includes/structured-data-firefox-faq.html
@@ -1,0 +1,108 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+
+<script type="application/ld+json">
+  {
+        "@context": "https://schema.org",
+        "@type": "FAQPage",
+        "mainEntity": [
+            {
+                "@type": "Question",
+                "name": "What is Firefox?",
+                "acceptedAnswer": {
+                    "@type": "Answer",
+                    "text": "The Firefox browser is the only major browser backed by a non-profit that doesn’t sell your personal data to advertisers, while helping you protect your personal information. Learn more about the Firefox browsers and other products."
+                }
+            },
+            {
+                "@type": "Question",
+                "name": "How do I get the Firefox Browser?",
+                "acceptedAnswer": {
+                    "@type": "Answer",
+                    "text": "You can easily download the Firefox desktop browser here. Firefox works on Windows, Mac and Linux devices, and is also available for Android and iOS. Make sure you’re downloading our browser from one of our trusted Mozilla/Firefox pages."
+                }
+            },
+            {
+                "@type": "Question",
+                "name": "Is Firefox free?",
+                "acceptedAnswer": {
+                    "@type": "Answer",
+                    "text": "Yep! The Firefox browser is free. Super free, actually. No hidden costs or anything. You don’t pay anything to use it, and we don’t sell your personal data.\n"
+                }
+            },
+            {
+                "@type": "Question",
+                "name": "Is Chrome better than Firefox?",
+                "acceptedAnswer": {
+                    "@type": "Answer",
+                    "text": "No, we don’t think Chrome is better than Firefox, and here is why: when people ask which browser is better, they’re really asking which browser is faster and safer. Firefox is updated monthly to make sure you have the speediest browser that respects your privacy automatically. "
+                }
+            },
+            {
+                "@type": "Question",
+                "name": "Is Firefox safe to download?",
+                "acceptedAnswer": {
+                    "@type": "Answer",
+                    "text": "Protecting your privacy is our number one priority, and we ensure that installing Firefox on your devices is completely safe — but always make sure you are downloading from a trusted Mozilla/Firefox site, like our download page."
+                }
+            },
+            {
+                "@type": "Question",
+                "name": "Is Firefox safe?",
+                "acceptedAnswer": {
+                    "@type": "Answer",
+                    "text": "Not only is Firefox safe to use, it also helps keep your data and private information safe. The Firefox browser automatically blocks known third party trackers, social media trackers, cryptominers and fingerprinters from collecting your data. Learn more about the privacy in our products."
+                }
+            },
+            {
+                "@type": "Question",
+                "name": "Does Firefox sell your personal data?",
+                "acceptedAnswer": {
+                    "@type": "Answer",
+                    "text": "Nope. Never have, never will. And we protect you from many of the advertisers who do. Firefox products are designed to protect your privacy. That’s a promise. "
+                }
+            },
+            {
+                "@type": "Question",
+                "name": "Why is Firefox so slow?",
+                "acceptedAnswer": {
+                    "@type": "Answer",
+                    "text": "Firefox isn’t slow… now. In 2017, we completely rebuilt our browser engine (called Quantum), to ensure Firefox could compete with other major browsers. And, our tracker blockers help pages load even faster. So Firefox is lightning fast without sacrificing any of your privacy."
+                }
+            },
+            {
+                "@type": "Question",
+                "name": "Is Firefox Chromium based?",
+                "acceptedAnswer": {
+                    "@type": "Answer",
+                    "text": "Firefox is not based on Chromium (the open source browser project at the core of Google Chrome). In fact, we’re one of the last major browsers that isn’t. Firefox runs on our Quantum browser engine built specifically for Firefox, so we can ensure your data is handled respectfully and kept private."
+                }
+            },
+            {
+                "@type": "Question",
+                "name": "Does Firefox use Google?",
+                "acceptedAnswer": {
+                    "@type": "Answer",
+                    "text": "Firefox’s default search engine is Google, which means you can search the web directly from the address bar. Learn more about search engine preferences and changing defaults.\n"
+                }
+            },
+            {
+                "@type": "Question",
+                "name": "Does Firefox have a built-in VPN?",
+                "acceptedAnswer": {
+                    "@type": "Answer",
+                    "text": "Firefox does not have a built-in VPN (virtual private network), but there are two products made by Mozilla/Firefox that you can use in addition to the private Firefox browser that can protect either your browser (Firefox Private Network) or device (Mozilla VPN) connections on WiFi, as well as your IP address.\n"
+                }
+            },
+            {
+                "@type": "Question",
+                "name": "Who owns Firefox?",
+                "acceptedAnswer": {
+                    "@type": "Answer",
+                    "text": "Firefox is made by Mozilla Corporation, a wholly owned subsidiary of the non-profit Mozilla Foundation, and is guided by the principles of the Mozilla Manifesto. Learn more about the maker of Firefox here.\n"
+                }
+            }
+        ]
+    }
+</script>

--- a/bedrock/firefox/urls.py
+++ b/bedrock/firefox/urls.py
@@ -177,4 +177,5 @@ urlpatterns = (
     # Issue #9490 - Evergreen Content for SEO
     page('firefox/more', 'firefox/more.html', ftl_files='firefox/more'),
     page('firefox/browsers/quantum', 'firefox/browsers/quantum.html', ftl_files='firefox/browsers/quantum'),
+    page('firefox/faq', 'firefox/faq.html', ftl_files='firefox/faq'),
 )

--- a/l10n/en/brands.ftl
+++ b/l10n/en/brands.ftl
@@ -64,6 +64,7 @@
 -brand-name-firefox-monitor = Firefox Monitor
 -brand-name-firefox-send = Firefox Send
 -brand-name-firefox-sync = Firefox Sync
+-brand-name-firefox-private-network = Firefox Private Network
 
 ## Firefox products (short names)
 

--- a/l10n/en/firefox/browsers/quantum.ftl
+++ b/l10n/en/firefox/browsers/quantum.ftl
@@ -5,10 +5,10 @@
 ### URL: https://www-dev.allizom.org/firefox/browsers/quantum/
 
 page-title= Download { -brand-name-firefox-quantum }
-page-description= { -brand-name-firefox-quantum } was a revolution. In 2017 we created a new, lightning fast browser that constantly improves. { -brand-name-firefox-quantum } is the { -brand-name-firefox-browser }.
+page-description= { -brand-name-firefox-quantum } was a revolution. In 2017, we created a new, lightning fast browser that constantly improves. { -brand-name-firefox-quantum } is the { -brand-name-firefox-browser }.
 
 the-latest-firefox = The latest { -brand-name-firefox } engine: { -brand-name-firefox-quantum }
-firefox-quantum-was = { -brand-name-firefox-quantum } was a revolution in { -brand-name-firefox } development. In 2017 we created a new, lightning fast browser that constantly improves. { -brand-name-firefox-quantum } is the { -brand-name-firefox-browser }.
+firefox-quantum-was = { -brand-name-firefox-quantum } was a revolution in { -brand-name-firefox } development. In 2017, we created a new, lightning fast browser that constantly improves. { -brand-name-firefox-quantum } is the { -brand-name-firefox-browser }.
 
 # https://blog.mozilla.org/blog/2017/11/14/introducing-firefox-quantum/
 learn-more-about = Learn more about { -brand-name-firefox-quantum }

--- a/l10n/en/firefox/faq.ftl
+++ b/l10n/en/firefox/faq.ftl
@@ -1,0 +1,99 @@
+# This Source Code Form is subject to the terms of the { -brand-name-mozilla } Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+### URL: https://www-dev.allizom.org/firefox/faq/
+
+# HTML page title
+page-title = There is a way to protect your privacy. Join { -brand-name-firefox }.
+
+firefox-faq = { -brand-name-firefox } FAQ
+whether-you-searched-privacy = Whether you searched for a fast browser that protects your privacy, this FAQ is here to answer the most pressing { -brand-name-firefox }-related questions.
+whether-you-searched-independant = Whether you searched for a fast browser, or you’re looking for independent tech that protects your privacy, this FAQ is here to answer the most pressing { -brand-name-firefox }-related questions.
+
+what-is-firefox = What is { -brand-name-firefox }?
+
+# Variables:
+# $url (url) - link to https://www.mozilla.org/firefox/browsers/
+# $url2 (url) - link to https://www.mozilla.org/firefox/products/
+
+the-firefox-browser = The { -brand-name-firefox-browser } is the only major browser backed by a non-profit that doesn’t sell your personal data to advertisers, while helping you protect your personal information. Learn more about the <a href="{ $url }">{ -brand-name-firefox-browsers }</a> and <a href="{ $url2 }">other products</a>.
+
+how-do-i = How do I get the { -brand-name-firefox-browser }?
+
+# Variables:
+# $url (url) - link to https://www.mozilla.org/firefox/new/
+# $url2 (url) - link to https://www.mozilla.org/firefox/windows/
+# $url3 (url) - link to https://www.mozilla.org/firefox/mac/
+# $url4 (url) - link to https://www.mozilla.org/firefox/linux/
+# $url5 (url) - link to https://www.mozilla.org/firefox/mobile/
+
+you-can-easily = You can easily download the { -brand-name-firefox } desktop browser <a href="{ $url }">here</a>. { -brand-name-firefox } works on <a href="{ $url2 }">{ -brand-name-windows }</a>, <a href="{ $url3 }">{ -brand-name-mac-short }</a> and <a href="{ $url4 }">{ -brand-name-linux}</a> devices, and is also available for <a href="{ $url5 }">{ -brand-name-android } and { -brand-name-ios }</a>. Make sure you’re downloading our browser from one of our trusted { -brand-name-mozilla }/{ -brand-name-firefox } pages.
+
+is-firefox-free = Is { -brand-name-firefox } free?
+yep-the-firefox = Yep! The { -brand-name-firefox-browser } is free. Super free, actually. No hidden costs or anything. You don’t pay anything to use it, and we don’t sell your personal data.
+related-questions-free = Related questions: is { -brand-name-firefox-browser } free, does { -brand-name-firefox } cost money
+
+is-chrome-better = Is { -brand-name-chrome } better than { -brand-name-firefox }?
+no-we-dont = No, we don’t think { -brand-name-chrome } is better than { -brand-name-firefox }, and here is why: when people ask which browser is better, they’re really asking which browser is faster and safer. { -brand-name-firefox } is updated monthly to make sure you have the speediest browser that respects your privacy automatically.
+
+# Variables:
+# $url (url) - link to https://www.mozilla.org/firefox/browsers/compare/chrome/
+
+see-how-firefox = <a href="{ $url }">See how { -brand-name-firefox } compares { -brand-name-chrome }.</a>
+
+related-questions-better = Related questions: is { -brand-name-firefox } better than { -brand-name-chrome }, is { -brand-name-firefox } better than { -brand-name-google }, is { -brand-name-firefox } safer than { -brand-name-chrome }, is { -brand-name-firefox } more private than { -brand-name-chrome }
+is-firefox-safe-download = Is { -brand-name-firefox } safe to download?
+
+# Variables:
+# $url (url) - link to https://www.mozilla.org/firefox/new/
+
+protecting-your-privacy = Protecting your privacy is our number one priority, and we ensure that installing { -brand-name-firefox } on your devices is completely safe — but always make sure you are downloading from a trusted { -brand-name-mozilla }/{ -brand-name-firefox } site, like <a href="{ $url }">our download page</a>.
+
+is-firefox-safe = Is { -brand-name-firefox } safe?
+
+# Variables:
+# $url (url) - link to https://www.mozilla.org/firefox/privacy/products/
+
+not-only-is = Not only is { -brand-name-firefox } safe to use, it also helps keep your data and private information safe. The { -brand-name-firefox-browser } automatically blocks known third party trackers, social media trackers, cryptominers and fingerprinters from collecting your data. <a href="{ $url }">Learn more about the privacy in our products</a>.
+
+related-questions-safe = Related questions: is { -brand-name-firefox } good for privacy, is { -brand-name-firefox } secure, Is { -brand-name-firefox } better for privacy
+does-firefox-sell = Does { -brand-name-firefox } sell your personal data?
+
+# Variables:
+# $url (url) - link to https://www.mozilla.org/firefox/privacy/
+
+nope-never-have = Nope. Never have, never will. And we protect you from many of the advertisers who do. { -brand-name-firefox } products are designed to protect your privacy. <a href="{ $url }">That’s a promise.</a>
+
+why-is-firefox = Why is { -brand-name-firefox } so slow?
+firefox-isnt-slow = { -brand-name-firefox } isn’t slow… now. In 2017, we completely rebuilt our browser engine (called Quantum), to ensure { -brand-name-firefox } could compete with other major browsers. And, our tracker blockers help pages load even faster. So { -brand-name-firefox } is lightning fast without sacrificing any of your privacy.
+
+is-firefox-chromium = Is { -brand-name-firefox } { -brand-name-chromium } based?
+firefox-is-not = { -brand-name-firefox } is not based on { -brand-name-chromium } (the open source browser project at the core of { -brand-name-google } { -brand-name-chrome }). In fact, we’re one of the last major browsers that isn’t. { -brand-name-firefox } runs on our Quantum browser engine built specifically for { -brand-name-firefox }, so we can ensure your data is handled respectfully and kept private.
+
+does-firefox-use = Does { -brand-name-firefox } use { -brand-name-google }?
+
+# Variables:
+# $url (url) - link to https://support.mozilla.org/kb/change-your-default-search-settings-firefox
+
+firefoxs-default-search = { -brand-name-firefox }’s default search engine is { -brand-name-google }, which means you can search the web directly from the address bar. <a href="{ $url }">Learn more about search engine preferences and changing defaults.</a>
+
+does-firefox-have = Does { -brand-name-firefox } have a built-in VPN?
+
+# Variables:
+# $url (url) - link to https://fpn.firefox.com/
+# $url2 (url) - link to https://vpn.mozilla.org/
+
+firefox-does-not = { -brand-name-firefox } does not have a built-in VPN (virtual private network), but there are two products made by { -brand-name-mozilla }/{ -brand-name-firefox } that you can use in addition to the private { -brand-name-firefox-browser } that can protect either your browser (<a href="{ $url }">{ -brand-name-firefox-private-network }</a>) or device (<a href="{ $url2 }">{ -brand-name-mozilla-vpn }</a>) connections on WiFi, as well as your IP address.
+
+related-questions-ip = Related questions: does { -brand-name-firefox } hide your IP address
+
+who-owns-firefox = Who owns { -brand-name-firefox }?
+
+# Variables:
+# $url (url) - link to https://foundation.mozilla.org
+# $url2 (url) - link to https://www.mozilla.org/foundation/moco/
+
+firefox-is-made = { -brand-name-firefox } is made by { -brand-name-mozilla-corporation  }, a wholly owned subsidiary of the non-profit <a href="{ $url }">{ -brand-name-mozilla-foundation }</a>, and is guided by the principles of the { -brand-name-mozilla } Manifesto. Learn more about the maker of { -brand-name-firefox } <a href="{ $url2 }">here.</a>
+
+related-questions-who = Related questions: who is { -brand-name-firefox } owned by, who owns { -brand-name-firefox-browser }, is { -brand-name-firefox } owned by { -brand-name-google }, is { -brand-name-mozilla } { -brand-name-firefox } owned by { -brand-name-google }

--- a/media/css/firefox/faq.scss
+++ b/media/css/firefox/faq.scss
@@ -16,7 +16,7 @@ h2 {
     margin-bottom: $layout-lg;
 }
 
-.mzp-c-button-download-container {
+.mzp-t-content-md .mzp-c-button-download-container {
     display: block;
     margin: 0 auto;
 }

--- a/media/css/firefox/faq.scss
+++ b/media/css/firefox/faq.scss
@@ -1,0 +1,22 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+$font-path: '/media/fonts';
+$image-path: '/media/protocol/img';
+
+@import '../../protocol/css/includes/lib';
+@import '../../protocol/css/components/hero';
+
+h2 {
+    @include text-display-md;
+}
+
+li {
+    margin-bottom: $layout-lg;
+}
+
+.mzp-c-button-download-container {
+    display: block;
+    margin: 0 auto;
+}

--- a/media/css/firefox/faq.scss
+++ b/media/css/firefox/faq.scss
@@ -12,7 +12,7 @@ h2 {
     @include text-display-md;
 }
 
-li {
+.faq-list li {
     margin-bottom: $layout-lg;
 }
 

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -693,6 +693,12 @@
     },
     {
       "files": [
+        "css/firefox/faq.scss"
+      ],
+      "name": "firefox-faq"
+    },
+    {
+      "files": [
         "css/firefox/unfck.de.scss"
       ],
       "name": "firefox-unfck-de"

--- a/tests/redirects/map_globalconf.py
+++ b/tests/redirects/map_globalconf.py
@@ -1183,8 +1183,8 @@ URLS = flatten((
     # bug 1416706
     url_test('/firefox/desktop/', '/firefox/new/'),
 
-    # bug 1416708
-    url_test('/firefox/quantum/', '/firefox/'),
+    # issue 9502
+    url_test('/firefox/quantum/', '/firefox/browsers/quantum/'),
 
     # bug 1421584, issue 7491
     url_test('/firefox/organizations/faq/', '/firefox/enterprise/'),


### PR DESCRIPTION
## Description
Adds firefox/faq SEO page.
Includes redirect for [new firefox/browsers/quantum page](#9502).

## Issue / Bugzilla link
#9490
#9491
#9498

## Testing
[Final copy](https://docs.google.com/document/d/1LAdUXUovciI1N4xNN1lNGmWv-6kdXVunvM7arrGyK-E/edit?ts=5f74df55)
[Design](https://github.com/mozilla/bedrock/issues/9497#issuecomment-707772063)