### PR TITLE
Add download button to compare pages non-Firefox (Fix #9640)

### DIFF
--- a/bedrock/firefox/templates/firefox/browsers/compare/brave.html
+++ b/bedrock/firefox/templates/firefox/browsers/compare/brave.html
@@ -23,6 +23,9 @@
         <img src="{{ static('img/logos/brave/logo-brave.png') }}" height="36" width="36" alt="">
       </div>
       <h1 class="mzp-c-hero-title">{{ ftl('compare-brave-comparing-firefox-browser') }}</h1>
+      <div class="mzp-c-hero-cta">
+        {{ download_firefox_thanks(locale_in_transition=True, download_location='primary cta') }}
+      </div>
     </div>
   </div>
 </section>
@@ -253,7 +256,7 @@
       </div>
 
       <aside class="secondary-download-cta">
-        {{ download_firefox(dom_id='download-secondary', alt_copy=ftl('download-button-download-firefox'), download_location='secondary cta') }}
+        {{ download_firefox_thanks(dom_id='download-secondary', alt_copy=ftl('download-button-download-firefox'), download_location='secondary cta') }}
       </aside>
 
     </section>

--- a/bedrock/firefox/templates/firefox/browsers/compare/chrome.html
+++ b/bedrock/firefox/templates/firefox/browsers/compare/chrome.html
@@ -25,6 +25,9 @@
         <img src="{{ static('img/logos/chrome/logo-chrome.png') }}" height="36" width="36" alt="">
       </div>
       <h1 class="mzp-c-hero-title">{{ ftl('compare-chrome-comparing-firefox-browser') }}</h1>
+      <div class="mzp-c-hero-cta">
+        {{ download_firefox_thanks(locale_in_transition=True, download_location='primary cta') }}
+      </div>
     </div>
   </div>
 </section>
@@ -250,7 +253,7 @@
       </div>
 
       <aside class="secondary-download-cta">
-        {{ download_firefox(dom_id='download-secondary', alt_copy=ftl('download-button-download-firefox'), download_location='secondary cta') }}
+        {{ download_firefox_thanks(dom_id='download-secondary', alt_copy=ftl('download-button-download-firefox'), download_location='secondary cta') }}
       </aside>
 
     </section>

--- a/bedrock/firefox/templates/firefox/browsers/compare/edge.html
+++ b/bedrock/firefox/templates/firefox/browsers/compare/edge.html
@@ -23,6 +23,9 @@
         <img src="{{ static('img/logos/edge/logo-edge.png') }}" height="36" width="36" alt="">
       </div>
       <h1 class="mzp-c-hero-title">{{ ftl('compare-edge-comparing-firefox-browser-with') }}</h1>
+      <div class="mzp-c-hero-cta">
+        {{ download_firefox_thanks(locale_in_transition=True, download_location='primary cta') }}
+      </div>
     </div>
   </div>
 </section>
@@ -248,7 +251,7 @@
       </div>
 
       <aside class="secondary-download-cta">
-        {{ download_firefox(dom_id='download-secondary', alt_copy=ftl('download-button-download-firefox'), download_location='secondary cta') }}
+        {{ download_firefox_thanks(dom_id='download-secondary', alt_copy=ftl('download-button-download-firefox'), download_location='secondary cta') }}
       </aside>
 
     </section>

--- a/bedrock/firefox/templates/firefox/browsers/compare/ie.html
+++ b/bedrock/firefox/templates/firefox/browsers/compare/ie.html
@@ -23,6 +23,9 @@
           <img src="{{ static('img/logos/ie/logo-ie.png') }}" height="36" width="36" alt="">
       </div>
       <h1 class="mzp-c-hero-title">{{ ftl('compare-ie-comparing-firefox-browser-with') }}</h1>
+      <div class="mzp-c-hero-cta">
+        {{ download_firefox_thanks(locale_in_transition=True, download_location='primary cta') }}
+      </div>
     </div>
   </div>
 </section>
@@ -243,7 +246,7 @@
       </div>
 
       <aside class="secondary-download-cta">
-        {{ download_firefox(dom_id='download-secondary', alt_copy=ftl('download-button-download-firefox'), download_location='secondary cta') }}
+        {{ download_firefox_thanks(dom_id='download-secondary', alt_copy=ftl('download-button-download-firefox'), download_location='secondary cta') }}
       </aside>
 
     </section>

--- a/bedrock/firefox/templates/firefox/browsers/compare/opera.html
+++ b/bedrock/firefox/templates/firefox/browsers/compare/opera.html
@@ -25,6 +25,9 @@
         <img src="{{ static('img/logos/opera/logo-opera.png') }}" height="36" width="36" alt="">
       </div>
       <h1 class="mzp-c-hero-title">{{ ftl('compare-opera-comparing-firefox-browser') }}</h1>
+      <div class="mzp-c-hero-cta">
+        {{ download_firefox_thanks(locale_in_transition=True, download_location='primary cta') }}
+      </div>
     </div>
   </div>
 </section>
@@ -245,7 +248,7 @@
       </div>
 
       <aside class="secondary-download-cta">
-        {{ download_firefox(dom_id='download-secondary', alt_copy=ftl('download-button-download-firefox'), download_location='secondary cta') }}
+        {{ download_firefox_thanks(dom_id='download-secondary', alt_copy=ftl('download-button-download-firefox'), download_location='secondary cta') }}
       </aside>
 
     </section>

--- a/bedrock/firefox/templates/firefox/browsers/compare/safari.html
+++ b/bedrock/firefox/templates/firefox/browsers/compare/safari.html
@@ -25,6 +25,9 @@
           <img src="{{ static('img/logos/safari/logo-safari.png') }}" height="36" width="36" alt="">
       </div>
       <h1 class="mzp-c-hero-title">{{ ftl('compare-safari-comparing-firefox-browser') }}</h1>
+      <div class="mzp-c-hero-cta">
+        {{ download_firefox_thanks(locale_in_transition=True, download_location='primary cta') }}
+      </div>
     </div>
   </div>
 </section>
@@ -258,7 +261,7 @@
       </div>
 
       <aside class="secondary-download-cta">
-        {{ download_firefox(dom_id='download-secondary', alt_copy=ftl('download-button-download-firefox'), download_location='secondary cta') }}
+        {{ download_firefox_thanks(dom_id='download-secondary', alt_copy=ftl('download-button-download-firefox'), download_location='secondary cta') }}
       </aside>
 
     </section>

--- a/media/css/firefox/compare/compare-details.scss
+++ b/media/css/firefox/compare/compare-details.scss
@@ -21,12 +21,25 @@ $image-path: "/media/protocol/img";
     .mzp-c-hero-title {
         @include font-size(32px);
         margin-bottom: 0;
+
         @media #{$mq-sm} {
             @include font-size(40px);
         }
         @media #{$mq-md} {
             @include font-size(48px);
         }
+    }
+
+    .mzp-c-hero-cta {
+        margin-top: $layout-sm;
+
+        .is-firefox & {
+            display: none;
+        }
+    }
+
+    .mzp-c-button-download-container {
+        margin-bottom: 0;
     }
 }
 
@@ -141,7 +154,7 @@ $image-path: "/media/protocol/img";
 .secondary-download-cta {
     margin-top: $layout-lg;
 
-    .download-button {
+    .mzp-c-button-download-container {
         display: block;
         margin: 0 auto;
     }


### PR DESCRIPTION
## Description

- add download button to hero; hide if Firefox
- switch to simplified download button for secondary download cta

## Issue / Bugzilla link

Fix #9640

## Testing

In Fx and not-fx:

- http://localhost:8000/en-US/firefox/browsers/compare/brave/
- http://localhost:8000/en-US/firefox/browsers/compare/chrome/
- http://localhost:8000/en-US/firefox/browsers/compare/edge/
- http://localhost:8000/en-US/firefox/browsers/compare/ie/
- http://localhost:8000/en-US/firefox/browsers/compare/opera/
- http://localhost:8000/en-US/firefox/browsers/compare/safari/