### PR TITLE
Add JIRA to eligible websites

### DIFF
--- a/bedrock/security/templates/security/bug-bounty/web-eligible-sites.html
+++ b/bedrock/security/templates/security/bug-bounty/web-eligible-sites.html
@@ -180,6 +180,7 @@
 
   <h3>Internal</h3>
   <ul class="mzp-u-list-styled">
+    <li>jira.mozilla.com</li>
     <li>login.mozilla.com</li>
     <li>mana.mozilla.org</li>
     <li>phonebook.mozilla.org</li>


### PR DESCRIPTION
Jira is becoming a core engineering facility for Mozilla, thus we'd like to include JIRA in the web bug bounty program eligibility list.
