### PR TITLE
Fix brand names in firefox/browsers/windows-64-bit.ftl [skip l10n]

### DIFF
--- a/l10n/en/firefox/browsers/windows-64-bit.ftl
+++ b/l10n/en/firefox/browsers/windows-64-bit.ftl
@@ -31,7 +31,7 @@ windows-64-bit-how-do-you-get-64 = How do you get 64-bit { -brand-name-firefox }
 # $check (url) - link to https://support.mozilla.org/kb/update-firefox-latest-version
 windows-64-bit-if-youre-running = If you’re running 64-bit { -brand-name-windows } (<a href="{ $version }">here’s how to check</a>), your { -brand-name-firefox } may already be 64-bit. <a href="{ $check }">Check your { -brand-name-firefox } version</a> (in the “About { -brand-name-firefox }” window) and look for “(32-bit)” or “(64-bit)” after the version number:
 windows-64-bit-if-you-see-32-bit-older = If you see “(32-bit)” and you are running { -brand-name-firefox } 56.0 or older, updating to the latest { -brand-name-firefox } version should automatically upgrade you to 64-bit.
-windows-64-bit-if-you-see-32-bit-newer = If you see “(32-bit)” and are running Firefox 56.0.1 or newer, then your computer may not meet the minimum memory requirement for 64-bit (3 GB RAM or more). You can still manually install 64-bit Firefox, if you choose.
+windows-64-bit-if-you-see-32-bit-newer = If you see “(32-bit)” and are running { -brand-name-firefox } 56.0.1 or newer, then your computer may not meet the minimum memory requirement for 64-bit (3 GB RAM or more). You can still manually install 64-bit { -brand-name-firefox }, if you choose.
 
 # Variables:
 # $all (url) - link to https://www.mozilla.org/firefox/all/


### PR DESCRIPTION
## Description
Missed some brand names in the migration.

www-l10n PR: https://github.com/mozilla-l10n/www-l10n/pull/137

## Issue / Bugzilla link
https://github.com/mozilla/bedrock/pull/9709#discussion_r527040196
