### PR TITLE
Migrate /firefox/firstrun/ page to Fluent (Fixes #9193)

### DIFF
--- a/bedrock/firefox/templates/firefox/firstrun/firstrun.html
+++ b/bedrock/firefox/templates/firefox/firstrun/firstrun.html
@@ -2,8 +2,6 @@
  # License, v. 2.0. If a copy of the MPL was not distributed with this
  # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
 
-{% add_lang_files "firefox/new/quantum" %}
-
 {% from "macros.html" import fxa_email_form with context %}
 
 {% extends "firefox/base/base-protocol.html" %}
@@ -16,7 +14,7 @@
 {% block body_id %}firstrun-quantum-onboarding{% endblock %}
 
 {% block page_title %}
-  {{ _('Welcome to Firefox') }}
+  {{ ftl('firstrun-welcome-to-firefox') }}
 {% endblock %}
 
 {% block page_css %}
@@ -25,8 +23,7 @@
 
 {% block gtm_page_id %}data-gtm-page-id="/firefox/firstrun/"{% endblock %}
 
-{% block global_nav %}{% endblock %}
-{% block site_header %}   {% endblock %}
+{% block site_header %}{% endblock %}
 
 {% block page_image %}{{ static('img/firefox/template/page-image-master.jpg') }}{% endblock %}
 
@@ -37,22 +34,15 @@
       <div class="mzp-l-content">
         <div class="hero-body">
           <div class="browser-logo">
-            <img alt="Firefox" class="browser-logo" src="{{ static('protocol/img/logos/firefox/browser/logo-word-hor-md.png') }}" width="260" height="48" />
+            <img alt="{{ ftl('firstrun-firefox-browser') }}" class="browser-logo" src="{{ static('protocol/img/logos/firefox/browser/logo-word-hor-md.png') }}" width="260" height="48" />
           </div>
           <h1 class="hero-title">
-            {% if l10n_has_tag('firstrun_email_only_form') %}
-              {{ _('Take Firefox with You') }}
-            {% else %}
-              {{_('Already using Firefox?')}}
-            {% endif %}
+            {{ ftl('firstrun-take-firefox-with-you', fallback='firstrun-already-using-firefox') }}
           </h1>
           <div class="hero-desc">
             <p>
-            {% if l10n_has_tag('firstrun_email_only_form') %}
-              {{ _('Get your bookmarks, history, passwords and other settings on all your devices.') }}
-            {% else %}
-              {{_('Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.')}}
-            {% endif %}</p>
+              {{ ftl('firstrun-get-your-bookmarks-history', fallback='firstrun-sign-in-to-your-account') }}
+            </p>
           </div>
           <aside class="mzp-c-emphasis-box hero-form" id="fxaccounts-wrapper">
             {{ fxa_email_form(
@@ -60,11 +50,11 @@
               button_class='mzp-c-button mzp-t-product')
             }}
             <p class="fxa-signin">
-              {{ _('Already have an account?') }}
+              {{ ftl('firstrun-already-have-an-account') }}
 
               {{ fxa_button(
                 entrypoint=_entrypoint,
-                button_text='Sign In',
+                button_text=ftl('firstrun-sign-in'),
                 action='signin',
                 is_button_class=False,
                 optional_parameters={'utm_campaign': 'fxa-embedded-form'},

--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -495,6 +495,11 @@ def show_firefox_lite_whatsnew(version):
 
 
 class FirstrunView(l10n_utils.LangFilesMixin, TemplateView):
+
+    ftl_files_map = {
+        'firefox/firstrun/firstrun.html': ['firefox/firstrun'],
+    }
+
     def get(self, *args, **kwargs):
         version = self.kwargs.get('version') or ''
 

--- a/l10n/en/firefox/firstrun.ftl
+++ b/l10n/en/firefox/firstrun.ftl
@@ -1,0 +1,14 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+### URL: https://www-dev.allizom.org/firefox/firstrun/
+
+firstrun-firefox-browser = { -brand-name-firefox-browser }
+firstrun-welcome-to-firefox = Welcome to { -brand-name-firefox }
+firstrun-take-firefox-with-you = Take { -brand-name-firefox } with You
+firstrun-already-using-firefox = Already using { -brand-name-firefox }?
+firstrun-get-your-bookmarks-history = Get your bookmarks, history, passwords and other settings on all your devices.
+firstrun-sign-in-to-your-account = Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to { -brand-name-firefox } on other devices.
+firstrun-already-have-an-account = Already have an account?
+firstrun-sign-in = Sign In

--- a/lib/fluent_migrations/firefox/firstrun/firstrun.py
+++ b/lib/fluent_migrations/firefox/firstrun/firstrun.py
@@ -1,0 +1,66 @@
+from __future__ import absolute_import
+import fluent.syntax.ast as FTL
+from fluent.migrate.helpers import transforms_from
+from fluent.migrate.helpers import VARIABLE_REFERENCE, TERM_REFERENCE
+from fluent.migrate import REPLACE, COPY
+
+firstrun = "firefox/firstrun/firstrun.lang"
+quantum = "firefox/new/quantum.lang"
+
+def migrate(ctx):
+    """Migrate bedrock/firefox/templates/firefox/firstrun/firstrun.html, part {index}."""
+
+    ctx.add_transforms(
+        "firefox/firstrun.ftl",
+        "firefox/firstrun.ftl",
+        transforms_from("""
+firstrun-firefox-browser = { -brand-name-firefox-browser }
+""", quantum=quantum) + [
+            FTL.Message(
+                id=FTL.Identifier("firstrun-welcome-to-firefox"),
+                value=REPLACE(
+                    quantum,
+                    "Welcome to Firefox",
+                    {
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("firstrun-take-firefox-with-you"),
+                value=REPLACE(
+                    quantum,
+                    "Take Firefox with You",
+                    {
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("firstrun-already-using-firefox"),
+                value=REPLACE(
+                    quantum,
+                    "Already using Firefox?",
+                    {
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                    }
+                )
+            ),
+        ] + transforms_from("""
+firstrun-get-your-bookmarks-history = {COPY(quantum, "Get your bookmarks, history, passwords and other settings on all your devices.",)}
+""", quantum=quantum) + [
+            FTL.Message(
+                id=FTL.Identifier("firstrun-sign-in-to-your-account"),
+                value=REPLACE(
+                    quantum,
+                    "Sign in to your account and we’ll sync the bookmarks, passwords and other great things you’ve saved to Firefox on other devices.",
+                    {
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                    }
+                )
+            ),
+        ] + transforms_from("""
+firstrun-already-have-an-account = {COPY(quantum, "Already have an account?",)}
+firstrun-sign-in = {COPY(quantum, "Sign In",)}
+""", quantum=quantum)
+        )


### PR DESCRIPTION
## Description
http://localhost:8000/en-US/firefox/firstrun/

## Issue / Bugzilla link
#9193

## Testing
```
./manage.py l10n_update
```