### PR TITLE
Fix Daylight banner on rest-of-world home page (Fixes #9582)

### DIFF
--- a/bedrock/mozorg/templates/mozorg/home/home.html
+++ b/bedrock/mozorg/templates/mozorg/home/home.html
@@ -40,7 +40,7 @@ accessible to all.') }}
   {% endif %}
 
   {% if switch('firefox-daylight-promo-banner') %}
-    {% include 'includes/banners/daylight/daylight-promo.html' %}
+    {{ css_bundle('daylight-promo-banner') }}
   {% endif %}
 {% endblock %}
 


### PR DESCRIPTION
## Description
http://localhost:8000/es-ES/

## Issue / Bugzilla link
#9582