### PR TITLE
Use helpers for footer social media links (Fix #9699)

### DIFF
--- a/bedrock/base/templates/includes/protocol/footer/footer.html
+++ b/bedrock/base/templates/includes/protocol/footer/footer.html
@@ -71,8 +71,8 @@
 
           <h5 class="c-footer-heading">{{ ftl('footer-follow-firefox') }}</h5>
           <ul class="c-footer-list-social">
-            <li><a class="twitter" href="https://twitter.com/firefox" data-link-type="footer" data-link-name="Twitter (@firefox)">{{ ftl('footer-twitter') }}<span> (@firefox)</span></a></li>
-            <li><a class="instagram" href="https://www.instagram.com/firefox/" data-link-type="footer" data-link-name="Instagram (@firefox)">{{ ftl('footer-instagram') }}<span> (@firefox)</span></a></li>
+            <li><a class="twitter" href="{{ firefox_twitter_url() }}" data-link-type="footer" data-link-name="Twitter (@firefox)">{{ ftl('footer-twitter') }}<span> (@firefox)</span></a></li>
+            <li><a class="instagram" href="{{ firefox_instagram_url() }}" data-link-type="footer" data-link-name="Instagram (@firefox)">{{ ftl('footer-instagram') }}<span> (@firefox)</span></a></li>
             <li><a class="youtube" href="https://www.youtube.com/user/firefoxchannel" data-link-type="footer" data-link-name="YouTube (@firefoxchannel)">{{ ftl('footer-youtube') }}<span> (@firefoxchannel)</span></a></li>
           </ul>
         </section>

--- a/bedrock/mozorg/templatetags/misc.py
+++ b/bedrock/mozorg/templatetags/misc.py
@@ -439,6 +439,39 @@ def firefox_twitter_url(ctx):
     return settings.FIREFOX_TWITTER_ACCOUNTS[locale]
 
 
+@library.global_function
+@jinja2.contextfunction
+def firefox_instagram_url(ctx):
+    """Output a link to Instagram taking locales into account.
+
+    Uses the locale from the current request. Checks to see if we have
+    a Instagram account that match this locale, returns the localized account
+    url or falls back to the US account url if not.
+
+    Examples
+    ========
+
+    In Template
+    -----------
+
+        {{ firefox_instagram_url() }}
+
+    For en-US this would output:
+
+        https://www.instagram.com/firefox/
+
+    For DE this would output:
+
+        https://www.instagram.com/unfcktheinternet/
+
+    """
+    locale = getattr(ctx['request'], 'locale', 'en-US')
+    if locale not in settings.FIREFOX_INSTAGRAM_ACCOUNTS:
+        locale = 'en-US'
+
+    return settings.FIREFOX_INSTAGRAM_ACCOUNTS[locale]
+
+
 @library.filter
 def absolute_url(url):
     """

--- a/bedrock/mozorg/tests/test_helper_misc.py
+++ b/bedrock/mozorg/tests/test_helper_misc.py
@@ -47,6 +47,11 @@ TEST_FIREFOX_TWITTER_ACCOUNTS = {
     'pt-BR': 'https://twitter.com/firefoxbrasil',
 }
 
+TEST_FIREFOX_INSTAGRAM_ACCOUNTS = {
+    'de': 'https://www.instagram.com/unfcktheinternet/',
+    'en-US': 'https://www.instagram.com/firefox/',
+}
+
 TEST_FXA_ENDPOINT = 'https://accounts.firefox.com/'
 TEST_FXA_MOZILLAONLINE_ENDPOINT = 'https://accounts.firefox.com.cn/'
 
@@ -420,6 +425,32 @@ class TestFirefoxTwitterUrl(TestCase):
         assert self._render('es-CL') == 'https://twitter.com/firefox'
         assert self._render('es-MX') == 'https://twitter.com/firefox'
         assert self._render('pt-PT') == 'https://twitter.com/firefox'
+
+
+@override_settings(FIREFOX_INSTAGRAM_ACCOUNTS=TEST_FIREFOX_INSTAGRAM_ACCOUNTS)
+class TestFirefoxInstagramUrl(TestCase):
+    rf = RequestFactory()
+
+    def _render(self, locale):
+        req = self.rf.get('/')
+        req.locale = locale
+        return render('{{ firefox_instagram_url() }}', {'request': req})
+
+    def test_firefox_twitter_url_no_locale(self):
+        """No locale, fallback to default account"""
+        assert self._render('') == 'https://www.instagram.com/firefox/'
+
+    def test_firefox_twitter_url_english(self):
+        """en-US locale, default account"""
+        assert self._render('en-US') == 'https://www.instagram.com/firefox/'
+
+    def test_firefox_twitter_url_spanish(self):
+        """de locale, a local account"""
+        assert self._render('de') == 'https://www.instagram.com/unfcktheinternet/'
+
+    def test_firefox_twitter_url_other_locale(self):
+        """No account for locale, fallback to default account"""
+        assert self._render('es-AR') == 'https://www.instagram.com/firefox/'
 
 
 @override_settings(STATIC_URL='/media/')

--- a/bedrock/settings/base.py
+++ b/bedrock/settings/base.py
@@ -1239,6 +1239,12 @@ FIREFOX_TWITTER_ACCOUNTS = {
     'pt-BR': 'https://twitter.com/firefoxbrasil',
 }
 
+# Official Firefox Instagram accounts
+FIREFOX_INSTAGRAM_ACCOUNTS = {
+    'de': 'https://www.instagram.com/unfcktheinternet/',
+    'en-US': 'https://www.instagram.com/firefox/',
+}
+
 # Fx Accounts iframe-less form & JS endpoint
 # ***This URL *MUST* end in a traling slash!***
 


### PR DESCRIPTION
## Description

- use Twitter helper for Firefox twitter link in footer
- add and use Instagram helper for Firefox Instagram link in footer

## Issue / Bugzilla link

Fix #9699

## Testing

- [x] English loads on English pages
- [x] German loads on German pages
- [x] falls back to English on unsupported page (I used Acholi because it's first in the list)