### PR TITLE
Update privacy contact info, migrate to Fluent [fix #9388]

### DIFF
--- a/bedrock/privacy/templates/privacy/index.html
+++ b/bedrock/privacy/templates/privacy/index.html
@@ -5,7 +5,7 @@
 {% extends "privacy/base-protocol.html" %}
 
 {% block page_title_suffix %}{% endblock %}
-{% block page_title %}{{ _('Mozilla Privacy') }}{% endblock %}
+{% block page_title %}{{ ftl('privacy-index-mozilla-privacy') }}{% endblock %}
 
 {% block body_class %}mzp-t-mozilla format-none{% endblock%}
 {% block body_id %}privacy-landing{% endblock %}
@@ -33,120 +33,56 @@
 {% endblock %}
 {% block footnote %}
   <section id="contact" class="section-content">
-      <h4>{{ _('Contact Mozilla') }}</h4>
+    <h4>{{ ftl('privacy-index-contact-mozilla') }}</h4>
+    <p>{{ ftl('privacy-index-if-you-want-to-make-a-correction') }}</p>
 
-      <p>
-        {%- trans -%}
-          If you want to make a correction to your information, or you have any questions about our
-          privacy policies, please get in touch with:
-        {%- endtrans -%}
-      </p>
+    <p lang="en" dir="ltr" itemscope itemtype="http://schema.org/Organization">
+      <span itemprop="name">Mozilla Corporation</span><br>
+      <span itemprop="address" itemscope itemtype="http://schema.org/PostalAddress">
+        {{ _('Attn:') }} <span itemprop="name">Legal Notices - Privacy</span><br>
+        <span itemprop="streetAddress">331 E. Evelyn Ave</span>,<br>
+        <span itemprop="addressLocality">Mountain View</span>,
+        <span itemprop="addressRegion">CA</span>
+        <span itemprop="postalCode">94041</span><br>
+        <span itemprop="email"><a href="mailto:compliance@mozilla.com">compliance@mozilla.com</a></span>
+      </span>
+    </p>
 
-      <p lang="en" dir="ltr" itemscope itemtype="http://schema.org/Organization">
-        <span itemprop="name">Mozilla Corporation</span><br>
-        <span itemprop="address" itemscope itemtype="http://schema.org/PostalAddress">
-          {{ _('Attn:') }} <span itemprop="name">Legal Notices - Privacy</span><br>
-          <span itemprop="streetAddress">331 E. Evelyn Ave</span>,<br>
-          <span itemprop="addressLocality">Mountain View</span>,
-          <span itemprop="addressRegion">CA</span>
-          <span itemprop="postalCode">94041</span><br>
-          <span itemprop="email"><a href="mailto:compliance@mozilla.com">compliance@mozilla.com</a></span>
-        </span>
-      </p>
-
-    {% if l10n_has_tag('privacy_email_2019') %}
-      <p>
-      {% trans dsar='https://app.onetrust.com/app/#/webform/4ba08202-2ede-4934-a89e-f0b0870f95f0' %}
-        <a href="{{ dsar }}">See here for Data Subject Access Requests.</a>
-      {% endtrans %}
-      </p>
+    {% if ftl_has_messages('privacy-index-see-here-for-data-subject') %}
+    <p>{{ ftl('privacy-index-see-here-for-data-subject', dsar='https://app.onetrust.com/app/#/webform/4ba08202-2ede-4934-a89e-f0b0870f95f0') }}</p>
     {% endif %}
 
-    {% if l10n_has_tag('privacy_sumo_032020') %}
-      <p>
-      {% trans sumo='https://support.mozilla.org/' %}
-        For product support requests, please <a href="{{ sumo }}">visit our forums</a>.
-      {% endtrans %}
-      </p>
+    {% if ftl_has_messages('privacy-index-for-product-support-requests') %}
+    <p>{{ ftl('privacy-index-for-product-support-requests', sumo='https://support.mozilla.org/') }}</p>
     {% endif %}
   </section>
 {% endblock %}
 
 
 {% block side_extra %}
+  {% if ftl_has_messages('privacy-index-data-privacy-principles', 'privacy-index-mozillas-data-privacy-principles') %}
   <section id="side-principles" class="side-reference">
-    <h2 class="side-reference-title">{{ _('Data Privacy Principles') }}</h2>
-    <p>
-      {% if l10n_has_tag('updates-072018') %}
-      {%- trans principles=url('privacy.principles'), faq=url('privacy.faq') -%}
-        Mozilla's <a href="{{ principles }}">Data Privacy Principles</a> inspire our
-        practices that respect and protect people who use the Internet. Learn how
-        these principles shape Firefox and all of our products in this
-        <a href="{{ faq }}">FAQ</a>.
-      {%- endtrans -%}
-      {% elif l10n_has_tag('updates-052018') %}
-      {%- trans faq=url('privacy.faq') -%}
-        Mozilla's Data Privacy Principles inspire our practices that respect and
-        protect people who use the Internet. Learn how these principles shape
-        Firefox and all of our products in this <a href="{{ faq }}">FAQ</a>.
-      {%- endtrans -%}
-      {% else %}
-        {%- trans link=url('privacy.principles') -%}
-          Mozilla is an open source project with a mission to improve your Internet
-          experience. This is a driving force behind our data privacy practices.
-          <a href="{{ link }}">Read More</a>
-        {%- endtrans -%}
-      {% endif %}
-    </p>
+    <h2 class="side-reference-title">{{ ftl('privacy-index-data-privacy-principles') }}</h2>
+    <p>{{ ftl('privacy-index-mozillas-data-privacy-principles', principles=url('privacy.principles'), faq=url('privacy.faq')) }}</p>
   </section>
-  {% if l10n_has_tag('updates-052018') %}
-    <section id="side-transparency" class="side-reference">
-      <h2 class="side-reference-title">{{ _('Transparency Report') }}</h2>
-      <p>
-        {%- trans report=url('mozorg.about.policy.transparency.index') -%}
-          As an open source project, transparency and openness are an essential
-          part of Mozilla’s founding principles. Our codebases are open and
-          auditable. Our development work is open. Our bi-annual
-          <a href="{{ report }}">Transparency Report</a> also demonstrates our
-          commitment to these principles.
-        {%- endtrans -%}
-      </p>
-    </section>
   {% endif %}
 
-  <section id="side-involved" class="side-reference">
-    <h2 class="side-reference-title">{{ _('Get Involved') }}</h2>
-    <p>
-      {% set group_url = 'https://groups.google.com/forum/?fromgroups#!forum/mozilla.governance' %}
-      {% if l10n_has_tag('updates-052018') %}
-        {%- trans group=group_url -%}
-          To review and comment on proposed changes to our privacy policies, <a href="{{ group }}">
-          subscribe to Mozilla’s governance group</a>.
-        {%- endtrans -%}
-      {% else %}
-        {%- trans group=group_url -%}
-          To review and comment on proposed changes to our privacy policies <a href="{{ group }}">
-          subscribe to Mozilla’s Governance Group</a>.
-        {%- endtrans -%}
-      {% endif %}
-    </p>
-    <p>
-      {% set blog_url = 'https://blog.mozilla.org/privacy/' %}
-      {% if l10n_has_tag('updates-052018') %}
-        {%- trans blog=blog_url -%}
-          Read more about our ongoing privacy and security public policy work on
-          <a href="{{ blog }}">Mozilla's Open Policy and Advocacy Blog</a>.
-        {%- endtrans -%}
-      {% else %}
-        {%- trans blog=blog_url, wiki='https://wiki.mozilla.org/Privacy' -%}
-          Our ongoing work on privacy is covered by the <a href="{{ blog }}">Privacy &amp; Data Safety
-          Blog</a> and information about our ongoing work is available on <a href="{{ wiki }}">
-          Mozilla’s privacy team wiki</a>.
-        {%- endtrans -%}
-      {% endif %}
-    </p>
+  {% if ftl_has_messages('privacy-index-transparency-report', 'privacy-index-as-an-open-source-project') %}
+  <section id="side-transparency" class="side-reference">
+    <h2 class="side-reference-title">{{ ftl('privacy-index-transparency-report') }}</h2>
+    <p>{{ ftl('privacy-index-as-an-open-source-project', report=url('mozorg.about.policy.transparency.index')) }}</p>
   </section>
+  {% endif %}
+
+  {% if ftl_has_messages('privacy-index-get-involved', 'privacy-index-to-review-and-comment-on-proposed', 'privacy-index-read-more-about-our-ongoing') %}
+  <section id="side-involved" class="side-reference">
+    <h2 class="side-reference-title">{{ ftl('privacy-index-get-involved') }}</h2>
+    <p>{{ ftl('privacy-index-to-review-and-comment-on-proposed', group='https://groups.google.com/forum/?fromgroups#!forum/mozilla.governance') }}</p>
+    <p>{{ ftl('privacy-index-read-more-about-our-ongoing', blog='https://blog.mozilla.org/privacy/') }}</p>
+  </section>
+  {% endif %}
+
   <section id="side-archives" class="side-reference">
-    <h2 class="side-reference-title"><a href="{{ url('privacy.archive.index') }}">{{ _('Outdated Policies') }}</a></h2>
+    <h2 class="side-reference-title"><a href="{{ url('privacy.archive.index') }}">{{ ftl('privacy-index-outdated-policies') }}</a></h2>
   </section>
 {% endblock %}

--- a/bedrock/privacy/templates/privacy/principles.html
+++ b/bedrock/privacy/templates/privacy/principles.html
@@ -4,8 +4,8 @@
 
 {% extends "privacy/base-protocol.html" %}
 
-{% block page_title %}{{ _('Data Privacy Principles') }}{% endblock %}
-{% block page_desc %}{{ _('Mozilla is an open source project with a mission to improve your Internet experience. This is a driving force behind our privacy practices.') }}{% endblock %}
+{% block page_title %}{{ ftl('privacy-principles-data-privacy-principles') }}{% endblock %}
+{% block page_desc %}{{ ftl('privacy-principles-mozilla-is-an-open-source') }}{% endblock %}
 
 {% block body_id %}privacy-principles{% endblock %}
 {% block body_class %}mzp-t-mozilla{% endblock %}
@@ -14,58 +14,45 @@
   <header>
     <h1 class="mzp-c-article-title" itemprop="name">{{ self.page_title() }}</h1>
     <p itemprop="description">
-      {%- trans link=url('mozorg.about.manifesto') -%}
-        The following five principles stem from the <a href="{{ link }}">Mozilla
-        Manifesto</a> and inform how we:
-      {%- endtrans -%}
+      {{ ftl('privacy-principles-the-following-five-principles', link=url('mozorg.about.manifesto')) }}
     </p>
     <ul class="mzp-u-list-styled">
-      <li>{{ _('develop our products and services') }}</li>
-      <li>{{ _('manage user data we collect') }}</li>
-      <li>{{ _('select and interact with partners') }}</li>
-      <li>{{ _('shape our public policy and advocacy work') }}</li>
+      <li>{{ ftl('privacy-principles-develop-our-products') }}</li>
+      <li>{{ ftl('privacy-principles-manage-user-data-we-collect') }}</li>
+      <li>{{ ftl('privacy-principles-select-and-interact-with') }}</li>
+      <li>{{ ftl('privacy-principles-shape-our-public-policy') }}</li>
     </ul>
   </header>
   <div itemprop="articleBody" class="mzp-c-article">
     <ol class="mzp-u-list-styled">
       <li>
-        <h2>{{ _('No surprises') }}</h2>
+        <h2>{{ ftl('privacy-principles-no-surprises') }}</h2>
         <p>
-          {%- trans -%}
-            Use and share information in a way that is transparent and benefits the user.
-          {%- endtrans -%}
+          {{ ftl('privacy-principles-use-and-share-information') }}
         </p>
       </li>
       <li>
-        <h2>{{ _('User control') }}</h2>
+        <h2>{{ ftl('privacy-principles-user-control') }}</h2>
         <p>
-          {%- trans -%}
-            Develop products and advocate for best practices that put users in control of their data and online experiences.
-          {%- endtrans -%}
+          {{ ftl('privacy-principles-develop-products-and') }}
         </p>
       </li>
       <li>
-        <h2>{{ _('Limited data') }}</h2>
+        <h2>{{ ftl('privacy-principles-limited-data') }}</h2>
         <p>
-          {%- trans -%}
-            Collect what we need, de-identify where we can and delete when no longer necessary.
-          {%- endtrans -%}
+          {{ ftl('privacy-principles-collect-what-we-need') }}
         </p>
       </li>
       <li>
-        <h2>{{ _('Sensible settings') }}</h2>
+        <h2>{{ ftl('privacy-principles-sensible-settings') }}</h2>
         <p>
-          {%- trans -%}
-            Design for a thoughtful balance of safety and user experience.
-          {%- endtrans -%}
+          {{ ftl('privacy-principles-design-for-a-thoughtful') }}
         </p>
       </li>
       <li>
-        <h2>{{ _('Defense in depth') }}</h2>
+        <h2>{{ ftl('privacy-principles-defense-in-depth') }}</h2>
         <p>
-          {%- trans -%}
-            Maintain multi-layered security controls and practices, many of which are publicly verifiable.
-          {%- endtrans -%}
+          {{ ftl('privacy-principles-maintain-multi-layered') }}
         </p>
       </li>
     </ol>

--- a/bedrock/privacy/urls.py
+++ b/bedrock/privacy/urls.py
@@ -10,7 +10,7 @@ from bedrock.redirects.util import redirect
 
 urlpatterns = (
     url(r'^$', views.privacy, name='privacy'),
-    page('principles', 'privacy/principles.html'),
+    page('principles', 'privacy/principles.html', ftl_files=['privacy/principles']),
     page('faq', 'privacy/faq.html'),
     page('email', 'privacy/email.html', active_locales=['en-US', 'de', 'fr']),
     url(r'^betterweb/$', views.firefox_betterweb_notices, name='privacy.notices.firefox-betterweb'),

--- a/bedrock/privacy/views.py
+++ b/bedrock/privacy/views.py
@@ -126,4 +126,4 @@ def privacy(request):
         'active_locales': doc['active_locales'],
     }
 
-    return l10n_utils.render(request, 'privacy/index.html', template_vars)
+    return l10n_utils.render(request, 'privacy/index.html', template_vars, ftl_files='privacy/index')

--- a/l10n/en/privacy/index.ftl
+++ b/l10n/en/privacy/index.ftl
@@ -1,0 +1,39 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+### URL: https://www-dev.allizom.org/privacy
+
+# HTML page title
+privacy-index-mozilla-privacy = { -brand-name-mozilla } Privacy
+privacy-index-contact-mozilla = Contact { -brand-name-mozilla }
+privacy-index-if-you-want-to-make-a-correction = If you want to make a correction to your information, or you have any questions about our privacy policies, please get in touch with:
+
+# Variables:
+#   $dsar (url) - link to https://app.onetrust.com/app/#/webform/4ba08202-2ede-4934-a89e-f0b0870f95f0
+privacy-index-see-here-for-data-subject = <a href="{ $dsar }">See here for Data Subject Access Requests.</a>
+
+# Variables:
+#   $sumo (url) - link to https://support.mozilla.org/
+privacy-index-for-product-support-requests = For product support requests, please <a href="{ $sumo }">visit our forums</a>.
+privacy-index-data-privacy-principles = Data Privacy Principles
+
+# Variables:
+#   $principles (url) - link to https://www.mozilla.org/privacy/principles/
+#   $faq (url) - link to https://www.mozilla.org/privacy/faq/
+privacy-index-mozillas-data-privacy-principles = { -brand-name-mozilla }'s <a href="{ $principles }">Data Privacy Principles</a> inspire our practices that respect and protect people who use the Internet. Learn how these principles shape { -brand-name-firefox } and all of our products in this <a href="{ $faq }">FAQ</a>
+privacy-index-transparency-report = Transparency Report
+privacy-index-get-involved = Get Involved
+
+# Variables:
+#   $report (url) - link to https://www.mozilla.org/about/policy/transparency/
+privacy-index-as-an-open-source-project = As an open source project, transparency and openness are an essential part of { -brand-name-mozilla }’s founding principles. Our codebases are open and auditable. Our development work is open. Our bi-annual <a href="{ $report }">Transparency Report</a> also demonstrates our commitment to these principles.
+
+# Variables:
+#   $group (url) - link to https://groups.google.com/forum/?fromgroups#!forum/mozilla.governance
+privacy-index-to-review-and-comment-on-proposed = To review and comment on proposed changes to our privacy policies, <a href="{ $group }"> subscribe to { -brand-name-mozilla }’s governance group</a>.
+
+# Variables:
+#   $blog (url) - link to https://blog.mozilla.org/privacy/
+privacy-index-read-more-about-our-ongoing = Read more about our ongoing privacy and security public policy work on <a href="{ $blog }">{ -brand-name-mozilla }'s Open Policy and Advocacy Blog</a>.
+privacy-index-outdated-policies = Outdated Policies

--- a/l10n/en/privacy/principles.ftl
+++ b/l10n/en/privacy/principles.ftl
@@ -1,0 +1,29 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+### URL: https://www-dev.allizom.org/privacy/principles/
+
+# HTML page title and main title
+privacy-principles-data-privacy-principles = Data Privacy Principles
+
+# HTML page description
+privacy-principles-mozilla-is-an-open-source = { -brand-name-mozilla } is an open source project with a mission to improve your Internet experience. This is a driving force behind our privacy practices.
+
+# Variables:
+#   $link (url) - link to https://www.mozilla.org/about/manifesto/
+privacy-principles-the-following-five-principles = The following five principles stem from the <a href="{ $link }">{ -brand-name-mozilla } Manifesto</a> and inform how we:
+privacy-principles-develop-our-products = develop our products and services
+privacy-principles-manage-user-data-we-collect = manage user data we collect
+privacy-principles-select-and-interact-with = select and interact with partners
+privacy-principles-shape-our-public-policy = shape our public policy and advocacy work
+privacy-principles-no-surprises = No surprises
+privacy-principles-use-and-share-information = Use and share information in a way that is transparent and benefits the user.
+privacy-principles-user-control = User control
+privacy-principles-develop-products-and = Develop products and advocate for best practices that put users in control of their data and online experiences.
+privacy-principles-limited-data = Limited data
+privacy-principles-collect-what-we-need = Collect what we need, de-identify where we can and delete when no longer necessary.
+privacy-principles-sensible-settings = Sensible settings
+privacy-principles-design-for-a-thoughtful = Design for a thoughtful balance of safety and user experience.
+privacy-principles-defense-in-depth = Defense in depth
+privacy-principles-maintain-multi-layered = Maintain multi-layered security controls and practices, many of which are publicly verifiable.

--- a/lib/fluent_migrations/privacy/faq.py
+++ b/lib/fluent_migrations/privacy/faq.py
@@ -1,0 +1,313 @@
+from __future__ import absolute_import
+import fluent.syntax.ast as FTL
+from fluent.migrate.helpers import transforms_from
+from fluent.migrate.helpers import VARIABLE_REFERENCE, TERM_REFERENCE
+from fluent.migrate import REPLACE, COPY
+
+faq = "privacy/faq.lang"
+
+def migrate(ctx):
+    """Migrate bedrock/privacy/templates/privacy/faq.html, part {index}."""
+
+    ctx.add_transforms(
+        "privacy/faq.ftl",
+        "privacy/faq.ftl",
+        [
+            FTL.Message(
+                id=FTL.Identifier("privacy-faq-mozillas-data-privacy-faq"),
+                value=REPLACE(
+                    faq,
+                    "Mozilla’s Data Privacy FAQ",
+                    {
+                        "Mozilla": TERM_REFERENCE("brand-name-mozilla"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("privacy-faq-at-mozilla-we-respect-and-protect"),
+                value=REPLACE(
+                    faq,
+                    "At Mozilla we respect and protect your personal information.",
+                    {
+                        "Mozilla": TERM_REFERENCE("brand-name-mozilla"),
+                    }
+                )
+            ),
+        ] + transforms_from("""
+privacy-faq-we-stand-for-people-over-profit = {COPY(faq, "We Stand for People Over Profit.",)}
+""", faq=faq) + [
+            FTL.Message(
+                id=FTL.Identifier("privacy-faq-it-can-be-tricky-for-people"),
+                value=REPLACE(
+                    faq,
+                    "It can be tricky for people to know what to expect of any software or services they use today. The technology that powers our lives is complex and people don’t have the time to dig into the details. That is still true for Firefox, where we find that people have many different ideas of what is happening under the hood in their browser.",
+                    {
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("privacy-faq-at-mozilla-we-respect-and-protect"),
+                value=REPLACE(
+                    faq,
+                    "At Mozilla, we respect and protect your personal information:",
+                    {
+                        "Mozilla": TERM_REFERENCE("brand-name-mozilla"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("privacy-faq-we-follow-a-set-of-data-privacy"),
+                value=REPLACE(
+                    faq,
+                    "We follow a set of <a href=\"%(link)s\">Data Privacy Principles</a> that shape our approach to privacy in the Firefox desktop and mobile browsers.",
+                    {
+                        "%%": "%",
+                        "%(link)s": VARIABLE_REFERENCE("link"),
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                    }
+                )
+            ),
+        ] + transforms_from("""
+privacy-faq-we-only-collect-the-data-we = {COPY(faq, "We only collect the data we need to make the best products.",)}
+privacy-faq-we-put-people-in-control-of = {COPY(faq, "We put people in control of their data and online experiences.",)}
+""", faq=faq) + [
+            FTL.Message(
+                id=FTL.Identifier("privacy-faq-we-adhere-to-no-surprises-principle"),
+                value=REPLACE(
+                    faq,
+                    "We adhere to “no surprises” principle, meaning we work hard to ensure people’s understanding of Firefox matches reality.",
+                    {
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("privacy-faq-the-following-questions-and"),
+                value=REPLACE(
+                    faq,
+                    "The following questions and answers should help you understand what to expect from Mozilla and Firefox:",
+                    {
+                        "Mozilla": TERM_REFERENCE("brand-name-mozilla"),
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("privacy-faq-i-use-firefox-for-almost-everything"),
+                value=REPLACE(
+                    faq,
+                    "I use Firefox for almost everything on the Web. You folks at Mozilla must know a ton of stuff about me, right?",
+                    {
+                        "Mozilla": TERM_REFERENCE("brand-name-mozilla"),
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("privacy-faq-firefox-the-web-browser-that"),
+                value=REPLACE(
+                    faq,
+                    "Firefox, the web browser that runs on your device or computer, is your gateway to the internet. Your browser will manage a lot of information about the websites you visit, but that information stays on your device. Mozilla, the company that makes Firefox, doesn’t collect it (unless you ask us to).",
+                    {
+                        "Mozilla": TERM_REFERENCE("brand-name-mozilla"),
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                    }
+                )
+            ),
+        ] + transforms_from("""
+privacy-faq-really-you-dont-collect-my-browsing = {COPY(faq, "Really, you don’t collect my browsing history?",)}
+""", faq=faq) + [
+            FTL.Message(
+                id=FTL.Identifier("privacy-faq-mozilla-doesnt-know-as-much"),
+                value=REPLACE(
+                    faq,
+                    "Mozilla doesn’t know as much as you’d expect about how people browse the web. As a browser maker, that’s actually a big challenge for us. That is why we’ve built opt-in tools, such as <a href=\"%(link)s\">Firefox Pioneer</a>, which allows interested users to give us insight into their web browsing. If you sync your browsing history across Firefox installations, we don’t know what that history is - because it’s encrypted by your device.",
+                    {
+                        "%%": "%",
+                        "%(link)s": VARIABLE_REFERENCE("link"),
+                        "Mozilla": TERM_REFERENCE("brand-name-mozilla"),
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                    }
+                )
+            ),
+        ] + transforms_from("""
+privacy-faq-it-seems-like-every-company = {COPY(faq, "It seems like every company on the web is buying and selling my data. You’re probably no different.",)}
+""", faq=faq) + [
+            FTL.Message(
+                id=FTL.Identifier("privacy-faq-mozilla-doesnt-sell-data-about"),
+                value=REPLACE(
+                    faq,
+                    "Mozilla doesn’t sell data about you, and we don’t buy data about you.",
+                    {
+                        "Mozilla": TERM_REFERENCE("brand-name-mozilla"),
+                    }
+                )
+            ),
+        ] + transforms_from("""
+privacy-faq-wait-so-how-do-you-make-money = {COPY(faq, "Wait, so how do you make money?",)}
+""", faq=faq) + [
+            FTL.Message(
+                id=FTL.Identifier("privacy-faq-mozilla-is-not-your-average"),
+                value=REPLACE(
+                    faq,
+                    "Mozilla is not your average organization. Founded as a community open source project in 1998, Mozilla is a mission-driven organization working towards a more healthy internet. The majority of Mozilla Corporation’s revenue is from royalties earned through Firefox web browser search partnerships and distribution deals around the world. You can learn more about how we make money in our <a href=\"%(link)s\">annual financial report</a>.",
+                    {
+                        "%%": "%",
+                        "%(link)s": VARIABLE_REFERENCE("link"),
+                        "Mozilla Corporation": TERM_REFERENCE("brand-name-mozilla-corporation"),
+                        "Mozilla": TERM_REFERENCE("brand-name-mozilla"),
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                    }
+                )
+            ),
+        ] + transforms_from("""
+privacy-faq-okay-those-first-few-were-softballs = {COPY(faq, "Okay, those first few were softballs. What data do you collect?",)}
+""", faq=faq) + [
+            FTL.Message(
+                id=FTL.Identifier("privacy-faq-mozilla-does-collect-a-limited"),
+                value=REPLACE(
+                    faq,
+                    "Mozilla does collect a limited set of data by default from Firefox that helps us to understand how people use the browser. That data is tied to a random identifier, rather than your name or email address. You can read more about that on our <a href=\"%(privacy)s\">privacy notice</a> and you can read the <a href=\"%(data)s\">full documentation for that data collection</a>.",
+                    {
+                        "%%": "%",
+                        "%(privacy)s": VARIABLE_REFERENCE("privacy"),
+                        "%(data)s": VARIABLE_REFERENCE("data"),
+                        "Mozilla": TERM_REFERENCE("brand-name-mozilla"),
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                    }
+                )
+            ),
+        ] + transforms_from("""
+privacy-faq-we-make-our-documentation-public = {COPY(faq, "We make our documentation public so that anyone can verify what we say is true, tell us if we need to improve, and have confidence that we aren’t hiding anything.",)}
+privacy-faq-that-documentation-is-gobbledygook = {COPY(faq, "That documentation is gobbledygook to me! Can you give it to me in plain English?",)}
+""", faq=faq) + [
+            FTL.Message(
+                id=FTL.Identifier("privacy-faq-there-are-two-categories-of"),
+                value=REPLACE(
+                    faq,
+                    "There are two categories of data that we collect by default in our release version of Firefox.",
+                    {
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                    }
+                )
+            ),
+        ] + transforms_from("""
+privacy-faq-the-first-is-what-we-call-technical = {COPY(faq, "The first is what we call \"technical data.\" This is data about the browser itself, such as the operating system it is running on and information about errors or crashes.",)}
+""", faq=faq) + [
+            FTL.Message(
+                id=FTL.Identifier("privacy-faq-the-second-is-what-we-call-interaction"),
+                value=REPLACE(
+                    faq,
+                    "The second is what we call \"interaction data.\" This is data about an individual's engagement with Firefox, such as the number of tabs that were open, the status of user preferences, or number of times certain browser features were used, such as screenshots or containers. For example, we collect this data in terms of the back button, that arrow in the upper left corner of your browser that lets you navigate back to a previous webpage in a way that shows us someone used the back button, but doesn’t tell what specific webpages are accessed.",
+                    {
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("privacy-faq-do-you-collect-more-data-in"),
+                value=REPLACE(
+                    faq,
+                    "Do you collect more data in pre-release versions of Firefox?",
+                    {
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("privacy-faq-sort-of-in-addition-to-the-data"),
+                value=REPLACE(
+                    faq,
+                    "Sort-of. In addition to the data described above, we receive crash and error reports by default in pre-release version of Firefox.",
+                    {
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("privacy-faq-we-may-also-collect-additional"),
+                value=REPLACE(
+                    faq,
+                    "We may also collect additional data in pre-release for one of our <a href=\"%(link)s\">studies</a>. For example, some studies require what we call “web activity data” data, which may include URLs and other information about certain websites. This helps us answer specific questions to improve Firefox, for example, how to better integrate popular websites in specific locales.",
+                    {
+                        "%%": "%",
+                        "%(link)s": VARIABLE_REFERENCE("link"),
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("privacy-faq-mozillas-pre-release-versions"),
+                value=REPLACE(
+                    faq,
+                    "Mozilla’s pre-release versions of Firefox are development platforms, frequently updated with experimental features. We collect more data in pre-release than what we do after release in order to understand how these experimental features are working. You can opt out of having this data collected in preferences.",
+                    {
+                        "Mozilla": TERM_REFERENCE("brand-name-mozilla"),
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                    }
+                )
+            ),
+        ] + transforms_from("""
+privacy-faq-but-why-do-you-collect-any-data = {COPY(faq, "But why do you collect any data at all?",)}
+privacy-faq-if-we-dont-know-how-the-browser = {COPY(faq, "If we don’t know how the browser is performing or which features people use, we can’t make it better and deliver the great product you want. We’ve invested in building data collection and analysis tools that allow us to make smart decisions about our product while respecting people's privacy.",)}
+privacy-faq-data-collection-still-bugs-me = {COPY(faq, "Data collection still bugs me. Can I turn it off?",)}
+""", faq=faq) + [
+            FTL.Message(
+                id=FTL.Identifier("privacy-faq-yes-user-control-is-one-of-our"),
+                value=REPLACE(
+                    faq,
+                    "Yes. User control is one of our data privacy principles. We put that into practice in Firefox on our <a href=\"%(settings)s\">privacy settings page</a>, which serves as a one-stop shop for anyone looking to take control of their privacy in Firefox. You can <a href=\"%(data)s\">turn off data collection</a> there.",
+                    {
+                        "%%": "%",
+                        "%(settings)s": VARIABLE_REFERENCE("settings"),
+                        "%(data)s": VARIABLE_REFERENCE("data"),
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                    }
+                )
+            ),
+        ] + transforms_from("""
+privacy-faq-what-about-my-account-data = {COPY(faq, "What about my account data?",)}
+privacy-faq-we-are-big-believers-of-data = {COPY(faq, "We are big believers of data minimization and not asking for things we don't need.",)}
+""", faq=faq) + [
+            FTL.Message(
+                id=FTL.Identifier("privacy-faq-you-dont-need-an-account-to"),
+                value=REPLACE(
+                    faq,
+                    "You don't need an account to use Firefox. <a href=\"%(accounts)s\">Accounts</a> are required to sync data across devices, but we only ask you for an email address. We don't want to know things like your name, address, birthday and phone number.",
+                    {
+                        "%%": "%",
+                        "%(accounts)s": VARIABLE_REFERENCE("accounts"),
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("privacy-faq-you-dont-need-an-account-to"),
+                value=REPLACE(
+                    faq,
+                    "You don't need an account to use Firefox. Accounts are required to sync data across devices, but we only ask you for an email address. We don't want to know things like your name, address, birthday and phone number.",
+                    {
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                    }
+                )
+            ),
+        ] + transforms_from("""
+privacy-faq-you-use-digital-advertising = {COPY(faq, "You use digital advertising as part of your marketing mix. Do you buy people's data to better target your online ads?",)}
+privacy-faq-no-we-do-not-buy-peoples-data = {COPY(faq, "No, we do not buy people's data to target advertising.",)}
+privacy-faq-we-do-ask-our-advertising-partners = {COPY(faq, "We do ask our advertising partners to use only first party data that websites and publishers know about all users, such as the browser you are using and the device you are on.",)}
+privacy-faq-well-it-seems-like-you-really = {COPY(faq, "Well, it seems like you really have my back on this privacy stuff.",)}
+privacy-faq-yes-we-do = {COPY(faq, "Yes, we do.",)}
+""", faq=faq) + [
+            FTL.Message(
+                id=FTL.Identifier("privacy-faq-find-out-more-about-how-mozilla"),
+                value=REPLACE(
+                    faq,
+                    "Find out more about how Mozilla protects the internet.",
+                    {
+                        "Mozilla": TERM_REFERENCE("brand-name-mozilla"),
+                    }
+                )
+            ),
+        ]
+        )

--- a/lib/fluent_migrations/privacy/index.py
+++ b/lib/fluent_migrations/privacy/index.py
@@ -1,0 +1,170 @@
+from __future__ import absolute_import
+import fluent.syntax.ast as FTL
+from fluent.migrate.helpers import transforms_from
+from fluent.migrate.helpers import VARIABLE_REFERENCE, TERM_REFERENCE
+from fluent.migrate import REPLACE, COPY
+
+index = "privacy/index.lang"
+
+def migrate(ctx):
+    """Migrate bedrock/privacy/templates/privacy/index.html, part {index}."""
+
+    ctx.add_transforms(
+        "privacy/index.ftl",
+        "privacy/index.ftl",
+        [
+            FTL.Message(
+                id=FTL.Identifier("privacy-index-mozilla-privacy"),
+                value=REPLACE(
+                    index,
+                    "Mozilla Privacy",
+                    {
+                        "Mozilla": TERM_REFERENCE("brand-name-mozilla"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("privacy-index-contact-mozilla"),
+                value=REPLACE(
+                    index,
+                    "Contact Mozilla",
+                    {
+                        "Mozilla": TERM_REFERENCE("brand-name-mozilla"),
+                    }
+                )
+            ),
+        ] + transforms_from("""
+privacy-index-if-you-want-to-make-a-correction = {COPY(index, "If you want to make a correction to your information, or you have any questions about our privacy policies, please get in touch with:",)}
+""", index=index) + [
+            FTL.Message(
+                id=FTL.Identifier("privacy-index-see-here-for-data-subject"),
+                value=REPLACE(
+                    index,
+                    "<a href=\"%(dsar)s\">See here for Data Subject Access Requests.</a>",
+                    {
+                        "%%": "%",
+                        "%(dsar)s": VARIABLE_REFERENCE("dsar"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("privacy-index-for-product-support-requests"),
+                value=REPLACE(
+                    index,
+                    "For product support requests, please <a href=\"%(sumo)s\">visit our forums</a>.",
+                    {
+                        "%%": "%",
+                        "%(sumo)s": VARIABLE_REFERENCE("sumo"),
+                    }
+                )
+            ),
+        ] + transforms_from("""
+privacy-index-data-privacy-principles = {COPY(index, "Data Privacy Principles",)}
+""", index=index) + [
+            FTL.Message(
+                id=FTL.Identifier("privacy-index-mozillas-data-privacy-principles"),
+                value=REPLACE(
+                    index,
+                    "Mozilla's <a href=\"%(principles)s\">Data Privacy Principles</a> inspire our practices that respect and protect people who use the Internet. Learn how these principles shape Firefox and all of our products in this <a href=\"%(faq)s\">FAQ</a>.",
+                    {
+                        "%%": "%",
+                        "%(principles)s": VARIABLE_REFERENCE("principles"),
+                        "%(faq)s": VARIABLE_REFERENCE("faq"),
+                        "Mozilla": TERM_REFERENCE("brand-name-mozilla"),
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("privacy-index-mozillas-data-privacy-principles"),
+                value=REPLACE(
+                    index,
+                    "Mozilla's Data Privacy Principles inspire our practices that respect and protect people who use the Internet. Learn how these principles shape Firefox and all of our products in this <a href=\"%(faq)s\">FAQ</a>.",
+                    {
+                        "%%": "%",
+                        "%(faq)s": VARIABLE_REFERENCE("faq"),
+                        "Mozilla": TERM_REFERENCE("brand-name-mozilla"),
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("privacy-index-mozilla-is-an-open-source"),
+                value=REPLACE(
+                    index,
+                    "Mozilla is an open source project with a mission to improve your Internet experience. This is a driving force behind our data privacy practices. <a href=\"%(link)s\">Read More</a>",
+                    {
+                        "%%": "%",
+                        "%(link)s": VARIABLE_REFERENCE("link"),
+                        "Mozilla": TERM_REFERENCE("brand-name-mozilla"),
+                    }
+                )
+            ),
+        ] + transforms_from("""
+privacy-index-transparency-report = {COPY(index, "Transparency Report",)}
+""", index=index) + [
+            FTL.Message(
+                id=FTL.Identifier("privacy-index-as-an-open-source-project"),
+                value=REPLACE(
+                    index,
+                    "As an open source project, transparency and openness are an essential part of Mozilla’s founding principles. Our codebases are open and auditable. Our development work is open. Our bi-annual <a href=\"%(report)s\">Transparency Report</a> also demonstrates our commitment to these principles.",
+                    {
+                        "%%": "%",
+                        "%(report)s": VARIABLE_REFERENCE("report"),
+                        "Mozilla": TERM_REFERENCE("brand-name-mozilla"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("privacy-index-to-review-and-comment-on-proposed"),
+                value=REPLACE(
+                    index,
+                    "To review and comment on proposed changes to our privacy policies, <a href=\"%(group)s\"> subscribe to Mozilla’s governance group</a>.",
+                    {
+                        "%%": "%",
+                        "%(group)s": VARIABLE_REFERENCE("group"),
+                        "Mozilla": TERM_REFERENCE("brand-name-mozilla"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("privacy-index-to-review-and-comment-on-proposed"),
+                value=REPLACE(
+                    index,
+                    "To review and comment on proposed changes to our privacy policies <a href=\"%(group)s\"> subscribe to Mozilla’s Governance Group</a>.",
+                    {
+                        "%%": "%",
+                        "%(group)s": VARIABLE_REFERENCE("group"),
+                        "Mozilla": TERM_REFERENCE("brand-name-mozilla"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("privacy-index-read-more-about-our-ongoing"),
+                value=REPLACE(
+                    index,
+                    "Read more about our ongoing privacy and security public policy work on <a href=\"%(blog)s\">Mozilla's Open Policy and Advocacy Blog</a>.",
+                    {
+                        "%%": "%",
+                        "%(blog)s": VARIABLE_REFERENCE("blog"),
+                        "Mozilla": TERM_REFERENCE("brand-name-mozilla"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("privacy-index-our-ongoing-work-on-privacy"),
+                value=REPLACE(
+                    index,
+                    "Our ongoing work on privacy is covered by the <a href=\"%(blog)s\">Privacy &amp; Data Safety Blog</a> and information about our ongoing work is available on <a href=\"%(wiki)s\"> Mozilla’s privacy team wiki</a>.",
+                    {
+                        "%%": "%",
+                        "%(blog)s": VARIABLE_REFERENCE("blog"),
+                        "%(wiki)s": VARIABLE_REFERENCE("wiki"),
+                        "Mozilla": TERM_REFERENCE("brand-name-mozilla"),
+                    }
+                )
+            ),
+        ] + transforms_from("""
+privacy-index-outdated-policies = {COPY(index, "Outdated Policies",)}
+""", index=index)
+        )

--- a/lib/fluent_migrations/privacy/principles.py
+++ b/lib/fluent_migrations/privacy/principles.py
@@ -1,0 +1,56 @@
+from __future__ import absolute_import
+import fluent.syntax.ast as FTL
+from fluent.migrate.helpers import transforms_from
+from fluent.migrate.helpers import VARIABLE_REFERENCE, TERM_REFERENCE
+from fluent.migrate import REPLACE, COPY
+
+principles = "privacy/principles.lang"
+
+def migrate(ctx):
+    """Migrate bedrock/privacy/templates/privacy/principles.html, part {index}."""
+
+    ctx.add_transforms(
+        "privacy/principles.ftl",
+        "privacy/principles.ftl",
+        transforms_from("""
+privacy-principles-data-privacy-principles = {COPY(principles, "Data Privacy Principles",)}
+""", principles=principles) + [
+            FTL.Message(
+                id=FTL.Identifier("privacy-principles-mozilla-is-an-open-source"),
+                value=REPLACE(
+                    principles,
+                    "Mozilla is an open source project with a mission to improve your Internet experience. This is a driving force behind our privacy practices.",
+                    {
+                        "Mozilla": TERM_REFERENCE("brand-name-mozilla"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("privacy-principles-the-following-five-principles"),
+                value=REPLACE(
+                    principles,
+                    "The following five principles stem from the <a href=\"%(link)s\">Mozilla Manifesto</a> and inform how we:",
+                    {
+                        "%%": "%",
+                        "%(link)s": VARIABLE_REFERENCE("link"),
+                        "Mozilla": TERM_REFERENCE("brand-name-mozilla"),
+                    }
+                )
+            ),
+        ] + transforms_from("""
+privacy-principles-develop-our-products = {COPY(principles, "develop our products and services",)}
+privacy-principles-manage-user-data-we-collect = {COPY(principles, "manage user data we collect",)}
+privacy-principles-select-and-interact-with = {COPY(principles, "select and interact with partners",)}
+privacy-principles-shape-our-public-policy = {COPY(principles, "shape our public policy and advocacy work",)}
+privacy-principles-no-surprises = {COPY(principles, "No surprises",)}
+privacy-principles-use-and-share-information = {COPY(principles, "Use and share information in a way that is transparent and benefits the user.",)}
+privacy-principles-user-control = {COPY(principles, "User control",)}
+privacy-principles-develop-products-and = {COPY(principles, "Develop products and advocate for best practices that put users in control of their data and online experiences.",)}
+privacy-principles-limited-data = {COPY(principles, "Limited data",)}
+privacy-principles-collect-what-we-need = {COPY(principles, "Collect what we need, de-identify where we can and delete when no longer necessary.",)}
+privacy-principles-sensible-settings = {COPY(principles, "Sensible settings",)}
+privacy-principles-design-for-a-thoughtful = {COPY(principles, "Design for a thoughtful balance of safety and user experience.",)}
+privacy-principles-defense-in-depth = {COPY(principles, "Defense in depth",)}
+privacy-principles-maintain-multi-layered = {COPY(principles, "Maintain multi-layered security controls and practices, many of which are publicly verifiable.",)}
+""", principles=principles)
+        )


### PR DESCRIPTION
## Description
Updates the contact section of the privacy landing page, and migrates the page to Fluent in the process. 

This also migrates the privacy principles page, which is as far as I got on migrating the entire privacy section before it became clear it was going to take more time than I had.

## Issue / Bugzilla link
#9388 

## Testing
http://localhost:8000/privacy/