### PR TITLE
Fix docker image tagging

### DIFF
--- a/bin/build-release-image.sh
+++ b/bin/build-release-image.sh
@@ -4,12 +4,14 @@ set -ex
 source docker/bin/set_git_env_vars.sh
 
 if docker pull "$DEPLOYMENT_DOCKER_IMAGE"; then
-    # image already exists, skip the build
-    exit 0
+    echo "image already exists, skipping the build"
+else
+    make clean build-ci
 fi
 
-make clean build-ci
-
+# push and tag images
+# we have to do this even if we didn't build a new image so that
+# the latest and git-tag tags are pushed
 if [[ "$1" == "--push" ]]; then
     docker/bin/push2dockerhub.sh mozmeao/bedrock_test
     docker/bin/push2dockerhub.sh mozmeao/bedrock_assets


### PR DESCRIPTION
Raphael discovered that the sitemap was behind. I found that this is because the `prod-latest` and git-tag-based docker tags weren't being pushed to Docker Hub. This is because we moved to promoting images instead of building fresh for stage and prod. Because of this the docker hub push was being skipped for stage and prod. This change ensures that the tagging and pushing happens regardless.
