### PR TITLE
Send-to-device JS form error when geo lookup times out (Fixes #9617)

### DIFF
--- a/media/js/base/send-to-device.js
+++ b/media/js/base/send-to-device.js
@@ -88,7 +88,9 @@ if (typeof window.Mozilla === 'undefined') {
 
         // should /country-code.json be slow to load,
         // just show the email messaging after 5 seconds waiting.
-        this.formTimeout = setTimeout(self.updateMessaging, 5000);
+        this.formTimeout = setTimeout(function() {
+            self.updateMessaging();
+        }, 5000);
 
         $.get('/country-code.json')
             .done(function(data) {


### PR DESCRIPTION
## Description
Fixes `this.inSupportedCountry is not a function` JS error when geo-location check times out.

## Issue / Bugzilla link
#9617

## Testing
- [x] An easy way to test this locally is to comment out the `$.get` call on line 95 so the timeout triggers.