### PR TITLE
Migrate firefox/browsers/windows-64-bit to Fluent [fix #9691] [skip l10n]

### DIFF
--- a/bedrock/firefox/templates/firefox/browsers/windows-64-bit.html
+++ b/bedrock/firefox/templates/firefox/browsers/windows-64-bit.html
@@ -2,8 +2,6 @@
  # License, v. 2.0. If a copy of the MPL was not distributed with this
  # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
 
-{% add_lang_files "firefox/windows-64-bit" %}
-
 {% from "macros-protocol.html" import call_out_compact, hero with context %}
 
 {% extends "firefox/base/base-protocol.html" %}

--- a/bedrock/firefox/templates/firefox/browsers/windows-64-bit.html
+++ b/bedrock/firefox/templates/firefox/browsers/windows-64-bit.html
@@ -8,10 +8,10 @@
 
 {% extends "firefox/base/base-protocol.html" %}
 
-{% block page_title %}{{ _('Firefox for Windows 64-bit') }}{% endblock %}
+{% block page_title %}{{ ftl('windows-64-bit-firefox-for-windows') }}{% endblock %}
 
 {% block page_desc %}
-  {{ _('Users on 64-bit Windows who download Firefox can get our 64-bit version by default. That means you get a more secure version of Firefox.') }}
+  {{ ftl('windows-64-bit-users-on-64-bit-windows') }}
 {% endblock %}
 
 {% block page_css %}
@@ -40,8 +40,8 @@
   <div class="mzp-c-hero">
     <div class="hero-content">
       {{ high_res_img('protocol/img/logos/firefox/browser/logo-sm.png', {'alt': 'Firefox', 'width': '50', 'height': '50'}) }}
-      <p>{{ _('64-bit') }}</p>
-      <h1>{{ _('A more secure Firefox.') }}</h1>
+      <p>{{ ftl('windows-64-bit-64-bit') }}</p>
+      <h1>{{ ftl('windows-64-bit-a-more-secure-firefox') }}</h1>
       <div class="download-firefox">
         {{ download_firefox(dom_id='win64-hero-download', download_location='primary cta') }}
       </div>
@@ -50,34 +50,26 @@
   <div class="mzp-l-content">
   <article class="mzp-c-article">
   <p class="mzp-c-article-intro">
-    {% trans crashes='https://blog.mozilla.org/firefox/defeat-browser-crashes/' %}
-    Users on 64-bit Windows who download Firefox can get our 64-bit version by default. That means you get a more secure version of Firefox, one that also <a href="{{ crashes }}">crashes a whole lot less</a>. How much less? In our tests so far, 64-bit Firefox reduced crashes by 39% on machines with 4GB of RAM or more.
-    {% endtrans %}
+    {{ ftl('windows-64-bit-users-on-64-bit-windows-crashes', crashes='https://blog.mozilla.org/firefox/defeat-browser-crashes/') }}
   </p>
 
   <hr>
   <section class="article-section">
-    <h2>{{ _('What’s the difference between 32-bit and 64-bit?') }}</h2>
+    <h2>{{ ftl('windows-64-bit-whats-the-difference') }}</h2>
     <p>
-      {% trans ASLR='https://en.wikipedia.org/wiki/Address_space_layout_randomization' %}
-      Here’s the key thing to know: 64-bit applications can access more memory and are less likely to crash than 32-bit applications. Also, with the jump from 32 to 64 bits, a security feature called <a href={{ ASLR }}>Address Space Layout Randomization (ASLR)</a> works better to protect you from attackers. Linux and macOS users, fret not, you already enjoy a Firefox that’s optimized for 64-bit.
-      {% endtrans %}
+      {{ ftl('windows-64-bit-heres-the-key-thing', ASLR='https://en.wikipedia.org/wiki/Address_space_layout_randomization') }}
     </p>
   </section>
 
   <section class="article-section">
-    <h2>{{ _('How do you get 64-bit Firefox?') }}</h2>
+    <h2>{{ ftl('windows-64-bit-how-do-you-get-64') }}</h2>
     <p>
-    {% trans version='https://support.microsoft.com/help/13443/windows-which-operating-system', check='https://support.mozilla.org/kb/update-firefox-latest-version' %}
-      If you’re running 64-bit Windows (<a href="{{ version }}">here’s how to check</a>), your Firefox may already be 64-bit. <a href="{{ check }}">Check your Firefox version</a> (in the “About Firefox” window) and look for “(32-bit)” or “(64-bit)” after the version number:
-    {% endtrans %}
+    {{ ftl('windows-64-bit-if-youre-running', version='https://support.microsoft.com/help/13443/windows-which-operating-system', check='https://support.mozilla.org/kb/update-firefox-latest-version') }}
       <ul class="mzp-u-list-styled">
-        <li>{{ _('If you see “(32-bit)” and you are running Firefox 56.0 or older, updating to the latest Firefox version should automatically upgrade you to 64-bit.') }}</li>
-        <li>{{ _('If you see “(32-bit)” and are running Firefox 56.0.1 or newer, then your computer may not meet the minimum memory requirement for 64-bit (3 GB RAM or more). You can still manually install 64-bit Firefox, if you choose.') }}</li>
+        <li>{{ ftl('windows-64-bit-if-you-see-32-bit-older') }}</li>
+        <li>{{ ftl('windows-64-bit-if-you-see-32-bit-newer') }}</li>
       </ul>
-      {% trans all=url('firefox.all') %}
-      If you need to run 32-bit Firefox or manually install 64-bit Firefox, you can simply download and re-run the Windows (32-bit or 64-bit) Firefox installer from the <a href="{{ all }}">Firefox platforms and languages download page.</a>
-      {% endtrans %}
+      {{ ftl('windows-64-bit-if-you-need-to-run', all=url('firefox.all')) }}
     </p>
   </section>
 
@@ -85,7 +77,7 @@
 </div>
 
 {% call call_out_compact(
-title=_('Take control of your browser.'),
+title=ftl('windows-64-bit-take-control-of-your'),
 class='mzp-t-product-firefox mzp-t-firefox mzp-t-dark'
 ) %}
 <div class="download-firefox">

--- a/bedrock/firefox/urls.py
+++ b/bedrock/firefox/urls.py
@@ -154,7 +154,7 @@ urlpatterns = (
     page('firefox/browsers/incognito-browser', 'firefox/browsers/incognito-browser.html'),
     page('firefox/browsers/update-your-browser', 'firefox/browsers/update-browser.html'),
     page('firefox/browsers/what-is-a-browser', 'firefox/browsers/what-is-a-browser.html'),
-    page('firefox/browsers/windows-64-bit', 'firefox/browsers/windows-64-bit.html'),
+    page('firefox/browsers/windows-64-bit', 'firefox/browsers/windows-64-bit.html', ftl_files=['firefox/windows-64-bit']),
 
     # Lockwise
     page('firefox/lockwise', 'firefox/products/lockwise.html', ftl_files=['firefox/products/lockwise']),

--- a/bedrock/firefox/urls.py
+++ b/bedrock/firefox/urls.py
@@ -154,7 +154,7 @@ urlpatterns = (
     page('firefox/browsers/incognito-browser', 'firefox/browsers/incognito-browser.html'),
     page('firefox/browsers/update-your-browser', 'firefox/browsers/update-browser.html'),
     page('firefox/browsers/what-is-a-browser', 'firefox/browsers/what-is-a-browser.html'),
-    page('firefox/browsers/windows-64-bit', 'firefox/browsers/windows-64-bit.html', ftl_files=['firefox/windows-64-bit']),
+    page('firefox/browsers/windows-64-bit', 'firefox/browsers/windows-64-bit.html', ftl_files=['firefox/browsers/windows-64-bit']),
 
     # Lockwise
     page('firefox/lockwise', 'firefox/products/lockwise.html', ftl_files=['firefox/products/lockwise']),

--- a/l10n/en/firefox/browsers/windows-64-bit.ftl
+++ b/l10n/en/firefox/browsers/windows-64-bit.ftl
@@ -23,7 +23,7 @@ windows-64-bit-whats-the-difference = What’s the difference between 32-bit and
 # Variables:
 # $ASLR (url) - link to https://en.wikipedia.org/wiki/Address_space_layout_randomization
 # The term "fret not" can be translated as "not to worry", or "don’t worry".
-windows-64-bit-heres-the-key-thing = Here’s the key thing to know: 64-bit applications can access more memory and are less likely to crash than 32-bit applications. Also, with the jump from 32 to 64 bits, a security feature called <a href={ $ASLR }>Address Space Layout Randomization (ASLR)</a> works better to protect you from attackers. { -brand-name-linux } and { -brand-name-mac } users, fret not, you already enjoy a { -brand-name-firefox } that’s optimized for 64-bit.
+windows-64-bit-heres-the-key-thing = Here’s the key thing to know: 64-bit applications can access more memory and are less likely to crash than 32-bit applications. Also, with the jump from 32 to 64 bits, a security feature called <a href="{ $ASLR }">Address Space Layout Randomization (ASLR)</a> works better to protect you from attackers. { -brand-name-linux } and { -brand-name-mac } users, fret not, you already enjoy a { -brand-name-firefox } that’s optimized for 64-bit.
 windows-64-bit-how-do-you-get-64 = How do you get 64-bit { -brand-name-firefox }?
 
 # Variables:

--- a/l10n/en/firefox/windows-64-bit.ftl
+++ b/l10n/en/firefox/windows-64-bit.ftl
@@ -1,0 +1,39 @@
+# This Source Code Form is subject to the terms of the { -brand-name-mozilla } Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+### URL: https://www-dev.allizom.org/firefox/browsers/windows-64-bit/
+
+
+# HTML page title
+windows-64-bit-firefox-for-windows = { -brand-name-firefox } for { -brand-name-windows } 64-bit
+
+# HTML page description
+windows-64-bit-users-on-64-bit-windows = Users on 64-bit { -brand-name-windows } who download { -brand-name-firefox } can get our 64-bit version by default. That means you get a more secure version of { -brand-name-firefox }.
+windows-64-bit-64-bit = 64-bit
+
+# Main title
+windows-64-bit-a-more-secure-firefox = A more secure { -brand-name-firefox }.
+
+# Variables:
+# $crashes (url) - link to https://blog.mozilla.org/firefox/defeat-browser-crashes/
+windows-64-bit-users-on-64-bit-windows-crashes = Users on 64-bit { -brand-name-windows } who download { -brand-name-firefox } can get our 64-bit version by default. That means you get a more secure version of { -brand-name-firefox }, one that also <a href="{ $crashes }">crashes a whole lot less</a>. How much less? In our tests so far, 64-bit { -brand-name-firefox } reduced crashes by 39% on machines with 4GB of RAM or more.
+windows-64-bit-whats-the-difference = What’s the difference between 32-bit and 64-bit?
+
+# Variables:
+# $ASLR (url) - link to https://en.wikipedia.org/wiki/Address_space_layout_randomization
+# The term "fret not" can be translated as "not to worry", or "don’t worry".
+windows-64-bit-heres-the-key-thing = Here’s the key thing to know: 64-bit applications can access more memory and are less likely to crash than 32-bit applications. Also, with the jump from 32 to 64 bits, a security feature called <a href={ $ASLR }>Address Space Layout Randomization (ASLR)</a> works better to protect you from attackers. { -brand-name-linux } and { -brand-name-mac } users, fret not, you already enjoy a { -brand-name-firefox } that’s optimized for 64-bit.
+windows-64-bit-how-do-you-get-64 = How do you get 64-bit { -brand-name-firefox }?
+
+# Variables:
+# $version (url) - link to https://support.microsoft.com/help/13443/windows-which-operating-system
+# $check (url) - link to https://support.mozilla.org/kb/update-firefox-latest-version
+windows-64-bit-if-youre-running = If you’re running 64-bit { -brand-name-windows } (<a href="{ $version }">here’s how to check</a>), your { -brand-name-firefox } may already be 64-bit. <a href="{ $check }">Check your { -brand-name-firefox } version</a> (in the “About { -brand-name-firefox }” window) and look for “(32-bit)” or “(64-bit)” after the version number:
+windows-64-bit-if-you-see-32-bit-older = If you see “(32-bit)” and you are running { -brand-name-firefox } 56.0 or older, updating to the latest { -brand-name-firefox } version should automatically upgrade you to 64-bit.
+windows-64-bit-if-you-see-32-bit-newer = If you see “(32-bit)” and are running Firefox 56.0.1 or newer, then your computer may not meet the minimum memory requirement for 64-bit (3 GB RAM or more). You can still manually install 64-bit Firefox, if you choose.
+
+# Variables:
+# $all (url) - link to https://www.mozilla.org/firefox/all/
+windows-64-bit-if-you-need-to-run = If you need to run 32-bit { -brand-name-firefox } or manually install 64-bit { -brand-name-firefox }, you can simply download and re-run the { -brand-name-windows } (32-bit or 64-bit) { -brand-name-firefox } installer from the <a href="{ $all }">{ -brand-name-firefox } platforms and languages download page.</a>
+windows-64-bit-take-control-of-your = Take control of your browser.

--- a/lib/fluent_migrations/firefox/browsers/windows-64-bit.py
+++ b/lib/fluent_migrations/firefox/browsers/windows-64-bit.py
@@ -4,7 +4,6 @@ from fluent.migrate.helpers import transforms_from
 from fluent.migrate.helpers import VARIABLE_REFERENCE, TERM_REFERENCE
 from fluent.migrate import REPLACE, COPY
 
-windows_64_bit = "firefox/browsers/windows-64-bit.lang"
 windows_64_bit = "firefox/windows-64-bit.lang"
 
 def migrate(ctx):
@@ -53,9 +52,9 @@ windows-64-bit-64-bit = {COPY(windows_64_bit, "64-bit",)}
                 id=FTL.Identifier("windows-64-bit-users-on-64-bit-windows-crashes"),
                 value=REPLACE(
                     windows_64_bit,
-                    "Users on 64-bit Windows who download Firefox can get our 64-bit version by default. That means you get a more secure version of Firefox, one that also <a href=\"%(crashes)s\">crashes a whole lot less</a>. How much less? In our tests so far, 64-bit Firefox reduced crashes by 39% on machines with 4GB of RAM or more.",
+                    "Users on 64-bit Windows who download Firefox can get our 64-bit version by default. That means you get a more secure version of Firefox, one that also <a href=\"%(crashes)s\">crashes a whole lot less</a>. How much less? In our tests so far, 64-bit Firefox reduced crashes by 39%% on machines with 4GB of RAM or more.",
                     {
-                        "%%": "%",
+                        "%%": FTL.TextElement("%"),
                         "%(crashes)s": VARIABLE_REFERENCE("crashes"),
                         "Firefox": TERM_REFERENCE("brand-name-firefox"),
                         "Windows": TERM_REFERENCE("brand-name-windows"),

--- a/lib/fluent_migrations/firefox/browsers/windows-64-bit.py
+++ b/lib/fluent_migrations/firefox/browsers/windows-64-bit.py
@@ -1,0 +1,142 @@
+from __future__ import absolute_import
+import fluent.syntax.ast as FTL
+from fluent.migrate.helpers import transforms_from
+from fluent.migrate.helpers import VARIABLE_REFERENCE, TERM_REFERENCE
+from fluent.migrate import REPLACE, COPY
+
+windows_64_bit = "firefox/browsers/windows-64-bit.lang"
+windows_64_bit = "firefox/windows-64-bit.lang"
+
+def migrate(ctx):
+    """Migrate bedrock/firefox/templates/firefox/browsers/windows-64-bit.html, part {index}."""
+
+    ctx.add_transforms(
+        "firefox/windows-64-bit.ftl",
+        "firefox/windows-64-bit.ftl",
+        [
+            FTL.Message(
+                id=FTL.Identifier("windows-64-bit-firefox-for-windows"),
+                value=REPLACE(
+                    windows_64_bit,
+                    "Firefox for Windows 64-bit",
+                    {
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                        "Windows": TERM_REFERENCE("brand-name-windows"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("windows-64-bit-users-on-64-bit-windows"),
+                value=REPLACE(
+                    windows_64_bit,
+                    "Users on 64-bit Windows who download Firefox can get our 64-bit version by default. That means you get a more secure version of Firefox.",
+                    {
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                        "Windows": TERM_REFERENCE("brand-name-windows"),
+                    }
+                )
+            ),
+        ] + transforms_from("""
+windows-64-bit-64-bit = {COPY(windows_64_bit, "64-bit",)}
+""", windows_64_bit=windows_64_bit) + [
+            FTL.Message(
+                id=FTL.Identifier("windows-64-bit-a-more-secure-firefox"),
+                value=REPLACE(
+                    windows_64_bit,
+                    "A more secure Firefox.",
+                    {
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("windows-64-bit-users-on-64-bit-windows-crashes"),
+                value=REPLACE(
+                    windows_64_bit,
+                    "Users on 64-bit Windows who download Firefox can get our 64-bit version by default. That means you get a more secure version of Firefox, one that also <a href=\"%(crashes)s\">crashes a whole lot less</a>. How much less? In our tests so far, 64-bit Firefox reduced crashes by 39% on machines with 4GB of RAM or more.",
+                    {
+                        "%%": "%",
+                        "%(crashes)s": VARIABLE_REFERENCE("crashes"),
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                        "Windows": TERM_REFERENCE("brand-name-windows"),
+                    }
+                )
+            ),
+        ] + transforms_from("""
+windows-64-bit-whats-the-difference = {COPY(windows_64_bit, "What’s the difference between 32-bit and 64-bit?",)}
+""", windows_64_bit=windows_64_bit) + [
+            FTL.Message(
+                id=FTL.Identifier("windows-64-bit-heres-the-key-thing"),
+                value=REPLACE(
+                    windows_64_bit,
+                    "Here’s the key thing to know: 64-bit applications can access more memory and are less likely to crash than 32-bit applications. Also, with the jump from 32 to 64 bits, a security feature called <a href=%(ASLR)s>Address Space Layout Randomization (ASLR)</a> works better to protect you from attackers. Linux and macOS users, fret not, you already enjoy a Firefox that’s optimized for 64-bit.",
+                    {
+                        "%%": "%",
+                        "%(ASLR)s": VARIABLE_REFERENCE("ASLR"),
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                        "Linux": TERM_REFERENCE("brand-name-linux"),
+                        "macOS": TERM_REFERENCE("brand-name-mac"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("windows-64-bit-how-do-you-get-64"),
+                value=REPLACE(
+                    windows_64_bit,
+                    "How do you get 64-bit Firefox?",
+                    {
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("windows-64-bit-if-youre-running"),
+                value=REPLACE(
+                    windows_64_bit,
+                    "If you’re running 64-bit Windows (<a href=\"%(version)s\">here’s how to check</a>), your Firefox may already be 64-bit. <a href=\"%(check)s\">Check your Firefox version</a> (in the “About Firefox” window) and look for “(32-bit)” or “(64-bit)” after the version number:",
+                    {
+                        "%%": "%",
+                        "%(version)s": VARIABLE_REFERENCE("version"),
+                        "%(check)s": VARIABLE_REFERENCE("check"),
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                        "Windows": TERM_REFERENCE("brand-name-windows"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("windows-64-bit-if-you-see-32-bit-older"),
+                value=REPLACE(
+                    windows_64_bit,
+                    "If you see “(32-bit)” and you are running Firefox 56.0 or older, updating to the latest Firefox version should automatically upgrade you to 64-bit.",
+                    {
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("windows-64-bit-if-you-see-32-bit-newer"),
+                value=REPLACE(
+                    windows_64_bit,
+                    "If you see “(32-bit)” and are running Firefox 56.0.1 or newer, then your computer may not meet the minimum memory requirement for 64-bit (3 GB RAM or more). You can still manually install 64-bit Firefox, if you choose.",
+                    {
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("windows-64-bit-if-you-need-to-run"),
+                value=REPLACE(
+                    windows_64_bit,
+                    "If you need to run 32-bit Firefox or manually install 64-bit Firefox, you can simply download and re-run the Windows (32-bit or 64-bit) Firefox installer from the <a href=\"%(all)s\">Firefox platforms and languages download page.</a>",
+                    {
+                        "%%": "%",
+                        "%(all)s": VARIABLE_REFERENCE("all"),
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                        "Windows": TERM_REFERENCE("brand-name-windows"),
+                    }
+                )
+            ),
+        ] + transforms_from("""
+windows-64-bit-take-control-of-your = {COPY(windows_64_bit, "Take control of your browser.",)}
+""", windows_64_bit=windows_64_bit)
+        )


### PR DESCRIPTION
## Description
L10n PR: https://github.com/mozilla-l10n/www-l10n/pull/134

One possible sticking point is that the .lang file is in the root of /firefox but I'm trying to move the corresponding Fluent file into /firefox/browsers (to match the URL). Not sure if that will cause problems, maybe better to leave it in the /firefox folder?

Edit: ^^ that was indeed problematic, I've moved it back into the /firefox folder.

Edit 2: After moving it back to the /firefox folder to make it easier to run the migration, I then moved all the files to /firefox/browsers manually when committing to www-l10n.

## Issue / Bugzilla link
#9691 

## Testing
http://localhost:8000/firefox/browsers/windows-64-bit/