### PR TITLE
Configure firefox/privacy/book.ftl for de, fr, and en only. [no bug]

### DIFF
--- a/l10n/configs/pontoon.toml
+++ b/l10n/configs/pontoon.toml
@@ -146,5 +146,13 @@ locales = [
         "ru"
     ]
 [[paths]]
+    reference = "en/firefox/privacy/book.ftl"
+    l10n = "{locale}/firefox/privacy/book.ftl"
+    locales = [
+        "de",
+        "fr"
+    ]
+[[paths]]
     reference = "en/**/*.ftl"
     l10n = "{locale}/**/*.ftl"
+


### PR DESCRIPTION
## Description

Configure firefox/privacy/book to be exposed for DE, FR, and EN localization only.

[Context from Peiying:](https://github.com/mozilla-l10n/www-l10n/pull/127#pullrequestreview-529626438)
> Given the length of this page, we are discussing with Justin on how to keep a content heavy page like this one to the target markets and offer an alternative, a shorter version to smaller communities. This page is best left for the l10n vendor to do.

The EU team already has translations available for DE and FR once this is available in Pontoon.

**www-l10n ref:** https://github.com/mozilla-l10n/www-l10n/pull/139