### PR TITLE
Fix JS error when join-firefox-content not found (Fix #9688)

### DIFF
--- a/media/js/firefox/new/desktop/join-modal.js
+++ b/media/js/firefox/new/desktop/join-modal.js
@@ -42,8 +42,8 @@
     };
 
     // Only Firefox desktop 57+ (post-quantum) should get the FxA modal
-    if (client.isFirefoxDesktop && client._getFirefoxMajorVersion() >= '57') {
-        initFxAccountModal();
+    if (joinFirefoxContent && client.isFirefoxDesktop && client._getFirefoxMajorVersion() >= '57') {
+        window.Mozilla.run(initFxAccountModal);
     }
 
 })();


### PR DESCRIPTION
## Description

- This content is only displayed to Firefox browses
- The error is only appearing in Firefox < 6.0

## Issue / Bugzilla link

Fix #9687

## Testing

- The error can be replicated by deleting the HTML element from the page
