### PR TITLE
Update links to point to sync page (Fix#9704)

### DIFF
--- a/bedrock/firefox/templates/firefox/features/includes/features-content.html
+++ b/bedrock/firefox/templates/firefox/features/includes/features-content.html
@@ -65,7 +65,7 @@
     <section class="mzp-c-card-picto sync">
       <div class="mzp-c-card-picto-content">
         <div class="mzp-c-card-picto-desc">
-          <a href="{{ url('firefox.accounts') }}" rel="external">{{ ftl('features-shared-sync-between-devices') }}</a>
+          <a href="{{ url('firefox.sync') }}" rel="external">{{ ftl('features-shared-sync-between-devices') }}</a>
         </div>
       </div>
     </section>

--- a/bedrock/firefox/templates/firefox/features/index.html
+++ b/bedrock/firefox/templates/firefox/features/index.html
@@ -113,7 +113,7 @@
           <h3 class="mzp-c-card-picto-title">{{ ftl('features-shared-sync-between-devices') }}</h3>
           <div class="mzp-c-card-picto-desc">
             <p>{{ ftl('features-index-important-stuff') }}</p>
-            <a class="mzp-c-cta-link" href="{{ url('firefox.accounts') }}">{{ ftl('features-index-get-an-account') }}</a>
+            <a class="mzp-c-cta-link" href="{{ url('firefox.sync') }}">{{ ftl('features-index-get-an-account') }}</a>
           </div>
         </div>
       </section>

--- a/bedrock/firefox/templates/firefox/features/private-browsing.html
+++ b/bedrock/firefox/templates/firefox/features/private-browsing.html
@@ -63,7 +63,7 @@
     </p>
     {% endcall %}
 
-</section>
+</div>
 
 {% include "firefox/features/includes/features-content.html" %}
 


### PR DESCRIPTION
## Description

Update two links on features pages which reference sync to point to new sync page.

## Issue / Bugzilla link

Fix  #9704 

## Testing

http://localhost:8000/en-US/firefox/features/
http://localhost:8000/en-US/firefox/features/fast/