### PR TITLE
Fix Metropolis font for Firefox banner on home page (Fixes #9803)

### DIFF
--- a/media/css/mozorg/home/home-en.scss
+++ b/media/css/mozorg/home/home-en.scss
@@ -31,6 +31,11 @@ $image-path: '/media/protocol/img';
     padding-bottom: 0;
     text-align: left;
 
+    .mzp-c-hero-title {
+        @include font-firefox;
+        @include font-size(32px);
+    }
+
     .mzp-c-hero-body {
         max-width: none;
     }
@@ -45,11 +50,6 @@ $image-path: '/media/protocol/img';
     }
 
     @media #{$mq-md} {
-        .mzp-c-hero-title {
-            @include font-firefox;
-            @include font-size(32px);
-        }
-
         .privacy-promise-hero-desc {
             margin-bottom: $spacing-lg;
         }


### PR DESCRIPTION
## Description
Fix "Firefox products are designed to protect your privacy" title font on home page.

http://localhost:8000/en-US/

## Issue / Bugzilla link
#9803

## Testing
- [x] At small screen sizes, header should use Metropolis and not Zilla Slab.