### PR TITLE
Fix error on /download/thanks/ if 'try again' link is not well formatted (Fixes #9615)

### DIFF
--- a/media/js/firefox/new/common/thanks-init.js
+++ b/media/js/firefox/new/common/thanks-init.js
@@ -13,8 +13,11 @@
         downloadURL = Mozilla.DownloadThanks.getDownloadURL(window.site);
 
         if (downloadURL) {
-            // Pull download link from the download button and add to the 'click here' link.
-            directDownloadLink.href = downloadURL;
+            // Pull download link from the download button and add to the 'Try downloading again' link.
+            // Make sure the 'Try downloading again' link is well formatted! (issue 9615)
+            if (directDownloadLink && directDownloadLink.href) {
+                directDownloadLink.href = downloadURL;
+            }
 
             // Start the platform-detected download a second after DOM ready event.
             // We don't rely on the window load event as we have third-party tracking pixels.


### PR DESCRIPTION
## Description
Ensure a download still happens if prior code encounters an unexpected error introduced in the /thanks page.

## Issue / Bugzilla link
#9615

## Testing
- [x] An easy way to test this locally is to [remove this line](https://github.com/mozilla/bedrock/blob/master/bedrock/firefox/templates/firefox/new/desktop/thanks.html#L38) from the template.