### PR TITLE
update sync redirect (#9490)

### DIFF
--- a/bedrock/firefox/redirects.py
+++ b/bedrock/firefox/redirects.py
@@ -607,7 +607,10 @@ redirectpatterns = (
 
     # fxa
     redirect(r'^firefox/accounts/features/?', 'firefox.accounts'),
-    redirect(r'^firefox/features/sync/?', 'firefox.accounts'),
+
+    # issue 9490
+    redirect(r'^firefox/features/sync/?', 'firefox.sync'),
+
     # bug 1577449
     redirect(r'^firefox/features/send-tabs/?', 'https://support.mozilla.org/kb/send-tab-firefox-desktop-other-devices'),
 

--- a/tests/redirects/map_globalconf.py
+++ b/tests/redirects/map_globalconf.py
@@ -1004,6 +1004,9 @@ URLS = flatten((
     # Bug 1252332
     url_test('/sync/', '/firefox/sync/'),
 
+    # issue 9490
+    url_test('/firefox/features/sync/', '/firefox/sync/'),
+
     url_test('/projects/bonecho/', '/firefox/channel/desktop/'),
     url_test('/projects/bonsai/', 'https://wiki.mozilla.org/Bonsai'),
     url_test('/projects/camino/{,homepage.html}', 'http://caminobrowser.org/'),


### PR DESCRIPTION
## Description
firefox/features/sync redirects to firefox/sync

## Issue / Bugzilla link
#9490 

