### PR TITLE
Remove Stub Attribution script from in-product Firefox pages (#9620)

### DIFF
--- a/bedrock/firefox/templates/firefox/developer/firstrun.html
+++ b/bedrock/firefox/templates/firefox/developer/firstrun.html
@@ -66,3 +66,6 @@
   {{ js_bundle('firefox_developer') }}
 {% endblock %}
 
+{# Exclude stub attribution for in-product pages: issus 9620 #}
+{% block stub_attribution %}{% endblock %}
+

--- a/bedrock/firefox/templates/firefox/developer/whatsnew.html
+++ b/bedrock/firefox/templates/firefox/developer/whatsnew.html
@@ -63,3 +63,6 @@
 {% block js %}
   {{ js_bundle('firefox_developer') }}
 {% endblock %}
+
+{# Exclude stub attribution for in-product pages: issus 9620 #}
+{% block stub_attribution %}{% endblock %}

--- a/bedrock/firefox/templates/firefox/nightly/whatsnew.html
+++ b/bedrock/firefox/templates/firefox/nightly/whatsnew.html
@@ -58,3 +58,6 @@
 {% block js %}
   {{ js_bundle('firefox_nightly_whatsnew') }}
 {% endblock %}
+
+{# Exclude stub attribution for in-product pages: issus 9620 #}
+{% block stub_attribution %}{% endblock %}

--- a/bedrock/firefox/templates/firefox/nightly_firstrun.html
+++ b/bedrock/firefox/templates/firefox/nightly_firstrun.html
@@ -99,3 +99,6 @@
 {% block email_form %}{% endblock %}
 
 {% block js %}{% endblock %}
+
+{# Exclude stub attribution for in-product pages: issus 9620 #}
+{% block stub_attribution %}{% endblock %}

--- a/bedrock/firefox/templates/firefox/welcome/base.html
+++ b/bedrock/firefox/templates/firefox/welcome/base.html
@@ -49,3 +49,6 @@
   </aside>
 </main>
 {% endblock %}
+
+{# Exclude stub attribution for in-product pages: issus 9620 #}
+{% block stub_attribution %}{% endblock %}

--- a/bedrock/firefox/templates/firefox/whatsnew/base.html
+++ b/bedrock/firefox/templates/firefox/whatsnew/base.html
@@ -8,3 +8,6 @@
 {% block canonical_urls %}<meta name="robots" content="noindex,follow">{% endblock %}
 
 {% block gtm_page_id %}data-gtm-page-id="/firefox/whatsnew/"{% endblock %}
+
+{# Exclude stub attribution for in-product pages: issus 9620 #}
+{% block stub_attribution %}{% endblock %}

--- a/bedrock/privacy/templates/privacy/notices/firefox.html
+++ b/bedrock/privacy/templates/privacy/notices/firefox.html
@@ -15,3 +15,6 @@
 
 {# disable GA on Fx Privacy Notice. Bug 1576673 #}
 {% block google_analytics %}{% endblock %}
+
+{# Exclude stub attribution for in-product pages: issus 9620 #}
+{% block stub_attribution %}{% endblock %}

--- a/media/js/base/stub-attribution.js
+++ b/media/js/base/stub-attribution.js
@@ -246,7 +246,9 @@ if (typeof window.Mozilla === 'undefined') {
      */
     StubAttribution.meetsRequirements = function() {
 
-        if (typeof window.site === 'undefined' || typeof Mozilla.Cookies === 'undefined') {
+        if (typeof window.site === 'undefined' ||
+            typeof Mozilla.Cookies === 'undefined' ||
+            typeof window._SearchParams === 'undefined') {
             return false;
         }
 


### PR DESCRIPTION
## Description
- Removes Stub Attribution script from in-product pages such as /whatsnew, /welcome, and /privacy/firefox/ (those users are already on Firefox, and if they should go on to download attribution should still happen on the download page)
- Adds a check for `window._SearchParams` in stub attribution script to fail more gracefully when network errors happen.

## Issue / Bugzilla link
#9620

## Testing
- [ ] Stub attribution script should not be loaded for in-product page templates.