### PR TITLE
Android native styled banners A/B test on /firefox. (#9434)

### DIFF
--- a/bedrock/base/templates/includes/banners/mobile/native-android-exp.html
+++ b/bedrock/base/templates/includes/banners/mobile/native-android-exp.html
@@ -1,0 +1,32 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+
+{% set android_url = firefox_adjust_url('android', 'native-android-exp-banner') %}
+
+<aside class="c-banner hide-from-legacy-ie mzp-t-firefox" id="native-android-banner">
+  {# Exclude banners from search result snippets using `data-nosnippet` (issue 8739) #}
+  <div class="c-banner-inner" data-nosnippet="true">
+    <button type="button" class="c-banner-close"><span>{{ ftl('ui-close') }}</span></button>
+    <div class="mzp-l-content">
+      <div class="c-banner-main">
+        <img class="smartbanner-icon" src="https://www.mozilla.org/media/cro_exp/img/nativedownload/android-icon-512.jpg" alt="Firefox icon" />
+
+        <span>
+          <h2 class="c-banner-title">Firefox: Private, Safe Browser</h2>
+          <p>Mozilla</p>
+          {% if variant == 'b' %}
+          <img class="smartbanner-rating" src="https://www.mozilla.org/media/cro_exp/img/nativedownload/stars-android.png" alt="star rating" />
+          {% endif %}
+          <p>Free &ndash; In Google Play</p>
+        </span>
+
+        <div class="c-cta android">
+          <a id="play-store-link" class="smartbanner-button" href="{{ android_url }}">View</a>
+        </div>
+
+      </div>
+    </div>
+  </div>
+</aside>
+

--- a/bedrock/firefox/templates/firefox/home/index-master.html
+++ b/bedrock/firefox/templates/firefox/home/index-master.html
@@ -28,8 +28,8 @@
 {% block page_css %}
   {{ css_bundle('firefox-master') }}
 
-  {% if switch('firefox-daylight-promo-banner') %}
-    {{ css_bundle('daylight-promo-banner') }}
+  {% if switch('firefox-mobile-android-experiment') %}
+    {{ css_bundle('native-android-exp-banner') }}
   {% endif %}
 {% endblock %}
 
@@ -63,8 +63,8 @@
 {% endblock %}
 
 {% block page_banner %}
-  {% if switch('firefox-daylight-promo-banner') %}
-    {% include 'includes/banners/daylight/daylight-promo.html' %}
+  {% if switch('firefox-mobile-android-experiment') %}
+    {% include 'includes/banners/mobile/native-android-exp.html' %}
   {% endif %}
 {% endblock %}
 
@@ -269,8 +269,14 @@
 {% block js %}
   {{ js_bundle('firefox-master') }}
 
-  {% if switch('firefox-daylight-promo-banner') %}
-    {{ js_bundle('daylight-promo-banner') }}
+  {% if switch('firefox-mobile-android-experiment') %}
+    {{ js_bundle('native-android-exp-banner') }}
+  {% endif %}
+{% endblock %}
+
+{% block experiments %}
+  {% if switch('firefox-mobile-android-experiment', ['en-US']) %}
+    {{ js_bundle('firefox-mobile-android-experiment') }}
   {% endif %}
 {% endblock %}
 

--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -839,6 +839,21 @@ class FirefoxHomeView(L10nTemplateView):
     }
     activation_files = ['firefox/home', 'firefox/home/index-quantum.html']
 
+    # place expected ?v= values in this list
+    variations = ['a', 'b', 'c', 'd']
+
+    def get_context_data(self, **kwargs):
+        ctx = super(FirefoxHomeView, self).get_context_data(**kwargs)
+        variant = self.request.GET.get('v', None)
+
+        # ensure variant matches pre-defined value
+        if variant not in self.variations:
+            variant = None
+
+        ctx['variant'] = variant
+
+        return ctx
+
     def get_template_names(self):
         if ftl_file_is_active('firefox/home'):
             template_name = 'firefox/home/index-master.html'

--- a/media/css/base/banners/native-android-exp.scss
+++ b/media/css/base/banners/native-android-exp.scss
@@ -1,0 +1,143 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+$font-path: '/media/fonts';
+$image-path: '/media/protocol/img';
+
+@import '../../../protocol/css/includes/lib';
+
+  .smartbanner-icon {
+    width: 57px;
+    height: 57px;
+    background-size: cover;
+    background-image: url("https://www.mozilla.org/media/cro_exp/img/nativedownload/android-icon-512.jpg");
+    border-radius: 8px;
+    margin-right: 10px;
+  }
+
+  .smartbanner-button {
+    padding: 4px 12px;
+    font-size: 16px;
+    font-weight: 500;
+    color: $color-white;
+    text-decoration: none;
+    border-radius: 5px;
+    background-color: #68A036;
+    text-transform: uppercase;
+  }
+
+  .smartbanner-button-text {
+    text-align: center;
+    display: block;
+    padding: 0 5px;
+    text-decoration: none;
+  }
+
+#native-android-banner {
+    &.c-banner {
+        @include text-body-sm;
+        align-items: center;
+        background: #f2f2f2;
+        border-bottom: 1px solid #ccc;
+        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+        margin-bottom: 10px;
+        padding: 10px;
+
+        // hide by default if JS is available to avoid flicker
+        // (if visitor previously dismissed)
+        .js & {
+            display: none;
+        }
+
+        // conditional class used to display the banner.
+        &.c-banner-is-visible {
+            display: block;
+        }
+    }
+
+    .c-banner-title {
+        @include bidi(((padding-right, $spacing-lg, 0), (padding-left, 0, $spacing-lg),)); // make room for the close button
+        @include text-body-md;
+        line-height: 20px;
+        color: #000;
+        font-weight: 500;
+    }
+
+    @media #{$mq-md} {
+        .c-banner-main {
+            display: flex;
+            align-items: center;
+
+            .smartbanner-rating {
+                width: 70px;
+                padding: 1px 0;
+              }
+
+            span p {
+                margin: 0;
+            }
+        }
+
+        .c-banner-title {
+            margin: 0;
+            padding: 0;
+        }
+
+        .c-cta {
+            line-height: 0;
+            min-width: 180px;
+            padding: 0 $spacing-xl;
+        }
+    }
+
+
+    // Conditional content
+
+    .android & .mobile-download-buttons {
+        .android {
+            display: inline-block;
+        }
+    }
+
+    // Close button
+    .c-banner-close {
+        @include background-size(20px 20px);
+        @include bidi((
+            (left, $spacing-sm, auto),
+            (right, auto, $spacing-sm),
+        ));
+        @include image-replaced;
+        background: transparent url('#{$image-path}/icons/close.svg') center center no-repeat;
+        border: none;
+        cursor: pointer;
+        display: none;
+        height: 42px;
+        min-width: 0;
+        padding: 0;
+        position: absolute;
+        top: $spacing-sm;
+        width: 42px;
+        z-index: 1;
+
+        &:hover,
+        &:focus {
+            @include transition(transform .1s ease-in-out);
+            @include transform(scale(1.1));
+        }
+
+        &:focus {
+            outline: 1px dotted $color-white;
+        }
+
+        // hide the 'Close' text
+        span {
+            @include visually-hidden;
+        }
+
+        // only display when JS is available
+        .js & {
+            display: block;
+        }
+    }
+}

--- a/media/js/firefox/mobile/android-experiment.js
+++ b/media/js/firefox/mobile/android-experiment.js
@@ -1,0 +1,46 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+(function (Mozilla) {
+    'use strict';
+
+    var isAndroid = document.getElementsByTagName('html')[0].classList.contains('android');
+    var href = window.location.href;
+
+    var initTrafficCop = function () {
+        if (href.indexOf('v=') !== -1) {
+            if (href.indexOf('v=1') !== -1) {
+                window.dataLayer.push({
+                    'data-ex-variant': 'firefox-mobile-android-control',
+                    'data-ex-name': 'firefox-mobile-android-experiment'
+                });
+            } else if (href.indexOf('v=2') !== -1) {
+                window.dataLayer.push({
+                    'data-ex-variant': 'firefox-mobile-android-v2',
+                    'data-ex-name': 'firefox-mobile-android-experiment'
+                });
+            }
+        } else {
+            var cop = new Mozilla.TrafficCop({
+                id: 'experiment-firefox-mobile-android',
+                variations: {
+                    'v=1': 12,
+                    'v=2': 12,
+                    'v=3': 12,
+                    'v=4': 12,
+                    'v=5': 12,
+                }
+            });
+
+            cop.init();
+        }
+    };
+
+    // Avoid entering automated tests into random experiments.
+    // Target audience is Android mobile users.
+    if (href.indexOf('automation=true') && isAndroid) {
+        initTrafficCop();
+    }
+
+})(window.Mozilla);

--- a/media/js/firefox/mobile/android-native-banner-init.js
+++ b/media/js/firefox/mobile/android-native-banner-init.js
@@ -1,0 +1,14 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+(function() {
+    'use strict';
+
+    function onLoad() {
+        window.Mozilla.Banner.init('native-android-banner');
+    }
+
+    window.Mozilla.run(onLoad);
+
+})();

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -246,6 +246,12 @@
     },
     {
       "files": [
+        "css/base/banners/native-android-exp.scss"
+      ],
+      "name": "native-android-exp-banner"
+    },
+    {
+      "files": [
         "css/protocol/common-old-ie.scss"
       ],
       "name": "common-old-ie"
@@ -1006,6 +1012,13 @@
     },
     {
       "files": [
+        "js/base/banners/mozilla-banner.js",
+        "js/firefox/mobile/android-native-banner-init.js"
+      ],
+      "name": "native-android-exp-banner"
+    },
+    {
+      "files": [
         "protocol/js/protocol-sidemenu.js",
         "js/base/mozilla-article.js",
         "js/privacy/privacy-protocol.js"
@@ -1044,6 +1057,13 @@
         "js/firefox/mobile/mobile.js"
       ],
       "name": "firefox-mobile"
+    },
+    {
+      "files": [
+        "js/libs/mozilla-traffic-cop.js",
+        "js/firefox/mobile/android-experiment.js"
+      ],
+      "name": "firefox-mobile-android-experiment"
     },
     {
       "files": [


### PR DESCRIPTION
## Description

A traffic cop experiment to test the potential effectiveness of a native android banner. Banner is styled to look like a native banner (based off of previously coded variations in convert.)

## Issue / Bugzilla link
#9434

## Testing
[Test Plan](https://docs.google.com/document/d/16W-gpAmN4ZE7WIYiUh3ux1-GisF_0VYrH-qqkVr4RZI/edit?usp=sharing)

- [ ] **Audience:** Android mobile users.
- [ ] **Total Distribution:** 72%
- [ ] **Traffic % per group:** 12%

**5 variations:**
- [ ] Mozilla style banner.
- [ ] Android native-style banner.
- [ ] Android native-style banner with hearts rating.
- [ ] Android native-style banner with dark background.
