### PR TITLE
Fix JS error on 404 pages (#9642)

### DIFF
--- a/bedrock/base/templates/404.html
+++ b/bedrock/base/templates/404.html
@@ -95,6 +95,6 @@
   {% endif %}
 {% endblock %}
 
-{% block js%}
+{% block js %}
   {{ js_bundle('page_not_found') }}
 {% endblock %}

--- a/media/js/base/error-pages.js
+++ b/media/js/base/error-pages.js
@@ -6,13 +6,19 @@
 
 (function(){
     'use strict';
-    // Hides back button if there is no previous page to go back to.
-    if (window.history.length > 1) {
-        var div = document.getElementById('go-back');
-        div.classList.remove('hide-back');
+    var backLink = document.getElementById('go-back');
+
+    // Issue 9642
+    if (!backLink) {
+        return;
     }
 
-    document.getElementById('go-back').addEventListener('click', function(){
+    // Hides back button if there is no previous page to go back to.
+    if (window.history.length > 1) {
+        backLink.classList.remove('hide-back');
+    }
+
+    backLink.addEventListener('click', function(){
         window.history.back();
     });
 }());


### PR DESCRIPTION
## Description
Prevent JS error on 404 pages where locales still display older messaging.

## Issue / Bugzilla link
#9642

## Testing
Locales that don't satisfy [this conditional statement](https://github.com/mozilla/bedrock/blob/master/bedrock/base/templates/404.html#L20) currently receive an error.