### PR TITLE
Set never-cache headers for experiment responses for /firefox/new/

### DIFF
--- a/bedrock/firefox/tests/test_views.py
+++ b/bedrock/firefox/tests/test_views.py
@@ -714,7 +714,7 @@ class TestFirefoxNew(TestCase):
         resp = view(req)
         assert resp.status_code == 302
         assert resp['location'].endswith('/exp/firefox/new/')
-        assert resp['cache-control'] == 'max-age=60'
+        assert resp['cache-control'] == 'max-age=0, no-cache, no-store, must-revalidate'
         req.locale = 'en-US'
         resp = view(req)
         assert resp.status_code == 200

--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -19,7 +19,7 @@ from django.http import (
     JsonResponse,
 )
 
-from django.utils.cache import patch_response_headers
+from django.utils.cache import add_never_cache_headers, patch_response_headers
 from django.utils.encoding import force_text
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_GET, require_POST
@@ -755,8 +755,8 @@ class NewView(L10nTemplateView):
                     response = HttpResponseRedirect(exp_url)
                 else:
                     response = super().render_to_response(context, **response_kwargs)
-                # reduce cache time for better experiment results
-                patch_response_headers(response, 60)
+                # remove cache for better experiment results
+                add_never_cache_headers(response)
                 return response
 
         return super().render_to_response(context, **response_kwargs)


### PR DESCRIPTION
Allowing the responses to be cached means that the query params in the
redirect responses are also cached and therefore we need a unique
response per visitor in order to ensure that we are giving them the
right experiment and stub attribution.
