### PR TITLE
Migrate firefox/nightly/firstrun to Fluent (Fixes #9684) [skip l10n]

### DIFF
--- a/bedrock/firefox/redirects.py
+++ b/bedrock/firefox/redirects.py
@@ -37,7 +37,7 @@ redirectpatterns = (
              '/firefox/nightly/firstrun{p}'),
 
     # bug 1275483
-    redirect(r'^firefox/nightly/whatsnew/?', 'firefox.nightly_firstrun'),
+    redirect(r'^firefox/nightly/whatsnew/?', 'firefox.nightly.firstrun'),
 
     # bug 840814
     redirect(r'^projects/firefox'

--- a/bedrock/firefox/templates/firefox/nightly/firstrun.cs.html
+++ b/bedrock/firefox/templates/firefox/nightly/firstrun.cs.html
@@ -1,0 +1,21 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+
+{% extends "/firefox/nightly/firstrun.html" %}
+
+{% block locale_promo %}
+  <div class="mzp-l-content mzp-t-content-md locale-specific">
+    <h3>Zjistěte více o místní komunitě Mozilla</h3>
+    <p>
+      Česká komunita Mozilla překládá aplikace Mozilly do češtiny, pomáhá uživatelům a popularizuje projekt.
+      Do projektu se může zapojit každý z vás podle svých možností a schopností. Zní to zajímavě?
+      <a href="mailto:info@mozilla.cz">Ozvěte se nám</a>!
+    </p>
+    <ul>
+      <li><a href="http://www.mozilla.cz/">Navštivte náš web Mozilla.cz</a></li>
+      <li><a href="https://twitter.com/MozillaCZ">Sledujte nás na Twitteru (@MozillaCZ)</a></li>
+      <li><a href="https://www.facebook.com/Mozillacz">Staňte se našimi fanoušky na Facebooku</a></li>
+    </ul>
+  </div>
+{% endblock %}

--- a/bedrock/firefox/templates/firefox/nightly/firstrun.de.html
+++ b/bedrock/firefox/templates/firefox/nightly/firstrun.de.html
@@ -1,0 +1,26 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+
+{% extends "/firefox/nightly/firstrun.html" %}
+
+{% block locale_promo %}
+  <div class="mzp-l-content mzp-t-content-md locale-specific">
+    <h3>Erfahren Sie mehr über die lokale Mozilla-Community</h3>
+    <p>Unsere Projekte bieten einige vielfältige Möglichkeiten, wie sich wirklich jeder aktiv einbringen kann: Helfen Sie Anwendern von Mozilla-Software, arbeiten Sie an der Übersetzung der Mozilla-Software von Webseiten mit oder planen Sie Veranstaltungen für das WebMaker-Projekt.</p>
+
+    <p>Werden Sie Teil der Gemeinschaft</p>
+    <ul>
+      <li><a href="http://www.mozilla.de/">www.mozilla.de</a></li>
+      <li><a href="http://www.mibbit.com/?server=irc.mozilla.org&amp;channel=%23mozilla.de">IRC-Chat: #mozilla.de</a></li>
+      <li><a href="https://lists.mozilla.org/listinfo/community-german">Mailing-Liste</a></li>
+      <li><a href="https://twitter.com/mozilla_deutsch">@mozilla_deutsch</a></li>
+      <li><a href="https://www.facebook.com/mozilla.de">Facebook</a></li>
+    </ul>
+
+    <h4>Aktuelle Veranstaltungen</h4>
+      <ul>
+        <li>Open Mozilla Nights (Berlin) &ndash; jeden 2. Donnerstag &ndash; <a href="https://www.meetup.com/de-DE/Berlin-Mozilla-Meetup/">Meetup</a> &ndash; <a href="https://twitter.com/MozillaNight">Twitter</a></li>
+      </ul>
+  </div>
+{% endblock %}

--- a/bedrock/firefox/templates/firefox/nightly/firstrun.es-AR.html
+++ b/bedrock/firefox/templates/firefox/nightly/firstrun.es-AR.html
@@ -1,0 +1,14 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+
+{% extends "/firefox/nightly/firstrun.html" %}
+
+{% block locale_promo %}
+<div class="mzp-l-content mzp-t-content-md locale-specific">
+  <h3>¡Conocé a la comunidad argentina!</h3>
+  <p>Mozilla es una organización sin fines de lucro conformada por una comunidad en la que cualquiera puede ser parte. Sólo tenés que traer tus ganas de participar y aprender. Desde la página de colabora podés acercar tus ganas de participar. También podés visitar <a href="http://www.mozilla-hispano.org/">la página de Mozilla Hispano</a> para enterarte de las últimas novedades sobre Mozilla.</p>
+  <p>Y si querés juntarte con vecinos en Argentina, podés suscribirte a la <a href="https://listas.usla.org.ar/cgi-bin/mailman/listinfo/mozilla-general">lista de correo</a>, o pasearte por la sala de IRC de Mozilla Hispano.</p>
+  <p>¡Gracias por usar Firefox Nightly!</p>
+</div>
+{% endblock %}

--- a/bedrock/firefox/templates/firefox/nightly/firstrun.es-ES.html
+++ b/bedrock/firefox/templates/firefox/nightly/firstrun.es-ES.html
@@ -1,0 +1,13 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+
+{% extends "/firefox/nightly/firstrun.html" %}
+
+{% block locale_promo %}
+<div class="mzp-l-content mzp-t-content-md locale-specific">
+  <h3>¡Descubre tu comunidad en español!</h3>
+  <p>Mozilla Hispano es la comunidad de Mozilla que reúne a desarrolladores, traductores y usuarios de quince comunidades de habla hispana a uno y otro lado del Atlántico. Infórmate sobre nuestros proyectos, productos y principios diseñados para que la gente se haga con el control y explore el pleno potencial de sus vidas digitales.<p>Visita <a href="http://www.mozilla-hispano.org/">la página de Mozilla Hispano</a> para enterarte de las últimas novedades sobre Mozilla. Y si te interesa participar, en esta <a href="https://www.mozilla.org/es-ES/contribute/">página </a> puedes encontrar toda la información.</p>
+  <p>¡Gracias por usar Firefox Nightly!</p>
+</div>
+{% endblock %}

--- a/bedrock/firefox/templates/firefox/nightly/firstrun.fr.html
+++ b/bedrock/firefox/templates/firefox/nightly/firstrun.fr.html
@@ -1,0 +1,20 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+
+{% extends "/firefox/nightly/firstrun.html" %}
+
+{% block locale_promo %}
+  <div class="mzp-l-content mzp-t-content-md locale-specific">
+    <h3>La communauté Mozilla francophone a besoin de vous&nbsp;!</h3>
+    <p>Traduction, participation à des évènements locaux du Web ou du libre, développement, assistance aux utilisateurs, promotion du libre et des valeurs de Mozilla, enseignement. Les possibilités de participation au projet Mozilla directement dans votre langue ne manquent pas&nbsp;!</p>
+
+    <p>Venez découvrir MozFR, la communauté Mozilla francophone&nbsp;:</p>
+    <ul>
+        <li><a href="https://mozfr.org/participer">Le site de MozFR</a></li>
+        <li><a href="https://twitter.com/mozilla_fr/">@mozilla_fr sur Twitter</a></li>
+        <li><a href="https://mozfr.org/liste">Inscrivez-vous à la liste de discussion</a></li>
+        <li><a href="https://chat.mozilla.org/#/room/#mozfr:mozilla.org">Venez nous rencontrer sur le canal #mozfr de notre instance Matrix</a></li>
+    </ul>
+  </div>
+{% endblock %}

--- a/bedrock/firefox/templates/firefox/nightly/firstrun.html
+++ b/bedrock/firefox/templates/firefox/nightly/firstrun.html
@@ -2,8 +2,6 @@
  # License, v. 2.0. If a copy of the MPL was not distributed with this
  # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
 
-{# firstrun for nightlies #}
-
 {% from "macros-protocol.html" import hero, picto_card with context %}
 
 {% extends "/firefox/base/base-protocol.html" %}
@@ -15,90 +13,74 @@
   {{ css_bundle('nightly_firstrun') }}
 {% endblock %}
 
-{% add_lang_files "firstrun" "mobile" %}
-
 {% block page_title_prefix %}{% endblock %}
 {% block page_image %}{{ static('protocol/img/logos/firefox/browser/nightly/og.png') }}{% endblock %}
 {% block page_favicon %}{{ static('img/favicons/firefox/browser/nightly/favicon.ico') }}{% endblock %}
 {% block page_favicon_large %}{{ static('img/favicons/firefox/browser/nightly/favicon-196x196.png') }}{% endblock %}
 {% block page_ios_icon %}{{ static('img/favicons/firefox/browser/nightly/apple-touch-icon.png') }}{% endblock %}
-{% block page_title %}{{ _('Firefox Nightly First Run Page') }}{% endblock %}
+{% block page_title %}{{ ftl('nightly-firstrun-firefox-nightly') }}{% endblock %}
 {% block page_title_suffix %}{% endblock %}
 {% block page_og_url %}{{ firefox_url('desktop', 'all', 'nightly') }}{% endblock %}
 
 {% block body_id %}firefox-firstrun{% endblock %}
 
 {% block site_header %}{% endblock %}
-{% block global_nav %}{% endblock %}
 
 {% block content %}
 <main role="main">
   {{ hero(
-    title=_('Thank you for using Firefox Nightly'),
+    title=ftl('nightly-firstrun-thank-you-for-using'),
     class='mzp-t-dark mzp-t-product-nightly main-header',
     heading_level=1
   )}}
 
   <section class="contribute">
     <div class="mzp-l-content">
-      <h2 class="contribute-title">{{ _('Choose an area to get involved below and help make Firefox better for users everywhere') }}</h2>
+      <h2 class="contribute-title">{{ ftl('nightly-firstrun-choose-an-area') }}</h2>
       <ul class="mzp-l-card-third mzp-t-dark">
         {% call picto_card(
-          title=_('Test'),
+          title=ftl('nightly-firstrun-test'),
           class='test',
           heading_level=3,
           custom_desc=True
         ) %}
-          <p>{{ _('Find and file bugs and generally make sure things work as they should.') }}</p>
-          <a href="https://quality.mozilla.org/get-involved/" class="mzp-c-button mzp-t-product mzp-t-dark" data-cta-type="button" data-cta-text="Start testing">{{ _('Start testing') }}</a>
+          <p>{{ ftl('nightly-firstrun-find-and-file-bugs') }}</p>
+          <a href="https://quality.mozilla.org/get-involved/" class="mzp-c-button mzp-t-product mzp-t-dark" data-cta-type="button" data-cta-text="Start testing">{{ ftl('nightly-firstrun-start-testing') }}</a>
         {% endcall %}
 
         {% call picto_card(
-          title=_('Code'),
+          title=ftl('nightly-firstrun-code'),
           class='code',
           heading_level=3,
           custom_desc=True
         ) %}
-          <p>{{ _('File bugs and work on the building blocks of the Firefox browser.') }}</p>
-          <a href="https://developer.mozilla.org/docs/Introduction" class="mzp-c-button mzp-t-product mzp-t-dark" data-cta-type="button" data-cta-text="Start coding">{{ _('Start coding') }}</a>
+          <p>{{ ftl('nightly-firstrun-file-bugs-and-work') }}</p>
+          <a href="https://developer.mozilla.org/docs/Introduction" class="mzp-c-button mzp-t-product mzp-t-dark" data-cta-type="button" data-cta-text="Start coding">{{ ftl('nightly-firstrun-start-coding') }}</a>
         {% endcall %}
 
         {% call picto_card(
-          title=_('Localize'),
+          title=ftl('nightly-firstrun-localize'),
           class='localize',
           heading_level=3,
           custom_desc=True
         ) %}
-          <p>{{ _('Make Firefox available (and better) in more languages around the world.') }}</p>
-          <a href="{{ _('https://wiki.mozilla.org/L10n:Contribute') }}" class="mzp-c-button mzp-t-product mzp-t-dark" data-cta-type="button" data-cta-text="Start localizing">{{ _('Start localizing') }}</a>
+          <p>{{ ftl('nightly-firstrun-make-firefox-available') }}</p>
+          <a href="{{ ftl('nightly-firstrun-contribute-link') }}" class="mzp-c-button mzp-t-product mzp-t-dark" data-cta-type="button" data-cta-text="Start localizing">{{ ftl('nightly-firstrun-start-localizing') }}</a>
         {% endcall %}
       </ul>
     </div>
   </section>
 
-  {% if not request.locale.startswith('en') %}
-    {% if l10n_has_tag('promo_locale') %}
-    {# The following block is entirely defined by locales, and the placeholder in en-US here will never be exposed to production #}
-    <div class="mzp-l-content">
-      <div class="locale-specific">
-        {% l10n promo_locale 20150101 %}
-          <h3>Learn more about your local Mozilla community</h3>
-          <ul class="unstyled">
-            <li><a href="http://www.example.com">Meet our community</a></li>
-          </ul>
-        {% endl10n %}
-      </div>
-    </div>
-    {% endif %}
-  {% endif %}
+  {# Locale specific conmmunity promos #}
+  {% block locale_promo %}{% endblock %}
 </main>
-
-
 {% endblock %}
 
-{% block email_form %}{% endblock %}
-
-{% block js %}{% endblock %}
+{% block site_footer %}
+  {% with theme_class='mzp-t-ink' %}
+    {% include 'includes/protocol/footer/footer.html' %}
+  {% endwith %}
+{% endblock %}
 
 {# Exclude stub attribution for in-product pages: issus 9620 #}
 {% block stub_attribution %}{% endblock %}

--- a/bedrock/firefox/templates/firefox/nightly/firstrun.it.html
+++ b/bedrock/firefox/templates/firefox/nightly/firstrun.it.html
@@ -1,0 +1,23 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+
+{% extends "/firefox/nightly/firstrun.html" %}
+
+{% block locale_promo %}
+  <div class="mzp-l-content mzp-t-content-md locale-specific">
+    <h3>La comunità italiana ha bisogno del tuo aiuto</h3>
+    <p>Da oltre dieci anni esiste in Italia una comunità di volontari che si occupa principalmente di traduzione e supporto per i software Mozilla. Siamo alla costante ricerca di volontari per diffondere la cultura di Mozilla in Italia, contribuire all’organizzazione di eventi, alle traduzioni, al supporto per gli utenti e molto altro ancora.</p>
+    <p>Scopri la comunità italiana di Mozilla:</p>
+    <ul>
+        <li><a href="http://www.mozillaitalia.org">Il sito di Mozilla Italia</a></li>
+        <li><a href="http://forum.mozillaitalia.org">Il forum di supporto e centro di ogni nostra attività</a></li>
+        <li><a href="https://twitter.com/mozillaitalia/">@mozillaitalia su Twitter</a></li>
+        <li><a href="https://www.facebook.com/mozillaitalia">Mozilla Italia su Facebook</a></li>
+    </ul>
+    <h4>Che cos’è Firefox Nightly?</h4>
+    <p>Per Firefox esistono quattro diversi <a href="https://www.mozilla.org/firefox/channel/">canali di aggiornamento</a>. La versione <em>nightly</em> viene compilata ogni notte, da cui il nome, con l’ultima versione del codice disponibile. Questo significa che ogni pomeriggio, a meno di problemi tecnici, riceverai un aggiornamento di Firefox.</p>
+    <p>Essendo compilata a partire dall’ultima versione del codice, è normale che Firefox risulti meno stabile, presenti stringhe in inglese per alcuni giorni, o che includa funzioni sperimentali che verranno poi rimosse nel passaggio al canale <em>Aurora</em>.</p>
+    <p>Utilizzando Firefox Nightly in italiano puoi contribuire al miglioramento di Firefox e della traduzione prima che raggiunga il grande pubblico. Se riscontri dei problemi con Firefox Nightly, puoi aprire una discussione nella sezione del nostro forum dedicata alle <a href="http://forum.mozillaitalia.org/index.php?board=29.0">versioni di sviluppo</a>, oppure segnalare un <a href="http://forum.mozillaitalia.org/index.php?topic=45710.0">errore di traduzione</a>.
+  </div>
+{% endblock %}

--- a/bedrock/firefox/templates/firefox/nightly/firstrun.ru.html
+++ b/bedrock/firefox/templates/firefox/nightly/firstrun.ru.html
@@ -1,0 +1,20 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+
+{% extends "/firefox/nightly/firstrun.html" %}
+
+{% block locale_promo %}
+  <div class="mzp-l-content mzp-t-content-md locale-specific">
+    <h3>Вы нужны сообществу Mozilla Россия&nbsp;!</h3>
+    <p>Окажите помощь пользователям, примите участие в разработке, участвуйте в переводе, осуществляйте развитие открытых и свободных программ от Mozilla. Не пропустите возможность принять участие в проекте Mozilla на своем языке! </p>
+    <p>Узнайте больше о Mozilla Россия, русскоязычном сообществе Mozilla:</p>
+    <ul class="unstyled">
+        <li><a href="https://mozilla-russia.org/">Сайт Mozilla Россия</a></li>
+        <li><a href="https://forum.mozilla-russia.org/">Форум Mozilla Россия</a></li>
+        <li><a href="https://vk.com/club9845974">Mozilla Россия в Контакте</a></li>
+        <li><a href="https://www.facebook.com/MozillaRussia">Mozilla Россия в Фейсбуке</a></li>
+        <li><a href="https://twitter.com/mozilla_russia/">@mozilla_russia в Твиттере</a></li>
+    </ul>
+  </div>
+{% endblock %}

--- a/bedrock/firefox/urls.py
+++ b/bedrock/firefox/urls.py
@@ -70,7 +70,7 @@ urlpatterns = (
     page('firefox/unsupported-systems', 'firefox/unsupported-systems.html'),
     url(r'^firefox/new/$', views.NewView.as_view(), name='firefox.new'),
     url(r'^firefox/download/thanks/$', views.DownloadThanksView.as_view(), name='firefox.download.thanks'),
-    page('firefox/nightly/firstrun', 'firefox/nightly_firstrun.html'),
+    page('firefox/nightly/firstrun', 'firefox/nightly/firstrun.html', ftl_files=['firefox/nightly/firstrun']),
     url(r'^firefox/installer-help/$', views.InstallerHelpView.as_view(), name='firefox.installer-help'),
     url(firstrun_re, views.FirstrunView.as_view(), name='firefox.firstrun'),
     url(whatsnew_re, views.WhatsNewRedirectorView.as_view(), name='firefox.whatsnew'),

--- a/l10n/en/firefox/nightly/firstrun.ftl
+++ b/l10n/en/firefox/nightly/firstrun.ftl
@@ -1,0 +1,22 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+### URL: https://www-dev.allizom.org/firefox/nightly/firstrun/
+
+nightly-firstrun-firefox-nightly = { -brand-name-firefox-nightly } First Run Page
+nightly-firstrun-thank-you-for-using = Thank you for using { -brand-name-firefox-nightly }
+nightly-firstrun-choose-an-area = Choose an area to get involved below and help make { -brand-name-firefox } better for users everywhere
+nightly-firstrun-test = Test
+nightly-firstrun-find-and-file-bugs = Find and file bugs and generally make sure things work as they should.
+nightly-firstrun-start-testing = Start testing
+nightly-firstrun-code = Code
+nightly-firstrun-file-bugs-and-work = File bugs and work on the building blocks of the { -brand-name-firefox } browser.
+nightly-firstrun-start-coding = Start coding
+nightly-firstrun-localize = Localize
+nightly-firstrun-make-firefox-available = Make { -brand-name-firefox } available (and better) in more languages around the world.
+
+# Link used for the "Start localizing" button. You can instead use your own link if your community have a similar onboarding page about how to contribute to l10n. Must start with http:// or https://
+nightly-firstrun-contribute-link = https://wiki.mozilla.org/L10n:Contribute
+
+nightly-firstrun-start-localizing = Start localizing

--- a/l10n/en/firefox/nightly/firstrun.ftl
+++ b/l10n/en/firefox/nightly/firstrun.ftl
@@ -17,6 +17,6 @@ nightly-firstrun-localize = Localize
 nightly-firstrun-make-firefox-available = Make { -brand-name-firefox } available (and better) in more languages around the world.
 
 # Link used for the "Start localizing" button. You can instead use your own link if your community have a similar onboarding page about how to contribute to l10n. Must start with http:// or https://
-nightly-firstrun-contribute-link = https://wiki.mozilla.org/L10n:Contribute
+nightly-firstrun-contribute-link = https://pontoon.mozilla.org
 
 nightly-firstrun-start-localizing = Start localizing

--- a/lib/fluent_migrations/firefox/nightly_firstrun.py
+++ b/lib/fluent_migrations/firefox/nightly_firstrun.py
@@ -1,0 +1,80 @@
+from __future__ import absolute_import
+import fluent.syntax.ast as FTL
+from fluent.migrate.helpers import transforms_from
+from fluent.migrate.helpers import VARIABLE_REFERENCE, TERM_REFERENCE
+from fluent.migrate import REPLACE, COPY
+
+nightly_firstrun = "firefox/nightly_firstrun.lang"
+
+def migrate(ctx):
+    """Migrate bedrock/firefox/templates/firefox/nightly_firstrun.html, part {index}."""
+
+    ctx.add_transforms(
+        "firefox/nightly/firstrun.ftl",
+        "firefox/nightly/firstrun.ftl",
+        [
+            FTL.Message(
+                id=FTL.Identifier("nightly-firstrun-firefox-nightly"),
+                value=REPLACE(
+                    nightly_firstrun,
+                    "Firefox Nightly First Run Page",
+                    {
+                        "Firefox Nightly": TERM_REFERENCE("brand-name-firefox-nightly"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("nightly-firstrun-thank-you-for-using"),
+                value=REPLACE(
+                    nightly_firstrun,
+                    "Thank you for using Firefox Nightly",
+                    {
+                        "Firefox Nightly": TERM_REFERENCE("brand-name-firefox-nightly"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("nightly-firstrun-choose-an-area"),
+                value=REPLACE(
+                    nightly_firstrun,
+                    "Choose an area to get involved below and help make Firefox better for users everywhere",
+                    {
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                    }
+                )
+            ),
+        ] + transforms_from("""
+nightly-firstrun-test = {COPY(nightly_firstrun, "Test",)}
+nightly-firstrun-find-and-file-bugs = {COPY(nightly_firstrun, "Find and file bugs and generally make sure things work as they should.",)}
+nightly-firstrun-start-testing = {COPY(nightly_firstrun, "Start testing",)}
+nightly-firstrun-code = {COPY(nightly_firstrun, "Code",)}
+""", nightly_firstrun=nightly_firstrun) + [
+            FTL.Message(
+                id=FTL.Identifier("nightly-firstrun-file-bugs-and-work"),
+                value=REPLACE(
+                    nightly_firstrun,
+                    "File bugs and work on the building blocks of the Firefox browser.",
+                    {
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                    }
+                )
+            ),
+        ] + transforms_from("""
+nightly-firstrun-start-coding = {COPY(nightly_firstrun, "Start coding",)}
+nightly-firstrun-localize = {COPY(nightly_firstrun, "Localize",)}
+""", nightly_firstrun=nightly_firstrun) + [
+            FTL.Message(
+                id=FTL.Identifier("nightly-firstrun-make-firefox-available"),
+                value=REPLACE(
+                    nightly_firstrun,
+                    "Make Firefox available (and better) in more languages around the world.",
+                    {
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                    }
+                )
+            ),
+        ] + transforms_from("""
+nightly-firstrun-contribute-link = {COPY(nightly_firstrun, "https://wiki.mozilla.org/L10n:Contribute",)}
+nightly-firstrun-start-localizing = {COPY(nightly_firstrun, "Start localizing",)}
+""", nightly_firstrun=nightly_firstrun)
+        )

--- a/media/css/firefox/firstrun/nightly.scss
+++ b/media/css/firefox/firstrun/nightly.scss
@@ -5,10 +5,10 @@
 $font-path: '/media/fonts';
 $image-path: '/media/protocol/img';
 
-@import '../../protocol/css/includes/lib';
-@import '../../protocol/css/components/picto-card';
-@import '../../protocol/css/components/hero';
-@import '../../protocol/css/templates/card-layout';
+@import '../../../protocol/css/includes/lib';
+@import '../../../protocol/css/components/picto-card';
+@import '../../../protocol/css/components/hero';
+@import '../../../protocol/css/templates/card-layout';
 
 main {
     background-color: $color-ink-80;
@@ -71,9 +71,8 @@ main {
 
 .locale-specific {
     @include light-links;
-    max-width: 1060px;
-    margin-right: 0 auto;
-    padding-top: $layout-md;
+    margin: $layout-md auto 0;
+    text-align: center;
 
     h3,
     h4,

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -338,7 +338,7 @@
     },
     {
       "files": [
-        "css/firefox/nightly-firstrun.scss"
+        "css/firefox/firstrun/nightly.scss"
       ],
       "name": "nightly_firstrun"
     },


### PR DESCRIPTION
## Description
http://localhost:8000/en-US/firefox/nightly/firstrun/

## Issue / Bugzilla link
#9684

## Testing
```
./manage.py l10n_update
```