### PR TITLE
Migrate firefox/developer pages to Fluent (Fixes #9191) [skip l10n]

### DIFF
--- a/bedrock/firefox/templates/firefox/developer/firstrun.html
+++ b/bedrock/firefox/templates/firefox/developer/firstrun.html
@@ -2,15 +2,13 @@
  # License, v. 2.0. If a copy of the MPL was not distributed with this
  # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
 
-{% add_lang_files "firefox/products/developer-quantum" "firefox/shared" %}
-
 {% extends "firefox/base/base-protocol.html" %}
 
 {# "noindex" pages should not have the canonical or hreflang tags: bug 1442331 #}
 {% block canonical_urls %}<meta name="robots" content="noindex,follow">{% endblock %}
 
-{% block page_title %}{{_('Firefox Developer Edition')}}{% endblock %}
-{% block page_desc %}{{ _('Firefox Developer Edition is the blazing fast browser that offers cutting edge developer tools and latest features like CSS Grid support and framework debugging') }}{% endblock %}
+{% block page_title %}{{ ftl('firefox-developer-page-title') }}{% endblock %}
+{% block page_desc %}{{ ftl('firefox-developer-firefox-developer-edition-desc') }}{% endblock %}
 {% block page_image %}{{ static('protocol/img/logos/firefox/browser/developer/og.png') }}{% endblock %}
 {% block page_favicon %}{{ static('img/favicons/firefox/browser/developer/favicon.ico') }}{% endblock %}
 {% block page_favicon_large %}{{ static('img/favicons/firefox/browser/developer/favicon-196x196.png') }}{% endblock %}
@@ -29,14 +27,9 @@
       <div class="mzp-l-content">
         {{ high_res_img('protocol/img/logos/firefox/browser/developer/logo-word-hor-md.png', {'alt': '', 'width': '368', 'height': '68'}) }}
         <h1 class="intro-title">
-        {% if l10n_has_tag('made_for_devs_102019') %}
-          {# L10n: "Firefox Browser Developer Edition" is a product name and shouldn't be translated #}
-          {{ _('Welcome to Firefox Browser Developer Edition') }}
-        {% else %}
-          {{ _('Welcome to the all-new Firefox Quantum: Developer Edition') }}
-        {% endif %}
+          {{ ftl('firefox-developer-welcome-to-firefox-browser', fallback='firefox-developer-welcome-to-the-all-new') }}
         </h1>
-        <p class="intro-tagline">{{ _('Firefox has been rebuilt from the ground-up to be faster, sleeker, and more powerful than ever.') }}</p>
+        <p class="intro-tagline">{{ ftl('firefox-developer-firefox-has-been-rebuilt') }}</p>
 
         {% include '/firefox/developer/includes/intro-features.html' %}
     </div>
@@ -46,7 +39,7 @@
 
   {% include '/firefox/developer/includes/highlights.html' %}
 
-  {% if l10n_has_tag('made_for_devs_102019') %}
+  {% if ftl_has_messages('firefox-developer-made-for-developers', 'firefox-developer-all-the-latest') %}
     {% include '/firefox/developer/includes/for-developers.html' %}
   {% else %}
     {% include '/firefox/developer/includes/performance.html' %}

--- a/bedrock/firefox/templates/firefox/developer/includes/alt-newsletter.html
+++ b/bedrock/firefox/templates/firefox/developer/includes/alt-newsletter.html
@@ -1,11 +1,10 @@
 <section class="t-newsletter">
   <div class="mzp-l-content">
     {% if LANG.startswith('en-') %}
-      {# L10n: line break for visual formatting #}
       {{ email_newsletter_form(
         'app-dev',
         title='Mozilla Developer Newsletter',
-        desc=_('Get developer news, tricks and resources <br /> sent straight to your inbox.'),
+        desc='Get developer news, tricks and resources <br /> sent straight to your inbox.'|safe,
         button_class='mzp-t-product mzp-t-lg',
         include_language=False) }}
     {% else %}

--- a/bedrock/firefox/templates/firefox/developer/includes/engage.html
+++ b/bedrock/firefox/templates/firefox/developer/includes/engage.html
@@ -1,16 +1,16 @@
 <div class="mzp-l-content t-do">
   <section class="mzp-c-card-picto mzp-c-card-picto-compact t-speak-up">
     <div class="mzp-c-card-picto-content">
-        <h3 class="mzp-c-card-picto-title">{{ _('Speak up') }}</h3>
-        <p>{{ _('Feedback makes us better. Tell us how we can improve the browser and Developer tools.') }}</p>
-        <p><a class="mzp-c-cta-link" href="https://discourse.mozilla.org/c/devtools">{{ _('Join the conversation') }}</a></p>
+        <h3 class="mzp-c-card-picto-title">{{ ftl('firefox-developer-speak-up') }}</h3>
+        <p>{{ ftl('firefox-developer-feedback-makes-us') }}</p>
+        <p><a class="mzp-c-cta-link" href="https://discourse.mozilla.org/c/devtools">{{ ftl('firefox-developer-join-the-convo') }}</a></p>
     </div>
   </section>
   <section class="mzp-c-card-picto mzp-c-card-picto-compact t-get-involved">
     <div class="mzp-c-card-picto-content">
-        <h3 class="mzp-c-card-picto-title">{{ _('Get involved') }}</h3>
-        <p>{{ _('Help build the last independent browser. Write code, fix bugs, make add-ons, and more.') }}</p>
-        <p><a class="mzp-c-cta-link" href="https://firefox-dev.tools/">{{ _('Start now') }}</a></p>
+        <h3 class="mzp-c-card-picto-title">{{ ftl('firefox-developer-get-involved') }}</h3>
+        <p>{{ ftl('firefox-developer-help-build-the-last') }}</p>
+        <p><a class="mzp-c-cta-link" href="https://firefox-dev.tools/">{{ ftl('firefox-developer-start-now') }}</a></p>
     </div>
   </section>
 </div>

--- a/bedrock/firefox/templates/firefox/developer/includes/features.html
+++ b/bedrock/firefox/templates/firefox/developer/includes/features.html
@@ -1,115 +1,155 @@
+
 <section class="t-features mzp-l-content mzp-t-content-xl">
-  <h2 class="c-title"><span>{{ _('Design. Code. Test. Refine.') }}</span></h2>
-  {# L10n: line break for visual formatting #}
-  <h3 class="c-subtitle">{{ _('Build and Perfect your sites<br> with Firefox DevTools') }}</h3>
+  <h2 class="c-title"><span>{{ ftl('firefox-developer-design-code-test') }}</span></h2>
+  <h3 class="c-subtitle">{{ ftl('firefox-developer-build-and-perfect') }}</h3>
 
   <ul class="c-gallery-grid">
     <li class="c-gallery-item">
       <img class="c-feature-img" src="{{ static('img/firefox/developer/feature-inspector.svg') }}" alt="">
-      <h3 class="c-feature-name">{{ _('Inspector') }}</h3>
+      <h3 class="c-feature-name">{{ ftl('firefox-developer-inspector') }}</h3>
       <p class="c-feature-desc">
-        {{ _('Inspect and refine code to build pixel-perfect layouts.') }}
-        {% if l10n_has_tag('quantum-firstrun-whatsnew') %}
-          <p class="c-feature-more"><a href="https://developer.mozilla.org/docs/Tools/Page_Inspector" class="mzp-c-cta-link" rel="external">{{ _('Learn more about Page Inspector') }}</a></p>
+        {{ ftl('firefox-developer-inspect-and-refine') }}
+        {% if ftl_has_messages('firefox-developer-learn-about-page-inspector') %}
+          <p class="c-feature-more">
+            <a href="https://developer.mozilla.org/docs/Tools/Page_Inspector" class="mzp-c-cta-link" rel="external">
+              {{ ftl('firefox-developer-learn-about-page-inspector') }}
+            </a>
+          </p>
         {% endif %}
       </p>
     </li>
 
     <li class="c-gallery-item">
       <img class="c-feature-img" src="{{ static('img/firefox/developer/feature-console.svg') }}" alt="">
-      <h3 class="c-feature-name">{{ _('Console') }}</h3>
+      <h3 class="c-feature-name">{{ ftl('firefox-developer-console') }}</h3>
       <p class="c-feature-desc">
-        {{ _('Track CSS, JavaScript, security and network issues.') }}
-        {% if l10n_has_tag('quantum-firstrun-whatsnew') %}
-          <p class="c-feature-more"><a href="https://developer.mozilla.org/docs/Tools/Web_Console" class="mzp-c-cta-link" rel="external">{{ _('Learn more about Web Console') }}</a></p>
+        {{ ftl('firefox-developer-track-css') }}
+        {% if ftl_has_messages('firefox-developer-learn-about-web-console') %}
+          <p class="c-feature-more">
+            <a href="https://developer.mozilla.org/docs/Tools/Web_Console" class="mzp-c-cta-link" rel="external">
+              {{ ftl('firefox-developer-learn-about-web-console') }}
+            </a>
+          </p>
         {% endif %}
       </p>
     </li>
 
     <li class="c-gallery-item">
       <img class="c-feature-img" src="{{ static('img/firefox/developer/feature-debugger.svg') }}" alt="">
-      <h3 class="c-feature-name">{{ _('Debugger') }}</h3>
+      <h3 class="c-feature-name">{{ ftl('firefox-developer-debugger') }}</h3>
       <p class="c-feature-desc">
-        {{ _('Powerful JavaScript debugger with support for your framework.') }}
-        {% if l10n_has_tag('quantum-firstrun-whatsnew') %}
-          <p class="c-feature-more"><a href="https://developer.mozilla.org/docs/Tools/Debugger" class="mzp-c-cta-link" rel="external">{{ _('Learn more about JavaScript Debugger') }}</a></p>
+        {{ ftl('firefox-developer-powerful-javascript') }}
+        {% if ftl_has_messages('firefox-developer-learn-more-about-debugger') %}
+          <p class="c-feature-more">
+            <a href="https://developer.mozilla.org/docs/Tools/Debugger" class="mzp-c-cta-link" rel="external">
+              {{ ftl('firefox-developer-learn-more-about-debugger') }}
+            </a>
+          </p>
         {% endif %}
       </p>
     </li>
 
     <li class="c-gallery-item">
       <img class="c-feature-img" src="{{ static('img/firefox/developer/feature-network.svg') }}" alt="">
-      <h3 class="c-feature-name">{{ _('Network') }}</h3>
+      <h3 class="c-feature-name">{{ ftl('firefox-developer-network') }}</h3>
       <p class="c-feature-desc">
-        {{ _('Monitor network requests that can slow or block your site.') }}
-        {% if l10n_has_tag('quantum-firstrun-whatsnew') %}
-          <p class="c-feature-more"><a href="https://developer.mozilla.org/docs/Tools/Network_Monitor" class="mzp-c-cta-link" rel="external">{{ _('Learn more about Network Monitor') }}</a></p>
+        {{ ftl('firefox-developer-monitor-network-requests') }}
+        {% if ftl_has_messages('firefox-developer-learn-more-about-newtork-monitor') %}
+          <p class="c-feature-more">
+            <a href="https://developer.mozilla.org/docs/Tools/Network_Monitor" class="mzp-c-cta-link" rel="external">
+              {{ ftl('firefox-developer-learn-more-about-newtork-monitor') }}
+            </a>
+          </p>
         {% endif %}
       </p>
     </li>
 
     <li class="c-gallery-item">
       <img class="c-feature-img" src="{{ static('img/firefox/developer/feature-storage.svg') }}" alt="">
-      <h3 class="c-feature-name">{{ _('Storage panel') }}</h3>
+      <h3 class="c-feature-name">{{ ftl('firefox-developer-storage-panel') }}</h3>
       <p class="c-feature-desc">
-        {{ _('Add, modify and remove cache, cookies, databases and session data.') }}
-        {% if l10n_has_tag('quantum-firstrun-whatsnew') %}
-          <p class="c-feature-more"><a href="https://developer.mozilla.org/docs/Tools/Storage_Inspector" class="mzp-c-cta-link" rel="external">{{ _('Learn more about Storage Panel') }}</a></p>
+        {{ ftl('firefox-developer-add-modify-remove') }}
+        {% if ftl_has_messages('firefox-developer-learn-more-about-storage') %}
+          <p class="c-feature-more">
+            <a href="https://developer.mozilla.org/docs/Tools/Storage_Inspector" class="mzp-c-cta-link" rel="external">
+              {{ ftl('firefox-developer-learn-more-about-storage') }}
+            </a>
+          </p>
         {% endif %}
       </p>
     </li>
 
     <li class="c-gallery-item">
       <img class="c-feature-img" src="{{ static('img/firefox/developer/feature-responsive-mode.svg') }}" alt="">
-      <h3 class="c-feature-name">{{ _('Responsive Design Mode') }}</h3>
+      <h3 class="c-feature-name">{{ ftl('firefox-developer-responsive-design-mode') }}</h3>
       <p class="c-feature-desc">
-        {{ _('Test sites on emulated devices in your browser.') }}
-        {% if l10n_has_tag('quantum-firstrun-whatsnew') %}
-          <p class="c-feature-more"><a href="https://developer.mozilla.org/docs/Tools/Responsive_Design_View" class="mzp-c-cta-link" rel="external">{{ _('Learn more about Responsive Design View') }}</a></p>
+        {{ ftl('firefox-developer-test-sites-emulated') }}
+        {% if ftl_has_messages('firefox-developer-learn-more-about-responsive') %}
+          <p class="c-feature-more">
+            <a href="https://developer.mozilla.org/docs/Tools/Responsive_Design_View" class="mzp-c-cta-link" rel="external">
+              {{ ftl('firefox-developer-learn-more-about-responsive') }}
+            </a>
+          </p>
         {% endif %}
       </p>
     </li>
 
     <li class="c-gallery-item">
       <img class="c-feature-img" src="{{ static('img/firefox/developer/feature-visual-editing.svg') }}" alt="">
-      <h3 class="c-feature-name">{{ _('Visual Editing') }}</h3>
+      <h3 class="c-feature-name">{{ ftl('firefox-developer-visual-editing') }}</h3>
       <p class="c-feature-desc">
-        {{ _('Fine-tune animations, alignment and padding.') }}
-        {% if l10n_has_tag('quantum-firstrun-whatsnew') %}
-          <p class="c-feature-more"><a href="https://hacks.mozilla.org/2015/11/developer-edition-44-creative-tools-and-more" class="mzp-c-cta-link" rel="external">{{ _('Learn more about Visual Editing') }}</a></p>
+        {{ ftl('firefox-developer-fine-tuning-animations') }}
+        {% if ftl_has_messages('firefox-developer-learn-more-about-visual-editing') %}
+          <p class="c-feature-more">
+            <a href="https://hacks.mozilla.org/2015/11/developer-edition-44-creative-tools-and-more" class="mzp-c-cta-link" rel="external">
+              {{ ftl('firefox-developer-learn-more-about-visual-editing') }}
+            </a>
+          </p>
         {% endif %}
       </p>
     </li>
 
     <li class="c-gallery-item">
       <img class="c-feature-img" src="{{ static('img/firefox/developer/feature-performance.svg') }}" alt="">
-      <h3 class="c-feature-name">{{ _('Performance') }}</h3>
+      <h3 class="c-feature-name">{{ ftl('firefox-developer-performance') }}</h3>
       <p class="c-feature-desc">
-        {{ _('Unblock bottlenecks, streamline processes, optimize assets.') }}
-        {% if l10n_has_tag('quantum-firstrun-whatsnew') %}
-          <p class="c-feature-more"><a href="https://developer.mozilla.org/docs/Tools/Performance" class="mzp-c-cta-link" rel="external">{{ _('Learn more about Performance Tools') }}</a></p>
+        {{ ftl('firefox-developer-unblock-bottlenecks') }}
+        {% if ftl_has_messages('firefox-developer-learn-more-about-performance') %}
+          <p class="c-feature-more">
+            <a href="https://developer.mozilla.org/docs/Tools/Performance" class="mzp-c-cta-link" rel="external">
+              {{ ftl('firefox-developer-learn-more-about-performance') }}
+            </a>
+          </p>
         {% endif %}
       </p>
     </li>
 
     <li class="c-gallery-item">
       <img class="c-feature-img" src="{{ static('img/firefox/developer/feature-memory.svg') }}" alt="">
-      <h3 class="c-feature-name">{{ _('Memory') }}</h3>
+      <h3 class="c-feature-name">{{ ftl('firefox-developer-memory') }}</h3>
       <p class="c-feature-desc">
-        {{ _('Find memory leaks and make your application zippy.') }}
-        {% if l10n_has_tag('quantum-firstrun-whatsnew') %}
-          <p class="c-feature-more"><a href="https://developer.mozilla.org/docs/Tools/Memory" class="mzp-c-cta-link" rel="external">{{ _('Learn more about Memory Tools') }}</a></p>
+        {{ ftl('firefox-developer-find-memory-leaks') }}
+        {% if ftl_has_messages('firefox-developer-learn-more-about-memory') %}
+          <p class="c-feature-more">
+            <a href="https://developer.mozilla.org/docs/Tools/Memory" class="mzp-c-cta-link" rel="external">
+              {{ ftl('firefox-developer-learn-more-about-memory') }}
+            </a>
+          </p>
         {% endif %}
       </p>
     </li>
 
     <li class="c-gallery-item">
       <img class="c-feature-img" src="{{ static('img/firefox/developer/feature-style-editor.svg') }}" alt="">
-      <h3 class="c-feature-name">{{ _('Style Editor') }}</h3>
+      <h3 class="c-feature-name">{{ ftl('firefox-developer-style-editor') }}</h3>
       <p class="c-feature-desc">
-        {{ _('Edit and manage all your CSS stylesheets in your browser.') }}
-        {% if l10n_has_tag('quantum-firstrun-whatsnew') %}
-          <p class="c-feature-more"><a href="https://developer.mozilla.org/docs/Tools/Style_Editor" class="mzp-c-cta-link" rel="external">{{ _('Learn more about Style Editor') }}</a></p>
+        {{ ftl('firefox-developer-edit-and-manage') }}
+        {% if ftl_has_messages('firefox-developer-learn-more-about-style') %}
+          <p class="c-feature-more">
+            <a href="https://developer.mozilla.org/docs/Tools/Style_Editor" class="mzp-c-cta-link" rel="external">
+              {{ ftl('firefox-developer-learn-more-about-style') }}
+            </a>
+          </p>
         {% endif %}
       </p>
     </li>

--- a/bedrock/firefox/templates/firefox/developer/includes/for-developers.html
+++ b/bedrock/firefox/templates/firefox/developer/includes/for-developers.html
@@ -7,26 +7,12 @@
     </div>
     <div class="mzp-c-card-feature-content">
       <div class="mzp-c-card-feature-content-container">
-        <h2 class="mzp-c-card-feature-title">Firefox Browser Developer Edition</h2>
+        <h2 class="mzp-c-card-feature-title">{{ ftl('firefox-developer-firefox-browser') }}</h2>
         <div class="mzp-c-card-feature-desc">
-          <p class="c-subtitle">{{ _('The browser made for developers') }}</p>
-          <p>
-          {% trans %}
-            All the latest developer tools in beta, plus <strong>experimental features</strong> like the Multi-line Console Editor and WebSocket Inspector.
-          {% endtrans %}
-          </p>
-
-          <p>
-          {% trans %}
-            A <strong>separate profile and path</strong> so you can easily run it alongside Release or Beta Firefox.
-          {% endtrans %}
-          </p>
-
-          <p>
-          {% trans %}
-          Preferences <strong>tailored for web developers</strong>: Browser and remote debugging are enabled by default, as are the dark theme and developer toolbar button.
-          {% endtrans %}
-          </p>
+          <p class="c-subtitle">{{ ftl('firefox-developer-made-for-developers') }}</p>
+          <p>{{ ftl('firefox-developer-all-the-latest') }}</p>
+          <p>{{ ftl('firefox-developer-a-separate-profile') }}</p>
+          <p>{{ ftl('firefox-developer-preferences-tailored') }}</p>
         </div>
       </div>
     </div>

--- a/bedrock/firefox/templates/firefox/developer/includes/highlights.html
+++ b/bedrock/firefox/templates/firefox/developer/includes/highlights.html
@@ -1,80 +1,58 @@
 <section class="t-highlights mzp-l-content mzp-t-content-lg">
   <div class="c-gallery-grid">
-    {% if l10n_has_tag('new_features_20191129') %}
+    {% if ftl_has_messages('firefox-developer-new-tools', 'firefox-developer-firefox-devtools-now-grays-out') %}
       <div class="c-gallery-item" id="devtools">
         <a href="https://hacks.mozilla.org/2019/10/firefox-70-a-bountiful-release-for-all/#developertools" rel="external">
-          {{ high_res_img('img/firefox/developer/hero-inactive-css.png', {'alt': _('Inactive CSS'), 'class': 'highlight-image'}) }}
+          {{ high_res_img('img/firefox/developer/hero-inactive-css.png', {'alt': ftl('firefox-developer-inactive-css'), 'class': 'highlight-image'}) }}
         </a>
-        <h2 class="c-title">{{ _('New Tools') }}</h2>
-        <h3 class="c-subtitle">{{ _('Inactive CSS') }}</h3>
+        <h2 class="c-title">{{ ftl('firefox-developer-new-tools') }}</h2>
+        <h3 class="c-subtitle">{{ ftl('firefox-developer-inactive-css') }}</h3>
+        <p>{{ ftl('firefox-developer-firefox-devtools-now-grays-out') }}</p>
         <p>
-        {% trans %}
-          Firefox DevTools now grays out CSS declarations that don’t have an
-          effect on the page. When you hover over the info icon, you’ll see a
-          useful message about why the CSS is not being applied, including a
-          hint about how to fix the problem.
-        {% endtrans %}
+          <a class="mzp-c-cta-link" rel="external" href="https://hacks.mozilla.org/2019/10/firefox-70-a-bountiful-release-for-all/#developertools">
+            {{ ftl('ui-learn-more') }}
+          </a>
         </p>
-        <p><a class="mzp-c-cta-link" rel="external" href="https://hacks.mozilla.org/2019/10/firefox-70-a-bountiful-release-for-all/#developertools">{{ ftl('ui-learn-more') }}</a></p>
       </div>
     {% endif %}
     <div class="c-gallery-item" id="devtools">
       <a href="https://mozilladevelopers.github.io/playground/debugger/" rel="external">
-        <img class="highlight-image" src="{{ static('img/firefox/developer/hero-debugger-ani.gif') }}" alt="_('Firefox DevTools')">
+        <img class="highlight-image" src="{{ static('img/firefox/developer/hero-debugger-ani.gif') }}" alt="{{ ftl('firefox-developer-firefox-devtools') }}">
       </a>
-      <h2 class="c-title">{{ _('New Tools') }}</h2>
-      <h3 class="c-subtitle">{{ _('Firefox DevTools') }}</h3>
+      <h2 class="c-title">{{ ftl('firefox-developer-new-tools') }}</h2>
+      <h3 class="c-subtitle">{{ ftl('firefox-developer-firefox-devtools') }}</h3>
+      <p>{{ ftl('firefox-developer-the-new-firefox-devtools') }}</p>
       <p>
-      {% trans %}
-        The new Firefox DevTools are powerful, flexible, and best of all,
-        hackable. This includes a best-in-class JavaScript debugger, which
-        can target multiple browsers and is built in React and Redux.
-      {% endtrans %}
+        <a class="mzp-c-cta-link" rel="external" href="https://mozilladevelopers.github.io/playground/debugger/">
+          {{ ftl('ui-learn-more') }}
+        </a>
       </p>
-      <p><a class="mzp-c-cta-link" rel="external" href="https://mozilladevelopers.github.io/playground/debugger/">{{ ftl('ui-learn-more') }}</a></p>
     </div>
 
     <div class="c-gallery-item" id="cssgrid">
       <a href="https://mozilladevelopers.github.io/playground/css-grid/" rel="external">
-        <img class="highlight-image" src="{{ static('img/firefox/developer/hero-cssgrid-ani.gif') }}" alt="_('Master CSS Grid')">
+        <img class="highlight-image" src="{{ static('img/firefox/developer/hero-cssgrid-ani.gif') }}" alt="{{ ftl('firefox-developer-master-css-grid') }}">
       </a>
-      <h2 class="c-title">{{ _('Innovative Features') }}</h2>
-      <h3 class="c-subtitle">{{ _('Master CSS Grid') }}</h3>
+      <h2 class="c-title">{{ ftl('firefox-developer-master-innovative-features') }}</h2>
+      <h3 class="c-subtitle">{{ ftl('firefox-developer-master-css-grid') }}</h3>
+      <p>{{ ftl('firefox-developer-firefox-is-the-only-browser') }}</p>
       <p>
-      {% trans %}
-        Firefox is the only browser with tools built specifically for
-        building and designing with CSS Grid. These tools allow you to
-        visualize the grid, display associated area names, preview
-        transformations on the grid and much more.
-      {% endtrans %}
+        <a class="mzp-c-cta-link" rel="external" href="https://mozilladevelopers.github.io/playground/css-grid/">
+          {{ ftl('ui-learn-more') }}
+        </a>
       </p>
-      <p><a class="mzp-c-cta-link" rel="external" href="https://mozilladevelopers.github.io/playground/css-grid/">{{ ftl('ui-learn-more') }}</a></p>
     </div>
 
-    {% if l10n_has_tag('new_features_20180830') %}
-      {% if not l10n_has_tag('new_features_20191129') %}
+    {% if ftl_has_messages('firefox-developer-faster-innovation', 'firefox-developer-the-new-fonts-panel') %}
+      {% if not ftl_has_messages('firefox-developer-new-tools', 'firefox-developer-firefox-devtools-now-grays-out') %}
         <div class="c-gallery-item">
           <a rel="external" href="https://developer.mozilla.org/docs/Tools/Page_Inspector/How_to/Edit_CSS_shapes">
             <img class="highlight-image" src="{{ static('img/firefox/developer/hero-clip-ani.gif') }}" alt="_('Shapes Editor')">
           </a>
-          <h2 class="c-title">{{ _('Convenient Features') }}</h2>
-          <h3 class="c-subtitle">{{ _('Shapes Editor') }}</h3>
+          <h2 class="c-title">{{ ftl('firefox-developer-convenient-features') }}</h2>
+          <h3 class="c-subtitle">{{ ftl('firefox-developer-shapes-editor') }}</h3>
           <p>
-          {% if l10n_has_tag('new_features_shape_outside') %}
-            {% trans %}
-              Firefox DevTools has a brand new shape path editor that takes
-              the guesswork out of fine-tuning your shape-outside and clip-path
-              shapes by allowing you to very easily fine-tune your adjustments
-              with a visual editor.
-            {% endtrans %}
-          {% else %}
-            {% trans %}
-              Firefox DevTools has a brand new shape path editor that takes
-              the guesswork out of fine-tuning your shadow-outside and clip-path
-              shapes by allowing you to very easily fine-tune your adjustments
-              with a visual editor.
-            {% endtrans %}
-          {% endif %}
+            {{ ftl('firefox-developer-firefox-devtools-has-a-brand-new-v2', fallbacl='firefox-developer-firefox-devtools-has-a-brand-new') }}
           </p>
           <p><a class="mzp-c-cta-link" rel="external" href="https://developer.mozilla.org/docs/Tools/Page_Inspector/How_to/Edit_CSS_shapes">{{ ftl('ui-learn-more') }}</a></p>
         </div>
@@ -84,15 +62,10 @@
         <a rel="external" href="https://developer.mozilla.org/docs/Tools/Page_Inspector/How_to/Edit_fonts">
           <img class="highlight-image" src="{{ static('img/firefox/developer/hero-fonts.gif') }}" alt="_('Fonts Panel')">
         </a>
-        <h2 class="c-title">{{ _('Faster Information') }}</h2>
-        <h3 class="c-subtitle">{{ _('Fonts Panel') }}</h3>
+        <h2 class="c-title">{{ ftl('firefox-developer-faster-innovation') }}</h2>
+        <h3 class="c-subtitle">{{ ftl('firefox-developer-fonts-panel') }}</h3>
         <p>
-        {% trans %}
-          The new fonts panel in Firefox DevTools gives developers quick
-          access to all of the information they need about the fonts being
-          used in an element. It also includes valuable information such
-          as the font source, weight, style and more.
-        {% endtrans %}
+          {{ ftl('firefox-developer-the-new-fonts-panel') }}
         </p>
         <p><a class="mzp-c-cta-link" rel="external" href="https://developer.mozilla.org/docs/Tools/Page_Inspector/How_to/Edit_fonts">{{ ftl('ui-learn-more') }}</a></p>
       </div>

--- a/bedrock/firefox/templates/firefox/developer/includes/intro-features.html
+++ b/bedrock/firefox/templates/firefox/developer/includes/intro-features.html
@@ -1,17 +1,17 @@
 <ul class="c-gallery-grid">
   <li class="c-gallery-item">
     <img class="icon" src="{{ static('img/firefox/developer/devtools-icon.svg') }}" alt="">
-    <h3 class="c-title">{{ _('Firefox Devtools') }}</h3>
+    <h3 class="c-title">{{ ftl('firefox-developer-firefox-devtools') }}</h3>
     <p><a href="#devtools" class="mzp-c-cta-link">{{ ftl('ui-learn-more') }}</a></p>
   </li>
   <li class="c-gallery-item">
     <img class="icon" src="{{ static('img/firefox/developer/css-grid-icon.svg') }}" alt="">
-    <h3 class="c-title">{{ _('Master CSS Grid') }}</h3>
+    <h3 class="c-title">{{ ftl('firefox-developer-master-css-grid') }}</h3>
     <p><a href="#cssgrid" class="mzp-c-cta-link">{{ ftl('ui-learn-more') }}</a></p>
   </li>
   <li class="c-gallery-item">
     <img class="icon" src="{{ static('img/firefox/developer/next-gen-icon.svg') }}" alt="">
-    <h3 class="c-title">{{ _('Next-Gen CSS Engine') }}</h3>
+    <h3 class="c-title">{{ ftl('firefox-developer-next-gen-css-engine') }}</h3>
     <p><a href="#nextgen" class="mzp-c-cta-link">{{ ftl('ui-learn-more')}}</a></p>
   </li>
 </ul>

--- a/bedrock/firefox/templates/firefox/developer/includes/nightly.html
+++ b/bedrock/firefox/templates/firefox/developer/includes/nightly.html
@@ -7,9 +7,9 @@
     </div>
     <div class="mzp-c-card-feature-content">
       <div class="mzp-c-card-feature-content-container">
-        <h2 class="mzp-c-card-feature-title">{{ _('Want to be on the cutting-edge?') }}</h2>
+        <h2 class="mzp-c-card-feature-title">{{ ftl('firefox-developer-want-to-be-on-the-cutting-edge') }}</h2>
         <div class="mzp-c-card-feature-desc">
-            <p>{{ _('Firefox Nightly receives daily updates and allows you to access features months before they go mainstream.') }}</p>
+            <p>{{ ftl('firefox-developer-firefox-nightly-receives') }}</p>
             <p>{{ download_firefox('nightly', platform='desktop', dom_id='footer-download', download_location='footer cta') }}</p>
         </div>
       </div>

--- a/bedrock/firefox/templates/firefox/developer/includes/performance.html
+++ b/bedrock/firefox/templates/firefox/developer/includes/performance.html
@@ -7,13 +7,11 @@
     </div>
     <div class="mzp-c-card-feature-content">
       <div class="mzp-c-card-feature-content-container">
-        <h2 class="mzp-c-card-feature-title">{{ _('Faster Performance') }}</h2>
+        <h2 class="mzp-c-card-feature-title">{{ ftl('firefox-developer-faster-performance') }}</h2>
         <div class="mzp-c-card-feature-desc">
-          <p class="c-subtitle">{{ _('A Next-Generation CSS Engine') }}</p>
+          <p class="c-subtitle">{{ ftl('firefox-developer-a-next-generation') }}</p>
           <p>
-            {% trans %}
-              Firefox Quantum includes a new CSS engine, written in Rust, that has state-of-the-art innovations and is blazingly fast.
-            {% endtrans %}
+            {{ ftl('firefox-developer-firefox-quantum-includes') }}
           </p>
           <p class="mzp-c-cta-link"><a href="https://hacks.mozilla.org/2017/08/inside-a-super-fast-css-engine-quantum-css-aka-stylo/">{{ ftl('ui-learn-more') }}</a></p>
         </div>

--- a/bedrock/firefox/templates/firefox/developer/index.html
+++ b/bedrock/firefox/templates/firefox/developer/index.html
@@ -2,12 +2,10 @@
  # License, v. 2.0. If a copy of the MPL was not distributed with this
  # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
 
-{% add_lang_files "firefox/products/developer-quantum" "firefox/shared" %}
-
 {% extends "firefox/base/base-protocol.html" %}
 
-{% block page_title %}{{_('Firefox Developer Edition')}}{% endblock %}
-{% block page_desc %}{{ _('Firefox Developer Edition is the blazing fast browser that offers cutting edge developer tools and latest features like CSS Grid support and framework debugging') }}{% endblock %}
+{% block page_title %}{{ ftl('firefox-developer-page-title') }}{% endblock %}
+{% block page_desc %}{{ ftl('firefox-developer-firefox-developer-edition-desc') }}{% endblock %}
 {% block page_image %}{{ static('protocol/img/logos/firefox/browser/developer/og.png') }}{% endblock %}
 {% block page_favicon %}{{ static('img/favicons/firefox/browser/developer/favicon.ico') }}{% endblock %}
 {% block page_favicon_large %}{{ static('img/favicons/firefox/browser/developer/favicon-196x196.png') }}{% endblock %}
@@ -51,13 +49,13 @@
   <section class="t-intro">
     <div class="mzp-l-content">
       {{ high_res_img('protocol/img/logos/firefox/browser/developer/logo-word-hor-lg.png', {'alt': '', 'width': '368', 'height': '68'}) }}
-      <h1 class="intro-title">Firefox Browser Developer Edition</h1>
-      <p class="intro-tagline">{{ _('Welcome to your new favorite browser. Get the latest features, fast performance, and the development tools you need to build for the open web.') }}</p>
+      <h1 class="intro-title">{{ ftl('firefox-developer-firefox-browser') }}</h1>
+      <p class="intro-tagline">{{ ftl('firefox-developer-welcome-to-your-new-favorite') }}</p>
 
       {{ download_firefox('alpha', platform='desktop', dom_id='intro-download', download_location='primary cta') }}
 
       <p class="intro-feedback-note">
-        {{ _('Firefox Developer Edition automatically sends feedback to Mozilla.') }}
+        {{ ftl('firefox-developer-firefox-developer-edition-sends') }}
         <a href="{{ url('privacy.notices.firefox') }}#pre-release" class="more">{{ ftl('ui-learn-more') }}</a>
       </p>
     </div>
@@ -66,7 +64,7 @@
     </div>
   </section>
 
-  {% if l10n_has_tag('made_for_devs_102019') %}
+  {% if ftl_has_messages('firefox-developer-made-for-developers', 'firefox-developer-all-the-latest') %}
     {% include '/firefox/developer/includes/for-developers.html' %}
   {% else %}
     {% include '/firefox/developer/includes/performance.html' %}
@@ -88,7 +86,7 @@
         </div>
         <div class="mzp-c-card-feature-content">
           <div class="mzp-c-card-feature-content-container">
-            <h2 class="mzp-c-card-feature-title">{{ _('Download the Firefox browser made for developers') }}</h2>
+            <h2 class="mzp-c-card-feature-title">{{ ftl('firefox-developer-download-the-firefox-browser') }}</h2>
             <div class="mzp-c-card-feature-desc">
                 {{ download_firefox('alpha', platform='desktop', dom_id='footer-download', download_location='footer cta') }}
             </div>

--- a/bedrock/firefox/templates/firefox/developer/whatsnew.html
+++ b/bedrock/firefox/templates/firefox/developer/whatsnew.html
@@ -2,12 +2,10 @@
  # License, v. 2.0. If a copy of the MPL was not distributed with this
  # file, You can obtain one at http://mozilla.org/MPL/2.0/. -#}
 
-{% add_lang_files "firefox/products/developer-quantum" "firefox/shared" %}
-
 {% extends "firefox/whatsnew/base.html" %}
 
-{% block page_title %}{{_('Firefox Developer Edition')}}{% endblock %}
-{% block page_desc %}{{ _('Firefox Developer Edition is the blazing fast browser that offers cutting edge developer tools and latest features like CSS Grid support and framework debugging') }}{% endblock %}
+{% block page_title %}{{ ftl('firefox-developer-page-title') }}{% endblock %}
+{% block page_desc %}{{ ftl('firefox-developer-firefox-developer-edition-desc') }}{% endblock %}
 {% block page_image %}{{ static('protocol/img/logos/firefox/browser/developer/og.png') }}{% endblock %}
 {% block page_favicon %}{{ static('img/favicons/firefox/browser/developer/favicon.ico') }}{% endblock %}
 {% block page_favicon_large %}{{ static('img/favicons/firefox/browser/developer/favicon-196x196.png') }}{% endblock %}
@@ -26,14 +24,13 @@
     <div class="mzp-l-content">
       {{ high_res_img('protocol/img/logos/firefox/browser/developer/logo-word-hor-md.png', {'alt': '', 'width': '368', 'height': '68'}) }}
 
-    {% if l10n_has_tag('made_for_devs_102019') %}
-      {# L10n: "Firefox Browser Developer Edition" is a product name and shouldn't be translated #}
-      <h1 class="intro-title">{{ _('Congrats. You now have Firefox Browser Developer Edition.') }}</h1>
-      <p class="intro-tagline">{{ _('Welcome to your new favorite browser. Get the latest features, fast performance, and the development tools you need to build for the open web.') }}</p>
-    {% else %}
-      <h1 class="intro-title">{{ _('Congrats. You now have Firefox Quantum: Developer Edition.') }}</h1>
-      <p class="intro-tagline">{{ _('This isn’t just an update. This is Firefox Quantum: A brand new Firefox that has been rebuilt from the ground-up to be faster, sleeker, and more powerful than ever.') }}</p>
-    {% endif %}
+      {% if ftl_has_messages('firefox-developer-congrats-you-now-have', 'firefox-developer-welcome-to-your-new-favorite') %}
+        <h1 class="intro-title">{{ ftl('firefox-developer-congrats-you-now-have') }}</h1>
+        <p class="intro-tagline">{{ ftl('firefox-developer-welcome-to-your-new-favorite') }}</p>
+      {% else %}
+        <h1 class="intro-title">{{ ftl('firefox-developer-congrats-you-now-have-firefox') }}</h1>
+        <p class="intro-tagline">{{ ftl('firefox-developer-this-isnt-just-an-update') }}</p>
+      {% endif %}
 
       {% include '/firefox/developer/includes/intro-features.html' %}
     </div>
@@ -43,7 +40,7 @@
 
   {% include '/firefox/developer/includes/highlights.html' %}
 
-  {% if l10n_has_tag('made_for_devs_102019') %}
+  {% if ftl_has_messages('firefox-developer-made-for-developers', 'firefox-developer-all-the-latest') %}
     {% include '/firefox/developer/includes/for-developers.html' %}
   {% else %}
     {% include '/firefox/developer/includes/performance.html' %}

--- a/bedrock/firefox/urls.py
+++ b/bedrock/firefox/urls.py
@@ -39,7 +39,7 @@ urlpatterns = (
     page('firefox/channel/desktop', 'firefox/channel/desktop.html', ftl_files=['firefox/channel']),
     page('firefox/channel/android', 'firefox/channel/android.html', ftl_files=['firefox/channel']),
     page('firefox/channel/ios', 'firefox/channel/ios.html', ftl_files=['firefox/channel']),
-    page('firefox/developer', 'firefox/developer/index.html'),
+    page('firefox/developer', 'firefox/developer/index.html', ftl_files=['firefox/developer']),
     page('firefox/enterprise', 'firefox/enterprise/index.html', ftl_files=['firefox/enterprise']),
     page('firefox/enterprise/signup', 'firefox/enterprise/signup.html'),
     page('firefox/enterprise/signup/thanks', 'firefox/enterprise/signup-thanks.html'),

--- a/bedrock/firefox/views.py
+++ b/bedrock/firefox/views.py
@@ -520,6 +520,7 @@ class FirstrunView(l10n_utils.LangFilesMixin, TemplateView):
 
     ftl_files_map = {
         'firefox/firstrun/firstrun.html': ['firefox/firstrun'],
+        'firefox/developer/firstrun.html': ['firefox/developer'],
     }
 
     def get(self, *args, **kwargs):
@@ -580,6 +581,7 @@ class WhatsNewRedirectorView(GeoRedirectView):
 class WhatsnewView(L10nTemplateView):
 
     ftl_files_map = {
+        'firefox/developer/whatsnew.html': ['firefox/developer'],
         'firefox/nightly/whatsnew.html': ['firefox/nightly/whatsnew', 'firefox/whatsnew/whatsnew'],
         'firefox/whatsnew/index-account.html': ['firefox/whatsnew/whatsnew-account', 'firefox/whatsnew/whatsnew'],
         'firefox/whatsnew/index.html': ['firefox/whatsnew/whatsnew-s2d', 'firefox/whatsnew/whatsnew'],

--- a/l10n/en/firefox/developer.ftl
+++ b/l10n/en/firefox/developer.ftl
@@ -1,0 +1,86 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+### URL: https://www-dev.allizom.org/firefox/developer/
+
+## Strings in this file also cover: https://www-dev.allizom.org/firefox/83.0a2/firstrun/ and https://www-dev.allizom.org/firefox/83.0a2/whatsnew/all/
+
+firefox-developer-page-title = { -brand-name-firefox-developer-edition }
+firefox-developer-firefox-developer-edition-desc = { -brand-name-firefox-developer-edition } is the blazing fast browser that offers cutting edge developer tools and latest features like CSS Grid support and framework debugging
+firefox-developer-firefox-browser = { -brand-name-firefox-browser } { -brand-name-developer-edition }
+firefox-developer-welcome-to-your-new-favorite = Welcome to your new favorite browser. Get the latest features, fast performance, and the development tools you need to build for the open web.
+firefox-developer-speak-up = Speak up
+firefox-developer-feedback-makes-us = Feedback makes us better. Tell us how we can improve the browser and Developer tools.
+firefox-developer-join-the-convo = Join the conversation
+firefox-developer-get-involved = Get involved
+firefox-developer-help-build-the-last = Help build the last independent browser. Write code, fix bugs, make add-ons, and more.
+firefox-developer-start-now = Start now
+firefox-developer-design-code-test = Design. Code. Test. Refine.
+
+# Line break for visual formatting
+firefox-developer-build-and-perfect = Build and Perfect your sites<br> with { -brand-name-firefox-devtools }
+
+firefox-developer-inspector = Inspector
+firefox-developer-inspect-and-refine = Inspect and refine code to build pixel-perfect layouts.
+firefox-developer-learn-about-page-inspector = Learn more about Page Inspector
+firefox-developer-console = Console
+firefox-developer-track-css = Track CSS, JavaScript, security and network issues.
+firefox-developer-learn-about-web-console = Learn more about Web Console
+firefox-developer-debugger = Debugger
+firefox-developer-powerful-javascript = Powerful JavaScript debugger with support for your framework.
+firefox-developer-learn-more-about-debugger = Learn more about JavaScript Debugger
+firefox-developer-network = Network
+firefox-developer-monitor-network-requests = Monitor network requests that can slow or block your site.
+firefox-developer-learn-more-about-newtork-monitor = Learn more about Network Monitor
+firefox-developer-storage-panel = Storage panel
+firefox-developer-add-modify-remove = Add, modify and remove cache, cookies, databases and session data.
+firefox-developer-learn-more-about-storage = Learn more about Storage Panel
+firefox-developer-responsive-design-mode = Responsive Design Mode
+firefox-developer-test-sites-emulated = Test sites on emulated devices in your browser.
+firefox-developer-learn-more-about-responsive = Learn more about Responsive Design View
+firefox-developer-visual-editing = Visual Editing
+firefox-developer-fine-tuning-animations = Fine-tune animations, alignment and padding.
+firefox-developer-learn-more-about-visual-editing = Learn more about Visual Editing
+firefox-developer-performance = Performance
+firefox-developer-unblock-bottlenecks = Unblock bottlenecks, streamline processes, optimize assets.
+firefox-developer-learn-more-about-performance = Learn more about Performance Tools
+firefox-developer-memory = Memory
+firefox-developer-find-memory-leaks = Find memory leaks and make your application zippy.
+firefox-developer-learn-more-about-memory = Learn more about Memory Tools
+firefox-developer-style-editor = Style Editor
+firefox-developer-edit-and-manage = Edit and manage all your CSS stylesheets in your browser.
+firefox-developer-learn-more-about-style = Learn more about Style Editor
+firefox-developer-new-tools = New Tools
+firefox-developer-inactive-css = Inactive CSS
+firefox-developer-firefox-devtools-now-grays-out = { -brand-name-firefox-devtools } now grays out CSS declarations that don’t have an effect on the page. When you hover over the info icon, you’ll see a useful message about why the CSS is not being applied, including a hint about how to fix the problem.
+firefox-developer-firefox-devtools = { -brand-name-firefox-devtools }
+firefox-developer-the-new-firefox-devtools = The new { -brand-name-firefox-devtools } are powerful, flexible, and best of all, hackable. This includes a best-in-class JavaScript debugger, which can target multiple browsers and is built in React and Redux.
+firefox-developer-master-css-grid = Master CSS Grid
+firefox-developer-next-gen-css-engine = Next-Gen CSS Engine
+firefox-developer-a-next-generation = A Next-Generation CSS Engine
+firefox-developer-master-innovative-features = Innovative Features
+firefox-developer-want-to-be-on-the-cutting-edge = Want to be on the cutting-edge?
+firefox-developer-firefox-nightly-receives = { -brand-name-firefox-nightly } receives daily updates and allows you to access features months before they go mainstream.
+firefox-developer-firefox-quantum-includes = { -brand-name-firefox-quantum } includes a new CSS engine, written in Rust, that has state-of-the-art innovations and is blazingly fast.
+firefox-developer-firefox-is-the-only-browser = { -brand-name-firefox } is the only browser with tools built specifically for building and designing with CSS Grid. These tools allow you to visualize the grid, display associated area names, preview transformations on the grid and much more.
+firefox-developer-convenient-features = Convenient Features
+firefox-developer-faster-performance = Faster Performance
+firefox-developer-shapes-editor = Shapes Editor
+firefox-developer-firefox-devtools-has-a-brand-new-v2 = { -brand-name-firefox-devtools } has a brand new shape path editor that takes the guesswork out of fine-tuning your shape-outside and clip-path shapes by allowing you to very easily fine-tune your adjustments with a visual editor.
+firefox-developer-firefox-devtools-has-a-brand-new = { -brand-name-firefox-devtools } has a brand new shape path editor that takes the guesswork out of fine-tuning your shadow-outside and clip-path shapes by allowing you to very easily fine-tune your adjustments with a visual editor.
+firefox-developer-faster-innovation = Faster Information
+firefox-developer-fonts-panel = Fonts Panel
+firefox-developer-the-new-fonts-panel = The new fonts panel in { -brand-name-firefox-devtools } gives developers quick access to all of the information they need about the fonts being used in an element. It also includes valuable information such as the font source, weight, style and more.
+firefox-developer-firefox-developer-edition-sends = { -brand-name-firefox-developer-edition } automatically sends feedback to { -brand-name-mozilla }.
+firefox-developer-download-the-firefox-browser = Download the { -brand-name-firefox } browser made for developers
+firefox-developer-welcome-to-the-all-new = Welcome to the all-new { -brand-name-firefox-quantum }: { -brand-name-developer-edition }
+firefox-developer-firefox-has-been-rebuilt = { -brand-name-firefox } has been rebuilt from the ground-up to be faster, sleeker, and more powerful than ever.
+firefox-developer-congrats-you-now-have-firefox = Congrats. You now have { -brand-name-firefox-quantum }: { -brand-name-developer-edition }.
+firefox-developer-this-isnt-just-an-update = This isn’t just an update. This is { -brand-name-firefox-quantum }: A brand new { -brand-name-firefox } that has been rebuilt from the ground-up to be faster, sleeker, and more powerful than ever.
+firefox-developer-welcome-to-firefox-browser = Welcome to { -brand-name-firefox-browser } { -brand-name-developer-edition }
+firefox-developer-made-for-developers = The browser made for developers
+firefox-developer-all-the-latest = All the latest developer tools in beta, plus <strong>experimental features</strong> like the Multi-line Console Editor and WebSocket Inspector.
+firefox-developer-a-separate-profile = A <strong>separate profile and path</strong> so you can easily run it alongside Release or { -brand-name-beta } { -brand-name-firefox }.
+firefox-developer-preferences-tailored = Preferences <strong>tailored for web developers</strong>: Browser and remote debugging are enabled by default, as are the dark theme and developer toolbar button.
+firefox-developer-congrats-you-now-have = Congrats. You now have { -brand-name-firefox-browser } { -brand-name-developer-edition }.

--- a/lib/fluent_migrations/firefox/developer/index.py
+++ b/lib/fluent_migrations/firefox/developer/index.py
@@ -1,0 +1,308 @@
+from __future__ import absolute_import
+import fluent.syntax.ast as FTL
+from fluent.migrate.helpers import transforms_from
+from fluent.migrate.helpers import VARIABLE_REFERENCE, TERM_REFERENCE
+from fluent.migrate import REPLACE, COPY
+
+index = "firefox/developer/index.lang"
+developer_quantum = "firefox/products/developer-quantum.lang"
+shared = "firefox/shared.lang"
+
+def migrate(ctx):
+    """Migrate bedrock/firefox/templates/firefox/developer/index.html, part {index}."""
+
+    ctx.add_transforms(
+        "firefox/developer.ftl",
+        "firefox/developer.ftl",
+        transforms_from("""
+firefox-developer-page-title = { -brand-name-firefox-developer-edition }
+""", developer_quantum=developer_quantum) + [
+            FTL.Message(
+                id=FTL.Identifier("firefox-developer-firefox-developer-edition-desc"),
+                value=REPLACE(
+                    developer_quantum,
+                    "Firefox Developer Edition is the blazing fast browser that offers cutting edge developer tools and latest features like CSS Grid support and framework debugging",
+                    {
+                        "Firefox Developer Edition": TERM_REFERENCE("brand-name-firefox-developer-edition"),
+                    }
+                )
+            ),
+        ] + transforms_from("""
+firefox-developer-firefox-browser = { -brand-name-firefox-browser } { -brand-name-developer-edition }
+firefox-developer-welcome-to-your-new-favorite = {COPY(developer_quantum, "Welcome to your new favorite browser. Get the latest features, fast performance, and the development tools you need to build for the open web.",)}
+firefox-developer-speak-up = {COPY(developer_quantum, "Speak up",)}
+firefox-developer-feedback-makes-us = {COPY(developer_quantum, "Feedback makes us better. Tell us how we can improve the browser and Developer tools.",)}
+firefox-developer-join-the-convo = {COPY(developer_quantum, "Join the conversation",)}
+firefox-developer-get-involved = {COPY(developer_quantum, "Get involved",)}
+firefox-developer-help-build-the-last = {COPY(developer_quantum, "Help build the last independent browser. Write code, fix bugs, make add-ons, and more.",)}
+firefox-developer-start-now = {COPY(developer_quantum, "Start now",)}
+firefox-developer-design-code-test = {COPY(developer_quantum, "Design. Code. Test. Refine.",)}
+""", developer_quantum=developer_quantum) + [
+            FTL.Message(
+                id=FTL.Identifier("firefox-developer-build-and-perfect"),
+                value=REPLACE(
+                    developer_quantum,
+                    "Build and Perfect your sites<br> with Firefox DevTools",
+                    {
+                        "Firefox DevTools": TERM_REFERENCE("brand-name-firefox-devtools"),
+                    }
+                )
+            ),
+        ] + transforms_from("""
+firefox-developer-inspector = {COPY(developer_quantum, "Inspector",)}
+firefox-developer-inspect-and-refine = {COPY(developer_quantum, "Inspect and refine code to build pixel-perfect layouts.",)}
+firefox-developer-learn-about-page-inspector = {COPY(developer_quantum, "Learn more about Page Inspector",)}
+firefox-developer-console = {COPY(developer_quantum, "Console",)}
+firefox-developer-track-css = {COPY(developer_quantum, "Track CSS, JavaScript, security and network issues.",)}
+firefox-developer-learn-about-web-console = {COPY(developer_quantum, "Learn more about Web Console",)}
+firefox-developer-debugger = {COPY(developer_quantum, "Debugger",)}
+firefox-developer-powerful-javascript = {COPY(developer_quantum, "Powerful JavaScript debugger with support for your framework.",)}
+firefox-developer-learn-more-about-debugger = {COPY(developer_quantum, "Learn more about JavaScript Debugger",)}
+firefox-developer-network = {COPY(developer_quantum, "Network",)}
+firefox-developer-monitor-network-requests = {COPY(developer_quantum, "Monitor network requests that can slow or block your site.",)}
+firefox-developer-learn-more-about-newtork-monitor = {COPY(developer_quantum, "Learn more about Network Monitor",)}
+firefox-developer-storage-panel = {COPY(developer_quantum, "Storage panel",)}
+firefox-developer-add-modify-remove = {COPY(developer_quantum, "Add, modify and remove cache, cookies, databases and session data.",)}
+firefox-developer-learn-more-about-storage = {COPY(developer_quantum, "Learn more about Storage Panel",)}
+firefox-developer-responsive-design-mode = {COPY(developer_quantum, "Responsive Design Mode",)}
+firefox-developer-test-sites-emulated = {COPY(developer_quantum, "Test sites on emulated devices in your browser.",)}
+firefox-developer-learn-more-about-responsive = {COPY(developer_quantum, "Learn more about Responsive Design View",)}
+firefox-developer-visual-editing = {COPY(developer_quantum, "Visual Editing",)}
+firefox-developer-fine-tuning-animations = {COPY(developer_quantum, "Fine-tune animations, alignment and padding.",)}
+firefox-developer-learn-more-about-visual-editing = {COPY(developer_quantum, "Learn more about Visual Editing",)}
+firefox-developer-performance = {COPY(developer_quantum, "Performance",)}
+firefox-developer-unblock-bottlenecks = {COPY(developer_quantum, "Unblock bottlenecks, streamline processes, optimize assets.",)}
+firefox-developer-learn-more-about-performance = {COPY(developer_quantum, "Learn more about Performance Tools",)}
+firefox-developer-memory = {COPY(developer_quantum, "Memory",)}
+firefox-developer-find-memory-leaks = {COPY(developer_quantum, "Find memory leaks and make your application zippy.",)}
+firefox-developer-learn-more-about-memory = {COPY(developer_quantum, "Learn more about Memory Tools",)}
+firefox-developer-style-editor = {COPY(developer_quantum, "Style Editor",)}
+firefox-developer-edit-and-manage = {COPY(developer_quantum, "Edit and manage all your CSS stylesheets in your browser.",)}
+firefox-developer-learn-more-about-style = {COPY(developer_quantum, "Learn more about Style Editor",)}
+firefox-developer-made-for-developers = {COPY(developer_quantum, "The browser made for developers",)}
+firefox-developer-all-the-latest = {COPY(developer_quantum, "All the latest developer tools in beta, plus <strong>experimental features</strong> like the Multi-line Console Editor and WebSocket Inspector.",)}
+""", developer_quantum=developer_quantum) + [
+            FTL.Message(
+                id=FTL.Identifier("firefox-developer-welcome-to-firefox-browser"),
+                value=REPLACE(
+                    developer_quantum,
+                    "Welcome to Firefox Browser Developer Edition",
+                    {
+                        "Firefox Browser": TERM_REFERENCE("brand-name-firefox-browser"),
+                        "Developer Edition": TERM_REFERENCE("brand-name-developer-edition"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("firefox-developer-congrats-you-now-have"),
+                value=REPLACE(
+                    developer_quantum,
+                    "Congrats. You now have Firefox Browser Developer Edition.",
+                    {
+                        "Firefox Browser": TERM_REFERENCE("brand-name-firefox-browser"),
+                        "Developer Edition": TERM_REFERENCE("brand-name-developer-edition"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("firefox-developer-a-separate-profile"),
+                value=REPLACE(
+                    developer_quantum,
+                    "A <strong>separate profile and path</strong> so you can easily run it alongside Release or Beta Firefox.",
+                    {
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                    }
+                )
+            ),
+        ] + transforms_from("""
+firefox-developer-preferences-tailored = {COPY(developer_quantum, "Preferences <strong>tailored for web developers</strong>: Browser and remote debugging are enabled by default, as are the dark theme and developer toolbar button.",)}
+firefox-developer-new-tools = {COPY(developer_quantum, "New Tools",)}
+firefox-developer-inactive-css = {COPY(developer_quantum, "Inactive CSS",)}
+""", developer_quantum=developer_quantum) + [
+            FTL.Message(
+                id=FTL.Identifier("firefox-developer-firefox-devtools-now-grays-out"),
+                value=REPLACE(
+                    developer_quantum,
+                    "Firefox DevTools now grays out CSS declarations that don’t have an effect on the page. When you hover over the info icon, you’ll see a useful message about why the CSS is not being applied, including a hint about how to fix the problem.",
+                    {
+                        "Firefox DevTools": TERM_REFERENCE("brand-name-firefox-devtools"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("firefox-developer-firefox-devtools"),
+                value=REPLACE(
+                    developer_quantum,
+                    "Firefox DevTools",
+                    {
+                        "Firefox DevTools": TERM_REFERENCE("brand-name-firefox-devtools"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("firefox-developer-the-new-firefox-devtools"),
+                value=REPLACE(
+                    developer_quantum,
+                    "The new Firefox DevTools are powerful, flexible, and best of all, hackable. This includes a best-in-class JavaScript debugger, which can target multiple browsers and is built in React and Redux.",
+                    {
+                        "Firefox DevTools": TERM_REFERENCE("brand-name-firefox-devtools"),
+                    }
+                )
+            ),
+        ] + transforms_from("""
+firefox-developer-master-css-grid = {COPY(developer_quantum, "Master CSS Grid",)}
+firefox-developer-next-gen-css-engine = {COPY(developer_quantum, "Next-Gen CSS Engine",)}
+firefox-developer-a-next-generation = {COPY(developer_quantum, "A Next-Generation CSS Engine",)}
+firefox-developer-master-innovative-features = {COPY(developer_quantum, "Innovative Features",)}
+firefox-developer-want-to-be-on-the-cutting-edge = {COPY(developer_quantum, "Want to be on the cutting-edge?",)}
+""", developer_quantum=developer_quantum) + [
+
+            FTL.Message(
+                id=FTL.Identifier("firefox-developer-firefox-nightly-receives"),
+                value=REPLACE(
+                    developer_quantum,
+                    "Firefox Nightly receives daily updates and allows you to access features months before they go mainstream.",
+                    {
+                        "Firefox Nightly": TERM_REFERENCE("brand-name-firefox-nightly"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("firefox-developer-firefox-quantum-includes"),
+                value=REPLACE(
+                    developer_quantum,
+                    "Firefox Quantum includes a new CSS engine, written in Rust, that has state-of-the-art innovations and is blazingly fast.",
+                    {
+                        "Firefox Quantum": TERM_REFERENCE("brand-name-firefox-quantum"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("firefox-developer-firefox-is-the-only-browser"),
+                value=REPLACE(
+                    developer_quantum,
+                    "Firefox is the only browser with tools built specifically for building and designing with CSS Grid. These tools allow you to visualize the grid, display associated area names, preview transformations on the grid and much more.",
+                    {
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                    }
+                )
+            ),
+        ] + transforms_from("""
+firefox-developer-convenient-features = {COPY(developer_quantum, "Convenient Features",)}
+firefox-developer-faster-performance = {COPY(developer_quantum, "Faster Performance",)}
+firefox-developer-shapes-editor = {COPY(developer_quantum, "Shapes Editor",)}
+""", developer_quantum=developer_quantum) + [
+            FTL.Message(
+                id=FTL.Identifier("firefox-developer-firefox-devtools-has-a-brand-new-v2"),
+                value=REPLACE(
+                    developer_quantum,
+                    "Firefox DevTools has a brand new shape path editor that takes the guesswork out of fine-tuning your shape-outside and clip-path shapes by allowing you to very easily fine-tune your adjustments with a visual editor.",
+                    {
+                        "Firefox DevTools": TERM_REFERENCE("brand-name-firefox-devtools"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("firefox-developer-firefox-devtools-has-a-brand-new"),
+                value=REPLACE(
+                    developer_quantum,
+                    "Firefox DevTools has a brand new shape path editor that takes the guesswork out of fine-tuning your shadow-outside and clip-path shapes by allowing you to very easily fine-tune your adjustments with a visual editor.",
+                    {
+                        "Firefox DevTools": TERM_REFERENCE("brand-name-firefox-devtools"),
+                    }
+                )
+            ),
+        ] + transforms_from("""
+firefox-developer-faster-innovation = {COPY(developer_quantum, "Faster Information",)}
+firefox-developer-fonts-panel = {COPY(developer_quantum, "Fonts Panel",)}
+""", developer_quantum=developer_quantum) + [
+            FTL.Message(
+                id=FTL.Identifier("firefox-developer-the-new-fonts-panel"),
+                value=REPLACE(
+                    developer_quantum,
+                    "The new fonts panel in Firefox DevTools gives developers quick access to all of the information they need about the fonts being used in an element. It also includes valuable information such as the font source, weight, style and more.",
+                    {
+                        "Firefox DevTools": TERM_REFERENCE("brand-name-firefox-devtools"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("firefox-developer-firefox-developer-edition-sends"),
+                value=REPLACE(
+                    developer_quantum,
+                    "Firefox Developer Edition automatically sends feedback to Mozilla.",
+                    {
+                        "Firefox Developer Edition": TERM_REFERENCE("brand-name-firefox-developer-edition"),
+                        "Mozilla": TERM_REFERENCE("brand-name-mozilla"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("firefox-developer-download-the-firefox-browser"),
+                value=REPLACE(
+                    developer_quantum,
+                    "Download the Firefox browser made for developers",
+                    {
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                    }
+                )
+            ),
+        ]
+        )
+
+    ctx.add_transforms(
+        "firefox/developer.ftl",
+        "firefox/developer.ftl",
+        [
+            FTL.Message(
+                id=FTL.Identifier("firefox-developer-welcome-to-the-all-new"),
+                value=REPLACE(
+                    developer_quantum,
+                    "Welcome to the all-new Firefox Quantum: Developer Edition",
+                    {
+                        "Developer Edition": TERM_REFERENCE("brand-name-developer-edition"),
+                        "Firefox Quantum": TERM_REFERENCE("brand-name-firefox-quantum"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("firefox-developer-firefox-has-been-rebuilt"),
+                value=REPLACE(
+                    developer_quantum,
+                    "Firefox has been rebuilt from the ground-up to be faster, sleeker, and more powerful than ever.",
+                    {
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                    }
+                )
+            ),
+        ]
+        )
+
+    ctx.add_transforms(
+        "firefox/developer.ftl",
+        "firefox/developer.ftl",
+        [
+            FTL.Message(
+                id=FTL.Identifier("firefox-developer-congrats-you-now-have-firefox"),
+                value=REPLACE(
+                    developer_quantum,
+                    "Congrats. You now have Firefox Quantum: Developer Edition.",
+                    {
+                        "Developer Edition": TERM_REFERENCE("brand-name-developer-edition"),
+                        "Firefox Quantum": TERM_REFERENCE("brand-name-firefox-quantum"),
+                    }
+                )
+            ),
+            FTL.Message(
+                id=FTL.Identifier("firefox-developer-this-isnt-just-an-update"),
+                value=REPLACE(
+                    developer_quantum,
+                    "This isn’t just an update. This is Firefox Quantum: A brand new Firefox that has been rebuilt from the ground-up to be faster, sleeker, and more powerful than ever.",
+                    {
+                        "Firefox Quantum": TERM_REFERENCE("brand-name-firefox-quantum"),
+                        "Firefox": TERM_REFERENCE("brand-name-firefox"),
+                    }
+                )
+            ),
+        ]
+        )


### PR DESCRIPTION
## Description
- http://localhost:8000/en-US/firefox/developer/
- http://localhost:8000/en-US/firefox/83.0a2/whatsnew/all/
- http://localhost:8000/en-US/firefox/83.0a2/firstrun/

## Issue / Bugzilla link
#9191

## Testing
```
./manage.py l10n_update
```