### PR TITLE
Fix #9786 - Add CSS qualification to visible sticky promo box

### DIFF
--- a/media/css/firefox/includes/_sticky-promo.scss
+++ b/media/css/firefox/includes/_sticky-promo.scss
@@ -65,7 +65,7 @@ $image-path: '/media/protocol/img';
 }
 
 @media #{$mq-md} {
-    .mzp-c-sticky-promo {
+    .mzp-c-sticky-promo.mzp-a-slide-in {
         display: block;
     }
 }


### PR DESCRIPTION
## Description

Sticky Promo box was just being visually hidden, rather than not displayed, once dismissed.

## Issue / Bugzilla link

#9786 

## Testing

Go to [http://localhost:8000/en-US/firefox/](http://localhost:8000/en-US/firefox/) and dismiss the box. It should no longer visible and should not intefer with selecting the language from the footer. 
