### PR TITLE
Enable multiprocess mode for prometheus metrics gathering

### DIFF
--- a/bin/run-prod.sh
+++ b/bin/run-prod.sh
@@ -1,10 +1,15 @@
 #!/bin/bash -xe
 
+export prometheus_multiproc_dir=/tmp/prometheus_metrics
+# ensure the multiproc dir is empty
+rm -rf "$prometheus_multiproc_dir" && mkdir -p "$prometheus_multiproc_dir"
+
 function run-gunicorn () {
     if [[ -z "$NEW_RELIC_LICENSE_KEY" ]]; then
-        gunicorn "$@"
+        exec gunicorn "$@"
     else
-        NEW_RELIC_CONFIG_FILE=newrelic.ini newrelic-admin run-program gunicorn "$@"
+        export NEW_RELIC_CONFIG_FILE=newrelic.ini
+        exec newrelic-admin run-program gunicorn "$@"
     fi
 }
 
@@ -14,9 +19,4 @@ if [[ ! -f "data/bedrock.db" ]]; then
     exit 1
 fi
 
-run-gunicorn wsgi.app:application -b 0.0.0.0:${PORT:-8000} \
-                                  -w ${WEB_CONCURRENCY:-2} \
-                                  --error-logfile - \
-                                  --access-logfile - \
-                                  --log-level ${LOGLEVEL:-info} \
-                                  --worker-class ${GUNICORN_WORKER_CLASS:-meinheld.gmeinheld.MeinheldWorker}
+run-gunicorn wsgi.app:application --config wsgi/config.py

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -314,9 +314,9 @@ packaging==20.4 \
 pyparsing==2.4.7 \
     --hash=sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1 \
     --hash=sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b
-django-prometheus==2.1.0.dev52 \
-    --hash=sha256:441bd85531ecdeddacbe73c930f16de926c426869ce388fa1e8c8092f7ee5a1b \
-    --hash=sha256:6e824cd407b56c01810c69d2e296940d00afe609b58818794525f9760a9a5364
+django-prometheus==2.1.0 \
+    --hash=sha256:c338d6efde1ca336e90c540b5e87afe9287d7bcc82d651a778f302b0be17a933 \
+    --hash=sha256:dd3f8da1399140fbef5c00d1526a23d1ade286b144281c325f8e409a781643f2
 prometheus-client==0.8.0 \
     --hash=sha256:983c7ac4b47478720db338f1491ef67a100b474e3bc7dafcbaefb7d0b8f9b01c \
     --hash=sha256:c6e6b706833a6bd1fd51711299edee907857be10ece535126a158f911ee80915

--- a/wsgi/config.py
+++ b/wsgi/config.py
@@ -1,0 +1,23 @@
+# see http://docs.gunicorn.org/en/latest/configure.html#configuration-file
+
+from os import getenv
+
+from prometheus_client import multiprocess
+
+
+bind = f'0.0.0.0:{getenv("PORT", "8000")}'
+workers = getenv('WEB_CONCURRENCY', 2)
+accesslog = '-'
+errorlog = '-'
+loglevel = getenv('LOGLEVEL', 'info')
+
+# Larger keep-alive values maybe needed when directly talking to ELBs
+# See https://github.com/benoitc/gunicorn/issues/1194
+keepalive = getenv('WSGI_KEEP_ALIVE', 2)
+worker_class = getenv('GUNICORN_WORKER_CLASS', 'meinheld.gmeinheld.MeinheldWorker')
+worker_tmp_dir = '/dev/shm'
+
+
+# see https://github.com/prometheus/client_python#multiprocess-mode-gunicorn
+def child_exit(server, worker):
+    multiprocess.mark_process_dead(worker.pid)


### PR DESCRIPTION
@duallain I think this works. My mistake before in 89a6b9c8bd9df8272371a5dd5114da7129c8434c was that I added the env var in the Docker image which meant it tried to use it all the time and some of the management commands and the dev server didn't play nice with it. I tested locally by running `make run-prod` and looking at `/prometheus/metrics/` as well as getting a shell on the running container `docker-compose exec release-local bash` and looking at the `/tmp/prometheus_metrics` dir.