### PR TITLE
Add ?automation=true param to functional tests (Fixes #8917)

### DIFF
--- a/docs/abtest.rst
+++ b/docs/abtest.rst
@@ -268,3 +268,10 @@ A/B Test PRs that might have useful code to reuse
 - https://github.com/mozilla/bedrock/pull/5443/files
 - https://github.com/mozilla/bedrock/pull/5492/files
 - https://github.com/mozilla/bedrock/pull/5499/files
+
+Excluding automated tests from experiments
+------------------------------------------
+
+Automated functional tests include a `automation=true` parameter in their URLs. So
+for whichever kind of experimental redirect you're performing, automated tests can
+be excluded from the audience criteria by checking for existance of said parameter.

--- a/tests/functional/firefox/browsers/compare/test_browsers.py
+++ b/tests/functional/firefox/browsers/compare/test_browsers.py
@@ -9,14 +9,28 @@ from pages.firefox.browsers.compare import BrowserComparisonPage
 
 @pytest.mark.nondestructive
 @pytest.mark.parametrize('slug', [
-    ('/chrome/'),
-    ('/edge/'),
-    ('/safari/'),
-    ('/opera/'),
-    ('/brave/'),
-    ('/ie/')])
-def test_download_links_are_displayed(slug, base_url, selenium):
+    ('chrome'),
+    ('edge'),
+    ('safari'),
+    ('opera'),
+    ('brave'),
+    ('ie')])
+def test_menu_list_is_displayed(slug, base_url, selenium):
     page = BrowserComparisonPage(selenium, base_url, slug=slug).open()
     page.browser_menu_list.click()
     assert page.browser_menu_list.list_is_open
+
+
+@pytest.mark.skip_if_firefox(reason='Download button only visible to non-Firefox users')
+@pytest.mark.nondestructive
+@pytest.mark.parametrize('slug', [
+    ('chrome'),
+    ('edge'),
+    ('safari'),
+    ('opera'),
+    ('brave'),
+    ('ie')])
+def test_download_buttons_are_displayed(slug, base_url, selenium):
+    page = BrowserComparisonPage(selenium, base_url, slug=slug).open()
+    assert page.primary_download_button.is_displayed
     assert page.secondary_download_button.is_displayed

--- a/tests/functional/firefox/browsers/compare/test_landing.py
+++ b/tests/functional/firefox/browsers/compare/test_landing.py
@@ -4,12 +4,12 @@
 
 import pytest
 
-from pages.firefox.browsers.compare import BrowserComparisonPage
+from pages.firefox.browsers.compare_landing import BrowserComparisonLandingPage
 
 
 @pytest.mark.smoke
 @pytest.mark.nondestructive
 def test_download_buttons_are_displayed(base_url, selenium):
-    page = BrowserComparisonPage(selenium, base_url, slug='/').open()
+    page = BrowserComparisonLandingPage(selenium, base_url).open()
     assert page.primary_download_button.is_displayed
     assert page.secondary_download_button.is_displayed

--- a/tests/functional/firefox/new/test_download.py
+++ b/tests/functional/firefox/new/test_download.py
@@ -11,7 +11,7 @@ from pages.firefox.new.download import DownloadPage
 @pytest.mark.sanity
 @pytest.mark.nondestructive
 def test_download_button_displayed(base_url, selenium):
-    page = DownloadPage(selenium, base_url, params='').open()
+    page = DownloadPage(selenium, base_url).open()
     assert page.is_download_button_displayed
 
 
@@ -20,7 +20,7 @@ def test_download_button_displayed(base_url, selenium):
 @pytest.mark.skip_if_internet_explorer(reason='https://github.com/SeleniumHQ/selenium/issues/448')
 @pytest.mark.nondestructive
 def test_click_download_button(base_url, selenium):
-    page = DownloadPage(selenium, base_url, params='').open()
+    page = DownloadPage(selenium, base_url).open()
     thank_you_page = page.download_firefox()
     assert thank_you_page.seed_url in selenium.current_url
 
@@ -28,7 +28,7 @@ def test_click_download_button(base_url, selenium):
 @pytest.mark.nondestructive
 @pytest.mark.skip_if_not_firefox(reason='Join Firefox form is only displayed to Firefox users')
 def test_firefox_account_modal(base_url, selenium):
-    page = DownloadPage(selenium, base_url, params='').open()
+    page = DownloadPage(selenium, base_url).open()
     modal = page.open_join_firefox_modal()
     assert modal.is_displayed
     modal.close()

--- a/tests/functional/firefox/test_browsers.py
+++ b/tests/functional/firefox/test_browsers.py
@@ -17,7 +17,7 @@ def test_primary_download_button_displayed(base_url, selenium):
 
 @pytest.mark.nondestructive
 def test_account_form(base_url, selenium):
-    page = FirefoxBrowsersPage(selenium, base_url, params='').open()
+    page = FirefoxBrowsersPage(selenium, base_url).open()
     page.join_firefox_form.type_email('success@example.com')
     page.join_firefox_form.click_continue()
     url = unquote(selenium.current_url)

--- a/tests/functional/firefox/whatsnew/test_whatsnew_79.py
+++ b/tests/functional/firefox/whatsnew/test_whatsnew_79.py
@@ -10,5 +10,5 @@ from pages.firefox.whatsnew.whatsnew_79 import FirefoxWhatsNew79Page
 @pytest.mark.skip_if_not_firefox(reason='Whatsnew pages are shown to Firefox only.')
 @pytest.mark.nondestructive
 def test_default_browser_button_is_displayed(base_url, selenium):
-    page = FirefoxWhatsNew79Page(selenium, base_url, params='').open()
+    page = FirefoxWhatsNew79Page(selenium, base_url).open()
     assert page.is_default_browser_button_displayed

--- a/tests/functional/firefox/whatsnew/test_whatsnew_80.py
+++ b/tests/functional/firefox/whatsnew/test_whatsnew_80.py
@@ -10,7 +10,7 @@ from pages.firefox.whatsnew.whatsnew_80 import FirefoxWhatsNew80Page
 @pytest.mark.skip_if_not_firefox(reason='Whatsnew pages are shown to Firefox only.')
 @pytest.mark.nondestructive
 def test_send_to_device_success(base_url, selenium):
-    page = FirefoxWhatsNew80Page(selenium, base_url, params='').open()
+    page = FirefoxWhatsNew80Page(selenium, base_url).open()
     assert not page.is_qr_code_displayed
     send_to_device = page.send_to_device
     send_to_device.type_email('success@example.com')
@@ -21,7 +21,7 @@ def test_send_to_device_success(base_url, selenium):
 @pytest.mark.skip_if_not_firefox(reason='Whatsnew pages are shown to Firefox only.')
 @pytest.mark.nondestructive
 def test_send_to_device_failure(base_url, selenium):
-    page = FirefoxWhatsNew80Page(selenium, base_url, params='').open()
+    page = FirefoxWhatsNew80Page(selenium, base_url).open()
     send_to_device = page.send_to_device
     send_to_device.type_email('invalid@email')
     send_to_device.click_send(expected_result='error')
@@ -31,5 +31,5 @@ def test_send_to_device_failure(base_url, selenium):
 @pytest.mark.skip_if_not_firefox(reason='Whatsnew pages are shown to Firefox only.')
 @pytest.mark.nondestructive
 def test_get_firefox_qr_code(base_url, selenium):
-    page = FirefoxWhatsNew80Page(selenium, base_url, locale='sv-SE', params='').open()
+    page = FirefoxWhatsNew80Page(selenium, base_url, locale='sv-SE').open()
     assert page.is_qr_code_displayed

--- a/tests/functional/firefox/whatsnew/test_whatsnew_81.py
+++ b/tests/functional/firefox/whatsnew/test_whatsnew_81.py
@@ -10,7 +10,7 @@ from pages.firefox.whatsnew.whatsnew_81 import FirefoxWhatsNew81Page
 @pytest.mark.skip_if_not_firefox(reason='Whatsnew pages are shown to Firefox only.')
 @pytest.mark.nondestructive
 def test_send_to_device_success(base_url, selenium):
-    page = FirefoxWhatsNew81Page(selenium, base_url, params='').open()
+    page = FirefoxWhatsNew81Page(selenium, base_url).open()
     send_to_device = page.send_to_device
     send_to_device.type_email('success@example.com')
     send_to_device.click_send()
@@ -20,7 +20,7 @@ def test_send_to_device_success(base_url, selenium):
 @pytest.mark.skip_if_not_firefox(reason='Whatsnew pages are shown to Firefox only.')
 @pytest.mark.nondestructive
 def test_send_to_device_failure(base_url, selenium):
-    page = FirefoxWhatsNew81Page(selenium, base_url, params='').open()
+    page = FirefoxWhatsNew81Page(selenium, base_url).open()
     send_to_device = page.send_to_device
     send_to_device.type_email('invalid@email')
     send_to_device.click_send(expected_result='error')

--- a/tests/functional/test_contact.py
+++ b/tests/functional/test_contact.py
@@ -16,17 +16,16 @@ def test_tab_navigation(base_url, selenium):
     spaces_page = SpacesPage(selenium, base_url, slug='').open()
     assert not spaces_page.contact_tab.is_selected
     assert spaces_page.spaces_tab.is_selected
-    assert spaces_page.seed_url in selenium.current_url
 
 
 @pytest.mark.nondestructive
 @pytest.mark.parametrize('slug', [
-    ('portland'),
-    ('san-francisco'),
-    ('vancouver')])
+    ('portland/'),
+    ('san-francisco/'),
+    ('vancouver/')])
 def test_spaces_menus(slug, base_url, selenium):
     page = SpacesPage(selenium, base_url, slug=slug).open()
-    space_menu = [s for s in page.spaces if s.id == slug]
+    space_menu = [s for s in page.spaces if s.id in slug]
     assert len(space_menu) == 1
     assert space_menu[0].is_selected
 

--- a/tests/functional/test_lean_data.py
+++ b/tests/functional/test_lean_data.py
@@ -8,8 +8,6 @@ from pages.lean_data import LeanDataPage
 
 
 @pytest.mark.nondestructive
-@pytest.mark.parametrize('slug', [
-    ('/')])
-def test_contact_button_is_displayed(slug, base_url, selenium):
-    page = LeanDataPage(selenium, base_url, slug=slug).open()
+def test_contact_button_is_displayed(base_url, selenium):
+    page = LeanDataPage(selenium, base_url).open()
     assert page.is_contact_button_displayed

--- a/tests/pages/__init__.py
+++ b/tests/pages/__init__.py
@@ -13,4 +13,11 @@ def scroll_element_into_view(self, strategy, locator, x=0, y=0):
     return el
 
 
+def set_attribute(self, el, att_name, att_value):
+    self.selenium.execute_script(
+        'arguments[0].setAttribute(arguments[1], arguments[2]);', el, att_name, att_value)
+    return el
+
+
 WebView.scroll_element_into_view = scroll_element_into_view
+WebView.set_attribute = set_attribute

--- a/tests/pages/about.py
+++ b/tests/pages/about.py
@@ -9,7 +9,7 @@ from pages.base import BasePage
 
 class AboutPage(BasePage):
 
-    URL_TEMPLATE = '/{locale}/about/'
+    _URL_TEMPLATE = '/{locale}/about/'
 
     _read_mission_button_locator = (By.ID, 'read-mission-button')
 

--- a/tests/pages/base.py
+++ b/tests/pages/base.py
@@ -24,8 +24,6 @@ class BaseRegion(ScrollElementIntoView, Region):
 
 class BasePage(ScrollElementIntoView, Page):
 
-    URL_TEMPLATE = '/{locale}/'
-
     def __init__(self, selenium, base_url, locale='en-US', **url_kwargs):
         super(BasePage, self).__init__(selenium, base_url, locale=locale, **url_kwargs)
 
@@ -34,6 +32,13 @@ class BasePage(ScrollElementIntoView, Page):
         el = self.find_element(By.TAG_NAME, 'html')
         self.wait.until(lambda s: 'loaded' in el.get_attribute('class'))
         return self
+
+    @property
+    def URL_TEMPLATE(self):
+        if '?' in self._URL_TEMPLATE:
+            return f'{self._URL_TEMPLATE}&automation=true'
+        else:
+            return f'{self._URL_TEMPLATE}?automation=true'
 
     @property
     def navigation(self):
@@ -91,19 +96,28 @@ class BasePage(ScrollElementIntoView, Page):
 
         def open_firefox_desktop_page(self):
             self.open_navigation_menu(self._firefox_menu_locator)
-            self.find_element(*self._firefox_desktop_page_locator).click()
+            link = self.find_element(*self._firefox_desktop_page_locator)
+            href = link.get_attribute('href')
+            self.page.set_attribute(link, att_name='href', att_value=href + '?automation=true')
+            link.click()
             from .firefox.new.download import DownloadPage
-            return DownloadPage(self.selenium, self.page.base_url, params='').wait_for_page_to_load()
+            return DownloadPage(self.selenium, self.page.base_url).wait_for_page_to_load()
 
         def open_developer_edition_page(self):
             self.open_navigation_menu(self._developers_menu_locator)
-            self.find_element(*self._developer_edition_page_locator).click()
+            link = self.find_element(*self._developer_edition_page_locator)
+            href = link.get_attribute('href')
+            self.page.set_attribute(link, att_name='href', att_value=href + '?automation=true')
+            link.click()
             from .firefox.developer import DeveloperPage
             return DeveloperPage(self.selenium, self.page.base_url).wait_for_page_to_load()
 
         def open_about_page(self):
             self.open_navigation_menu(self._about_menu_locator)
-            self.find_element(*self._about_page_locator).click()
+            link = self.find_element(*self._about_page_locator)
+            href = link.get_attribute('href')
+            self.page.set_attribute(link, att_name='href', att_value=href + '?automation=true')
+            link.click()
             from .about import AboutPage
             return AboutPage(self.selenium, self.page.base_url).wait_for_page_to_load()
 

--- a/tests/pages/contact.py
+++ b/tests/pages/contact.py
@@ -9,7 +9,7 @@ from pages.base import BasePage, BaseRegion
 
 class ContactPage(BasePage):
 
-    URL_TEMPLATE = '/{locale}/contact/'
+    _URL_TEMPLATE = '/{locale}/contact/'
 
     _contact_tab_locator = (By.CSS_SELECTOR, '.category-tabs > li[data-id=contact]')
     _spaces_tab_locator = (By.CSS_SELECTOR, '.category-tabs > li[data-id=spaces]')
@@ -38,7 +38,7 @@ class ContactPage(BasePage):
 
 class SpacesPage(ContactPage):
 
-    URL_TEMPLATE = '/{locale}/contact/spaces/{slug}'
+    _URL_TEMPLATE = '/{locale}/contact/spaces/{slug}'
 
     _map_locator = (By.ID, 'map')
     _nav_locator = (By.CSS_SELECTOR, '#nav-spaces li h4')

--- a/tests/pages/contribute/contribute.py
+++ b/tests/pages/contribute/contribute.py
@@ -7,4 +7,4 @@ from pages.base import BasePage
 
 class ContributePage(BasePage):
 
-    URL_TEMPLATE = '/{locale}/contribute/'
+    _URL_TEMPLATE = '/{locale}/contribute/'

--- a/tests/pages/firefox/accounts.py
+++ b/tests/pages/firefox/accounts.py
@@ -10,7 +10,7 @@ from pages.regions.join_firefox_form import JoinFirefoxForm
 
 class FirefoxAccountsPage(BasePage):
 
-    URL_TEMPLATE = '/{locale}/firefox/accounts/{params}'
+    _URL_TEMPLATE = '/{locale}/firefox/accounts/{params}'
 
     _firefox_monitor_button_locator = (By.CSS_SELECTOR, '.c-accounts-hero-body-signed-in .js-fxa-product-button')
 

--- a/tests/pages/firefox/all.py
+++ b/tests/pages/firefox/all.py
@@ -10,7 +10,7 @@ from pages.base import BasePage, BaseRegion
 
 class FirefoxAllPage(BasePage):
 
-    URL_TEMPLATE = '/{locale}/firefox/all/'
+    _URL_TEMPLATE = '/{locale}/firefox/all/'
 
     _product_locator = (By.ID, 'select-product')
     _product_options_locator = (By.CLASS_NAME, 'c-selection-options')

--- a/tests/pages/firefox/browsers/best_browser.py
+++ b/tests/pages/firefox/browsers/best_browser.py
@@ -10,7 +10,7 @@ from pages.regions.download_button import DownloadButton
 
 class BestBrowserPage(BasePage):
 
-    URL_TEMPLATE = '/{locale}/firefox/browsers/best-browser/'
+    _URL_TEMPLATE = '/{locale}/firefox/browsers/best-browser/'
 
     _download_button_locator = (By.ID, 'safebrowser-hero-download')
 

--- a/tests/pages/firefox/browsers/browser_history.py
+++ b/tests/pages/firefox/browsers/browser_history.py
@@ -10,7 +10,7 @@ from pages.regions.download_button import DownloadButton
 
 class BrowserHistoryPage(BasePage):
 
-    URL_TEMPLATE = '/{locale}/firefox/browsers/browser-history/'
+    _URL_TEMPLATE = '/{locale}/firefox/browsers/browser-history/'
 
     _download_button_locator = (By.ID, 'download-button-desktop-release')
 

--- a/tests/pages/firefox/browsers/compare.py
+++ b/tests/pages/firefox/browsers/compare.py
@@ -11,9 +11,9 @@ from pages.regions.menu_list import MenuList
 
 class BrowserComparisonPage(BasePage):
 
-    URL_TEMPLATE = '/{locale}/firefox/browsers/compare{slug}'
+    _URL_TEMPLATE = '/{locale}/firefox/browsers/compare/{slug}/'
 
-    _primary_download_button_locator = (By.ID, 'compare-hero-download')
+    _primary_download_button_locator = (By.ID, 'download-button-thanks')
     _secondary_download_button_locator = (By.ID, 'download-secondary')
     _browser_menu_list_locator = (By.CSS_SELECTOR, '.mzp-c-menu-list.mzp-t-download')
 

--- a/tests/pages/firefox/browsers/compare_landing.py
+++ b/tests/pages/firefox/browsers/compare_landing.py
@@ -8,12 +8,12 @@ from pages.base import BasePage
 from pages.regions.download_button import DownloadButton
 
 
-class FirefoxPrivacyProductsPage(BasePage):
+class BrowserComparisonLandingPage(BasePage):
 
-    _URL_TEMPLATE = '/{locale}/firefox/privacy/products/'
+    _URL_TEMPLATE = '/{locale}/firefox/browsers/compare/'
 
-    _primary_download_button_locator = (By.ID, 'download-button-primary-non-firefox')
-    _secondary_download_button_locator = (By.ID, 'download-button-secondary-non-firefox')
+    _primary_download_button_locator = (By.ID, 'compare-hero-download')
+    _secondary_download_button_locator = (By.ID, 'download-secondary')
 
     @property
     def primary_download_button(self):

--- a/tests/pages/firefox/browsers/incognito_browser.py
+++ b/tests/pages/firefox/browsers/incognito_browser.py
@@ -10,7 +10,7 @@ from pages.regions.download_button import DownloadButton
 
 class IncognitoBrowserPage(BasePage):
 
-    URL_TEMPLATE = '/{locale}/firefox/browsers/incognito-browser/'
+    _URL_TEMPLATE = '/{locale}/firefox/browsers/incognito-browser/'
 
     _download_button_locator = (By.ID, 'download-button-desktop-release')
 

--- a/tests/pages/firefox/browsers/landing.py
+++ b/tests/pages/firefox/browsers/landing.py
@@ -10,7 +10,7 @@ from pages.regions.join_firefox_form import JoinFirefoxForm
 
 class FirefoxBrowsersPage(BasePage):
 
-    URL_TEMPLATE = '/{locale}/firefox/browsers/'
+    _URL_TEMPLATE = '/{locale}/firefox/browsers/'
 
     _primary_download_button_locator = (By.ID, 'qa-desktop-download')
 

--- a/tests/pages/firefox/browsers/update_browser.py
+++ b/tests/pages/firefox/browsers/update_browser.py
@@ -10,7 +10,7 @@ from pages.regions.download_button import DownloadButton
 
 class UpdateBrowserPage(BasePage):
 
-    URL_TEMPLATE = '/{locale}/firefox/browsers/update-your-browser/'
+    _URL_TEMPLATE = '/{locale}/firefox/browsers/update-your-browser/'
 
     _download_button_locator = (By.ID, 'download-button-desktop-release')
 

--- a/tests/pages/firefox/browsers/what_is_a_browser.py
+++ b/tests/pages/firefox/browsers/what_is_a_browser.py
@@ -10,7 +10,7 @@ from pages.regions.download_button import DownloadButton
 
 class WhatIsABrowserPage(BasePage):
 
-    URL_TEMPLATE = '/{locale}/firefox/browsers/what-is-a-browser/'
+    _URL_TEMPLATE = '/{locale}/firefox/browsers/what-is-a-browser/'
 
     _download_button_locator = (By.ID, 'download-button-desktop-release')
 

--- a/tests/pages/firefox/browsers/windows_64_bit.py
+++ b/tests/pages/firefox/browsers/windows_64_bit.py
@@ -10,7 +10,7 @@ from pages.regions.download_button import DownloadButton
 
 class Windows64BitPage(BasePage):
 
-    URL_TEMPLATE = '/{locale}/firefox/browsers/windows-64-bit/'
+    _URL_TEMPLATE = '/{locale}/firefox/browsers/windows-64-bit/'
 
     _download_button_locator = (By.ID, 'win64-hero-download')
 

--- a/tests/pages/firefox/channel/android.py
+++ b/tests/pages/firefox/channel/android.py
@@ -10,7 +10,7 @@ from pages.regions.download_button import DownloadButton
 
 class ChannelAndroidPage(BasePage):
 
-    URL_TEMPLATE = '/{locale}/firefox/channel/android/'
+    _URL_TEMPLATE = '/{locale}/firefox/channel/android/'
 
     _beta_download_locator = (By.ID, 'android-beta-download')
     _nightly_download_locator = (By.ID, 'android-nightly-download')

--- a/tests/pages/firefox/channel/desktop.py
+++ b/tests/pages/firefox/channel/desktop.py
@@ -10,7 +10,7 @@ from pages.regions.download_button import DownloadButton
 
 class ChannelDesktopPage(BasePage):
 
-    URL_TEMPLATE = '/{locale}/firefox/channel/desktop/'
+    _URL_TEMPLATE = '/{locale}/firefox/channel/desktop/'
 
     _beta_download_locator = (By.ID, 'desktop-beta-download')
     _developer_download_locator = (By.ID, 'desktop-developer-download')

--- a/tests/pages/firefox/channel/ios.py
+++ b/tests/pages/firefox/channel/ios.py
@@ -9,7 +9,7 @@ from pages.base import BasePage
 
 class ChannelIOSPage(BasePage):
 
-    URL_TEMPLATE = '/{locale}/firefox/channel/ios/'
+    _URL_TEMPLATE = '/{locale}/firefox/channel/ios/'
 
     _testflight_button_locator = (By.CLASS_NAME, 'testflight-cta')
 

--- a/tests/pages/firefox/developer.py
+++ b/tests/pages/firefox/developer.py
@@ -10,7 +10,7 @@ from pages.regions.download_button import DownloadButton
 
 class DeveloperPage(BasePage):
 
-    URL_TEMPLATE = '/{locale}/firefox/developer/'
+    _URL_TEMPLATE = '/{locale}/firefox/developer/'
 
     _primary_download_locator = (By.ID, 'intro-download')
     _secondary_download_locator = (By.ID, 'footer-download')

--- a/tests/pages/firefox/enterprise/landing.py
+++ b/tests/pages/firefox/enterprise/landing.py
@@ -10,7 +10,7 @@ from pages.regions.menu_list import MenuList
 
 class EnterprisePage(BasePage):
 
-    URL_TEMPLATE = '/{locale}/firefox/enterprise/'
+    _URL_TEMPLATE = '/{locale}/firefox/enterprise/'
 
     _primary_download_button_locator = (By.ID, 'primary-download-button')
     _win64_download_list_locator = (By.ID, 'win64-download-list')

--- a/tests/pages/firefox/facebook_container.py
+++ b/tests/pages/firefox/facebook_container.py
@@ -10,7 +10,7 @@ from pages.regions.download_button import DownloadButton
 
 class FacebookContainerPage(BasePage):
 
-    URL_TEMPLATE = '/{locale}/firefox/facebookcontainer/'
+    _URL_TEMPLATE = '/{locale}/firefox/facebookcontainer/'
 
     _facebook_container_link_locator = (By.CLASS_NAME, 'extension-cta')
     _firefox_download_button_locator = (By.ID, 'download-firefox-cta')

--- a/tests/pages/firefox/features/adblocker.py
+++ b/tests/pages/firefox/features/adblocker.py
@@ -10,7 +10,7 @@ from pages.regions.download_button import DownloadButton
 
 class FeatureAdblockerPage(BasePage):
 
-    URL_TEMPLATE = '/{locale}/firefox/features/adblocker/'
+    _URL_TEMPLATE = '/{locale}/firefox/features/adblocker/'
 
     _download_button_locator = (By.ID, 'download-button-desktop-release')
 

--- a/tests/pages/firefox/features/feature.py
+++ b/tests/pages/firefox/features/feature.py
@@ -10,7 +10,7 @@ from pages.regions.download_button import DownloadButton
 
 class FeaturePage(BasePage):
 
-    URL_TEMPLATE = '/{locale}/firefox/features/{slug}/'
+    _URL_TEMPLATE = '/{locale}/firefox/features/{slug}/'
 
     _download_button_locator = (By.ID, 'features-header-download')
 

--- a/tests/pages/firefox/features/landing.py
+++ b/tests/pages/firefox/features/landing.py
@@ -10,7 +10,7 @@ from pages.regions.download_button import DownloadButton
 
 class FeaturesLandingPage(BasePage):
 
-    URL_TEMPLATE = '/{locale}/firefox/features/'
+    _URL_TEMPLATE = '/{locale}/firefox/features/'
 
     _download_button_locator = (By.ID, 'features-header-download')
 

--- a/tests/pages/firefox/firstrun.py
+++ b/tests/pages/firefox/firstrun.py
@@ -8,7 +8,7 @@ from pages.regions.join_firefox_form import JoinFirefoxForm
 
 class FirefoxFirstrunPage(BasePage):
 
-    URL_TEMPLATE = '/{locale}/firefox/firstrun/'
+    _URL_TEMPLATE = '/{locale}/firefox/firstrun/'
 
     @property
     def join_firefox_form(self):

--- a/tests/pages/firefox/home.py
+++ b/tests/pages/firefox/home.py
@@ -10,7 +10,7 @@ from pages.regions.menu_list import MenuList
 
 class FirefoxHomePage(BasePage):
 
-    URL_TEMPLATE = '/{locale}/firefox/'
+    _URL_TEMPLATE = '/{locale}/firefox/'
 
     # browser download menu list
     _browser_menu_list_locator = (By.ID, 'test-menu-browsers-wrapper')

--- a/tests/pages/firefox/installer_help.py
+++ b/tests/pages/firefox/installer_help.py
@@ -10,7 +10,7 @@ from pages.regions.download_button import DownloadButton
 
 class InstallerHelpPage(BasePage):
 
-    URL_TEMPLATE = '/{locale}/firefox/installer-help/'
+    _URL_TEMPLATE = '/{locale}/firefox/installer-help/'
 
     _firefox_download_button_locator = (By.ID, 'download-button-desktop-release')
     _beta_download_button_locator = (By.ID, 'download-button-desktop-beta')

--- a/tests/pages/firefox/ios_testflight.py
+++ b/tests/pages/firefox/ios_testflight.py
@@ -10,7 +10,7 @@ from pages.base import BasePage
 
 class iOSTestFlightPage(BasePage):
 
-    URL_TEMPLATE = '/{locale}/firefox/ios/testflight/'
+    _URL_TEMPLATE = '/{locale}/firefox/ios/testflight/'
 
     _email_locator = (By.ID, 'id_email')
     _html_format_locator = (By.ID, 'format-html')

--- a/tests/pages/firefox/lockwise.py
+++ b/tests/pages/firefox/lockwise.py
@@ -10,7 +10,7 @@ from pages.regions.download_button import DownloadButton
 
 class LockwisePage(BasePage):
 
-    URL_TEMPLATE = '/{locale}/firefox/lockwise/'
+    _URL_TEMPLATE = '/{locale}/firefox/lockwise/'
 
     _app_store_button_locator = (By.CSS_SELECTOR, '.mobile-download-buttons > a[data-cta-text="apple-app-store"]')
     _play_store_button_locator = (By.CSS_SELECTOR, '.mobile-download-buttons > a[data-cta-text="google-play-store"]')

--- a/tests/pages/firefox/mobile.py
+++ b/tests/pages/firefox/mobile.py
@@ -10,7 +10,7 @@ from pages.regions.send_to_device import SendToDevice
 
 class FirefoxMobilePage(BasePage):
 
-    URL_TEMPLATE = '/{locale}/firefox/mobile/'
+    _URL_TEMPLATE = '/{locale}/firefox/mobile/'
 
     _get_firefox_header_button_locator = (By.ID, 'get-firefox')
     _get_firefox_qr_code_locator = (By.ID, 'firefox-qr')

--- a/tests/pages/firefox/mobile_get_app.py
+++ b/tests/pages/firefox/mobile_get_app.py
@@ -10,7 +10,7 @@ from pages.regions.send_to_device import SendToDevice
 
 class FirefoxMobileGetAppPage(BasePage):
 
-    URL_TEMPLATE = '/{locale}/firefox/mobile/get-app/'
+    _URL_TEMPLATE = '/{locale}/firefox/mobile/get-app/'
 
     _get_firefox_qr_code_locator = (By.ID, 'firefox-qr')
 

--- a/tests/pages/firefox/new/download.py
+++ b/tests/pages/firefox/new/download.py
@@ -10,7 +10,7 @@ from pages.regions.modal import ModalProtocol
 
 class DownloadPage(BasePage):
 
-    URL_TEMPLATE = '/{locale}/firefox/new/{params}'
+    _URL_TEMPLATE = '/{locale}/firefox/new/'
 
     _download_button_locator = (By.CSS_SELECTOR, '#download-button-thanks > .download-link')
     _platforms_modal_link_locator = (By.CLASS_NAME, 'js-platform-modal-button')
@@ -22,7 +22,10 @@ class DownloadPage(BasePage):
         return self.is_element_displayed(*self._download_button_locator)
 
     def download_firefox(self):
-        self.find_element(*self._download_button_locator).click()
+        link = self.find_element(*self._download_button_locator)
+        href = link.get_attribute('href')
+        self.set_attribute(link, att_name='href', att_value=href + '?automation=true')
+        link.click()
         from pages.firefox.new.thank_you import ThankYouPage
         return ThankYouPage(self.selenium, self.base_url).wait_for_page_to_load()
 

--- a/tests/pages/firefox/new/download_yandex.py
+++ b/tests/pages/firefox/new/download_yandex.py
@@ -11,7 +11,7 @@ from pages.regions.modal import ModalProtocol
 
 class YandexDownloadPage(BasePage):
 
-    URL_TEMPLATE = '/{locale}/firefox/new/{params}'
+    _URL_TEMPLATE = '/{locale}/firefox/new/{params}'
 
     _download_button_locator = (By.ID, 'download-button-desktop-release')
     _platforms_modal_link_locator = (By.CLASS_NAME, 'js-platform-modal-button')

--- a/tests/pages/firefox/new/platform.py
+++ b/tests/pages/firefox/new/platform.py
@@ -11,7 +11,7 @@ from pages.regions.modal import ModalProtocol
 
 class PlatformDownloadPage(BasePage):
 
-    URL_TEMPLATE = '/{locale}/firefox/{slug}/'
+    _URL_TEMPLATE = '/{locale}/firefox/{slug}/'
 
     _download_button_locator = (By.ID, 'download-button-desktop-release')
     _platforms_modal_link_locator = (By.CLASS_NAME, 'js-platform-modal-button')
@@ -23,6 +23,8 @@ class PlatformDownloadPage(BasePage):
         return DownloadButton(self, root=el)
 
     def download_firefox(self):
+        href = self.download_button.platform_link.get_attribute('href')
+        self.set_attribute(self.download_button.platform_link, att_name='href', att_value=href + '?automation=true')
         self.download_button.click()
         from pages.firefox.new.thank_you import ThankYouPage
         return ThankYouPage(self.selenium, self.base_url).wait_for_page_to_load()

--- a/tests/pages/firefox/new/thank_you.py
+++ b/tests/pages/firefox/new/thank_you.py
@@ -9,7 +9,7 @@ from pages.base import BasePage
 
 class ThankYouPage(BasePage):
 
-    URL_TEMPLATE = '/{locale}/firefox/download/thanks/'
+    _URL_TEMPLATE = '/{locale}/firefox/download/thanks/'
 
     _direct_download_link_locator = (By.ID, 'direct-download-link')
 

--- a/tests/pages/firefox/nightly.py
+++ b/tests/pages/firefox/nightly.py
@@ -9,7 +9,7 @@ from pages.base import BasePage
 
 class FirstRunPage(BasePage):
 
-    URL_TEMPLATE = '/{locale}/firefox/nightly/firstrun/'
+    _URL_TEMPLATE = '/{locale}/firefox/nightly/firstrun/'
 
     _start_testing_locator = (By.CSS_SELECTOR, '.contribute .test .mzp-c-button')
     _start_coding_locator = (By.CSS_SELECTOR, '.contribute .code .mzp-c-button')

--- a/tests/pages/firefox/pocket.py
+++ b/tests/pages/firefox/pocket.py
@@ -9,7 +9,7 @@ from pages.base import BasePage
 
 class FirefoxPocketPage(BasePage):
 
-    URL_TEMPLATE = '/{locale}/firefox/pocket/'
+    _URL_TEMPLATE = '/{locale}/firefox/pocket/'
 
     _pocket_primary_button_locator = (By.CSS_SELECTOR, '#pocket-hero .js-fxa-product-button')
     _pocket_secondary_button_locator = (By.CSS_SELECTOR, '#pocket-sidekick .js-fxa-product-button')

--- a/tests/pages/firefox/products.py
+++ b/tests/pages/firefox/products.py
@@ -10,7 +10,7 @@ from pages.regions.join_firefox_form import JoinFirefoxForm
 
 class FirefoxProductsPage(BasePage):
 
-    URL_TEMPLATE = '/{locale}/firefox/products/'
+    _URL_TEMPLATE = '/{locale}/firefox/products/'
 
     _monitor_button_locator = (By.CSS_SELECTOR, '#qa-monitor-button-wrapper a.js-fxa-product-button')
 

--- a/tests/pages/firefox/releasenotes.py
+++ b/tests/pages/firefox/releasenotes.py
@@ -10,7 +10,7 @@ from pages.regions.download_button import DownloadButton
 
 class FirefoxReleaseNotesPage(BasePage):
 
-    URL_TEMPLATE = '/{locale}/firefox/{slug}/releasenotes/'
+    _URL_TEMPLATE = '/{locale}/firefox/{slug}/releasenotes/'
 
     _primary_download_button_release_locator = (By.ID, 'download-release-primary')
     _secondary_download_button_release_locator = (By.ID, 'download-release-secondary')

--- a/tests/pages/firefox/set_as_default/landing.py
+++ b/tests/pages/firefox/set_as_default/landing.py
@@ -9,7 +9,7 @@ from pages.base import BasePage
 
 class DefaultLandingPage(BasePage):
 
-    URL_TEMPLATE = '/{locale}/firefox/set-as-default/'
+    _URL_TEMPLATE = '/{locale}/firefox/set-as-default/'
 
     _set_default_button_locator = (By.ID, 'set-as-default-button')
 

--- a/tests/pages/firefox/set_as_default/thanks.py
+++ b/tests/pages/firefox/set_as_default/thanks.py
@@ -10,7 +10,7 @@ from pages.regions.download_button import DownloadButton
 
 class DefaultThanksPage(BasePage):
 
-    URL_TEMPLATE = '/{locale}/firefox/set-as-default/thanks/'
+    _URL_TEMPLATE = '/{locale}/firefox/set-as-default/thanks/'
 
     _download_button_locator = (By.ID, 'download-button-desktop-release')
 

--- a/tests/pages/firefox/switch.py
+++ b/tests/pages/firefox/switch.py
@@ -10,7 +10,7 @@ from pages.regions.download_button import DownloadButton
 
 class FirefoxSwitchPage(BasePage):
 
-    URL_TEMPLATE = '/{locale}/firefox/switch/'
+    _URL_TEMPLATE = '/{locale}/firefox/switch/'
 
     _download_button_locator = (By.ID, 'download-button-desktop-release')
 

--- a/tests/pages/firefox/unfck.py
+++ b/tests/pages/firefox/unfck.py
@@ -10,7 +10,7 @@ from pages.regions.download_button import DownloadButton
 
 class FirefoxUnfckPage(BasePage):
 
-    URL_TEMPLATE = '/{locale}/firefox/unfck/'
+    _URL_TEMPLATE = '/{locale}/firefox/unfck/'
 
     _download_button_locator = (By.ID, 'download-button-desktop-release')
     _play_store_button_locator = (By.ID, 'playStoreLink')

--- a/tests/pages/firefox/welcome/page1.py
+++ b/tests/pages/firefox/welcome/page1.py
@@ -9,7 +9,7 @@ from pages.base import BasePage
 
 class FirefoxWelcomePage1(BasePage):
 
-    URL_TEMPLATE = '/{locale}/firefox/welcome/1/'
+    _URL_TEMPLATE = '/{locale}/firefox/welcome/1/'
 
     _monitor_primary_button_locator = (By.CSS_SELECTOR, '.primary-cta .js-fxa-product-button')
     _monitor_secondary_button_locator = (By.CSS_SELECTOR, '.secondary-cta .js-fxa-product-button')

--- a/tests/pages/firefox/welcome/page2.py
+++ b/tests/pages/firefox/welcome/page2.py
@@ -9,7 +9,7 @@ from pages.base import BasePage
 
 class FirefoxWelcomePage2(BasePage):
 
-    URL_TEMPLATE = '/{locale}/firefox/welcome/2/'
+    _URL_TEMPLATE = '/{locale}/firefox/welcome/2/'
 
     _pocket_primary_button_locator = (By.CSS_SELECTOR, '.primary-cta .js-fxa-product-button')
     _pocket_secondary_button_locator = (By.CSS_SELECTOR, '.secondary-cta .js-fxa-product-button')

--- a/tests/pages/firefox/welcome/page3.py
+++ b/tests/pages/firefox/welcome/page3.py
@@ -9,7 +9,7 @@ from pages.base import BasePage
 
 class FirefoxWelcomePage3(BasePage):
 
-    URL_TEMPLATE = '/{locale}/firefox/welcome/3/'
+    _URL_TEMPLATE = '/{locale}/firefox/welcome/3/'
 
     _fxa_primary_button_locator = (By.CSS_SELECTOR, '.primary-cta .js-fxa-product-button')
     _fxa_secondary_button_locator = (By.CSS_SELECTOR, '.secondary-cta .js-fxa-product-button')

--- a/tests/pages/firefox/welcome/page4.py
+++ b/tests/pages/firefox/welcome/page4.py
@@ -10,7 +10,7 @@ from pages.regions.send_to_device import SendToDevice
 
 class FirefoxWelcomePage4(BasePage):
 
-    URL_TEMPLATE = '/{locale}/firefox/welcome/4/'
+    _URL_TEMPLATE = '/{locale}/firefox/welcome/4/'
 
     _get_firefox_qr_code_locator = (By.ID, 'firefox-qr')
 

--- a/tests/pages/firefox/welcome/page5.py
+++ b/tests/pages/firefox/welcome/page5.py
@@ -11,7 +11,7 @@ from pages.regions.send_to_device import SendToDevice
 
 class FirefoxWelcomePage5(BasePage):
 
-    URL_TEMPLATE = '/{locale}/firefox/welcome/5/'
+    _URL_TEMPLATE = '/{locale}/firefox/welcome/5/'
 
     _modal_primary_button_locator = (By.CSS_SELECTOR, '.primary-cta .js-modal-link')
     _modal_secondary_button_locator = (By.CSS_SELECTOR, '.secondary-cta .js-modal-link')

--- a/tests/pages/firefox/welcome/page6.py
+++ b/tests/pages/firefox/welcome/page6.py
@@ -11,7 +11,7 @@ from pages.regions.send_to_device import SendToDevice
 
 class FirefoxWelcomePage6(BasePage):
 
-    URL_TEMPLATE = '/{locale}/firefox/welcome/6/{params}'
+    _URL_TEMPLATE = '/{locale}/firefox/welcome/6/{params}'
 
     _set_default_button_locator = (By.ID, 'set-as-default-button')
     _modal_button_locator = (By.CSS_SELECTOR, '.primary-cta .js-modal-link')

--- a/tests/pages/firefox/welcome/page7.py
+++ b/tests/pages/firefox/welcome/page7.py
@@ -9,7 +9,7 @@ from pages.base import BasePage
 
 class FirefoxWelcomePage7(BasePage):
 
-    URL_TEMPLATE = '/{locale}/firefox/welcome/7/'
+    _URL_TEMPLATE = '/{locale}/firefox/welcome/7/'
 
     _facebook_container_button_locator = (By.ID, 'facebook-container-button')
 

--- a/tests/pages/firefox/welcome/page8.py
+++ b/tests/pages/firefox/welcome/page8.py
@@ -9,7 +9,7 @@ from pages.base import BasePage
 
 class FirefoxWelcomePage8(BasePage):
 
-    URL_TEMPLATE = '/{locale}/firefox/welcome/8/'
+    _URL_TEMPLATE = '/{locale}/firefox/welcome/8/'
 
     _protection_report_button_locator = (By.CSS_SELECTOR, '.primary-cta .mzp-c-button')
 

--- a/tests/pages/firefox/whatsnew/whatsnew.py
+++ b/tests/pages/firefox/whatsnew/whatsnew.py
@@ -10,7 +10,7 @@ from pages.regions.send_to_device import SendToDevice
 
 class FirefoxWhatsNewPage(BasePage):
 
-    URL_TEMPLATE = '/{locale}/firefox/whatsnew/all/'
+    _URL_TEMPLATE = '/{locale}/firefox/whatsnew/all/'
 
     _qr_code_locator = (By.CSS_SELECTOR, '.qr-code img')
 

--- a/tests/pages/firefox/whatsnew/whatsnew_60.py
+++ b/tests/pages/firefox/whatsnew/whatsnew_60.py
@@ -10,7 +10,7 @@ from pages.regions.send_to_device import SendToDevice
 
 class FirefoxWhatsNew60Page(BasePage):
 
-    URL_TEMPLATE = '/{locale}/firefox/60.0/whatsnew/all/{params}'
+    _URL_TEMPLATE = '/{locale}/firefox/60.0/whatsnew/all/{params}'
 
     _account_button_locator = (By.CSS_SELECTOR, '.wnp-content-main .js-fxa-product-button')
     _qr_code_locator = (By.CSS_SELECTOR, '#qr-wrapper img')

--- a/tests/pages/firefox/whatsnew/whatsnew_79.py
+++ b/tests/pages/firefox/whatsnew/whatsnew_79.py
@@ -9,7 +9,7 @@ from pages.base import BasePage
 
 class FirefoxWhatsNew79Page(BasePage):
 
-    URL_TEMPLATE = '/{locale}/firefox/79.0/whatsnew/all/{params}'
+    _URL_TEMPLATE = '/{locale}/firefox/79.0/whatsnew/all/'
 
     _set_default_button_locator = (By.ID, 'set-as-default-button')
 

--- a/tests/pages/firefox/whatsnew/whatsnew_80.py
+++ b/tests/pages/firefox/whatsnew/whatsnew_80.py
@@ -10,7 +10,7 @@ from pages.regions.send_to_device import SendToDevice
 
 class FirefoxWhatsNew80Page(BasePage):
 
-    URL_TEMPLATE = '/{locale}/firefox/80.0/whatsnew/all/{params}'
+    _URL_TEMPLATE = '/{locale}/firefox/80.0/whatsnew/all/'
 
     _qr_code_locator = (By.CSS_SELECTOR, '#firefox-qr')
 

--- a/tests/pages/firefox/whatsnew/whatsnew_81.py
+++ b/tests/pages/firefox/whatsnew/whatsnew_81.py
@@ -9,7 +9,7 @@ from pages.regions.send_to_device import SendToDevice
 
 class FirefoxWhatsNew81Page(BasePage):
 
-    URL_TEMPLATE = '/{locale}/firefox/81.0/whatsnew/all/{params}'
+    _URL_TEMPLATE = '/{locale}/firefox/81.0/whatsnew/all/'
 
     @property
     def send_to_device(self):

--- a/tests/pages/firefox/whatsnew/whatsnew_africa.py
+++ b/tests/pages/firefox/whatsnew/whatsnew_africa.py
@@ -9,7 +9,7 @@ from pages.base import BasePage
 
 class FirefoxWhatsNewAfricaPage(BasePage):
 
-    URL_TEMPLATE = '/{locale}/firefox/79.0/whatsnew/africa/'
+    _URL_TEMPLATE = '/{locale}/firefox/79.0/whatsnew/africa/'
 
     _qr_code_locator = (By.CSS_SELECTOR, '.lite-qrcode-container > img')
 

--- a/tests/pages/firefox/whatsnew/whatsnew_developer_70.py
+++ b/tests/pages/firefox/whatsnew/whatsnew_developer_70.py
@@ -10,7 +10,7 @@ from pages.regions.download_button import DownloadButton
 
 class FirefoxWhatsNewDeveloper70Page(BasePage):
 
-    URL_TEMPLATE = '/{locale}/firefox/70.0a2/whatsnew/all/'
+    _URL_TEMPLATE = '/{locale}/firefox/70.0a2/whatsnew/all/'
 
     _nightly_download_button_locator = (By.ID, 'footer-download')
 

--- a/tests/pages/firefox/whatsnew/whatsnew_india.py
+++ b/tests/pages/firefox/whatsnew/whatsnew_india.py
@@ -9,7 +9,7 @@ from pages.base import BasePage
 
 class FirefoxWhatsNewIndiaPage(BasePage):
 
-    URL_TEMPLATE = '/{locale}/firefox/79.0/whatsnew/india/'
+    _URL_TEMPLATE = '/{locale}/firefox/79.0/whatsnew/india/'
 
     _qr_code_locator = (By.CSS_SELECTOR, '.lite-qrcode-container > img')
 

--- a/tests/pages/firefox/whatsnew/whatsnew_nightly_70.py
+++ b/tests/pages/firefox/whatsnew/whatsnew_nightly_70.py
@@ -9,7 +9,7 @@ from pages.base import BasePage
 
 class FirefoxWhatsNewNightly70Page(BasePage):
 
-    URL_TEMPLATE = '/{locale}/firefox/70.0a1/whatsnew/all/'
+    _URL_TEMPLATE = '/{locale}/firefox/70.0a1/whatsnew/all/'
 
     _upgrade_message_locator = (By.CSS_SELECTOR, '.content-wrapper .c-emphasis-box-title')
 

--- a/tests/pages/home.py
+++ b/tests/pages/home.py
@@ -9,6 +9,8 @@ from pages.base import BasePage
 
 class HomePage(BasePage):
 
+    _URL_TEMPLATE = '/{locale}/'
+
     _privacy_hero_button_locator = (By.CSS_SELECTOR, '.privacy-promise-hero .mzp-c-button')
     _rest_of_world_download_button_locator = (By.CSS_SELECTOR, '#download-intro > .download-link')  # legacy home page
     _primary_download_button_locator = (By.CSS_SELECTOR, '#download-primary > .download-link')

--- a/tests/pages/leadership.py
+++ b/tests/pages/leadership.py
@@ -10,7 +10,7 @@ from pages.regions.modal import ModalProtocol
 
 class LeadershipPage(BasePage):
 
-    URL_TEMPLATE = '/{locale}/about/leadership/'
+    _URL_TEMPLATE = '/{locale}/about/leadership/'
 
     _corporation_bios_locator = (By.CSS_SELECTOR, '.gallery.mgmt-corp .vcard.has-bio')
     _foundation_bios_locator = (By.CSS_SELECTOR, '.gallery.mgmt-foundation .vcard.has-bio')

--- a/tests/pages/lean_data.py
+++ b/tests/pages/lean_data.py
@@ -9,7 +9,7 @@ from pages.base import BasePage
 
 class LeanDataPage(BasePage):
 
-    URL_TEMPLATE = '/{locale}/about/policy/lean-data{slug}'
+    _URL_TEMPLATE = '/{locale}/about/policy/lean-data/'
 
     _contact_button_locator = (By.ID, 'contact-button')
 

--- a/tests/pages/locales.py
+++ b/tests/pages/locales.py
@@ -9,7 +9,7 @@ from pages.base import BasePage
 
 class LocalesPage(BasePage):
 
-    URL_TEMPLATE = '/locales/'
+    _URL_TEMPLATE = '/locales/'
 
     _america_locales_locator = (By.CSS_SELECTOR, '#america ul > li > a')
     _asia_pacific_locales_locator = (By.CSS_SELECTOR, '#asia-pacific ul > li > a')

--- a/tests/pages/manifesto.py
+++ b/tests/pages/manifesto.py
@@ -9,7 +9,7 @@ from pages.base import BasePage
 
 class ManifestoPage(BasePage):
 
-    URL_TEMPLATE = '/{locale}/about/manifesto/'
+    _URL_TEMPLATE = '/{locale}/about/manifesto/'
 
     _primary_share_button_locator = (By.CSS_SELECTOR, '.share-addendum .js-manifesto-share')
     _secondary_share_button_locator = (By.CSS_SELECTOR, '.principles-foot .js-manifesto-share')

--- a/tests/pages/mission.py
+++ b/tests/pages/mission.py
@@ -7,4 +7,4 @@ from pages.base import BasePage
 
 class MissionPage(BasePage):
 
-    URL_TEMPLATE = '/{locale}/mission/'
+    _URL_TEMPLATE = '/{locale}/mission/'

--- a/tests/pages/newsletter/base.py
+++ b/tests/pages/newsletter/base.py
@@ -11,7 +11,7 @@ from pages.base import BasePage
 
 class NewsletterBasePage(BasePage):
 
-    URL_TEMPLATE = '/{locale}/newsletter/'
+    _URL_TEMPLATE = '/{locale}/newsletter/'
 
     _email_locator = (By.ID, 'id_email')
     _country_locator = (By.ID, 'id_country')

--- a/tests/pages/newsletter/developer.py
+++ b/tests/pages/newsletter/developer.py
@@ -7,4 +7,4 @@ from pages.newsletter.base import NewsletterBasePage
 
 class DeveloperNewsletterPage(NewsletterBasePage):
 
-    URL_TEMPLATE = '/{locale}/newsletter/developer/'
+    _URL_TEMPLATE = '/{locale}/newsletter/developer/'

--- a/tests/pages/newsletter/firefox.py
+++ b/tests/pages/newsletter/firefox.py
@@ -7,4 +7,4 @@ from pages.newsletter.base import NewsletterBasePage
 
 class FirefoxNewsletterPage(NewsletterBasePage):
 
-    URL_TEMPLATE = '/{locale}/newsletter/firefox/'
+    _URL_TEMPLATE = '/{locale}/newsletter/firefox/'

--- a/tests/pages/newsletter/mozilla.py
+++ b/tests/pages/newsletter/mozilla.py
@@ -7,4 +7,4 @@ from pages.newsletter.base import NewsletterBasePage
 
 class MozillaNewsletterPage(NewsletterBasePage):
 
-    URL_TEMPLATE = '/{locale}/newsletter/mozilla/'
+    _URL_TEMPLATE = '/{locale}/newsletter/mozilla/'

--- a/tests/pages/not_found.py
+++ b/tests/pages/not_found.py
@@ -8,7 +8,8 @@ from pages.base import BasePage
 
 class NotFoundPage(BasePage):
 
-    URL_TEMPLATE = '/{locale}/404/'
+    _URL_TEMPLATE = '/{locale}/404/'
+
     _go_back_button_locator = (By.ID, 'go-back')
 
     @property

--- a/tests/pages/regions/download_button.py
+++ b/tests/pages/regions/download_button.py
@@ -12,7 +12,7 @@ class DownloadButton(BaseRegion):
     _download_link_locator = (By.CSS_SELECTOR, '.download-link')
 
     @property
-    def _platform_link(self):
+    def platform_link(self):
         els = [el for el in self.find_elements(*self._download_link_locator)
                if el.is_displayed()]
         assert len(els) == 1, 'Expected one platform link to be displayed'
@@ -20,11 +20,11 @@ class DownloadButton(BaseRegion):
 
     @property
     def is_displayed(self):
-        return self.root.is_displayed() and self._platform_link.is_displayed() or False
+        return self.root.is_displayed() and self.platform_link.is_displayed() or False
 
     @property
     def is_transitional_link(self):
-        return '/firefox/download/thanks/' in self._platform_link.get_attribute('href')
+        return '/firefox/download/thanks/' in self.platform_link.get_attribute('href')
 
     def click(self):
-        self._platform_link.click()
+        self.platform_link.click()

--- a/tests/pages/regions/join_firefox_form.py
+++ b/tests/pages/regions/join_firefox_form.py
@@ -18,6 +18,10 @@ class JoinFirefoxForm(BaseRegion):
         return self.page.is_element_displayed(*self._root_locator)
 
     @property
+    def is_enabled(self):
+        return self.find_element(*self._continue_button_locator).is_enabled()
+
+    @property
     def email(self):
         el = self.find_element(*self._email_locator)
         return el.get_attribute('value')
@@ -26,5 +30,6 @@ class JoinFirefoxForm(BaseRegion):
         self.find_element(*self._email_locator).send_keys(value)
 
     def click_continue(self):
+        self.wait.until(lambda s: self.is_enabled)
         self.find_element(*self._continue_button_locator).click()
         self.wait.until(lambda s: '?action=email' in s.current_url)


### PR DESCRIPTION
## Description
- Adds `automation=true` param to functional tests so we can exclude those sessions from experimentation (see https://github.com/mozilla/bedrock/pull/9622)

## Issue / Bugzilla link
#8917

## Testing
Successful test run: https://gitlab.com/mozmeao/www-config/-/pipelines/211599010