### PR TITLE
Sticky promo fixes (#9721, #9728)

### DIFF
--- a/bedrock/base/templates/includes/sticky-promo.html
+++ b/bedrock/base/templates/includes/sticky-promo.html
@@ -8,30 +8,30 @@
     <button class="mzp-c-sticky-promo-close" type="button">{{ ftl('ui-close') }}</button>
     <div class="promo-firefox">
       <h3 class="mzp-c-sticky-promo-title">{{ ftl('firefox-sticky-promo-get-the-latest-firefox') }}</h3>
-      {{ download_firefox_thanks(dom_id='sticky-promo', download_location='other', button_class='mzp-c-button mzp-t-product mzp-t-small') }}
+      {{ download_firefox_thanks(dom_id='sticky-promo', download_location='sticky-promo-box', button_class='mzp-c-button mzp-t-product mzp-t-small') }}
     </div>
     <div class="promo-products">
       <h3 class="mzp-c-sticky-promo-title">{{ ftl('firefox-sticky-promo-meet-our-family-of') }}</h3>
       <ul class="promo-products-list">
         <li>
           <a data-link-name="Browsers" data-link-type="link" data-link-position="sticky-promo" class="promo-products-link" href="{{ url('firefox.browsers.index') }}{{ promo_referrals }}">
-            <img src="{{ static('protocol/img/logos/firefox/browser/logo.svg') }}" alt="">
+            <img src="{{ static('protocol/img/logos/firefox/browser/logo.svg') }}" width="32" height="32" alt="">
             {{ ftl('firefox-sticky-promo-browsers') }}
           </a>
           <a data-link-name="Monitor" data-link-type="link" data-link-position="sticky-promo" class="promo-products-link" href="https://monitor.firefox.com/{{ referral|safe }}{{ promo_referrals }}" rel="external noopener">
-            <img src="{{ static('protocol/img/logos/firefox/monitor/logo.svg') }}" alt="">
+            <img src="{{ static('protocol/img/logos/firefox/monitor/logo.svg') }}" width="32" height="32" alt="">
             {{ ftl('firefox-sticky-promo-monitor') }}
           </a>
           <a data-link-name="Lockwise" data-link-type="link" data-link-position="sticky-promo" class="promo-products-link" rel="" href="{{ url('firefox.products.lockwise') }}{{ promo_referrals }}">
-            <img src="{{ static('protocol/img/logos/firefox/lockwise/logo.svg') }}" alt="">
+            <img src="{{ static('protocol/img/logos/firefox/lockwise/logo.svg') }}" width="32" height="32" alt="">
             {{ ftl('firefox-sticky-promo-lockwise') }}
           </a>
           <a data-link-name="Pocket" data-link-type="link" data-link-position="sticky-promo" class="promo-products-link" rel="external noopener" href="https://getpocket.com/{{ referral|safe }}{{ promo_referrals }}">
-            <img src="{{ static('protocol/img/logos/pocket/pocket.svg') }}" alt="">
+            <img src="{{ static('protocol/img/logos/pocket/pocket.svg') }}" width="32" height="29" alt="">
             {{ ftl('firefox-sticky-promo-pocket') }}
           </a>
           <a data-link-name="Mozilla VPN" data-link-type="link" data-link-position="sticky-promo" class="promo-products-link" rel="external noopener" href="https://vpn.mozilla.org/{{ referral|safe }}{{ promo_referrals }}">
-            <img src="{{ static('img/icons/connection.svg') }}" alt="">
+            <img src="{{ static('img/icons/connection.svg') }}" width="32" height="35" alt="">
             {{ ftl('firefox-sticky-promo-mozilla-vpn') }}
           </a>
         </li>


### PR DESCRIPTION
## Description
- Fix GA attribution.
- Declare explicit logo sizes.

## Issue / Bugzilla link
https://github.com/mozilla/bedrock/issues/9721
https://github.com/mozilla/bedrock/issues/9728