### PR TITLE
Android native styled banners A/B test on /firefox. (#9434)

### DIFF
--- a/bedrock/base/templates/includes/banners/mobile/native-android-exp.html
+++ b/bedrock/base/templates/includes/banners/mobile/native-android-exp.html
@@ -1,0 +1,46 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
+
+{% from "macros.html" import google_play_button with context %}
+{% set android_url = firefox_adjust_url('android', 'native-android-exp-banner') %}
+
+{% if variant == '2' %}
+<aside class="c-banner hide-from-legacy-ie mzp-t-firefox t-mozilla" id="native-android-banner">
+  {# Exclude banners from search result snippets using `data-nosnippet` (issue 8739) #}
+  <div class="c-banner-inner" data-nosnippet="true">
+      <button type="button" class="c-banner-close"><span>Close</span></button>
+    <div class="mzp-l-content">
+      <div class="c-banner-main">
+          <h2 class="c-banner-title">Download the Firefox browser designed for Android</h2>
+          {{ google_play_button(href=android_url, extra_data_attributes={'data-download-location': 'native app banner exp'}) }}
+      </div>
+    </div>
+  </div>
+</aside>
+{% else %}
+<aside class="c-banner hide-from-legacy-ie mzp-t-firefox t-native {% if variant in ['5', '6'] %}t-dark{% endif %}" id="native-android-banner">
+  {# Exclude banners from search result snippets using `data-nosnippet` (issue 8739) #}
+  <div class="c-banner-inner" data-nosnippet="true">
+    <div class="mzp-l-content">
+      <div class="c-banner-main">
+          <button type="button" class="c-banner-close"><span>Close</span></button>
+          {% if variant in ['5', '6'] %}
+            <img class="c-banner-icon" src="https://www.mozilla.org/media/cro_exp/img/nativedownload/android-icon-white-512.jpg" width="57" height="57" alt="" />
+          {% else %}
+            <img class="c-banner-icon" src="https://www.mozilla.org/media/cro_exp/img/nativedownload/android-icon-512.jpg" width="57" height="57" alt="" />
+          {% endif %}
+          <div class=c-banner-copy>
+            <h2 class="c-banner-title">Firefox: Private, Safe Browser</h2>
+            <p>Mozilla</p>
+            {% if variant in ['4', '5'] %}
+            <img class="c-banner-rating" src="https://www.mozilla.org/media/cro_exp/img/nativedownload/stars-android.png" width="70" alt="Rating: four and a half stars out of five" />
+            {% endif %}
+            <p>Free – In Google Play</p>
+          </div>
+          <a class="c-banner-button" href="{{ android_url }}" data-link-type="download" data-download-os="Android" data-download-location="native app banner exp">View</a>
+      </div>
+    </div>
+  </div>
+</aside>
+{% endif %}

--- a/bedrock/firefox/templates/firefox/home/exp/v-1.html
+++ b/bedrock/firefox/templates/firefox/home/exp/v-1.html
@@ -1,0 +1,10 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. #}
+
+{% extends "firefox/home/index-master.html" %}
+
+{% block js %}
+  {{ js_bundle('firefox-master') }}
+  {{ js_bundle('native-android-exp-banner') }}
+{% endblock %}

--- a/bedrock/firefox/templates/firefox/home/exp/v-2.html
+++ b/bedrock/firefox/templates/firefox/home/exp/v-2.html
@@ -1,0 +1,19 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. #}
+
+{% extends "firefox/home/index-master.html" %}
+
+{% block page_css %}
+  {{ super() }}
+  {{ css_bundle('native-android-exp-banner') }}
+{% endblock %}
+
+{% block page_banner %}
+  {% include 'includes/banners/mobile/native-android-exp.html' %}
+{% endblock %}
+
+{% block js %}
+  {{ js_bundle('firefox-master') }}
+  {{ js_bundle('native-android-exp-banner') }}
+{% endblock %}

--- a/bedrock/firefox/templates/firefox/home/exp/v-3.html
+++ b/bedrock/firefox/templates/firefox/home/exp/v-3.html
@@ -1,0 +1,19 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. #}
+
+{% extends "firefox/home/index-master.html" %}
+
+{% block page_css %}
+  {{ super() }}
+  {{ css_bundle('native-android-exp-banner') }}
+{% endblock %}
+
+{% block page_banner %}
+  {% include 'includes/banners/mobile/native-android-exp.html' %}
+{% endblock %}
+
+{% block js %}
+  {{ js_bundle('firefox-master') }}
+  {{ js_bundle('native-android-exp-banner') }}
+{% endblock %}

--- a/bedrock/firefox/templates/firefox/home/exp/v-4.html
+++ b/bedrock/firefox/templates/firefox/home/exp/v-4.html
@@ -1,0 +1,19 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. #}
+
+{% extends "firefox/home/index-master.html" %}
+
+{% block page_css %}
+  {{ super() }}
+  {{ css_bundle('native-android-exp-banner') }}
+{% endblock %}
+
+{% block page_banner %}
+  {% include 'includes/banners/mobile/native-android-exp.html' %}
+{% endblock %}
+
+{% block js %}
+  {{ js_bundle('firefox-master') }}
+  {{ js_bundle('native-android-exp-banner') }}
+{% endblock %}

--- a/bedrock/firefox/templates/firefox/home/exp/v-5.html
+++ b/bedrock/firefox/templates/firefox/home/exp/v-5.html
@@ -1,0 +1,19 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. #}
+
+{% extends "firefox/home/index-master.html" %}
+
+{% block page_css %}
+  {{ super() }}
+  {{ css_bundle('native-android-exp-banner') }}
+{% endblock %}
+
+{% block page_banner %}
+  {% include 'includes/banners/mobile/native-android-exp.html' %}
+{% endblock %}
+
+{% block js %}
+  {{ js_bundle('firefox-master') }}
+  {{ js_bundle('native-android-exp-banner') }}
+{% endblock %}

--- a/bedrock/firefox/templates/firefox/home/exp/v-6.html
+++ b/bedrock/firefox/templates/firefox/home/exp/v-6.html
@@ -1,0 +1,19 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at http://mozilla.org/MPL/2.0/. #}
+
+{% extends "firefox/home/index-master.html" %}
+
+{% block page_css %}
+  {{ super() }}
+  {{ css_bundle('native-android-exp-banner') }}
+{% endblock %}
+
+{% block page_banner %}
+  {% include 'includes/banners/mobile/native-android-exp.html' %}
+{% endblock %}
+
+{% block js %}
+  {{ js_bundle('firefox-master') }}
+  {{ js_bundle('native-android-exp-banner') }}
+{% endblock %}

--- a/bedrock/firefox/templates/firefox/home/index-master.html
+++ b/bedrock/firefox/templates/firefox/home/index-master.html
@@ -24,6 +24,11 @@
 {% block page_favicon_large %}{{ static('img/favicons/firefox/favicon-196x196.png') }}{% endblock %}
 {% block page_ios_icon %}{{ static('img/favicons/firefox/apple-touch-icon.png') }}{% endblock %}
 
+{% block experiments %}
+  {% if switch('firefox-mobile-android-experiment', ['en-US']) %}
+    {{ js_bundle('firefox-mobile-android-experiment') }}
+  {% endif %}
+{% endblock %}
 
 {% block page_css %}
   {{ css_bundle('firefox-master') }}

--- a/bedrock/firefox/tests/test_views.py
+++ b/bedrock/firefox/tests/test_views.py
@@ -782,6 +782,64 @@ class TestFirefoxHome(TestCase):
         template = render_mock.call_args[0][1]
         assert template == ['firefox/home/index-quantum.html']
 
+    @patch('bedrock.firefox.views.l10n_utils.render')
+    def test_firefox_native_app_banner_exp_variant_1(self, render_mock):
+        req = RequestFactory().get('/firefox/?v=1')
+        req.locale = 'en-US'
+        view = views.FirefoxHomeView.as_view()
+        view(req)
+        template = render_mock.call_args[0][1]
+        assert template == ['firefox/home/exp/v-1.html']
+
+    # Begin android native app banner exp: issue 9434
+
+    @patch('bedrock.firefox.views.l10n_utils.render')
+    def test_firefox_native_app_banner_exp_variant_2(self, render_mock):
+        req = RequestFactory().get('/firefox/?v=2')
+        req.locale = 'en-US'
+        view = views.FirefoxHomeView.as_view()
+        view(req)
+        template = render_mock.call_args[0][1]
+        assert template == ['firefox/home/exp/v-2.html']
+
+    @patch('bedrock.firefox.views.l10n_utils.render')
+    def test_firefox_native_app_banner_exp_variant_3(self, render_mock):
+        req = RequestFactory().get('/firefox/?v=3')
+        req.locale = 'en-US'
+        view = views.FirefoxHomeView.as_view()
+        view(req)
+        template = render_mock.call_args[0][1]
+        assert template == ['firefox/home/exp/v-3.html']
+
+    @patch('bedrock.firefox.views.l10n_utils.render')
+    def test_firefox_native_app_banner_exp_variant_4(self, render_mock):
+        req = RequestFactory().get('/firefox/?v=4')
+        req.locale = 'en-US'
+        view = views.FirefoxHomeView.as_view()
+        view(req)
+        template = render_mock.call_args[0][1]
+        assert template == ['firefox/home/exp/v-4.html']
+
+    @patch('bedrock.firefox.views.l10n_utils.render')
+    def test_firefox_native_app_banner_exp_variant_5(self, render_mock):
+        req = RequestFactory().get('/firefox/?v=5')
+        req.locale = 'en-US'
+        view = views.FirefoxHomeView.as_view()
+        view(req)
+        template = render_mock.call_args[0][1]
+        assert template == ['firefox/home/exp/v-5.html']
+
+    @patch('bedrock.firefox.views.l10n_utils.render')
+    def test_firefox_native_app_banner_exp_variant_6(self, render_mock):
+        req = RequestFactory().get('/firefox/?v=6')
+        req.locale = 'en-US'
+        view = views.FirefoxHomeView.as_view()
+        view(req)
+        template = render_mock.call_args[0][1]
+        assert template == ['firefox/home/exp/v-6.html']
+
+    # End android native app banner exp: issue 9434
+
 
 class TestFirefoxWelcomePage1(TestCase):
     @patch('bedrock.firefox.views.l10n_utils.render')

--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -836,13 +836,44 @@ def ios_testflight(request):
 
 class FirefoxHomeView(L10nTemplateView):
     ftl_files_map = {
-        'firefox/home/index-master.html': ['firefox/home']
+        'firefox/home/index-master.html': ['firefox/home'],
+        'firefox/home/exp/v-1.html': ['firefox/home'],
+        'firefox/home/exp/v-2.html': ['firefox/home'],
+        'firefox/home/exp/v-3.html': ['firefox/home'],
+        'firefox/home/exp/v-4.html': ['firefox/home'],
+        'firefox/home/exp/v-5.html': ['firefox/home'],
+        'firefox/home/exp/v-6.html': ['firefox/home'],
     }
     activation_files = ['firefox/home', 'firefox/home/index-quantum.html']
 
+    # place expected ?v= values in this list
+    variations = ['1', '2', '3', '4', '5', '6']
+
+    def get_context_data(self, **kwargs):
+        ctx = super(FirefoxHomeView, self).get_context_data(**kwargs)
+        variant = self.request.GET.get('v', None)
+
+        # ensure variant matches pre-defined value
+        if variant not in self.variations:
+            variant = None
+
+        ctx['variant'] = variant
+
+        return ctx
+
     def get_template_names(self):
+        locale = l10n_utils.get_locale(self.request)
+        variant = self.request.GET.get('v', None)
+
+        # ensure variant matches pre-defined value
+        if variant not in self.variations:
+            variant = None
+
         if ftl_file_is_active('firefox/home'):
-            template_name = 'firefox/home/index-master.html'
+            if locale == 'en-US' and variant:
+                template_name = 'firefox/home/exp/v-{}.html'.format(variant)
+            else:
+                template_name = 'firefox/home/index-master.html'
         else:
             template_name = 'firefox/home/index-quantum.html'
 

--- a/media/css/base/banners/native-android-exp.scss
+++ b/media/css/base/banners/native-android-exp.scss
@@ -1,0 +1,205 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+$font-path: '/media/fonts';
+$image-path: '/media/protocol/img';
+
+@import '../../../protocol/css/includes/lib';
+
+#native-android-banner {
+    position: relative;
+    z-index: 1000; //banner shares same z-index as sticky nav.
+
+    &.c-banner {
+        background: #f2f2f2;
+
+        // hide by default if JS is available to avoid flicker
+        // (if visitor previously dismissed)
+        .js & {
+            display: none;
+        }
+
+        // conditional class used to display the banner.
+        &.c-banner-is-visible {
+            display: block;
+        }
+    }
+
+    .c-banner-icon {
+        border-radius: $border-radius-md;
+        display: block;
+        height: 57px;
+        margin-right: $spacing-sm;
+        width: 57px;
+    }
+
+    .c-banner-button {
+        @include text-body-md;
+        background-color: #68A036;
+        border-radius: $border-radius-sm;
+        color: $color-white;
+        margin-left: auto;
+        padding: $spacing-xs $spacing-md;
+        text-decoration: none;
+        text-transform: uppercase;
+    }
+
+    .c-banner-rating {
+        padding: 1px 0;
+        width: 70px;
+    }
+
+    .mzp-l-content {
+        padding-top: $spacing-md;
+        padding-bottom: $spacing-md;
+    }
+
+    .c-banner-copy {
+        @include text-body-xs;
+    }
+
+    .c-banner-title {
+        @include bidi(((padding-right, $spacing-lg, 0), (padding-left, 0, $spacing-lg),));
+        @include text-body-md;
+        color: $color-black;
+        font-weight: 500;
+        line-height: 1.2;
+        margin: 0;
+        padding: 0;
+    }
+
+    .c-banner-main {
+        @include align-items(center);
+        @include flexbox;
+
+        p {
+            margin: 0;
+        }
+    }
+}
+
+//native theme
+#native-android-banner.t-native {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+
+    .c-banner-title {
+        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+    }
+
+    // Close button
+    .c-banner-close {
+        @include image-replaced;
+        background: transparent url('#{$image-path}/icons/close.svg') center center no-repeat;
+        @include background-size(15px 15px);
+        border: none;
+        cursor: pointer;
+        display: none;
+        height: 21px;
+        margin-right: $spacing-sm;
+        min-width: 0;
+        padding: 0;
+        width: 21px;
+    }
+}
+
+//native dark theme
+#native-android-banner.t-native.t-dark {
+    &.c-banner {
+        background: #3f3f3f;
+        color: $color-white;
+    }
+
+    .c-banner-title {
+        color: $color-white;
+    }
+
+    .c-banner-close {
+        background-color: #1c1e21;
+        background-image: url('#{$image-path}/icons/close-white.svg');
+        border-radius: 50%;
+        box-shadow: inset 0 0 1px $color-black;
+        color: #adadb0;
+        min-width: 24px;
+    }
+
+    .c-banner-button {
+        background-color: #3db1c4;
+        border: 1px solid $color-white;
+        box-shadow: inset 0 0 3px 0 $color-black, 0 0 1px 1px $color-black;
+        color: $color-white;
+    }
+}
+
+//mozilla theme
+#native-android-banner.t-mozilla {
+    background: #ffd567 no-repeat center center url('https://www.mozilla.org/media/cro_exp/img/switch/NoodleBg_yellow.svg');
+    @include background-size(120% auto);
+    color: $color-white;
+    padding-bottom: $spacing-xl;
+    padding-top: $spacing-xl;
+
+    .c-banner-main {
+        display: block;
+        text-align: center;
+
+        a:link,
+        a:visited {
+            display: block;
+        }
+    }
+
+    .c-banner-title {
+        @include text-title-sm;
+        color: #7542e5;
+        font-weight: bold;
+        line-height: 1.5;
+        margin: 0 auto $spacing-lg;
+        max-width: 500px;
+        padding: 0;
+    }
+
+    .c-banner-close {
+        @include background-size(20px 20px);
+        @include bidi(((right, $spacing-sm, auto), (left, auto, $spacing-sm)));
+        @include image-replaced;
+        background: transparent url('#{$image-path}/icons/close.svg') center center no-repeat;
+        border: none;
+        cursor: pointer;
+        display: none;
+        height: 42px;
+        min-width: 0;
+        padding: 0;
+        position: absolute;
+        top: $spacing-sm;
+        width: 42px;
+    }
+}
+
+// Close button
+#native-android-banner.t-native,
+#native-android-banner.t-mozilla {
+    .c-banner-close {
+        &:hover,
+        &:focus {
+            @include transform(scale(1.1));
+            @include transition(transform .1s ease-in-out);
+        }
+
+        &:focus {
+            outline: 1px dotted $color-white;
+        }
+
+        // hide the 'Close' text
+        span {
+            @include visually-hidden;
+        }
+
+        // only display when JS is available
+        .js & {
+            display: block;
+        }
+    }
+}
+
+

--- a/media/js/firefox/home/android-experiment.js
+++ b/media/js/firefox/home/android-experiment.js
@@ -1,0 +1,69 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+(function (Mozilla) {
+    'use strict';
+
+    var href = window.location.href;
+
+    var initTrafficCop = function () {
+        if (href.indexOf('v=') !== -1) {
+            if (href.indexOf('v=1') !== -1) {
+                window.dataLayer.push({
+                    'data-ex-variant': 'firefox-mobile-android-control',
+                    'data-ex-name': 'firefox-mobile-android-experiment'
+                });
+            } else if (href.indexOf('v=2') !== -1) {
+                window.dataLayer.push({
+                    'data-ex-variant': 'firefox-mobile-android-v2',
+                    'data-ex-name': 'firefox-mobile-android-experiment'
+                });
+            } else if (href.indexOf('v=3') !== -1) {
+                window.dataLayer.push({
+                    'data-ex-variant': 'firefox-mobile-android-v3',
+                    'data-ex-name': 'firefox-mobile-android-experiment'
+                });
+            }
+            else if (href.indexOf('v=4') !== -1) {
+                window.dataLayer.push({
+                    'data-ex-variant': 'firefox-mobile-android-v4',
+                    'data-ex-name': 'firefox-mobile-android-experiment'
+                });
+            }
+            else if (href.indexOf('v=5') !== -1) {
+                window.dataLayer.push({
+                    'data-ex-variant': 'firefox-mobile-android-v5',
+                    'data-ex-name': 'firefox-mobile-android-experiment'
+                });
+            }
+            else if (href.indexOf('v=6') !== -1) {
+                window.dataLayer.push({
+                    'data-ex-variant': 'firefox-mobile-android-v6',
+                    'data-ex-name': 'firefox-mobile-android-experiment'
+                });
+            }
+        } else {
+            var cop = new Mozilla.TrafficCop({
+                id: 'experiment-firefox-mobile-android',
+                variations: {
+                    'v=1': 12,
+                    'v=2': 12,
+                    'v=3': 12,
+                    'v=4': 12,
+                    'v=5': 12,
+                    'v=6': 12,
+                }
+            });
+
+            cop.init();
+        }
+    };
+
+    // Avoid entering automated tests into random experiments.
+    // Target audience is Android mobile users.
+    if (href.indexOf('automation=true') === -1 && window.site && window.site.platform === 'android') {
+        initTrafficCop();
+    }
+
+})(window.Mozilla);

--- a/media/js/firefox/home/android-native-banner-init.js
+++ b/media/js/firefox/home/android-native-banner-init.js
@@ -1,0 +1,97 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// Create namespace
+if (typeof window.Mozilla === 'undefined') {
+    window.Mozilla = {};
+}
+
+(function() {
+    'use strict';
+
+    var _pageBanner;
+
+    // This is a slightly modified version of mozilla-banner.js that inserts the banner
+    // right to the top of the viewport instead of in-page.
+    var NativeBanner = {};
+
+    NativeBanner.setCookie = function(id) {
+        var date = new Date();
+        var cookieDuration = 1 * 24 * 60 * 60 * 1000; // 1 day expiration
+        date.setTime(date.getTime() + cookieDuration); // 1 day expiration
+        Mozilla.Cookies.setItem(id, true, date.toUTCString(), '/');
+    };
+
+    NativeBanner.hasCookie = function(id) {
+        return Mozilla.Cookies.hasItem(id);
+    };
+
+    NativeBanner.close = function() {
+        // Remove the banner from the DOM.
+        _pageBanner.parentNode.removeChild(_pageBanner);
+
+        // Set a cookie to not display it again.
+        NativeBanner.setCookie(NativeBanner.id);
+
+        // Track the event in GA.
+        window.dataLayer.push({
+            'event': 'in-page-interaction',
+            'eLabel': 'Banner Dismissal',
+            'data-banner-name': NativeBanner.id,
+            'data-banner-dismissal': '1'
+        });
+    };
+
+    NativeBanner.show = function() {
+        // remove banner from bottom of page and reinsert at the top of the page, above the main navigation.
+        _pageBanner = _pageBanner.parentNode.removeChild(_pageBanner);
+        document.body.insertBefore(_pageBanner, document.body.firstChild);
+
+        // display the banner
+        _pageBanner.classList.add('c-banner-is-visible');
+
+        // wire up close button
+        _pageBanner.querySelector('.c-banner-close').addEventListener('click', NativeBanner.close, false);
+    };
+
+    NativeBanner.init = function(id) {
+        var cookiesEnabled = typeof Mozilla.Cookies !== 'undefined' && Mozilla.Cookies.enabled();
+
+        _pageBanner = document.getElementById(id);
+
+        /**
+         * If the banner does not exist on a page,
+         * or there's not a valid banner ID then do nothing.
+         */
+        if (!_pageBanner || typeof id !== 'string') {
+            return false;
+        }
+
+        NativeBanner.id = id;
+
+        // Show only if cookies enabled & banner not previously dismissed.
+        if (cookiesEnabled && !NativeBanner.hasCookie(NativeBanner.id)) {
+            NativeBanner.show();
+        }
+    };
+
+    window.Mozilla.NativeBanner = NativeBanner;
+
+})();
+
+
+(function() {
+    'use strict';
+
+    function onLoad() {
+        window.Mozilla.NativeBanner.init('native-android-banner');
+    }
+
+    window.Mozilla.run(onLoad);
+
+})();

--- a/media/static-bundles.json
+++ b/media/static-bundles.json
@@ -246,6 +246,12 @@
     },
     {
       "files": [
+        "css/base/banners/native-android-exp.scss"
+      ],
+      "name": "native-android-exp-banner"
+    },
+    {
+      "files": [
         "css/protocol/common-old-ie.scss"
       ],
       "name": "common-old-ie"
@@ -1018,6 +1024,12 @@
     },
     {
       "files": [
+        "js/firefox/home/android-native-banner-init.js"
+      ],
+      "name": "native-android-exp-banner"
+    },
+    {
+      "files": [
         "protocol/js/protocol-sidemenu.js",
         "js/base/mozilla-article.js",
         "js/privacy/privacy-protocol.js"
@@ -1056,6 +1068,13 @@
         "js/firefox/mobile/mobile.js"
       ],
       "name": "firefox-mobile"
+    },
+    {
+      "files": [
+        "js/libs/mozilla-traffic-cop.js",
+        "js/firefox/home/android-experiment.js"
+      ],
+      "name": "firefox-mobile-android-experiment"
     },
     {
       "files": [


### PR DESCRIPTION
## Description
Adds multi-variant Traffic Cop experiment for testing native app banners for Android on the /firefox page.

- http://localhost:8000/en-US/firefox/?v=1 (control)
- http://localhost:8000/en-US/firefox/?v=2 (mozilla banner)
- http://localhost:8000/en-US/firefox/?v=3 (native no star rating)
- http://localhost:8000/en-US/firefox/?v=4 (native star rating)
- http://localhost:8000/en-US/firefox/?v=5 (native dark star rating)
- http://localhost:8000/en-US/firefox/?v=6 (native dark no stars)

## Issue / Bugzilla link
#9434

## Testing
- [ ] Experiment is configured for Android only.
- [ ] Experiment is behind the switch `firefox-mobile-android-experiment` for en-US locale only.
- [ ] Each variation URL shows the correct banner.
- [ ] Android Play Store CTAs have apropriate download attribution for GA.