### PR TITLE
Add more explicit path definitions to pontoon Fluent config

### DIFF
--- a/docs/l10n.rst
+++ b/docs/l10n.rst
@@ -396,6 +396,12 @@ in one or more configuration files. For example:
 
 You can read more about configuration files in the `L10n Project Configuration`_ docs.
 
+.. important::
+
+    Path definitions in Fluent configuration files are not source order dependent. A broad
+    definition using a wild card can invalidate all previous path definitions for example.
+    Paths should be defined carefully to avoid exposing .ftl files to unintended locales.
+
 Using a combination of vendor and pontoon configuration offers a flexible but specific set of
 options to choose from when it comes to defining an l10n strategy for a page. The available
 choices are:

--- a/l10n/configs/pontoon.toml
+++ b/l10n/configs/pontoon.toml
@@ -159,11 +159,11 @@ locales = [
     reference = "en/mozorg/about/**/*.ftl"
     l10n = "{locale}/mozorg/about/**/*.ftl"
 [[paths]]
-    reference = "en/mozorg/about/contribute.ftl"
-    l10n = "{locale}/mozorg/about/contribute.ftl"
+    reference = "en/mozorg/contribute.ftl"
+    l10n = "{locale}/mozorg/contribute.ftl"
 [[paths]]
-    reference = "en/mozorg/about/mission.ftl"
-    l10n = "{locale}/mozorg/about/mission.ftl"
+    reference = "en/mozorg/mission.ftl"
+    l10n = "{locale}/mozorg/mission.ftl"
 [[paths]]
     reference = "en/mozorg/newsletters.ftl"
     l10n = "{locale}/mozorg/newsletters.ftl"

--- a/l10n/configs/pontoon.toml
+++ b/l10n/configs/pontoon.toml
@@ -116,6 +116,55 @@ locales = [
 ]
 
 [[paths]]
+    reference = "en/*.ftl"
+    l10n = "{locale}/*.ftl"
+[[paths]]
+    reference = "en/banners/**/*.ftl"
+    l10n = "{locale}/banners/**/*.ftl"
+[[paths]]
+    reference = "en/firefox/*.ftl"
+    l10n = "{locale}/firefox/*.ftl"
+[[paths]]
+    reference = "en/firefox/browsers/**/*.ftl"
+    l10n = "{locale}/firefox/browsers/**/*.ftl"
+[[paths]]
+    reference = "en/firefox/features/**/*.ftl"
+    l10n = "{locale}/firefox/features/**/*.ftl"
+[[paths]]
+    reference = "en/firefox/new/**/*.ftl"
+    l10n = "{locale}/firefox/new/**/*.ftl"
+[[paths]]
+    reference = "en/firefox/nightly/**/*.ftl"
+    l10n = "{locale}/firefox/nightly/**/*.ftl"
+[[paths]]
+    reference = "en/firefox/privacy/book.ftl"
+    l10n = "{locale}/firefox/privacy/book.ftl"
+    locales = [
+        "de",
+        "fr"
+    ]
+[[paths]]
+    reference = "en/firefox/products/**/*.ftl"
+    l10n = "{locale}/firefox/products/**/*.ftl"
+[[paths]]
+    reference = "en/firefox/set-as-default/**/*.ftl"
+    l10n = "{locale}/firefox/set-as-default/**/*.ftl"
+[[paths]]
+    reference = "en/firefox/welcome/**/*.ftl"
+    l10n = "{locale}/firefox/welcome/**/*.ftl"
+[[paths]]
+    reference = "en/firefox/whatsnew/**/*.ftl"
+    l10n = "{locale}/firefox/whatsnew/**/*.ftl"
+[[paths]]
+    reference = "en/mozorg/about/**/*.ftl"
+    l10n = "{locale}/mozorg/about/**/*.ftl"
+[[paths]]
+    reference = "en/mozorg/about/contribute.ftl"
+    l10n = "{locale}/mozorg/about/contribute.ftl"
+[[paths]]
+    reference = "en/mozorg/about/mission.ftl"
+    l10n = "{locale}/mozorg/about/mission.ftl"
+[[paths]]
     reference = "en/mozorg/newsletters.ftl"
     l10n = "{locale}/mozorg/newsletters.ftl"
     locales = [
@@ -145,14 +194,3 @@ locales = [
         "pt-BR",
         "ru"
     ]
-[[paths]]
-    reference = "en/firefox/privacy/book.ftl"
-    l10n = "{locale}/firefox/privacy/book.ftl"
-    locales = [
-        "de",
-        "fr"
-    ]
-[[paths]]
-    reference = "en/**/*.ftl"
-    l10n = "{locale}/**/*.ftl"
-


### PR DESCRIPTION
See discussion in https://github.com/mozilla-l10n/www-l10n/pull/146

@pmac r? It seems like these config files don't quite work the way we originally thought, and we can't use broad wild cards like the way we have been if we need to expose certain files only to a subset of locales. 

This fix is a little verbose, but (from what I can tell) it's the only real option we have that doesn't involve re-architecting all the L10n files into different directories (which feels like a somewhat large change to make suddenly).

Thoughts?
