### PR TITLE
update ftl IDs for firefox/quantum [no bug]

### DIFF
--- a/bedrock/firefox/templates/firefox/browsers/quantum.html
+++ b/bedrock/firefox/templates/firefox/browsers/quantum.html
@@ -6,8 +6,8 @@
 
 {% extends "firefox/base/base-protocol.html" %}
 
-{% block page_title %}{{ ftl('page-title') }}{% endblock %}
-{% block page_desc %}{{ ftl('page-description') }}{% endblock %}
+{% block page_title %}{{ ftl('firefox-quantum-page-title') }}{% endblock %}
+{% block page_desc %}{{ ftl('firefox-quantum-page-description') }}{% endblock %}
 
 {% block page_css %}
   {{ css_bundle('quantum') }}
@@ -16,14 +16,14 @@
 {% block content %}
 
 {% call hero(
-  title=ftl('the-latest-firefox'),
+  title=ftl('firefox-quantum-the-latest-firefox'),
   class='mzp-has-image mzp-t-firefox mzp-t-product-firefox',
   image_url='img/firefox/browsers/quantum/browser.jpg',
   include_highres_image=True,
   include_cta=True,
   heading_level=1
 ) %}
-<p>{{ ftl('firefox-quantum-was') }}</p>
+<p>{{ ftl('firefox-quantum-firefox-quantum-was') }}</p>
 {{ download_firefox_thanks() }}
 <p><a class="mzp-c-cta-link" href="https://blog.mozilla.org/blog/2017/11/14/introducing-firefox-quantum/?utm_source=mozilla.org-firefox-browsers-quantum&utm_medium=referral&utm_campaign=seo-quantum&amp;utm_content=hero&amp;entrypoint=mozilla.org-firefox-browsers-quantum">{{ ftl('learn-more-about') }}</a></p>
 {% endcall %}
@@ -32,18 +32,18 @@
   <section class="mzp-c-emphasis-box">
     <ul class="mzp-l-card-third">
       {{ picto_card(
-        title=ftl('privacy-first'),
-        desc=ftl('firefox-doesnt-spy'),
+        title=ftl('firefox-quantum-privacy-first'),
+        desc=ftl('firefox-quantum-firefox-doesnt-spy'),
         class='privacy') }}
 
       {{ picto_card(
-        title=ftl('super-fast'),
-        desc=ftl('get-speed-and'),
+        title=ftl('firefox-quantum-super-fast'),
+        desc=ftl('firefox-quantum-get-speed-and'),
         class='fast') }}
 
       {{ picto_card(
-        title=ftl('always-evolving'),
-        desc=ftl('find-out-about', url=url('firefox.features.index')),
+        title=ftl('firefox-quantum-always-evolving'),
+        desc=ftl('firefox-quantum-find-out-about', url=url('firefox.features.index')),
         class='evolve') }}
     </ul>
   </section>

--- a/l10n/en/firefox/browsers/quantum.ftl
+++ b/l10n/en/firefox/browsers/quantum.ftl
@@ -4,21 +4,27 @@
 
 ### URL: https://www-dev.allizom.org/firefox/browsers/quantum/
 
-page-title= Download { -brand-name-firefox-quantum }
-page-description= { -brand-name-firefox-quantum } was a revolution. In 2017, we created a new, lightning fast browser that constantly improves. { -brand-name-firefox-quantum } is the { -brand-name-firefox-browser }.
+firefox-quantum-page-title= Download { -brand-name-firefox-quantum }
 
-the-latest-firefox = The latest { -brand-name-firefox } engine: { -brand-name-firefox-quantum }
-firefox-quantum-was = { -brand-name-firefox-quantum } was a revolution in { -brand-name-firefox } development. In 2017, we created a new, lightning fast browser that constantly improves. { -brand-name-firefox-quantum } is the { -brand-name-firefox-browser }.
+firefox-quantum-page-description= { -brand-name-firefox-quantum } was a revolution. In 2017, we created a new, lightning fast browser that constantly improves. { -brand-name-firefox-quantum } is the { -brand-name-firefox-browser }.
+
+firefox-quantum-the-latest-firefox = The latest { -brand-name-firefox } engine: { -brand-name-firefox-quantum }
+
+firefox-quantum-firefox-quantum-was = { -brand-name-firefox-quantum } was a revolution in { -brand-name-firefox } development. In 2017, we created a new, lightning fast browser that constantly improves. { -brand-name-firefox-quantum } is the { -brand-name-firefox-browser }.
 
 # https://blog.mozilla.org/blog/2017/11/14/introducing-firefox-quantum/
 learn-more-about = Learn more about { -brand-name-firefox-quantum }
 
-privacy-first = Privacy first
-firefox-doesnt-spy = { -brand-name-firefox } doesn’t spy on you online. We stop many known third-party tracking cookies and give you full control.
-super-fast = Super Fast
-get-speed-and = Get speed and security. { -brand-name-firefox } is fast because we don’t track your moves.
-always-evolving = Always evolving
+firefox-quantum-privacy-first = Privacy first
+
+firefox-quantum-firefox-doesnt-spy = { -brand-name-firefox } doesn’t spy on you online. We stop many known third-party tracking cookies and give you full control.
+
+firefox-quantum-super-fast = Super Fast
+
+firefox-quantum-get-speed-and = Get speed and security. { -brand-name-firefox } is fast because we don’t track your moves.
+
+firefox-quantum-always-evolving = Always evolving
 
 # Variables:
 # $url (url) - link to https://www.mozilla.org/firefox/features
-find-out-about = Find out about all the amazing <a href="{ $url }">{ -brand-name-firefox } features</a>.
+firefox-quantum-find-out-about = Find out about all the amazing <a href="{ $url }">{ -brand-name-firefox } features</a>.


### PR DESCRIPTION
## Description

Updates firefox/quantum fluent strings to have a standardized prefix per https://bedrock.readthedocs.io/en/latest/l10n.html#ftl-string-ids