### PR TITLE
Filter Sentry JS errors to /media/ scripts (#8444) 

### DIFF
--- a/media/js/base/sentry-init.js
+++ b/media/js/base/sentry-init.js
@@ -16,12 +16,11 @@
             window.Sentry.init({
                 dsn: sentryDsn ,
                 sampleRate: 0.10,
-                denyUrls: [
-                    // Chrome extensions
-                    /extensions\//i,
-                    /^chrome:\/\//i,
-                    // Firefox extensions
-                    /^resource:\/\//i
+                ignoreErrors: [
+                    'https://plugin.ucads.ucweb.com/api/flow/'
+                ],
+                allowUrls: [
+                    '/media/js/'
                 ]
             });
         }


### PR DESCRIPTION
## Description
This should hopefully help cut down on a lot of the noise created by external scripts / extensions.

## Issue / Bugzilla link
#8444

## Testing

I pushed an undefined function error to the home page on demo: https://www-demo1.allizom.org/en-US/

Error in Sentry: https://sentry.prod.mozaws.net/operations/bedrock-demos/issues/9190127/