### PR TITLE
Add Convert to /de/ and /fr/ unfck landing pages (Fixes #9670)

### DIFF
--- a/bedrock/firefox/templates/firefox/campaign/unfck/index.de.html
+++ b/bedrock/firefox/templates/firefox/campaign/unfck/index.de.html
@@ -8,10 +8,19 @@
 {% from "macros-protocol.html" import card, call_out, hero with context %}
 {% from "firefox/campaign/unfck/includes/macros.html" import share_item with context %}
 
+{% block html_attrs %}{{ super() }} {% include 'exp/includes/id.html' %}{% endblock %}
+
 {% block page_title %}Unfck the Internet - Aus Liebe zum Web{% endblock %}
 {% block page_desc %}Wenn das Internet genutzt wird, um Menschen online zu folgen und ihre persönlichen Daten zu sammeln, müssen Lösungen her, die uns alle besser schützen.{% endblock %}
-
 {% block page_image %}{{ static('img/firefox/campaign/unfck/de/og.png') }}{% endblock %}
+
+{% block experiments %}
+  {% if switch('unfck-convert-de') %}
+    {# Pre-fetch the DNS lookup prior to loading the convert script #}
+    <link rel="dns-prefetch" href="https://cdn-3.convertexperiments.com/">
+    {{ js_bundle('convert') }}
+  {% endif %}
+{% endblock %}
 
 {% block page_css %}
   {{ css_bundle('firefox-unfck-de') }}
@@ -227,6 +236,32 @@
   </div>
 
 </main>
+{% endblock %}
+
+{% block site_js %}
+  {% if switch('unfck-convert-de') %}
+    <!--[if !IE]><!-->
+      {{ js_bundle('common-no-jquery') }}
+    <!--<![endif]-->
+  {% else %}
+    <!--[if !IE]><!-->
+      {{ js_bundle('common') }}
+    <!--<![endif]-->
+  {% endif %}
+
+  <!--[if IE]>
+    {{ js_bundle('common-ie') }}
+  <![endif]-->
+{% endblock %}
+
+{% block stub_attribution %}
+  {% if settings.STUB_ATTRIBUTION_RATE %}
+    {% if switch('unfck-convert-de') %}
+      {{ js_bundle('stub-attribution-convert') }}
+    {% else %}
+      {{ js_bundle('stub-attribution') }}
+    {% endif %}
+  {% endif %}
 {% endblock %}
 
 {% block js %}

--- a/bedrock/firefox/templates/firefox/campaign/unfck/index.fr.html
+++ b/bedrock/firefox/templates/firefox/campaign/unfck/index.fr.html
@@ -6,8 +6,15 @@
 
 {% block page_title %}N’acceptez pas tout du Net. Rendons le Net plus net{% endblock %}
 {% block page_desc %}Quand les données personnelles deviennent une monnaie d’échange, il est temps de choisir un navigateur qui vous protège et protège le Net que vous aimez.{% endblock %}
-
 {% block page_image %}{{ static('img/firefox/campaign/unfck/fr/og.png') }}{% endblock %}
+
+{% block experiments %}
+  {% if switch('unfck-convert-fr') %}
+    {# Pre-fetch the DNS lookup prior to loading the convert script #}
+    <link rel="dns-prefetch" href="https://cdn-3.convertexperiments.com/">
+    {{ js_bundle('convert') }}
+  {% endif %}
+{% endblock %}
 
 {% block page_css %}
   {{ super() }}
@@ -198,4 +205,30 @@
   </div>
 
 </main>
+{% endblock %}
+
+{% block site_js %}
+  {% if switch('unfck-convert-fr') %}
+    <!--[if !IE]><!-->
+      {{ js_bundle('common-no-jquery') }}
+    <!--<![endif]-->
+  {% else %}
+    <!--[if !IE]><!-->
+      {{ js_bundle('common') }}
+    <!--<![endif]-->
+  {% endif %}
+
+  <!--[if IE]>
+    {{ js_bundle('common-ie') }}
+  <![endif]-->
+{% endblock %}
+
+{% block stub_attribution %}
+  {% if settings.STUB_ATTRIBUTION_RATE %}
+    {% if switch('unfck-convert-fr') %}
+      {{ js_bundle('stub-attribution-convert') }}
+    {% else %}
+      {{ js_bundle('stub-attribution') }}
+    {% endif %}
+  {% endif %}
 {% endblock %}


### PR DESCRIPTION
## Description
Adds Convert JS to:

- http://localhost:8000/de/firefox/unfck/
- http://localhost:8000/fr/firefox/unfck/

## Issue / Bugzilla link
#9670

## Testing
Test using a browser with DNT disabled using the following in your `.env`:
- [ ] Pages should load Convert JS when:
  - `SWITCH_UNFCK_CONVERT_DE=on`
  - `SWITCH_UNFCK_CONVERT_FR=on`
- [ ] Pages should load without Convert JS when:
  - `SWITCH_UNFCK_CONVERT_DE=off`
  - `SWITCH_UNFCK_CONVERT_FR=off`