### PR TITLE
Convert NodeList to array for compatibility

### DIFF
--- a/media/js/firefox/new/desktop/download.js
+++ b/media/js/firefox/new/desktop/download.js
@@ -133,12 +133,12 @@
 
     var supportsInsersectionObserver = function() {
         return 'IntersectionObserver' in window &&
-               'IntersectionObserverEntry' in window &&
-               'intersectionRatio' in window.IntersectionObserverEntry.prototype;
+            'IntersectionObserverEntry' in window &&
+            'intersectionRatio' in window.IntersectionObserverEntry.prototype;
     }();
 
     // check for support
-    if(supportsInsersectionObserver) {
+    if(supportsInsersectionObserver && window.NodeList && NodeList.prototype.forEach) {
         // needs a sec to report rect.top right if the page loaded partially scrolled already
         setTimeout(function(){
 
@@ -156,11 +156,8 @@
                 }
             );
 
-            // convert NodeList into array - support for Edge 15 and older
-            var jsAnimateNodesArray = Array.prototype.slice.call(document.querySelectorAll('.js-animate'));
-
             // add observers
-            jsAnimateNodesArray.forEach(function(element) {
+            document.querySelectorAll('.js-animate').forEach(function(element) {
                 var rect = element.getBoundingClientRect();
                 var viewHeight = window.innerHeight;
                 // check element isn't above user's current position on the page
@@ -209,4 +206,3 @@
     }
 
 })(window.Mozilla);
-

--- a/media/js/firefox/new/desktop/download.js
+++ b/media/js/firefox/new/desktop/download.js
@@ -157,10 +157,10 @@
             );
 
             // convert NodeList into array - support for Edge 15 and older
-            var jsAnimate = Array.prototype.slice.call(document.querySelectorAll('.js-animate'), 0);
+            var jsAnimateNodesArray = Array.prototype.slice.call(document.querySelectorAll('.js-animate'));
 
             // add observers
-            jsAnimate.forEach(function(element) {
+            jsAnimateNodesArray.forEach(function(element) {
                 var rect = element.getBoundingClientRect();
                 var viewHeight = window.innerHeight;
                 // check element isn't above user's current position on the page

--- a/media/js/firefox/new/desktop/download.js
+++ b/media/js/firefox/new/desktop/download.js
@@ -156,8 +156,11 @@
                 }
             );
 
+            // convert NodeList into array - support for Edge 15 and older
+            var jsAnimate = Array.prototype.slice.call(document.querySelectorAll('.js-animate'), 0);
+
             // add observers
-            document.querySelectorAll('.js-animate').forEach(function(element) {
+            jsAnimate.forEach(function(element) {
                 var rect = element.getBoundingClientRect();
                 var viewHeight = window.innerHeight;
                 // check element isn't above user's current position on the page


### PR DESCRIPTION
## Description
The forEach() method of the NodeList interface calls the callback given in parameter once for each value pair in the list, in insertion order. While more modern browsers support forEach on a NodeList, older ones only allow it on arrays. To solve this, I converted the original NodeList to an array than iterated through that new array.

## Issue / Bugzilla link
[Type error on /firefox/new/ in older Edge browsers #9644](https://github.com/mozilla/bedrock/issues/9644)

## Testing
fix bug #9644