### PR TITLE
Fix ESLint parsing depth (Fixes #9626)

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,1 @@
-media/js/libs/*.js
+media/js/libs/**/*.js

--- a/media/js/firefox/browsers/chromebook.js
+++ b/media/js/firefox/browsers/chromebook.js
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
- (function() {
+(function() {
     'use strict';
 
     window.Mzp.Details.init('.mzp-c-menu-list-title');

--- a/media/js/firefox/campaign/unfck.js
+++ b/media/js/firefox/campaign/unfck.js
@@ -33,15 +33,15 @@
     }
 
     function handleShareLinkClick(e) {
-        var link_href = e.target.href;
+        var linkHref = e.target.href;
         var service = '';
 
-        if(link_href.indexOf('twitter') > -1) {
-            openTwitterSubwin(link_href);
+        if(linkHref.indexOf('twitter') > -1) {
+            openTwitterSubwin(linkHref);
             service = 'twitter';
             e.preventDefault();
-        } else if(link_href.indexOf('facebook') > -1) {
-            openFacebookSubwin(link_href);
+        } else if(linkHref.indexOf('facebook') > -1) {
+            openFacebookSubwin(linkHref);
             service = 'facebook';
             e.preventDefault();
         }
@@ -57,11 +57,11 @@
     function onLoad() {
         // Set up twitter link handler
         var tw = document.getElementById('js-tw');
-        var tw_jack = document.getElementById('js-tw-jack');
+        var twJack = document.getElementById('js-tw-jack');
         var fb = document.getElementById('js-fb');
 
         tw.addEventListener('click', handleShareLinkClick, false);
-        tw_jack.addEventListener('click', handleShareLinkClick, false);
+        twJack.addEventListener('click', handleShareLinkClick, false);
         fb.addEventListener('click', handleShareLinkClick, false);
     }
 

--- a/media/js/firefox/whatsnew/whatsnew-account.js
+++ b/media/js/firefox/whatsnew/whatsnew-account.js
@@ -10,7 +10,6 @@ if (typeof window.Mozilla === 'undefined') {
 (function(Mozilla) {
     'use strict';
 
-    var client = Mozilla.Client;
     var sendTo = document.getElementById('send-to-device');
 
     if (sendTo) {

--- a/package.json
+++ b/package.json
@@ -48,9 +48,9 @@
   },
   "scripts": {
     "start": "concurrently --kill-others \"python manage.py runserver 0.0.0.0:8080\" \"gulp\"",
-    "lint-js": "./node_modules/.bin/eslint media/js/**/*.js tests/unit/spec/**/*.js gulpfile.js",
+    "lint-js": "./node_modules/.bin/eslint \"media/js/**/*.js\" \"tests/unit/spec/**/*.js\" gulpfile.js",
     "lint-css": "./node_modules/.bin/stylelint \"media/css/**/*.{css,scss}\"",
-    "lint-json": "./node_modules/.bin/eslint bedrock/base/templates/includes/structured-data/**/*.json",
+    "lint-json": "./node_modules/.bin/eslint \"bedrock/base/templates/includes/structured-data/**/*.json\"",
     "lint": "npm run lint-js && npm run lint-css && npm run lint-json",
     "pretest": "npm run lint",
     "test": "./node_modules/.bin/karma start ./tests/unit/karma.conf.js"

--- a/tests/unit/spec/firefox/new/common/thanks.js
+++ b/tests/unit/spec/firefox/new/common/thanks.js
@@ -3,8 +3,6 @@
  * Sinon docs: http://sinonjs.org/docs/
  */
 
-/* global sinon */
-
 describe('thanks.js', function() {
     'use strict';
 


### PR DESCRIPTION
## Description
- Fixes ESLint parsing depth (NPM stripts require quotes around Node globs).
- Fixes a few linting errors that have been missed as a result of this bug.

## Issue / Bugzilla link
#9626