### PR TITLE
Add "Download" Sticky Promo to various pages

### DIFF
--- a/bedrock/base/templates/includes/sticky-promo.html
+++ b/bedrock/base/templates/includes/sticky-promo.html
@@ -4,7 +4,7 @@
 
 {% set promo_referrals = '?utm_source=www.mozilla.org&utm_medium=referral&utm_campaign=sticky-promo' %}
 {% if ftl_has_messages('firefox-sticky-promo-get-the-latest-firefox', 'firefox-sticky-promo-meet-our-family-of') %}
-  <aside class="mzp-c-sticky-promo mzp-t-product-firefox mzp-t-dark hide-from-legacy-ie">
+  <aside class="mzp-c-sticky-promo mzp-t-product-firefox mzp-t-dark hide-from-legacy-ie {% if non_fx_only %} hide-from-fx-user{% endif %}">
     <button class="mzp-c-sticky-promo-close" type="button">{{ ftl('ui-close') }}</button>
     <div class="promo-firefox">
       <h3 class="mzp-c-sticky-promo-title">{{ ftl('firefox-sticky-promo-get-the-latest-firefox') }}</h3>

--- a/bedrock/firefox/templates/firefox/browsers/best-browser.html
+++ b/bedrock/firefox/templates/firefox/browsers/best-browser.html
@@ -120,3 +120,13 @@
 {% endcall %}
 
 {% endblock %}
+
+{% block sticky_promo %}
+  {% with non_fx_only=True %}
+    {% include '/includes/sticky-promo.html' %}
+  {% endwith %}
+{% endblock %}
+
+{% block js %}
+  {{ js_bundle('sticky_promo') }}
+{% endblock %}

--- a/bedrock/firefox/templates/firefox/browsers/browser-history.html
+++ b/bedrock/firefox/templates/firefox/browsers/browser-history.html
@@ -116,3 +116,13 @@
 {% endcall %}
 
 {% endblock %}
+
+{% block sticky_promo %}
+  {% with non_fx_only=True %}
+    {% include '/includes/sticky-promo.html' %}
+  {% endwith %}
+{% endblock %}
+
+{% block js %}
+  {{ js_bundle('sticky_promo') }}
+{% endblock %}

--- a/bedrock/firefox/templates/firefox/browsers/browser-history.html
+++ b/bedrock/firefox/templates/firefox/browsers/browser-history.html
@@ -4,7 +4,7 @@
 
 {% from "macros-protocol.html" import call_out_compact with context %}
 
-{% extends "base-protocol.html" %}
+{% extends "firefox/base/base-protocol.html" %}
 
 {% block page_title %}{{ ftl('browser-history-browser-history') }}{% endblock %}
 

--- a/bedrock/firefox/templates/firefox/browsers/compare/brave.html
+++ b/bedrock/firefox/templates/firefox/browsers/compare/brave.html
@@ -266,6 +266,12 @@
 </div>
 {% endblock %}
 
+{% block sticky_promo %}
+  {% with non_fx_only=True %}
+    {% include '/includes/sticky-promo.html' %}
+  {% endwith %}
+{% endblock %}
+
 {% block js %}
   {{ js_bundle('firefox_compare_details') }}
 {% endblock %}

--- a/bedrock/firefox/templates/firefox/browsers/compare/chrome.html
+++ b/bedrock/firefox/templates/firefox/browsers/compare/chrome.html
@@ -263,7 +263,12 @@
 </div>
 {% endblock %}
 
+{% block sticky_promo %}
+  {% with non_fx_only=True %}
+    {% include '/includes/sticky-promo.html' %}
+  {% endwith %}
+{% endblock %}
+
 {% block js %}
   {{ js_bundle('firefox_compare_details') }}
 {% endblock %}
-

--- a/bedrock/firefox/templates/firefox/browsers/compare/edge.html
+++ b/bedrock/firefox/templates/firefox/browsers/compare/edge.html
@@ -261,7 +261,12 @@
 </div>
 {% endblock %}
 
+{% block sticky_promo %}
+  {% with non_fx_only=True %}
+    {% include '/includes/sticky-promo.html' %}
+  {% endwith %}
+{% endblock %}
+
 {% block js %}
   {{ js_bundle('firefox_compare_details') }}
 {% endblock %}
-

--- a/bedrock/firefox/templates/firefox/browsers/compare/ie.html
+++ b/bedrock/firefox/templates/firefox/browsers/compare/ie.html
@@ -256,6 +256,12 @@
 </div>
 {% endblock %}
 
+{% block sticky_promo %}
+  {% with non_fx_only=True %}
+    {% include '/includes/sticky-promo.html' %}
+  {% endwith %}
+{% endblock %}
+
 {% block js %}
   {{ js_bundle('firefox_compare_details') }}
 {% endblock %}

--- a/bedrock/firefox/templates/firefox/browsers/compare/index.html
+++ b/bedrock/firefox/templates/firefox/browsers/compare/index.html
@@ -384,3 +384,13 @@
   </article>
 </div>
 {% endblock %}
+
+{% block sticky_promo %}
+  {% with non_fx_only=True %}
+    {% include '/includes/sticky-promo.html' %}
+  {% endwith %}
+{% endblock %}
+
+{% block js %}
+  {{ js_bundle('sticky_promo') }}
+{% endblock %}

--- a/bedrock/firefox/templates/firefox/browsers/compare/opera.html
+++ b/bedrock/firefox/templates/firefox/browsers/compare/opera.html
@@ -258,7 +258,12 @@
 </div>
 {% endblock %}
 
+{% block sticky_promo %}
+  {% with non_fx_only=True %}
+    {% include '/includes/sticky-promo.html' %}
+  {% endwith %}
+{% endblock %}
+
 {% block js %}
   {{ js_bundle('firefox_compare_details') }}
 {% endblock %}
-

--- a/bedrock/firefox/templates/firefox/browsers/compare/safari.html
+++ b/bedrock/firefox/templates/firefox/browsers/compare/safari.html
@@ -271,6 +271,12 @@
 </div>
 {% endblock %}
 
+{% block sticky_promo %}
+  {% with non_fx_only=True %}
+    {% include '/includes/sticky-promo.html' %}
+  {% endwith %}
+{% endblock %}
+
 {% block js %}
   {{ js_bundle('firefox_compare_details') }}
 {% endblock %}

--- a/bedrock/firefox/templates/firefox/browsers/incognito-browser.html
+++ b/bedrock/firefox/templates/firefox/browsers/incognito-browser.html
@@ -212,3 +212,13 @@
 {% endcall %}
 
 {% endblock %}
+
+{% block sticky_promo %}
+  {% with non_fx_only=True %}
+    {% include '/includes/sticky-promo.html' %}
+  {% endwith %}
+{% endblock %}
+
+{% block js %}
+  {{ js_bundle('sticky_promo') }}
+{% endblock %}

--- a/bedrock/firefox/templates/firefox/browsers/incognito-browser.html
+++ b/bedrock/firefox/templates/firefox/browsers/incognito-browser.html
@@ -4,7 +4,7 @@
 
 {% from "macros-protocol.html" import call_out_compact with context %}
 
-{% extends "base-protocol.html" %}
+{% extends "firefox/base/base-protocol.html" %}
 
 {% block page_title %}{{ _('Incognito browser: What it really means') }}{% endblock %}
 

--- a/bedrock/firefox/templates/firefox/browsers/quantum.html
+++ b/bedrock/firefox/templates/firefox/browsers/quantum.html
@@ -51,3 +51,12 @@
 
 {% endblock %}
 
+{% block sticky_promo %}
+  {% with non_fx_only=True %}
+    {% include '/includes/sticky-promo.html' %}
+  {% endwith %}
+{% endblock %}
+
+{% block js %}
+  {{ js_bundle('sticky_promo') }}
+{% endblock %}

--- a/bedrock/firefox/templates/firefox/browsers/update-browser.html
+++ b/bedrock/firefox/templates/firefox/browsers/update-browser.html
@@ -4,7 +4,7 @@
 
 {% from "macros-protocol.html" import call_out_compact with context %}
 
-{% extends "base-protocol.html" %}
+{% extends "firefox/base/base-protocol.html" %}
 
 {% block page_title %}{{ _('Update your browser to fast, safe and secure Firefox.') }}{% endblock %}
 

--- a/bedrock/firefox/templates/firefox/browsers/what-is-a-browser.html
+++ b/bedrock/firefox/templates/firefox/browsers/what-is-a-browser.html
@@ -95,3 +95,13 @@
   </article>
 </div>
 {% endblock %}
+
+{% block sticky_promo %}
+  {% with non_fx_only=True %}
+    {% include '/includes/sticky-promo.html' %}
+  {% endwith %}
+{% endblock %}
+
+{% block js %}
+  {{ js_bundle('sticky_promo') }}
+{% endblock %}

--- a/bedrock/firefox/templates/firefox/browsers/what-is-a-browser.html
+++ b/bedrock/firefox/templates/firefox/browsers/what-is-a-browser.html
@@ -2,7 +2,7 @@
  # License, v. 2.0. If a copy of the MPL was not distributed with this
  # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
 
-{% extends "base-protocol.html" %}
+{% extends "firefox/base/base-protocol.html" %}
 
 {% block page_title %}{{ ftl('what-is-a-browser-what-is-a-web') }}{% endblock %}
 

--- a/bedrock/firefox/templates/firefox/browsers/windows-64-bit.html
+++ b/bedrock/firefox/templates/firefox/browsers/windows-64-bit.html
@@ -88,3 +88,13 @@ class='mzp-t-product-firefox mzp-t-firefox mzp-t-dark'
 {% block structured_data %}
 {% include 'includes/structured-data/software/firefox-windows-software.json' %}
 {% endblock %}
+
+{% block sticky_promo %}
+  {% with non_fx_only=True %}
+    {% include '/includes/sticky-promo.html' %}
+  {% endwith %}
+{% endblock %}
+
+{% block js %}
+  {{ js_bundle('sticky_promo') }}
+{% endblock %}

--- a/bedrock/firefox/templates/firefox/features/adblocker.html
+++ b/bedrock/firefox/templates/firefox/features/adblocker.html
@@ -152,3 +152,13 @@
   {% endcall %}
 
 {% endblock %}
+
+{% block sticky_promo %}
+  {% with non_fx_only=True %}
+    {% include '/includes/sticky-promo.html' %}
+  {% endwith %}
+{% endblock %}
+
+{% block js %}
+  {{ js_bundle('sticky_promo') }}
+{% endblock %}

--- a/bedrock/firefox/templates/firefox/features/bookmarks.html
+++ b/bedrock/firefox/templates/firefox/features/bookmarks.html
@@ -65,4 +65,12 @@
 
 {% endblock %}
 
+{% block sticky_promo %}
+  {% with non_fx_only=True %}
+    {% include '/includes/sticky-promo.html' %}
+  {% endwith %}
+{% endblock %}
 
+{% block js %}
+  {{ js_bundle('sticky_promo') }}
+{% endblock %}

--- a/bedrock/firefox/templates/firefox/features/fast.html
+++ b/bedrock/firefox/templates/firefox/features/fast.html
@@ -63,3 +63,13 @@
 {% include "firefox/features/includes/features-content.html" %}
 
 {% endblock %}
+
+{% block sticky_promo %}
+  {% with non_fx_only=True %}
+    {% include '/includes/sticky-promo.html' %}
+  {% endwith %}
+{% endblock %}
+
+{% block js %}
+  {{ js_bundle('sticky_promo') }}
+{% endblock %}

--- a/bedrock/firefox/templates/firefox/features/independent.html
+++ b/bedrock/firefox/templates/firefox/features/independent.html
@@ -63,3 +63,13 @@
 {% include "firefox/features/includes/features-content.html" %}
 
 {% endblock %}
+
+{% block sticky_promo %}
+  {% with non_fx_only=True %}
+    {% include '/includes/sticky-promo.html' %}
+  {% endwith %}
+{% endblock %}
+
+{% block js %}
+  {{ js_bundle('sticky_promo') }}
+{% endblock %}

--- a/bedrock/firefox/templates/firefox/features/index.html
+++ b/bedrock/firefox/templates/firefox/features/index.html
@@ -225,3 +225,13 @@
     </div>
   </section>
 {% endblock %}
+
+{% block sticky_promo %}
+  {% with non_fx_only=True %}
+    {% include '/includes/sticky-promo.html' %}
+  {% endwith %}
+{% endblock %}
+
+{% block js %}
+  {{ js_bundle('sticky_promo') }}
+{% endblock %}

--- a/bedrock/firefox/templates/firefox/features/memory.html
+++ b/bedrock/firefox/templates/firefox/features/memory.html
@@ -63,3 +63,13 @@
 {% include "firefox/features/includes/features-content.html" %}
 
 {% endblock %}
+
+{% block sticky_promo %}
+  {% with non_fx_only=True %}
+    {% include '/includes/sticky-promo.html' %}
+  {% endwith %}
+{% endblock %}
+
+{% block js %}
+  {{ js_bundle('sticky_promo') }}
+{% endblock %}

--- a/bedrock/firefox/templates/firefox/features/password-manager.html
+++ b/bedrock/firefox/templates/firefox/features/password-manager.html
@@ -64,3 +64,13 @@
 {% include "firefox/features/includes/features-content.html" %}
 
 {% endblock %}
+
+{% block sticky_promo %}
+  {% with non_fx_only=True %}
+    {% include '/includes/sticky-promo.html' %}
+  {% endwith %}
+{% endblock %}
+
+{% block js %}
+  {{ js_bundle('sticky_promo') }}
+{% endblock %}

--- a/bedrock/firefox/templates/firefox/features/private-browsing.html
+++ b/bedrock/firefox/templates/firefox/features/private-browsing.html
@@ -66,3 +66,13 @@
 {% include "firefox/features/includes/features-content.html" %}
 
 {% endblock %}
+
+{% block sticky_promo %}
+  {% with non_fx_only=True %}
+    {% include '/includes/sticky-promo.html' %}
+  {% endwith %}
+{% endblock %}
+
+{% block js %}
+  {{ js_bundle('sticky_promo') }}
+{% endblock %}

--- a/bedrock/firefox/templates/firefox/features/safebrowser.html
+++ b/bedrock/firefox/templates/firefox/features/safebrowser.html
@@ -166,3 +166,13 @@
 {% endcall %}
 
 {% endblock %}
+
+{% block sticky_promo %}
+  {% with non_fx_only=True %}
+    {% include '/includes/sticky-promo.html' %}
+  {% endwith %}
+{% endblock %}
+
+{% block js %}
+  {{ js_bundle('sticky_promo') }}
+{% endblock %}

--- a/bedrock/firefox/templates/firefox/releases/notes.html
+++ b/bedrock/firefox/templates/firefox/releases/notes.html
@@ -360,6 +360,17 @@
 </main>
 {% endblock %}
 
+{% block sticky_promo %}
+  {% with non_fx_only=True %}
+    {% include '/includes/sticky-promo.html' %}
+  {% endwith %}
+{% endblock %}
+
+{% block js %}
+  {{ js_bundle('sticky_promo') }}
+{% endblock %}
+
+
 {% block email_form %}{% endblock %}
 
 {% macro note_entry(note) %}

--- a/media/css/firefox/browsers-products.scss
+++ b/media/css/firefox/browsers-products.scss
@@ -11,7 +11,7 @@ $image-path: '/media/protocol/img';
 @import '../../protocol/css/components/zap';
 @import '../protocol/components/fxa-form';
 @import '../protocol/components/custom-menu-list';
-@import 'includes/sticky-promo';
+@import './sticky-promo';
 
 
 $send-svg: '<svg width="24px" height="24px" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd"><g transform="translate(3.000000, 1.000000)" stroke="#{$color-link-hover}" stroke-width="2"><path d="M2,16 L2,20 C2,21.1045695 2.8954305,22 4,22 L14,22 C15.1045695,22 16,21.1045695 16,20 L16,2 C16,0.8954305 15.1045695,-2.02906125e-16 14,0 L4,0 C2.8954305,2.02906125e-16 2,0.8954305 2,2 L2,6" stroke-linecap="round"></path><path d="M2,4 L16,4"></path><path d="M2,18 L16,18"></path><path d="M3.55271368e-15,11 L10,11" stroke-linecap="round" stroke-linejoin="round"></path><polyline stroke-linecap="round" stroke-linejoin="round" points="6 7 10 11 6 15"></polyline></g></g></svg>';

--- a/media/css/firefox/home/master.scss
+++ b/media/css/firefox/home/master.scss
@@ -8,7 +8,7 @@ $image-path: '/media/protocol/img';
 @import '../../../protocol/css/includes/lib';
 @import '../../../protocol/css/components/feature-card';
 @import '../../protocol/components/custom-menu-list';
-@import '../includes/sticky-promo';
+@import '../sticky-promo';
 
 
 // conditional content

--- a/media/css/firefox/new/desktop/download.scss
+++ b/media/css/firefox/new/desktop/download.scss
@@ -11,7 +11,7 @@ $image-path: '/media/protocol/img';
 @import '../../../../protocol/css/components/zap';
 @import '../../../../protocol/css/templates/card-layout';
 @import '../../../protocol/components/sub-navigation';
-@import '../../includes/sticky-promo';
+@import '../../sticky-promo';
 
 
 // --------------------------------------------------------------------------

--- a/media/css/firefox/sticky-promo.scss
+++ b/media/css/firefox/sticky-promo.scss
@@ -6,9 +6,8 @@ $brand-theme: 'firefox';
 
 $font-path: '/media/fonts';
 $image-path: '/media/protocol/img';
-
-@import '../../../protocol/css/includes/lib';
-@import '../../../protocol/css/components/sticky-promo';
+@import '../../protocol/css/includes/lib';
+@import '../../protocol/css/components/sticky-promo';
 
 // Hide promo by default for mobile devices (<$mq-md)
 .mzp-c-sticky-promo {

--- a/media/js/firefox/sticky-promo.js
+++ b/media/js/firefox/sticky-promo.js
@@ -14,6 +14,14 @@
             return;
         }
 
+        // If the user is on Firefox and is NOT supposed to see sticky promo.
+        var fxUser = document.documentElement.classList.contains('is-firefox');
+        var hideFromFxUser = promo.classList.contains('hide-from-fx-user');
+
+        if ( fxUser && hideFromFxUser) {
+            return;
+        }
+
         var StickyPromo = {};
         var STICKY_PROMO_COOKIE_ID = 'firefox-sticky-promo';
 

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -542,6 +542,7 @@
     },
     {
       "files": [
+        "css/firefox/sticky-promo.scss",
         "css/firefox/releasenotes.scss"
       ],
       "name": "firefox_releasenotes"

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -190,6 +190,7 @@
     },
     {
       "files": [
+        "css/firefox/sticky-promo.scss",
         "css/firefox/features/detail.scss",
         "css/firefox/features/features-cards.scss"
       ],
@@ -479,6 +480,7 @@
     },
     {
       "files": [
+        "css/firefox/sticky-promo.scss",
         "css/firefox/features/index.scss",
         "css/firefox/features/features-cards-index.scss"
       ],
@@ -667,6 +669,7 @@
     },
     {
       "files": [
+        "css/firefox/sticky-promo.scss",
         "css/firefox/features/safebrowser.scss"
       ],
       "name": "safebrowser"

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -639,6 +639,7 @@
     },
     {
       "files": [
+        "css/firefox/sticky-promo.scss",
         "css/firefox/browsers/what-is-a-browser.scss"
       ],
       "name": "what-is-a-browser"
@@ -651,18 +652,21 @@
     },
     {
       "files": [
+        "css/firefox/sticky-promo.scss",
         "css/firefox/browsers/incognito-browser.scss"
       ],
       "name": "incognito-browser"
     },
     {
       "files": [
+        "css/firefox/sticky-promo.scss",
         "css/firefox/browsers/browser-history.scss"
       ],
       "name": "browser-history"
     },
     {
       "files": [
+        "css/firefox/sticky-promo.scss",
         "css/firefox/browsers/windows-64-bit.scss"
       ],
       "name": "windows-64-bit"
@@ -682,18 +686,21 @@
     },
     {
       "files": [
+        "css/firefox/sticky-promo.scss",
         "css/firefox/browsers/best-browser.scss"
       ],
       "name": "best-browser"
     },
     {
       "files": [
+        "css/firefox/sticky-promo.scss",
         "css/firefox/compare/compare.scss"
       ],
       "name": "compare"
     },
     {
       "files": [
+        "css/firefox/sticky-promo.scss",
         "css/firefox/compare/compare.scss",
         "css/firefox/compare/compare-details.scss"
       ],
@@ -739,6 +746,7 @@
     },
     {
       "files": [
+        "css/firefox/sticky-promo.scss",
         "css/firefox/browsers/quantum.scss"
       ],
       "name": "quantum"
@@ -1372,6 +1380,8 @@
     },
     {
       "files": [
+        "protocol/js/protocol-sticky-promo.js",
+        "js/firefox/sticky-promo.js",
         "js/firefox/compare-details.js"
       ],
       "name": "firefox_compare_details"

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -630,6 +630,7 @@
     },
     {
       "files": [
+        "css/firefox/sticky-promo.scss",
         "css/firefox/features/adblocker.scss"
       ],
       "name": "adblocker"

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -98,6 +98,12 @@
     },
     {
       "files": [
+        "css/firefox/sticky-promo.scss"
+      ],
+      "name": "sticky_promo"
+    },
+    {
+      "files": [
         "css/firefox/new/trailhead/download.scss"
       ],
       "name": "firefox_new_download"
@@ -939,6 +945,13 @@
         "js/firefox/new/yandex/scene1-init.js"
       ],
       "name": "firefox_new_download_yandex"
+    },
+    {
+      "files": [
+        "protocol/js/protocol-sticky-promo.js",
+        "js/firefox/sticky-promo.js"
+      ],
+      "name": "sticky_promo"
     },
     {
       "files": [

--- a/tests/functional/firefox/browsers/compare/test_browsers.py
+++ b/tests/functional/firefox/browsers/compare/test_browsers.py
@@ -38,8 +38,10 @@ def test_download_buttons_are_displayed(slug, base_url, selenium):
 
 @pytest.mark.skip_if_firefox(reason='Sticky promo is displayed only to non-Firefox users')
 @pytest.mark.nondestructive
-def test_sticky_promo(base_url, selenium):
-    page = BrowserComparisonPage(selenium, base_url).open()
+@pytest.mark.parametrize('slug', [
+    ('chrome')])
+def test_sticky_promo(slug, base_url, selenium):
+    page = BrowserComparisonPage(selenium, base_url, slug=slug).open()
     assert page.promo.is_displayed
     page.promo.close()
     assert not page.promo.is_displayed

--- a/tests/functional/firefox/browsers/compare/test_browsers.py
+++ b/tests/functional/firefox/browsers/compare/test_browsers.py
@@ -34,3 +34,12 @@ def test_download_buttons_are_displayed(slug, base_url, selenium):
     page = BrowserComparisonPage(selenium, base_url, slug=slug).open()
     assert page.primary_download_button.is_displayed
     assert page.secondary_download_button.is_displayed
+
+
+@pytest.mark.skip_if_firefox(reason='Sticky promo is displayed only to non-Firefox users')
+@pytest.mark.nondestructive
+def test_sticky_promo(base_url, selenium):
+    page = BrowserComparisonPage(selenium, base_url).open()
+    assert page.promo.is_displayed
+    page.promo.close()
+    assert not page.promo.is_displayed

--- a/tests/functional/firefox/browsers/test_best_browser.py
+++ b/tests/functional/firefox/browsers/test_best_browser.py
@@ -11,3 +11,12 @@ from pages.firefox.browsers.best_browser import BestBrowserPage
 def test_download_button_is_displayed(base_url, selenium):
     page = BestBrowserPage(selenium, base_url).open()
     assert page.download_button.is_displayed
+
+
+@pytest.mark.skip_if_firefox(reason='Sticky promo is displayed only to non-Firefox users')
+@pytest.mark.nondestructive
+def test_sticky_promo(base_url, selenium):
+    page = BestBrowserPage(selenium, base_url).open()
+    assert page.promo.is_displayed
+    page.promo.close()
+    assert not page.promo.is_displayed

--- a/tests/functional/firefox/browsers/test_browser_history.py
+++ b/tests/functional/firefox/browsers/test_browser_history.py
@@ -13,3 +13,12 @@ def test_download_buttons_are_displayed(base_url, selenium):
     page = BrowserHistoryPage(selenium, base_url).open()
     assert page.primary_download_button.is_displayed
     assert page.secondary_download_button.is_displayed
+
+
+@pytest.mark.skip_if_firefox(reason='Sticky promo is displayed only to non-Firefox users')
+@pytest.mark.nondestructive
+def test_sticky_promo(base_url, selenium):
+    page = BrowserHistoryPage(selenium, base_url).open()
+    assert page.promo.is_displayed
+    page.promo.close()
+    assert not page.promo.is_displayed

--- a/tests/functional/firefox/browsers/test_incognito_browser.py
+++ b/tests/functional/firefox/browsers/test_incognito_browser.py
@@ -13,3 +13,12 @@ def test_download_buttons_are_displayed(base_url, selenium):
     page = IncognitoBrowserPage(selenium, base_url).open()
     assert page.primary_download_button.is_displayed
     assert page.secondary_download_button.is_displayed
+
+
+@pytest.mark.skip_if_firefox(reason='Sticky promo is displayed only to non-Firefox users')
+@pytest.mark.nondestructive
+def test_sticky_promo(base_url, selenium):
+    page = IncognitoBrowserPage(selenium, base_url).open()
+    assert page.promo.is_displayed
+    page.promo.close()
+    assert not page.promo.is_displayed

--- a/tests/functional/firefox/browsers/test_what_is_a_browser.py
+++ b/tests/functional/firefox/browsers/test_what_is_a_browser.py
@@ -13,3 +13,12 @@ def test_download_buttons_are_displayed(base_url, selenium):
     page = WhatIsABrowserPage(selenium, base_url).open()
     assert page.primary_download_button.is_displayed
     assert page.secondary_download_button.is_displayed
+
+
+@pytest.mark.skip_if_firefox(reason='Sticky promo is displayed only to non-Firefox users')
+@pytest.mark.nondestructive
+def test_sticky_promo(base_url, selenium):
+    page = WhatIsABrowserPage(selenium, base_url).open()
+    assert page.promo.is_displayed
+    page.promo.close()
+    assert not page.promo.is_displayed

--- a/tests/functional/firefox/browsers/test_windows_64_bit.py
+++ b/tests/functional/firefox/browsers/test_windows_64_bit.py
@@ -12,3 +12,12 @@ from pages.firefox.browsers.windows_64_bit import Windows64BitPage
 def test_download_button_is_displayed(base_url, selenium):
     page = Windows64BitPage(selenium, base_url).open()
     assert page.download_button.is_displayed
+
+
+@pytest.mark.skip_if_firefox(reason='Sticky promo is displayed only to non-Firefox users')
+@pytest.mark.nondestructive
+def test_sticky_promo(base_url, selenium):
+    page = Windows64BitPage(selenium, base_url).open()
+    assert page.promo.is_displayed
+    page.promo.close()
+    assert not page.promo.is_displayed

--- a/tests/functional/firefox/features/test_adblocker.py
+++ b/tests/functional/firefox/features/test_adblocker.py
@@ -11,3 +11,12 @@ from pages.firefox.features.adblocker import FeatureAdblockerPage
 def test_download_button_is_displayed(base_url, selenium):
     page = FeatureAdblockerPage(selenium, base_url).open()
     assert page.download_button.is_displayed
+
+
+@pytest.mark.skip_if_firefox(reason='Sticky promo is displayed only to non-Firefox users')
+@pytest.mark.nondestructive
+def test_sticky_promo(base_url, selenium):
+    page = FeatureAdblockerPage(selenium, base_url).open()
+    assert page.promo.is_displayed
+    page.promo.close()
+    assert not page.promo.is_displayed

--- a/tests/functional/firefox/features/test_features.py
+++ b/tests/functional/firefox/features/test_features.py
@@ -22,8 +22,10 @@ def test_download_button_is_displayed(slug, base_url, selenium):
 
 @pytest.mark.skip_if_firefox(reason='Sticky promo is displayed only to non-Firefox users')
 @pytest.mark.nondestructive
-def test_sticky_promo(base_url, selenium):
-    page = FeaturePage(selenium, base_url).open()
+@pytest.mark.parametrize('slug', [
+    ('private-browsing')])
+def test_sticky_promo(slug, base_url, selenium):
+    page = FeaturePage(selenium, base_url, slug=slug).open()
     assert page.promo.is_displayed
     page.promo.close()
     assert not page.promo.is_displayed

--- a/tests/functional/firefox/features/test_features.py
+++ b/tests/functional/firefox/features/test_features.py
@@ -18,3 +18,12 @@ from pages.firefox.features.feature import FeaturePage
 def test_download_button_is_displayed(slug, base_url, selenium):
     page = FeaturePage(selenium, base_url, slug=slug).open()
     assert page.download_button.is_displayed
+
+
+@pytest.mark.skip_if_firefox(reason='Sticky promo is displayed only to non-Firefox users')
+@pytest.mark.nondestructive
+def test_sticky_promo(base_url, selenium):
+    page = FeaturePage(selenium, base_url).open()
+    assert page.promo.is_displayed
+    page.promo.close()
+    assert not page.promo.is_displayed

--- a/tests/functional/firefox/features/test_landing.py
+++ b/tests/functional/firefox/features/test_landing.py
@@ -11,3 +11,12 @@ from pages.firefox.features.landing import FeaturesLandingPage
 def test_download_button_is_displayed(base_url, selenium):
     page = FeaturesLandingPage(selenium, base_url).open()
     assert page.download_button.is_displayed
+
+
+@pytest.mark.skip_if_firefox(reason='Sticky promo is displayed only to non-Firefox users')
+@pytest.mark.nondestructive
+def test_sticky_promo(base_url, selenium):
+    page = FeaturesLandingPage(selenium, base_url).open()
+    assert page.promo.is_displayed
+    page.promo.close()
+    assert not page.promo.is_displayed

--- a/tests/functional/firefox/test_releasenotes.py
+++ b/tests/functional/firefox/test_releasenotes.py
@@ -137,3 +137,12 @@ def test_secondary_download_button_android_nightly_displayed(base_url, selenium)
 def test_secondary_download_button_ios_displayed(base_url, selenium):
     page = FirefoxReleaseNotesPage(selenium, base_url, slug='ios/25.0').open()
     assert page.is_secondary_app_store_button_displayed
+
+
+@pytest.mark.skip_if_firefox(reason='Sticky promo is displayed only to non-Firefox users')
+@pytest.mark.nondestructive
+def test_sticky_promo(base_url, selenium):
+    page = FirefoxReleaseNotesPage(selenium, base_url).open()
+    assert page.promo.is_displayed
+    page.promo.close()
+    assert not page.promo.is_displayed

--- a/tests/functional/firefox/test_releasenotes.py
+++ b/tests/functional/firefox/test_releasenotes.py
@@ -142,7 +142,7 @@ def test_secondary_download_button_ios_displayed(base_url, selenium):
 @pytest.mark.skip_if_firefox(reason='Sticky promo is displayed only to non-Firefox users')
 @pytest.mark.nondestructive
 def test_sticky_promo(base_url, selenium):
-    page = FirefoxReleaseNotesPage(selenium, base_url).open()
+    page = FirefoxReleaseNotesPage(selenium, base_url, slug='84.0').open()
     assert page.promo.is_displayed
     page.promo.close()
     assert not page.promo.is_displayed

--- a/tests/pages/firefox/browsers/best_browser.py
+++ b/tests/pages/firefox/browsers/best_browser.py
@@ -6,6 +6,7 @@ from selenium.webdriver.common.by import By
 
 from pages.base import BasePage
 from pages.regions.download_button import DownloadButton
+from pages.regions.sticky_promo import StickyPromo
 
 
 class BestBrowserPage(BasePage):
@@ -18,3 +19,14 @@ class BestBrowserPage(BasePage):
     def download_button(self):
         el = self.find_element(*self._download_button_locator)
         return DownloadButton(self, root=el)
+
+    def wait_for_page_to_load(self):
+        el = self.find_element(By.TAG_NAME, 'html')
+        self.wait.until(lambda s: 'loaded' in el.get_attribute('class'))
+        promo = self.find_element(*self._sticky_promo_modal_content_locator)
+        self.wait.until(lambda s: 'is-displayed' in promo.get_attribute('class'))
+        return self
+
+    @property
+    def promo(self):
+        return StickyPromo(self)

--- a/tests/pages/firefox/browsers/best_browser.py
+++ b/tests/pages/firefox/browsers/best_browser.py
@@ -14,18 +14,23 @@ class BestBrowserPage(BasePage):
     _URL_TEMPLATE = '/{locale}/firefox/browsers/best-browser/'
 
     _download_button_locator = (By.ID, 'safebrowser-hero-download')
+    _sticky_promo_modal_content_locator = (By.CSS_SELECTOR, '.mzp-c-sticky-promo.mzp-a-slide-in')
+
+    def wait_for_page_to_load(self):
+        el = self.find_element(By.TAG_NAME, 'html')
+        self.wait.until(lambda s: 'loaded' in el.get_attribute('class'))
+
+        # Sticky promo is shown to non-Firefox browsers only.
+        if self.selenium.capabilities.get('browserName').lower() != 'firefox':
+            promo = self.find_element(*self._sticky_promo_modal_content_locator)
+            self.wait.until(lambda s: 'is-displayed' in promo.get_attribute('class'))
+
+        return self
 
     @property
     def download_button(self):
         el = self.find_element(*self._download_button_locator)
         return DownloadButton(self, root=el)
-
-    def wait_for_page_to_load(self):
-        el = self.find_element(By.TAG_NAME, 'html')
-        self.wait.until(lambda s: 'loaded' in el.get_attribute('class'))
-        promo = self.find_element(*self._sticky_promo_modal_content_locator)
-        self.wait.until(lambda s: 'is-displayed' in promo.get_attribute('class'))
-        return self
 
     @property
     def promo(self):

--- a/tests/pages/firefox/browsers/browser_history.py
+++ b/tests/pages/firefox/browsers/browser_history.py
@@ -6,6 +6,7 @@ from selenium.webdriver.common.by import By
 
 from pages.base import BasePage
 from pages.regions.download_button import DownloadButton
+from pages.regions.sticky_promo import StickyPromo
 
 
 class BrowserHistoryPage(BasePage):
@@ -24,3 +25,14 @@ class BrowserHistoryPage(BasePage):
     def secondary_download_button(self):
         el = self.find_element(*self._secondary_download_button_locator)
         return DownloadButton(self, root=el)
+
+    def wait_for_page_to_load(self):
+        el = self.find_element(By.TAG_NAME, 'html')
+        self.wait.until(lambda s: 'loaded' in el.get_attribute('class'))
+        promo = self.find_element(*self._sticky_promo_modal_content_locator)
+        self.wait.until(lambda s: 'is-displayed' in promo.get_attribute('class'))
+        return self
+
+    @property
+    def promo(self):
+        return StickyPromo(self)

--- a/tests/pages/firefox/browsers/browser_history.py
+++ b/tests/pages/firefox/browsers/browser_history.py
@@ -15,6 +15,7 @@ class BrowserHistoryPage(BasePage):
 
     _primary_download_button_locator = (By.ID, 'download-button-primary')
     _secondary_download_button_locator = (By.ID, 'download-button-secondary')
+    _sticky_promo_modal_content_locator = (By.CSS_SELECTOR, '.mzp-c-sticky-promo.mzp-a-slide-in')
 
     @property
     def primary_download_button(self):
@@ -29,9 +30,18 @@ class BrowserHistoryPage(BasePage):
     def wait_for_page_to_load(self):
         el = self.find_element(By.TAG_NAME, 'html')
         self.wait.until(lambda s: 'loaded' in el.get_attribute('class'))
-        promo = self.find_element(*self._sticky_promo_modal_content_locator)
-        self.wait.until(lambda s: 'is-displayed' in promo.get_attribute('class'))
+
+        # Sticky promo is shown to non-Firefox browsers only.
+        if self.selenium.capabilities.get('browserName').lower() != 'firefox':
+            promo = self.find_element(*self._sticky_promo_modal_content_locator)
+            self.wait.until(lambda s: 'is-displayed' in promo.get_attribute('class'))
+
         return self
+
+    @property
+    def download_button(self):
+        el = self.find_element(*self._download_button_locator)
+        return DownloadButton(self, root=el)
 
     @property
     def promo(self):

--- a/tests/pages/firefox/browsers/compare.py
+++ b/tests/pages/firefox/browsers/compare.py
@@ -17,6 +17,18 @@ class BrowserComparisonPage(BasePage):
     _primary_download_button_locator = (By.ID, 'download-button-thanks')
     _secondary_download_button_locator = (By.ID, 'download-secondary')
     _browser_menu_list_locator = (By.CSS_SELECTOR, '.mzp-c-menu-list.mzp-t-download')
+    _sticky_promo_modal_content_locator = (By.CSS_SELECTOR, '.mzp-c-sticky-promo.mzp-a-slide-in')
+
+    def wait_for_page_to_load(self):
+        el = self.find_element(By.TAG_NAME, 'html')
+        self.wait.until(lambda s: 'loaded' in el.get_attribute('class'))
+
+        # Sticky promo is shown to non-Firefox browsers only.
+        if self.selenium.capabilities.get('browserName').lower() != 'firefox':
+            promo = self.find_element(*self._sticky_promo_modal_content_locator)
+            self.wait.until(lambda s: 'is-displayed' in promo.get_attribute('class'))
+
+        return self
 
     @property
     def primary_download_button(self):
@@ -32,13 +44,6 @@ class BrowserComparisonPage(BasePage):
     def browser_menu_list(self):
         el = self.find_element(*self._browser_menu_list_locator)
         return MenuList(self, root=el)
-
-    def wait_for_page_to_load(self):
-        el = self.find_element(By.TAG_NAME, 'html')
-        self.wait.until(lambda s: 'loaded' in el.get_attribute('class'))
-        promo = self.find_element(*self._sticky_promo_modal_content_locator)
-        self.wait.until(lambda s: 'is-displayed' in promo.get_attribute('class'))
-        return self
 
     @property
     def promo(self):

--- a/tests/pages/firefox/browsers/compare.py
+++ b/tests/pages/firefox/browsers/compare.py
@@ -7,6 +7,7 @@ from selenium.webdriver.common.by import By
 from pages.base import BasePage
 from pages.regions.download_button import DownloadButton
 from pages.regions.menu_list import MenuList
+from pages.regions.sticky_promo import StickyPromo
 
 
 class BrowserComparisonPage(BasePage):
@@ -31,3 +32,14 @@ class BrowserComparisonPage(BasePage):
     def browser_menu_list(self):
         el = self.find_element(*self._browser_menu_list_locator)
         return MenuList(self, root=el)
+
+    def wait_for_page_to_load(self):
+        el = self.find_element(By.TAG_NAME, 'html')
+        self.wait.until(lambda s: 'loaded' in el.get_attribute('class'))
+        promo = self.find_element(*self._sticky_promo_modal_content_locator)
+        self.wait.until(lambda s: 'is-displayed' in promo.get_attribute('class'))
+        return self
+
+    @property
+    def promo(self):
+        return StickyPromo(self)

--- a/tests/pages/firefox/browsers/incognito_browser.py
+++ b/tests/pages/firefox/browsers/incognito_browser.py
@@ -6,6 +6,7 @@ from selenium.webdriver.common.by import By
 
 from pages.base import BasePage
 from pages.regions.download_button import DownloadButton
+from pages.regions.sticky_promo import StickyPromo
 
 
 class IncognitoBrowserPage(BasePage):
@@ -24,3 +25,14 @@ class IncognitoBrowserPage(BasePage):
     def secondary_download_button(self):
         el = self.find_element(*self._secondary_download_button_locator)
         return DownloadButton(self, root=el)
+
+    def wait_for_page_to_load(self):
+        el = self.find_element(By.TAG_NAME, 'html')
+        self.wait.until(lambda s: 'loaded' in el.get_attribute('class'))
+        promo = self.find_element(*self._sticky_promo_modal_content_locator)
+        self.wait.until(lambda s: 'is-displayed' in promo.get_attribute('class'))
+        return self
+
+    @property
+    def promo(self):
+        return StickyPromo(self)

--- a/tests/pages/firefox/browsers/incognito_browser.py
+++ b/tests/pages/firefox/browsers/incognito_browser.py
@@ -15,6 +15,7 @@ class IncognitoBrowserPage(BasePage):
 
     _primary_download_button_locator = (By.ID, 'download-button-primary')
     _secondary_download_button_locator = (By.ID, 'download-button-secondary')
+    _sticky_promo_modal_content_locator = (By.CSS_SELECTOR, '.mzp-c-sticky-promo.mzp-a-slide-in')
 
     @property
     def primary_download_button(self):
@@ -29,9 +30,18 @@ class IncognitoBrowserPage(BasePage):
     def wait_for_page_to_load(self):
         el = self.find_element(By.TAG_NAME, 'html')
         self.wait.until(lambda s: 'loaded' in el.get_attribute('class'))
-        promo = self.find_element(*self._sticky_promo_modal_content_locator)
-        self.wait.until(lambda s: 'is-displayed' in promo.get_attribute('class'))
+
+        # Sticky promo is shown to non-Firefox browsers only.
+        if self.selenium.capabilities.get('browserName').lower() != 'firefox':
+            promo = self.find_element(*self._sticky_promo_modal_content_locator)
+            self.wait.until(lambda s: 'is-displayed' in promo.get_attribute('class'))
+
         return self
+
+    @property
+    def download_button(self):
+        el = self.find_element(*self._download_button_locator)
+        return DownloadButton(self, root=el)
 
     @property
     def promo(self):

--- a/tests/pages/firefox/browsers/what_is_a_browser.py
+++ b/tests/pages/firefox/browsers/what_is_a_browser.py
@@ -6,6 +6,7 @@ from selenium.webdriver.common.by import By
 
 from pages.base import BasePage
 from pages.regions.download_button import DownloadButton
+from pages.regions.sticky_promo import StickyPromo
 
 
 class WhatIsABrowserPage(BasePage):
@@ -24,3 +25,14 @@ class WhatIsABrowserPage(BasePage):
     def secondary_download_button(self):
         el = self.find_element(*self._secondary_download_button_locator)
         return DownloadButton(self, root=el)
+
+    def wait_for_page_to_load(self):
+        el = self.find_element(By.TAG_NAME, 'html')
+        self.wait.until(lambda s: 'loaded' in el.get_attribute('class'))
+        promo = self.find_element(*self._sticky_promo_modal_content_locator)
+        self.wait.until(lambda s: 'is-displayed' in promo.get_attribute('class'))
+        return self
+
+    @property
+    def promo(self):
+        return StickyPromo(self)

--- a/tests/pages/firefox/browsers/what_is_a_browser.py
+++ b/tests/pages/firefox/browsers/what_is_a_browser.py
@@ -15,6 +15,7 @@ class WhatIsABrowserPage(BasePage):
 
     _primary_download_button_locator = (By.ID, 'download-button-primary')
     _secondary_download_button_locator = (By.ID, 'download-button-secondary')
+    _sticky_promo_modal_content_locator = (By.CSS_SELECTOR, '.mzp-c-sticky-promo.mzp-a-slide-in')
 
     @property
     def primary_download_button(self):
@@ -29,9 +30,18 @@ class WhatIsABrowserPage(BasePage):
     def wait_for_page_to_load(self):
         el = self.find_element(By.TAG_NAME, 'html')
         self.wait.until(lambda s: 'loaded' in el.get_attribute('class'))
-        promo = self.find_element(*self._sticky_promo_modal_content_locator)
-        self.wait.until(lambda s: 'is-displayed' in promo.get_attribute('class'))
+
+        # Sticky promo is shown to non-Firefox browsers only.
+        if self.selenium.capabilities.get('browserName').lower() != 'firefox':
+            promo = self.find_element(*self._sticky_promo_modal_content_locator)
+            self.wait.until(lambda s: 'is-displayed' in promo.get_attribute('class'))
+
         return self
+
+    @property
+    def download_button(self):
+        el = self.find_element(*self._download_button_locator)
+        return DownloadButton(self, root=el)
 
     @property
     def promo(self):

--- a/tests/pages/firefox/browsers/windows_64_bit.py
+++ b/tests/pages/firefox/browsers/windows_64_bit.py
@@ -6,6 +6,7 @@ from selenium.webdriver.common.by import By
 
 from pages.base import BasePage
 from pages.regions.download_button import DownloadButton
+from pages.regions.sticky_promo import StickyPromo
 
 
 class Windows64BitPage(BasePage):
@@ -18,3 +19,14 @@ class Windows64BitPage(BasePage):
     def download_button(self):
         el = self.find_element(*self._download_button_locator)
         return DownloadButton(self, root=el)
+
+    def wait_for_page_to_load(self):
+        el = self.find_element(By.TAG_NAME, 'html')
+        self.wait.until(lambda s: 'loaded' in el.get_attribute('class'))
+        promo = self.find_element(*self._sticky_promo_modal_content_locator)
+        self.wait.until(lambda s: 'is-displayed' in promo.get_attribute('class'))
+        return self
+
+    @property
+    def promo(self):
+        return StickyPromo(self)

--- a/tests/pages/firefox/browsers/windows_64_bit.py
+++ b/tests/pages/firefox/browsers/windows_64_bit.py
@@ -14,18 +14,23 @@ class Windows64BitPage(BasePage):
     _URL_TEMPLATE = '/{locale}/firefox/browsers/windows-64-bit/'
 
     _download_button_locator = (By.ID, 'win64-hero-download')
+    _sticky_promo_modal_content_locator = (By.CSS_SELECTOR, '.mzp-c-sticky-promo.mzp-a-slide-in')
+
+    def wait_for_page_to_load(self):
+        el = self.find_element(By.TAG_NAME, 'html')
+        self.wait.until(lambda s: 'loaded' in el.get_attribute('class'))
+
+        # Sticky promo is shown to non-Firefox browsers only.
+        if self.selenium.capabilities.get('browserName').lower() != 'firefox':
+            promo = self.find_element(*self._sticky_promo_modal_content_locator)
+            self.wait.until(lambda s: 'is-displayed' in promo.get_attribute('class'))
+
+        return self
 
     @property
     def download_button(self):
         el = self.find_element(*self._download_button_locator)
         return DownloadButton(self, root=el)
-
-    def wait_for_page_to_load(self):
-        el = self.find_element(By.TAG_NAME, 'html')
-        self.wait.until(lambda s: 'loaded' in el.get_attribute('class'))
-        promo = self.find_element(*self._sticky_promo_modal_content_locator)
-        self.wait.until(lambda s: 'is-displayed' in promo.get_attribute('class'))
-        return self
 
     @property
     def promo(self):

--- a/tests/pages/firefox/features/adblocker.py
+++ b/tests/pages/firefox/features/adblocker.py
@@ -14,18 +14,23 @@ class FeatureAdblockerPage(BasePage):
     _URL_TEMPLATE = '/{locale}/firefox/features/adblocker/'
 
     _download_button_locator = (By.ID, 'download-button-desktop-release')
+    _sticky_promo_modal_content_locator = (By.CSS_SELECTOR, '.mzp-c-sticky-promo.mzp-a-slide-in')
+
+    def wait_for_page_to_load(self):
+        el = self.find_element(By.TAG_NAME, 'html')
+        self.wait.until(lambda s: 'loaded' in el.get_attribute('class'))
+
+        # Sticky promo is shown to non-Firefox browsers only.
+        if self.selenium.capabilities.get('browserName').lower() != 'firefox':
+            promo = self.find_element(*self._sticky_promo_modal_content_locator)
+            self.wait.until(lambda s: 'is-displayed' in promo.get_attribute('class'))
+
+        return self
 
     @property
     def download_button(self):
         el = self.find_element(*self._download_button_locator)
         return DownloadButton(self, root=el)
-
-    def wait_for_page_to_load(self):
-        el = self.find_element(By.TAG_NAME, 'html')
-        self.wait.until(lambda s: 'loaded' in el.get_attribute('class'))
-        promo = self.find_element(*self._sticky_promo_modal_content_locator)
-        self.wait.until(lambda s: 'is-displayed' in promo.get_attribute('class'))
-        return self
 
     @property
     def promo(self):

--- a/tests/pages/firefox/features/adblocker.py
+++ b/tests/pages/firefox/features/adblocker.py
@@ -6,6 +6,7 @@ from selenium.webdriver.common.by import By
 
 from pages.base import BasePage
 from pages.regions.download_button import DownloadButton
+from pages.regions.sticky_promo import StickyPromo
 
 
 class FeatureAdblockerPage(BasePage):
@@ -18,3 +19,14 @@ class FeatureAdblockerPage(BasePage):
     def download_button(self):
         el = self.find_element(*self._download_button_locator)
         return DownloadButton(self, root=el)
+
+    def wait_for_page_to_load(self):
+        el = self.find_element(By.TAG_NAME, 'html')
+        self.wait.until(lambda s: 'loaded' in el.get_attribute('class'))
+        promo = self.find_element(*self._sticky_promo_modal_content_locator)
+        self.wait.until(lambda s: 'is-displayed' in promo.get_attribute('class'))
+        return self
+
+    @property
+    def promo(self):
+        return StickyPromo(self)

--- a/tests/pages/firefox/features/feature.py
+++ b/tests/pages/firefox/features/feature.py
@@ -6,6 +6,7 @@ from selenium.webdriver.common.by import By
 
 from pages.base import BasePage
 from pages.regions.download_button import DownloadButton
+from pages.regions.sticky_promo import StickyPromo
 
 
 class FeaturePage(BasePage):
@@ -18,3 +19,14 @@ class FeaturePage(BasePage):
     def download_button(self):
         el = self.find_element(*self._download_button_locator)
         return DownloadButton(self, root=el)
+
+    def wait_for_page_to_load(self):
+        el = self.find_element(By.TAG_NAME, 'html')
+        self.wait.until(lambda s: 'loaded' in el.get_attribute('class'))
+        promo = self.find_element(*self._sticky_promo_modal_content_locator)
+        self.wait.until(lambda s: 'is-displayed' in promo.get_attribute('class'))
+        return self
+
+    @property
+    def promo(self):
+        return StickyPromo(self)

--- a/tests/pages/firefox/features/feature.py
+++ b/tests/pages/firefox/features/feature.py
@@ -14,18 +14,23 @@ class FeaturePage(BasePage):
     _URL_TEMPLATE = '/{locale}/firefox/features/{slug}/'
 
     _download_button_locator = (By.ID, 'features-header-download')
+    _sticky_promo_modal_content_locator = (By.CSS_SELECTOR, '.mzp-c-sticky-promo.mzp-a-slide-in')
+
+    def wait_for_page_to_load(self):
+        el = self.find_element(By.TAG_NAME, 'html')
+        self.wait.until(lambda s: 'loaded' in el.get_attribute('class'))
+
+        # Sticky promo is shown to non-Firefox browsers only.
+        if self.selenium.capabilities.get('browserName').lower() != 'firefox':
+            promo = self.find_element(*self._sticky_promo_modal_content_locator)
+            self.wait.until(lambda s: 'is-displayed' in promo.get_attribute('class'))
+
+        return self
 
     @property
     def download_button(self):
         el = self.find_element(*self._download_button_locator)
         return DownloadButton(self, root=el)
-
-    def wait_for_page_to_load(self):
-        el = self.find_element(By.TAG_NAME, 'html')
-        self.wait.until(lambda s: 'loaded' in el.get_attribute('class'))
-        promo = self.find_element(*self._sticky_promo_modal_content_locator)
-        self.wait.until(lambda s: 'is-displayed' in promo.get_attribute('class'))
-        return self
 
     @property
     def promo(self):

--- a/tests/pages/firefox/features/landing.py
+++ b/tests/pages/firefox/features/landing.py
@@ -6,6 +6,7 @@ from selenium.webdriver.common.by import By
 
 from pages.base import BasePage
 from pages.regions.download_button import DownloadButton
+from pages.regions.sticky_promo import StickyPromo
 
 
 class FeaturesLandingPage(BasePage):
@@ -18,3 +19,14 @@ class FeaturesLandingPage(BasePage):
     def download_button(self):
         el = self.find_element(*self._download_button_locator)
         return DownloadButton(self, root=el)
+
+    def wait_for_page_to_load(self):
+        el = self.find_element(By.TAG_NAME, 'html')
+        self.wait.until(lambda s: 'loaded' in el.get_attribute('class'))
+        promo = self.find_element(*self._sticky_promo_modal_content_locator)
+        self.wait.until(lambda s: 'is-displayed' in promo.get_attribute('class'))
+        return self
+
+    @property
+    def promo(self):
+        return StickyPromo(self)

--- a/tests/pages/firefox/features/landing.py
+++ b/tests/pages/firefox/features/landing.py
@@ -14,18 +14,23 @@ class FeaturesLandingPage(BasePage):
     _URL_TEMPLATE = '/{locale}/firefox/features/'
 
     _download_button_locator = (By.ID, 'features-header-download')
+    _sticky_promo_modal_content_locator = (By.CSS_SELECTOR, '.mzp-c-sticky-promo.mzp-a-slide-in')
+
+    def wait_for_page_to_load(self):
+        el = self.find_element(By.TAG_NAME, 'html')
+        self.wait.until(lambda s: 'loaded' in el.get_attribute('class'))
+
+        # Sticky promo is shown to non-Firefox browsers only.
+        if self.selenium.capabilities.get('browserName').lower() != 'firefox':
+            promo = self.find_element(*self._sticky_promo_modal_content_locator)
+            self.wait.until(lambda s: 'is-displayed' in promo.get_attribute('class'))
+
+        return self
 
     @property
     def download_button(self):
         el = self.find_element(*self._download_button_locator)
         return DownloadButton(self, root=el)
-
-    def wait_for_page_to_load(self):
-        el = self.find_element(By.TAG_NAME, 'html')
-        self.wait.until(lambda s: 'loaded' in el.get_attribute('class'))
-        promo = self.find_element(*self._sticky_promo_modal_content_locator)
-        self.wait.until(lambda s: 'is-displayed' in promo.get_attribute('class'))
-        return self
 
     @property
     def promo(self):

--- a/tests/pages/firefox/releasenotes.py
+++ b/tests/pages/firefox/releasenotes.py
@@ -33,6 +33,18 @@ class FirefoxReleaseNotesPage(BasePage):
     _secondary_play_store_button_locator = (By.ID, 'download-android-secondary')
     _primary_app_store_button_locator = (By.ID, 'download-ios-primary')
     _secondary_app_store_button_locator = (By.ID, 'download-ios-secondary')
+    _sticky_promo_modal_content_locator = (By.CSS_SELECTOR, '.mzp-c-sticky-promo.mzp-a-slide-in')
+
+    def wait_for_page_to_load(self):
+        el = self.find_element(By.TAG_NAME, 'html')
+        self.wait.until(lambda s: 'loaded' in el.get_attribute('class'))
+
+        # Sticky promo is shown to non-Firefox browsers only.
+        if self.selenium.capabilities.get('browserName').lower() != 'firefox':
+            promo = self.find_element(*self._sticky_promo_modal_content_locator)
+            self.wait.until(lambda s: 'is-displayed' in promo.get_attribute('class'))
+
+        return self
 
     @property
     def primary_download_button_release(self):
@@ -133,13 +145,6 @@ class FirefoxReleaseNotesPage(BasePage):
     @property
     def is_pre_releases_menu_displayed(self):
         return self.is_element_displayed(*self._pre_releases_menu_locator)
-
-    def wait_for_page_to_load(self):
-        el = self.find_element(By.TAG_NAME, 'html')
-        self.wait.until(lambda s: 'loaded' in el.get_attribute('class'))
-        promo = self.find_element(*self._sticky_promo_modal_content_locator)
-        self.wait.until(lambda s: 'is-displayed' in promo.get_attribute('class'))
-        return self
 
     @property
     def promo(self):

--- a/tests/pages/firefox/releasenotes.py
+++ b/tests/pages/firefox/releasenotes.py
@@ -33,7 +33,6 @@ class FirefoxReleaseNotesPage(BasePage):
     _secondary_play_store_button_locator = (By.ID, 'download-android-secondary')
     _primary_app_store_button_locator = (By.ID, 'download-ios-primary')
     _secondary_app_store_button_locator = (By.ID, 'download-ios-secondary')
-    _sticky_promo_modal_content_locator = (By.CSS_SELECTOR, '.mzp-c-sticky-promo.mzp-a-slide-in')
 
     @property
     def primary_download_button_release(self):

--- a/tests/pages/firefox/releasenotes.py
+++ b/tests/pages/firefox/releasenotes.py
@@ -6,6 +6,7 @@ from selenium.webdriver.common.by import By
 
 from pages.base import BasePage
 from pages.regions.download_button import DownloadButton
+from pages.regions.sticky_promo import StickyPromo
 
 
 class FirefoxReleaseNotesPage(BasePage):
@@ -32,6 +33,7 @@ class FirefoxReleaseNotesPage(BasePage):
     _secondary_play_store_button_locator = (By.ID, 'download-android-secondary')
     _primary_app_store_button_locator = (By.ID, 'download-ios-primary')
     _secondary_app_store_button_locator = (By.ID, 'download-ios-secondary')
+    _sticky_promo_modal_content_locator = (By.CSS_SELECTOR, '.mzp-c-sticky-promo.mzp-a-slide-in')
 
     @property
     def primary_download_button_release(self):
@@ -132,3 +134,14 @@ class FirefoxReleaseNotesPage(BasePage):
     @property
     def is_pre_releases_menu_displayed(self):
         return self.is_element_displayed(*self._pre_releases_menu_locator)
+
+    def wait_for_page_to_load(self):
+        el = self.find_element(By.TAG_NAME, 'html')
+        self.wait.until(lambda s: 'loaded' in el.get_attribute('class'))
+        promo = self.find_element(*self._sticky_promo_modal_content_locator)
+        self.wait.until(lambda s: 'is-displayed' in promo.get_attribute('class'))
+        return self
+
+    @property
+    def promo(self):
+        return StickyPromo(self)


### PR DESCRIPTION
## Description

This PR adds the "Download" [Sticky Promo element](https://protocol.mozilla.org/patterns/molecules/sticky-promo.html) to mulitple pages. 

### Pages Checklist: 
- [x] /firefox/releasenotes
- [x] /firefox/features/adblocker/ 
- [x] /firefox/features/bookmarks
- [x] /firefox/features/fast
- [x] /firefox/features/independant
- [x] /firefox/features/memory
- [x] /firefox/features/password-manager
- [x] /firefox/features/private-browsing
- [x] /firefox/features/safe-browser
- [x] /firefox/browsers/best-browser
- [x] /firefox/browsers/browser-history
- [x] /firefox/browsers/incognito-browser
- [x] /firefox/browsers/what-is-a-browser
- [x] /firefox/browsers/windows-64-bit/
- [x] /firefox/browsers/compare/brave
- [x] /firefox/browsers/compare/opera
- [x] /firefox/browsers/compare/chrome
- [x] /firefox/browsers/compare/ie
- [x] /firefox/browsers/compare/edge
- [x] /firefox/browsers/compare/safari

New pages: (Not listed in #9767)
- [x] /firefox/features/
- [x] /firefox/browsers/quantum/
- [ ] ~/firefox/browsers/chromebook/~

Updated Theme from Moz to Firefox: 
- [x] /firefox/browsers/what-is-a-browser/
- [x] /firefox/browsers/incognito-browser/
- [x] /firefox/browsers/browser-history/
- [x] /firefox/browsers/update-your-browser/ (not getting a promo but should be updated as well)

## Issue / Bugzilla link

#9767

## Testing

- The promo should be visible only if in a Non-Firefox browser AND you have not dismissed the promo by clicking the "X" to dismiss. 

### Localhost URLs to check

- [localhost:8000/en-US/firefox/releasenotes/](localhost:8000/en-US/firefox/releasenotes/)

### Screenshot

<img width="423" alt="image" src="https://user-images.githubusercontent.com/2692333/101828373-0fb84600-3af7-11eb-8592-65bb3344f679.png">
